### PR TITLE
fix(openai): preserve native chat SSE framing

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -396,6 +396,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		defer streamUsage.Publish(ctx, reporter)
 		if passThroughSSE {
 			reader := bufio.NewReader(httpResp.Body)
+			hasSSEEventLine := false
 			for {
 				line, errRead := reader.ReadBytes('\n')
 				if len(line) > 0 {
@@ -403,6 +404,21 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 					helps.AppendAPIResponseChunk(ctx, e.cfg, rawLine)
 					streamUsage.ObserveOpenAIStream(rawLine)
 					trimmedLine := bytes.TrimSpace(rawLine)
+					if len(trimmedLine) == 0 {
+						if !hasSSEEventLine {
+							continue
+						}
+						select {
+						case out <- cliproxyexecutor.StreamChunk{Payload: rawLine, SSEPassthrough: true}:
+						case <-ctx.Done():
+							return
+						}
+						hasSSEEventLine = false
+						continue
+					}
+					if bytes.HasPrefix(trimmedLine, []byte(":")) {
+						continue
+					}
 					if bytes.HasPrefix(trimmedLine, []byte("{")) || bytes.HasPrefix(trimmedLine, []byte("[")) {
 						streamErr := statusErr{code: http.StatusBadGateway, msg: string(trimmedLine)}
 						helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
@@ -418,6 +434,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 					case <-ctx.Done():
 						return
 					}
+					hasSSEEventLine = true
 				}
 				if errRead == nil {
 					continue

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -307,6 +307,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("openai")
+	passThroughSSE := isOpenAIChatSSEPassthrough(from, responseFormat, opts)
 	originalPayloadSource := req.Payload
 	if len(opts.OriginalRequest) > 0 {
 		originalPayloadSource = opts.OriginalRequest
@@ -390,11 +391,53 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 				log.Errorf("openai compat executor: close response body error: %v", errClose)
 			}
 		}()
-		scanner := bufio.NewScanner(httpResp.Body)
-		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
 		var streamUsage helps.StreamUsageBuffer
 		defer streamUsage.Publish(ctx, reporter)
+		if passThroughSSE {
+			reader := bufio.NewReader(httpResp.Body)
+			for {
+				line, errRead := reader.ReadBytes('\n')
+				if len(line) > 0 {
+					rawLine := bytes.Clone(line)
+					helps.AppendAPIResponseChunk(ctx, e.cfg, rawLine)
+					streamUsage.ObserveOpenAIStream(rawLine)
+					trimmedLine := bytes.TrimSpace(rawLine)
+					if bytes.HasPrefix(trimmedLine, []byte("{")) || bytes.HasPrefix(trimmedLine, []byte("[")) {
+						streamErr := statusErr{code: http.StatusBadGateway, msg: string(trimmedLine)}
+						helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
+						reporter.PublishFailure(ctx, streamErr)
+						select {
+						case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
+						case <-ctx.Done():
+						}
+						return
+					}
+					select {
+					case out <- cliproxyexecutor.StreamChunk{Payload: rawLine, SSEPassthrough: true}:
+					case <-ctx.Done():
+						return
+					}
+				}
+				if errRead == nil {
+					continue
+				}
+				if errRead != io.EOF {
+					helps.RecordAPIResponseError(ctx, e.cfg, errRead)
+					reporter.PublishFailure(ctx, errRead)
+					select {
+					case out <- cliproxyexecutor.StreamChunk{Err: errRead}:
+					case <-ctx.Done():
+					}
+				}
+				break
+			}
+			streamUsage.Publish(ctx, reporter)
+			reporter.EnsurePublished(ctx)
+			return
+		}
+		scanner := bufio.NewScanner(httpResp.Body)
+		scanner.Buffer(nil, 52_428_800) // 50MB
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
@@ -457,6 +500,15 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		reporter.EnsurePublished(ctx)
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+func isOpenAIChatSSEPassthrough(from, responseFormat sdktranslator.Format, opts cliproxyexecutor.Options) bool {
+	openAIFormat := sdktranslator.FromString("openai")
+	if from != openAIFormat || responseFormat != openAIFormat {
+		return false
+	}
+	requestPath := helps.PayloadRequestPath(opts)
+	return requestPath == "" || strings.HasSuffix(requestPath, "/chat/completions")
 }
 
 func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, endpointPath string) (_ *cliproxyexecutor.StreamResult, err error) {

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -442,3 +442,25 @@ func TestOpenAICompatExecutorStreamSkipsKeepAliveUntilDataLine(t *testing.T) {
 		t.Fatalf("stream payload = %s", got.String())
 	}
 }
+
+func TestIsOpenAIChatSSEPassthrough(t *testing.T) {
+	openAIFormat := sdktranslator.FromString("openai")
+	for _, tc := range []struct {
+		name           string
+		responseFormat sdktranslator.Format
+		requestPath    string
+		want           bool
+	}{
+		{name: "chat completions", responseFormat: openAIFormat, requestPath: "/v1/chat/completions", want: true},
+		{name: "implicit chat completions", responseFormat: openAIFormat, want: true},
+		{name: "completions conversion", responseFormat: openAIFormat, requestPath: "/v1/completions", want: false},
+		{name: "translated response", responseFormat: sdktranslator.FromString("claude"), requestPath: "/v1/chat/completions", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := cliproxyexecutor.Options{Metadata: map[string]any{cliproxyexecutor.RequestPathMetadataKey: tc.requestPath}}
+			if got := isOpenAIChatSSEPassthrough(openAIFormat, tc.responseFormat, opts); got != tc.want {
+				t.Fatalf("isOpenAIChatSSEPassthrough() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -959,15 +959,56 @@ func executionErrorMessage(err error) *interfaces.ErrorMessage {
 // This path is the only supported execution route.
 // The returned http.Header carries upstream response headers captured before streaming begins.
 func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handlerType, modelName string, rawJSON []byte, alt string) (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
+	chunks, headers, errs := h.executeStreamWithAuthManager(ctx, handlerType, modelName, rawJSON, alt, false)
+	return StreamChunkPayloads(ctx, chunks), headers, errs
+}
+
+// ExecuteStreamWithAuthManagerWithSSEPassthrough preserves native SSE framing metadata for routes that support it.
+func (h *BaseAPIHandler) ExecuteStreamWithAuthManagerWithSSEPassthrough(ctx context.Context, handlerType, modelName string, rawJSON []byte, alt string) (<-chan coreexecutor.StreamChunk, http.Header, <-chan *interfaces.ErrorMessage) {
 	return h.executeStreamWithAuthManager(ctx, handlerType, modelName, rawJSON, alt, false)
 }
 
 // ExecuteImageStreamWithAuthManager executes a streaming OpenAI-compatible image endpoint request.
 func (h *BaseAPIHandler) ExecuteImageStreamWithAuthManager(ctx context.Context, handlerType, modelName string, rawJSON []byte, alt string) (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
-	return h.executeStreamWithAuthManager(ctx, handlerType, modelName, rawJSON, alt, true)
+	chunks, headers, errs := h.executeStreamWithAuthManager(ctx, handlerType, modelName, rawJSON, alt, true)
+	return StreamChunkPayloads(ctx, chunks), headers, errs
 }
 
-func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProtocol, responseProtocol, modelName, originalRequestedModel string, rawJSON []byte, alt, executorPluginID string, execOptions modelExecutionOptions) (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
+// StreamChunkPayloads adapts executor stream chunks for callers that do not need framing metadata.
+func StreamChunkPayloads(ctx context.Context, chunks <-chan coreexecutor.StreamChunk) <-chan []byte {
+	if chunks == nil {
+		return nil
+	}
+	var done <-chan struct{}
+	if ctx != nil {
+		done = ctx.Done()
+	}
+	out := make(chan []byte)
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case <-done:
+				return
+			case chunk, ok := <-chunks:
+				if !ok {
+					return
+				}
+				if len(chunk.Payload) == 0 {
+					continue
+				}
+				select {
+				case <-done:
+					return
+				case out <- chunk.Payload:
+				}
+			}
+		}
+	}()
+	return out
+}
+
+func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProtocol, responseProtocol, modelName, originalRequestedModel string, rawJSON []byte, alt, executorPluginID string, execOptions modelExecutionOptions) (<-chan coreexecutor.StreamChunk, http.Header, <-chan *interfaces.ErrorMessage) {
 	host := h.pluginExecutorHost()
 	if host == nil {
 		errChan := make(chan *interfaces.ErrorMessage, 1)
@@ -1025,7 +1066,7 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 		applyStreamHeaders(intercepted.Headers)
 	}
 
-	dataChan := make(chan []byte)
+	dataChan := make(chan coreexecutor.StreamChunk)
 	errChan := make(chan *interfaces.ErrorMessage, 1)
 	var done <-chan struct{}
 	if ctx != nil {
@@ -1097,7 +1138,7 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 			}
 			streamHeadersCommitted = true
 			select {
-			case dataChan <- payload:
+			case dataChan <- coreexecutor.StreamChunk{Payload: payload}:
 				if streamInterceptorsActive {
 					historyChunks = appendStreamInterceptorHistory(historyChunks, payload)
 				}
@@ -1109,11 +1150,11 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 	return dataChan, upstreamHeaders, errChan
 }
 
-func (h *BaseAPIHandler) executeStreamWithAuthManager(ctx context.Context, handlerType, modelName string, rawJSON []byte, alt string, allowImageModel bool) (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
+func (h *BaseAPIHandler) executeStreamWithAuthManager(ctx context.Context, handlerType, modelName string, rawJSON []byte, alt string, allowImageModel bool) (<-chan coreexecutor.StreamChunk, http.Header, <-chan *interfaces.ErrorMessage) {
 	return h.executeStreamWithAuthManagerFormats(ctx, handlerType, handlerType, modelName, rawJSON, alt, allowImageModel, modelExecutionOptions{})
 }
 
-func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context, entryProtocol, exitProtocol, modelName string, rawJSON []byte, alt string, allowImageModel bool, execOptions modelExecutionOptions) (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
+func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context, entryProtocol, exitProtocol, modelName string, rawJSON []byte, alt string, allowImageModel bool, execOptions modelExecutionOptions) (<-chan coreexecutor.StreamChunk, http.Header, <-chan *interfaces.ErrorMessage) {
 	originalRequestedModel := modelName
 	routeDecision := h.applyModelRouter(ctx, entryProtocol, modelName, rawJSON, true, execOptions)
 	responseProtocol := modelExecutionResponseProtocol(entryProtocol, exitProtocol)
@@ -1196,7 +1237,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		upstreamHeaders = make(http.Header)
 	}
 	chunks := streamResult.Chunks
-	dataChan := make(chan []byte)
+	dataChan := make(chan coreexecutor.StreamChunk)
 	errChan := make(chan *interfaces.ErrorMessage, 1)
 	streamHeaderInitialized := false
 	streamHeadersCommitted := false
@@ -1289,7 +1330,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 			}
 		}
 
