### PR TITLE
fix(codex): quarantine terminal OAuth refresh failures

### DIFF
--- a/internal/auth/codex/openai_auth.go
+++ b/internal/auth/codex/openai_auth.go
@@ -372,19 +372,21 @@ func isNonRetryableRefreshErr(err error) bool {
 	return isTerminalRefreshFailure(err.Error())
 }
 
+var terminalRefreshFailureMarkers = []string{
+	"refresh_token_reused",
+	"refresh_token_invalidated",
+	"invalid_client",
+	"invalid_grant",
+	"refresh token has already been used",
+	"refresh token was already used",
+	"refresh token has been invalidated",
+	"authentication token has been invalidated",
+	"invalid client specified",
+}
+
 func isTerminalRefreshFailure(message string) bool {
 	lower := strings.ToLower(message)
-	for _, marker := range []string{
-		"refresh_token_reused",
-		"refresh_token_invalidated",
-		"invalid_client",
-		"invalid_grant",
-		"refresh token has already been used",
-		"refresh token was already used",
-		"refresh token has been invalidated",
-		"authentication token has been invalidated",
-		"invalid client specified",
-	} {
+	for _, marker := range terminalRefreshFailureMarkers {
 		if strings.Contains(lower, marker) {
 			return true
 		}

--- a/internal/auth/codex/openai_auth.go
+++ b/internal/auth/codex/openai_auth.go
@@ -7,6 +7,7 @@ package codex
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -33,6 +34,38 @@ const (
 // exchanging authorization codes for tokens, and refreshing access tokens.
 type CodexAuth struct {
 	httpClient *http.Client
+}
+
+type tokenRefreshError struct {
+	statusCode int
+	body       string
+}
+
+func (e *tokenRefreshError) Error() string {
+	if e == nil {
+		return "token refresh failed"
+	}
+	return fmt.Sprintf("token refresh failed with status %d: %s", e.statusCode, e.body)
+}
+
+func (e *tokenRefreshError) StatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.statusCode
+}
+
+// NonRetryable reports whether retrying with the same refresh token cannot recover.
+func (e *tokenRefreshError) NonRetryable() bool {
+	if e == nil {
+		return false
+	}
+	return e.statusCode == http.StatusUnauthorized || isTerminalRefreshFailure(e.body)
+}
+
+// AuthUnavailable marks terminal refresh failures for the auth manager to quarantine.
+func (e *tokenRefreshError) AuthUnavailable() bool {
+	return e.NonRetryable()
 }
 
 var codexRefreshGroup singleflight.Group
@@ -239,7 +272,7 @@ func (o *CodexAuth) refreshTokensSingleFlight(ctx context.Context, refreshToken 
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("token refresh failed with status %d: %s", resp.StatusCode, string(body))
+		return nil, &tokenRefreshError{statusCode: resp.StatusCode, body: string(body)}
 	}
 
 	var tokenResp struct {
@@ -329,8 +362,34 @@ func isNonRetryableRefreshErr(err error) bool {
 	if err == nil {
 		return false
 	}
-	raw := strings.ToLower(err.Error())
-	return strings.Contains(raw, "refresh_token_reused")
+	type nonRetryableError interface {
+		NonRetryable() bool
+	}
+	var terminal nonRetryableError
+	if errors.As(err, &terminal) && terminal != nil {
+		return terminal.NonRetryable()
+	}
+	return isTerminalRefreshFailure(err.Error())
+}
+
+func isTerminalRefreshFailure(message string) bool {
+	lower := strings.ToLower(message)
+	for _, marker := range []string{
+		"refresh_token_reused",
+		"refresh_token_invalidated",
+		"invalid_client",
+		"invalid_grant",
+		"refresh token has already been used",
+		"refresh token was already used",
+		"refresh token has been invalidated",
+		"authentication token has been invalidated",
+		"invalid client specified",
+	} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // UpdateTokenStorage updates an existing CodexTokenStorage with new token data.

--- a/internal/auth/codex/openai_auth_test.go
+++ b/internal/auth/codex/openai_auth_test.go
@@ -52,6 +52,93 @@ func TestRefreshTokensWithRetry_NonRetryableOnlyAttemptsOnce(t *testing.T) {
 	}
 }
 
+func TestRefreshTokensWithRetry_TerminalOAuthErrorsOnlyAttemptOnce(t *testing.T) {
+	testCases := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{
+			name:       "rotated token message",
+			statusCode: http.StatusBadRequest,
+			body:       `{"error":{"message":"Your refresh token has already been used to generate a new access token."}}`,
+		},
+		{
+			name:       "invalidated refresh token",
+			statusCode: http.StatusBadRequest,
+			body:       `{"error":"invalid_grant","code":"refresh_token_invalidated"}`,
+		},
+		{
+			name:       "invalid client code",
+			statusCode: http.StatusBadRequest,
+			body:       `{"error":"invalid_client"}`,
+		},
+		{
+			name:       "invalid client message",
+			statusCode: http.StatusUnauthorized,
+			body:       `Invalid client specified`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			resetCodexRefreshGroupForTest()
+			t.Cleanup(resetCodexRefreshGroupForTest)
+
+			var calls int32
+			auth := &CodexAuth{
+				httpClient: &http.Client{
+					Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						atomic.AddInt32(&calls, 1)
+						return &http.Response{
+							StatusCode: testCase.statusCode,
+							Body:       io.NopCloser(strings.NewReader(testCase.body)),
+							Header:     make(http.Header),
+							Request:    req,
+						}, nil
+					}),
+				},
+			}
+
+			_, err := auth.RefreshTokensWithRetry(context.Background(), "dummy_refresh_token", 3)
+			if err == nil {
+				t.Fatal("expected terminal token refresh error")
+			}
+			if got := atomic.LoadInt32(&calls); got != 1 {
+				t.Fatalf("expected 1 refresh attempt, got %d", got)
+			}
+		})
+	}
+}
+
+func TestRefreshTokensWithRetry_TransientErrorStillRetries(t *testing.T) {
+	resetCodexRefreshGroupForTest()
+	t.Cleanup(resetCodexRefreshGroupForTest)
+
+	var calls int32
+	auth := &CodexAuth{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				atomic.AddInt32(&calls, 1)
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader(`{"error":"temporarily_unavailable"}`)),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			}),
+		},
+	}
+
+	_, err := auth.RefreshTokensWithRetry(context.Background(), "dummy_refresh_token", 3)
+	if err == nil {
+		t.Fatal("expected transient token refresh error")
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("expected 3 refresh attempts, got %d", got)
+	}
+}
+
 func TestRefreshTokens_DeduplicatesConcurrentRefreshAcrossInstances(t *testing.T) {
 	resetCodexRefreshGroupForTest()
 	t.Cleanup(resetCodexRefreshGroupForTest)

--- a/sdk/cliproxy/auth/auto_refresh_loop.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop.go
@@ -339,6 +339,9 @@ func nextRefreshCheckAt(now time.Time, auth *Auth, interval time.Duration) (time
 	if auth == nil {
 		return time.Time{}, false
 	}
+	if auth.RefreshBlocked {
+		return time.Time{}, false
+	}
 	if hasUnauthorizedAuthFailure(auth) {
 		return time.Time{}, false
 	}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -4106,6 +4106,13 @@ func isUnauthorizedError(err error) bool {
 	if err == nil {
 		return false
 	}
+	type authUnavailableError interface {
+		AuthUnavailable() bool
+	}
+	var terminal authUnavailableError
+	if errors.As(err, &terminal) && terminal != nil && terminal.AuthUnavailable() {
+		return true
+	}
 	if statusCodeFromError(err) == http.StatusUnauthorized {
 		return true
 	}
@@ -4125,7 +4132,7 @@ func refreshErrorFromError(err error) *Error {
 		return nil
 	}
 	statusCode := statusCodeFromError(err)
-	if statusCode == 0 && isUnauthorizedError(err) {
+	if isUnauthorizedError(err) {
 		statusCode = http.StatusUnauthorized
 	}
 	authErr := &Error{Message: err.Error(), HTTPStatus: statusCode}
@@ -5661,6 +5668,9 @@ func (m *Manager) shouldRefresh(a *Auth, now time.Time) bool {
 	if a == nil {
 		return false
 	}
+	if a.RefreshBlocked {
+		return false
+	}
 	if hasUnauthorizedAuthFailure(a) {
 		return false
 	}
@@ -6004,6 +6014,7 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 			if unauthorized {
 				current.NextRefreshAfter = time.Time{}
 				current.Unavailable = true
+				current.RefreshBlocked = true
 				current.Status = StatusError
 				current.StatusMessage = "unauthorized"
 			} else {
@@ -6034,6 +6045,7 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 	updated.LastError = nil
 	updated.StatusMessage = ""
 	updated.Unavailable = false
+	updated.RefreshBlocked = false
 	if updated.Status == StatusError {
 		updated.Status = StatusActive
 	}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -711,7 +711,7 @@ func dedupeStrings(values []string) []string {
 	return out
 }
 
-// ResetQuota clears quota/cooldown state for an auth and resumes registry routing.
+// ResetQuota clears quota/cooldown and refresh quarantine state for an auth and resumes registry routing.
 func (m *Manager) ResetQuota(ctx context.Context, authID string) (*Auth, []string, error) {
 	if m == nil {
 		return nil, nil, nil
@@ -733,6 +733,7 @@ func (m *Manager) ResetQuota(ctx context.Context, authID string) (*Auth, []strin
 		m.mu.Unlock()
 		return nil, nil, nil
 	}
+	auth.RefreshBlocked = false
 
 	var cooldownRecordsBefore []CooldownStateRecord
 	trackCooldownState := m.cooldownStore != nil
@@ -789,6 +790,7 @@ func (m *Manager) ResetQuota(ctx context.Context, authID string) (*Auth, []strin
 	if snapshot != nil && cooldownStateChanged {
 		m.persistCooldownStates(ctx)
 	}
+	m.queueRefreshReschedule(authID)
 	return snapshot, models, nil
 }
 

--- a/sdk/cliproxy/auth/conductor_availability_test.go
+++ b/sdk/cliproxy/auth/conductor_availability_test.go
@@ -107,6 +107,10 @@ func TestManager_AvailableProvidersAndHasProviderAuth_ExcludeDisabled(t *testing
 
 func TestManager_ResetQuotaClearsRuntimeAndRegistryState(t *testing.T) {
 	manager := NewManager(nil, nil, nil)
+	refreshLoop := newAuthAutoRefreshLoop(manager, time.Second, 1)
+	manager.mu.Lock()
+	manager.refreshLoop = refreshLoop
+	manager.mu.Unlock()
 	ctx := context.Background()
 	authID := "reset-quota-auth"
 	model := "reset-quota-model"
@@ -124,7 +128,9 @@ func TestManager_ResetQuotaClearsRuntimeAndRegistryState(t *testing.T) {
 		Status:         StatusError,
 		StatusMessage:  "quota exhausted",
 		Unavailable:    true,
+		RefreshBlocked: true,
 		NextRetryAfter: next,
+		Runtime:        testRefreshEvaluator{},
 		Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: next, BackoffLevel: 2},
 		ModelStates: map[string]*ModelState{
 			model: {
@@ -145,6 +151,13 @@ func TestManager_ResetQuotaClearsRuntimeAndRegistryState(t *testing.T) {
 	if count := reg.GetModelCount(model); count != 0 {
 		t.Fatalf("registry model count before reset = %d, want 0", count)
 	}
+	refreshLoop.applyDirty(time.Now())
+	refreshLoop.mu.Lock()
+	_, scheduledBeforeReset := refreshLoop.index[authID]
+	refreshLoop.mu.Unlock()
+	if scheduledBeforeReset {
+		t.Fatalf("refresh-blocked auth %q was scheduled before reset", authID)
+	}
 
 	updated, models, errReset := manager.ResetQuota(ctx, authID)
 	if errReset != nil {
@@ -158,6 +171,9 @@ func TestManager_ResetQuotaClearsRuntimeAndRegistryState(t *testing.T) {
 	}
 	if updated.Status != StatusActive || updated.StatusMessage != "" || updated.Unavailable || !updated.NextRetryAfter.IsZero() {
 		t.Fatalf("updated auth state = status %q message %q unavailable %v next %v", updated.Status, updated.StatusMessage, updated.Unavailable, updated.NextRetryAfter)
+	}
+	if updated.RefreshBlocked {
+		t.Fatal("updated auth remained refresh-blocked after administrative quota reset")
 	}
 	if updated.Quota.Exceeded || updated.Quota.Reason != "" || !updated.Quota.NextRecoverAt.IsZero() || updated.Quota.BackoffLevel != 0 {
 		t.Fatalf("updated auth quota = %+v, want cleared", updated.Quota)
@@ -174,5 +190,12 @@ func TestManager_ResetQuotaClearsRuntimeAndRegistryState(t *testing.T) {
 	}
 	if count := reg.GetModelCount(model); count != 1 {
 		t.Fatalf("registry model count after reset = %d, want 1", count)
+	}
+	refreshLoop.applyDirty(time.Now())
+	refreshLoop.mu.Lock()
+	_, scheduledAfterReset := refreshLoop.index[authID]
+	refreshLoop.mu.Unlock()
+	if !scheduledAfterReset {
+		t.Fatalf("auth %q was not rescheduled for refresh after reset", authID)
 	}
 }

--- a/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
@@ -45,6 +45,20 @@ func (e unauthorizedRefreshTestExecutor) Refresh(ctx context.Context, auth *Auth
 	return nil, errors.New("token refresh failed with status 401: invalid_grant")
 }
 
+type terminalCredentialRefreshError struct{}
+
+func (terminalCredentialRefreshError) Error() string         { return "invalid_client" }
+func (terminalCredentialRefreshError) StatusCode() int       { return http.StatusBadRequest }
+func (terminalCredentialRefreshError) AuthUnavailable() bool { return true }
+
+type terminalCredentialRefreshTestExecutor struct {
+	schedulerProviderTestExecutor
+}
+
+func (e terminalCredentialRefreshTestExecutor) Refresh(context.Context, *Auth) (*Auth, error) {
+	return nil, terminalCredentialRefreshError{}
+}
+
 func TestManager_RefreshAuthUnauthorizedFailureStopsAutoRefreshRetry(t *testing.T) {
 	ctx := context.Background()
 	manager := NewManager(nil, &RoundRobinSelector{}, nil)
@@ -87,6 +101,71 @@ func TestManager_RefreshAuthUnauthorizedFailureStopsAutoRefreshRetry(t *testing.
 	}
 	if _, shouldSchedule := nextRefreshCheckAt(now, updated, time.Second); shouldSchedule {
 		t.Fatal("expected unauthorized auth to be removed from the auto-refresh schedule")
+	}
+}
+
+func TestManager_RefreshAuthTerminalCredentialFailureQuarantinesAuth(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(terminalCredentialRefreshTestExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "codex"},
+	})
+
+	primary := &Auth{
+		ID:       "terminal-refresh-primary",
+		Provider: "codex",
+		Metadata: map[string]any{"refresh_token": "rotated-refresh-token"},
+	}
+	backup := &Auth{ID: "terminal-refresh-backup", Provider: "codex"}
+	if _, errRegister := manager.Register(ctx, primary); errRegister != nil {
+		t.Fatalf("register primary: %v", errRegister)
+	}
+	if _, errRegister := manager.Register(ctx, backup); errRegister != nil {
+		t.Fatalf("register backup: %v", errRegister)
+	}
+
+	manager.refreshAuth(ctx, primary.ID)
+
+	updated, ok := manager.GetByID(primary.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected primary auth after refresh failure")
+	}
+	if updated.LastError == nil || updated.LastError.Code != "unauthorized" {
+		t.Fatalf("expected terminal refresh failure to be recorded as unauthorized, got %+v", updated.LastError)
+	}
+	if !updated.NextRefreshAfter.IsZero() {
+		t.Fatalf("NextRefreshAfter = %s, want terminal failure unscheduled", updated.NextRefreshAfter)
+	}
+
+	available, errAvailable := getAvailableAuths(manager.List(), "codex", "gpt-5.5", time.Now())
+	if errAvailable != nil {
+		t.Fatalf("getAvailableAuths error: %v", errAvailable)
+	}
+	if len(available) != 1 || available[0].ID != backup.ID {
+		availableIDs := make([]string, 0, len(available))
+		for _, auth := range available {
+			if auth != nil {
+				availableIDs = append(availableIDs, auth.ID)
+			}
+		}
+		t.Fatalf("available auths = %v, want only %q", availableIDs, backup.ID)
+	}
+
+	reloaded := &Auth{
+		ID:       primary.ID,
+		Provider: primary.Provider,
+		Status:   StatusActive,
+		Metadata: map[string]any{"refresh_token": "new-refresh-token"},
+	}
+	if _, errUpdate := manager.Update(ctx, reloaded); errUpdate != nil {
+		t.Fatalf("reload primary: %v", errUpdate)
+	}
+	available, errAvailable = getAvailableAuths(manager.List(), "codex", "gpt-5.5", time.Now())
+	if errAvailable != nil {
+		t.Fatalf("getAvailableAuths after reload error: %v", errAvailable)
+	}
+	if len(available) != 2 {
+		t.Fatalf("available auth count after reload = %d, want 2", len(available))
 	}
 }
 

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -306,6 +306,9 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	if auth == nil {
 		return true, blockReasonOther, time.Time{}
 	}
+	if auth.RefreshBlocked {
+		return true, blockReasonOther, time.Time{}
+	}
 	if auth.Disabled || auth.Status == StatusDisabled {
 		return true, blockReasonDisabled, time.Time{}
 	}

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -92,6 +92,8 @@ type Auth struct {
 
 	// Runtime carries non-serialisable data used during execution (in-memory only).
 	Runtime any `json:"-"`
+	// RefreshBlocked quarantines credentials after a terminal refresh failure until refresh succeeds or they are reloaded.
+	RefreshBlocked bool `json:"-"`
 
 	Success int64 `json:"-"`
 	Failed  int64 `json:"-"`


### PR DESCRIPTION
## Summary

- classify terminal Codex OAuth refresh failures, including rotated or invalidated refresh tokens, invalid grants, and mismatched OAuth clients
- stop retrying the same refresh token after the first terminal failure
- quarantine the affected auth from auto-refresh and request routing until refresh succeeds or the credential is reloaded
- keep transient refresh failures, such as HTTP 5xx responses, retryable

## Problem

CLIProxyAPI currently short-circuits only errors containing the exact `refresh_token_reused` code. OpenAI can also return a human-readable reused-token message, `refresh_token_invalidated`, `invalid_grant`, `invalid_client`, or `Invalid client specified`.

Those responses cannot recover by retrying the same credential. With multiple independent instances using copies of the same rotating Codex refresh token, one instance can rotate the token while another keeps the stale copy. The stale credential then generates redundant refresh calls and can remain eligible for request routing, delaying otherwise healthy requests.

Process-local `singleflight` cannot coordinate refreshes across separate hosts. This PR intentionally contains the failure instead: the stale credential is quarantined and the pool can immediately use another healthy auth. Reloading or successfully refreshing the credential clears the quarantine.

## Reproduction covered by tests

1. Register a primary Codex auth and a healthy backup auth.
2. Make the primary refresh return a terminal OAuth failure.
3. Verify the failure is attempted once and removed from auto-refresh scheduling.
4. Verify model routing selects only the healthy backup.
5. Reload the primary credential and verify it becomes eligible again.

## Verification

- `go test ./... -count=1`
- `go test -race ./internal/auth/codex ./sdk/cliproxy/auth -count=1`
- `go vet ./internal/auth/codex ./sdk/cliproxy/auth`
- `go build -o /tmp/cliproxyapi-test-output ./cmd/server`

## Scope

This PR does not add distributed locking or a shared token store. True cross-host refresh coordination would require shared atomic credential storage; this change provides safe failure containment for existing file-based and independent-instance deployments.
