### PR TITLE
feat(codex): 支持从现有 OAuth 凭据注册 Agent Identity 并导出 auth.json（兼容 Free 賬號 Codex 免接码）

### DIFF
--- a/internal/api/handlers/management/agent_identity.go
+++ b/internal/api/handlers/management/agent_identity.go
@@ -1,0 +1,441 @@
+package management
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/buildinfo"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+const codexAgentIdentityHarnessID = "codex-cli"
+
+var (
+	errAgentIdentityAuthNotFound = errors.New("auth credential not found")
+	errAgentIdentityAuthConflict = errors.New("auth index identifies multiple credentials")
+)
+
+type agentIdentityRegistrar interface {
+	RegisterAgent(context.Context, codex.AgentRegistration) (string, error)
+	RegisterTask(context.Context, codex.AgentIdentityKey) (string, error)
+}
+
+type agentIdentityRegistrarFactory func(*coreauth.Auth) agentIdentityRegistrar
+
+type provisionAgentIdentityRequest struct {
+	AuthIndex    string `json:"auth_index"`
+	RegisterTask *bool  `json:"register_task"`
+	Force        bool   `json:"force"`
+}
+
+type provisionAgentIdentityResult struct {
+	Status    codex.ManagedAgentIdentityState
+	AuthIndex string
+	HasTask   bool
+	Reused    bool
+}
+
+// ProvisionAgentIdentity creates and persists a managed Codex Agent Identity.
+func (h *Handler) ProvisionAgentIdentity(c *gin.Context) {
+	if h == nil || h.authManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
+		return
+	}
+
+	var request provisionAgentIdentityRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+	request.AuthIndex = strings.TrimSpace(request.AuthIndex)
+	if request.AuthIndex == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "auth_index is required"})
+		return
+	}
+	registerTask := request.RegisterTask == nil || *request.RegisterTask
+
+	var result provisionAgentIdentityResult
+	var persisted bool
+	finalAuth, err := h.authManager.WithMetadataTransactionByIndex(c.Request.Context(), request.AuthIndex, func(transaction *coreauth.MetadataTransaction) error {
+		auth := transaction.Auth()
+		if auth == nil {
+			return errAgentIdentityAuthNotFound
+		}
+		if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+			return &agentIdentityStateError{message: "auth credential is not a Codex credential"}
+		}
+		if coreauth.IsPluginVirtualAuth(auth) || isRuntimeOnlyAuth(auth) {
+			return &agentIdentityStateError{message: "auth credential cannot be modified directly"}
+		}
+
+		credentials, errCredentials := codex.ManagedAgentIdentityCredentialsFromMetadata(auth.Metadata)
+		if errCredentials != nil {
+			return &agentIdentityCredentialError{cause: errCredentials}
+		}
+		var errProvision error
+		result, errProvision = h.provisionManagedAgentIdentity(c.Request.Context(), transaction, auth, credentials, registerTask, request.Force)
+		persisted = transaction.Persisted()
+		return errProvision
+	})
+	if persisted && finalAuth != nil && h.postAuthPersistHook != nil {
+		if errHook := h.postAuthPersistHook(c.Request.Context(), finalAuth.Clone()); errHook != nil {
+			if err == nil {
+				err = fmt.Errorf("post-auth persist hook failed: %w", errHook)
+			}
+		}
+	}
+	if err != nil {
+		switch {
+		case errors.Is(err, coreauth.ErrAuthStoreUnavailable):
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "durable auth store unavailable"})
+			return
+		case errors.Is(err, coreauth.ErrAuthIndexNotFound), errors.Is(err, errAgentIdentityAuthNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "auth credential not found"})
+			return
+		case errors.Is(err, coreauth.ErrAuthIndexAmbiguous), errors.Is(err, errAgentIdentityAuthConflict):
+			c.JSON(http.StatusConflict, gin.H{"error": "auth_index is not unique"})
+			return
+		}
+		var upstreamError *agentIdentityUpstreamError
+		if errors.As(err, &upstreamError) {
+			payload := gin.H{
+				"error":              upstreamError.message,
+				"status":             upstreamError.state,
+				"auth_index":         request.AuthIndex,
+				"has_tokens":         true,
+				"has_agent_identity": upstreamError.hasIdentity,
+				"has_task":           false,
+			}
+			c.JSON(http.StatusBadGateway, payload)
+			return
+		}
+		var conflictError *agentIdentityStateError
+		if errors.As(err, &conflictError) {
+			c.JSON(http.StatusConflict, gin.H{"error": conflictError.Error()})
+			return
+		}
+		var credentialError *agentIdentityCredentialError
+		if errors.As(err, &credentialError) {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "invalid Codex credential"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to persist Agent Identity credential"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"status":             result.Status,
+		"auth_index":         result.AuthIndex,
+		"has_tokens":         true,
+		"has_agent_identity": true,
+		"has_task":           result.HasTask,
+		"reused":             result.Reused,
+	})
+}
+
+// ExportAgentIdentityAuth returns a Codex CLI-compatible auth.json representation.
+func (h *Handler) ExportAgentIdentityAuth(c *gin.Context) {
+	if h == nil || h.authManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
+		return
+	}
+	authIndex := strings.TrimSpace(c.Query("auth_index"))
+	if authIndex == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "auth_index is required"})
+		return
+	}
+
+	auth, err := h.agentIdentityAuthByIndex(authIndex)
+	if err != nil {
+		switch {
+		case errors.Is(err, errAgentIdentityAuthNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "auth credential not found"})
+		case errors.Is(err, errAgentIdentityAuthConflict):
+			c.JSON(http.StatusConflict, gin.H{"error": "auth_index is not unique"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve auth credential"})
+		}
+		return
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		c.JSON(http.StatusConflict, gin.H{"error": "auth credential is not a Codex credential"})
+		return
+	}
+
+	credentials, err := codex.ManagedAgentIdentityCredentialsFromMetadata(auth.Metadata)
+	if err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "invalid Codex credential"})
+		return
+	}
+	data, err := credentials.MarshalCodexAuthFile()
+	if err != nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "managed Agent Identity is not ready for export"})
+		return
+	}
+
+	c.Header("Content-Disposition", `attachment; filename="auth.json"`)
+	c.Header("Cache-Control", "no-store, private")
+	c.Header("Pragma", "no-cache")
+	c.Header("X-Content-Type-Options", "nosniff")
+	c.Data(http.StatusOK, "application/json", data)
+}
+
+func (h *Handler) provisionManagedAgentIdentity(ctx context.Context, transaction *coreauth.MetadataTransaction, auth *coreauth.Auth, credentials codex.ManagedAgentIdentityCredentials, registerTask, force bool) (provisionAgentIdentityResult, error) {
+	result := provisionAgentIdentityResult{AuthIndex: lockedAuthIndex(auth)}
+	hasRuntime := strings.TrimSpace(credentials.AgentRuntimeID) != ""
+	hasPrivateKey := strings.TrimSpace(credentials.AgentPrivateKey) != ""
+	hasTask := strings.TrimSpace(credentials.TaskID) != ""
+	hasIdentityMaterial := hasRuntime || hasPrivateKey || hasTask
+	bindingSnapshotMissing := hasIdentityMaterial && agentIdentityBindingSnapshotMissing(auth.Metadata)
+	if !force && hasIdentityMaterial && (strings.TrimSpace(credentials.AgentAccountID) != strings.TrimSpace(credentials.AccountID) || strings.TrimSpace(credentials.AgentChatGPTUserID) != strings.TrimSpace(credentials.ChatGPTUserID)) {
+		return result, &agentIdentityStateError{message: "managed Agent Identity belongs to a different ChatGPT account; re-provision with force=true"}
+	}
+
+	if !force && hasRuntime != hasPrivateKey {
+		if hasRuntime {
+			return result, &agentIdentityStateError{message: "managed Agent Identity is missing its private key; re-provision with force=true"}
+		}
+		// A persisted private key without a runtime ID resumes the interrupted registration.
+	}
+	if !force && !hasRuntime && !hasPrivateKey && hasTask {
+		return result, &agentIdentityStateError{message: "managed Agent Identity has a task without registration material; re-provision with force=true"}
+	}
+	if !force && hasRuntime && hasPrivateKey {
+		if _, err := codex.ParseAgentIdentityPrivateKey(credentials.AgentPrivateKey); err != nil {
+			return result, &agentIdentityStateError{message: "managed Agent Identity private key is invalid; re-provision with force=true"}
+		}
+		result.Reused = true
+		desiredState := codex.ManagedAgentIdentityStateNeedsTask
+		if hasTask {
+			desiredState = codex.ManagedAgentIdentityStateReady
+		}
+		setLastRefresh := strings.TrimSpace(credentials.LastRefresh) == ""
+		stateChanged := credentials.State != desiredState
+		credentials.State = desiredState
+		if setLastRefresh {
+			credentials.LastRefresh = time.Now().UTC().Format(time.RFC3339)
+		}
+		if setLastRefresh || stateChanged || bindingSnapshotMissing {
+			if _, err := mergeAgentIdentityMetadata(transaction, credentials, setLastRefresh); err != nil {
+				return result, err
+			}
+		}
+		if hasTask {
+			result.Status = desiredState
+			result.HasTask = true
+			return result, nil
+		}
+		if !registerTask {
+			result.Status = desiredState
+			return result, nil
+		}
+		return h.registerAndPersistAgentTask(ctx, transaction, auth, credentials, true)
+	}
+
+	var keyMaterial codex.AgentKeyMaterial
+	if !force && hasPrivateKey {
+		publicKey, err := codex.PublicKeySSHFromPrivateKey(credentials.AgentPrivateKey)
+		if err != nil {
+			return result, &agentIdentityStateError{message: "managed Agent Identity private key is invalid; re-provision with force=true"}
+		}
+		keyMaterial = codex.AgentKeyMaterial{
+			PrivateKeyPKCS8Base64: credentials.AgentPrivateKey,
+			PublicKeySSH:          publicKey,
+		}
+	} else {
+		var err error
+		keyMaterial, err = codex.GenerateAgentKeyMaterial()
+		if err != nil {
+			return result, err
+		}
+		credentials.AgentPrivateKey = keyMaterial.PrivateKeyPKCS8Base64
+		credentials.AgentRuntimeID = ""
+		credentials.TaskID = ""
+		credentials.AgentAccountID = strings.TrimSpace(credentials.AccountID)
+		credentials.AgentChatGPTUserID = strings.TrimSpace(credentials.ChatGPTUserID)
+		credentials.State = codex.ManagedAgentIdentityStateProvisioning
+		if _, err = mergeAgentIdentityMetadata(transaction, credentials, false); err != nil {
+			return result, err
+		}
+	}
+
+	registrar := h.agentIdentityRegistrarFor(auth)
+	runtimeID, err := registrar.RegisterAgent(ctx, codex.AgentRegistration{
+		AccessToken:      credentials.AccessToken,
+		IsFedRAMPAccount: credentials.ChatGPTAccountIsFedRAMP,
+		KeyMaterial:      keyMaterial,
+		BillOfMaterials: codex.AgentBillOfMaterials{
+			AgentVersion:    agentIdentityVersion(),
+			AgentHarnessID:  codexAgentIdentityHarnessID,
+			RunningLocation: "custom-" + runtime.GOOS,
+		},
+	})
+	if err == nil && strings.TrimSpace(runtimeID) == "" {
+		err = errors.New("Agent Identity registration returned an empty runtime ID")
+	}
+	if err != nil {
+		credentials.State = codex.ManagedAgentIdentityStateError
+		_, _ = mergeAgentIdentityMetadata(transaction, credentials, false)
+		return result, &agentIdentityUpstreamError{
+			message:     "Agent Identity registration failed",
+			state:       codex.ManagedAgentIdentityStateError,
+			hasIdentity: false,
+			cause:       err,
+		}
+	}
+
+	credentials.AgentRuntimeID = strings.TrimSpace(runtimeID)
+	credentials.AgentPrivateKey = keyMaterial.PrivateKeyPKCS8Base64
+	credentials.TaskID = ""
+	credentials.State = codex.ManagedAgentIdentityStateNeedsTask
+	setLastRefresh := strings.TrimSpace(credentials.LastRefresh) == ""
+	if setLastRefresh {
+		credentials.LastRefresh = time.Now().UTC().Format(time.RFC3339)
+	}
+	if _, err = mergeAgentIdentityMetadata(transaction, credentials, setLastRefresh); err != nil {
+		return result, err
+	}
+	if !registerTask {
+		result.Status = codex.ManagedAgentIdentityStateNeedsTask
+		return result, nil
+	}
+	return h.registerAndPersistAgentTask(ctx, transaction, auth, credentials, false)
+}
+
+func agentIdentityBindingSnapshotMissing(metadata map[string]any) bool {
+	accountID, _ := metadata["agent_identity_account_id"].(string)
+	userID, _ := metadata["chatgpt_user_id"].(string)
+	return strings.TrimSpace(accountID) == "" || strings.TrimSpace(userID) == ""
+}
+
+func (h *Handler) registerAndPersistAgentTask(ctx context.Context, transaction *coreauth.MetadataTransaction, auth *coreauth.Auth, credentials codex.ManagedAgentIdentityCredentials, reused bool) (provisionAgentIdentityResult, error) {
+	result := provisionAgentIdentityResult{
+		Status:    codex.ManagedAgentIdentityStateNeedsTask,
+		AuthIndex: lockedAuthIndex(auth),
+		Reused:    reused,
+	}
+	credentials.TaskID = ""
+	registrar := h.agentIdentityRegistrarFor(auth)
+	taskID, err := registrar.RegisterTask(ctx, codex.AgentIdentityKey{
+		AgentRuntimeID:        credentials.AgentRuntimeID,
+		PrivateKeyPKCS8Base64: credentials.AgentPrivateKey,
+	})
+	if err == nil && strings.TrimSpace(taskID) == "" {
+		err = errors.New("task registration returned an empty task ID")
+	}
+	if err != nil {
+		credentials.State = codex.ManagedAgentIdentityStateNeedsTask
+		_, _ = mergeAgentIdentityMetadata(transaction, credentials, false)
+		return result, &agentIdentityUpstreamError{
+			message:     "Agent Identity task registration failed",
+			state:       codex.ManagedAgentIdentityStateNeedsTask,
+			hasIdentity: true,
+			cause:       err,
+		}
+	}
+
+	credentials.TaskID = taskID
+	credentials.State = codex.ManagedAgentIdentityStateReady
+	if _, err = mergeAgentIdentityMetadata(transaction, credentials, false); err != nil {
+		return result, err
+	}
+	result.Status = codex.ManagedAgentIdentityStateReady
+	result.HasTask = true
+	return result, nil
+}
+
+func mergeAgentIdentityMetadata(transaction *coreauth.MetadataTransaction, credentials codex.ManagedAgentIdentityCredentials, setLastRefresh bool) (*coreauth.Auth, error) {
+	updates := map[string]any{
+		"auth_mode":                  codex.CodexAuthModeChatGPT,
+		"agent_identity_account_id":  strings.TrimSpace(credentials.AgentAccountID),
+		"agent_runtime_id":           strings.TrimSpace(credentials.AgentRuntimeID),
+		"agent_private_key":          strings.TrimSpace(credentials.AgentPrivateKey),
+		"chatgpt_user_id":            strings.TrimSpace(credentials.AgentChatGPTUserID),
+		"email":                      strings.TrimSpace(credentials.Email),
+		"plan_type":                  strings.TrimSpace(credentials.PlanType),
+		"chatgpt_account_is_fedramp": credentials.ChatGPTAccountIsFedRAMP,
+		"task_id":                    credentials.TaskID,
+		"agent_identity_state":       string(credentials.State),
+	}
+	if setLastRefresh {
+		updates["last_refresh"] = strings.TrimSpace(credentials.LastRefresh)
+	}
+	return transaction.Merge(updates)
+}
+
+func (h *Handler) agentIdentityAuthByIndex(authIndex string) (*coreauth.Auth, error) {
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" || h == nil || h.authManager == nil {
+		return nil, errAgentIdentityAuthNotFound
+	}
+	var match *coreauth.Auth
+	for _, auth := range h.authManager.List() {
+		if auth == nil || lockedAuthIndex(auth) != authIndex {
+			continue
+		}
+		if match != nil {
+			return nil, errAgentIdentityAuthConflict
+		}
+		match = auth
+	}
+	if match == nil {
+		return nil, errAgentIdentityAuthNotFound
+	}
+	return match, nil
+}
+
+func (h *Handler) agentIdentityRegistrarFor(auth *coreauth.Auth) agentIdentityRegistrar {
+	if h.agentIdentityRegistrar != nil {
+		return h.agentIdentityRegistrar(auth)
+	}
+	return codex.NewAgentIdentityClient(&http.Client{Transport: h.apiCallTransport(auth)})
+}
+
+func agentIdentityVersion() string {
+	if version := strings.TrimSpace(buildinfo.Version); version != "" {
+		return version
+	}
+	return "dev"
+}
+
+type agentIdentityStateError struct {
+	message string
+}
+
+type agentIdentityCredentialError struct {
+	cause error
+}
+
+func (err *agentIdentityCredentialError) Error() string {
+	return err.cause.Error()
+}
+
+func (err *agentIdentityCredentialError) Unwrap() error {
+	return err.cause
+}
+
+func (err *agentIdentityStateError) Error() string {
+	return err.message
+}
+
+type agentIdentityUpstreamError struct {
+	message     string
+	state       codex.ManagedAgentIdentityState
+	hasIdentity bool
+	cause       error
+}
+
+func (err *agentIdentityUpstreamError) Error() string {
+	return err.message
+}
+
+func (err *agentIdentityUpstreamError) Unwrap() error {
+	return err.cause
+}

