### PR TITLE
feat(sdk): add headless embedded runtime

### DIFF
--- a/sdk/cliproxy/auth/auto_refresh_lease_test.go
+++ b/sdk/cliproxy/auth/auto_refresh_lease_test.go
@@ -1,0 +1,171 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type leaseTestSelector struct {
+	stopped atomic.Bool
+}
+
+type leaseRefreshEvaluator struct{}
+
+func (leaseRefreshEvaluator) ShouldRefresh(time.Time, *Auth) bool { return true }
+
+func (s *leaseTestSelector) Pick(context.Context, string, string, cliproxyexecutor.Options, []*Auth) (*Auth, error) {
+	return nil, nil
+}
+
+func (s *leaseTestSelector) Stop() {
+	s.stopped.Store(true)
+}
+
+type blockingRefreshExecutor struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (e *blockingRefreshExecutor) Identifier() string { return "codex" }
+
+func (e *blockingRefreshExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *blockingRefreshExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+
+func (e *blockingRefreshExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	select {
+	case <-e.started:
+	default:
+		close(e.started)
+	}
+	<-e.release
+	return auth, nil
+}
+
+func (e *blockingRefreshExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *blockingRefreshExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestAutoRefreshLeaseWaitsWithoutStoppingSelector(t *testing.T) {
+	selector := &leaseTestSelector{}
+	manager := NewManager(nil, selector, nil)
+	executor := &blockingRefreshExecutor{started: make(chan struct{}), release: make(chan struct{})}
+	manager.RegisterExecutor(executor)
+	_, errRegister := manager.Register(t.Context(), &Auth{
+		ID:       "codex-refresh-lease",
+		Provider: "codex",
+		Attributes: map[string]string{
+			AttributeAuthKind: AuthKindOAuth,
+		},
+		Metadata: map[string]any{
+			"access_token":  "expired-access",
+			"refresh_token": "refresh-token",
+			"expires_at":    time.Now().Add(-time.Minute).Format(time.RFC3339),
+		},
+		Runtime: leaseRefreshEvaluator{},
+	})
+	if errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	lease := manager.EnsureAutoRefresh(t.Context(), time.Millisecond)
+	if lease == nil || !lease.owned {
+		t.Fatal("expected an owned auto-refresh lease")
+	}
+	select {
+	case <-executor.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("refresh worker did not start")
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- lease.Close(context.Background()) }()
+	select {
+	case errClose := <-closed:
+		t.Fatalf("lease closed before refresh worker exited: %v", errClose)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(executor.release)
+	select {
+	case errClose := <-closed:
+		if errClose != nil {
+			t.Fatalf("close lease: %v", errClose)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("lease did not wait for refresh worker shutdown")
+	}
+	if selector.stopped.Load() {
+		t.Fatal("closing refresh lease stopped host selector")
+	}
+	manager.mu.RLock()
+	defer manager.mu.RUnlock()
+	if manager.refreshLoop != nil || manager.refreshCancel != nil || manager.refreshDone != nil {
+		t.Fatal("owned refresh loop remains installed after lease close")
+	}
+}
+
+func TestAutoRefreshLeasePreservesExistingHostLoop(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.StartAutoRefresh(t.Context(), time.Hour)
+	manager.mu.RLock()
+	hostLoop := manager.refreshLoop
+	manager.mu.RUnlock()
+	if hostLoop == nil {
+		t.Fatal("host refresh loop was not installed")
+	}
+
+	lease := manager.EnsureAutoRefresh(t.Context(), time.Minute)
+	if lease == nil || lease.owned {
+		t.Fatal("expected a non-owning lease for the existing host loop")
+	}
+	if errClose := lease.Close(t.Context()); errClose != nil {
+		t.Fatalf("close non-owning lease: %v", errClose)
+	}
+	manager.mu.RLock()
+	current := manager.refreshLoop
+	manager.mu.RUnlock()
+	if current != hostLoop {
+		t.Fatal("closing non-owning lease replaced or removed host loop")
+	}
+	manager.StopAutoRefresh()
+}
+
+func TestAutoRefreshLeaseReplacesExitedHostLoop(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	hostCtx, cancelHost := context.WithCancel(t.Context())
+	manager.StartAutoRefresh(hostCtx, time.Hour)
+	manager.mu.RLock()
+	hostLoop := manager.refreshLoop
+	hostDone := manager.refreshDone
+	manager.mu.RUnlock()
+	cancelHost()
+	select {
+	case <-hostDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("host refresh loop did not exit")
+	}
+
+	lease := manager.EnsureAutoRefresh(t.Context(), time.Hour)
+	if lease == nil || !lease.owned {
+		t.Fatal("expected an owned lease after host loop exit")
+	}
+	if lease.loop == hostLoop {
+		t.Fatal("exited host loop was reused")
+	}
+	if errClose := lease.Close(t.Context()); errClose != nil {
+		t.Fatalf("close replacement lease: %v", errClose)
+	}
+}

--- a/sdk/cliproxy/auth/auto_refresh_loop.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop.go
@@ -68,11 +68,17 @@ func (l *authAutoRefreshLoop) run(ctx context.Context) {
 	if workers <= 0 {
 		workers = refreshMaxConcurrency
 	}
+	var workerWG sync.WaitGroup
+	workerWG.Add(workers)
 	for i := 0; i < workers; i++ {
-		go l.worker(ctx)
+		go func() {
+			defer workerWG.Done()
+			l.worker(ctx)
+		}()
 	}
 
 	l.loop(ctx)
+	workerWG.Wait()
 }
 
 func (l *authAutoRefreshLoop) worker(ctx context.Context) {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -259,6 +259,7 @@ type Manager struct {
 	// Auto refresh state
 	refreshCancel context.CancelFunc
 	refreshLoop   *authAutoRefreshLoop
+	refreshDone   <-chan struct{}
 
 	requestPrepareLocks sync.Map
 	// refreshLocks serializes credential refresh per auth ID so concurrent
@@ -5695,6 +5696,7 @@ func (m *Manager) StartAutoRefresh(parent context.Context, interval time.Duratio
 	cancelPrev := m.refreshCancel
 	m.refreshCancel = nil
 	m.refreshLoop = nil
+	m.refreshDone = nil
 	m.mu.Unlock()
 	if cancelPrev != nil {
 		cancelPrev()
@@ -5706,14 +5708,123 @@ func (m *Manager) StartAutoRefresh(parent context.Context, interval time.Duratio
 		workers = cfg.AuthAutoRefreshWorkers
 	}
 	loop := newAuthAutoRefreshLoop(m, interval, workers)
+	done := make(chan struct{})
 
 	m.mu.Lock()
 	m.refreshCancel = cancelCtx
 	m.refreshLoop = loop
+	m.refreshDone = done
 	m.mu.Unlock()
 
 	loop.rebuild(time.Now())
-	go loop.run(ctx)
+	go m.runAutoRefreshLoop(ctx, loop, done)
+}
+
+func (m *Manager) runAutoRefreshLoop(ctx context.Context, loop *authAutoRefreshLoop, done chan struct{}) {
+	loop.run(ctx)
+	close(done)
+	m.mu.Lock()
+	if m.refreshLoop == loop {
+		m.refreshCancel = nil
+		m.refreshLoop = nil
+		m.refreshDone = nil
+	}
+	m.mu.Unlock()
+}
+
+// AutoRefreshLease represents an auto-refresh loop acquired for an embedding
+// runtime. A lease only stops the exact loop it created; an existing host-owned
+// loop is reused and remains untouched when the lease closes.
+type AutoRefreshLease struct {
+	manager *Manager
+	loop    *authAutoRefreshLoop
+	cancel  context.CancelFunc
+	done    <-chan struct{}
+	owned   bool
+	once    sync.Once
+}
+
+// EnsureAutoRefresh reuses an existing manager loop or starts one owned by the
+// returned lease. Closing a non-owning lease is a no-op.
+func (m *Manager) EnsureAutoRefresh(parent context.Context, interval time.Duration) *AutoRefreshLease {
+	if m == nil {
+		return &AutoRefreshLease{}
+	}
+	if parent == nil {
+		parent = context.Background()
+	}
+	if interval <= 0 {
+		interval = refreshCheckInterval
+	}
+
+	m.mu.Lock()
+	if m.refreshLoop != nil {
+		loopDone := m.refreshDone
+		loopRunning := true
+		if loopDone != nil {
+			select {
+			case <-loopDone:
+				loopRunning = false
+			default:
+			}
+		}
+		if loopRunning {
+			lease := &AutoRefreshLease{manager: m, loop: m.refreshLoop, done: loopDone}
+			m.mu.Unlock()
+			return lease
+		}
+		m.refreshCancel = nil
+		m.refreshLoop = nil
+		m.refreshDone = nil
+	}
+	ctx, cancelCtx := context.WithCancel(parent)
+	workers := refreshMaxConcurrency
+	if cfg, ok := m.runtimeConfig.Load().(*internalconfig.Config); ok && cfg != nil && cfg.AuthAutoRefreshWorkers > 0 {
+		workers = cfg.AuthAutoRefreshWorkers
+	}
+	loop := newAuthAutoRefreshLoop(m, interval, workers)
+	done := make(chan struct{})
+	m.refreshCancel = cancelCtx
+	m.refreshLoop = loop
+	m.refreshDone = done
+	m.mu.Unlock()
+
+	loop.rebuild(time.Now())
+	go m.runAutoRefreshLoop(ctx, loop, done)
+	return &AutoRefreshLease{manager: m, loop: loop, cancel: cancelCtx, done: done, owned: true}
+}
+
+// Close cancels an owned loop and waits for its scheduler and workers to exit.
+func (l *AutoRefreshLease) Close(ctx context.Context) error {
+	if l == nil || !l.owned {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	l.once.Do(func() {
+		if l.manager != nil {
+			l.manager.mu.Lock()
+			if l.manager.refreshLoop == l.loop {
+				l.manager.refreshCancel = nil
+				l.manager.refreshLoop = nil
+				l.manager.refreshDone = nil
+			}
+			l.manager.mu.Unlock()
+		}
+		if l.cancel != nil {
+			l.cancel()
+		}
+	})
+	if l.done == nil {
+		return nil
+	}
+	select {
+	case <-l.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // StopAutoRefresh cancels the background refresh loop, if running.
@@ -5723,6 +5834,7 @@ func (m *Manager) StopAutoRefresh() {
 	cancel := m.refreshCancel
 	m.refreshCancel = nil
 	m.refreshLoop = nil
+	m.refreshDone = nil
 	m.mu.Unlock()
 	if cancel != nil {
 		cancel()

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -10,6 +10,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -500,6 +501,21 @@ func (m *Manager) SetRoundTripperProvider(p RoundTripperProvider) {
 	m.mu.Lock()
 	m.rtProvider = p
 	m.mu.Unlock()
+}
+
+// SetRoundTripperProviderIfAbsent installs p only when the host has not
+// already configured a RoundTripper provider. It reports whether p was stored.
+func (m *Manager) SetRoundTripperProviderIfAbsent(p RoundTripperProvider) bool {
+	if m == nil || p == nil {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.rtProvider != nil {
+		return false
+	}
+	m.rtProvider = p
+	return true
 }
 
 // SetConfig updates the runtime config snapshot used by request-time helpers.
@@ -2144,6 +2160,57 @@ func (m *Manager) RegisterExecutor(executor ProviderExecutor) {
 	}
 }
 
+// RegisterExecutorIfAbsent registers executor only when its provider key has
+// no current executor. It reports whether the executor was installed.
+func (m *Manager) RegisterExecutorIfAbsent(executor ProviderExecutor) bool {
+	if m == nil || executor == nil {
+		return false
+	}
+	provider := strings.ToLower(strings.TrimSpace(executor.Identifier()))
+	if provider == "" {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if current := m.executors[provider]; current != nil {
+		return false
+	}
+	m.executors[provider] = executor
+	return true
+}
+
+// UnregisterExecutorIfMatch removes provider only when expected is still the
+// registered executor. This lets embedding hosts avoid deleting replacements
+// installed concurrently by another owner.
+func (m *Manager) UnregisterExecutorIfMatch(provider string, expected ProviderExecutor) bool {
+	if m == nil || expected == nil {
+		return false
+	}
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	current := m.executors[provider]
+	if !sameProviderExecutor(current, expected) {
+		return false
+	}
+	delete(m.executors, provider)
+	return true
+}
+
+func sameProviderExecutor(first, second ProviderExecutor) bool {
+	if first == nil || second == nil {
+		return first == nil && second == nil
+	}
+	firstType := reflect.TypeOf(first)
+	if firstType != reflect.TypeOf(second) || !firstType.Comparable() {
+		return false
+	}
+	return first == second
+}
+
 // UnregisterExecutor removes the executor associated with the provider key.
 func (m *Manager) UnregisterExecutor(provider string) {
 	provider = strings.ToLower(strings.TrimSpace(provider))
@@ -2233,6 +2300,41 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 		m.persistCooldownStates(ctx)
 	}
 	return auth.Clone(), nil
+}
+
+// SyncRuntimeAuth adds or replaces auth in runtime memory without persistence
+// or host hooks. It is intended for embedded runtimes whose host owns durable
+// storage and mutation notifications.
+func (m *Manager) SyncRuntimeAuth(auth *Auth) *Auth {
+	if m == nil || auth == nil || strings.TrimSpace(auth.ID) == "" {
+		return nil
+	}
+	auth = auth.Clone()
+	m.mu.Lock()
+	if existing := m.auths[auth.ID]; existing != nil {
+		auth.CreatedAt = existing.CreatedAt
+		auth.Success = existing.Success
+		auth.Failed = existing.Failed
+		auth.recentRequests = existing.recentRequests
+		if !existing.Disabled && existing.Status != StatusDisabled && !auth.Disabled && auth.Status != StatusDisabled {
+			auth.LastRefreshedAt = existing.LastRefreshedAt
+			auth.NextRefreshAfter = existing.NextRefreshAfter
+			if len(auth.ModelStates) == 0 && len(existing.ModelStates) > 0 {
+				auth.ModelStates = existing.ModelStates
+			}
+		}
+	}
+	auth.EnsureIndex()
+	stored := auth.Clone()
+	m.auths[auth.ID] = stored
+	m.mu.Unlock()
+
+	m.rebuildAPIKeyModelAliasFromRuntimeConfig()
+	if m.scheduler != nil {
+		m.scheduler.upsertAuth(stored)
+	}
+	m.queueRefreshReschedule(auth.ID)
+	return stored.Clone()
 }
 
 // Remove deletes an auth from runtime state without persisting.

--- a/sdk/cliproxy/auth/conductor_executor_replace_test.go
+++ b/sdk/cliproxy/auth/conductor_executor_replace_test.go
@@ -102,3 +102,32 @@ func TestManagerExecutorReturnsRegisteredExecutor(t *testing.T) {
 		t.Fatal("expected unknown provider lookup to fail")
 	}
 }
+
+func TestManagerRegisterAndUnregisterExecutorOwnershipIsAtomic(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager(nil, nil, nil)
+	owned := &replaceAwareExecutor{id: "codex"}
+	host := &replaceAwareExecutor{id: "codex"}
+
+	if !manager.RegisterExecutorIfAbsent(owned) {
+		t.Fatal("expected first executor registration to succeed")
+	}
+	if manager.RegisterExecutorIfAbsent(host) {
+		t.Fatal("expected second executor registration to preserve current owner")
+	}
+	manager.RegisterExecutor(host)
+	if manager.UnregisterExecutorIfMatch("codex", owned) {
+		t.Fatal("stale owner removed host replacement")
+	}
+	resolved, okResolved := manager.Executor("codex")
+	if !okResolved || resolved != host {
+		t.Fatalf("executor after stale unregister = %T, want host executor", resolved)
+	}
+	if !manager.UnregisterExecutorIfMatch("codex", host) {
+		t.Fatal("current owner could not unregister its executor")
+	}
+	if _, okResolved := manager.Executor("codex"); okResolved {
+		t.Fatal("executor remains registered after matching unregister")
+	}
+}

--- a/sdk/cliproxy/embedded_runtime.go
+++ b/sdk/cliproxy/embedded_runtime.go
@@ -1,0 +1,291 @@
+package cliproxy
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+// EmbeddedRuntime provides native provider execution and model registration
+// without starting the CLIProxyAPI HTTP server or file watcher.
+type EmbeddedRuntime struct {
+	manager *coreauth.Manager
+	service *Service
+
+	mu                 sync.Mutex
+	started            bool
+	closed             bool
+	modelsReconciled   bool
+	activeModels       map[string]struct{}
+	registeredAuthIDs  map[string]struct{}
+	installedExecutors map[string]coreauth.ProviderExecutor
+}
+
+// NewEmbeddedRuntime creates a headless runtime backed by a host-owned auth manager.
+func NewEmbeddedRuntime(cfg *config.Config, manager *coreauth.Manager) (*EmbeddedRuntime, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("cliproxy: embedded runtime configuration is required")
+	}
+	if manager == nil {
+		return nil, fmt.Errorf("cliproxy: embedded runtime auth manager is required")
+	}
+
+	manager.SetRoundTripperProvider(newDefaultRoundTripperProvider())
+	manager.SetConfig(cfg)
+	manager.SetOAuthModelAlias(cfg.OAuthModelAlias)
+
+	return &EmbeddedRuntime{
+		manager:            manager,
+		service:            &Service{cfg: cfg, coreManager: manager},
+		registeredAuthIDs:  make(map[string]struct{}),
+		installedExecutors: make(map[string]coreauth.ProviderExecutor),
+	}, nil
+}
+
+// Start registers native executors and model projections for existing auths.
+func (r *EmbeddedRuntime) Start(ctx context.Context) error {
+	if r == nil {
+		return fmt.Errorf("cliproxy: embedded runtime is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if errContext := ctx.Err(); errContext != nil {
+		return errContext
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return fmt.Errorf("cliproxy: embedded runtime is closed")
+	}
+	if r.started {
+		return nil
+	}
+
+	auths := r.manager.List()
+	r.service.registerAvailableExecutors(ctx, executorRegistrationOptions{
+		auths:             auths,
+		forceReplaceAuths: true,
+	})
+	for _, auth := range auths {
+		if errContext := ctx.Err(); errContext != nil {
+			return errContext
+		}
+		r.trackExecutorForAuthLocked(auth)
+		r.registerAuthModelsLocked(ctx, auth)
+	}
+	r.started = true
+	return nil
+}
+
+// SyncAuth adds or updates one auth in the native runtime without persisting it.
+func (r *EmbeddedRuntime) SyncAuth(ctx context.Context, auth *coreauth.Auth) error {
+	if r == nil {
+		return fmt.Errorf("cliproxy: embedded runtime is nil")
+	}
+	if auth == nil || strings.TrimSpace(auth.ID) == "" {
+		return fmt.Errorf("cliproxy: embedded runtime auth ID is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if errContext := ctx.Err(); errContext != nil {
+		return errContext
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if errState := r.requireStartedLocked(); errState != nil {
+		return errState
+	}
+
+	runtimeCtx := coreauth.WithSkipPersist(ctx)
+	prepared := r.service.prepareCoreAuthForModelRegistration(runtimeCtx, auth)
+	if prepared == nil {
+		return fmt.Errorf("cliproxy: failed to synchronize auth %q", auth.ID)
+	}
+	r.trackExecutorForAuthLocked(prepared)
+	r.registerAuthModelsLocked(runtimeCtx, prepared)
+	return nil
+}
+
+// RemoveAuth removes one auth and its model projection from the native runtime.
+func (r *EmbeddedRuntime) RemoveAuth(ctx context.Context, authID string) error {
+	if r == nil {
+		return fmt.Errorf("cliproxy: embedded runtime is nil")
+	}
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return fmt.Errorf("cliproxy: embedded runtime auth ID is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if errContext := ctx.Err(); errContext != nil {
+		return errContext
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if errState := r.requireStartedLocked(); errState != nil {
+		return errState
+	}
+
+	r.service.applyCoreAuthRemoval(coreauth.WithSkipPersist(ctx), authID)
+	delete(r.registeredAuthIDs, authID)
+	return nil
+}
+
+// ReconcileModels limits each auth's native model projection to active model IDs.
+func (r *EmbeddedRuntime) ReconcileModels(ctx context.Context, activeModels []string) error {
+	if r == nil {
+		return fmt.Errorf("cliproxy: embedded runtime is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if errContext := ctx.Err(); errContext != nil {
+		return errContext
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if errState := r.requireStartedLocked(); errState != nil {
+		return errState
+	}
+
+	r.activeModels = make(map[string]struct{}, len(activeModels))
+	for _, modelID := range activeModels {
+		modelID = strings.TrimSpace(modelID)
+		if modelID != "" {
+			r.activeModels[modelID] = struct{}{}
+		}
+	}
+	r.modelsReconciled = true
+
+	for _, auth := range r.manager.List() {
+		if errContext := ctx.Err(); errContext != nil {
+			return errContext
+		}
+		r.registerAuthModelsLocked(ctx, auth)
+	}
+	return nil
+}
+
+// Close removes model projections owned by the runtime. Host-owned auths remain registered.
+func (r *EmbeddedRuntime) Close(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return nil
+	}
+	for authID := range r.registeredAuthIDs {
+		registry.GetGlobalRegistry().UnregisterClient(authID)
+		r.manager.RefreshSchedulerEntry(authID)
+	}
+	for provider, installed := range r.installedExecutors {
+		current, okExecutor := r.manager.Executor(provider)
+		if !okExecutor || !sameProviderExecutor(current, installed) {
+			continue
+		}
+		if closer, okCloser := current.(coreauth.ExecutionSessionCloser); okCloser {
+			closer.CloseExecutionSession(coreauth.CloseAllExecutionSessionsID)
+		}
+		r.manager.UnregisterExecutor(provider)
+	}
+	r.registeredAuthIDs = make(map[string]struct{})
+	r.installedExecutors = make(map[string]coreauth.ProviderExecutor)
+	r.closed = true
+	return nil
+}
+
+// ServerStarted reports whether an HTTP server was constructed by this runtime.
+func (r *EmbeddedRuntime) ServerStarted() bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.service != nil && r.service.server != nil
+}
+
+// WatcherStarted reports whether a file watcher was constructed by this runtime.
+func (r *EmbeddedRuntime) WatcherStarted() bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.service != nil && r.service.watcher != nil
+}
+
+func (r *EmbeddedRuntime) requireStartedLocked() error {
+	if r.closed {
+		return fmt.Errorf("cliproxy: embedded runtime is closed")
+	}
+	if !r.started {
+		return fmt.Errorf("cliproxy: embedded runtime is not started")
+	}
+	return nil
+}
+
+func (r *EmbeddedRuntime) registerAuthModelsLocked(ctx context.Context, auth *coreauth.Auth) {
+	if auth == nil || strings.TrimSpace(auth.ID) == "" {
+		return
+	}
+	var activeModels map[string]struct{}
+	if r.modelsReconciled {
+		activeModels = r.activeModels
+	}
+	r.service.reconcileModelsForAuth(ctx, auth, activeModels)
+	r.registeredAuthIDs[auth.ID] = struct{}{}
+}
+
+func (r *EmbeddedRuntime) trackExecutorForAuthLocked(auth *coreauth.Auth) {
+	provider := embeddedRuntimeExecutorProvider(auth)
+	if provider == "" {
+		return
+	}
+	executor, okExecutor := r.manager.Executor(provider)
+	if okExecutor && executor != nil {
+		r.installedExecutors[provider] = executor
+	}
+}
+
+func embeddedRuntimeExecutorProvider(auth *coreauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	if providerKey, _, isCompat := openAICompatInfoFromAuth(auth); isCompat {
+		if providerKey != "" {
+			return providerKey
+		}
+		return "openai-compatibility"
+	}
+	return strings.ToLower(strings.TrimSpace(auth.Provider))
+}
+
+func sameProviderExecutor(first, second coreauth.ProviderExecutor) bool {
+	if first == nil || second == nil {
+		return first == nil && second == nil
+	}
+	firstType := reflect.TypeOf(first)
+	if firstType != reflect.TypeOf(second) || !firstType.Comparable() {
+		return false
+	}
+	return first == second
+}

--- a/sdk/cliproxy/embedded_runtime.go
+++ b/sdk/cliproxy/embedded_runtime.go
@@ -3,7 +3,6 @@ package cliproxy
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strings"
 	"sync"
 
@@ -18,6 +17,7 @@ type EmbeddedRuntime struct {
 	manager *coreauth.Manager
 	service *Service
 
+	opMu               sync.Mutex
 	mu                 sync.Mutex
 	started            bool
 	closed             bool
@@ -28,6 +28,9 @@ type EmbeddedRuntime struct {
 }
 
 // NewEmbeddedRuntime creates a headless runtime backed by a host-owned auth manager.
+// The supplied configuration becomes the manager's runtime configuration and OAuth
+// alias source. A default RoundTripper provider is installed only when the host has
+// not already configured one.
 func NewEmbeddedRuntime(cfg *config.Config, manager *coreauth.Manager) (*EmbeddedRuntime, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("cliproxy: embedded runtime configuration is required")
@@ -36,7 +39,7 @@ func NewEmbeddedRuntime(cfg *config.Config, manager *coreauth.Manager) (*Embedde
 		return nil, fmt.Errorf("cliproxy: embedded runtime auth manager is required")
 	}
 
-	manager.SetRoundTripperProvider(newDefaultRoundTripperProvider())
+	manager.SetRoundTripperProviderIfAbsent(newDefaultRoundTripperProvider())
 	manager.SetConfig(cfg)
 	manager.SetOAuthModelAlias(cfg.OAuthModelAlias)
 
@@ -60,28 +63,42 @@ func (r *EmbeddedRuntime) Start(ctx context.Context) error {
 		return errContext
 	}
 
+	r.opMu.Lock()
+	defer r.opMu.Unlock()
+	if errContext := ctx.Err(); errContext != nil {
+		return errContext
+	}
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	if r.closed {
+		r.mu.Unlock()
 		return fmt.Errorf("cliproxy: embedded runtime is closed")
 	}
 	if r.started {
+		r.mu.Unlock()
 		return nil
 	}
+	r.mu.Unlock()
 
+	runtimeCtx := coreauth.WithSkipPersist(ctx)
 	auths := r.manager.List()
-	r.service.registerAvailableExecutors(ctx, executorRegistrationOptions{
-		auths:             auths,
-		forceReplaceAuths: true,
-	})
 	for _, auth := range auths {
+		installed, owned := r.service.registerExecutorForAuth(auth, false)
+		if owned {
+			r.installedExecutors[embeddedRuntimeExecutorProvider(auth)] = installed
+		}
 		if errContext := ctx.Err(); errContext != nil {
+			r.rollbackStartLocked()
 			return errContext
 		}
-		r.trackExecutorForAuthLocked(auth)
-		r.registerAuthModelsLocked(ctx, auth)
+		r.registerAuthModelsLocked(runtimeCtx, auth)
+		if errContext := ctx.Err(); errContext != nil {
+			r.rollbackStartLocked()
+			return errContext
+		}
 	}
+	r.mu.Lock()
 	r.started = true
+	r.mu.Unlock()
 	return nil
 }
 
@@ -100,19 +117,28 @@ func (r *EmbeddedRuntime) SyncAuth(ctx context.Context, auth *coreauth.Auth) err
 		return errContext
 	}
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if errState := r.requireStartedLocked(); errState != nil {
+	r.opMu.Lock()
+	defer r.opMu.Unlock()
+	if errContext := ctx.Err(); errContext != nil {
+		return errContext
+	}
+	if errState := r.requireStarted(); errState != nil {
 		return errState
 	}
 
+	installed, owned := r.service.registerExecutorForAuth(auth, false)
+	if owned {
+		r.installedExecutors[embeddedRuntimeExecutorProvider(auth)] = installed
+	}
 	runtimeCtx := coreauth.WithSkipPersist(ctx)
-	prepared := r.service.prepareCoreAuthForModelRegistration(runtimeCtx, auth)
+	prepared := r.manager.SyncRuntimeAuth(auth)
 	if prepared == nil {
 		return fmt.Errorf("cliproxy: failed to synchronize auth %q", auth.ID)
 	}
-	r.trackExecutorForAuthLocked(prepared)
 	r.registerAuthModelsLocked(runtimeCtx, prepared)
+	if errContext := ctx.Err(); errContext != nil {
+		return errContext
+	}
 	return nil
 }
 
@@ -132,9 +158,12 @@ func (r *EmbeddedRuntime) RemoveAuth(ctx context.Context, authID string) error {
 		return errContext
 	}
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if errState := r.requireStartedLocked(); errState != nil {
+	r.opMu.Lock()
+	defer r.opMu.Unlock()
+	if errContext := ctx.Err(); errContext != nil {
+		return errContext
+	}
+	if errState := r.requireStarted(); errState != nil {
 		return errState
 	}
 
@@ -155,26 +184,33 @@ func (r *EmbeddedRuntime) ReconcileModels(ctx context.Context, activeModels []st
 		return errContext
 	}
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if errState := r.requireStartedLocked(); errState != nil {
+	r.opMu.Lock()
+	defer r.opMu.Unlock()
+	if errContext := ctx.Err(); errContext != nil {
+		return errContext
+	}
+	if errState := r.requireStarted(); errState != nil {
 		return errState
 	}
 
 	r.activeModels = make(map[string]struct{}, len(activeModels))
 	for _, modelID := range activeModels {
-		modelID = strings.TrimSpace(modelID)
+		modelID = strings.ToLower(strings.TrimSpace(modelID))
 		if modelID != "" {
 			r.activeModels[modelID] = struct{}{}
 		}
 	}
 	r.modelsReconciled = true
 
+	runtimeCtx := coreauth.WithSkipPersist(ctx)
 	for _, auth := range r.manager.List() {
 		if errContext := ctx.Err(); errContext != nil {
 			return errContext
 		}
-		r.registerAuthModelsLocked(ctx, auth)
+		r.registerAuthModelsLocked(runtimeCtx, auth)
+		if errContext := ctx.Err(); errContext != nil {
+			return errContext
+		}
 	}
 	return nil
 }
@@ -188,28 +224,30 @@ func (r *EmbeddedRuntime) Close(ctx context.Context) error {
 		ctx = context.Background()
 	}
 
+	r.opMu.Lock()
+	defer r.opMu.Unlock()
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	if r.closed {
+		r.mu.Unlock()
 		return nil
 	}
+	r.mu.Unlock()
 	for authID := range r.registeredAuthIDs {
 		registry.GetGlobalRegistry().UnregisterClient(authID)
 		r.manager.RefreshSchedulerEntry(authID)
 	}
 	for provider, installed := range r.installedExecutors {
-		current, okExecutor := r.manager.Executor(provider)
-		if !okExecutor || !sameProviderExecutor(current, installed) {
-			continue
-		}
-		if closer, okCloser := current.(coreauth.ExecutionSessionCloser); okCloser {
+		if closer, okCloser := installed.(coreauth.ExecutionSessionCloser); okCloser {
 			closer.CloseExecutionSession(coreauth.CloseAllExecutionSessionsID)
 		}
-		r.manager.UnregisterExecutor(provider)
+		r.manager.UnregisterExecutorIfMatch(provider, installed)
 	}
 	r.registeredAuthIDs = make(map[string]struct{})
 	r.installedExecutors = make(map[string]coreauth.ProviderExecutor)
+	r.mu.Lock()
 	r.closed = true
+	r.started = false
+	r.mu.Unlock()
 	return nil
 }
 
@@ -233,7 +271,9 @@ func (r *EmbeddedRuntime) WatcherStarted() bool {
 	return r.service != nil && r.service.watcher != nil
 }
 
-func (r *EmbeddedRuntime) requireStartedLocked() error {
+func (r *EmbeddedRuntime) requireStarted() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if r.closed {
 		return fmt.Errorf("cliproxy: embedded runtime is closed")
 	}
@@ -247,6 +287,16 @@ func (r *EmbeddedRuntime) registerAuthModelsLocked(ctx context.Context, auth *co
 	if auth == nil || strings.TrimSpace(auth.ID) == "" {
 		return
 	}
+	provider := embeddedRuntimeExecutorProvider(auth)
+	if provider == "" {
+		return
+	}
+	if _, okExecutor := r.manager.Executor(provider); !okExecutor {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+		r.manager.RefreshSchedulerEntry(auth.ID)
+		delete(r.registeredAuthIDs, auth.ID)
+		return
+	}
 	var activeModels map[string]struct{}
 	if r.modelsReconciled {
 		activeModels = r.activeModels
@@ -255,15 +305,19 @@ func (r *EmbeddedRuntime) registerAuthModelsLocked(ctx context.Context, auth *co
 	r.registeredAuthIDs[auth.ID] = struct{}{}
 }
 
-func (r *EmbeddedRuntime) trackExecutorForAuthLocked(auth *coreauth.Auth) {
-	provider := embeddedRuntimeExecutorProvider(auth)
-	if provider == "" {
-		return
+func (r *EmbeddedRuntime) rollbackStartLocked() {
+	for authID := range r.registeredAuthIDs {
+		registry.GetGlobalRegistry().UnregisterClient(authID)
+		r.manager.RefreshSchedulerEntry(authID)
 	}
-	executor, okExecutor := r.manager.Executor(provider)
-	if okExecutor && executor != nil {
-		r.installedExecutors[provider] = executor
+	for provider, installed := range r.installedExecutors {
+		if closer, okCloser := installed.(coreauth.ExecutionSessionCloser); okCloser {
+			closer.CloseExecutionSession(coreauth.CloseAllExecutionSessionsID)
+		}
+		r.manager.UnregisterExecutorIfMatch(provider, installed)
 	}
+	r.registeredAuthIDs = make(map[string]struct{})
+	r.installedExecutors = make(map[string]coreauth.ProviderExecutor)
 }
 
 func embeddedRuntimeExecutorProvider(auth *coreauth.Auth) string {
@@ -277,15 +331,4 @@ func embeddedRuntimeExecutorProvider(auth *coreauth.Auth) string {
 		return "openai-compatibility"
 	}
 	return strings.ToLower(strings.TrimSpace(auth.Provider))
-}
-
-func sameProviderExecutor(first, second coreauth.ProviderExecutor) bool {
-	if first == nil || second == nil {
-		return first == nil && second == nil
-	}
-	firstType := reflect.TypeOf(first)
-	if firstType != reflect.TypeOf(second) || !firstType.Comparable() {
-		return false
-	}
-	return first == second
 }

--- a/sdk/cliproxy/embedded_runtime.go
+++ b/sdk/cliproxy/embedded_runtime.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -25,7 +26,10 @@ type EmbeddedRuntime struct {
 	activeModels       map[string]struct{}
 	registeredAuthIDs  map[string]struct{}
 	installedExecutors map[string]coreauth.ProviderExecutor
+	refreshLease       *coreauth.AutoRefreshLease
 }
+
+const embeddedRuntimeRefreshInterval = 15 * time.Minute
 
 // NewEmbeddedRuntime creates a headless runtime backed by a host-owned auth manager.
 // The supplied configuration becomes the manager's runtime configuration and OAuth
@@ -95,6 +99,11 @@ func (r *EmbeddedRuntime) Start(ctx context.Context) error {
 			r.rollbackStartLocked()
 			return errContext
 		}
+	}
+	r.refreshLease = r.manager.EnsureAutoRefresh(context.Background(), embeddedRuntimeRefreshInterval)
+	if errContext := ctx.Err(); errContext != nil {
+		r.rollbackStartLocked()
+		return errContext
 	}
 	r.mu.Lock()
 	r.started = true
@@ -232,6 +241,14 @@ func (r *EmbeddedRuntime) Close(ctx context.Context) error {
 		return nil
 	}
 	r.mu.Unlock()
+	var refreshErr error
+	if r.refreshLease != nil {
+		refreshErr = r.refreshLease.Close(ctx)
+		if refreshErr != nil {
+			return refreshErr
+		}
+		r.refreshLease = nil
+	}
 	for authID := range r.registeredAuthIDs {
 		registry.GetGlobalRegistry().UnregisterClient(authID)
 		r.manager.RefreshSchedulerEntry(authID)
@@ -248,7 +265,7 @@ func (r *EmbeddedRuntime) Close(ctx context.Context) error {
 	r.closed = true
 	r.started = false
 	r.mu.Unlock()
-	return nil
+	return refreshErr
 }
 
 // ServerStarted reports whether an HTTP server was constructed by this runtime.
@@ -306,6 +323,10 @@ func (r *EmbeddedRuntime) registerAuthModelsLocked(ctx context.Context, auth *co
 }
 
 func (r *EmbeddedRuntime) rollbackStartLocked() {
+	if r.refreshLease != nil {
+		_ = r.refreshLease.Close(context.Background())
+		r.refreshLease = nil
+	}
 	for authID := range r.registeredAuthIDs {
 		registry.GetGlobalRegistry().UnregisterClient(authID)
 		r.manager.RefreshSchedulerEntry(authID)

--- a/sdk/cliproxy/embedded_runtime_test.go
+++ b/sdk/cliproxy/embedded_runtime_test.go
@@ -2,9 +2,12 @@ package cliproxy_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
@@ -16,6 +19,10 @@ import (
 
 type embeddedRuntimeTestExecutor struct {
 	provider string
+
+	refreshOnce sync.Once
+	refreshed   chan struct{}
+	release     chan struct{}
 }
 
 func (e *embeddedRuntimeTestExecutor) Identifier() string { return e.provider }
@@ -31,6 +38,12 @@ func (e *embeddedRuntimeTestExecutor) ExecuteStream(context.Context, *coreauth.A
 }
 
 func (e *embeddedRuntimeTestExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	if e.refreshed != nil {
+		e.refreshOnce.Do(func() { close(e.refreshed) })
+	}
+	if e.release != nil {
+		<-e.release
+	}
 	return auth, nil
 }
 
@@ -285,5 +298,83 @@ func TestEmbeddedRuntimeCanceledStartRollsBackOwnedExecutors(t *testing.T) {
 	}
 	if _, okExecutor := manager.Executor("claude"); okExecutor {
 		t.Fatal("canceled start leaked claude executor")
+	}
+}
+
+func TestEmbeddedRuntimeOwnsManagerAutoRefreshLifecycle(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	refreshed := make(chan struct{})
+	manager.RegisterExecutor(&embeddedRuntimeTestExecutor{provider: "codex", refreshed: refreshed})
+	if _, errRegister := manager.Register(t.Context(), &coreauth.Auth{
+		ID:       "codex-refresh-1",
+		Provider: "codex",
+		Attributes: map[string]string{
+			coreauth.AttributeAuthKind: coreauth.AuthKindOAuth,
+		},
+		Metadata: map[string]any{
+			"access_token":  "expired-access",
+			"refresh_token": "refresh-token",
+			"expires_at":    time.Now().Add(-time.Minute).Format(time.RFC3339),
+		},
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	runtime, errRuntime := cliproxy.NewEmbeddedRuntime(&config.Config{}, manager)
+	if errRuntime != nil {
+		t.Fatalf("new embedded runtime: %v", errRuntime)
+	}
+	if errStart := runtime.Start(t.Context()); errStart != nil {
+		t.Fatalf("start embedded runtime: %v", errStart)
+	}
+	t.Cleanup(func() { _ = runtime.Close(context.Background()) })
+
+	select {
+	case <-refreshed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("embedded runtime did not start manager auto-refresh")
+	}
+}
+
+func TestEmbeddedRuntimeCloseCanRetryRefreshDrain(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	refreshed := make(chan struct{})
+	release := make(chan struct{})
+	manager.RegisterExecutor(&embeddedRuntimeTestExecutor{provider: "codex", refreshed: refreshed, release: release})
+	if _, errRegister := manager.Register(t.Context(), &coreauth.Auth{
+		ID:       "codex-refresh-close",
+		Provider: "codex",
+		Attributes: map[string]string{
+			coreauth.AttributeAuthKind: coreauth.AuthKindOAuth,
+		},
+		Metadata: map[string]any{
+			"access_token":  "expired-access",
+			"refresh_token": "refresh-token",
+			"expires_at":    time.Now().Add(-time.Minute).Format(time.RFC3339),
+		},
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	runtime, errRuntime := cliproxy.NewEmbeddedRuntime(&config.Config{}, manager)
+	if errRuntime != nil {
+		t.Fatalf("new embedded runtime: %v", errRuntime)
+	}
+	if errStart := runtime.Start(t.Context()); errStart != nil {
+		t.Fatalf("start embedded runtime: %v", errStart)
+	}
+	select {
+	case <-refreshed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("refresh worker did not start")
+	}
+
+	closeCtx, cancelClose := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancelClose()
+	if errClose := runtime.Close(closeCtx); !errors.Is(errClose, context.DeadlineExceeded) {
+		t.Fatalf("first close error = %v, want context deadline exceeded", errClose)
+	}
+	close(release)
+	if errClose := runtime.Close(context.Background()); errClose != nil {
+		t.Fatalf("retry close: %v", errClose)
 	}
 }

--- a/sdk/cliproxy/embedded_runtime_test.go
+++ b/sdk/cliproxy/embedded_runtime_test.go
@@ -2,14 +2,45 @@ package cliproxy_test
 
 import (
 	"context"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
+
+type embeddedRuntimeTestExecutor struct {
+	provider string
+}
+
+func (e *embeddedRuntimeTestExecutor) Identifier() string { return e.provider }
+
+func (e *embeddedRuntimeTestExecutor) Execute(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *embeddedRuntimeTestExecutor) ExecuteStream(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	chunks := make(chan cliproxyexecutor.StreamChunk)
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *embeddedRuntimeTestExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *embeddedRuntimeTestExecutor) CountTokens(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *embeddedRuntimeTestExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
 
 func TestEmbeddedRuntimeRegistersNativeExecutorsWithoutServer(t *testing.T) {
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -145,5 +176,114 @@ func TestEmbeddedRuntimeCloseUnregistersModelsWithoutRemovingAuth(t *testing.T) 
 	}
 	if _, okExecutor := manager.Executor("claude"); okExecutor {
 		t.Fatal("closed runtime still exposes its claude executor")
+	}
+}
+
+func TestEmbeddedRuntimePreservesHostExecutor(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	hostExecutor := &embeddedRuntimeTestExecutor{provider: "codex"}
+	manager.RegisterExecutor(hostExecutor)
+	if _, errRegister := manager.Register(t.Context(), &coreauth.Auth{ID: "codex-host-1", Provider: "codex"}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	runtime, errRuntime := cliproxy.NewEmbeddedRuntime(&config.Config{}, manager)
+	if errRuntime != nil {
+		t.Fatalf("new embedded runtime: %v", errRuntime)
+	}
+	if errStart := runtime.Start(t.Context()); errStart != nil {
+		t.Fatalf("start embedded runtime: %v", errStart)
+	}
+
+	resolved, okResolved := manager.Executor("codex")
+	if !okResolved || resolved != hostExecutor {
+		t.Fatalf("executor after start = %T, want host executor", resolved)
+	}
+	if errClose := runtime.Close(t.Context()); errClose != nil {
+		t.Fatalf("close embedded runtime: %v", errClose)
+	}
+	resolved, okResolved = manager.Executor("codex")
+	if !okResolved || resolved != hostExecutor {
+		t.Fatalf("executor after close = %T, want host executor", resolved)
+	}
+}
+
+func TestEmbeddedRuntimeDoesNotProjectModelsWithoutExecutor(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	auth := &coreauth.Auth{ID: "aistudio-headless-1", Provider: "aistudio"}
+	if _, errRegister := manager.Register(t.Context(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	runtime, errRuntime := cliproxy.NewEmbeddedRuntime(&config.Config{}, manager)
+	if errRuntime != nil {
+		t.Fatalf("new embedded runtime: %v", errRuntime)
+	}
+	if errStart := runtime.Start(t.Context()); errStart != nil {
+		t.Fatalf("start embedded runtime: %v", errStart)
+	}
+	t.Cleanup(func() { _ = runtime.Close(context.Background()) })
+
+	if _, okExecutor := manager.Executor("aistudio"); okExecutor {
+		t.Fatal("headless runtime unexpectedly installed an AI Studio executor")
+	}
+	for _, model := range registry.GetAIStudioModels() {
+		if model != nil && cliproxy.GlobalModelRegistry().ClientSupportsModel(auth.ID, model.ID) {
+			t.Fatalf("auth without executor supports model %q", model.ID)
+		}
+	}
+}
+
+func TestEmbeddedRuntimeReconcileModelsIsCaseInsensitive(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	auth := &coreauth.Auth{ID: "codex-case-1", Provider: "codex"}
+	if _, errRegister := manager.Register(t.Context(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	runtime, errRuntime := cliproxy.NewEmbeddedRuntime(&config.Config{}, manager)
+	if errRuntime != nil {
+		t.Fatalf("new embedded runtime: %v", errRuntime)
+	}
+	if errStart := runtime.Start(t.Context()); errStart != nil {
+		t.Fatalf("start embedded runtime: %v", errStart)
+	}
+	t.Cleanup(func() { _ = runtime.Close(context.Background()) })
+
+	models := registry.GetCodexProModels()
+	if len(models) == 0 {
+		t.Fatal("codex model fixture is empty")
+	}
+	keptModel := models[0].ID
+	if errReconcile := runtime.ReconcileModels(t.Context(), []string{strings.ToUpper(keptModel)}); errReconcile != nil {
+		t.Fatalf("reconcile models: %v", errReconcile)
+	}
+	if !cliproxy.GlobalModelRegistry().ClientSupportsModel(auth.ID, keptModel) {
+		t.Fatalf("case-insensitive reconciliation removed model %q", keptModel)
+	}
+}
+
+func TestEmbeddedRuntimeCanceledStartRollsBackOwnedExecutors(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(t.Context(), &coreauth.Auth{ID: "codex-cancel-1", Provider: "codex"}); errRegister != nil {
+		t.Fatalf("register codex auth: %v", errRegister)
+	}
+	if _, errRegister := manager.Register(t.Context(), &coreauth.Auth{ID: "claude-cancel-1", Provider: "claude"}); errRegister != nil {
+		t.Fatalf("register claude auth: %v", errRegister)
+	}
+	runtime, errRuntime := cliproxy.NewEmbeddedRuntime(&config.Config{}, manager)
+	if errRuntime != nil {
+		t.Fatalf("new embedded runtime: %v", errRuntime)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if errStart := runtime.Start(ctx); errStart == nil {
+		t.Fatal("canceled start returned nil error")
+	}
+	if _, okExecutor := manager.Executor("codex"); okExecutor {
+		t.Fatal("canceled start leaked codex executor")
+	}
+	if _, okExecutor := manager.Executor("claude"); okExecutor {
+		t.Fatal("canceled start leaked claude executor")
 	}
 }

--- a/sdk/cliproxy/embedded_runtime_test.go
+++ b/sdk/cliproxy/embedded_runtime_test.go
@@ -1,0 +1,149 @@
+package cliproxy_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+func TestEmbeddedRuntimeRegistersNativeExecutorsWithoutServer(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(t.Context(), &coreauth.Auth{ID: "codex-1", Provider: "codex"}); errRegister != nil {
+		t.Fatalf("register codex auth: %v", errRegister)
+	}
+	if _, errRegister := manager.Register(t.Context(), &coreauth.Auth{ID: "claude-1", Provider: "claude"}); errRegister != nil {
+		t.Fatalf("register claude auth: %v", errRegister)
+	}
+
+	runtime, errRuntime := cliproxy.NewEmbeddedRuntime(&config.Config{}, manager)
+	if errRuntime != nil {
+		t.Fatalf("new embedded runtime: %v", errRuntime)
+	}
+	if errStart := runtime.Start(t.Context()); errStart != nil {
+		t.Fatalf("start embedded runtime: %v", errStart)
+	}
+	t.Cleanup(func() {
+		if errClose := runtime.Close(context.Background()); errClose != nil {
+			t.Errorf("close embedded runtime: %v", errClose)
+		}
+	})
+
+	codexExecutor, okCodex := manager.Executor("codex")
+	if !okCodex {
+		t.Fatal("codex executor was not registered")
+	}
+	if _, okNative := codexExecutor.(*runtimeexecutor.CodexAutoExecutor); !okNative {
+		t.Fatalf("codex executor type = %T, want *executor.CodexAutoExecutor", codexExecutor)
+	}
+
+	claudeExecutor, okClaude := manager.Executor("claude")
+	if !okClaude {
+		t.Fatal("claude executor was not registered")
+	}
+	if _, okNative := claudeExecutor.(*runtimeexecutor.ClaudeExecutor); !okNative {
+		t.Fatalf("claude executor type = %T, want *executor.ClaudeExecutor", claudeExecutor)
+	}
+
+	if runtime.ServerStarted() {
+		t.Fatal("embedded runtime started an HTTP server")
+	}
+	if runtime.WatcherStarted() {
+		t.Fatal("embedded runtime started a file watcher")
+	}
+}
+
+func TestEmbeddedRuntimeSyncRemoveAndReconcileModels(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	runtime, errRuntime := cliproxy.NewEmbeddedRuntime(&config.Config{}, manager)
+	if errRuntime != nil {
+		t.Fatalf("new embedded runtime: %v", errRuntime)
+	}
+	if errStart := runtime.Start(t.Context()); errStart != nil {
+		t.Fatalf("start embedded runtime: %v", errStart)
+	}
+	t.Cleanup(func() {
+		if errClose := runtime.Close(context.Background()); errClose != nil {
+			t.Errorf("close embedded runtime: %v", errClose)
+		}
+	})
+
+	auth := &coreauth.Auth{ID: "codex-sync-1", Provider: "codex"}
+	if errSync := runtime.SyncAuth(t.Context(), auth); errSync != nil {
+		t.Fatalf("sync auth: %v", errSync)
+	}
+	if _, okAuth := manager.GetByID(auth.ID); !okAuth {
+		t.Fatal("synced auth is missing from manager")
+	}
+
+	models := registry.GetCodexProModels()
+	if len(models) < 2 {
+		t.Fatalf("codex model fixture count = %d, want at least 2", len(models))
+	}
+	keptModel := models[0].ID
+	removedModel := models[1].ID
+	if !cliproxy.GlobalModelRegistry().ClientSupportsModel(auth.ID, keptModel) {
+		t.Fatalf("synced auth does not support native model %q", keptModel)
+	}
+
+	if errReconcile := runtime.ReconcileModels(t.Context(), []string{keptModel}); errReconcile != nil {
+		t.Fatalf("reconcile models: %v", errReconcile)
+	}
+	if !cliproxy.GlobalModelRegistry().ClientSupportsModel(auth.ID, keptModel) {
+		t.Fatalf("reconciled auth does not support active model %q", keptModel)
+	}
+	if cliproxy.GlobalModelRegistry().ClientSupportsModel(auth.ID, removedModel) {
+		t.Fatalf("reconciled auth still supports inactive model %q", removedModel)
+	}
+
+	if errRemove := runtime.RemoveAuth(t.Context(), auth.ID); errRemove != nil {
+		t.Fatalf("remove auth: %v", errRemove)
+	}
+	if _, okAuth := manager.GetByID(auth.ID); okAuth {
+		t.Fatal("removed auth is still present in manager")
+	}
+	if cliproxy.GlobalModelRegistry().ClientSupportsModel(auth.ID, keptModel) {
+		t.Fatalf("removed auth still supports model %q", keptModel)
+	}
+}
+
+func TestEmbeddedRuntimeCloseUnregistersModelsWithoutRemovingAuth(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	auth := &coreauth.Auth{ID: "claude-close-1", Provider: "claude"}
+	if _, errRegister := manager.Register(t.Context(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	runtime, errRuntime := cliproxy.NewEmbeddedRuntime(&config.Config{}, manager)
+	if errRuntime != nil {
+		t.Fatalf("new embedded runtime: %v", errRuntime)
+	}
+	if errStart := runtime.Start(t.Context()); errStart != nil {
+		t.Fatalf("start embedded runtime: %v", errStart)
+	}
+
+	models := registry.GetClaudeModels()
+	if len(models) == 0 {
+		t.Fatal("claude model fixture is empty")
+	}
+	model := models[0].ID
+	if !cliproxy.GlobalModelRegistry().ClientSupportsModel(auth.ID, model) {
+		t.Fatalf("started runtime does not register model %q", model)
+	}
+
+	if errClose := runtime.Close(t.Context()); errClose != nil {
+		t.Fatalf("close embedded runtime: %v", errClose)
+	}
+	if _, okAuth := manager.GetByID(auth.ID); !okAuth {
+		t.Fatal("closing runtime removed host-owned auth")
+	}
+	if cliproxy.GlobalModelRegistry().ClientSupportsModel(auth.ID, model) {
+		t.Fatalf("closed runtime still registers model %q", model)
+	}
+	if _, okExecutor := manager.Executor("claude"); okExecutor {
+		t.Fatal("closed runtime still exposes its claude executor")
+	}
+}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1023,22 +1023,12 @@ func (s *Service) registerExecutorsForAuths(auths []*coreauth.Auth, forceReplace
 	}
 }
 
-func (s *Service) registerExecutorForAuth(a *coreauth.Auth, forceReplace bool) {
+func (s *Service) registerExecutorForAuth(a *coreauth.Auth, forceReplace bool) (installed coreauth.ProviderExecutor, owned bool) {
 	if s == nil || s.coreManager == nil || a == nil {
 		return
 	}
 	if strings.EqualFold(strings.TrimSpace(a.Provider), "codex") {
-		if !forceReplace {
-			existingExecutor, hasExecutor := s.coreManager.Executor("codex")
-			if hasExecutor {
-				_, isCodexAutoExecutor := existingExecutor.(*executor.CodexAutoExecutor)
-				if isCodexAutoExecutor {
-					return
-				}
-			}
-		}
-		s.coreManager.RegisterExecutor(executor.NewCodexAutoExecutor(s.cfg))
-		return
+		return s.installExecutor(executor.NewCodexAutoExecutor(s.cfg), forceReplace)
 	}
 	// Skip disabled auth entries when (re)binding executors.
 	// Disabled auths can linger during config reloads (e.g., removed OpenAI-compat entries)
@@ -1053,36 +1043,28 @@ func (s *Service) registerExecutorForAuth(a *coreauth.Auth, forceReplace bool) {
 		if compatProviderKey == "" {
 			compatProviderKey = "openai-compatibility"
 		}
-		if !forceReplace {
-			if existingExecutor, hasExecutor := s.coreManager.Executor(compatProviderKey); hasExecutor {
-				if _, isOpenAICompatExecutor := existingExecutor.(*executor.OpenAICompatExecutor); isOpenAICompatExecutor {
-					return
-				}
-			}
-		}
-		s.coreManager.RegisterExecutor(executor.NewOpenAICompatExecutor(compatProviderKey, s.cfg))
-		return
+		return s.installExecutor(executor.NewOpenAICompatExecutor(compatProviderKey, s.cfg), forceReplace)
 	}
 	switch strings.ToLower(a.Provider) {
 	case constant.Gemini:
-		s.coreManager.RegisterExecutor(executor.NewGeminiExecutor(s.cfg))
+		return s.installExecutor(executor.NewGeminiExecutor(s.cfg), forceReplace)
 	case constant.GeminiInteractions:
-		s.coreManager.RegisterExecutor(executor.NewGeminiInteractionsExecutor(s.cfg))
+		return s.installExecutor(executor.NewGeminiInteractionsExecutor(s.cfg), forceReplace)
 	case "vertex":
-		s.coreManager.RegisterExecutor(executor.NewGeminiVertexExecutor(s.cfg))
+		return s.installExecutor(executor.NewGeminiVertexExecutor(s.cfg), forceReplace)
 	case "aistudio":
 		if s.wsGateway != nil {
-			s.coreManager.RegisterExecutor(executor.NewAIStudioExecutor(s.cfg, a.ID, s.wsGateway))
+			return s.installExecutor(executor.NewAIStudioExecutor(s.cfg, a.ID, s.wsGateway), forceReplace)
 		}
 		return
 	case "antigravity":
-		s.coreManager.RegisterExecutor(executor.NewAntigravityExecutor(s.cfg))
+		return s.installExecutor(executor.NewAntigravityExecutor(s.cfg), forceReplace)
 	case "claude":
-		s.coreManager.RegisterExecutor(executor.NewClaudeExecutor(s.cfg))
+		return s.installExecutor(executor.NewClaudeExecutor(s.cfg), forceReplace)
 	case "kimi":
-		s.coreManager.RegisterExecutor(executor.NewKimiExecutor(s.cfg))
+		return s.installExecutor(executor.NewKimiExecutor(s.cfg), forceReplace)
 	case "xai":
-		s.coreManager.RegisterExecutor(executor.NewXAIAutoExecutor(s.cfg))
+		return s.installExecutor(executor.NewXAIAutoExecutor(s.cfg), forceReplace)
 	default:
 		providerKey := strings.ToLower(strings.TrimSpace(a.Provider))
 		if providerKey == "" {
@@ -1094,15 +1076,22 @@ func (s *Service) registerExecutorForAuth(a *coreauth.Auth, forceReplace bool) {
 			s.unregisterOpenAICompatExecutor(providerKey)
 			return
 		}
-		if !forceReplace {
-			if existingExecutor, hasExecutor := s.coreManager.Executor(providerKey); hasExecutor {
-				if _, isOpenAICompatExecutor := existingExecutor.(*executor.OpenAICompatExecutor); isOpenAICompatExecutor {
-					return
-				}
-			}
-		}
-		s.coreManager.RegisterExecutor(executor.NewOpenAICompatExecutor(providerKey, s.cfg))
+		return s.installExecutor(executor.NewOpenAICompatExecutor(providerKey, s.cfg), forceReplace)
 	}
+}
+
+func (s *Service) installExecutor(candidate coreauth.ProviderExecutor, forceReplace bool) (coreauth.ProviderExecutor, bool) {
+	if candidate == nil {
+		return nil, false
+	}
+	if forceReplace {
+		s.coreManager.RegisterExecutor(candidate)
+		return candidate, true
+	}
+	if !s.coreManager.RegisterExecutorIfAbsent(candidate) {
+		return nil, false
+	}
+	return candidate, true
 }
 
 func (s *Service) registerResolvedModelsForAuth(a *coreauth.Auth, providerKey string, models []*ModelInfo) {
@@ -1920,7 +1909,7 @@ func (s *Service) reconcileModelsForAuth(ctx context.Context, a *coreauth.Auth, 
 			if model == nil {
 				continue
 			}
-			if _, active := activeModels[strings.TrimSpace(model.ID)]; active {
+			if _, active := activeModels[strings.ToLower(strings.TrimSpace(model.ID))]; active {
 				filtered = append(filtered, model)
 			}
 		}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1906,6 +1906,34 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 	s.registerModelsForAuthWithCache(ctx, a, nil)
 }
 
+// reconcileModelsForAuth rebuilds one auth's native model projection and,
+// when activeModels is non-nil, prunes models the embedding host has not activated.
+func (s *Service) reconcileModelsForAuth(ctx context.Context, a *coreauth.Auth, activeModels map[string]struct{}) {
+	if s == nil || s.coreManager == nil || a == nil || strings.TrimSpace(a.ID) == "" {
+		return
+	}
+	s.registerModelsForAuth(ctx, a)
+	if activeModels != nil {
+		models := registry.GetGlobalRegistry().GetModelsForClient(a.ID)
+		filtered := make([]*ModelInfo, 0, len(models))
+		for _, model := range models {
+			if model == nil {
+				continue
+			}
+			if _, active := activeModels[strings.TrimSpace(model.ID)]; active {
+				filtered = append(filtered, model)
+			}
+		}
+		provider := strings.ToLower(strings.TrimSpace(a.Provider))
+		if providerKey, _, isCompat := openAICompatInfoFromAuth(a); isCompat && providerKey != "" {
+			provider = providerKey
+		}
+		s.registerResolvedModelsForAuth(a, provider, filtered)
+	}
+	s.coreManager.ReconcileRegistryModelStates(ctx, a.ID)
+	s.coreManager.RefreshSchedulerEntry(a.ID)
+}
+
 func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreauth.Auth, compatCache *openAICompatibilityRegistrationCache) {
 	if a == nil || a.ID == "" {
 		return


### PR DESCRIPTION
## Summary
- add a public `EmbeddedRuntime` lifecycle backed by a host-supplied core auth manager
- reuse native executor and model registration without constructing the HTTP server, watcher, access manager, or management routes
- support targeted auth sync/removal, active-model reconciliation, and cleanup of runtime-owned projections

## Test plan
- `go test ./sdk/cliproxy ./sdk/cliproxy/auth -count=1`
- `go test -race ./sdk/cliproxy ./sdk/cliproxy/auth -count=1`
- `go build -o test-output ./cmd/server && rm test-output`
- `go test ./... -count=1`
- `git diff --check`