### PR TITLE
fix(executor): normalize Kimi upstream model ID to canonical k3

### DIFF
--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -77,6 +77,7 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 	from := opts.SourceFormat
 	if from.String() == "claude" {
 		auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
+		req.Model = normalizeKimiUpstreamModel(req.Model)
 		return e.ClaudeExecutor.Execute(ctx, auth, req, opts)
 	}
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
@@ -97,8 +98,8 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
 	body := sdktranslator.TranslateRequest(from, to, baseModel, bytes.Clone(req.Payload), false)
 
-	// Strip kimi- prefix for upstream API
-	upstreamModel := stripKimiPrefix(baseModel)
+	// Strip kimi- prefix and any [1m] suffix for upstream API
+	upstreamModel := normalizeKimiUpstreamModel(baseModel)
 	body, err = sjson.SetBytes(body, "model", upstreamModel)
 	if err != nil {
 		return resp, fmt.Errorf("kimi executor: failed to set model in payload: %w", err)
@@ -187,6 +188,7 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 	from := opts.SourceFormat
 	if from.String() == "claude" {
 		auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
+		req.Model = normalizeKimiUpstreamModel(req.Model)
 		return e.ClaudeExecutor.ExecuteStream(ctx, auth, req, opts)
 	}
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
@@ -206,8 +208,8 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
 	body := sdktranslator.TranslateRequest(from, to, baseModel, bytes.Clone(req.Payload), true)
 
-	// Strip kimi- prefix for upstream API
-	upstreamModel := stripKimiPrefix(baseModel)
+	// Strip kimi- prefix and any [1m] suffix for upstream API
+	upstreamModel := normalizeKimiUpstreamModel(baseModel)
 	body, err = sjson.SetBytes(body, "model", upstreamModel)
 	if err != nil {
 		return nil, fmt.Errorf("kimi executor: failed to set model in payload: %w", err)
@@ -327,6 +329,7 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 // CountTokens estimates token count for Kimi requests.
 func (e *KimiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
+	req.Model = normalizeKimiUpstreamModel(req.Model)
 	return e.ClaudeExecutor.CountTokens(ctx, auth, req, opts)
 }
 
@@ -753,4 +756,22 @@ func stripKimiPrefix(model string) string {
 		return model[5:]
 	}
 	return model
+}
+
+// normalizeKimiUpstreamModel returns the canonical upstream model ID for Kimi.
+// It strips the CLIProxyAPI "kimi-" prefix and any Claude Code "[1m]" context
+// suffix while preserving a trailing thinking suffix (e.g. "(1024)"), so that
+// the upstream API receives IDs such as "k3(1024)" instead of "kimi-k3[1m](1024)".
+func normalizeKimiUpstreamModel(model string) string {
+	model = strings.TrimSpace(model)
+	parsed := thinking.ParseSuffix(model)
+	base := parsed.ModelName
+	if strings.HasSuffix(strings.ToLower(base), "[1m]") {
+		base = base[:len(base)-len("[1m]")]
+	}
+	normalized := strings.ToLower(stripKimiPrefix(strings.TrimSpace(base)))
+	if parsed.HasSuffix {
+		return normalized + "(" + parsed.RawSuffix + ")"
+	}
+	return normalized
 }

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -270,3 +270,29 @@ func TestNormalizeKimiToolMessageLinks_PreservesAssistantWithToolLinkOrReasoning
 		t.Fatalf("messages.3.content.0.text = %q, want %q", got, " visible ")
 	}
 }
+
+func TestNormalizeKimiUpstreamModel(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"kimi-k3[1m]", "k3"},
+		{"kimi-k3", "k3"},
+		{"Kimi-K3[1M]", "k3"},
+		{"k3[1m]", "k3"},
+		{"k3", "k3"},
+		{"kimi-k2.6", "k2.6"},
+		{"kimi-k2.6[1m]", "k2.6"},
+		{"kimi-k3(1024)", "k3(1024)"},
+		{"kimi-k3[1m](1024)", "k3(1024)"},
+		{"kimi-k2.6(high)", "k2.6(high)"},
+		{"kimi-k2.6[1m](high)", "k2.6(high)"},
+	}
+
+	for _, c := range cases {
+		got := normalizeKimiUpstreamModel(c.in)
+		if got != c.want {
+			t.Errorf("normalizeKimiUpstreamModel(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

When using the Kimi K3 profile through CLIProxyAPI, long requests fail with:

```
400 Invalid request: Your request exceeded model token limit: 262144 (requested: 263932)
```

The user is configured to use `kimi-k3[1m]`, which should give the 1M context window. However, the upstream Kimi API receives an ID that only supports 256K.

## Root cause

CLIProxyAPI's internal model ID is `kimi-k3[1m]`. The Kimi executor's **Claude branch** forwarded this ID verbatim to `https://api.kimi.com/coding/v1/messages`. Kimi treats the following IDs as 256K models:

- `kimi-k3`
- `kimi-k3[1m]`
- `k3[1m]`

Only the bare ID `k3` unlocks the full 1,048,576 context window.

## Fix

Normalize the upstream model ID in the Kimi executor by stripping the `kimi-` prefix and any Claude Code `[1m]` suffix before sending to Kimi. This affects:

- `Execute` (Claude and OpenAI branches)
- `ExecuteStream` (Claude and OpenAI branches)
- `CountTokens`

## Validation

Using the stored Kimi token directly against `https://api.kimi.com/coding/v1/models`:

| model | context_length |
|-------|----------------|
| `k3` | 1,048,576 |
| `kimi-for-coding` | 262,144 |
| `kimi-for-coding-highspeed` | 262,144 |

Sending ~270k input tokens to `/v1/messages`:

| upstream model | result |
|----------------|--------|
| `k3` | ✅ success |
| `k3[1m]` | ❌ `token limit: 262144` |
| `kimi-k3` | ❌ `token limit: 262144` |
| `kimi-k3[1m]` | ❌ `token limit: 262144` |

After the fix, CLIProxyAPI sends `k3` for both `kimi-k3` and `kimi-k3[1m]` requests.

## Checklist

- [x] `gofmt -w .`
- [x] `go build -o cli-proxy-api ./cmd/server`
- [x] `go test ./internal/runtime/executor/...`
- [x] Added unit tests for `normalizeKimiUpstreamModel`

Closes #4418
