### PR TITLE
feat(logging): add NDJSON request logging format support

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -111,6 +111,9 @@ plugins:
 # When true, disable high-overhead request logging and HTTP middleware features to reduce per-request memory usage under high concurrency.
 commercial-mode: false
 
+# Format for request log files: "text" (default) or "json" (NDJSON)
+request-log-format: "text"
+
 # When true, write application logs to rotating files instead of stdout
 logging-to-file: false
 

--- a/internal/api/middleware/request_logging.go
+++ b/internal/api/middleware/request_logging.go
@@ -257,14 +257,14 @@ func attachRequestLogSources(c *gin.Context, logger logging.RequestLogger, logge
 	if source, errSource := factory.NewFileBodySource("api-response"); errSource == nil {
 		c.Set(logging.APIResponseSourceContextKey, source)
 	}
+	if source, errSource := factory.NewFileBodySource("api-websocket-timeline"); errSource == nil {
+		c.Set(logging.APIWebsocketTimelineSourceContextKey, source)
+	}
 	if !isResponsesWebsocketUpgrade(c.Request) {
 		return
 	}
 	if source, errSource := factory.NewFileBodySource("websocket-timeline"); errSource == nil {
 		c.Set(logging.WebsocketTimelineSourceContextKey, source)
-	}
-	if source, errSource := factory.NewFileBodySource("api-websocket-timeline"); errSource == nil {
-		c.Set(logging.APIWebsocketTimelineSourceContextKey, source)
 	}
 }
 

--- a/internal/api/middleware/request_logging.go
+++ b/internal/api/middleware/request_logging.go
@@ -59,7 +59,6 @@ func RequestLoggingMiddleware(logger logging.RequestLogger) gin.HandlerFunc {
 		}
 		if formatter, ok := logger.(interface{ RequestLogFormat() string }); ok {
 			requestInfo.LogFormat = formatter.RequestLogFormat()
-			c.Set(requestLogFormatContextKey, requestInfo.LogFormat)
 		}
 
 		// Create response writer wrapper
@@ -68,7 +67,7 @@ func RequestLoggingMiddleware(logger logging.RequestLogger) gin.HandlerFunc {
 			wrapper.logOnErrorOnly = true
 		}
 		c.Writer = wrapper
-		attachRequestLogSources(c, logger, loggerEnabled)
+		attachRequestLogSources(c, logger, loggerEnabled, requestInfo.LogFormat)
 		attachDeferredRequestBodyCapture(c.Request, logger, requestInfo, loggerEnabled, captureBody)
 
 		// Process the request
@@ -251,7 +250,7 @@ func (c *deferredRequestBodyCapture) Cleanup() {
 	c.source = nil
 }
 
