### PR TITLE
fix(xai): promote Codex additional_tools out of input (ModelInput 422)

### DIFF
--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -933,6 +933,7 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	}
 	body = normalizeXAIInputCustomToolCalls(body)
 	body = normalizeXAIInputNamespaceToolCalls(body)
+	body = normalizeXAIInputAgentMessages(body)
 	body = normalizeXAIInputReasoningItems(body)
 	body = sanitizeXAIInputEncryptedContent(body)
 	body = normalizeCodexInstructions(body)
@@ -1330,6 +1331,13 @@ func sanitizeXAIResponsesBody(body []byte, model string) []byte {
 		if reasoning := gjson.GetBytes(body, "reasoning"); reasoning.Exists() && reasoning.IsObject() && len(reasoning.Map()) == 0 {
 			body, _ = sjson.DeleteBytes(body, "reasoning")
 		}
+	}
+	// OpenAI service tiers (priority/flex) are not part of xAI Responses.
+	if gjson.GetBytes(body, "service_tier").Exists() {
+		body, _ = sjson.DeleteBytes(body, "service_tier")
+	}
+	if gjson.GetBytes(body, "client_metadata").Exists() {
+		body, _ = sjson.DeleteBytes(body, "client_metadata")
 	}
 	return body
 }
@@ -2466,6 +2474,102 @@ func sanitizeXAIInputEncryptedContent(body []byte) []byte {
 		}).Debug("xai executor: removed invalid encrypted_content before upstream")
 	}
 	return mergeAdjacentXAIInputReasoningSummaries(updated)
