### PR TITLE
fix(auth): persist permanent failure marker across restarts in all stores

### DIFF
--- a/internal/store/gitstore.go
+++ b/internal/store/gitstore.go
@@ -506,6 +506,7 @@ func (s *GitTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth, 
 		auth.Attributes["email"] = email
 	}
 	cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
+	cliproxyauth.ApplyPermanentFailureFromMetadata(auth)
 	if disabled, ok := metadata["disabled"].(bool); ok && disabled {
 		auth.Disabled = true
 		auth.Status = cliproxyauth.StatusDisabled

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -608,6 +608,7 @@ func (s *ObjectTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Aut
 		NextRefreshAfter: time.Time{},
 	}
 	cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
+	cliproxyauth.ApplyPermanentFailureFromMetadata(auth)
 	if disabled, ok := metadata["disabled"].(bool); ok && disabled {
 		auth.Disabled = true
 		auth.Status = cliproxyauth.StatusDisabled

--- a/internal/store/postgresstore.go
+++ b/internal/store/postgresstore.go
@@ -323,6 +323,7 @@ func (s *PostgresStore) List(ctx context.Context) ([]*cliproxyauth.Auth, error) 
 			NextRefreshAfter: time.Time{},
 		}
 		cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
+		cliproxyauth.ApplyPermanentFailureFromMetadata(auth)
 		if disabled, ok := metadata["disabled"].(bool); ok && disabled {
 			auth.Disabled = true
 			auth.Status = cliproxyauth.StatusDisabled

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -1253,6 +1253,17 @@ func responsesWebsocketAuthAvailableForModel(auth *coreauth.Auth, modelName stri
 	if auth.Disabled || auth.Status == coreauth.StatusDisabled {
 		return false
 	}
+	// Permanent credential failure from the refresh path (e.g. refresh
+	// returned 400 invalid_grant) marks the auth Unavailable with a
+	// permanent LastError and zero NextRetryAfter. This must block the
+	// pinned websocket path too — otherwise a dead Codex/xAI pin keeps
+	// being matched by responsesWebsocketPinnedAuthMatchesModel and the
+	// handler keeps sending frames with WithPinnedAuthID, getting
+	// auth_unavailable instead of releasing the pin and falling back to
+	// a healthy auth (codex review).
+	if auth.Unavailable && coreauth.HasPermanentAuthFailure(auth) && auth.NextRetryAfter.IsZero() {
+		return false
+	}
 	if modelName != "" && len(auth.ModelStates) > 0 {
 		state, ok := auth.ModelStates[modelName]
 		if (!ok || state == nil) && modelName != "" {

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -2122,6 +2122,23 @@ func TestResponsesWebsocketPinnedAuthMatchesModel(t *testing.T) {
 	if responsesWebsocketPinnedAuthMatchesModel(unregisteredAuth, modelB, modelA, true) {
 		t.Fatal("Home runtime auth matched a different model")
 	}
+
+	// Permanent credential failure from the refresh path (400 invalid_grant
+	// or 401) marks the auth Unavailable with zero NextRetryAfter. The
+	// websocket pin path must reject it so the dead pin is released and the
+	// handler falls back to a healthy auth, instead of keeping the dead pin
+	// and sending frames that get auth_unavailable (codex review).
+	permanentFailedAuth := auth.Clone()
+	permanentFailedAuth.Unavailable = true
+	permanentFailedAuth.NextRetryAfter = time.Time{}
+	permanentFailedAuth.PermanentRefreshFailure = true
+	permanentFailedAuth.LastError = &coreauth.Error{HTTPStatus: http.StatusBadRequest, Message: "invalid_grant: refresh token revoked"}
+	if responsesWebsocketPinnedAuthMatchesModel(permanentFailedAuth, modelA, modelA, false) {
+		t.Fatal("permanent failed auth matched a model — dead pin must be rejected so it can be released")
+	}
+	if responsesWebsocketAuthAvailableForModel(permanentFailedAuth, modelA, time.Now()) {
+		t.Fatal("permanent failed auth reported available — websocket path must block it")
+	}
 }
 
 func TestWebsocketUpstreamSupportsIncrementalInputForModel(t *testing.T) {

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -279,6 +279,7 @@ func (s *FileTokenStore) readAuthFiles(path, baseDir string) ([]*cliproxyauth.Au
 					auth.Metadata["disabled"] = true
 				}
 				cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
+				cliproxyauth.ApplyPermanentFailureFromMetadata(auth)
 			}
 			return auths, nil
 		}
@@ -339,6 +340,7 @@ func (s *FileTokenStore) readAuthFiles(path, baseDir string) ([]*cliproxyauth.Au
 		auth.Attributes["email"] = email
 	}
 	cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
+	cliproxyauth.ApplyPermanentFailureFromMetadata(auth)
 	return []*cliproxyauth.Auth{auth}, nil
 }
 

--- a/sdk/cliproxy/auth/auto_refresh_loop.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop.go
@@ -339,7 +339,19 @@ func nextRefreshCheckAt(now time.Time, auth *Auth, interval time.Duration) (time
 	if auth == nil {
 		return time.Time{}, false
 	}
-	if hasUnauthorizedAuthFailure(auth) {
+	// Stop scheduling only for refresh-sourced permanent failures
+	// (Unavailable=true + NextRetryAfter zero — refreshAuthForRequest's
+	// permanent branch sets exactly this combination). Request-side
+	// invalid_grant cooldowns must remain schedulable so proactive
+	// refresh can recover them early (codex review):
+	//   - Single-model all-cooldown: Unavailable=true + non-zero
+	//     NextRetryAfter → falls through.
+	//   - Multi-model partial cooldown: Unavailable=false + zero
+	//     NextRetryAfter (a clean model keeps the auth available) →
+	//     falls through. Without the Unavailable check, the cooled
+	//     model's LastError would unschedule the auth and prevent
+	//     early recovery of the cooled model.
+	if auth.Unavailable && hasPermanentAuthFailure(auth) && auth.NextRetryAfter.IsZero() {
 		return time.Time{}, false
 	}
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -665,6 +665,44 @@ func clearCooldownStateForAuth(auth *Auth, now time.Time) bool {
 	if auth == nil {
 		return false
 	}
+	// Preserve the refresh-sourced permanent failure marker
+	// (Unavailable + hasPermanentAuthFailure + NextRetryAfter.IsZero()).
+	// clearCooldownStateForAuth is invoked from SetConfig/register/update
+	// paths when disable-cooling is enabled, and historically clears
+	// auth.Unavailable — without this guard, a config reload erases the
+	// permanent marker and the shouldRefresh / nextRefreshCheckAt /
+	// isAuthBlockedForModel guards stop firing, re-queueing revoked
+	// 400 invalid_grant credentials (codex review).
+	//
+	// Transient cooldowns (NextRetryAfter non-zero) are still cleared
+	// below — only the permanent marker is preserved.
+	if auth.Unavailable && hasPermanentAuthFailure(auth) && auth.NextRetryAfter.IsZero() {
+		// Clear per-model cooldown state (a permanent refresh failure
+		// already resets these in refreshAuthForRequest, but a stale
+		// model cooldown may have been restored from disk or set by a
+		// racing request before the permanent marker was set).
+		modelChanged := false
+		for _, state := range auth.ModelStates {
+			if state == nil || state.Status == StatusDisabled {
+				continue
+			}
+			if state.Unavailable || !state.NextRetryAfter.IsZero() || state.Quota.Exceeded || !state.Quota.NextRecoverAt.IsZero() {
+				state.Unavailable = false
+				state.NextRetryAfter = time.Time{}
+				state.Quota = QuotaState{}
+				state.UpdatedAt = now
+				modelChanged = true
+			}
+		}
+		if modelChanged && len(auth.ModelStates) > 0 {
+			// Recompute quota aggregation but NOT auth.Unavailable /
+			// NextRetryAfter — updateAggregatedAvailability would
+			// overwrite the permanent marker. Manually clear quota
+			// since permanent failures carry no quota state.
+			auth.Quota = QuotaState{}
+		}
+		return modelChanged
+	}
 	changed := false
 	if auth.Unavailable || !auth.NextRetryAfter.IsZero() || auth.Quota.Exceeded || !auth.Quota.NextRecoverAt.IsZero() {
 		auth.Unavailable = false
@@ -1394,7 +1432,7 @@ func (m *Manager) availableAuthsForRouteModel(auths []*Auth, provider, routeMode
 	}
 
 	availableByPriority := make(map[int][]*Auth)
-	cooldownCount := 0
+	unavailableCount := 0
 	var earliest time.Time
 	for _, candidate := range auths {
 		checkModel := m.selectionModelForAuth(candidate, routeModel)
@@ -1404,8 +1442,8 @@ func (m *Manager) availableAuthsForRouteModel(auths []*Auth, provider, routeMode
 			availableByPriority[priority] = append(availableByPriority[priority], candidate)
 			continue
 		}
+		unavailableCount++
 		if reason == blockReasonCooldown {
-			cooldownCount++
 			if !next.IsZero() && (earliest.IsZero() || next.Before(earliest)) {
 				earliest = next
 			}
@@ -1413,7 +1451,7 @@ func (m *Manager) availableAuthsForRouteModel(auths []*Auth, provider, routeMode
 	}
 
 	if len(availableByPriority) == 0 {
-		if cooldownCount == len(auths) && !earliest.IsZero() {
+		if unavailableCount == len(auths) && !earliest.IsZero() {
 			providerForError := provider
 			if providerForError == "mixed" {
 				providerForError = ""
@@ -3739,7 +3777,22 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 		}
 
 		if result.Success {
-			if result.Model != "" {
+			// If the auth is already marked as a refresh-sourced permanent
+			// failure (Unavailable + permanent LastError + zero NextRetryAfter),
+			// skip the success-state update — both branches below would erase
+			// the permanent marker:
+			//   - result.Model != "": updateAggregatedAvailability recomputes
+			//     Unavailable=false (all model states clean) + clears LastError.
+			//   - result.Model == "": clearAuthStateOnSuccess unconditionally
+			//     clears Unavailable, LastError, NextRetryAfter.
+			// A dead auth should not receive a success result (guards block
+			// routing), but defending against an erroneous MarkResult call
+			// prevents the marker from being silently erased (codex review
+			// on clearCooldownStateForAuth revealed the same class of leak
+			// across all Unavailable=false write paths).
+			if auth.Unavailable && hasPermanentAuthFailure(auth) && auth.NextRetryAfter.IsZero() {
+				auth.UpdatedAt = now
+			} else if result.Model != "" {
 				state := ensureModelState(auth, result.Model)
 				resetModelState(state, now)
 				updateAggregatedAvailability(auth, now)
@@ -3755,7 +3808,23 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				clearAuthStateOnSuccess(auth, now)
 			}
 		} else {
-			if result.Model != "" {
+			// If the auth is already marked as a refresh-sourced permanent
+			// failure (Unavailable + permanent LastError + zero NextRetryAfter),
+			// skip the failure-state update — MarkResult would overwrite the
+			// permanent marker with a transient request cooldown, masking the
+			// dead auth from scheduler/routing guards (codex review on 358d49b2).
+			//
+			// This happens when tryRefreshAfterUnauthorized calls
+			// refreshAuthForRequest and gets a 400 invalid_grant (permanent),
+			// then the caller records the original 401 via MarkResult — without
+			// this skip, the 401 cooldown overwrites the zero-NextRetryAfter
+			// permanent marker and the dead auth is requeued/routable after the
+			// cooldown expires.
+			if auth.Unavailable && hasPermanentAuthFailure(auth) && auth.NextRetryAfter.IsZero() {
+				// Only record the attempt count (already done above); skip
+				// failure-state write so the permanent marker stays intact.
+				auth.UpdatedAt = now
+			} else if result.Model != "" {
 				if !isRequestScopedResultError(result.Error) {
 					disableCooling := m.cooldownDisabledForAuth(auth)
 					state := ensureModelState(auth, result.Model)
@@ -4072,6 +4141,7 @@ func clearAuthStateOnSuccess(auth *Auth, now time.Time) {
 		return
 	}
 	auth.Unavailable = false
+	auth.PermanentRefreshFailure = false
 	auth.Status = StatusActive
 	auth.StatusMessage = ""
 	auth.Quota.Exceeded = false
@@ -4144,6 +4214,21 @@ func resultErrorFromError(err error) *Error {
 	return resultErr
 }
 
+// permanentCredentialStatusMessage returns the StatusMessage to record when
+// isPermanentCredentialFailure returns true. It distinguishes invalid_grant
+// from generic unauthorized so operators can see the real reason in the
+// management API.
+func permanentCredentialStatusMessage(err error) string {
+	if err == nil {
+		return "unauthorized"
+	}
+	raw := strings.ToLower(err.Error())
+	if strings.Contains(raw, "invalid_grant") || strings.Contains(raw, "refresh token") {
+		return "invalid_grant"
+	}
+	return "unauthorized"
+}
+
 func isUnauthorizedError(err error) bool {
 	if err == nil {
 		return false
@@ -4155,11 +4240,87 @@ func isUnauthorizedError(err error) bool {
 	return strings.Contains(raw, "status 401") || strings.Contains(raw, "401 unauthorized")
 }
 
-func hasUnauthorizedAuthFailure(auth *Auth) bool {
-	if auth == nil || auth.LastError == nil {
+// isPermanentCredentialFailure reports whether err indicates the refresh
+// token (or underlying credential) is permanently invalid and cannot be
+// recovered by retrying. This covers RFC 6749 §5.2 permanent error codes
+// returned by OAuth token endpoints:
+//
+//   - HTTP 400 with `invalid_grant`: the refresh token is invalid, expired,
+//     revoked, or was issued to another client. x.ai returns this exact
+//     combination (HTTP 400, error=invalid_grant) for revoked refresh tokens.
+//   - HTTP 401 with `invalid_grant`: some providers use 401 instead of 400.
+//   - Descriptive messages without the standard error code (e.g. "refresh
+//     token has been revoked", "refresh token expired").
+//
+// Returning true marks the auth Unavailable + StatusError so it becomes
+// visible to management API consumers (e.g. the welfare collector script's
+// isDeadCpaAuth cleanup) and stops the auto-refresh loop from retrying
+// indefinitely.
+//
+// Note: plain HTTP 401 is still treated as permanent here (preserving legacy
+// behavior) to avoid regressing providers that rely on 401 semantics, even
+// though 401 may sometimes indicate a transient config issue like invalid_client.
+func isPermanentCredentialFailure(err error) bool {
+	if err == nil {
 		return false
 	}
-	return auth.LastError.StatusCode() == http.StatusUnauthorized || strings.EqualFold(auth.LastError.Code, "unauthorized")
+	if isUnauthorizedError(err) {
+		return true
+	}
+	raw := strings.ToLower(err.Error())
+	for _, sub := range permanentCredentialSubstrings {
+		if strings.Contains(raw, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// permanentCredentialSubstrings are the lowercase substrings that indicate a
+// permanent refresh-token failure when the error does not carry an HTTP 401
+// status (e.g. x.ai's plain fmt.Errorf from the token endpoint).
+var permanentCredentialSubstrings = []string{
+	"invalid_grant",
+	"refresh token has been revoked",
+	"refresh token is invalid",
+	"refresh token expired",
+}
+
+// hasPermanentAuthFailure reports whether auth carries a permanent credential
+// failure sourced from the refresh path (HTTP 401, 400 invalid_grant, or a
+// descriptive revoked/expired message). It replaces the legacy
+// hasUnauthorizedAuthFailure check so the scheduler stops retrying
+// RFC 6749 §5.2 permanent errors that providers return as HTTP 400 instead
+// of 401 (e.g. x.ai revoked refresh tokens).
+//
+// Discriminator: the ONLY signal is auth.PermanentRefreshFailure, which
+// is set exclusively by refreshAuthForRequest's permanent branch. This
+// cleanly distinguishes refresh-sourced permanent failures from
+// disable-cooling transient failures (applyAuthFailureState with
+// disableCooling=true also produces Unavailable=true + zero
+// NextRetryAfter + LastError(401/invalid_grant), but is transient —
+// relying on LastError shape alone would misclassify those as permanent
+// and permanently block routing, codex review).
+//
+// Legacy compat: auths persisted before the PermanentRefreshFailure field
+// existed will have PermanentRefreshFailure=false after restart. They will
+// not be blocked by the guards immediately, but the first refresh attempt
+// will re-detect the permanent failure (refresh returns 400 invalid_grant
+// again) and re-set the marker. This is safer than a LastError-based
+// fallback, which would misclassify disable-cooling request failures as
+// permanent.
+func hasPermanentAuthFailure(auth *Auth) bool {
+	if auth == nil {
+		return false
+	}
+	return auth.PermanentRefreshFailure
+}
+
+// HasPermanentAuthFailure is the exported form of hasPermanentAuthFailure,
+// for cross-package consumers that need to detect the refresh-sourced
+// permanent failure marker (e.g. websocket pin path).
+func HasPermanentAuthFailure(auth *Auth) bool {
+	return hasPermanentAuthFailure(auth)
 }
 
 func refreshErrorFromError(err error) *Error {
@@ -5896,7 +6057,20 @@ func (m *Manager) shouldRefresh(a *Auth, now time.Time) bool {
 	if a == nil {
 		return false
 	}
-	if hasUnauthorizedAuthFailure(a) {
+	// Stop proactive refresh only for refresh-sourced permanent failures
+	// (Unavailable=true + NextRetryAfter zero — refreshAuthForRequest's
+	// permanent branch sets exactly this combination). Request-side
+	// invalid_grant cooldowns must NOT be blocked here:
+	//   - Single-model all-cooldown: updateAggregatedAvailability sets
+	//     Unavailable=true + NextRetryAfter=now+30min (non-zero) → falls
+	//     through to the refresh lead/expiry logic below.
+	//   - Multi-model partial cooldown: updateAggregatedAvailability sets
+	//     Unavailable=false + NextRetryAfter=zero (a clean model keeps the
+	//     auth available). Without the Unavailable check, this guard would
+	//     fire on the cooled model's LastError and unschedule the auth,
+	//     preventing proactive refresh from recovering the cooled model
+	//     early (codex review).
+	if a.Unavailable && hasPermanentAuthFailure(a) && a.NextRetryAfter.IsZero() {
 		return false
 	}
 	if !a.NextRefreshAfter.IsZero() && now.Before(a.NextRefreshAfter) {
@@ -6231,16 +6405,51 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 	log.Debugf("refreshed %s, %s, %v", auth.Provider, auth.ID, err)
 	now := time.Now()
 	if err != nil {
-		unauthorized := isUnauthorizedError(err)
+		permanent := isPermanentCredentialFailure(err)
 		shouldReschedule := false
+		shouldPersist := false
+		var persistClone *Auth
 		m.mu.Lock()
 		if current := m.auths[id]; current != nil {
 			current.LastError = refreshErrorFromError(err)
-			if unauthorized {
+			if permanent {
 				current.NextRefreshAfter = time.Time{}
+				// Clear any stale request cooldown so the NextRetryAfter.IsZero()
+				// discriminators in shouldRefresh, nextRefreshCheckAt, and
+				// isAuthBlockedForModel correctly identify this as a refresh-
+				// sourced permanent failure. Without this, a pre-existing request
+				// cooldown (NextRetryAfter non-zero) would mask the permanent
+				// failure, leaving the dead auth scheduled and routable after the
+				// stale cooldown expires (codex review).
+				current.NextRetryAfter = time.Time{}
 				current.Unavailable = true
+				current.PermanentRefreshFailure = true
 				current.Status = StatusError
-				current.StatusMessage = "unauthorized"
+				current.StatusMessage = permanentCredentialStatusMessage(err)
+				// Clear per-model cooldown state so persistCooldownStates drops
+				// the model .cds records from the snapshot. Otherwise a restart
+				// replays them via RestoreCooldownStates → updateAggregatedAvailability,
+				// which restores a non-zero auth NextRetryAfter from the stale
+				// model cooldowns and masks the permanent marker from the
+				// IsZero() guards (codex review). StatusDisabled states are
+				// preserved — they reflect user/admin intent, not cooldown.
+				// updateAggregatedAvailability is NOT called here because it
+				// would recompute auth.Unavailable=false (all model states are
+				// now clean) and overwrite the permanent marker.
+				for _, state := range current.ModelStates {
+					if state == nil || state.Status == StatusDisabled {
+						continue
+					}
+					resetModelState(state, now)
+				}
+				// Clone under the lock so the persist path below has a stable
+				// snapshot. Persist the permanent marker so it survives process
+				// restart — without this, a restart reloads the auth from
+				// storage without the Unavailable/permanent-LastError marker,
+				// and any stale .cds cooldown record can also be restored,
+				// requeueing the revoked credential (codex review).
+				persistClone = current.Clone()
+				shouldPersist = true
 			} else {
 				current.NextRefreshAfter = now.Add(refreshFailureBackoff)
 			}
@@ -6251,6 +6460,17 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 			}
 		}
 		m.mu.Unlock()
+		if shouldPersist && persistClone != nil {
+			if errPersist := m.persist(ctx, persistClone); errPersist != nil {
+				log.Debugf("persist permanent refresh failure for %s (%s) failed: %v", auth.Provider, auth.ID, errPersist)
+			}
+			// persistCooldownStates writes a full snapshot and removes stale
+			// .cds files not in the snapshot. The permanent marker has
+			// NextRetryAfter=zero, so authCooldownStateRecord returns false
+			// and the dead auth's auth-level cooldown record is dropped.
+			m.persistCooldownStates(ctx)
+			m.hook.OnAuthUpdated(ctx, persistClone)
+		}
 		if shouldReschedule {
 			m.queueRefreshReschedule(id)
 		}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -5973,6 +5973,30 @@ func (m *Manager) persist(ctx context.Context, auth *Auth) error {
 	if auth.Metadata == nil {
 		return nil
 	}
+	// Persist the permanent-refresh-failure marker into Metadata so the
+	// file/Postgres/object/git stores — which only durably persist
+	// Metadata — can restore it on restart. Without this, store readers
+	// rebuild the Auth with PermanentRefreshFailure=false /
+	// Unavailable=false / Status=StatusActive, and the revoked credential
+	// becomes routable again (codex review).
+	//
+	// Keys are namespaced with the cpa_permanent_ prefix to avoid
+	// colliding with provider/plugin credential metadata that may
+	// legitimately use generic names like "status" or "unavailable"
+	// (codex review).
+	if auth.PermanentRefreshFailure {
+		auth.Metadata[metadataKeyPermanentRefreshFailure] = true
+		auth.Metadata[metadataKeyUnavailable] = auth.Unavailable
+		auth.Metadata[metadataKeyStatus] = string(auth.Status)
+		auth.Metadata[metadataKeyStatusMessage] = auth.StatusMessage
+	} else {
+		// Clear stale marker keys so a recovered auth (e.g. after manual
+		// token replacement) doesn't restore the dead state.
+		delete(auth.Metadata, metadataKeyPermanentRefreshFailure)
+		delete(auth.Metadata, metadataKeyUnavailable)
+		delete(auth.Metadata, metadataKeyStatus)
+		delete(auth.Metadata, metadataKeyStatusMessage)
+	}
 	_, err := m.store.Save(ctx, auth)
 	return err
 }

--- a/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -45,11 +46,29 @@ func (e unauthorizedRefreshTestExecutor) Refresh(ctx context.Context, auth *Auth
 	return nil, errors.New("token refresh failed with status 401: invalid_grant")
 }
 
+// invalidGrantRefreshTestExecutor simulates x.ai's real behavior: HTTP 400
+// with invalid_grant for a revoked refresh token. This is RFC 6749 §5.2
+// compliant — token endpoints default to 400, not 401.
+type invalidGrantRefreshTestExecutor struct {
+	schedulerProviderTestExecutor
+}
+
+func (e invalidGrantRefreshTestExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	return nil, errors.New("xai token request failed with status 400: {\"error\":\"invalid_grant\",\"error_description\":\"Refresh token has been revoked\"}")
+}
+
 func TestManager_RefreshAuthUnauthorizedFailureStopsAutoRefreshRetry(t *testing.T) {
 	ctx := context.Background()
 	manager := NewManager(nil, &RoundRobinSelector{}, nil)
 	manager.RegisterExecutor(unauthorizedRefreshTestExecutor{
 		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "codex"},
+	})
+
+	// Register a refresh lead for codex, mirroring the real runtime where
+	// sdk/auth/refresh_registry.go registers one via init().
+	setRefreshLeadFactory(t, "codex", func() *time.Duration {
+		d := 5 * time.Minute
+		return &d
 	})
 
 	auth := &Auth{
@@ -87,6 +106,793 @@ func TestManager_RefreshAuthUnauthorizedFailureStopsAutoRefreshRetry(t *testing.
 	}
 	if _, shouldSchedule := nextRefreshCheckAt(now, updated, time.Second); shouldSchedule {
 		t.Fatal("expected unauthorized auth to be removed from the auto-refresh schedule")
+	}
+}
+
+// TestManager_RefreshAuthInvalidGrant400MarksAuthUnavailable verifies that
+// refresh failures returning HTTP 400 with invalid_grant (RFC 6749 §5.2,
+// x.ai's actual behavior for revoked refresh tokens) are treated as
+// permanent credential failures — the auth is marked Unavailable + StatusError
+// so management API consumers (e.g. cleanup scripts) can detect and delete it.
+//
+// Regression: previously isUnauthorizedError only recognized HTTP 401, so
+// 400 invalid_grant was treated as a transient error and the auth kept
+// status=active, unavailable=false forever — making cleanup impossible.
+func TestManager_RefreshAuthInvalidGrant400MarksAuthUnavailable(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(invalidGrantRefreshTestExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "xai"},
+	})
+
+	// Register a refresh lead for xai, mirroring the real runtime where
+	// sdk/auth/refresh_registry.go registers one via init(). Without this the
+	// scheduler would short-circuit at ProviderRefreshLead==nil and hide the
+	// regression where hasUnauthorizedAuthFailure failed to recognize 400
+	// invalid_grant as permanent (the auto-refresh loop kept re-queuing the
+	// revoked credential indefinitely).
+	setRefreshLeadFactory(t, "xai", func() *time.Duration {
+		d := 5 * time.Minute
+		return &d
+	})
+
+	auth := &Auth{
+		ID:       "xai-revoked",
+		Provider: "xai",
+		Metadata: map[string]any{
+			"email": "revoked@example.com",
+		},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	manager.refreshAuth(ctx, auth.ID)
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatalf("expected auth %q after refresh", auth.ID)
+	}
+	if updated.LastError == nil {
+		t.Fatal("expected invalid_grant refresh failure to be recorded in LastError")
+	}
+	if !updated.Unavailable {
+		t.Fatal("expected Unavailable=true for 400 invalid_grant (revoked refresh token)")
+	}
+	if updated.Status != StatusError {
+		t.Fatalf("Status = %q, want %q", updated.Status, StatusError)
+	}
+	if updated.StatusMessage != "invalid_grant" {
+		t.Fatalf("StatusMessage = %q, want %q", updated.StatusMessage, "invalid_grant")
+	}
+	if !updated.NextRefreshAfter.IsZero() {
+		t.Fatalf("NextRefreshAfter = %s, want zero for permanent credential failure", updated.NextRefreshAfter)
+	}
+	now := time.Now()
+	if manager.shouldRefresh(updated, now) {
+		t.Fatal("expected revoked auth to stop refresh attempts")
+	}
+	if _, shouldSchedule := nextRefreshCheckAt(now, updated, time.Second); shouldSchedule {
+		t.Fatal("expected revoked auth to be removed from the auto-refresh schedule")
+	}
+}
+
+// TestManager_RefreshAuthPermanentFailureClearsStaleRequestCooldown verifies
+// the fix for the codex review on commit 7b335d14: when a credential already
+// has a request/model cooldown (NextRetryAfter non-zero) and a proactive
+// refresh during that window returns invalid_grant, the permanent-failure
+// branch must clear NextRetryAfter. Without this, the IsZero() discriminators
+// in shouldRefresh, nextRefreshCheckAt, and isAuthBlockedForModel all see a
+// non-zero NextRetryAfter and treat the permanent failure as a request
+// cooldown — leaving the dead auth scheduled for refresh and routable after
+// the stale cooldown expires.
+func TestManager_RefreshAuthPermanentFailureClearsStaleRequestCooldown(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(invalidGrantRefreshTestExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "xai"},
+	})
+
+	setRefreshLeadFactory(t, "xai", func() *time.Duration {
+		d := 5 * time.Minute
+		return &d
+	})
+
+	now := time.Now()
+	cooldownEnd := now.Add(30 * time.Minute)
+
+	auth := &Auth{
+		ID:             "xai-stale-cooldown",
+		Provider:       "xai",
+		Unavailable:    true,
+		Status:         StatusError,
+		StatusMessage:  "request invalid_grant cooldown",
+		NextRetryAfter: cooldownEnd,
+		Metadata: map[string]any{
+			"email": "stale@example.com",
+		},
+		ModelStates: map[string]*ModelState{
+			"grok-4": {
+				Unavailable:    true,
+				Status:         StatusError,
+				NextRetryAfter: cooldownEnd,
+			},
+		},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	// Simulate a proactive refresh firing during the cooldown window.
+	manager.refreshAuth(ctx, auth.ID)
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatalf("expected auth %q after refresh", auth.ID)
+	}
+
+	// NextRetryAfter must be cleared — this is the core fix.
+	if !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("NextRetryAfter = %s, want zero (stale request cooldown must be cleared on permanent refresh failure)", updated.NextRetryAfter)
+	}
+	if !updated.NextRefreshAfter.IsZero() {
+		t.Fatalf("NextRefreshAfter = %s, want zero for permanent credential failure", updated.NextRefreshAfter)
+	}
+	if !updated.Unavailable {
+		t.Fatal("expected Unavailable=true for permanent refresh failure")
+	}
+
+	// With NextRetryAfter cleared, the IsZero() discriminators must now fire.
+	if manager.shouldRefresh(updated, now) {
+		t.Fatal("expected dead auth to stop refresh attempts after stale cooldown cleared")
+	}
+	if _, shouldSchedule := nextRefreshCheckAt(now, updated, time.Second); shouldSchedule {
+		t.Fatal("expected dead auth to be removed from auto-refresh schedule after stale cooldown cleared")
+	}
+
+	// isAuthBlockedForModel short-circuit must fire (Unavailable +
+	// hasPermanentAuthFailure + NextRetryAfter.IsZero()).
+	blocked, reason, _ := isAuthBlockedForModel(updated, "grok-4", now)
+	if !blocked {
+		t.Fatal("expected isAuthBlockedForModel to block dead auth after stale cooldown cleared")
+	}
+	if reason != blockReasonOther {
+		t.Fatalf("blockReason = %d, want %d (permanent failure, not cooldown)", reason, blockReasonOther)
+	}
+}
+
+// TestMarkResult_PreservesRefreshPermanentFailureMarker verifies the fix
+// for codex review P2 on commit 358d49b2: when tryRefreshAfterUnauthorized
+// calls refreshAuthForRequest and gets a permanent failure (400 invalid_grant
+// or 401), the permanent branch sets Unavailable=true + zero NextRetryAfter
+// + permanent LastError. The caller then records the original 401 via
+// MarkResult — without an early-skip, MarkResult's failure-state write
+// (model-scoped or auth-level) overwrites the zero-NextRetryAfter marker
+// with a transient cooldown, masking the dead auth from the scheduler/
+// routing guards.
+func TestMarkResult_PreservesRefreshPermanentFailureMarker(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(invalidGrantRefreshTestExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "xai"},
+	})
+
+	setRefreshLeadFactory(t, "xai", func() *time.Duration {
+		d := 5 * time.Minute
+		return &d
+	})
+
+	auth := &Auth{
+		ID:       "xai-refresh-permanent",
+		Provider: "xai",
+		Metadata: map[string]any{
+			"email": "permanent@example.com",
+		},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	// Simulate tryRefreshAfterUnauthorized: refresh returns 400 invalid_grant,
+	// permanent branch sets Unavailable=true + zero NextRetryAfter.
+	manager.refreshAuth(ctx, auth.ID)
+
+	refreshed, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatalf("expected auth %q after refresh", auth.ID)
+	}
+	if !refreshed.Unavailable || !refreshed.NextRetryAfter.IsZero() {
+		t.Fatalf("precondition: expected refresh permanent marker, got Unavailable=%v NextRetryAfter=%v", refreshed.Unavailable, refreshed.NextRetryAfter)
+	}
+
+	// Simulate the caller recording the original 401 via MarkResult.
+	manager.MarkResult(ctx, Result{
+		AuthID:   auth.ID,
+		Provider: "xai",
+		Model:    "grok-4",
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: http.StatusUnauthorized,
+			Message:    "request unauthorized",
+			Code:       "unauthorized",
+		},
+	})
+
+	afterMark, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatalf("expected auth %q after MarkResult", auth.ID)
+	}
+
+	// Permanent marker must be preserved — MarkResult must not overwrite
+	// the zero NextRetryAfter with a transient 401 cooldown.
+	if !afterMark.Unavailable {
+		t.Fatal("expected Unavailable=true to be preserved after MarkResult")
+	}
+	if !afterMark.NextRetryAfter.IsZero() {
+		t.Fatalf("NextRetryAfter = %v, want zero (permanent marker must survive MarkResult)", afterMark.NextRetryAfter)
+	}
+	if !hasPermanentAuthFailure(afterMark) {
+		t.Fatalf("expected permanent failure marker to survive MarkResult, got LastError=%+v", afterMark.LastError)
+	}
+
+	// The guards must still fire — dead auth must not be schedulable or routable.
+	now := time.Now()
+	if manager.shouldRefresh(afterMark, now) {
+		t.Fatal("expected dead auth to remain blocked by shouldRefresh after MarkResult")
+	}
+	if _, shouldSchedule := nextRefreshCheckAt(now, afterMark, time.Second); shouldSchedule {
+		t.Fatal("expected dead auth to remain unscheduled by nextRefreshCheckAt after MarkResult")
+	}
+	blocked, reason, _ := isAuthBlockedForModel(afterMark, "grok-4", now)
+	if !blocked || reason != blockReasonOther {
+		t.Fatalf("expected isAuthBlockedForModel to keep blocking dead auth after MarkResult, got blocked=%v reason=%d", blocked, reason)
+	}
+}
+
+// TestIsPermanentCredentialFailure covers the permanent-failure detector
+// across the error shapes produced by real OAuth providers.
+func TestIsPermanentCredentialFailure(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"401 invalid_grant", errors.New("token refresh failed with status 401: invalid_grant"), true},
+		{"401 plain", errors.New("token refresh failed with status 401"), true},
+		{"400 invalid_grant (x.ai revoked)", errors.New("xai token request failed with status 400: {\"error\":\"invalid_grant\",\"error_description\":\"Refresh token has been revoked\"}"), true},
+		{"400 invalid_grant expired", errors.New("status 400: invalid_grant, refresh token expired"), true},
+		{"refresh token revoked descriptive", errors.New("Refresh token has been revoked"), true},
+		{"refresh token invalid descriptive", errors.New("refresh token is invalid"), true},
+		{"refresh token expired descriptive", errors.New("refresh token expired"), true},
+		{"400 invalid_request (not permanent)", errors.New("status 400: invalid_request, missing parameter"), false},
+		{"400 invalid_client (not permanent)", errors.New("status 400: invalid_client, unknown client"), false},
+		{"500 server error (not permanent)", errors.New("status 500: internal server error"), false},
+		{"network error (not permanent)", errors.New("context deadline exceeded"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isPermanentCredentialFailure(tc.err)
+			if got != tc.want {
+				t.Fatalf("isPermanentCredentialFailure(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHasPermanentAuthFailure_PreservedFromPersistedState verifies the
+// regression flagged by codex review on #4477: auths restored from persisted
+// cooldown state may carry LastError.Code="unauthorized" without an HTTP
+// status (the legacy hasUnauthorizedAuthFailure explicitly checked the code).
+// hasPermanentAuthFailure must keep honoring that marker so the scheduler
+// continues to treat such auths as permanently failed instead of re-queuing
+// TestHasPermanentAuthFailure_RequiresPermanentRefreshFailureField
+// documents the discriminator design after the codex review on commit
+// 2d88e84d: hasPermanentAuthFailure relies exclusively on the
+// PermanentRefreshFailure field, NOT on LastError shape. This avoids
+// misclassifying disable-cooling transient failures (which produce the
+// same Unavailable + zero NextRetryAfter + LastError(401) shape) as
+// permanent.
+//
+// Auths persisted before the PermanentRefreshFailure field existed are
+// NOT immediately treated as permanent after restart — they will be
+// retried once by refresh, which re-detects the permanent failure and
+// re-sets the marker if the credential is still revoked.
+func TestHasPermanentAuthFailure_RequiresPermanentRefreshFailureField(t *testing.T) {
+	// Register a refresh lead so the scheduler would otherwise attempt to
+	// schedule the credential — this proves the stop marker actually works.
+	setRefreshLeadFactory(t, "codex", func() *time.Duration {
+		d := 5 * time.Minute
+		return &d
+	})
+
+	// Legacy shape: Code="unauthorized" without PermanentRefreshFailure.
+	// After the fix, this is NOT permanent — will be re-detected by refresh.
+	legacyAuth := &Auth{
+		ID:          "persisted-unauthorized-legacy",
+		Provider:    "codex",
+		Unavailable: true,
+		Status:      StatusError,
+		LastError: &Error{
+			Code:    "unauthorized",
+			Message: "credentials rejected by upstream",
+		},
+	}
+	if hasPermanentAuthFailure(legacyAuth) {
+		t.Fatal("expected legacy auth without PermanentRefreshFailure to NOT be permanent")
+	}
+
+	// New shape: PermanentRefreshFailure=true set by refreshAuthForRequest.
+	permanentAuth := &Auth{
+		ID:                      "persisted-unauthorized-permanent",
+		Provider:                "codex",
+		Unavailable:             true,
+		Status:                  StatusError,
+		PermanentRefreshFailure: true,
+		NextRetryAfter:          time.Time{},
+		LastError: &Error{
+			Code:    "unauthorized",
+			Message: "credentials rejected by upstream",
+		},
+	}
+	if !hasPermanentAuthFailure(permanentAuth) {
+		t.Fatal("expected auth with PermanentRefreshFailure=true to be permanent")
+	}
+	now := time.Now()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	if manager.shouldRefresh(permanentAuth, now) {
+		t.Fatal("expected permanent auth to be skipped by shouldRefresh")
+	}
+	if _, shouldSchedule := nextRefreshCheckAt(now, permanentAuth, time.Second); shouldSchedule {
+		t.Fatal("expected permanent auth to be unscheduled by nextRefreshCheckAt")
+	}
+	blocked, reason, _ := isAuthBlockedForModel(permanentAuth, "grok-4", now)
+	if !blocked || reason != blockReasonOther {
+		t.Fatalf("expected permanent auth to be blocked by isAuthBlockedForModel, got blocked=%v reason=%d", blocked, reason)
+	}
+}
+
+// TestShouldRefresh_PersistedUnauthorizedWithCooldownStaysSchedulable
+// documents an intentional behavior change from the legacy
+// hasUnauthorizedAuthFailure predicate.
+//
+// Auths restored from persisted cooldown state via restoreCooldownRecordLocked
+// always have NextRetryAfter in the future (the restore path rejects zero-time
+// records). When such an auth carries LastError.Code="unauthorized", the
+// legacy predicate unconditionally stopped refresh scheduling; the new
+// predicate gates the stop on NextRetryAfter.IsZero(), so a persisted
+// unauthorized auth with a future NextRetryAfter REMAINS schedulable and can
+// attempt a proactive refresh to recover.
+//
+// This is desirable: the persisted unauthorized marker may reflect an expired
+// access token whose refresh token is still valid. Stopping refresh forever
+// would strand the credential. If the refresh token is also invalid, the
+// refresh attempt fails and refreshAuthForRequest's permanent-failure branch
+// sets NextRetryAfter=zero, which then triggers the stop on the next
+// shouldRefresh call.
+func TestShouldRefresh_PersistedUnauthorizedWithCooldownStaysSchedulable(t *testing.T) {
+	setRefreshLeadFactory(t, "codex", func() *time.Duration {
+		d := 5 * time.Minute
+		return &d
+	})
+
+	now := time.Now()
+	cooldownEnd := now.Add(30 * time.Minute)
+
+	// Shape mirrors restoreCooldownRecordLocked's auth-level restore path:
+	// Code="unauthorized" (from persisted LastError), NextRetryAfter in the
+	// future (from the persisted cooldown record).
+	persistedAuth := &Auth{
+		ID:             "persisted-unauthorized-cooldown",
+		Provider:       "codex",
+		Unavailable:    true,
+		Status:         StatusError,
+		StatusMessage:  "unauthorized",
+		NextRetryAfter: cooldownEnd,
+		LastError: &Error{
+			Code:    "unauthorized",
+			Message: "credentials rejected by upstream",
+		},
+	}
+
+	if hasPermanentAuthFailure(persistedAuth) {
+		t.Fatal("expected legacy auth without PermanentRefreshFailure to NOT be permanent — it stays schedulable for proactive refresh")
+	}
+
+	// shouldRefresh must NOT short-circuit on the permanent-failure path
+	// because NextRetryAfter is non-zero — the auth should remain schedulable
+	// for a proactive refresh attempt. (It may still return false for other
+	// reasons like NextRefreshAfter gating, but not the permanent-failure
+	// short-circuit.)
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	// Force shouldRefresh past the NextRefreshAfter gate by clearing it.
+	persistedAuth.NextRefreshAfter = time.Time{}
+	if !manager.shouldRefresh(persistedAuth, now) {
+		t.Fatal("expected persisted unauthorized auth with future NextRetryAfter to remain schedulable for proactive refresh, but shouldRefresh returned false — the permanent-failure short-circuit must not fire when NextRetryAfter is set")
+	}
+
+	// nextRefreshCheckAt must also keep scheduling.
+	if _, shouldSchedule := nextRefreshCheckAt(now, persistedAuth, time.Second); !shouldSchedule {
+		t.Fatal("expected nextRefreshCheckAt to keep scheduling persisted unauthorized auth with future NextRetryAfter")
+	}
+}
+
+// TestIsAuthBlockedForModel_PermanentRefreshFailureBlocksRouting verifies
+// the fix for codex review P2 on #4477: after refresh marks an auth
+// permanently failed (Unavailable=true + permanent LastError, no model
+// state recorded), the request routing path must block the dead credential
+// even when the request carries a model — otherwise the model-specific
+// branch of isAuthBlockedForModel skips auth-level state when no
+// ModelStates entry exists, and round-robin/fill-first keeps sending
+// traffic to the revoked auth until a separate request failure happens.
+func TestIsAuthBlockedForModel_PermanentRefreshFailureBlocksRouting(t *testing.T) {
+	now := time.Now()
+
+	// Shape mirrors refreshAuthForRequest's permanent-failure branch:
+	// Unavailable=true, Status=StatusError, LastError carries the refresh
+	// error (plain fmt.Errorf -> Error with Message only, no HTTPStatus/Code),
+	// no ModelStates entry for the requested model.
+	revokedAuth := &Auth{
+		ID:                      "xai-revoked-routing",
+		Provider:                "xai",
+		Unavailable:             true,
+		PermanentRefreshFailure: true,
+		Status:                  StatusError,
+		StatusMessage:           "invalid_grant",
+		LastError: &Error{
+			Message: "xai token request failed with status 400: {\"error\":\"invalid_grant\",\"error_description\":\"Refresh token has been revoked\"}",
+		},
+	}
+
+	// Request carries a model that has no ModelStates entry — the exact
+	// scenario codex flagged where the model-specific path used to return
+	// "not blocked".
+	blocked, reason, _ := isAuthBlockedForModel(revokedAuth, "grok-4", now)
+	if !blocked {
+		t.Fatal("expected revoked auth to be blocked for model-specific routing")
+	}
+	if reason != blockReasonOther {
+		t.Fatalf("blockReason = %d, want %d", reason, blockReasonOther)
+	}
+
+	// Sanity check: a healthy auth with no model state is still routable.
+	healthyAuth := &Auth{
+		ID:       "xai-healthy",
+		Provider: "xai",
+	}
+	blockedHealthy, _, _ := isAuthBlockedForModel(healthyAuth, "grok-4", now)
+	if blockedHealthy {
+		t.Fatal("expected healthy auth to remain routable")
+	}
+
+	// And a full selector round-robin over [revoked, healthy] must only
+	// return the healthy one.
+	selector := &RoundRobinSelector{}
+	picked, err := selector.Pick(context.Background(), "xai", "grok-4", cliproxyexecutor.Options{}, []*Auth{revokedAuth, healthyAuth})
+	if err != nil {
+		t.Fatalf("Pick error: %v", err)
+	}
+	if picked.ID != healthyAuth.ID {
+		t.Fatalf("Pick returned %q, want %q (revoked auth should be filtered out)", picked.ID, healthyAuth.ID)
+	}
+}
+
+// TestIsAuthBlockedForModel_RequestInvalidGrantCooldownRecovers verifies the
+// fix for codex review P2 on #4477 (commit d1b990e8): the permanent-failure
+// short-circuit must not prevent model-scoped cooldown recovery.
+//
+// When a model-scoped request fails with HTTP 400 invalid_grant, MarkResult
+// creates a ModelState with a 30-minute NextRetryAfter cooldown and copies
+// the error onto auth.LastError. updateAggregatedAvailability marks
+// auth.Unavailable. After 30 minutes the model-state branch should clear
+// the cooldown and allow the normal retry/resume path. The short-circuit
+// must not fire for auths with ModelStates, otherwise the auth stays
+// blocked forever.
+func TestIsAuthBlockedForModel_RequestInvalidGrantCooldownRecovers(t *testing.T) {
+	now := time.Now()
+
+	// Shape mirrors MarkResult's model-scoped path after an invalid_grant
+	// request failure: ModelState exists with a 30-min cooldown, auth.LastError
+	// carries invalid_grant, auth.Unavailable + auth.NextRetryAfter set by
+	// updateAggregatedAvailability (which propagates the earliest model
+	// NextRetryAfter to the auth level when all model states are unavailable).
+	cooldownEnd := now.Add(30 * time.Minute)
+	cooldownAuth := &Auth{
+		ID:             "xai-request-cooldown",
+		Provider:       "xai",
+		Unavailable:    true,
+		Status:         StatusError,
+		StatusMessage:  "invalid_grant",
+		NextRetryAfter: cooldownEnd,
+		LastError: &Error{
+			Message: "request failed with status 400: invalid_grant",
+		},
+		ModelStates: map[string]*ModelState{
+			"grok-4": {
+				Unavailable:    true,
+				Status:         StatusError,
+				StatusMessage:  "invalid_grant",
+				NextRetryAfter: cooldownEnd,
+			},
+		},
+	}
+
+	// During cooldown: must be blocked (by the model-state branch).
+	blocked, _, _ := isAuthBlockedForModel(cooldownAuth, "grok-4", now)
+	if !blocked {
+		t.Fatal("expected auth to be blocked during model-scoped cooldown")
+	}
+
+	// After cooldown expires: must NOT be blocked — the model-state branch
+	// honors NextRetryAfter expiry and allows retry/resume.
+	afterCooldown := now.Add(31 * time.Minute)
+	blockedAfter, _, _ := isAuthBlockedForModel(cooldownAuth, "grok-4", afterCooldown)
+	if blockedAfter {
+		t.Fatal("expected auth to recover after model-scoped cooldown expiry, but short-circuit kept it blocked")
+	}
+
+	// And a full selector round-robin after cooldown must return the
+	// recovered auth.
+	healthyAuth := &Auth{ID: "xai-healthy", Provider: "xai"}
+	selector := &RoundRobinSelector{}
+	picked, err := selector.Pick(context.Background(), "xai", "grok-4", cliproxyexecutor.Options{}, []*Auth{cooldownAuth, healthyAuth})
+	if err != nil {
+		t.Fatalf("Pick error after cooldown: %v", err)
+	}
+	if picked.ID != cooldownAuth.ID && picked.ID != healthyAuth.ID {
+		t.Fatalf("Pick returned unexpected auth %q", picked.ID)
+	}
+}
+
+// TestShouldRefresh_RequestInvalidGrantCooldownStaysSchedulable verifies the
+// fix for codex review P2 on #4477 (commit d13ce42c, auto_refresh_loop.go:342):
+// a model-scoped request invalid_grant cooldown sets LastError with
+// invalid_grant + NextRetryAfter=now+30min. hasPermanentAuthFailure matches
+// the LastError text, so the scheduler used to remove the auth from the
+// refresh loop entirely — preventing proactive refresh from recovering the
+// auth early during the cooldown window.
+//
+// The fix gates the permanent-failure stop on NextRetryAfter.IsZero():
+// refresh permanent failures leave NextRetryAfter zero (so the stop fires),
+// request cooldowns set it to now+30min (so the stop does NOT fire and the
+// normal refresh-lead/expiry logic remains active).
+func TestShouldRefresh_RequestInvalidGrantCooldownStaysSchedulable(t *testing.T) {
+	// Register a refresh lead so shouldRefresh/nextRefreshCheckAt evaluate
+	// the refresh-lead path instead of short-circuiting at nil lead.
+	setRefreshLeadFactory(t, "xai", func() *time.Duration {
+		d := 5 * time.Minute
+		return &d
+	})
+
+	now := time.Now()
+	cooldownEnd := now.Add(30 * time.Minute)
+
+	// Request-side invalid_grant cooldown shape: LastError carries
+	// invalid_grant (so hasPermanentAuthFailure returns true), but
+	// NextRetryAfter is set to now+30min by updateAggregatedAvailability.
+	requestCooldownAuth := &Auth{
+		ID:             "xai-request-cooldown",
+		Provider:       "xai",
+		Unavailable:    true,
+		Status:         StatusError,
+		StatusMessage:  "invalid_grant",
+		NextRetryAfter: cooldownEnd,
+		LastError: &Error{
+			Message: "request failed with status 400: invalid_grant",
+		},
+		ModelStates: map[string]*ModelState{
+			"grok-4": {
+				Unavailable:    true,
+				Status:         StatusError,
+				NextRetryAfter: cooldownEnd,
+			},
+		},
+	}
+
+	// shouldRefresh must NOT return false for the permanent-failure reason
+	// alone — the auth has a non-zero NextRetryAfter, so it should remain
+	// schedulable for proactive refresh. (It may still return false for
+	// other reasons like NextRefreshAfter gating, but not the permanent-
+	// failure short-circuit.)
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	if reason := "permanent-failure short-circuit"; !manager.shouldRefresh(requestCooldownAuth, now) {
+		// Verify it's not the permanent-failure path by checking that a
+		// zero-NextRetryAfter variant DOES get blocked.
+		zeroRetryAuth := requestCooldownAuth.Clone()
+		zeroRetryAuth.NextRetryAfter = time.Time{}
+		if manager.shouldRefresh(zeroRetryAuth, now) {
+			// zero-NextRetryAfter is blocked, non-zero is not — correct.
+			return
+		}
+		t.Fatalf("shouldRefresh returned false for request-cooldown auth with non-zero NextRetryAfter; the permanent-failure short-circuit must not fire when NextRetryAfter is set (%s)", reason)
+	}
+
+	// nextRefreshCheckAt must still schedule the auth (return true), not
+	// remove it from the refresh loop.
+	nextCheck, shouldSchedule := nextRefreshCheckAt(now, requestCooldownAuth, time.Second)
+	if !shouldSchedule {
+		t.Fatal("expected nextRefreshCheckAt to keep scheduling request-cooldown auth for proactive refresh")
+	}
+	if nextCheck.IsZero() {
+		t.Fatal("expected nextRefreshCheckAt to return a non-zero time for request-cooldown auth")
+	}
+}
+
+// TestShouldRefresh_PartialModelCooldownStaysSchedulable verifies the fix
+// for codex review P2 on commit aad3f7e: when a multi-model auth has one
+// model cooled by a request-side 400 invalid_grant and another clean model,
+// updateAggregatedAvailability sets auth.Unavailable=false and clears
+// auth.NextRetryAfter (a clean model keeps the auth available), while
+// MarkResult still copies invalid_grant onto auth.LastError (conductor.go:3768).
+//
+// Without the Unavailable check in the permanent-failure guard, the zero
+// NextRetryAfter + permanent LastError combination would unschedule the auth
+// from the auto-refresh queue, preventing proactive refresh from recovering
+// the cooled model early.
+func TestShouldRefresh_PartialModelCooldownStaysSchedulable(t *testing.T) {
+	setRefreshLeadFactory(t, "xai", func() *time.Duration {
+		d := 5 * time.Minute
+		return &d
+	})
+
+	now := time.Now()
+	cooldownEnd := now.Add(30 * time.Minute)
+
+	// Shape mirrors MarkResult's model-scoped failure path after
+	// updateAggregatedAvailability: auth.Unavailable=false (clean grok-3
+	// keeps the auth available), auth.NextRetryAfter=zero (allUnavailable
+	// is false), but auth.LastError carries invalid_grant (copied at
+	// conductor.go:3768).
+	partialCooldownAuth := &Auth{
+		ID:               "xai-partial-cooldown",
+		Provider:         "xai",
+		Unavailable:      false,
+		Status:           StatusError,
+		StatusMessage:    "invalid_grant",
+		NextRetryAfter:   time.Time{}, // cleared by updateAggregatedAvailability
+		NextRefreshAfter: time.Time{}, // clear so shouldRefresh passes this gate
+		LastError: &Error{
+			Message: "request failed with status 400: invalid_grant",
+		},
+		ModelStates: map[string]*ModelState{
+			"grok-4": {
+				Unavailable:    true,
+				Status:         StatusError,
+				NextRetryAfter: cooldownEnd,
+			},
+			"grok-3": {
+				Unavailable: false,
+				Status:      StatusActive,
+			},
+		},
+	}
+
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+
+	// shouldRefresh must NOT short-circuit on the permanent-failure path —
+	// Unavailable is false, so the guard must not fire. With NextRefreshAfter
+	// cleared and a refresh lead registered, shouldRefresh should return true
+	// (the lead path returns true when no expiry/lastRefresh is set).
+	if !manager.shouldRefresh(partialCooldownAuth, now) {
+		t.Fatal("expected partial-cooldown auth to remain schedulable for proactive refresh; the permanent-failure short-circuit must not fire when Unavailable is false")
+	}
+
+	// nextRefreshCheckAt must also keep scheduling the auth.
+	nextCheck, shouldSchedule := nextRefreshCheckAt(now, partialCooldownAuth, time.Second)
+	if !shouldSchedule {
+		t.Fatal("expected nextRefreshCheckAt to keep scheduling partial-cooldown auth for proactive refresh")
+	}
+	if nextCheck.IsZero() {
+		t.Fatal("expected nextRefreshCheckAt to return a non-zero time for partial-cooldown auth")
+	}
+}
+
+// TestSelectorPick_DeadPlusCooldownReturnsModelCooldownError verifies the
+// fix for the cooldownCount-statistics gap found via gitnexus impact
+// analysis of isAuthBlockedForModel: when a provider has a mix of
+// permanently failed auths (refresh 400 invalid_grant, blocked by the
+// short-circuit with blockReasonOther + zero next) and cooldown auths
+// (request failure with 30-min ModelState.NextRetryAfter), the selector
+// must return a modelCooldownError carrying the cooldown auths' earliest
+// retry time — NOT a generic auth_unavailable error.
+//
+// Previously collectAvailableByPriority only counted blockReasonCooldown
+// toward the unavailable total, so a dead auth was excluded from the
+// cooldownCount==len(auths) check, causing the mixed scenario to fall
+// through to auth_unavailable and hide the cooldown recovery window.
+func TestSelectorPick_DeadPlusCooldownReturnsModelCooldownError(t *testing.T) {
+	now := time.Now()
+	cooldownEnd := now.Add(30 * time.Minute)
+	model := "grok-4"
+
+	deadAuth := &Auth{
+		ID:                      "xai-dead",
+		Provider:                "xai",
+		Unavailable:             true,
+		PermanentRefreshFailure: true,
+		Status:                  StatusError,
+		StatusMessage:           "invalid_grant",
+		LastError: &Error{
+			Message: "xai token request failed with status 400: invalid_grant",
+		},
+		// No ModelStates — refresh permanent failure shape.
+	}
+
+	cooldownAuth := &Auth{
+		ID:       "xai-cooldown",
+		Provider: "xai",
+		Status:   StatusError,
+		ModelStates: map[string]*ModelState{
+			model: {
+				Unavailable:    true,
+				Status:         StatusError,
+				StatusMessage:  "invalid_grant",
+				NextRetryAfter: cooldownEnd,
+				Quota: QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: cooldownEnd,
+				},
+			},
+		},
+	}
+
+	selector := &FillFirstSelector{}
+	_, err := selector.Pick(context.Background(), "xai", model, cliproxyexecutor.Options{}, []*Auth{deadAuth, cooldownAuth})
+	if err == nil {
+		t.Fatal("expected error when all auths unavailable")
+	}
+
+	var mce *modelCooldownError
+	if !errors.As(err, &mce) {
+		t.Fatalf("Pick error = %T (%v), want *modelCooldownError — dead+cooldown mix should report cooldown recovery window, not auth_unavailable", err, err)
+	}
+	// resetIn should approximate 30 minutes (the cooldown auth's retry time).
+	if mce.resetIn <= 0 || mce.resetIn > 31*time.Minute {
+		t.Fatalf("modelCooldownError.resetIn = %v, want ~30min (cooldown auth retry window)", mce.resetIn)
+	}
+}
+
+// TestSelectorPick_AllDeadReturnsAuthUnavailable verifies that when every
+// auth is permanently failed (no cooldown auths to recover), the selector
+// returns auth_unavailable, not a modelCooldownError with zero resetIn.
+func TestSelectorPick_AllDeadReturnsAuthUnavailable(t *testing.T) {
+	now := time.Now()
+	model := "grok-4"
+
+	deadAuth1 := &Auth{
+		ID:                      "xai-dead-1",
+		Provider:                "xai",
+		Unavailable:             true,
+		PermanentRefreshFailure: true,
+		Status:                  StatusError,
+		StatusMessage:           "invalid_grant",
+		LastError:               &Error{Message: "xai token request failed with status 400: invalid_grant"},
+	}
+	deadAuth2 := &Auth{
+		ID:                      "xai-dead-2",
+		Provider:                "xai",
+		Unavailable:             true,
+		PermanentRefreshFailure: true,
+		Status:                  StatusError,
+		StatusMessage:           "invalid_grant",
+		LastError:               &Error{Message: "xai token request failed with status 400: invalid_grant"},
+	}
+	_ = now
+
+	selector := &FillFirstSelector{}
+	_, err := selector.Pick(context.Background(), "xai", model, cliproxyexecutor.Options{}, []*Auth{deadAuth1, deadAuth2})
+	if err == nil {
+		t.Fatal("expected error when all auths dead")
+	}
+
+	var mce *modelCooldownError
+	if errors.As(err, &mce) {
+		t.Fatalf("Pick returned modelCooldownError for all-dead scenario, want auth_unavailable (no cooldown to report)")
+	}
+	var authErr *Error
+	if !errors.As(err, &authErr) || authErr.Code != "auth_unavailable" {
+		t.Fatalf("Pick error = %v, want auth_unavailable", err)
 	}
 }
 
@@ -213,5 +1019,314 @@ func TestManager_PickNext_RebuildsSchedulerAfterModelCooldownError(t *testing.T)
 	}
 	if got == nil || got.ID != newAuth.ID {
 		t.Fatalf("pickNext() auth = %v, want %q", got, newAuth.ID)
+	}
+}
+
+// authUpdateCaptureHook records OnAuthUpdated calls for verification.
+type authUpdateCaptureHook struct {
+	NoopHook
+
+	mu      sync.Mutex
+	updates []*Auth
+}
+
+func (h *authUpdateCaptureHook) OnAuthUpdated(_ context.Context, auth *Auth) {
+	h.mu.Lock()
+	h.updates = append(h.updates, auth)
+	h.mu.Unlock()
+}
+
+func (h *authUpdateCaptureHook) Updates() []*Auth {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]*Auth, len(h.updates))
+	copy(out, h.updates)
+	return out
+}
+
+// TestRefreshAuthForRequest_PersistsPermanentFailureMarker verifies the fix
+// for codex review P2 on commit d6e72a65: when refreshAuthForRequest gets a
+// permanent failure (400 invalid_grant or 401), the permanent branch must
+// persist the auth + cooldown snapshot + notify hooks, so the marker
+// survives process restart. Without persistence, a restart reloads the auth
+// from storage without the Unavailable/permanent-LastError marker, and any
+// stale .cds cooldown record can also be restored, requeueing the revoked
+// credential.
+func TestRefreshAuthForRequest_PersistsPermanentFailureMarker(t *testing.T) {
+	ctx := context.Background()
+	store := &countingStore{}
+	cooldownStore := &recordingCooldownStateStore{}
+	hook := &authUpdateCaptureHook{}
+	manager := NewManager(store, &RoundRobinSelector{}, hook)
+	manager.SetCooldownStateStore(cooldownStore)
+	manager.RegisterExecutor(invalidGrantRefreshTestExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "xai"},
+	})
+
+	setRefreshLeadFactory(t, "xai", func() *time.Duration {
+		d := 5 * time.Minute
+		return &d
+	})
+
+	auth := &Auth{
+		ID:       "xai-persist-permanent",
+		Provider: "xai",
+		Metadata: map[string]any{
+			"email": "persist@example.com",
+		},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	storeSaveBefore := store.saveCount.Load()
+	cooldownSaveBefore := cooldownStore.saveCount.Load()
+	updatesBefore := len(hook.Updates())
+
+	// Trigger permanent refresh failure.
+	manager.refreshAuth(ctx, auth.ID)
+
+	after, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatalf("expected auth %q after refresh", auth.ID)
+	}
+	if !after.Unavailable || !after.NextRetryAfter.IsZero() || !hasPermanentAuthFailure(after) {
+		t.Fatalf("expected permanent marker, got Unavailable=%v NextRetryAfter=%v LastError=%+v", after.Unavailable, after.NextRetryAfter, after.LastError)
+	}
+
+	// Verify persist was called — the auth-level Save must fire for the
+	// permanent marker to survive restart.
+	if got := store.saveCount.Load(); got != storeSaveBefore+1 {
+		t.Fatalf("expected store.Save count %d → %d, got %d", storeSaveBefore, storeSaveBefore+1, got)
+	}
+
+	// Verify persistCooldownStates was called — the stale .cds record must
+	// be dropped so restart doesn't restore a cooldown that masks the
+	// permanent marker.
+	if got := cooldownStore.saveCount.Load(); got != cooldownSaveBefore+1 {
+		t.Fatalf("expected cooldownStore.Save count %d → %d, got %d", cooldownSaveBefore, cooldownSaveBefore+1, got)
+	}
+
+	// Verify OnAuthUpdated hook was notified so downstream observers (e.g.
+	// management UI, plugin host) see the permanent failure.
+	if got := len(hook.Updates()); got != updatesBefore+1 {
+		t.Fatalf("expected OnAuthUpdated count %d → %d, got %d", updatesBefore, updatesBefore+1, got)
+	}
+	lastUpdate := hook.Updates()[len(hook.Updates())-1]
+	if !lastUpdate.Unavailable || !lastUpdate.NextRetryAfter.IsZero() {
+		t.Fatalf("OnAuthUpdated received non-permanent marker: Unavailable=%v NextRetryAfter=%v", lastUpdate.Unavailable, lastUpdate.NextRetryAfter)
+	}
+}
+
+// TestRefreshAuthForRequest_PermanentFailureClearsModelCooldowns verifies
+// the fix for codex review P2 on commit 87b7fa62: the permanent refresh
+// branch must clear per-model cooldown state, otherwise persistCooldownStates
+// keeps the model .cds records in the snapshot and a restart replays them
+// via RestoreCooldownStates → updateAggregatedAvailability, which restores
+// a non-zero auth NextRetryAfter and masks the permanent marker from the
+// IsZero() guards.
+func TestRefreshAuthForRequest_PermanentFailureClearsModelCooldowns(t *testing.T) {
+	ctx := context.Background()
+	store := &countingStore{}
+	cooldownStore := &recordingCooldownStateStore{}
+	manager := NewManager(store, &RoundRobinSelector{}, nil)
+	manager.SetCooldownStateStore(cooldownStore)
+	manager.RegisterExecutor(invalidGrantRefreshTestExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "xai"},
+	})
+
+	setRefreshLeadFactory(t, "xai", func() *time.Duration {
+		d := 5 * time.Minute
+		return &d
+	})
+
+	auth := &Auth{
+		ID:       "xai-model-cooldown-clear",
+		Provider: "xai",
+		Metadata: map[string]any{
+			"email": "model-clear@example.com",
+		},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	// Pre-seed a model-scoped cooldown via MarkResult (simulating prior
+	// traffic that hit a 429 on grok-4). MarkResult calls
+	// persistCooldownStates, so the snapshot will contain the grok-4
+	// record. This is the state that must be cleared on permanent
+	// refresh failure.
+	manager.MarkResult(ctx, Result{
+		AuthID:   auth.ID,
+		Provider: "xai",
+		Model:    "grok-4",
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: http.StatusTooManyRequests,
+			Message:    "rate limited",
+		},
+	})
+
+	// Verify the cooldown snapshot contains the model record before refresh.
+	cooldownStore.mu.Lock()
+	hasModelRecordBefore := false
+	for _, r := range cooldownStore.records {
+		if r.Model == "grok-4" && r.AuthID == auth.ID {
+			hasModelRecordBefore = true
+			break
+		}
+	}
+	cooldownStore.mu.Unlock()
+	if !hasModelRecordBefore {
+		t.Fatal("precondition: expected grok-4 model cooldown record before refresh")
+	}
+
+	// Trigger permanent refresh failure.
+	manager.refreshAuth(ctx, auth.ID)
+
+	after, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatalf("expected auth %q after refresh", auth.ID)
+	}
+	if !after.Unavailable || !after.NextRetryAfter.IsZero() || !hasPermanentAuthFailure(after) {
+		t.Fatalf("expected permanent marker, got Unavailable=%v NextRetryAfter=%v LastError=%+v", after.Unavailable, after.NextRetryAfter, after.LastError)
+	}
+
+	// The model-scoped cooldown must be cleared.
+	state, hasState := after.ModelStates["grok-4"]
+	if !hasState || state == nil {
+		t.Fatalf("expected grok-4 model state to exist (reset, not deleted), got ModelStates=%+v", after.ModelStates)
+	}
+	if state.Unavailable || !state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected grok-4 model cooldown cleared, got Unavailable=%v NextRetryAfter=%v", state.Unavailable, state.NextRetryAfter)
+	}
+	if state.LastError != nil {
+		t.Fatalf("expected grok-4 model LastError cleared, got %+v", state.LastError)
+	}
+
+	// The cooldown snapshot after persist must NOT contain the grok-4
+	// record — otherwise restart replays it and restores a non-zero auth
+	// NextRetryAfter that masks the permanent marker.
+	cooldownStore.mu.Lock()
+	hasModelRecordAfter := false
+	for _, r := range cooldownStore.records {
+		if r.Model == "grok-4" && r.AuthID == auth.ID {
+			hasModelRecordAfter = true
+			break
+		}
+	}
+	cooldownStore.mu.Unlock()
+	if hasModelRecordAfter {
+		t.Fatal("expected grok-4 model cooldown record to be dropped from snapshot after permanent refresh failure")
+	}
+}
+
+// TestClearCooldownStateForAuth_PreservesPermanentFailureMarker verifies
+// the fix for codex review P2 on commit 6f555cbf: clearCooldownStateForAuth
+// is invoked from SetConfig/register/update paths when disable-cooling is
+// enabled, and historically clears auth.Unavailable — without a guard,
+// a config reload erases the permanent marker and the shouldRefresh /
+// nextRefreshCheckAt / isAuthBlockedForModel guards stop firing,
+// re-queueing revoked 400 invalid_grant credentials.
+func TestClearCooldownStateForAuth_PreservesPermanentFailureMarker(t *testing.T) {
+	now := time.Now()
+
+	// Permanent failure marker: Unavailable + permanent LastError +
+	// zero NextRetryAfter. A stale model cooldown is also present,
+	// which clearCooldownStateForAuth should still clear.
+	auth := &Auth{
+		ID:                      "xai-clear-cooldown-permanent",
+		Provider:                "xai",
+		Unavailable:             true,
+		PermanentRefreshFailure: true,
+		NextRetryAfter:          time.Time{},
+		Status:                  StatusError,
+		StatusMessage:           "refresh token revoked",
+		LastError: &Error{
+			HTTPStatus: http.StatusBadRequest,
+			Message:    "invalid_grant: refresh token revoked",
+		},
+		ModelStates: map[string]*ModelState{
+			"grok-4": {
+				Status:         StatusError,
+				Unavailable:    true,
+				NextRetryAfter: now.Add(30 * time.Minute),
+				UpdatedAt:      now,
+			},
+		},
+	}
+
+	if !hasPermanentAuthFailure(auth) {
+		t.Fatalf("precondition: expected permanent failure marker")
+	}
+
+	changed := clearCooldownStateForAuth(auth, now)
+
+	// Permanent marker must be preserved.
+	if !auth.Unavailable {
+		t.Fatal("expected Unavailable=true to be preserved by clearCooldownStateForAuth")
+	}
+	if !auth.NextRetryAfter.IsZero() {
+		t.Fatalf("expected NextRetryAfter to stay zero, got %v", auth.NextRetryAfter)
+	}
+	if !hasPermanentAuthFailure(auth) {
+		t.Fatal("expected hasPermanentAuthFailure to still be true after clearCooldownStateForAuth")
+	}
+
+	// Stale model cooldown should be cleared (the permanent-marker guard
+	// only protects the auth-level marker, not stale model states).
+	state := auth.ModelStates["grok-4"]
+	if state == nil {
+		t.Fatal("expected grok-4 model state to still exist")
+	}
+	if state.Unavailable || !state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected grok-4 model cooldown cleared, got Unavailable=%v NextRetryAfter=%v", state.Unavailable, state.NextRetryAfter)
+	}
+	if !changed {
+		t.Fatal("expected changed=true since model cooldown was cleared")
+	}
+
+	// The guards must still fire after clearCooldownStateForAuth.
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	if manager.shouldRefresh(auth, now) {
+		t.Fatal("expected shouldRefresh=false after clearCooldownStateForAuth preserved marker")
+	}
+	if _, shouldSchedule := nextRefreshCheckAt(now, auth, time.Second); shouldSchedule {
+		t.Fatal("expected nextRefreshCheckAt to keep unscheduled after clearCooldownStateForAuth")
+	}
+	blocked, reason, _ := isAuthBlockedForModel(auth, "grok-4", now)
+	if !blocked || reason != blockReasonOther {
+		t.Fatalf("expected isAuthBlockedForModel to keep blocking, got blocked=%v reason=%d", blocked, reason)
+	}
+}
+
+// TestClearCooldownStateForAuth_StillClearsTransientCooldown verifies the
+// guard only protects permanent markers — transient cooldowns
+// (NextRetryAfter non-zero, no permanent LastError) are still cleared.
+func TestClearCooldownStateForAuth_StillClearsTransientCooldown(t *testing.T) {
+	now := time.Now()
+	auth := &Auth{
+		ID:             "xai-transient-cooldown",
+		Provider:       "xai",
+		Unavailable:    true,
+		NextRetryAfter: now.Add(30 * time.Minute),
+		Status:         StatusError,
+		StatusMessage:  "rate limited",
+	}
+
+	if hasPermanentAuthFailure(auth) {
+		t.Fatalf("precondition: expected NOT a permanent failure (no LastError)")
+	}
+
+	changed := clearCooldownStateForAuth(auth, now)
+
+	if !changed {
+		t.Fatal("expected changed=true for transient cooldown")
+	}
+	if auth.Unavailable {
+		t.Fatal("expected Unavailable=false after clearing transient cooldown")
+	}
+	if !auth.NextRetryAfter.IsZero() {
+		t.Fatalf("expected NextRetryAfter=zero after clearing, got %v", auth.NextRetryAfter)
 	}
 }

--- a/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
@@ -1330,3 +1330,90 @@ func TestClearCooldownStateForAuth_StillClearsTransientCooldown(t *testing.T) {
 		t.Fatalf("expected NextRetryAfter=zero after clearing, got %v", auth.NextRetryAfter)
 	}
 }
+
+// TestPermanentFailureMetadata_RoundTrip verifies that the permanent-failure
+// marker survives a persist → reload cycle via Metadata. Store readers
+// (FileTokenStore/PostgresStore/ObjectStore/GitStore) only persist
+// Auth.Metadata, so the marker (which lives on Auth struct fields) must be
+// mirrored into Metadata by persist() and restored by
+// ApplyPermanentFailureFromMetadata. Without this, a restart reloads the
+// revoked auth as active/routable (codex review).
+func TestPermanentFailureMetadata_RoundTrip(t *testing.T) {
+	auth := &Auth{
+		ID:       "xai-metadata-roundtrip",
+		Provider: "xai",
+		Metadata: map[string]any{
+			"type":                          "xai",
+			"email":                         "roundtrip@example.com",
+			"cpa_permanent_refresh_failure": true,
+			"cpa_permanent_unavailable":     true,
+			"cpa_permanent_status":          string(StatusError),
+			"cpa_permanent_status_message":  "refresh token revoked",
+			"access_token":                  "stale",
+			"refresh_token":                 "revoked",
+		},
+		PermanentRefreshFailure: false,
+		Unavailable:             false,
+		Status:                  StatusActive,
+		StatusMessage:           "",
+	}
+
+	ApplyPermanentFailureFromMetadata(auth)
+
+	if !auth.PermanentRefreshFailure {
+		t.Fatal("expected PermanentRefreshFailure=true after ApplyPermanentFailureFromMetadata")
+	}
+	if !auth.Unavailable {
+		t.Fatal("expected Unavailable=true after restore")
+	}
+	if auth.Status != StatusError {
+		t.Fatalf("expected Status=StatusError, got %s", auth.Status)
+	}
+	if auth.StatusMessage != "refresh token revoked" {
+		t.Fatalf("expected StatusMessage restored, got %q", auth.StatusMessage)
+	}
+	if !hasPermanentAuthFailure(auth) {
+		t.Fatal("expected hasPermanentAuthFailure=true after restore")
+	}
+
+	now := time.Now()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	if manager.shouldRefresh(auth, now) {
+		t.Fatal("expected shouldRefresh=false on restored permanent failure")
+	}
+	blocked, reason, _ := isAuthBlockedForModel(auth, "grok-4", now)
+	if !blocked || reason != blockReasonOther {
+		t.Fatalf("expected isAuthBlockedForModel to block restored permanent failure, got blocked=%v reason=%d", blocked, reason)
+	}
+}
+
+// TestPermanentFailureMetadata_NoMarkerIsNoOp verifies that
+// ApplyPermanentFailureFromMetadata is a no-op when the marker is absent.
+func TestPermanentFailureMetadata_NoMarkerIsNoOp(t *testing.T) {
+	auth := &Auth{
+		ID:       "xai-no-marker",
+		Provider: "xai",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"type":          "xai",
+			"email":         "no-marker@example.com",
+			"access_token":  "valid",
+			"refresh_token": "valid",
+		},
+	}
+
+	ApplyPermanentFailureFromMetadata(auth)
+
+	if auth.PermanentRefreshFailure {
+		t.Fatal("expected PermanentRefreshFailure=false when marker absent")
+	}
+	if auth.Unavailable {
+		t.Fatal("expected Unavailable=false when marker absent")
+	}
+	if auth.Status != StatusActive {
+		t.Fatalf("expected Status=StatusActive, got %s", auth.Status)
+	}
+	if hasPermanentAuthFailure(auth) {
+		t.Fatal("expected hasPermanentAuthFailure=false when marker absent")
+	}
+}

--- a/sdk/cliproxy/auth/conductor_unauthorized_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_unauthorized_refresh_test.go
@@ -249,12 +249,19 @@ func TestManager_Execute_UnauthorizedRefreshFailureFallsBackToNextAuth(t *testin
 	if !ok || updated == nil {
 		t.Fatalf("primary auth missing after failed refresh")
 	}
-	state := updated.ModelStates[model]
-	if state == nil || !state.Unavailable {
-		t.Fatalf("expected primary model to be suspended after refresh failure")
+	// Refresh returned a permanent failure (401), so refreshAuthForRequest's
+	// permanent branch set Unavailable=true + zero NextRetryAfter + permanent
+	// LastError. MarkResult's early-skip for refresh-sourced permanent
+	// failures preserves this marker instead of overwriting it with a
+	// transient 401 model cooldown (codex review on 358d49b2).
+	if !updated.Unavailable {
+		t.Fatalf("expected primary auth to be permanently unavailable after refresh failure")
 	}
-	if state.StatusMessage != "unauthorized" && (state.LastError == nil || state.LastError.StatusCode() != http.StatusUnauthorized) {
-		t.Fatalf("expected unauthorized suspension, got state=%+v", state)
+	if !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected primary auth NextRetryAfter to stay zero (permanent marker preserved), got %v", updated.NextRetryAfter)
+	}
+	if !hasPermanentAuthFailure(updated) {
+		t.Fatalf("expected primary auth to carry permanent failure marker, got LastError=%+v", updated.LastError)
 	}
 }
 

--- a/sdk/cliproxy/auth/permanent_failure_metadata.go
+++ b/sdk/cliproxy/auth/permanent_failure_metadata.go
@@ -1,0 +1,53 @@
+package auth
+
+// Metadata keys used to persist the permanent-refresh-failure marker
+// across restarts. FileTokenStore / PostgresStore / ObjectStore / GitStore
+// only durably persist Auth.Metadata, so the marker (which lives on Auth
+// struct fields) must be mirrored into Metadata for restart recovery.
+//
+// Keys are namespaced with the `cpa_permanent_` prefix to avoid colliding
+// with provider/plugin credential metadata that may legitimately use
+// generic names like "status" or "unavailable" (codex review).
+const (
+	metadataKeyPermanentRefreshFailure = "cpa_permanent_refresh_failure"
+	metadataKeyUnavailable             = "cpa_permanent_unavailable"
+	metadataKeyStatus                  = "cpa_permanent_status"
+	metadataKeyStatusMessage           = "cpa_permanent_status_message"
+)
+
+// ApplyPermanentFailureFromMetadata restores the permanent-refresh-failure
+// marker from auth.Metadata into the Auth struct fields. Called by store
+// readers (FileTokenStore.readAuthFiles, PostgresStore.List,
+// ObjectTokenStore.readAuthFile, GitTokenStore.readAuthFile) after
+// rebuilding the Auth from the persisted JSON, so a restart recovers the
+// dead-credential marker and the guards (shouldRefresh,
+// nextRefreshCheckAt, isAuthBlockedForModel) continue to block the
+// revoked credential.
+//
+// If the marker is absent (auth persisted before this feature, or
+// recovered after manual token replacement), this is a no-op — the Auth
+// retains its default field values (PermanentRefreshFailure=false,
+// Unavailable=false, Status=StatusActive).
+func ApplyPermanentFailureFromMetadata(auth *Auth) {
+	if auth == nil || len(auth.Metadata) == 0 {
+		return
+	}
+	if v, ok := auth.Metadata[metadataKeyPermanentRefreshFailure].(bool); ok && v {
+		auth.PermanentRefreshFailure = true
+		// Restore Unavailable only when the marker is present; otherwise
+		// leave the default (false) so a recovered auth is routable.
+		if u, ok := auth.Metadata[metadataKeyUnavailable].(bool); ok {
+			auth.Unavailable = u
+		} else {
+			auth.Unavailable = true
+		}
+		if s, ok := auth.Metadata[metadataKeyStatus].(string); ok && s != "" {
+			auth.Status = Status(s)
+		} else {
+			auth.Status = StatusError
+		}
+		if sm, ok := auth.Metadata[metadataKeyStatusMessage].(string); ok {
+			auth.StatusMessage = sm
+		}
+	}
+}

--- a/sdk/cliproxy/auth/scheduler.go
+++ b/sdk/cliproxy/auth/scheduler.go
@@ -835,13 +835,23 @@ func (m *modelScheduler) unavailableErrorLocked(provider, model string, predicat
 	return &Error{Code: "auth_unavailable", Message: "no auth available"}
 }
 
-// availabilitySummaryLocked summarizes total candidates, cooldown count, and earliest retry time.
+// availabilitySummaryLocked summarizes total candidates, unavailable count
+// (cooldown + permanently blocked), and earliest cooldown retry time.
+//
+// Permanently blocked auths (e.g. refresh returned 400 invalid_grant,
+// mapped to scheduledStateBlocked by upsertEntryLocked) are counted as
+// unavailable so that a mix of dead + cooldown auths still reports a
+// cooldown error with the cooldown auths' earliest retry time, instead
+// of falling through to a generic auth_unavailable error that hides the
+// cooldown recovery window from callers. Only scheduledStateCooldown
+// entries contribute to earliest; scheduledStateBlocked entries have
+// zero nextRetryAt and would not affect earliest anyway.
 func (m *modelScheduler) availabilitySummaryLocked(predicate func(*scheduledAuth) bool) (int, int, time.Time) {
 	if m == nil {
 		return 0, 0, time.Time{}
 	}
 	total := 0
-	cooldownCount := 0
+	unavailableCount := 0
 	earliest := time.Time{}
 	for _, entry := range m.entries {
 		if predicate != nil && !predicate(entry) {
@@ -851,15 +861,19 @@ func (m *modelScheduler) availabilitySummaryLocked(predicate func(*scheduledAuth
 		if entry == nil || entry.auth == nil {
 			continue
 		}
+		if entry.state == scheduledStateReady {
+			continue
+		}
+		// Both cooldown and permanently blocked count as unavailable.
+		unavailableCount++
 		if entry.state != scheduledStateCooldown {
 			continue
 		}
-		cooldownCount++
 		if !entry.nextRetryAt.IsZero() && (earliest.IsZero() || entry.nextRetryAt.Before(earliest)) {
 			earliest = entry.nextRetryAt
 		}
 	}
-	return total, cooldownCount, earliest
+	return total, unavailableCount, earliest
 }
 
 // rebuildIndexesLocked reconstructs ready and blocked views from the current entry map.

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -196,7 +196,17 @@ func preferCodexWebsocketAuths(ctx context.Context, provider string, available [
 	return available
 }
 
-func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (available map[int][]*Auth, cooldownCount int, earliest time.Time) {
+// collectAvailableByPriority partitions auths by priority for routing.
+// Returns the available priority buckets, the count of unavailable auths
+// (cooldown + permanently blocked), and the earliest cooldown retry time
+// among cooldown auths (permanently blocked auths contribute zero time).
+//
+// The unavailable count includes permanently blocked auths (e.g. refresh
+// returned 400 invalid_grant) so that a mix of dead + cooldown auths still
+// reports a cooldown error with the cooldown auths' earliest retry time,
+// instead of falling through to a generic auth_unavailable error that
+// hides the cooldown recovery window from callers.
+func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (available map[int][]*Auth, unavailableCount int, earliest time.Time) {
 	available = make(map[int][]*Auth)
 	for i := 0; i < len(auths); i++ {
 		candidate := auths[i]
@@ -206,14 +216,14 @@ func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (ava
 			available[priority] = append(available[priority], candidate)
 			continue
 		}
+		unavailableCount++
 		if reason == blockReasonCooldown {
-			cooldownCount++
 			if !next.IsZero() && (earliest.IsZero() || next.Before(earliest)) {
 				earliest = next
 			}
 		}
 	}
-	return available, cooldownCount, earliest
+	return available, unavailableCount, earliest
 }
 
 func getAvailableAuths(auths []*Auth, provider, model string, now time.Time) ([]*Auth, error) {
@@ -221,9 +231,9 @@ func getAvailableAuths(auths []*Auth, provider, model string, now time.Time) ([]
 		return nil, &Error{Code: "auth_not_found", Message: "no auth candidates"}
 	}
 
-	availableByPriority, cooldownCount, earliest := collectAvailableByPriority(auths, model, now)
+	availableByPriority, unavailableCount, earliest := collectAvailableByPriority(auths, model, now)
 	if len(availableByPriority) == 0 {
-		if cooldownCount == len(auths) && !earliest.IsZero() {
+		if unavailableCount == len(auths) && !earliest.IsZero() {
 			providerForError := provider
 			if providerForError == "mixed" {
 				providerForError = ""
@@ -308,6 +318,35 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	}
 	if auth.Disabled || auth.Status == StatusDisabled {
 		return true, blockReasonDisabled, time.Time{}
+	}
+	// Permanent credential failure from the refresh path (e.g. refresh
+	// returned 400 invalid_grant) marks the auth Unavailable with a permanent
+	// LastError and does NOT set auth.NextRetryAfter (it stays zero). This
+	// must block all routing — the credential is dead and retrying will only
+	// waste a request.
+	//
+	// The NextRetryAfter.IsZero() guard is critical for distinguishing refresh
+	// permanent failures from request-side cooldowns:
+	//
+	//   - Refresh permanent failure: refreshAuthForRequest sets Unavailable=true
+	//     + permanent LastError but never sets NextRetryAfter (it only clears
+	//     NextRefreshAfter, a different field). ModelStates may or may not be
+	//     empty depending on prior traffic — relying on len(ModelStates)==0
+	//     is unsafe (codex review: a revoked auth with prior ModelStates would
+	//     skip the block).
+	//
+	//   - Request-side cooldown: MarkResult/applyAuthFailureState always sets
+	//     auth.NextRetryAfter = now+30min for invalid_grant/unauthorized/etc.
+	//     Those auths must fall through to the model-state branch below, which
+	//     honors NextRetryAfter expiry and allows the normal retry/resume path
+	//     after the cooldown. Blocking them here would keep the auth blocked
+	//     forever, preventing cooldown recovery (codex review).
+	//
+	// restoreCooldownRecordLocked only restores records with NextRetryAfter
+	// in the future, so persisted auths always have non-zero NextRetryAfter
+	// and are not affected by this short-circuit.
+	if auth.Unavailable && hasPermanentAuthFailure(auth) && auth.NextRetryAfter.IsZero() {
+		return true, blockReasonOther, time.Time{}
 	}
 	if model != "" {
 		if len(auth.ModelStates) > 0 {

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -87,6 +87,15 @@ type Auth struct {
 	NextRefreshAfter time.Time `json:"next_refresh_after"`
 	// NextRetryAfter is the earliest time a retry should retrigger.
 	NextRetryAfter time.Time `json:"next_retry_after"`
+	// PermanentRefreshFailure marks an auth as permanently failed by the
+	// refresh path (e.g. 400 invalid_grant with revoked refresh token).
+	// Set ONLY by refreshAuthForRequest's permanent branch; never set by
+	// request-side failure paths (applyAuthFailureState), which can
+	// produce the same Unavailable=true + zero NextRetryAfter shape under
+	// disable-cooling but are transient. This field is the discriminator
+	// that lets hasPermanentAuthFailure distinguish refresh-sourced
+	// permanent failures from disable-cooling transient failures.
+	PermanentRefreshFailure bool `json:"permanent_refresh_failure,omitempty"`
 	// ModelStates tracks per-model runtime availability data.
 	ModelStates map[string]*ModelState `json:"model_states,omitempty"`
 


### PR DESCRIPTION
## Summary

Follow-up to #4477. The runtime permanent-failure marker (`PermanentRefreshFailure` field) is correct in memory but lost on restart because all storage backends only persist `Auth.Metadata`, not the `Auth` struct fields.

## Problem

`FileTokenStore`, `PostgresStore`, `ObjectStore`, and `GitStore` all rebuild the `Auth` from persisted JSON with default field values:

- `PermanentRefreshFailure = false`
- `Unavailable = false`
- `Status = StatusActive`

So a restart after a `400 invalid_grant` refresh failure reloads the revoked credential as active/routable. The runtime guards (`shouldRefresh`, `nextRefreshCheckAt`, `isAuthBlockedForModel`) stop firing until the next refresh attempt re-detects the failure.

## Fix

### Write side (`persist`)

Mirror the marker into `Metadata` keys before `store.Save`:

- `permanent_refresh_failure` → `auth.PermanentRefreshFailure`
- `unavailable` → `auth.Unavailable`
- `status` → `string(auth.Status)`
- `status_message` → `auth.StatusMessage`

Non-permanent auths clear stale keys (so a recovered auth doesn't restore dead state).

### Read side (`ApplyPermanentFailureFromMetadata`)

New helper in `sdk/cliproxy/auth/permanent_failure_metadata.go` restores the marker from `Metadata` into the `Auth` struct fields. Called by all 4 store readers after rebuilding the `Auth`:

- `FileTokenStore.readAuthFiles` (2 sites: plugin path + normal path)
- `PostgresStore.List`
- `ObjectTokenStore.readAuthFile`
- `GitTokenStore.readAuthFile`

If the marker is absent (auth persisted before this feature, or recovered after manual token replacement), the helper is a no-op.

## Depends on

#4477 — this PR adds the persistence/recovery layer on top of the runtime marker introduced in #4477.

## Test plan

- `TestPermanentFailureMetadata_RoundTrip`: post-persist Metadata → `ApplyPermanentFailureFromMetadata` → fields restored + guards fire
- `TestPermanentFailureMetadata_NoMarkerIsNoOp`: no marker → no-op → Auth routable