### PR TITLE
feat(auth): add conditional priority mutation contract

### DIFF
--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -335,7 +335,9 @@ func (h *Handler) refreshAntigravityOAuthAccessToken(ctx context.Context, auth *
 	if h != nil && h.authManager != nil {
 		auth.LastRefreshedAt = now
 		auth.UpdatedAt = now
-		_, _ = h.authManager.Update(ctx, auth)
+		if _, errUpdate := h.authManager.Update(ctx, auth); errUpdate != nil {
+			return "", fmt.Errorf("persist antigravity oauth token refresh: %w", errUpdate)
+		}
 	}
 
 	return strings.TrimSpace(tokenResp.AccessToken), nil

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -2,13 +2,37 @@ package management
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
+
+type apiToolsFailingStore struct {
+	saves int
+}
+
+func (s *apiToolsFailingStore) List(context.Context) ([]*coreauth.Auth, error) {
+	return nil, nil
+}
+
+func (s *apiToolsFailingStore) Save(context.Context, *coreauth.Auth) (string, error) {
+	s.saves++
+	if s.saves > 1 {
+		return "", errors.New("save failed")
+	}
+	return "synthetic-auth.json", nil
+}
+
+func (s *apiToolsFailingStore) Delete(context.Context, string) error {
+	return nil
+}
 
 func TestAPICallTransportDirectBypassesGlobalProxy(t *testing.T) {
 	t.Parallel()
@@ -220,5 +244,46 @@ func TestAuthByIndexDistinguishesSharedAPIKeysAcrossProviders(t *testing.T) {
 	}
 	if gotCompat.ID != compatAuth.ID {
 		t.Fatalf("authByIndex(compat) returned %q, want %q", gotCompat.ID, compatAuth.ID)
+	}
+}
+
+func TestRefreshAntigravityOAuthAccessTokenReturnsPersistenceFailure(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-token","expires_in":3600}`))
+	}))
+	defer tokenServer.Close()
+
+	previousTokenURL := antigravityOAuthTokenURL
+	antigravityOAuthTokenURL = tokenServer.URL
+	defer func() { antigravityOAuthTokenURL = previousTokenURL }()
+
+	store := &apiToolsFailingStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	auth := &coreauth.Auth{
+		ID:       "synthetic-auth",
+		Provider: "antigravity",
+		ProxyURL: "direct",
+		Metadata: map[string]any{
+			"access_token":  "old-token",
+			"refresh_token": "synthetic-refresh-token",
+			"expired":       time.Now().Add(-time.Hour).Format(time.RFC3339),
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	h := &Handler{authManager: manager}
+	if _, errRefresh := h.refreshAntigravityOAuthAccessToken(context.Background(), auth); errRefresh == nil || !strings.Contains(errRefresh.Error(), "persist antigravity oauth token refresh") {
+		t.Fatalf("refresh error = %v, want persistence failure", errRefresh)
+	}
+
+	current, ok := manager.GetByID(auth.ID)
+	if !ok || current == nil {
+		t.Fatal("expected registered auth to remain available")
+	}
+	if got := current.Metadata["access_token"]; got != "old-token" {
+		t.Fatalf("runtime access_token = %v, want old-token", got)
 	}
 }

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -567,6 +567,7 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 	if websockets, ok := authWebsocketsValue(auth); ok {
 		entry["websockets"] = websockets
 	}
+	addPriorityManagementState(entry, auth)
 	return entry
 }
 

--- a/internal/api/handlers/management/auth_files_priority.go
+++ b/internal/api/handlers/management/auth_files_priority.go
@@ -1,0 +1,239 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+const maxManagementPriority = int64(1<<31 - 1)
+const maxPriorityRequestBytes = 16 * 1024
+
+type patchAuthFilePriorityRequest struct {
+	Name             string          `json:"name"`
+	ExpectedRevision string          `json:"expected_revision"`
+	Operation        string          `json:"operation"`
+	Priority         json.RawMessage `json:"priority"`
+}
+
+func (h *Handler) PatchAuthFilePriority(c *gin.Context) {
+	if h == nil || h.authManager == nil {
+		writePriorityError(c, http.StatusNotFound, "management_unavailable", "auth manager unavailable")
+		return
+	}
+	rawBody, errRead := io.ReadAll(io.LimitReader(c.Request.Body, maxPriorityRequestBytes+1))
+	errDuplicate := rejectDuplicateTopLevelJSONFields(rawBody)
+	if errRead != nil || len(rawBody) > maxPriorityRequestBytes || errDuplicate != nil {
+		writePriorityError(c, http.StatusBadRequest, "invalid_request", "invalid request body")
+		return
+	}
+	var req patchAuthFilePriorityRequest
+	decoder := json.NewDecoder(bytes.NewReader(rawBody))
+	decoder.DisallowUnknownFields()
+	if errDecode := decoder.Decode(&req); errDecode != nil {
+		writePriorityError(c, http.StatusBadRequest, "invalid_request", "invalid request body")
+		return
+	}
+	if errTrailing := rejectTrailingJSON(decoder); errTrailing != nil {
+		writePriorityError(c, http.StatusBadRequest, "invalid_request", "invalid request body")
+		return
+	}
+	req.Name = strings.TrimSpace(req.Name)
+	req.ExpectedRevision = strings.TrimSpace(req.ExpectedRevision)
+	req.Operation = strings.ToLower(strings.TrimSpace(req.Operation))
+	if req.Name == "" {
+		writePriorityError(c, http.StatusBadRequest, "invalid_name", "name is required")
+		return
+	}
+	if req.ExpectedRevision == "" {
+		writePriorityError(c, http.StatusConflict, "revision_conflict", "expected_revision is required")
+		return
+	}
+
+	mutation := coreauth.PriorityMutation{}
+	switch coreauth.PriorityMutationOperation(req.Operation) {
+	case coreauth.PriorityMutationSet:
+		priority, errPriority := decodeStrictPriority(req.Priority)
+		if errPriority != nil {
+			writePriorityError(c, http.StatusBadRequest, "invalid_priority", "priority must be a non-negative 32-bit integer")
+			return
+		}
+		mutation.Operation = coreauth.PriorityMutationSet
+		mutation.Priority = priority
+	case coreauth.PriorityMutationUnset:
+		if len(bytes.TrimSpace(req.Priority)) != 0 {
+			writePriorityError(c, http.StatusBadRequest, "invalid_priority", "unset must omit priority")
+			return
+		}
+		mutation.Operation = coreauth.PriorityMutationUnset
+	default:
+		writePriorityError(c, http.StatusBadRequest, "invalid_operation", "operation must be set or unset")
+		return
+	}
+
+	target, errTarget := findPriorityMutationTarget(h.authManager, req.Name)
+	if errTarget != nil {
+		writePriorityMutationError(c, errTarget)
+		return
+	}
+	result, errMutation := h.authManager.MutatePriority(c.Request.Context(), target.ID, req.ExpectedRevision, mutation)
+	if errMutation != nil {
+		writePriorityMutationError(c, errMutation)
+		return
+	}
+	name := strings.TrimSpace(result.Auth.FileName)
+	if name == "" {
+		name = result.Auth.ID
+	}
+	priority := gin.H{"present": result.Priority.Present}
+	if result.Priority.Present {
+		priority["value"] = result.Priority.Value
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"status":    "ok",
+		"id":        result.Auth.ID,
+		"name":      name,
+		"revision":  result.Revision,
+		"priority":  priority,
+		"persisted": true,
+	})
+}
+
+func rejectDuplicateTopLevelJSONFields(raw []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	token, errToken := decoder.Token()
+	if errToken != nil {
+		return errToken
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '{' {
+		return errors.New("request must be a JSON object")
+	}
+	seen := make(map[string]struct{})
+	for decoder.More() {
+		keyToken, errToken := decoder.Token()
+		if errToken != nil {
+			return errToken
+		}
+		key, okKey := keyToken.(string)
+		if !okKey {
+			return errors.New("invalid JSON object key")
+		}
+		if _, exists := seen[key]; exists {
+			return errors.New("duplicate JSON field")
+		}
+		seen[key] = struct{}{}
+		var value json.RawMessage
+		if errDecode := decoder.Decode(&value); errDecode != nil {
+			return errDecode
+		}
+	}
+	if _, errEnd := decoder.Token(); errEnd != nil {
+		return errEnd
+	}
+	return rejectTrailingJSON(decoder)
+}
+
+func rejectTrailingJSON(decoder *json.Decoder) error {
+	var trailing any
+	errDecode := decoder.Decode(&trailing)
+	if errors.Is(errDecode, io.EOF) {
+		return nil
+	}
+	if errDecode == nil {
+		return errors.New("trailing JSON value")
+	}
+	return errDecode
+}
+
+func decodeStrictPriority(raw json.RawMessage) (int, error) {
+	value := bytes.TrimSpace(raw)
+	if len(value) == 0 {
+		return 0, errors.New("missing priority")
+	}
+	for i, ch := range value {
+		if ch < '0' || ch > '9' || (i == 0 && ch == '0' && len(value) > 1) {
+			return 0, errors.New("priority is not a canonical integer")
+		}
+	}
+	parsed, errParse := strconv.ParseInt(string(value), 10, 32)
+	if errParse != nil || parsed < 0 || parsed > maxManagementPriority {
+		return 0, errors.New("priority outside safe range")
+	}
+	return int(parsed), nil
+}
+
+func findPriorityMutationTarget(manager *coreauth.Manager, name string) (*coreauth.Auth, error) {
+	if auth, ok := manager.GetByID(name); ok && auth != nil {
+		return auth, nil
+	}
+	var target *coreauth.Auth
+	for _, auth := range manager.List() {
+		if auth == nil || auth.FileName != name {
+			continue
+		}
+		if target != nil {
+			return nil, coreauth.ErrAuthRevisionConflict
+		}
+		target = auth
+	}
+	if target == nil {
+		return nil, coreauth.ErrAuthNotFound
+	}
+	return target, nil
+}
+
+func writePriorityMutationError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, coreauth.ErrAuthNotFound):
+		writePriorityError(c, http.StatusNotFound, "auth_not_found", "auth file not found")
+	case errors.Is(err, coreauth.ErrAuthRevisionConflict), errors.Is(err, coreauth.ErrAuthSourceConflict):
+		writePriorityError(c, http.StatusConflict, "revision_conflict", "auth changed before mutation")
+	case errors.Is(err, coreauth.ErrPriorityMutationRoutingIncompatible):
+		writePriorityError(c, http.StatusUnprocessableEntity, "routing_incompatible", "priority mutation incompatible with active websocket routing")
+	case errors.Is(err, coreauth.ErrPriorityMutationUnsupported):
+		writePriorityError(c, http.StatusUnprocessableEntity, "priority_mutation_unsupported", "priority mutation unsupported")
+	default:
+		writePriorityError(c, http.StatusInternalServerError, "persistence_failed", "priority mutation failed")
+	}
+}
+
+func writePriorityError(c *gin.Context, status int, code, message string) {
+	c.JSON(status, gin.H{"error": message, "code": code})
+}
+
+func addPriorityManagementState(entry gin.H, auth *coreauth.Auth) {
+	if entry == nil || auth == nil {
+		return
+	}
+	entry["revision"] = auth.Revision()
+	_, present := auth.Metadata["priority"]
+	entry["priority_present"] = present
+	if !present {
+		entry["priority"] = 0
+	} else if _, exists := entry["priority"]; !exists {
+		entry["priority"] = runtimePriority(auth)
+	}
+}
+
+func runtimePriority(auth *coreauth.Auth) int {
+	if auth == nil || auth.Attributes == nil {
+		return 0
+	}
+	value := strings.TrimSpace(auth.Attributes["priority"])
+	if value == "" {
+		return 0
+	}
+	priority, errPriority := strconv.Atoi(value)
+	if errPriority != nil {
+		return 0
+	}
+	return priority
+}

--- a/internal/api/handlers/management/auth_files_priority_test.go
+++ b/internal/api/handlers/management/auth_files_priority_test.go
@@ -1,0 +1,441 @@
+package management
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	sdkauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+type managementPriorityStore struct {
+	mu    sync.Mutex
+	auths map[string]*coreauth.Auth
+}
+
+func (s *managementPriorityStore) List(context.Context) ([]*coreauth.Auth, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*coreauth.Auth, 0, len(s.auths))
+	for _, auth := range s.auths {
+		out = append(out, auth.Clone())
+	}
+	return out, nil
+}
+
+func (s *managementPriorityStore) Save(_ context.Context, auth *coreauth.Auth) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.auths == nil {
+		s.auths = make(map[string]*coreauth.Auth)
+	}
+	s.auths[auth.ID] = auth.Clone()
+	return auth.ID, nil
+}
+
+func (*managementPriorityStore) Delete(context.Context, string) error { return nil }
+
+func (s *managementPriorityStore) PersistMutation(_ context.Context, before, after *coreauth.Auth) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current := s.auths[before.ID]
+	if current == nil || current.Revision() != before.Revision() {
+		return "", coreauth.ErrAuthSourceConflict
+	}
+	s.auths[after.ID] = after.Clone()
+	return after.ID, nil
+}
+
+func TestListAuthFilesIncludesRevisionAndExactPriorityPresence(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	manager := coreauth.NewManager(nil, &coreauth.FillFirstSelector{}, nil)
+	registered, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:         "synthetic-auth.json",
+		FileName:   "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"path": t.TempDir() + "/synthetic-auth.json"},
+		Metadata:   map[string]any{"type": "codex"},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{}, manager)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/auth-files", nil)
+	h.ListAuthFiles(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var payload struct {
+		Files []map[string]any `json:"files"`
+	}
+	if err = json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(payload.Files) != 1 {
+		t.Fatalf("files len = %d, want 1", len(payload.Files))
+	}
+	entry := payload.Files[0]
+	if got := entry["revision"]; got != registered.Revision() {
+		t.Fatalf("revision = %#v, want %q", got, registered.Revision())
+	}
+	if got := entry["priority_present"]; got != false {
+		t.Fatalf("priority_present = %#v, want false", got)
+	}
+	if got := entry["priority"]; got != float64(0) {
+		t.Fatalf("priority = %#v, want runtime default 0", got)
+	}
+}
+
+func TestPatchAuthFilePrioritySetsPriorityConditionally(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &managementPriorityStore{}
+	manager := coreauth.NewManager(store, &coreauth.FillFirstSelector{}, nil)
+	registered, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:         "synthetic-auth.json",
+		FileName:   "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"path": "/synthetic/synthetic-auth.json", "priority": "10"},
+		Metadata: map[string]any{
+			"type":         "codex",
+			"priority":     float64(10),
+			"access_token": "synthetic-token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"name":              registered.FileName,
+		"expected_revision": registered.Revision(),
+		"operation":         "set",
+		"priority":          101,
+	})
+	if err != nil {
+		t.Fatalf("encode request: %v", err)
+	}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{}, manager)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/priority", bytes.NewReader(body))
+	h.PatchAuthFilePriority(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var payload struct {
+		Status    string `json:"status"`
+		ID        string `json:"id"`
+		Name      string `json:"name"`
+		Revision  string `json:"revision"`
+		Persisted bool   `json:"persisted"`
+		Priority  struct {
+			Present bool `json:"present"`
+			Value   int  `json:"value"`
+		} `json:"priority"`
+	}
+	if err = json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Status != "ok" || payload.ID != registered.ID || payload.Name != registered.FileName || !payload.Persisted {
+		t.Fatalf("unexpected response: %#v", payload)
+	}
+	if payload.Revision == "" || payload.Revision == registered.Revision() {
+		t.Fatalf("revision = %q, want rotated token", payload.Revision)
+	}
+	if !payload.Priority.Present || payload.Priority.Value != 101 {
+		t.Fatalf("priority = %#v, want present 101", payload.Priority)
+	}
+
+	current, ok := manager.GetByID(registered.ID)
+	if !ok {
+		t.Fatal("GetByID() missing auth")
+	}
+	if got := current.Metadata["access_token"]; got != "synthetic-token" {
+		t.Fatalf("access_token changed = %#v", got)
+	}
+}
+
+func TestPatchAuthFilePriorityUnsetsExactFieldAndOmitsValue(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &managementPriorityStore{}
+	manager := coreauth.NewManager(store, &coreauth.FillFirstSelector{}, nil)
+	registered, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:         "synthetic-auth.json",
+		FileName:   "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"path": "/synthetic/synthetic-auth.json", "priority": "10"},
+		Metadata:   map[string]any{"type": "codex", "priority": float64(10), "note": "keep"},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	body, _ := json.Marshal(map[string]any{
+		"name":              registered.FileName,
+		"expected_revision": registered.Revision(),
+		"operation":         "unset",
+	})
+	h := NewHandlerWithoutConfigFilePath(&config.Config{}, manager)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/priority", bytes.NewReader(body))
+	h.PatchAuthFilePriority(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var payload map[string]any
+	if err = json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	priority, ok := payload["priority"].(map[string]any)
+	if !ok || priority["present"] != false {
+		t.Fatalf("priority response = %#v, want absent", payload["priority"])
+	}
+	if _, ok = priority["value"]; ok {
+		t.Fatalf("unset response included value: %#v", priority)
+	}
+	current, _ := manager.GetByID(registered.ID)
+	if _, ok = current.Metadata["priority"]; ok {
+		t.Fatalf("priority metadata still present: %#v", current.Metadata)
+	}
+	if _, ok = current.Attributes["priority"]; ok {
+		t.Fatalf("priority attribute still present: %#v", current.Attributes)
+	}
+	if got := current.Metadata["note"]; got != "keep" {
+		t.Fatalf("note changed = %#v", got)
+	}
+}
+
+func TestPatchAuthFilePriorityRejectsStaleRevisionWithoutMutation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &managementPriorityStore{}
+	manager := coreauth.NewManager(store, &coreauth.FillFirstSelector{}, nil)
+	registered, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:         "synthetic-auth.json",
+		FileName:   "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"path": "/synthetic/synthetic-auth.json", "priority": "10"},
+		Metadata:   map[string]any{"type": "codex", "priority": float64(10)},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	body := []byte(`{"name":"synthetic-auth.json","expected_revision":"stale","operation":"set","priority":101}`)
+	h := NewHandlerWithoutConfigFilePath(&config.Config{}, manager)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/priority", bytes.NewReader(body))
+	h.PatchAuthFilePriority(ctx)
+
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusConflict, recorder.Body.String())
+	}
+	current, _ := manager.GetByID(registered.ID)
+	if current.Revision() != registered.Revision() || current.Attributes["priority"] != "10" {
+		t.Fatalf("stale mutation changed auth: revision=%q priority=%q", current.Revision(), current.Attributes["priority"])
+	}
+}
+
+func TestPatchAuthFilePriorityRejectsAmbiguousNumbers(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &managementPriorityStore{}
+	manager := coreauth.NewManager(store, &coreauth.FillFirstSelector{}, nil)
+	registered, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:         "synthetic-auth.json",
+		FileName:   "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"path": "/synthetic/synthetic-auth.json", "priority": "10"},
+		Metadata:   map[string]any{"type": "codex", "priority": float64(10)},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{}, manager)
+	for _, rawPriority := range []string{`1.5`, `1e2`, `"101"`, `-1`, `2147483648`, `null`} {
+		t.Run(rawPriority, func(t *testing.T) {
+			body := []byte(`{"name":"synthetic-auth.json","expected_revision":"` + registered.Revision() + `","operation":"set","priority":` + rawPriority + `}`)
+			recorder := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(recorder)
+			ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/priority", bytes.NewReader(body))
+			h.PatchAuthFilePriority(ctx)
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestPatchAuthFilePriorityRejectsDuplicateJSONFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &managementPriorityStore{}
+	manager := coreauth.NewManager(store, &coreauth.FillFirstSelector{}, nil)
+	registered, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:         "synthetic-auth.json",
+		FileName:   "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"path": "/synthetic/synthetic-auth.json", "priority": "10"},
+		Metadata:   map[string]any{"type": "codex", "priority": float64(10)},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	body := []byte(`{"name":"synthetic-auth.json","name":"synthetic-auth.json","expected_revision":"` + registered.Revision() + `","operation":"set","priority":101}`)
+	h := NewHandlerWithoutConfigFilePath(&config.Config{}, manager)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/priority", bytes.NewReader(body))
+	h.PatchAuthFilePriority(ctx)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
+	}
+	current, _ := manager.GetByID(registered.ID)
+	if current.Attributes["priority"] != "10" {
+		t.Fatalf("duplicate-field request mutated priority to %q", current.Attributes["priority"])
+	}
+}
+
+func TestPatchAuthFilePriorityPersistsExactUnsetThroughFileStore(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "synthetic-auth.json")
+	if err := os.WriteFile(path, []byte(`{"type":"codex","access_token":"synthetic-token","priority":10,"note":"keep","disabled":false}`), 0o600); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+	store := sdkauth.NewFileTokenStore()
+	store.SetBaseDir(dir)
+	manager := coreauth.NewManager(store, &coreauth.FillFirstSelector{}, nil)
+	if err := manager.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	registered, ok := manager.GetByID("synthetic-auth.json")
+	if !ok {
+		t.Fatal("GetByID() missing file-backed auth")
+	}
+	body := []byte(`{"name":"synthetic-auth.json","expected_revision":"` + registered.Revision() + `","operation":"unset"}`)
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: dir}, manager)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/priority", bytes.NewReader(body))
+	h.PatchAuthFilePriority(ctx)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read auth file: %v", err)
+	}
+	var persisted map[string]any
+	if err = json.Unmarshal(raw, &persisted); err != nil {
+		t.Fatalf("decode auth file: %v", err)
+	}
+	if _, ok = persisted["priority"]; ok {
+		t.Fatalf("priority remains on disk: %s", raw)
+	}
+	if persisted["access_token"] != "synthetic-token" || persisted["note"] != "keep" || persisted["disabled"] != false {
+		t.Fatalf("unrelated fields changed: %s", raw)
+	}
+	committed, _ := manager.GetByID(registered.ID)
+	replayedAuths, err := store.List(context.Background())
+	if err != nil || len(replayedAuths) != 1 {
+		t.Fatalf("List() after mutation auths=%d error=%v", len(replayedAuths), err)
+	}
+	replayed, err := manager.Update(coreauth.WithSkipPersist(context.Background()), replayedAuths[0])
+	if err != nil {
+		t.Fatalf("watcher replay Update() error = %v", err)
+	}
+	if replayed.Revision() != committed.Revision() {
+		t.Fatalf("watcher replay rotated revision from %q to %q", committed.Revision(), replayed.Revision())
+	}
+}
+
+func TestPatchAuthFilePriorityRejectsSameNameReplacementBeforeWatcherReload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "synthetic-auth.json")
+	if err := os.WriteFile(path, []byte(`{"type":"codex","access_token":"old-synthetic-token","priority":10}`), 0o600); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+	store := sdkauth.NewFileTokenStore()
+	store.SetBaseDir(dir)
+	manager := coreauth.NewManager(store, &coreauth.FillFirstSelector{}, nil)
+	if err := manager.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	registered, _ := manager.GetByID("synthetic-auth.json")
+	replacement := []byte(`{"type":"codex","access_token":"replacement-synthetic-token","priority":7}`)
+	if err := os.WriteFile(path, replacement, 0o600); err != nil {
+		t.Fatalf("replace auth file: %v", err)
+	}
+	body := []byte(`{"name":"synthetic-auth.json","expected_revision":"` + registered.Revision() + `","operation":"set","priority":101}`)
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: dir}, manager)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/priority", bytes.NewReader(body))
+	h.PatchAuthFilePriority(ctx)
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusConflict, recorder.Body.String())
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read replacement: %v", err)
+	}
+	if string(got) != string(replacement) {
+		t.Fatalf("replacement changed: got %s want %s", got, replacement)
+	}
+	current, _ := manager.GetByID(registered.ID)
+	if current.Revision() != registered.Revision() || current.Metadata["priority"] != float64(10) {
+		t.Fatalf("manager changed after source conflict: revision=%q priority=%#v", current.Revision(), current.Metadata["priority"])
+	}
+}
+
+func TestPatchAuthFilePriorityReportsWebsocketIncompatibility(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &managementPriorityStore{}
+	manager := coreauth.NewManager(store, &coreauth.FillFirstSelector{}, nil)
+	registered, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:         "synthetic-auth.json",
+		FileName:   "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"path": "/synthetic/synthetic-auth.json", "priority": "10", "websockets": "true"},
+		Metadata:   map[string]any{"type": "codex", "priority": float64(10), "websockets": true},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	body := []byte(`{"name":"synthetic-auth.json","expected_revision":"` + registered.Revision() + `","operation":"set","priority":101}`)
+	h := NewHandlerWithoutConfigFilePath(&config.Config{}, manager)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/priority", bytes.NewReader(body))
+	h.PatchAuthFilePriority(ctx)
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusUnprocessableEntity, recorder.Body.String())
+	}
+	var payload struct {
+		Code string `json:"code"`
+	}
+	if err = json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Code != "routing_incompatible" {
+		t.Fatalf("code = %q, want routing_incompatible", payload.Code)
+	}
+	current, _ := manager.GetByID(registered.ID)
+	if current.Revision() != registered.Revision() || current.Attributes["priority"] != "10" {
+		t.Fatalf("incompatible mutation changed auth: revision=%q priority=%q", current.Revision(), current.Attributes["priority"])
+	}
+}

