### PR TITLE
feat(management): expose session-affinity stats

### DIFF
--- a/internal/api/handlers/management/session_affinity.go
+++ b/internal/api/handlers/management/session_affinity.go
@@ -1,0 +1,37 @@
+package management
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type sessionAffinityStatsResponse struct {
+	Enabled        bool `json:"enabled"`
+	ActiveSessions int  `json:"active_sessions"`
+	ActiveBindings int  `json:"active_bindings"`
+}
+
+// GetSessionAffinityStats returns aggregate statistics for active
+// session-affinity bindings without exposing session identifiers.
+func (h *Handler) GetSessionAffinityStats(c *gin.Context) {
+	if h == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "handler not initialized"})
+		return
+	}
+
+	h.mu.Lock()
+	manager := h.authManager
+	h.mu.Unlock()
+	if manager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
+		return
+	}
+
+	stats, enabled := manager.SessionAffinityStats()
+	c.JSON(http.StatusOK, sessionAffinityStatsResponse{
+		ActiveSessions: stats.ActiveSessions,
+		Enabled:        enabled,
+		ActiveBindings: stats.ActiveBindings,
+	})
+}

--- a/internal/api/handlers/management/session_affinity_test.go
+++ b/internal/api/handlers/management/session_affinity_test.go
@@ -1,0 +1,91 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestGetSessionAffinityStats(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	selector := coreauth.NewSessionAffinitySelectorWithConfig(coreauth.SessionAffinityConfig{
+		Fallback: &coreauth.RoundRobinSelector{},
+		TTL:      time.Hour,
+	})
+	defer selector.Stop()
+	manager := coreauth.NewManager(nil, selector, nil)
+	handler := &Handler{authManager: manager}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	handler.GetSessionAffinityStats(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	var response sessionAffinityStatsResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !response.Enabled {
+		t.Fatal("enabled = false, want true")
+	}
+	if response.ActiveBindings != 0 {
+		t.Fatalf("active_bindings = %d, want 0", response.ActiveBindings)
+	}
+	if response.ActiveSessions != 0 {
+		t.Fatalf("active_sessions = %d, want 0", response.ActiveSessions)
+	}
+}
+
+func TestGetSessionAffinityStatsDisabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := &Handler{authManager: coreauth.NewManager(nil, nil, nil)}
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	handler.GetSessionAffinityStats(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	var response sessionAffinityStatsResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Enabled {
+		t.Fatal("enabled = true, want false")
+	}
+	if response.ActiveBindings != 0 {
+		t.Fatalf("active_bindings = %d, want 0", response.ActiveBindings)
+	}
+	if response.ActiveSessions != 0 {
+		t.Fatalf("active_sessions = %d, want 0", response.ActiveSessions)
+	}
+}
+
+func TestGetSessionAffinityStatsManagerUnavailable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := &Handler{}
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	handler.GetSessionAffinityStats(ctx)
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+	var response map[string]string
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response["error"] != "core auth manager unavailable" {
+		t.Fatalf("error = %q, want core auth manager unavailable", response["error"])
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -905,6 +905,7 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/routing/strategy", s.mgmt.GetRoutingStrategy)
 		mgmt.PUT("/routing/strategy", s.mgmt.PutRoutingStrategy)
 		mgmt.PATCH("/routing/strategy", s.mgmt.PutRoutingStrategy)
+		mgmt.GET("/routing/session-affinity/stats", s.mgmt.GetSessionAffinityStats)
 
 		mgmt.GET("/claude-api-key", s.mgmt.GetClaudeKeys)
 		mgmt.PUT("/claude-api-key", s.mgmt.PutClaudeKeys)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -606,6 +606,37 @@ func TestManagementUsageRequiresManagementAuthAndPopsArray(t *testing.T) {
 	}
 }
 
+func TestManagementSessionAffinityStatsRouteRegistered(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "test-management-key")
+
+	server := newTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/routing/session-affinity/stats", nil)
+	req.Header.Set("Authorization", "Bearer test-management-key")
+	recorder := httptest.NewRecorder()
+	server.engine.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var response struct {
+		Enabled        bool `json:"enabled"`
+		ActiveSessions int  `json:"active_sessions"`
+		ActiveBindings int  `json:"active_bindings"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal response: %v body=%s", err, recorder.Body.String())
+	}
+	if response.Enabled {
+		t.Fatal("enabled = true, want false")
+	}
+	if response.ActiveBindings != 0 {
+		t.Fatalf("active_bindings = %d, want 0", response.ActiveBindings)
+	}
+	if response.ActiveSessions != 0 {
+		t.Fatalf("active_sessions = %d, want 0", response.ActiveSessions)
+	}
+}
+
 func TestManagementPluginsRouteRegistered(t *testing.T) {
 	t.Setenv("MANAGEMENT_PASSWORD", "test-management-key")
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -478,6 +478,26 @@ func (m *Manager) SetSelector(selector Selector) {
 	}
 }
 
+// SessionAffinityStats returns aggregate affinity statistics when the active
+// selector supports session affinity. The boolean result reports whether the
+// session-affinity selector is currently active.
+func (m *Manager) SessionAffinityStats() (SessionAffinityStats, bool) {
+	if m == nil {
+		return SessionAffinityStats{}, false
+	}
+
+	m.mu.RLock()
+	selector := m.selector
+	m.mu.RUnlock()
+	provider, ok := selector.(interface {
+		SessionAffinityStats() SessionAffinityStats
+	})
+	if !ok || provider == nil {
+		return SessionAffinityStats{}, false
+	}
+	return provider.SessionAffinityStats(), true
+}
+
 // SetStore swaps the underlying persistence store.
 func (m *Manager) SetStore(store Store) {
 	m.mu.Lock()

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -427,6 +427,10 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	if err != nil {
 		return nil, err
 	}
+	logicalSessionID := primaryID
+	if fallbackID != "" {
+		logicalSessionID = fallbackID
+	}
 
 	cacheKey := provider + "::" + primaryID + "::" + model
 
@@ -442,7 +446,7 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		if err != nil {
 			return nil, err
 		}
-		s.cache.Set(cacheKey, auth.ID)
+		s.cache.setBinding(cacheKey, logicalSessionID, auth.ID)
 		entry.Infof("session-affinity: cache hit but auth unavailable, reselected | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
 		return auth, nil
 	}
@@ -452,7 +456,7 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		if cachedAuthID, ok := s.cache.Get(fallbackKey); ok {
 			for _, auth := range available {
 				if auth.ID == cachedAuthID {
-					s.cache.Set(cacheKey, auth.ID)
+					s.cache.setBinding(cacheKey, logicalSessionID, auth.ID)
 					entry.Infof("session-affinity: fallback cache hit | session=%s fallback=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model)
 					return auth, nil
 				}
@@ -464,7 +468,7 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	if err != nil {
 		return nil, err
 	}
-	s.cache.Set(cacheKey, auth.ID)
+	s.cache.setBinding(cacheKey, logicalSessionID, auth.ID)
 	entry.Infof("session-affinity: cache miss, new binding | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
 	return auth, nil
 }
@@ -485,6 +489,14 @@ func truncateSessionID(id string) string {
 		return id
 	}
 	return id[:8] + "..."
+}
+
+// SessionAffinityStats returns aggregate statistics for active affinity bindings.
+func (s *SessionAffinitySelector) SessionAffinityStats() SessionAffinityStats {
+	if s == nil || s.cache == nil {
+		return SessionAffinityStats{}
+	}
+	return s.cache.Stats()
 }
 
 // Stop releases resources held by the selector.

--- a/sdk/cliproxy/auth/session_cache.go
+++ b/sdk/cliproxy/auth/session_cache.go
@@ -7,8 +7,9 @@ import (
 
 // sessionEntry stores auth binding with expiration.
 type sessionEntry struct {
-	authID    string
-	expiresAt time.Time
+	authID           string
+	logicalSessionID string
+	expiresAt        time.Time
 }
 
 // SessionCache provides TTL-based session to auth mapping with automatic cleanup.
@@ -17,6 +18,14 @@ type SessionCache struct {
 	entries map[string]sessionEntry
 	ttl     time.Duration
 	stopCh  chan struct{}
+}
+
+// SessionAffinityStats summarizes active logical sessions and affinity bindings.
+// A binding represents one provider, extracted session ID, and model tuple;
+// one logical session may therefore own multiple bindings.
+type SessionAffinityStats struct {
+	ActiveSessions int `json:"active_sessions"`
+	ActiveBindings int `json:"active_bindings"`
 }
 
 // NewSessionCache creates a cache with the specified TTL.
@@ -82,13 +91,23 @@ func (c *SessionCache) GetAndRefresh(sessionID string) (string, bool) {
 
 // Set binds a session to an auth ID with TTL refresh.
 func (c *SessionCache) Set(sessionID, authID string) {
-	if sessionID == "" || authID == "" {
+	c.setBinding(sessionID, sessionID, authID)
+}
+
+// setBinding binds a cache key to an auth while retaining its logical session ID.
+// Existing logical session metadata is preserved when an auth is reselected.
+func (c *SessionCache) setBinding(cacheKey, logicalSessionID, authID string) {
+	if cacheKey == "" || logicalSessionID == "" || authID == "" {
 		return
 	}
 	c.mu.Lock()
-	c.entries[sessionID] = sessionEntry{
-		authID:    authID,
-		expiresAt: time.Now().Add(c.ttl),
+	if existing, ok := c.entries[cacheKey]; ok && existing.logicalSessionID != "" {
+		logicalSessionID = existing.logicalSessionID
+	}
+	c.entries[cacheKey] = sessionEntry{
+		authID:           authID,
+		logicalSessionID: logicalSessionID,
+		expiresAt:        time.Now().Add(c.ttl),
 	}
 	c.mu.Unlock()
 }
@@ -116,6 +135,32 @@ func (c *SessionCache) InvalidateAuth(authID string) {
 		}
 	}
 	c.mu.Unlock()
+}
+
+// Stats returns a point-in-time count of unexpired bindings.
+// Expired entries are ignored even if the background cleanup has not removed them yet.
+func (c *SessionCache) Stats() SessionAffinityStats {
+	if c == nil {
+		return SessionAffinityStats{}
+	}
+
+	now := time.Now()
+	stats := SessionAffinityStats{}
+	sessions := make(map[string]struct{})
+	c.mu.RLock()
+	for cacheKey, entry := range c.entries {
+		if !now.After(entry.expiresAt) {
+			stats.ActiveBindings++
+			logicalSessionID := entry.logicalSessionID
+			if logicalSessionID == "" {
+				logicalSessionID = cacheKey
+			}
+			sessions[logicalSessionID] = struct{}{}
+		}
+	}
+	c.mu.RUnlock()
+	stats.ActiveSessions = len(sessions)
+	return stats
 }
 
 // Stop terminates the background cleanup goroutine.

--- a/sdk/cliproxy/auth/session_cache_test.go
+++ b/sdk/cliproxy/auth/session_cache_test.go
@@ -1,0 +1,133 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestSessionCacheStatsCountsOnlyActiveBindings(t *testing.T) {
+	t.Parallel()
+
+	cache := NewSessionCache(time.Hour)
+	defer cache.Stop()
+
+	cache.setBinding("provider::session-a::model-a", "session-a", "auth-a")
+	cache.setBinding("provider::session-a::model-b", "session-a", "auth-a")
+
+	cache.mu.Lock()
+	activeExpiry := cache.entries["provider::session-a::model-a"].expiresAt
+	cache.entries["provider::expired::model-a"] = sessionEntry{
+		authID:           "auth-b",
+		logicalSessionID: "expired",
+		expiresAt:        time.Now().Add(-time.Minute),
+	}
+	cache.mu.Unlock()
+
+	stats := cache.Stats()
+	if stats.ActiveBindings != 2 {
+		t.Fatalf("Stats().ActiveBindings = %d, want 2", stats.ActiveBindings)
+	}
+	if stats.ActiveSessions != 1 {
+		t.Fatalf("Stats().ActiveSessions = %d, want 1", stats.ActiveSessions)
+	}
+	cache.mu.RLock()
+	gotExpiry := cache.entries["provider::session-a::model-a"].expiresAt
+	cache.mu.RUnlock()
+	if !gotExpiry.Equal(activeExpiry) {
+		t.Fatalf("Stats() refreshed expiry to %v, want %v", gotExpiry, activeExpiry)
+	}
+}
+
+func TestNilSessionCacheStats(t *testing.T) {
+	t.Parallel()
+
+	var cache *SessionCache
+	if stats := cache.Stats(); stats.ActiveBindings != 0 || stats.ActiveSessions != 0 {
+		t.Fatalf("Stats() = %+v, want zero value", stats)
+	}
+}
+
+func TestManagerSessionAffinityStats(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &RoundRobinSelector{},
+		TTL:      time.Hour,
+	})
+	defer selector.Stop()
+	auths := []*Auth{{ID: "auth-a"}}
+	headers := make(http.Header)
+	headers.Set("X-Session-ID", "session-a")
+	opts := cliproxyexecutor.Options{Headers: headers}
+	for _, model := range []string{"model-a", "model-b"} {
+		if _, err := selector.Pick(context.Background(), "provider", model, opts, auths); err != nil {
+			t.Fatalf("Pick(%q) error = %v", model, err)
+		}
+	}
+
+	manager := NewManager(nil, selector, nil)
+	stats, enabled := manager.SessionAffinityStats()
+	if !enabled {
+		t.Fatal("SessionAffinityStats() enabled = false, want true")
+	}
+	if stats.ActiveBindings != 2 {
+		t.Fatalf("SessionAffinityStats().ActiveBindings = %d, want 2", stats.ActiveBindings)
+	}
+	if stats.ActiveSessions != 1 {
+		t.Fatalf("SessionAffinityStats().ActiveSessions = %d, want 1", stats.ActiveSessions)
+	}
+
+	manager.SetSelector(&RoundRobinSelector{})
+	stats, enabled = manager.SessionAffinityStats()
+	if enabled {
+		t.Fatal("SessionAffinityStats() enabled = true after selector change, want false")
+	}
+	if stats.ActiveBindings != 0 {
+		t.Fatalf("SessionAffinityStats().ActiveBindings = %d after selector change, want 0", stats.ActiveBindings)
+	}
+	if stats.ActiveSessions != 0 {
+		t.Fatalf("SessionAffinityStats().ActiveSessions = %d after selector change, want 0", stats.ActiveSessions)
+	}
+}
+
+func TestSessionAffinityStatsGroupsFallbackKeyMigration(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &RoundRobinSelector{},
+		TTL:      time.Hour,
+	})
+	defer selector.Stop()
+	auths := []*Auth{{ID: "auth-a"}}
+	firstTurn := cliproxyexecutor.Options{OriginalRequest: []byte(`{
+		"messages":[{"role":"user","content":"hello"}]
+	}`)}
+	laterTurn := cliproxyexecutor.Options{OriginalRequest: []byte(`{
+		"messages":[
+			{"role":"user","content":"hello"},
+			{"role":"assistant","content":"hi"}
+		]
+	}`)}
+
+	if _, err := selector.Pick(context.Background(), "provider", "model-a", firstTurn, auths); err != nil {
+		t.Fatalf("first-turn Pick() error = %v", err)
+	}
+	if _, err := selector.Pick(context.Background(), "provider", "model-a", laterTurn, auths); err != nil {
+		t.Fatalf("later-turn Pick() error = %v", err)
+	}
+	if _, err := selector.Pick(context.Background(), "provider", "model-b", laterTurn, auths); err != nil {
+		t.Fatalf("second-model Pick() error = %v", err)
+	}
+
+	stats := selector.SessionAffinityStats()
+	if stats.ActiveBindings != 3 {
+		t.Fatalf("ActiveBindings = %d, want 3", stats.ActiveBindings)
+	}
+	if stats.ActiveSessions != 1 {
+		t.Fatalf("ActiveSessions = %d, want 1", stats.ActiveSessions)
+	}
+}


### PR DESCRIPTION
## Summary

- track logical session IDs alongside provider/model affinity bindings
- expose active session and binding counts through the protected management API
- return aggregate counts only, without exposing session identifiers

## API

`GET /v0/management/routing/session-affinity/stats`

Example response:

```json
{
  "enabled": true,
  "active_sessions": 2,
  "active_bindings": 5
}
```

`active_sessions` counts distinct logical sessions with unexpired affinity entries, including deduplication across models and hash-key migration. `active_bindings` counts the underlying provider/session/model cache entries. Reading stats does not refresh affinity TTLs.

When session affinity is disabled, the endpoint returns `enabled: false` with zero counts.

## Testing

- `go test ./...`
- `go test -race ./sdk/cliproxy/auth`
- `go build -o <temp> ./cmd/server`
