### PR TITLE
feat(pluginhost): add stateful stream interceptor sessions

### DIFF
--- a/examples/plugin/README.md
+++ b/examples/plugin/README.md
@@ -15,6 +15,7 @@ This directory contains standard dynamic library plugin examples for the CLIProx
 - `request-normalizer/`: request normalization capability only.
 - `codex-service-tier/`: Go-only request normalizer that sets Codex `gpt-5.5` requests to the priority service tier when enabled.
 - `request-lifecycle/`: Go-only request admission example with concurrency control, active HTTP termination, and terminal callbacks.
+- `stateful-stream-interceptor/`: Go-only response stream example with stable stream IDs, per-stream state, and deterministic end cleanup.
 - `scheduler/`: Go-only scheduler that can select a configured auth ID, delegate to a built-in scheduler, or deny picks.
 - `claude-web-search-router/`: ModelRouter + executor for Claude Code built-in `web_search` (antigravity / codex / xai / Tavily). See `claude-web-search-router/README.md`.
 - `response-translator/`: response translation capability only.
@@ -57,6 +58,21 @@ plugins:
 ```
 
 See `request-lifecycle/README.md` for build instructions and lifecycle semantics.
+
+## Stateful Stream Interceptor
+
+`stateful-stream-interceptor` declares the schema 3 stateful response stream capability. It maintains isolated payload counts by stable `StreamID`, adds an initialization response header, drops payloads beyond `max_chunks`, and releases state from the end callback.
+
+```yaml
+plugins:
+  configs:
+    stateful-stream-interceptor:
+      enabled: true
+      priority: 100
+      max_chunks: 3
+```
+
+See `stateful-stream-interceptor/README.md` for build instructions and the init, payload, and end lifecycle contract.
 
 ## Host Auth Files Callback
 

--- a/examples/plugin/README_CN.md
+++ b/examples/plugin/README_CN.md
@@ -15,6 +15,7 @@
 - `request-normalizer/`：只演示请求规整能力。
 - `codex-service-tier/`：仅 Go 实现的请求规整插件，启用后会将 Codex `gpt-5.5` 请求设置为 priority service tier。
 - `request-lifecycle/`：仅 Go 实现的请求生命周期插件，演示并发控制、主动终止 HTTP 请求和终态回调。
+- `stateful-stream-interceptor/`：仅 Go 实现的响应流拦截插件，演示稳定流 ID、逐流状态和确定性终态清理。
 - `scheduler/`：仅 Go 实现的调度插件，可选择指定 auth ID、委托内置调度器或拒绝调度。
 - `response-translator/`：只演示响应转换能力。
 - `response-normalizer/`：只演示响应规整能力。
@@ -56,6 +57,21 @@ plugins:
 ```
 
 构建方式和生命周期语义详见 `request-lifecycle/README.md`。
+
+## 有状态响应流拦截器
+
+`stateful-stream-interceptor` 声明 schema 3 有状态响应流能力。它按稳定 `StreamID` 隔离 payload 计数，在初始化时添加响应头，丢弃超过 `max_chunks` 的 payload，并在终态回调中释放状态。
+
+```yaml
+plugins:
+  configs:
+    stateful-stream-interceptor:
+      enabled: true
+      priority: 100
+      max_chunks: 3
+```
+
+构建方式以及 init、payload、end 生命周期契约详见 `stateful-stream-interceptor/README.md`。
 
 ## Host Auth Files 回调
 

--- a/examples/plugin/stateful-stream-interceptor/README.md
+++ b/examples/plugin/stateful-stream-interceptor/README.md
@@ -1,0 +1,60 @@
+# Stateful Stream Interceptor Plugin
+
+This Go dynamic-library plugin demonstrates the stateful response stream interceptor lifecycle introduced by plugin RPC schema version 3.
+
+It declares:
+
+- `response_stream_interceptor`: intercepts response stream initialization and payload chunks.
+- `response_stream_interceptor_stateful`: opts into a stable `StreamID`, an end callback, and host-managed plugin pinning for the stream lifetime.
+
+## Lifecycle
+
+The host serializes calls for each stream:
+
+1. `ChunkIndex == -1` (`StreamChunkHeaderInitIndex`) initializes plugin state. The request includes the stable `StreamID` and heavy request fields.
+2. `ChunkIndex >= 0` processes payload chunks. After every stateful interceptor initializes successfully, the host may omit `OriginalRequest`, `RequestBody`, and `HistoryChunks`.
+3. `ChunkIndex == -2` (`StreamChunkEndIndex`) releases state. The host sends this callback with a context detached from downstream cancellation.
+
+This example keeps an independent payload count for each `StreamID`. It adds `X-Stateful-Stream: initialized` during header initialization, forwards the first `max_chunks` payloads, drops later payloads, and deletes stream state at the end callback.
+
+`DropChunk` affects payload delivery only. Initialization and end callbacks still run for every eligible stateful interceptor.
+
+## Configuration
+
+```yaml
+plugins:
+  enabled: true
+  configs:
+    stateful-stream-interceptor:
+      enabled: true
+      priority: 100
+      max_chunks: 3
+```
+
+`max_chunks` must be greater than zero.
+
+## Build
+
+From the repository root on macOS:
+
+```bash
+mkdir -p plugins/darwin/$(go env GOARCH)
+go build -buildmode=c-shared \
+  -o plugins/darwin/$(go env GOARCH)/stateful-stream-interceptor.dylib \
+  ./examples/plugin/stateful-stream-interceptor/go
+rm -f plugins/darwin/$(go env GOARCH)/stateful-stream-interceptor.h
+```
+
+Use `.so` on Linux or FreeBSD and `.dll` on Windows.
+
+The output filename is the plugin ID, so the artifact must be named `stateful-stream-interceptor` for the configuration above.
+
+## Relevant RPC Methods
+
+```text
+plugin.register
+plugin.reconfigure
+response.intercept_stream_chunk
+```
+
+Stateful stream interception requires host and plugin schema version 3 or newer. A schema 2 plugin registration is treated as a legacy stream interceptor even if it sends the stateful capability field.

--- a/examples/plugin/stateful-stream-interceptor/README.md
+++ b/examples/plugin/stateful-stream-interceptor/README.md
@@ -1,0 +1,60 @@
+# Stateful Stream Interceptor Plugin
+
+This Go dynamic-library plugin demonstrates the stateful response stream interceptor lifecycle introduced by plugin RPC schema version 4.
+
+It declares:
+
+- `response_stream_interceptor`: intercepts response stream initialization and payload chunks.
+- `response_stream_interceptor_stateful`: opts into a stable `StreamID`, an end callback, and host-managed plugin pinning for the stream lifetime.
+
+## Lifecycle
+
+The host serializes calls for each stream:
+
+1. `ChunkIndex == -1` (`StreamChunkHeaderInitIndex`) initializes plugin state. The request includes the stable `StreamID` and heavy request fields.
+2. `ChunkIndex >= 0` processes payload chunks. After every stateful interceptor initializes successfully, the host may omit `OriginalRequest`, `RequestBody`, and `HistoryChunks`.
+3. `ChunkIndex == -2` (`StreamChunkEndIndex`) releases state. The host sends this callback with a context detached from downstream cancellation.
+
+This example keeps an independent payload count for each `StreamID`. It adds `X-Stateful-Stream: initialized` during header initialization, forwards the first `max_chunks` payloads, drops later payloads, and deletes stream state at the end callback.
+
+`DropChunk` affects payload delivery only. Initialization and end callbacks still run for every eligible stateful interceptor.
+
+## Configuration
+
+```yaml
+plugins:
+  enabled: true
+  configs:
+    stateful-stream-interceptor:
+      enabled: true
+      priority: 100
+      max_chunks: 3
+```
+
+`max_chunks` must be greater than zero.
+
+## Build
+
+From the repository root on macOS:
+
+```bash
+mkdir -p plugins/darwin/$(go env GOARCH)
+go build -buildmode=c-shared \
+  -o plugins/darwin/$(go env GOARCH)/stateful-stream-interceptor.dylib \
+  ./examples/plugin/stateful-stream-interceptor/go
+rm -f plugins/darwin/$(go env GOARCH)/stateful-stream-interceptor.h
+```
+
+Use `.so` on Linux or FreeBSD and `.dll` on Windows.
+
+The output filename is the plugin ID, so the artifact must be named `stateful-stream-interceptor` for the configuration above.
+
+## Relevant RPC Methods
+
+```text
+plugin.register
+plugin.reconfigure
+response.intercept_stream_chunk
+```
+
+Stateful stream interception requires host and plugin schema version 4 or newer. A schema 3 plugin registration still uses the payload request-body omission contract, but is treated as a non-stateful stream interceptor even if it sends the stateful capability field.

