### PR TITLE
fix(translator): omit unsupported response options

### DIFF
--- a/internal/translator/codex/openai/responses/codex_openai-responses_request.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request.go
@@ -27,6 +27,7 @@ func ConvertOpenAIResponsesRequestToCodex(modelName string, inputRawJSON []byte,
 	rawJSON, _ = sjson.DeleteBytes(rawJSON, "max_completion_tokens")
 	rawJSON, _ = sjson.DeleteBytes(rawJSON, "temperature")
 	rawJSON, _ = sjson.DeleteBytes(rawJSON, "top_p")
+	rawJSON, _ = sjson.DeleteBytes(rawJSON, "output_config")
 	if v := gjson.GetBytes(rawJSON, "service_tier"); v.Exists() {
 		if v.String() != "priority" {
 			rawJSON, _ = sjson.DeleteBytes(rawJSON, "service_tier")

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
@@ -356,6 +356,29 @@ func TestContextManagementCompactionCompatibility(t *testing.T) {
 	}
 }
 
+func TestOutputConfigRemovedForCodexCompatibility(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "gpt-5.6-sol",
+		"output_config": {
+			"effort": "high"
+		},
+		"reasoning": {
+			"effort": "medium"
+		},
+		"input": [{"role":"user","content":"hello"}]
+	}`)
+
+	output := ConvertOpenAIResponsesRequestToCodex("gpt-5.6-sol", inputJSON, false)
+	outputStr := string(output)
+
+	if gjson.Get(outputStr, "output_config").Exists() {
+		t.Fatalf("output_config should be removed for Codex compatibility")
+	}
+	if effort := gjson.Get(outputStr, "reasoning.effort").String(); effort != "medium" {
+		t.Fatalf("reasoning.effort = %q, want medium", effort)
+	}
+}
+
 func TestTruncationRemovedForCodexCompatibility(t *testing.T) {
 	inputJSON := []byte(`{
 		"model": "gpt-5.2",


### PR DESCRIPTION
## Summary

- remove `output_config` before subscription-backed Responses requests
- retain the supported `reasoning.effort` setting
- add focused regression coverage

## Test plan

- [x] focused translator package tests
- [x] formatting and patch hygiene checks
