### PR TITLE
fix(codex): resync plan models after credential refresh

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1098,6 +1098,8 @@ func (h *Handler) deleteAuthFileByName(ctx context.Context, name string) (string
 		targetID = strings.TrimSpace(targetAuth.ID)
 		if path := strings.TrimSpace(authAttribute(targetAuth, "path")); path != "" {
 			targetPath = path
+		} else if path := strings.TrimSpace(authAttribute(targetAuth, coreauth.AttributeVirtualSource)); path != "" {
+			targetPath = path
 		}
 	}
 	if !filepath.IsAbs(targetPath) {
@@ -1118,9 +1120,23 @@ func (h *Handler) deleteAuthFileByName(ctx context.Context, name string) (string
 		return nil
 	}
 
-	var errDelete error
+	targetIDs := h.authIDsSharingCredentialPath(targetPath)
 	if targetID != "" {
-		errDelete = h.authManager.RemoveWithCleanup(ctx, targetID, removeStoredCredential)
+		found := false
+		for _, id := range targetIDs {
+			if id == targetID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			targetIDs = append(targetIDs, targetID)
+		}
+	}
+
+	var errDelete error
+	if len(targetIDs) > 0 {
+		errDelete = h.authManager.RemovePathWithCleanup(ctx, targetIDs, removeStoredCredential)
 	} else {
 		errDelete = removeStoredCredential()
 	}
@@ -1132,6 +1148,31 @@ func (h *Handler) deleteAuthFileByName(ctx context.Context, name string) (string
 	}
 	h.removeAuthsForPath(ctx, targetPath, targetID)
 	return filepath.Base(name), http.StatusOK, nil
+}
+
+// authIDsSharingCredentialPath returns runtime auth IDs that share a credential path.
+// Plugin-owned files can expand into multiple virtual auths that must be locked together
+// during delete so an in-flight sibling refresh cannot restore the file.
+func (h *Handler) authIDsSharingCredentialPath(path string) []string {
+	if h == nil || h.authManager == nil {
+		return nil
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	var ids []string
+	for _, auth := range h.authManager.List() {
+		if auth == nil {
+			continue
+		}
+		if sameAuthFilePath(authAttribute(auth, "path"), path) || sameAuthFilePath(authAttribute(auth, coreauth.AttributeVirtualSource), path) {
+			if id := strings.TrimSpace(auth.ID); id != "" {
+				ids = append(ids, id)
+			}
+		}
+	}
+	return ids
 }
 
 func isPluginVirtualSourceDelete(name string, auth *coreauth.Auth) bool {

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -903,7 +903,16 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 			if !strings.HasSuffix(strings.ToLower(name), ".json") {
 				continue
 			}
-			if _, status, errDelete := h.deleteAuthFileByName(ctx, name); errDelete != nil {
+			// Bulk delete must remove the enumerated AuthDir entry itself. Resolving
+			// only by basename can match another runtime auth with the same filename
+			// (subpath/external) and leave the enumerated file behind.
+			full := filepath.Join(h.cfg.AuthDir, name)
+			if !filepath.IsAbs(full) {
+				if abs, errAbs := filepath.Abs(full); errAbs == nil {
+					full = abs
+				}
+			}
+			if _, status, errDelete := h.deleteAuthFileAtPath(ctx, full); errDelete != nil {
 				c.JSON(status, gin.H{"error": errDelete.Error()})
 				return
 			}
@@ -1084,22 +1093,47 @@ func uniqueAuthFileNames(names []string) []string {
 }
 
 func (h *Handler) deleteAuthFileByName(ctx context.Context, name string) (string, int, error) {
+	return h.deleteAuthFile(ctx, name, "")
+}
+
+// deleteAuthFileAtPath removes one credential file at an already-resolved path.
+// Bulk delete uses this so basename collisions cannot redirect the deletion target.
+func (h *Handler) deleteAuthFileAtPath(ctx context.Context, fullPath string) (string, int, error) {
+	fullPath = strings.TrimSpace(fullPath)
+	if fullPath == "" {
+		return "", http.StatusBadRequest, fmt.Errorf("invalid path")
+	}
+	if !filepath.IsAbs(fullPath) {
+		if abs, errAbs := filepath.Abs(fullPath); errAbs == nil {
+			fullPath = abs
+		}
+	}
+	return h.deleteAuthFile(ctx, filepath.Base(fullPath), fullPath)
+}
+
+// deleteAuthFile removes a credential and its runtime auths.
+// When fixedPath is empty, the target path may be resolved from a runtime auth matched by name.
+// When fixedPath is set, that absolute path is deleted even if another auth shares the basename.
+func (h *Handler) deleteAuthFile(ctx context.Context, name, fixedPath string) (string, int, error) {
 	name = strings.TrimSpace(name)
 	if isUnsafeAuthFileName(name) {
 		return "", http.StatusBadRequest, fmt.Errorf("invalid name")
 	}
 
-	targetPath := filepath.Join(h.cfg.AuthDir, filepath.Base(name))
+	targetPath := strings.TrimSpace(fixedPath)
 	targetID := ""
-	if targetAuth := h.findAuthForDelete(name); targetAuth != nil {
-		if !isPluginVirtualSourceDelete(name, targetAuth) {
-			return filepath.Base(name), http.StatusConflict, errPluginVirtualAuth
-		}
-		targetID = strings.TrimSpace(targetAuth.ID)
-		if path := strings.TrimSpace(authAttribute(targetAuth, "path")); path != "" {
-			targetPath = path
-		} else if path := strings.TrimSpace(authAttribute(targetAuth, coreauth.AttributeVirtualSource)); path != "" {
-			targetPath = path
+	if targetPath == "" {
+		targetPath = filepath.Join(h.cfg.AuthDir, filepath.Base(name))
+		if targetAuth := h.findAuthForDelete(name); targetAuth != nil {
+			if !isPluginVirtualSourceDelete(name, targetAuth) {
+				return filepath.Base(name), http.StatusConflict, errPluginVirtualAuth
+			}
+			targetID = strings.TrimSpace(targetAuth.ID)
+			if path := strings.TrimSpace(authAttribute(targetAuth, "path")); path != "" {
+				targetPath = path
+			} else if path := strings.TrimSpace(authAttribute(targetAuth, coreauth.AttributeVirtualSource)); path != "" {
+				targetPath = path
+			}
 		}
 	}
 	if !filepath.IsAbs(targetPath) {

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -388,6 +388,74 @@ func (h *Handler) GetAuthFileModels(c *gin.Context) {
 	c.JSON(200, gin.H{"models": result})
 }
 
+// RefreshAuthFile refreshes one runtime auth selected by auth ID or filename.
+func (h *Handler) RefreshAuthFile(c *gin.Context) {
+	if h == nil || h.authManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
+		return
+	}
+
+	var req struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	if errBind := c.ShouldBindJSON(&req); errBind != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+	selector := strings.TrimSpace(req.ID)
+	if selector == "" {
+		selector = strings.TrimSpace(req.Name)
+	}
+	if selector == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "id or name is required"})
+		return
+	}
+
+	targetAuth := h.findAuthByNameOrID(selector)
+	if targetAuth == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "auth file not found"})
+		return
+	}
+	refreshed, errRefresh := h.authManager.RefreshAuth(c.Request.Context(), targetAuth.ID)
+	if errRefresh != nil {
+		log.WithError(errRefresh).WithField("auth_id", targetAuth.ID).Warn("failed to refresh auth file")
+		switch {
+		case errors.Is(errRefresh, coreauth.ErrAuthNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "auth file not found"})
+		case errors.Is(errRefresh, coreauth.ErrAuthNotRefreshable):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "auth file is not refreshable"})
+		default:
+			c.JSON(http.StatusBadGateway, gin.H{"error": "failed to refresh auth file"})
+		}
+		return
+	}
+	if refreshed == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "refreshed auth unavailable"})
+		return
+	}
+
+	name := strings.TrimSpace(refreshed.FileName)
+	if name == "" {
+		name = refreshed.ID
+	}
+	response := gin.H{
+		"status":   "ok",
+		"id":       refreshed.ID,
+		"name":     name,
+		"provider": strings.TrimSpace(refreshed.Provider),
+	}
+	if refreshed.Attributes != nil {
+		if planType := strings.TrimSpace(refreshed.Attributes["plan_type"]); planType != "" {
+			response["plan_type"] = planType
+		}
+	}
+	if !refreshed.LastRefreshedAt.IsZero() {
+		response["last_refresh"] = refreshed.LastRefreshedAt
+	}
+	c.JSON(http.StatusOK, response)
+}
+
 // List auth files from disk when the auth manager is unavailable.
 func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 	entries, err := os.ReadDir(h.cfg.AuthDir)
@@ -835,20 +903,11 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 			if !strings.HasSuffix(strings.ToLower(name), ".json") {
 				continue
 			}
