### PR TITLE
fix(codex): pin client profile per auth

### DIFF
--- a/internal/runtime/executor/codex_client_profile_pin.go
+++ b/internal/runtime/executor/codex_client_profile_pin.go
@@ -3,13 +3,13 @@ package executor
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
-
-const codexClientProfilePinnedMetadataKey = "codex_client_profile_pinned"
 
 var codexPinnedClientProfileHeaders = []string{
 	"X-Codex-Beta-Features",
@@ -19,14 +19,40 @@ var codexPinnedClientProfileHeaders = []string{
 	"x-responsesapi-include-timing-metrics",
 }
 
+type codexClientProfile struct {
+	headers http.Header
+}
+
+type codexClientProfileKey struct {
+	id   string
+	auth *cliproxyauth.Auth
+}
+
+var (
+	codexClientProfilesMu sync.RWMutex
+	codexClientProfiles   = make(map[codexClientProfileKey]codexClientProfile)
+)
+
 func codexPinClientProfileFromFirstRequest(_ context.Context, auth *cliproxyauth.Auth, target http.Header, source http.Header, cfg *config.Config) {
-	if auth == nil || (target == nil && source == nil) || codexClientProfilePinned(auth) {
+	key, ok := codexClientProfileKeyForAuth(auth)
+	if !ok || (target == nil && source == nil) {
 		return
 	}
 
-	codexEnsureAuthMetadata(auth)
-	auth.Metadata[codexClientProfilePinnedMetadataKey] = true
+	codexClientProfilesMu.RLock()
+	_, pinned := codexClientProfiles[key]
+	codexClientProfilesMu.RUnlock()
+	if pinned {
+		return
+	}
 
+	codexClientProfilesMu.Lock()
+	defer codexClientProfilesMu.Unlock()
+	if _, pinned = codexClientProfiles[key]; pinned {
+		return
+	}
+
+	pinnedHeaders := make(http.Header)
 	for _, headerName := range codexPinnedClientProfileHeaders {
 		if codexAuthHeaderFixed(auth, headerName) {
 			continue
@@ -37,19 +63,27 @@ func codexPinClientProfileFromFirstRequest(_ context.Context, auth *cliproxyauth
 				value = cfgUserAgent
 			}
 		}
+		if strings.EqualFold(headerName, "Version") && (value == "" || !codexVersionAtLeast(value, codexDefaultVersion)) {
+			if value != "" || !codexAuthUsesAPIKey(auth) {
+				value = codexDefaultVersion
+			}
+		}
 		if value == "" {
 			continue
 		}
-		codexSetAuthMetadataHeader(auth, headerName, value)
-		codexSetAuthAttribute(auth, "header:"+headerName, value)
+		pinnedHeaders.Set(headerName, value)
 	}
+	codexClientProfiles[key] = codexClientProfile{headers: pinnedHeaders}
 }
 
 func codexClientProfilePinned(auth *cliproxyauth.Auth) bool {
-	if auth == nil || len(auth.Metadata) == 0 {
+	key, ok := codexClientProfileKeyForAuth(auth)
+	if !ok {
 		return false
 	}
-	pinned, _ := auth.Metadata[codexClientProfilePinnedMetadataKey].(bool)
+	codexClientProfilesMu.RLock()
+	_, pinned := codexClientProfiles[key]
+	codexClientProfilesMu.RUnlock()
 	return pinned
 }
 
@@ -61,35 +95,41 @@ func codexClientProfileSourceHeaders(auth *cliproxyauth.Auth, source http.Header
 }
 
 func codexPreparePinnedClientProfileHeaders(headers http.Header, auth *cliproxyauth.Auth) {
-	if headers == nil || !codexClientProfilePinned(auth) {
+	if headers == nil {
 		return
 	}
+	key, ok := codexClientProfileKeyForAuth(auth)
+	if !ok {
+		return
+	}
+
+	codexClientProfilesMu.RLock()
+	profile, pinned := codexClientProfiles[key]
+	codexClientProfilesMu.RUnlock()
+	if !pinned {
+		return
+	}
+
 	for _, headerName := range codexPinnedClientProfileHeaders {
-		if !codexAuthHeaderFixed(auth, headerName) {
-			headers.Del(headerName)
+		if codexAuthHeaderFixed(auth, headerName) {
+			continue
+		}
+		if value := profile.headers.Get(headerName); value != "" {
+			setHeaderCasePreserved(headers, headerName, value)
+		} else {
+			deleteHeaderCaseInsensitive(headers, headerName)
 		}
 	}
 }
 
-func codexEnsureAuthMetadata(auth *cliproxyauth.Auth) {
-	if auth != nil && auth.Metadata == nil {
-		auth.Metadata = make(map[string]any)
-	}
-}
-
-func codexSetAuthAttribute(auth *cliproxyauth.Auth, key string, value string) {
+func codexClientProfileKeyForAuth(auth *cliproxyauth.Auth) (codexClientProfileKey, bool) {
 	if auth == nil {
-		return
+		return codexClientProfileKey{}, false
 	}
-	key = strings.TrimSpace(key)
-	value = strings.TrimSpace(value)
-	if key == "" || value == "" {
-		return
+	if id := strings.TrimSpace(auth.ID); id != "" {
+		return codexClientProfileKey{id: id}, true
 	}
-	if auth.Attributes == nil {
-		auth.Attributes = make(map[string]string)
-	}
-	auth.Attributes[key] = value
+	return codexClientProfileKey{auth: auth}, true
 }
 
 func codexAuthHeaderFixed(auth *cliproxyauth.Auth, name string) bool {
@@ -107,9 +147,6 @@ func codexAuthHeaderFixed(auth *cliproxyauth.Auth, name string) bool {
 				return true
 			}
 		}
-	}
-	if len(auth.Metadata) == 0 {
-		return false
 	}
 	return codexMetadataHeaderValue(auth.Metadata, name) != ""
 }
@@ -142,41 +179,65 @@ func codexMetadataHeaderValue(metadata map[string]any, name string) string {
 	return ""
 }
 
-func codexSetAuthMetadataHeader(auth *cliproxyauth.Auth, name string, value string) {
-	if auth == nil {
-		return
-	}
-	name = strings.TrimSpace(name)
-	value = strings.TrimSpace(value)
-	if name == "" || value == "" {
-		return
-	}
-	if auth.Metadata == nil {
-		auth.Metadata = make(map[string]any)
-	}
-	headers, ok := auth.Metadata["headers"].(map[string]any)
-	if !ok || headers == nil {
-		headers = make(map[string]any)
-		if existing, okExisting := auth.Metadata["headers"].(map[string]string); okExisting {
-			for key, existingValue := range existing {
-				if strings.TrimSpace(key) != "" && strings.TrimSpace(existingValue) != "" {
-					headers[key] = strings.TrimSpace(existingValue)
-				}
-			}
-		}
-		auth.Metadata["headers"] = headers
-	}
-	for key := range headers {
-		if strings.EqualFold(strings.TrimSpace(key), name) {
-			delete(headers, key)
-		}
-	}
-	headers[name] = value
-}
-
 func firstNonEmptyHeaderValue(primary http.Header, secondary http.Header, key string) string {
 	if value := headerValueCaseInsensitive(primary, key); value != "" {
 		return value
 	}
 	return headerValueCaseInsensitive(secondary, key)
+}
+
+func codexEnsureVersionHeader(target http.Header, source http.Header, useDefault bool) {
+	if target == nil {
+		return
+	}
+	version := firstNonEmptyHeaderValue(target, source, "Version")
+	if version == "" && useDefault {
+		version = codexDefaultVersion
+	}
+	if version == "" {
+		return
+	}
+	if !codexVersionAtLeast(version, codexDefaultVersion) {
+		version = codexDefaultVersion
+	}
+	setHeaderCasePreserved(target, "Version", version)
+}
+
+func codexVersionAtLeast(version string, minimum string) bool {
+	currentParts, okCurrent := codexParseVersionParts(version)
+	minimumParts, okMinimum := codexParseVersionParts(minimum)
+	if !okCurrent || !okMinimum {
+		return true
+	}
+	for i := 0; i < len(currentParts); i++ {
+		if currentParts[i] > minimumParts[i] {
+			return true
+		}
+		if currentParts[i] < minimumParts[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func codexParseVersionParts(version string) ([3]int, bool) {
+	version = strings.TrimSpace(strings.TrimPrefix(version, "v"))
+	if version == "" {
+		return [3]int{}, false
+	}
+	fields := strings.FieldsFunc(version, func(r rune) bool {
+		return r == '.' || r == '-'
+	})
+	if len(fields) < 3 {
+		return [3]int{}, false
+	}
+	var parts [3]int
+	for i := 0; i < len(parts); i++ {
+		value, err := strconv.Atoi(fields[i])
+		if err != nil {
+			return [3]int{}, false
+		}
+		parts[i] = value
+	}
+	return parts, true
 }

--- a/internal/runtime/executor/codex_client_profile_pin.go
+++ b/internal/runtime/executor/codex_client_profile_pin.go
@@ -1,0 +1,182 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+const codexClientProfilePinnedMetadataKey = "codex_client_profile_pinned"
+
+var codexPinnedClientProfileHeaders = []string{
+	"X-Codex-Beta-Features",
+	"Version",
+	"User-Agent",
+	"Originator",
+	"x-responsesapi-include-timing-metrics",
+}
+
+func codexPinClientProfileFromFirstRequest(_ context.Context, auth *cliproxyauth.Auth, target http.Header, source http.Header, cfg *config.Config) {
+	if auth == nil || (target == nil && source == nil) || codexClientProfilePinned(auth) {
+		return
+	}
+
+	codexEnsureAuthMetadata(auth)
+	auth.Metadata[codexClientProfilePinnedMetadataKey] = true
+
+	for _, headerName := range codexPinnedClientProfileHeaders {
+		if codexAuthHeaderFixed(auth, headerName) {
+			continue
+		}
+		value := firstNonEmptyHeaderValue(target, source, headerName)
+		if strings.EqualFold(headerName, "User-Agent") {
+			if cfgUserAgent, _ := codexHeaderDefaults(cfg, auth); headerValueCaseInsensitive(target, headerName) == "" && cfgUserAgent != "" {
+				value = cfgUserAgent
+			}
+		}
+		if value == "" {
+			continue
+		}
+		codexSetAuthMetadataHeader(auth, headerName, value)
+		codexSetAuthAttribute(auth, "header:"+headerName, value)
+	}
+}
+
+func codexClientProfilePinned(auth *cliproxyauth.Auth) bool {
+	if auth == nil || len(auth.Metadata) == 0 {
+		return false
+	}
+	pinned, _ := auth.Metadata[codexClientProfilePinnedMetadataKey].(bool)
+	return pinned
+}
+
+func codexClientProfileSourceHeaders(auth *cliproxyauth.Auth, source http.Header) http.Header {
+	if codexClientProfilePinned(auth) {
+		return nil
+	}
+	return source
+}
+
+func codexPreparePinnedClientProfileHeaders(headers http.Header, auth *cliproxyauth.Auth) {
+	if headers == nil || !codexClientProfilePinned(auth) {
+		return
+	}
+	for _, headerName := range codexPinnedClientProfileHeaders {
+		if !codexAuthHeaderFixed(auth, headerName) {
+			headers.Del(headerName)
+		}
+	}
+}
+
+func codexEnsureAuthMetadata(auth *cliproxyauth.Auth) {
+	if auth != nil && auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+}
+
+func codexSetAuthAttribute(auth *cliproxyauth.Auth, key string, value string) {
+	if auth == nil {
+		return
+	}
+	key = strings.TrimSpace(key)
+	value = strings.TrimSpace(value)
+	if key == "" || value == "" {
+		return
+	}
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	auth.Attributes[key] = value
+}
+
+func codexAuthHeaderFixed(auth *cliproxyauth.Auth, name string) bool {
+	name = strings.TrimSpace(name)
+	if auth == nil || name == "" {
+		return false
+	}
+	if len(auth.Attributes) > 0 {
+		for key, value := range auth.Attributes {
+			headerName, ok := strings.CutPrefix(key, "header:")
+			if !ok {
+				continue
+			}
+			if strings.EqualFold(strings.TrimSpace(headerName), name) && strings.TrimSpace(value) != "" {
+				return true
+			}
+		}
+	}
+	if len(auth.Metadata) == 0 {
+		return false
+	}
+	return codexMetadataHeaderValue(auth.Metadata, name) != ""
+}
+
+func codexMetadataHeaderValue(metadata map[string]any, name string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	raw, ok := metadata["headers"]
+	if !ok || raw == nil {
+		return ""
+	}
+	switch headers := raw.(type) {
+	case map[string]any:
+		for key, value := range headers {
+			if !strings.EqualFold(strings.TrimSpace(key), name) {
+				continue
+			}
+			if typed, ok := value.(string); ok {
+				return strings.TrimSpace(typed)
+			}
+		}
+	case map[string]string:
+		for key, value := range headers {
+			if strings.EqualFold(strings.TrimSpace(key), name) {
+				return strings.TrimSpace(value)
+			}
+		}
+	}
+	return ""
+}
+
+func codexSetAuthMetadataHeader(auth *cliproxyauth.Auth, name string, value string) {
+	if auth == nil {
+		return
+	}
+	name = strings.TrimSpace(name)
+	value = strings.TrimSpace(value)
+	if name == "" || value == "" {
+		return
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	headers, ok := auth.Metadata["headers"].(map[string]any)
+	if !ok || headers == nil {
+		headers = make(map[string]any)
+		if existing, okExisting := auth.Metadata["headers"].(map[string]string); okExisting {
+			for key, existingValue := range existing {
+				if strings.TrimSpace(key) != "" && strings.TrimSpace(existingValue) != "" {
+					headers[key] = strings.TrimSpace(existingValue)
+				}
+			}
+		}
+		auth.Metadata["headers"] = headers
+	}
+	for key := range headers {
+		if strings.EqualFold(strings.TrimSpace(key), name) {
+			delete(headers, key)
+		}
+	}
+	headers[name] = value
+}
+
+func firstNonEmptyHeaderValue(primary http.Header, secondary http.Header, key string) string {
+	if value := headerValueCaseInsensitive(primary, key); value != "" {
+		return value
+	}
+	return headerValueCaseInsensitive(secondary, key)
+}

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -35,6 +35,7 @@ import (
 )
 
 const (
+	codexDefaultVersion        = "0.144.6"
 	codexUserAgent             = "codex-tui/0.144.6 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10 (codex-tui; 0.144.6)"
 	codexOriginator            = "codex-tui"
 	codexDefaultImageToolModel = "gpt-image-2"
@@ -1994,7 +1995,7 @@ func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, toke
 	if profileHeaders != nil && profileHeaders.Get("X-Codex-Beta-Features") != "" {
 		r.Header.Set("X-Codex-Beta-Features", profileHeaders.Get("X-Codex-Beta-Features"))
 	}
-	misc.EnsureHeader(r.Header, profileHeaders, "Version", "")
+	codexEnsureVersionHeader(r.Header, profileHeaders, !codexAuthUsesAPIKey(auth))
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Codex-Turn-Metadata", "")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Client-Request-Id", "")
 	cfgUserAgent, _ := codexHeaderDefaults(cfg, auth)
@@ -2017,7 +2018,7 @@ func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, toke
 			isAPIKey = true
 		}
 	}
-	if originator := strings.TrimSpace(profileHeaders.Get("Originator")); originator != "" {
+	if originator := firstNonEmptyHeaderValue(r.Header, profileHeaders, "Originator"); originator != "" {
 		r.Header.Set("Originator", originator)
 	} else if !isAPIKey {
 		r.Header.Set("Originator", codexOriginator)

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1987,14 +1987,18 @@ func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, toke
 	r.Header.Set("Content-Type", "application/json")
 	r.Header.Set("Authorization", "Bearer "+token)
 
-	if ginHeaders != nil && ginHeaders.Get("X-Codex-Beta-Features") != "" {
-		r.Header.Set("X-Codex-Beta-Features", ginHeaders.Get("X-Codex-Beta-Features"))
+	codexPinClientProfileFromFirstRequest(r.Context(), auth, r.Header, ginHeaders, cfg)
+	codexPreparePinnedClientProfileHeaders(r.Header, auth)
+	profileHeaders := codexClientProfileSourceHeaders(auth, ginHeaders)
+
+	if profileHeaders != nil && profileHeaders.Get("X-Codex-Beta-Features") != "" {
+		r.Header.Set("X-Codex-Beta-Features", profileHeaders.Get("X-Codex-Beta-Features"))
 	}
-	misc.EnsureHeader(r.Header, ginHeaders, "Version", "")
+	misc.EnsureHeader(r.Header, profileHeaders, "Version", "")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Codex-Turn-Metadata", "")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Client-Request-Id", "")
 	cfgUserAgent, _ := codexHeaderDefaults(cfg, auth)
-	ensureHeaderWithConfigPrecedence(r.Header, ginHeaders, "User-Agent", cfgUserAgent, codexUserAgent)
+	ensureHeaderWithConfigPrecedence(r.Header, profileHeaders, "User-Agent", cfgUserAgent, codexUserAgent)
 
 	if strings.Contains(r.Header.Get("User-Agent"), "Mac OS") {
 		misc.EnsureHeader(r.Header, ginHeaders, "Session_id", uuid.NewString())
@@ -2013,7 +2017,7 @@ func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, toke
 			isAPIKey = true
 		}
 	}
-	if originator := strings.TrimSpace(ginHeaders.Get("Originator")); originator != "" {
+	if originator := strings.TrimSpace(profileHeaders.Get("Originator")); originator != "" {
 		r.Header.Set("Originator", originator)
 	} else if !isAPIKey {
 		r.Header.Set("Originator", codexOriginator)

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	codexUserAgent             = "codex-tui/0.135.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10 (codex-tui; 0.135.0)"
+	codexUserAgent             = "codex-tui/0.144.6 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10 (codex-tui; 0.144.6)"
 	codexOriginator            = "codex-tui"
 	codexDefaultImageToolModel = "gpt-image-2"
 	codexResponsesLiteHeader   = "X-OpenAI-Internal-Codex-Responses-Lite"

--- a/internal/runtime/executor/codex_openai_images_test.go
+++ b/internal/runtime/executor/codex_openai_images_test.go
@@ -70,7 +70,7 @@ func TestCodexExecutorDirectOpenAIImageGenerationUsesImagesEndpoint(t *testing.T
 
 	ctx := contextWithGinHeaders(map[string]string{
 		"User-Agent":            "downstream-client/9.9",
-		"Version":               "0.135.0",
+		"Version":               codexDefaultVersion,
 		"X-Codex-Turn-Metadata": `{"turn_id":"turn-1"}`,
 		"X-Client-Request-Id":   "client-request-1",
 		"Originator":            "Codex Desktop",
@@ -96,8 +96,8 @@ func TestCodexExecutorDirectOpenAIImageGenerationUsesImagesEndpoint(t *testing.T
 	if gotUA != codexUserAgent {
 		t.Fatalf("User-Agent = %q, want codex default %q", gotUA, codexUserAgent)
 	}
-	if gotVersion != "0.135.0" {
-		t.Fatalf("Version = %q, want %q", gotVersion, "0.135.0")
+	if gotVersion != codexDefaultVersion {
+		t.Fatalf("Version = %q, want %q", gotVersion, codexDefaultVersion)
 	}
 	if gotTurnMetadata != `{"turn_id":"turn-1"}` {
 		t.Fatalf("X-Codex-Turn-Metadata = %q, want %q", gotTurnMetadata, `{"turn_id":"turn-1"}`)

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -1067,7 +1067,7 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, auth *
 	misc.EnsureHeader(headers, ginHeaders, "x-codex-turn-metadata", "")
 	misc.EnsureHeader(headers, ginHeaders, "x-client-request-id", "")
 	misc.EnsureHeader(headers, profileHeaders, "x-responsesapi-include-timing-metrics", "")
-	misc.EnsureHeader(headers, profileHeaders, "Version", "")
+	codexEnsureVersionHeader(headers, profileHeaders, !isAPIKey)
 	if isAPIKey {
 		ensureHeaderWithPriority(headers, profileHeaders, "User-Agent", "", "")
 	} else {
@@ -1087,7 +1087,7 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, auth *
 		sessionFallback = uuid.NewString()
 	}
 	ensureCodexWebsocketSessionHeader(headers, ginHeaders, sessionFallback)
-	if originator := strings.TrimSpace(profileHeaders.Get("Originator")); originator != "" {
+	if originator := firstNonEmptyHeaderValue(headers, profileHeaders, "Originator"); originator != "" {
 		headers.Set("Originator", originator)
 	} else if !isAPIKey {
 		headers.Set("Originator", codexOriginator)

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -1057,17 +1057,21 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, auth *
 	}
 
 	isAPIKey := codexAuthUsesAPIKey(auth)
+	codexPinClientProfileFromFirstRequest(ctx, auth, headers, ginHeaders, cfg)
+	codexPreparePinnedClientProfileHeaders(headers, auth)
+	profileHeaders := codexClientProfileSourceHeaders(auth, ginHeaders)
+
 	cfgUserAgent, cfgBetaFeatures := codexHeaderDefaults(cfg, auth)
-	ensureHeaderWithPriority(headers, ginHeaders, "x-codex-beta-features", cfgBetaFeatures, "")
+	ensureHeaderWithPriority(headers, profileHeaders, "x-codex-beta-features", cfgBetaFeatures, "")
 	misc.EnsureHeader(headers, ginHeaders, "x-codex-turn-state", "")
 	misc.EnsureHeader(headers, ginHeaders, "x-codex-turn-metadata", "")
 	misc.EnsureHeader(headers, ginHeaders, "x-client-request-id", "")
-	misc.EnsureHeader(headers, ginHeaders, "x-responsesapi-include-timing-metrics", "")
-	misc.EnsureHeader(headers, ginHeaders, "Version", "")
+	misc.EnsureHeader(headers, profileHeaders, "x-responsesapi-include-timing-metrics", "")
+	misc.EnsureHeader(headers, profileHeaders, "Version", "")
 	if isAPIKey {
-		ensureHeaderWithPriority(headers, ginHeaders, "User-Agent", "", "")
+		ensureHeaderWithPriority(headers, profileHeaders, "User-Agent", "", "")
 	} else {
-		ensureHeaderWithConfigPrecedence(headers, ginHeaders, "User-Agent", cfgUserAgent, codexUserAgent)
+		ensureHeaderWithConfigPrecedence(headers, profileHeaders, "User-Agent", cfgUserAgent, codexUserAgent)
 	}
 
 	betaHeader := strings.TrimSpace(headers.Get("OpenAI-Beta"))
@@ -1083,7 +1087,7 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, auth *
 		sessionFallback = uuid.NewString()
 	}
 	ensureCodexWebsocketSessionHeader(headers, ginHeaders, sessionFallback)
-	if originator := strings.TrimSpace(ginHeaders.Get("Originator")); originator != "" {
+	if originator := strings.TrimSpace(profileHeaders.Get("Originator")); originator != "" {
 		headers.Set("Originator", originator)
 	} else if !isAPIKey {
 		headers.Set("Originator", codexOriginator)

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -692,6 +692,48 @@ func TestApplyCodexWebsocketHeadersPassesThroughClientIdentityHeaders(t *testing
 	}
 }
 
+func TestApplyCodexWebsocketHeadersPinsClientProfilePerAuth(t *testing.T) {
+	auth := &cliproxyauth.Auth{Provider: "codex", Metadata: map[string]any{"email": "user@example.com"}}
+
+	firstCtx := contextWithGinHeaders(map[string]string{
+		"Originator":                            "Codex Desktop",
+		"User-Agent":                            "codex_cli_rs/0.1.0",
+		"Version":                               "0.115.0-alpha.27",
+		"X-Codex-Beta-Features":                 "first-beta",
+		"x-responsesapi-include-timing-metrics": "true",
+		"X-Codex-Turn-Metadata":                 `{"turn_id":"turn-1"}`,
+	})
+	first := applyCodexWebsocketHeaders(firstCtx, http.Header{}, auth, "", nil)
+	if got := first.Get("User-Agent"); got != "codex_cli_rs/0.1.0" {
+		t.Fatalf("first User-Agent = %q, want %q", got, "codex_cli_rs/0.1.0")
+	}
+
+	secondCtx := contextWithGinHeaders(map[string]string{
+		"Originator":            "Other Client",
+		"User-Agent":            "other-client/9.9",
+		"Version":               "9.9.9",
+		"X-Codex-Beta-Features": "second-beta",
+		"X-Codex-Turn-Metadata": `{"turn_id":"turn-2"}`,
+	})
+	second := applyCodexWebsocketHeaders(secondCtx, http.Header{}, auth, "", nil)
+
+	if got := second.Get("User-Agent"); got != "codex_cli_rs/0.1.0" {
+		t.Fatalf("second User-Agent = %q, want pinned first value", got)
+	}
+	if got := second.Get("Originator"); got != "Codex Desktop" {
+		t.Fatalf("second Originator = %q, want pinned first value", got)
+	}
+	if got := second.Get("Version"); got != "0.115.0-alpha.27" {
+		t.Fatalf("second Version = %q, want pinned first value", got)
+	}
+	if got := second.Get("X-Codex-Beta-Features"); got != "first-beta" {
+		t.Fatalf("second X-Codex-Beta-Features = %q, want pinned first value", got)
+	}
+	if got := second.Get("X-Codex-Turn-Metadata"); got != `{"turn_id":"turn-2"}` {
+		t.Fatalf("second X-Codex-Turn-Metadata = %q, want per-request value", got)
+	}
+}
+
 func TestApplyCodexWebsocketHeadersCanonicalizesLegacyUnderscoreSessionHeader(t *testing.T) {
 	auth := &cliproxyauth.Auth{
 		Provider: "codex",
@@ -1234,6 +1276,52 @@ func TestApplyCodexHeadersPassesThroughClientIdentityHeaders(t *testing.T) {
 	}
 	if got := req.Header.Get("X-Client-Request-Id"); got != "019d2233-e240-7162-992d-38df0a2a0e0d" {
 		t.Fatalf("X-Client-Request-Id = %s, want %s", got, "019d2233-e240-7162-992d-38df0a2a0e0d")
+	}
+}
+
+func TestApplyCodexHeadersPinsClientProfilePerAuth(t *testing.T) {
+	auth := &cliproxyauth.Auth{Provider: "codex", Metadata: map[string]any{"email": "user@example.com"}}
+
+	firstReq, err := http.NewRequest(http.MethodPost, "https://example.com/responses", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	firstReq = firstReq.WithContext(contextWithGinHeaders(map[string]string{
+		"Originator":            "Codex Desktop",
+		"User-Agent":            "codex_cli_rs/0.1.0",
+		"Version":               "0.115.0-alpha.27",
+		"X-Codex-Beta-Features": "first-beta",
+		"X-Codex-Turn-Metadata": `{"turn_id":"turn-1"}`,
+	}))
+	applyCodexHeaders(firstReq, auth, "oauth-token", true, nil)
+
+	secondReq, err := http.NewRequest(http.MethodPost, "https://example.com/responses", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	secondReq = secondReq.WithContext(contextWithGinHeaders(map[string]string{
+		"Originator":            "Other Client",
+		"User-Agent":            "other-client/9.9",
+		"Version":               "9.9.9",
+		"X-Codex-Beta-Features": "second-beta",
+		"X-Codex-Turn-Metadata": `{"turn_id":"turn-2"}`,
+	}))
+	applyCodexHeaders(secondReq, auth, "oauth-token", true, nil)
+
+	if got := secondReq.Header.Get("User-Agent"); got != "codex_cli_rs/0.1.0" {
+		t.Fatalf("second User-Agent = %q, want pinned first value", got)
+	}
+	if got := secondReq.Header.Get("Originator"); got != "Codex Desktop" {
+		t.Fatalf("second Originator = %q, want pinned first value", got)
+	}
+	if got := secondReq.Header.Get("Version"); got != "0.115.0-alpha.27" {
+		t.Fatalf("second Version = %q, want pinned first value", got)
+	}
+	if got := secondReq.Header.Get("X-Codex-Beta-Features"); got != "first-beta" {
+		t.Fatalf("second X-Codex-Beta-Features = %q, want pinned first value", got)
+	}
+	if got := secondReq.Header.Get("X-Codex-Turn-Metadata"); got != `{"turn_id":"turn-2"}` {
+		t.Fatalf("second X-Codex-Turn-Metadata = %q, want per-request value", got)
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -639,8 +641,8 @@ func TestApplyCodexWebsocketHeadersDefaultsToCurrentResponsesBeta(t *testing.T) 
 	if got := headers.Get("Originator"); got != codexOriginator {
 		t.Fatalf("Originator = %s, want %s", got, codexOriginator)
 	}
-	if got := headers.Get("Version"); got != "" {
-		t.Fatalf("Version = %q, want empty", got)
+	if got := headers.Get("Version"); got != codexDefaultVersion {
+		t.Fatalf("Version = %q, want %q", got, codexDefaultVersion)
 	}
 	if got := headers.Get("x-codex-beta-features"); got != "" {
 		t.Fatalf("x-codex-beta-features = %q, want empty", got)
@@ -661,7 +663,7 @@ func TestApplyCodexWebsocketHeadersPassesThroughClientIdentityHeaders(t *testing
 	ctx := contextWithGinHeaders(map[string]string{
 		"Originator":            "Codex Desktop",
 		"User-Agent":            "codex_cli_rs/0.1.0",
-		"Version":               "0.115.0-alpha.27",
+		"Version":               codexDefaultVersion,
 		"X-Codex-Turn-Metadata": `{"turn_id":"turn-1"}`,
 		"X-Client-Request-Id":   "019d2233-e240-7162-992d-38df0a2a0e0d",
 		"session-id":            "legacy-session",
@@ -675,8 +677,8 @@ func TestApplyCodexWebsocketHeadersPassesThroughClientIdentityHeaders(t *testing
 	if got := headers.Get("User-Agent"); got != "codex_cli_rs/0.1.0" {
 		t.Fatalf("User-Agent = %s, want %s", got, "codex_cli_rs/0.1.0")
 	}
-	if got := headers.Get("Version"); got != "0.115.0-alpha.27" {
-		t.Fatalf("Version = %s, want %s", got, "0.115.0-alpha.27")
+	if got := headers.Get("Version"); got != codexDefaultVersion {
+		t.Fatalf("Version = %s, want %s", got, codexDefaultVersion)
 	}
 	if got := headers.Get("X-Codex-Turn-Metadata"); got != `{"turn_id":"turn-1"}` {
 		t.Fatalf("X-Codex-Turn-Metadata = %s, want %s", got, `{"turn_id":"turn-1"}`)
@@ -698,7 +700,7 @@ func TestApplyCodexWebsocketHeadersPinsClientProfilePerAuth(t *testing.T) {
 	firstCtx := contextWithGinHeaders(map[string]string{
 		"Originator":                            "Codex Desktop",
 		"User-Agent":                            "codex_cli_rs/0.1.0",
-		"Version":                               "0.115.0-alpha.27",
+		"Version":                               codexDefaultVersion,
 		"X-Codex-Beta-Features":                 "first-beta",
 		"x-responsesapi-include-timing-metrics": "true",
 		"X-Codex-Turn-Metadata":                 `{"turn_id":"turn-1"}`,
@@ -723,14 +725,92 @@ func TestApplyCodexWebsocketHeadersPinsClientProfilePerAuth(t *testing.T) {
 	if got := second.Get("Originator"); got != "Codex Desktop" {
 		t.Fatalf("second Originator = %q, want pinned first value", got)
 	}
-	if got := second.Get("Version"); got != "0.115.0-alpha.27" {
-		t.Fatalf("second Version = %q, want pinned first value", got)
+	if got := second.Get("Version"); got != codexDefaultVersion {
+		t.Fatalf("second Version = %q, want pinned default value", got)
 	}
 	if got := second.Get("X-Codex-Beta-Features"); got != "first-beta" {
 		t.Fatalf("second X-Codex-Beta-Features = %q, want pinned first value", got)
 	}
 	if got := second.Get("X-Codex-Turn-Metadata"); got != `{"turn_id":"turn-2"}` {
 		t.Fatalf("second X-Codex-Turn-Metadata = %q, want per-request value", got)
+	}
+}
+
+func TestCodexClientProfilePinDoesNotMutateAuthMaps(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		ID:       "test-codex-profile-no-mutate",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"existing": "value",
+		},
+		Metadata: map[string]any{
+			"email": "user@example.com",
+		},
+	}
+	ctx := contextWithGinHeaders(map[string]string{
+		"Originator":            "Codex Desktop",
+		"User-Agent":            "codex_cli_rs/0.1.0",
+		"Version":               codexDefaultVersion,
+		"X-Codex-Beta-Features": "first-beta",
+	})
+
+	headers := applyCodexWebsocketHeaders(ctx, http.Header{}, auth, "", nil)
+
+	if got := headers.Get("User-Agent"); got != "codex_cli_rs/0.1.0" {
+		t.Fatalf("User-Agent = %q, want pinned value", got)
+	}
+	if _, ok := auth.Attributes["header:User-Agent"]; ok {
+		t.Fatalf("auth.Attributes was mutated: %#v", auth.Attributes)
+	}
+	if _, ok := auth.Metadata["headers"]; ok {
+		t.Fatalf("auth.Metadata was mutated: %#v", auth.Metadata)
+	}
+	if _, ok := auth.Metadata["codex_client_profile_pinned"]; ok {
+		t.Fatalf("auth.Metadata contains stale pin marker: %#v", auth.Metadata)
+	}
+}
+
+func TestCodexClientProfilePinConcurrentRequests(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		ID:       "test-codex-profile-concurrent",
+		Provider: "codex",
+		Metadata: map[string]any{"email": "user@example.com"},
+	}
+
+	const workers = 32
+	contexts := make([]context.Context, workers)
+	for i := 0; i < workers; i++ {
+		contexts[i] = contextWithGinHeaders(map[string]string{
+			"Originator":            "Codex Desktop",
+			"User-Agent":            fmt.Sprintf("codex_cli_rs/0.144.%d", i),
+			"Version":               codexDefaultVersion,
+			"X-Codex-Beta-Features": fmt.Sprintf("beta-%d", i),
+		})
+	}
+
+	start := make(chan struct{})
+	errCh := make(chan string, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			headers := applyCodexWebsocketHeaders(contexts[i], http.Header{}, auth, "", nil)
+			if headers.Get("User-Agent") == "" {
+				errCh <- "missing User-Agent"
+			}
+			if got := headers.Get("Version"); got != codexDefaultVersion {
+				errCh <- fmt.Sprintf("Version = %q, want %q", got, codexDefaultVersion)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errCh)
+	for msg := range errCh {
+		t.Fatal(msg)
 	}
 }
 
@@ -1258,7 +1338,7 @@ func TestApplyCodexHeadersPassesThroughClientIdentityHeaders(t *testing.T) {
 	}
 	req = req.WithContext(contextWithGinHeaders(map[string]string{
 		"Originator":            "Codex Desktop",
-		"Version":               "0.115.0-alpha.27",
+		"Version":               codexDefaultVersion,
 		"X-Codex-Turn-Metadata": `{"turn_id":"turn-1"}`,
 		"X-Client-Request-Id":   "019d2233-e240-7162-992d-38df0a2a0e0d",
 	}))
@@ -1268,8 +1348,8 @@ func TestApplyCodexHeadersPassesThroughClientIdentityHeaders(t *testing.T) {
 	if got := req.Header.Get("Originator"); got != "Codex Desktop" {
 		t.Fatalf("Originator = %s, want %s", got, "Codex Desktop")
 	}
-	if got := req.Header.Get("Version"); got != "0.115.0-alpha.27" {
-		t.Fatalf("Version = %s, want %s", got, "0.115.0-alpha.27")
+	if got := req.Header.Get("Version"); got != codexDefaultVersion {
+		t.Fatalf("Version = %s, want %s", got, codexDefaultVersion)
 	}
 	if got := req.Header.Get("X-Codex-Turn-Metadata"); got != `{"turn_id":"turn-1"}` {
 		t.Fatalf("X-Codex-Turn-Metadata = %s, want %s", got, `{"turn_id":"turn-1"}`)
@@ -1289,7 +1369,7 @@ func TestApplyCodexHeadersPinsClientProfilePerAuth(t *testing.T) {
 	firstReq = firstReq.WithContext(contextWithGinHeaders(map[string]string{
 		"Originator":            "Codex Desktop",
 		"User-Agent":            "codex_cli_rs/0.1.0",
-		"Version":               "0.115.0-alpha.27",
+		"Version":               codexDefaultVersion,
 		"X-Codex-Beta-Features": "first-beta",
 		"X-Codex-Turn-Metadata": `{"turn_id":"turn-1"}`,
 	}))
@@ -1314,8 +1394,8 @@ func TestApplyCodexHeadersPinsClientProfilePerAuth(t *testing.T) {
 	if got := secondReq.Header.Get("Originator"); got != "Codex Desktop" {
 		t.Fatalf("second Originator = %q, want pinned first value", got)
 	}
-	if got := secondReq.Header.Get("Version"); got != "0.115.0-alpha.27" {
-		t.Fatalf("second Version = %q, want pinned first value", got)
+	if got := secondReq.Header.Get("Version"); got != codexDefaultVersion {
+		t.Fatalf("second Version = %q, want pinned default value", got)
 	}
 	if got := secondReq.Header.Get("X-Codex-Beta-Features"); got != "first-beta" {
 		t.Fatalf("second X-Codex-Beta-Features = %q, want pinned first value", got)
@@ -1333,8 +1413,8 @@ func TestApplyCodexHeadersDoesNotInjectClientOnlyHeadersByDefault(t *testing.T) 
 
 	applyCodexHeaders(req, nil, "oauth-token", true, nil)
 
-	if got := req.Header.Get("Version"); got != "" {
-		t.Fatalf("Version = %q, want empty", got)
+	if got := req.Header.Get("Version"); got != codexDefaultVersion {
+		t.Fatalf("Version = %q, want %q", got, codexDefaultVersion)
 	}
 	if got := req.Header.Get("X-Codex-Turn-Metadata"); got != "" {
 		t.Fatalf("X-Codex-Turn-Metadata = %q, want empty", got)


### PR DESCRIPTION
## Summary
- pin Codex client profile headers on the first request for each auth
- prevent later downstream requests from changing profile-like headers such as User-Agent, Originator, Version, Codex beta features, and timing metrics
- keep per-request headers such as turn metadata flowing from each request

## Tests
- go test ./...
