### PR TITLE
fix(executor): close request-owned uTLS HTTP/2 connections

### DIFF
--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -2,6 +2,7 @@ package helps
 
 import (
 	"context"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -25,6 +26,8 @@ type utlsRoundTripper struct {
 	pending     map[string]*sync.Cond
 	dialer      proxy.Dialer
 }
+
+const utlsConnectionShutdownTimeout = 30 * time.Second
 
 func newUtlsRoundTripper(proxyURL string) *utlsRoundTripper {
 	var dialer proxy.Dialer = proxy.Direct
@@ -75,8 +78,22 @@ func (t *utlsRoundTripper) getOrCreateConnection(host, addr string) (*http2.Clie
 		return nil, err
 	}
 
+	if old := t.connections[host]; old != nil && old != h2Conn {
+		go shutdownUtlsConnection(old)
+	}
 	t.connections[host] = h2Conn
 	return h2Conn, nil
+}
+
+func shutdownUtlsConnection(conn *http2.ClientConn) {
+	if conn == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), utlsConnectionShutdownTimeout)
+	defer cancel()
+	if err := conn.Shutdown(ctx); err != nil {
+		_ = conn.Close()
+	}
 }
 
 func (t *utlsRoundTripper) createConnection(host, addr string) (*http2.ClientConn, error) {
@@ -123,10 +140,73 @@ func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 			delete(t.connections, hostname)
 		}
 		t.mu.Unlock()
+		go shutdownUtlsConnection(h2Conn)
 		return nil, err
 	}
 
 	return resp, nil
+}
+
+func (t *utlsRoundTripper) CloseIdleConnections() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	connections := make([]*http2.ClientConn, 0, len(t.connections))
+	for host, conn := range t.connections {
+		delete(t.connections, host)
+		connections = append(connections, conn)
+	}
+	t.mu.Unlock()
+
+	for _, conn := range connections {
+		go shutdownUtlsConnection(conn)
+	}
+}
+
+type closeOwnedTransportRoundTripper struct {
+	base http.RoundTripper
+}
+
+// RoundTrip ties a request-owned uTLS transport to its response body. CPA
+// creates a fresh uTLS client for each upstream request, so the transport must
+// be drained when that request finishes instead of being left to a global pool.
+func (t *closeOwnedTransportRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		t.CloseIdleConnections()
+		return resp, err
+	}
+	if resp == nil || resp.Body == nil {
+		t.CloseIdleConnections()
+		return resp, nil
+	}
+	resp.Body = &closeOwnedTransportReadCloser{
+		ReadCloser: resp.Body,
+		close:      t.CloseIdleConnections,
+	}
+	return resp, nil
+}
+
+func (t *closeOwnedTransportRoundTripper) CloseIdleConnections() {
+	if t == nil || t.base == nil {
+		return
+	}
+	if closer, ok := t.base.(interface{ CloseIdleConnections() }); ok {
+		closer.CloseIdleConnections()
+	}
+}
+
+type closeOwnedTransportReadCloser struct {
+	io.ReadCloser
+	once  sync.Once
+	close func()
+}
+
+func (r *closeOwnedTransportReadCloser) Close() error {
+	err := r.ReadCloser.Close()
+	r.once.Do(r.close)
+	return err
 }
 
 // utlsProtectedHosts contains the hosts that should use utls Chrome TLS fingerprint
@@ -169,7 +249,9 @@ func NewUtlsHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyau
 		ctxRoundTripper, _ = ctx.Value("cliproxy.roundtripper").(http.RoundTripper)
 	}
 