--- a/internal/api/priority_management_route_test.go
+++ b/internal/api/priority_management_route_test.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPriorityManagementRouteUsesManagementAuthenticationAndRuntimeHeaders(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "test-management-key")
+	server := newTestServer(t)
+
+	unauthorizedReq := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/priority", strings.NewReader(`{}`))
+	unauthorizedReq.Header.Set("Content-Type", "application/json")
+	unauthorizedRR := httptest.NewRecorder()
+	server.engine.ServeHTTP(unauthorizedRR, unauthorizedReq)
+	if unauthorizedRR.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthorized status = %d, want %d body=%s", unauthorizedRR.Code, http.StatusUnauthorized, unauthorizedRR.Body.String())
+	}
+
+	authorizedReq := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/priority", strings.NewReader(`{}`))
+	authorizedReq.Header.Set("Content-Type", "application/json")
+	authorizedReq.Header.Set("X-Management-Key", "test-management-key")
+	authorizedRR := httptest.NewRecorder()
+	server.engine.ServeHTTP(authorizedRR, authorizedReq)
+	if authorizedRR.Code != http.StatusBadRequest {
+		t.Fatalf("authorized status = %d, want %d body=%s", authorizedRR.Code, http.StatusBadRequest, authorizedRR.Body.String())
+	}
+	for _, header := range []string{"X-CPA-VERSION", "X-CPA-COMMIT", "X-CPA-BUILD-DATE"} {
+		if _, ok := authorizedRR.Header()[http.CanonicalHeaderKey(header)]; !ok {
+			t.Fatalf("response missing runtime header %s", header)
+		}
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -946,6 +946,7 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.DELETE("/auth-files", s.mgmt.DeleteAuthFile)
 		mgmt.PATCH("/auth-files/status", s.mgmt.PatchAuthFileStatus)
 		mgmt.PATCH("/auth-files/fields", s.mgmt.PatchAuthFileFields)
+		mgmt.PATCH("/auth-files/priority", s.mgmt.PatchAuthFilePriority)
 		mgmt.POST("/vertex/import", s.mgmt.ImportVertexCredential)
 
 		mgmt.GET("/anthropic-auth-url", s.mgmt.RequestAnthropicToken)

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -64,14 +64,18 @@ type codexWebsocketSession struct {
 
 	reqMu sync.Mutex
 
-	connMu sync.Mutex
-	conn   *websocket.Conn
-	wsURL  string
-	authID string
+	connMu               sync.Mutex
+	conn                 *websocket.Conn
+	wsURL                string
+	authID               string
+	closed               bool
+	generation           uint64
+	recoverableWriteConn *websocket.Conn
 
 	writeMu sync.Mutex
 
 	activeMu     sync.Mutex
+	activeConn   *websocket.Conn
 	activeCh     chan codexWebsocketRead
 	activeDone   <-chan struct{}
 	activeCancel context.CancelFunc
@@ -97,6 +101,10 @@ type codexWebsocketRead struct {
 }
 
 func (s *codexWebsocketSession) setActive(ch chan codexWebsocketRead) {
+	s.setActiveForConn(nil, ch)
+}
+
+func (s *codexWebsocketSession) setActiveForConn(conn *websocket.Conn, ch chan codexWebsocketRead) {
 	if s == nil {
 		return
 	}
@@ -106,6 +114,7 @@ func (s *codexWebsocketSession) setActive(ch chan codexWebsocketRead) {
 		s.activeCancel = nil
 		s.activeDone = nil
 	}
+	s.activeConn = conn
 	s.activeCh = ch
 	if ch != nil {
 		activeCtx, activeCancel := context.WithCancel(context.Background())
@@ -116,11 +125,17 @@ func (s *codexWebsocketSession) setActive(ch chan codexWebsocketRead) {
 }
 
 func (s *codexWebsocketSession) clearActive(ch chan codexWebsocketRead) {
+	s.clearActiveForConn(nil, ch)
+}
+
+func (s *codexWebsocketSession) clearActiveForConn(conn *websocket.Conn, ch chan codexWebsocketRead) bool {
 	if s == nil {
-		return
+		return false
 	}
 	s.activeMu.Lock()
-	if s.activeCh == ch {
+	cleared := s.activeConn == conn && s.activeCh == ch
+	if cleared {
+		s.activeConn = nil
 		s.activeCh = nil
 		if s.activeCancel != nil {
 			s.activeCancel()
@@ -129,6 +144,7 @@ func (s *codexWebsocketSession) clearActive(ch chan codexWebsocketRead) {
 		s.activeDone = nil
 	}
 	s.activeMu.Unlock()
+	return cleared
 }
 
 func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, payload []byte) error {
@@ -138,9 +154,51 @@ func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, 
 	if conn == nil {
 		return fmt.Errorf("codex websockets executor: websocket conn is nil")
 	}
+	s.connMu.Lock()
+	if s.closed || s.conn != conn {
+		s.connMu.Unlock()
+		return fmt.Errorf("codex websockets executor: websocket conn is not current")
+	}
+	s.recoverableWriteConn = conn
+	s.connMu.Unlock()
+
 	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
-	return conn.WriteMessage(msgType, payload)
+	s.connMu.Lock()
+	if s.closed || s.conn != conn {
+		if s.recoverableWriteConn == conn {
+			s.recoverableWriteConn = nil
+		}
+		s.connMu.Unlock()
+		s.writeMu.Unlock()
+		return fmt.Errorf("codex websockets executor: websocket conn is not current")
+	}
+	s.connMu.Unlock()
+	errWrite := conn.WriteMessage(msgType, payload)
+	var detached bool
+	var authID, wsURL, sessionID string
+	s.connMu.Lock()
+	if s.recoverableWriteConn == conn {
+		s.recoverableWriteConn = nil
+	}
+	if errWrite != nil && s.conn == conn {
+		detached = true
+		authID = s.authID
+		wsURL = s.wsURL
+		sessionID = s.sessionID
+		s.conn = nil
+		if s.readerConn == conn {
+			s.readerConn = nil
+		}
+	}
+	s.connMu.Unlock()
+	s.writeMu.Unlock()
+	if detached {
+		logCodexWebsocketDisconnected(sessionID, authID, wsURL, "send_error", errWrite)
+		if errClose := conn.Close(); errClose != nil {
+			log.Errorf("codex websockets executor: close failed websocket error: %v", errClose)
+		}
+	}
+	return errWrite
 }
 
 func (s *codexWebsocketSession) configureConn(conn *websocket.Conn) {
@@ -297,19 +355,21 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	var readCh chan codexWebsocketRead
 	if sess != nil {
 		readCh = make(chan codexWebsocketRead, 4096)
-		sess.setActive(readCh)
-		defer sess.clearActive(readCh)
+		sess.setActiveForConn(conn, readCh)
+		defer func() { sess.clearActiveForConn(conn, readCh) }()
 	}
 
 	if errSend := writeCodexWebsocketMessage(sess, conn, wsReqBody); errSend != nil {
 		if sess != nil {
-			e.invalidateUpstreamConn(sess, conn, "send_error", errSend)
+			sess.clearActiveForConn(conn, readCh)
 
 			// Retry once with a fresh websocket connection. This is mainly to handle
 			// upstream closing the socket between sequential requests within the same
 			// execution session.
 			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
 			if errDialRetry == nil && connRetry != nil {
+				readChRetry := make(chan codexWebsocketRead, 4096)
+				sess.setActiveForConn(connRetry, readChRetry)
 				wsReqBodyRetry := buildCodexWebsocketRequestBody(upstreamBody)
 				helps.RecordAPIWebsocketRequest(ctx, e.cfg, helps.UpstreamRequestLog{
 					URL:       wsURL,
@@ -326,15 +386,18 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 				reporter.StartResponseTTFT()
 				if errSendRetry := writeCodexWebsocketMessage(sess, connRetry, wsReqBodyRetry); errSendRetry == nil {
 					conn = connRetry
+					readCh = readChRetry
 					wsReqBody = wsReqBodyRetry
 				} else {
-					e.invalidateUpstreamConn(sess, connRetry, "send_error", errSendRetry)
+					sess.clearActiveForConn(connRetry, readChRetry)
+					sess.notifyUpstreamDisconnect(errSendRetry)
 					helps.RecordAPIWebsocketError(ctx, e.cfg, "send_retry", errSendRetry)
 					return resp, errSendRetry
 				}
 			} else {
 				closeHTTPResponseBody(respHSRetry, "codex websockets executor: close handshake response body error")
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "dial_retry", errDialRetry)
+				sess.notifyUpstreamDisconnect(errDialRetry)
 				return resp, errDialRetry
 			}
 		} else {
@@ -516,24 +579,26 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	var readCh chan codexWebsocketRead
 	if sess != nil {
 		readCh = make(chan codexWebsocketRead, 4096)
-		sess.setActive(readCh)
+		sess.setActiveForConn(conn, readCh)
 	}
 
 	if errSend := writeCodexWebsocketMessage(sess, conn, wsReqBody); errSend != nil {
 		helps.RecordAPIWebsocketError(ctx, e.cfg, "send", errSend)
 		if sess != nil {
-			e.invalidateUpstreamConn(sess, conn, "send_error", errSend)
+			sess.clearActiveForConn(conn, readCh)
 
 			// Retry once with a new websocket connection for the same execution session.
 			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
 			if errDialRetry != nil || connRetry == nil {
 				closeHTTPResponseBody(respHSRetry, "codex websockets executor: close handshake response body error")
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "dial_retry", errDialRetry)
-				sess.clearActive(readCh)
+				sess.notifyUpstreamDisconnect(errDialRetry)
 				sess.reqMu.Unlock()
 				return nil, errDialRetry
 			}
 			wsReqBodyRetry := buildCodexWebsocketRequestBody(upstreamBody)
+			readChRetry := make(chan codexWebsocketRead, 4096)
+			sess.setActiveForConn(connRetry, readChRetry)
 			helps.RecordAPIWebsocketRequest(ctx, e.cfg, helps.UpstreamRequestLog{
 				URL:       wsURL,
 				Method:    "WEBSOCKET",
@@ -549,12 +614,13 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			reporter.StartResponseTTFT()
 			if errSendRetry := writeCodexWebsocketMessage(sess, connRetry, wsReqBodyRetry); errSendRetry != nil {
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "send_retry", errSendRetry)
-				e.invalidateUpstreamConn(sess, connRetry, "send_error", errSendRetry)
-				sess.clearActive(readCh)
+				sess.clearActiveForConn(connRetry, readChRetry)
+				sess.notifyUpstreamDisconnect(errSendRetry)
 				sess.reqMu.Unlock()
 				return nil, errSendRetry
 			}
 			conn = connRetry
+			readCh = readChRetry
 			wsReqBody = wsReqBodyRetry
 		} else {
 			logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, "send_error", errSend)
@@ -573,7 +639,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		defer close(out)
 		defer func() {
 			if sess != nil {
-				sess.clearActive(readCh)
+				sess.clearActiveForConn(conn, readCh)
 				sess.reqMu.Unlock()
 				return
 			}
@@ -1399,9 +1465,37 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 	}
 
 	sess.connMu.Lock()
+	if sess.closed {
+		sess.connMu.Unlock()
+		return nil, nil, fmt.Errorf("codex websockets executor: execution session is closed")
+	}
+	generation := sess.generation
 	conn := sess.conn
 	readerConn := sess.readerConn
+	previousAuthID := sess.authID
+	previousWSURL := sess.wsURL
+	var staleConn *websocket.Conn
+	if conn != nil && (previousAuthID != authID || previousWSURL != wsURL) {
+		staleConn = conn
+		sess.conn = nil
+		if sess.readerConn == conn {
+			sess.readerConn = nil
+		}
+		sess.authID = ""
+		sess.wsURL = ""
+		if sess.recoverableWriteConn == conn {
+			sess.recoverableWriteConn = nil
+		}
+		conn = nil
+		readerConn = nil
+	}
 	sess.connMu.Unlock()
+	if staleConn != nil {
+		logCodexWebsocketDisconnected(sess.sessionID, previousAuthID, previousWSURL, "routing_target_changed", nil)
+		if errClose := staleConn.Close(); errClose != nil {
+			log.Errorf("codex websockets executor: close stale websocket error: %v", errClose)
+		}
+	}
 	if conn != nil {
 		if readerConn != conn {
 			sess.connMu.Lock()
@@ -1419,6 +1513,14 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 	}
 
 	sess.connMu.Lock()
+	if sess.closed || sess.generation != generation {
+		sess.connMu.Unlock()
+		if errClose := conn.Close(); errClose != nil {
+			log.Errorf("codex websockets executor: close rejected websocket error: %v", errClose)
+		}
+		closeHTTPResponseBody(resp, "codex websockets executor: close rejected handshake response body error")
+		return nil, nil, fmt.Errorf("codex websockets executor: execution session closed during websocket dial")
+	}
 	if sess.conn != nil {
 		previous := sess.conn
 		sess.connMu.Unlock()
@@ -1448,8 +1550,12 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 		msgType, payload, errRead := conn.ReadMessage()
 		if errRead != nil {
 			sess.activeMu.Lock()
-			ch := sess.activeCh
-			done := sess.activeDone
+			var ch chan codexWebsocketRead
+			var done <-chan struct{}
+			if sess.activeConn == conn {
+				ch = sess.activeCh
+				done = sess.activeDone
+			}
 			sess.activeMu.Unlock()
 			if ch != nil {
 				select {
@@ -1457,8 +1563,9 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 				case <-done:
 				default:
 				}
-				sess.clearActive(ch)
-				close(ch)
+				if sess.clearActiveForConn(conn, ch) {
+					close(ch)
+				}
 			}
 			e.invalidateUpstreamConn(sess, conn, "upstream_disconnected", errRead)
 			return
@@ -1468,8 +1575,12 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 			if msgType == websocket.BinaryMessage {
 				errBinary := fmt.Errorf("codex websockets executor: unexpected binary message")
 				sess.activeMu.Lock()
-				ch := sess.activeCh
-				done := sess.activeDone
+				var ch chan codexWebsocketRead
+				var done <-chan struct{}
+				if sess.activeConn == conn {
+					ch = sess.activeCh
+					done = sess.activeDone
+				}
 				sess.activeMu.Unlock()
 				if ch != nil {
 					select {
@@ -1477,8 +1588,9 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 					case <-done:
 					default:
 					}
-					sess.clearActive(ch)
-					close(ch)
+					if sess.clearActiveForConn(conn, ch) {
+						close(ch)
+					}
 				}
 				e.invalidateUpstreamConn(sess, conn, "unexpected_binary", errBinary)
 				return
@@ -1487,8 +1599,12 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 		}
 
 		sess.activeMu.Lock()
-		ch := sess.activeCh
-		done := sess.activeDone
+		var ch chan codexWebsocketRead
+		var done <-chan struct{}
+		if sess.activeConn == conn {
+			ch = sess.activeCh
+			done = sess.activeDone
+		}
 		sess.activeMu.Unlock()
 		if ch == nil {
 			continue
@@ -1510,6 +1626,10 @@ func (e *CodexWebsocketsExecutor) invalidateUpstreamConn(sess *codexWebsocketSes
 	authID := sess.authID
 	wsURL := sess.wsURL
 	sessionID := sess.sessionID
+	recoverable := sess.recoverableWriteConn == conn
+	if recoverable {
+		sess.recoverableWriteConn = nil
+	}
 	if current == nil || current != conn {
 		sess.connMu.Unlock()
 		return
@@ -1521,7 +1641,9 @@ func (e *CodexWebsocketsExecutor) invalidateUpstreamConn(sess *codexWebsocketSes
 	sess.connMu.Unlock()
 
 	logCodexWebsocketDisconnected(sessionID, authID, wsURL, reason, err)
-	sess.notifyUpstreamDisconnect(err)
+	if !recoverable {
+		sess.notifyUpstreamDisconnect(err)
+	}
 	if errClose := conn.Close(); errClose != nil {
 		log.Errorf("codex websockets executor: close websocket error: %v", errClose)
 	}
@@ -1595,6 +1717,9 @@ func closeCodexWebsocketSession(sess *codexWebsocketSession, reason string) {
 	conn := sess.conn
 	authID := sess.authID
 	wsURL := sess.wsURL
+	sess.closed = true
+	sess.generation++
+	sess.recoverableWriteConn = nil
 	sess.conn = nil
 	if sess.readerConn == conn {
 		sess.readerConn = nil

--- a/internal/runtime/executor/codex_websockets_rotation_test.go
+++ b/internal/runtime/executor/codex_websockets_rotation_test.go
@@ -1,0 +1,579 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func TestCodexWebsocketsEnsureUpstreamConnRebindsWhenAuthChanges(t *testing.T) {
+	acceptedAuth := make(chan string, 2)
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, errUpgrade := upgrader.Upgrade(w, r, nil)
+		if errUpgrade != nil {
+			return
+		}
+		acceptedAuth <- r.Header.Get("Authorization")
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	})
+	serverA := httptest.NewServer(handler)
+	defer serverA.Close()
+
+	wsURLA := "ws" + strings.TrimPrefix(serverA.URL, "http")
+	firstHeaders := http.Header{"Authorization": []string{"Bearer auth-a-token"}}
+	first, _, errDial := websocket.DefaultDialer.Dial(wsURLA, firstHeaders)
+	if errDial != nil {
+		t.Fatalf("dial first websocket: %v", errDial)
+	}
+	if got := waitAcceptedAuth(t, acceptedAuth); got != "Bearer auth-a-token" {
+		t.Fatalf("first authorization = %q", got)
+	}
+	sess := &codexWebsocketSession{
+		sessionID:            "rotation-session",
+		conn:                 first,
+		readerConn:           first,
+		wsURL:                wsURLA,
+		authID:               "auth-a",
+		upstreamDisconnectCh: make(chan error, 1),
+	}
+	exec := NewCodexWebsocketsExecutor(&config.Config{})
+	secondHeaders := http.Header{"Authorization": []string{"Bearer auth-b-token"}}
+
+	second, _, errRebind := exec.ensureUpstreamConn(context.Background(), nil, sess, "auth-b", wsURLA, secondHeaders)
+	if errRebind != nil {
+		t.Fatalf("rebind websocket: %v", errRebind)
+	}
+	defer func() { _ = second.Close() }()
+	if second == first {
+		t.Fatal("auth change reused stale websocket connection")
+	}
+	if got := waitAcceptedAuth(t, acceptedAuth); got != "Bearer auth-b-token" {
+		t.Fatalf("rebound authorization = %q", got)
+	}
+
+	active := make(chan codexWebsocketRead, 1)
+	sess.setActiveForConn(second, active)
+	staleReaderDone := make(chan struct{})
+	go func() {
+		exec.readUpstreamLoop(sess, first)
+		close(staleReaderDone)
+	}()
+	select {
+	case <-staleReaderDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stale websocket reader")
+	}
+	sess.activeMu.Lock()
+	activeConn := sess.activeConn
+	activeCh := sess.activeCh
+	sess.activeMu.Unlock()
+	if activeConn != second || activeCh != active {
+		t.Fatal("stale reader cleared rebound websocket active channel")
+	}
+	sess.connMu.Lock()
+	boundAuthID := sess.authID
+	sess.connMu.Unlock()
+	if boundAuthID != "auth-b" {
+		t.Fatalf("session auth ID = %q, want auth-b", boundAuthID)
+	}
+	sess.clearActiveForConn(second, active)
+	select {
+	case errDisconnect := <-sess.upstreamDisconnectCh:
+		t.Fatalf("intentional auth rebind signaled session disconnect: %v", errDisconnect)
+	default:
+	}
+}
+
+func TestCodexWebsocketsEnsureUpstreamConnRebindsWhenURLChanges(t *testing.T) {
+	acceptedAuth := make(chan string, 2)
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, errUpgrade := upgrader.Upgrade(w, r, nil)
+		if errUpgrade != nil {
+			return
+		}
+		acceptedAuth <- r.Header.Get("Authorization")
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	})
+	serverA := httptest.NewServer(handler)
+	defer serverA.Close()
+	serverB := httptest.NewServer(handler)
+	defer serverB.Close()
+	wsURLA := "ws" + strings.TrimPrefix(serverA.URL, "http")
+	wsURLB := "ws" + strings.TrimPrefix(serverB.URL, "http")
+	headers := http.Header{"Authorization": []string{"Bearer auth-b-token"}}
+	first, _, errDial := websocket.DefaultDialer.Dial(wsURLA, headers)
+	if errDial != nil {
+		t.Fatalf("dial first websocket: %v", errDial)
+	}
+	if got := waitAcceptedAuth(t, acceptedAuth); got != "Bearer auth-b-token" {
+		t.Fatalf("first authorization = %q", got)
+	}
+	sess := &codexWebsocketSession{
+		sessionID:            "url-rotation-session",
+		conn:                 first,
+		readerConn:           first,
+		wsURL:                wsURLA,
+		authID:               "auth-b",
+		upstreamDisconnectCh: make(chan error, 1),
+	}
+	exec := NewCodexWebsocketsExecutor(&config.Config{})
+
+	second, _, errRebind := exec.ensureUpstreamConn(context.Background(), nil, sess, "auth-b", wsURLB, headers)
+	if errRebind != nil {
+		t.Fatalf("rebind websocket URL: %v", errRebind)
+	}
+	defer func() { _ = second.Close() }()
+	if second == first {
+		t.Fatal("URL change reused stale websocket connection")
+	}
+	if got := waitAcceptedAuth(t, acceptedAuth); got != "Bearer auth-b-token" {
+		t.Fatalf("rebound authorization = %q", got)
+	}
+	active := make(chan codexWebsocketRead, 1)
+	sess.setActiveForConn(second, active)
+	staleReaderDone := make(chan struct{})
+	go func() {
+		exec.readUpstreamLoop(sess, first)
+		close(staleReaderDone)
+	}()
+	select {
+	case <-staleReaderDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stale URL reader")
+	}
+	sess.connMu.Lock()
+	boundWSURL := sess.wsURL
+	sess.connMu.Unlock()
+	if boundWSURL != wsURLB {
+		t.Fatalf("session websocket URL = %q, want %q", boundWSURL, wsURLB)
+	}
+	sess.activeMu.Lock()
+	activeConn := sess.activeConn
+	activeCh := sess.activeCh
+	sess.activeMu.Unlock()
+	if activeConn != second || activeCh != active {
+		t.Fatal("stale URL reader cleared rebound websocket active channel")
+	}
+	sess.clearActiveForConn(second, active)
+	select {
+	case errDisconnect := <-sess.upstreamDisconnectCh:
+		t.Fatalf("intentional URL rebind signaled session disconnect: %v", errDisconnect)
+	default:
+	}
+}
+
+func TestCodexWebsocketsEnsureUpstreamConnRejectsDialAfterSessionClose(t *testing.T) {
+	dialStarted := make(chan struct{})
+	allowUpgrade := make(chan struct{})
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(dialStarted)
+		<-allowUpgrade
+		conn, errUpgrade := upgrader.Upgrade(w, r, nil)
+		if errUpgrade != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	sess := &codexWebsocketSession{
+		sessionID:            "closing-session",
+		upstreamDisconnectCh: make(chan error, 1),
+	}
+	exec := NewCodexWebsocketsExecutor(&config.Config{})
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	type dialResult struct {
+		conn *websocket.Conn
+		err  error
+	}
+	resultCh := make(chan dialResult, 1)
+	go func() {
+		conn, _, errDial := exec.ensureUpstreamConn(context.Background(), nil, sess, "auth-b", wsURL, nil)
+		resultCh <- dialResult{conn: conn, err: errDial}
+	}()
+
+	select {
+	case <-dialStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for websocket dial")
+	}
+	closeCodexWebsocketSession(sess, "session_closed")
+	close(allowUpgrade)
+	var result dialResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for rejected websocket dial")
+	}
+	if result.conn != nil {
+		_ = result.conn.Close()
+		t.Fatal("closed session installed rebound websocket connection")
+	}
+	if result.err == nil || !strings.Contains(result.err.Error(), "closed during websocket dial") {
+		t.Fatalf("dial error = %v, want closed-session error", result.err)
+	}
+	sess.connMu.Lock()
+	installed := sess.conn
+	closed := sess.closed
+	sess.connMu.Unlock()
+	if installed != nil || !closed {
+		t.Fatalf("closed session state = conn:%v closed:%v", installed, closed)
+	}
+}
+
+func TestCodexWebsocketsSendFailureOwnsDetachBeforeStaleReader(t *testing.T) {
+	accepted := make(chan struct{}, 1)
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, errUpgrade := upgrader.Upgrade(w, r, nil)
+		if errUpgrade != nil {
+			return
+		}
+		accepted <- struct{}{}
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, errDial := websocket.DefaultDialer.Dial(wsURL, nil)
+	if errDial != nil {
+		t.Fatalf("dial websocket: %v", errDial)
+	}
+	<-accepted
+	sess := &codexWebsocketSession{
+		sessionID:            "send-reader-race",
+		conn:                 conn,
+		readerConn:           conn,
+		wsURL:                wsURL,
+		authID:               "auth-a",
+		upstreamDisconnectCh: make(chan error, 1),
+	}
+	exec := NewCodexWebsocketsExecutor(&config.Config{})
+	_ = conn.Close()
+
+	sess.writeMu.Lock()
+	writeResult := make(chan error, 1)
+	go func() {
+		writeResult <- sess.writeMessage(conn, websocket.TextMessage, []byte(`{"type":"response.create"}`))
+	}()
+	waitRecoverableWrite(t, sess, conn)
+	readerDone := make(chan struct{})
+	go func() {
+		exec.readUpstreamLoop(sess, conn)
+		close(readerDone)
+	}()
+	sess.writeMu.Unlock()
+	select {
+	case errWrite := <-writeResult:
+		if errWrite == nil {
+			t.Fatal("closed websocket write unexpectedly succeeded")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for websocket write failure")
+	}
+	select {
+	case <-readerDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stale reader failure")
+	}
+	assertNoUpstreamDisconnect(t, sess)
+}
+
+func TestCodexWebsocketsSessionCloseDoesNotWaitForBlockedWrite(t *testing.T) {
+	accepted := make(chan struct{}, 1)
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, errUpgrade := upgrader.Upgrade(w, r, nil)
+		if errUpgrade != nil {
+			return
+		}
+		accepted <- struct{}{}
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, errDial := websocket.DefaultDialer.Dial(wsURL, nil)
+	if errDial != nil {
+		t.Fatalf("dial websocket: %v", errDial)
+	}
+	<-accepted
+	sess := &codexWebsocketSession{
+		sessionID:            "close-blocked-write",
+		conn:                 conn,
+		readerConn:           conn,
+		wsURL:                wsURL,
+		authID:               "auth-a",
+		upstreamDisconnectCh: make(chan error, 1),
+	}
+	sess.writeMu.Lock()
+	writeResult := make(chan error, 1)
+	go func() {
+		writeResult <- sess.writeMessage(conn, websocket.TextMessage, []byte(`{"type":"response.create"}`))
+	}()
+	waitRecoverableWrite(t, sess, conn)
+	closeDone := make(chan struct{})
+	go func() {
+		closeCodexWebsocketSession(sess, "session_closed")
+		close(closeDone)
+	}()
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		sess.writeMu.Unlock()
+		t.Fatal("session close waited for blocked websocket write")
+	}
+	sess.writeMu.Unlock()
+	select {
+	case errWrite := <-writeResult:
+		if errWrite == nil {
+			t.Fatal("closed session write unexpectedly succeeded")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for closed-session write failure")
+	}
+	sess.connMu.Lock()
+	closed := sess.closed
+	installed := sess.conn
+	sess.connMu.Unlock()
+	if !closed || installed != nil {
+		t.Fatalf("session close state = closed:%v conn:%v", closed, installed)
+	}
+}
+
+func TestCodexWebsocketsExecuteRebindsActiveReaderAfterSendRetry(t *testing.T) {
+	fixture := newCodexWebsocketSendRetryFixture(t, "unary-retry")
+	defer fixture.close()
+
+	if _, errExecute := fixture.exec.Execute(context.Background(), fixture.auth, fixture.request, fixture.options); errExecute != nil {
+		t.Fatalf("Execute() retry error = %v", errExecute)
+	}
+	if got := fixture.acceptedConnections(); got != 2 {
+		t.Fatalf("accepted websocket connections = %d, want 2", got)
+	}
+	assertNoUpstreamDisconnect(t, fixture.session)
+}
+
+func TestCodexWebsocketsExecuteStreamRebindsActiveReaderAfterSendRetry(t *testing.T) {
+	fixture := newCodexWebsocketSendRetryFixture(t, "stream-retry")
+	defer fixture.close()
+	fixture.options.ResponseFormat = sdktranslator.FromString("openai-response")
+	ctx, cancel := context.WithCancel(cliproxyexecutor.WithDownstreamWebsocket(context.Background()))
+	defer cancel()
+
+	result, errExecute := fixture.exec.ExecuteStream(ctx, fixture.auth, fixture.request, fixture.options)
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() retry error = %v", errExecute)
+	}
+	want := []byte(`{"type":"response.output_text.delta","delta":"retry-ok"}`)
+	sawDelta := false
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case chunk, ok := <-result.Chunks:
+			if !ok {
+				if !sawDelta {
+					t.Fatal("retry stream closed without expected delta")
+				}
+				goto drained
+			}
+			if chunk.Err != nil {
+				t.Fatalf("retry stream chunk error = %v", chunk.Err)
+			}
+			if bytes.Equal(bytes.TrimSpace(chunk.Payload), want) {
+				sawDelta = true
+			}
+		case <-deadline:
+			t.Fatal("timed out draining retry stream")
+		}
+	}
+
+drained:
+	if got := fixture.acceptedConnections(); got != 2 {
+		t.Fatalf("accepted websocket connections = %d, want 2", got)
+	}
+	assertNoUpstreamDisconnect(t, fixture.session)
+}
+
+type codexWebsocketSendRetryFixture struct {
+	exec        *CodexWebsocketsExecutor
+	auth        *cliproxyauth.Auth
+	request     cliproxyexecutor.Request
+	options     cliproxyexecutor.Options
+	server      *httptest.Server
+	accepted    chan int
+	connections *atomic.Int32
+	session     *codexWebsocketSession
+	release     chan struct{}
+}
+
+func newCodexWebsocketSendRetryFixture(t *testing.T, sessionID string) *codexWebsocketSendRetryFixture {
+	t.Helper()
+	accepted := make(chan int, 2)
+	connections := &atomic.Int32{}
+	release := make(chan struct{})
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, errUpgrade := upgrader.Upgrade(w, r, nil)
+		if errUpgrade != nil {
+			return
+		}
+		connectionNumber := int(connections.Add(1))
+		accepted <- connectionNumber
+		defer func() { _ = conn.Close() }()
+		if connectionNumber == 1 {
+			_, _, _ = conn.ReadMessage()
+			return
+		}
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			return
+		}
+		delta := []byte(`{"type":"response.output_text.delta","delta":"retry-ok"}`)
+		completed := []byte(`{"type":"response.completed","response":{"id":"resp-retry","output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`)
+		_ = conn.WriteMessage(websocket.TextMessage, delta)
+		_ = conn.WriteMessage(websocket.TextMessage, completed)
+		<-release
+	}))
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/responses"
+	first, _, errDial := websocket.DefaultDialer.Dial(wsURL, nil)
+	if errDial != nil {
+		server.Close()
+		t.Fatalf("dial stale websocket: %v", errDial)
+	}
+	select {
+	case <-accepted:
+	case <-time.After(time.Second):
+		_ = first.Close()
+		server.Close()
+		t.Fatal("timed out waiting for stale websocket connection")
+	}
+	_ = first.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	exec.store = &codexWebsocketSessionStore{sessions: map[string]*codexWebsocketSession{}}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-retry",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"api_key":  "retry-token",
+			"base_url": server.URL,
+		},
+	}
+	session := &codexWebsocketSession{
+		sessionID:            sessionID,
+		conn:                 first,
+		readerConn:           first,
+		wsURL:                wsURL,
+		authID:               auth.ID,
+		upstreamDisconnectCh: make(chan error, 1),
+	}
+	exec.store.sessions[sessionID] = session
+	return &codexWebsocketSendRetryFixture{
+		exec: exec,
+		auth: auth,
+		request: cliproxyexecutor.Request{
+			Model:   "gpt-5-codex",
+			Payload: []byte(`{"model":"gpt-5-codex","input":[{"role":"user","content":"retry"}]}`),
+		},
+		options: cliproxyexecutor.Options{
+			SourceFormat: sdktranslator.FromString("openai-response"),
+			Metadata: map[string]any{
+				cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+			},
+		},
+		server:      server,
+		accepted:    accepted,
+		connections: connections,
+		session:     session,
+		release:     release,
+	}
+}
+
+func (f *codexWebsocketSendRetryFixture) acceptedConnections() int {
+	return int(f.connections.Load())
+}
+
+func (f *codexWebsocketSendRetryFixture) close() {
+	if f == nil {
+		return
+	}
+	close(f.release)
+	f.exec.CloseExecutionSession(executionSessionIDFromOptions(f.options))
+	f.server.Close()
+}
+
+func assertNoUpstreamDisconnect(t *testing.T, sess *codexWebsocketSession) {
+	t.Helper()
+	select {
+	case errDisconnect := <-sess.upstreamDisconnectCh:
+		t.Fatalf("successful websocket retry signaled session disconnect: %v", errDisconnect)
+	default:
+	}
+}
+
+func waitRecoverableWrite(t *testing.T, sess *codexWebsocketSession, conn *websocket.Conn) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		sess.connMu.Lock()
+		marked := sess.recoverableWriteConn == conn
+		sess.connMu.Unlock()
+		if marked {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for recoverable write marker")
+		}
+		runtime.Gosched()
+	}
+}
+
+func waitAcceptedAuth(t *testing.T, accepted <-chan string) string {
+	t.Helper()
+	select {
+	case auth := <-accepted:
+		return auth
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for websocket handshake")
+		return ""
+	}
+}

--- a/internal/watcher/clients.go
+++ b/internal/watcher/clients.go
@@ -169,10 +169,12 @@ func (w *Watcher) addOrUpdateClientLocked(path string) {
 	data, errRead := os.ReadFile(path)
 	if errRead != nil {
 		log.Errorf("failed to read auth file %s: %v", filepath.Base(path), errRead)
+		w.scheduleAuthReconciliation()
 		return
 	}
 	if len(data) == 0 {
 		log.Debugf("ignoring empty auth file: %s", filepath.Base(path))
+		w.scheduleAuthReconciliation()
 		return
 	}
 
@@ -184,6 +186,7 @@ func (w *Watcher) addOrUpdateClientLocked(path string) {
 	var newAuth coreauth.Auth
 	if errParse := json.Unmarshal(data, &newAuth); errParse != nil {
 		log.Errorf("failed to parse auth file %s: %v", filepath.Base(path), errParse)
+		w.scheduleAuthReconciliation()
 		return
 	}
 

--- a/internal/watcher/dispatcher.go
+++ b/internal/watcher/dispatcher.go
@@ -303,7 +303,7 @@ func normalizeAuth(a *coreauth.Auth) *coreauth.Auth {
 	if a == nil {
 		return nil
 	}
-	clone := a.Clone()
+	clone := a.CloneWithoutRevision()
 	clone.CreatedAt = time.Time{}
 	clone.UpdatedAt = time.Time{}
 	clone.LastRefreshedAt = time.Time{}

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -52,16 +52,23 @@ func (w *Watcher) processEvents(ctx context.Context) {
 			return
 		case event, ok := <-w.watcher.Events:
 			if !ok {
+				w.scheduleAuthReconciliation()
 				return
 			}
 			w.handleEvent(event)
 		case errWatch, ok := <-w.watcher.Errors:
 			if !ok {
+				w.scheduleAuthReconciliation()
 				return
 			}
-			log.Errorf("file watcher error: %v", errWatch)
+			w.handleWatcherError(errWatch)
 		}
 	}
+}
+
+func (w *Watcher) handleWatcherError(err error) {
+	log.WithError(err).Error("file watcher error")
+	w.scheduleAuthReconciliation()
 }
 
 func (w *Watcher) handleEvent(event fsnotify.Event) {

--- a/internal/watcher/reconciliation.go
+++ b/internal/watcher/reconciliation.go
@@ -1,0 +1,34 @@
+package watcher
+
+import "time"
+
+const authReconcileDebounce = 100 * time.Millisecond
+
+func (w *Watcher) scheduleAuthReconciliation() {
+	if w == nil || w.stopped.Load() {
+		return
+	}
+	w.authReconcileMu.Lock()
+	if w.authReconcileTimer != nil {
+		w.authReconcileTimer.Stop()
+	}
+	w.authReconcileTimer = time.AfterFunc(authReconcileDebounce, func() {
+		if w.stopped.Load() {
+			return
+		}
+		w.refreshAuthState(false)
+	})
+	w.authReconcileMu.Unlock()
+}
+
+func (w *Watcher) stopAuthReconciliation() {
+	if w == nil {
+		return
+	}
+	w.authReconcileMu.Lock()
+	if w.authReconcileTimer != nil {
+		w.authReconcileTimer.Stop()
+		w.authReconcileTimer = nil
+	}
+	w.authReconcileMu.Unlock()
+}

--- a/internal/watcher/reconciliation_test.go
+++ b/internal/watcher/reconciliation_test.go
@@ -1,0 +1,73 @@
+package watcher
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/synthesizer"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestProcessEventsReconcilesAuthsAfterWatcherError(t *testing.T) {
+	originalSnapshot := snapshotCoreAuthsFunc
+	snapshotCoreAuthsFunc = func(*config.Config, string, synthesizer.PluginAuthParser) []*coreauth.Auth {
+		return []*coreauth.Auth{{ID: "synthetic-auth.json", Provider: "codex", Metadata: map[string]any{"type": "codex"}}}
+	}
+	t.Cleanup(func() { snapshotCoreAuthsFunc = originalSnapshot })
+
+	queue := make(chan AuthUpdate, 2)
+	w := &Watcher{
+		config:          &config.Config{},
+		authDir:         t.TempDir(),
+		currentAuths:    make(map[string]*coreauth.Auth),
+		runtimeAuths:    make(map[string]*coreauth.Auth),
+		fileAuthsByPath: make(map[string]map[string]*coreauth.Auth),
+		lastAuthHashes:  make(map[string]string),
+		pendingUpdates:  make(map[string]AuthUpdate),
+	}
+	w.dispatchCond = sync.NewCond(&w.dispatchMu)
+	w.setAuthUpdateQueue(queue)
+	t.Cleanup(w.stopDispatch)
+
+	w.handleWatcherError(errors.New("synthetic watcher overflow"))
+
+	select {
+	case update := <-queue:
+		if update.Action != AuthUpdateActionAdd || update.Auth == nil || update.Auth.ID != "synthetic-auth.json" {
+			t.Fatalf("unexpected reconciliation update: %#v", update)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("watcher error did not trigger bounded auth reconciliation")
+	}
+}
+
+func TestAuthEqualIgnoresProcessLocalRevision(t *testing.T) {
+	firstManager := coreauth.NewManager(nil, nil, nil)
+	first, err := firstManager.Register(context.Background(), &coreauth.Auth{
+		ID:       "synthetic-auth.json",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex"},
+	})
+	if err != nil {
+		t.Fatalf("first Register() error = %v", err)
+	}
+	secondManager := coreauth.NewManager(nil, nil, nil)
+	second, err := secondManager.Register(context.Background(), &coreauth.Auth{
+		ID:       "synthetic-auth.json",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex"},
+	})
+	if err != nil {
+		t.Fatalf("second Register() error = %v", err)
+	}
+	if first.Revision() == second.Revision() {
+		t.Fatal("test setup produced equal revisions")
+	}
+	if !authEqual(first, second) {
+		t.Fatal("authEqual treated process-local revision as durable file change")
+	}
+}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -31,37 +31,39 @@ type authDirProvider interface {
 
 // Watcher manages file watching for configuration and authentication files
 type Watcher struct {
-	configPath        string
-	authDir           string
-	config            *config.Config
-	clientsMutex      sync.RWMutex
-	authRescanMu      sync.Mutex
-	configReloadMu    sync.Mutex
-	configReloadTimer *time.Timer
-	serverUpdateMu    sync.Mutex
-	serverUpdateTimer *time.Timer
-	serverUpdateLast  time.Time
-	serverUpdatePend  bool
-	stopped           atomic.Bool
-	reloadCallback    func(*config.Config)
-	watcher           *fsnotify.Watcher
-	lastAuthHashes    map[string]string
-	lastAuthContents  map[string]*coreauth.Auth
-	fileAuthsByPath   map[string]map[string]*coreauth.Auth
-	lastRemoveTimes   map[string]time.Time
-	lastConfigHash    string
-	authQueue         chan<- AuthUpdate
-	currentAuths      map[string]*coreauth.Auth
-	runtimeAuths      map[string]*coreauth.Auth
-	dispatchMu        sync.Mutex
-	dispatchCond      *sync.Cond
-	pendingUpdates    map[string]AuthUpdate
-	pendingOrder      []string
-	dispatchCancel    context.CancelFunc
-	storePersister    storePersister
-	pluginAuthParser  synthesizer.PluginAuthParser
-	mirroredAuthDir   string
-	oldConfigYaml     []byte
+	configPath         string
+	authDir            string
+	config             *config.Config
+	clientsMutex       sync.RWMutex
+	authRescanMu       sync.Mutex
+	configReloadMu     sync.Mutex
+	configReloadTimer  *time.Timer
+	serverUpdateMu     sync.Mutex
+	serverUpdateTimer  *time.Timer
+	serverUpdateLast   time.Time
+	serverUpdatePend   bool
+	stopped            atomic.Bool
+	reloadCallback     func(*config.Config)
+	watcher            *fsnotify.Watcher
+	lastAuthHashes     map[string]string
+	lastAuthContents   map[string]*coreauth.Auth
+	fileAuthsByPath    map[string]map[string]*coreauth.Auth
+	lastRemoveTimes    map[string]time.Time
+	lastConfigHash     string
+	authQueue          chan<- AuthUpdate
+	currentAuths       map[string]*coreauth.Auth
+	runtimeAuths       map[string]*coreauth.Auth
+	dispatchMu         sync.Mutex
+	dispatchCond       *sync.Cond
+	pendingUpdates     map[string]AuthUpdate
+	pendingOrder       []string
+	dispatchCancel     context.CancelFunc
+	authReconcileMu    sync.Mutex
+	authReconcileTimer *time.Timer
+	storePersister     storePersister
+	pluginAuthParser   synthesizer.PluginAuthParser
+	mirroredAuthDir    string
+	oldConfigYaml      []byte
 }
 
 // AuthUpdateAction represents the type of change detected in auth sources.
@@ -128,6 +130,7 @@ func (w *Watcher) Start(ctx context.Context) error {
 func (w *Watcher) Stop() error {
 	w.stopped.Store(true)
 	w.stopDispatch()
+	w.stopAuthReconciliation()
 	w.stopConfigReloadTimer()
 	w.stopServerUpdateTimer()
 	return w.watcher.Close()

--- a/sdk/auth/filestore_mutation.go
+++ b/sdk/auth/filestore_mutation.go
@@ -1,0 +1,328 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+var replaceAuthMutationFile = publishAuthMutationFile
+
+// ValidateSource checks that an already-persisted auth snapshot still matches disk.
+func (s *FileTokenStore) ValidateSource(ctx context.Context, auth *cliproxyauth.Auth) error {
+	if auth == nil || auth.Metadata == nil {
+		return nil
+	}
+	pathHint := ""
+	if auth.Attributes != nil {
+		pathHint = strings.TrimSpace(auth.Attributes[cliproxyauth.AttributePath])
+		if pathHint == "" {
+			pathHint = strings.TrimSpace(auth.Attributes[cliproxyauth.AttributeSource])
+		}
+	}
+	if pathHint == "" && strings.TrimSpace(auth.FileName) == "" {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	path, err := s.resolveAuthPath(auth)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	currentRaw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("auth filestore: read validation source: %w", err)
+	}
+	currentMetadata, err := decodeMutationMetadata(currentRaw)
+	if err != nil {
+		return fmt.Errorf("auth filestore: decode validation source: %w", err)
+	}
+	expected := comparableMutationMetadata(auth.Metadata, auth.Disabled)
+	if !reflect.DeepEqual(comparableMutationMetadata(currentMetadata, false), expected) {
+		return cliproxyauth.ErrAuthSourceConflict
+	}
+	return nil
+}
+
+// PersistMutation conditionally replaces one file-backed auth snapshot.
+// The destination is published only after a complete same-directory temp write.
+func (s *FileTokenStore) PersistMutation(ctx context.Context, before, after *cliproxyauth.Auth) (resultPath string, resultErr error) {
+	if before == nil || after == nil || strings.TrimSpace(before.ID) == "" || before.ID != after.ID {
+		return "", fmt.Errorf("auth filestore: invalid conditional mutation")
+	}
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+	}
+	path, err := s.resolveAuthPath(after)
+	if err != nil {
+		return "", err
+	}
+	if path == "" {
+		return "", fmt.Errorf("auth filestore: missing file path attribute for %s", after.ID)
+	}
+	if before.Metadata == nil || after.Metadata == nil {
+		return "", cliproxyauth.ErrPriorityMutationUnsupported
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	currentRaw, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("auth filestore: read current mutation source: %w", err)
+	}
+	currentMetadata, err := decodeMutationMetadata(currentRaw)
+	if err != nil {
+		return "", fmt.Errorf("auth filestore: decode current mutation source: %w", err)
+	}
+	preservedMetadata, err := decodePreservedMutationMetadata(currentRaw)
+	if err != nil {
+		return "", fmt.Errorf("auth filestore: preserve current mutation source: %w", err)
+	}
+	beforeMetadata := comparableMutationMetadata(before.Metadata, before.Disabled)
+	if !reflect.DeepEqual(comparableMutationMetadata(currentMetadata, false), beforeMetadata) {
+		return "", cliproxyauth.ErrAuthSourceConflict
+	}
+
+	afterMetadata := mergeMutationMetadata(preservedMetadata, before.Metadata, after.Metadata)
+	_, disabledPresent := currentMetadata["disabled"]
+	if disabledPresent || after.Disabled {
+		afterMetadata["disabled"] = after.Disabled
+	} else {
+		delete(afterMetadata, "disabled")
+	}
+	raw, err := json.Marshal(afterMetadata)
+	if err != nil {
+		return "", fmt.Errorf("auth filestore: marshal conditional mutation: %w", err)
+	}
+	if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("auth filestore: create mutation dir: %w", err)
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), ".cliproxy-auth-mutation-*")
+	if err != nil {
+		return "", fmt.Errorf("auth filestore: create mutation temp: %w", err)
+	}
+	tempPath := temp.Name()
+	removeTemp := true
+	tempClosed := false
+	defer func() {
+		if !tempClosed {
+			if errClose := temp.Close(); errClose != nil {
+				resultErr = errors.Join(resultErr, fmt.Errorf("auth filestore: close mutation temp during cleanup: %w", errClose))
+			}
+		}
+		if removeTemp {
+			if errRemove := os.Remove(tempPath); errRemove != nil && !os.IsNotExist(errRemove) {
+				resultErr = errors.Join(resultErr, fmt.Errorf("auth filestore: remove mutation temp during cleanup: %w", errRemove))
+			}
+		}
+	}()
+	if err = temp.Chmod(0o600); err != nil {
+		return "", fmt.Errorf("auth filestore: chmod mutation temp: %w", err)
+	}
+	if _, err = temp.Write(raw); err != nil {
+		return "", fmt.Errorf("auth filestore: write mutation temp: %w", err)
+	}
+	if err = temp.Sync(); err != nil {
+		return "", fmt.Errorf("auth filestore: sync mutation temp: %w", err)
+	}
+	if err = temp.Close(); err != nil {
+		return "", fmt.Errorf("auth filestore: close mutation temp: %w", err)
+	}
+	tempClosed = true
+	latestRaw, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("auth filestore: re-read mutation source: %w", err)
+	}
+	if !reflect.DeepEqual(latestRaw, currentRaw) {
+		return "", cliproxyauth.ErrAuthSourceConflict
+	}
+	if err = replaceAuthMutationFile(tempPath, path, currentRaw); err != nil {
+		return "", fmt.Errorf("auth filestore: publish conditional mutation: %w", err)
+	}
+
+	if after.Attributes == nil {
+		after.Attributes = make(map[string]string)
+	}
+	after.Attributes[cliproxyauth.AttributePath] = path
+	after.Attributes[cliproxyauth.AttributeSource] = path
+	after.Attributes[cliproxyauth.AttributeSourceBackend] = cliproxyauth.AuthSourceFile
+	return path, nil
+}
+
+func publishAuthMutationFile(tempPath, destinationPath string, expectedRaw []byte) (resultErr error) {
+	dir := filepath.Dir(destinationPath)
+	backup, err := os.CreateTemp(dir, ".cliproxy-auth-previous-*")
+	if err != nil {
+		return fmt.Errorf("create mutation backup path: %w", err)
+	}
+	backupPath := backup.Name()
+	if err = backup.Close(); err != nil {
+		errClose := fmt.Errorf("close mutation backup path: %w", err)
+		if errRemove := os.Remove(backupPath); errRemove != nil && !os.IsNotExist(errRemove) {
+			return errors.Join(errClose, fmt.Errorf("remove mutation backup after close failure: %w", errRemove))
+		}
+		return errClose
+	}
+	if err = os.Remove(backupPath); err != nil {
+		return fmt.Errorf("prepare mutation backup path: %w", err)
+	}
+	cleanupBackup := true
+	defer func() {
+		if cleanupBackup {
+			if errRemove := os.Remove(backupPath); errRemove != nil && !os.IsNotExist(errRemove) {
+				resultErr = errors.Join(resultErr, fmt.Errorf("remove mutation backup during cleanup: %w", errRemove))
+			}
+		}
+	}()
+
+	if err = os.Rename(destinationPath, backupPath); err != nil {
+		return fmt.Errorf("displace mutation source: %w", err)
+	}
+	displacedRaw, err := os.ReadFile(backupPath)
+	if err != nil {
+		if errRestore := restoreDisplacedAuthMutationFile(backupPath, destinationPath); errRestore != nil {
+			cleanupBackup = false
+			return fmt.Errorf("read displaced mutation source: %w (restore failed: %v)", err, errRestore)
+		}
+		cleanupBackup = false
+		return fmt.Errorf("read displaced mutation source: %w", err)
+	}
+	if !reflect.DeepEqual(displacedRaw, expectedRaw) {
+		if errRestore := restoreDisplacedAuthMutationFile(backupPath, destinationPath); errRestore != nil {
+			cleanupBackup = false
+			return fmt.Errorf("%w: restore displaced source: %v", cliproxyauth.ErrAuthSourceConflict, errRestore)
+		}
+		cleanupBackup = false
+		return cliproxyauth.ErrAuthSourceConflict
+	}
+
+	if err = os.Link(tempPath, destinationPath); err != nil {
+		errRestore := restoreDisplacedAuthMutationFile(backupPath, destinationPath)
+		cleanupBackup = false
+		if os.IsExist(err) {
+			if errRestore != nil {
+				return fmt.Errorf("%w: restore displaced source: %v", cliproxyauth.ErrAuthSourceConflict, errRestore)
+			}
+			return cliproxyauth.ErrAuthSourceConflict
+		}
+		if errRestore != nil {
+			return fmt.Errorf("publish mutation source: %w (restore failed: %v)", err, errRestore)
+		}
+		return fmt.Errorf("publish mutation source: %w", err)
+	}
+	if err = os.Remove(tempPath); err != nil {
+		if errRestore := rollbackPublishedAuthMutationFile(tempPath, backupPath, destinationPath); errRestore != nil {
+			cleanupBackup = false
+			return fmt.Errorf("remove mutation temp link: %w (rollback failed: %v)", err, errRestore)
+		}
+		cleanupBackup = false
+		return fmt.Errorf("remove mutation temp link: %w", err)
+	}
+	if err = os.Remove(backupPath); err != nil {
+		if errRestore := rollbackPublishedAuthMutationFile(destinationPath, backupPath, destinationPath); errRestore != nil {
+			cleanupBackup = false
+			return fmt.Errorf("remove mutation backup: %w (rollback failed: %v)", err, errRestore)
+		}
+		cleanupBackup = false
+		return fmt.Errorf("remove mutation backup: %w", err)
+	}
+	cleanupBackup = false
+	return nil
+}
+
+func restoreDisplacedAuthMutationFile(backupPath, destinationPath string) error {
+	if _, err := os.Lstat(destinationPath); err == nil {
+		return os.Remove(backupPath)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.Link(backupPath, destinationPath); err != nil {
+		if os.IsExist(err) {
+			return os.Remove(backupPath)
+		}
+		return err
+	}
+	return os.Remove(backupPath)
+}
+
+func rollbackPublishedAuthMutationFile(publishedPath, backupPath, destinationPath string) error {
+	publishedInfo, errPublished := os.Stat(publishedPath)
+	destinationInfo, errDestination := os.Stat(destinationPath)
+	if errPublished == nil && errDestination == nil && os.SameFile(publishedInfo, destinationInfo) {
+		if errRemove := os.Remove(destinationPath); errRemove != nil {
+			return errRemove
+		}
+	}
+	return restoreDisplacedAuthMutationFile(backupPath, destinationPath)
+}
+
+func decodeMutationMetadata(raw []byte) (map[string]any, error) {
+	var metadata map[string]any
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		return nil, err
+	}
+	if metadata == nil {
+		metadata = make(map[string]any)
+	}
+	return metadata, nil
+}
+
+func decodePreservedMutationMetadata(raw []byte) (map[string]any, error) {
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.UseNumber()
+	var metadata map[string]any
+	if err := decoder.Decode(&metadata); err != nil {
+		return nil, err
+	}
+	if metadata == nil {
+		metadata = make(map[string]any)
+	}
+	return metadata, nil
+}
+
+func mergeMutationMetadata(current, before, after map[string]any) map[string]any {
+	merged := cloneMutationMetadata(current)
+	for key := range before {
+		if _, present := after[key]; !present {
+			delete(merged, key)
+		}
+	}
+	for key, value := range after {
+		beforeValue, present := before[key]
+		if !present || !reflect.DeepEqual(beforeValue, value) {
+			merged[key] = value
+		}
+	}
+	return merged
+}
+
+func comparableMutationMetadata(metadata map[string]any, disabled bool) map[string]any {
+	comparable := cloneMutationMetadata(metadata)
+	if _, present := comparable["disabled"]; !present {
+		comparable["disabled"] = disabled
+	}
+	return comparable
+}
+
+func cloneMutationMetadata(metadata map[string]any) map[string]any {
+	clone := make(map[string]any, len(metadata)+1)
+	for key, value := range metadata {
+		clone[key] = value
+	}
+	return clone
+}

--- a/sdk/auth/filestore_mutation_test.go
+++ b/sdk/auth/filestore_mutation_test.go
@@ -1,0 +1,201 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestFileTokenStorePersistMutationUnsetsPriorityExactly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "synthetic-auth.json")
+	if err := os.WriteFile(path, []byte(`{"type":"codex","access_token":"synthetic-token","priority":10,"note":"keep","large_id":9007199254740993}`), 0o600); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+	auths, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("List() len = %d, want 1", len(auths))
+	}
+	before := auths[0]
+	after := before.Clone()
+	delete(after.Metadata, "priority")
+	delete(after.Attributes, "priority")
+
+	if _, err = store.PersistMutation(context.Background(), before, after); err != nil {
+		t.Fatalf("PersistMutation() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read auth file: %v", err)
+	}
+	var persisted map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err = decoder.Decode(&persisted); err != nil {
+		t.Fatalf("decode auth file: %v", err)
+	}
+	if _, ok := persisted["priority"]; ok {
+		t.Fatalf("priority still present: %s", raw)
+	}
+	if got := persisted["access_token"]; got != "synthetic-token" {
+		t.Fatalf("access_token = %#v, want preserved", got)
+	}
+	if got := persisted["note"]; got != "keep" {
+		t.Fatalf("note = %#v, want preserved", got)
+	}
+	if got := persisted["large_id"]; got != json.Number("9007199254740993") {
+		t.Fatalf("large_id = %#v, want exact numeric preservation", got)
+	}
+	if _, present := persisted["disabled"]; present {
+		t.Fatalf("disabled field was added: %s", raw)
+	}
+}
+
+func TestFileTokenStorePersistMutationRejectsReplacedSource(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "synthetic-auth.json")
+	if err := os.WriteFile(path, []byte(`{"type":"codex","access_token":"old-synthetic-token","priority":10}`), 0o600); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+	auths, err := store.List(context.Background())
+	if err != nil || len(auths) != 1 {
+		t.Fatalf("List() auths=%d error=%v", len(auths), err)
+	}
+	before := auths[0]
+	after := before.Clone()
+	after.Metadata["priority"] = 101
+	after.Attributes["priority"] = "101"
+
+	replacement := []byte(`{"type":"codex","access_token":"replacement-synthetic-token","priority":7}`)
+	if err = os.WriteFile(path, replacement, 0o600); err != nil {
+		t.Fatalf("replace auth file: %v", err)
+	}
+	if _, err = store.PersistMutation(context.Background(), before, after); !errors.Is(err, cliproxyauth.ErrAuthSourceConflict) {
+		t.Fatalf("PersistMutation() error = %v, want ErrAuthSourceConflict", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read replacement: %v", err)
+	}
+	if string(got) != string(replacement) {
+		t.Fatalf("replacement changed: got %s want %s", got, replacement)
+	}
+}
+
+func TestFileTokenStorePersistMutationRejectsReplacementDuringPublish(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "synthetic-auth.json")
+	if err := os.WriteFile(path, []byte(`{"type":"codex","access_token":"old-synthetic-token","priority":10}`), 0o600); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+	auths, err := store.List(context.Background())
+	if err != nil || len(auths) != 1 {
+		t.Fatalf("List() auths=%d error=%v", len(auths), err)
+	}
+	after := auths[0].Clone()
+	after.Metadata["priority"] = float64(101)
+	after.Attributes["priority"] = "101"
+
+	replacement := []byte(`{"type":"codex","access_token":"replacement-synthetic-token","priority":7}`)
+	originalReplace := replaceAuthMutationFile
+	replaceAuthMutationFile = func(tempPath, destinationPath string, expectedRaw []byte) error {
+		if errWrite := os.WriteFile(destinationPath, replacement, 0o600); errWrite != nil {
+			return errWrite
+		}
+		return originalReplace(tempPath, destinationPath, expectedRaw)
+	}
+	t.Cleanup(func() { replaceAuthMutationFile = originalReplace })
+
+	if _, err = store.PersistMutation(context.Background(), auths[0], after); !errors.Is(err, cliproxyauth.ErrAuthSourceConflict) {
+		t.Fatalf("PersistMutation() error = %v, want ErrAuthSourceConflict", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read replacement: %v", err)
+	}
+	if string(got) != string(replacement) {
+		t.Fatalf("replacement changed: got %s want %s", got, replacement)
+	}
+}
+
+func TestFileTokenStorePersistMutationPublishFailureLeavesOriginalBytes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "synthetic-auth.json")
+	original := []byte(`{"type":"codex","access_token":"synthetic-token","priority":10}`)
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+	auths, err := store.List(context.Background())
+	if err != nil || len(auths) != 1 {
+		t.Fatalf("List() auths=%d error=%v", len(auths), err)
+	}
+	after := auths[0].Clone()
+	after.Metadata["priority"] = float64(101)
+	after.Attributes["priority"] = "101"
+
+	originalReplace := replaceAuthMutationFile
+	replaceAuthMutationFile = func(string, string, []byte) error { return errors.New("synthetic rename failure") }
+	t.Cleanup(func() { replaceAuthMutationFile = originalReplace })
+	if _, err = store.PersistMutation(context.Background(), auths[0], after); err == nil {
+		t.Fatal("PersistMutation() error = nil, want publish failure")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read original: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("original bytes changed: got %s want %s", got, original)
+	}
+}
+
+func TestFileTokenStoreRejectsStalePersistedWatcherSnapshotAfterPriorityMutation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "synthetic-auth.json")
+	if err := os.WriteFile(path, []byte(`{"type":"codex","access_token":"synthetic-token","priority":10}`), 0o600); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+	manager := cliproxyauth.NewManager(store, &cliproxyauth.FillFirstSelector{}, nil)
+	if err := manager.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	staleSnapshots, err := store.List(context.Background())
+	if err != nil || len(staleSnapshots) != 1 {
+		t.Fatalf("List() auths=%d error=%v", len(staleSnapshots), err)
+	}
+	registered, _ := manager.GetByID("synthetic-auth.json")
+	result, err := manager.MutatePriority(context.Background(), registered.ID, registered.Revision(), cliproxyauth.PriorityMutation{
+		Operation: cliproxyauth.PriorityMutationSet,
+		Priority:  101,
+	})
+	if err != nil {
+		t.Fatalf("MutatePriority() error = %v", err)
+	}
+	if _, err = manager.Update(cliproxyauth.WithSkipPersist(context.Background()), staleSnapshots[0]); !errors.Is(err, cliproxyauth.ErrAuthSourceConflict) {
+		t.Fatalf("stale watcher Update() error = %v, want ErrAuthSourceConflict", err)
+	}
+	current, _ := manager.GetByID(registered.ID)
+	if current.Revision() != result.Revision || current.Attributes["priority"] != "101" {
+		t.Fatalf("stale watcher rolled back runtime: revision=%q priority=%q", current.Revision(), current.Attributes["priority"])
+	}
+}

