### PR TITLE
fix(codex/claude): preserve Responses cache-write usage in Anthropic responses

### DIFF
--- a/internal/translator/codex/claude/codex_claude_response.go
+++ b/internal/translator/codex/claude/codex_claude_response.go
@@ -141,11 +141,14 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 		output = appendPendingCodexFunctionCallsFromTerminal(output, params, originalRequestRawJSON, responseData)
 		template, _ = sjson.SetBytes(template, "delta.stop_reason", mapCodexStopReasonToClaude(codexStopReason(responseData), params.HasEmittedToolUse))
 		template = setClaudeStopSequence(template, "delta.stop_sequence", responseData)
-		inputTokens, outputTokens, cachedTokens := extractResponsesUsage(responseData.Get("usage"))
+		inputTokens, outputTokens, cachedTokens, cacheWriteTokens := extractResponsesUsage(responseData.Get("usage"))
 		template, _ = sjson.SetBytes(template, "usage.input_tokens", inputTokens)
 		template, _ = sjson.SetBytes(template, "usage.output_tokens", outputTokens)
 		if cachedTokens > 0 {
 			template, _ = sjson.SetBytes(template, "usage.cache_read_input_tokens", cachedTokens)
+		}
+		if cacheWriteTokens > 0 {
+			template, _ = sjson.SetBytes(template, "usage.cache_creation_input_tokens", cacheWriteTokens)
 		}
 
 		output = translatorcommon.AppendSSEEventBytes(output, "message_delta", template, 2)
@@ -352,11 +355,14 @@ func ConvertCodexResponseToClaudeNonStream(_ context.Context, _ string, original
 	out := []byte(`{"id":"","type":"message","role":"assistant","model":"","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}`)
 	out, _ = sjson.SetBytes(out, "id", responseData.Get("id").String())
 	out, _ = sjson.SetBytes(out, "model", responseData.Get("model").String())
-	inputTokens, outputTokens, cachedTokens := extractResponsesUsage(responseData.Get("usage"))
+	inputTokens, outputTokens, cachedTokens, cacheWriteTokens := extractResponsesUsage(responseData.Get("usage"))
 	out, _ = sjson.SetBytes(out, "usage.input_tokens", inputTokens)
 	out, _ = sjson.SetBytes(out, "usage.output_tokens", outputTokens)
 	if cachedTokens > 0 {
 		out, _ = sjson.SetBytes(out, "usage.cache_read_input_tokens", cachedTokens)
+	}
+	if cacheWriteTokens > 0 {
+		out, _ = sjson.SetBytes(out, "usage.cache_creation_input_tokens", cacheWriteTokens)
 	}
 
 	hasToolCall := false
@@ -778,14 +784,15 @@ func resolveCodexClaudeToolUseName(originalRequestRawJSON []byte, name string) s
 	return name
 }
 
