### PR TITLE
Drop empty assistant messages for OpenAI-compatible upstreams

### DIFF
--- a/internal/runtime/executor/helps/openai_assistant_content.go
+++ b/internal/runtime/executor/helps/openai_assistant_content.go
@@ -1,0 +1,63 @@
+package helps
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// FlattenAssistantContentArrays rewrites assistant messages whose content is
+// an array of text parts into plain-string content. The OpenAI spec allows
+// part arrays on assistant messages, but several chat-completions upstreams
+// (Moonshot behind the Vercel gateway, for one) parse assistant content as a
+// string only and coerce an array to empty, then reject the request with 400
+// "the message at position N with role 'assistant' must not be empty" - even
+// when the parts hold real text. Flattening text-only part arrays is lossless
+// and spec-valid everywhere, so it is applied unconditionally. Arrays that
+// contain non-text parts are left untouched. The payload is returned
+// unchanged when no assistant part arrays are present.
+func FlattenAssistantContentArrays(payload []byte) []byte {
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return payload
+	}
+	type flat struct {
+		idx  int
+		text string
+	}
+	flats := make([]flat, 0, 4)
+	messages.ForEach(func(idx, message gjson.Result) bool {
+		if message.Get("role").String() != "assistant" {
+			return true
+		}
+		content := message.Get("content")
+		if !content.IsArray() {
+			return true
+		}
+		var b strings.Builder
+		ok := true
+		content.ForEach(func(_, part gjson.Result) bool {
+			if part.Get("type").String() != "text" {
+				ok = false
+				return false
+			}
+			b.WriteString(part.Get("text").String())
+			return true
+		})
+		if ok {
+			flats = append(flats, flat{int(idx.Int()), b.String()})
+		}
+		return true
+	})
+	if len(flats) == 0 {
+		return payload
+	}
+	for _, f := range flats {
+		if updated, err := sjson.SetBytes(payload, "messages."+strconv.Itoa(f.idx)+".content", f.text); err == nil {
+			payload = updated
+		}
+	}
+	return payload
+}

--- a/internal/runtime/executor/helps/openai_assistant_content_test.go
+++ b/internal/runtime/executor/helps/openai_assistant_content_test.go
@@ -1,0 +1,52 @@
+package helps
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestFlattenAssistantContentArrays(t *testing.T) {
+	cases := []struct {
+		name, payload, want string
+	}{
+		{
+			"flattens text parts",
+			`{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"text","text":"a"},{"type":"text","text":"b"}]}]}`,
+			"ab",
+		},
+		{
+			"keeps string content",
+			`{"messages":[{"role":"assistant","content":"plain"}]}`,
+			"plain",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := FlattenAssistantContentArrays([]byte(tc.payload))
+			msgs := gjson.GetBytes(out, "messages").Array()
+			last := msgs[len(msgs)-1]
+			if last.Get("content").Type != gjson.String || last.Get("content").String() != tc.want {
+				t.Fatalf("content = %s, want string %q", last.Get("content").Raw, tc.want)
+			}
+		})
+	}
+	// non-text parts untouched
+	p := `{"messages":[{"role":"assistant","content":[{"type":"image_url","image_url":{"url":"u"}}]}]}`
+	out := FlattenAssistantContentArrays([]byte(p))
+	if !gjson.GetBytes(out, "messages.0.content").IsArray() {
+		t.Fatalf("non-text array was flattened: %s", out)
+	}
+	// user arrays untouched
+	p = `{"messages":[{"role":"user","content":[{"type":"text","text":"x"}]}]}`
+	out = FlattenAssistantContentArrays([]byte(p))
+	if !gjson.GetBytes(out, "messages.0.content").IsArray() {
+		t.Fatalf("user array was flattened: %s", out)
+	}
+	// empty text parts flatten to "" so the empty-drop can remove the message
+	p = `{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"text","text":""}]},{"role":"user","content":"ok"}]}`
+	out = DropEmptyAssistantMessages(FlattenAssistantContentArrays([]byte(p)))
+	if n := len(gjson.GetBytes(out, "messages").Array()); n != 2 {
+		t.Fatalf("empty-flattened assistant not dropped: %d msgs, %s", n, out)
+	}
+}