-func attachRequestLogSources(c *gin.Context, logger logging.RequestLogger, loggerEnabled bool) {
+func attachRequestLogSources(c *gin.Context, logger logging.RequestLogger, loggerEnabled bool, format string) {
 	if c == nil || !loggerEnabled {
 		return
 	}
@@ -261,12 +260,6 @@ func attachRequestLogSources(c *gin.Context, logger logging.RequestLogger, logge
 	}
 	newSource := factory.NewFileBodySource
 	if formattedFactory, ok := logger.(formattedFileBodySourceFactory); ok {
-		format := requestLogFormatFromContext(c)
-		if format == "" {
-			if formatter, ok := logger.(interface{ RequestLogFormat() string }); ok {
-				format = formatter.RequestLogFormat()
-			}
-		}
 		newSource = func(prefix string) (*logging.FileBodySource, error) {
 			return formattedFactory.NewFileBodySourceWithFormat(prefix, format)
 		}
@@ -286,17 +279,6 @@ func attachRequestLogSources(c *gin.Context, logger logging.RequestLogger, logge
 	if source, errSource := newSource("websocket-timeline"); errSource == nil {
 		c.Set(logging.WebsocketTimelineSourceContextKey, source)
 	}
-}
-
-const requestLogFormatContextKey = "REQUEST_LOG_FORMAT"
-
-func requestLogFormatFromContext(c *gin.Context) string {
-	if c == nil {
-		return ""
-	}
-	value, _ := c.Get(requestLogFormatContextKey)
-	format, _ := value.(string)
-	return format
 }
 
 func shouldSkipMethodForRequestLogging(req *http.Request) bool {

--- a/internal/api/middleware/request_logging.go
+++ b/internal/api/middleware/request_logging.go
@@ -57,6 +57,10 @@ func RequestLoggingMiddleware(logger logging.RequestLogger) gin.HandlerFunc {
 			c.Next()
 			return
 		}
+		if formatter, ok := logger.(interface{ RequestLogFormat() string }); ok {
+			requestInfo.LogFormat = formatter.RequestLogFormat()
+			c.Set(requestLogFormatContextKey, requestInfo.LogFormat)
+		}
 
 		// Create response writer wrapper
 		wrapper := NewResponseWriterWrapper(c.Writer, logger, requestInfo)
@@ -80,6 +84,10 @@ func RequestLoggingMiddleware(logger logging.RequestLogger) gin.HandlerFunc {
 
 type fileBodySourceFactory interface {
 	NewFileBodySource(prefix string) (*logging.FileBodySource, error)
+}
+
+type formattedFileBodySourceFactory interface {
+	NewFileBodySourceWithFormat(prefix, format string) (*logging.FileBodySource, error)
 }
 
 type deferredRequestBodyCapture struct {
@@ -251,21 +259,44 @@ func attachRequestLogSources(c *gin.Context, logger logging.RequestLogger, logge
 	if !ok || factory == nil {
 		return
 	}
-	if source, errSource := factory.NewFileBodySource("api-request"); errSource == nil {
+	newSource := factory.NewFileBodySource
+	if formattedFactory, ok := logger.(formattedFileBodySourceFactory); ok {
+		format := requestLogFormatFromContext(c)
+		if format == "" {
+			if formatter, ok := logger.(interface{ RequestLogFormat() string }); ok {
+				format = formatter.RequestLogFormat()
+			}
+		}
+		newSource = func(prefix string) (*logging.FileBodySource, error) {
+			return formattedFactory.NewFileBodySourceWithFormat(prefix, format)
+		}
+	}
+	if source, errSource := newSource("api-request"); errSource == nil {
 		c.Set(logging.APIRequestSourceContextKey, source)
 	}
-	if source, errSource := factory.NewFileBodySource("api-response"); errSource == nil {
+	if source, errSource := newSource("api-response"); errSource == nil {
 		c.Set(logging.APIResponseSourceContextKey, source)
 	}
-	if source, errSource := factory.NewFileBodySource("api-websocket-timeline"); errSource == nil {
+	if source, errSource := newSource("api-websocket-timeline"); errSource == nil {
 		c.Set(logging.APIWebsocketTimelineSourceContextKey, source)
 	}
 	if !isResponsesWebsocketUpgrade(c.Request) {
 		return
 	}
-	if source, errSource := factory.NewFileBodySource("websocket-timeline"); errSource == nil {
+	if source, errSource := newSource("websocket-timeline"); errSource == nil {
 		c.Set(logging.WebsocketTimelineSourceContextKey, source)
 	}
+}
+
+const requestLogFormatContextKey = "REQUEST_LOG_FORMAT"
+
+func requestLogFormatFromContext(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	value, _ := c.Get(requestLogFormatContextKey)
+	format, _ := value.(string)
+	return format
 }
 
 func shouldSkipMethodForRequestLogging(req *http.Request) bool {

--- a/internal/api/middleware/request_logging_test.go
+++ b/internal/api/middleware/request_logging_test.go
@@ -309,7 +309,7 @@ func TestAttachRequestLogSourcesUsesLoggerLogsDir(t *testing.T) {
 	c.Request = httptest.NewRequest(http.MethodGet, "/backend-api/codex/responses", nil)
 	c.Request.Header.Set("Upgrade", "websocket")
 
-	attachRequestLogSources(c, logger, true)
+	attachRequestLogSources(c, logger, true, "json")
 	defer cleanupFileBodySourcesFromContext(c)
 
 	for _, key := range []string{
@@ -346,7 +346,7 @@ func TestAttachRequestLogSourcesIncludesUpstreamWebsocketTimelineForHTTP(t *test
 	c, _ := gin.CreateTestContext(recorder)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
 
-	attachRequestLogSources(c, logger, true)
+	attachRequestLogSources(c, logger, true, "json")
 	defer cleanupFileBodySourcesFromContext(c)
 
 	value, exists := c.Get(logging.APIWebsocketTimelineSourceContextKey)
@@ -372,9 +372,7 @@ func TestRequestLogSourcesKeepFormatSnapshotAcrossReload(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
-	c.Set(requestLogFormatContextKey, "json")
-
-	attachRequestLogSources(c, logger, true)
+	attachRequestLogSources(c, logger, true, "json")
 	defer cleanupFileBodySourcesFromContext(c)
 	logger.SetFormat("text")
 

--- a/internal/api/middleware/request_logging_test.go
+++ b/internal/api/middleware/request_logging_test.go
@@ -328,6 +328,37 @@ func TestAttachRequestLogSourcesIncludesUpstreamWebsocketTimelineForHTTP(t *test
 	}
 }
 
+func TestRequestLogSourcesKeepFormatSnapshotAcrossReload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := logging.NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 0, "json")
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+	c.Set(requestLogFormatContextKey, "json")
+
+	attachRequestLogSources(c, logger, true)
+	defer cleanupFileBodySourcesFromContext(c)
+	logger.SetFormat("text")
+
+	value, exists := c.Get(logging.APIRequestSourceContextKey)
+	if !exists {
+		t.Fatal("expected API request source")
+	}
+	source, ok := value.(*logging.FileBodySource)
+	if !ok || source == nil {
+		t.Fatalf("source type = %T", value)
+	}
+	if source.Format() != "json" {
+		t.Fatalf("source format = %q, want json", source.Format())
+	}
+	if err := source.AppendBytes(bytes.Repeat([]byte("x"), (8<<20)+1)); err != nil {
+		t.Fatalf("AppendBytes failed: %v", err)
+	}
+	if !source.Truncated() {
+		t.Fatal("source lost JSON bound after format reload")
+	}
+}
+
 func cleanupFileBodySourcesFromContext(c *gin.Context) {
 	if c == nil {
 		return

--- a/internal/api/middleware/request_logging_test.go
+++ b/internal/api/middleware/request_logging_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -259,6 +260,43 @@ func TestRequestLoggingMiddlewareCapturesLargeErrorRequestAndDeferredAPIRequest(
 	if !bytes.Contains(content, upstreamBody) {
 		t.Fatal("error log does not contain the deferred upstream request body")
 	}
+}
+
+func TestRequestLoggingMiddlewareKeepsErrorLogFormatAcrossReload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	logsDir := t.TempDir()
+	logger := logging.NewFileRequestLoggerWithFormat(false, logsDir, "", 10, "json")
+	router := gin.New()
+	router.Use(RequestLoggingMiddleware(logger))
+	router.POST("/v1/responses", func(c *gin.Context) {
+		logger.SetFormat("text")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "rejected"})
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"test"}`))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	entries, errReadDir := os.ReadDir(logsDir)
+	if errReadDir != nil {
+		t.Fatalf("read logs dir: %v", errReadDir)
+	}
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), "error-") || !strings.HasSuffix(entry.Name(), ".log") {
+			continue
+		}
+		content, errRead := os.ReadFile(logsDir + string(os.PathSeparator) + entry.Name())
+		if errRead != nil {
+			t.Fatalf("read error log: %v", errRead)
+		}
+		if !json.Valid(content) {
+			t.Fatalf("error log used reloaded text format: %q", content)
+		}
+		return
+	}
+	t.Fatal("forced error log was not created")
 }
 
 func TestAttachRequestLogSourcesUsesLoggerLogsDir(t *testing.T) {

--- a/internal/api/middleware/request_logging_test.go
+++ b/internal/api/middleware/request_logging_test.go
@@ -300,11 +300,41 @@ func TestAttachRequestLogSourcesUsesLoggerLogsDir(t *testing.T) {
 	}
 }
 
+func TestAttachRequestLogSourcesIncludesUpstreamWebsocketTimelineForHTTP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	logger := logging.NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 0, "json")
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+
+	attachRequestLogSources(c, logger, true)
+	defer cleanupFileBodySourcesFromContext(c)
+
+	value, exists := c.Get(logging.APIWebsocketTimelineSourceContextKey)
+	if !exists {
+		t.Fatal("expected upstream websocket timeline source for ordinary HTTP request")
+	}
+	source, ok := value.(*logging.FileBodySource)
+	if !ok || source == nil {
+		t.Fatalf("source type = %T", value)
+	}
+	payload := bytes.Repeat([]byte("frame"), (8<<20)/5+1)
+	if err := source.AppendPart(payload); err != nil {
+		t.Fatalf("AppendPart failed: %v", err)
+	}
+	if !source.Truncated() {
+		t.Fatal("upstream websocket timeline source is not bounded")
+	}
+}
+
 func cleanupFileBodySourcesFromContext(c *gin.Context) {
 	if c == nil {
 		return
 	}
 	for _, key := range []string{
+		logging.APIRequestSourceContextKey,
+		logging.APIResponseSourceContextKey,
 		logging.WebsocketTimelineSourceContextKey,
 		logging.APIWebsocketTimelineSourceContextKey,
 	} {

--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -300,6 +300,9 @@ func (w *ResponseWriterWrapper) Finalize(c *gin.Context) error {
 	apiRequestSource := w.extractAPIRequestSource(c)
 	apiResponseSource := w.extractAPIResponseSource(c)
 	apiWebsocketTimelineSource := w.extractAPIWebsocketTimelineSource(c)
+	if forceLog && apiRequestSource == nil && apiResponseSource == nil && websocketTimelineSource == nil && apiWebsocketTimelineSource == nil {
+		apiRequestSource = w.newRequestLogFormatSource()
+	}
 	if !w.logger.IsEnabled() && !forceLog {
 		cleanupFileBodySources(websocketTimelineSource, apiRequestSource, apiResponseSource, apiWebsocketTimelineSource)
 		return nil
@@ -390,6 +393,21 @@ func (w *ResponseWriterWrapper) Finalize(c *gin.Context) error {
 		apiRequest = w.extractDeferredAPIRequest(c)
 	}
 	return w.logRequest(w.extractRequestBody(c), finalStatusCode, w.cloneHeaders(), w.extractResponseBody(c), w.extractWebsocketTimeline(c), websocketTimelineSource, apiRequest, apiRequestSource, w.extractAPIResponse(c), apiResponseSource, w.extractAPIWebsocketTimeline(c), apiWebsocketTimelineSource, w.extractAPIResponseTimestamp(c), slicesAPIResponseError, forceLog)
+}
+
+func (w *ResponseWriterWrapper) newRequestLogFormatSource() *logging.FileBodySource {
+	if w == nil || w.requestInfo == nil || w.requestInfo.LogFormat == "" {
+		return nil
+	}
+	factory, ok := w.logger.(formattedFileBodySourceFactory)
+	if !ok || factory == nil {
+		return nil
+	}
+	source, errSource := factory.NewFileBodySourceWithFormat("request-format", w.requestInfo.LogFormat)
+	if errSource != nil {
+		return nil
+	}
+	return source
 }
 
 func (w *ResponseWriterWrapper) cloneHeaders() map[string][]string {

--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -90,6 +90,7 @@ func (w *ResponseWriterWrapper) Write(data []byte) (int, error) {
 		select {
 		case w.chunkChannel <- append([]byte(nil), data...): // Non-blocking send with copy
 		default: // Channel full, skip logging to avoid blocking
+			w.markStreamingLogTruncated()
 		}
 		return n, err
 	}
@@ -137,6 +138,7 @@ func (w *ResponseWriterWrapper) WriteString(data string) (int, error) {
 		select {
 		case w.chunkChannel <- []byte(data):
 		default:
+			w.markStreamingLogTruncated()
 		}
 		return n, err
 	}
@@ -145,6 +147,12 @@ func (w *ResponseWriterWrapper) WriteString(data string) (int, error) {
 		w.body.WriteString(data)
 	}
 	return n, err
+}
+
+func (w *ResponseWriterWrapper) markStreamingLogTruncated() {
+	if marker, ok := w.streamWriter.(interface{ MarkResponseBodyTruncated() }); ok {
+		marker.MarkResponseBodyTruncated()
+	}
 }
 
 // WriteHeader wraps the underlying ResponseWriter's WriteHeader method.

--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -354,14 +354,23 @@ func (w *ResponseWriterWrapper) Finalize(c *gin.Context) error {
 			}
 		}
 		apiWebsocketTimeline := w.extractAPIWebsocketTimeline(c)
-		var errMerge error
-		apiWebsocketTimeline, errMerge = mergeFileBodySource(apiWebsocketTimeline, apiWebsocketTimelineSource)
-		if errMerge != nil {
-			cleanupFileBodySources(websocketTimelineSource, apiRequestSource, apiResponseSource)
-			return errMerge
-		}
 		if len(apiWebsocketTimeline) > 0 {
 			_ = w.streamWriter.WriteAPIWebsocketTimeline(apiWebsocketTimeline)
+		}
+		if sourceWriter, ok := w.streamWriter.(interface {
+			WriteAPIWebsocketTimelineSource(*logging.FileBodySource) error
+		}); ok && apiWebsocketTimelineSource != nil && apiWebsocketTimelineSource.HasPayload() {
+			_ = sourceWriter.WriteAPIWebsocketTimelineSource(apiWebsocketTimelineSource)
+		} else {
+			var errMerge error
+			apiWebsocketTimeline, errMerge = mergeFileBodySource(nil, apiWebsocketTimelineSource)
+			if errMerge != nil {
+				cleanupFileBodySources(websocketTimelineSource, apiRequestSource, apiResponseSource)
+				return errMerge
+			}
+			if len(apiWebsocketTimeline) > 0 {
+				_ = w.streamWriter.WriteAPIWebsocketTimeline(apiWebsocketTimeline)
+			}
 		}
 		if err := w.streamWriter.Close(); err != nil {
 			w.streamWriter = nil

--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -28,6 +28,7 @@ type RequestInfo struct {
 	RequestID           string                      // RequestID is the unique identifier for the request.
 	Timestamp           time.Time                   // Timestamp is when the request was received.
 	deferredBodyCapture *deferredRequestBodyCapture // deferredBodyCapture spools large error-only request bodies.
+	LogFormat           string
 }
 
 // ResponseWriterWrapper wraps the standard gin.ResponseWriter to intercept and log response data.
@@ -170,13 +171,15 @@ func (w *ResponseWriterWrapper) WriteHeader(statusCode int) {
 
 	// If streaming, initialize streaming log writer
 	if w.isStreaming && w.logger.IsEnabled() {
-		streamWriter, err := w.logger.LogStreamingRequest(
-			w.requestInfo.URL,
-			w.requestInfo.Method,
-			w.requestInfo.Headers,
-			w.requestInfo.Body,
-			w.requestInfo.RequestID,
-		)
+		var streamWriter logging.StreamingLogWriter
+		var err error
+		if loggerWithFormat, ok := w.logger.(interface {
+			LogStreamingRequestWithFormat(string, string, map[string][]string, []byte, string, string) (logging.StreamingLogWriter, error)
+		}); ok {
+			streamWriter, err = loggerWithFormat.LogStreamingRequestWithFormat(w.requestInfo.URL, w.requestInfo.Method, w.requestInfo.Headers, w.requestInfo.Body, w.requestInfo.RequestID, w.requestInfo.LogFormat)
+		} else {
+			streamWriter, err = w.logger.LogStreamingRequest(w.requestInfo.URL, w.requestInfo.Method, w.requestInfo.Headers, w.requestInfo.Body, w.requestInfo.RequestID)
+		}
 		if err == nil {
 			w.streamWriter = streamWriter
 			w.chunkChannel = make(chan []byte, 100) // Buffered channel for async writes

--- a/internal/api/middleware/response_writer_test.go
+++ b/internal/api/middleware/response_writer_test.go
@@ -173,9 +173,12 @@ func (l *testRequestLogger) IsEnabled() bool {
 type testStreamingLogWriter struct {
 	apiWebsocketTimeline []byte
 	closed               bool
+	truncated            bool
 }
 
 func (w *testStreamingLogWriter) WriteChunkAsync([]byte) {}
+
+func (w *testStreamingLogWriter) MarkResponseBodyTruncated() { w.truncated = true }
 
 func (w *testStreamingLogWriter) WriteStatus(int, map[string][]string) error {
 	return nil
@@ -199,4 +202,13 @@ func (w *testStreamingLogWriter) SetFirstChunkTimestamp(time.Time) {}
 func (w *testStreamingLogWriter) Close() error {
 	w.closed = true
 	return nil
+}
+
+func TestResponseWriterWrapperMarksFirstStageStreamingDrops(t *testing.T) {
+	streamWriter := &testStreamingLogWriter{}
+	wrapper := &ResponseWriterWrapper{streamWriter: streamWriter}
+	wrapper.markStreamingLogTruncated()
+	if !streamWriter.truncated {
+		t.Fatalf("expected middleware queue drop to mark stream truncated")
+	}
 }

--- a/internal/api/middleware/response_writer_test.go
+++ b/internal/api/middleware/response_writer_test.go
@@ -142,12 +142,24 @@ func TestFinalizeStreamingWritesAPIWebsocketTimeline(t *testing.T) {
 	}
 
 	c.Set("API_WEBSOCKET_TIMELINE", []byte("Timestamp: 2026-04-01T12:00:00Z\nEvent: api.websocket.request\n{}"))
+	source, err := logging.NewFileBodySourceInDir(t.TempDir(), "api-websocket-timeline")
+	if err != nil {
+		t.Fatalf("NewFileBodySourceInDir failed: %v", err)
+	}
+	defer source.Cleanup()
+	if err := source.AppendPart([]byte("source timeline")); err != nil {
+		t.Fatalf("AppendPart failed: %v", err)
+	}
+	c.Set(logging.APIWebsocketTimelineSourceContextKey, source)
 
 	if err := wrapper.Finalize(c); err != nil {
 		t.Fatalf("Finalize error: %v", err)
 	}
 	if string(streamWriter.apiWebsocketTimeline) != "Timestamp: 2026-04-01T12:00:00Z\nEvent: api.websocket.request\n{}" {
 		t.Fatalf("stream writer websocket timeline = %q", string(streamWriter.apiWebsocketTimeline))
+	}
+	if streamWriter.apiWebsocketTimelineSource != source {
+		t.Fatal("stream writer did not receive websocket timeline source")
 	}
 	if !streamWriter.closed {
 		t.Fatal("expected stream writer to be closed")
@@ -171,9 +183,10 @@ func (l *testRequestLogger) IsEnabled() bool {
 }
 
 type testStreamingLogWriter struct {
-	apiWebsocketTimeline []byte
-	closed               bool
-	truncated            bool
+	apiWebsocketTimeline       []byte
+	apiWebsocketTimelineSource *logging.FileBodySource
+	closed                     bool
+	truncated                  bool
 }
 
 func (w *testStreamingLogWriter) WriteChunkAsync([]byte) {}
@@ -194,6 +207,11 @@ func (w *testStreamingLogWriter) WriteAPIResponse([]byte) error {
 
 func (w *testStreamingLogWriter) WriteAPIWebsocketTimeline(apiWebsocketTimeline []byte) error {
 	w.apiWebsocketTimeline = bytes.Clone(apiWebsocketTimeline)
+	return nil
+}
+
+func (w *testStreamingLogWriter) WriteAPIWebsocketTimelineSource(source *logging.FileBodySource) error {
+	w.apiWebsocketTimelineSource = source
 	return nil
 }
 

--- a/internal/api/server_options.go
+++ b/internal/api/server_options.go
@@ -35,7 +35,7 @@ type ServerOption func(*serverOptionConfig)
 func defaultRequestLoggerFactory(cfg *config.Config, configPath string) logging.RequestLogger {
 	configDir := filepath.Dir(configPath)
 	logsDir := logging.ResolveLogDirectory(cfg)
-	logger := logging.NewFileRequestLogger(cfg.RequestLog, logsDir, configDir, cfg.ErrorLogsMaxFiles)
+	logger := logging.NewFileRequestLoggerWithFormat(cfg.RequestLog, logsDir, configDir, cfg.ErrorLogsMaxFiles, cfg.RequestLogFormat)
 	logger.SetHomeEnabled(cfg != nil && cfg.Home.Enabled)
 	return logger
 }

--- a/internal/api/server_reload.go
+++ b/internal/api/server_reload.go
@@ -74,6 +74,11 @@ func (s *Server) UpdateClientsContext(ctx context.Context, cfg *config.Config) b
 			setter.SetHomeEnabled(cfg.Home.Enabled)
 		}
 	}
+	if oldCfg == nil || oldCfg.RequestLogFormat != cfg.RequestLogFormat {
+		if setter, ok := s.requestLogger.(interface{ SetFormat(string) }); ok {
+			setter.SetFormat(cfg.RequestLogFormat)
+		}
+	}
 
 	if oldCfg == nil || oldCfg.LoggingToFile != cfg.LoggingToFile || oldCfg.LogsMaxTotalSizeMB != cfg.LogsMaxTotalSizeMB {
 		if err := logging.ConfigureLogOutput(cfg); err != nil {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -451,6 +451,30 @@ func newTestServerWithOptions(t *testing.T, opts ...ServerOption) *Server {
 	return NewServer(cfg, authManager, accessManager, configPath, opts...)
 }
 
+type reloadableRequestLogger struct {
+	internallogging.RequestLogger
+	format string
+}
+
+func (l *reloadableRequestLogger) SetFormat(format string) {
+	l.format = format
+}
+
+func TestUpdateClientsAppliesRequestLogFormat(t *testing.T) {
+	logger := &reloadableRequestLogger{}
+	server := newTestServerWithOptions(t, WithRequestLoggerFactory(func(*proxyconfig.Config, string) internallogging.RequestLogger {
+		return logger
+	}))
+
+	nextCfg := *server.cfg
+	nextCfg.RequestLogFormat = "json"
+	server.UpdateClients(&nextCfg)
+
+	if logger.format != "json" {
+		t.Fatalf("format = %q, want json", logger.format)
+	}
+}
+
 func TestHealthz(t *testing.T) {
 	server := newTestServer(t)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,9 @@ type Config struct {
 	// LoggingToFile controls whether application logs are written to rotating files or stdout.
 	LoggingToFile bool `yaml:"logging-to-file" json:"logging-to-file"`
 
+	// RequestLogFormat specifies the request log format: "text" (default) or "json" (NDJSON).
+	RequestLogFormat string `yaml:"request-log-format" json:"request-log-format"`
+
 	// LogsMaxTotalSizeMB limits the total size (in MB) of log files under the logs directory.
 	// When exceeded, the oldest log files are deleted until within the limit. Set to 0 to disable.
 	LogsMaxTotalSizeMB int `yaml:"logs-max-total-size-mb" json:"logs-max-total-size-mb"`

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -64,6 +64,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	var cfg Config
 	// Set defaults before unmarshal so that absent keys keep defaults.
 	cfg.Host = "" // Default empty: binds to all interfaces (IPv4 + IPv6)
+	cfg.RequestLogFormat = "text"
 	cfg.LoggingToFile = false
 	cfg.LogsMaxTotalSizeMB = 0
 	cfg.ErrorLogsMaxFiles = 10
@@ -140,6 +141,10 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	if cfg.MaxRetryCredentials < 0 {
 		cfg.MaxRetryCredentials = 0
+	}
+	cfg.RequestLogFormat = strings.ToLower(strings.TrimSpace(cfg.RequestLogFormat))
+	if cfg.RequestLogFormat != "json" {
+		cfg.RequestLogFormat = "text"
 	}
 
 	cfg.NormalizePluginsConfig()

--- a/internal/config/config_yaml.go
+++ b/internal/config/config_yaml.go
@@ -337,6 +337,8 @@ func isKnownDefaultValue(path []string, node *yaml.Node) bool {
 			return node.Value == DefaultPanelGitHubRepository
 		case "plugins.dir":
 			return node.Value == "plugins"
+		case "request-log-format":
+			return node.Value == "text"
 		case "routing.strategy":
 			return node.Value == "round-robin"
 		}

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -23,6 +23,7 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	var cfg Config
 	// Keep defaults aligned with LoadConfigOptional.
 	cfg.Host = "" // Default empty: binds to all interfaces (IPv4 + IPv6)
+	cfg.RequestLogFormat = "text"
 	cfg.LoggingToFile = false
 	cfg.LogsMaxTotalSizeMB = 0
 	cfg.ErrorLogsMaxFiles = 10
@@ -86,6 +87,10 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 
 	if cfg.MaxRetryCredentials < 0 {
 		cfg.MaxRetryCredentials = 0
+	}
+	cfg.RequestLogFormat = strings.ToLower(strings.TrimSpace(cfg.RequestLogFormat))
+	if cfg.RequestLogFormat != "json" {
+		cfg.RequestLogFormat = "text"
 	}
 
 	cfg.NormalizePluginsConfig()

--- a/internal/config/plugin_config_test.go
+++ b/internal/config/plugin_config_test.go
@@ -206,6 +206,26 @@ func TestSaveConfigPreserveComments_PrunesDefaultPluginsDir(t *testing.T) {
 	}
 }
 
+func TestSaveConfigPreserveComments_PrunesDefaultRequestLogFormat(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if errWrite := os.WriteFile(configPath, []byte("debug: true\n"), 0o600); errWrite != nil {
+		t.Fatalf("os.WriteFile() error = %v", errWrite)
+	}
+
+	cfg := &Config{Debug: true, RequestLogFormat: "text"}
+	if errSave := SaveConfigPreserveComments(configPath, cfg); errSave != nil {
+		t.Fatalf("SaveConfigPreserveComments() error = %v", errSave)
+	}
+
+	data, errRead := os.ReadFile(configPath)
+	if errRead != nil {
+		t.Fatalf("os.ReadFile() error = %v", errRead)
+	}
+	if strings.Contains(string(data), "request-log-format:") {
+		t.Fatalf("saved config contains default request log format:\n%s", data)
+	}
+}
+
 func TestParseConfigBytes_PluginInstanceRawYAML(t *testing.T) {
 	cfg, errParse := ParseConfigBytes([]byte(`
 plugins:

--- a/internal/logging/json_logger_test.go
+++ b/internal/logging/json_logger_test.go
@@ -228,7 +228,7 @@ func TestJSONRequestLoggingPreservesDecompressionError(t *testing.T) {
 	tempDir := t.TempDir()
 	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
 	err := logger.writeNonStreamingLog(
-		io.Discard, "/v1/chat/completions", "POST", nil, []byte(`{"model":"gpt-4"}`), "",
+		io.Discard, "/v1/chat/completions", "POST", nil, []byte(`{"model":"gpt-4"}`), "", false,
 		nil, nil, nil, nil, nil, nil, nil, nil, nil,
 		200, map[string][]string{"Content-Encoding": {"gzip"}}, []byte("not-gzip"),
 		errors.New("gzip: invalid header"), time.Now(), time.Time{},
@@ -239,7 +239,7 @@ func TestJSONRequestLoggingPreservesDecompressionError(t *testing.T) {
 
 	var buf bytes.Buffer
 	err = logger.writeNonStreamingLog(
-		&buf, "/v1/chat/completions", "POST", nil, []byte(`{"model":"gpt-4"}`), "",
+		&buf, "/v1/chat/completions", "POST", nil, []byte(`{"model":"gpt-4"}`), "", false,
 		nil, nil, nil, nil, nil, nil, nil, nil, nil,
 		200, map[string][]string{"Content-Encoding": {"gzip"}}, []byte("not-gzip"),
 		errors.New("gzip: invalid header"), time.Now(), time.Time{},
@@ -811,6 +811,38 @@ func TestJSONWebsocketTimelineSourceCapsAppendPartWhileSpooling(t *testing.T) {
 	}
 	if len(data) != maxJSONFileBackedSectionBytes {
 		t.Fatalf("merged source size = %d, want %d", len(data), maxJSONFileBackedSectionBytes)
+	}
+}
+
+func TestJSONRequestBodyTempFileCapsWhileSpooling(t *testing.T) {
+	logger := NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 10, "json")
+	payload := bytes.Repeat([]byte("x"), maxJSONFileBackedSectionBytes+1024)
+	path, truncated, err := logger.writeRequestBodyTempFile(payload)
+	if err != nil {
+		t.Fatalf("writeRequestBodyTempFile failed: %v", err)
+	}
+	defer os.Remove(path)
+	if !truncated {
+		t.Fatal("request body temp file was not marked truncated")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat request body temp file: %v", err)
+	}
+	if info.Size() != maxJSONFileBackedSectionBytes {
+		t.Fatalf("request body temp file size = %d, want %d", info.Size(), maxJSONFileBackedSectionBytes)
+	}
+
+	var buf bytes.Buffer
+	if err := logger.writeJSONLog(&buf, "/v1/responses", "POST", nil, nil, path, truncated, 200, nil, nil, "", false, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, time.Now(), time.Time{}, "http", "http"); err != nil {
+		t.Fatalf("writeJSONLog failed: %v", err)
+	}
+	var entry jsonLogPayload
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("unmarshal JSON log: %v", err)
+	}
+	if !entry.RequestBodyTruncated {
+		t.Fatal("request_body_truncated = false, want true")
 	}
 }
 

--- a/internal/logging/json_logger_test.go
+++ b/internal/logging/json_logger_test.go
@@ -745,7 +745,7 @@ func TestLimitedFileBodySourceWrites(t *testing.T) {
 func TestJSONRequestBodyTempFileCapsWhileSpooling(t *testing.T) {
 	logger := NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 10, "json")
 	payload := bytes.Repeat([]byte("x"), maxJSONFileBackedSectionBytes+1024)
-	path, truncated, err := logger.writeRequestBodyTempFile(payload)
+	path, truncated, err := logger.writeRequestBodyTempFile(payload, "json")
 	if err != nil {
 		t.Fatalf("writeRequestBodyTempFile failed: %v", err)
 	}
@@ -915,6 +915,29 @@ func TestJSONStreamingRequestLoggingPreservesWebsocketSourceTruncation(t *testin
 	}
 	if !entry.APIWebsocketTimelineTruncated {
 		t.Fatal("api_websocket_timeline_truncated = false, want true")
+	}
+}
+
+func TestRequestLogFormatSnapshotSurvivesReload(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+	source, err := logger.NewFileBodySourceWithFormat("api-request", "json")
+	if err != nil {
+		t.Fatalf("NewFileBodySourceWithFormat failed: %v", err)
+	}
+	if err := source.AppendBytes([]byte(`{"model":"gpt-5"}`)); err != nil {
+		t.Fatalf("AppendBytes failed: %v", err)
+	}
+	logger.SetFormat("text")
+	if err := logger.LogRequestWithOptionsAndAllSources(
+		"/v1/responses", "POST", nil, nil, 200, nil, nil,
+		nil, nil, nil, source, nil, nil, nil, nil, nil, false,
+		"req-format-snapshot-123", time.Now(), time.Time{},
+	); err != nil {
+		t.Fatalf("LogRequestWithOptionsAndAllSources failed: %v", err)
+	}
+	if data := readOnlyLogFile(t, tempDir); !json.Valid(data) {
+		t.Fatalf("request finalized with reloaded text format: %q", data)
 	}
 }
 

--- a/internal/logging/json_logger_test.go
+++ b/internal/logging/json_logger_test.go
@@ -1,0 +1,784 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+)
+
+func TestJSONRequestLogging(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+
+	reqHeaders := map[string][]string{
+		"Authorization": {"Bearer secret-token"},
+		"User-Agent":    {"test-agent"},
+	}
+	respHeaders := map[string][]string{
+		"Content-Type": {"application/json"},
+	}
+	reqBody := []byte(`{"model":"gpt-4","max_tokens":100}`)
+	respBody := []byte(`{"id":"chatcmpl-123","object":"chat.completion"}`)
+
+	reqTime := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	respTime := reqTime.Add(200 * time.Millisecond)
+
+	err := logger.LogRequest(
+		"/v1/chat/completions",
+		"POST",
+		reqHeaders,
+		reqBody,
+		200,
+		respHeaders,
+		respBody,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		"req-json-123",
+		reqTime,
+		respTime,
+	)
+	if err != nil {
+		t.Fatalf("LogRequest failed: %v", err)
+	}
+
+	files, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatalf("failed to read temp log dir: %v", err)
+	}
+
+	if len(files) == 0 {
+		t.Fatalf("expected at least 1 log file, found 0")
+	}
+
+	logPath := filepath.Join(tempDir, files[0].Name())
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+
+	var entry jsonLogPayload
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("failed to unmarshal NDJSON entry: %v, raw data: %s", err, string(data))
+	}
+
+	if entry.URL != "/v1/chat/completions" {
+		t.Errorf("expected URL /v1/chat/completions, got %s", entry.URL)
+	}
+	if entry.Method != "POST" {
+		t.Errorf("expected Method POST, got %s", entry.Method)
+	}
+
+	if entry.Headers["Authorization"][0] != "Bearer s***n" && entry.Headers["Authorization"][0] != "Bearer s***" {
+		// Masked check
+		if entry.Headers["Authorization"][0] == "Bearer secret-token" {
+			t.Errorf("Authorization header was not masked")
+		}
+	}
+
+	var reqBodyObj map[string]interface{}
+	if err := json.Unmarshal(entry.RequestBody, &reqBodyObj); err != nil {
+		t.Fatalf("failed to unmarshal request_body JSON: %v", err)
+	}
+	if reqBodyObj["model"] != "gpt-4" {
+		t.Errorf("expected model gpt-4, got %v", reqBodyObj["model"])
+	}
+
+	if entry.Response == nil {
+		t.Fatalf("expected response object to be non-nil")
+	}
+	if entry.Response.Status != 200 {
+		t.Errorf("expected status 200, got %d", entry.Response.Status)
+	}
+}
+
+func TestJSONStreamingRequestLogging(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+
+	writer, err := logger.LogStreamingRequest(
+		"/v1/chat/completions",
+		"POST",
+		map[string][]string{"User-Agent": {"test-agent"}},
+		[]byte(`{"model":"gpt-4","stream":true}`),
+		"req-stream-123",
+	)
+	if err != nil {
+		t.Fatalf("LogStreamingRequest failed: %v", err)
+	}
+
+	_ = writer.WriteStatus(200, map[string][]string{"Content-Type": {"text/event-stream"}})
+	writer.WriteChunkAsync([]byte("data: {\"choices\":[]}\n\n"))
+	_ = writer.WriteAPIRequest([]byte(`{"upstream":"req"}`))
+	_ = writer.WriteAPIResponse([]byte(`{"upstream":"resp"}`))
+	firstChunkTimestamp := time.Date(2026, time.July, 25, 12, 34, 56, 123, time.UTC)
+	writer.SetFirstChunkTimestamp(firstChunkTimestamp)
+
+	time.Sleep(50 * time.Millisecond)
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	files, err := os.ReadDir(tempDir)
+	if err != nil || len(files) == 0 {
+		t.Fatalf("expected log file in tempDir")
+	}
+
+	logPath := filepath.Join(tempDir, files[0].Name())
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+
+	var entry jsonLogPayload
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("failed to unmarshal NDJSON streaming entry: %v, raw data: %s", err, string(data))
+	}
+
+	if entry.URL != "/v1/chat/completions" {
+		t.Errorf("expected URL /v1/chat/completions, got %s", entry.URL)
+	}
+	if entry.APIRequest == nil && entry.APIRequestRaw == "" {
+		t.Errorf("expected non-empty APIRequest")
+	}
+	if entry.APIResponse == nil && entry.APIResponseRaw == "" {
+		t.Errorf("expected non-empty APIResponse")
+	}
+	if entry.APIResponseTimestamp != firstChunkTimestamp.Format(time.RFC3339Nano) {
+		t.Errorf("api_response_timestamp = %q, want %q", entry.APIResponseTimestamp, firstChunkTimestamp.Format(time.RFC3339Nano))
+	}
+}
+
+func TestJSONRequestLoggingSerializesErrorsAndMasksAddonHeaders(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+
+	err := logger.LogRequest(
+		"/v1/chat/completions",
+		"POST",
+		nil,
+		[]byte(`{"model":"gpt-4"}`),
+		502,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		[]*interfaces.ErrorMessage{{
+			StatusCode: http.StatusBadGateway,
+			Error:      errors.New("upstream connection failed"),
+			Addon: http.Header{
+				"Authorization": {"Bearer secret-token"},
+			},
+		}},
+		"req-error-123",
+		time.Now(),
+		time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("LogRequest failed: %v", err)
+	}
+
+	files, err := os.ReadDir(tempDir)
+	if err != nil || len(files) == 0 {
+		t.Fatalf("expected log file in tempDir")
+	}
+	data, err := os.ReadFile(filepath.Join(tempDir, files[0].Name()))
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+
+	var entry struct {
+		APIResponseErrors []struct {
+			StatusCode int                 `json:"status_code"`
+			Error      string              `json:"error"`
+			Addon      map[string][]string `json:"addon,omitempty"`
+		} `json:"api_response_errors"`
+	}
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("failed to unmarshal NDJSON entry: %v", err)
+	}
+	if len(entry.APIResponseErrors) != 1 {
+		t.Fatalf("expected one API error, got %d", len(entry.APIResponseErrors))
+	}
+	if entry.APIResponseErrors[0].Error != "upstream connection failed" {
+		t.Fatalf("error = %q, want upstream connection failed", entry.APIResponseErrors[0].Error)
+	}
+	if got := entry.APIResponseErrors[0].Addon["Authorization"][0]; got == "Bearer secret-token" {
+		t.Fatalf("Authorization addon header was not masked")
+	}
+}
+
+func TestJSONRequestLoggingPreservesDecompressionError(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+	err := logger.writeNonStreamingLog(
+		io.Discard, "/v1/chat/completions", "POST", nil, []byte(`{"model":"gpt-4"}`), "",
+		nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		200, map[string][]string{"Content-Encoding": {"gzip"}}, []byte("not-gzip"),
+		errors.New("gzip: invalid header"), time.Now(), time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("writeNonStreamingLog failed: %v", err)
+	}
+
+	var buf bytes.Buffer
+	err = logger.writeNonStreamingLog(
+		&buf, "/v1/chat/completions", "POST", nil, []byte(`{"model":"gpt-4"}`), "",
+		nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		200, map[string][]string{"Content-Encoding": {"gzip"}}, []byte("not-gzip"),
+		errors.New("gzip: invalid header"), time.Now(), time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("writeNonStreamingLog failed: %v", err)
+	}
+	var entry jsonLogPayload
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("unmarshal JSON log: %v", err)
+	}
+	if entry.Response == nil || entry.Response.DecompressionError != "gzip: invalid header" {
+		t.Fatalf("decompression_error = %q", entry.Response.DecompressionError)
+	}
+}
+
+func TestFileRequestLoggerSetFormat(t *testing.T) {
+	logger := NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 10, "text")
+	logger.SetFormat("json")
+	if got := logger.currentFormat(); got != "json" {
+		t.Fatalf("format = %q, want json", got)
+	}
+	logger.SetFormat("invalid")
+	if got := logger.currentFormat(); got != "text" {
+		t.Fatalf("format = %q, want text", got)
+	}
+}
+
+func TestFileRequestLoggerSetFormatConcurrentAccess(t *testing.T) {
+	logger := NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 10, "text")
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				logger.SetFormat("json")
+				_ = logger.currentFormat()
+				logger.SetFormat("text")
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestJSONRequestLoggingPreservesAPIWebsocketTimeline(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+
+	err := logger.LogRequest(
+		"/v1/chat/completions",
+		"POST",
+		nil,
+		[]byte(`{"model":"gpt-4"}`),
+		200,
+		nil,
+		[]byte(`{"ok":true}`),
+		nil,
+		nil,
+		nil,
+		[]byte("connected\nframe: response.completed"),
+		nil,
+		"req-ws-123",
+		time.Now(),
+		time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("LogRequest failed: %v", err)
+	}
+
+	files, err := os.ReadDir(tempDir)
+	if err != nil || len(files) == 0 {
+		t.Fatalf("expected log file in tempDir")
+	}
+	data, err := os.ReadFile(filepath.Join(tempDir, files[0].Name()))
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+
+	var entry struct {
+		APIWebsocketTimelineRaw string `json:"api_websocket_timeline_raw"`
+	}
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("failed to unmarshal NDJSON entry: %v", err)
+	}
+	if entry.APIWebsocketTimelineRaw != "connected\nframe: response.completed" {
+		t.Fatalf("timeline = %q", entry.APIWebsocketTimelineRaw)
+	}
+}
+
+func TestJSONStreamingRequestLoggingCapsResponseBody(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+
+	writer, err := logger.LogStreamingRequest(
+		"/v1/chat/completions",
+		"POST",
+		nil,
+		[]byte(`{"model":"gpt-4","stream":true}`),
+		"req-large-stream-123",
+	)
+	if err != nil {
+		t.Fatalf("LogStreamingRequest failed: %v", err)
+	}
+	_ = writer.WriteStatus(200, map[string][]string{"Content-Type": {"text/event-stream"}})
+	writer.WriteChunkAsync(bytes.Repeat([]byte("x"), maxJSONStreamingResponseBytes+1024))
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	files, err := os.ReadDir(tempDir)
+	if err != nil || len(files) == 0 {
+		t.Fatalf("expected log file in tempDir")
+	}
+	data, err := os.ReadFile(filepath.Join(tempDir, files[0].Name()))
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+
+	var entry struct {
+		Response struct {
+			BodyRaw       string `json:"body_raw"`
+			BodyTruncated bool   `json:"body_truncated"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("failed to unmarshal NDJSON entry: %v", err)
+	}
+	if !entry.Response.BodyTruncated {
+		t.Fatalf("expected response body to be marked truncated")
+	}
+	if len(entry.Response.BodyRaw) > maxJSONStreamingResponseBytes {
+		t.Fatalf("response body length = %d, limit = %d", len(entry.Response.BodyRaw), maxJSONStreamingResponseBytes)
+	}
+}
+
+func TestJSONRequestLoggingCapsFileBackedAPIResponse(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+	source, err := NewFileBodySourceInDir(tempDir, "api-response")
+	if err != nil {
+		t.Fatalf("NewFileBodySourceInDir failed: %v", err)
+	}
+	part, err := source.CreatePart("response")
+	if err != nil {
+		t.Fatalf("CreatePart failed: %v", err)
+	}
+	if _, err := part.Write(bytes.Repeat([]byte("y"), maxJSONFileBackedSectionBytes+1024)); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+	if err := part.Close(); err != nil {
+		t.Fatalf("failed to close source: %v", err)
+	}
+
+	err = logger.LogRequestWithOptionsAndAllSources(
+		"/v1/chat/completions",
+		"POST",
+		nil,
+		[]byte(`{"model":"gpt-4"}`),
+		502,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		source,
+		nil,
+		nil,
+		nil,
+		false,
+		"req-api-response-123",
+		time.Now(),
+		time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("LogRequestWithOptionsAndAllSources failed: %v", err)
+	}
+
+	files, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatalf("failed to read tempDir: %v", err)
+	}
+	var data []byte
+	for _, file := range files {
+		if filepath.Ext(file.Name()) != ".log" {
+			continue
+		}
+		data, err = os.ReadFile(filepath.Join(tempDir, file.Name()))
+		if err != nil {
+			t.Fatalf("failed to read log: %v", err)
+		}
+		break
+	}
+	if len(data) == 0 {
+		t.Fatalf("expected request log file")
+	}
+
+	var entry struct {
+		APIResponseRaw       string `json:"api_response_raw"`
+		APIResponseTruncated bool   `json:"api_response_truncated"`
+	}
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("failed to unmarshal NDJSON entry: %v", err)
+	}
+	if !entry.APIResponseTruncated {
+		t.Fatalf("expected API response to be marked truncated")
+	}
+	if len(entry.APIResponseRaw) > maxJSONFileBackedSectionBytes {
+		t.Fatalf("API response length = %d, limit = %d", len(entry.APIResponseRaw), maxJSONFileBackedSectionBytes)
+	}
+}
+
+func TestJSONRequestLoggingKeepsDownstreamWebsocketTimelineInJSON(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+
+	err := logger.LogRequest(
+		"/v1/responses",
+		"GET",
+		map[string][]string{"Upgrade": {"websocket"}},
+		nil,
+		101,
+		nil,
+		nil,
+		[]byte("client: open\nserver: ready"),
+		nil,
+		nil,
+		nil,
+		nil,
+		"req-downstream-ws-123",
+		time.Now(),
+		time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("LogRequest failed: %v", err)
+	}
+
+	files, err := os.ReadDir(tempDir)
+	if err != nil || len(files) == 0 {
+		t.Fatalf("expected log file in tempDir")
+	}
+	data, err := os.ReadFile(filepath.Join(tempDir, files[0].Name()))
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+
+	var entry struct {
+		DownstreamTransport  string `json:"downstream_transport"`
+		WebsocketTimelineRaw string `json:"websocket_timeline_raw"`
+	}
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("expected NDJSON websocket log, got %v: %s", err, string(data))
+	}
+	if entry.DownstreamTransport != "websocket" {
+		t.Fatalf("downstream transport = %q, want websocket", entry.DownstreamTransport)
+	}
+	if entry.WebsocketTimelineRaw != "client: open\nserver: ready" {
+		t.Fatalf("timeline = %q", entry.WebsocketTimelineRaw)
+	}
+}
+
+func TestJSONRequestLoggingCapsFileBackedAPIRequest(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+	source, err := NewFileBodySourceInDir(tempDir, "api-request")
+	if err != nil {
+		t.Fatalf("NewFileBodySourceInDir failed: %v", err)
+	}
+	part, err := source.CreatePart("request")
+	if err != nil {
+		t.Fatalf("CreatePart failed: %v", err)
+	}
+	if _, err := part.Write(bytes.Repeat([]byte("z"), maxJSONFileBackedSectionBytes+1024)); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+	if err := part.Close(); err != nil {
+		t.Fatalf("failed to close source: %v", err)
+	}
+
+	err = logger.LogRequestWithOptionsAndAllSources(
+		"/v1/chat/completions", "POST", nil, []byte(`{"model":"gpt-4"}`),
+		200, nil, nil, nil, nil, nil, source, nil, nil, nil, nil, nil,
+		false, "req-api-request-123", time.Now(), time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("LogRequestWithOptionsAndAllSources failed: %v", err)
+	}
+
+	data := readOnlyLogFile(t, tempDir)
+	var entry struct {
+		APIRequestRaw       string `json:"api_request_raw"`
+		APIRequestTruncated bool   `json:"api_request_truncated"`
+	}
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("failed to unmarshal NDJSON entry: %v", err)
+	}
+	if !entry.APIRequestTruncated {
+		t.Fatalf("expected API request to be marked truncated")
+	}
+	if len(entry.APIRequestRaw) > maxJSONFileBackedSectionBytes {
+		t.Fatalf("API request length = %d, limit = %d", len(entry.APIRequestRaw), maxJSONFileBackedSectionBytes)
+	}
+}
+
+func TestJSONRequestLoggingMergesInlineAndFileBackedAPISections(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+	requestSource, err := NewFileBodySourceInDir(tempDir, "api-request-merge")
+	if err != nil {
+		t.Fatalf("NewFileBodySourceInDir request: %v", err)
+	}
+	if err := requestSource.AppendPart([]byte("source-request\n")); err != nil {
+		t.Fatalf("AppendPart request: %v", err)
+	}
+	responseSource, err := NewFileBodySourceInDir(tempDir, "api-response-merge")
+	if err != nil {
+		t.Fatalf("NewFileBodySourceInDir response: %v", err)
+	}
+	if err := responseSource.AppendPart([]byte("source-response\n")); err != nil {
+		t.Fatalf("AppendPart response: %v", err)
+	}
+
+	err = logger.LogRequestWithOptionsAndAllSources(
+		"/v1/chat/completions", "POST", nil, nil, 200, nil, nil, nil, nil,
+		[]byte("inline-request"), requestSource, []byte("inline-response"), responseSource,
+		nil, nil, nil, false, "req-merge-123", time.Now(), time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("LogRequestWithOptionsAndAllSources: %v", err)
+	}
+	data := readOnlyLogFile(t, tempDir)
+	var entry jsonLogPayload
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("unmarshal JSON log: %v", err)
+	}
+	if entry.APIRequestRaw != "source-request\ninline-request" {
+		t.Fatalf("api_request_raw = %q", entry.APIRequestRaw)
+	}
+	if entry.APIResponseRaw != "source-response\ninline-response" {
+		t.Fatalf("api_response_raw = %q", entry.APIResponseRaw)
+	}
+}
+
+func TestJSONStreamingRequestLoggingMarksQueueDropsTruncated(t *testing.T) {
+	writer := &FileStreamingLogWriter{chunkChan: make(chan []byte, 1), format: "json"}
+	writer.chunkChan <- []byte("queued")
+	writer.WriteChunkAsync([]byte("dropped"))
+	if !writer.responseBodyTruncated.Load() {
+		t.Fatalf("expected queue drop to mark response body truncated")
+	}
+
+	homeWriter := &homeStreamingLogWriter{chunkChan: make(chan []byte, 1), format: "json"}
+	homeWriter.chunkChan <- []byte("queued")
+	homeWriter.WriteChunkAsync([]byte("dropped"))
+	if !homeWriter.responseBodyTruncated.Load() {
+		t.Fatalf("expected Home queue drop to mark response body truncated")
+	}
+}
+
+func TestJSONStreamingRequestLoggingSerializesQueueDropOnResponse(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+	streamWriter, err := logger.LogStreamingRequest(
+		"/v1/chat/completions", "POST", nil, []byte(`{"model":"gpt-4","stream":true}`),
+		"req-queue-drop-123",
+	)
+	if err != nil {
+		t.Fatalf("LogStreamingRequest failed: %v", err)
+	}
+	writer := streamWriter.(*FileStreamingLogWriter)
+	writer.responseBodyTruncated.Store(true)
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	data := readOnlyLogFile(t, tempDir)
+	var entry jsonLogPayload
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("unmarshal JSON log: %v", err)
+	}
+	if entry.RequestBodyTruncated {
+		t.Fatalf("request body incorrectly marked truncated")
+	}
+	if entry.Response == nil || !entry.Response.BodyTruncated {
+		t.Fatalf("response body missing queue-drop truncation marker")
+	}
+}
+
+func TestJSONStreamingRequestLoggingCapsTempFileWhileSpooling(t *testing.T) {
+	tempDir := t.TempDir()
+	responseFile, err := os.CreateTemp(tempDir, "response-body-*.tmp")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	writer := &FileStreamingLogWriter{
+		responseBodyFile: responseFile,
+		responseBodyPath: responseFile.Name(),
+		chunkChan:        make(chan []byte, 2),
+		closeChan:        make(chan struct{}),
+		errorChan:        make(chan error, 1),
+		format:           "json",
+	}
+	go writer.asyncWriter()
+	writer.chunkChan <- bytes.Repeat([]byte("x"), maxJSONStreamingResponseBytes)
+	writer.chunkChan <- []byte("overflow")
+	close(writer.chunkChan)
+	<-writer.closeChan
+
+	info, err := os.Stat(writer.responseBodyPath)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Size() > maxJSONStreamingResponseBytes {
+		t.Fatalf("temp file size = %d", info.Size())
+	}
+	if !writer.responseBodyTruncated.Load() {
+		t.Fatalf("expected spooling limit to mark response truncated")
+	}
+}
+
+func TestJSONStreamingRequestLoggingCapsRequestBody(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+	writer, err := logger.LogStreamingRequest(
+		"/v1/chat/completions", "POST", nil,
+		bytes.Repeat([]byte("r"), maxJSONFileBackedSectionBytes+1024),
+		"req-stream-request-body-123",
+	)
+	if err != nil {
+		t.Fatalf("LogStreamingRequest failed: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	data := readOnlyLogFile(t, tempDir)
+	var entry struct {
+		RequestBodyRaw       string `json:"request_body_raw"`
+		RequestBodyTruncated bool   `json:"request_body_truncated"`
+	}
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("failed to unmarshal NDJSON entry: %v", err)
+	}
+	if !entry.RequestBodyTruncated {
+		t.Fatalf("expected request body to be marked truncated")
+	}
+	if len(entry.RequestBodyRaw) > maxJSONFileBackedSectionBytes {
+		t.Fatalf("request body length = %d, limit = %d", len(entry.RequestBodyRaw), maxJSONFileBackedSectionBytes)
+	}
+}
+
+func TestJSONStreamingRequestLoggingPropagatesMissingRequestBodyFile(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+	streamWriter, err := logger.LogStreamingRequest(
+		"/v1/chat/completions", "POST", nil, []byte(`{"model":"gpt-4","stream":true}`),
+		"req-missing-body-123",
+	)
+	if err != nil {
+		t.Fatalf("LogStreamingRequest failed: %v", err)
+	}
+	writer, ok := streamWriter.(*FileStreamingLogWriter)
+	if !ok {
+		t.Fatalf("writer type = %T", streamWriter)
+	}
+	if err := os.Remove(writer.requestBodyPath); err != nil {
+		t.Fatalf("remove request body temp file: %v", err)
+	}
+	if err := writer.Close(); err == nil {
+		t.Fatalf("Close succeeded with missing request body temp file")
+	}
+}
+
+func TestJSONRequestLoggingMarksFileBackedWebsocketTimelinesTruncated(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+	downstream := newLargeFileBodySource(t, tempDir, "downstream-ws")
+	upstream := newLargeFileBodySource(t, tempDir, "upstream-ws")
+
+	err := logger.LogRequestWithOptionsAndAllSources(
+		"/v1/responses", "GET", map[string][]string{"Upgrade": {"websocket"}}, nil,
+		101, nil, nil, nil, downstream, nil, nil, nil, nil, nil, upstream, nil,
+		false, "req-ws-truncated-123", time.Now(), time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("LogRequestWithOptionsAndAllSources failed: %v", err)
+	}
+
+	data := readOnlyLogFile(t, tempDir)
+	var entry struct {
+		WebsocketTimelineTruncated    bool `json:"websocket_timeline_truncated"`
+		APIWebsocketTimelineTruncated bool `json:"api_websocket_timeline_truncated"`
+	}
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("failed to unmarshal NDJSON entry: %v", err)
+	}
+	if !entry.WebsocketTimelineTruncated {
+		t.Fatalf("expected downstream websocket timeline to be marked truncated")
+	}
+	if !entry.APIWebsocketTimelineTruncated {
+		t.Fatalf("expected upstream websocket timeline to be marked truncated")
+	}
+}
+
+func newLargeFileBodySource(t *testing.T, dir, prefix string) *FileBodySource {
+	t.Helper()
+	source, err := NewFileBodySourceInDir(dir, prefix)
+	if err != nil {
+		t.Fatalf("NewFileBodySourceInDir failed: %v", err)
+	}
+	part, err := source.CreatePart("timeline")
+	if err != nil {
+		t.Fatalf("CreatePart failed: %v", err)
+	}
+	if _, err := part.Write(bytes.Repeat([]byte("w"), maxJSONFileBackedSectionBytes+1024)); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+	if err := part.Close(); err != nil {
+		t.Fatalf("failed to close source: %v", err)
+	}
+	return source
+}
+
+func readOnlyLogFile(t *testing.T, dir string) []byte {
+	t.Helper()
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read log dir: %v", err)
+	}
+	for _, file := range files {
+		if filepath.Ext(file.Name()) != ".log" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, file.Name()))
+		if err != nil {
+			t.Fatalf("failed to read log file: %v", err)
+		}
+		return data
+	}
+	t.Fatalf("expected log file in %s", dir)
+	return nil
+}

--- a/internal/logging/json_logger_test.go
+++ b/internal/logging/json_logger_test.go
@@ -776,6 +776,44 @@ func TestJSONFileBodySourcesCapWhileSpooling(t *testing.T) {
 	}
 }
 
+func TestJSONWebsocketTimelineSourceCapsAppendPartWhileSpooling(t *testing.T) {
+	logger := NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 10, "json")
+	source, err := logger.NewFileBodySource("api-websocket-timeline")
+	if err != nil {
+		t.Fatalf("NewFileBodySource failed: %v", err)
+	}
+	defer source.Cleanup()
+
+	part := bytes.Repeat([]byte("frame"), 1024)
+	for !source.Truncated() {
+		if err := source.AppendPart(part); err != nil {
+			t.Fatalf("AppendPart failed: %v", err)
+		}
+	}
+	var total int64
+	for _, path := range source.Paths() {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat source part: %v", err)
+		}
+		total += info.Size()
+	}
+	if total != maxJSONFileBackedSectionBytes {
+		t.Fatalf("source size = %d, want %d", total, maxJSONFileBackedSectionBytes)
+	}
+
+	data, truncated, err := mergeJSONSectionLimited(source, nil, maxJSONFileBackedSectionBytes)
+	if err != nil {
+		t.Fatalf("mergeJSONSectionLimited failed: %v", err)
+	}
+	if !truncated {
+		t.Fatal("merged source was not marked truncated")
+	}
+	if len(data) != maxJSONFileBackedSectionBytes {
+		t.Fatalf("merged source size = %d, want %d", len(data), maxJSONFileBackedSectionBytes)
+	}
+}
+
 func TestJSONStreamingRequestLoggingMarksQueueDropsTruncated(t *testing.T) {
 	writer := &FileStreamingLogWriter{chunkChan: make(chan []byte, 1), format: "json"}
 	writer.chunkChan <- []byte("queued")

--- a/internal/logging/json_logger_test.go
+++ b/internal/logging/json_logger_test.go
@@ -659,6 +659,40 @@ func TestJSONRequestLoggingEncodesJSONLikeInvalidUTF8Losslessly(t *testing.T) {
 	}
 }
 
+func TestJSONRequestLoggingEncodesInvalidUTF8WebsocketTimelines(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+	timeline := []byte{0xff, 0x00, 0xfe}
+	err := logger.LogRequest(
+		"/v1/responses", "GET", map[string][]string{"Upgrade": {"websocket"}}, nil, 101, nil, nil,
+		timeline, nil, nil, timeline, nil, "req-ws-binary-123", time.Now(), time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("LogRequest failed: %v", err)
+	}
+
+	data := readOnlyLogFile(t, tempDir)
+	if !utf8.Valid(data) || !json.Valid(data) {
+		t.Fatalf("log entry is not valid UTF-8 JSON: %q", data)
+	}
+	var entry struct {
+		WebsocketTimelineRaw         string `json:"websocket_timeline_raw"`
+		WebsocketTimelineEncoding    string `json:"websocket_timeline_encoding"`
+		APIWebsocketTimelineRaw      string `json:"api_websocket_timeline_raw"`
+		APIWebsocketTimelineEncoding string `json:"api_websocket_timeline_encoding"`
+	}
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("unmarshal JSON log: %v", err)
+	}
+	want := base64.StdEncoding.EncodeToString(timeline)
+	if entry.WebsocketTimelineRaw != want || entry.WebsocketTimelineEncoding != "base64" {
+		t.Fatalf("downstream timeline = %q encoding=%q", entry.WebsocketTimelineRaw, entry.WebsocketTimelineEncoding)
+	}
+	if entry.APIWebsocketTimelineRaw != want || entry.APIWebsocketTimelineEncoding != "base64" {
+		t.Fatalf("upstream timeline = %q encoding=%q", entry.APIWebsocketTimelineRaw, entry.APIWebsocketTimelineEncoding)
+	}
+}
+
 func TestJSONStreamingRequestLoggingMarksQueueDropsTruncated(t *testing.T) {
 	writer := &FileStreamingLogWriter{chunkChan: make(chan []byte, 1), format: "json"}
 	writer.chunkChan <- []byte("queued")

--- a/internal/logging/json_logger_test.go
+++ b/internal/logging/json_logger_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -227,18 +226,8 @@ func TestJSONRequestLoggingSerializesErrorsAndMasksAddonHeaders(t *testing.T) {
 func TestJSONRequestLoggingPreservesDecompressionError(t *testing.T) {
 	tempDir := t.TempDir()
 	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
-	err := logger.writeNonStreamingLog(
-		io.Discard, "/v1/chat/completions", "POST", nil, []byte(`{"model":"gpt-4"}`), "", false,
-		nil, nil, nil, nil, nil, nil, nil, nil, nil,
-		200, map[string][]string{"Content-Encoding": {"gzip"}}, []byte("not-gzip"),
-		errors.New("gzip: invalid header"), time.Now(), time.Time{},
-	)
-	if err != nil {
-		t.Fatalf("writeNonStreamingLog failed: %v", err)
-	}
-
 	var buf bytes.Buffer
-	err = logger.writeNonStreamingLog(
+	err := logger.writeNonStreamingLog(
 		&buf, "/v1/chat/completions", "POST", nil, []byte(`{"model":"gpt-4"}`), "", false,
 		nil, nil, nil, nil, nil, nil, nil, nil, nil,
 		200, map[string][]string{"Content-Encoding": {"gzip"}}, []byte("not-gzip"),
@@ -725,92 +714,31 @@ func TestJSONRequestLoggingCompactsStructuredPayloadsForNDJSON(t *testing.T) {
 	}
 }
 
-func TestJSONFileBodySourcesCapWhileSpooling(t *testing.T) {
-	logger := NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 10, "json")
-	payload := bytes.Repeat([]byte("x"), maxJSONFileBackedSectionBytes+1024)
-	for _, prefix := range []string{"api-request", "api-response", "websocket-timeline", "api-websocket-timeline"} {
-		t.Run(prefix, func(t *testing.T) {
-			source, err := logger.NewFileBodySource(prefix)
+func TestLimitedFileBodySourceWrites(t *testing.T) {
+	for _, appendPayload := range []struct {
+		name string
+		fn   func(*FileBodySource, []byte) error
+	}{
+		{name: "bytes", fn: (*FileBodySource).AppendBytes},
+		{name: "part", fn: (*FileBodySource).AppendPart},
+	} {
+		t.Run(appendPayload.name, func(t *testing.T) {
+			source, err := newLimitedFileBodySourceInDir(t.TempDir(), appendPayload.name, 32)
 			if err != nil {
-				t.Fatalf("NewFileBodySource failed: %v", err)
+				t.Fatalf("newLimitedFileBodySourceInDir failed: %v", err)
 			}
 			defer source.Cleanup()
-			if err := source.AppendBytes(payload); err != nil {
-				t.Fatalf("AppendBytes failed: %v", err)
+			if err := appendPayload.fn(source, bytes.Repeat([]byte("x"), 64)); err != nil {
+				t.Fatalf("append failed: %v", err)
 			}
-			if !source.Truncated() {
-				t.Fatal("source was not marked truncated")
-			}
-			paths := source.Paths()
-			if len(paths) != 1 {
-				t.Fatalf("source paths = %d, want 1", len(paths))
-			}
-			info, err := os.Stat(paths[0])
+			data, err := source.Bytes()
 			if err != nil {
-				t.Fatalf("stat source: %v", err)
+				t.Fatalf("read source: %v", err)
 			}
-			if info.Size() != maxJSONFileBackedSectionBytes {
-				t.Fatalf("source size = %d, want %d", info.Size(), maxJSONFileBackedSectionBytes)
+			if len(data) != 32 || !source.Truncated() {
+				t.Fatalf("source length=%d truncated=%v", len(data), source.Truncated())
 			}
 		})
-	}
-
-	source, err := logger.NewFileBodySource("api-request")
-	if err != nil {
-		t.Fatalf("NewFileBodySource failed: %v", err)
-	}
-	defer source.Cleanup()
-	if err := source.AppendBytes(payload); err != nil {
-		t.Fatalf("AppendBytes failed: %v", err)
-	}
-	var buf bytes.Buffer
-	if err := logger.writeJSONLog(&buf, "/v1/responses", "POST", nil, nil, "", false, 200, nil, nil, "", false, nil, nil, source, nil, nil, nil, nil, nil, nil, nil, time.Now(), time.Time{}, "http", "http"); err != nil {
-		t.Fatalf("writeJSONLog failed: %v", err)
-	}
-	var entry jsonLogPayload
-	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
-		t.Fatalf("unmarshal JSON log: %v", err)
-	}
-	if !entry.APIRequestTruncated {
-		t.Fatal("api_request_truncated = false, want true")
-	}
-}
-
-func TestJSONWebsocketTimelineSourceCapsAppendPartWhileSpooling(t *testing.T) {
-	logger := NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 10, "json")
-	source, err := logger.NewFileBodySource("api-websocket-timeline")
-	if err != nil {
-		t.Fatalf("NewFileBodySource failed: %v", err)
-	}
-	defer source.Cleanup()
-
-	part := bytes.Repeat([]byte("frame"), 1024)
-	for !source.Truncated() {
-		if err := source.AppendPart(part); err != nil {
-			t.Fatalf("AppendPart failed: %v", err)
-		}
-	}
-	var total int64
-	for _, path := range source.Paths() {
-		info, err := os.Stat(path)
-		if err != nil {
-			t.Fatalf("stat source part: %v", err)
-		}
-		total += info.Size()
-	}
-	if total != maxJSONFileBackedSectionBytes {
-		t.Fatalf("source size = %d, want %d", total, maxJSONFileBackedSectionBytes)
-	}
-
-	data, truncated, err := mergeJSONSectionLimited(source, nil, maxJSONFileBackedSectionBytes)
-	if err != nil {
-		t.Fatalf("mergeJSONSectionLimited failed: %v", err)
-	}
-	if !truncated {
-		t.Fatal("merged source was not marked truncated")
-	}
-	if len(data) != maxJSONFileBackedSectionBytes {
-		t.Fatalf("merged source size = %d, want %d", len(data), maxJSONFileBackedSectionBytes)
 	}
 }
 
@@ -951,6 +879,42 @@ func TestJSONStreamingRequestLoggingCapsRequestBody(t *testing.T) {
 	}
 	if len(entry.RequestBodyRaw) > maxJSONFileBackedSectionBytes {
 		t.Fatalf("request body length = %d, limit = %d", len(entry.RequestBodyRaw), maxJSONFileBackedSectionBytes)
+	}
+}
+
+func TestJSONStreamingRequestLoggingPreservesWebsocketSourceTruncation(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+	streamWriter, err := logger.LogStreamingRequest("/v1/responses", "POST", nil, nil, "req-stream-ws-source-123")
+	if err != nil {
+		t.Fatalf("LogStreamingRequest failed: %v", err)
+	}
+	source, err := newLimitedFileBodySourceInDir(tempDir, "api-websocket-timeline", 32)
+	if err != nil {
+		t.Fatalf("newLimitedFileBodySourceInDir failed: %v", err)
+	}
+	if err := source.AppendBytes(bytes.Repeat([]byte("x"), 64)); err != nil {
+		t.Fatalf("AppendBytes failed: %v", err)
+	}
+	sourceWriter, ok := streamWriter.(interface {
+		WriteAPIWebsocketTimelineSource(*FileBodySource) error
+	})
+	if !ok {
+		t.Fatalf("writer type %T does not accept websocket timeline sources", streamWriter)
+	}
+	if err := sourceWriter.WriteAPIWebsocketTimelineSource(source); err != nil {
+		t.Fatalf("WriteAPIWebsocketTimelineSource failed: %v", err)
+	}
+	if err := streamWriter.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	var entry jsonLogPayload
+	if err := json.Unmarshal(readOnlyLogFile(t, tempDir), &entry); err != nil {
+		t.Fatalf("unmarshal JSON log: %v", err)
+	}
+	if !entry.APIWebsocketTimelineTruncated {
+		t.Fatal("api_websocket_timeline_truncated = false, want true")
 	}
 }
 

--- a/internal/logging/json_logger_test.go
+++ b/internal/logging/json_logger_test.go
@@ -725,32 +725,44 @@ func TestJSONRequestLoggingCompactsStructuredPayloadsForNDJSON(t *testing.T) {
 	}
 }
 
-func TestJSONAPIRequestSourceCapsWhileSpooling(t *testing.T) {
+func TestJSONFileBodySourcesCapWhileSpooling(t *testing.T) {
 	logger := NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 10, "json")
+	payload := bytes.Repeat([]byte("x"), maxJSONFileBackedSectionBytes+1024)
+	for _, prefix := range []string{"api-request", "api-response", "websocket-timeline", "api-websocket-timeline"} {
+		t.Run(prefix, func(t *testing.T) {
+			source, err := logger.NewFileBodySource(prefix)
+			if err != nil {
+				t.Fatalf("NewFileBodySource failed: %v", err)
+			}
+			defer source.Cleanup()
+			if err := source.AppendBytes(payload); err != nil {
+				t.Fatalf("AppendBytes failed: %v", err)
+			}
+			if !source.Truncated() {
+				t.Fatal("source was not marked truncated")
+			}
+			paths := source.Paths()
+			if len(paths) != 1 {
+				t.Fatalf("source paths = %d, want 1", len(paths))
+			}
+			info, err := os.Stat(paths[0])
+			if err != nil {
+				t.Fatalf("stat source: %v", err)
+			}
+			if info.Size() != maxJSONFileBackedSectionBytes {
+				t.Fatalf("source size = %d, want %d", info.Size(), maxJSONFileBackedSectionBytes)
+			}
+		})
+	}
+
 	source, err := logger.NewFileBodySource("api-request")
 	if err != nil {
 		t.Fatalf("NewFileBodySource failed: %v", err)
 	}
 	defer source.Cleanup()
-	payload := bytes.Repeat([]byte("x"), maxJSONFileBackedSectionBytes+1024)
 	if err := source.AppendBytes(payload); err != nil {
 		t.Fatalf("AppendBytes failed: %v", err)
 	}
-	if !source.Truncated() {
-		t.Fatal("source was not marked truncated")
-	}
-	paths := source.Paths()
-	if len(paths) != 1 {
-		t.Fatalf("source paths = %d, want 1", len(paths))
-	}
-	info, err := os.Stat(paths[0])
-	if err != nil {
-		t.Fatalf("stat source: %v", err)
-	}
-	if info.Size() != maxJSONFileBackedSectionBytes {
-		t.Fatalf("source size = %d, want %d", info.Size(), maxJSONFileBackedSectionBytes)
-	}
-
 	var buf bytes.Buffer
 	if err := logger.writeJSONLog(&buf, "/v1/responses", "POST", nil, nil, "", false, 200, nil, nil, "", false, nil, nil, source, nil, nil, nil, nil, nil, nil, nil, time.Now(), time.Time{}, "http", "http"); err != nil {
 		t.Fatalf("writeJSONLog failed: %v", err)

--- a/internal/logging/json_logger_test.go
+++ b/internal/logging/json_logger_test.go
@@ -126,8 +126,6 @@ func TestJSONStreamingRequestLogging(t *testing.T) {
 	firstChunkTimestamp := time.Date(2026, time.July, 25, 12, 34, 56, 123, time.UTC)
 	writer.SetFirstChunkTimestamp(firstChunkTimestamp)
 
-	time.Sleep(50 * time.Millisecond)
-
 	if err := writer.Close(); err != nil {
 		t.Fatalf("Close failed: %v", err)
 	}
@@ -762,7 +760,7 @@ func TestJSONRequestBodyTempFileCapsWhileSpooling(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := logger.writeJSONLog(&buf, "/v1/responses", "POST", nil, nil, path, truncated, 200, nil, nil, "", false, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, time.Now(), time.Time{}, "http", "http"); err != nil {
+	if err := writeJSONLog(&buf, "/v1/responses", "POST", nil, nil, path, truncated, 200, nil, nil, "", false, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, time.Now(), time.Time{}, "http", "http"); err != nil {
 		t.Fatalf("writeJSONLog failed: %v", err)
 	}
 	var entry jsonLogPayload

--- a/internal/logging/json_logger_test.go
+++ b/internal/logging/json_logger_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 )
@@ -623,6 +624,38 @@ func TestJSONRequestLoggingEncodesInvalidUTF8Losslessly(t *testing.T) {
 	}
 	if entry.Response.BodyRaw != want || entry.Response.BodyEncoding != "base64" {
 		t.Fatalf("response = %q encoding=%q", entry.Response.BodyRaw, entry.Response.BodyEncoding)
+	}
+}
+
+func TestJSONRequestLoggingEncodesJSONLikeInvalidUTF8Losslessly(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+	payload := []byte{'"', 0xff, '"'}
+	if !json.Valid(payload) {
+		t.Fatalf("test payload must exercise json.Valid with invalid UTF-8")
+	}
+	err := logger.LogRequest(
+		"/v1/chat/completions", "POST", nil, payload, 200, nil, payload,
+		nil, payload, payload, nil, nil, "req-json-binary-123", time.Now(), time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("LogRequest failed: %v", err)
+	}
+
+	data := readOnlyLogFile(t, tempDir)
+	if !utf8.Valid(data) || !json.Valid(data) {
+		t.Fatalf("log entry is not valid UTF-8 JSON: %q", data)
+	}
+	var entry struct {
+		RequestBodyRaw      string `json:"request_body_raw"`
+		RequestBodyEncoding string `json:"request_body_encoding"`
+	}
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("unmarshal JSON log: %v", err)
+	}
+	want := base64.StdEncoding.EncodeToString(payload)
+	if entry.RequestBodyRaw != want || entry.RequestBodyEncoding != "base64" {
+		t.Fatalf("request body = %q encoding=%q", entry.RequestBodyRaw, entry.RequestBodyEncoding)
 	}
 }
 

--- a/internal/logging/json_logger_test.go
+++ b/internal/logging/json_logger_test.go
@@ -725,6 +725,45 @@ func TestJSONRequestLoggingCompactsStructuredPayloadsForNDJSON(t *testing.T) {
 	}
 }
 
+func TestJSONAPIRequestSourceCapsWhileSpooling(t *testing.T) {
+	logger := NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 10, "json")
+	source, err := logger.NewFileBodySource("api-request")
+	if err != nil {
+		t.Fatalf("NewFileBodySource failed: %v", err)
+	}
+	defer source.Cleanup()
+	payload := bytes.Repeat([]byte("x"), maxJSONFileBackedSectionBytes+1024)
+	if err := source.AppendBytes(payload); err != nil {
+		t.Fatalf("AppendBytes failed: %v", err)
+	}
+	if !source.Truncated() {
+		t.Fatal("source was not marked truncated")
+	}
+	paths := source.Paths()
+	if len(paths) != 1 {
+		t.Fatalf("source paths = %d, want 1", len(paths))
+	}
+	info, err := os.Stat(paths[0])
+	if err != nil {
+		t.Fatalf("stat source: %v", err)
+	}
+	if info.Size() != maxJSONFileBackedSectionBytes {
+		t.Fatalf("source size = %d, want %d", info.Size(), maxJSONFileBackedSectionBytes)
+	}
+
+	var buf bytes.Buffer
+	if err := logger.writeJSONLog(&buf, "/v1/responses", "POST", nil, nil, "", false, 200, nil, nil, "", false, nil, nil, source, nil, nil, nil, nil, nil, nil, nil, time.Now(), time.Time{}, "http", "http"); err != nil {
+		t.Fatalf("writeJSONLog failed: %v", err)
+	}
+	var entry jsonLogPayload
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("unmarshal JSON log: %v", err)
+	}
+	if !entry.APIRequestTruncated {
+		t.Fatal("api_request_truncated = false, want true")
+	}
+}
+
 func TestJSONStreamingRequestLoggingMarksQueueDropsTruncated(t *testing.T) {
 	writer := &FileStreamingLogWriter{chunkChan: make(chan []byte, 1), format: "json"}
 	writer.chunkChan <- []byte("queued")

--- a/internal/logging/json_logger_test.go
+++ b/internal/logging/json_logger_test.go
@@ -941,6 +941,37 @@ func TestRequestLogFormatSnapshotSurvivesReload(t *testing.T) {
 	}
 }
 
+func TestTextStreamingRequestLoggingIncludesWebsocketTimelineSource(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "text")
+	streamWriter, err := logger.LogStreamingRequest("/v1/responses", "POST", nil, nil, "req-text-ws-source-123")
+	if err != nil {
+		t.Fatalf("LogStreamingRequest failed: %v", err)
+	}
+	source, err := NewFileBodySourceInDir(tempDir, "api-websocket-timeline")
+	if err != nil {
+		t.Fatalf("NewFileBodySourceInDir failed: %v", err)
+	}
+	if err := source.AppendPart([]byte("source-backed websocket timeline")); err != nil {
+		t.Fatalf("AppendPart failed: %v", err)
+	}
+	sourceWriter, ok := streamWriter.(interface {
+		WriteAPIWebsocketTimelineSource(*FileBodySource) error
+	})
+	if !ok {
+		t.Fatalf("writer type %T does not accept websocket timeline sources", streamWriter)
+	}
+	if err := sourceWriter.WriteAPIWebsocketTimelineSource(source); err != nil {
+		t.Fatalf("WriteAPIWebsocketTimelineSource failed: %v", err)
+	}
+	if err := streamWriter.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+	if data := readOnlyLogFile(t, tempDir); !bytes.Contains(data, []byte("source-backed websocket timeline")) {
+		t.Fatalf("text log omitted source-backed websocket timeline: %q", data)
+	}
+}
+
 func TestJSONStreamingRequestLoggingPropagatesMissingRequestBodyFile(t *testing.T) {
 	tempDir := t.TempDir()
 	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")

--- a/internal/logging/json_logger_test.go
+++ b/internal/logging/json_logger_test.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"io"
@@ -580,6 +581,48 @@ func TestJSONRequestLoggingMergesInlineAndFileBackedAPISections(t *testing.T) {
 	}
 	if entry.APIResponseRaw != "source-response\ninline-response" {
 		t.Fatalf("api_response_raw = %q", entry.APIResponseRaw)
+	}
+}
+
+func TestJSONRequestLoggingEncodesInvalidUTF8Losslessly(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+	binary := []byte{0xff, 0xfe, 0x00, 0x80}
+	err := logger.LogRequest(
+		"/v1/files", "POST", nil, binary, 200, nil, binary,
+		nil, binary, binary, nil, nil, "req-binary-123", time.Now(), time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("LogRequest failed: %v", err)
+	}
+	data := readOnlyLogFile(t, tempDir)
+	var entry struct {
+		RequestBodyRaw      string `json:"request_body_raw"`
+		RequestBodyEncoding string `json:"request_body_encoding"`
+		APIRequestRaw       string `json:"api_request_raw"`
+		APIRequestEncoding  string `json:"api_request_encoding"`
+		APIResponseRaw      string `json:"api_response_raw"`
+		APIResponseEncoding string `json:"api_response_encoding"`
+		Response            struct {
+			BodyRaw      string `json:"body_raw"`
+			BodyEncoding string `json:"body_encoding"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("unmarshal JSON log: %v", err)
+	}
+	want := base64.StdEncoding.EncodeToString(binary)
+	if entry.RequestBodyRaw != want || entry.RequestBodyEncoding != "base64" {
+		t.Fatalf("request body = %q encoding=%q", entry.RequestBodyRaw, entry.RequestBodyEncoding)
+	}
+	if entry.APIRequestRaw != want || entry.APIRequestEncoding != "base64" {
+		t.Fatalf("API request = %q encoding=%q", entry.APIRequestRaw, entry.APIRequestEncoding)
+	}
+	if entry.APIResponseRaw != want || entry.APIResponseEncoding != "base64" {
+		t.Fatalf("API response = %q encoding=%q", entry.APIResponseRaw, entry.APIResponseEncoding)
+	}
+	if entry.Response.BodyRaw != want || entry.Response.BodyEncoding != "base64" {
+		t.Fatalf("response = %q encoding=%q", entry.Response.BodyRaw, entry.Response.BodyEncoding)
 	}
 }
 

--- a/internal/logging/json_logger_test.go
+++ b/internal/logging/json_logger_test.go
@@ -693,6 +693,38 @@ func TestJSONRequestLoggingEncodesInvalidUTF8WebsocketTimelines(t *testing.T) {
 	}
 }
 
+func TestJSONRequestLoggingCompactsStructuredPayloadsForNDJSON(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 10, "json")
+	payload := []byte("{\n  \"message\": \"hello\",\n  \"items\": [1, 2]\n}")
+	err := logger.LogRequest(
+		"/v1/chat/completions", "POST", nil, payload, 200, nil, payload,
+		nil, payload, payload, nil, nil, "req-pretty-json-123", time.Now(), time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("LogRequest failed: %v", err)
+	}
+
+	data := readOnlyLogFile(t, tempDir)
+	if bytes.Count(data, []byte("\n")) != 1 || data[len(data)-1] != '\n' {
+		t.Fatalf("NDJSON entry must occupy exactly one physical line: %q", data)
+	}
+	var entry jsonLogPayload
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("unmarshal JSON log: %v", err)
+	}
+	want := `{"message":"hello","items":[1,2]}`
+	if string(entry.RequestBody) != want {
+		t.Fatalf("request body = %s, want %s", entry.RequestBody, want)
+	}
+	if string(entry.APIRequest) != want || string(entry.APIResponse) != want {
+		t.Fatalf("upstream payloads were not compacted: request=%s response=%s", entry.APIRequest, entry.APIResponse)
+	}
+	if entry.Response == nil || string(entry.Response.Body) != want {
+		t.Fatalf("response body was not compacted: %#v", entry.Response)
+	}
+}
+
 func TestJSONStreamingRequestLoggingMarksQueueDropsTruncated(t *testing.T) {
 	writer := &FileStreamingLogWriter{chunkChan: make(chan []byte, 1), format: "json"}
 	writer.chunkChan <- []byte("queued")

--- a/internal/logging/request_logger.go
+++ b/internal/logging/request_logger.go
@@ -6,6 +6,8 @@ package logging
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
@@ -144,6 +146,9 @@ type FileRequestLogger struct {
 	errorLogsMaxFiles int
 
 	homeEnabled bool
+
+	// format stores the normalized log entry structure ("text" or "json").
+	format atomic.Value
 }
 
 // NewFileRequestLogger creates a new file-based request logger.
@@ -158,6 +163,11 @@ type FileRequestLogger struct {
 // Returns:
 //   - *FileRequestLogger: A new file-based request logger instance
 func NewFileRequestLogger(enabled bool, logsDir string, configDir string, errorLogsMaxFiles int) *FileRequestLogger {
+	return NewFileRequestLoggerWithFormat(enabled, logsDir, configDir, errorLogsMaxFiles, "text")
+}
+
+// NewFileRequestLoggerWithFormat creates a file request logger with the selected output format.
+func NewFileRequestLoggerWithFormat(enabled bool, logsDir string, configDir string, errorLogsMaxFiles int, format string) *FileRequestLogger {
 	// Resolve logsDir relative to the configuration file directory when it's not absolute.
 	if !filepath.IsAbs(logsDir) {
 		// If configDir is provided, resolve logsDir relative to it.
@@ -165,12 +175,39 @@ func NewFileRequestLogger(enabled bool, logsDir string, configDir string, errorL
 			logsDir = filepath.Join(configDir, logsDir)
 		}
 	}
-	return &FileRequestLogger{
+	logger := &FileRequestLogger{
 		enabled:           enabled,
 		logsDir:           logsDir,
 		errorLogsMaxFiles: errorLogsMaxFiles,
 		homeEnabled:       false,
 	}
+	logger.format.Store(normalizeRequestLogFormat(format))
+	return logger
+}
+
+func normalizeRequestLogFormat(format string) string {
+	if strings.EqualFold(strings.TrimSpace(format), "json") {
+		return "json"
+	}
+	return "text"
+}
+
+// SetFormat updates the output format used for future request log entries.
+func (l *FileRequestLogger) SetFormat(format string) {
+	if l == nil {
+		return
+	}
+	l.format.Store(normalizeRequestLogFormat(format))
+}
+
+func (l *FileRequestLogger) currentFormat() string {
+	if l == nil {
+		return "text"
+	}
+	if format, ok := l.format.Load().(string); ok {
+		return format
+	}
+	return "text"
 }
 
 // IsEnabled returns whether request logging is currently enabled.

--- a/internal/logging/request_logger.go
+++ b/internal/logging/request_logger.go
@@ -240,5 +240,8 @@ func (l *FileRequestLogger) NewFileBodySource(prefix string) (*FileBodySource, e
 	if errEnsure := l.ensureLogsDir(); errEnsure != nil {
 		return nil, errEnsure
 	}
+	if l.currentFormat() == "json" && strings.EqualFold(strings.TrimSpace(prefix), "api-request") {
+		return newLimitedFileBodySourceInDir(l.logsDir, prefix, maxJSONFileBackedSectionBytes)
+	}
 	return NewFileBodySourceInDir(l.logsDir, prefix)
 }

--- a/internal/logging/request_logger.go
+++ b/internal/logging/request_logger.go
@@ -210,6 +210,11 @@ func (l *FileRequestLogger) currentFormat() string {
 	return "text"
 }
 
+// RequestLogFormat returns the normalized format used for newly started requests.
+func (l *FileRequestLogger) RequestLogFormat() string {
+	return l.currentFormat()
+}
+
 // IsEnabled returns whether request logging is currently enabled.
 //
 // Returns:
@@ -234,16 +239,30 @@ func (l *FileRequestLogger) SetErrorLogsMaxFiles(maxFiles int) {
 
 // NewFileBodySource creates a temp-backed source under the request log directory.
 func (l *FileRequestLogger) NewFileBodySource(prefix string) (*FileBodySource, error) {
+	return l.NewFileBodySourceWithFormat(prefix, l.currentFormat())
+}
+
+// NewFileBodySourceWithFormat creates a source using a per-request format snapshot.
+func (l *FileRequestLogger) NewFileBodySourceWithFormat(prefix, format string) (*FileBodySource, error) {
 	if l == nil {
 		return nil, fmt.Errorf("file request logger is nil")
 	}
 	if errEnsure := l.ensureLogsDir(); errEnsure != nil {
 		return nil, errEnsure
 	}
-	if l.currentFormat() == "json" && jsonFileBodySourceLimited(prefix) {
-		return newLimitedFileBodySourceInDir(l.logsDir, prefix, maxJSONFileBackedSectionBytes)
+	format = normalizeRequestLogFormat(format)
+	if format == "json" && jsonFileBodySourceLimited(prefix) {
+		source, err := newLimitedFileBodySourceInDir(l.logsDir, prefix, maxJSONFileBackedSectionBytes)
+		if source != nil {
+			source.format = format
+		}
+		return source, err
 	}
-	return NewFileBodySourceInDir(l.logsDir, prefix)
+	source, err := NewFileBodySourceInDir(l.logsDir, prefix)
+	if source != nil {
+		source.format = format
+	}
+	return source, err
 }
 
 func jsonFileBodySourceLimited(prefix string) bool {

--- a/internal/logging/request_logger.go
+++ b/internal/logging/request_logger.go
@@ -240,8 +240,17 @@ func (l *FileRequestLogger) NewFileBodySource(prefix string) (*FileBodySource, e
 	if errEnsure := l.ensureLogsDir(); errEnsure != nil {
 		return nil, errEnsure
 	}
-	if l.currentFormat() == "json" && strings.EqualFold(strings.TrimSpace(prefix), "api-request") {
+	if l.currentFormat() == "json" && jsonFileBodySourceLimited(prefix) {
 		return newLimitedFileBodySourceInDir(l.logsDir, prefix, maxJSONFileBackedSectionBytes)
 	}
 	return NewFileBodySourceInDir(l.logsDir, prefix)
+}
+
+func jsonFileBodySourceLimited(prefix string) bool {
+	switch strings.ToLower(strings.TrimSpace(prefix)) {
+	case "api-request", "api-response", "websocket-timeline", "api-websocket-timeline":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/logging/request_logger_body_source.go
+++ b/internal/logging/request_logger_body_source.go
@@ -13,10 +13,22 @@ import (
 
 // FileBodySource stores large log sections as ordered temp-file parts.
 type FileBodySource struct {
-	mu      sync.Mutex
-	dir     string
-	paths   []string
-	cleaned bool
+	mu           sync.Mutex
+	dir          string
+	paths        []string
+	cleaned      bool
+	maxBytes     int
+	bytesWritten int
+	truncated    bool
+}
+
+func newLimitedFileBodySourceInDir(baseDir, prefix string, maxBytes int) (*FileBodySource, error) {
+	source, err := NewFileBodySourceInDir(baseDir, prefix)
+	if err != nil {
+		return nil, err
+	}
+	source.maxBytes = maxBytes
+	return source, nil
 }
 
 // NewFileBodySourceInDir creates a temp-backed source under baseDir.
@@ -117,6 +129,17 @@ func (s *FileBodySource) AppendBytes(data []byte) error {
 	if s.cleaned {
 		return fmt.Errorf("file body source has been cleaned")
 	}
+	if s.maxBytes > 0 {
+		remaining := s.maxBytes - s.bytesWritten
+		if remaining <= 0 {
+			s.truncated = true
+			return nil
+		}
+		if len(data) > remaining {
+			data = data[:remaining]
+			s.truncated = true
+		}
+	}
 	if errMkdir := os.MkdirAll(s.dir, 0755); errMkdir != nil {
 		return errMkdir
 	}
@@ -135,13 +158,24 @@ func (s *FileBodySource) AppendBytes(data []byte) error {
 		return errOpen
 	}
 
-	_, writeErr := file.Write(data)
+	written, writeErr := file.Write(data)
+	s.bytesWritten += written
 	if errClose := file.Close(); errClose != nil {
 		if writeErr == nil {
 			writeErr = errClose
 		}
 	}
 	return writeErr
+}
+
+// Truncated reports whether the source dropped bytes because of its write limit.
+func (s *FileBodySource) Truncated() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.truncated
 }
 
 // HasPayload reports whether any detail parts were recorded.

--- a/internal/logging/request_logger_body_source.go
+++ b/internal/logging/request_logger_body_source.go
@@ -103,11 +103,42 @@ func (s *FileBodySource) AppendPart(data []byte) error {
 	if len(data) == 0 {
 		return nil
 	}
-	file, errCreate := s.CreatePart("part")
+	if !bytes.HasSuffix(data, []byte("\n")) {
+		data = append(bytes.Clone(data), '\n')
+	}
+	return s.appendPartBytes(data)
+}
+
+func (s *FileBodySource) appendPartBytes(data []byte) error {
+	if s == nil {
+		return fmt.Errorf("file body source is nil")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cleaned {
+		return fmt.Errorf("file body source has been cleaned")
+	}
+	if s.maxBytes > 0 {
+		remaining := s.maxBytes - s.bytesWritten
+		if remaining <= 0 {
+			s.truncated = true
+			return nil
+		}
+		if len(data) > remaining {
+			data = data[:remaining]
+			s.truncated = true
+		}
+	}
+	if errMkdir := os.MkdirAll(s.dir, 0755); errMkdir != nil {
+		return errMkdir
+	}
+	file, errCreate := os.CreateTemp(s.dir, "part-*.tmp")
 	if errCreate != nil {
 		return errCreate
 	}
-	writeErr := writeLogPart(file, data, false)
+	s.paths = append(s.paths, file.Name())
+	written, writeErr := file.Write(data)
+	s.bytesWritten += written
 	if errClose := file.Close(); errClose != nil {
 		if writeErr == nil {
 			writeErr = errClose

--- a/internal/logging/request_logger_body_source.go
+++ b/internal/logging/request_logger_body_source.go
@@ -20,6 +20,17 @@ type FileBodySource struct {
 	maxBytes     int
 	bytesWritten int
 	truncated    bool
+	format       string
+}
+
+// Format returns the request-log format captured when the source was created.
+func (s *FileBodySource) Format() string {
+	if s == nil {
+		return ""
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.format
 }
 
 func newLimitedFileBodySourceInDir(baseDir, prefix string, maxBytes int) (*FileBodySource, error) {

--- a/internal/logging/request_logger_format.go
+++ b/internal/logging/request_logger_format.go
@@ -47,13 +47,13 @@ func (l *FileRequestLogger) writeNonStreamingLog(
 	}
 	isWebsocketTranscript := hasSectionPayload(websocketTimeline) || hasFileBodySourcePayload(websocketTimelineSource)
 	downstreamTransport := inferDownstreamTransport(requestHeaders, websocketTimeline, websocketTimelineSource)
-	upstreamTransport := inferUpstreamTransport(apiRequest, apiRequestSource, apiResponse, apiResponseSource, apiWebsocketTimeline, apiWebsocketTimelineSource, apiResponseErrors)
+	upstreamTransport := inferUpstreamTransport(apiRequest, apiRequestSource, apiResponse, apiResponseSource, apiWebsocketTimeline, apiWebsocketTimelineSource)
 	format := requestLogFormatFromSources(apiRequestSource, apiResponseSource, websocketTimelineSource, apiWebsocketTimelineSource)
 	if format == "" {
 		format = l.currentFormat()
 	}
 	if format == "json" {
-		return l.writeJSONLog(w, url, method, requestHeaders, requestBody, requestBodyPath, requestBodyTruncated, statusCode, responseHeaders, response, "", false, decompressErr, apiRequest, apiRequestSource, apiResponse, apiResponseSource, apiResponseErrors, websocketTimeline, websocketTimelineSource, apiWebsocketTimeline, apiWebsocketTimelineSource, requestTimestamp, apiResponseTimestamp, downstreamTransport, upstreamTransport)
+		return writeJSONLog(w, url, method, requestHeaders, requestBody, requestBodyPath, requestBodyTruncated, statusCode, responseHeaders, response, "", false, decompressErr, apiRequest, apiRequestSource, apiResponse, apiResponseSource, apiResponseErrors, websocketTimeline, websocketTimelineSource, apiWebsocketTimeline, apiWebsocketTimelineSource, requestTimestamp, apiResponseTimestamp, downstreamTransport, upstreamTransport)
 	}
 	if errWrite := writeRequestInfoWithBody(w, url, method, requestHeaders, requestBody, requestBodyPath, requestTimestamp, downstreamTransport, upstreamTransport, !isWebsocketTranscript); errWrite != nil {
 		return errWrite
@@ -246,7 +246,7 @@ func inferDownstreamTransport(headers map[string][]string, websocketTimeline []b
 	return "http"
 }
 
-func inferUpstreamTransport(apiRequest []byte, apiRequestSource *FileBodySource, apiResponse []byte, apiResponseSource *FileBodySource, apiWebsocketTimeline []byte, apiWebsocketTimelineSource *FileBodySource, _ []*interfaces.ErrorMessage) string {
+func inferUpstreamTransport(apiRequest []byte, apiRequestSource *FileBodySource, apiResponse []byte, apiResponseSource *FileBodySource, apiWebsocketTimeline []byte, apiWebsocketTimelineSource *FileBodySource) string {
 	hasHTTP := hasSectionPayload(apiRequest) || hasFileBodySourcePayload(apiRequestSource) || hasSectionPayload(apiResponse) || hasFileBodySourcePayload(apiResponseSource)
 	hasWS := hasSectionPayload(apiWebsocketTimeline) || hasFileBodySourcePayload(apiWebsocketTimelineSource)
 	switch {
@@ -466,7 +466,7 @@ func (l *FileRequestLogger) formatLogContent(url, method string, headers map[str
 	var content strings.Builder
 	isWebsocketTranscript := hasSectionPayload(websocketTimeline)
 	downstreamTransport := inferDownstreamTransport(headers, websocketTimeline, nil)
-	upstreamTransport := inferUpstreamTransport(apiRequest, nil, apiResponse, nil, apiWebsocketTimeline, nil, apiResponseErrors)
+	upstreamTransport := inferUpstreamTransport(apiRequest, nil, apiResponse, nil, apiWebsocketTimeline, nil)
 
 	// Request info
 	content.WriteString(l.formatRequestInfo(url, method, headers, body, downstreamTransport, upstreamTransport, !isWebsocketTranscript))

--- a/internal/logging/request_logger_format.go
+++ b/internal/logging/request_logger_format.go
@@ -25,6 +25,7 @@ func (l *FileRequestLogger) writeNonStreamingLog(
 	requestHeaders map[string][]string,
 	requestBody []byte,
 	requestBodyPath string,
+	requestBodyTruncated bool,
 	websocketTimeline []byte,
 	websocketTimelineSource *FileBodySource,
 	apiRequest []byte,
@@ -48,7 +49,7 @@ func (l *FileRequestLogger) writeNonStreamingLog(
 	downstreamTransport := inferDownstreamTransport(requestHeaders, websocketTimeline, websocketTimelineSource)
 	upstreamTransport := inferUpstreamTransport(apiRequest, apiRequestSource, apiResponse, apiResponseSource, apiWebsocketTimeline, apiWebsocketTimelineSource, apiResponseErrors)
 	if l.currentFormat() == "json" {
-		return l.writeJSONLog(w, url, method, requestHeaders, requestBody, requestBodyPath, false, statusCode, responseHeaders, response, "", false, decompressErr, apiRequest, apiRequestSource, apiResponse, apiResponseSource, apiResponseErrors, websocketTimeline, websocketTimelineSource, apiWebsocketTimeline, apiWebsocketTimelineSource, requestTimestamp, apiResponseTimestamp, downstreamTransport, upstreamTransport)
+		return l.writeJSONLog(w, url, method, requestHeaders, requestBody, requestBodyPath, requestBodyTruncated, statusCode, responseHeaders, response, "", false, decompressErr, apiRequest, apiRequestSource, apiResponse, apiResponseSource, apiResponseErrors, websocketTimeline, websocketTimelineSource, apiWebsocketTimeline, apiWebsocketTimelineSource, requestTimestamp, apiResponseTimestamp, downstreamTransport, upstreamTransport)
 	}
 	if errWrite := writeRequestInfoWithBody(w, url, method, requestHeaders, requestBody, requestBodyPath, requestTimestamp, downstreamTransport, upstreamTransport, !isWebsocketTranscript); errWrite != nil {
 		return errWrite

--- a/internal/logging/request_logger_format.go
+++ b/internal/logging/request_logger_format.go
@@ -48,7 +48,11 @@ func (l *FileRequestLogger) writeNonStreamingLog(
 	isWebsocketTranscript := hasSectionPayload(websocketTimeline) || hasFileBodySourcePayload(websocketTimelineSource)
 	downstreamTransport := inferDownstreamTransport(requestHeaders, websocketTimeline, websocketTimelineSource)
 	upstreamTransport := inferUpstreamTransport(apiRequest, apiRequestSource, apiResponse, apiResponseSource, apiWebsocketTimeline, apiWebsocketTimelineSource, apiResponseErrors)
-	if l.currentFormat() == "json" {
+	format := requestLogFormatFromSources(apiRequestSource, apiResponseSource, websocketTimelineSource, apiWebsocketTimelineSource)
+	if format == "" {
+		format = l.currentFormat()
+	}
+	if format == "json" {
 		return l.writeJSONLog(w, url, method, requestHeaders, requestBody, requestBodyPath, requestBodyTruncated, statusCode, responseHeaders, response, "", false, decompressErr, apiRequest, apiRequestSource, apiResponse, apiResponseSource, apiResponseErrors, websocketTimeline, websocketTimelineSource, apiWebsocketTimeline, apiWebsocketTimelineSource, requestTimestamp, apiResponseTimestamp, downstreamTransport, upstreamTransport)
 	}
 	if errWrite := writeRequestInfoWithBody(w, url, method, requestHeaders, requestBody, requestBodyPath, requestTimestamp, downstreamTransport, upstreamTransport, !isWebsocketTranscript); errWrite != nil {
@@ -76,6 +80,15 @@ func (l *FileRequestLogger) writeNonStreamingLog(
 		return nil
 	}
 	return writeResponseSection(w, statusCode, true, responseHeaders, bytes.NewReader(response), decompressErr, true)
+}
+
+func requestLogFormatFromSources(sources ...*FileBodySource) string {
+	for _, source := range sources {
+		if format := source.Format(); format != "" {
+			return format
+		}
+	}
+	return ""
 }
 
 func writeRequestInfoWithBody(

--- a/internal/logging/request_logger_format.go
+++ b/internal/logging/request_logger_format.go
@@ -47,6 +47,9 @@ func (l *FileRequestLogger) writeNonStreamingLog(
 	isWebsocketTranscript := hasSectionPayload(websocketTimeline) || hasFileBodySourcePayload(websocketTimelineSource)
 	downstreamTransport := inferDownstreamTransport(requestHeaders, websocketTimeline, websocketTimelineSource)
 	upstreamTransport := inferUpstreamTransport(apiRequest, apiRequestSource, apiResponse, apiResponseSource, apiWebsocketTimeline, apiWebsocketTimelineSource, apiResponseErrors)
+	if l.currentFormat() == "json" {
+		return l.writeJSONLog(w, url, method, requestHeaders, requestBody, requestBodyPath, false, statusCode, responseHeaders, response, "", false, decompressErr, apiRequest, apiRequestSource, apiResponse, apiResponseSource, apiResponseErrors, websocketTimeline, websocketTimelineSource, apiWebsocketTimeline, apiWebsocketTimelineSource, requestTimestamp, apiResponseTimestamp, downstreamTransport, upstreamTransport)
+	}
 	if errWrite := writeRequestInfoWithBody(w, url, method, requestHeaders, requestBody, requestBodyPath, requestTimestamp, downstreamTransport, upstreamTransport, !isWebsocketTranscript); errWrite != nil {
 		return errWrite
 	}

--- a/internal/logging/request_logger_home.go
+++ b/internal/logging/request_logger_home.go
@@ -106,7 +106,6 @@ type homeStreamingLogWriter struct {
 	apiWebsocketTimelineSource *FileBodySource
 	requestID                  string
 	apiResponseTS              time.Time
-	firstChunkTS               time.Time
 	format                     string
 }
 
@@ -247,7 +246,6 @@ func (w *homeStreamingLogWriter) SetFirstChunkTimestamp(timestamp time.Time) {
 		return
 	}
 	if !timestamp.IsZero() {
-		w.firstChunkTS = timestamp
 		w.apiResponseTS = timestamp
 	}
 }
@@ -273,10 +271,9 @@ func (w *homeStreamingLogWriter) Close() error {
 	responsePayload := w.responseBody.Bytes()
 
 	var buf bytes.Buffer
-	upstreamTransport := inferUpstreamTransport(w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, w.apiWebsocketTime, w.apiWebsocketTimelineSource, nil)
+	upstreamTransport := inferUpstreamTransport(w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, w.apiWebsocketTime, w.apiWebsocketTimelineSource)
 	if w.format == "json" {
-		logger := NewFileRequestLoggerWithFormat(true, "", "", 0, "json")
-		if errWrite := logger.writeJSONLog(&buf, w.url, w.method, w.requestHeaders, w.requestBody, "", w.requestBodyTruncated, w.responseStatus, w.responseHeaders, responsePayload, "", w.responseBodyTruncated.Load(), nil, w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, nil, nil, nil, w.apiWebsocketTime, w.apiWebsocketTimelineSource, w.timestamp, w.apiResponseTS, "http", upstreamTransport); errWrite != nil {
+		if errWrite := writeJSONLog(&buf, w.url, w.method, w.requestHeaders, w.requestBody, "", w.requestBodyTruncated, w.responseStatus, w.responseHeaders, responsePayload, "", w.responseBodyTruncated.Load(), nil, w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, nil, nil, nil, w.apiWebsocketTime, w.apiWebsocketTimelineSource, w.timestamp, w.apiResponseTS, "http", upstreamTransport); errWrite != nil {
 			return errWrite
 		}
 	} else {

--- a/internal/logging/request_logger_home.go
+++ b/internal/logging/request_logger_home.go
@@ -93,20 +93,21 @@ type homeStreamingLogWriter struct {
 	chunkChan chan []byte
 	doneChan  chan struct{}
 
-	responseStatus        int
-	statusWritten         bool
-	responseHeaders       map[string][]string
-	responseBody          bytes.Buffer
-	responseBodyTruncated atomic.Bool
-	apiRequest            []byte
-	apiRequestSource      *FileBodySource
-	apiResponse           []byte
-	apiResponseSource     *FileBodySource
-	apiWebsocketTime      []byte
-	requestID             string
-	apiResponseTS         time.Time
-	firstChunkTS          time.Time
-	format                string
+	responseStatus             int
+	statusWritten              bool
+	responseHeaders            map[string][]string
+	responseBody               bytes.Buffer
+	responseBodyTruncated      atomic.Bool
+	apiRequest                 []byte
+	apiRequestSource           *FileBodySource
+	apiResponse                []byte
+	apiResponseSource          *FileBodySource
+	apiWebsocketTime           []byte
+	apiWebsocketTimelineSource *FileBodySource
+	requestID                  string
+	apiResponseTS              time.Time
+	firstChunkTS               time.Time
+	format                     string
 }
 
 func newHomeStreamingLogWriter(url, method string, headers map[string][]string, body []byte, requestID, format string) *homeStreamingLogWriter {
@@ -233,6 +234,14 @@ func (w *homeStreamingLogWriter) WriteAPIWebsocketTimeline(apiWebsocketTimeline 
 	return nil
 }
 
+func (w *homeStreamingLogWriter) WriteAPIWebsocketTimelineSource(source *FileBodySource) error {
+	if source == nil || !source.HasPayload() {
+		return nil
+	}
+	w.apiWebsocketTimelineSource = source
+	return nil
+}
+
 func (w *homeStreamingLogWriter) SetFirstChunkTimestamp(timestamp time.Time) {
 	if w == nil {
 		return
@@ -248,7 +257,7 @@ func (w *homeStreamingLogWriter) Close() error {
 		return nil
 	}
 
-	defer cleanupFileBodySources(w.apiRequestSource, w.apiResponseSource)
+	defer cleanupFileBodySources(w.apiRequestSource, w.apiResponseSource, w.apiWebsocketTimelineSource)
 
 	client := currentHomeRequestLogClient()
 	if client == nil || !client.HeartbeatOK() {
@@ -264,10 +273,10 @@ func (w *homeStreamingLogWriter) Close() error {
 	responsePayload := w.responseBody.Bytes()
 
 	var buf bytes.Buffer
-	upstreamTransport := inferUpstreamTransport(w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, w.apiWebsocketTime, nil, nil)
+	upstreamTransport := inferUpstreamTransport(w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, w.apiWebsocketTime, w.apiWebsocketTimelineSource, nil)
 	if w.format == "json" {
 		logger := NewFileRequestLoggerWithFormat(true, "", "", 0, "json")
-		if errWrite := logger.writeJSONLog(&buf, w.url, w.method, w.requestHeaders, w.requestBody, "", w.requestBodyTruncated, w.responseStatus, w.responseHeaders, responsePayload, "", w.responseBodyTruncated.Load(), nil, w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, nil, nil, nil, w.apiWebsocketTime, nil, w.timestamp, w.apiResponseTS, "http", upstreamTransport); errWrite != nil {
+		if errWrite := logger.writeJSONLog(&buf, w.url, w.method, w.requestHeaders, w.requestBody, "", w.requestBodyTruncated, w.responseStatus, w.responseHeaders, responsePayload, "", w.responseBodyTruncated.Load(), nil, w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, nil, nil, nil, w.apiWebsocketTime, w.apiWebsocketTimelineSource, w.timestamp, w.apiResponseTS, "http", upstreamTransport); errWrite != nil {
 			return errWrite
 		}
 	} else {

--- a/internal/logging/request_logger_home.go
+++ b/internal/logging/request_logger_home.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
@@ -85,25 +86,30 @@ type homeStreamingLogWriter struct {
 	method    string
 	timestamp time.Time
 
-	requestHeaders map[string][]string
-	requestBody    []byte
+	requestHeaders       map[string][]string
+	requestBody          []byte
+	requestBodyTruncated bool
 
 	chunkChan chan []byte
 	doneChan  chan struct{}
 
-	responseStatus   int
-	statusWritten    bool
-	responseHeaders  map[string][]string
-	responseBody     bytes.Buffer
-	apiRequest       []byte
-	apiResponse      []byte
-	apiWebsocketTime []byte
-	requestID        string
-	apiResponseTS    time.Time
-	firstChunkTS     time.Time
+	responseStatus        int
+	statusWritten         bool
+	responseHeaders       map[string][]string
+	responseBody          bytes.Buffer
+	responseBodyTruncated atomic.Bool
+	apiRequest            []byte
+	apiRequestSource      *FileBodySource
+	apiResponse           []byte
+	apiResponseSource     *FileBodySource
+	apiWebsocketTime      []byte
+	requestID             string
+	apiResponseTS         time.Time
+	firstChunkTS          time.Time
+	format                string
 }
 
-func newHomeStreamingLogWriter(url, method string, headers map[string][]string, body []byte, requestID string) *homeStreamingLogWriter {
+func newHomeStreamingLogWriter(url, method string, headers map[string][]string, body []byte, requestID, format string) *homeStreamingLogWriter {
 	requestHeaders := make(map[string][]string, len(headers))
 	for key, values := range headers {
 		headerValues := make([]string, len(values))
@@ -111,15 +117,22 @@ func newHomeStreamingLogWriter(url, method string, headers map[string][]string, 
 		requestHeaders[key] = headerValues
 	}
 
+	format = normalizeRequestLogFormat(format)
+	requestBodyTruncated := format == "json" && len(body) > maxJSONFileBackedSectionBytes
+	if requestBodyTruncated {
+		body = body[:maxJSONFileBackedSectionBytes]
+	}
 	writer := &homeStreamingLogWriter{
-		url:            url,
-		method:         method,
-		timestamp:      time.Now(),
-		requestHeaders: requestHeaders,
-		requestBody:    append([]byte(nil), body...),
-		requestID:      strings.TrimSpace(requestID),
-		chunkChan:      make(chan []byte, 100),
-		doneChan:       make(chan struct{}),
+		url:                  url,
+		method:               method,
+		timestamp:            time.Now(),
+		requestHeaders:       requestHeaders,
+		requestBody:          append([]byte(nil), body...),
+		requestBodyTruncated: requestBodyTruncated,
+		requestID:            strings.TrimSpace(requestID),
+		format:               format,
+		chunkChan:            make(chan []byte, 100),
+		doneChan:             make(chan struct{}),
 	}
 
 	go writer.asyncWriter()
@@ -132,6 +145,18 @@ func (w *homeStreamingLogWriter) asyncWriter() {
 		if len(chunk) == 0 {
 			continue
 		}
+		if w.format == "json" {
+			remaining := maxJSONStreamingResponseBytes - w.responseBody.Len()
+			if remaining <= 0 {
+				w.responseBodyTruncated.Store(true)
+				continue
+			}
+			if len(chunk) > remaining {
+				_, _ = w.responseBody.Write(chunk[:remaining])
+				w.responseBodyTruncated.Store(true)
+				continue
+			}
+		}
 		_, _ = w.responseBody.Write(chunk)
 	}
 }
@@ -143,7 +168,12 @@ func (w *homeStreamingLogWriter) WriteChunkAsync(chunk []byte) {
 	select {
 	case w.chunkChan <- append([]byte(nil), chunk...):
 	default:
+		w.responseBodyTruncated.Store(true)
 	}
+}
+
+func (w *homeStreamingLogWriter) MarkResponseBodyTruncated() {
+	w.responseBodyTruncated.Store(true)
 }
 
 func (w *homeStreamingLogWriter) WriteStatus(status int, headers map[string][]string) error {
@@ -171,11 +201,27 @@ func (w *homeStreamingLogWriter) WriteAPIRequest(apiRequest []byte) error {
 	return nil
 }
 
+func (w *homeStreamingLogWriter) WriteAPIRequestSource(source *FileBodySource) error {
+	if source == nil || !source.HasPayload() {
+		return nil
+	}
+	w.apiRequestSource = source
+	return nil
+}
+
 func (w *homeStreamingLogWriter) WriteAPIResponse(apiResponse []byte) error {
 	if w == nil || len(apiResponse) == 0 {
 		return nil
 	}
 	w.apiResponse = bytes.Clone(apiResponse)
+	return nil
+}
+
+func (w *homeStreamingLogWriter) WriteAPIResponseSource(source *FileBodySource) error {
+	if source == nil || !source.HasPayload() {
+		return nil
+	}
+	w.apiResponseSource = source
 	return nil
 }
 
@@ -202,6 +248,8 @@ func (w *homeStreamingLogWriter) Close() error {
 		return nil
 	}
 
+	defer cleanupFileBodySources(w.apiRequestSource, w.apiResponseSource)
+
 	client := currentHomeRequestLogClient()
 	if client == nil || !client.HeartbeatOK() {
 		return nil
@@ -216,21 +264,28 @@ func (w *homeStreamingLogWriter) Close() error {
 	responsePayload := w.responseBody.Bytes()
 
 	var buf bytes.Buffer
-	upstreamTransport := inferUpstreamTransport(w.apiRequest, nil, w.apiResponse, nil, w.apiWebsocketTime, nil, nil)
-	if errWrite := writeRequestInfoWithBody(&buf, w.url, w.method, w.requestHeaders, w.requestBody, "", w.timestamp, "http", upstreamTransport, true); errWrite != nil {
-		return errWrite
-	}
-	if errWrite := writeAPISection(&buf, "=== API WEBSOCKET TIMELINE ===\n", "=== API WEBSOCKET TIMELINE", w.apiWebsocketTime, time.Time{}); errWrite != nil {
-		return errWrite
-	}
-	if errWrite := writeAPISection(&buf, "=== API REQUEST ===\n", "=== API REQUEST", w.apiRequest, time.Time{}); errWrite != nil {
-		return errWrite
-	}
-	if errWrite := writeAPISection(&buf, "=== API RESPONSE ===\n", "=== API RESPONSE", w.apiResponse, w.apiResponseTS); errWrite != nil {
-		return errWrite
-	}
-	if errWrite := writeResponseSection(&buf, w.responseStatus, w.statusWritten, w.responseHeaders, bytes.NewReader(responsePayload), nil, false); errWrite != nil {
-		return errWrite
+	upstreamTransport := inferUpstreamTransport(w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, w.apiWebsocketTime, nil, nil)
+	if w.format == "json" {
+		logger := NewFileRequestLoggerWithFormat(true, "", "", 0, "json")
+		if errWrite := logger.writeJSONLog(&buf, w.url, w.method, w.requestHeaders, w.requestBody, "", w.requestBodyTruncated, w.responseStatus, w.responseHeaders, responsePayload, "", w.responseBodyTruncated.Load(), nil, w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, nil, nil, nil, w.apiWebsocketTime, nil, w.timestamp, w.apiResponseTS, "http", upstreamTransport); errWrite != nil {
+			return errWrite
+		}
+	} else {
+		if errWrite := writeRequestInfoWithBody(&buf, w.url, w.method, w.requestHeaders, w.requestBody, "", w.timestamp, "http", upstreamTransport, true); errWrite != nil {
+			return errWrite
+		}
+		if errWrite := writeAPISection(&buf, "=== API WEBSOCKET TIMELINE ===\n", "=== API WEBSOCKET TIMELINE", w.apiWebsocketTime, time.Time{}); errWrite != nil {
+			return errWrite
+		}
+		if errWrite := writePreformattedAPISectionWithSource(&buf, "=== API REQUEST ===\n", "=== API REQUEST", w.apiRequest, w.apiRequestSource, time.Time{}); errWrite != nil {
+			return errWrite
+		}
+		if errWrite := writePreformattedAPISectionWithSource(&buf, "=== API RESPONSE ===\n", "=== API RESPONSE", w.apiResponse, w.apiResponseSource, w.apiResponseTS); errWrite != nil {
+			return errWrite
+		}
+		if errWrite := writeResponseSection(&buf, w.responseStatus, w.statusWritten, w.responseHeaders, bytes.NewReader(responsePayload), nil, false); errWrite != nil {
+			return errWrite
+		}
 	}
 
 	payload := homeRequestLogPayload{

--- a/internal/logging/request_logger_home.go
+++ b/internal/logging/request_logger_home.go
@@ -283,7 +283,7 @@ func (w *homeStreamingLogWriter) Close() error {
 		if errWrite := writeRequestInfoWithBody(&buf, w.url, w.method, w.requestHeaders, w.requestBody, "", w.timestamp, "http", upstreamTransport, true); errWrite != nil {
 			return errWrite
 		}
-		if errWrite := writeAPISection(&buf, "=== API WEBSOCKET TIMELINE ===\n", "=== API WEBSOCKET TIMELINE", w.apiWebsocketTime, time.Time{}); errWrite != nil {
+		if errWrite := writeAPISectionWithSource(&buf, "=== API WEBSOCKET TIMELINE ===\n", "=== API WEBSOCKET TIMELINE", w.apiWebsocketTime, w.apiWebsocketTimelineSource, time.Time{}); errWrite != nil {
 			return errWrite
 		}
 		if errWrite := writePreformattedAPISectionWithSource(&buf, "=== API REQUEST ===\n", "=== API REQUEST", w.apiRequest, w.apiRequestSource, time.Time{}); errWrite != nil {

--- a/internal/logging/request_logger_home_test.go
+++ b/internal/logging/request_logger_home_test.go
@@ -383,46 +383,6 @@ func TestFileRequestLogger_HomeEnabled_ForwardsStreamingRequestID(t *testing.T) 
 	}
 }
 
-func TestFileRequestLogger_HomeEnabled_ForwardsStreamingJSON(t *testing.T) {
-	original := currentHomeRequestLogClient
-	defer func() { currentHomeRequestLogClient = original }()
-
-	stub := &stubHomeRequestLogClient{heartbeatOK: true}
-	currentHomeRequestLogClient = func() homeRequestLogClient { return stub }
-
-	logger := NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 0, "json")
-	logger.SetHomeEnabled(true)
-	writer, err := logger.LogStreamingRequest(
-		"/v1/chat/completions", http.MethodPost,
-		map[string][]string{"Content-Type": {"application/json"}},
-		[]byte(`{"model":"gpt-4","stream":true}`), "home-json-stream-1",
-	)
-	if err != nil {
-		t.Fatalf("LogStreamingRequest error: %v", err)
-	}
-	if err := writer.WriteStatus(http.StatusOK, map[string][]string{"Content-Type": {"text/event-stream"}}); err != nil {
-		t.Fatalf("WriteStatus error: %v", err)
-	}
-	writer.WriteChunkAsync([]byte("data: ok\n\n"))
-	if err := writer.Close(); err != nil {
-		t.Fatalf("Close error: %v", err)
-	}
-
-	var envelope struct {
-		RequestLog string `json:"request_log"`
-	}
-	if err := json.Unmarshal(stub.pushed[0], &envelope); err != nil {
-		t.Fatalf("unmarshal envelope: %v", err)
-	}
-	var entry jsonLogPayload
-	if err := json.Unmarshal([]byte(envelope.RequestLog), &entry); err != nil {
-		t.Fatalf("request_log is not JSON: %v log=%q", err, envelope.RequestLog)
-	}
-	if entry.URL != "/v1/chat/completions" {
-		t.Fatalf("url = %q", entry.URL)
-	}
-}
-
 func TestFileRequestLogger_HomeEnabled_BoundsStreamingJSONBodies(t *testing.T) {
 	original := currentHomeRequestLogClient
 	defer func() { currentHomeRequestLogClient = original }()
@@ -453,6 +413,9 @@ func TestFileRequestLogger_HomeEnabled_BoundsStreamingJSONBodies(t *testing.T) {
 	var entry jsonLogPayload
 	if err := json.Unmarshal([]byte(envelope.RequestLog), &entry); err != nil {
 		t.Fatalf("request_log is not JSON: %v", err)
+	}
+	if entry.URL != "/v1/chat/completions" {
+		t.Fatalf("url = %q", entry.URL)
 	}
 	if !entry.RequestBodyTruncated {
 		t.Fatalf("expected request body to be marked truncated")

--- a/internal/logging/request_logger_home_test.go
+++ b/internal/logging/request_logger_home_test.go
@@ -485,19 +485,25 @@ func TestFileRequestLogger_HomeEnabled_BoundsStreamingJSONUpstreamSources(t *tes
 	sourceWriter, ok := streamWriter.(interface {
 		WriteAPIRequestSource(*FileBodySource) error
 		WriteAPIResponseSource(*FileBodySource) error
+		WriteAPIWebsocketTimelineSource(*FileBodySource) error
 	})
 	if !ok {
 		t.Fatalf("Home streaming writer does not implement source interface")
 	}
 	requestSource := newLargeFileBodySource(t, tempDir, "home-api-request")
 	responseSource := newLargeFileBodySource(t, tempDir, "home-api-response")
+	timelineSource := newLargeFileBodySource(t, tempDir, "home-api-websocket-timeline")
 	requestPaths := requestSource.Paths()
 	responsePaths := responseSource.Paths()
+	timelinePaths := timelineSource.Paths()
 	if err := sourceWriter.WriteAPIRequestSource(requestSource); err != nil {
 		t.Fatalf("WriteAPIRequestSource: %v", err)
 	}
 	if err := sourceWriter.WriteAPIResponseSource(responseSource); err != nil {
 		t.Fatalf("WriteAPIResponseSource: %v", err)
+	}
+	if err := sourceWriter.WriteAPIWebsocketTimelineSource(timelineSource); err != nil {
+		t.Fatalf("WriteAPIWebsocketTimelineSource: %v", err)
 	}
 	if err := streamWriter.Close(); err != nil {
 		t.Fatalf("Close error: %v", err)
@@ -516,7 +522,11 @@ func TestFileRequestLogger_HomeEnabled_BoundsStreamingJSONUpstreamSources(t *tes
 	if !entry.APIRequestTruncated || !entry.APIResponseTruncated {
 		t.Fatalf("upstream truncation markers: request=%v response=%v", entry.APIRequestTruncated, entry.APIResponseTruncated)
 	}
-	assertFileBodySourceCleaned(t, append(requestPaths, responsePaths...))
+	if !entry.APIWebsocketTimelineTruncated {
+		t.Fatal("api websocket timeline was not marked truncated")
+	}
+	paths := append(requestPaths, responsePaths...)
+	assertFileBodySourceCleaned(t, append(paths, timelinePaths...))
 }
 
 func TestFileRequestLogger_HomeEnabled_DoesNotTruncateStreamingTextBodies(t *testing.T) {

--- a/internal/logging/request_logger_home_test.go
+++ b/internal/logging/request_logger_home_test.go
@@ -150,6 +150,40 @@ func TestFileRequestLogger_HomeEnabled_ForwardsWhenRequestLogEnabled(t *testing.
 	}
 }
 
+func TestFileRequestLogger_HomeEnabled_BoundsNonStreamingJSONBodies(t *testing.T) {
+	original := currentHomeRequestLogClient
+	defer func() { currentHomeRequestLogClient = original }()
+
+	stub := &stubHomeRequestLogClient{heartbeatOK: true}
+	currentHomeRequestLogClient = func() homeRequestLogClient { return stub }
+
+	logger := NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 0, "json")
+	logger.SetHomeEnabled(true)
+	err := logger.LogRequest(
+		"/v1/chat/completions", http.MethodPost, nil,
+		bytes.Repeat([]byte("r"), maxJSONFileBackedSectionBytes+1024),
+		http.StatusOK, nil, bytes.Repeat([]byte("s"), maxJSONStreamingResponseBytes+1024),
+		nil, nil, nil, nil, nil, "home-json-non-stream-1", time.Now(), time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("LogRequest error: %v", err)
+	}
+
+	var envelope struct {
+		RequestLog string `json:"request_log"`
+	}
+	if err := json.Unmarshal(stub.pushed[0], &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	var entry jsonLogPayload
+	if err := json.Unmarshal([]byte(envelope.RequestLog), &entry); err != nil {
+		t.Fatalf("unmarshal request log: %v", err)
+	}
+	if !entry.RequestBodyTruncated || entry.Response == nil || !entry.Response.BodyTruncated {
+		t.Fatalf("missing truncation markers: request=%v response=%+v", entry.RequestBodyTruncated, entry.Response)
+	}
+}
+
 func TestFileRequestLogger_LogRequestWithSourcesWritesLocalLogAndCleansParts(t *testing.T) {
 	logsDir := t.TempDir()
 	logger := NewFileRequestLogger(true, logsDir, "", 0)
@@ -346,6 +380,178 @@ func TestFileRequestLogger_HomeEnabled_ForwardsStreamingRequestID(t *testing.T) 
 	}
 	if got.RequestLog == "" {
 		t.Fatalf("request_log empty, want non-empty")
+	}
+}
+
+func TestFileRequestLogger_HomeEnabled_ForwardsStreamingJSON(t *testing.T) {
+	original := currentHomeRequestLogClient
+	defer func() { currentHomeRequestLogClient = original }()
+
+	stub := &stubHomeRequestLogClient{heartbeatOK: true}
+	currentHomeRequestLogClient = func() homeRequestLogClient { return stub }
+
+	logger := NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 0, "json")
+	logger.SetHomeEnabled(true)
+	writer, err := logger.LogStreamingRequest(
+		"/v1/chat/completions", http.MethodPost,
+		map[string][]string{"Content-Type": {"application/json"}},
+		[]byte(`{"model":"gpt-4","stream":true}`), "home-json-stream-1",
+	)
+	if err != nil {
+		t.Fatalf("LogStreamingRequest error: %v", err)
+	}
+	if err := writer.WriteStatus(http.StatusOK, map[string][]string{"Content-Type": {"text/event-stream"}}); err != nil {
+		t.Fatalf("WriteStatus error: %v", err)
+	}
+	writer.WriteChunkAsync([]byte("data: ok\n\n"))
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close error: %v", err)
+	}
+
+	var envelope struct {
+		RequestLog string `json:"request_log"`
+	}
+	if err := json.Unmarshal(stub.pushed[0], &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	var entry jsonLogPayload
+	if err := json.Unmarshal([]byte(envelope.RequestLog), &entry); err != nil {
+		t.Fatalf("request_log is not JSON: %v log=%q", err, envelope.RequestLog)
+	}
+	if entry.URL != "/v1/chat/completions" {
+		t.Fatalf("url = %q", entry.URL)
+	}
+}
+
+func TestFileRequestLogger_HomeEnabled_BoundsStreamingJSONBodies(t *testing.T) {
+	original := currentHomeRequestLogClient
+	defer func() { currentHomeRequestLogClient = original }()
+
+	stub := &stubHomeRequestLogClient{heartbeatOK: true}
+	currentHomeRequestLogClient = func() homeRequestLogClient { return stub }
+
+	logger := NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 0, "json")
+	logger.SetHomeEnabled(true)
+	writer, err := logger.LogStreamingRequest(
+		"/v1/chat/completions", http.MethodPost, nil,
+		bytes.Repeat([]byte("r"), maxJSONFileBackedSectionBytes+1024), "home-json-bounded-1",
+	)
+	if err != nil {
+		t.Fatalf("LogStreamingRequest error: %v", err)
+	}
+	writer.WriteChunkAsync(bytes.Repeat([]byte("s"), maxJSONStreamingResponseBytes+1024))
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close error: %v", err)
+	}
+
+	var envelope struct {
+		RequestLog string `json:"request_log"`
+	}
+	if err := json.Unmarshal(stub.pushed[0], &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	var entry jsonLogPayload
+	if err := json.Unmarshal([]byte(envelope.RequestLog), &entry); err != nil {
+		t.Fatalf("request_log is not JSON: %v", err)
+	}
+	if !entry.RequestBodyTruncated {
+		t.Fatalf("expected request body to be marked truncated")
+	}
+	if len(entry.RequestBodyRaw) > maxJSONFileBackedSectionBytes {
+		t.Fatalf("request body length = %d", len(entry.RequestBodyRaw))
+	}
+	if entry.Response == nil || !entry.Response.BodyTruncated {
+		t.Fatalf("expected response body to be marked truncated")
+	}
+	if len(entry.Response.BodyRaw) > maxJSONStreamingResponseBytes {
+		t.Fatalf("response body length = %d", len(entry.Response.BodyRaw))
+	}
+}
+
+func TestFileRequestLogger_HomeEnabled_BoundsStreamingJSONUpstreamSources(t *testing.T) {
+	original := currentHomeRequestLogClient
+	defer func() { currentHomeRequestLogClient = original }()
+
+	stub := &stubHomeRequestLogClient{heartbeatOK: true}
+	currentHomeRequestLogClient = func() homeRequestLogClient { return stub }
+
+	tempDir := t.TempDir()
+	logger := NewFileRequestLoggerWithFormat(true, tempDir, "", 0, "json")
+	logger.SetHomeEnabled(true)
+	streamWriter, err := logger.LogStreamingRequest("/v1/chat/completions", http.MethodPost, nil, nil, "home-json-sources-1")
+	if err != nil {
+		t.Fatalf("LogStreamingRequest error: %v", err)
+	}
+	sourceWriter, ok := streamWriter.(interface {
+		WriteAPIRequestSource(*FileBodySource) error
+		WriteAPIResponseSource(*FileBodySource) error
+	})
+	if !ok {
+		t.Fatalf("Home streaming writer does not implement source interface")
+	}
+	requestSource := newLargeFileBodySource(t, tempDir, "home-api-request")
+	responseSource := newLargeFileBodySource(t, tempDir, "home-api-response")
+	requestPaths := requestSource.Paths()
+	responsePaths := responseSource.Paths()
+	if err := sourceWriter.WriteAPIRequestSource(requestSource); err != nil {
+		t.Fatalf("WriteAPIRequestSource: %v", err)
+	}
+	if err := sourceWriter.WriteAPIResponseSource(responseSource); err != nil {
+		t.Fatalf("WriteAPIResponseSource: %v", err)
+	}
+	if err := streamWriter.Close(); err != nil {
+		t.Fatalf("Close error: %v", err)
+	}
+
+	var envelope struct {
+		RequestLog string `json:"request_log"`
+	}
+	if err := json.Unmarshal(stub.pushed[0], &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	var entry jsonLogPayload
+	if err := json.Unmarshal([]byte(envelope.RequestLog), &entry); err != nil {
+		t.Fatalf("unmarshal request log: %v", err)
+	}
+	if !entry.APIRequestTruncated || !entry.APIResponseTruncated {
+		t.Fatalf("upstream truncation markers: request=%v response=%v", entry.APIRequestTruncated, entry.APIResponseTruncated)
+	}
+	assertFileBodySourceCleaned(t, append(requestPaths, responsePaths...))
+}
+
+func TestFileRequestLogger_HomeEnabled_DoesNotTruncateStreamingTextBodies(t *testing.T) {
+	original := currentHomeRequestLogClient
+	defer func() { currentHomeRequestLogClient = original }()
+
+	stub := &stubHomeRequestLogClient{heartbeatOK: true}
+	currentHomeRequestLogClient = func() homeRequestLogClient { return stub }
+
+	requestBody := bytes.Repeat([]byte("r"), maxJSONFileBackedSectionBytes+1024)
+	responseBody := bytes.Repeat([]byte("s"), maxJSONStreamingResponseBytes+1024)
+	logger := NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 0, "text")
+	logger.SetHomeEnabled(true)
+	writer, err := logger.LogStreamingRequest(
+		"/v1/chat/completions", http.MethodPost, nil, requestBody, "home-text-unbounded-1",
+	)
+	if err != nil {
+		t.Fatalf("LogStreamingRequest error: %v", err)
+	}
+	writer.WriteChunkAsync(responseBody)
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close error: %v", err)
+	}
+
+	var envelope struct {
+		RequestLog string `json:"request_log"`
+	}
+	if err := json.Unmarshal(stub.pushed[0], &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if !strings.Contains(envelope.RequestLog, string(requestBody[len(requestBody)-1024:])) {
+		t.Fatalf("text Home log truncated request body")
+	}
+	if !strings.Contains(envelope.RequestLog, string(responseBody[len(responseBody)-1024:])) {
+		t.Fatalf("text Home log truncated response body")
 	}
 }
 

--- a/internal/logging/request_logger_home_test.go
+++ b/internal/logging/request_logger_home_test.go
@@ -547,6 +547,22 @@ func TestFileRequestLogger_HomeEnabled_DoesNotTruncateStreamingTextBodies(t *tes
 		t.Fatalf("LogStreamingRequest error: %v", err)
 	}
 	writer.WriteChunkAsync(responseBody)
+	timelineSource, err := NewFileBodySourceInDir(t.TempDir(), "home-text-api-websocket-timeline")
+	if err != nil {
+		t.Fatalf("NewFileBodySourceInDir failed: %v", err)
+	}
+	if err := timelineSource.AppendPart([]byte("source-backed websocket timeline")); err != nil {
+		t.Fatalf("AppendPart failed: %v", err)
+	}
+	sourceWriter, ok := writer.(interface {
+		WriteAPIWebsocketTimelineSource(*FileBodySource) error
+	})
+	if !ok {
+		t.Fatalf("writer type %T does not accept websocket timeline sources", writer)
+	}
+	if err := sourceWriter.WriteAPIWebsocketTimelineSource(timelineSource); err != nil {
+		t.Fatalf("WriteAPIWebsocketTimelineSource failed: %v", err)
+	}
 	if err := writer.Close(); err != nil {
 		t.Fatalf("Close error: %v", err)
 	}
@@ -562,6 +578,9 @@ func TestFileRequestLogger_HomeEnabled_DoesNotTruncateStreamingTextBodies(t *tes
 	}
 	if !strings.Contains(envelope.RequestLog, string(responseBody[len(responseBody)-1024:])) {
 		t.Fatalf("text Home log truncated response body")
+	}
+	if !strings.Contains(envelope.RequestLog, "source-backed websocket timeline") {
+		t.Fatal("Home text log omitted source-backed websocket timeline")
 	}
 }
 

--- a/internal/logging/request_logger_json.go
+++ b/internal/logging/request_logger_json.go
@@ -1,0 +1,280 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/buildinfo"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	maxJSONStreamingResponseBytes = 8 << 20
+	maxJSONFileBackedSectionBytes = 8 << 20
+)
+
+type jsonLogPayload struct {
+	Version                       string              `json:"version"`
+	URL                           string              `json:"url"`
+	Method                        string              `json:"method"`
+	DownstreamTransport           string              `json:"downstream_transport,omitempty"`
+	UpstreamTransport             string              `json:"upstream_transport,omitempty"`
+	Timestamp                     string              `json:"timestamp"`
+	Headers                       map[string][]string `json:"headers,omitempty"`
+	RequestBody                   json.RawMessage     `json:"request_body,omitempty"`
+	RequestBodyRaw                string              `json:"request_body_raw,omitempty"`
+	RequestBodyTruncated          bool                `json:"request_body_truncated,omitempty"`
+	Response                      *jsonLogResponse    `json:"response,omitempty"`
+	APIRequest                    json.RawMessage     `json:"api_request,omitempty"`
+	APIRequestRaw                 string              `json:"api_request_raw,omitempty"`
+	APIRequestTruncated           bool                `json:"api_request_truncated,omitempty"`
+	APIResponse                   json.RawMessage     `json:"api_response,omitempty"`
+	APIResponseRaw                string              `json:"api_response_raw,omitempty"`
+	APIResponseTruncated          bool                `json:"api_response_truncated,omitempty"`
+	APIResponseErrors             []jsonLogError      `json:"api_response_errors,omitempty"`
+	APIResponseTimestamp          string              `json:"api_response_timestamp,omitempty"`
+	APIWebsocketTimelineRaw       string              `json:"api_websocket_timeline_raw,omitempty"`
+	APIWebsocketTimelineTruncated bool                `json:"api_websocket_timeline_truncated,omitempty"`
+	WebsocketTimelineRaw          string              `json:"websocket_timeline_raw,omitempty"`
+	WebsocketTimelineTruncated    bool                `json:"websocket_timeline_truncated,omitempty"`
+}
+
+type jsonLogError struct {
+	StatusCode int                 `json:"status_code"`
+	Error      string              `json:"error,omitempty"`
+	Addon      map[string][]string `json:"addon,omitempty"`
+}
+
+type jsonLogResponse struct {
+	Status             int                 `json:"status"`
+	Headers            map[string][]string `json:"headers,omitempty"`
+	Body               json.RawMessage     `json:"body,omitempty"`
+	BodyRaw            string              `json:"body_raw,omitempty"`
+	BodyTruncated      bool                `json:"body_truncated,omitempty"`
+	DecompressionError string              `json:"decompression_error,omitempty"`
+}
+
+func maskHeaders(headers map[string][]string) map[string][]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	masked := make(map[string][]string, len(headers))
+	for key, values := range headers {
+		maskedValues := make([]string, len(values))
+		for i, value := range values {
+			maskedValues[i] = util.MaskSensitiveHeaderValue(key, value)
+		}
+		masked[key] = maskedValues
+	}
+	return masked
+}
+
+func (l *FileRequestLogger) writeJSONLog(
+	w io.Writer,
+	url, method string,
+	requestHeaders map[string][]string,
+	requestBody []byte,
+	requestBodyPath string,
+	requestBodyTruncated bool,
+	statusCode int,
+	responseHeaders map[string][]string,
+	response []byte,
+	responsePath string,
+	responseBodyTruncated bool,
+	decompressErr error,
+	apiRequest []byte,
+	apiRequestSource *FileBodySource,
+	apiResponse []byte,
+	apiResponseSource *FileBodySource,
+	apiResponseErrors []*interfaces.ErrorMessage,
+	websocketTimeline []byte,
+	websocketTimelineSource *FileBodySource,
+	apiWebsocketTimeline []byte,
+	apiWebsocketTimelineSource *FileBodySource,
+	requestTimestamp time.Time,
+	apiResponseTimestamp time.Time,
+	downstreamTransport string,
+	upstreamTransport string,
+) error {
+	if requestTimestamp.IsZero() {
+		requestTimestamp = time.Now()
+	}
+
+	var requestBytes []byte
+	if requestBodyPath != "" {
+		var truncated bool
+		var errRead error
+		requestBytes, truncated, errRead = readFileLimited(requestBodyPath, maxJSONFileBackedSectionBytes)
+		if errRead != nil {
+			return fmt.Errorf("read JSON request body: %w", errRead)
+		}
+		requestBodyTruncated = requestBodyTruncated || truncated
+	} else {
+		requestBytes = requestBody
+		if len(requestBytes) > maxJSONFileBackedSectionBytes {
+			requestBytes = requestBytes[:maxJSONFileBackedSectionBytes]
+			requestBodyTruncated = true
+		}
+	}
+
+	entry := jsonLogPayload{
+		Version:              buildinfo.Version,
+		URL:                  url,
+		Method:               method,
+		DownstreamTransport:  downstreamTransport,
+		UpstreamTransport:    upstreamTransport,
+		Timestamp:            requestTimestamp.Format(time.RFC3339Nano),
+		Headers:              maskHeaders(requestHeaders),
+		RequestBodyTruncated: requestBodyTruncated,
+	}
+	setJSONPayload(requestBytes, &entry.RequestBody, &entry.RequestBodyRaw)
+	if !apiResponseTimestamp.IsZero() {
+		entry.APIResponseTimestamp = apiResponseTimestamp.Format(time.RFC3339Nano)
+	}
+
+	apiRequestBytes, truncated, errMerge := mergeJSONSectionLimited(apiRequestSource, apiRequest, maxJSONFileBackedSectionBytes)
+	if errMerge != nil {
+		return fmt.Errorf("read JSON API request: %w", errMerge)
+	}
+	entry.APIRequestTruncated = truncated
+	setJSONPayload(apiRequestBytes, &entry.APIRequest, &entry.APIRequestRaw)
+
+	apiResponseBytes, truncated, errMerge := mergeJSONSectionLimited(apiResponseSource, apiResponse, maxJSONFileBackedSectionBytes)
+	if errMerge != nil {
+		return fmt.Errorf("read JSON API response: %w", errMerge)
+	}
+	entry.APIResponseTruncated = truncated
+	setJSONPayload(apiResponseBytes, &entry.APIResponse, &entry.APIResponseRaw)
+
+	for _, apiErr := range apiResponseErrors {
+		if apiErr == nil {
+			continue
+		}
+		logErr := jsonLogError{StatusCode: apiErr.StatusCode, Addon: maskHeaders(apiErr.Addon)}
+		if apiErr.Error != nil {
+			logErr.Error = apiErr.Error.Error()
+		}
+		entry.APIResponseErrors = append(entry.APIResponseErrors, logErr)
+	}
+
+	apiTimeline, truncated, errMerge := mergeJSONSectionLimited(apiWebsocketTimelineSource, apiWebsocketTimeline, maxJSONFileBackedSectionBytes)
+	if errMerge != nil {
+		return fmt.Errorf("read JSON API websocket timeline: %w", errMerge)
+	}
+	entry.APIWebsocketTimelineRaw = string(apiTimeline)
+	entry.APIWebsocketTimelineTruncated = truncated
+
+	downstreamTimeline, truncated, errMerge := mergeJSONSectionLimited(websocketTimelineSource, websocketTimeline, maxJSONFileBackedSectionBytes)
+	if errMerge != nil {
+		return fmt.Errorf("read JSON websocket timeline: %w", errMerge)
+	}
+	entry.WebsocketTimelineRaw = string(downstreamTimeline)
+	entry.WebsocketTimelineTruncated = truncated
+
+	responseEntry := &jsonLogResponse{Status: statusCode, Headers: maskHeaders(responseHeaders)}
+	if decompressErr != nil {
+		responseEntry.DecompressionError = decompressErr.Error()
+	}
+	if responsePath != "" {
+		var truncated bool
+		var errRead error
+		response, truncated, errRead = readFileLimited(responsePath, maxJSONStreamingResponseBytes)
+		if errRead != nil {
+			return fmt.Errorf("read JSON response body: %w", errRead)
+		}
+		responseBodyTruncated = responseBodyTruncated || truncated
+	} else if len(response) > maxJSONStreamingResponseBytes {
+		response = response[:maxJSONStreamingResponseBytes]
+		responseBodyTruncated = true
+	}
+	responseEntry.BodyTruncated = responseBodyTruncated
+	setJSONPayload(response, &responseEntry.Body, &responseEntry.BodyRaw)
+	entry.Response = responseEntry
+
+	data, errMarshal := json.Marshal(&entry)
+	if errMarshal != nil {
+		return errMarshal
+	}
+	data = append(data, '\n')
+	_, errWrite := w.Write(data)
+	return errWrite
+}
+
+func setJSONPayload(payload []byte, structured *json.RawMessage, raw *string) {
+	if len(payload) == 0 {
+		return
+	}
+	if json.Valid(payload) {
+		*structured = json.RawMessage(payload)
+		return
+	}
+	*raw = string(payload)
+}
+
+func readFileLimited(path string, limit int) ([]byte, bool, error) {
+	file, errOpen := os.Open(path)
+	if errOpen != nil {
+		return nil, false, errOpen
+	}
+	defer func() {
+		if errClose := file.Close(); errClose != nil {
+			log.WithError(errClose).Warn("failed to close JSON log source file")
+		}
+	}()
+
+	payload, errRead := io.ReadAll(io.LimitReader(file, int64(limit)+1))
+	if errRead != nil {
+		return nil, false, errRead
+	}
+	if len(payload) > limit {
+		return payload[:limit], true, nil
+	}
+	return payload, false, nil
+}
+
+var errJSONLogSectionLimit = errors.New("JSON log section size limit reached")
+
+type limitedJSONLogWriter struct {
+	buffer bytes.Buffer
+	limit  int
+}
+
+func (w *limitedJSONLogWriter) Write(payload []byte) (int, error) {
+	remaining := w.limit - w.buffer.Len()
+	if remaining <= 0 {
+		return 0, errJSONLogSectionLimit
+	}
+	if len(payload) > remaining {
+		_, _ = w.buffer.Write(payload[:remaining])
+		return remaining, errJSONLogSectionLimit
+	}
+	return w.buffer.Write(payload)
+}
+
+func mergeJSONSectionLimited(source *FileBodySource, inline []byte, limit int) ([]byte, bool, error) {
+	writer := &limitedJSONLogWriter{limit: limit}
+	if source != nil && source.HasPayload() {
+		if errWrite := source.WriteTo(writer); errWrite != nil {
+			if errors.Is(errWrite, errJSONLogSectionLimit) {
+				return writer.buffer.Bytes(), true, nil
+			}
+			return nil, false, errWrite
+		}
+	}
+	if len(inline) > 0 {
+		if _, errWrite := writer.Write(inline); errWrite != nil {
+			if errors.Is(errWrite, errJSONLogSectionLimit) {
+				return writer.buffer.Bytes(), true, nil
+			}
+			return nil, false, errWrite
+		}
+	}
+	return writer.buffer.Bytes(), false, nil
+}

--- a/internal/logging/request_logger_json.go
+++ b/internal/logging/request_logger_json.go
@@ -2,12 +2,14 @@ package logging
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"time"
+	"unicode/utf8"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/buildinfo"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
@@ -30,13 +32,16 @@ type jsonLogPayload struct {
 	Headers                       map[string][]string `json:"headers,omitempty"`
 	RequestBody                   json.RawMessage     `json:"request_body,omitempty"`
 	RequestBodyRaw                string              `json:"request_body_raw,omitempty"`
+	RequestBodyEncoding           string              `json:"request_body_encoding,omitempty"`
 	RequestBodyTruncated          bool                `json:"request_body_truncated,omitempty"`
 	Response                      *jsonLogResponse    `json:"response,omitempty"`
 	APIRequest                    json.RawMessage     `json:"api_request,omitempty"`
 	APIRequestRaw                 string              `json:"api_request_raw,omitempty"`
+	APIRequestEncoding            string              `json:"api_request_encoding,omitempty"`
 	APIRequestTruncated           bool                `json:"api_request_truncated,omitempty"`
 	APIResponse                   json.RawMessage     `json:"api_response,omitempty"`
 	APIResponseRaw                string              `json:"api_response_raw,omitempty"`
+	APIResponseEncoding           string              `json:"api_response_encoding,omitempty"`
 	APIResponseTruncated          bool                `json:"api_response_truncated,omitempty"`
 	APIResponseErrors             []jsonLogError      `json:"api_response_errors,omitempty"`
 	APIResponseTimestamp          string              `json:"api_response_timestamp,omitempty"`
@@ -57,6 +62,7 @@ type jsonLogResponse struct {
 	Headers            map[string][]string `json:"headers,omitempty"`
 	Body               json.RawMessage     `json:"body,omitempty"`
 	BodyRaw            string              `json:"body_raw,omitempty"`
+	BodyEncoding       string              `json:"body_encoding,omitempty"`
 	BodyTruncated      bool                `json:"body_truncated,omitempty"`
 	DecompressionError string              `json:"decompression_error,omitempty"`
 }
@@ -134,7 +140,7 @@ func (l *FileRequestLogger) writeJSONLog(
 		Headers:              maskHeaders(requestHeaders),
 		RequestBodyTruncated: requestBodyTruncated,
 	}
-	setJSONPayload(requestBytes, &entry.RequestBody, &entry.RequestBodyRaw)
+	setJSONPayload(requestBytes, &entry.RequestBody, &entry.RequestBodyRaw, &entry.RequestBodyEncoding)
 	if !apiResponseTimestamp.IsZero() {
 		entry.APIResponseTimestamp = apiResponseTimestamp.Format(time.RFC3339Nano)
 	}
@@ -144,14 +150,14 @@ func (l *FileRequestLogger) writeJSONLog(
 		return fmt.Errorf("read JSON API request: %w", errMerge)
 	}
 	entry.APIRequestTruncated = truncated
-	setJSONPayload(apiRequestBytes, &entry.APIRequest, &entry.APIRequestRaw)
+	setJSONPayload(apiRequestBytes, &entry.APIRequest, &entry.APIRequestRaw, &entry.APIRequestEncoding)
 
 	apiResponseBytes, truncated, errMerge := mergeJSONSectionLimited(apiResponseSource, apiResponse, maxJSONFileBackedSectionBytes)
 	if errMerge != nil {
 		return fmt.Errorf("read JSON API response: %w", errMerge)
 	}
 	entry.APIResponseTruncated = truncated
-	setJSONPayload(apiResponseBytes, &entry.APIResponse, &entry.APIResponseRaw)
+	setJSONPayload(apiResponseBytes, &entry.APIResponse, &entry.APIResponseRaw, &entry.APIResponseEncoding)
 
 	for _, apiErr := range apiResponseErrors {
 		if apiErr == nil {
@@ -195,7 +201,7 @@ func (l *FileRequestLogger) writeJSONLog(
 		responseBodyTruncated = true
 	}
 	responseEntry.BodyTruncated = responseBodyTruncated
-	setJSONPayload(response, &responseEntry.Body, &responseEntry.BodyRaw)
+	setJSONPayload(response, &responseEntry.Body, &responseEntry.BodyRaw, &responseEntry.BodyEncoding)
 	entry.Response = responseEntry
 
 	data, errMarshal := json.Marshal(&entry)
@@ -207,12 +213,17 @@ func (l *FileRequestLogger) writeJSONLog(
 	return errWrite
 }
 
-func setJSONPayload(payload []byte, structured *json.RawMessage, raw *string) {
+func setJSONPayload(payload []byte, structured *json.RawMessage, raw, encoding *string) {
 	if len(payload) == 0 {
 		return
 	}
 	if json.Valid(payload) {
 		*structured = json.RawMessage(payload)
+		return
+	}
+	if !utf8.Valid(payload) {
+		*raw = base64.StdEncoding.EncodeToString(payload)
+		*encoding = "base64"
 		return
 	}
 	*raw = string(payload)

--- a/internal/logging/request_logger_json.go
+++ b/internal/logging/request_logger_json.go
@@ -46,8 +46,10 @@ type jsonLogPayload struct {
 	APIResponseErrors             []jsonLogError      `json:"api_response_errors,omitempty"`
 	APIResponseTimestamp          string              `json:"api_response_timestamp,omitempty"`
 	APIWebsocketTimelineRaw       string              `json:"api_websocket_timeline_raw,omitempty"`
+	APIWebsocketTimelineEncoding  string              `json:"api_websocket_timeline_encoding,omitempty"`
 	APIWebsocketTimelineTruncated bool                `json:"api_websocket_timeline_truncated,omitempty"`
 	WebsocketTimelineRaw          string              `json:"websocket_timeline_raw,omitempty"`
+	WebsocketTimelineEncoding     string              `json:"websocket_timeline_encoding,omitempty"`
 	WebsocketTimelineTruncated    bool                `json:"websocket_timeline_truncated,omitempty"`
 }
 
@@ -174,14 +176,14 @@ func (l *FileRequestLogger) writeJSONLog(
 	if errMerge != nil {
 		return fmt.Errorf("read JSON API websocket timeline: %w", errMerge)
 	}
-	entry.APIWebsocketTimelineRaw = string(apiTimeline)
+	setJSONRawPayload(apiTimeline, &entry.APIWebsocketTimelineRaw, &entry.APIWebsocketTimelineEncoding)
 	entry.APIWebsocketTimelineTruncated = truncated
 
 	downstreamTimeline, truncated, errMerge := mergeJSONSectionLimited(websocketTimelineSource, websocketTimeline, maxJSONFileBackedSectionBytes)
 	if errMerge != nil {
 		return fmt.Errorf("read JSON websocket timeline: %w", errMerge)
 	}
-	entry.WebsocketTimelineRaw = string(downstreamTimeline)
+	setJSONRawPayload(downstreamTimeline, &entry.WebsocketTimelineRaw, &entry.WebsocketTimelineEncoding)
 	entry.WebsocketTimelineTruncated = truncated
 
 	responseEntry := &jsonLogResponse{Status: statusCode, Headers: maskHeaders(responseHeaders)}
@@ -224,6 +226,18 @@ func setJSONPayload(payload []byte, structured *json.RawMessage, raw, encoding *
 	}
 	if json.Valid(payload) {
 		*structured = json.RawMessage(payload)
+		return
+	}
+	*raw = string(payload)
+}
+
+func setJSONRawPayload(payload []byte, raw, encoding *string) {
+	if len(payload) == 0 {
+		return
+	}
+	if !utf8.Valid(payload) {
+		*raw = base64.StdEncoding.EncodeToString(payload)
+		*encoding = "base64"
 		return
 	}
 	*raw = string(payload)

--- a/internal/logging/request_logger_json.go
+++ b/internal/logging/request_logger_json.go
@@ -84,7 +84,7 @@ func maskHeaders(headers map[string][]string) map[string][]string {
 	return masked
 }
 
-func (l *FileRequestLogger) writeJSONLog(
+func writeJSONLog(
 	w io.Writer,
 	url, method string,
 	requestHeaders map[string][]string,

--- a/internal/logging/request_logger_json.go
+++ b/internal/logging/request_logger_json.go
@@ -217,13 +217,13 @@ func setJSONPayload(payload []byte, structured *json.RawMessage, raw, encoding *
 	if len(payload) == 0 {
 		return
 	}
-	if json.Valid(payload) {
-		*structured = json.RawMessage(payload)
-		return
-	}
 	if !utf8.Valid(payload) {
 		*raw = base64.StdEncoding.EncodeToString(payload)
 		*encoding = "base64"
+		return
+	}
+	if json.Valid(payload) {
+		*structured = json.RawMessage(payload)
 		return
 	}
 	*raw = string(payload)

--- a/internal/logging/request_logger_json.go
+++ b/internal/logging/request_logger_json.go
@@ -285,6 +285,7 @@ func (w *limitedJSONLogWriter) Write(payload []byte) (int, error) {
 
 func mergeJSONSectionLimited(source *FileBodySource, inline []byte, limit int) ([]byte, bool, error) {
 	writer := &limitedJSONLogWriter{limit: limit}
+	truncated := source != nil && source.Truncated()
 	if source != nil && source.HasPayload() {
 		if errWrite := source.WriteTo(writer); errWrite != nil {
 			if errors.Is(errWrite, errJSONLogSectionLimit) {
@@ -301,5 +302,5 @@ func mergeJSONSectionLimited(source *FileBodySource, inline []byte, limit int) (
 			return nil, false, errWrite
 		}
 	}
-	return writer.buffer.Bytes(), false, nil
+	return writer.buffer.Bytes(), truncated, nil
 }

--- a/internal/logging/request_logger_streaming.go
+++ b/internal/logging/request_logger_streaming.go
@@ -319,7 +319,7 @@ func (w *FileStreamingLogWriter) writeFinalLog(logFile *os.File) error {
 	if errWrite := writeRequestInfoWithBody(logFile, w.url, w.method, w.requestHeaders, nil, w.requestBodyPath, w.timestamp, "http", upstreamTransport, true); errWrite != nil {
 		return errWrite
 	}
-	if errWrite := writeAPISection(logFile, "=== API WEBSOCKET TIMELINE ===\n", "=== API WEBSOCKET TIMELINE", w.apiWebsocketTimeline, time.Time{}); errWrite != nil {
+	if errWrite := writeAPISectionWithSource(logFile, "=== API WEBSOCKET TIMELINE ===\n", "=== API WEBSOCKET TIMELINE", w.apiWebsocketTimeline, w.apiWebsocketTimelineSource, time.Time{}); errWrite != nil {
 		return errWrite
 	}
 	if errWrite := writePreformattedAPISectionWithSource(logFile, "=== API REQUEST ===\n", "=== API REQUEST", w.apiRequest, w.apiRequestSource, time.Time{}); errWrite != nil {

--- a/internal/logging/request_logger_streaming.go
+++ b/internal/logging/request_logger_streaming.go
@@ -30,7 +30,8 @@ type FileStreamingLogWriter struct {
 	requestHeaders map[string][]string
 
 	// requestBodyPath is a temporary file path holding the request body.
-	requestBodyPath string
+	requestBodyPath      string
+	requestBodyTruncated bool
 
 	// responseBodyPath is a temporary file path holding the streaming response body.
 	responseBodyPath string
@@ -301,7 +302,7 @@ func (w *FileStreamingLogWriter) writeFinalLog(logFile *os.File) error {
 	upstreamTransport := inferUpstreamTransport(w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, w.apiWebsocketTimeline, nil, nil)
 	if w.format == "json" {
 		logger := NewFileRequestLoggerWithFormat(true, "", "", 0, "json")
-		return logger.writeJSONLog(logFile, w.url, w.method, w.requestHeaders, nil, w.requestBodyPath, false, w.responseStatus, w.responseHeaders, nil, w.responseBodyPath, w.responseBodyTruncated.Load(), nil, w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, nil, nil, nil, w.apiWebsocketTimeline, nil, w.timestamp, w.apiResponseTimestamp, "http", upstreamTransport)
+		return logger.writeJSONLog(logFile, w.url, w.method, w.requestHeaders, nil, w.requestBodyPath, w.requestBodyTruncated, w.responseStatus, w.responseHeaders, nil, w.responseBodyPath, w.responseBodyTruncated.Load(), nil, w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, nil, nil, nil, w.apiWebsocketTimeline, nil, w.timestamp, w.apiResponseTimestamp, "http", upstreamTransport)
 	}
 
 	if errWrite := writeRequestInfoWithBody(logFile, w.url, w.method, w.requestHeaders, nil, w.requestBodyPath, w.timestamp, "http", upstreamTransport, true); errWrite != nil {

--- a/internal/logging/request_logger_streaming.go
+++ b/internal/logging/request_logger_streaming.go
@@ -310,10 +310,9 @@ func (w *FileStreamingLogWriter) asyncWriter() {
 }
 
 func (w *FileStreamingLogWriter) writeFinalLog(logFile *os.File) error {
-	upstreamTransport := inferUpstreamTransport(w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, w.apiWebsocketTimeline, w.apiWebsocketTimelineSource, nil)
+	upstreamTransport := inferUpstreamTransport(w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, w.apiWebsocketTimeline, w.apiWebsocketTimelineSource)
 	if w.format == "json" {
-		logger := NewFileRequestLoggerWithFormat(true, "", "", 0, "json")
-		return logger.writeJSONLog(logFile, w.url, w.method, w.requestHeaders, nil, w.requestBodyPath, w.requestBodyTruncated, w.responseStatus, w.responseHeaders, nil, w.responseBodyPath, w.responseBodyTruncated.Load(), nil, w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, nil, nil, nil, w.apiWebsocketTimeline, w.apiWebsocketTimelineSource, w.timestamp, w.apiResponseTimestamp, "http", upstreamTransport)
+		return writeJSONLog(logFile, w.url, w.method, w.requestHeaders, nil, w.requestBodyPath, w.requestBodyTruncated, w.responseStatus, w.responseHeaders, nil, w.responseBodyPath, w.responseBodyTruncated.Load(), nil, w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, nil, nil, nil, w.apiWebsocketTimeline, w.apiWebsocketTimelineSource, w.timestamp, w.apiResponseTimestamp, "http", upstreamTransport)
 	}
 
 	if errWrite := writeRequestInfoWithBody(logFile, w.url, w.method, w.requestHeaders, nil, w.requestBodyPath, w.timestamp, "http", upstreamTransport, true); errWrite != nil {

--- a/internal/logging/request_logger_streaming.go
+++ b/internal/logging/request_logger_streaming.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -36,6 +37,7 @@ type FileStreamingLogWriter struct {
 
 	// responseBodyFile is the temp file where chunks are appended by the async writer.
 	responseBodyFile *os.File
+	responseBodySize int
 
 	// chunkChan is a channel for receiving response chunks to spool.
 	chunkChan chan []byte
@@ -72,6 +74,10 @@ type FileStreamingLogWriter struct {
 
 	// apiResponseTimestamp captures when the API response was received.
 	apiResponseTimestamp time.Time
+
+	format string
+
+	responseBodyTruncated atomic.Bool
 }
 
 // WriteChunkAsync writes a response chunk asynchronously (non-blocking).
@@ -92,7 +98,12 @@ func (w *FileStreamingLogWriter) WriteChunkAsync(chunk []byte) {
 	case w.chunkChan <- chunkCopy:
 	default:
 		// Channel is full, skip this chunk to avoid blocking
+		w.responseBodyTruncated.Store(true)
 	}
+}
+
+func (w *FileStreamingLogWriter) MarkResponseBodyTruncated() {
+	w.responseBodyTruncated.Store(true)
 }
 
 // WriteStatus buffers the response status and headers for later writing.
@@ -246,6 +257,17 @@ func (w *FileStreamingLogWriter) asyncWriter() {
 		if w.responseBodyFile == nil {
 			continue
 		}
+		if w.format == "json" {
+			remaining := maxJSONStreamingResponseBytes - w.responseBodySize
+			if remaining <= 0 {
+				w.responseBodyTruncated.Store(true)
+				continue
+			}
+			if len(chunk) > remaining {
+				chunk = chunk[:remaining]
+				w.responseBodyTruncated.Store(true)
+			}
+		}
 		if _, errWrite := w.responseBodyFile.Write(chunk); errWrite != nil {
 			select {
 			case w.errorChan <- errWrite:
@@ -258,7 +280,9 @@ func (w *FileStreamingLogWriter) asyncWriter() {
 				}
 			}
 			w.responseBodyFile = nil
+			continue
 		}
+		w.responseBodySize += len(chunk)
 	}
 
 	if w.responseBodyFile == nil {
@@ -274,7 +298,13 @@ func (w *FileStreamingLogWriter) asyncWriter() {
 }
 
 func (w *FileStreamingLogWriter) writeFinalLog(logFile *os.File) error {
-	if errWrite := writeRequestInfoWithBody(logFile, w.url, w.method, w.requestHeaders, nil, w.requestBodyPath, w.timestamp, "http", inferUpstreamTransport(w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, w.apiWebsocketTimeline, nil, nil), true); errWrite != nil {
+	upstreamTransport := inferUpstreamTransport(w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, w.apiWebsocketTimeline, nil, nil)
+	if w.format == "json" {
+		logger := NewFileRequestLoggerWithFormat(true, "", "", 0, "json")
+		return logger.writeJSONLog(logFile, w.url, w.method, w.requestHeaders, nil, w.requestBodyPath, false, w.responseStatus, w.responseHeaders, nil, w.responseBodyPath, w.responseBodyTruncated.Load(), nil, w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, nil, nil, nil, w.apiWebsocketTimeline, nil, w.timestamp, w.apiResponseTimestamp, "http", upstreamTransport)
+	}
+
+	if errWrite := writeRequestInfoWithBody(logFile, w.url, w.method, w.requestHeaders, nil, w.requestBodyPath, w.timestamp, "http", upstreamTransport, true); errWrite != nil {
 		return errWrite
 	}
 	if errWrite := writeAPISection(logFile, "=== API WEBSOCKET TIMELINE ===\n", "=== API WEBSOCKET TIMELINE", w.apiWebsocketTimeline, time.Time{}); errWrite != nil {

--- a/internal/logging/request_logger_streaming.go
+++ b/internal/logging/request_logger_streaming.go
@@ -71,7 +71,8 @@ type FileStreamingLogWriter struct {
 	apiResponseSource *FileBodySource
 
 	// apiWebsocketTimeline stores the upstream websocket event timeline.
-	apiWebsocketTimeline []byte
+	apiWebsocketTimeline       []byte
+	apiWebsocketTimelineSource *FileBodySource
 
 	// apiResponseTimestamp captures when the API response was received.
 	apiResponseTimestamp time.Time
@@ -196,6 +197,15 @@ func (w *FileStreamingLogWriter) WriteAPIWebsocketTimeline(apiWebsocketTimeline 
 	return nil
 }
 
+// WriteAPIWebsocketTimelineSource buffers a file-backed upstream websocket timeline.
+func (w *FileStreamingLogWriter) WriteAPIWebsocketTimelineSource(source *FileBodySource) error {
+	if source == nil || !source.HasPayload() {
+		return nil
+	}
+	w.apiWebsocketTimelineSource = source
+	return nil
+}
+
 func (w *FileStreamingLogWriter) SetFirstChunkTimestamp(timestamp time.Time) {
 	if !timestamp.IsZero() {
 		w.apiResponseTimestamp = timestamp
@@ -209,6 +219,7 @@ func (w *FileStreamingLogWriter) SetFirstChunkTimestamp(timestamp time.Time) {
 // Returns:
 //   - error: An error if closing fails, nil otherwise
 func (w *FileStreamingLogWriter) Close() error {
+	defer cleanupFileBodySources(w.apiRequestSource, w.apiResponseSource, w.apiWebsocketTimelineSource)
 	if w.chunkChan != nil {
 		close(w.chunkChan)
 	}
@@ -299,10 +310,10 @@ func (w *FileStreamingLogWriter) asyncWriter() {
 }
 
 func (w *FileStreamingLogWriter) writeFinalLog(logFile *os.File) error {
-	upstreamTransport := inferUpstreamTransport(w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, w.apiWebsocketTimeline, nil, nil)
+	upstreamTransport := inferUpstreamTransport(w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, w.apiWebsocketTimeline, w.apiWebsocketTimelineSource, nil)
 	if w.format == "json" {
 		logger := NewFileRequestLoggerWithFormat(true, "", "", 0, "json")
-		return logger.writeJSONLog(logFile, w.url, w.method, w.requestHeaders, nil, w.requestBodyPath, w.requestBodyTruncated, w.responseStatus, w.responseHeaders, nil, w.responseBodyPath, w.responseBodyTruncated.Load(), nil, w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, nil, nil, nil, w.apiWebsocketTimeline, nil, w.timestamp, w.apiResponseTimestamp, "http", upstreamTransport)
+		return logger.writeJSONLog(logFile, w.url, w.method, w.requestHeaders, nil, w.requestBodyPath, w.requestBodyTruncated, w.responseStatus, w.responseHeaders, nil, w.responseBodyPath, w.responseBodyTruncated.Load(), nil, w.apiRequest, w.apiRequestSource, w.apiResponse, w.apiResponseSource, nil, nil, nil, w.apiWebsocketTimeline, w.apiWebsocketTimelineSource, w.timestamp, w.apiResponseTimestamp, "http", upstreamTransport)
 	}
 
 	if errWrite := writeRequestInfoWithBody(logFile, w.url, w.method, w.requestHeaders, nil, w.requestBodyPath, w.timestamp, "http", upstreamTransport, true); errWrite != nil {

--- a/internal/logging/request_logger_writer.go
+++ b/internal/logging/request_logger_writer.go
@@ -82,6 +82,7 @@ func (l *FileRequestLogger) logRequestWithSources(url, method string, requestHea
 			requestHeaders,
 			body,
 			"",
+			false,
 			websocketTimeline,
 			websocketTimelineSource,
 			apiRequest,
@@ -116,7 +117,7 @@ func (l *FileRequestLogger) logRequestWithSources(url, method string, requestHea
 	}
 	filePath := filepath.Join(l.logsDir, filename)
 
-	requestBodyPath, errTemp := l.writeRequestBodyTempFile(body)
+	requestBodyPath, requestBodyTruncated, errTemp := l.writeRequestBodyTempFile(body)
 	if errTemp != nil {
 		log.WithError(errTemp).Warn("failed to create request body temp file, falling back to direct write")
 	}
@@ -146,6 +147,7 @@ func (l *FileRequestLogger) logRequestWithSources(url, method string, requestHea
 		requestHeaders,
 		body,
 		requestBodyPath,
+		requestBodyTruncated,
 		websocketTimeline,
 		websocketTimelineSource,
 		apiRequest,
@@ -222,7 +224,7 @@ func (l *FileRequestLogger) LogStreamingRequest(url, method string, headers map[
 		requestHeaders[key] = headerValues
 	}
 
-	requestBodyPath, errTemp := l.writeRequestBodyTempFile(body)
+	requestBodyPath, requestBodyTruncated, errTemp := l.writeRequestBodyTempFile(body)
 	if errTemp != nil {
 		return nil, fmt.Errorf("failed to create request body temp file: %w", errTemp)
 	}
@@ -236,18 +238,19 @@ func (l *FileRequestLogger) LogStreamingRequest(url, method string, headers map[
 
 	// Create streaming writer
 	writer := &FileStreamingLogWriter{
-		logFilePath:      filePath,
-		url:              url,
-		method:           method,
-		timestamp:        time.Now(),
-		requestHeaders:   requestHeaders,
-		requestBodyPath:  requestBodyPath,
-		responseBodyPath: responseBodyPath,
-		responseBodyFile: responseBodyFile,
-		chunkChan:        make(chan []byte, 100), // Buffered channel for async writes
-		closeChan:        make(chan struct{}),
-		errorChan:        make(chan error, 1),
-		format:           l.currentFormat(),
+		logFilePath:          filePath,
+		url:                  url,
+		method:               method,
+		timestamp:            time.Now(),
+		requestHeaders:       requestHeaders,
+		requestBodyPath:      requestBodyPath,
+		requestBodyTruncated: requestBodyTruncated,
+		responseBodyPath:     responseBodyPath,
+		responseBodyFile:     responseBodyFile,
+		chunkChan:            make(chan []byte, 100), // Buffered channel for async writes
+		closeChan:            make(chan struct{}),
+		errorChan:            make(chan error, 1),
+		format:               l.currentFormat(),
 	}
 
 	// Start async writer goroutine
@@ -394,21 +397,25 @@ func (l *FileRequestLogger) cleanupOldErrorLogs() error {
 	return nil
 }
 
-func (l *FileRequestLogger) writeRequestBodyTempFile(body []byte) (string, error) {
+func (l *FileRequestLogger) writeRequestBodyTempFile(body []byte) (string, bool, error) {
 	tmpFile, errCreate := os.CreateTemp(l.logsDir, "request-body-*.tmp")
 	if errCreate != nil {
-		return "", errCreate
+		return "", false, errCreate
 	}
 	tmpPath := tmpFile.Name()
+	truncated := l.currentFormat() == "json" && len(body) > maxJSONFileBackedSectionBytes
+	if truncated {
+		body = body[:maxJSONFileBackedSectionBytes]
+	}
 
 	if _, errCopy := io.Copy(tmpFile, bytes.NewReader(body)); errCopy != nil {
 		_ = tmpFile.Close()
 		_ = os.Remove(tmpPath)
-		return "", errCopy
+		return "", false, errCopy
 	}
 	if errClose := tmpFile.Close(); errClose != nil {
 		_ = os.Remove(tmpPath)
-		return "", errClose
+		return "", false, errClose
 	}
-	return tmpPath, nil
+	return tmpPath, truncated, nil
 }

--- a/internal/logging/request_logger_writer.go
+++ b/internal/logging/request_logger_writer.go
@@ -203,7 +203,7 @@ func (l *FileRequestLogger) LogStreamingRequest(url, method string, headers map[
 		if client == nil || !client.HeartbeatOK() {
 			return &NoOpStreamingLogWriter{}, nil
 		}
-		return newHomeStreamingLogWriter(url, method, headers, body, requestID), nil
+		return newHomeStreamingLogWriter(url, method, headers, body, requestID, l.currentFormat()), nil
 	}
 
 	// Ensure logs directory exists
@@ -247,6 +247,7 @@ func (l *FileRequestLogger) LogStreamingRequest(url, method string, headers map[
 		chunkChan:        make(chan []byte, 100), // Buffered channel for async writes
 		closeChan:        make(chan struct{}),
 		errorChan:        make(chan error, 1),
+		format:           l.currentFormat(),
 	}
 
 	// Start async writer goroutine

--- a/internal/logging/request_logger_writer.go
+++ b/internal/logging/request_logger_writer.go
@@ -117,7 +117,11 @@ func (l *FileRequestLogger) logRequestWithSources(url, method string, requestHea
 	}
 	filePath := filepath.Join(l.logsDir, filename)
 
-	requestBodyPath, requestBodyTruncated, errTemp := l.writeRequestBodyTempFile(body)
+	format := requestLogFormatFromSources(apiRequestSource, apiResponseSource, websocketTimelineSource, apiWebsocketTimelineSource)
+	if format == "" {
+		format = l.currentFormat()
+	}
+	requestBodyPath, requestBodyTruncated, errTemp := l.writeRequestBodyTempFile(body, format)
 	if errTemp != nil {
 		log.WithError(errTemp).Warn("failed to create request body temp file, falling back to direct write")
 	}
@@ -196,6 +200,12 @@ func (l *FileRequestLogger) logRequestWithSources(url, method string, requestHea
 //   - StreamingLogWriter: A writer for streaming response chunks
 //   - error: An error if logging initialization fails, nil otherwise
 func (l *FileRequestLogger) LogStreamingRequest(url, method string, headers map[string][]string, body []byte, requestID string) (StreamingLogWriter, error) {
+	return l.LogStreamingRequestWithFormat(url, method, headers, body, requestID, l.currentFormat())
+}
+
+// LogStreamingRequestWithFormat starts streaming logging with a per-request format snapshot.
+func (l *FileRequestLogger) LogStreamingRequestWithFormat(url, method string, headers map[string][]string, body []byte, requestID, format string) (StreamingLogWriter, error) {
+	format = normalizeRequestLogFormat(format)
 	if !l.enabled {
 		return &NoOpStreamingLogWriter{}, nil
 	}
@@ -205,7 +215,7 @@ func (l *FileRequestLogger) LogStreamingRequest(url, method string, headers map[
 		if client == nil || !client.HeartbeatOK() {
 			return &NoOpStreamingLogWriter{}, nil
 		}
-		return newHomeStreamingLogWriter(url, method, headers, body, requestID, l.currentFormat()), nil
+		return newHomeStreamingLogWriter(url, method, headers, body, requestID, format), nil
 	}
 
 	// Ensure logs directory exists
@@ -224,7 +234,7 @@ func (l *FileRequestLogger) LogStreamingRequest(url, method string, headers map[
 		requestHeaders[key] = headerValues
 	}
 
-	requestBodyPath, requestBodyTruncated, errTemp := l.writeRequestBodyTempFile(body)
+	requestBodyPath, requestBodyTruncated, errTemp := l.writeRequestBodyTempFile(body, format)
 	if errTemp != nil {
 		return nil, fmt.Errorf("failed to create request body temp file: %w", errTemp)
 	}
@@ -250,7 +260,7 @@ func (l *FileRequestLogger) LogStreamingRequest(url, method string, headers map[
 		chunkChan:            make(chan []byte, 100), // Buffered channel for async writes
 		closeChan:            make(chan struct{}),
 		errorChan:            make(chan error, 1),
-		format:               l.currentFormat(),
+		format:               format,
 	}
 
 	// Start async writer goroutine
@@ -397,13 +407,13 @@ func (l *FileRequestLogger) cleanupOldErrorLogs() error {
 	return nil
 }
 
-func (l *FileRequestLogger) writeRequestBodyTempFile(body []byte) (string, bool, error) {
+func (l *FileRequestLogger) writeRequestBodyTempFile(body []byte, format string) (string, bool, error) {
 	tmpFile, errCreate := os.CreateTemp(l.logsDir, "request-body-*.tmp")
 	if errCreate != nil {
 		return "", false, errCreate
 	}
 	tmpPath := tmpFile.Name()
-	truncated := l.currentFormat() == "json" && len(body) > maxJSONFileBackedSectionBytes
+	truncated := normalizeRequestLogFormat(format) == "json" && len(body) > maxJSONFileBackedSectionBytes
 	if truncated {
 		body = body[:maxJSONFileBackedSectionBytes]
 	}

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -611,7 +611,7 @@ func TestApplyClaudeHeaders_DisableDeviceProfileStabilization(t *testing.T) {
 		"X-Stainless-Arch":            []string{"x64"},
 	})
 	applyClaudeHeaders(thirdPartyReq, auth, "key-disable-stability", false, nil, nil, cfg, nil, false)
-	assertClaudeFingerprint(t, thirdPartyReq.Header, "claude-cli/2.1.60 (external, cli)", "0.70.0", "v22.0.0", helps.MapStainlessOS(), helps.MapStainlessArch())
+	assertClaudeFingerprint(t, thirdPartyReq.Header, "claude-cli/2.1.60 (external, cli)", "0.70.0", "v22.0.0", "MacOS", "arm64")
 
 	lowerReq := newClaudeHeaderTestRequest(t, http.Header{
 		"User-Agent":                  []string{"claude-cli/2.1.61 (external, cli)"},
@@ -653,7 +653,7 @@ func TestApplyClaudeHeaders_LegacyModePreservesConfiguredUserAgentOverrideForCla
 	})
 	applyClaudeHeaders(req, auth, "key-legacy-ua-override", false, nil, nil, cfg, nil, true)
 
-	assertClaudeFingerprint(t, req.Header, "config-ua/1.0", "0.70.0", "v22.0.0", helps.MapStainlessOS(), helps.MapStainlessArch())
+	assertClaudeFingerprint(t, req.Header, "config-ua/1.0", "0.70.0", "v22.0.0", "MacOS", "arm64")
 }
 
 func TestApplyClaudeHeaders_LegacyThirdPartyUsesStableConfiguredOSArch(t *testing.T) {
@@ -758,7 +758,7 @@ func TestClaudeExecutor_NonClaudeRequestUsesClaudeCode220CLIFingerprint(t *testi
 		t.Fatalf("Execute() error = %v", errExecute)
 	}
 
-	assertClaudeFingerprint(t, seenHeaders, "claude-cli/2.1.220 (external, cli)", "0.94.0", "v26.3.0", helps.MapStainlessOS(), helps.MapStainlessArch())
+	assertClaudeFingerprint(t, seenHeaders, "claude-cli/2.1.220 (external, cli)", "0.94.0", "v26.3.0", "MacOS", "arm64")
 	if got := seenHeaders.Get("X-App"); got != "cli" {
 		t.Fatalf("X-App = %q, want cli", got)
 	}

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -2472,6 +2472,24 @@ func TestResponsesWebsocketTimelineRecordsDisconnectEvent(t *testing.T) {
 	}
 }
 
+func TestResponsesWebsocketTimelineUsesBoundedJSONSource(t *testing.T) {
+	logger := requestlogging.NewFileRequestLoggerWithFormat(true, t.TempDir(), "", 0, "json")
+	source, err := logger.NewFileBodySource("websocket-timeline")
+	if err != nil {
+		t.Fatalf("NewFileBodySource failed: %v", err)
+	}
+	defer source.Cleanup()
+	timeline := newWebsocketTimelineLog(true, source)
+	timeline.BeginRequest()
+	payload := bytes.Repeat([]byte("x"), 64<<10)
+	for !source.Truncated() {
+		timeline.Append("response.output_text.delta", payload, time.Now())
+	}
+	if !source.Truncated() {
+		t.Fatal("downstream websocket timeline source is not bounded")
+	}
+}
+
 func TestResponsesWebsocketMirrorsUpstreamMessageTooBigDisconnect(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -2482,7 +2482,7 @@ func TestResponsesWebsocketTimelineUsesBoundedJSONSource(t *testing.T) {
 	timeline := newWebsocketTimelineLog(true, source)
 	timeline.BeginRequest()
 	payload := bytes.Repeat([]byte("x"), 64<<10)
-	for !source.Truncated() {
+	for range 130 {
 		timeline.Append("response.output_text.delta", payload, time.Now())
 	}
 	if !source.Truncated() {

--- a/sdk/api/handlers/openai/openai_responses_websocket_timeline.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_timeline.go
@@ -3,7 +3,6 @@ package openai
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -146,19 +145,6 @@ func (l *websocketTimelineLog) closeCurrentPart() {
 	}
 	l.currentPartHasLog = false
 	l.currentPartNeedsNewline = false
-}
-
-func writeWebsocketTimelinePart(w io.Writer, data []byte, prependNewline bool) error {
-	if w == nil || len(data) == 0 {
-		return nil
-	}
-	if prependNewline {
-		if _, errWrite := io.WriteString(w, "\n"); errWrite != nil {
-			return errWrite
-		}
-	}
-	_, errWrite := w.Write(data)
-	return errWrite
 }
 
 func writeWebsocketTimelineBuilder(builder *strings.Builder, data []byte) {

--- a/sdk/api/handlers/openai/openai_responses_websocket_timeline.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_timeline.go
@@ -30,8 +30,8 @@ type websocketTimelineLog struct {
 	source  *requestlogging.FileBodySource
 	builder *strings.Builder
 
-	currentPart       io.WriteCloser
-	currentPartHasLog bool
+	currentPartHasLog       bool
+	currentPartNeedsNewline bool
 }
 
 func newWebsocketTimelineLog(enabled bool, source *requestlogging.FileBodySource) *websocketTimelineLog {
@@ -74,13 +74,7 @@ func (l *websocketTimelineLog) BeginRequest() {
 		return
 	}
 	l.closeCurrentPart()
-	part, errCreate := l.source.CreatePart("request")
-	if errCreate != nil {
-		log.WithError(errCreate).Warn("failed to create websocket request detail log")
-		return
-	}
-	l.currentPart = part
-	l.currentPartHasLog = false
+	l.currentPartNeedsNewline = l.source.HasPayload()
 }
 
 func (l *websocketTimelineLog) Append(eventType string, payload []byte, timestamp time.Time) {
@@ -92,17 +86,16 @@ func (l *websocketTimelineLog) Append(eventType string, payload []byte, timestam
 		return
 	}
 	if l.source != nil {
-		if l.currentPart == nil {
-			l.BeginRequest()
+		prependNewline := l.currentPartHasLog || l.currentPartNeedsNewline
+		if prependNewline {
+			data = append([]byte{'\n'}, data...)
 		}
-		if l.currentPart == nil {
-			return
-		}
-		if errWrite := writeWebsocketTimelinePart(l.currentPart, data, l.currentPartHasLog); errWrite != nil {
+		if errWrite := l.source.AppendBytes(data); errWrite != nil {
 			log.WithError(errWrite).Warn("failed to write websocket request detail log")
 			return
 		}
 		l.currentPartHasLog = true
+		l.currentPartNeedsNewline = false
 		return
 	}
 	if l.builder != nil {
@@ -148,14 +141,11 @@ func (l *websocketTimelineLog) String() string {
 }
 
 func (l *websocketTimelineLog) closeCurrentPart() {
-	if l == nil || l.currentPart == nil {
+	if l == nil {
 		return
 	}
-	if errClose := l.currentPart.Close(); errClose != nil {
-		log.WithError(errClose).Warn("failed to close websocket request detail log")
-	}
-	l.currentPart = nil
 	l.currentPartHasLog = false
+	l.currentPartNeedsNewline = false
 }
 
 func writeWebsocketTimelinePart(w io.Writer, data []byte, prependNewline bool) error {


### PR DESCRIPTION
## Description
This PR introduces support for single-line NDJSON (Structured JSON) request logging.

### Changes:
- Added  setting ( or ) in  /  struct.
- Added NDJSON output generator for request logs in .
- Preserved 100% backward compatibility ( format remains default).
- Added unit tests in .