### PR TITLE
fix(codex): discover models per OAuth account

### DIFF
--- a/cmd/fetch_codex_models/main.go
+++ b/cmd/fetch_codex_models/main.go
@@ -21,9 +21,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,11 +38,7 @@ import (
 )
 
 const (
-	codexModelsBaseURL       = "https://chatgpt.com/backend-api/codex"
-	codexModelsPath          = "/models"
-	defaultClientVersion     = "0.144.1"
-	defaultCodexUserAgent    = "codex_cli_rs/0.144.1 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9"
-	defaultCodexOriginator   = "codex_cli_rs"
+	defaultClientVersion     = codexauth.DefaultModelsClientVersion
 	accessTokenRefreshLeeway = 30 * time.Second
 )
 
@@ -229,85 +223,29 @@ func ensureAccessToken(ctx context.Context, store *sdkauth.FileTokenStore, auth 
 }
 
 func fetchModels(ctx context.Context, auth *coreauth.Auth, accessToken, clientVersion string) ([]byte, int, error) {
-	modelsURL, errURL := codexModelsURL(clientVersion)
-	if errURL != nil {
-		return nil, 0, errURL
-	}
-
-	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
-	if errReq != nil {
-		return nil, 0, errReq
-	}
-	httpReq.Close = true
-	httpReq.Header.Set("Accept", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+accessToken)
-	httpReq.Header.Set("Originator", defaultCodexOriginator)
-	httpReq.Header.Set("User-Agent", defaultCodexUserAgent)
-	if accountID := metaStringValue(auth.Metadata, "account_id"); accountID != "" {
-		httpReq.Header.Set("Chatgpt-Account-Id", accountID)
-	}
-	if auth != nil {
-		util.ApplyCustomHeadersFromAttrs(httpReq, auth.Attributes)
-	}
-
 	httpClient := &http.Client{}
 	if auth != nil {
 		if transport, _, errProxy := proxyutil.BuildHTTPTransport(auth.ProxyURL); errProxy == nil && transport != nil {
 			httpClient.Transport = transport
 		}
 	}
-
-	httpResp, errDo := httpClient.Do(httpReq)
-	if errDo != nil {
-		return nil, 0, errDo
+	customRequest := &http.Request{Header: make(http.Header)}
+	accountID := ""
+	if auth != nil {
+		util.ApplyCustomHeadersFromAttrs(customRequest, auth.Attributes)
+		accountID = metaStringValue(auth.Metadata, "account_id")
 	}
-
-	bodyBytes, errRead := io.ReadAll(httpResp.Body)
-	if errClose := httpResp.Body.Close(); errClose != nil && errRead == nil {
-		errRead = errClose
+	catalog, errFetch := codexauth.FetchModelsCatalog(ctx, httpClient, codexauth.ModelsRequest{
+		AccessToken:   accessToken,
+		AccountID:     accountID,
+		ClientVersion: clientVersion,
+		Headers:       customRequest.Header,
+		Host:          customRequest.Host,
+	})
+	if errFetch != nil {
+		return nil, 0, errFetch
 	}
-	if errRead != nil {
-		return nil, 0, errRead
-	}
-
-	if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
-		return nil, 0, fmt.Errorf("models request failed with status %d: %s", httpResp.StatusCode, strings.TrimSpace(string(bodyBytes)))
-	}
-
-	count, errCount := countModels(bodyBytes)
-	if errCount != nil {
-		return nil, 0, errCount
-	}
-	return bodyBytes, count, nil
-}
-
-func codexModelsURL(clientVersion string) (string, error) {
-	u, err := url.Parse(codexModelsBaseURL + codexModelsPath)
-	if err != nil {
-		return "", err
-	}
-	if strings.TrimSpace(clientVersion) != "" {
-		q := u.Query()
-		q.Set("client_version", strings.TrimSpace(clientVersion))
-		u.RawQuery = q.Encode()
-	}
-	return u.String(), nil
-}
-
-func countModels(raw []byte) (int, error) {
-	var payload struct {
-		Models []json.RawMessage `json:"models"`
-	}
-	if err := json.Unmarshal(raw, &payload); err != nil {
-		return 0, fmt.Errorf("failed to parse response JSON: %w", err)
-	}
-	// Keep this check intentionally loose: fetch_codex_models dumps the upstream
-	// Codex API payload. Strict CPA catalog validation belongs in
-	// cmd/validate_codex_models and registry.ValidateCodexClientModelsJSON.
-	if payload.Models == nil {
-		return 0, fmt.Errorf("response JSON does not contain models array")
-	}
-	return len(payload.Models), nil
+	return catalog.Raw, len(catalog.Models), nil
 }
 
 func prettyJSON(raw []byte) ([]byte, error) {

--- a/cmd/fetch_codex_models/main_test.go
+++ b/cmd/fetch_codex_models/main_test.go
@@ -2,47 +2,13 @@ package main
 
 import "testing"
 
-func TestCodexModelsURL(t *testing.T) {
-	got, err := codexModelsURL(" 0.144.1 ")
+func TestPrettyJSON(t *testing.T) {
+	got, err := prettyJSON([]byte(`{"models":[{"slug":"gpt-5.6-sol"}]}`))
 	if err != nil {
-		t.Fatalf("codexModelsURL: %v", err)
+		t.Fatalf("prettyJSON() error = %v", err)
 	}
-	want := "https://chatgpt.com/backend-api/codex/models?client_version=0.144.1"
-	if got != want {
-		t.Fatalf("codexModelsURL = %q, want %q", got, want)
-	}
-}
-
-func TestCountModels(t *testing.T) {
-	count, err := countModels([]byte(`{"models":[{"slug":"a"},{"slug":"b"}]}`))
-	if err != nil {
-		t.Fatalf("countModels(valid): %v", err)
-	}
-	if count != 2 {
-		t.Fatalf("countModels(valid) = %d, want 2", count)
-	}
-
-	// Upstream dumps may omit CPA catalog-required fields; counting must still work.
-	count, err = countModels([]byte(`{"models":[{"slug":"gpt-5.6-sol"}]}`))
-	if err != nil {
-		t.Fatalf("countModels(incomplete upstream model): %v", err)
-	}
-	if count != 1 {
-		t.Fatalf("countModels(incomplete upstream model) = %d, want 1", count)
-	}
-
-	count, err = countModels([]byte(`{"models":[]}`))
-	if err != nil {
-		t.Fatalf("countModels(empty): %v", err)
-	}
-	if count != 0 {
-		t.Fatalf("countModels(empty) = %d, want 0", count)
-	}
-
-	if _, err := countModels([]byte(`{"models":`)); err == nil {
-		t.Fatal("countModels(malformed) error = nil, want error")
-	}
-	if _, err := countModels([]byte(`{}`)); err == nil {
-		t.Fatal("countModels(missing models) error = nil, want error")
+	want := "{\n  \"models\": [\n    {\n      \"slug\": \"gpt-5.6-sol\"\n    }\n  ]\n}\n"
+	if string(got) != want {
+		t.Fatalf("prettyJSON() = %q, want %q", string(got), want)
 	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -491,6 +491,7 @@ func main() {
 	if cfg == nil {
 		cfg = &config.Config{}
 	}
+	cfg.DisableCodexModelDiscovery = localModel
 
 	// In cloud deploy mode, check if we have a valid configuration
 	var configFileExists bool

--- a/internal/auth/codex/models.go
+++ b/internal/auth/codex/models.go
@@ -1,0 +1,201 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	DefaultModelsBaseURL       = "https://chatgpt.com/backend-api/codex"
+	DefaultModelsClientVersion = "0.144.1"
+	DefaultModelsUserAgent     = "codex_cli_rs/0.144.1 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9"
+	DefaultModelsOriginator    = "codex_cli_rs"
+	maxModelsCatalogSize       = 8 << 20
+	maxModelsErrorBodySize     = 4 << 10
+)
+
+// ModelCatalogReasoningLevel describes one reasoning effort advertised by Codex.
+type ModelCatalogReasoningLevel struct {
+	Effort      string `json:"effort"`
+	Description string `json:"description"`
+}
+
+// ModelCatalogEntry contains the upstream fields needed for runtime model registration.
+type ModelCatalogEntry struct {
+	Slug                     string                       `json:"slug"`
+	DisplayName              string                       `json:"display_name"`
+	Description              string                       `json:"description"`
+	ContextWindow            int                          `json:"context_window"`
+	MaxContextWindow         int                          `json:"max_context_window"`
+	SupportedReasoningLevels []ModelCatalogReasoningLevel `json:"supported_reasoning_levels"`
+}
+
+// ModelsCatalog is a validated upstream Codex model catalog.
+type ModelsCatalog struct {
+	Raw    []byte
+	Models []ModelCatalogEntry
+}
+
+// ModelsRequest configures an authenticated Codex model catalog request.
+type ModelsRequest struct {
+	BaseURL       string
+	ClientVersion string
+	AccessToken   string
+	AccountID     string
+	UserAgent     string
+	Originator    string
+	Headers       http.Header
+	Host          string
+}
+
+// FetchModelsCatalog fetches and validates the model catalog available to one Codex account.
+func FetchModelsCatalog(ctx context.Context, client *http.Client, request ModelsRequest) (*ModelsCatalog, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	accessToken := strings.TrimSpace(request.AccessToken)
+	if accessToken == "" {
+		return nil, fmt.Errorf("Codex models request missing access token")
+	}
+
+	modelsURL, errURL := ModelsURL(request.BaseURL, request.ClientVersion)
+	if errURL != nil {
+		return nil, errURL
+	}
+	req, errReq := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
+	if errReq != nil {
+		return nil, fmt.Errorf("create Codex models request: %w", errReq)
+	}
+	req.Close = true
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	originator := strings.TrimSpace(request.Originator)
+	if originator == "" {
+		originator = DefaultModelsOriginator
+	}
+	req.Header.Set("Originator", originator)
+	userAgent := strings.TrimSpace(request.UserAgent)
+	if userAgent == "" {
+		userAgent = DefaultModelsUserAgent
+	}
+	req.Header.Set("User-Agent", userAgent)
+	if accountID := strings.TrimSpace(request.AccountID); accountID != "" {
+		req.Header.Set("Chatgpt-Account-Id", accountID)
+	}
+	for name, values := range request.Headers {
+		if strings.TrimSpace(name) == "" {
+			continue
+		}
+		req.Header.Del(name)
+		for _, value := range values {
+			if value = strings.TrimSpace(value); value != "" {
+				req.Header.Add(name, value)
+			}
+		}
+	}
+	if host := strings.TrimSpace(request.Host); host != "" {
+		req.Host = host
+	}
+
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, errDo := client.Do(req)
+	if errDo != nil {
+		return nil, fmt.Errorf("fetch Codex models: %w", errDo)
+	}
+	body, errRead := io.ReadAll(io.LimitReader(resp.Body, maxModelsCatalogSize+1))
+	errClose := resp.Body.Close()
+	if errRead != nil {
+		return nil, fmt.Errorf("read Codex models response: %w", errRead)
+	}
+	if errClose != nil {
+		return nil, fmt.Errorf("close Codex models response: %w", errClose)
+	}
+	if len(body) > maxModelsCatalogSize {
+		return nil, fmt.Errorf("Codex models response exceeded %d bytes", maxModelsCatalogSize)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		detail := strings.TrimSpace(string(body))
+		if len(detail) > maxModelsErrorBodySize {
+			detail = detail[:maxModelsErrorBodySize] + "..."
+		}
+		return nil, fmt.Errorf("Codex models request failed with status %d: %s", resp.StatusCode, detail)
+	}
+
+	models, errParse := ParseModelsCatalog(body)
+	if errParse != nil {
+		return nil, errParse
+	}
+	return &ModelsCatalog{Raw: append([]byte(nil), body...), Models: models}, nil
+}
+
+// ModelsURL returns the upstream model catalog URL for a Codex base URL.
+func ModelsURL(baseURL, clientVersion string) (string, error) {
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		baseURL = DefaultModelsBaseURL
+	}
+	u, err := url.Parse(strings.TrimRight(baseURL, "/") + "/models")
+	if err != nil {
+		return "", fmt.Errorf("parse Codex models URL: %w", err)
+	}
+	if clientVersion = strings.TrimSpace(clientVersion); clientVersion != "" {
+		query := u.Query()
+		query.Set("client_version", clientVersion)
+		u.RawQuery = query.Encode()
+	}
+	return u.String(), nil
+}
+
+// ParseModelsCatalog validates and normalizes an upstream Codex model catalog.
+func ParseModelsCatalog(raw []byte) ([]ModelCatalogEntry, error) {
+	var payload struct {
+		Models []ModelCatalogEntry `json:"models"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, fmt.Errorf("decode Codex models response: %w", err)
+	}
+	if len(payload.Models) == 0 {
+		return nil, fmt.Errorf("Codex models response has no models")
+	}
+
+	models := make([]ModelCatalogEntry, 0, len(payload.Models))
+	seen := make(map[string]struct{}, len(payload.Models))
+	for index := range payload.Models {
+		model := payload.Models[index]
+		model.Slug = strings.TrimSpace(model.Slug)
+		if model.Slug == "" {
+			return nil, fmt.Errorf("Codex models response models[%d] has empty slug", index)
+		}
+		key := strings.ToLower(model.Slug)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		model.DisplayName = strings.TrimSpace(model.DisplayName)
+		model.Description = strings.TrimSpace(model.Description)
+		levels := make([]ModelCatalogReasoningLevel, 0, len(model.SupportedReasoningLevels))
+		seenLevels := make(map[string]struct{}, len(model.SupportedReasoningLevels))
+		for _, level := range model.SupportedReasoningLevels {
+			level.Effort = strings.ToLower(strings.TrimSpace(level.Effort))
+			if level.Effort == "" {
+				continue
+			}
+			if _, exists := seenLevels[level.Effort]; exists {
+				continue
+			}
+			seenLevels[level.Effort] = struct{}{}
+			level.Description = strings.TrimSpace(level.Description)
+			levels = append(levels, level)
+		}
+		model.SupportedReasoningLevels = levels
+		models = append(models, model)
+	}
+	return models, nil
+}

--- a/internal/auth/codex/models_test.go
+++ b/internal/auth/codex/models_test.go
@@ -1,0 +1,119 @@
+package codex
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFetchModelsCatalog(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			t.Errorf("path = %q, want /models", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("client_version"); got != "0.144.1" {
+			t.Errorf("client_version = %q, want 0.144.1", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer access-token" {
+			t.Errorf("Authorization = %q", got)
+		}
+		if got := r.Header.Get("Chatgpt-Account-Id"); got != "account-1" {
+			t.Errorf("Chatgpt-Account-Id = %q", got)
+		}
+		if got := r.Header.Get("Originator"); got != "test-origin" {
+			t.Errorf("Originator = %q", got)
+		}
+		if got := r.Header.Get("User-Agent"); got != "test-agent" {
+			t.Errorf("User-Agent = %q", got)
+		}
+		if got := r.Header.Get("X-Test"); got != "custom" {
+			t.Errorf("X-Test = %q", got)
+		}
+		_, _ = w.Write([]byte(`{"models":[{"slug":" gpt-5.6-sol ","supported_reasoning_levels":[{"effort":"HIGH"},{"effort":"high"}]},{"slug":"GPT-5.6-SOL"},{"slug":"gpt-5.6-luna"}]}`))
+	}))
+	defer server.Close()
+
+	catalog, err := FetchModelsCatalog(context.Background(), server.Client(), ModelsRequest{
+		BaseURL:       server.URL,
+		ClientVersion: " 0.144.1 ",
+		AccessToken:   "access-token",
+		AccountID:     "account-1",
+		Originator:    "test-origin",
+		UserAgent:     "test-agent",
+		Headers:       http.Header{"X-Test": []string{"custom"}},
+	})
+	if err != nil {
+		t.Fatalf("FetchModelsCatalog() error = %v", err)
+	}
+	if len(catalog.Models) != 2 {
+		t.Fatalf("models = %d, want 2", len(catalog.Models))
+	}
+	if catalog.Models[0].Slug != "gpt-5.6-sol" {
+		t.Fatalf("first slug = %q", catalog.Models[0].Slug)
+	}
+	if got := catalog.Models[0].SupportedReasoningLevels; len(got) != 1 || got[0].Effort != "high" {
+		t.Fatalf("reasoning levels = %#v", got)
+	}
+}
+
+func TestFetchModelsCatalogRejectsInvalidResponses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "malformed", body: `{"models":`},
+		{name: "empty", body: `{"models":[]}`},
+		{name: "missing slug", body: `{"models":[{"display_name":"missing"}]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			_, err := FetchModelsCatalog(context.Background(), server.Client(), ModelsRequest{
+				BaseURL:     server.URL,
+				AccessToken: "access-token",
+			})
+			if err == nil {
+				t.Fatal("FetchModelsCatalog() error = nil, want error")
+			}
+		})
+	}
+}
+
+func TestFetchModelsCatalogRejectsOversizedResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("x", maxModelsCatalogSize+1)))
+	}))
+	defer server.Close()
+
+	_, err := FetchModelsCatalog(context.Background(), server.Client(), ModelsRequest{
+		BaseURL:     server.URL,
+		AccessToken: "access-token",
+	})
+	if err == nil || !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("FetchModelsCatalog() error = %v, want size error", err)
+	}
+}
+
+func TestModelsURL(t *testing.T) {
+	t.Parallel()
+
+	got, err := ModelsURL("https://example.com/backend-api/codex/", " 0.144.1 ")
+	if err != nil {
+		t.Fatalf("ModelsURL() error = %v", err)
+	}
+	if want := "https://example.com/backend-api/codex/models?client_version=0.144.1"; got != want {
+		t.Fatalf("ModelsURL() = %q, want %q", got, want)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,10 @@ type Config struct {
 	// Home config is runtime-only and is populated from -home-jwt.
 	Home HomeConfig `yaml:"-" json:"-"`
 
+	// DisableCodexModelDiscovery disables authenticated per-account Codex model discovery.
+	// It is runtime-only and is enabled by the --local-model command-line flag.
+	DisableCodexModelDiscovery bool `yaml:"-" json:"-"`
+
 	// RemoteManagement nests management-related options under 'remote-management'.
 	RemoteManagement RemoteManagement `yaml:"remote-management" json:"-"`
 

--- a/sdk/cliproxy/codex_models.go
+++ b/sdk/cliproxy/codex_models.go
@@ -151,18 +151,30 @@ func (s *Service) refreshDiscoveredCodexModels(ctx context.Context, auth *coreau
 		GlobalModelRegistry().UnregisterClient(auth.ID)
 		return
 	}
-	if !s.codexModelDiscoveryResultCurrent(auth.ID, identity, generation) || codexModelDiscoveryIdentity(latest) != identity {
-		s.completeModelRegistrationForAuth(ctx, latest)
+	s.reconcileDiscoveredCodexModelRegistration(ctx, latest, identity, generation)
+}
+
+func (s *Service) reconcileDiscoveredCodexModelRegistration(ctx context.Context, auth *coreauth.Auth, identity string, generation uint64) {
+	if s == nil || s.coreManager == nil || auth == nil || auth.ID == "" {
 		return
 	}
-	s.completeModelRegistrationForAuth(ctx, latest)
+	authID := auth.ID
+	if !s.codexModelDiscoveryResultCurrent(authID, identity, generation) || codexModelDiscoveryIdentity(auth) != identity {
+		current, exists := s.coreManager.GetByID(authID)
+		if !exists || current == nil || current.Disabled {
+			GlobalModelRegistry().UnregisterClient(authID)
+			return
+		}
+		auth = current
+	}
+	s.completeModelRegistrationForAuth(ctx, auth)
 
 	// An auth update can race between the pre-registration checks and the registry
 	// write. Restore the newest auth snapshot if that happened.
-	current, exists := s.coreManager.GetByID(auth.ID)
-	if !s.codexModelDiscoveryResultCurrent(auth.ID, identity, generation) || !exists || current == nil || current.Disabled || codexModelDiscoveryIdentity(current) != identity {
+	current, exists := s.coreManager.GetByID(authID)
+	if !s.codexModelDiscoveryResultCurrent(authID, identity, generation) || !exists || current == nil || current.Disabled || codexModelDiscoveryIdentity(current) != identity {
 		if !exists || current == nil || current.Disabled {
-			GlobalModelRegistry().UnregisterClient(auth.ID)
+			GlobalModelRegistry().UnregisterClient(authID)
 			return
 		}
 		s.completeModelRegistrationForAuth(ctx, current)

--- a/sdk/cliproxy/codex_models.go
+++ b/sdk/cliproxy/codex_models.go
@@ -20,6 +20,7 @@ type codexModelCatalogFetcher func(context.Context, *coreauth.Auth) ([]codexauth
 
 type codexModelDiscoveryEntry struct {
 	generation uint64
+	revision   uint64
 	identity   string
 	models     []codexauth.ModelCatalogEntry
 	ready      bool
@@ -55,9 +56,9 @@ func (s *Service) stopCodexModelDiscovery() {
 	s.codexModelsMu.Unlock()
 }
 
-func (s *Service) discoveredCodexModelsForAuth(ctx context.Context, auth *coreauth.Auth) ([]*ModelInfo, bool) {
+func (s *Service) discoveredCodexModelsForAuth(ctx context.Context, auth *coreauth.Auth) ([]*ModelInfo, bool, uint64) {
 	if !s.codexModelDiscoveryEnabled(auth) {
-		return nil, false
+		return nil, false, 0
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -79,12 +80,14 @@ func (s *Service) discoveredCodexModelsForAuth(ctx context.Context, auth *coreau
 		entry.generation = s.nextCodexModelGenerationLocked()
 		entry.identity = identity
 		entry.models = nil
+		entry.revision = 0
 		entry.ready = false
 		entry.fetching = false
 		entry.attempted = false
 	}
 
 	ready := entry.ready
+	revision := entry.revision
 	cached := cloneCodexModelCatalogEntries(entry.models)
 	fetchCtx := ctx
 	if s.codexModelsCtx != nil {
@@ -100,9 +103,9 @@ func (s *Service) discoveredCodexModelsForAuth(ctx context.Context, auth *coreau
 	s.codexModelsMu.Unlock()
 
 	if !ready || len(cached) == 0 {
-		return nil, false
+		return nil, false, revision
 	}
-	return codexCatalogModelInfos(cached), true
+	return codexCatalogModelInfos(cached), true, revision
 }
 
 func (s *Service) codexModelDiscoveryEnabled(auth *coreauth.Auth) bool {
@@ -176,6 +179,17 @@ func (s *Service) codexModelDiscoveryResultCurrent(authID, identity string, gene
 	return entry != nil && entry.generation == generation && entry.identity == identity && entry.ready
 }
 
+func (s *Service) codexModelDiscoveryRevisionChanged(auth *coreauth.Auth, revision uint64) bool {
+	if s == nil || auth == nil || auth.ID == "" {
+		return false
+	}
+	identity := codexModelDiscoveryIdentity(auth)
+	s.codexModelsMu.Lock()
+	defer s.codexModelsMu.Unlock()
+	entry := s.codexModels[auth.ID]
+	return entry != nil && entry.identity == identity && entry.ready && len(entry.models) > 0 && entry.revision != revision
+}
+
 func (s *Service) finishCodexModelFetch(authID, identity string, generation uint64, models []codexauth.ModelCatalogEntry, success bool) bool {
 	if s == nil || authID == "" {
 		return false
@@ -187,8 +201,10 @@ func (s *Service) finishCodexModelFetch(authID, identity string, generation uint
 		return false
 	}
 	entry.fetching = false
+	entry.attempted = success
 	if success {
 		entry.models = cloneCodexModelCatalogEntries(models)
+		entry.revision++
 		entry.ready = true
 	}
 	return success

--- a/sdk/cliproxy/codex_models.go
+++ b/sdk/cliproxy/codex_models.go
@@ -1,0 +1,400 @@
+package cliproxy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+
+	codexauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
+	log "github.com/sirupsen/logrus"
+)
+
+type codexModelCatalogFetcher func(context.Context, *coreauth.Auth) ([]codexauth.ModelCatalogEntry, error)
+
+type codexModelDiscoveryEntry struct {
+	generation uint64
+	identity   string
+	models     []codexauth.ModelCatalogEntry
+	ready      bool
+	fetching   bool
+	attempted  bool
+}
+
+func (s *Service) startCodexModelDiscovery(ctx context.Context) {
+	if s == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.codexModelsMu.Lock()
+	if s.codexModelsCancel != nil {
+		s.codexModelsCancel()
+	}
+	s.codexModelsCtx, s.codexModelsCancel = context.WithCancel(ctx)
+	s.codexModelsMu.Unlock()
+}
+
+func (s *Service) stopCodexModelDiscovery() {
+	if s == nil {
+		return
+	}
+	s.codexModelsMu.Lock()
+	if s.codexModelsCancel != nil {
+		s.codexModelsCancel()
+		s.codexModelsCancel = nil
+	}
+	s.codexModelsCtx = nil
+	s.codexModelsMu.Unlock()
+}
+
+func (s *Service) discoveredCodexModelsForAuth(ctx context.Context, auth *coreauth.Auth) ([]*ModelInfo, bool) {
+	if !s.codexModelDiscoveryEnabled(auth) {
+		return nil, false
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	identity := codexModelDiscoveryIdentity(auth)
+	s.codexModelsMu.Lock()
+	if s.codexModels == nil {
+		s.codexModels = make(map[string]*codexModelDiscoveryEntry)
+	}
+	entry := s.codexModels[auth.ID]
+	if entry == nil {
+		entry = &codexModelDiscoveryEntry{
+			generation: s.nextCodexModelGenerationLocked(),
+			identity:   identity,
+		}
+		s.codexModels[auth.ID] = entry
+	} else if entry.identity != identity {
+		entry.generation = s.nextCodexModelGenerationLocked()
+		entry.identity = identity
+		entry.models = nil
+		entry.ready = false
+		entry.fetching = false
+		entry.attempted = false
+	}
+
+	ready := entry.ready
+	cached := cloneCodexModelCatalogEntries(entry.models)
+	fetchCtx := ctx
+	if s.codexModelsCtx != nil {
+		fetchCtx = s.codexModelsCtx
+	}
+	if !entry.fetching && !entry.attempted && fetchCtx.Err() == nil {
+		entry.fetching = true
+		entry.attempted = true
+		generation := entry.generation
+		authSnapshot := auth.Clone()
+		go s.refreshDiscoveredCodexModels(fetchCtx, authSnapshot, identity, generation)
+	}
+	s.codexModelsMu.Unlock()
+
+	if !ready || len(cached) == 0 {
+		return nil, false
+	}
+	return codexCatalogModelInfos(cached), true
+}
+
+func (s *Service) codexModelDiscoveryEnabled(auth *coreauth.Auth) bool {
+	if s == nil || auth == nil || auth.ID == "" || auth.Disabled {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") || auth.AuthKind() != coreauth.AuthKindOAuth {
+		return false
+	}
+	if codexAuthMetadataString(auth, "access_token") == "" {
+		return false
+	}
+	s.cfgMu.RLock()
+	cfg := s.cfg
+	enabled := cfg == nil || !cfg.DisableCodexModelDiscovery && !cfg.Home.Enabled
+	s.cfgMu.RUnlock()
+	return enabled
+}
+
+func (s *Service) refreshDiscoveredCodexModels(ctx context.Context, auth *coreauth.Auth, identity string, generation uint64) {
+	fetcher := s.codexModelsFetch
+	if fetcher == nil {
+		fetcher = s.fetchCodexModelCatalog
+	}
+	models, errFetch := fetcher(ctx, auth)
+	if errFetch != nil {
+		s.finishCodexModelFetch(auth.ID, identity, generation, nil, false)
+		log.WithFields(log.Fields{"auth_id": auth.ID, "provider": "codex"}).Debugf("Codex model discovery failed, keeping fallback catalog: %v", errFetch)
+		return
+	}
+	if len(models) == 0 {
+		s.finishCodexModelFetch(auth.ID, identity, generation, nil, false)
+		return
+	}
+	if !s.finishCodexModelFetch(auth.ID, identity, generation, models, true) {
+		return
+	}
+	if ctx.Err() != nil || s.coreManager == nil {
+		return
+	}
+	latest, ok := s.coreManager.GetByID(auth.ID)
+	if !ok || latest == nil || latest.Disabled {
+		GlobalModelRegistry().UnregisterClient(auth.ID)
+		return
+	}
+	if !s.codexModelDiscoveryResultCurrent(auth.ID, identity, generation) || codexModelDiscoveryIdentity(latest) != identity {
+		s.completeModelRegistrationForAuth(ctx, latest)
+		return
+	}
+	s.completeModelRegistrationForAuth(ctx, latest)
+
+	// An auth update can race between the pre-registration checks and the registry
+	// write. Restore the newest auth snapshot if that happened.
+	current, exists := s.coreManager.GetByID(auth.ID)
+	if !s.codexModelDiscoveryResultCurrent(auth.ID, identity, generation) || !exists || current == nil || current.Disabled || codexModelDiscoveryIdentity(current) != identity {
+		if !exists || current == nil || current.Disabled {
+			GlobalModelRegistry().UnregisterClient(auth.ID)
+			return
+		}
+		s.completeModelRegistrationForAuth(ctx, current)
+	}
+}
+
+func (s *Service) codexModelDiscoveryResultCurrent(authID, identity string, generation uint64) bool {
+	if s == nil || authID == "" {
+		return false
+	}
+	s.codexModelsMu.Lock()
+	defer s.codexModelsMu.Unlock()
+	entry := s.codexModels[authID]
+	return entry != nil && entry.generation == generation && entry.identity == identity && entry.ready
+}
+
+func (s *Service) finishCodexModelFetch(authID, identity string, generation uint64, models []codexauth.ModelCatalogEntry, success bool) bool {
+	if s == nil || authID == "" {
+		return false
+	}
+	s.codexModelsMu.Lock()
+	defer s.codexModelsMu.Unlock()
+	entry := s.codexModels[authID]
+	if entry == nil || entry.generation != generation || entry.identity != identity {
+		return false
+	}
+	entry.fetching = false
+	if success {
+		entry.models = cloneCodexModelCatalogEntries(models)
+		entry.ready = true
+	}
+	return success
+}
+
+func (s *Service) invalidateCodexModelDiscovery(auth *coreauth.Auth) {
+	if s == nil || auth == nil || auth.ID == "" || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return
+	}
+	identity := codexModelDiscoveryIdentity(auth)
+	s.codexModelsMu.Lock()
+	defer s.codexModelsMu.Unlock()
+	if s.codexModels == nil {
+		s.codexModels = make(map[string]*codexModelDiscoveryEntry)
+	}
+	entry := s.codexModels[auth.ID]
+	if entry == nil {
+		entry = &codexModelDiscoveryEntry{}
+		s.codexModels[auth.ID] = entry
+	}
+	if entry.identity != "" && entry.identity != identity {
+		entry.models = nil
+		entry.ready = false
+	}
+	entry.generation = s.nextCodexModelGenerationLocked()
+	entry.identity = identity
+	entry.fetching = false
+	entry.attempted = false
+}
+
+func (s *Service) removeCodexModelDiscovery(authID string) {
+	if s == nil || strings.TrimSpace(authID) == "" {
+		return
+	}
+	s.codexModelsMu.Lock()
+	delete(s.codexModels, authID)
+	s.codexModelsGeneration++
+	s.codexModelsMu.Unlock()
+}
+
+func (s *Service) nextCodexModelGenerationLocked() uint64 {
+	s.codexModelsGeneration++
+	return s.codexModelsGeneration
+}
+
+func (s *Service) fetchCodexModelCatalog(ctx context.Context, auth *coreauth.Auth) ([]codexauth.ModelCatalogEntry, error) {
+	if auth == nil {
+		return nil, fmt.Errorf("Codex model discovery auth is nil")
+	}
+	accessToken := codexAuthMetadataString(auth, "access_token")
+	if accessToken == "" {
+		return nil, fmt.Errorf("Codex model discovery missing access token")
+	}
+
+	baseURL := codexAuthAttributeString(auth, "base_url")
+	if baseURL == "" {
+		baseURL = codexAuthMetadataString(auth, "base_url")
+	}
+	userAgent := ""
+	s.cfgMu.RLock()
+	if s.cfg != nil {
+		userAgent = strings.TrimSpace(s.cfg.CodexHeaderDefaults.UserAgent)
+	}
+	s.cfgMu.RUnlock()
+
+	customRequest := &http.Request{Header: make(http.Header)}
+	util.ApplyCustomHeadersFromAttrs(customRequest, auth.Attributes)
+	client := &http.Client{}
+	if transport, _, errProxy := proxyutil.BuildHTTPTransport(auth.ProxyURL); errProxy != nil {
+		return nil, fmt.Errorf("build Codex model discovery proxy transport: %w", errProxy)
+	} else if transport != nil {
+		client.Transport = transport
+	}
+
+	catalog, errFetch := codexauth.FetchModelsCatalog(ctx, client, codexauth.ModelsRequest{
+		BaseURL:       baseURL,
+		AccessToken:   accessToken,
+		AccountID:     codexModelDiscoveryAccountID(auth),
+		ClientVersion: codexauth.DefaultModelsClientVersion,
+		UserAgent:     userAgent,
+		Headers:       customRequest.Header,
+		Host:          customRequest.Host,
+	})
+	if errFetch != nil {
+		return nil, errFetch
+	}
+	return cloneCodexModelCatalogEntries(catalog.Models), nil
+}
+
+func codexCatalogModelInfos(entries []codexauth.ModelCatalogEntry) []*ModelInfo {
+	models := make([]*ModelInfo, 0, len(entries))
+	for _, entry := range entries {
+		slug := strings.TrimSpace(entry.Slug)
+		if slug == "" {
+			continue
+		}
+		if model := registry.LookupStaticModelInfo(slug); model != nil {
+			models = append(models, model)
+			continue
+		}
+		displayName := strings.TrimSpace(entry.DisplayName)
+		if displayName == "" {
+			displayName = slug
+		}
+		description := strings.TrimSpace(entry.Description)
+		if description == "" {
+			description = displayName
+		}
+		contextLength := entry.ContextWindow
+		if contextLength <= 0 {
+			contextLength = entry.MaxContextWindow
+		}
+		model := &ModelInfo{
+			ID:                  slug,
+			Object:              "model",
+			OwnedBy:             "openai",
+			Type:                "openai",
+			DisplayName:         displayName,
+			Version:             slug,
+			Description:         description,
+			ContextLength:       contextLength,
+			SupportedParameters: []string{"tools"},
+		}
+		levels := codexCatalogReasoningLevels(entry.SupportedReasoningLevels)
+		if len(levels) > 0 {
+			model.Thinking = &registry.ThinkingSupport{Levels: levels}
+		}
+		models = append(models, model)
+	}
+	return registry.WithCodexBuiltins(models)
+}
+
+func codexCatalogReasoningLevels(levels []codexauth.ModelCatalogReasoningLevel) []string {
+	result := make([]string, 0, len(levels))
+	seen := make(map[string]struct{}, len(levels))
+	for _, level := range levels {
+		effort := strings.ToLower(strings.TrimSpace(level.Effort))
+		if effort == "" {
+			continue
+		}
+		if _, exists := seen[effort]; exists {
+			continue
+		}
+		seen[effort] = struct{}{}
+		result = append(result, effort)
+	}
+	return result
+}
+
+func codexModelDiscoveryIdentity(auth *coreauth.Auth) string {
+	if accountID := codexModelDiscoveryAccountID(auth); accountID != "" {
+		return "account:" + accountID
+	}
+	if email := codexAuthMetadataString(auth, "email"); email != "" {
+		return "email:" + strings.ToLower(email)
+	}
+	if auth == nil {
+		return ""
+	}
+	if accessToken := codexAuthMetadataString(auth, "access_token"); accessToken != "" {
+		digest := sha256.Sum256([]byte(accessToken))
+		return "token:" + hex.EncodeToString(digest[:8])
+	}
+	return "auth:" + auth.ID
+}
+
+func codexModelDiscoveryAccountID(auth *coreauth.Auth) string {
+	if accountID := codexAuthMetadataString(auth, "account_id"); accountID != "" {
+		return accountID
+	}
+	idToken := codexAuthMetadataString(auth, "id_token")
+	if idToken == "" {
+		return ""
+	}
+	claims, errParse := codexauth.ParseJWTToken(idToken)
+	if errParse != nil || claims == nil {
+		return ""
+	}
+	return strings.TrimSpace(claims.CodexAuthInfo.ChatgptAccountID)
+}
+
+func codexAuthMetadataString(auth *coreauth.Auth, key string) string {
+	if auth == nil || auth.Metadata == nil {
+		return ""
+	}
+	value, _ := auth.Metadata[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func codexAuthAttributeString(auth *coreauth.Auth, key string) string {
+	if auth == nil || auth.Attributes == nil {
+		return ""
+	}
+	return strings.TrimSpace(auth.Attributes[key])
+}
+
+func cloneCodexModelCatalogEntries(entries []codexauth.ModelCatalogEntry) []codexauth.ModelCatalogEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	cloned := make([]codexauth.ModelCatalogEntry, len(entries))
+	copy(cloned, entries)
+	for index := range cloned {
+		if len(entries[index].SupportedReasoningLevels) > 0 {
+			cloned[index].SupportedReasoningLevels = append([]codexauth.ModelCatalogReasoningLevel(nil), entries[index].SupportedReasoningLevels...)
+		}
+	}
+	return cloned
+}

--- a/sdk/cliproxy/codex_models_test.go
+++ b/sdk/cliproxy/codex_models_test.go
@@ -105,40 +105,66 @@ func TestCodexModelDiscoveryReplacesStaleFreeCatalog(t *testing.T) {
 
 func TestCodexModelDiscoveryFailureKeepsLastGoodCatalog(t *testing.T) {
 	manager := coreauth.NewManager(nil, nil, nil)
-	service := &Service{cfg: &config.Config{}, coreManager: manager}
 	auth := testCodexDiscoveryAuth("codex-last-good")
 	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
 		t.Fatalf("Register() error = %v", errRegister)
 	}
-
-	firstDone := make(chan struct{})
-	service.codexModelsFetch = func(context.Context, *coreauth.Auth) ([]codexauth.ModelCatalogEntry, error) {
-		close(firstDone)
-		return []codexauth.ModelCatalogEntry{{Slug: "gpt-5.6-sol"}}, nil
+	service := &Service{
+		cfg:                   &config.Config{},
+		coreManager:           manager,
+		codexModelsGeneration: 1,
+		codexModels: map[string]*codexModelDiscoveryEntry{
+			auth.ID: {
+				generation: 1,
+				revision:   1,
+				identity:   codexModelDiscoveryIdentity(auth),
+				models:     []codexauth.ModelCatalogEntry{{Slug: "gpt-5.6-sol"}},
+				ready:      true,
+				attempted:  true,
+			},
+		},
 	}
 	modelRegistry := registry.GetGlobalRegistry()
 	modelRegistry.UnregisterClient(auth.ID)
 	t.Cleanup(func() { modelRegistry.UnregisterClient(auth.ID) })
 	service.registerModelsForAuth(context.Background(), auth)
-	waitSignal(t, firstDone, "first model discovery")
-	waitFor(t, "first model registration", func() bool {
-		return clientHasModel(modelRegistry, auth.ID, "gpt-5.6-sol")
-	})
 
 	failedDone := make(chan struct{})
+	retryDone := make(chan struct{})
+	var calls atomic.Int32
 	service.codexModelsFetch = func(context.Context, *coreauth.Auth) ([]codexauth.ModelCatalogEntry, error) {
-		close(failedDone)
-		return nil, errors.New("upstream unavailable")
+		switch calls.Add(1) {
+		case 1:
+			close(failedDone)
+			return nil, errors.New("upstream unavailable")
+		case 2:
+			close(retryDone)
+			return []codexauth.ModelCatalogEntry{{Slug: "gpt-5.6-luna"}}, nil
+		default:
+			return nil, errors.New("unexpected model discovery fetch")
+		}
 	}
 	service.invalidateCodexModelDiscovery(auth)
 	service.registerModelsForAuth(context.Background(), auth)
 	waitSignal(t, failedDone, "failed model discovery")
+	waitFor(t, "failed discovery to become retryable", func() bool {
+		return codexModelDiscoveryRetryable(service, auth.ID)
+	})
 	if !clientHasModel(modelRegistry, auth.ID, "gpt-5.6-sol") {
 		t.Fatal("failed refresh removed last-good model catalog")
 	}
+
+	service.registerModelsForAuth(context.Background(), auth)
+	waitSignal(t, retryDone, "model discovery retry")
+	waitFor(t, "retried model registration", func() bool {
+		return clientHasModel(modelRegistry, auth.ID, "gpt-5.6-luna")
+	})
+	if clientHasModel(modelRegistry, auth.ID, "gpt-5.6-sol") {
+		t.Fatal("successful retry retained the stale last-good model catalog")
+	}
 }
 
-func TestCodexModelDiscoveryFirstFailureKeepsPlanFallback(t *testing.T) {
+func TestCodexModelDiscoveryFirstFailureKeepsPlanFallbackAndRetries(t *testing.T) {
 	manager := coreauth.NewManager(nil, nil, nil)
 	service := &Service{cfg: &config.Config{}, coreManager: manager}
 	auth := testCodexDiscoveryAuth("codex-first-failure")
@@ -147,21 +173,43 @@ func TestCodexModelDiscoveryFirstFailureKeepsPlanFallback(t *testing.T) {
 	}
 
 	done := make(chan struct{})
+	retryDone := make(chan struct{})
+	var calls atomic.Int32
 	service.codexModelsFetch = func(context.Context, *coreauth.Auth) ([]codexauth.ModelCatalogEntry, error) {
-		close(done)
-		return nil, errors.New("upstream unavailable")
+		switch calls.Add(1) {
+		case 1:
+			close(done)
+			return nil, errors.New("upstream unavailable")
+		case 2:
+			close(retryDone)
+			return []codexauth.ModelCatalogEntry{{Slug: "gpt-5.6-sol"}}, nil
+		default:
+			return nil, errors.New("unexpected model discovery fetch")
+		}
 	}
 	modelRegistry := registry.GetGlobalRegistry()
 	modelRegistry.UnregisterClient(auth.ID)
 	t.Cleanup(func() { modelRegistry.UnregisterClient(auth.ID) })
 	service.registerModelsForAuth(context.Background(), auth)
 	waitSignal(t, done, "failed first model discovery")
+	waitFor(t, "failed discovery to become retryable", func() bool {
+		return codexModelDiscoveryRetryable(service, auth.ID)
+	})
 
 	if clientHasModel(modelRegistry, auth.ID, "gpt-5.6-sol") {
 		t.Fatal("failed first discovery registered paid-tier model for free fallback")
 	}
 	if !clientHasModel(modelRegistry, auth.ID, "gpt-5.6-luna") {
 		t.Fatal("failed first discovery removed free plan fallback")
+	}
+
+	service.registerModelsForAuth(context.Background(), auth)
+	waitSignal(t, retryDone, "model discovery retry")
+	waitFor(t, "retried model registration", func() bool {
+		return clientHasModel(modelRegistry, auth.ID, "gpt-5.6-sol")
+	})
+	if clientHasModel(modelRegistry, auth.ID, "gpt-5.6-luna") {
+		t.Fatal("successful retry retained the plan fallback catalog")
 	}
 }
 
@@ -384,6 +432,13 @@ func clientHasModel(modelRegistry *registry.ModelRegistry, authID, modelID strin
 		}
 	}
 	return false
+}
+
+func codexModelDiscoveryRetryable(service *Service, authID string) bool {
+	service.codexModelsMu.Lock()
+	defer service.codexModelsMu.Unlock()
+	entry := service.codexModels[authID]
+	return entry != nil && !entry.fetching && !entry.attempted
 }
 
 func waitSignal(t *testing.T, signal <-chan struct{}, label string) {

--- a/sdk/cliproxy/codex_models_test.go
+++ b/sdk/cliproxy/codex_models_test.go
@@ -1,0 +1,408 @@
+package cliproxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	codexauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+func TestFetchCodexModelCatalogUsesAuthProxyAndHeaders(t *testing.T) {
+	var gotURL string
+	var gotAccountID string
+	var gotUserAgent string
+	var gotCustomHeader string
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.String()
+		gotAccountID = r.Header.Get("Chatgpt-Account-Id")
+		gotUserAgent = r.Header.Get("User-Agent")
+		gotCustomHeader = r.Header.Get("X-Test")
+		_, _ = w.Write([]byte(`{"models":[{"slug":"gpt-5.6-sol"}]}`))
+	}))
+	defer proxy.Close()
+
+	service := &Service{cfg: &config.Config{}}
+	service.cfg.CodexHeaderDefaults.UserAgent = "configured-agent"
+	auth := testCodexDiscoveryAuth("codex-proxy")
+	auth.ProxyURL = proxy.URL
+	auth.Attributes["base_url"] = "http://upstream.invalid/backend-api/codex"
+	auth.Attributes["header:X-Test"] = "custom-value"
+
+	models, errFetch := service.fetchCodexModelCatalog(context.Background(), auth)
+	if errFetch != nil {
+		t.Fatalf("fetchCodexModelCatalog() error = %v", errFetch)
+	}
+	if len(models) != 1 || models[0].Slug != "gpt-5.6-sol" {
+		t.Fatalf("models = %#v", models)
+	}
+	if gotURL != "http://upstream.invalid/backend-api/codex/models?client_version=0.144.1" {
+		t.Fatalf("proxy request URL = %q", gotURL)
+	}
+	if gotAccountID != "test-account" {
+		t.Fatalf("Chatgpt-Account-Id = %q", gotAccountID)
+	}
+	if gotUserAgent != "configured-agent" {
+		t.Fatalf("User-Agent = %q", gotUserAgent)
+	}
+	if gotCustomHeader != "custom-value" {
+		t.Fatalf("X-Test = %q", gotCustomHeader)
+	}
+}
+
+func TestCodexModelDiscoveryReplacesStaleFreeCatalog(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{cfg: &config.Config{}, coreManager: manager}
+	auth := testCodexDiscoveryAuth("codex-stale-free")
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	service.codexModelsFetch = func(ctx context.Context, _ *coreauth.Auth) ([]codexauth.ModelCatalogEntry, error) {
+		close(started)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-release:
+		}
+		return []codexauth.ModelCatalogEntry{{Slug: "gpt-5.6-sol"}}, nil
+	}
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(auth.ID)
+	t.Cleanup(func() { modelRegistry.UnregisterClient(auth.ID) })
+	service.registerModelsForAuth(context.Background(), auth)
+	waitSignal(t, started, "model discovery start")
+
+	if clientHasModel(modelRegistry, auth.ID, "gpt-5.6-sol") {
+		t.Fatal("free fallback unexpectedly registered gpt-5.6-sol")
+	}
+	if !clientHasModel(modelRegistry, auth.ID, "gpt-5.6-luna") {
+		t.Fatal("free fallback did not register gpt-5.6-luna")
+	}
+
+	close(release)
+	waitFor(t, "dynamic model registration", func() bool {
+		return clientHasModel(modelRegistry, auth.ID, "gpt-5.6-sol")
+	})
+	if clientHasModel(modelRegistry, auth.ID, "gpt-5.6-luna") {
+		t.Fatal("authoritative catalog retained model absent upstream")
+	}
+	if !clientHasModel(modelRegistry, auth.ID, "gpt-image-2") {
+		t.Fatal("authoritative catalog omitted local Codex image built-in")
+	}
+}
+
+func TestCodexModelDiscoveryFailureKeepsLastGoodCatalog(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{cfg: &config.Config{}, coreManager: manager}
+	auth := testCodexDiscoveryAuth("codex-last-good")
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	firstDone := make(chan struct{})
+	service.codexModelsFetch = func(context.Context, *coreauth.Auth) ([]codexauth.ModelCatalogEntry, error) {
+		close(firstDone)
+		return []codexauth.ModelCatalogEntry{{Slug: "gpt-5.6-sol"}}, nil
+	}
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(auth.ID)
+	t.Cleanup(func() { modelRegistry.UnregisterClient(auth.ID) })
+	service.registerModelsForAuth(context.Background(), auth)
+	waitSignal(t, firstDone, "first model discovery")
+	waitFor(t, "first model registration", func() bool {
+		return clientHasModel(modelRegistry, auth.ID, "gpt-5.6-sol")
+	})
+
+	failedDone := make(chan struct{})
+	service.codexModelsFetch = func(context.Context, *coreauth.Auth) ([]codexauth.ModelCatalogEntry, error) {
+		close(failedDone)
+		return nil, errors.New("upstream unavailable")
+	}
+	service.invalidateCodexModelDiscovery(auth)
+	service.registerModelsForAuth(context.Background(), auth)
+	waitSignal(t, failedDone, "failed model discovery")
+	if !clientHasModel(modelRegistry, auth.ID, "gpt-5.6-sol") {
+		t.Fatal("failed refresh removed last-good model catalog")
+	}
+}
+
+func TestCodexModelDiscoveryFirstFailureKeepsPlanFallback(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{cfg: &config.Config{}, coreManager: manager}
+	auth := testCodexDiscoveryAuth("codex-first-failure")
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	done := make(chan struct{})
+	service.codexModelsFetch = func(context.Context, *coreauth.Auth) ([]codexauth.ModelCatalogEntry, error) {
+		close(done)
+		return nil, errors.New("upstream unavailable")
+	}
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(auth.ID)
+	t.Cleanup(func() { modelRegistry.UnregisterClient(auth.ID) })
+	service.registerModelsForAuth(context.Background(), auth)
+	waitSignal(t, done, "failed first model discovery")
+
+	if clientHasModel(modelRegistry, auth.ID, "gpt-5.6-sol") {
+		t.Fatal("failed first discovery registered paid-tier model for free fallback")
+	}
+	if !clientHasModel(modelRegistry, auth.ID, "gpt-5.6-luna") {
+		t.Fatal("failed first discovery removed free plan fallback")
+	}
+}
+
+func TestCodexModelDiscoveryDeduplicatesAndRejectsRemovedAuth(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{cfg: &config.Config{}, coreManager: manager}
+	auth := testCodexDiscoveryAuth("codex-removed")
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	service.codexModelsFetch = func(ctx context.Context, _ *coreauth.Auth) ([]codexauth.ModelCatalogEntry, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-release:
+			return []codexauth.ModelCatalogEntry{{Slug: "gpt-5.6-sol"}}, nil
+		}
+	}
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(auth.ID)
+	t.Cleanup(func() { modelRegistry.UnregisterClient(auth.ID) })
+	for range 5 {
+		service.registerModelsForAuth(context.Background(), auth)
+	}
+	waitSignal(t, started, "deduplicated model discovery")
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("fetch calls = %d, want 1", got)
+	}
+
+	service.removeCodexModelDiscovery(auth.ID)
+	manager.Remove(context.Background(), auth.ID)
+	modelRegistry.UnregisterClient(auth.ID)
+	close(release)
+	time.Sleep(20 * time.Millisecond)
+	if clientHasModel(modelRegistry, auth.ID, "gpt-5.6-sol") {
+		t.Fatal("late discovery result registered a removed auth")
+	}
+}
+
+func TestCodexModelDiscoveryDisabledForLocalModeAndAPIKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		auth *coreauth.Auth
+	}{
+		{
+			name: "local mode",
+			cfg:  &config.Config{DisableCodexModelDiscovery: true},
+			auth: testCodexDiscoveryAuth("codex-local"),
+		},
+		{
+			name: "api key",
+			cfg:  &config.Config{},
+			auth: &coreauth.Auth{
+				ID:       "codex-api-key",
+				Provider: "codex",
+				Attributes: map[string]string{
+					coreauth.AttributeAuthKind: coreauth.AuthKindAPIKey,
+					coreauth.AttributeAPIKey:   "key",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &Service{cfg: tt.cfg}
+			var calls atomic.Int32
+			service.codexModelsFetch = func(context.Context, *coreauth.Auth) ([]codexauth.ModelCatalogEntry, error) {
+				calls.Add(1)
+				return []codexauth.ModelCatalogEntry{{Slug: "gpt-5.6-sol"}}, nil
+			}
+			service.registerModelsForAuth(context.Background(), tt.auth)
+			t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(tt.auth.ID) })
+			time.Sleep(10 * time.Millisecond)
+			if got := calls.Load(); got != 0 {
+				t.Fatalf("fetch calls = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestCodexModelDiscoveryStopsWithServiceContext(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{cfg: &config.Config{}, coreManager: manager}
+	auth := testCodexDiscoveryAuth("codex-context-cancel")
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	started := make(chan struct{})
+	stopped := make(chan struct{})
+	service.codexModelsFetch = func(ctx context.Context, _ *coreauth.Auth) ([]codexauth.ModelCatalogEntry, error) {
+		close(started)
+		<-ctx.Done()
+		close(stopped)
+		return nil, ctx.Err()
+	}
+	serviceCtx, cancel := context.WithCancel(context.Background())
+	service.startCodexModelDiscovery(serviceCtx)
+	t.Cleanup(service.stopCodexModelDiscovery)
+	service.registerModelsForAuth(context.Background(), auth)
+	waitSignal(t, started, "model discovery start")
+	cancel()
+	waitSignal(t, stopped, "model discovery cancellation")
+}
+
+func TestCodexCatalogModelInfosSynthesizesUnknownModels(t *testing.T) {
+	models := codexCatalogModelInfos([]codexauth.ModelCatalogEntry{{
+		Slug:             "gpt-future",
+		DisplayName:      "GPT Future",
+		Description:      "Future model",
+		ContextWindow:    123456,
+		MaxContextWindow: 234567,
+		SupportedReasoningLevels: []codexauth.ModelCatalogReasoningLevel{
+			{Effort: "low"},
+			{Effort: " HIGH "},
+			{Effort: "high"},
+		},
+	}})
+	var future *ModelInfo
+	for _, model := range models {
+		if model != nil && model.ID == "gpt-future" {
+			future = model
+			break
+		}
+	}
+	if future == nil {
+		t.Fatal("unknown upstream model was not synthesized")
+	}
+	if future.DisplayName != "GPT Future" || future.ContextLength != 123456 {
+		t.Fatalf("future model metadata = %+v", future)
+	}
+	if future.Thinking == nil || len(future.Thinking.Levels) != 2 || future.Thinking.Levels[1] != "high" {
+		t.Fatalf("future model thinking = %+v", future.Thinking)
+	}
+}
+
+func TestCodexDiscoveredModelsApplyExclusionsAliasesAndPrefixes(t *testing.T) {
+	auth := testCodexDiscoveryAuth("codex-dynamic-transforms")
+	auth.Prefix = "account"
+	auth.Attributes["excluded_models"] = "gpt-5.6-luna"
+	service := &Service{
+		cfg: &config.Config{
+			SDKConfig: config.SDKConfig{ForceModelPrefix: true},
+			OAuthModelAlias: map[string][]config.OAuthModelAlias{
+				"codex": {{Name: "gpt-5.6-sol", Alias: "sol-live"}},
+			},
+		},
+		codexModels: map[string]*codexModelDiscoveryEntry{
+			auth.ID: {
+				identity:  codexModelDiscoveryIdentity(auth),
+				models:    []codexauth.ModelCatalogEntry{{Slug: "gpt-5.6-sol"}, {Slug: "gpt-5.6-luna"}},
+				ready:     true,
+				attempted: true,
+			},
+		},
+	}
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(auth.ID)
+	t.Cleanup(func() { modelRegistry.UnregisterClient(auth.ID) })
+	service.registerModelsForAuth(context.Background(), auth)
+
+	if !clientHasModel(modelRegistry, auth.ID, "account/sol-live") {
+		t.Fatal("dynamic model alias or prefix was not applied")
+	}
+	for _, forbidden := range []string{"gpt-5.6-sol", "sol-live", "gpt-5.6-luna", "account/gpt-5.6-luna"} {
+		if clientHasModel(modelRegistry, auth.ID, forbidden) {
+			t.Fatalf("unexpected registered model %q", forbidden)
+		}
+	}
+}
+
+func TestCodexModelDiscoveryIdentityFallsBackToTokenFingerprint(t *testing.T) {
+	first := &coreauth.Auth{
+		ID:       "imported-codex",
+		Provider: "codex",
+		Metadata: map[string]any{"access_token": "token-one"},
+	}
+	second := first.Clone()
+	second.Metadata["access_token"] = "token-two"
+
+	firstIdentity := codexModelDiscoveryIdentity(first)
+	secondIdentity := codexModelDiscoveryIdentity(second)
+	if firstIdentity == secondIdentity {
+		t.Fatalf("token identities matched: %q", firstIdentity)
+	}
+	if strings.Contains(firstIdentity, "token-one") || strings.Contains(secondIdentity, "token-two") {
+		t.Fatal("model discovery identity leaked an access token")
+	}
+}
+
+func testCodexDiscoveryAuth(id string) *coreauth.Auth {
+	return &coreauth.Auth{
+		ID:       id,
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			coreauth.AttributeAuthKind: coreauth.AuthKindOAuth,
+			"plan_type":                "free",
+		},
+		Metadata: map[string]any{
+			"access_token": "test-token",
+			"account_id":   "test-account",
+		},
+	}
+}
+
+func clientHasModel(modelRegistry *registry.ModelRegistry, authID, modelID string) bool {
+	for _, model := range modelRegistry.GetModelsForClient(authID) {
+		if model != nil && model.ID == modelID {
+			return true
+		}
+	}
+	return false
+}
+
+func waitSignal(t *testing.T, signal <-chan struct{}, label string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", label)
+	}
+}
+
+func waitFor(t *testing.T, label string, ready func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if ready() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", label)
+}

--- a/sdk/cliproxy/codex_models_test.go
+++ b/sdk/cliproxy/codex_models_test.go
@@ -257,6 +257,72 @@ func TestCodexModelDiscoveryDeduplicatesAndRejectsRemovedAuth(t *testing.T) {
 	}
 }
 
+func TestCodexModelDiscoveryReconciliationRejectsRemovedAuthSnapshot(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{cfg: &config.Config{}, coreManager: manager}
+	auth := testCodexDiscoveryAuth("codex-removed-snapshot")
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	identity := codexModelDiscoveryIdentity(auth)
+	stale := auth.Clone()
+	service.removeCodexModelDiscovery(auth.ID)
+	manager.Remove(context.Background(), auth.ID)
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.6-sol"}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(auth.ID) })
+
+	service.reconcileDiscoveredCodexModelRegistration(context.Background(), stale, identity, 1)
+	if models := modelRegistry.GetModelsForClient(auth.ID); len(models) != 0 {
+		t.Fatalf("removed auth retained models after stale discovery reconciliation: %#v", models)
+	}
+}
+
+func TestCodexModelDiscoveryReconciliationUsesUpdatedAuthSnapshot(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	auth := testCodexDiscoveryAuth("codex-updated-snapshot")
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	identity := codexModelDiscoveryIdentity(auth)
+	service := &Service{
+		cfg:                   &config.Config{SDKConfig: config.SDKConfig{ForceModelPrefix: true}},
+		coreManager:           manager,
+		codexModelsGeneration: 2,
+		codexModels: map[string]*codexModelDiscoveryEntry{
+			auth.ID: {
+				generation: 2,
+				revision:   1,
+				identity:   identity,
+				models:     []codexauth.ModelCatalogEntry{{Slug: "gpt-5.6-sol"}},
+				ready:      true,
+				attempted:  true,
+			},
+		},
+	}
+	stale := auth.Clone()
+	updated := auth.Clone()
+	updated.Prefix = "updated"
+	if _, errUpdate := manager.Update(context.Background(), updated); errUpdate != nil {
+		t.Fatalf("Update() error = %v", errUpdate)
+	}
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(auth.ID)
+	t.Cleanup(func() { modelRegistry.UnregisterClient(auth.ID) })
+
+	service.reconcileDiscoveredCodexModelRegistration(context.Background(), stale, identity, 1)
+	if !clientHasModel(modelRegistry, auth.ID, "updated/gpt-5.6-sol") {
+		t.Fatal("stale discovery reconciliation did not apply the updated auth prefix")
+	}
+	if clientHasModel(modelRegistry, auth.ID, "gpt-5.6-sol") {
+		t.Fatal("stale discovery reconciliation retained the old unprefixed route")
+	}
+}
+
 func TestCodexModelDiscoveryDisabledForLocalModeAndAPIKeys(t *testing.T) {
 	tests := []struct {
 		name string

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -756,9 +756,11 @@ func (s *Service) applyCoreAuthRemoval(ctx context.Context, id string) {
 	if existing, ok := s.coreManager.GetByID(id); ok && existing != nil {
 		provider = strings.TrimSpace(existing.Provider)
 	}
-	GlobalModelRegistry().UnregisterClient(id)
 	s.removeCodexModelDiscovery(id)
 	s.coreManager.Remove(ctx, id)
+	// Unregister after removing the manager entry so an in-flight model refresh
+	// cannot restore a client after the removal cleanup has completed.
+	GlobalModelRegistry().UnregisterClient(id)
 	if strings.EqualFold(provider, "codex") {
 		executor.CloseCodexWebsocketSessionsForAuthID(id, "auth_removed")
 	}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -96,6 +96,14 @@ type Service struct {
 	// coreManager handles core authentication and execution.
 	coreManager *coreauth.Manager
 
+	// codexModels caches authenticated per-account Codex model catalogs.
+	codexModelsMu         sync.Mutex
+	codexModels           map[string]*codexModelDiscoveryEntry
+	codexModelsGeneration uint64
+	codexModelsFetch      codexModelCatalogFetcher
+	codexModelsCtx        context.Context
+	codexModelsCancel     context.CancelFunc
+
 	// pluginHost owns dynamic plugin lifecycle and runtime capability adapters.
 	pluginHost *pluginhost.Host
 
@@ -522,6 +530,7 @@ func (s *Service) handleAuthUpdates(ctx context.Context, updates []watcher.AuthU
 			if update.Auth == nil || update.Auth.ID == "" {
 				continue
 			}
+			s.invalidateCodexModelDiscovery(update.Auth)
 			auth := s.prepareCoreAuthForModelRegistration(registrationCtx, update.Auth)
 			if auth == nil {
 				continue
@@ -748,6 +757,7 @@ func (s *Service) applyCoreAuthRemoval(ctx context.Context, id string) {
 		provider = strings.TrimSpace(existing.Provider)
 	}
 	GlobalModelRegistry().UnregisterClient(id)
+	s.removeCodexModelDiscovery(id)
 	s.coreManager.Remove(ctx, id)
 	if strings.EqualFold(provider, "codex") {
 		executor.CloseCodexWebsocketSessionsForAuthID(id, "auth_removed")
@@ -1259,11 +1269,13 @@ func (s *Service) applyConfigUpdateWithAuthSynthesis(newCfg *config.Config, synt
 	previousStrategy := ""
 	var previousSessionAffinity bool
 	var previousSessionAffinityTTL string
+	var disableCodexModelDiscovery bool
 	s.cfgMu.RLock()
 	if s.cfg != nil {
 		previousStrategy = strings.ToLower(strings.TrimSpace(s.cfg.Routing.Strategy))
 		previousSessionAffinity = s.cfg.Routing.SessionAffinity
 		previousSessionAffinityTTL = s.cfg.Routing.SessionAffinityTTL
+		disableCodexModelDiscovery = s.cfg.DisableCodexModelDiscovery
 	}
 	s.cfgMu.RUnlock()
 
@@ -1274,6 +1286,9 @@ func (s *Service) applyConfigUpdateWithAuthSynthesis(newCfg *config.Config, synt
 	}
 	if newCfg == nil {
 		return
+	}
+	if disableCodexModelDiscovery {
+		newCfg.DisableCodexModelDiscovery = true
 	}
 
 	nextStrategy := strings.ToLower(strings.TrimSpace(newCfg.Routing.Strategy))
@@ -1613,6 +1628,7 @@ func (s *Service) Run(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	s.startCodexModelDiscovery(ctx)
 
 	usage.StartDefault(ctx)
 	homeEnabled := s.cfg != nil && s.cfg.Home.Enabled
@@ -1798,6 +1814,7 @@ func (s *Service) Shutdown(ctx context.Context) error {
 		if ctx == nil {
 			ctx = context.Background()
 		}
+		s.stopCodexModelDiscovery()
 
 		if s.homeCancel != nil {
 			s.homeCancel()
@@ -1997,21 +2014,25 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 		}
 		models = applyExcludedModels(models, excluded)
 	case "codex":
-		codexPlanType := ""
-		if a.Attributes != nil {
-			codexPlanType = strings.TrimSpace(a.Attributes["plan_type"])
-		}
-		switch strings.ToLower(codexPlanType) {
-		case "pro":
-			models = registry.GetCodexProModels()
-		case "plus":
-			models = registry.GetCodexPlusModels()
-		case "team", "business", "go":
-			models = registry.GetCodexTeamModels()
-		case "free":
-			models = registry.GetCodexFreeModels()
-		default:
-			models = registry.GetCodexProModels()
+		if discovered, ok := s.discoveredCodexModelsForAuth(ctx, a); ok {
+			models = discovered
+		} else {
+			codexPlanType := ""
+			if a.Attributes != nil {
+				codexPlanType = strings.TrimSpace(a.Attributes["plan_type"])
+			}
+			switch strings.ToLower(codexPlanType) {
+			case "pro":
+				models = registry.GetCodexProModels()
+			case "plus":
+				models = registry.GetCodexPlusModels()
+			case "team", "business", "go":
+				models = registry.GetCodexTeamModels()
+			case "free":
+				models = registry.GetCodexFreeModels()
+			default:
+				models = registry.GetCodexProModels()
+			}
 		}
 		if entry := s.resolveConfigCodexKey(a); entry != nil {
 			if len(entry.Models) > 0 {

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1960,6 +1960,7 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 		return
 	}
 	var models []*ModelInfo
+	var codexDiscoveryRevision uint64
 	switch provider {
 	case constant.Gemini:
 		models = registry.GetGeminiModels()
@@ -2014,7 +2015,9 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 		}
 		models = applyExcludedModels(models, excluded)
 	case "codex":
-		if discovered, ok := s.discoveredCodexModelsForAuth(ctx, a); ok {
+		discovered, ok, revision := s.discoveredCodexModelsForAuth(ctx, a)
+		codexDiscoveryRevision = revision
+		if ok {
 			models = discovered
 		} else {
 			codexPlanType := ""
@@ -2165,10 +2168,16 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 	models = s.appendPluginModels(key, models)
 	if len(models) > 0 {
 		s.registerResolvedModelsForAuth(a, key, applyModelPrefixes(models, a.Prefix, s.cfg != nil && s.cfg.ForceModelPrefix))
-		return
+	} else {
+		GlobalModelRegistry().UnregisterClient(a.ID)
 	}
 
-	GlobalModelRegistry().UnregisterClient(a.ID)
+	// A fast asynchronous discovery can complete before this call finishes
+	// registering its current catalog. Reconcile from the now-cached revision
+	// so older or fallback models cannot overwrite a successful discovery.
+	if provider == "codex" && s.codexModelDiscoveryRevisionChanged(a, codexDiscoveryRevision) {
+		s.registerModelsForAuthWithCache(ctx, a, compatCache)
+	}
 }
 
 // refreshModelRegistrationForAuth re-applies the latest model registration for


### PR DESCRIPTION
## Summary

- Fetch the authenticated upstream Codex model catalog per OAuth account so model registration follows actual account availability instead of a potentially stale JWT plan_type.
- Cache the last successful account catalog and preserve the existing plan-based fallback when discovery is unavailable.
- Preserve model aliases, exclusions, prefixes, Codex built-ins, custom headers, proxies, and --local-model behavior.
- Share the authenticated fetch and validation logic with fetch_codex_models.

## Testing

- Go 1.26: go test ./...
- Go 1.26 race tests: go test -race ./internal/auth/codex ./sdk/cliproxy ./cmd/fetch_codex_models ./cmd/server
- Go 1.26 required build: go build -o /tmp/cliproxy-pr-ready ./cmd/server
- Live dashboard validation with an imported OAuth JSON account: gpt-5.6-sol appeared correctly in /v1/models.

Addresses #4330