-			full := filepath.Join(h.cfg.AuthDir, name)
-			if !filepath.IsAbs(full) {
-				if abs, errAbs := filepath.Abs(full); errAbs == nil {
-					full = abs
-				}
+			if _, status, errDelete := h.deleteAuthFileByName(ctx, name); errDelete != nil {
+				c.JSON(status, gin.H{"error": errDelete.Error()})
+				return
 			}
-			if err = os.Remove(full); err == nil {
-				if errDel := h.deleteTokenRecord(ctx, full); errDel != nil {
-					c.JSON(500, gin.H{"error": errDel.Error()})
-					return
-				}
-				deleted++
-				h.removeAuth(ctx, full)
-			}
+			deleted++
 		}
 		c.JSON(200, gin.H{"status": "ok", "deleted": deleted})
 		return
@@ -1046,14 +1105,30 @@ func (h *Handler) deleteAuthFileByName(ctx context.Context, name string) (string
 			targetPath = abs
 		}
 	}
-	if errRemove := os.Remove(targetPath); errRemove != nil {
-		if os.IsNotExist(errRemove) {
+	removeStoredCredential := func() error {
+		if errRemove := os.Remove(targetPath); errRemove != nil {
+			if os.IsNotExist(errRemove) {
+				return errAuthFileNotFound
+			}
+			return fmt.Errorf("failed to remove file: %w", errRemove)
+		}
+		if errDeleteRecord := h.deleteTokenRecord(ctx, targetPath); errDeleteRecord != nil {
+			return errDeleteRecord
+		}
+		return nil
+	}
+
+	var errDelete error
+	if targetID != "" {
+		errDelete = h.authManager.RemoveWithCleanup(ctx, targetID, removeStoredCredential)
+	} else {
+		errDelete = removeStoredCredential()
+	}
+	if errDelete != nil {
+		if errors.Is(errDelete, errAuthFileNotFound) {
 			return filepath.Base(name), http.StatusNotFound, errAuthFileNotFound
 		}
-		return filepath.Base(name), http.StatusInternalServerError, fmt.Errorf("failed to remove file: %w", errRemove)
-	}
-	if errDeleteRecord := h.deleteTokenRecord(ctx, targetPath); errDeleteRecord != nil {
-		return filepath.Base(name), http.StatusInternalServerError, errDeleteRecord
+		return filepath.Base(name), http.StatusInternalServerError, errDelete
 	}
 	h.removeAuthsForPath(ctx, targetPath, targetID)
 	return filepath.Base(name), http.StatusOK, nil
@@ -1074,6 +1149,10 @@ func isPluginVirtualSourceDelete(name string, auth *coreauth.Auth) bool {
 }
 
 func (h *Handler) findAuthForDelete(name string) *coreauth.Auth {
+	return h.findAuthByNameOrID(name)
+}
+
+func (h *Handler) findAuthByNameOrID(name string) *coreauth.Auth {
 	if h == nil || h.authManager == nil {
 		return nil
 	}

--- a/internal/api/handlers/management/auth_files_delete_test.go
+++ b/internal/api/handlers/management/auth_files_delete_test.go
@@ -170,3 +170,65 @@ func TestDeleteAuthFile_RemovesRuntimeAuth(t *testing.T) {
 		t.Fatalf("expected runtime auth %q to be removed", record.ID)
 	}
 }
+
+func TestDeleteAuthFile_AllDeletesEnumeratedAuthDirFiles(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	tempDir := t.TempDir()
+	authDir := filepath.Join(tempDir, "auth")
+	subDir := filepath.Join(authDir, "sub")
+	if errMkdir := os.MkdirAll(subDir, 0o700); errMkdir != nil {
+		t.Fatalf("mkdir: %v", errMkdir)
+	}
+
+	fileName := "same-name.json"
+	rootPath := filepath.Join(authDir, fileName)
+	subPath := filepath.Join(subDir, fileName)
+	if errWrite := os.WriteFile(rootPath, []byte(`{"type":"codex","email":"root@example.com"}`), 0o600); errWrite != nil {
+		t.Fatalf("write root auth: %v", errWrite)
+	}
+	if errWrite := os.WriteFile(subPath, []byte(`{"type":"codex","email":"sub@example.com"}`), 0o600); errWrite != nil {
+		t.Fatalf("write sub auth: %v", errWrite)
+	}
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	// Runtime auth points at the nested file with the same basename.
+	record := &coreauth.Auth{
+		ID:       "nested/" + fileName,
+		FileName: fileName,
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"path": subPath,
+		},
+		Metadata: map[string]any{
+			"type":  "codex",
+			"email": "sub@example.com",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+	h.tokenStore = &memoryAuthStore{}
+
+	deleteRec := httptest.NewRecorder()
+	deleteCtx, _ := gin.CreateTestContext(deleteRec)
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/v0/management/auth-files?all=true", nil)
+	deleteCtx.Request = deleteReq
+	h.DeleteAuthFile(deleteCtx)
+
+	if deleteRec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", deleteRec.Code, deleteRec.Body.String())
+	}
+	if _, errStat := os.Stat(rootPath); !os.IsNotExist(errStat) {
+		t.Fatalf("expected enumerated AuthDir file to be deleted, stat err: %v", errStat)
+	}
+	if _, errStat := os.Stat(subPath); errStat != nil {
+		t.Fatalf("expected nested same-basename file to remain, stat err: %v", errStat)
+	}
+	if _, ok := manager.GetByID(record.ID); !ok {
+		t.Fatal("nested runtime auth was unexpectedly removed by bulk delete of root basename")
+	}
+}

--- a/internal/api/handlers/management/auth_files_refresh_test.go
+++ b/internal/api/handlers/management/auth_files_refresh_test.go
@@ -1,0 +1,133 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type managementRefreshExecutor struct{}
+
+func (managementRefreshExecutor) Identifier() string { return "codex" }
+
+func (managementRefreshExecutor) Execute(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (managementRefreshExecutor) ExecuteStream(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+
+func (managementRefreshExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	auth.Attributes["plan_type"] = "plus"
+	auth.Metadata["access_token"] = "new-access-secret"
+	auth.Metadata["refresh_token"] = "new-refresh-secret"
+	auth.Metadata["id_token"] = "new-id-secret"
+	return auth, nil
+}
+
+func (managementRefreshExecutor) CountTokens(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (managementRefreshExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestRefreshAuthFileResolvesFilenameAndOmitsSecrets(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(managementRefreshExecutor{})
+	record := &coreauth.Auth{
+		ID:         "codex-runtime-id",
+		FileName:   "codex-user.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"plan_type": "free"},
+		Metadata: map[string]any{
+			"access_token":  "old-access-secret",
+			"refresh_token": "old-refresh-secret",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+	handler := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	request := httptest.NewRequest(http.MethodPost, "/v0/management/auth-files/refresh", strings.NewReader(`{"name":"codex-user.json"}`))
+	request.Header.Set("Content-Type", "application/json")
+	ctx.Request = request
+	handler.RefreshAuthFile(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var response map[string]any
+	if errDecode := json.Unmarshal(recorder.Body.Bytes(), &response); errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if got := response["id"]; got != record.ID {
+		t.Fatalf("id = %#v, want %q", got, record.ID)
+	}
+	if got := response["plan_type"]; got != "plus" {
+		t.Fatalf("plan_type = %#v, want plus", got)
+	}
+	for _, secret := range []string{"old-access-secret", "old-refresh-secret", "new-access-secret", "new-refresh-secret", "new-id-secret"} {
+		if strings.Contains(recorder.Body.String(), secret) {
+			t.Fatalf("response leaked secret %q: %s", secret, recorder.Body.String())
+		}
+	}
+
+	updated, ok := manager.GetByID(record.ID)
+	if !ok || updated == nil {
+		t.Fatal("refreshed auth missing from manager")
+	}
+	if got := updated.Attributes["plan_type"]; got != "plus" {
+		t.Fatalf("updated plan_type = %q, want plus", got)
+	}
+}
+
+func TestRefreshAuthFileRejectsAuthWithoutRefreshCredential(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(managementRefreshExecutor{})
+	record := &coreauth.Auth{
+		ID:       "codex-api-key",
+		FileName: "codex-api-key.json",
+		Provider: "codex",
+		Metadata: map[string]any{"access_token": "access-token"},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+	handler := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	request := httptest.NewRequest(http.MethodPost, "/v0/management/auth-files/refresh", strings.NewReader(`{"id":"codex-api-key"}`))
+	request.Header.Set("Content-Type", "application/json")
+	ctx.Request = request
+	handler.RefreshAuthFile(ctx)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "not refreshable") {
+		t.Fatalf("body = %s, want not refreshable error", recorder.Body.String())
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -946,6 +946,7 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/model-definitions/:channel", s.mgmt.GetStaticModelDefinitions)
 		mgmt.GET("/auth-files/download", s.mgmt.DownloadAuthFile)
 		mgmt.POST("/auth-files", s.mgmt.UploadAuthFile)
+		mgmt.POST("/auth-files/refresh", s.mgmt.RefreshAuthFile)
 		mgmt.DELETE("/auth-files", s.mgmt.DeleteAuthFile)
 		mgmt.PATCH("/auth-files/status", s.mgmt.PatchAuthFileStatus)
 		mgmt.PATCH("/auth-files/fields", s.mgmt.PatchAuthFileFields)

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1785,6 +1785,9 @@ func syncCodexPlanType(auth *cliproxyauth.Auth, idToken string) {
 		log.Warnf("codex executor: failed to parse refreshed ID token: %v", errParse)
 		return
 	}
+	if claims == nil {
+		return
+	}
 	planType := strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType)
 	if planType == "" {
 		return

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1725,6 +1725,9 @@ func countCodexInputTokens(enc tokenizer.Codec, body []byte) (int64, error) {
 func (e *CodexExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
 	log.Debugf("codex executor: refresh called")
 	if refreshed, handled, err := helps.RefreshAuthViaHome(ctx, e.cfg, auth); handled {
+		if err == nil {
+			syncCodexPlanTypeFromMetadata(refreshed)
+		}
 		return refreshed, err
 	}
 	if auth == nil {
@@ -1749,6 +1752,7 @@ func (e *CodexExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*
 	}
 	auth.Metadata["id_token"] = td.IDToken
 	auth.Metadata["access_token"] = td.AccessToken
+	syncCodexPlanType(auth, td.IDToken)
 	if td.RefreshToken != "" {
 		auth.Metadata["refresh_token"] = td.RefreshToken
 	}
@@ -1762,6 +1766,37 @@ func (e *CodexExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*
 	now := time.Now().Format(time.RFC3339)
 	auth.Metadata["last_refresh"] = now
 	return auth, nil
+}
+
+func syncCodexPlanTypeFromMetadata(auth *cliproxyauth.Auth) {
+	if auth == nil || auth.Metadata == nil {
+		return
+	}
+	idToken, _ := auth.Metadata["id_token"].(string)
+	syncCodexPlanType(auth, idToken)
+}
+
+func syncCodexPlanType(auth *cliproxyauth.Auth, idToken string) {
+	if auth == nil || strings.TrimSpace(idToken) == "" {
+		return
+	}
+	claims, errParse := codexauth.ParseJWTToken(idToken)
+	if errParse != nil {
+		log.Warnf("codex executor: failed to parse refreshed ID token: %v", errParse)
+		return
+	}
+	planType := strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType)
+	if planType == "" {
+		return
+	}
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	auth.Attributes["plan_type"] = planType
+	auth.Metadata["plan_type"] = planType
 }
 
 type codexIdentityConfuseState struct {

--- a/internal/runtime/executor/codex_executor_refresh_test.go
+++ b/internal/runtime/executor/codex_executor_refresh_test.go
@@ -1,0 +1,75 @@
+package executor
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestSyncCodexPlanTypeUpdatesRuntimeAndPersistedMetadata(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider:   "codex",
+		Attributes: map[string]string{"plan_type": "free"},
+		Metadata:   map[string]any{"plan_type": "free"},
+	}
+
+	syncCodexPlanType(auth, codexPlanJWT(t, "plus"))
+
+	if got := auth.Attributes["plan_type"]; got != "plus" {
+		t.Fatalf("Attributes plan_type = %q, want plus", got)
+	}
+	if got, _ := auth.Metadata["plan_type"].(string); got != "plus" {
+		t.Fatalf("Metadata plan_type = %q, want plus", got)
+	}
+}
+
+func TestSyncCodexPlanTypeKeepsExistingPlanForInvalidToken(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider:   "codex",
+		Attributes: map[string]string{"plan_type": "free"},
+		Metadata:   map[string]any{"plan_type": "free"},
+	}
+
+	syncCodexPlanType(auth, "invalid-token")
+
+	if got := auth.Attributes["plan_type"]; got != "free" {
+		t.Fatalf("Attributes plan_type = %q, want free", got)
+	}
+	if got, _ := auth.Metadata["plan_type"].(string); got != "free" {
+		t.Fatalf("Metadata plan_type = %q, want free", got)
+	}
+}
+
+func TestSyncCodexPlanTypeFromMetadataUpdatesHomeRefreshResult(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider:   "codex",
+		Attributes: map[string]string{"plan_type": "free"},
+		Metadata: map[string]any{
+			"id_token": codexPlanJWT(t, "plus"),
+		},
+	}
+
+	syncCodexPlanTypeFromMetadata(auth)
+
+	if got := auth.Attributes["plan_type"]; got != "plus" {
+		t.Fatalf("Attributes plan_type = %q, want plus", got)
+	}
+	if got, _ := auth.Metadata["plan_type"].(string); got != "plus" {
+		t.Fatalf("Metadata plan_type = %q, want plus", got)
+	}
+}
+
+func codexPlanJWT(t *testing.T, planType string) string {
+	t.Helper()
+	payload, errMarshal := json.Marshal(map[string]any{
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_plan_type": planType,
+		},
+	})
+	if errMarshal != nil {
+		t.Fatalf("marshal JWT payload: %v", errMarshal)
+	}
+	return "e30." + base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -6249,7 +6249,7 @@ func authHasStorageRefreshMaterial(auth *Auth) bool {
 	if !ok {
 		return false
 	}
-	return len(bytes.TrimSpace(rawProvider.RawJSON())) > 0
+	return storagePayloadHasRefreshMaterial(rawProvider.RawJSON())
 }
 
 // authIsExplicitlyRefreshable reports whether an auth has local refresh material.
@@ -6257,6 +6257,46 @@ func authHasStorageRefreshMaterial(auth *Auth) bool {
 // refresh_token field.
 func authIsExplicitlyRefreshable(auth *Auth) bool {
 	return authHasRefreshCredential(auth) || authHasStorageRefreshMaterial(auth)
+}
+
+func storagePayloadHasRefreshMaterial(raw []byte) bool {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return false
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		// Opaque non-JSON blobs can still be plugin-owned refresh material.
+		return true
+	}
+	return mapHasRefreshMaterial(payload)
+}
+
+func mapHasRefreshMaterial(payload map[string]any) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	for _, key := range []string{
+		"refresh_token",
+		"refreshToken",
+		"token",
+		"refresh_material",
+		"refreshMaterial",
+		"session_token",
+		"sessionToken",
+	} {
+		switch value := payload[key].(type) {
+		case string:
+			if strings.TrimSpace(value) != "" {
+				return true
+			}
+		case []byte:
+			if len(bytes.TrimSpace(value)) > 0 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func clearUnauthorizedModelStates(auth *Auth, now time.Time) []string {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -6222,9 +6222,12 @@ func (m *Manager) tryRefreshAfterUnauthorized(ctx context.Context, auth *Auth, e
 	}
 	log.Debugf("unauthorized response for %s (%s), refreshing credentials before fallback", auth.Provider, auth.ID)
 	refreshed, errRefresh := m.refreshAuthForRequest(ctx, auth.ID, authAccessToken(auth))
-	if errRefresh != nil || refreshed == nil {
+	if refreshed == nil {
 		log.Debugf("credential refresh before fallback failed for %s (%s): %v", auth.Provider, auth.ID, errRefresh)
 		return auth, false
+	}
+	if errRefresh != nil {
+		log.Debugf("credential refresh before fallback updated runtime auth for %s (%s) with follow-up error: %v", auth.Provider, auth.ID, errRefresh)
 	}
 	return refreshed, true
 }

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -6241,62 +6241,22 @@ func authHasRefreshCredential(auth *Auth) bool {
 	return authMetadataString(auth, "refreshToken") != ""
 }
 
-func authHasStorageRefreshMaterial(auth *Auth) bool {
+// authHasPluginOwnedStorage reports whether auth carries provider-owned storage.
+// Plugin TokenStorage exposes RawJSON and may keep refresh material in nested or
+// provider-specific fields that the host must not second-guess.
+func authHasPluginOwnedStorage(auth *Auth) bool {
 	if auth == nil || auth.Storage == nil {
 		return false
 	}
-	rawProvider, ok := auth.Storage.(interface{ RawJSON() []byte })
-	if !ok {
-		return false
-	}
-	return storagePayloadHasRefreshMaterial(rawProvider.RawJSON())
+	_, ok := auth.Storage.(interface{ RawJSON() []byte })
+	return ok
 }
 
-// authIsExplicitlyRefreshable reports whether an auth has local refresh material.
-// Plugin credentials may keep refresh state in Storage.RawJSON instead of a top-level
-// refresh_token field.
+// authIsExplicitlyRefreshable reports whether an auth has a local refresh path.
+// Host-side checks only cover top-level refresh tokens and plugin-owned storage.
+// When plugin storage is present, the provider executor decides refreshability.
 func authIsExplicitlyRefreshable(auth *Auth) bool {
-	return authHasRefreshCredential(auth) || authHasStorageRefreshMaterial(auth)
-}
-
-func storagePayloadHasRefreshMaterial(raw []byte) bool {
-	raw = bytes.TrimSpace(raw)
-	if len(raw) == 0 {
-		return false
-	}
-	var payload map[string]any
-	if err := json.Unmarshal(raw, &payload); err != nil {
-		// Opaque non-JSON blobs can still be plugin-owned refresh material.
-		return true
-	}
-	return mapHasRefreshMaterial(payload)
-}
-
-func mapHasRefreshMaterial(payload map[string]any) bool {
-	if len(payload) == 0 {
-		return false
-	}
-	for _, key := range []string{
-		"refresh_token",
-		"refreshToken",
-		"token",
-		"refresh_material",
-		"refreshMaterial",
-		"session_token",
-		"sessionToken",
-	} {
-		switch value := payload[key].(type) {
-		case string:
-			if strings.TrimSpace(value) != "" {
-				return true
-			}
-		case []byte:
-			if len(bytes.TrimSpace(value)) > 0 {
-				return true
-			}
-		}
-	}
-	return false
+	return authHasRefreshCredential(auth) || authHasPluginOwnedStorage(auth)
 }
 
 func clearUnauthorizedModelStates(auth *Auth, now time.Time) []string {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2272,40 +2272,69 @@ func (m *Manager) Remove(ctx context.Context, id string) {
 // cleanup runs while the auth refresh lock is held and must remove any external persisted
 // credential before the auth is removed from runtime state.
 func (m *Manager) RemoveWithCleanup(ctx context.Context, id string, cleanup func() error) error {
-	if m == nil {
-		return errors.New("auth manager is nil")
-	}
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return errors.New("auth id is empty")
 	}
-	refreshLock := m.refreshLockFor(id)
-	refreshLock.mu.Lock()
-	defer refreshLock.mu.Unlock()
+	return m.RemovePathWithCleanup(ctx, []string{id}, cleanup)
+}
+
+// RemovePathWithCleanup serializes cleanup and runtime removal against credential refresh
+// for every provided auth ID. Locks are acquired in sorted ID order to avoid deadlocks with
+// concurrent multi-auth cleanup. cleanup runs after all refresh locks are held so a sibling
+// refresh that shares the same credential path cannot recreate the file after deletion.
+func (m *Manager) RemovePathWithCleanup(ctx context.Context, ids []string, cleanup func() error) error {
+	if m == nil {
+		return errors.New("auth manager is nil")
+	}
+	normalized := uniqueSortedAuthIDs(ids)
+	if len(normalized) == 0 {
+		if cleanup != nil {
+			return cleanup()
+		}
+		return nil
+	}
+
+	locks := make([]*authRefreshLock, 0, len(normalized))
+	for _, id := range normalized {
+		lock := m.refreshLockFor(id)
+		lock.mu.Lock()
+		locks = append(locks, lock)
+	}
+	defer func() {
+		for i := len(locks) - 1; i >= 0; i-- {
+			locks[i].mu.Unlock()
+		}
+	}()
+
 	if cleanup != nil {
 		if errCleanup := cleanup(); errCleanup != nil {
 			return errCleanup
 		}
 	}
 
+	providers := make(map[string]struct{})
 	m.mu.Lock()
-	existing := m.auths[id]
-	if existing == nil {
-		m.mu.Unlock()
-		return nil
-	}
-	provider := strings.TrimSpace(existing.Provider)
-	delete(m.auths, id)
-	if m.modelPoolOffsets != nil {
-		delete(m.modelPoolOffsets, id)
-	}
-	for sessionID, sessionAuths := range m.homeRuntimeAuths {
-		if sessionAuths == nil {
+	for _, id := range normalized {
+		existing := m.auths[id]
+		if existing == nil {
 			continue
 		}
-		delete(sessionAuths, id)
-		if len(sessionAuths) == 0 {
-			delete(m.homeRuntimeAuths, sessionID)
+		if provider := strings.TrimSpace(existing.Provider); provider != "" {
+			providers[provider] = struct{}{}
+		}
+		delete(m.auths, id)
+		if m.modelPoolOffsets != nil {
+			delete(m.modelPoolOffsets, id)
+		}
+		for sessionID, sessionAuths := range m.homeRuntimeAuths {
+			if sessionAuths == nil {
+				continue
+			}
+			delete(sessionAuths, id)
+			if len(sessionAuths) == 0 {
+				delete(m.homeRuntimeAuths, sessionID)
+			}
 		}
 	}
 	m.mu.Unlock()
@@ -2313,13 +2342,14 @@ func (m *Manager) RemoveWithCleanup(ctx context.Context, id string, cleanup func
 	if !shouldDeferAPIKeyModelAliasRebuild(ctx) {
 		m.rebuildAPIKeyModelAliasFromRuntimeConfig()
 	}
-	if m.scheduler != nil {
-		m.scheduler.removeAuth(id)
+	for _, id := range normalized {
+		if m.scheduler != nil {
+			m.scheduler.removeAuth(id)
+		}
+		m.queueRefreshUnschedule(id)
+		m.invalidateSessionAffinity(id)
 	}
-	m.queueRefreshUnschedule(id)
-	m.invalidateSessionAffinity(id)
-
-	if provider != "" {
+	for provider := range providers {
 		if exec, ok := m.Executor(provider); ok && exec != nil {
 			if closer, okCloser := exec.(ExecutionSessionCloser); okCloser {
 				closer.CloseExecutionSession(CloseAllExecutionSessionsID)
@@ -2328,6 +2358,27 @@ func (m *Manager) RemoveWithCleanup(ctx context.Context, id string, cleanup func
 	}
 	m.persistCooldownStates(ctx)
 	return nil
+}
+
+func uniqueSortedAuthIDs(ids []string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func (m *Manager) invalidateSessionAffinity(authID string) {
@@ -6190,6 +6241,24 @@ func authHasRefreshCredential(auth *Auth) bool {
 	return authMetadataString(auth, "refreshToken") != ""
 }
 
+func authHasStorageRefreshMaterial(auth *Auth) bool {
+	if auth == nil || auth.Storage == nil {
+		return false
+	}
+	rawProvider, ok := auth.Storage.(interface{ RawJSON() []byte })
+	if !ok {
+		return false
+	}
+	return len(bytes.TrimSpace(rawProvider.RawJSON())) > 0
+}
+
+// authIsExplicitlyRefreshable reports whether an auth has local refresh material.
+// Plugin credentials may keep refresh state in Storage.RawJSON instead of a top-level
+// refresh_token field.
+func authIsExplicitlyRefreshable(auth *Auth) bool {
+	return authHasRefreshCredential(auth) || authHasStorageRefreshMaterial(auth)
+}
+
 func clearUnauthorizedModelStates(auth *Auth, now time.Time) []string {
 	if auth == nil || len(auth.ModelStates) == 0 {
 		return nil
@@ -6253,7 +6322,7 @@ func (m *Manager) RefreshAuth(ctx context.Context, id string) (*Auth, error) {
 	}
 	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
 	homeRefreshEnabled := cfg != nil && cfg.Home.Enabled
-	if !homeRefreshEnabled && !authHasRefreshCredential(auth) {
+	if !homeRefreshEnabled && !authIsExplicitlyRefreshable(auth) {
 		return nil, ErrAuthNotRefreshable
 	}
 	return m.refreshAuthForRequest(ctx, id, "")

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -89,6 +89,13 @@ const (
 	transientErrorCooldown    = time.Minute
 )
 
+var (
+	// ErrAuthNotFound indicates that a requested auth no longer exists in the manager.
+	ErrAuthNotFound = errors.New("auth not found")
+	// ErrAuthNotRefreshable indicates that an auth has no refresh mechanism available.
+	ErrAuthNotRefreshable = errors.New("auth is not refreshable")
+)
+
 var quotaCooldownDisabled atomic.Bool
 var transientErrorCooldownSeconds atomic.Int64
 
@@ -215,6 +222,9 @@ func (NoopHook) OnAuthUpdated(context.Context, *Auth) {}
 // OnResult implements Hook.
 func (NoopHook) OnResult(context.Context, Result) {}
 
+// PostRefreshHook runs after refreshed credentials have been updated in the manager.
+type PostRefreshHook = PostAuthHook
+
 // Manager orchestrates auth lifecycle, selection, execution, and persistence.
 type Manager struct {
 	store         Store
@@ -263,6 +273,8 @@ type Manager struct {
 	// refreshLocks serializes credential refresh per auth ID so concurrent
 	// 401 recoveries and auto-refresh workers do not race the same refresh_token.
 	refreshLocks sync.Map
+
+	postRefreshHook PostRefreshHook
 }
 
 // NewManager constructs a manager with optional custom selector and hook.
@@ -499,6 +511,16 @@ func (m *Manager) SetCooldownStateStore(store CooldownStateStore) {
 func (m *Manager) SetRoundTripperProvider(p RoundTripperProvider) {
 	m.mu.Lock()
 	m.rtProvider = p
+	m.mu.Unlock()
+}
+
+// SetPostRefreshHook registers a callback invoked after a successful credential refresh.
+func (m *Manager) SetPostRefreshHook(hook PostRefreshHook) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.postRefreshHook = hook
 	m.mu.Unlock()
 }
 
@@ -2190,6 +2212,11 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 
 // Update replaces an existing auth entry and notifies hooks.
 func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
+	updated, _ := m.updateWithPersistResult(ctx, auth)
+	return updated, nil
+}
+
+func (m *Manager) updateWithPersistResult(ctx context.Context, auth *Auth) (*Auth, error) {
 	if auth == nil || auth.ID == "" {
 		return nil, nil
 	}
@@ -2227,31 +2254,45 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 		m.scheduler.upsertAuth(authClone)
 	}
 	m.queueRefreshReschedule(auth.ID)
-	_ = m.persist(ctx, auth)
+	errPersist := m.persist(ctx, auth)
 	m.hook.OnAuthUpdated(ctx, auth.Clone())
 	if clearedCooldown {
 		m.persistCooldownStates(ctx)
 	}
-	return auth.Clone(), nil
+	return auth.Clone(), errPersist
 }
 
 // Remove deletes an auth from runtime state without persisting.
 // Disk and token-store deletion must be handled by the caller.
 func (m *Manager) Remove(ctx context.Context, id string) {
+	_ = m.RemoveWithCleanup(ctx, id, nil)
+}
+
+// RemoveWithCleanup serializes cleanup and runtime removal against credential refresh.
+// cleanup runs while the auth refresh lock is held and must remove any external persisted
+// credential before the auth is removed from runtime state.
+func (m *Manager) RemoveWithCleanup(ctx context.Context, id string, cleanup func() error) error {
 	if m == nil {
-		return
+		return errors.New("auth manager is nil")
 	}
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return
+		return errors.New("auth id is empty")
 	}
-	_ = ctx
+	refreshLock := m.refreshLockFor(id)
+	refreshLock.mu.Lock()
+	defer refreshLock.mu.Unlock()
+	if cleanup != nil {
+		if errCleanup := cleanup(); errCleanup != nil {
+			return errCleanup
+		}
+	}
 
 	m.mu.Lock()
 	existing := m.auths[id]
 	if existing == nil {
 		m.mu.Unlock()
-		return
+		return nil
 	}
 	provider := strings.TrimSpace(existing.Provider)
 	delete(m.auths, id)
@@ -2286,6 +2327,7 @@ func (m *Manager) Remove(ctx context.Context, id string) {
 		}
 	}
 	m.persistCooldownStates(ctx)
+	return nil
 }
 
 func (m *Manager) invalidateSessionAffinity(authID string) {
@@ -6123,6 +6165,17 @@ type authRefreshLock struct {
 	mu sync.Mutex
 }
 
+func (m *Manager) refreshLockFor(id string) *authRefreshLock {
+	lockValue, _ := m.refreshLocks.LoadOrStore(id, &authRefreshLock{})
+	lock, _ := lockValue.(*authRefreshLock)
+	if lock != nil {
+		return lock
+	}
+	lock = &authRefreshLock{}
+	m.refreshLocks.Store(id, lock)
+	return lock
+}
+
 func authAccessToken(auth *Auth) string {
 	if token := authMetadataString(auth, "access_token"); token != "" {
 		return token
@@ -6180,6 +6233,29 @@ func (m *Manager) refreshAuth(ctx context.Context, id string) {
 	_, _ = m.refreshAuthForRequest(ctx, id, "")
 }
 
+// RefreshAuth synchronously refreshes one auth while serializing concurrent refreshes by auth ID.
+func (m *Manager) RefreshAuth(ctx context.Context, id string) (*Auth, error) {
+	if m == nil {
+		return nil, errors.New("auth manager is nil")
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, errors.New("auth id is empty")
+	}
+	m.mu.RLock()
+	auth := m.auths[id]
+	m.mu.RUnlock()
+	if auth == nil {
+		return nil, ErrAuthNotFound
+	}
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	homeRefreshEnabled := cfg != nil && cfg.Home.Enabled
+	if !homeRefreshEnabled && !authHasRefreshCredential(auth) {
+		return nil, ErrAuthNotRefreshable
+	}
+	return m.refreshAuthForRequest(ctx, id, "")
+}
+
 // refreshAuthForRequest performs a synchronous credential refresh for the given auth.
 // failedAccessToken lets concurrent callers reuse a refresh that already replaced the
 // access token that produced the unauthorized response.
@@ -6195,12 +6271,7 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		return nil, errors.New("auth id is empty")
 	}
 
-	lockValue, _ := m.refreshLocks.LoadOrStore(id, &authRefreshLock{})
-	lock, _ := lockValue.(*authRefreshLock)
-	if lock == nil {
-		lock = &authRefreshLock{}
-		m.refreshLocks.Store(id, lock)
-	}
+	lock := m.refreshLockFor(id)
 	lock.mu.Lock()
 	defer lock.mu.Unlock()
 
@@ -6211,8 +6282,11 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		exec = m.executors[auth.Provider]
 	}
 	m.mu.RUnlock()
-	if auth == nil || exec == nil {
-		return nil, errors.New("auth or executor not found")
+	if auth == nil {
+		return nil, ErrAuthNotFound
+	}
+	if exec == nil {
+		return nil, errors.New("auth executor not found")
 	}
 
 	// Another request may already have refreshed this credential.
@@ -6277,17 +6351,31 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 	if m.shouldRefresh(updated, now) {
 		updated.NextRefreshAfter = now.Add(refreshIneffectiveBackoff)
 	}
-	saved, errUpdate := m.Update(ctx, updated)
+	saved, errUpdate := m.updateWithPersistResult(ctx, updated)
 	for _, model := range modelsToResume {
 		registry.GetGlobalRegistry().ResumeClientModel(id, model)
 	}
+	if saved == nil {
+		return nil, ErrAuthNotFound
+	}
+	m.mu.RLock()
+	postRefreshHook := m.postRefreshHook
+	m.mu.RUnlock()
+	if postRefreshHook != nil {
+		if errHook := postRefreshHook(ctx, saved.Clone()); errHook != nil {
+			if errUpdate != nil {
+				return saved, errors.Join(
+					fmt.Errorf("persist refreshed auth %s (%s): %w", auth.Provider, auth.ID, errUpdate),
+					fmt.Errorf("post-refresh hook failed: %w", errHook),
+				)
+			}
+			return saved, fmt.Errorf("post-refresh hook failed: %w", errHook)
+		}
+	}
 	if errUpdate != nil {
-		log.Debugf("persist refreshed auth %s (%s) failed: %v", auth.Provider, auth.ID, errUpdate)
+		return saved, fmt.Errorf("persist refreshed auth %s (%s): %w", auth.Provider, auth.ID, errUpdate)
 	}
-	if saved != nil {
-		return saved, nil
-	}
-	return updated.Clone(), nil
+	return saved, nil
 }
 
 func (m *Manager) executorFor(provider string) ProviderExecutor {

--- a/sdk/cliproxy/auth/conductor_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_refresh_test.go
@@ -350,3 +350,129 @@ func TestManager_TryRefreshAfterUnauthorizedRetriesWithRuntimeAuthAfterPersisten
 		t.Fatalf("runtime access token = %q, want fresh-access-token", got)
 	}
 }
+
+type rawJSONRefreshStorage struct {
+	raw []byte
+}
+
+func (s *rawJSONRefreshStorage) SaveTokenToFile(string) error { return nil }
+
+func (s *rawJSONRefreshStorage) RawJSON() []byte {
+	if s == nil {
+		return nil
+	}
+	return append([]byte(nil), s.raw...)
+}
+
+func TestManager_RefreshAuthAllowsPluginStorageWithoutRefreshToken(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(planRefreshExecutor{})
+	auth := &Auth{
+		ID:       "plugin-storage-refresh",
+		Provider: "codex",
+		Storage:  &rawJSONRefreshStorage{raw: []byte(`{"type":"plugin","token":"stored-refresh-material"}`)},
+		Metadata: map[string]any{"access_token": "access-token"},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	refreshed, errRefresh := manager.RefreshAuth(ctx, auth.ID)
+	if errRefresh != nil {
+		t.Fatalf("RefreshAuth() error = %v", errRefresh)
+	}
+	if refreshed == nil {
+		t.Fatal("RefreshAuth() auth = nil")
+	}
+	if got := authAccessToken(refreshed); got != "fresh-access-token" {
+		t.Fatalf("access token = %q, want fresh-access-token", got)
+	}
+}
+
+func TestManager_RemovePathWithCleanupLocksSiblingAuthsBeforeDelete(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "plugin-shared.json")
+	if errWrite := os.WriteFile(path, []byte("stale-credential"), 0o600); errWrite != nil {
+		t.Fatalf("WriteFile() error = %v", errWrite)
+	}
+	store := &fileRefreshStore{path: path}
+	manager := NewManager(store, nil, nil)
+	executor := blockingPlanRefreshExecutor{
+		entered: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+
+	authA := &Auth{
+		ID:       "plugin-shared-a",
+		Provider: "codex",
+		Attributes: map[string]string{
+			AttributePath:          path,
+			AttributeVirtualSource: path,
+			AttributePluginVirtual: pluginVirtualAttrEnabled,
+		},
+		Metadata: map[string]any{
+			"access_token":  "stale-access-a",
+			"refresh_token": "refresh-token-a",
+		},
+	}
+	authB := &Auth{
+		ID:       "plugin-shared-b",
+		Provider: "codex",
+		Attributes: map[string]string{
+			AttributePath:          path,
+			AttributeVirtualSource: path,
+			AttributePluginVirtual: pluginVirtualAttrEnabled,
+		},
+		Metadata: map[string]any{
+			"access_token":  "stale-access-b",
+			"refresh_token": "refresh-token-b",
+		},
+	}
+	if _, errRegister := manager.Register(ctx, authA); errRegister != nil {
+		t.Fatalf("Register(A) error = %v", errRegister)
+	}
+	if _, errRegister := manager.Register(ctx, authB); errRegister != nil {
+		t.Fatalf("Register(B) error = %v", errRegister)
+	}
+
+	refreshResult := make(chan error, 1)
+	go func() {
+		_, errRefresh := manager.RefreshAuth(ctx, authB.ID)
+		refreshResult <- errRefresh
+	}()
+	<-executor.entered
+
+	cleanupEntered := make(chan struct{})
+	removeResult := make(chan error, 1)
+	go func() {
+		removeResult <- manager.RemovePathWithCleanup(ctx, []string{authA.ID, authB.ID}, func() error {
+			close(cleanupEntered)
+			return os.Remove(path)
+		})
+	}()
+
+	select {
+	case <-cleanupEntered:
+		t.Fatal("cleanup ran before the sibling refresh released its auth lock")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(executor.release)
+	if errRefresh := <-refreshResult; errRefresh != nil {
+		t.Fatalf("RefreshAuth() error = %v", errRefresh)
+	}
+	if errRemove := <-removeResult; errRemove != nil {
+		t.Fatalf("RemovePathWithCleanup() error = %v", errRemove)
+	}
+	if _, errStat := os.Stat(path); !os.IsNotExist(errStat) {
+		t.Fatalf("credential file still exists after multi-auth removal: %v", errStat)
+	}
+	if _, ok := manager.GetByID(authA.ID); ok {
+		t.Fatal("auth A remains registered after multi-auth removal")
+	}
+	if _, ok := manager.GetByID(authB.ID); ok {
+		t.Fatal("auth B remains registered after multi-auth removal")
+	}
+}

--- a/sdk/cliproxy/auth/conductor_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_refresh_test.go
@@ -310,3 +310,43 @@ func TestManager_RefreshAuthReturnsPersistenceFailureAfterPostRefreshHook(t *tes
 		t.Fatal("post-refresh hook was not called for the updated runtime auth")
 	}
 }
+
+func TestManager_TryRefreshAfterUnauthorizedRetriesWithRuntimeAuthAfterPersistenceFailure(t *testing.T) {
+	ctx := context.Background()
+	persistErr := errors.New("save failed")
+	manager := NewManager(&refreshFailingStore{err: persistErr}, nil, nil)
+	manager.RegisterExecutor(planRefreshExecutor{})
+	auth := &Auth{
+		ID:       "codex-401-refresh-persist-failure",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"access_token":  "stale-access-token",
+			"refresh_token": "refresh-token",
+		},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	refreshed, retry := manager.tryRefreshAfterUnauthorized(ctx, auth, &Error{
+		Code:       "unauthorized",
+		Message:    "access token expired",
+		HTTPStatus: http.StatusUnauthorized,
+	}, false)
+	if !retry {
+		t.Fatal("tryRefreshAfterUnauthorized() retry = false, want true")
+	}
+	if refreshed == nil {
+		t.Fatal("tryRefreshAfterUnauthorized() auth = nil")
+	}
+	if got := authAccessToken(refreshed); got != "fresh-access-token" {
+		t.Fatalf("refreshed access token = %q, want fresh-access-token", got)
+	}
+	current, ok := manager.GetByID(auth.ID)
+	if !ok || current == nil {
+		t.Fatal("refreshed runtime auth missing from manager")
+	}
+	if got := authAccessToken(current); got != "fresh-access-token" {
+		t.Fatalf("runtime access token = %q, want fresh-access-token", got)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_refresh_test.go
@@ -390,14 +390,15 @@ func TestManager_RefreshAuthAllowsPluginStorageWithoutRefreshToken(t *testing.T)
 	}
 }
 
-func TestManager_RefreshAuthRejectsTypeOnlyStoragePayload(t *testing.T) {
+func TestManager_RefreshAuthDefersPluginStorageRefreshabilityToExecutor(t *testing.T) {
 	ctx := context.Background()
 	manager := NewManager(nil, nil, nil)
 	manager.RegisterExecutor(planRefreshExecutor{})
+	// Nested provider-specific fields only; host must not reject before the executor runs.
 	auth := &Auth{
-		ID:       "plugin-type-only-storage",
+		ID:       "plugin-nested-storage",
 		Provider: "codex",
-		Storage:  &rawJSONRefreshStorage{raw: []byte(`{"type":"plugin","access_token":"access-only"}`)},
+		Storage:  &rawJSONRefreshStorage{raw: []byte(`{"type":"plugin","creds":{"refresh":"nested-material"}}`)},
 		Metadata: map[string]any{"access_token": "access-only"},
 	}
 	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
@@ -405,26 +406,14 @@ func TestManager_RefreshAuthRejectsTypeOnlyStoragePayload(t *testing.T) {
 	}
 
 	refreshed, errRefresh := manager.RefreshAuth(ctx, auth.ID)
-	if !errors.Is(errRefresh, ErrAuthNotRefreshable) {
-		t.Fatalf("RefreshAuth() error = %v, want ErrAuthNotRefreshable", errRefresh)
+	if errRefresh != nil {
+		t.Fatalf("RefreshAuth() error = %v", errRefresh)
 	}
-	if refreshed != nil {
-		t.Fatalf("RefreshAuth() auth = %#v, want nil", refreshed)
+	if refreshed == nil {
+		t.Fatal("RefreshAuth() auth = nil")
 	}
-}
-
-func TestStoragePayloadHasRefreshMaterial(t *testing.T) {
-	if !storagePayloadHasRefreshMaterial([]byte(`{"type":"plugin","token":"x"}`)) {
-		t.Fatal("expected token field to count as refresh material")
-	}
-	if storagePayloadHasRefreshMaterial([]byte(`{"type":"plugin","access_token":"x"}`)) {
-		t.Fatal("access_token alone must not count as refresh material")
-	}
-	if storagePayloadHasRefreshMaterial([]byte(`{"type":"plugin"}`)) {
-		t.Fatal("type-only payload must not count as refresh material")
-	}
-	if !storagePayloadHasRefreshMaterial([]byte("opaque-refresh-blob")) {
-		t.Fatal("opaque non-JSON payload should count as refresh material")
+	if got := authAccessToken(refreshed); got != "fresh-access-token" {
+		t.Fatalf("access token = %q, want fresh-access-token", got)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_refresh_test.go
@@ -1,0 +1,312 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type planRefreshExecutor struct{}
+
+type blockingPlanRefreshExecutor struct {
+	planRefreshExecutor
+	entered chan struct{}
+	release chan struct{}
+}
+
+type refreshFailingStore struct {
+	err error
+}
+
+type fileRefreshStore struct {
+	path string
+}
+
+func (s *refreshFailingStore) List(context.Context) ([]*Auth, error) { return nil, nil }
+
+func (s *refreshFailingStore) Save(context.Context, *Auth) (string, error) {
+	return "", s.err
+}
+
+func (s *refreshFailingStore) Delete(context.Context, string) error { return nil }
+
+func (s *fileRefreshStore) List(context.Context) ([]*Auth, error) { return nil, nil }
+
+func (s *fileRefreshStore) Save(_ context.Context, auth *Auth) (string, error) {
+	value := authMetadataString(auth, "access_token")
+	if errWrite := os.WriteFile(s.path, []byte(value), 0o600); errWrite != nil {
+		return "", errWrite
+	}
+	return s.path, nil
+}
+
+func (s *fileRefreshStore) Delete(context.Context, string) error {
+	return os.Remove(s.path)
+}
+
+func (planRefreshExecutor) Identifier() string { return "codex" }
+
+func (planRefreshExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (planRefreshExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+
+func (planRefreshExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	auth.Attributes["plan_type"] = "plus"
+	auth.Metadata["plan_type"] = "plus"
+	auth.Metadata["access_token"] = "fresh-access-token"
+	return auth, nil
+}
+
+func (e blockingPlanRefreshExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	e.entered <- struct{}{}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-e.release:
+	}
+	return e.planRefreshExecutor.Refresh(ctx, auth)
+}
+
+func (planRefreshExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (planRefreshExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestManager_RefreshAuthInvokesPostRefreshHook(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(planRefreshExecutor{})
+	auth := &Auth{
+		ID:         "codex-plan-refresh",
+		Provider:   "codex",
+		Attributes: map[string]string{"plan_type": "free"},
+		Metadata: map[string]any{
+			"access_token":  "stale-access-token",
+			"refresh_token": "refresh-token",
+		},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	var hooked *Auth
+	manager.SetPostRefreshHook(func(_ context.Context, refreshed *Auth) error {
+		hooked = refreshed.Clone()
+		return nil
+	})
+
+	refreshed, errRefresh := manager.RefreshAuth(ctx, auth.ID)
+	if errRefresh != nil {
+		t.Fatalf("RefreshAuth() error = %v", errRefresh)
+	}
+	if refreshed == nil {
+		t.Fatal("RefreshAuth() auth = nil")
+	}
+	if got := refreshed.Attributes["plan_type"]; got != "plus" {
+		t.Fatalf("refreshed plan_type = %q, want plus", got)
+	}
+	if hooked == nil {
+		t.Fatal("post-refresh hook was not called")
+	}
+	if got := hooked.Attributes["plan_type"]; got != "plus" {
+		t.Fatalf("hooked plan_type = %q, want plus", got)
+	}
+	if got, _ := hooked.Metadata["access_token"].(string); got != "fresh-access-token" {
+		t.Fatalf("hooked access_token = %q, want fresh-access-token", got)
+	}
+}
+
+func TestManager_RefreshAuthRejectsAuthWithoutRefreshMechanism(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(planRefreshExecutor{})
+	auth := &Auth{
+		ID:       "codex-not-refreshable",
+		Provider: "codex",
+		Metadata: map[string]any{"access_token": "access-token"},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	refreshed, errRefresh := manager.RefreshAuth(ctx, auth.ID)
+	if !errors.Is(errRefresh, ErrAuthNotRefreshable) {
+		t.Fatalf("RefreshAuth() error = %v, want ErrAuthNotRefreshable", errRefresh)
+	}
+	if refreshed != nil {
+		t.Fatalf("RefreshAuth() auth = %#v, want nil", refreshed)
+	}
+	current, ok := manager.GetByID(auth.ID)
+	if !ok || current == nil {
+		t.Fatal("auth missing after rejected refresh")
+	}
+	if !current.LastRefreshedAt.IsZero() {
+		t.Fatalf("LastRefreshedAt = %v, want zero", current.LastRefreshedAt)
+	}
+}
+
+func TestManager_RefreshAuthDoesNotRestoreConcurrentlyRemovedAuth(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, nil, nil)
+	executor := blockingPlanRefreshExecutor{
+		entered: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "codex-removed-during-refresh",
+		Provider: "codex",
+		Metadata: map[string]any{"refresh_token": "refresh-token"},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+	hookCalled := false
+	manager.SetPostRefreshHook(func(context.Context, *Auth) error {
+		hookCalled = true
+		return nil
+	})
+
+	type refreshResult struct {
+		auth *Auth
+		err  error
+	}
+	result := make(chan refreshResult, 1)
+	go func() {
+		refreshed, errRefresh := manager.RefreshAuth(ctx, auth.ID)
+		result <- refreshResult{auth: refreshed, err: errRefresh}
+	}()
+
+	<-executor.entered
+	removeDone := make(chan struct{})
+	go func() {
+		manager.Remove(ctx, auth.ID)
+		close(removeDone)
+	}()
+	close(executor.release)
+	got := <-result
+	if got.err != nil {
+		t.Fatalf("RefreshAuth() error = %v", got.err)
+	}
+	if got.auth == nil {
+		t.Fatal("RefreshAuth() auth = nil")
+	}
+	<-removeDone
+	if _, ok := manager.GetByID(auth.ID); ok {
+		t.Fatal("concurrently removed auth was restored")
+	}
+	if !hookCalled {
+		t.Fatal("post-refresh hook was not called before serialized removal")
+	}
+}
+
+func TestManager_RemoveWithCleanupDeletesCredentialAfterConcurrentRefresh(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "codex.json")
+	store := &fileRefreshStore{path: path}
+	manager := NewManager(store, nil, nil)
+	executor := blockingPlanRefreshExecutor{
+		entered: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "codex-delete-during-refresh",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"access_token":  "stale-access-token",
+			"refresh_token": "refresh-token",
+		},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	refreshResult := make(chan error, 1)
+	go func() {
+		_, errRefresh := manager.RefreshAuth(ctx, auth.ID)
+		refreshResult <- errRefresh
+	}()
+	<-executor.entered
+
+	removeStarted := make(chan struct{})
+	cleanupEntered := make(chan struct{})
+	removeResult := make(chan error, 1)
+	go func() {
+		close(removeStarted)
+		removeResult <- manager.RemoveWithCleanup(ctx, auth.ID, func() error {
+			close(cleanupEntered)
+			return os.Remove(path)
+		})
+	}()
+	<-removeStarted
+	select {
+	case <-cleanupEntered:
+		t.Fatal("cleanup ran before the in-flight refresh released its auth lock")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(executor.release)
+	if errRefresh := <-refreshResult; errRefresh != nil {
+		t.Fatalf("RefreshAuth() error = %v", errRefresh)
+	}
+	if errRemove := <-removeResult; errRemove != nil {
+		t.Fatalf("RemoveWithCleanup() error = %v", errRemove)
+	}
+	if _, errStat := os.Stat(path); !os.IsNotExist(errStat) {
+		t.Fatalf("credential file still exists after serialized removal: %v", errStat)
+	}
+	if _, ok := manager.GetByID(auth.ID); ok {
+		t.Fatal("auth remains registered after serialized removal")
+	}
+}
+
+func TestManager_RefreshAuthReturnsPersistenceFailureAfterPostRefreshHook(t *testing.T) {
+	ctx := context.Background()
+	persistErr := errors.New("save failed")
+	manager := NewManager(&refreshFailingStore{err: persistErr}, nil, nil)
+	manager.RegisterExecutor(planRefreshExecutor{})
+	auth := &Auth{
+		ID:       "codex-refresh-persist-failure",
+		Provider: "codex",
+		Metadata: map[string]any{"refresh_token": "refresh-token"},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+	hookCalled := false
+	manager.SetPostRefreshHook(func(context.Context, *Auth) error {
+		hookCalled = true
+		return nil
+	})
+
+	refreshed, errRefresh := manager.RefreshAuth(ctx, auth.ID)
+	if !errors.Is(errRefresh, persistErr) {
+		t.Fatalf("RefreshAuth() error = %v, want persistence failure", errRefresh)
+	}
+	if refreshed == nil {
+		t.Fatal("RefreshAuth() auth = nil, want updated runtime auth")
+	}
+	if !hookCalled {
+		t.Fatal("post-refresh hook was not called for the updated runtime auth")
+	}
+}

--- a/sdk/cliproxy/auth/conductor_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_refresh_test.go
@@ -390,6 +390,44 @@ func TestManager_RefreshAuthAllowsPluginStorageWithoutRefreshToken(t *testing.T)
 	}
 }
 
+func TestManager_RefreshAuthRejectsTypeOnlyStoragePayload(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(planRefreshExecutor{})
+	auth := &Auth{
+		ID:       "plugin-type-only-storage",
+		Provider: "codex",
+		Storage:  &rawJSONRefreshStorage{raw: []byte(`{"type":"plugin","access_token":"access-only"}`)},
+		Metadata: map[string]any{"access_token": "access-only"},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	refreshed, errRefresh := manager.RefreshAuth(ctx, auth.ID)
+	if !errors.Is(errRefresh, ErrAuthNotRefreshable) {
+		t.Fatalf("RefreshAuth() error = %v, want ErrAuthNotRefreshable", errRefresh)
+	}
+	if refreshed != nil {
+		t.Fatalf("RefreshAuth() auth = %#v, want nil", refreshed)
+	}
+}
+
+func TestStoragePayloadHasRefreshMaterial(t *testing.T) {
+	if !storagePayloadHasRefreshMaterial([]byte(`{"type":"plugin","token":"x"}`)) {
+		t.Fatal("expected token field to count as refresh material")
+	}
+	if storagePayloadHasRefreshMaterial([]byte(`{"type":"plugin","access_token":"x"}`)) {
+		t.Fatal("access_token alone must not count as refresh material")
+	}
+	if storagePayloadHasRefreshMaterial([]byte(`{"type":"plugin"}`)) {
+		t.Fatal("type-only payload must not count as refresh material")
+	}
+	if !storagePayloadHasRefreshMaterial([]byte("opaque-refresh-blob")) {
+		t.Fatal("opaque non-JSON payload should count as refresh material")
+	}
+}
+
 func TestManager_RemovePathWithCleanupLocksSiblingAuthsBeforeDelete(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "plugin-shared.json")

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -290,8 +290,10 @@ func (b *Builder) Build() (*Service, error) {
 	if b.postAuthHook != nil {
 		service.serverOptions = append(service.serverOptions, api.WithPostAuthHook(b.postAuthHook))
 	}
+	runtimeAuthSyncHook := service.runtimeAuthSyncHook()
+	coreManager.SetPostRefreshHook(service.runtimeAuthRefreshHook())
 	service.serverOptions = append(service.serverOptions,
-		api.WithPostAuthPersistHook(service.runtimeAuthSyncHook()),
+		api.WithPostAuthPersistHook(runtimeAuthSyncHook),
 		api.WithPluginHost(pluginHost),
 		api.WithConfigReloadHook(func(_ context.Context, _ *config.Config) {
 			service.reloadConfigFromWatcher()
@@ -302,19 +304,9 @@ func (b *Builder) Build() (*Service, error) {
 
 func (s *Service) runtimeAuthSyncHook() coreauth.PostAuthHook {
 	return func(ctx context.Context, auth *coreauth.Auth) error {
-		if s == nil || auth == nil || auth.ID == "" {
+		update, ok := s.runtimeAuthUpdate(auth)
+		if !ok {
 			return nil
-		}
-		action := watcher.AuthUpdateActionAdd
-		if s.coreManager != nil {
-			if _, ok := s.coreManager.GetByID(auth.ID); ok {
-				action = watcher.AuthUpdateActionModify
-			}
-		}
-		update := watcher.AuthUpdate{
-			Action: action,
-			ID:     auth.ID,
-			Auth:   auth,
 		}
 		if s.watcher != nil && s.watcher.DispatchPersistedAuthUpdate(update) {
 			return nil
@@ -322,4 +314,32 @@ func (s *Service) runtimeAuthSyncHook() coreauth.PostAuthHook {
 		s.handleAuthUpdate(coreauth.WithSkipPersist(ctx), update)
 		return nil
 	}
+}
+
+func (s *Service) runtimeAuthRefreshHook() coreauth.PostRefreshHook {
+	return func(ctx context.Context, auth *coreauth.Auth) error {
+		update, ok := s.runtimeAuthUpdate(auth)
+		if !ok {
+			return nil
+		}
+		s.handleAuthUpdate(coreauth.WithSkipPersist(ctx), update)
+		return nil
+	}
+}
+
+func (s *Service) runtimeAuthUpdate(auth *coreauth.Auth) (watcher.AuthUpdate, bool) {
+	if s == nil || auth == nil || auth.ID == "" {
+		return watcher.AuthUpdate{}, false
+	}
+	action := watcher.AuthUpdateActionAdd
+	if s.coreManager != nil {
+		if _, ok := s.coreManager.GetByID(auth.ID); ok {
+			action = watcher.AuthUpdateActionModify
+		}
+	}
+	return watcher.AuthUpdate{
+		Action: action,
+		ID:     auth.ID,
+		Auth:   auth,
+	}, true
 }

--- a/sdk/cliproxy/service_codex_plan_refresh_test.go
+++ b/sdk/cliproxy/service_codex_plan_refresh_test.go
@@ -1,0 +1,101 @@
+package cliproxy
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+type serviceCodexPlanRefreshExecutor struct{}
+
+func (serviceCodexPlanRefreshExecutor) Identifier() string { return "codex" }
+
+func (serviceCodexPlanRefreshExecutor) Execute(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (serviceCodexPlanRefreshExecutor) ExecuteStream(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+
+func (serviceCodexPlanRefreshExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	auth.Attributes["plan_type"] = "plus"
+	return auth, nil
+}
+
+func (serviceCodexPlanRefreshExecutor) CountTokens(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (serviceCodexPlanRefreshExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestServiceCodexPlanRefreshReregistersPlusModels(t *testing.T) {
+	ctx := context.Background()
+	manager := coreauth.NewManager(nil, nil, nil)
+	service, errBuild := NewBuilder().
+		WithConfig(&config.Config{}).
+		WithConfigPath(filepath.Join(t.TempDir(), "config.yaml")).
+		WithCoreAuthManager(manager).
+		Build()
+	if errBuild != nil {
+		t.Fatalf("Build() error = %v", errBuild)
+	}
+	service.watcher = &WatcherWrapper{
+		dispatchPersistedAuth: func(watcher.AuthUpdate) bool { return true },
+	}
+	manager.RegisterExecutor(serviceCodexPlanRefreshExecutor{})
+
+	auth := &coreauth.Auth{
+		ID:         "codex-free-to-plus",
+		Provider:   "codex",
+		Attributes: map[string]string{"plan_type": "free"},
+		Metadata: map[string]any{
+			"access_token":  "stale-access-token",
+			"refresh_token": "refresh-token",
+		},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+	service.registerModelsForAuth(ctx, auth)
+	manager.RefreshSchedulerEntry(auth.ID)
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	if hasModel(registry.GetGlobalRegistry().GetModelsForClient(auth.ID), "gpt-5.6-sol") {
+		t.Fatal("free Codex auth unexpectedly exposes gpt-5.6-sol before refresh")
+	}
+
+	refreshed, errRefresh := manager.RefreshAuth(ctx, auth.ID)
+	if errRefresh != nil {
+		t.Fatalf("RefreshAuth() error = %v", errRefresh)
+	}
+	if refreshed == nil || refreshed.Attributes["plan_type"] != "plus" {
+		t.Fatalf("refreshed auth = %#v, want plus plan", refreshed)
+	}
+	if !hasModel(registry.GetGlobalRegistry().GetModelsForClient(auth.ID), "gpt-5.6-sol") {
+		t.Fatal("plus Codex auth does not expose gpt-5.6-sol after refresh")
+	}
+}
+
+func hasModel(models []*registry.ModelInfo, id string) bool {
+	for _, model := range models {
+		if model != nil && model.ID == id {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Fix Codex accounts remaining on the model catalog of their original subscription after the account plan changes. A credential imported while the account was Free can now expose Plus-only models such as `gpt-5.6-sol` after its tokens are refreshed.

## Problem and root cause

Codex `plan_type` is derived from the ID token when an auth file is initially loaded. Token refresh replaced `id_token` and `access_token`, but did not update the runtime `plan_type` attribute or rebuild the client model registration and scheduler entry. As a result, upgrading the account did not change the models available to that auth until credentials were re-imported or the service state was rebuilt.

## Purpose

- Keep plan-dependent Codex model availability aligned with the latest refreshed ID token.
- Allow management clients to force a credential refresh immediately after a plan change instead of waiting for token expiry.
- Avoid requiring users to delete and re-import credentials or restart the service.

## Why this approach

The refreshed ID token is the authoritative point where the updated subscription claim becomes available. Synchronizing `plan_type` during credential refresh keeps the persisted credential and runtime auth consistent. A synchronous post-refresh hook then rebuilds model registration before the refresh operation completes, avoiding dependence on file-watcher timing.

The new management endpoint provides an explicit operator action for accounts upgraded before their current token expires. Refresh and removal share a per-auth lock so a concurrent delete cannot be undone by an in-flight refresh rewriting the credential.

## Changes

- Synchronize Codex `plan_type` from refreshed ID tokens, including Home refreshes.
- Re-register runtime models and refresh scheduler state after credential refresh.
- Add `POST /auth-files/refresh`, selectable by auth ID or filename, with a secret-free response.
- Propagate refresh persistence failures while keeping the updated runtime model state consistent.
- Serialize credential cleanup with refresh to prevent deleted auth files from being restored.

## Testing

- `go test ./...`
- Focused race tests for auth refresh/removal, service model registration, management handlers, and Codex plan synchronization
- `go vet ./sdk/cliproxy/auth ./sdk/cliproxy ./internal/runtime/executor ./internal/api/handlers/management`
- `go build -o test-output ./cmd/server`
- `git diff --check`

## Related

- https://github.com/seakee/CPA-Manager-Plus/issues/414

Refs #4482.
