### PR TITLE
feat(executor): add automatic request compression

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -44,6 +44,16 @@ api-keys:
 # Enable debug logging
 debug: false
 
+# Upstream request body compression (experimental).
+# Supported values: "off" (default) and "auto". Auto uses only the encoding
+# verified for each provider (Claude: gzip; Codex: zstd). Providers without
+# verified support always stay uncompressed.
+# Bodies smaller than request-compression-min-size are sent uncompressed.
+# The optional minimum size accepts positive integer KiB values and defaults to 16 KiB.
+# Enable debug logging to observe compression ratios.
+# request-compression: "off"
+# request-compression-min-size: "16k"
+
 # Enable pprof HTTP debug server (host:port). Keep it bound to localhost for safety.
 pprof:
   enable: false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -771,6 +771,14 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		}
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
+	if err = cfg.NormalizeRequestCompression(); err != nil {
+		if optional {
+			cfgOptional := &Config{}
+			cfgOptional.NormalizePluginsConfig()
+			return cfgOptional, nil
+		}
+		return nil, err
+	}
 
 	// Hash remote management key if plaintext is detected (nested)
 	// We consider a value to be already hashed if it looks like a bcrypt hash ($2a$, $2b$, or $2y$ prefix).

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -36,6 +36,9 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parse config payload: %w", err)
 	}
+	if err := cfg.NormalizeRequestCompression(); err != nil {
+		return nil, err
+	}
 
 	// Hash remote management key if plaintext is detected (nested), but do NOT persist.
 	if cfg.RemoteManagement.SecretKey != "" && !looksLikeBcrypt(cfg.RemoteManagement.SecretKey) {

--- a/internal/config/request_compression.go
+++ b/internal/config/request_compression.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	// RequestCompressionOff disables upstream request body compression.
+	RequestCompressionOff = "off"
+	// RequestCompressionAuto applies the provider's verified compression encoding.
+	RequestCompressionAuto = "auto"
+
+	// DefaultRequestCompressionMinBytes is the default minimum uncompressed body
+	// size required before upstream request compression is applied.
+	DefaultRequestCompressionMinBytes = 16 << 10 // 16 KiB
+)
+
+// NormalizeRequestCompression normalizes and validates request compression
+// configuration values. Empty values retain their serialized form and use
+// effective defaults at runtime.
+func (cfg *Config) NormalizeRequestCompression() error {
+	if cfg == nil {
+		return nil
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(cfg.RequestCompression))
+	switch mode {
+	case "", RequestCompressionOff, RequestCompressionAuto:
+		cfg.RequestCompression = mode
+	default:
+		return fmt.Errorf("invalid request-compression value %q (allowed: auto, off)", cfg.RequestCompression)
+	}
+
+	_, normalizedMinSize, err := parseRequestCompressionMinSize(cfg.RequestCompressionMinSize)
+	if err != nil {
+		return err
+	}
+	cfg.RequestCompressionMinSize = normalizedMinSize
+	return nil
+}
+
+// EffectiveRequestCompressionMode returns the mode used at runtime. Invalid
+// programmatic values fail closed and disable compression.
+func (cfg *Config) EffectiveRequestCompressionMode() string {
+	if cfg == nil {
+		return RequestCompressionOff
+	}
+
+	switch strings.ToLower(strings.TrimSpace(cfg.RequestCompression)) {
+	case RequestCompressionAuto:
+		return RequestCompressionAuto
+	case "", RequestCompressionOff:
+		return RequestCompressionOff
+	default:
+		return RequestCompressionOff
+	}
+}
+
+// EffectiveRequestCompressionMinBytes returns the configured request size
+// threshold in bytes. Invalid programmatic values use the default threshold.
+func (cfg *Config) EffectiveRequestCompressionMinBytes() int {
+	if cfg == nil {
+		return DefaultRequestCompressionMinBytes
+	}
+
+	minBytes, _, err := parseRequestCompressionMinSize(cfg.RequestCompressionMinSize)
+	if err != nil {
+		return DefaultRequestCompressionMinBytes
+	}
+	return minBytes
+}
+
+func parseRequestCompressionMinSize(raw string) (int, string, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return DefaultRequestCompressionMinBytes, "", nil
+	}
+	if len(value) < 2 || value[len(value)-1] != 'k' && value[len(value)-1] != 'K' {
+		return 0, "", fmt.Errorf("invalid request-compression-min-size value %q (expected a positive integer followed by k, for example 16k)", raw)
+	}
+
+	kibibytes, err := strconv.ParseUint(value[:len(value)-1], 10, 64)
+	if err != nil || kibibytes == 0 {
+		return 0, "", fmt.Errorf("invalid request-compression-min-size value %q (expected a positive integer followed by k, for example 16k)", raw)
+	}
+
+	const bytesPerKiB = 1024
+	maxInt := uint64(^uint(0) >> 1)
+	if kibibytes > maxInt/bytesPerKiB {
+		return 0, "", fmt.Errorf("request-compression-min-size value %q is too large", raw)
+	}
+
+	return int(kibibytes * bytesPerKiB), strconv.FormatUint(kibibytes, 10) + "k", nil
+}

