### PR TITLE
fix: propagate context cancellation in executeClaudeNonStream

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1063,27 +1063,44 @@ attemptLoop:
 						reporter.Publish(ctx, detail)
 					}
 
-					out <- cliproxyexecutor.StreamChunk{Payload: payload}
+					select {
+					case out <- cliproxyexecutor.StreamChunk{Payload: payload}:
+					case <-ctx.Done():
+						return
+					}
 				}
 				if errScan := scanner.Err(); errScan != nil {
 					helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 					reporter.PublishFailure(ctx, errScan)
-					out <- cliproxyexecutor.StreamChunk{Err: errScan}
+					select {
+					case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
+					case <-ctx.Done():
+					}
 				} else {
 					reporter.EnsurePublished(ctx)
 				}
 			}(httpResp)
 
 			var buffer bytes.Buffer
-			for chunk := range out {
-				if chunk.Err != nil {
-					return resp, chunk.Err
-				}
-				if len(chunk.Payload) > 0 {
-					_, _ = buffer.Write(chunk.Payload)
-					_, _ = buffer.Write([]byte("\n"))
+			for {
+				select {
+				case chunk, ok := <-out:
+					if !ok {
+						goto claudeNonStreamDone
+					}
+					if chunk.Err != nil {
+						return resp, chunk.Err
+					}
+					if len(chunk.Payload) > 0 {
+						_, _ = buffer.Write(chunk.Payload)
+						_, _ = buffer.Write([]byte("\n"))
+					}
+				case <-ctx.Done():
+					err = ctx.Err()
+					return resp, err
 				}
 			}
+		claudeNonStreamDone:
 			resp = cliproxyexecutor.Response{Payload: e.convertStreamToNonStream(buffer.Bytes())}
 
 			resp.Payload = e.resolveWebSearchGroundingURLs(ctx, auth, from, originalPayload, translated, resp.Payload)


### PR DESCRIPTION
## Summary

- `executeClaudeNonStream` goroutine sends chunks via bare channel sends without `ctx.Done()` checks, and the reader uses a plain `range` loop — neither reacts to context cancellation
- When a client disconnects mid-generation, the upstream request continues to completion instead of being cancelled promptly
- Add `select { case out <- …: case <-ctx.Done(): return }` in the goroutine (matching the existing pattern in `ExecuteStream` at L1559-1564), and replace the `range` reader with a `select` that also listens on `ctx.Done()`

> ⚠️ This PR was AI-generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)