### PR TITLE
fix(conductor): preserve auth on count_tokens route 404

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2733,7 +2733,11 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
 				}
-				m.MarkResult(execCtx, result)
+				// Some Anthropic-compatible upstreams do not implement the
+				// count_tokens route and return a generic endpoint 404. Record
+				// the failure for hooks and metrics without suspending a model
+				// that remains usable through the messages endpoint.
+				m.recordResult(execCtx, result, !isCountTokensEndpointNotFoundError(errExec))
 				if isRequestInvalidError(errExec) {
 					return cliproxyexecutor.Response{}, errExec
 				}
@@ -3703,6 +3707,10 @@ func waitForCooldown(ctx context.Context, wait, maxWait time.Duration) error {
 
 // MarkResult records an execution result and notifies hooks.
 func (m *Manager) MarkResult(ctx context.Context, result Result) {
+	m.recordResult(ctx, result, true)
+}
+
+func (m *Manager) recordResult(ctx context.Context, result Result, updateAvailability bool) {
 	if result.AuthID == "" {
 		return
 	}
@@ -3746,7 +3754,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			} else {
 				clearAuthStateOnSuccess(auth, now)
 			}
-		} else {
+		} else if updateAvailability {
 			if result.Model != "" {
 				if !isRequestScopedResultError(result.Error) {
 					disableCooling := m.cooldownDisabledForAuth(auth)
@@ -4294,6 +4302,46 @@ func isRequestScopedNotFoundResultError(err *Error) bool {
 
 func isRequestScopedResultError(err *Error) bool {
 	return err != nil && (err.IsRequestScoped() || isRequestScopedNotFoundResultError(err))
+}
+
+func isCountTokensEndpointNotFoundError(err error) bool {
+	if err == nil || statusCodeFromError(err) != http.StatusNotFound {
+		return false
+	}
+	message := strings.TrimSpace(err.Error())
+	if message == "" {
+		return false
+	}
+
+	normalized := strings.ToLower(strings.Join(strings.Fields(message), " "))
+	switch normalized {
+	case "not found", "404 not found", "404 page not found":
+		return true
+	}
+
+	var payload map[string]any
+	if errJSON := json.Unmarshal([]byte(message), &payload); errJSON == nil && len(payload) == 1 {
+		for _, key := range []string{"detail", "error", "message"} {
+			value, ok := payload[key].(string)
+			if !ok {
+				continue
+			}
+			switch strings.ToLower(strings.TrimSpace(value)) {
+			case "not found", "404 not found", "404 page not found":
+				return true
+			}
+		}
+	}
+
+	if strings.Contains(normalized, "count_tokens") {
+		if strings.Contains(normalized, "cannot post") ||
+			strings.Contains(normalized, "no route") ||
+			strings.Contains(normalized, "route not found") {
+			return true
+		}
+	}
+	return strings.Contains(normalized, "<title>404") &&
+		strings.Contains(normalized, "not found")
 }
 
 // isRequestInvalidError returns true if the error represents a client request

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -4313,14 +4313,14 @@ func isCountTokensEndpointNotFoundError(err error) bool {
 		return false
 	}
 
-	normalized := strings.ToLower(strings.Join(strings.Fields(message), " "))
-	switch normalized {
+	lower := strings.ToLower(message)
+	switch lower {
 	case "not found", "404 not found", "404 page not found":
 		return true
 	}
 
 	var payload map[string]any
-	if errJSON := json.Unmarshal([]byte(message), &payload); errJSON == nil && len(payload) == 1 {
+	if errJSON := json.Unmarshal([]byte(message), &payload); errJSON == nil {
 		for _, key := range []string{"detail", "error", "message"} {
 			value, ok := payload[key].(string)
 			if !ok {
@@ -4328,20 +4328,25 @@ func isCountTokensEndpointNotFoundError(err error) bool {
 			}
 			switch strings.ToLower(strings.TrimSpace(value)) {
 			case "not found", "404 not found", "404 page not found":
+				if strings.Contains(lower, "model_not_found") ||
+					strings.Contains(lower, "model not found") ||
+					strings.Contains(lower, `"model"`) {
+					return false
+				}
 				return true
 			}
 		}
 	}
 
-	if strings.Contains(normalized, "count_tokens") {
-		if strings.Contains(normalized, "cannot post") ||
-			strings.Contains(normalized, "no route") ||
-			strings.Contains(normalized, "route not found") {
+	if strings.Contains(lower, "count_tokens") {
+		if strings.Contains(lower, "cannot post") ||
+			strings.Contains(lower, "no route") ||
+			strings.Contains(lower, "route not found") {
 			return true
 		}
 	}
-	return strings.Contains(normalized, "<title>404") &&
-		strings.Contains(normalized, "not found")
+	return strings.Contains(lower, "<title>404") &&
+		strings.Contains(lower, "not found")
 }
 
 // isRequestInvalidError returns true if the error represents a client request

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -160,8 +160,10 @@ type authFallbackExecutor struct {
 	mu                sync.Mutex
 	executeCalls      []string
 	streamCalls       []string
+	countTokenCalls   []string
 	executeErrors     map[string]error
 	streamFirstErrors map[string]error
+	countTokenErrors  map[string]error
 }
 
 func (e *authFallbackExecutor) Identifier() string {
@@ -200,8 +202,15 @@ func (e *authFallbackExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, er
 	return auth, nil
 }
 
-func (e *authFallbackExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
-	return cliproxyexecutor.Response{}, &Error{HTTPStatus: 500, Message: "not implemented"}
+func (e *authFallbackExecutor) CountTokens(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	e.countTokenCalls = append(e.countTokenCalls, auth.ID)
+	err := e.countTokenErrors[auth.ID]
+	e.mu.Unlock()
+	if err != nil {
+		return cliproxyexecutor.Response{}, err
+	}
+	return cliproxyexecutor.Response{Payload: []byte(auth.ID)}, nil
 }
 
 func (e *authFallbackExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
@@ -221,6 +230,35 @@ func (e *authFallbackExecutor) StreamCalls() []string {
 	defer e.mu.Unlock()
 	out := make([]string, len(e.streamCalls))
 	copy(out, e.streamCalls)
+	return out
+}
+
+func (e *authFallbackExecutor) CountTokenCalls() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]string, len(e.countTokenCalls))
+	copy(out, e.countTokenCalls)
+	return out
+}
+
+type resultCaptureHook struct {
+	NoopHook
+
+	mu      sync.Mutex
+	results []Result
+}
+
+func (h *resultCaptureHook) OnResult(_ context.Context, result Result) {
+	h.mu.Lock()
+	h.results = append(h.results, result)
+	h.mu.Unlock()
+}
+
+func (h *resultCaptureHook) Results() []Result {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]Result, len(h.results))
+	copy(out, h.results)
 	return out
 }
 
@@ -1339,5 +1377,161 @@ func TestManager_RequestScopedNotFoundStopsRetryWithoutSuspendingAuth(t *testing
 	}
 	if state := updatedBad.ModelStates[model]; state != nil {
 		t.Fatalf("expected request-scoped 404 to avoid bad auth model cooldown state, got %#v", state)
+	}
+}
+
+func TestManagerExecuteCount_Endpoint404DoesNotSuspendAuth(t *testing.T) {
+	hook := &resultCaptureHook{}
+	m := NewManager(nil, nil, hook)
+	executor := &authFallbackExecutor{
+		id: "claude",
+		countTokenErrors: map[string]error{
+			"aa-count-auth": &Error{
+				HTTPStatus: http.StatusNotFound,
+				Message:    "404 page not found",
+			},
+		},
+	}
+	m.RegisterExecutor(executor)
+
+	model := "claude-fable-5"
+	auth := &Auth{ID: "aa-count-auth", Provider: "claude"}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	_, errCount := m.ExecuteCount(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if errCount == nil {
+		t.Fatal("expected count_tokens endpoint 404")
+	}
+	if calls := executor.CountTokenCalls(); len(calls) != 1 || calls[0] != auth.ID {
+		t.Fatalf("count_tokens calls = %v, want [%s]", calls, auth.ID)
+	}
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("expected auth to remain registered")
+	}
+	if updated.Unavailable {
+		t.Fatal("expected endpoint 404 to keep auth available")
+	}
+	if !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected endpoint 404 to keep auth cooldown unset, got %v", updated.NextRetryAfter)
+	}
+	if state := updated.ModelStates[model]; state != nil {
+		t.Fatalf("expected endpoint 404 to avoid model cooldown state, got %#v", state)
+	}
+	if updated.Failed != 1 {
+		t.Fatalf("failed request count = %d, want 1", updated.Failed)
+	}
+
+	results := hook.Results()
+	if len(results) != 1 {
+		t.Fatalf("hook results = %d, want 1", len(results))
+	}
+	if results[0].Success || results[0].Error == nil || results[0].Error.HTTPStatus != http.StatusNotFound {
+		t.Fatalf("unexpected hook result: %#v", results[0])
+	}
+
+	resp, errExecute := m.Execute(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if errExecute != nil {
+		t.Fatalf("expected Execute to succeed after count_tokens endpoint 404, got: %v", errExecute)
+	}
+	if string(resp.Payload) != auth.ID {
+		t.Fatalf("execute payload = %q, want %q", string(resp.Payload), auth.ID)
+	}
+}
+
+func TestManagerExecuteCount_ModelNotFound404StillSuspendsAuth(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	executor := &authFallbackExecutor{
+		id: "claude",
+		countTokenErrors: map[string]error{
+			"aa-count-auth": &Error{
+				HTTPStatus: http.StatusNotFound,
+				Message:    `{"type":"error","error":{"type":"not_found_error","message":"model claude-missing was not found"}}`,
+			},
+		},
+	}
+	m.RegisterExecutor(executor)
+
+	model := "claude-missing"
+	auth := &Auth{ID: "aa-count-auth", Provider: "claude"}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	_, errCount := m.ExecuteCount(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if errCount == nil {
+		t.Fatal("expected count_tokens model 404")
+	}
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("expected auth to remain registered")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || !state.Unavailable {
+		t.Fatalf("expected model 404 to suspend model, got %#v", state)
+	}
+	if state.NextRetryAfter.IsZero() {
+		t.Fatal("expected model 404 to set model cooldown")
+	}
+}
+
+func TestIsCountTokensEndpointNotFoundError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "plain router 404",
+			err:  &Error{HTTPStatus: http.StatusNotFound, Message: "404 page not found"},
+			want: true,
+		},
+		{
+			name: "fastapi route 404",
+			err:  &Error{HTTPStatus: http.StatusNotFound, Message: `{"detail":"Not Found"}`},
+			want: true,
+		},
+		{
+			name: "express route 404",
+			err:  &Error{HTTPStatus: http.StatusNotFound, Message: "Cannot POST /v1/messages/count_tokens"},
+			want: true,
+		},
+		{
+			name: "structured model 404",
+			err:  &Error{HTTPStatus: http.StatusNotFound, Message: `{"error":{"type":"not_found_error","message":"model claude-missing was not found"}}`},
+			want: false,
+		},
+		{
+			name: "messages endpoint 404",
+			err:  &Error{HTTPStatus: http.StatusNotFound, Message: "Cannot POST /v1/messages"},
+			want: false,
+		},
+		{
+			name: "non 404",
+			err:  &Error{HTTPStatus: http.StatusInternalServerError, Message: "404 page not found"},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isCountTokensEndpointNotFoundError(tc.err); got != tc.want {
+				t.Fatalf("isCountTokensEndpointNotFoundError() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -1506,6 +1506,11 @@ func TestIsCountTokensEndpointNotFoundError(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "gateway route 404 with request metadata",
+			err:  &Error{HTTPStatus: http.StatusNotFound, Message: `{"detail":"Not Found","request_id":"req-1","path":"/v1/messages/count_tokens"}`},
+			want: true,
+		},
+		{
 			name: "express route 404",
 			err:  &Error{HTTPStatus: http.StatusNotFound, Message: "Cannot POST /v1/messages/count_tokens"},
 			want: true,
@@ -1513,6 +1518,11 @@ func TestIsCountTokensEndpointNotFoundError(t *testing.T) {
 		{
 			name: "structured model 404",
 			err:  &Error{HTTPStatus: http.StatusNotFound, Message: `{"error":{"type":"not_found_error","message":"model claude-missing was not found"}}`},
+			want: false,
+		},
+		{
+			name: "generic text with model not found code",
+			err:  &Error{HTTPStatus: http.StatusNotFound, Message: `{"message":"Not Found","code":"model_not_found","model":"claude-missing"}`},
 			want: false,
 		},
 		{


### PR DESCRIPTION
## Summary

- keep auth/model availability unchanged for generic route-level 404 responses from `count_tokens`
- continue recording those failures for request counters, hooks, error events, and observability
- preserve the existing 12-hour model cooldown for structured model-not-found 404 responses

## Why

Some Anthropic-compatible custom upstreams implement `/v1/messages` but do not implement `/v1/messages/count_tokens?beta=true`. On v7.2.86, the generic route 404 is passed to `MarkResult`, which classifies it as `not_found`, suspends the auth/model pair for 12 hours, and removes the configured alias from `/v1/models`.

A production incident on July 18, 2026 showed this sequence:

```text
12:51:05  count_tokens returned 404
12:51:05  subsequent count_tokens calls returned 503
12:51:07  subsequent messages calls returned 503
12:51:14  configured alias was absent from both model-list formats
14:47:44  alias recovered after an unchanged config save/hot reload
```

CLIProxyAPI stayed on the same PID with zero restarts, and all configured model declarations remained present.

## Implementation

`executeCountMixedOnce` now distinguishes generic endpoint/router 404 bodies from structured API errors:

- generic responses such as `404 page not found`, `{"detail":"Not Found"}`, or `Cannot POST /v1/messages/count_tokens` are recorded without updating auth/model availability;
- structured model-not-found responses still use the normal `MarkResult` availability path.

`MarkResult` delegates to an internal recording path so availability-neutral failures still reach hooks and error publishing. This addresses the observability and over-broad matching concerns raised on #2895.

## Test plan

- `go test ./sdk/cliproxy/auth -count=1`
- `go test ./... -count=1`
- `go build -o /tmp/cli-proxy-api-fable5-fix ./cmd/server`

New regression coverage verifies:

- a generic `count_tokens` endpoint 404 does not create cooldown state;
- the failure is still reported to hooks and counters;
- a subsequent ordinary execution with the same auth/model succeeds;
- a structured model-not-found 404 still suspends the model;
- generic endpoint 404 matching does not apply to the ordinary messages endpoint.

Fixes #4410

Related: #2895, #3326