-		sendData := func(chunk []byte) bool {
+		sendData := func(chunk coreexecutor.StreamChunk) bool {
 			if ctx == nil {
 				dataChan <- chunk
 				return true
@@ -1402,7 +1443,8 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 					}
 					sentPayload = true
 					streamHeadersCommitted = true
-					if okSendData := sendData(payload); !okSendData {
+					chunk.Payload = payload
+					if okSendData := sendData(chunk); !okSendData {
 						return
 					}
 					if streamInterceptorsActive {

--- a/sdk/api/handlers/model_execution.go
+++ b/sdk/api/handlers/model_execution.go
@@ -123,14 +123,14 @@ func (h *BaseAPIHandler) ExecuteModelStream(ctx context.Context, req ModelExecut
 	if !req.Stream {
 		return ModelExecutionStream{}, modelExecutionModeError("ExecuteModelStream requires Stream=true")
 	}
-	dataChan, headers, errChan := h.executeStreamWithAuthManagerFormats(ctx, req.EntryProtocol, req.ExitProtocol, req.Model, cloneBytes(req.Body), req.Alt, false, modelExecutionOptions{
+	streamChunks, headers, errChan := h.executeStreamWithAuthManagerFormats(ctx, req.EntryProtocol, req.ExitProtocol, req.Model, cloneBytes(req.Body), req.Alt, false, modelExecutionOptions{
 		Headers:                 req.Headers,
 		Query:                   req.Query,
 		InternalSource:          true,
 		SkipInterceptorPluginID: req.SkipInterceptorPluginID,
 		SkipRouterPluginID:      req.SkipRouterPluginID,
 	})
-	chunks, errMsg := prepareModelExecutionStream(ctx, dataChan, errChan)
+	chunks, errMsg := prepareModelExecutionStream(ctx, StreamChunkPayloads(ctx, streamChunks), errChan)
 	if errMsg != nil {
 		return ModelExecutionStream{}, errMsg
 	}
@@ -167,13 +167,13 @@ func (h *BaseAPIHandler) ExecuteProtocolStreamWithAuthManager(ctx context.Contex
 	if !req.Stream {
 		return ModelExecutionStream{}, modelExecutionModeError("ExecuteProtocolStreamWithAuthManager requires Stream=true")
 	}
-	dataChan, headers, errChan := h.executeStreamWithAuthManagerFormats(ctx, req.EntryProtocol, req.ExitProtocol, req.Model, cloneBytes(req.Body), req.Alt, false, modelExecutionOptions{
+	streamChunks, headers, errChan := h.executeStreamWithAuthManagerFormats(ctx, req.EntryProtocol, req.ExitProtocol, req.Model, cloneBytes(req.Body), req.Alt, false, modelExecutionOptions{
 		Headers:            req.Headers,
 		Query:              req.Query,
 		ForcedProvider:     req.ForcedProvider,
 		AuthSelectionModel: req.AuthSelectionModel,
 	})
-	chunks, errMsg := prepareModelExecutionStream(ctx, dataChan, errChan)
+	chunks, errMsg := prepareModelExecutionStream(ctx, StreamChunkPayloads(ctx, streamChunks), errChan)
 	if errMsg != nil {
 		return ModelExecutionStream{}, errMsg
 	}

--- a/sdk/api/handlers/openai/openai_chat_stream_passthrough_test.go
+++ b/sdk/api/handlers/openai/openai_chat_stream_passthrough_test.go
@@ -1,0 +1,206 @@
+package openai
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+const openAICompatStreamFixtureModel = "openai-sse-fixture-model"
+
+func newOpenAICompatStreamFixtureHandler(t *testing.T, upstreamURL string) *OpenAIAPIHandler {
+	t.Helper()
+
+	manager := coreauth.NewManager(nil, &coreauth.RoundRobinSelector{}, nil)
+	compatExecutor := runtimeexecutor.NewOpenAICompatExecutor("openai-compatibility", &internalconfig.Config{})
+	manager.RegisterExecutor(compatExecutor)
+
+	auth := &coreauth.Auth{
+		ID:       "openai-sse-fixture-auth",
+		Provider: compatExecutor.Identifier(),
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"api_key":  "fixture-key",
+			"base_url": upstreamURL + "/v1",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register fixture auth: %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: openAICompatStreamFixtureModel}})
+	manager.RefreshSchedulerEntry(auth.ID)
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	return NewOpenAIAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager))
+}
+
+func runOpenAICompatStreamFixture(t *testing.T, body string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("upstream path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer upstream.Close()
+
+	gin.SetMode(gin.TestMode)
+	handler := newOpenAICompatStreamFixtureHandler(t, upstream.URL)
+	router := gin.New()
+	router.POST("/v1/chat/completions", handler.ChatCompletions)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"openai-sse-fixture-model","stream":true,"messages":[{"role":"user","content":"fixture"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	return resp
+}
+
+func TestOpenAICompatChatStreamPreservesNativeSSEFraming(t *testing.T) {
+	terminalWithoutDone := "data: {\"id\":\"chatcmpl-native-no-done\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"fixture response\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":60,\"completion_tokens\":9,\"total_tokens\":69,\"prompt_tokens_details\":{\"cached_tokens\":20}}}\n"
+	malformedEvent := "event: message\ndata: {\"usage\":\n\ndata: [DONE]\n"
+	terminalWithDone := ": fixture keepalive\n\ndata: {\"id\":\"chatcmpl-native-terminal\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"fixture response\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":101,\"completion_tokens\":17,\"total_tokens\":125,\"prompt_tokens_details\":{\"cached_tokens\":60},\"completion_tokens_details\":{\"reasoning_tokens\":7}}}\n\ndata: {\"id\":\"chatcmpl-native-terminal\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":999,\"completion_tokens\":999,\"total_tokens\":1998}}\n\ndata: [DONE]\n"
+	framingFields := "event: message\nid: fixture-42\nretry: 2500\ndata: {\"id\":\"chatcmpl-framing\",\"object\":\"chat.completion.chunk\",\"choices\":[]}\n\n"
+
+	for _, tc := range []struct {
+		name      string
+		upstream  string
+		doneCount int
+	}{
+		{name: "clean EOF does not add DONE", upstream: terminalWithoutDone, doneCount: 0},
+		{name: "malformed event retains event field", upstream: malformedEvent, doneCount: 1},
+		{name: "normal terminal usage and DONE remain unchanged", upstream: terminalWithDone, doneCount: 1},
+		{name: "event id and retry fields remain unchanged", upstream: framingFields, doneCount: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := runOpenAICompatStreamFixture(t, tc.upstream)
+			if resp.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body=%q", resp.Code, http.StatusOK, resp.Body.String())
+			}
+			if got := resp.Body.String(); got != tc.upstream {
+				t.Fatalf("stream body = %q, want %q", got, tc.upstream)
+			}
+			if got := strings.Count(resp.Body.String(), "data: [DONE]"); got != tc.doneCount {
+				t.Fatalf("DONE count = %d, want %d; body=%q", got, tc.doneCount, resp.Body.String())
+			}
+		})
+	}
+}
+
+func TestOpenAICompatChatStreamKeepsCommitErrorBehavior(t *testing.T) {
+	t.Run("pre-commit HTTP failure remains an HTTP error", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":{"message":"fixture pre-commit failure"}}`))
+		}))
+		defer upstream.Close()
+
+		gin.SetMode(gin.TestMode)
+		handler := newOpenAICompatStreamFixtureHandler(t, upstream.URL)
+		router := gin.New()
+		router.POST("/v1/chat/completions", handler.ChatCompletions)
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"openai-sse-fixture-model","stream":true,"messages":[{"role":"user","content":"fixture"}]}`))
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want %d; body=%q", resp.Code, http.StatusServiceUnavailable, resp.Body.String())
+		}
+		if strings.Contains(resp.Body.String(), "[DONE]") {
+			t.Fatalf("pre-commit response synthesized DONE: %q", resp.Body.String())
+		}
+	})
+
+	t.Run("post-commit stream failure remains in stream without DONE", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl-partial\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"partial\"}}]}\n\n"))
+			_, _ = w.Write([]byte("{\"error\":{\"message\":\"fixture post-commit failure\"}}\n"))
+		}))
+		defer upstream.Close()
+
+		gin.SetMode(gin.TestMode)
+		handler := newOpenAICompatStreamFixtureHandler(t, upstream.URL)
+		router := gin.New()
+		router.POST("/v1/chat/completions", handler.ChatCompletions)
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"openai-sse-fixture-model","stream":true,"messages":[{"role":"user","content":"fixture"}]}`))
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body=%q", resp.Code, http.StatusOK, resp.Body.String())
+		}
+		if !strings.Contains(resp.Body.String(), "chatcmpl-partial") || !strings.Contains(resp.Body.String(), "fixture post-commit failure") {
+			t.Fatalf("post-commit stream body = %q", resp.Body.String())
+		}
+		if strings.Contains(resp.Body.String(), "[DONE]") {
+			t.Fatalf("post-commit stream synthesized DONE: %q", resp.Body.String())
+		}
+	})
+}
+
+func TestOpenAICompatChatStreamCancellationReachesUpstream(t *testing.T) {
+	upstreamCanceled := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl-cancel\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"partial\"}}]}\n\n"))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+		close(upstreamCanceled)
+	}))
+	defer upstream.Close()
+
+	gin.SetMode(gin.TestMode)
+	handler := newOpenAICompatStreamFixtureHandler(t, upstream.URL)
+	router := gin.New()
+	router.POST("/v1/chat/completions", handler.ChatCompletions)
+	downstream := httptest.NewServer(router)
+	defer downstream.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, errRequest := http.NewRequestWithContext(ctx, http.MethodPost, downstream.URL+"/v1/chat/completions", strings.NewReader(`{"model":"openai-sse-fixture-model","stream":true,"messages":[{"role":"user","content":"fixture"}]}`))
+	if errRequest != nil {
+		t.Fatalf("new request: %v", errRequest)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, errDo := http.DefaultClient.Do(req)
+	if errDo != nil {
+		t.Fatalf("stream request: %v", errDo)
+	}
+	defer resp.Body.Close()
+
+	line, errRead := bufio.NewReader(resp.Body).ReadString('\n')
+	if errRead != nil {
+		t.Fatalf("read first stream line: %v", errRead)
+	}
+	if !strings.Contains(line, "chatcmpl-cancel") {
+		t.Fatalf("first stream line = %q", line)
+	}
+	cancel()
+
+	select {
+	case <-upstreamCanceled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upstream did not observe client cancellation")
+	}
+}

