### PR TITLE
fix(codex): preserve cyber policy errors

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -161,7 +161,7 @@ func codexTerminalFailureStatus(body []byte) int {
 	errorType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.type").String()))
 	errorCode := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.code").String()))
 	switch {
-	case errorType == "invalid_request_error", errorType == "bad_request_error":
+	case errorType == "invalid_request", errorType == "invalid_request_error", errorType == "bad_request_error", errorCode == "cyber_policy":
 		return http.StatusBadRequest
 	case errorType == "authentication_error", errorCode == "invalid_api_key", errorCode == "unauthorized":
 		return http.StatusUnauthorized

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -161,7 +161,7 @@ func codexTerminalFailureStatus(body []byte) int {
 	errorType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.type").String()))
 	errorCode := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.code").String()))
 	switch {
-	case errorType == "invalid_request", errorType == "invalid_request_error", errorType == "bad_request_error", errorCode == "cyber_policy":
+	case errorType == "invalid_request", errorType == "invalid_request_error", errorType == "bad_request_error", errorCode == "cyber_policy", errorCode == "content_policy_violation":
 		return http.StatusBadRequest
 	case errorType == "authentication_error", errorCode == "invalid_api_key", errorCode == "unauthorized":
 		return http.StatusUnauthorized

--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -523,6 +523,11 @@ func TestCodexTerminalFailureErrClassifiesStatus(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
+			name:       "content policy code without recognized type",
+			event:      `{"type":"error","error":{"code":"content_policy_violation","message":"The request was rejected by the safety system."}}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
 			name:       "authentication",
 			event:      `{"type":"response.failed","response":{"error":{"type":"authentication_error","code":"invalid_api_key","message":"Invalid token."}}}`,
 			wantStatus: http.StatusUnauthorized,

--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -419,6 +419,54 @@ func TestCodexExecutorExecuteStreamSurfacesTerminalStreamError(t *testing.T) {
 	assertCodexErrorCode(t, streamErr.Error(), "invalid_request_error", "context_too_large")
 }
 
+func TestCodexExecutorExecuteStreamSurfacesCyberPolicyError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"type":"error","error":{"type":"invalid_request","code":"cyber_policy","message":"This content was flagged for possible cybersecurity risk.","param":null},"sequence_number":3}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.6-sol",
+		Payload: []byte(`{"model":"gpt-5.6-sol","input":"hello"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var streamErr error
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			streamErr = chunk.Err
+			break
+		}
+	}
+	if streamErr == nil {
+		t.Fatal("missing cyber policy stream error")
+	}
+	if got := statusCodeFromTestError(t, streamErr); got != http.StatusBadRequest {
+		t.Fatalf("status code = %d, want %d; err=%v", got, http.StatusBadRequest, streamErr)
+	}
+	if got := gjson.Get(streamErr.Error(), "error.type").String(); got != "invalid_request" {
+		t.Fatalf("error type = %q, want invalid_request; err=%v", got, streamErr)
+	}
+	if got := gjson.Get(streamErr.Error(), "error.code").String(); got != "cyber_policy" {
+		t.Fatalf("error code = %q, want cyber_policy; err=%v", got, streamErr)
+	}
+	if got := gjson.Get(streamErr.Error(), "error.message").String(); got != "This content was flagged for possible cybersecurity risk." {
+		t.Fatalf("error message = %q; err=%v", got, streamErr)
+	}
+}
+
 func TestCodexTerminalStreamContextLengthErrFromResponseFailed(t *testing.T) {
 	err, ok := codexTerminalStreamContextLengthErr([]byte(`{"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"code":"context_length_exceeded","message":"Your input exceeds the context window of this model. Please adjust your input and try again."}}}`))
 	if !ok {
@@ -467,6 +515,11 @@ func TestCodexTerminalFailureErrClassifiesStatus(t *testing.T) {
 		{
 			name:       "invalid request",
 			event:      `{"type":"error","error":{"type":"invalid_request_error","code":"invalid_value","message":"Invalid input."}}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "cyber policy invalid request",
+			event:      `{"type":"error","error":{"type":"invalid_request","code":"cyber_policy","message":"This content was flagged for possible cybersecurity risk."}}`,
 			wantStatus: http.StatusBadRequest,
 		},
 		{

--- a/sdk/api/handlers/handlers_error_response_test.go
+++ b/sdk/api/handlers/handlers_error_response_test.go
@@ -79,6 +79,27 @@ func TestWriteErrorResponse_AddonHeadersEnabled(t *testing.T) {
 	}
 }
 
+func TestWriteErrorResponse_PreservesUpstreamJSONBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	const body = `{"error":{"type":"invalid_request","code":"cyber_policy","message":"This content was flagged for possible cybersecurity risk.","param":null}}`
+	handler := NewBaseAPIHandlers(nil, nil)
+	handler.WriteErrorResponse(c, &interfaces.ErrorMessage{
+		StatusCode: http.StatusBadRequest,
+		Error:      errors.New(body),
+	})
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+	if got := recorder.Body.String(); got != body {
+		t.Fatalf("body = %q, want exact upstream body %q", got, body)
+	}
+}
+
 func TestEnrichAuthSelectionError_DefaultsTo503WithContext(t *testing.T) {
 	in := &coreauth.Error{Code: "auth_not_found", Message: "no auth available"}
 	out := enrichAuthSelectionError(in, []string{"claude"}, "claude-sonnet-4-6")

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -4549,6 +4549,9 @@ func isRequestInvalidError(err error) bool {
 	if isModelSupportError(err) {
 		return false
 	}
+	if isNonRetryablePolicyError(err) {
+		return true
+	}
 	status := statusCodeFromError(err)
 	switch status {
 	case http.StatusBadRequest:
@@ -4565,6 +4568,29 @@ func isRequestInvalidError(err error) bool {
 		msg := err.Error()
 		return strings.Contains(msg, "\"status\":\"UNKNOWN\"") ||
 			strings.Contains(msg, "\"status\": \"UNKNOWN\"")
+	default:
+		return false
+	}
+}
+
+// isNonRetryablePolicyError identifies structured upstream policy rejections.
+// These errors are tied to the request content, so rotating credentials cannot
+// make the request succeed and must not put a healthy credential on cooldown.
+func isNonRetryablePolicyError(err error) bool {
+	if err == nil || statusCodeFromError(err) != http.StatusBadRequest {
+		return false
+	}
+	var payload struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if json.Unmarshal([]byte(strings.TrimSpace(err.Error())), &payload) != nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(payload.Error.Code)) {
+	case "cyber_policy", "content_policy_violation":
+		return true
 	default:
 		return false
 	}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -4580,12 +4580,22 @@ func isNonRetryablePolicyError(err error) bool {
 	if err == nil || statusCodeFromError(err) != http.StatusBadRequest {
 		return false
 	}
+	errMessage := err.Error()
+	var apiErr *Error
+	if errors.As(err, &apiErr) && apiErr != nil {
+		errMessage = apiErr.Message
+	} else {
+		for unwrapped := errors.Unwrap(err); unwrapped != nil; unwrapped = errors.Unwrap(err) {
+			err = unwrapped
+			errMessage = err.Error()
+		}
+	}
 	var payload struct {
 		Error struct {
 			Code string `json:"code"`
 		} `json:"error"`
 	}
-	if json.Unmarshal([]byte(strings.TrimSpace(err.Error())), &payload) != nil {
+	if json.Unmarshal([]byte(errMessage), &payload) != nil {
 		return false
 	}
 	switch strings.ToLower(strings.TrimSpace(payload.Error.Code)) {

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -1158,6 +1158,7 @@ func TestManager_Execute_DisableCooling_RetriesAfter429RetryAfter(t *testing.T) 
 }
 
 func TestManager_RequestScopedErrorStopsCredentialFallbackWithoutSuspendingAuth(t *testing.T) {
+	const cyberPolicyBody = `{"error":{"type":"invalid_request","code":"cyber_policy","message":"This content was flagged for possible cybersecurity risk.","param":null}}`
 	incompleteErr := &requestScopedStatusError{
 		status:  http.StatusRequestTimeout,
 		message: "stream error: stream disconnected before completion: stream closed before response.completed",
@@ -1175,6 +1176,7 @@ func TestManager_RequestScopedErrorStopsCredentialFallbackWithoutSuspendingAuth(
 		stream     bool
 		err        error
 		wantStatus int
+		wantBody   string
 	}{
 		{name: "non-streaming incomplete", err: incompleteErr, wantStatus: http.StatusRequestTimeout},
 		{name: "streaming incomplete", stream: true, err: incompleteErr, wantStatus: http.StatusRequestTimeout},
@@ -1182,6 +1184,8 @@ func TestManager_RequestScopedErrorStopsCredentialFallbackWithoutSuspendingAuth(
 		{name: "streaming invalid request", stream: true, err: invalidRequestErr, wantStatus: http.StatusBadRequest},
 		{name: "non-streaming bad request", err: badRequestErr, wantStatus: http.StatusBadRequest},
 		{name: "streaming bad request", stream: true, err: badRequestErr, wantStatus: http.StatusBadRequest},
+		{name: "non-streaming cyber policy", err: &Error{HTTPStatus: http.StatusBadRequest, Message: cyberPolicyBody}, wantStatus: http.StatusBadRequest, wantBody: cyberPolicyBody},
+		{name: "streaming cyber policy", stream: true, err: &Error{HTTPStatus: http.StatusBadRequest, Message: cyberPolicyBody}, wantStatus: http.StatusBadRequest, wantBody: cyberPolicyBody},
 	}
 
 	for _, tc := range tests {
@@ -1232,6 +1236,9 @@ func TestManager_RequestScopedErrorStopsCredentialFallbackWithoutSuspendingAuth(
 			}
 			if got := statusCodeFromError(errExecute); got != tc.wantStatus {
 				t.Fatalf("status = %d, want %d", got, tc.wantStatus)
+			}
+			if tc.wantBody != "" && errExecute.Error() != tc.wantBody {
+				t.Fatalf("error body = %q, want exact upstream body %q", errExecute.Error(), tc.wantBody)
 			}
 
 			var calls []string

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -1159,6 +1159,7 @@ func TestManager_Execute_DisableCooling_RetriesAfter429RetryAfter(t *testing.T) 
 
 func TestManager_RequestScopedErrorStopsCredentialFallbackWithoutSuspendingAuth(t *testing.T) {
 	const cyberPolicyBody = `{"error":{"type":"invalid_request","code":"cyber_policy","message":"This content was flagged for possible cybersecurity risk.","param":null}}`
+	const contentPolicyBody = `{"error":{"type":"invalid_request_error","code":"content_policy_violation","message":"The request was rejected by the safety system.","param":null}}`
 	incompleteErr := &requestScopedStatusError{
 		status:  http.StatusRequestTimeout,
 		message: "stream error: stream disconnected before completion: stream closed before response.completed",
@@ -1186,6 +1187,9 @@ func TestManager_RequestScopedErrorStopsCredentialFallbackWithoutSuspendingAuth(
 		{name: "streaming bad request", stream: true, err: badRequestErr, wantStatus: http.StatusBadRequest},
 		{name: "non-streaming cyber policy", err: &Error{HTTPStatus: http.StatusBadRequest, Message: cyberPolicyBody}, wantStatus: http.StatusBadRequest, wantBody: cyberPolicyBody},
 		{name: "streaming cyber policy", stream: true, err: &Error{HTTPStatus: http.StatusBadRequest, Message: cyberPolicyBody}, wantStatus: http.StatusBadRequest, wantBody: cyberPolicyBody},
+		{name: "wrapped non-streaming cyber policy", err: fmt.Errorf("wrapped upstream error: %w", &retryAfterStatusError{status: http.StatusBadRequest, message: cyberPolicyBody}), wantStatus: http.StatusBadRequest},
+		{name: "wrapped streaming cyber policy", stream: true, err: fmt.Errorf("wrapped upstream error: %w", &Error{HTTPStatus: http.StatusBadRequest, Message: cyberPolicyBody}), wantStatus: http.StatusBadRequest},
+		{name: "non-streaming content policy", err: &Error{HTTPStatus: http.StatusBadRequest, Message: contentPolicyBody}, wantStatus: http.StatusBadRequest, wantBody: contentPolicyBody},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- classify Codex Responses `invalid_request` / `cyber_policy` terminal events as HTTP 400
- treat structured policy rejections as request-scoped so credential fallback and cooldown are skipped
- preserve the upstream JSON error body for clients and cover streaming/non-streaming paths

## Root cause

Codex can return a Responses error with `error.type=invalid_request` and `error.code=cyber_policy`. The terminal-event status mapper only recognized `invalid_request_error`, so the event became a 502-class failure. The auth manager then rotated credentials and could ultimately replace the useful upstream error with `503 auth_unavailable`.

This change keeps policy rejections attached to the request: the first upstream 400 is returned and healthy credentials remain available.

## Validation

- `go test ./... -count=1`
- `go test ./internal/runtime/executor ./sdk/cliproxy/auth ./sdk/api/handlers -count=1`
- `go vet ./internal/runtime/executor ./sdk/cliproxy/auth`
- `git diff --check upstream/main...HEAD`

The branch is based directly on `router-for-me/CLIProxyAPI@fde40c5a` (`v7.2.91`) and contains one focused commit.
