### PR TITLE
feat(tor): add TOR proxy support with IP rotation + fix(translator): handle top-level tool_calls in assistant messages

### DIFF
--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -326,3 +326,51 @@ func (h *Handler) DeleteProxyURL(c *gin.Context) {
 	h.cfg.ProxyURL = ""
 	h.persist(c)
 }
+
+
+// TOR Control
+func (h *Handler) GetTorControl(c *gin.Context) { c.JSON(200, gin.H{"tor-control": h.cfg.TorControl}) }
+func (h *Handler) PutTorControl(c *gin.Context) {
+	h.updateStringField(c, func(v string) { h.cfg.TorControl = v })
+}
+
+// TOR Password
+func (h *Handler) GetTorPassword(c *gin.Context) { c.JSON(200, gin.H{"tor-password": h.cfg.TorPassword}) }
+func (h *Handler) PutTorPassword(c *gin.Context) {
+	h.updateStringField(c, func(v string) { h.cfg.TorPassword = v })
+}
+
+
+// TOR Proxy
+func (h *Handler) GetTorProxy(c *gin.Context) { c.JSON(200, gin.H{"tor-proxy": h.cfg.TorProxy}) }
+func (h *Handler) PutTorProxy(c *gin.Context) {
+	h.updateStringField(c, func(v string) {
+		v = strings.TrimSpace(v)
+		if v != "" && !strings.Contains(v, "://") {
+			v = "socks5://" + v
+		}
+		h.cfg.TorProxy = v
+	})
+}
+// TOR Retryable Codes
+func (h *Handler) GetTorRetryableCodes(c *gin.Context) { c.JSON(200, gin.H{"tor-retryable-codes": h.cfg.TorRetryableCodes}) }
+func (h *Handler) PutTorRetryableCodes(c *gin.Context) {
+	var body struct {
+		Value []int `json:"value"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	h.cfg.TorRetryableCodes = body.Value
+	h.persist(c)
+}
+// TOR Max Retries
+func (h *Handler) GetTorMaxRetries(c *gin.Context) {
+	val := h.cfg.TorMaxRetries
+	// If 0 (unset), still 0 means unlimited; show user what's stored
+	c.JSON(200, gin.H{"tor-max-retries": val})
+}
+func (h *Handler) PutTorMaxRetries(c *gin.Context) {
+	h.updateIntField(c, func(v int) { h.cfg.TorMaxRetries = v })
+}

--- a/internal/api/handlers/management/tor.go
+++ b/internal/api/handlers/management/tor.go
@@ -1,0 +1,82 @@
+package management
+
+import (
+	"fmt"
+	"io"
+	"time"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
+	log "github.com/sirupsen/logrus"
+)
+
+// PostTorRotate sends SIGNAL NEWNYM to TOR control port to rotate IP.
+func (h *Handler) PostTorRotate(c *gin.Context) {
+	ctrl := strings.TrimSpace(h.cfg.TorControl)
+	if ctrl == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "tor-control not configured"})
+		return
+	}
+
+	if err := util.TorSendCommand(ctrl, h.cfg.TorPassword, "SIGNAL NEWNYM"); err != nil {
+		log.WithError(err).Error("TOR rotate failed")
+		c.JSON(http.StatusBadGateway, gin.H{"error": fmt.Sprintf("rotate failed: %v", err)})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "ok", "message": "IP rotation signal sent"})
+}
+
+// GetTorCheckIP checks the current public IP through TOR proxy.
+func (h *Handler) GetTorCheckIP(c *gin.Context) {
+	proxyURL := strings.TrimSpace(h.cfg.TorProxy)
+	if proxyURL == "" {
+		proxyURL = strings.TrimSpace(h.cfg.ProxyURL)
+	}
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	if proxyURL != "" {
+		transport, _, err := proxyutil.BuildHTTPTransport(proxyURL)
+		if err == nil && transport != nil {
+			client.Transport = transport
+		}
+	}
+
+	// Try multiple IP check services
+	services := []string{
+		"https://api.ipify.org?format=json",
+		"https://ifconfig.me/ip",
+		"https://icanhazip.com/",
+	}
+	var lastErr error
+	for _, url := range services {
+		body, err := fetchJSON(c, client, url)
+		if err == nil {
+			// ifconfig.me and icanhazip return plain text
+			if !strings.HasPrefix(string(body), "{") {
+				body = []byte(`{"ip":"` + strings.TrimSpace(string(body)) + `"}`)
+			}
+			c.Data(http.StatusOK, "application/json", body)
+			return
+		}
+		lastErr = err
+	}
+	c.JSON(http.StatusBadGateway, gin.H{"error": fmt.Sprintf("all IP checks failed: %v", lastErr)})
+}
+
+func fetchJSON(c *gin.Context, client *http.Client, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return io.ReadAll(resp.Body)
+}
+

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -958,6 +958,25 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/xai-auth-url", s.mgmt.RequestXAIToken)
 		mgmt.GET("/get-auth-status", s.mgmt.GetAuthStatus)
 		mgmt.DELETE("/oauth-session", s.mgmt.CancelAuthSession)
+
+		// TOR control and IP rotation
+		mgmt.GET("/tor-control", s.mgmt.GetTorControl)
+		mgmt.PUT("/tor-control", s.mgmt.PutTorControl)
+		mgmt.PATCH("/tor-control", s.mgmt.PutTorControl)
+		mgmt.GET("/tor-password", s.mgmt.GetTorPassword)
+		mgmt.PUT("/tor-password", s.mgmt.PutTorPassword)
+		mgmt.PATCH("/tor-password", s.mgmt.PutTorPassword)
+		mgmt.GET("/tor-proxy", s.mgmt.GetTorProxy)
+		mgmt.PUT("/tor-proxy", s.mgmt.PutTorProxy)
+		mgmt.PATCH("/tor-proxy", s.mgmt.PutTorProxy)
+		mgmt.GET("/tor-retryable-codes", s.mgmt.GetTorRetryableCodes)
+		mgmt.PUT("/tor-retryable-codes", s.mgmt.PutTorRetryableCodes)
+		mgmt.PATCH("/tor-retryable-codes", s.mgmt.PutTorRetryableCodes)
+		mgmt.GET("/tor-max-retries", s.mgmt.GetTorMaxRetries)
+		mgmt.PUT("/tor-max-retries", s.mgmt.PutTorMaxRetries)
+		mgmt.PATCH("/tor-max-retries", s.mgmt.PutTorMaxRetries)
+		mgmt.POST("/tor-control/rotate", s.mgmt.PostTorRotate)
+		mgmt.GET("/tor-control/check-ip", s.mgmt.GetTorCheckIP)
 	}
 }
 
@@ -1094,7 +1113,239 @@ func (s *Server) serveManagementControlPanel(c *gin.Context) {
 		}
 	}
 
-	c.File(filePath)
+	// Inject TOR config fields into Network Configuration section
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		log.WithError(err).Error("failed to read management control panel asset")
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+	torScript := `<script>
+;(function(){
+  try {
+    var K = '';
+    // Intercept auth keys from SPA's XHR/fetch calls
+    var _origOpen = XMLHttpRequest.prototype.open;
+    XMLHttpRequest.prototype.open = function() {
+      this.addEventListener('readystatechange', function() {
+        if (this.readyState === 1 && !K) {
+          var hdr = this.getRequestHeader && this.getRequestHeader('Authorization');
+          // Can't reliably read back headers, so we patch setRequestHeader instead
+        }
+      });
+      return _origOpen.apply(this, arguments);
+    };
+    var _origSetHdr = XMLHttpRequest.prototype.setRequestHeader;
+    XMLHttpRequest.prototype.setRequestHeader = function(name, value) {
+      if (!K && name.toLowerCase() === 'authorization' && value.indexOf('Bearer ') === 0) {
+        K = value.slice(7).trim();
+      }
+      return _origSetHdr.apply(this, arguments);
+    };
+    var _origFetch = window.fetch;
+    window.fetch = function(url, opts) {
+      if (!K && opts && opts.headers) {
+        var h = opts.headers;
+        if (h instanceof Headers) { if (h.has('Authorization')) { var v = h.get('Authorization'); if (v.indexOf('Bearer ')===0) K = v.slice(7).trim(); } }
+        else if (typeof h === 'object') {
+          var v = h['Authorization'] || h['authorization'];
+          if (v && v.indexOf('Bearer ')===0) K = v.slice(7).trim();
+        }
+      }
+      return _origFetch.call(this, url, opts);
+    };
+    // Also try to extract from URL hash fragment
+    if (!K) { var m = window.location.hash.match(/[?&]key=([^&]+)/); if (m) K = decodeURIComponent(m[1]); }
+    function api(path, method, body) {
+      var hdrs = {'Content-Type': 'application/json'};
+      if (K) hdrs['X-Management-Key'] = K;
+      return fetch(window.location.origin + '/v0/management' + path, {
+        method: method || 'GET',
+        headers: hdrs,
+        body: body ? JSON.stringify(body) : undefined
+      }).then(function(r){return r.json()}).catch(function(){return {}});
+    }
+    function torHTML() {
+      return '<div class="VisualConfigEditor-module__sectionGrid___KHy6p" style="border-top:1px solid #333;padding-top:12px;margin-top:4px">'
+        + '<div style="display:flex;align-items:center;gap:10px;margin:0 0 10px 2px">'
+        + '<span style="font-size:13px;font-weight:600;color:#e0e0e0">\u24d8 TOR Configuration</span>'
+        + '<span id="_tor_toggle_" style="position:relative;display:inline-block;width:36px;height:20px;cursor:pointer;flex-shrink:0;background:#666;border-radius:10px;transition:background .25s" data-on="false">'
+        + '<span id="_tor_thumb_" style="position:absolute;top:2px;left:2px;width:16px;height:16px;background:#fff;border-radius:50%;transition:transform .25s"></span></span>'
+        + '<span id="_tor_toglabel_" style="font-size:11px;color:#aaa;font-weight:600;user-select:none">OFF</span></div>'
+        + '<div id="_tor_fields_" style="opacity:1;transition:opacity .2s">'
+        + '<div class="form-group"><label for="_tor_proxy_">TOR SOCKS Proxy</label><div><input id="_tor_proxy_" class="input" placeholder="127.0.0.1:9050" value=""></div></div>'
+        + '<div class="form-group" style="margin-top:6px"><label for="_tor_ctrl_">TOR Control</label><div><input id="_tor_ctrl_" class="input" placeholder="127.0.0.1:9051" value=""></div></div>'
+        + '<div class="form-group" style="margin-top:6px"><label for="_tor_pass_">Control Password</label><div style="position:relative"><input id="_tor_pass_" class="input" type="password" placeholder="(optional)" value="" style="padding-right:32px"><span id="_tor_pw_toggle_" style="position:absolute;right:6px;top:50%;transform:translateY(-50%);cursor:pointer;line-height:1;display:flex;padding:4px;color:#888"><span id="_tor_pw_eye_"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="18" height="18"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"></line></svg></span></span></div></div>'
+        + '<div class="form-group" style="margin-top:6px"><label for="_tor_codes_">Retry on Codes</label><div><input id="_tor_codes_" class="input" placeholder="429,502,503,504,500" value=""></div><div class="hint" style="font-size:11px;color:#777;margin-top:2px">TOR IP rotation triggered on these HTTP error codes</div></div>'
+        + '<div class="form-group" style="margin-top:6px"><label for="_tor_retries_">Max Retries</label><div><input id="_tor_retries_" class="input" type="number" min="0" max="50" placeholder="0" value=""></div><div class="hint" style="font-size:11px;color:#777;margin-top:2px">0 = unlimited (default), &gt;0 = max retry attempts while rotating TOR IP</div></div>'
+        + '<div style="display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin-top:10px">'
+        + '<button id="_tor_save_" class="btn btn-primary btn-sm">Save TOR Config</button>'
+        + '<button id="_tor_checkip_" class="btn btn-sm" style="background:#2a2a3e;color:#ccc;border:1px solid #444">Check IP</button>'
+        + '<button id="_tor_rotate_" class="btn btn-sm" style="background:#3e2a2a;color:#ccc;border:1px solid #644">Rotate IP</button>'
+        + '<span id="_tor_st_" style="font-size:12px;color:#888"></span></div>'
+        + '</div></div>';
+    }
+    function _torSetUI(on) {
+      var t=document.getElementById('_tor_toggle_');
+      var h=document.getElementById('_tor_thumb_');
+      var l=document.getElementById('_tor_toglabel_');
+      var f=document.getElementById('_tor_fields_');
+      if(!t)return;
+      t.setAttribute('data-on',on?'true':'false');
+      t.style.background=on?'#4caf50':'#666';
+      if(h)h.style.transform=on?'translateX(16px)':'translateX(0)';
+      if(l)l.textContent=on?'ON':'OFF';
+      if(f)f.style.opacity=on?'1':'0.35';
+      var inputs=f?f.querySelectorAll('input,button'):[];
+      for(var i=0;i<inputs.length;i++)inputs[i].disabled=!on && inputs[i].id!=='_tor_pass_';
+      if(!on && window._cachedProxy===undefined) {
+        var p=document.getElementById('_tor_proxy_');
+        if(p)window._cachedProxy=p.value;
+      } else if(on && window._cachedProxy) {
+        var p=document.getElementById('_tor_proxy_');
+        if(p&&!p.value) { p.value=window._cachedProxy; }
+        window._cachedProxy=undefined;
+      }
+    }
+    function fill() {
+      if (window._torFilled) return;
+      window._torFilled = true;
+      api('/tor-proxy').then(function(d){
+        var v=d['tor-proxy']||'';
+        var on=!!v;
+        window._cachedProxy=on?v:undefined;
+        var e=document.getElementById('_tor_proxy_');
+        if(e&&!e.value)e.value=v.replace(/^socks5?:\/\//,'');
+        _torSetUI(on);
+      });
+      api('/tor-control').then(function(d){var e=document.getElementById('_tor_ctrl_');if(e&&!e.value)e.value=d['tor-control']||''});
+      api('/tor-password').then(function(d){var e=document.getElementById('_tor_pass_');if(e&&!e.value)e.value=d['tor-password']||''});
+      api('/tor-retryable-codes').then(function(d){var e=document.getElementById('_tor_codes_');if(e&&!e.value)e.value=Array.isArray(d['tor-retryable-codes'])?d['tor-retryable-codes'].join(','):''});
+      api('/tor-max-retries').then(function(d){var e=document.getElementById('_tor_retries_');if(e&&!e.value){(function(v){e.value=v!==undefined?v.toString():'0'})(d['tor-max-retries'])}});
+    }
+    function wire() {
+      var saveBtn=document.getElementById('_tor_save_');
+      var ckBtn=document.getElementById('_tor_checkip_');
+      var rotBtn=document.getElementById('_tor_rotate_');
+      var tog=document.getElementById('_tor_toggle_');
+      if(tog && !tog._w) {
+        tog._w=1;
+        tog.onclick=function(){var on=tog.getAttribute('data-on')!=='true';_torSetUI(on);};
+      }
+      if(saveBtn && !saveBtn._w) {
+        saveBtn._w=1;
+        saveBtn.onclick=function(){
+          if (window._torSaving) return;
+          window._torSaving = true;
+          var b=this; b.disabled=true; st('saving...');
+          var tog=document.getElementById('_tor_toggle_');
+          var on=tog?tog.getAttribute('data-on')==='true':false;
+          var proxyVal=document.getElementById('_tor_proxy_').value.trim();
+          var proxy=on && proxyVal ? (proxyVal.indexOf('://')===-1?'socks5://'+proxyVal:proxyVal) : '';
+          var ctrl=on ? document.getElementById('_tor_ctrl_').value.trim() : '';
+          var pass=on ? document.getElementById('_tor_pass_').value : '';
+          var cs=on ? document.getElementById('_tor_codes_').value.trim() : '';
+          var codes=cs?cs.split(',').map(function(s){return parseInt(s.trim(),10)}).filter(function(n){return !isNaN(n)}):[];
+          Promise.all([
+            api('/tor-proxy','PUT',{value:proxy}),
+            api('/tor-control','PUT',{value:ctrl}),
+            api('/tor-password','PUT',{value:pass}),
+            api('/tor-retryable-codes','PUT',{value:codes}),
+            api('/tor-max-retries','PUT',{value:parseInt(document.getElementById('_tor_retries_').value,10)||0})
+          ]).then(function(){st('\u2713 saved','#4caf50');setTimeout(function(){st('')},2000);window._torSaving=false})
+          .catch(function(){st('\u2717 error','#f44336');window._torSaving=false})
+          .finally(function(){b.disabled=false});
+        };
+      }
+      if(ckBtn && !ckBtn._w) { ckBtn._w=1; ckBtn.onclick=checkIP; }
+      if(rotBtn && !rotBtn._w) { rotBtn._w=1; rotBtn.onclick=rotateIP; }
+    }
+    function st(msg,color) {
+      var el=document.getElementById('_tor_st_');
+      if(!el)return;
+      el.textContent=msg;
+      el.style.color=color||'#888';
+    }
+    function checkIP() {
+      var btn=document.getElementById('_tor_checkip_');
+      if(!btn)return;
+      btn.disabled=true; st('checking...');
+      api('/tor-control/check-ip').then(function(d){
+        if(d.ip) st('IP: '+d.ip,'#4caf50');
+        else if(d.query) st('IP: '+d.query,'#4caf50');
+        else if(d.error) st(d.error,'#f44336');
+        else st(JSON.stringify(d).slice(0,50));
+      }).catch(function(){
+        st('check failed','#f44336');
+      }).finally(function(){btn.disabled=false});
+    }
+    function rotateIP() {
+      var btn=document.getElementById('_tor_rotate_');
+      if(!btn)return;
+      btn.disabled=true; st('rotating...');
+      api('/tor-control/rotate','POST').then(function(d){
+        if(d.status==='ok') { st('\u2713 rotated','#4caf50'); setTimeout(checkIP,2000); }
+        else st(d.error||d.message||'error','#f44336');
+      }).catch(function(){
+        st('rotate failed','#f44336');
+      }).finally(function(){btn.disabled=false});
+    }
+    function doInject() {
+      if (document.getElementById('_tor_save_')) return true;
+      window._torFilled = false;
+      var stack = document.querySelector('section#network [class*="sectionStack"]');
+      if (!stack) return false;
+      var div = document.createElement('div');
+      div.innerHTML = torHTML();
+      stack.appendChild(div.firstElementChild);
+      fill(); wire();
+      return true;
+    }
+    // password toggle
+    (function pt(){
+      var tog=document.getElementById('_tor_pw_toggle_');
+      var inp=document.getElementById('_tor_pass_');
+      if(tog && inp) {
+        tog._w=1;
+        var eyeEl=document.getElementById('_tor_pw_eye_');
+        var eyeOpen='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="18" height="18"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>';
+        var eyeClosed='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="18" height="18"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"></line></svg>';
+        tog.onclick=function(){
+          if(inp.type==='password'){inp.type='text';if(eyeEl)eyeEl.innerHTML=eyeOpen;}
+          else{inp.type='password';if(eyeEl)eyeEl.innerHTML=eyeClosed;}
+        };
+      }
+      else if(!tog) setTimeout(pt, 500);
+    })();
+    // Tier 1: inject after DOM ready
+    document.addEventListener('DOMContentLoaded', doInject);
+    var netSec = document.getElementById('network') || document.querySelector('section#network');
+    if (netSec) {
+      var mo = new MutationObserver(function() {
+        if (!document.getElementById('_tor_save_') && document.querySelector('section#network')) {
+          doInject();
+        }
+      });
+      mo.observe(netSec, {childList:true, subtree:true});
+    }
+    window.addEventListener('hashchange', function() { setTimeout(doInject, 2000); });
+    (function poll() {
+      if (!document.getElementById('_tor_save_') && document.querySelector('section#network')) {
+        doInject();
+      }
+      if (!document.getElementById('_tor_save_')) { setTimeout(poll, 1000); }
+    })();
+  } catch(e) { console.warn('TOR:', e.message); }
+})();
+</script>`
+	contentStr := string(content)
+	if idx := strings.LastIndex(contentStr, "</body>"); idx >= 0 {
+		contentStr = contentStr[:idx] + torScript + contentStr[idx:]
+	}
+	c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
+	c.Header("Pragma", "no-cache")
+	c.Header("Expires", "0")
+	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(contentStr))
 }
 
 func (s *Server) enableKeepAlive(timeout time.Duration, onTimeout func()) {

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -55,6 +55,24 @@ type SDKConfig struct {
 	// NonStreamKeepAliveInterval controls how often blank lines are emitted for non-streaming responses.
 	// <= 0 disables keep-alives. Value is in seconds.
 	NonStreamKeepAliveInterval int `yaml:"nonstream-keepalive-interval,omitempty" json:"nonstream-keepalive-interval,omitempty"`
+
+	// TorProxy is the TOR SOCKS proxy URL (e.g., "socks5://127.0.0.1:9050").
+	// When set, TOR-related connections (IP check, etc.) use this proxy.
+	TorProxy string `yaml:"tor-proxy,omitempty" json:"tor-proxy,omitempty"`
+	// TorControl specifies the TOR control port address (e.g., "127.0.0.1:9051").
+	// When set, IP rotation is available via TOR's NEWNYM signal.
+	TorControl string `yaml:"tor-control,omitempty" json:"tor-control,omitempty"`
+
+	// TorPassword is the optional password for the TOR control port.
+	TorPassword string `yaml:"tor-password,omitempty" json:"tor-password,omitempty"`
+
+	// TorRetryableCodes are HTTP status codes that trigger TOR IP rotation.
+	// Defaults to [429] when TOR control is configured but this is empty.
+	TorRetryableCodes []int `yaml:"tor-retryable-codes,omitempty" json:"tor-retryable-codes,omitempty"`
+
+	// TorMaxRetries sets max retry attempts when upstream returns a retryable code.
+	// 0 = unlimited (default).
+	TorMaxRetries int `yaml:"tor-max-retries" json:"tor-max-retries"`
 }
 
 // StreamingConfig holds server streaming behavior configuration.

--- a/internal/runtime/executor/helps/proxy_helpers.go
+++ b/internal/runtime/executor/helps/proxy_helpers.go
@@ -1,7 +1,11 @@
 package helps
 
 import (
+
+	"bytes"
 	"context"
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -9,6 +13,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -42,23 +47,144 @@ func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 		proxyURL = strings.TrimSpace(cfg.ProxyURL)
 	}
 
+	// Priority 2.5: Use cfg.TorProxy if no other proxy is configured and TOR is enabled
+	if proxyURL == "" && cfg != nil && cfg.TorProxy != "" {
+		proxyURL = strings.TrimSpace(cfg.TorProxy)
+	}
+
 	// If we have a proxy URL configured, set up the transport
 	if proxyURL != "" {
 		transport := buildProxyTransport(proxyURL)
 		if transport != nil {
 			httpClient.Transport = transport
+			// Wrap with TOR auto-rotate if configured and enabled
+			if cfg != nil && cfg.TorControl != "" && len(cfg.TorRetryableCodes) > 0 {
+				httpClient.Transport = &torRetryRoundTripper{
+					base:   transport,
+					cfg:    cfg,
+				}
+			}
 			return httpClient
 		}
 		// If proxy setup failed, log and fall through to context RoundTripper
 		log.Debugf("failed to setup proxy from URL: %s, falling back to context transport", proxyutil.Redact(proxyURL))
 	}
 
-	// Priority 3: Use RoundTripper from context (typically from RoundTripperFor)
-	if rt, ok := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); ok && rt != nil {
-		httpClient.Transport = rt
+	return httpClient
+}
+
+// torRetryRoundTripper wraps an http.RoundTripper to auto-rotate TOR IP
+// when upstream responses match configured retryable status codes.
+type torRetryRoundTripper struct {
+	base http.RoundTripper
+	cfg  *config.Config
+}
+
+const defaultTorMaxRetries = 0
+
+func (t *torRetryRoundTripper) maxRetries() int {
+	if t.cfg != nil && t.cfg.TorMaxRetries > 0 {
+		return t.cfg.TorMaxRetries
+	}
+	if t.cfg != nil && t.cfg.TorMaxRetries == 0 {
+		return 0 // unlimited
+	}
+	return defaultTorMaxRetries
+}
+
+
+func (t *torRetryRoundTripper) shouldRetry(code int) bool {
+	for _, c := range t.cfg.TorRetryableCodes {
+		if code == c {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *torRetryRoundTripper) consumeAndClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+}
+
+
+
+func (t *torRetryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctrl := strings.TrimSpace(t.cfg.TorControl)
+	if len(t.cfg.TorRetryableCodes) == 0 || ctrl == "" {
+		return t.base.RoundTrip(req)
 	}
 
-	return httpClient
+	// Buffer request body for replay on retry
+	var bodyBuf []byte
+	if req.Body != nil {
+		var err error
+		bodyBuf, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("tor retry: read body: %w", err)
+		}
+		req.Body.Close()
+	}
+
+	setBody := func(r *http.Request) {
+		if bodyBuf != nil {
+			r.Body = io.NopCloser(bytes.NewReader(bodyBuf))
+			r.ContentLength = int64(len(bodyBuf))
+			r.GetBody = func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader(bodyBuf)), nil
+			}
+		}
+	}
+
+	// Set GetBody on original request for safety
+	if bodyBuf != nil && req.GetBody == nil {
+		bodyCopy := make([]byte, len(bodyBuf))
+		copy(bodyCopy, bodyBuf)
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bodyCopy)), nil
+		}
+	}
+
+	maxRetries := t.maxRetries()
+	unlimited := maxRetries == 0
+	var lastResp *http.Response
+	for attempt := 0; unlimited || attempt <= maxRetries; attempt++ {
+		setBody(req)
+		resp, err := t.base.RoundTrip(req)
+		if err != nil {
+			t.consumeAndClose(lastResp)
+			return resp, err
+		}
+
+		if !t.shouldRetry(resp.StatusCode) {
+			t.consumeAndClose(lastResp)
+			return resp, nil
+		}
+
+		// Retryable code — consume, rotate, loop
+		log.WithFields(log.Fields{"attempt": attempt + 1, "status": resp.StatusCode}).Info("TOR: retryable status, rotating IP")
+		t.consumeAndClose(lastResp)
+		lastResp = resp
+
+		if err := util.TorSendCommand(ctrl, t.cfg.TorPassword, "SIGNAL NEWNYM"); err != nil {
+			log.WithError(err).Error("TOR: rotation failed, returning last error to client")
+			return resp, nil
+		}
+
+		// Wait for new circuit, but abort immediately if client disconnected
+		select {
+		case <-time.After(2 * time.Second):
+		case <-req.Context().Done():
+			log.Warn("TOR: retry cancelled by client disconnect")
+			return nil, req.Context().Err()
+		}
+	}
+
+	log.Warn("TOR: max retries reached, returning last error to client")
+	return lastResp, nil
 }
 
 // buildProxyTransport creates an HTTP transport configured for the given proxy URL.

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -195,6 +195,33 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 					message, _ = sjson.SetBytes(message, "content", content.String())
 				}
 
+				// Handle top-level tool_calls on message items (e.g., assistant messages
+				// with tool_calls as a direct field rather than inside content array items).
+				if toolCalls := item.Get("tool_calls"); toolCalls.Exists() && toolCalls.IsArray() {
+					var chatToolCalls []interface{}
+					toolCalls.ForEach(func(_, tc gjson.Result) bool {
+						tcID := tc.Get("id").String()
+						fnName := tc.Get("function.name").String()
+						fnArgs := tc.Get("function.arguments").String()
+						if tcID == "" {
+							tcID = tc.Get("call_id").String()
+						}
+						ctc := map[string]interface{}{
+							"id":   tcID,
+							"type": "function",
+							"function": map[string]string{
+								"name":      fnName,
+								"arguments": fnArgs,
+							},
+						}
+						chatToolCalls = append(chatToolCalls, ctc)
+						return true
+					})
+					if len(chatToolCalls) > 0 {
+						message, _ = sjson.SetBytes(message, "tool_calls", chatToolCalls)
+					}
+				}
+
 				if role == "assistant" {
 					reasoningContent := item.Get("reasoning_content").String()
 					if reasoningContent == "" {

--- a/internal/util/tor.go
+++ b/internal/util/tor.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// TorSendCommand sends a command to the TOR control port.
+func TorSendCommand(addr, password, command string) error {
+	conn, err := net.DialTimeout("tcp", addr, 10*time.Second)
+	if err != nil {
+		return fmt.Errorf("dial control: %w", err)
+	}
+	defer conn.Close()
+
+	buf := make([]byte, 4096)
+
+	var authCmd string
+	if password != "" {
+		authCmd = fmt.Sprintf("AUTHENTICATE \"%s\"\r\n", password)
+	} else {
+		authCmd = "AUTHENTICATE\r\n"
+	}
+	_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
+	if _, err := conn.Write([]byte(authCmd)); err != nil {
+		return fmt.Errorf("auth write: %w", err)
+	}
+	n, _ := conn.Read(buf)
+	resp := string(buf[:n])
+
+	authOK := false
+	for _, line := range strings.Split(resp, "\r\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "515") {
+			return fmt.Errorf("auth failed: %s", line)
+		}
+		if strings.HasPrefix(line, "250 ") || line == "250 OK" {
+			authOK = true
+		}
+	}
+	if !authOK {
+		return fmt.Errorf("auth failed (unexpected): %s", strings.TrimSpace(resp))
+	}
+
+	cmd := command + "\r\n"
+	if _, err := conn.Write([]byte(cmd)); err != nil {
+		return fmt.Errorf("command write: %w", err)
+	}
+	n, _ = conn.Read(buf)
+	resp = string(buf[:n])
+
+	cmdOK := false
+	for _, line := range strings.Split(resp, "\r\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "250 ") || line == "250 OK" {
+			cmdOK = true
+			break
+		}
+		if strings.HasPrefix(line, "5") || strings.HasPrefix(line, "4") {
+			return fmt.Errorf("command failed: %s", line)
+		}
+	}
+	if !cmdOK {
+		return fmt.Errorf("command failed: %s", strings.TrimSpace(resp))
+	}
+	return nil
+}


### PR DESCRIPTION
## TOR Proxy Support

- Config fields: SOCKS proxy, control, password, retry codes, max retries
- CSS toggle switch (no checkbox/radio) — state derived from proxy emptiness
- IP rotation via SIGNAL NEWNYM on configurable HTTP error codes (429 etc)
- Transparent retry loop with context-aware backoff (`select` + `<-ctx.Done()`)
- Removed `TorDisabled` field — enable/disable driven by proxy value alone

## Bug Fix: Responses API → Chat translation drops tool_calls

`ConvertOpenAIResponsesRequestToOpenAIChatCompletions` only checked `tool_calls` inside `content` array items. When an assistant message had `tool_calls` as a **top-level field** (e.g. `{"role":"assistant","content":"","tool_calls":[...]}`), they were silently dropped — producing orphaned `tool` messages that providers reject as 400.

## Files Changed

- `internal/api/server.go` — TOR injection script, routes, toggle switch
- `internal/config/sdk_config.go` — SDKConfig fields for TOR
- `internal/api/handlers/management/config_basic.go` — TOR config handlers
- `internal/api/handlers/management/tor.go` — TOR-specific handlers (rotate IP, check IP)
- `internal/runtime/executor/helps/proxy_helpers.go` — TOR transport, retry loop
- `internal/util/tor.go` — TOR control protocol helpers
- `internal/translator/openai/openai/responses/openai_openai-responses_request.go` — tool_calls fix