--- a/internal/api/handlers/management/agent_identity_test.go
+++ b/internal/api/handlers/management/agent_identity_test.go
@@ -1,0 +1,845 @@
+package management
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	sdkauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestProvisionAgentIdentityAndExportCodexAuthFile(t *testing.T) {
+	h, manager, registrar := newAgentIdentityTestHandler(t)
+
+	recorder := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("provision status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	for _, secret := range []string{"access-secret", "refresh-secret"} {
+		if strings.Contains(recorder.Body.String(), secret) {
+			t.Fatalf("provision response leaked %q: %s", secret, recorder.Body.String())
+		}
+	}
+
+	updated, ok := manager.GetByID("codex-auth")
+	if !ok {
+		t.Fatal("updated auth was not found")
+	}
+	if got := updated.Metadata["access_token"]; got != "access-secret" {
+		t.Fatalf("access_token = %#v, want original token", got)
+	}
+	if got := updated.Metadata["refresh_token"]; got != "refresh-secret" {
+		t.Fatalf("refresh_token = %#v, want original token", got)
+	}
+	if got := updated.Metadata["agent_runtime_id"]; got != "runtime-1" {
+		t.Fatalf("agent_runtime_id = %#v, want runtime-1", got)
+	}
+	if got := updated.Metadata["task_id"]; got != "task-1" {
+		t.Fatalf("task_id = %#v, want task-1", got)
+	}
+	if got := updated.Metadata["agent_identity_account_id"]; got != "account-1" {
+		t.Fatalf("agent_identity_account_id = %#v, want account-1", got)
+	}
+	privateKey, _ := updated.Metadata["agent_private_key"].(string)
+	if privateKey == "" {
+		t.Fatal("agent_private_key was not persisted")
+	}
+	if strings.Contains(recorder.Body.String(), privateKey) {
+		t.Fatal("provision response leaked agent_private_key")
+	}
+
+	agentCalls, taskCalls := registrar.calls()
+	if agentCalls != 1 || taskCalls != 1 {
+		t.Fatalf("registrar calls = agent:%d task:%d, want 1 each", agentCalls, taskCalls)
+	}
+	delete(updated.Metadata, "last_refresh")
+	if _, err := manager.Update(context.Background(), updated); err != nil {
+		t.Fatalf("remove last_refresh from legacy credential: %v", err)
+	}
+
+	reusedRecorder := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if reusedRecorder.Code != http.StatusOK {
+		t.Fatalf("reused provision status = %d, want %d body=%s", reusedRecorder.Code, http.StatusOK, reusedRecorder.Body.String())
+	}
+	var reusedPayload map[string]any
+	if err := json.Unmarshal(reusedRecorder.Body.Bytes(), &reusedPayload); err != nil {
+		t.Fatalf("decode reused response: %v", err)
+	}
+	if reusedPayload["reused"] != true {
+		t.Fatalf("reused = %#v, want true", reusedPayload["reused"])
+	}
+	agentCalls, taskCalls = registrar.calls()
+	if agentCalls != 1 || taskCalls != 1 {
+		t.Fatalf("reused request called registrar: agent:%d task:%d", agentCalls, taskCalls)
+	}
+	reusedAuth, _ := manager.GetByID("codex-auth")
+	if lastRefresh, _ := reusedAuth.Metadata["last_refresh"].(string); lastRefresh == "" {
+		t.Fatal("reused legacy credential did not receive last_refresh")
+	}
+
+	exportRecorder := httptest.NewRecorder()
+	exportContext, _ := gin.CreateTestContext(exportRecorder)
+	exportContext.Request = httptest.NewRequest(http.MethodGet, "/v0/management/auth-files/agent-identity/export?auth_index=idx-codex", nil)
+	h.ExportAgentIdentityAuth(exportContext)
+
+	if exportRecorder.Code != http.StatusOK {
+		t.Fatalf("export status = %d, want %d body=%s", exportRecorder.Code, http.StatusOK, exportRecorder.Body.String())
+	}
+	if got := exportRecorder.Header().Get("Cache-Control"); got != "no-store, private" {
+		t.Fatalf("Cache-Control = %q, want no-store, private", got)
+	}
+	if got := exportRecorder.Header().Get("Content-Disposition"); got != `attachment; filename="auth.json"` {
+		t.Fatalf("Content-Disposition = %q", got)
+	}
+	if got := exportRecorder.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q, want nosniff", got)
+	}
+	if got := exportRecorder.Header().Get("Pragma"); got != "no-cache" {
+		t.Fatalf("Pragma = %q, want no-cache", got)
+	}
+	if got := exportRecorder.Header().Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+
+	var authFile codex.CodexAuthFile
+	if err := json.Unmarshal(exportRecorder.Body.Bytes(), &authFile); err != nil {
+		t.Fatalf("decode exported auth.json: %v", err)
+	}
+	if authFile.AuthMode != codex.CodexAuthModeChatGPT {
+		t.Fatalf("auth_mode = %q, want %q", authFile.AuthMode, codex.CodexAuthModeChatGPT)
+	}
+	if authFile.Tokens.AccessToken != "access-secret" || authFile.Tokens.RefreshToken != "refresh-secret" {
+		t.Fatalf("exported OAuth tokens were not preserved: %+v", authFile.Tokens)
+	}
+	if authFile.Tokens.IDToken != testAgentIdentityIDToken(t) {
+		t.Fatal("exported id_token was not preserved byte-for-byte")
+	}
+	if authFile.AgentIdentity.AgentRuntimeID != "runtime-1" || authFile.AgentIdentity.TaskID != "task-1" {
+		t.Fatalf("unexpected exported Agent Identity: %+v", authFile.AgentIdentity)
+	}
+	if authFile.AgentIdentity.AgentPrivateKey != privateKey {
+		t.Fatal("exported Agent Identity private key does not match persisted key")
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(exportRecorder.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw exported auth.json: %v", err)
+	}
+	if _, exists := raw["type"]; exists {
+		t.Fatal("exported auth.json contains internal type metadata")
+	}
+	if apiKey, exists := raw["OPENAI_API_KEY"]; !exists || string(apiKey) != "null" {
+		t.Fatalf("OPENAI_API_KEY = %s, want explicit null", apiKey)
+	}
+}
+
+func TestProvisionAgentIdentityTaskFailureCanResume(t *testing.T) {
+	h, manager, registrar := newAgentIdentityTestHandler(t)
+	registrar.setTaskError(errors.New("task service unavailable"))
+
+	failed := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if failed.Code != http.StatusBadGateway {
+		t.Fatalf("failed task status = %d, want %d body=%s", failed.Code, http.StatusBadGateway, failed.Body.String())
+	}
+	if strings.Contains(failed.Body.String(), "task service unavailable") {
+		t.Fatalf("response exposed upstream error detail: %s", failed.Body.String())
+	}
+	updated, ok := manager.GetByID("codex-auth")
+	if !ok {
+		t.Fatal("updated auth was not found")
+	}
+	if updated.Metadata["agent_runtime_id"] != "runtime-1" {
+		t.Fatalf("runtime ID was not retained after task failure: %#v", updated.Metadata["agent_runtime_id"])
+	}
+	if updated.Metadata["agent_identity_state"] != string(codex.ManagedAgentIdentityStateNeedsTask) {
+		t.Fatalf("state = %#v, want needs_task", updated.Metadata["agent_identity_state"])
+	}
+	if privateKey, _ := updated.Metadata["agent_private_key"].(string); privateKey == "" {
+		t.Fatal("private key was not retained after task failure")
+	}
+
+	registrar.setTaskError(nil)
+	resumed := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if resumed.Code != http.StatusOK {
+		t.Fatalf("resumed status = %d, want %d body=%s", resumed.Code, http.StatusOK, resumed.Body.String())
+	}
+	agentCalls, taskCalls := registrar.calls()
+	if agentCalls != 1 || taskCalls != 2 {
+		t.Fatalf("resume calls = agent:%d task:%d, want agent:1 task:2", agentCalls, taskCalls)
+	}
+}
+
+func TestProvisionAgentIdentityBlankTaskIDCanResume(t *testing.T) {
+	h, manager, registrar := newAgentIdentityTestHandler(t)
+	registrar.setTaskID(" \t")
+
+	recorder := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if recorder.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusBadGateway, recorder.Body.String())
+	}
+	updated, _ := manager.GetByID("codex-auth")
+	if got := updated.Metadata["agent_identity_state"]; got != string(codex.ManagedAgentIdentityStateNeedsTask) {
+		t.Fatalf("agent_identity_state = %#v, want needs_task", got)
+	}
+	if got := updated.Metadata["task_id"]; got != "" {
+		t.Fatalf("task_id = %#v, want empty", got)
+	}
+
+	registrar.setTaskID(" task-2 ")
+	resumed := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if resumed.Code != http.StatusOK {
+		t.Fatalf("resumed status = %d, want %d body=%s", resumed.Code, http.StatusOK, resumed.Body.String())
+	}
+	updated, _ = manager.GetByID("codex-auth")
+	if got := updated.Metadata["task_id"]; got != " task-2 " {
+		t.Fatalf("task_id = %#v, want original non-empty value", got)
+	}
+	agentCalls, taskCalls := registrar.calls()
+	if agentCalls != 1 || taskCalls != 2 {
+		t.Fatalf("resume calls = agent:%d task:%d, want agent:1 task:2", agentCalls, taskCalls)
+	}
+}
+
+func TestProvisionAgentIdentityBlankRuntimeIDCanResume(t *testing.T) {
+	h, manager, registrar := newAgentIdentityTestHandler(t)
+	registrar.setAgentRuntimeID(" \t")
+
+	failed := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if failed.Code != http.StatusBadGateway {
+		t.Fatalf("blank runtime status = %d, want %d body=%s", failed.Code, http.StatusBadGateway, failed.Body.String())
+	}
+	if strings.Contains(failed.Body.String(), "empty runtime ID") {
+		t.Fatalf("response exposed runtime validation detail: %s", failed.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(failed.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode failure response: %v", err)
+	}
+	if payload["has_agent_identity"] != false || payload["has_task"] != false {
+		t.Fatalf("unexpected failure response: %s", failed.Body.String())
+	}
+
+	pending, ok := manager.GetByID("codex-auth")
+	if !ok {
+		t.Fatal("pending auth was not found")
+	}
+	pendingKey, _ := pending.Metadata["agent_private_key"].(string)
+	if pendingKey == "" {
+		t.Fatal("blank runtime failure did not retain the generated key")
+	}
+	if got := pending.Metadata["agent_runtime_id"]; got != "" {
+		t.Fatalf("agent_runtime_id = %#v, want empty", got)
+	}
+	if got := pending.Metadata["agent_identity_state"]; got != string(codex.ManagedAgentIdentityStateError) {
+		t.Fatalf("agent_identity_state = %#v, want error", got)
+	}
+
+	registrar.setAgentRuntimeID("runtime-2")
+	resumed := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if resumed.Code != http.StatusOK {
+		t.Fatalf("resumed status = %d, want %d body=%s", resumed.Code, http.StatusOK, resumed.Body.String())
+	}
+	keys := registrar.registrationKeys()
+	if len(keys) != 2 || keys[0] != pendingKey || keys[1] != pendingKey {
+		t.Fatal("registration retry did not reuse pending key")
+	}
+	agentCalls, taskCalls := registrar.calls()
+	if agentCalls != 2 || taskCalls != 1 {
+		t.Fatalf("resume calls = agent:%d task:%d, want agent:2 task:1", agentCalls, taskCalls)
+	}
+}
+
+func TestForceProvisionPersistsKeyForRegistrationRetry(t *testing.T) {
+	h, manager, registrar := newAgentIdentityTestHandler(t)
+	initial := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if initial.Code != http.StatusOK {
+		t.Fatalf("initial provision status = %d, want %d body=%s", initial.Code, http.StatusOK, initial.Body.String())
+	}
+	initialAuth, _ := manager.GetByID("codex-auth")
+	initialKey, _ := initialAuth.Metadata["agent_private_key"].(string)
+
+	registrar.setAgentError(errors.New("registration timeout"))
+	failed := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex","force":true}`)
+	if failed.Code != http.StatusBadGateway {
+		t.Fatalf("forced provision status = %d, want %d body=%s", failed.Code, http.StatusBadGateway, failed.Body.String())
+	}
+	pendingAuth, _ := manager.GetByID("codex-auth")
+	pendingKey, _ := pendingAuth.Metadata["agent_private_key"].(string)
+	if pendingKey == "" || pendingKey == initialKey {
+		t.Fatal("force provision did not persist newly generated pending key")
+	}
+	if pendingAuth.Metadata["agent_runtime_id"] != "" {
+		t.Fatalf("pending runtime ID = %#v, want empty", pendingAuth.Metadata["agent_runtime_id"])
+	}
+
+	registrar.setAgentError(nil)
+	resumed := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if resumed.Code != http.StatusOK {
+		t.Fatalf("resumed provision status = %d, want %d body=%s", resumed.Code, http.StatusOK, resumed.Body.String())
+	}
+	keys := registrar.registrationKeys()
+	if len(keys) != 3 {
+		t.Fatalf("registration key count = %d, want 3", len(keys))
+	}
+	if keys[1] != pendingKey || keys[2] != pendingKey {
+		t.Fatal("retry did not reuse the force provision pending key")
+	}
+}
+
+func TestProvisionAgentIdentityRequiresCompleteOAuthBundle(t *testing.T) {
+	h, manager, registrar := newAgentIdentityTestHandler(t)
+	auth, ok := manager.GetByID("codex-auth")
+	if !ok {
+		t.Fatal("auth was not found")
+	}
+	auth.Metadata["refresh_token"] = ""
+	if _, err := manager.Update(context.Background(), auth); err != nil {
+		t.Fatalf("update auth: %v", err)
+	}
+
+	recorder := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusUnprocessableEntity, recorder.Body.String())
+	}
+	agentCalls, taskCalls := registrar.calls()
+	if agentCalls != 0 || taskCalls != 0 {
+		t.Fatalf("invalid credential called registrar: agent:%d task:%d", agentCalls, taskCalls)
+	}
+}
+
+func TestAgentIdentityCredentialErrorsDoNotExposeMetadataValues(t *testing.T) {
+	h, manager, registrar := newAgentIdentityTestHandler(t)
+	auth, ok := manager.GetByID("codex-auth")
+	if !ok {
+		t.Fatal("auth was not found")
+	}
+	auth.Metadata["access_token"] = "access-token-sentinel"
+	auth.Metadata["agent_private_key"] = "private-key-sentinel"
+	auth.Metadata["agent_identity_state"] = "private-key-sentinel"
+	if _, err := manager.Update(context.Background(), auth); err != nil {
+		t.Fatalf("update auth: %v", err)
+	}
+
+	provisionRecorder := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if provisionRecorder.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("provision status = %d, want %d body=%s", provisionRecorder.Code, http.StatusUnprocessableEntity, provisionRecorder.Body.String())
+	}
+
+	exportRecorder := httptest.NewRecorder()
+	exportContext, _ := gin.CreateTestContext(exportRecorder)
+	exportContext.Request = httptest.NewRequest(http.MethodGet, "/v0/management/auth-files/agent-identity/export?auth_index=idx-codex", nil)
+	h.ExportAgentIdentityAuth(exportContext)
+	if exportRecorder.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("export status = %d, want %d body=%s", exportRecorder.Code, http.StatusUnprocessableEntity, exportRecorder.Body.String())
+	}
+
+	for operation, body := range map[string]string{
+		"provision": provisionRecorder.Body.String(),
+		"export":    exportRecorder.Body.String(),
+	} {
+		if !strings.Contains(body, `"error":"invalid Codex credential"`) {
+			t.Fatalf("%s response = %s, want generic credential error", operation, body)
+		}
+		for _, secret := range []string{"access-token-sentinel", "private-key-sentinel", "refresh-secret"} {
+			if strings.Contains(body, secret) {
+				t.Fatalf("%s response leaked %q: %s", operation, secret, body)
+			}
+		}
+	}
+
+	agentCalls, taskCalls := registrar.calls()
+	if agentCalls != 0 || taskCalls != 0 {
+		t.Fatalf("invalid credential called registrar: agent:%d task:%d", agentCalls, taskCalls)
+	}
+}
+
+func TestProvisionAgentIdentityCanSkipTaskRegistration(t *testing.T) {
+	h, manager, registrar := newAgentIdentityTestHandler(t)
+
+	recorder := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex","register_task":false}`)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload["status"] != string(codex.ManagedAgentIdentityStateNeedsTask) || payload["has_task"] != false {
+		t.Fatalf("unexpected response: %s", recorder.Body.String())
+	}
+	agentCalls, taskCalls := registrar.calls()
+	if agentCalls != 1 || taskCalls != 0 {
+		t.Fatalf("registrar calls = agent:%d task:%d, want agent:1 task:0", agentCalls, taskCalls)
+	}
+	updated, _ := manager.GetByID("codex-auth")
+	if updated.Metadata["agent_identity_state"] != string(codex.ManagedAgentIdentityStateNeedsTask) {
+		t.Fatalf("state = %#v, want needs_task", updated.Metadata["agent_identity_state"])
+	}
+
+	exportRecorder := httptest.NewRecorder()
+	exportContext, _ := gin.CreateTestContext(exportRecorder)
+	exportContext.Request = httptest.NewRequest(http.MethodGet, "/v0/management/auth-files/agent-identity/export?auth_index=idx-codex", nil)
+	h.ExportAgentIdentityAuth(exportContext)
+	if exportRecorder.Code != http.StatusOK {
+		t.Fatalf("export status = %d, want %d body=%s", exportRecorder.Code, http.StatusOK, exportRecorder.Body.String())
+	}
+	var document struct {
+		AgentIdentity map[string]any `json:"agent_identity"`
+	}
+	if err := json.Unmarshal(exportRecorder.Body.Bytes(), &document); err != nil {
+		t.Fatalf("decode exported auth.json: %v", err)
+	}
+	if _, exists := document.AgentIdentity["task_id"]; exists {
+		t.Fatal("exported needs_task auth.json contains task_id")
+	}
+}
+
+func TestProvisionAgentIdentityBackfillsLegacyAccountBinding(t *testing.T) {
+	h, manager, registrar := newAgentIdentityTestHandler(t)
+	auth, _ := manager.GetByID("codex-auth")
+	keyMaterial, errKey := codex.GenerateAgentKeyMaterial()
+	if errKey != nil {
+		t.Fatalf("GenerateAgentKeyMaterial() error = %v", errKey)
+	}
+	auth.Metadata["agent_runtime_id"] = "runtime-legacy"
+	auth.Metadata["agent_private_key"] = keyMaterial.PrivateKeyPKCS8Base64
+	auth.Metadata["chatgpt_user_id"] = "user-1"
+	auth.Metadata["task_id"] = "task-legacy"
+	auth.Metadata["agent_identity_state"] = string(codex.ManagedAgentIdentityStateReady)
+	delete(auth.Metadata, "agent_identity_account_id")
+	if _, errUpdate := manager.Update(context.Background(), auth); errUpdate != nil {
+		t.Fatalf("Update() error = %v", errUpdate)
+	}
+
+	recorder := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	updated, _ := manager.GetByID("codex-auth")
+	if got := updated.Metadata["agent_identity_account_id"]; got != "account-1" {
+		t.Fatalf("agent_identity_account_id = %#v, want account-1", got)
+	}
+	agentCalls, taskCalls := registrar.calls()
+	if agentCalls != 0 || taskCalls != 0 {
+		t.Fatalf("legacy binding backfill called registrar: agent:%d task:%d", agentCalls, taskCalls)
+	}
+}
+
+func TestProvisionAgentIdentityPersistsFlatCredentialToFile(t *testing.T) {
+	authDir := t.TempDir()
+	filePath := filepath.Join(authDir, "codex-auth.json")
+	store := sdkauth.NewFileTokenStore()
+	store.SetBaseDir(authDir)
+	manager := coreauth.NewManager(store, nil, nil)
+	auth := &coreauth.Auth{
+		ID:       "codex-auth",
+		Index:    "idx-codex",
+		FileName: "codex-auth.json",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			coreauth.AttributePath:   filePath,
+			coreauth.AttributeSource: filePath,
+		},
+		Metadata: map[string]any{
+			"type":          "codex",
+			"id_token":      testAgentIdentityIDToken(t),
+			"access_token":  "access-secret",
+			"refresh_token": "refresh-secret",
+			"account_id":    "account-1",
+			"last_refresh":  "2026-07-22T10:00:00Z",
+		},
+	}
+	if _, err := manager.Register(coreauth.WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	registrar := &fakeAgentIdentityRegistrar{agentRuntimeID: "runtime-1", taskID: "task-1"}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+	h.agentIdentityRegistrar = func(*coreauth.Auth) agentIdentityRegistrar { return registrar }
+
+	recorder := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("read persisted credential: %v", err)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("decode persisted credential: %v", err)
+	}
+	for key, want := range map[string]string{
+		"access_token":              "access-secret",
+		"refresh_token":             "refresh-secret",
+		"agent_identity_account_id": "account-1",
+		"agent_runtime_id":          "runtime-1",
+		"task_id":                   "task-1",
+	} {
+		if got := metadata[key]; got != want {
+			t.Fatalf("persisted %s = %#v, want %q", key, got, want)
+		}
+	}
+	if privateKey, _ := metadata["agent_private_key"].(string); privateKey == "" {
+		t.Fatal("persisted credential is missing agent_private_key")
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filePath)
+		if err != nil {
+			t.Fatalf("stat persisted credential: %v", err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("credential mode = %o, want 600", got)
+		}
+	}
+}
+
+func TestProvisionAgentIdentitySerializesSameAuthIndex(t *testing.T) {
+	h, _, registrar := newAgentIdentityTestHandler(t)
+
+	const requestCount = 12
+	statuses := make(chan int, requestCount)
+	var waitGroup sync.WaitGroup
+	for range requestCount {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			recorder := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+			statuses <- recorder.Code
+		}()
+	}
+	waitGroup.Wait()
+	close(statuses)
+	for status := range statuses {
+		if status != http.StatusOK {
+			t.Errorf("concurrent provision status = %d, want %d", status, http.StatusOK)
+		}
+	}
+	agentCalls, taskCalls := registrar.calls()
+	if agentCalls != 1 || taskCalls != 1 {
+		t.Fatalf("concurrent registrar calls = agent:%d task:%d, want 1 each", agentCalls, taskCalls)
+	}
+}
+
+func TestProvisionAgentIdentityRequiresDurableStore(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	registerAuthForLookupTest(t, manager, newAgentIdentityTestAuth(t))
+	registrar := &fakeAgentIdentityRegistrar{agentRuntimeID: "runtime-1", taskID: "task-1"}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+	h.agentIdentityRegistrar = func(*coreauth.Auth) agentIdentityRegistrar { return registrar }
+
+	recorder := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusServiceUnavailable, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "durable auth store unavailable") {
+		t.Fatalf("unexpected response body: %s", recorder.Body.String())
+	}
+	agentCalls, taskCalls := registrar.calls()
+	if agentCalls != 0 || taskCalls != 0 {
+		t.Fatalf("registrar calls = agent:%d task:%d, want zero", agentCalls, taskCalls)
+	}
+}
+
+func TestProvisionAgentIdentityRejectsChangedAccountBindingWithoutForce(t *testing.T) {
+	h, manager, registrar := newAgentIdentityTestHandler(t)
+	initial := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if initial.Code != http.StatusOK {
+		t.Fatalf("initial status = %d, want %d body=%s", initial.Code, http.StatusOK, initial.Body.String())
+	}
+
+	auth, _ := manager.GetByID("codex-auth")
+	auth.Metadata["account_id"] = "account-2"
+	if _, errUpdate := manager.Update(context.Background(), auth); errUpdate != nil {
+		t.Fatalf("Update() error = %v", errUpdate)
+	}
+
+	conflict := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if conflict.Code != http.StatusConflict {
+		t.Fatalf("changed binding status = %d, want %d body=%s", conflict.Code, http.StatusConflict, conflict.Body.String())
+	}
+	if !strings.Contains(conflict.Body.String(), "different ChatGPT account") {
+		t.Fatalf("unexpected binding conflict response: %s", conflict.Body.String())
+	}
+	agentCalls, taskCalls := registrar.calls()
+	if agentCalls != 1 || taskCalls != 1 {
+		t.Fatalf("binding conflict called registrar: agent:%d task:%d", agentCalls, taskCalls)
+	}
+
+	forced := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex","force":true}`)
+	if forced.Code != http.StatusOK {
+		t.Fatalf("forced status = %d, want %d body=%s", forced.Code, http.StatusOK, forced.Body.String())
+	}
+	rotated, _ := manager.GetByID("codex-auth")
+	if got := rotated.Metadata["account_id"]; got != "account-2" {
+		t.Fatalf("OAuth account_id = %#v, want account-2", got)
+	}
+	if got := rotated.Metadata["agent_identity_account_id"]; got != "account-2" {
+		t.Fatalf("Agent Identity account binding = %#v, want account-2", got)
+	}
+}
+
+func TestProvisionAgentIdentityPostPersistHookCanReenterManager(t *testing.T) {
+	h, manager, _ := newAgentIdentityTestHandler(t)
+	hookCalled := make(chan struct{})
+	h.SetPostAuthPersistHook(func(ctx context.Context, auth *coreauth.Auth) error {
+		_, errMerge := manager.MergeMetadataByIndex(ctx, auth.Index, map[string]any{"post_hook_marker": "set"})
+		close(hookCalled)
+		return errMerge
+	})
+
+	type provisionResponse struct {
+		recorder *httptest.ResponseRecorder
+	}
+	done := make(chan provisionResponse, 1)
+	go func() {
+		done <- provisionResponse{recorder: performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)}
+	}()
+	select {
+	case <-hookCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("post-auth persist hook deadlocked while re-entering manager")
+	}
+	select {
+	case response := <-done:
+		if response.recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d body=%s", response.recorder.Code, http.StatusOK, response.recorder.Body.String())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("provision request did not finish after post-auth persist hook")
+	}
+	updated, _ := manager.GetByID("codex-auth")
+	if got := updated.Metadata["post_hook_marker"]; got != "set" {
+		t.Fatalf("post_hook_marker = %#v, want set", got)
+	}
+}
+
+func TestProvisionAgentIdentityReportsPostPersistHookFailureAfterSuccess(t *testing.T) {
+	h, _, _ := newAgentIdentityTestHandler(t)
+	h.SetPostAuthPersistHook(func(context.Context, *coreauth.Auth) error {
+		return errors.New("hook unavailable")
+	})
+
+	recorder := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusInternalServerError, recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), "hook unavailable") {
+		t.Fatalf("response leaked post-persist hook detail: %s", recorder.Body.String())
+	}
+}
+
+func TestProvisionAgentIdentityPreservesUpstreamErrorWhenPostPersistHookFails(t *testing.T) {
+	h, _, registrar := newAgentIdentityTestHandler(t)
+	registrar.setTaskError(errors.New("task unavailable"))
+	h.SetPostAuthPersistHook(func(context.Context, *coreauth.Auth) error {
+		return errors.New("hook unavailable")
+	})
+
+	recorder := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if recorder.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want primary upstream status %d body=%s", recorder.Code, http.StatusBadGateway, recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), "task unavailable") || strings.Contains(recorder.Body.String(), "hook unavailable") {
+		t.Fatalf("response leaked internal error detail: %s", recorder.Body.String())
+	}
+}
+
+type failNthAgentIdentityStore struct {
+	store  *memoryAuthStore
+	mu     sync.Mutex
+	calls  int
+	failAt int
+}
+
+func (s *failNthAgentIdentityStore) List(ctx context.Context) ([]*coreauth.Auth, error) {
+	return s.store.List(ctx)
+}
+
+func (s *failNthAgentIdentityStore) Save(ctx context.Context, auth *coreauth.Auth) (string, error) {
+	s.mu.Lock()
+	s.calls++
+	call := s.calls
+	s.mu.Unlock()
+	if call == s.failAt {
+		return "", errors.New("injected save failure")
+	}
+	return s.store.Save(ctx, auth)
+}
+
+func (s *failNthAgentIdentityStore) Delete(ctx context.Context, id string) error {
+	return s.store.Delete(ctx, id)
+}
+
+func TestProvisionAgentIdentityDoesNotPublishFailedFinalMerge(t *testing.T) {
+	// Registration persists the initial OAuth auth, followed by pending key,
+	// registered runtime, and ready task snapshots.
+	store := &failNthAgentIdentityStore{store: &memoryAuthStore{}, failAt: 4}
+	manager := coreauth.NewManager(store, nil, nil)
+	registerAuthForLookupTest(t, manager, newAgentIdentityTestAuth(t))
+	registrar := &fakeAgentIdentityRegistrar{agentRuntimeID: "runtime-1", taskID: "task-1"}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+	h.agentIdentityRegistrar = func(*coreauth.Auth) agentIdentityRegistrar { return registrar }
+
+	recorder := performAgentIdentityProvision(t, h, `{"auth_index":"idx-codex"}`)
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusInternalServerError, recorder.Body.String())
+	}
+	updated, _ := manager.GetByID("codex-auth")
+	if got := updated.Metadata["agent_runtime_id"]; got != "runtime-1" {
+		t.Fatalf("agent_runtime_id = %#v, want durable runtime-1", got)
+	}
+	if got := updated.Metadata["agent_identity_state"]; got != string(codex.ManagedAgentIdentityStateNeedsTask) {
+		t.Fatalf("agent_identity_state = %#v, want needs_task", got)
+	}
+	if got := updated.Metadata["task_id"]; got != "" {
+		t.Fatalf("task_id = %#v after failed Save, want empty", got)
+	}
+}
+
+type fakeAgentIdentityRegistrar struct {
+	mu             sync.Mutex
+	agentCalls     int
+	taskCalls      int
+	agentRuntimeID string
+	taskID         string
+	agentErr       error
+	taskErr        error
+	registeredKeys []string
+}
+
+func (registrar *fakeAgentIdentityRegistrar) RegisterAgent(_ context.Context, registration codex.AgentRegistration) (string, error) {
+	registrar.mu.Lock()
+	defer registrar.mu.Unlock()
+	registrar.agentCalls++
+	registrar.registeredKeys = append(registrar.registeredKeys, registration.KeyMaterial.PrivateKeyPKCS8Base64)
+	if registration.AccessToken != "access-secret" {
+		return "", errors.New("unexpected access token")
+	}
+	if registration.KeyMaterial.PrivateKeyPKCS8Base64 == "" || registration.KeyMaterial.PublicKeySSH == "" {
+		return "", errors.New("missing key material")
+	}
+	return registrar.agentRuntimeID, registrar.agentErr
+}
+
+func (registrar *fakeAgentIdentityRegistrar) RegisterTask(_ context.Context, key codex.AgentIdentityKey) (string, error) {
+	registrar.mu.Lock()
+	defer registrar.mu.Unlock()
+	registrar.taskCalls++
+	if key.AgentRuntimeID != registrar.agentRuntimeID || key.PrivateKeyPKCS8Base64 == "" {
+		return "", errors.New("unexpected Agent Identity key")
+	}
+	return registrar.taskID, registrar.taskErr
+}
+
+func (registrar *fakeAgentIdentityRegistrar) calls() (int, int) {
+	registrar.mu.Lock()
+	defer registrar.mu.Unlock()
+	return registrar.agentCalls, registrar.taskCalls
+}
+
+func (registrar *fakeAgentIdentityRegistrar) setTaskError(err error) {
+	registrar.mu.Lock()
+	registrar.taskErr = err
+	registrar.mu.Unlock()
+}
+
+func (registrar *fakeAgentIdentityRegistrar) setTaskID(taskID string) {
+	registrar.mu.Lock()
+	registrar.taskID = taskID
+	registrar.mu.Unlock()
+}
+
+func (registrar *fakeAgentIdentityRegistrar) setAgentError(err error) {
+	registrar.mu.Lock()
+	registrar.agentErr = err
+	registrar.mu.Unlock()
+}
+
+func (registrar *fakeAgentIdentityRegistrar) setAgentRuntimeID(runtimeID string) {
+	registrar.mu.Lock()
+	registrar.agentRuntimeID = runtimeID
+	registrar.mu.Unlock()
+}
+
+func (registrar *fakeAgentIdentityRegistrar) registrationKeys() []string {
+	registrar.mu.Lock()
+	defer registrar.mu.Unlock()
+	return append([]string(nil), registrar.registeredKeys...)
+}
+
+func newAgentIdentityTestHandler(t *testing.T) (*Handler, *coreauth.Manager, *fakeAgentIdentityRegistrar) {
+	t.Helper()
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	registerAuthForLookupTest(t, manager, newAgentIdentityTestAuth(t))
+	registrar := &fakeAgentIdentityRegistrar{agentRuntimeID: "runtime-1", taskID: "task-1"}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+	h.agentIdentityRegistrar = func(*coreauth.Auth) agentIdentityRegistrar { return registrar }
+	return h, manager, registrar
+}
+
+func newAgentIdentityTestAuth(t *testing.T) *coreauth.Auth {
+	t.Helper()
+	return &coreauth.Auth{
+		ID:       "codex-auth",
+		Index:    "idx-codex",
+		FileName: "codex-auth.json",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{
+			"type":          "codex",
+			"id_token":      testAgentIdentityIDToken(t),
+			"access_token":  "access-secret",
+			"refresh_token": "refresh-secret",
+			"account_id":    "account-1",
+			"last_refresh":  "2026-07-22T10:00:00Z",
+			"unrelated":     "preserve-me",
+		},
+	}
+}
+
+func performAgentIdentityProvision(t *testing.T, h *Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	request := httptest.NewRequest(http.MethodPost, "/v0/management/auth-files/agent-identity/provision", strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	ctx.Request = request
+	h.ProvisionAgentIdentity(ctx)
+	return recorder
+}
+
+func testAgentIdentityIDToken(t *testing.T) string {
+	t.Helper()
+	header, err := json.Marshal(map[string]any{"alg": "none", "typ": "JWT"})
+	if err != nil {
+		t.Fatalf("marshal JWT header: %v", err)
+	}
+	payload, err := json.Marshal(map[string]any{
+		"email": "owner@example.com",
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id":         "account-1",
+			"chatgpt_user_id":            "user-1",
+			"chatgpt_plan_type":          "pro",
+			"chatgpt_account_is_fedramp": false,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal JWT payload: %v", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(header) + "." + base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+}

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -60,6 +60,7 @@ type Handler struct {
 	pluginStoreHTTPClient   pluginstore.HTTPDoer
 	pluginReleaseCacheMu    sync.Mutex
 	pluginReleaseCache      map[string]pluginReleaseCacheEntry
+	agentIdentityRegistrar  agentIdentityRegistrarFactory
 }
 
 type configReloadSnapshot struct {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -945,6 +945,8 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/auth-files/models", s.mgmt.GetAuthFileModels)
 		mgmt.GET("/model-definitions/:channel", s.mgmt.GetStaticModelDefinitions)
 		mgmt.GET("/auth-files/download", s.mgmt.DownloadAuthFile)
+		mgmt.POST("/auth-files/agent-identity/provision", s.mgmt.ProvisionAgentIdentity)
+		mgmt.GET("/auth-files/agent-identity/export", s.mgmt.ExportAgentIdentityAuth)
 		mgmt.POST("/auth-files", s.mgmt.UploadAuthFile)
 		mgmt.DELETE("/auth-files", s.mgmt.DeleteAuthFile)
 		mgmt.PATCH("/auth-files/status", s.mgmt.PatchAuthFileStatus)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -496,6 +496,51 @@ func TestManagementResponseExposesPluginSupportHeaderForCORS(t *testing.T) {
 	}
 }
 
+func TestAgentIdentityManagementRoutesAreRegisteredAndProtected(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "test-management-key")
+	server := newTestServer(t)
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{
+			name:   "provision",
+			method: http.MethodPost,
+			path:   "/v0/management/auth-files/agent-identity/provision",
+			body:   `{}`,
+		},
+		{
+			name:   "export",
+			method: http.MethodGet,
+			path:   "/v0/management/auth-files/agent-identity/export",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			unauthorizedRequest := httptest.NewRequest(test.method, test.path, strings.NewReader(test.body))
+			unauthorizedRequest.Header.Set("Content-Type", "application/json")
+			unauthorizedRecorder := httptest.NewRecorder()
+			server.engine.ServeHTTP(unauthorizedRecorder, unauthorizedRequest)
+			if unauthorizedRecorder.Code != http.StatusUnauthorized {
+				t.Fatalf("unauthorized status = %d, want %d body=%s", unauthorizedRecorder.Code, http.StatusUnauthorized, unauthorizedRecorder.Body.String())
+			}
+
+			authorizedRequest := httptest.NewRequest(test.method, test.path, strings.NewReader(test.body))
+			authorizedRequest.Header.Set("Authorization", "Bearer test-management-key")
+			authorizedRequest.Header.Set("Content-Type", "application/json")
+			authorizedRecorder := httptest.NewRecorder()
+			server.engine.ServeHTTP(authorizedRecorder, authorizedRequest)
+			if authorizedRecorder.Code != http.StatusBadRequest {
+				t.Fatalf("authorized status = %d, want %d body=%s", authorizedRecorder.Code, http.StatusBadRequest, authorizedRecorder.Body.String())
+			}
+		})
+	}
+}
+
 func TestOAuthCallbackRouteSkipsManagementKeyMiddleware(t *testing.T) {
 	t.Setenv("MANAGEMENT_PASSWORD", "test-management-key")
 

--- a/internal/auth/codex/agent_identity.go
+++ b/internal/auth/codex/agent_identity.go
@@ -1,0 +1,177 @@
+package codex
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha512"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"unicode/utf8"
+
+	"golang.org/x/crypto/curve25519"
+	"golang.org/x/crypto/nacl/box"
+)
+
+const sshEd25519KeyType = "ssh-ed25519"
+
+const (
+	agentIdentityKeySeedBytes         = 64
+	agentIdentityKeyDerivationContext = "codex-agent-identity-ed25519-v1"
+)
+
+// AgentKeyMaterial contains a registered agent's durable private key and its public form.
+type AgentKeyMaterial struct {
+	PrivateKeyPKCS8Base64 string
+	PublicKeySSH          string
+}
+
+// AgentIdentityKey identifies the durable signing material used for task registration.
+type AgentIdentityKey struct {
+	AgentRuntimeID        string
+	PrivateKeyPKCS8Base64 string
+}
+
+// GenerateAgentKeyMaterial creates an Ed25519 key pair in Codex-compatible encodings.
+func GenerateAgentKeyMaterial() (AgentKeyMaterial, error) {
+	return generateAgentKeyMaterial(rand.Reader)
+}
+
+func generateAgentKeyMaterial(random io.Reader) (AgentKeyMaterial, error) {
+	seedMaterial := make([]byte, agentIdentityKeySeedBytes)
+	if _, err := io.ReadFull(random, seedMaterial); err != nil {
+		return AgentKeyMaterial{}, fmt.Errorf("generate Agent Identity key: %w", err)
+	}
+	digest := sha512.New()
+	_, _ = digest.Write([]byte(agentIdentityKeyDerivationContext))
+	_, _ = digest.Write(seedMaterial)
+	privateKey := ed25519.NewKeyFromSeed(digest.Sum(nil)[:ed25519.SeedSize])
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+	privateKeyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return AgentKeyMaterial{}, fmt.Errorf("marshal Agent Identity private key: %w", err)
+	}
+	return AgentKeyMaterial{
+		PrivateKeyPKCS8Base64: base64.StdEncoding.EncodeToString(privateKeyDER),
+		PublicKeySSH:          encodeSSHEd25519PublicKey(publicKey),
+	}, nil
+}
+
+// ParseAgentIdentityPrivateKey decodes a standard-base64 PKCS#8 Ed25519 private key.
+func ParseAgentIdentityPrivateKey(encoded string) (ed25519.PrivateKey, error) {
+	privateKeyDER, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, errors.New("Agent Identity private key is not valid standard base64")
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(privateKeyDER)
+	if err != nil {
+		return nil, errors.New("Agent Identity private key is not valid PKCS#8")
+	}
+	privateKey, ok := parsed.(ed25519.PrivateKey)
+	if !ok || len(privateKey) != ed25519.PrivateKeySize {
+		return nil, errors.New("Agent Identity private key is not Ed25519")
+	}
+	return append(ed25519.PrivateKey(nil), privateKey...), nil
+}
+
+// PublicKeySSHFromPrivateKey derives the OpenSSH public key for a stored private key.
+func PublicKeySSHFromPrivateKey(privateKeyPKCS8Base64 string) (string, error) {
+	privateKey, err := ParseAgentIdentityPrivateKey(privateKeyPKCS8Base64)
+	if err != nil {
+		return "", err
+	}
+	publicKey, ok := privateKey.Public().(ed25519.PublicKey)
+	if !ok {
+		return "", errors.New("Agent Identity public key is not Ed25519")
+	}
+	return encodeSSHEd25519PublicKey(publicKey), nil
+}
+
+func validateAgentKeyMaterial(keyMaterial AgentKeyMaterial) error {
+	if keyMaterial.PrivateKeyPKCS8Base64 == "" {
+		return errors.New("Agent Identity private key is missing")
+	}
+	if keyMaterial.PublicKeySSH == "" {
+		return errors.New("Agent Identity public key is missing")
+	}
+	derivedPublicKey, err := PublicKeySSHFromPrivateKey(keyMaterial.PrivateKeyPKCS8Base64)
+	if err != nil {
+		return err
+	}
+	if derivedPublicKey != keyMaterial.PublicKeySSH {
+		return errors.New("Agent Identity public and private keys do not match")
+	}
+	return nil
+}
+
+func encodeSSHEd25519PublicKey(publicKey ed25519.PublicKey) string {
+	blob := make([]byte, 0, 4+len(sshEd25519KeyType)+4+ed25519.PublicKeySize)
+	blob = appendSSHString(blob, []byte(sshEd25519KeyType))
+	blob = appendSSHString(blob, publicKey)
+	return sshEd25519KeyType + " " + base64.StdEncoding.EncodeToString(blob)
+}
+
+func appendSSHString(destination []byte, value []byte) []byte {
+	length := make([]byte, 4)
+	binary.BigEndian.PutUint32(length, uint32(len(value)))
+	destination = append(destination, length...)
+	return append(destination, value...)
+}
+
+func signAgentTaskRegistration(key AgentIdentityKey, timestamp string) (string, error) {
+	runtimeID := key.AgentRuntimeID
+	if runtimeID == "" {
+		return "", errors.New("Agent Identity runtime ID is missing")
+	}
+	if timestamp == "" {
+		return "", errors.New("Agent Identity task registration timestamp is missing")
+	}
+	privateKey, err := ParseAgentIdentityPrivateKey(key.PrivateKeyPKCS8Base64)
+	if err != nil {
+		return "", err
+	}
+	signature := ed25519.Sign(privateKey, []byte(runtimeID+":"+timestamp))
+	return base64.StdEncoding.EncodeToString(signature), nil
+}
+
+func decryptAgentTaskID(key AgentIdentityKey, encoded string) (string, error) {
+	privateKey, err := ParseAgentIdentityPrivateKey(key.PrivateKeyPKCS8Base64)
+	if err != nil {
+		return "", err
+	}
+	ciphertext, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", errors.New("encrypted Agent Identity task ID is not valid standard base64")
+	}
+	curvePublicKey, curvePrivateKey, err := curve25519KeyPair(privateKey)
+	if err != nil {
+		return "", err
+	}
+	plaintext, ok := box.OpenAnonymous(nil, ciphertext, &curvePublicKey, &curvePrivateKey)
+	if !ok {
+		return "", errors.New("failed to decrypt Agent Identity task ID")
+	}
+	if !utf8.Valid(plaintext) {
+		return "", errors.New("decrypted Agent Identity task ID is not valid UTF-8")
+	}
+	return string(plaintext), nil
+}
+
+func curve25519KeyPair(privateKey ed25519.PrivateKey) ([32]byte, [32]byte, error) {
+	digest := sha512.Sum512(privateKey.Seed())
+	var curvePrivateKey [32]byte
+	copy(curvePrivateKey[:], digest[:32])
+	curvePrivateKey[0] &= 248
+	curvePrivateKey[31] &= 127
+	curvePrivateKey[31] |= 64
+	publicKeyBytes, err := curve25519.X25519(curvePrivateKey[:], curve25519.Basepoint)
+	if err != nil {
+		return [32]byte{}, [32]byte{}, errors.New("failed to derive Agent Identity Curve25519 public key")
+	}
+	var curvePublicKey [32]byte
+	copy(curvePublicKey[:], publicKeyBytes)
+	return curvePublicKey, curvePrivateKey, nil
+}

