### PR TITLE
fix(codex): unwrap stringified tool image outputs

### DIFF
--- a/internal/translator/codex/openai/chat-completions/codex_openai_request.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_request.go
@@ -472,6 +472,12 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 func setToolCallOutputContent(funcOutput []byte, content gjson.Result) []byte {
 	switch {
 	case content.Type == gjson.String:
+		// Codex clients may serialize structured tool output into the string
+		// field. Unwrap only arrays that contain a recognized image part so
+		// ordinary JSON/text tool output keeps its existing behavior.
+		if structured := gjson.Parse(content.String()); structured.IsArray() && hasToolOutputImagePart(structured) {
+			return setToolCallOutputContent(funcOutput, structured)
+		}
 		funcOutput, _ = sjson.SetBytes(funcOutput, "output", content.String())
 	case content.IsArray():
 		outputItems := make([][]byte, 0, 4)
@@ -491,14 +497,21 @@ func setToolCallOutputContent(funcOutput []byte, content gjson.Result) []byte {
 
 func toolOutputContentPart(item gjson.Result) []byte {
 	switch item.Get("type").String() {
-	case "text":
+	case "text", "input_text", "output_text":
 		part := []byte(`{}`)
 		part, _ = sjson.SetBytes(part, "type", "input_text")
 		part, _ = sjson.SetBytes(part, "text", item.Get("text").String())
 		return part
-	case "image_url":
-		imageURL := item.Get("image_url.url").String()
-		fileID := item.Get("image_url.file_id").String()
+	case "image_url", "input_image":
+		imageURL := ""
+		fileID := ""
+		if item.Get("type").String() == "input_image" {
+			imageURL = item.Get("image_url").String()
+			fileID = item.Get("file_id").String()
+		} else {
+			imageURL = item.Get("image_url.url").String()
+			fileID = item.Get("image_url.file_id").String()
+		}
 		if imageURL == "" && fileID == "" {
 			return toolOutputFallbackPart(item)
 		}
@@ -510,7 +523,13 @@ func toolOutputContentPart(item gjson.Result) []byte {
 		if fileID != "" {
 			part, _ = sjson.SetBytes(part, "file_id", fileID)
 		}
-		if detail := item.Get("image_url.detail").String(); detail != "" {
+		detail := ""
+		if item.Get("type").String() == "input_image" {
+			detail = item.Get("detail").String()
+		} else {
+			detail = item.Get("image_url.detail").String()
+		}
+		if detail != "" {
 			part, _ = sjson.SetBytes(part, "detail", detail)
 		}
 		return part
@@ -539,6 +558,19 @@ func toolOutputContentPart(item gjson.Result) []byte {
 	default:
 		return toolOutputFallbackPart(item)
 	}
+}
+
+func hasToolOutputImagePart(content gjson.Result) bool {
+	if !content.IsArray() {
+		return false
+	}
+	for _, item := range content.Array() {
+		switch item.Get("type").String() {
+		case "image_url", "input_image":
+			return true
+		}
+	}
+	return false
 }
 
 func toolOutputFallbackPart(item gjson.Result) []byte {

--- a/internal/translator/codex/openai/chat-completions/codex_openai_request_test.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_request_test.go
@@ -254,6 +254,49 @@ func TestToolCallOutputWithMultimodalContent(t *testing.T) {
 	}
 }
 
+func TestToolCallOutputWithStringifiedCodexImageContent(t *testing.T) {
+	input := []byte(`{
+		"model": "gpt-5.6-sol",
+		"messages": [
+			{"role": "user", "content": "Inspect the screenshot."},
+			{
+				"role": "assistant",
+				"content": null,
+				"tool_calls": [
+					{"id": "call_screenshot", "type": "function", "function": {"name": "view_image", "arguments": "{}"}}
+				]
+			},
+			{
+				"role": "tool",
+				"tool_call_id": "call_screenshot",
+				"content": "[{\"detail\":\"original\",\"image_url\":\"data:image/png;base64,AA==\",\"type\":\"input_image\"}]"
+			}
+		],
+		"tools": [
+			{"type": "function", "function": {"name": "view_image", "parameters": {"type": "object", "properties": {}}}}
+		]
+	}`)
+
+	out := ConvertOpenAIRequestToCodex("gpt-5.6-sol", input, true)
+	output := gjson.GetBytes(out, "input.2.output")
+	if !output.IsArray() {
+		t.Fatalf("expected stringified image output to be an array, got: %s", output.Raw)
+	}
+	parts := output.Array()
+	if len(parts) != 1 {
+		t.Fatalf("expected one output part, got %d: %s", len(parts), output.Raw)
+	}
+	if parts[0].Get("type").String() != "input_image" {
+		t.Fatalf("expected input_image, got: %s", parts[0].Raw)
+	}
+	if parts[0].Get("image_url").String() != "data:image/png;base64,AA==" {
+		t.Fatalf("unexpected image URL: %s", parts[0].Get("image_url").String())
+	}
+	if parts[0].Get("detail").String() != "original" {
+		t.Fatalf("unexpected image detail: %s", parts[0].Get("detail").String())
+	}
+}
+
 func TestToolCallOutputFallsBackForInvalidStructuredParts(t *testing.T) {
 	input := []byte(`{
 		"model": "gpt-4o",


### PR DESCRIPTION
## Summary

- unwrap stringified tool-output arrays when they contain a recognized image part
- normalize Chat Completions `text` / `input_text` / `output_text` and `image_url` / `input_image` parts into Codex Responses-compatible output parts
- leave ordinary JSON strings and plain-text tool outputs unchanged

## Problem

Some Codex clients serialize structured screenshot output into the Chat Completions tool message `content` string. The OpenAI Chat -> Codex translator currently forwards that serialized array as plain text, so the upstream Responses request receives the base64 image payload as text instead of a structured `input_image` part. Repeated tool screenshots can then inflate the effective context dramatically.

## Test

- `go test ./internal/translator/codex/openai/chat-completions`
- added a regression test for a stringified Codex `input_image` tool output