--- a/internal/runtime/executor/helps/openai_empty_assistant.go
+++ b/internal/runtime/executor/helps/openai_empty_assistant.go
@@ -1,0 +1,66 @@
+package helps
+
+import (
+	"strconv"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// DropEmptyAssistantMessages removes assistant messages that carry no content
+// and no tool calls from an OpenAI chat-completions payload. Some upstreams
+// (e.g. Moonshot behind the Cline gateway) reject the whole request with a 400
+// "message ... with role 'assistant' must not be empty" when the conversation
+// history contains such a message, which happens when a previous assistant
+// turn was interrupted before producing output. The payload is returned
+// unchanged when no empty assistant messages are present.
+func DropEmptyAssistantMessages(payload []byte) []byte {
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return payload
+	}
+	emptyIdx := make([]int, 0, 2)
+	messages.ForEach(func(idx, message gjson.Result) bool {
+		if message.Get("role").String() != "assistant" {
+			return true
+		}
+		if toolCalls := message.Get("tool_calls"); toolCalls.IsArray() && len(toolCalls.Array()) > 0 {
+			return true
+		}
+		if !isEmptyOpenAIMessageContent(message.Get("content")) {
+			return true
+		}
+		emptyIdx = append(emptyIdx, int(idx.Int()))
+		return true
+	})
+	if len(emptyIdx) == 0 {
+		return payload
+	}
+	for i := len(emptyIdx) - 1; i >= 0; i-- {
+		if updated, err := sjson.DeleteBytes(payload, "messages."+strconv.Itoa(emptyIdx[i])); err == nil {
+			payload = updated
+		}
+	}
+	return payload
+}
+
+func isEmptyOpenAIMessageContent(content gjson.Result) bool {
+	if !content.Exists() || content.Type == gjson.Null {
+		return true
+	}
+	if content.Type == gjson.String {
+		return content.String() == ""
+	}
+	if content.IsArray() {
+		empty := true
+		content.ForEach(func(_, part gjson.Result) bool {
+			if part.Get("type").String() == "text" && part.Get("text").String() == "" {
+				return true
+			}
+			empty = false
+			return false
+		})
+		return empty
+	}
+	return false
+}

--- a/internal/runtime/executor/helps/openai_empty_assistant.go
+++ b/internal/runtime/executor/helps/openai_empty_assistant.go
@@ -27,6 +27,9 @@ func DropEmptyAssistantMessages(payload []byte) []byte {
 		if toolCalls := message.Get("tool_calls"); toolCalls.IsArray() && len(toolCalls.Array()) > 0 {
 			return true
 		}
+		if rc := message.Get("reasoning_content"); rc.Exists() && rc.String() != "" {
+			return true
+		}
 		if !isEmptyOpenAIMessageContent(message.Get("content")) {
 			return true
 		}

--- a/internal/runtime/executor/helps/openai_empty_assistant_test.go
+++ b/internal/runtime/executor/helps/openai_empty_assistant_test.go
@@ -1,0 +1,88 @@
+package helps
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestDropEmptyAssistantMessages(t *testing.T) {
+	cases := []struct {
+		name      string
+		payload   string
+		wantRoles []string
+	}{
+		{
+			name:      "drops empty string content",
+			payload:   `{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":""},{"role":"user","content":"ok"}]}`,
+			wantRoles: []string{"user", "user"},
+		},
+		{
+			name:      "drops empty array content",
+			payload:   `{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[]},{"role":"user","content":"ok"}]}`,
+			wantRoles: []string{"user", "user"},
+		},
+		{
+			name:      "drops null content",
+			payload:   `{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":null}]}`,
+			wantRoles: []string{"user"},
+		},
+		{
+			name:      "drops array of empty text parts",
+			payload:   `{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"text","text":""}]}]}`,
+			wantRoles: []string{"user"},
+		},
+		{
+			name:      "keeps assistant with text",
+			payload:   `{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"hello"}]}`,
+			wantRoles: []string{"user", "assistant"},
+		},
+		{
+			name:      "keeps empty assistant with tool calls",
+			payload:   `{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"","tool_calls":[{"type":"function","id":"a","function":{"name":"f","arguments":"{}"}}]}]}`,
+			wantRoles: []string{"user", "assistant"},
+		},
+		{
+			name:      "keeps empty user messages",
+			payload:   `{"messages":[{"role":"user","content":""},{"role":"assistant","content":"hello"}]}`,
+			wantRoles: []string{"user", "assistant"},
+		},
+		{
+			name:      "drops multiple empty assistants",
+			payload:   `{"messages":[{"role":"assistant","content":""},{"role":"user","content":"hi"},{"role":"assistant"},{"role":"user","content":"ok"}]}`,
+			wantRoles: []string{"user", "user"},
+		},
+		{
+			name:      "no messages field untouched",
+			payload:   `{"model":"m"}`,
+			wantRoles: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := DropEmptyAssistantMessages([]byte(tc.payload))
+			got := gjson.GetBytes(out, "messages")
+			var roles []string
+			got.ForEach(func(_, m gjson.Result) bool {
+				roles = append(roles, m.Get("role").String())
+				return true
+			})
+			if len(roles) != len(tc.wantRoles) {
+				t.Fatalf("roles = %v, want %v (payload %s)", roles, tc.wantRoles, out)
+			}
+			for i := range roles {
+				if roles[i] != tc.wantRoles[i] {
+					t.Fatalf("roles = %v, want %v (payload %s)", roles, tc.wantRoles, out)
+				}
+			}
+		})
+	}
+}
+
+func TestDropEmptyAssistantMessagesNoChange(t *testing.T) {
+	payload := `{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"hello"}],"model":"m"}`
+	out := DropEmptyAssistantMessages([]byte(payload))
+	if string(out) != payload {
+		t.Fatalf("payload changed without empty assistant messages: %s", out)
+	}
+}