--- a/sdk/cliproxy/auth/clone.go
+++ b/sdk/cliproxy/auth/clone.go
@@ -1,0 +1,58 @@
+package auth
+
+// Clone copies Auth, recursively duplicating JSON-like metadata containers.
+func (a *Auth) Clone() *Auth {
+	if a == nil {
+		return nil
+	}
+	copyAuth := *a
+	if len(a.Attributes) > 0 {
+		copyAuth.Attributes = make(map[string]string, len(a.Attributes))
+		for key, value := range a.Attributes {
+			copyAuth.Attributes[key] = value
+		}
+	}
+	if len(a.Metadata) > 0 {
+		copyAuth.Metadata = make(map[string]any, len(a.Metadata))
+		for key, value := range a.Metadata {
+			copyAuth.Metadata[key] = cloneMetadataValue(value)
+		}
+	}
+	if len(a.ModelStates) > 0 {
+		copyAuth.ModelStates = make(map[string]*ModelState, len(a.ModelStates))
+		for key, state := range a.ModelStates {
+			copyAuth.ModelStates[key] = state.Clone()
+		}
+	}
+	copyAuth.Runtime = a.Runtime
+	return &copyAuth
+}
+
+func cloneMetadataValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		clone := make(map[string]any, len(typed))
+		for key, nested := range typed {
+			clone[key] = cloneMetadataValue(nested)
+		}
+		return clone
+	case map[string]string:
+		clone := make(map[string]string, len(typed))
+		for key, nested := range typed {
+			clone[key] = nested
+		}
+		return clone
+	case []any:
+		clone := make([]any, len(typed))
+		for index, nested := range typed {
+			clone[index] = cloneMetadataValue(nested)
+		}
+		return clone
+	case []string:
+		return append([]string(nil), typed...)
+	case []byte:
+		return append([]byte(nil), typed...)
+	default:
+		return value
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -260,9 +260,8 @@ type Manager struct {
 	refreshLoop   *authAutoRefreshLoop
 
 	requestPrepareLocks sync.Map
-	// refreshLocks serializes credential refresh per auth ID so concurrent
-	// 401 recoveries and auto-refresh workers do not race the same refresh_token.
-	refreshLocks sync.Map
+	// mutationLocks serialize durable auth mutations per auth ID for process lifetime.
+	mutationLocks sync.Map
 }
 
 // NewManager constructs a manager with optional custom selector and hook.