-func extractResponsesUsage(usage gjson.Result) (int64, int64, int64) {
+func extractResponsesUsage(usage gjson.Result) (int64, int64, int64, int64) {
 	if !usage.Exists() || usage.Type == gjson.Null {
-		return 0, 0, 0
+		return 0, 0, 0, 0
 	}
 
 	inputTokens := usage.Get("input_tokens").Int()
 	outputTokens := usage.Get("output_tokens").Int()
 	cachedTokens := usage.Get("input_tokens_details.cached_tokens").Int()
+	cacheWriteTokens := usage.Get("input_tokens_details.cache_write_tokens").Int()
 
 	if cachedTokens > 0 {
 		if inputTokens >= cachedTokens {
@@ -795,7 +802,7 @@ func extractResponsesUsage(usage gjson.Result) (int64, int64, int64) {
 		}
 	}
 
-	return inputTokens, outputTokens, cachedTokens
+	return inputTokens, outputTokens, cachedTokens, cacheWriteTokens
 }
 
 // buildReverseMapFromClaudeOriginalShortToOriginal builds a map[short]original from original Claude request tools.

--- a/internal/translator/codex/claude/codex_claude_response_cachewrite_test.go
+++ b/internal/translator/codex/claude/codex_claude_response_cachewrite_test.go
@@ -1,0 +1,101 @@
+package claude
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// The Codex Responses API reports cache-write tokens under
+// usage.input_tokens_details.cache_write_tokens. Anthropic's response schema
+// carries the same figure as usage.cache_creation_input_tokens. The sibling
+// Codex->OpenAI translator already maps it; these tests pin the Codex->Claude
+// path so it is no longer dropped (upstream issue #4262). Without the mapping,
+// clients reading the Anthropic usage block under-report cost and context.
+
+func TestConvertCodexResponseToClaude_StreamPreservesCacheWriteTokens(t *testing.T) {
+	ctx := context.Background()
+	originalRequest := []byte(`{"messages":[]}`)
+	var param any
+
+	chunks := [][]byte{
+		[]byte(`data: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5.6-sol"}}`),
+		[]byte(`data: {"type":"response.completed","response":{"id":"resp_1","usage":{"input_tokens":100,"output_tokens":20,"input_tokens_details":{"cached_tokens":30,"cache_write_tokens":40}}}}`),
+	}
+
+	var outputs [][]byte
+	for _, chunk := range chunks {
+		outputs = append(outputs, ConvertCodexResponseToClaude(ctx, "", originalRequest, nil, chunk, &param)...)
+	}
+
+	var delta gjson.Result
+	found := false
+	for _, out := range outputs {
+		for _, line := range strings.Split(string(out), "\n") {
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			d := gjson.Parse(strings.TrimPrefix(line, "data: "))
+			if d.Get("type").String() == "message_delta" {
+				delta = d
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no message_delta emitted; outputs=%v", outputs)
+	}
+
+	if got := delta.Get("usage.cache_creation_input_tokens"); !got.Exists() {
+		t.Fatalf("cache_creation_input_tokens missing; delta=%s", delta.Raw)
+	} else if got.Int() != 40 {
+		t.Fatalf("cache_creation_input_tokens = %d, want 40; delta=%s", got.Int(), delta.Raw)
+	}
+	// input_tokens still has cached reads subtracted (100 - 30), unchanged behavior.
+	if got := delta.Get("usage.input_tokens").Int(); got != 70 {
+		t.Fatalf("input_tokens = %d, want 70; delta=%s", got, delta.Raw)
+	}
+	if got := delta.Get("usage.cache_read_input_tokens").Int(); got != 30 {
+		t.Fatalf("cache_read_input_tokens = %d, want 30; delta=%s", got, delta.Raw)
+	}
+}
+
+func TestConvertCodexResponseToClaude_StreamOmitsCacheWriteWhenZero(t *testing.T) {
+	ctx := context.Background()
+	var param any
+	chunks := [][]byte{
+		[]byte(`data: {"type":"response.created","response":{"id":"resp_2","model":"gpt-5.6-sol"}}`),
+		[]byte(`data: {"type":"response.completed","response":{"id":"resp_2","usage":{"input_tokens":10,"output_tokens":2,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":0}}}}`),
+	}
+	var outputs [][]byte
+	for _, chunk := range chunks {
+		outputs = append(outputs, ConvertCodexResponseToClaude(ctx, "", []byte(`{"messages":[]}`), nil, chunk, &param)...)
+	}
+	for _, out := range outputs {
+		for _, line := range strings.Split(string(out), "\n") {
+			d := gjson.Parse(strings.TrimPrefix(line, "data: "))
+			if d.Get("type").String() == "message_delta" &&
+				d.Get("usage.cache_creation_input_tokens").Exists() {
+				t.Fatalf("cache_creation_input_tokens should be omitted when zero; delta=%s", d.Raw)
+			}
+		}
+	}
+}
+
+func TestConvertCodexResponseToClaudeNonStream_PreservesCacheWriteTokens(t *testing.T) {
+	raw := []byte(`{"type":"response.completed","response":{"id":"resp_3","model":"gpt-5.6-sol","usage":{"input_tokens":100,"output_tokens":20,"input_tokens_details":{"cached_tokens":30,"cache_write_tokens":40}},"output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}}`)
+	out := ConvertCodexResponseToClaudeNonStream(context.Background(), "", []byte(`{"messages":[]}`), nil, raw, nil)
+
+	got := gjson.GetBytes(out, "usage.cache_creation_input_tokens")
+	if !got.Exists() {
+		t.Fatalf("cache_creation_input_tokens missing; out=%s", string(out))
+	}
+	if got.Int() != 40 {
+		t.Fatalf("cache_creation_input_tokens = %d, want 40; out=%s", got.Int(), string(out))
+	}
+	if v := gjson.GetBytes(out, "usage.input_tokens").Int(); v != 70 {
+		t.Fatalf("input_tokens = %d, want 70; out=%s", v, string(out))
+	}
+}


### PR DESCRIPTION
## Problem

The Codex→Claude response translator reads `input_tokens_details.cached_tokens` (→ `cache_read_input_tokens`) but drops `input_tokens_details.cache_write_tokens`. So on the Anthropic-shaped path, `usage.cache_creation_input_tokens` is never set.

Two consequences for clients (e.g. Claude Code pointed at the proxy):

- **Cost is under-reported** — cache writes bill at 1.25× uncached input, and that spend is invisible.
- **Context usage reads low** — Claude Code computes the window as `input_tokens + cache_creation_input_tokens + cache_read_input_tokens`; a missing `cache_creation` term means the context bar under-counts real usage.

## Fix

Mirror what the sibling **Codex→OpenAI** translator already does. It maps the same upstream field at `codex_openai_response.go`:

```go
input_tokens_details.cache_write_tokens  ->  prompt_tokens_details.cached_creation_tokens
```

This PR does the Anthropic-shape equivalent — `input_tokens_details.cache_write_tokens` → `usage.cache_creation_input_tokens` — at both the streaming `message_delta` and non-streaming call sites, guarded `> 0` exactly like the existing `cache_read` mapping so nothing is emitted when absent.

The change threads one extra return value through `extractResponsesUsage`; no behavior changes for `input_tokens` (cached reads are still subtracted), `output_tokens`, or `cache_read_input_tokens`.

## Tests

`codex_claude_response_cachewrite_test.go` covers:
- stream: `cache_write_tokens: 40` → `usage.cache_creation_input_tokens: 40`, with `input_tokens` (70) and `cache_read_input_tokens` (30) unchanged
- stream: omitted when `cache_write_tokens: 0`
- non-stream: same preservation

Full `./internal/translator/codex/...` suite passes (`go test`, go 1.26).

Fixes #4262.
