### PR TITLE
feat(pluginhost): add structured errors and fail-closed interceptors

### DIFF
--- a/internal/pluginhost/adapters_interceptors.go
+++ b/internal/pluginhost/adapters_interceptors.go
@@ -18,6 +18,17 @@ func (h *Host) callRequestInterceptor(ctx context.Context, record capabilityReco
 	if h == nil || call == nil || h.isPluginFused(record.id) || !h.recordCurrent(record) {
 		return pluginapi.RequestInterceptResponse{}, false
 	}
+	panicked := false
+	call = markRequestInterceptorPanic(call, &panicked)
+	defer func() {
+		if panicked {
+			out = pluginapi.RequestInterceptResponse{
+				Reject:       true,
+				RejectReason: "request interceptor panic: " + record.id,
+			}
+			ok = true
+		}
+	}()
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			h.fusePlugin(record.id, method, recovered)
@@ -118,6 +129,12 @@ func (h *Host) interceptRequest(ctx context.Context, req pluginapi.RequestInterc
 				current.StatusCode = resp.StatusCode
 				current.ResponseHeaders = cloneHeader(resp.ResponseHeaders)
 				current.ResponseBody = bytes.Clone(resp.ResponseBody)
+			}
+			if resp.Reject {
+				current.Reject = true
+				current.RejectReason = resp.RejectReason
+			}
+			if resp.Terminate || resp.Reject {
 				break
 			}
 		}

--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -3,6 +3,7 @@ package pluginhost
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -1579,8 +1580,15 @@ func TestInterceptorsSkipErrorsAndFusePanics(t *testing.T) {
 	)
 
 	got := host.InterceptRequestBeforeAuth(context.Background(), pluginapi.RequestInterceptRequest{Body: []byte("body")})
-	if string(got.Body) != "body|success" {
-		t.Fatalf("body = %q, want body|success", got.Body)
+	// Plain errors fail open, while panics fail closed and stop the chain.
+	if string(got.Body) != "body" {
+		t.Fatalf("body = %q, want body", got.Body)
+	}
+	if !got.Reject {
+		t.Fatal("panic request interceptor did not set Reject")
+	}
+	if got.RejectReason != "request interceptor panic: panic" {
+		t.Fatalf("RejectReason = %q, want \"request interceptor panic: panic\"", got.RejectReason)
 	}
 	if !host.isPluginFused("panic") {
 		t.Fatal("panic plugin was not fused")
@@ -3458,4 +3466,74 @@ func (failingReadCloser) Read(p []byte) (int, error) {
 
 func (failingReadCloser) Close() error {
 	return nil
+}
+
+func TestInterceptRequestRejectAbortsChain(t *testing.T) {
+	downstreamCalled := false
+	host := newHostWithRecords(
+		capabilityRecord{
+			id:       "reject",
+			priority: 20,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				RequestInterceptor: requestInterceptorFunc(func(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+					return pluginapi.RequestInterceptResponse{Reject: true, RejectReason: "policy denied"}, nil
+				}),
+			}},
+		},
+		capabilityRecord{
+			id:       "downstream",
+			priority: 10,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				RequestInterceptor: requestInterceptorFunc(func(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+					downstreamCalled = true
+					return pluginapi.RequestInterceptResponse{Body: append(req.Body, []byte("|downstream")...)}, nil
+				}),
+			}},
+		},
+	)
+
+	got := host.InterceptRequestBeforeAuth(context.Background(), pluginapi.RequestInterceptRequest{Body: []byte("body")})
+
+	if !got.Reject {
+		t.Fatal("expected Reject to propagate")
+	}
+	if got.RejectReason != "policy denied" {
+		t.Fatalf("RejectReason = %q, want %q", got.RejectReason, "policy denied")
+	}
+	if downstreamCalled {
+		t.Fatal("downstream interceptor ran after a rejection; chain was not aborted")
+	}
+}
+
+func TestRequestInterceptResponseRejectRoundTrip(t *testing.T) {
+	// The reject signal crosses the RPC boundary as JSON on pluginapi.RequestInterceptResponse.
+	original := pluginapi.RequestInterceptResponse{Reject: true, RejectReason: "policy denied"}
+
+	raw, errMarshal := json.Marshal(original)
+	if errMarshal != nil {
+		t.Fatalf("marshal RequestInterceptResponse: %v", errMarshal)
+	}
+	if !strings.Contains(string(raw), `"reject":true`) {
+		t.Fatalf("marshalled JSON missing reject field: %s", raw)
+	}
+	if !strings.Contains(string(raw), `"reject_reason":"policy denied"`) {
+		t.Fatalf("marshalled JSON missing reject_reason field: %s", raw)
+	}
+
+	var decoded pluginapi.RequestInterceptResponse
+	if errUnmarshal := json.Unmarshal(raw, &decoded); errUnmarshal != nil {
+		t.Fatalf("unmarshal RequestInterceptResponse: %v", errUnmarshal)
+	}
+	if !decoded.Reject || decoded.RejectReason != "policy denied" {
+		t.Fatalf("round-trip lost reject fields: %+v", decoded)
+	}
+
+	// An empty rejection must omit both fields (omitempty) so unrelated responses stay unchanged.
+	empty, errEmpty := json.Marshal(pluginapi.RequestInterceptResponse{})
+	if errEmpty != nil {
+		t.Fatalf("marshal empty RequestInterceptResponse: %v", errEmpty)
+	}
+	if strings.Contains(string(empty), "reject") {
+		t.Fatalf("empty response should omit reject fields: %s", empty)
+	}
 }

--- a/internal/pluginhost/callback_contexts.go
+++ b/internal/pluginhost/callback_contexts.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginabi"
 )
 
 type callbackContextRegistry struct {
@@ -15,9 +17,10 @@ type callbackContextRegistry struct {
 }
 
 type callbackContextEntry struct {
-	ctx      context.Context
-	pluginID string
-	cleanup  []func()
+	ctx           context.Context
+	pluginID      string
+	schemaVersion uint32
+	cleanup       []func()
 }
 
 func newCallbackContextRegistry() *callbackContextRegistry {
@@ -25,6 +28,10 @@ func newCallbackContextRegistry() *callbackContextRegistry {
 }
 
 func (r *callbackContextRegistry) open(ctx context.Context, pluginID string) (string, func()) {
+	return r.openWithSchemaVersion(ctx, pluginID, pluginabi.CurrentSchemaVersion)
+}
+
+func (r *callbackContextRegistry) openWithSchemaVersion(ctx context.Context, pluginID string, schemaVersion uint32) (string, func()) {
 	if r == nil {
 		return "", func() {}
 	}
@@ -32,10 +39,10 @@ func (r *callbackContextRegistry) open(ctx context.Context, pluginID string) (st
 		ctx = context.Background()
 	}
 	pluginID = strings.TrimSpace(pluginID)
-	ctx = withHostCallbackPluginID(ctx, pluginID)
+	ctx = withHostCallbackCaller(ctx, pluginID, schemaVersion)
 	id := strconv.FormatUint(r.next.Add(1), 10)
 	r.mu.Lock()
-	r.contexts[id] = callbackContextEntry{ctx: ctx, pluginID: pluginID}
+	r.contexts[id] = callbackContextEntry{ctx: ctx, pluginID: pluginID, schemaVersion: schemaVersion}
 	r.mu.Unlock()
 
 	var once sync.Once
@@ -54,6 +61,16 @@ func (r *callbackContextRegistry) open(ctx context.Context, pluginID string) (st
 			}
 		})
 	}
+}
+
+func (r *callbackContextRegistry) schemaVersion(id string) uint32 {
+	if r == nil || id == "" {
+		return 0
+	}
+	r.mu.RLock()
+	schemaVersion := r.contexts[id].schemaVersion
+	r.mu.RUnlock()
+	return schemaVersion
 }
 
 func (r *callbackContextRegistry) pluginID(id string) string {
@@ -105,10 +122,14 @@ func (h *Host) openCallbackContext(ctx context.Context) (string, func()) {
 }
 
 func (h *Host) openCallbackContextForPlugin(ctx context.Context, pluginID string) (string, func()) {
+	return h.openCallbackContextForPluginVersion(ctx, pluginID, pluginabi.CurrentSchemaVersion)
+}
+
+func (h *Host) openCallbackContextForPluginVersion(ctx context.Context, pluginID string, schemaVersion uint32) (string, func()) {
 	if h == nil || h.callbackContexts == nil {
 		return "", func() {}
 	}
-	return h.callbackContexts.open(ctx, pluginID)
+	return h.callbackContexts.openWithSchemaVersion(ctx, pluginID, schemaVersion)
 }
 
 func (h *Host) addCallbackCleanup(id string, cleanup func()) bool {
@@ -136,4 +157,11 @@ func (h *Host) callbackContextPluginID(id string) string {
 		return ""
 	}
 	return h.callbackContexts.pluginID(id)
+}
+
+func (h *Host) callbackContextSchemaVersion(id string) uint32 {
+	if h == nil || h.callbackContexts == nil {
+		return 0
+	}
+	return h.callbackContexts.schemaVersion(id)
 }

--- a/internal/pluginhost/client_schema_version.go
+++ b/internal/pluginhost/client_schema_version.go
@@ -1,0 +1,24 @@
+package pluginhost
+
+type schemaVersionedPluginClient interface {
+	setSchemaVersion(uint32)
+}
+
+func setPluginClientSchemaVersion(client pluginClient, schemaVersion uint32) {
+	if client == nil {
+		return
+	}
+	if versioned, ok := client.(schemaVersionedPluginClient); ok {
+		versioned.setSchemaVersion(schemaVersion)
+	}
+}
+
+func (c *guardedPluginClient) setSchemaVersion(schemaVersion uint32) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	inner := c.inner
+	c.mu.Unlock()
+	setPluginClientSchemaVersion(inner, schemaVersion)
+}

--- a/internal/pluginhost/host_callbacks.go
+++ b/internal/pluginhost/host_callbacks.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
+	"sync/atomic"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
@@ -67,15 +69,44 @@ type rpcHostModelExecutionRequest struct {
 }
 
 type dynamicHostCallbackEntry struct {
-	host     *Host
-	pluginID string
+	host          *Host
+	pluginID      string
+	schemaVersion atomic.Uint32
 }
 
-type hostCallbackPluginIDKey struct{}
+func newDynamicHostCallbackEntry(host *Host, pluginID string) *dynamicHostCallbackEntry {
+	entry := &dynamicHostCallbackEntry{host: host, pluginID: strings.TrimSpace(pluginID)}
+	entry.schemaVersion.Store(pluginabi.SchemaVersionV1)
+	return entry
+}
 