+}
+
+
+// normalizeXAIInputAgentMessages rewrites Codex multi-agent "agent_message"
+// input items to plain "message" items. xAI ModelInput has no agent_message
+// variant, so multi-agent subagent turns otherwise fail with HTTP 422.
+// Nested content parts of type encrypted_content are also dropped — they are
+// Codex collaboration payloads, not xAI message content.
+func normalizeXAIInputAgentMessages(body []byte) []byte {
+	input := gjson.GetBytes(body, "input")
+	if !input.Exists() || !input.IsArray() {
+		return body
+	}
+
+	changed := false
+	items := make([]json.RawMessage, 0, len(input.Array()))
+	for _, item := range input.Array() {
+		if item.Get("type").String() != "agent_message" {
+			items = append(items, json.RawMessage(item.Raw))
+			continue
+		}
+		changed = true
+		raw := []byte(item.Raw)
+		updated, errSet := sjson.SetBytes(raw, "type", "message")
+		if errSet != nil {
+			return body
+		}
+		raw = updated
+		if !item.Get("role").Exists() || strings.TrimSpace(item.Get("role").String()) == "" {
+			updated, errSet = sjson.SetBytes(raw, "role", "user")
+			if errSet != nil {
+				return body
+			}
+			raw = updated
+		}
+		for _, field := range []string{"author", "recipient", "name", "id"} {
+			if item.Get(field).Exists() {
+				updated, errDel := sjson.DeleteBytes(raw, field)
+				if errDel != nil {
+					return body
+				}
+				raw = updated
+			}
+		}
+		content := item.Get("content")
+		if content.IsArray() {
+			filtered := []byte(`[]`)
+			kept := 0
+			for _, part := range content.Array() {
+				partType := strings.TrimSpace(part.Get("type").String())
+				if partType == "encrypted_content" || partType == "" {
+					continue
+				}
+				next, errSet := sjson.SetRawBytes(filtered, "-1", []byte(part.Raw))
+				if errSet != nil {
+					return body
+				}
+				filtered = next
+				kept++
+			}
+			if kept == 0 {
+				author := strings.TrimSpace(item.Get("author").String())
+				recipient := strings.TrimSpace(item.Get("recipient").String())
+				placeholder := "[agent_message]"
+				if author != "" || recipient != "" {
+					placeholder = fmt.Sprintf("[agent_message %s -> %s]", author, recipient)
+				}
+				partJSON, errMarshal := json.Marshal([]map[string]string{{
+					"type": "input_text",
+					"text": placeholder,
+				}})
+				if errMarshal != nil {
+					return body
+				}
+				filtered = partJSON
+			}
+			updated, errSet = sjson.SetRawBytes(raw, "content", filtered)
+			if errSet != nil {
+				return body
+			}
+			raw = updated
+		}
+		items = append(items, json.RawMessage(raw))
+	}
+	if !changed {
+		return body
+	}
+	rawInput, errMarshal := json.Marshal(items)
+	if errMarshal != nil {
+		return body
+	}
+	updated, errSet := sjson.SetRawBytes(body, "input", rawInput)
+	if errSet != nil {
+		return body
+	}
+	return updated
 }
 
 func normalizeXAIInputReasoningItems(body []byte) []byte {

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -1610,7 +1610,7 @@ func promoteXAIAdditionalToolsToTopLevel(body []byte) []byte {
 		return body
 	}
 	body = updated
-	if len(gjson.ParseBytes(mergedTools).Array()) == 0 {
+	if gjson.GetBytes(mergedTools, "#").Int() == 0 {
 		if gjson.GetBytes(body, "tools").Exists() {
 			body, _ = sjson.DeleteBytes(body, "tools")
 		}

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -915,6 +915,10 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	// the post-restore (namespace, short-name) shape used by the response filter.
 	clientDeclaredTools := collectXAIClientDeclaredToolKeys(body)
 	body = normalizeXAITools(body)
+	// Codex Responses Lite declares tools via input[].type=additional_tools.
+	// xAI's Responses endpoint rejects that item as ModelInput (HTTP 422). Promote
+	// the declared tools into the top-level tools array and drop the items.
+	body = promoteXAIAdditionalToolsToTopLevel(body)
 	// Drop choices that point at tools removed by normalizeXAITools before we
 	// inject native x_search, so a surviving allowed_tools / forced choice is not
 	// left pointing at a deleted tool once only x_search remains.
@@ -1537,6 +1541,80 @@ func normalizeXAITools(body []byte) []byte {
 	return body
 }
 
+// promoteXAIAdditionalToolsToTopLevel merges Codex "additional_tools" input
+// items into the top-level tools array and removes those items from input.
+// Upstream xAI (cli-chat-proxy) rejects additional_tools as a ModelInput
+// variant with HTTP 422, even after nested tool normalization.
+func promoteXAIAdditionalToolsToTopLevel(body []byte) []byte {
+	if !gjson.ValidBytes(body) {
+		return body
+	}
+	input := gjson.GetBytes(body, "input")
+	if !input.Exists() || !input.IsArray() {
+		return body
+	}
+
+	tools := gjson.GetBytes(body, "tools")
+	mergedTools := []byte(`[]`)
+	if tools.Exists() && tools.IsArray() {
+		mergedTools = []byte(tools.Raw)
+	}
+
+	newInput := []byte(`[]`)
+	changed := false
+	for _, item := range input.Array() {
+		if item.Get("type").String() != "additional_tools" {
+			updated, errSet := sjson.SetRawBytes(newInput, "-1", []byte(item.Raw))
+			if errSet != nil {
+				return body
+			}
+			newInput = updated
+			continue
+		}
+		changed = true
+		nested := item.Get("tools")
+		if !nested.Exists() || !nested.IsArray() {
+			continue
+		}
+		for _, tool := range nested.Array() {
+			raw := []byte(tool.Raw)
+			// custom tool format is not valid on function tools after rewrite.
+			if tool.Get("format").Exists() {
+				stripped, errDel := sjson.DeleteBytes(raw, "format")
+				if errDel != nil {
+					return body
+				}
+				raw = stripped
+			}
+			updated, errSet := sjson.SetRawBytes(mergedTools, "-1", raw)
+			if errSet != nil {
+				return body
+			}
+			mergedTools = updated
+		}
+	}
+	if !changed {
+		return body
+	}
+
+	updated, errSet := sjson.SetRawBytes(body, "input", newInput)
+	if errSet != nil {
+		return body
+	}
+	body = updated
+	if len(gjson.ParseBytes(mergedTools).Array()) == 0 {
+		if gjson.GetBytes(body, "tools").Exists() {
+			body, _ = sjson.DeleteBytes(body, "tools")
+		}
+		return body
+	}
+	updated, errSet = sjson.SetRawBytes(body, "tools", mergedTools)
+	if errSet != nil {
+		return body
+	}
+	return updated
+}
+
 func normalizeXAIToolArray(tools gjson.Result) ([]byte, bool, bool) {
 	changed := false
 	filtered := []byte(`[]`)
@@ -1690,6 +1768,15 @@ func normalizeXAITool(tool gjson.Result, namespaceName string) ([]byte, bool, bo
 			return nil, false, false
 		}
 		raw = updatedTool
+		// Codex custom tools carry a freeform "format" field that is invalid on
+		// xAI function tools and can contribute to upstream rejection.
+		if gjson.GetBytes(raw, "format").Exists() {
+			stripped, errDel := sjson.DeleteBytes(raw, "format")
+			if errDel != nil {
+				return nil, false, false
+			}
+			raw = stripped
+		}
 		toolType = xaiFunctionToolType
 		changed = true
 	}

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -253,9 +253,23 @@ func TestXAIExecutorExecuteRestoresAdditionalToolsNamespaceCalls(t *testing.T) {
 		t.Fatalf("Execute() error = %v", err)
 	}
 
-	tool := gjson.GetBytes(gotBody, "input.0.tools.0")
-	if got := tool.Get("name").String(); got != "mcp__exa__web_search_exa" {
-		t.Fatalf("upstream additional tool name = %q, want qualified name; body=%s", got, gotBody)
+	// additional_tools must be promoted out of input (xAI ModelInput 422).
+	for _, item := range gjson.GetBytes(gotBody, "input").Array() {
+		if item.Get("type").String() == "additional_tools" {
+			t.Fatalf("upstream input still contains additional_tools: %s", gotBody)
+		}
+	}
+	var tool gjson.Result
+	found := false
+	for _, candidate := range gjson.GetBytes(gotBody, "tools").Array() {
+		if candidate.Get("name").String() == "mcp__exa__web_search_exa" {
+			tool = candidate
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("upstream tools missing promoted mcp__exa__web_search_exa; body=%s", gotBody)
 	}
 	if got := tool.Get("type").String(); got != "function" {
 		t.Fatalf("upstream additional tool type = %q, want function; body=%s", got, gotBody)
@@ -2925,6 +2939,75 @@ func TestNormalizeXAITools_AdditionalToolsNamespace(t *testing.T) {
 	}
 	if got := tools[0].Get("type").String(); got != "function" {
 		t.Fatalf("additional tool type = %q, want function; body=%s", got, string(out))
+	}
+}
+
+func TestPromoteXAIAdditionalToolsToTopLevel(t *testing.T) {
+	body := []byte(`{
+"tools":[{"type":"x_search"}],
+"input":[
+{"type":"additional_tools","role":"developer","tools":[
+{"type":"function","name":"read_file","parameters":{"type":"object"}},
+{"type":"custom","name":"shell","description":"Run","format":{"type":"text"},"parameters":{"type":"object","properties":{}}}
+]},
+{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}
+]
+}`)
+	out := promoteXAIAdditionalToolsToTopLevel(body)
+
+	for _, item := range gjson.GetBytes(out, "input").Array() {
+		if item.Get("type").String() == "additional_tools" {
+			t.Fatalf("additional_tools should be removed from input: %s", string(out))
+		}
+	}
+	tools := gjson.GetBytes(out, "tools").Array()
+	if len(tools) != 3 {
+		t.Fatalf("tools length = %d, want 3; body=%s", len(tools), string(out))
+	}
+	if got := tools[0].Get("type").String(); got != "x_search" {
+		t.Fatalf("tools.0.type = %q, want x_search; body=%s", got, string(out))
+	}
+	if got := tools[1].Get("name").String(); got != "read_file" {
+		t.Fatalf("tools.1.name = %q, want read_file; body=%s", got, string(out))
+	}
+	if got := tools[2].Get("name").String(); got != "shell" {
+		t.Fatalf("tools.2.name = %q, want shell; body=%s", got, string(out))
+	}
+	if tools[2].Get("format").Exists() {
+		t.Fatalf("promoted custom tool should strip format: %s", string(out))
+	}
+	if len(gjson.GetBytes(out, "input").Array()) != 1 {
+		t.Fatalf("input should keep only the user message: %s", string(out))
+	}
+}
+
+func TestPromoteXAIAdditionalToolsAfterNormalize(t *testing.T) {
+	body := []byte(`{
+"input":[
+{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"shell","format":{"type":"text"}}]},
+{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}
+]
+}`)
+	out := normalizeXAITools(body)
+	out = promoteXAIAdditionalToolsToTopLevel(out)
+
+	for _, item := range gjson.GetBytes(out, "input").Array() {
+		if item.Get("type").String() == "additional_tools" {
+			t.Fatalf("additional_tools should be removed from input: %s", string(out))
+		}
+	}
+	tool := gjson.GetBytes(out, "tools.0")
+	if got := tool.Get("type").String(); got != "function" {
+		t.Fatalf("tools.0.type = %q, want function; body=%s", got, string(out))
+	}
+	if got := tool.Get("name").String(); got != "shell" {
+		t.Fatalf("tools.0.name = %q, want shell; body=%s", got, string(out))
+	}
+	if tool.Get("format").Exists() {
+		t.Fatalf("format should be stripped: %s", string(out))
+	}
+	if !tool.Get("parameters").Exists() {
+		t.Fatalf("parameters should be injected for custom→function: %s", string(out))
 	}
 }
 

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -2942,6 +2942,55 @@ func TestNormalizeXAITools_AdditionalToolsNamespace(t *testing.T) {
 	}
 }
 
+
+func TestNormalizeXAIInputAgentMessages(t *testing.T) {
+	body := []byte(`{
+"model":"grok-4.5",
+"input":[
+{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},
+{"type":"agent_message","author":"/root","recipient":"/root/worker","content":[
+{"type":"input_text","text":"Message Type: NEW_TASK"},
+{"type":"encrypted_content","encrypted_content":"gAAAAABqX"}
+]}
+]
+}`)
+	out := normalizeXAIInputAgentMessages(body)
+	input := gjson.GetBytes(out, "input").Array()
+	if len(input) != 2 {
+		t.Fatalf("input length = %d, want 2; body=%s", len(input), string(out))
+	}
+	if got := input[1].Get("type").String(); got != "message" {
+		t.Fatalf("input.1.type = %q, want message; body=%s", got, string(out))
+	}
+	if got := input[1].Get("role").String(); got != "user" {
+		t.Fatalf("input.1.role = %q, want user; body=%s", got, string(out))
+	}
+	if input[1].Get("author").Exists() || input[1].Get("recipient").Exists() {
+		t.Fatalf("author/recipient should be stripped: %s", string(out))
+	}
+	parts := input[1].Get("content").Array()
+	if len(parts) != 1 {
+		t.Fatalf("content parts = %d, want 1 (encrypted dropped); body=%s", len(parts), string(out))
+	}
+	if got := parts[0].Get("type").String(); got != "input_text" {
+		t.Fatalf("content.0.type = %q, want input_text; body=%s", got, string(out))
+	}
+	if got := parts[0].Get("text").String(); got != "Message Type: NEW_TASK" {
+		t.Fatalf("content.0.text = %q; body=%s", got, string(out))
+	}
+}
+
+func TestSanitizeXAIResponsesBodyDropsServiceTierAndClientMetadata(t *testing.T) {
+	body := []byte(`{"model":"grok-4.5","service_tier":"priority","client_metadata":{"x":"y"},"input":[]}`)
+	out := sanitizeXAIResponsesBody(body, "grok-4.5")
+	if gjson.GetBytes(out, "service_tier").Exists() {
+		t.Fatalf("service_tier should be removed: %s", string(out))
+	}
+	if gjson.GetBytes(out, "client_metadata").Exists() {
+		t.Fatalf("client_metadata should be removed: %s", string(out))
+	}
+}
+
 func TestPromoteXAIAdditionalToolsToTopLevel(t *testing.T) {
 	body := []byte(`{
 "tools":[{"type":"x_search"}],

--- a/internal/runtime/executor/xai_websockets_executor_test.go
+++ b/internal/runtime/executor/xai_websockets_executor_test.go
@@ -202,9 +202,23 @@ func TestXAIWebsocketsExecuteStreamRestoresNamespaceToolCalls(t *testing.T) {
 
 	select {
 	case payload := <-capturedPayload:
-		tool := gjson.GetBytes(payload, "input.0.tools.0")
-		if got := tool.Get("name").String(); got != "mcp__exa__web_search_exa" {
-			t.Fatalf("upstream tool name = %q, want qualified name; payload=%s", got, payload)
+		// additional_tools are promoted to top-level tools for xAI ModelInput.
+		for _, item := range gjson.GetBytes(payload, "input").Array() {
+			if item.Get("type").String() == "additional_tools" {
+				t.Fatalf("upstream input still contains additional_tools: %s", payload)
+			}
+		}
+		var tool gjson.Result
+		found := false
+		for _, candidate := range gjson.GetBytes(payload, "tools").Array() {
+			if candidate.Get("name").String() == "mcp__exa__web_search_exa" {
+				tool = candidate
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("upstream tools missing promoted mcp__exa__web_search_exa; payload=%s", payload)
 		}
 		if tool.Get("tools").Exists() {
 			t.Fatalf("upstream tool should not contain namespace children: %s", payload)


### PR DESCRIPTION
## Summary

- Codex Responses Lite declares tools as `input[].type=additional_tools`. xAI's Responses API rejects that item as an untagged `ModelInput` variant (**HTTP 422**), so tool-enabled Grok turns never complete (appears hung in Codex).
- After `normalizeXAITools`, **promote** nested tools into top-level `tools` and **drop** `additional_tools` items from `input`.
- Defensive: strip freeform custom-tool `format` when rewriting `custom` → `function`.

Fixes #4434

## Problem proof (live xAI)

| Payload | Before | After |
|--------|--------|--------|
| Message only | 200 | 200 |
| Top-level `tools` (incl. custom) | 200 | 200 |
| `input` contains `additional_tools` + function | **422 ModelInput** | **200 / completed** |
| `input` contains `additional_tools` + custom/`format` | **422 ModelInput** | **200 / completed** |

CLIProxyAPI error dumps showed the upstream body still contained `additional_tools` after nested tool normalization, e.g. to `https://cli-chat-proxy.grok.com/v1/responses`.

## Test plan

- [x] Unit: `TestPromoteXAIAdditionalToolsToTopLevel`
- [x] Unit: `TestPromoteXAIAdditionalToolsAfterNormalize`
- [x] Updated `TestXAIExecutorExecuteRestoresAdditionalToolsNamespaceCalls` to assert tools land at top-level `tools` and `input` has no `additional_tools`
- [x] Focused package tests:
  ```bash
  go test ./internal/runtime/executor/ -count=1 \
    -run 'TestPromoteXAIAdditionalTools|TestNormalizeXAITools_AdditionalTools|TestXAIExecutorExecuteRestoresAdditionalTools|TestNormalizeXAIToolChoiceForTools_KeepsWhenAdditional'
  ```
- [x] Live xAI OAuth path: same three `additional_tools` payloads return HTTP 200 / `status: completed` / text `pong` against `cli-chat-proxy.grok.com`

## Notes

- Related prior work: #3704 (`custom_tool_call` history), #4282 (ModelInput after `x_search` inject) — different item types / phases.
- Existing unit tests that only call `normalizeXAITools` still leave `additional_tools` in place by design; promotion is a separate step on the prepare path.
