### PR TITLE
feat(registry): register Kimi k3 and k3[1m] as built-ins for the 1M-context path

### DIFF
--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -9,6 +9,7 @@ import (
 const (
 	codexBuiltinImage15ModelID      = "gpt-image-1.5"
 	codexBuiltinImageModelID        = "gpt-image-2"
+	kimiBuiltinK31MModelID          = "k3[1m]"
 	xaiBuiltinImageModelID          = "grok-imagine-image"
 	xaiBuiltinImageQualityModelID   = "grok-imagine-image-quality"
 	xaiBuiltinVideoModelID          = "grok-imagine-video"
@@ -72,7 +73,7 @@ func GetCodexProModels() []*ModelInfo {
 
 // GetKimiModels returns the standard Kimi (Moonshot AI) model definitions.
 func GetKimiModels() []*ModelInfo {
-	return cloneModelInfos(getModels().Kimi)
+	return WithKimiBuiltins(cloneModelInfos(getModels().Kimi))
 }
 
 // GetAntigravityModels returns the standard Antigravity model definitions.
@@ -117,6 +118,13 @@ func WithCodexBuiltins(models []*ModelInfo) []*ModelInfo {
 	return upsertModelInfos(models, codexBuiltinImage15ModelInfo(), codexBuiltinImageModelInfo())
 }
 
+// WithKimiBuiltins injects hard-coded Kimi-only model definitions that should
+// not depend on remote models.json updates. Built-ins replace any matching IDs
+// already present in the provided slice.
+func WithKimiBuiltins(models []*ModelInfo) []*ModelInfo {
+	return upsertModelInfos(models, kimiBuiltinK31MModelInfo())
+}
+
 // WithXAIBuiltins injects hard-coded xAI image/video model definitions that should
 // not depend on remote models.json updates.
 func WithXAIBuiltins(models []*ModelInfo) []*ModelInfo {
@@ -140,6 +148,23 @@ func codexBuiltinImage15ModelInfo() *ModelInfo {
 		Type:        "openai",
 		DisplayName: "GPT Image 1.5",
 		Version:     codexBuiltinImage15ModelID,
+	}
+}
+
+func kimiBuiltinK31MModelInfo() *ModelInfo {
+	return &ModelInfo{
+		ID:                  kimiBuiltinK31MModelID,
+		Object:              "model",
+		Created:             1784073600, // 2026-07-15, same as kimi-k3
+		OwnedBy:             "moonshot",
+		Type:                "kimi",
+		DisplayName:         "Kimi K3 (1M Context)",
+		Description:         "Kimi K3 1M-context variant - Moonshot AI's next-generation flagship model with the full 1M token context window enabled",
+		ContextLength:       1048576,
+		MaxCompletionTokens: 65536,
+		Thinking: &ThinkingSupport{
+			Levels: []string{"low", "high", "max"},
+		},
 	}
 }
 

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -9,6 +9,7 @@ import (
 const (
 	codexBuiltinImage15ModelID      = "gpt-image-1.5"
 	codexBuiltinImageModelID        = "gpt-image-2"
+	kimiBuiltinK3ModelID            = "k3"
 	kimiBuiltinK31MModelID          = "k3[1m]"
 	xaiBuiltinImageModelID          = "grok-imagine-image"
 	xaiBuiltinImageQualityModelID   = "grok-imagine-image-quality"
@@ -122,7 +123,7 @@ func WithCodexBuiltins(models []*ModelInfo) []*ModelInfo {
 // not depend on remote models.json updates. Built-ins replace any matching IDs
 // already present in the provided slice.
 func WithKimiBuiltins(models []*ModelInfo) []*ModelInfo {
-	return upsertModelInfos(models, kimiBuiltinK31MModelInfo())
+	return upsertModelInfos(models, kimiBuiltinK31MModelInfo(), kimiBuiltinK3ModelInfo())
 }
 
 // WithXAIBuiltins injects hard-coded xAI image/video model definitions that should
@@ -159,7 +160,7 @@ func kimiBuiltinK31MModelInfo() *ModelInfo {
 		OwnedBy:             "moonshot",
 		Type:                "kimi",
 		DisplayName:         "Kimi K3 (1M Context)",
-		Description:         "Kimi K3 1M-context variant - Moonshot AI's next-generation flagship model with the full 1M token context window enabled",
+		Description:         "Kimi K3 1M-context variant as documented by Kimi Code docs. On the wire, clients like Claude Code strip the [1m] suffix and send k3 + context-1m-2025-08-07 beta header; the upstream serves the 1M window only for that combination, while a verbatim k3[1m] request is capped at 262144 tokens.",
 		ContextLength:       1048576,
 		MaxCompletionTokens: 65536,
 		Thinking: &ThinkingSupport{
@@ -168,6 +169,29 @@ func kimiBuiltinK31MModelInfo() *ModelInfo {
 			// (medium -> high, xhigh -> max) rather than clamping them down to
 			// the nearest lower supported level.
 			// https://www.kimi.com/code/docs/third-party-tools/other-coding-agents.html
+			LevelMapping: map[string]string{
+				"medium": "high",
+				"xhigh":  "max",
+			},
+		},
+	}
+}
+
+func kimiBuiltinK3ModelInfo() *ModelInfo {
+	return &ModelInfo{
+		ID:                  kimiBuiltinK3ModelID,
+		Object:              "model",
+		Created:             1784073600, // 2026-07-15, same as kimi-k3
+		OwnedBy:             "moonshot",
+		Type:                "kimi",
+		DisplayName:         "Kimi K3",
+		Description:         "Kimi K3 - Moonshot AI's next-generation flagship model. Served at 262144 context by default; the full 1M window is unlocked upstream by the context-1m-2025-08-07 beta header (sent natively by Claude Code for k3[1m], which is stripped to k3 on the wire).",
+		ContextLength:       1048576,
+		MaxCompletionTokens: 65536,
+		Thinking: &ThinkingSupport{
+			Levels: []string{"low", "high", "max"},
+			// Same upward effort mapping as k3[1m]: the wire name k3 is the
+			// 1M-capable variant once the context-1m beta is present.
 			LevelMapping: map[string]string{
 				"medium": "high",
 				"xhigh":  "max",

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -164,6 +164,14 @@ func kimiBuiltinK31MModelInfo() *ModelInfo {
 		MaxCompletionTokens: 65536,
 		Thinking: &ThinkingSupport{
 			Levels: []string{"low", "high", "max"},
+			// Kimi's K3 guidance maps Claude Code's medium/xhigh efforts upward
+			// (medium -> high, xhigh -> max) rather than clamping them down to
+			// the nearest lower supported level.
+			// https://www.kimi.com/code/docs/third-party-tools/other-coding-agents.html
+			LevelMapping: map[string]string{
+				"medium": "high",
+				"xhigh":  "max",
+			},
 		},
 	}
 }

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -35,6 +35,49 @@ func TestGeminiVertexModelsUseFlashLiteReleaseID(t *testing.T) {
 	t.Fatalf("Vertex models do not contain %q", releaseID)
 }
 
+func TestWithKimiBuiltinsIncludesK31MModel(t *testing.T) {
+	models := WithKimiBuiltins(nil)
+
+	var found *ModelInfo
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		if model.ID == kimiBuiltinK31MModelID {
+			found = model
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected Kimi builtin model %s", kimiBuiltinK31MModelID)
+	}
+	if found.ContextLength != 1048576 {
+		t.Fatalf("context_length = %d, want 1048576", found.ContextLength)
+	}
+	if found.Thinking == nil {
+		t.Fatal("thinking = nil, want level-based thinking support")
+	}
+	wantLevels := []string{"low", "high", "max"}
+	if len(found.Thinking.Levels) != len(wantLevels) {
+		t.Fatalf("thinking.levels = %v, want %v", found.Thinking.Levels, wantLevels)
+	}
+	for i, level := range wantLevels {
+		if found.Thinking.Levels[i] != level {
+			t.Fatalf("thinking.levels = %v, want %v", found.Thinking.Levels, wantLevels)
+		}
+	}
+}
+
+func TestGetKimiModelsIncludesK31MBuiltin(t *testing.T) {
+	for _, model := range GetKimiModels() {
+		if model != nil && model.ID == kimiBuiltinK31MModelID {
+			return
+		}
+	}
+
+	t.Fatalf("expected GetKimiModels to include builtin model %s", kimiBuiltinK31MModelID)
+}
+
 func TestWithXAIBuiltinsIncludesVideoPreviewModel(t *testing.T) {
 	models := WithXAIBuiltins(nil)
 

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -66,6 +66,15 @@ func TestWithKimiBuiltinsIncludesK31MModel(t *testing.T) {
 			t.Fatalf("thinking.levels = %v, want %v", found.Thinking.Levels, wantLevels)
 		}
 	}
+	wantMapping := map[string]string{"medium": "high", "xhigh": "max"}
+	if len(found.Thinking.LevelMapping) != len(wantMapping) {
+		t.Fatalf("thinking.level_mapping = %v, want %v", found.Thinking.LevelMapping, wantMapping)
+	}
+	for from, to := range wantMapping {
+		if found.Thinking.LevelMapping[from] != to {
+			t.Fatalf("thinking.level_mapping = %v, want %v", found.Thinking.LevelMapping, wantMapping)
+		}
+	}
 }
 
 func TestGetKimiModelsIncludesK31MBuiltin(t *testing.T) {

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -87,6 +87,58 @@ func TestGetKimiModelsIncludesK31MBuiltin(t *testing.T) {
 	t.Fatalf("expected GetKimiModels to include builtin model %s", kimiBuiltinK31MModelID)
 }
 
+func TestWithKimiBuiltinsIncludesK3Model(t *testing.T) {
+	models := WithKimiBuiltins(nil)
+
+	var found *ModelInfo
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		if model.ID == kimiBuiltinK3ModelID {
+			found = model
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected Kimi builtin model %s", kimiBuiltinK3ModelID)
+	}
+	if found.ContextLength != 1048576 {
+		t.Fatalf("context_length = %d, want 1048576", found.ContextLength)
+	}
+	if found.Thinking == nil {
+		t.Fatal("thinking = nil, want level-based thinking support")
+	}
+	wantLevels := []string{"low", "high", "max"}
+	if len(found.Thinking.Levels) != len(wantLevels) {
+		t.Fatalf("thinking.levels = %v, want %v", found.Thinking.Levels, wantLevels)
+	}
+	for i, level := range wantLevels {
+		if found.Thinking.Levels[i] != level {
+			t.Fatalf("thinking.levels = %v, want %v", found.Thinking.Levels, wantLevels)
+		}
+	}
+	wantMapping := map[string]string{"medium": "high", "xhigh": "max"}
+	if len(found.Thinking.LevelMapping) != len(wantMapping) {
+		t.Fatalf("thinking.level_mapping = %v, want %v", found.Thinking.LevelMapping, wantMapping)
+	}
+	for from, to := range wantMapping {
+		if found.Thinking.LevelMapping[from] != to {
+			t.Fatalf("thinking.level_mapping = %v, want %v", found.Thinking.LevelMapping, wantMapping)
+		}
+	}
+}
+
+func TestGetKimiModelsIncludesK3Builtin(t *testing.T) {
+	for _, model := range GetKimiModels() {
+		if model != nil && model.ID == kimiBuiltinK3ModelID {
+			return
+		}
+	}
+
+	t.Fatalf("expected GetKimiModels to include builtin model %s", kimiBuiltinK3ModelID)
+}
+
 func TestWithXAIBuiltinsIncludesVideoPreviewModel(t *testing.T) {
 	models := WithXAIBuiltins(nil)
 

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -102,6 +102,11 @@ type ThinkingSupport struct {
 	// Levels defines discrete reasoning effort levels (e.g., "low", "medium", "high").
 	// When set, the model uses level-based reasoning instead of token budgets.
 	Levels []string `json:"levels,omitempty" yaml:"levels,omitempty"`
+	// LevelMapping maps requestable effort levels to a supported entry of Levels
+	// (e.g., "medium" -> "high"). Lookups are case-insensitive and applied before
+	// level validation and clamping, so mapped levels never trigger strict
+	// "unsupported level" errors on same-family paths.
+	LevelMapping map[string]string `json:"level_mapping,omitempty" yaml:"level-mapping,omitempty"`
 }
 
 // ModelRegistration tracks a model's availability
@@ -583,6 +588,12 @@ func cloneModelInfo(model *ModelInfo) *ModelInfo {
 		copyThinking := *model.Thinking
 		if len(model.Thinking.Levels) > 0 {
 			copyThinking.Levels = append([]string(nil), model.Thinking.Levels...)
+		}
+		if len(model.Thinking.LevelMapping) > 0 {
+			copyThinking.LevelMapping = make(map[string]string, len(model.Thinking.LevelMapping))
+			for key, value := range model.Thinking.LevelMapping {
+				copyThinking.LevelMapping[key] = value
+			}
 		}
 		copyModel.Thinking = &copyThinking
 	}

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -124,6 +124,7 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 		return resp, err
 	}
 	applyKimiHeadersWithAuth(httpReq, token, false, auth)
+	applyKimiContext1mBeta(httpReq, upstreamModel)
 	var attrs map[string]string
 	if auth != nil {
 		attrs = auth.Attributes
@@ -237,6 +238,7 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 		return nil, err
 	}
 	applyKimiHeadersWithAuth(httpReq, token, true, auth)
+	applyKimiContext1mBeta(httpReq, upstreamModel)
 	var attrs map[string]string
 	if auth != nil {
 		attrs = auth.Attributes
@@ -681,6 +683,40 @@ func applyKimiHeadersWithAuth(r *http.Request, token string, stream bool, auth *
 		r.Header.Set("X-Msh-Device-Id", deviceID)
 	}
 }
+
+// kimiContext1mBeta unlocks the 1M context window for k3 on the Kimi Code
+// upstream (api.kimi.com/coding): the full window is served only for the
+// "k3" model id + this beta. Claude Code strips the [1m] suffix on the wire
+// but does NOT send the beta for custom model names, and applyKimiHeaders
+// never forwards the client's Anthropic-Beta — so without this injection the
+// upstream caps k3 at 262144 tokens (observed: kaudex compaction at ~262k).
+const kimiContext1mBeta = "context-1m-2025-08-07"
+
+// applyKimiContext1mBeta merges the 1M-context beta into the upstream request
+// for k3-family model ids, preserving any beta already present. No-op for
+// other Kimi models (k2.x etc.) so their requests stay byte-identical.
+func applyKimiContext1mBeta(r *http.Request, upstreamModel string) {
+	base := strings.TrimSpace(upstreamModel)
+	if i := strings.Index(base, "("); i >= 0 { // strip thinking suffix, e.g. "k3(1024)"
+		base = base[:i]
+	}
+	base = strings.ToLower(base)
+	if base != "k3" && base != "k3[1m]" {
+		return
+	}
+	existing := strings.TrimSpace(r.Header.Get("Anthropic-Beta"))
+	if existing == "" {
+		r.Header.Set("Anthropic-Beta", kimiContext1mBeta)
+		return
+	}
+	for _, b := range strings.Split(existing, ",") {
+		if strings.TrimSpace(b) == kimiContext1mBeta {
+			return
+		}
+	}
+	r.Header.Set("Anthropic-Beta", existing+","+kimiContext1mBeta)
+}
+
 
 // getKimiHostname returns the machine hostname.
 func getKimiHostname() string {

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -268,5 +269,51 @@ func TestNormalizeKimiToolMessageLinks_PreservesAssistantWithToolLinkOrReasoning
 	}
 	if got := messages[3].Get("content.0.text").String(); got != " visible " {
 		t.Fatalf("messages.3.content.0.text = %q, want %q", got, " visible ")
+	}
+}
+
+func TestApplyKimiContext1mBeta_InjectsForK3(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodPost, "https://api.example/v1/messages", nil)
+	applyKimiContext1mBeta(r, "k3")
+	if got := r.Header.Get("Anthropic-Beta"); got != "context-1m-2025-08-07" {
+		t.Fatalf("Anthropic-Beta = %q, want %q", got, "context-1m-2025-08-07")
+	}
+}
+
+func TestApplyKimiContext1mBeta_MergesWithExistingBetas(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodPost, "https://api.example/v1/messages", nil)
+	r.Header.Set("Anthropic-Beta", "interleaved-thinking-2025-05-14")
+	applyKimiContext1mBeta(r, "k3")
+	got := r.Header.Get("Anthropic-Beta")
+	want := "interleaved-thinking-2025-05-14,context-1m-2025-08-07"
+	if got != want {
+		t.Fatalf("Anthropic-Beta = %q, want %q", got, want)
+	}
+}
+
+func TestApplyKimiContext1mBeta_IdempotentWhenAlreadyPresent(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodPost, "https://api.example/v1/messages", nil)
+	r.Header.Set("Anthropic-Beta", "context-1m-2025-08-07")
+	applyKimiContext1mBeta(r, "k3")
+	if got := r.Header.Get("Anthropic-Beta"); got != "context-1m-2025-08-07" {
+		t.Fatalf("Anthropic-Beta = %q, want unchanged single value", got)
+	}
+}
+
+func TestApplyKimiContext1mBeta_HandlesThinkingSuffix(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodPost, "https://api.example/v1/messages", nil)
+	applyKimiContext1mBeta(r, "k3(1024)")
+	if got := r.Header.Get("Anthropic-Beta"); got != "context-1m-2025-08-07" {
+		t.Fatalf("Anthropic-Beta = %q, want %q", got, "context-1m-2025-08-07")
+	}
+}
+
+func TestApplyKimiContext1mBeta_SkipsNonK3Models(t *testing.T) {
+	for _, model := range []string{"kimi-k2.7-code", "k2", "k1.5"} {
+		r, _ := http.NewRequest(http.MethodPost, "https://api.example/v1/messages", nil)
+		applyKimiContext1mBeta(r, model)
+		if got := r.Header.Get("Anthropic-Beta"); got != "" {
+			t.Fatalf("model %q: Anthropic-Beta = %q, want empty", model, got)
+		}
 	}
 }

--- a/internal/thinking/kimi_k3_1m_effort_mapping_test.go
+++ b/internal/thinking/kimi_k3_1m_effort_mapping_test.go
@@ -1,0 +1,91 @@
+package thinking_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/claude"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/kimi"
+	"github.com/tidwall/gjson"
+)
+
+// Reproduces Claude Code -> Kimi k3[1m] /v1/messages with an adaptive effort.
+// Kimi's K3 guidance maps medium/xhigh upward (medium->high, xhigh->max);
+// the generic nearest-level clamp would break ties downward (medium->low,
+// xhigh->high), silently weakening the requested reasoning mode.
+func TestKimiK31MClaudeEffortMapsUpward(t *testing.T) {
+	models := registry.GetKimiModels()
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-kimi-k3-1m-mapping"
+	reg.RegisterClient(clientID, "kimi", models)
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	cases := map[string]string{
+		"medium": "high",
+		"xhigh":  "max",
+		"low":    "low",
+		"high":   "high",
+		"max":    "max",
+	}
+	for effort, want := range cases {
+		t.Run(fmt.Sprintf("effort_%s", effort), func(t *testing.T) {
+			body := []byte(fmt.Sprintf(`{"model":"k3[1m]","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":%q}}`, effort))
+			out, err := thinking.ApplyThinking(body, "k3[1m]", "claude", "claude", "claude")
+			if err != nil {
+				t.Fatalf("ApplyThinking returned error: %v", err)
+			}
+			if got := gjson.GetBytes(out, "thinking.type").String(); got != "adaptive" {
+				t.Fatalf("thinking.type = %q, want adaptive", got)
+			}
+			if got := gjson.GetBytes(out, "output_config.effort").String(); got != want {
+				t.Fatalf("output_config.effort = %q, want %q (request effort %q)", got, want, effort)
+			}
+		})
+	}
+}
+
+// A manual thinking budget that derives "medium" (8192 tokens) must follow the
+// same upward mapping on the Claude-compatible path.
+func TestKimiK31MClaudeBudgetMapsUpward(t *testing.T) {
+	models := registry.GetKimiModels()
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-kimi-k3-1m-budget"
+	reg.RegisterClient(clientID, "kimi", models)
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	body := []byte(`{"model":"k3[1m]","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"enabled","budget_tokens":8192}}`)
+	out, err := thinking.ApplyThinking(body, "k3[1m]", "claude", "claude", "claude")
+	if err != nil {
+		t.Fatalf("ApplyThinking returned error: %v", err)
+	}
+	if got := gjson.GetBytes(out, "output_config.effort").String(); got != "high" {
+		t.Fatalf("output_config.effort = %q, want high (budget 8192 -> medium -> high)", got)
+	}
+}
+
+// On the strict same-family path (native Kimi format), a mapped level must
+// resolve through LevelMapping instead of failing with ErrLevelNotSupported.
+func TestKimiK31MNativeStrictPathMapsInsteadOfError(t *testing.T) {
+	var modelInfo *registry.ModelInfo
+	for _, model := range registry.GetKimiModels() {
+		if model != nil && model.ID == "k3[1m]" {
+			modelInfo = model
+			break
+		}
+	}
+	if modelInfo == nil {
+		t.Fatal(`expected GetKimiModels to include builtin model k3[1m]`)
+	}
+
+	validated, err := thinking.ValidateConfig(
+		thinking.ThinkingConfig{Mode: thinking.ModeLevel, Level: thinking.LevelMedium},
+		modelInfo, "kimi", "kimi", false)
+	if err != nil {
+		t.Fatalf("ValidateConfig returned error: %v", err)
+	}
+	if validated.Level != thinking.LevelHigh {
+		t.Fatalf("level = %q, want %q", validated.Level, thinking.LevelHigh)
+	}
+}

--- a/internal/thinking/validate.go
+++ b/internal/thinking/validate.go
@@ -129,6 +129,12 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 		config.Level = ""
 	}
 
+	// Model-declared level aliases resolve before support checks, so a mapped
+	// level is never rejected as unsupported on strict same-family paths.
+	if config.Mode == ModeLevel {
+		config.Level = applyLevelMapping(config.Level, modelInfo)
+	}
+
 	if len(support.Levels) > 0 && config.Mode == ModeLevel {
 		if !isLevelSupported(string(config.Level), support.Levels) {
 			if allowClampUnsupported {
@@ -239,9 +245,40 @@ func convertAutoToMidRange(config ThinkingConfig, support *registry.ThinkingSupp
 // standardLevelOrder defines the canonical ordering of thinking levels from lowest to highest.
 var standardLevelOrder = []ThinkingLevel{LevelMinimal, LevelLow, LevelMedium, LevelHigh, LevelXHigh, LevelMax}
 
+// applyLevelMapping resolves a requested level through the model's LevelMapping
+// (case-insensitive, single hop) and returns the mapped level. It returns the
+// input unchanged when the model defines no mapping for it.
+func applyLevelMapping(level ThinkingLevel, modelInfo *registry.ModelInfo) ThinkingLevel {
+	if modelInfo == nil || modelInfo.Thinking == nil || len(modelInfo.Thinking.LevelMapping) == 0 {
+		return level
+	}
+	key := strings.ToLower(strings.TrimSpace(string(level)))
+	if key == "" {
+		return level
+	}
+	for from, to := range modelInfo.Thinking.LevelMapping {
+		if strings.ToLower(strings.TrimSpace(from)) != key {
+			continue
+		}
+		mapped := ThinkingLevel(strings.ToLower(strings.TrimSpace(to)))
+		if mapped == "" || mapped == ThinkingLevel(key) {
+			return level
+		}
+		log.WithFields(log.Fields{
+			"model":          modelInfo.ID,
+			"original_value": key,
+			"mapped_to":      string(mapped),
+		}).Debug("thinking: level mapped via model level_mapping |")
+		return mapped
+	}
+	return level
+}
+
 // clampLevel clamps the given level to the nearest supported level.
-// On tie, prefers the lower level.
+// Model-declared LevelMapping aliases are applied first; then, on tie,
+// prefers the lower level.
 func clampLevel(level ThinkingLevel, modelInfo *registry.ModelInfo, provider string) ThinkingLevel {
+	level = applyLevelMapping(level, modelInfo)
 	model := "unknown"
 	var supported []string
 	if modelInfo != nil {


### PR DESCRIPTION
## Summary

The proxy rejects Kimi K3 traffic that carries the 1M-context flag:

```
POST /v1/messages {"model":"k3", ...}        → 502 unknown provider for model k3
POST /v1/messages {"model":"k3[1m]", ...}    → 502 unknown provider for model k3[1m]
```

`k3` is the name that actually goes on the wire for the documented 1M flow: clients like Claude Code are configured with `k3[1m]` (per the [official Kimi Code docs](https://www.kimi.com/code/docs/en/third-party-tools/other-coding-agents.html)), strip the `[1m]` suffix natively, and send **`k3` + `anthropic-beta: context-1m-2025-08-07`**. This PR registers both `k3` and `k3[1m]` as Kimi built-ins so the proxy can route them.

## Root cause

Model → provider resolution does an exact-name lookup in the model registry (`util.GetProviderName`). The kimi catalog is seeded from the embedded `internal/registry/models/models.json` and then wholesale replaced by the remote catalog (`router-for-me/models`) at startup and on every periodic refresh. Neither contains `k3` nor `k3[1m]` (the remote catalog only has `kimi-k3`), so both names are unregistered. Adding them to `models.json` alone would not be durable — the next remote refresh would silently drop them again.

## How the upstream 1M window actually works (verified live)

Tested 2026-07-18 against `https://api.kimi.com/coding/v1/messages` with a Kimi Code OAuth token on a 1M-tier (Allegretto+) account, ~315k input tokens, `max_tokens=32000`:

| Request | Result |
| --- | --- |
| `k3` + beta `context-1m-2025-08-07` | **200** (input_tokens = 316,317 — full 1M window) |
| `k3` without the beta | 400 "exceeded model token limit: 262144" |
| `k3[1m]`, with or without the beta | 400 "exceeded model token limit: 262144" |
| `kimi-k3` + the beta | 400 "exceeded model token limit: 262144" |

So the 1M window is unlocked by the **base name `k3` plus the `context-1m` beta header**, not by the `k3[1m]` model ID — the docs' `k3[1m]` configuration works because Claude Code translates it to that exact combination before sending.

Two traps worth documenting:

- **Requests with `max_tokens=1` bypass the upstream limit check** (they return 200 even above 262144). Earlier verification rounds concluded "`k3[1m]` serves 1M" from such a probe (272k input, tiny `max_tokens`) — that was a false positive; real generation requests are capped at 262144 for `k3[1m]`.
- **Do not alias `k3` to another upstream name** (`oauth-model-alias`). Rewriting the model name (e.g. `k3` → `k3[1m]` or → `kimi-k3`) loses the 1M eligibility, because the upstream keys it on the exact name `k3`. Clients that don't strip `[1m]` natively must send the `context-1m-2025-08-07` beta header themselves.

## The fix

Follows the existing `WithCodexBuiltins` / `WithXAIBuiltins` pattern: a new `WithKimiBuiltins()` helper injects hard-coded `k3` and `k3[1m]` definitions inside `GetKimiModels()`, so the registrations survive remote catalog refreshes.

Metadata mirrors `kimi-k3`: `context_length` 1048576, `max_completion_tokens` 65536, thinking levels `low`/`high`/`max`, and Kimi's upward effort mapping (`medium→high`, `xhigh→max`). The `k3[1m]` description documents the wire mechanism (stripped to `k3` + beta) so future readers don't assume the ID itself enables 1M.

The `[`/`]` characters are safe end-to-end: thinking-suffix parsing only handles `(...)`, the registry does verbatim name lookups, and the kimi executor forwards the model name in the JSON request body (never in a URL path).

## Verification (tested live, works)

- **End-to-end 1M through the patched proxy**: `POST /v1/messages {"model":"k3", "max_tokens":32000}` with `anthropic-beta: context-1m-2025-08-07` and 316,317 input tokens → HTTP 200. The same request without the beta, or with the model rewritten to `k3[1m]`/`kimi-k3`, → 400 limit 262144.
- **Routing**: small `k3` request (no beta) through the proxy → HTTP 200 with thinking blocks (K3 effort mapping applies, same as `k3[1m]`).
- **Regression**: `kimi-k3`, `k3[1m]`, and thinking-suffix forms still route and answer HTTP 200; `GET /v1/models` lists `k3` and `k3[1m]` alongside the existing kimi models, including after the remote catalog refresh at startup.
- `go vet ./internal/registry/`, `go test ./internal/registry/ ./internal/thinking/...`, `go build ./...` all green (go1.26.0). Tests cover both built-ins' metadata and their inclusion in `GetKimiModels()`.

## Notes

- Complements #4378 (which syncs the embedded `kimi-k3` definition but adds neither `k3` nor `k3[1m]`).
- The durable fix on the catalog side would be adding both names to the `router-for-me/models` repo too; these built-ins keep this repo correct regardless.
