### PR TITLE
feat(home): manage credential dispatch leases

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -691,6 +691,7 @@ func (s *Server) codexAlphaSearch(c *gin.Context) {
 		c.JSON(status, gin.H{"error": err.Error()})
 		return
 	}
+	defer s.handlers.AuthManager.ReleaseHomeLease(selected, "codex_alpha_search_terminal")
 	logging.SetGinCPATraceID(c, selected.EnsureIndex())
 
 	headers := make(http.Header)

--- a/internal/home/client.go
+++ b/internal/home/client.go
@@ -864,20 +864,26 @@ func queryToLowerMap(query url.Values) map[string]string {
 	return out
 }
 
-func newAuthDispatchRequest(requestedModel string, sessionID string, headers http.Header, count int) authDispatchRequest {
+func newAuthDispatchRequest(requestedModel string, requestID string, dispatchID string, sessionID string, headers http.Header, count int) authDispatchRequest {
 	if count <= 0 {
 		count = 1
 	}
 	return authDispatchRequest{
-		Type:      "auth",
-		Model:     requestedModel,
-		Count:     count,
-		SessionID: strings.TrimSpace(sessionID),
-		Headers:   headersToLowerMap(headers),
+		Type:       "auth",
+		Model:      requestedModel,
+		Count:      count,
+		RequestID:  strings.TrimSpace(requestID),
+		DispatchID: strings.TrimSpace(dispatchID),
+		SessionID:  strings.TrimSpace(sessionID),
+		Headers:    headersToLowerMap(headers),
 	}
 }
 
 func (c *Client) RPopAuth(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int) ([]byte, error) {
+	return c.RPopAuthWithIdentity(ctx, requestedModel, "", "", sessionID, headers, count)
+}
+
+func (c *Client) RPopAuthWithIdentity(ctx context.Context, requestedModel string, requestID string, dispatchID string, sessionID string, headers http.Header, count int) ([]byte, error) {
 	cmd, errClient := c.commandClient()
 	if errClient != nil {
 		return nil, errClient
@@ -886,7 +892,7 @@ func (c *Client) RPopAuth(ctx context.Context, requestedModel string, sessionID 
 	if requestedModel == "" {
 		return nil, fmt.Errorf("home: requested model is empty")
 	}
-	req := newAuthDispatchRequest(requestedModel, sessionID, headers, count)
+	req := newAuthDispatchRequest(requestedModel, requestID, dispatchID, sessionID, headers, count)
 	keyBytes, err := json.Marshal(&req)
 	if err != nil {
 		return nil, err
@@ -903,6 +909,33 @@ func (c *Client) RPopAuth(ctx context.Context, requestedModel string, sessionID 
 		return nil, ErrEmptyResponse
 	}
 	return raw, nil
+}
+
+func (c *Client) RenewInFlightLease(ctx context.Context, leaseID string) (bool, error) {
+	return c.pushInFlightLease(ctx, inFlightLeaseRequest{Action: "renew", LeaseID: strings.TrimSpace(leaseID)})
+}
+
+func (c *Client) ReleaseInFlightLease(ctx context.Context, leaseID string, reason string) (bool, error) {
+	return c.pushInFlightLease(ctx, inFlightLeaseRequest{Action: "release", LeaseID: strings.TrimSpace(leaseID), Reason: strings.TrimSpace(reason)})
+}
+
+func (c *Client) pushInFlightLease(ctx context.Context, req inFlightLeaseRequest) (bool, error) {
+	cmd, errClient := c.commandClient()
+	if errClient != nil {
+		return false, errClient
+	}
+	if req.LeaseID == "" {
+		return false, nil
+	}
+	payload, errMarshal := json.Marshal(req)
+	if errMarshal != nil {
+		return false, errMarshal
+	}
+	count, errPush := cmd.LPush(ctx, "in-flight", payload).Result()
+	if errPush != nil {
+		return false, errPush
+	}
+	return count > 0, nil
 }
 
 func (c *Client) GetRefreshAuth(ctx context.Context, authIndex string) ([]byte, error) {

--- a/internal/home/client_test.go
+++ b/internal/home/client_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestAuthDispatchRequestIncludesCount(t *testing.T) {
-	req := newAuthDispatchRequest("gpt-5.4", "session-1", http.Header{"Authorization": {"Bearer test"}}, 2)
+	req := newAuthDispatchRequest("gpt-5.4", "request-1", "dispatch-1", "session-1", http.Header{"Authorization": {"Bearer test"}}, 2)
 
 	raw, err := json.Marshal(&req)
 	if err != nil {
@@ -38,10 +38,13 @@ func TestAuthDispatchRequestIncludesCount(t *testing.T) {
 	if got := int(payload["count"].(float64)); got != 2 {
 		t.Fatalf("count = %d, want 2", got)
 	}
+	if payload["request_id"] != "request-1" || payload["dispatch_id"] != "dispatch-1" {
+		t.Fatalf("identity = request:%v dispatch:%v", payload["request_id"], payload["dispatch_id"])
+	}
 }
 
 func TestAuthDispatchRequestDefaultsCountToOne(t *testing.T) {
-	req := newAuthDispatchRequest("gpt-5.4", "", nil, 0)
+	req := newAuthDispatchRequest("gpt-5.4", "", "", "", nil, 0)
 
 	if req.Count != 1 {
 		t.Fatalf("count = %d, want 1", req.Count)

--- a/internal/home/requests.go
+++ b/internal/home/requests.go
@@ -1,11 +1,19 @@
 package home
 
 type authDispatchRequest struct {
-	Type      string            `json:"type"`
-	Model     string            `json:"model"`
-	Count     int               `json:"count"`
-	SessionID string            `json:"session_id,omitempty"`
-	Headers   map[string]string `json:"headers,omitempty"`
+	Type       string            `json:"type"`
+	Model      string            `json:"model"`
+	Count      int               `json:"count"`
+	RequestID  string            `json:"request_id,omitempty"`
+	DispatchID string            `json:"dispatch_id,omitempty"`
+	SessionID  string            `json:"session_id,omitempty"`
+	Headers    map[string]string `json:"headers,omitempty"`
+}
+
+type inFlightLeaseRequest struct {
+	Action  string `json:"action"`
+	LeaseID string `json:"lease_id"`
+	Reason  string `json:"reason,omitempty"`
 }
 
 type modelsRequest struct {

--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -52,6 +52,7 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 	}
 	apiKey := strings.TrimSpace(record.APIKey)
 	requestID := strings.TrimSpace(internallogging.GetRequestID(ctx))
+	leaseID := coreusage.HomeLeaseIDFromContext(ctx)
 	reasoningEffort := strings.TrimSpace(record.ReasoningEffort)
 	if reasoningEffort == "" {
 		reasoningEffort = coreusage.ReasoningEffortFromContext(ctx)
@@ -111,6 +112,7 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		AuthType:            authType,
 		APIKey:              apiKey,
 		RequestID:           requestID,
+		LeaseID:             leaseID,
 		ReasoningEffort:     reasoningEffort,
 		ServiceTier:         serviceTier,
 		ResponseServiceTier: responseServiceTier,
@@ -131,6 +133,7 @@ type queuedUsageDetail struct {
 	AuthType            string `json:"auth_type"`
 	APIKey              string `json:"api_key"`
 	RequestID           string `json:"request_id"`
+	LeaseID             string `json:"lease_id,omitempty"`
 	ReasoningEffort     string `json:"reasoning_effort"`
 	ServiceTier         string `json:"service_tier"`
 	ResponseServiceTier string `json:"response_service_tier,omitempty"`

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -16,6 +16,7 @@ import (
 func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 	withEnabledQueue(t, func() {
 		ctx := internallogging.WithRequestID(context.Background(), "ctx-request-id")
+		ctx = coreusage.WithHomeLeaseID(ctx, "lease-1")
 		ctx = internallogging.WithEndpoint(ctx, "POST /v1/chat/completions")
 		ctx = internallogging.WithResponseStatusHolder(ctx)
 		internallogging.SetResponseStatus(ctx, http.StatusOK)
@@ -57,6 +58,7 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 		requireStringField(t, payload, "auth_type", "apikey")
 		requireMissingField(t, payload, "user_api_key")
 		requireStringField(t, payload, "request_id", "ctx-request-id")
+		requireStringField(t, payload, "lease_id", "lease-1")
 		requireStringField(t, payload, "reasoning_effort", "medium")
 		requireStringField(t, payload, "service_tier", "auto")
 		requireMissingField(t, payload, "request_service_tier")

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1776,6 +1776,10 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {
 		defer close(out)
+		releaseReason := "stream_terminal"
+		defer func() {
+			releaseHomeLease(auth, releaseReason)
+		}()
 		var failed bool
 		forward := true
 		var rewriter *StreamRewriter
@@ -1798,6 +1802,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 				}
 				select {
 				case <-ctx.Done():
+					releaseReason = "request_canceled"
 					forward = false
 					return false
 				case out <- chunk:
@@ -1818,6 +1823,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 			}
 			select {
 			case <-ctx.Done():
+				releaseReason = "request_canceled"
 				forward = false
 				return false
 			case out <- chunk:
@@ -1835,6 +1841,9 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 				discardStreamChunks(remaining)
 				return
 			}
+		}
+		if ctx != nil && ctx.Err() != nil {
+			releaseReason = "request_canceled"
 		}
 		if tail := finishForceMappedStreamChunks(rewriter); len(tail) > 0 {
 			tailChunk := cliproxyexecutor.StreamChunk{Payload: tail}
@@ -1854,6 +1863,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		return nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
 	ctx = contextWithRequestedModelAlias(ctx, opts, routeModel)
+	homeLease := homeLeaseFromAuth(auth)
 	var lastErr error
 	didRefreshOnUnauthorized := false
 	for idx, execModel := range execModels {
@@ -1872,6 +1882,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(ctx, auth, errStream, didRefreshOnUnauthorized); okRefresh {
 				auth = refreshed
+				preserveHomeLease(auth, homeLease)
 				didRefreshOnUnauthorized = true
 				streamResult, errStream = executor.ExecuteStream(ctx, auth, execReq, execOpts)
 				if errStream != nil {
@@ -1902,6 +1913,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(ctx, auth, bootstrapErr, didRefreshOnUnauthorized); okRefresh {
 				discardStreamChunks(streamResult.Chunks)
 				auth = refreshed
+				preserveHomeLease(auth, homeLease)
 				didRefreshOnUnauthorized = true
 				retryStream, retryErr := executor.ExecuteStream(ctx, auth, execReq, execOpts)
 				if retryErr != nil {
@@ -2330,6 +2342,7 @@ func (m *Manager) Load(ctx context.Context) error {
 // Execute performs a non-streaming execution using the configured selector and executor.
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	ctx = ensureExecutionRequestID(ctx)
 	normalized := m.normalizeProviders(providers)
 	if len(normalized) == 0 {
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
@@ -2368,6 +2381,7 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	ctx = ensureExecutionRequestID(ctx)
 	normalized := m.normalizeProviders(providers)
 	if len(normalized) == 0 {
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
@@ -2400,6 +2414,7 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 // ExecuteStream performs a streaming execution using the configured selector and executor.
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	ctx = ensureExecutionRequestID(ctx)
 	normalized := m.normalizeProviders(providers)
 	if len(normalized) == 0 {
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
@@ -2573,20 +2588,25 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
+		execCtx = contextWithHomeLease(execCtx, auth)
 
 		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
 		if len(models) == 0 {
+			releaseHomeLease(auth, "no_execution_model")
 			continue
 		}
 		attempted[auth.ID] = struct{}{}
+		homeLease := homeLeaseFromAuth(auth)
 		var errPrepare error
 		auth, errPrepare = m.prepareRequestAuth(execCtx, executor, auth)
 		if errPrepare != nil {
 			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: resultErrorFromError(errPrepare)}
 			m.MarkResult(execCtx, result)
+			releaseHomeLease(auth, "prepare_failed")
 			lastErr = errPrepare
 			continue
 		}
+		preserveHomeLease(auth, homeLease)
 		var authErr error
 		didRefreshOnUnauthorized := false
 		for _, upstreamModel := range models {
@@ -2601,14 +2621,17 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			resp, errExec := executor.Execute(execCtx, auth, execReq, execOpts)
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
+					releaseHomeLease(auth, "request_canceled")
 					return cliproxyexecutor.Response{}, errCtx
 				}
 				if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(execCtx, auth, errExec, didRefreshOnUnauthorized); okRefresh {
 					auth = refreshed
+					preserveHomeLease(auth, homeLease)
 					didRefreshOnUnauthorized = true
 					resp, errExec = executor.Execute(execCtx, auth, execReq, execOpts)
 					if errExec != nil {
 						if errCtx := execCtx.Err(); errCtx != nil {
+							releaseHomeLease(auth, "request_canceled")
 							return cliproxyexecutor.Response{}, errCtx
 						}
 					}
@@ -2622,19 +2645,23 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				}
 				m.MarkResult(execCtx, result)
 				if isRequestInvalidError(errExec) {
+					releaseHomeLease(auth, "request_invalid")
 					return cliproxyexecutor.Response{}, errExec
 				}
 				authErr = errExec
 				continue
 			}
 			m.MarkResult(execCtx, result)
+			releaseHomeLease(auth, "completed")
 			rewriteForceMappedResponse(&resp, aliasResult)
 			return resp, nil
 		}
 		if authErr != nil {
 			if isRequestInvalidError(authErr) {
+				releaseHomeLease(auth, "request_invalid")
 				return cliproxyexecutor.Response{}, authErr
 			}
+			releaseHomeLease(auth, "attempt_failed")
 			lastErr = authErr
 			if homeMode {
 				homeAuthCount++
@@ -2686,20 +2713,25 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
+		execCtx = contextWithHomeLease(execCtx, auth)
 
 		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
 		if len(models) == 0 {
+			releaseHomeLease(auth, "no_execution_model")
 			continue
 		}
 		attempted[auth.ID] = struct{}{}
+		homeLease := homeLeaseFromAuth(auth)
 		var errPrepare error
 		auth, errPrepare = m.prepareRequestAuth(execCtx, executor, auth)
 		if errPrepare != nil {
 			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: resultErrorFromError(errPrepare)}
 			m.MarkResult(execCtx, result)
+			releaseHomeLease(auth, "prepare_failed")
 			lastErr = errPrepare
 			continue
 		}
+		preserveHomeLease(auth, homeLease)
 		var authErr error
 		didRefreshOnUnauthorized := false
 		for _, upstreamModel := range models {
@@ -2714,14 +2746,17 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			resp, errExec := executor.CountTokens(execCtx, auth, execReq, execOpts)
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
+					releaseHomeLease(auth, "request_canceled")
 					return cliproxyexecutor.Response{}, errCtx
 				}
 				if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(execCtx, auth, errExec, didRefreshOnUnauthorized); okRefresh {
 					auth = refreshed
+					preserveHomeLease(auth, homeLease)
 					didRefreshOnUnauthorized = true
 					resp, errExec = executor.CountTokens(execCtx, auth, execReq, execOpts)
 					if errExec != nil {
 						if errCtx := execCtx.Err(); errCtx != nil {
+							releaseHomeLease(auth, "request_canceled")
 							return cliproxyexecutor.Response{}, errCtx
 						}
 					}
@@ -2743,19 +2778,23 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 					m.MarkResult(execCtx, result)
 				}
 				if isRequestInvalidError(errExec) {
+					releaseHomeLease(auth, "request_invalid")
 					return cliproxyexecutor.Response{}, errExec
 				}
 				authErr = errExec
 				continue
 			}
 			m.MarkResult(execCtx, result)
+			releaseHomeLease(auth, "completed")
 			rewriteForceMappedResponse(&resp, aliasResult)
 			return resp, nil
 		}
 		if authErr != nil {
 			if isRequestInvalidError(authErr) {
+				releaseHomeLease(auth, "request_invalid")
 				return cliproxyexecutor.Response{}, authErr
 			}
+			releaseHomeLease(auth, "attempt_failed")
 			lastErr = authErr
 			if homeMode {
 				homeAuthCount++
@@ -2806,19 +2845,24 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
+		execCtx = contextWithHomeLease(execCtx, auth)
 		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
 		if len(models) == 0 {
+			releaseHomeLease(auth, "no_execution_model")
 			continue
 		}
 		attempted[auth.ID] = struct{}{}
+		homeLease := homeLeaseFromAuth(auth)
 		var errPrepare error
 		auth, errPrepare = m.prepareRequestAuth(execCtx, executor, auth)
 		if errPrepare != nil {
 			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: resultErrorFromError(errPrepare)}
 			m.MarkResult(execCtx, result)
+			releaseHomeLease(auth, "prepare_failed")
 			lastErr = errPrepare
 			continue
 		}
+		preserveHomeLease(auth, homeLease)
 		execReq := sanitizeDownstreamWebsocketFallbackRequest(execCtx, auth, req)
 		streamExecutionModel := ""
 		if restoreExecutionModel {
@@ -2827,11 +2871,14 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		streamResult, errStream := m.executeStreamWithModelPool(execCtx, executor, auth, provider, execReq, opts, routeModel, streamExecutionModel, models, pooled, aliasResult)
 		if errStream != nil {
 			if errCtx := execCtx.Err(); errCtx != nil {
+				releaseHomeLease(auth, "request_canceled")
 				return nil, errCtx
 			}
 			if isRequestInvalidError(errStream) {
+				releaseHomeLease(auth, "request_invalid")
 				return nil, errStream
 			}
+			releaseHomeLease(auth, "attempt_failed")
 			lastErr = errStream
 			if homeMode {
 				homeAuthCount++
@@ -3015,6 +3062,16 @@ func (m *Manager) prepareRequestAuth(ctx context.Context, executor ProviderExecu
 		return saved, nil
 	}
 	return updated, nil
+}
+
+func ensureExecutionRequestID(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if strings.TrimSpace(logging.GetRequestID(ctx)) != "" {
+		return ctx
+	}
+	return logging.WithRequestID(ctx, uuid.NewString())
 }
 
 func contextWithRequestedModelAlias(ctx context.Context, opts cliproxyexecutor.Options, fallback string) context.Context {
@@ -3659,7 +3716,15 @@ func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []stri
 	if status != http.StatusTooManyRequests {
 		return 0, false
 	}
-	if !m.retryAllowed(attempt, providers) {
+	if m.HomeEnabled() && isHomeConcurrencyError(err) {
+		defaultRetry := int(m.requestRetry.Load())
+		if defaultRetry < 0 {
+			defaultRetry = 0
+		}
+		if attempt >= defaultRetry {
+			return 0, false
+		}
+	} else if !m.retryAllowed(attempt, providers) {
 		return 0, false
 	}
 	retryAfter := retryAfterFromError(err)
@@ -4900,8 +4965,12 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 }
 
 // SelectAuth selects one credential through the configured scheduling strategy.
-// It does not execute or alter the selected credential's result state.
+// In Home mode the returned auth can carry a reserved in-flight lease; callers
+// that do not pass it to Execute must release it with ReleaseHomeLease.
 func (m *Manager) SelectAuth(ctx context.Context, provider, model string, opts cliproxyexecutor.Options) (*Auth, error) {
+	if m.HomeEnabled() {
+		ctx = ensureExecutionRequestID(ctx)
+	}
 	selected, _, errPick := m.pickNext(ctx, provider, model, opts, nil)
 	if errPick != nil {
 		return nil, errPick
@@ -4918,6 +4987,9 @@ func (m *Manager) SelectAuthByKind(ctx context.Context, provider, model, require
 	}
 
 	homeMode := m.HomeEnabled()
+	if homeMode {
+		ctx = ensureExecutionRequestID(ctx)
+	}
 	homeAuthCount := homeAuthCountFromMetadata(opts.Metadata)
 	tried := make(map[string]struct{})
 	for {
@@ -4935,6 +5007,7 @@ func (m *Manager) SelectAuthByKind(ctx context.Context, provider, model, require
 		if selected.AuthKind() == requiredKind {
 			return selected, nil
 		}
+		releaseHomeLease(selected, "ineligible_auth_kind")
 		authID := strings.TrimSpace(selected.ID)
 		if authID == "" {
 			return nil, &Error{Code: "auth_not_found", Message: "selected auth has no ID"}
@@ -4947,6 +5020,12 @@ func (m *Manager) SelectAuthByKind(ctx context.Context, provider, model, require
 			homeAuthCount++
 		}
 	}
+}
+
+// ReleaseHomeLease releases an in-flight reservation attached to an auth
+// returned by a Home-mode selection API. It is a no-op for standalone auths.
+func (m *Manager) ReleaseHomeLease(auth *Auth, reason string) {
+	releaseHomeLease(auth, reason)
 }
 
 func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, error) {
@@ -5208,9 +5287,59 @@ type homeErrorEnvelope struct {
 }
 
 type homeErrorDetail struct {
-	Type    string `json:"type"`
-	Message string `json:"message"`
-	Code    string `json:"code,omitempty"`
+	Type         string `json:"type"`
+	Message      string `json:"message"`
+	Code         string `json:"code,omitempty"`
+	Retryable    bool   `json:"retryable,omitempty"`
+	RetryAfterMS int64  `json:"retry_after_ms,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+}
+
+type homeRemoteError struct {
+	cause      *Error
+	retryAfter *time.Duration
+}
+
+func isHomeConcurrencyError(err error) bool {
+	var authErr *Error
+	if !errors.As(err, &authErr) || authErr == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(authErr.Code)) {
+	case "credential_concurrency_exceeded", "credential_model_concurrency_exceeded":
+		return true
+	default:
+		return false
+	}
+}
+
+func (e *homeRemoteError) Error() string {
+	if e == nil || e.cause == nil {
+		return "home returned error"
+	}
+	return e.cause.Error()
+}
+
+func (e *homeRemoteError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func (e *homeRemoteError) StatusCode() int {
+	if e == nil || e.cause == nil {
+		return 0
+	}
+	return e.cause.StatusCode()
+}
+
+func (e *homeRemoteError) RetryAfter() *time.Duration {
+	if e == nil || e.retryAfter == nil {
+		return nil
+	}
+	value := *e.retryAfter
+	return &value
 }
 
 const (
@@ -5256,18 +5385,25 @@ func repeatedHomeAuthError() *Error {
 }
 
 type homeAuthDispatchResponse struct {
-	Model         string `json:"model"`
-	Provider      string `json:"provider"`
-	AuthIndex     string `json:"auth_index"`
-	UserAPIKey    string `json:"user_api_key"`
-	ForceMapping  bool   `json:"force_mapping"`
-	OriginalAlias string `json:"original_alias"`
-	Auth          Auth   `json:"auth"`
+	Model           string `json:"model"`
+	Provider        string `json:"provider"`
+	AuthIndex       string `json:"auth_index"`
+	UserAPIKey      string `json:"user_api_key"`
+	ForceMapping    bool   `json:"force_mapping"`
+	OriginalAlias   string `json:"original_alias"`
+	LeaseID         string `json:"lease_id"`
+	LeaseTTLSeconds int64  `json:"lease_ttl_seconds"`
+	LeaseExpiresAt  string `json:"lease_expires_at"`
+	Auth            Auth   `json:"auth"`
 }
 
 type homeAuthDispatcher interface {
 	HeartbeatOK() bool
 	RPopAuth(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int) ([]byte, error)
+}
+
+type homeAuthIdentityDispatcher interface {
+	RPopAuthWithIdentity(ctx context.Context, requestedModel string, requestID string, dispatchID string, sessionID string, headers http.Header, count int) ([]byte, error)
 }
 
 var currentHomeDispatcher = func() homeAuthDispatcher {
@@ -5462,16 +5598,6 @@ func (m *Manager) pickNextViaHome(ctx context.Context, model string, opts clipro
 	}
 	executionSessionID := homeExecutionSessionIDFromMetadata(opts.Metadata)
 	count := homeAuthCountFromMetadata(opts.Metadata)
-	if cliproxyexecutor.DownstreamWebsocket(ctx) && executionSessionID != "" && count <= 1 {
-		if pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata); pinnedAuthID != "" {
-			_, alreadyTried := tried[pinnedAuthID]
-			if !alreadyTried {
-				if auth, executor, providerKey, ok := m.homeRuntimeAuthByID(executionSessionID, pinnedAuthID); ok {
-					return auth, executor, providerKey, nil
-				}
-			}
-		}
-	}
 
 	client := currentHomeDispatcher()
 	if client == nil || !client.HeartbeatOK() {
@@ -5481,8 +5607,23 @@ func (m *Manager) pickNextViaHome(ctx context.Context, model string, opts clipro
 	requestedModel := requestedModelFromMetadata(opts.Metadata, model)
 	sessionID := ExtractSessionID(opts.Headers, opts.OriginalRequest, opts.Metadata)
 	dispatchHeaders := homeDispatchHeaders(ctx, opts.Headers)
+	requestID := logging.GetRequestID(ctx)
+	dispatchID := uuid.NewString()
 
-	raw, err := client.RPopAuth(ctx, requestedModel, sessionID, dispatchHeaders, count)
+	identityClient, supportsIdentity := client.(homeAuthIdentityDispatcher)
+	dispatchAuth := func() ([]byte, error) {
+		if supportsIdentity {
+			return identityClient.RPopAuthWithIdentity(ctx, requestedModel, requestID, dispatchID, sessionID, dispatchHeaders, count)
+		}
+		return client.RPopAuth(ctx, requestedModel, sessionID, dispatchHeaders, count)
+	}
+	raw, err := dispatchAuth()
+	if err != nil && supportsIdentity && !errors.Is(err, home.ErrAuthNotFound) && ctx.Err() == nil {
+		// The first RPOP may have reserved a lease even when its response was
+		// lost. Retry once with the same dispatch ID so Home can return that
+		// idempotent reservation instead of leaving a ghost slot until TTL.
+		raw, err = dispatchAuth()
+	}
 	if err != nil {
 		if errors.Is(err, home.ErrAuthNotFound) {
 			return nil, nil, "", &Error{Code: "auth_not_found", Message: err.Error(), HTTPStatus: http.StatusServiceUnavailable}
@@ -5506,19 +5647,39 @@ func (m *Manager) pickNextViaHome(ctx context.Context, model string, opts clipro
 			status = http.StatusNotFound
 		case "authentication_error", "unauthorized", "no_credentials", "invalid_credential":
 			status = http.StatusUnauthorized
+		case "credential_concurrency_exceeded", "credential_model_concurrency_exceeded":
+			status = http.StatusTooManyRequests
+		case "dispatch_replayed":
+			status = http.StatusConflict
+		case "concurrency_identity_required", "concurrency_tracker_unavailable":
+			status = http.StatusServiceUnavailable
 		}
-		return nil, nil, "", &Error{Code: code, Message: msg, HTTPStatus: status}
+		cause := &Error{Code: code, Message: msg, Retryable: env.Error.Retryable, HTTPStatus: status}
+		if env.Error.RetryAfterMS > 0 {
+			retryAfter := time.Duration(env.Error.RetryAfterMS) * time.Millisecond
+			return nil, nil, "", &homeRemoteError{cause: cause, retryAfter: &retryAfter}
+		}
+		return nil, nil, "", cause
 	}
 
 	var dispatch homeAuthDispatchResponse
 	if errUnmarshal := json.Unmarshal(raw, &dispatch); errUnmarshal != nil {
 		return nil, nil, "", &Error{Code: "invalid_auth", Message: "home returned invalid auth payload", HTTPStatus: http.StatusBadGateway}
 	}
+	leaseClient, _ := client.(homeInFlightLeaseDispatcher)
+	leaseTTL := time.Duration(dispatch.LeaseTTLSeconds) * time.Second
+	lease := newHomeLeaseHandle(leaseClient, dispatch.LeaseID, leaseTTL)
+	releaseLease := func(reason string) {
+		if lease != nil {
+			lease.release(reason)
+		}
+	}
 	setHomeUserAPIKeyOnGinContext(ctx, dispatch.UserAPIKey)
 	auth := dispatch.Auth
 	if strings.TrimSpace(auth.ID) == "" {
 		// Backward compatibility: older home instances returned the auth directly.
 		if errUnmarshal := json.Unmarshal(raw, &auth); errUnmarshal != nil {
+			releaseLease("invalid_auth")
 			return nil, nil, "", &Error{Code: "invalid_auth", Message: "home returned invalid auth payload", HTTPStatus: http.StatusBadGateway}
 		}
 	}
@@ -5536,13 +5697,16 @@ func (m *Manager) pickNextViaHome(ctx context.Context, model string, opts clipro
 		auth.Attributes[homeOriginalAliasAttributeKey] = originalAlias
 	}
 	if strings.TrimSpace(auth.ID) == "" {
+		releaseLease("invalid_auth")
 		return nil, nil, "", &Error{Code: "invalid_auth", Message: "home returned auth without id", HTTPStatus: http.StatusBadGateway}
 	}
 	if homeAuthAlreadyTried(tried, auth.ID) {
+		releaseLease("repeated_auth")
 		return nil, nil, "", repeatedHomeAuthError()
 	}
 	providerKey := executorKeyFromAuth(&auth)
 	if providerKey == "" {
+		releaseLease("invalid_provider")
 		return nil, nil, "", &Error{Code: "invalid_auth", Message: "home returned auth without provider", HTTPStatus: http.StatusBadGateway}
 	}
 
@@ -5562,10 +5726,12 @@ func (m *Manager) pickNextViaHome(ctx context.Context, model string, opts clipro
 		}
 	}
 	if !ok {
+		releaseLease("executor_not_found")
 		return nil, nil, "", &Error{Code: "executor_not_found", Message: "executor not registered", HTTPStatus: http.StatusBadGateway}
 	}
 
 	authCopy := auth.Clone()
+	setHomeLease(authCopy, lease)
 	if cliproxyexecutor.DownstreamWebsocket(ctx) && executionSessionID != "" && authWebsocketsEnabled(authCopy) {
 		m.rememberHomeRuntimeAuth(executionSessionID, authCopy)
 	}

--- a/sdk/cliproxy/auth/home_lease.go
+++ b/sdk/cliproxy/auth/home_lease.go
@@ -1,0 +1,152 @@
+package auth
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	cliproxyusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	log "github.com/sirupsen/logrus"
+)
+
+var homeLeaseReleaseRetryDelays = [...]time.Duration{250 * time.Millisecond, time.Second, 2 * time.Second}
+
+type homeInFlightLeaseDispatcher interface {
+	RenewInFlightLease(ctx context.Context, leaseID string) (bool, error)
+	ReleaseInFlightLease(ctx context.Context, leaseID string, reason string) (bool, error)
+}
+
+type homeLeaseHandle struct {
+	leaseID    string
+	ttl        time.Duration
+	renewEvery time.Duration
+	client     homeInFlightLeaseDispatcher
+	stop       chan struct{}
+
+	startOnce   sync.Once
+	releaseOnce sync.Once
+}
+
+func homeLeaseRenewInterval(ttl time.Duration) time.Duration {
+	interval := ttl / 3
+	if interval < 10*time.Second {
+		return 10 * time.Second
+	}
+	if interval > 5*time.Minute {
+		return 5 * time.Minute
+	}
+	return interval
+}
+
+func newHomeLeaseHandle(client homeInFlightLeaseDispatcher, leaseID string, ttl time.Duration) *homeLeaseHandle {
+	leaseID = strings.TrimSpace(leaseID)
+	if client == nil || leaseID == "" {
+		return nil
+	}
+	return &homeLeaseHandle{
+		leaseID:    leaseID,
+		ttl:        ttl,
+		renewEvery: homeLeaseRenewInterval(ttl),
+		client:     client,
+		stop:       make(chan struct{}),
+	}
+}
+
+func (h *homeLeaseHandle) start() {
+	if h == nil || h.client == nil || h.ttl <= 0 {
+		return
+	}
+	h.startOnce.Do(func() {
+		interval := h.renewEvery
+		if interval <= 0 {
+			return
+		}
+		go func() {
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-h.stop:
+					return
+				case <-ticker.C:
+					renewed, errRenew := h.client.RenewInFlightLease(context.Background(), h.leaseID)
+					if errRenew != nil {
+						log.WithError(errRenew).WithField("lease_id", h.leaseID).Warn("failed to renew Home in-flight lease")
+						continue
+					}
+					if !renewed {
+						return
+					}
+				}
+			}
+		}()
+	})
+}
+
+func (h *homeLeaseHandle) release(reason string) {
+	if h == nil || h.client == nil {
+		return
+	}
+	h.releaseOnce.Do(func() {
+		close(h.stop)
+		reason = strings.TrimSpace(reason)
+		if _, errRelease := h.client.ReleaseInFlightLease(context.Background(), h.leaseID, reason); errRelease != nil {
+			log.WithError(errRelease).WithField("lease_id", h.leaseID).Warn("failed to release Home in-flight lease; retrying")
+			go h.retryRelease(reason)
+		}
+	})
+}
+
+func (h *homeLeaseHandle) retryRelease(reason string) {
+	if h == nil || h.client == nil {
+		return
+	}
+	var lastErr error
+	for _, delay := range homeLeaseReleaseRetryDelays {
+		timer := time.NewTimer(delay)
+		<-timer.C
+		if _, errRelease := h.client.ReleaseInFlightLease(context.Background(), h.leaseID, reason); errRelease == nil {
+			return
+		} else {
+			lastErr = errRelease
+		}
+	}
+	log.WithError(lastErr).WithField("lease_id", h.leaseID).Warn("failed to release Home in-flight lease after retries")
+}
+
+func setHomeLease(auth *Auth, lease *homeLeaseHandle) {
+	if auth == nil || lease == nil {
+		return
+	}
+	auth.homeLease = lease
+	lease.start()
+}
+
+func preserveHomeLease(auth *Auth, lease *homeLeaseHandle) {
+	if auth == nil || lease == nil || homeLeaseFromAuth(auth) != nil {
+		return
+	}
+	setHomeLease(auth, lease)
+}
+
+func homeLeaseFromAuth(auth *Auth) *homeLeaseHandle {
+	if auth == nil {
+		return nil
+	}
+	return auth.homeLease
+}
+
+func contextWithHomeLease(ctx context.Context, auth *Auth) context.Context {
+	lease := homeLeaseFromAuth(auth)
+	if lease == nil {
+		return ctx
+	}
+	return cliproxyusage.WithHomeLeaseID(ctx, lease.leaseID)
+}
+
+func releaseHomeLease(auth *Auth, reason string) {
+	if lease := homeLeaseFromAuth(auth); lease != nil {
+		lease.release(reason)
+	}
+}

--- a/sdk/cliproxy/auth/home_lease_test.go
+++ b/sdk/cliproxy/auth/home_lease_test.go
@@ -1,0 +1,585 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	cliproxyusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+type leaseExecutionIdentity struct {
+	requestID string
+	leaseID   string
+	authIndex string
+	model     string
+	websocket bool
+}
+
+type leaseIdentityExecutor struct {
+	schedulerTestExecutor
+	captured chan leaseExecutionIdentity
+}
+
+func (e *leaseIdentityExecutor) capture(ctx context.Context, auth *Auth, req cliproxyexecutor.Request) {
+	if e == nil || e.captured == nil {
+		return
+	}
+	identity := leaseExecutionIdentity{
+		requestID: logging.GetRequestID(ctx),
+		leaseID:   cliproxyusage.HomeLeaseIDFromContext(ctx),
+		model:     req.Model,
+		websocket: cliproxyexecutor.DownstreamWebsocket(ctx),
+	}
+	if auth != nil {
+		identity.authIndex = auth.Index
+	}
+	e.captured <- identity
+}
+
+func (e *leaseIdentityExecutor) Execute(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.capture(ctx, auth, req)
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *leaseIdentityExecutor) CountTokens(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.capture(ctx, auth, req)
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *leaseIdentityExecutor) ExecuteStream(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.capture(ctx, auth, req)
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(`{"type":"response.completed"}`)}
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+type leaseTestDispatcher struct {
+	mu             sync.Mutex
+	requestIDs     []string
+	dispatchIDs    []string
+	renewedIDs     []string
+	releasedIDs    []string
+	releaseReason  []string
+	renewed        chan struct{}
+	released       chan struct{}
+	releaseErrors  int
+	dispatchErrors int
+	dispatchError  error
+	busy           bool
+	busyResponses  int
+	busyCode       string
+}
+
+func (d *leaseTestDispatcher) HeartbeatOK() bool { return true }
+
+func (d *leaseTestDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+	return nil, nil
+}
+
+func (d *leaseTestDispatcher) RPopAuthWithIdentity(_ context.Context, requestedModel string, requestID string, dispatchID string, _ string, _ http.Header, _ int) ([]byte, error) {
+	d.mu.Lock()
+	d.requestIDs = append(d.requestIDs, requestID)
+	d.dispatchIDs = append(d.dispatchIDs, dispatchID)
+	busy := d.busy
+	if d.busyResponses > 0 {
+		d.busyResponses--
+		busy = true
+	}
+	busyCode := d.busyCode
+	dispatchError := d.dispatchError
+	if d.dispatchErrors > 0 {
+		d.dispatchErrors--
+		d.mu.Unlock()
+		if dispatchError == nil {
+			dispatchError = context.DeadlineExceeded
+		}
+		return nil, dispatchError
+	}
+	d.mu.Unlock()
+	if busy {
+		if busyCode == "" {
+			busyCode = "credential_concurrency_exceeded"
+		}
+		return []byte(`{"error":{"type":"` + busyCode + `","message":"busy","retryable":true,"retry_after_ms":250,"scope":"credential"}}`), nil
+	}
+	return json.Marshal(homeAuthDispatchResponse{
+		Model:           requestedModel,
+		Provider:        "test",
+		AuthIndex:       "home-auth-1",
+		LeaseID:         dispatchID,
+		LeaseTTLSeconds: 60,
+		Auth: Auth{
+			ID:       "home-auth-1",
+			Provider: "test",
+			Status:   StatusActive,
+		},
+	})
+}
+
+func (d *leaseTestDispatcher) RenewInFlightLease(_ context.Context, leaseID string) (bool, error) {
+	d.mu.Lock()
+	d.renewedIDs = append(d.renewedIDs, leaseID)
+	renewed := d.renewed
+	d.mu.Unlock()
+	if renewed != nil {
+		select {
+		case renewed <- struct{}{}:
+		default:
+		}
+	}
+	return true, nil
+}
+
+func (d *leaseTestDispatcher) ReleaseInFlightLease(_ context.Context, leaseID string, reason string) (bool, error) {
+	d.mu.Lock()
+	d.releasedIDs = append(d.releasedIDs, leaseID)
+	d.releaseReason = append(d.releaseReason, reason)
+	if d.released != nil {
+		select {
+		case d.released <- struct{}{}:
+		default:
+		}
+	}
+	if d.releaseErrors > 0 {
+		d.releaseErrors--
+		d.mu.Unlock()
+		return false, context.DeadlineExceeded
+	}
+	d.mu.Unlock()
+	return true, nil
+}
+
+func TestHomeDispatchIdentityAndLeaseRelease(t *testing.T) {
+	dispatcher := &leaseTestDispatcher{}
+	oldCurrentHomeDispatcher := currentHomeDispatcher
+	currentHomeDispatcher = func() homeAuthDispatcher { return dispatcher }
+	t.Cleanup(func() { currentHomeDispatcher = oldCurrentHomeDispatcher })
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	captured := make(chan leaseExecutionIdentity, 1)
+	manager.RegisterExecutor(&leaseIdentityExecutor{captured: captured})
+	ctx := logging.WithRequestID(context.Background(), "request-lease-1")
+	if _, errExecute := manager.Execute(ctx, []string{"test"}, cliproxyexecutor.Request{Model: "model-a"}, cliproxyexecutor.Options{}); errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+	identity := <-captured
+
+	dispatcher.mu.Lock()
+	defer dispatcher.mu.Unlock()
+	if len(dispatcher.requestIDs) != 1 || dispatcher.requestIDs[0] != "request-lease-1" {
+		t.Fatalf("request IDs = %v", dispatcher.requestIDs)
+	}
+	if len(dispatcher.dispatchIDs) != 1 || dispatcher.dispatchIDs[0] == "" {
+		t.Fatalf("dispatch IDs = %v", dispatcher.dispatchIDs)
+	}
+	if len(dispatcher.releasedIDs) != 1 || dispatcher.releasedIDs[0] != dispatcher.dispatchIDs[0] {
+		t.Fatalf("released IDs = %v, dispatch IDs = %v", dispatcher.releasedIDs, dispatcher.dispatchIDs)
+	}
+	if len(dispatcher.releaseReason) != 1 || dispatcher.releaseReason[0] != "completed" {
+		t.Fatalf("release reasons = %v", dispatcher.releaseReason)
+	}
+	if identity.requestID != "request-lease-1" || identity.leaseID != dispatcher.dispatchIDs[0] || identity.authIndex != "home-auth-1" || identity.model != "model-a" {
+		t.Fatalf("execution identity = %+v", identity)
+	}
+}
+
+func TestHomeDispatchGeneratesRequestID(t *testing.T) {
+	dispatcher := &leaseTestDispatcher{}
+	oldCurrentHomeDispatcher := currentHomeDispatcher
+	currentHomeDispatcher = func() homeAuthDispatcher { return dispatcher }
+	t.Cleanup(func() { currentHomeDispatcher = oldCurrentHomeDispatcher })
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.RegisterExecutor(schedulerTestExecutor{})
+	if _, errExecute := manager.Execute(context.Background(), []string{"test"}, cliproxyexecutor.Request{Model: "model-a"}, cliproxyexecutor.Options{}); errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+
+	dispatcher.mu.Lock()
+	defer dispatcher.mu.Unlock()
+	if len(dispatcher.requestIDs) != 1 || dispatcher.requestIDs[0] == "" {
+		t.Fatalf("request IDs = %v, want generated request ID", dispatcher.requestIDs)
+	}
+}
+
+func TestHomeDispatchTransportRetryReusesDispatchIdentity(t *testing.T) {
+	dispatcher := &leaseTestDispatcher{dispatchErrors: 1, dispatchError: context.DeadlineExceeded}
+	oldCurrentHomeDispatcher := currentHomeDispatcher
+	currentHomeDispatcher = func() homeAuthDispatcher { return dispatcher }
+	t.Cleanup(func() { currentHomeDispatcher = oldCurrentHomeDispatcher })
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.RegisterExecutor(schedulerTestExecutor{})
+	ctx := logging.WithRequestID(context.Background(), "request-transport-retry")
+	if _, errExecute := manager.Execute(ctx, []string{"test"}, cliproxyexecutor.Request{Model: "model-a"}, cliproxyexecutor.Options{}); errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+
+	dispatcher.mu.Lock()
+	defer dispatcher.mu.Unlock()
+	if len(dispatcher.requestIDs) != 2 || dispatcher.requestIDs[0] != dispatcher.requestIDs[1] || dispatcher.requestIDs[0] != "request-transport-retry" {
+		t.Fatalf("request IDs = %v, want one stable request identity", dispatcher.requestIDs)
+	}
+	if len(dispatcher.dispatchIDs) != 2 || dispatcher.dispatchIDs[0] == "" || dispatcher.dispatchIDs[0] != dispatcher.dispatchIDs[1] {
+		t.Fatalf("dispatch IDs = %v, want the same ID for transport recovery", dispatcher.dispatchIDs)
+	}
+	if len(dispatcher.releasedIDs) != 1 || dispatcher.releasedIDs[0] != dispatcher.dispatchIDs[0] {
+		t.Fatalf("released IDs = %v, dispatch IDs = %v", dispatcher.releasedIDs, dispatcher.dispatchIDs)
+	}
+}
+
+func TestHomeLeaseRenewsUntilRelease(t *testing.T) {
+	dispatcher := &leaseTestDispatcher{renewed: make(chan struct{}, 1)}
+	lease := newHomeLeaseHandle(dispatcher, "lease-renew", time.Minute)
+	if lease == nil {
+		t.Fatal("newHomeLeaseHandle() = nil")
+	}
+	lease.renewEvery = 5 * time.Millisecond
+	lease.start()
+
+	select {
+	case <-dispatcher.renewed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for lease renewal")
+	}
+	lease.release("completed")
+
+	dispatcher.mu.Lock()
+	defer dispatcher.mu.Unlock()
+	if len(dispatcher.renewedIDs) == 0 || dispatcher.renewedIDs[0] != "lease-renew" {
+		t.Fatalf("renewed IDs = %v", dispatcher.renewedIDs)
+	}
+	if len(dispatcher.releasedIDs) != 1 || dispatcher.releasedIDs[0] != "lease-renew" {
+		t.Fatalf("released IDs = %v", dispatcher.releasedIDs)
+	}
+}
+
+func TestHomeLeaseRetriesFailedRelease(t *testing.T) {
+	dispatcher := &leaseTestDispatcher{released: make(chan struct{}, 2), releaseErrors: 1}
+	lease := newHomeLeaseHandle(dispatcher, "lease-release-retry", time.Minute)
+	if lease == nil {
+		t.Fatal("newHomeLeaseHandle() = nil")
+	}
+	lease.release("completed")
+
+	for attempt := 0; attempt < 2; attempt++ {
+		select {
+		case <-dispatcher.released:
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for release attempt %d", attempt+1)
+		}
+	}
+	dispatcher.mu.Lock()
+	defer dispatcher.mu.Unlock()
+	if len(dispatcher.releasedIDs) != 2 {
+		t.Fatalf("release attempts = %d, want 2", len(dispatcher.releasedIDs))
+	}
+}
+
+type leaseInvalidExecutor struct{ leaseIdentityExecutor }
+
+func (e *leaseInvalidExecutor) Execute(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.capture(ctx, auth, req)
+	return cliproxyexecutor.Response{}, &Error{Code: "invalid_request", Message: "invalid_request_error: invalid request", HTTPStatus: http.StatusBadRequest}
+}
+
+func TestHomeLeaseDoesNotReplaceAuthRuntime(t *testing.T) {
+	dispatcher := &leaseTestDispatcher{}
+	runtimeState := &struct{ name string }{name: "provider-runtime"}
+	auth := &Auth{Runtime: runtimeState}
+	lease := newHomeLeaseHandle(dispatcher, "lease-runtime", time.Minute)
+	setHomeLease(auth, lease)
+	t.Cleanup(func() { releaseHomeLease(auth, "test_cleanup") })
+
+	if auth.Runtime != runtimeState {
+		t.Fatalf("auth runtime = %#v, want original provider runtime", auth.Runtime)
+	}
+	if got := homeLeaseFromAuth(auth); got != lease {
+		t.Fatalf("home lease = %#v, want %#v", got, lease)
+	}
+	if clone := auth.Clone(); clone.Runtime != runtimeState || homeLeaseFromAuth(clone) != lease {
+		t.Fatalf("cloned auth lost runtime or lease: runtime=%#v lease=%#v", clone.Runtime, homeLeaseFromAuth(clone))
+	}
+}
+
+func TestHomeCountReleasesLeaseAfterCompletion(t *testing.T) {
+	dispatcher := &leaseTestDispatcher{}
+	oldCurrentHomeDispatcher := currentHomeDispatcher
+	currentHomeDispatcher = func() homeAuthDispatcher { return dispatcher }
+	t.Cleanup(func() { currentHomeDispatcher = oldCurrentHomeDispatcher })
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	captured := make(chan leaseExecutionIdentity, 1)
+	manager.RegisterExecutor(&leaseIdentityExecutor{captured: captured})
+	if _, errExecute := manager.ExecuteCount(context.Background(), []string{"test"}, cliproxyexecutor.Request{Model: "model-a"}, cliproxyexecutor.Options{}); errExecute != nil {
+		t.Fatalf("ExecuteCount() error = %v", errExecute)
+	}
+	identity := <-captured
+
+	dispatcher.mu.Lock()
+	defer dispatcher.mu.Unlock()
+	if len(dispatcher.releasedIDs) != 1 || len(dispatcher.releaseReason) != 1 || dispatcher.releaseReason[0] != "completed" {
+		t.Fatalf("released IDs = %v, reasons = %v", dispatcher.releasedIDs, dispatcher.releaseReason)
+	}
+	if identity.requestID == "" || identity.leaseID != dispatcher.releasedIDs[0] || identity.authIndex != "home-auth-1" || identity.model != "model-a" {
+		t.Fatalf("count identity = %+v", identity)
+	}
+}
+
+type leaseCountEndpointMissingExecutor struct{ leaseIdentityExecutor }
+
+func (e *leaseCountEndpointMissingExecutor) CountTokens(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.capture(ctx, auth, req)
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusNotFound, Message: "404 page not found"}
+}
+
+func TestHomeCountEndpointErrorReleasesEveryReservedLease(t *testing.T) {
+	dispatcher := &leaseTestDispatcher{}
+	oldCurrentHomeDispatcher := currentHomeDispatcher
+	currentHomeDispatcher = func() homeAuthDispatcher { return dispatcher }
+	t.Cleanup(func() { currentHomeDispatcher = oldCurrentHomeDispatcher })
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.RegisterExecutor(&leaseCountEndpointMissingExecutor{})
+	_, errExecute := manager.ExecuteCount(context.Background(), []string{"test"}, cliproxyexecutor.Request{Model: "model-a"}, cliproxyexecutor.Options{})
+	if errExecute == nil || statusCodeFromError(errExecute) != http.StatusNotFound {
+		t.Fatalf("ExecuteCount() error = %v, want endpoint 404", errExecute)
+	}
+
+	dispatcher.mu.Lock()
+	defer dispatcher.mu.Unlock()
+	if len(dispatcher.dispatchIDs) != 2 || len(dispatcher.releasedIDs) != 2 {
+		t.Fatalf("dispatches=%v releases=%v, want every reservation released", dispatcher.dispatchIDs, dispatcher.releasedIDs)
+	}
+	for index, dispatchID := range dispatcher.dispatchIDs {
+		if dispatcher.releasedIDs[index] != dispatchID {
+			t.Fatalf("release[%d]=%q, want dispatch %q", index, dispatcher.releasedIDs[index], dispatchID)
+		}
+	}
+}
+
+func TestHomeInvalidRequestReleasesLease(t *testing.T) {
+	dispatcher := &leaseTestDispatcher{}
+	oldCurrentHomeDispatcher := currentHomeDispatcher
+	currentHomeDispatcher = func() homeAuthDispatcher { return dispatcher }
+	t.Cleanup(func() { currentHomeDispatcher = oldCurrentHomeDispatcher })
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	captured := make(chan leaseExecutionIdentity, 1)
+	manager.RegisterExecutor(&leaseInvalidExecutor{leaseIdentityExecutor: leaseIdentityExecutor{captured: captured}})
+	_, errExecute := manager.Execute(context.Background(), []string{"test"}, cliproxyexecutor.Request{Model: "model-a"}, cliproxyexecutor.Options{})
+	if errExecute == nil || statusCodeFromError(errExecute) != http.StatusBadRequest {
+		t.Fatalf("Execute() error = %v, want 400", errExecute)
+	}
+	identity := <-captured
+
+	dispatcher.mu.Lock()
+	defer dispatcher.mu.Unlock()
+	if len(dispatcher.releasedIDs) != 1 || len(dispatcher.releaseReason) != 1 || dispatcher.releaseReason[0] != "request_invalid" {
+		t.Fatalf("released IDs = %v, reasons = %v", dispatcher.releasedIDs, dispatcher.releaseReason)
+	}
+	if identity.requestID == "" || identity.leaseID != dispatcher.releasedIDs[0] || identity.authIndex != "home-auth-1" || identity.model != "model-a" {
+		t.Fatalf("failure identity = %+v", identity)
+	}
+}
+
+type leaseCanceledStreamExecutor struct{ leaseIdentityExecutor }
+
+func (e *leaseCanceledStreamExecutor) ExecuteStream(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.capture(ctx, auth, req)
+	chunks := make(chan cliproxyexecutor.StreamChunk)
+	go func() {
+		defer close(chunks)
+		chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(`{"type":"response.output_text.delta","delta":"hello"}`)}
+		<-ctx.Done()
+	}()
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func TestHomeWebsocketStreamCarriesIdentityAndReleasesLease(t *testing.T) {
+	dispatcher := &leaseTestDispatcher{}
+	oldCurrentHomeDispatcher := currentHomeDispatcher
+	currentHomeDispatcher = func() homeAuthDispatcher { return dispatcher }
+	t.Cleanup(func() { currentHomeDispatcher = oldCurrentHomeDispatcher })
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	captured := make(chan leaseExecutionIdentity, 1)
+	manager.RegisterExecutor(&leaseIdentityExecutor{captured: captured})
+	ctx := logging.WithRequestID(cliproxyexecutor.WithDownstreamWebsocket(context.Background()), "request-websocket")
+	result, errExecute := manager.ExecuteStream(ctx, []string{"test"}, cliproxyexecutor.Request{Model: "model-a"}, cliproxyexecutor.Options{})
+	if errExecute != nil || result == nil {
+		t.Fatalf("ExecuteStream() = %#v, %v", result, errExecute)
+	}
+	for range result.Chunks {
+	}
+	identity := <-captured
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		dispatcher.mu.Lock()
+		released := len(dispatcher.releasedIDs)
+		reason := ""
+		if len(dispatcher.releaseReason) > 0 {
+			reason = dispatcher.releaseReason[0]
+		}
+		dispatcher.mu.Unlock()
+		if released == 1 {
+			if reason != "stream_terminal" {
+				t.Fatalf("release reason = %q, want stream_terminal", reason)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for stream lease release")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if identity.requestID != "request-websocket" || identity.leaseID == "" || identity.authIndex != "home-auth-1" || identity.model != "model-a" || !identity.websocket {
+		t.Fatalf("websocket identity = %+v", identity)
+	}
+}
+
+func TestHomeStreamCancellationReleasesLease(t *testing.T) {
+	dispatcher := &leaseTestDispatcher{}
+	oldCurrentHomeDispatcher := currentHomeDispatcher
+	currentHomeDispatcher = func() homeAuthDispatcher { return dispatcher }
+	t.Cleanup(func() { currentHomeDispatcher = oldCurrentHomeDispatcher })
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	captured := make(chan leaseExecutionIdentity, 1)
+	manager.RegisterExecutor(&leaseCanceledStreamExecutor{leaseIdentityExecutor: leaseIdentityExecutor{captured: captured}})
+	ctx, cancel := context.WithCancel(logging.WithRequestID(context.Background(), "request-stream-cancel"))
+	result, errExecute := manager.ExecuteStream(ctx, []string{"test"}, cliproxyexecutor.Request{Model: "model-a"}, cliproxyexecutor.Options{})
+	if errExecute != nil || result == nil {
+		t.Fatalf("ExecuteStream() = %#v, %v", result, errExecute)
+	}
+	if _, ok := <-result.Chunks; !ok {
+		t.Fatal("stream closed before the first chunk")
+	}
+	cancel()
+	for range result.Chunks {
+	}
+	identity := <-captured
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		dispatcher.mu.Lock()
+		released := len(dispatcher.releasedIDs)
+		reason := ""
+		if len(dispatcher.releaseReason) > 0 {
+			reason = dispatcher.releaseReason[0]
+		}
+		dispatcher.mu.Unlock()
+		if released == 1 {
+			if reason != "request_canceled" {
+				t.Fatalf("release reason = %q, want request_canceled", reason)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for canceled stream lease release")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if identity.requestID != "request-stream-cancel" || identity.leaseID == "" || identity.authIndex != "home-auth-1" || identity.model != "model-a" {
+		t.Fatalf("canceled stream identity = %+v", identity)
+	}
+}
+
+func TestHomeConcurrencyErrorMapsToRetryable429(t *testing.T) {
+	for _, errorCode := range []string{"credential_concurrency_exceeded", "credential_model_concurrency_exceeded"} {
+		t.Run(errorCode, func(t *testing.T) {
+			dispatcher := &leaseTestDispatcher{busy: true, busyCode: errorCode}
+			oldCurrentHomeDispatcher := currentHomeDispatcher
+			currentHomeDispatcher = func() homeAuthDispatcher { return dispatcher }
+			t.Cleanup(func() { currentHomeDispatcher = oldCurrentHomeDispatcher })
+
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			_, _, _, errPick := manager.pickNextViaHome(logging.WithRequestID(context.Background(), "request-busy"), "model-a", cliproxyexecutor.Options{}, nil)
+			if errPick == nil || statusCodeFromError(errPick) != http.StatusTooManyRequests {
+				t.Fatalf("pickNextViaHome() error = %v, status = %d", errPick, statusCodeFromError(errPick))
+			}
+			retryAfter := retryAfterFromError(errPick)
+			if retryAfter == nil || *retryAfter != 250*time.Millisecond {
+				t.Fatalf("retry after = %v, want 250ms", retryAfter)
+			}
+		})
+	}
+}
+
+func TestHomeConcurrencyBusyRetriesWithStableRequestIdentity(t *testing.T) {
+	dispatcher := &leaseTestDispatcher{busyResponses: 1}
+	oldCurrentHomeDispatcher := currentHomeDispatcher
+	currentHomeDispatcher = func() homeAuthDispatcher { return dispatcher }
+	t.Cleanup(func() { currentHomeDispatcher = oldCurrentHomeDispatcher })
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(1, time.Second, 0)
+	manager.RegisterExecutor(schedulerTestExecutor{})
+	ctx := logging.WithRequestID(context.Background(), "request-busy-retry")
+	if _, errExecute := manager.Execute(ctx, []string{"test"}, cliproxyexecutor.Request{Model: "model-a"}, cliproxyexecutor.Options{}); errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+
+	dispatcher.mu.Lock()
+	defer dispatcher.mu.Unlock()
+	if len(dispatcher.requestIDs) != 2 || dispatcher.requestIDs[0] != "request-busy-retry" || dispatcher.requestIDs[1] != "request-busy-retry" {
+		t.Fatalf("request IDs = %v, want stable request-busy-retry", dispatcher.requestIDs)
+	}
+	if len(dispatcher.dispatchIDs) != 2 || dispatcher.dispatchIDs[0] == "" || dispatcher.dispatchIDs[1] == "" || dispatcher.dispatchIDs[0] == dispatcher.dispatchIDs[1] {
+		t.Fatalf("dispatch IDs = %v, want two unique IDs", dispatcher.dispatchIDs)
+	}
+	if len(dispatcher.releasedIDs) != 1 || dispatcher.releasedIDs[0] != dispatcher.dispatchIDs[1] {
+		t.Fatalf("released IDs = %v, dispatch IDs = %v", dispatcher.releasedIDs, dispatcher.dispatchIDs)
+	}
+}
+
+type leaseRateLimitedExecutor struct{ schedulerTestExecutor }
+
+func (e *leaseRateLimitedExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &retryAfterStatusError{
+		status:     http.StatusTooManyRequests,
+		message:    "upstream rate limited",
+		retryAfter: 250 * time.Millisecond,
+	}
+}
+
+func TestHomeUpstreamRateLimitDoesNotGainOuterConcurrencyRetry(t *testing.T) {
+	dispatcher := &leaseTestDispatcher{}
+	oldCurrentHomeDispatcher := currentHomeDispatcher
+	currentHomeDispatcher = func() homeAuthDispatcher { return dispatcher }
+	t.Cleanup(func() { currentHomeDispatcher = oldCurrentHomeDispatcher })
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(1, time.Second, 0)
+	manager.RegisterExecutor(&leaseRateLimitedExecutor{})
+	_, errExecute := manager.Execute(context.Background(), []string{"test"}, cliproxyexecutor.Request{Model: "model-a"}, cliproxyexecutor.Options{})
+	if errExecute == nil || statusCodeFromError(errExecute) != http.StatusTooManyRequests {
+		t.Fatalf("Execute() error = %v, want upstream 429", errExecute)
+	}
+
+	dispatcher.mu.Lock()
+	defer dispatcher.mu.Unlock()
+	if len(dispatcher.dispatchIDs) != 2 {
+		t.Fatalf("Home dispatches = %d, want one credential attempt plus repeated-auth stop", len(dispatcher.dispatchIDs))
+	}
+}

--- a/sdk/cliproxy/auth/home_websocket_reuse_test.go
+++ b/sdk/cliproxy/auth/home_websocket_reuse_test.go
@@ -10,7 +10,7 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
-func TestPickNextViaHomeReusesPinnedWebsocketAuthWithoutHomeDispatch(t *testing.T) {
+func TestPickNextViaHomeDoesNotBypassHomeForPinnedWebsocketAuth(t *testing.T) {
 	manager := NewManager(nil, nil, nil)
 	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
 	manager.RegisterExecutor(schedulerTestExecutor{})
@@ -42,21 +42,16 @@ func TestPickNextViaHomeReusesPinnedWebsocketAuthWithoutHomeDispatch(t *testing.
 	}
 
 	got, executor, provider, errPick := manager.pickNextViaHome(ctx, "gpt-5.4", opts, nil)
-	if errPick != nil {
-		t.Fatalf("pickNextViaHome() error = %v", errPick)
+	var authErr *Error
+	if !errors.As(errPick, &authErr) || authErr.Code != "home_unavailable" {
+		t.Fatalf("pickNextViaHome() error = %v, want home_unavailable", errPick)
 	}
-	if got == nil || got.ID != "home-auth-1" {
-		t.Fatalf("pickNextViaHome() auth = %#v, want home-auth-1", got)
-	}
-	if executor == nil {
-		t.Fatal("pickNextViaHome() executor is nil")
-	}
-	if provider != "test" {
-		t.Fatalf("pickNextViaHome() provider = %q, want test", provider)
+	if got != nil || executor != nil || provider != "" {
+		t.Fatalf("pickNextViaHome() bypassed Home: auth=%#v executor=%#v provider=%q", got, executor, provider)
 	}
 }
 
-func TestPickNextViaHomeKeepsSameAuthIDPayloadSessionScoped(t *testing.T) {
+func TestRememberedHomeWebsocketAuthKeepsSameAuthIDPayloadSessionScoped(t *testing.T) {
 	manager := NewManager(nil, nil, nil)
 	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
 	manager.RegisterExecutor(schedulerTestExecutor{})
@@ -80,34 +75,20 @@ func TestPickNextViaHomeKeepsSameAuthIDPayloadSessionScoped(t *testing.T) {
 		},
 	})
 
-	ctx := cliproxyexecutor.WithDownstreamWebsocket(context.Background())
-	optsSession1 := cliproxyexecutor.Options{
-		Metadata: map[string]any{
-			cliproxyexecutor.ExecutionSessionMetadataKey: "session-1",
-			cliproxyexecutor.PinnedAuthMetadataKey:       "home-auth-1",
-		},
-	}
-	optsSession2 := cliproxyexecutor.Options{
-		Metadata: map[string]any{
-			cliproxyexecutor.ExecutionSessionMetadataKey: "session-2",
-			cliproxyexecutor.PinnedAuthMetadataKey:       "home-auth-1",
-		},
-	}
-
-	gotSession1, _, _, errSession1 := manager.pickNextViaHome(ctx, "gpt-5.4", optsSession1, nil)
-	if errSession1 != nil {
-		t.Fatalf("pickNextViaHome(session-1) error = %v", errSession1)
+	gotSession1, okSession1 := manager.GetExecutionSessionAuthByID("session-1", "home-auth-1")
+	if !okSession1 {
+		t.Fatal("session-1 remembered auth not found")
 	}
 	if got := gotSession1.Attributes[homeUpstreamModelAttributeKey]; got != "upstream-model-a" {
-		t.Fatalf("pickNextViaHome(session-1) upstream model = %q, want upstream-model-a", got)
+		t.Fatalf("session-1 upstream model = %q, want upstream-model-a", got)
 	}
 
-	gotSession2, _, _, errSession2 := manager.pickNextViaHome(ctx, "gpt-5.4", optsSession2, nil)
-	if errSession2 != nil {
-		t.Fatalf("pickNextViaHome(session-2) error = %v", errSession2)
+	gotSession2, okSession2 := manager.GetExecutionSessionAuthByID("session-2", "home-auth-1")
+	if !okSession2 {
+		t.Fatal("session-2 remembered auth not found")
 	}
 	if got := gotSession2.Attributes[homeUpstreamModelAttributeKey]; got != "upstream-model-b" {
-		t.Fatalf("pickNextViaHome(session-2) upstream model = %q, want upstream-model-b", got)
+		t.Fatalf("session-2 upstream model = %q, want upstream-model-b", got)
 	}
 }
 

--- a/sdk/cliproxy/auth/scheduler_test.go
+++ b/sdk/cliproxy/auth/scheduler_test.go
@@ -62,8 +62,11 @@ type inactivePluginScheduler struct {
 }
 
 type authKindHomeDispatcher struct {
-	auths  []Auth
-	counts []int
+	auths       []Auth
+	counts      []int
+	requestIDs  []string
+	dispatchIDs []string
+	releasedIDs []string
 }
 
 func (d *authKindHomeDispatcher) HeartbeatOK() bool {
@@ -71,11 +74,30 @@ func (d *authKindHomeDispatcher) HeartbeatOK() bool {
 }
 
 func (d *authKindHomeDispatcher) RPopAuth(_ context.Context, _ string, _ string, _ http.Header, count int) ([]byte, error) {
+	return d.RPopAuthWithIdentity(context.Background(), "", "", "", "", nil, count)
+}
+
+func (d *authKindHomeDispatcher) RPopAuthWithIdentity(_ context.Context, _ string, requestID string, dispatchID string, _ string, _ http.Header, count int) ([]byte, error) {
 	d.counts = append(d.counts, count)
+	d.requestIDs = append(d.requestIDs, requestID)
+	d.dispatchIDs = append(d.dispatchIDs, dispatchID)
 	if count < 1 || count > len(d.auths) {
 		return nil, home.ErrAuthNotFound
 	}
-	return json.Marshal(homeAuthDispatchResponse{Auth: d.auths[count-1]})
+	return json.Marshal(homeAuthDispatchResponse{
+		Auth:            d.auths[count-1],
+		LeaseID:         dispatchID,
+		LeaseTTLSeconds: 60,
+	})
+}
+
+func (d *authKindHomeDispatcher) RenewInFlightLease(context.Context, string) (bool, error) {
+	return true, nil
+}
+
+func (d *authKindHomeDispatcher) ReleaseInFlightLease(_ context.Context, leaseID string, _ string) (bool, error) {
+	d.releasedIDs = append(d.releasedIDs, leaseID)
+	return true, nil
 }
 
 func (s *inactivePluginScheduler) HasScheduler() bool {
@@ -564,9 +586,18 @@ func TestManagerSelectAuthByKindAdvancesHomeAuthCount(t *testing.T) {
 				if selected == nil || selected.ID != tt.wantAuthID {
 					t.Fatalf("SelectAuthByKind() auth = %#v, want %s", selected, tt.wantAuthID)
 				}
+				manager.ReleaseHomeLease(selected, "test_completed")
 			}
 			if len(dispatcher.counts) != 2 || dispatcher.counts[0] != 1 || dispatcher.counts[1] != 2 {
 				t.Fatalf("home auth counts = %v, want [1 2]", dispatcher.counts)
+			}
+			for index, requestID := range dispatcher.requestIDs {
+				if requestID == "" || dispatcher.dispatchIDs[index] == "" {
+					t.Fatalf("dispatch identity at %d = request:%q dispatch:%q", index, requestID, dispatcher.dispatchIDs[index])
+				}
+			}
+			if len(dispatcher.releasedIDs) != len(tt.auths) {
+				t.Fatalf("released leases = %v, want %d", dispatcher.releasedIDs, len(tt.auths))
 			}
 		})
 	}

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -93,6 +93,10 @@ type Auth struct {
 	// Runtime carries non-serialisable data used during execution (in-memory only).
 	Runtime any `json:"-"`
 
+	// homeLease tracks a Home in-flight reservation without occupying Runtime,
+	// which remains reserved for provider and plugin state.
+	homeLease *homeLeaseHandle
+
 	Success int64 `json:"-"`
 	Failed  int64 `json:"-"`
 

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -75,6 +75,7 @@ type requestedModelAliasContextKey struct{}
 type reasoningEffortContextKey struct{}
 type serviceTierContextKey struct{}
 type generateContextKey struct{}
+type homeLeaseIDContextKey struct{}
 
 // WithRequestedModelAlias stores the client-requested model name for usage sinks.
 func WithRequestedModelAlias(ctx context.Context, alias string) context.Context {
@@ -102,6 +103,29 @@ func RequestedModelAliasFromContext(ctx context.Context) string {
 	default:
 		return ""
 	}
+}
+
+// WithHomeLeaseID stores the Home dispatch lease for usage correlation.
+// Usage may describe one upstream attempt before the overall request finishes,
+// so consumers must not treat this field as a terminal lease-release signal.
+func WithHomeLeaseID(ctx context.Context, leaseID string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	leaseID = strings.TrimSpace(leaseID)
+	if leaseID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, homeLeaseIDContextKey{}, leaseID)
+}
+
+// HomeLeaseIDFromContext returns the Home dispatch lease stored in ctx.
+func HomeLeaseIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	leaseID, _ := ctx.Value(homeLeaseIDContextKey{}).(string)
+	return strings.TrimSpace(leaseID)
 }
 
 // WithReasoningEffort stores the client-requested reasoning effort for usage sinks.


### PR DESCRIPTION
## Summary

- propagate a stable `request_id` for each client request to Home
- generate a distinct `dispatch_id` for each credential reservation attempt
- reuse the same dispatch identity when retrying an ambiguous Home response
- attach returned Home leases to the active request lifecycle
- periodically renew leases while upstream work remains active
- release leases on terminal success, failure, or cancellation
- preserve lease ownership across fallback and WebSocket execution paths
- carry lease correlation through usage handling without treating intermediate usage events as terminal
- preserve compatibility with Home deployments that do not return a lease
- propagate Home concurrency busy responses without misclassifying them as invalid credentials
- add focused lifecycle, retry, release, scheduler, and WebSocket tests

## Why CPA changes are required

Home can reserve capacity when it dispatches a credential, but only CPA knows when the actual upstream request completes, fails, or is cancelled.

Without CPA-side renewal and release, Home can only wait for the lease TTL. This would leave completed requests counted as in-flight, consume concurrency capacity unnecessarily, and make hard limits unreliable.

## Compatibility

The lease contract is additive. Existing Home deployments that do not return lease metadata continue to work.

Upgrade Home and CPA before enabling credential concurrency limits.

## Testing

- `go test ./internal/home ./internal/redisqueue ./sdk/cliproxy/auth ./sdk/cliproxy/usage`
- `go build -o test-output ./cmd/server && rm test-output`

Closes #4340

Related:

- https://github.com/router-for-me/CLIProxyAPIHome/issues/41
- https://github.com/router-for-me/Home-Management-Center/issues/55