### PR TITLE
fix(codex): identity-confuse never remaps installation_id, and emits UUIDv5 where the real client emits v7/v4

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -1833,11 +1834,11 @@ func applyCodexIdentityConfuseBody(cfg *config.Config, auth *cliproxyauth.Auth, 
 	state := codexIdentityConfuseState{enabled: true, authID: strings.TrimSpace(auth.ID)}
 	if promptCacheKey := strings.TrimSpace(gjson.GetBytes(userPayload, "prompt_cache_key").String()); promptCacheKey != "" {
 		state.originalPromptCacheKey = promptCacheKey
-		state.promptCacheKey = codexIdentityConfuseUUID(auth.ID, "prompt-cache", promptCacheKey)
+		state.promptCacheKey = codexIdentityConfuseUUIDLike(auth.ID, "prompt-cache", promptCacheKey)
 		rawJSON = helps.SetStringIfDifferent(rawJSON, "prompt_cache_key", state.promptCacheKey)
 	}
 	if installationID := strings.TrimSpace(gjson.GetBytes(userPayload, "client_metadata.x-codex-installation-id").String()); installationID != "" {
-		rawJSON, _ = sjson.SetBytes(rawJSON, "client_metadata.x-codex-installation-id", codexIdentityConfuseUUID(auth.ID, "installation", installationID))
+		rawJSON, _ = sjson.SetBytes(rawJSON, "client_metadata.x-codex-installation-id", codexIdentityConfuseUUIDLike(auth.ID, "installation", installationID))
 	}
 	if turnMetadata := strings.TrimSpace(gjson.GetBytes(rawJSON, "client_metadata.x-codex-turn-metadata").String()); turnMetadata != "" {
 		rawJSON, _ = sjson.SetBytes(rawJSON, "client_metadata.x-codex-turn-metadata", applyCodexTurnMetadataIdentityConfuse(turnMetadata, &state))
@@ -1891,6 +1892,37 @@ func applyCodexTurnMetadataIdentityConfuse(rawTurnMetadata string, state *codexI
 	if state.promptCacheKey != "" && gjson.Get(rawTurnMetadata, "window_id").Exists() {
 		updatedTurnMetadata, _ = sjson.Set(updatedTurnMetadata, "window_id", state.promptCacheKey+":0")
 	}
+	// installation_id is stable for the life of a Codex install, so an unconfused one
+	// is the strongest cross-account correlation anchor there is: every account in the
+	// pool would carry the same value for a given downstream client. The
+	// client_metadata.x-codex-installation-id path never covers it — a real client
+	// (Codex Desktop 0.144.x, live-captured 2026-07-17) sends installation_id ONLY here,
+	// in x-codex-turn-metadata, and sends no client_metadata at all. The ReplaceAll above
+	// cannot reach it either, since installation_id never equals prompt_cache_key.
+	// Same "installation" kind as the body path so both agree when both are present,
+	// but stamped version 4 to match what a real client's randomly-generated install id
+	// looks like. Guard on authID: a blank one would hash identically for every account,
+	// i.e. confused-looking but still a perfect correlation anchor.
+	if strings.TrimSpace(state.authID) != "" {
+		if installationID := strings.TrimSpace(gjson.Get(rawTurnMetadata, "installation_id").String()); installationID != "" {
+			if confused := codexIdentityConfuseUUIDLike(state.authID, "installation", installationID); confused != "" {
+				updatedTurnMetadata, _ = sjson.Set(updatedTurnMetadata, "installation_id", confused)
+			}
+		}
+		// turn_started_at_unix_ms comes off the same clock as turn_id — in the capture the
+		// two sit 17 ms apart. Shifting the version-7 ids while leaving this one raw would
+		// put a request's own two timestamps ~40 s apart, which no real client can produce:
+		// they are minted together. Move it by the same account offset so the whole request
+		// reads as one client whose clock runs slightly behind — internally consistent, and
+		// a skewed client clock is unremarkable, unlike a self-contradicting one.
+		if startedAt := gjson.Get(rawTurnMetadata, "turn_started_at_unix_ms"); startedAt.Exists() && startedAt.Type == gjson.Number {
+			shifted := startedAt.Int() - codexIdentityConfuseMillisOffset(state.authID)
+			if shifted < 0 {
+				shifted = 0
+			}
+			updatedTurnMetadata, _ = sjson.Set(updatedTurnMetadata, "turn_started_at_unix_ms", shifted)
+		}
+	}
 	return updatedTurnMetadata
 }
 
@@ -1920,7 +1952,7 @@ func (state *codexIdentityConfuseState) confuseTurnID(turnID string) string {
 			return replacement.confused
 		}
 	}
-	confusedTurnID := codexIdentityConfuseUUID(state.authID, "turn", turnID)
+	confusedTurnID := codexIdentityConfuseUUIDLike(state.authID, "turn", turnID)
 	state.turnIDs = append(state.turnIDs, codexIdentityReplacement{original: turnID, confused: confusedTurnID})
 	return confusedTurnID
 }