--- a/examples/plugin/stateful-stream-interceptor/go/go.mod
+++ b/examples/plugin/stateful-stream-interceptor/go/go.mod
@@ -1,0 +1,10 @@
+module github.com/router-for-me/CLIProxyAPI/v7/examples/plugin/stateful-stream-interceptor/go
+
+go 1.26.0
+
+require (
+	github.com/router-for-me/CLIProxyAPI/v7 v7.0.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+replace github.com/router-for-me/CLIProxyAPI/v7 => ../../../..

--- a/examples/plugin/stateful-stream-interceptor/go/go.sum
+++ b/examples/plugin/stateful-stream-interceptor/go/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/plugin/stateful-stream-interceptor/go/main.go
+++ b/examples/plugin/stateful-stream-interceptor/go/main.go
@@ -1,0 +1,273 @@
+package main
+
+/*
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+	void* ptr;
+	size_t len;
+} cliproxy_buffer;
+
+typedef struct {
+	uint32_t abi_version;
+	void* host_ctx;
+	void* call;
+	void* free_buffer;
+} cliproxy_host_api;
+
+typedef int (*cliproxy_plugin_call_fn)(char*, uint8_t*, size_t, cliproxy_buffer*);
+typedef void (*cliproxy_plugin_free_fn)(void*, size_t);
+typedef void (*cliproxy_plugin_shutdown_fn)(void);
+
+typedef struct {
+	uint32_t abi_version;
+	cliproxy_plugin_call_fn call;
+	cliproxy_plugin_free_fn free_buffer;
+	cliproxy_plugin_shutdown_fn shutdown;
+} cliproxy_plugin_api;
+
+extern int cliproxyPluginCall(char*, uint8_t*, size_t, cliproxy_buffer*);
+extern void cliproxyPluginFree(void*, size_t);
+extern void cliproxyPluginShutdown(void);
+*/
+import "C"
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"unsafe"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginabi"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+	"gopkg.in/yaml.v3"
+)
+
+const pluginSchemaVersion = pluginabi.SchemaVersionStatefulStreamInterceptor
+
+var state = pluginState{
+	config:  pluginConfig{MaxChunks: 3},
+	streams: make(map[string]int),
+}
+
+type pluginState struct {
+	mu      sync.Mutex
+	config  pluginConfig
+	streams map[string]int
+}
+
+type pluginConfig struct {
+	MaxChunks int `yaml:"max_chunks"`
+}
+
+type envelope struct {
+	OK     bool            `json:"ok"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  *envelopeError  `json:"error,omitempty"`
+}
+
+type envelopeError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type lifecycleRequest struct {
+	ConfigYAML    []byte `json:"config_yaml"`
+	SchemaVersion uint32 `json:"schema_version"`
+}
+
+type registration struct {
+	SchemaVersion uint32                 `json:"schema_version"`
+	Metadata      pluginapi.Metadata     `json:"metadata"`
+	Capabilities  registrationCapability `json:"capabilities"`
+}
+
+type registrationCapability struct {
+	StreamChunkInterceptor         bool `json:"response_stream_interceptor"`
+	StreamChunkInterceptorStateful bool `json:"response_stream_interceptor_stateful"`
+}
+
+func main() {}
+
+//export cliproxy_plugin_init
+func cliproxy_plugin_init(_ *C.cliproxy_host_api, plugin *C.cliproxy_plugin_api) C.int {
+	if plugin == nil {
+		return 1
+	}
+	plugin.abi_version = C.uint32_t(pluginabi.ABIVersion)
+	plugin.call = C.cliproxy_plugin_call_fn(C.cliproxyPluginCall)
+	plugin.free_buffer = C.cliproxy_plugin_free_fn(C.cliproxyPluginFree)
+	plugin.shutdown = C.cliproxy_plugin_shutdown_fn(C.cliproxyPluginShutdown)
+	return 0
+}
+
+//export cliproxyPluginCall
+func cliproxyPluginCall(method *C.char, request *C.uint8_t, requestLen C.size_t, response *C.cliproxy_buffer) C.int {
+	if response != nil {
+		response.ptr = nil
+		response.len = 0
+	}
+	if method == nil {
+		writeResponse(response, errorEnvelope("invalid_method", "method is required"))
+		return 1
+	}
+	var requestBytes []byte
+	if request != nil && requestLen > 0 {
+		requestBytes = C.GoBytes(unsafe.Pointer(request), C.int(requestLen))
+	}
+	raw, errHandle := handleMethod(C.GoString(method), requestBytes)
+	if errHandle != nil {
+		writeResponse(response, errorEnvelope("plugin_error", errHandle.Error()))
+		return 1
+	}
+	writeResponse(response, raw)
+	return 0
+}
+
+//export cliproxyPluginFree
+func cliproxyPluginFree(ptr unsafe.Pointer, len C.size_t) {
+	if ptr != nil {
+		C.free(ptr)
+	}
+	_ = len
+}
+
+//export cliproxyPluginShutdown
+func cliproxyPluginShutdown() {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	state.streams = make(map[string]int)
+}
+
+func handleMethod(method string, request []byte) ([]byte, error) {
+	switch method {
+	case pluginabi.MethodPluginRegister, pluginabi.MethodPluginReconfigure:
+		if errConfigure := configure(request); errConfigure != nil {
+			return nil, errConfigure
+		}
+		return okEnvelope(pluginRegistration())
+	case pluginabi.MethodResponseInterceptStreamChunk:
+		return interceptStreamChunk(request)
+	default:
+		return errorEnvelope("unknown_method", "unknown method: "+method), nil
+	}
+}
+
+func configure(raw []byte) error {
+	var req lifecycleRequest
+	if len(raw) > 0 {
+		if errUnmarshal := json.Unmarshal(raw, &req); errUnmarshal != nil {
+			return errUnmarshal
+		}
+	}
+	if req.SchemaVersion < pluginSchemaVersion {
+		return fmt.Errorf("stateful stream interceptor requires host schema version %d or newer", pluginSchemaVersion)
+	}
+	cfg := pluginConfig{MaxChunks: 3}
+	if len(req.ConfigYAML) > 0 {
+		if errUnmarshal := yaml.Unmarshal(req.ConfigYAML, &cfg); errUnmarshal != nil {
+			return errUnmarshal
+		}
+	}
+	if cfg.MaxChunks < 1 {
+		return fmt.Errorf("max_chunks must be greater than zero")
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	state.config = cfg
+	return nil
+}
+
+func pluginRegistration() registration {
+	return registration{
+		SchemaVersion: pluginSchemaVersion,
+		Metadata: pluginapi.Metadata{
+			Name:             "stateful-stream-interceptor",
+			Version:          "0.1.0",
+			Author:           "router-for-me",
+			GitHubRepository: "https://github.com/router-for-me/CLIProxyAPI",
+			Logo:             "https://raw.githubusercontent.com/router-for-me/CLIProxyAPI/main/docs/logo.png",
+			ConfigFields: []pluginapi.ConfigField{
+				{
+					Name:        "max_chunks",
+					Type:        pluginapi.ConfigFieldTypeInteger,
+					Description: "Maximum number of payload chunks forwarded for each stream.",
+				},
+			},
+		},
+		Capabilities: registrationCapability{
+			StreamChunkInterceptor:         true,
+			StreamChunkInterceptorStateful: true,
+		},
+	}
+}
+
+func interceptStreamChunk(raw []byte) ([]byte, error) {
+	var req pluginapi.StreamChunkInterceptRequest
+	if errUnmarshal := json.Unmarshal(raw, &req); errUnmarshal != nil {
+		return nil, errUnmarshal
+	}
+	req.StreamID = strings.TrimSpace(req.StreamID)
+	if req.StreamID == "" {
+		return nil, fmt.Errorf("stream ID is required")
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	switch req.ChunkIndex {
+	case pluginapi.StreamChunkHeaderInitIndex:
+		state.streams[req.StreamID] = 0
+		return okEnvelope(pluginapi.StreamChunkInterceptResponse{
+			Headers: http.Header{"X-Stateful-Stream": {"initialized"}},
+			Body:    req.Body,
+		})
+	case pluginapi.StreamChunkEndIndex:
+		delete(state.streams, req.StreamID)
+		return okEnvelope(pluginapi.StreamChunkInterceptResponse{})
+	default:
+		if req.ChunkIndex < 0 {
+			return nil, fmt.Errorf("unsupported stream chunk index %d", req.ChunkIndex)
+		}
+		count, initialized := state.streams[req.StreamID]
+		if !initialized {
+			return nil, fmt.Errorf("stream %q was not initialized", req.StreamID)
+		}
+		count++
+		state.streams[req.StreamID] = count
+		return okEnvelope(pluginapi.StreamChunkInterceptResponse{
+			Body:      req.Body,
+			DropChunk: count > state.config.MaxChunks,
+		})
+	}
+}
+
+func okEnvelope(v any) ([]byte, error) {
+	raw, errMarshal := json.Marshal(v)
+	if errMarshal != nil {
+		return nil, errMarshal
+	}
+	return json.Marshal(envelope{OK: true, Result: raw})
+}
+
+func errorEnvelope(code, message string) []byte {
+	raw, errMarshal := json.Marshal(envelope{OK: false, Error: &envelopeError{Code: code, Message: message}})
+	if errMarshal != nil {
+		return []byte(`{"ok":false,"error":{"code":"plugin_error","message":"encode error"}}`)
+	}
+	return raw
+}
+
+func writeResponse(response *C.cliproxy_buffer, raw []byte) {
+	if response == nil || len(raw) == 0 {
+		return
+	}
+	ptr := C.CBytes(raw)
+	if ptr == nil {
+		return
+	}
+	response.ptr = ptr
+	response.len = C.size_t(len(raw))
+}

--- a/examples/plugin/stateful-stream-interceptor/go/main.go
+++ b/examples/plugin/stateful-stream-interceptor/go/main.go
@@ -1,0 +1,273 @@
+package main
+
+/*
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+	void* ptr;
+	size_t len;
+} cliproxy_buffer;
+
+typedef struct {
+	uint32_t abi_version;
+	void* host_ctx;
+	void* call;
+	void* free_buffer;
+} cliproxy_host_api;
+
+typedef int (*cliproxy_plugin_call_fn)(char*, uint8_t*, size_t, cliproxy_buffer*);
+typedef void (*cliproxy_plugin_free_fn)(void*, size_t);
+typedef void (*cliproxy_plugin_shutdown_fn)(void);
+
+typedef struct {
+	uint32_t abi_version;
+	cliproxy_plugin_call_fn call;
+	cliproxy_plugin_free_fn free_buffer;
+	cliproxy_plugin_shutdown_fn shutdown;
+} cliproxy_plugin_api;
+
+extern int cliproxyPluginCall(char*, uint8_t*, size_t, cliproxy_buffer*);
+extern void cliproxyPluginFree(void*, size_t);
+extern void cliproxyPluginShutdown(void);
+*/
+import "C"
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"unsafe"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginabi"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+	"gopkg.in/yaml.v3"
+)
+
+const pluginSchemaVersion uint32 = 3
+
+var state = pluginState{
+	config:  pluginConfig{MaxChunks: 3},
+	streams: make(map[string]int),
+}
+
+type pluginState struct {
+	mu      sync.Mutex
+	config  pluginConfig
+	streams map[string]int
+}
+
+type pluginConfig struct {
+	MaxChunks int `yaml:"max_chunks"`
+}
+
+type envelope struct {
+	OK     bool            `json:"ok"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  *envelopeError  `json:"error,omitempty"`
+}
+
+type envelopeError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type lifecycleRequest struct {
+	ConfigYAML    []byte `json:"config_yaml"`
+	SchemaVersion uint32 `json:"schema_version"`
+}
+
+type registration struct {
+	SchemaVersion uint32                 `json:"schema_version"`
+	Metadata      pluginapi.Metadata     `json:"metadata"`
+	Capabilities  registrationCapability `json:"capabilities"`
+}
+
+type registrationCapability struct {
+	StreamChunkInterceptor         bool `json:"response_stream_interceptor"`
+	StreamChunkInterceptorStateful bool `json:"response_stream_interceptor_stateful"`
+}
+
+func main() {}
+
+//export cliproxy_plugin_init
+func cliproxy_plugin_init(_ *C.cliproxy_host_api, plugin *C.cliproxy_plugin_api) C.int {
+	if plugin == nil {
+		return 1
+	}
+	plugin.abi_version = C.uint32_t(pluginabi.ABIVersion)
+	plugin.call = C.cliproxy_plugin_call_fn(C.cliproxyPluginCall)
+	plugin.free_buffer = C.cliproxy_plugin_free_fn(C.cliproxyPluginFree)
+	plugin.shutdown = C.cliproxy_plugin_shutdown_fn(C.cliproxyPluginShutdown)
+	return 0
+}
+
+//export cliproxyPluginCall
+func cliproxyPluginCall(method *C.char, request *C.uint8_t, requestLen C.size_t, response *C.cliproxy_buffer) C.int {
+	if response != nil {
+		response.ptr = nil
+		response.len = 0
+	}
+	if method == nil {
+		writeResponse(response, errorEnvelope("invalid_method", "method is required"))
+		return 1
+	}
+	var requestBytes []byte
+	if request != nil && requestLen > 0 {
+		requestBytes = C.GoBytes(unsafe.Pointer(request), C.int(requestLen))
+	}
+	raw, errHandle := handleMethod(C.GoString(method), requestBytes)
+	if errHandle != nil {
+		writeResponse(response, errorEnvelope("plugin_error", errHandle.Error()))
+		return 1
+	}
+	writeResponse(response, raw)
+	return 0
+}
+
+//export cliproxyPluginFree
+func cliproxyPluginFree(ptr unsafe.Pointer, len C.size_t) {
+	if ptr != nil {
+		C.free(ptr)
+	}
+	_ = len
+}
+
+//export cliproxyPluginShutdown
+func cliproxyPluginShutdown() {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	state.streams = make(map[string]int)
+}
+
+func handleMethod(method string, request []byte) ([]byte, error) {
+	switch method {
+	case pluginabi.MethodPluginRegister, pluginabi.MethodPluginReconfigure:
+		if errConfigure := configure(request); errConfigure != nil {
+			return nil, errConfigure
+		}
+		return okEnvelope(pluginRegistration())
+	case pluginabi.MethodResponseInterceptStreamChunk:
+		return interceptStreamChunk(request)
+	default:
+		return errorEnvelope("unknown_method", "unknown method: "+method), nil
+	}
+}
+
+func configure(raw []byte) error {
+	var req lifecycleRequest
+	if len(raw) > 0 {
+		if errUnmarshal := json.Unmarshal(raw, &req); errUnmarshal != nil {
+			return errUnmarshal
+		}
+	}
+	if req.SchemaVersion < pluginSchemaVersion {
+		return fmt.Errorf("stateful stream interceptor requires host schema version %d or newer", pluginSchemaVersion)
+	}
+	cfg := pluginConfig{MaxChunks: 3}
+	if len(req.ConfigYAML) > 0 {
+		if errUnmarshal := yaml.Unmarshal(req.ConfigYAML, &cfg); errUnmarshal != nil {
+			return errUnmarshal
+		}
+	}
+	if cfg.MaxChunks < 1 {
+		return fmt.Errorf("max_chunks must be greater than zero")
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	state.config = cfg
+	return nil
+}
+
+func pluginRegistration() registration {
+	return registration{
+		SchemaVersion: pluginSchemaVersion,
+		Metadata: pluginapi.Metadata{
+			Name:             "stateful-stream-interceptor",
+			Version:          "0.1.0",
+			Author:           "router-for-me",
+			GitHubRepository: "https://github.com/router-for-me/CLIProxyAPI",
+			Logo:             "https://raw.githubusercontent.com/router-for-me/CLIProxyAPI/main/docs/logo.png",
+			ConfigFields: []pluginapi.ConfigField{
+				{
+					Name:        "max_chunks",
+					Type:        pluginapi.ConfigFieldTypeInteger,
+					Description: "Maximum number of payload chunks forwarded for each stream.",
+				},
+			},
+		},
+		Capabilities: registrationCapability{
+			StreamChunkInterceptor:         true,
+			StreamChunkInterceptorStateful: true,
+		},
+	}
+}
+
+func interceptStreamChunk(raw []byte) ([]byte, error) {
+	var req pluginapi.StreamChunkInterceptRequest
+	if errUnmarshal := json.Unmarshal(raw, &req); errUnmarshal != nil {
+		return nil, errUnmarshal
+	}
+	req.StreamID = strings.TrimSpace(req.StreamID)
+	if req.StreamID == "" {
+		return nil, fmt.Errorf("stream ID is required")
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	switch req.ChunkIndex {
+	case pluginapi.StreamChunkHeaderInitIndex:
+		state.streams[req.StreamID] = 0
+		return okEnvelope(pluginapi.StreamChunkInterceptResponse{
+			Headers: http.Header{"X-Stateful-Stream": {"initialized"}},
+			Body:    req.Body,
+		})
+	case pluginapi.StreamChunkEndIndex:
+		delete(state.streams, req.StreamID)
+		return okEnvelope(pluginapi.StreamChunkInterceptResponse{})
+	default:
+		if req.ChunkIndex < 0 {
+			return nil, fmt.Errorf("unsupported stream chunk index %d", req.ChunkIndex)
+		}
+		count, initialized := state.streams[req.StreamID]
+		if !initialized {
+			return nil, fmt.Errorf("stream %q was not initialized", req.StreamID)
+		}
+		count++
+		state.streams[req.StreamID] = count
+		return okEnvelope(pluginapi.StreamChunkInterceptResponse{
+			Body:      req.Body,
+			DropChunk: count > state.config.MaxChunks,
+		})
+	}
+}
+
+func okEnvelope(v any) ([]byte, error) {
+	raw, errMarshal := json.Marshal(v)
+	if errMarshal != nil {
+		return nil, errMarshal
+	}
+	return json.Marshal(envelope{OK: true, Result: raw})
+}
+
+func errorEnvelope(code, message string) []byte {
+	raw, errMarshal := json.Marshal(envelope{OK: false, Error: &envelopeError{Code: code, Message: message}})
+	if errMarshal != nil {
+		return []byte(`{"ok":false,"error":{"code":"plugin_error","message":"encode error"}}`)
+	}
+	return raw
+}
+
+func writeResponse(response *C.cliproxy_buffer, raw []byte) {
+	if response == nil || len(raw) == 0 {
+		return
+	}
+	ptr := C.CBytes(raw)
+	if ptr == nil {
+		return
+	}
+	response.ptr = ptr
+	response.len = C.size_t(len(raw))
+}

--- a/examples/plugin/stateful-stream-interceptor/go/main_test.go
+++ b/examples/plugin/stateful-stream-interceptor/go/main_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+func TestConfigureRequiresStatefulStreamSchema(t *testing.T) {
+	raw, errMarshal := json.Marshal(lifecycleRequest{SchemaVersion: 3})
+	if errMarshal != nil {
+		t.Fatalf("marshal lifecycle request: %v", errMarshal)
+	}
+	if errConfigure := configure(raw); errConfigure == nil {
+		t.Fatal("configure() error = nil for schema version 3")
+	}
+}
+
+func TestRegistrationDeclaresSchema4StatefulStreamCapability(t *testing.T) {
+	registration := pluginRegistration()
+	if registration.SchemaVersion != 4 {
+		t.Fatalf("schema version = %d, want 4", registration.SchemaVersion)
+	}
+	if !registration.Capabilities.StreamChunkInterceptor || !registration.Capabilities.StreamChunkInterceptorStateful {
+		t.Fatalf("stream capabilities = %#v, want stateful stream interceptor", registration.Capabilities)
+	}
+}
+
+func TestStreamStateIsIsolatedAndCleanedUp(t *testing.T) {
+	resetState(pluginConfig{MaxChunks: 1})
+	initStreamForTest(t, "stream-a")
+	initStreamForTest(t, "stream-b")
+
+	if response := interceptStreamForTest(t, pluginapi.StreamChunkInterceptRequest{StreamID: "stream-a", ChunkIndex: 0, Body: []byte("a-0")}); response.DropChunk {
+		t.Fatal("stream-a first payload was dropped")
+	}
+	if response := interceptStreamForTest(t, pluginapi.StreamChunkInterceptRequest{StreamID: "stream-a", ChunkIndex: 1, Body: []byte("a-1")}); !response.DropChunk {
+		t.Fatal("stream-a second payload was not dropped")
+	}
+	if response := interceptStreamForTest(t, pluginapi.StreamChunkInterceptRequest{StreamID: "stream-b", ChunkIndex: 0, Body: []byte("b-0")}); response.DropChunk {
+		t.Fatal("stream-b first payload inherited stream-a state")
+	}
+
+	interceptStreamForTest(t, pluginapi.StreamChunkInterceptRequest{StreamID: "stream-a", ChunkIndex: pluginapi.StreamChunkEndIndex})
+	if got := activeStreamCountForTest(); got != 1 {
+		t.Fatalf("active stream count after stream-a end = %d, want 1", got)
+	}
+	interceptStreamForTest(t, pluginapi.StreamChunkInterceptRequest{StreamID: "stream-b", ChunkIndex: pluginapi.StreamChunkEndIndex})
+	if got := activeStreamCountForTest(); got != 0 {
+		t.Fatalf("active stream count after all ends = %d, want 0", got)
+	}
+}
+
+func TestConcurrentStreamsRemainIsolated(t *testing.T) {
+	resetState(pluginConfig{MaxChunks: 1})
+	const streamCount = 32
+	errors := make(chan error, streamCount)
+	var wg sync.WaitGroup
+	for i := range streamCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			streamID := fmt.Sprintf("stream-%d", i)
+			requests := []pluginapi.StreamChunkInterceptRequest{
+				{StreamID: streamID, ChunkIndex: pluginapi.StreamChunkHeaderInitIndex},
+				{StreamID: streamID, ChunkIndex: 0, Body: []byte("first")},
+				{StreamID: streamID, ChunkIndex: 1, Body: []byte("second")},
+				{StreamID: streamID, ChunkIndex: pluginapi.StreamChunkEndIndex},
+			}
+			for index, req := range requests {
+				response, errIntercept := interceptStream(req)
+				if errIntercept != nil {
+					errors <- fmt.Errorf("stream %s request %d: %w", streamID, index, errIntercept)
+					return
+				}
+				if index == 1 && response.DropChunk {
+					errors <- fmt.Errorf("stream %s first payload was dropped", streamID)
+					return
+				}
+				if index == 2 && !response.DropChunk {
+					errors <- fmt.Errorf("stream %s second payload was not dropped", streamID)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errors)
+	for errConcurrent := range errors {
+		t.Error(errConcurrent)
+	}
+	if got := activeStreamCountForTest(); got != 0 {
+		t.Fatalf("active stream count after concurrent ends = %d, want 0", got)
+	}
+}
+
+func initStreamForTest(t *testing.T, streamID string) {
+	t.Helper()
+	response := interceptStreamForTest(t, pluginapi.StreamChunkInterceptRequest{
+		StreamID:   streamID,
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+	if response.Headers.Get("X-Stateful-Stream") != "initialized" {
+		t.Fatalf("stream %q init headers = %#v", streamID, response.Headers)
+	}
+}
+
+func interceptStreamForTest(t *testing.T, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+	t.Helper()
+	response, errIntercept := interceptStream(req)
+	if errIntercept != nil {
+		t.Fatal(errIntercept)
+	}
+	return response
+}
+
+func interceptStream(req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+	raw, errMarshal := json.Marshal(req)
+	if errMarshal != nil {
+		return pluginapi.StreamChunkInterceptResponse{}, fmt.Errorf("marshal stream request: %w", errMarshal)
+	}
+	rawEnvelope, errIntercept := interceptStreamChunk(raw)
+	if errIntercept != nil {
+		return pluginapi.StreamChunkInterceptResponse{}, fmt.Errorf("intercept stream chunk: %w", errIntercept)
+	}
+	var env envelope
+	if errUnmarshal := json.Unmarshal(rawEnvelope, &env); errUnmarshal != nil {
+		return pluginapi.StreamChunkInterceptResponse{}, fmt.Errorf("unmarshal envelope: %w", errUnmarshal)
+	}
+	var response pluginapi.StreamChunkInterceptResponse
+	if errUnmarshal := json.Unmarshal(env.Result, &response); errUnmarshal != nil {
+		return pluginapi.StreamChunkInterceptResponse{}, fmt.Errorf("unmarshal response: %w", errUnmarshal)
+	}
+	return response, nil
+}
+
+func resetState(cfg pluginConfig) {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	state.config = cfg
+	state.streams = make(map[string]int)
+}
+
+func activeStreamCountForTest() int {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return len(state.streams)
+}

--- a/examples/plugin/stateful-stream-interceptor/go/main_test.go
+++ b/examples/plugin/stateful-stream-interceptor/go/main_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+func TestConfigureRequiresStatefulStreamSchema(t *testing.T) {
+	raw, errMarshal := json.Marshal(lifecycleRequest{SchemaVersion: 2})
+	if errMarshal != nil {
+		t.Fatalf("marshal lifecycle request: %v", errMarshal)
+	}
+	if errConfigure := configure(raw); errConfigure == nil {
+		t.Fatal("configure() error = nil for schema version 2")
+	}
+}
+
+func TestRegistrationDeclaresSchema3StatefulStreamCapability(t *testing.T) {
+	registration := pluginRegistration()
+	if registration.SchemaVersion != 3 {
+		t.Fatalf("schema version = %d, want 3", registration.SchemaVersion)
+	}
+	if !registration.Capabilities.StreamChunkInterceptor || !registration.Capabilities.StreamChunkInterceptorStateful {
+		t.Fatalf("stream capabilities = %#v, want stateful stream interceptor", registration.Capabilities)
+	}
+}
+
+func TestStreamStateIsIsolatedAndCleanedUp(t *testing.T) {
+	resetState(pluginConfig{MaxChunks: 1})
+	initStreamForTest(t, "stream-a")
+	initStreamForTest(t, "stream-b")
+
+	if response := interceptStreamForTest(t, pluginapi.StreamChunkInterceptRequest{StreamID: "stream-a", ChunkIndex: 0, Body: []byte("a-0")}); response.DropChunk {
+		t.Fatal("stream-a first payload was dropped")
+	}
+	if response := interceptStreamForTest(t, pluginapi.StreamChunkInterceptRequest{StreamID: "stream-a", ChunkIndex: 1, Body: []byte("a-1")}); !response.DropChunk {
+		t.Fatal("stream-a second payload was not dropped")
+	}
+	if response := interceptStreamForTest(t, pluginapi.StreamChunkInterceptRequest{StreamID: "stream-b", ChunkIndex: 0, Body: []byte("b-0")}); response.DropChunk {
+		t.Fatal("stream-b first payload inherited stream-a state")
+	}
+
+	interceptStreamForTest(t, pluginapi.StreamChunkInterceptRequest{StreamID: "stream-a", ChunkIndex: pluginapi.StreamChunkEndIndex})
+	if got := activeStreamCountForTest(); got != 1 {
+		t.Fatalf("active stream count after stream-a end = %d, want 1", got)
+	}
+	interceptStreamForTest(t, pluginapi.StreamChunkInterceptRequest{StreamID: "stream-b", ChunkIndex: pluginapi.StreamChunkEndIndex})
+	if got := activeStreamCountForTest(); got != 0 {
+		t.Fatalf("active stream count after all ends = %d, want 0", got)
+	}
+}
+
+func TestConcurrentStreamsRemainIsolated(t *testing.T) {
+	resetState(pluginConfig{MaxChunks: 1})
+	const streamCount = 32
+	errors := make(chan error, streamCount)
+	var wg sync.WaitGroup
+	for i := range streamCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			streamID := fmt.Sprintf("stream-%d", i)
+			requests := []pluginapi.StreamChunkInterceptRequest{
+				{StreamID: streamID, ChunkIndex: pluginapi.StreamChunkHeaderInitIndex},
+				{StreamID: streamID, ChunkIndex: 0, Body: []byte("first")},
+				{StreamID: streamID, ChunkIndex: 1, Body: []byte("second")},
+				{StreamID: streamID, ChunkIndex: pluginapi.StreamChunkEndIndex},
+			}
+			for index, req := range requests {
+				response, errIntercept := interceptStream(req)
+				if errIntercept != nil {
+					errors <- fmt.Errorf("stream %s request %d: %w", streamID, index, errIntercept)
+					return
+				}
+				if index == 1 && response.DropChunk {
+					errors <- fmt.Errorf("stream %s first payload was dropped", streamID)
+					return
+				}
+				if index == 2 && !response.DropChunk {
+					errors <- fmt.Errorf("stream %s second payload was not dropped", streamID)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errors)
+	for errConcurrent := range errors {
+		t.Error(errConcurrent)
+	}
+	if got := activeStreamCountForTest(); got != 0 {
+		t.Fatalf("active stream count after concurrent ends = %d, want 0", got)
+	}
+}
+
+func initStreamForTest(t *testing.T, streamID string) {
+	t.Helper()
+	response := interceptStreamForTest(t, pluginapi.StreamChunkInterceptRequest{
+		StreamID:   streamID,
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+	if response.Headers.Get("X-Stateful-Stream") != "initialized" {
+		t.Fatalf("stream %q init headers = %#v", streamID, response.Headers)
+	}
+}
+
+func interceptStreamForTest(t *testing.T, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+	t.Helper()
+	response, errIntercept := interceptStream(req)
+	if errIntercept != nil {
+		t.Fatal(errIntercept)
+	}
+	return response
+}
+
+func interceptStream(req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+	raw, errMarshal := json.Marshal(req)
+	if errMarshal != nil {
+		return pluginapi.StreamChunkInterceptResponse{}, fmt.Errorf("marshal stream request: %w", errMarshal)
+	}
+	rawEnvelope, errIntercept := interceptStreamChunk(raw)
+	if errIntercept != nil {
+		return pluginapi.StreamChunkInterceptResponse{}, fmt.Errorf("intercept stream chunk: %w", errIntercept)
+	}
+	var env envelope
+	if errUnmarshal := json.Unmarshal(rawEnvelope, &env); errUnmarshal != nil {
+		return pluginapi.StreamChunkInterceptResponse{}, fmt.Errorf("unmarshal envelope: %w", errUnmarshal)
+	}
+	var response pluginapi.StreamChunkInterceptResponse
+	if errUnmarshal := json.Unmarshal(env.Result, &response); errUnmarshal != nil {
+		return pluginapi.StreamChunkInterceptResponse{}, fmt.Errorf("unmarshal response: %w", errUnmarshal)
+	}
+	return response, nil
+}
+
+func resetState(cfg pluginConfig) {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	state.config = cfg
+	state.streams = make(map[string]int)
+}
+
+func activeStreamCountForTest() int {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return len(state.streams)
+}

--- a/internal/pluginhost/adapters.go
+++ b/internal/pluginhost/adapters.go
@@ -319,7 +319,7 @@ func (h *Host) ModelsForAuth(ctx context.Context, auth *coreauth.Auth) AuthModel
 		}
 		authProvider := record.plugin.Capabilities.AuthProvider
 		if authProvider != nil {
-			identifier, okIdentifier := h.callAuthProviderIdentifier(record.id, authProvider)
+			identifier, okIdentifier := h.callAuthProviderIdentifier(record, authProvider)
 			if !okIdentifier || normalizeProviderID(identifier) != providerKey {
 				continue
 			}
@@ -452,7 +452,7 @@ func (h *Host) callModelRegistrar(ctx context.Context, record capabilityRecord, 
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "ModelRegistrar.RegisterModels", recovered)
+			h.fusePlugin(record, "ModelRegistrar.RegisterModels", recovered)
 			resp = pluginapi.ModelRegistrationResponse{}
 			err = fmt.Errorf("model registrar panic: %v", recovered)
 		}
@@ -466,7 +466,7 @@ func (h *Host) callModelProviderStaticModels(ctx context.Context, record capabil
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "ModelProvider.StaticModels", recovered)
+			h.fusePlugin(record, "ModelProvider.StaticModels", recovered)
 			resp = pluginapi.ModelResponse{}
 			err = fmt.Errorf("model provider panic: %v", recovered)
 		}
@@ -483,7 +483,7 @@ func (h *Host) callModelsForAuth(ctx context.Context, record capabilityRecord, p
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "ModelProvider.ModelsForAuth", recovered)
+			h.fusePlugin(record, "ModelProvider.ModelsForAuth", recovered)
 			resp = pluginapi.ModelResponse{}
 			err = fmt.Errorf("model provider per-auth models panic: %v", recovered)
 		}

--- a/internal/pluginhost/adapters_auth.go
+++ b/internal/pluginhost/adapters_auth.go
@@ -98,7 +98,7 @@ func (a *accessAdapter) Identifier() (identifier string) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			if a.host != nil {
-				a.host.fusePlugin(a.pluginID, "FrontendAuthProvider.Identifier", recovered)
+				a.host.fusePluginIdentity(a.pluginID, a.path, a.version, "FrontendAuthProvider.Identifier", recovered)
 			}
 			identifier = ""
 		}
@@ -117,7 +117,7 @@ func (a *accessAdapter) Authenticate(ctx context.Context, r *http.Request) (resu
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			a.host.fusePlugin(a.pluginID, "FrontendAuthProvider.Authenticate", recovered)
+			a.host.fusePluginIdentity(a.pluginID, a.path, a.version, "FrontendAuthProvider.Authenticate", recovered)
 			result = nil
 			authErr = sdkaccess.NewNotHandledError()
 		}

--- a/internal/pluginhost/adapters_executors.go
+++ b/internal/pluginhost/adapters_executors.go
@@ -242,7 +242,7 @@ func (h *Host) executorProvider(record capabilityRecord, executor pluginapi.Prov
 	}
 	provider := h.modelProvider(record.id)
 	if provider == "" {
-		identifier, okIdentifier := h.callExecutorIdentifier(record.id, executor)
+		identifier, okIdentifier := h.callExecutorIdentifier(record, executor)
 		if !okIdentifier {
 			return "", false
 		}
@@ -252,13 +252,13 @@ func (h *Host) executorProvider(record capabilityRecord, executor pluginapi.Prov
 	return provider, provider != ""
 }
 
-func (h *Host) callExecutorIdentifier(pluginID string, executor pluginapi.ProviderExecutor) (provider string, ok bool) {
-	if h == nil || executor == nil || h.isPluginFused(pluginID) {
+func (h *Host) callExecutorIdentifier(record capabilityRecord, executor pluginapi.ProviderExecutor) (provider string, ok bool) {
+	if h == nil || executor == nil || h.isPluginFused(record.id) || !h.recordCurrent(record) {
 		return "", false
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(pluginID, "Executor.Identifier", recovered)
+			h.fusePlugin(record, "Executor.Identifier", recovered)
 			provider = ""
 			ok = false
 		}
@@ -638,7 +638,7 @@ func (a *executorAdapter) Execute(ctx context.Context, auth *coreauth.Auth, req 
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			a.host.fusePlugin(a.pluginID, "Executor.Execute", recovered)
+			a.host.fusePluginIdentity(a.pluginID, a.path, a.version, "Executor.Execute", recovered)
 			resp = coreexecutor.Response{}
 			err = fmt.Errorf("plugin executor %s panic: %v", a.Identifier(), recovered)
 		}
@@ -665,7 +665,7 @@ func (a *executorAdapter) ExecuteStream(ctx context.Context, auth *coreauth.Auth
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			a.host.fusePlugin(a.pluginID, "Executor.ExecuteStream", recovered)
+			a.host.fusePluginIdentity(a.pluginID, a.path, a.version, "Executor.ExecuteStream", recovered)
 			result = nil
 			err = fmt.Errorf("plugin executor %s stream panic: %v", a.Identifier(), recovered)
 		}
@@ -695,7 +695,7 @@ func (a *executorAdapter) Refresh(ctx context.Context, auth *coreauth.Auth) (ref
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			a.host.fusePlugin(record.id, "AuthProvider.RefreshAuth", recovered)
+			a.host.fusePlugin(*record, "AuthProvider.RefreshAuth", recovered)
 			refreshed = nil
 			err = fmt.Errorf("plugin executor %s refresh panic: %v", a.Identifier(), recovered)
 		}
@@ -764,7 +764,7 @@ func (a *executorAdapter) CountTokens(ctx context.Context, auth *coreauth.Auth, 
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			a.host.fusePlugin(a.pluginID, "Executor.CountTokens", recovered)
+			a.host.fusePluginIdentity(a.pluginID, a.path, a.version, "Executor.CountTokens", recovered)
 			resp = coreexecutor.Response{}
 			err = fmt.Errorf("plugin executor %s count tokens panic: %v", a.Identifier(), recovered)
 		}
@@ -794,7 +794,7 @@ func (a *executorAdapter) HttpRequest(ctx context.Context, auth *coreauth.Auth, 
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			a.host.fusePlugin(a.pluginID, "Executor.HttpRequest", recovered)
+			a.host.fusePluginIdentity(a.pluginID, a.path, a.version, "Executor.HttpRequest", recovered)
 			resp = nil
 			err = fmt.Errorf("plugin executor %s http request panic: %v", a.Identifier(), recovered)
 		}

--- a/internal/pluginhost/adapters_interceptors.go
+++ b/internal/pluginhost/adapters_interceptors.go
@@ -21,7 +21,7 @@ func (h *Host) callRequestInterceptor(ctx context.Context, record capabilityReco
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, method, recovered)
+			h.fusePlugin(record, method, recovered)
 			out = pluginapi.RequestInterceptResponse{}
 			ok = false
 		}
@@ -40,7 +40,7 @@ func (h *Host) callResponseInterceptor(ctx context.Context, record capabilityRec
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "ResponseInterceptor.InterceptResponse", recovered)
+			h.fusePlugin(record, "ResponseInterceptor.InterceptResponse", recovered)
 			out = pluginapi.ResponseInterceptResponse{}
 			ok = false
 		}
@@ -59,7 +59,7 @@ func (h *Host) callStreamChunkInterceptor(ctx context.Context, record capability
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "StreamChunkInterceptor.InterceptStreamChunk", recovered)
+			h.fusePlugin(record, "StreamChunkInterceptor.InterceptStreamChunk", recovered)
 			out = pluginapi.StreamChunkInterceptResponse{}
 			ok = false
 		}
@@ -152,7 +152,7 @@ func (h *Host) CompleteRequestExcept(ctx context.Context, completion pluginapi.R
 		go func(record capabilityRecord, plugin pluginapi.RequestLifecyclePlugin, completion pluginapi.RequestCompletion) {
 			defer func() {
 				if recovered := recover(); recovered != nil {
-					h.fusePlugin(record.id, "RequestLifecyclePlugin.HandleRequestComplete", recovered)
+					h.fusePlugin(record, "RequestLifecyclePlugin.HandleRequestComplete", recovered)
 				}
 			}()
 			if errComplete := plugin.HandleRequestComplete(ctx, completion); errComplete != nil {

--- a/internal/pluginhost/adapters_interceptors.go
+++ b/internal/pluginhost/adapters_interceptors.go
@@ -20,7 +20,7 @@ func (h *Host) callRequestInterceptor(ctx context.Context, record capabilityReco
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, method, recovered)
+			h.fusePlugin(record, method, recovered)
 			out = pluginapi.RequestInterceptResponse{}
 			ok = false
 		}
@@ -39,7 +39,7 @@ func (h *Host) callResponseInterceptor(ctx context.Context, record capabilityRec
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "ResponseInterceptor.InterceptResponse", recovered)
+			h.fusePlugin(record, "ResponseInterceptor.InterceptResponse", recovered)
 			out = pluginapi.ResponseInterceptResponse{}
 			ok = false
 		}
@@ -58,7 +58,7 @@ func (h *Host) callStreamChunkInterceptor(ctx context.Context, record capability
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "StreamChunkInterceptor.InterceptStreamChunk", recovered)
+			h.fusePlugin(record, "StreamChunkInterceptor.InterceptStreamChunk", recovered)
 			out = pluginapi.StreamChunkInterceptResponse{}
 			ok = false
 		}
@@ -151,7 +151,7 @@ func (h *Host) CompleteRequestExcept(ctx context.Context, completion pluginapi.R
 		go func(record capabilityRecord, plugin pluginapi.RequestLifecyclePlugin, completion pluginapi.RequestCompletion) {
 			defer func() {
 				if recovered := recover(); recovered != nil {
-					h.fusePlugin(record.id, "RequestLifecyclePlugin.HandleRequestComplete", recovered)
+					h.fusePlugin(record, "RequestLifecyclePlugin.HandleRequestComplete", recovered)
 				}
 			}()
 			if errComplete := plugin.HandleRequestComplete(ctx, completion); errComplete != nil {

--- a/internal/pluginhost/adapters_stream_session.go
+++ b/internal/pluginhost/adapters_stream_session.go
@@ -1,0 +1,347 @@
+package pluginhost
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+	log "github.com/sirupsen/logrus"
+)
+
+type streamChunkInterceptorSessionRecord struct {
+	record          capabilityRecord
+	interceptor     pluginapi.StreamChunkInterceptor
+	stateful        bool
+	rpcMetadataSafe bool
+	fuseEpoch       uint64
+	initAttempted   bool
+	initialized     bool
+	disabled        bool
+	cleanupPending  bool
+	cleanupRequired bool
+}
+
+type streamChunkInterceptorSession struct {
+	host                    *Host
+	callMu                  sync.Mutex
+	stateMu                 sync.Mutex
+	records                 []streamChunkInterceptorSessionRecord
+	releases                []func()
+	skipID                  string
+	closed                  bool
+	omitHeavyFieldsNextCall bool
+}
+
+// OpenStreamChunkInterceptorSession captures the currently active stream
+// interceptors. Stateful RPC interceptors are pinned for the stream lifetime;
+// legacy RPC interceptors retain their existing cancellation and reload behavior.
+func (h *Host) OpenStreamChunkInterceptorSession(skipPluginID string) pluginapi.StreamChunkInterceptorSession {
+	if h == nil {
+		return nil
+	}
+	skipPluginID = strings.TrimSpace(skipPluginID)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	raw := h.snapshot.Load()
+	snap, _ := raw.(*Snapshot)
+	if snap == nil {
+		return nil
+	}
+	records := make([]streamChunkInterceptorSessionRecord, 0, len(snap.records))
+	releases := make([]func(), 0, len(snap.records))
+	hasLegacy := false
+	for _, record := range snap.records {
+		if record.id == skipPluginID || !h.pluginIdentityCurrentLocked(record.id, record.path, record.version) {
+			continue
+		}
+		if _, fused := h.fused[record.id]; fused {
+			continue
+		}
+		fuseEpoch := h.fusedIdentities[makePluginIdentityKey(record.id, record.path, record.version)]
+		if record.plugin.Capabilities.StreamChunkInterceptor == nil {
+			continue
+		}
+		interceptor := record.plugin.Capabilities.StreamChunkInterceptor
+		stateful := record.plugin.Capabilities.StreamChunkInterceptorStateful
+		if !stateful {
+			hasLegacy = true
+			continue
+		}
+		rpcMetadataSafe := false
+		if adapter, okAdapter := interceptor.(*rpcPluginAdapter); okAdapter {
+			client, okClient := adapter.client.(*guardedPluginClient)
+			if !okClient {
+				continue
+			}
+			rpcMetadataSafe = true
+			lease, errPin := client.Pin()
+			if errPin != nil {
+				continue
+			}
+			pinnedAdapter := *adapter
+			pinnedAdapter.client = lease
+			interceptor = &pinnedAdapter
+			releases = append(releases, lease.Shutdown)
+		}
+		records = append(records, streamChunkInterceptorSessionRecord{
+			record:          record,
+			interceptor:     interceptor,
+			stateful:        stateful,
+			rpcMetadataSafe: rpcMetadataSafe,
+			fuseEpoch:       fuseEpoch,
+		})
+	}
+	if len(records) == 0 && !hasLegacy {
+		for _, release := range releases {
+			release()
+		}
+		return nil
+	}
+	return &streamChunkInterceptorSession{host: h, records: records, releases: releases, skipID: skipPluginID}
+}
+
+func (s *streamChunkInterceptorSession) CanOmitHeavyFields() bool {
+	if s == nil {
+		return false
+	}
+	s.callMu.Lock()
+	defer s.callMu.Unlock()
+	s.omitHeavyFieldsNextCall = false
+	if s.isClosed() {
+		return false
+	}
+	for i := range s.records {
+		if s.records[i].disabled || !s.records[i].stateful || !s.records[i].initialized {
+			return false
+		}
+	}
+	if len(s.legacyRecords()) > 0 {
+		return false
+	}
+	s.omitHeavyFieldsNextCall = len(s.records) > 0
+	return s.omitHeavyFieldsNextCall
+}
+
+func (s *streamChunkInterceptorSession) InterceptStreamChunk(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+	passthrough := pluginapi.StreamChunkInterceptResponse{
+		Headers: cloneHeader(req.ResponseHeaders),
+		Body:    bytes.Clone(req.Body),
+	}
+	if s == nil || s.host == nil || s.isClosed() {
+		return passthrough
+	}
+	s.callMu.Lock()
+	defer s.callMu.Unlock()
+	if s.isClosed() {
+		return passthrough
+	}
+	includeLegacy := !s.omitHeavyFieldsNextCall
+	s.omitHeavyFieldsNextCall = false
+
+	current := pluginapi.StreamChunkInterceptResponse{
+		Headers: cloneHeader(req.ResponseHeaders),
+		Body:    bytes.Clone(req.Body),
+	}
+	for _, state := range s.callRecords(includeLegacy) {
+		if s.isClosed() {
+			return passthrough
+		}
+		if state.stateful && !state.disabled && s.host.isPinnedStreamInterceptorFused(state.record, state.fuseEpoch) {
+			state.disabled = true
+			if state.stateful && state.cleanupRequired {
+				state.cleanupPending = true
+			}
+		}
+		if state.disabled {
+			if req.ChunkIndex != pluginapi.StreamChunkEndIndex || !state.cleanupPending {
+				continue
+			}
+			state.cleanupPending = false
+		}
+		if req.ChunkIndex == pluginapi.StreamChunkEndIndex {
+			if !state.stateful || !state.initAttempted {
+				continue
+			}
+		} else if req.ChunkIndex >= 0 && current.DropChunk {
+			continue
+		}
+
+		nextReq := req
+		nextReq.RequestHeaders = cloneHeader(req.RequestHeaders)
+		nextReq.ResponseHeaders = cloneHeader(current.Headers)
+		nextReq.OriginalRequest = bytes.Clone(req.OriginalRequest)
+		nextReq.RequestBody = bytes.Clone(req.RequestBody)
+		nextReq.Body = bytes.Clone(current.Body)
+		nextReq.HistoryChunks = cloneByteSlices(req.HistoryChunks)
+		if state.rpcMetadataSafe {
+			nextReq.Metadata = req.Metadata
+		} else {
+			nextReq.Metadata = cloneInterceptorMetadata(req.Metadata)
+		}
+		if !state.stateful {
+			nextReq.StreamID = ""
+		}
+		if req.ChunkIndex == pluginapi.StreamChunkHeaderInitIndex && state.stateful {
+			state.initAttempted = true
+		}
+
+		wasInitialized := state.initialized
+		var resp pluginapi.StreamChunkInterceptResponse
+		var ok, panicked bool
+		if state.stateful {
+			resp, ok, panicked = s.host.callSessionStreamChunkInterceptor(ctx, state.record, state.interceptor, nextReq)
+		} else {
+			resp, ok = s.host.callStreamChunkInterceptor(ctx, state.record, state.interceptor, nextReq)
+		}
+		if s.isClosed() {
+			return passthrough
+		}
+		if panicked {
+			if req.ChunkIndex != pluginapi.StreamChunkEndIndex && state.stateful && (wasInitialized || state.cleanupRequired) {
+				state.cleanupPending = true
+			}
+			state.disabled = true
+		}
+		if req.ChunkIndex == pluginapi.StreamChunkHeaderInitIndex && state.stateful {
+			state.initialized = ok
+			if ok {
+				state.cleanupRequired = true
+			}
+		}
+		if !ok {
+			continue
+		}
+		current.Headers = mergeHeaders(current.Headers, resp.Headers, resp.ClearHeaders)
+		if len(resp.Body) > 0 {
+			current.Body = bytes.Clone(resp.Body)
+		}
+		if resp.DropChunk && req.ChunkIndex >= 0 {
+			current.DropChunk = true
+		}
+	}
+	s.stateMu.Lock()
+	if s.closed {
+		s.stateMu.Unlock()
+		return passthrough
+	}
+	s.stateMu.Unlock()
+	return current
+}
+
+func (s *streamChunkInterceptorSession) callRecords(includeLegacy bool) []*streamChunkInterceptorSessionRecord {
+	if s == nil {
+		return nil
+	}
+	records := make([]*streamChunkInterceptorSessionRecord, 0, len(s.records))
+	for i := range s.records {
+		records = append(records, &s.records[i])
+	}
+	if includeLegacy {
+		legacy := s.legacyRecords()
+		for i := range legacy {
+			records = append(records, &legacy[i])
+		}
+	}
+	sort.SliceStable(records, func(i, j int) bool {
+		if records[i].record.priority == records[j].record.priority {
+			return records[i].record.id < records[j].record.id
+		}
+		return records[i].record.priority > records[j].record.priority
+	})
+	return records
+}
+
+func (s *streamChunkInterceptorSession) legacyRecords() []streamChunkInterceptorSessionRecord {
+	if s == nil || s.host == nil {
+		return nil
+	}
+	pinnedIDs := make(map[string]struct{}, len(s.records))
+	for i := range s.records {
+		pinnedIDs[s.records[i].record.id] = struct{}{}
+	}
+	records := make([]streamChunkInterceptorSessionRecord, 0)
+	for _, record := range s.host.activeRecords() {
+		interceptor := record.plugin.Capabilities.StreamChunkInterceptor
+		if record.id == s.skipID || interceptor == nil || record.plugin.Capabilities.StreamChunkInterceptorStateful || s.host.isPluginFused(record.id) {
+			continue
+		}
+		if _, pinned := pinnedIDs[record.id]; pinned {
+			continue
+		}
+		_, rpcMetadataSafe := interceptor.(*rpcPluginAdapter)
+		records = append(records, streamChunkInterceptorSessionRecord{
+			record:          record,
+			interceptor:     interceptor,
+			rpcMetadataSafe: rpcMetadataSafe,
+		})
+	}
+	return records
+}
+
+func (s *streamChunkInterceptorSession) Close() {
+	if s == nil {
+		return
+	}
+	s.stateMu.Lock()
+	if s.closed {
+		s.stateMu.Unlock()
+		return
+	}
+	s.closed = true
+	releases := s.releases
+	s.releases = nil
+	s.stateMu.Unlock()
+	if len(releases) == 0 {
+		return
+	}
+	go func() {
+		for _, release := range releases {
+			release()
+		}
+	}()
+}
+
+func (s *streamChunkInterceptorSession) isClosed() bool {
+	s.stateMu.Lock()
+	closed := s.closed
+	s.stateMu.Unlock()
+	return closed
+}
+
+func (h *Host) callSessionStreamChunkInterceptor(ctx context.Context, record capabilityRecord, interceptor pluginapi.StreamChunkInterceptor, req pluginapi.StreamChunkInterceptRequest) (out pluginapi.StreamChunkInterceptResponse, ok bool, panicked bool) {
+	if h == nil || interceptor == nil {
+		return pluginapi.StreamChunkInterceptResponse{}, false, false
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			h.fusePlugin(record, "StreamChunkInterceptor.InterceptStreamChunk", recovered)
+			out = pluginapi.StreamChunkInterceptResponse{}
+			ok = false
+			panicked = true
+		}
+	}()
+	resp, errIntercept := interceptor.InterceptStreamChunk(ctx, req)
+	if errIntercept != nil {
+		log.Warnf("pluginhost: stream chunk interceptor session %s failed: %v", record.id, errIntercept)
+		return pluginapi.StreamChunkInterceptResponse{}, false, false
+	}
+	return resp, true, false
+}
+
+func (h *Host) isPinnedStreamInterceptorFused(record capabilityRecord, openedAtFuseEpoch uint64) bool {
+	if h == nil {
+		return false
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.pluginIdentityCurrentLocked(record.id, record.path, record.version) {
+		if _, fused := h.fused[record.id]; fused {
+			return true
+		}
+	}
+	return h.fusedIdentities[makePluginIdentityKey(record.id, record.path, record.version)] > openedAtFuseEpoch
+}

--- a/internal/pluginhost/adapters_stream_session.go
+++ b/internal/pluginhost/adapters_stream_session.go
@@ -1,0 +1,352 @@
+package pluginhost
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+	log "github.com/sirupsen/logrus"
+)
+
+type streamChunkInterceptorSessionRecord struct {
+	record          capabilityRecord
+	interceptor     pluginapi.StreamChunkInterceptor
+	stateful        bool
+	rpcMetadataSafe bool
+	fuseEpoch       uint64
+	initAttempted   bool
+	initialized     bool
+	disabled        bool
+	cleanupPending  bool
+	cleanupRequired bool
+}
+
+type streamChunkInterceptorSession struct {
+	host                    *Host
+	callMu                  sync.Mutex
+	stateMu                 sync.Mutex
+	records                 []streamChunkInterceptorSessionRecord
+	releases                []func()
+	skipID                  string
+	closed                  bool
+	omitHeavyFieldsNextCall bool
+}
+
+// OpenStreamChunkInterceptorSession captures the currently active stream
+// interceptors. Stateful RPC interceptors are pinned for the stream lifetime;
+// legacy RPC interceptors retain their existing cancellation and reload behavior.
+func (h *Host) OpenStreamChunkInterceptorSession(skipPluginID string) pluginapi.StreamChunkInterceptorSession {
+	if h == nil {
+		return nil
+	}
+	skipPluginID = strings.TrimSpace(skipPluginID)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	raw := h.snapshot.Load()
+	snap, _ := raw.(*Snapshot)
+	if snap == nil {
+		return nil
+	}
+	records := make([]streamChunkInterceptorSessionRecord, 0, len(snap.records))
+	releases := make([]func(), 0, len(snap.records))
+	hasLegacy := false
+	for _, record := range snap.records {
+		if record.id == skipPluginID || !h.pluginIdentityCurrentLocked(record.id, record.path, record.version) {
+			continue
+		}
+		if _, fused := h.fused[record.id]; fused {
+			continue
+		}
+		fuseEpoch := h.fusedIdentities[makePluginIdentityKey(record.id, record.path, record.version)]
+		if record.plugin.Capabilities.StreamChunkInterceptor == nil {
+			continue
+		}
+		interceptor := record.plugin.Capabilities.StreamChunkInterceptor
+		stateful := record.plugin.Capabilities.StreamChunkInterceptorStateful
+		if !stateful {
+			hasLegacy = true
+			continue
+		}
+		rpcMetadataSafe := false
+		if adapter, okAdapter := interceptor.(*rpcPluginAdapter); okAdapter {
+			client, okClient := adapter.client.(*guardedPluginClient)
+			if !okClient {
+				continue
+			}
+			rpcMetadataSafe = true
+			lease, errPin := client.Pin()
+			if errPin != nil {
+				continue
+			}
+			pinnedAdapter := *adapter
+			pinnedAdapter.client = lease
+			interceptor = &pinnedAdapter
+			releases = append(releases, lease.Shutdown)
+		}
+		records = append(records, streamChunkInterceptorSessionRecord{
+			record:          record,
+			interceptor:     interceptor,
+			stateful:        stateful,
+			rpcMetadataSafe: rpcMetadataSafe,
+			fuseEpoch:       fuseEpoch,
+		})
+	}
+	if len(records) == 0 && !hasLegacy {
+		for _, release := range releases {
+			release()
+		}
+		return nil
+	}
+	return &streamChunkInterceptorSession{host: h, records: records, releases: releases, skipID: skipPluginID}
+}
+
+func (s *streamChunkInterceptorSession) CanOmitHeavyFields() bool {
+	if s == nil {
+		return false
+	}
+	s.callMu.Lock()
+	defer s.callMu.Unlock()
+	s.omitHeavyFieldsNextCall = false
+	if s.isClosed() {
+		return false
+	}
+	for i := range s.records {
+		if s.records[i].disabled || !s.records[i].stateful || !s.records[i].initialized {
+			return false
+		}
+	}
+	if len(s.legacyRecords()) > 0 {
+		return false
+	}
+	s.omitHeavyFieldsNextCall = len(s.records) > 0
+	return s.omitHeavyFieldsNextCall
+}
+
+func (s *streamChunkInterceptorSession) InterceptStreamChunk(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+	passthrough := pluginapi.StreamChunkInterceptResponse{
+		Headers: cloneHeader(req.ResponseHeaders),
+		Body:    bytes.Clone(req.Body),
+	}
+	if s == nil || s.host == nil || s.isClosed() {
+		return passthrough
+	}
+	s.callMu.Lock()
+	defer s.callMu.Unlock()
+	if s.isClosed() {
+		return passthrough
+	}
+	includeLegacy := !s.omitHeavyFieldsNextCall
+	s.omitHeavyFieldsNextCall = false
+
+	current := pluginapi.StreamChunkInterceptResponse{
+		Headers: cloneHeader(req.ResponseHeaders),
+		Body:    bytes.Clone(req.Body),
+	}
+	for _, state := range s.callRecords(includeLegacy) {
+		if s.isClosed() {
+			return passthrough
+		}
+		if state.stateful && !state.disabled && s.host.isPinnedStreamInterceptorFused(state.record, state.fuseEpoch) {
+			state.disabled = true
+			if state.stateful && state.cleanupRequired {
+				state.cleanupPending = true
+			}
+		}
+		if state.disabled {
+			if req.ChunkIndex != pluginapi.StreamChunkEndIndex || !state.cleanupPending {
+				continue
+			}
+			state.cleanupPending = false
+		}
+		if req.ChunkIndex == pluginapi.StreamChunkEndIndex {
+			if !state.stateful || !state.initAttempted {
+				continue
+			}
+		} else if req.ChunkIndex >= 0 && current.DropChunk {
+			continue
+		}
+
+		nextReq := req
+		nextReq.RequestHeaders = cloneHeader(req.RequestHeaders)
+		nextReq.ResponseHeaders = cloneHeader(current.Headers)
+		if req.ChunkIndex >= 0 && streamChunkOmitsRequestBodies(state.record.plugin.SchemaVersion) {
+			nextReq.OriginalRequest = nil
+			nextReq.RequestBody = nil
+		} else {
+			nextReq.OriginalRequest = bytes.Clone(req.OriginalRequest)
+			nextReq.RequestBody = bytes.Clone(req.RequestBody)
+		}
+		nextReq.Body = bytes.Clone(current.Body)
+		nextReq.HistoryChunks = cloneByteSlices(req.HistoryChunks)
+		if state.rpcMetadataSafe {
+			nextReq.Metadata = req.Metadata
+		} else {
+			nextReq.Metadata = cloneInterceptorMetadata(req.Metadata)
+		}
+		if !state.stateful {
+			nextReq.StreamID = ""
+		}
+		if req.ChunkIndex == pluginapi.StreamChunkHeaderInitIndex && state.stateful {
+			state.initAttempted = true
+		}
+
+		wasInitialized := state.initialized
+		var resp pluginapi.StreamChunkInterceptResponse
+		var ok, panicked bool
+		if state.stateful {
+			resp, ok, panicked = s.host.callSessionStreamChunkInterceptor(ctx, state.record, state.interceptor, nextReq)
+		} else {
+			resp, ok = s.host.callStreamChunkInterceptor(ctx, state.record, state.interceptor, nextReq)
+		}
+		if s.isClosed() {
+			return passthrough
+		}
+		if panicked {
+			if req.ChunkIndex != pluginapi.StreamChunkEndIndex && state.stateful && (wasInitialized || state.cleanupRequired) {
+				state.cleanupPending = true
+			}
+			state.disabled = true
+		}
+		if req.ChunkIndex == pluginapi.StreamChunkHeaderInitIndex && state.stateful {
+			state.initialized = ok
+			if ok {
+				state.cleanupRequired = true
+			}
+		}
+		if !ok {
+			continue
+		}
+		current.Headers = mergeHeaders(current.Headers, resp.Headers, resp.ClearHeaders)
+		if len(resp.Body) > 0 {
+			current.Body = bytes.Clone(resp.Body)
+		}
+		if resp.DropChunk && req.ChunkIndex >= 0 {
+			current.DropChunk = true
+		}
+	}
+	s.stateMu.Lock()
+	if s.closed {
+		s.stateMu.Unlock()
+		return passthrough
+	}
+	s.stateMu.Unlock()
+	return current
+}
+
+func (s *streamChunkInterceptorSession) callRecords(includeLegacy bool) []*streamChunkInterceptorSessionRecord {
+	if s == nil {
+		return nil
+	}
+	records := make([]*streamChunkInterceptorSessionRecord, 0, len(s.records))
+	for i := range s.records {
+		records = append(records, &s.records[i])
+	}
+	if includeLegacy {
+		legacy := s.legacyRecords()
+		for i := range legacy {
+			records = append(records, &legacy[i])
+		}
+	}
+	sort.SliceStable(records, func(i, j int) bool {
+		if records[i].record.priority == records[j].record.priority {
+			return records[i].record.id < records[j].record.id
+		}
+		return records[i].record.priority > records[j].record.priority
+	})
+	return records
+}
+
+func (s *streamChunkInterceptorSession) legacyRecords() []streamChunkInterceptorSessionRecord {
+	if s == nil || s.host == nil {
+		return nil
+	}
+	pinnedIDs := make(map[string]struct{}, len(s.records))
+	for i := range s.records {
+		pinnedIDs[s.records[i].record.id] = struct{}{}
+	}
+	records := make([]streamChunkInterceptorSessionRecord, 0)
+	for _, record := range s.host.activeRecords() {
+		interceptor := record.plugin.Capabilities.StreamChunkInterceptor
+		if record.id == s.skipID || interceptor == nil || record.plugin.Capabilities.StreamChunkInterceptorStateful || s.host.isPluginFused(record.id) {
+			continue
+		}
+		if _, pinned := pinnedIDs[record.id]; pinned {
+			continue
+		}
+		_, rpcMetadataSafe := interceptor.(*rpcPluginAdapter)
+		records = append(records, streamChunkInterceptorSessionRecord{
+			record:          record,
+			interceptor:     interceptor,
+			rpcMetadataSafe: rpcMetadataSafe,
+		})
+	}
+	return records
+}
+
+func (s *streamChunkInterceptorSession) Close() {
+	if s == nil {
+		return
+	}
+	s.stateMu.Lock()
+	if s.closed {
+		s.stateMu.Unlock()
+		return
+	}
+	s.closed = true
+	releases := s.releases
+	s.releases = nil
+	s.stateMu.Unlock()
+	if len(releases) == 0 {
+		return
+	}
+	go func() {
+		for _, release := range releases {
+			release()
+		}
+	}()
+}
+
+func (s *streamChunkInterceptorSession) isClosed() bool {
+	s.stateMu.Lock()
+	closed := s.closed
+	s.stateMu.Unlock()
+	return closed
+}
+
+func (h *Host) callSessionStreamChunkInterceptor(ctx context.Context, record capabilityRecord, interceptor pluginapi.StreamChunkInterceptor, req pluginapi.StreamChunkInterceptRequest) (out pluginapi.StreamChunkInterceptResponse, ok bool, panicked bool) {
+	if h == nil || interceptor == nil {
+		return pluginapi.StreamChunkInterceptResponse{}, false, false
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			h.fusePlugin(record, "StreamChunkInterceptor.InterceptStreamChunk", recovered)
+			out = pluginapi.StreamChunkInterceptResponse{}
+			ok = false
+			panicked = true
+		}
+	}()
+	resp, errIntercept := interceptor.InterceptStreamChunk(ctx, req)
+	if errIntercept != nil {
+		log.Warnf("pluginhost: stream chunk interceptor session %s failed: %v", record.id, errIntercept)
+		return pluginapi.StreamChunkInterceptResponse{}, false, false
+	}
+	return resp, true, false
+}
+
+func (h *Host) isPinnedStreamInterceptorFused(record capabilityRecord, openedAtFuseEpoch uint64) bool {
+	if h == nil {
+		return false
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.pluginIdentityCurrentLocked(record.id, record.path, record.version) {
+		if _, fused := h.fused[record.id]; fused {
+			return true
+		}
+	}
+	return h.fusedIdentities[makePluginIdentityKey(record.id, record.path, record.version)] > openedAtFuseEpoch
+}

--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1643,6 +1644,1512 @@ func TestStreamInterceptorsDropChunkStopsChain(t *testing.T) {
 	}
 }
 
+func TestStreamInterceptorSessionRoutesMixedLifecyclePerPlugin(t *testing.T) {
+	var statefulCalls []pluginapi.StreamChunkInterceptRequest
+	var legacyCalls []pluginapi.StreamChunkInterceptRequest
+	host := newHostWithRecords(
+		capabilityRecord{
+			id:       "stateful",
+			priority: 20,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						statefulCalls = append(statefulCalls, req)
+						return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+					},
+				},
+				StreamChunkInterceptorStateful: true,
+			}},
+		},
+		capabilityRecord{
+			id:       "legacy",
+			priority: 10,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						legacyCalls = append(legacyCalls, req)
+						return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+					},
+				},
+			}},
+		},
+	)
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	if session == nil {
+		t.Fatal("OpenStreamChunkInterceptorSession() = nil, want active session")
+	}
+	initReq := pluginapi.StreamChunkInterceptRequest{
+		StreamID:        "stream-1",
+		OriginalRequest: []byte("original"),
+		RequestBody:     []byte("request"),
+		ChunkIndex:      pluginapi.StreamChunkHeaderInitIndex,
+	}
+	session.InterceptStreamChunk(context.Background(), initReq)
+	if session.CanOmitHeavyFields() {
+		t.Fatal("CanOmitHeavyFields() = true, want false for mixed stateful and legacy interceptors")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:        "stream-1",
+		OriginalRequest: []byte("original"),
+		RequestBody:     []byte("request"),
+		Body:            []byte("chunk"),
+		HistoryChunks:   [][]byte{[]byte("previous")},
+		ChunkIndex:      0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+
+	if len(statefulCalls) != 3 {
+		t.Fatalf("stateful calls = %d, want init, payload, and end", len(statefulCalls))
+	}
+	for i, req := range statefulCalls {
+		if req.StreamID != "stream-1" {
+			t.Fatalf("stateful call %d StreamID = %q, want stream-1", i, req.StreamID)
+		}
+	}
+	if len(legacyCalls) != 2 {
+		t.Fatalf("legacy calls = %d, want init and payload only", len(legacyCalls))
+	}
+	for i, req := range legacyCalls {
+		if req.StreamID != "" {
+			t.Fatalf("legacy call %d StreamID = %q, want empty", i, req.StreamID)
+		}
+		if string(req.RequestBody) != "request" || string(req.OriginalRequest) != "original" {
+			t.Fatalf("legacy call %d heavy fields = request %q original %q", i, req.RequestBody, req.OriginalRequest)
+		}
+	}
+	if len(legacyCalls[1].HistoryChunks) != 1 || string(legacyCalls[1].HistoryChunks[0]) != "previous" {
+		t.Fatalf("legacy payload history = %#v, want previous chunk", legacyCalls[1].HistoryChunks)
+	}
+}
+
+func TestLegacyRPCStreamInterceptorSessionReturnsOnContextCancellation(t *testing.T) {
+	callStarted := make(chan struct{})
+	releaseCall := make(chan struct{})
+	shutdownDone := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseCall) })
+	}
+
+	inner := &blockingStreamPluginClient{
+		callStarted:  callStarted,
+		releaseCall:  releaseCall,
+		shutdownDone: shutdownDone,
+	}
+	guarded := newGuardedPluginClient(inner)
+	host := New()
+	adapter := &rpcPluginAdapter{id: "legacy", host: host, client: guarded}
+	setHostSnapshotForTest(host, true, capabilityRecord{
+		id: "legacy",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: adapter,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	if session == nil {
+		t.Fatal("OpenStreamChunkInterceptorSession() = nil, want active session")
+	}
+	t.Cleanup(func() {
+		release()
+		session.Close()
+		guarded.Shutdown()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan pluginapi.StreamChunkInterceptResponse, 1)
+	go func() {
+		result <- session.InterceptStreamChunk(ctx, pluginapi.StreamChunkInterceptRequest{
+			ResponseHeaders: http.Header{"X-Original": []string{"true"}},
+			Body:            []byte("original"),
+			ChunkIndex:      0,
+		})
+	}()
+	waitForHostTestSignal(t, callStarted, "legacy stream interceptor RPC call")
+	cancel()
+
+	select {
+	case got := <-result:
+		if string(got.Body) != "original" || got.Headers.Get("X-Original") != "true" || got.DropChunk {
+			t.Fatalf("result after cancellation = %#v, want original passthrough", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("legacy stream interceptor session did not return after context cancellation")
+	}
+
+	release()
+	guarded.Shutdown()
+	waitForHostTestSignal(t, shutdownDone, "legacy plugin client shutdown")
+}
+
+func TestStreamInterceptorSessionPinsRecordsAcrossReload(t *testing.T) {
+	var oldCalls []int
+	var replacementCalls []int
+	host := newHostWithRecords(capabilityRecord{
+		id:      "privacy",
+		path:    "testdata/privacy-v1.plugin",
+		version: "v1",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					oldCalls = append(oldCalls, req.ChunkIndex)
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:    "stream-1",
+		RequestBody: []byte("request"),
+		ChunkIndex:  pluginapi.StreamChunkHeaderInitIndex,
+	})
+	if !session.CanOmitHeavyFields() {
+		t.Fatal("CanOmitHeavyFields() = false, want true after successful stateful initialization")
+	}
+
+	setHostSnapshotForTest(host, true, capabilityRecord{
+		id:      "privacy",
+		path:    "testdata/privacy-v2.plugin",
+		version: "v2",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					replacementCalls = append(replacementCalls, req.ChunkIndex)
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("chunk"),
+		ChunkIndex: 0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+
+	if fmt.Sprint(oldCalls) != "[-1 0 -2]" {
+		t.Fatalf("pinned plugin calls = %v, want [-1 0 -2]", oldCalls)
+	}
+	if len(replacementCalls) != 0 {
+		t.Fatalf("replacement plugin calls = %v, want none for existing session", replacementCalls)
+	}
+}
+
+func TestStreamInterceptorSessionUsesCurrentLegacyRecordAfterReload(t *testing.T) {
+	var oldCalls []int
+	var replacementCalls []int
+	host := newHostWithRecords(capabilityRecord{
+		id:      "legacy",
+		path:    "testdata/legacy-v1.plugin",
+		version: "v1",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					oldCalls = append(oldCalls, req.ChunkIndex)
+					return pluginapi.StreamChunkInterceptResponse{Body: append(req.Body, []byte("|v1")...)}, nil
+				},
+			},
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	if session == nil {
+		t.Fatal("OpenStreamChunkInterceptorSession() = nil, want active legacy session")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		RequestBody: []byte("request"),
+		ChunkIndex:  pluginapi.StreamChunkHeaderInitIndex,
+	})
+
+	setHostSnapshotForTest(host, true, capabilityRecord{
+		id:      "legacy",
+		path:    "testdata/legacy-v2.plugin",
+		version: "v2",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					replacementCalls = append(replacementCalls, req.ChunkIndex)
+					return pluginapi.StreamChunkInterceptResponse{Body: append(req.Body, []byte("|v2")...)}, nil
+				},
+			},
+		}},
+	})
+	got := session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		RequestBody: []byte("request"),
+		Body:        []byte("chunk"),
+		ChunkIndex:  0,
+	})
+
+	if fmt.Sprint(oldCalls) != "[-1]" {
+		t.Fatalf("retired legacy calls = %v, want header init only", oldCalls)
+	}
+	if fmt.Sprint(replacementCalls) != "[0]" {
+		t.Fatalf("replacement legacy calls = %v, want payload only", replacementCalls)
+	}
+	if string(got.Body) != "chunk|v2" {
+		t.Fatalf("payload body = %q, want replacement output", got.Body)
+	}
+}
+
+func TestStreamInterceptorSessionDefersNewLegacyRecordAfterOmissionDecision(t *testing.T) {
+	statefulRecord := capabilityRecord{
+		id:      "stateful",
+		path:    "testdata/stateful.plugin",
+		version: "v1",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	}
+	host := newHostWithRecords(statefulRecord)
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:    "stream-1",
+		RequestBody: []byte("request"),
+		ChunkIndex:  pluginapi.StreamChunkHeaderInitIndex,
+	})
+	if !session.CanOmitHeavyFields() {
+		t.Fatal("CanOmitHeavyFields() = false, want true before legacy plugin loads")
+	}
+
+	var legacyRequests []pluginapi.StreamChunkInterceptRequest
+	setHostSnapshotForTest(host, true, statefulRecord, capabilityRecord{
+		id:      "legacy",
+		path:    "testdata/legacy.plugin",
+		version: "v1",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					legacyRequests = append(legacyRequests, req)
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+		}},
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("omitted-fields"),
+		ChunkIndex: 0,
+	})
+	if len(legacyRequests) != 0 {
+		t.Fatalf("legacy calls after omission decision = %d, want 0", len(legacyRequests))
+	}
+
+	if session.CanOmitHeavyFields() {
+		t.Fatal("CanOmitHeavyFields() = true, want false after legacy plugin loads")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:        "stream-1",
+		OriginalRequest: []byte("original"),
+		RequestBody:     []byte("request"),
+		HistoryChunks:   [][]byte{[]byte("history")},
+		Body:            []byte("full-fields"),
+		ChunkIndex:      1,
+	})
+	if len(legacyRequests) != 1 {
+		t.Fatalf("legacy calls after fields restored = %d, want 1", len(legacyRequests))
+	}
+	if string(legacyRequests[0].OriginalRequest) != "original" || string(legacyRequests[0].RequestBody) != "request" || len(legacyRequests[0].HistoryChunks) != 1 || string(legacyRequests[0].HistoryChunks[0]) != "history" {
+		t.Fatalf("legacy request heavy fields = %#v, want restored request data", legacyRequests[0])
+	}
+}
+
+func TestStreamInterceptorSessionCloseReturnsBeforeInflightRPCCall(t *testing.T) {
+	callStarted := make(chan struct{})
+	releaseCall := make(chan struct{})
+	shutdownDone := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseCall) })
+	}
+	t.Cleanup(release)
+
+	inner := &blockingStreamPluginClient{
+		callStarted:  callStarted,
+		releaseCall:  releaseCall,
+		shutdownDone: shutdownDone,
+	}
+	guarded := newGuardedPluginClient(inner)
+	host := New()
+	adapter := &rpcPluginAdapter{id: "blocking", host: host, client: guarded}
+	setHostSnapshotForTest(host, true, capabilityRecord{
+		id: "blocking",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor:         adapter,
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	if session == nil {
+		t.Fatal("OpenStreamChunkInterceptorSession() = nil, want active session")
+	}
+	result := make(chan pluginapi.StreamChunkInterceptResponse, 1)
+	go func() {
+		result <- session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+			ResponseHeaders: http.Header{"X-Original": []string{"true"}},
+			Body:            []byte("original"),
+			ChunkIndex:      0,
+		})
+	}()
+	waitForHostTestSignal(t, callStarted, "stream interceptor RPC call")
+
+	guarded.Shutdown()
+	closeDone := make(chan struct{})
+	go func() {
+		session.Close()
+		close(closeDone)
+	}()
+	closedBeforeRelease := false
+	select {
+	case <-closeDone:
+		closedBeforeRelease = true
+	case <-time.After(time.Second):
+		t.Error("Close() blocked behind an in-flight RPC call")
+	}
+
+	release()
+	if !closedBeforeRelease {
+		waitForHostTestSignal(t, closeDone, "session close after RPC release")
+	}
+	var got pluginapi.StreamChunkInterceptResponse
+	select {
+	case got = <-result:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stream interceptor result")
+	}
+	if string(got.Body) != "original" || got.Headers.Get("X-Original") != "true" || got.DropChunk {
+		t.Fatalf("result after Close() = %#v, want original passthrough", got)
+	}
+	waitForHostTestSignal(t, shutdownDone, "deferred plugin client shutdown")
+}
+
+func TestStreamInterceptorSessionCallAfterCloseBypassesInflightRPCCall(t *testing.T) {
+	callStarted := make(chan struct{})
+	releaseCall := make(chan struct{})
+	shutdownDone := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseCall) })
+	}
+	t.Cleanup(release)
+
+	inner := &blockingStreamPluginClient{
+		callStarted:  callStarted,
+		releaseCall:  releaseCall,
+		shutdownDone: shutdownDone,
+	}
+	guarded := newGuardedPluginClient(inner)
+	host := New()
+	adapter := &rpcPluginAdapter{id: "blocking", host: host, client: guarded}
+	setHostSnapshotForTest(host, true, capabilityRecord{
+		id: "blocking",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor:         adapter,
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	firstResult := make(chan pluginapi.StreamChunkInterceptResponse, 1)
+	go func() {
+		firstResult <- session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+			Body:       []byte("first"),
+			ChunkIndex: 0,
+		})
+	}()
+	waitForHostTestSignal(t, callStarted, "first stream interceptor RPC call")
+
+	guarded.Shutdown()
+	session.Close()
+	secondResult := make(chan pluginapi.StreamChunkInterceptResponse, 1)
+	go func() {
+		secondResult <- session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+			ResponseHeaders: http.Header{"X-Original": []string{"true"}},
+			Body:            []byte("second"),
+			ChunkIndex:      1,
+		})
+	}()
+
+	select {
+	case got := <-secondResult:
+		if string(got.Body) != "second" || got.Headers.Get("X-Original") != "true" || got.DropChunk {
+			t.Fatalf("call after Close() = %#v, want original passthrough", got)
+		}
+	case <-time.After(time.Second):
+		t.Error("call after Close() blocked behind an earlier in-flight RPC call")
+	}
+
+	release()
+	select {
+	case <-firstResult:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first stream interceptor result")
+	}
+	waitForHostTestSignal(t, shutdownDone, "deferred plugin client shutdown")
+}
+
+func TestStreamInterceptorSessionWaitsForInflightRPCBeforeEnd(t *testing.T) {
+	payloadStarted := make(chan struct{})
+	endStarted := make(chan struct{})
+	releasePayload := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releasePayload) })
+	}
+	t.Cleanup(release)
+
+	inner := &orderedStreamPluginClient{
+		payloadStarted: payloadStarted,
+		endStarted:     endStarted,
+		releasePayload: releasePayload,
+	}
+	host := New()
+	adapter := &rpcPluginAdapter{id: "ordered", host: host, client: newGuardedPluginClient(inner)}
+	setHostSnapshotForTest(host, true, capabilityRecord{
+		id: "ordered",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor:         adapter,
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	t.Cleanup(session.Close)
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+
+	payloadCtx, cancelPayload := context.WithCancel(context.Background())
+	payloadDone := make(chan struct{})
+	go func() {
+		session.InterceptStreamChunk(payloadCtx, pluginapi.StreamChunkInterceptRequest{
+			StreamID:   "stream-1",
+			Body:       []byte("payload"),
+			ChunkIndex: 0,
+		})
+		close(payloadDone)
+	}()
+	waitForHostTestSignal(t, payloadStarted, "stateful payload RPC call")
+	cancelPayload()
+
+	endDone := make(chan struct{})
+	go func() {
+		session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+			StreamID:   "stream-1",
+			ChunkIndex: pluginapi.StreamChunkEndIndex,
+		})
+		close(endDone)
+	}()
+
+	select {
+	case <-endStarted:
+		t.Fatal("stream end entered the plugin before the canceled payload RPC exited")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	release()
+	waitForHostTestSignal(t, payloadDone, "stateful payload completion")
+	waitForHostTestSignal(t, endStarted, "stateful stream end RPC call")
+	waitForHostTestSignal(t, endDone, "stateful stream end completion")
+}
+
+func TestStreamInterceptorSessionSkipsCurrentPluginAfterExternalFuse(t *testing.T) {
+	var calls []int
+	host := newHostWithRecords(capabilityRecord{
+		id: "stateful",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					calls = append(calls, req.ChunkIndex)
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+	host.mu.Lock()
+	host.fused["stateful"] = "fused by concurrent request"
+	host.mu.Unlock()
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("skipped"),
+		ChunkIndex: 0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if fmt.Sprint(calls) != "[-1 -2]" {
+		t.Fatalf("interceptor calls = %v, want init and one best-effort end after external fuse", calls)
+	}
+}
+
+func TestStreamInterceptorSessionIgnoresFuseForReplacementIdentity(t *testing.T) {
+	var oldCalls []int
+	host := newHostWithRecords(capabilityRecord{
+		id:      "privacy",
+		path:    "testdata/privacy-v1.plugin",
+		version: "v1",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					oldCalls = append(oldCalls, req.ChunkIndex)
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+	setHostSnapshotForTest(host, true, capabilityRecord{
+		id:      "privacy",
+		path:    "testdata/privacy-v2.plugin",
+		version: "v2",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+	host.mu.Lock()
+	host.fused["privacy"] = "replacement fused"
+	host.mu.Unlock()
+
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("chunk"),
+		ChunkIndex: 0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if fmt.Sprint(oldCalls) != "[-1 0 -2]" {
+		t.Fatalf("pinned plugin calls = %v, want old identity to ignore replacement fuse", oldCalls)
+	}
+}
+
+func TestSafePluginCallDoesNotFuseActivePluginForReplacementPanic(t *testing.T) {
+	host := newHostWithRecords(capabilityRecord{
+		id:      "privacy",
+		path:    "testdata/privacy-v1.plugin",
+		version: "v1",
+	})
+	replacement := &loadedPlugin{
+		id:      "privacy",
+		path:    "testdata/privacy-v2.plugin",
+		version: "v2",
+	}
+
+	if _, ok := host.safePluginCall(context.Background(), replacement, "register", func() pluginapi.Plugin {
+		panic("replacement registration panic")
+	}); ok {
+		t.Fatal("safePluginCall returned ok=true for a panicking register")
+	}
+
+	host.mu.Lock()
+	_, activeFused := host.fused["privacy"]
+	oldEpoch := host.fusedIdentities[makePluginIdentityKey("privacy", "testdata/privacy-v1.plugin", "v1")]
+	replacementEpoch := host.fusedIdentities[makePluginIdentityKey("privacy", replacement.path, replacement.version)]
+	host.mu.Unlock()
+	if activeFused {
+		t.Fatal("replacement register panic fused the active plugin")
+	}
+	if oldEpoch != 0 {
+		t.Fatalf("active identity fuse epoch = %d, want 0", oldEpoch)
+	}
+	if replacementEpoch == 0 {
+		t.Fatal("replacement identity fuse epoch was not advanced")
+	}
+}
+
+func TestStreamInterceptorSessionSurvivesFailedReplacementApplyConfig(t *testing.T) {
+	var oldCalls []int
+	oldPlugin := validTestPlugin("privacy")
+	oldPlugin.Capabilities = pluginapi.Capabilities{
+		StreamChunkInterceptor: responseInterceptorFunc{
+			interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+				oldCalls = append(oldCalls, req.ChunkIndex)
+				return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+			},
+		},
+		StreamChunkInterceptorStateful: true,
+	}
+	loader := newTestSymbolLoader()
+	loader.lookups["privacy"] = newTestSymbolLookup(&testPlugin{registerResult: oldPlugin})
+	host := NewForTest(loader)
+	t.Cleanup(host.ShutdownAll)
+	pluginsDir, paths := makeVersionedPluginDir(t, "privacy", "1.0.0")
+	host.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"privacy": enabledPluginConfigWithStoreVersion(t, "1.0.0"),
+		},
+	}})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	if session == nil {
+		t.Fatal("OpenStreamChunkInterceptorSession returned nil")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+
+	loader.lookups["privacy"] = newTestSymbolLookup(&testPlugin{panicOnRegister: true})
+	paths["2.0.0"] = writeVersionedPluginFile(t, pluginsDir, "privacy", "2.0.0")
+	host.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"privacy": enabledPluginConfigWithStoreVersion(t, "2.0.0"),
+		},
+	}})
+
+	host.mu.Lock()
+	_, activeFused := host.fused["privacy"]
+	oldEpoch := host.fusedIdentities[makePluginIdentityKey("privacy", paths["1.0.0"], "1.0.0")]
+	replacementEpoch := host.fusedIdentities[makePluginIdentityKey("privacy", paths["2.0.0"], "2.0.0")]
+	host.mu.Unlock()
+	if activeFused {
+		t.Fatal("failed replacement left the plugin ID fused")
+	}
+	if oldEpoch != 0 {
+		t.Fatalf("old identity fuse epoch = %d, want 0", oldEpoch)
+	}
+	if replacementEpoch == 0 {
+		t.Fatal("replacement identity fuse epoch was not advanced")
+	}
+
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("chunk"),
+		ChunkIndex: 0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if fmt.Sprint(oldCalls) != "[-1 0 -2]" {
+		t.Fatalf("pinned plugin calls = %v, want old identity to survive failed replacement", oldCalls)
+	}
+}
+
+func TestFailedReplacementPreservesPreviousActiveCapabilities(t *testing.T) {
+	oldPlugin := validTestPlugin("privacy")
+	oldPlugin.Capabilities.RequestInterceptor = requestInterceptorFunc(func(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+		return pluginapi.RequestInterceptResponse{Body: append(req.Body, []byte("|v1")...)}, nil
+	})
+	loader := newTestSymbolLoader()
+	loader.lookups["privacy"] = newTestSymbolLookup(&testPlugin{registerResult: oldPlugin})
+	host := NewForTest(loader)
+	t.Cleanup(host.ShutdownAll)
+	pluginsDir, _ := makeVersionedPluginDir(t, "privacy", "1.0.0")
+	initialConfig := &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"privacy": enabledPluginConfigWithStoreVersion(t, "1.0.0"),
+		},
+	}}
+	host.ApplyConfig(context.Background(), initialConfig)
+
+	loader.lookups["privacy"] = newTestSymbolLookup(&testPlugin{panicOnRegister: true})
+	writeVersionedPluginFile(t, pluginsDir, "privacy", "2.0.0")
+	host.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"privacy": enabledPluginConfigWithStoreVersion(t, "2.0.0"),
+		},
+	}})
+
+	got := host.InterceptRequestBeforeAuth(context.Background(), pluginapi.RequestInterceptRequest{Body: []byte("request")})
+	if string(got.Body) != "request|v1" {
+		t.Fatalf("request response after failed replacement = %q, want %q", got.Body, "request|v1")
+	}
+}
+
+func TestFailedReplacementCanRetryAfterFusedPlugin(t *testing.T) {
+	loader := newTestSymbolLoader()
+	loader.lookups["privacy"] = newTestSymbolLookup(&testPlugin{registerResult: validTestPlugin("privacy")})
+	host := NewForTest(loader)
+	t.Cleanup(host.ShutdownAll)
+	pluginsDir, paths := makeVersionedPluginDir(t, "privacy", "1.0.0")
+	host.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"privacy": enabledPluginConfigWithStoreVersion(t, "1.0.0"),
+		},
+	}})
+	host.fusePlugin(host.activeRecords()[0], "test", "fused v1")
+
+	failedShutdown := make(chan struct{})
+	failedLookup := newTestSymbolLookup(&testPlugin{panicOnRegister: true})
+	failedLookup.shutdownDone = failedShutdown
+	loader.lookups["privacy"] = failedLookup
+	paths["2.0.0"] = writeVersionedPluginFile(t, pluginsDir, "privacy", "2.0.0")
+	replacementConfig := &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"privacy": enabledPluginConfigWithStoreVersion(t, "2.0.0"),
+		},
+	}}
+	host.ApplyConfig(context.Background(), replacementConfig)
+
+	host.mu.Lock()
+	loadedPath := host.loaded["privacy"].path
+	host.mu.Unlock()
+	if loadedPath != paths["1.0.0"] {
+		t.Fatalf("loaded plugin path after failed replacement = %q, want old path %q", loadedPath, paths["1.0.0"])
+	}
+	waitForHostTestSignal(t, failedShutdown, "failed replacement shutdown")
+	deadline := time.Now().Add(time.Second)
+	for {
+		host.mu.Lock()
+		_, loading := host.loading["privacy"]
+		host.mu.Unlock()
+		if !loading {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("failed replacement load token was not cleared")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	newPlugin := validTestPlugin("privacy")
+	newPlugin.Capabilities.RequestInterceptor = requestInterceptorFunc(func(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+		return pluginapi.RequestInterceptResponse{Body: append(req.Body, []byte("|v2")...)}, nil
+	})
+	loader.lookups["privacy"] = newTestSymbolLookup(&testPlugin{registerResult: newPlugin})
+	host.ApplyConfig(context.Background(), replacementConfig)
+
+	if loader.openCalls != 3 {
+		t.Fatalf("Open calls = %d, want 3 after retrying replacement", loader.openCalls)
+	}
+	if host.isPluginFused("privacy") {
+		t.Fatal("old fuse marker remained after successful replacement retry")
+	}
+	got := host.InterceptRequestBeforeAuth(context.Background(), pluginapi.RequestInterceptRequest{Body: []byte("request")})
+	if string(got.Body) != "request|v2" {
+		t.Fatalf("replacement response body = %q, want %q", got.Body, "request|v2")
+	}
+}
+
+func TestRuntimePanicAfterReplacementDoesNotFuseReplacement(t *testing.T) {
+	callStarted := make(chan struct{})
+	releaseCall := make(chan struct{})
+	oldPlugin := validTestPlugin("privacy")
+	oldPlugin.Capabilities.RequestInterceptor = requestInterceptorFunc(func(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+		close(callStarted)
+		<-releaseCall
+		panic("retired runtime panic")
+	})
+	newPlugin := validTestPlugin("privacy")
+	newPlugin.Capabilities.RequestInterceptor = requestInterceptorFunc(func(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+		return pluginapi.RequestInterceptResponse{Body: append(req.Body, []byte("|v2")...)}, nil
+	})
+
+	loader := newTestSymbolLoader()
+	loader.lookups["privacy"] = newTestSymbolLookup(&testPlugin{registerResult: oldPlugin})
+	host := NewForTest(loader)
+	t.Cleanup(host.ShutdownAll)
+	pluginsDir, paths := makeVersionedPluginDir(t, "privacy", "1.0.0")
+	host.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"privacy": enabledPluginConfigWithStoreVersion(t, "1.0.0"),
+		},
+	}})
+
+	oldCallDone := make(chan struct{})
+	go func() {
+		host.InterceptRequestBeforeAuth(context.Background(), pluginapi.RequestInterceptRequest{Body: []byte("old")})
+		close(oldCallDone)
+	}()
+	waitForHostTestSignal(t, callStarted, "old runtime call")
+
+	loader.lookups["privacy"] = newTestSymbolLookup(&testPlugin{registerResult: newPlugin})
+	paths["2.0.0"] = writeVersionedPluginFile(t, pluginsDir, "privacy", "2.0.0")
+	host.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"privacy": enabledPluginConfigWithStoreVersion(t, "2.0.0"),
+		},
+	}})
+	close(releaseCall)
+	waitForHostTestSignal(t, oldCallDone, "old runtime panic recovery")
+
+	host.mu.Lock()
+	_, activeFused := host.fused["privacy"]
+	oldEpoch := host.fusedIdentities[makePluginIdentityKey("privacy", paths["1.0.0"], "1.0.0")]
+	replacementEpoch := host.fusedIdentities[makePluginIdentityKey("privacy", paths["2.0.0"], "2.0.0")]
+	host.mu.Unlock()
+	if activeFused {
+		t.Fatal("retired runtime panic fused the active replacement")
+	}
+	if oldEpoch == 0 {
+		t.Fatal("retired identity fuse epoch was not advanced")
+	}
+	if replacementEpoch != 0 {
+		t.Fatalf("replacement identity fuse epoch = %d, want 0", replacementEpoch)
+	}
+
+	got := host.InterceptRequestBeforeAuth(context.Background(), pluginapi.RequestInterceptRequest{Body: []byte("new")})
+	if string(got.Body) != "new|v2" {
+		t.Fatalf("replacement response body = %q, want %q", got.Body, "new|v2")
+	}
+}
+
+func TestFusedPluginRemainsDisabledUntilReplacementSnapshotCommit(t *testing.T) {
+	oldCalled := make(chan struct{}, 1)
+	oldPlugin := validTestPlugin("alpha")
+	oldPlugin.Capabilities.RequestInterceptor = requestInterceptorFunc(func(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+		oldCalled <- struct{}{}
+		return pluginapi.RequestInterceptResponse{Body: append(req.Body, []byte("|old")...)}, nil
+	})
+	newPlugin := validTestPlugin("alpha")
+	newPlugin.Capabilities.RequestInterceptor = requestInterceptorFunc(func(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+		return pluginapi.RequestInterceptResponse{Body: append(req.Body, []byte("|new")...)}, nil
+	})
+
+	loader := newTestSymbolLoader()
+	loader.lookups["alpha"] = newTestSymbolLookup(&testPlugin{registerResult: oldPlugin})
+	host := NewForTest(loader)
+	t.Cleanup(host.ShutdownAll)
+	pluginsDir, _ := makeVersionedPluginDir(t, "alpha", "1.0.0")
+	host.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"alpha": enabledPluginConfigWithStoreVersion(t, "1.0.0"),
+		},
+	}})
+	host.fusePlugin(host.activeRecords()[0], "test", "fused old plugin")
+
+	loader.lookups["alpha"] = newTestSymbolLookup(&testPlugin{registerResult: newPlugin})
+	writeVersionedPluginFile(t, pluginsDir, "alpha", "2.0.0")
+	blockerStarted := make(chan struct{})
+	releaseBlocker := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseBlocker) }) }
+	t.Cleanup(release)
+	blockerLookup := newTestSymbolLookup(&testPlugin{registerResult: validTestPlugin("zeta")})
+	blockerLookup.registerOverride = func([]byte) pluginapi.Plugin {
+		close(blockerStarted)
+		<-releaseBlocker
+		return validTestPlugin("zeta")
+	}
+	loader.lookups["zeta"] = blockerLookup
+	writeVersionedPluginFile(t, pluginsDir, "zeta", "1.0.0")
+	replacementConfig := &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"alpha": enabledPluginConfigWithStoreVersion(t, "2.0.0"),
+			"zeta":  enabledPluginConfigWithStoreVersion(t, "1.0.0"),
+		},
+	}}
+
+	applyDone := make(chan struct{})
+	go func() {
+		host.ApplyConfig(context.Background(), replacementConfig)
+		close(applyDone)
+	}()
+	waitForHostTestSignal(t, blockerStarted, "replacement snapshot barrier")
+
+	got := host.InterceptRequestBeforeAuth(context.Background(), pluginapi.RequestInterceptRequest{Body: []byte("request")})
+	if string(got.Body) != "request" {
+		t.Fatalf("old fused plugin response body = %q, want unchanged request", got.Body)
+	}
+	select {
+	case <-oldCalled:
+		t.Fatal("old fused plugin was invoked before replacement snapshot commit")
+	default:
+	}
+
+	release()
+	waitForHostTestSignal(t, applyDone, "replacement ApplyConfig completion")
+	if host.isPluginFused("alpha") {
+		t.Fatal("old fuse marker remained after replacement snapshot commit")
+	}
+	got = host.InterceptRequestBeforeAuth(context.Background(), pluginapi.RequestInterceptRequest{Body: []byte("request")})
+	if string(got.Body) != "request|new" {
+		t.Fatalf("replacement response body = %q, want %q", got.Body, "request|new")
+	}
+}
+
+func TestUnversionedReconfigurePanicFusesPinnedStreamIdentity(t *testing.T) {
+	var calls []int
+	plugin := &testPlugin{registerResult: validTestPlugin("privacy"), panicOnReload: true}
+	plugin.registerResult.Capabilities.StreamChunkInterceptor = responseInterceptorFunc{
+		interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+			calls = append(calls, req.ChunkIndex)
+			return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+		},
+	}
+	plugin.registerResult.Capabilities.StreamChunkInterceptorStateful = true
+
+	loader := newTestSymbolLoader()
+	loader.lookups["privacy"] = newTestSymbolLookup(plugin)
+	host := NewForTest(loader)
+	t.Cleanup(host.ShutdownAll)
+	cfg := &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     makePluginDir(t, "privacy"),
+		Configs: enabledPluginConfigs("privacy"),
+	}}
+	host.ApplyConfig(context.Background(), cfg)
+	records := host.activeRecords()
+	if len(records) != 1 {
+		t.Fatalf("active records = %d, want 1", len(records))
+	}
+	if records[0].version != "1.0.0" {
+		t.Errorf("unversioned plugin identity version = %q, want metadata version %q", records[0].version, "1.0.0")
+	}
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+	host.ApplyConfig(context.Background(), cfg)
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("skipped"),
+		ChunkIndex: 0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if fmt.Sprint(calls) != "[-1 -2]" {
+		t.Fatalf("pinned plugin calls = %v, want init and cleanup only after Reconfigure panic", calls)
+	}
+}
+
+func TestStreamInterceptorSessionRemembersPinnedIdentityFuseAcrossReload(t *testing.T) {
+	var oldCalls []int
+	host := newHostWithRecords(capabilityRecord{
+		id:      "privacy",
+		path:    "testdata/privacy-v1.plugin",
+		version: "v1",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					oldCalls = append(oldCalls, req.ChunkIndex)
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+	host.fusePlugin(host.activeRecords()[0], "test", "fused v1")
+	setHostSnapshotForTest(host, true, capabilityRecord{
+		id:      "privacy",
+		path:    "testdata/privacy-v2.plugin",
+		version: "v2",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+	if host.isPluginFused("privacy") {
+		t.Fatal("old identity fuse remained attached to the replacement")
+	}
+
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("skipped"),
+		ChunkIndex: 0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if fmt.Sprint(oldCalls) != "[-1 -2]" {
+		t.Fatalf("pinned plugin calls = %v, want init and cleanup only after fused identity reload", oldCalls)
+	}
+}
+
+func TestStreamInterceptorSessionPreservesCleanupAfterPayloadErrorAndFuse(t *testing.T) {
+	var calls []int
+	host := newHostWithRecords(capabilityRecord{
+		id: "stateful",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					calls = append(calls, req.ChunkIndex)
+					if req.ChunkIndex == 0 {
+						return pluginapi.StreamChunkInterceptResponse{}, errors.New("payload failed")
+					}
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("payload"),
+		ChunkIndex: 0,
+	})
+	host.mu.Lock()
+	host.fused["stateful"] = "fused after payload error"
+	host.mu.Unlock()
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if fmt.Sprint(calls) != "[-1 0 -2]" {
+		t.Fatalf("interceptor calls = %v, want init, failed payload, and one best-effort end", calls)
+	}
+}
+
+func TestStreamInterceptorSessionPreservesStateAfterPayloadError(t *testing.T) {
+	var calls []pluginapi.StreamChunkInterceptRequest
+	host := newHostWithRecords(capabilityRecord{
+		id: "stateful",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					calls = append(calls, req)
+					if req.ChunkIndex == 0 {
+						return pluginapi.StreamChunkInterceptResponse{}, errors.New("payload failed")
+					}
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("failed payload"),
+		ChunkIndex: 0,
+	})
+	if !session.CanOmitHeavyFields() {
+		t.Error("CanOmitHeavyFields() = false after transient payload error")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("next payload"),
+		ChunkIndex: 1,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+
+	if len(calls) != 4 {
+		t.Fatalf("calls = %d, want init, failed payload, next payload, and end", len(calls))
+	}
+	for i, req := range calls {
+		if req.StreamID != "stream-1" {
+			t.Errorf("call %d StreamID = %q, want stream-1", i, req.StreamID)
+		}
+	}
+}
+
+func TestStreamInterceptorSessionMetadataIsolation(t *testing.T) {
+	t.Run("RPC defers isolation to serialization", func(t *testing.T) {
+		host := New()
+		client := newGuardedPluginClient(&capturePluginClient{})
+		adapter := &rpcPluginAdapter{id: "rpc", host: host, client: client}
+		setHostSnapshotForTest(host, true, capabilityRecord{
+			id: "rpc",
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: adapter,
+			}},
+		})
+
+		probe := &metadataMarshalProbe{}
+		session := host.OpenStreamChunkInterceptorSession("")
+		session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+			Metadata:   map[string]any{"probe": probe},
+			ChunkIndex: 0,
+		})
+		session.Close()
+
+		if !probe.called {
+			t.Fatal("RPC metadata was cloned before serialization")
+		}
+	})
+
+	t.Run("local interceptor receives isolated metadata", func(t *testing.T) {
+		metadata := map[string]any{
+			"nested": map[string]any{"value": "original"},
+		}
+		host := newHostWithRecords(capabilityRecord{
+			id: "local",
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						req.Metadata["added"] = true
+						req.Metadata["nested"].(map[string]any)["value"] = "mutated"
+						return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+					},
+				},
+			}},
+		})
+
+		session := host.OpenStreamChunkInterceptorSession("")
+		session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+			Metadata:   metadata,
+			ChunkIndex: 0,
+		})
+		session.Close()
+
+		if _, added := metadata["added"]; added {
+			t.Fatal("local interceptor mutated top-level metadata")
+		}
+		if got := metadata["nested"].(map[string]any)["value"]; got != "original" {
+			t.Fatalf("nested metadata value = %v, want original", got)
+		}
+	})
+}
+
+func TestStreamInterceptorSessionInitFailureForcesLegacyPayload(t *testing.T) {
+	var calls []pluginapi.StreamChunkInterceptRequest
+	host := newHostWithRecords(capabilityRecord{
+		id: "stateful",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					calls = append(calls, req)
+					if req.ChunkIndex == pluginapi.StreamChunkHeaderInitIndex {
+						return pluginapi.StreamChunkInterceptResponse{}, errors.New("init failed")
+					}
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:    "stream-1",
+		RequestBody: []byte("request"),
+		ChunkIndex:  pluginapi.StreamChunkHeaderInitIndex,
+	})
+	if session.CanOmitHeavyFields() {
+		t.Fatal("CanOmitHeavyFields() = true after failed initialization")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:        "stream-1",
+		OriginalRequest: []byte("original"),
+		RequestBody:     []byte("request"),
+		Body:            []byte("chunk"),
+		HistoryChunks:   [][]byte{[]byte("previous")},
+		ChunkIndex:      0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+
+	if len(calls) != 3 {
+		t.Fatalf("calls = %d, want init, payload, and end", len(calls))
+	}
+	for i, call := range calls {
+		if call.StreamID != "stream-1" {
+			t.Fatalf("call %d StreamID = %q, want stream-1", i, call.StreamID)
+		}
+	}
+	if string(calls[1].RequestBody) != "request" || string(calls[1].OriginalRequest) != "original" || len(calls[1].HistoryChunks) != 1 {
+		t.Fatalf("fallback payload heavy fields = %#v", calls[1])
+	}
+}
+
+func TestStreamInterceptorSessionIgnoresDropChunkDuringLifecycleCalls(t *testing.T) {
+	var highCalls []int
+	var lowCalls []int
+	host := newHostWithRecords(
+		capabilityRecord{
+			id:       "high",
+			priority: 20,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						highCalls = append(highCalls, req.ChunkIndex)
+						return pluginapi.StreamChunkInterceptResponse{Body: req.Body, DropChunk: true}, nil
+					},
+				},
+				StreamChunkInterceptorStateful: true,
+			}},
+		},
+		capabilityRecord{
+			id:       "low",
+			priority: 10,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						lowCalls = append(lowCalls, req.ChunkIndex)
+						return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+					},
+				},
+				StreamChunkInterceptorStateful: true,
+			}},
+		},
+	)
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	initResp := session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+	if initResp.DropChunk {
+		t.Fatal("header initialization propagated DropChunk")
+	}
+	payloadResp := session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("chunk"),
+		ChunkIndex: 0,
+	})
+	if !payloadResp.DropChunk {
+		t.Fatal("payload DropChunk = false, want true")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+
+	if fmt.Sprint(highCalls) != "[-1 0 -2]" {
+		t.Fatalf("high-priority calls = %v, want lifecycle and payload calls", highCalls)
+	}
+	if fmt.Sprint(lowCalls) != "[-1 -2]" {
+		t.Fatalf("low-priority calls = %v, want init and end despite DropChunk", lowCalls)
+	}
+}
+
+func TestStreamInterceptorSessionDisablesPanickingRecordLocally(t *testing.T) {
+	panicCalls := 0
+	var fallbackCalls []int
+	host := newHostWithRecords(
+		capabilityRecord{
+			id:       "panic",
+			priority: 20,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						panicCalls++
+						panic("stream interceptor panic")
+					},
+				},
+				StreamChunkInterceptorStateful: true,
+			}},
+		},
+		capabilityRecord{
+			id:       "fallback",
+			priority: 10,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						fallbackCalls = append(fallbackCalls, req.ChunkIndex)
+						return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+					},
+				},
+				StreamChunkInterceptorStateful: true,
+			}},
+		},
+	)
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:    "stream-1",
+		RequestBody: []byte("request"),
+		ChunkIndex:  pluginapi.StreamChunkHeaderInitIndex,
+	})
+	if session.CanOmitHeavyFields() {
+		t.Fatal("CanOmitHeavyFields() = true after one pinned interceptor panicked")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:    "stream-1",
+		RequestBody: []byte("request"),
+		Body:        []byte("chunk"),
+		ChunkIndex:  0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if panicCalls != 1 {
+		t.Fatalf("panicking interceptor calls = %d, want 1 before local disable", panicCalls)
+	}
+	if fmt.Sprint(fallbackCalls) != "[-1 0 -2]" {
+		t.Fatalf("fallback interceptor calls = %v, want [-1 0 -2]", fallbackCalls)
+	}
+}
+
+func TestStreamInterceptorSessionEndsRecordDisabledAfterPayloadPanic(t *testing.T) {
+	var calls []int
+	host := newHostWithRecords(capabilityRecord{
+		id: "panic",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					calls = append(calls, req.ChunkIndex)
+					if req.ChunkIndex == 0 {
+						panic("stream payload panic")
+					}
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:    "stream-1",
+		RequestBody: []byte("request"),
+		ChunkIndex:  pluginapi.StreamChunkHeaderInitIndex,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("panic"),
+		ChunkIndex: 0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("skipped"),
+		ChunkIndex: 1,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if fmt.Sprint(calls) != "[-1 0 -2]" {
+		t.Fatalf("interceptor calls = %v, want init, panicking payload, and one best-effort end", calls)
+	}
+}
+
+func TestStreamInterceptorSessionEndsRecordDisabledAfterRetryInitPanic(t *testing.T) {
+	var calls []int
+	initCalls := 0
+	host := newHostWithRecords(capabilityRecord{
+		id: "panic",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					calls = append(calls, req.ChunkIndex)
+					if req.ChunkIndex == pluginapi.StreamChunkHeaderInitIndex {
+						initCalls++
+						if initCalls == 2 {
+							panic("retry stream init panic")
+						}
+					}
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	for range 2 {
+		session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+			StreamID:    "stream-1",
+			RequestBody: []byte("request"),
+			ChunkIndex:  pluginapi.StreamChunkHeaderInitIndex,
+		})
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("skipped"),
+		ChunkIndex: 0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if fmt.Sprint(calls) != "[-1 -1 -2]" {
+		t.Fatalf("interceptor calls = %v, want initial init, panicking retry init, and one best-effort end", calls)
+	}
+}
+
 func TestHasStreamInterceptorsReflectsActiveStreamInterceptors(t *testing.T) {
 	requestOnly := newHostWithRecords(capabilityRecord{
 		id: "request",
@@ -3152,6 +4659,61 @@ func normalizeTestCapabilityRecords(records []capabilityRecord) []capabilityReco
 type stringSliceAlias []string
 
 type mapSliceAlias []map[string]string
+
+type blockingStreamPluginClient struct {
+	callStarted  chan<- struct{}
+	releaseCall  <-chan struct{}
+	shutdownDone chan<- struct{}
+}
+
+func (c *blockingStreamPluginClient) Call(ctx context.Context, method string, request []byte) ([]byte, error) {
+	close(c.callStarted)
+	<-c.releaseCall
+	return marshalRPCResult(pluginapi.StreamChunkInterceptResponse{
+		Headers:   http.Header{"X-Plugin": []string{"mutated"}},
+		Body:      []byte("mutated"),
+		DropChunk: true,
+	})
+}
+
+func (c *blockingStreamPluginClient) Shutdown() {
+	close(c.shutdownDone)
+}
+
+type orderedStreamPluginClient struct {
+	mu             sync.Mutex
+	calls          int
+	payloadStarted chan<- struct{}
+	endStarted     chan<- struct{}
+	releasePayload <-chan struct{}
+}
+
+func (c *orderedStreamPluginClient) Call(context.Context, string, []byte) ([]byte, error) {
+	c.mu.Lock()
+	c.calls++
+	call := c.calls
+	c.mu.Unlock()
+
+	switch call {
+	case 2:
+		close(c.payloadStarted)
+		<-c.releasePayload
+	case 3:
+		close(c.endStarted)
+	}
+	return marshalRPCResult(pluginapi.StreamChunkInterceptResponse{})
+}
+
+func (*orderedStreamPluginClient) Shutdown() {}
+
+type metadataMarshalProbe struct {
+	called bool
+}
+
+func (p *metadataMarshalProbe) MarshalJSON() ([]byte, error) {
+	p.called = true
+	return []byte(`"probe"`), nil
+}
 
 type requestNormalizerFunc func(context.Context, pluginapi.RequestTransformRequest) (pluginapi.PayloadResponse, error)
 

--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1644,6 +1645,1592 @@ func TestStreamInterceptorsDropChunkStopsChain(t *testing.T) {
 	}
 }
 
+func TestStreamInterceptorSessionRoutesMixedLifecyclePerPlugin(t *testing.T) {
+	var statefulCalls []pluginapi.StreamChunkInterceptRequest
+	var legacyCalls []pluginapi.StreamChunkInterceptRequest
+	host := newHostWithRecords(
+		capabilityRecord{
+			id:       "stateful",
+			priority: 20,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						statefulCalls = append(statefulCalls, req)
+						return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+					},
+				},
+				StreamChunkInterceptorStateful: true,
+			}},
+		},
+		capabilityRecord{
+			id:       "legacy",
+			priority: 10,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						legacyCalls = append(legacyCalls, req)
+						return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+					},
+				},
+			}},
+		},
+	)
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	if session == nil {
+		t.Fatal("OpenStreamChunkInterceptorSession() = nil, want active session")
+	}
+	initReq := pluginapi.StreamChunkInterceptRequest{
+		StreamID:        "stream-1",
+		OriginalRequest: []byte("original"),
+		RequestBody:     []byte("request"),
+		ChunkIndex:      pluginapi.StreamChunkHeaderInitIndex,
+	}
+	session.InterceptStreamChunk(context.Background(), initReq)
+	if session.CanOmitHeavyFields() {
+		t.Fatal("CanOmitHeavyFields() = true, want false for mixed stateful and legacy interceptors")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:        "stream-1",
+		OriginalRequest: []byte("original"),
+		RequestBody:     []byte("request"),
+		Body:            []byte("chunk"),
+		HistoryChunks:   [][]byte{[]byte("previous")},
+		ChunkIndex:      0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+
+	if len(statefulCalls) != 3 {
+		t.Fatalf("stateful calls = %d, want init, payload, and end", len(statefulCalls))
+	}
+	for i, req := range statefulCalls {
+		if req.StreamID != "stream-1" {
+			t.Fatalf("stateful call %d StreamID = %q, want stream-1", i, req.StreamID)
+		}
+	}
+	if len(legacyCalls) != 2 {
+		t.Fatalf("legacy calls = %d, want init and payload only", len(legacyCalls))
+	}
+	for i, req := range legacyCalls {
+		if req.StreamID != "" {
+			t.Fatalf("legacy call %d StreamID = %q, want empty", i, req.StreamID)
+		}
+		if string(req.RequestBody) != "request" || string(req.OriginalRequest) != "original" {
+			t.Fatalf("legacy call %d heavy fields = request %q original %q", i, req.RequestBody, req.OriginalRequest)
+		}
+	}
+	if len(legacyCalls[1].HistoryChunks) != 1 || string(legacyCalls[1].HistoryChunks[0]) != "previous" {
+		t.Fatalf("legacy payload history = %#v, want previous chunk", legacyCalls[1].HistoryChunks)
+	}
+}
+
+func TestStreamInterceptorSessionPreservesSchemaRequestBodyPolicy(t *testing.T) {
+	var legacyGot, modernGot pluginapi.StreamChunkInterceptRequest
+	host := newHostWithRecords(
+		capabilityRecord{
+			id:       "stateful",
+			priority: 30,
+			plugin: pluginapi.Plugin{
+				SchemaVersion: pluginabi.SchemaVersionStreamChunkOmitRequestBody,
+				Capabilities: pluginapi.Capabilities{
+					StreamChunkInterceptor: responseInterceptorFunc{
+						interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+							return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+						},
+					},
+					StreamChunkInterceptorStateful: true,
+				},
+			},
+		},
+		capabilityRecord{
+			id:       "modern",
+			priority: 20,
+			plugin: pluginapi.Plugin{
+				SchemaVersion: pluginabi.SchemaVersionStreamChunkOmitRequestBody,
+				Capabilities: pluginapi.Capabilities{
+					StreamChunkInterceptor: responseInterceptorFunc{
+						interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+							modernGot = req
+							return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+						},
+					},
+				},
+			},
+		},
+		capabilityRecord{
+			id:       "legacy",
+			priority: 10,
+			plugin: pluginapi.Plugin{
+				SchemaVersion: 2,
+				Capabilities: pluginapi.Capabilities{
+					StreamChunkInterceptor: responseInterceptorFunc{
+						interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+							legacyGot = req
+							return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+						},
+					},
+				},
+			},
+		},
+	)
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	if session == nil {
+		t.Fatal("OpenStreamChunkInterceptorSession() = nil, want active session")
+	}
+	t.Cleanup(session.Close)
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:        "stream-1",
+		OriginalRequest: []byte("original"),
+		RequestBody:     []byte("request"),
+		ChunkIndex:      pluginapi.StreamChunkHeaderInitIndex,
+	})
+	if session.CanOmitHeavyFields() {
+		t.Fatal("CanOmitHeavyFields() = true, want false while schema 2 interceptor is active")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:        "stream-1",
+		OriginalRequest: []byte("original"),
+		RequestBody:     []byte("request"),
+		Body:            []byte("chunk"),
+		ChunkIndex:      0,
+	})
+
+	if string(legacyGot.OriginalRequest) != "original" || string(legacyGot.RequestBody) != "request" {
+		t.Fatalf("legacy payload bodies = original:%q body:%q, want preserved", legacyGot.OriginalRequest, legacyGot.RequestBody)
+	}
+	if len(modernGot.OriginalRequest) != 0 || len(modernGot.RequestBody) != 0 {
+		t.Fatalf("modern payload bodies = original:%q body:%q, want omitted", modernGot.OriginalRequest, modernGot.RequestBody)
+	}
+}
+
+func TestLegacyRPCStreamInterceptorSessionReturnsOnContextCancellation(t *testing.T) {
+	callStarted := make(chan struct{})
+	releaseCall := make(chan struct{})
+	shutdownDone := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseCall) })
+	}
+
+	inner := &blockingStreamPluginClient{
+		callStarted:  callStarted,
+		releaseCall:  releaseCall,
+		shutdownDone: shutdownDone,
+	}
+	guarded := newGuardedPluginClient(inner)
+	host := New()
+	adapter := &rpcPluginAdapter{id: "legacy", host: host, client: guarded}
+	setHostSnapshotForTest(host, true, capabilityRecord{
+		id: "legacy",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: adapter,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	if session == nil {
+		t.Fatal("OpenStreamChunkInterceptorSession() = nil, want active session")
+	}
+	t.Cleanup(func() {
+		release()
+		session.Close()
+		guarded.Shutdown()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan pluginapi.StreamChunkInterceptResponse, 1)
+	go func() {
+		result <- session.InterceptStreamChunk(ctx, pluginapi.StreamChunkInterceptRequest{
+			ResponseHeaders: http.Header{"X-Original": []string{"true"}},
+			Body:            []byte("original"),
+			ChunkIndex:      0,
+		})
+	}()
+	waitForHostTestSignal(t, callStarted, "legacy stream interceptor RPC call")
+	cancel()
+
+	select {
+	case got := <-result:
+		if string(got.Body) != "original" || got.Headers.Get("X-Original") != "true" || got.DropChunk {
+			t.Fatalf("result after cancellation = %#v, want original passthrough", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("legacy stream interceptor session did not return after context cancellation")
+	}
+
+	release()
+	guarded.Shutdown()
+	waitForHostTestSignal(t, shutdownDone, "legacy plugin client shutdown")
+}
+
+func TestStreamInterceptorSessionPinsRecordsAcrossReload(t *testing.T) {
+	var oldCalls []int
+	var replacementCalls []int
+	host := newHostWithRecords(capabilityRecord{
+		id:      "privacy",
+		path:    "testdata/privacy-v1.plugin",
+		version: "v1",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					oldCalls = append(oldCalls, req.ChunkIndex)
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:    "stream-1",
+		RequestBody: []byte("request"),
+		ChunkIndex:  pluginapi.StreamChunkHeaderInitIndex,
+	})
+	if !session.CanOmitHeavyFields() {
+		t.Fatal("CanOmitHeavyFields() = false, want true after successful stateful initialization")
+	}
+
+	setHostSnapshotForTest(host, true, capabilityRecord{
+		id:      "privacy",
+		path:    "testdata/privacy-v2.plugin",
+		version: "v2",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					replacementCalls = append(replacementCalls, req.ChunkIndex)
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("chunk"),
+		ChunkIndex: 0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+
+	if fmt.Sprint(oldCalls) != "[-1 0 -2]" {
+		t.Fatalf("pinned plugin calls = %v, want [-1 0 -2]", oldCalls)
+	}
+	if len(replacementCalls) != 0 {
+		t.Fatalf("replacement plugin calls = %v, want none for existing session", replacementCalls)
+	}
+}
+
+func TestStreamInterceptorSessionUsesCurrentLegacyRecordAfterReload(t *testing.T) {
+	var oldCalls []int
+	var replacementCalls []int
+	host := newHostWithRecords(capabilityRecord{
+		id:      "legacy",
+		path:    "testdata/legacy-v1.plugin",
+		version: "v1",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					oldCalls = append(oldCalls, req.ChunkIndex)
+					return pluginapi.StreamChunkInterceptResponse{Body: append(req.Body, []byte("|v1")...)}, nil
+				},
+			},
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	if session == nil {
+		t.Fatal("OpenStreamChunkInterceptorSession() = nil, want active legacy session")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		RequestBody: []byte("request"),
+		ChunkIndex:  pluginapi.StreamChunkHeaderInitIndex,
+	})
+
+	setHostSnapshotForTest(host, true, capabilityRecord{
+		id:      "legacy",
+		path:    "testdata/legacy-v2.plugin",
+		version: "v2",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					replacementCalls = append(replacementCalls, req.ChunkIndex)
+					return pluginapi.StreamChunkInterceptResponse{Body: append(req.Body, []byte("|v2")...)}, nil
+				},
+			},
+		}},
+	})
+	got := session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		RequestBody: []byte("request"),
+		Body:        []byte("chunk"),
+		ChunkIndex:  0,
+	})
+
+	if fmt.Sprint(oldCalls) != "[-1]" {
+		t.Fatalf("retired legacy calls = %v, want header init only", oldCalls)
+	}
+	if fmt.Sprint(replacementCalls) != "[0]" {
+		t.Fatalf("replacement legacy calls = %v, want payload only", replacementCalls)
+	}
+	if string(got.Body) != "chunk|v2" {
+		t.Fatalf("payload body = %q, want replacement output", got.Body)
+	}
+}
+
+func TestStreamInterceptorSessionDefersNewLegacyRecordAfterOmissionDecision(t *testing.T) {
+	statefulRecord := capabilityRecord{
+		id:      "stateful",
+		path:    "testdata/stateful.plugin",
+		version: "v1",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	}
+	host := newHostWithRecords(statefulRecord)
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:    "stream-1",
+		RequestBody: []byte("request"),
+		ChunkIndex:  pluginapi.StreamChunkHeaderInitIndex,
+	})
+	if !session.CanOmitHeavyFields() {
+		t.Fatal("CanOmitHeavyFields() = false, want true before legacy plugin loads")
+	}
+
+	var legacyRequests []pluginapi.StreamChunkInterceptRequest
+	setHostSnapshotForTest(host, true, statefulRecord, capabilityRecord{
+		id:      "legacy",
+		path:    "testdata/legacy.plugin",
+		version: "v1",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					legacyRequests = append(legacyRequests, req)
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+		}},
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("omitted-fields"),
+		ChunkIndex: 0,
+	})
+	if len(legacyRequests) != 0 {
+		t.Fatalf("legacy calls after omission decision = %d, want 0", len(legacyRequests))
+	}
+
+	if session.CanOmitHeavyFields() {
+		t.Fatal("CanOmitHeavyFields() = true, want false after legacy plugin loads")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:        "stream-1",
+		OriginalRequest: []byte("original"),
+		RequestBody:     []byte("request"),
+		HistoryChunks:   [][]byte{[]byte("history")},
+		Body:            []byte("full-fields"),
+		ChunkIndex:      1,
+	})
+	if len(legacyRequests) != 1 {
+		t.Fatalf("legacy calls after fields restored = %d, want 1", len(legacyRequests))
+	}
+	if string(legacyRequests[0].OriginalRequest) != "original" || string(legacyRequests[0].RequestBody) != "request" || len(legacyRequests[0].HistoryChunks) != 1 || string(legacyRequests[0].HistoryChunks[0]) != "history" {
+		t.Fatalf("legacy request heavy fields = %#v, want restored request data", legacyRequests[0])
+	}
+}
+
+func TestStreamInterceptorSessionCloseReturnsBeforeInflightRPCCall(t *testing.T) {
+	callStarted := make(chan struct{})
+	releaseCall := make(chan struct{})
+	shutdownDone := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseCall) })
+	}
+	t.Cleanup(release)
+
+	inner := &blockingStreamPluginClient{
+		callStarted:  callStarted,
+		releaseCall:  releaseCall,
+		shutdownDone: shutdownDone,
+	}
+	guarded := newGuardedPluginClient(inner)
+	host := New()
+	adapter := &rpcPluginAdapter{id: "blocking", host: host, client: guarded}
+	setHostSnapshotForTest(host, true, capabilityRecord{
+		id: "blocking",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor:         adapter,
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	if session == nil {
+		t.Fatal("OpenStreamChunkInterceptorSession() = nil, want active session")
+	}
+	result := make(chan pluginapi.StreamChunkInterceptResponse, 1)
+	go func() {
+		result <- session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+			ResponseHeaders: http.Header{"X-Original": []string{"true"}},
+			Body:            []byte("original"),
+			ChunkIndex:      0,
+		})
+	}()
+	waitForHostTestSignal(t, callStarted, "stream interceptor RPC call")
+
+	guarded.Shutdown()
+	closeDone := make(chan struct{})
+	go func() {
+		session.Close()
+		close(closeDone)
+	}()
+	closedBeforeRelease := false
+	select {
+	case <-closeDone:
+		closedBeforeRelease = true
+	case <-time.After(time.Second):
+		t.Error("Close() blocked behind an in-flight RPC call")
+	}
+
+	release()
+	if !closedBeforeRelease {
+		waitForHostTestSignal(t, closeDone, "session close after RPC release")
+	}
+	var got pluginapi.StreamChunkInterceptResponse
+	select {
+	case got = <-result:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stream interceptor result")
+	}
+	if string(got.Body) != "original" || got.Headers.Get("X-Original") != "true" || got.DropChunk {
+		t.Fatalf("result after Close() = %#v, want original passthrough", got)
+	}
+	waitForHostTestSignal(t, shutdownDone, "deferred plugin client shutdown")
+}
+
+func TestStreamInterceptorSessionCallAfterCloseBypassesInflightRPCCall(t *testing.T) {
+	callStarted := make(chan struct{})
+	releaseCall := make(chan struct{})
+	shutdownDone := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseCall) })
+	}
+	t.Cleanup(release)
+
+	inner := &blockingStreamPluginClient{
+		callStarted:  callStarted,
+		releaseCall:  releaseCall,
+		shutdownDone: shutdownDone,
+	}
+	guarded := newGuardedPluginClient(inner)
+	host := New()
+	adapter := &rpcPluginAdapter{id: "blocking", host: host, client: guarded}
+	setHostSnapshotForTest(host, true, capabilityRecord{
+		id: "blocking",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor:         adapter,
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	firstResult := make(chan pluginapi.StreamChunkInterceptResponse, 1)
+	go func() {
+		firstResult <- session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+			Body:       []byte("first"),
+			ChunkIndex: 0,
+		})
+	}()
+	waitForHostTestSignal(t, callStarted, "first stream interceptor RPC call")
+
+	guarded.Shutdown()
+	session.Close()
+	secondResult := make(chan pluginapi.StreamChunkInterceptResponse, 1)
+	go func() {
+		secondResult <- session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+			ResponseHeaders: http.Header{"X-Original": []string{"true"}},
+			Body:            []byte("second"),
+			ChunkIndex:      1,
+		})
+	}()
+
+	select {
+	case got := <-secondResult:
+		if string(got.Body) != "second" || got.Headers.Get("X-Original") != "true" || got.DropChunk {
+			t.Fatalf("call after Close() = %#v, want original passthrough", got)
+		}
+	case <-time.After(time.Second):
+		t.Error("call after Close() blocked behind an earlier in-flight RPC call")
+	}
+
+	release()
+	select {
+	case <-firstResult:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first stream interceptor result")
+	}
+	waitForHostTestSignal(t, shutdownDone, "deferred plugin client shutdown")
+}
+
+func TestStreamInterceptorSessionWaitsForInflightRPCBeforeEnd(t *testing.T) {
+	payloadStarted := make(chan struct{})
+	endStarted := make(chan struct{})
+	releasePayload := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releasePayload) })
+	}
+	t.Cleanup(release)
+
+	inner := &orderedStreamPluginClient{
+		payloadStarted: payloadStarted,
+		endStarted:     endStarted,
+		releasePayload: releasePayload,
+	}
+	host := New()
+	adapter := &rpcPluginAdapter{id: "ordered", host: host, client: newGuardedPluginClient(inner)}
+	setHostSnapshotForTest(host, true, capabilityRecord{
+		id: "ordered",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor:         adapter,
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	t.Cleanup(session.Close)
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+
+	payloadCtx, cancelPayload := context.WithCancel(context.Background())
+	payloadDone := make(chan struct{})
+	go func() {
+		session.InterceptStreamChunk(payloadCtx, pluginapi.StreamChunkInterceptRequest{
+			StreamID:   "stream-1",
+			Body:       []byte("payload"),
+			ChunkIndex: 0,
+		})
+		close(payloadDone)
+	}()
+	waitForHostTestSignal(t, payloadStarted, "stateful payload RPC call")
+	cancelPayload()
+
+	endDone := make(chan struct{})
+	go func() {
+		session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+			StreamID:   "stream-1",
+			ChunkIndex: pluginapi.StreamChunkEndIndex,
+		})
+		close(endDone)
+	}()
+
+	select {
+	case <-endStarted:
+		t.Fatal("stream end entered the plugin before the canceled payload RPC exited")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	release()
+	waitForHostTestSignal(t, payloadDone, "stateful payload completion")
+	waitForHostTestSignal(t, endStarted, "stateful stream end RPC call")
+	waitForHostTestSignal(t, endDone, "stateful stream end completion")
+}
+
+func TestStreamInterceptorSessionSkipsCurrentPluginAfterExternalFuse(t *testing.T) {
+	var calls []int
+	host := newHostWithRecords(capabilityRecord{
+		id: "stateful",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					calls = append(calls, req.ChunkIndex)
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+	host.mu.Lock()
+	host.fused["stateful"] = "fused by concurrent request"
+	host.mu.Unlock()
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("skipped"),
+		ChunkIndex: 0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if fmt.Sprint(calls) != "[-1 -2]" {
+		t.Fatalf("interceptor calls = %v, want init and one best-effort end after external fuse", calls)
+	}
+}
+
+func TestStreamInterceptorSessionIgnoresFuseForReplacementIdentity(t *testing.T) {
+	var oldCalls []int
+	host := newHostWithRecords(capabilityRecord{
+		id:      "privacy",
+		path:    "testdata/privacy-v1.plugin",
+		version: "v1",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					oldCalls = append(oldCalls, req.ChunkIndex)
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+	setHostSnapshotForTest(host, true, capabilityRecord{
+		id:      "privacy",
+		path:    "testdata/privacy-v2.plugin",
+		version: "v2",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+	host.mu.Lock()
+	host.fused["privacy"] = "replacement fused"
+	host.mu.Unlock()
+
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("chunk"),
+		ChunkIndex: 0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if fmt.Sprint(oldCalls) != "[-1 0 -2]" {
+		t.Fatalf("pinned plugin calls = %v, want old identity to ignore replacement fuse", oldCalls)
+	}
+}
+
+func TestSafePluginCallDoesNotFuseActivePluginForReplacementPanic(t *testing.T) {
+	host := newHostWithRecords(capabilityRecord{
+		id:      "privacy",
+		path:    "testdata/privacy-v1.plugin",
+		version: "v1",
+	})
+	replacement := &loadedPlugin{
+		id:      "privacy",
+		path:    "testdata/privacy-v2.plugin",
+		version: "v2",
+	}
+
+	if _, ok := host.safePluginCall(context.Background(), replacement, "register", func() pluginapi.Plugin {
+		panic("replacement registration panic")
+	}); ok {
+		t.Fatal("safePluginCall returned ok=true for a panicking register")
+	}
+
+	host.mu.Lock()
+	_, activeFused := host.fused["privacy"]
+	oldEpoch := host.fusedIdentities[makePluginIdentityKey("privacy", "testdata/privacy-v1.plugin", "v1")]
+	replacementEpoch := host.fusedIdentities[makePluginIdentityKey("privacy", replacement.path, replacement.version)]
+	host.mu.Unlock()
+	if activeFused {
+		t.Fatal("replacement register panic fused the active plugin")
+	}
+	if oldEpoch != 0 {
+		t.Fatalf("active identity fuse epoch = %d, want 0", oldEpoch)
+	}
+	if replacementEpoch == 0 {
+		t.Fatal("replacement identity fuse epoch was not advanced")
+	}
+}
+
+func TestStreamInterceptorSessionSurvivesFailedReplacementApplyConfig(t *testing.T) {
+	var oldCalls []int
+	oldPlugin := validTestPlugin("privacy")
+	oldPlugin.Capabilities = pluginapi.Capabilities{
+		StreamChunkInterceptor: responseInterceptorFunc{
+			interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+				oldCalls = append(oldCalls, req.ChunkIndex)
+				return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+			},
+		},
+		StreamChunkInterceptorStateful: true,
+	}
+	loader := newTestSymbolLoader()
+	loader.lookups["privacy"] = newTestSymbolLookup(&testPlugin{registerResult: oldPlugin})
+	host := NewForTest(loader)
+	t.Cleanup(host.ShutdownAll)
+	pluginsDir, paths := makeVersionedPluginDir(t, "privacy", "1.0.0")
+	host.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"privacy": enabledPluginConfigWithStoreVersion(t, "1.0.0"),
+		},
+	}})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	if session == nil {
+		t.Fatal("OpenStreamChunkInterceptorSession returned nil")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+
+	loader.lookups["privacy"] = newTestSymbolLookup(&testPlugin{panicOnRegister: true})
+	paths["2.0.0"] = writeVersionedPluginFile(t, pluginsDir, "privacy", "2.0.0")
+	host.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"privacy": enabledPluginConfigWithStoreVersion(t, "2.0.0"),
+		},
+	}})
+
+	host.mu.Lock()
+	_, activeFused := host.fused["privacy"]
+	oldEpoch := host.fusedIdentities[makePluginIdentityKey("privacy", paths["1.0.0"], "1.0.0")]
+	replacementEpoch := host.fusedIdentities[makePluginIdentityKey("privacy", paths["2.0.0"], "2.0.0")]
+	host.mu.Unlock()
+	if activeFused {
+		t.Fatal("failed replacement left the plugin ID fused")
+	}
+	if oldEpoch != 0 {
+		t.Fatalf("old identity fuse epoch = %d, want 0", oldEpoch)
+	}
+	if replacementEpoch == 0 {
+		t.Fatal("replacement identity fuse epoch was not advanced")
+	}
+
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("chunk"),
+		ChunkIndex: 0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if fmt.Sprint(oldCalls) != "[-1 0 -2]" {
+		t.Fatalf("pinned plugin calls = %v, want old identity to survive failed replacement", oldCalls)
+	}
+}
+
+func TestFailedReplacementPreservesPreviousActiveCapabilities(t *testing.T) {
+	oldPlugin := validTestPlugin("privacy")
+	oldPlugin.Capabilities.RequestInterceptor = requestInterceptorFunc(func(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+		return pluginapi.RequestInterceptResponse{Body: append(req.Body, []byte("|v1")...)}, nil
+	})
+	loader := newTestSymbolLoader()
+	loader.lookups["privacy"] = newTestSymbolLookup(&testPlugin{registerResult: oldPlugin})
+	host := NewForTest(loader)
+	t.Cleanup(host.ShutdownAll)
+	pluginsDir, _ := makeVersionedPluginDir(t, "privacy", "1.0.0")
+	initialConfig := &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"privacy": enabledPluginConfigWithStoreVersion(t, "1.0.0"),
+		},
+	}}
+	host.ApplyConfig(context.Background(), initialConfig)
+
+	loader.lookups["privacy"] = newTestSymbolLookup(&testPlugin{panicOnRegister: true})
+	writeVersionedPluginFile(t, pluginsDir, "privacy", "2.0.0")
+	host.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"privacy": enabledPluginConfigWithStoreVersion(t, "2.0.0"),
+		},
+	}})
+
+	got := host.InterceptRequestBeforeAuth(context.Background(), pluginapi.RequestInterceptRequest{Body: []byte("request")})
+	if string(got.Body) != "request|v1" {
+		t.Fatalf("request response after failed replacement = %q, want %q", got.Body, "request|v1")
+	}
+}
+
+func TestFailedReplacementCanRetryAfterFusedPlugin(t *testing.T) {
+	loader := newTestSymbolLoader()
+	loader.lookups["privacy"] = newTestSymbolLookup(&testPlugin{registerResult: validTestPlugin("privacy")})
+	host := NewForTest(loader)
+	t.Cleanup(host.ShutdownAll)
+	pluginsDir, paths := makeVersionedPluginDir(t, "privacy", "1.0.0")
+	host.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"privacy": enabledPluginConfigWithStoreVersion(t, "1.0.0"),
+		},
+	}})
+	host.fusePlugin(host.activeRecords()[0], "test", "fused v1")
+
+	failedShutdown := make(chan struct{})
+	failedLookup := newTestSymbolLookup(&testPlugin{panicOnRegister: true})
+	failedLookup.shutdownDone = failedShutdown
+	loader.lookups["privacy"] = failedLookup
+	paths["2.0.0"] = writeVersionedPluginFile(t, pluginsDir, "privacy", "2.0.0")
+	replacementConfig := &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"privacy": enabledPluginConfigWithStoreVersion(t, "2.0.0"),
+		},
+	}}
+	host.ApplyConfig(context.Background(), replacementConfig)
+
+	host.mu.Lock()
+	loadedPath := host.loaded["privacy"].path
+	host.mu.Unlock()
+	if loadedPath != paths["1.0.0"] {
+		t.Fatalf("loaded plugin path after failed replacement = %q, want old path %q", loadedPath, paths["1.0.0"])
+	}
+	waitForHostTestSignal(t, failedShutdown, "failed replacement shutdown")
+	deadline := time.Now().Add(time.Second)
+	for {
+		host.mu.Lock()
+		_, loading := host.loading["privacy"]
+		host.mu.Unlock()
+		if !loading {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("failed replacement load token was not cleared")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	newPlugin := validTestPlugin("privacy")
+	newPlugin.Capabilities.RequestInterceptor = requestInterceptorFunc(func(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+		return pluginapi.RequestInterceptResponse{Body: append(req.Body, []byte("|v2")...)}, nil
+	})
+	loader.lookups["privacy"] = newTestSymbolLookup(&testPlugin{registerResult: newPlugin})
+	host.ApplyConfig(context.Background(), replacementConfig)
+
+	if loader.openCalls != 3 {
+		t.Fatalf("Open calls = %d, want 3 after retrying replacement", loader.openCalls)
+	}
+	if host.isPluginFused("privacy") {
+		t.Fatal("old fuse marker remained after successful replacement retry")
+	}
+	got := host.InterceptRequestBeforeAuth(context.Background(), pluginapi.RequestInterceptRequest{Body: []byte("request")})
+	if string(got.Body) != "request|v2" {
+		t.Fatalf("replacement response body = %q, want %q", got.Body, "request|v2")
+	}
+}
+
+func TestRuntimePanicAfterReplacementDoesNotFuseReplacement(t *testing.T) {
+	callStarted := make(chan struct{})
+	releaseCall := make(chan struct{})
+	oldPlugin := validTestPlugin("privacy")
+	oldPlugin.Capabilities.RequestInterceptor = requestInterceptorFunc(func(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+		close(callStarted)
+		<-releaseCall
+		panic("retired runtime panic")
+	})
+	newPlugin := validTestPlugin("privacy")
+	newPlugin.Capabilities.RequestInterceptor = requestInterceptorFunc(func(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+		return pluginapi.RequestInterceptResponse{Body: append(req.Body, []byte("|v2")...)}, nil
+	})
+
+	loader := newTestSymbolLoader()
+	loader.lookups["privacy"] = newTestSymbolLookup(&testPlugin{registerResult: oldPlugin})
+	host := NewForTest(loader)
+	t.Cleanup(host.ShutdownAll)
+	pluginsDir, paths := makeVersionedPluginDir(t, "privacy", "1.0.0")
+	host.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"privacy": enabledPluginConfigWithStoreVersion(t, "1.0.0"),
+		},
+	}})
+
+	oldCallDone := make(chan struct{})
+	go func() {
+		host.InterceptRequestBeforeAuth(context.Background(), pluginapi.RequestInterceptRequest{Body: []byte("old")})
+		close(oldCallDone)
+	}()
+	waitForHostTestSignal(t, callStarted, "old runtime call")
+
+	loader.lookups["privacy"] = newTestSymbolLookup(&testPlugin{registerResult: newPlugin})
+	paths["2.0.0"] = writeVersionedPluginFile(t, pluginsDir, "privacy", "2.0.0")
+	host.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"privacy": enabledPluginConfigWithStoreVersion(t, "2.0.0"),
+		},
+	}})
+	close(releaseCall)
+	waitForHostTestSignal(t, oldCallDone, "old runtime panic recovery")
+
+	host.mu.Lock()
+	_, activeFused := host.fused["privacy"]
+	oldEpoch := host.fusedIdentities[makePluginIdentityKey("privacy", paths["1.0.0"], "1.0.0")]
+	replacementEpoch := host.fusedIdentities[makePluginIdentityKey("privacy", paths["2.0.0"], "2.0.0")]
+	host.mu.Unlock()
+	if activeFused {
+		t.Fatal("retired runtime panic fused the active replacement")
+	}
+	if oldEpoch == 0 {
+		t.Fatal("retired identity fuse epoch was not advanced")
+	}
+	if replacementEpoch != 0 {
+		t.Fatalf("replacement identity fuse epoch = %d, want 0", replacementEpoch)
+	}
+
+	got := host.InterceptRequestBeforeAuth(context.Background(), pluginapi.RequestInterceptRequest{Body: []byte("new")})
+	if string(got.Body) != "new|v2" {
+		t.Fatalf("replacement response body = %q, want %q", got.Body, "new|v2")
+	}
+}
+
+func TestFusedPluginRemainsDisabledUntilReplacementSnapshotCommit(t *testing.T) {
+	oldCalled := make(chan struct{}, 1)
+	oldPlugin := validTestPlugin("alpha")
+	oldPlugin.Capabilities.RequestInterceptor = requestInterceptorFunc(func(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+		oldCalled <- struct{}{}
+		return pluginapi.RequestInterceptResponse{Body: append(req.Body, []byte("|old")...)}, nil
+	})
+	newPlugin := validTestPlugin("alpha")
+	newPlugin.Capabilities.RequestInterceptor = requestInterceptorFunc(func(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+		return pluginapi.RequestInterceptResponse{Body: append(req.Body, []byte("|new")...)}, nil
+	})
+
+	loader := newTestSymbolLoader()
+	loader.lookups["alpha"] = newTestSymbolLookup(&testPlugin{registerResult: oldPlugin})
+	host := NewForTest(loader)
+	t.Cleanup(host.ShutdownAll)
+	pluginsDir, _ := makeVersionedPluginDir(t, "alpha", "1.0.0")
+	host.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"alpha": enabledPluginConfigWithStoreVersion(t, "1.0.0"),
+		},
+	}})
+	host.fusePlugin(host.activeRecords()[0], "test", "fused old plugin")
+
+	loader.lookups["alpha"] = newTestSymbolLookup(&testPlugin{registerResult: newPlugin})
+	writeVersionedPluginFile(t, pluginsDir, "alpha", "2.0.0")
+	blockerStarted := make(chan struct{})
+	releaseBlocker := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseBlocker) }) }
+	t.Cleanup(release)
+	blockerLookup := newTestSymbolLookup(&testPlugin{registerResult: validTestPlugin("zeta")})
+	blockerLookup.registerOverride = func([]byte) pluginapi.Plugin {
+		close(blockerStarted)
+		<-releaseBlocker
+		return validTestPlugin("zeta")
+	}
+	loader.lookups["zeta"] = blockerLookup
+	writeVersionedPluginFile(t, pluginsDir, "zeta", "1.0.0")
+	replacementConfig := &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"alpha": enabledPluginConfigWithStoreVersion(t, "2.0.0"),
+			"zeta":  enabledPluginConfigWithStoreVersion(t, "1.0.0"),
+		},
+	}}
+
+	applyDone := make(chan struct{})
+	go func() {
+		host.ApplyConfig(context.Background(), replacementConfig)
+		close(applyDone)
+	}()
+	waitForHostTestSignal(t, blockerStarted, "replacement snapshot barrier")
+
+	got := host.InterceptRequestBeforeAuth(context.Background(), pluginapi.RequestInterceptRequest{Body: []byte("request")})
+	if string(got.Body) != "request" {
+		t.Fatalf("old fused plugin response body = %q, want unchanged request", got.Body)
+	}
+	select {
+	case <-oldCalled:
+		t.Fatal("old fused plugin was invoked before replacement snapshot commit")
+	default:
+	}
+
+	release()
+	waitForHostTestSignal(t, applyDone, "replacement ApplyConfig completion")
+	if host.isPluginFused("alpha") {
+		t.Fatal("old fuse marker remained after replacement snapshot commit")
+	}
+	got = host.InterceptRequestBeforeAuth(context.Background(), pluginapi.RequestInterceptRequest{Body: []byte("request")})
+	if string(got.Body) != "request|new" {
+		t.Fatalf("replacement response body = %q, want %q", got.Body, "request|new")
+	}
+}
+
+func TestUnversionedReconfigurePanicFusesPinnedStreamIdentity(t *testing.T) {
+	var calls []int
+	plugin := &testPlugin{registerResult: validTestPlugin("privacy"), panicOnReload: true}
+	plugin.registerResult.Capabilities.StreamChunkInterceptor = responseInterceptorFunc{
+		interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+			calls = append(calls, req.ChunkIndex)
+			return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+		},
+	}
+	plugin.registerResult.Capabilities.StreamChunkInterceptorStateful = true
+
+	loader := newTestSymbolLoader()
+	loader.lookups["privacy"] = newTestSymbolLookup(plugin)
+	host := NewForTest(loader)
+	t.Cleanup(host.ShutdownAll)
+	cfg := &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     makePluginDir(t, "privacy"),
+		Configs: enabledPluginConfigs("privacy"),
+	}}
+	host.ApplyConfig(context.Background(), cfg)
+	records := host.activeRecords()
+	if len(records) != 1 {
+		t.Fatalf("active records = %d, want 1", len(records))
+	}
+	if records[0].version != "1.0.0" {
+		t.Errorf("unversioned plugin identity version = %q, want metadata version %q", records[0].version, "1.0.0")
+	}
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+	host.ApplyConfig(context.Background(), cfg)
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("skipped"),
+		ChunkIndex: 0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if fmt.Sprint(calls) != "[-1 -2]" {
+		t.Fatalf("pinned plugin calls = %v, want init and cleanup only after Reconfigure panic", calls)
+	}
+}
+
+func TestStreamInterceptorSessionRemembersPinnedIdentityFuseAcrossReload(t *testing.T) {
+	var oldCalls []int
+	host := newHostWithRecords(capabilityRecord{
+		id:      "privacy",
+		path:    "testdata/privacy-v1.plugin",
+		version: "v1",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					oldCalls = append(oldCalls, req.ChunkIndex)
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+	host.fusePlugin(host.activeRecords()[0], "test", "fused v1")
+	setHostSnapshotForTest(host, true, capabilityRecord{
+		id:      "privacy",
+		path:    "testdata/privacy-v2.plugin",
+		version: "v2",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+	if host.isPluginFused("privacy") {
+		t.Fatal("old identity fuse remained attached to the replacement")
+	}
+
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("skipped"),
+		ChunkIndex: 0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if fmt.Sprint(oldCalls) != "[-1 -2]" {
+		t.Fatalf("pinned plugin calls = %v, want init and cleanup only after fused identity reload", oldCalls)
+	}
+}
+
+func TestStreamInterceptorSessionPreservesCleanupAfterPayloadErrorAndFuse(t *testing.T) {
+	var calls []int
+	host := newHostWithRecords(capabilityRecord{
+		id: "stateful",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					calls = append(calls, req.ChunkIndex)
+					if req.ChunkIndex == 0 {
+						return pluginapi.StreamChunkInterceptResponse{}, errors.New("payload failed")
+					}
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("payload"),
+		ChunkIndex: 0,
+	})
+	host.mu.Lock()
+	host.fused["stateful"] = "fused after payload error"
+	host.mu.Unlock()
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if fmt.Sprint(calls) != "[-1 0 -2]" {
+		t.Fatalf("interceptor calls = %v, want init, failed payload, and one best-effort end", calls)
+	}
+}
+
+func TestStreamInterceptorSessionPreservesStateAfterPayloadError(t *testing.T) {
+	var calls []pluginapi.StreamChunkInterceptRequest
+	host := newHostWithRecords(capabilityRecord{
+		id: "stateful",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					calls = append(calls, req)
+					if req.ChunkIndex == 0 {
+						return pluginapi.StreamChunkInterceptResponse{}, errors.New("payload failed")
+					}
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("failed payload"),
+		ChunkIndex: 0,
+	})
+	if !session.CanOmitHeavyFields() {
+		t.Error("CanOmitHeavyFields() = false after transient payload error")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("next payload"),
+		ChunkIndex: 1,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+
+	if len(calls) != 4 {
+		t.Fatalf("calls = %d, want init, failed payload, next payload, and end", len(calls))
+	}
+	for i, req := range calls {
+		if req.StreamID != "stream-1" {
+			t.Errorf("call %d StreamID = %q, want stream-1", i, req.StreamID)
+		}
+	}
+}
+
+func TestStreamInterceptorSessionMetadataIsolation(t *testing.T) {
+	t.Run("RPC defers isolation to serialization", func(t *testing.T) {
+		host := New()
+		client := newGuardedPluginClient(&capturePluginClient{})
+		adapter := &rpcPluginAdapter{id: "rpc", host: host, client: client}
+		setHostSnapshotForTest(host, true, capabilityRecord{
+			id: "rpc",
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: adapter,
+			}},
+		})
+
+		probe := &metadataMarshalProbe{}
+		session := host.OpenStreamChunkInterceptorSession("")
+		session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+			Metadata:   map[string]any{"probe": probe},
+			ChunkIndex: 0,
+		})
+		session.Close()
+
+		if !probe.called {
+			t.Fatal("RPC metadata was cloned before serialization")
+		}
+	})
+
+	t.Run("local interceptor receives isolated metadata", func(t *testing.T) {
+		metadata := map[string]any{
+			"nested": map[string]any{"value": "original"},
+		}
+		host := newHostWithRecords(capabilityRecord{
+			id: "local",
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						req.Metadata["added"] = true
+						req.Metadata["nested"].(map[string]any)["value"] = "mutated"
+						return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+					},
+				},
+			}},
+		})
+
+		session := host.OpenStreamChunkInterceptorSession("")
+		session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+			Metadata:   metadata,
+			ChunkIndex: 0,
+		})
+		session.Close()
+
+		if _, added := metadata["added"]; added {
+			t.Fatal("local interceptor mutated top-level metadata")
+		}
+		if got := metadata["nested"].(map[string]any)["value"]; got != "original" {
+			t.Fatalf("nested metadata value = %v, want original", got)
+		}
+	})
+}
+
+func TestStreamInterceptorSessionInitFailureForcesLegacyPayload(t *testing.T) {
+	var calls []pluginapi.StreamChunkInterceptRequest
+	host := newHostWithRecords(capabilityRecord{
+		id: "stateful",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					calls = append(calls, req)
+					if req.ChunkIndex == pluginapi.StreamChunkHeaderInitIndex {
+						return pluginapi.StreamChunkInterceptResponse{}, errors.New("init failed")
+					}
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:    "stream-1",
+		RequestBody: []byte("request"),
+		ChunkIndex:  pluginapi.StreamChunkHeaderInitIndex,
+	})
+	if session.CanOmitHeavyFields() {
+		t.Fatal("CanOmitHeavyFields() = true after failed initialization")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:        "stream-1",
+		OriginalRequest: []byte("original"),
+		RequestBody:     []byte("request"),
+		Body:            []byte("chunk"),
+		HistoryChunks:   [][]byte{[]byte("previous")},
+		ChunkIndex:      0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+
+	if len(calls) != 3 {
+		t.Fatalf("calls = %d, want init, payload, and end", len(calls))
+	}
+	for i, call := range calls {
+		if call.StreamID != "stream-1" {
+			t.Fatalf("call %d StreamID = %q, want stream-1", i, call.StreamID)
+		}
+	}
+	if string(calls[1].RequestBody) != "request" || string(calls[1].OriginalRequest) != "original" || len(calls[1].HistoryChunks) != 1 {
+		t.Fatalf("fallback payload heavy fields = %#v", calls[1])
+	}
+}
+
+func TestStreamInterceptorSessionIgnoresDropChunkDuringLifecycleCalls(t *testing.T) {
+	var highCalls []int
+	var lowCalls []int
+	host := newHostWithRecords(
+		capabilityRecord{
+			id:       "high",
+			priority: 20,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						highCalls = append(highCalls, req.ChunkIndex)
+						return pluginapi.StreamChunkInterceptResponse{Body: req.Body, DropChunk: true}, nil
+					},
+				},
+				StreamChunkInterceptorStateful: true,
+			}},
+		},
+		capabilityRecord{
+			id:       "low",
+			priority: 10,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						lowCalls = append(lowCalls, req.ChunkIndex)
+						return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+					},
+				},
+				StreamChunkInterceptorStateful: true,
+			}},
+		},
+	)
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	initResp := session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+	if initResp.DropChunk {
+		t.Fatal("header initialization propagated DropChunk")
+	}
+	payloadResp := session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("chunk"),
+		ChunkIndex: 0,
+	})
+	if !payloadResp.DropChunk {
+		t.Fatal("payload DropChunk = false, want true")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+
+	if fmt.Sprint(highCalls) != "[-1 0 -2]" {
+		t.Fatalf("high-priority calls = %v, want lifecycle and payload calls", highCalls)
+	}
+	if fmt.Sprint(lowCalls) != "[-1 -2]" {
+		t.Fatalf("low-priority calls = %v, want init and end despite DropChunk", lowCalls)
+	}
+}
+
+func TestStreamInterceptorSessionDisablesPanickingRecordLocally(t *testing.T) {
+	panicCalls := 0
+	var fallbackCalls []int
+	host := newHostWithRecords(
+		capabilityRecord{
+			id:       "panic",
+			priority: 20,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						panicCalls++
+						panic("stream interceptor panic")
+					},
+				},
+				StreamChunkInterceptorStateful: true,
+			}},
+		},
+		capabilityRecord{
+			id:       "fallback",
+			priority: 10,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						fallbackCalls = append(fallbackCalls, req.ChunkIndex)
+						return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+					},
+				},
+				StreamChunkInterceptorStateful: true,
+			}},
+		},
+	)
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:    "stream-1",
+		RequestBody: []byte("request"),
+		ChunkIndex:  pluginapi.StreamChunkHeaderInitIndex,
+	})
+	if session.CanOmitHeavyFields() {
+		t.Fatal("CanOmitHeavyFields() = true after one pinned interceptor panicked")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:    "stream-1",
+		RequestBody: []byte("request"),
+		Body:        []byte("chunk"),
+		ChunkIndex:  0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if panicCalls != 1 {
+		t.Fatalf("panicking interceptor calls = %d, want 1 before local disable", panicCalls)
+	}
+	if fmt.Sprint(fallbackCalls) != "[-1 0 -2]" {
+		t.Fatalf("fallback interceptor calls = %v, want [-1 0 -2]", fallbackCalls)
+	}
+}
+
+func TestStreamInterceptorSessionEndsRecordDisabledAfterPayloadPanic(t *testing.T) {
+	var calls []int
+	host := newHostWithRecords(capabilityRecord{
+		id: "panic",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					calls = append(calls, req.ChunkIndex)
+					if req.ChunkIndex == 0 {
+						panic("stream payload panic")
+					}
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:    "stream-1",
+		RequestBody: []byte("request"),
+		ChunkIndex:  pluginapi.StreamChunkHeaderInitIndex,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("panic"),
+		ChunkIndex: 0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("skipped"),
+		ChunkIndex: 1,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if fmt.Sprint(calls) != "[-1 0 -2]" {
+		t.Fatalf("interceptor calls = %v, want init, panicking payload, and one best-effort end", calls)
+	}
+}
+
+func TestStreamInterceptorSessionEndsRecordDisabledAfterRetryInitPanic(t *testing.T) {
+	var calls []int
+	initCalls := 0
+	host := newHostWithRecords(capabilityRecord{
+		id: "panic",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			StreamChunkInterceptor: responseInterceptorFunc{
+				interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+					calls = append(calls, req.ChunkIndex)
+					if req.ChunkIndex == pluginapi.StreamChunkHeaderInitIndex {
+						initCalls++
+						if initCalls == 2 {
+							panic("retry stream init panic")
+						}
+					}
+					return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+				},
+			},
+			StreamChunkInterceptorStateful: true,
+		}},
+	})
+
+	session := host.OpenStreamChunkInterceptorSession("")
+	for range 2 {
+		session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+			StreamID:    "stream-1",
+			RequestBody: []byte("request"),
+			ChunkIndex:  pluginapi.StreamChunkHeaderInitIndex,
+		})
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("skipped"),
+		ChunkIndex: 0,
+	})
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+
+	if fmt.Sprint(calls) != "[-1 -1 -2]" {
+		t.Fatalf("interceptor calls = %v, want initial init, panicking retry init, and one best-effort end", calls)
+	}
+}
+
 func TestHasStreamInterceptorsReflectsActiveStreamInterceptors(t *testing.T) {
 	requestOnly := newHostWithRecords(capabilityRecord{
 		id: "request",
@@ -3231,6 +4818,61 @@ func normalizeTestCapabilityRecords(records []capabilityRecord) []capabilityReco
 type stringSliceAlias []string
 
 type mapSliceAlias []map[string]string
+
+type blockingStreamPluginClient struct {
+	callStarted  chan<- struct{}
+	releaseCall  <-chan struct{}
+	shutdownDone chan<- struct{}
+}
+
+func (c *blockingStreamPluginClient) Call(ctx context.Context, method string, request []byte) ([]byte, error) {
+	close(c.callStarted)
+	<-c.releaseCall
+	return marshalRPCResult(pluginapi.StreamChunkInterceptResponse{
+		Headers:   http.Header{"X-Plugin": []string{"mutated"}},
+		Body:      []byte("mutated"),
+		DropChunk: true,
+	})
+}
+
+func (c *blockingStreamPluginClient) Shutdown() {
+	close(c.shutdownDone)
+}
+
+type orderedStreamPluginClient struct {
+	mu             sync.Mutex
+	calls          int
+	payloadStarted chan<- struct{}
+	endStarted     chan<- struct{}
+	releasePayload <-chan struct{}
+}
+
+func (c *orderedStreamPluginClient) Call(context.Context, string, []byte) ([]byte, error) {
+	c.mu.Lock()
+	c.calls++
+	call := c.calls
+	c.mu.Unlock()
+
+	switch call {
+	case 2:
+		close(c.payloadStarted)
+		<-c.releasePayload
+	case 3:
+		close(c.endStarted)
+	}
+	return marshalRPCResult(pluginapi.StreamChunkInterceptResponse{})
+}
+
+func (*orderedStreamPluginClient) Shutdown() {}
+
+type metadataMarshalProbe struct {
+	called bool
+}
+
+func (p *metadataMarshalProbe) MarshalJSON() ([]byte, error) {
+	p.called = true
+	return []byte(`"probe"`), nil
+}
 
 type requestNormalizerFunc func(context.Context, pluginapi.RequestTransformRequest) (pluginapi.PayloadResponse, error)
 

--- a/internal/pluginhost/adapters_usage_translation.go
+++ b/internal/pluginhost/adapters_usage_translation.go
@@ -3,8 +3,6 @@ package pluginhost
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"runtime/debug"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
@@ -12,7 +10,6 @@ import (
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
-	log "github.com/sirupsen/logrus"
 )
 
 func (h *Host) RegisterUsagePlugins() {
@@ -47,7 +44,8 @@ func (h *Host) refreshThinkingProviders(records []capabilityRecord) {
 		if !okProvider {
 			continue
 		}
-		thinking.RegisterPluginProvider(record.id, provider, record.priority, &thinkingAdapter{
+		generation := pluginIdentityGeneration(record.path, record.version)
+		registered := thinking.RegisterPluginProviderGeneration(record.id, generation, provider, record.priority, &thinkingAdapter{
 			host:     h,
 			pluginID: record.id,
 			path:     record.path,
@@ -55,6 +53,9 @@ func (h *Host) refreshThinkingProviders(records []capabilityRecord) {
 			provider: provider,
 			applier:  applier,
 		})
+		if registered && (h.isPluginFused(record.id) || !h.recordCurrent(record)) {
+			thinking.UnregisterPluginProvidersGeneration(record.id, generation)
+		}
 	}
 }
 
@@ -64,7 +65,7 @@ func (h *Host) callThinkingIdentifier(record capabilityRecord, applier pluginapi
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "ThinkingApplier.Identifier", recovered)
+			h.fusePlugin(record, "ThinkingApplier.Identifier", recovered)
 			provider = ""
 			ok = false
 		}
@@ -76,31 +77,21 @@ func (h *Host) callThinkingIdentifier(record capabilityRecord, applier pluginapi
 	return provider, true
 }
 
-func (h *Host) currentUsagePlugin(pluginID string) pluginapi.UsagePlugin {
+func (h *Host) currentUsagePlugin(pluginID string) (pluginapi.UsagePlugin, capabilityRecord, bool) {
 	if h == nil || strings.TrimSpace(pluginID) == "" {
-		return nil
+		return nil, capabilityRecord{}, false
 	}
 	for _, record := range h.activeRecords() {
 		if record.id != pluginID {
 			continue
 		}
 		if h.isPluginFused(record.id) {
-			return nil
+			return nil, capabilityRecord{}, false
 		}
-		return record.plugin.Capabilities.UsagePlugin
+		plugin := record.plugin.Capabilities.UsagePlugin
+		return plugin, record, plugin != nil
 	}
-	return nil
-}
-
-func (h *Host) fusePlugin(id, method string, recovered any) {
-	if h == nil {
-		return
-	}
-	h.mu.Lock()
-	h.fused[id] = fmt.Sprintf("%s panic: %v", method, recovered)
-	h.mu.Unlock()
-	thinking.UnregisterPluginProviders(id)
-	log.WithField("plugin_id", id).WithField("method", method).Errorf("pluginhost: plugin panic recovered: %v\n%s", recovered, debug.Stack())
+	return nil, capabilityRecord{}, false
 }
 
 func (h *Host) isPluginFused(id string) bool {
@@ -132,13 +123,13 @@ func (a *usageAdapter) HandleUsage(ctx context.Context, record coreusage.Record)
 	if a == nil {
 		return
 	}
-	plugin := a.host.currentUsagePlugin(a.pluginID)
-	if plugin == nil {
+	plugin, pluginRecord, okPlugin := a.host.currentUsagePlugin(a.pluginID)
+	if !okPlugin {
 		return
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			a.host.fusePlugin(a.pluginID, "UsagePlugin.HandleUsage", recovered)
+			a.host.fusePlugin(pluginRecord, "UsagePlugin.HandleUsage", recovered)
 		}
 	}()
 	plugin.HandleUsage(ctx, pluginapi.UsageRecord{
@@ -181,7 +172,7 @@ func (a *thinkingAdapter) Apply(body []byte, config thinking.ThinkingConfig, mod
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			a.host.fusePlugin(a.pluginID, "ThinkingApplier.ApplyThinking", recovered)
+			a.host.fusePluginIdentity(a.pluginID, a.path, a.version, "ThinkingApplier.ApplyThinking", recovered)
 			out = bytes.Clone(body)
 			err = nil
 		}
@@ -274,7 +265,7 @@ func (h *Host) callRequestNormalizer(ctx context.Context, record capabilityRecor
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "RequestNormalizer.NormalizeRequest", recovered)
+			h.fusePlugin(record, "RequestNormalizer.NormalizeRequest", recovered)
 			out = nil
 			ok = false
 		}
@@ -298,7 +289,7 @@ func (h *Host) callRequestTranslator(ctx context.Context, record capabilityRecor
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "RequestTranslator.TranslateRequest", recovered)
+			h.fusePlugin(record, "RequestTranslator.TranslateRequest", recovered)
 			out = nil
 			ok = false
 		}
@@ -322,7 +313,7 @@ func (h *Host) callResponseNormalizer(ctx context.Context, record capabilityReco
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, method, recovered)
+			h.fusePlugin(record, method, recovered)
 			out = nil
 			ok = false
 		}
@@ -348,7 +339,7 @@ func (h *Host) callResponseTranslator(ctx context.Context, record capabilityReco
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "ResponseTranslator.TranslateResponse", recovered)
+			h.fusePlugin(record, "ResponseTranslator.TranslateResponse", recovered)
 			out = nil
 			ok = false
 		}

--- a/internal/pluginhost/auth_provider.go
+++ b/internal/pluginhost/auth_provider.go
@@ -115,7 +115,7 @@ func (h *Host) AuthProviderIdentifiers() []string {
 		if provider == nil || h.isPluginFused(record.id) {
 			continue
 		}
-		identifier, okIdentifier := h.callAuthProviderIdentifier(record.id, provider)
+		identifier, okIdentifier := h.callAuthProviderIdentifier(record, provider)
 		if okIdentifier && identifier != "" {
 			out = append(out, identifier)
 		}
@@ -137,7 +137,7 @@ func (h *Host) authProviderRecord(provider string) *capabilityRecord {
 		if authProvider == nil || h.isPluginFused(record.id) {
 			continue
 		}
-		identifier, okIdentifier := h.callAuthProviderIdentifier(record.id, authProvider)
+		identifier, okIdentifier := h.callAuthProviderIdentifier(record, authProvider)
 		if okIdentifier && identifier == provider {
 			copyRecord := record
 			return &copyRecord
@@ -146,13 +146,13 @@ func (h *Host) authProviderRecord(provider string) *capabilityRecord {
 	return nil
 }
 
-func (h *Host) callAuthProviderIdentifier(pluginID string, provider pluginapi.AuthProvider) (identifier string, ok bool) {
-	if h == nil || provider == nil || h.isPluginFused(pluginID) {
+func (h *Host) callAuthProviderIdentifier(record capabilityRecord, provider pluginapi.AuthProvider) (identifier string, ok bool) {
+	if h == nil || provider == nil || h.isPluginFused(record.id) || !h.recordCurrent(record) {
 		return "", false
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(pluginID, "AuthProvider.Identifier", recovered)
+			h.fusePlugin(record, "AuthProvider.Identifier", recovered)
 			identifier = ""
 			ok = false
 		}
@@ -206,7 +206,7 @@ func (h *Host) callParseAuths(ctx context.Context, record capabilityRecord, req 
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "AuthProvider.ParseAuth", recovered)
+			h.fusePlugin(record, "AuthProvider.ParseAuth", recovered)
 			auths = nil
 			handled = false
 			err = fmt.Errorf("auth provider panic: %v", recovered)
@@ -270,7 +270,7 @@ func (h *Host) callStartLogin(ctx context.Context, record capabilityRecord, prov
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "AuthProvider.StartLogin", recovered)
+			h.fusePlugin(record, "AuthProvider.StartLogin", recovered)
 			resp = pluginapi.AuthLoginStartResponse{}
 			handled = false
 			err = fmt.Errorf("auth provider start login panic: %v", recovered)
@@ -308,7 +308,7 @@ func (h *Host) callPollLogin(ctx context.Context, record capabilityRecord, provi
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "AuthProvider.PollLogin", recovered)
+			h.fusePlugin(record, "AuthProvider.PollLogin", recovered)
 			resp = pluginapi.AuthLoginPollResponse{}
 			handled = false
 			err = fmt.Errorf("auth provider poll login panic: %v", recovered)
@@ -341,7 +341,7 @@ func (h *Host) RefreshAuth(ctx context.Context, auth *coreauth.Auth) (refreshed 
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "AuthProvider.RefreshAuth", recovered)
+			h.fusePlugin(*record, "AuthProvider.RefreshAuth", recovered)
 			refreshed = nil
 			handled = true
 			err = fmt.Errorf("auth provider refresh panic: %v", recovered)

--- a/internal/pluginhost/client_guard.go
+++ b/internal/pluginhost/client_guard.go
@@ -7,18 +7,23 @@ import (
 )
 
 type guardedPluginClient struct {
-	mu           sync.Mutex
-	cond         *sync.Cond
-	inner        pluginClient
-	calls        int
-	closed       bool
-	shutdownDone chan struct{}
+	mu              sync.Mutex
+	inner           pluginClient
+	calls           int
+	pins            int
+	closed          bool
+	shutdownStarted bool
+	shutdownDone    chan struct{}
+}
+
+type guardedPluginClientLease struct {
+	mu       sync.Mutex
+	parent   *guardedPluginClient
+	released bool
 }
 
 func newGuardedPluginClient(inner pluginClient) *guardedPluginClient {
-	client := &guardedPluginClient{inner: inner, shutdownDone: make(chan struct{})}
-	client.cond = sync.NewCond(&client.mu)
-	return client
+	return &guardedPluginClient{inner: inner, shutdownDone: make(chan struct{})}
 }
 
 func (c *guardedPluginClient) Call(ctx context.Context, method string, request []byte) ([]byte, error) {
@@ -57,6 +62,19 @@ type guardedPluginCallResult struct {
 	recovered any
 }
 
+func (c *guardedPluginClient) Pin() (pluginClient, error) {
+	if c == nil {
+		return nil, fmt.Errorf("plugin client is closed")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed || c.inner == nil {
+		return nil, fmt.Errorf("plugin client is closed")
+	}
+	c.pins++
+	return &guardedPluginClientLease{parent: c}, nil
+}
+
 func (c *guardedPluginClient) acquire() (pluginClient, error) {
 	if c == nil {
 		return nil, fmt.Errorf("plugin client is closed")
@@ -73,10 +91,9 @@ func (c *guardedPluginClient) acquire() (pluginClient, error) {
 func (c *guardedPluginClient) release() {
 	c.mu.Lock()
 	c.calls--
-	if c.calls == 0 {
-		c.cond.Broadcast()
-	}
+	inner := c.takeInnerForShutdownLocked()
 	c.mu.Unlock()
+	c.finishShutdown(inner)
 }
 
 func (c *guardedPluginClient) Shutdown() {
@@ -94,35 +111,115 @@ func (c *guardedPluginClient) ShutdownContext(ctx context.Context) {
 	}
 
 	c.mu.Lock()
-	if c.closed {
-		done := c.shutdownDone
-		c.mu.Unlock()
-		select {
-		case <-done:
-		case <-ctx.Done():
-		}
-		return
-	}
 	c.closed = true
-	inner := c.inner
-	c.inner = nil
+	shutdownDeferred := c.pins > 0
+	inner := c.takeInnerForShutdownLocked()
 	done := c.shutdownDone
 	c.mu.Unlock()
-
-	go func() {
-		c.mu.Lock()
-		for c.calls > 0 {
-			c.cond.Wait()
-		}
-		c.mu.Unlock()
-		if inner != nil {
-			inner.Shutdown()
-		}
-		close(done)
-	}()
+	c.finishShutdown(inner)
+	if shutdownDeferred {
+		return
+	}
 
 	select {
 	case <-done:
 	case <-ctx.Done():
+	}
+}
+
+func (c *guardedPluginClient) finishShutdown(inner pluginClient) {
+	if inner == nil {
+		return
+	}
+	go func() {
+		c.finishShutdownSync(inner)
+	}()
+}
+
+func (c *guardedPluginClient) finishShutdownSync(inner pluginClient) {
+	if inner == nil {
+		return
+	}
+	inner.Shutdown()
+	close(c.shutdownDone)
+}
+
+func (c *guardedPluginClient) takeInnerForShutdownLocked() pluginClient {
+	if c == nil || !c.closed || c.pins > 0 || c.calls > 0 || c.shutdownStarted || c.inner == nil {
+		return nil
+	}
+	c.shutdownStarted = true
+	inner := c.inner
+	c.inner = nil
+	return inner
+}
+
+func (c *guardedPluginClient) acquirePinned() (pluginClient, error) {
+	if c == nil {
+		return nil, fmt.Errorf("plugin client is closed")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.inner == nil {
+		return nil, fmt.Errorf("plugin client is closed")
+	}
+	c.calls++
+	return c.inner, nil
+}
+
+func (c *guardedPluginClient) releasePin() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	if c.pins > 0 {
+		c.pins--
+	}
+	if c.pins > 0 || !c.closed {
+		c.mu.Unlock()
+		return
+	}
+	inner := c.takeInnerForShutdownLocked()
+	c.mu.Unlock()
+	c.finishShutdownSync(inner)
+}
+
+func (l *guardedPluginClientLease) Call(ctx context.Context, method string, request []byte) ([]byte, error) {
+	if l == nil {
+		return nil, fmt.Errorf("plugin client lease is closed")
+	}
+	l.mu.Lock()
+	if l.released || l.parent == nil {
+		l.mu.Unlock()
+		return nil, fmt.Errorf("plugin client lease is closed")
+	}
+	parent := l.parent
+	inner, errAcquire := parent.acquirePinned()
+	l.mu.Unlock()
+	if errAcquire != nil {
+		return nil, errAcquire
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	defer parent.release()
+	return inner.Call(ctx, method, request)
+}
+
+func (l *guardedPluginClientLease) Shutdown() {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	if l.released {
+		l.mu.Unlock()
+		return
+	}
+	l.released = true
+	parent := l.parent
+	l.parent = nil
+	l.mu.Unlock()
+	if parent != nil {
+		parent.releasePin()
 	}
 }

--- a/internal/pluginhost/command_line.go
+++ b/internal/pluginhost/command_line.go
@@ -50,7 +50,7 @@ func (h *Host) callCommandLineRegistrar(ctx context.Context, record capabilityRe
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "CommandLinePlugin.RegisterCommandLine", recovered)
+			h.fusePlugin(record, "CommandLinePlugin.RegisterCommandLine", recovered)
 			resp = pluginapi.CommandLineRegistrationResponse{}
 			err = fmt.Errorf("command-line registrar panic: %v", recovered)
 		}
@@ -354,7 +354,7 @@ func (h *Host) callCommandLineExecutor(ctx context.Context, record capabilityRec
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "CommandLinePlugin.ExecuteCommandLine", recovered)
+			h.fusePlugin(record, "CommandLinePlugin.ExecuteCommandLine", recovered)
 			resp = pluginapi.CommandLineExecutionResponse{}
 			err = fmt.Errorf("command-line execution panic: %v", recovered)
 		}

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -25,6 +25,21 @@ type loadedPlugin struct {
 	name       string
 	registered bool
 	client     pluginClient
+	retiring   bool
+}
+
+type pluginIdentityKey struct {
+	id      string
+	path    string
+	version string
+}
+
+func makePluginIdentityKey(id, path, version string) pluginIdentityKey {
+	return pluginIdentityKey{
+		id:      strings.TrimSpace(id),
+		path:    cleanPluginPath(path),
+		version: strings.TrimSpace(version),
+	}
 }
 
 type modelExecutor interface {
@@ -60,6 +75,8 @@ type Host struct {
 	retired                map[string][]*loadedPlugin
 	loading                map[string]*pluginLoadRequest
 	fused                  map[string]string
+	fusedIdentities        map[pluginIdentityKey]uint64
+	nextFuseEpoch          uint64
 	pluginFileVersions     map[string]string
 	activePluginVersions   map[string]string
 	activePluginPaths      map[string]string
@@ -93,6 +110,7 @@ func New() *Host {
 		retired:                make(map[string][]*loadedPlugin),
 		loading:                make(map[string]*pluginLoadRequest),
 		fused:                  make(map[string]string),
+		fusedIdentities:        make(map[pluginIdentityKey]uint64),
 		pluginFileVersions:     make(map[string]string),
 		activePluginVersions:   make(map[string]string),
 		activePluginPaths:      make(map[string]string),
@@ -239,9 +257,33 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 	}
 	files = h.withLoadedPluginFallbacks(files, rc.Items, desiredVersions)
 
+	previousRecords := make(map[string]capabilityRecord)
+	for _, record := range h.Snapshot().records {
+		previousRecords[record.id] = record
+	}
 	records := make([]capabilityRecord, 0, len(files))
+	recordedIDs := make(map[string]struct{}, len(files))
 	loadedFiles := make([]pluginFile, 0, len(files))
 	hotReloadLogs := make([]log.Fields, 0)
+	successfulReplacementIDs := make([]string, 0)
+	preservePreviousRecord := func(id string, priority int) {
+		if _, recorded := recordedIDs[id]; recorded {
+			return
+		}
+		record, okRecord := previousRecords[id]
+		if !okRecord {
+			return
+		}
+		h.mu.Lock()
+		_, disabled := h.fused[id]
+		h.mu.Unlock()
+		if disabled {
+			return
+		}
+		record.priority = priority
+		records = append(records, record)
+		recordedIDs[id] = struct{}{}
+	}
 	for _, file := range files {
 		item, ok := rc.Items[file.ID]
 		if !ok {
@@ -272,6 +314,7 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 			h.mu.Lock()
 			if _, loading := h.loading[file.ID]; loading {
 				h.mu.Unlock()
+				preservePreviousRecord(file.ID, item.Priority)
 				continue
 			}
 			h.loading[file.ID] = request
@@ -285,6 +328,13 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 			if loadResult.err != nil {
 				h.cleanupPluginLoad(file.ID, request, loadResult.loaded)
 				log.Warnf("pluginhost: failed to load plugin %s from %s: %v", file.ID, file.Path, loadResult.err)
+				preservePreviousRecord(file.ID, item.Priority)
+				continue
+			}
+			if !loadResult.initialized {
+				log.WithFields(pluginLogFields(file.ID, "", file.Version, file.Path)).Info("pluginhost: plugin loaded")
+				h.cleanupPluginLoad(file.ID, request, loadResult.loaded)
+				preservePreviousRecord(file.ID, item.Priority)
 				continue
 			}
 
@@ -304,8 +354,8 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 			if replaced != nil {
 				hotReloadFields = pluginHotReloadLogFields(file.ID, file.Version, file.Path, replaced.version, replaced.path)
 				h.retireLoadedPluginLocked(replaced)
-				delete(h.fused, file.ID)
 				h.removePluginRuntimeStateLocked(file.ID)
+				successfulReplacementIDs = append(successfulReplacementIDs, file.ID)
 			}
 			h.loaded[file.ID] = lp
 			loadedNow = true
@@ -322,16 +372,19 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 			var okCall bool
 			plugin, okCall = h.callRegister(ctx, lp, item)
 			if !okCall {
+				preservePreviousRecord(file.ID, item.Priority)
 				continue
 			}
 		}
 		plugin.Metadata = clonePluginMetadata(plugin.Metadata)
+		recordVersion := strings.TrimSpace(file.Version)
 		h.mu.Lock()
 		if lp != nil {
 			lp.name = strings.TrimSpace(plugin.Metadata.Name)
 			if strings.TrimSpace(lp.version) == "" {
 				lp.version = strings.TrimSpace(plugin.Metadata.Version)
 			}
+			recordVersion = lp.version
 		}
 		h.mu.Unlock()
 		if loadedNow {
@@ -343,11 +396,12 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 		records = append(records, capabilityRecord{
 			id:       file.ID,
 			path:     file.Path,
-			version:  file.Version,
+			version:  recordVersion,
 			priority: item.Priority,
 			meta:     plugin.Metadata,
 			plugin:   plugin,
 		})
+		recordedIDs[file.ID] = struct{}{}
 		loadedFiles = append(loadedFiles, file)
 	}
 
@@ -359,7 +413,14 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 	}
 	h.rebuildActivePluginMapsLocked(records)
 	h.snapshot.Store(&Snapshot{enabled: true, records: records})
+	for _, id := range successfulReplacementIDs {
+		delete(h.fused, id)
+	}
+	retiredPlugins := h.pendingRetiredPluginsLocked()
 	h.mu.Unlock()
+	for _, retired := range retiredPlugins {
+		h.cleanupRetiredPlugin(retired)
+	}
 	h.refreshThinkingProviders(records)
 	for _, fields := range hotReloadLogs {
 		log.WithFields(fields).Info("pluginhost: plugin hot reloaded")
@@ -682,6 +743,15 @@ func shutdownPluginClient(ctx context.Context, client pluginClient) {
 	client.Shutdown()
 }
 
+func detachPluginClient(client pluginClient) {
+	if client == nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	shutdownPluginClient(ctx, client)
+}
+
 func cleanPluginPath(path string) string {
 	path = strings.TrimSpace(path)
 	if path == "" {
@@ -697,6 +767,57 @@ func (h *Host) retireLoadedPluginLocked(lp *loadedPlugin) {
 	h.retired[lp.id] = append(h.retired[lp.id], lp)
 }
 
+func (h *Host) pendingRetiredPluginsLocked() []*loadedPlugin {
+	plugins := make([]*loadedPlugin, 0)
+	for _, retiredPlugins := range h.retired {
+		for _, lp := range retiredPlugins {
+			if lp == nil || lp.retiring {
+				continue
+			}
+			lp.retiring = true
+			plugins = append(plugins, lp)
+		}
+	}
+	return plugins
+}
+
+func (h *Host) cleanupRetiredPlugin(lp *loadedPlugin) {
+	if h == nil || lp == nil {
+		return
+	}
+	detachPluginClient(lp.client)
+	guarded, ok := lp.client.(*guardedPluginClient)
+	if !ok {
+		h.removeRetiredPlugin(lp)
+		return
+	}
+	go func() {
+		<-guarded.shutdownDone
+		h.removeRetiredPlugin(lp)
+	}()
+}
+
+func (h *Host) removeRetiredPlugin(lp *loadedPlugin) {
+	if h == nil || lp == nil {
+		return
+	}
+	h.mu.Lock()
+	retired := h.retired[lp.id]
+	for index, candidate := range retired {
+		if candidate != lp {
+			continue
+		}
+		retired = append(retired[:index], retired[index+1:]...)
+		break
+	}
+	if len(retired) == 0 {
+		delete(h.retired, lp.id)
+	} else {
+		h.retired[lp.id] = retired
+	}
+	h.mu.Unlock()
+}
+
 func (h *Host) recordCurrent(record capabilityRecord) bool {
 	return h.pluginIdentityCurrent(record.id, record.path, record.version)
 }
@@ -705,9 +826,13 @@ func (h *Host) pluginIdentityCurrent(id string, path string, version string) boo
 	if h == nil {
 		return false
 	}
-	version = strings.TrimSpace(version)
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	return h.pluginIdentityCurrentLocked(id, path, version)
+}
+
+func (h *Host) pluginIdentityCurrentLocked(id string, path string, version string) bool {
+	version = strings.TrimSpace(version)
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return false
@@ -764,6 +889,8 @@ func (h *Host) removePluginRuntimeStateLocked(id string) {
 }
 
 func (h *Host) rebuildActivePluginMapsLocked(records []capabilityRecord) {
+	previousPaths := h.activePluginPaths
+	previousVersions := h.activePluginVersions
 	h.pluginFileVersions = make(map[string]string, len(records))
 	h.activePluginVersions = make(map[string]string, len(records))
 	h.activePluginPaths = make(map[string]string, len(records))
@@ -776,6 +903,17 @@ func (h *Host) rebuildActivePluginMapsLocked(records []capabilityRecord) {
 		h.pluginFileVersions[path] = strings.TrimSpace(record.version)
 		h.activePluginVersions[id] = strings.TrimSpace(record.version)
 		h.activePluginPaths[id] = path
+	}
+	for id, path := range h.activePluginPaths {
+		previousPath := previousPaths[id]
+		if previousPath == "" {
+			continue
+		}
+		previousIdentity := makePluginIdentityKey(id, previousPath, previousVersions[id])
+		currentIdentity := makePluginIdentityKey(id, path, h.activePluginVersions[id])
+		if previousIdentity != currentIdentity {
+			delete(h.fused, id)
+		}
 	}
 }
 
@@ -792,7 +930,7 @@ func (h *Host) callRegister(ctx context.Context, lp *loadedPlugin, item runtimeI
 		method = pluginabi.MethodPluginReconfigure
 	}
 
-	plugin, okCall := h.safePluginCall(ctx, lp.id, method, func() pluginapi.Plugin {
+	plugin, okCall := h.safePluginCall(ctx, lp, method, func() pluginapi.Plugin {
 		plugin, errRegister := registerRPCPlugin(ctx, h, lp.id, lp.client, method, item.ConfigYAML)
 		if errRegister != nil {
 			log.Warnf("pluginhost: plugin %s %s failed: %v", lp.id, method, errRegister)
@@ -813,10 +951,14 @@ func (h *Host) callRegister(ctx context.Context, lp *loadedPlugin, item runtimeI
 	return plugin, true
 }
 
-func (h *Host) safePluginCall(ctx context.Context, id, method string, fn func() pluginapi.Plugin) (out pluginapi.Plugin, ok bool) {
+func (h *Host) safePluginCall(ctx context.Context, lp *loadedPlugin, method string, fn func() pluginapi.Plugin) (out pluginapi.Plugin, ok bool) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(id, method, recovered)
+			// Fuse using the loading plugin's own identity. During initial load
+			// and hot reload lp is not yet in h.loaded, so deriving the identity
+			// from the map would resolve the outgoing plugin and advance the
+			// wrong fuse epoch.
+			h.fuseLoadingPluginIdentity(lp.id, lp.path, lp.version, method, recovered)
 			out = pluginapi.Plugin{}
 			ok = false
 		}

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -267,11 +267,11 @@ func TestHostUnloadPluginTargetsOnlyRequestedPlugin(t *testing.T) {
 	if !h.PluginLoaded("bravo") {
 		t.Fatal("PluginLoaded(bravo) = false, want true after alpha unload")
 	}
-	if alphaLookup.shutdownCalls != 1 {
-		t.Fatalf("alpha shutdown calls = %d, want 1", alphaLookup.shutdownCalls)
+	if shutdownCalls := alphaLookup.shutdownCalls.Load(); shutdownCalls != 1 {
+		t.Fatalf("alpha shutdown calls = %d, want 1", shutdownCalls)
 	}
-	if bravoLookup.shutdownCalls != 0 {
-		t.Fatalf("bravo shutdown calls = %d, want 0", bravoLookup.shutdownCalls)
+	if shutdownCalls := bravoLookup.shutdownCalls.Load(); shutdownCalls != 0 {
+		t.Fatalf("bravo shutdown calls = %d, want 0", shutdownCalls)
 	}
 	plugins := h.RegisteredPlugins()
 	if len(plugins) != 1 || plugins[0].ID != "bravo" {
@@ -291,6 +291,145 @@ func TestHostUnloadPluginTargetsOnlyRequestedPlugin(t *testing.T) {
 	}
 	if bravo.reconfigureCalls != 1 {
 		t.Fatalf("bravo reconfigure calls = %d, want 1", bravo.reconfigureCalls)
+	}
+}
+
+func TestHostUnloadPluginDefersPinnedStreamClientShutdown(t *testing.T) {
+	loader := newTestSymbolLoader()
+	var calls []int
+	plugin := &testPlugin{
+		registerResult: pluginapi.Plugin{
+			Metadata: validTestPlugin("alpha").Metadata,
+			Capabilities: pluginapi.Capabilities{
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						calls = append(calls, req.ChunkIndex)
+						return pluginapi.StreamChunkInterceptResponse{Body: append(req.Body, []byte("|alpha")...)}, nil
+					},
+				},
+				StreamChunkInterceptorStateful: true,
+			},
+		},
+	}
+	lookup := newTestSymbolLookup(plugin)
+	lookup.shutdownDone = make(chan struct{})
+	loader.lookups["alpha"] = lookup
+	h := NewForTest(loader)
+	h.ApplyConfig(context.Background(), &config.Config{
+		Plugins: config.PluginsConfig{
+			Enabled: true,
+			Dir:     makePluginDir(t, "alpha"),
+			Configs: enabledPluginConfigs("alpha"),
+		},
+	})
+
+	session := h.OpenStreamChunkInterceptorSession("")
+	if session == nil {
+		t.Fatal("OpenStreamChunkInterceptorSession() = nil, want active session")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:    "stream-1",
+		RequestBody: []byte("request"),
+		ChunkIndex:  pluginapi.StreamChunkHeaderInitIndex,
+	})
+
+	if !h.UnloadPlugin("alpha") {
+		t.Fatal("UnloadPlugin(alpha) = false, want true")
+	}
+	if shutdownCalls := lookup.shutdownCalls.Load(); shutdownCalls != 0 {
+		t.Fatalf("shutdown calls = %d while stream session is pinned, want 0", shutdownCalls)
+	}
+	resp := session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		Body:       []byte("chunk"),
+		ChunkIndex: 0,
+	})
+	if string(resp.Body) != "chunk|alpha" {
+		t.Fatalf("pinned stream payload = %q, want chunk|alpha after unload", resp.Body)
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkEndIndex,
+	})
+	session.Close()
+	waitForHostTestSignal(t, lookup.shutdownDone, "deferred pinned plugin shutdown")
+
+	if fmt.Sprint(calls) != "[-1 0 -2]" {
+		t.Fatalf("pinned plugin calls = %v, want [-1 0 -2]", calls)
+	}
+	if shutdownCalls := lookup.shutdownCalls.Load(); shutdownCalls != 1 {
+		t.Fatalf("shutdown calls = %d after session close, want 1", shutdownCalls)
+	}
+}
+
+func TestHostRetiredPinnedStreamClientShutsDownAfterSessionClose(t *testing.T) {
+	loader := newTestSymbolLoader()
+	oldPlugin := validTestPlugin("alpha")
+	oldPlugin.Capabilities = pluginapi.Capabilities{
+		StreamChunkInterceptor: responseInterceptorFunc{
+			interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+				return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+			},
+		},
+		StreamChunkInterceptorStateful: true,
+	}
+	oldLookup := newTestSymbolLookup(&testPlugin{registerResult: oldPlugin})
+	oldLookup.shutdownDone = make(chan struct{})
+	loader.lookups["alpha"] = oldLookup
+	h := NewForTest(loader)
+	t.Cleanup(h.ShutdownAll)
+	pluginsDir, _ := makeVersionedPluginDir(t, "alpha", "1.0.0")
+	h.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"alpha": enabledPluginConfigWithStoreVersion(t, "1.0.0"),
+		},
+	}})
+	h.mu.Lock()
+	oldClient, okGuarded := h.loaded["alpha"].client.(*guardedPluginClient)
+	h.mu.Unlock()
+	if !okGuarded {
+		t.Fatal("loaded client is not guarded")
+	}
+
+	session := h.OpenStreamChunkInterceptorSession("")
+	if session == nil {
+		t.Fatal("OpenStreamChunkInterceptorSession() = nil, want active session")
+	}
+	session.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		StreamID:   "stream-1",
+		ChunkIndex: pluginapi.StreamChunkHeaderInitIndex,
+	})
+
+	loader.lookups["alpha"] = newTestSymbolLookup(&testPlugin{registerResult: validTestPlugin("alpha")})
+	writeVersionedPluginFile(t, pluginsDir, "alpha", "2.0.0")
+	h.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"alpha": enabledPluginConfigWithStoreVersion(t, "2.0.0"),
+		},
+	}})
+
+	session.Close()
+	waitForHostTestSignal(t, oldLookup.shutdownDone, "retired pinned plugin shutdown")
+	waitForHostTestSignal(t, oldClient.shutdownDone, "retired plugin cleanup")
+	if shutdownCalls := oldLookup.shutdownCalls.Load(); shutdownCalls != 1 {
+		t.Fatalf("retired plugin shutdown calls = %d, want 1", shutdownCalls)
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		h.mu.Lock()
+		retiredCount := len(h.retired["alpha"])
+		h.mu.Unlock()
+		if retiredCount == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("retired plugin count after shutdown = %d, want 0", retiredCount)
+		}
+		time.Sleep(time.Millisecond)
 	}
 }
 

--- a/internal/pluginhost/management.go
+++ b/internal/pluginhost/management.go
@@ -102,7 +102,7 @@ func (h *Host) callManagementRegistrar(ctx context.Context, record capabilityRec
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "ManagementAPI.RegisterManagement", recovered)
+			h.fusePlugin(record, "ManagementAPI.RegisterManagement", recovered)
 			resp = pluginapi.ManagementRegistrationResponse{}
 			err = fmt.Errorf("management registrar panic: %v", recovered)
 		}
@@ -332,7 +332,7 @@ func (h *Host) callManagementHandler(ctx context.Context, record managementRoute
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.pluginID, "ManagementHandler.HandleManagement", recovered)
+			h.fusePluginIdentity(record.pluginID, record.path, record.version, "ManagementHandler.HandleManagement", recovered)
 			resp = pluginapi.ManagementResponse{}
 			err = fmt.Errorf("management handler panic: %v", recovered)
 		}
@@ -354,7 +354,7 @@ func (h *Host) callResourceHandler(ctx context.Context, record resourceRouteReco
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.pluginID, "ResourceHandler.HandleManagement", recovered)
+			h.fusePluginIdentity(record.pluginID, record.path, record.version, "ResourceHandler.HandleManagement", recovered)
 			resp = pluginapi.ManagementResponse{}
 			err = fmt.Errorf("resource handler panic: %v", recovered)
 		}

--- a/internal/pluginhost/model_router.go
+++ b/internal/pluginhost/model_router.go
@@ -44,7 +44,7 @@ func (h *Host) RouteModelExcept(ctx context.Context, req pluginapi.ModelRouteReq
 		nextReq := cloneModelRouteRequest(req)
 		nextReq.Plugin = clonePluginMetadata(record.meta)
 		nextReq.PluginID = record.id
-		resp, ok := h.callModelRouter(ctx, record.id, router, nextReq)
+		resp, ok := h.callModelRouter(ctx, record, router, nextReq)
 		if !ok || !resp.Handled {
 			continue
 		}
@@ -74,20 +74,20 @@ func (h *Host) RouteModelExcept(ctx context.Context, req pluginapi.ModelRouteReq
 	return pluginapi.ModelRouteResponse{}, false
 }
 
-func (h *Host) callModelRouter(ctx context.Context, pluginID string, router pluginapi.ModelRouter, req pluginapi.ModelRouteRequest) (out pluginapi.ModelRouteResponse, ok bool) {
-	if h == nil || router == nil || h.isPluginFused(pluginID) {
+func (h *Host) callModelRouter(ctx context.Context, record capabilityRecord, router pluginapi.ModelRouter, req pluginapi.ModelRouteRequest) (out pluginapi.ModelRouteResponse, ok bool) {
+	if h == nil || router == nil || h.isPluginFused(record.id) || !h.recordCurrent(record) {
 		return pluginapi.ModelRouteResponse{}, false
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(pluginID, "ModelRouter.RouteModel", recovered)
+			h.fusePlugin(record, "ModelRouter.RouteModel", recovered)
 			out = pluginapi.ModelRouteResponse{}
 			ok = false
 		}
 	}()
 	resp, errRoute := router.RouteModel(ctx, req)
 	if errRoute != nil {
-		log.WithField("plugin_id", pluginID).WithError(errRoute).Warn("pluginhost: model router failed")
+		log.WithField("plugin_id", record.id).WithError(errRoute).Warn("pluginhost: model router failed")
 		return pluginapi.ModelRouteResponse{}, false
 	}
 	return resp, true

--- a/internal/pluginhost/plugin_fuse.go
+++ b/internal/pluginhost/plugin_fuse.go
@@ -1,0 +1,60 @@
+package pluginhost
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	log "github.com/sirupsen/logrus"
+)
+
+func (h *Host) fusePlugin(record capabilityRecord, method string, recovered any) {
+	h.fusePluginIdentity(record.id, record.path, record.version, method, recovered)
+}
+
+func (h *Host) fusePluginIdentity(id, path, version, method string, recovered any) {
+	if h == nil {
+		return
+	}
+	reason := fmt.Sprintf("%s panic: %v", method, recovered)
+	h.mu.Lock()
+	fuseID := h.pluginIdentityCurrentLocked(id, path, version)
+	h.recordPluginFuseLocked(id, path, version, reason, fuseID)
+	h.mu.Unlock()
+	thinking.UnregisterPluginProvidersGeneration(id, pluginIdentityGeneration(path, version))
+	log.WithField("plugin_id", id).WithField("method", method).Errorf("pluginhost: plugin panic recovered: %v\n%s", recovered, debug.Stack())
+}
+
+// fuseLoadingPluginIdentity uses the identity being registered because it may
+// not be present in h.loaded yet during initial load or hot reload.
+func (h *Host) fuseLoadingPluginIdentity(id, path, version, method string, recovered any) {
+	if h == nil {
+		return
+	}
+	reason := fmt.Sprintf("%s panic: %v", method, recovered)
+	h.mu.Lock()
+	fuseID := h.activePluginPaths[id] == "" || h.pluginIdentityCurrentLocked(id, path, version)
+	if loaded := h.loaded[id]; loaded != nil {
+		fuseID = makePluginIdentityKey(id, loaded.path, loaded.version) == makePluginIdentityKey(id, path, version)
+	}
+	h.recordPluginFuseLocked(id, path, version, reason, fuseID)
+	h.mu.Unlock()
+	thinking.UnregisterPluginProvidersGeneration(id, pluginIdentityGeneration(path, version))
+	log.WithField("plugin_id", id).WithField("method", method).Errorf("pluginhost: plugin panic recovered: %v\n%s", recovered, debug.Stack())
+}
+
+func (h *Host) recordPluginFuseLocked(id, path, version, reason string, fuseID bool) {
+	if fuseID {
+		h.fused[id] = reason
+	}
+	identityKey := makePluginIdentityKey(id, path, version)
+	if identityKey.path != "" {
+		h.nextFuseEpoch++
+		h.fusedIdentities[identityKey] = h.nextFuseEpoch
+	}
+}
+
+func pluginIdentityGeneration(path, version string) string {
+	identity := makePluginIdentityKey("", path, version)
+	return identity.path + "\x00" + identity.version
+}

--- a/internal/pluginhost/rpc_client.go
+++ b/internal/pluginhost/rpc_client.go
@@ -53,6 +53,8 @@ type rpcResponseNormalizer struct {
 	method string
 }
 
+const statefulStreamInterceptorSchemaVersion uint32 = 3
+
 func registerRPCPlugin(ctx context.Context, host *Host, id string, client pluginClient, method string, configYAML []byte) (pluginapi.Plugin, error) {
 	if client == nil {
 		return pluginapi.Plugin{}, fmt.Errorf("plugin client is nil")
@@ -124,6 +126,7 @@ func registerRPCPlugin(ctx context.Context, host *Host, id string, client plugin
 	}
 	if resp.Capabilities.StreamChunkInterceptor {
 		plugin.Capabilities.StreamChunkInterceptor = adapter
+		plugin.Capabilities.StreamChunkInterceptorStateful = resp.SchemaVersion >= statefulStreamInterceptorSchemaVersion && resp.Capabilities.StreamChunkInterceptorStateful
 	}
 	if resp.Capabilities.ThinkingApplier {
 		plugin.Capabilities.ThinkingApplier = rpcThinkingApplier{rpcPluginAdapter: adapter}

--- a/internal/pluginhost/rpc_client.go
+++ b/internal/pluginhost/rpc_client.go
@@ -130,6 +130,7 @@ func registerRPCPlugin(ctx context.Context, host *Host, id string, client plugin
 	}
 	if resp.Capabilities.StreamChunkInterceptor {
 		plugin.Capabilities.StreamChunkInterceptor = adapter
+		plugin.Capabilities.StreamChunkInterceptorStateful = resp.SchemaVersion >= pluginabi.SchemaVersionStatefulStreamInterceptor && resp.Capabilities.StreamChunkInterceptorStateful
 	}
 	if resp.Capabilities.ThinkingApplier {
 		plugin.Capabilities.ThinkingApplier = rpcThinkingApplier{rpcPluginAdapter: adapter}

--- a/internal/pluginhost/rpc_schema.go
+++ b/internal/pluginhost/rpc_schema.go
@@ -19,30 +19,31 @@ type rpcRegistration struct {
 }
 
 type rpcCapabilities struct {
-	ModelRegistrar                bool                         `json:"model_registrar"`
-	ModelProvider                 bool                         `json:"model_provider"`
-	AuthProvider                  bool                         `json:"auth_provider"`
-	FrontendAuthProvider          bool                         `json:"frontend_auth_provider"`
-	FrontendAuthProviderExclusive bool                         `json:"frontend_auth_provider_exclusive"`
-	Scheduler                     bool                         `json:"scheduler"`
-	ModelRouter                   bool                         `json:"model_router"`
-	Executor                      bool                         `json:"executor"`
-	ExecutorModelScope            pluginapi.ExecutorModelScope `json:"executor_model_scope"`
-	ExecutorInputFormats          []string                     `json:"executor_input_formats,omitempty"`
-	ExecutorOutputFormats         []string                     `json:"executor_output_formats,omitempty"`
-	RequestTranslator             bool                         `json:"request_translator"`
-	RequestNormalizer             bool                         `json:"request_normalizer"`
-	RequestInterceptor            bool                         `json:"request_interceptor"`
-	RequestLifecyclePlugin        bool                         `json:"request_lifecycle_plugin"`
-	ResponseTranslator            bool                         `json:"response_translator"`
-	ResponseBeforeTranslator      bool                         `json:"response_before_translator"`
-	ResponseAfterTranslator       bool                         `json:"response_after_translator"`
-	ResponseInterceptor           bool                         `json:"response_interceptor"`
-	StreamChunkInterceptor        bool                         `json:"response_stream_interceptor"`
-	ThinkingApplier               bool                         `json:"thinking_applier"`
-	UsagePlugin                   bool                         `json:"usage_plugin"`
-	CommandLinePlugin             bool                         `json:"command_line_plugin"`
-	ManagementAPI                 bool                         `json:"management_api"`
+	ModelRegistrar                 bool                         `json:"model_registrar"`
+	ModelProvider                  bool                         `json:"model_provider"`
+	AuthProvider                   bool                         `json:"auth_provider"`
+	FrontendAuthProvider           bool                         `json:"frontend_auth_provider"`
+	FrontendAuthProviderExclusive  bool                         `json:"frontend_auth_provider_exclusive"`
+	Scheduler                      bool                         `json:"scheduler"`
+	ModelRouter                    bool                         `json:"model_router"`
+	Executor                       bool                         `json:"executor"`
+	ExecutorModelScope             pluginapi.ExecutorModelScope `json:"executor_model_scope"`
+	ExecutorInputFormats           []string                     `json:"executor_input_formats,omitempty"`
+	ExecutorOutputFormats          []string                     `json:"executor_output_formats,omitempty"`
+	RequestTranslator              bool                         `json:"request_translator"`
+	RequestNormalizer              bool                         `json:"request_normalizer"`
+	RequestInterceptor             bool                         `json:"request_interceptor"`
+	RequestLifecyclePlugin         bool                         `json:"request_lifecycle_plugin"`
+	ResponseTranslator             bool                         `json:"response_translator"`
+	ResponseBeforeTranslator       bool                         `json:"response_before_translator"`
+	ResponseAfterTranslator        bool                         `json:"response_after_translator"`
+	ResponseInterceptor            bool                         `json:"response_interceptor"`
+	StreamChunkInterceptor         bool                         `json:"response_stream_interceptor"`
+	StreamChunkInterceptorStateful bool                         `json:"response_stream_interceptor_stateful"`
+	ThinkingApplier                bool                         `json:"thinking_applier"`
+	UsagePlugin                    bool                         `json:"usage_plugin"`
+	CommandLinePlugin              bool                         `json:"command_line_plugin"`
+	ManagementAPI                  bool                         `json:"management_api"`
 }
 
 type rpcIdentifierResponse struct {
@@ -130,30 +131,31 @@ type rpcEmptyResponse struct{}
 func rpcCapabilitiesFromPlugin(plugin pluginapi.Plugin) rpcCapabilities {
 	caps := plugin.Capabilities
 	return rpcCapabilities{
-		ModelRegistrar:                caps.ModelRegistrar != nil,
-		ModelProvider:                 caps.ModelProvider != nil,
-		AuthProvider:                  caps.AuthProvider != nil,
-		FrontendAuthProvider:          caps.FrontendAuthProvider != nil,
-		FrontendAuthProviderExclusive: caps.FrontendAuthProvider != nil && caps.FrontendAuthProviderExclusive,
-		Scheduler:                     caps.Scheduler != nil,
-		ModelRouter:                   caps.ModelRouter != nil,
-		Executor:                      caps.Executor != nil,
-		ExecutorModelScope:            normalizedExecutorModelScope(caps),
-		ExecutorInputFormats:          append([]string(nil), caps.ExecutorInputFormats...),
-		ExecutorOutputFormats:         append([]string(nil), caps.ExecutorOutputFormats...),
-		RequestTranslator:             caps.RequestTranslator != nil,
-		RequestNormalizer:             caps.RequestNormalizer != nil,
-		RequestInterceptor:            caps.RequestInterceptor != nil,
-		RequestLifecyclePlugin:        caps.RequestLifecyclePlugin != nil,
-		ResponseTranslator:            caps.ResponseTranslator != nil,
-		ResponseBeforeTranslator:      caps.ResponseBeforeTranslator != nil,
-		ResponseAfterTranslator:       caps.ResponseAfterTranslator != nil,
-		ResponseInterceptor:           caps.ResponseInterceptor != nil,
-		StreamChunkInterceptor:        caps.StreamChunkInterceptor != nil,
-		ThinkingApplier:               caps.ThinkingApplier != nil,
-		UsagePlugin:                   caps.UsagePlugin != nil,
-		CommandLinePlugin:             caps.CommandLinePlugin != nil,
-		ManagementAPI:                 caps.ManagementAPI != nil,
+		ModelRegistrar:                 caps.ModelRegistrar != nil,
+		ModelProvider:                  caps.ModelProvider != nil,
+		AuthProvider:                   caps.AuthProvider != nil,
+		FrontendAuthProvider:           caps.FrontendAuthProvider != nil,
+		FrontendAuthProviderExclusive:  caps.FrontendAuthProvider != nil && caps.FrontendAuthProviderExclusive,
+		Scheduler:                      caps.Scheduler != nil,
+		ModelRouter:                    caps.ModelRouter != nil,
+		Executor:                       caps.Executor != nil,
+		ExecutorModelScope:             normalizedExecutorModelScope(caps),
+		ExecutorInputFormats:           append([]string(nil), caps.ExecutorInputFormats...),
+		ExecutorOutputFormats:          append([]string(nil), caps.ExecutorOutputFormats...),
+		RequestTranslator:              caps.RequestTranslator != nil,
+		RequestNormalizer:              caps.RequestNormalizer != nil,
+		RequestInterceptor:             caps.RequestInterceptor != nil,
+		RequestLifecyclePlugin:         caps.RequestLifecyclePlugin != nil,
+		ResponseTranslator:             caps.ResponseTranslator != nil,
+		ResponseBeforeTranslator:       caps.ResponseBeforeTranslator != nil,
+		ResponseAfterTranslator:        caps.ResponseAfterTranslator != nil,
+		ResponseInterceptor:            caps.ResponseInterceptor != nil,
+		StreamChunkInterceptor:         caps.StreamChunkInterceptor != nil,
+		StreamChunkInterceptorStateful: caps.StreamChunkInterceptor != nil && caps.StreamChunkInterceptorStateful,
+		ThinkingApplier:                caps.ThinkingApplier != nil,
+		UsagePlugin:                    caps.UsagePlugin != nil,
+		CommandLinePlugin:              caps.CommandLinePlugin != nil,
+		ManagementAPI:                  caps.ManagementAPI != nil,
 	}
 }
 

--- a/internal/pluginhost/rpc_schema_test.go
+++ b/internal/pluginhost/rpc_schema_test.go
@@ -43,6 +43,40 @@ func TestRPCCapabilitiesIncludeFrontendAuthProviderExclusive(t *testing.T) {
 	}
 }
 
+func TestRPCCapabilitiesIncludeStatefulStreamInterceptor(t *testing.T) {
+	plugin := pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+		StreamChunkInterceptor: responseInterceptorFunc{
+			interceptStreamChunk: func(context.Context, pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+				return pluginapi.StreamChunkInterceptResponse{}, nil
+			},
+		},
+		StreamChunkInterceptorStateful: true,
+	}}
+
+	caps := rpcCapabilitiesFromPlugin(plugin)
+	if !caps.StreamChunkInterceptor || !caps.StreamChunkInterceptorStateful {
+		t.Fatalf("stream capabilities = %+v, want interceptor and stateful true", caps)
+	}
+	raw, errMarshal := json.Marshal(caps)
+	if errMarshal != nil {
+		t.Fatalf("Marshal() error = %v", errMarshal)
+	}
+	var decoded map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &decoded); errUnmarshal != nil {
+		t.Fatalf("Unmarshal() error = %v", errUnmarshal)
+	}
+	if decoded["response_stream_interceptor_stateful"] != true {
+		t.Fatalf("response_stream_interceptor_stateful = %#v, want true", decoded["response_stream_interceptor_stateful"])
+	}
+
+	withoutInterceptor := rpcCapabilitiesFromPlugin(pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+		StreamChunkInterceptorStateful: true,
+	}})
+	if withoutInterceptor.StreamChunkInterceptorStateful {
+		t.Fatal("stateful flag must be ignored without a stream interceptor")
+	}
+}
+
 func TestRPCCapabilitiesIncludeScheduler(t *testing.T) {
 	plugin := pluginapi.Plugin{
 		Capabilities: pluginapi.Capabilities{
@@ -120,6 +154,51 @@ func TestRegisterRPCPluginSendsHostSchemaVersion(t *testing.T) {
 	}
 	if string(lookup.lastLifecycle.ConfigYAML) != "mode: test" {
 		t.Fatalf("lifecycle config = %q, want input config", lookup.lastLifecycle.ConfigYAML)
+	}
+}
+
+func TestRegisterRPCPluginCopiesStatefulStreamInterceptorCapability(t *testing.T) {
+	plugin := validTestPlugin("stateful-stream")
+	plugin.Capabilities.StreamChunkInterceptor = responseInterceptorFunc{
+		interceptStreamChunk: func(context.Context, pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+			return pluginapi.StreamChunkInterceptResponse{}, nil
+		},
+	}
+	plugin.Capabilities.StreamChunkInterceptorStateful = true
+	lookup := newTestSymbolLookup(&testPlugin{registerResult: plugin})
+
+	registered, errRegister := registerRPCPlugin(context.Background(), nil, "stateful-stream", lookup, pluginabi.MethodPluginRegister, nil)
+	if errRegister != nil {
+		t.Fatalf("registerRPCPlugin() error = %v", errRegister)
+	}
+	if registered.Capabilities.StreamChunkInterceptor == nil {
+		t.Fatal("StreamChunkInterceptor = nil, want RPC adapter")
+	}
+	if !registered.Capabilities.StreamChunkInterceptorStateful {
+		t.Fatal("StreamChunkInterceptorStateful = false, want copied registration capability")
+	}
+}
+
+func TestRegisterRPCPluginIgnoresStatefulStreamCapabilityBeforeSchema4(t *testing.T) {
+	plugin := validTestPlugin("stateful-stream-schema3")
+	plugin.Capabilities.StreamChunkInterceptor = responseInterceptorFunc{
+		interceptStreamChunk: func(context.Context, pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+			return pluginapi.StreamChunkInterceptResponse{}, nil
+		},
+	}
+	plugin.Capabilities.StreamChunkInterceptorStateful = true
+	lookup := newTestSymbolLookup(&testPlugin{registerResult: plugin})
+	lookup.schemaVersion = 3
+
+	registered, errRegister := registerRPCPlugin(context.Background(), nil, "stateful-stream-schema3", lookup, pluginabi.MethodPluginRegister, nil)
+	if errRegister != nil {
+		t.Fatalf("registerRPCPlugin() error = %v", errRegister)
+	}
+	if registered.Capabilities.StreamChunkInterceptor == nil {
+		t.Fatal("StreamChunkInterceptor = nil, want legacy RPC adapter")
+	}
+	if registered.Capabilities.StreamChunkInterceptorStateful {
+		t.Fatal("StreamChunkInterceptorStateful = true for schema 3 registration")
 	}
 }
 

--- a/internal/pluginhost/rpc_schema_test.go
+++ b/internal/pluginhost/rpc_schema_test.go
@@ -43,6 +43,40 @@ func TestRPCCapabilitiesIncludeFrontendAuthProviderExclusive(t *testing.T) {
 	}
 }
 
+func TestRPCCapabilitiesIncludeStatefulStreamInterceptor(t *testing.T) {
+	plugin := pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+		StreamChunkInterceptor: responseInterceptorFunc{
+			interceptStreamChunk: func(context.Context, pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+				return pluginapi.StreamChunkInterceptResponse{}, nil
+			},
+		},
+		StreamChunkInterceptorStateful: true,
+	}}
+
+	caps := rpcCapabilitiesFromPlugin(plugin)
+	if !caps.StreamChunkInterceptor || !caps.StreamChunkInterceptorStateful {
+		t.Fatalf("stream capabilities = %+v, want interceptor and stateful true", caps)
+	}
+	raw, errMarshal := json.Marshal(caps)
+	if errMarshal != nil {
+		t.Fatalf("Marshal() error = %v", errMarshal)
+	}
+	var decoded map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &decoded); errUnmarshal != nil {
+		t.Fatalf("Unmarshal() error = %v", errUnmarshal)
+	}
+	if decoded["response_stream_interceptor_stateful"] != true {
+		t.Fatalf("response_stream_interceptor_stateful = %#v, want true", decoded["response_stream_interceptor_stateful"])
+	}
+
+	withoutInterceptor := rpcCapabilitiesFromPlugin(pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+		StreamChunkInterceptorStateful: true,
+	}})
+	if withoutInterceptor.StreamChunkInterceptorStateful {
+		t.Fatal("stateful flag must be ignored without a stream interceptor")
+	}
+}
+
 func TestRPCCapabilitiesIncludeScheduler(t *testing.T) {
 	plugin := pluginapi.Plugin{
 		Capabilities: pluginapi.Capabilities{
@@ -116,6 +150,51 @@ func TestRegisterRPCPluginSendsHostSchemaVersion(t *testing.T) {
 	}
 	if string(lookup.lastLifecycle.ConfigYAML) != "mode: test" {
 		t.Fatalf("lifecycle config = %q, want input config", lookup.lastLifecycle.ConfigYAML)
+	}
+}
+
+func TestRegisterRPCPluginCopiesStatefulStreamInterceptorCapability(t *testing.T) {
+	plugin := validTestPlugin("stateful-stream")
+	plugin.Capabilities.StreamChunkInterceptor = responseInterceptorFunc{
+		interceptStreamChunk: func(context.Context, pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+			return pluginapi.StreamChunkInterceptResponse{}, nil
+		},
+	}
+	plugin.Capabilities.StreamChunkInterceptorStateful = true
+	lookup := newTestSymbolLookup(&testPlugin{registerResult: plugin})
+
+	registered, errRegister := registerRPCPlugin(context.Background(), nil, "stateful-stream", lookup, pluginabi.MethodPluginRegister, nil)
+	if errRegister != nil {
+		t.Fatalf("registerRPCPlugin() error = %v", errRegister)
+	}
+	if registered.Capabilities.StreamChunkInterceptor == nil {
+		t.Fatal("StreamChunkInterceptor = nil, want RPC adapter")
+	}
+	if !registered.Capabilities.StreamChunkInterceptorStateful {
+		t.Fatal("StreamChunkInterceptorStateful = false, want copied registration capability")
+	}
+}
+
+func TestRegisterRPCPluginIgnoresStatefulStreamCapabilityBeforeSchema3(t *testing.T) {
+	plugin := validTestPlugin("stateful-stream-schema2")
+	plugin.Capabilities.StreamChunkInterceptor = responseInterceptorFunc{
+		interceptStreamChunk: func(context.Context, pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+			return pluginapi.StreamChunkInterceptResponse{}, nil
+		},
+	}
+	plugin.Capabilities.StreamChunkInterceptorStateful = true
+	lookup := newTestSymbolLookup(&testPlugin{registerResult: plugin})
+	lookup.schemaVersion = 2
+
+	registered, errRegister := registerRPCPlugin(context.Background(), nil, "stateful-stream-schema2", lookup, pluginabi.MethodPluginRegister, nil)
+	if errRegister != nil {
+		t.Fatalf("registerRPCPlugin() error = %v", errRegister)
+	}
+	if registered.Capabilities.StreamChunkInterceptor == nil {
+		t.Fatal("StreamChunkInterceptor = nil, want legacy RPC adapter")
+	}
+	if registered.Capabilities.StreamChunkInterceptorStateful {
+		t.Fatal("StreamChunkInterceptorStateful = true for schema 2 registration")
 	}
 }
 

--- a/internal/pluginhost/scheduler.go
+++ b/internal/pluginhost/scheduler.go
@@ -55,7 +55,7 @@ func (h *Host) callScheduler(ctx context.Context, record capabilityRecord, req p
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.fusePlugin(record.id, "Scheduler.Pick", recovered)
+			h.fusePlugin(record, "Scheduler.Pick", recovered)
 			resp = pluginapi.SchedulerPickResponse{}
 			handled = false
 			err = nil

--- a/internal/pluginhost/snapshot.go
+++ b/internal/pluginhost/snapshot.go
@@ -71,7 +71,7 @@ func (h *Host) RegisteredPlugins() []RegisteredPluginInfo {
 		authProvider := record.plugin.Capabilities.AuthProvider
 		oauthProvider := ""
 		if authProvider != nil && !h.isPluginFused(record.id) {
-			if identifier, okIdentifier := h.callAuthProviderIdentifier(record.id, authProvider); okIdentifier {
+			if identifier, okIdentifier := h.callAuthProviderIdentifier(record, authProvider); okIdentifier {
 				oauthProvider = identifier
 			}
 		}

--- a/internal/pluginhost/test_helpers_test.go
+++ b/internal/pluginhost/test_helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync/atomic"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -36,7 +37,8 @@ func (l *testSymbolLoader) Open(file pluginFile, host *Host) (pluginClient, erro
 type testSymbolLookup struct {
 	plugin              *testPlugin
 	active              pluginapi.Plugin
-	shutdownCalls       int
+	shutdownCalls       atomic.Int32
+	shutdownDone        chan struct{}
 	registerOverride    func([]byte) pluginapi.Plugin
 	reconfigureOverride func([]byte) pluginapi.Plugin
 	schemaVersion       uint32
@@ -179,7 +181,10 @@ func (l *testSymbolLookup) Call(ctx context.Context, method string, request []by
 }
 
 func (l *testSymbolLookup) Shutdown() {
-	l.shutdownCalls++
+	l.shutdownCalls.Add(1)
+	if l.shutdownDone != nil {
+		close(l.shutdownDone)
+	}
 }
 
 func (l *testSymbolLookup) callLifecycle(request []byte, reload bool) ([]byte, error) {

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -11,9 +11,10 @@ import (
 )
 
 type pluginProviderApplier struct {
-	owner    string
-	priority int
-	applier  ProviderApplier
+	owner      string
+	generation string
+	priority   int
+	applier    ProviderApplier
 }
 
 var providerAppliersMu sync.RWMutex
@@ -60,7 +61,13 @@ func RegisterProvider(name string, applier ProviderApplier) {
 
 // RegisterPluginProvider registers a plugin-owned provider applier.
 func RegisterPluginProvider(owner string, name string, priority int, applier ProviderApplier) bool {
+	return RegisterPluginProviderGeneration(owner, "", name, priority, applier)
+}
+
+// RegisterPluginProviderGeneration registers a generation of a plugin-owned provider applier.
+func RegisterPluginProviderGeneration(owner string, generation string, name string, priority int, applier ProviderApplier) bool {
 	owner = strings.TrimSpace(owner)
+	generation = strings.TrimSpace(generation)
 	name = normalizedProviderName(name)
 	if owner == "" || name == "" || applier == nil {
 		return false
@@ -75,11 +82,28 @@ func RegisterPluginProvider(owner string, name string, priority int, applier Pro
 		return false
 	}
 	pluginProviderAppliers[name] = pluginProviderApplier{
-		owner:    owner,
-		priority: priority,
-		applier:  applier,
+		owner:      owner,
+		generation: generation,
+		priority:   priority,
+		applier:    applier,
 	}
 	return true
+}
+
+// UnregisterPluginProvidersGeneration removes provider appliers owned by one plugin generation.
+func UnregisterPluginProvidersGeneration(owner string, generation string) {
+	owner = strings.TrimSpace(owner)
+	generation = strings.TrimSpace(generation)
+	if owner == "" {
+		return
+	}
+	providerAppliersMu.Lock()
+	defer providerAppliersMu.Unlock()
+	for provider, record := range pluginProviderAppliers {
+		if record.owner == owner && record.generation == generation {
+			delete(pluginProviderAppliers, provider)
+		}
+	}
 }
 
 // UnregisterPluginProviders removes all provider appliers owned by one plugin.

--- a/internal/thinking/apply_test.go
+++ b/internal/thinking/apply_test.go
@@ -1,0 +1,36 @@
+package thinking
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+type testPluginProviderApplier struct {
+	marker []byte
+}
+
+func (a *testPluginProviderApplier) Apply(body []byte, config ThinkingConfig, modelInfo *registry.ModelInfo) ([]byte, error) {
+	return bytes.Clone(a.marker), nil
+}
+
+func TestUnregisterPluginProviderGenerationDoesNotRemoveReplacement(t *testing.T) {
+	ClearPluginProviders()
+	t.Cleanup(ClearPluginProviders)
+
+	old := &testPluginProviderApplier{marker: []byte("old")}
+	replacement := &testPluginProviderApplier{marker: []byte("replacement")}
+	if !RegisterPluginProviderGeneration("privacy", "v1", "test-provider", 0, old) {
+		t.Fatal("failed to register old plugin provider generation")
+	}
+	ClearPluginProviders()
+	if !RegisterPluginProviderGeneration("privacy", "v2", "test-provider", 0, replacement) {
+		t.Fatal("failed to register replacement plugin provider generation")
+	}
+
+	UnregisterPluginProvidersGeneration("privacy", "v1")
+	if got := GetProviderApplier("test-provider"); got != replacement {
+		t.Fatalf("provider after stale unregister = %T %p, want replacement %p", got, got, replacement)
+	}
+}

--- a/sdk/api/handlers/handlers_interceptors_test.go
+++ b/sdk/api/handlers/handlers_interceptors_test.go
@@ -28,14 +28,49 @@ type handlerInterceptorTestHost struct {
 	completeRequest            func(context.Context, pluginapi.RequestCompletion)
 	// includeStreamChunkRequestBodies simulates legacy schema_version < 3 plugins.
 	includeStreamChunkRequestBodies bool
+	streamSession                   pluginapi.StreamChunkInterceptorSession
+}
+
+type handlerStreamInterceptorSession struct {
+	intercept func(context.Context, pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse
+	canOmit   func() bool
+	onClose   func()
+}
+
+func (s *handlerStreamInterceptorSession) InterceptStreamChunk(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+	if s != nil && s.intercept != nil {
+		return s.intercept(ctx, req)
+	}
+	return pluginapi.StreamChunkInterceptResponse{Headers: cloneHeader(req.ResponseHeaders), Body: cloneBytes(req.Body)}
+}
+
+func (s *handlerStreamInterceptorSession) CanOmitHeavyFields() bool {
+	return s != nil && s.canOmit != nil && s.canOmit()
+}
+
+func (s *handlerStreamInterceptorSession) Close() {
+	if s != nil && s.onClose != nil {
+		s.onClose()
+	}
 }
 
 type handlerInterceptorNoStreamTestHost struct {
 	*handlerInterceptorTestHost
 }
 
+type handlerSessionInterceptorTestHost struct {
+	*handlerInterceptorTestHost
+}
+
 func (h *handlerInterceptorNoStreamTestHost) HasStreamInterceptors() bool {
 	return false
+}
+
+func (h *handlerSessionInterceptorTestHost) OpenStreamChunkInterceptorSession(skipPluginID string) pluginapi.StreamChunkInterceptorSession {
+	if h == nil || h.handlerInterceptorTestHost == nil {
+		return nil
+	}
+	return h.streamSession
 }
 
 func (h *handlerInterceptorTestHost) InterceptRequestBeforeAuth(ctx context.Context, req pluginapi.RequestInterceptRequest) pluginapi.RequestInterceptResponse {
@@ -1033,6 +1068,326 @@ func TestHandlerStreamInterceptorLegacySchemaClonesRequestBodiesOnPayloadChunks(
 	}
 }
 
+func TestHandlerStatefulStreamInterceptorOmitsHeavyPayloadFields(t *testing.T) {
+	model := "handler-stateful-stream-interceptor-model"
+	executor := &interceptorCaptureExecutor{
+		stream: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+			chunks := make(chan coreexecutor.StreamChunk, 2)
+			chunks <- coreexecutor.StreamChunk{Payload: []byte("first")}
+			chunks <- coreexecutor.StreamChunk{Payload: []byte("second")}
+			close(chunks)
+			return &coreexecutor.StreamResult{Chunks: chunks}, nil
+		},
+	}
+	handler := newInterceptorHandler(t, model, executor, &sdkconfig.SDKConfig{})
+	var requests []pluginapi.StreamChunkInterceptRequest
+	sessionClosed := make(chan struct{})
+	host := &handlerInterceptorTestHost{}
+	host.streamSession = &handlerStreamInterceptorSession{
+		canOmit: func() bool { return true },
+		onClose: func() { close(sessionClosed) },
+		intercept: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+			requests = append(requests, pluginapi.StreamChunkInterceptRequest{
+				StreamID:        req.StreamID,
+				OriginalRequest: cloneBytes(req.OriginalRequest),
+				RequestBody:     cloneBytes(req.RequestBody),
+				Body:            cloneBytes(req.Body),
+				HistoryChunks:   cloneByteSlices(req.HistoryChunks),
+				ChunkIndex:      req.ChunkIndex,
+			})
+			return pluginapi.StreamChunkInterceptResponse{Body: cloneBytes(req.Body)}
+		},
+	}
+	handler.SetPluginHost(&handlerSessionInterceptorTestHost{handlerInterceptorTestHost: host})
+
+	requestBody := []byte(fmt.Sprintf(`{"model":%q}`, model))
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, requestBody, "")
+	for range dataChan {
+	}
+	for msg := range errChan {
+		if msg != nil {
+			t.Fatalf("unexpected stream error: %+v", msg)
+		}
+	}
+	<-sessionClosed
+
+	if len(requests) != 4 {
+		t.Fatalf("stream interceptor calls = %d, want init, two chunks, and end", len(requests))
+	}
+	streamID := requests[0].StreamID
+	if streamID == "" {
+		t.Fatal("header-init StreamID is empty")
+	}
+	if requests[0].ChunkIndex != pluginapi.StreamChunkHeaderInitIndex || len(requests[0].RequestBody) == 0 {
+		t.Fatalf("header-init request = %+v, want heavy RequestBody", requests[0])
+	}
+	for i, req := range requests[1:3] {
+		if req.StreamID != streamID {
+			t.Fatalf("chunk %d StreamID = %q, want %q", i, req.StreamID, streamID)
+		}
+		if req.ChunkIndex != i {
+			t.Fatalf("chunk %d index = %d", i, req.ChunkIndex)
+		}
+		if len(req.RequestBody) != 0 || len(req.OriginalRequest) != 0 || len(req.HistoryChunks) != 0 {
+			t.Fatalf("chunk %d retained heavy fields: request=%d original=%d history=%d", i, len(req.RequestBody), len(req.OriginalRequest), len(req.HistoryChunks))
+		}
+	}
+	if requests[3].StreamID != streamID || requests[3].ChunkIndex != pluginapi.StreamChunkEndIndex {
+		t.Fatalf("stream end request = %+v, want StreamID %q and end index", requests[3], streamID)
+	}
+}
+
+func TestHandlerStatefulStreamInterceptorFallsBackWhenSessionDisablesOmission(t *testing.T) {
+	model := "handler-stateful-stream-session-fallback-model"
+	executor := &interceptorCaptureExecutor{
+		stream: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+			chunks := make(chan coreexecutor.StreamChunk, 2)
+			chunks <- coreexecutor.StreamChunk{Payload: []byte("first")}
+			chunks <- coreexecutor.StreamChunk{Payload: []byte("second")}
+			close(chunks)
+			return &coreexecutor.StreamResult{Chunks: chunks}, nil
+		},
+	}
+	handler := newInterceptorHandler(t, model, executor, &sdkconfig.SDKConfig{})
+	var requests []pluginapi.StreamChunkInterceptRequest
+	canOmit := true
+	sessionClosed := make(chan struct{})
+	host := &handlerInterceptorTestHost{}
+	host.streamSession = &handlerStreamInterceptorSession{
+		canOmit: func() bool { return canOmit },
+		onClose: func() { close(sessionClosed) },
+		intercept: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+			requests = append(requests, pluginapi.StreamChunkInterceptRequest{
+				StreamID:        req.StreamID,
+				OriginalRequest: cloneBytes(req.OriginalRequest),
+				RequestBody:     cloneBytes(req.RequestBody),
+				HistoryChunks:   cloneByteSlices(req.HistoryChunks),
+				ChunkIndex:      req.ChunkIndex,
+			})
+			if req.ChunkIndex == 0 {
+				canOmit = false
+			}
+			return pluginapi.StreamChunkInterceptResponse{Body: cloneBytes(req.Body)}
+		},
+	}
+	handler.SetPluginHost(&handlerSessionInterceptorTestHost{handlerInterceptorTestHost: host})
+
+	requestBody := []byte(fmt.Sprintf(`{"model":%q}`, model))
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, requestBody, "")
+	for range dataChan {
+	}
+	for msg := range errChan {
+		if msg != nil {
+			t.Fatalf("unexpected stream error: %+v", msg)
+		}
+	}
+	<-sessionClosed
+
+	if len(requests) != 4 {
+		t.Fatalf("stream interceptor calls = %d, want init, two chunks, and end", len(requests))
+	}
+	if len(requests[1].RequestBody) != 0 || len(requests[1].OriginalRequest) != 0 || len(requests[1].HistoryChunks) != 0 {
+		t.Fatalf("first chunk retained heavy fields before revision change: %+v", requests[1])
+	}
+	if string(requests[2].RequestBody) != string(requestBody) || string(requests[2].OriginalRequest) != string(requestBody) {
+		t.Fatalf("second chunk request fields = %q, %q, want %q", requests[2].RequestBody, requests[2].OriginalRequest, requestBody)
+	}
+	if len(requests[2].HistoryChunks) != 1 || string(requests[2].HistoryChunks[0]) != "first" {
+		t.Fatalf("second chunk history = %#v, want first payload", requests[2].HistoryChunks)
+	}
+	if requests[3].ChunkIndex != pluginapi.StreamChunkEndIndex || requests[3].StreamID != requests[0].StreamID {
+		t.Fatalf("stream end request = %+v, want end for StreamID %q", requests[3], requests[0].StreamID)
+	}
+}
+
+func TestHandlerStatefulStreamInterceptorEndsLifecycleAfterDroppedBootstrapRetry(t *testing.T) {
+	model := "handler-stateful-stream-retry-cleanup-model"
+	var executorCalls int
+	executor := &interceptorCaptureExecutor{
+		stream: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+			executorCalls++
+			chunks := make(chan coreexecutor.StreamChunk, 2)
+			if executorCalls == 1 {
+				chunks <- coreexecutor.StreamChunk{Payload: []byte("drop")}
+			}
+			chunks <- coreexecutor.StreamChunk{Err: &coreauth.Error{
+				Code:       "upstream_closed",
+				Message:    "upstream closed before delivery",
+				HTTPStatus: http.StatusBadGateway,
+			}}
+			close(chunks)
+			return &coreexecutor.StreamResult{Chunks: chunks}, nil
+		},
+	}
+	handler := newInterceptorHandler(t, model, executor, &sdkconfig.SDKConfig{
+		Streaming: sdkconfig.StreamingConfig{BootstrapRetries: 1},
+	})
+	retryAuth := &coreauth.Auth{
+		ID:       "handler-interceptor-retry-" + model,
+		Provider: executor.Identifier(),
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"email": "retry-" + model + "@example.com"},
+	}
+	if _, errRegister := handler.AuthManager.Register(context.Background(), retryAuth); errRegister != nil {
+		t.Fatalf("manager.Register(retry auth): %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(retryAuth.ID, retryAuth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(retryAuth.ID)
+	})
+	var requests []pluginapi.StreamChunkInterceptRequest
+	sessionClosed := make(chan struct{})
+	host := &handlerInterceptorTestHost{}
+	host.streamSession = &handlerStreamInterceptorSession{
+		canOmit: func() bool { return true },
+		onClose: func() { close(sessionClosed) },
+		intercept: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+			requests = append(requests, pluginapi.StreamChunkInterceptRequest{
+				StreamID:   req.StreamID,
+				Body:       cloneBytes(req.Body),
+				ChunkIndex: req.ChunkIndex,
+			})
+			if req.ChunkIndex == 0 {
+				return pluginapi.StreamChunkInterceptResponse{DropChunk: true}
+			}
+			return pluginapi.StreamChunkInterceptResponse{Body: cloneBytes(req.Body)}
+		},
+	}
+	handler.SetPluginHost(&handlerSessionInterceptorTestHost{handlerInterceptorTestHost: host})
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, []byte(fmt.Sprintf(`{"model":%q}`, model)), "")
+	for chunk := range dataChan {
+		t.Fatalf("unexpected delivered payload after interceptor drop: %q", chunk)
+	}
+	var gotErr *interfaces.ErrorMessage
+	for msg := range errChan {
+		if msg != nil {
+			gotErr = msg
+		}
+	}
+	<-sessionClosed
+
+	if gotErr == nil {
+		t.Fatal("expected terminal error from retry stream")
+	}
+	if executorCalls != 2 {
+		t.Fatalf("stream attempts = %d, want 2", executorCalls)
+	}
+	if len(requests) != 3 {
+		t.Fatalf("stream interceptor calls = %d, want init, dropped payload, and end", len(requests))
+	}
+	streamID := requests[0].StreamID
+	if streamID == "" || requests[0].ChunkIndex != pluginapi.StreamChunkHeaderInitIndex {
+		t.Fatalf("header-init request = %+v", requests[0])
+	}
+	if requests[1].ChunkIndex != 0 || string(requests[1].Body) != "drop" {
+		t.Fatalf("payload request = %+v, want dropped first chunk", requests[1])
+	}
+	if requests[2].ChunkIndex != pluginapi.StreamChunkEndIndex || requests[2].StreamID != streamID {
+		t.Fatalf("stream end request = %+v, want cleanup for StreamID %q", requests[2], streamID)
+	}
+}
+
+func TestHandlerStatefulStreamInterceptorRestartsLifecycleOnSuccessfulBootstrapRetry(t *testing.T) {
+	model := "handler-stateful-stream-retry-success-model"
+	var executorCalls int
+	executor := &interceptorCaptureExecutor{
+		stream: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+			executorCalls++
+			chunks := make(chan coreexecutor.StreamChunk, 2)
+			if executorCalls == 1 {
+				chunks <- coreexecutor.StreamChunk{Payload: []byte("drop")}
+				chunks <- coreexecutor.StreamChunk{Err: &coreauth.Error{
+					Code:       "upstream_closed",
+					Message:    "upstream closed before delivery",
+					HTTPStatus: http.StatusBadGateway,
+				}}
+			} else {
+				chunks <- coreexecutor.StreamChunk{Payload: []byte("retry")}
+			}
+			close(chunks)
+			return &coreexecutor.StreamResult{
+				Headers: http.Header{"X-Upstream-Attempt": []string{fmt.Sprintf("%d", executorCalls)}},
+				Chunks:  chunks,
+			}, nil
+		},
+	}
+	handler := newInterceptorHandler(t, model, executor, &sdkconfig.SDKConfig{
+		PassthroughHeaders: true,
+		Streaming:          sdkconfig.StreamingConfig{BootstrapRetries: 1},
+	})
+	retryAuth := &coreauth.Auth{
+		ID:       "handler-interceptor-retry-" + model,
+		Provider: executor.Identifier(),
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"email": "retry-" + model + "@example.com"},
+	}
+	if _, errRegister := handler.AuthManager.Register(context.Background(), retryAuth); errRegister != nil {
+		t.Fatalf("manager.Register(retry auth): %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(retryAuth.ID, retryAuth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(retryAuth.ID)
+	})
+	var requests []pluginapi.StreamChunkInterceptRequest
+	sessionClosed := make(chan struct{})
+	host := &handlerInterceptorTestHost{}
+	host.streamSession = &handlerStreamInterceptorSession{
+		canOmit: func() bool { return true },
+		onClose: func() { close(sessionClosed) },
+		intercept: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+			requests = append(requests, pluginapi.StreamChunkInterceptRequest{
+				StreamID:      req.StreamID,
+				Body:          cloneBytes(req.Body),
+				HistoryChunks: cloneByteSlices(req.HistoryChunks),
+				ChunkIndex:    req.ChunkIndex,
+			})
+			if string(req.Body) == "drop" {
+				return pluginapi.StreamChunkInterceptResponse{DropChunk: true}
+			}
+			return pluginapi.StreamChunkInterceptResponse{Body: cloneBytes(req.Body)}
+		},
+	}
+	handler.SetPluginHost(&handlerSessionInterceptorTestHost{handlerInterceptorTestHost: host})
+
+	dataChan, upstreamHeaders, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, []byte(fmt.Sprintf(`{"model":%q}`, model)), "")
+	var delivered []byte
+	for chunk := range dataChan {
+		delivered = append(delivered, chunk...)
+	}
+	for msg := range errChan {
+		if msg != nil {
+			t.Fatalf("unexpected stream error: %+v", msg)
+		}
+	}
+	<-sessionClosed
+	if got := upstreamHeaders.Get("X-Upstream-Attempt"); got != "2" {
+		t.Fatalf("returned upstream headers = attempt %q, want successful retry attempt 2", got)
+	}
+
+	if string(delivered) != "retry" {
+		t.Fatalf("delivered payload = %q, want retry", delivered)
+	}
+	if executorCalls != 2 {
+		t.Fatalf("stream attempts = %d, want 2", executorCalls)
+	}
+	if len(requests) != 5 {
+		t.Fatalf("stream interceptor calls = %d, want init, dropped payload, retry init, retry payload, and end", len(requests))
+	}
+	wantIndexes := []int{pluginapi.StreamChunkHeaderInitIndex, 0, pluginapi.StreamChunkHeaderInitIndex, 0, pluginapi.StreamChunkEndIndex}
+	for i, wantIndex := range wantIndexes {
+		if requests[i].ChunkIndex != wantIndex {
+			t.Fatalf("call %d chunk index = %d, want %d", i, requests[i].ChunkIndex, wantIndex)
+		}
+		if requests[i].StreamID != requests[0].StreamID {
+			t.Fatalf("call %d StreamID = %q, want %q", i, requests[i].StreamID, requests[0].StreamID)
+		}
+	}
+	if len(requests[3].HistoryChunks) != 0 {
+		t.Fatalf("retry payload history = %#v, want empty history for restarted upstream", requests[3].HistoryChunks)
+	}
+}
+
 func TestHandlerStreamInterceptorInitializesHeadersBeforeReturn(t *testing.T) {
 	model := "handler-interceptor-stream-header-before-return-model"
 	initStarted := make(chan struct{})
@@ -1170,7 +1525,71 @@ func TestAppendStreamInterceptorHistoryBoundsRetainedChunks(t *testing.T) {
 	}
 }
 