--- a/internal/auth/codex/agent_identity_client.go
+++ b/internal/auth/codex/agent_identity_client.go
@@ -1,0 +1,294 @@
+package codex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	agentIdentityAuthAPIBaseURL      = "https://auth.openai.com/api/accounts"
+	agentRegistrationTimeout         = 15 * time.Second
+	agentTaskRegistrationTimeout     = 30 * time.Second
+	maxAgentRegistrationAttempts     = 3
+	maxAgentRegistrationResponseSize = 64 * 1024
+)
+
+// AgentIdentityResponsesCapability is the capability advertised by Codex clients.
+const AgentIdentityResponsesCapability = "responsesapi"
+
+// AgentBillOfMaterials identifies the client registering an Agent Identity.
+type AgentBillOfMaterials struct {
+	AgentVersion    string `json:"agent_version"`
+	AgentHarnessID  string `json:"agent_harness_id"`
+	RunningLocation string `json:"running_location"`
+}
+
+// AgentRegistration contains the credentials and metadata for initial registration.
+type AgentRegistration struct {
+	AccessToken      string
+	IsFedRAMPAccount bool
+	KeyMaterial      AgentKeyMaterial
+	BillOfMaterials  AgentBillOfMaterials
+}
+
+// AgentIdentityClient registers Agent Identities and their task-scoped credentials.
+type AgentIdentityClient struct {
+	httpClient *http.Client
+	baseURL    string
+	now        func() time.Time
+}
+
+// AgentIdentityHTTPError reports an upstream status without retaining a secret-bearing body.
+type AgentIdentityHTTPError struct {
+	operation  string
+	statusCode int
+}
+
+func (err *AgentIdentityHTTPError) Error() string {
+	return fmt.Sprintf("%s failed with status %d", err.operation, err.statusCode)
+}
+
+// StatusCode returns the HTTP status received from the registration service.
+func (err *AgentIdentityHTTPError) StatusCode() int {
+	if err == nil {
+		return 0
+	}
+	return err.statusCode
+}
+
+// NewAgentIdentityClient creates a client pinned to OpenAI's production registration service.
+// The supplied HTTP client controls proxy and transport behavior.
+func NewAgentIdentityClient(httpClient *http.Client) *AgentIdentityClient {
+	return newAgentIdentityClient(httpClient, agentIdentityAuthAPIBaseURL)
+}
+
+func newAgentIdentityClient(httpClient *http.Client, baseURL string) *AgentIdentityClient {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &AgentIdentityClient{
+		httpClient: httpClient,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		now:        time.Now,
+	}
+}
+
+// RegisterAgent registers a generated public key and returns its durable runtime ID.
+func (client *AgentIdentityClient) RegisterAgent(ctx context.Context, registration AgentRegistration) (string, error) {
+	if client == nil || client.httpClient == nil {
+		return "", errors.New("Agent Identity client is not initialized")
+	}
+	if ctx == nil {
+		return "", errors.New("Agent Identity registration context is nil")
+	}
+	if strings.TrimSpace(registration.AccessToken) == "" {
+		return "", errors.New("Agent Identity registration access token is missing")
+	}
+	if err := validateAgentKeyMaterial(registration.KeyMaterial); err != nil {
+		return "", err
+	}
+	if err := validateAgentBillOfMaterials(registration.BillOfMaterials); err != nil {
+		return "", err
+	}
+
+	requestBody := registerAgentRequest{
+		BillOfMaterials: registration.BillOfMaterials,
+		AgentPublicKey:  registration.KeyMaterial.PublicKeySSH,
+		Capabilities:    []string{AgentIdentityResponsesCapability},
+		TTL:             nil,
+	}
+	endpoint := client.baseURL + "/v1/agent/register"
+	return retryAgentIdentityRegistration(ctx, func() (string, error) {
+		requestContext, cancel := context.WithTimeout(ctx, agentRegistrationTimeout)
+		defer cancel()
+		req, err := newJSONRequest(requestContext, endpoint, requestBody)
+		if err != nil {
+			return "", fmt.Errorf("build Agent Identity registration request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+registration.AccessToken)
+		if registration.IsFedRAMPAccount {
+			req.Header.Set("X-OpenAI-Fedramp", "true")
+		}
+
+		var response registerAgentResponse
+		if err := client.doRegistration(req, "Agent Identity registration", &response); err != nil {
+			return "", err
+		}
+		runtimeID := response.AgentRuntimeID
+		if runtimeID == "" {
+			return "", errors.New("Agent Identity registration response omitted agent_runtime_id")
+		}
+		return runtimeID, nil
+	})
+}
+
+// RegisterTask signs and registers a task for a durable Agent Identity key.
+func (client *AgentIdentityClient) RegisterTask(ctx context.Context, key AgentIdentityKey) (string, error) {
+	if client == nil || client.httpClient == nil {
+		return "", errors.New("Agent Identity client is not initialized")
+	}
+	if ctx == nil {
+		return "", errors.New("Agent Identity task registration context is nil")
+	}
+	runtimeID := key.AgentRuntimeID
+	if runtimeID == "" {
+		return "", errors.New("Agent Identity runtime ID is missing")
+	}
+	endpoint := client.baseURL + "/v1/agent/" + url.PathEscape(runtimeID) + "/task/register"
+	return retryAgentIdentityRegistration(ctx, func() (string, error) {
+		timestamp := client.now().UTC().Format(time.RFC3339)
+		signature, err := signAgentTaskRegistration(key, timestamp)
+		if err != nil {
+			return "", err
+		}
+		requestBody := registerTaskRequest{Timestamp: timestamp, Signature: signature}
+		requestContext, cancel := context.WithTimeout(ctx, agentTaskRegistrationTimeout)
+		defer cancel()
+		req, err := newJSONRequest(requestContext, endpoint, requestBody)
+		if err != nil {
+			return "", fmt.Errorf("build Agent Identity task registration request: %w", err)
+		}
+
+		var response registerTaskResponse
+		if err := client.doRegistration(req, "Agent Identity task registration", &response); err != nil {
+			return "", err
+		}
+		if taskID, ok := firstPresent(response.TaskID, response.TaskIDCamel); ok {
+			return taskID, nil
+		}
+		encryptedTaskID, ok := firstPresent(response.EncryptedTaskID, response.EncryptedTaskIDCamel)
+		if !ok {
+			return "", errors.New("Agent Identity task registration response omitted task ID")
+		}
+		return decryptAgentTaskID(key, encryptedTaskID)
+	})
+}
+
+// IsRetryableAgentIdentityRegistrationError reports transient upstream and transport failures.
+func IsRetryableAgentIdentityRegistrationError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var httpError *AgentIdentityHTTPError
+	if errors.As(err, &httpError) {
+		return httpError.statusCode == http.StatusTooManyRequests ||
+			(httpError.statusCode >= http.StatusInternalServerError && httpError.statusCode <= 599)
+	}
+	var urlError *url.Error
+	return errors.As(err, &urlError)
+}
+
+func retryAgentIdentityRegistration(ctx context.Context, operation func() (string, error)) (string, error) {
+	var lastErr error
+	for attempt := 0; attempt < maxAgentRegistrationAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		value, err := operation()
+		if err == nil {
+			return value, nil
+		}
+		lastErr = err
+		if !IsRetryableAgentIdentityRegistrationError(err) {
+			break
+		}
+	}
+	return "", lastErr
+}
+
+type registerAgentRequest struct {
+	BillOfMaterials AgentBillOfMaterials `json:"abom"`
+	AgentPublicKey  string               `json:"agent_public_key"`
+	Capabilities    []string             `json:"capabilities"`
+	TTL             *uint64              `json:"ttl"`
+}
+
+type registerAgentResponse struct {
+	AgentRuntimeID string `json:"agent_runtime_id"`
+}
+
+type registerTaskRequest struct {
+	Timestamp string `json:"timestamp"`
+	Signature string `json:"signature"`
+}
+
+type registerTaskResponse struct {
+	TaskID               *string `json:"task_id"`
+	TaskIDCamel          *string `json:"taskId"`
+	EncryptedTaskID      *string `json:"encrypted_task_id"`
+	EncryptedTaskIDCamel *string `json:"encryptedTaskId"`
+}
+
+func (client *AgentIdentityClient) doRegistration(req *http.Request, operation string, target any) error {
+	resp, err := client.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s request failed: %w", operation, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxAgentRegistrationResponseSize))
+		return &AgentIdentityHTTPError{operation: operation, statusCode: resp.StatusCode}
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxAgentRegistrationResponseSize+1))
+	if err != nil {
+		return fmt.Errorf("read %s response: %w", operation, err)
+	}
+	if len(data) > maxAgentRegistrationResponseSize {
+		return fmt.Errorf("%s response exceeds %d bytes", operation, maxAgentRegistrationResponseSize)
+	}
+	if !utf8.Valid(data) {
+		return fmt.Errorf("decode %s response: response is not valid UTF-8", operation)
+	}
+	if err := json.Unmarshal(data, target); err != nil {
+		return fmt.Errorf("decode %s response: %w", operation, err)
+	}
+	return nil
+}
+
+func newJSONRequest(ctx context.Context, endpoint string, body any) (*http.Request, error) {
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(encoded))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+func validateAgentBillOfMaterials(materials AgentBillOfMaterials) error {
+	if strings.TrimSpace(materials.AgentVersion) == "" {
+		return errors.New("Agent Identity agent version is missing")
+	}
+	if strings.TrimSpace(materials.AgentHarnessID) == "" {
+		return errors.New("Agent Identity harness ID is missing")
+	}
+	if strings.TrimSpace(materials.RunningLocation) == "" {
+		return errors.New("Agent Identity running location is missing")
+	}
+	return nil
+}
+
+func firstPresent(values ...*string) (string, bool) {
+	for _, value := range values {
+		if value != nil {
+			return *value, true
+		}
+	}
+	return "", false
+}

