### PR TITLE
[codex] sync Codex quota state

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -130,6 +130,13 @@ disable-cooling: false
 # Default is false; when false, cooldown status is kept in memory only.
 save-cooldown-status: false
 
+# Synchronize Codex quota from response headers and actively verify exhausted accounts.
+# codex-quota-refresh:
+#   enabled: true
+#   scan-interval: 15m
+#   min-account-interval: 30m
+#   account-stagger: 3s
+
 # Cooldown duration in seconds for transient upstream errors (408/500/502/503/504).
 # Set to 0 to keep the legacy 60-second cooldown; set to -1 to disable transient error cooldowns.
 transient-error-cooldown-seconds: 0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,19 @@ const (
 	DefaultAuthDir               = "~/.cli-proxy-api"
 )
 
+// CodexQuotaRefreshConfig controls active verification for quota-exhausted Codex credentials.
+type CodexQuotaRefreshConfig struct {
+	Enabled            *bool  `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	ScanInterval       string `yaml:"scan-interval,omitempty" json:"scan-interval,omitempty"`
+	MinAccountInterval string `yaml:"min-account-interval,omitempty" json:"min-account-interval,omitempty"`
+	AccountStagger     string `yaml:"account-stagger,omitempty" json:"account-stagger,omitempty"`
+}
+
+// IsEnabled reports whether active Codex quota synchronization is enabled.
+func (c CodexQuotaRefreshConfig) IsEnabled() bool {
+	return c.Enabled == nil || *c.Enabled
+}
+
 // Config represents the application's configuration, loaded from a YAML file.
 type Config struct {
 	SDKConfig `yaml:",inline"`
@@ -83,6 +96,9 @@ type Config struct {
 
 	// SaveCooldownStatus persists runtime cooldown status next to auth files when true.
 	SaveCooldownStatus bool `yaml:"save-cooldown-status" json:"save-cooldown-status"`
+
+	// CodexQuotaRefresh configures passive and active Codex quota synchronization.
+	CodexQuotaRefresh CodexQuotaRefreshConfig `yaml:"codex-quota-refresh" json:"codex-quota-refresh"`
 
 	// TransientErrorCooldownSeconds controls cooldowns for transient upstream errors.
 	// 0 keeps the legacy default cooldown. Negative values disable these cooldowns.

--- a/sdk/cliproxy/auth/codex_quota.go
+++ b/sdk/cliproxy/auth/codex_quota.go
@@ -1,0 +1,62 @@
+package auth
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// CodexQuotaWindow is a quota window reported by the Codex upstream.
+type CodexQuotaWindow struct {
+	UsedPercent   float64
+	WindowMinutes int64
+	ResetAt       time.Time
+}
+
+// CodexQuotaHeaders contains quota windows parsed from an upstream response.
+type CodexQuotaHeaders struct {
+	Primary   *CodexQuotaWindow
+	Secondary *CodexQuotaWindow
+}
+
+// ParseCodexQuotaHeaders extracts Codex quota windows from upstream response headers.
+func ParseCodexQuotaHeaders(headers http.Header) (CodexQuotaHeaders, bool) {
+	if len(headers) == 0 {
+		return CodexQuotaHeaders{}, false
+	}
+	primary := parseCodexQuotaWindow(headers, "X-Codex-Primary")
+	secondary := parseCodexQuotaWindow(headers, "X-Codex-Secondary")
+	if primary == nil && secondary == nil {
+		return CodexQuotaHeaders{}, false
+	}
+	return CodexQuotaHeaders{Primary: primary, Secondary: secondary}, true
+}
+
+func parseCodexQuotaWindow(headers http.Header, prefix string) *CodexQuotaWindow {
+	usedRaw := strings.TrimSpace(headers.Get(prefix + "-Used-Percent"))
+	if usedRaw == "" {
+		return nil
+	}
+	used, errUsed := strconv.ParseFloat(usedRaw, 64)
+	if errUsed != nil {
+		return nil
+	}
+	window := &CodexQuotaWindow{UsedPercent: used}
+	if minutes, errMinutes := strconv.ParseInt(strings.TrimSpace(headers.Get(prefix+"-Window-Minutes")), 10, 64); errMinutes == nil && minutes > 0 {
+		window.WindowMinutes = minutes
+	}
+	if resetAt, errReset := strconv.ParseInt(strings.TrimSpace(headers.Get(prefix+"-Reset-At")), 10, 64); errReset == nil && resetAt > 0 {
+		window.ResetAt = time.Unix(resetAt, 0)
+	}
+	return window
+}
+
+func (q CodexQuotaHeaders) exhaustedWindow() *CodexQuotaWindow {
+	for _, window := range []*CodexQuotaWindow{q.Primary, q.Secondary} {
+		if window != nil && window.UsedPercent >= 100 {
+			return window
+		}
+	}
+	return nil
+}

--- a/sdk/cliproxy/auth/codex_quota_test.go
+++ b/sdk/cliproxy/auth/codex_quota_test.go
@@ -1,0 +1,68 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestManagerMarkResultSynchronizesCodexQuotaHeaders(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	ctx := context.Background()
+	const authID = "codex-quota-headers"
+	const model = "gpt-5"
+	if _, errRegister := manager.Register(ctx, &Auth{ID: authID, Provider: "codex", Status: StatusActive}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	exhaustedHeaders := http.Header{}
+	exhaustedHeaders.Set("X-Codex-Primary-Used-Percent", "100")
+	exhaustedHeaders.Set("X-Codex-Primary-Reset-At", "4102444800")
+	manager.MarkResult(ctx, Result{AuthID: authID, Provider: "codex", Model: model, Success: true, Headers: exhaustedHeaders})
+
+	exhausted, ok := manager.GetByID(authID)
+	if !ok || exhausted.ModelStates[model] == nil || !exhausted.ModelStates[model].Quota.Exceeded {
+		t.Fatalf("exhausted auth = %#v, %v", exhausted, ok)
+	}
+
+	recoveredHeaders := http.Header{}
+	recoveredHeaders.Set("X-Codex-Primary-Used-Percent", "10")
+	manager.MarkResult(ctx, Result{AuthID: authID, Provider: "codex", Model: model, Success: true, Headers: recoveredHeaders})
+
+	recovered, ok := manager.GetByID(authID)
+	if !ok || recovered.ModelStates[model] == nil {
+		t.Fatalf("recovered auth = %#v, %v", recovered, ok)
+	}
+	if recovered.ModelStates[model].Quota.Exceeded || recovered.ModelStates[model].Unavailable {
+		t.Fatalf("recovered model state = %#v", recovered.ModelStates[model])
+	}
+}
+
+func TestParseCodexQuotaHeaders(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("X-Codex-Primary-Used-Percent", "42.5")
+	headers.Set("X-Codex-Primary-Window-Minutes", "300")
+	headers.Set("X-Codex-Primary-Reset-At", "1700000000")
+	headers.Set("X-Codex-Secondary-Used-Percent", "100")
+
+	quota, ok := ParseCodexQuotaHeaders(headers)
+	if !ok || quota.Primary == nil || quota.Secondary == nil {
+		t.Fatalf("ParseCodexQuotaHeaders() = %#v, %v", quota, ok)
+	}
+	if quota.Primary.UsedPercent != 42.5 || quota.Primary.WindowMinutes != 300 {
+		t.Fatalf("primary = %#v", quota.Primary)
+	}
+	if !quota.Primary.ResetAt.Equal(time.Unix(1700000000, 0)) {
+		t.Fatalf("primary reset = %v", quota.Primary.ResetAt)
+	}
+	if exhausted := quota.exhaustedWindow(); exhausted != quota.Secondary {
+		t.Fatalf("exhaustedWindow() = %#v, want secondary", exhausted)
+	}
+}
+
+func TestParseCodexQuotaHeadersMissing(t *testing.T) {
+	if quota, ok := ParseCodexQuotaHeaders(http.Header{}); ok {
+		t.Fatalf("ParseCodexQuotaHeaders() = %#v, true", quota)
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -171,6 +171,8 @@ type Result struct {
 	RetryAfter *time.Duration
 	// Error describes the failure when Success is false.
 	Error *Error
+	// Headers carries upstream response metadata used to synchronize provider quota state.
+	Headers http.Header
 }
 
 // Selector chooses an auth candidate for execution.
@@ -1843,7 +1845,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 			}
 		}
 		if !failed {
-			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: true})
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: true, Headers: headers})
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: headers, Chunks: out}
@@ -2627,6 +2629,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				authErr = errExec
 				continue
 			}
+			result.Headers = resp.Headers
 			m.MarkResult(execCtx, result)
 			rewriteForceMappedResponse(&resp, aliasResult)
 			return resp, nil
@@ -2740,6 +2743,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				authErr = errExec
 				continue
 			}
+			result.Headers = resp.Headers
 			m.MarkResult(execCtx, result)
 			rewriteForceMappedResponse(&resp, aliasResult)
 			return resp, nil
@@ -3714,6 +3718,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	setModelQuota := false
 	var authSnapshot *Auth
 	cooldownStateChanged := false
+	codexQuota, hasCodexQuota := ParseCodexQuotaHeaders(result.Headers)
 
 	m.mu.Lock()
 	if auth, ok := m.auths[result.AuthID]; ok && auth != nil {
@@ -3745,6 +3750,30 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				clearModelQuota = true
 			} else {
 				clearAuthStateOnSuccess(auth, now)
+			}
+			if strings.EqualFold(result.Provider, "codex") && result.Model != "" && hasCodexQuota {
+				if exhausted := codexQuota.exhaustedWindow(); exhausted != nil {
+					state := ensureModelState(auth, result.Model)
+					next := exhausted.ResetAt
+					if !next.After(now) {
+						next, _ = quotaCooldownAfterFailure(state.Quota, now)
+					}
+					state.Unavailable = true
+					state.Status = StatusError
+					state.StatusMessage = "quota"
+					state.NextRetryAfter = next
+					state.Quota = QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: next}
+					state.UpdatedAt = now
+					auth.Status = StatusError
+					auth.StatusMessage = "quota"
+					auth.UpdatedAt = now
+					updateAggregatedAvailability(auth, now)
+					shouldResumeModel = false
+					clearModelQuota = false
+					shouldSuspendModel = true
+					suspendReason = "quota"
+					setModelQuota = true
+				}
 			}
 		} else {
 			if result.Model != "" {
@@ -5509,6 +5538,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 				m.MarkResult(creditsCtx, result)
 				continue
 			}
+			result.Headers = resp.Headers
 			m.MarkResult(creditsCtx, result)
 			rewriteForceMappedResponse(&resp, aliasResult)
 			return resp, true, nil

--- a/sdk/cliproxy/codex_quota_refresher.go
+++ b/sdk/cliproxy/codex_quota_refresher.go
@@ -1,0 +1,262 @@
+package cliproxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	defaultCodexQuotaScanInterval       = 15 * time.Minute
+	defaultCodexQuotaMinAccountInterval = 30 * time.Minute
+	defaultCodexQuotaAccountStagger     = 3 * time.Second
+	codexQuotaRequestTimeout            = 15 * time.Second
+)
+
+type codexQuotaRefresher struct {
+	manager *coreauth.Manager
+	cfg     *config.Config
+
+	mu        sync.Mutex
+	lastCheck map[string]time.Time
+}
+
+type codexUsageResponse struct {
+	RateLimit *codexUsageRateLimit `json:"rate_limit"`
+}
+
+type codexUsageRateLimit struct {
+	LimitReached    *bool                  `json:"limit_reached"`
+	PrimaryWindow   *codexUsageQuotaWindow `json:"primary_window"`
+	SecondaryWindow *codexUsageQuotaWindow `json:"secondary_window"`
+}
+
+type codexUsageQuotaWindow struct {
+	UsedPercent float64 `json:"used_percent"`
+}
+
+func newCodexQuotaRefresher(manager *coreauth.Manager, cfg *config.Config) *codexQuotaRefresher {
+	return &codexQuotaRefresher{manager: manager, cfg: cfg, lastCheck: make(map[string]time.Time)}
+}
+
+func (s *Service) restartCodexQuotaRefresher(parent context.Context, cfg *config.Config) {
+	if s == nil {
+		return
+	}
+	if s.codexQuotaRefreshCancel != nil {
+		s.codexQuotaRefreshCancel()
+		s.codexQuotaRefreshCancel = nil
+	}
+	if s.coreManager == nil || cfg == nil || !cfg.CodexQuotaRefresh.IsEnabled() {
+		return
+	}
+	if parent == nil {
+		parent = context.Background()
+	}
+	refreshCtx, cancel := context.WithCancel(parent)
+	s.codexQuotaRefreshCancel = cancel
+	refresher := newCodexQuotaRefresher(s.coreManager, cfg)
+	go refresher.run(refreshCtx)
+}
+
+func (r *codexQuotaRefresher) run(ctx context.Context) {
+	if r == nil || r.manager == nil || r.cfg == nil || !r.cfg.CodexQuotaRefresh.IsEnabled() {
+		return
+	}
+	interval := quotaRefreshDuration(r.cfg.CodexQuotaRefresh.ScanInterval, defaultCodexQuotaScanInterval)
+	if !waitCodexQuotaRefresh(ctx, jitterCodexQuotaDuration(interval)) {
+		return
+	}
+	for {
+		r.scan(ctx)
+		if !waitCodexQuotaRefresh(ctx, jitterCodexQuotaDuration(interval)) {
+			return
+		}
+	}
+}
+
+func (r *codexQuotaRefresher) scan(ctx context.Context) {
+	minInterval := quotaRefreshDuration(r.cfg.CodexQuotaRefresh.MinAccountInterval, defaultCodexQuotaMinAccountInterval)
+	stagger := quotaRefreshDuration(r.cfg.CodexQuotaRefresh.AccountStagger, defaultCodexQuotaAccountStagger)
+	for _, auth := range r.manager.List() {
+		if ctx.Err() != nil {
+			return
+		}
+		if !isCodexQuotaCooldown(auth) || !r.shouldCheck(auth.ID, minInterval) {
+			continue
+		}
+		r.markChecked(auth.ID)
+		recovered, errCheck := r.checkAuth(ctx, auth)
+		if errCheck != nil {
+			log.Warnf("codex quota refresh failed for auth %s: %v", auth.ID, errCheck)
+		} else if recovered {
+			if _, _, errReset := r.manager.ResetQuota(ctx, auth.ID); errReset != nil {
+				log.Warnf("codex quota refresh failed to resume auth %s: %v", auth.ID, errReset)
+			} else {
+				log.Infof("codex quota recovered for auth %s; cooldown cleared", auth.ID)
+			}
+		}
+		if stagger > 0 && !waitCodexQuotaRefresh(ctx, jitterCodexQuotaDuration(stagger)) {
+			return
+		}
+	}
+}
+
+func (r *codexQuotaRefresher) shouldCheck(authID string, interval time.Duration) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	last := r.lastCheck[authID]
+	return last.IsZero() || time.Since(last) >= interval
+}
+
+func (r *codexQuotaRefresher) markChecked(authID string) {
+	r.mu.Lock()
+	r.lastCheck[authID] = time.Now()
+	r.mu.Unlock()
+}
+
+func (r *codexQuotaRefresher) checkAuth(ctx context.Context, auth *coreauth.Auth) (bool, error) {
+	token := authMetadataString(auth, "access_token")
+	if token == "" {
+		return false, fmt.Errorf("access token is missing")
+	}
+	accountID := authMetadataString(auth, "account_id")
+	urls := codexUsageEndpoints(auth)
+	client := helps.NewProxyAwareHTTPClient(ctx, r.cfg, auth, codexQuotaRequestTimeout)
+	var lastErr error
+	for _, endpoint := range urls {
+		req, errRequest := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if errRequest != nil {
+			return false, errRequest
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Accept", "application/json")
+		if accountID != "" {
+			req.Header.Set("ChatGPT-Account-ID", accountID)
+		}
+		resp, errDo := client.Do(req)
+		if errDo != nil {
+			lastErr = errDo
+			continue
+		}
+		body, errRead := io.ReadAll(resp.Body)
+		errClose := resp.Body.Close()
+		if errRead != nil {
+			lastErr = errRead
+			continue
+		}
+		if errClose != nil {
+			log.Debugf("codex quota refresh response close failed: %v", errClose)
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			lastErr = fmt.Errorf("upstream returned status %d", resp.StatusCode)
+			continue
+		}
+		var usage codexUsageResponse
+		if errJSON := json.Unmarshal(body, &usage); errJSON != nil || !validCodexUsageRateLimit(usage.RateLimit) {
+			lastErr = fmt.Errorf("invalid usage response")
+			continue
+		}
+		return !codexUsageExhausted(usage.RateLimit), nil
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("usage endpoint unavailable")
+	}
+	return false, lastErr
+}
+
+func isCodexQuotaCooldown(auth *coreauth.Auth) bool {
+	if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") || auth.Disabled {
+		return false
+	}
+	if authMetadataString(auth, "access_token") == "" {
+		return false
+	}
+	if auth.Quota.Exceeded && strings.EqualFold(strings.TrimSpace(auth.Quota.Reason), "quota") {
+		return true
+	}
+	for _, state := range auth.ModelStates {
+		if state != nil && state.Quota.Exceeded && strings.EqualFold(strings.TrimSpace(state.Quota.Reason), "quota") {
+			return true
+		}
+	}
+	return false
+}
+
+func codexUsageEndpoints(auth *coreauth.Auth) []string {
+	baseURL := "https://chatgpt.com/backend-api"
+	if auth != nil && auth.Attributes != nil {
+		if configured := strings.TrimRight(strings.TrimSpace(auth.Attributes["base_url"]), "/"); configured != "" {
+			baseURL = strings.TrimSuffix(configured, "/codex")
+		}
+	}
+	if strings.Contains(baseURL, "/backend-api") {
+		return []string{baseURL + "/wham/usage", baseURL + "/codex/usage"}
+	}
+	return []string{baseURL + "/api/codex/usage", baseURL + "/codex/usage"}
+}
+
+func codexUsageExhausted(limit *codexUsageRateLimit) bool {
+	if limit == nil || (limit.LimitReached != nil && *limit.LimitReached) {
+		return true
+	}
+	for _, window := range []*codexUsageQuotaWindow{limit.PrimaryWindow, limit.SecondaryWindow} {
+		if window != nil && window.UsedPercent >= 100 {
+			return true
+		}
+	}
+	return false
+}
+
+func validCodexUsageRateLimit(limit *codexUsageRateLimit) bool {
+	return limit != nil && (limit.LimitReached != nil || limit.PrimaryWindow != nil || limit.SecondaryWindow != nil)
+}
+
+func authMetadataString(auth *coreauth.Auth, key string) string {
+	if auth == nil || auth.Metadata == nil {
+		return ""
+	}
+	value, _ := auth.Metadata[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func quotaRefreshDuration(raw string, fallback time.Duration) time.Duration {
+	parsed, errParse := time.ParseDuration(strings.TrimSpace(raw))
+	if errParse != nil || parsed <= 0 {
+		return fallback
+	}
+	return parsed
+}
+
+func jitterCodexQuotaDuration(base time.Duration) time.Duration {
+	if base <= 0 {
+		return 0
+	}
+	spread := base / 5
+	if spread <= 0 {
+		return base
+	}
+	return base - spread + time.Duration(rand.Int64N(int64(spread*2)+1))
+}
+
+func waitCodexQuotaRefresh(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/sdk/cliproxy/codex_quota_refresher_test.go
+++ b/sdk/cliproxy/codex_quota_refresher_test.go
@@ -1,0 +1,47 @@
+package cliproxy
+
+import (
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestIsCodexQuotaCooldown(t *testing.T) {
+	auth := &coreauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{"access_token": "token"},
+		ModelStates: map[string]*coreauth.ModelState{
+			"gpt-5": {Quota: coreauth.QuotaState{Exceeded: true, Reason: "quota"}},
+		},
+	}
+	if !isCodexQuotaCooldown(auth) {
+		t.Fatal("expected Codex quota cooldown")
+	}
+	auth.ModelStates["gpt-5"].Quota.Reason = "cloudflare challenge"
+	if isCodexQuotaCooldown(auth) {
+		t.Fatal("non-quota cooldown must not be actively refreshed")
+	}
+}
+
+func TestCodexUsageExhausted(t *testing.T) {
+	reached := true
+	if !codexUsageExhausted(&codexUsageRateLimit{LimitReached: &reached}) {
+		t.Fatal("limit_reached must be exhausted")
+	}
+	if !codexUsageExhausted(&codexUsageRateLimit{SecondaryWindow: &codexUsageQuotaWindow{UsedPercent: 100}}) {
+		t.Fatal("100 percent secondary window must be exhausted")
+	}
+	if codexUsageExhausted(&codexUsageRateLimit{PrimaryWindow: &codexUsageQuotaWindow{UsedPercent: 25}}) {
+		t.Fatal("available primary window must not be exhausted")
+	}
+}
+
+func TestQuotaRefreshDuration(t *testing.T) {
+	if got := quotaRefreshDuration("2m", time.Hour); got != 2*time.Minute {
+		t.Fatalf("quotaRefreshDuration() = %v", got)
+	}
+	if got := quotaRefreshDuration("invalid", time.Hour); got != time.Hour {
+		t.Fatalf("invalid quotaRefreshDuration() = %v", got)
+	}
+}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -88,6 +88,9 @@ type Service struct {
 	// authQueueStop cancels the auth update queue processing.
 	authQueueStop context.CancelFunc
 
+	// codexQuotaRefreshCancel stops active Codex quota synchronization.
+	codexQuotaRefreshCancel context.CancelFunc
+
 	// authManager handles legacy authentication operations.
 	authManager *sdkAuth.Manager
 
@@ -1331,6 +1334,7 @@ func (s *Service) applyConfigUpdateWithAuthSynthesis(newCfg *config.Config, synt
 	s.cfgMu.Lock()
 	s.cfg = newCfg
 	s.cfgMu.Unlock()
+	s.restartCodexQuotaRefresher(context.Background(), newCfg)
 	if s.coreManager != nil {
 		s.coreManager.SetConfig(newCfg)
 		s.coreManager.SetOAuthModelAlias(newCfg.OAuthModelAlias)
@@ -1679,6 +1683,7 @@ func (s *Service) Run(ctx context.Context) error {
 	// legacy clients removed; no caches to refresh
 
 	s.ensureWebsocketGateway()
+	s.restartCodexQuotaRefresher(ctx, s.cfg)
 	if homeEnabled {
 		s.registerAvailableExecutors(ctx, executorRegistrationOptions{
 			includeBaseline: true,
@@ -1824,6 +1829,10 @@ func (s *Service) Shutdown(ctx context.Context) error {
 
 		if s.watcherCancel != nil {
 			s.watcherCancel()
+		}
+		if s.codexQuotaRefreshCancel != nil {
+			s.codexQuotaRefreshCancel()
+			s.codexQuotaRefreshCancel = nil
 		}
 		if s.coreManager != nil {
 			s.coreManager.StopAutoRefresh()


### PR DESCRIPTION
## What changed

- synchronize Codex quota state from `x-codex-*` response headers
- actively verify quota-exhausted Codex OAuth accounts with staggered, throttled usage checks
- clear local cooldown only after upstream confirms quota recovery
- add configurable scan, per-account, and stagger intervals
- add unit coverage for quota parsing, cooldown filtering, and recovery behavior

## Why

Codex quota windows can reset earlier than their previously reported `resets_at`. The existing scheduler can therefore keep an account cooled down after upstream capacity has already recovered.

This adopts the passive-header plus active-verification approach used by codex-proxy while retaining CLIProxyAPI's existing cooldown and routing state machinery.

## Impact

Active accounts update quota without extra requests. Only quota-exhausted Codex OAuth accounts are actively checked, with a default 15-minute scan, 30-minute minimum per-account interval, and staggered requests.

## Validation

- `go test ./...`
- `go build -o test-output.exe ./cmd/server`
- `git diff --check`