-func TestHandlerStreamInterceptorKeepsReturnedHeadersStableAfterFirstPayload(t *testing.T) {
+func TestStreamFinalizerContextPreservesValuesWithoutCancellation(t *testing.T) {
+	type contextKey string
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), contextKey("request"), "value"))
+	cancel()
+
+	finalizerCtx := streamFinalizerContext(ctx)
+	if got := finalizerCtx.Value(contextKey("request")); got != "value" {
+		t.Fatalf("finalizer context value = %#v, want preserved request value", got)
+	}
+	if err := finalizerCtx.Err(); err != nil {
+		t.Fatalf("finalizer context error = %v, want cancellation detached", err)
+	}
+}
+
+func TestHandlerStreamChannelsCloseBeforeBlockedSessionCleanup(t *testing.T) {
+	model := "handler-stream-blocked-cleanup-model"
+	executor := &interceptorCaptureExecutor{
+		stream: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+			chunks := make(chan coreexecutor.StreamChunk, 1)
+			chunks <- coreexecutor.StreamChunk{Payload: []byte("payload")}
+			close(chunks)
+			return &coreexecutor.StreamResult{Chunks: chunks}, nil
+		},
+	}
+	endStarted := make(chan struct{})
+	allowEnd := make(chan struct{})
+	defer close(allowEnd)
+	host := &handlerInterceptorTestHost{}
+	host.streamSession = &handlerStreamInterceptorSession{
+		canOmit: func() bool { return true },
+		intercept: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+			if req.ChunkIndex == pluginapi.StreamChunkEndIndex {
+				close(endStarted)
+				<-allowEnd
+			}
+			return pluginapi.StreamChunkInterceptResponse{Body: cloneBytes(req.Body)}
+		},
+	}
+	handler := newInterceptorHandler(t, model, executor, &sdkconfig.SDKConfig{})
+	handler.SetPluginHost(&handlerSessionInterceptorTestHost{handlerInterceptorTestHost: host})
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, []byte(fmt.Sprintf(`{"model":%q}`, model)), "")
+	if chunk := <-dataChan; string(chunk) != "payload" {
+		t.Fatalf("stream payload = %q, want payload", chunk)
+	}
+	<-endStarted
+	select {
+	case _, ok := <-dataChan:
+		if ok {
+			t.Fatal("data channel produced an extra payload")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("data channel remained open while session cleanup was blocked")
+	}
+	select {
+	case _, ok := <-errChan:
+		if ok {
+			t.Fatal("error channel remained open with an unexpected value")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("error channel remained open while session cleanup was blocked")
+	}
+}
+
+func TestHandlerStreamInterceptorKeepsReturnedHeadersStableAfterReturn(t *testing.T) {
 	model := "handler-interceptor-stream-stable-headers-model"
 	releaseSecond := make(chan struct{})
 	executor := &interceptorCaptureExecutor{
@@ -1208,6 +1627,9 @@ func TestHandlerStreamInterceptorKeepsReturnedHeadersStableAfterFirstPayload(t *
 	})
 
 	dataChan, upstreamHeaders, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, []byte(fmt.Sprintf(`{"model":%q}`, model)), "")
+	if upstreamHeaders.Get("X-Chunk") != "first" || upstreamHeaders.Get("X-Stage") != "init" {
+		t.Fatalf("upstream headers on return = %#v, want first transformed chunk headers", upstreamHeaders)
+	}
 	firstChunk, ok := <-dataChan
 	if !ok {
 		t.Fatal("data channel closed before first chunk")

--- a/sdk/api/handlers/handlers_interceptors_test.go
+++ b/sdk/api/handlers/handlers_interceptors_test.go
@@ -26,14 +26,49 @@ type handlerInterceptorTestHost struct {
 	interceptResponse          func(context.Context, pluginapi.ResponseInterceptRequest) pluginapi.ResponseInterceptResponse
 	interceptStreamChunk       func(context.Context, pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse
 	completeRequest            func(context.Context, pluginapi.RequestCompletion)
+	streamSession              pluginapi.StreamChunkInterceptorSession
+}
+
+type handlerStreamInterceptorSession struct {
+	intercept func(context.Context, pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse
+	canOmit   func() bool
+	onClose   func()
+}
+
+func (s *handlerStreamInterceptorSession) InterceptStreamChunk(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+	if s != nil && s.intercept != nil {
+		return s.intercept(ctx, req)
+	}
+	return pluginapi.StreamChunkInterceptResponse{Headers: cloneHeader(req.ResponseHeaders), Body: cloneBytes(req.Body)}
+}
+
+func (s *handlerStreamInterceptorSession) CanOmitHeavyFields() bool {
+	return s != nil && s.canOmit != nil && s.canOmit()
+}
+
+func (s *handlerStreamInterceptorSession) Close() {
+	if s != nil && s.onClose != nil {
+		s.onClose()
+	}
 }
 
 type handlerInterceptorNoStreamTestHost struct {
 	*handlerInterceptorTestHost
 }
 
+type handlerSessionInterceptorTestHost struct {
+	*handlerInterceptorTestHost
+}
+
 func (h *handlerInterceptorNoStreamTestHost) HasStreamInterceptors() bool {
 	return false
+}
+
+func (h *handlerSessionInterceptorTestHost) OpenStreamChunkInterceptorSession(skipPluginID string) pluginapi.StreamChunkInterceptorSession {
+	if h == nil || h.handlerInterceptorTestHost == nil {
+		return nil
+	}
+	return h.streamSession
 }
 
 func (h *handlerInterceptorTestHost) InterceptRequestBeforeAuth(ctx context.Context, req pluginapi.RequestInterceptRequest) pluginapi.RequestInterceptResponse {
@@ -957,6 +992,326 @@ func TestHandlerStreamInterceptorRewritesAndDropsChunks(t *testing.T) {
 	}
 }
 
+func TestHandlerStatefulStreamInterceptorOmitsHeavyPayloadFields(t *testing.T) {
+	model := "handler-stateful-stream-interceptor-model"
+	executor := &interceptorCaptureExecutor{
+		stream: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+			chunks := make(chan coreexecutor.StreamChunk, 2)
+			chunks <- coreexecutor.StreamChunk{Payload: []byte("first")}
+			chunks <- coreexecutor.StreamChunk{Payload: []byte("second")}
+			close(chunks)
+			return &coreexecutor.StreamResult{Chunks: chunks}, nil
+		},
+	}
+	handler := newInterceptorHandler(t, model, executor, &sdkconfig.SDKConfig{})
+	var requests []pluginapi.StreamChunkInterceptRequest
+	sessionClosed := make(chan struct{})
+	host := &handlerInterceptorTestHost{}
+	host.streamSession = &handlerStreamInterceptorSession{
+		canOmit: func() bool { return true },
+		onClose: func() { close(sessionClosed) },
+		intercept: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+			requests = append(requests, pluginapi.StreamChunkInterceptRequest{
+				StreamID:        req.StreamID,
+				OriginalRequest: cloneBytes(req.OriginalRequest),
+				RequestBody:     cloneBytes(req.RequestBody),
+				Body:            cloneBytes(req.Body),
+				HistoryChunks:   cloneByteSlices(req.HistoryChunks),
+				ChunkIndex:      req.ChunkIndex,
+			})
+			return pluginapi.StreamChunkInterceptResponse{Body: cloneBytes(req.Body)}
+		},
+	}
+	handler.SetPluginHost(&handlerSessionInterceptorTestHost{handlerInterceptorTestHost: host})
+
+	requestBody := []byte(fmt.Sprintf(`{"model":%q}`, model))
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, requestBody, "")
+	for range dataChan {
+	}
+	for msg := range errChan {
+		if msg != nil {
+			t.Fatalf("unexpected stream error: %+v", msg)
+		}
+	}
+	<-sessionClosed
+
+	if len(requests) != 4 {
+		t.Fatalf("stream interceptor calls = %d, want init, two chunks, and end", len(requests))
+	}
+	streamID := requests[0].StreamID
+	if streamID == "" {
+		t.Fatal("header-init StreamID is empty")
+	}
+	if requests[0].ChunkIndex != pluginapi.StreamChunkHeaderInitIndex || len(requests[0].RequestBody) == 0 {
+		t.Fatalf("header-init request = %+v, want heavy RequestBody", requests[0])
+	}
+	for i, req := range requests[1:3] {
+		if req.StreamID != streamID {
+			t.Fatalf("chunk %d StreamID = %q, want %q", i, req.StreamID, streamID)
+		}
+		if req.ChunkIndex != i {
+			t.Fatalf("chunk %d index = %d", i, req.ChunkIndex)
+		}
+		if len(req.RequestBody) != 0 || len(req.OriginalRequest) != 0 || len(req.HistoryChunks) != 0 {
+			t.Fatalf("chunk %d retained heavy fields: request=%d original=%d history=%d", i, len(req.RequestBody), len(req.OriginalRequest), len(req.HistoryChunks))
+		}
+	}
+	if requests[3].StreamID != streamID || requests[3].ChunkIndex != pluginapi.StreamChunkEndIndex {
+		t.Fatalf("stream end request = %+v, want StreamID %q and end index", requests[3], streamID)
+	}
+}
+
+func TestHandlerStatefulStreamInterceptorFallsBackWhenSessionDisablesOmission(t *testing.T) {
+	model := "handler-stateful-stream-session-fallback-model"
+	executor := &interceptorCaptureExecutor{
+		stream: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+			chunks := make(chan coreexecutor.StreamChunk, 2)
+			chunks <- coreexecutor.StreamChunk{Payload: []byte("first")}
+			chunks <- coreexecutor.StreamChunk{Payload: []byte("second")}
+			close(chunks)
+			return &coreexecutor.StreamResult{Chunks: chunks}, nil
+		},
+	}
+	handler := newInterceptorHandler(t, model, executor, &sdkconfig.SDKConfig{})
+	var requests []pluginapi.StreamChunkInterceptRequest
+	canOmit := true
+	sessionClosed := make(chan struct{})
+	host := &handlerInterceptorTestHost{}
+	host.streamSession = &handlerStreamInterceptorSession{
+		canOmit: func() bool { return canOmit },
+		onClose: func() { close(sessionClosed) },
+		intercept: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+			requests = append(requests, pluginapi.StreamChunkInterceptRequest{
+				StreamID:        req.StreamID,
+				OriginalRequest: cloneBytes(req.OriginalRequest),
+				RequestBody:     cloneBytes(req.RequestBody),
+				HistoryChunks:   cloneByteSlices(req.HistoryChunks),
+				ChunkIndex:      req.ChunkIndex,
+			})
+			if req.ChunkIndex == 0 {
+				canOmit = false
+			}
+			return pluginapi.StreamChunkInterceptResponse{Body: cloneBytes(req.Body)}
+		},
+	}
+	handler.SetPluginHost(&handlerSessionInterceptorTestHost{handlerInterceptorTestHost: host})
+
+	requestBody := []byte(fmt.Sprintf(`{"model":%q}`, model))
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, requestBody, "")
+	for range dataChan {
+	}
+	for msg := range errChan {
+		if msg != nil {
+			t.Fatalf("unexpected stream error: %+v", msg)
+		}
+	}
+	<-sessionClosed
+
+	if len(requests) != 4 {
+		t.Fatalf("stream interceptor calls = %d, want init, two chunks, and end", len(requests))
+	}
+	if len(requests[1].RequestBody) != 0 || len(requests[1].OriginalRequest) != 0 || len(requests[1].HistoryChunks) != 0 {
+		t.Fatalf("first chunk retained heavy fields before revision change: %+v", requests[1])
+	}
+	if string(requests[2].RequestBody) != string(requestBody) || string(requests[2].OriginalRequest) != string(requestBody) {
+		t.Fatalf("second chunk request fields = %q, %q, want %q", requests[2].RequestBody, requests[2].OriginalRequest, requestBody)
+	}
+	if len(requests[2].HistoryChunks) != 1 || string(requests[2].HistoryChunks[0]) != "first" {
+		t.Fatalf("second chunk history = %#v, want first payload", requests[2].HistoryChunks)
+	}
+	if requests[3].ChunkIndex != pluginapi.StreamChunkEndIndex || requests[3].StreamID != requests[0].StreamID {
+		t.Fatalf("stream end request = %+v, want end for StreamID %q", requests[3], requests[0].StreamID)
+	}
+}
+
+func TestHandlerStatefulStreamInterceptorEndsLifecycleAfterDroppedBootstrapRetry(t *testing.T) {
+	model := "handler-stateful-stream-retry-cleanup-model"
+	var executorCalls int
+	executor := &interceptorCaptureExecutor{
+		stream: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+			executorCalls++
+			chunks := make(chan coreexecutor.StreamChunk, 2)
+			if executorCalls == 1 {
+				chunks <- coreexecutor.StreamChunk{Payload: []byte("drop")}
+			}
+			chunks <- coreexecutor.StreamChunk{Err: &coreauth.Error{
+				Code:       "upstream_closed",
+				Message:    "upstream closed before delivery",
+				HTTPStatus: http.StatusBadGateway,
+			}}
+			close(chunks)
+			return &coreexecutor.StreamResult{Chunks: chunks}, nil
+		},
+	}
+	handler := newInterceptorHandler(t, model, executor, &sdkconfig.SDKConfig{
+		Streaming: sdkconfig.StreamingConfig{BootstrapRetries: 1},
+	})
+	retryAuth := &coreauth.Auth{
+		ID:       "handler-interceptor-retry-" + model,
+		Provider: executor.Identifier(),
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"email": "retry-" + model + "@example.com"},
+	}
+	if _, errRegister := handler.AuthManager.Register(context.Background(), retryAuth); errRegister != nil {
+		t.Fatalf("manager.Register(retry auth): %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(retryAuth.ID, retryAuth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(retryAuth.ID)
+	})
+	var requests []pluginapi.StreamChunkInterceptRequest
+	sessionClosed := make(chan struct{})
+	host := &handlerInterceptorTestHost{}
+	host.streamSession = &handlerStreamInterceptorSession{
+		canOmit: func() bool { return true },
+		onClose: func() { close(sessionClosed) },
+		intercept: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+			requests = append(requests, pluginapi.StreamChunkInterceptRequest{
+				StreamID:   req.StreamID,
+				Body:       cloneBytes(req.Body),
+				ChunkIndex: req.ChunkIndex,
+			})
+			if req.ChunkIndex == 0 {
+				return pluginapi.StreamChunkInterceptResponse{DropChunk: true}
+			}
+			return pluginapi.StreamChunkInterceptResponse{Body: cloneBytes(req.Body)}
+		},
+	}
+	handler.SetPluginHost(&handlerSessionInterceptorTestHost{handlerInterceptorTestHost: host})
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, []byte(fmt.Sprintf(`{"model":%q}`, model)), "")
+	for chunk := range dataChan {
+		t.Fatalf("unexpected delivered payload after interceptor drop: %q", chunk)
+	}
+	var gotErr *interfaces.ErrorMessage
+	for msg := range errChan {
+		if msg != nil {
+			gotErr = msg
+		}
+	}
+	<-sessionClosed
+
+	if gotErr == nil {
+		t.Fatal("expected terminal error from retry stream")
+	}
+	if executorCalls != 2 {
+		t.Fatalf("stream attempts = %d, want 2", executorCalls)
+	}
+	if len(requests) != 3 {
+		t.Fatalf("stream interceptor calls = %d, want init, dropped payload, and end", len(requests))
+	}
+	streamID := requests[0].StreamID
+	if streamID == "" || requests[0].ChunkIndex != pluginapi.StreamChunkHeaderInitIndex {
+		t.Fatalf("header-init request = %+v", requests[0])
+	}
+	if requests[1].ChunkIndex != 0 || string(requests[1].Body) != "drop" {
+		t.Fatalf("payload request = %+v, want dropped first chunk", requests[1])
+	}
+	if requests[2].ChunkIndex != pluginapi.StreamChunkEndIndex || requests[2].StreamID != streamID {
+		t.Fatalf("stream end request = %+v, want cleanup for StreamID %q", requests[2], streamID)
+	}
+}
+
+func TestHandlerStatefulStreamInterceptorRestartsLifecycleOnSuccessfulBootstrapRetry(t *testing.T) {
+	model := "handler-stateful-stream-retry-success-model"
+	var executorCalls int
+	executor := &interceptorCaptureExecutor{
+		stream: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+			executorCalls++
+			chunks := make(chan coreexecutor.StreamChunk, 2)
+			if executorCalls == 1 {
+				chunks <- coreexecutor.StreamChunk{Payload: []byte("drop")}
+				chunks <- coreexecutor.StreamChunk{Err: &coreauth.Error{
+					Code:       "upstream_closed",
+					Message:    "upstream closed before delivery",
+					HTTPStatus: http.StatusBadGateway,
+				}}
+			} else {
+				chunks <- coreexecutor.StreamChunk{Payload: []byte("retry")}
+			}
+			close(chunks)
+			return &coreexecutor.StreamResult{
+				Headers: http.Header{"X-Upstream-Attempt": []string{fmt.Sprintf("%d", executorCalls)}},
+				Chunks:  chunks,
+			}, nil
+		},
+	}
+	handler := newInterceptorHandler(t, model, executor, &sdkconfig.SDKConfig{
+		PassthroughHeaders: true,
+		Streaming:          sdkconfig.StreamingConfig{BootstrapRetries: 1},
+	})
+	retryAuth := &coreauth.Auth{
+		ID:       "handler-interceptor-retry-" + model,
+		Provider: executor.Identifier(),
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"email": "retry-" + model + "@example.com"},
+	}
+	if _, errRegister := handler.AuthManager.Register(context.Background(), retryAuth); errRegister != nil {
+		t.Fatalf("manager.Register(retry auth): %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(retryAuth.ID, retryAuth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(retryAuth.ID)
+	})
+	var requests []pluginapi.StreamChunkInterceptRequest
+	sessionClosed := make(chan struct{})
+	host := &handlerInterceptorTestHost{}
+	host.streamSession = &handlerStreamInterceptorSession{
+		canOmit: func() bool { return true },
+		onClose: func() { close(sessionClosed) },
+		intercept: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+			requests = append(requests, pluginapi.StreamChunkInterceptRequest{
+				StreamID:      req.StreamID,
+				Body:          cloneBytes(req.Body),
+				HistoryChunks: cloneByteSlices(req.HistoryChunks),
+				ChunkIndex:    req.ChunkIndex,
+			})
+			if string(req.Body) == "drop" {
+				return pluginapi.StreamChunkInterceptResponse{DropChunk: true}
+			}
+			return pluginapi.StreamChunkInterceptResponse{Body: cloneBytes(req.Body)}
+		},
+	}
+	handler.SetPluginHost(&handlerSessionInterceptorTestHost{handlerInterceptorTestHost: host})
+
+	dataChan, upstreamHeaders, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, []byte(fmt.Sprintf(`{"model":%q}`, model)), "")
+	var delivered []byte
+	for chunk := range dataChan {
+		delivered = append(delivered, chunk...)
+	}
+	for msg := range errChan {
+		if msg != nil {
+			t.Fatalf("unexpected stream error: %+v", msg)
+		}
+	}
+	<-sessionClosed
+	if got := upstreamHeaders.Get("X-Upstream-Attempt"); got != "2" {
+		t.Fatalf("returned upstream headers = attempt %q, want successful retry attempt 2", got)
+	}
+
+	if string(delivered) != "retry" {
+		t.Fatalf("delivered payload = %q, want retry", delivered)
+	}
+	if executorCalls != 2 {
+		t.Fatalf("stream attempts = %d, want 2", executorCalls)
+	}
+	if len(requests) != 5 {
+		t.Fatalf("stream interceptor calls = %d, want init, dropped payload, retry init, retry payload, and end", len(requests))
+	}
+	wantIndexes := []int{pluginapi.StreamChunkHeaderInitIndex, 0, pluginapi.StreamChunkHeaderInitIndex, 0, pluginapi.StreamChunkEndIndex}
+	for i, wantIndex := range wantIndexes {
+		if requests[i].ChunkIndex != wantIndex {
+			t.Fatalf("call %d chunk index = %d, want %d", i, requests[i].ChunkIndex, wantIndex)
+		}
+		if requests[i].StreamID != requests[0].StreamID {
+			t.Fatalf("call %d StreamID = %q, want %q", i, requests[i].StreamID, requests[0].StreamID)
+		}
+	}
+	if len(requests[3].HistoryChunks) != 0 {
+		t.Fatalf("retry payload history = %#v, want empty history for restarted upstream", requests[3].HistoryChunks)
+	}
+}
+
 func TestHandlerStreamInterceptorInitializesHeadersBeforeReturn(t *testing.T) {
 	model := "handler-interceptor-stream-header-before-return-model"
 	initStarted := make(chan struct{})
@@ -1094,7 +1449,71 @@ func TestAppendStreamInterceptorHistoryBoundsRetainedChunks(t *testing.T) {
 	}
 }
 
