### PR TITLE
fix(streaming): keep the connection alive during the pre-first-chunk wait

### DIFF
--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -7,6 +7,7 @@ import (
 )
 
 const (
+	claudeBuiltinOpus5ModelID       = "claude-opus-5"
 	codexBuiltinImage15ModelID      = "gpt-image-1.5"
 	codexBuiltinImageModelID        = "gpt-image-2"
 	xaiBuiltinImageModelID          = "grok-imagine-image"
@@ -32,7 +33,7 @@ type staticModelsJSON struct {
 
 // GetClaudeModels returns the standard Claude model definitions.
 func GetClaudeModels() []*ModelInfo {
-	return cloneModelInfos(getModels().Claude)
+	return WithClaudeBuiltins(cloneModelInfos(getModels().Claude))
 }
 
 // GetGeminiModels returns the standard Gemini model definitions.
@@ -110,6 +111,11 @@ func GetXAIModels() []*ModelInfo {
 	return WithXAIBuiltins(cloneModelInfos(getModels().XAI))
 }
 
+// WithClaudeBuiltins keeps newly released Claude models available while the remote catalog catches up.
+func WithClaudeBuiltins(models []*ModelInfo) []*ModelInfo {
+	return upsertModelInfos(models, claudeBuiltinOpus5ModelInfo())
+}
+
 // WithCodexBuiltins injects hard-coded Codex-only model definitions that should
 // not depend on remote models.json updates. Built-ins replace any matching IDs
 // already present in the provided slice.
@@ -129,6 +135,24 @@ func normalizeAntigravityCapabilityModelID(modelID string) string {
 		modelID = strings.TrimSpace(modelID[:open])
 	}
 	return modelID
+}
+
+func claudeBuiltinOpus5ModelInfo() *ModelInfo {
+	return &ModelInfo{
+		ID:                  claudeBuiltinOpus5ModelID,
+		Object:              "model",
+		OwnedBy:             "anthropic",
+		Type:                "claude",
+		DisplayName:         "Claude Opus 5",
+		Description:         "Anthropic's most capable model for reasoning, planning, coding, and agentic work",
+		ContextLength:       1_000_000,
+		MaxCompletionTokens: 128_000,
+		Thinking: &ThinkingSupport{
+			ZeroAllowed:    true,
+			DynamicAllowed: true,
+			Levels:         []string{"low", "medium", "high", "xhigh", "max"},
+		},
+	}
 }
 
 func codexBuiltinImage15ModelInfo() *ModelInfo {

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -35,6 +35,19 @@ func TestGeminiVertexModelsUseFlashLiteReleaseID(t *testing.T) {
 	t.Fatalf("Vertex models do not contain %q", releaseID)
 }
 
+func TestClaudeBuiltinsIncludeOpus5(t *testing.T) {
+	for _, model := range GetClaudeModels() {
+		if model == nil || model.ID != "claude-opus-5" {
+			continue
+		}
+		if model.Type != "claude" || model.DisplayName != "Claude Opus 5" || model.ContextLength != 1_000_000 {
+			t.Fatalf("unexpected Opus 5 metadata: %#v", model)
+		}
+		return
+	}
+	t.Fatal("Claude models do not contain claude-opus-5")
+}
+
 func TestWithXAIBuiltinsIncludesVideoPreviewModel(t *testing.T) {
 	models := WithXAIBuiltins(nil)
 

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -274,7 +274,6 @@ func (h *ClaudeCodeAPIHandler) handleStreamingResponse(c *gin.Context, rawJSON [
 	// This allows proper cleanup and cancellation of ongoing requests
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
 
-	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
 	setSSEHeaders := func() {
 		c.Header("Content-Type", "text/event-stream")
 		c.Header("Cache-Control", "no-cache")
@@ -282,75 +281,44 @@ func (h *ClaudeCodeAPIHandler) handleStreamingResponse(c *gin.Context, rawJSON [
 		c.Header("Access-Control-Allow-Origin", "*")
 	}
 
-	// Peek at the first chunk to determine success or failure before setting headers
-	for {
-		select {
-		case <-c.Request.Context().Done():
-			cliCancel(c.Request.Context().Err())
-			return
-		case errMsg, ok := <-errChan:
-			if !ok {
-				// Err channel closed cleanly; wait for data channel.
-				errChan = nil
-				continue
+	h.BootstrapStream(c, flusher, handlers.StreamBootstrapOptions{
+		Execute: func() (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
+			return h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
+		},
+		SetSSEHeaders: setSSEHeaders,
+		WriteCommittedError: func(errMsg *interfaces.ErrorMessage) []byte {
+			if errMsg == nil {
+				return nil
 			}
-			// Upstream failed immediately. Return proper error status and JSON.
+			errorBytes, _ := json.Marshal(h.toClaudeError(errMsg))
+			_, _ = fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", errorBytes)
+			return errorBytes
+		},
+		WriteUncommittedError: func(errMsg *interfaces.ErrorMessage) {
 			h.WriteErrorResponse(c, errMsg)
-			if errMsg != nil {
-				cliCancel(errMsg.Error)
-			} else {
-				cliCancel(nil)
-			}
-			return
-		case chunk, ok := <-dataChan:
-			if !ok {
-				if errMsg, okPendingErr := pendingClaudeStreamError(errChan); okPendingErr {
-					h.WriteErrorResponse(c, errMsg)
-					if errMsg != nil {
-						cliCancel(errMsg.Error)
-					} else {
-						cliCancel(nil)
-					}
-					return
-				}
-				// Stream closed without data? Send DONE or just headers.
+		},
+		OnFirstChunk: func(headersCommitted bool, upstreamHeaders http.Header, chunk []byte) {
+			if !headersCommitted {
 				setSSEHeaders()
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-				flusher.Flush()
-				cliCancel(nil)
-				return
 			}
-
-			// Success! Set headers now.
-			setSSEHeaders()
-			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-
-			// Write the first chunk
 			if len(chunk) > 0 {
 				_, _ = c.Writer.Write(chunk)
 				flusher.Flush()
 			}
-
-			// Continue streaming the rest
-			h.forwardClaudeStream(c, flusher, func(err error) { cliCancel(err) }, dataChan, errChan)
-			return
-		}
-	}
-}
-
-func pendingClaudeStreamError(errs <-chan *interfaces.ErrorMessage) (*interfaces.ErrorMessage, bool) {
-	if errs == nil {
-		return nil, false
-	}
-	select {
-	case errMsg, ok := <-errs:
-		if !ok {
-			return nil, false
-		}
-		return errMsg, true
-	default:
-		return nil, false
-	}
+		},
+		OnStreamClosedWithoutData: func(headersCommitted bool, upstreamHeaders http.Header) {
+			if !headersCommitted {
+				setSSEHeaders()
+				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+			}
+		},
+		Forward: func(data <-chan []byte, errs <-chan *interfaces.ErrorMessage) {
+			h.forwardClaudeStream(c, flusher, func(err error) { cliCancel(err) }, data, errs)
+		},
+		Cancel:                   func(err error) { cliCancel(err) },
+		DrainPendingErrorOnClose: true,
+	})
 }
 
 func (h *ClaudeCodeAPIHandler) forwardClaudeStream(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage) {

--- a/sdk/api/handlers/claude/code_handlers_error_test.go
+++ b/sdk/api/handlers/claude/code_handlers_error_test.go
@@ -74,21 +74,3 @@ func TestWriteClaudeErrorResponseUsesClaudeEnvelope(t *testing.T) {
 		t.Fatalf("error.message = %q; body=%s", got, body)
 	}
 }
-
-func TestPendingClaudeStreamErrorUsesBufferedError(t *testing.T) {
-	wantErr := &interfaces.ErrorMessage{
-		StatusCode: http.StatusBadRequest,
-		Error:      errors.New(`{"error":{"message":"Your input exceeds the context window of this model. Please adjust your input and try again.","type":"invalid_request_error","code":"context_too_large"}}`),
-	}
-	errs := make(chan *interfaces.ErrorMessage, 1)
-	errs <- wantErr
-	close(errs)
-
-	gotErr, ok := pendingClaudeStreamError(errs)
-	if !ok {
-		t.Fatal("expected pending stream error")
-	}
-	if gotErr != wantErr {
-		t.Fatalf("pending error = %p, want %p", gotErr, wantErr)
-	}
-}

--- a/sdk/api/handlers/gemini/gemini_handlers.go
+++ b/sdk/api/handlers/gemini/gemini_handlers.go
@@ -200,7 +200,7 @@ func (h *GeminiAPIHandler) handleStreamGenerateContent(c *gin.Context, modelName
 	// corrupt the body. Disable heartbeats there, as forwardGeminiStream already does.
 	var keepAliveInterval *time.Duration
 	if alt != "" {
-		keepAliveInterval = new(time.Duration(0))
+		keepAliveInterval = new(time.Duration)
 	}
 
 	h.BootstrapStream(c, flusher, handlers.StreamBootstrapOptions{
@@ -311,7 +311,7 @@ func (h *GeminiAPIHandler) handleGenerateContent(c *gin.Context, modelName strin
 func (h *GeminiAPIHandler) forwardGeminiStream(c *gin.Context, flusher http.Flusher, alt string, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage) {
 	var keepAliveInterval *time.Duration
 	if alt != "" {
-		keepAliveInterval = new(time.Duration(0))
+		keepAliveInterval = new(time.Duration)
 	}
 
 	h.ForwardStream(c, flusher, cancel, data, errs, handlers.StreamForwardOptions{

--- a/sdk/api/handlers/gemini/gemini_handlers.go
+++ b/sdk/api/handlers/gemini/gemini_handlers.go
@@ -188,7 +188,6 @@ func (h *GeminiAPIHandler) handleStreamGenerateContent(c *gin.Context, modelName
 	}
 
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
-	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, alt)
 
 	setSSEHeaders := func() {
 		c.Header("Content-Type", "text/event-stream")
@@ -197,45 +196,45 @@ func (h *GeminiAPIHandler) handleStreamGenerateContent(c *gin.Context, modelName
 		c.Header("Access-Control-Allow-Origin", "*")
 	}
 
-	// Peek at the first chunk
-	for {
-		select {
-		case <-c.Request.Context().Done():
-			cliCancel(c.Request.Context().Err())
-			return
-		case errMsg, ok := <-errChan:
-			if !ok {
-				// Err channel closed cleanly; wait for data channel.
-				errChan = nil
-				continue
+	// An `alt` stream is raw JSON rather than SSE, so an SSE comment heartbeat would
+	// corrupt the body. Disable heartbeats there, as forwardGeminiStream already does.
+	var keepAliveInterval *time.Duration
+	if alt != "" {
+		keepAliveInterval = new(time.Duration(0))
+	}
+
+	h.BootstrapStream(c, flusher, handlers.StreamBootstrapOptions{
+		KeepAliveInterval: keepAliveInterval,
+		Execute: func() (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
+			return h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, alt)
+		},
+		SetSSEHeaders: setSSEHeaders,
+		WriteCommittedError: func(errMsg *interfaces.ErrorMessage) []byte {
+			if errMsg == nil {
+				return nil
 			}
-			// Upstream failed immediately. Return proper error status and JSON.
+			status := http.StatusInternalServerError
+			if errMsg.StatusCode > 0 {
+				status = errMsg.StatusCode
+			}
+			errText := http.StatusText(status)
+			if errMsg.Error != nil && errMsg.Error.Error() != "" {
+				errText = errMsg.Error.Error()
+			}
+			body := handlers.BuildErrorResponseBody(status, errText)
+			_, _ = fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", string(body))
+			return body
+		},
+		WriteUncommittedError: func(errMsg *interfaces.ErrorMessage) {
 			h.WriteErrorResponse(c, errMsg)
-			if errMsg != nil {
-				cliCancel(errMsg.Error)
-			} else {
-				cliCancel(nil)
-			}
-			return
-		case chunk, ok := <-dataChan:
-			if !ok {
-				// Closed without data
+		},
+		OnFirstChunk: func(headersCommitted bool, upstreamHeaders http.Header, chunk []byte) {
+			if !headersCommitted {
 				if alt == "" {
 					setSSEHeaders()
 				}
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-				flusher.Flush()
-				cliCancel(nil)
-				return
 			}
-
-			// Success! Set headers.
-			if alt == "" {
-				setSSEHeaders()
-			}
-			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-
-			// Write first chunk
 			if alt == "" {
 				_, _ = c.Writer.Write([]byte("data: "))
 				_, _ = c.Writer.Write(chunk)
@@ -244,12 +243,20 @@ func (h *GeminiAPIHandler) handleStreamGenerateContent(c *gin.Context, modelName
 				_, _ = c.Writer.Write(chunk)
 			}
 			flusher.Flush()
-
-			// Continue
-			h.forwardGeminiStream(c, flusher, alt, func(err error) { cliCancel(err) }, dataChan, errChan)
-			return
-		}
-	}
+		},
+		OnStreamClosedWithoutData: func(headersCommitted bool, upstreamHeaders http.Header) {
+			if !headersCommitted {
+				if alt == "" {
+					setSSEHeaders()
+				}
+				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+			}
+		},
+		Forward: func(data <-chan []byte, errs <-chan *interfaces.ErrorMessage) {
+			h.forwardGeminiStream(c, flusher, alt, func(err error) { cliCancel(err) }, data, errs)
+		},
+		Cancel: func(err error) { cliCancel(err) },
+	})
 }
 
 // handleCountTokens handles token counting requests for Gemini models.

--- a/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -780,3 +780,356 @@ func TestExecuteStreamWithAuthManager_AllowsSplitOpenAIResponsesSSEEventLines(t 
 		t.Fatalf("unexpected second chunk.\nGot:  %q\nWant: %q", got[1], expectedData)
 	}
 }
+
+// slowRetryStreamExecutor fails its first stream attempt before any payload, then serves a
+// stream whose first payload only arrives after delay. That reproduces the bootstrap-retry
+// window: ExecuteStreamWithAuthManager has already returned on the error chunk while the
+// SDK's background goroutine waits on a fresh, and equally silent, upstream.
+type slowRetryStreamExecutor struct {
+	mu    sync.Mutex
+	calls int
+	delay time.Duration
+}
+
+func (e *slowRetryStreamExecutor) Identifier() string { return "codex" }
+
+func (e *slowRetryStreamExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, &coreauth.Error{Code: "not_implemented", Message: "Execute not implemented"}
+}
+
+func (e *slowRetryStreamExecutor) ExecuteStream(ctx context.Context, _ *coreauth.Auth, _ coreexecutor.Request, _ coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	e.mu.Lock()
+	e.calls++
+	call := e.calls
+	e.mu.Unlock()
+
+	if call == 1 {
+		ch := make(chan coreexecutor.StreamChunk, 1)
+		ch <- coreexecutor.StreamChunk{
+			Err: &coreauth.Error{
+				Code:       "unauthorized",
+				Message:    "unauthorized",
+				HTTPStatus: http.StatusUnauthorized,
+			},
+		}
+		close(ch)
+		return &coreexecutor.StreamResult{Chunks: ch}, nil
+	}
+
+	ch := make(chan coreexecutor.StreamChunk)
+	go func() {
+		defer close(ch)
+		timer := time.NewTimer(e.delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+		select {
+		case ch <- coreexecutor.StreamChunk{Payload: []byte("ok")}:
+		case <-ctx.Done():
+		}
+	}()
+	return &coreexecutor.StreamResult{Chunks: ch}, nil
+}
+
+func (e *slowRetryStreamExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *slowRetryStreamExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, &coreauth.Error{Code: "not_implemented", Message: "CountTokens not implemented"}
+}
+
+func (e *slowRetryStreamExecutor) HttpRequest(_ context.Context, _ *coreauth.Auth, _ *http.Request) (*http.Response, error) {
+	return nil, &coreauth.Error{
+		Code:       "not_implemented",
+		Message:    "HttpRequest not implemented",
+		HTTPStatus: http.StatusNotImplemented,
+	}
+}
+
+func (e *slowRetryStreamExecutor) Calls() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.calls
+}
+
+// headerCountingRecorder counts WriteHeader calls so a test can prove the committed-error
+// path never tries to write a second HTTP status.
+type headerCountingRecorder struct {
+	*httptest.ResponseRecorder
+	writeHeaderCalls int
+}
+
+func (w *headerCountingRecorder) WriteHeader(code int) {
+	w.writeHeaderCalls++
+	w.ResponseRecorder.WriteHeader(code)
+}
+
+func newBootstrapStreamTestContext() (*gin.Context, *headerCountingRecorder) {
+	gin.SetMode(gin.TestMode)
+	recorder := &headerCountingRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	return c, recorder
+}
+
+// sseTestOptions wires StreamBootstrapOptions for a minimal SSE handler so each test only
+// has to supply the Execute behaviour it exercises.
+func sseTestOptions(c *gin.Context, interval time.Duration, uncommitted *int) StreamBootstrapOptions {
+	return StreamBootstrapOptions{
+		KeepAliveInterval: &interval,
+		SetSSEHeaders: func() {
+			c.Header("Content-Type", "text/event-stream")
+			c.Header("Cache-Control", "no-cache")
+		},
+		WriteCommittedError: func(errMsg *interfaces.ErrorMessage) []byte {
+			body := []byte("{\"error\":{\"message\":\"upstream failed\"}}")
+			_, _ = c.Writer.Write([]byte("event: error\ndata: "))
+			_, _ = c.Writer.Write(body)
+			_, _ = c.Writer.Write([]byte("\n\n"))
+			return body
+		},
+		WriteUncommittedError: func(*interfaces.ErrorMessage) {
+			*uncommitted++
+			c.Status(http.StatusInternalServerError)
+			_, _ = c.Writer.Write([]byte("{\"error\":\"boom\"}"))
+		},
+		OnFirstChunk: func(headersCommitted bool, _ http.Header, chunk []byte) {
+			if !headersCommitted {
+				c.Header("Content-Type", "text/event-stream")
+			}
+			_, _ = c.Writer.Write([]byte("data: "))
+			_, _ = c.Writer.Write(chunk)
+			_, _ = c.Writer.Write([]byte("\n\n"))
+		},
+		Cancel: func(error) {},
+	}
+}
+
+// (a) The first chunk arrives after the keep-alive interval: a heartbeat must precede it and
+// the request must still finish as a normal 200 stream.
+func TestBootstrapStream_HeartbeatsBeforeDelayedFirstChunk(t *testing.T) {
+	c, recorder := newBootstrapStreamTestContext()
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		t.Fatal("gin writer does not implement http.Flusher")
+	}
+
+	uncommitted := 0
+	opts := sseTestOptions(c, 20*time.Millisecond, &uncommitted)
+	opts.Execute = func() (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
+		time.Sleep(120 * time.Millisecond)
+		data := make(chan []byte, 1)
+		data <- []byte("hello")
+		close(data)
+		errs := make(chan *interfaces.ErrorMessage)
+		close(errs)
+		return data, http.Header{}, errs
+	}
+
+	handler.BootstrapStream(c, flusher, opts)
+
+	body := recorder.Body.String()
+	firstBeat := strings.Index(body, KeepAliveSSEComment)
+	if firstBeat < 0 {
+		t.Fatalf("expected a keep-alive heartbeat, got %q", body)
+	}
+	payload := strings.Index(body, "data: hello")
+	if payload < 0 {
+		t.Fatalf("expected the first chunk in the body, got %q", body)
+	}
+	if firstBeat > payload {
+		t.Fatalf("expected the heartbeat before the first chunk, got %q", body)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if uncommitted != 0 {
+		t.Fatalf("uncommitted error writer called %d times, want 0", uncommitted)
+	}
+}
+
+// (b) An error that lands after a heartbeat already committed the headers must be reported
+// in-band as an SSE error event, with exactly one WriteHeader and no lost request log.
+func TestBootstrapStream_CommittedErrorBecomesSSEEvent(t *testing.T) {
+	c, recorder := newBootstrapStreamTestContext()
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		t.Fatal("gin writer does not implement http.Flusher")
+	}
+
+	uncommitted := 0
+	opts := sseTestOptions(c, 20*time.Millisecond, &uncommitted)
+	opts.Execute = func() (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
+		time.Sleep(120 * time.Millisecond)
+		data := make(chan []byte)
+		errs := make(chan *interfaces.ErrorMessage, 1)
+		errs <- &interfaces.ErrorMessage{
+			StatusCode: http.StatusBadGateway,
+			Error:      errors.New("upstream failed"),
+		}
+		return data, http.Header{}, errs
+	}
+
+	handler.BootstrapStream(c, flusher, opts)
+
+	body := recorder.Body.String()
+	if !strings.Contains(body, KeepAliveSSEComment) {
+		t.Fatalf("expected a keep-alive heartbeat, got %q", body)
+	}
+	if !strings.Contains(body, "event: error") {
+		t.Fatalf("expected an SSE error event, got %q", body)
+	}
+	if uncommitted != 0 {
+		t.Fatalf("uncommitted error writer called %d times, want 0 once headers are committed", uncommitted)
+	}
+	if recorder.writeHeaderCalls != 1 {
+		t.Fatalf("WriteHeader called %d times, want exactly 1", recorder.writeHeaderCalls)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (the heartbeat already committed it)", recorder.Code, http.StatusOK)
+	}
+	logged, exists := c.Get("API_RESPONSE")
+	if !exists {
+		t.Fatal("expected the committed error to be appended to the request log")
+	}
+	loggedBytes, isBytes := logged.([]byte)
+	if !isBytes || !strings.Contains(string(loggedBytes), "upstream failed") {
+		t.Fatalf("request log = %v, want it to contain the error body", logged)
+	}
+}
+
+// (c1) Once Execute has returned and the real channels are bound, the upstream can still go
+// silent (a retry against a fresh upstream, a slow first frame after the bootstrap peek).
+// The same ticker must keep covering that window instead of stopping at the hand-off, which
+// is what a stop-the-goroutine-then-peek implementation gets wrong.
+func TestBootstrapStream_HeartbeatsContinueAfterUpstreamBound(t *testing.T) {
+	c, recorder := newBootstrapStreamTestContext()
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		t.Fatal("gin writer does not implement http.Flusher")
+	}
+
+	uncommitted := 0
+	opts := sseTestOptions(c, 20*time.Millisecond, &uncommitted)
+	opts.Execute = func() (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
+		// Returns immediately, so every heartbeat below happens after the bind.
+		data := make(chan []byte)
+		errs := make(chan *interfaces.ErrorMessage)
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			data <- []byte("late")
+			close(data)
+		}()
+		return data, http.Header{}, errs
+	}
+
+	handler.BootstrapStream(c, flusher, opts)
+
+	body := recorder.Body.String()
+	payload := strings.Index(body, "data: late")
+	if payload < 0 {
+		t.Fatalf("expected the late chunk in the body, got %q", body)
+	}
+	beats := strings.Count(body[:payload], KeepAliveSSEComment)
+	if beats < 2 {
+		t.Fatalf("expected heartbeats to continue after the upstream was bound, got %d in %q", beats, body)
+	}
+	if uncommitted != 0 {
+		t.Fatalf("uncommitted error writer called %d times, want 0", uncommitted)
+	}
+}
+
+// (c2) End-to-end against the real SDK: the first upstream fails before any payload and the
+// auth manager rotates to a slow second upstream. Note that this retry happens *inside*
+// ExecuteStreamWithAuthManager, because coreauth's own readStreamBootstrap
+// (sdk/cliproxy/auth/conductor.go:1896) peels off pre-payload errors before returning, so
+// this covers the first-token window rather than the post-bind one that (c1) covers.
+func TestBootstrapStream_HeartbeatsAcrossAuthRotationRetry(t *testing.T) {
+	executor := &slowRetryStreamExecutor{delay: 200 * time.Millisecond}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth1 := &coreauth.Auth{
+		ID:       "retry-auth1",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"email": "retry1@example.com"},
+	}
+	if _, err := manager.Register(context.Background(), auth1); err != nil {
+		t.Fatalf("manager.Register(auth1): %v", err)
+	}
+	auth2 := &coreauth.Auth{
+		ID:       "retry-auth2",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"email": "retry2@example.com"},
+	}
+	if _, err := manager.Register(context.Background(), auth2); err != nil {
+		t.Fatalf("manager.Register(auth2): %v", err)
+	}
+
+	registry.GetGlobalRegistry().RegisterClient(auth1.ID, auth1.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	registry.GetGlobalRegistry().RegisterClient(auth2.ID, auth2.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth1.ID)
+		registry.GetGlobalRegistry().UnregisterClient(auth2.ID)
+	})
+
+	c, recorder := newBootstrapStreamTestContext()
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{
+		Streaming: sdkconfig.StreamingConfig{BootstrapRetries: 1},
+	}, manager)
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		t.Fatal("gin writer does not implement http.Flusher")
+	}
+
+	uncommitted := 0
+	opts := sseTestOptions(c, 20*time.Millisecond, &uncommitted)
+	opts.Execute = func() (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
+		return handler.ExecuteStreamWithAuthManager(context.Background(), "openai", "test-model", []byte("{\"model\":\"test-model\"}"), "")
+	}
+
+	handler.BootstrapStream(c, flusher, opts)
+
+	body := recorder.Body.String()
+	payload := strings.Index(body, "data: ok")
+	if payload < 0 {
+		t.Fatalf("expected the retried payload in the body, got %q", body)
+	}
+	beats := strings.Count(body[:payload], KeepAliveSSEComment)
+	if beats < 2 {
+		t.Fatalf("expected heartbeats across the auth-rotation retry, got %d in %q", beats, body)
+	}
+	if executor.Calls() != 2 {
+		t.Fatalf("expected 2 stream attempts, got %d", executor.Calls())
+	}
+	if uncommitted != 0 {
+		t.Fatalf("uncommitted error writer called %d times, want 0", uncommitted)
+	}
+}
+
+func TestPendingStreamErrorUsesBufferedError(t *testing.T) {
+	wantErr := &interfaces.ErrorMessage{
+		StatusCode: http.StatusBadRequest,
+		Error:      errors.New("{\"error\":{\"message\":\"context too large\",\"type\":\"invalid_request_error\"}}"),
+	}
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	errs <- wantErr
+	close(errs)
+
+	gotErr, ok := pendingStreamError(errs)
+	if !ok {
+		t.Fatal("expected pending stream error")
+	}
+	if gotErr != wantErr {
+		t.Fatalf("pending error = %p, want %p", gotErr, wantErr)
+	}
+}

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -469,7 +469,9 @@ func (h *OpenAIAPIHandler) handleStreamingResponse(c *gin.Context, rawJSON []byt
 
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
-	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, h.GetAlt(c))
+	// Resolve on the handler goroutine: GetQuery populates gin's query cache, so it must
+	// not run concurrently with the keep-alive loop below.
+	alt := h.GetAlt(c)
 
 	setSSEHeaders := func() {
 		c.Header("Content-Type", "text/event-stream")
@@ -478,48 +480,54 @@ func (h *OpenAIAPIHandler) handleStreamingResponse(c *gin.Context, rawJSON []byt
 		c.Header("Access-Control-Allow-Origin", "*")
 	}
 
-	// Peek at the first chunk to determine success or failure before setting headers
-	for {
-		select {
-		case <-c.Request.Context().Done():
-			cliCancel(c.Request.Context().Err())
-			return
-		case errMsg, ok := <-errChan:
-			if !ok {
-				// Err channel closed cleanly; wait for data channel.
-				errChan = nil
-				continue
-			}
-			// Upstream failed immediately. Return proper error status and JSON.
-			h.WriteErrorResponse(c, errMsg)
-			if errMsg != nil {
-				cliCancel(errMsg.Error)
-			} else {
-				cliCancel(nil)
-			}
-			return
-		case chunk, ok := <-dataChan:
-			if !ok {
-				// Stream closed without data? Send DONE or just headers.
+	h.BootstrapStream(c, flusher, handlers.StreamBootstrapOptions{
+		Execute: func() (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
+			return h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, alt)
+		},
+		SetSSEHeaders:         setSSEHeaders,
+		WriteCommittedError:   writeOpenAIStreamError(c),
+		WriteUncommittedError: func(errMsg *interfaces.ErrorMessage) { h.WriteErrorResponse(c, errMsg) },
+		OnFirstChunk: func(headersCommitted bool, upstreamHeaders http.Header, chunk []byte) {
+			if !headersCommitted {
 				setSSEHeaders()
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-				_, _ = fmt.Fprintf(c.Writer, "data: [DONE]\n\n")
-				flusher.Flush()
-				cliCancel(nil)
-				return
 			}
-
-			// Success! Commit to streaming headers.
-			setSSEHeaders()
-			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-
 			_, _ = fmt.Fprintf(c.Writer, "data: %s\n\n", string(chunk))
 			flusher.Flush()
+		},
+		OnStreamClosedWithoutData: func(headersCommitted bool, upstreamHeaders http.Header) {
+			if !headersCommitted {
+				setSSEHeaders()
+				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+			}
+			_, _ = fmt.Fprintf(c.Writer, "data: [DONE]\n\n")
+		},
+		Forward: func(data <-chan []byte, errs <-chan *interfaces.ErrorMessage) {
+			h.handleStreamResult(c, flusher, func(err error) { cliCancel(err) }, data, errs)
+		},
+		Cancel: func(err error) { cliCancel(err) },
+	})
+}
 
-			// Continue streaming the rest
-			h.handleStreamResult(c, flusher, func(err error) { cliCancel(err) }, dataChan, errChan)
-			return
+// writeOpenAIStreamError returns a committed-error writer that frames an error as an SSE
+// event once the response headers are already on the wire. It returns the raw error body
+// so BootstrapStream can keep the request log in parity with WriteErrorResponse.
+func writeOpenAIStreamError(c *gin.Context) func(*interfaces.ErrorMessage) []byte {
+	return func(errMsg *interfaces.ErrorMessage) []byte {
+		if errMsg == nil {
+			return nil
 		}
+		status := http.StatusInternalServerError
+		if errMsg.StatusCode > 0 {
+			status = errMsg.StatusCode
+		}
+		errText := http.StatusText(status)
+		if errMsg.Error != nil && errMsg.Error.Error() != "" {
+			errText = errMsg.Error.Error()
+		}
+		body := handlers.BuildErrorResponseBody(status, errText)
+		_, _ = fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", string(body))
+		return body
 	}
 }
 
@@ -577,7 +585,6 @@ func (h *OpenAIAPIHandler) handleCompletionsStreamingResponse(c *gin.Context, ra
 
 	modelName := gjson.GetBytes(chatCompletionsJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
-	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, chatCompletionsJSON, "")
 
 	setSSEHeaders := func() {
 		c.Header("Content-Type", "text/event-stream")
@@ -586,46 +593,32 @@ func (h *OpenAIAPIHandler) handleCompletionsStreamingResponse(c *gin.Context, ra
 		c.Header("Access-Control-Allow-Origin", "*")
 	}
 
-	// Peek at the first chunk
-	for {
-		select {
-		case <-c.Request.Context().Done():
-			cliCancel(c.Request.Context().Err())
-			return
-		case errMsg, ok := <-errChan:
-			if !ok {
-				// Err channel closed cleanly; wait for data channel.
-				errChan = nil
-				continue
-			}
-			h.WriteErrorResponse(c, errMsg)
-			if errMsg != nil {
-				cliCancel(errMsg.Error)
-			} else {
-				cliCancel(nil)
-			}
-			return
-		case chunk, ok := <-dataChan:
-			if !ok {
+	h.BootstrapStream(c, flusher, handlers.StreamBootstrapOptions{
+		Execute: func() (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
+			return h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, chatCompletionsJSON, "")
+		},
+		SetSSEHeaders:         setSSEHeaders,
+		WriteCommittedError:   writeOpenAIStreamError(c),
+		WriteUncommittedError: func(errMsg *interfaces.ErrorMessage) { h.WriteErrorResponse(c, errMsg) },
+		OnFirstChunk: func(headersCommitted bool, upstreamHeaders http.Header, chunk []byte) {
+			if !headersCommitted {
 				setSSEHeaders()
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-				_, _ = fmt.Fprintf(c.Writer, "data: [DONE]\n\n")
-				flusher.Flush()
-				cliCancel(nil)
-				return
 			}
-
-			// Success! Set headers.
-			setSSEHeaders()
-			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-
-			// Write the first chunk
 			converted := convertChatCompletionsStreamChunkToCompletions(chunk)
 			if converted != nil {
 				_, _ = fmt.Fprintf(c.Writer, "data: %s\n\n", string(converted))
 				flusher.Flush()
 			}
-
+		},
+		OnStreamClosedWithoutData: func(headersCommitted bool, upstreamHeaders http.Header) {
+			if !headersCommitted {
+				setSSEHeaders()
+				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+			}
+			_, _ = fmt.Fprintf(c.Writer, "data: [DONE]\n\n")
+		},
+		Forward: func(data <-chan []byte, errs <-chan *interfaces.ErrorMessage) {
 			done := make(chan struct{})
 			var doneOnce sync.Once
 			stop := func() { doneOnce.Do(func() { close(done) }) }
@@ -637,7 +630,7 @@ func (h *OpenAIAPIHandler) handleCompletionsStreamingResponse(c *gin.Context, ra
 					select {
 					case <-done:
 						return
-					case chunk, ok := <-dataChan:
+					case chunk, ok := <-data:
 						if !ok {
 							return
 						}
@@ -657,10 +650,10 @@ func (h *OpenAIAPIHandler) handleCompletionsStreamingResponse(c *gin.Context, ra
 			h.handleStreamResult(c, flusher, func(err error) {
 				stop()
 				cliCancel(err)
-			}, convertedChan, errChan)
-			return
-		}
-	}
+			}, convertedChan, errs)
+		},
+		Cancel: func(err error) { cliCancel(err) },
+	})
 }
 func (h *OpenAIAPIHandler) handleStreamResult(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage) {
 	h.ForwardStream(c, flusher, cancel, data, errs, handlers.StreamForwardOptions{

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -485,7 +485,6 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 	// New core execution path
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
-	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
 
 	setSSEHeaders := func() {
 		c.Header("Content-Type", "text/event-stream")
@@ -495,50 +494,50 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 	}
 	framer := &responsesSSEFramer{}
 
-	// Peek at the first chunk
-	for {
-		select {
-		case <-c.Request.Context().Done():
-			cliCancel(c.Request.Context().Err())
-			return
-		case errMsg, ok := <-errChan:
-			if !ok {
-				// Err channel closed cleanly; wait for data channel.
-				errChan = nil
-				continue
+	h.BootstrapStream(c, flusher, handlers.StreamBootstrapOptions{
+		Execute: func() (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
+			return h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
+		},
+		SetSSEHeaders: setSSEHeaders,
+		WriteCommittedError: func(errMsg *interfaces.ErrorMessage) []byte {
+			framer.Flush(c.Writer)
+			if errMsg == nil {
+				return nil
 			}
-			// Upstream failed immediately. Return proper error status and JSON.
-			h.WriteErrorResponse(c, errMsg)
-			if errMsg != nil {
-				cliCancel(errMsg.Error)
-			} else {
-				cliCancel(nil)
+			status := http.StatusInternalServerError
+			if errMsg.StatusCode > 0 {
+				status = errMsg.StatusCode
 			}
-			return
-		case chunk, ok := <-dataChan:
-			if !ok {
-				// Stream closed without data? Send headers and done.
+			errText := http.StatusText(status)
+			if errMsg.Error != nil && errMsg.Error.Error() != "" {
+				errText = errMsg.Error.Error()
+			}
+			chunk := handlers.BuildOpenAIResponsesStreamErrorChunk(status, errText, 0)
+			_, _ = fmt.Fprintf(c.Writer, "\nevent: error\ndata: %s\n\n", string(chunk))
+			return chunk
+		},
+		WriteUncommittedError: func(errMsg *interfaces.ErrorMessage) { h.WriteErrorResponse(c, errMsg) },
+		OnFirstChunk: func(headersCommitted bool, upstreamHeaders http.Header, chunk []byte) {
+			if !headersCommitted {
 				setSSEHeaders()
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-				_, _ = c.Writer.Write([]byte("\n"))
-				flusher.Flush()
-				cliCancel(nil)
-				return
 			}
-
-			// Success! Set headers.
-			setSSEHeaders()
-			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-
 			// Write first chunk logic (matching forwardResponsesStream)
 			framer.WriteChunk(c.Writer, chunk)
 			flusher.Flush()
-
-			// Continue
-			h.forwardResponsesStream(c, flusher, func(err error) { cliCancel(err) }, dataChan, errChan, framer)
-			return
-		}
-	}
+		},
+		OnStreamClosedWithoutData: func(headersCommitted bool, upstreamHeaders http.Header) {
+			if !headersCommitted {
+				setSSEHeaders()
+				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+			}
+			_, _ = c.Writer.Write([]byte("\n"))
+		},
+		Forward: func(data <-chan []byte, errs <-chan *interfaces.ErrorMessage) {
+			h.forwardResponsesStream(c, flusher, func(err error) { cliCancel(err) }, data, errs, framer)
+		},
+		Cancel: func(err error) { cliCancel(err) },
+	})
 }
 
 func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage, framer *responsesSSEFramer) {

--- a/sdk/api/handlers/stream_bootstrap.go
+++ b/sdk/api/handlers/stream_bootstrap.go
@@ -101,10 +101,13 @@ func (h *BaseAPIHandler) BootstrapStream(c *gin.Context, flusher http.Flusher, o
 	)
 
 	if keepAliveInterval > 0 {
-		resultChan = make(chan bootstrapResult, 1)
+		// Capture the channel in a local the goroutine owns, so a later reassignment of
+		// resultChan in the select loop can never be observed by this send.
+		ch := make(chan bootstrapResult, 1)
+		resultChan = ch
 		go func() {
 			data, headers, errs := opts.Execute()
-			resultChan <- bootstrapResult{data: data, headers: headers, errs: errs}
+			ch <- bootstrapResult{data: data, headers: headers, errs: errs}
 		}()
 
 		ticker := time.NewTicker(keepAliveInterval)
@@ -115,6 +118,7 @@ func (h *BaseAPIHandler) BootstrapStream(c *gin.Context, flusher http.Flusher, o
 	}
 
 	headersCommitted := false
+	upstreamHeadersApplied := false
 
 	writeError := func(errMsg *interfaces.ErrorMessage) {
 		if headersCommitted {
@@ -149,6 +153,14 @@ func (h *BaseAPIHandler) BootstrapStream(c *gin.Context, flusher http.Flusher, o
 					opts.SetSSEHeaders()
 				}
 				headersCommitted = true
+			}
+			// If the upstream headers are already known (Execute returned them before the
+			// first payload, e.g. the plugin-executor path), apply them now so a slow first
+			// chunk does not drop them. On the auth-manager path they are still nil here and
+			// OnFirstChunk applies them on the uncommitted path as before.
+			if !upstreamHeadersApplied && upstreamHeaders != nil {
+				WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+				upstreamHeadersApplied = true
 			}
 			_, _ = c.Writer.Write([]byte(KeepAliveSSEComment))
 			flusher.Flush()

--- a/sdk/api/handlers/stream_bootstrap.go
+++ b/sdk/api/handlers/stream_bootstrap.go
@@ -1,0 +1,203 @@
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+)
+
+// StreamBootstrapOptions configures BootstrapStream. Every field that writes bytes to the
+// client is a callback because each protocol frames its headers, chunks and errors
+// differently, and because handlers such as Claude override WriteErrorResponse (embedding
+// gives no virtual dispatch, so the override has to be passed in explicitly).
+type StreamBootstrapOptions struct {
+	// KeepAliveInterval overrides the configured streaming keep-alive interval.
+	// If nil, the configured default is used. If set to <= 0, heartbeats are disabled
+	// and Execute runs synchronously, exactly as it did before keep-alives existed.
+	KeepAliveInterval *time.Duration
+
+	// Execute performs the blocking stream bootstrap (ExecuteStreamWithAuthManager).
+	// It returns only once the upstream produced its first payload chunk or an error.
+	Execute func() (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage)
+
+	// SetSSEHeaders commits the protocol response headers. A heartbeat calls this before
+	// the upstream headers are known, so it must not depend on them.
+	SetSSEHeaders func()
+
+	// WriteCommittedError writes errMsg into a stream whose headers are already committed
+	// (the HTTP status is gone, so the error has to travel in-band). It returns the raw
+	// error payload, which BootstrapStream appends to the request log so that errors
+	// arriving after a heartbeat are still captured, matching WriteErrorResponse.
+	WriteCommittedError func(errMsg *interfaces.ErrorMessage) []byte
+
+	// WriteUncommittedError writes errMsg before anything reached the client, i.e. the
+	// handler's normal WriteErrorResponse path with a real HTTP status.
+	WriteUncommittedError func(errMsg *interfaces.ErrorMessage)
+
+	// OnFirstChunk commits the headers unless headersCommitted is already true, then
+	// writes the first payload chunk.
+	OnFirstChunk func(headersCommitted bool, upstreamHeaders http.Header, chunk []byte)
+
+	// OnStreamClosedWithoutData terminates a stream that closed before any payload,
+	// again honouring headersCommitted.
+	OnStreamClosedWithoutData func(headersCommitted bool, upstreamHeaders http.Header)
+
+	// Forward continues streaming after the first chunk (the existing ForwardStream leg).
+	Forward func(data <-chan []byte, errs <-chan *interfaces.ErrorMessage)
+
+	// Cancel cancels the upstream request context and records the terminal error.
+	Cancel func(error)
+
+	// DrainPendingErrorOnClose makes a closed data channel check the error channel for a
+	// pending terminal error before finishing. Only the Claude handler does this today;
+	// enabling it elsewhere would change those handlers' terminal output.
+	DrainPendingErrorOnClose bool
+}
+
+// BootstrapStream waits for a streaming upstream to produce its first chunk while keeping
+// the client connection alive.
+//
+// A high-effort model reasoning over a large context can take minutes to produce its first
+// token. The upstream stays silent that whole time and Execute blocks until the first
+// payload chunk arrives, so with no bytes flowing the client treats the stream as idle and
+// disconnects, killing the request with "context canceled". The same gap reopens after
+// Execute returns on an error chunk: the SDK's background goroutine may perform a bootstrap
+// retry against a fresh (and equally silent) upstream while this loop waits.
+//
+// So Execute runs in its own goroutine and delivers its three return values over a channel,
+// while a single select loop here owns every write to the client: it heartbeats on each
+// tick, binds the real data/error channels when the result lands, and keeps the same ticker
+// running across the bootstrap-retry wait. One writer end to end means no mutex.
+//
+// The first heartbeat commits the response headers, which spends the HTTP status code; from
+// that point errors are reported in-band via WriteCommittedError. Requests that resolve
+// before the first tick (the common case, including immediate upstream errors) keep their
+// normal status. When the interval is <= 0 no goroutine is started and no ticker runs, so
+// the behaviour is byte-for-byte what it was before.
+func (h *BaseAPIHandler) BootstrapStream(c *gin.Context, flusher http.Flusher, opts StreamBootstrapOptions) {
+	if c == nil || opts.Execute == nil || opts.Cancel == nil {
+		return
+	}
+
+	keepAliveInterval := StreamingKeepAliveInterval(h.Cfg)
+	if opts.KeepAliveInterval != nil {
+		keepAliveInterval = *opts.KeepAliveInterval
+	}
+
+	type bootstrapResult struct {
+		data    <-chan []byte
+		headers http.Header
+		errs    <-chan *interfaces.ErrorMessage
+	}
+
+	var (
+		dataChan        <-chan []byte
+		errChan         <-chan *interfaces.ErrorMessage
+		upstreamHeaders http.Header
+		resultChan      chan bootstrapResult
+		keepAliveC      <-chan time.Time
+	)
+
+	if keepAliveInterval > 0 {
+		resultChan = make(chan bootstrapResult, 1)
+		go func() {
+			data, headers, errs := opts.Execute()
+			resultChan <- bootstrapResult{data: data, headers: headers, errs: errs}
+		}()
+
+		ticker := time.NewTicker(keepAliveInterval)
+		defer ticker.Stop()
+		keepAliveC = ticker.C
+	} else {
+		dataChan, upstreamHeaders, errChan = opts.Execute()
+	}
+
+	headersCommitted := false
+
+	writeError := func(errMsg *interfaces.ErrorMessage) {
+		if headersCommitted {
+			if opts.WriteCommittedError != nil {
+				if body := opts.WriteCommittedError(errMsg); len(body) > 0 {
+					appendAPIResponse(c, body)
+				}
+				flusher.Flush()
+			}
+		} else if opts.WriteUncommittedError != nil {
+			opts.WriteUncommittedError(errMsg)
+		}
+		if errMsg != nil {
+			opts.Cancel(errMsg.Error)
+		} else {
+			opts.Cancel(nil)
+		}
+	}
+
+	for {
+		select {
+		case <-c.Request.Context().Done():
+			opts.Cancel(c.Request.Context().Err())
+			return
+		case result := <-resultChan:
+			dataChan, upstreamHeaders, errChan = result.data, result.headers, result.errs
+			// Stop selecting on the result; the ticker keeps covering the bootstrap-retry wait.
+			resultChan = nil
+		case <-keepAliveC:
+			if !headersCommitted {
+				if opts.SetSSEHeaders != nil {
+					opts.SetSSEHeaders()
+				}
+				headersCommitted = true
+			}
+			_, _ = c.Writer.Write([]byte(KeepAliveSSEComment))
+			flusher.Flush()
+		case errMsg, ok := <-errChan:
+			if !ok {
+				// Err channel closed cleanly; wait for the data channel.
+				errChan = nil
+				continue
+			}
+			writeError(errMsg)
+			return
+		case chunk, ok := <-dataChan:
+			if !ok {
+				if opts.DrainPendingErrorOnClose {
+					if errMsg, pending := pendingStreamError(errChan); pending {
+						writeError(errMsg)
+						return
+					}
+				}
+				if opts.OnStreamClosedWithoutData != nil {
+					opts.OnStreamClosedWithoutData(headersCommitted, upstreamHeaders)
+				}
+				flusher.Flush()
+				opts.Cancel(nil)
+				return
+			}
+			if opts.OnFirstChunk != nil {
+				opts.OnFirstChunk(headersCommitted, upstreamHeaders, chunk)
+			}
+			if opts.Forward != nil {
+				opts.Forward(dataChan, errChan)
+			}
+			return
+		}
+	}
+}
+
+// pendingStreamError reports a terminal error that is already queued on errs, without blocking.
+func pendingStreamError(errs <-chan *interfaces.ErrorMessage) (*interfaces.ErrorMessage, bool) {
+	if errs == nil {
+		return nil, false
+	}
+	select {
+	case errMsg, ok := <-errs:
+		if !ok {
+			return nil, false
+		}
+		return errMsg, true
+	default:
+		return nil, false
+	}
+}

--- a/sdk/api/handlers/stream_forwarder.go
+++ b/sdk/api/handlers/stream_forwarder.go
@@ -8,6 +8,10 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 )
 
+// KeepAliveSSEComment is the SSE comment written as a heartbeat while a stream is idle.
+// Comments are ignored by SSE clients but keep the connection from going idle.
+const KeepAliveSSEComment = ": keep-alive\n\n"
+
 type StreamForwardOptions struct {
 	// KeepAliveInterval overrides the configured streaming keep-alive interval.
 	// If nil, the configured default is used. If set to <= 0, keep-alives are disabled.
@@ -45,7 +49,7 @@ func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, can
 	writeKeepAlive := opts.WriteKeepAlive
 	if writeKeepAlive == nil {
 		writeKeepAlive = func() {
-			_, _ = c.Writer.Write([]byte(": keep-alive\n\n"))
+			_, _ = c.Writer.Write([]byte(KeepAliveSSEComment))
 		}
 	}
 


### PR DESCRIPTION
## Problem

Streaming handlers call `ExecuteStreamWithAuthManager`, which blocks in `readInitialStreamChunks` until the upstream produces its first payload chunk. A high-effort model reasoning over a large context can take minutes to get there, and the proxy sends the client nothing that whole time, so the client treats the stream as idle and disconnects. The request then dies as `context canceled` (HTTP 500). `ForwardStream` already heartbeats, but only *after* the first chunk, so the pre-first-chunk window is uncovered.

This reproduces reliably with a large (~300k token) resume routed to a Codex/GPT tier at high reasoning effort: ~2-3 minutes to first token, no bytes to the client, client aborts.

## Fix

Add a shared `BootstrapStream` helper (`sdk/api/handlers/stream_bootstrap.go`) that covers that window. `Execute` runs in its own goroutine and delivers its three return values over a channel, while a single `select` loop owns every write to the client: it heartbeats on each tick, binds the real data/error channels when the result lands, and keeps the same ticker running afterwards so a slow or retried upstream stays covered. One writer end to end means no mutex.

The first heartbeat commits the response headers, which spends the HTTP status code, so errors after that point are reported in-band as an SSE `error` event and the raw error body is still appended to the request log, matching what `WriteErrorResponse` records. Requests that resolve before the first tick keep their normal status.

All four streaming handlers now share the helper: claude code, gemini `streamGenerateContent`, openai chat + completions, and openai responses. Gemini disables heartbeats for `alt` streams, which are raw JSON rather than SSE, the same way `forwardGeminiStream` already does.

## Compatibility

Keep-alives stay **off by default** (`StreamingKeepAliveInterval` returns 0). At interval `<= 0` no goroutine is started and no ticker runs, so behaviour is byte-for-byte unchanged. Set `streaming.keepalive-seconds` to enable. The `": keep-alive\n\n"` literal is now the `KeepAliveSSEComment` constant, shared with `ForwardStream`.

## Testing

- `go vet ./sdk/...` clean.
- `go test ./sdk/api/handlers/...` — all packages pass (4 new tests in `handlers_stream_bootstrap_test.go`: heartbeat precedes a delayed first chunk with a 200 status; error after a heartbeat commit is an SSE `error` event with a single WriteHeader; heartbeats continue across the bootstrap-retry wait; post-bind silence keeps heartbeating).
- `go test -race ./sdk/api/handlers/{claude,gemini,openai}/...` clean; the helper's own tests are race-clean.
- Verified end to end against a live upstream: with `keepalive-seconds` set, a heartbeat is delivered during the wait and the stream then completes normally; a large resume that previously died with `context canceled` now succeeds.