--- a/internal/auth/codex/agent_identity_client_test.go
+++ b/internal/auth/codex/agent_identity_client_test.go
@@ -1,0 +1,461 @@
+package codex
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/nacl/box"
+)
+
+func TestAgentIdentityClientRegisterAgent(t *testing.T) {
+	keyMaterial := deterministicAgentKeyMaterial(t, 0x33)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPost || req.URL.Path != "/v1/agent/register" {
+			t.Errorf("request = %s %s", req.Method, req.URL.Path)
+		}
+		if got := req.Header.Get("Authorization"); got != "Bearer access-token" {
+			t.Errorf("Authorization header is incorrect")
+		}
+		if got := req.Header.Get("X-OpenAI-Fedramp"); got != "true" {
+			t.Errorf("X-OpenAI-Fedramp = %q, want true", got)
+		}
+		if got := req.Header.Get("Accept"); got != "application/json" {
+			t.Errorf("Accept = %q", got)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if value, exists := body["ttl"]; !exists || value != nil {
+			t.Errorf("ttl = %#v, exists = %t; want null", value, exists)
+		}
+		if body["agent_public_key"] != keyMaterial.PublicKeySSH {
+			t.Errorf("agent_public_key does not match generated key")
+		}
+		capabilities, ok := body["capabilities"].([]any)
+		if !ok || len(capabilities) != 1 || capabilities[0] != AgentIdentityResponsesCapability {
+			t.Errorf("capabilities = %#v", body["capabilities"])
+		}
+		bill, ok := body["abom"].(map[string]any)
+		if !ok || bill["agent_harness_id"] != "codex-cli" || bill["running_location"] != "cli-windows" {
+			t.Errorf("abom = %#v", body["abom"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"agent_runtime_id":"runtime-123"}`)
+	}))
+	defer server.Close()
+
+	client := newAgentIdentityClient(server.Client(), server.URL)
+	runtimeID, err := client.RegisterAgent(context.Background(), AgentRegistration{
+		AccessToken:      "access-token",
+		IsFedRAMPAccount: true,
+		KeyMaterial:      keyMaterial,
+		BillOfMaterials: AgentBillOfMaterials{
+			AgentVersion:    "7.2.94",
+			AgentHarnessID:  "codex-cli",
+			RunningLocation: "cli-windows",
+		},
+	})
+	if err != nil {
+		t.Fatalf("RegisterAgent() error = %v", err)
+	}
+	if runtimeID != "runtime-123" {
+		t.Fatalf("runtime ID = %q", runtimeID)
+	}
+}
+
+func TestAgentIdentityClientRegisterAgentOmitsFedRAMPHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if _, exists := req.Header["X-Openai-Fedramp"]; exists {
+			t.Errorf("FedRAMP header must be omitted for non-FedRAMP accounts")
+		}
+		_, _ = io.WriteString(w, `{"agent_runtime_id":"runtime-123"}`)
+	}))
+	defer server.Close()
+	client := newAgentIdentityClient(server.Client(), server.URL)
+	_, err := client.RegisterAgent(context.Background(), validAgentRegistration(t))
+	if err != nil {
+		t.Fatalf("RegisterAgent() error = %v", err)
+	}
+}
+
+func TestAgentIdentityClientRegisterTaskSignsRequest(t *testing.T) {
+	keyMaterial := deterministicAgentKeyMaterial(t, 0x44)
+	privateKey, err := ParseAgentIdentityPrivateKey(keyMaterial.PrivateKeyPKCS8Base64)
+	if err != nil {
+		t.Fatalf("parse private key: %v", err)
+	}
+	fixedTime := time.Date(2026, 7, 22, 12, 34, 56, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPost || req.URL.Path != "/v1/agent/runtime-123/task/register" {
+			t.Errorf("request = %s %s", req.Method, req.URL.Path)
+		}
+		if got := req.Header.Get("Authorization"); got != "" {
+			t.Errorf("task registration Authorization = %q, want empty", got)
+		}
+		var body registerTaskRequest
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if body.Timestamp != "2026-07-22T12:34:56Z" {
+			t.Errorf("timestamp = %q", body.Timestamp)
+		}
+		signature, err := base64.StdEncoding.DecodeString(body.Signature)
+		if err != nil {
+			t.Errorf("decode signature: %v", err)
+		}
+		publicKey := privateKey.Public().(ed25519.PublicKey)
+		if !ed25519.Verify(publicKey, []byte("runtime-123:"+body.Timestamp), signature) {
+			t.Errorf("signature did not verify")
+		}
+		_, _ = io.WriteString(w, `{"taskId":"task-123"}`)
+	}))
+	defer server.Close()
+	client := newAgentIdentityClient(server.Client(), server.URL)
+	client.now = func() time.Time { return fixedTime }
+	taskID, err := client.RegisterTask(context.Background(), AgentIdentityKey{
+		AgentRuntimeID:        "runtime-123",
+		PrivateKeyPKCS8Base64: keyMaterial.PrivateKeyPKCS8Base64,
+	})
+	if err != nil {
+		t.Fatalf("RegisterTask() error = %v", err)
+	}
+	if taskID != "task-123" {
+		t.Fatalf("task ID = %q", taskID)
+	}
+}
+
+func TestAgentIdentityClientRegisterTaskAcceptsResponseAliases(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "snake case", body: `{"task_id":"task-snake"}`},
+		{name: "camel case", body: `{"taskId":"task-camel"}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = io.WriteString(w, test.body)
+			}))
+			defer server.Close()
+			client := newAgentIdentityClient(server.Client(), server.URL)
+			keyMaterial := deterministicAgentKeyMaterial(t, 0x55)
+			taskID, err := client.RegisterTask(context.Background(), AgentIdentityKey{
+				AgentRuntimeID:        "runtime-123",
+				PrivateKeyPKCS8Base64: keyMaterial.PrivateKeyPKCS8Base64,
+			})
+			if err != nil {
+				t.Fatalf("RegisterTask() error = %v", err)
+			}
+			if !strings.HasPrefix(taskID, "task-") {
+				t.Fatalf("task ID = %q", taskID)
+			}
+		})
+	}
+}
+
+func TestAgentIdentityClientRegisterTaskPreservesPlainTaskID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"task_id":"  task-123\n"}`)
+	}))
+	defer server.Close()
+
+	client := newAgentIdentityClient(server.Client(), server.URL)
+	keyMaterial := deterministicAgentKeyMaterial(t, 0x56)
+	taskID, err := client.RegisterTask(context.Background(), AgentIdentityKey{
+		AgentRuntimeID:        "runtime-123",
+		PrivateKeyPKCS8Base64: keyMaterial.PrivateKeyPKCS8Base64,
+	})
+	if err != nil {
+		t.Fatalf("RegisterTask() error = %v", err)
+	}
+	if taskID != "  task-123\n" {
+		t.Fatalf("task ID = %q", taskID)
+	}
+}
+
+func TestAgentIdentityClientRegisterTaskHonorsPresentEmptyTaskID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"task_id":"","encrypted_task_id":"not-used"}`)
+	}))
+	defer server.Close()
+
+	client := newAgentIdentityClient(server.Client(), server.URL)
+	keyMaterial := deterministicAgentKeyMaterial(t, 0x57)
+	taskID, err := client.RegisterTask(context.Background(), AgentIdentityKey{
+		AgentRuntimeID:        "runtime-123",
+		PrivateKeyPKCS8Base64: keyMaterial.PrivateKeyPKCS8Base64,
+	})
+	if err != nil {
+		t.Fatalf("RegisterTask() error = %v", err)
+	}
+	if taskID != "" {
+		t.Fatalf("task ID = %q, want present empty value", taskID)
+	}
+}
+
+func TestAgentIdentityClientRegisterTaskDecryptsEncryptedResponse(t *testing.T) {
+	keyMaterial := deterministicAgentKeyMaterial(t, 0x66)
+	privateKey, err := ParseAgentIdentityPrivateKey(keyMaterial.PrivateKeyPKCS8Base64)
+	if err != nil {
+		t.Fatalf("parse private key: %v", err)
+	}
+	curvePublicKey, _, err := curve25519KeyPair(privateKey)
+	if err != nil {
+		t.Fatalf("derive Curve25519 key: %v", err)
+	}
+	ciphertext, err := box.SealAnonymous(nil, []byte("encrypted-task-123"), &curvePublicKey, rand.Reader)
+	if err != nil {
+		t.Fatalf("encrypt task ID: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"encryptedTaskId":"`+base64.StdEncoding.EncodeToString(ciphertext)+`"}`)
+	}))
+	defer server.Close()
+	client := newAgentIdentityClient(server.Client(), server.URL)
+	taskID, err := client.RegisterTask(context.Background(), AgentIdentityKey{
+		AgentRuntimeID:        "runtime-123",
+		PrivateKeyPKCS8Base64: keyMaterial.PrivateKeyPKCS8Base64,
+	})
+	if err != nil {
+		t.Fatalf("RegisterTask() error = %v", err)
+	}
+	if taskID != "encrypted-task-123" {
+		t.Fatalf("task ID = %q", taskID)
+	}
+}
+
+func TestAgentIdentityClientRedactsHTTPErrorBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"echoed_secret":"access-token"}`)
+	}))
+	defer server.Close()
+	client := newAgentIdentityClient(server.Client(), server.URL)
+	_, err := client.RegisterAgent(context.Background(), validAgentRegistration(t))
+	if err == nil {
+		t.Fatal("RegisterAgent() unexpectedly succeeded")
+	}
+	if strings.Contains(err.Error(), "access-token") || strings.Contains(err.Error(), "echoed_secret") {
+		t.Fatalf("HTTP error leaked response body: %v", err)
+	}
+	var httpError *AgentIdentityHTTPError
+	if !errors.As(err, &httpError) || httpError.StatusCode() != http.StatusTooManyRequests {
+		t.Fatalf("error = %#v, want typed 429 error", err)
+	}
+	if !IsRetryableAgentIdentityRegistrationError(err) {
+		t.Fatal("429 must be retryable")
+	}
+}
+
+func TestAgentIdentityClientRegisterAgentRetriesTransientFailuresWithSameKey(t *testing.T) {
+	keyMaterial := deterministicAgentKeyMaterial(t, 0x7a)
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		attempt := attempts.Add(1)
+		var body registerAgentRequest
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		if body.AgentPublicKey != keyMaterial.PublicKeySSH {
+			t.Errorf("attempt %d used a different public key", attempt)
+		}
+		if attempt < maxAgentRegistrationAttempts {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = io.WriteString(w, `{"agent_runtime_id":"runtime-after-retry"}`)
+	}))
+	defer server.Close()
+	registration := validAgentRegistration(t)
+	registration.KeyMaterial = keyMaterial
+	client := newAgentIdentityClient(server.Client(), server.URL)
+	runtimeID, err := client.RegisterAgent(context.Background(), registration)
+	if err != nil {
+		t.Fatalf("RegisterAgent() error = %v", err)
+	}
+	if runtimeID != "runtime-after-retry" || attempts.Load() != maxAgentRegistrationAttempts {
+		t.Fatalf("runtime ID = %q, attempts = %d", runtimeID, attempts.Load())
+	}
+}
+
+func TestAgentIdentityClientRegisterTaskRetriesTransientFailures(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) < maxAgentRegistrationAttempts {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		_, _ = io.WriteString(w, `{"task_id":"task-after-retry"}`)
+	}))
+	defer server.Close()
+	client := newAgentIdentityClient(server.Client(), server.URL)
+	keyMaterial := deterministicAgentKeyMaterial(t, 0x7b)
+	taskID, err := client.RegisterTask(context.Background(), AgentIdentityKey{
+		AgentRuntimeID:        "runtime-123",
+		PrivateKeyPKCS8Base64: keyMaterial.PrivateKeyPKCS8Base64,
+	})
+	if err != nil {
+		t.Fatalf("RegisterTask() error = %v", err)
+	}
+	if taskID != "task-after-retry" || attempts.Load() != maxAgentRegistrationAttempts {
+		t.Fatalf("task ID = %q, attempts = %d", taskID, attempts.Load())
+	}
+}
+
+func TestAgentIdentityClientRetriesTransportTimeout(t *testing.T) {
+	var attempts atomic.Int32
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if attempts.Add(1) < maxAgentRegistrationAttempts {
+			return nil, &url.Error{Op: "Post", URL: req.URL.String(), Err: context.DeadlineExceeded}
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"agent_runtime_id":"runtime-after-timeout"}`)),
+			Request:    req,
+		}, nil
+	})}
+	client := newAgentIdentityClient(httpClient, "https://auth.openai.test/api/accounts")
+	runtimeID, err := client.RegisterAgent(context.Background(), validAgentRegistration(t))
+	if err != nil {
+		t.Fatalf("RegisterAgent() error = %v", err)
+	}
+	if runtimeID != "runtime-after-timeout" || attempts.Load() != maxAgentRegistrationAttempts {
+		t.Fatalf("runtime ID = %q, attempts = %d", runtimeID, attempts.Load())
+	}
+}
+
+func TestAgentIdentityClientDoesNotRetryHardFailure(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+	client := newAgentIdentityClient(server.Client(), server.URL)
+	_, err := client.RegisterAgent(context.Background(), validAgentRegistration(t))
+	if err == nil {
+		t.Fatal("RegisterAgent() unexpectedly succeeded")
+	}
+	if attempts.Load() != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts.Load())
+	}
+}
+
+func TestAgentIdentityClientStopsAfterMaximumAttempts(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	client := newAgentIdentityClient(server.Client(), server.URL)
+	_, err := client.RegisterAgent(context.Background(), validAgentRegistration(t))
+	if err == nil {
+		t.Fatal("RegisterAgent() unexpectedly succeeded")
+	}
+	if attempts.Load() != maxAgentRegistrationAttempts {
+		t.Fatalf("attempts = %d, want %d", attempts.Load(), maxAgentRegistrationAttempts)
+	}
+}
+
+func TestIsRetryableAgentIdentityRegistrationError(t *testing.T) {
+	tests := []struct {
+		status int
+		want   bool
+	}{
+		{status: http.StatusBadRequest, want: false},
+		{status: http.StatusUnauthorized, want: false},
+		{status: http.StatusTooManyRequests, want: true},
+		{status: http.StatusInternalServerError, want: true},
+		{status: http.StatusServiceUnavailable, want: true},
+		{status: 600, want: false},
+	}
+	for _, test := range tests {
+		err := &AgentIdentityHTTPError{operation: "test", statusCode: test.status}
+		if got := IsRetryableAgentIdentityRegistrationError(err); got != test.want {
+			t.Fatalf("status %d retryable = %t, want %t", test.status, got, test.want)
+		}
+	}
+	if IsRetryableAgentIdentityRegistrationError(context.Canceled) {
+		t.Fatal("canceled context must not be retryable")
+	}
+	if !IsRetryableAgentIdentityRegistrationError(context.DeadlineExceeded) {
+		t.Fatal("deadline exceeded must be retryable")
+	}
+}
+
+func TestAgentIdentityClientRejectsOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, strings.Repeat("x", maxAgentRegistrationResponseSize+1))
+	}))
+	defer server.Close()
+	client := newAgentIdentityClient(server.Client(), server.URL)
+	_, err := client.RegisterAgent(context.Background(), validAgentRegistration(t))
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("RegisterAgent() error = %v, want size error", err)
+	}
+}
+
+func TestAgentIdentityClientRejectsInvalidUTF8Response(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte{'{', '"', 't', 'a', 's', 'k', '_', 'i', 'd', '"', ':', '"', 0xff, '"', '}'})
+	}))
+	defer server.Close()
+	client := newAgentIdentityClient(server.Client(), server.URL)
+	keyMaterial := deterministicAgentKeyMaterial(t, 0x58)
+	_, err := client.RegisterTask(context.Background(), AgentIdentityKey{
+		AgentRuntimeID:        "runtime-123",
+		PrivateKeyPKCS8Base64: keyMaterial.PrivateKeyPKCS8Base64,
+	})
+	if err == nil || !strings.Contains(err.Error(), "not valid UTF-8") {
+		t.Fatalf("RegisterTask() error = %v, want UTF-8 error", err)
+	}
+}
+
+func TestAgentIdentityClientHonorsCallerCancellation(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		<-release
+	}))
+	defer server.Close()
+	client := newAgentIdentityClient(server.Client(), server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err := client.RegisterAgent(ctx, validAgentRegistration(t))
+	close(release)
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("RegisterAgent() error = %v, want deadline exceeded", err)
+	}
+}
+
+func validAgentRegistration(t *testing.T) AgentRegistration {
+	t.Helper()
+	return AgentRegistration{
+		AccessToken: "access-token",
+		KeyMaterial: deterministicAgentKeyMaterial(t, 0x77),
+		BillOfMaterials: AgentBillOfMaterials{
+			AgentVersion:    "7.2.94",
+			AgentHarnessID:  "codex-cli",
+			RunningLocation: "cli-windows",
+		},
+	}
+}

--- a/internal/auth/codex/agent_identity_test.go
+++ b/internal/auth/codex/agent_identity_test.go
@@ -1,0 +1,201 @@
+package codex
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha512"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/nacl/box"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestGenerateAgentKeyMaterialProducesCompatibleEncodings(t *testing.T) {
+	material, err := GenerateAgentKeyMaterial()
+	if err != nil {
+		t.Fatalf("GenerateAgentKeyMaterial() error = %v", err)
+	}
+	privateKey, err := ParseAgentIdentityPrivateKey(material.PrivateKeyPKCS8Base64)
+	if err != nil {
+		t.Fatalf("ParseAgentIdentityPrivateKey() error = %v", err)
+	}
+	derivedPublicKey, err := PublicKeySSHFromPrivateKey(material.PrivateKeyPKCS8Base64)
+	if err != nil {
+		t.Fatalf("PublicKeySSHFromPrivateKey() error = %v", err)
+	}
+	if derivedPublicKey != material.PublicKeySSH {
+		t.Fatalf("derived public key does not match generated public key")
+	}
+	parsedSSHKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(material.PublicKeySSH))
+	if err != nil {
+		t.Fatalf("parse OpenSSH public key: %v", err)
+	}
+	cryptoPublicKey, ok := parsedSSHKey.(ssh.CryptoPublicKey)
+	if !ok {
+		t.Fatalf("OpenSSH key has type %T, want ssh.CryptoPublicKey", parsedSSHKey)
+	}
+	sshEd25519Key, ok := cryptoPublicKey.CryptoPublicKey().(ed25519.PublicKey)
+	if !ok {
+		t.Fatalf("crypto public key has type %T", cryptoPublicKey.CryptoPublicKey())
+	}
+	privatePublicKey, ok := privateKey.Public().(ed25519.PublicKey)
+	if !ok || !bytes.Equal(sshEd25519Key, privatePublicKey) {
+		t.Fatal("OpenSSH and PKCS#8 keys are not the same key pair")
+	}
+}
+
+func TestGenerateAgentKeyMaterialReportsEntropyFailure(t *testing.T) {
+	_, err := generateAgentKeyMaterial(errorReader{})
+	if err == nil || !strings.Contains(err.Error(), "generate Agent Identity key") {
+		t.Fatalf("generateAgentKeyMaterial() error = %v", err)
+	}
+}
+
+func TestGenerateAgentKeyMaterialUsesCodexSeedDerivation(t *testing.T) {
+	seedMaterial := bytes.Repeat([]byte{0x5a}, agentIdentityKeySeedBytes)
+	material, err := generateAgentKeyMaterial(bytes.NewReader(seedMaterial))
+	if err != nil {
+		t.Fatalf("generateAgentKeyMaterial() error = %v", err)
+	}
+	privateKey, err := ParseAgentIdentityPrivateKey(material.PrivateKeyPKCS8Base64)
+	if err != nil {
+		t.Fatalf("ParseAgentIdentityPrivateKey() error = %v", err)
+	}
+	digest := sha512.New()
+	_, _ = digest.Write([]byte(agentIdentityKeyDerivationContext))
+	_, _ = digest.Write(seedMaterial)
+	if !bytes.Equal(privateKey.Seed(), digest.Sum(nil)[:ed25519.SeedSize]) {
+		t.Fatal("private key seed does not match Codex Agent Identity derivation")
+	}
+}
+
+func TestParseAgentIdentityPrivateKeyRejectsInvalidFormats(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "base64", value: "%%%"},
+		{name: "PKCS8", value: base64.StdEncoding.EncodeToString([]byte("not-der"))},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := ParseAgentIdentityPrivateKey(test.value); err == nil {
+				t.Fatal("ParseAgentIdentityPrivateKey() unexpectedly succeeded")
+			}
+		})
+	}
+}
+
+func TestSignAgentTaskRegistrationSignsCanonicalPayload(t *testing.T) {
+	material := deterministicAgentKeyMaterial(t, 0x11)
+	key := AgentIdentityKey{AgentRuntimeID: "runtime-123", PrivateKeyPKCS8Base64: material.PrivateKeyPKCS8Base64}
+	timestamp := "2026-07-22T12:34:56Z"
+	signatureText, err := signAgentTaskRegistration(key, timestamp)
+	if err != nil {
+		t.Fatalf("signAgentTaskRegistration() error = %v", err)
+	}
+	signature, err := base64.StdEncoding.DecodeString(signatureText)
+	if err != nil {
+		t.Fatalf("decode signature: %v", err)
+	}
+	privateKey, err := ParseAgentIdentityPrivateKey(material.PrivateKeyPKCS8Base64)
+	if err != nil {
+		t.Fatalf("parse private key: %v", err)
+	}
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+	if !ed25519.Verify(publicKey, []byte("runtime-123:"+timestamp), signature) {
+		t.Fatal("task registration signature did not verify")
+	}
+	if ed25519.Verify(publicKey, []byte("runtime-123:task-123:"+timestamp), signature) {
+		t.Fatal("task registration signature used assertion payload format")
+	}
+}
+
+func TestDecryptAgentTaskIDPreservesUTF8Plaintext(t *testing.T) {
+	material := deterministicAgentKeyMaterial(t, 0x22)
+	privateKey, err := ParseAgentIdentityPrivateKey(material.PrivateKeyPKCS8Base64)
+	if err != nil {
+		t.Fatalf("ParseAgentIdentityPrivateKey() error = %v", err)
+	}
+	curvePublicKey, _, err := curve25519KeyPair(privateKey)
+	if err != nil {
+		t.Fatalf("curve25519KeyPair() error = %v", err)
+	}
+	plaintext := []byte("  task-123\n")
+	ciphertext, err := box.SealAnonymous(nil, plaintext, &curvePublicKey, rand.Reader)
+	if err != nil {
+		t.Fatalf("box.SealAnonymous() error = %v", err)
+	}
+
+	got, err := decryptAgentTaskID(
+		AgentIdentityKey{PrivateKeyPKCS8Base64: material.PrivateKeyPKCS8Base64},
+		base64.StdEncoding.EncodeToString(ciphertext),
+	)
+	if err != nil {
+		t.Fatalf("decryptAgentTaskID() error = %v", err)
+	}
+	if got != string(plaintext) {
+		t.Fatalf("decryptAgentTaskID() = %q, want %q", got, plaintext)
+	}
+}
+
+func TestDecryptAgentTaskIDRejectsInvalidUTF8(t *testing.T) {
+	material := deterministicAgentKeyMaterial(t, 0x33)
+	privateKey, err := ParseAgentIdentityPrivateKey(material.PrivateKeyPKCS8Base64)
+	if err != nil {
+		t.Fatalf("ParseAgentIdentityPrivateKey() error = %v", err)
+	}
+	curvePublicKey, _, err := curve25519KeyPair(privateKey)
+	if err != nil {
+		t.Fatalf("curve25519KeyPair() error = %v", err)
+	}
+	ciphertext, err := box.SealAnonymous(nil, []byte{0xff}, &curvePublicKey, rand.Reader)
+	if err != nil {
+		t.Fatalf("box.SealAnonymous() error = %v", err)
+	}
+
+	_, err = decryptAgentTaskID(
+		AgentIdentityKey{PrivateKeyPKCS8Base64: material.PrivateKeyPKCS8Base64},
+		base64.StdEncoding.EncodeToString(ciphertext),
+	)
+	if err == nil || !strings.Contains(err.Error(), "not valid UTF-8") {
+		t.Fatalf("decryptAgentTaskID() error = %v", err)
+	}
+}
+
+func TestDecryptAgentTaskIDAcceptsEmptyOpaqueValue(t *testing.T) {
+	material := deterministicAgentKeyMaterial(t, 0x44)
+	privateKey, err := ParseAgentIdentityPrivateKey(material.PrivateKeyPKCS8Base64)
+	if err != nil {
+		t.Fatalf("ParseAgentIdentityPrivateKey() error = %v", err)
+	}
+	curvePublicKey, _, err := curve25519KeyPair(privateKey)
+	if err != nil {
+		t.Fatalf("curve25519KeyPair() error = %v", err)
+	}
+	ciphertext, err := box.SealAnonymous(nil, nil, &curvePublicKey, rand.Reader)
+	if err != nil {
+		t.Fatalf("box.SealAnonymous() error = %v", err)
+	}
+
+	got, err := decryptAgentTaskID(
+		AgentIdentityKey{PrivateKeyPKCS8Base64: material.PrivateKeyPKCS8Base64},
+		base64.StdEncoding.EncodeToString(ciphertext),
+	)
+	if err != nil {
+		t.Fatalf("decryptAgentTaskID() error = %v", err)
+	}
+	if got != "" {
+		t.Fatalf("decryptAgentTaskID() = %q, want empty value", got)
+	}
+}
+
+type errorReader struct{}
+
+func (errorReader) Read([]byte) (int, error) {
+	return 0, errors.New("entropy unavailable")
+}

