### PR TITLE
propagate request_id into plugin execution metadata

### DIFF
--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -294,6 +294,9 @@ func requestExecutionMetadata(ctx context.Context) map[string]any {
 	if executionSessionID := executionSessionIDFromContext(ctx); executionSessionID != "" {
 		meta[coreexecutor.ExecutionSessionMetadataKey] = executionSessionID
 	}
+	if requestID := requestIDFromContext(ctx); requestID != "" {
+		meta[coreexecutor.RequestIDMetadataKey] = requestID
+	}
 	if disallowFreeAuthFromContext(ctx) {
 		meta[coreexecutor.DisallowFreeAuthMetadataKey] = true
 	}
@@ -416,6 +419,21 @@ func executionSessionIDFromContext(ctx context.Context) string {
 	default:
 		return ""
 	}
+}
+
+// requestIDFromContext returns the host-generated request correlation ID when present.
+// It prefers the Go context value, then falls back to the Gin request ID for plugin metadata.
+func requestIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if requestID := strings.TrimSpace(logging.GetRequestID(ctx)); requestID != "" {
+		return requestID
+	}
+	if ginCtx, ok := ctx.Value("gin").(*gin.Context); ok && ginCtx != nil {
+		return strings.TrimSpace(logging.GetGinRequestID(ginCtx))
+	}
+	return ""
 }
 
 func disallowFreeAuthFromContext(ctx context.Context) bool {

--- a/sdk/api/handlers/handlers_metadata_test.go
+++ b/sdk/api/handlers/handlers_metadata_test.go
@@ -137,3 +137,32 @@ func TestSetGenerateMetadataHonorsExplicitFalse(t *testing.T) {
 		t.Fatalf("GenerateMetadataKey = %v, want false", got)
 	}
 }
+
+func TestRequestExecutionMetadataIncludesRequestID(t *testing.T) {
+	ctx := logging.WithRequestID(context.Background(), "abcd1234")
+
+	meta := requestExecutionMetadata(ctx)
+	if got := meta[coreexecutor.RequestIDMetadataKey]; got != "abcd1234" {
+		t.Fatalf("RequestIDMetadataKey = %v, want %q", got, "abcd1234")
+	}
+}
+
+func TestRequestExecutionMetadataIncludesRequestIDFromGin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	logging.SetGinRequestID(ginCtx, "gin-req-1")
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+
+	meta := requestExecutionMetadata(ctx)
+	if got := meta[coreexecutor.RequestIDMetadataKey]; got != "gin-req-1" {
+		t.Fatalf("RequestIDMetadataKey = %v, want %q", got, "gin-req-1")
+	}
+}
+
+func TestRequestExecutionMetadataOmitsEmptyRequestID(t *testing.T) {
+	meta := requestExecutionMetadata(context.Background())
+	if _, ok := meta[coreexecutor.RequestIDMetadataKey]; ok {
+		t.Fatalf("unexpected request_id in metadata: %v", meta[coreexecutor.RequestIDMetadataKey])
+	}
+}

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -44,6 +44,8 @@ const (
 	SelectedAuthIndexCallbackMetadataKey = "selected_auth_index_callback"
 	// ExecutionSessionMetadataKey identifies a long-lived downstream execution session.
 	ExecutionSessionMetadataKey = "execution_session_id"
+	// RequestIDMetadataKey stores the host-generated request correlation ID.
+	RequestIDMetadataKey = "request_id"
 )
 
 // Request encapsulates the translated payload that will be sent to a provider executor.


### PR DESCRIPTION
The host already generates a `request_id` for every inbound request (used for logging and the `X-CPA-TRACE-ID` header), but it stays inside the Go `context.Context` and never actually reaches plugins. Since plugins run as separate processes via go-plugin, they can't read context values at all — so today there's no shared ID a plugin can use to tell that a `model.route` call and a later `executor.execute` call are the *same* request.

That makes it really hard to build plugins that need any kind of per-request state: request correlation, caching keyed on the request, rate limiting, distributed locks, and so on. You see the router fire, then the executor fire, and you have nothing to tie them together.

This change just copies the existing `request_id` into the `Metadata` map that's already handed to every per-request hook, so a plugin can read `req.Metadata["request_id"]` and correlate the whole chain (`model.route`, `executor.execute`, the request/response interceptors, `scheduler.pick`, …). Because every hook pulls from the same request context, the ID is identical across all of them — including across conductor auth retries, which reuse that context.

It's purely additive: a new key on an existing `map[string]any`, nothing removed or renamed, no RPC protocol bump. Existing plugins are unaffected.