### PR TITLE
fix(xai): 尊重 using_api，官方 API 聊天路由与 OAuth 默认 base_url

### DIFF
--- a/internal/auth/xai/types.go
+++ b/internal/auth/xai/types.go
@@ -4,12 +4,16 @@ package xai
 import "time"
 
 const (
-	// DefaultAPIBaseURL is the default official xAI API base URL.
-	// Used for OAuth credential defaults, websocket, media (image/video),
-	// and non-media HTTP chat when auth using_api is true or non-OAuth.
+	// DefaultAPIBaseURL is the official xAI API base URL.
+	// Used for websocket, media (image/video), non-OAuth keys, and non-media
+	// HTTP chat when auth using_api is true (or when base_url is empty on that path).
+	// OAuth files may store this value historically; chat still rewrites it to
+	// CLIChatProxyBaseURL unless using_api is true. Set using_api=true to force
+	// chat through the official API (or an explicit base_url).
 	DefaultAPIBaseURL = "https://api.x.ai/v1"
 	// CLIChatProxyBaseURL is the Grok CLI chat-proxy base URL for non-image/video
-	// HTTP chat when auth using_api is false, including the OAuth default.
+	// HTTP chat when using_api is false (OAuth default). Media and websocket do
+	// not use this host (cli-chat-proxy rejects websocket upgrades).
 	CLIChatProxyBaseURL = "https://cli-chat-proxy.grok.com/v1"
 	// Issuer is xAI's OAuth issuer.
 	Issuer = "https://auth.x.ai"

--- a/internal/auth/xai/xai.go
+++ b/internal/auth/xai/xai.go
@@ -185,10 +185,13 @@ func (a *XAIAuth) WaitForAuthorization(ctx context.Context, deviceCode *DeviceCo
 	if deviceCode != nil {
 		tokenEndpoint = strings.TrimSpace(deviceCode.TokenEndpoint)
 	}
+	// Leave BaseURL empty so each transport picks its channel default:
+	// chat (using_api=false) → CLIChatProxyBaseURL, media/websocket → DefaultAPIBaseURL.
+	// Operators can set base_url and/or using_api=true on the auth file to override.
 	return &AuthBundle{
 		TokenData:     *tokenData,
 		LastRefresh:   time.Now().UTC().Format(time.RFC3339),
-		BaseURL:       DefaultAPIBaseURL,
+		BaseURL:       "",
 		TokenEndpoint: tokenEndpoint,
 	}, nil
 }
@@ -416,17 +419,20 @@ func (a *XAIAuth) CreateTokenStorage(bundle *AuthBundle) *TokenStorage {
 		return nil
 	}
 	return &TokenStorage{
-		Type:          "xai",
-		AccessToken:   bundle.TokenData.AccessToken,
-		RefreshToken:  bundle.TokenData.RefreshToken,
-		IDToken:       bundle.TokenData.IDToken,
-		TokenType:     bundle.TokenData.TokenType,
-		ExpiresIn:     bundle.TokenData.ExpiresIn,
-		Expire:        bundle.TokenData.Expire,
-		LastRefresh:   bundle.LastRefresh,
-		Email:         strings.TrimSpace(bundle.TokenData.Email),
-		Subject:       bundle.TokenData.Subject,
-		BaseURL:       firstNonEmpty(bundle.BaseURL, DefaultAPIBaseURL),
+		Type:         "xai",
+		AccessToken:  bundle.TokenData.AccessToken,
+		RefreshToken: bundle.TokenData.RefreshToken,
+		IDToken:      bundle.TokenData.IDToken,
+		TokenType:    bundle.TokenData.TokenType,
+		ExpiresIn:    bundle.TokenData.ExpiresIn,
+		Expire:       bundle.TokenData.Expire,
+		LastRefresh:  bundle.LastRefresh,
+		Email:        strings.TrimSpace(bundle.TokenData.Email),
+		Subject:      bundle.TokenData.Subject,
+		// Do not invent DefaultAPIBaseURL here: empty means channel defaults
+		// (chat → CLI proxy for OAuth, media/WS → official API). Explicit values
+		// (including CLIChatProxyBaseURL or DefaultAPIBaseURL) are preserved.
+		BaseURL:       strings.TrimSpace(bundle.BaseURL),
 		RedirectURI:   bundle.RedirectURI,
 		TokenEndpoint: bundle.TokenEndpoint,
 		AuthKind:      "oauth",

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -827,7 +827,11 @@ func (e *XAIExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cl
 	if tokenEndpoint != "" {
 		auth.Metadata["token_endpoint"] = tokenEndpoint
 	}
-	if xaiMetadataString(auth.Metadata, "base_url") == "" {
+	// Preserve an explicit base_url. When missing, only backfill the official API
+	// base for using_api=true so chat stays on api.x.ai; OAuth chat (using_api=false)
+	// keeps base_url empty and resolves to CLIChatProxyBaseURL at request time.
+	// Media/websocket already fall back to DefaultAPIBaseURL when base_url is empty.
+	if xaiMetadataString(auth.Metadata, "base_url") == "" && xaiUsingAPI(auth) {
 		auth.Metadata["base_url"] = xaiauth.DefaultAPIBaseURL
 	}
 	auth.Metadata["last_refresh"] = time.Now().UTC().Format(time.RFC3339)
@@ -835,7 +839,7 @@ func (e *XAIExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cl
 		auth.Attributes = make(map[string]string)
 	}
 	auth.Attributes["auth_kind"] = "oauth"
-	if strings.TrimSpace(auth.Attributes["base_url"]) == "" {
+	if strings.TrimSpace(auth.Attributes["base_url"]) == "" && xaiUsingAPI(auth) {
 		auth.Attributes["base_url"] = xaiauth.DefaultAPIBaseURL
 	}
 	return auth, nil
@@ -1026,12 +1030,18 @@ func xaiUsingAPI(auth *cliproxyauth.Auth) bool {
 }
 
 // xaiChatBaseURL returns the base URL for non-image/video xAI HTTP chat requests.
-// When auth using_api is true, the official API base URL logic is used. When it
-// is false (including its OAuth default), empty or official default base_url is
-// rewritten to the CLI chat-proxy endpoint; an explicit non-default base_url is
-// still honored.
-// Websocket transport intentionally does not use this helper: cli-chat-proxy only
-// accepts HTTP POST and returns 405 for websocket upgrades.
+//
+// Resolution order:
+//  1. using_api=true (or non-OAuth): honor auth base_url; empty → DefaultAPIBaseURL.
+//  2. using_api=false / OAuth default: honor any non-empty base_url that is not the
+//     official DefaultAPIBaseURL (custom gateways and explicit CLIChatProxyBaseURL).
+//  3. Otherwise (empty base_url, or historical OAuth files that stored
+//     DefaultAPIBaseURL without using_api): CLIChatProxyBaseURL.
+//
+// To force chat through the official API for an OAuth account, set
+// using_api=true (and optionally base_url=https://api.x.ai/v1) on the auth file.
+// Websocket/media intentionally do not use this helper: they use xaiCreds and
+// fall back to DefaultAPIBaseURL (cli-chat-proxy rejects websocket upgrades).
 func xaiChatBaseURL(auth *cliproxyauth.Auth) string {
 	_, baseURL := xaiCreds(auth)
 	if xaiUsingAPI(auth) {

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -827,22 +827,36 @@ func (e *XAIExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cl
 	if tokenEndpoint != "" {
 		auth.Metadata["token_endpoint"] = tokenEndpoint
 	}
-	// Preserve an explicit base_url. When missing, only backfill the official API
-	// base for using_api=true so chat stays on api.x.ai; OAuth chat (using_api=false)
-	// keeps base_url empty and resolves to CLIChatProxyBaseURL at request time.
-	// Media/websocket already fall back to DefaultAPIBaseURL when base_url is empty.
-	if xaiMetadataString(auth.Metadata, "base_url") == "" && xaiUsingAPI(auth) {
-		auth.Metadata["base_url"] = xaiauth.DefaultAPIBaseURL
-	}
 	auth.Metadata["last_refresh"] = time.Now().UTC().Format(time.RFC3339)
 	if auth.Attributes == nil {
 		auth.Attributes = make(map[string]string)
 	}
 	auth.Attributes["auth_kind"] = "oauth"
-	if strings.TrimSpace(auth.Attributes["base_url"]) == "" && xaiUsingAPI(auth) {
+	// Backfill official API base only when using_api=true and neither Attributes nor
+	// Metadata already carries a base_url. Checking via xaiCreds avoids overwriting
+	// Attributes with DefaultAPI when Metadata alone holds a custom gateway URL
+	// (Attributes is preferred by xaiCreds and would otherwise mask Metadata).
+	xaiBackfillBaseURLAfterRefresh(auth)
+	return auth, nil
+}
+
+// xaiBackfillBaseURLAfterRefresh fills DefaultAPIBaseURL when using_api is true and
+// the resolved base_url from Attributes/Metadata is empty. OAuth chat with
+// using_api=false keeps base_url empty so xaiChatBaseURL can select CLIChatProxy.
+func xaiBackfillBaseURLAfterRefresh(auth *cliproxyauth.Auth) {
+	if auth == nil {
+		return
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	if _, resolvedBaseURL := xaiCreds(auth); resolvedBaseURL == "" && xaiUsingAPI(auth) {
+		auth.Metadata["base_url"] = xaiauth.DefaultAPIBaseURL
 		auth.Attributes["base_url"] = xaiauth.DefaultAPIBaseURL
 	}
-	return auth, nil
 }
 
 type xaiPreparedRequest struct {

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -3794,6 +3794,51 @@ func TestXAIChatBaseURL(t *testing.T) {
 			},
 			want: xaiauth.DefaultAPIBaseURL,
 		},
+		{
+			name: "OAuth with empty base_url defaults to chat proxy",
+			auth: &cliproxyauth.Auth{
+				Attributes: map[string]string{"auth_kind": "oauth"},
+			},
+			want: xaiauth.CLIChatProxyBaseURL,
+		},
+		{
+			name: "OAuth metadata empty base_url defaults to chat proxy",
+			auth: &cliproxyauth.Auth{
+				Metadata: map[string]any{"auth_kind": "oauth"},
+			},
+			want: xaiauth.CLIChatProxyBaseURL,
+		},
+		{
+			name: "OAuth using_api true empty base_url uses official api",
+			auth: &cliproxyauth.Auth{
+				Attributes: map[string]string{
+					"auth_kind":     "oauth",
+					xaiUsingAPIAttr: "true",
+				},
+			},
+			want: xaiauth.DefaultAPIBaseURL,
+		},
+		{
+			name: "OAuth using_api true custom base_url is honored",
+			auth: &cliproxyauth.Auth{
+				Attributes: map[string]string{
+					"auth_kind":     "oauth",
+					"base_url":      "https://gateway.example.com/v1",
+					xaiUsingAPIAttr: "true",
+				},
+			},
+			want: "https://gateway.example.com/v1",
+		},
+		{
+			name: "OAuth explicit CLI chat proxy base_url is preserved",
+			auth: &cliproxyauth.Auth{
+				Attributes: map[string]string{
+					"auth_kind": "oauth",
+					"base_url":  xaiauth.CLIChatProxyBaseURL,
+				},
+			},
+			want: xaiauth.CLIChatProxyBaseURL,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -3665,6 +3665,75 @@ func TestXAIBaseURLSource(t *testing.T) {
 	}
 }
 
+func TestXAIBackfillBaseURLAfterRefresh(t *testing.T) {
+	const customGateway = "https://custom-xai-gateway.example/v1"
+
+	t.Run("preserves metadata-only custom base_url when using_api true", func(t *testing.T) {
+		auth := &cliproxyauth.Auth{
+			Attributes: map[string]string{
+				xaiUsingAPIAttr: "true",
+			},
+			Metadata: map[string]any{
+				"base_url": customGateway,
+			},
+		}
+		xaiBackfillBaseURLAfterRefresh(auth)
+		if got := strings.TrimSpace(auth.Attributes["base_url"]); got != "" {
+			t.Fatalf("Attributes base_url = %q, want empty (must not mask Metadata custom gateway)", got)
+		}
+		if got := xaiMetadataString(auth.Metadata, "base_url"); got != customGateway {
+			t.Fatalf("Metadata base_url = %q, want %q", got, customGateway)
+		}
+		if _, resolved := xaiCreds(auth); resolved != customGateway {
+			t.Fatalf("xaiCreds base_url = %q, want %q", resolved, customGateway)
+		}
+	})
+
+	t.Run("backfills both when empty and using_api true", func(t *testing.T) {
+		auth := &cliproxyauth.Auth{
+			Attributes: map[string]string{xaiUsingAPIAttr: "true"},
+			Metadata:   map[string]any{"auth_kind": "oauth"},
+		}
+		xaiBackfillBaseURLAfterRefresh(auth)
+		if got := strings.TrimSpace(auth.Attributes["base_url"]); got != xaiauth.DefaultAPIBaseURL {
+			t.Fatalf("Attributes base_url = %q, want %q", got, xaiauth.DefaultAPIBaseURL)
+		}
+		if got := xaiMetadataString(auth.Metadata, "base_url"); got != xaiauth.DefaultAPIBaseURL {
+			t.Fatalf("Metadata base_url = %q, want %q", got, xaiauth.DefaultAPIBaseURL)
+		}
+	})
+
+	t.Run("does not backfill when using_api false oauth", func(t *testing.T) {
+		auth := &cliproxyauth.Auth{
+			Attributes: map[string]string{
+				"auth_kind":     "oauth",
+				xaiUsingAPIAttr: "false",
+			},
+			Metadata: map[string]any{"auth_kind": "oauth"},
+		}
+		xaiBackfillBaseURLAfterRefresh(auth)
+		if got := strings.TrimSpace(auth.Attributes["base_url"]); got != "" {
+			t.Fatalf("Attributes base_url = %q, want empty", got)
+		}
+		if got := xaiMetadataString(auth.Metadata, "base_url"); got != "" {
+			t.Fatalf("Metadata base_url = %q, want empty", got)
+		}
+	})
+
+	t.Run("preserves attributes custom base_url", func(t *testing.T) {
+		auth := &cliproxyauth.Auth{
+			Attributes: map[string]string{
+				"base_url":      customGateway,
+				xaiUsingAPIAttr: "true",
+			},
+		}
+		xaiBackfillBaseURLAfterRefresh(auth)
+		if got := strings.TrimSpace(auth.Attributes["base_url"]); got != customGateway {
+			t.Fatalf("Attributes base_url = %q, want %q", got, customGateway)
+		}
+	})
+}
+
 func TestXAIChatBaseURL(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## 摘要

澄清并固化 xAI OAuth 聊天在 **CLI chat-proxy** 与官方 **`api.x.ai`** 之间的路由语义，**不破坏**历史 auth 文件行为。

### 背景 / 动机

大量 OAuth 凭证文件里写着 `base_url: https://api.x.ai/v1`，但在 `using_api` 未开启（默认）时，聊天请求仍会被改写到：

`https://cli-chat-proxy.grok.com/v1`

因此运营侧若只改文件里的 `base_url`，**无法**让 chat 真正走官方 API。  
实际开关本就是 **`using_api: true`**：此时会尊重文件中的 `base_url`（为空则回退官方 API）。

部分账号在 CLI 网关返回 403（`permission-denied` / chat endpoint denied），但同一 `access_token` 直连 `api.x.ai` 仍可用，且**无需重新登录**。本 PR 把这条路径文档化，并修正 OAuth 落盘/刷新时的误导默认值。

### 本 PR 改动

1. **OAuth 新登录**：不再强制把 `base_url` 写成 `https://api.x.ai/v1`，改为**留空**，由各传输层按通道默认解析  
   - chat（`using_api=false`）→ `CLIChatProxyBaseURL`  
   - media / websocket → 仍回退官方 API（cli-chat-proxy 不支持 WS 升级）
2. **Token 刷新回填**：仅在 `using_api=true` 时，才把空的 `base_url` 回填为 `DefaultAPIBaseURL`
3. **注释 / 文档化** `xaiChatBaseURL` 解析顺序
4. **单测**：覆盖 empty OAuth base_url、`using_api=true` 等路径

### 行为矩阵（chat HTTP）

| 条件 | 实际 chat base URL |
|------|-------------------|
| `using_api=true` | 文件 `base_url`；空则 `https://api.x.ai/v1` |
| OAuth / `using_api=false` + `base_url` 为空 | `https://cli-chat-proxy.grok.com/v1` |
| OAuth / `using_api=false` + `base_url == DefaultAPIBaseURL`（历史文件） | **仍走 CLI**（兼容，避免全体 OAuth 突然切官方 API） |
| OAuth / `using_api=false` + 自定义 / 显式 CLI proxy `base_url` | **尊重文件** |

Media / websocket：**未改**，仍走 `xaiCreds`，空 base 回退 `DefaultAPIBaseURL`。

### 运营如何强制官方 API 聊天

在 auth 文件上设置（token 已在 `api.x.ai` 可用时**无需重登**）：

```json
{
  "using_api": true,
  "base_url": "https://api.x.ai/v1"
}
```

### 兼容性

- 新 OAuth：空 `base_url` → chat 默认仍为 CLI  
- 旧 OAuth：文件写着 DefaultAPI 且无 `using_api` → 仍 CLI（无大规模迁移）  
- 非 OAuth / API Key：行为不变  
- **不修改** `internal/translator/**`、`AGENTS.md`  
- **不修改** openai-compatibility 通道

### 测试计划

- [x] `go test ./internal/runtime/executor/ -count=1 -run 'XAIChatBaseURL|ApplyXAIChatHeaders'`
- [x] `go test ./internal/auth/xai/ -count=1`（若适用）
- [x] 本地/Docker 构建 `./cmd/server`
- [x] 现网验证：`using_api=true` + 官方 `base_url` 后日志  
      `xai: using base_url=https://api.x.ai/v1 source=DefaultAPIBaseURL`，chat HTTP 200
- [ ] Reviewer：无 `using_api` 的 OAuth 仍命中 CLI chat-proxy

### PR 目标分支

**`dev`**（非 main）

### 关联

配套运维插件 [grok-inspection](https://github.com/ywddd/grok-inspection) 支持双网关巡检，并在 CLI 拒绝但 `api.x.ai` 可用时一键写入 `using_api=true` + 官方 `base_url`。