-func TestHandlerStreamInterceptorKeepsReturnedHeadersStableAfterFirstPayload(t *testing.T) {
+func TestStreamFinalizerContextPreservesValuesWithoutCancellation(t *testing.T) {
+	type contextKey string
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), contextKey("request"), "value"))
+	cancel()
+
+	finalizerCtx := streamFinalizerContext(ctx)
+	if got := finalizerCtx.Value(contextKey("request")); got != "value" {
+		t.Fatalf("finalizer context value = %#v, want preserved request value", got)
+	}
+	if err := finalizerCtx.Err(); err != nil {
+		t.Fatalf("finalizer context error = %v, want cancellation detached", err)
+	}
+}
+
+func TestHandlerStreamChannelsCloseBeforeBlockedSessionCleanup(t *testing.T) {
+	model := "handler-stream-blocked-cleanup-model"
+	executor := &interceptorCaptureExecutor{
+		stream: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+			chunks := make(chan coreexecutor.StreamChunk, 1)
+			chunks <- coreexecutor.StreamChunk{Payload: []byte("payload")}
+			close(chunks)
+			return &coreexecutor.StreamResult{Chunks: chunks}, nil
+		},
+	}
+	endStarted := make(chan struct{})
+	allowEnd := make(chan struct{})
+	defer close(allowEnd)
+	host := &handlerInterceptorTestHost{}
+	host.streamSession = &handlerStreamInterceptorSession{
+		canOmit: func() bool { return true },
+		intercept: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+			if req.ChunkIndex == pluginapi.StreamChunkEndIndex {
+				close(endStarted)
+				<-allowEnd
+			}
+			return pluginapi.StreamChunkInterceptResponse{Body: cloneBytes(req.Body)}
+		},
+	}
+	handler := newInterceptorHandler(t, model, executor, &sdkconfig.SDKConfig{})
+	handler.SetPluginHost(&handlerSessionInterceptorTestHost{handlerInterceptorTestHost: host})
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, []byte(fmt.Sprintf(`{"model":%q}`, model)), "")
+	if chunk := <-dataChan; string(chunk) != "payload" {
+		t.Fatalf("stream payload = %q, want payload", chunk)
+	}
+	<-endStarted
+	select {
+	case _, ok := <-dataChan:
+		if ok {
+			t.Fatal("data channel produced an extra payload")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("data channel remained open while session cleanup was blocked")
+	}
+	select {
+	case _, ok := <-errChan:
+		if ok {
+			t.Fatal("error channel remained open with an unexpected value")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("error channel remained open while session cleanup was blocked")
+	}
+}
+
+func TestHandlerStreamInterceptorKeepsReturnedHeadersStableAfterReturn(t *testing.T) {
 	model := "handler-interceptor-stream-stable-headers-model"
 	releaseSecond := make(chan struct{})
 	executor := &interceptorCaptureExecutor{
@@ -1132,6 +1551,9 @@ func TestHandlerStreamInterceptorKeepsReturnedHeadersStableAfterFirstPayload(t *
 	})
 
 	dataChan, upstreamHeaders, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, []byte(fmt.Sprintf(`{"model":%q}`, model)), "")
+	if upstreamHeaders.Get("X-Chunk") != "first" || upstreamHeaders.Get("X-Stage") != "init" {
+		t.Fatalf("upstream headers on return = %#v, want first transformed chunk headers", upstreamHeaders)
+	}
 	firstChunk, ok := <-dataChan
 	if !ok {
 		t.Fatal("data channel closed before first chunk")

--- a/sdk/api/handlers/handlers_model_router_test.go
+++ b/sdk/api/handlers/handlers_model_router_test.go
@@ -136,13 +136,25 @@ func (h *handlerDirectExecutorRouteHost) CountPluginExecutor(ctx context.Context
 
 type handlerDirectExecutorInterceptorHost struct {
 	handlerDirectExecutorRouteHost
-	afterAuthCalled bool
-	afterAuthReq    pluginapi.RequestInterceptRequest
+	afterAuthCalled    bool
+	afterAuthReq       pluginapi.RequestInterceptRequest
+	streamStateful     bool
+	streamSession      pluginapi.StreamChunkInterceptorSession
+	streamInterceptReq []pluginapi.StreamChunkInterceptRequest
 }
 
 func (h *handlerDirectExecutorInterceptorHost) HasRequestInterceptors() bool { return true }
 
-func (h *handlerDirectExecutorInterceptorHost) HasStreamInterceptors() bool { return false }
+func (h *handlerDirectExecutorInterceptorHost) HasStreamInterceptors() bool {
+	return h != nil && h.streamStateful
+}
+
+func (h *handlerDirectExecutorInterceptorHost) OpenStreamChunkInterceptorSession(skipPluginID string) pluginapi.StreamChunkInterceptorSession {
+	if h == nil {
+		return nil
+	}
+	return h.streamSession
+}
 
 func (h *handlerDirectExecutorInterceptorHost) InterceptRequestBeforeAuth(ctx context.Context, req pluginapi.RequestInterceptRequest) pluginapi.RequestInterceptResponse {
 	return pluginapi.RequestInterceptResponse{Headers: cloneHeader(req.Headers), Body: cloneBytes(req.Body)}
@@ -164,6 +176,7 @@ func (h *handlerDirectExecutorInterceptorHost) InterceptResponse(ctx context.Con
 }
 
 func (h *handlerDirectExecutorInterceptorHost) InterceptStreamChunk(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+	h.streamInterceptReq = append(h.streamInterceptReq, req)
 	return pluginapi.StreamChunkInterceptResponse{Headers: cloneHeader(req.ResponseHeaders), Body: cloneBytes(req.Body)}
 }
 
@@ -543,6 +556,72 @@ func TestExecuteModelStreamDoesNotReusePreparedRouteWhenRouterPluginSkipped(t *t
 	}
 	if errMsg == nil {
 		t.Fatal("ExecuteModelStream() error = nil, want normal provider resolution failure with empty auth manager")
+	}
+}
+
+func TestHandlerPluginExecutorStatefulStreamInterceptorOmitsHeavyPayloadFields(t *testing.T) {
+	originalModel := "handler-plugin-executor-stateful-stream-model"
+	host := &handlerDirectExecutorInterceptorHost{streamStateful: true}
+	sessionClosed := make(chan struct{})
+	host.streamSession = &handlerStreamInterceptorSession{
+		canOmit: func() bool { return true },
+		onClose: func() { close(sessionClosed) },
+		intercept: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+			host.streamInterceptReq = append(host.streamInterceptReq, req)
+			headers := cloneHeader(req.ResponseHeaders)
+			if headers == nil {
+				headers = make(http.Header)
+			}
+			switch req.ChunkIndex {
+			case pluginapi.StreamChunkHeaderInitIndex:
+				headers.Set("X-Stage", "init")
+			case 0:
+				headers.Set("X-Chunk", "payload")
+			}
+			return pluginapi.StreamChunkInterceptResponse{Headers: headers, Body: cloneBytes(req.Body)}
+		},
+	}
+	host.hasRouters = true
+	host.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: "stream-plugin"}, true
+	}
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetPluginHost(host)
+
+	dataChan, upstreamHeaders, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", originalModel, []byte(fmt.Sprintf(`{"model":%q,"stream":true}`, originalModel)), "")
+	if upstreamHeaders.Get("X-Stage") != "init" || upstreamHeaders.Get("X-Chunk") != "" {
+		t.Fatalf("upstream headers on return = %#v, want only initialized headers", upstreamHeaders)
+	}
+	for range dataChan {
+	}
+	for errMsg := range errChan {
+		if errMsg != nil {
+			t.Fatalf("ExecuteStreamWithAuthManager() error = %+v", errMsg)
+		}
+	}
+	<-sessionClosed
+	if upstreamHeaders.Get("X-Stage") != "init" || upstreamHeaders.Get("X-Chunk") != "" {
+		t.Fatalf("upstream headers changed after return: %#v", upstreamHeaders)
+	}
+
+	if len(host.streamInterceptReq) != 3 {
+		t.Fatalf("stream interceptor calls = %d, want init, payload, and end", len(host.streamInterceptReq))
+	}
+	initReq, payloadReq, endReq := host.streamInterceptReq[0], host.streamInterceptReq[1], host.streamInterceptReq[2]
+	if initReq.ChunkIndex != pluginapi.StreamChunkHeaderInitIndex || initReq.StreamID == "" {
+		t.Fatalf("init request = %#v, want header init with stream ID", initReq)
+	}
+	if len(initReq.RequestBody) == 0 || len(initReq.OriginalRequest) == 0 {
+		t.Fatalf("init request heavy fields = %#v/%#v, want request body and original request", initReq.RequestBody, initReq.OriginalRequest)
+	}
+	if payloadReq.ChunkIndex != 0 || payloadReq.StreamID != initReq.StreamID {
+		t.Fatalf("payload request = %#v, want chunk 0 with init stream ID", payloadReq)
+	}
+	if len(payloadReq.RequestBody) != 0 || len(payloadReq.OriginalRequest) != 0 || len(payloadReq.HistoryChunks) != 0 {
+		t.Fatalf("payload heavy fields = %#v/%#v/%#v, want omitted", payloadReq.RequestBody, payloadReq.OriginalRequest, payloadReq.HistoryChunks)
+	}
+	if endReq.ChunkIndex != pluginapi.StreamChunkEndIndex || endReq.StreamID != initReq.StreamID {
+		t.Fatalf("end request = %#v, want end marker with init stream ID", endReq)
 	}
 }
 

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
@@ -78,7 +79,15 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 
 	passthroughHeadersEnabled := PassthroughHeadersEnabled(h.Cfg)
 	interceptorHost := h.interceptorHost()