--- a/internal/auth/codex/jwt_parser.go
+++ b/internal/auth/codex/jwt_parser.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // JWTClaims represents the claims section of a JSON Web Token (JWT).
@@ -13,12 +14,13 @@ import (
 // custom claims specific to OpenAI's authentication.
 type JWTClaims struct {
 	AtHash        string        `json:"at_hash"`
-	Aud           []string      `json:"aud"`
+	Aud           JWTAudience   `json:"aud"`
 	AuthProvider  string        `json:"auth_provider"`
 	AuthTime      int           `json:"auth_time"`
 	Email         string        `json:"email"`
 	EmailVerified bool          `json:"email_verified"`
 	Exp           int           `json:"exp"`
+	Profile       CodexProfile  `json:"https://api.openai.com/profile"`
 	CodexAuthInfo CodexAuthInfo `json:"https://api.openai.com/auth"`
 	Iat           int           `json:"iat"`
 	Iss           string        `json:"iss"`
@@ -26,6 +28,29 @@ type JWTClaims struct {
 	Rat           int           `json:"rat"`
 	Sid           string        `json:"sid"`
 	Sub           string        `json:"sub"`
+}
+
+// JWTAudience accepts either standard JWT audience representation.
+type JWTAudience []string
+
+// UnmarshalJSON accepts an audience string or an array of audience strings.
+func (audience *JWTAudience) UnmarshalJSON(data []byte) error {
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		*audience = JWTAudience{single}
+		return nil
+	}
+	var multiple []string
+	if err := json.Unmarshal(data, &multiple); err != nil {
+		return err
+	}
+	*audience = multiple
+	return nil
+}
+
+// CodexProfile contains profile claims that may supplement top-level identity claims.
+type CodexProfile struct {
+	Email string `json:"email"`
 }
 
 // Organizations defines the structure for organization details within the JWT claims.
@@ -41,6 +66,7 @@ type Organizations struct {
 // This includes ChatGPT account information, subscription status, and user/organization IDs.
 type CodexAuthInfo struct {
 	ChatgptAccountID               string          `json:"chatgpt_account_id"`
+	ChatgptAccountIsFedramp        bool            `json:"chatgpt_account_is_fedramp"`
 	ChatgptPlanType                string          `json:"chatgpt_plan_type"`
 	ChatgptSubscriptionActiveStart any             `json:"chatgpt_subscription_active_start"`
 	ChatgptSubscriptionActiveUntil any             `json:"chatgpt_subscription_active_until"`
@@ -60,11 +86,19 @@ func ParseJWTToken(token string) (*JWTClaims, error) {
 	if len(parts) != 3 {
 		return nil, fmt.Errorf("invalid JWT token format: expected 3 parts, got %d", len(parts))
 	}
+	for _, part := range parts {
+		if part == "" {
+			return nil, fmt.Errorf("invalid JWT token format: token parts must be non-empty")
+		}
+	}
 
 	// Decode the claims (payload) part
 	claimsData, err := base64URLDecode(parts[1])
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode JWT claims: %w", err)
+	}
+	if !utf8.Valid(claimsData) {
+		return nil, fmt.Errorf("failed to unmarshal JWT claims: payload is not valid UTF-8")
 	}
 
 	var claims JWTClaims
@@ -75,28 +109,39 @@ func ParseJWTToken(token string) (*JWTClaims, error) {
 	return &claims, nil
 }
 
-// base64URLDecode decodes a Base64 URL-encoded string, adding padding if necessary.
-// JWTs use a URL-safe Base64 alphabet and omit padding, so this function ensures
-// correct decoding by re-adding the padding before decoding.
+// base64URLDecode decodes the unpadded Base64 URL encoding required by JWTs.
 func base64URLDecode(data string) ([]byte, error) {
-	// Add padding if necessary
-	switch len(data) % 4 {
-	case 2:
-		data += "=="
-	case 3:
-		data += "="
-	}
-
-	return base64.URLEncoding.DecodeString(data)
+	return base64.RawURLEncoding.DecodeString(data)
 }
 
 // GetUserEmail extracts the user's email address from the JWT claims.
 func (c *JWTClaims) GetUserEmail() string {
-	return c.Email
+	if email := strings.TrimSpace(c.Email); email != "" {
+		return email
+	}
+	return strings.TrimSpace(c.Profile.Email)
 }
 
 // GetAccountID extracts the user's account ID (subject) from the JWT claims.
 // It retrieves the unique identifier for the user's ChatGPT account.
 func (c *JWTClaims) GetAccountID() string {
-	return c.CodexAuthInfo.ChatgptAccountID
+	return strings.TrimSpace(c.CodexAuthInfo.ChatgptAccountID)
+}
+
+// GetUserID extracts the ChatGPT user ID, falling back to the generic user ID claim.
+func (c *JWTClaims) GetUserID() string {
+	if userID := strings.TrimSpace(c.CodexAuthInfo.ChatgptUserID); userID != "" {
+		return userID
+	}
+	return strings.TrimSpace(c.CodexAuthInfo.UserID)
+}
+
+// GetPlanType returns the raw ChatGPT plan type claim.
+func (c *JWTClaims) GetPlanType() string {
+	return strings.TrimSpace(c.CodexAuthInfo.ChatgptPlanType)
+}
+
+// IsFedRAMPAccount reports whether the selected ChatGPT account uses FedRAMP routing.
+func (c *JWTClaims) IsFedRAMPAccount() bool {
+	return c.CodexAuthInfo.ChatgptAccountIsFedramp
 }

--- a/internal/auth/codex/jwt_parser_test.go
+++ b/internal/auth/codex/jwt_parser_test.go
@@ -1,0 +1,59 @@
+package codex
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+func TestParseJWTTokenAcceptsStringAudience(t *testing.T) {
+	payload, err := json.Marshal(map[string]any{
+		"aud": "codex",
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": "account-123",
+			"chatgpt_user_id":    "user-123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	token := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`)) + "." +
+		base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+
+	claims, err := ParseJWTToken(token)
+	if err != nil {
+		t.Fatalf("ParseJWTToken() error = %v", err)
+	}
+	if len(claims.Aud) != 1 || claims.Aud[0] != "codex" {
+		t.Fatalf("Aud = %#v", claims.Aud)
+	}
+}
+
+func TestParseJWTTokenRejectsMalformedCompactSerialization(t *testing.T) {
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{}`))
+	tests := []string{
+		"." + payload + ".signature",
+		"header..signature",
+		"header." + payload + ".",
+		"header." + payload + ".signature.extra",
+	}
+	for _, token := range tests {
+		if _, err := ParseJWTToken(token); err == nil {
+			t.Fatalf("ParseJWTToken(%q) unexpectedly succeeded", token)
+		}
+	}
+}
+
+func TestParseJWTTokenRejectsPaddedPayload(t *testing.T) {
+	payload := base64.URLEncoding.EncodeToString([]byte(`{"sub":"padding"}`))
+	if _, err := ParseJWTToken("header." + payload + ".signature"); err == nil {
+		t.Fatal("ParseJWTToken() accepted padded JWT payload")
+	}
+}
+
+func TestParseJWTTokenRejectsInvalidUTF8Payload(t *testing.T) {
+	payload := base64.RawURLEncoding.EncodeToString([]byte{'{', '"', 'e', 'm', 'a', 'i', 'l', '"', ':', '"', 0xff, '"', '}'})
+	if _, err := ParseJWTToken("header." + payload + ".signature"); err == nil {
+		t.Fatal("ParseJWTToken() accepted invalid UTF-8 payload")
+	}
+}

--- a/internal/auth/codex/managed_agent_identity.go
+++ b/internal/auth/codex/managed_agent_identity.go
@@ -1,0 +1,380 @@
+package codex
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// CodexAuthModeChatGPT is the auth.json mode for managed ChatGPT credentials.
+const CodexAuthModeChatGPT = "chatgpt"
+
+// ManagedAgentIdentityState describes whether durable Agent Identity material is ready for use.
+type ManagedAgentIdentityState string
+
+const (
+	ManagedAgentIdentityStateProvisioning ManagedAgentIdentityState = "provisioning"
+	ManagedAgentIdentityStateNeedsTask    ManagedAgentIdentityState = "needs_task"
+	ManagedAgentIdentityStateReady        ManagedAgentIdentityState = "ready"
+	ManagedAgentIdentityStateError        ManagedAgentIdentityState = "error"
+)
+
+// ManagedAgentIdentityCredentials is the canonical flat representation stored by CLIProxyAPI.
+// AccountID and ChatGPTUserID describe the current OAuth binding, while the Agent-prefixed
+// fields snapshot the account and user that own the registered key. CodexAuthFile converts
+// this representation to the nested schema consumed by Codex CLI.
+type ManagedAgentIdentityCredentials struct {
+	IDToken                 string                    `json:"id_token"`
+	AccessToken             string                    `json:"access_token"`
+	RefreshToken            string                    `json:"refresh_token"`
+	AccountID               string                    `json:"account_id"`
+	ChatGPTUserID           string                    `json:"current_chatgpt_user_id"`
+	LastRefresh             string                    `json:"last_refresh"`
+	AgentRuntimeID          string                    `json:"agent_runtime_id"`
+	AgentPrivateKey         string                    `json:"agent_private_key"`
+	AgentAccountID          string                    `json:"agent_identity_account_id"`
+	AgentChatGPTUserID      string                    `json:"chatgpt_user_id"`
+	Email                   string                    `json:"email"`
+	PlanType                string                    `json:"plan_type"`
+	ChatGPTAccountIsFedRAMP bool                      `json:"chatgpt_account_is_fedramp"`
+	TaskID                  string                    `json:"task_id,omitempty"`
+	State                   ManagedAgentIdentityState `json:"agent_identity_state,omitempty"`
+}
+
+// CodexAuthFile is the managed ChatGPT auth.json schema consumed by Codex CLI.
+type CodexAuthFile struct {
+	AuthMode      string                   `json:"auth_mode"`
+	OpenAIAPIKey  *string                  `json:"OPENAI_API_KEY"`
+	Tokens        CodexAuthTokens          `json:"tokens"`
+	LastRefresh   string                   `json:"last_refresh"`
+	AgentIdentity CodexAgentIdentityRecord `json:"agent_identity"`
+}
+
+// CodexAuthTokens contains the OAuth token bundle in Codex CLI's nested format.
+type CodexAuthTokens struct {
+	IDToken      string `json:"id_token"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	AccountID    string `json:"account_id"`
+}
+
+// CodexAgentIdentityRecord is the record form of Codex CLI's agent_identity field.
+type CodexAgentIdentityRecord struct {
+	AgentRuntimeID          string `json:"agent_runtime_id"`
+	AgentPrivateKey         string `json:"agent_private_key"`
+	AccountID               string `json:"account_id"`
+	ChatGPTUserID           string `json:"chatgpt_user_id"`
+	Email                   string `json:"email"`
+	PlanType                string `json:"plan_type"`
+	ChatGPTAccountIsFedRAMP bool   `json:"chatgpt_account_is_fedramp"`
+	TaskID                  string `json:"task_id,omitempty"`
+}
+
+// ManagedAgentIdentityCredentialsFromMetadata normalizes a flat CLIProxyAPI credential.
+// JWT claims are used as identity metadata only; token validity is established upstream.
+func ManagedAgentIdentityCredentialsFromMetadata(metadata map[string]any) (ManagedAgentIdentityCredentials, error) {
+	idToken, err := metadataString(metadata, "id_token")
+	if err != nil {
+		return ManagedAgentIdentityCredentials{}, err
+	}
+	accessToken, err := metadataString(metadata, "access_token")
+	if err != nil {
+		return ManagedAgentIdentityCredentials{}, err
+	}
+	refreshToken, err := metadataString(metadata, "refresh_token")
+	if err != nil {
+		return ManagedAgentIdentityCredentials{}, err
+	}
+	requiredTokens := []struct {
+		name  string
+		value string
+	}{
+		{name: "id_token", value: idToken},
+		{name: "access_token", value: accessToken},
+		{name: "refresh_token", value: refreshToken},
+	}
+	for _, token := range requiredTokens {
+		if strings.TrimSpace(token.value) == "" {
+			return ManagedAgentIdentityCredentials{}, fmt.Errorf("managed Agent Identity credential is missing %s", token.name)
+		}
+	}
+
+	claims, err := ParseJWTToken(idToken)
+	if err != nil {
+		return ManagedAgentIdentityCredentials{}, fmt.Errorf("parse managed Agent Identity id_token: %w", err)
+	}
+	metadataAccountID, err := metadataString(metadata, "account_id")
+	if err != nil {
+		return ManagedAgentIdentityCredentials{}, err
+	}
+	claimAccountID := claims.GetAccountID()
+	// A selected workspace intentionally overrides the default account in the ID token.
+	accountID := claimAccountID
+	if strings.TrimSpace(metadataAccountID) != "" {
+		accountID = strings.TrimSpace(metadataAccountID)
+	}
+	if accountID == "" {
+		return ManagedAgentIdentityCredentials{}, errors.New("managed Agent Identity credential is missing account_id")
+	}
+
+	userID := claims.GetUserID()
+	if userID == "" {
+		return ManagedAgentIdentityCredentials{}, errors.New("managed Agent Identity credential is missing chatgpt_user_id")
+	}
+
+	lastRefresh, err := normalizeMetadataTimestamp(metadata, "last_refresh")
+	if err != nil {
+		return ManagedAgentIdentityCredentials{}, err
+	}
+	agentRuntimeID, err := metadataString(metadata, "agent_runtime_id")
+	if err != nil {
+		return ManagedAgentIdentityCredentials{}, err
+	}
+	agentPrivateKey, err := metadataString(metadata, "agent_private_key")
+	if err != nil {
+		return ManagedAgentIdentityCredentials{}, err
+	}
+	agentAccountID, err := metadataString(metadata, "agent_identity_account_id")
+	if err != nil {
+		return ManagedAgentIdentityCredentials{}, err
+	}
+	agentUserID, err := metadataString(metadata, "chatgpt_user_id")
+	if err != nil {
+		return ManagedAgentIdentityCredentials{}, err
+	}
+	taskID, err := metadataString(metadata, "task_id")
+	if err != nil {
+		return ManagedAgentIdentityCredentials{}, err
+	}
+	state, err := metadataString(metadata, "agent_identity_state")
+	if err != nil {
+		return ManagedAgentIdentityCredentials{}, err
+	}
+	normalizedState := ManagedAgentIdentityState(strings.TrimSpace(state))
+	switch normalizedState {
+	case "", ManagedAgentIdentityStateProvisioning, ManagedAgentIdentityStateNeedsTask, ManagedAgentIdentityStateReady, ManagedAgentIdentityStateError:
+	default:
+		return ManagedAgentIdentityCredentials{}, fmt.Errorf("managed Agent Identity credential has unknown state %q", normalizedState)
+	}
+	email, err := metadataString(metadata, "email")
+	if err != nil {
+		return ManagedAgentIdentityCredentials{}, err
+	}
+	planType, err := metadataString(metadata, "plan_type")
+	if err != nil {
+		return ManagedAgentIdentityCredentials{}, err
+	}
+	if claimEmail := claims.GetUserEmail(); claimEmail != "" {
+		email = claimEmail
+	}
+	if claimPlanType := claims.GetPlanType(); claimPlanType != "" {
+		planType = claimPlanType
+	}
+
+	agentRuntimeID = strings.TrimSpace(agentRuntimeID)
+	agentPrivateKey = strings.TrimSpace(agentPrivateKey)
+	agentAccountID = strings.TrimSpace(agentAccountID)
+	agentUserID = strings.TrimSpace(agentUserID)
+	hasAgentMaterial := agentRuntimeID != "" || agentPrivateKey != "" || strings.TrimSpace(taskID) != ""
+	if !hasAgentMaterial {
+		agentAccountID = accountID
+		agentUserID = userID
+	} else {
+		// Records created before the binding snapshot was introduced belong to
+		// the selected account that carried the material.
+		if agentAccountID == "" {
+			agentAccountID = accountID
+		}
+		if agentUserID == "" {
+			agentUserID = userID
+		}
+	}
+
+	return ManagedAgentIdentityCredentials{
+		IDToken:                 idToken,
+		AccessToken:             accessToken,
+		RefreshToken:            refreshToken,
+		AccountID:               accountID,
+		ChatGPTUserID:           userID,
+		LastRefresh:             lastRefresh,
+		AgentRuntimeID:          agentRuntimeID,
+		AgentPrivateKey:         agentPrivateKey,
+		AgentAccountID:          agentAccountID,
+		AgentChatGPTUserID:      agentUserID,
+		Email:                   strings.TrimSpace(email),
+		PlanType:                normalizeAgentIdentityPlanType(planType),
+		ChatGPTAccountIsFedRAMP: claims.IsFedRAMPAccount(),
+		TaskID:                  taskID,
+		State:                   normalizedState,
+	}, nil
+}
+
+func normalizeAgentIdentityPlanType(planType string) string {
+	switch strings.ToLower(strings.TrimSpace(planType)) {
+	case "":
+		return "unknown"
+	case "free":
+		return "free"
+	case "go":
+		return "go"
+	case "plus":
+		return "plus"
+	case "pro":
+		return "pro"
+	case "prolite":
+		return "prolite"
+	case "team":
+		return "team"
+	case "self_serve_business_usage_based":
+		return "self_serve_business_usage_based"
+	case "business":
+		return "business"
+	case "enterprise_cbp_usage_based":
+		return "enterprise_cbp_usage_based"
+	case "hc":
+		return "enterprise"
+	case "enterprise":
+		return "enterprise"
+	case "education":
+		return "edu"
+	case "edu":
+		return "edu"
+	default:
+		return "unknown"
+	}
+}
+
+// CodexAuthFile validates the managed credential and returns the Codex CLI-compatible auth.json form.
+func (credentials ManagedAgentIdentityCredentials) CodexAuthFile() (CodexAuthFile, error) {
+	if err := credentials.validateForExport(); err != nil {
+		return CodexAuthFile{}, err
+	}
+
+	lastRefresh, err := time.Parse(time.RFC3339, strings.TrimSpace(credentials.LastRefresh))
+	if err != nil {
+		return CodexAuthFile{}, errors.New("last_refresh must be a valid RFC3339 timestamp")
+	}
+
+	return CodexAuthFile{
+		AuthMode:     CodexAuthModeChatGPT,
+		OpenAIAPIKey: nil,
+		Tokens: CodexAuthTokens{
+			IDToken:      credentials.IDToken,
+			AccessToken:  credentials.AccessToken,
+			RefreshToken: credentials.RefreshToken,
+			AccountID:    strings.TrimSpace(credentials.AccountID),
+		},
+		LastRefresh: lastRefresh.UTC().Format(time.RFC3339Nano),
+		AgentIdentity: CodexAgentIdentityRecord{
+			AgentRuntimeID:          strings.TrimSpace(credentials.AgentRuntimeID),
+			AgentPrivateKey:         strings.TrimSpace(credentials.AgentPrivateKey),
+			AccountID:               strings.TrimSpace(credentials.AgentAccountID),
+			ChatGPTUserID:           strings.TrimSpace(credentials.AgentChatGPTUserID),
+			Email:                   strings.TrimSpace(credentials.Email),
+			PlanType:                normalizeAgentIdentityPlanType(credentials.PlanType),
+			ChatGPTAccountIsFedRAMP: credentials.ChatGPTAccountIsFedRAMP,
+			TaskID:                  credentials.TaskID,
+		},
+	}, nil
+}
+
+// MarshalCodexAuthFile returns an indented auth.json document with a trailing newline.
+func (credentials ManagedAgentIdentityCredentials) MarshalCodexAuthFile() ([]byte, error) {
+	authFile, err := credentials.CodexAuthFile()
+	if err != nil {
+		return nil, err
+	}
+	data, err := json.MarshalIndent(authFile, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal Codex auth file: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func (credentials ManagedAgentIdentityCredentials) validateForExport() error {
+	required := []struct {
+		name  string
+		value string
+	}{
+		{name: "id_token", value: credentials.IDToken},
+		{name: "access_token", value: credentials.AccessToken},
+		{name: "refresh_token", value: credentials.RefreshToken},
+		{name: "account_id", value: credentials.AccountID},
+		{name: "last_refresh", value: credentials.LastRefresh},
+		{name: "agent_runtime_id", value: credentials.AgentRuntimeID},
+		{name: "agent_private_key", value: credentials.AgentPrivateKey},
+		{name: "current token chatgpt_user_id", value: credentials.ChatGPTUserID},
+		{name: "agent_identity_account_id", value: credentials.AgentAccountID},
+		{name: "Agent Identity chatgpt_user_id", value: credentials.AgentChatGPTUserID},
+		{name: "plan_type", value: credentials.PlanType},
+	}
+	for _, field := range required {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("managed Agent Identity credential is missing %s", field.name)
+		}
+	}
+
+	switch credentials.State {
+	case "", ManagedAgentIdentityStateNeedsTask:
+	case ManagedAgentIdentityStateReady:
+		if strings.TrimSpace(credentials.TaskID) == "" {
+			return errors.New("managed Agent Identity credential is ready but missing task_id")
+		}
+	case ManagedAgentIdentityStateProvisioning, ManagedAgentIdentityStateError:
+		return fmt.Errorf("managed Agent Identity credential is not exportable in state %q", credentials.State)
+	default:
+		return fmt.Errorf("managed Agent Identity credential has unknown state %q", credentials.State)
+	}
+
+	if _, err := ParseAgentIdentityPrivateKey(credentials.AgentPrivateKey); err != nil {
+		return fmt.Errorf("managed Agent Identity credential has invalid agent_private_key: %w", err)
+	}
+	if strings.TrimSpace(credentials.AgentAccountID) != strings.TrimSpace(credentials.AccountID) {
+		return errors.New("managed Agent Identity account binding does not match the selected account")
+	}
+	if strings.TrimSpace(credentials.AgentChatGPTUserID) != strings.TrimSpace(credentials.ChatGPTUserID) {
+		return errors.New("managed Agent Identity user binding does not match the current token")
+	}
+	return nil
+}
+
+func metadataString(metadata map[string]any, key string) (string, error) {
+	value, ok := metadata[key]
+	if !ok || value == nil {
+		return "", nil
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("managed Agent Identity field %s must be a string", key)
+	}
+	return text, nil
+}
+
+func normalizeMetadataTimestamp(metadata map[string]any, key string) (string, error) {
+	value, ok := metadata[key]
+	if !ok || value == nil {
+		return "", nil
+	}
+	var timestamp time.Time
+	switch typed := value.(type) {
+	case string:
+		if strings.TrimSpace(typed) == "" {
+			return "", nil
+		}
+		parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(typed))
+		if err != nil {
+			return "", fmt.Errorf("managed Agent Identity field %s must be an RFC3339 timestamp", key)
+		}
+		timestamp = parsed
+	case time.Time:
+		if typed.IsZero() {
+			return "", nil
+		}
+		timestamp = typed
+	default:
+		return "", fmt.Errorf("managed Agent Identity field %s must be a string or time.Time", key)
+	}
+	return timestamp.UTC().Format(time.RFC3339Nano), nil
+}

--- a/internal/auth/codex/managed_agent_identity_test.go
+++ b/internal/auth/codex/managed_agent_identity_test.go
@@ -1,0 +1,477 @@
+package codex
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestManagedAgentIdentityCredentialsCodexAuthFile(t *testing.T) {
+	keyMaterial := deterministicAgentKeyMaterial(t, 0x42)
+	credentials := ManagedAgentIdentityCredentials{
+		IDToken:                 "id-token-with-original-bytes",
+		AccessToken:             "access-token-with-original-bytes",
+		RefreshToken:            "refresh-token-with-original-bytes",
+		AccountID:               "account-123",
+		LastRefresh:             "2026-07-22T20:34:56+08:00",
+		AgentRuntimeID:          "runtime-123",
+		AgentPrivateKey:         keyMaterial.PrivateKeyPKCS8Base64,
+		ChatGPTUserID:           "user-123",
+		AgentAccountID:          "account-123",
+		AgentChatGPTUserID:      "user-123",
+		Email:                   "owner@example.com",
+		PlanType:                "pro",
+		ChatGPTAccountIsFedRAMP: true,
+		TaskID:                  "  task-123\n",
+		State:                   ManagedAgentIdentityStateReady,
+	}
+
+	authFile, err := credentials.CodexAuthFile()
+	if err != nil {
+		t.Fatalf("CodexAuthFile() error = %v", err)
+	}
+	if authFile.AuthMode != CodexAuthModeChatGPT {
+		t.Fatalf("AuthMode = %q, want %q", authFile.AuthMode, CodexAuthModeChatGPT)
+	}
+	if authFile.OpenAIAPIKey != nil {
+		t.Fatal("OpenAIAPIKey must be nil for managed ChatGPT auth")
+	}
+	if authFile.LastRefresh != "2026-07-22T12:34:56Z" {
+		t.Fatalf("LastRefresh = %q, want UTC timestamp", authFile.LastRefresh)
+	}
+	if authFile.Tokens.IDToken != credentials.IDToken ||
+		authFile.Tokens.AccessToken != credentials.AccessToken ||
+		authFile.Tokens.RefreshToken != credentials.RefreshToken {
+		t.Fatal("OAuth token bytes changed during export")
+	}
+	if authFile.AgentIdentity.TaskID != credentials.TaskID {
+		t.Fatalf("TaskID = %q, want %q", authFile.AgentIdentity.TaskID, credentials.TaskID)
+	}
+
+	data, err := credentials.MarshalCodexAuthFile()
+	if err != nil {
+		t.Fatalf("MarshalCodexAuthFile() error = %v", err)
+	}
+	if !bytes.HasSuffix(data, []byte("\n")) {
+		t.Fatal("auth.json must end with a newline")
+	}
+	var document map[string]any
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatalf("unmarshal exported auth.json: %v", err)
+	}
+	wantRootKeys := []string{"OPENAI_API_KEY", "agent_identity", "auth_mode", "last_refresh", "tokens"}
+	if got := sortedMapKeys(document); !reflect.DeepEqual(got, wantRootKeys) {
+		t.Fatalf("root keys = %v, want %v", got, wantRootKeys)
+	}
+	if document["OPENAI_API_KEY"] != nil {
+		t.Fatalf("OPENAI_API_KEY = %#v, want null", document["OPENAI_API_KEY"])
+	}
+	tokens, ok := document["tokens"].(map[string]any)
+	if !ok {
+		t.Fatalf("tokens has type %T", document["tokens"])
+	}
+	wantTokenKeys := []string{"access_token", "account_id", "id_token", "refresh_token"}
+	if got := sortedMapKeys(tokens); !reflect.DeepEqual(got, wantTokenKeys) {
+		t.Fatalf("token keys = %v, want %v", got, wantTokenKeys)
+	}
+	agentIdentity, ok := document["agent_identity"].(map[string]any)
+	if !ok {
+		t.Fatalf("agent_identity has type %T", document["agent_identity"])
+	}
+	if _, exists := agentIdentity["agent_identity_state"]; exists {
+		t.Fatal("internal Agent Identity state leaked into auth.json")
+	}
+	wantAgentKeys := []string{
+		"account_id", "agent_private_key", "agent_runtime_id", "chatgpt_account_is_fedramp",
+		"chatgpt_user_id", "email", "plan_type", "task_id",
+	}
+	if got := sortedMapKeys(agentIdentity); !reflect.DeepEqual(got, wantAgentKeys) {
+		t.Fatalf("Agent Identity keys = %v, want %v", got, wantAgentKeys)
+	}
+}
+
+func TestManagedAgentIdentityCredentialsCodexAuthFileOmitsMissingTask(t *testing.T) {
+	credentials := validManagedAgentIdentityCredentials(t)
+	credentials.TaskID = ""
+	credentials.State = ManagedAgentIdentityStateNeedsTask
+
+	data, err := credentials.MarshalCodexAuthFile()
+	if err != nil {
+		t.Fatalf("MarshalCodexAuthFile() error = %v", err)
+	}
+	var document struct {
+		AgentIdentity map[string]any `json:"agent_identity"`
+	}
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatalf("unmarshal exported auth.json: %v", err)
+	}
+	if _, exists := document.AgentIdentity["task_id"]; exists {
+		t.Fatal("empty task_id must be omitted")
+	}
+}
+
+func TestManagedAgentIdentityCredentialsCodexAuthFileRejectsIncompleteData(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*ManagedAgentIdentityCredentials)
+		want   string
+	}{
+		{name: "missing token", mutate: func(value *ManagedAgentIdentityCredentials) { value.RefreshToken = "" }, want: "refresh_token"},
+		{name: "invalid private key", mutate: func(value *ManagedAgentIdentityCredentials) { value.AgentPrivateKey = "not-base64" }, want: "agent_private_key"},
+		{name: "invalid timestamp", mutate: func(value *ManagedAgentIdentityCredentials) { value.LastRefresh = "yesterday" }, want: "last_refresh"},
+		{name: "ready without task", mutate: func(value *ManagedAgentIdentityCredentials) { value.TaskID = "" }, want: "missing task_id"},
+		{name: "ready with whitespace task", mutate: func(value *ManagedAgentIdentityCredentials) { value.TaskID = " \t\n" }, want: "missing task_id"},
+		{name: "account binding mismatch", mutate: func(value *ManagedAgentIdentityCredentials) { value.AgentAccountID = "other-account" }, want: "account binding"},
+		{name: "user binding mismatch", mutate: func(value *ManagedAgentIdentityCredentials) { value.AgentChatGPTUserID = "other-user" }, want: "user binding"},
+		{name: "provisioning", mutate: func(value *ManagedAgentIdentityCredentials) { value.State = ManagedAgentIdentityStateProvisioning }, want: "not exportable"},
+		{name: "unknown state", mutate: func(value *ManagedAgentIdentityCredentials) { value.State = "mystery" }, want: "unknown state"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			credentials := validManagedAgentIdentityCredentials(t)
+			test.mutate(&credentials)
+			_, err := credentials.CodexAuthFile()
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("CodexAuthFile() error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestManagedAgentIdentityCredentialsFromMetadata(t *testing.T) {
+	idToken := testJWT(t, map[string]any{
+		"email": "jwt-owner@example.com",
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id":         "account-123",
+			"chatgpt_user_id":            "user-123",
+			"chatgpt_plan_type":          "business",
+			"chatgpt_account_is_fedramp": true,
+		},
+	})
+	metadata := map[string]any{
+		"id_token":                   idToken,
+		"access_token":               "access-token",
+		"refresh_token":              "refresh-token",
+		"account_id":                 "account-123",
+		"last_refresh":               "2026-07-22T20:34:56+08:00",
+		"agent_runtime_id":           "runtime-123",
+		"agent_private_key":          "private-key-placeholder",
+		"chatgpt_user_id":            "user-123",
+		"email":                      "stale@example.com",
+		"plan_type":                  "stale-plan",
+		"chatgpt_account_is_fedramp": false,
+		"task_id":                    "task-123",
+		"agent_identity_state":       "ready",
+	}
+
+	credentials, err := ManagedAgentIdentityCredentialsFromMetadata(metadata)
+	if err != nil {
+		t.Fatalf("ManagedAgentIdentityCredentialsFromMetadata() error = %v", err)
+	}
+	if credentials.IDToken != idToken || credentials.AccessToken != "access-token" || credentials.RefreshToken != "refresh-token" {
+		t.Fatal("normalizer did not preserve OAuth token bytes")
+	}
+	if credentials.AccountID != "account-123" || credentials.ChatGPTUserID != "user-123" {
+		t.Fatalf("normalized binding = %q/%q", credentials.AccountID, credentials.ChatGPTUserID)
+	}
+	if credentials.AgentAccountID != "account-123" || credentials.AgentChatGPTUserID != "user-123" {
+		t.Fatalf("Agent Identity binding = %q/%q", credentials.AgentAccountID, credentials.AgentChatGPTUserID)
+	}
+	if credentials.Email != "jwt-owner@example.com" || credentials.PlanType != "business" {
+		t.Fatalf("normalized profile = %q/%q", credentials.Email, credentials.PlanType)
+	}
+	if !credentials.ChatGPTAccountIsFedRAMP {
+		t.Fatal("FedRAMP claim was not normalized")
+	}
+	if credentials.LastRefresh != "2026-07-22T12:34:56Z" {
+		t.Fatalf("LastRefresh = %q", credentials.LastRefresh)
+	}
+	if credentials.AgentRuntimeID != "runtime-123" || credentials.AgentPrivateKey != "private-key-placeholder" || credentials.TaskID != "task-123" {
+		t.Fatal("existing flat Agent Identity fields were not preserved")
+	}
+	if credentials.State != ManagedAgentIdentityStateReady {
+		t.Fatalf("State = %q", credentials.State)
+	}
+}
+
+func TestManagedAgentIdentityCredentialsFromMetadataUsesClaimFallbacks(t *testing.T) {
+	idToken := testJWT(t, map[string]any{
+		"https://api.openai.com/profile": map[string]any{"email": "profile@example.com"},
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": "account-123",
+			"user_id":            "fallback-user",
+		},
+	})
+	credentials, err := ManagedAgentIdentityCredentialsFromMetadata(map[string]any{
+		"id_token":      idToken,
+		"access_token":  "access-token",
+		"refresh_token": "refresh-token",
+	})
+	if err != nil {
+		t.Fatalf("ManagedAgentIdentityCredentialsFromMetadata() error = %v", err)
+	}
+	if credentials.Email != "profile@example.com" || credentials.ChatGPTUserID != "fallback-user" {
+		t.Fatalf("fallback claims = email %q, user %q", credentials.Email, credentials.ChatGPTUserID)
+	}
+	if credentials.LastRefresh != "" {
+		t.Fatalf("missing LastRefresh = %q, want empty", credentials.LastRefresh)
+	}
+}
+
+func TestManagedAgentIdentityCredentialsFromMetadataUsesSelectedAccount(t *testing.T) {
+	idToken := testJWT(t, map[string]any{
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": "jwt-account",
+			"chatgpt_user_id":    "jwt-user",
+		},
+	})
+	credentials, err := ManagedAgentIdentityCredentialsFromMetadata(map[string]any{
+		"id_token":      idToken,
+		"access_token":  "access-token",
+		"refresh_token": "refresh-token",
+		"account_id":    "selected-workspace",
+	})
+	if err != nil {
+		t.Fatalf("ManagedAgentIdentityCredentialsFromMetadata() error = %v", err)
+	}
+	if credentials.AccountID != "selected-workspace" {
+		t.Fatalf("AccountID = %q, want selected-workspace", credentials.AccountID)
+	}
+	if credentials.AgentAccountID != "selected-workspace" {
+		t.Fatalf("AgentAccountID = %q, want selected-workspace", credentials.AgentAccountID)
+	}
+}
+
+func TestManagedAgentIdentityCredentialsFromMetadataPreservesRegisteredBinding(t *testing.T) {
+	idToken := testJWT(t, map[string]any{
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": "default-account",
+			"chatgpt_user_id":    "current-user",
+		},
+	})
+	credentials, err := ManagedAgentIdentityCredentialsFromMetadata(map[string]any{
+		"id_token":                  idToken,
+		"access_token":              "access-token",
+		"refresh_token":             "refresh-token",
+		"account_id":                "selected-account",
+		"agent_runtime_id":          "runtime-123",
+		"agent_private_key":         "private-key-placeholder",
+		"agent_identity_account_id": "registered-account",
+		"chatgpt_user_id":           "registered-user",
+	})
+	if err != nil {
+		t.Fatalf("ManagedAgentIdentityCredentialsFromMetadata() error = %v", err)
+	}
+	if credentials.AccountID != "selected-account" || credentials.ChatGPTUserID != "current-user" {
+		t.Fatalf("current binding = %q/%q", credentials.AccountID, credentials.ChatGPTUserID)
+	}
+	if credentials.AgentAccountID != "registered-account" || credentials.AgentChatGPTUserID != "registered-user" {
+		t.Fatalf("registered binding = %q/%q", credentials.AgentAccountID, credentials.AgentChatGPTUserID)
+	}
+}
+
+func TestManagedAgentIdentityCredentialsFromMetadataInitializesBindingWithoutMaterial(t *testing.T) {
+	idToken := testJWT(t, map[string]any{
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": "current-account",
+			"chatgpt_user_id":    "current-user",
+		},
+	})
+	credentials, err := ManagedAgentIdentityCredentialsFromMetadata(map[string]any{
+		"id_token":                  idToken,
+		"access_token":              "access-token",
+		"refresh_token":             "refresh-token",
+		"agent_identity_account_id": "stale-account",
+		"chatgpt_user_id":           "stale-user",
+	})
+	if err != nil {
+		t.Fatalf("ManagedAgentIdentityCredentialsFromMetadata() error = %v", err)
+	}
+	if credentials.AgentAccountID != "current-account" || credentials.AgentChatGPTUserID != "current-user" {
+		t.Fatalf("initialized binding = %q/%q", credentials.AgentAccountID, credentials.AgentChatGPTUserID)
+	}
+}
+
+func TestManagedAgentIdentityCredentialsFromMetadataPreservesUserBindingConflict(t *testing.T) {
+	idToken := testJWT(t, map[string]any{
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": "jwt-account",
+			"chatgpt_user_id":    "jwt-user",
+		},
+	})
+	credentials, err := ManagedAgentIdentityCredentialsFromMetadata(map[string]any{
+		"id_token":          idToken,
+		"access_token":      "access-token",
+		"refresh_token":     "refresh-token",
+		"agent_runtime_id":  "runtime-123",
+		"agent_private_key": "private-key-placeholder",
+		"chatgpt_user_id":   "other-user",
+	})
+	if err != nil {
+		t.Fatalf("ManagedAgentIdentityCredentialsFromMetadata() error = %v", err)
+	}
+	if credentials.ChatGPTUserID != "jwt-user" || credentials.AgentChatGPTUserID != "other-user" {
+		t.Fatalf("current/agent users = %q/%q", credentials.ChatGPTUserID, credentials.AgentChatGPTUserID)
+	}
+}
+
+func TestManagedAgentIdentityCredentialsFromMetadataNormalizesPlanType(t *testing.T) {
+	tests := []struct {
+		name string
+		plan string
+		want string
+	}{
+		{name: "missing", want: "unknown"},
+		{name: "health care", plan: "hc", want: "enterprise"},
+		{name: "education", plan: "education", want: "edu"},
+		{name: "known", plan: "pro", want: "pro"},
+		{name: "unknown", plan: "future-plan", want: "unknown"},
+		{name: "case-insensitive alias", plan: "HC", want: "enterprise"},
+		{name: "case-insensitive known", plan: "Pro", want: "pro"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			idToken := testJWT(t, map[string]any{
+				"https://api.openai.com/auth": map[string]any{
+					"chatgpt_account_id": "account-123",
+					"chatgpt_user_id":    "user-123",
+					"chatgpt_plan_type":  test.plan,
+				},
+			})
+			credentials, err := ManagedAgentIdentityCredentialsFromMetadata(map[string]any{
+				"id_token":      idToken,
+				"access_token":  "access-token",
+				"refresh_token": "refresh-token",
+			})
+			if err != nil {
+				t.Fatalf("ManagedAgentIdentityCredentialsFromMetadata() error = %v", err)
+			}
+			if credentials.PlanType != test.want {
+				t.Fatalf("PlanType = %q, want %q", credentials.PlanType, test.want)
+			}
+		})
+	}
+}
+
+func TestManagedAgentIdentityCredentialsFromMetadataRequiresCompleteTokenBundle(t *testing.T) {
+	idToken := testJWT(t, map[string]any{
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": "account-123",
+			"chatgpt_user_id":    "user-123",
+		},
+	})
+	tests := []string{"id_token", "access_token", "refresh_token"}
+	for _, missing := range tests {
+		t.Run(missing, func(t *testing.T) {
+			metadata := map[string]any{
+				"id_token":      idToken,
+				"access_token":  "access-token",
+				"refresh_token": "refresh-token",
+			}
+			delete(metadata, missing)
+			_, err := ManagedAgentIdentityCredentialsFromMetadata(metadata)
+			if err == nil || !strings.Contains(err.Error(), missing) {
+				t.Fatalf("error = %v, want missing %s", err, missing)
+			}
+		})
+	}
+}
+
+func TestManagedAgentIdentityCredentialsFromMetadataRejectsUnknownState(t *testing.T) {
+	idToken := testJWT(t, map[string]any{
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": "account-123",
+			"chatgpt_user_id":    "user-123",
+		},
+	})
+	_, err := ManagedAgentIdentityCredentialsFromMetadata(map[string]any{
+		"id_token":             idToken,
+		"access_token":         "access-token",
+		"refresh_token":        "refresh-token",
+		"agent_identity_state": "mystery",
+	})
+	if err == nil || !strings.Contains(err.Error(), "unknown state") {
+		t.Fatalf("error = %v, want unknown state", err)
+	}
+}
+
+func validManagedAgentIdentityCredentials(t *testing.T) ManagedAgentIdentityCredentials {
+	t.Helper()
+	return ManagedAgentIdentityCredentials{
+		IDToken:            "id-token",
+		AccessToken:        "access-token",
+		RefreshToken:       "refresh-token",
+		AccountID:          "account-123",
+		LastRefresh:        "2026-07-22T12:34:56Z",
+		AgentRuntimeID:     "runtime-123",
+		AgentPrivateKey:    deterministicAgentKeyMaterial(t, 0x24).PrivateKeyPKCS8Base64,
+		ChatGPTUserID:      "user-123",
+		AgentAccountID:     "account-123",
+		AgentChatGPTUserID: "user-123",
+		Email:              "owner@example.com",
+		PlanType:           "pro",
+		TaskID:             "task-123",
+		State:              ManagedAgentIdentityStateReady,
+	}
+}
+
+func deterministicAgentKeyMaterial(t *testing.T, value byte) AgentKeyMaterial {
+	t.Helper()
+	material, err := generateAgentKeyMaterial(bytes.NewReader(bytes.Repeat([]byte{value}, agentIdentityKeySeedBytes)))
+	if err != nil {
+		t.Fatalf("generateAgentKeyMaterial() error = %v", err)
+	}
+	return material
+}
+
+func testJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	header, err := json.Marshal(map[string]string{"alg": "none", "typ": "JWT"})
+	if err != nil {
+		t.Fatalf("marshal JWT header: %v", err)
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal JWT payload: %v", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(header) + "." +
+		base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+}
+
+func sortedMapKeys(values map[string]any) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func TestNormalizeMetadataTimestampAcceptsTime(t *testing.T) {
+	got, err := normalizeMetadataTimestamp(map[string]any{
+		"last_refresh": time.Date(2026, 7, 22, 20, 34, 56, 0, time.FixedZone("HKT", 8*60*60)),
+	}, "last_refresh")
+	if err != nil {
+		t.Fatalf("normalizeMetadataTimestamp() error = %v", err)
+	}
+	if got != "2026-07-22T12:34:56Z" {
+		t.Fatalf("timestamp = %q", got)
+	}
+}
+
+func TestNormalizeMetadataTimestampPreservesFractionalSeconds(t *testing.T) {
+	got, err := normalizeMetadataTimestamp(map[string]any{
+		"last_refresh": "2026-07-22T20:34:56.123456+08:00",
+	}, "last_refresh")
+	if err != nil {
+		t.Fatalf("normalizeMetadataTimestamp() error = %v", err)
+	}
+	if got != "2026-07-22T12:34:56.123456Z" {
+		t.Fatalf("timestamp = %q", got)
+	}
+}

