### PR TITLE
feat(api): expose account subscription limits

### DIFF
--- a/internal/accountlimits/limits.go
+++ b/internal/accountlimits/limits.go
@@ -393,9 +393,45 @@ func cloneSnapshots(snapshots []ProviderLimitSnapshot) []ProviderLimitSnapshot {
 	cloned := make([]ProviderLimitSnapshot, len(snapshots))
 	copy(cloned, snapshots)
 	for i := range cloned {
+		if cloned[i].LimitName != nil {
+			name := *cloned[i].LimitName
+			cloned[i].LimitName = &name
+		}
 		if cloned[i].Primary != nil {
 			primary := *cloned[i].Primary
+			if primary.WindowMinutes != nil {
+				windowMinutes := *primary.WindowMinutes
+				primary.WindowMinutes = &windowMinutes
+			}
+			if primary.ResetsAt != nil {
+				resetsAt := *primary.ResetsAt
+				primary.ResetsAt = &resetsAt
+			}
 			cloned[i].Primary = &primary
+		}
+		if cloned[i].Secondary != nil {
+			secondary := *cloned[i].Secondary
+			if secondary.WindowMinutes != nil {
+				windowMinutes := *secondary.WindowMinutes
+				secondary.WindowMinutes = &windowMinutes
+			}
+			if secondary.ResetsAt != nil {
+				resetsAt := *secondary.ResetsAt
+				secondary.ResetsAt = &resetsAt
+			}
+			cloned[i].Secondary = &secondary
+		}
+		if cloned[i].Credits != nil {
+			credits := *cloned[i].Credits
+			if credits.Balance != nil {
+				balance := *credits.Balance
+				credits.Balance = &balance
+			}
+			cloned[i].Credits = &credits
+		}
+		if cloned[i].PlanType != nil {
+			planType := *cloned[i].PlanType
+			cloned[i].PlanType = &planType
 		}
 		if cloned[i].RateLimitReachedType != nil {
 			status := *cloned[i].RateLimitReachedType

--- a/internal/accountlimits/limits.go
+++ b/internal/accountlimits/limits.go
@@ -2,6 +2,7 @@ package accountlimits
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -86,21 +87,42 @@ func ProviderLimitsForAccount(accountID string) ProviderLimitsPayload {
 }
 
 func OpenAIProviderLimitsFromUsage(accountID string, payload map[string]any) ProviderLimitsPayload {
+	snapshots := []ProviderLimitSnapshot{openAIRateLimitSnapshot("codex", nil, payload)}
+	if additional, ok := payload["additional_rate_limits"].([]any); ok {
+		for index, raw := range additional {
+			entry := asMap(raw)
+			if entry == nil {
+				continue
+			}
+			limitID := firstString(entry, "limit_id", "id", "metered_feature", "limit_name", "name")
+			if limitID == "" {
+				limitID = fmt.Sprintf("additional_%d", index+1)
+			}
+			limitName := firstString(entry, "limit_name", "name")
+			snapshots = append(snapshots, openAIRateLimitSnapshot(limitID, stringPointer(limitName), entry))
+		}
+	}
 	return ProviderLimitsPayload{
 		Object:    ProviderLimitsObject,
 		AccountID: normalizeAccountID(accountID),
 		Provider:  ProviderOpenAI,
 		Source:    "usage_endpoint",
-		Snapshots: []ProviderLimitSnapshot{openAIRateLimitSnapshot(payload)},
+		Snapshots: snapshots,
 	}
 }
 
-func openAIRateLimitSnapshot(payload map[string]any) ProviderLimitSnapshot {
-	rateLimit, _ := payload["rate_limit"].(map[string]any)
+func openAIRateLimitSnapshot(limitID string, limitName *string, payload map[string]any) ProviderLimitSnapshot {
+	rateLimit := asMap(payload["rate_limit"])
+	if rateLimit == nil {
+		rateLimit = payload
+	}
 	reachedType := openAIRateLimitReachedType(payload["rate_limit_reached_type"])
+	if reachedType == nil {
+		reachedType = openAIRateLimitReachedType(rateLimit["rate_limit_reached_type"])
+	}
 	return ProviderLimitSnapshot{
-		LimitID:              "codex",
-		LimitName:            nil,
+		LimitID:              limitID,
+		LimitName:            limitName,
 		Primary:              openAIRateLimitWindow(asMap(rateLimit["primary_window"])),
 		Secondary:            openAIRateLimitWindow(asMap(rateLimit["secondary_window"])),
 		Credits:              openAICreditsSnapshot(asMap(payload["credits"])),
@@ -240,11 +262,29 @@ func openAICreditsSnapshot(credits map[string]any) *CreditsSnapshot {
 }
 
 func openAIRateLimitReachedType(value any) *string {
-	kind := stringOrNil(asMap(value)["kind"])
-	if kind == nil || *kind == "" {
+	reached := asMap(value)
+	if reached == nil {
+		return stringOrNil(value)
+	}
+	return stringPointer(firstString(reached, "type", "kind"))
+}
+
+func firstString(values map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := values[key].(string); ok {
+			if value = strings.TrimSpace(value); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func stringPointer(value string) *string {
+	if value == "" {
 		return nil
 	}
-	return kind
+	return &value
 }
 
 func CaptureAnthropicRateLimits(accountID string, headers http.Header, capturedAt time.Time) bool {

--- a/internal/accountlimits/limits.go
+++ b/internal/accountlimits/limits.go
@@ -1,0 +1,441 @@
+package accountlimits
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	ProviderLimitsObject = "account.limits"
+	ProviderAnthropic    = "anthropic"
+	ProviderOpenAI       = "openai"
+	ProviderZai          = "zai"
+)
+
+type RateLimitWindow struct {
+	UsedPercent   float64 `json:"used_percent"`
+	WindowMinutes *int    `json:"window_minutes"`
+	ResetsAt      *int64  `json:"resets_at"`
+}
+
+type CreditsSnapshot struct {
+	HasCredits bool    `json:"has_credits"`
+	Unlimited  bool    `json:"unlimited"`
+	Balance    *string `json:"balance"`
+}
+
+type ProviderLimitSnapshot struct {
+	LimitID              string           `json:"limit_id"`
+	LimitName            *string          `json:"limit_name"`
+	Primary              *RateLimitWindow `json:"primary"`
+	Secondary            *RateLimitWindow `json:"secondary"`
+	Credits              *CreditsSnapshot `json:"credits"`
+	PlanType             *string          `json:"plan_type"`
+	RateLimitReachedType *string          `json:"rate_limit_reached_type"`
+}
+
+type ProviderLimitsPayload struct {
+	Object     string                  `json:"object"`
+	AccountID  string                  `json:"account_id"`
+	Provider   string                  `json:"provider"`
+	Source     string                  `json:"source"`
+	CapturedAt *int64                  `json:"captured_at"`
+	Snapshots  []ProviderLimitSnapshot `json:"snapshots"`
+}
+
+type limitsRecord struct {
+	capturedAt int64
+	snapshots  []ProviderLimitSnapshot
+}
+
+var anthropicLimitsCache = struct {
+	sync.RWMutex
+	byAccount map[string]limitsRecord
+}{byAccount: map[string]limitsRecord{}}
+
+func ProviderLimitsForAccount(accountID string) ProviderLimitsPayload {
+	accountID = normalizeAccountID(accountID)
+
+	anthropicLimitsCache.RLock()
+	record, ok := anthropicLimitsCache.byAccount[accountID]
+	anthropicLimitsCache.RUnlock()
+	if !ok {
+		return ProviderLimitsPayload{
+			Object:     ProviderLimitsObject,
+			AccountID:  accountID,
+			Provider:   ProviderAnthropic,
+			Source:     "unavailable",
+			CapturedAt: nil,
+			Snapshots:  []ProviderLimitSnapshot{},
+		}
+	}
+
+	capturedAt := record.capturedAt
+	return ProviderLimitsPayload{
+		Object:     ProviderLimitsObject,
+		AccountID:  accountID,
+		Provider:   ProviderAnthropic,
+		Source:     "response_headers",
+		CapturedAt: &capturedAt,
+		Snapshots:  cloneSnapshots(record.snapshots),
+	}
+}
+
+func OpenAIProviderLimitsFromUsage(accountID string, payload map[string]any) ProviderLimitsPayload {
+	return ProviderLimitsPayload{
+		Object:    ProviderLimitsObject,
+		AccountID: normalizeAccountID(accountID),
+		Provider:  ProviderOpenAI,
+		Source:    "usage_endpoint",
+		Snapshots: []ProviderLimitSnapshot{openAIRateLimitSnapshot(payload)},
+	}
+}
+
+func openAIRateLimitSnapshot(payload map[string]any) ProviderLimitSnapshot {
+	rateLimit, _ := payload["rate_limit"].(map[string]any)
+	reachedType := openAIRateLimitReachedType(payload["rate_limit_reached_type"])
+	return ProviderLimitSnapshot{
+		LimitID:              "codex",
+		LimitName:            nil,
+		Primary:              openAIRateLimitWindow(asMap(rateLimit["primary_window"])),
+		Secondary:            openAIRateLimitWindow(asMap(rateLimit["secondary_window"])),
+		Credits:              openAICreditsSnapshot(asMap(payload["credits"])),
+		PlanType:             stringOrNil(payload["plan_type"]),
+		RateLimitReachedType: reachedType,
+	}
+}
+
+// Z.AI (GLM coding plan) quota unit codes seen on
+// GET https://api.z.ai/api/monitor/usage/quota/limit:
+//
+//	unit 3 -> 5-hour token window, unit 6 -> weekly token window.
+const (
+	zaiUnitFiveHour = 3
+	zaiUnitWeekly   = 6
+)
+
+// ZaiProviderLimitsFromQuota parses the Z.AI monitor quota payload
+// (the `data` object) into 5h/weekly snapshots. Windows are classified by
+// unit code first, then by appearance order among TOKENS_LIMIT entries.
+func ZaiProviderLimitsFromQuota(accountID string, data map[string]any) ProviderLimitsPayload {
+	snapshots := zaiQuotaSnapshots(data)
+	return ProviderLimitsPayload{
+		Object:    ProviderLimitsObject,
+		AccountID: normalizeAccountID(accountID),
+		Provider:  ProviderZai,
+		Source:    "quota_endpoint",
+		Snapshots: snapshots,
+	}
+}
+
+func zaiQuotaSnapshots(data map[string]any) []ProviderLimitSnapshot {
+	limits, ok := data["limits"].([]any)
+	if !ok {
+		return []ProviderLimitSnapshot{}
+	}
+	planType := stringOrNil(data["level"])
+
+	snapshots := make([]ProviderLimitSnapshot, 0, 2)
+	tokenLimitSeen := 0
+	fiveHourDone := false
+	weeklyDone := false
+	for _, raw := range limits {
+		entry := asMap(raw)
+		if entry == nil {
+			continue
+		}
+		limitType, _ := entry["type"].(string)
+		if !strings.EqualFold(strings.TrimSpace(limitType), "TOKENS_LIMIT") {
+			continue
+		}
+		unit, _ := numericFloat(entry["unit"])
+
+		// Classify by unit, then fall back to appearance order.
+		isFiveHour := int(unit) == zaiUnitFiveHour
+		isWeekly := int(unit) == zaiUnitWeekly
+		if !isFiveHour && !isWeekly {
+			if tokenLimitSeen == 0 {
+				isFiveHour = true
+			} else if tokenLimitSeen == 1 {
+				isWeekly = true
+			}
+		}
+		tokenLimitSeen++
+
+		if isFiveHour && !fiveHourDone {
+			snapshots = append(snapshots, zaiSnapshot("five_hour", "five hour", 5*60, entry, planType))
+			fiveHourDone = true
+		} else if isWeekly && !weeklyDone {
+			snapshots = append(snapshots, zaiSnapshot("seven_day", "seven day", 7*24*60, entry, planType))
+			weeklyDone = true
+		}
+	}
+	return snapshots
+}
+
+func zaiSnapshot(limitID, limitName string, windowMinutes int, entry map[string]any, planType *string) ProviderLimitSnapshot {
+	usedPercent, _ := numericFloat(entry["percentage"])
+	minutes := windowMinutes
+	window := &RateLimitWindow{
+		UsedPercent:   clampPercent(usedPercent),
+		WindowMinutes: &minutes,
+	}
+	if reset, ok := numericFloat(entry["nextResetTime"]); ok {
+		// nextResetTime is a Unix timestamp in milliseconds.
+		resetSeconds := int64(reset / 1000)
+		window.ResetsAt = &resetSeconds
+	}
+	name := limitName
+	return ProviderLimitSnapshot{
+		LimitID:   limitID,
+		LimitName: &name,
+		Primary:   window,
+		PlanType:  planType,
+	}
+}
+
+func openAIRateLimitWindow(window map[string]any) *RateLimitWindow {
+	if window == nil {
+		return nil
+	}
+	usedPercent, ok := numericFloat(window["used_percent"])
+	if !ok {
+		return nil
+	}
+	var windowMinutes *int
+	if seconds, ok := numericFloat(window["limit_window_seconds"]); ok {
+		minutes := int(seconds / 60)
+		windowMinutes = &minutes
+	}
+	var resetsAt *int64
+	if reset, ok := numericFloat(window["reset_at"]); ok {
+		resetValue := int64(reset)
+		resetsAt = &resetValue
+	}
+	return &RateLimitWindow{
+		UsedPercent:   usedPercent,
+		WindowMinutes: windowMinutes,
+		ResetsAt:      resetsAt,
+	}
+}
+
+func openAICreditsSnapshot(credits map[string]any) *CreditsSnapshot {
+	if credits == nil {
+		return nil
+	}
+	hasCredits, okHasCredits := credits["has_credits"].(bool)
+	unlimited, okUnlimited := credits["unlimited"].(bool)
+	if !okHasCredits || !okUnlimited {
+		return nil
+	}
+	return &CreditsSnapshot{
+		HasCredits: hasCredits,
+		Unlimited:  unlimited,
+		Balance:    stringOrNil(credits["balance"]),
+	}
+}
+
+func openAIRateLimitReachedType(value any) *string {
+	kind := stringOrNil(asMap(value)["kind"])
+	if kind == nil || *kind == "" {
+		return nil
+	}
+	return kind
+}
+
+func CaptureAnthropicRateLimits(accountID string, headers http.Header, capturedAt time.Time) bool {
+	accountID = normalizeAccountID(accountID)
+	snapshots := ParseAnthropicRateLimitHeaders(headers)
+	if len(snapshots) == 0 {
+		return false
+	}
+	if capturedAt.IsZero() {
+		capturedAt = time.Now()
+	}
+
+	anthropicLimitsCache.Lock()
+	if previous, ok := anthropicLimitsCache.byAccount[accountID]; ok {
+		snapshots = mergeSnapshots(previous.snapshots, snapshots)
+	}
+	anthropicLimitsCache.byAccount[accountID] = limitsRecord{
+		capturedAt: capturedAt.Unix(),
+		snapshots:  cloneSnapshots(snapshots),
+	}
+	anthropicLimitsCache.Unlock()
+	return true
+}
+
+func mergeSnapshots(previous, current []ProviderLimitSnapshot) []ProviderLimitSnapshot {
+	merged := cloneSnapshots(previous)
+	positions := make(map[string]int, len(merged))
+	for index := range merged {
+		positions[merged[index].LimitID] = index
+	}
+	for _, snapshot := range current {
+		if index, ok := positions[snapshot.LimitID]; ok {
+			merged[index] = snapshot
+			continue
+		}
+		positions[snapshot.LimitID] = len(merged)
+		merged = append(merged, snapshot)
+	}
+	return merged
+}
+
+func ParseAnthropicRateLimitHeaders(headers http.Header) []ProviderLimitSnapshot {
+	if headers == nil {
+		return nil
+	}
+
+	snapshots := make([]ProviderLimitSnapshot, 0, 2)
+	for _, item := range []struct {
+		id   string
+		name string
+	}{
+		{id: "five_hour", name: "five hour"},
+		{id: "seven_day", name: "seven day"},
+	} {
+		window, ok := parseAnthropicWindow(headers, item.id)
+		if !ok {
+			continue
+		}
+		name := item.name
+		snapshots = append(snapshots, ProviderLimitSnapshot{
+			LimitID:              item.id,
+			LimitName:            &name,
+			Primary:              window,
+			Secondary:            nil,
+			Credits:              nil,
+			PlanType:             nil,
+			RateLimitReachedType: rateLimitStatus(headers, item.id),
+		})
+	}
+	return snapshots
+}
+
+func parseAnthropicWindow(headers http.Header, limitID string) (*RateLimitWindow, bool) {
+	headerPart := strings.ReplaceAll(limitID, "_", "")
+	var windowMinutes int
+	if limitID == "five_hour" {
+		headerPart = "5h"
+		windowMinutes = 5 * 60
+	}
+	if limitID == "seven_day" {
+		headerPart = "7d"
+		windowMinutes = 7 * 24 * 60
+	}
+
+	utilization := strings.TrimSpace(headers.Get("anthropic-ratelimit-unified-" + headerPart + "-utilization"))
+	if utilization == "" {
+		return nil, false
+	}
+	used, err := strconv.ParseFloat(utilization, 64)
+	if err != nil {
+		return nil, false
+	}
+	usedPercent := clampPercent(used * 100)
+
+	var resetsAt *int64
+	if resetRaw := strings.TrimSpace(headers.Get("anthropic-ratelimit-unified-" + headerPart + "-reset")); resetRaw != "" {
+		if reset, err := strconv.ParseInt(resetRaw, 10, 64); err == nil {
+			resetsAt = &reset
+		}
+	}
+
+	return &RateLimitWindow{
+		UsedPercent:   usedPercent,
+		WindowMinutes: &windowMinutes,
+		ResetsAt:      resetsAt,
+	}, true
+}
+
+func rateLimitStatus(headers http.Header, limitID string) *string {
+	headerPart := strings.ReplaceAll(limitID, "_", "")
+	if limitID == "five_hour" {
+		headerPart = "5h"
+	}
+	if limitID == "seven_day" {
+		headerPart = "7d"
+	}
+	status := strings.TrimSpace(headers.Get("anthropic-ratelimit-unified-" + headerPart + "-status"))
+	if status == "" || strings.EqualFold(status, "allowed") {
+		return nil
+	}
+	return &status
+}
+
+func normalizeAccountID(accountID string) string {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return "default"
+	}
+	return accountID
+}
+
+func clampPercent(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	if value > 100 {
+		return 100
+	}
+	return value
+}
+
+func cloneSnapshots(snapshots []ProviderLimitSnapshot) []ProviderLimitSnapshot {
+	if len(snapshots) == 0 {
+		return []ProviderLimitSnapshot{}
+	}
+	cloned := make([]ProviderLimitSnapshot, len(snapshots))
+	copy(cloned, snapshots)
+	for i := range cloned {
+		if cloned[i].Primary != nil {
+			primary := *cloned[i].Primary
+			cloned[i].Primary = &primary
+		}
+		if cloned[i].RateLimitReachedType != nil {
+			status := *cloned[i].RateLimitReachedType
+			cloned[i].RateLimitReachedType = &status
+		}
+	}
+	return cloned
+}
+
+func asMap(value any) map[string]any {
+	if typed, ok := value.(map[string]any); ok {
+		return typed
+	}
+	return nil
+}
+
+func numericFloat(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return typed, true
+	case float32:
+		return float64(typed), true
+	case int:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case json.Number:
+		parsed, err := typed.Float64()
+		return parsed, err == nil
+	case string:
+		parsed, err := strconv.ParseFloat(typed, 64)
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func stringOrNil(value any) *string {
+	if typed, ok := value.(string); ok {
+		return &typed
+	}
+	return nil
+}

--- a/internal/accountlimits/limits.go
+++ b/internal/accountlimits/limits.go
@@ -86,8 +86,8 @@ func ProviderLimitsForAccount(accountID string) ProviderLimitsPayload {
 	}
 }
 
-func OpenAIProviderLimitsFromUsage(accountID string, payload map[string]any) ProviderLimitsPayload {
-	snapshots := []ProviderLimitSnapshot{openAIRateLimitSnapshot("codex", nil, payload)}
+func OpenAIProviderLimitsFromUsage(accountID string, payload map[string]any, capturedAt int64) ProviderLimitsPayload {
+	snapshots := []ProviderLimitSnapshot{openAIRateLimitSnapshot("codex", nil, payload, capturedAt)}
 	if additional, ok := payload["additional_rate_limits"].([]any); ok {
 		for index, raw := range additional {
 			entry := asMap(raw)
@@ -99,7 +99,7 @@ func OpenAIProviderLimitsFromUsage(accountID string, payload map[string]any) Pro
 				limitID = fmt.Sprintf("additional_%d", index+1)
 			}
 			limitName := firstString(entry, "limit_name", "name")
-			snapshots = append(snapshots, openAIRateLimitSnapshot(limitID, stringPointer(limitName), entry))
+			snapshots = append(snapshots, openAIRateLimitSnapshot(limitID, stringPointer(limitName), entry, capturedAt))
 		}
 	}
 	return ProviderLimitsPayload{
@@ -111,7 +111,7 @@ func OpenAIProviderLimitsFromUsage(accountID string, payload map[string]any) Pro
 	}
 }
 
-func openAIRateLimitSnapshot(limitID string, limitName *string, payload map[string]any) ProviderLimitSnapshot {
+func openAIRateLimitSnapshot(limitID string, limitName *string, payload map[string]any, capturedAt int64) ProviderLimitSnapshot {
 	rateLimit := asMap(payload["rate_limit"])
 	if rateLimit == nil {
 		rateLimit = payload
@@ -123,8 +123,8 @@ func openAIRateLimitSnapshot(limitID string, limitName *string, payload map[stri
 	return ProviderLimitSnapshot{
 		LimitID:              limitID,
 		LimitName:            limitName,
-		Primary:              openAIRateLimitWindow(asMap(rateLimit["primary_window"])),
-		Secondary:            openAIRateLimitWindow(asMap(rateLimit["secondary_window"])),
+		Primary:              openAIRateLimitWindow(asMap(rateLimit["primary_window"]), capturedAt),
+		Secondary:            openAIRateLimitWindow(asMap(rateLimit["secondary_window"]), capturedAt),
 		Credits:              openAICreditsSnapshot(asMap(payload["credits"])),
 		PlanType:             stringOrNil(payload["plan_type"]),
 		RateLimitReachedType: reachedType,
@@ -220,7 +220,7 @@ func zaiSnapshot(limitID, limitName string, windowMinutes int, entry map[string]
 	}
 }
 
-func openAIRateLimitWindow(window map[string]any) *RateLimitWindow {
+func openAIRateLimitWindow(window map[string]any, capturedAt int64) *RateLimitWindow {
 	if window == nil {
 		return nil
 	}
@@ -236,6 +236,9 @@ func openAIRateLimitWindow(window map[string]any) *RateLimitWindow {
 	var resetsAt *int64
 	if reset, ok := numericFloat(window["reset_at"]); ok {
 		resetValue := int64(reset)
+		resetsAt = &resetValue
+	} else if resetAfter, ok := numericFloat(window["reset_after_seconds"]); ok && capturedAt > 0 {
+		resetValue := capturedAt + int64(resetAfter)
 		resetsAt = &resetValue
 	}
 	return &RateLimitWindow{

--- a/internal/accountlimits/limits_test.go
+++ b/internal/accountlimits/limits_test.go
@@ -1,0 +1,184 @@
+package accountlimits
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseAnthropicRateLimitHeaders(t *testing.T) {
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-5h-Status":      []string{"Allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":       []string{"1777477800"},
+		"Anthropic-Ratelimit-Unified-5h-Utilization": []string{"0.8"},
+		"Anthropic-Ratelimit-Unified-7d-Status":      []string{"warning"},
+		"Anthropic-Ratelimit-Unified-7d-Reset":       []string{"1777755600"},
+		"Anthropic-Ratelimit-Unified-7d-Utilization": []string{"0.56"},
+	}
+
+	snapshots := ParseAnthropicRateLimitHeaders(headers)
+
+	if len(snapshots) != 2 {
+		t.Fatalf("snapshots length = %d, want 2", len(snapshots))
+	}
+	if snapshots[0].LimitID != "five_hour" {
+		t.Fatalf("first limit_id = %q, want five_hour", snapshots[0].LimitID)
+	}
+	if snapshots[0].Primary == nil || snapshots[0].Primary.UsedPercent != 80 {
+		t.Fatalf("five_hour used_percent = %+v, want 80", snapshots[0].Primary)
+	}
+	if snapshots[0].Primary.ResetsAt == nil || *snapshots[0].Primary.ResetsAt != 1777477800 {
+		t.Fatalf("five_hour resets_at = %+v, want 1777477800", snapshots[0].Primary.ResetsAt)
+	}
+	if snapshots[0].Primary.WindowMinutes == nil || *snapshots[0].Primary.WindowMinutes != 300 {
+		t.Fatalf("five_hour window_minutes = %+v, want 300", snapshots[0].Primary.WindowMinutes)
+	}
+	if snapshots[0].RateLimitReachedType != nil {
+		t.Fatalf("five_hour status = %q, want nil", *snapshots[0].RateLimitReachedType)
+	}
+	if snapshots[1].LimitID != "seven_day" {
+		t.Fatalf("second limit_id = %q, want seven_day", snapshots[1].LimitID)
+	}
+	if snapshots[1].Primary == nil || snapshots[1].Primary.UsedPercent < 55.999 || snapshots[1].Primary.UsedPercent > 56.001 {
+		t.Fatalf("seven_day used_percent = %+v, want 56", snapshots[1].Primary)
+	}
+	if snapshots[1].Primary.WindowMinutes == nil || *snapshots[1].Primary.WindowMinutes != 10080 {
+		t.Fatalf("seven_day window_minutes = %+v, want 10080", snapshots[1].Primary.WindowMinutes)
+	}
+	if snapshots[1].RateLimitReachedType == nil || *snapshots[1].RateLimitReachedType != "warning" {
+		t.Fatalf("seven_day status = %+v, want warning", snapshots[1].RateLimitReachedType)
+	}
+}
+
+func TestParseAnthropicRateLimitHeadersReturnsEmptyWithoutUtilization(t *testing.T) {
+	snapshots := ParseAnthropicRateLimitHeaders(http.Header{"Content-Type": []string{"application/json"}})
+
+	if len(snapshots) != 0 {
+		t.Fatalf("snapshots length = %d, want 0", len(snapshots))
+	}
+}
+
+func TestParseAnthropicRateLimitHeadersClampsUtilization(t *testing.T) {
+	snapshots := ParseAnthropicRateLimitHeaders(http.Header{
+		"Anthropic-Ratelimit-Unified-5h-Utilization": []string{"1.5"},
+		"Anthropic-Ratelimit-Unified-7d-Utilization": []string{"-0.1"},
+	})
+
+	if len(snapshots) != 2 {
+		t.Fatalf("snapshots length = %d, want 2", len(snapshots))
+	}
+	if snapshots[0].Primary == nil || snapshots[0].Primary.UsedPercent != 100 {
+		t.Fatalf("five_hour used_percent = %+v, want 100", snapshots[0].Primary)
+	}
+	if snapshots[1].Primary == nil || snapshots[1].Primary.UsedPercent != 0 {
+		t.Fatalf("seven_day used_percent = %+v, want 0", snapshots[1].Primary)
+	}
+}
+
+func TestProviderLimitsForAccountUsesCapturedHeaders(t *testing.T) {
+	capturedAt := time.Unix(1779695597, 0)
+	ok := CaptureAnthropicRateLimits("anthropic_acc_b", http.Header{
+		"Anthropic-Ratelimit-Unified-5h-Utilization": []string{"0.14"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":       []string{"1779706800"},
+	}, capturedAt)
+	if !ok {
+		t.Fatal("CaptureAnthropicRateLimits returned false")
+	}
+
+	payload := ProviderLimitsForAccount("anthropic_acc_b")
+
+	if payload.Object != ProviderLimitsObject {
+		t.Fatalf("object = %q, want %q", payload.Object, ProviderLimitsObject)
+	}
+	if payload.Source != "response_headers" {
+		t.Fatalf("source = %q, want response_headers", payload.Source)
+	}
+	if payload.CapturedAt == nil || *payload.CapturedAt != 1779695597 {
+		t.Fatalf("captured_at = %+v, want 1779695597", payload.CapturedAt)
+	}
+	if len(payload.Snapshots) != 1 {
+		t.Fatalf("snapshots length = %d, want 1", len(payload.Snapshots))
+	}
+	if payload.Snapshots[0].Primary == nil || payload.Snapshots[0].Primary.UsedPercent < 13.999 || payload.Snapshots[0].Primary.UsedPercent > 14.001 {
+		t.Fatalf("used_percent = %+v, want 14", payload.Snapshots[0].Primary)
+	}
+}
+
+func TestCaptureAnthropicRateLimitsMergesPartialWindows(t *testing.T) {
+	accountID := "anthropic_partial_windows"
+	CaptureAnthropicRateLimits(accountID, http.Header{
+		"Anthropic-Ratelimit-Unified-5h-Utilization": []string{"0.2"},
+	}, time.Unix(1, 0))
+	CaptureAnthropicRateLimits(accountID, http.Header{
+		"Anthropic-Ratelimit-Unified-7d-Utilization": []string{"0.4"},
+	}, time.Unix(2, 0))
+
+	payload := ProviderLimitsForAccount(accountID)
+	if len(payload.Snapshots) != 2 {
+		t.Fatalf("snapshots length = %d, want 2", len(payload.Snapshots))
+	}
+	if payload.Snapshots[0].LimitID != "five_hour" || payload.Snapshots[1].LimitID != "seven_day" {
+		t.Fatalf("unexpected snapshots: %+v", payload.Snapshots)
+	}
+}
+
+func TestZaiProviderLimitsFromQuota(t *testing.T) {
+	// Real response shape from GET https://api.z.ai/api/monitor/usage/quota/limit.
+	// First TOKENS_LIMIT (unit 3) = 5h, second (unit 6) = weekly; the TIME_LIMIT
+	// entry (MCP quota) must be ignored.
+	raw := `{
+		"code": 200,
+		"data": {
+			"limits": [
+				{"type": "TOKENS_LIMIT", "unit": 3, "percentage": 12},
+				{"type": "TOKENS_LIMIT", "unit": 6, "percentage": 34, "nextResetTime": 1783682427974},
+				{"type": "TIME_LIMIT", "unit": 5, "percentage": 0}
+			],
+			"level": "max"
+		}
+	}`
+
+	var parsed struct {
+		Data map[string]any `json:"data"`
+	}
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&parsed); err != nil {
+		t.Fatalf("failed to decode zai payload: %v", err)
+	}
+
+	payload := ZaiProviderLimitsFromQuota("zai_acc_a", parsed.Data)
+
+	if payload.Provider != ProviderZai || payload.AccountID != "zai_acc_a" || payload.Source != "quota_endpoint" {
+		t.Fatalf("unexpected metadata: %+v", payload)
+	}
+	if len(payload.Snapshots) != 2 {
+		t.Fatalf("snapshots length = %d, want 2", len(payload.Snapshots))
+	}
+
+	fiveHour := payload.Snapshots[0]
+	if fiveHour.LimitID != "five_hour" || fiveHour.Primary == nil {
+		t.Fatalf("five_hour snapshot = %+v", fiveHour)
+	}
+	if fiveHour.Primary.UsedPercent != 12 || fiveHour.Primary.WindowMinutes == nil || *fiveHour.Primary.WindowMinutes != 300 {
+		t.Fatalf("five_hour window = %+v", fiveHour.Primary)
+	}
+	planType := fiveHour.PlanType
+	if planType == nil || *planType != "max" {
+		t.Fatalf("five_hour plan_type = %v, want max", fiveHour.PlanType)
+	}
+
+	weekly := payload.Snapshots[1]
+	if weekly.LimitID != "seven_day" || weekly.Primary == nil {
+		t.Fatalf("seven_day snapshot = %+v", weekly)
+	}
+	if weekly.Primary.UsedPercent != 34 || weekly.Primary.WindowMinutes == nil || *weekly.Primary.WindowMinutes != 10080 {
+		t.Fatalf("seven_day window = %+v", weekly.Primary)
+	}
+	// nextResetTime 1783682427974 ms -> 1783682427 s
+	if weekly.Primary.ResetsAt == nil || *weekly.Primary.ResetsAt != 1783682427 {
+		t.Fatalf("seven_day resets_at = %+v, want 1783682427", weekly.Primary.ResetsAt)
+	}
+}

--- a/internal/accountlimits/limits_test.go
+++ b/internal/accountlimits/limits_test.go
@@ -124,6 +124,45 @@ func TestCaptureAnthropicRateLimitsMergesPartialWindows(t *testing.T) {
 	}
 }
 
+func TestCloneSnapshotsDoesNotSharePointers(t *testing.T) {
+	name := "limit"
+	windowMinutes := 60
+	resetsAt := int64(100)
+	balance := "10"
+	planType := "plus"
+	status := "limited"
+	original := []ProviderLimitSnapshot{{
+		LimitName: &name,
+		Primary: &RateLimitWindow{
+			WindowMinutes: &windowMinutes,
+			ResetsAt:      &resetsAt,
+		},
+		Secondary: &RateLimitWindow{
+			WindowMinutes: &windowMinutes,
+			ResetsAt:      &resetsAt,
+		},
+		Credits:              &CreditsSnapshot{Balance: &balance},
+		PlanType:             &planType,
+		RateLimitReachedType: &status,
+	}}
+
+	cloned := cloneSnapshots(original)
+	*cloned[0].LimitName = "changed"
+	*cloned[0].Primary.WindowMinutes = 120
+	*cloned[0].Primary.ResetsAt = 200
+	*cloned[0].Secondary.WindowMinutes = 180
+	*cloned[0].Secondary.ResetsAt = 300
+	*cloned[0].Credits.Balance = "0"
+	*cloned[0].PlanType = "free"
+	*cloned[0].RateLimitReachedType = "allowed"
+
+	if *original[0].LimitName != "limit" || *original[0].Primary.WindowMinutes != 60 || *original[0].Primary.ResetsAt != 100 ||
+		*original[0].Secondary.WindowMinutes != 60 || *original[0].Secondary.ResetsAt != 100 || *original[0].Credits.Balance != "10" ||
+		*original[0].PlanType != "plus" || *original[0].RateLimitReachedType != "limited" {
+		t.Fatalf("clone mutated original snapshot: %+v", original[0])
+	}
+}
+
 func TestZaiProviderLimitsFromQuota(t *testing.T) {
 	// Real response shape from GET https://api.z.ai/api/monitor/usage/quota/limit.
 	// First TOKENS_LIMIT (unit 3) = 5h, second (unit 6) = weekly; the TIME_LIMIT

--- a/internal/accountlimits/limits_test.go
+++ b/internal/accountlimits/limits_test.go
@@ -124,6 +124,43 @@ func TestCaptureAnthropicRateLimitsMergesPartialWindows(t *testing.T) {
 	}
 }
 
+func TestOpenAIProviderLimitsIncludesAdditionalBuckets(t *testing.T) {
+	payload := OpenAIProviderLimitsFromUsage("codex-local", map[string]any{
+		"rate_limit": map[string]any{
+			"primary_window": map[string]any{"used_percent": 10.0},
+		},
+		"rate_limit_reached_type": map[string]any{"type": "primary"},
+		"additional_rate_limits": []any{
+			map[string]any{
+				"limit_id":   "spark",
+				"limit_name": "Spark",
+				"rate_limit": map[string]any{
+					"primary_window":   map[string]any{"used_percent": 25.0},
+					"secondary_window": map[string]any{"used_percent": 50.0},
+				},
+			},
+			map[string]any{
+				"metered_feature": "code_review",
+				"name":            "Code review",
+				"primary_window":  map[string]any{"used_percent": 75.0},
+			},
+		},
+	})
+
+	if len(payload.Snapshots) != 3 {
+		t.Fatalf("snapshots length = %d, want 3", len(payload.Snapshots))
+	}
+	if reached := payload.Snapshots[0].RateLimitReachedType; reached == nil || *reached != "primary" {
+		t.Fatalf("reached type = %v, want primary", reached)
+	}
+	if snapshot := payload.Snapshots[1]; snapshot.LimitID != "spark" || snapshot.LimitName == nil || *snapshot.LimitName != "Spark" || snapshot.Primary == nil || snapshot.Primary.UsedPercent != 25 || snapshot.Secondary == nil || snapshot.Secondary.UsedPercent != 50 {
+		t.Fatalf("spark snapshot = %+v", snapshot)
+	}
+	if snapshot := payload.Snapshots[2]; snapshot.LimitID != "code_review" || snapshot.LimitName == nil || *snapshot.LimitName != "Code review" || snapshot.Primary == nil || snapshot.Primary.UsedPercent != 75 {
+		t.Fatalf("code review snapshot = %+v", snapshot)
+	}
+}
+
 func TestCloneSnapshotsDoesNotSharePointers(t *testing.T) {
 	name := "limit"
 	windowMinutes := 60

--- a/internal/accountlimits/limits_test.go
+++ b/internal/accountlimits/limits_test.go
@@ -125,9 +125,11 @@ func TestCaptureAnthropicRateLimitsMergesPartialWindows(t *testing.T) {
 }
 
 func TestOpenAIProviderLimitsIncludesAdditionalBuckets(t *testing.T) {
+	capturedAt := int64(1_800_000_000)
 	payload := OpenAIProviderLimitsFromUsage("codex-local", map[string]any{
 		"rate_limit": map[string]any{
-			"primary_window": map[string]any{"used_percent": 10.0},
+			"primary_window":   map[string]any{"used_percent": 10.0, "reset_after_seconds": 120.0},
+			"secondary_window": map[string]any{"used_percent": 20.0, "reset_at": 1_900_000_000.0, "reset_after_seconds": 999.0},
 		},
 		"rate_limit_reached_type": map[string]any{"type": "primary"},
 		"additional_rate_limits": []any{
@@ -145,13 +147,19 @@ func TestOpenAIProviderLimitsIncludesAdditionalBuckets(t *testing.T) {
 				"primary_window":  map[string]any{"used_percent": 75.0},
 			},
 		},
-	})
+	}, capturedAt)
 
 	if len(payload.Snapshots) != 3 {
 		t.Fatalf("snapshots length = %d, want 3", len(payload.Snapshots))
 	}
 	if reached := payload.Snapshots[0].RateLimitReachedType; reached == nil || *reached != "primary" {
 		t.Fatalf("reached type = %v, want primary", reached)
+	}
+	if primary := payload.Snapshots[0].Primary; primary == nil || primary.ResetsAt == nil || *primary.ResetsAt != capturedAt+120 {
+		t.Fatalf("primary resets_at = %+v, want %d", primary, capturedAt+120)
+	}
+	if secondary := payload.Snapshots[0].Secondary; secondary == nil || secondary.ResetsAt == nil || *secondary.ResetsAt != 1_900_000_000 {
+		t.Fatalf("secondary resets_at = %+v, want 1900000000", secondary)
 	}
 	if snapshot := payload.Snapshots[1]; snapshot.LimitID != "spark" || snapshot.LimitName == nil || *snapshot.LimitName != "Spark" || snapshot.Primary == nil || snapshot.Primary.UsedPercent != 25 || snapshot.Secondary == nil || snapshot.Secondary.UsedPercent != 50 {
 		t.Fatalf("spark snapshot = %+v", snapshot)

--- a/internal/api/account_limits.go
+++ b/internal/api/account_limits.go
@@ -20,11 +20,12 @@ import (
 )
 
 type accountLimitsCredential struct {
-	provider  string
-	accountID string
-	token     string
-	baseURL   string
-	proxyURL  string
+	provider          string
+	accountID         string
+	upstreamAccountID string
+	token             string
+	baseURL           string
+	proxyURL          string
 }
 
 func (s *Server) accountLimitsHandler(c *gin.Context) {
@@ -100,11 +101,12 @@ func (s *Server) accountLimitsCredentials() []accountLimitsCredential {
 					continue
 				}
 				candidates = append(candidates, accountLimitsCredential{
-					provider:  accountlimits.ProviderOpenAI,
-					accountID: accountID,
-					token:     token,
-					baseURL:   attributeString(entry.Attributes, "base_url"),
-					proxyURL:  strings.TrimSpace(entry.ProxyURL),
+					provider:          accountlimits.ProviderOpenAI,
+					accountID:         accountID,
+					upstreamAccountID: metadataString(entry.Metadata, "account_id"),
+					token:             token,
+					baseURL:           attributeString(entry.Attributes, "base_url"),
+					proxyURL:          strings.TrimSpace(entry.ProxyURL),
 				})
 			}
 		}
@@ -149,9 +151,13 @@ func normalizeLimitsProvider(provider string) string {
 }
 
 func (s *Server) fetchOpenAIAccountLimits(ctx context.Context, credential accountLimitsCredential) (accountlimits.ProviderLimitsPayload, int, string) {
-	upstreamAccountID, err := chatGPTAccountIDFromAccessToken(credential.token)
-	if err != nil {
-		return accountlimits.ProviderLimitsPayload{}, http.StatusUnauthorized, "local Codex credential has no ChatGPT account id"
+	upstreamAccountID := credential.upstreamAccountID
+	if upstreamAccountID == "" {
+		var err error
+		upstreamAccountID, err = chatGPTAccountIDFromAccessToken(credential.token)
+		if err != nil {
+			return accountlimits.ProviderLimitsPayload{}, http.StatusUnauthorized, "local Codex credential has no ChatGPT account id"
+		}
 	}
 	request, errRequest := http.NewRequestWithContext(ctx, http.MethodGet, codexUsageURL(credential.baseURL), nil)
 	if errRequest != nil {
@@ -162,7 +168,7 @@ func (s *Server) fetchOpenAIAccountLimits(ctx context.Context, credential accoun
 	request.Header.Set("User-Agent", "codex-cli")
 	request.Header.Set("Accept", "application/json")
 
-	response, status, errMessage := s.doLimitsRequest(ctx, request, credential.proxyURL)
+	response, status, errMessage := s.doLimitsRequest(ctx, request, credential.proxyURL, true)
 	if errMessage != "" {
 		return accountlimits.ProviderLimitsPayload{}, status, errMessage
 	}
@@ -186,7 +192,7 @@ func (s *Server) fetchZaiAccountLimits(ctx context.Context, credential accountLi
 	request.Header.Set("Authorization", "Bearer "+credential.token)
 	request.Header.Set("Accept", "application/json")
 
-	response, status, errMessage := s.doLimitsRequest(ctx, request, credential.proxyURL)
+	response, status, errMessage := s.doLimitsRequest(ctx, request, credential.proxyURL, false)
 	if errMessage != "" {
 		return accountlimits.ProviderLimitsPayload{}, status, errMessage
 	}
@@ -204,8 +210,13 @@ func (s *Server) fetchZaiAccountLimits(ctx context.Context, credential accountLi
 	return payload, http.StatusOK, ""
 }
 
-func (s *Server) doLimitsRequest(ctx context.Context, request *http.Request, proxyURL string) ([]byte, int, string) {
-	client := helps.NewProxyAwareHTTPClient(ctx, s.accountLimitsConfig(), &cliproxyauth.Auth{ProxyURL: proxyURL}, 0)
+func (s *Server) doLimitsRequest(ctx context.Context, request *http.Request, proxyURL string, useUTLS bool) ([]byte, int, string) {
+	auth := &cliproxyauth.Auth{ProxyURL: proxyURL}
+	cfg := s.accountLimitsConfig()
+	client := helps.NewProxyAwareHTTPClient(ctx, cfg, auth, 0)
+	if useUTLS {
+		client = helps.NewUtlsHTTPClient(ctx, cfg, auth, 0)
+	}
 	response, errDo := client.Do(request)
 	if errDo != nil {
 		return nil, http.StatusBadGateway, errDo.Error()

--- a/internal/api/account_limits.go
+++ b/internal/api/account_limits.go
@@ -51,6 +51,8 @@ func (s *Server) accountLimitsHandler(c *gin.Context) {
 			return
 		}
 		c.JSON(http.StatusOK, payload)
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"message": "unsupported account limits provider", "type": "internal_error"}})
 	}
 }
 
@@ -107,10 +109,7 @@ func (s *Server) accountLimitsCredentials() []accountLimitsCredential {
 			}
 		}
 	}
-	var cfgSnapshot *config.Config
-	if s != nil {
-		cfgSnapshot = s.accountLimitsConfigSnapshot()
-	}
+	cfgSnapshot := s.accountLimitsConfig()
 	if cfgSnapshot != nil {
 		for _, compatibility := range cfgSnapshot.OpenAICompatibility {
 			if compatibility.Disabled || !strings.EqualFold(strings.TrimSpace(compatibility.Name), accountlimits.ProviderZai) {
@@ -290,24 +289,11 @@ func (s *Server) accountLimitsConfig() *config.Config {
 	if s == nil {
 		return nil
 	}
-	s.cfgMu.RLock()
-	defer s.cfgMu.RUnlock()
-	if s.cfg == nil {
+	cfg := s.accountLimitsCfg.Load()
+	if cfg == nil {
 		return nil
 	}
-	return s.cfg.CloneForRuntime()
-}
-
-func (s *Server) accountLimitsConfigSnapshot() *config.Config {
-	if s == nil {
-		return nil
-	}
-	s.cfgMu.RLock()
-	defer s.cfgMu.RUnlock()
-	if s.cfg == nil {
-		return nil
-	}
-	return s.cfg.CloneForRuntime()
+	return cfg
 }
 
 var unixNow = func() int64 { return time.Now().Unix() }

--- a/internal/api/account_limits.go
+++ b/internal/api/account_limits.go
@@ -23,6 +23,7 @@ type accountLimitsCredential struct {
 	provider          string
 	accountID         string
 	upstreamAccountID string
+	hasRefreshToken   bool
 	token             string
 	baseURL           string
 	proxyURL          string
@@ -104,6 +105,7 @@ func (s *Server) accountLimitsCredentials() []accountLimitsCredential {
 					provider:          accountlimits.ProviderOpenAI,
 					accountID:         accountID,
 					upstreamAccountID: metadataString(entry.Metadata, "account_id"),
+					hasRefreshToken:   metadataString(entry.Metadata, "refresh_token") != "",
 					token:             token,
 					baseURL:           attributeString(entry.Attributes, "base_url"),
 					proxyURL:          strings.TrimSpace(entry.ProxyURL),
@@ -169,6 +171,20 @@ func (s *Server) fetchOpenAIAccountLimits(ctx context.Context, credential accoun
 	request.Header.Set("Accept", "application/json")
 
 	response, status, errMessage := s.doLimitsRequest(ctx, request, credential.proxyURL, true)
+	if status == http.StatusUnauthorized && credential.hasRefreshToken && s.handlers != nil && s.handlers.AuthManager != nil {
+		refreshed, errRefresh := s.handlers.AuthManager.RefreshAuth(ctx, credential.accountID, credential.token)
+		if errRefresh == nil && refreshed != nil {
+			credential.token = metadataString(refreshed.Metadata, "access_token")
+			credential.upstreamAccountID = metadataString(refreshed.Metadata, "account_id")
+			if credential.token != "" {
+				request.Header.Set("Authorization", "Bearer "+credential.token)
+				if credential.upstreamAccountID != "" {
+					request.Header.Set("ChatGPT-Account-Id", credential.upstreamAccountID)
+				}
+				response, status, errMessage = s.doLimitsRequest(ctx, request, credential.proxyURL, true)
+			}
+		}
+	}
 	if errMessage != "" {
 		return accountlimits.ProviderLimitsPayload{}, status, errMessage
 	}

--- a/internal/api/account_limits.go
+++ b/internal/api/account_limits.go
@@ -1,0 +1,313 @@
+package api
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/accountlimits"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+type accountLimitsCredential struct {
+	provider  string
+	accountID string
+	token     string
+	baseURL   string
+	proxyURL  string
+}
+
+func (s *Server) accountLimitsHandler(c *gin.Context) {
+	credential, status, errMessage := s.resolveAccountLimitsCredential(c.Query("provider"), c.Query("account_id"))
+	if errMessage != "" {
+		c.JSON(status, gin.H{"error": gin.H{"message": errMessage, "type": "invalid_request_error"}})
+		return
+	}
+
+	switch credential.provider {
+	case accountlimits.ProviderAnthropic:
+		c.JSON(http.StatusOK, accountlimits.ProviderLimitsForAccount(credential.accountID))
+	case accountlimits.ProviderOpenAI:
+		payload, upstreamStatus, upstreamError := s.fetchOpenAIAccountLimits(c.Request.Context(), credential)
+		if upstreamError != "" {
+			c.JSON(upstreamStatus, gin.H{"error": gin.H{"message": upstreamError, "type": "upstream_error"}})
+			return
+		}
+		c.JSON(http.StatusOK, payload)
+	case accountlimits.ProviderZai:
+		payload, upstreamStatus, upstreamError := s.fetchZaiAccountLimits(c.Request.Context(), credential)
+		if upstreamError != "" {
+			c.JSON(upstreamStatus, gin.H{"error": gin.H{"message": upstreamError, "type": "upstream_error"}})
+			return
+		}
+		c.JSON(http.StatusOK, payload)
+	}
+}
+
+func (s *Server) resolveAccountLimitsCredential(provider, accountID string) (accountLimitsCredential, int, string) {
+	provider = normalizeLimitsProvider(provider)
+	accountID = strings.TrimSpace(accountID)
+	candidates := s.accountLimitsCredentials()
+	filtered := candidates[:0]
+	for _, candidate := range candidates {
+		if provider != "" && candidate.provider != provider {
+			continue
+		}
+		if accountID != "" && candidate.accountID != accountID {
+			continue
+		}
+		filtered = append(filtered, candidate)
+	}
+
+	if len(filtered) == 1 {
+		return filtered[0], http.StatusOK, ""
+	}
+	if len(filtered) == 0 {
+		return accountLimitsCredential{}, http.StatusNotFound, "no matching local credential supports account limits"
+	}
+	return accountLimitsCredential{}, http.StatusConflict, "multiple credentials support account limits; specify provider and account_id"
+}
+
+func (s *Server) accountLimitsCredentials() []accountLimitsCredential {
+	candidates := make([]accountLimitsCredential, 0)
+	if s != nil && s.handlers != nil && s.handlers.AuthManager != nil {
+		for _, entry := range s.handlers.AuthManager.List() {
+			if entry == nil || entry.Disabled || entry.Status == cliproxyauth.StatusDisabled {
+				continue
+			}
+			accountID := strings.TrimSpace(entry.ID)
+			if accountID == "" {
+				continue
+			}
+			switch strings.ToLower(strings.TrimSpace(entry.Provider)) {
+			case "claude":
+				candidates = append(candidates, accountLimitsCredential{provider: accountlimits.ProviderAnthropic, accountID: accountID})
+			case "codex":
+				token := metadataString(entry.Metadata, "access_token")
+				if token == "" {
+					continue
+				}
+				candidates = append(candidates, accountLimitsCredential{
+					provider:  accountlimits.ProviderOpenAI,
+					accountID: accountID,
+					token:     token,
+					baseURL:   attributeString(entry.Attributes, "base_url"),
+					proxyURL:  strings.TrimSpace(entry.ProxyURL),
+				})
+			}
+		}
+	}
+	var cfgSnapshot *config.Config
+	if s != nil {
+		cfgSnapshot = s.accountLimitsConfigSnapshot()
+	}
+	if cfgSnapshot != nil {
+		for _, compatibility := range cfgSnapshot.OpenAICompatibility {
+			if compatibility.Disabled || !strings.EqualFold(strings.TrimSpace(compatibility.Name), accountlimits.ProviderZai) {
+				continue
+			}
+			for index, entry := range compatibility.APIKeyEntries {
+				if token := strings.TrimSpace(entry.APIKey); token != "" {
+					id := strings.TrimSpace(compatibility.Name)
+					if len(compatibility.APIKeyEntries) > 1 {
+						id = fmt.Sprintf("%s:%d", id, index+1)
+					}
+					candidates = append(candidates, accountLimitsCredential{
+						provider:  accountlimits.ProviderZai,
+						accountID: id,
+						token:     token,
+						baseURL:   strings.TrimSpace(compatibility.BaseURL),
+						proxyURL:  strings.TrimSpace(entry.ProxyURL),
+					})
+				}
+			}
+		}
+	}
+	return candidates
+}
+
+func normalizeLimitsProvider(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "anthropic", "claude":
+		return accountlimits.ProviderAnthropic
+	case "openai", "codex":
+		return accountlimits.ProviderOpenAI
+	case "zai", "z.ai":
+		return accountlimits.ProviderZai
+	default:
+		return strings.ToLower(strings.TrimSpace(provider))
+	}
+}
+
+func (s *Server) fetchOpenAIAccountLimits(ctx context.Context, credential accountLimitsCredential) (accountlimits.ProviderLimitsPayload, int, string) {
+	upstreamAccountID, err := chatGPTAccountIDFromAccessToken(credential.token)
+	if err != nil {
+		return accountlimits.ProviderLimitsPayload{}, http.StatusUnauthorized, "local Codex credential has no ChatGPT account id"
+	}
+	request, errRequest := http.NewRequestWithContext(ctx, http.MethodGet, codexUsageURL(credential.baseURL), nil)
+	if errRequest != nil {
+		return accountlimits.ProviderLimitsPayload{}, http.StatusBadRequest, errRequest.Error()
+	}
+	request.Header.Set("Authorization", "Bearer "+credential.token)
+	request.Header.Set("ChatGPT-Account-Id", upstreamAccountID)
+	request.Header.Set("User-Agent", "codex-cli")
+	request.Header.Set("Accept", "application/json")
+
+	response, status, errMessage := s.doLimitsRequest(ctx, request, credential.proxyURL)
+	if errMessage != "" {
+		return accountlimits.ProviderLimitsPayload{}, status, errMessage
+	}
+	var upstreamPayload map[string]any
+	decoder := json.NewDecoder(strings.NewReader(string(response)))
+	decoder.UseNumber()
+	if errDecode := decoder.Decode(&upstreamPayload); errDecode != nil {
+		return accountlimits.ProviderLimitsPayload{}, http.StatusBadGateway, "Codex usage response has unexpected shape"
+	}
+	payload := accountlimits.OpenAIProviderLimitsFromUsage(credential.accountID, upstreamPayload)
+	capturedAt := unixNow()
+	payload.CapturedAt = &capturedAt
+	return payload, http.StatusOK, ""
+}
+
+func (s *Server) fetchZaiAccountLimits(ctx context.Context, credential accountLimitsCredential) (accountlimits.ProviderLimitsPayload, int, string) {
+	request, errRequest := http.NewRequestWithContext(ctx, http.MethodGet, zaiQuotaURL(credential.baseURL), nil)
+	if errRequest != nil {
+		return accountlimits.ProviderLimitsPayload{}, http.StatusBadRequest, errRequest.Error()
+	}
+	request.Header.Set("Authorization", "Bearer "+credential.token)
+	request.Header.Set("Accept", "application/json")
+
+	response, status, errMessage := s.doLimitsRequest(ctx, request, credential.proxyURL)
+	if errMessage != "" {
+		return accountlimits.ProviderLimitsPayload{}, status, errMessage
+	}
+	var upstreamPayload struct {
+		Data map[string]any `json:"data"`
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(response)))
+	decoder.UseNumber()
+	if errDecode := decoder.Decode(&upstreamPayload); errDecode != nil {
+		return accountlimits.ProviderLimitsPayload{}, http.StatusBadGateway, "Z.AI quota response has unexpected shape"
+	}
+	payload := accountlimits.ZaiProviderLimitsFromQuota(credential.accountID, upstreamPayload.Data)
+	capturedAt := unixNow()
+	payload.CapturedAt = &capturedAt
+	return payload, http.StatusOK, ""
+}
+
+func (s *Server) doLimitsRequest(ctx context.Context, request *http.Request, proxyURL string) ([]byte, int, string) {
+	client := helps.NewProxyAwareHTTPClient(ctx, s.accountLimitsConfig(), &cliproxyauth.Auth{ProxyURL: proxyURL}, 0)
+	response, errDo := client.Do(request)
+	if errDo != nil {
+		return nil, http.StatusBadGateway, errDo.Error()
+	}
+	defer func() {
+		if errClose := response.Body.Close(); errClose != nil {
+			log.WithError(errClose).Debug("failed to close account limits response body")
+		}
+	}()
+	body, errRead := io.ReadAll(io.LimitReader(response.Body, 2<<20))
+	if errRead != nil {
+		return nil, http.StatusBadGateway, errRead.Error()
+	}
+	if response.StatusCode >= http.StatusBadRequest {
+		return nil, response.StatusCode, fmt.Sprintf("limits upstream returned HTTP %d", response.StatusCode)
+	}
+	return body, http.StatusOK, ""
+}
+
+func chatGPTAccountIDFromAccessToken(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid JWT token format")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		payload, err = base64.URLEncoding.DecodeString(parts[1])
+	}
+	if err != nil {
+		return "", err
+	}
+	var claims struct {
+		OpenAIAuth struct {
+			ChatGPTAccountID string `json:"chatgpt_account_id"`
+		} `json:"https://api.openai.com/auth"`
+	}
+	if errUnmarshal := json.Unmarshal(payload, &claims); errUnmarshal != nil {
+		return "", errUnmarshal
+	}
+	accountID := strings.TrimSpace(claims.OpenAIAuth.ChatGPTAccountID)
+	if accountID == "" {
+		return "", fmt.Errorf("missing ChatGPT account id")
+	}
+	return accountID, nil
+}
+
+func codexUsageURL(baseURL string) string {
+	normalized := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if normalized == "" {
+		normalized = "https://chatgpt.com/backend-api"
+	}
+	if (strings.HasPrefix(normalized, "https://chatgpt.com") || strings.HasPrefix(normalized, "https://chat.openai.com")) && !strings.Contains(normalized, "/backend-api") {
+		normalized += "/backend-api"
+	}
+	if strings.Contains(normalized, "/backend-api") {
+		normalized = strings.TrimSuffix(normalized, "/codex")
+		return normalized + "/wham/usage"
+	}
+	return normalized + "/api/codex/usage"
+}
+
+func zaiQuotaURL(baseURL string) string {
+	const quotaPath = "/api/monitor/usage/quota/limit"
+	base := strings.TrimSpace(baseURL)
+	if parsed, err := url.Parse(base); err == nil && parsed.Scheme != "" && parsed.Host != "" {
+		return parsed.Scheme + "://" + parsed.Host + quotaPath
+	}
+	return "https://api.z.ai" + quotaPath
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	value, _ := metadata[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func attributeString(attributes map[string]string, key string) string {
+	return strings.TrimSpace(attributes[key])
+}
+
+func (s *Server) accountLimitsConfig() *config.Config {
+	if s == nil {
+		return nil
+	}
+	s.cfgMu.RLock()
+	defer s.cfgMu.RUnlock()
+	if s.cfg == nil {
+		return nil
+	}
+	return s.cfg.CloneForRuntime()
+}
+
+func (s *Server) accountLimitsConfigSnapshot() *config.Config {
+	if s == nil {
+		return nil
+	}
+	s.cfgMu.RLock()
+	defer s.cfgMu.RUnlock()
+	if s.cfg == nil {
+		return nil
+	}
+	return s.cfg.CloneForRuntime()
+}
+
+var unixNow = func() int64 { return time.Now().Unix() }

--- a/internal/api/account_limits.go
+++ b/internal/api/account_limits.go
@@ -194,8 +194,8 @@ func (s *Server) fetchOpenAIAccountLimits(ctx context.Context, credential accoun
 	if errDecode := decoder.Decode(&upstreamPayload); errDecode != nil {
 		return accountlimits.ProviderLimitsPayload{}, http.StatusBadGateway, "Codex usage response has unexpected shape"
 	}
-	payload := accountlimits.OpenAIProviderLimitsFromUsage(credential.accountID, upstreamPayload)
 	capturedAt := unixNow()
+	payload := accountlimits.OpenAIProviderLimitsFromUsage(credential.accountID, upstreamPayload, capturedAt)
 	payload.CapturedAt = &capturedAt
 	return payload, http.StatusOK, ""
 }

--- a/internal/api/account_limits_test.go
+++ b/internal/api/account_limits_test.go
@@ -14,6 +14,17 @@ import (
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
+type accountLimitsRefreshExecutor struct {
+	codexSearchCaptureExecutor
+	refreshCalls int
+}
+
+func (e *accountLimitsRefreshExecutor) Refresh(_ context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	e.refreshCalls++
+	auth.Metadata["access_token"] = "fresh-access-token"
+	return auth, nil
+}
+
 func TestAccountLimitsRequiresProxyAuthentication(t *testing.T) {
 	server := newTestServer(t)
 	recorder := httptest.NewRecorder()
@@ -110,6 +121,48 @@ func TestAccountLimitsFetchesCodexUsageFromLocalCredential(t *testing.T) {
 	}
 	if payload.AccountID != "codex-local" || payload.Provider != accountlimits.ProviderOpenAI || payload.CapturedAt == nil {
 		t.Fatalf("unexpected payload metadata: %+v", payload)
+	}
+}
+
+func TestAccountLimitsRefreshesCodexCredentialAfterUnauthorized(t *testing.T) {
+	requests := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests++
+		if request.Header.Get("Authorization") == "Bearer stale-access-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if request.Header.Get("Authorization") != "Bearer fresh-access-token" {
+			t.Fatalf("Authorization = %q", request.Header.Get("Authorization"))
+		}
+		_, _ = w.Write([]byte(`{"rate_limit":{"primary_window":{"used_percent":12}}}`))
+	}))
+	defer upstream.Close()
+
+	server := newTestServer(t)
+	executor := &accountLimitsRefreshExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	registerLimitsAuth(t, server, &cliproxyauth.Auth{
+		ID:       "codex-refresh",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"access_token":  "stale-access-token",
+			"refresh_token": "refresh-token",
+			"account_id":    "chatgpt-account",
+		},
+		Attributes: map[string]string{"base_url": upstream.URL},
+	})
+
+	recorder := performLimitsRequest(server, "/v1/account/limits")
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if requests != 2 || executor.refreshCalls != 1 {
+		t.Fatalf("requests = %d, refresh calls = %d; want 2 and 1", requests, executor.refreshCalls)
+	}
+	updated, ok := server.handlers.AuthManager.GetByID("codex-refresh")
+	if !ok || metadataString(updated.Metadata, "access_token") != "fresh-access-token" {
+		t.Fatalf("refreshed credential not persisted: %+v", updated)
 	}
 }
 

--- a/internal/api/account_limits_test.go
+++ b/internal/api/account_limits_test.go
@@ -87,7 +87,7 @@ func TestAccountLimitsFetchesCodexUsageFromLocalCredential(t *testing.T) {
 	registerLimitsAuth(t, server, &cliproxyauth.Auth{
 		ID:       "codex-local",
 		Provider: "codex",
-		Metadata: map[string]any{"access_token": testCodexJWT("chatgpt-account")},
+		Metadata: map[string]any{"access_token": "opaque-access-token", "account_id": "chatgpt-account"},
 		Attributes: map[string]string{
 			"base_url": upstream.URL,
 		},
@@ -101,7 +101,7 @@ func TestAccountLimitsFetchesCodexUsageFromLocalCredential(t *testing.T) {
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
 	}
-	if receivedAuthorization != "Bearer "+testCodexJWT("chatgpt-account") {
+	if receivedAuthorization != "Bearer opaque-access-token" {
 		t.Fatalf("Authorization = %q", receivedAuthorization)
 	}
 	var payload accountlimits.ProviderLimitsPayload

--- a/internal/api/account_limits_test.go
+++ b/internal/api/account_limits_test.go
@@ -126,11 +126,13 @@ func TestAccountLimitsFetchesZaiQuotaFromLocalConfig(t *testing.T) {
 	defer upstream.Close()
 
 	server := newTestServer(t)
-	server.cfg.OpenAICompatibility = []proxyconfig.OpenAICompatibility{{
+	cfg := server.accountLimitsConfig().CloneForRuntime()
+	cfg.OpenAICompatibility = []proxyconfig.OpenAICompatibility{{
 		Name:          "zai",
 		BaseURL:       upstream.URL + "/v1",
 		APIKeyEntries: []proxyconfig.OpenAICompatibilityAPIKey{{APIKey: "zai-key"}},
 	}}
+	server.UpdateClients(cfg)
 
 	recorder := performLimitsRequest(server, "/v1/account/limits")
 	if recorder.Code != http.StatusOK {

--- a/internal/api/account_limits_test.go
+++ b/internal/api/account_limits_test.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/accountlimits"
+	proxyconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestAccountLimitsRequiresProxyAuthentication(t *testing.T) {
+	server := newTestServer(t)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/v1/account/limits", nil)
+
+	server.engine.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestAccountLimitsReturnsCapturedAnthropicLimits(t *testing.T) {
+	server := newTestServer(t)
+	registerLimitsAuth(t, server, &cliproxyauth.Auth{ID: "claude-local", Provider: "claude"})
+	accountlimits.CaptureAnthropicRateLimits("claude-local", http.Header{
+		"Anthropic-Ratelimit-Unified-5h-Utilization": []string{"0.25"},
+	}, time.Unix(1779695597, 0))
+
+	recorder := performLimitsRequest(server, "/v1/account/limits")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var payload accountlimits.ProviderLimitsPayload
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Object != accountlimits.ProviderLimitsObject || payload.AccountID != "claude-local" || payload.Provider != accountlimits.ProviderAnthropic {
+		t.Fatalf("unexpected payload metadata: %+v", payload)
+	}
+	if len(payload.Snapshots) != 1 || payload.Snapshots[0].Primary == nil || payload.Snapshots[0].Primary.UsedPercent != 25 {
+		t.Fatalf("unexpected snapshots: %+v", payload.Snapshots)
+	}
+}
+
+func TestAccountLimitsRequiresSelectorWhenMultipleCredentialsMatch(t *testing.T) {
+	server := newTestServer(t)
+	registerLimitsAuth(t, server,
+		&cliproxyauth.Auth{ID: "claude-a", Provider: "claude"},
+		&cliproxyauth.Auth{ID: "claude-b", Provider: "claude"},
+	)
+
+	recorder := performLimitsRequest(server, "/v1/account/limits")
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusConflict, recorder.Body.String())
+	}
+
+	recorder = performLimitsRequest(server, "/v1/account/limits?provider=anthropic&account_id=claude-b")
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("selected status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestAccountLimitsFetchesCodexUsageFromLocalCredential(t *testing.T) {
+	var receivedAuthorization string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		receivedAuthorization = request.Header.Get("Authorization")
+		if request.URL.Path != "/api/codex/usage" {
+			t.Fatalf("path = %q, want /api/codex/usage", request.URL.Path)
+		}
+		if request.Header.Get("ChatGPT-Account-Id") != "chatgpt-account" {
+			t.Fatalf("ChatGPT-Account-Id = %q", request.Header.Get("ChatGPT-Account-Id"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"rate_limit":{"primary_window":{"used_percent":12,"limit_window_seconds":18000}},"plan_type":"plus"}`))
+	}))
+	defer upstream.Close()
+
+	server := newTestServer(t)
+	registerLimitsAuth(t, server, &cliproxyauth.Auth{
+		ID:       "codex-local",
+		Provider: "codex",
+		Metadata: map[string]any{"access_token": testCodexJWT("chatgpt-account")},
+		Attributes: map[string]string{
+			"base_url": upstream.URL,
+		},
+	})
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/v1/account/limits", nil)
+	request.Header.Set("Authorization", "Bearer test-key")
+	server.engine.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if receivedAuthorization != "Bearer "+testCodexJWT("chatgpt-account") {
+		t.Fatalf("Authorization = %q", receivedAuthorization)
+	}
+	var payload accountlimits.ProviderLimitsPayload
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.AccountID != "codex-local" || payload.Provider != accountlimits.ProviderOpenAI || payload.CapturedAt == nil {
+		t.Fatalf("unexpected payload metadata: %+v", payload)
+	}
+}
+
+func TestAccountLimitsFetchesZaiQuotaFromLocalConfig(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/monitor/usage/quota/limit" {
+			t.Fatalf("path = %q", request.URL.Path)
+		}
+		if request.Header.Get("Authorization") != "Bearer zai-key" {
+			t.Fatalf("Authorization = %q", request.Header.Get("Authorization"))
+		}
+		_, _ = w.Write([]byte(`{"data":{"limits":[{"type":"TOKENS_LIMIT","unit":3,"percentage":30}],"level":"max"}}`))
+	}))
+	defer upstream.Close()
+
+	server := newTestServer(t)
+	server.cfg.OpenAICompatibility = []proxyconfig.OpenAICompatibility{{
+		Name:          "zai",
+		BaseURL:       upstream.URL + "/v1",
+		APIKeyEntries: []proxyconfig.OpenAICompatibilityAPIKey{{APIKey: "zai-key"}},
+	}}
+
+	recorder := performLimitsRequest(server, "/v1/account/limits")
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var payload accountlimits.ProviderLimitsPayload
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Provider != accountlimits.ProviderZai || payload.AccountID != "zai" || payload.CapturedAt == nil {
+		t.Fatalf("unexpected payload metadata: %+v", payload)
+	}
+}
+
+func registerLimitsAuth(t *testing.T, server *Server, entries ...*cliproxyauth.Auth) {
+	t.Helper()
+	for _, entry := range entries {
+		if _, err := server.handlers.AuthManager.Register(context.Background(), entry); err != nil {
+			t.Fatalf("register auth: %v", err)
+		}
+	}
+}
+
+func performLimitsRequest(server *Server, target string) *httptest.ResponseRecorder {
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, target, nil)
+	request.Header.Set("Authorization", "Bearer test-key")
+	server.engine.ServeHTTP(recorder, request)
+	return recorder
+}
+
+func testCodexJWT(accountID string) string {
+	payload, _ := json.Marshal(map[string]any{
+		"https://api.openai.com/auth": map[string]string{"chatgpt_account_id": accountID},
+	})
+	return "header." + base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -211,8 +211,9 @@ type Server struct {
 	handlers *handlers.BaseAPIHandler
 
 	// cfg holds the current server configuration.
-	cfg   *config.Config
-	cfgMu sync.RWMutex
+	cfg *config.Config
+	// accountLimitsCfg holds an immutable runtime snapshot for account limits requests.
+	accountLimitsCfg atomic.Pointer[config.Config]
 
 	// oldConfigYaml stores a YAML snapshot of the previous configuration for change detection.
 	// This prevents issues when the config object is modified in place by Management API.
@@ -341,6 +342,7 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 
 		exampleAPIKeySafeModeEnabled: optionState.exampleAPIKeySafeMode,
 	}
+	s.accountLimitsCfg.Store(cfg.CloneForRuntime())
 	s.wsAuthEnabled.Store(cfg.WebsocketAuth)
 	s.exampleAPIKeySafeModeActive.Store(s.exampleAPIKeySafeModeRequired(cfg))
 	s.handlers.SetPluginHost(optionState.pluginHost)
@@ -1922,9 +1924,8 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 	if accessConfigApplied || exampleAPIKeySafeModeRequired {
 		s.exampleAPIKeySafeModeActive.Store(exampleAPIKeySafeModeRequired)
 	}
-	s.cfgMu.Lock()
 	s.cfg = cfg
-	s.cfgMu.Unlock()
+	s.accountLimitsCfg.Store(cfg.CloneForRuntime())
 	s.wsAuthEnabled.Store(cfg.WebsocketAuth)
 	if oldCfg != nil && s.wsAuthChanged != nil && oldCfg.WebsocketAuth != cfg.WebsocketAuth {
 		s.wsAuthChanged(oldCfg.WebsocketAuth, cfg.WebsocketAuth)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -211,7 +211,8 @@ type Server struct {
 	handlers *handlers.BaseAPIHandler
 
 	// cfg holds the current server configuration.
-	cfg *config.Config
+	cfg   *config.Config
+	cfgMu sync.RWMutex
 
 	// oldConfigYaml stores a YAML snapshot of the previous configuration for change detection.
 	// This prevents issues when the config object is modified in place by Management API.
@@ -523,6 +524,7 @@ func (s *Server) setupRoutes() {
 	v1.Use(AuthMiddleware(s.accessManager))
 	{
 		v1.GET("/models", s.unifiedModelsHandler(openaiHandlers, claudeCodeHandlers))
+		v1.GET("/account/limits", s.accountLimitsHandler)
 		v1.POST("/chat/completions", openaiHandlers.ChatCompletions)
 		v1.POST("/completions", openaiHandlers.Completions)
 		v1.POST("/images/generations", openaiHandlers.ImagesGenerations)
@@ -1920,7 +1922,9 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 	if accessConfigApplied || exampleAPIKeySafeModeRequired {
 		s.exampleAPIKeySafeModeActive.Store(exampleAPIKeySafeModeRequired)
 	}
+	s.cfgMu.Lock()
 	s.cfg = cfg
+	s.cfgMu.Unlock()
 	s.wsAuthEnabled.Store(cfg.WebsocketAuth)
 	if oldCfg != nil && s.wsAuthChanged != nil && oldCfg.WebsocketAuth != cfg.WebsocketAuth {
 		s.wsAuthChanged(oldCfg.WebsocketAuth, cfg.WebsocketAuth)

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/andybalholm/brotli"
 	"github.com/google/uuid"
 	"github.com/klauspost/compress/zstd"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/accountlimits"
 	claudeauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/claude"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
@@ -263,6 +264,13 @@ func (e *ClaudeExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Aut
 	return httpClient.Do(httpReq)
 }
 
+func (e *ClaudeExecutor) captureClaudeRateLimits(auth *cliproxyauth.Auth, headers http.Header) {
+	if auth == nil || strings.TrimSpace(auth.ID) == "" || len(headers) == 0 {
+		return
+	}
+	accountlimits.CaptureAnthropicRateLimits(auth.ID, headers, time.Now())
+}
+
 func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	if opts.Alt == "responses/compact" {
 		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
@@ -384,6 +392,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		return resp, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	e.captureClaudeRateLimits(auth, httpResp.Header)
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		// Decompress error responses — pass the Content-Encoding value (may be empty)
 		// and let decodeResponseBody handle both header-declared and magic-byte-detected
@@ -575,6 +584,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		return nil, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	e.captureClaudeRateLimits(auth, httpResp.Header)
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		// Decompress error responses — pass the Content-Encoding value (may be empty)
 		// and let decodeResponseBody handle both header-declared and magic-byte-detected
@@ -833,6 +843,7 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 		return cliproxyexecutor.Response{}, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, resp.StatusCode, resp.Header.Clone())
+	e.captureClaudeRateLimits(auth, resp.Header)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// Decompress error responses — pass the Content-Encoding value (may be empty)
 		// and let decodeResponseBody handle both header-declared and magic-byte-detected

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -6180,6 +6180,13 @@ func (m *Manager) refreshAuth(ctx context.Context, id string) {
 	_, _ = m.refreshAuthForRequest(ctx, id, "")
 }
 
+// RefreshAuth synchronously refreshes one credential and persists the result.
+// failedAccessToken lets concurrent callers reuse a refresh that already replaced
+// the token which produced an unauthorized response.
+func (m *Manager) RefreshAuth(ctx context.Context, id, failedAccessToken string) (*Auth, error) {
+	return m.refreshAuthForRequest(ctx, id, failedAccessToken)
+}
+
 // refreshAuthForRequest performs a synchronous credential refresh for the given auth.
 // failedAccessToken lets concurrent callers reuse a refresh that already replaced the
 // access token that produced the unauthorized response.


### PR DESCRIPTION
## Summary

- add an authenticated `GET /v1/account/limits` endpoint
- expose normalized subscription limits for Anthropic, Codex OAuth, and Z.AI accounts
- select local credentials automatically when exactly one supported account is configured
- support explicit `provider` and `account_id` selectors for multi-account configurations
- capture Anthropic rate-limit windows from upstream response headers
- fetch Codex and Z.AI limits from their provider usage endpoints
- add focused parser, credential-selection, endpoint, and race tests

## Motivation

CLIProxyAPI manages subscription-backed provider credentials, but clients currently have no provider-neutral way to inspect their quota windows.

This endpoint allows dashboards and local management tools to display account limits without reading credential files or implementing provider-specific authentication.

## API

For a deployment with one supported credential:

```http
GET /v1/account/limits
Authorization: Bearer <proxy-api-key>
```

For deployments with multiple supported credentials:

```http
GET /v1/account/limits?provider=openai&account_id=codex-local
Authorization: Bearer <proxy-api-key>
```

The response uses a normalized `account.limits` object with provider metadata, capture time, and quota snapshots.

## Provider behavior

- **Anthropic:** limits are captured from response headers produced by normal Claude requests. Partial 5-hour and 7-day snapshots are merged.
- **Codex OAuth:** limits are fetched from the Codex usage endpoint using the selected local OAuth credential.
- **Z.AI:** limits are fetched from the monitor quota endpoint using the selected local `openai-compatibility` credential.

## Security

- callers cannot provide or override provider access tokens
- callers cannot override upstream base URLs or proxy settings through request headers
- only locally configured credentials are used for provider requests
- upstream response bodies are limited to 2 MiB
- upstream error bodies are not forwarded to clients
- configuration reads use an immutable snapshot during live reload

The endpoint uses the existing `/v1` bearer authentication. Proxy API keys should therefore be trusted to view quota metadata for locally configured accounts.

## Compatibility

This change is additive and does not alter existing inference routes.

Anthropic quota data is initially unavailable until a normal Claude request returns rate-limit headers.

Codex API-key credentials are not included because the subscription usage endpoint requires an OAuth credential with a ChatGPT account ID.

## Testing

- `go test ./...`
- `go test -race ./internal/accountlimits ./internal/api`
- `go build -o test-output ./cmd/server && rm test-output`
- `git diff --check`