### PR TITLE
fix(registry): sync embedded Kimi K3 catalog

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2190,6 +2190,26 @@
           "high"
         ]
       }
+    },
+    {
+      "id": "kimi-k3",
+      "object": "model",
+      "created": 1784073600,
+      "owned_by": "moonshot",
+      "type": "kimi",
+      "display_name": "Kimi K3",
+      "description": "Kimi K3 - Moonshot AI's next-generation flagship model (~2.5T MoE) with multimodal input and 1M context",
+      "context_length": 1048576,
+      "max_completion_tokens": 65536,
+      "thinking": {
+        "min": 1024,
+        "max": 32000,
+        "zero_allowed": false,
+        "dynamic_allowed": true,
+        "levels": [
+          "max"
+        ]
+      }
     }
   ],
   "antigravity": [


### PR DESCRIPTION
## Summary

Sync the embedded Kimi catalog with the remote catalog's existing `kimi-k3` definition.

Default CPA instances already receive K3 through the remote model updater. This one-file change makes the same model available when `--local-model` disables remote updates, or when startup cannot reach the remote catalog. The existing executor already maps `kimi-k3` to the documented upstream ID `k3` through its generic `kimi-` prefix handling.

## Verification

- confirmed the embedded and remote `kimi-k3` definitions are byte-for-byte equivalent after JSON parsing
- live pre-PR CPA instance: `/v1/models` returned `kimi-k3`
- live pre-PR CPA instance: non-streaming `kimi-k3` completion returned HTTP 200 with upstream model `k3`
- `go test ./internal/registry`
- `go build -o test-output ./cmd/server && rm test-output`

Closes #4377