-	var utlsRT http.RoundTripper = newUtlsRoundTripper(proxyURL)
+	var utlsRT http.RoundTripper = &closeOwnedTransportRoundTripper{
+		base: newUtlsRoundTripper(proxyURL),
+	}
 	var standardTransport http.RoundTripper = http.DefaultTransport
 	if proxyURL != "" {
 		if transport := buildProxyTransport(proxyURL); transport != nil {

--- a/internal/runtime/executor/helps/utls_client_test.go
+++ b/internal/runtime/executor/helps/utls_client_test.go
@@ -2,9 +2,11 @@ package helps
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -12,6 +14,20 @@ type utlsClientRoundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f utlsClientRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+type closeTrackingRoundTripper struct {
+	response   *http.Response
+	err        error
+	closeCalls atomic.Int32
+}
+
+func (t *closeTrackingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return t.response, t.err
+}
+
+func (t *closeTrackingRoundTripper) CloseIdleConnections() {
+	t.closeCalls.Add(1)
 }
 
 func TestNewUtlsHTTPClientUsesContextRoundTripperForProtectedHost(t *testing.T) {
@@ -41,5 +57,117 @@ func TestNewUtlsHTTPClientUsesContextRoundTripperForProtectedHost(t *testing.T) 
 	}
 	if !called {
 		t.Fatal("expected context RoundTripper to handle protected host request")
+	}
+}
+
+func TestNewUtlsHTTPClientDoesNotCloseContextRoundTripper(t *testing.T) {
+	t.Parallel()
+
+	shared := &closeTrackingRoundTripper{
+		response: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("{}")),
+		},
+	}
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", shared)
+	client := NewUtlsHTTPClient(ctx, nil, nil, 0)
+	resp, err := client.Get("https://chatgpt.com/backend-api/codex/responses")
+	if err != nil {
+		t.Fatalf("client.Get returned error: %v", err)
+	}
+	if errClose := resp.Body.Close(); errClose != nil {
+		t.Fatalf("response body close returned error: %v", errClose)
+	}
+	if got := shared.closeCalls.Load(); got != 0 {
+		t.Fatalf("context RoundTripper close calls = %d, want 0", got)
+	}
+}
+
+func TestCloseOwnedTransportRoundTripperClosesAfterResponseBody(t *testing.T) {
+	t.Parallel()
+
+	base := &closeTrackingRoundTripper{
+		response: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("{}")),
+		},
+	}
+	transport := &closeOwnedTransportRoundTripper{base: base}
+	req, err := http.NewRequest(http.MethodGet, "https://chatgpt.com", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest returned error: %v", err)
+	}
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip returned error: %v", err)
+	}
+	if got := base.closeCalls.Load(); got != 0 {
+		t.Fatalf("close calls before body close = %d, want 0", got)
+	}
+	if errClose := resp.Body.Close(); errClose != nil {
+		t.Fatalf("response body close returned error: %v", errClose)
+	}
+	if errClose := resp.Body.Close(); errClose != nil {
+		t.Fatalf("second response body close returned error: %v", errClose)
+	}
+	if got := base.closeCalls.Load(); got != 1 {
+		t.Fatalf("close calls after body close = %d, want 1", got)
+	}
+}
+
+func TestCloseOwnedTransportRoundTripperClosesAfterRoundTripError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("dial failed")
+	base := &closeTrackingRoundTripper{err: wantErr}
+	transport := &closeOwnedTransportRoundTripper{base: base}
+	req, err := http.NewRequest(http.MethodGet, "https://chatgpt.com", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest returned error: %v", err)
+	}
+	if _, err = transport.RoundTrip(req); !errors.Is(err, wantErr) {
+		t.Fatalf("RoundTrip error = %v, want %v", err, wantErr)
+	}
+	if got := base.closeCalls.Load(); got != 1 {
+		t.Fatalf("close calls after RoundTrip error = %d, want 1", got)
+	}
+}
+
+func TestCloseOwnedTransportRoundTripperClosesEveryTrackedResponse(t *testing.T) {
+	t.Parallel()
+
+	const requestCount = 25
+	base := &closeTrackingRoundTripper{}
+	base.response = &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+	}
+	transport := usageTTFTRoundTripper{
+		base:     &closeOwnedTransportRoundTripper{base: base},
+		reporter: &UsageReporter{},
+	}
+
+	for i := 0; i < requestCount; i++ {
+		base.response.Body = io.NopCloser(strings.NewReader("{}"))
+		req, err := http.NewRequest(http.MethodGet, "https://chatgpt.com", nil)
+		if err != nil {
+			t.Fatalf("request %d: http.NewRequest returned error: %v", i, err)
+		}
+		resp, err := transport.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("request %d: RoundTrip returned error: %v", i, err)
+		}
+		if _, err = io.ReadAll(resp.Body); err != nil {
+			t.Fatalf("request %d: read response body: %v", i, err)
+		}
+		if err = resp.Body.Close(); err != nil {
+			t.Fatalf("request %d: close response body: %v", i, err)
+		}
+	}
+
+	if got := base.closeCalls.Load(); got != requestCount {
+		t.Fatalf("close calls = %d, want %d", got, requestCount)
 	}
 }