@@ -2163,6 +2162,14 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 	if auth.ID == "" {
 		auth.ID = uuid.NewString()
 	}
+	mutationLock := m.mutationLock(auth.ID)
+	mutationLock.mu.Lock()
+	defer mutationLock.mu.Unlock()
+	revision, errRevision := newAuthRevision()
+	if errRevision != nil {
+		return nil, errRevision
+	}
+	auth.revision = revision
 	now := time.Now()
 	clearedCooldown := false
 	if m.cooldownDisabledForAuth(auth) || auth.Disabled || auth.Status == StatusDisabled {
@@ -2170,6 +2177,9 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 	}
 	auth.EnsureIndex()
 	authClone := auth.Clone()
+	if errPersist := m.persist(ctx, authClone); errPersist != nil {
+		return nil, errPersist
+	}
 	m.mu.Lock()
 	m.auths[auth.ID] = authClone
 	m.mu.Unlock()
@@ -2180,12 +2190,11 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 		m.scheduler.upsertAuth(authClone)
 	}
 	m.queueRefreshReschedule(auth.ID)
-	_ = m.persist(ctx, auth)
-	m.hook.OnAuthRegistered(ctx, auth.Clone())
+	m.hook.OnAuthRegistered(ctx, authClone.Clone())
 	if clearedCooldown {
 		m.persistCooldownStates(ctx)
 	}
