### PR TITLE
feat: add adaptive Codex quota cooldown

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -184,6 +184,14 @@ codex:
   # Some superstitious users believe request tracking identifiers can be used
   # as evidence for TOS enforcement bans; this option only satisfies those odd concerns.
   identity-confuse: false
+  # Adaptive Codex cooldowns are opt-in. When enabled, ordinary 429 responses use
+  # 15s, 30s, 1m, 2m, and 5m backoff with jitter. usage_limit_reached follows the
+  # provider reset time and is checked through the non-consuming WHAM usage endpoint.
+  quota-cooldown:
+    enabled: false
+    unauthorized-cooldown-seconds: 1800
+    transient-backoff-seconds: [15, 30, 60, 120, 300]
+    jitter-percent: 20
 
 # When true, enable authentication for the WebSocket API (/v1/ws).
 ws-auth: true

--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -703,7 +703,7 @@ func mergeFileBodySource(payload []byte, source *logging.FileBodySource) ([]byte
 		}
 		buf.WriteByte('\n')
 	}
-	if errWrite := source.WriteTo(&buf); errWrite != nil {
+	if _, errWrite := source.WriteTo(&buf); errWrite != nil {
 		return nil, errWrite
 	}
 	return buf.Bytes(), nil

--- a/internal/config/codex_quota_cooldown_test.go
+++ b/internal/config/codex_quota_cooldown_test.go
@@ -1,0 +1,34 @@
+package config
+
+import "testing"
+
+func TestParseConfigBytes_CodexQuotaCooldown(t *testing.T) {
+	cfg, errParse := ParseConfigBytes([]byte(`
+codex:
+  quota-cooldown:
+    enabled: true
+    unauthorized-cooldown-seconds: 10800
+    transient-backoff-seconds: [15, 30, 60, 120, 300]
+    jitter-percent: 20
+`))
+	if errParse != nil {
+		t.Fatalf("ParseConfigBytes() returned error: %v", errParse)
+	}
+	got := cfg.Codex.QuotaCooldown
+	if !got.Enabled || got.UnauthorizedCooldownSeconds != 10800 || got.JitterPercent != 20 {
+		t.Fatalf("quota cooldown = %+v", got)
+	}
+	if len(got.TransientBackoffSeconds) != 5 || got.TransientBackoffSeconds[4] != 300 {
+		t.Fatalf("transient backoff = %v", got.TransientBackoffSeconds)
+	}
+}
+
+func TestParseConfigBytes_CodexQuotaCooldownDefaultsDisabled(t *testing.T) {
+	cfg, errParse := ParseConfigBytes([]byte("port: 8317\n"))
+	if errParse != nil {
+		t.Fatalf("ParseConfigBytes() returned error: %v", errParse)
+	}
+	if cfg.Codex.QuotaCooldown.Enabled {
+		t.Fatal("Codex quota cooldown should be disabled by default")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -285,6 +285,23 @@ type CodexHeaderDefaults struct {
 // CodexConfig configures provider-wide Codex request behavior.
 type CodexConfig struct {
 	IdentityConfuse bool `yaml:"identity-confuse" json:"identity-confuse"`
+	// QuotaCooldown configures Codex-specific 401 and 429 recovery behavior.
+	// It is disabled by default so existing installations keep upstream behavior.
+	QuotaCooldown CodexQuotaCooldownConfig `yaml:"quota-cooldown" json:"quota-cooldown"`
+}
+
+// CodexQuotaCooldownConfig controls adaptive Codex cooldown behavior.
+type CodexQuotaCooldownConfig struct {
+	// Enabled activates Codex-specific adaptive rate-limit cooldowns and quota probes.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// UnauthorizedCooldownSeconds overrides the legacy 30-minute 401 cooldown when positive.
+	UnauthorizedCooldownSeconds int `yaml:"unauthorized-cooldown-seconds" json:"unauthorized-cooldown-seconds"`
+	// TransientBackoffSeconds defines the progressive cooldown ladder for non-quota 429 responses.
+	// Empty uses 15, 30, 60, 120, and 300 seconds. Values are capped at five minutes.
+	TransientBackoffSeconds []int `yaml:"transient-backoff-seconds" json:"transient-backoff-seconds"`
+	// JitterPercent applies symmetric jitter to transient 429 cooldowns.
+	// Non-positive values use 20 percent. The final cooldown never exceeds five minutes.
+	JitterPercent int `yaml:"jitter-percent" json:"jitter-percent"`
 }
 
 // TLSConfig holds HTTPS server settings.

--- a/internal/logging/request_logger.go
+++ b/internal/logging/request_logger.go
@@ -210,29 +210,33 @@ func (s *FileBodySource) Paths() []string {
 }
 
 // WriteTo merges all ordered parts into w.
-func (s *FileBodySource) WriteTo(w io.Writer) error {
+func (s *FileBodySource) WriteTo(w io.Writer) (int64, error) {
 	if s == nil || w == nil {
-		return nil
+		return 0, nil
 	}
 	paths := s.Paths()
 	wrote := false
+	var total int64
 	for _, path := range paths {
 		file, errOpen := os.Open(path)
 		if errOpen != nil {
 			if os.IsNotExist(errOpen) {
 				continue
 			}
-			return errOpen
+			return total, errOpen
 		}
 		if wrote {
-			if _, errWrite := io.WriteString(w, "\n"); errWrite != nil {
+			n, errWrite := io.WriteString(w, "\n")
+			total += int64(n)
+			if errWrite != nil {
 				if errClose := file.Close(); errClose != nil {
 					log.WithError(errClose).Warn("failed to close log part file")
 				}
-				return errWrite
+				return total, errWrite
 			}
 		}
-		_, errCopy := io.Copy(w, file)
+		n, errCopy := io.Copy(w, file)
+		total += n
 		if errClose := file.Close(); errClose != nil {
 			log.WithError(errClose).Warn("failed to close log part file")
 			if errCopy == nil {
@@ -240,17 +244,17 @@ func (s *FileBodySource) WriteTo(w io.Writer) error {
 			}
 		}
 		if errCopy != nil {
-			return errCopy
+			return total, errCopy
 		}
 		wrote = true
 	}
-	return nil
+	return total, nil
 }
 
 // Bytes merges all ordered parts into memory.
 func (s *FileBodySource) Bytes() ([]byte, error) {
 	var buf bytes.Buffer
-	if errWrite := s.WriteTo(&buf); errWrite != nil {
+	if _, errWrite := s.WriteTo(&buf); errWrite != nil {
 		return nil, errWrite
 	}
 	return buf.Bytes(), nil
@@ -1227,7 +1231,7 @@ func writeAPISectionWithSource(w io.Writer, sectionHeader string, sectionPrefix 
 		}
 	}
 	tracker := &trailingNewlineTrackingWriter{writer: w}
-	if errWrite := source.WriteTo(tracker); errWrite != nil {
+	if _, errWrite := source.WriteTo(tracker); errWrite != nil {
 		return errWrite
 	}
 	if errWrite := writeSectionSpacing(w, tracker.trailingNewlines); errWrite != nil {
@@ -1246,7 +1250,7 @@ func writePreformattedAPISectionWithSource(w io.Writer, sectionHeader string, se
 		}
 	}
 	tracker := &trailingNewlineTrackingWriter{writer: w}
-	if errWrite := source.WriteTo(tracker); errWrite != nil {
+	if _, errWrite := source.WriteTo(tracker); errWrite != nil {
 		return errWrite
 	}
 	if errWrite := writeSectionSpacing(w, tracker.trailingNewlines); errWrite != nil {

--- a/internal/logging/request_logger_home_test.go
+++ b/internal/logging/request_logger_home_test.go
@@ -75,6 +75,36 @@ func TestFileBodySource_RecreatesPartDirAfterManualCleanup(t *testing.T) {
 	assertFileBodySourceCleaned(t, partPaths)
 }
 
+func TestFileBodySource_WriteToReportsBytes(t *testing.T) {
+	source, errSource := NewFileBodySourceInDir(t.TempDir(), "write-to-count")
+	if errSource != nil {
+		t.Fatalf("NewFileBodySourceInDir: %v", errSource)
+	}
+	t.Cleanup(func() {
+		if errCleanup := source.Cleanup(); errCleanup != nil {
+			t.Errorf("Cleanup: %v", errCleanup)
+		}
+	})
+	if errAppend := source.AppendPart([]byte("first")); errAppend != nil {
+		t.Fatalf("AppendPart first: %v", errAppend)
+	}
+	if errAppend := source.AppendPart([]byte("second")); errAppend != nil {
+		t.Fatalf("AppendPart second: %v", errAppend)
+	}
+
+	var buf bytes.Buffer
+	written, errWrite := source.WriteTo(&buf)
+	if errWrite != nil {
+		t.Fatalf("WriteTo: %v", errWrite)
+	}
+	if got, want := buf.String(), "first\n\nsecond\n"; got != want {
+		t.Fatalf("WriteTo body = %q, want %q", got, want)
+	}
+	if got, want := written, int64(buf.Len()); got != want {
+		t.Fatalf("WriteTo count = %d, want %d", got, want)
+	}
+}
+
 func TestFileRequestLogger_HomeEnabled_ForwardsWhenRequestLogEnabled(t *testing.T) {
 	original := currentHomeRequestLogClient
 	defer func() {

--- a/internal/pluginhost/host_callbacks.go
+++ b/internal/pluginhost/host_callbacks.go
@@ -162,9 +162,14 @@ func (h *Host) callHostHTTPDoStream(ctx context.Context, request []byte) ([]byte
 		ctx = context.Background()
 	}
 	streamCtx, cancel := context.WithCancel(ctx)
+	cancelOwnedByBridge := false
+	defer func() {
+		if !cancelOwnedByBridge {
+			cancel()
+		}
+	}()
 	resp, errDo := h.newHTTPClient(nil).DoStream(streamCtx, httpReq)
 	if errDo != nil {
-		cancel()
 		return nil, errDo
 	}
 	streamID := ""
@@ -172,9 +177,9 @@ func (h *Host) callHostHTTPDoStream(ctx context.Context, request []byte) ([]byte
 		streamID = h.httpStreams.open(resp.Chunks, cancel)
 	}
 	if streamID == "" {
-		cancel()
 		return nil, fmt.Errorf("host http stream bridge is unavailable")
 	}
+	cancelOwnedByBridge = true
 	return marshalRPCResult(rpcHostHTTPStreamResponse{
 		StatusCode: resp.StatusCode,
 		Headers:    httpHeader(resp.Headers),

--- a/internal/pluginhost/host_model_stream_callbacks.go
+++ b/internal/pluginhost/host_model_stream_callbacks.go
@@ -27,9 +27,14 @@ func (h *Host) callHostModelExecuteStream(ctx context.Context, request []byte) (
 	}
 	// Detach request cancellation while preserving callback values; callback cleanup owns the model stream lifetime.
 	streamCtx, cancel := context.WithCancel(context.WithoutCancel(callbackCtx))
+	cancelOwnedByBridge := false
+	defer func() {
+		if !cancelOwnedByBridge {
+			cancel()
+		}
+	}()
 	stream, errMsg := executor.ExecuteModelStream(streamCtx, modelExecutionRequestFromPlugin(req.HostModelExecutionRequest, skipPluginID))
 	if errMsg != nil {
-		cancel()
 		return nil, modelExecutionError(errMsg)
 	}
 	streamID := ""
@@ -37,9 +42,9 @@ func (h *Host) callHostModelExecuteStream(ctx context.Context, request []byte) (
 		streamID = h.modelStreams.open(req.HostCallbackID, stream.Chunks, cancel)
 	}
 	if streamID == "" {
-		cancel()
 		return nil, fmt.Errorf("host model stream bridge is unavailable")
 	}
+	cancelOwnedByBridge = true
 	if req.HostCallbackID != "" {
 		h.addCallbackCleanup(req.HostCallbackID, func() {
 			h.modelStreams.close(streamID)

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -21,10 +20,19 @@ import (
 )
 
 func resetAntigravityCreditsRetryState() {
-	antigravityCreditsFailureByAuth = sync.Map{}
-	antigravityShortCooldownByAuth = sync.Map{}
-	antigravityCreditsBalanceByAuth = sync.Map{}
-	antigravityCreditsHintRefreshByID = sync.Map{}
+	antigravityCreditsHintRefreshByID.Range(func(_, value any) bool {
+		state, ok := value.(*antigravityCreditsHintRefreshState)
+		if !ok || state == nil {
+			return true
+		}
+		state.mu.Lock()
+		state.mu.Unlock()
+		return true
+	})
+	antigravityCreditsFailureByAuth.Clear()
+	antigravityShortCooldownByAuth.Clear()
+	antigravityCreditsBalanceByAuth.Clear()
+	antigravityCreditsHintRefreshByID.Clear()
 }
 
 type fakeAntigravityKVClient struct {
@@ -547,7 +555,7 @@ func TestAntigravityShortCooldownRequiredHomeKV(t *testing.T) {
 	if client.setCount != 1 || client.lastSetTTL != duration+5*time.Second {
 		t.Fatalf("KVSet count/ttl = %d/%v, want 1/%v", client.setCount, client.lastSetTTL, duration+5*time.Second)
 	}
-	antigravityShortCooldownByAuth = sync.Map{}
+	antigravityShortCooldownByAuth.Clear()
 	inCooldown, remaining, errRead := antigravityIsInShortCooldownRequired(context.Background(), auth, "claude-sonnet-4-5", now.Add(5*time.Second))
 	if errRead != nil {
 		t.Fatalf("antigravityIsInShortCooldownRequired() error = %v", errRead)

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -51,6 +51,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.TransientErrorCooldownSeconds != newCfg.TransientErrorCooldownSeconds {
 		changes = append(changes, fmt.Sprintf("transient-error-cooldown-seconds: %d -> %d", oldCfg.TransientErrorCooldownSeconds, newCfg.TransientErrorCooldownSeconds))
 	}
+	if !reflect.DeepEqual(oldCfg.Codex.QuotaCooldown, newCfg.Codex.QuotaCooldown) {
+		changes = append(changes, fmt.Sprintf("codex.quota-cooldown: enabled %t -> %t", oldCfg.Codex.QuotaCooldown.Enabled, newCfg.Codex.QuotaCooldown.Enabled))
+	}
 	if oldCfg.DisableClaudeCloakMode != newCfg.DisableClaudeCloakMode {
 		changes = append(changes, fmt.Sprintf("disable-claude-cloak-mode: %t -> %t", oldCfg.DisableClaudeCloakMode, newCfg.DisableClaudeCloakMode))
 	}

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -93,6 +93,19 @@ func TestBuildConfigChangeDetails_NoChanges(t *testing.T) {
 	}
 }
 
+func TestBuildConfigChangeDetails_CodexQuotaCooldown(t *testing.T) {
+	oldCfg := &config.Config{}
+	newCfg := &config.Config{}
+	newCfg.Codex.QuotaCooldown = config.CodexQuotaCooldownConfig{
+		Enabled:                     true,
+		UnauthorizedCooldownSeconds: 10800,
+		TransientBackoffSeconds:     []int{15, 30, 60, 120, 300},
+		JitterPercent:               20,
+	}
+	details := BuildConfigChangeDetails(oldCfg, newCfg)
+	expectContains(t, details, "codex.quota-cooldown: enabled false -> true")
+}
+
 func TestBuildConfigChangeDetails_GeminiVertexHeaders(t *testing.T) {
 	oldCfg := &config.Config{
 		GeminiKey: []config.GeminiKey{

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1510,11 +1510,14 @@ func TestNormalizeAuthNil(t *testing.T) {
 
 // stubStore implements coreauth.Store plus watcher-specific persistence helpers.
 type stubStore struct {
+	mu              sync.Mutex
 	authDir         string
 	cfgPersisted    int32
 	authPersisted   int32
 	lastAuthMessage string
 	lastAuthPaths   []string
+	cfgDone         chan struct{}
+	authDone        chan struct{}
 }
 
 func (s *stubStore) List(context.Context) ([]*coreauth.Auth, error) { return nil, nil }
@@ -1524,15 +1527,29 @@ func (s *stubStore) Save(context.Context, *coreauth.Auth) (string, error) {
 func (s *stubStore) Delete(context.Context, string) error { return nil }
 func (s *stubStore) PersistConfig(context.Context) error {
 	atomic.AddInt32(&s.cfgPersisted, 1)
+	if s.cfgDone != nil {
+		s.cfgDone <- struct{}{}
+	}
 	return nil
 }
 func (s *stubStore) PersistAuthFiles(_ context.Context, message string, paths ...string) error {
 	atomic.AddInt32(&s.authPersisted, 1)
+	s.mu.Lock()
 	s.lastAuthMessage = message
-	s.lastAuthPaths = paths
+	s.lastAuthPaths = append([]string(nil), paths...)
+	s.mu.Unlock()
+	if s.authDone != nil {
+		s.authDone <- struct{}{}
+	}
 	return nil
 }
 func (s *stubStore) AuthDir() string { return s.authDir }
+
+func (s *stubStore) authSnapshot() (string, []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastAuthMessage, append([]string(nil), s.lastAuthPaths...)
+}
 
 func TestNewWatcherDetectsPersisterAndAuthDir(t *testing.T) {
 	tmp := t.TempDir()
@@ -1554,26 +1571,40 @@ func TestNewWatcherDetectsPersisterAndAuthDir(t *testing.T) {
 }
 
 func TestPersistConfigAndAuthAsyncInvokePersister(t *testing.T) {
+	store := &stubStore{
+		cfgDone:  make(chan struct{}, 1),
+		authDone: make(chan struct{}, 1),
+	}
 	w := &Watcher{
-		storePersister: &stubStore{},
+		storePersister: store,
 	}
 
 	w.persistConfigAsync()
 	w.persistAuthAsync("msg", " a ", "", "b ")
 
-	time.Sleep(30 * time.Millisecond)
-	store := w.storePersister.(*stubStore)
-	if atomic.LoadInt32(&store.cfgPersisted) != 1 {
-		t.Fatalf("expected PersistConfig to be called once, got %d", store.cfgPersisted)
+	select {
+	case <-store.cfgDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for PersistConfig")
 	}
-	if atomic.LoadInt32(&store.authPersisted) != 1 {
-		t.Fatalf("expected PersistAuthFiles to be called once, got %d", store.authPersisted)
+	select {
+	case <-store.authDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for PersistAuthFiles")
 	}
-	if store.lastAuthMessage != "msg" {
-		t.Fatalf("unexpected auth message: %s", store.lastAuthMessage)
+
+	if got := atomic.LoadInt32(&store.cfgPersisted); got != 1 {
+		t.Fatalf("expected PersistConfig to be called once, got %d", got)
 	}
-	if len(store.lastAuthPaths) != 2 || store.lastAuthPaths[0] != "a" || store.lastAuthPaths[1] != "b" {
-		t.Fatalf("unexpected filtered paths: %#v", store.lastAuthPaths)
+	if got := atomic.LoadInt32(&store.authPersisted); got != 1 {
+		t.Fatalf("expected PersistAuthFiles to be called once, got %d", got)
+	}
+	message, paths := store.authSnapshot()
+	if message != "msg" {
+		t.Fatalf("unexpected auth message: %s", message)
+	}
+	if len(paths) != 2 || paths[0] != "a" || paths[1] != "b" {
+		t.Fatalf("unexpected filtered paths: %#v", paths)
 	}
 }
 
@@ -1586,22 +1617,31 @@ func TestScheduleConfigReloadDebounces(t *testing.T) {
 	}
 
 	var reloads int32
+	store := &stubStore{cfgDone: make(chan struct{}, 1)}
 	w := &Watcher{
 		configPath:     cfgPath,
 		authDir:        authDir,
 		reloadCallback: func(*config.Config) { atomic.AddInt32(&reloads, 1) },
+		storePersister: store,
 	}
 	w.SetConfig(&config.Config{AuthDir: authDir})
 
 	w.scheduleConfigReload()
 	w.scheduleConfigReload()
 
-	time.Sleep(400 * time.Millisecond)
+	select {
+	case <-store.cfgDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for debounced config reload")
+	}
 
 	if atomic.LoadInt32(&reloads) != 1 {
 		t.Fatalf("expected single debounced reload, got %d", reloads)
 	}
-	if w.lastConfigHash == "" {
+	w.clientsMutex.RLock()
+	lastConfigHash := w.lastConfigHash
+	w.clientsMutex.RUnlock()
+	if lastConfigHash == "" {
 		t.Fatal("expected lastConfigHash to be set after reload")
 	}
 }

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -1427,8 +1427,6 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 					}
 				}
 			}
-			applyStreamHeaderInit()
-			return
 		}
 	}()
 	return dataChan, upstreamHeaders, errChan

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -1040,6 +1040,7 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 		}, execOptions.SkipInterceptorPluginID)
 		applyStreamHeaders(intercepted.Headers)
 	}
+	returnedHeaders := cloneHeader(upstreamHeaders)
 
 	dataChan := make(chan []byte)
 	errChan := make(chan *interfaces.ErrorMessage, 1)
@@ -1122,7 +1123,7 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 			}
 		}
 	}()
-	return dataChan, upstreamHeaders, errChan
+	return dataChan, returnedHeaders, errChan
 }
 
 func (h *BaseAPIHandler) executeStreamWithAuthManager(ctx context.Context, handlerType, modelName string, rawJSON []byte, alt string, allowImageModel bool) (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
@@ -1250,6 +1251,22 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	pendingChunks := make([]coreexecutor.StreamChunk, 0, 1)
 	streamClosedBeforeRead := false
 	streamCanceledBeforeRead := false
+	maxBootstrapRetries := StreamingBootstrapRetries(h.Cfg)
+	bootstrapRetries := 0
+	chunkIndex := 0
+	bootstrapEligible := func(err error) bool {
+		status := statusFromError(err)
+		if status == 0 {
+			return true
+		}
+		switch status {
+		case http.StatusUnauthorized, http.StatusForbidden, http.StatusPaymentRequired,
+			http.StatusRequestTimeout, http.StatusTooManyRequests:
+			return true
+		default:
+			return status >= http.StatusInternalServerError
+		}
+	}
 	readInitialStreamChunks := func() {
 		for {
 			var chunk coreexecutor.StreamChunk
@@ -1280,6 +1297,78 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		}
 	}
 	readInitialStreamChunks()
+	for {
+		for len(pendingChunks) > 0 && pendingChunks[0].Err == nil && len(pendingChunks[0].Payload) == 0 {
+			pendingChunks = pendingChunks[1:]
+		}
+		if len(pendingChunks) == 0 || pendingChunks[0].Err == nil || bootstrapRetries >= maxBootstrapRetries || !bootstrapEligible(pendingChunks[0].Err) {
+			break
+		}
+
+		bootstrapRetries++
+		retryResult, retryErr := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
+		if retryErr != nil {
+			pendingChunks[0].Err = enrichAuthSelectionError(retryErr, providers, normalizedModel)
+			break
+		}
+		rawStreamHeaders = cloneHeader(retryResult.Headers)
+		baseStreamHeaders = cloneHeader(retryResult.Headers)
+		replaceHeader(upstreamHeaders, downstreamHeadersFromExecutor(rawStreamHeaders, passthroughHeadersEnabled))
+		streamHeaderInitialized = false
+		streamHeadersCommitted = false
+		pendingChunks = nil
+		streamClosedBeforeRead = false
+		chunks = retryResult.Chunks
+		readInitialStreamChunks()
+	}
+
+	var initialPayload []byte
+	initialPayloadReady := false
+	var initialErr *interfaces.ErrorMessage
+	for len(pendingChunks) > 0 && pendingChunks[0].Err == nil && len(pendingChunks[0].Payload) == 0 {
+		pendingChunks = pendingChunks[1:]
+	}
+	if len(pendingChunks) > 0 && pendingChunks[0].Err == nil && len(pendingChunks[0].Payload) > 0 {
+		chunk := pendingChunks[0]
+		pendingChunks = pendingChunks[1:]
+		applyStreamHeaderInit()
+		payload := cloneBytes(chunk.Payload)
+		dropChunk := false
+		if streamInterceptorsActive {
+			executedReq, executedOpts := executedRequest()
+			intercepted := interceptStreamChunk(ctx, interceptorHost, pluginapi.StreamChunkInterceptRequest{
+				SourceFormat:    responseProtocol,
+				Model:           normalizedModel,
+				RequestedModel:  originalRequestedModel,
+				RequestHeaders:  cloneHeader(executedOpts.Headers),
+				ResponseHeaders: cloneHeader(rawStreamHeaders),
+				OriginalRequest: cloneBytes(executedOpts.OriginalRequest),
+				RequestBody:     cloneBytes(executedReq.Payload),
+				Body:            payload,
+				ChunkIndex:      chunkIndex,
+				Metadata:        executedOpts.Metadata,
+			}, execOptions.SkipInterceptorPluginID)
+			applyStreamHeaders(intercepted.Headers)
+			if len(intercepted.Body) > 0 {
+				payload = cloneBytes(intercepted.Body)
+			}
+			dropChunk = intercepted.DropChunk
+		}
+		chunkIndex++
+		if !dropChunk {
+			if responseProtocol == "openai-response" {
+				if errValidate := validateSSEDataJSON(payload); errValidate != nil {
+					initialErr = &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errValidate}
+				}
+			}
+			if initialErr == nil {
+				initialPayload = payload
+				initialPayloadReady = true
+				streamHeadersCommitted = true
+			}
+		}
+	}
+	returnedHeaders := cloneHeader(upstreamHeaders)
 
 	go func() {
 		defer close(dataChan)
@@ -1288,10 +1377,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 			return
 		}
 		sentPayload := false
-		bootstrapRetries := 0
-		chunkIndex := 0
 		var historyChunks [][]byte
-		maxBootstrapRetries := StreamingBootstrapRetries(h.Cfg)
 
 		sendErr := func(msg *interfaces.ErrorMessage) bool {
 			if ctx == nil {
@@ -1319,17 +1405,17 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 			}
 		}
 
-		bootstrapEligible := func(err error) bool {
-			status := statusFromError(err)
-			if status == 0 {
-				return true
+		if initialErr != nil {
+			_ = sendErr(initialErr)
+			return
+		}
+		if initialPayloadReady {
+			sentPayload = true
+			if okSendData := sendData(initialPayload); !okSendData {
+				return
 			}
-			switch status {
-			case http.StatusUnauthorized, http.StatusForbidden, http.StatusPaymentRequired,
-				http.StatusRequestTimeout, http.StatusTooManyRequests:
-				return true
-			default:
-				return status >= http.StatusInternalServerError
+			if streamInterceptorsActive {
+				historyChunks = appendStreamInterceptorHistory(historyChunks, initialPayload)
 			}
 		}
 
@@ -1429,7 +1515,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 			}
 		}
 	}()
-	return dataChan, upstreamHeaders, errChan
+	return dataChan, returnedHeaders, errChan
 }
 
 func validateSSEDataJSON(chunk []byte) error {

--- a/sdk/cliproxy/auth/codex_adaptive_cooldown_test.go
+++ b/sdk/cliproxy/auth/codex_adaptive_cooldown_test.go
@@ -1,0 +1,243 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+const cooldownTestTolerance = 2 * time.Second
+
+func registerCooldownTestAuth(t *testing.T, manager *Manager, id string) {
+	t.Helper()
+	_, err := manager.Register(context.Background(), &Auth{
+		ID:       id,
+		Provider: "codex",
+		Status:   StatusActive,
+	})
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+}
+
+func enableAdaptiveCooldown(manager *Manager, unauthorizedSeconds int) {
+	manager.SetConfig(&internalconfig.Config{
+		Codex: internalconfig.CodexConfig{
+			QuotaCooldown: internalconfig.CodexQuotaCooldownConfig{
+				Enabled:                     true,
+				UnauthorizedCooldownSeconds: unauthorizedSeconds,
+			},
+		},
+	})
+}
+
+func assertCooldownNear(t *testing.T, next, before, after time.Time, want time.Duration) {
+	t.Helper()
+	minimum := before.Add(want)
+	maximum := after.Add(want).Add(cooldownTestTolerance)
+	if next.Before(minimum) || next.After(maximum) {
+		t.Fatalf("cooldown deadline %v outside [%v, %v]", next, minimum, maximum)
+	}
+}
+
+func TestManager_MarkResult_UnauthorizedDefaultsToLegacyCooldown(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	registerCooldownTestAuth(t, manager, "auth-401-default")
+
+	before := time.Now()
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   "auth-401-default",
+		Provider: "codex",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+	after := time.Now()
+
+	updated, _ := manager.GetByID("auth-401-default")
+	assertCooldownNear(t, updated.NextRetryAfter, before, after, legacyUnauthorizedCooldown)
+}
+
+func TestManager_MarkResult_UnauthorizedUsesConfiguredCooldown(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	enableAdaptiveCooldown(manager, int((3 * time.Hour).Seconds()))
+	registerCooldownTestAuth(t, manager, "model-401-configured")
+
+	before := time.Now()
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   "model-401-configured",
+		Provider: "codex",
+		Model:    "gpt-5.4-mini",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+	after := time.Now()
+
+	updated, _ := manager.GetByID("model-401-configured")
+	state := updated.ModelStates["gpt-5.4-mini"]
+	if state == nil {
+		t.Fatal("model state not found")
+	}
+	assertCooldownNear(t, state.NextRetryAfter, before, after, 3*time.Hour)
+}
+
+func TestQuotaCooldownAfterFailure_AdaptiveLadderAndCap(t *testing.T) {
+	policy := codexCooldownPolicy{
+		adaptive:         true,
+		transientBackoff: normalizeAdaptiveBackoff(nil),
+		jitterPercent:    20,
+	}
+	now := time.Unix(1_700_000_000, 0)
+	quota := QuotaState{}
+	want := []time.Duration{15 * time.Second, 30 * time.Second, time.Minute, 2 * time.Minute, 5 * time.Minute, 5 * time.Minute}
+	for i, expected := range want {
+		next, level := quotaCooldownAfterFailure(quota, now, policy, 0.5)
+		if got := next.Sub(now); got != expected {
+			t.Fatalf("step %d cooldown = %v, want %v", i, got, expected)
+		}
+		quota.BackoffLevel = level
+		quota.NextRecoverAt = time.Time{}
+	}
+}
+
+func TestQuotaCooldownAfterFailure_DuplicateWithinWindowDoesNotEscalate(t *testing.T) {
+	policy := codexCooldownPolicy{adaptive: true, transientBackoff: normalizeAdaptiveBackoff(nil), jitterPercent: 20}
+	now := time.Unix(1_700_000_000, 0)
+	first, level := quotaCooldownAfterFailure(QuotaState{}, now, policy, 0.5)
+	duplicate, duplicateLevel := quotaCooldownAfterFailure(QuotaState{
+		Exceeded:      true,
+		Reason:        "rate_limit",
+		NextRecoverAt: first,
+		BackoffLevel:  level,
+	}, now.Add(time.Second), policy, 1)
+	if !duplicate.Equal(first) || duplicateLevel != level {
+		t.Fatalf("duplicate failure changed window: next=%v level=%d, want next=%v level=%d", duplicate, duplicateLevel, first, level)
+	}
+}
+
+func TestManager_MarkResult_ConcurrentRateLimitsAdvanceOnce(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	enableAdaptiveCooldown(manager, 0)
+	registerCooldownTestAuth(t, manager, "concurrent-429")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			manager.MarkResult(context.Background(), Result{
+				AuthID:   "concurrent-429",
+				Provider: "codex",
+				Model:    "gpt-5.4-mini",
+				Error:    &Error{HTTPStatus: http.StatusTooManyRequests, Code: "rate_limit", Message: "rate limit"},
+			})
+		}()
+	}
+	wg.Wait()
+
+	updated, _ := manager.GetByID("concurrent-429")
+	state := updated.ModelStates["gpt-5.4-mini"]
+	if state == nil || state.Quota.BackoffLevel != 1 {
+		t.Fatalf("concurrent backoff level = %+v, want 1", state)
+	}
+	remaining := time.Until(state.Quota.NextRecoverAt)
+	if remaining < 10*time.Second || remaining > 20*time.Second {
+		t.Fatalf("concurrent cooldown remaining = %v, want first adaptive window", remaining)
+	}
+}
+
+func TestManager_MarkResult_UsageLimitPreservesProviderReset(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	enableAdaptiveCooldown(manager, 0)
+	registerCooldownTestAuth(t, manager, "auth-usage-limit")
+	retryAfter := 7*24*time.Hour + 17*time.Second
+
+	before := time.Now()
+	manager.MarkResult(context.Background(), Result{
+		AuthID:     "auth-usage-limit",
+		Provider:   "codex",
+		RetryAfter: &retryAfter,
+		Error: &Error{
+			HTTPStatus: http.StatusTooManyRequests,
+			Code:       "usage_limit_reached",
+			Message:    `{"error":{"type":"usage_limit_reached"}}`,
+		},
+	})
+	after := time.Now()
+
+	updated, _ := manager.GetByID("auth-usage-limit")
+	if updated.Quota.Reason != "usage_limit_reached" {
+		t.Fatalf("quota reason = %q, want usage_limit_reached", updated.Quota.Reason)
+	}
+	assertCooldownNear(t, updated.NextRetryAfter, before, after, retryAfter)
+}
+
+func TestManager_MarkResult_ModelUsageLimitPreservesProviderReset(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	enableAdaptiveCooldown(manager, 0)
+	registerCooldownTestAuth(t, manager, "model-usage-limit")
+	retryAfter := 6*time.Hour + 31*time.Second
+
+	before := time.Now()
+	manager.MarkResult(context.Background(), Result{
+		AuthID:     "model-usage-limit",
+		Provider:   "codex",
+		Model:      "gpt-5.4-mini",
+		RetryAfter: &retryAfter,
+		Error: &Error{
+			HTTPStatus: http.StatusTooManyRequests,
+			Code:       "usage_limit_reached",
+			Message:    `{"error":{"type":"usage_limit_reached"}}`,
+		},
+	})
+	after := time.Now()
+
+	updated, _ := manager.GetByID("model-usage-limit")
+	state := updated.ModelStates["gpt-5.4-mini"]
+	if state == nil || state.Quota.Reason != "usage_limit_reached" {
+		t.Fatalf("model usage state = %+v", state)
+	}
+	assertCooldownNear(t, state.NextRetryAfter, before, after, retryAfter)
+}
+
+func TestManager_MarkResult_SuccessClearsAdaptiveBackoff(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	enableAdaptiveCooldown(manager, 0)
+	registerCooldownTestAuth(t, manager, "model-success-reset")
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   "model-success-reset",
+		Provider: "codex",
+		Model:    "gpt-5.4-mini",
+		Error:    &Error{HTTPStatus: http.StatusTooManyRequests, Code: "rate_limit", Message: "rate limit"},
+	})
+	failed, _ := manager.GetByID("model-success-reset")
+	if failed.ModelStates["gpt-5.4-mini"].Quota.BackoffLevel != 1 {
+		t.Fatalf("backoff level after failure = %d, want 1", failed.ModelStates["gpt-5.4-mini"].Quota.BackoffLevel)
+	}
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   "model-success-reset",
+		Provider: "codex",
+		Model:    "gpt-5.4-mini",
+		Success:  true,
+	})
+	updated, _ := manager.GetByID("model-success-reset")
+	state := updated.ModelStates["gpt-5.4-mini"]
+	if state.Quota.BackoffLevel != 0 || state.Quota.Exceeded || !state.NextRetryAfter.IsZero() {
+		t.Fatalf("success did not clear adaptive cooldown: %+v", state.Quota)
+	}
+}
+
+func TestJitterAdaptiveCooldownBoundsAndCap(t *testing.T) {
+	if got := jitterAdaptiveCooldown(time.Minute, 20, 0); got != 48*time.Second {
+		t.Fatalf("minimum jitter = %v, want 48s", got)
+	}
+	if got := jitterAdaptiveCooldown(time.Minute, 20, 1); got != 72*time.Second {
+		t.Fatalf("maximum jitter = %v, want 72s", got)
+	}
+	if got := jitterAdaptiveCooldown(5*time.Minute, 20, 1); got != 5*time.Minute {
+		t.Fatalf("capped jitter = %v, want 5m", got)
+	}
+}

--- a/sdk/cliproxy/auth/codex_cooldown_policy.go
+++ b/sdk/cliproxy/auth/codex_cooldown_policy.go
@@ -1,0 +1,249 @@
+package auth
+
+import (
+	"strings"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+const (
+	legacyUnauthorizedCooldown = 30 * time.Minute
+	adaptiveCooldownMax        = 5 * time.Minute
+	defaultCooldownJitter      = 20
+	quotaProbeNearThreshold    = 2 * time.Hour
+	quotaProbeFarInterval      = 30 * time.Minute
+	quotaProbeNearInterval     = 5 * time.Minute
+)
+
+var defaultAdaptiveBackoff = [...]time.Duration{
+	15 * time.Second,
+	30 * time.Second,
+	time.Minute,
+	2 * time.Minute,
+	5 * time.Minute,
+}
+
+type codexCooldownPolicy struct {
+	adaptive          bool
+	unauthorized      time.Duration
+	transientBackoff  []time.Duration
+	jitterPercent     int
+	quotaProbeEnabled bool
+}
+
+func (m *Manager) codexCooldownPolicyForAuth(auth *Auth) codexCooldownPolicy {
+	policy := codexCooldownPolicy{unauthorized: legacyUnauthorizedCooldown}
+	if m == nil || auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return policy
+	}
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	if cfg == nil || !cfg.Codex.QuotaCooldown.Enabled {
+		return policy
+	}
+	configured := cfg.Codex.QuotaCooldown
+	policy.adaptive = true
+	policy.quotaProbeEnabled = true
+	if configured.UnauthorizedCooldownSeconds > 0 {
+		policy.unauthorized = time.Duration(configured.UnauthorizedCooldownSeconds) * time.Second
+	}
+	policy.transientBackoff = normalizeAdaptiveBackoff(configured.TransientBackoffSeconds)
+	policy.jitterPercent = configured.JitterPercent
+	if policy.jitterPercent <= 0 {
+		policy.jitterPercent = defaultCooldownJitter
+	}
+	if policy.jitterPercent > 100 {
+		policy.jitterPercent = 100
+	}
+	return policy
+}
+
+func normalizeAdaptiveBackoff(configured []int) []time.Duration {
+	if len(configured) == 0 {
+		out := make([]time.Duration, len(defaultAdaptiveBackoff))
+		copy(out, defaultAdaptiveBackoff[:])
+		return out
+	}
+	out := make([]time.Duration, 0, len(configured))
+	for _, seconds := range configured {
+		if seconds <= 0 {
+			continue
+		}
+		cooldown := adaptiveCooldownMax
+		if seconds < int(adaptiveCooldownMax/time.Second) {
+			cooldown = time.Duration(seconds) * time.Second
+		}
+		out = append(out, cooldown)
+	}
+	if len(out) == 0 {
+		return normalizeAdaptiveBackoff(nil)
+	}
+	return out
+}
+
+func isCodexUsageLimitResult(auth *Auth, resultErr *Error) bool {
+	if auth == nil || resultErr == nil || resultErr.StatusCode() != 429 {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return false
+	}
+	return strings.Contains(strings.ToLower(resultErr.Code+" "+resultErr.Message), "usage_limit_reached")
+}
+
+func jitterAdaptiveCooldown(base time.Duration, jitterPercent int, randomUnit float64) time.Duration {
+	if base <= 0 {
+		return 0
+	}
+	if base > adaptiveCooldownMax {
+		base = adaptiveCooldownMax
+	}
+	if jitterPercent <= 0 {
+		return base
+	}
+	if randomUnit < 0 {
+		randomUnit = 0
+	} else if randomUnit > 1 {
+		randomUnit = 1
+	}
+	spread := float64(jitterPercent) / 100
+	factor := 1 - spread + 2*spread*randomUnit
+	cooldown := time.Duration(float64(base) * factor)
+	if cooldown > adaptiveCooldownMax {
+		return adaptiveCooldownMax
+	}
+	if cooldown < time.Second {
+		return time.Second
+	}
+	return cooldown
+}
+
+func nextCodexQuotaProbeAt(now, resetAt time.Time) time.Time {
+	if resetAt.IsZero() {
+		return now
+	}
+	remaining := resetAt.Sub(now)
+	if remaining <= 0 {
+		return now
+	}
+	interval := quotaProbeFarInterval
+	if remaining <= quotaProbeNearThreshold {
+		interval = quotaProbeNearInterval
+	}
+	next := now.Add(interval)
+	if next.After(resetAt) {
+		return resetAt
+	}
+	return next
+}
+
+func (m *Manager) normalizeRestoredCodexCooldownRecord(auth *Auth, record CooldownStateRecord, now time.Time) CooldownStateRecord {
+	policy := m.codexCooldownPolicyForAuth(auth)
+	if !policy.adaptive || record.LastError == nil || record.LastError.StatusCode() != 429 || record.Quota.Reason != "quota" {
+		return record
+	}
+	if isCodexUsageLimitResult(auth, record.LastError) {
+		record.Quota.Reason = "usage_limit_reached"
+		record.Reason = "usage_limit_reached"
+		if record.Quota.NextRecoverAt.IsZero() {
+			record.Quota.NextRecoverAt = record.NextRetryAfter
+		}
+		record.Quota.NextProbeAt = nextCodexQuotaProbeAt(now, record.Quota.NextRecoverAt)
+		return record
+	}
+	next, level := quotaCooldownAfterFailure(QuotaState{}, now, policy, 0.5)
+	record.NextRetryAfter = next
+	record.Quota = QuotaState{
+		Exceeded:      true,
+		Reason:        "rate_limit",
+		NextRecoverAt: next,
+		BackoffLevel:  level,
+	}
+	record.Reason = "rate_limit"
+	return record
+}
+
+func (m *Manager) reconcileCodexQuotaCooldownConfig() bool {
+	if m == nil {
+		return false
+	}
+	now := time.Now()
+	changed := false
+	snapshots := make([]*Auth, 0)
+	m.mu.Lock()
+	for _, auth := range m.auths {
+		if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") || m.cooldownDisabledForAuth(auth) {
+			continue
+		}
+		policy := m.codexCooldownPolicyForAuth(auth)
+		authChanged := reconcileCodexQuotaState(auth, &auth.Quota, &auth.NextRetryAfter, &auth.Unavailable, &auth.Status, &auth.StatusMessage, &auth.LastError, policy, now)
+		modelChanged := false
+		for _, state := range auth.ModelStates {
+			if state == nil {
+				continue
+			}
+			if reconcileCodexQuotaState(auth, &state.Quota, &state.NextRetryAfter, &state.Unavailable, &state.Status, &state.StatusMessage, &state.LastError, policy, now) {
+				state.UpdatedAt = now
+				modelChanged = true
+			}
+		}
+		if modelChanged && !auth.Quota.Exceeded {
+			updateAggregatedAvailability(auth, now)
+		}
+		if authChanged || modelChanged {
+			auth.UpdatedAt = now
+			snapshots = append(snapshots, auth.Clone())
+			changed = true
+		}
+	}
+	m.mu.Unlock()
+	if m.scheduler != nil {
+		for _, snapshot := range snapshots {
+			m.scheduler.upsertAuth(snapshot)
+		}
+	}
+	if changed {
+		m.signalCodexQuotaProbe()
+	}
+	return changed
+}
+
+func reconcileCodexQuotaState(auth *Auth, quota *QuotaState, nextRetry *time.Time, unavailable *bool, status *Status, statusMessage *string, lastError **Error, policy codexCooldownPolicy, now time.Time) bool {
+	if quota == nil || nextRetry == nil || unavailable == nil || status == nil || statusMessage == nil || lastError == nil || *lastError == nil || (*lastError).StatusCode() != 429 || !quota.Exceeded {
+		return false
+	}
+	if policy.adaptive {
+		if quota.Reason != "quota" {
+			return false
+		}
+		if isCodexUsageLimitResult(auth, *lastError) {
+			quota.Reason = "usage_limit_reached"
+			if quota.NextRecoverAt.IsZero() {
+				quota.NextRecoverAt = *nextRetry
+			}
+			quota.NextProbeAt = nextCodexQuotaProbeAt(now, quota.NextRecoverAt)
+			return true
+		}
+		next, level := quotaCooldownAfterFailure(QuotaState{}, now, policy, 0.5)
+		*quota = QuotaState{Exceeded: true, Reason: "rate_limit", NextRecoverAt: next, BackoffLevel: level}
+		*nextRetry = next
+		return true
+	}
+	if quota.Reason != "usage_limit_reached" {
+		return false
+	}
+	quota.NextProbeAt = time.Time{}
+	quota.Reason = "quota"
+	if quota.NextRecoverAt.After(now) {
+		*nextRetry = quota.NextRecoverAt
+		*unavailable = true
+		return true
+	}
+	*quota = QuotaState{}
+	*nextRetry = time.Time{}
+	*unavailable = false
+	*status = StatusActive
+	*statusMessage = ""
+	*lastError = nil
+	return true
+}

--- a/sdk/cliproxy/auth/codex_quota_probe.go
+++ b/sdk/cliproxy/auth/codex_quota_probe.go
@@ -1,0 +1,486 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	codexQuotaUsageURL       = "https://chatgpt.com/backend-api/wham/usage"
+	codexQuotaProbeWorkers   = 4
+	codexQuotaProbeBodyLimit = 1 << 20
+)
+
+type codexQuotaProbeBucket struct {
+	key     string
+	auth    *Auth
+	authIDs []string
+}
+
+type codexQuotaProbeOutcome struct {
+	recovered bool
+	resetAt   time.Time
+	err       error
+}
+
+type codexWhamUsageResponse struct {
+	PlanType  string `json:"plan_type"`
+	RateLimit struct {
+		LimitReached  *bool `json:"limit_reached"`
+		PrimaryWindow struct {
+			UsedPercent       *float64        `json:"used_percent"`
+			ResetAt           json.RawMessage `json:"reset_at"`
+			ResetAfterSeconds *float64        `json:"reset_after_seconds"`
+		} `json:"primary_window"`
+	} `json:"rate_limit"`
+}
+
+// StartCodexQuotaProbe starts the non-consuming Codex quota-status loop.
+// Starting it again replaces the previous loop.
+func (m *Manager) StartCodexQuotaProbe(parent context.Context) {
+	if m == nil {
+		return
+	}
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parent)
+	wake := make(chan struct{}, 1)
+
+	m.mu.Lock()
+	previous := m.quotaProbeCancel
+	m.quotaProbeCancel = cancel
+	m.quotaProbeWake = wake
+	m.mu.Unlock()
+	if previous != nil {
+		previous()
+	}
+	go m.runCodexQuotaProbeLoop(ctx, wake)
+	m.signalCodexQuotaProbe()
+}
+
+// StopCodexQuotaProbe stops the Codex quota-status loop.
+func (m *Manager) StopCodexQuotaProbe() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	cancel := m.quotaProbeCancel
+	m.quotaProbeCancel = nil
+	m.quotaProbeWake = nil
+	m.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (m *Manager) signalCodexQuotaProbe() {
+	if m == nil {
+		return
+	}
+	m.mu.RLock()
+	wake := m.quotaProbeWake
+	m.mu.RUnlock()
+	if wake == nil {
+		return
+	}
+	select {
+	case wake <- struct{}{}:
+	default:
+	}
+}
+
+func (m *Manager) runCodexQuotaProbeLoop(ctx context.Context, wake <-chan struct{}) {
+	for {
+		now := time.Now()
+		due, next := m.collectCodexQuotaProbeBuckets(now)
+		if len(due) > 0 {
+			m.probeDueCodexQuotaBuckets(ctx, due)
+			continue
+		}
+
+		if next.IsZero() {
+			select {
+			case <-ctx.Done():
+				return
+			case <-wake:
+				continue
+			}
+		}
+
+		wait := time.Until(next)
+		if wait < 0 {
+			wait = 0
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			stopAndDrainQuotaProbeTimer(timer)
+			return
+		case <-wake:
+			stopAndDrainQuotaProbeTimer(timer)
+		case <-timer.C:
+		}
+	}
+}
+
+func stopAndDrainQuotaProbeTimer(timer *time.Timer) {
+	if timer == nil || timer.Stop() {
+		return
+	}
+	select {
+	case <-timer.C:
+	default:
+	}
+}
+
+func (m *Manager) collectCodexQuotaProbeBuckets(now time.Time) ([]codexQuotaProbeBucket, time.Time) {
+	if m == nil {
+		return nil, time.Time{}
+	}
+	type bucketState struct {
+		bucket codexQuotaProbeBucket
+		dueAt  time.Time
+	}
+	buckets := make(map[string]*bucketState)
+
+	m.mu.RLock()
+	for _, auth := range m.auths {
+		if auth == nil || !m.codexCooldownPolicyForAuth(auth).quotaProbeEnabled {
+			continue
+		}
+		dueAt, ok := codexUsageQuotaProbeAt(auth, now)
+		if !ok {
+			continue
+		}
+		key := codexQuotaBucketKey(auth)
+		state := buckets[key]
+		if state == nil {
+			state = &bucketState{bucket: codexQuotaProbeBucket{key: key, auth: auth.Clone()}, dueAt: dueAt}
+			buckets[key] = state
+		}
+		state.bucket.authIDs = append(state.bucket.authIDs, auth.ID)
+		if state.dueAt.IsZero() || (!dueAt.IsZero() && dueAt.Before(state.dueAt)) {
+			state.dueAt = dueAt
+			state.bucket.auth = auth.Clone()
+		} else if dueAt.Equal(state.dueAt) && state.bucket.auth != nil && auth.ID < state.bucket.auth.ID {
+			state.bucket.auth = auth.Clone()
+		}
+	}
+	m.mu.RUnlock()
+
+	due := make([]codexQuotaProbeBucket, 0)
+	var next time.Time
+	for _, state := range buckets {
+		sort.Strings(state.bucket.authIDs)
+		if state.dueAt.IsZero() || !state.dueAt.After(now) {
+			due = append(due, state.bucket)
+			continue
+		}
+		if next.IsZero() || state.dueAt.Before(next) {
+			next = state.dueAt
+		}
+	}
+	sort.Slice(due, func(i, j int) bool { return due[i].key < due[j].key })
+	return due, next
+}
+
+func codexUsageQuotaProbeAt(auth *Auth, now time.Time) (time.Time, bool) {
+	if auth == nil {
+		return time.Time{}, false
+	}
+	var next time.Time
+	found := false
+	consider := func(quota QuotaState) {
+		if !quota.Exceeded || quota.Reason != "usage_limit_reached" {
+			return
+		}
+		found = true
+		candidate := quota.NextProbeAt
+		if candidate.IsZero() {
+			candidate = nextCodexQuotaProbeAt(now, quota.NextRecoverAt)
+		}
+		if next.IsZero() || candidate.Before(next) {
+			next = candidate
+		}
+	}
+	consider(auth.Quota)
+	for _, state := range auth.ModelStates {
+		if state != nil {
+			consider(state.Quota)
+		}
+	}
+	return next, found
+}
+
+func codexQuotaBucketKey(auth *Auth) string {
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	accountID := authMetadataString(auth, "account_id")
+	if accountID == "" {
+		accountID = authMetadataString(auth, "chatgpt_account_id")
+	}
+	if accountID == "" {
+		accountID = authAttribute(auth, "account_id")
+	}
+	planType := authMetadataString(auth, "plan_type")
+	if planType == "" {
+		planType = authAttribute(auth, "plan_type")
+	}
+	if accountID == "" || planType == "" {
+		return strings.Join([]string{provider, "auth", strings.TrimSpace(auth.ID)}, "|")
+	}
+	return strings.Join([]string{provider, strings.ToLower(accountID), strings.ToLower(planType)}, "|")
+}
+
+func (m *Manager) probeDueCodexQuotaBuckets(ctx context.Context, buckets []codexQuotaProbeBucket) {
+	if len(buckets) == 0 {
+		return
+	}
+	workers := codexQuotaProbeWorkers
+	if workers > len(buckets) {
+		workers = len(buckets)
+	}
+	jobs := make(chan codexQuotaProbeBucket)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for bucket := range jobs {
+				if ctx.Err() != nil {
+					return
+				}
+				outcome := m.probeCodexQuotaBucket(ctx, bucket)
+				if ctx.Err() != nil {
+					return
+				}
+				m.applyCodexQuotaProbeOutcome(context.Background(), bucket.key, outcome, time.Now())
+			}
+		}()
+	}
+	for _, bucket := range buckets {
+		select {
+		case <-ctx.Done():
+			close(jobs)
+			wg.Wait()
+			return
+		case jobs <- bucket:
+		}
+	}
+	close(jobs)
+	wg.Wait()
+}
+
+func (m *Manager) probeCodexQuotaBucket(ctx context.Context, bucket codexQuotaProbeBucket) codexQuotaProbeOutcome {
+	if bucket.auth == nil {
+		return codexQuotaProbeOutcome{err: fmt.Errorf("quota probe auth is nil")}
+	}
+	req, errRequest := http.NewRequestWithContext(ctx, http.MethodGet, codexQuotaUsageURL, nil)
+	if errRequest != nil {
+		return codexQuotaProbeOutcome{err: errRequest}
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, errDo := m.HttpRequest(ctx, bucket.auth, req)
+	if errDo != nil {
+		return codexQuotaProbeOutcome{err: errDo}
+	}
+	if resp == nil {
+		return codexQuotaProbeOutcome{err: fmt.Errorf("quota probe returned nil response")}
+	}
+	if resp.Body == nil {
+		return codexQuotaProbeOutcome{err: fmt.Errorf("quota probe returned nil response body")}
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Debugf("close Codex quota probe response: %v", errClose)
+		}
+	}()
+	body, errRead := io.ReadAll(io.LimitReader(resp.Body, codexQuotaProbeBodyLimit))
+	if errRead != nil {
+		return codexQuotaProbeOutcome{err: fmt.Errorf("read quota probe response: %w", errRead)}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return codexQuotaProbeOutcome{err: fmt.Errorf("quota probe returned HTTP %d", resp.StatusCode)}
+	}
+	var payload codexWhamUsageResponse
+	if errUnmarshal := json.Unmarshal(body, &payload); errUnmarshal != nil {
+		return codexQuotaProbeOutcome{err: fmt.Errorf("parse quota probe response: %w", errUnmarshal)}
+	}
+	if payload.RateLimit.LimitReached == nil || payload.RateLimit.PrimaryWindow.UsedPercent == nil {
+		return codexQuotaProbeOutcome{err: fmt.Errorf("quota probe response is missing limiter fields")}
+	}
+	resetAt := parseCodexQuotaResetAt(payload.RateLimit.PrimaryWindow.ResetAt, payload.RateLimit.PrimaryWindow.ResetAfterSeconds, time.Now())
+	recovered := !*payload.RateLimit.LimitReached && *payload.RateLimit.PrimaryWindow.UsedPercent < 100
+	return codexQuotaProbeOutcome{recovered: recovered, resetAt: resetAt}
+}
+
+func parseCodexQuotaResetAt(raw json.RawMessage, resetAfterSeconds *float64, now time.Time) time.Time {
+	text := strings.Trim(strings.TrimSpace(string(raw)), `"`)
+	if text != "" && text != "null" {
+		if unixSeconds, errParse := strconv.ParseInt(text, 10, 64); errParse == nil && unixSeconds > 0 {
+			return time.Unix(unixSeconds, 0)
+		}
+		if unixSeconds, errParse := strconv.ParseFloat(text, 64); errParse == nil && unixSeconds > 0 {
+			return time.Unix(int64(unixSeconds), 0)
+		}
+		if parsed, errParse := time.Parse(time.RFC3339, text); errParse == nil {
+			return parsed
+		}
+	}
+	if resetAfterSeconds != nil && *resetAfterSeconds > 0 {
+		return now.Add(time.Duration(*resetAfterSeconds * float64(time.Second)))
+	}
+	return time.Time{}
+}
+
+func nextCodexQuotaProbeAfterAttempt(now, resetAt time.Time) time.Time {
+	if resetAt.IsZero() || !resetAt.After(now) {
+		return now.Add(quotaProbeNearInterval)
+	}
+	return nextCodexQuotaProbeAt(now, resetAt)
+}
+
+func (m *Manager) applyCodexQuotaProbeOutcome(ctx context.Context, bucketKey string, outcome codexQuotaProbeOutcome, now time.Time) {
+	if m == nil || bucketKey == "" {
+		return
+	}
+	if outcome.recovered && outcome.err == nil {
+		ids := m.codexQuotaAuthIDsForBucket(bucketKey)
+		for _, authID := range ids {
+			if _, _, errReset := m.ResetQuota(ctx, authID); errReset != nil {
+				log.Warnf("failed to reset recovered Codex quota state for %s: %v", authID, errReset)
+			}
+		}
+		return
+	}
+
+	snapshots := make([]*Auth, 0)
+	m.mu.Lock()
+	for _, auth := range m.auths {
+		if auth == nil || codexQuotaBucketKey(auth) != bucketKey {
+			continue
+		}
+		changed := updateUsageQuotaProbeState(auth, outcome, now)
+		if changed {
+			snapshots = append(snapshots, auth.Clone())
+		}
+	}
+	m.mu.Unlock()
+	if m.scheduler != nil {
+		for _, snapshot := range snapshots {
+			m.scheduler.upsertAuth(snapshot)
+		}
+	}
+	if len(snapshots) > 0 {
+		m.persistCooldownStates(ctx)
+	}
+}
+
+func (m *Manager) codexQuotaAuthIDsForBucket(bucketKey string) []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	ids := make([]string, 0)
+	for _, auth := range m.auths {
+		if auth != nil && codexQuotaBucketKey(auth) == bucketKey {
+			if _, ok := codexUsageQuotaProbeAt(auth, time.Now()); ok {
+				ids = append(ids, auth.ID)
+			}
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func updateUsageQuotaProbeState(auth *Auth, outcome codexQuotaProbeOutcome, now time.Time) bool {
+	if auth == nil {
+		return false
+	}
+	changed := false
+	authLevelUsage := auth.Quota.Exceeded && auth.Quota.Reason == "usage_limit_reached"
+	modelChanged := false
+	update := func(quota *QuotaState, nextRetry *time.Time, unavailable *bool, status *Status, updatedAt *time.Time) {
+		if quota == nil || !quota.Exceeded || quota.Reason != "usage_limit_reached" {
+			return
+		}
+		resetAt := quota.NextRecoverAt
+		if !outcome.resetAt.IsZero() {
+			resetAt = outcome.resetAt
+			quota.NextRecoverAt = resetAt
+			*nextRetry = resetAt
+		}
+		quota.NextProbeAt = nextCodexQuotaProbeAfterAttempt(now, resetAt)
+		*unavailable = true
+		*status = StatusError
+		*updatedAt = now
+		changed = true
+	}
+	update(&auth.Quota, &auth.NextRetryAfter, &auth.Unavailable, &auth.Status, &auth.UpdatedAt)
+	for _, state := range auth.ModelStates {
+		if state == nil {
+			continue
+		}
+		before := changed
+		update(&state.Quota, &state.NextRetryAfter, &state.Unavailable, &state.Status, &state.UpdatedAt)
+		if changed != before {
+			modelChanged = true
+		}
+	}
+	if modelChanged && !authLevelUsage {
+		updateAggregatedAvailability(auth, now)
+	}
+	return changed
+}
+
+func (m *Manager) scheduleCodexQuotaProbeNow(authID string) {
+	if m == nil || strings.TrimSpace(authID) == "" {
+		return
+	}
+	now := time.Now()
+	changed := false
+	var snapshot *Auth
+	m.mu.Lock()
+	if auth := m.auths[authID]; auth != nil && m.codexCooldownPolicyForAuth(auth).quotaProbeEnabled {
+		if auth.Quota.Exceeded && auth.Quota.Reason == "usage_limit_reached" {
+			auth.Quota.NextProbeAt = now
+			auth.Unavailable = true
+			auth.Status = StatusError
+			auth.UpdatedAt = now
+			changed = true
+		}
+		modelChanged := false
+		for _, state := range auth.ModelStates {
+			if state != nil && state.Quota.Exceeded && state.Quota.Reason == "usage_limit_reached" {
+				state.Quota.NextProbeAt = now
+				state.Unavailable = true
+				state.Status = StatusError
+				state.UpdatedAt = now
+				changed = true
+				modelChanged = true
+			}
+		}
+		if modelChanged && !(auth.Quota.Exceeded && auth.Quota.Reason == "usage_limit_reached") {
+			updateAggregatedAvailability(auth, now)
+		}
+		if changed {
+			snapshot = auth.Clone()
+		}
+	}
+	m.mu.Unlock()
+	if changed {
+		if m.scheduler != nil && snapshot != nil {
+			m.scheduler.upsertAuth(snapshot)
+		}
+		m.persistCooldownStates(context.Background())
+		m.signalCodexQuotaProbe()
+	}
+}

--- a/sdk/cliproxy/auth/codex_quota_probe_test.go
+++ b/sdk/cliproxy/auth/codex_quota_probe_test.go
@@ -1,0 +1,299 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type quotaProbeTestExecutor struct {
+	status int
+	body   string
+	err    error
+	calls  atomic.Int32
+}
+
+func (e *quotaProbeTestExecutor) Identifier() string { return "codex" }
+
+func (e *quotaProbeTestExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *quotaProbeTestExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+
+func (e *quotaProbeTestExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *quotaProbeTestExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *quotaProbeTestExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	e.calls.Add(1)
+	if e.err != nil {
+		return nil, e.err
+	}
+	return &http.Response{
+		StatusCode: e.status,
+		Body:       io.NopCloser(strings.NewReader(e.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func registerUsageLimitAuth(t *testing.T, manager *Manager, id, accountID, planType string, retryAfter time.Duration) {
+	t.Helper()
+	_, errRegister := manager.Register(context.Background(), &Auth{
+		ID:       id,
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"account_id": accountID,
+			"plan_type":  planType,
+		},
+	})
+	if errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	manager.MarkResult(context.Background(), Result{
+		AuthID:     id,
+		Provider:   "codex",
+		RetryAfter: &retryAfter,
+		Error: &Error{
+			HTTPStatus: http.StatusTooManyRequests,
+			Code:       "usage_limit_reached",
+			Message:    `{"error":{"type":"usage_limit_reached"}}`,
+		},
+	})
+	manager.scheduleCodexQuotaProbeNow(id)
+}
+
+func TestNextCodexQuotaProbeAt_FarNearAndResetBoundary(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	if got := nextCodexQuotaProbeAt(now, now.Add(7*24*time.Hour)); !got.Equal(now.Add(30 * time.Minute)) {
+		t.Fatalf("far probe = %v, want %v", got, now.Add(30*time.Minute))
+	}
+	if got := nextCodexQuotaProbeAt(now, now.Add(90*time.Minute)); !got.Equal(now.Add(5 * time.Minute)) {
+		t.Fatalf("near probe = %v, want %v", got, now.Add(5*time.Minute))
+	}
+	if got := nextCodexQuotaProbeAt(now, now.Add(2*time.Minute)); !got.Equal(now.Add(2 * time.Minute)) {
+		t.Fatalf("boundary probe = %v, want provider reset", got)
+	}
+}
+
+func TestManager_CollectCodexQuotaProbeBuckets_DeduplicatesSharedQuota(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	enableAdaptiveCooldown(manager, 0)
+	retryAfter := 7 * 24 * time.Hour
+	registerUsageLimitAuth(t, manager, "auth-a", "acct-shared", "plus", retryAfter)
+	registerUsageLimitAuth(t, manager, "auth-b", "acct-shared", "plus", retryAfter)
+
+	buckets, _ := manager.collectCodexQuotaProbeBuckets(time.Now())
+	if len(buckets) != 1 {
+		t.Fatalf("probe buckets = %d, want 1", len(buckets))
+	}
+	if len(buckets[0].authIDs) != 2 {
+		t.Fatalf("bucket auth ids = %v, want two auths", buckets[0].authIDs)
+	}
+}
+
+func TestManager_CodexQuotaProbe_RecoveryResetsWholeSharedBucket(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	enableAdaptiveCooldown(manager, 0)
+	executor := &quotaProbeTestExecutor{
+		status: http.StatusOK,
+		body:   `{"plan_type":"plus","rate_limit":{"limit_reached":false,"primary_window":{"used_percent":42,"reset_at":1700003600}}}`,
+	}
+	manager.RegisterExecutor(executor)
+	retryAfter := 7 * 24 * time.Hour
+	registerUsageLimitAuth(t, manager, "auth-a", "acct-shared", "plus", retryAfter)
+	registerUsageLimitAuth(t, manager, "auth-b", "acct-shared", "plus", retryAfter)
+
+	buckets, _ := manager.collectCodexQuotaProbeBuckets(time.Now())
+	outcome := manager.probeCodexQuotaBucket(context.Background(), buckets[0])
+	if outcome.err != nil || !outcome.recovered {
+		t.Fatalf("probe outcome = %+v, want recovered", outcome)
+	}
+	manager.applyCodexQuotaProbeOutcome(context.Background(), buckets[0].key, outcome, time.Now())
+
+	if got := executor.calls.Load(); got != 1 {
+		t.Fatalf("WHAM calls = %d, want 1", got)
+	}
+	for _, id := range []string{"auth-a", "auth-b"} {
+		auth, _ := manager.GetByID(id)
+		if auth.Unavailable || auth.Quota.Exceeded || !auth.NextRetryAfter.IsZero() {
+			t.Fatalf("%s remained quota blocked: %+v", id, auth.Quota)
+		}
+	}
+}
+
+func TestManager_StartCodexQuotaProbe_ProcessesImmediateRecovery(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	enableAdaptiveCooldown(manager, 0)
+	executor := &quotaProbeTestExecutor{
+		status: http.StatusOK,
+		body:   `{"plan_type":"plus","rate_limit":{"limit_reached":false,"primary_window":{"used_percent":1}}}`,
+	}
+	manager.RegisterExecutor(executor)
+	registerUsageLimitAuth(t, manager, "auth-loop", "acct-loop", "plus", 7*24*time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	manager.StartCodexQuotaProbe(ctx)
+	defer manager.StopCodexQuotaProbe()
+
+	deadline := time.After(2 * time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("quota probe loop did not recover auth; calls=%d", executor.calls.Load())
+		case <-ticker.C:
+			auth, _ := manager.GetByID("auth-loop")
+			if executor.calls.Load() > 0 && auth != nil && !auth.Unavailable && !auth.Quota.Exceeded {
+				return
+			}
+		}
+	}
+}
+
+func TestManager_CodexQuotaProbe_FailureNeverUnlocks(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	enableAdaptiveCooldown(manager, 0)
+	executor := &quotaProbeTestExecutor{status: http.StatusBadGateway, body: `{"error":"temporary"}`}
+	manager.RegisterExecutor(executor)
+	retryAfter := 90 * time.Minute
+	registerUsageLimitAuth(t, manager, "auth-failure", "acct-failure", "plus", retryAfter)
+
+	buckets, _ := manager.collectCodexQuotaProbeBuckets(time.Now())
+	outcome := manager.probeCodexQuotaBucket(context.Background(), buckets[0])
+	if outcome.err == nil || outcome.recovered {
+		t.Fatalf("probe outcome = %+v, want failed and blocked", outcome)
+	}
+	now := time.Now()
+	manager.applyCodexQuotaProbeOutcome(context.Background(), buckets[0].key, outcome, now)
+	auth, _ := manager.GetByID("auth-failure")
+	if !auth.Unavailable || !auth.Quota.Exceeded {
+		t.Fatalf("failed probe unlocked auth: %+v", auth.Quota)
+	}
+	if !auth.Quota.NextProbeAt.After(now) {
+		t.Fatalf("next probe = %v, want after %v", auth.Quota.NextProbeAt, now)
+	}
+}
+
+func TestManager_CodexQuotaProbe_LimitReachedUpdatesProviderReset(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	enableAdaptiveCooldown(manager, 0)
+	resetAt := time.Now().Add(90 * time.Minute).Truncate(time.Second)
+	executor := &quotaProbeTestExecutor{
+		status: http.StatusOK,
+		body:   fmt.Sprintf(`{"plan_type":"plus","rate_limit":{"limit_reached":true,"primary_window":{"used_percent":100,"reset_at":%d}}}`, resetAt.Unix()),
+	}
+	manager.RegisterExecutor(executor)
+	registerUsageLimitAuth(t, manager, "auth-limited", "acct-limited", "plus", 7*24*time.Hour)
+
+	buckets, _ := manager.collectCodexQuotaProbeBuckets(time.Now())
+	outcome := manager.probeCodexQuotaBucket(context.Background(), buckets[0])
+	if outcome.err != nil || outcome.recovered {
+		t.Fatalf("probe outcome = %+v, want still limited", outcome)
+	}
+	manager.applyCodexQuotaProbeOutcome(context.Background(), buckets[0].key, outcome, time.Now())
+	auth, _ := manager.GetByID("auth-limited")
+	if !auth.Quota.NextRecoverAt.Equal(resetAt) {
+		t.Fatalf("provider reset = %v, want %v", auth.Quota.NextRecoverAt, resetAt)
+	}
+}
+
+func TestManager_CodexQuotaProbe_MissingFieldsNeverUnlocks(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	enableAdaptiveCooldown(manager, 0)
+	executor := &quotaProbeTestExecutor{status: http.StatusOK, body: `{"rate_limit":{"limit_reached":false,"primary_window":{}}}`}
+	manager.RegisterExecutor(executor)
+	registerUsageLimitAuth(t, manager, "auth-missing", "acct-missing", "plus", 7*24*time.Hour)
+
+	buckets, _ := manager.collectCodexQuotaProbeBuckets(time.Now())
+	outcome := manager.probeCodexQuotaBucket(context.Background(), buckets[0])
+	if outcome.err == nil || outcome.recovered {
+		t.Fatalf("probe outcome = %+v, want missing-field failure", outcome)
+	}
+}
+
+func TestManager_RefreshSchedulesImmediateQuotaProbe(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	enableAdaptiveCooldown(manager, 0)
+	executor := &quotaProbeTestExecutor{status: http.StatusOK, body: `{}`}
+	manager.RegisterExecutor(executor)
+	retryAfter := 7 * 24 * time.Hour
+	registerUsageLimitAuth(t, manager, "auth-refresh", "acct-refresh", "plus", retryAfter)
+
+	authBefore, _ := manager.GetByID("auth-refresh")
+	authBefore.Quota.NextProbeAt = time.Now().Add(time.Hour)
+	if _, errUpdate := manager.Update(context.Background(), authBefore); errUpdate != nil {
+		t.Fatalf("set future probe: %v", errUpdate)
+	}
+	before := time.Now()
+	refreshed, errRefresh := manager.refreshAuthForRequest(context.Background(), "auth-refresh", "")
+	if errRefresh != nil {
+		t.Fatalf("refresh auth: %v", errRefresh)
+	}
+	after := time.Now()
+	updated, _ := manager.GetByID("auth-refresh")
+	if refreshed == nil || !refreshed.Unavailable || !refreshed.Quota.Exceeded {
+		t.Fatalf("refresh returned prematurely unlocked auth: %+v", refreshed)
+	}
+	if !updated.Unavailable || !updated.Quota.Exceeded {
+		t.Fatalf("refresh unlocked usage-limited auth before probe: %+v", updated.Quota)
+	}
+	if updated.Quota.NextProbeAt.Before(before) || updated.Quota.NextProbeAt.After(after.Add(cooldownTestTolerance)) {
+		t.Fatalf("next probe after refresh = %v, want immediate within [%v, %v]", updated.Quota.NextProbeAt, before, after)
+	}
+}
+
+func TestManager_DisablingAdaptiveCooldownDowngradesUsageState(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	enableAdaptiveCooldown(manager, 0)
+	retryAfter := time.Hour
+	registerUsageLimitAuth(t, manager, "auth-disable", "acct-disable", "plus", retryAfter)
+	before, _ := manager.GetByID("auth-disable")
+	providerReset := before.Quota.NextRecoverAt
+
+	manager.SetConfig(&internalconfig.Config{})
+	updated, _ := manager.GetByID("auth-disable")
+	if updated.Quota.Reason != "quota" || !updated.Quota.NextProbeAt.IsZero() {
+		t.Fatalf("disabled adaptive state = %+v, want legacy quota state", updated.Quota)
+	}
+	if !updated.Unavailable || !updated.NextRetryAfter.Equal(providerReset) {
+		t.Fatalf("disabled adaptive state unlocked early: unavailable=%t next=%v reset=%v", updated.Unavailable, updated.NextRetryAfter, providerReset)
+	}
+}
+
+func TestIsAuthBlockedForModel_UsageLimitRemainsBlockedAfterResetUntilProbe(t *testing.T) {
+	now := time.Now()
+	auth := &Auth{
+		ID:          "auth-expired-reset",
+		Provider:    "codex",
+		Unavailable: true,
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "usage_limit_reached",
+			NextRecoverAt: now.Add(-time.Minute),
+			NextProbeAt:   now.Add(time.Minute),
+		},
+		NextRetryAfter: now.Add(-time.Minute),
+	}
+	blocked, reason, next := isAuthBlockedForModel(auth, "", now)
+	if !blocked || reason != blockReasonCooldown || !next.Equal(auth.Quota.NextProbeAt) {
+		t.Fatalf("blocked=%t reason=%v next=%v, want usage-limit block until %v", blocked, reason, next, auth.Quota.NextProbeAt)
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -256,8 +256,10 @@ type Manager struct {
 	rtProvider RoundTripperProvider
 
 	// Auto refresh state
-	refreshCancel context.CancelFunc
-	refreshLoop   *authAutoRefreshLoop
+	refreshCancel    context.CancelFunc
+	refreshLoop      *authAutoRefreshLoop
+	quotaProbeCancel context.CancelFunc
+	quotaProbeWake   chan struct{}
 
 	requestPrepareLocks sync.Map
 	// refreshLocks serializes credential refresh per auth ID so concurrent
@@ -512,12 +514,14 @@ func (m *Manager) SetConfig(cfg *internalconfig.Config) {
 		cfg = &internalconfig.Config{}
 	}
 	m.runtimeConfig.Store(cfg)
+	m.signalCodexQuotaProbe()
 	clearedCooldowns := m.clearDisabledCooldownStates(cfg)
+	reconciledCodexCooldowns := m.reconcileCodexQuotaCooldownConfig()
 	if !cfg.Home.Enabled {
 		m.clearHomeRuntimeAuths()
 	}
 	m.rebuildAPIKeyModelAliasFromRuntimeConfig()
-	if clearedCooldowns {
+	if clearedCooldowns || reconciledCodexCooldowns {
 		m.persistCooldownStates(context.Background())
 	}
 }
@@ -611,16 +615,22 @@ func (m *Manager) RestoreCooldownStates(ctx context.Context) error {
 		}
 	}
 	m.persistCooldownStates(ctx)
+	m.signalCodexQuotaProbe()
 	return nil
 }
 
 func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now time.Time) bool {
 	authID := strings.TrimSpace(record.AuthID)
-	if authID == "" || record.NextRetryAfter.IsZero() || !record.NextRetryAfter.After(now) {
+	if authID == "" {
 		return false
 	}
 	auth := m.auths[authID]
 	if auth == nil || auth.Disabled || auth.Status == StatusDisabled || m.cooldownDisabledForAuth(auth) {
+		return false
+	}
+	record = m.normalizeRestoredCodexCooldownRecord(auth, record, now)
+	usageLimit := record.Quota.Exceeded && record.Quota.Reason == "usage_limit_reached"
+	if !usageLimit && (record.NextRetryAfter.IsZero() || !record.NextRetryAfter.After(now)) {
 		return false
 	}
 	updatedAt := record.UpdatedAt
@@ -897,7 +907,8 @@ func cooldownQuotaEqual(a, b QuotaState) bool {
 	return a.Exceeded == b.Exceeded &&
 		a.Reason == b.Reason &&
 		a.BackoffLevel == b.BackoffLevel &&
-		a.NextRecoverAt.Equal(b.NextRecoverAt)
+		a.NextRecoverAt.Equal(b.NextRecoverAt) &&
+		a.NextProbeAt.Equal(b.NextProbeAt)
 }
 
 func cooldownErrorEqual(a, b *Error) bool {
@@ -911,7 +922,8 @@ func cooldownErrorEqual(a, b *Error) bool {
 }
 
 func authCooldownStateRecord(auth *Auth, now time.Time) (CooldownStateRecord, bool) {
-	if auth == nil || !auth.Unavailable || auth.NextRetryAfter.IsZero() || !auth.NextRetryAfter.After(now) {
+	usageLimit := auth != nil && auth.Quota.Exceeded && auth.Quota.Reason == "usage_limit_reached"
+	if auth == nil || !auth.Unavailable || (!usageLimit && (auth.NextRetryAfter.IsZero() || !auth.NextRetryAfter.After(now))) {
 		return CooldownStateRecord{}, false
 	}
 	return CooldownStateRecord{
@@ -929,7 +941,8 @@ func authCooldownStateRecord(auth *Auth, now time.Time) (CooldownStateRecord, bo
 
 func modelCooldownStateRecord(auth *Auth, model string, state *ModelState, now time.Time) (CooldownStateRecord, bool) {
 	model = strings.TrimSpace(model)
-	if auth == nil || state == nil || model == "" || !state.Unavailable || state.NextRetryAfter.IsZero() || !state.NextRetryAfter.After(now) {
+	usageLimit := state != nil && state.Quota.Exceeded && state.Quota.Reason == "usage_limit_reached"
+	if auth == nil || state == nil || model == "" || !state.Unavailable || (!usageLimit && (state.NextRetryAfter.IsZero() || !state.NextRetryAfter.After(now))) {
 		return CooldownStateRecord{}, false
 	}
 	return CooldownStateRecord{
@@ -3746,6 +3759,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			if result.Model != "" {
 				if !isRequestScopedResultError(result.Error) {
 					disableCooling := m.cooldownDisabledForAuth(auth)
+					cooldownPolicy := m.codexCooldownPolicyForAuth(auth)
 					state := ensureModelState(auth, result.Model)
 					state.Unavailable = true
 					state.Status = StatusError
@@ -3790,7 +3804,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							if disableCooling {
 								state.NextRetryAfter = time.Time{}
 							} else {
-								next := now.Add(30 * time.Minute)
+								next := now.Add(cooldownPolicy.unauthorized)
 								state.NextRetryAfter = next
 								suspendReason = "unauthorized"
 								shouldSuspendModel = true
@@ -3816,19 +3830,33 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						case 429:
 							var next time.Time
 							backoffLevel := state.Quota.BackoffLevel
+							quotaReason := "quota"
+							if cooldownPolicy.adaptive {
+								quotaReason = "rate_limit"
+							}
+							var nextProbeAt time.Time
 							if !disableCooling {
-								if result.RetryAfter != nil {
+								if cooldownPolicy.adaptive && isCodexUsageLimitResult(auth, result.Error) {
+									quotaReason = "usage_limit_reached"
+									if result.RetryAfter != nil {
+										next = now.Add(*result.RetryAfter)
+									} else {
+										next = now.Add(adaptiveCooldownMax)
+									}
+									nextProbeAt = nextCodexQuotaProbeAt(now, next)
+								} else if result.RetryAfter != nil && !cooldownPolicy.adaptive {
 									next = now.Add(*result.RetryAfter)
 								} else {
-									next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
+									next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now, cooldownPolicy, rand.Float64())
 								}
 							}
 							state.NextRetryAfter = next
 							state.Quota = QuotaState{
 								Exceeded:      true,
-								Reason:        "quota",
+								Reason:        quotaReason,
 								NextRecoverAt: next,
 								BackoffLevel:  backoffLevel,
+								NextProbeAt:   nextProbeAt,
 							}
 							if !disableCooling {
 								suspendReason = "quota"
@@ -3852,7 +3880,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				}
 			} else {
 				disableCooling := m.cooldownDisabledForAuth(auth)
-				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling)
+				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling, m.codexCooldownPolicyForAuth(auth), rand.Float64())
 			}
 		}
 
@@ -3869,6 +3897,9 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	}
 	if authSnapshot != nil && cooldownStateChanged {
 		m.persistCooldownStates(context.Background())
+	}
+	if authSnapshot != nil && isCodexUsageLimitResult(authSnapshot, result.Error) {
+		m.signalCodexQuotaProbe()
 	}
 
 	if clearModelQuota && result.Model != "" {
@@ -3925,7 +3956,7 @@ func modelStateIsClean(state *ModelState) bool {
 	if state.Unavailable || state.StatusMessage != "" || !state.NextRetryAfter.IsZero() || state.LastError != nil {
 		return false
 	}
-	if state.Quota.Exceeded || state.Quota.Reason != "" || !state.Quota.NextRecoverAt.IsZero() || state.Quota.BackoffLevel != 0 {
+	if state.Quota.Exceeded || state.Quota.Reason != "" || !state.Quota.NextRecoverAt.IsZero() || state.Quota.BackoffLevel != 0 || !state.Quota.NextProbeAt.IsZero() {
 		return false
 	}
 	return true
@@ -3943,6 +3974,8 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 	earliestRetry := time.Time{}
 	quotaExceeded := false
 	quotaRecover := time.Time{}
+	quotaNextProbe := time.Time{}
+	usageLimitReached := false
 	maxBackoffLevel := 0
 	hasState := false
 	for _, state := range auth.ModelStates {
@@ -3954,7 +3987,16 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 		if state.Status == StatusDisabled {
 			stateUnavailable = true
 		} else if state.Unavailable {
-			if state.NextRetryAfter.IsZero() {
+			if state.Quota.Exceeded && state.Quota.Reason == "usage_limit_reached" {
+				stateUnavailable = true
+				next := state.Quota.NextProbeAt
+				if next.IsZero() {
+					next = state.Quota.NextRecoverAt
+				}
+				if !next.IsZero() && (earliestRetry.IsZero() || next.Before(earliestRetry)) {
+					earliestRetry = next
+				}
+			} else if state.NextRetryAfter.IsZero() {
 				stateUnavailable = false
 			} else if state.NextRetryAfter.After(now) {
 				stateUnavailable = true
@@ -3971,8 +4013,14 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 		}
 		if state.Quota.Exceeded {
 			quotaExceeded = true
+			if state.Quota.Reason == "usage_limit_reached" {
+				usageLimitReached = true
+			}
 			if quotaRecover.IsZero() || (!state.Quota.NextRecoverAt.IsZero() && state.Quota.NextRecoverAt.Before(quotaRecover)) {
 				quotaRecover = state.Quota.NextRecoverAt
+			}
+			if quotaNextProbe.IsZero() || (!state.Quota.NextProbeAt.IsZero() && state.Quota.NextProbeAt.Before(quotaNextProbe)) {
+				quotaNextProbe = state.Quota.NextProbeAt
 			}
 			if state.Quota.BackoffLevel > maxBackoffLevel {
 				maxBackoffLevel = state.Quota.BackoffLevel
@@ -3992,13 +4040,14 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 	if quotaExceeded {
 		auth.Quota.Exceeded = true
 		auth.Quota.Reason = "quota"
+		if usageLimitReached {
+			auth.Quota.Reason = "usage_limit_reached"
+		}
 		auth.Quota.NextRecoverAt = quotaRecover
 		auth.Quota.BackoffLevel = maxBackoffLevel
+		auth.Quota.NextProbeAt = quotaNextProbe
 	} else {
-		auth.Quota.Exceeded = false
-		auth.Quota.Reason = ""
-		auth.Quota.NextRecoverAt = time.Time{}
-		auth.Quota.BackoffLevel = 0
+		auth.Quota = QuotaState{}
 	}
 }
 
@@ -4038,10 +4087,7 @@ func clearAuthStateOnSuccess(auth *Auth, now time.Time) {
 	auth.Unavailable = false
 	auth.Status = StatusActive
 	auth.StatusMessage = ""
-	auth.Quota.Exceeded = false
-	auth.Quota.Reason = ""
-	auth.Quota.NextRecoverAt = time.Time{}
-	auth.Quota.BackoffLevel = 0
+	auth.Quota = QuotaState{}
 	auth.LastError = nil
 	auth.NextRetryAfter = time.Time{}
 	auth.UpdatedAt = now
@@ -4335,7 +4381,7 @@ func isRequestInvalidError(err error) bool {
 	}
 }
 
-func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time, disableCooling bool) {
+func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time, disableCooling bool, cooldownPolicy codexCooldownPolicy, randomUnit float64) {
 	if auth == nil {
 		return
 	}
@@ -4379,7 +4425,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		if disableCooling {
 			auth.NextRetryAfter = time.Time{}
 		} else {
-			auth.NextRetryAfter = now.Add(30 * time.Minute)
+			auth.NextRetryAfter = now.Add(cooldownPolicy.unauthorized)
 		}
 	case 402, 403:
 		auth.StatusMessage = "payment_required"
@@ -4399,15 +4445,28 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.StatusMessage = "quota exhausted"
 		auth.Quota.Exceeded = true
 		auth.Quota.Reason = "quota"
+		if cooldownPolicy.adaptive {
+			auth.Quota.Reason = "rate_limit"
+		}
 		var next time.Time
+		var nextProbeAt time.Time
 		if !disableCooling {
-			if retryAfter != nil {
+			if cooldownPolicy.adaptive && isCodexUsageLimitResult(auth, resultErr) {
+				auth.Quota.Reason = "usage_limit_reached"
+				if retryAfter != nil {
+					next = now.Add(*retryAfter)
+				} else {
+					next = now.Add(adaptiveCooldownMax)
+				}
+				nextProbeAt = nextCodexQuotaProbeAt(now, next)
+			} else if retryAfter != nil && !cooldownPolicy.adaptive {
 				next = now.Add(*retryAfter)
 			} else {
-				next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
+				next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now, cooldownPolicy, randomUnit)
 			}
 		}
 		auth.Quota.NextRecoverAt = next
+		auth.Quota.NextProbeAt = nextProbeAt
 		auth.NextRetryAfter = next
 	case 408, 500, 502, 503, 504:
 		auth.StatusMessage = "transient upstream error"
@@ -4428,9 +4487,29 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 // window is still open reuse that window instead of escalating, so a burst of
 // concurrent in-flight failures advances the backoff ladder at most once per
 // window.
-func quotaCooldownAfterFailure(quota QuotaState, now time.Time) (time.Time, int) {
+func quotaCooldownAfterFailure(quota QuotaState, now time.Time, policy codexCooldownPolicy, randomUnit float64) (time.Time, int) {
 	if quota.NextRecoverAt.After(now) {
 		return quota.NextRecoverAt, quota.BackoffLevel
+	}
+	if policy.adaptive {
+		steps := policy.transientBackoff
+		if len(steps) == 0 {
+			steps = normalizeAdaptiveBackoff(nil)
+		}
+		level := quota.BackoffLevel
+		if level < 0 {
+			level = 0
+		}
+		index := level
+		if index >= len(steps) {
+			index = len(steps) - 1
+		}
+		cooldown := jitterAdaptiveCooldown(steps[index], policy.jitterPercent, randomUnit)
+		nextLevel := level + 1
+		if nextLevel > len(steps) {
+			nextLevel = len(steps)
+		}
+		return now.Add(cooldown), nextLevel
 	}
 	cooldown, nextLevel := nextQuotaCooldown(quota.BackoffLevel, false)
 	var next time.Time
@@ -6043,11 +6122,15 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		updated.NextRefreshAfter = now.Add(refreshIneffectiveBackoff)
 	}
 	saved, errUpdate := m.Update(ctx, updated)
+	m.scheduleCodexQuotaProbeNow(id)
 	for _, model := range modelsToResume {
 		registry.GetGlobalRegistry().ResumeClientModel(id, model)
 	}
 	if errUpdate != nil {
 		log.Debugf("persist refreshed auth %s (%s) failed: %v", auth.Provider, auth.ID, errUpdate)
+	}
+	if current, ok := m.GetByID(id); ok {
+		return current, nil
 	}
 	if saved != nil {
 		return saved, nil

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -114,7 +114,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	quotaErr := &Error{Code: "rate_limit", Message: "quota", HTTPStatus: http.StatusTooManyRequests}
 	auth := &Auth{ID: "auth-level-quota"}
 
-	applyAuthFailureState(auth, quotaErr, nil, now, false)
+	applyAuthFailureState(auth, quotaErr, nil, now, false, codexCooldownPolicy{}, 0.5)
 	if auth.Quota.BackoffLevel != 1 {
 		t.Fatalf("expected BackoffLevel 1 after first failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -124,7 +124,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	}
 
 	// In-window failure keeps the current window and level.
-	applyAuthFailureState(auth, quotaErr, nil, now.Add(100*time.Millisecond), false)
+	applyAuthFailureState(auth, quotaErr, nil, now.Add(100*time.Millisecond), false, codexCooldownPolicy{}, 0.5)
 	if auth.Quota.BackoffLevel != 1 {
 		t.Fatalf("expected BackoffLevel to stay 1 for in-window failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -133,22 +133,26 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	}
 
 	// A failure after the window expired escalates to the next level.
-	applyAuthFailureState(auth, quotaErr, nil, now.Add(2*time.Second), false)
+	secondNow := now.Add(2 * time.Second)
+	applyAuthFailureState(auth, quotaErr, nil, secondNow, false, codexCooldownPolicy{}, 0.5)
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel 2 after post-window failure, got %d", auth.Quota.BackoffLevel)
 	}
-	if !auth.Quota.NextRecoverAt.Equal(now.Add(4 * time.Second)) {
-		t.Fatalf("expected second window to close at %v, got %v", now.Add(4*time.Second), auth.Quota.NextRecoverAt)
+	secondRecover := secondNow.Add(2 * time.Second)
+	if !auth.Quota.NextRecoverAt.Equal(secondRecover) {
+		t.Fatalf("expected second window to close at %v, got %v", secondRecover, auth.Quota.NextRecoverAt)
 	}
 
 	// A provider supplied retry hint always takes effect, even in-window.
 	retryAfter := 10 * time.Second
-	applyAuthFailureState(auth, quotaErr, &retryAfter, now.Add(3*time.Second), false)
+	retryNow := secondNow.Add(3 * time.Second)
+	applyAuthFailureState(auth, quotaErr, &retryAfter, retryNow, false, codexCooldownPolicy{}, 0.5)
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel to stay 2 with retry hint, got %d", auth.Quota.BackoffLevel)
 	}
-	if !auth.Quota.NextRecoverAt.Equal(now.Add(13 * time.Second)) {
-		t.Fatalf("expected retry hint window to close at %v, got %v", now.Add(13*time.Second), auth.Quota.NextRecoverAt)
+	retryRecover := retryNow.Add(retryAfter)
+	if !auth.Quota.NextRecoverAt.Equal(retryRecover) {
+		t.Fatalf("expected retry hint window to close at %v, got %v", retryRecover, auth.Quota.NextRecoverAt)
 	}
 }
 

--- a/sdk/cliproxy/auth/cooldown_state_test.go
+++ b/sdk/cliproxy/auth/cooldown_state_test.go
@@ -114,6 +114,7 @@ func TestFileCooldownStateStore_SaveLoadAndCleanStale(t *testing.T) {
 	}
 
 	nextRetry := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	nextProbe := time.Now().Add(5 * time.Minute).UTC().Truncate(time.Second)
 	updatedAt := time.Now().UTC().Truncate(time.Second)
 	record := CooldownStateRecord{
 		Provider:       "xai",
@@ -125,9 +126,10 @@ func TestFileCooldownStateStore_SaveLoadAndCleanStale(t *testing.T) {
 		Reason:         "quota",
 		Quota: QuotaState{
 			Exceeded:      true,
-			Reason:        "quota",
+			Reason:        "usage_limit_reached",
 			NextRecoverAt: nextRetry,
 			BackoffLevel:  1,
+			NextProbeAt:   nextProbe,
 		},
 		LastError: &Error{Message: "rate limited", HTTPStatus: 429},
 		UpdatedAt: updatedAt,
@@ -156,12 +158,110 @@ func TestFileCooldownStateStore_SaveLoadAndCleanStale(t *testing.T) {
 	if loaded[0].LastError == nil || loaded[0].LastError.HTTPStatus != 429 {
 		t.Fatalf("loaded last error = %+v, want HTTP 429", loaded[0].LastError)
 	}
+	if !loaded[0].Quota.NextProbeAt.Equal(nextProbe) {
+		t.Fatalf("loaded next probe = %v, want %v", loaded[0].Quota.NextProbeAt, nextProbe)
+	}
 
 	if errSave := store.Save(ctx, nil); errSave != nil {
 		t.Fatalf("Save(nil) returned error: %v", errSave)
 	}
 	if _, errStat := os.Stat(filepath.Join(authDir, "xai.cds")); !errors.Is(errStat, os.ErrNotExist) {
 		t.Fatalf("expected xai.cds to be removed, stat error = %v", errStat)
+	}
+}
+
+func TestFileCooldownStateStore_LoadsLegacyStateWithoutProbeField(t *testing.T) {
+	authDir := t.TempDir()
+	store := NewFileCooldownStateStoreWithAuthDir(authDir, authDir)
+	nextRetry := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	payload := []byte(`{"version":1,"auth_id":"legacy-auth","provider":"codex","records":[{"provider":"codex","auth_id":"legacy-auth","next_retry_after":"` + nextRetry.Format(time.RFC3339) + `","reason":"quota","quota":{"exceeded":true,"reason":"quota","next_recover_at":"` + nextRetry.Format(time.RFC3339) + `"},"updated_at":"` + time.Now().UTC().Format(time.RFC3339) + `"}]}`)
+	if errWrite := os.WriteFile(filepath.Join(authDir, "legacy.cds"), payload, 0o600); errWrite != nil {
+		t.Fatalf("write legacy state: %v", errWrite)
+	}
+	loaded, errLoad := store.Load(context.Background())
+	if errLoad != nil {
+		t.Fatalf("load legacy state: %v", errLoad)
+	}
+	if len(loaded) != 1 || !loaded[0].Quota.NextProbeAt.IsZero() {
+		t.Fatalf("legacy state = %+v, want one record with zero next probe", loaded)
+	}
+}
+
+func TestManager_RestoreCooldownStates_KeepsUsageLimitAfterProviderReset(t *testing.T) {
+	now := time.Now()
+	store := &recordingCooldownStateStore{load: []CooldownStateRecord{{
+		Provider:       "codex",
+		AuthID:         "usage-auth",
+		Status:         "cooling",
+		NextRetryAfter: now.Add(-time.Minute),
+		Reason:         "usage_limit_reached",
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "usage_limit_reached",
+			NextRecoverAt: now.Add(-time.Minute),
+			NextProbeAt:   now.Add(time.Minute),
+		},
+		LastError: &Error{Code: "usage_limit_reached", Message: "usage limit", HTTPStatus: 429},
+		UpdatedAt: now.Add(-time.Hour),
+	}}}
+	manager := NewManager(nil, nil, nil)
+	manager.SetCooldownStateStore(store)
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: "usage-auth", Provider: "codex"}); errRegister != nil {
+		t.Fatalf("register usage auth: %v", errRegister)
+	}
+	if errRestore := manager.RestoreCooldownStates(context.Background()); errRestore != nil {
+		t.Fatalf("restore usage state: %v", errRestore)
+	}
+	auth, _ := manager.GetByID("usage-auth")
+	if !auth.Unavailable || !auth.Quota.Exceeded || auth.Quota.Reason != "usage_limit_reached" {
+		t.Fatalf("restored usage state was unlocked: %+v", auth.Quota)
+	}
+}
+
+func TestManager_RestoreCooldownStates_MigratesLegacyThreeHour429(t *testing.T) {
+	now := time.Now()
+	legacyRetry := now.Add(3 * time.Hour)
+	store := &recordingCooldownStateStore{load: []CooldownStateRecord{
+		{
+			Provider:       "codex",
+			AuthID:         "legacy-usage",
+			NextRetryAfter: legacyRetry,
+			Reason:         "quota",
+			Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: legacyRetry, BackoffLevel: 1},
+			LastError:      &Error{Code: "usage_limit_reached", Message: `{"error":{"type":"usage_limit_reached"}}`, HTTPStatus: 429},
+			UpdatedAt:      now,
+		},
+		{
+			Provider:       "codex",
+			AuthID:         "legacy-rate",
+			NextRetryAfter: legacyRetry,
+			Reason:         "quota",
+			Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: legacyRetry, BackoffLevel: 1},
+			LastError:      &Error{Code: "rate_limit", Message: "rate limit", HTTPStatus: 429},
+			UpdatedAt:      now,
+		},
+	}}
+	manager := NewManager(nil, nil, nil)
+	enableAdaptiveCooldown(manager, int((3 * time.Hour).Seconds()))
+	manager.SetCooldownStateStore(store)
+	for _, id := range []string{"legacy-usage", "legacy-rate"} {
+		if _, errRegister := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: id, Provider: "codex"}); errRegister != nil {
+			t.Fatalf("register %s: %v", id, errRegister)
+		}
+	}
+	before := time.Now()
+	if errRestore := manager.RestoreCooldownStates(context.Background()); errRestore != nil {
+		t.Fatalf("restore legacy states: %v", errRestore)
+	}
+
+	usage, _ := manager.GetByID("legacy-usage")
+	if usage.Quota.Reason != "usage_limit_reached" || usage.Quota.NextProbeAt.IsZero() {
+		t.Fatalf("legacy usage state was not migrated: %+v", usage.Quota)
+	}
+	rate, _ := manager.GetByID("legacy-rate")
+	remaining := rate.NextRetryAfter.Sub(before)
+	if rate.Quota.Reason != "rate_limit" || remaining < 14*time.Second || remaining > 16*time.Second {
+		t.Fatalf("legacy transient state = %+v remaining=%v, want first adaptive window", rate.Quota, remaining)
 	}
 }
 

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -322,6 +322,16 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 				if state.Status == StatusDisabled {
 					return true, blockReasonDisabled, time.Time{}
 				}
+				if state.Unavailable && state.Quota.Exceeded && state.Quota.Reason == "usage_limit_reached" {
+					next := state.Quota.NextProbeAt
+					if next.IsZero() {
+						next = state.Quota.NextRecoverAt
+					}
+					if next.Before(now) {
+						next = now
+					}
+					return true, blockReasonCooldown, next
+				}
 				if state.Unavailable {
 					if state.NextRetryAfter.IsZero() {
 						return false, blockReasonNone, time.Time{}
@@ -344,6 +354,16 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 			}
 		}
 		return false, blockReasonNone, time.Time{}
+	}
+	if auth.Unavailable && auth.Quota.Exceeded && auth.Quota.Reason == "usage_limit_reached" {
+		next := auth.Quota.NextProbeAt
+		if next.IsZero() {
+			next = auth.Quota.NextRecoverAt
+		}
+		if next.Before(now) {
+			next = now
+		}
+		return true, blockReasonCooldown, next
 	}
 	if auth.Unavailable && auth.NextRetryAfter.After(now) {
 		next := auth.NextRetryAfter

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -174,6 +174,8 @@ type QuotaState struct {
 	NextRecoverAt time.Time `json:"next_recover_at"`
 	// BackoffLevel stores the progressive cooldown exponent used for rate limits.
 	BackoffLevel int `json:"backoff_level,omitempty"`
+	// NextProbeAt schedules the next non-consuming provider quota-status check.
+	NextProbeAt time.Time `json:"next_probe_at,omitempty"`
 }
 
 // ModelState captures the execution state for a specific model under an auth entry.

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1775,6 +1775,7 @@ func (s *Service) Run(ctx context.Context) error {
 	if s.coreManager != nil && !homeEnabled {
 		interval := 15 * time.Minute
 		s.coreManager.StartAutoRefresh(context.Background(), interval)
+		s.coreManager.StartCodexQuotaProbe(context.Background())
 		log.Infof("core auth auto-refresh started (interval=%s)", interval)
 	}
 
@@ -1826,6 +1827,7 @@ func (s *Service) Shutdown(ctx context.Context) error {
 			s.watcherCancel()
 		}
 		if s.coreManager != nil {
+			s.coreManager.StopCodexQuotaProbe()
 			s.coreManager.StopAutoRefresh()
 		}
 		if s.watcher != nil {


### PR DESCRIPTION
## Summary

- classify Codex HTTP 429 responses into transient throttling and explicit usage-limit exhaustion
- use bounded adaptive backoff for transient throttling, while preserving provider reset times for usage limits
- add non-consuming WHAM usage probes with shared quota-bucket deduplication and strict recovery checks
- persist the optional next probe time and migrate legacy cooldown state without breaking old files
- keep the adaptive policy disabled by default
- include prerequisite Go 1.26 race/vet fixes for async test cleanup, watcher synchronization, and immutable returned stream headers

## Safety

- no active model requests are introduced by the probe path
- failed, incomplete, or ambiguous usage responses never unlock credentials
- returned stream headers are frozen before the API returns
- the Seoul-specific three-hour compatibility patch is not included as an upstream behavior

## Verification

- Windows: focused affected packages x20, full `go test -count=1 ./...`, and server build
- NAS Linux Go 1.26.1 with vendored dependencies and GOMAXPROCS=2:
  - full `go vet ./...`
  - five critical adaptive cooldown race tests x100 each
  - full `go test -race -count=1 -p 2 ./...`
  - linux/amd64 CGO build
- NAS source archive SHA-256: `d0e328e020d1cbe6b4b508919293fc4f75ed2e9158d45b12d52e8d239af1ba28`
- NAS binary SHA-256: `f70e47ea2e11158d2033ee4893a1aa4494dd3e5022a3503e93c5a7d909938cea`