-func withHostCallbackPluginID(ctx context.Context, pluginID string) context.Context {
+func (e *dynamicHostCallbackEntry) setSchemaVersion(schemaVersion uint32) {
+	if e == nil {
+		return
+	}
+	if schemaVersion == 0 {
+		schemaVersion = pluginabi.SchemaVersionV1
+	}
+	e.schemaVersion.Store(schemaVersion)
+}
+
+func (e *dynamicHostCallbackEntry) context() context.Context {
+	if e == nil {
+		return context.Background()
+	}
+	return withHostCallbackCaller(context.Background(), e.pluginID, e.schemaVersion.Load())
+}
+
+type hostCallbackCaller struct {
+	pluginID      string
+	schemaVersion uint32
+}
+
+type hostCallbackCallerKey struct{}
+
+func withHostCallbackCaller(ctx context.Context, pluginID string, schemaVersion uint32) context.Context {
 	pluginID = strings.TrimSpace(pluginID)
-	if pluginID == "" {
+	if pluginID == "" && schemaVersion == 0 {
 		if ctx == nil {
 			return context.Background()
 		}
@@ -84,15 +115,26 @@ func withHostCallbackPluginID(ctx context.Context, pluginID string) context.Cont
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return context.WithValue(ctx, hostCallbackPluginIDKey{}, pluginID)
+	return context.WithValue(ctx, hostCallbackCallerKey{}, hostCallbackCaller{
+		pluginID:      pluginID,
+		schemaVersion: schemaVersion,
+	})
 }
 
 func hostCallbackPluginIDFromContext(ctx context.Context) string {
 	if ctx == nil {
 		return ""
 	}
-	pluginID, _ := ctx.Value(hostCallbackPluginIDKey{}).(string)
-	return strings.TrimSpace(pluginID)
+	caller, _ := ctx.Value(hostCallbackCallerKey{}).(hostCallbackCaller)
+	return strings.TrimSpace(caller.pluginID)
+}
+
+func hostCallbackSchemaVersionFromContext(ctx context.Context) uint32 {
+	if ctx == nil {
+		return 0
+	}
+	caller, _ := ctx.Value(hostCallbackCallerKey{}).(hostCallbackCaller)
+	return caller.schemaVersion
 }
 
 func (h *Host) callFromPlugin(ctx context.Context, method string, request []byte) ([]byte, error) {
@@ -137,6 +179,22 @@ func (h *Host) callbackCallerPluginID(ctx context.Context, callbackID string) st
 		return pluginID
 	}
 	return h.callbackContextPluginID(callbackID)
+}
+
+func (h *Host) callbackCallerSchemaVersion(ctx context.Context, callbackID string) uint32 {
+	if callbackID != "" {
+		if schemaVersion := h.callbackContextSchemaVersion(callbackID); schemaVersion != 0 {
+			return schemaVersion
+		}
+	}
+	if schemaVersion := hostCallbackSchemaVersionFromContext(ctx); schemaVersion != 0 {
+		return schemaVersion
+	}
+	return pluginabi.CurrentSchemaVersion
+}
+
+func (h *Host) usesStructuredHostModelErrors(ctx context.Context, callbackID string) bool {
+	return h.callbackCallerSchemaVersion(ctx, callbackID) >= pluginabi.SchemaVersionV2
 }
 
 func (h *Host) callHostHTTPDo(ctx context.Context, request []byte) ([]byte, error) {
@@ -248,7 +306,9 @@ func (h *Host) callHostStreamEmit(ctx context.Context, request []byte) ([]byte, 
 		return nil, fmt.Errorf("decode stream emit request: %w", errUnmarshal)
 	}
 	chunk := pluginapi.ExecutorStreamChunk{Payload: append([]byte(nil), req.Payload...)}
-	if req.Error != "" {
+	if req.ErrorDetails != nil {
+		chunk.Err = newPluginStreamError(req.ErrorDetails, req.Error)
+	} else if req.Error != "" {
 		chunk.Err = fmt.Errorf("%s", req.Error)
 	}
 	if errEmit := h.streams.emit(ctx, req.StreamID, chunk); errEmit != nil {
@@ -262,7 +322,7 @@ func (h *Host) callHostStreamClose(request []byte) ([]byte, error) {
 	if errUnmarshal := json.Unmarshal(request, &req); errUnmarshal != nil {
 		return nil, fmt.Errorf("decode stream close request: %w", errUnmarshal)
 	}
-	h.streams.close(req.StreamID, req.Error)
+	h.streams.close(req.StreamID, req.Error, req.ErrorDetails)
 	return marshalRPCResult(rpcEmptyResponse{})
 }
 
@@ -282,13 +342,29 @@ func (h *Host) callHostModelExecute(ctx context.Context, request []byte) ([]byte
 	ctx = h.resolveCallbackContext(req.HostCallbackID, ctx)
 	resp, errMsg := executor.ExecuteModel(ctx, modelExecutionRequestFromPlugin(req.HostModelExecutionRequest, skipPluginID))
 	if errMsg != nil {
-		return nil, modelExecutionError(errMsg)
+		if !h.usesStructuredHostModelErrors(ctx, req.HostCallbackID) {
+			return nil, legacyHostModelError(errMsg)
+		}
+		return marshalRPCResult(hostModelExecutionErrorResponse(errMsg))
 	}
 	return marshalRPCResult(pluginapi.HostModelExecutionResponse{
 		StatusCode: resp.StatusCode,
 		Headers:    cloneHeader(resp.Headers),
 		Body:       append([]byte(nil), resp.Body...),
 	})
+}
+
+func legacyHostModelError(errMsg *interfaces.ErrorMessage) error {
+	details := hostModelErrorFromMessage(errMsg)
+	if details == nil {
+		return fmt.Errorf("host model execution failed")
+	}
+	return &pluginStreamError{
+		statusCode: details.StatusCode,
+		headers:    httpHeader(cloneHeader(details.Headers)),
+		body:       append([]byte(nil), details.Body...),
+		message:    details.Message,
+	}
 }
 
 func modelExecutionRequestFromPlugin(req pluginapi.HostModelExecutionRequest, skipPluginID string) handlers.ModelExecutionRequest {
@@ -306,17 +382,129 @@ func modelExecutionRequestFromPlugin(req pluginapi.HostModelExecutionRequest, sk
 	}
 }
 
-func modelExecutionError(errMsg *interfaces.ErrorMessage) error {
+type pluginStreamError struct {
+	statusCode int
+	headers    httpHeader
+	body       []byte
+	message    string
+}
+
+func newPluginStreamError(details *pluginapi.HostModelError, fallback string) error {
+	if details == nil {
+		return fmt.Errorf("%s", fallback)
+	}
+	message := details.Message
+	if message == "" && len(details.Body) > 0 {
+		message = string(details.Body)
+	}
+	if message == "" {
+		message = fallback
+	}
+	if message == "" && details.StatusCode > 0 {
+		message = fmt.Sprintf("upstream returned status %d", details.StatusCode)
+	}
+	return &pluginStreamError{
+		statusCode: details.StatusCode,
+		headers:    httpHeader(cloneHeader(details.Headers)),
+		body:       append([]byte(nil), details.Body...),
+		message:    message,
+	}
+}
+
+func (e *pluginStreamError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if len(e.body) > 0 {
+		return string(e.body)
+	}
+	return e.message
+}
+
+func (e *pluginStreamError) StatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.statusCode
+}
+
+func (e *pluginStreamError) Headers() http.Header {
+	if e == nil {
+		return nil
+	}
+	return cloneHeader(http.Header(e.headers))
+}
+
+// hostModelExecutionErrorResponse builds a successful RPC result that carries a
+// structured model failure in Error. Callers must inspect Error/StatusCode.
+func hostModelExecutionErrorResponse(errMsg *interfaces.ErrorMessage) pluginapi.HostModelExecutionResponse {
+	details := hostModelErrorFromMessage(errMsg)
+	if details == nil {
+		return pluginapi.HostModelExecutionResponse{}
+	}
+	return pluginapi.HostModelExecutionResponse{
+		StatusCode: details.StatusCode,
+		Headers:    cloneHeader(details.Headers),
+		Body:       append([]byte(nil), details.Body...),
+		Error:      details,
+	}
+}
+
+// hostModelStreamErrorResponse builds a successful RPC result that carries a
+// structured stream-startup failure in Error. StreamID is left empty.
+func hostModelStreamErrorResponse(errMsg *interfaces.ErrorMessage) pluginapi.HostModelStreamResponse {
+	details := hostModelErrorFromMessage(errMsg)
+	if details == nil {
+		return pluginapi.HostModelStreamResponse{}
+	}
+	return pluginapi.HostModelStreamResponse{
+		StatusCode: details.StatusCode,
+		Headers:    cloneHeader(details.Headers),
+		Error:      details,
+	}
+}
+
+// hostModelErrorFromMessage maps interfaces.ErrorMessage into HostModelError.
+// Body is filled from the error string when no raw upstream body is available.
+func hostModelErrorFromMessage(errMsg *interfaces.ErrorMessage) *pluginapi.HostModelError {
 	if errMsg == nil {
 		return nil
 	}
+	message := ""
 	if errMsg.Error != nil {
-		return errMsg.Error
+		message = errMsg.Error.Error()
 	}
-	if errMsg.StatusCode > 0 {
-		return fmt.Errorf("model execution failed with status %d", errMsg.StatusCode)
+	if message == "" && errMsg.StatusCode > 0 {
+		message = fmt.Sprintf("model execution failed with status %d", errMsg.StatusCode)
 	}
-	return fmt.Errorf("model execution failed")
+	return &pluginapi.HostModelError{
+		StatusCode: errMsg.StatusCode,
+		Headers:    cloneHeader(errMsg.Addon),
+		Body:       []byte(message),
+		Message:    message,
+	}
+}
+
+func hostModelErrorFromError(err error) *pluginapi.HostModelError {
+	if err == nil {
+		return nil
+	}
+	message := err.Error()
+	details := &pluginapi.HostModelError{
+		Body:    []byte(message),
+		Message: message,
+	}
+	if statusErr, ok := err.(interface{ StatusCode() int }); ok {
+		details.StatusCode = statusErr.StatusCode()
+	}
+	if headerErr, ok := err.(interface{ Headers() http.Header }); ok {
+		details.Headers = cloneHeader(headerErr.Headers())
+	}
+	if streamErr, ok := err.(*handlers.ModelExecutionStreamError); ok && streamErr != nil {
+		details.StatusCode = streamErr.StatusCode
+		details.Headers = cloneHeader(streamErr.Headers)
+	}
+	return details
 }
 
 func (h *Host) callHostLog(ctx context.Context, request []byte) ([]byte, error) {

--- a/internal/pluginhost/host_callbacks_test.go
+++ b/internal/pluginhost/host_callbacks_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -233,6 +234,49 @@ func TestHostStreamCallbacksEmitAndClose(t *testing.T) {
 	}
 }
 
+func TestHostStreamEmitPreservesStructuredError(t *testing.T) {
+	host := New()
+	streamID, chunks, cleanup := host.streams.open(context.Background())
+	defer cleanup()
+
+	upstreamBody := `{"error":{"message":"quota","code":"rate_limit"}}`
+	emitReq, errMarshal := json.Marshal(rpcStreamEmitRequest{
+		StreamID: streamID,
+		Error:    upstreamBody,
+		ErrorDetails: &pluginapi.HostModelError{
+			StatusCode: http.StatusTooManyRequests,
+			Headers:    http.Header{"Retry-After": []string{"5"}},
+			Body:       []byte(upstreamBody),
+			Message:    upstreamBody,
+		},
+	})
+	if errMarshal != nil {
+		t.Fatalf("marshal emit request: %v", errMarshal)
+	}
+	if _, errEmit := host.callFromPlugin(context.Background(), pluginabi.MethodHostStreamEmit, emitReq); errEmit != nil {
+		t.Fatalf("emit callback error = %v", errEmit)
+	}
+
+	chunk, ok := <-chunks
+	if !ok {
+		t.Fatal("stream closed before structured error chunk")
+	}
+	if len(chunk.Payload) != 0 || chunk.Err == nil {
+		t.Fatalf("chunk = %#v, want structured error without payload", chunk)
+	}
+	statusErr, ok := chunk.Err.(interface{ StatusCode() int })
+	if !ok || statusErr.StatusCode() != http.StatusTooManyRequests {
+		t.Fatalf("chunk error status = %#v, want 429", chunk.Err)
+	}
+	headerErr, ok := chunk.Err.(interface{ Headers() http.Header })
+	if !ok || headerErr.Headers().Get("Retry-After") != "5" {
+		t.Fatalf("chunk error headers = %#v, want retry-after", chunk.Err)
+	}
+	if chunk.Err.Error() != upstreamBody {
+		t.Fatalf("chunk error body = %q, want upstream body", chunk.Err.Error())
+	}
+}
+
 func TestHostModelExecuteCallback(t *testing.T) {
 	host := New()
 	var got handlers.ModelExecutionRequest
@@ -290,6 +334,109 @@ func TestHostModelExecuteCallback(t *testing.T) {
 	}
 	if got.Alt != "raw" {
 		t.Fatalf("alt = %q, want raw", got.Alt)
+	}
+}
+
+func TestHostModelExecuteCallbackReturnsStructuredUpstreamError(t *testing.T) {
+	host := New()
+	upstreamBody := `{"error":{"message":"quota","code":"rate_limit"}}`
+	host.SetModelExecutor(&fakeHostModelExecutor{
+		executeModel: func(ctx context.Context, req handlers.ModelExecutionRequest) (handlers.ModelExecutionResponse, *interfaces.ErrorMessage) {
+			return handlers.ModelExecutionResponse{}, &interfaces.ErrorMessage{
+				StatusCode: http.StatusTooManyRequests,
+				Error:      errors.New(upstreamBody),
+				Addon:      http.Header{"Retry-After": []string{"5"}},
+			}
+		},
+	})
+
+	rawReq, errMarshal := json.Marshal(pluginapi.HostModelExecutionRequest{
+		EntryProtocol: "openai",
+		ExitProtocol:  "openai",
+		Model:         "model-1",
+		Body:          []byte(`{"request":true}`),
+	})
+	if errMarshal != nil {
+		t.Fatalf("marshal request: %v", errMarshal)
+	}
+	rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostModelExecute, rawReq)
+	if errCall != nil {
+		t.Fatalf("callFromPlugin() error = %v", errCall)
+	}
+
+	resp, errDecode := decodeRPCEnvelope[pluginapi.HostModelExecutionResponse](rawResp)
+	if errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if resp.StatusCode != http.StatusTooManyRequests ||
+		resp.Headers.Get("Retry-After") != "5" ||
+		string(resp.Body) != upstreamBody ||
+		resp.Error == nil ||
+		resp.Error.StatusCode != http.StatusTooManyRequests ||
+		resp.Error.Headers.Get("Retry-After") != "5" ||
+		string(resp.Error.Body) != upstreamBody ||
+		resp.Error.Message != upstreamBody {
+		t.Fatalf("response = %#v, want structured upstream error", resp)
+	}
+}
+
+func TestHostModelExecuteCallbackKeepsLegacyEnvelopeErrorForSchema1(t *testing.T) {
+	host := New()
+	host.SetModelExecutor(&fakeHostModelExecutor{
+		executeModel: func(context.Context, handlers.ModelExecutionRequest) (handlers.ModelExecutionResponse, *interfaces.ErrorMessage) {
+			return handlers.ModelExecutionResponse{}, &interfaces.ErrorMessage{
+				StatusCode: http.StatusTooManyRequests,
+				Error:      errors.New("quota exceeded"),
+			}
+		},
+	})
+	callbackID, cleanup := host.openCallbackContextForPluginVersion(context.Background(), "legacy", 1)
+	defer cleanup()
+
+	rawReq, errMarshal := json.Marshal(rpcHostModelExecutionRequest{
+		HostModelExecutionRequest: pluginapi.HostModelExecutionRequest{Model: "model-1"},
+		HostCallbackID:            callbackID,
+	})
+	if errMarshal != nil {
+		t.Fatalf("marshal request: %v", errMarshal)
+	}
+	rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostModelExecute, rawReq)
+	if errCall == nil {
+		t.Fatalf("callFromPlugin() error = nil, want schema 1 callback error")
+	}
+	if rawResp != nil {
+		t.Fatalf("raw response = %s, want no successful result", rawResp)
+	}
+}
+
+func TestHostModelExecuteCallbackUsesCallingInstanceSchema(t *testing.T) {
+	host := New()
+	host.SetModelExecutor(&fakeHostModelExecutor{
+		executeModel: func(context.Context, handlers.ModelExecutionRequest) (handlers.ModelExecutionResponse, *interfaces.ErrorMessage) {
+			return handlers.ModelExecutionResponse{}, &interfaces.ErrorMessage{
+				StatusCode: http.StatusTooManyRequests,
+				Error:      errors.New("quota exceeded"),
+			}
+		},
+	})
+	legacy := newDynamicHostCallbackEntry(host, "reloaded-plugin")
+	legacy.setSchemaVersion(pluginabi.SchemaVersionV1)
+	replacement := newDynamicHostCallbackEntry(host, "reloaded-plugin")
+	replacement.setSchemaVersion(pluginabi.SchemaVersionV2)
+
+	rawReq, errMarshal := json.Marshal(pluginapi.HostModelExecutionRequest{Model: "model-1"})
+	if errMarshal != nil {
+		t.Fatalf("marshal request: %v", errMarshal)
+	}
+	rawResp, errCall := host.callFromPlugin(legacy.context(), pluginabi.MethodHostModelExecute, rawReq)
+	if errCall == nil {
+		t.Fatalf("callFromPlugin() error = nil, want schema 1 callback error")
+	}
+	if rawResp != nil {
+		t.Fatalf("raw response = %s, want no successful result", rawResp)
+	}
+	if got := replacement.schemaVersion.Load(); got != pluginabi.SchemaVersionV2 {
+		t.Fatalf("replacement schema version = %d, want %d", got, pluginabi.SchemaVersionV2)
 	}
 }
 
@@ -456,11 +603,14 @@ func TestHostModelStreamReadAfterCallbackCloseReturnsDone(t *testing.T) {
 func TestHostModelExecuteStreamStartupErrorCleansUp(t *testing.T) {
 	host := New()
 	ctxSeen := make(chan context.Context, 1)
+	upstreamBody := `{"error":{"message":"quota","code":"rate_limit"}}`
 	host.SetModelExecutor(&fakeHostModelExecutor{
 		executeModelStream: func(ctx context.Context, req handlers.ModelExecutionRequest) (handlers.ModelExecutionStream, *interfaces.ErrorMessage) {
 			ctxSeen <- ctx
 			return handlers.ModelExecutionStream{}, &interfaces.ErrorMessage{
-				StatusCode: http.StatusBadGateway,
+				StatusCode: http.StatusTooManyRequests,
+				Error:      errors.New(upstreamBody),
+				Addon:      http.Header{"Retry-After": []string{"5"}},
 			}
 		},
 	})
@@ -476,14 +626,22 @@ func TestHostModelExecuteStreamStartupErrorCleansUp(t *testing.T) {
 		t.Fatalf("marshal request: %v", errMarshal)
 	}
 	rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostModelExecuteStream, rawReq)
-	if errCall == nil {
-		t.Fatalf("execute stream callback error is nil, raw response = %q", rawResp)
+	if errCall != nil {
+		t.Fatalf("execute stream callback error = %v", errCall)
 	}
-	if rawResp != nil {
-		t.Fatalf("raw response = %q, want nil on startup error", rawResp)
+	resp, errDecode := decodeRPCEnvelope[pluginapi.HostModelStreamResponse](rawResp)
+	if errDecode != nil {
+		t.Fatalf("decode stream response: %v", errDecode)
 	}
-	if !strings.Contains(errCall.Error(), "status 502") {
-		t.Fatalf("execute stream callback error = %v, want status 502", errCall)
+	if resp.StreamID != "" ||
+		resp.StatusCode != http.StatusTooManyRequests ||
+		resp.Headers.Get("Retry-After") != "5" ||
+		resp.Error == nil ||
+		resp.Error.StatusCode != http.StatusTooManyRequests ||
+		resp.Error.Headers.Get("Retry-After") != "5" ||
+		string(resp.Error.Body) != upstreamBody ||
+		resp.Error.Message != upstreamBody {
+		t.Fatalf("stream response = %#v, want structured startup error", resp)
 	}
 
 	var streamCtx context.Context
@@ -599,6 +757,7 @@ func TestHostModelStreamReadReturnsPayloadAndTerminalError(t *testing.T) {
 	chunks <- handlers.ModelExecutionChunk{Err: &handlers.ModelExecutionStreamError{
 		StatusCode: http.StatusBadGateway,
 		Message:    "terminal boom",
+		Headers:    http.Header{"Retry-After": []string{"5"}},
 	}}
 	host.SetModelExecutor(&fakeHostModelExecutor{
 		executeModelStream: func(ctx context.Context, req handlers.ModelExecutionRequest) (handlers.ModelExecutionStream, *interfaces.ErrorMessage) {
@@ -635,7 +794,14 @@ func TestHostModelStreamReadReturnsPayloadAndTerminalError(t *testing.T) {
 	if errDecode != nil {
 		t.Fatalf("decode terminal response: %v", errDecode)
 	}
-	if !terminal.Done || terminal.Error != "terminal boom" || len(terminal.Payload) != 0 {
+	if !terminal.Done ||
+		terminal.Error != "terminal boom" ||
+		len(terminal.Payload) != 0 ||
+		terminal.ErrorDetails == nil ||
+		terminal.ErrorDetails.StatusCode != http.StatusBadGateway ||
+		terminal.ErrorDetails.Headers.Get("Retry-After") != "5" ||
+		string(terminal.ErrorDetails.Body) != "terminal boom" ||
+		terminal.ErrorDetails.Message != "terminal boom" {
 		t.Fatalf("terminal read = %#v, want done terminal error", terminal)
 	}
 }

--- a/internal/pluginhost/host_callbacks_unix.go
+++ b/internal/pluginhost/host_callbacks_unix.go
@@ -13,10 +13,7 @@ typedef struct {
 */
 import "C"
 
-import (
-	"context"
-	"unsafe"
-)
+import "unsafe"
 
 //export cliproxyHostCall
 func cliproxyHostCall(hostCtx unsafe.Pointer, method *C.char, request *C.uint8_t, requestLen C.size_t, response *C.cliproxy_buffer) C.int {
@@ -32,7 +29,7 @@ func cliproxyHostCall(hostCtx unsafe.Pointer, method *C.char, request *C.uint8_t
 	if !okHost {
 		return 1
 	}
-	entry, okHost := rawHost.(dynamicHostCallbackEntry)
+	entry, okHost := rawHost.(*dynamicHostCallbackEntry)
 	if !okHost || entry.host == nil {
 		return 1
 	}
@@ -40,7 +37,7 @@ func cliproxyHostCall(hostCtx unsafe.Pointer, method *C.char, request *C.uint8_t
 	if request != nil && requestLen > 0 {
 		requestBytes = C.GoBytes(unsafe.Pointer(request), C.int(requestLen))
 	}
-	ctx := withHostCallbackPluginID(context.Background(), entry.pluginID)
+	ctx := entry.context()
 	resp, errCall := entry.host.callFromPlugin(ctx, C.GoString(method), requestBytes)
 	if errCall != nil {
 		resp = marshalRPCError("host_call_failed", errCall.Error())

--- a/internal/pluginhost/host_model_stream_callbacks.go
+++ b/internal/pluginhost/host_model_stream_callbacks.go
@@ -30,7 +30,10 @@ func (h *Host) callHostModelExecuteStream(ctx context.Context, request []byte) (
 	stream, errMsg := executor.ExecuteModelStream(streamCtx, modelExecutionRequestFromPlugin(req.HostModelExecutionRequest, skipPluginID))
 	if errMsg != nil {
 		cancel()
-		return nil, modelExecutionError(errMsg)
+		if !h.usesStructuredHostModelErrors(ctx, req.HostCallbackID) {
+			return nil, legacyHostModelError(errMsg)
+		}
+		return marshalRPCResult(hostModelStreamErrorResponse(errMsg))
 	}
 	streamID := ""
 	if h.modelStreams != nil {
@@ -70,6 +73,7 @@ func (h *Host) callHostModelStreamRead(ctx context.Context, request []byte) ([]b
 	}
 	if chunk.Err != nil {
 		resp.Error = chunk.Err.Error()
+		resp.ErrorDetails = hostModelErrorFromError(chunk.Err)
 		resp.Done = true
 	}
 	return marshalRPCResult(resp)

--- a/internal/pluginhost/host_model_stream_callbacks_test.go
+++ b/internal/pluginhost/host_model_stream_callbacks_test.go
@@ -3,6 +3,7 @@ package pluginhost
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -72,5 +73,34 @@ func TestHostModelExecuteStreamDetachesFromCallbackParentCancel(t *testing.T) {
 	case <-streamCtx.Done():
 	case <-time.After(time.Second):
 		t.Fatal("stream context was not canceled after callback scope closed")
+	}
+}
+
+func TestHostModelExecuteStreamKeepsLegacyEnvelopeErrorForSchema1(t *testing.T) {
+	host := New()
+	host.SetModelExecutor(&fakeHostModelExecutor{
+		executeModelStream: func(context.Context, handlers.ModelExecutionRequest) (handlers.ModelExecutionStream, *interfaces.ErrorMessage) {
+			return handlers.ModelExecutionStream{}, &interfaces.ErrorMessage{
+				StatusCode: http.StatusUnauthorized,
+				Error:      errors.New("unauthorized"),
+			}
+		},
+	})
+	callbackID, cleanup := host.openCallbackContextForPluginVersion(context.Background(), "legacy", 1)
+	defer cleanup()
+
+	rawReq, errMarshal := json.Marshal(rpcHostModelExecutionRequest{
+		HostModelExecutionRequest: pluginapi.HostModelExecutionRequest{Model: "model-1", Stream: true},
+		HostCallbackID:            callbackID,
+	})
+	if errMarshal != nil {
+		t.Fatalf("marshal request: %v", errMarshal)
+	}
+	rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostModelExecuteStream, rawReq)
+	if errCall == nil {
+		t.Fatalf("callFromPlugin() error = nil, want schema 1 callback error")
+	}
+	if rawResp != nil {
+		t.Fatalf("raw response = %s, want no successful result", rawResp)
 	}
 }

--- a/internal/pluginhost/loader_unix.go
+++ b/internal/pluginhost/loader_unix.go
@@ -98,10 +98,11 @@ var (
 type dynamicLibraryLoader struct{}
 
 type dynamicLibraryClient struct {
-	handle  unsafe.Pointer
-	hostAPI *C.cliproxy_host_api
-	hostCtx unsafe.Pointer
-	api     C.cliproxy_plugin_api
+	handle    unsafe.Pointer
+	hostAPI   *C.cliproxy_host_api
+	hostCtx   unsafe.Pointer
+	hostEntry *dynamicHostCallbackEntry
+	api       C.cliproxy_plugin_api
 }
 
 func defaultPluginLoader() pluginLoader {
@@ -138,13 +139,15 @@ func (dynamicLibraryLoader) Open(file pluginFile, host *Host) (pluginClient, err
 	}
 	id := hostCallbackID.Add(1)
 	*(*C.uintptr_t)(hostCtx) = C.uintptr_t(id)
-	hostCallbackEntries.Store(id, dynamicHostCallbackEntry{host: host, pluginID: file.ID})
+	hostEntry := newDynamicHostCallbackEntry(host, file.ID)
+	hostCallbackEntries.Store(id, hostEntry)
 	C.cliproxy_set_host_api(hostAPI, C.uint32_t(pluginHostABIVersion), hostCtx)
 
 	client := &dynamicLibraryClient{
-		handle:  handle,
-		hostAPI: hostAPI,
-		hostCtx: hostCtx,
+		handle:    handle,
+		hostAPI:   hostAPI,
+		hostCtx:   hostCtx,
+		hostEntry: hostEntry,
 	}
 	rc := C.cliproxy_call_init(initSymbol, hostAPI, &client.api)
 	if rc != 0 {
@@ -197,6 +200,12 @@ func (c *dynamicLibraryClient) Call(ctx context.Context, method string, request 
 		return nil, fmt.Errorf("plugin call %s returned %d: %s", method, int(rc), string(out))
 	}
 	return out, nil
+}
+
+func (c *dynamicLibraryClient) setSchemaVersion(schemaVersion uint32) {
+	if c != nil && c.hostEntry != nil {
+		c.hostEntry.setSchemaVersion(schemaVersion)
+	}
 }
 
 func (c *dynamicLibraryClient) Shutdown() {

--- a/internal/pluginhost/loader_windows.go
+++ b/internal/pluginhost/loader_windows.go
@@ -57,11 +57,12 @@ const (
 type dynamicLibraryLoader struct{}
 
 type dynamicLibraryClient struct {
-	dll      *syscall.DLL
-	tempPath string
-	hostAPI  *windowsHostAPI
-	hostCtx  *uintptr
-	api      windowsPluginAPI
+	dll       *syscall.DLL
+	tempPath  string
+	hostAPI   *windowsHostAPI
+	hostCtx   *uintptr
+	hostEntry *dynamicHostCallbackEntry
+	api       windowsPluginAPI
 }
 
 func defaultPluginLoader() pluginLoader {
@@ -87,11 +88,13 @@ func (dynamicLibraryLoader) Open(file pluginFile, host *Host) (pluginClient, err
 	id := windowsHostCallbackID.Add(1)
 	hostCtx := new(uintptr)
 	*hostCtx = id
-	windowsHostCallbackEntries.Store(id, dynamicHostCallbackEntry{host: host, pluginID: file.ID})
+	hostEntry := newDynamicHostCallbackEntry(host, file.ID)
+	windowsHostCallbackEntries.Store(id, hostEntry)
 	client := &dynamicLibraryClient{
-		dll:      dll,
-		tempPath: loadPath,
-		hostCtx:  hostCtx,
+		dll:       dll,
+		tempPath:  loadPath,
+		hostCtx:   hostCtx,
+		hostEntry: hostEntry,
 		hostAPI: &windowsHostAPI{
 			abiVersion: pluginHostABIVersion,
 			hostCtx:    uintptr(unsafe.Pointer(hostCtx)),
@@ -307,6 +310,12 @@ func (c *dynamicLibraryClient) Call(ctx context.Context, method string, request 
 	return out, nil
 }
 
+func (c *dynamicLibraryClient) setSchemaVersion(schemaVersion uint32) {
+	if c != nil && c.hostEntry != nil {
+		c.hostEntry.setSchemaVersion(schemaVersion)
+	}
+}
+
 func (c *dynamicLibraryClient) Shutdown() {
 	// Windows Go DLLs are not safe to hot-unload from the host process.
 	// The plugin was loaded from a shadow copy, so keeping the module mapped
@@ -354,7 +363,7 @@ func windowsHostCall(hostCtx uintptr, methodPtr uintptr, requestPtr uintptr, req
 	if !okHost {
 		return 1
 	}
-	entry, okHost := rawHost.(dynamicHostCallbackEntry)
+	entry, okHost := rawHost.(*dynamicHostCallbackEntry)
 	if !okHost || entry.host == nil {
 		return 1
 	}
@@ -363,7 +372,7 @@ func windowsHostCall(hostCtx uintptr, methodPtr uintptr, requestPtr uintptr, req
 		request = unsafe.Slice((*byte)(unsafe.Pointer(requestPtr)), requestLen)
 		request = append([]byte(nil), request...)
 	}
-	ctx := withHostCallbackPluginID(context.Background(), entry.pluginID)
+	ctx := entry.context()
 	resp, errCall := entry.host.callFromPlugin(ctx, windowsString(methodPtr), request)
 	if errCall != nil {
 		resp = marshalRPCError("host_call_failed", errCall.Error())

--- a/internal/pluginhost/request_interceptor_rejection.go
+++ b/internal/pluginhost/request_interceptor_rejection.go
@@ -1,0 +1,21 @@
+package pluginhost
+
+import (
+	"context"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+func markRequestInterceptorPanic(call func(context.Context, pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error), panicked *bool) func(context.Context, pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+	return func(ctx context.Context, req pluginapi.RequestInterceptRequest) (resp pluginapi.RequestInterceptResponse, err error) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				if panicked != nil {
+					*panicked = true
+				}
+				panic(recovered)
+			}
+		}()
+		return call(ctx, req)
+	}
+}

--- a/internal/pluginhost/rpc_client.go
+++ b/internal/pluginhost/rpc_client.go
@@ -14,9 +14,10 @@ import (
 )
 
 type rpcPluginAdapter struct {
-	id     string
-	host   *Host
-	client pluginClient
+	id            string
+	host          *Host
+	client        pluginClient
+	schemaVersion uint32
 }
 
 type rpcAuthProvider struct {
@@ -59,15 +60,20 @@ func registerRPCPlugin(ctx context.Context, host *Host, id string, client plugin
 	}
 	resp, errCall := callPlugin[rpcRegistration](ctx, client, method, rpcLifecycleRequest{
 		ConfigYAML:    bytes.Clone(configYAML),
-		SchemaVersion: pluginabi.SchemaVersion,
+		SchemaVersion: pluginabi.CurrentSchemaVersion,
 	})
 	if errCall != nil {
 		return pluginapi.Plugin{}, errCall
 	}
-	if resp.SchemaVersion > pluginabi.SchemaVersion {
+	schemaVersion := resp.SchemaVersion
+	if schemaVersion == 0 {
+		schemaVersion = pluginabi.SchemaVersionV1
+	}
+	if schemaVersion > pluginabi.CurrentSchemaVersion {
 		return pluginapi.Plugin{}, fmt.Errorf("plugin schema version %d is not supported", resp.SchemaVersion)
 	}
-	adapter := &rpcPluginAdapter{id: id, host: host, client: client}
+	setPluginClientSchemaVersion(client, schemaVersion)
+	adapter := &rpcPluginAdapter{id: id, host: host, client: client, schemaVersion: schemaVersion}
 	plugin := pluginapi.Plugin{
 		Metadata: resp.Metadata,
 		Capabilities: pluginapi.Capabilities{
@@ -340,7 +346,7 @@ func (a *rpcPluginAdapter) openHostCallbackContext(ctx context.Context) (string,
 	if a == nil || a.host == nil {
 		return "", func() {}
 	}
-	return a.host.openCallbackContextForPlugin(ctx, a.id)
+	return a.host.openCallbackContextForPluginVersion(ctx, a.id, a.schemaVersion)
 }
 
 func (a *rpcPluginAdapter) RegisterModels(ctx context.Context, req pluginapi.ModelRegistrationRequest) (pluginapi.ModelRegistrationResponse, error) {

--- a/internal/pluginhost/rpc_schema_test.go
+++ b/internal/pluginhost/rpc_schema_test.go
@@ -103,7 +103,7 @@ func TestRPCCapabilitiesIncludeModelRouter(t *testing.T) {
 	}
 }
 
-func TestRegisterRPCPluginSendsHostSchemaVersion(t *testing.T) {
+func TestRegisterRPCPluginSendsCurrentHostSchemaVersion(t *testing.T) {
 	lookup := newTestSymbolLookup(&testPlugin{
 		registerResult: validTestPlugin("schema"),
 	})
@@ -111,8 +111,8 @@ func TestRegisterRPCPluginSendsHostSchemaVersion(t *testing.T) {
 	if _, errRegister := registerRPCPlugin(context.Background(), nil, "schema", lookup, pluginabi.MethodPluginRegister, []byte("mode: test")); errRegister != nil {
 		t.Fatalf("registerRPCPlugin() error = %v", errRegister)
 	}
-	if lookup.lastLifecycle.SchemaVersion != pluginabi.SchemaVersion {
-		t.Fatalf("lifecycle schema_version = %d, want %d", lookup.lastLifecycle.SchemaVersion, pluginabi.SchemaVersion)
+	if lookup.lastLifecycle.SchemaVersion != pluginabi.SchemaVersionV2 {
+		t.Fatalf("lifecycle schema_version = %d, want %d", lookup.lastLifecycle.SchemaVersion, pluginabi.SchemaVersionV2)
 	}
 	if string(lookup.lastLifecycle.ConfigYAML) != "mode: test" {
 		t.Fatalf("lifecycle config = %q, want input config", lookup.lastLifecycle.ConfigYAML)
@@ -123,7 +123,7 @@ func TestRegisterRPCPluginRejectsFutureSchemaVersion(t *testing.T) {
 	lookup := newTestSymbolLookup(&testPlugin{
 		registerResult: validTestPlugin("future-schema"),
 	})
-	lookup.schemaVersion = pluginabi.SchemaVersion + 1
+	lookup.schemaVersion = pluginabi.SchemaVersionV2 + 1
 
 	_, errRegister := registerRPCPlugin(context.Background(), nil, "future-schema", lookup, pluginabi.MethodPluginRegister, nil)
 	if errRegister == nil || !strings.Contains(errRegister.Error(), "schema version") {

--- a/internal/pluginhost/rpc_schema_version_test.go
+++ b/internal/pluginhost/rpc_schema_version_test.go
@@ -1,0 +1,57 @@
+package pluginhost
+
+import (
+	"context"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginabi"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+type schemaVersionTrackingClient struct {
+	pluginClient
+	schemaVersion uint32
+}
+
+func (c *schemaVersionTrackingClient) setSchemaVersion(schemaVersion uint32) {
+	c.schemaVersion = schemaVersion
+}
+
+func TestRegisterRPCPluginKeepsSDKDefaultAtSchema1(t *testing.T) {
+	lookup := newTestSymbolLookup(&testPlugin{
+		registerResult: validTestPlugin("default-schema"),
+	})
+	client := &schemaVersionTrackingClient{pluginClient: lookup}
+
+	if _, errRegister := registerRPCPlugin(context.Background(), nil, "default-schema", client, pluginabi.MethodPluginRegister, nil); errRegister != nil {
+		t.Fatalf("registerRPCPlugin() error = %v", errRegister)
+	}
+	if client.schemaVersion != pluginabi.SchemaVersionV1 {
+		t.Fatalf("negotiated schema version = %d, want compatibility default %d", client.schemaVersion, pluginabi.SchemaVersionV1)
+	}
+}
+
+func TestRegisterRPCPluginPropagatesSchemaVersionToCallbackContexts(t *testing.T) {
+	plugin := validTestPlugin("callback-schema")
+	plugin.Capabilities.ModelRouter = modelRouterFunc(func(context.Context, pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, error) {
+		return pluginapi.ModelRouteResponse{}, nil
+	})
+	lookup := newTestSymbolLookup(&testPlugin{registerResult: plugin})
+	lookup.schemaVersion = pluginabi.SchemaVersionV1
+	host := New()
+
+	registered, errRegister := registerRPCPlugin(context.Background(), host, "callback-schema", lookup, pluginabi.MethodPluginRegister, nil)
+	if errRegister != nil {
+		t.Fatalf("registerRPCPlugin() error = %v", errRegister)
+	}
+	adapter, okAdapter := registered.Capabilities.ModelRouter.(*rpcPluginAdapter)
+	if !okAdapter {
+		t.Fatalf("ModelRouter type = %T, want *rpcPluginAdapter", registered.Capabilities.ModelRouter)
+	}
+
+	callbackID, cleanup := adapter.openHostCallbackContext(context.Background())
+	defer cleanup()
+	if got := host.callbackContexts.schemaVersion(callbackID); got != pluginabi.SchemaVersionV1 {
+		t.Fatalf("callback schema version = %d, want %d", got, pluginabi.SchemaVersionV1)
+	}
+}

--- a/internal/pluginhost/stream_bridge.go
+++ b/internal/pluginhost/stream_bridge.go
@@ -40,18 +40,21 @@ type streamBridgeEmit struct {
 
 type streamBridgeClose struct {
 	errorMessage string
+	errorDetails *pluginapi.HostModelError
 	accepted     chan struct{}
 }
 
 type rpcStreamEmitRequest struct {
-	StreamID string `json:"stream_id"`
-	Payload  []byte `json:"payload,omitempty"`
-	Error    string `json:"error,omitempty"`
+	StreamID     string                    `json:"stream_id"`
+	Payload      []byte                    `json:"payload,omitempty"`
+	Error        string                    `json:"error,omitempty"`
+	ErrorDetails *pluginapi.HostModelError `json:"error_details,omitempty"`
 }
 
 type rpcStreamCloseRequest struct {
-	StreamID string `json:"stream_id"`
-	Error    string `json:"error,omitempty"`
+	StreamID     string                    `json:"stream_id"`
+	Error        string                    `json:"error,omitempty"`
+	ErrorDetails *pluginapi.HostModelError `json:"error_details,omitempty"`
 }
 
 func newStreamBridge() *streamBridge {
@@ -97,8 +100,14 @@ func (s *streamBridgeStream) run() {
 		case request := <-s.closes:
 			s.markClosed()
 			close(request.accepted)
-			if request.errorMessage != "" {
-				queue = append(queue, pluginapi.ExecutorStreamChunk{Err: fmt.Errorf("%s", request.errorMessage)})
+			if request.errorDetails != nil || request.errorMessage != "" {
+				var err error
+				if request.errorDetails != nil {
+					err = newPluginStreamError(request.errorDetails, request.errorMessage)
+				} else {
+					err = fmt.Errorf("%s", request.errorMessage)
+				}
+				queue = append(queue, pluginapi.ExecutorStreamChunk{Err: err})
 			}
 			for len(queue) > 0 {
 				select {
@@ -161,12 +170,13 @@ func (s *streamBridgeStream) emit(ctx context.Context, chunk pluginapi.ExecutorS
 	return <-request.done
 }
 
-func (s *streamBridgeStream) close(errorMessage string) {
+func (s *streamBridgeStream) close(errorMessage string, errorDetails *pluginapi.HostModelError) {
 	if s == nil {
 		return
 	}
 	request := streamBridgeClose{
 		errorMessage: errorMessage,
+		errorDetails: errorDetails,
 		accepted:     make(chan struct{}),
 	}
 	select {
@@ -228,7 +238,7 @@ func (b *streamBridge) emit(ctx context.Context, id string, chunk pluginapi.Exec
 	return nil
 }
 
-func (b *streamBridge) close(id string, errorMessage string) {
+func (b *streamBridge) close(id string, errorMessage string, errorDetails *pluginapi.HostModelError) {
 	if b == nil || id == "" {
 		return
 	}
@@ -239,5 +249,5 @@ func (b *streamBridge) close(id string, errorMessage string) {
 	if stream == nil {
 		return
 	}
-	stream.close(errorMessage)
+	stream.close(errorMessage, errorDetails)
 }

--- a/internal/pluginhost/stream_bridge_test.go
+++ b/internal/pluginhost/stream_bridge_test.go
@@ -2,6 +2,8 @@ package pluginhost
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"strings"
 	"sync"
 	"testing"
@@ -51,7 +53,7 @@ func TestStreamBridgeCloseUnblocksPendingEmit(t *testing.T) {
 	default:
 	}
 
-	bridge.close(streamID, "")
+	bridge.close(streamID, "", nil)
 
 	select {
 	case err := <-emitDone:
@@ -127,7 +129,7 @@ func TestStreamBridgeCleanupAbortsPendingGracefulClose(t *testing.T) {
 			t.Fatalf("fill stream buffer: %v", err)
 		}
 	}
-	bridge.close(streamID, "plugin stream failed")
+	bridge.close(streamID, "plugin stream failed", nil)
 
 	cleanup()
 
@@ -145,7 +147,11 @@ func TestStreamBridgeCloseDeliversTerminalError(t *testing.T) {
 	bridge := newStreamBridge()
 	streamID, chunks, _ := bridge.open(context.Background())
 
-	bridge.close(streamID, "plugin stream failed")
+	bridge.close(streamID, "plugin stream failed", &pluginapi.HostModelError{
+		StatusCode: http.StatusBadGateway,
+		Headers:    http.Header{"Retry-After": []string{"5"}},
+		Message:    "plugin stream failed",
+	})
 
 	chunk, ok := <-chunks
 	if !ok {
@@ -153,6 +159,14 @@ func TestStreamBridgeCloseDeliversTerminalError(t *testing.T) {
 	}
 	if chunk.Err == nil || chunk.Err.Error() != "plugin stream failed" {
 		t.Fatalf("terminal error = %v, want plugin stream failed", chunk.Err)
+	}
+	statusErr, ok := chunk.Err.(interface{ StatusCode() int })
+	if !ok || statusErr.StatusCode() != http.StatusBadGateway {
+		t.Fatalf("terminal error status = %#v, want 502", chunk.Err)
+	}
+	headerErr, ok := chunk.Err.(interface{ Headers() http.Header })
+	if !ok || headerErr.Headers().Get("Retry-After") != "5" {
+		t.Fatalf("terminal error headers = %#v, want retry-after", chunk.Err)
 	}
 	if _, ok = <-chunks; ok {
 		t.Fatal("stream remains open after terminal error")
@@ -171,7 +185,10 @@ func TestStreamBridgeClosePreservesTerminalErrorWhenBufferIsFull(t *testing.T) {
 
 	closeDone := make(chan struct{})
 	go func() {
-		bridge.close(streamID, "plugin stream failed")
+		bridge.close(streamID, "plugin stream failed", &pluginapi.HostModelError{
+			StatusCode: http.StatusBadGateway,
+			Message:    "plugin stream failed",
+		})
 		close(closeDone)
 	}()
 	select {
@@ -193,5 +210,52 @@ func TestStreamBridgeClosePreservesTerminalErrorWhenBufferIsFull(t *testing.T) {
 	}
 	if terminalErr == nil || terminalErr.Error() != "plugin stream failed" {
 		t.Fatalf("terminal error = %v, want plugin stream failed", terminalErr)
+	}
+	statusErr, ok := terminalErr.(interface{ StatusCode() int })
+	if !ok || statusErr.StatusCode() != http.StatusBadGateway {
+		t.Fatalf("terminal error status = %#v, want 502", terminalErr)
+	}
+}
+
+func TestStreamBridgeEmitUnblocksOnContextCancellationWhenFull(t *testing.T) {
+	bridge := newStreamBridge()
+	id, _, cleanup := bridge.open(context.Background())
+	defer cleanup()
+
+	for i := 0; i < streamBridgeBufferSize; i++ {
+		if err := bridge.emit(context.Background(), id, pluginapi.ExecutorStreamChunk{Payload: []byte("p")}); err != nil {
+			t.Fatalf("emit %d: %v", i, err)
+		}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	emitDone := make(chan error, 1)
+	go func() {
+		emitDone <- bridge.emit(ctx, id, pluginapi.ExecutorStreamChunk{Payload: []byte("blocked")})
+	}()
+	cancel()
+
+	select {
+	case err := <-emitDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("emit error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("emit did not stop after context cancellation")
+	}
+}
+
+func TestStreamBridgeUsesPerStreamSignals(t *testing.T) {
+	bridge := newStreamBridge()
+	firstID, _, firstCleanup := bridge.open(context.Background())
+	defer firstCleanup()
+	secondID, _, secondCleanup := bridge.open(context.Background())
+	defer secondCleanup()
+
+	bridge.mu.Lock()
+	firstSignal := bridge.streams[firstID].emits
+	secondSignal := bridge.streams[secondID].emits
+	bridge.mu.Unlock()
+	if firstSignal == secondSignal {
+		t.Fatal("streams share a space signal")
 	}
 }

--- a/sdk/api/handlers/handlers_execution.go
+++ b/sdk/api/handlers/handlers_execution.go
@@ -280,6 +280,13 @@ func (h *BaseAPIHandler) applyRequestInterceptorsAfterPluginExecutorRoute(ctx co
 		Body:           cloneBytes(req.Payload),
 		Metadata:       opts.Metadata,
 	}, requestID, skipPluginID)
+	if resp.Reject {
+		return req, opts, &interfaces.ErrorMessage{
+			StatusCode:     http.StatusForbidden,
+			Error:          fmt.Errorf("request rejected by plugin: %s", resp.RejectReason),
+			DirectResponse: true,
+		}
+	}
 	opts.Headers = mergeRequestInterceptorHeaders(opts.Headers, resp.Headers, resp.ClearHeaders)
 	if len(resp.Body) > 0 {
 		req.Payload = cloneBytes(resp.Body)

--- a/sdk/api/handlers/handlers_interceptors.go
+++ b/sdk/api/handlers/handlers_interceptors.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -420,6 +421,13 @@ func (h *BaseAPIHandler) applyRequestInterceptorsBeforeAuth(ctx context.Context,
 		Body:           cloneBytes(req.Payload),
 		Metadata:       opts.Metadata,
 	}, skipPluginID)
+	if resp.Reject {
+		return req, opts, &interfaces.ErrorMessage{
+			StatusCode:     http.StatusForbidden,
+			Error:          fmt.Errorf("request rejected by plugin: %s", resp.RejectReason),
+			DirectResponse: true,
+		}
+	}
 	opts.Headers = finalInterceptorHeaders(opts.Headers, resp.Headers)
 	if len(resp.Body) > 0 {
 		req.Payload = cloneBytes(resp.Body)
@@ -469,6 +477,8 @@ func (h *BaseAPIHandler) applyRequestInterceptorsAfterAuth(ctx context.Context, 
 		StatusCode:      normalizedTerminationStatus(resp.StatusCode),
 		ResponseHeaders: resp.ResponseHeaders,
 		ResponseBody:    resp.ResponseBody,
+		Reject:          resp.Reject,
+		RejectReason:    resp.RejectReason,
 	}
 }
 

--- a/sdk/api/handlers/handlers_interceptors_test.go
+++ b/sdk/api/handlers/handlers_interceptors_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -665,6 +666,81 @@ func TestHandlerRequestInterceptorAfterAuthRewritesExecutorRequest(t *testing.T)
 	}
 	if !responseChecked {
 		t.Fatal("response interceptor was not called")
+	}
+}
+
+func TestApplyRequestInterceptorsBeforeAuthRejectReturns403(t *testing.T) {
+	handler := &BaseAPIHandler{}
+	handler.SetPluginHost(&handlerInterceptorTestHost{
+		interceptRequestBeforeAuth: func(context.Context, pluginapi.RequestInterceptRequest) pluginapi.RequestInterceptResponse {
+			return pluginapi.RequestInterceptResponse{Reject: true, RejectReason: "policy denied"}
+		},
+	})
+
+	req := coreexecutor.Request{Model: "gpt", Payload: []byte("body")}
+	opts := coreexecutor.Options{}
+	outReq, _, rejectErr := handler.applyRequestInterceptorsBeforeAuth(context.Background(), "openai", "gpt", "request-id", req, opts, "")
+
+	if rejectErr == nil {
+		t.Fatal("expected a rejection ErrorMessage from the before-auth interceptors")
+	}
+	if rejectErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("StatusCode = %d, want %d", rejectErr.StatusCode, http.StatusForbidden)
+	}
+	if rejectErr.Error == nil || !strings.Contains(rejectErr.Error.Error(), "policy denied") {
+		t.Fatalf("Error = %v, want reason substring %q", rejectErr.Error, "policy denied")
+	}
+	if !strings.Contains(rejectErr.Error.Error(), "request rejected by plugin") {
+		t.Fatalf("Error = %v, want prefix %q", rejectErr.Error, "request rejected by plugin")
+	}
+	if string(outReq.Payload) != "body" {
+		t.Fatalf("Payload = %q, want original body on reject", outReq.Payload)
+	}
+}
+
+func TestApplyRequestInterceptorsAfterPluginExecutorRouteRejectReturns403(t *testing.T) {
+	handler := &BaseAPIHandler{}
+	handler.SetPluginHost(&handlerInterceptorTestHost{
+		interceptRequestAfterAuth: func(context.Context, pluginapi.RequestInterceptRequest) pluginapi.RequestInterceptResponse {
+			return pluginapi.RequestInterceptResponse{
+				Reject:       true,
+				RejectReason: "policy denied",
+				Body:         []byte("should-not-be-applied"),
+			}
+		},
+	})
+
+	req := coreexecutor.Request{Model: "gpt", Payload: []byte("body")}
+	opts := coreexecutor.Options{}
+	outReq, outOpts, rejectErr := handler.applyRequestInterceptorsAfterPluginExecutorRoute(
+		context.Background(),
+		nil,
+		"executor-plugin",
+		"openai",
+		"gpt",
+		"request-id",
+		req,
+		opts,
+		"",
+	)
+
+	if rejectErr == nil {
+		t.Fatal("expected a rejection ErrorMessage from the plugin-executor after-auth path")
+	}
+	if rejectErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("StatusCode = %d, want %d", rejectErr.StatusCode, http.StatusForbidden)
+	}
+	if rejectErr.Error == nil || !strings.Contains(rejectErr.Error.Error(), "policy denied") {
+		t.Fatalf("Error = %v, want reason substring %q", rejectErr.Error, "policy denied")
+	}
+	if !strings.Contains(rejectErr.Error.Error(), "request rejected by plugin") {
+		t.Fatalf("Error = %v, want prefix %q", rejectErr.Error, "request rejected by plugin")
+	}
+	if string(outReq.Payload) != "body" {
+		t.Fatalf("Payload = %q, want original body (mutations discarded on reject)", outReq.Payload)
+	}
+	if string(outOpts.OriginalRequest) == "should-not-be-applied" {
+		t.Fatalf("OriginalRequest was mutated on reject: %q", outOpts.OriginalRequest)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1535,14 +1535,18 @@ func isMissingModelPhrase(value string) bool {
 // isRequestInvalidError returns true if the error represents a client request
 // error that should not be retried. Specifically, it treats 400 responses with
 // "invalid_request_error", request-scoped 404 item misses caused by `store=false`,
-// and all 422 responses as request-shape failures, where switching auths or
-// pooled upstream models will not help. Model-support errors are excluded so
-// routing can fall through to another auth or upstream.
+// all 422 responses, and plugin policy rejections (request_rejected_by_plugin)
+// as request-shape / policy failures, where switching auths or pooled upstream
+// models will not help. Model-support errors are excluded so routing can fall
+// through to another auth or upstream.
 func isRequestInvalidError(err error) bool {
 	if err == nil {
 		return false
 	}
 	if isRequestScopedError(err) {
+		return true
+	}
+	if isRequestRejectedByPluginError(err) {
 		return true
 	}
 	if isCloudflareChallengeError(err) {
@@ -1573,6 +1577,19 @@ func isRequestInvalidError(err error) bool {
 	default:
 		return false
 	}
+}
+
+// isRequestRejectedByPluginError reports plugin policy rejections that must
+// terminate auth selection and outer cooldown retries immediately.
+func isRequestRejectedByPluginError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var authErr *Error
+	if errors.As(err, &authErr) && authErr != nil {
+		return authErr.Code == "request_rejected_by_plugin"
+	}
+	return false
 }
 
 func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time, disableCooling bool) {

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -180,6 +180,14 @@ func applyRequestAfterAuthInterceptor(ctx context.Context, executor ProviderExec
 		Body:           bytes.Clone(req.Payload),
 		Metadata:       opts.Metadata,
 	})
+	if resp.Reject {
+		return req, opts, &Error{
+			Code:       "request_rejected_by_plugin",
+			Message:    resp.RejectReason,
+			HTTPStatus: http.StatusForbidden,
+			Retryable:  false,
+		}
+	}
 	opts.Headers = mergeRequestHeaders(opts.Headers, resp.Headers, resp.ClearHeaders)
 	if len(resp.Body) > 0 {
 		req.Payload = bytes.Clone(resp.Body)

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -746,11 +746,13 @@ func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []stri
 	if maxWait <= 0 {
 		return 0, false
 	}
-	status := statusCodeFromError(err)
-	if status == http.StatusOK {
+	// Plugin policy rejections are terminal even when some auth is cooling down.
+	// Check before closestCooldownWait so a 403 reject never sleeps/retries.
+	if isRequestInvalidError(err) {
 		return 0, false
 	}
-	if isRequestInvalidError(err) {
+	status := statusCodeFromError(err)
+	if status == http.StatusOK {
 		return 0, false
 	}
 	wait, found := m.closestCooldownWait(providers, model, attempt)

--- a/sdk/cliproxy/auth/request_after_auth_reject_test.go
+++ b/sdk/cliproxy/auth/request_after_auth_reject_test.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestApplyRequestAfterAuthInterceptorRejectPropagates(t *testing.T) {
+	opts := cliproxyexecutor.Options{
+		RequestAfterAuthInterceptor: func(_ context.Context, _ cliproxyexecutor.RequestAfterAuthInterceptRequest) cliproxyexecutor.RequestAfterAuthInterceptResponse {
+			return cliproxyexecutor.RequestAfterAuthInterceptResponse{Reject: true, RejectReason: "policy denied"}
+		},
+	}
+	req := cliproxyexecutor.Request{Model: "gpt", Payload: []byte("body")}
+
+	outReq, _, errAfterAuth := applyRequestAfterAuthInterceptor(context.Background(), nil, "openai", req, opts, "gpt")
+
+	if errAfterAuth == nil {
+		t.Fatal("expected a rejection error to propagate from the after-auth interceptor")
+	}
+	if e, ok := errAfterAuth.(*Error); ok {
+		if e.HTTPStatus != http.StatusForbidden {
+			t.Fatalf("HTTPStatus = %d, want %d", e.HTTPStatus, http.StatusForbidden)
+		}
+		if e.Code != "request_rejected_by_plugin" {
+			t.Fatalf("Code = %q, want %q", e.Code, "request_rejected_by_plugin")
+		}
+		if e.Message != "policy denied" {
+			t.Fatalf("Message = %q, want %q", e.Message, "policy denied")
+		}
+		if e.Retryable {
+			t.Fatal("Retryable = true, want false for plugin policy rejection")
+		}
+	} else {
+		t.Fatalf("error type = %T, want *Error", errAfterAuth)
+	}
+	if string(outReq.Payload) != "body" {
+		t.Fatalf("Payload = %q, want original body on reject", outReq.Payload)
+	}
+	if !isRequestInvalidError(errAfterAuth) {
+		t.Fatal("isRequestInvalidError should treat plugin rejection as terminal")
+	}
+	if !isRequestRejectedByPluginError(errAfterAuth) {
+		t.Fatal("isRequestRejectedByPluginError should match request_rejected_by_plugin")
+	}
+	if _, shouldRetry := (&Manager{}).shouldRetryAfterError(errAfterAuth, 0, []string{"openai"}, "gpt", time.Minute); shouldRetry {
+		t.Fatal("shouldRetryAfterError should not retry plugin policy rejections")
+	}
+}

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -101,6 +101,10 @@ type RequestAfterAuthInterceptResponse struct {
 	ResponseHeaders http.Header
 	// ResponseBody contains the downstream response body used when Terminate is true.
 	ResponseBody []byte
+	// Reject, when true, aborts the request after auth selection (fail-closed).
+	Reject bool
+	// RejectReason is an optional human-readable explanation surfaced to the caller.
+	RejectReason string
 }
 
 // RequestTerminatedError carries a plugin-defined downstream response without executing upstream.

--- a/sdk/pluginabi/types.go
+++ b/sdk/pluginabi/types.go
@@ -5,9 +5,16 @@ import "encoding/json"
 const (
 	// ABIVersion tracks the native C ABI shape (native plugin exports).
 	ABIVersion uint32 = 1
-	// SchemaVersion tracks the RPC JSON contract exchanged at plugin.register.
-	// Version 2 adds request lifecycle completion and active request termination.
-	SchemaVersion uint32 = 2
+	// SchemaVersionV1 is the original RPC JSON contract.
+	SchemaVersionV1 uint32 = 1
+	// SchemaVersionV2 adds request lifecycle completion, active request termination,
+	// and structured host model execution errors.
+	SchemaVersionV2 uint32 = 2
+	// SchemaVersion is the compatibility default for plugins that have not
+	// explicitly opted into a newer RPC JSON contract.
+	SchemaVersion uint32 = SchemaVersionV1
+	// CurrentSchemaVersion is the latest RPC JSON contract supported by the host.
+	CurrentSchemaVersion uint32 = SchemaVersionV2
 )
 
 const (

--- a/sdk/pluginabi/types_test.go
+++ b/sdk/pluginabi/types_test.go
@@ -5,6 +5,12 @@ import (
 	"testing"
 )
 
+func TestSchemaVersionPreservesV1Compatibility(t *testing.T) {
+	if SchemaVersion != SchemaVersionV1 {
+		t.Fatalf("SchemaVersion = %d, want compatibility default %d", SchemaVersion, SchemaVersionV1)
+	}
+}
+
 func TestEnvelopeRoundTrip(t *testing.T) {
 	payload := json.RawMessage(`{"name":"example"}`)
 	env := Envelope{
@@ -27,8 +33,8 @@ func TestEnvelopeRoundTrip(t *testing.T) {
 }
 
 func TestMethodNamesAreStable(t *testing.T) {
-	if SchemaVersion != 2 {
-		t.Fatalf("SchemaVersion = %d, want 2", SchemaVersion)
+	if CurrentSchemaVersion != SchemaVersionV2 {
+		t.Fatalf("CurrentSchemaVersion = %d, want %d", CurrentSchemaVersion, SchemaVersionV2)
 	}
 	if MethodPluginRegister != "plugin.register" {
 		t.Fatalf("MethodPluginRegister = %q", MethodPluginRegister)

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -616,7 +616,27 @@ type HostModelExecutionRequest struct {
 	Alt string `json:"alt"`
 }
 
+// HostModelError preserves upstream model execution error details for plugins.
+//
+// Body is best-effort. When the host only has an error string (not a raw upstream
+// response body), Body may contain that string and match Message.
+type HostModelError struct {
+	// StatusCode is the upstream model execution HTTP status code.
+	StatusCode int `json:"status_code"`
+	// Headers contains upstream error response headers when available.
+	Headers http.Header `json:"headers"`
+	// Body contains the upstream error response body when available.
+	// If the host only has a string error, Body may hold that string.
+	Body []byte `json:"body"`
+	// Message is a human-readable error message.
+	Message string `json:"message"`
+}
+
 // HostModelExecutionResponse describes a non-streaming host model execution response.
+//
+// Error contract: host.model.execute returns a successful RPC envelope even when
+// model execution fails. Callers must inspect Error (or StatusCode) rather than
+// relying only on the RPC-level error channel.
 type HostModelExecutionResponse struct {
 	// StatusCode is the model execution HTTP status code.
 	StatusCode int `json:"status_code"`
@@ -624,16 +644,27 @@ type HostModelExecutionResponse struct {
 	Headers http.Header `json:"headers"`
 	// Body contains the raw response body.
 	Body []byte `json:"body"`
+	// Error is set when model execution fails before a normal response is available.
+	// Prefer checking Error (or StatusCode >= 400) over the RPC error channel alone.
+	Error *HostModelError `json:"error,omitempty"`
 }
 
 // HostModelStreamResponse describes a streaming host model execution response.
+//
+// Error contract: host.model.execute_stream returns a successful RPC envelope
+// even when stream startup fails. Callers must inspect Error (or StatusCode)
+// rather than relying only on the RPC-level error channel.
 type HostModelStreamResponse struct {
 	// StatusCode is the model execution HTTP status code.
 	StatusCode int `json:"status_code"`
 	// Headers contains response headers.
 	Headers http.Header `json:"headers"`
 	// StreamID identifies the host-owned stream for later reads.
+	// Empty when Error is set and no stream was opened.
 	StreamID string `json:"stream_id"`
+	// Error is set when streaming fails before a stream is opened.
+	// Prefer checking Error (or StatusCode >= 400) over the RPC error channel alone.
+	Error *HostModelError `json:"error,omitempty"`
 }
 
 // HostModelStreamReadRequest asks the host to read the next model stream chunk.
@@ -643,11 +674,17 @@ type HostModelStreamReadRequest struct {
 }
 
 // HostModelStreamReadResponse returns one model stream chunk or terminal state.
+//
+// ErrorDetails carries structured stream errors when available. Error remains
+// the plain-string form for older callers.
 type HostModelStreamReadResponse struct {
 	// Payload contains the raw stream chunk bytes.
 	Payload []byte `json:"payload"`
 	// Error reports a stream error associated with this read.
 	Error string `json:"error"`
+	// ErrorDetails preserves structured stream error details when available.
+	// Prefer ErrorDetails when present; Error is the string fallback.
+	ErrorDetails *HostModelError `json:"error_details,omitempty"`
 	// Done reports whether the stream has ended.
 	Done bool `json:"done"`
 }
@@ -1021,6 +1058,12 @@ type RequestInterceptResponse struct {
 	ResponseHeaders http.Header
 	// ResponseBody contains the downstream response body used when Terminate is true.
 	ResponseBody []byte
+	// Reject, when true, aborts the request before it reaches the upstream.
+	// Interceptors use this to fail closed (for example, when a policy plugin
+	// cannot safely continue) instead of forwarding the original body.
+	Reject bool `json:"reject,omitempty"`
+	// RejectReason is an optional human-readable explanation surfaced to the caller.
+	RejectReason string `json:"reject_reason,omitempty"`
 }
 
 // RequestCompletionOutcome identifies how an intercepted request ended.

--- a/sdk/pluginapi/types_test.go
+++ b/sdk/pluginapi/types_test.go
@@ -211,17 +211,24 @@ func TestHostModelTypesPreserveFields(t *testing.T) {
 		t.Fatalf("HostModelExecutionRequest headers = %#v", decodedRequest.Headers)
 	}
 
+	upstreamErrorBody := `{"error":{"message":"quota","code":"rate_limit"}}`
 	response := HostModelExecutionResponse{
-		StatusCode: http.StatusAccepted,
-		Headers:    http.Header{"Content-Type": []string{"application/json"}},
-		Body:       []byte(`{"ok":true}`),
+		StatusCode: http.StatusTooManyRequests,
+		Headers:    http.Header{"Retry-After": []string{"5"}},
+		Body:       []byte(upstreamErrorBody),
+		Error: &HostModelError{
+			StatusCode: http.StatusTooManyRequests,
+			Headers:    http.Header{"Retry-After": []string{"5"}},
+			Body:       []byte(upstreamErrorBody),
+			Message:    upstreamErrorBody,
+		},
 	}
 	rawResponse, errMarshalResponse := json.Marshal(response)
 	if errMarshalResponse != nil {
 		t.Fatalf("marshal HostModelExecutionResponse: %v", errMarshalResponse)
 	}
 	responseJSON := string(rawResponse)
-	for _, field := range []string{"status_code", "headers", "body"} {
+	for _, field := range []string{"status_code", "headers", "body", "error"} {
 		if !strings.Contains(responseJSON, `"`+field+`"`) {
 			t.Fatalf("HostModelExecutionResponse JSON missing field %q: %s", field, responseJSON)
 		}
@@ -231,22 +238,32 @@ func TestHostModelTypesPreserveFields(t *testing.T) {
 		t.Fatalf("unmarshal HostModelExecutionResponse: %v", errUnmarshalResponse)
 	}
 	if decodedResponse.StatusCode != response.StatusCode ||
-		decodedResponse.Headers.Get("Content-Type") != "application/json" ||
-		string(decodedResponse.Body) != string(response.Body) {
+		decodedResponse.Headers.Get("Retry-After") != "5" ||
+		string(decodedResponse.Body) != string(response.Body) ||
+		decodedResponse.Error == nil ||
+		decodedResponse.Error.StatusCode != http.StatusTooManyRequests ||
+		decodedResponse.Error.Headers.Get("Retry-After") != "5" ||
+		string(decodedResponse.Error.Body) != upstreamErrorBody ||
+		decodedResponse.Error.Message != upstreamErrorBody {
 		t.Fatalf("HostModelExecutionResponse round trip = %#v", decodedResponse)
 	}
 
 	streamResponse := HostModelStreamResponse{
-		StatusCode: http.StatusOK,
-		Headers:    http.Header{"Content-Type": []string{"text/event-stream"}},
-		StreamID:   "stream-1",
+		StatusCode: http.StatusTooManyRequests,
+		Headers:    http.Header{"Retry-After": []string{"5"}},
+		Error: &HostModelError{
+			StatusCode: http.StatusTooManyRequests,
+			Headers:    http.Header{"Retry-After": []string{"5"}},
+			Body:       []byte(upstreamErrorBody),
+			Message:    upstreamErrorBody,
+		},
 	}
 	rawStreamResponse, errMarshalStreamResponse := json.Marshal(streamResponse)
 	if errMarshalStreamResponse != nil {
 		t.Fatalf("marshal HostModelStreamResponse: %v", errMarshalStreamResponse)
 	}
 	streamResponseJSON := string(rawStreamResponse)
-	for _, field := range []string{"status_code", "headers", "stream_id"} {
+	for _, field := range []string{"status_code", "headers", "error"} {
 		if !strings.Contains(streamResponseJSON, `"`+field+`"`) {
 			t.Fatalf("HostModelStreamResponse JSON missing field %q: %s", field, streamResponseJSON)
 		}
@@ -256,8 +273,13 @@ func TestHostModelTypesPreserveFields(t *testing.T) {
 		t.Fatalf("unmarshal HostModelStreamResponse: %v", errUnmarshalStreamResponse)
 	}
 	if decodedStreamResponse.StatusCode != streamResponse.StatusCode ||
-		decodedStreamResponse.Headers.Get("Content-Type") != "text/event-stream" ||
-		decodedStreamResponse.StreamID != streamResponse.StreamID {
+		decodedStreamResponse.Headers.Get("Retry-After") != "5" ||
+		decodedStreamResponse.StreamID != "" ||
+		decodedStreamResponse.Error == nil ||
+		decodedStreamResponse.Error.StatusCode != http.StatusTooManyRequests ||
+		decodedStreamResponse.Error.Headers.Get("Retry-After") != "5" ||
+		string(decodedStreamResponse.Error.Body) != upstreamErrorBody ||
+		decodedStreamResponse.Error.Message != upstreamErrorBody {
 		t.Fatalf("HostModelStreamResponse round trip = %#v", decodedStreamResponse)
 	}
 
@@ -281,13 +303,19 @@ func TestHostModelTypesPreserveFields(t *testing.T) {
 		Payload: []byte("data: test\n\n"),
 		Error:   "temporary stream error",
 		Done:    true,
+		ErrorDetails: &HostModelError{
+			StatusCode: http.StatusBadGateway,
+			Headers:    http.Header{"Retry-After": []string{"5"}},
+			Body:       []byte("temporary stream error"),
+			Message:    "temporary stream error",
+		},
 	}
 	rawReadResponse, errMarshalReadResponse := json.Marshal(readResponse)
 	if errMarshalReadResponse != nil {
 		t.Fatalf("marshal HostModelStreamReadResponse: %v", errMarshalReadResponse)
 	}
 	readResponseJSON := string(rawReadResponse)
-	for _, field := range []string{"payload", "error", "done"} {
+	for _, field := range []string{"payload", "error", "done", "error_details"} {
 		if !strings.Contains(readResponseJSON, `"`+field+`"`) {
 			t.Fatalf("HostModelStreamReadResponse JSON missing field %q: %s", field, readResponseJSON)
 		}
@@ -298,7 +326,12 @@ func TestHostModelTypesPreserveFields(t *testing.T) {
 	}
 	if string(decodedReadResponse.Payload) != string(readResponse.Payload) ||
 		decodedReadResponse.Error != readResponse.Error ||
-		decodedReadResponse.Done != readResponse.Done {
+		decodedReadResponse.Done != readResponse.Done ||
+		decodedReadResponse.ErrorDetails == nil ||
+		decodedReadResponse.ErrorDetails.StatusCode != http.StatusBadGateway ||
+		decodedReadResponse.ErrorDetails.Headers.Get("Retry-After") != "5" ||
+		string(decodedReadResponse.ErrorDetails.Body) != "temporary stream error" ||
+		decodedReadResponse.ErrorDetails.Message != "temporary stream error" {
 		t.Fatalf("HostModelStreamReadResponse round trip = %#v", decodedReadResponse)
 	}
 


### PR DESCRIPTION
## Summary

Improve PluginHost error propagation and request interception safety.

This change:

- Preserves structured upstream model errors, including status codes, headers, response bodies, and messages.
- Adds explicit request rejection support for before-auth and after-auth interceptors.
- Stops interceptor chains when a request is rejected or an interceptor panics.
- Keeps ordinary interceptor errors fail-open to avoid unexpectedly blocking traffic.

## Motivation

PluginHost currently loses important provider error details by reducing model failures to RPC errors or plain strings. This makes it difficult for plugin callers to inspect upstream failures and make correct retry decisions.

Request interceptors also lack an explicit rejection mechanism. A plugin cannot safely reject a request before it reaches an upstream provider, and interceptor panics do not reliably terminate the chain.

## Changes

- Add `HostModelError` with status code, headers, body, and message fields.
- Propagate structured errors through model execution, stream startup, and stream reads.
- Preserve structured terminal errors in the stream bridge.
- Add `Reject` and `RejectReason` to request interceptor responses.
- Stop interceptor processing immediately after explicit rejection or panic.
- Return HTTP 403 for before-auth and after-auth request rejection.
- Return `request_rejected_by_plugin` for after-auth rejection.
- Prevent authentication and cooldown retries after after-auth rejection.
- Discard partial request mutations when a request is rejected.
- Add coverage for structured errors, JSON round trips, chain short-circuiting, panic handling, and pre- and post-auth rejection paths.
- Advertise schema v2 from the host while keeping `pluginabi.SchemaVersion` as the source-compatible v1 default.
- Return structured model errors only to plugins that explicitly negotiate schema v2.
- Preserve legacy RPC envelope errors for schema-v1 callers.
- Bind negotiated schema versions to the calling plugin instance and callback context, including across hot reloads.

## Compatibility

- Existing legacy interceptor behavior remains supported.
- Ordinary interceptor errors continue to fail open.
- No dependency on the stateful stream interceptor session change.
- Existing plugins using `pluginabi.SchemaVersion` remain on schema v1.
- Schema-v1 plugins retain legacy host model RPC error semantics.
- Plugins must explicitly return `pluginabi.SchemaVersionV2` to receive structured model errors.

## Testing

- `go test ./...`