-	return auth.Clone(), nil
+	return authClone.Clone(), nil
 }
 
 // Update replaces an existing auth entry and notifies hooks.
@@ -2193,46 +2202,10 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	if auth == nil || auth.ID == "" {
 		return nil, nil
 	}
-	m.mu.Lock()
-	existing, ok := m.auths[auth.ID]
-	if !ok || existing == nil {
-		m.mu.Unlock()
-		return nil, nil
-	}
-	if !auth.indexAssigned && auth.Index == "" {
-		auth.Index = existing.Index
-		auth.indexAssigned = existing.indexAssigned
-	}
-	auth.Success = existing.Success
-	auth.Failed = existing.Failed
-	auth.recentRequests = existing.recentRequests
-	if !existing.Disabled && existing.Status != StatusDisabled && !auth.Disabled && auth.Status != StatusDisabled {
-		if len(auth.ModelStates) == 0 && len(existing.ModelStates) > 0 {
-			auth.ModelStates = existing.ModelStates
-		}
-	}
-	now := time.Now()
-	clearedCooldown := false
-	if m.cooldownDisabledForAuth(auth) || auth.Disabled || auth.Status == StatusDisabled {
-		clearedCooldown = clearCooldownStateForAuth(auth, now)
-	}
-	auth.EnsureIndex()
-	authClone := auth.Clone()
-	m.auths[auth.ID] = authClone
-	m.mu.Unlock()
-	if !shouldDeferAPIKeyModelAliasRebuild(ctx) {
-		m.rebuildAPIKeyModelAliasFromRuntimeConfig()
-	}
-	if m.scheduler != nil {
-		m.scheduler.upsertAuth(authClone)
-	}
-	m.queueRefreshReschedule(auth.ID)
-	_ = m.persist(ctx, auth)
-	m.hook.OnAuthUpdated(ctx, auth.Clone())
-	if clearedCooldown {
-		m.persistCooldownStates(ctx)
-	}
-	return auth.Clone(), nil
+	mutationLock := m.mutationLock(auth.ID)
+	mutationLock.mu.Lock()
+	defer mutationLock.mu.Unlock()
+	return m.updateLocked(ctx, auth)
 }
 
 // Remove deletes an auth from runtime state without persisting.
@@ -2245,6 +2218,9 @@ func (m *Manager) Remove(ctx context.Context, id string) {
 	if id == "" {
 		return
 	}
+	mutationLock := m.mutationLock(id)
+	mutationLock.mu.Lock()
+	defer mutationLock.mu.Unlock()
 	_ = ctx
 
 	m.mu.Lock()
@@ -2314,6 +2290,12 @@ func (m *Manager) Load(ctx context.Context) error {
 		if auth == nil || auth.ID == "" {
 			continue
 		}
+		revision, errRevision := newAuthRevision()
+		if errRevision != nil {
+			m.mu.Unlock()
+			return errRevision
+		}
+		auth.revision = revision
 		auth.EnsureIndex()
 		m.auths[auth.ID] = auth.Clone()
 	}
@@ -5960,12 +5942,7 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		return nil, errors.New("auth id is empty")
 	}
 
-	lockValue, _ := m.refreshLocks.LoadOrStore(id, &authRefreshLock{})
-	lock, _ := lockValue.(*authRefreshLock)
-	if lock == nil {
-		lock = &authRefreshLock{}
-		m.refreshLocks.Store(id, lock)
-	}
+	lock := m.mutationLock(id)
 	lock.mu.Lock()
 	defer lock.mu.Unlock()
 
@@ -6042,12 +6019,13 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 	if m.shouldRefresh(updated, now) {
 		updated.NextRefreshAfter = now.Add(refreshIneffectiveBackoff)
 	}