### PR DESCRIPTION
## Problem

`NewUtlsHTTPClient` builds a **new** `http.Client` per request (8 call sites: `claude_executor.go:194,310,499,755`, `codex_executor.go:808,891,1067,1183`). Its roundtripper hand-builds an HTTP/2 connection with `tr.NewClientConn(tlsConn)` (`utls_client.go:97`), which bypasses `http2.Transport`'s own pool — so nothing ever owns or closes it.

The result is roughly **one leaked ESTABLISHED socket per request** to the protected hosts. Nothing reuses the connection (the client is per-request) and nothing closes it (there is no `CloseIdleConnections` on `utlsRoundTripper`, and the RoundTrip error path at `:121-125` only `delete`s the map entry without closing).

Measured on a busy deployment: the process climbed to **9733 fd / 3.47 GB RSS over ~3h**. With this patch it stays flat at **44–64 fd / ~300 MB** under the same load.

Worth noting: fixing only the "replace a stale connection" branch in `getOrCreateConnection` (`:49-78`) does **not** help — on a per-request client that map is always empty, so that branch is dead code in practice. The leak has to be fixed by giving the connection an owner.

## Approach

Tie the connection's lifetime to the response body, which is the one thing whose lifetime already matches the request:

- `closeOwnedTransportRoundTripper` wraps the per-request transport and reclaims it when `resp.Body.Close()` runs (and immediately on a RoundTrip error, where there is no body to tie to).
- `utlsRoundTripper.CloseIdleConnections()` closes the pooled connections.
- `shutdownUtlsConnection` drains gracefully, then closes.
- The stale-connection replace path and the RoundTrip error path now close the connection they drop.
- A RoundTripper injected through the context is **not** owned, so it is never closed by this wrapper.

### Relation to #3861

#3861 reported the same leak and fixed it by globally caching roundtrippers keyed by proxy URL. The review objection there was that the cache is unbounded with no eviction, and the PR was closed.

This patch takes the opposite approach — **ownership instead of caching**. There is no global state and no cache to bound: each request's transport is reclaimed deterministically when its body closes. It fixes correctness first; connection *reuse* can be layered on later as a separate optimization if desired.

### On `AGENTS.md`'s timeout rule

`AGENTS.md` says not to set timeouts on network behaviour after an upstream connection is established. The 30s bound in `shutdownUtlsConnection` is not that: it applies only to the graceful drain of a connection whose request has **already finished**, and it falls back to an unconditional `Close()`. It never constrains in-flight request/response traffic. Happy to drop it to a bare `Close()` if you'd prefer to avoid the ambiguity entirely.

## Testing

`utls_client_test.go` adds coverage for: reclaim-once on body close (idempotent across a double `Close()`), reclaim on RoundTrip error, and that a ctx-injected shared RoundTripper is left alone.

- `go build ./...` — OK
- `gofmt -l` / `go vet` — clean
- `go test ./internal/runtime/executor/helps/` — **5/5 pass** (4 new + the existing ctx-roundtripper test)

Branched from and verified against `dev`.