### PR TITLE
fix(executor): normalize upstream base URL joins

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1705,14 +1705,13 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 	var lastErr error
 
 	for idx, baseURL := range baseURLs {
-		base := strings.TrimSuffix(baseURL, "/")
+		base := helps.NormalizeBaseURL(baseURL)
 		if base == "" {
 			base = buildBaseURL(auth)
 		}
 
 		var requestURL strings.Builder
-		requestURL.WriteString(base)
-		requestURL.WriteString(antigravityCountTokensPath)
+		requestURL.WriteString(helps.JoinBaseURL(base, antigravityCountTokensPath))
 		if opts.Alt != "" {
 			requestURL.WriteString("?$alt=")
 			requestURL.WriteString(url.QueryEscape(opts.Alt))
@@ -2114,7 +2113,7 @@ func (e *AntigravityExecutor) updateAntigravityCreditsBalance(ctx context.Contex
 		return
 	}
 	baseURL := antigravityLoadCodeAssistBaseURL(auth)
-	endpointURL := strings.TrimSuffix(baseURL, "/") + "/v1internal:loadCodeAssist"
+	endpointURL := helps.JoinBaseURL(baseURL, "/v1internal:loadCodeAssist")
 	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, bytes.NewReader(loadReqBody))
 	if errReq != nil {
 		log.Debugf("antigravity executor: create loadCodeAssist request error: %v", errReq)
@@ -2195,7 +2194,7 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 		return nil, statusErr{code: http.StatusUnauthorized, msg: "missing access token"}
 	}
 
-	base := strings.TrimSuffix(baseURL, "/")
+	base := helps.NormalizeBaseURL(baseURL)
 	if base == "" {
 		base = buildBaseURL(auth)
 	}
@@ -2204,8 +2203,7 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 		path = antigravityStreamPath
 	}
 	var requestURL strings.Builder
-	requestURL.WriteString(base)
-	requestURL.WriteString(path)
+	requestURL.WriteString(helps.JoinBaseURL(base, path))
 	if stream {
 		if alt != "" {
 			requestURL.WriteString("?$alt=")
@@ -2737,14 +2735,14 @@ func resolveCustomAntigravityBaseURL(auth *cliproxyauth.Auth) string {
 	}
 	if auth.Attributes != nil {
 		if v := strings.TrimSpace(auth.Attributes["base_url"]); v != "" {
-			return strings.TrimSuffix(v, "/")
+			return helps.NormalizeBaseURL(v)
 		}
 	}
 	if auth.Metadata != nil {
 		if v, ok := auth.Metadata["base_url"].(string); ok {
 			v = strings.TrimSpace(v)
 			if v != "" {
-				return strings.TrimSuffix(v, "/")
+				return helps.NormalizeBaseURL(v)
 			}
 		}
 	}

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -281,7 +281,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	}
 	reporter.SetTranslatedReasoningEffort(bodyForUpstream, to.String())
 
-	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
+	url := helps.JoinBaseURL(baseURL, "/v1/messages?beta=true")
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyForUpstream))
 	if err != nil {
 		return resp, err
@@ -470,7 +470,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	}
 	reporter.SetTranslatedReasoningEffort(bodyForUpstream, to.String())
 
-	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
+	url := helps.JoinBaseURL(baseURL, "/v1/messages?beta=true")
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyForUpstream))
 	if err != nil {
 		return nil, err
@@ -726,7 +726,7 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	}
 	body = sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, body, baseModel)
 
-	url := fmt.Sprintf("%s/v1/messages/count_tokens?beta=true", baseURL)
+	url := helps.JoinBaseURL(baseURL, "/v1/messages/count_tokens?beta=true")
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return cliproxyexecutor.Response{}, err

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1289,6 +1289,40 @@ func TestClaudeExecutor_ExecuteStreamDirectPassthroughEmitsCompleteSSEEvents(t *
 	}
 }
 