-	saved, errUpdate := m.Update(ctx, updated)
-	for _, model := range modelsToResume {
-		registry.GetGlobalRegistry().ResumeClientModel(id, model)
-	}
+	saved, errUpdate := m.updateLocked(ctx, updated)
 	if errUpdate != nil {
 		log.Debugf("persist refreshed auth %s (%s) failed: %v", auth.Provider, auth.ID, errUpdate)
+		return nil, errUpdate
+	}
+	for _, model := range modelsToResume {
+		registry.GetGlobalRegistry().ResumeClientModel(id, model)
 	}
 	if saved != nil {
 		return saved, nil

--- a/sdk/cliproxy/auth/mutation.go
+++ b/sdk/cliproxy/auth/mutation.go
@@ -1,0 +1,448 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	ErrAuthNotFound                        = errors.New("auth not found")
+	ErrAuthRevisionConflict                = errors.New("auth revision conflict")
+	ErrAuthSourceConflict                  = errors.New("auth source conflict")
+	ErrPriorityMutationUnsupported         = errors.New("priority mutation unsupported")
+	ErrPriorityMutationRoutingIncompatible = errors.New("priority mutation routing incompatible")
+)
+
+type PriorityMutationOperation string
+
+const (
+	PriorityMutationSet   PriorityMutationOperation = "set"
+	PriorityMutationUnset PriorityMutationOperation = "unset"
+)
+
+type PriorityMutation struct {
+	Operation PriorityMutationOperation
+	Priority  int
+}
+
+type PriorityValue struct {
+	Present bool
+	Value   int
+}
+
+type PriorityMutationResult struct {
+	Auth     *Auth
+	Revision string
+	Priority PriorityValue
+}
+
+// ConditionalMutationStore persists a mutation only while the backing source
+// still matches the manager snapshot supplied as before.
+type ConditionalMutationStore interface {
+	PersistMutation(ctx context.Context, before, after *Auth) (string, error)
+}
+
+// SourceValidationStore validates an already-persisted watcher snapshot before publication.
+type SourceValidationStore interface {
+	ValidateSource(ctx context.Context, auth *Auth) error
+}
+
+type authMutationLock struct {
+	mu sync.Mutex
+}
+
+func (m *Manager) mutationLock(id string) *authMutationLock {
+	id = strings.TrimSpace(id)
+	value, _ := m.mutationLocks.LoadOrStore(id, &authMutationLock{})
+	lock, _ := value.(*authMutationLock)
+	if lock == nil {
+		lock = &authMutationLock{}
+		m.mutationLocks.Store(id, lock)
+	}
+	return lock
+}
+
+func (m *Manager) updateLocked(ctx context.Context, auth *Auth) (*Auth, error) {
+	skipPersist := shouldSkipPersist(ctx)
+	m.mu.Lock()
+	existing, ok := m.auths[auth.ID]
+	if !ok || existing == nil {
+		m.mu.Unlock()
+		return nil, nil
+	}
+	if auth.revision != "" && auth.revision != existing.revision {
+		m.mu.Unlock()
+		return nil, ErrAuthRevisionConflict
+	}
+	if skipPersist {
+		if store, ok := m.store.(SourceValidationStore); ok && store != nil {
+			candidate := auth.Clone()
+			m.mu.Unlock()
+			if errValidate := store.ValidateSource(ctx, candidate); errValidate != nil {
+				return nil, errValidate
+			}
+			m.mu.Lock()
+			existing = m.auths[auth.ID]
+			if existing == nil {
+				m.mu.Unlock()
+				return nil, ErrAuthNotFound
+			}
+		}
+	}
+	if skipPersist && auth.revision == "" && sameDurableAuthState(existing, auth) {
+		result := existing.Clone()
+		m.mu.Unlock()
+		return result, nil
+	}
+	if !auth.indexAssigned && auth.Index == "" {
+		auth.Index = existing.Index
+		auth.indexAssigned = existing.indexAssigned
+	}
+	auth.Success = existing.Success
+	auth.Failed = existing.Failed
+	auth.recentRequests = existing.recentRequests
+	if !existing.Disabled && existing.Status != StatusDisabled && !auth.Disabled && auth.Status != StatusDisabled {
+		if len(auth.ModelStates) == 0 && len(existing.ModelStates) > 0 {
+			auth.ModelStates = existing.ModelStates
+		}
+	}
+	now := time.Now()
+	clearedCooldown := false
+	if m.cooldownDisabledForAuth(auth) || auth.Disabled || auth.Status == StatusDisabled {
+		clearedCooldown = clearCooldownStateForAuth(auth, now)
+	}
+	auth.EnsureIndex()
+	revision, errRevision := newAuthRevision()
+	if errRevision != nil {
+		m.mu.Unlock()
+		return nil, errRevision
+	}
+	auth.revision = revision
+	authClone := auth.Clone()
+	existingClone := existing.Clone()
+	m.mu.Unlock()
+	if errPersist := m.persistUpdate(ctx, existingClone, authClone); errPersist != nil {
+		return nil, errPersist
+	}
+	if errPublication := ctx.Err(); errPublication != nil {
+		return nil, m.recoverAuthUpdate(ctx, existingClone, authClone, errPublication, !skipPersist)
+	}
+	if errPublication := m.publishAuthUpdate(ctx, existingClone, authClone, clearedCooldown); errPublication != nil {
+		return nil, m.recoverAuthUpdate(ctx, existingClone, authClone, errPublication, !skipPersist)
+	}
+	return authClone.Clone(), nil
+}
+
+func (m *Manager) publishAuthUpdate(ctx context.Context, existing, candidate *Auth, clearedCooldown bool) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("publish auth update: %v", recovered)
+		}
+	}()
+	candidateClone := candidate.Clone()
+	m.mu.Lock()
+	current := m.auths[candidate.ID]
+	if current == nil || current.revision != existing.revision {
+		m.mu.Unlock()
+		return ErrAuthRevisionConflict
+	}
+	m.auths[candidate.ID] = candidateClone
+	m.mu.Unlock()
+	if !shouldDeferAPIKeyModelAliasRebuild(ctx) {
+		m.rebuildAPIKeyModelAliasFromRuntimeConfig()
+	}
+	if m.scheduler != nil {
+		m.scheduler.upsertAuth(candidateClone)
+	}
+	m.queueRefreshReschedule(candidate.ID)
+	m.hook.OnAuthUpdated(ctx, candidateClone.Clone())
+	if clearedCooldown {
+		m.persistCooldownStates(ctx)
+	}
+	return nil
+}
+
+func (m *Manager) recoverAuthUpdate(ctx context.Context, existing, candidate *Auth, cause error, persisted bool) error {
+	recoveryCtx := context.WithoutCancel(ctx)
+	if !persisted {
+		if errReconcile := m.reconcileAuthFromStore(recoveryCtx, existing.ID); errReconcile != nil {
+			return errors.Join(cause, fmt.Errorf("reconcile source auth update: %w", errReconcile))
+		}
+		return cause
+	}
+
+	var errRollback error
+	if store, ok := m.store.(ConditionalMutationStore); ok && store != nil {
+		_, errRollback = store.PersistMutation(recoveryCtx, candidate.Clone(), existing.Clone())
+	} else {
+		errRollback = m.persist(recoveryCtx, existing.Clone())
+	}
+	if errRollback == nil {
+		if errRuntime := m.restoreUpdatedAuthRuntime(existing); errRuntime != nil {
+			return errors.Join(cause, fmt.Errorf("restore auth update runtime: %w", errRuntime))
+		}
+		return cause
+	}
+	if errReconcile := m.reconcileAuthFromStore(recoveryCtx, existing.ID); errReconcile != nil {
+		return errors.Join(cause, fmt.Errorf("rollback persisted auth update: %w", errRollback), fmt.Errorf("reconcile persisted auth update: %w", errReconcile))
+	}
+	return errors.Join(cause, fmt.Errorf("rollback persisted auth update: %w", errRollback))
+}
+
+func (m *Manager) restoreUpdatedAuthRuntime(auth *Auth) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("restore auth update runtime: %v", recovered)
+		}
+	}()
+	authClone := auth.Clone()
+	m.mu.Lock()
+	m.auths[auth.ID] = authClone
+	m.mu.Unlock()
+	m.rebuildAPIKeyModelAliasFromRuntimeConfig()
+	if m.scheduler != nil {
+		m.scheduler.upsertAuth(authClone)
+	}
+	m.queueRefreshReschedule(auth.ID)
+	return nil
+}
+
+func sameDurableAuthState(left, right *Auth) bool {
+	normalize := func(auth *Auth) *Auth {
+		if auth == nil {
+			return nil
+		}
+		clone := auth.Clone()
+		clone.revision = ""
+		clone.Index = ""
+		clone.indexAssigned = false
+		clone.Storage = nil
+		clone.Runtime = nil
+		clone.CreatedAt = time.Time{}
+		clone.UpdatedAt = time.Time{}
+		clone.LastRefreshedAt = time.Time{}
+		clone.NextRefreshAfter = time.Time{}
+		clone.NextRetryAfter = time.Time{}
+		clone.LastError = nil
+		clone.ModelStates = nil
+		clone.Quota = QuotaState{}
+		clone.Unavailable = false
+		clone.StatusMessage = ""
+		clone.Success = 0
+		clone.Failed = 0
+		clone.recentRequests = recentRequestRing{}
+		return clone
+	}
+	return reflect.DeepEqual(normalize(left), normalize(right))
+}
+
+func (m *Manager) persistUpdate(ctx context.Context, before, after *Auth) error {
+	if shouldSkipPersist(ctx) {
+		return nil
+	}
+	if store, ok := m.store.(ConditionalMutationStore); ok && store != nil {
+		_, err := store.PersistMutation(ctx, before, after)
+		return err
+	}
+	return m.persist(ctx, after)
+}
+
+func (m *Manager) MutatePriority(ctx context.Context, id, expectedRevision string, mutation PriorityMutation) (*PriorityMutationResult, error) {
+	if m == nil {
+		return nil, ErrAuthNotFound
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, ErrAuthNotFound
+	}
+	lock := m.mutationLock(id)
+	lock.mu.Lock()
+	defer lock.mu.Unlock()
+
+	m.mu.RLock()
+	current := m.auths[id]
+	if current != nil {
+		current = current.Clone()
+	}
+	m.mu.RUnlock()
+	if current == nil {
+		return nil, ErrAuthNotFound
+	}
+	if strings.TrimSpace(expectedRevision) == "" || expectedRevision != current.revision {
+		return nil, ErrAuthRevisionConflict
+	}
+	if errCompatibility := m.priorityMutationCompatibilityError(current); errCompatibility != nil {
+		return nil, errCompatibility
+	}
+	store, ok := m.store.(ConditionalMutationStore)
+	if !ok || store == nil {
+		return nil, ErrPriorityMutationUnsupported
+	}
+
+	candidate := current.Clone()
+	if candidate.Metadata == nil {
+		candidate.Metadata = make(map[string]any)
+	}
+	if candidate.Attributes == nil {
+		candidate.Attributes = make(map[string]string)
+	}
+	priority := PriorityValue{}
+	switch mutation.Operation {
+	case PriorityMutationSet:
+		candidate.Metadata["priority"] = float64(mutation.Priority)
+		candidate.Attributes["priority"] = strconv.Itoa(mutation.Priority)
+		priority = PriorityValue{Present: true, Value: mutation.Priority}
+	case PriorityMutationUnset:
+		delete(candidate.Metadata, "priority")
+		delete(candidate.Attributes, "priority")
+	default:
+		return nil, fmt.Errorf("invalid priority operation %q", mutation.Operation)
+	}
+	revision, errRevision := newAuthRevision()
+	if errRevision != nil {
+		return nil, errRevision
+	}
+	candidate.revision = revision
+	if _, errPersist := store.PersistMutation(ctx, current.Clone(), candidate.Clone()); errPersist != nil {
+		return nil, errPersist
+	}
+	if errPublication := ctx.Err(); errPublication != nil {
+		return nil, m.recoverPriorityMutation(ctx, store, current, candidate, errPublication)
+	}
+	if errPublication := m.publishPriorityMutation(ctx, current, candidate); errPublication != nil {
+		return nil, m.recoverPriorityMutation(ctx, store, current, candidate, errPublication)
+	}
+	return &PriorityMutationResult{
+		Auth:     candidate.Clone(),
+		Revision: revision,
+		Priority: priority,
+	}, nil
+}
+
+func (m *Manager) publishPriorityMutation(ctx context.Context, current, candidate *Auth) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("publish priority mutation: %v", recovered)
+		}
+	}()
+	candidateClone := candidate.Clone()
+	m.mu.Lock()
+	live := m.auths[current.ID]
+	if live == nil || live.revision != current.revision {
+		m.mu.Unlock()
+		return ErrAuthRevisionConflict
+	}
+	m.auths[current.ID] = candidateClone
+	m.mu.Unlock()
+	if m.scheduler != nil {
+		m.scheduler.upsertAuth(candidateClone)
+	}
+	m.queueRefreshReschedule(current.ID)
+	m.hook.OnAuthUpdated(ctx, candidateClone.Clone())
+	return nil
+}
+
+func (m *Manager) recoverPriorityMutation(ctx context.Context, store ConditionalMutationStore, current, candidate *Auth, cause error) error {
+	recoveryCtx := context.WithoutCancel(ctx)
+	if _, errRollback := store.PersistMutation(recoveryCtx, candidate.Clone(), current.Clone()); errRollback == nil {
+		if errRuntime := m.restorePriorityRuntime(current); errRuntime != nil {
+			return errors.Join(cause, fmt.Errorf("restore priority runtime: %w", errRuntime))
+		}
+		return cause
+	} else {
+		errReconcile := m.reconcileAuthFromStore(recoveryCtx, current.ID)
+		if errReconcile != nil {
+			return errors.Join(cause, fmt.Errorf("rollback persisted priority mutation: %w", errRollback), fmt.Errorf("reconcile persisted priority mutation: %w", errReconcile))
+		}
+		return errors.Join(cause, fmt.Errorf("rollback persisted priority mutation: %w", errRollback))
+	}
+}
+
+func (m *Manager) restorePriorityRuntime(auth *Auth) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("restore priority runtime: %v", recovered)
+		}
+	}()
+	authClone := auth.Clone()
+	m.mu.Lock()
+	m.auths[auth.ID] = authClone
+	m.mu.Unlock()
+	if m.scheduler != nil {
+		m.scheduler.upsertAuth(authClone)
+	}
+	m.queueRefreshReschedule(auth.ID)
+	return nil
+}
+
+func (m *Manager) reconcileAuthFromStore(ctx context.Context, id string) (resultErr error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			resultErr = fmt.Errorf("reconcile auth from store: %v", recovered)
+		}
+	}()
+	if m.store == nil {
+		return errors.New("auth store unavailable")
+	}
+	items, err := m.store.List(ctx)
+	if err != nil {
+		return err
+	}
+	for _, auth := range items {
+		if auth == nil || auth.ID != id {
+			continue
+		}
+		snapshot := auth.Clone()
+		snapshot.revision = ""
+		m.mu.RLock()
+		current := m.auths[id]
+		if current != nil {
+			current = current.Clone()
+		}
+		m.mu.RUnlock()
+		alreadyPublished := current != nil && sameDurableAuthState(current, snapshot)
+		reconciled, errUpdate := m.updateLocked(WithSkipPersist(ctx), snapshot)
+		if errUpdate != nil {
+			return errUpdate
+		}
+		if alreadyPublished && reconciled != nil {
+			if m.scheduler != nil {
+				m.scheduler.upsertAuth(reconciled)
+			}
+			m.queueRefreshReschedule(id)
+			m.hook.OnAuthUpdated(ctx, reconciled.Clone())
+		}
+		return nil
+	}
+	return ErrAuthNotFound
+}
+
+func (m *Manager) priorityMutationCompatibilityError(target *Auth) error {
+	if target == nil || target.Metadata == nil || IsPluginVirtualAuth(target) || IsConfigAPIKeyAuth(target) {
+		return ErrPriorityMutationUnsupported
+	}
+	if target.Attributes != nil {
+		if strings.EqualFold(strings.TrimSpace(target.Attributes["runtime_only"]), "true") {
+			return ErrPriorityMutationUnsupported
+		}
+	}
+	if m.hasPluginScheduler() {
+		return ErrPriorityMutationUnsupported
+	}
+	if strings.EqualFold(strings.TrimSpace(target.Provider), "codex") {
+		m.mu.RLock()
+		defer m.mu.RUnlock()
+		for _, auth := range m.auths {
+			if auth != nil && strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") && authWebsocketsEnabled(auth) {
+				return ErrPriorityMutationRoutingIncompatible
+			}
+		}
+	}
+	return nil
+}