--- a/internal/config/request_compression_test.go
+++ b/internal/config/request_compression_test.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseConfigBytesNormalizesRequestCompression(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte("request-compression: ' AUTO '\nrequest-compression-min-size: '16K'\n"))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes: %v", err)
+	}
+	if cfg.RequestCompression != RequestCompressionAuto {
+		t.Fatalf("mode: got %q, want %q", cfg.RequestCompression, RequestCompressionAuto)
+	}
+	if cfg.RequestCompressionMinSize != "16k" {
+		t.Fatalf("minimum size: got %q, want 16k", cfg.RequestCompressionMinSize)
+	}
+	if cfg.EffectiveRequestCompressionMinBytes() != 16<<10 {
+		t.Fatalf("effective threshold: got %d, want %d", cfg.EffectiveRequestCompressionMinBytes(), 16<<10)
+	}
+}
+
+func TestRequestCompressionDefaults(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte("debug: false\n"))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes: %v", err)
+	}
+	if cfg.RequestCompression != "" {
+		t.Fatalf("serialized mode: got %q, want empty", cfg.RequestCompression)
+	}
+	if cfg.EffectiveRequestCompressionMode() != RequestCompressionOff {
+		t.Fatalf("effective mode: got %q, want %q", cfg.EffectiveRequestCompressionMode(), RequestCompressionOff)
+	}
+	if cfg.EffectiveRequestCompressionMinBytes() != DefaultRequestCompressionMinBytes {
+		t.Fatalf("effective threshold: got %d, want %d", cfg.EffectiveRequestCompressionMinBytes(), DefaultRequestCompressionMinBytes)
+	}
+}
+
+func TestRequestCompressionRejectsInvalidValues(t *testing.T) {
+	for _, data := range []string{
+		"request-compression: gzip\n",
+		"request-compression: zstd\n",
+		"request-compression: br\n",
+		"request-compression-min-size: 0k\n",
+		"request-compression-min-size: 16\n",
+		"request-compression-min-size: 16kb\n",
+		"request-compression-min-size: 1.5k\n",
+		"request-compression-min-size: -1k\n",
+		"request-compression-min-size: 999999999999999999999999999999999999999k\n",
+	} {
+		if _, err := ParseConfigBytes([]byte(data)); err == nil {
+			t.Fatalf("ParseConfigBytes(%q): expected error", data)
+		}
+	}
+}
+
+func TestLoadConfigNormalizesRequestCompression(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("request-compression: OFF\nrequest-compression-min-size: 32K\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.RequestCompression != RequestCompressionOff {
+		t.Fatalf("mode: got %q, want %q", cfg.RequestCompression, RequestCompressionOff)
+	}
+	if cfg.RequestCompressionMinSize != "32k" {
+		t.Fatalf("minimum size: got %q, want 32k", cfg.RequestCompressionMinSize)
+	}
+	if cfg.EffectiveRequestCompressionMinBytes() != 32<<10 {
+		t.Fatalf("effective threshold: got %d, want %d", cfg.EffectiveRequestCompressionMinBytes(), 32<<10)
+	}
+}

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -42,6 +42,16 @@ type SDKConfig struct {
 	// RequestLog enables or disables detailed request logging functionality.
 	RequestLog bool `yaml:"request-log" json:"request-log"`
 
+	// RequestCompression controls upstream request body compression. Supported
+	// values are "off" (default) and "auto". Auto uses only the encoding verified
+	// for each provider.
+	RequestCompression string `yaml:"request-compression,omitempty" json:"request-compression,omitempty"`
+
+	// RequestCompressionMinSize is the minimum uncompressed body size required
+	// before request compression is applied. It accepts positive integer KiB
+	// values such as "16k" and defaults to 16 KiB when empty.
+	RequestCompressionMinSize string `yaml:"request-compression-min-size,omitempty" json:"request-compression-min-size,omitempty"`
+
 	// APIKeys is a list of keys for authenticating clients to this proxy server.
 	APIKeys []string `yaml:"api-keys" json:"api-keys"`
 

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -351,9 +351,13 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	reporter.SetTranslatedReasoningEffort(bodyForUpstream, to.String())
 
 	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyForUpstream))
