### PR TITLE
fix(xai): simplify flattened codex_app__automation_update tool schema

### DIFF
--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -2112,8 +2112,9 @@ func xaiFunctionParametersNeedSimplification(tool gjson.Result, namespaceName st
 }
 
 // xaiParametersHaveInvalidUnionRoot reports whether a JSON Schema root is an
-// anyOf/oneOf union that xAI rejects (especially unions that include non-object
-// branches such as null).
+// anyOf/oneOf union that xAI rejects because at least one branch is not an
+// object (for example null). Object-only unions are preserved so unrelated
+// tools keep their original parameter contracts.
 func xaiParametersHaveInvalidUnionRoot(params gjson.Result) bool {
 	if !params.Exists() || !params.IsObject() {
 		return false
@@ -2123,10 +2124,14 @@ func xaiParametersHaveInvalidUnionRoot(params gjson.Result) bool {
 	}
 	for _, key := range []string{"anyOf", "oneOf"} {
 		branches := params.Get(key)
-		if !branches.IsArray() || len(branches.Array()) == 0 {
+		if !branches.IsArray() {
 			continue
 		}
-		for _, branch := range branches.Array() {
+		arr := branches.Array()
+		if len(arr) == 0 {
+			continue
+		}
+		for _, branch := range arr {
 			branchType := strings.ToLower(strings.TrimSpace(branch.Get("type").String()))
 			if branchType == "" {
 				// Nested unions or untyped branches are also unsafe for xAI.
@@ -2136,8 +2141,7 @@ func xaiParametersHaveInvalidUnionRoot(params gjson.Result) bool {
 				return true
 			}
 		}
-		// Pure union root without type:object is rejected by xAI.
-		return true
+		// All branches are typed objects: keep the original schema.
 	}
 	return false
 }

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -2086,12 +2086,60 @@ func restoreXAINamespaceToolCallAtPath(data []byte, path string, refs map[string
 	return updated
 }
 
-// xaiFunctionParametersNeedSimplification reports whether a function tool is
-// the Codex Desktop automation tool known to hang xAI Responses streaming.
+// xaiFunctionParametersNeedSimplification reports whether a function tool
+// should have its parameters schema simplified before being sent to xAI.
+//
+// Covers:
+// 1. Codex Desktop namespaced form: namespace=codex_app, name=automation_update
+// 2. Flattened form already renamed to codex_app__automation_update
+// 3. Any function tool whose parameter root is anyOf/oneOf with a non-object
+//    branch (xAI rejects these with invalid_client_tool_schema)
 func xaiFunctionParametersNeedSimplification(tool gjson.Result, namespaceName string) bool {
-	return strings.EqualFold(strings.TrimSpace(tool.Get("type").String()), xaiFunctionToolType) &&
-		strings.EqualFold(strings.TrimSpace(namespaceName), xaiCodexAppNamespaceName) &&
-		strings.EqualFold(strings.TrimSpace(tool.Get("name").String()), xaiAutomationUpdateToolName)
+	if !strings.EqualFold(strings.TrimSpace(tool.Get("type").String()), xaiFunctionToolType) {
+		return false
+	}
+	name := strings.TrimSpace(tool.Get("name").String())
+	namespace := strings.TrimSpace(namespaceName)
+	qualified := xaiCodexAppNamespaceName + "__" + xaiAutomationUpdateToolName
+	if strings.EqualFold(name, qualified) {
+		return true
+	}
+	if strings.EqualFold(namespace, xaiCodexAppNamespaceName) &&
+		strings.EqualFold(name, xaiAutomationUpdateToolName) {
+		return true
+	}
+	return xaiParametersHaveInvalidUnionRoot(tool.Get("parameters"))
+}
+
+// xaiParametersHaveInvalidUnionRoot reports whether a JSON Schema root is an
+// anyOf/oneOf union that xAI rejects (especially unions that include non-object
+// branches such as null).
+func xaiParametersHaveInvalidUnionRoot(params gjson.Result) bool {
+	if !params.Exists() || !params.IsObject() {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(params.Get("type").String()), "object") {
+		return false
+	}
+	for _, key := range []string{"anyOf", "oneOf"} {
+		branches := params.Get(key)
+		if !branches.IsArray() || len(branches.Array()) == 0 {
+			continue
+		}
+		for _, branch := range branches.Array() {
+			branchType := strings.ToLower(strings.TrimSpace(branch.Get("type").String()))
+			if branchType == "" {
+				// Nested unions or untyped branches are also unsafe for xAI.
+				return true
+			}
+			if branchType != "object" {
+				return true
+			}
+		}
+		// Pure union root without type:object is rejected by xAI.
+		return true
+	}
+	return false
 }
 
 func sanitizeXAIInputEncryptedContent(body []byte) []byte {

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -2086,27 +2086,37 @@ func restoreXAINamespaceToolCallAtPath(data []byte, path string, refs map[string
 	return updated
 }
 
-// xaiFunctionParametersNeedSimplification reports whether a function tool
-// should have its parameters schema simplified before being sent to xAI.
+// xaiFunctionParametersNeedSimplification reports whether a tool's parameters
+// schema should be simplified before being sent to xAI.
 //
 // Covers:
 // 1. Codex Desktop namespaced form: namespace=codex_app, name=automation_update
 // 2. Flattened form already renamed to codex_app__automation_update
-// 3. Any function tool whose parameter root is anyOf/oneOf with a non-object
-//    branch (xAI rejects these with invalid_client_tool_schema)
+// 3. Function tools (and client custom tools rewritten to function) whose
+//    parameter root is anyOf/oneOf with a non-object branch
+//    (xAI rejects these with invalid_client_tool_schema)
+//
+// Name-based force simplification stays limited to function tools so ordinary
+// custom tools keep their parameter contracts unless the schema itself is
+// invalid for xAI.
 func xaiFunctionParametersNeedSimplification(tool gjson.Result, namespaceName string) bool {
-	if !strings.EqualFold(strings.TrimSpace(tool.Get("type").String()), xaiFunctionToolType) {
+	toolType := strings.ToLower(strings.TrimSpace(tool.Get("type").String()))
+	// non-apply_patch custom tools are rewritten to function before upstream
+	// send; still evaluate their parameter schemas here.
+	if toolType != xaiFunctionToolType && toolType != xaiCustomToolType {
 		return false
 	}
 	name := strings.TrimSpace(tool.Get("name").String())
 	namespace := strings.TrimSpace(namespaceName)
-	qualified := xaiCodexAppNamespaceName + "__" + xaiAutomationUpdateToolName
-	if strings.EqualFold(name, qualified) {
-		return true
-	}
-	if strings.EqualFold(namespace, xaiCodexAppNamespaceName) &&
-		strings.EqualFold(name, xaiAutomationUpdateToolName) {
-		return true
+	if toolType == xaiFunctionToolType {
+		qualified := xaiCodexAppNamespaceName + "__" + xaiAutomationUpdateToolName
+		if strings.EqualFold(name, qualified) {
+			return true
+		}
+		if strings.EqualFold(namespace, xaiCodexAppNamespaceName) &&
+			strings.EqualFold(name, xaiAutomationUpdateToolName) {
+			return true
+		}
 	}
 	return xaiParametersHaveInvalidUnionRoot(tool.Get("parameters"))
 }

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -2508,6 +2508,14 @@ func TestXAIFunctionParametersNeedSimplification(t *testing.T) {
 	if xaiFunctionParametersNeedSimplification(auto, "") {
 		t.Fatal("top-level automation_update should not need simplification")
 	}
+	flat := gjson.Parse(`{"type":"function","name":"codex_app__automation_update","parameters":{"oneOf":[{"type":"object"},{"type":"null"}]}}`)
+	if !xaiFunctionParametersNeedSimplification(flat, "") {
+		t.Fatal("flattened codex_app__automation_update should need simplification")
+	}
+	union := gjson.Parse(`{"type":"function","name":"other_tool","parameters":{"anyOf":[{"type":"object","properties":{"a":{"type":"string"}}},{"type":"null"}]}}`)
+	if !xaiFunctionParametersNeedSimplification(union, "") {
+		t.Fatal("anyOf root with non-object branch should need simplification")
+	}
 	custom := gjson.Parse(`{"type":"custom","name":"automation_update","parameters":{"type":"object"}}`)
 	if xaiFunctionParametersNeedSimplification(custom, "codex_app") {
 		t.Fatal("custom codex_app.automation_update should not need simplification")

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -2520,6 +2520,10 @@ func TestXAIFunctionParametersNeedSimplification(t *testing.T) {
 	if xaiFunctionParametersNeedSimplification(objectOnlyUnion, "codex_app") {
 		t.Fatal("object-only oneOf root should be preserved")
 	}
+	customUnion := gjson.Parse(`{"type":"custom","name":"custom_lookup","parameters":{"oneOf":[{"type":"object","properties":{"q":{"type":"string"}}},{"type":"null"}]}}`)
+	if !xaiFunctionParametersNeedSimplification(customUnion, "") {
+		t.Fatal("custom tool with non-object union root should need simplification after rewrite to function")
+	}
 	custom := gjson.Parse(`{"type":"custom","name":"automation_update","parameters":{"type":"object"}}`)
 	if xaiFunctionParametersNeedSimplification(custom, "codex_app") {
 		t.Fatal("custom codex_app.automation_update should not need simplification")
@@ -2527,6 +2531,31 @@ func TestXAIFunctionParametersNeedSimplification(t *testing.T) {
 	safe := gjson.Parse(`{"type":"function","name":"exec_command","parameters":{"type":"object","properties":{"cmd":{"type":"string"}}}}`)
 	if xaiFunctionParametersNeedSimplification(safe, "codex_app") {
 		t.Fatal("unrelated codex_app function should not need simplification")
+	}
+}
+
+func TestNormalizeXAITools_SimplifiesCustomInvalidUnionRoot(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"custom","name":"custom_lookup","strict":true,"parameters":{"oneOf":[{"type":"object","properties":{"q":{"type":"string"}}},{"type":"null"}]}}]}`)
+	out := normalizeXAITools(body)
+	tool := gjson.GetBytes(out, "tools.0")
+	if got := tool.Get("type").String(); got != "function" {
+		t.Fatalf("custom tool type = %q, want function; body=%s", got, string(out))
+	}
+	if got := tool.Get("name").String(); got != "custom_lookup" {
+		t.Fatalf("tool name = %q, want custom_lookup; body=%s", got, string(out))
+	}
+	params := tool.Get("parameters")
+	if got := params.Get("type").String(); got != "object" {
+		t.Fatalf("parameters.type = %q, want object; body=%s", got, string(out))
+	}
+	if params.Get("oneOf").Exists() || params.Get("anyOf").Exists() {
+		t.Fatalf("invalid union root was not simplified: %s", string(out))
+	}
+	if params.Get("additionalProperties").Type != gjson.True {
+		t.Fatalf("simplified parameters should allow additionalProperties: %s", string(out))
+	}
+	if tool.Get("strict").Type != gjson.False {
+		t.Fatalf("strict = %s, want false after simplification; body=%s", tool.Get("strict").Raw, string(out))
 	}
 }
 

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -2516,6 +2516,10 @@ func TestXAIFunctionParametersNeedSimplification(t *testing.T) {
 	if !xaiFunctionParametersNeedSimplification(union, "") {
 		t.Fatal("anyOf root with non-object branch should need simplification")
 	}
+	objectOnlyUnion := gjson.Parse(`{"type":"function","name":"exec_command","parameters":{"oneOf":[{"type":"object","properties":{"mode":{"type":"string"}}},{"type":"object","properties":{"cmd":{"type":"string"}}}]}}`)
+	if xaiFunctionParametersNeedSimplification(objectOnlyUnion, "codex_app") {
+		t.Fatal("object-only oneOf root should be preserved")
+	}
 	custom := gjson.Parse(`{"type":"custom","name":"automation_update","parameters":{"type":"object"}}`)
 	if xaiFunctionParametersNeedSimplification(custom, "codex_app") {
 		t.Fatal("custom codex_app.automation_update should not need simplification")


### PR DESCRIPTION
Fixes #4343

Extend the existing xAI tool-schema simplification path so flattened codex_app__automation_update tools and anyOf/oneOf non-object parameter roots are rewritten before upstream send, while preserving normal tool calling.