### PR TITLE
优化 apply_patch 在 Chat 与 xAI 渠道的工具转换

### DIFF
--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -1692,11 +1692,12 @@ type xaiApplyPatchResponseAdapter struct {
 }
 
 func newXAIApplyPatchResponseAdapter(enabled bool) *xaiApplyPatchResponseAdapter {
-	return &xaiApplyPatchResponseAdapter{
-		enabled:   enabled,
-		itemIDs:   make(map[string]struct{}),
-		arguments: make(map[string]*strings.Builder),
+	adapter := &xaiApplyPatchResponseAdapter{enabled: enabled}
+	if enabled {
+		adapter.itemIDs = make(map[string]struct{})
+		adapter.arguments = make(map[string]*strings.Builder)
 	}
+	return adapter
 }
 
 func (a *xaiApplyPatchResponseAdapter) apply(data []byte) []byte {
@@ -1778,7 +1779,7 @@ func xaiApplyPatchInput(arguments gjson.Result) string {
 		return input.Raw
 	}
 	trimmed := strings.TrimSpace(raw)
-	if len(trimmed) > 1 && trimmed[0] == '"' && json.Valid([]byte(trimmed)) {
+	if len(trimmed) > 1 && trimmed[0] == '"' {
 		var decoded string
 		if err := json.Unmarshal([]byte(trimmed), &decoded); err == nil {
 			return decoded
@@ -1871,7 +1872,8 @@ func normalizeXAITool(tool gjson.Result, namespaceName string) ([]byte, bool, bo
 			return nil, false, false
 		}
 		raw = updatedTool
-		if !tool.Get("parameters").Exists() || strings.TrimSpace(tool.Get("name").String()) == "apply_patch" {
+		toolName := strings.TrimSpace(tool.Get("name").String())
+		if !tool.Get("parameters").Exists() || toolName == "apply_patch" {
 			updatedTool, errSet = sjson.SetRawBytes(raw, "parameters", []byte(`{"type":"object","properties":{"input":{"type":"string"}},"required":["input"],"additionalProperties":false}`))
 			if errSet != nil {
 				return nil, false, false
@@ -1882,7 +1884,7 @@ func normalizeXAITool(tool gjson.Result, namespaceName string) ([]byte, bool, bo
 		if errSet == nil {
 			raw = updatedTool
 		}
-		if strings.TrimSpace(tool.Get("name").String()) == "apply_patch" {
+		if toolName == "apply_patch" {
 			raw, _ = sjson.SetBytes(raw, "description", xaiApplyPatchToolDescription)
 			raw, _ = sjson.SetBytes(raw, "parameters.properties.input.description", xaiApplyPatchInputDescription(tool))
 			schemaTool = gjson.ParseBytes(raw)

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -46,6 +46,9 @@ const (
 	xaiToolSearchType          = "tool_search"
 	xaiWebSearchToolType       = "web_search"
 	xaiXSearchToolType         = "x_search"
+
+	xaiApplyPatchToolDescription  = "Apply file changes using an apply_patch document. Call this function with exactly one argument named `input`."
+	xaiApplyPatchInputDescription = "The complete decoded patch document, not nested JSON and not Markdown. It must start with `*** Begin Patch` and end with `*** End Patch`. Put no explanatory text or code fences around it. Use `*** Add File:`, `*** Update File:`, or `*** Delete File:` sections. Update hunks use `@@` and lines prefixed with space, `+`, or `-`.\n\nExample:\n*** Begin Patch\n*** Update File: app.py\n@@\n-old\n+new\n*** End Patch"
 	// Codex Desktop injects codex_app.automation_update with a large oneOf+$ref
 	// schema. xAI's free/build Responses path accepts the HTTP request but never
 	// emits SSE when that schema is present, so Desktop hangs on "thinking".
@@ -190,6 +193,7 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 	outputItemsByIndex := make(map[int64][]byte)
 	var outputItemsFallback [][]byte
 	responseFilter := newXAIInternalXSearchResponseFilter(prepared.filterInternalXSearch, prepared.clientDeclaredTools)
+	applyPatchAdapter := newXAIApplyPatchResponseAdapter(prepared.restoreApplyPatch)
 	for _, line := range bytes.Split(data, []byte("\n")) {
 		if !bytes.HasPrefix(line, xaiDataTag) {
 			continue
@@ -197,6 +201,7 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 		eventData := xaiNormalizeReasoningSummaryData(bytes.TrimSpace(line[len(xaiDataTag):]))
 		eventData = restoreXAINamespaceToolCalls(eventData, prepared.namespaceTools)
 		eventData = responseFilter.apply(eventData)
+		eventData = applyPatchAdapter.apply(eventData)
 		if len(eventData) == 0 {
 			continue
 		}
@@ -673,6 +678,7 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 		outputItemsByIndex := make(map[int64][]byte)
 		var outputItemsFallback [][]byte
 		responseFilter := newXAIInternalXSearchResponseFilter(prepared.filterInternalXSearch, prepared.clientDeclaredTools)
+		applyPatchAdapter := newXAIApplyPatchResponseAdapter(prepared.restoreApplyPatch)
 		var pendingEventLine []byte
 		emitTranslatedLine := func(translatedLine []byte) bool {
 			chunks := sdktranslator.TranslateStream(ctx, prepared.to, prepared.responseFormat, req.Model, prepared.originalPayload, prepared.body, translatedLine, &param)
@@ -703,6 +709,7 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 				for i, eventData := range eventDataList {
 					eventData = restoreXAINamespaceToolCalls(eventData, prepared.namespaceTools)
 					eventData = responseFilter.apply(eventData)
+					eventData = applyPatchAdapter.apply(eventData)
 					if len(eventData) == 0 {
 						if hasPendingEventLine && i == 0 {
 							pendingEventLine = nil
@@ -859,6 +866,7 @@ type xaiPreparedRequest struct {
 	sessionID             string
 	replayScope           xaiReasoningReplayScope
 	filterInternalXSearch bool
+	restoreApplyPatch     bool
 }
 
 type xaiNamespaceToolRef struct {
@@ -914,6 +922,7 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	// Collect before normalizeXAITools flattens namespace wrappers so keys match
 	// the post-restore (namespace, short-name) shape used by the response filter.
 	clientDeclaredTools := collectXAIClientDeclaredToolKeys(body)
+	restoreApplyPatch := xaiHasCustomApplyPatchTool(body)
 	body = normalizeXAITools(body)
 	// Drop choices that point at tools removed by normalizeXAITools before we
 	// inject native x_search, so a surviving allowed_tools / forced choice is not
@@ -955,6 +964,7 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 		sessionID:             sessionID,
 		replayScope:           replayScope,
 		filterInternalXSearch: xaiRequestHasNativeXSearch(body),
+		restoreApplyPatch:     restoreApplyPatch,
 	}, nil
 }
 
@@ -1615,6 +1625,136 @@ func normalizeXAIToolChoiceForTools(body []byte) []byte {
 	return body
 }
 
+func xaiHasCustomApplyPatchTool(body []byte) bool {
+	found := false
+	var collect func(gjson.Result)
+	collect = func(tools gjson.Result) {
+		if found || !tools.IsArray() {
+			return
+		}
+		for _, tool := range tools.Array() {
+			switch strings.TrimSpace(tool.Get("type").String()) {
+			case xaiCustomToolType:
+				if strings.TrimSpace(tool.Get("name").String()) == "apply_patch" {
+					found = true
+					return
+				}
+			case xaiNamespaceToolType:
+				collect(tool.Get("tools"))
+			}
+		}
+	}
+	collect(gjson.GetBytes(body, "tools"))
+	for _, item := range gjson.GetBytes(body, "input").Array() {
+		if item.Get("type").String() == "additional_tools" {
+			collect(item.Get("tools"))
+		}
+	}
+	return found
+}
+
+type xaiApplyPatchResponseAdapter struct {
+	enabled   bool
+	itemIDs   map[string]struct{}
+	arguments map[string]*strings.Builder
+}
+
+func newXAIApplyPatchResponseAdapter(enabled bool) *xaiApplyPatchResponseAdapter {
+	return &xaiApplyPatchResponseAdapter{
+		enabled:   enabled,
+		itemIDs:   make(map[string]struct{}),
+		arguments: make(map[string]*strings.Builder),
+	}
+}
+
+func (a *xaiApplyPatchResponseAdapter) apply(data []byte) []byte {
+	if a == nil || !a.enabled || len(data) == 0 || !gjson.ValidBytes(data) {
+		return data
+	}
+
+	eventType := gjson.GetBytes(data, "type").String()
+	if eventType == "response.output_item.added" || eventType == "response.output_item.done" {
+		item := gjson.GetBytes(data, "item")
+		if item.Get("type").String() == "function_call" && strings.TrimSpace(item.Get("name").String()) == "apply_patch" {
+			itemID := strings.TrimSpace(item.Get("id").String())
+			if itemID != "" {
+				a.itemIDs[itemID] = struct{}{}
+			}
+			data = xaiRestoreApplyPatchItemAtPath(data, "item", a.bufferedArguments(itemID, item.Get("arguments")))
+			return data
+		}
+	}
+
+	itemID := strings.TrimSpace(gjson.GetBytes(data, "item_id").String())
+	if _, ok := a.itemIDs[itemID]; ok {
+		switch eventType {
+		case "response.function_call_arguments.delta":
+			if delta := gjson.GetBytes(data, "delta").String(); delta != "" {
+				buf := a.arguments[itemID]
+				if buf == nil {
+					buf = &strings.Builder{}
+					a.arguments[itemID] = buf
+				}
+				buf.WriteString(delta)
+			}
+			return nil
+		case "response.function_call_arguments.done":
+			input := a.bufferedArguments(itemID, gjson.GetBytes(data, "arguments"))
+			data, _ = sjson.SetBytes(data, "type", "response.custom_tool_call_input.done")
+			data, _ = sjson.SetBytes(data, "input", input)
+			data, _ = sjson.DeleteBytes(data, "arguments")
+			return data
+		}
+	}
+
+	output := gjson.GetBytes(data, "response.output")
+	if output.IsArray() {
+		for index, item := range output.Array() {
+			if item.Get("type").String() != "function_call" || strings.TrimSpace(item.Get("name").String()) != "apply_patch" {
+				continue
+			}
+			path := fmt.Sprintf("response.output.%d", index)
+			data = xaiRestoreApplyPatchItemAtPath(data, path, xaiApplyPatchInput(item.Get("arguments")))
+		}
+	}
+	return data
+}
+
+func (a *xaiApplyPatchResponseAdapter) bufferedArguments(itemID string, arguments gjson.Result) string {
+	if arguments.Exists() && strings.TrimSpace(arguments.String()) != "" {
+		return xaiApplyPatchInput(arguments)
+	}
+	if buf := a.arguments[itemID]; buf != nil {
+		return xaiApplyPatchInput(gjson.Result{Type: gjson.String, Str: buf.String()})
+	}
+	return ""
+}
+
+func xaiRestoreApplyPatchItemAtPath(data []byte, path, input string) []byte {
+	data, _ = sjson.SetBytes(data, path+".type", "custom_tool_call")
+	data, _ = sjson.SetBytes(data, path+".input", input)
+	data, _ = sjson.DeleteBytes(data, path+".arguments")
+	return data
+}
+
+func xaiApplyPatchInput(arguments gjson.Result) string {
+	raw := arguments.String()
+	if input := gjson.Get(raw, "input"); input.Exists() {
+		if input.Type == gjson.String {
+			return input.String()
+		}
+		return input.Raw
+	}
+	trimmed := strings.TrimSpace(raw)
+	if len(trimmed) > 1 && trimmed[0] == '"' && json.Valid([]byte(trimmed)) {
+		var decoded string
+		if err := json.Unmarshal([]byte(trimmed), &decoded); err == nil {
+			return decoded
+		}
+	}
+	return raw
+}
+
 // normalizeXAINamespaceToolChoice qualifies namespaced function choices using
 // the same names sent in the flattened tools list. xAI does not accept the
 // Responses namespace field on tool choices.
@@ -1625,7 +1765,20 @@ func normalizeXAINamespaceToolChoice(body []byte) []byte {
 	original := body
 	normalizeAtPath := func(path string) bool {
 		toolChoice := gjson.GetBytes(body, path)
-		if !toolChoice.IsObject() || toolChoice.Get("type").String() != xaiFunctionToolType {
+		if !toolChoice.IsObject() {
+			return true
+		}
+		toolType := toolChoice.Get("type").String()
+		if toolType == xaiCustomToolType {
+			updated, errSet := sjson.SetBytes(body, path+".type", xaiFunctionToolType)
+			if errSet != nil {
+				return false
+			}
+			body = updated
+			toolChoice = gjson.GetBytes(body, path)
+			toolType = xaiFunctionToolType
+		}
+		if toolType != xaiFunctionToolType {
 			return true
 		}
 		namespaceName := strings.TrimSpace(toolChoice.Get("namespace").String())
@@ -1666,10 +1819,6 @@ func normalizeXAITool(tool gjson.Result, namespaceName string) ([]byte, bool, bo
 	if toolType == xaiToolSearchType || toolType == xaiImageGenerationToolType {
 		return nil, true, true
 	}
-	if toolType == xaiCustomToolType && tool.Get("name").String() == "apply_patch" {
-		return nil, true, true
-	}
-
 	raw := []byte(tool.Raw)
 	schemaTool := tool
 	if toolType == xaiFunctionToolType || toolType == xaiCustomToolType {
@@ -1690,6 +1839,22 @@ func normalizeXAITool(tool gjson.Result, namespaceName string) ([]byte, bool, bo
 			return nil, false, false
 		}
 		raw = updatedTool
+		if !tool.Get("parameters").Exists() || strings.TrimSpace(tool.Get("name").String()) == "apply_patch" {
+			updatedTool, errSet = sjson.SetRawBytes(raw, "parameters", []byte(`{"type":"object","properties":{"input":{"type":"string"}},"required":["input"],"additionalProperties":false}`))
+			if errSet != nil {
+				return nil, false, false
+			}
+			raw = updatedTool
+		}
+		updatedTool, errSet = sjson.DeleteBytes(raw, "format")
+		if errSet == nil {
+			raw = updatedTool
+		}
+		if strings.TrimSpace(tool.Get("name").String()) == "apply_patch" {
+			raw, _ = sjson.SetBytes(raw, "description", xaiApplyPatchToolDescription)
+			raw, _ = sjson.SetBytes(raw, "parameters.properties.input.description", xaiApplyPatchInputDescription)
+			schemaTool = gjson.ParseBytes(raw)
+		}
 		toolType = xaiFunctionToolType
 		changed = true
 	}

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -225,7 +225,7 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 	outputItemsByIndex := make(map[int64][]byte)
 	var outputItemsFallback [][]byte
 	responseFilter := newXAIInternalXSearchResponseFilter(prepared.filterInternalXSearch, prepared.clientDeclaredTools)
-	applyPatchAdapter := newXAIApplyPatchResponseAdapter(prepared.restoreApplyPatch)
+	applyPatchAdapter := newXAIApplyPatchResponseAdapter(prepared.applyPatchTools)
 	for _, line := range bytes.Split(data, []byte("\n")) {
 		if !bytes.HasPrefix(line, xaiDataTag) {
 			continue
@@ -710,7 +710,7 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 		outputItemsByIndex := make(map[int64][]byte)
 		var outputItemsFallback [][]byte
 		responseFilter := newXAIInternalXSearchResponseFilter(prepared.filterInternalXSearch, prepared.clientDeclaredTools)
-		applyPatchAdapter := newXAIApplyPatchResponseAdapter(prepared.restoreApplyPatch)
+		applyPatchAdapter := newXAIApplyPatchResponseAdapter(prepared.applyPatchTools)
 		var pendingEventLine []byte
 		emitTranslatedLine := func(translatedLine []byte) bool {
 			chunks := sdktranslator.TranslateStream(ctx, prepared.to, prepared.responseFormat, req.Model, prepared.originalPayload, prepared.body, translatedLine, &param)
@@ -898,7 +898,7 @@ type xaiPreparedRequest struct {
 	sessionID             string
 	replayScope           xaiReasoningReplayScope
 	filterInternalXSearch bool
-	restoreApplyPatch     bool
+	applyPatchTools       map[xaiApplyPatchToolKey]struct{}
 }
 
 type xaiNamespaceToolRef struct {
@@ -954,7 +954,7 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	// Collect before normalizeXAITools flattens namespace wrappers so keys match
 	// the post-restore (namespace, short-name) shape used by the response filter.
 	clientDeclaredTools := collectXAIClientDeclaredToolKeys(body)
-	restoreApplyPatch := xaiHasCustomApplyPatchTool(body)
+	applyPatchTools := collectXAICustomApplyPatchToolKeys(body)
 	body = normalizeXAITools(body)
 	// Drop choices that point at tools removed by normalizeXAITools before we
 	// inject native x_search, so a surviving allowed_tools / forced choice is not
@@ -996,7 +996,7 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 		sessionID:             sessionID,
 		replayScope:           replayScope,
 		filterInternalXSearch: xaiRequestHasNativeXSearch(body),
-		restoreApplyPatch:     restoreApplyPatch,
+		applyPatchTools:       applyPatchTools,
 	}, nil
 }
 
@@ -1657,43 +1657,47 @@ func normalizeXAIToolChoiceForTools(body []byte) []byte {
 	return body
 }
 
-func xaiHasCustomApplyPatchTool(body []byte) bool {
-	found := false
-	var collect func(gjson.Result)
-	collect = func(tools gjson.Result) {
-		if found || !tools.IsArray() {
+type xaiApplyPatchToolKey struct {
+	namespace string
+	name      string
+}
+
+func collectXAICustomApplyPatchToolKeys(body []byte) map[xaiApplyPatchToolKey]struct{} {
+	keys := make(map[xaiApplyPatchToolKey]struct{})
+	var collect func(gjson.Result, string)
+	collect = func(tools gjson.Result, namespace string) {
+		if !tools.IsArray() {
 			return
 		}
 		for _, tool := range tools.Array() {
 			switch strings.TrimSpace(tool.Get("type").String()) {
 			case xaiCustomToolType:
 				if strings.TrimSpace(tool.Get("name").String()) == "apply_patch" {
-					found = true
-					return
+					keys[xaiApplyPatchToolKey{namespace: namespace, name: "apply_patch"}] = struct{}{}
 				}
 			case xaiNamespaceToolType:
-				collect(tool.Get("tools"))
+				collect(tool.Get("tools"), strings.TrimSpace(tool.Get("name").String()))
 			}
 		}
 	}
-	collect(gjson.GetBytes(body, "tools"))
+	collect(gjson.GetBytes(body, "tools"), "")
 	for _, item := range gjson.GetBytes(body, "input").Array() {
 		if item.Get("type").String() == "additional_tools" {
-			collect(item.Get("tools"))
+			collect(item.Get("tools"), "")
 		}
 	}
-	return found
+	return keys
 }
 
 type xaiApplyPatchResponseAdapter struct {
-	enabled   bool
+	tools     map[xaiApplyPatchToolKey]struct{}
 	itemIDs   map[string]struct{}
 	arguments map[string]*strings.Builder
 }
 
-func newXAIApplyPatchResponseAdapter(enabled bool) *xaiApplyPatchResponseAdapter {
-	adapter := &xaiApplyPatchResponseAdapter{enabled: enabled}
-	if enabled {
+func newXAIApplyPatchResponseAdapter(tools map[xaiApplyPatchToolKey]struct{}) *xaiApplyPatchResponseAdapter {
+	adapter := &xaiApplyPatchResponseAdapter{tools: tools}
+	if len(tools) > 0 {
 		adapter.itemIDs = make(map[string]struct{})
 		adapter.arguments = make(map[string]*strings.Builder)
 	}
@@ -1701,14 +1705,14 @@ func newXAIApplyPatchResponseAdapter(enabled bool) *xaiApplyPatchResponseAdapter
 }
 
 func (a *xaiApplyPatchResponseAdapter) apply(data []byte) []byte {
-	if a == nil || !a.enabled || len(data) == 0 || !gjson.ValidBytes(data) {
+	if a == nil || len(a.tools) == 0 || len(data) == 0 || !gjson.ValidBytes(data) {
 		return data
 	}
 
 	eventType := gjson.GetBytes(data, "type").String()
 	if eventType == "response.output_item.added" || eventType == "response.output_item.done" {
 		item := gjson.GetBytes(data, "item")
-		if item.Get("type").String() == "function_call" && strings.TrimSpace(item.Get("name").String()) == "apply_patch" {
+		if a.matches(item) {
 			itemID := strings.TrimSpace(item.Get("id").String())
 			if itemID != "" {
 				a.itemIDs[itemID] = struct{}{}
@@ -1743,7 +1747,7 @@ func (a *xaiApplyPatchResponseAdapter) apply(data []byte) []byte {
 	output := gjson.GetBytes(data, "response.output")
 	if output.IsArray() {
 		for index, item := range output.Array() {
-			if item.Get("type").String() != "function_call" || strings.TrimSpace(item.Get("name").String()) != "apply_patch" {
+			if !a.matches(item) {
 				continue
 			}
 			path := fmt.Sprintf("response.output.%d", index)
@@ -1751,6 +1755,18 @@ func (a *xaiApplyPatchResponseAdapter) apply(data []byte) []byte {
 		}
 	}
 	return data
+}
+
+func (a *xaiApplyPatchResponseAdapter) matches(item gjson.Result) bool {
+	if item.Get("type").String() != "function_call" {
+		return false
+	}
+	key := xaiApplyPatchToolKey{
+		namespace: strings.TrimSpace(item.Get("namespace").String()),
+		name:      strings.TrimSpace(item.Get("name").String()),
+	}
+	_, ok := a.tools[key]
+	return ok
 }
 
 func (a *xaiApplyPatchResponseAdapter) bufferedArguments(itemID string, arguments gjson.Result) string {

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -47,8 +47,7 @@ const (
 	xaiWebSearchToolType       = "web_search"
 	xaiXSearchToolType         = "x_search"
 
-	xaiApplyPatchToolDescription  = "Apply file changes using an apply_patch document. Call this function with exactly one argument named `input`."
-	xaiApplyPatchInputDescription = "The complete decoded patch document, not nested JSON and not Markdown. It must start with `*** Begin Patch` and end with `*** End Patch`. Put no explanatory text or code fences around it. Use `*** Add File:`, `*** Update File:`, or `*** Delete File:` sections. Update hunks use `@@` and lines prefixed with space, `+`, or `-`.\n\nExample:\n*** Begin Patch\n*** Update File: app.py\n@@\n-old\n+new\n*** End Patch"
+	xaiApplyPatchToolDescription = "Apply file changes using an apply_patch document. Invoke this function with exactly one JSON argument object containing only `input`."
 	// Codex Desktop injects codex_app.automation_update with a large oneOf+$ref
 	// schema. xAI's free/build Responses path accepts the HTTP request but never
 	// emits SSE when that schema is present, so Desktop hangs on "thinking".
@@ -73,6 +72,39 @@ const (
 	// xaiUsingAPIAttr enables the official API path for non-media HTTP chat.
 	xaiUsingAPIAttr = "using_api"
 )
+
+const xaiApplyPatchFallbackLarkGrammar = `start: begin_patch hunk+ end_patch
+begin_patch: "*** Begin Patch" LF
+end_patch: "*** End Patch" LF?
+
+hunk: add_hunk | delete_hunk | update_hunk
+add_hunk: "*** Add File: " filename LF add_line+
+delete_hunk: "*** Delete File: " filename LF
+update_hunk: "*** Update File: " filename LF change_move? change?
+
+filename: /(.+)/
+add_line: "+" /(.*)/ LF -> line
+
+change_move: "*** Move to: " filename LF
+change: (change_context | change_line)+ eof_line?
+change_context: ("@@" | "@@ " /(.+)/) LF
+change_line: ("+" | "-" | " ") /(.*)/ LF
+eof_line: "*** End of File" LF
+
+%import common.LF`
+
+const xaiApplyPatchInputDescriptionPrefix = "The value of `input` must be the complete raw apply_patch document after JSON decoding. Do not put a JSON object, a second JSON-encoded string, Markdown code fences, or explanatory text inside `input`. The value must satisfy this Lark grammar:\n\n"
+
+func xaiApplyPatchInputDescription(tool gjson.Result) string {
+	definition := ""
+	if strings.EqualFold(strings.TrimSpace(tool.Get("format.syntax").String()), "lark") {
+		definition = strings.TrimSpace(tool.Get("format.definition").String())
+	}
+	if definition == "" {
+		definition = xaiApplyPatchFallbackLarkGrammar
+	}
+	return xaiApplyPatchInputDescriptionPrefix + definition
+}
 
 // Always inject native x_search when the client did not declare it so Grok can
 // run X Search server-side. Internal subtool traces are still filtered downstream
@@ -1852,7 +1884,7 @@ func normalizeXAITool(tool gjson.Result, namespaceName string) ([]byte, bool, bo
 		}
 		if strings.TrimSpace(tool.Get("name").String()) == "apply_patch" {
 			raw, _ = sjson.SetBytes(raw, "description", xaiApplyPatchToolDescription)
-			raw, _ = sjson.SetBytes(raw, "parameters.properties.input.description", xaiApplyPatchInputDescription)
+			raw, _ = sjson.SetBytes(raw, "parameters.properties.input.description", xaiApplyPatchInputDescription(tool))
 			schemaTool = gjson.ParseBytes(raw)
 		}
 		toolType = xaiFunctionToolType

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -1873,7 +1873,8 @@ func normalizeXAITool(tool gjson.Result, namespaceName string) ([]byte, bool, bo
 		}
 		raw = updatedTool
 		toolName := strings.TrimSpace(tool.Get("name").String())
-		if !tool.Get("parameters").Exists() || toolName == "apply_patch" {
+		wrappedCustomInput := !tool.Get("parameters").Exists() || toolName == "apply_patch"
+		if wrappedCustomInput {
 			updatedTool, errSet = sjson.SetRawBytes(raw, "parameters", []byte(`{"type":"object","properties":{"input":{"type":"string"}},"required":["input"],"additionalProperties":false}`))
 			if errSet != nil {
 				return nil, false, false
@@ -1887,6 +1888,8 @@ func normalizeXAITool(tool gjson.Result, namespaceName string) ([]byte, bool, bo
 		if toolName == "apply_patch" {
 			raw, _ = sjson.SetBytes(raw, "description", xaiApplyPatchToolDescription)
 			raw, _ = sjson.SetBytes(raw, "parameters.properties.input.description", xaiApplyPatchInputDescription(tool))
+		}
+		if wrappedCustomInput {
 			schemaTool = gjson.ParseBytes(raw)
 		}
 		toolType = xaiFunctionToolType

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -2957,6 +2957,25 @@ func TestNormalizeXAITools_WrapsApplyPatchCustomTool(t *testing.T) {
 	}
 }
 
+func TestNormalizeXAITools_WrapsCustomToolWithoutParameters(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"custom","name":"custom_lookup"}]}`)
+	out := normalizeXAITools(body)
+	tool := gjson.GetBytes(out, "tools.0")
+
+	if got := tool.Get("type").String(); got != xaiFunctionToolType {
+		t.Fatalf("custom tool type = %q, want function; body=%s", got, out)
+	}
+	if got := tool.Get("parameters.properties.input.type").String(); got != "string" {
+		t.Fatalf("custom tool input type = %q, want string; body=%s", got, out)
+	}
+	if got := tool.Get("parameters.required.0").String(); got != "input" {
+		t.Fatalf("custom tool required.0 = %q, want input; body=%s", got, out)
+	}
+	if tool.Get("parameters.additionalProperties").Type != gjson.False {
+		t.Fatalf("custom tool additionalProperties must be false; body=%s", out)
+	}
+}
+
 func TestNormalizeXAITools_ApplyPatchUsesFallbackGrammar(t *testing.T) {
 	body := []byte(`{"tools":[{"type":"custom","name":"apply_patch"}]}`)
 	out := normalizeXAITools(body)

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -132,12 +132,13 @@ func TestXAIExecutorExecuteShapesResponsesRequest(t *testing.T) {
 		t.Fatalf("input.2 exists, want consecutive reasoning item merged; body=%s", string(gotBody))
 	}
 	tools := gjson.GetBytes(gotBody, "tools").Array()
-	if len(tools) != 6 {
-		t.Fatalf("tools length = %d, want 6; body=%s", len(tools), string(gotBody))
+	if len(tools) != 7 {
+		t.Fatalf("tools length = %d, want 7; body=%s", len(tools), string(gotBody))
 	}
 	foundAutomationUpdate := false
 	foundNamespaceCustom := false
 	foundXSearch := false
+	foundApplyPatch := false
 	for i, tool := range tools {
 		toolType := tool.Get("type").String()
 		if toolType == "image_generation" {
@@ -153,7 +154,10 @@ func TestXAIExecutorExecuteShapesResponsesRequest(t *testing.T) {
 			t.Fatalf("tools.%d.parameters missing for xAI function tool; body=%s", i, string(gotBody))
 		}
 		if got := tool.Get("name").String(); got == "apply_patch" {
-			t.Fatalf("tools.%d.name = apply_patch, want removed; body=%s", i, string(gotBody))
+			foundApplyPatch = true
+			if tool.Get("parameters.properties.input.type").String() != "string" || tool.Get("parameters.additionalProperties").Type != gjson.False {
+				t.Fatalf("tools.%d apply_patch wrapper schema invalid; body=%s", i, string(gotBody))
+			}
 		}
 		switch tool.Get("name").String() {
 		case "codex_app__automation_update":
@@ -178,6 +182,9 @@ func TestXAIExecutorExecuteShapesResponsesRequest(t *testing.T) {
 	}
 	if !foundXSearch {
 		t.Fatalf("native x_search tool was not injected; body=%s", string(gotBody))
+	}
+	if !foundApplyPatch {
+		t.Fatalf("apply_patch function wrapper was not preserved; body=%s", string(gotBody))
 	}
 	if got := gjson.GetBytes(gotBody, "tool_choice.tools.0.name").String(); got != "codex_app__automation_update" {
 		t.Fatalf("tool_choice.tools.0.name = %q, want codex_app__automation_update; body=%s", got, string(gotBody))
@@ -1991,8 +1998,8 @@ func TestXAIExecutorExecuteStreamFiltersToolSearchTool(t *testing.T) {
 	}
 
 	tools := gjson.GetBytes(gotBody, "tools").Array()
-	if len(tools) != 6 {
-		t.Fatalf("tools length = %d, want 6; body=%s", len(tools), string(gotBody))
+	if len(tools) != 7 {
+		t.Fatalf("tools length = %d, want 7; body=%s", len(tools), string(gotBody))
 	}
 	if gjson.GetBytes(gotBody, "input.0.content").Exists() {
 		t.Fatalf("input.0.content exists, want removed; body=%s", string(gotBody))
@@ -2015,6 +2022,7 @@ func TestXAIExecutorExecuteStreamFiltersToolSearchTool(t *testing.T) {
 	foundAutomationUpdate := false
 	foundNamespaceCustom := false
 	foundXSearch := false
+	foundApplyPatch := false
 	for i, tool := range tools {
 		toolType := tool.Get("type").String()
 		if toolType == "image_generation" {
@@ -2027,7 +2035,10 @@ func TestXAIExecutorExecuteStreamFiltersToolSearchTool(t *testing.T) {
 			t.Fatalf("tools.%d.parameters missing for xAI function tool; body=%s", i, string(gotBody))
 		}
 		if got := tool.Get("name").String(); got == "apply_patch" {
-			t.Fatalf("tools.%d.name = apply_patch, want removed; body=%s", i, string(gotBody))
+			foundApplyPatch = true
+			if tool.Get("parameters.properties.input.type").String() != "string" || tool.Get("parameters.additionalProperties").Type != gjson.False {
+				t.Fatalf("tools.%d apply_patch wrapper schema invalid; body=%s", i, string(gotBody))
+			}
 		}
 		switch tool.Get("name").String() {
 		case "codex_app__automation_update":
@@ -2055,6 +2066,9 @@ func TestXAIExecutorExecuteStreamFiltersToolSearchTool(t *testing.T) {
 	}
 	if !foundXSearch {
 		t.Fatalf("native x_search tool was not injected; body=%s", string(gotBody))
+	}
+	if !foundApplyPatch {
+		t.Fatalf("apply_patch function wrapper was not preserved; body=%s", string(gotBody))
 	}
 }
 
@@ -2904,6 +2918,81 @@ func TestNormalizeXAITools_QualifiesSameNamedNamespaceTools(t *testing.T) {
 	}
 	if got := tools[1].Get("name").String(); got != "mcp__docs__search" {
 		t.Fatalf("tools.1.name = %q, want mcp__docs__search; body=%s", got, string(out))
+	}
+}
+
+func TestNormalizeXAITools_WrapsApplyPatchCustomTool(t *testing.T) {
+	body := []byte(`{
+		"tools":[{
+			"type":"custom",
+			"name":"apply_patch",
+			"format":{"type":"grammar","syntax":"lark","definition":"start: patch"}
+		}],
+		"tool_choice":{"type":"custom","name":"apply_patch"}
+	}`)
+
+	out := normalizeXAITools(body)
+	out = normalizeXAINamespaceToolChoice(out)
+	tool := gjson.GetBytes(out, "tools.0")
+	if got := tool.Get("type").String(); got != "function" {
+		t.Fatalf("apply_patch type = %q, want function; body=%s", got, out)
+	}
+	if got := tool.Get("parameters.properties.input.type").String(); got != "string" {
+		t.Fatalf("apply_patch input type = %q, want string; body=%s", got, out)
+	}
+	if tool.Get("parameters.additionalProperties").Type != gjson.False {
+		t.Fatalf("apply_patch additionalProperties must be false; body=%s", out)
+	}
+	if tool.Get("format").Exists() {
+		t.Fatalf("apply_patch grammar leaked upstream; body=%s", out)
+	}
+	inputDescription := tool.Get("parameters.properties.input.description").String()
+	for _, want := range []string{"*** Add File:", "*** Update File:", "*** Delete File:", "Example:"} {
+		if !strings.Contains(inputDescription, want) {
+			t.Fatalf("apply_patch input description missing %q; body=%s", want, out)
+		}
+	}
+	if got := gjson.GetBytes(out, "tool_choice.type").String(); got != "function" {
+		t.Fatalf("tool_choice.type = %q, want function; body=%s", got, out)
+	}
+}
+
+func TestXAIApplyPatchResponseAdapterRestoresCustomCall(t *testing.T) {
+	adapter := newXAIApplyPatchResponseAdapter(true)
+
+	added := adapter.apply([]byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_patch","type":"function_call","call_id":"call_patch","name":"apply_patch","arguments":""}}`))
+	if got := gjson.GetBytes(added, "item.type").String(); got != "custom_tool_call" {
+		t.Fatalf("added item type = %q, want custom_tool_call; event=%s", got, added)
+	}
+
+	delta := adapter.apply([]byte(`{"type":"response.function_call_arguments.delta","item_id":"fc_patch","output_index":0,"delta":"{\"input\":\"*** Begin Patch\\n"}`))
+	if delta != nil {
+		t.Fatalf("custom tool argument delta should be buffered, got=%s", delta)
+	}
+	delta = adapter.apply([]byte(`{"type":"response.function_call_arguments.delta","item_id":"fc_patch","output_index":0,"delta":"*** End Patch\"}"}`))
+	if delta != nil {
+		t.Fatalf("custom tool argument delta should be buffered, got=%s", delta)
+	}
+
+	inputDone := adapter.apply([]byte(`{"type":"response.function_call_arguments.done","item_id":"fc_patch","output_index":0,"arguments":"{\"input\":\"*** Begin Patch\\n*** End Patch\"}"}`))
+	if got := gjson.GetBytes(inputDone, "type").String(); got != "response.custom_tool_call_input.done" {
+		t.Fatalf("done event type = %q; event=%s", got, inputDone)
+	}
+	if got := gjson.GetBytes(inputDone, "input").String(); got != "*** Begin Patch\n*** End Patch" {
+		t.Fatalf("done input = %q; event=%s", got, inputDone)
+	}
+
+	itemDone := adapter.apply([]byte(`{"type":"response.output_item.done","output_index":0,"item":{"id":"fc_patch","type":"function_call","call_id":"call_patch","name":"apply_patch","arguments":"{\"input\":\"*** Begin Patch\\n*** End Patch\"}","status":"completed"}}`))
+	if got := gjson.GetBytes(itemDone, "item.type").String(); got != "custom_tool_call" {
+		t.Fatalf("item done type = %q; event=%s", got, itemDone)
+	}
+	if got := gjson.GetBytes(itemDone, "item.input").String(); got != "*** Begin Patch\n*** End Patch" {
+		t.Fatalf("item done input = %q; event=%s", got, itemDone)
+	}
+
+	completed := adapter.apply([]byte(`{"type":"response.completed","response":{"output":[{"id":"fc_patch","type":"function_call","call_id":"call_patch","name":"apply_patch","arguments":"{\"input\":\"*** Begin Patch\\n*** End Patch\"}"}]}}`))
+	if got := gjson.GetBytes(completed, "response.output.0.type").String(); got != "custom_tool_call" {
+		t.Fatalf("completed item type = %q; event=%s", got, completed)
 	}
 }
 

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -2926,7 +2926,7 @@ func TestNormalizeXAITools_WrapsApplyPatchCustomTool(t *testing.T) {
 		"tools":[{
 			"type":"custom",
 			"name":"apply_patch",
-			"format":{"type":"grammar","syntax":"lark","definition":"start: patch"}
+			"format":{"type":"grammar","syntax":"lark","definition":"start: begin_patch hunk+ end_patch\nchange_move: \"*** Move to: \" filename LF\neof_line: \"*** End of File\" LF"}
 		}],
 		"tool_choice":{"type":"custom","name":"apply_patch"}
 	}`)
@@ -2947,13 +2947,24 @@ func TestNormalizeXAITools_WrapsApplyPatchCustomTool(t *testing.T) {
 		t.Fatalf("apply_patch grammar leaked upstream; body=%s", out)
 	}
 	inputDescription := tool.Get("parameters.properties.input.description").String()
-	for _, want := range []string{"*** Add File:", "*** Update File:", "*** Delete File:", "Example:"} {
+	for _, want := range []string{"after JSON decoding", "start: begin_patch hunk+ end_patch", "*** Move to:", "*** End of File"} {
 		if !strings.Contains(inputDescription, want) {
 			t.Fatalf("apply_patch input description missing %q; body=%s", want, out)
 		}
 	}
 	if got := gjson.GetBytes(out, "tool_choice.type").String(); got != "function" {
 		t.Fatalf("tool_choice.type = %q, want function; body=%s", got, out)
+	}
+}
+
+func TestNormalizeXAITools_ApplyPatchUsesFallbackGrammar(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"custom","name":"apply_patch"}]}`)
+	out := normalizeXAITools(body)
+	description := gjson.GetBytes(out, "tools.0.parameters.properties.input.description").String()
+	for _, want := range []string{"start: begin_patch hunk+ end_patch", "add_line+", "change_move?", "eof_line?", "%import common.LF"} {
+		if !strings.Contains(description, want) {
+			t.Fatalf("fallback apply_patch grammar missing %q: %q", want, description)
+		}
 	}
 }
 

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -2988,7 +2988,9 @@ func TestNormalizeXAITools_ApplyPatchUsesFallbackGrammar(t *testing.T) {
 }
 
 func TestXAIApplyPatchResponseAdapterRestoresCustomCall(t *testing.T) {
-	adapter := newXAIApplyPatchResponseAdapter(true)
+	adapter := newXAIApplyPatchResponseAdapter(map[xaiApplyPatchToolKey]struct{}{
+		{namespace: "", name: "apply_patch"}: {},
+	})
 
 	added := adapter.apply([]byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_patch","type":"function_call","call_id":"call_patch","name":"apply_patch","arguments":""}}`))
 	if got := gjson.GetBytes(added, "item.type").String(); got != "custom_tool_call" {
@@ -3023,6 +3025,53 @@ func TestXAIApplyPatchResponseAdapterRestoresCustomCall(t *testing.T) {
 	completed := adapter.apply([]byte(`{"type":"response.completed","response":{"output":[{"id":"fc_patch","type":"function_call","call_id":"call_patch","name":"apply_patch","arguments":"{\"input\":\"*** Begin Patch\\n*** End Patch\"}"}]}}`))
 	if got := gjson.GetBytes(completed, "response.output.0.type").String(); got != "custom_tool_call" {
 		t.Fatalf("completed item type = %q; event=%s", got, completed)
+	}
+}
+
+func TestXAIApplyPatchResponseAdapterPreservesNamespacedFunctionWithSameShortName(t *testing.T) {
+	request := []byte(`{
+		"tools":[
+			{"type":"custom","name":"apply_patch"},
+			{"type":"namespace","name":"terminal","tools":[{"type":"function","name":"apply_patch","parameters":{"type":"object"}}]}
+		]
+	}`)
+	adapter := newXAIApplyPatchResponseAdapter(collectXAICustomApplyPatchToolKeys(request))
+	refs := collectXAINamespaceToolRefs(request)
+	event := []byte(`{"type":"response.output_item.done","item":{"id":"fc_namespaced","type":"function_call","name":"terminal__apply_patch","arguments":"{\"path\":\"file.txt\"}"}}`)
+
+	event = restoreXAINamespaceToolCalls(event, refs)
+	event = adapter.apply(event)
+	item := gjson.GetBytes(event, "item")
+	if got := item.Get("type").String(); got != "function_call" {
+		t.Fatalf("namespaced apply_patch type = %q, want function_call; event=%s", got, event)
+	}
+	if got := item.Get("namespace").String(); got != "terminal" {
+		t.Fatalf("namespaced apply_patch namespace = %q, want terminal; event=%s", got, event)
+	}
+	if got := gjson.Get(item.Get("arguments").String(), "path").String(); got != "file.txt" {
+		t.Fatalf("namespaced apply_patch arguments.path = %q, want file.txt; event=%s", got, event)
+	}
+}
+
+func TestXAIApplyPatchResponseAdapterRestoresNamespacedCustomCall(t *testing.T) {
+	request := []byte(`{
+		"tools":[{"type":"namespace","name":"editor","tools":[{"type":"custom","name":"apply_patch"}]}]
+	}`)
+	adapter := newXAIApplyPatchResponseAdapter(collectXAICustomApplyPatchToolKeys(request))
+	refs := collectXAINamespaceToolRefs(request)
+	event := []byte(`{"type":"response.output_item.done","item":{"id":"fc_namespaced_custom","type":"function_call","name":"editor__apply_patch","arguments":"{\"input\":\"*** Begin Patch\\n*** End Patch\"}"}}`)
+
+	event = restoreXAINamespaceToolCalls(event, refs)
+	event = adapter.apply(event)
+	item := gjson.GetBytes(event, "item")
+	if got := item.Get("type").String(); got != "custom_tool_call" {
+		t.Fatalf("namespaced custom apply_patch type = %q, want custom_tool_call; event=%s", got, event)
+	}
+	if got := item.Get("namespace").String(); got != "editor" {
+		t.Fatalf("namespaced custom apply_patch namespace = %q, want editor; event=%s", got, event)
+	}
+	if got := item.Get("input").String(); got != "*** Begin Patch\n*** End Patch" {
+		t.Fatalf("namespaced custom apply_patch input = %q; event=%s", got, event)
 	}
 }
 

--- a/internal/runtime/executor/xai_websockets_executor.go
+++ b/internal/runtime/executor/xai_websockets_executor.go
@@ -583,6 +583,7 @@ func (e *XAIWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliprox
 		outputItemsByIndex := make(map[int64][]byte)
 		var outputItemsFallback [][]byte
 		responseFilter := newXAIInternalXSearchResponseFilter(prepared.filterInternalXSearch, prepared.clientDeclaredTools)
+		applyPatchAdapter := newXAIApplyPatchResponseAdapter(prepared.restoreApplyPatch)
 		recordedTranscript := false
 		for {
 			if ctx != nil && ctx.Err() != nil {
@@ -644,6 +645,7 @@ func (e *XAIWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliprox
 			for _, payload := range xaiNormalizeReasoningSummaryDataEvents(payload) {
 				payload = restoreXAINamespaceToolCalls(payload, prepared.namespaceTools)
 				payload = responseFilter.apply(payload)
+				payload = applyPatchAdapter.apply(payload)
 				if len(payload) == 0 {
 					continue
 				}

--- a/internal/runtime/executor/xai_websockets_executor.go
+++ b/internal/runtime/executor/xai_websockets_executor.go
@@ -583,7 +583,7 @@ func (e *XAIWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliprox
 		outputItemsByIndex := make(map[int64][]byte)
 		var outputItemsFallback [][]byte
 		responseFilter := newXAIInternalXSearchResponseFilter(prepared.filterInternalXSearch, prepared.clientDeclaredTools)
-		applyPatchAdapter := newXAIApplyPatchResponseAdapter(prepared.restoreApplyPatch)
+		applyPatchAdapter := newXAIApplyPatchResponseAdapter(prepared.applyPatchTools)
 		recordedTranscript := false
 		for {
 			if ctx != nil && ctx.Err() != nil {

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -338,6 +338,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 	if toolChoice := root.Get("tool_choice"); toolChoice.Exists() {
 		if toolChoice.IsObject() && toolChoice.Get("type").String() == "custom" {
 			name := strings.TrimSpace(toolChoice.Get("name").String())
+			name = qualifyResponsesNamespaceToolName(strings.TrimSpace(toolChoice.Get("namespace").String()), name)
 			if name != "" {
 				convertedChoice := []byte(`{"type":"function","function":{"name":""}}`)
 				convertedChoice, _ = sjson.SetBytes(convertedChoice, "function.name", name)

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -336,7 +336,16 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 
 	// Convert tool_choice if present
 	if toolChoice := root.Get("tool_choice"); toolChoice.Exists() {
-		out, _ = sjson.SetRawBytes(out, "tool_choice", []byte(toolChoice.Raw))
+		if toolChoice.IsObject() && toolChoice.Get("type").String() == "custom" {
+			name := strings.TrimSpace(toolChoice.Get("name").String())
+			if name != "" {
+				convertedChoice := []byte(`{"type":"function","function":{"name":""}}`)
+				convertedChoice, _ = sjson.SetBytes(convertedChoice, "function.name", name)
+				out, _ = sjson.SetRawBytes(out, "tool_choice", convertedChoice)
+			}
+		} else {
+			out, _ = sjson.SetRawBytes(out, "tool_choice", []byte(toolChoice.Raw))
+		}
 	}
 
 	return out

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
@@ -338,7 +338,7 @@ func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_OptimizesApplyPatc
 			"type":"custom",
 			"name":"apply_patch",
 			"description":"original description",
-			"format":{"type":"grammar","syntax":"lark","definition":"start: patch"}
+			"format":{"type":"grammar","syntax":"lark","definition":"start: begin_patch hunk+ end_patch\nchange_move: \"*** Move to: \" filename LF\neof_line: \"*** End of File\" LF"}
 		}]
 	}`)
 
@@ -353,11 +353,25 @@ func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_OptimizesApplyPatc
 	if !tool.Get("parameters.additionalProperties").Exists() || tool.Get("parameters.additionalProperties").Bool() {
 		t.Fatalf("additionalProperties must be false; output=%s", out)
 	}
-	if description := tool.Get("parameters.properties.input.description").String(); !strings.Contains(description, "*** Begin Patch") || !strings.Contains(description, "*** End Patch") {
-		t.Fatalf("apply_patch input description missing patch boundaries: %q", description)
+	description := tool.Get("parameters.properties.input.description").String()
+	for _, want := range []string{"after JSON decoding", "start: begin_patch hunk+ end_patch", "*** Move to:", "*** End of File"} {
+		if !strings.Contains(description, want) {
+			t.Fatalf("apply_patch input description missing %q: %q", want, description)
+		}
 	}
 	if tool.Get("format").Exists() {
 		t.Fatalf("custom grammar must not leak into Chat Completions tool: %s", out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_ApplyPatchUsesFallbackGrammar(t *testing.T) {
+	raw := []byte(`{"tools":[{"type":"custom","name":"apply_patch"}]}`)
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("gpt-5.4", raw, false)
+	description := gjson.GetBytes(out, "tools.0.function.parameters.properties.input.description").String()
+	for _, want := range []string{"start: begin_patch hunk+ end_patch", "add_line+", "change_move?", "eof_line?", "%import common.LF"} {
+		if !strings.Contains(description, want) {
+			t.Fatalf("fallback apply_patch grammar missing %q: %q", want, description)
+		}
 	}
 }
 

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
@@ -412,6 +412,25 @@ func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_ConvertsCustomTool
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_QualifiesNamespacedCustomToolChoice(t *testing.T) {
+	raw := []byte(`{
+		"tools":[{
+			"type":"namespace",
+			"name":"terminal",
+			"tools":[{"type":"custom","name":"exec"}]
+		}],
+		"tool_choice":{"type":"custom","namespace":"terminal","name":"exec"}
+	}`)
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("gpt-5.4", raw, false)
+
+	if got := gjson.GetBytes(out, "tools.0.function.name").String(); got != "terminal__exec" {
+		t.Fatalf("tools.0.function.name = %q, want terminal__exec; output=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "tool_choice.function.name").String(); got != "terminal__exec" {
+		t.Fatalf("tool_choice.function.name = %q, want terminal__exec; output=%s", got, out)
+	}
+}
+
 func TestUnwrapCustomToolInputCompatibility(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
@@ -3,6 +3,7 @@ package responses
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -331,6 +332,35 @@ func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_FlattensNamespaceC
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_OptimizesApplyPatchCustomTool(t *testing.T) {
+	raw := []byte(`{
+		"tools":[{
+			"type":"custom",
+			"name":"apply_patch",
+			"description":"original description",
+			"format":{"type":"grammar","syntax":"lark","definition":"start: patch"}
+		}]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("gpt-5.4", raw, false)
+	tool := gjson.GetBytes(out, "tools.0.function")
+	if got := tool.Get("name").String(); got != "apply_patch" {
+		t.Fatalf("tool name = %q, want apply_patch; output=%s", got, out)
+	}
+	if got := tool.Get("parameters.properties.input.type").String(); got != "string" {
+		t.Fatalf("input type = %q, want string; output=%s", got, out)
+	}
+	if !tool.Get("parameters.additionalProperties").Exists() || tool.Get("parameters.additionalProperties").Bool() {
+		t.Fatalf("additionalProperties must be false; output=%s", out)
+	}
+	if description := tool.Get("parameters.properties.input.description").String(); !strings.Contains(description, "*** Begin Patch") || !strings.Contains(description, "*** End Patch") {
+		t.Fatalf("apply_patch input description missing patch boundaries: %q", description)
+	}
+	if tool.Get("format").Exists() {
+		t.Fatalf("custom grammar must not leak into Chat Completions tool: %s", out)
+	}
+}
+
 func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_PreservesStructuredToolChoice(t *testing.T) {
 	raw := []byte(`{
 		"input": [
@@ -353,6 +383,37 @@ func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_PreservesStructure
 	}
 	if got := gjson.GetBytes(out, "tool_choice.function.name").String(); got != "run_command" {
 		t.Fatalf("tool_choice.function.name = %q, want run_command; output=%s", got, out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_ConvertsCustomToolChoice(t *testing.T) {
+	raw := []byte(`{"tool_choice":{"type":"custom","name":"apply_patch"}}`)
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("gpt-5.4", raw, false)
+
+	if got := gjson.GetBytes(out, "tool_choice.type").String(); got != "function" {
+		t.Fatalf("tool_choice.type = %q, want function; output=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "tool_choice.function.name").String(); got != "apply_patch" {
+		t.Fatalf("tool_choice.function.name = %q, want apply_patch; output=%s", got, out)
+	}
+}
+
+func TestUnwrapCustomToolInputCompatibility(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "wrapped object", in: `{"input":"*** Begin Patch\n*** End Patch"}`, want: "*** Begin Patch\n*** End Patch"},
+		{name: "encoded string", in: `"*** Begin Patch\n*** End Patch"`, want: "*** Begin Patch\n*** End Patch"},
+		{name: "raw input", in: "*** Begin Patch\n*** End Patch", want: "*** Begin Patch\n*** End Patch"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := unwrapCustomToolInput(tt.in); got != tt.want {
+				t.Fatalf("unwrapCustomToolInput() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
@@ -364,6 +364,62 @@ func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_OptimizesApplyPatc
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_OptimizesNamespacedApplyPatchCustomTool(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{
+			name: "top-level tools",
+			raw: []byte(`{
+				"tools":[{
+					"type":"namespace",
+					"name":"editor",
+					"tools":[{
+						"type":"custom",
+						"name":"apply_patch",
+						"format":{"type":"grammar","syntax":"lark","definition":"start: namespaced_apply_patch"}
+					}]
+				}]
+			}`),
+		},
+		{
+			name: "additional tools",
+			raw: []byte(`{
+				"input":[{
+					"type":"additional_tools",
+					"tools":[{
+						"type":"namespace",
+						"name":"editor",
+						"tools":[{
+							"type":"custom",
+							"name":"apply_patch",
+							"format":{"type":"grammar","syntax":"lark","definition":"start: namespaced_apply_patch"}
+						}]
+					}]
+				}]
+			}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("gpt-5.4", tt.raw, false)
+			tool := gjson.GetBytes(out, "tools.0.function")
+			if got := tool.Get("name").String(); got != "editor__apply_patch" {
+				t.Fatalf("tool name = %q, want editor__apply_patch; output=%s", got, out)
+			}
+			if got := tool.Get("description").String(); got != applyPatchCompatibilityDescription {
+				t.Fatalf("tool description = %q, want apply_patch compatibility description; output=%s", got, out)
+			}
+			inputDescription := tool.Get("parameters.properties.input.description").String()
+			if !strings.Contains(inputDescription, "start: namespaced_apply_patch") {
+				t.Fatalf("namespaced apply_patch grammar missing from input description: %q", inputDescription)
+			}
+		})
+	}
+}
+
 func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_ApplyPatchUsesFallbackGrammar(t *testing.T) {
 	raw := []byte(`{"tools":[{"type":"custom","name":"apply_patch"}]}`)
 	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("gpt-5.4", raw, false)

--- a/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
@@ -272,7 +272,7 @@ func unwrapCustomToolInput(arguments string) string {
 		return v.Raw
 	}
 	trimmed := strings.TrimSpace(arguments)
-	if len(trimmed) > 1 && trimmed[0] == '"' && json.Valid([]byte(trimmed)) {
+	if len(trimmed) > 1 && trimmed[0] == '"' {
 		var decoded string
 		if err := json.Unmarshal([]byte(trimmed), &decoded); err == nil {
 			return decoded

--- a/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
@@ -1,11 +1,18 @@
 package responses
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
+
+const applyPatchToolName = "apply_patch"
+
+const applyPatchCompatibilityDescription = "Chat Completions compatibility wrapper for the free-form apply_patch tool. Call this function with exactly one argument named `input`."
+
+const applyPatchInputDescription = "The complete decoded patch document, not JSON and not Markdown. It must start with `*** Begin Patch` and end with `*** End Patch`. Put no explanatory text or code fences around it. Use `*** Add File:`, `*** Update File:`, or `*** Delete File:` sections. Update hunks use `@@` and lines prefixed with space, `+`, or `-`.\n\nExample:\n*** Begin Patch\n*** Update File: app.py\n@@\n-old\n+new\n*** End Patch"
 
 func convertResponsesToolToOpenAIChatTools(tool gjson.Result) [][]byte {
 	toolType := strings.TrimSpace(tool.Get("type").String())
@@ -37,9 +44,12 @@ func convertResponsesCustomToolToOpenAIChat(tool gjson.Result, overrideName stri
 	if name == "" {
 		return nil, false
 	}
-	chatTool := []byte(`{"type":"function","function":{"name":"","description":"","parameters":{"type":"object","properties":{"input":{"type":"string"}},"required":["input"]}}}`)
+	chatTool := []byte(`{"type":"function","function":{"name":"","description":"","parameters":{"type":"object","properties":{"input":{"type":"string"}},"required":["input"],"additionalProperties":false}}`)
 	chatTool, _ = sjson.SetBytes(chatTool, "function.name", name)
-	if description := responsesToolDescription(tool); description != "" {
+	if name == applyPatchToolName {
+		chatTool, _ = sjson.SetBytes(chatTool, "function.description", applyPatchCompatibilityDescription)
+		chatTool, _ = sjson.SetBytes(chatTool, "function.parameters.properties.input.description", applyPatchInputDescription)
+	} else if description := responsesToolDescription(tool); description != "" {
 		chatTool, _ = sjson.SetBytes(chatTool, "function.description", description)
 	}
 	return chatTool, true
@@ -229,6 +239,13 @@ func unwrapCustomToolInput(arguments string) string {
 			return v.String()
 		}
 		return v.Raw
+	}
+	trimmed := strings.TrimSpace(arguments)
+	if len(trimmed) > 1 && trimmed[0] == '"' && json.Valid([]byte(trimmed)) {
+		var decoded string
+		if err := json.Unmarshal([]byte(trimmed), &decoded); err == nil {
+			return decoded
+		}
 	}
 	return arguments
 }

--- a/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
@@ -68,16 +68,17 @@ func convertResponsesToolToOpenAIChatTools(tool gjson.Result) [][]byte {
 // tool onto a Chat Completions function tool with a single freeform "input"
 // string, mirroring the function-based shape Codex uses for apply_patch.
 func convertResponsesCustomToolToOpenAIChat(tool gjson.Result, overrideName string) ([]byte, bool) {
+	sourceName := responsesToolName(tool)
 	name := strings.TrimSpace(overrideName)
 	if name == "" {
-		name = responsesToolName(tool)
+		name = sourceName
 	}
 	if name == "" {
 		return nil, false
 	}
 	chatTool := []byte(`{"type":"function","function":{"name":"","description":"","parameters":{"type":"object","properties":{"input":{"type":"string"}},"required":["input"],"additionalProperties":false}}`)
 	chatTool, _ = sjson.SetBytes(chatTool, "function.name", name)
-	if name == applyPatchToolName {
+	if sourceName == applyPatchToolName {
 		chatTool, _ = sjson.SetBytes(chatTool, "function.description", applyPatchCompatibilityDescription)
 		chatTool, _ = sjson.SetBytes(chatTool, "function.parameters.properties.input.description", applyPatchInputDescription(tool))
 	} else if description := responsesToolDescription(tool); description != "" {

--- a/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
@@ -10,9 +10,40 @@ import (
 
 const applyPatchToolName = "apply_patch"
 
-const applyPatchCompatibilityDescription = "Chat Completions compatibility wrapper for the free-form apply_patch tool. Call this function with exactly one argument named `input`."
+const applyPatchCompatibilityDescription = "Chat Completions compatibility wrapper for the free-form apply_patch tool. Invoke it with exactly one JSON argument object containing only `input`."
 
-const applyPatchInputDescription = "The complete decoded patch document, not JSON and not Markdown. It must start with `*** Begin Patch` and end with `*** End Patch`. Put no explanatory text or code fences around it. Use `*** Add File:`, `*** Update File:`, or `*** Delete File:` sections. Update hunks use `@@` and lines prefixed with space, `+`, or `-`.\n\nExample:\n*** Begin Patch\n*** Update File: app.py\n@@\n-old\n+new\n*** End Patch"
+const applyPatchFallbackLarkGrammar = `start: begin_patch hunk+ end_patch
+begin_patch: "*** Begin Patch" LF
+end_patch: "*** End Patch" LF?
+
+hunk: add_hunk | delete_hunk | update_hunk
+add_hunk: "*** Add File: " filename LF add_line+
+delete_hunk: "*** Delete File: " filename LF
+update_hunk: "*** Update File: " filename LF change_move? change?
+
+filename: /(.+)/
+add_line: "+" /(.*)/ LF -> line
+
+change_move: "*** Move to: " filename LF
+change: (change_context | change_line)+ eof_line?
+change_context: ("@@" | "@@ " /(.+)/) LF
+change_line: ("+" | "-" | " ") /(.*)/ LF
+eof_line: "*** End of File" LF
+
+%import common.LF`
+
+const applyPatchInputDescriptionPrefix = "The value of `input` must be the complete raw apply_patch document after JSON decoding. Do not put a JSON object, a second JSON-encoded string, Markdown code fences, or explanatory text inside `input`. The value must satisfy this Lark grammar:\n\n"
+
+func applyPatchInputDescription(tool gjson.Result) string {
+	definition := ""
+	if strings.EqualFold(strings.TrimSpace(tool.Get("format.syntax").String()), "lark") {
+		definition = strings.TrimSpace(tool.Get("format.definition").String())
+	}
+	if definition == "" {
+		definition = applyPatchFallbackLarkGrammar
+	}
+	return applyPatchInputDescriptionPrefix + definition
+}
 
 func convertResponsesToolToOpenAIChatTools(tool gjson.Result) [][]byte {
 	toolType := strings.TrimSpace(tool.Get("type").String())
@@ -48,7 +79,7 @@ func convertResponsesCustomToolToOpenAIChat(tool gjson.Result, overrideName stri
 	chatTool, _ = sjson.SetBytes(chatTool, "function.name", name)
 	if name == applyPatchToolName {
 		chatTool, _ = sjson.SetBytes(chatTool, "function.description", applyPatchCompatibilityDescription)
-		chatTool, _ = sjson.SetBytes(chatTool, "function.parameters.properties.input.description", applyPatchInputDescription)
+		chatTool, _ = sjson.SetBytes(chatTool, "function.parameters.properties.input.description", applyPatchInputDescription(tool))
 	} else if description := responsesToolDescription(tool); description != "" {
 		chatTool, _ = sjson.SetBytes(chatTool, "function.description", description)
 	}


### PR DESCRIPTION
## 背景

Codex 的 `apply_patch` 是带 Lark grammar 的 Responses 自定义工具，而 Chat Completions 兼容渠道和 xAI 只能按 function tool 调用。直接丢弃 grammar 或沿用“不要使用 JSON”的原始描述，会让模型难以同时理解外层函数参数和内层原始补丁格式。

## 改动

- Chat/OpenAI-compatible/Kimi 将 `apply_patch` 转换为只接受 `input` 字符串的 function tool，并转换对应的 `tool_choice`。
- xAI 的 HTTP、流式及 WebSocket 路径采用相同 function 包装，并把返回调用还原为 Codex `custom_tool_call`。
- 明确区分外层 JSON 参数对象与 `input` 内部的原始 patch，避免描述互相矛盾。
- 优先把请求携带的完整 Lark `format.definition` 注入 `input.description`，保留 `Move to`、`End of File` 及可选 `Environment ID` 等实际规则。
- 请求缺少有效 Lark 定义时，使用 Codex 标准 apply_patch grammar 兜底。
- 返回侧兼容标准 `{ "input": "..." }`、JSON 字符串及原始 patch，降低不同兼容服务的格式差异影响。

## 影响

Chat 兼容渠道与 xAI 获得一致且无歧义的 `apply_patch` 调用约定；模型在不支持 free-form grammar 的上游仍能看到完整语法，同时下游 Codex 保持原有自定义工具调用形态。

## 验证

- `go test ./internal/translator/openai/openai/responses ./internal/runtime/executor`
- `go build -o D:\Cache\cpa\build\cli-proxy-api.exe ./cmd/server`