### PR TITLE
fix(codex): distinguish accounts sharing email and plan

### DIFF
--- a/internal/auth/codex/filename.go
+++ b/internal/auth/codex/filename.go
@@ -8,8 +8,8 @@ import (
 
 // CredentialFileName returns the filename used to persist Codex OAuth credentials.
 // When planType is available (e.g. "plus", "team"), it is appended after the email
-// as a suffix to disambiguate subscriptions. Team-scoped plans include the account
-// hash to avoid overwriting credentials for the same email across multiple teams.
+// as a suffix to disambiguate subscriptions. The account hash avoids overwriting
+// credentials when multiple accounts share the same email and plan.
 func CredentialFileName(email, planType, hashAccountID string, includeProviderPrefix bool) string {
 	email = strings.TrimSpace(email)
 	plan := normalizePlanTypeForFilename(planType)
@@ -20,16 +20,16 @@ func CredentialFileName(email, planType, hashAccountID string, includeProviderPr
 		prefix = "codex"
 	}
 
-	if plan == "" {
-		return fmt.Sprintf("%s-%s.json", prefix, email)
-	} else if isTeamScopedPlan(plan) && hashAccountID != "" {
+	if hashAccountID != "" {
+		if plan == "" {
+			return fmt.Sprintf("%s-%s-%s.json", prefix, hashAccountID, email)
+		}
 		return fmt.Sprintf("%s-%s-%s-%s.json", prefix, hashAccountID, email, plan)
 	}
+	if plan == "" {
+		return fmt.Sprintf("%s-%s.json", prefix, email)
+	}
 	return fmt.Sprintf("%s-%s-%s.json", prefix, email, plan)
-}
-
-func isTeamScopedPlan(plan string) bool {
-	return plan == "team" || plan == "k12"
 }
 
 func normalizePlanTypeForFilename(planType string) string {

--- a/internal/auth/codex/filename_test.go
+++ b/internal/auth/codex/filename_test.go
@@ -36,20 +36,28 @@ func TestCredentialFileName(t *testing.T) {
 			want:                  "codex-user@example.com-k12.json",
 		},
 		{
-			name:                  "plus ignores account hash",
+			name:                  "plus includes account hash",
 			email:                 " user@example.com ",
 			planType:              "Plus",
 			hashAccountID:         "abc12345",
 			includeProviderPrefix: true,
-			want:                  "codex-user@example.com-plus.json",
+			want:                  "codex-abc12345-user@example.com-plus.json",
 		},
 		{
-			name:                  "plan is normalized",
+			name:                  "normalized plan includes account hash",
 			email:                 "user@example.com",
 			planType:              " Team Plan ",
 			hashAccountID:         "abc12345",
 			includeProviderPrefix: true,
-			want:                  "codex-user@example.com-team-plan.json",
+			want:                  "codex-abc12345-user@example.com-team-plan.json",
+		},
+		{
+			name:                  "missing plan includes account hash",
+			email:                 "user@example.com",
+			planType:              "",
+			hashAccountID:         "abc12345",
+			includeProviderPrefix: true,
+			want:                  "codex-abc12345-user@example.com.json",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- include the stable ChatGPT account hash in Codex credential filenames for every plan
- retain the existing email/plan filename fallback when the account ID is unavailable
- cover Plus, normalized-plan, and missing-plan account-hash cases

## Problem

Two ChatGPT accounts with the same email and plan currently resolve to the same filename, for example `codex-user@example.com-plus.json`. Logging into the second account overwrites the first credential, so only one account remains available.

Both Codex OAuth login paths already compute and pass a stable hash of the ChatGPT account ID. This change uses that hash consistently instead of restricting it to team-scoped plans.

## Validation

- `go test ./internal/auth/codex`
- `go build -o <temporary-file> ./cmd/server`