--- a/sdk/api/handlers/openai/openai_chat_stream_passthrough_test.go
+++ b/sdk/api/handlers/openai/openai_chat_stream_passthrough_test.go
@@ -76,25 +76,27 @@ func TestOpenAICompatChatStreamPreservesNativeSSEFraming(t *testing.T) {
 	terminalWithoutDone := "data: {\"id\":\"chatcmpl-native-no-done\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"fixture response\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":60,\"completion_tokens\":9,\"total_tokens\":69,\"prompt_tokens_details\":{\"cached_tokens\":20}}}\n"
 	malformedEvent := "event: message\ndata: {\"usage\":\n\ndata: [DONE]\n"
 	terminalWithDone := ": fixture keepalive\n\ndata: {\"id\":\"chatcmpl-native-terminal\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"fixture response\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":101,\"completion_tokens\":17,\"total_tokens\":125,\"prompt_tokens_details\":{\"cached_tokens\":60},\"completion_tokens_details\":{\"reasoning_tokens\":7}}}\n\ndata: {\"id\":\"chatcmpl-native-terminal\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":999,\"completion_tokens\":999,\"total_tokens\":1998}}\n\ndata: [DONE]\n"
+	terminalWithDoneExpected := strings.TrimPrefix(terminalWithDone, ": fixture keepalive\n\n")
 	framingFields := "event: message\nid: fixture-42\nretry: 2500\ndata: {\"id\":\"chatcmpl-framing\",\"object\":\"chat.completion.chunk\",\"choices\":[]}\n\n"
 
 	for _, tc := range []struct {
 		name      string
 		upstream  string
+		expected  string
 		doneCount int
 	}{
-		{name: "clean EOF does not add DONE", upstream: terminalWithoutDone, doneCount: 0},
-		{name: "malformed event retains event field", upstream: malformedEvent, doneCount: 1},
-		{name: "normal terminal usage and DONE remain unchanged", upstream: terminalWithDone, doneCount: 1},
-		{name: "event id and retry fields remain unchanged", upstream: framingFields, doneCount: 0},
+		{name: "clean EOF does not add DONE", upstream: terminalWithoutDone, expected: terminalWithoutDone, doneCount: 0},
+		{name: "malformed event retains event field", upstream: malformedEvent, expected: malformedEvent, doneCount: 1},
+		{name: "normal terminal usage and DONE preserve data order", upstream: terminalWithDone, expected: terminalWithDoneExpected, doneCount: 1},
+		{name: "event id and retry fields remain unchanged", upstream: framingFields, expected: framingFields, doneCount: 0},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			resp := runOpenAICompatStreamFixture(t, tc.upstream)
 			if resp.Code != http.StatusOK {
 				t.Fatalf("status = %d, want %d; body=%q", resp.Code, http.StatusOK, resp.Body.String())
 			}
-			if got := resp.Body.String(); got != tc.upstream {
-				t.Fatalf("stream body = %q, want %q", got, tc.upstream)
+			if got := resp.Body.String(); got != tc.expected {
+				t.Fatalf("stream body = %q, want %q", got, tc.expected)
 			}
 			if got := strings.Count(resp.Body.String(), "data: [DONE]"); got != tc.doneCount {
 				t.Fatalf("DONE count = %d, want %d; body=%q", got, tc.doneCount, resp.Body.String())

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	responsesconverter "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/openai/openai/responses"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -469,7 +470,7 @@ func (h *OpenAIAPIHandler) handleStreamingResponse(c *gin.Context, rawJSON []byt
 
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
-	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, h.GetAlt(c))
+	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManagerWithSSEPassthrough(cliCtx, h.HandlerType(), modelName, rawJSON, h.GetAlt(c))
 
 	setSSEHeaders := func() {
 		c.Header("Content-Type", "text/event-stream")
@@ -513,11 +514,19 @@ func (h *OpenAIAPIHandler) handleStreamingResponse(c *gin.Context, rawJSON []byt
 			setSSEHeaders()
 			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 
-			_, _ = fmt.Fprintf(c.Writer, "data: %s\n\n", string(chunk))
+			if chunk.SSEPassthrough {
+				_, _ = c.Writer.Write(chunk.Payload)
+			} else {
+				_, _ = fmt.Fprintf(c.Writer, "data: %s\n\n", string(chunk.Payload))
+			}
 			flusher.Flush()
 
 			// Continue streaming the rest
-			h.handleStreamResult(c, flusher, func(err error) { cliCancel(err) }, dataChan, errChan)
+			if chunk.SSEPassthrough {
+				h.handleRawSSEStreamResult(c, flusher, func(err error) { cliCancel(err) }, dataChan, errChan)
+			} else {
+				h.handleStreamResult(c, flusher, func(err error) { cliCancel(err) }, handlers.StreamChunkPayloads(cliCtx, dataChan), errChan)
+			}
 			return
 		}
 	}
@@ -668,22 +677,37 @@ func (h *OpenAIAPIHandler) handleStreamResult(c *gin.Context, flusher http.Flush
 			_, _ = fmt.Fprintf(c.Writer, "data: %s\n\n", string(chunk))
 		},
 		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) {
-			if errMsg == nil {
-				return
-			}
-			status := http.StatusInternalServerError
-			if errMsg.StatusCode > 0 {
-				status = errMsg.StatusCode
-			}
-			errText := http.StatusText(status)
-			if errMsg.Error != nil && errMsg.Error.Error() != "" {
-				errText = errMsg.Error.Error()
-			}
-			body := handlers.BuildErrorResponseBody(status, errText)
-			_, _ = fmt.Fprintf(c.Writer, "data: %s\n\n", string(body))
+			writeOpenAIStreamTerminalError(c, errMsg)
 		},
 		WriteDone: func() {
 			_, _ = fmt.Fprint(c.Writer, "data: [DONE]\n\n")
 		},
 	})
+}
+
+func (h *OpenAIAPIHandler) handleRawSSEStreamResult(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan coreexecutor.StreamChunk, errs <-chan *interfaces.ErrorMessage) {
+	h.ForwardStream(c, flusher, cancel, handlers.StreamChunkPayloads(c.Request.Context(), data), errs, handlers.StreamForwardOptions{
+		WriteChunk: func(chunk []byte) {
+			_, _ = c.Writer.Write(chunk)
+		},
+		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) {
+			writeOpenAIStreamTerminalError(c, errMsg)
+		},
+	})
+}
+
+func writeOpenAIStreamTerminalError(c *gin.Context, errMsg *interfaces.ErrorMessage) {
+	if errMsg == nil {
+		return
+	}
+	status := http.StatusInternalServerError
+	if errMsg.StatusCode > 0 {
+		status = errMsg.StatusCode
+	}
+	errText := http.StatusText(status)
+	if errMsg.Error != nil && errMsg.Error.Error() != "" {
+		errText = errMsg.Error.Error()
+	}
+	body := handlers.BuildErrorResponseBody(status, errText)
+	_, _ = fmt.Fprintf(c.Writer, "data: %s\n\n", string(body))
 }

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -128,6 +128,8 @@ type Response struct {
 type StreamChunk struct {
 	// Payload is the raw provider chunk payload.
 	Payload []byte
+	// SSEPassthrough reports that Payload is already native SSE framing and must not be reframed.
+	SSEPassthrough bool
 	// Err reports any terminal error encountered while producing chunks.
 	Err error
 }


### PR DESCRIPTION
Fixes #4333.

## Summary
- Preserve native SSE field/data framing for the direct OpenAI-compatible `/v1/chat/completions` path.
- Forward an upstream `data: [DONE]` exactly once and do not manufacture one after a clean upstream EOF.
- Keep cross-protocol translation and `/v1/completions` conversion on their existing paths.

## Fixture Evidence
- Baseline upstream `main`: `c8803713c972af0076f55933fdeed4db81d72d24` / tree `920f98a1638ea1adf6b67545b5b4e56ae4bb49e3`; the loopback-only ticket-25 harness had 13 passing checks and the two documented failures.
- PR candidate: `d997d59fd227bac9d16e7c51fd63ec98ee2055b6` / tree `18454ac20adfa2b3b9b2b305d72b99a02a352946`; the adapted immutable-identity harness passed all 15 checks with a clean source tree before and after execution.
- Both runs use only local `127.0.0.1` fixture servers. No provider request, credential, production configuration, Tunnel, release, or deployment was used.

## Verification
- `go test ./... -count=1`
- `go build -buildvcs=false -o <temp> ./cmd/server`
- focused SSE framing, cancellation, pre/post-commit error regression tests
- ticket-18 native fixtures and ticket-25 15-gate harness

## Status
No deploy, release, merge, or production change is included or authorized.