### PR TITLE
feat(codex): support AgentAssertion auth for Codex agent identity

### DIFF
--- a/internal/runtime/executor/agent_identity.go
+++ b/internal/runtime/executor/agent_identity.go
@@ -1,0 +1,126 @@
+package executor
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// agentAssertionScheme is the Authorization scheme used by Codex agent identity auths.
+const agentAssertionScheme = "AgentAssertion"
+
+// agentAssertion is the signed identity envelope carried in the Authorization header.
+type agentAssertion struct {
+	AgentRuntimeID string `json:"agent_runtime_id"`
+	TaskID         string `json:"task_id"`
+	Timestamp      string `json:"timestamp"`
+	Signature      string `json:"signature"`
+}
+
+// agentIdentityCreds holds agent identity credential material extracted from auth metadata.
+type agentIdentityCreds struct {
+	runtimeID     string
+	privateKeyB64 string
+	taskID        string
+	accountID     string
+}
+
+func agentIdentityMetadataString(auth *cliproxyauth.Auth, keys ...string) string {
+	if auth == nil || auth.Metadata == nil {
+		return ""
+	}
+	for _, key := range keys {
+		if v, ok := auth.Metadata[key].(string); ok {
+			if trimmed := strings.TrimSpace(v); trimmed != "" {
+				return trimmed
+			}
+		}
+	}
+	return ""
+}
+
+// agentIdentityCredsFromAuth extracts agent identity credentials from auth metadata.
+// Canonical keys are agent_runtime_id, agent_private_key and task_id; legacy
+// private_key_pkcs8_base64 and private_key spellings are accepted as aliases.
+func agentIdentityCredsFromAuth(auth *cliproxyauth.Auth) agentIdentityCreds {
+	return agentIdentityCreds{
+		runtimeID:     agentIdentityMetadataString(auth, "agent_runtime_id"),
+		privateKeyB64: agentIdentityMetadataString(auth, "agent_private_key", "private_key_pkcs8_base64", "private_key"),
+		taskID:        agentIdentityMetadataString(auth, "task_id"),
+		accountID:     agentIdentityMetadataString(auth, "account_id", "chatgpt_account_id"),
+	}
+}
+
+// isAgentIdentityAuth reports whether the auth carries agent identity credentials.
+func isAgentIdentityAuth(auth *cliproxyauth.Auth) bool {
+	if auth == nil || auth.Metadata == nil {
+		return false
+	}
+	if kind := agentIdentityMetadataString(auth, "auth_kind"); strings.EqualFold(kind, "agent_identity") {
+		return true
+	}
+	if t := agentIdentityMetadataString(auth, "type"); strings.EqualFold(t, "agent_identity") {
+		return true
+	}
+	creds := agentIdentityCredsFromAuth(auth)
+	return creds.runtimeID != "" && creds.privateKeyB64 != ""
+}
+
+// agentIdentityAccountID returns the ChatGPT account id associated with an agent identity auth.
+func agentIdentityAccountID(auth *cliproxyauth.Auth) string {
+	return agentIdentityCredsFromAuth(auth).accountID
+}
+
+// agentIdentityPrivateKey decodes the base64 PKCS#8 DER private key into an Ed25519 key.
+func agentIdentityPrivateKey(privateKeyB64 string) (ed25519.PrivateKey, error) {
+	der, err := base64.StdEncoding.DecodeString(privateKeyB64)
+	if err != nil {
+		return nil, fmt.Errorf("agent identity auth: decode private key: %w", err)
+	}
+	parsedKey, err := x509.ParsePKCS8PrivateKey(der)
+	if err != nil {
+		return nil, fmt.Errorf("agent identity auth: parse private key: %w", err)
+	}
+	privateKey, ok := parsedKey.(ed25519.PrivateKey)
+	if !ok || len(privateKey) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("agent identity auth: private key is not ed25519")
+	}
+	return privateKey, nil
+}
+
+// buildAgentAssertion signs "<agent_runtime_id>:<task_id>:<timestamp>" with the Ed25519
+// private key and returns the Authorization header value
+// "AgentAssertion <base64url(JSON envelope)>".
+func buildAgentAssertion(creds agentIdentityCreds, now time.Time) (string, error) {
+	if creds.runtimeID == "" || creds.privateKeyB64 == "" || creds.taskID == "" {
+		return "", fmt.Errorf("agent identity auth: missing agent_runtime_id, agent_private_key or task_id")
+	}
+	privateKey, err := agentIdentityPrivateKey(creds.privateKeyB64)
+	if err != nil {
+		return "", err
+	}
+	timestamp := now.UTC().Format(time.RFC3339)
+	payload := creds.runtimeID + ":" + creds.taskID + ":" + timestamp
+	signature := ed25519.Sign(privateKey, []byte(payload))
+	envelope, err := json.Marshal(agentAssertion{
+		AgentRuntimeID: creds.runtimeID,
+		TaskID:         creds.taskID,
+		Timestamp:      timestamp,
+		Signature:      base64.StdEncoding.EncodeToString(signature),
+	})
+	if err != nil {
+		return "", fmt.Errorf("agent identity auth: marshal assertion: %w", err)
+	}
+	return agentAssertionScheme + " " + base64.RawURLEncoding.EncodeToString(envelope), nil
+}
+
+// generateAgentAssertion builds a fresh Authorization header value for the auth.
+func generateAgentAssertion(auth *cliproxyauth.Auth) (string, error) {
+	return buildAgentAssertion(agentIdentityCredsFromAuth(auth), time.Now())
+}

--- a/internal/runtime/executor/agent_identity.go
+++ b/internal/runtime/executor/agent_identity.go
@@ -78,10 +78,24 @@ func agentIdentityAccountID(auth *cliproxyauth.Auth) string {
 }
 
 // agentIdentityPrivateKey decodes the base64 PKCS#8 DER private key into an Ed25519 key.
+// Metadata often contains whitespace/newlines or omits padding, so decoding accepts both
+// standard and raw base64 after stripping whitespace.
 func agentIdentityPrivateKey(privateKeyB64 string) (ed25519.PrivateKey, error) {
-	der, err := base64.StdEncoding.DecodeString(privateKeyB64)
+	cleaned := strings.Map(func(r rune) rune {
+		switch r {
+		case ' ', '\n', '\r', '	':
+			return -1
+		default:
+			return r
+		}
+	}, privateKeyB64)
+	der, err := base64.StdEncoding.DecodeString(cleaned)
 	if err != nil {
-		return nil, fmt.Errorf("agent identity auth: decode private key: %w", err)
+		var errRaw error
+		der, errRaw = base64.RawStdEncoding.DecodeString(cleaned)
+		if errRaw != nil {
+			return nil, fmt.Errorf("agent identity auth: decode private key: %w", err)
+		}
 	}
 	parsedKey, err := x509.ParsePKCS8PrivateKey(der)
 	if err != nil {

--- a/internal/runtime/executor/agent_identity.go
+++ b/internal/runtime/executor/agent_identity.go
@@ -69,7 +69,7 @@ func isAgentIdentityAuth(auth *cliproxyauth.Auth) bool {
 		return true
 	}
 	creds := agentIdentityCredsFromAuth(auth)
-	return creds.runtimeID != "" && creds.privateKeyB64 != ""
+	return creds.runtimeID != "" && creds.privateKeyB64 != "" && creds.taskID != ""
 }
 
 // agentIdentityAccountID returns the ChatGPT account id associated with an agent identity auth.

--- a/internal/runtime/executor/agent_identity.go
+++ b/internal/runtime/executor/agent_identity.go
@@ -58,18 +58,9 @@ func agentIdentityCredsFromAuth(auth *cliproxyauth.Auth) agentIdentityCreds {
 }
 
 // isAgentIdentityAuth reports whether the auth carries agent identity credentials.
+// Delegates to the shared classifier so executor and auth manager agree.
 func isAgentIdentityAuth(auth *cliproxyauth.Auth) bool {
-	if auth == nil || auth.Metadata == nil {
-		return false
-	}
-	if kind := agentIdentityMetadataString(auth, "auth_kind"); strings.EqualFold(kind, "agent_identity") {
-		return true
-	}
-	if t := agentIdentityMetadataString(auth, "type"); strings.EqualFold(t, "agent_identity") {
-		return true
-	}
-	creds := agentIdentityCredsFromAuth(auth)
-	return creds.runtimeID != "" && creds.privateKeyB64 != "" && creds.taskID != ""
+	return cliproxyauth.IsAgentIdentityAuth(auth)
 }
 
 // agentIdentityAccountID returns the ChatGPT account id associated with an agent identity auth.

--- a/internal/runtime/executor/agent_identity_test.go
+++ b/internal/runtime/executor/agent_identity_test.go
@@ -201,6 +201,24 @@ func TestCodexPrepareRequestOAuthKeepsBearer(t *testing.T) {
 	}
 }
 
