### PR TITLE
Bound proxy connection timeout

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -488,6 +488,7 @@ func main() {
 	redisqueue.SetRetentionSeconds(cfg.RedisUsageQueueRetentionSeconds)
 	coreauth.SetQuotaCooldownDisabled(cfg.DisableCooling)
 	coreauth.SetRateLimitDefaults(cfg.RPMLimitDefault, cfg.TPMLimitDefault, cfg.ConcurrencyLimitDefault)
+	coreauth.SetClaudeUsageLimitThreshold(cfg.ClaudeUsageLimitThreshold)
 
 	if err = logging.ConfigureLogOutput(cfg); err != nil {
 		log.Errorf("failed to configure log output: %v", err)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -487,7 +487,7 @@ func main() {
 	redisqueue.SetUsageStatisticsEnabled(cfg.UsageStatisticsEnabled)
 	redisqueue.SetRetentionSeconds(cfg.RedisUsageQueueRetentionSeconds)
 	coreauth.SetQuotaCooldownDisabled(cfg.DisableCooling)
-	coreauth.SetRateLimitDefaults(cfg.RPMLimitDefault, cfg.TPMLimitDefault, cfg.ConcurrencyLimitDefault)
+	coreauth.SetRateLimitDefaults(cfg.RPMLimitDefault, cfg.TPMLimitDefault, cfg.ConcurrencyLimitDefault, cfg.RPHLimitDefault)
 	coreauth.SetClaudeUsageLimitThreshold(cfg.ClaudeUsageLimitThreshold)
 
 	if err = logging.ConfigureLogOutput(cfg); err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -487,6 +487,7 @@ func main() {
 	redisqueue.SetUsageStatisticsEnabled(cfg.UsageStatisticsEnabled)
 	redisqueue.SetRetentionSeconds(cfg.RedisUsageQueueRetentionSeconds)
 	coreauth.SetQuotaCooldownDisabled(cfg.DisableCooling)
+	coreauth.SetRateLimitDefaults(cfg.RPMLimitDefault, cfg.TPMLimitDefault, cfg.ConcurrencyLimitDefault)
 
 	if err = logging.ConfigureLogOutput(cfg); err != nil {
 		log.Errorf("failed to configure log output: %v", err)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -98,15 +98,18 @@ disable-cooling: false
 # Proactive per-account rate limiting (anti-abuse / reduces upstream ban risk).
 # These are GLOBAL DEFAULTS applied to every credential; set 0 to disable a dimension.
 # Each account can override any of them via its auth-file metadata keys
-# "rpm_limit" / "tpm_limit" / "concurrency_limit" (editable through the management API/WebUI).
+# "rpm_limit" / "tpm_limit" / "concurrency_limit" / "rph_limit"
+# (editable through the management API/WebUI).
 # When a credential is over budget it is skipped and the request fails over to another
 # credential; if no credential is available the client receives 429 with Retry-After.
 # - rpm-limit-default: max requests per 60s window per account (0 = unlimited).
 # - tpm-limit-default: max tokens per 60s window per account (0 = unlimited).
 # - concurrency-limit-default: max simultaneous in-flight requests per account (0 = unlimited).
+# - rph-limit-default: max requests per trailing 1-hour window per account (0 = unlimited).
 rpm-limit-default: 0
 tpm-limit-default: 0
 concurrency-limit-default: 0
+rph-limit-default: 0
 
 # Claude rolling usage-window avoidance (Max/subscription "unified" limits).
 # Anthropic returns per-response headers exposing the rolling 5-hour and 7-day

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -95,6 +95,19 @@ max-retry-interval: 30
 # When true, disable auth/model cooldown scheduling globally (prevents blackout windows after failure states).
 disable-cooling: false
 
+# Proactive per-account rate limiting (anti-abuse / reduces upstream ban risk).
+# These are GLOBAL DEFAULTS applied to every credential; set 0 to disable a dimension.
+# Each account can override any of them via its auth-file metadata keys
+# "rpm_limit" / "tpm_limit" / "concurrency_limit" (editable through the management API/WebUI).
+# When a credential is over budget it is skipped and the request fails over to another
+# credential; if no credential is available the client receives 429 with Retry-After.
+# - rpm-limit-default: max requests per 60s window per account (0 = unlimited).
+# - tpm-limit-default: max tokens per 60s window per account (0 = unlimited).
+# - concurrency-limit-default: max simultaneous in-flight requests per account (0 = unlimited).
+rpm-limit-default: 0
+tpm-limit-default: 0
+concurrency-limit-default: 0
+
 # disable-image-generation supports: false (default), true, or "chat".
 # - true: disable image_generation everywhere (also returns 404 for /v1/images/generations and /v1/images/edits).
 # - "chat": disable image_generation injection on non-images endpoints, but keep /v1/images/generations and /v1/images/edits enabled.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -108,6 +108,15 @@ rpm-limit-default: 0
 tpm-limit-default: 0
 concurrency-limit-default: 0
 
+# Claude rolling usage-window avoidance (Max/subscription "unified" limits).
+# Anthropic returns per-response headers exposing the rolling 5-hour and 7-day
+# usage windows. When an account's window utilization reaches this fraction (0..1),
+# the proxy stops routing to that account until the window resets, failing over to
+# other accounts so the hard limit is not tripped. A hard "rejected" status always
+# parks the account regardless of this value. Default 0.85 (= stop at 85%);
+# set 0 to disable proactive avoidance (only react to a hard rejection).
+claude-usage-limit-threshold: 0.85
+
 # disable-image-generation supports: false (default), true, or "chat".
 # - true: disable image_generation everywhere (also returns 404 for /v1/images/generations and /v1/images/edits).
 # - "chat": disable image_generation injection on non-images endpoints, but keep /v1/images/generations and /v1/images/edits enabled.

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -262,8 +262,181 @@ func (h *Handler) resolveTokenForAuth(ctx context.Context, auth *coreauth.Auth) 
 		token, errToken := h.refreshAntigravityOAuthAccessToken(ctx, auth)
 		return token, errToken
 	}
+	if shouldRefreshAPICallOAuthToken(auth) {
+		refreshed, errRefresh := h.refreshManagedOAuthAuth(ctx, auth)
+		if errRefresh != nil {
+			return "", errRefresh
+		}
+		if refreshed != nil {
+			auth = refreshed
+		}
+	}
 
 	return tokenValueForAuth(auth), nil
+}
+
+func shouldRefreshAPICallOAuthToken(auth *coreauth.Auth) bool {
+	if auth == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(auth.Provider)) {
+	case "claude", "codex", "kimi", "xai":
+	default:
+		return false
+	}
+	if refreshTokenValueForAuth(auth) == "" {
+		return false
+	}
+	if tokenValueForAuth(auth) == "" {
+		return true
+	}
+	expiry, ok := authTokenExpiry(auth.Metadata)
+	if !ok {
+		return false
+	}
+	const refreshSkew = 2 * time.Minute
+	return !expiry.After(time.Now().Add(refreshSkew))
+}
+
+func (h *Handler) refreshManagedOAuthAuth(ctx context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	if h == nil || h.authManager == nil || auth == nil {
+		return auth, nil
+	}
+	exec, ok := h.authManager.Executor(auth.Provider)
+	if !ok || exec == nil {
+		return auth, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	refreshCtx, cancel := context.WithTimeout(ctx, defaultAPICallTimeout)
+	defer cancel()
+
+	cloned := auth.Clone()
+	refreshed, errRefresh := exec.Refresh(refreshCtx, cloned)
+	if errRefresh != nil {
+		return nil, errRefresh
+	}
+	if refreshed == nil {
+		refreshed = cloned
+	}
+	if refreshed == nil {
+		return auth, nil
+	}
+	if strings.TrimSpace(refreshed.ID) == "" {
+		refreshed.ID = auth.ID
+	}
+	if strings.TrimSpace(refreshed.FileName) == "" {
+		refreshed.FileName = auth.FileName
+	}
+	if refreshed.Runtime == nil {
+		refreshed.Runtime = auth.Runtime
+	}
+	now := time.Now()
+	refreshed.LastRefreshedAt = now
+	refreshed.NextRefreshAfter = time.Time{}
+	refreshed.LastError = nil
+	refreshed.UpdatedAt = now
+
+	updated, errUpdate := h.authManager.Update(ctx, refreshed)
+	if errUpdate != nil {
+		return nil, errUpdate
+	}
+	if updated != nil {
+		return updated, nil
+	}
+	return refreshed, nil
+}
+
+func refreshTokenValueForAuth(auth *coreauth.Auth) string {
+	if auth == nil || len(auth.Metadata) == 0 {
+		return ""
+	}
+	if v := stringValue(auth.Metadata, "refresh_token"); v != "" {
+		return v
+	}
+	if tokenRaw, ok := auth.Metadata["token"]; ok && tokenRaw != nil {
+		switch typed := tokenRaw.(type) {
+		case map[string]any:
+			if v, ok := typed["refresh_token"].(string); ok && strings.TrimSpace(v) != "" {
+				return strings.TrimSpace(v)
+			}
+		case map[string]string:
+			if v := strings.TrimSpace(typed["refresh_token"]); v != "" {
+				return v
+			}
+		}
+	}
+	return ""
+}
+
+func authTokenExpiry(metadata map[string]any) (time.Time, bool) {
+	if len(metadata) == 0 {
+		return time.Time{}, false
+	}
+	for _, key := range []string{"expired", "expiry", "expires_at", "expiresAt", "expires", "expiration"} {
+		if ts, ok := parseAPICallTokenExpiry(metadata[key]); ok {
+			return ts, true
+		}
+	}
+	if tokenRaw, ok := metadata["token"]; ok && tokenRaw != nil {
+		switch typed := tokenRaw.(type) {
+		case map[string]any:
+			for _, key := range []string{"expiry", "expired", "expires_at", "expiresAt", "expires", "expiration"} {
+				if ts, ok := parseAPICallTokenExpiry(typed[key]); ok {
+					return ts, true
+				}
+			}
+		case map[string]string:
+			for _, key := range []string{"expiry", "expired", "expires_at", "expiresAt", "expires", "expiration"} {
+				if ts, ok := parseAPICallTokenExpiry(typed[key]); ok {
+					return ts, true
+				}
+			}
+		}
+	}
+	expiresIn := int64Value(metadata["expires_in"])
+	timestampMs := int64Value(metadata["timestamp"])
+	if expiresIn > 0 && timestampMs > 0 {
+		return time.UnixMilli(timestampMs).Add(time.Duration(expiresIn) * time.Second), true
+	}
+	return time.Time{}, false
+}
+
+func parseAPICallTokenExpiry(raw any) (time.Time, bool) {
+	switch typed := raw.(type) {
+	case time.Time:
+		if !typed.IsZero() {
+			return typed, true
+		}
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if trimmed == "" {
+			return time.Time{}, false
+		}
+		if ts, errParse := time.Parse(time.RFC3339, trimmed); errParse == nil {
+			return ts, true
+		}
+		if ts, errParse := time.Parse(time.RFC3339Nano, trimmed); errParse == nil {
+			return ts, true
+		}
+		if seconds, errParse := json.Number(trimmed).Int64(); errParse == nil {
+			return unixTimeFromExpiryNumber(seconds), true
+		}
+	case int, int32, int64, uint, uint32, uint64, float32, float64, json.Number:
+		value := int64Value(typed)
+		if value > 0 {
+			return unixTimeFromExpiryNumber(value), true
+		}
+	}
+	return time.Time{}, false
+}
+
+func unixTimeFromExpiryNumber(value int64) time.Time {
+	if value > 1_000_000_000_000 {
+		return time.UnixMilli(value)
+	}
+	return time.Unix(value, 0)
 }
 
 func (h *Handler) refreshGeminiOAuthAccessToken(ctx context.Context, auth *coreauth.Auth) (string, error) {

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
 
@@ -209,4 +211,125 @@ func TestAuthByIndexDistinguishesSharedAPIKeysAcrossProviders(t *testing.T) {
 	if gotCompat.ID != compatAuth.ID {
 		t.Fatalf("authByIndex(compat) returned %q, want %q", gotCompat.ID, compatAuth.ID)
 	}
+}
+
+func TestResolveTokenForAuthRefreshesExpiredManagedOAuthToken(t *testing.T) {
+	t.Parallel()
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	expiredAt := time.Now().Add(-time.Minute).UTC()
+	auth := &coreauth.Auth{
+		ID:       "codex-expired",
+		FileName: "codex-expired.json",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"type":          "codex",
+			"access_token":  "old-token",
+			"refresh_token": "refresh-token",
+			"expired":       expiredAt.Format(time.RFC3339),
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	refreshed := auth.Clone()
+	refreshed.Metadata["access_token"] = "new-token"
+	refreshed.Metadata["expired"] = time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	executor := &apiCallRefreshTestExecutor{provider: "codex", refreshed: refreshed}
+	manager.RegisterExecutor(executor)
+
+	h := &Handler{authManager: manager}
+	token, errToken := h.resolveTokenForAuth(context.Background(), h.authByIndex(auth.EnsureIndex()))
+	if errToken != nil {
+		t.Fatalf("resolveTokenForAuth returned error: %v", errToken)
+	}
+	if token != "new-token" {
+		t.Fatalf("token = %q, want new-token", token)
+	}
+	if executor.calls != 1 {
+		t.Fatalf("refresh calls = %d, want 1", executor.calls)
+	}
+
+	stored, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("expected refreshed auth to be stored")
+	}
+	if got := tokenValueForAuth(stored); got != "new-token" {
+		t.Fatalf("stored token = %q, want new-token", got)
+	}
+	if stored.LastRefreshedAt.IsZero() {
+		t.Fatal("expected LastRefreshedAt to be updated")
+	}
+}
+
+func TestResolveTokenForAuthSkipsFreshManagedOAuthTokenRefresh(t *testing.T) {
+	t.Parallel()
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	auth := &coreauth.Auth{
+		ID:       "claude-fresh",
+		FileName: "claude-fresh.json",
+		Provider: "claude",
+		Metadata: map[string]any{
+			"type":          "claude",
+			"access_token":  "fresh-token",
+			"refresh_token": "refresh-token",
+			"expired":       time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	refreshed := auth.Clone()
+	refreshed.Metadata["access_token"] = "unexpected-token"
+	executor := &apiCallRefreshTestExecutor{provider: "claude", refreshed: refreshed}
+	manager.RegisterExecutor(executor)
+
+	h := &Handler{authManager: manager}
+	token, errToken := h.resolveTokenForAuth(context.Background(), h.authByIndex(auth.EnsureIndex()))
+	if errToken != nil {
+		t.Fatalf("resolveTokenForAuth returned error: %v", errToken)
+	}
+	if token != "fresh-token" {
+		t.Fatalf("token = %q, want fresh-token", token)
+	}
+	if executor.calls != 0 {
+		t.Fatalf("refresh calls = %d, want 0", executor.calls)
+	}
+}
+
+type apiCallRefreshTestExecutor struct {
+	provider  string
+	refreshed *coreauth.Auth
+	calls     int
+}
+
+func (e *apiCallRefreshTestExecutor) Identifier() string {
+	return e.provider
+}
+
+func (e *apiCallRefreshTestExecutor) Execute(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *apiCallRefreshTestExecutor) ExecuteStream(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+
+func (e *apiCallRefreshTestExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	e.calls++
+	if e.refreshed != nil {
+		return e.refreshed.Clone(), nil
+	}
+	return auth, nil
+}
+
+func (e *apiCallRefreshTestExecutor) CountTokens(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *apiCallRefreshTestExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
 }

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -334,7 +334,12 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 			continue
 		}
 		if info, errInfo := e.Info(); errInfo == nil {
-			fileData := gin.H{"name": name, "size": info.Size(), "modtime": info.ModTime()}
+			fileData := gin.H{
+				"name":       name,
+				"size":       info.Size(),
+				"modtime":    info.ModTime(),
+				"created_at": info.ModTime(),
+			}
 
 			// Read file to get type field
 			full := filepath.Join(h.cfg.AuthDir, name)
@@ -442,6 +447,55 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 	}
 	if !auth.NextRetryAfter.IsZero() {
 		entry["next_retry_after"] = auth.NextRetryAfter
+	}
+	// Surface the last error so operators can see *what* went wrong, not just
+	// that the auth is in an error state.
+	if auth.LastError != nil {
+		entry["last_error"] = gin.H{
+			"code":        auth.LastError.Code,
+			"message":     auth.LastError.Message,
+			"retryable":   auth.LastError.Retryable,
+			"http_status": auth.LastError.HTTPStatus,
+		}
+	}
+	// Surface quota/rate-limit cooldown state for visibility.
+	if auth.Quota.Exceeded || auth.Quota.Reason != "" || !auth.Quota.NextRecoverAt.IsZero() {
+		quota := gin.H{
+			"exceeded":      auth.Quota.Exceeded,
+			"backoff_level": auth.Quota.BackoffLevel,
+		}
+		if auth.Quota.Reason != "" {
+			quota["reason"] = auth.Quota.Reason
+		}
+		if !auth.Quota.NextRecoverAt.IsZero() {
+			quota["next_recover_at"] = auth.Quota.NextRecoverAt
+		}
+		entry["quota"] = quota
+	}
+	// Surface the Claude usage-window (5h/7d) park time when active.
+	if until := auth.UsageLimitUntil(); !until.IsZero() {
+		entry["usage_limit_until"] = until
+	}
+	// Surface effective per-account RPM/TPM/concurrency/RPH limits and current usage.
+	if rl := auth.RateLimitSnapshot(time.Now()); rl.HasData() {
+		entry["rate_limit"] = gin.H{
+			"rpm_limit":         rl.RPMLimit,
+			"tpm_limit":         rl.TPMLimit,
+			"concurrency_limit": rl.ConcurrencyLimit,
+			"rph_limit":         rl.RPHLimit,
+			"rpm_current":       rl.RPMCurrent,
+			"tpm_current":       rl.TPMCurrent,
+			"rph_current":       rl.RPHCurrent,
+			"in_flight":         rl.InFlight,
+		}
+	}
+	// Surface recent warnings (what/when/how-many) so operators can diagnose
+	// flapping credentials without grepping ephemeral logs.
+	if warnings, total := auth.WarningsSnapshot(); total > 0 {
+		entry["warning_count"] = total
+		if len(warnings) > 0 {
+			entry["warnings"] = warnings
+		}
 	}
 	if path != "" {
 		entry["path"] = path

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -129,6 +129,15 @@ func isWebUIRequest(c *gin.Context) bool {
 	}
 }
 
+// parseRequestedProxyURL extracts an optional per-account proxy URL from the
+// "proxy_url" query parameter of the OAuth-start request. Returns an empty
+// string when none is supplied, in which case the global proxy-url (if any)
+// is used. The OAuth-start routes are registered as GET so only the query
+// parameter form is supported.
+func parseRequestedProxyURL(c *gin.Context) string {
+	return strings.TrimSpace(c.Query("proxy_url"))
+}
+
 func startCallbackForwarder(port int, provider, targetBase string) (*callbackForwarder, error) {
 	callbackForwardersMu.Lock()
 	prev := callbackForwarders[port]
@@ -1637,6 +1646,11 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 
 	fmt.Println("Initializing Claude authentication...")
 
+	// Optional per-account proxy: bind this account to a dedicated proxy/egress IP
+	// before authentication. When provided, the token exchange and all subsequent
+	// API traffic for this account go through this proxy (falls back to global proxy-url).
+	proxyURL := parseRequestedProxyURL(c)
+
 	// Generate PKCE codes
 	pkceCodes, err := claude.GeneratePKCECodes()
 	if err != nil {
@@ -1653,8 +1667,9 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 		return
 	}
 
-	// Initialize Claude auth service
-	anthropicAuth := claude.NewClaudeAuth(h.cfg)
+	// Initialize Claude auth service (proxy-aware so the code-for-token exchange
+	// is performed through the requested proxy when set).
+	anthropicAuth := claude.NewClaudeAuthWithProxyURL(h.cfg, proxyURL)
 
 	// Generate authorization URL (then override redirect_uri to reuse server port)
 	authURL, state, err := anthropicAuth.GenerateAuthURL(state, pkceCodes)
@@ -1750,12 +1765,19 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 
 		// Create token storage
 		tokenStorage := anthropicAuth.CreateTokenStorage(bundle)
+		metadata := map[string]any{"email": tokenStorage.Email}
+		// Persist the per-account proxy into metadata so the synthesizer restores
+		// auth.ProxyURL on reload, keeping the account bound to this proxy/IP.
+		if proxyURL != "" {
+			metadata["proxy_url"] = proxyURL
+		}
 		record := &coreauth.Auth{
 			ID:       fmt.Sprintf("claude-%s.json", tokenStorage.Email),
 			Provider: "claude",
 			FileName: fmt.Sprintf("claude-%s.json", tokenStorage.Email),
 			Storage:  tokenStorage,
-			Metadata: map[string]any{"email": tokenStorage.Email},
+			ProxyURL: proxyURL,
+			Metadata: metadata,
 		}
 		savedPath, errSave := h.saveTokenRecord(ctx, record)
 		if errSave != nil {

--- a/internal/api/handlers/management/auth_files_project_id_test.go
+++ b/internal/api/handlers/management/auth_files_project_id_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -31,6 +32,9 @@ func TestListAuthFiles_IncludesProjectIDFromManager(t *testing.T) {
 		FileName: fileName,
 		Provider: "gemini-cli",
 		Status:   coreauth.StatusActive,
+		CreatedAt: time.Date(
+			2026, time.May, 31, 12, 0, 0, 0, time.UTC,
+		),
 		Attributes: map[string]string{
 			"path": filePath,
 		},
@@ -51,6 +55,9 @@ func TestListAuthFiles_IncludesProjectIDFromManager(t *testing.T) {
 	if got := entry["project_id"]; got != "project-a" {
 		t.Fatalf("expected project_id %q, got %#v", "project-a", got)
 	}
+	if _, ok := entry["created_at"].(string); !ok {
+		t.Fatalf("expected created_at timestamp string, got %#v", entry["created_at"])
+	}
 }
 
 func TestListAuthFilesFromDisk_IncludesProjectID(t *testing.T) {
@@ -68,6 +75,9 @@ func TestListAuthFilesFromDisk_IncludesProjectID(t *testing.T) {
 	entry := firstAuthFileEntry(t, h)
 	if got := entry["project_id"]; got != "project-a" {
 		t.Fatalf("expected project_id %q, got %#v", "project-a", got)
+	}
+	if _, ok := entry["created_at"].(string); !ok {
+		t.Fatalf("expected created_at timestamp string, got %#v", entry["created_at"])
 	}
 }
 

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -263,12 +263,49 @@ func (h *Handler) PutRequestRetry(c *gin.Context) {
 	h.updateIntField(c, func(v int) { h.cfg.RequestRetry = v })
 }
 
+// Max retry credentials
+func (h *Handler) GetMaxRetryCredentials(c *gin.Context) {
+	c.JSON(200, gin.H{"max-retry-credentials": h.cfg.MaxRetryCredentials})
+}
+func (h *Handler) PutMaxRetryCredentials(c *gin.Context) {
+	h.updateIntField(c, func(v int) { h.cfg.MaxRetryCredentials = v })
+}
+
 // Max retry interval
 func (h *Handler) GetMaxRetryInterval(c *gin.Context) {
 	c.JSON(200, gin.H{"max-retry-interval": h.cfg.MaxRetryInterval})
 }
 func (h *Handler) PutMaxRetryInterval(c *gin.Context) {
 	h.updateIntField(c, func(v int) { h.cfg.MaxRetryInterval = v })
+}
+
+// Rate limit defaults
+func (h *Handler) GetRPMLimitDefault(c *gin.Context) {
+	c.JSON(200, gin.H{"rpm-limit-default": h.cfg.RPMLimitDefault})
+}
+func (h *Handler) PutRPMLimitDefault(c *gin.Context) {
+	h.updateIntField(c, func(v int) { h.cfg.RPMLimitDefault = v })
+}
+
+func (h *Handler) GetTPMLimitDefault(c *gin.Context) {
+	c.JSON(200, gin.H{"tpm-limit-default": h.cfg.TPMLimitDefault})
+}
+func (h *Handler) PutTPMLimitDefault(c *gin.Context) {
+	h.updateIntField(c, func(v int) { h.cfg.TPMLimitDefault = v })
+}
+
+func (h *Handler) GetConcurrencyLimitDefault(c *gin.Context) {
+	c.JSON(200, gin.H{"concurrency-limit-default": h.cfg.ConcurrencyLimitDefault})
+}
+func (h *Handler) PutConcurrencyLimitDefault(c *gin.Context) {
+	h.updateIntField(c, func(v int) { h.cfg.ConcurrencyLimitDefault = v })
+}
+
+func (h *Handler) GetRPHLimitDefault(c *gin.Context) {
+	c.JSON(200, gin.H{"rph-limit-default": h.cfg.RPHLimitDefault})
+}
+func (h *Handler) PutRPHLimitDefault(c *gin.Context) {
+	h.updateIntField(c, func(v int) { h.cfg.RPHLimitDefault = v })
 }
 
 // ForceModelPrefix

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1395,6 +1395,12 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 		auth.SetQuotaCooldownDisabled(cfg.DisableCooling)
 	}
 
+	if oldCfg == nil || oldCfg.RPMLimitDefault != cfg.RPMLimitDefault ||
+		oldCfg.TPMLimitDefault != cfg.TPMLimitDefault ||
+		oldCfg.ConcurrencyLimitDefault != cfg.ConcurrencyLimitDefault {
+		auth.SetRateLimitDefaults(cfg.RPMLimitDefault, cfg.TPMLimitDefault, cfg.ConcurrencyLimitDefault)
+	}
+
 	if oldCfg != nil && oldCfg.DisableImageGeneration != cfg.DisableImageGeneration {
 		log.Infof("disable-image-generation updated: %v -> %v", oldCfg.DisableImageGeneration, cfg.DisableImageGeneration)
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1401,6 +1401,10 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 		auth.SetRateLimitDefaults(cfg.RPMLimitDefault, cfg.TPMLimitDefault, cfg.ConcurrencyLimitDefault)
 	}
 
+	if oldCfg == nil || oldCfg.ClaudeUsageLimitThreshold != cfg.ClaudeUsageLimitThreshold {
+		auth.SetClaudeUsageLimitThreshold(cfg.ClaudeUsageLimitThreshold)
+	}
+
 	if oldCfg != nil && oldCfg.DisableImageGeneration != cfg.DisableImageGeneration {
 		log.Infof("disable-image-generation updated: %v -> %v", oldCfg.DisableImageGeneration, cfg.DisableImageGeneration)
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -647,9 +647,25 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/request-retry", s.mgmt.GetRequestRetry)
 		mgmt.PUT("/request-retry", s.mgmt.PutRequestRetry)
 		mgmt.PATCH("/request-retry", s.mgmt.PutRequestRetry)
+		mgmt.GET("/max-retry-credentials", s.mgmt.GetMaxRetryCredentials)
+		mgmt.PUT("/max-retry-credentials", s.mgmt.PutMaxRetryCredentials)
+		mgmt.PATCH("/max-retry-credentials", s.mgmt.PutMaxRetryCredentials)
 		mgmt.GET("/max-retry-interval", s.mgmt.GetMaxRetryInterval)
 		mgmt.PUT("/max-retry-interval", s.mgmt.PutMaxRetryInterval)
 		mgmt.PATCH("/max-retry-interval", s.mgmt.PutMaxRetryInterval)
+
+		mgmt.GET("/rpm-limit-default", s.mgmt.GetRPMLimitDefault)
+		mgmt.PUT("/rpm-limit-default", s.mgmt.PutRPMLimitDefault)
+		mgmt.PATCH("/rpm-limit-default", s.mgmt.PutRPMLimitDefault)
+		mgmt.GET("/tpm-limit-default", s.mgmt.GetTPMLimitDefault)
+		mgmt.PUT("/tpm-limit-default", s.mgmt.PutTPMLimitDefault)
+		mgmt.PATCH("/tpm-limit-default", s.mgmt.PutTPMLimitDefault)
+		mgmt.GET("/concurrency-limit-default", s.mgmt.GetConcurrencyLimitDefault)
+		mgmt.PUT("/concurrency-limit-default", s.mgmt.PutConcurrencyLimitDefault)
+		mgmt.PATCH("/concurrency-limit-default", s.mgmt.PutConcurrencyLimitDefault)
+		mgmt.GET("/rph-limit-default", s.mgmt.GetRPHLimitDefault)
+		mgmt.PUT("/rph-limit-default", s.mgmt.PutRPHLimitDefault)
+		mgmt.PATCH("/rph-limit-default", s.mgmt.PutRPHLimitDefault)
 
 		mgmt.GET("/force-model-prefix", s.mgmt.GetForceModelPrefix)
 		mgmt.PUT("/force-model-prefix", s.mgmt.PutForceModelPrefix)
@@ -1397,8 +1413,9 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 
 	if oldCfg == nil || oldCfg.RPMLimitDefault != cfg.RPMLimitDefault ||
 		oldCfg.TPMLimitDefault != cfg.TPMLimitDefault ||
-		oldCfg.ConcurrencyLimitDefault != cfg.ConcurrencyLimitDefault {
-		auth.SetRateLimitDefaults(cfg.RPMLimitDefault, cfg.TPMLimitDefault, cfg.ConcurrencyLimitDefault)
+		oldCfg.ConcurrencyLimitDefault != cfg.ConcurrencyLimitDefault ||
+		oldCfg.RPHLimitDefault != cfg.RPHLimitDefault {
+		auth.SetRateLimitDefaults(cfg.RPMLimitDefault, cfg.TPMLimitDefault, cfg.ConcurrencyLimitDefault, cfg.RPHLimitDefault)
 	}
 
 	if oldCfg == nil || oldCfg.ClaudeUsageLimitThreshold != cfg.ClaudeUsageLimitThreshold {

--- a/internal/auth/claude/utls_transport.go
+++ b/internal/auth/claude/utls_transport.go
@@ -34,7 +34,12 @@ func newUtlsRoundTripper(cfg *config.SDKConfig) *utlsRoundTripper {
 	if cfg != nil {
 		proxyDialer, mode, errBuild := proxyutil.BuildDialer(cfg.ProxyURL)
 		if errBuild != nil {
+			// Fail closed: a proxy was requested but unparseable. Returning a
+			// dialer that always errors prevents the round tripper from silently
+			// leaking traffic over the host network and exposing the account's
+			// real IP.
 			log.Errorf("failed to configure proxy dialer for %q: %v", proxyutil.Redact(cfg.ProxyURL), errBuild)
+			dialer = proxyutil.FailClosedDialer{Err: errBuild}
 		} else if mode != proxyutil.ModeInherit && proxyDialer != nil {
 			dialer = proxyDialer
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,11 @@ type Config struct {
 	// ConcurrencyLimitDefault sets the default per-account maximum in-flight requests
 	// applied to every credential that does not override it. 0 (default) disables it.
 	ConcurrencyLimitDefault int `yaml:"concurrency-limit-default" json:"concurrency-limit-default"`
+	// ClaudeUsageLimitThreshold is the utilization fraction (0..1) of a Claude
+	// rolling usage window (5h/7d) at which an account is parked until that window
+	// resets, to avoid tripping the hard limit. Default 0.85; 0 disables proactive
+	// avoidance (only a hard "rejected" status parks the account).
+	ClaudeUsageLimitThreshold float64 `yaml:"claude-usage-limit-threshold" json:"claude-usage-limit-threshold"`
 
 	// QuotaExceeded defines the behavior when a quota is exceeded.
 	QuotaExceeded QuotaExceeded `yaml:"quota-exceeded" json:"quota-exceeded"`
@@ -654,6 +659,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.RPMLimitDefault = 0
 	cfg.TPMLimitDefault = 0
 	cfg.ConcurrencyLimitDefault = 0
+	cfg.ClaudeUsageLimitThreshold = 0.85
 	cfg.DisableImageGeneration = DisableImageGenerationOff
 	cfg.Pprof.Enable = false
 	cfg.Pprof.Addr = DefaultPprofAddr

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,9 @@ type Config struct {
 	// ConcurrencyLimitDefault sets the default per-account maximum in-flight requests
 	// applied to every credential that does not override it. 0 (default) disables it.
 	ConcurrencyLimitDefault int `yaml:"concurrency-limit-default" json:"concurrency-limit-default"`
+	// RPHLimitDefault sets the default per-account requests-per-hour limit applied
+	// to every credential that does not override it. 0 (default) disables RPH limiting.
+	RPHLimitDefault int `yaml:"rph-limit-default" json:"rph-limit-default"`
 	// ClaudeUsageLimitThreshold is the utilization fraction (0..1) of a Claude
 	// rolling usage window (5h/7d) at which an account is parked until that window
 	// resets, to avoid tripping the hard limit. Default 0.85; 0 disables proactive
@@ -659,6 +662,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.RPMLimitDefault = 0
 	cfg.TPMLimitDefault = 0
 	cfg.ConcurrencyLimitDefault = 0
+	cfg.RPHLimitDefault = 0
 	cfg.ClaudeUsageLimitThreshold = 0.85
 	cfg.DisableImageGeneration = DisableImageGenerationOff
 	cfg.Pprof.Enable = false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,6 +89,16 @@ type Config struct {
 	// MaxRetryInterval defines the maximum wait time in seconds before retrying a cooled-down credential.
 	MaxRetryInterval int `yaml:"max-retry-interval" json:"max-retry-interval"`
 
+	// RPMLimitDefault sets the default per-account requests-per-minute limit applied
+	// to every credential that does not override it. 0 (default) disables RPM limiting.
+	RPMLimitDefault int `yaml:"rpm-limit-default" json:"rpm-limit-default"`
+	// TPMLimitDefault sets the default per-account tokens-per-minute limit applied
+	// to every credential that does not override it. 0 (default) disables TPM limiting.
+	TPMLimitDefault int `yaml:"tpm-limit-default" json:"tpm-limit-default"`
+	// ConcurrencyLimitDefault sets the default per-account maximum in-flight requests
+	// applied to every credential that does not override it. 0 (default) disables it.
+	ConcurrencyLimitDefault int `yaml:"concurrency-limit-default" json:"concurrency-limit-default"`
+
 	// QuotaExceeded defines the behavior when a quota is exceeded.
 	QuotaExceeded QuotaExceeded `yaml:"quota-exceeded" json:"quota-exceeded"`
 
@@ -641,6 +651,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.UsageStatisticsEnabled = false
 	cfg.RedisUsageQueueRetentionSeconds = 60
 	cfg.DisableCooling = false
+	cfg.RPMLimitDefault = 0
+	cfg.TPMLimitDefault = 0
+	cfg.ConcurrencyLimitDefault = 0
 	cfg.DisableImageGeneration = DisableImageGenerationOff
 	cfg.Pprof.Enable = false
 	cfg.Pprof.Addr = DefaultPprofAddr

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -992,8 +992,15 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Runtime", "node")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Lang", "js")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Timeout", hdrDefault(hd.Timeout, "600"))
-	// Session ID: stable per auth/apiKey, matches Claude Code's X-Claude-Code-Session-Id header.
-	misc.EnsureHeader(r.Header, ginHeaders, "X-Claude-Code-Session-Id", helps.CachedSessionID(apiKey))
+	// Session ID: stable per (apiKey, proxyURL). Mixing the proxy URL into the
+	// cache key ensures an account rebound to a new egress IP rotates its
+	// session ID, so Anthropic never sees the same session ID arriving from
+	// two different IPs.
+	var sessionProxyURL string
+	if auth != nil {
+		sessionProxyURL = auth.ProxyURL
+	}
+	misc.EnsureHeader(r.Header, ginHeaders, "X-Claude-Code-Session-Id", helps.CachedSessionID(apiKey, sessionProxyURL))
 	// Per-request UUID, matches Claude Code's x-client-request-id for first-party API.
 	if isAnthropicBase {
 		misc.EnsureHeader(r.Header, ginHeaders, "x-client-request-id", uuid.New().String())

--- a/internal/runtime/executor/helps/session_id_cache.go
+++ b/internal/runtime/executor/helps/session_id_cache.go
@@ -46,20 +46,30 @@ func purgeExpiredSessionIDs() {
 	sessionIDCacheMu.Unlock()
 }
 
-func sessionIDCacheKey(apiKey string) string {
-	sum := sha256.Sum256([]byte(apiKey))
-	return hex.EncodeToString(sum[:])
+// sessionIDCacheKey derives a cache key from the downstream apiKey and the
+// per-account proxy URL. Mixing in the proxy URL ensures that an account
+// rebound to a different egress IP gets a fresh session ID, so Anthropic does
+// not see the same Claude Code session ID coming from two different IPs (which
+// can break session affinity or trigger anti-abuse heuristics).
+func sessionIDCacheKey(apiKey, proxyURL string) string {
+	h := sha256.New()
+	h.Write([]byte(apiKey))
+	h.Write([]byte{0}) // domain separator so apiKey + proxyURL cannot collide with another apiKey
+	h.Write([]byte(proxyURL))
+	return hex.EncodeToString(h.Sum(nil))
 }
 
-// CachedSessionID returns a stable session UUID per apiKey, refreshing the TTL on each access.
-func CachedSessionID(apiKey string) string {
+// CachedSessionID returns a stable session UUID per (apiKey, proxyURL),
+// refreshing the TTL on each access. Pass the empty string for proxyURL when
+// no per-account proxy is configured.
+func CachedSessionID(apiKey, proxyURL string) string {
 	if apiKey == "" {
 		return uuid.New().String()
 	}
 
 	sessionIDCacheCleanupOnce.Do(startSessionIDCacheCleanup)
 
-	key := sessionIDCacheKey(apiKey)
+	key := sessionIDCacheKey(apiKey, proxyURL)
 	now := time.Now()
 
 	sessionIDCacheMu.RLock()

--- a/internal/runtime/executor/helps/session_id_cache_test.go
+++ b/internal/runtime/executor/helps/session_id_cache_test.go
@@ -1,0 +1,45 @@
+package helps
+
+import "testing"
+
+// Same (apiKey, proxyURL) must return a stable session ID within the TTL.
+func TestCachedSessionID_StableForSameKeyAndProxy(t *testing.T) {
+	a := CachedSessionID("user-key-1", "socks5://proxy-A:1080")
+	b := CachedSessionID("user-key-1", "socks5://proxy-A:1080")
+	if a == "" || a != b {
+		t.Fatalf("expected stable session ID, got a=%q b=%q", a, b)
+	}
+}
+
+// Same apiKey but different proxy URLs must yield different session IDs so
+// Anthropic never sees the same Claude Code session ID arriving from two
+// different egress IPs.
+func TestCachedSessionID_RotatesOnProxyChange(t *testing.T) {
+	a := CachedSessionID("user-key-2", "socks5://proxy-A:1080")
+	b := CachedSessionID("user-key-2", "socks5://proxy-B:1080")
+	if a == "" || b == "" || a == b {
+		t.Fatalf("expected different session IDs for different proxies; got a=%q b=%q", a, b)
+	}
+}
+
+// The empty-proxy variant must be stable and distinct from any proxied variant.
+func TestCachedSessionID_EmptyProxyIsIsolated(t *testing.T) {
+	none1 := CachedSessionID("user-key-3", "")
+	none2 := CachedSessionID("user-key-3", "")
+	proxied := CachedSessionID("user-key-3", "http://proxy:8080")
+	if none1 == "" || none1 != none2 {
+		t.Fatalf("empty-proxy variant should be stable, got %q vs %q", none1, none2)
+	}
+	if none1 == proxied {
+		t.Fatalf("empty-proxy variant must differ from proxied variant")
+	}
+}
+
+// Empty apiKey returns a fresh random ID every call (no caching).
+func TestCachedSessionID_EmptyAPIKeyAlwaysFresh(t *testing.T) {
+	a := CachedSessionID("", "http://proxy:8080")
+	b := CachedSessionID("", "http://proxy:8080")
+	if a == "" || b == "" || a == b {
+		t.Fatalf("expected fresh IDs for empty apiKey, got a=%q b=%q", a, b)
+	}
+}

--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -30,7 +30,11 @@ func newUtlsRoundTripper(proxyURL string) *utlsRoundTripper {
 	if proxyURL != "" {
 		proxyDialer, mode, errBuild := proxyutil.BuildDialer(proxyURL)
 		if errBuild != nil {
+			// Fail closed on malformed proxy URL: see utls_transport.go for
+			// rationale. Silent direct-connection fallback would leak the
+			// host IP for an account intentionally bound to a proxy.
 			log.Errorf("utls: failed to configure proxy dialer for %q: %v", proxyutil.Redact(proxyURL), errBuild)
+			dialer = proxyutil.FailClosedDialer{Err: errBuild}
 		} else if mode != proxyutil.ModeInherit && proxyDialer != nil {
 			dialer = proxyDialer
 		}

--- a/internal/tui/config_tab.go
+++ b/internal/tui/config_tab.go
@@ -332,7 +332,12 @@ func (m configTabModel) parseConfig(cfg map[string]any) []configField {
 	fields = append(fields, configField{"Debug", "debug", "bool", fmt.Sprintf("%v", getBool(cfg, "debug")), nil})
 	fields = append(fields, configField{"Proxy URL", "proxy-url", "string", getString(cfg, "proxy-url"), nil})
 	fields = append(fields, configField{"Request Retry", "request-retry", "int", fmt.Sprintf("%.0f", getFloat(cfg, "request-retry")), nil})
+	fields = append(fields, configField{"Max Retry Credentials", "max-retry-credentials", "int", fmt.Sprintf("%.0f", getFloat(cfg, "max-retry-credentials")), nil})
 	fields = append(fields, configField{"Max Retry Interval (s)", "max-retry-interval", "int", fmt.Sprintf("%.0f", getFloat(cfg, "max-retry-interval")), nil})
+	fields = append(fields, configField{"Default RPM Limit", "rpm-limit-default", "int", fmt.Sprintf("%.0f", getFloat(cfg, "rpm-limit-default")), nil})
+	fields = append(fields, configField{"Default TPM Limit", "tpm-limit-default", "int", fmt.Sprintf("%.0f", getFloat(cfg, "tpm-limit-default")), nil})
+	fields = append(fields, configField{"Default Concurrency Limit", "concurrency-limit-default", "int", fmt.Sprintf("%.0f", getFloat(cfg, "concurrency-limit-default")), nil})
+	fields = append(fields, configField{"Default Hourly Request Limit", "rph-limit-default", "int", fmt.Sprintf("%.0f", getFloat(cfg, "rph-limit-default")), nil})
 	fields = append(fields, configField{"Force Model Prefix", "force-model-prefix", "string", getString(cfg, "force-model-prefix"), nil})
 
 	// Logging
@@ -379,7 +384,7 @@ func fieldSection(apiPath string) string {
 		return T("section_routing")
 	}
 	switch apiPath {
-	case "port", "host", "debug", "proxy-url", "request-retry", "max-retry-interval", "force-model-prefix":
+	case "port", "host", "debug", "proxy-url", "request-retry", "max-retry-credentials", "max-retry-interval", "rpm-limit-default", "tpm-limit-default", "concurrency-limit-default", "rph-limit-default", "force-model-prefix":
 		return T("section_server")
 	case "logging-to-file", "logs-max-total-size-mb", "error-logs-max-files", "usage-statistics-enabled", "request-log":
 		return T("section_logging")

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -69,6 +69,18 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.MaxRetryInterval != newCfg.MaxRetryInterval {
 		changes = append(changes, fmt.Sprintf("max-retry-interval: %d -> %d", oldCfg.MaxRetryInterval, newCfg.MaxRetryInterval))
 	}
+	if oldCfg.RPMLimitDefault != newCfg.RPMLimitDefault {
+		changes = append(changes, fmt.Sprintf("rpm-limit-default: %d -> %d", oldCfg.RPMLimitDefault, newCfg.RPMLimitDefault))
+	}
+	if oldCfg.TPMLimitDefault != newCfg.TPMLimitDefault {
+		changes = append(changes, fmt.Sprintf("tpm-limit-default: %d -> %d", oldCfg.TPMLimitDefault, newCfg.TPMLimitDefault))
+	}
+	if oldCfg.ConcurrencyLimitDefault != newCfg.ConcurrencyLimitDefault {
+		changes = append(changes, fmt.Sprintf("concurrency-limit-default: %d -> %d", oldCfg.ConcurrencyLimitDefault, newCfg.ConcurrencyLimitDefault))
+	}
+	if oldCfg.RPHLimitDefault != newCfg.RPHLimitDefault {
+		changes = append(changes, fmt.Sprintf("rph-limit-default: %d -> %d", oldCfg.RPHLimitDefault, newCfg.RPHLimitDefault))
+	}
 	if oldCfg.ProxyURL != newCfg.ProxyURL {
 		changes = append(changes, fmt.Sprintf("proxy-url: %s -> %s", formatProxyURL(oldCfg.ProxyURL), formatProxyURL(newCfg.ProxyURL)))
 	}

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -219,21 +219,25 @@ func TestBuildConfigChangeDetails_SecretsAndCounts(t *testing.T) {
 
 func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 	oldCfg := &config.Config{
-		Port:                   1000,
-		AuthDir:                "/old",
-		Debug:                  false,
-		LoggingToFile:          false,
-		UsageStatisticsEnabled: false,
-		DisableCooling:         false,
-		RequestRetry:           1,
-		MaxRetryCredentials:    1,
-		MaxRetryInterval:       1,
-		WebsocketAuth:          false,
-		QuotaExceeded:          config.QuotaExceeded{SwitchProject: false, SwitchPreviewModel: false, AntigravityCredits: false},
-		ClaudeKey:              []config.ClaudeKey{{APIKey: "c1"}},
-		CodexKey:               []config.CodexKey{{APIKey: "x1"}},
-		AmpCode:                config.AmpCode{UpstreamAPIKey: "keep", RestrictManagementToLocalhost: false},
-		RemoteManagement:       config.RemoteManagement{DisableControlPanel: false, PanelGitHubRepository: "old/repo", SecretKey: "keep"},
+		Port:                    1000,
+		AuthDir:                 "/old",
+		Debug:                   false,
+		LoggingToFile:           false,
+		UsageStatisticsEnabled:  false,
+		DisableCooling:          false,
+		RequestRetry:            1,
+		MaxRetryCredentials:     1,
+		MaxRetryInterval:        1,
+		RPMLimitDefault:         10,
+		TPMLimitDefault:         1000,
+		ConcurrencyLimitDefault: 2,
+		RPHLimitDefault:         100,
+		WebsocketAuth:           false,
+		QuotaExceeded:           config.QuotaExceeded{SwitchProject: false, SwitchPreviewModel: false, AntigravityCredits: false},
+		ClaudeKey:               []config.ClaudeKey{{APIKey: "c1"}},
+		CodexKey:                []config.CodexKey{{APIKey: "x1"}},
+		AmpCode:                 config.AmpCode{UpstreamAPIKey: "keep", RestrictManagementToLocalhost: false},
+		RemoteManagement:        config.RemoteManagement{DisableControlPanel: false, PanelGitHubRepository: "old/repo", SecretKey: "keep"},
 		SDKConfig: sdkconfig.SDKConfig{
 			RequestLog:                 false,
 			ProxyURL:                   "http://old-proxy",
@@ -243,17 +247,21 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 		},
 	}
 	newCfg := &config.Config{
-		Port:                   2000,
-		AuthDir:                "/new",
-		Debug:                  true,
-		LoggingToFile:          true,
-		UsageStatisticsEnabled: true,
-		DisableCooling:         true,
-		RequestRetry:           2,
-		MaxRetryCredentials:    3,
-		MaxRetryInterval:       3,
-		WebsocketAuth:          true,
-		QuotaExceeded:          config.QuotaExceeded{SwitchProject: true, SwitchPreviewModel: true, AntigravityCredits: true},
+		Port:                    2000,
+		AuthDir:                 "/new",
+		Debug:                   true,
+		LoggingToFile:           true,
+		UsageStatisticsEnabled:  true,
+		DisableCooling:          true,
+		RequestRetry:            2,
+		MaxRetryCredentials:     3,
+		MaxRetryInterval:        3,
+		RPMLimitDefault:         20,
+		TPMLimitDefault:         2000,
+		ConcurrencyLimitDefault: 3,
+		RPHLimitDefault:         200,
+		WebsocketAuth:           true,
+		QuotaExceeded:           config.QuotaExceeded{SwitchProject: true, SwitchPreviewModel: true, AntigravityCredits: true},
 		ClaudeKey: []config.ClaudeKey{
 			{APIKey: "c1", BaseURL: "http://new", ProxyURL: "http://p", Headers: map[string]string{"H": "1"}, ExcludedModels: []string{"a"}},
 			{APIKey: "c2"},
@@ -293,6 +301,10 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 	expectContains(t, details, "request-retry: 1 -> 2")
 	expectContains(t, details, "max-retry-credentials: 1 -> 3")
 	expectContains(t, details, "max-retry-interval: 1 -> 3")
+	expectContains(t, details, "rpm-limit-default: 10 -> 20")
+	expectContains(t, details, "tpm-limit-default: 1000 -> 2000")
+	expectContains(t, details, "concurrency-limit-default: 2 -> 3")
+	expectContains(t, details, "rph-limit-default: 100 -> 200")
 	expectContains(t, details, "proxy-url: http://old-proxy -> http://new-proxy")
 	expectContains(t, details, "ws-auth: false -> true")
 	expectContains(t, details, "force-model-prefix: false -> true")

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -76,6 +76,15 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 			auth.Metadata = make(map[string]any)
 		}
 		auth.Metadata["disabled"] = auth.Disabled
+		// Mirror the top-level ProxyURL into Metadata when Metadata does not
+		// already carry one. The synthesizer restores auth.ProxyURL on reload
+		// from Metadata["proxy_url"], so any caller that sets only ProxyURL
+		// (and forgets to update Metadata) would otherwise lose the per-account
+		// proxy after restart. We do not overwrite an existing Metadata value
+		// because PatchAuthFileFields treats Metadata as canonical.
+		if _, has := auth.Metadata["proxy_url"]; !has && strings.TrimSpace(auth.ProxyURL) != "" {
+			auth.Metadata["proxy_url"] = auth.ProxyURL
+		}
 		if setter, ok := auth.Storage.(metadataSetter); ok {
 			setter.SetMetadata(auth.Metadata)
 		}
@@ -84,6 +93,9 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 		}
 	case auth.Metadata != nil:
 		auth.Metadata["disabled"] = auth.Disabled
+		if _, has := auth.Metadata["proxy_url"]; !has && strings.TrimSpace(auth.ProxyURL) != "" {
+			auth.Metadata["proxy_url"] = auth.ProxyURL
+		}
 		raw, errMarshal := json.Marshal(auth.Metadata)
 		if errMarshal != nil {
 			return "", fmt.Errorf("auth filestore: marshal metadata failed: %w", errMarshal)

--- a/sdk/cliproxy/auth/claude_usage_limit.go
+++ b/sdk/cliproxy/auth/claude_usage_limit.go
@@ -1,0 +1,100 @@
+package auth
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Anthropic unified rate-limit response headers (returned on every response for
+// Max/subscription "unified" plans). These expose the rolling 5-hour and 7-day
+// usage windows so the proxy can proactively stop routing to an account before
+// it trips the hard limit. Captured from a live OAuth response, e.g.:
+//
+//	Anthropic-Ratelimit-Unified-5h-Utilization: 0.25   (fraction 0..1 of the window used)
+//	Anthropic-Ratelimit-Unified-5h-Reset: 1780084200   (unix seconds when the window resets)
+//	Anthropic-Ratelimit-Unified-5h-Status: allowed|allowed_warning|rejected
+//	Anthropic-Ratelimit-Unified-7d-Utilization / -7d-Reset / -7d-Status
+//	Anthropic-Ratelimit-Unified-Status / -Reset (overall, representative window)
+const (
+	hdrUnified5hUtilization = "Anthropic-Ratelimit-Unified-5h-Utilization"
+	hdrUnified5hReset       = "Anthropic-Ratelimit-Unified-5h-Reset"
+	hdrUnified5hStatus      = "Anthropic-Ratelimit-Unified-5h-Status"
+	hdrUnified7dUtilization = "Anthropic-Ratelimit-Unified-7d-Utilization"
+	hdrUnified7dReset       = "Anthropic-Ratelimit-Unified-7d-Reset"
+	hdrUnified7dStatus      = "Anthropic-Ratelimit-Unified-7d-Status"
+	hdrUnifiedStatus        = "Anthropic-Ratelimit-Unified-Status"
+	hdrUnifiedReset         = "Anthropic-Ratelimit-Unified-Reset"
+)
+
+// parseUnifiedReset parses a unified reset header. The unified headers use unix
+// seconds (e.g. "1780084200"); RFC 3339 is accepted as a fallback for safety.
+func parseUnifiedReset(raw string) (time.Time, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, false
+	}
+	if secs, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		if secs <= 0 {
+			return time.Time{}, false
+		}
+		return time.Unix(secs, 0), true
+	}
+	if t, err := time.Parse(time.RFC3339, raw); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}
+
+// windowBreached reports whether a single unified window should cause avoidance,
+// based on its status and utilization against the threshold. A "rejected" status
+// always counts. A positive threshold (fraction in (0,1]) triggers proactively
+// once utilization reaches it.
+func windowBreached(status, utilization string, threshold float64) bool {
+	if strings.EqualFold(strings.TrimSpace(status), "rejected") {
+		return true
+	}
+	if threshold <= 0 {
+		return false
+	}
+	util, err := strconv.ParseFloat(strings.TrimSpace(utilization), 64)
+	if err != nil {
+		return false
+	}
+	return util > 0 && util >= threshold
+}
+
+// claudeUsageParkUntil inspects Anthropic unified rate-limit headers and returns
+// the time until which the account should be parked (not routed to), or the zero
+// time when no window is breached. When multiple windows are breached it returns
+// the latest reset, since the account stays limited until every breached window
+// recovers. threshold is the utilization fraction (e.g. 0.85) at which to start
+// avoiding; <= 0 disables proactive avoidance (only hard "rejected" triggers).
+func claudeUsageParkUntil(h http.Header, threshold float64, now time.Time) time.Time {
+	if h == nil {
+		return time.Time{}
+	}
+	var until time.Time
+	consider := func(statusKey, utilKey, resetKey string) {
+		if !windowBreached(h.Get(statusKey), h.Get(utilKey), threshold) {
+			return
+		}
+		reset, ok := parseUnifiedReset(h.Get(resetKey))
+		if !ok || !reset.After(now) {
+			return
+		}
+		if reset.After(until) {
+			until = reset
+		}
+	}
+	consider(hdrUnified5hStatus, hdrUnified5hUtilization, hdrUnified5hReset)
+	consider(hdrUnified7dStatus, hdrUnified7dUtilization, hdrUnified7dReset)
+	// Overall status has no utilization field; only the hard "rejected" matters.
+	if strings.EqualFold(strings.TrimSpace(h.Get(hdrUnifiedStatus)), "rejected") {
+		if reset, ok := parseUnifiedReset(h.Get(hdrUnifiedReset)); ok && reset.After(now) && reset.After(until) {
+			until = reset
+		}
+	}
+	return until
+}

--- a/sdk/cliproxy/auth/claude_usage_limit_test.go
+++ b/sdk/cliproxy/auth/claude_usage_limit_test.go
@@ -1,0 +1,91 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func hdr(pairs map[string]string) http.Header {
+	h := http.Header{}
+	for k, v := range pairs {
+		h.Set(k, v)
+	}
+	return h
+}
+
+func TestClaudeUsageParkUntil(t *testing.T) {
+	now := time.Unix(1780084000, 0)
+	fiveHReset := "1780084200" // now + 200s
+	sevenDReset := "1780221600"
+
+	// Below threshold -> no park.
+	if got := claudeUsageParkUntil(hdr(map[string]string{
+		hdrUnified5hStatus:      "allowed",
+		hdrUnified5hUtilization: "0.25",
+		hdrUnified5hReset:       fiveHReset,
+	}), 0.85, now); !got.IsZero() {
+		t.Fatalf("below threshold: expected zero, got %v", got)
+	}
+
+	// At/over threshold -> park until 5h reset.
+	if got := claudeUsageParkUntil(hdr(map[string]string{
+		hdrUnified5hStatus:      "allowed_warning",
+		hdrUnified5hUtilization: "0.90",
+		hdrUnified5hReset:       fiveHReset,
+	}), 0.85, now); !got.Equal(time.Unix(1780084200, 0)) {
+		t.Fatalf("over threshold: expected 5h reset, got %v", got)
+	}
+
+	// Hard rejected parks regardless of threshold (even threshold 0).
+	if got := claudeUsageParkUntil(hdr(map[string]string{
+		hdrUnified5hStatus:      "rejected",
+		hdrUnified5hUtilization: "1.0",
+		hdrUnified5hReset:       fiveHReset,
+	}), 0, now); !got.Equal(time.Unix(1780084200, 0)) {
+		t.Fatalf("rejected: expected park even with threshold 0, got %v", got)
+	}
+
+	// When 7d window is also breached, the later reset wins.
+	if got := claudeUsageParkUntil(hdr(map[string]string{
+		hdrUnified5hStatus:      "allowed_warning",
+		hdrUnified5hUtilization: "0.90",
+		hdrUnified5hReset:       fiveHReset,
+		hdrUnified7dStatus:      "allowed_warning",
+		hdrUnified7dUtilization: "0.88",
+		hdrUnified7dReset:       sevenDReset,
+	}), 0.85, now); !got.Equal(time.Unix(1780221600, 0)) {
+		t.Fatalf("7d breach: expected latest (7d) reset, got %v", got)
+	}
+
+	// threshold 0 disables proactive avoidance when status is allowed.
+	if got := claudeUsageParkUntil(hdr(map[string]string{
+		hdrUnified5hStatus:      "allowed",
+		hdrUnified5hUtilization: "0.99",
+		hdrUnified5hReset:       fiveHReset,
+	}), 0, now); !got.IsZero() {
+		t.Fatalf("threshold 0 + allowed: expected zero, got %v", got)
+	}
+}
+
+func TestRateLimitedUsageWindowGate(t *testing.T) {
+	defer SetRateLimitDefaults(0, 0, 0)
+	SetRateLimitDefaults(0, 0, 0) // RPM/TPM/concurrency all off
+	m := NewManager(nil, nil, nil)
+	a := &Auth{ID: "a1", Provider: "claude"}
+	m.auths["a1"] = a
+	now := time.Unix(1780084000, 0)
+
+	// No park -> not limited even with all numeric limits disabled.
+	if _, limited := m.rateLimited("a1", now); limited {
+		t.Fatalf("expected not limited before park")
+	}
+	// Park until reset -> limited until then, then free.
+	a.rate.parkUntil(time.Unix(1780084200, 0))
+	if until, limited := m.rateLimited("a1", now); !limited || !until.Equal(time.Unix(1780084200, 0)) {
+		t.Fatalf("expected limited until 5h reset, got until=%v limited=%v", until, limited)
+	}
+	if _, limited := m.rateLimited("a1", time.Unix(1780084201, 0)); limited {
+		t.Fatalf("expected free after the window reset")
+	}
+}

--- a/sdk/cliproxy/auth/claude_usage_limit_test.go
+++ b/sdk/cliproxy/auth/claude_usage_limit_test.go
@@ -69,8 +69,8 @@ func TestClaudeUsageParkUntil(t *testing.T) {
 }
 
 func TestRateLimitedUsageWindowGate(t *testing.T) {
-	defer SetRateLimitDefaults(0, 0, 0)
-	SetRateLimitDefaults(0, 0, 0) // RPM/TPM/concurrency all off
+	defer SetRateLimitDefaults(0, 0, 0, 0)
+	SetRateLimitDefaults(0, 0, 0, 0) // RPM/TPM/concurrency/RPH all off
 	m := NewManager(nil, nil, nil)
 	a := &Auth{ID: "a1", Provider: "claude"}
 	m.auths["a1"] = a

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -107,6 +107,28 @@ var (
 	concurrencyLimitDefault atomic.Int64
 )
 
+// claudeUsageThresholdMilli stores the Claude 5h/7d usage-limit avoidance threshold
+// as parts-per-thousand of the utilization fraction (e.g. 850 = 0.85 = 85%). 0
+// disables proactive avoidance (only a hard "rejected" status parks the account).
+var claudeUsageThresholdMilli atomic.Int64
+
+// SetClaudeUsageLimitThreshold sets the utilization fraction (0..1) at which an
+// account is parked until its Claude usage window (rolling 5h/7d) resets. <= 0
+// disables proactive avoidance; the value is clamped to [0,1].
+func SetClaudeUsageLimitThreshold(fraction float64) {
+	if fraction < 0 {
+		fraction = 0
+	}
+	if fraction > 1 {
+		fraction = 1
+	}
+	claudeUsageThresholdMilli.Store(int64(fraction * 1000))
+}
+
+func claudeUsageThreshold() float64 {
+	return float64(claudeUsageThresholdMilli.Load()) / 1000
+}
+
 // SetRateLimitDefaults sets the global default requests-per-minute, tokens-per-minute,
 // and max-concurrency limits applied to every credential that does not override them.
 // Pass 0 (or negative) for any dimension to disable that limit globally.
@@ -150,6 +172,11 @@ func (m *Manager) rateLimited(authID string, now time.Time) (time.Time, bool) {
 	a := m.auths[authID]
 	if a == nil {
 		return time.Time{}, false
+	}
+	// Provider usage-window avoidance (e.g. Claude rolling 5h/7d limit): park the
+	// account until the observed reset time, independent of RPM/TPM/concurrency.
+	if until := a.rate.usageLimitUntil; !until.IsZero() && now.Before(until) {
+		return until, true
 	}
 	rpm, tpm, concurrency := effectiveRateLimits(a)
 	if rpm <= 0 && tpm <= 0 && concurrency <= 0 {
@@ -214,19 +241,40 @@ func (m *Manager) RecordTokenUsage(authID string, tokens int64, at time.Time) {
 	m.mu.Unlock()
 }
 
+// noteClaudeUsageLimit inspects Anthropic unified rate-limit headers from a
+// response and, when a usage window is at/over the avoidance threshold (or hard
+// rejected), parks the account until that window resets so it is not routed to.
+func (m *Manager) noteClaudeUsageLimit(authID string, headers http.Header, now time.Time) {
+	if m == nil || authID == "" || headers == nil {
+		return
+	}
+	until := claudeUsageParkUntil(headers, claudeUsageThreshold(), now)
+	if until.IsZero() {
+		return
+	}
+	m.mu.Lock()
+	if a := m.auths[authID]; a != nil {
+		a.rate.parkUntil(until)
+	}
+	m.mu.Unlock()
+}
+
 // rateUsagePlugin feeds published token usage into the manager's per-account TPM
-// windows. It implements coreusage.Plugin.
+// windows and applies Claude usage-window (5h/7d) avoidance. It implements
+// coreusage.Plugin.
 type rateUsagePlugin struct {
 	m *Manager
 }
 
-// HandleUsage records the total tokens of a usage record against its auth.
+// HandleUsage records token usage for TPM and parks accounts approaching their
+// Claude rolling usage limit based on the response's unified rate-limit headers.
 func (p rateUsagePlugin) HandleUsage(_ context.Context, record coreusage.Record) {
 	total := record.Detail.TotalTokens
 	if total <= 0 {
 		total = record.Detail.InputTokens + record.Detail.OutputTokens
 	}
 	p.m.RecordTokenUsage(record.AuthID, total, record.RequestedAt)
+	p.m.noteClaudeUsageLimit(record.AuthID, record.ResponseHeaders, record.RequestedAt)
 }
 
 // Result captures execution outcome used to adjust auth state.

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -105,6 +105,7 @@ var (
 	rpmLimitDefault         atomic.Int64
 	tpmLimitDefault         atomic.Int64
 	concurrencyLimitDefault atomic.Int64
+	rphLimitDefault         atomic.Int64
 )
 
 // claudeUsageThresholdMilli stores the Claude 5h/7d usage-limit avoidance threshold
@@ -129,22 +130,25 @@ func claudeUsageThreshold() float64 {
 	return float64(claudeUsageThresholdMilli.Load()) / 1000
 }
 
-// SetRateLimitDefaults sets the global default requests-per-minute, tokens-per-minute,
-// and max-concurrency limits applied to every credential that does not override them.
+// SetRateLimitDefaults sets the global default requests-per-minute,
+// tokens-per-minute, max-concurrency, and requests-per-hour limits applied to
+// every credential that does not override them.
 // Pass 0 (or negative) for any dimension to disable that limit globally.
-func SetRateLimitDefaults(rpm, tpm, concurrency int) {
+func SetRateLimitDefaults(rpm, tpm, concurrency, rph int) {
 	rpmLimitDefault.Store(int64(rpm))
 	tpmLimitDefault.Store(int64(tpm))
 	concurrencyLimitDefault.Store(int64(concurrency))
+	rphLimitDefault.Store(int64(rph))
 }
 
-// effectiveRateLimits resolves the active RPM/TPM/concurrency limits for an auth,
+// effectiveRateLimits resolves the active RPM/TPM/concurrency/RPH limits for an auth,
 // preferring per-account overrides over the global defaults. A returned value
 // <= 0 means that dimension is unlimited.
-func effectiveRateLimits(a *Auth) (rpm, tpm, concurrency int64) {
+func effectiveRateLimits(a *Auth) (rpm, tpm, concurrency, rph int64) {
 	rpm = rpmLimitDefault.Load()
 	tpm = tpmLimitDefault.Load()
 	concurrency = concurrencyLimitDefault.Load()
+	rph = rphLimitDefault.Load()
 	if a != nil {
 		if v, ok := a.RPMLimitOverride(); ok {
 			rpm = int64(v)
@@ -155,14 +159,18 @@ func effectiveRateLimits(a *Auth) (rpm, tpm, concurrency int64) {
 		if v, ok := a.ConcurrencyLimitOverride(); ok {
 			concurrency = int64(v)
 		}
+		if v, ok := a.RPHLimitOverride(); ok {
+			rph = int64(v)
+		}
 	}
-	return rpm, tpm, concurrency
+	return rpm, tpm, concurrency, rph
 }
 
-// rateLimited reports whether the auth identified by authID is currently over any
-// of its RPM/TPM/concurrency budgets. When limited, it returns a conservative time
-// at which the caller may retry. The read is performed under the manager mutex so
-// it observes the same counters updated by recordDispatch/recordDispatchDone/RecordTokenUsage.
+// rateLimited reports whether the auth identified by authID is currently over
+// any of its RPM/TPM/concurrency/RPH budgets. When limited, it returns a
+// conservative time at which the caller may retry. The read is performed under
+// the manager mutex so it observes the same counters updated by
+// recordDispatch/recordDispatchDone/RecordTokenUsage.
 func (m *Manager) rateLimited(authID string, now time.Time) (time.Time, bool) {
 	if m == nil || authID == "" {
 		return time.Time{}, false
@@ -178,21 +186,38 @@ func (m *Manager) rateLimited(authID string, now time.Time) (time.Time, bool) {
 	if until := a.rate.usageLimitUntil; !until.IsZero() && now.Before(until) {
 		return until, true
 	}
-	rpm, tpm, concurrency := effectiveRateLimits(a)
-	if rpm <= 0 && tpm <= 0 && concurrency <= 0 {
+	rpm, tpm, concurrency, rph := effectiveRateLimits(a)
+	if rpm <= 0 && tpm <= 0 && concurrency <= 0 && rph <= 0 {
 		return time.Time{}, false
+	}
+	retryAt := time.Time{}
+	limited := false
+	setRetryAt := func(ts time.Time) {
+		if ts.IsZero() {
+			return
+		}
+		limited = true
+		if retryAt.IsZero() || ts.After(retryAt) {
+			retryAt = ts
+		}
 	}
 	if concurrency > 0 && a.rate.inFlight >= concurrency {
 		// Concurrency frees when an in-flight request completes; the exact time is
 		// unknown, so suggest a short retry hint.
-		return now.Add(time.Second), true
+		setRetryAt(now.Add(time.Second))
 	}
 	reqs, toks := a.rate.sums(now)
 	if rpm > 0 && reqs >= rpm {
-		return a.rate.earliestFree(now), true
+		setRetryAt(a.rate.earliestFree(now))
 	}
 	if tpm > 0 && toks >= tpm {
-		return a.rate.earliestFree(now), true
+		setRetryAt(a.rate.earliestFree(now))
+	}
+	if rph > 0 && a.rate.hourlyRequests(now) >= rph {
+		setRetryAt(a.rate.hourlyEarliestFree(now))
+	}
+	if limited {
+		return retryAt, true
 	}
 	return time.Time{}, false
 }
@@ -255,6 +280,7 @@ func (m *Manager) noteClaudeUsageLimit(authID string, headers http.Header, now t
 	m.mu.Lock()
 	if a := m.auths[authID]; a != nil {
 		a.rate.parkUntil(until)
+		a.recordWarning(now, "usage_limit", "", "parked until "+until.UTC().Format(time.RFC3339)+" to avoid Claude usage window limit", 0, "")
 	}
 	m.mu.Unlock()
 }
@@ -1570,7 +1596,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 
 		tried[auth.ID] = struct{}{}
 		// Proactive per-account rate limiting: skip this credential when it is over
-		// its RPM/TPM/concurrency budget and try the next one (failover).
+		// its RPM/TPM/concurrency/RPH budget and try the next one (failover).
 		if reset, limited := m.rateLimited(auth.ID, time.Now()); limited {
 			rateLimitedSeen = true
 			if rateLimitedReset.IsZero() || reset.Before(rateLimitedReset) {
@@ -1786,7 +1812,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 
 		tried[auth.ID] = struct{}{}
 		// Proactive per-account rate limiting: skip this credential when it is over
-		// its RPM/TPM/concurrency budget and try the next one (failover).
+		// its RPM/TPM/concurrency/RPH budget and try the next one (failover).
 		if reset, limited := m.rateLimited(auth.ID, time.Now()); limited {
 			rateLimitedSeen = true
 			if rateLimitedReset.IsZero() || reset.Before(rateLimitedReset) {
@@ -2551,6 +2577,9 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				clearAuthStateOnSuccess(auth, now)
 			}
 		} else {
+			if !isRequestScopedNotFoundResultError(result.Error) {
+				recordResultWarning(auth, result, now)
+			}
 			if result.Model != "" {
 				if !isRequestScopedNotFoundResultError(result.Error) {
 					disableCooling := quotaCooldownDisabledForAuth(auth)
@@ -2921,6 +2950,45 @@ func statusCodeFromResult(err *Error) int {
 		return 0
 	}
 	return err.StatusCode()
+}
+
+// warningKindForStatus maps an HTTP-like status code to a warning kind label
+// used by the management API to classify operator-facing warnings.
+func warningKindForStatus(code int) string {
+	switch code {
+	case 401:
+		return "unauthorized"
+	case 402, 403:
+		return "payment_required"
+	case 404:
+		return "not_found"
+	case 429:
+		return "rate_limit"
+	case 408, 500, 502, 503, 504:
+		return "server_error"
+	default:
+		return "error"
+	}
+}
+
+// recordResultWarning appends an operator-facing warning derived from a failed
+// execution result. The caller must hold the manager mutex (MarkResult does).
+func recordResultWarning(auth *Auth, result Result, now time.Time) {
+	if auth == nil {
+		return
+	}
+	code := statusCodeFromResult(result.Error)
+	kind := warningKindForStatus(code)
+	if isModelSupportResultError(result.Error) {
+		kind = "model_not_supported"
+	}
+	message := ""
+	errCode := ""
+	if result.Error != nil {
+		message = result.Error.Message
+		errCode = result.Error.Code
+	}
+	auth.recordWarning(now, kind, errCode, message, code, result.Model)
 }
 
 func isModelSupportErrorMessage(message string) bool {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -99,6 +99,136 @@ func quotaCooldownDisabledForAuth(auth *Auth) bool {
 	return quotaCooldownDisabled.Load()
 }
 
+// Global per-account rate-limit defaults. A value <= 0 means "unlimited" for that
+// dimension. Per-account metadata overrides take precedence (see effectiveRateLimits).
+var (
+	rpmLimitDefault         atomic.Int64
+	tpmLimitDefault         atomic.Int64
+	concurrencyLimitDefault atomic.Int64
+)
+
+// SetRateLimitDefaults sets the global default requests-per-minute, tokens-per-minute,
+// and max-concurrency limits applied to every credential that does not override them.
+// Pass 0 (or negative) for any dimension to disable that limit globally.
+func SetRateLimitDefaults(rpm, tpm, concurrency int) {
+	rpmLimitDefault.Store(int64(rpm))
+	tpmLimitDefault.Store(int64(tpm))
+	concurrencyLimitDefault.Store(int64(concurrency))
+}
+
+// effectiveRateLimits resolves the active RPM/TPM/concurrency limits for an auth,
+// preferring per-account overrides over the global defaults. A returned value
+// <= 0 means that dimension is unlimited.
+func effectiveRateLimits(a *Auth) (rpm, tpm, concurrency int64) {
+	rpm = rpmLimitDefault.Load()
+	tpm = tpmLimitDefault.Load()
+	concurrency = concurrencyLimitDefault.Load()
+	if a != nil {
+		if v, ok := a.RPMLimitOverride(); ok {
+			rpm = int64(v)
+		}
+		if v, ok := a.TPMLimitOverride(); ok {
+			tpm = int64(v)
+		}
+		if v, ok := a.ConcurrencyLimitOverride(); ok {
+			concurrency = int64(v)
+		}
+	}
+	return rpm, tpm, concurrency
+}
+
+// rateLimited reports whether the auth identified by authID is currently over any
+// of its RPM/TPM/concurrency budgets. When limited, it returns a conservative time
+// at which the caller may retry. The read is performed under the manager mutex so
+// it observes the same counters updated by recordDispatch/recordDispatchDone/RecordTokenUsage.
+func (m *Manager) rateLimited(authID string, now time.Time) (time.Time, bool) {
+	if m == nil || authID == "" {
+		return time.Time{}, false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	a := m.auths[authID]
+	if a == nil {
+		return time.Time{}, false
+	}
+	rpm, tpm, concurrency := effectiveRateLimits(a)
+	if rpm <= 0 && tpm <= 0 && concurrency <= 0 {
+		return time.Time{}, false
+	}
+	if concurrency > 0 && a.rate.inFlight >= concurrency {
+		// Concurrency frees when an in-flight request completes; the exact time is
+		// unknown, so suggest a short retry hint.
+		return now.Add(time.Second), true
+	}
+	reqs, toks := a.rate.sums(now)
+	if rpm > 0 && reqs >= rpm {
+		return a.rate.earliestFree(now), true
+	}
+	if tpm > 0 && toks >= tpm {
+		return a.rate.earliestFree(now), true
+	}
+	return time.Time{}, false
+}
+
+// recordDispatch records one dispatched request against an auth's RPM window and
+// increments its in-flight counter. Pair every call with recordDispatchDone.
+func (m *Manager) recordDispatch(authID string) {
+	if m == nil || authID == "" {
+		return
+	}
+	now := time.Now()
+	m.mu.Lock()
+	if a := m.auths[authID]; a != nil {
+		a.rate.addRequest(now)
+		a.rate.acquire()
+	}
+	m.mu.Unlock()
+}
+
+// recordDispatchDone decrements an auth's in-flight counter when a request completes.
+func (m *Manager) recordDispatchDone(authID string) {
+	if m == nil || authID == "" {
+		return
+	}
+	m.mu.Lock()
+	if a := m.auths[authID]; a != nil {
+		a.rate.release()
+	}
+	m.mu.Unlock()
+}
+
+// RecordTokenUsage adds observed token consumption to an auth's TPM window. It is
+// invoked by the usage plugin registered in NewManager when an upstream response's
+// usage is published.
+func (m *Manager) RecordTokenUsage(authID string, tokens int64, at time.Time) {
+	if m == nil || authID == "" || tokens <= 0 {
+		return
+	}
+	if at.IsZero() {
+		at = time.Now()
+	}
+	m.mu.Lock()
+	if a := m.auths[authID]; a != nil {
+		a.rate.addTokens(at, tokens)
+	}
+	m.mu.Unlock()
+}
+
+// rateUsagePlugin feeds published token usage into the manager's per-account TPM
+// windows. It implements coreusage.Plugin.
+type rateUsagePlugin struct {
+	m *Manager
+}
+
+// HandleUsage records the total tokens of a usage record against its auth.
+func (p rateUsagePlugin) HandleUsage(_ context.Context, record coreusage.Record) {
+	total := record.Detail.TotalTokens
+	if total <= 0 {
+		total = record.Detail.InputTokens + record.Detail.OutputTokens
+	}
+	p.m.RecordTokenUsage(record.AuthID, total, record.RequestedAt)
+}
+
 // Result captures execution outcome used to adjust auth state.
 type Result struct {
 	// AuthID references the auth that produced this result.
@@ -215,6 +345,8 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 	manager.runtimeConfig.Store(&internalconfig.Config{})
 	manager.apiKeyModelAlias.Store(apiKeyModelAliasTable(nil))
 	manager.scheduler = newAuthScheduler(selector)
+	// Feed published token usage into this manager's per-account TPM windows.
+	coreusage.RegisterPlugin(rateUsagePlugin{m: manager})
 	return manager
 }
 
@@ -815,10 +947,14 @@ func readStreamBootstrap(ctx context.Context, ch <-chan cliproxyexecutor.StreamC
 	}
 }
 
-func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, resultModel string, headers http.Header, buffered []cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk) *cliproxyexecutor.StreamResult {
+func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, resultModel string, headers http.Header, buffered []cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk, onDone func()) *cliproxyexecutor.StreamResult {
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {
 		defer close(out)
+		if onDone != nil {
+			// Release the in-flight concurrency slot when the stream completes.
+			defer onDone()
+		}
 		var failed bool
 		forward := true
 		emit := func(chunk cliproxyexecutor.StreamChunk) bool {
@@ -874,8 +1010,21 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		resultModel := m.stateModelForExecution(auth, routeModel, execModel, pooled)
 		execReq := req
 		execReq.Model = execModel
+		// Count this dispatch toward the auth's RPM and in-flight concurrency.
+		// release is idempotent: it is invoked on every synchronous failure path,
+		// and handed to wrapStreamResult on success so the in-flight slot is held
+		// until the stream finishes.
+		m.recordDispatch(auth.ID)
+		streamReleased := false
+		release := func() {
+			if !streamReleased {
+				streamReleased = true
+				m.recordDispatchDone(auth.ID)
+			}
+		}
 		streamResult, errStream := executor.ExecuteStream(ctx, auth, execReq, opts)
 		if errStream != nil {
+			release()
 			if errCtx := ctx.Err(); errCtx != nil {
 				return nil, errCtx
 			}
@@ -895,6 +1044,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 
 		buffered, closed, bootstrapErr := readStreamBootstrap(ctx, streamResult.Chunks)
 		if bootstrapErr != nil {
+			release()
 			if errCtx := ctx.Err(); errCtx != nil {
 				discardStreamChunks(streamResult.Chunks)
 				return nil, errCtx
@@ -934,6 +1084,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		}
 
 		if closed && len(buffered) == 0 {
+			release()
 			emptyErr := &Error{Code: "empty_stream", Message: "upstream stream closed before first payload", Retryable: true}
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: emptyErr}
 			m.MarkResult(ctx, result)
@@ -950,7 +1101,8 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			close(closedCh)
 			remaining = closedCh
 		}
-		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, buffered, remaining), nil
+		// Success: hold the in-flight slot until the stream goroutine completes.
+		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, buffered, remaining, release), nil
 	}
 	if lastErr == nil {
 		lastErr = &Error{Code: "auth_not_found", Message: "no upstream model available"}
@@ -1338,6 +1490,8 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 	tried := make(map[string]struct{})
 	attempted := make(map[string]struct{})
 	var lastErr error
+	var rateLimitedSeen bool
+	var rateLimitedReset time.Time
 	for {
 		if !homeMode && maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
 			if lastErr != nil {
@@ -1351,6 +1505,11 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		}
 		auth, executor, provider, errPick := m.pickNextMixed(ctx, providers, routeModel, pickOpts, tried)
 		if errPick != nil {
+			// When the only reason no auth is available is per-account rate limiting,
+			// surface a 429 with a Retry-After hint instead of a generic error.
+			if rateLimitedSeen && lastErr == nil {
+				return cliproxyexecutor.Response{}, newModelCooldownError(routeModel, "", time.Until(rateLimitedReset))
+			}
 			if shouldReturnLastErrorOnPickFailure(homeMode, lastErr, errPick) {
 				return cliproxyexecutor.Response{}, lastErr
 			}
@@ -1362,6 +1521,15 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		publishSelectedAuthMetadata(opts.Metadata, auth.ID)
 
 		tried[auth.ID] = struct{}{}
+		// Proactive per-account rate limiting: skip this credential when it is over
+		// its RPM/TPM/concurrency budget and try the next one (failover).
+		if reset, limited := m.rateLimited(auth.ID, time.Now()); limited {
+			rateLimitedSeen = true
+			if rateLimitedReset.IsZero() || reset.Before(rateLimitedReset) {
+				rateLimitedReset = reset
+			}
+			continue
+		}
 		execCtx := ctx
 		if rt := m.roundTripperFor(auth); rt != nil {
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
@@ -1390,7 +1558,9 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			resultModel := m.stateModelForExecution(auth, routeModel, upstreamModel, pooled)
 			execReq := req
 			execReq.Model = upstreamModel
+			m.recordDispatch(auth.ID)
 			resp, errExec := executor.Execute(execCtx, auth, execReq, opts)
+			m.recordDispatchDone(auth.ID)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
@@ -1536,6 +1706,8 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 	tried := make(map[string]struct{})
 	attempted := make(map[string]struct{})
 	var lastErr error
+	var rateLimitedSeen bool
+	var rateLimitedReset time.Time
 	for {
 		if !homeMode && maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
 			if lastErr != nil {
@@ -1549,6 +1721,11 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		}
 		auth, executor, provider, errPick := m.pickNextMixed(ctx, providers, routeModel, pickOpts, tried)
 		if errPick != nil {
+			// When the only reason no auth is available is per-account rate limiting,
+			// surface a 429 with a Retry-After hint instead of a generic error.
+			if rateLimitedSeen && lastErr == nil {
+				return nil, newModelCooldownError(routeModel, "", time.Until(rateLimitedReset))
+			}
 			if shouldReturnLastErrorOnPickFailure(homeMode, lastErr, errPick) {
 				return nil, lastErr
 			}
@@ -1560,6 +1737,15 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		publishSelectedAuthMetadata(opts.Metadata, auth.ID)
 
 		tried[auth.ID] = struct{}{}
+		// Proactive per-account rate limiting: skip this credential when it is over
+		// its RPM/TPM/concurrency budget and try the next one (failover).
+		if reset, limited := m.rateLimited(auth.ID, time.Now()); limited {
+			rateLimitedSeen = true
+			if rateLimitedReset.IsZero() || reset.Before(rateLimitedReset) {
+				rateLimitedReset = reset
+			}
+			continue
+		}
 		execCtx := ctx
 		if rt := m.roundTripperFor(auth); rt != nil {
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)

--- a/sdk/cliproxy/auth/rate_window.go
+++ b/sdk/cliproxy/auth/rate_window.go
@@ -6,12 +6,28 @@ import "time"
 // accounting. One bucket per second gives a 60s sliding window.
 const rateWindowSeconds = 60
 
+// hourlyRequestWindowMinutes is the trailing window length used for per-account
+// requests-per-hour accounting.
+const hourlyRequestWindowMinutes = 60
+
+// hourlyRequestWindowBuckets keeps one extra minute bucket so any minute that
+// intersects the trailing hour is counted conservatively.
+const hourlyRequestWindowBuckets = hourlyRequestWindowMinutes + 1
+
 // rateBucket accumulates requests and tokens observed during a single wall-clock
 // second. The sec field guards against stale reuse when the ring wraps.
 type rateBucket struct {
 	sec  int64
 	reqs int64
 	toks int64
+}
+
+// hourlyRequestBucket accumulates request counts observed during a single
+// wall-clock minute. The minute field guards against stale reuse when the ring
+// wraps.
+type hourlyRequestBucket struct {
+	minute int64
+	reqs   int64
 }
 
 // rateWindow tracks per-auth requests and tokens over a trailing rateWindowSeconds
@@ -22,8 +38,9 @@ type rateBucket struct {
 // recentRequestRing pattern. This keeps Auth.Clone() (a by-value copy) free of
 // lock-copy hazards.
 type rateWindow struct {
-	buckets  [rateWindowSeconds]rateBucket
-	inFlight int64
+	buckets       [rateWindowSeconds]rateBucket
+	hourlyBuckets [hourlyRequestWindowBuckets]hourlyRequestBucket
+	inFlight      int64
 	// usageLimitUntil parks the account until this time when a provider usage
 	// window (e.g. Claude's rolling 5h/7d limit) is at or over the avoidance
 	// threshold. Zero means no active usage-limit park.
@@ -63,6 +80,7 @@ func (w *rateWindow) addRequest(now time.Time) {
 		return
 	}
 	w.bucketFor(now).reqs++
+	w.hourlyBucketFor(now).reqs++
 }
 
 // addTokens records token consumption observed at now.
@@ -106,6 +124,39 @@ func (w *rateWindow) sums(now time.Time) (reqs int64, toks int64) {
 	return reqs, toks
 }
 
+// hourlyBucketFor returns the bucket for the given minute, resetting it when
+// the ring slot belonged to an older minute.
+func (w *rateWindow) hourlyBucketFor(now time.Time) *hourlyRequestBucket {
+	minute := now.Unix() / 60
+	idx := minute % hourlyRequestWindowBuckets
+	if idx < 0 {
+		idx += hourlyRequestWindowBuckets
+	}
+	b := &w.hourlyBuckets[idx]
+	if b.minute != minute {
+		b.minute = minute
+		b.reqs = 0
+	}
+	return b
+}
+
+// hourlyRequests returns the total requests within the trailing hour ending at now.
+func (w *rateWindow) hourlyRequests(now time.Time) int64 {
+	if w == nil {
+		return 0
+	}
+	currentMinute := now.Unix() / 60
+	minMinute := currentMinute - hourlyRequestWindowMinutes
+	var reqs int64
+	for i := range w.hourlyBuckets {
+		b := w.hourlyBuckets[i]
+		if b.minute >= minMinute && b.minute <= currentMinute {
+			reqs += b.reqs
+		}
+	}
+	return reqs
+}
+
 // earliestFree estimates when the trailing window will drop below the limit,
 // i.e. the oldest counted second plus the window length. It is used as a
 // conservative Retry-After hint. Returns now+1s when nothing is counted.
@@ -135,4 +186,79 @@ func (w *rateWindow) earliestFree(now time.Time) time.Time {
 		return fallback
 	}
 	return free
+}
+
+// hourlyEarliestFree estimates when the hourly request window will drop below
+// the configured limit. It returns the minute boundary after the oldest counted
+// minute leaves the trailing hour.
+func (w *rateWindow) hourlyEarliestFree(now time.Time) time.Time {
+	fallback := now.Add(time.Second)
+	if w == nil {
+		return fallback
+	}
+	currentMinute := now.Unix() / 60
+	minMinute := currentMinute - hourlyRequestWindowMinutes
+	oldest := int64(0)
+	found := false
+	for i := range w.hourlyBuckets {
+		b := w.hourlyBuckets[i]
+		if b.reqs > 0 && b.minute >= minMinute && b.minute <= currentMinute {
+			if !found || b.minute < oldest {
+				oldest = b.minute
+				found = true
+			}
+		}
+	}
+	if !found {
+		return fallback
+	}
+	free := time.Unix((oldest+hourlyRequestWindowBuckets)*60, 0)
+	if !free.After(now) {
+		return fallback
+	}
+	return free
+}
+
+// RateLimitSnapshot captures an auth's effective per-account rate limits (after
+// applying per-account overrides over the global defaults) together with the
+// current usage observed within the trailing window. It is exposed via the
+// management API so operators can see both the configured limits and how close
+// an account currently is to them. A limit of 0 means "unlimited".
+type RateLimitSnapshot struct {
+	RPMLimit         int64 `json:"rpm_limit"`
+	TPMLimit         int64 `json:"tpm_limit"`
+	ConcurrencyLimit int64 `json:"concurrency_limit"`
+	RPHLimit         int64 `json:"rph_limit"`
+	RPMCurrent       int64 `json:"rpm_current"`
+	TPMCurrent       int64 `json:"tpm_current"`
+	RPHCurrent       int64 `json:"rph_current"`
+	InFlight         int64 `json:"in_flight"`
+}
+
+// HasData reports whether the snapshot carries any non-zero limit or usage, used
+// to avoid emitting an all-zero object for idle, unlimited accounts.
+func (s RateLimitSnapshot) HasData() bool {
+	return s.RPMLimit > 0 || s.TPMLimit > 0 || s.ConcurrencyLimit > 0 || s.RPHLimit > 0 ||
+		s.RPMCurrent > 0 || s.TPMCurrent > 0 || s.RPHCurrent > 0 || s.InFlight > 0
+}
+
+// RateLimitSnapshot resolves the effective RPM/TPM/concurrency/RPH limits and the
+// current trailing-window usage for this auth. Read from a cloned Auth (where
+// the rate window is copied by value), it is race-free without extra locking.
+func (a *Auth) RateLimitSnapshot(now time.Time) RateLimitSnapshot {
+	if a == nil {
+		return RateLimitSnapshot{}
+	}
+	rpm, tpm, concurrency, rph := effectiveRateLimits(a)
+	reqs, toks := a.rate.sums(now)
+	return RateLimitSnapshot{
+		RPMLimit:         rpm,
+		TPMLimit:         tpm,
+		ConcurrencyLimit: concurrency,
+		RPHLimit:         rph,
+		RPMCurrent:       reqs,
+		TPMCurrent:       toks,
+		RPHCurrent:       a.rate.hourlyRequests(now),
+		InFlight:         a.rate.inFlight,
+	}
 }

--- a/sdk/cliproxy/auth/rate_window.go
+++ b/sdk/cliproxy/auth/rate_window.go
@@ -24,6 +24,20 @@ type rateBucket struct {
 type rateWindow struct {
 	buckets  [rateWindowSeconds]rateBucket
 	inFlight int64
+	// usageLimitUntil parks the account until this time when a provider usage
+	// window (e.g. Claude's rolling 5h/7d limit) is at or over the avoidance
+	// threshold. Zero means no active usage-limit park.
+	usageLimitUntil time.Time
+}
+
+// parkUntil extends the usage-limit park time, never shortening an existing one.
+func (w *rateWindow) parkUntil(t time.Time) {
+	if w == nil || t.IsZero() {
+		return
+	}
+	if t.After(w.usageLimitUntil) {
+		w.usageLimitUntil = t
+	}
 }
 
 // bucketFor returns the bucket for the given second, resetting it when the ring

--- a/sdk/cliproxy/auth/rate_window.go
+++ b/sdk/cliproxy/auth/rate_window.go
@@ -1,0 +1,124 @@
+package auth
+
+import "time"
+
+// rateWindowSeconds is the trailing window length used for per-account RPM/TPM
+// accounting. One bucket per second gives a 60s sliding window.
+const rateWindowSeconds = 60
+
+// rateBucket accumulates requests and tokens observed during a single wall-clock
+// second. The sec field guards against stale reuse when the ring wraps.
+type rateBucket struct {
+	sec  int64
+	reqs int64
+	toks int64
+}
+
+// rateWindow tracks per-auth requests and tokens over a trailing rateWindowSeconds
+// window, plus the count of in-flight requests for concurrency limiting.
+//
+// rateWindow is intentionally NOT internally synchronized: every access must be
+// performed while holding the owning Manager's mutex, mirroring the existing
+// recentRequestRing pattern. This keeps Auth.Clone() (a by-value copy) free of
+// lock-copy hazards.
+type rateWindow struct {
+	buckets  [rateWindowSeconds]rateBucket
+	inFlight int64
+}
+
+// bucketFor returns the bucket for the given second, resetting it when the ring
+// slot belonged to an older second.
+func (w *rateWindow) bucketFor(now time.Time) *rateBucket {
+	sec := now.Unix()
+	idx := sec % rateWindowSeconds
+	if idx < 0 {
+		idx += rateWindowSeconds
+	}
+	b := &w.buckets[idx]
+	if b.sec != sec {
+		b.sec = sec
+		b.reqs = 0
+		b.toks = 0
+	}
+	return b
+}
+
+// addRequest records one dispatched request at now.
+func (w *rateWindow) addRequest(now time.Time) {
+	if w == nil {
+		return
+	}
+	w.bucketFor(now).reqs++
+}
+
+// addTokens records token consumption observed at now.
+func (w *rateWindow) addTokens(now time.Time, n int64) {
+	if w == nil || n <= 0 {
+		return
+	}
+	w.bucketFor(now).toks += n
+}
+
+// acquire increments the in-flight counter when a request is dispatched.
+func (w *rateWindow) acquire() {
+	if w == nil {
+		return
+	}
+	w.inFlight++
+}
+
+// release decrements the in-flight counter when a request completes, flooring at zero.
+func (w *rateWindow) release() {
+	if w == nil || w.inFlight <= 0 {
+		return
+	}
+	w.inFlight--
+}
+
+// sums returns the total requests and tokens within the trailing window ending at now.
+func (w *rateWindow) sums(now time.Time) (reqs int64, toks int64) {
+	if w == nil {
+		return 0, 0
+	}
+	current := now.Unix()
+	minSec := current - rateWindowSeconds + 1
+	for i := range w.buckets {
+		b := w.buckets[i]
+		if b.sec >= minSec && b.sec <= current {
+			reqs += b.reqs
+			toks += b.toks
+		}
+	}
+	return reqs, toks
+}
+
+// earliestFree estimates when the trailing window will drop below the limit,
+// i.e. the oldest counted second plus the window length. It is used as a
+// conservative Retry-After hint. Returns now+1s when nothing is counted.
+func (w *rateWindow) earliestFree(now time.Time) time.Time {
+	fallback := now.Add(time.Second)
+	if w == nil {
+		return fallback
+	}
+	current := now.Unix()
+	minSec := current - rateWindowSeconds + 1
+	oldest := int64(0)
+	found := false
+	for i := range w.buckets {
+		b := w.buckets[i]
+		if (b.reqs > 0 || b.toks > 0) && b.sec >= minSec && b.sec <= current {
+			if !found || b.sec < oldest {
+				oldest = b.sec
+				found = true
+			}
+		}
+	}
+	if !found {
+		return fallback
+	}
+	free := time.Unix(oldest+rateWindowSeconds, 0)
+	if !free.After(now) {
+		return fallback
+	}
+	return free
+}

--- a/sdk/cliproxy/auth/rate_window_test.go
+++ b/sdk/cliproxy/auth/rate_window_test.go
@@ -1,0 +1,107 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRateWindowSumsAndExpiry(t *testing.T) {
+	var w rateWindow
+	base := time.Unix(1_700_000_000, 0)
+
+	w.addRequest(base)
+	w.addRequest(base.Add(2 * time.Second))
+	w.addTokens(base.Add(2*time.Second), 50)
+
+	reqs, toks := w.sums(base.Add(2 * time.Second))
+	if reqs != 2 || toks != 50 {
+		t.Fatalf("within window: got reqs=%d toks=%d, want 2/50", reqs, toks)
+	}
+
+	// At base+61s the base+2s event is still within the trailing 60s window.
+	if reqs, toks := w.sums(base.Add(61 * time.Second)); reqs != 1 || toks != 50 {
+		t.Fatalf("at +61s: got reqs=%d toks=%d, want 1/50 (base+2s still in window)", reqs, toks)
+	}
+	// At base+62s every recorded event has aged out of the window.
+	if reqs, toks := w.sums(base.Add(62 * time.Second)); reqs != 0 || toks != 0 {
+		t.Fatalf("after expiry: got reqs=%d toks=%d, want 0/0", reqs, toks)
+	}
+}
+
+func TestRateWindowInFlight(t *testing.T) {
+	var w rateWindow
+	w.acquire()
+	w.acquire()
+	if w.inFlight != 2 {
+		t.Fatalf("inFlight=%d, want 2", w.inFlight)
+	}
+	w.release()
+	if w.inFlight != 1 {
+		t.Fatalf("inFlight=%d, want 1", w.inFlight)
+	}
+	// release floors at zero and never goes negative.
+	w.release()
+	w.release()
+	if w.inFlight != 0 {
+		t.Fatalf("inFlight=%d, want 0 (floored)", w.inFlight)
+	}
+}
+
+func TestRateLimitedRPMTPMConcurrency(t *testing.T) {
+	defer SetRateLimitDefaults(0, 0, 0)
+	m := NewManager(nil, nil, nil)
+	a := &Auth{ID: "a1", Provider: "claude"}
+	m.auths["a1"] = a
+	now := time.Unix(1_700_000_000, 0)
+
+	// RPM: limit 2 -> blocked once two requests are recorded in the window.
+	SetRateLimitDefaults(2, 0, 0)
+	a.rate.addRequest(now)
+	if _, limited := m.rateLimited("a1", now); limited {
+		t.Fatalf("rpm: should not be limited at 1/2")
+	}
+	a.rate.addRequest(now)
+	if _, limited := m.rateLimited("a1", now); !limited {
+		t.Fatalf("rpm: should be limited at 2/2")
+	}
+	if _, limited := m.rateLimited("a1", now.Add(61*time.Second)); limited {
+		t.Fatalf("rpm: should recover after the window expires")
+	}
+
+	// TPM: independent window keyed on tokens.
+	SetRateLimitDefaults(0, 100, 0)
+	a2 := &Auth{ID: "a2", Provider: "claude"}
+	m.auths["a2"] = a2
+	a2.rate.addTokens(now, 100)
+	if _, limited := m.rateLimited("a2", now); !limited {
+		t.Fatalf("tpm: should be limited at 100/100")
+	}
+
+	// Concurrency: limit 1 -> blocked while one request is in flight.
+	SetRateLimitDefaults(0, 0, 1)
+	a3 := &Auth{ID: "a3", Provider: "claude"}
+	m.auths["a3"] = a3
+	a3.rate.acquire()
+	if _, limited := m.rateLimited("a3", now); !limited {
+		t.Fatalf("concurrency: should be limited at 1 in-flight/1")
+	}
+	a3.rate.release()
+	if _, limited := m.rateLimited("a3", now); limited {
+		t.Fatalf("concurrency: should be free after release")
+	}
+}
+
+func TestRateLimitPerAccountOverride(t *testing.T) {
+	defer SetRateLimitDefaults(0, 0, 0)
+	// Global RPM disabled; the per-account override must still apply.
+	SetRateLimitDefaults(0, 0, 0)
+	m := NewManager(nil, nil, nil)
+	a := &Auth{ID: "a1", Provider: "claude", Metadata: map[string]any{"rpm_limit": 1}}
+	m.auths["a1"] = a
+	now := time.Unix(1_700_000_000, 0)
+
+	a.rate.addRequest(now)
+	if _, limited := m.rateLimited("a1", now); !limited {
+		t.Fatalf("override: should be limited at 1/1 via metadata rpm_limit")
+	}
+}

--- a/sdk/cliproxy/auth/rate_window_test.go
+++ b/sdk/cliproxy/auth/rate_window_test.go
@@ -48,14 +48,14 @@ func TestRateWindowInFlight(t *testing.T) {
 }
 
 func TestRateLimitedRPMTPMConcurrency(t *testing.T) {
-	defer SetRateLimitDefaults(0, 0, 0)
+	defer SetRateLimitDefaults(0, 0, 0, 0)
 	m := NewManager(nil, nil, nil)
 	a := &Auth{ID: "a1", Provider: "claude"}
 	m.auths["a1"] = a
 	now := time.Unix(1_700_000_000, 0)
 
 	// RPM: limit 2 -> blocked once two requests are recorded in the window.
-	SetRateLimitDefaults(2, 0, 0)
+	SetRateLimitDefaults(2, 0, 0, 0)
 	a.rate.addRequest(now)
 	if _, limited := m.rateLimited("a1", now); limited {
 		t.Fatalf("rpm: should not be limited at 1/2")
@@ -69,7 +69,7 @@ func TestRateLimitedRPMTPMConcurrency(t *testing.T) {
 	}
 
 	// TPM: independent window keyed on tokens.
-	SetRateLimitDefaults(0, 100, 0)
+	SetRateLimitDefaults(0, 100, 0, 0)
 	a2 := &Auth{ID: "a2", Provider: "claude"}
 	m.auths["a2"] = a2
 	a2.rate.addTokens(now, 100)
@@ -78,7 +78,7 @@ func TestRateLimitedRPMTPMConcurrency(t *testing.T) {
 	}
 
 	// Concurrency: limit 1 -> blocked while one request is in flight.
-	SetRateLimitDefaults(0, 0, 1)
+	SetRateLimitDefaults(0, 0, 1, 0)
 	a3 := &Auth{ID: "a3", Provider: "claude"}
 	m.auths["a3"] = a3
 	a3.rate.acquire()
@@ -91,10 +91,33 @@ func TestRateLimitedRPMTPMConcurrency(t *testing.T) {
 	}
 }
 
+func TestRateLimitedRPH(t *testing.T) {
+	defer SetRateLimitDefaults(0, 0, 0, 0)
+	m := NewManager(nil, nil, nil)
+	a := &Auth{ID: "a1", Provider: "claude"}
+	m.auths["a1"] = a
+	now := time.Unix(1_700_000_000, 0)
+
+	SetRateLimitDefaults(0, 0, 0, 2)
+	a.rate.addRequest(now)
+	if _, limited := m.rateLimited("a1", now); limited {
+		t.Fatalf("rph: should not be limited at 1/2")
+	}
+	a.rate.addRequest(now.Add(30 * time.Minute))
+	if retryAt, limited := m.rateLimited("a1", now.Add(30*time.Minute)); !limited {
+		t.Fatalf("rph: should be limited at 2/2")
+	} else if !retryAt.After(now.Add(59 * time.Minute)) {
+		t.Fatalf("rph: retryAt=%s, want after the trailing hour starts expiring", retryAt)
+	}
+	if _, limited := m.rateLimited("a1", now.Add(61*time.Minute)); limited {
+		t.Fatalf("rph: should recover after the hourly window expires")
+	}
+}
+
 func TestRateLimitPerAccountOverride(t *testing.T) {
-	defer SetRateLimitDefaults(0, 0, 0)
+	defer SetRateLimitDefaults(0, 0, 0, 0)
 	// Global RPM disabled; the per-account override must still apply.
-	SetRateLimitDefaults(0, 0, 0)
+	SetRateLimitDefaults(0, 0, 0, 0)
 	m := NewManager(nil, nil, nil)
 	a := &Auth{ID: "a1", Provider: "claude", Metadata: map[string]any{"rpm_limit": 1}}
 	m.auths["a1"] = a
@@ -103,5 +126,19 @@ func TestRateLimitPerAccountOverride(t *testing.T) {
 	a.rate.addRequest(now)
 	if _, limited := m.rateLimited("a1", now); !limited {
 		t.Fatalf("override: should be limited at 1/1 via metadata rpm_limit")
+	}
+}
+
+func TestRateLimitPerAccountRPHOverride(t *testing.T) {
+	defer SetRateLimitDefaults(0, 0, 0, 0)
+	SetRateLimitDefaults(0, 0, 0, 0)
+	m := NewManager(nil, nil, nil)
+	a := &Auth{ID: "a1", Provider: "claude", Metadata: map[string]any{"rph_limit": 1}}
+	m.auths["a1"] = a
+	now := time.Unix(1_700_000_000, 0)
+
+	a.rate.addRequest(now)
+	if _, limited := m.rateLimited("a1", now); !limited {
+		t.Fatalf("override: should be limited at 1/1 via metadata rph_limit")
 	}
 }

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -98,6 +98,11 @@ type Auth struct {
 
 	recentRequests recentRequestRing `json:"-"`
 	indexAssigned  bool              `json:"-"`
+
+	// rate tracks per-account RPM/TPM sliding-window counts and in-flight
+	// concurrency for proactive rate limiting. Access is guarded by the owning
+	// Manager's mutex (same pattern as recentRequests); see rate_window.go.
+	rate rateWindow `json:"-"`
 }
 
 const (
@@ -444,6 +449,41 @@ func (a *Auth) RequestRetryOverride() (int, bool) {
 		}
 	}
 	return 0, false
+}
+
+// rateLimitOverride reads a non-negative integer override from the auth metadata
+// under the given primary/legacy keys. A value <= 0 is treated as "not set" so
+// the global default still applies.
+func (a *Auth) rateLimitOverride(primaryKey, legacyKey string) (int, bool) {
+	if a == nil || a.Metadata == nil {
+		return 0, false
+	}
+	for _, key := range []string{primaryKey, legacyKey} {
+		if val, ok := a.Metadata[key]; ok {
+			if parsed, okParse := parseIntAny(val); okParse && parsed > 0 {
+				return parsed, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// RPMLimitOverride returns the auth-scoped requests-per-minute limit when set
+// (metadata key "rpm_limit" or legacy "rpm-limit").
+func (a *Auth) RPMLimitOverride() (int, bool) {
+	return a.rateLimitOverride("rpm_limit", "rpm-limit")
+}
+
+// TPMLimitOverride returns the auth-scoped tokens-per-minute limit when set
+// (metadata key "tpm_limit" or legacy "tpm-limit").
+func (a *Auth) TPMLimitOverride() (int, bool) {
+	return a.rateLimitOverride("tpm_limit", "tpm-limit")
+}
+
+// ConcurrencyLimitOverride returns the auth-scoped max in-flight request limit
+// when set (metadata key "concurrency_limit" or legacy "concurrency-limit").
+func (a *Auth) ConcurrencyLimitOverride() (int, bool) {
+	return a.rateLimitOverride("concurrency_limit", "concurrency-limit")
 }
 
 func parseBoolAny(val any) (bool, bool) {

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -99,6 +99,12 @@ type Auth struct {
 	recentRequests recentRequestRing `json:"-"`
 	indexAssigned  bool              `json:"-"`
 
+	// warnings retains recent operator-facing warnings (failed requests,
+	// rate-limit/usage-window parks, etc.) so the management API can report what
+	// happened, when, and how often. Access is guarded by the owning Manager's
+	// mutex (same pattern as recentRequests); see warning_ring.go.
+	warnings warningRing `json:"-"`
+
 	// rate tracks per-account RPM/TPM sliding-window counts and in-flight
 	// concurrency for proactive rate limiting. Access is guarded by the owning
 	// Manager's mutex (same pattern as recentRequests); see rate_window.go.
@@ -484,6 +490,12 @@ func (a *Auth) TPMLimitOverride() (int, bool) {
 // when set (metadata key "concurrency_limit" or legacy "concurrency-limit").
 func (a *Auth) ConcurrencyLimitOverride() (int, bool) {
 	return a.rateLimitOverride("concurrency_limit", "concurrency-limit")
+}
+
+// RPHLimitOverride returns the auth-scoped requests-per-hour limit when set
+// (metadata key "rph_limit" or legacy "rph-limit").
+func (a *Auth) RPHLimitOverride() (int, bool) {
+	return a.rateLimitOverride("rph_limit", "rph-limit")
 }
 
 func parseBoolAny(val any) (bool, bool) {

--- a/sdk/cliproxy/auth/warning_ring.go
+++ b/sdk/cliproxy/auth/warning_ring.go
@@ -1,0 +1,146 @@
+package auth
+
+import (
+	"strings"
+	"time"
+)
+
+// warningRingCapacity bounds how many distinct recent warnings are retained per
+// auth. Older distinct warnings are evicted in newest-wins order once the ring
+// is full. Consecutive identical warnings are coalesced (see warningRing.record)
+// so a credential failing the same way repeatedly occupies a single slot.
+const warningRingCapacity = 50
+
+// WarningEvent is an operator-facing record of a warning that affected an auth:
+// a failed request, a quota/rate-limit cooldown, a provider usage-window park,
+// etc. It is exposed via the management API so operators can answer "what
+// happened, when, and how many times" without grepping ephemeral logs.
+type WarningEvent struct {
+	// Kind classifies the warning (e.g. "rate_limit", "unauthorized",
+	// "usage_limit", "server_error").
+	Kind string `json:"kind"`
+	// Code is the provider/machine-readable error code, when available.
+	Code string `json:"code,omitempty"`
+	// Message is the human readable description.
+	Message string `json:"message"`
+	// HTTPStatus records the HTTP-like status code, when available.
+	HTTPStatus int `json:"http_status,omitempty"`
+	// Model identifies the model involved, when the warning is model-scoped.
+	Model string `json:"model,omitempty"`
+	// Count is how many consecutive times this same warning was observed.
+	Count int64 `json:"count"`
+	// FirstAt is when this warning was first observed (UTC).
+	FirstAt time.Time `json:"first_at"`
+	// LastAt is when this warning was most recently observed (UTC).
+	LastAt time.Time `json:"last_at"`
+}
+
+// warningRing is a fixed-capacity, newest-wins ring of WarningEvent plus a
+// monotonic total counter.
+//
+// Like recentRequestRing and rateWindow, warningRing is intentionally NOT
+// internally synchronized: every access must happen while holding the owning
+// Manager's mutex. This keeps Auth.Clone() (a by-value copy) free of lock-copy
+// hazards.
+type warningRing struct {
+	events [warningRingCapacity]WarningEvent
+	// next is the index of the next write slot.
+	next int
+	// count is the number of valid entries currently stored (<= capacity).
+	count int
+	// total is the monotonic lifetime count of warnings recorded; it never
+	// decreases even when older distinct warnings are evicted.
+	total int64
+}
+
+// warningEventsEqual reports whether two warnings are the "same" for coalescing
+// purposes (identical classification, status, message and model).
+func warningEventsEqual(a *WarningEvent, kind, code, message string, httpStatus int, model string) bool {
+	return a.Kind == kind &&
+		a.Code == code &&
+		a.Message == message &&
+		a.HTTPStatus == httpStatus &&
+		a.Model == model
+}
+
+// record appends a warning, coalescing it with the most recent entry when it is
+// identical (bumping that entry's Count and LastAt instead of consuming a new
+// slot). total is always incremented.
+func (w *warningRing) record(at time.Time, kind, code, message string, httpStatus int, model string) {
+	if at.IsZero() {
+		at = time.Now()
+	}
+	at = at.UTC()
+	kind = strings.TrimSpace(kind)
+	if kind == "" {
+		kind = "error"
+	}
+	message = strings.TrimSpace(message)
+
+	w.total++
+
+	if w.count > 0 {
+		lastIdx := (w.next - 1 + warningRingCapacity) % warningRingCapacity
+		last := &w.events[lastIdx]
+		if warningEventsEqual(last, kind, code, message, httpStatus, model) {
+			last.Count++
+			last.LastAt = at
+			return
+		}
+	}
+
+	w.events[w.next] = WarningEvent{
+		Kind:       kind,
+		Code:       code,
+		Message:    message,
+		HTTPStatus: httpStatus,
+		Model:      model,
+		Count:      1,
+		FirstAt:    at,
+		LastAt:     at,
+	}
+	w.next = (w.next + 1) % warningRingCapacity
+	if w.count < warningRingCapacity {
+		w.count++
+	}
+}
+
+// snapshot returns the retained warnings newest-first, along with the monotonic
+// lifetime total.
+func (w *warningRing) snapshot() ([]WarningEvent, int64) {
+	out := make([]WarningEvent, 0, w.count)
+	for i := 0; i < w.count; i++ {
+		idx := (w.next - 1 - i + warningRingCapacity*2) % warningRingCapacity
+		out = append(out, w.events[idx])
+	}
+	return out, w.total
+}
+
+// recordWarning records an operator-facing warning for this auth. Callers must
+// hold the owning Manager's mutex (same discipline as recordRecentRequest).
+func (a *Auth) recordWarning(at time.Time, kind, code, message string, httpStatus int, model string) {
+	if a == nil {
+		return
+	}
+	a.warnings.record(at, kind, code, message, httpStatus, model)
+}
+
+// WarningsSnapshot returns the retained recent warnings (newest first) and the
+// monotonic lifetime total observed for this auth. It is read from a cloned Auth
+// in the management API, so it is race-free without additional locking.
+func (a *Auth) WarningsSnapshot() ([]WarningEvent, int64) {
+	if a == nil {
+		return nil, 0
+	}
+	return a.warnings.snapshot()
+}
+
+// UsageLimitUntil returns the time until which this auth is parked due to a
+// provider usage window (e.g. Claude's rolling 5h/7d limit), or the zero time
+// when no park is active. Read from a cloned Auth, it is race-free.
+func (a *Auth) UsageLimitUntil() time.Time {
+	if a == nil {
+		return time.Time{}
+	}
+	return a.rate.usageLimitUntil
+}

--- a/sdk/cliproxy/auth/warning_ring_test.go
+++ b/sdk/cliproxy/auth/warning_ring_test.go
@@ -1,0 +1,95 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWarningRingCoalescesConsecutiveDuplicates(t *testing.T) {
+	a := &Auth{}
+	base := time.Date(2026, 5, 30, 10, 0, 0, 0, time.UTC)
+
+	a.recordWarning(base, "rate_limit", "", "429 too many requests", 429, "claude-3")
+	a.recordWarning(base.Add(time.Second), "rate_limit", "", "429 too many requests", 429, "claude-3")
+	a.recordWarning(base.Add(2*time.Second), "rate_limit", "", "429 too many requests", 429, "claude-3")
+
+	events, total := a.WarningsSnapshot()
+	if total != 3 {
+		t.Fatalf("total = %d, want 3", total)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1 (coalesced)", len(events))
+	}
+	if events[0].Count != 3 {
+		t.Fatalf("Count = %d, want 3", events[0].Count)
+	}
+	if !events[0].FirstAt.Equal(base) {
+		t.Fatalf("FirstAt = %v, want %v", events[0].FirstAt, base)
+	}
+	if !events[0].LastAt.Equal(base.Add(2 * time.Second)) {
+		t.Fatalf("LastAt = %v, want %v", events[0].LastAt, base.Add(2*time.Second))
+	}
+}
+
+func TestWarningRingSnapshotNewestFirst(t *testing.T) {
+	a := &Auth{}
+	base := time.Date(2026, 5, 30, 10, 0, 0, 0, time.UTC)
+
+	a.recordWarning(base, "unauthorized", "", "401", 401, "")
+	a.recordWarning(base.Add(time.Second), "rate_limit", "", "429", 429, "")
+	a.recordWarning(base.Add(2*time.Second), "server_error", "", "503", 503, "")
+
+	events, total := a.WarningsSnapshot()
+	if total != 3 {
+		t.Fatalf("total = %d, want 3", total)
+	}
+	want := []string{"server_error", "rate_limit", "unauthorized"}
+	if len(events) != len(want) {
+		t.Fatalf("len(events) = %d, want %d", len(events), len(want))
+	}
+	for i, kind := range want {
+		if events[i].Kind != kind {
+			t.Fatalf("events[%d].Kind = %q, want %q", i, events[i].Kind, kind)
+		}
+	}
+}
+
+func TestWarningRingEvictsButKeepsTotal(t *testing.T) {
+	a := &Auth{}
+	base := time.Date(2026, 5, 30, 10, 0, 0, 0, time.UTC)
+
+	// Record more distinct warnings than the ring capacity.
+	n := warningRingCapacity + 10
+	for i := 0; i < n; i++ {
+		a.recordWarning(base.Add(time.Duration(i)*time.Second), "error", "", "msg", 500+i, "")
+	}
+
+	events, total := a.WarningsSnapshot()
+	if total != int64(n) {
+		t.Fatalf("total = %d, want %d", total, n)
+	}
+	if len(events) != warningRingCapacity {
+		t.Fatalf("len(events) = %d, want %d (capacity)", len(events), warningRingCapacity)
+	}
+	// Newest entry should be the last recorded one.
+	if events[0].HTTPStatus != 500+n-1 {
+		t.Fatalf("newest HTTPStatus = %d, want %d", events[0].HTTPStatus, 500+n-1)
+	}
+}
+
+func TestWarningRingClonedByValue(t *testing.T) {
+	a := &Auth{}
+	a.recordWarning(time.Now(), "error", "", "boom", 500, "")
+	clone := a.Clone()
+	// Mutating the clone must not affect the original ring.
+	clone.recordWarning(time.Now(), "error2", "", "boom2", 500, "")
+
+	_, origTotal := a.WarningsSnapshot()
+	_, cloneTotal := clone.WarningsSnapshot()
+	if origTotal != 1 {
+		t.Fatalf("original total = %d, want 1 (clone is by-value)", origTotal)
+	}
+	if cloneTotal != 2 {
+		t.Fatalf("clone total = %d, want 2", cloneTotal)
+	}
+}

--- a/sdk/cliproxy/rtprovider.go
+++ b/sdk/cliproxy/rtprovider.go
@@ -38,7 +38,9 @@ func (p *defaultRoundTripperProvider) RoundTripperFor(auth *coreauth.Auth) http.
 	}
 	transport, _, errBuild := proxyutil.BuildHTTPTransport(proxyStr)
 	if errBuild != nil {
-		log.Errorf("%v", errBuild)
+		// Include a redacted form of the proxy URL so operators can identify
+		// which auth's proxy is misconfigured without leaking credentials.
+		log.Errorf("build per-auth proxy transport failed for %q: %v", proxyutil.Redact(proxyStr), errBuild)
 		return nil
 	}
 	if transport == nil {

--- a/sdk/proxyutil/proxy.go
+++ b/sdk/proxyutil/proxy.go
@@ -264,3 +264,20 @@ func (c *bufferedConn) Read(p []byte) (int, error) {
 	}
 	return c.Conn.Read(p)
 }
+
+// FailClosedDialer is a proxy.Dialer that always returns the cached error on
+// Dial. Use it when a proxy URL was configured but could not be parsed: every
+// connection deliberately fails instead of silently falling back to a direct
+// connection, which would leak the host's IP for an account intentionally
+// bound to a proxy.
+type FailClosedDialer struct {
+	Err error
+}
+
+// Dial always returns FailClosedDialer.Err wrapped with proxy context.
+func (d FailClosedDialer) Dial(network, addr string) (net.Conn, error) {
+	if d.Err == nil {
+		return nil, fmt.Errorf("proxy unavailable")
+	}
+	return nil, fmt.Errorf("proxy unavailable: %w", d.Err)
+}


### PR DESCRIPTION
## What changed

- Added a 15 second timeout around proxy connection establishment for SOCKS5 and HTTP CONNECT dialers.
- Kept the timeout limited to credential/proxy acquisition so established upstream connections are not cut off.

## Why

Bad or unreachable account proxies could previously wait on OS-level TCP timeouts, causing downstream requests to fail only after a long delay. This makes unavailable proxies fail fast while preserving long-running upstream behavior after a connection is established.

## Validation

- go test ./sdk/proxyutil
- go build -o test-output ./cmd/server && rm test-output
