### PR TITLE
fix(translator): make OpenAI→Claude response conversion work with the Cline API

### DIFF
--- a/internal/translator/openai/claude/openai_claude_response.go
+++ b/internal/translator/openai/claude/openai_claude_response.go
@@ -21,6 +21,25 @@ var (
 	dataTag = []byte("data:")
 )
 
+// unwrapOpenAIDataEnvelope returns the inner payload when the upstream wraps the
+// Chat Completions object in an envelope like {"success":true,"data":{...}} (some
+// OpenAI-compatible gateways, e.g. the Cline API, do this for both streaming chunks
+// and non-streaming bodies). Standard responses (top-level "choices"/"id"/"object")
+// are returned unchanged.
+func unwrapOpenAIDataEnvelope(raw []byte) []byte {
+	root := gjson.ParseBytes(raw)
+	if !root.IsObject() {
+		return raw
+	}
+	if root.Get("choices").Exists() || root.Get("id").Exists() || root.Get("object").Exists() {
+		return raw
+	}
+	if inner := root.Get("data"); inner.Exists() && inner.IsObject() {
+		return []byte(inner.Raw)
+	}
+	return raw
+}
+
 // ConvertOpenAIResponseToAnthropicParams holds parameters for response conversion
 type ConvertOpenAIResponseToAnthropicParams struct {
 	MessageID   string
@@ -107,6 +126,7 @@ func ConvertOpenAIResponseToClaude(_ context.Context, _ string, originalRequestR
 		return [][]byte{}
 	}
 	rawJSON = bytes.TrimSpace(rawJSON[5:])
+	rawJSON = unwrapOpenAIDataEnvelope(rawJSON)
 
 	if (*param).(*ConvertOpenAIResponseToAnthropicParams).ToolNameMap == nil {
 		(*param).(*ConvertOpenAIResponseToAnthropicParams).ToolNameMap = util.ToolNameMapFromClaudeRequest(originalRequestRawJSON)
@@ -166,7 +186,7 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 		}
 
 		// Handle reasoning content delta
-		if reasoning := delta.Get("reasoning_content"); reasoning.Exists() {
+		if reasoning := openAIReasoningNode(delta); reasoning.Exists() {
 			for _, reasoningText := range collectOpenAIReasoningTexts(reasoning) {
 				if reasoningText == "" {
 					continue
@@ -417,6 +437,7 @@ func convertOpenAIDoneToAnthropic(param *ConvertOpenAIResponseToAnthropicParams)
 
 // convertOpenAINonStreamingToAnthropic converts OpenAI non-streaming response to Anthropic format
 func convertOpenAINonStreamingToAnthropic(rawJSON []byte) [][]byte {
+	rawJSON = unwrapOpenAIDataEnvelope(rawJSON)
 	root := gjson.ParseBytes(rawJSON)
 
 	out := []byte(`{"id":"","type":"message","role":"assistant","model":"","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}`)
@@ -427,7 +448,7 @@ func convertOpenAINonStreamingToAnthropic(rawJSON []byte) [][]byte {
 	if choices := root.Get("choices"); choices.Exists() && choices.IsArray() && len(choices.Array()) > 0 {
 		choice := choices.Array()[0] // Take first choice
 
-		reasoningNode := choice.Get("message.reasoning_content")
+		reasoningNode := openAIReasoningNode(choice.Get("message"))
 		for _, reasoningText := range collectOpenAIReasoningTexts(reasoningNode) {
 			if reasoningText == "" {
 				continue
@@ -513,6 +534,21 @@ func (p *ConvertOpenAIResponseToAnthropicParams) toolContentBlockIndex(openAIToo
 	p.NextContentBlockIndex++
 	p.ToolCallBlockIndexes[openAIToolIndex] = idx
 	return idx
+}
+
+// openAIReasoningNode returns the reasoning payload from a message/delta node,
+// accepting both "reasoning_content" (DeepSeek/OpenRouter convention) and
+// "reasoning" (used by some OpenAI-compatible gateways such as the Cline API).
+//
+// "reasoning_content" is preferred, but only when it actually yields collectable
+// text: some gateways emit a placeholder ("reasoning_content": null or "") next to
+// a populated "reasoning" field. In that case Exists() is still true for the
+// placeholder, so we must not select it and lose the real reasoning text.
+func openAIReasoningNode(node gjson.Result) gjson.Result {
+	if r := node.Get("reasoning_content"); r.Exists() && len(collectOpenAIReasoningTexts(r)) > 0 {
+		return r
+	}
+	return node.Get("reasoning")
 }
 
 func collectOpenAIReasoningTexts(node gjson.Result) []string {
@@ -613,6 +649,7 @@ func toolCallAccumulatorIndexes(accumulators map[int]*ToolCallAccumulator) []int
 func ConvertOpenAIResponseToClaudeNonStream(_ context.Context, _ string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, _ *any) []byte {
 	_ = requestRawJSON
 
+	rawJSON = unwrapOpenAIDataEnvelope(rawJSON)
 	root := gjson.ParseBytes(rawJSON)
 	toolNameMap := util.ToolNameMapFromClaudeRequest(originalRequestRawJSON)
 	out := []byte(`{"id":"","type":"message","role":"assistant","model":"","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}`)
@@ -711,7 +748,7 @@ func ConvertOpenAIResponseToClaudeNonStream(_ context.Context, _ string, origina
 				}
 			}
 
-			if reasoning := message.Get("reasoning_content"); reasoning.Exists() {
+			if reasoning := openAIReasoningNode(message); reasoning.Exists() {
 				for _, reasoningText := range collectOpenAIReasoningTexts(reasoning) {
 					if reasoningText == "" {
 						continue

--- a/internal/translator/openai/claude/openai_claude_response_test.go
+++ b/internal/translator/openai/claude/openai_claude_response_test.go
@@ -364,3 +364,79 @@ func TestStreamingTool_StopReasonMixedSuppressedAndValid(t *testing.T) {
 		t.Fatalf("stop_reason = %q, want %q", got, "tool_use")
 	}
 }
+
+// Regression test for OpenAI-compatible gateways that wrap the Chat Completions
+// payload in an envelope like {"success":true,"data":{...}} (e.g. the Cline API)
+// and return reasoning under "reasoning" instead of "reasoning_content".
+func TestNonStreaming_DataEnvelopeAndReasoningField(t *testing.T) {
+	raw := []byte(`{"success":true,"data":{"id":"gen_x","model":"moonshotai/kimi-k3","choices":[{"finish_reason":"stop","index":0,"message":{"role":"assistant","content":"4","reasoning":"simple arithmetic"}}],"usage":{"prompt_tokens":90,"completion_tokens":20}}}`)
+	out := ConvertOpenAIResponseToClaudeNonStream(context.Background(), "", []byte(`{"stream":false}`), nil, raw, nil)
+
+	if got := gjson.GetBytes(out, "id").String(); got != "gen_x" {
+		t.Fatalf("id = %q, want %q (envelope not unwrapped)", got, "gen_x")
+	}
+	var sawText, sawThinking bool
+	for _, b := range gjson.GetBytes(out, "content").Array() {
+		switch b.Get("type").String() {
+		case "text":
+			sawText = true
+			if b.Get("text").String() != "4" {
+				t.Fatalf("text = %q, want %q", b.Get("text").String(), "4")
+			}
+		case "thinking":
+			sawThinking = true
+		}
+	}
+	if !sawText {
+		t.Fatal("no text content block produced from wrapped response")
+	}
+	if !sawThinking {
+		t.Fatal("no thinking block produced from \"reasoning\" field")
+	}
+}
+
+func TestStreaming_DataEnvelopeChunk(t *testing.T) {
+	events := runStream(t, streamReq,
+		`{"success":true,"data":{"id":"gen_x","model":"m","choices":[{"index":0,"delta":{"content":"4"}}]}}`,
+		`{"success":true,"data":{"id":"gen_x","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}}`,
+	)
+	var sawTextDelta bool
+	for _, e := range events {
+		if e.Type == "content_block_delta" && gjson.Get(e.Payload, "delta.type").String() == "text_delta" {
+			sawTextDelta = true
+		}
+	}
+	if !sawTextDelta {
+		t.Fatalf("no text_delta emitted from wrapped streaming chunk (events=%+v)", events)
+	}
+}
+
+// Regression test: when reasoning_content is an empty placeholder (null/"") but
+// the real reasoning text is present under "reasoning", openAIReasoningNode must
+// fall back to "reasoning" rather than selecting the empty placeholder.
+func TestNonStreaming_EmptyReasoningContentPlaceholderFallsBack(t *testing.T) {
+	raw := []byte(`{"id":"gen_x","model":"m","choices":[{"finish_reason":"stop","index":0,"message":{"role":"assistant","content":"4","reasoning_content":null,"reasoning":"simple arithmetic"}}]}`)
+	out := ConvertOpenAIResponseToClaudeNonStream(context.Background(), "", []byte(`{"stream":false}`), nil, raw, nil)
+	var sawThinking bool
+	for _, b := range gjson.GetBytes(out, "content").Array() {
+		if b.Get("type").String() == "thinking" && b.Get("thinking").String() != "" {
+			sawThinking = true
+		}
+	}
+	if !sawThinking {
+		t.Fatal("no thinking block produced when reasoning_content is a null placeholder but reasoning is populated")
+	}
+
+	// Empty-string placeholder variant.
+	raw = []byte(`{"id":"gen_x","model":"m","choices":[{"finish_reason":"stop","index":0,"message":{"role":"assistant","content":"4","reasoning_content":"","reasoning":"more reasoning"}}]}`)
+	out = ConvertOpenAIResponseToClaudeNonStream(context.Background(), "", []byte(`{"stream":false}`), nil, raw, nil)
+	sawThinking = false
+	for _, b := range gjson.GetBytes(out, "content").Array() {
+		if b.Get("type").String() == "thinking" && b.Get("thinking").String() != "" {
+			sawThinking = true
+		}
+	}
+	if !sawThinking {
+		t.Fatal("no thinking block produced when reasoning_content is an empty-string placeholder but reasoning is populated")
+	}
+}


### PR DESCRIPTION
Closes #4512

## Problem
The Cline API (an OpenAI-compatible upstream) wraps its Chat Completions response in an envelope like `{"success":true,"data":{...}}` for both streaming chunks and non-streaming bodies, and returns the reasoning text under `reasoning` instead of `reasoning_content`.

The OpenAI→Claude response converter reads top-level `choices` and `reasoning_content`, so responses coming back from Cline came through **empty** (blank `id`/`model`/`content`, zero tokens) and with **no thinking blocks**.

## Fix
- **`unwrapOpenAIDataEnvelope()`** — returns the inner payload when the body is an envelope; passes standard OpenAI responses through unchanged. Applied to the streaming chunk path, the shared non-streaming helper, and the `ConvertOpenAIResponseToClaudeNonStream` entrypoint.
- **`openAIReasoningNode()`** — accepts both `reasoning_content` and `reasoning`. `reasoning_content` is preferred only when it yields collectable text, so a placeholder (`null`/`""`) next to a populated `reasoning` field still falls back correctly. Applied at all four reasoning read sites.
- **Regression tests** for the envelope (stream + non-stream), the `reasoning` field, and the empty-placeholder fallback.

## Scope
Additive and defensive — standard (non-enveloped) OpenAI responses are byte-for-byte unchanged, and the existing test suite still passes. Verified live against the Cline API (`cline-pass/kimi-k3`): non-stream, stream, tool_use blocks, and thinking blocks all come through correctly.