+func TestCodexPrepareRequestOAuthWithIncompleteAgentIdentityKeepsBearer(t *testing.T) {
+	auth, _ := agentIdentityTestAuth(t, "agent_private_key")
+	auth.Metadata["type"] = "codex"
+	auth.Metadata["access_token"] = "tok"
+	delete(auth.Metadata, "task_id")
+	req, err := http.NewRequest(http.MethodPost, "https://example.test/responses", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	if err = NewCodexExecutor(nil).PrepareRequest(req, auth); err != nil {
+		t.Fatalf("PrepareRequest() error = %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer tok" {
+		t.Fatalf("Authorization = %q, want Bearer tok", got)
+	}
+}
+
 func TestApplyCodexWebsocketHeadersFreshAssertionPerDial(t *testing.T) {
 	auth, publicKey := agentIdentityTestAuth(t, "agent_private_key")
 

--- a/internal/runtime/executor/agent_identity_test.go
+++ b/internal/runtime/executor/agent_identity_test.go
@@ -111,7 +111,9 @@ func TestApplyCodexHeadersFromSourcesUsesAgentAssertion(t *testing.T) {
 		t.Fatalf("new request: %v", err)
 	}
 
-	applyCodexHeadersFromSources(req, auth, "ignored-bearer", true, nil, nil)
+	if err := applyCodexHeadersFromSources(req, auth, "ignored-bearer", true, nil, nil); err != nil {
+		t.Fatalf("applyCodexHeadersFromSources() error = %v", err)
+	}
 	parseAgentAssertionForTest(t, req.Header.Get("Authorization"))
 	if got := req.Header.Get("Chatgpt-Account-Id"); got != "acct-test" {
 		t.Fatalf("Chatgpt-Account-Id = %q, want acct-test", got)
@@ -152,7 +154,9 @@ func TestApplyCodexHeadersFromSourcesPrefersNonEmptyAccountID(t *testing.T) {
 		t.Fatalf("new request: %v", err)
 	}
 
-	applyCodexHeadersFromSources(req, auth, "ignored-bearer", true, nil, nil)
+	if err := applyCodexHeadersFromSources(req, auth, "ignored-bearer", true, nil, nil); err != nil {
+		t.Fatalf("applyCodexHeadersFromSources() error = %v", err)
+	}
 	if got := req.Header.Get("Chatgpt-Account-Id"); got != "acct-fallback" {
 		t.Fatalf("Chatgpt-Account-Id = %q, want acct-fallback", got)
 	}
@@ -168,7 +172,9 @@ func TestApplyCodexHeadersFromSourcesOAuthKeepsBearer(t *testing.T) {
 		t.Fatalf("new request: %v", err)
 	}
 
-	applyCodexHeadersFromSources(req, auth, "tok", true, nil, nil)
+	if err := applyCodexHeadersFromSources(req, auth, "tok", true, nil, nil); err != nil {
+		t.Fatalf("applyCodexHeadersFromSources() error = %v", err)
+	}
 	if got := req.Header.Get("Authorization"); got != "Bearer tok" {
 		t.Fatalf("Authorization = %q, want Bearer tok", got)
 	}
@@ -198,7 +204,10 @@ func TestCodexPrepareRequestOAuthKeepsBearer(t *testing.T) {
 func TestApplyCodexWebsocketHeadersFreshAssertionPerDial(t *testing.T) {
 	auth, publicKey := agentIdentityTestAuth(t, "agent_private_key")
 
-	first := applyCodexWebsocketHeaders(context.Background(), nil, auth, "", nil)
+	first, err := applyCodexWebsocketHeaders(context.Background(), nil, auth, "", nil)
+	if err != nil {
+		t.Fatalf("applyCodexWebsocketHeaders() error = %v", err)
+	}
 	firstAssertion := parseAgentAssertionForTest(t, first.Get("Authorization"))
 	if firstAssertion.TaskID != "task-test" {
 		t.Fatalf("first dial task_id = %q, want task-test", firstAssertion.TaskID)
@@ -209,7 +218,10 @@ func TestApplyCodexWebsocketHeadersFreshAssertionPerDial(t *testing.T) {
 
 	// A later dial must sign the current metadata, not reuse a cached assertion.
 	auth.Metadata["task_id"] = "task-rotated"
-	second := applyCodexWebsocketHeaders(context.Background(), nil, auth, "", nil)
+	second, err := applyCodexWebsocketHeaders(context.Background(), nil, auth, "", nil)
+	if err != nil {
+		t.Fatalf("second applyCodexWebsocketHeaders() error = %v", err)
+	}
 	secondAssertion := parseAgentAssertionForTest(t, second.Get("Authorization"))
 	if secondAssertion.TaskID != "task-rotated" {
 		t.Fatalf("second dial task_id = %q, want task-rotated", secondAssertion.TaskID)
@@ -229,11 +241,54 @@ func TestApplyCodexWebsocketHeadersOAuthKeepsBearer(t *testing.T) {
 		Provider: "codex",
 		Metadata: map[string]any{"type": "codex", "access_token": "tok", "account_id": "acct-oauth"},
 	}
-	headers := applyCodexWebsocketHeaders(context.Background(), nil, auth, "tok", nil)
+	headers, err := applyCodexWebsocketHeaders(context.Background(), nil, auth, "tok", nil)
+	if err != nil {
+		t.Fatalf("applyCodexWebsocketHeaders() error = %v", err)
+	}
 	if got := headers.Get("Authorization"); got != "Bearer tok" {
 		t.Fatalf("Authorization = %q, want Bearer tok", got)
 	}
 	if got := headerValueCaseInsensitive(headers, "ChatGPT-Account-ID"); got != "acct-oauth" {
 		t.Fatalf("ChatGPT-Account-ID = %q, want acct-oauth", got)
+	}
+}
+
+func TestApplyCodexHeadersFromSourcesReturnsAssertionError(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{
+			"type":             "agent_identity",
+			"agent_runtime_id": "agent-test",
+			// missing task_id and private key
+		},
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://example.test/responses", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := applyCodexHeadersFromSources(req, auth, "", true, nil, nil); err == nil {
+		t.Fatal("expected assertion generation error")
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want empty on failure", got)
+	}
+}
+
+func TestApplyCodexWebsocketHeadersReturnsAssertionError(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{
+			"type":              "agent_identity",
+			"agent_runtime_id":  "agent-test",
+			"agent_private_key": "not-valid-base64!!!",
+			"task_id":           "task-test",
+		},
+	}
+	headers, err := applyCodexWebsocketHeaders(context.Background(), nil, auth, "", nil)
+	if err == nil {
+		t.Fatal("expected assertion generation error")
+	}
+	if headers != nil {
+		t.Fatalf("headers = %#v, want nil on failure", headers)
 	}
 }

--- a/internal/runtime/executor/agent_identity_test.go
+++ b/internal/runtime/executor/agent_identity_test.go
@@ -8,9 +8,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/gorilla/websocket"
 
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
@@ -219,38 +223,91 @@ func TestCodexPrepareRequestOAuthWithIncompleteAgentIdentityKeepsBearer(t *testi
 	}
 }
 
-func TestApplyCodexWebsocketHeadersFreshAssertionPerDial(t *testing.T) {
-	auth, publicKey := agentIdentityTestAuth(t, "agent_private_key")
+func TestApplyCodexWebsocketHeadersDefersAssertionToDial(t *testing.T) {
+	auth, _ := agentIdentityTestAuth(t, "agent_private_key")
 
-	first, err := applyCodexWebsocketHeaders(context.Background(), nil, auth, "", nil)
+	headers, err := applyCodexWebsocketHeaders(context.Background(), nil, auth, "", nil)
 	if err != nil {
 		t.Fatalf("applyCodexWebsocketHeaders() error = %v", err)
 	}
-	firstAssertion := parseAgentAssertionForTest(t, first.Get("Authorization"))
-	if firstAssertion.TaskID != "task-test" {
-		t.Fatalf("first dial task_id = %q, want task-test", firstAssertion.TaskID)
+	if got := headers.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want empty before dial", got)
 	}
-	if got := headerValueCaseInsensitive(first, "ChatGPT-Account-ID"); got != "acct-test" {
+	if got := headerValueCaseInsensitive(headers, "ChatGPT-Account-ID"); got != "acct-test" {
 		t.Fatalf("ChatGPT-Account-ID = %q, want acct-test", got)
 	}
+}
 
-	// A later dial must sign the current metadata, not reuse a cached assertion.
+func TestDialCodexWebsocketMintsFreshAssertionPerDial(t *testing.T) {
+	auth, publicKey := agentIdentityTestAuth(t, "agent_private_key")
+
+	var (
+		mu          sync.Mutex
+		authHeaders []string
+		upgrader    = websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+		mu.Unlock()
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		_ = conn.Close()
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	executor := NewCodexWebsocketsExecutor(nil)
+	baseHeaders, err := applyCodexWebsocketHeaders(context.Background(), nil, auth, "", nil)
+	if err != nil {
+		t.Fatalf("applyCodexWebsocketHeaders() error = %v", err)
+	}
+
+	// First dial
+	conn1, _, err := executor.dialCodexWebsocket(context.Background(), auth, wsURL, baseHeaders)
+	if err != nil {
+		t.Fatalf("first dial error = %v", err)
+	}
+	_ = conn1.Close()
+
+	// Simulate queue delay and rotated task metadata before reconnect dial.
+	time.Sleep(1100 * time.Millisecond)
 	auth.Metadata["task_id"] = "task-rotated"
-	second, err := applyCodexWebsocketHeaders(context.Background(), nil, auth, "", nil)
+	conn2, _, err := executor.dialCodexWebsocket(context.Background(), auth, wsURL, baseHeaders)
 	if err != nil {
-		t.Fatalf("second applyCodexWebsocketHeaders() error = %v", err)
+		t.Fatalf("second dial error = %v", err)
 	}
-	secondAssertion := parseAgentAssertionForTest(t, second.Get("Authorization"))
-	if secondAssertion.TaskID != "task-rotated" {
-		t.Fatalf("second dial task_id = %q, want task-rotated", secondAssertion.TaskID)
+	_ = conn2.Close()
+
+	mu.Lock()
+	gotHeaders := append([]string(nil), authHeaders...)
+	mu.Unlock()
+	if len(gotHeaders) != 2 {
+		t.Fatalf("dial count = %d, want 2; headers=%v", len(gotHeaders), gotHeaders)
 	}
-	signature, err := base64.StdEncoding.DecodeString(secondAssertion.Signature)
-	if err != nil {
-		t.Fatalf("decode signature: %v", err)
+	first := parseAgentAssertionForTest(t, gotHeaders[0])
+	second := parseAgentAssertionForTest(t, gotHeaders[1])
+	if first.TaskID != "task-test" {
+		t.Fatalf("first dial task_id = %q, want task-test", first.TaskID)
 	}
-	payload := secondAssertion.AgentRuntimeID + ":" + secondAssertion.TaskID + ":" + secondAssertion.Timestamp
-	if !ed25519.Verify(publicKey, []byte(payload), signature) {
-		t.Fatal("second dial signature does not verify")
+	if second.TaskID != "task-rotated" {
+		t.Fatalf("second dial task_id = %q, want task-rotated", second.TaskID)
+	}
+	if first.Timestamp == second.Timestamp && first.Signature == second.Signature {
+		t.Fatalf("expected distinct assertions across dials; first=%+v second=%+v", first, second)
+	}
+	for i, assertion := range []agentAssertion{first, second} {
+		signature, err := base64.StdEncoding.DecodeString(assertion.Signature)
+		if err != nil {
+			t.Fatalf("decode signature %d: %v", i, err)
+		}
+		payload := assertion.AgentRuntimeID + ":" + assertion.TaskID + ":" + assertion.Timestamp
+		if !ed25519.Verify(publicKey, []byte(payload), signature) {
+			t.Fatalf("dial %d signature does not verify", i)
+		}
 	}
 }
 

--- a/internal/runtime/executor/agent_identity_test.go
+++ b/internal/runtime/executor/agent_identity_test.go
@@ -118,6 +118,46 @@ func TestApplyCodexHeadersFromSourcesUsesAgentAssertion(t *testing.T) {
 	}
 }
 
+func TestAgentIdentityPrivateKeyAcceptsWhitespaceAndRawBase64(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("marshal private key: %v", err)
+	}
+	std := base64.StdEncoding.EncodeToString(der)
+	raw := base64.RawStdEncoding.EncodeToString(der)
+	wrapped := std[:20] + "\n " + std[20:]
+
+	for _, keyB64 := range []string{wrapped, raw} {
+		got, err := agentIdentityPrivateKey(keyB64)
+		if err != nil {
+			t.Fatalf("agentIdentityPrivateKey(%q) error = %v", keyB64[:24], err)
+		}
+		if len(got) != ed25519.PrivateKeySize {
+			t.Fatalf("private key size = %d", len(got))
+		}
+	}
+}
+
+func TestApplyCodexHeadersFromSourcesPrefersNonEmptyAccountID(t *testing.T) {
+	auth, _ := agentIdentityTestAuth(t, "agent_private_key")
+	// Empty account_id must not clobber chatgpt_account_id fallback.
+	auth.Metadata["account_id"] = "   "
+	auth.Metadata["chatgpt_account_id"] = "acct-fallback"
+	req, err := http.NewRequest(http.MethodPost, "https://example.test/responses", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	applyCodexHeadersFromSources(req, auth, "ignored-bearer", true, nil, nil)
+	if got := req.Header.Get("Chatgpt-Account-Id"); got != "acct-fallback" {
+		t.Fatalf("Chatgpt-Account-Id = %q, want acct-fallback", got)
+	}
+}
+
 func TestApplyCodexHeadersFromSourcesOAuthKeepsBearer(t *testing.T) {
 	auth := &cliproxyauth.Auth{
 		Provider: "codex",

--- a/internal/runtime/executor/agent_identity_test.go
+++ b/internal/runtime/executor/agent_identity_test.go
@@ -1,0 +1,199 @@
+package executor
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func agentIdentityTestAuth(t *testing.T, keyName string) (*cliproxyauth.Auth, ed25519.PublicKey) {
+	t.Helper()
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("marshal private key: %v", err)
+	}
+	metadata := map[string]any{
+		"type":             "agent_identity",
+		"agent_runtime_id": "agent-test",
+		"task_id":          "task-test",
+		"account_id":       "acct-test",
+		keyName:            base64.StdEncoding.EncodeToString(der),
+	}
+	return &cliproxyauth.Auth{Provider: "codex", Metadata: metadata}, publicKey
+}
+
+func parseAgentAssertionForTest(t *testing.T, header string) agentAssertion {
+	t.Helper()
+	if !strings.HasPrefix(header, agentAssertionScheme+" ") {
+		t.Fatalf("Authorization = %q, want %s scheme", header, agentAssertionScheme)
+	}
+	encoded := strings.TrimPrefix(header, agentAssertionScheme+" ")
+	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode assertion envelope: %v", err)
+	}
+	var assertion agentAssertion
+	if err = json.Unmarshal(raw, &assertion); err != nil {
+		t.Fatalf("unmarshal assertion envelope: %v", err)
+	}
+	return assertion
+}
+
+func TestBuildAgentAssertionSignsCanonicalPayload(t *testing.T) {
+	auth, publicKey := agentIdentityTestAuth(t, "agent_private_key")
+	now := time.Date(2026, time.July, 15, 12, 34, 56, 0, time.UTC)
+
+	header, err := buildAgentAssertion(agentIdentityCredsFromAuth(auth), now)
+	if err != nil {
+		t.Fatalf("buildAgentAssertion() error = %v", err)
+	}
+	assertion := parseAgentAssertionForTest(t, header)
+	if assertion.AgentRuntimeID != "agent-test" || assertion.TaskID != "task-test" {
+		t.Fatalf("assertion identity = %#v", assertion)
+	}
+	if assertion.Timestamp != "2026-07-15T12:34:56Z" {
+		t.Fatalf("timestamp = %q", assertion.Timestamp)
+	}
+	signature, err := base64.StdEncoding.DecodeString(assertion.Signature)
+	if err != nil {
+		t.Fatalf("decode signature: %v", err)
+	}
+	payload := assertion.AgentRuntimeID + ":" + assertion.TaskID + ":" + assertion.Timestamp
+	if !ed25519.Verify(publicKey, []byte(payload), signature) {
+		t.Fatal("signature does not verify canonical payload")
+	}
+}
+
+func TestAgentIdentityAcceptsLegacyPrivateKeyAliases(t *testing.T) {
+	for _, keyName := range []string{"private_key_pkcs8_base64", "private_key"} {
+		t.Run(keyName, func(t *testing.T) {
+			auth, _ := agentIdentityTestAuth(t, keyName)
+			if _, err := buildAgentAssertion(agentIdentityCredsFromAuth(auth), time.Unix(0, 0)); err != nil {
+				t.Fatalf("legacy key %s rejected: %v", keyName, err)
+			}
+		})
+	}
+}
+
+func TestCodexPrepareRequestUsesAgentAssertion(t *testing.T) {
+	auth, _ := agentIdentityTestAuth(t, "agent_private_key")
+	req, err := http.NewRequest(http.MethodPost, "https://example.test/responses", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	if err = NewCodexExecutor(nil).PrepareRequest(req, auth); err != nil {
+		t.Fatalf("PrepareRequest() error = %v", err)
+	}
+	parseAgentAssertionForTest(t, req.Header.Get("Authorization"))
+	if got := req.Header.Get("Chatgpt-Account-Id"); got != "acct-test" {
+		t.Fatalf("Chatgpt-Account-Id = %q, want acct-test", got)
+	}
+}
+
+func TestApplyCodexHeadersFromSourcesUsesAgentAssertion(t *testing.T) {
+	auth, _ := agentIdentityTestAuth(t, "agent_private_key")
+	req, err := http.NewRequest(http.MethodPost, "https://example.test/responses", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	applyCodexHeadersFromSources(req, auth, "ignored-bearer", true, nil, nil)
+	parseAgentAssertionForTest(t, req.Header.Get("Authorization"))
+	if got := req.Header.Get("Chatgpt-Account-Id"); got != "acct-test" {
+		t.Fatalf("Chatgpt-Account-Id = %q, want acct-test", got)
+	}
+}
+
+func TestApplyCodexHeadersFromSourcesOAuthKeepsBearer(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex", "access_token": "tok", "account_id": "acct-oauth"},
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://example.test/responses", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	applyCodexHeadersFromSources(req, auth, "tok", true, nil, nil)
+	if got := req.Header.Get("Authorization"); got != "Bearer tok" {
+		t.Fatalf("Authorization = %q, want Bearer tok", got)
+	}
+	if got := req.Header.Get("Chatgpt-Account-Id"); got != "acct-oauth" {
+		t.Fatalf("Chatgpt-Account-Id = %q, want acct-oauth", got)
+	}
+}
+
+func TestCodexPrepareRequestOAuthKeepsBearer(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex", "access_token": "tok"},
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://example.test/responses", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	if err = NewCodexExecutor(nil).PrepareRequest(req, auth); err != nil {
+		t.Fatalf("PrepareRequest() error = %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer tok" {
+		t.Fatalf("Authorization = %q, want Bearer tok", got)
+	}
+}
+
+func TestApplyCodexWebsocketHeadersFreshAssertionPerDial(t *testing.T) {
+	auth, publicKey := agentIdentityTestAuth(t, "agent_private_key")
+
+	first := applyCodexWebsocketHeaders(context.Background(), nil, auth, "", nil)
+	firstAssertion := parseAgentAssertionForTest(t, first.Get("Authorization"))
+	if firstAssertion.TaskID != "task-test" {
+		t.Fatalf("first dial task_id = %q, want task-test", firstAssertion.TaskID)
+	}
+	if got := headerValueCaseInsensitive(first, "ChatGPT-Account-ID"); got != "acct-test" {
+		t.Fatalf("ChatGPT-Account-ID = %q, want acct-test", got)
+	}
+
+	// A later dial must sign the current metadata, not reuse a cached assertion.
+	auth.Metadata["task_id"] = "task-rotated"
+	second := applyCodexWebsocketHeaders(context.Background(), nil, auth, "", nil)
+	secondAssertion := parseAgentAssertionForTest(t, second.Get("Authorization"))
+	if secondAssertion.TaskID != "task-rotated" {
+		t.Fatalf("second dial task_id = %q, want task-rotated", secondAssertion.TaskID)
+	}
+	signature, err := base64.StdEncoding.DecodeString(secondAssertion.Signature)
+	if err != nil {
+		t.Fatalf("decode signature: %v", err)
+	}
+	payload := secondAssertion.AgentRuntimeID + ":" + secondAssertion.TaskID + ":" + secondAssertion.Timestamp
+	if !ed25519.Verify(publicKey, []byte(payload), signature) {
+		t.Fatal("second dial signature does not verify")
+	}
+}
+
+func TestApplyCodexWebsocketHeadersOAuthKeepsBearer(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex", "access_token": "tok", "account_id": "acct-oauth"},
+	}
+	headers := applyCodexWebsocketHeaders(context.Background(), nil, auth, "tok", nil)
+	if got := headers.Get("Authorization"); got != "Bearer tok" {
+		t.Fatalf("Authorization = %q, want Bearer tok", got)
+	}
+	if got := headerValueCaseInsensitive(headers, "ChatGPT-Account-ID"); got != "acct-oauth" {
+		t.Fatalf("ChatGPT-Account-ID = %q, want acct-oauth", got)
+	}
+}

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1684,10 +1684,17 @@ func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, toke
 		r.Header.Set("Originator", codexOriginator)
 	}
 	if !isAPIKey {
+		accountID := ""
 		if auth != nil && auth.Metadata != nil {
-			if accountID, ok := auth.Metadata["account_id"].(string); ok {
-				r.Header.Set("Chatgpt-Account-Id", accountID)
+			if v, ok := auth.Metadata["account_id"].(string); ok {
+				accountID = strings.TrimSpace(v)
 			}
+		}
+		if accountID == "" {
+			accountID = agentIdentityAccountID(auth)
+		}
+		if accountID != "" {
+			r.Header.Set("Chatgpt-Account-Id", accountID)
 		}
 	}
 	var attrs map[string]string

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -723,9 +723,20 @@ func (e *CodexExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Aut
 	if req == nil {
 		return nil
 	}
-	apiKey, _ := codexCreds(auth)
-	if strings.TrimSpace(apiKey) != "" {
-		req.Header.Set("Authorization", "Bearer "+apiKey)
+	if isAgentIdentityAuth(auth) {
+		assertion, err := generateAgentAssertion(auth)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", assertion)
+		if accountID := agentIdentityAccountID(auth); accountID != "" {
+			req.Header.Set("Chatgpt-Account-Id", accountID)
+		}
+	} else {
+		apiKey, _ := codexCreds(auth)
+		if strings.TrimSpace(apiKey) != "" {
+			req.Header.Set("Authorization", "Bearer "+apiKey)
+		}
 	}
 	var attrs map[string]string
 	if auth != nil {
@@ -1628,7 +1639,18 @@ func applyCodexDirectImageHeaders(r *http.Request, auth *cliproxyauth.Auth, toke
 
 func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, token string, stream bool, cfg *config.Config, ginHeaders http.Header) {
 	r.Header.Set("Content-Type", "application/json")
-	r.Header.Set("Authorization", "Bearer "+token)
+	if isAgentIdentityAuth(auth) {
+		if assertion, err := generateAgentAssertion(auth); err != nil {
+			log.Errorf("codex executor: generate agent assertion: %v", err)
+		} else {
+			r.Header.Set("Authorization", assertion)
+		}
+		if accountID := agentIdentityAccountID(auth); accountID != "" {
+			r.Header.Set("Chatgpt-Account-Id", accountID)
+		}
+	} else {
+		r.Header.Set("Authorization", "Bearer "+token)
+	}
 
 	if ginHeaders != nil && ginHeaders.Get("X-Codex-Beta-Features") != "" {
 		r.Header.Set("X-Codex-Beta-Features", ginHeaders.Get("X-Codex-Beta-Features"))
@@ -1925,6 +1947,10 @@ func codexCreds(a *cliproxyauth.Auth) (apiKey, baseURL string) {
 	if a.Attributes != nil {
 		apiKey = a.Attributes["api_key"]
 		baseURL = a.Attributes["base_url"]
+	}
+	if isAgentIdentityAuth(a) {
+		// Agent identity auths sign per-request assertions; there is no bearer credential.
+		return "", baseURL
 	}
 	if apiKey == "" && a.Metadata != nil {
 		if v, ok := a.Metadata["access_token"].(string); ok {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -821,7 +821,9 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	if err != nil {
 		return resp, err
 	}
-	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
+	if err = applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg); err != nil {
+		return resp, err
+	}
 	applyModelHeaderOverrides(httpReq.Header, baseModel)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	var authID, authLabel, authType, authValue string
@@ -991,7 +993,9 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	if err != nil {
 		return resp, err
 	}
-	applyCodexHeaders(httpReq, auth, apiKey, false, e.cfg)
+	if err = applyCodexHeaders(httpReq, auth, apiKey, false, e.cfg); err != nil {
+		return resp, err
+	}
 	applyModelHeaderOverrides(httpReq.Header, baseModel)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	var authID, authLabel, authType, authValue string
@@ -1106,7 +1110,9 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	if err != nil {
 		return nil, err
 	}
-	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
+	if err = applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg); err != nil {
+		return nil, err
+	}
 	applyModelHeaderOverrides(httpReq.Header, baseModel)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	var authID, authLabel, authType, authValue string
@@ -1601,12 +1607,12 @@ func codexIdentityConfuseUUID(authID string, kind string, value string) string {
 	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(name)).String()
 }
 
-func applyCodexHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, stream bool, cfg *config.Config) {
+func applyCodexHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, stream bool, cfg *config.Config) error {
 	var ginHeaders http.Header
 	if ginCtx, ok := r.Context().Value("gin").(*gin.Context); ok && ginCtx != nil && ginCtx.Request != nil {
 		ginHeaders = ginCtx.Request.Header
 	}
-	applyCodexHeadersFromSources(r, auth, token, stream, cfg, ginHeaders)
+	return applyCodexHeadersFromSources(r, auth, token, stream, cfg, ginHeaders)
 }
 
 // applyModelHeaderOverrides forces models.json config.override_header onto upstream headers.
@@ -1628,23 +1634,23 @@ func applyModelHeaderOverrides(headers http.Header, modelName string) {
 
 // applyCodexDirectImageHeaders sets Codex upstream headers for direct /images/* calls.
 // Downstream client User-Agent values are not forwarded to reduce Cloudflare 1010 blocks.
-func applyCodexDirectImageHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, stream bool, cfg *config.Config) {
+func applyCodexDirectImageHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, stream bool, cfg *config.Config) error {
 	var ginHeaders http.Header
 	if ginCtx, ok := r.Context().Value("gin").(*gin.Context); ok && ginCtx != nil && ginCtx.Request != nil {
 		ginHeaders = ginCtx.Request.Header.Clone()
 		ginHeaders.Del("User-Agent")
 	}
-	applyCodexHeadersFromSources(r, auth, token, stream, cfg, ginHeaders)
+	return applyCodexHeadersFromSources(r, auth, token, stream, cfg, ginHeaders)
 }
 
-func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, token string, stream bool, cfg *config.Config, ginHeaders http.Header) {
+func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, token string, stream bool, cfg *config.Config, ginHeaders http.Header) error {
 	r.Header.Set("Content-Type", "application/json")
 	if isAgentIdentityAuth(auth) {
-		if assertion, err := generateAgentAssertion(auth); err != nil {
-			log.Errorf("codex executor: generate agent assertion: %v", err)
-		} else {
-			r.Header.Set("Authorization", assertion)
+		assertion, err := generateAgentAssertion(auth)
+		if err != nil {
+			return fmt.Errorf("codex executor: generate agent assertion: %w", err)
 		}
+		r.Header.Set("Authorization", assertion)
 		if accountID := agentIdentityAccountID(auth); accountID != "" {
 			r.Header.Set("Chatgpt-Account-Id", accountID)
 		}
@@ -1702,6 +1708,7 @@ func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, toke
 		attrs = auth.Attributes
 	}
 	util.ApplyCustomHeadersFromAttrs(r, attrs)
+	return nil
 }
 
 func newCodexStatusErr(statusCode int, body []byte) statusErr {

--- a/internal/runtime/executor/codex_openai_images.go
+++ b/internal/runtime/executor/codex_openai_images.go
@@ -112,7 +112,9 @@ func (e *CodexExecutor) executeOpenAIImage(ctx context.Context, auth *cliproxyau
 	if errCache != nil {
 		return resp, errCache
 	}
-	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
+	if err := applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg); err != nil {
+		return resp, err
+	}
 	applyModelHeaderOverrides(httpReq.Header, mainModel)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	recordCodexOpenAIImageRequest(ctx, e.cfg, e.Identifier(), auth, url, httpReq.Header.Clone(), body)
@@ -209,7 +211,9 @@ func (e *CodexExecutor) executeOpenAIImageStream(ctx context.Context, auth *clip
 	if errCache != nil {
 		return nil, errCache
 	}
-	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
+	if err := applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg); err != nil {
+		return nil, err
+	}
 	applyModelHeaderOverrides(httpReq.Header, mainModel)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	recordCodexOpenAIImageRequest(ctx, e.cfg, e.Identifier(), auth, url, httpReq.Header.Clone(), body)
@@ -336,7 +340,9 @@ func (e *CodexExecutor) executeDirectOpenAIImage(ctx context.Context, auth *clip
 	if errCache != nil {
 		return resp, errCache
 	}
-	applyCodexDirectImageHeaders(httpReq, auth, apiKey, false, e.cfg)
+	if err := applyCodexDirectImageHeaders(httpReq, auth, apiKey, false, e.cfg); err != nil {
+		return resp, err
+	}
 	applyModelHeaderOverrides(httpReq.Header, model)
 	if contentType != "" {
 		httpReq.Header.Set("Content-Type", contentType)
@@ -397,7 +403,9 @@ func (e *CodexExecutor) executeDirectOpenAIImageStream(ctx context.Context, auth
 	if errCache != nil {
 		return nil, errCache
 	}
-	applyCodexDirectImageHeaders(httpReq, auth, apiKey, true, e.cfg)
+	if err := applyCodexDirectImageHeaders(httpReq, auth, apiKey, true, e.cfg); err != nil {
+		return nil, err
+	}
 	applyModelHeaderOverrides(httpReq.Header, model)
 	if contentType != "" {
 		httpReq.Header.Set("Content-Type", contentType)

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -912,7 +912,13 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, auth *
 	if headers == nil {
 		headers = http.Header{}
 	}
-	if strings.TrimSpace(token) != "" {
+	if isAgentIdentityAuth(auth) {
+		if assertion, err := generateAgentAssertion(auth); err != nil {
+			log.Errorf("codex websocket executor: generate agent assertion: %v", err)
+		} else {
+			headers.Set("Authorization", assertion)
+		}
+	} else if strings.TrimSpace(token) != "" {
 		headers.Set("Authorization", "Bearer "+token)
 	}
 
@@ -954,12 +960,17 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, auth *
 		headers.Set("Originator", codexOriginator)
 	}
 	if !isAPIKey {
+		accountID := ""
 		if auth != nil && auth.Metadata != nil {
-			if accountID, ok := auth.Metadata["account_id"].(string); ok {
-				if trimmed := strings.TrimSpace(accountID); trimmed != "" {
-					setHeaderCasePreserved(headers, "ChatGPT-Account-ID", trimmed)
-				}
+			if v, ok := auth.Metadata["account_id"].(string); ok {
+				accountID = strings.TrimSpace(v)
 			}
+		}
+		if accountID == "" {
+			accountID = agentIdentityAccountID(auth)
+		}
+		if accountID != "" {
+			setHeaderCasePreserved(headers, "ChatGPT-Account-ID", accountID)
 		}
 	}
 

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -718,7 +718,22 @@ func (e *CodexWebsocketsExecutor) dialCodexWebsocket(ctx context.Context, auth *
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	conn, resp, err := dialer.DialContext(ctx, wsURL, headers)
+	// AgentAssertion timestamps are short-lived. Always mint a fresh assertion
+	// immediately before DialContext so queued requests and reconnect dials never
+	// reuse a pre-lock / pre-retry Authorization header.
+	dialHeaders := headers
+	if isAgentIdentityAuth(auth) {
+		dialHeaders = http.Header{}
+		if headers != nil {
+			dialHeaders = headers.Clone()
+		}
+		assertion, errAssertion := generateAgentAssertion(auth)
+		if errAssertion != nil {
+			return nil, nil, fmt.Errorf("codex websocket executor: generate agent assertion: %w", errAssertion)
+		}
+		dialHeaders.Set("Authorization", assertion)
+	}
+	conn, resp, err := dialer.DialContext(ctx, wsURL, dialHeaders)
 	if conn != nil {
 		// Avoid gorilla/websocket flate tail validation issues on some upstreams/Go versions.
 		// Negotiating permessage-deflate is fine; we just don't compress outbound messages.
@@ -921,11 +936,12 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, auth *
 		headers = http.Header{}
 	}
 	if isAgentIdentityAuth(auth) {
-		assertion, err := generateAgentAssertion(auth)
-		if err != nil {
+		// Validate material early, but do not publish Authorization here.
+		// dialCodexWebsocket mints a fresh AgentAssertion immediately before each DialContext.
+		if _, err := generateAgentAssertion(auth); err != nil {
 			return nil, fmt.Errorf("codex websocket executor: generate agent assertion: %w", err)
 		}
-		headers.Set("Authorization", assertion)
+		headers.Del("Authorization")
 	} else if strings.TrimSpace(token) != "" {
 		headers.Set("Authorization", "Bearer "+token)
 	}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -230,7 +230,11 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	var identityState codexIdentityConfuseState
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
-	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
+	var errHeaders error
+	wsHeaders, errHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
+	if errHeaders != nil {
+		return resp, errHeaders
+	}
 	applyModelHeaderOverrides(wsHeaders, baseModel)
 	applyCodexIdentityConfuseHeaders(wsHeaders, &identityState)
 
@@ -452,7 +456,11 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	var identityState codexIdentityConfuseState
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, userPayload, body)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
-	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
+	var errHeaders error
+	wsHeaders, errHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
+	if errHeaders != nil {
+		return nil, errHeaders
+	}
 	applyModelHeaderOverrides(wsHeaders, baseModel)
 	applyCodexIdentityConfuseHeaders(wsHeaders, &identityState)
 
@@ -908,16 +916,16 @@ func applyCodexPromptCacheHeadersWithContext(ctx context.Context, from sdktransl
 	return rawJSON, headers, nil
 }
 
-func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, auth *cliproxyauth.Auth, token string, cfg *config.Config) http.Header {
+func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, auth *cliproxyauth.Auth, token string, cfg *config.Config) (http.Header, error) {
 	if headers == nil {
 		headers = http.Header{}
 	}
 	if isAgentIdentityAuth(auth) {
-		if assertion, err := generateAgentAssertion(auth); err != nil {
-			log.Errorf("codex websocket executor: generate agent assertion: %v", err)
-		} else {
-			headers.Set("Authorization", assertion)
+		assertion, err := generateAgentAssertion(auth)
+		if err != nil {
+			return nil, fmt.Errorf("codex websocket executor: generate agent assertion: %w", err)
 		}
+		headers.Set("Authorization", assertion)
 	} else if strings.TrimSpace(token) != "" {
 		headers.Set("Authorization", "Bearer "+token)
 	}
@@ -980,7 +988,7 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, auth *
 	}
 	util.ApplyCustomHeadersFromAttrs(&http.Request{Header: headers}, attrs)
 
-	return headers
+	return headers, nil
 }
 
 func ensureCodexWebsocketSessionHeader(target http.Header, source http.Header, fallbackValue string) {

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -407,7 +407,10 @@ func TestCodexWebsocketsUpstreamDisconnectChanSignalsOnInvalidate(t *testing.T) 
 }
 
 func TestApplyCodexWebsocketHeadersDefaultsToCurrentResponsesBeta(t *testing.T) {
-	headers := applyCodexWebsocketHeaders(context.Background(), http.Header{}, nil, "", nil)
+	headers, err := applyCodexWebsocketHeaders(context.Background(), http.Header{}, nil, "", nil)
+	if err != nil {
+		t.Fatalf("applyCodexWebsocketHeaders() error = %v", err)
+	}
 
 	if got := headers.Get("OpenAI-Beta"); got != codexResponsesWebsocketBetaHeaderValue {
 		t.Fatalf("OpenAI-Beta = %s, want %s", got, codexResponsesWebsocketBetaHeaderValue)
@@ -455,7 +458,10 @@ func TestApplyCodexWebsocketHeadersPassesThroughClientIdentityHeaders(t *testing
 		"session-id":            "legacy-session",
 	})
 
-	headers := applyCodexWebsocketHeaders(ctx, http.Header{}, auth, "", nil)
+	headers, err := applyCodexWebsocketHeaders(ctx, http.Header{}, auth, "", nil)
+	if err != nil {
+		t.Fatalf("applyCodexWebsocketHeaders() error = %v", err)
+	}
 
 	if got := headers.Get("Originator"); got != "Codex Desktop" {
 		t.Fatalf("Originator = %s, want %s", got, "Codex Desktop")
@@ -491,7 +497,10 @@ func TestApplyCodexWebsocketHeadersCanonicalizesLegacyUnderscoreSessionHeader(t 
 		"Session_id": "legacy-underscore-session",
 	})
 
-	headers := applyCodexWebsocketHeaders(ctx, http.Header{}, auth, "", nil)
+	headers, err := applyCodexWebsocketHeaders(ctx, http.Header{}, auth, "", nil)
+	if err != nil {
+		t.Fatalf("applyCodexWebsocketHeaders() error = %v", err)
+	}
 
 	if got := headers["session_id"]; len(got) != 1 || got[0] != "legacy-underscore-session" {
 		t.Fatalf("session_id = %#v, want [legacy-underscore-session]", got)
@@ -513,7 +522,10 @@ func TestApplyCodexWebsocketHeadersUsesConfigDefaultsForOAuth(t *testing.T) {
 		Metadata: map[string]any{"email": "user@example.com"},
 	}
 
-	headers := applyCodexWebsocketHeaders(context.Background(), http.Header{}, auth, "", cfg)
+	headers, err := applyCodexWebsocketHeaders(context.Background(), http.Header{}, auth, "", cfg)
+	if err != nil {
+		t.Fatalf("applyCodexWebsocketHeaders() error = %v", err)
+	}
 
 	if got := headers.Get("User-Agent"); got != "my-codex-client/1.0" {
 		t.Fatalf("User-Agent = %s, want %s", got, "my-codex-client/1.0")
@@ -545,7 +557,10 @@ func TestApplyCodexWebsocketHeadersPrefersExistingHeadersOverClientAndConfig(t *
 	headers.Set("User-Agent", "existing-ua")
 	headers.Set("X-Codex-Beta-Features", "existing-beta")
 
-	got := applyCodexWebsocketHeaders(ctx, headers, auth, "", cfg)
+	got, err := applyCodexWebsocketHeaders(ctx, headers, auth, "", cfg)
+	if err != nil {
+		t.Fatalf("applyCodexWebsocketHeaders() error = %v", err)
+	}
 
 	if gotVal := got.Get("User-Agent"); gotVal != "existing-ua" {
 		t.Fatalf("User-Agent = %s, want %s", gotVal, "existing-ua")
@@ -571,7 +586,10 @@ func TestApplyCodexWebsocketHeadersConfigUserAgentOverridesClientHeader(t *testi
 		"X-Codex-Beta-Features": "client-beta",
 	})
 
-	headers := applyCodexWebsocketHeaders(ctx, http.Header{}, auth, "", cfg)
+	headers, err := applyCodexWebsocketHeaders(ctx, http.Header{}, auth, "", cfg)
+	if err != nil {
+		t.Fatalf("applyCodexWebsocketHeaders() error = %v", err)
+	}
 
 	if got := headers.Get("User-Agent"); got != "config-ua" {
 		t.Fatalf("User-Agent = %s, want %s", got, "config-ua")
@@ -593,7 +611,10 @@ func TestApplyCodexWebsocketHeadersIgnoresConfigForAPIKeyAuth(t *testing.T) {
 		Attributes: map[string]string{"api_key": "sk-test"},
 	}
 
-	headers := applyCodexWebsocketHeaders(context.Background(), http.Header{}, auth, "sk-test", cfg)
+	headers, err := applyCodexWebsocketHeaders(context.Background(), http.Header{}, auth, "sk-test", cfg)
+	if err != nil {
+		t.Fatalf("applyCodexWebsocketHeaders() error = %v", err)
+	}
 
 	if got := headers.Get("User-Agent"); got != "" {
 		t.Fatalf("User-Agent = %s, want empty", got)
@@ -610,7 +631,10 @@ func TestApplyCodexWebsocketHeadersPreservesExplicitAPIKeyUserAgent(t *testing.T
 	auth := &cliproxyauth.Auth{Provider: "codex", Attributes: map[string]string{"api_key": "sk-test"}}
 	ctx := contextWithGinHeaders(map[string]string{"User-Agent": "api-key-client/1.0", "Originator": "explicit-origin"})
 
-	headers := applyCodexWebsocketHeaders(ctx, http.Header{}, auth, "sk-test", nil)
+	headers, err := applyCodexWebsocketHeaders(ctx, http.Header{}, auth, "sk-test", nil)
+	if err != nil {
+		t.Fatalf("applyCodexWebsocketHeaders() error = %v", err)
+	}
 
 	if got := headers.Get("User-Agent"); got != "api-key-client/1.0" {
 		t.Fatalf("User-Agent = %s, want api-key-client/1.0", got)
@@ -623,7 +647,10 @@ func TestApplyCodexWebsocketHeadersPreservesExplicitAPIKeyUserAgent(t *testing.T
 func TestApplyCodexWebsocketHeadersUsesCanonicalAccountHeader(t *testing.T) {
 	auth := &cliproxyauth.Auth{Provider: "codex", Metadata: map[string]any{"account_id": "acct-1"}}
 
-	headers := applyCodexWebsocketHeaders(context.Background(), http.Header{}, auth, "", nil)
+	headers, err := applyCodexWebsocketHeaders(context.Background(), http.Header{}, auth, "", nil)
+	if err != nil {
+		t.Fatalf("applyCodexWebsocketHeaders() error = %v", err)
+	}
 
 	if got := headerValueCaseInsensitive(headers, "ChatGPT-Account-ID"); got != "acct-1" {
 		t.Fatalf("ChatGPT-Account-ID = %s, want acct-1", got)
@@ -727,7 +754,11 @@ func TestApplyCodexWebsocketHeadersIdentityConfuseRemapsPromptCacheKey(t *testin
 		"X-Codex-Turn-Metadata": `{"prompt_cache_key":"cache-ws-1","turn_id":"turn-ws-1","window_id":"cache-ws-1:0"}`,
 		"X-Client-Request-Id":   "client-request-1",
 	})
-	headers = applyCodexWebsocketHeaders(ctx, headers, auth, "oauth-token", cfg)
+	var err error
+	headers, err = applyCodexWebsocketHeaders(ctx, headers, auth, "oauth-token", cfg)
+	if err != nil {
+		t.Fatalf("applyCodexWebsocketHeaders() error = %v", err)
+	}
 	applyCodexIdentityConfuseHeaders(headers, &identityState)
 
 	expectedPromptCacheKey := codexIdentityConfuseUUID("auth-ws-1", "prompt-cache", "cache-ws-1")

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -65,6 +65,30 @@ func SynthesizeAuthFile(ctx *SynthesisContext, fullPath string, data []byte) []*
 	return synthesizeFileAuths(ctx, fullPath, data)
 }
 
+
+// resolveFileAuthKind decides the shared auth_kind for a synthesized file credential.
+// Codex Agent Identity files must not be labeled oauth: they must be excluded from
+// OAuth-only selection (/alpha/search) and OAuth refresh paths.
+func resolveFileAuthKind(metadata map[string]any) string {
+	auth := &coreauth.Auth{Metadata: metadata}
+	if coreauth.IsAgentIdentityAuth(auth) {
+		return coreauth.AuthKindAgentIdentity
+	}
+	if kind, ok := metadata["auth_kind"].(string); ok {
+		if normalized := strings.ToLower(strings.TrimSpace(kind)); normalized != "" {
+			switch normalized {
+			case coreauth.AuthKindAPIKey, "api_key", "api-key":
+				return coreauth.AuthKindAPIKey
+			case coreauth.AuthKindOAuth, "oauth2":
+				return coreauth.AuthKindOAuth
+			case coreauth.AuthKindAgentIdentity, "agent-identity":
+				return coreauth.AuthKindAgentIdentity
+			}
+		}
+	}
+	return coreauth.AuthKindOAuth
+}
+
 func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []*coreauth.Auth {
 	if ctx == nil || len(data) == 0 {
 		return nil
@@ -206,7 +230,8 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 	}
 	coreauth.ApplyCustomHeadersFromMetadata(a)
 	coreauth.SetOAuthModelAliasesAttribute(a, perAccountModelAliases)
-	ApplyAuthExcludedModelsMeta(a, cfg, perAccountExcluded, "oauth")
+	authKind := resolveFileAuthKind(metadata)
+	ApplyAuthExcludedModelsMeta(a, cfg, perAccountExcluded, authKind)
 	// For codex auth files, extract plan_type from the JWT id_token.
 	if provider == "codex" {
 		if idTokenRaw, ok := metadata["id_token"].(string); ok && strings.TrimSpace(idTokenRaw) != "" {

--- a/internal/watcher/synthesizer/file_test.go
+++ b/internal/watcher/synthesizer/file_test.go
@@ -698,3 +698,35 @@ func TestFileSynthesizer_Synthesize_NoteParsing(t *testing.T) {
 		})
 	}
 }
+
+func TestSynthesizeAuthFileAgentIdentityAuthKind(t *testing.T) {
+	tempDir := t.TempDir()
+	fullPath := filepath.Join(tempDir, "codex-agent.json")
+	raw := []byte(`{
+		"type": "codex",
+		"auth_kind": "agent_identity",
+		"email": "agent@example.com",
+		"refresh_token": "stale-refresh",
+		"agent_runtime_id": "agent-1",
+		"task_id": "task-1",
+		"agent_private_key": "cHJpdmF0ZQ=="
+	}`)
+
+	ctx := &SynthesisContext{
+		Config:  &config.Config{},
+		AuthDir: tempDir,
+		Now:     time.Date(2026, 6, 21, 0, 0, 0, 0, time.UTC),
+	}
+	auths := SynthesizeAuthFile(ctx, fullPath, raw)
+	if len(auths) != 1 {
+		t.Fatalf("SynthesizeAuthFile() len = %d, want 1", len(auths))
+	}
+	auth := auths[0]
+	if got := auth.Attributes["auth_kind"]; got != coreauth.AuthKindAgentIdentity {
+		t.Fatalf("auth_kind attribute = %q, want %q", got, coreauth.AuthKindAgentIdentity)
+	}
+	if got := auth.AuthKind(); got != coreauth.AuthKindAgentIdentity {
+		t.Fatalf("AuthKind() = %q, want %q", got, coreauth.AuthKindAgentIdentity)
+	}
+}
+

--- a/internal/watcher/synthesizer/helpers.go
+++ b/internal/watcher/synthesizer/helpers.go
@@ -72,7 +72,8 @@ func ApplyAuthExcludedModelsMeta(auth *coreauth.Auth, cfg *config.Config, perKey
 			}
 		}
 	}
-	if authKindKey == "apikey" {
+	if authKindKey == "apikey" || authKindKey == "agent_identity" {
+		// API keys and Agent Identity are not OAuth credentials; only per-account exclusions apply.
 		add(perKey)
 	} else {
 		// For OAuth: merge per-account excluded models with global provider-level exclusions

--- a/sdk/cliproxy/auth/auto_refresh_loop.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop.go
@@ -343,7 +343,9 @@ func nextRefreshCheckAt(now time.Time, auth *Auth, interval time.Duration) (time
 		return time.Time{}, false
 	}
 
-	if auth.AuthKind() == AuthKindAPIKey {
+	switch auth.AuthKind() {
+	case AuthKindAPIKey, AuthKindAgentIdentity:
+		// API keys never refresh; Agent Identity signs each request and has no OAuth token lifecycle.
 		return time.Time{}, false
 	}
 

--- a/sdk/cliproxy/auth/auto_refresh_loop_test.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop_test.go
@@ -70,6 +70,26 @@ func TestNextRefreshCheckAt_APIKeyUnschedule(t *testing.T) {
 	}
 }
 
+func TestNextRefreshCheckAt_AgentIdentityUnschedule(t *testing.T) {
+	now := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
+	auth := &Auth{
+		ID:       "agent-1",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"auth_kind":         AuthKindAgentIdentity,
+			"email":             "agent@example.com",
+			"refresh_token":     "stale-refresh",
+			"agent_runtime_id":  "agent-1",
+			"task_id":           "task-1",
+			"agent_private_key": "cHJpdmF0ZQ==",
+		},
+	}
+	if _, ok := nextRefreshCheckAt(now, auth, 15*time.Minute); ok {
+		t.Fatalf("nextRefreshCheckAt() ok = true, want false for agent identity")
+	}
+}
+
+
 func TestNextRefreshCheckAt_NextRefreshAfterGate(t *testing.T) {
 	now := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
 	nextAfter := now.Add(30 * time.Minute)

--- a/sdk/cliproxy/auth/classification.go
+++ b/sdk/cliproxy/auth/classification.go
@@ -3,8 +3,9 @@ package auth
 import "strings"
 
 const (
-	AuthKindAPIKey = "apikey"
-	AuthKindOAuth  = "oauth"
+	AuthKindAPIKey         = "apikey"
+	AuthKindOAuth          = "oauth"
+	AuthKindAgentIdentity  = "agent_identity"
 
 	AuthSourceConfig      = "config"
 	AuthSourceFile        = "file"
@@ -32,6 +33,11 @@ func (a *Auth) AuthKind() string {
 	}
 	if kind := normalizeAuthKind(authMetadataString(a, AttributeAuthKind)); kind != "" {
 		return kind
+	}
+	// Agent Identity must be classified before OAuth fallbacks: files often retain
+	// email / stale refresh_token fields that would otherwise look like OAuth.
+	if IsAgentIdentityAuth(a) {
+		return AuthKindAgentIdentity
 	}
 	if authAttribute(a, AttributeAPIKey) != "" {
 		return AuthKindAPIKey
@@ -79,6 +85,8 @@ func normalizeAuthKind(kind string) string {
 		return AuthKindAPIKey
 	case AuthKindOAuth, "oauth2":
 		return AuthKindOAuth
+	case AuthKindAgentIdentity, "agent-identity":
+		return AuthKindAgentIdentity
 	default:
 		return ""
 	}
@@ -101,6 +109,34 @@ func normalizeAuthSourceKind(source string) string {
 	default:
 		return ""
 	}
+}
+
+
+// IsAgentIdentityAuth reports whether the auth carries Codex Agent Identity material.
+// Detection prefers explicit auth_kind/type, then required signing fields.
+func IsAgentIdentityAuth(auth *Auth) bool {
+	if auth == nil {
+		return false
+	}
+	if kind := normalizeAuthKind(authAttribute(auth, AttributeAuthKind)); kind == AuthKindAgentIdentity {
+		return true
+	}
+	if kind := normalizeAuthKind(authMetadataString(auth, AttributeAuthKind)); kind == AuthKindAgentIdentity {
+		return true
+	}
+	if strings.EqualFold(authMetadataString(auth, "type"), AuthKindAgentIdentity) {
+		return true
+	}
+	runtimeID := authMetadataString(auth, "agent_runtime_id")
+	taskID := authMetadataString(auth, "task_id")
+	privateKey := authMetadataString(auth, "agent_private_key")
+	if privateKey == "" {
+		privateKey = authMetadataString(auth, "private_key_pkcs8_base64")
+	}
+	if privateKey == "" {
+		privateKey = authMetadataString(auth, "private_key")
+	}
+	return runtimeID != "" && taskID != "" && privateKey != ""
 }
 
 func authHasOAuthMetadata(auth *Auth) bool {

--- a/sdk/cliproxy/auth/classification_test.go
+++ b/sdk/cliproxy/auth/classification_test.go
@@ -34,6 +34,23 @@ func TestAuthKind(t *testing.T) {
 			want: AuthKindOAuth,
 		},
 		{
+			name: "explicit agent identity attribute",
+			auth: &Auth{Attributes: map[string]string{AttributeAuthKind: AuthKindAgentIdentity}},
+			want: AuthKindAgentIdentity,
+		},
+		{
+			name: "agent identity fields beat retained oauth metadata",
+			auth: &Auth{Metadata: map[string]any{
+				"type":              "codex",
+				"email":             "agent@example.com",
+				"refresh_token":     "stale-refresh",
+				"agent_runtime_id":  "agent-1",
+				"task_id":           "task-1",
+				"agent_private_key": "cHJpdmF0ZQ==",
+			}},
+			want: AuthKindAgentIdentity,
+		},
+		{
 			name: "unknown metadata shape",
 			auth: &Auth{Metadata: map[string]any{"type": "test"}},
 			want: "",
@@ -121,5 +138,17 @@ func TestAccountInfoUsesAuthKind(t *testing.T) {
 	kind, value = oauthWithoutEmail.AccountInfo()
 	if kind != "oauth" || value != "" {
 		t.Fatalf("oauth without email AccountInfo() = %q, %q", kind, value)
+	}
+
+	agentAuth := &Auth{Metadata: map[string]any{
+		"auth_kind":         AuthKindAgentIdentity,
+		"email":             "agent@example.com",
+		"agent_runtime_id":  "agent-1",
+		"task_id":           "task-1",
+		"agent_private_key": "cHJpdmF0ZQ==",
+	}}
+	kind, value = agentAuth.AccountInfo()
+	if kind != AuthKindAgentIdentity || value != "agent@example.com" {
+		t.Fatalf("agent identity AccountInfo() = %q, %q", kind, value)
 	}
 }

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -5913,6 +5913,10 @@ func (m *Manager) tryRefreshAfterUnauthorized(ctx context.Context, auth *Auth, e
 	if m == nil || auth == nil || alreadyTried || execErr == nil {
 		return auth, false
 	}
+	// Agent Identity credentials authenticate via per-request assertions, not OAuth refresh.
+	if auth.AuthKind() == AuthKindAgentIdentity {
+		return auth, false
+	}
 	if !isUnauthorizedError(execErr) || !authHasRefreshCredential(auth) {
 		return auth, false
 	}

--- a/sdk/cliproxy/auth/scheduler_test.go
+++ b/sdk/cliproxy/auth/scheduler_test.go
@@ -509,6 +509,39 @@ func TestManagerSelectAuthByKindRejectsInvalidKind(t *testing.T) {
 	}
 }
 
+func TestManagerSelectAuthByKindExcludesAgentIdentity(t *testing.T) {
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.executors["codex"] = schedulerTestExecutor{}
+	for _, candidate := range []*Auth{
+		{
+			ID:       "codex-agent",
+			Provider: "codex",
+			Attributes: map[string]string{AttributeAuthKind: AuthKindAgentIdentity},
+			Metadata: map[string]any{
+				"auth_kind":         AuthKindAgentIdentity,
+				"email":             "agent@example.com",
+				"refresh_token":     "stale-refresh",
+				"agent_runtime_id":  "agent-1",
+				"task_id":           "task-1",
+				"agent_private_key": "cHJpdmF0ZQ==",
+			},
+		},
+		{ID: "codex-oauth", Provider: "codex", Metadata: map[string]any{"access_token": "test-token"}},
+	} {
+		if _, errRegister := manager.Register(context.Background(), candidate); errRegister != nil {
+			t.Fatalf("Register(%s) error = %v", candidate.ID, errRegister)
+		}
+	}
+
+	selected, errSelect := manager.SelectAuthByKind(context.Background(), "codex", "", AuthKindOAuth, cliproxyexecutor.Options{})
+	if errSelect != nil {
+		t.Fatalf("SelectAuthByKind() error = %v", errSelect)
+	}
+	if selected == nil || selected.ID != "codex-oauth" {
+		t.Fatalf("SelectAuthByKind() auth = %#v, want codex-oauth", selected)
+	}
+}
+
 func TestManagerSelectAuthByKindAdvancesHomeAuthCount(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -574,6 +574,22 @@ func (a *Auth) AccountInfo() (string, string) {
 			}
 		}
 		return "oauth", ""
+	case AuthKindAgentIdentity:
+		if a.Metadata != nil {
+			if v, ok := a.Metadata["email"].(string); ok {
+				email := strings.TrimSpace(v)
+				if email != "" {
+					return AuthKindAgentIdentity, email
+				}
+			}
+			if v, ok := a.Metadata["agent_runtime_id"].(string); ok {
+				runtimeID := strings.TrimSpace(v)
+				if runtimeID != "" {
+					return AuthKindAgentIdentity, runtimeID
+				}
+			}
+		}
+		return AuthKindAgentIdentity, ""
 	case AuthKindAPIKey:
 		if apiKey := authAttribute(a, AttributeAPIKey); apiKey != "" {
 			return "api_key", apiKey


### PR DESCRIPTION
## Summary

Adds minimal first-class support for Codex **Agent Identity** authentication in the built-in Codex executor.

Agent Identity credentials do not carry an OAuth bearer token. Each upstream request is signed as:

```text
Authorization: AgentAssertion <base64url(JSON envelope)>
```

where the signed payload is:

```text
{agent_runtime_id}:{task_id}:{timestamp}
```

This PR is intentionally small and protocol-focused so it can be reviewed and merged independently of external conversion tooling.

## Changes

- New `internal/runtime/executor/agent_identity.go`
  - Detect agent-identity auth from `type` / `auth_kind` / required metadata fields
  - Decode Ed25519 PKCS#8 private keys
  - Build `AgentAssertion` headers
  - Accept canonical `agent_private_key` plus legacy `private_key_pkcs8_base64` / `private_key`
- Wire agent-identity path into:
  - `CodexExecutor.PrepareRequest`
  - `applyCodexHeadersFromSources` (HTTP/SSE)
  - `applyCodexWebsocketHeaders` (WebSocket dial)
- Keep existing OAuth / API-key bearer paths unchanged
- Unit tests for signing, alias compatibility, HTTP/WS header paths, and OAuth regression

## Credential shape

Flat CPA auth JSON:

```json
{
  "type": "codex",
  "auth_kind": "agent_identity",
  "agent_runtime_id": "agent-...",
  "task_id": "task-...",
  "agent_private_key": "<base64 PKCS#8 Ed25519>",
  "email": "optional@example.com",
  "account_id": "optional-chatgpt-account-id",
  "disabled": false
}
```

Notes:
- Top-level `type` remains `codex` so the existing file synthesizer routes to the Codex executor.
- Private key aliases `private_key_pkcs8_base64` and `private_key` are accepted for import compatibility.

## Non-goals

Out of scope for this PR (intentionally left to follow-ups / external tools):

- OAuth → Agent Identity conversion / registration flow
- Task-invalid recovery (`invalid_task_id` re-register + retry)
- Admin UI labels / import wizard
- Credential redaction policy changes beyond current auth-file handling
- Token Foundry / external batch tooling

## Verification

```bash
docker run --rm -v "$(pwd):/src" -w /src golang:1.26 go test ./internal/runtime/executor -count=1
```

Result: `ok .../internal/runtime/executor`

Focused coverage includes:

- assertion signature verifies against the generated Ed25519 public key
- legacy private-key aliases accepted
- HTTP path sets `Authorization: AgentAssertion ...`
- WebSocket dial issues a fresh assertion per dial
- OAuth bearer path remains `Bearer ...`

## Compatibility / Runtime Notes

- Default OFF for existing deployments: only credentials carrying agent-identity metadata take the new path.
- Existing OAuth/API-key Codex accounts are unchanged.
- No config schema change.
- No database / store schema change.
- No new third-party dependency (uses Go stdlib crypto).

## Data / Security Notes

- Private keys remain in auth-file metadata (same storage model as other auth material).
- Assertions are generated per request / per websocket dial; they are not cached.
- No private key is logged by the new code path.
- Follow-up hardening still recommended: admin-API redaction of `agent_private_key` and task-invalid recovery.