+	wireBody, contentEncoding := helps.MaybeCompressRequestBodyContext(ctx, e.cfg, e.Identifier(), bodyForUpstream)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(wireBody))
 	if err != nil {
 		return resp, err
+	}
+	if contentEncoding != "" {
+		httpReq.Header.Set("Content-Encoding", contentEncoding)
 	}
 	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg, opts.Headers); errHeaders != nil {
 		return resp, errHeaders
@@ -542,9 +546,13 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	reporter.SetTranslatedReasoningEffort(bodyForUpstream, to.String())
 
 	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyForUpstream))
+	wireBody, contentEncoding := helps.MaybeCompressRequestBodyContext(ctx, e.cfg, e.Identifier(), bodyForUpstream)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(wireBody))
 	if err != nil {
 		return nil, err
+	}
+	if contentEncoding != "" {
+		httpReq.Header.Set("Content-Encoding", contentEncoding)
 	}
 	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, true, extraBetas, e.cfg, opts.Headers); errHeaders != nil {
 		return nil, errHeaders
@@ -801,9 +809,13 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	body = sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, body, baseModel)
 
 	url := fmt.Sprintf("%s/v1/messages/count_tokens?beta=true", baseURL)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	wireBody, contentEncoding := helps.MaybeCompressRequestBodyContext(ctx, e.cfg, e.Identifier(), body)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(wireBody))
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
+	}
+	if contentEncoding != "" {
+		httpReq.Header.Set("Content-Encoding", contentEncoding)
 	}
 	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg, opts.Headers); errHeaders != nil {
 		return cliproxyexecutor.Response{}, errHeaders

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1815,9 +1815,13 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 	if identityState.promptCacheKey != "" {
 		cache.ID = identityState.promptCacheKey
 	}
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(rawJSON))
+	wireBody, contentEncoding := helps.MaybeCompressRequestBody(e.cfg, e.Identifier(), rawJSON)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(wireBody))
 	if err != nil {
 		return nil, nil, codexIdentityConfuseState{}, err
+	}
+	if contentEncoding != "" {
+		httpReq.Header.Set("Content-Encoding", contentEncoding)
 	}
 	if cache.ID != "" {
 		httpReq.Header.Set("Session_id", cache.ID)

--- a/internal/runtime/executor/helps/request_compression.go
+++ b/internal/runtime/executor/helps/request_compression.go
@@ -1,0 +1,206 @@
+package helps
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	log "github.com/sirupsen/logrus"
+)
+
+// RequestCompressionCapable reports whether the given provider path is
+// business-verified to accept a compressed upstream request body. The
+// capability matrix lives in code (not config) because support differs per
+// provider and per path, and was established by live probing:
+//   - claude: accepts Content-Encoding: gzip (zstd is rejected with a 400).
+//   - codex: accepts Content-Encoding: zstd (gzip is rejected with a 400);
+//     matches the official Codex CLI enable_request_compression behavior.
+//   - kimi: NOT capable. Live probing contradicts an early assumption: BOTH
+//     Kimi endpoints reject compressed request bodies with a 400 — the native
+//     /v1/chat/completions path AND the Anthropic-compatible /v1/messages
+//     path served by the ClaudeExecutor embedded in KimiExecutor (gzip, both
+//     streaming and non-streaming). Kimi therefore stays uncompressed.
+func RequestCompressionCapable(provider string) bool {
+	return RequestCompressionDefaultEncoding(provider) != ""
+}
+
+// RequestCompressionDefaultEncoding returns the encoding verified to work for
+// the given provider, or "" when the provider has no verified compression
+// support.
+func RequestCompressionDefaultEncoding(provider string) string {
+	switch provider {
+	case "claude":
+		return "gzip"
+	case "codex":
+		return "zstd"
+	default:
+		return ""
+	}
+}
+
+var gzipWriterPool = sync.Pool{
+	New: func() any {
+		writer, err := gzip.NewWriterLevel(io.Discard, gzip.BestSpeed)
+		if err != nil {
+			return gzip.NewWriter(io.Discard)
+		}
+		return writer
+	},
+}
+
+var (
+	zstdEncoderOnce sync.Once
+	zstdEncoder     *zstd.Encoder
+	zstdEncoderErr  error
+)
+
+type requestCompressionProviderOverrideKey struct{}
+
+// WithRequestCompressionProvider returns a context that makes
+// MaybeCompressRequestBody use providerOverride instead of the executing
+// provider's own identity.
+func WithRequestCompressionProvider(ctx context.Context, providerOverride string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, requestCompressionProviderOverrideKey{}, providerOverride)
+}
+
+// requestCompressionProvider resolves the effective provider identity for
+// compression decisions: the context override when set, else the executing
+// provider.
+func requestCompressionProvider(ctx context.Context, provider string) string {
+	if ctx != nil {
+		if override, ok := ctx.Value(requestCompressionProviderOverrideKey{}).(string); ok && override != "" {
+			return override
+		}
+	}
+	return provider
+}
+
+// requestCompressionEncodingForProvider resolves the effective Content-Encoding
+// for a provider from the configured mode:
+//   - "off" -> "" (never compress)
+//   - "auto" -> the provider's verified default encoding
+func requestCompressionEncodingForProvider(cfg *config.Config, provider string) (encoding, mode string) {
+	if cfg == nil {
+		return "", config.RequestCompressionOff
+	}
+
+	mode = cfg.EffectiveRequestCompressionMode()
+	if mode != config.RequestCompressionAuto {
+		return "", mode
+	}
+	return RequestCompressionDefaultEncoding(provider), mode
+}
+
+// MaybeCompressRequestBody compresses an upstream request body according to
+// cfg.RequestCompression and the provider's verified capability (see
+// RequestCompressionCapable). Bodies below the configured threshold are
+// returned unchanged. The returned encoding is the Content-Encoding value to
+// set on the request, or "" when the body was not modified. Invalid direct
+// configuration values disable compression and log a warning.
+func MaybeCompressRequestBody(cfg *config.Config, provider string, body []byte) ([]byte, string) {
+	return MaybeCompressRequestBodyContext(nil, cfg, provider, body)
+}
+
+// MaybeCompressRequestBodyContext is MaybeCompressRequestBody with a context
+// that may carry a provider identity override set via
+// WithRequestCompressionProvider.
+func MaybeCompressRequestBodyContext(ctx context.Context, cfg *config.Config, provider string, body []byte) ([]byte, string) {
+	provider = requestCompressionProvider(ctx, provider)
+	if cfg == nil || len(body) == 0 {
+		return body, ""
+	}
+
+	encoding, mode := requestCompressionEncodingForProvider(cfg, provider)
+	if encoding == "" {
+		rawMode := strings.ToLower(strings.TrimSpace(cfg.RequestCompression))
+		if rawMode != "" && rawMode != config.RequestCompressionOff && rawMode != config.RequestCompressionAuto {
+			log.Warnf("request compression: unsupported mode %q for provider %s, sending uncompressed", cfg.RequestCompression, provider)
+		}
+		return body, ""
+	}
+
+	minBytes := cfg.EffectiveRequestCompressionMinBytes()
+	if len(body) < minBytes {
+		return body, ""
+	}
+
+	var (
+		compressed []byte
+		err        error
+	)
+	switch encoding {
+	case "gzip":
+		compressed, err = compressGzip(body)
+	case "zstd":
+		compressed, err = compressZstd(body)
+	default:
+		err = fmt.Errorf("unsupported encoding %q", encoding)
+	}
+	if err != nil {
+		log.Warnf("request compression: failed to compress %d bytes for provider %s with %s: %v; sending uncompressed", len(body), provider, encoding, err)
+		return body, ""
+	}
+
+	ratio := float64(len(compressed)) / float64(len(body))
+	log.Debugf("request compression: provider=%s mode=%s encoding=%s original_bytes=%d compressed_bytes=%d ratio=%.3f", provider, mode, encoding, len(body), len(compressed), ratio)
+	return compressed, encoding
+}
+
+func compressGzip(body []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	buf.Grow(len(body) / 2)
+
+	writer, ok := gzipWriterPool.Get().(*gzip.Writer)
+	if !ok || writer == nil {
+		writer = gzip.NewWriter(io.Discard)
+	}
+	defer func() {
+		writer.Reset(io.Discard)
+		gzipWriterPool.Put(writer)
+	}()
+
+	writer.Reset(&buf)
+	if _, err := writer.Write(body); err != nil {
+		return nil, fmt.Errorf("gzip write: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("gzip close: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func compressZstd(body []byte) (compressed []byte, err error) {
+	encoder, err := requestCompressionZstdEncoder()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			compressed = nil
+			err = fmt.Errorf("zstd encode: %v", recovered)
+		}
+	}()
+	return encoder.EncodeAll(body, nil), nil
+}
+
+func requestCompressionZstdEncoder() (*zstd.Encoder, error) {
+	zstdEncoderOnce.Do(func() {
+		zstdEncoder, zstdEncoderErr = zstd.NewWriter(nil,
+			zstd.WithEncoderLevel(zstd.SpeedDefault),
+			zstd.WithEncoderConcurrency(1),
+		)
+	})
+	if zstdEncoderErr != nil {
+		return nil, fmt.Errorf("create zstd encoder: %w", zstdEncoderErr)
+	}
+	return zstdEncoder, nil
+}

--- a/internal/runtime/executor/helps/request_compression_test.go
+++ b/internal/runtime/executor/helps/request_compression_test.go
@@ -1,0 +1,270 @@
+package helps
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func testConfig(mode string) *config.Config {
+	return &config.Config{SDKConfig: config.SDKConfig{RequestCompression: mode}}
+}
+
+func bigBody() []byte {
+	return bytes.Repeat([]byte(`{"role":"user","content":"hello world"} `), 4096)
+}
+
+func TestMaybeCompressRequestBodyOff(t *testing.T) {
+	body := bigBody()
+	for _, mode := range []string{"", "off", "OFF"} {
+		for _, provider := range []string{"claude", "codex", "kimi"} {
+			got, enc := MaybeCompressRequestBody(testConfig(mode), provider, body)
+			if enc != "" {
+				t.Fatalf("mode %q provider %s: expected empty encoding, got %q", mode, provider, enc)
+			}
+			if !bytes.Equal(got, body) {
+				t.Fatalf("mode %q provider %s: body was modified while disabled", mode, provider)
+			}
+		}
+	}
+}
+
+func TestMaybeCompressRequestBodyAutoUsesProviderDefault(t *testing.T) {
+	body := bigBody()
+	cases := map[string]string{
+		"claude": "gzip",
+		"codex":  "zstd",
+		"kimi":   "",
+		"gemini": "",
+	}
+	for provider, wantEnc := range cases {
+		_, enc := MaybeCompressRequestBody(testConfig("auto"), provider, body)
+		if enc != wantEnc {
+			t.Fatalf("auto provider %s: expected encoding %q, got %q", provider, wantEnc, enc)
+		}
+	}
+}
+
+func TestMaybeCompressRequestBodyInvalidModeFailsClosed(t *testing.T) {
+	body := bigBody()
+	for _, mode := range []string{"gzip", "zstd", "br"} {
+		got, enc := MaybeCompressRequestBody(testConfig(mode), "claude", body)
+		if enc != "" {
+			t.Fatalf("mode %q: expected passthrough, got %q", mode, enc)
+		}
+		if !bytes.Equal(got, body) {
+			t.Fatalf("mode %q: body was modified", mode)
+		}
+	}
+}
+
+func TestMaybeCompressRequestBodyThreshold(t *testing.T) {
+	cfg := testConfig("auto")
+	cfg.RequestCompressionMinSize = "16k"
+
+	belowThreshold := bytes.Repeat([]byte("x"), config.DefaultRequestCompressionMinBytes-1)
+	got, enc := MaybeCompressRequestBody(cfg, "claude", belowThreshold)
+	if enc != "" || !bytes.Equal(got, belowThreshold) {
+		t.Fatalf("expected passthrough below threshold, got encoding=%q len=%d", enc, len(got))
+	}
+
+	atThreshold := bytes.Repeat([]byte("x"), config.DefaultRequestCompressionMinBytes)
+	_, enc = MaybeCompressRequestBody(cfg, "claude", atThreshold)
+	if enc != "gzip" {
+		t.Fatalf("expected compression at threshold, got %q", enc)
+	}
+}
+
+func TestMaybeCompressRequestBodyCustomThreshold(t *testing.T) {
+	cfg := testConfig("auto")
+	cfg.RequestCompressionMinSize = "1024k"
+	body := bytes.Repeat([]byte("y"), 64<<10)
+	_, enc := MaybeCompressRequestBody(cfg, "claude", body)
+	if enc != "" {
+		t.Fatalf("expected passthrough below custom threshold, got %q", enc)
+	}
+}
+
+func TestMaybeCompressRequestBodyRoundtrip(t *testing.T) {
+	body := bigBody()
+
+	gzipBody, enc := MaybeCompressRequestBody(testConfig("auto"), "claude", body)
+	if enc != "gzip" {
+		t.Fatalf("expected gzip, got %q", enc)
+	}
+	gzReader, err := gzip.NewReader(bytes.NewReader(gzipBody))
+	if err != nil {
+		t.Fatalf("gzip.NewReader: %v", err)
+	}
+	roundtrip, err := io.ReadAll(gzReader)
+	if err != nil {
+		t.Fatalf("gzip read: %v", err)
+	}
+	if err := gzReader.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	if !bytes.Equal(roundtrip, body) {
+		t.Fatalf("gzip roundtrip mismatch")
+	}
+
+	zstdBody, enc := MaybeCompressRequestBody(testConfig("auto"), "codex", body)
+	if enc != "zstd" {
+		t.Fatalf("expected zstd, got %q", enc)
+	}
+	zsReader, err := zstd.NewReader(bytes.NewReader(zstdBody))
+	if err != nil {
+		t.Fatalf("zstd.NewReader: %v", err)
+	}
+	defer zsReader.Close()
+	roundtrip, err = io.ReadAll(zsReader)
+	if err != nil {
+		t.Fatalf("zstd read: %v", err)
+	}
+	if !bytes.Equal(roundtrip, body) {
+		t.Fatalf("zstd roundtrip mismatch")
+	}
+}
+
+func TestMaybeCompressRequestBodyNilConfig(t *testing.T) {
+	body := []byte(`{}`)
+	got, enc := MaybeCompressRequestBody(nil, "claude", body)
+	if enc != "" || !bytes.Equal(got, body) {
+		t.Fatalf("expected passthrough for nil config")
+	}
+}
+
+func TestRequestCompressionCapabilityMatrix(t *testing.T) {
+	if !RequestCompressionCapable("claude") || !RequestCompressionCapable("codex") {
+		t.Fatalf("claude and codex must be compression capable")
+	}
+	for _, provider := range []string{"kimi", "kimi/anthropic", "gemini", "antigravity", ""} {
+		if RequestCompressionCapable(provider) {
+			t.Fatalf("provider %q must not be compression capable", provider)
+		}
+	}
+	if got := RequestCompressionDefaultEncoding("claude"); got != "gzip" {
+		t.Fatalf("claude default encoding: expected gzip, got %q", got)
+	}
+	if got := RequestCompressionDefaultEncoding("codex"); got != "zstd" {
+		t.Fatalf("codex default encoding: expected zstd, got %q", got)
+	}
+	if got := RequestCompressionDefaultEncoding("kimi"); got != "" {
+		t.Fatalf("kimi default encoding: expected empty, got %q", got)
+	}
+	if got := RequestCompressionDefaultEncoding("kimi/anthropic"); got != "" {
+		t.Fatalf("kimi/anthropic default encoding: expected empty, got %q", got)
+	}
+}
+
+func TestMaybeCompressRequestBodyContextProviderOverride(t *testing.T) {
+	body := bigBody()
+	ctx := WithRequestCompressionProvider(nil, "kimi")
+	_, enc := MaybeCompressRequestBodyContext(ctx, testConfig("auto"), "claude", body)
+	if enc != "" {
+		t.Fatalf("override to incapable provider: expected passthrough, got %q", enc)
+	}
+	_, enc = MaybeCompressRequestBodyContext(nil, testConfig("auto"), "claude", body)
+	if enc != "gzip" {
+		t.Fatalf("no override: expected gzip, got %q", enc)
+	}
+}
+
+func TestMaybeCompressRequestBodyGzipWriterReuse(t *testing.T) {
+	cfg := testConfig("auto")
+	bodies := [][]byte{
+		bytes.Repeat([]byte("first payload "), 4096),
+		bytes.Repeat([]byte("second payload "), 4096),
+	}
+	for _, body := range bodies {
+		compressed, encoding := MaybeCompressRequestBody(cfg, "claude", body)
+		if encoding != "gzip" {
+			t.Fatalf("encoding: got %q, want gzip", encoding)
+		}
+		reader, err := gzip.NewReader(bytes.NewReader(compressed))
+		if err != nil {
+			t.Fatalf("gzip.NewReader: %v", err)
+		}
+		decompressed, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatalf("read gzip body: %v", err)
+		}
+		if err := reader.Close(); err != nil {
+			t.Fatalf("close gzip reader: %v", err)
+		}
+		if !bytes.Equal(decompressed, body) {
+			t.Fatalf("gzip writer reuse corrupted body")
+		}
+	}
+}
+
+func TestMaybeCompressRequestBodyConcurrent(t *testing.T) {
+	cfg := testConfig("auto")
+	type compressionRequest struct {
+		provider string
+		body     []byte
+	}
+	cases := make([]compressionRequest, 0, 32)
+	for index := 0; index < cap(cases); index++ {
+		provider := "claude"
+		if index%2 == 1 {
+			provider = "codex"
+		}
+		cases = append(cases, compressionRequest{
+			provider: provider,
+			body:     bytes.Repeat([]byte{byte(index)}, config.DefaultRequestCompressionMinBytes),
+		})
+	}
+
+	var group sync.WaitGroup
+	errs := make(chan error, len(cases))
+	for _, request := range cases {
+		group.Add(1)
+		go func(request compressionRequest) {
+			defer group.Done()
+			compressed, encoding := MaybeCompressRequestBody(cfg, request.provider, request.body)
+			var decompressed []byte
+			var err error
+			switch encoding {
+			case "gzip":
+				reader, errReader := gzip.NewReader(bytes.NewReader(compressed))
+				if errReader != nil {
+					errs <- errReader
+					return
+				}
+				decompressed, err = io.ReadAll(reader)
+				if errClose := reader.Close(); err == nil {
+					err = errClose
+				}
+			case "zstd":
+				reader, errReader := zstd.NewReader(bytes.NewReader(compressed))
+				if errReader != nil {
+					errs <- errReader
+					return
+				}
+				decompressed, err = io.ReadAll(reader)
+				reader.Close()
+			default:
+				errs <- fmt.Errorf("provider %s returned encoding %q", request.provider, encoding)
+				return
+			}
+			if err != nil {
+				errs <- err
+				return
+			}
+			if !bytes.Equal(decompressed, request.body) {
+				errs <- fmt.Errorf("provider %s returned corrupted body", request.provider)
+			}
+		}(request)
+	}
+	group.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+}

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -85,7 +85,13 @@ func (e *KimiExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth,
 func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	from := opts.SourceFormat
 	if from.String() == "claude" {
+		// The Claude-compatible path is served by the embedded ClaudeExecutor.
+		// Mark the compression identity so a future "kimi/anthropic" capability
+		// entry would apply here instead of the delegate's "claude" one; today
+		// Kimi is not compression-capable on any probed endpoint, so this
+		// currently keeps the body uncompressed under every hint.
 		auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
+		ctx = helps.WithRequestCompressionProvider(ctx, "kimi/anthropic")
 		return e.ClaudeExecutor.Execute(ctx, auth, req, opts)
 	}
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
@@ -128,9 +134,13 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 	reporter.SetTranslatedReasoningEffort(body, e.Identifier())
 
 	url := kimiauth.KimiAPIBaseURL + "/v1/chat/completions"
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	wireBody, contentEncoding := helps.MaybeCompressRequestBody(e.cfg, e.Identifier(), body)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(wireBody))
 	if err != nil {
 		return resp, err
+	}
+	if contentEncoding != "" {
+		httpReq.Header.Set("Content-Encoding", contentEncoding)
 	}
 	applyKimiHeadersWithAuth(httpReq, token, false, auth)
 	var attrs map[string]string
