### PR TITLE
perf(codex): precompute reasoning replay input fingerprints

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -500,6 +500,13 @@ func insertCodexReasoningReplayTurns(body []byte, replayItems [][]byte) ([]byte,
 	}
 	inputItems := input.Array()
 	turns := splitCodexReasoningReplayTurns(replayItems)
+	var inputPrefixFingerprints []string
+	for _, turn := range turns {
+		if turn.requestFingerprint != "" {
+			inputPrefixFingerprints = codexReplayInputPrefixFingerprints(body, inputItems)
+			break
+		}
+	}
 	insertions := make(map[int][][]byte)
 	usedAnchorIndexes := make(map[int]bool)
 	fallbackAnchorEnd := len(inputItems) - 1
@@ -521,7 +528,7 @@ func insertCodexReasoningReplayTurns(body []byte, replayItems [][]byte) ([]byte,
 			continue
 		}
 
-		anchorIndex, matched := codexReasoningReplayTurnAnchorIndex(inputItems, turn, fallbackAnchorEnd, usedAnchorIndexes)
+		anchorIndex, matched := codexReasoningReplayTurnAnchorIndex(inputItems, inputPrefixFingerprints, turn, fallbackAnchorEnd, usedAnchorIndexes)
 		if !matched {
 			continue
 		}
@@ -590,7 +597,7 @@ func splitCodexReasoningReplayTurns(items [][]byte) []codexReasoningReplayTurn {
 	return turns
 }
 