-	streamInterceptorsActive := streamInterceptorsEnabled(interceptorHost)
+	streamInterceptorSession, streamSessionsSupported := openStreamChunkInterceptorSession(interceptorHost, execOptions.SkipInterceptorPluginID)
+	streamInterceptorsActive := streamInterceptorSession != nil
+	if !streamSessionsSupported {
+		streamInterceptorsActive = streamInterceptorsEnabled(interceptorHost)
+	}
+	streamID := ""
+	if streamInterceptorSession != nil {
+		streamID = uuid.NewString()
+	}
 	rawStreamHeaders := cloneHeader(streamResult.Headers)
 	baseStreamHeaders := cloneHeader(streamResult.Headers)
 	// Request headers and request bodies are stream-invariant. Keep a private snapshot
@@ -94,8 +103,9 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 		streamRequestHeaders = cloneHeader(opts.Headers)
 		streamOriginalRequest = cloneBytes(opts.OriginalRequest)
 		streamRequestBody = cloneBytes(req.Payload)
-		intercepted := interceptStreamChunk(ctx, interceptorHost, pluginapi.StreamChunkInterceptRequest{
+		intercepted := interceptStreamChunkWithSession(ctx, streamInterceptorSession, interceptorHost, pluginapi.StreamChunkInterceptRequest{
 			RequestID:       lifecycle.requestID(),
+			StreamID:        streamID,
 			SourceFormat:    responseProtocol,
 			Model:           modelName,
 			RequestedModel:  originalRequestedModel,
@@ -112,6 +122,23 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 	if upstreamHeaders == nil && (passthroughHeadersEnabled || streamInterceptorsActive) {
 		upstreamHeaders = make(http.Header)
 	}
+	endStreamInterceptors := func() {
+		if streamInterceptorSession == nil {
+			return
+		}
+		defer streamInterceptorSession.Close()
+		streamInterceptorSession.InterceptStreamChunk(streamFinalizerContext(ctx), pluginapi.StreamChunkInterceptRequest{
+			RequestID:       lifecycle.requestID(),
+			StreamID:        streamID,
+			SourceFormat:    responseProtocol,
+			Model:           modelName,
+			RequestedModel:  originalRequestedModel,
+			RequestHeaders:  cloneHeader(opts.Headers),
+			ResponseHeaders: cloneHeader(rawStreamHeaders),
+			ChunkIndex:      pluginapi.StreamChunkEndIndex,
+			Metadata:        opts.Metadata,
+		})
+	}
 
 	dataChan := make(chan []byte)
 	errChan := make(chan *interfaces.ErrorMessage, 1)
@@ -126,6 +153,7 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 		chunks = closed
 	}
 	go func() {
+		defer endStreamInterceptors()
 		completionOutcome := pluginapi.RequestCompletionSucceeded
 		completionStatus := http.StatusOK
 		var completionErr error
@@ -170,8 +198,9 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 			}
 			payload := cloneBytes(chunk.Payload)
 			if streamInterceptorsActive {
-				chunkReq := pluginapi.StreamChunkInterceptRequest{
+				interceptReq := pluginapi.StreamChunkInterceptRequest{
 					RequestID:       lifecycle.requestID(),
+					StreamID:        streamID,
 					SourceFormat:    responseProtocol,
 					Model:           modelName,
 					RequestedModel:  originalRequestedModel,
@@ -182,13 +211,18 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 					ChunkIndex:      chunkIndex,
 					Metadata:        opts.Metadata,
 				}
-				// Re-evaluate each chunk so mid-stream plugin reloads stay correct.
-				// Schema v3+ omits bodies here (one header-init clone only).
-				if streamChunkPayloadIncludesRequestBody(interceptorHost) {
-					chunkReq.OriginalRequest = cloneBytes(streamOriginalRequest)
-					chunkReq.RequestBody = cloneBytes(streamRequestBody)
+				if streamInterceptorSession != nil {
+					if streamInterceptorSession.CanOmitHeavyFields() {
+						interceptReq.HistoryChunks = nil
+					} else {
+						interceptReq.OriginalRequest = cloneBytes(streamOriginalRequest)
+						interceptReq.RequestBody = cloneBytes(streamRequestBody)
+					}
+				} else if streamChunkPayloadIncludesRequestBody(interceptorHost) {
+					interceptReq.OriginalRequest = cloneBytes(streamOriginalRequest)
+					interceptReq.RequestBody = cloneBytes(streamRequestBody)
 				}
-				intercepted := interceptStreamChunk(ctx, interceptorHost, chunkReq, execOptions.SkipInterceptorPluginID)
+				intercepted := interceptStreamChunkWithSession(ctx, streamInterceptorSession, interceptorHost, interceptReq, execOptions.SkipInterceptorPluginID)
 				applyStreamHeaders(intercepted.Headers)
 				if len(intercepted.Body) > 0 {
 					payload = cloneBytes(intercepted.Body)
@@ -323,7 +357,15 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	}
 	passthroughHeadersEnabled := PassthroughHeadersEnabled(h.Cfg)
 	interceptorHost := h.interceptorHost()
-	streamInterceptorsActive := streamInterceptorsEnabled(interceptorHost)
+	streamInterceptorSession, streamSessionsSupported := openStreamChunkInterceptorSession(interceptorHost, execOptions.SkipInterceptorPluginID)
+	streamInterceptorsActive := streamInterceptorSession != nil
+	if !streamSessionsSupported {
+		streamInterceptorsActive = streamInterceptorsEnabled(interceptorHost)
+	}
+	streamID := ""
+	if streamInterceptorSession != nil {
+		streamID = uuid.NewString()
+	}
 	// Resolve bootstrap retries and header initialization before returning so the
 	// returned header snapshot is never modified by the stream goroutine.
 	rawStreamHeaders := cloneHeader(streamResult.Headers)
@@ -343,6 +385,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	var streamRequestHeaders http.Header
 	var streamOriginalRequest []byte
 	var streamRequestBody []byte
+	streamLifecycleStarted := false
 
 	applyStreamHeaders := func(headers http.Header) {
 		rawStreamHeaders = finalInterceptorHeaders(rawStreamHeaders, headers)
@@ -356,8 +399,10 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		streamRequestHeaders = cloneHeader(executedOpts.Headers)
 		streamOriginalRequest = cloneBytes(executedOpts.OriginalRequest)
 		streamRequestBody = cloneBytes(executedReq.Payload)
-		intercepted := interceptStreamChunk(ctx, interceptorHost, pluginapi.StreamChunkInterceptRequest{
+		streamLifecycleStarted = streamInterceptorSession != nil
+		intercepted := interceptStreamChunkWithSession(ctx, streamInterceptorSession, interceptorHost, pluginapi.StreamChunkInterceptRequest{
 			RequestID:       lifecycle.requestID(),
+			StreamID:        streamID,
 			SourceFormat:    responseProtocol,
 			Model:           normalizedModel,
 			RequestedModel:  originalRequestedModel,
@@ -371,13 +416,35 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		applyStreamHeaders(intercepted.Headers)
 		streamHeaderInitialized = true
 	}
+	endStreamInterceptors := func() {
+		if streamInterceptorSession == nil {
+			return
+		}
+		defer streamInterceptorSession.Close()
+		if !streamLifecycleStarted {
+			return
+		}
+		_, executedOpts := executedRequest()
+		streamInterceptorSession.InterceptStreamChunk(streamFinalizerContext(ctx), pluginapi.StreamChunkInterceptRequest{
+			RequestID:       lifecycle.requestID(),
+			StreamID:        streamID,
+			SourceFormat:    responseProtocol,
+			Model:           normalizedModel,
+			RequestedModel:  originalRequestedModel,
+			RequestHeaders:  cloneHeader(executedOpts.Headers),
+			ResponseHeaders: cloneHeader(rawStreamHeaders),
+			ChunkIndex:      pluginapi.StreamChunkEndIndex,
+			Metadata:        executedOpts.Metadata,
+		})
+	}
 
 	transformStreamPayload := func(payload []byte, chunkIndex *int, historyChunks [][]byte) ([]byte, bool, *interfaces.ErrorMessage) {
 		applyStreamHeaderInit()
 		payload = cloneBytes(payload)
 		if streamInterceptorsActive {
-			chunkReq := pluginapi.StreamChunkInterceptRequest{
+			interceptReq := pluginapi.StreamChunkInterceptRequest{
 				RequestID:       lifecycle.requestID(),
+				StreamID:        streamID,
 				SourceFormat:    responseProtocol,
 				Model:           normalizedModel,
 				RequestedModel:  originalRequestedModel,
@@ -388,13 +455,18 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 				ChunkIndex:      *chunkIndex,
 				Metadata:        opts.Metadata,
 			}
-			// Re-evaluate each chunk so mid-stream plugin reloads stay correct.
-			// Schema v3+ omits bodies here (one header-init clone only).
-			if streamChunkPayloadIncludesRequestBody(interceptorHost) {
-				chunkReq.OriginalRequest = cloneBytes(streamOriginalRequest)
-				chunkReq.RequestBody = cloneBytes(streamRequestBody)
+			if streamInterceptorSession != nil {
+				if streamInterceptorSession.CanOmitHeavyFields() {
+					interceptReq.HistoryChunks = nil
+				} else {
+					interceptReq.OriginalRequest = cloneBytes(streamOriginalRequest)
+					interceptReq.RequestBody = cloneBytes(streamRequestBody)
+				}
+			} else if streamChunkPayloadIncludesRequestBody(interceptorHost) {
+				interceptReq.OriginalRequest = cloneBytes(streamOriginalRequest)
+				interceptReq.RequestBody = cloneBytes(streamRequestBody)
 			}
-			intercepted := interceptStreamChunk(ctx, interceptorHost, chunkReq, execOptions.SkipInterceptorPluginID)
+			intercepted := interceptStreamChunkWithSession(ctx, streamInterceptorSession, interceptorHost, interceptReq, execOptions.SkipInterceptorPluginID)
 			applyStreamHeaders(intercepted.Headers)
 			if len(intercepted.Body) > 0 {
 				payload = cloneBytes(intercepted.Body)
@@ -524,6 +596,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	errChan := make(chan *interfaces.ErrorMessage, 1)
 
 	go func() {
+		defer endStreamInterceptors()
 		completionOutcome := pluginapi.RequestCompletionSucceeded
 		completionStatus := http.StatusOK
 		var completionErr error

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
@@ -78,15 +79,24 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 
 	passthroughHeadersEnabled := PassthroughHeadersEnabled(h.Cfg)
 	interceptorHost := h.interceptorHost()
-	streamInterceptorsActive := streamInterceptorsEnabled(interceptorHost)
+	streamInterceptorSession, streamSessionsSupported := openStreamChunkInterceptorSession(interceptorHost, execOptions.SkipInterceptorPluginID)
+	streamInterceptorsActive := streamInterceptorSession != nil
+	if !streamSessionsSupported {
+		streamInterceptorsActive = streamInterceptorsEnabled(interceptorHost)
+	}
+	streamID := ""
+	if streamInterceptorSession != nil {
+		streamID = uuid.NewString()
+	}
 	rawStreamHeaders := cloneHeader(streamResult.Headers)
 	baseStreamHeaders := cloneHeader(streamResult.Headers)
 	applyStreamHeaders := func(headers http.Header) {
 		rawStreamHeaders = finalInterceptorHeaders(rawStreamHeaders, headers)
 	}
 	if streamInterceptorsActive {
-		intercepted := interceptStreamChunk(ctx, interceptorHost, pluginapi.StreamChunkInterceptRequest{
+		intercepted := interceptStreamChunkWithSession(ctx, streamInterceptorSession, interceptorHost, pluginapi.StreamChunkInterceptRequest{
 			RequestID:       lifecycle.requestID(),
+			StreamID:        streamID,
 			SourceFormat:    responseProtocol,
 			Model:           modelName,
 			RequestedModel:  originalRequestedModel,
@@ -103,6 +113,23 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 	if upstreamHeaders == nil && (passthroughHeadersEnabled || streamInterceptorsActive) {
 		upstreamHeaders = make(http.Header)
 	}
+	endStreamInterceptors := func() {
+		if streamInterceptorSession == nil {
+			return
+		}
+		defer streamInterceptorSession.Close()
+		streamInterceptorSession.InterceptStreamChunk(streamFinalizerContext(ctx), pluginapi.StreamChunkInterceptRequest{
+			RequestID:       lifecycle.requestID(),
+			StreamID:        streamID,
+			SourceFormat:    responseProtocol,
+			Model:           modelName,
+			RequestedModel:  originalRequestedModel,
+			RequestHeaders:  cloneHeader(opts.Headers),
+			ResponseHeaders: cloneHeader(rawStreamHeaders),
+			ChunkIndex:      pluginapi.StreamChunkEndIndex,
+			Metadata:        opts.Metadata,
+		})
+	}
 
 	dataChan := make(chan []byte)
 	errChan := make(chan *interfaces.ErrorMessage, 1)
@@ -117,6 +144,7 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 		chunks = closed
 	}
 	go func() {
+		defer endStreamInterceptors()
 		completionOutcome := pluginapi.RequestCompletionSucceeded
 		completionStatus := http.StatusOK
 		var completionErr error
@@ -161,20 +189,24 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 			}
 			payload := cloneBytes(chunk.Payload)
 			if streamInterceptorsActive {
-				intercepted := interceptStreamChunk(ctx, interceptorHost, pluginapi.StreamChunkInterceptRequest{
+				interceptReq := pluginapi.StreamChunkInterceptRequest{
 					RequestID:       lifecycle.requestID(),
+					StreamID:        streamID,
 					SourceFormat:    responseProtocol,
 					Model:           modelName,
 					RequestedModel:  originalRequestedModel,
 					RequestHeaders:  cloneHeader(opts.Headers),
 					ResponseHeaders: cloneHeader(rawStreamHeaders),
-					OriginalRequest: cloneBytes(opts.OriginalRequest),
-					RequestBody:     cloneBytes(req.Payload),
 					Body:            payload,
-					HistoryChunks:   cloneByteSlices(historyChunks),
 					ChunkIndex:      chunkIndex,
 					Metadata:        opts.Metadata,
-				}, execOptions.SkipInterceptorPluginID)
+				}
+				if streamInterceptorSession == nil || !streamInterceptorSession.CanOmitHeavyFields() {
+					interceptReq.OriginalRequest = cloneBytes(opts.OriginalRequest)
+					interceptReq.RequestBody = cloneBytes(req.Payload)
+					interceptReq.HistoryChunks = cloneByteSlices(historyChunks)
+				}
+				intercepted := interceptStreamChunkWithSession(ctx, streamInterceptorSession, interceptorHost, interceptReq, execOptions.SkipInterceptorPluginID)
 				applyStreamHeaders(intercepted.Headers)
 				if len(intercepted.Body) > 0 {
 					payload = cloneBytes(intercepted.Body)
@@ -309,7 +341,15 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	}
 	passthroughHeadersEnabled := PassthroughHeadersEnabled(h.Cfg)
 	interceptorHost := h.interceptorHost()
-	streamInterceptorsActive := streamInterceptorsEnabled(interceptorHost)
+	streamInterceptorSession, streamSessionsSupported := openStreamChunkInterceptorSession(interceptorHost, execOptions.SkipInterceptorPluginID)
+	streamInterceptorsActive := streamInterceptorSession != nil
+	if !streamSessionsSupported {
+		streamInterceptorsActive = streamInterceptorsEnabled(interceptorHost)
+	}
+	streamID := ""
+	if streamInterceptorSession != nil {
+		streamID = uuid.NewString()
+	}
 	// Resolve bootstrap retries and header initialization before returning so the
 	// returned header snapshot is never modified by the stream goroutine.
 	rawStreamHeaders := cloneHeader(streamResult.Headers)
@@ -323,6 +363,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	streamClosedBeforeRead := false
 	streamCanceledBeforeRead := false
 	streamHeaderInitialized := false
+	streamLifecycleStarted := false
 
 	applyStreamHeaders := func(headers http.Header) {
 		rawStreamHeaders = finalInterceptorHeaders(rawStreamHeaders, headers)
@@ -333,8 +374,10 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 			return
 		}
 		executedReq, executedOpts := executedRequest()
-		intercepted := interceptStreamChunk(ctx, interceptorHost, pluginapi.StreamChunkInterceptRequest{
+		streamLifecycleStarted = streamInterceptorSession != nil
+		intercepted := interceptStreamChunkWithSession(ctx, streamInterceptorSession, interceptorHost, pluginapi.StreamChunkInterceptRequest{
 			RequestID:       lifecycle.requestID(),
+			StreamID:        streamID,
 			SourceFormat:    responseProtocol,
 			Model:           normalizedModel,
 			RequestedModel:  originalRequestedModel,
@@ -348,26 +391,51 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		applyStreamHeaders(intercepted.Headers)
 		streamHeaderInitialized = true
 	}
+	endStreamInterceptors := func() {
+		if streamInterceptorSession == nil {
+			return
+		}
+		defer streamInterceptorSession.Close()
+		if !streamLifecycleStarted {
+			return
+		}
+		_, executedOpts := executedRequest()
+		streamInterceptorSession.InterceptStreamChunk(streamFinalizerContext(ctx), pluginapi.StreamChunkInterceptRequest{
+			RequestID:       lifecycle.requestID(),
+			StreamID:        streamID,
+			SourceFormat:    responseProtocol,
+			Model:           normalizedModel,
+			RequestedModel:  originalRequestedModel,
+			RequestHeaders:  cloneHeader(executedOpts.Headers),
+			ResponseHeaders: cloneHeader(rawStreamHeaders),
+			ChunkIndex:      pluginapi.StreamChunkEndIndex,
+			Metadata:        executedOpts.Metadata,
+		})
+	}
 
 	transformStreamPayload := func(payload []byte, chunkIndex *int, historyChunks [][]byte) ([]byte, bool, *interfaces.ErrorMessage) {
 		applyStreamHeaderInit()
 		payload = cloneBytes(payload)
 		if streamInterceptorsActive {
 			executedReq, executedOpts := executedRequest()
-			intercepted := interceptStreamChunk(ctx, interceptorHost, pluginapi.StreamChunkInterceptRequest{
+			interceptReq := pluginapi.StreamChunkInterceptRequest{
 				RequestID:       lifecycle.requestID(),
+				StreamID:        streamID,
 				SourceFormat:    responseProtocol,
 				Model:           normalizedModel,
 				RequestedModel:  originalRequestedModel,
 				RequestHeaders:  cloneHeader(executedOpts.Headers),
 				ResponseHeaders: cloneHeader(rawStreamHeaders),
-				OriginalRequest: cloneBytes(executedOpts.OriginalRequest),
-				RequestBody:     cloneBytes(executedReq.Payload),
 				Body:            payload,
-				HistoryChunks:   cloneByteSlices(historyChunks),
 				ChunkIndex:      *chunkIndex,
 				Metadata:        executedOpts.Metadata,
-			}, execOptions.SkipInterceptorPluginID)
+			}
+			if streamInterceptorSession == nil || !streamInterceptorSession.CanOmitHeavyFields() {
+				interceptReq.OriginalRequest = cloneBytes(executedOpts.OriginalRequest)
+				interceptReq.RequestBody = cloneBytes(executedReq.Payload)
+				interceptReq.HistoryChunks = cloneByteSlices(historyChunks)
+			}
+			intercepted := interceptStreamChunkWithSession(ctx, streamInterceptorSession, interceptorHost, interceptReq, execOptions.SkipInterceptorPluginID)
 			applyStreamHeaders(intercepted.Headers)
 			if len(intercepted.Body) > 0 {
 				payload = cloneBytes(intercepted.Body)
@@ -497,6 +565,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	errChan := make(chan *interfaces.ErrorMessage, 1)
 
 	go func() {
+		defer endStreamInterceptors()
 		completionOutcome := pluginapi.RequestCompletionSucceeded
 		completionStatus := http.StatusOK
 		var completionErr error

--- a/sdk/api/handlers/handlers_stream_session.go
+++ b/sdk/api/handlers/handlers_stream_session.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	stdcontext "context"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+	"golang.org/x/net/context"
+)
+
+func openStreamChunkInterceptorSession(host PluginInterceptorHost, skipPluginID string) (pluginapi.StreamChunkInterceptorSession, bool) {
+	if host == nil {
+		return nil, false
+	}
+	opener, ok := host.(pluginapi.StreamChunkInterceptorSessionHost)
+	if !ok {
+		return nil, false
+	}
+	return opener.OpenStreamChunkInterceptorSession(skipPluginID), true
+}
+
+func streamFinalizerContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return stdcontext.WithoutCancel(ctx)
+}
+
+func interceptStreamChunkWithSession(ctx context.Context, session pluginapi.StreamChunkInterceptorSession, host PluginInterceptorHost, req pluginapi.StreamChunkInterceptRequest, skipPluginID string) pluginapi.StreamChunkInterceptResponse {
+	if session != nil {
+		return session.InterceptStreamChunk(ctx, req)
+	}
+	return interceptStreamChunk(ctx, host, req, skipPluginID)
+}

--- a/sdk/pluginabi/types.go
+++ b/sdk/pluginabi/types.go
@@ -8,12 +8,16 @@ const (
 	// SchemaVersion tracks the RPC JSON contract exchanged at plugin.register.
 	// Version 2 adds request lifecycle completion and active request termination.
 	// Version 3 omits OriginalRequest/RequestBody on payload stream chunks
-	// (ChunkIndex >= 0); those fields remain on StreamChunkHeaderInitIndex only.
-	// Plugins that still need per-chunk request bodies should keep schema_version < 3.
-	SchemaVersion uint32 = 3
+	// (ChunkIndex >= 0); request fields remain on StreamChunkHeaderInitIndex only.
+	// Plugins that need per-chunk request bodies should keep schema_version < 3.
+	// Version 4 adds stateful stream interceptor session negotiation and lifecycle.
+	SchemaVersion uint32 = 4
 	// SchemaVersionStreamChunkOmitRequestBody is the first schema version that omits
 	// request bodies on payload stream-chunk interceptor calls.
 	SchemaVersionStreamChunkOmitRequestBody uint32 = 3
+	// SchemaVersionStatefulStreamInterceptor is the first schema version that supports
+	// stateful stream interceptor session negotiation and lifecycle.
+	SchemaVersionStatefulStreamInterceptor uint32 = 4
 )
 
 const (

--- a/sdk/pluginabi/types.go
+++ b/sdk/pluginabi/types.go
@@ -7,7 +7,8 @@ const (
 	ABIVersion uint32 = 1
 	// SchemaVersion tracks the RPC JSON contract exchanged at plugin.register.
 	// Version 2 adds request lifecycle completion and active request termination.
-	SchemaVersion uint32 = 2
+	// Version 3 adds stateful stream interceptor session negotiation and lifecycle.
+	SchemaVersion uint32 = 3
 )
 
 const (

--- a/sdk/pluginabi/types_test.go
+++ b/sdk/pluginabi/types_test.go
@@ -27,8 +27,8 @@ func TestEnvelopeRoundTrip(t *testing.T) {
 }
 
 func TestMethodNamesAreStable(t *testing.T) {
-	if SchemaVersion != 2 {
-		t.Fatalf("SchemaVersion = %d, want 2", SchemaVersion)
+	if SchemaVersion != 3 {
+		t.Fatalf("SchemaVersion = %d, want 3", SchemaVersion)
 	}
 	if MethodPluginRegister != "plugin.register" {
 		t.Fatalf("MethodPluginRegister = %q", MethodPluginRegister)

--- a/sdk/pluginabi/types_test.go
+++ b/sdk/pluginabi/types_test.go
@@ -27,11 +27,14 @@ func TestEnvelopeRoundTrip(t *testing.T) {
 }
 
 func TestMethodNamesAreStable(t *testing.T) {
-	if SchemaVersion != 3 {
-		t.Fatalf("SchemaVersion = %d, want 3", SchemaVersion)
+	if SchemaVersion != 4 {
+		t.Fatalf("SchemaVersion = %d, want 4", SchemaVersion)
 	}
 	if SchemaVersionStreamChunkOmitRequestBody != 3 {
 		t.Fatalf("SchemaVersionStreamChunkOmitRequestBody = %d, want 3", SchemaVersionStreamChunkOmitRequestBody)
+	}
+	if SchemaVersionStatefulStreamInterceptor != 4 {
+		t.Fatalf("SchemaVersionStatefulStreamInterceptor = %d, want 4", SchemaVersionStatefulStreamInterceptor)
 	}
 	if MethodPluginRegister != "plugin.register" {
 		t.Fatalf("MethodPluginRegister = %q", MethodPluginRegister)

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -112,6 +112,16 @@ type Capabilities struct {
 	ResponseInterceptor ResponseInterceptor
 	// StreamChunkInterceptor rewrites successful HTTP stream chunks before downstream delivery.
 	StreamChunkInterceptor StreamChunkInterceptor
+	// StreamChunkInterceptorStateful declares that the interceptor keys per-stream
+	// state on StreamChunkInterceptRequest.StreamID and only needs the heavy
+	// RequestBody, OriginalRequest, and HistoryChunks fields on the header-init
+	// call (ChunkIndex == StreamChunkHeaderInitIndex). When every active stream
+	// interceptor is stateful, the host omits those heavy fields on payload
+	// chunks, avoiding a full clone and re-serialization of the request body on
+	// every chunk. The host sends StreamChunkEndIndex when the stream finishes;
+	// the interceptor must release state for that StreamID. Ignored unless
+	// StreamChunkInterceptor is set. RPC plugins require schema_version >= 4.
+	StreamChunkInterceptorStateful bool
 	// ThinkingApplier applies validated thinking configuration to provider payloads.
 	ThinkingApplier ThinkingApplier
 	// UsagePlugin receives completed usage records.
@@ -949,8 +959,35 @@ type StreamChunkInterceptor interface {
 	InterceptStreamChunk(context.Context, StreamChunkInterceptRequest) (StreamChunkInterceptResponse, error)
 }
 
-// StreamChunkHeaderInitIndex marks the header-only stream initialization interceptor call.
-const StreamChunkHeaderInitIndex = -1
+// StreamChunkInterceptorSession pins one stream to a stable interceptor set.
+// Calls must be made in stream order, beginning with StreamChunkHeaderInitIndex
+// and ending with StreamChunkEndIndex when initialization was attempted. A
+// bootstrap retry before downstream delivery may send header-init again for the
+// same StreamID; it replaces state from the abandoned upstream attempt and
+// payload indexes restart at zero.
+type StreamChunkInterceptorSession interface {
+	InterceptStreamChunk(context.Context, StreamChunkInterceptRequest) StreamChunkInterceptResponse
+	// CanOmitHeavyFields reports whether every pinned interceptor initialized
+	// state successfully and the next payload call may omit RequestBody,
+	// OriginalRequest, and HistoryChunks.
+	CanOmitHeavyFields() bool
+	// Close releases host resources pinned for this stream. It must be called
+	// exactly once by convention; implementations must tolerate repeated calls.
+	Close()
+}
+
+// StreamChunkInterceptorSessionHost opens pinned stream interceptor sessions.
+// A nil result means no stream interceptor is active for the request.
+type StreamChunkInterceptorSessionHost interface {
+	OpenStreamChunkInterceptorSession(skipPluginID string) StreamChunkInterceptorSession
+}
+
+const (
+	// StreamChunkEndIndex marks the stateful stream completion interceptor call.
+	StreamChunkEndIndex = -2
+	// StreamChunkHeaderInitIndex marks the header-only stream initialization interceptor call.
+	StreamChunkHeaderInitIndex = -1
+)
 
 // RequestTransformRequest describes a request payload transformation.
 type RequestTransformRequest struct {
@@ -1084,7 +1121,13 @@ type ResponseInterceptResponse struct {
 
 // StreamChunkInterceptRequest describes a successful stream chunk before downstream delivery.
 type StreamChunkInterceptRequest struct {
-	RequestID       string
+	RequestID string
+	// StreamID is a stable identifier for the whole stream. It is identical for
+	// the header-init call and every payload chunk of the same stream, and
+	// unique across concurrent streams. Stateful interceptors can key per-stream
+	// state on it instead of hashing the request body on every chunk. Hosts that
+	// predate this field leave it empty; interceptors must fall back accordingly.
+	StreamID        string
 	SourceFormat    string
 	Model           string
 	RequestedModel  string
@@ -1104,7 +1147,8 @@ type StreamChunkInterceptRequest struct {
 	// HistoryChunks contains a bounded recent history of chunks already delivered downstream.
 	// The host currently retains at most 64 chunks and 1 MiB total history bytes.
 	HistoryChunks [][]byte
-	// ChunkIndex starts at 0 for payload chunks. StreamChunkHeaderInitIndex marks the header-only initialization call.
+	// ChunkIndex starts at 0 for payload chunks. StreamChunkHeaderInitIndex marks
+	// initialization, and StreamChunkEndIndex marks stateful stream completion.
 	ChunkIndex int
 	// Metadata is a best-effort cloned context snapshot. Treat it as read-only and JSON-like.
 	Metadata map[string]any

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -109,6 +109,16 @@ type Capabilities struct {
 	ResponseInterceptor ResponseInterceptor
 	// StreamChunkInterceptor rewrites successful HTTP stream chunks before downstream delivery.
 	StreamChunkInterceptor StreamChunkInterceptor
+	// StreamChunkInterceptorStateful declares that the interceptor keys per-stream
+	// state on StreamChunkInterceptRequest.StreamID and only needs the heavy
+	// RequestBody, OriginalRequest, and HistoryChunks fields on the header-init
+	// call (ChunkIndex == StreamChunkHeaderInitIndex). When every active stream
+	// interceptor is stateful, the host omits those heavy fields on payload
+	// chunks, avoiding a full clone and re-serialization of the request body on
+	// every chunk. The host sends StreamChunkEndIndex when the stream finishes;
+	// the interceptor must release state for that StreamID. Ignored unless
+	// StreamChunkInterceptor is set.
+	StreamChunkInterceptorStateful bool
 	// ThinkingApplier applies validated thinking configuration to provider payloads.
 	ThinkingApplier ThinkingApplier
 	// UsagePlugin receives completed usage records.
@@ -946,8 +956,35 @@ type StreamChunkInterceptor interface {
 	InterceptStreamChunk(context.Context, StreamChunkInterceptRequest) (StreamChunkInterceptResponse, error)
 }
 
-// StreamChunkHeaderInitIndex marks the header-only stream initialization interceptor call.
-const StreamChunkHeaderInitIndex = -1
+// StreamChunkInterceptorSession pins one stream to a stable interceptor set.
+// Calls must be made in stream order, beginning with StreamChunkHeaderInitIndex
+// and ending with StreamChunkEndIndex when initialization was attempted. A
+// bootstrap retry before downstream delivery may send header-init again for the
+// same StreamID; it replaces state from the abandoned upstream attempt and
+// payload indexes restart at zero.
+type StreamChunkInterceptorSession interface {
+	InterceptStreamChunk(context.Context, StreamChunkInterceptRequest) StreamChunkInterceptResponse
+	// CanOmitHeavyFields reports whether every pinned interceptor initialized
+	// state successfully and the next payload call may omit RequestBody,
+	// OriginalRequest, and HistoryChunks.
+	CanOmitHeavyFields() bool
+	// Close releases host resources pinned for this stream. It must be called
+	// exactly once by convention; implementations must tolerate repeated calls.
+	Close()
+}
+
+// StreamChunkInterceptorSessionHost opens pinned stream interceptor sessions.
+// A nil result means no stream interceptor is active for the request.
+type StreamChunkInterceptorSessionHost interface {
+	OpenStreamChunkInterceptorSession(skipPluginID string) StreamChunkInterceptorSession
+}
+
+const (
+	// StreamChunkEndIndex marks the stateful stream completion interceptor call.
+	StreamChunkEndIndex = -2
+	// StreamChunkHeaderInitIndex marks the header-only stream initialization interceptor call.
+	StreamChunkHeaderInitIndex = -1
+)
 
 // RequestTransformRequest describes a request payload transformation.
 type RequestTransformRequest struct {
@@ -1081,7 +1118,13 @@ type ResponseInterceptResponse struct {
 
 // StreamChunkInterceptRequest describes a successful stream chunk before downstream delivery.
 type StreamChunkInterceptRequest struct {
-	RequestID       string
+	RequestID string
+	// StreamID is a stable identifier for the whole stream. It is identical for
+	// the header-init call and every payload chunk of the same stream, and
+	// unique across concurrent streams. Stateful interceptors can key per-stream
+	// state on it instead of hashing the request body on every chunk. Hosts that
+	// predate this field leave it empty; interceptors must fall back accordingly.
+	StreamID        string
 	SourceFormat    string
 	Model           string
 	RequestedModel  string
@@ -1093,7 +1136,8 @@ type StreamChunkInterceptRequest struct {
 	// HistoryChunks contains a bounded recent history of chunks already delivered downstream.
 	// The host currently retains at most 64 chunks and 1 MiB total history bytes.
 	HistoryChunks [][]byte
-	// ChunkIndex starts at 0 for payload chunks. StreamChunkHeaderInitIndex marks the header-only initialization call.
+	// ChunkIndex starts at 0 for payload chunks. StreamChunkHeaderInitIndex marks
+	// initialization, and StreamChunkEndIndex marks stateful stream completion.
 	ChunkIndex int
 	// Metadata is a best-effort cloned context snapshot. Treat it as read-only and JSON-like.
 	Metadata map[string]any


### PR DESCRIPTION
## Summary

Add opt-in stateful stream interceptor sessions to PluginHost.

Stateful stream plugins can now keep isolated per-stream state across header initialization, payload chunks, and stream completion while preserving legacy interceptor behavior and cancellation semantics.

## Changes

- Bump the plugin RPC schema to version 4 for stateful stream lifecycle support.
- Add `StreamChunkInterceptorSession` APIs and stable `StreamID` propagation.
- Add header initialization, payload, and stream completion callbacks.
- Pin stateful RPC plugin clients for the lifetime of a stream.
- Preserve plugin generation and fuse identity safety across hot reloads.
- Keep legacy stream interceptors dynamically reloadable and cancellation-aware.
- Preserve `StreamID` after transient initialization or payload errors.
- Restrict `DropChunk` short-circuiting to payload chunks.
- Gate `response_stream_interceptor_stateful` on schema 4 negotiation.
- Avoid cloning large request and history fields when they can be omitted.
- Add failed replacement recovery after registration failures.
- Add a standalone Go stateful stream interceptor example under:
  `examples/plugin/stateful-stream-interceptor`

## Example Plugin

The example demonstrates:

- Schema 4 registration
- Stateful stream capability declaration
- Stable `StreamID` usage
- Header, payload, and end lifecycle handling
- Per-stream state isolation
- Deterministic cleanup
- Payload-only `DropChunk` behavior
- Concurrent stream handling

## Testing

- `go test -count=1 ./internal/pluginhost ./sdk/api/handlers ./sdk/pluginapi ./sdk/pluginabi`
- `go test -race -count=1 ./internal/pluginhost ./sdk/api/handlers ./sdk/pluginapi ./sdk/pluginabi`
- Stateful stream example tests
- Stateful stream example race tests
- Stateful stream example c-shared build
- `go build -o test-output ./cmd/server`
- `git diff origin/main --check`