@@ -195,7 +205,10 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	from := opts.SourceFormat
 	if from.String() == "claude" {
+		// See Execute: the Claude-compatible path overrides the compression
+		// identity to "kimi/anthropic".
 		auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
+		ctx = helps.WithRequestCompressionProvider(ctx, "kimi/anthropic")
 		return e.ClaudeExecutor.ExecuteStream(ctx, auth, req, opts)
 	}
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
@@ -241,9 +254,13 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 	reporter.SetTranslatedReasoningEffort(body, e.Identifier())
 
 	url := kimiauth.KimiAPIBaseURL + "/v1/chat/completions"
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	wireBody, contentEncoding := helps.MaybeCompressRequestBody(e.cfg, e.Identifier(), body)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(wireBody))
 	if err != nil {
 		return nil, err
+	}
+	if contentEncoding != "" {
+		httpReq.Header.Set("Content-Encoding", contentEncoding)
 	}
 	applyKimiHeadersWithAuth(httpReq, token, true, auth)
 	var attrs map[string]string
@@ -336,6 +353,8 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 // CountTokens estimates token count for Kimi requests.
 func (e *KimiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
+	req.Model = normalizeKimiUpstreamModel(req.Model)
+	ctx = helps.WithRequestCompressionProvider(ctx, "kimi/anthropic")
 	return e.ClaudeExecutor.CountTokens(ctx, auth, req, opts)
 }
 