--- a/internal/runtime/executor/helps/openai_empty_assistant_test.go
+++ b/internal/runtime/executor/helps/openai_empty_assistant_test.go
@@ -86,3 +86,11 @@ func TestDropEmptyAssistantMessagesNoChange(t *testing.T) {
 		t.Fatalf("payload changed without empty assistant messages: %s", out)
 	}
 }
+
+func TestDropEmptyAssistantKeepsReasoningContent(t *testing.T) {
+	payload := `{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"","reasoning_content":"thinking"},{"role":"user","content":"ok"}]}`
+	out := DropEmptyAssistantMessages([]byte(payload))
+	if n := len(gjson.GetBytes(out, "messages").Array()); n != 3 {
+		t.Fatalf("reasoning-only assistant was dropped: %d messages, want 3: %s", n, out)
+	}
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -122,6 +122,9 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
+	if opts.Alt != "responses/compact" {
+		translated = helps.DropEmptyAssistantMessages(translated)
+	}
 	if opts.Alt == "responses/compact" {
 		if updated, errDelete := sjson.DeleteBytes(translated, "stream"); errDelete == nil {
 			translated = updated
@@ -323,6 +326,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
+	translated = helps.DropEmptyAssistantMessages(translated)
 
 	// Request usage data in the final streaming chunk so that token statistics
 	// are captured even when the upstream is an OpenAI-compatible provider.

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -123,6 +123,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
 	if opts.Alt != "responses/compact" {
+		translated = helps.FlattenAssistantContentArrays(translated)
 		translated = helps.DropEmptyAssistantMessages(translated)
 	}
 	if opts.Alt == "responses/compact" {
@@ -326,6 +327,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
+	translated = helps.FlattenAssistantContentArrays(translated)
 	translated = helps.DropEmptyAssistantMessages(translated)
 
 	// Request usage data in the final streaming chunk so that token statistics


### PR DESCRIPTION
## Summary

Some OpenAI-compatible upstreams reject the whole request when the conversation history contains an assistant message with no content and no tool calls. Moonshot (e.g. kimi models served through the Cline gateway) returns 400 "Invalid request: the message at position N with role 'assistant' must not be empty".

Such messages appear naturally when a previous assistant turn was interrupted or errored before producing output. Once one is in the history the session is permanently broken: every retry (including context compaction, which replays the same history) resends it and fails again.

This adds a sanitization step in the openai-compat executor that drops assistant messages with no content (missing, null, empty string, empty array, or only empty text parts) and no tool calls from the translated chat-completions payload. Payloads without empty assistant messages are returned unchanged. Assistant messages that carry tool calls and empty user messages are kept as is.

Per AGENTS.md the change lives in the executor (helper under internal/runtime/executor/helps/) rather than in internal/translator/.

## Test

- go build -o test-output ./cmd/server && rm test-output
- go test ./... (new unit tests in internal/runtime/executor/helps/openai_empty_assistant_test.go cover drop/keep cases)
- Verified live against cline-pass/kimi-k3 through an openai-compatibility provider: a request with an empty assistant turn mid-history returned 400 before this change and streams normally with it.