@@ -1945,6 +1977,77 @@ func codexIdentityConfuseEnabled(cfg *config.Config) bool {
 func codexIdentityConfuseUUID(authID string, kind string, value string) string {
 	name := strings.Join([]string{"cli-proxy-api", "codex", "identity-confuse", kind, strings.TrimSpace(authID), strings.TrimSpace(value)}, ":")
 	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(name)).String()
+}
+
+// codexIdentityConfuseMaxSkewMillis bounds the per-account clock shift below. It is
+// wide enough that two accounts practically never land on the same millisecond, and
+// narrow enough that the shifted timestamp stays consistent with when the request
+// actually arrives.
+const codexIdentityConfuseMaxSkewMillis = 60_000
+
+// codexIdentityConfuseMillisOffset returns a stable backward clock shift for one
+// account. A real client's version-7 ids carry a genuine millisecond timestamp, so
+// reusing the original's verbatim would leave every account in the pool reporting the
+// identical millisecond — an anchor as good as the id it replaces. The offset is keyed
+// on the account ALONE, never the id: one shift per account moves every id in the
+// request together, preserving the ordering the real client encodes (a turn is minted
+// later than the session that contains it, and that gap has to survive).
+func codexIdentityConfuseMillisOffset(authID string) int64 {
+	seed := uuid.NewSHA1(uuid.NameSpaceOID, []byte("cli-proxy-api:codex:identity-confuse:clock:"+strings.TrimSpace(authID)))
+	return int64(binary.BigEndian.Uint32(seed[0:4]) % codexIdentityConfuseMaxSkewMillis)
+}
+
+func codexUUIDMillis(u uuid.UUID) int64 {
+	return int64(u[0])<<40 | int64(u[1])<<32 | int64(u[2])<<24 | int64(u[3])<<16 | int64(u[4])<<8 | int64(u[5])
+}
+
+func codexSetUUIDMillis(u *uuid.UUID, ms int64) {
+	u[0], u[1], u[2] = byte(ms>>40), byte(ms>>32), byte(ms>>24)
+	u[3], u[4], u[5] = byte(ms>>16), byte(ms>>8), byte(ms)
+}
+
+// codexIdentityConfuseUUIDLike is codexIdentityConfuseUUID re-shaped to look like the id
+// it replaces. uuid.NewSHA1 always yields version 5, but a real client emits none: a live
+// capture (codex 0.142.5 / Codex Desktop 0.144.x, 2026-07-17) shows session, thread and
+// turn ids as version 7 and installation_id as version 4. A confused id that stops the
+// original from leaking while stamping "5" in the version nibble of every request just
+// trades one tell for another — and a version-5 id read as version 7 decodes to a
+// timestamp in the year 6335.
+//
+// So mirror the original: keep its version, and for version 7 carry its timestamp forward
+// shifted by this account's offset. Everything else stays hash-derived, so the result is
+// deterministic per (account, kind, original) — a session id that drifted between requests
+// would be its own tell — while a v4/v7 payload is defined to be opaque, leaving it
+// indistinguishable from a randomly generated one.
+func codexIdentityConfuseUUIDLike(authID string, kind string, value string) string {
+	confused, err := uuid.Parse(codexIdentityConfuseUUID(authID, kind, value))
+	if err != nil {
+		return ""
+	}
+	original, errOriginal := uuid.Parse(strings.TrimSpace(value))
+	if errOriginal != nil {
+		// Not a UUID, so there is no shape to mirror: leave the hash as-is rather than
+		// invent a version the caller never had.
+		return confused.String()
+	}
+	switch original.Version() {
+	case 4:
+		confused[6] = (confused[6] & 0x0f) | 0x40
+	case 7:
+		millis := codexUUIDMillis(original) - codexIdentityConfuseMillisOffset(authID)
+		if millis < 0 {
+			millis = 0
+		}
+		codexSetUUIDMillis(&confused, millis)
+		confused[6] = (confused[6] & 0x0f) | 0x70
+	default:
+		return confused.String()
+	}
+	// NewSHA1 already sets the RFC 4122 variant, but the timestamp write above can land
+	// on byte 8 for neither version — set it explicitly so the result is well-formed
+	// regardless of which branch ran.
+	confused[8] = (confused[8] & 0x3f) | 0x80
+	return confused.String()
 }
 
 func applyCodexHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, stream bool, cfg *config.Config) {

--- a/internal/runtime/executor/codex_identity_confuse_shape_test.go
+++ b/internal/runtime/executor/codex_identity_confuse_shape_test.go
@@ -1,0 +1,209 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/tidwall/gjson"
+)
+
+// realCodexTurnMetadata is a verbatim x-codex-turn-metadata header from a real client
+// (Codex Desktop 0.144.0-alpha.4), captured 2026-07-17. It is the ground truth for every
+// assertion below. Note what the real client does:
+//   - installation_id lives ONLY here; the client sends no client_metadata at all
+//   - session_id == thread_id, and window_id is that same id + ":0"
+//   - session/thread/turn ids are UUID version 7; installation_id is version 4
+//   - turn_started_at_unix_ms is minted off the same clock as turn_id, 17 ms apart
+const realCodexTurnMetadata = `{"installation_id":"6ae1cc61-7e89-4a8c-8da2-982ddde8d432","session_id":"019f5a8a-cc68-7b92-89aa-17602176af46","thread_id":"019f5a8a-cc68-7b92-89aa-17602176af46","turn_id":"019f5aaa-1ca3-71f0-b3e4-de5b34ec347a","window_id":"019f5a8a-cc68-7b92-89aa-17602176af46:0","request_kind":"turn","thread_source":"user","sandbox":"none","turn_started_at_unix_ms":1783932525748,"workspace_kind":"projectless"}`
+
+const (
+	realCodexSessionID      = "019f5a8a-cc68-7b92-89aa-17602176af46"
+	realCodexTurnID         = "019f5aaa-1ca3-71f0-b3e4-de5b34ec347a"
+	realCodexInstallationID = "6ae1cc61-7e89-4a8c-8da2-982ddde8d432"
+)
+
+func confuseStateFor(authID string) *codexIdentityConfuseState {
+	return &codexIdentityConfuseState{
+		enabled:                true,
+		authID:                 authID,
+		originalPromptCacheKey: realCodexSessionID,
+		promptCacheKey:         codexIdentityConfuseUUIDLike(authID, "prompt-cache", realCodexSessionID),
+	}
+}
+
+func millisOf(t *testing.T, id string) int64 {
+	t.Helper()
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		t.Fatalf("parse %q: %v", id, err)
+	}
+	return codexUUIDMillis(parsed)
+}
+
+// installation_id is stable for the life of a Codex install, so it survives every other
+// per-account remap: leaving it raw lets the backend group every credential a single
+// client is routed across. The existing remap only covers
+// client_metadata.x-codex-installation-id, which a real client never populates.
+func TestIdentityConfuse_RemapsTurnMetadataInstallationID(t *testing.T) {
+	got := gjson.Get(applyCodexTurnMetadataIdentityConfuse(realCodexTurnMetadata, confuseStateFor("auth-a")), "installation_id").String()
+
+	if got == realCodexInstallationID {
+		t.Fatalf("raw installation_id reached the wire: %q", got)
+	}
+	if got == "" {
+		t.Fatalf("installation_id was dropped; a real client always sends one")
+	}
+}
+
+// The decisive property: two credentials serving one client must not share an
+// installation_id, or the id is a correlation anchor and identity-confuse is defeated.
+func TestIdentityConfuse_InstallationIDDiffersPerAuth(t *testing.T) {
+	a := gjson.Get(applyCodexTurnMetadataIdentityConfuse(realCodexTurnMetadata, confuseStateFor("auth-a")), "installation_id").String()
+	b := gjson.Get(applyCodexTurnMetadataIdentityConfuse(realCodexTurnMetadata, confuseStateFor("auth-b")), "installation_id").String()
+
+	if a == b {
+		t.Fatalf("two auths emitted the same installation_id %q", a)
+	}
+}
+
+// A blank authID would hash identically for every credential: confused-looking, but still
+// a perfect anchor. Leave the id alone instead.
+func TestIdentityConfuse_BlankAuthIDLeavesInstallationIDAlone(t *testing.T) {
+	state := &codexIdentityConfuseState{enabled: true, originalPromptCacheKey: realCodexSessionID, promptCacheKey: "confused"}
+	if got := gjson.Get(applyCodexTurnMetadataIdentityConfuse(realCodexTurnMetadata, state), "installation_id").String(); got != realCodexInstallationID {
+		t.Fatalf("installation_id = %q with a blank authID, want it untouched", got)
+	}
+}
+
+// uuid.NewSHA1 always yields version 5, which no real client emits. A confused id that
+// stops the original from leaking while stamping "5" in the version nibble of every
+// request just trades one tell for another.
+func TestIdentityConfuseUUIDLike_MirrorsOriginalVersion(t *testing.T) {
+	if got := realCodexSessionID[14]; got != '7' {
+		t.Fatalf("fixture drift: captured session id is version %c, want 7", got)
+	}
+	if got := realCodexInstallationID[14]; got != '4' {
+		t.Fatalf("fixture drift: captured installation id is version %c, want 4", got)
+	}
+
+	for name, tc := range map[string]struct{ original, kind string }{
+		"session (v7)":      {realCodexSessionID, "prompt-cache"},
+		"turn (v7)":         {realCodexTurnID, "turn"},
+		"installation (v4)": {realCodexInstallationID, "installation"},
+	} {
+		got := codexIdentityConfuseUUIDLike("auth-a", tc.kind, tc.original)
+		if len(got) != 36 {
+			t.Errorf("%s: got %q, want a 36-char hyphenated UUID", name, got)
+		}
+		if got[14] != tc.original[14] {
+			t.Errorf("%s: got version %c, want the original's %c", name, got[14], tc.original[14])
+		}
+		if parsed, err := uuid.Parse(got); err != nil {
+			t.Errorf("%s: %v", name, err)
+		} else if parsed.Variant() != uuid.RFC4122 {
+			t.Errorf("%s: variant = %v, want RFC4122", name, parsed.Variant())
+		}
+	}
+}
+
+// A version-7 id's leading 48 bits are a real millisecond timestamp, so a confused one has
+// to decode to a plausible instant. Reading a version-5 hash as a v7 lands in the year
+// 6335 — visible to anyone who parses the id.
+func TestIdentityConfuseUUIDLike_V7TimestampStaysPlausible(t *testing.T) {
+	original := millisOf(t, realCodexSessionID)
+	got := millisOf(t, codexIdentityConfuseUUIDLike("auth-a", "prompt-cache", realCodexSessionID))
+
+	if got > original {
+		t.Errorf("confused id is %d ms in the future of the original; a session cannot start after itself", got-original)
+	}
+	if original-got > codexIdentityConfuseMaxSkewMillis {
+		t.Errorf("confused id is %d ms before the original, beyond the %d ms bound", original-got, codexIdentityConfuseMaxSkewMillis)
+	}
+}
+
+// One shift per auth, applied to every id: a real client mints a turn after the session
+// that contains it, and that gap has to survive.
+func TestIdentityConfuseUUIDLike_PreservesSessionToTurnGap(t *testing.T) {
+	session := millisOf(t, codexIdentityConfuseUUIDLike("auth-a", "prompt-cache", realCodexSessionID))
+	turn := millisOf(t, codexIdentityConfuseUUIDLike("auth-a", "turn", realCodexTurnID))
+
+	if turn <= session {
+		t.Fatalf("turn (%d) is not after session (%d)", turn, session)
+	}
+	if want := millisOf(t, realCodexTurnID) - millisOf(t, realCodexSessionID); turn-session != want {
+		t.Errorf("session-to-turn gap = %d ms, want the original %d ms", turn-session, want)
+	}
+}
+
+// The shift must differ per auth, or every credential reports the identical millisecond
+// and the timestamp becomes the anchor the id no longer is.
+func TestIdentityConfuseUUIDLike_V7TimestampDiffersPerAuth(t *testing.T) {
+	a := millisOf(t, codexIdentityConfuseUUIDLike("auth-a", "prompt-cache", realCodexSessionID))
+	b := millisOf(t, codexIdentityConfuseUUIDLike("auth-b", "prompt-cache", realCodexSessionID))
+
+	if a == b {
+		t.Fatalf("two auths reported the same session millisecond (%d)", a)
+	}
+}
+
+// A real id never changes, so the remap has to be deterministic; one that drifted between
+// requests would be its own tell.
+func TestIdentityConfuseUUIDLike_IsDeterministic(t *testing.T) {
+	for _, original := range []string{realCodexSessionID, realCodexInstallationID} {
+		first := codexIdentityConfuseUUIDLike("auth-a", "prompt-cache", original)
+		if second := codexIdentityConfuseUUIDLike("auth-a", "prompt-cache", original); first != second {
+			t.Fatalf("%q remapped to %q then %q", original, first, second)
+		}
+	}
+}
+
+// An original that is not a UUID has no shape to mirror; keep the plain hash rather than
+// invent a version the caller never had.
+func TestIdentityConfuseUUIDLike_NonUUIDOriginalKeepsHash(t *testing.T) {
+	got := codexIdentityConfuseUUIDLike("auth-a", "prompt-cache", "not-a-uuid")
+	if want := codexIdentityConfuseUUID("auth-a", "prompt-cache", "not-a-uuid"); got != want {
+		t.Fatalf("got %q, want the plain hash %q", got, want)
+	}
+}
+
+// turn_started_at_unix_ms comes off the same clock as turn_id — 17 ms apart in the
+// capture, because a real client mints them together. Shifting the ids while leaving the
+// plaintext sibling raw puts a request's own two timestamps ~40 s apart, which no real
+// client can produce.
+func TestIdentityConfuse_TurnStartedAtTracksTurnID(t *testing.T) {
+	realStartedAt := gjson.Get(realCodexTurnMetadata, "turn_started_at_unix_ms").Int()
+	realDelta := realStartedAt - millisOf(t, realCodexTurnID)
+	if realDelta < 0 || realDelta > 1000 {
+		t.Fatalf("fixture drift: captured turn_started_at is %d ms from turn_id", realDelta)
+	}
+
+	for _, authID := range []string{"auth-a", "auth-b"} {
+		confused := applyCodexTurnMetadataIdentityConfuse(realCodexTurnMetadata, confuseStateFor(authID))
+		startedAt := gjson.Get(confused, "turn_started_at_unix_ms").Int()
+
+		if got := startedAt - millisOf(t, gjson.Get(confused, "turn_id").String()); got != realDelta {
+			t.Errorf("%s: turn_started_at is %d ms from turn_id, want the captured %d ms", authID, got, realDelta)
+		}
+		if startedAt >= realStartedAt {
+			t.Errorf("%s: turn_started_at %d was not shifted (raw %d)", authID, startedAt, realStartedAt)
+		}
+	}
+}
+
+// The identity graph a real client emits must survive the reshape:
+// session_id == thread_id and window_id == that id + ":0".
+func TestIdentityConfuse_TurnMetadataGraphStaysCoherent(t *testing.T) {
+	state := confuseStateFor("auth-a")
+	confused := applyCodexTurnMetadataIdentityConfuse(realCodexTurnMetadata, state)
+
+	sessionID := gjson.Get(confused, "session_id").String()
+	if sessionID == realCodexSessionID {
+		t.Fatalf("raw session id reached the wire")
+	}
+	if got := gjson.Get(confused, "thread_id").String(); got != sessionID {
+		t.Errorf("thread_id = %q, want it to equal session_id %q", got, sessionID)
+	}
+	if got, want := gjson.Get(confused, "window_id").String(), sessionID+":0"; got != want {
+		t.Errorf("window_id = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Two defects in `identity-confuse`, found while auditing a Codex account pool against a live capture of the real client.

### 1. `installation_id` is never remapped

The remap targets `client_metadata.x-codex-installation-id` — **a real client never populates it.** Codex Desktop
0.144.x sends `installation_id` only inside the `x-codex-turn-metadata` header, and sends no `client_metadata` at all,
so `codex_executor.go` L1559-1561 has never fired against a genuine client.

`applyCodexTurnMetadataIdentityConfuse` cannot reach it either: it rewrites occurrences of the original
`prompt_cache_key`, which covers `session_id`/`thread_id`/`window_id` only because a real client sets all three
**equal** to `prompt_cache_key`. `installation_id` is a different value, so `strings.ReplaceAll` skips it.

`installation_id` is stable for the life of an install — three runs against one `CODEX_HOME` produced the identical
value while `session_id` varied — so it survives every other per-account remap. Every credential a single client is
routed across therefore carries the same one, which is exactly what the option exists to prevent.
`config.example.yaml` advertises it as remapping *"prompt_cache_key and **installation identity**"*.

### 2. Every confused id is UUID version 5

`codexIdentityConfuseUUID` is `uuid.NewSHA1`. A real client emits **version 7** for session/thread/turn ids (leading
48 bits are a real millisecond timestamp) and **version 4** for `installation_id`. Version 5 is a single-nibble
compare away, and read as a v7 it decodes to **the year 6335**.

## Fix

`codexIdentityConfuseUUIDLike` mirrors the id it replaces — same version, and for v7 the original's timestamp carried
forward minus a per-account offset keyed on the **account alone, never the id**, so every timestamp in a request
shifts together and the ordering the client encodes survives.

`turn_started_at_unix_ms` shifts with them: it is minted off the same clock as `turn_id` (17 ms apart in the capture),
so shifting the ids while leaving the plaintext sibling raw would put a request's own two timestamps ~40 s apart.
Each account now reads as one client whose clock runs slightly behind — internally consistent, and a skewed client
clock is unremarkable, unlike a self-contradicting one.

```
REAL     session=08:14:33.576  turn_id=08:48:45.731  started_at=08:48:45.748  gap 34m12.155s  +17ms  v7/v7/v4
auth-a   session=08:13:55.655  turn_id=08:48:07.810  started_at=08:48:07.827  gap 34m12.155s  +17ms  clock -37s
auth-b   session=08:13:39.565  turn_id=08:47:51.720  started_at=08:47:51.737  gap 34m12.155s  +17ms  clock -54s
```

Reusing the original timestamp verbatim was not an option: every account would report the identical millisecond, an
anchor as good as the id it replaces. Everything stays deterministic per (account, kind, original) — an id that
drifted between requests would be its own tell. A non-UUID original keeps the plain hash; a blank `authID` leaves the
id alone, since it would hash identically for every account.

Known residual: the session→turn gap is identical across accounts. It is the user's real think time and the turn
timestamp has to stay consistent with actual request arrival, so randomising it would cost plausibility — arrival
timing already reveals at least as much.

## Ground truth

Live capture of the real codex CLI pointed at a local server (`chatgpt_base_url` + the provider `base_url` both
redirected), cross-checked against a verbatim inbound request from a production log. Invariants confirmed across two
client generations (1.3.0 and 0.142.5): `session_id == thread_id == body.prompt_cache_key`, `window_id == that + ":0"`,
`installation_id` header-only and stable per install, versions 7/7/7/4.

## Tests

11 tests replay the verbatim captured `x-codex-turn-metadata`. Against the pre-fix behaviour they report:

```
session (v7): got version 5, want the original's 7
turn (v7): got version 5, want the original's 7
installation (v4): got version 5, want the original's 4
session-to-turn gap = 170640235261055 ms, want the original 2052155 ms
```

They also pin: two auths must not share an `installation_id`; the v7 timestamp is plausible and never ahead of the
original; the session→turn gap survives; the absolute millisecond differs per auth; `turn_started_at_unix_ms` stays
17 ms from `turn_id`; the remap is deterministic; a blank `authID` and a non-UUID original are left alone.

## Verification

`go test -count=1 ./...` → exit 0, 77 packages ok, 0 FAIL · `gofmt` clean · `go vet` clean

Scope: `internal/runtime/executor/codex_executor.go` + one new test file. No behaviour change when
`identity-confuse` is off (default).