+func TestClaudeExecutor_ExecuteStreamNormalizesBaseURLSlashes(t *testing.T) {
+	requestURI := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestURI <- r.URL.RequestURI()
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL + "///",
+	}}
+	payload := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected chunk error: %v", chunk.Err)
+		}
+	}
+
+	if got := <-requestURI; got != "/v1/messages?beta=true" {
+		t.Fatalf("request URI = %q, want %q", got, "/v1/messages?beta=true")
+	}
+}
+
 func TestClaudeExecutor_CountTokensStripsOpenAIEncryptedThinkingBeforeUpstream(t *testing.T) {
 	var seenBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -862,7 +862,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	}
 	reporter.SetTranslatedReasoningEffort(body, to.String())
 
-	url := strings.TrimSuffix(baseURL, "/") + "/responses"
+	url := helps.JoinBaseURL(baseURL, "/responses")
 	var identityState codexIdentityConfuseState
 	httpReq, upstreamBody, identityState, err := e.cacheHelper(ctx, from, url, auth, req, originalPayloadSource, body)
 	if err != nil {
@@ -1038,7 +1038,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	body = normalizeCodexParallelToolCallsForTools(body)
 	reporter.SetTranslatedReasoningEffort(body, to.String())
 
-	url := strings.TrimSuffix(baseURL, "/") + "/responses/compact"
+	url := helps.JoinBaseURL(baseURL, "/responses/compact")
 	var identityState codexIdentityConfuseState
 	httpReq, upstreamBody, identityState, err := e.cacheHelper(ctx, from, url, auth, req, originalPayloadSource, body)
 	if err != nil {
@@ -1153,7 +1153,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	}
 	reporter.SetTranslatedReasoningEffort(body, to.String())
 
-	url := strings.TrimSuffix(baseURL, "/") + "/responses"
+	url := helps.JoinBaseURL(baseURL, "/responses")
 	var identityState codexIdentityConfuseState
 	httpReq, upstreamBody, identityState, err := e.cacheHelper(ctx, from, url, auth, req, originalPayloadSource, body)
 	if err != nil {

--- a/internal/runtime/executor/codex_openai_images.go
+++ b/internal/runtime/executor/codex_openai_images.go
@@ -106,7 +106,7 @@ func (e *CodexExecutor) executeOpenAIImage(ctx context.Context, auth *cliproxyau
 	}
 	reporter.SetTranslatedReasoningEffort(body, "codex")
 
-	url := strings.TrimSuffix(baseURL, "/") + "/responses"
+	url := helps.JoinBaseURL(baseURL, "/responses")
 	var identityState codexIdentityConfuseState
 	httpReq, body, identityState, errCache := e.cacheHelper(ctx, sdktranslator.FromString(codexOpenAIImageSourceFormat), url, auth, req, req.Payload, body)
 	if errCache != nil {
@@ -203,7 +203,7 @@ func (e *CodexExecutor) executeOpenAIImageStream(ctx context.Context, auth *clip
 	}
 	reporter.SetTranslatedReasoningEffort(body, "codex")
 
-	url := strings.TrimSuffix(baseURL, "/") + "/responses"
+	url := helps.JoinBaseURL(baseURL, "/responses")
 	var identityState codexIdentityConfuseState
 	httpReq, body, identityState, errCache := e.cacheHelper(ctx, sdktranslator.FromString(codexOpenAIImageSourceFormat), url, auth, req, req.Payload, body)
 	if errCache != nil {
@@ -330,7 +330,7 @@ func (e *CodexExecutor) executeDirectOpenAIImage(ctx context.Context, auth *clip
 	defer reporter.TrackFailure(ctx, &err)
 	reporter.SetTranslatedReasoningEffort(body, "openai")
 
-	url := strings.TrimSuffix(baseURL, "/") + endpointPath
+	url := helps.JoinBaseURL(baseURL, endpointPath)
 	var identityState codexIdentityConfuseState
 	httpReq, body, identityState, errCache := e.cacheHelper(ctx, sdktranslator.FromString(codexOpenAIImageSourceFormat), url, auth, req, req.Payload, body)
 	if errCache != nil {
@@ -391,7 +391,7 @@ func (e *CodexExecutor) executeDirectOpenAIImageStream(ctx context.Context, auth
 	defer reporter.TrackFailure(ctx, &err)
 	reporter.SetTranslatedReasoningEffort(body, "openai")
 
-	url := strings.TrimSuffix(baseURL, "/") + endpointPath
+	url := helps.JoinBaseURL(baseURL, endpointPath)
 	var identityState codexIdentityConfuseState
 	httpReq, body, identityState, errCache := e.cacheHelper(ctx, sdktranslator.FromString(codexOpenAIImageSourceFormat), url, auth, req, req.Payload, body)
 	if errCache != nil {

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -216,7 +216,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex websockets executor", body)
 
-	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
+	httpURL := helps.JoinBaseURL(baseURL, "/responses")
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)
 	if err != nil {
 		return resp, err
@@ -438,7 +438,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex websockets executor", body)
 
-	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
+	httpURL := helps.JoinBaseURL(baseURL, "/responses")
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)
 	if err != nil {
 		return nil, err

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -167,7 +167,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		}
 	}
 	baseURL := resolveGeminiBaseURL(auth)
-	url := fmt.Sprintf("%s/%s/models/%s:%s", baseURL, glAPIVersion, baseModel, action)
+	url := helps.JoinBaseURL(baseURL, fmt.Sprintf("/%s/models/%s:%s", glAPIVersion, baseModel, action))
 	if opts.Alt != "" && action != "countTokens" {
 		url = url + fmt.Sprintf("?$alt=%s", opts.Alt)
 	}
@@ -274,7 +274,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body = capGeminiMaxOutputTokens(body, baseModel)
 
 	baseURL := resolveGeminiBaseURL(auth)
-	url := fmt.Sprintf("%s/%s/models/%s:%s", baseURL, glAPIVersion, baseModel, "streamGenerateContent")
+	url := helps.JoinBaseURL(baseURL, fmt.Sprintf("/%s/models/%s:%s", glAPIVersion, baseModel, "streamGenerateContent"))
 	if opts.Alt == "" {
 		url = url + "?alt=sse"
 	} else {
@@ -401,7 +401,7 @@ func (e *GeminiExecutor) executeInteractions(ctx context.Context, auth *cliproxy
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, targetName, "interactions", fromProtocol, "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 
 	baseURL := resolveGeminiBaseURL(auth)
-	url := fmt.Sprintf("%s/%s/interactions", baseURL, glAPIVersion)
+	url := helps.JoinBaseURL(baseURL, fmt.Sprintf("/%s/interactions", glAPIVersion))
 	httpReq, errRequest := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if errRequest != nil {
 		return resp, errRequest
@@ -477,7 +477,7 @@ func (e *GeminiExecutor) executeInteractionsStream(ctx context.Context, auth *cl
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, targetName, "interactions", fromProtocol, "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body, _ = sjson.SetBytes(body, "stream", true)
 	baseURL := resolveGeminiBaseURL(auth)
-	url := fmt.Sprintf("%s/%s/interactions", baseURL, glAPIVersion)
+	url := helps.JoinBaseURL(baseURL, fmt.Sprintf("/%s/interactions", glAPIVersion))
 	httpReq, errRequest := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if errRequest != nil {
 		return nil, errRequest
@@ -628,7 +628,7 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	translatedReq, _ = sjson.SetBytes(translatedReq, "model", baseModel)
 
 	baseURL := resolveGeminiBaseURL(auth)
-	url := fmt.Sprintf("%s/%s/models/%s:%s", baseURL, glAPIVersion, baseModel, "countTokens")
+	url := helps.JoinBaseURL(baseURL, fmt.Sprintf("/%s/models/%s:%s", glAPIVersion, baseModel, "countTokens"))
 
 	requestBody := bytes.NewReader(translatedReq)
 

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -351,7 +351,7 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 		}
 	}
 	baseURL := vertexBaseURL(location)
-	url := fmt.Sprintf("%s/%s/projects/%s/locations/%s/publishers/google/models/%s:%s", baseURL, vertexAPIVersion, projectID, location, baseModel, action)
+	url := helps.JoinBaseURL(baseURL, fmt.Sprintf("/%s/projects/%s/locations/%s/publishers/google/models/%s:%s", vertexAPIVersion, projectID, location, baseModel, action))
 	if opts.Alt != "" && action != "countTokens" {
 		url = url + fmt.Sprintf("?$alt=%s", opts.Alt)
 	}
@@ -479,7 +479,7 @@ func (e *GeminiVertexExecutor) executeWithAPIKey(ctx context.Context, auth *clip
 	if baseURL == "" {
 		baseURL = "https://aiplatform.googleapis.com"
 	}
-	url := fmt.Sprintf("%s/%s/publishers/google/models/%s:%s", baseURL, vertexAPIVersion, baseModel, action)
+	url := helps.JoinBaseURL(baseURL, fmt.Sprintf("/%s/publishers/google/models/%s:%s", vertexAPIVersion, baseModel, action))
 	if opts.Alt != "" && action != "countTokens" {
 		url = url + fmt.Sprintf("?$alt=%s", opts.Alt)
 	}
@@ -585,7 +585,7 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 
 	action := getVertexAction(baseModel, true)
 	baseURL := vertexBaseURL(location)
-	url := fmt.Sprintf("%s/%s/projects/%s/locations/%s/publishers/google/models/%s:%s", baseURL, vertexAPIVersion, projectID, location, baseModel, action)
+	url := helps.JoinBaseURL(baseURL, fmt.Sprintf("/%s/projects/%s/locations/%s/publishers/google/models/%s:%s", vertexAPIVersion, projectID, location, baseModel, action))
 	// Imagen models don't support streaming, skip SSE params
 	if !isImagenModel(baseModel) {
 		if opts.Alt == "" {
@@ -733,7 +733,7 @@ func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth
 	if baseURL == "" {
 		baseURL = "https://aiplatform.googleapis.com"
 	}
-	url := fmt.Sprintf("%s/%s/publishers/google/models/%s:%s", baseURL, vertexAPIVersion, baseModel, action)
+	url := helps.JoinBaseURL(baseURL, fmt.Sprintf("/%s/publishers/google/models/%s:%s", vertexAPIVersion, baseModel, action))
 	// Imagen models don't support streaming, skip SSE params
 	if !isImagenModel(baseModel) {
 		if opts.Alt == "" {
@@ -866,7 +866,7 @@ func (e *GeminiVertexExecutor) countTokensWithServiceAccount(ctx context.Context
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "safetySettings")
 
 	baseURL := vertexBaseURL(location)
-	url := fmt.Sprintf("%s/%s/projects/%s/locations/%s/publishers/google/models/%s:%s", baseURL, vertexAPIVersion, projectID, location, baseModel, "countTokens")
+	url := helps.JoinBaseURL(baseURL, fmt.Sprintf("/%s/projects/%s/locations/%s/publishers/google/models/%s:%s", vertexAPIVersion, projectID, location, baseModel, "countTokens"))
 
 	httpReq, errNewReq := http.NewRequestWithContext(respCtx, http.MethodPost, url, bytes.NewReader(translatedReq))
 	if errNewReq != nil {
@@ -960,7 +960,7 @@ func (e *GeminiVertexExecutor) countTokensWithAPIKey(ctx context.Context, auth *
 	if baseURL == "" {
 		baseURL = "https://aiplatform.googleapis.com"
 	}
-	url := fmt.Sprintf("%s/%s/publishers/google/models/%s:%s", baseURL, vertexAPIVersion, baseModel, "countTokens")
+	url := helps.JoinBaseURL(baseURL, fmt.Sprintf("/%s/publishers/google/models/%s:%s", vertexAPIVersion, baseModel, "countTokens"))
 
 	httpReq, errNewReq := http.NewRequestWithContext(respCtx, http.MethodPost, url, bytes.NewReader(translatedReq))
 	if errNewReq != nil {

--- a/internal/runtime/executor/helps/url_helpers.go
+++ b/internal/runtime/executor/helps/url_helpers.go
@@ -1,0 +1,21 @@
+package helps
+
+import "strings"
+
+// NormalizeBaseURL trims whitespace and trailing slashes from an upstream base URL.
+func NormalizeBaseURL(baseURL string) string {
+	return strings.TrimRight(strings.TrimSpace(baseURL), "/")
+}
+
+// JoinBaseURL joins an upstream base URL and endpoint with exactly one slash.
+func JoinBaseURL(baseURL, endpoint string) string {
+	baseURL = NormalizeBaseURL(baseURL)
+	endpoint = strings.TrimLeft(strings.TrimSpace(endpoint), "/")
+	if endpoint == "" {
+		return baseURL
+	}
+	if baseURL == "" {
+		return "/" + endpoint
+	}
+	return baseURL + "/" + endpoint
+}

--- a/internal/runtime/executor/helps/url_helpers_test.go
+++ b/internal/runtime/executor/helps/url_helpers_test.go
@@ -1,0 +1,68 @@
+package helps
+
+import "testing"
+
+func TestNormalizeBaseURL(t *testing.T) {
+	t.Parallel()
+
+	if got := NormalizeBaseURL("  https://example.com/api///  "); got != "https://example.com/api" {
+		t.Fatalf("NormalizeBaseURL() = %q, want %q", got, "https://example.com/api")
+	}
+}
+
+func TestJoinBaseURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		baseURL  string
+		endpoint string
+		want     string
+	}{
+		{
+			name:     "no boundary slash",
+			baseURL:  "https://example.com",
+			endpoint: "v1/messages",
+			want:     "https://example.com/v1/messages",
+		},
+		{
+			name:     "single boundary slash",
+			baseURL:  "https://example.com/",
+			endpoint: "/v1/messages?beta=true",
+			want:     "https://example.com/v1/messages?beta=true",
+		},
+		{
+			name:     "multiple boundary slashes",
+			baseURL:  "https://example.com/api///",
+			endpoint: "///v1/messages",
+			want:     "https://example.com/api/v1/messages",
+		},
+		{
+			name:     "surrounding whitespace",
+			baseURL:  "  https://example.com/root/  ",
+			endpoint: "  /responses  ",
+			want:     "https://example.com/root/responses",
+		},
+		{
+			name:     "empty endpoint",
+			baseURL:  "https://example.com/",
+			endpoint: "",
+			want:     "https://example.com",
+		},
+		{
+			name:     "empty base URL",
+			baseURL:  "",
+			endpoint: "/v1/messages",
+			want:     "/v1/messages",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := JoinBaseURL(tt.baseURL, tt.endpoint); got != tt.want {
+				t.Fatalf("JoinBaseURL(%q, %q) = %q, want %q", tt.baseURL, tt.endpoint, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -130,7 +130,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	}
 	reporter.SetTranslatedReasoningEffort(translated, to.String())
 
-	url := strings.TrimSuffix(baseURL, "/") + endpoint
+	url := helps.JoinBaseURL(baseURL, endpoint)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
 	if err != nil {
 		return resp, err
@@ -221,7 +221,7 @@ func (e *OpenAICompatExecutor) executeImages(ctx context.Context, auth *cliproxy
 	}
 	reporter.SetTranslatedReasoningEffort(payload, "openai")
 
-	url := strings.TrimSuffix(baseURL, "/") + endpointPath
+	url := helps.JoinBaseURL(baseURL, endpointPath)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
 		return resp, err
@@ -329,7 +329,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	translated, _ = sjson.SetBytes(translated, "stream_options.include_usage", true)
 	reporter.SetTranslatedReasoningEffort(translated, to.String())
 
-	url := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
+	url := helps.JoinBaseURL(baseURL, "/chat/completions")
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
 	if err != nil {
 		return nil, err
@@ -481,7 +481,7 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 	}
 	reporter.SetTranslatedReasoningEffort(payload, "openai")
 
-	url := strings.TrimSuffix(baseURL, "/") + endpointPath
+	url := helps.JoinBaseURL(baseURL, endpointPath)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
 		return nil, err

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -148,7 +148,7 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 	defer reporter.TrackFailure(ctx, &err)
 	reporter.SetTranslatedReasoningEffort(prepared.body, e.Identifier())
 
-	url := strings.TrimSuffix(baseURL, "/") + "/responses"
+	url := helps.JoinBaseURL(baseURL, "/responses")
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(prepared.body))
 	if err != nil {
 		return resp, err
@@ -247,7 +247,7 @@ func (e *XAIExecutor) executeCompactRequest(ctx context.Context, auth *cliproxya
 	defer reporter.TrackFailure(ctx, &err)
 	reporter.SetTranslatedReasoningEffort(prepared.body, e.Identifier())
 
-	requestURL := strings.TrimSuffix(baseURL, "/") + "/responses/compact"
+	requestURL := helps.JoinBaseURL(baseURL, "/responses/compact")
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, bytes.NewReader(prepared.body))
 	if err != nil {
 		return nil, nil, nil, err
@@ -497,7 +497,7 @@ func (e *XAIExecutor) executeImages(ctx context.Context, auth *cliproxyauth.Auth
 		endpointPath = xaiDefaultImageEndpointPath
 	}
 
-	url := strings.TrimSuffix(baseURL, "/") + endpointPath
+	url := helps.JoinBaseURL(baseURL, endpointPath)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(req.Payload))
 	if err != nil {
 		return resp, err
@@ -557,7 +557,7 @@ func (e *XAIExecutor) executeVideos(ctx context.Context, auth *cliproxyauth.Auth
 			body = nil
 		}
 	}
-	requestURL := strings.TrimSuffix(baseURL, "/") + endpointPath
+	requestURL := helps.JoinBaseURL(baseURL, endpointPath)
 	httpReq, err := http.NewRequestWithContext(ctx, method, requestURL, body)
 	if err != nil {
 		return resp, err
@@ -623,7 +623,7 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 	defer reporter.TrackFailure(ctx, &err)
 	reporter.SetTranslatedReasoningEffort(prepared.body, e.Identifier())
 
-	url := strings.TrimSuffix(baseURL, "/") + "/responses"
+	url := helps.JoinBaseURL(baseURL, "/responses")
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(prepared.body))
 	if err != nil {
 		return nil, err

--- a/internal/runtime/executor/xai_websockets_executor.go
+++ b/internal/runtime/executor/xai_websockets_executor.go
@@ -422,7 +422,7 @@ func (e *XAIWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliprox
 	defer reporter.TrackFailure(ctx, &err)
 	reporter.SetTranslatedReasoningEffort(prepared.body, e.Identifier())
 
-	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
+	httpURL := helps.JoinBaseURL(baseURL, "/responses")
 	wsURL, err := buildXAIResponsesWebsocketURL(httpURL)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- add shared helpers that normalize upstream base URLs and join endpoint paths with exactly one slash
- use the shared join logic across Claude, Codex, xAI, OpenAI-compatible, Gemini, Vertex, and Antigravity HTTP/WebSocket/image/token endpoints
- add helper coverage for zero, one, and multiple boundary slashes plus a Claude streaming regression test

## Problem

A configured upstream `base-url` ending in `/` made the Claude executor build `//v1/messages`. Some compatible upstreams route that path to an HTML application page with HTTP 200, so downstream Claude clients fail while parsing the response as SSE JSON. Other executors used a mix of direct concatenation and `TrimSuffix`, which either did not normalize the boundary or removed only one trailing slash.

The shared helper now trims whitespace and all trailing base URL slashes, trims leading endpoint slashes, and inserts exactly one separator without changing the remaining path or query.

## Validation

- `gofmt -w` on all changed Go files
- `go test ./...`
- `go build -o test-output ./cmd/server && rm test-output`