--- a/sdk/cliproxy/auth/mutation_recovery_test.go
+++ b/sdk/cliproxy/auth/mutation_recovery_test.go
@@ -1,0 +1,501 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type cancelAfterPersistStore struct {
+	*transactionTestStore
+
+	mu          sync.Mutex
+	cancel      context.CancelFunc
+	rollbackErr error
+	calls       int
+}
+
+func (s *cancelAfterPersistStore) PersistMutation(ctx context.Context, before, after *Auth) (string, error) {
+	s.mu.Lock()
+	s.calls++
+	call := s.calls
+	cancel := s.cancel
+	rollbackErr := s.rollbackErr
+	s.mu.Unlock()
+	if call > 1 && rollbackErr != nil {
+		return "", rollbackErr
+	}
+	path, err := s.transactionTestStore.PersistMutation(ctx, before, after)
+	if call == 1 && err == nil && cancel != nil {
+		cancel()
+	}
+	return path, err
+}
+
+func TestManagerMutatePriorityCancellationAfterPersistenceRollsBackDurableState(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store := &cancelAfterPersistStore{transactionTestStore: &transactionTestStore{}, cancel: cancel}
+	hook := &transactionTestHook{}
+	manager := NewManager(store, &FillFirstSelector{}, hook)
+	manager.RegisterExecutor(&immediateRefreshExecutor{})
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:         "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"priority": "10"},
+		Metadata:   map[string]any{"type": "codex", "priority": float64(10)},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	result, err := manager.MutatePriority(ctx, registered.ID, registered.Revision(), PriorityMutation{
+		Operation: PriorityMutationSet,
+		Priority:  101,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("MutatePriority() error = %v, want context.Canceled", err)
+	}
+	if result != nil {
+		t.Fatalf("MutatePriority() result = %#v, want nil", result)
+	}
+	current, _ := manager.GetByID(registered.ID)
+	if current.Revision() != registered.Revision() || current.Attributes["priority"] != "10" {
+		t.Fatalf("runtime changed after rollback: revision=%q priority=%q", current.Revision(), current.Attributes["priority"])
+	}
+	store.transactionTestStore.mu.Lock()
+	persisted := store.saved[registered.ID].Clone()
+	store.transactionTestStore.mu.Unlock()
+	if persisted.Revision() != registered.Revision() || persisted.Attributes["priority"] != "10" {
+		t.Fatalf("durable state not rolled back: revision=%q priority=%q", persisted.Revision(), persisted.Attributes["priority"])
+	}
+	if got := hook.updateCount(); got != 0 {
+		t.Fatalf("update hook count = %d, want 0", got)
+	}
+}
+
+func TestManagerMutatePriorityRollbackFailureReconcilesPersistedState(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store := &cancelAfterPersistStore{
+		transactionTestStore: &transactionTestStore{},
+		cancel:               cancel,
+		rollbackErr:          errors.New("synthetic rollback failure"),
+	}
+	hook := &transactionTestHook{}
+	manager := NewManager(store, &FillFirstSelector{}, hook)
+	manager.RegisterExecutor(&immediateRefreshExecutor{})
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:         "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"priority": "10"},
+		Metadata:   map[string]any{"type": "codex", "priority": float64(10)},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	result, err := manager.MutatePriority(ctx, registered.ID, registered.Revision(), PriorityMutation{
+		Operation: PriorityMutationSet,
+		Priority:  101,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("MutatePriority() error = %v, want context.Canceled", err)
+	}
+	if result != nil {
+		t.Fatalf("MutatePriority() result = %#v, want nil", result)
+	}
+	current, _ := manager.GetByID(registered.ID)
+	if current.Attributes["priority"] != "101" || current.Metadata["priority"] != float64(101) {
+		t.Fatalf("runtime not reconciled to durable mutation: attributes=%q metadata=%#v", current.Attributes["priority"], current.Metadata["priority"])
+	}
+	if current.Revision() == registered.Revision() {
+		t.Fatalf("reconciled revision did not rotate: %q", current.Revision())
+	}
+	selected, _, errPick := manager.pickNext(context.Background(), "codex", "", cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("pickNext() error = %v", errPick)
+	}
+	if selected.Revision() != current.Revision() || selected.Attributes["priority"] != "101" {
+		t.Fatalf("scheduler not reconciled: revision=%q priority=%q", selected.Revision(), selected.Attributes["priority"])
+	}
+	if got := hook.updateCount(); got != 1 {
+		t.Fatalf("update hook count = %d, want 1 reconciliation update", got)
+	}
+}
+
+type panicUpdateHook struct{}
+
+func (panicUpdateHook) OnAuthRegistered(context.Context, *Auth) {}
+func (panicUpdateHook) OnAuthUpdated(context.Context, *Auth) {
+	panic("synthetic update hook panic")
+}
+func (panicUpdateHook) OnResult(context.Context, Result) {}
+
+type panicOnceUpdateHook struct {
+	mu      sync.Mutex
+	updates int
+}
+
+func (*panicOnceUpdateHook) OnAuthRegistered(context.Context, *Auth) {}
+func (h *panicOnceUpdateHook) OnAuthUpdated(context.Context, *Auth) {
+	h.mu.Lock()
+	h.updates++
+	updates := h.updates
+	h.mu.Unlock()
+	if updates == 1 {
+		panic("synthetic first update hook panic")
+	}
+}
+func (*panicOnceUpdateHook) OnResult(context.Context, Result) {}
+func (h *panicOnceUpdateHook) updateCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.updates
+}
+
+func TestManagerMutatePriorityPublicationPanicRollsBackDurableAndRuntimeState(t *testing.T) {
+	store := &transactionTestStore{}
+	manager := NewManager(store, &FillFirstSelector{}, panicUpdateHook{})
+	manager.RegisterExecutor(&immediateRefreshExecutor{})
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:         "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"priority": "10"},
+		Metadata:   map[string]any{"type": "codex", "priority": float64(10)},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	result, err := manager.MutatePriority(context.Background(), registered.ID, registered.Revision(), PriorityMutation{
+		Operation: PriorityMutationSet,
+		Priority:  101,
+	})
+	if err == nil {
+		t.Fatal("MutatePriority() error = nil, want publication failure")
+	}
+	if result != nil {
+		t.Fatalf("MutatePriority() result = %#v, want nil", result)
+	}
+	current, _ := manager.GetByID(registered.ID)
+	if current.Revision() != registered.Revision() || current.Attributes["priority"] != "10" {
+		t.Fatalf("runtime changed after publication rollback: revision=%q priority=%q", current.Revision(), current.Attributes["priority"])
+	}
+	store.mu.Lock()
+	persisted := store.saved[registered.ID].Clone()
+	store.mu.Unlock()
+	if persisted.Revision() != registered.Revision() || persisted.Attributes["priority"] != "10" {
+		t.Fatalf("durable state changed after publication rollback: revision=%q priority=%q", persisted.Revision(), persisted.Attributes["priority"])
+	}
+	selected, _, errPick := manager.pickNext(context.Background(), "codex", "", cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("pickNext() error = %v", errPick)
+	}
+	if selected.Revision() != registered.Revision() || selected.Attributes["priority"] != "10" {
+		t.Fatalf("scheduler changed after publication rollback: revision=%q priority=%q", selected.Revision(), selected.Attributes["priority"])
+	}
+}
+
+func TestManagerMutatePriorityPublicationAndRollbackFailureReconcilesAllConsumers(t *testing.T) {
+	store := &cancelAfterPersistStore{
+		transactionTestStore: &transactionTestStore{},
+		rollbackErr:          errors.New("synthetic rollback failure"),
+	}
+	hook := &panicOnceUpdateHook{}
+	manager := NewManager(store, &FillFirstSelector{}, hook)
+	manager.RegisterExecutor(&immediateRefreshExecutor{})
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:         "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"priority": "10"},
+		Metadata:   map[string]any{"type": "codex", "priority": float64(10)},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	result, err := manager.MutatePriority(context.Background(), registered.ID, registered.Revision(), PriorityMutation{
+		Operation: PriorityMutationSet,
+		Priority:  101,
+	})
+	if err == nil {
+		t.Fatal("MutatePriority() error = nil, want publication failure")
+	}
+	if result != nil {
+		t.Fatalf("MutatePriority() result = %#v, want nil", result)
+	}
+	current, _ := manager.GetByID(registered.ID)
+	if current.Attributes["priority"] != "101" || current.Metadata["priority"] != float64(101) {
+		t.Fatalf("runtime not reconciled: attributes=%q metadata=%#v", current.Attributes["priority"], current.Metadata["priority"])
+	}
+	selected, _, errPick := manager.pickNext(context.Background(), "codex", "", cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("pickNext() error = %v", errPick)
+	}
+	if selected.Revision() != current.Revision() || selected.Attributes["priority"] != "101" {
+		t.Fatalf("scheduler not reconciled: revision=%q priority=%q", selected.Revision(), selected.Attributes["priority"])
+	}
+	if got := hook.updateCount(); got != 2 {
+		t.Fatalf("update hook count = %d, want failed publication plus reconciliation", got)
+	}
+}
+
+func TestManagerUpdateCancellationAfterPersistenceRollsBackDurableState(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store := &cancelAfterPersistStore{transactionTestStore: &transactionTestStore{}, cancel: cancel}
+	hook := &transactionTestHook{}
+	manager := NewManager(store, &FillFirstSelector{}, hook)
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:         "synthetic-auth.json",
+		Provider:   "claude",
+		Attributes: map[string]string{"priority": "10"},
+		Metadata:   map[string]any{"type": "claude", "priority": float64(10)},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	updated := registered.Clone()
+	updated.Attributes["priority"] = "101"
+	updated.Metadata["priority"] = float64(101)
+
+	result, err := manager.Update(ctx, updated)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Update() error = %v, want context.Canceled", err)
+	}
+	if result != nil {
+		t.Fatalf("Update() result = %#v, want nil", result)
+	}
+	current, _ := manager.GetByID(registered.ID)
+	if current.Revision() != registered.Revision() || current.Attributes["priority"] != "10" {
+		t.Fatalf("runtime changed after rollback: revision=%q priority=%q", current.Revision(), current.Attributes["priority"])
+	}
+	store.transactionTestStore.mu.Lock()
+	persisted := store.saved[registered.ID].Clone()
+	store.transactionTestStore.mu.Unlock()
+	if persisted.Revision() != registered.Revision() || persisted.Attributes["priority"] != "10" {
+		t.Fatalf("durable state not rolled back: revision=%q priority=%q", persisted.Revision(), persisted.Attributes["priority"])
+	}
+	if got := hook.updateCount(); got != 0 {
+		t.Fatalf("update hook count = %d, want 0", got)
+	}
+}
+
+func TestManagerUpdatePublicationPanicRollsBackDurableAndRuntimeState(t *testing.T) {
+	store := &transactionTestStore{}
+	manager := NewManager(store, &FillFirstSelector{}, panicUpdateHook{})
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:         "synthetic-auth.json",
+		Provider:   "claude",
+		Attributes: map[string]string{"priority": "10"},
+		Metadata:   map[string]any{"type": "claude", "priority": float64(10)},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	updated := registered.Clone()
+	updated.Attributes["priority"] = "101"
+	updated.Metadata["priority"] = float64(101)
+
+	result, err := manager.Update(context.Background(), updated)
+	if err == nil {
+		t.Fatal("Update() error = nil, want publication failure")
+	}
+	if result != nil {
+		t.Fatalf("Update() result = %#v, want nil", result)
+	}
+	current, _ := manager.GetByID(registered.ID)
+	if current.Revision() != registered.Revision() || current.Attributes["priority"] != "10" {
+		t.Fatalf("runtime changed after publication rollback: revision=%q priority=%q", current.Revision(), current.Attributes["priority"])
+	}
+	store.mu.Lock()
+	persisted := store.saved[registered.ID].Clone()
+	store.mu.Unlock()
+	if persisted.Revision() != registered.Revision() || persisted.Attributes["priority"] != "10" {
+		t.Fatalf("durable state changed after publication rollback: revision=%q priority=%q", persisted.Revision(), persisted.Attributes["priority"])
+	}
+}
+
+type blockingPriorityPersistStore struct {
+	*transactionTestStore
+
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (s *blockingPriorityPersistStore) PersistMutation(ctx context.Context, before, after *Auth) (string, error) {
+	if before.Attributes["priority"] != after.Attributes["priority"] {
+		s.once.Do(func() {
+			close(s.started)
+			<-s.release
+		})
+	}
+	return s.transactionTestStore.PersistMutation(ctx, before, after)
+}
+
+func TestPriorityMutationBeforeConcurrentRefreshPreservesCredentialsAndPriorityOutcome(t *testing.T) {
+	tests := []struct {
+		name          string
+		mutation      PriorityMutation
+		wantPresent   bool
+		wantAttribute string
+	}{
+		{name: "set", mutation: PriorityMutation{Operation: PriorityMutationSet, Priority: 101}, wantPresent: true, wantAttribute: "101"},
+		{name: "unset", mutation: PriorityMutation{Operation: PriorityMutationUnset}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := &blockingPriorityPersistStore{
+				transactionTestStore: &transactionTestStore{},
+				started:              make(chan struct{}),
+				release:              make(chan struct{}),
+			}
+			manager := NewManager(store, &FillFirstSelector{}, nil)
+			manager.RegisterExecutor(&immediateRefreshExecutor{})
+			registered, err := manager.Register(context.Background(), &Auth{
+				ID:         "synthetic-auth.json",
+				Provider:   "codex",
+				Attributes: map[string]string{"priority": "10"},
+				Metadata: map[string]any{
+					"type":          "codex",
+					"priority":      float64(10),
+					"access_token":  "old-token",
+					"refresh_token": "synthetic-refresh",
+				},
+			})
+			if err != nil {
+				t.Fatalf("Register() error = %v", err)
+			}
+
+			priorityDone := make(chan error, 1)
+			go func() {
+				_, errPriority := manager.MutatePriority(context.Background(), registered.ID, registered.Revision(), test.mutation)
+				priorityDone <- errPriority
+			}()
+			<-store.started
+
+			refreshDone := make(chan error, 1)
+			go func() {
+				_, errRefresh := manager.refreshAuthForRequest(context.Background(), registered.ID, "")
+				refreshDone <- errRefresh
+			}()
+			select {
+			case errRefresh := <-refreshDone:
+				t.Fatalf("refresh completed before priority commit: %v", errRefresh)
+			case <-time.After(50 * time.Millisecond):
+			}
+			close(store.release)
+			if err = <-priorityDone; err != nil {
+				t.Fatalf("MutatePriority() error = %v", err)
+			}
+			if err = <-refreshDone; err != nil {
+				t.Fatalf("refreshAuthForRequest() error = %v", err)
+			}
+
+			current, _ := manager.GetByID(registered.ID)
+			if got := current.Metadata["access_token"]; got != "uncommitted-refreshed-token" {
+				t.Fatalf("access_token = %#v, want refreshed token", got)
+			}
+			_, priorityPresent := current.Metadata["priority"]
+			if priorityPresent != test.wantPresent || current.Attributes["priority"] != test.wantAttribute {
+				t.Fatalf("priority outcome: present=%v attribute=%q", priorityPresent, current.Attributes["priority"])
+			}
+		})
+	}
+}
+
+func TestRefreshBeforeConcurrentPriorityUnsetPreservesRefreshedCredentialsAndAllowsExactRetry(t *testing.T) {
+	store := &transactionTestStore{}
+	manager := NewManager(store, &FillFirstSelector{}, nil)
+	executor := &blockingRefreshExecutor{started: make(chan struct{}), release: make(chan struct{})}
+	manager.RegisterExecutor(executor)
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:         "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"priority": "10"},
+		Metadata: map[string]any{
+			"type":          "codex",
+			"priority":      float64(10),
+			"access_token":  "old-token",
+			"refresh_token": "synthetic-refresh",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, errRefresh := manager.refreshAuthForRequest(context.Background(), registered.ID, "")
+		refreshDone <- errRefresh
+	}()
+	<-executor.started
+	unsetDone := make(chan error, 1)
+	go func() {
+		_, errUnset := manager.MutatePriority(context.Background(), registered.ID, registered.Revision(), PriorityMutation{Operation: PriorityMutationUnset})
+		unsetDone <- errUnset
+	}()
+	select {
+	case errUnset := <-unsetDone:
+		t.Fatalf("unset completed before refresh commit: %v", errUnset)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(executor.release)
+	if err = <-refreshDone; err != nil {
+		t.Fatalf("refreshAuthForRequest() error = %v", err)
+	}
+	if err = <-unsetDone; !errors.Is(err, ErrAuthRevisionConflict) {
+		t.Fatalf("stale unset error = %v, want ErrAuthRevisionConflict", err)
+	}
+
+	refreshed, _ := manager.GetByID(registered.ID)
+	if _, err = manager.MutatePriority(context.Background(), refreshed.ID, refreshed.Revision(), PriorityMutation{Operation: PriorityMutationUnset}); err != nil {
+		t.Fatalf("retry unset error = %v", err)
+	}
+	current, _ := manager.GetByID(registered.ID)
+	if got := current.Metadata["access_token"]; got != "refreshed-token" {
+		t.Fatalf("access_token = %#v, want refreshed-token", got)
+	}
+	if _, present := current.Metadata["priority"]; present {
+		t.Fatalf("priority metadata still present: %#v", current.Metadata["priority"])
+	}
+	if _, present := current.Attributes["priority"]; present {
+		t.Fatalf("priority attribute still present: %#v", current.Attributes["priority"])
+	}
+}
+
+func TestManagerMutatePriorityAllowsUnrelatedProviderWhenCodexWebsocketEnabled(t *testing.T) {
+	store := &transactionTestStore{}
+	manager := NewManager(store, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(context.Background(), &Auth{
+		ID:         "codex-websocket.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"websockets": "true"},
+		Metadata:   map[string]any{"type": "codex", "websockets": true},
+	}); err != nil {
+		t.Fatalf("Register(codex) error = %v", err)
+	}
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:         "claude-auth.json",
+		Provider:   "claude",
+		Attributes: map[string]string{"priority": "10"},
+		Metadata:   map[string]any{"type": "claude", "priority": float64(10)},
+	})
+	if err != nil {
+		t.Fatalf("Register(claude) error = %v", err)
+	}
+
+	result, err := manager.MutatePriority(context.Background(), registered.ID, registered.Revision(), PriorityMutation{
+		Operation: PriorityMutationSet,
+		Priority:  101,
+	})
+	if err != nil {
+		t.Fatalf("MutatePriority() error = %v", err)
+	}
+	if result.Priority.Value != 101 {
+		t.Fatalf("priority result = %#v, want 101", result.Priority)
+	}
+}

