### PR TITLE
fix(auth): restrict credential file permissions

### DIFF
--- a/internal/auth/claude/token.go
+++ b/internal/auth/claude/token.go
@@ -4,7 +4,6 @@
 package claude
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -66,27 +65,14 @@ func (ts *ClaudeTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	// Create the token file
-	f, err := os.OpenFile(authFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		return fmt.Errorf("failed to create token file: %w", err)
-	}
-	defer func() {
-		_ = f.Close()
-	}()
-	if err = f.Chmod(0600); err != nil {
-		return fmt.Errorf("failed to restrict token file permissions: %w", err)
-	}
-
 	// Merge metadata using helper
 	data, errMerge := misc.MergeMetadata(ts, ts.Metadata)
 	if errMerge != nil {
 		return fmt.Errorf("failed to merge metadata: %w", errMerge)
 	}
 
-	// Encode and write the token data as JSON
-	if err = json.NewEncoder(f).Encode(data); err != nil {
-		return fmt.Errorf("failed to write token to file: %w", err)
+	if errWrite := misc.WriteCredentialFileAtomic(authFilePath, data); errWrite != nil {
+		return fmt.Errorf("failed to write token to file: %w", errWrite)
 	}
 	return nil
 }

--- a/internal/auth/claude/token.go
+++ b/internal/auth/claude/token.go
@@ -67,13 +67,16 @@ func (ts *ClaudeTokenStorage) SaveTokenToFile(authFilePath string) error {
 	}
 
 	// Create the token file
-	f, err := os.Create(authFilePath)
+	f, err := os.OpenFile(authFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}
 	defer func() {
 		_ = f.Close()
 	}()
+	if err = f.Chmod(0600); err != nil {
+		return fmt.Errorf("failed to restrict token file permissions: %w", err)
+	}
 
 	// Merge metadata using helper
 	data, errMerge := misc.MergeMetadata(ts, ts.Metadata)

--- a/internal/auth/claude/token_test.go
+++ b/internal/auth/claude/token_test.go
@@ -3,6 +3,7 @@
 package claude
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,6 +35,32 @@ func TestSaveTokenToFileTightensExistingFileMode(t *testing.T) {
 	}
 
 	assertPrivateFileMode(t, authFilePath)
+}
+
+func TestSaveTokenToFilePreservesExistingFileWhenEncodingFails(t *testing.T) {
+	dir := t.TempDir()
+	authFilePath := filepath.Join(dir, "credentials.json")
+	original := []byte(`{"refresh_token":"existing"}`)
+	if err := os.WriteFile(authFilePath, original, 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	storage := &ClaudeTokenStorage{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+		Metadata:     map[string]any{"unsupported": make(chan int)},
+	}
+	if err := storage.SaveTokenToFile(authFilePath); err == nil {
+		t.Fatal("SaveTokenToFile() error = nil, want encoding error")
+	}
+
+	got, err := os.ReadFile(authFilePath)
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatal("credential file contents changed after failed save")
+	}
 }
 
 func assertPrivateFileMode(t *testing.T, path string) {

--- a/internal/auth/claude/token_test.go
+++ b/internal/auth/claude/token_test.go
@@ -1,0 +1,48 @@
+//go:build !windows
+
+package claude
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveTokenToFileCreatesPrivateFile(t *testing.T) {
+	authFilePath := filepath.Join(t.TempDir(), "credentials.json")
+	storage := &ClaudeTokenStorage{AccessToken: "access", RefreshToken: "refresh"}
+
+	if err := storage.SaveTokenToFile(authFilePath); err != nil {
+		t.Fatalf("SaveTokenToFile() error = %v", err)
+	}
+
+	assertPrivateFileMode(t, authFilePath)
+}
+
+func TestSaveTokenToFileTightensExistingFileMode(t *testing.T) {
+	authFilePath := filepath.Join(t.TempDir(), "credentials.json")
+	if err := os.WriteFile(authFilePath, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+	if err := os.Chmod(authFilePath, 0o644); err != nil {
+		t.Fatalf("os.Chmod() error = %v", err)
+	}
+
+	storage := &ClaudeTokenStorage{AccessToken: "access", RefreshToken: "refresh"}
+	if err := storage.SaveTokenToFile(authFilePath); err != nil {
+		t.Fatalf("SaveTokenToFile() error = %v", err)
+	}
+
+	assertPrivateFileMode(t, authFilePath)
+}
+
+func assertPrivateFileMode(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("os.Stat() error = %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
+		t.Fatalf("credential file mode = %04o, want %04o", got, want)
+	}
+}

--- a/internal/auth/codex/token.go
+++ b/internal/auth/codex/token.go
@@ -4,7 +4,6 @@
 package codex
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -60,25 +59,14 @@ func (ts *CodexTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	f, err := os.OpenFile(authFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		return fmt.Errorf("failed to create token file: %w", err)
-	}
-	defer func() {
-		_ = f.Close()
-	}()
-	if err = f.Chmod(0600); err != nil {
-		return fmt.Errorf("failed to restrict token file permissions: %w", err)
-	}
-
 	// Merge metadata using helper
 	data, errMerge := misc.MergeMetadata(ts, ts.Metadata)
 	if errMerge != nil {
 		return fmt.Errorf("failed to merge metadata: %w", errMerge)
 	}
 
-	if err = json.NewEncoder(f).Encode(data); err != nil {
-		return fmt.Errorf("failed to write token to file: %w", err)
+	if errWrite := misc.WriteCredentialFileAtomic(authFilePath, data); errWrite != nil {
+		return fmt.Errorf("failed to write token to file: %w", errWrite)
 	}
 	return nil
 

--- a/internal/auth/codex/token.go
+++ b/internal/auth/codex/token.go
@@ -60,13 +60,16 @@ func (ts *CodexTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	f, err := os.Create(authFilePath)
+	f, err := os.OpenFile(authFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}
 	defer func() {
 		_ = f.Close()
 	}()
+	if err = f.Chmod(0600); err != nil {
+		return fmt.Errorf("failed to restrict token file permissions: %w", err)
+	}
 
 	// Merge metadata using helper
 	data, errMerge := misc.MergeMetadata(ts, ts.Metadata)

--- a/internal/auth/codex/token_test.go
+++ b/internal/auth/codex/token_test.go
@@ -1,0 +1,48 @@
+//go:build !windows
+
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveTokenToFileCreatesPrivateFile(t *testing.T) {
+	authFilePath := filepath.Join(t.TempDir(), "credentials.json")
+	storage := &CodexTokenStorage{AccessToken: "access", RefreshToken: "refresh"}
+
+	if err := storage.SaveTokenToFile(authFilePath); err != nil {
+		t.Fatalf("SaveTokenToFile() error = %v", err)
+	}
+
+	assertPrivateFileMode(t, authFilePath)
+}
+
+func TestSaveTokenToFileTightensExistingFileMode(t *testing.T) {
+	authFilePath := filepath.Join(t.TempDir(), "credentials.json")
+	if err := os.WriteFile(authFilePath, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+	if err := os.Chmod(authFilePath, 0o644); err != nil {
+		t.Fatalf("os.Chmod() error = %v", err)
+	}
+
+	storage := &CodexTokenStorage{AccessToken: "access", RefreshToken: "refresh"}
+	if err := storage.SaveTokenToFile(authFilePath); err != nil {
+		t.Fatalf("SaveTokenToFile() error = %v", err)
+	}
+
+	assertPrivateFileMode(t, authFilePath)
+}
+
+func assertPrivateFileMode(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("os.Stat() error = %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
+		t.Fatalf("credential file mode = %04o, want %04o", got, want)
+	}
+}

--- a/internal/auth/codex/token_test.go
+++ b/internal/auth/codex/token_test.go
@@ -3,6 +3,7 @@
 package codex
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,6 +35,32 @@ func TestSaveTokenToFileTightensExistingFileMode(t *testing.T) {
 	}
 
 	assertPrivateFileMode(t, authFilePath)
+}
+
+func TestSaveTokenToFilePreservesExistingFileWhenEncodingFails(t *testing.T) {
+	dir := t.TempDir()
+	authFilePath := filepath.Join(dir, "credentials.json")
+	original := []byte(`{"refresh_token":"existing"}`)
+	if err := os.WriteFile(authFilePath, original, 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	storage := &CodexTokenStorage{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+		Metadata:     map[string]any{"unsupported": make(chan int)},
+	}
+	if err := storage.SaveTokenToFile(authFilePath); err == nil {
+		t.Fatal("SaveTokenToFile() error = nil, want encoding error")
+	}
+
+	got, err := os.ReadFile(authFilePath)
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatal("credential file contents changed after failed save")
+	}
 }
 
 func assertPrivateFileMode(t *testing.T, path string) {

--- a/internal/misc/credentials.go
+++ b/internal/misc/credentials.go
@@ -2,7 +2,9 @@ package misc
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -58,4 +60,60 @@ func MergeMetadata(source any, metadata map[string]any) (map[string]any, error) 
 	}
 
 	return data, nil
+}
+
+type credentialFileOps struct {
+	createTemp func(string, string) (*os.File, error)
+	rename     func(string, string) error
+}
+
+// WriteCredentialFileAtomic writes JSON credential data to a private temporary
+// file and replaces the target only after the temporary file is synced and closed.
+func WriteCredentialFileAtomic(path string, data any) error {
+	return writeCredentialFileAtomic(path, data, credentialFileOps{
+		createTemp: os.CreateTemp,
+		rename:     os.Rename,
+	})
+}
+
+func writeCredentialFileAtomic(path string, data any, ops credentialFileOps) (returnErr error) {
+	temp, errCreate := ops.createTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if errCreate != nil {
+		return fmt.Errorf("failed to create temporary credential file: %w", errCreate)
+	}
+	tempPath := temp.Name()
+	closed := false
+	removeTemp := true
+	defer func() {
+		if !closed {
+			if errClose := temp.Close(); errClose != nil {
+				returnErr = errors.Join(returnErr, fmt.Errorf("failed to close temporary credential file: %w", errClose))
+			}
+		}
+		if removeTemp {
+			if errRemove := os.Remove(tempPath); errRemove != nil && !errors.Is(errRemove, os.ErrNotExist) {
+				returnErr = errors.Join(returnErr, fmt.Errorf("failed to remove temporary credential file: %w", errRemove))
+			}
+		}
+	}()
+
+	if errChmod := temp.Chmod(0600); errChmod != nil {
+		return fmt.Errorf("failed to restrict temporary credential file permissions: %w", errChmod)
+	}
+	if errEncode := json.NewEncoder(temp).Encode(data); errEncode != nil {
+		return fmt.Errorf("failed to encode temporary credential file: %w", errEncode)
+	}
+	if errSync := temp.Sync(); errSync != nil {
+		return fmt.Errorf("failed to sync temporary credential file: %w", errSync)
+	}
+	errClose := temp.Close()
+	closed = true
+	if errClose != nil {
+		return fmt.Errorf("failed to close temporary credential file: %w", errClose)
+	}
+	if errRename := ops.rename(tempPath, path); errRename != nil {
+		return fmt.Errorf("failed to replace credential file: %w", errRename)
+	}
+	removeTemp = false
+	return nil
 }

--- a/internal/misc/credentials_test.go
+++ b/internal/misc/credentials_test.go
@@ -1,0 +1,85 @@
+//go:build !windows
+
+package misc
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteCredentialFileAtomicPreservesExistingFileWhenCreateTempFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credentials.json")
+	original := []byte(`{"refresh_token":"existing"}`)
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	errPermission := errors.New("permission denied")
+	ops := credentialFileOps{
+		createTemp: func(string, string) (*os.File, error) {
+			return nil, errPermission
+		},
+		rename: os.Rename,
+	}
+	err := writeCredentialFileAtomic(path, map[string]any{"access_token": "replacement"}, ops)
+	if !errors.Is(err, errPermission) {
+		t.Fatalf("writeCredentialFileAtomic() error = %v, want permission error", err)
+	}
+
+	assertCredentialFileUnchanged(t, path, original)
+}
+
+func TestWriteCredentialFileAtomicPreservesExistingFileWhenRenameFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credentials.json")
+	original := []byte(`{"refresh_token":"existing"}`)
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	errRename := errors.New("rename failed")
+	ops := credentialFileOps{
+		createTemp: os.CreateTemp,
+		rename: func(tempPath, targetPath string) error {
+			if targetPath != path {
+				t.Fatalf("rename target = %q, want credential path", targetPath)
+			}
+			info, err := os.Stat(tempPath)
+			if err != nil {
+				t.Fatalf("os.Stat(temp) error = %v", err)
+			}
+			if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
+				t.Fatalf("temporary credential file mode = %04o, want %04o", got, want)
+			}
+			return errRename
+		},
+	}
+	err := writeCredentialFileAtomic(path, map[string]any{"access_token": "replacement"}, ops)
+	if !errors.Is(err, errRename) {
+		t.Fatalf("writeCredentialFileAtomic() error = %v, want rename error", err)
+	}
+
+	assertCredentialFileUnchanged(t, path, original)
+	matches, err := filepath.Glob(filepath.Join(dir, ".credentials.json.tmp-*"))
+	if err != nil {
+		t.Fatalf("filepath.Glob() error = %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary credential files remain after failed rename: %d", len(matches))
+	}
+}
+
+func assertCredentialFileUnchanged(t *testing.T, path string, want []byte) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatal("credential file contents changed after failed save")
+	}
+}


### PR DESCRIPTION
## Summary

- atomically replace credential files through a private same-directory temporary file
- set owner-only permissions before writing, then sync and close before replacement
- preserve the existing credential file on preparation or replacement failures and clean up failed temporary files
- cover both built-in OAuth token stores with permission and failure-path regression tests

## Why

Credential saves wrote directly to the destination using process-default creation permissions. A failed encode after opening the file could leave existing credentials truncated, and older permissive files remained permissive. Preparing a `0600` temporary file and replacing the destination only after a successful write closes both gaps without exposing a partially written credential file.

## Test plan

- [x] `go test -count=1 ./internal/auth/...`
- [x] `go test -count=1 ./internal/misc -run '^TestWriteCredentialFileAtomic'`
- [x] `go build -buildvcs=false -o <temp> ./cmd/server`
- [x] `git diff --check`
- [x] required pull-request checks: build and repository policy guards

## Baseline note

The unfiltered helper-package suite still has a pre-existing loopback-listener readiness failure in an unrelated updater-manifest test. The credential-write regressions pass in isolation. Permission assertions remain limited to non-Windows test builds because Windows does not expose the same mode-bit semantics.