--- a/internal/runtime/executor/kimi_request_compression_test.go
+++ b/internal/runtime/executor/kimi_request_compression_test.go
@@ -1,0 +1,70 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+type kimiRequestCompressionRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f kimiRequestCompressionRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestKimiExecutorCountTokensDoesNotCompressClaudeCompatibleRequests(t *testing.T) {
+	var (
+		contentEncoding string
+		body            []byte
+	)
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRequestCompressionRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		contentEncoding = req.Header.Get("Content-Encoding")
+		var err error
+		body, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"input_tokens":42}`)),
+			Request:    req,
+		}, nil
+	}))
+
+	executor := NewKimiExecutor(&config.Config{SDKConfig: config.SDKConfig{RequestCompression: config.RequestCompressionAuto}})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-123"}}
+	payload := []byte(`{"messages":[{"role":"user","content":"` + strings.Repeat("x", config.DefaultRequestCompressionMinBytes) + `"}]}`)
+
+	_, err := executor.CountTokens(ctx, auth, cliproxyexecutor.Request{
+		Model:   "kimi-k3",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("CountTokens: %v", err)
+	}
+	if contentEncoding != "" {
+		t.Fatalf("Content-Encoding: got %q, want empty", contentEncoding)
+	}
+	if !bytes.HasPrefix(body, []byte("{")) {
+		t.Fatalf("request body is not JSON: %q", body[:min(len(body), 32)])
+	}
+	if !bytes.Contains(body, []byte(`"model":"k3"`)) {
+		t.Fatalf("upstream model was not normalized: %s", body)
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -63,6 +63,12 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.RequestLog != newCfg.RequestLog {
 		changes = append(changes, fmt.Sprintf("request-log: %t -> %t", oldCfg.RequestLog, newCfg.RequestLog))
 	}
+	if oldCfg.EffectiveRequestCompressionMode() != newCfg.EffectiveRequestCompressionMode() {
+		changes = append(changes, fmt.Sprintf("request-compression: %s -> %s", oldCfg.EffectiveRequestCompressionMode(), newCfg.EffectiveRequestCompressionMode()))
+	}
+	if oldCfg.EffectiveRequestCompressionMinBytes() != newCfg.EffectiveRequestCompressionMinBytes() {
+		changes = append(changes, fmt.Sprintf("request-compression-min-size: %dk -> %dk", oldCfg.EffectiveRequestCompressionMinBytes()/1024, newCfg.EffectiveRequestCompressionMinBytes()/1024))
+	}
 	if oldCfg.LogsMaxTotalSizeMB != newCfg.LogsMaxTotalSizeMB {
 		changes = append(changes, fmt.Sprintf("logs-max-total-size-mb: %d -> %d", oldCfg.LogsMaxTotalSizeMB, newCfg.LogsMaxTotalSizeMB))
 	}

--- a/internal/watcher/diff/request_compression_test.go
+++ b/internal/watcher/diff/request_compression_test.go
@@ -1,0 +1,28 @@
+package diff
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestBuildConfigChangeDetailsRequestCompression(t *testing.T) {
+	oldCfg := &config.Config{SDKConfig: config.SDKConfig{RequestCompression: "off", RequestCompressionMinSize: "16k"}}
+	newCfg := &config.Config{SDKConfig: config.SDKConfig{RequestCompression: "auto", RequestCompressionMinSize: "32k"}}
+
+	details := BuildConfigChangeDetails(oldCfg, newCfg)
+	expectContains(t, details, "request-compression: off -> auto")
+	expectContains(t, details, "request-compression-min-size: 16k -> 32k")
+}
+
+func TestBuildConfigChangeDetailsRequestCompressionIgnoresExplicitDefault(t *testing.T) {
+	oldCfg := &config.Config{}
+	newCfg := &config.Config{SDKConfig: config.SDKConfig{RequestCompressionMinSize: "16k"}}
+
+	for _, detail := range BuildConfigChangeDetails(oldCfg, newCfg) {
+		if strings.HasPrefix(detail, "request-compression") {
+			t.Fatalf("unexpected effective compression change: %s", detail)
+		}
+	}
+}

--- a/internal/watcher/request_compression_test.go
+++ b/internal/watcher/request_compression_test.go
@@ -1,0 +1,49 @@
+package watcher
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestReloadConfigIfChangedRequestCompression(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeConfig := func(data string) {
+		t.Helper()
+		if err := os.WriteFile(configPath, []byte(data), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+	}
+
+	var received *config.Config
+	reloads := 0
+	w := &Watcher{
+		configPath: configPath,
+		reloadCallback: func(cfg *config.Config) {
+			reloads++
+			received = cfg
+		},
+	}
+
+	writeConfig("request-compression: auto\nrequest-compression-min-size: 32k\n")
+	w.reloadConfigIfChanged()
+	if reloads != 1 {
+		t.Fatalf("reload count: got %d, want 1", reloads)
+	}
+	if received == nil || received.EffectiveRequestCompressionMode() != config.RequestCompressionAuto || received.EffectiveRequestCompressionMinBytes() != 32<<10 {
+		t.Fatalf("unexpected reloaded compression config: %+v", received)
+	}
+
+	writeConfig("request-compression: gzip\n")
+	w.reloadConfigIfChanged()
+	if reloads != 1 {
+		t.Fatalf("invalid config changed reload count: got %d, want 1", reloads)
+	}
+	w.clientsMutex.RLock()
+	defer w.clientsMutex.RUnlock()
+	if w.config == nil || w.config.EffectiveRequestCompressionMode() != config.RequestCompressionAuto {
+		t.Fatalf("invalid reload replaced the active configuration: %+v", w.config)
+	}
+}


### PR DESCRIPTION
## Summary
- Add validated `request-compression` configuration with `off` and `auto` modes.
- Add an optional `request-compression-min-size` threshold using positive KiB values such as `16k` (default: 16 KiB).
- Keep encoding selection internal: auto uses gzip for Claude and zstd for Codex; unsupported providers, including Kimi, remain uncompressed.
- Make config changes visible to hot-reload diffs and reject invalid settings without replacing the active config.
- Preserve Kimi model semantics while preventing its Claude-compatible count-token path from being compressed.

## Validation
- `go test ./...`
- `go build -o test-output ./cmd/server && rm test-output`

🤖 Generated with [Claude Code](https://claude.com/claude-code)