--- a/internal/auth/codex/token.go
+++ b/internal/auth/codex/token.go
@@ -60,23 +60,19 @@ func (ts *CodexTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	f, err := os.Create(authFilePath)
-	if err != nil {
-		return fmt.Errorf("failed to create token file: %w", err)
-	}
-	defer func() {
-		_ = f.Close()
-	}()
-
 	// Merge metadata using helper
 	data, errMerge := misc.MergeMetadata(ts, ts.Metadata)
 	if errMerge != nil {
 		return fmt.Errorf("failed to merge metadata: %w", errMerge)
 	}
 
-	if err = json.NewEncoder(f).Encode(data); err != nil {
-		return fmt.Errorf("failed to write token to file: %w", err)
+	raw, errMarshal := json.Marshal(data)
+	if errMarshal != nil {
+		return fmt.Errorf("failed to marshal token data: %w", errMarshal)
+	}
+	raw = append(raw, '\n')
+	if errWrite := misc.WriteCredentialFileAtomic(authFilePath, raw); errWrite != nil {
+		return fmt.Errorf("failed to write token to file: %w", errWrite)
 	}
 	return nil
-
 }

--- a/internal/auth/codex/token_test.go
+++ b/internal/auth/codex/token_test.go
@@ -1,0 +1,104 @@
+package codex
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestCodexTokenStorageSaveTokenToFileReplacesExistingCredentialPrivately(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex.json")
+	if err := os.WriteFile(path, []byte(`{"type":"codex","access_token":"old"}`), 0o600); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+	if err := os.Chmod(path, 0o444); err != nil {
+		t.Fatalf("make auth file read-only: %v", err)
+	}
+
+	storage := &CodexTokenStorage{
+		IDToken:      "id-token",
+		AccessToken:  "access-token",
+		RefreshToken: "refresh-token",
+		AccountID:    "account-1",
+		LastRefresh:  "2026-07-22T12:34:56Z",
+		Metadata: map[string]any{
+			"agent_private_key": "private-key",
+		},
+	}
+	if err := storage.SaveTokenToFile(path); err != nil {
+		t.Fatalf("SaveTokenToFile() error: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read auth file: %v", err)
+	}
+	if !bytes.HasSuffix(raw, []byte("\n")) {
+		t.Fatal("Codex credential file must end with a newline")
+	}
+	var metadata map[string]any
+	if err = json.Unmarshal(raw, &metadata); err != nil {
+		t.Fatalf("decode auth file: %v", err)
+	}
+	if metadata["access_token"] != "access-token" || metadata["refresh_token"] != "refresh-token" || metadata["id_token"] != "id-token" {
+		t.Fatalf("OAuth token bundle was not preserved: %#v", metadata)
+	}
+	if metadata["agent_private_key"] != "private-key" {
+		t.Fatalf("agent_private_key = %#v", metadata["agent_private_key"])
+	}
+	assertCodexPrivateCredentialMode(t, path)
+	assertNoCodexCredentialTempFiles(t, dir, "codex.json")
+}
+
+func TestCodexTokenStorageSaveTokenToFileTightensSameCredential(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex.json")
+	storage := &CodexTokenStorage{
+		IDToken:      "id-token",
+		AccessToken:  "access-token",
+		RefreshToken: "refresh-token",
+		AccountID:    "account-1",
+		LastRefresh:  "2026-07-22T12:34:56Z",
+	}
+	if err := storage.SaveTokenToFile(path); err != nil {
+		t.Fatalf("first SaveTokenToFile() error: %v", err)
+	}
+	if err := os.Chmod(path, 0o666); err != nil {
+		t.Fatalf("loosen auth file permissions: %v", err)
+	}
+	if err := storage.SaveTokenToFile(path); err != nil {
+		t.Fatalf("second SaveTokenToFile() error: %v", err)
+	}
+
+	assertCodexPrivateCredentialMode(t, path)
+	assertNoCodexCredentialTempFiles(t, dir, "codex.json")
+}
+
+func assertCodexPrivateCredentialMode(t *testing.T, path string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat credential file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("credential mode = %o, want 600", got)
+	}
+}
+
+func assertNoCodexCredentialTempFiles(t *testing.T, dir, name string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "."+name+".tmp-*"))
+	if err != nil {
+		t.Fatalf("glob credential temp files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("credential temp files were not removed: %v", matches)
+	}
+}

--- a/internal/misc/credentials.go
+++ b/internal/misc/credentials.go
@@ -3,7 +3,9 @@ package misc
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -24,6 +26,100 @@ func LogSavingCredentials(path string) {
 // LogCredentialSeparator adds a visual separator to group auth/key processing logs.
 func LogCredentialSeparator() {
 	log.Debug(credentialSeparator)
+}
+
+// WriteCredentialFileAtomic writes credential data through a private temporary
+// file in the destination directory and atomically replaces the destination.
+func WriteCredentialFileAtomic(path string, data []byte) error {
+	return writeCredentialFileAtomicWithRename(path, data, os.Rename)
+}
+
+func writeCredentialFileAtomicWithRename(path string, data []byte, rename func(string, string) error) error {
+	if rename == nil {
+		return fmt.Errorf("replace credential file: rename function is nil")
+	}
+
+	dir := filepath.Dir(path)
+	temp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create credential temp file: %w", err)
+	}
+	tempPath := temp.Name()
+	closed := false
+	removeTemp := true
+	defer func() {
+		if !closed {
+			_ = temp.Close()
+		}
+		if removeTemp {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if err = temp.Chmod(0o600); err != nil {
+		return fmt.Errorf("set credential temp file permissions: %w", err)
+	}
+	if _, err = temp.Write(data); err != nil {
+		return fmt.Errorf("write credential temp file: %w", err)
+	}
+	if err = temp.Sync(); err != nil {
+		return fmt.Errorf("sync credential temp file: %w", err)
+	}
+	if err = temp.Close(); err != nil {
+		return fmt.Errorf("close credential temp file: %w", err)
+	}
+	closed = true
+
+	if info, errStat := os.Lstat(path); errStat == nil {
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("credential path is not a regular file")
+		}
+		// This also clears Windows' read-only attribute so MoveFileEx can replace
+		// the destination without removing it first.
+		if err = os.Chmod(path, 0o600); err != nil {
+			return fmt.Errorf("tighten existing credential file permissions: %w", err)
+		}
+	} else if !os.IsNotExist(errStat) {
+		return fmt.Errorf("inspect existing credential file: %w", errStat)
+	}
+
+	if err = rename(tempPath, path); err != nil {
+		return fmt.Errorf("replace credential file: %w", err)
+	}
+	removeTemp = false
+
+	if err = syncCredentialDirectory(dir); err != nil {
+		return fmt.Errorf("sync credential directory: %w", err)
+	}
+	return nil
+}
+
+// TightenCredentialFilePermissions restricts an existing regular credential
+// file to mode 0600. On Windows, os.Chmod only controls the read-only attribute.
+func TightenCredentialFilePermissions(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("credential path is not a regular file")
+	}
+	return os.Chmod(path, 0o600)
+}
+
+func syncCredentialDirectory(dir string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	directory, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	if err = directory.Sync(); err != nil {
+		_ = directory.Close()
+		return err
+	}
+	return directory.Close()
 }
 
 // MergeMetadata serializes the source struct into a map and merges the provided metadata into it.

--- a/internal/misc/credentials_test.go
+++ b/internal/misc/credentials_test.go
@@ -1,0 +1,119 @@
+package misc
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestWriteCredentialFileAtomicReplacesExistingPrivately(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex.json")
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatalf("seed credential file: %v", err)
+	}
+	if err := os.Chmod(path, 0o444); err != nil {
+		t.Fatalf("make credential file read-only: %v", err)
+	}
+
+	want := []byte("new credential data")
+	if err := WriteCredentialFileAtomic(path, want); err != nil {
+		t.Fatalf("WriteCredentialFileAtomic() error: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read credential file: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("credential file = %q, want %q", got, want)
+	}
+	assertPrivateCredentialMode(t, path)
+	assertNoCredentialTempFiles(t, dir, "codex.json")
+}
+
+func TestWriteCredentialFileAtomicPreservesExistingOnReplaceFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex.json")
+	original := []byte("original credential data")
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatalf("seed credential file: %v", err)
+	}
+	if err := os.Chmod(path, 0o666); err != nil {
+		t.Fatalf("loosen credential file permissions: %v", err)
+	}
+
+	errForced := errors.New("forced rename failure")
+	renameCalls := 0
+	err := writeCredentialFileAtomicWithRename(path, []byte("replacement credential data"), func(tempPath, destination string) error {
+		renameCalls++
+		if filepath.Dir(tempPath) != dir {
+			t.Errorf("temporary file directory = %q, want %q", filepath.Dir(tempPath), dir)
+		}
+		if destination != path {
+			t.Errorf("rename destination = %q, want %q", destination, path)
+		}
+		assertPrivateCredentialMode(t, tempPath)
+		return errForced
+	})
+	if !errors.Is(err, errForced) {
+		t.Fatalf("writeCredentialFileAtomicWithRename() error = %v, want %v", err, errForced)
+	}
+	if renameCalls != 1 {
+		t.Fatalf("rename calls = %d, want 1", renameCalls)
+	}
+
+	got, errRead := os.ReadFile(path)
+	if errRead != nil {
+		t.Fatalf("read original credential file: %v", errRead)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("original credential file changed: got %q, want %q", got, original)
+	}
+	assertPrivateCredentialMode(t, path)
+	assertNoCredentialTempFiles(t, dir, "codex.json")
+}
+
+func TestTightenCredentialFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex.json")
+	if err := os.WriteFile(path, []byte("credential data"), 0o600); err != nil {
+		t.Fatalf("seed credential file: %v", err)
+	}
+	if err := os.Chmod(path, 0o666); err != nil {
+		t.Fatalf("loosen credential file permissions: %v", err)
+	}
+
+	if err := TightenCredentialFilePermissions(path); err != nil {
+		t.Fatalf("TightenCredentialFilePermissions() error: %v", err)
+	}
+	assertPrivateCredentialMode(t, path)
+}
+
+func assertPrivateCredentialMode(t *testing.T, path string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat credential file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("credential mode = %o, want 600", got)
+	}
+}
+
+func assertNoCredentialTempFiles(t *testing.T, dir, name string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "."+name+".tmp-*"))
+	if err != nil {
+		t.Fatalf("glob credential temp files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("credential temp files were not removed: %v", matches)
+	}
+}

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 )
@@ -124,24 +125,15 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 		}
 		if existing, errRead := os.ReadFile(path); errRead == nil {
 			if jsonEqual(existing, raw) {
+				if errMode := misc.TightenCredentialFilePermissions(path); errMode != nil {
+					return "", fmt.Errorf("auth filestore: tighten existing file permissions: %w", errMode)
+				}
 				return path, nil
 			}
-			file, errOpen := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600)
-			if errOpen != nil {
-				return "", fmt.Errorf("auth filestore: open existing failed: %w", errOpen)
-			}
-			if _, errWrite := file.Write(raw); errWrite != nil {
-				_ = file.Close()
-				return "", fmt.Errorf("auth filestore: write existing failed: %w", errWrite)
-			}
-			if errClose := file.Close(); errClose != nil {
-				return "", fmt.Errorf("auth filestore: close existing failed: %w", errClose)
-			}
-			return path, nil
 		} else if !os.IsNotExist(errRead) {
 			return "", fmt.Errorf("auth filestore: read existing failed: %w", errRead)
 		}
-		if errWrite := os.WriteFile(path, raw, 0o600); errWrite != nil {
+		if errWrite := misc.WriteCredentialFileAtomic(path, raw); errWrite != nil {
 			return "", fmt.Errorf("auth filestore: write file failed: %w", errWrite)
 		}
 	default:
@@ -298,10 +290,7 @@ func (s *FileTokenStore) readAuthFiles(path, baseDir string) ([]*cliproxyauth.Au
 				if errFetch == nil && strings.TrimSpace(fetchedProjectID) != "" {
 					metadata["project_id"] = strings.TrimSpace(fetchedProjectID)
 					if raw, errMarshal := json.Marshal(metadata); errMarshal == nil {
-						if file, errOpen := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600); errOpen == nil {
-							_, _ = file.Write(raw)
-							_ = file.Close()
-						}
+						_ = misc.WriteCredentialFileAtomic(path, raw)
 					}
 				}
 			}

--- a/sdk/auth/filestore_test.go
+++ b/sdk/auth/filestore_test.go
@@ -2,13 +2,106 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 )
+
+func TestFileTokenStoreSaveMetadataReplacesExistingCredentialPrivately(t *testing.T) {
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "codex.json")
+	if err := os.WriteFile(path, []byte(`{"type":"codex","access_token":"old"}`), 0o600); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+	if err := os.Chmod(path, 0o444); err != nil {
+		t.Fatalf("make auth file read-only: %v", err)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	auth := &cliproxyauth.Auth{
+		ID:       "codex.json",
+		Provider: "codex",
+		FileName: "codex.json",
+		Metadata: map[string]any{
+			"type":         "codex",
+			"access_token": "new",
+		},
+	}
+	if _, err := store.Save(context.Background(), auth); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read auth file: %v", err)
+	}
+	var metadata map[string]any
+	if err = json.Unmarshal(raw, &metadata); err != nil {
+		t.Fatalf("decode auth file: %v", err)
+	}
+	if metadata["access_token"] != "new" {
+		t.Fatalf("access_token = %#v, want new", metadata["access_token"])
+	}
+	assertPrivateCredentialMode(t, path)
+	assertNoCredentialTempFiles(t, baseDir, "codex.json")
+}
+
+func TestFileTokenStoreSaveMetadataTightensUnchangedCredential(t *testing.T) {
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "codex.json")
+	if err := os.WriteFile(path, []byte(`{"type":"codex","disabled":false}`), 0o600); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+	if err := os.Chmod(path, 0o666); err != nil {
+		t.Fatalf("loosen auth file permissions: %v", err)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	auth := &cliproxyauth.Auth{
+		ID:       "codex.json",
+		Provider: "codex",
+		FileName: "codex.json",
+		Metadata: map[string]any{"type": "codex"},
+	}
+	if _, err := store.Save(context.Background(), auth); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	assertPrivateCredentialMode(t, path)
+	assertNoCredentialTempFiles(t, baseDir, "codex.json")
+}
+
+func assertPrivateCredentialMode(t *testing.T, path string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat credential file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("credential mode = %o, want 600", got)
+	}
+}
+
+func assertNoCredentialTempFiles(t *testing.T, dir, name string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "."+name+".tmp-*"))
+	if err != nil {
+		t.Fatalf("glob credential temp files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("credential temp files were not removed: %v", matches)
+	}
+}
 
 func TestExtractAccessToken(t *testing.T) {
 	t.Parallel()

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -260,6 +260,9 @@ type Manager struct {
 	refreshLoop   *authAutoRefreshLoop
 
 	requestPrepareLocks sync.Map
+	// mutationLocks serializes durable state transitions per auth ID. Callers that
+	// also need refresh exclusion must acquire refreshLocks before mutationLocks.
+	mutationLocks sync.Map
 	// refreshLocks serializes credential refresh per auth ID so concurrent
 	// 401 recoveries and auto-refresh workers do not race the same refresh_token.
 	refreshLocks sync.Map
@@ -2163,6 +2166,8 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 	if auth.ID == "" {
 		auth.ID = uuid.NewString()
 	}
+	mutationLock := m.mutationLockForAuth(auth.ID)
+	mutationLock.mu.Lock()
 	now := time.Now()
 	clearedCooldown := false
 	if m.cooldownDisabledForAuth(auth) || auth.Disabled || auth.Status == StatusDisabled {
@@ -2181,11 +2186,13 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 	}
 	m.queueRefreshReschedule(auth.ID)
 	_ = m.persist(ctx, auth)
+	result := auth.Clone()
+	mutationLock.mu.Unlock()
 	m.hook.OnAuthRegistered(ctx, auth.Clone())
 	if clearedCooldown {
 		m.persistCooldownStates(ctx)
 	}
-	return auth.Clone(), nil
+	return result, nil
 }
 
 // Update replaces an existing auth entry and notifies hooks.
@@ -2193,10 +2200,13 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	if auth == nil || auth.ID == "" {
 		return nil, nil
 	}
+	mutationLock := m.mutationLockForAuth(auth.ID)
+	mutationLock.mu.Lock()
 	m.mu.Lock()
 	existing, ok := m.auths[auth.ID]
 	if !ok || existing == nil {
 		m.mu.Unlock()
+		mutationLock.mu.Unlock()
 		return nil, nil
 	}
 	if !auth.indexAssigned && auth.Index == "" {
@@ -2228,11 +2238,13 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	}
 	m.queueRefreshReschedule(auth.ID)
 	_ = m.persist(ctx, auth)
+	result := auth.Clone()
+	mutationLock.mu.Unlock()
 	m.hook.OnAuthUpdated(ctx, auth.Clone())
 	if clearedCooldown {
 		m.persistCooldownStates(ctx)
 	}
-	return auth.Clone(), nil
+	return result, nil
 }
 
 // Remove deletes an auth from runtime state without persisting.
