### PR TITLE
perf(api): skip inactive request interceptors

### DIFF
--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -2064,7 +2064,7 @@ func interceptStreamChunk(ctx context.Context, host PluginInterceptorHost, req p
 
 func (h *BaseAPIHandler) applyRequestInterceptorsBeforeAuth(ctx context.Context, handlerType, requestedModel string, req coreexecutor.Request, opts coreexecutor.Options, skipPluginID string) (coreexecutor.Request, coreexecutor.Options) {
 	host := h.interceptorHost()
-	if host == nil {
+	if !requestInterceptorsEnabled(host) {
 		return req, opts
 	}
 	resp := interceptRequestBeforeAuth(ctx, host, pluginapi.RequestInterceptRequest{

--- a/sdk/api/handlers/handlers_interceptors_test.go
+++ b/sdk/api/handlers/handlers_interceptors_test.go
@@ -29,7 +29,15 @@ type handlerInterceptorNoStreamTestHost struct {
 	*handlerInterceptorTestHost
 }
 
+type handlerInterceptorDisabledRequestTestHost struct {
+	*handlerInterceptorTestHost
+}
+
 func (h *handlerInterceptorNoStreamTestHost) HasStreamInterceptors() bool {
+	return false
+}
+
+func (h *handlerInterceptorDisabledRequestTestHost) HasRequestInterceptors() bool {
 	return false
 }
 
@@ -252,6 +260,77 @@ func TestHandlerRequestInterceptorRewritesExecutorRequest(t *testing.T) {
 	}
 	if gotOpts.Metadata[coreexecutor.RequestedModelMetadataKey] != model {
 		t.Fatalf("metadata = %#v, want requested model", gotOpts.Metadata)
+	}
+}
+
+func TestHandlerSkipsDisabledRequestInterceptorsWithoutCopyingPayload(t *testing.T) {
+	payload := []byte(`{"model":"disabled-interceptor-model"}`)
+	called := false
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetPluginHost(&handlerInterceptorDisabledRequestTestHost{
+		handlerInterceptorTestHost: &handlerInterceptorTestHost{
+			interceptRequestBeforeAuth: func(context.Context, pluginapi.RequestInterceptRequest) pluginapi.RequestInterceptResponse {
+				called = true
+				return pluginapi.RequestInterceptResponse{Body: []byte(`{"unexpected":true}`)}
+			},
+		},
+	})
+
+	req := coreexecutor.Request{Model: "disabled-interceptor-model", Payload: payload}
+	opts := coreexecutor.Options{OriginalRequest: payload}
+	gotReq, gotOpts := handler.applyRequestInterceptorsBeforeAuth(context.Background(), "openai", req.Model, req, opts, "")
+
+	if called {
+		t.Fatal("disabled request interceptor was called")
+	}
+	if &gotReq.Payload[0] != &payload[0] {
+		t.Fatal("request payload was copied")
+	}
+	if &gotOpts.OriginalRequest[0] != &payload[0] {
+		t.Fatal("original request was copied")
+	}
+}
+
+func BenchmarkHandlerRequestInterceptors(b *testing.B) {
+	sizes := []struct {
+		name  string
+		bytes int
+	}{
+		{name: "1KiB", bytes: 1 << 10},
+		{name: "1MiB", bytes: 1 << 20},
+		{name: "8MiB", bytes: 8 << 20},
+	}
+	hosts := []struct {
+		name string
+		host PluginInterceptorHost
+	}{
+		{
+			name: "disabled",
+			host: &handlerInterceptorDisabledRequestTestHost{
+				handlerInterceptorTestHost: &handlerInterceptorTestHost{},
+			},
+		},
+		{name: "active", host: &handlerInterceptorTestHost{}},
+	}
+
+	for _, size := range sizes {
+		payload := make([]byte, size.bytes)
+		req := coreexecutor.Request{Model: "benchmark-model", Payload: payload}
+		opts := coreexecutor.Options{OriginalRequest: payload}
+		for _, host := range hosts {
+			b.Run(host.name+"/"+size.name, func(b *testing.B) {
+				handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+				handler.SetPluginHost(host.host)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for range b.N {
+					gotReq, gotOpts := handler.applyRequestInterceptorsBeforeAuth(context.Background(), "openai", req.Model, req, opts, "")
+					if len(gotReq.Payload) != size.bytes || len(gotOpts.OriginalRequest) != size.bytes {
+						b.Fatal("request payload length changed")
+					}
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Skip the before-auth request interceptor dispatch when the plugin host reports that no request interceptors are active.

The plugin host may exist even when request interception is disabled. In that state, the old path still copied the request body four times while building the interceptor request and response, which is especially costly for large Responses API payloads.

## Changes

- reuse the existing `HasRequestInterceptors` capability check before dispatch
- return the original request and options without copying their payloads when request interceptors are disabled
- add pointer-reuse regression coverage
- add allocation benchmarks for 1 KiB, 1 MiB, and 8 MiB payloads

## Benchmark

Go 1.26, Linux arm64, 100 ms benchmark window:

```text
BenchmarkHandlerRequestInterceptors/disabled/8MiB   21.88 ns/op          0 B/op   0 allocs/op
BenchmarkHandlerRequestInterceptors/active/8MiB      2.97 ms/op   33554482 B/op   4 allocs/op
```

Active interceptors retain the existing behavior; only the disabled fast path changes.

## Validation

- `go test ./sdk/api/handlers -run 'TestHandlerSkipsDisabledRequestInterceptorsWithoutCopyingPayload|TestHandlerRequestInterceptor' -count=1`
- `go test ./sdk/api/handlers -run '^$' -bench '^BenchmarkHandlerRequestInterceptors$' -benchmem -count=1`
- `go test ./... -count=1`
- `go build -o /tmp/test-output ./cmd/server`