--- a/sdk/cliproxy/auth/mutation_transaction_test.go
+++ b/sdk/cliproxy/auth/mutation_transaction_test.go
@@ -1,0 +1,577 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+type transactionTestStore struct {
+	mu    sync.Mutex
+	fail  bool
+	saved map[string]*Auth
+}
+
+func (s *transactionTestStore) List(context.Context) ([]*Auth, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*Auth, 0, len(s.saved))
+	for _, auth := range s.saved {
+		out = append(out, auth.Clone())
+	}
+	return out, nil
+}
+
+func (s *transactionTestStore) Save(_ context.Context, auth *Auth) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.fail {
+		return "", errors.New("synthetic persistence failure")
+	}
+	if s.saved == nil {
+		s.saved = make(map[string]*Auth)
+	}
+	s.saved[auth.ID] = auth.Clone()
+	return auth.ID, nil
+}
+
+func (s *transactionTestStore) Delete(context.Context, string) error { return nil }
+
+func (s *transactionTestStore) PersistMutation(_ context.Context, before, after *Auth) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.fail {
+		return "", errors.New("synthetic persistence failure")
+	}
+	current := s.saved[before.ID]
+	if current == nil || current.Revision() != before.Revision() {
+		return "", ErrAuthSourceConflict
+	}
+	s.saved[after.ID] = after.Clone()
+	return after.ID, nil
+}
+
+type transactionTestHook struct {
+	mu        sync.Mutex
+	registers int
+	updates   int
+}
+
+func (h *transactionTestHook) OnAuthRegistered(context.Context, *Auth) {
+	h.mu.Lock()
+	h.registers++
+	h.mu.Unlock()
+}
+
+func (h *transactionTestHook) OnAuthUpdated(context.Context, *Auth) {
+	h.mu.Lock()
+	h.updates++
+	h.mu.Unlock()
+}
+
+func (*transactionTestHook) OnResult(context.Context, Result) {}
+
+func (h *transactionTestHook) updateCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.updates
+}
+
+func (h *transactionTestHook) registerCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.registers
+}
+
+func TestManagerUpdatePersistenceFailureLeavesRuntimeAndRevisionUnchanged(t *testing.T) {
+	store := &transactionTestStore{}
+	hook := &transactionTestHook{}
+	manager := NewManager(store, &FillFirstSelector{}, hook)
+
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:         "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"priority": "10"},
+		Metadata:   map[string]any{"type": "codex", "priority": float64(10)},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	originalRevision := registered.Revision()
+
+	store.mu.Lock()
+	store.fail = true
+	store.mu.Unlock()
+
+	updated := registered.Clone()
+	updated.Attributes["priority"] = "101"
+	updated.Metadata["priority"] = float64(101)
+	if _, err = manager.Update(context.Background(), updated); err == nil {
+		t.Fatal("Update() error = nil, want persistence failure")
+	}
+
+	current, ok := manager.GetByID(registered.ID)
+	if !ok {
+		t.Fatal("GetByID() missing registered auth")
+	}
+	if got := current.Attributes["priority"]; got != "10" {
+		t.Fatalf("runtime priority = %q, want unchanged 10", got)
+	}
+	if got := current.Revision(); got != originalRevision {
+		t.Fatalf("revision = %q, want unchanged %q", got, originalRevision)
+	}
+	if got := hook.updateCount(); got != 0 {
+		t.Fatalf("update hook count = %d, want 0", got)
+	}
+}
+
+func TestManagerMutatePrioritySetsExactFieldAndRotatesRevision(t *testing.T) {
+	store := &transactionTestStore{}
+	manager := NewManager(store, &FillFirstSelector{}, nil)
+
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:         "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"priority": "10", "note": "keep"},
+		Metadata: map[string]any{
+			"type":         "codex",
+			"priority":     float64(10),
+			"note":         "keep",
+			"access_token": "synthetic-token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	result, err := manager.MutatePriority(context.Background(), registered.ID, registered.Revision(), PriorityMutation{
+		Operation: PriorityMutationSet,
+		Priority:  101,
+	})
+	if err != nil {
+		t.Fatalf("MutatePriority() error = %v", err)
+	}
+	if result == nil || result.Auth == nil {
+		t.Fatal("MutatePriority() returned nil result")
+	}
+	if result.Revision == registered.Revision() {
+		t.Fatalf("revision did not rotate: %q", result.Revision)
+	}
+	if !result.Priority.Present || result.Priority.Value != 101 {
+		t.Fatalf("priority result = %#v, want present value 101", result.Priority)
+	}
+	if got := result.Auth.Attributes["priority"]; got != "101" {
+		t.Fatalf("priority attribute = %q, want 101", got)
+	}
+	if got := result.Auth.Metadata["priority"]; got != float64(101) {
+		t.Fatalf("priority metadata = %#v, want exact numeric value 101", got)
+	}
+	if got := result.Auth.Metadata["access_token"]; got != "synthetic-token" {
+		t.Fatalf("access token changed = %#v", got)
+	}
+	if got := result.Auth.Metadata["note"]; got != "keep" {
+		t.Fatalf("note changed = %#v", got)
+	}
+}
+
+func TestManagerUpdateRejectsStaleRevisionWithoutOverwritingCurrentState(t *testing.T) {
+	store := &transactionTestStore{}
+	manager := NewManager(store, &FillFirstSelector{}, nil)
+
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:       "synthetic-auth.json",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex", "note": "base"},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	stale := registered.Clone()
+
+	newer := registered.Clone()
+	newer.Metadata["note"] = "newer"
+	newer, err = manager.Update(context.Background(), newer)
+	if err != nil {
+		t.Fatalf("first Update() error = %v", err)
+	}
+
+	stale.Metadata["note"] = "stale"
+	if _, err = manager.Update(context.Background(), stale); !errors.Is(err, ErrAuthRevisionConflict) {
+		t.Fatalf("stale Update() error = %v, want ErrAuthRevisionConflict", err)
+	}
+
+	current, ok := manager.GetByID(registered.ID)
+	if !ok {
+		t.Fatal("GetByID() missing auth")
+	}
+	if got := current.Metadata["note"]; got != "newer" {
+		t.Fatalf("current note = %#v, want newer", got)
+	}
+	if got := current.Revision(); got != newer.Revision() {
+		t.Fatalf("current revision = %q, want %q", got, newer.Revision())
+	}
+}
+
+type blockingRefreshExecutor struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (*blockingRefreshExecutor) Identifier() string { return "codex" }
+
+func (*blockingRefreshExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (*blockingRefreshExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+
+func (e *blockingRefreshExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	close(e.started)
+	<-e.release
+	auth.Metadata["access_token"] = "refreshed-token"
+	return auth, nil
+}
+
+func (*blockingRefreshExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (*blockingRefreshExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestRefreshOwnsPriorityMutationLockUntilCommit(t *testing.T) {
+	store := &transactionTestStore{}
+	manager := NewManager(store, &FillFirstSelector{}, nil)
+	executor := &blockingRefreshExecutor{started: make(chan struct{}), release: make(chan struct{})}
+	manager.RegisterExecutor(executor)
+
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:         "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"priority": "10"},
+		Metadata: map[string]any{
+			"type":          "codex",
+			"priority":      float64(10),
+			"access_token":  "old-token",
+			"refresh_token": "synthetic-refresh",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, errRefresh := manager.refreshAuthForRequest(context.Background(), registered.ID, "")
+		refreshDone <- errRefresh
+	}()
+	<-executor.started
+
+	priorityDone := make(chan error, 1)
+	go func() {
+		_, errPriority := manager.MutatePriority(context.Background(), registered.ID, registered.Revision(), PriorityMutation{
+			Operation: PriorityMutationSet,
+			Priority:  101,
+		})
+		priorityDone <- errPriority
+	}()
+
+	select {
+	case errPriority := <-priorityDone:
+		t.Fatalf("priority mutation completed before refresh commit: %v", errPriority)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(executor.release)
+
+	if err = <-refreshDone; err != nil {
+		t.Fatalf("refreshAuthForRequest() error = %v", err)
+	}
+	if err = <-priorityDone; !errors.Is(err, ErrAuthRevisionConflict) {
+		t.Fatalf("MutatePriority() error = %v, want ErrAuthRevisionConflict", err)
+	}
+
+	current, ok := manager.GetByID(registered.ID)
+	if !ok {
+		t.Fatal("GetByID() missing auth")
+	}
+	if got := current.Metadata["access_token"]; got != "refreshed-token" {
+		t.Fatalf("access_token = %#v, want refreshed-token", got)
+	}
+	if got := current.Attributes["priority"]; got != "10" {
+		t.Fatalf("priority = %q, want unchanged 10", got)
+	}
+}
+
+func TestManagerRegisterPersistenceFailureDoesNotPublishAuth(t *testing.T) {
+	store := &transactionTestStore{fail: true}
+	hook := &transactionTestHook{}
+	manager := NewManager(store, &FillFirstSelector{}, hook)
+
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:       "synthetic-auth.json",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex"},
+	})
+	if err == nil {
+		t.Fatal("Register() error = nil, want persistence failure")
+	}
+	if registered != nil {
+		t.Fatalf("Register() auth = %#v, want nil", registered)
+	}
+	if _, ok := manager.GetByID("synthetic-auth.json"); ok {
+		t.Fatal("failed registration published runtime auth")
+	}
+	if got := hook.registerCount(); got != 0 {
+		t.Fatalf("register hook count = %d, want 0", got)
+	}
+}
+
+type incompatiblePriorityScheduler struct{}
+
+func (incompatiblePriorityScheduler) PickAuth(context.Context, pluginapi.SchedulerPickRequest) (pluginapi.SchedulerPickResponse, bool, error) {
+	return pluginapi.SchedulerPickResponse{Handled: true, AuthID: "lower-priority-auth"}, true, nil
+}
+
+func TestManagerMutatePriorityRejectsActiveCustomScheduler(t *testing.T) {
+	store := &transactionTestStore{}
+	manager := NewManager(store, &FillFirstSelector{}, nil)
+	manager.SetPluginScheduler(incompatiblePriorityScheduler{})
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:         "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"priority": "10"},
+		Metadata:   map[string]any{"type": "codex", "priority": float64(10)},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	_, err = manager.MutatePriority(context.Background(), registered.ID, registered.Revision(), PriorityMutation{
+		Operation: PriorityMutationSet,
+		Priority:  101,
+	})
+	if !errors.Is(err, ErrPriorityMutationUnsupported) {
+		t.Fatalf("MutatePriority() error = %v, want ErrPriorityMutationUnsupported", err)
+	}
+	current, _ := manager.GetByID(registered.ID)
+	if got := current.Attributes["priority"]; got != "10" {
+		t.Fatalf("priority = %q, want unchanged 10", got)
+	}
+}
+
+func TestManagerUpdateSkipsIdenticalPersistedWatcherReplay(t *testing.T) {
+	store := &transactionTestStore{}
+	hook := &transactionTestHook{}
+	manager := NewManager(store, &FillFirstSelector{}, hook)
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:         "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"priority": "101"},
+		Metadata: map[string]any{
+			"type":         "codex",
+			"priority":     101,
+			"access_token": "synthetic-token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	replay := registered.Clone()
+	replay.revision = ""
+
+	updated, err := manager.Update(WithSkipPersist(context.Background()), replay)
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if updated.Revision() != registered.Revision() {
+		t.Fatalf("revision = %q, want unchanged %q", updated.Revision(), registered.Revision())
+	}
+	if got := hook.updateCount(); got != 0 {
+		t.Fatalf("update hook count = %d, want 0", got)
+	}
+}
+
+func TestManagerMutatePriorityRejectsCodexWebsocketRouting(t *testing.T) {
+	store := &transactionTestStore{}
+	manager := NewManager(store, &FillFirstSelector{}, nil)
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:         "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"priority": "10", "websockets": "true"},
+		Metadata: map[string]any{
+			"type":       "codex",
+			"priority":   float64(10),
+			"websockets": true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	_, err = manager.MutatePriority(context.Background(), registered.ID, registered.Revision(), PriorityMutation{
+		Operation: PriorityMutationSet,
+		Priority:  101,
+	})
+	if !errors.Is(err, ErrPriorityMutationRoutingIncompatible) {
+		t.Fatalf("MutatePriority() error = %v, want ErrPriorityMutationRoutingIncompatible", err)
+	}
+}
+
+func TestManagerMutatePriorityChangesFutureSelectionWithoutChangingSelectedClone(t *testing.T) {
+	store := &transactionTestStore{}
+	manager := NewManager(store, &FillFirstSelector{}, nil)
+	manager.RegisterExecutor(&blockingRefreshExecutor{started: make(chan struct{}), release: make(chan struct{})})
+	first, err := manager.Register(context.Background(), &Auth{
+		ID:         "auth-a",
+		Provider:   "codex",
+		Attributes: map[string]string{"priority": "10"},
+		Metadata:   map[string]any{"type": "codex", "priority": float64(10)},
+	})
+	if err != nil {
+		t.Fatalf("Register(auth-a) error = %v", err)
+	}
+	second, err := manager.Register(context.Background(), &Auth{
+		ID:         "auth-b",
+		Provider:   "codex",
+		Attributes: map[string]string{"priority": "5"},
+		Metadata:   map[string]any{"type": "codex", "priority": float64(5)},
+	})
+	if err != nil {
+		t.Fatalf("Register(auth-b) error = %v", err)
+	}
+
+	selectedBefore, _, err := manager.pickNext(context.Background(), "codex", "", cliproxyexecutor.Options{}, nil)
+	if err != nil {
+		t.Fatalf("pickNext() before mutation error = %v", err)
+	}
+	if selectedBefore.ID != first.ID {
+		t.Fatalf("selected before = %q, want %q", selectedBefore.ID, first.ID)
+	}
+	result, err := manager.MutatePriority(context.Background(), second.ID, second.Revision(), PriorityMutation{
+		Operation: PriorityMutationSet,
+		Priority:  101,
+	})
+	if err != nil {
+		t.Fatalf("MutatePriority() error = %v", err)
+	}
+	selectedAfter, _, err := manager.pickNext(context.Background(), "codex", "", cliproxyexecutor.Options{}, nil)
+	if err != nil {
+		t.Fatalf("pickNext() after mutation error = %v", err)
+	}
+	if selectedAfter.ID != second.ID {
+		t.Fatalf("selected after = %q, want %q", selectedAfter.ID, second.ID)
+	}
+	if selectedAfter.Revision() != result.Revision {
+		t.Fatalf("scheduler revision = %q, want %q", selectedAfter.Revision(), result.Revision)
+	}
+	if got := selectedBefore.Attributes["priority"]; got != "10" {
+		t.Fatalf("already-selected clone priority changed to %q", got)
+	}
+}
+
+type immediateRefreshExecutor struct{}
+
+func (*immediateRefreshExecutor) Identifier() string { return "codex" }
+func (*immediateRefreshExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (*immediateRefreshExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+func (*immediateRefreshExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	auth.Metadata["access_token"] = "uncommitted-refreshed-token"
+	return auth, nil
+}
+func (*immediateRefreshExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (*immediateRefreshExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestRefreshPersistenceFailureReturnsErrorAndKeepsCommittedCredentials(t *testing.T) {
+	const model = "synthetic-persistence-failure-model"
+	const provider = "synthetic-persistence-failure-provider"
+	store := &transactionTestStore{}
+	manager := NewManager(store, &FillFirstSelector{}, nil)
+	manager.RegisterExecutor(&immediateRefreshExecutor{})
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:       "synthetic-auth.json",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"type":          "codex",
+			"access_token":  "committed-token",
+			"refresh_token": "synthetic-refresh",
+		},
+		ModelStates: map[string]*ModelState{
+			model: {
+				Unavailable: true,
+				LastError:   &Error{HTTPStatus: http.StatusUnauthorized, Code: "unauthorized"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	store.mu.Lock()
+	store.fail = true
+	store.mu.Unlock()
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(registered.ID, provider, []*registry.ModelInfo{{ID: model}})
+	modelRegistry.SuspendClientModel(registered.ID, model, "unauthorized")
+	t.Cleanup(func() { modelRegistry.UnregisterClient(registered.ID) })
+
+	refreshed, err := manager.refreshAuthForRequest(context.Background(), registered.ID, "")
+	if err == nil {
+		t.Fatalf("refreshAuthForRequest() auth=%#v error=nil, want persistence failure", refreshed)
+	}
+	current, _ := manager.GetByID(registered.ID)
+	if got := current.Metadata["access_token"]; got != "committed-token" {
+		t.Fatalf("committed access_token = %#v, want unchanged", got)
+	}
+	if available := modelRegistry.GetAvailableModels(provider); len(available) != 0 {
+		t.Fatalf("available models = %#v, want failed refresh to keep model suspended", available)
+	}
+}
+
+func TestManagerMutatePriorityPersistenceFailureLeavesRuntimeRevisionAndHookUnchanged(t *testing.T) {
+	store := &transactionTestStore{}
+	hook := &transactionTestHook{}
+	manager := NewManager(store, &FillFirstSelector{}, hook)
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:         "synthetic-auth.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"priority": "10"},
+		Metadata:   map[string]any{"type": "codex", "priority": float64(10)},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	store.mu.Lock()
+	store.fail = true
+	store.mu.Unlock()
+
+	_, err = manager.MutatePriority(context.Background(), registered.ID, registered.Revision(), PriorityMutation{
+		Operation: PriorityMutationSet,
+		Priority:  101,
+	})
+	if err == nil {
+		t.Fatal("MutatePriority() error = nil, want persistence failure")
+	}
+	current, _ := manager.GetByID(registered.ID)
+	if current.Revision() != registered.Revision() || current.Attributes["priority"] != "10" {
+		t.Fatalf("failed mutation changed runtime: revision=%q priority=%q", current.Revision(), current.Attributes["priority"])
+	}
+	if got := hook.updateCount(); got != 0 {
+		t.Fatalf("update hook count = %d, want 0", got)
+	}
+}

--- a/sdk/cliproxy/auth/revision.go
+++ b/sdk/cliproxy/auth/revision.go
@@ -1,0 +1,34 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+)
+
+const authRevisionBytes = 16
+
+func newAuthRevision() (string, error) {
+	raw := make([]byte, authRevisionBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("auth revision: generate random token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+// Revision returns the opaque process-local revision for this auth snapshot.
+func (a *Auth) Revision() string {
+	if a == nil {
+		return ""
+	}
+	return a.revision
+}
+
+// CloneWithoutRevision returns a snapshot suitable for durable-state comparison.
+func (a *Auth) CloneWithoutRevision() *Auth {
+	clone := a.Clone()
+	if clone != nil {
+		clone.revision = ""
+	}
+	return clone
+}

--- a/sdk/cliproxy/auth/revision_test.go
+++ b/sdk/cliproxy/auth/revision_test.go
@@ -1,0 +1,88 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type revisionResetStore struct {
+	mu   sync.Mutex
+	auth *Auth
+}
+
+func (s *revisionResetStore) List(context.Context) ([]*Auth, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.auth == nil {
+		return nil, nil
+	}
+	return []*Auth{s.auth.Clone()}, nil
+}
+
+func (s *revisionResetStore) Save(_ context.Context, auth *Auth) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.auth = auth.Clone()
+	s.auth.revision = ""
+	return auth.ID, nil
+}
+
+func (*revisionResetStore) Delete(context.Context, string) error { return nil }
+
+func TestManagerRegisterAssignsOpaqueProcessLocalRevision(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+
+	registered, err := manager.Register(context.Background(), &Auth{
+		ID:       "synthetic-auth.json",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex"},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	if registered == nil {
+		t.Fatal("Register() returned nil auth")
+	}
+	if got := registered.Revision(); len(got) < 22 {
+		t.Fatalf("Revision() = %q, want opaque 128-bit-or-stronger token", got)
+	}
+
+	raw, err := json.Marshal(registered)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if strings.Contains(string(raw), registered.Revision()) {
+		t.Fatalf("serialized auth leaked process-local revision: %s", raw)
+	}
+}
+
+func TestManagerLoadRegeneratesRevisionAfterProcessRestart(t *testing.T) {
+	store := &revisionResetStore{}
+	firstManager := NewManager(store, nil, nil)
+	registered, err := firstManager.Register(context.Background(), &Auth{
+		ID:       "synthetic-auth.json",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex"},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	secondManager := NewManager(store, nil, nil)
+	if err = secondManager.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	loaded, ok := secondManager.GetByID(registered.ID)
+	if !ok {
+		t.Fatal("GetByID() missing loaded auth")
+	}
+	if loaded.Revision() == "" {
+		t.Fatal("loaded revision is empty")
+	}
+	if loaded.Revision() == registered.Revision() {
+		t.Fatalf("loaded revision reused prior-process token %q", loaded.Revision())
+	}
+}

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -92,6 +92,8 @@ type Auth struct {
 
 	// Runtime carries non-serialisable data used during execution (in-memory only).
 	Runtime any `json:"-"`
+	// revision is an opaque process-local compare-and-swap token. It is never persisted.
+	revision string
 
 	Success int64 `json:"-"`
 	Failed  int64 `json:"-"`
@@ -256,34 +258,6 @@ func (a *Auth) RecentRequestsSnapshot(now time.Time) []RecentRequestBucket {
 	}
 
 	return out
-}
-
-// Clone shallow copies the Auth structure, duplicating maps to avoid accidental mutation.
-func (a *Auth) Clone() *Auth {
-	if a == nil {
-		return nil
-	}
-	copyAuth := *a
-	if len(a.Attributes) > 0 {
-		copyAuth.Attributes = make(map[string]string, len(a.Attributes))
-		for key, value := range a.Attributes {
-			copyAuth.Attributes[key] = value
-		}
-	}
-	if len(a.Metadata) > 0 {
-		copyAuth.Metadata = make(map[string]any, len(a.Metadata))
-		for key, value := range a.Metadata {
-			copyAuth.Metadata[key] = value
-		}
-	}
-	if len(a.ModelStates) > 0 {
-		copyAuth.ModelStates = make(map[string]*ModelState, len(a.ModelStates))
-		for key, state := range a.ModelStates {
-			copyAuth.ModelStates[key] = state.Clone()
-		}
-	}
-	copyAuth.Runtime = a.Runtime
-	return &copyAuth
 }
 
 func stableAuthIndex(seed string) string {

--- a/sdk/cliproxy/auth/types_test.go
+++ b/sdk/cliproxy/auth/types_test.go
@@ -40,6 +40,23 @@ func TestToolPrefixDisabled(t *testing.T) {
 	}
 }
 
+func TestAuthCloneDeepCopiesNestedMetadata(t *testing.T) {
+	original := &Auth{Metadata: map[string]any{
+		"headers": map[string]any{"X-Test": "before"},
+		"scopes":  []any{"one", map[string]any{"nested": "before"}},
+	}}
+	clone := original.Clone()
+	clone.Metadata["headers"].(map[string]any)["X-Test"] = "after"
+	clone.Metadata["scopes"].([]any)[1].(map[string]any)["nested"] = "after"
+
+	if got := original.Metadata["headers"].(map[string]any)["X-Test"]; got != "before" {
+		t.Fatalf("original nested map changed = %#v", got)
+	}
+	if got := original.Metadata["scopes"].([]any)[1].(map[string]any)["nested"]; got != "before" {
+		t.Fatalf("original nested slice map changed = %#v", got)
+	}
+}
+
 func TestEnsureIndexUsesCredentialIdentity(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1207,9 +1207,18 @@ func (s *Service) tryRegisterPluginModelsForAuth(ctx context.Context, a *coreaut
 				result.Auth.Attributes[key] = value
 			}
 		}
-		if updated, errUpdate := s.coreManager.Update(context.Background(), result.Auth); errUpdate == nil && updated != nil {
-			activeAuth = updated.Clone()
+		updated, errUpdate := s.coreManager.Update(ctx, result.Auth)
+		if errUpdate != nil {
+			log.WithError(errUpdate).WithField("auth_id", a.ID).Error("failed to persist plugin auth update")
+			GlobalModelRegistry().UnregisterClient(a.ID)
+			return true
 		}
+		if updated == nil {
+			log.WithField("auth_id", a.ID).Warn("plugin auth update did not resolve to an active auth")
+			GlobalModelRegistry().UnregisterClient(a.ID)
+			return true
+		}
+		activeAuth = updated.Clone()
 	}
 	if activeAuth == nil {
 		activeAuth = a


### PR DESCRIPTION
## Summary

- add authenticated conditional priority set/unset endpoint with process-local revision CAS
- persist before runtime publication and serialize refresh, watcher, and management mutations per auth
- expose exact priority presence and revision through auth-file management responses
- fail closed for unsupported storage, plugin schedulers, and incompatible Codex WebSocket routing
- reconcile watcher errors and preserve unrelated JSON numeric metadata exactly

## Verification

- go test ./... — 3,457 passed across 111 packages
- go test -race ./sdk/cliproxy/auth ./sdk/auth ./internal/api/handlers/management — 551 passed
- go build ./cmd/server — passed on Go 1.26.5 darwin/arm64
- GOOS=windows GOARCH=amd64 go test -c ./sdk/auth — passed
- two watcher race-test failures reproduce unchanged on upstream main

Validation used synthetic local fixtures only; no real credentials or provider requests.