### PR TITLE
fix(kimi): coerce boolean tool-schema subschemas for MFJS

### DIFF
--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -113,6 +114,10 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body, err = normalizeKimiToolMessageLinks(body)
+	if err != nil {
+		return resp, err
+	}
+	body, err = sanitizeKimiToolSchemas(body)
 	if err != nil {
 		return resp, err
 	}
@@ -226,6 +231,10 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body, err = normalizeKimiToolMessageLinks(body)
+	if err != nil {
+		return nil, err
+	}
+	body, err = sanitizeKimiToolSchemas(body)
 	if err != nil {
 		return nil, err
 	}
@@ -452,6 +461,178 @@ func normalizeKimiToolMessageLinks(body []byte) ([]byte, error) {
 		}).Warn("kimi executor: tool messages missing tool_call_id with ambiguous candidates")
 	}
 
+	return out, nil
+}
+
+// mfjsBooleanLegalKeys are schema keywords whose value MAY be a bare JSON
+// boolean under Moonshot Flavored JSON Schema (MFJS). A boolean in these slots
+// is a native MFJS feature (open/closed object or tuple tail), not a subschema,
+// and must be preserved.
+var mfjsBooleanLegalKeys = map[string]struct{}{
+	"additionalProperties":  {},
+	"unevaluatedProperties": {},
+	"additionalItems":       {},
+	"unevaluatedItems":      {},
+}
+
+// mfjsSubschemaMapKeys are keywords whose value is an object mapping arbitrary
+// names to subschemas.
+var mfjsSubschemaMapKeys = map[string]struct{}{
+	"properties":        {},
+	"patternProperties": {},
+	"$defs":             {},
+	"definitions":       {},
+	"dependentSchemas":  {},
+}
+
+// mfjsSubschemaArrayKeys are keywords whose value is an array of subschemas.
+var mfjsSubschemaArrayKeys = map[string]struct{}{
+	"anyOf":       {},
+	"oneOf":       {},
+	"allOf":       {},
+	"prefixItems": {},
+}
+
+// mfjsSubschemaValueKeys are keywords whose value is a single subschema.
+var mfjsSubschemaValueKeys = map[string]struct{}{
+	"items":         {},
+	"contains":      {},
+	"propertyNames": {},
+	"if":            {},
+	"then":          {},
+	"else":          {},
+	"not":           {},
+	"contentSchema": {},
+}
+
+// coerceMFJSBooleanSubschema converts a bare boolean subschema to its object
+// form: `true` -> `{}` (accept anything), `false` -> `{"not": {}}` (accept
+// nothing). MFJS rejects boolean subschemas outside the additionalProperties
+// family with "property schema for '<name>' must be an object", even though a
+// boolean subschema is valid standard JSON Schema (draft-06+).
+func coerceMFJSBooleanSubschema(v interface{}) (interface{}, bool) {
+	b, ok := v.(bool)
+	if !ok {
+		return v, false
+	}
+	if b {
+		return map[string]interface{}{}, true
+	}
+	return map[string]interface{}{"not": map[string]interface{}{}}, true
+}
+
+// sanitizeMFJSSchemaNode walks a JSON-Schema node, coercing bare boolean
+// subschemas found in genuine subschema slots into their object form. Booleans
+// that are plain data (enum values, `additionalProperties`, const, default) are
+// left untouched. It returns the node and whether anything changed.
+func sanitizeMFJSSchemaNode(node interface{}) (interface{}, bool) {
+	switch n := node.(type) {
+	case map[string]interface{}:
+		changed := false
+		for key, child := range n {
+			switch {
+			case hasKey(mfjsBooleanLegalKeys, key):
+				// Boolean is a native MFJS feature here; recurse only into an
+				// object subschema, never coerce the boolean itself.
+				if _, isBool := child.(bool); isBool {
+					continue
+				}
+				if walked, c := sanitizeMFJSSchemaNode(child); c {
+					n[key] = walked
+					changed = true
+				}
+			case hasKey(mfjsSubschemaMapKeys, key):
+				childMap, ok := child.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				for name, sub := range childMap {
+					coerced, c1 := coerceMFJSBooleanSubschema(sub)
+					walked, c2 := sanitizeMFJSSchemaNode(coerced)
+					if c1 || c2 {
+						childMap[name] = walked
+						changed = true
+					}
+				}
+			case hasKey(mfjsSubschemaArrayKeys, key):
+				childArr, ok := child.([]interface{})
+				if !ok {
+					continue
+				}
+				for i, sub := range childArr {
+					coerced, c1 := coerceMFJSBooleanSubschema(sub)
+					walked, c2 := sanitizeMFJSSchemaNode(coerced)
+					if c1 || c2 {
+						childArr[i] = walked
+						changed = true
+					}
+				}
+			case hasKey(mfjsSubschemaValueKeys, key):
+				coerced, c1 := coerceMFJSBooleanSubschema(child)
+				walked, c2 := sanitizeMFJSSchemaNode(coerced)
+				if c1 || c2 {
+					n[key] = walked
+					changed = true
+				}
+			}
+			// Non-schema keywords (type, enum, const, description, required,
+			// default, ...) are intentionally left untouched: a boolean there is
+			// data, not a subschema.
+		}
+		return n, changed
+	default:
+		return node, false
+	}
+}
+
+func hasKey(set map[string]struct{}, key string) bool {
+	_, ok := set[key]
+	return ok
+}
+
+// sanitizeKimiToolSchemas rewrites each tool's parameters schema so bare boolean
+// subschemas become objects, which Moonshot's MFJS validator requires. Without
+// this, a tool whose schema carries a boolean subschema (e.g. `"outputSchema":
+// true`) makes Kimi 400 the entire turn with
+// "tools.function.parameters is not a valid moonshot flavored json schema".
+func sanitizeKimiToolSchemas(body []byte) ([]byte, error) {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return body, nil
+	}
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.Exists() || !tools.IsArray() {
+		return body, nil
+	}
+	out := body
+	for i, tool := range tools.Array() {
+		params := tool.Get("function.parameters")
+		path := fmt.Sprintf("tools.%d.function.parameters", i)
+		if !params.Exists() {
+			// Some dialects place parameters directly on the tool object.
+			params = tool.Get("parameters")
+			path = fmt.Sprintf("tools.%d.parameters", i)
+		}
+		if !params.Exists() || !params.IsObject() {
+			continue
+		}
+		var decoded interface{}
+		if err := json.Unmarshal([]byte(params.Raw), &decoded); err != nil {
+			continue
+		}
+		sanitized, changed := sanitizeMFJSSchemaNode(decoded)
+		if !changed {
+			continue
+		}
+		raw, err := json.Marshal(sanitized)
+		if err != nil {
+			return body, fmt.Errorf("kimi executor: marshal sanitized tool schema: %w", err)
+		}
+		next, err := sjson.SetRawBytes(out, path, raw)
+		if err != nil {
+			return body, fmt.Errorf("kimi executor: set sanitized tool schema: %w", err)
+		}
+		out = next
+	}
 	return out, nil
 }
 

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -526,63 +526,91 @@ func coerceMFJSBooleanSubschema(v interface{}) (interface{}, bool) {
 // that are plain data (enum values, `additionalProperties`, const, default) are
 // left untouched. It returns the node and whether anything changed.
 func sanitizeMFJSSchemaNode(node interface{}) (interface{}, bool) {
-	switch n := node.(type) {
-	case map[string]interface{}:
-		changed := false
-		for key, child := range n {
-			switch {
-			case hasKey(mfjsBooleanLegalKeys, key):
-				// Boolean is a native MFJS feature here; recurse only into an
-				// object subschema, never coerce the boolean itself.
-				if _, isBool := child.(bool); isBool {
-					continue
-				}
-				if walked, c := sanitizeMFJSSchemaNode(child); c {
-					n[key] = walked
-					changed = true
-				}
-			case hasKey(mfjsSubschemaMapKeys, key):
-				childMap, ok := child.(map[string]interface{})
-				if !ok {
-					continue
-				}
-				for name, sub := range childMap {
-					coerced, c1 := coerceMFJSBooleanSubschema(sub)
-					walked, c2 := sanitizeMFJSSchemaNode(coerced)
-					if c1 || c2 {
-						childMap[name] = walked
-						changed = true
-					}
-				}
-			case hasKey(mfjsSubschemaArrayKeys, key):
-				childArr, ok := child.([]interface{})
-				if !ok {
-					continue
-				}
-				for i, sub := range childArr {
-					coerced, c1 := coerceMFJSBooleanSubschema(sub)
-					walked, c2 := sanitizeMFJSSchemaNode(coerced)
-					if c1 || c2 {
-						childArr[i] = walked
-						changed = true
-					}
-				}
-			case hasKey(mfjsSubschemaValueKeys, key):
-				coerced, c1 := coerceMFJSBooleanSubschema(child)
-				walked, c2 := sanitizeMFJSSchemaNode(coerced)
-				if c1 || c2 {
-					n[key] = walked
+	n, ok := node.(map[string]interface{})
+	if !ok {
+		return node, false
+	}
+	changed := false
+	for key, child := range n {
+		switch {
+		case hasKey(mfjsBooleanLegalKeys, key):
+			// Boolean is a native MFJS feature here; recurse only into an object
+			// subschema, never coerce the boolean itself.
+			if _, isBool := child.(bool); isBool {
+				continue
+			}
+			if walked, c := sanitizeMFJSSchemaNode(child); c {
+				n[key] = walked
+				changed = true
+			}
+		case hasKey(mfjsSubschemaMapKeys, key):
+			if childMap, ok := child.(map[string]interface{}); ok {
+				if sanitizeMFJSSubschemaMap(childMap) {
+					n[key] = childMap
 					changed = true
 				}
 			}
-			// Non-schema keywords (type, enum, const, description, required,
-			// default, ...) are intentionally left untouched: a boolean there is
-			// data, not a subschema.
+		case hasKey(mfjsSubschemaArrayKeys, key):
+			if childArr, ok := child.([]interface{}); ok {
+				if sanitizeMFJSSubschemaArray(childArr) {
+					n[key] = childArr
+					changed = true
+				}
+			}
+		case hasKey(mfjsSubschemaValueKeys, key):
+			// `items` (draft-04/07) may be a single subschema OR an array of
+			// subschemas (tuple validation); handle both.
+			if childArr, ok := child.([]interface{}); ok {
+				if sanitizeMFJSSubschemaArray(childArr) {
+					n[key] = childArr
+					changed = true
+				}
+				continue
+			}
+			coerced, c1 := coerceMFJSBooleanSubschema(child)
+			walked, c2 := sanitizeMFJSSchemaNode(coerced)
+			if c1 || c2 {
+				n[key] = walked
+				changed = true
+			}
 		}
-		return n, changed
-	default:
-		return node, false
+		// Non-schema keywords (type, enum, const, description, required,
+		// default, ...) are intentionally left untouched: a boolean there is
+		// data, not a subschema.
 	}
+	return n, changed
+}
+
+// sanitizeMFJSSubschemaMap coerces boolean subschemas in a name->subschema map
+// (properties, patternProperties, $defs, ...) in place. Returns whether it
+// changed anything.
+func sanitizeMFJSSubschemaMap(m map[string]interface{}) bool {
+	changed := false
+	for name, sub := range m {
+		coerced, c1 := coerceMFJSBooleanSubschema(sub)
+		walked, c2 := sanitizeMFJSSchemaNode(coerced)
+		if c1 || c2 {
+			m[name] = walked
+			changed = true
+		}
+	}
+	return changed
+}
+
+// sanitizeMFJSSubschemaArray coerces boolean subschemas in an array of
+// subschemas (anyOf/oneOf/allOf/prefixItems, or tuple `items`) in place.
+// Returns whether it changed anything.
+func sanitizeMFJSSubschemaArray(arr []interface{}) bool {
+	changed := false
+	for i, sub := range arr {
+		coerced, c1 := coerceMFJSBooleanSubschema(sub)
+		walked, c2 := sanitizeMFJSSchemaNode(coerced)
+		if c1 || c2 {
+			arr[i] = walked
+			changed = true
+		}
+	}
+	return changed
 }
 
 func hasKey(set map[string]struct{}, key string) bool {
@@ -616,7 +644,12 @@ func sanitizeKimiToolSchemas(body []byte) ([]byte, error) {
 			continue
 		}
 		var decoded interface{}
-		if err := json.Unmarshal([]byte(params.Raw), &decoded); err != nil {
+		dec := json.NewDecoder(strings.NewReader(params.Raw))
+		// UseNumber keeps numeric literals (const/enum/bounds, incl. values above
+		// 2^53) exact instead of round-tripping them through float64, so boolean
+		// coercion never silently rewrites unrelated numbers in the tool contract.
+		dec.UseNumber()
+		if err := dec.Decode(&decoded); err != nil {
 			continue
 		}
 		sanitized, changed := sanitizeMFJSSchemaNode(decoded)

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -270,3 +270,129 @@ func TestNormalizeKimiToolMessageLinks_PreservesAssistantWithToolLinkOrReasoning
 		t.Fatalf("messages.3.content.0.text = %q, want %q", got, " visible ")
 	}
 }
+
+func TestSanitizeKimiToolSchemas_CoercesBooleanSubschemaInProperties(t *testing.T) {
+	// Reproduces the real oh-my-pi `task` tool schema whose nested
+	// `outputSchema: true` boolean subschema makes Kimi 400 the whole turn with
+	// "tools.function.parameters is not a valid moonshot flavored json schema".
+	body := []byte(`{
+		"tools":[
+			{"type":"function","function":{"name":"task","parameters":{
+				"type":"object",
+				"properties":{
+					"tasks":{"type":"array","items":{
+						"type":"object",
+						"properties":{"task":{"type":"string"},"outputSchema":true},
+						"required":["task"]
+					}}
+				},
+				"required":["tasks"]
+			}}}
+		]
+	}`)
+
+	out, err := sanitizeKimiToolSchemas(body)
+	if err != nil {
+		t.Fatalf("sanitizeKimiToolSchemas() error = %v", err)
+	}
+
+	node := gjson.GetBytes(out, "tools.0.function.parameters.properties.tasks.items.properties.outputSchema")
+	if !node.IsObject() {
+		t.Fatalf("outputSchema should be coerced to an object, got %q", node.Raw)
+	}
+	if len(node.Map()) != 0 {
+		t.Fatalf("outputSchema `true` should coerce to `{}`, got %q", node.Raw)
+	}
+}
+
+func TestSanitizeKimiToolSchemas_CoercesFalseToNot(t *testing.T) {
+	body := []byte(`{
+		"tools":[
+			{"type":"function","function":{"name":"f","parameters":{
+				"type":"object",
+				"properties":{"blocked":false}
+			}}}
+		]
+	}`)
+
+	out, err := sanitizeKimiToolSchemas(body)
+	if err != nil {
+		t.Fatalf("sanitizeKimiToolSchemas() error = %v", err)
+	}
+
+	node := gjson.GetBytes(out, "tools.0.function.parameters.properties.blocked")
+	if !node.Get("not").IsObject() {
+		t.Fatalf("`false` subschema should coerce to {\"not\":{}}, got %q", node.Raw)
+	}
+}
+
+func TestSanitizeKimiToolSchemas_PreservesLegalBooleanKeywords(t *testing.T) {
+	// `additionalProperties: false` is native MFJS and must NOT be coerced.
+	body := []byte(`{
+		"tools":[
+			{"type":"function","function":{"name":"f","parameters":{
+				"type":"object",
+				"properties":{"name":{"type":"string"}},
+				"additionalProperties":false
+			}}}
+		]
+	}`)
+
+	out, err := sanitizeKimiToolSchemas(body)
+	if err != nil {
+		t.Fatalf("sanitizeKimiToolSchemas() error = %v", err)
+	}
+
+	node := gjson.GetBytes(out, "tools.0.function.parameters.additionalProperties")
+	if node.Type != gjson.False {
+		t.Fatalf("additionalProperties:false must stay a boolean, got %q", node.Raw)
+	}
+}
+
+func TestSanitizeKimiToolSchemas_CoercesBooleanInCombinatorsAndItems(t *testing.T) {
+	body := []byte(`{
+		"tools":[
+			{"type":"function","function":{"name":"f","parameters":{
+				"type":"object",
+				"properties":{
+					"a":{"anyOf":[true,{"type":"string"}]},
+					"b":{"type":"array","items":true}
+				}
+			}}}
+		]
+	}`)
+
+	out, err := sanitizeKimiToolSchemas(body)
+	if err != nil {
+		t.Fatalf("sanitizeKimiToolSchemas() error = %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "tools.0.function.parameters.properties.a.anyOf.0"); !got.IsObject() {
+		t.Fatalf("anyOf[0] boolean should be coerced to object, got %q", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.0.function.parameters.properties.b.items"); !got.IsObject() {
+		t.Fatalf("items boolean should be coerced to object, got %q", got.Raw)
+	}
+}
+
+func TestSanitizeKimiToolSchemas_NoToolsIsNoOp(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+	out, err := sanitizeKimiToolSchemas(body)
+	if err != nil {
+		t.Fatalf("sanitizeKimiToolSchemas() error = %v", err)
+	}
+	if string(out) != string(body) {
+		t.Fatalf("body without tools should be unchanged, got %s", string(out))
+	}
+}
+
+func TestSanitizeKimiToolSchemas_CleanSchemaUnchanged(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object","properties":{"x":{"type":"string"}}}}}]}`)
+	out, err := sanitizeKimiToolSchemas(body)
+	if err != nil {
+		t.Fatalf("sanitizeKimiToolSchemas() error = %v", err)
+	}
+	if string(out) != string(body) {
+		t.Fatalf("clean schema should be byte-identical, got %s", string(out))
+	}
+}

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -356,7 +356,8 @@ func TestSanitizeKimiToolSchemas_CoercesBooleanInCombinatorsAndItems(t *testing.
 				"type":"object",
 				"properties":{
 					"a":{"anyOf":[true,{"type":"string"}]},
-					"b":{"type":"array","items":true}
+					"b":{"type":"array","items":true},
+					"c":{"type":"array","items":[true,{"type":"string"}]}
 				}
 			}}}
 		]
@@ -372,6 +373,45 @@ func TestSanitizeKimiToolSchemas_CoercesBooleanInCombinatorsAndItems(t *testing.
 	}
 	if got := gjson.GetBytes(out, "tools.0.function.parameters.properties.b.items"); !got.IsObject() {
 		t.Fatalf("items boolean should be coerced to object, got %q", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.0.function.parameters.properties.c.items.0"); !got.IsObject() {
+		t.Fatalf("tuple items[0] boolean should be coerced to object, got %q", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.0.function.parameters.properties.c.items.1.type"); got.String() != "string" {
+		t.Fatalf("tuple items[1] should be preserved, got %q", got.Raw)
+	}
+}
+
+func TestSanitizeKimiToolSchemas_PreservesExactNumbersDuringCoercion(t *testing.T) {
+	// A boolean subschema forces a rewrite; unrelated numeric literals — incl.
+	// values above 2^53 — must survive the round-trip byte-exact rather than
+	// being rounded through float64.
+	body := []byte(`{
+		"tools":[
+			{"type":"function","function":{"name":"f","parameters":{
+				"type":"object",
+				"properties":{
+					"open":true,
+					"n":{"type":"integer","const":9007199254740993},
+					"m":{"type":"integer","enum":[9007199254740993,1]}
+				}
+			}}}
+		]
+	}`)
+
+	out, err := sanitizeKimiToolSchemas(body)
+	if err != nil {
+		t.Fatalf("sanitizeKimiToolSchemas() error = %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "tools.0.function.parameters.properties.open"); !got.IsObject() {
+		t.Fatalf("open `true` should be coerced to object, got %q", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.0.function.parameters.properties.n.const").Raw; got != "9007199254740993" {
+		t.Fatalf("const should stay exact, got %q", got)
+	}
+	if got := gjson.GetBytes(out, "tools.0.function.parameters.properties.m.enum.0").Raw; got != "9007199254740993" {
+		t.Fatalf("enum[0] should stay exact, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

Kimi/Moonshot validates `tools.function.parameters` against **Moonshot Flavored JSON Schema (MFJS)**, a stricter subset that rejects a bare JSON boolean in a subschema slot. Any OpenAI-compatible client whose tool schema carries a boolean subschema makes the upstream **400 the entire turn on the first request**:

```
tools.function.parameters is not a valid moonshot flavored json schema,
details: <At path 'properties.tasks.items.properties': property schema for 'outputSchema' must be an object>
```

A boolean subschema (`true` = accept anything, `false` = accept nothing) is **valid standard JSON Schema (draft-06+)**, so the client request is well-formed — but Kimi rejects it. The failure surfaces as an empty assistant turn with no visible cause, which is hard to diagnose.

Concrete trigger: the [oh-my-pi](https://github.com/can1357/oh-my-pi) `task` delegation tool emits `"outputSchema": true` nested inside its parameters. Selecting any Kimi model through CLIProxyAPI then 400s every turn.

## Fix

Add `sanitizeKimiToolSchemas`, run right after `normalizeKimiToolMessageLinks` on **both** the non-streaming (`Execute`) and streaming (`ExecuteStream`) paths — the single choke point every client route already passes through.

It walks each tool's parameters schema and coerces bare boolean subschemas found in **genuine subschema slots** to their object form:

- `true` → `{}`
- `false` → `{"not": {}}`

Slots walked: `properties`, `patternProperties`, `$defs`/`definitions`, `dependentSchemas`, `anyOf`/`oneOf`/`allOf`/`prefixItems`, `items`, `contains`, `propertyNames`, `if`/`then`/`else`, `not`, `contentSchema`.

Booleans that are **native MFJS features** (`additionalProperties`, `unevaluatedProperties`, `additionalItems`, `unevaluatedItems`) or **plain data** (enum values, `const`, `default`) are left untouched — MFJS accepts those.

The pass is a no-op for bodies without tools and byte-identical for schemas that carry no boolean subschema, so it costs nothing on the common path.

## Tests

`internal/runtime/executor/kimi_executor_test.go` adds coverage for:

- the real oh-my-pi `outputSchema: true` nested case → coerced to `{}`
- `false` → `{"not": {}}`
- `additionalProperties: false` preserved (native MFJS, not coerced)
- booleans inside `anyOf` and `items` coerced
- no-tools body is a no-op
- clean schema stays byte-identical

`go test ./internal/runtime/executor/` passes; `gofmt` clean; `go vet` clean.