### PR TITLE
fix(translator): omit tool_choice and parallel_tool_calls when no tools are present

### DIFF
--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -339,9 +339,16 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 		}
 	}
 
-	// Convert tool_choice if present
-	if toolChoice := root.Get("tool_choice"); toolChoice.Exists() {
+	// Convert tool_choice if present. When the request carries no tools,
+	// omit tool_choice and parallel_tool_calls entirely: strict
+	// OpenAI-compatible upstreams (e.g. xAI) reject requests that set these
+	// fields without tools, and Codex sends "tools":[] together with
+	// "tool_choice":"auto" on compaction requests.
+	if toolChoice := root.Get("tool_choice"); toolChoice.Exists() && len(chatCompletionsTools) > 0 {
 		out, _ = sjson.SetRawBytes(out, "tool_choice", []byte(toolChoice.Raw))
+	}
+	if len(chatCompletionsTools) == 0 {
+		out, _ = sjson.DeleteBytes(out, "parallel_tool_calls")
 	}
 
 	return out

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -347,7 +347,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 	if toolChoice := root.Get("tool_choice"); toolChoice.Exists() && len(chatCompletionsTools) > 0 {
 		out, _ = sjson.SetRawBytes(out, "tool_choice", []byte(toolChoice.Raw))
 	}
-	if len(chatCompletionsTools) == 0 {
+	if len(chatCompletionsTools) == 0 && root.Get("parallel_tool_calls").Exists() {
 		out, _ = sjson.DeleteBytes(out, "parallel_tool_calls")
 	}
 

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
@@ -363,6 +363,14 @@ func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_PreservesStructure
 		"input": [
 			{"role":"user","content":"Run command."}
 		],
+		"tools": [
+			{
+				"type": "function",
+				"name": "run_command",
+				"description": "Run a command",
+				"parameters": {"type": "object", "properties": {}}
+			}
+		],
 		"tool_choice": {
 			"type": "function",
 			"function": {
@@ -380,6 +388,34 @@ func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_PreservesStructure
 	}
 	if got := gjson.GetBytes(out, "tool_choice.function.name").String(); got != "run_command" {
 		t.Fatalf("tool_choice.function.name = %q, want run_command; output=%s", got, out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_DropsToolChoiceWithoutTools(t *testing.T) {
+	// Codex sends "tools":[] with "tool_choice":"auto" on compaction
+	// requests; strict OpenAI-compatible upstreams (e.g. xAI) return 400
+	// when tool_choice or parallel_tool_calls is set without tools.
+	raw := []byte(`{
+		"input": [
+			{"role":"user","content":"Summarize the conversation."}
+		],
+		"tools": [],
+		"tool_choice": "auto",
+		"parallel_tool_calls": false
+	}`)
+	t.Logf("input json:\n%s", prettyJSONForTest(raw))
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("grok-4.5", raw, false)
+	t.Logf("output json:\n%s", prettyJSONForTest(out))
+
+	if gjson.GetBytes(out, "tools").Exists() {
+		t.Fatalf("tools should be omitted when empty; output=%s", out)
+	}
+	if gjson.GetBytes(out, "tool_choice").Exists() {
+		t.Fatalf("tool_choice should be omitted when no tools are present; output=%s", out)
+	}
+	if gjson.GetBytes(out, "parallel_tool_calls").Exists() {
+		t.Fatalf("parallel_tool_calls should be omitted when no tools are present; output=%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #4491.

The OpenAI Responses → OpenAI Chat Completions request translator drops an empty `tools` array (gated on `len(chatCompletionsTools) > 0`) but still forwarded `tool_choice` and `parallel_tool_calls` unconditionally. Strict OpenAI-compatible upstreams — notably xAI/Grok — reject `tool_choice` (and per OpenAI's docs, `parallel_tool_calls`) when no `tools` are specified, returning HTTP 400.

This breaks Codex **auto compaction** on `openai-compatibility` Grok providers: compaction requests carry `"tools":[]` + `"tool_choice":"auto"` + `"parallel_tool_calls":false`, so the session gets permanently stuck retrying (`Upstream error: 400`) — every subsequent turn re-triggers pre-turn compaction.

## Changes

- `openai_openai-responses_request.go`: only copy `tool_choice` when translated tools are present; delete `parallel_tool_calls` from the output when there are no tools.
- Tests:
  - New `TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_DropsToolChoiceWithoutTools` covering the Codex compaction shape (`tools:[]` + `tool_choice:"auto"` + `parallel_tool_calls:false`).
  - `..._PreservesStructuredToolChoice` now includes a matching `tools` entry so it keeps validating structured `tool_choice` passthrough (its previous input — `tool_choice` without `tools` — is exactly the combination upstreams reject).

## Testing

- `go build ./...`
- `go test ./internal/translator/openai/openai/responses/ ./test/... ./sdk/api/handlers/openai/...` — all pass.
- Verified end-to-end against a live xAI-compatible upstream: the compaction-shaped request 400s before this change and succeeds without `tool_choice`; normal tool-calling turns still emit `function_call` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