@@ -2246,11 +2258,14 @@ func (m *Manager) Remove(ctx context.Context, id string) {
 		return
 	}
 	_ = ctx
+	mutationLock := m.mutationLockForAuth(id)
+	mutationLock.mu.Lock()
 
 	m.mu.Lock()
 	existing := m.auths[id]
 	if existing == nil {
 		m.mu.Unlock()
+		mutationLock.mu.Unlock()
 		return
 	}
 	provider := strings.TrimSpace(existing.Provider)
@@ -2277,6 +2292,7 @@ func (m *Manager) Remove(ctx context.Context, id string) {
 	}
 	m.queueRefreshUnschedule(id)
 	m.invalidateSessionAffinity(id)
+	mutationLock.mu.Unlock()
 
 	if provider != "" {
 		if exec, ok := m.Executor(provider); ok && exec != nil {
@@ -6123,6 +6139,32 @@ type authRefreshLock struct {
 	mu sync.Mutex
 }
 
+type authMutationLock struct {
+	mu sync.Mutex
+}
+
+func (m *Manager) mutationLockForAuth(id string) *authMutationLock {
+	lockValue, _ := m.mutationLocks.LoadOrStore(id, &authMutationLock{})
+	lock, _ := lockValue.(*authMutationLock)
+	if lock != nil {
+		return lock
+	}
+	lock = &authMutationLock{}
+	m.mutationLocks.Store(id, lock)
+	return lock
+}
+
+func (m *Manager) refreshLockForAuth(id string) *authRefreshLock {
+	lockValue, _ := m.refreshLocks.LoadOrStore(id, &authRefreshLock{})
+	lock, _ := lockValue.(*authRefreshLock)
+	if lock != nil {
+		return lock
+	}
+	lock = &authRefreshLock{}
+	m.refreshLocks.Store(id, lock)
+	return lock
+}
+
 func authAccessToken(auth *Auth) string {
 	if token := authMetadataString(auth, "access_token"); token != "" {
 		return token
@@ -6195,12 +6237,7 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		return nil, errors.New("auth id is empty")
 	}
 
-	lockValue, _ := m.refreshLocks.LoadOrStore(id, &authRefreshLock{})
-	lock, _ := lockValue.(*authRefreshLock)
-	if lock == nil {
-		lock = &authRefreshLock{}
-		m.refreshLocks.Store(id, lock)
-	}
+	lock := m.refreshLockForAuth(id)
 	lock.mu.Lock()
 	defer lock.mu.Unlock()
 

--- a/sdk/cliproxy/auth/metadata_merge.go
+++ b/sdk/cliproxy/auth/metadata_merge.go
@@ -1,0 +1,288 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var (
+	// ErrAuthIndexNotFound indicates that no manager auth has the requested index.
+	ErrAuthIndexNotFound = errors.New("auth index not found")
+	// ErrAuthIndexAmbiguous indicates that more than one manager auth has the requested index.
+	ErrAuthIndexAmbiguous = errors.New("auth index is ambiguous")
+	// ErrAuthStoreUnavailable indicates that a durable metadata transaction cannot be started.
+	ErrAuthStoreUnavailable = errors.New("durable auth store unavailable")
+)
+
+// MetadataTransaction serializes durable metadata changes with both credential
+// refresh and ordinary Manager mutations for one auth. It is valid only for the
+// duration of the callback passed to WithMetadataTransactionByIndex.
+type MetadataTransaction struct {
+	manager   *Manager
+	ctx       context.Context
+	authID    string
+	authIndex string
+	current   *Auth
+	published []*Auth
+	active    bool
+}
+
+// Auth returns the latest auth snapshot visible to the transaction.
+func (transaction *MetadataTransaction) Auth() *Auth {
+	if transaction == nil || transaction.current == nil {
+		return nil
+	}
+	return cloneAuthForMetadataMerge(transaction.current)
+}
+
+// Persisted reports whether this transaction has durably published at least one merge.
+func (transaction *MetadataTransaction) Persisted() bool {
+	return transaction != nil && len(transaction.published) > 0
+}
+
+// Merge replaces the specified top-level metadata fields. Persistence completes
+// before the new snapshot is published; a failed Save leaves manager state unchanged.
+func (transaction *MetadataTransaction) Merge(updates map[string]any) (*Auth, error) {
+	if transaction == nil || transaction.manager == nil || !transaction.active {
+		return nil, errors.New("metadata transaction is not active")
+	}
+	if errContext := transaction.ctx.Err(); errContext != nil {
+		return nil, errContext
+	}
+	if len(updates) == 0 {
+		return transaction.Auth(), nil
+	}
+
+	manager := transaction.manager
+	manager.mu.Lock()
+	currentID, current, errCurrent := manager.authByUniqueIndexLocked(transaction.authIndex)
+	if errCurrent != nil {
+		manager.mu.Unlock()
+		return nil, errCurrent
+	}
+	if currentID != transaction.authID {
+		manager.mu.Unlock()
+		return nil, fmt.Errorf("%w: %s changed during transaction", ErrAuthIndexNotFound, transaction.authIndex)
+	}
+
+	updated := cloneAuthForMetadataMerge(current)
+	if updated.Metadata == nil {
+		updated.Metadata = make(map[string]any, len(updates))
+	}
+	for key, value := range updates {
+		updated.Metadata[key] = cloneMetadataValue(value)
+	}
+	updated.UpdatedAt = time.Now()
+
+	// Metadata is the canonical credential snapshot. A provider-specific runtime
+	// TokenStorage may contain tokens from before the latest refresh, so it must not
+	// participate in this persistence operation.
+	storage := updated.Storage
+	persistSnapshot := cloneAuthForMetadataMerge(updated)
+	persistSnapshot.Storage = nil
+	// Runtime availability paths persist while holding m.mu and do not acquire the
+	// durable mutation lock. Keep m.mu through Save so none can write the pre-merge
+	// credential snapshot after this Save and make disk older than manager state.
+	if errPersist := manager.persist(transaction.ctx, persistSnapshot); errPersist != nil {
+		manager.mu.Unlock()
+		return nil, fmt.Errorf("persist merged auth metadata: %w", errPersist)
+	}
+
+	// Stores may add canonical path attributes during Save. Publish exactly that
+	// durable snapshot while restoring the runtime-only token storage.
+	persistSnapshot.Storage = storage
+	published := cloneAuthForMetadataMerge(persistSnapshot)
+	manager.auths[transaction.authID] = published
+	transaction.current = cloneAuthForMetadataMerge(published)
+	transaction.published = append(transaction.published, cloneAuthForMetadataMerge(published))
+	result := cloneAuthForMetadataMerge(published)
+	manager.mu.Unlock()
+	return result, nil
+}
+
+// WithMetadataTransactionByIndex runs callback against a fresh auth snapshot.
+// Credential refresh and ordinary durable mutations for the auth are excluded for
+// the callback duration, but the manager-wide mutex is not held while callback runs.
+// Manager hooks and scheduler notifications run only after all transaction locks
+// have been released.
+func (m *Manager) WithMetadataTransactionByIndex(ctx context.Context, authIndex string, callback func(*MetadataTransaction) error) (result *Auth, err error) {
+	if m == nil {
+		return nil, errors.New("auth manager is nil")
+	}
+	if m.store == nil {
+		return nil, ErrAuthStoreUnavailable
+	}
+	if callback == nil {
+		return nil, errors.New("metadata transaction callback is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" {
+		return nil, fmt.Errorf("%w: index is empty", ErrAuthIndexNotFound)
+	}
+
+	for {
+		if errContext := ctx.Err(); errContext != nil {
+			return nil, errContext
+		}
+
+		authID, _, errLookup := m.authByUniqueIndex(authIndex)
+		if errLookup != nil {
+			return nil, errLookup
+		}
+
+		refreshLock := m.refreshLockForAuth(authID)
+		refreshLock.mu.Lock()
+		mutationLock := m.mutationLockForAuth(authID)
+		mutationLock.mu.Lock()
+
+		m.mu.Lock()
+		currentID, current, errCurrent := m.authByUniqueIndexLocked(authIndex)
+		if errCurrent != nil {
+			m.mu.Unlock()
+			mutationLock.mu.Unlock()
+			refreshLock.mu.Unlock()
+			return nil, errCurrent
+		}
+		if currentID != authID {
+			m.mu.Unlock()
+			mutationLock.mu.Unlock()
+			refreshLock.mu.Unlock()
+			continue
+		}
+		transaction := &MetadataTransaction{
+			manager:   m,
+			ctx:       ctx,
+			authID:    authID,
+			authIndex: authIndex,
+			current:   cloneAuthForMetadataMerge(current),
+			active:    true,
+		}
+		m.mu.Unlock()
+
+		func() {
+			defer func() {
+				transaction.active = false
+				mutationLock.mu.Unlock()
+				refreshLock.mu.Unlock()
+			}()
+			err = callback(transaction)
+			result = transaction.Auth()
+		}()
+		m.publishMetadataTransaction(ctx, transaction)
+		return result, err
+	}
+}
+
+// MergeMetadataByIndex durably merges metadata on the uniquely indexed auth.
+func (m *Manager) MergeMetadataByIndex(ctx context.Context, authIndex string, updates map[string]any) (*Auth, error) {
+	var merged *Auth
+	_, err := m.WithMetadataTransactionByIndex(ctx, authIndex, func(transaction *MetadataTransaction) error {
+		var errMerge error
+		merged, errMerge = transaction.Merge(updates)
+		return errMerge
+	})
+	if err != nil {
+		return nil, err
+	}
+	return cloneAuthForMetadataMerge(merged), nil
+}
+
+func (m *Manager) publishMetadataTransaction(ctx context.Context, transaction *MetadataTransaction) {
+	if transaction == nil || len(transaction.published) == 0 {
+		return
+	}
+	latest := transaction.published[len(transaction.published)-1]
+	if !shouldDeferAPIKeyModelAliasRebuild(ctx) {
+		m.rebuildAPIKeyModelAliasFromRuntimeConfig()
+	}
+	if m.scheduler != nil {
+		m.scheduler.upsertAuth(latest)
+	}
+	m.queueRefreshReschedule(transaction.authID)
+	for _, published := range transaction.published {
+		m.hook.OnAuthUpdated(ctx, cloneAuthForMetadataMerge(published))
+	}
+}
+
+func (m *Manager) authByUniqueIndex(authIndex string) (string, *Auth, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.authByUniqueIndexLocked(authIndex)
+}
+
+// authByUniqueIndexLocked may assign a missing index and therefore requires m.mu.
+func (m *Manager) authByUniqueIndexLocked(authIndex string) (string, *Auth, error) {
+	var matchedID string
+	var matched *Auth
+	for id, auth := range m.auths {
+		if auth == nil || strings.TrimSpace(auth.EnsureIndex()) != authIndex {
+			continue
+		}
+		if matched != nil {
+			return "", nil, fmt.Errorf("%w: %s", ErrAuthIndexAmbiguous, authIndex)
+		}
+		matchedID = id
+		matched = auth
+	}
+	if matched == nil {
+		return "", nil, fmt.Errorf("%w: %s", ErrAuthIndexNotFound, authIndex)
+	}
+	return matchedID, matched, nil
+}
+
+func cloneAuthForMetadataMerge(auth *Auth) *Auth {
+	if auth == nil {
+		return nil
+	}
+	cloned := auth.Clone()
+	cloned.Metadata = cloneMetadataMap(auth.Metadata)
+	return cloned
+}
+
+func cloneMetadataMap(metadata map[string]any) map[string]any {
+	if metadata == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(metadata))
+	for key, value := range metadata {
+		cloned[key] = cloneMetadataValue(value)
+	}
+	return cloned
+}
+
+func cloneMetadataValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneMetadataMap(typed)
+	case map[string]string:
+		cloned := make(map[string]string, len(typed))
+		for key, item := range typed {
+			cloned[key] = item
+		}
+		return cloned
+	case []any:
+		cloned := make([]any, len(typed))
+		for i, item := range typed {
+			cloned[i] = cloneMetadataValue(item)
+		}
+		return cloned
+	case []map[string]any:
+		cloned := make([]map[string]any, len(typed))
+		for i, item := range typed {
+			cloned[i] = cloneMetadataMap(item)
+		}
+		return cloned
+	case []string:
+		return append([]string(nil), typed...)
+	case []byte:
+		return append([]byte(nil), typed...)
+	default:
+		return value
+	}
+}

--- a/sdk/cliproxy/auth/metadata_merge_test.go
+++ b/sdk/cliproxy/auth/metadata_merge_test.go
@@ -1,0 +1,895 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type metadataMergeStore struct {
+	mu      sync.Mutex
+	saves   []*Auth
+	saveErr error
+}
+
+type blockingMetadataMergeStore struct {
+	store   *metadataMergeStore
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+type orderedMetadataMergeStore struct {
+	store         *metadataMergeStore
+	firstStarted  chan struct{}
+	secondStarted chan struct{}
+	releaseFirst  chan struct{}
+	mu            sync.Mutex
+	calls         int
+}
+
+func (s *orderedMetadataMergeStore) List(ctx context.Context) ([]*Auth, error) {
+	return s.store.List(ctx)
+}
+
+func (s *orderedMetadataMergeStore) Save(ctx context.Context, auth *Auth) (string, error) {
+	s.mu.Lock()
+	s.calls++
+	call := s.calls
+	s.mu.Unlock()
+	switch call {
+	case 1:
+		close(s.firstStarted)
+		select {
+		case <-s.releaseFirst:
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	case 2:
+		close(s.secondStarted)
+	}
+	return s.store.Save(ctx, auth)
+}
+
+func (s *orderedMetadataMergeStore) Delete(ctx context.Context, id string) error {
+	return s.store.Delete(ctx, id)
+}
+
+func (s *blockingMetadataMergeStore) List(ctx context.Context) ([]*Auth, error) {
+	return s.store.List(ctx)
+}
+
+func (s *blockingMetadataMergeStore) Save(ctx context.Context, auth *Auth) (string, error) {
+	s.once.Do(func() {
+		close(s.started)
+		select {
+		case <-s.release:
+		case <-ctx.Done():
+		}
+	})
+	return s.store.Save(ctx, auth)
+}
+
+func (s *blockingMetadataMergeStore) Delete(ctx context.Context, id string) error {
+	return s.store.Delete(ctx, id)
+}
+
+func (s *metadataMergeStore) List(context.Context) ([]*Auth, error) { return nil, nil }
+
+func (s *metadataMergeStore) Save(_ context.Context, auth *Auth) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.saves = append(s.saves, cloneAuthForMetadataMerge(auth))
+	if s.saveErr != nil {
+		return "", s.saveErr
+	}
+	return auth.ID, nil
+}
+
+func (s *metadataMergeStore) Delete(context.Context, string) error { return nil }
+
+func (s *metadataMergeStore) setSaveError(err error) {
+	s.mu.Lock()
+	s.saveErr = err
+	s.mu.Unlock()
+}
+
+func (s *metadataMergeStore) saved() []*Auth {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make([]*Auth, len(s.saves))
+	for i, auth := range s.saves {
+		result[i] = cloneAuthForMetadataMerge(auth)
+	}
+	return result
+}
+
+type metadataMergeTokenStorage struct{}
+
+func (*metadataMergeTokenStorage) SaveTokenToFile(string) error { return nil }
+
+func TestManagerMergeMetadataByIndexPreservesLatestMetadata(t *testing.T) {
+	ctx := context.Background()
+	store := &metadataMergeStore{}
+	manager := NewManager(store, nil, nil)
+	storage := &metadataMergeTokenStorage{}
+	auth := &Auth{
+		ID:       "codex-auth",
+		Index:    "codex-index",
+		Provider: "codex",
+		Status:   StatusActive,
+		Storage:  storage,
+		Metadata: map[string]any{
+			"access_token":  "latest-access-token",
+			"refresh_token": "latest-refresh-token",
+			"id_token":      "latest-id-token",
+			"other": map[string]any{
+				"preserved": true,
+			},
+		},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(ctx), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	agentIdentity := map[string]any{
+		"runtime_id": "runtime-1",
+		"key": map[string]any{
+			"private_key": "private-key",
+		},
+	}
+	updated, errMerge := manager.MergeMetadataByIndex(ctx, auth.Index, map[string]any{
+		"agent_identity": agentIdentity,
+		"task_id":        "task-1",
+	})
+	if errMerge != nil {
+		t.Fatalf("MergeMetadataByIndex() error = %v", errMerge)
+	}
+	if updated == nil {
+		t.Fatal("MergeMetadataByIndex() returned nil auth")
+	}
+
+	assertMetadataMergeValues(t, updated)
+	saves := store.saved()
+	if len(saves) != 1 {
+		t.Fatalf("Save() calls = %d, want 1", len(saves))
+	}
+	if saves[0].Storage != nil {
+		t.Fatal("persist snapshot retained stale TokenStorage")
+	}
+	assertMetadataMergeValues(t, saves[0])
+
+	current, ok := manager.GetByID(auth.ID)
+	if !ok || current == nil {
+		t.Fatal("manager auth missing after metadata merge")
+	}
+	if current.Storage != storage {
+		t.Fatal("manager auth did not preserve runtime TokenStorage")
+	}
+	assertMetadataMergeValues(t, current)
+
+	// Caller-owned nested maps must not become mutable manager state.
+	agentIdentity["runtime_id"] = "mutated-runtime"
+	agentIdentity["key"].(map[string]any)["private_key"] = "mutated-key"
+	current, _ = manager.GetByID(auth.ID)
+	identity, _ := current.Metadata["agent_identity"].(map[string]any)
+	if got := identity["runtime_id"]; got != "runtime-1" {
+		t.Fatalf("runtime_id = %#v after caller mutation, want runtime-1", got)
+	}
+	key, _ := identity["key"].(map[string]any)
+	if got := key["private_key"]; got != "private-key" {
+		t.Fatalf("private_key = %#v after caller mutation, want private-key", got)
+	}
+}
+
+func assertMetadataMergeValues(t *testing.T, auth *Auth) {
+	t.Helper()
+	if got := auth.Metadata["access_token"]; got != "latest-access-token" {
+		t.Fatalf("access_token = %#v, want latest-access-token", got)
+	}
+	if got := auth.Metadata["refresh_token"]; got != "latest-refresh-token" {
+		t.Fatalf("refresh_token = %#v, want latest-refresh-token", got)
+	}
+	if got := auth.Metadata["id_token"]; got != "latest-id-token" {
+		t.Fatalf("id_token = %#v, want latest-id-token", got)
+	}
+	other, _ := auth.Metadata["other"].(map[string]any)
+	if got := other["preserved"]; got != true {
+		t.Fatalf("other.preserved = %#v, want true", got)
+	}
+	identity, _ := auth.Metadata["agent_identity"].(map[string]any)
+	if got := identity["runtime_id"]; got != "runtime-1" {
+		t.Fatalf("agent_identity.runtime_id = %#v, want runtime-1", got)
+	}
+	if got := auth.Metadata["task_id"]; got != "task-1" {
+		t.Fatalf("task_id = %#v, want task-1", got)
+	}
+}
+
+func TestManagerMergeMetadataByIndexUnknownIndex(t *testing.T) {
+	store := &metadataMergeStore{}
+	manager := NewManager(store, nil, nil)
+
+	updated, errMerge := manager.MergeMetadataByIndex(context.Background(), "missing-index", map[string]any{"task_id": "task-1"})
+	if updated != nil {
+		t.Fatalf("MergeMetadataByIndex() auth = %#v, want nil", updated)
+	}
+	if !errors.Is(errMerge, ErrAuthIndexNotFound) {
+		t.Fatalf("MergeMetadataByIndex() error = %v, want ErrAuthIndexNotFound", errMerge)
+	}
+	if saves := store.saved(); len(saves) != 0 {
+		t.Fatalf("Save() calls = %d, want 0", len(saves))
+	}
+}
+
+func TestManagerMergeMetadataByIndexRejectsDuplicateIndex(t *testing.T) {
+	ctx := context.Background()
+	store := &metadataMergeStore{}
+	manager := NewManager(store, nil, nil)
+	for _, id := range []string{"auth-a", "auth-b"} {
+		if _, errRegister := manager.Register(WithSkipPersist(ctx), &Auth{
+			ID:       id,
+			Index:    "duplicate-index",
+			Provider: "codex",
+			Metadata: map[string]any{"access_token": id + "-token"},
+		}); errRegister != nil {
+			t.Fatalf("Register(%q) error = %v", id, errRegister)
+		}
+	}
+
+	updated, errMerge := manager.MergeMetadataByIndex(ctx, "duplicate-index", map[string]any{"task_id": "task-1"})
+	if updated != nil {
+		t.Fatalf("MergeMetadataByIndex() auth = %#v, want nil", updated)
+	}
+	if !errors.Is(errMerge, ErrAuthIndexAmbiguous) {
+		t.Fatalf("MergeMetadataByIndex() error = %v, want ErrAuthIndexAmbiguous", errMerge)
+	}
+	if saves := store.saved(); len(saves) != 0 {
+		t.Fatalf("Save() calls = %d, want 0", len(saves))
+	}
+}
+
+func TestManagerMergeMetadataByIndexRollsBackOnSaveFailure(t *testing.T) {
+	ctx := context.Background()
+	store := &metadataMergeStore{}
+	manager := NewManager(store, nil, nil)
+	auth := &Auth{
+		ID:       "codex-auth",
+		Index:    "codex-index",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"access_token":  "current-access-token",
+			"refresh_token": "current-refresh-token",
+		},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(ctx), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	errSave := errors.New("save failed")
+	store.setSaveError(errSave)
+	updated, errMerge := manager.MergeMetadataByIndex(ctx, auth.Index, map[string]any{
+		"agent_identity": map[string]any{"runtime_id": "runtime-1"},
+	})
+	if updated != nil {
+		t.Fatalf("MergeMetadataByIndex() auth = %#v, want nil", updated)
+	}
+	if !errors.Is(errMerge, errSave) {
+		t.Fatalf("MergeMetadataByIndex() error = %v, want wrapped save error", errMerge)
+	}
+
+	current, ok := manager.GetByID(auth.ID)
+	if !ok || current == nil {
+		t.Fatal("manager auth missing after failed save")
+	}
+	if _, exists := current.Metadata["agent_identity"]; exists {
+		t.Fatal("failed persistence made merged metadata observable")
+	}
+	if got := current.Metadata["access_token"]; got != "current-access-token" {
+		t.Fatalf("access_token = %#v after failed save, want current-access-token", got)
+	}
+	if saves := store.saved(); len(saves) != 1 {
+		t.Fatalf("Save() calls = %d, want 1", len(saves))
+	}
+}
+
+func TestManagerMergeMetadataByIndexWaitsForInFlightUpdatePersistence(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	recordingStore := &metadataMergeStore{}
+	store := &orderedMetadataMergeStore{
+		store:         recordingStore,
+		firstStarted:  make(chan struct{}),
+		secondStarted: make(chan struct{}),
+		releaseFirst:  make(chan struct{}),
+	}
+	manager := NewManager(store, nil, nil)
+	auth := &Auth{
+		ID:       "codex-auth",
+		Index:    "codex-index",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token": "original-access-token",
+		},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(ctx), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	updated := auth.Clone()
+	updated.Metadata["access_token"] = "updated-access-token"
+	updateDone := make(chan error, 1)
+	go func() {
+		_, errUpdate := manager.Update(ctx, updated)
+		updateDone <- errUpdate
+	}()
+	select {
+	case <-store.firstStarted:
+	case <-ctx.Done():
+		t.Fatalf("Update() did not reach persistence: %v", ctx.Err())
+	}
+
+	mergeAttempted := make(chan struct{})
+	mergeDone := make(chan error, 1)
+	go func() {
+		close(mergeAttempted)
+		_, errMerge := manager.MergeMetadataByIndex(ctx, auth.Index, map[string]any{
+			"agent_identity": map[string]any{"runtime_id": "runtime-1"},
+		})
+		mergeDone <- errMerge
+	}()
+	<-mergeAttempted
+	select {
+	case <-store.secondStarted:
+		t.Fatal("metadata merge reached persistence before the in-flight Update completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(store.releaseFirst)
+	select {
+	case errUpdate := <-updateDone:
+		if errUpdate != nil {
+			t.Fatalf("Update() error = %v", errUpdate)
+		}
+	case <-ctx.Done():
+		t.Fatalf("Update() did not finish: %v", ctx.Err())
+	}
+	select {
+	case errMerge := <-mergeDone:
+		if errMerge != nil {
+			t.Fatalf("MergeMetadataByIndex() error = %v", errMerge)
+		}
+	case <-ctx.Done():
+		t.Fatalf("metadata merge did not finish: %v", ctx.Err())
+	}
+
+	saves := recordingStore.saved()
+	if len(saves) != 2 {
+		t.Fatalf("Save() calls = %d, want Update then merge", len(saves))
+	}
+	last := saves[len(saves)-1]
+	if got := last.Metadata["access_token"]; got != "updated-access-token" {
+		t.Fatalf("last persisted access_token = %#v, want updated-access-token", got)
+	}
+	if _, ok := last.Metadata["agent_identity"].(map[string]any); !ok {
+		t.Fatalf("last persisted agent_identity = %#v, want object", last.Metadata["agent_identity"])
+	}
+}
+
+func TestManagerMetadataTransactionRequiresDurableStore(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "codex-auth",
+		Index:    "codex-index",
+		Provider: "codex",
+		Metadata: map[string]any{"access_token": "access-token"},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	called := false
+	result, errTransaction := manager.WithMetadataTransactionByIndex(context.Background(), auth.Index, func(*MetadataTransaction) error {
+		called = true
+		return nil
+	})
+	if result != nil {
+		t.Fatalf("WithMetadataTransactionByIndex() auth = %#v, want nil", result)
+	}
+	if !errors.Is(errTransaction, ErrAuthStoreUnavailable) {
+		t.Fatalf("WithMetadataTransactionByIndex() error = %v, want ErrAuthStoreUnavailable", errTransaction)
+	}
+	if called {
+		t.Fatal("transaction callback ran without a durable store")
+	}
+}
+
+type reentrantMetadataMergeHook struct {
+	NoopHook
+	manager *Manager
+	mu      sync.Mutex
+	called  bool
+	done    chan error
+}
+
+func (hook *reentrantMetadataMergeHook) OnAuthUpdated(ctx context.Context, auth *Auth) {
+	hook.mu.Lock()
+	if hook.called {
+		hook.mu.Unlock()
+		return
+	}
+	hook.called = true
+	hook.mu.Unlock()
+	_, errMerge := hook.manager.MergeMetadataByIndex(ctx, auth.Index, map[string]any{"hook_marker": "set"})
+	hook.done <- errMerge
+}
+
+func TestManagerMetadataTransactionHookCanReenterManager(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	store := &metadataMergeStore{}
+	hook := &reentrantMetadataMergeHook{done: make(chan error, 1)}
+	manager := NewManager(store, nil, hook)
+	hook.manager = manager
+	auth := &Auth{
+		ID:       "codex-auth",
+		Index:    "codex-index",
+		Provider: "codex",
+		Metadata: map[string]any{"access_token": "access-token"},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(ctx), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	if _, errMerge := manager.MergeMetadataByIndex(ctx, auth.Index, map[string]any{"agent_identity": "ready"}); errMerge != nil {
+		t.Fatalf("MergeMetadataByIndex() error = %v", errMerge)
+	}
+	select {
+	case errHook := <-hook.done:
+		if errHook != nil {
+			t.Fatalf("reentrant MergeMetadataByIndex() error = %v", errHook)
+		}
+	case <-ctx.Done():
+		t.Fatalf("OnAuthUpdated hook deadlocked: %v", ctx.Err())
+	}
+	updated, _ := manager.GetByID(auth.ID)
+	if got := updated.Metadata["hook_marker"]; got != "set" {
+		t.Fatalf("hook_marker = %#v, want set", got)
+	}
+}
+
+type metadataMergeRefreshExecutor struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (*metadataMergeRefreshExecutor) Identifier() string { return "codex" }
+
+func (*metadataMergeRefreshExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (*metadataMergeRefreshExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+
+func (e *metadataMergeRefreshExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	e.once.Do(func() { close(e.started) })
+	select {
+	case <-e.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	auth.Metadata["access_token"] = "refreshed-access-token"
+	auth.Metadata["refresh_token"] = "rotated-refresh-token"
+	return auth, nil
+}
+
+func (*metadataMergeRefreshExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (*metadataMergeRefreshExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestManagerMetadataTransactionStartsFromRefreshedAuth(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	store := &metadataMergeStore{}
+	manager := NewManager(store, nil, nil)
+	executor := &metadataMergeRefreshExecutor{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "codex-auth",
+		Index:    "codex-index",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token":  "stale-access-token",
+			"refresh_token": "original-refresh-token",
+		},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(ctx), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, errRefresh := manager.refreshAuthForRequest(ctx, auth.ID, "")
+		refreshDone <- errRefresh
+	}()
+	select {
+	case <-executor.started:
+	case <-ctx.Done():
+		t.Fatalf("refresh did not start: %v", ctx.Err())
+	}
+
+	callbackStarted := make(chan *Auth, 1)
+	transactionDone := make(chan error, 1)
+	go func() {
+		_, errTransaction := manager.WithMetadataTransactionByIndex(ctx, auth.Index, func(transaction *MetadataTransaction) error {
+			callbackStarted <- transaction.Auth()
+			return nil
+		})
+		transactionDone <- errTransaction
+	}()
+	select {
+	case <-callbackStarted:
+		t.Fatal("metadata transaction callback ran while refresh was in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(executor.release)
+	select {
+	case errRefresh := <-refreshDone:
+		if errRefresh != nil {
+			t.Fatalf("refreshAuthForRequest() error = %v", errRefresh)
+		}
+	case <-ctx.Done():
+		t.Fatalf("refresh did not finish: %v", ctx.Err())
+	}
+	var fresh *Auth
+	select {
+	case fresh = <-callbackStarted:
+	case <-ctx.Done():
+		t.Fatalf("metadata transaction did not start: %v", ctx.Err())
+	}
+	if got := fresh.Metadata["access_token"]; got != "refreshed-access-token" {
+		t.Fatalf("transaction access_token = %#v, want refreshed-access-token", got)
+	}
+	if got := fresh.Metadata["refresh_token"]; got != "rotated-refresh-token" {
+		t.Fatalf("transaction refresh_token = %#v, want rotated-refresh-token", got)
+	}
+	select {
+	case errTransaction := <-transactionDone:
+		if errTransaction != nil {
+			t.Fatalf("WithMetadataTransactionByIndex() error = %v", errTransaction)
+		}
+	case <-ctx.Done():
+		t.Fatalf("metadata transaction did not finish: %v", ctx.Err())
+	}
+}
+
+func TestManagerRefreshWaitsForMetadataTransactionCallback(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	store := &metadataMergeStore{}
+	manager := NewManager(store, nil, nil)
+	executor := &metadataMergeRefreshExecutor{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "codex-auth",
+		Index:    "codex-index",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token":  "stale-access-token",
+			"refresh_token": "original-refresh-token",
+		},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(ctx), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	callbackStarted := make(chan struct{})
+	releaseCallback := make(chan struct{})
+	transactionDone := make(chan error, 1)
+	go func() {
+		_, errTransaction := manager.WithMetadataTransactionByIndex(ctx, auth.Index, func(*MetadataTransaction) error {
+			close(callbackStarted)
+			select {
+			case <-releaseCallback:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		})
+		transactionDone <- errTransaction
+	}()
+	select {
+	case <-callbackStarted:
+	case <-ctx.Done():
+		t.Fatalf("metadata transaction did not start: %v", ctx.Err())
+	}
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, errRefresh := manager.refreshAuthForRequest(ctx, auth.ID, "")
+		refreshDone <- errRefresh
+	}()
+	select {
+	case <-executor.started:
+		t.Fatal("refresh entered its executor while metadata transaction callback was running")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseCallback)
+	select {
+	case errTransaction := <-transactionDone:
+		if errTransaction != nil {
+			t.Fatalf("WithMetadataTransactionByIndex() error = %v", errTransaction)
+		}
+	case <-ctx.Done():
+		t.Fatalf("metadata transaction did not finish: %v", ctx.Err())
+	}
+	select {
+	case <-executor.started:
+	case <-ctx.Done():
+		t.Fatalf("refresh did not start after transaction: %v", ctx.Err())
+	}
+	close(executor.release)
+	select {
+	case errRefresh := <-refreshDone:
+		if errRefresh != nil {
+			t.Fatalf("refreshAuthForRequest() error = %v", errRefresh)
+		}
+	case <-ctx.Done():
+		t.Fatalf("refresh did not finish: %v", ctx.Err())
+	}
+}
+
+func TestManagerMergeMetadataByIndexSerializesWithRefresh(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	store := &metadataMergeStore{}
+	manager := NewManager(store, nil, nil)
+	executor := &metadataMergeRefreshExecutor{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "codex-auth",
+		Index:    "codex-index",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token":  "stale-access-token",
+			"refresh_token": "original-refresh-token",
+			"other":         "preserved",
+		},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(ctx), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, errRefresh := manager.refreshAuthForRequest(ctx, auth.ID, "")
+		refreshDone <- errRefresh
+	}()
+	select {
+	case <-executor.started:
+	case <-ctx.Done():
+		t.Fatalf("refresh did not start: %v", ctx.Err())
+	}
+
+	type mergeResult struct {
+		auth *Auth
+		err  error
+	}
+	mergeStarted := make(chan struct{})
+	mergeDone := make(chan mergeResult, 1)
+	go func() {
+		close(mergeStarted)
+		updated, errMerge := manager.MergeMetadataByIndex(ctx, auth.Index, map[string]any{
+			"agent_identity": map[string]any{"runtime_id": "runtime-1"},
+		})
+		mergeDone <- mergeResult{auth: updated, err: errMerge}
+	}()
+	<-mergeStarted
+
+	var early *mergeResult
+	select {
+	case result := <-mergeDone:
+		early = &result
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(executor.release)
+
+	select {
+	case errRefresh := <-refreshDone:
+		if errRefresh != nil {
+			t.Fatalf("refreshAuthForRequest() error = %v", errRefresh)
+		}
+	case <-ctx.Done():
+		t.Fatalf("refresh did not finish: %v", ctx.Err())
+	}
+
+	var merged mergeResult
+	if early != nil {
+		merged = *early
+	} else {
+		select {
+		case merged = <-mergeDone:
+		case <-ctx.Done():
+			t.Fatalf("metadata merge did not finish: %v", ctx.Err())
+		}
+	}
+	if early != nil {
+		t.Fatal("metadata merge completed while refresh held the per-auth lock")
+	}
+	if merged.err != nil {
+		t.Fatalf("MergeMetadataByIndex() error = %v", merged.err)
+	}
+	if got := merged.auth.Metadata["access_token"]; got != "refreshed-access-token" {
+		t.Fatalf("merged access_token = %#v, want refreshed-access-token", got)
+	}
+	if got := merged.auth.Metadata["refresh_token"]; got != "rotated-refresh-token" {
+		t.Fatalf("merged refresh_token = %#v, want rotated-refresh-token", got)
+	}
+	if got := merged.auth.Metadata["other"]; got != "preserved" {
+		t.Fatalf("merged other metadata = %#v, want preserved", got)
+	}
+	if _, ok := merged.auth.Metadata["agent_identity"].(map[string]any); !ok {
+		t.Fatalf("merged agent_identity = %#v, want object", merged.auth.Metadata["agent_identity"])
+	}
+
+	current, ok := manager.GetByID(auth.ID)
+	if !ok || current == nil {
+		t.Fatal("manager auth missing after refresh and merge")
+	}
+	if got := current.Metadata["access_token"]; got != "refreshed-access-token" {
+		t.Fatalf("manager access_token = %#v, want refreshed-access-token", got)
+	}
+	if _, ok := current.Metadata["agent_identity"].(map[string]any); !ok {
+		t.Fatalf("manager agent_identity = %#v, want object", current.Metadata["agent_identity"])
+	}
+
+	saves := store.saved()
+	if len(saves) != 2 {
+		t.Fatalf("Save() calls = %d, want refresh and merge saves", len(saves))
+	}
+	last := saves[len(saves)-1]
+	if got := last.Metadata["access_token"]; got != "refreshed-access-token" {
+		t.Fatalf("last persisted access_token = %#v, want refreshed-access-token", got)
+	}
+	if _, ok := last.Metadata["agent_identity"].(map[string]any); !ok {
+		t.Fatalf("last persisted agent_identity = %#v, want object", last.Metadata["agent_identity"])
+	}
+}
+
+func TestManagerRefreshWaitsForMetadataMergePersistence(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	recordingStore := &metadataMergeStore{}
+	store := &blockingMetadataMergeStore{
+		store:   recordingStore,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	manager := NewManager(store, nil, nil)
+	executorRelease := make(chan struct{})
+	executor := &metadataMergeRefreshExecutor{
+		started: make(chan struct{}),
+		release: executorRelease,
+	}
+	manager.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "codex-auth",
+		Index:    "codex-index",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token":  "stale-access-token",
+			"refresh_token": "original-refresh-token",
+		},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(ctx), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	mergeDone := make(chan error, 1)
+	go func() {
+		_, errMerge := manager.MergeMetadataByIndex(ctx, auth.Index, map[string]any{
+			"agent_identity": map[string]any{"runtime_id": "runtime-1"},
+		})
+		mergeDone <- errMerge
+	}()
+	select {
+	case <-store.started:
+	case <-ctx.Done():
+		t.Fatalf("metadata merge did not reach persistence: %v", ctx.Err())
+	}
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, errRefresh := manager.refreshAuthForRequest(ctx, auth.ID, "")
+		refreshDone <- errRefresh
+	}()
+	select {
+	case <-executor.started:
+		t.Fatal("refresh entered the executor while metadata merge held the per-auth lock")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(store.release)
+	select {
+	case errMerge := <-mergeDone:
+		if errMerge != nil {
+			t.Fatalf("MergeMetadataByIndex() error = %v", errMerge)
+		}
+	case <-ctx.Done():
+		t.Fatalf("metadata merge did not finish: %v", ctx.Err())
+	}
+	select {
+	case <-executor.started:
+	case <-ctx.Done():
+		t.Fatalf("refresh did not start after metadata merge: %v", ctx.Err())
+	}
+	close(executorRelease)
+	select {
+	case errRefresh := <-refreshDone:
+		if errRefresh != nil {
+			t.Fatalf("refreshAuthForRequest() error = %v", errRefresh)
+		}
+	case <-ctx.Done():
+		t.Fatalf("refresh did not finish: %v", ctx.Err())
+	}
+
+	current, ok := manager.GetByID(auth.ID)
+	if !ok || current == nil {
+		t.Fatal("manager auth missing after merge and refresh")
+	}
+	if got := current.Metadata["access_token"]; got != "refreshed-access-token" {
+		t.Fatalf("manager access_token = %#v, want refreshed-access-token", got)
+	}
+	if _, ok := current.Metadata["agent_identity"].(map[string]any); !ok {
+		t.Fatalf("manager agent_identity = %#v, want object", current.Metadata["agent_identity"])
+	}
+
+	saves := recordingStore.saved()
+	if len(saves) != 2 {
+		t.Fatalf("Save() calls = %d, want merge and refresh saves", len(saves))
+	}
+	last := saves[len(saves)-1]
+	if got := last.Metadata["access_token"]; got != "refreshed-access-token" {
+		t.Fatalf("last persisted access_token = %#v, want refreshed-access-token", got)
+	}
+	if _, ok := last.Metadata["agent_identity"].(map[string]any); !ok {
+		t.Fatalf("last persisted agent_identity = %#v, want object", last.Metadata["agent_identity"])
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds backend provisioning and export support for Codex managed Agent Identities. It can take an existing file-backed Codex OAuth credential, generate and register Ed25519 identity material, optionally register the initial task, persist the result, and export a Codex CLI-compatible `auth.json` without exposing secrets through normal management responses.

The implementation keeps the managed identity alongside the existing ChatGPT OAuth tokens. OAuth refresh therefore remains available, and the exported file uses Codex's `auth_mode: "chatgpt"` record form rather than a standalone Agent Identity credential.

## Management API

Both routes remain behind the existing management authentication middleware.

### Provision

```http
POST /v0/management/auth-files/agent-identity/provision
```

```json
{
  "auth_index": "0123456789abcdef",
  "register_task": true,
  "force": false
}
```

- `auth_index` selects one existing, durable Codex credential and must be unique. Use the stable `auth_index` returned by the existing auth-files management API.
- The credential must contain a complete `id_token`, `access_token`, and `refresh_token` bundle.
- `register_task` defaults to `true` when omitted. Setting it to `false` leaves the identity in `needs_task` while still allowing a compatible export.
- `force` defaults to `false`. Only `force: true` rotates the key and creates a new upstream runtime.
- A successful response contains only status fields such as `has_tokens`, `has_agent_identity`, `has_task`, and `reused`; tokens and private key material are never returned here.
- If task registration fails after agent registration, the runtime and private key remain durable in `needs_task`. A later request resumes task registration instead of creating another agent.

Provisioning is serialized per credential with OAuth refresh and other durable auth mutations. Metadata is merged into the latest credential snapshot, persisted before publication, and rolled back in memory when persistence fails.

### Export

```http
GET /v0/management/auth-files/agent-identity/export?auth_index=0123456789abcdef
```

The response is an attachment named `auth.json` with `Cache-Control: no-store, private`, `Pragma: no-cache`, and `X-Content-Type-Options: nosniff`. Its shape is the nested Codex CLI file format:

```json
{
  "auth_mode": "chatgpt",
  "OPENAI_API_KEY": null,
  "tokens": {
    "id_token": "...",
    "access_token": "...",
    "refresh_token": "...",
    "account_id": "..."
  },
  "last_refresh": "...",
  "agent_identity": {
    "agent_runtime_id": "...",
    "agent_private_key": "...",
    "account_id": "...",
    "chatgpt_user_id": "...",
    "email": "...",
    "plan_type": "...",
    "chatgpt_account_is_fedramp": false,
    "task_id": "..."
  }
}
```

`task_id` is omitted when no task has been registered. Export validates the token bundle, private key, timestamp, state, and current account/user binding before returning secret material.

## Registration behavior

- Generates Ed25519 material and stores the private key as standard Base64-encoded PKCS#8 while registering the matching OpenSSH public key.
- Registers the agent at the fixed `https://auth.openai.com/api/accounts/v1/agent/register` endpoint using the existing access token and the credential's proxy transport.
- Registers tasks by signing `runtime_id:timestamp` and supports both plain task IDs and the Codex sealed-box encrypted task response.
- Uses a 15-second per-attempt agent registration timeout and a 30-second per-attempt task registration timeout.
- Retries transport errors, timeouts, HTTP 429, and HTTP 5xx responses for at most three total attempts. Other HTTP 4xx responses are not retried, and the same key is reused across attempts.
- Caps registration responses at 64 KiB, validates UTF-8, and discards upstream error bodies so they cannot be reflected in logs or management errors.

JWT decoding is used only to normalize account, user, email, plan, and FedRAMP metadata. The fixed upstream registration endpoint remains responsible for validating the bearer access token.

## Account binding

The current OAuth selection and the identity's registration snapshot are deliberately separate:

- `account_id` remains the currently selected OAuth account/workspace.
- `agent_identity_account_id` and `chatgpt_user_id` snapshot the account and user for which the key was registered.

Reuse and export require both the current account and current JWT user to match the registered snapshot. A changed account or user returns a conflict unless the caller explicitly requests `force: true`, which generates and registers new identity material. Legacy records without snapshots are backfilled from the credential that already owns the identity material.

This prevents a refreshed or reselected OAuth credential from silently reusing a key registered to another ChatGPT account.

## Credential persistence

The Codex token writer and file-backed metadata writer now share an atomic replacement helper:

1. Create a sibling temporary file and set mode `0600` before writing.
2. Write, sync, and close the temporary file.
3. Atomically rename it over the destination.
4. Sync the containing directory on POSIX systems.

The previous credential remains intact if replacement fails, and unchanged existing files are also tightened to `0600` on POSIX.

On Windows, Go's `os.Chmod(0600)` does not create an owner-only DACL; replacement files inherit the auth directory's ACL. Deployments on Windows must therefore restrict the auth directory to the service account/owner. This PR preserves the existing file-backed plaintext secret model and does not add an application-level encryption or key-management layer.

## Compatibility reference and provenance

The implementation is an independent Go implementation of the public Codex wire and storage contracts, pinned to `openai/codex` release `rust-v0.145.0` for reproducible review:

- [`AuthDotJson` managed storage schema](https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/login/src/auth/storage.rs#L38-L105)
- [Nested OAuth token schema](https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/login/src/token_data.rs#L10-L25)
- [Managed identity bootstrap and persistence](https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/login/src/auth/manager.rs#L659-L697)
- [Managed account/user binding selection](https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/login/src/auth/manager.rs#L755-L789)
- [Login-side agent and task registration flow](https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/login/src/auth/agent_identity.rs#L173-L218)
- [Managed account/user binding checks](https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/login/src/auth/agent_identity.rs#L243-L250)
- [Registration retry classification](https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/agent-identity/src/lib.rs#L205-L227)
- [Task signing and registration wire behavior](https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/agent-identity/src/lib.rs#L303-L353)
- [Agent registration and key derivation](https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/agent-identity/src/lib.rs#L355-L443)
- [Task decryption contract](https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/agent-identity/src/lib.rs#L408-L419)
- [ABOM construction](https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/agent-identity/src/lib.rs#L494-L508)

No sub2api source code, tests, fixtures, or other implementation material was copied into this change.

## Tests

Added coverage includes:

- Ed25519 generation/encoding, task signatures, sealed-box decryption, and invalid key/data cases.
- Exact agent/task request contracts, FedRAMP headers, retry classification, cancellation, response limits, and error redaction.
- JWT normalization, plan aliases, complete-token validation, nested `auth.json` serialization, and account/user binding conflicts.
- Provision, reuse, force rotation, skipped/resumed task registration, durable state transitions, export headers, and response redaction.
- Atomic credential replacement, `0600` mode, preservation on rename failure, and tightening unchanged files.
- Per-auth transaction serialization with refresh/update operations, persistence rollback, hook re-entry, and protected route registration.

Validation commands:

```shell
go test ./internal/auth/codex -count=1
go test ./internal/misc ./sdk/auth ./sdk/cliproxy/auth ./internal/api/handlers/management ./internal/api -count=1
go test -race ./sdk/cliproxy/auth -run 'Metadata|Merge' -count=1
go test ./...
go build -o test-output ./cmd/server && rm -f test-output
```

## Scope

This PR covers provisioning, durable storage, and Codex CLI export. It does not yet use `AgentAssertion` for CLIProxyAPI model traffic or add invalid-task recovery/replay; runtime assertion support will be a separate follow-up. Existing Codex bearer request behavior is unchanged.

---

## 中文说明

### 问题

Codex 的 managed Agent Identity 会把 ChatGPT OAuth token 和 Agent Identity 保存在同一份 `auth.json` 中：OAuth token 继续用于账号信息和刷新，注册后的密钥、runtime 和 task 保存在 `agent_identity` 里。

CPA 目前能保存和刷新 Codex OAuth 凭据，但不能用已有凭据完成 agent/task 注册，也不能导出 Codex CLI 直接读取的 managed `auth.json`。整个初始化流程仍然需要在其他工具里完成，CPA 本身无法从已有 OAuth 账号生成这份凭据。

### 修改

新增两个 management 接口，继续使用现有的管理鉴权：

```http
POST /v0/management/auth-files/agent-identity/provision
GET  /v0/management/auth-files/agent-identity/export?auth_index=...
```

`provision` 只接受已经持久化到文件，并且包含完整 `id_token`、`access_token` 和 `refresh_token` 的 Codex OAuth 凭据。

- 从 ID token 读取 account、user、email、plan 和 FedRAMP 信息；这些字段只用于整理账号信息，access token 仍由固定的上游注册接口验证。
- 生成 Ed25519 密钥，以 PKCS#8 Base64 保存私钥，并以 OpenSSH 格式提交公钥。注册请求和 `auth.json` 结构按 `openai/codex` 的 `rust-v0.145.0` 对齐。
- `register_task` 默认为 `true`；设为 `false` 时保留为 `needs_task`，导出文件不包含 `task_id`。agent 成功但 task 失败时，也会先保存 runtime 和私钥；账号绑定不变且未使用 `force` 时，再次调用只补 task。
- `force` 默认为 `false`。凭据里已有 Agent Identity 密钥或 runtime 时，只有 `force: true` 才会主动更换密钥并注册新的 runtime。
- 当前 OAuth 账号与注册 identity 时的 `account` 和 `user` 分开保存。复用和导出遇到绑定不一致时都会拒绝；只有重新调用 `provision` 才能通过 `force: true` 更换 identity。
- `provision` 和现有列表响应不返回 token 或私钥。`export` 返回包含敏感凭据的 Codex CLI `auth.json`，并设置 attachment、`no-store`、`no-cache` 和 `nosniff`。

在同一 Manager 进程内，同一凭据的 provisioning 会与 OAuth refresh 和其他持久化写入串行执行。Agent Identity 元数据从最新凭据快照开始合并，单次保存成功后才发布到 Manager 内存。

Codex token 和文件凭据的写入路径统一改为使用同目录临时文件：设置 `0600` 后写入、同步并原子替换目标文件；POSIX 上还会同步目录。目标文件替换失败时，旧文件内容保持不变。

这里没有增加应用层加密，仍然沿用项目现有的文件存储方式。Windows 上 `os.Chmod(0600)` 不会创建 owner-only DACL，因此仍需通过 auth 目录 ACL 限制服务账号或文件所有者以外的访问。

### 测试

```shell
go test ./internal/auth/codex -count=1
go test ./internal/misc ./sdk/auth ./sdk/cliproxy/auth ./internal/api/handlers/management ./internal/api -count=1
go test -p 1 ./... -count=1
go build ./cmd/server
```

Linux 容器中另外执行了：

```shell
go test -race ./sdk/cliproxy/auth -count=1
go test -race ./internal/api/handlers/management -run 'Test(ProvisionAgentIdentity|ForceProvision|AgentIdentity)' -count=1
```

测试覆盖：

- 密钥编码、task 签名和 sealed-box 解密。
- agent/task 请求格式、重试和错误脱敏。
- 嵌套 `auth.json`、账号绑定、失败续接和 `force` 更换。
- 原子写入，以及 provisioning 与 OAuth refresh、其他 Manager 写入的并发顺序。

### 范围

本次只包含 provisioning、持久化和 Codex CLI `auth.json` 导出，现有 Codex Bearer 请求行为不变。本 PR 不为模型请求生成 `AgentAssertion`，也不处理相应的 invalid-task 恢复和请求重放。