-func codexReasoningReplayTurnAnchorIndex(inputItems []gjson.Result, turn codexReasoningReplayTurn, fallbackEnd int, used map[int]bool) (int, bool) {
+func codexReasoningReplayTurnAnchorIndex(inputItems []gjson.Result, inputPrefixFingerprints []string, turn codexReasoningReplayTurn, fallbackEnd int, used map[int]bool) (int, bool) {
 	searchEnd := fallbackEnd
 	if turn.requestFingerprint != "" {
 		searchEnd = len(inputItems) - 1
@@ -599,7 +606,7 @@ func codexReasoningReplayTurnAnchorIndex(inputItems []gjson.Result, turn codexRe
 		searchEnd = len(inputItems) - 1
 	}
 	matchesRequestPrefix := func(index int) bool {
-		return turn.requestFingerprint == "" || codexReplayInputPrefixFingerprint(inputItems, index) == turn.requestFingerprint
+		return turn.requestFingerprint == "" || (index >= 0 && index < len(inputPrefixFingerprints) && inputPrefixFingerprints[index] == turn.requestFingerprint)
 	}
 	if len(turn.callIDs) > 0 {
 		callIDs := make(map[string]bool)
@@ -738,6 +745,19 @@ func codexReplayInputPrefixFingerprint(inputItems []gjson.Result, end int) strin
 		_, _ = hasher.Write([]byte(inputItems[index].Raw))
 	}
 	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+func codexReplayInputPrefixFingerprints(body []byte, inputItems []gjson.Result) []string {
+	fingerprints := make([]string, len(inputItems)+1)
+	hasher := sha256.New()
+	fingerprints[0] = hex.EncodeToString(hasher.Sum(nil))
+	for index, inputItem := range inputItems {
+		_, _ = hasher.Write([]byte("\x00item\x00"))
+		rawBytes := body[inputItem.Index : inputItem.Index+len(inputItem.Raw)]
+		_, _ = hasher.Write(rawBytes)
+		fingerprints[index+1] = hex.EncodeToString(hasher.Sum(nil))
+	}
+	return fingerprints
 }
 
 func filterCodexReasoningReplayItemsForInput(body []byte, items [][]byte) [][]byte {

--- a/internal/runtime/executor/codex_executor_reasoning_replay_cache_test.go
+++ b/internal/runtime/executor/codex_executor_reasoning_replay_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1089,4 +1090,55 @@ func TestCodexExecutorReasoningReplayCacheMatchesShortenedClaudeToolResultCallID
 	if got := gjson.GetBytes(secondBody, "input.3.call_id").String(); got != shortCallID {
 		t.Fatalf("input.3.call_id = %q, want shortened call_id %q; body=%s", got, shortCallID, string(secondBody))
 	}
+}
+
+func BenchmarkInsertCodexReasoningReplayTurnsLargeHistory(b *testing.B) {
+	body, replayItems := codexReasoningReplayLargeHistoryFixture(384, 4096, 32)
+	b.ReportMetric(float64(len(body)), "body_bytes")
+	b.ReportMetric(float64(len(replayItems)/2), "replay_turns")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		updated, inserted := insertCodexReasoningReplayTurns(body, replayItems)
+		if inserted || len(updated) != len(body) {
+			b.Fatalf("unexpected replay insertion: inserted=%t body_bytes=%d updated_bytes=%d", inserted, len(body), len(updated))
+		}
+	}
+}
+
+func TestCodexReplayInputPrefixFingerprintsMatchSingleCalculation(t *testing.T) {
+	body := []byte(`{"input":[{"type":"message","role":"user","content":"one"},{"type":"message","role":"assistant","content":"two"},{"type":"message","role":"user","content":"three"}]}`)
+	inputItems := gjson.GetBytes(body, "input").Array()
+	fingerprints := codexReplayInputPrefixFingerprints(body, inputItems)
+	if len(fingerprints) != len(inputItems)+1 {
+		t.Fatalf("fingerprint count = %d, want %d", len(fingerprints), len(inputItems)+1)
+	}
+	for end := 0; end <= len(inputItems); end++ {
+		if got, want := fingerprints[end], codexReplayInputPrefixFingerprint(inputItems, end); got != want {
+			t.Fatalf("fingerprint[%d] = %q, want %q", end, got, want)
+		}
+	}
+}
+
+func codexReasoningReplayLargeHistoryFixture(inputItemCount, textBytes, replayTurnCount int) ([]byte, [][]byte) {
+	text := strings.Repeat("x", textBytes)
+	var body strings.Builder
+	body.Grow(inputItemCount * (textBytes + 96))
+	body.WriteString(`{"model":"gpt-5.4","input":[`)
+	for index := 0; index < inputItemCount; index++ {
+		if index > 0 {
+			body.WriteByte(',')
+		}
+		_, _ = fmt.Fprintf(&body, `{"type":"message","role":"user","content":[{"type":"input_text","text":"%s-%d"}]}`, text, index)
+	}
+	body.WriteString(`]}`)
+
+	replayItems := make([][]byte, 0, replayTurnCount*2)
+	for index := 0; index < replayTurnCount; index++ {
+		replayItems = append(replayItems,
+			[]byte(fmt.Sprintf(`{"type":"%s","id":"turn-%d","request_fingerprint":"missing-prefix-%d","call_ids":["missing-call-%d"]}`, internalcache.CodexReasoningReplayTurnType, index, index, index)),
+			[]byte(fmt.Sprintf(`{"type":"reasoning","encrypted_content":"missing-reasoning-%d"}`, index)),
+		)
+	}
+	return []byte(body.String()), replayItems
 }


### PR DESCRIPTION
## Summary

- Precompute Codex reasoning replay input prefix fingerprints once per request.
- Reuse the precomputed fingerprints while matching replay turns instead of hashing the same prefixes repeatedly.
- Only build the fingerprint table when the request contains reasoning replay fingerprints.

## Root cause

`codexReasoningReplayTurnAnchorIndex` recalculated a SHA-256 fingerprint from `input[0]` for every replay turn and every candidate input index. With large histories, this caused repeated high-order scans and made otherwise fast upstream requests appear to stall inside the proxy.

## Fix

Build all input prefix fingerprints incrementally in one pass and look them up by candidate index during replay matching. The matching behavior remains unchanged; only redundant hashing is removed.

## Benchmark

Large-history reasoning replay benchmark:

| Version | Time/op | Memory/op | Allocs/op |
| --- | ---: | ---: | ---: |
| Before | 79.18 s | 11.45 GB | 2,390,583 |
| After | 11.6-18.4 ms | 3.70 MB | 1,852 |

## Testing

- Added equivalence coverage for precomputed prefix fingerprints.
- Added a large-history reasoning replay benchmark.
- Ran the targeted reasoning replay tests.
- Ran `go test ./...` successfully.