### PR TITLE
feat(codex): add managed desktop and CLI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,15 @@ PackyCode provides special discounts for our software users: register using <a h
 - Claude Code multi-account load balancing
 - OpenAI Codex multi-account load balancing
 - Grok Build multi-account load balancing
+- Codex desktop/CLI model integration through one local CLIProxyAPI process ([setup and operations guide](docs/codex-integration.md))
 - OpenAI-compatible upstream providers via config (e.g., OpenRouter)
 - Reusable Go SDK for embedding the proxy (see `docs/sdk-usage.md`)
 
 ## Getting Started
 
 CLIProxyAPI Guides: [https://help.router-for.me/](https://help.router-for.me/)
+
+To keep official GPT models while adding provider-qualified Grok, Gemini, and Claude models to Codex desktop or the Codex CLI, follow the [Codex integration guide](docs/codex-integration.md).
 
 ## Management API
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/api"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/buildinfo"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/cmd"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/codexintegration"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/homeplugins"
@@ -70,7 +71,12 @@ func shouldEnableExampleAPIKeySafeMode(cfg *config.Config, commandMode, tuiMode,
 // It parses command-line flags, loads configuration, and starts the appropriate
 // service based on the provided flags (login, codex-login, or server mode).
 func main() {
-	fmt.Printf("CLIProxyAPI Version: %s, Commit: %s, BuiltAt: %s\n", buildinfo.Version, buildinfo.Commit, buildinfo.BuildDate)
+	codexJSONMode := isCodexJSONInvocation(os.Args[1:])
+	if codexJSONMode {
+		log.SetOutput(os.Stderr)
+	} else {
+		fmt.Printf("CLIProxyAPI Version: %s, Commit: %s, BuiltAt: %s\n", buildinfo.Version, buildinfo.Commit, buildinfo.BuildDate)
+	}
 
 	// Command-line flags to control the application's behavior.
 	var codexLogin bool
@@ -90,6 +96,15 @@ func main() {
 	var tuiMode bool
 	var standalone bool
 	var localModel bool
+	var codexSetup bool
+	var codexSync bool
+	var codexDoctor bool
+	var codexRestore bool
+	var codexApply bool
+	var codexJSON bool
+	var codexProbeModels bool
+	var codexMigrateOpenCodex bool
+	var codexHome string
 
 	// Define command-line flags for different operation modes.
 	flag.BoolVar(&codexLogin, "codex-login", false, "Login to Codex using OAuth")
@@ -109,6 +124,15 @@ func main() {
 	flag.BoolVar(&tuiMode, "tui", false, "Start with terminal management UI")
 	flag.BoolVar(&standalone, "standalone", false, "In TUI mode, start an embedded local server")
 	flag.BoolVar(&localModel, "local-model", false, "Use embedded models.json and codex_client_models.json only, skip remote model catalog fetching")
+	flag.BoolVar(&codexSetup, "codex-setup", false, "Preview Codex Integration setup; use -apply to write")
+	flag.BoolVar(&codexSync, "codex-sync", false, "Preview Codex Integration catalog sync; use -apply to write")
+	flag.BoolVar(&codexDoctor, "codex-doctor", false, "Run read-only Codex Integration diagnostics")
+	flag.BoolVar(&codexRestore, "codex-restore", false, "Preview Codex Integration restore; use -apply to write")
+	flag.BoolVar(&codexApply, "apply", false, "Apply a Codex Integration setup, sync, or restore command")
+	flag.BoolVar(&codexJSON, "json", false, "Emit machine-readable JSON for Codex Integration commands")
+	flag.BoolVar(&codexProbeModels, "probe-models", false, "Send explicit low-cost model probes with -codex-doctor")
+	flag.BoolVar(&codexMigrateOpenCodex, "codex-migrate-opencodex", false, "Migrate recognized OpenCodex-managed root keys during setup")
+	flag.StringVar(&codexHome, "codex-home", "", "Override CODEX_HOME for Codex Integration commands")
 
 	flag.CommandLine.Usage = func() {
 		out := flag.CommandLine.Output()
@@ -145,6 +169,38 @@ func main() {
 
 	// Parse the command-line flags.
 	flag.Parse()
+	codexAction, hasCodexCommand, errSelectCodexCommand := selectCodexCommand(codexSetup, codexSync, codexDoctor, codexRestore)
+	if errSelectCodexCommand != nil {
+		if codexJSON {
+			_ = codexintegration.WriteCommandFailure(os.Stdout, "", errSelectCodexCommand)
+		} else {
+			fmt.Fprintf(os.Stderr, "Codex Integration error: %v\n", errSelectCodexCommand)
+		}
+		os.Exit(2)
+	}
+	codexCommandOptions := codexintegration.CommandOptions{
+		Action: codexAction, Apply: codexApply, JSON: codexJSON, ProbeModels: codexProbeModels,
+		MigrateOpenCodex: codexMigrateOpenCodex, CodexHome: codexHome,
+	}
+	otherOneShotCommand := vertexImport != "" || antigravityLogin || codexLogin || codexDeviceLogin || claudeLogin || kimiLogin || xaiLogin
+	if errCommandFlags := validateCodexCommandFlags(hasCodexCommand, otherOneShotCommand, codexCommandOptions); errCommandFlags != nil {
+		if codexJSON {
+			_ = codexintegration.WriteCommandFailure(os.Stdout, codexAction, errCommandFlags)
+		} else {
+			fmt.Fprintf(os.Stderr, "Codex Integration error: %v\n", errCommandFlags)
+		}
+		os.Exit(2)
+	}
+	if hasCodexCommand {
+		if errValidateCodexCommand := codexintegration.ValidateCommandOptions(codexCommandOptions); errValidateCodexCommand != nil {
+			if codexJSON {
+				_ = codexintegration.WriteCommandFailure(os.Stdout, codexAction, errValidateCodexCommand)
+			} else {
+				fmt.Fprintf(os.Stderr, "Codex Integration error: %v\n", errValidateCodexCommand)
+			}
+			os.Exit(2)
+		}
+	}
 
 	// Core application variables.
 	var err error
@@ -584,7 +640,7 @@ func main() {
 		CallbackPort: oauthCallbackPort,
 	}
 
-	commandMode := vertexImport != "" || antigravityLogin || codexLogin || codexDeviceLogin || claudeLogin || kimiLogin || xaiLogin
+	commandMode := vertexImport != "" || antigravityLogin || codexLogin || codexDeviceLogin || claudeLogin || kimiLogin || xaiLogin || hasCodexCommand
 	cloudConfigMissing := isCloudDeploy && !configFileExists
 	homeMode := configLoadedFromHome || (cfg != nil && cfg.Home.Enabled)
 	exampleAPIKeySafeMode := shouldEnableExampleAPIKeySafeMode(cfg, commandMode, tuiMode, standalone, cloudConfigMissing, homeMode)
@@ -629,6 +685,23 @@ func main() {
 			}
 			return
 		}
+	}
+	if hasCodexCommand {
+		exitCode, errCommand := codexintegration.RunCommand(context.Background(), cfg, codexCommandOptions, os.Stdout)
+		if errCommand != nil {
+			if codexJSON {
+				_ = codexintegration.WriteCommandFailure(os.Stdout, codexAction, errCommand)
+			} else {
+				fmt.Fprintf(os.Stderr, "Codex Integration error: %v\n", errCommand)
+			}
+			if exitCode == 0 {
+				exitCode = 2
+			}
+		}
+		if exitCode != 0 {
+			os.Exit(exitCode)
+		}
+		return
 	}
 
 	// Handle different command modes based on the provided flags.
@@ -767,6 +840,57 @@ func startModelCatalogUpdaters(localModel, homeEnabled bool) {
 	} else if homeEnabled {
 		log.Info("Home mode: remote models.json updates disabled; Codex client model list follows Home model IDs")
 	}
+}
+
+func selectCodexCommand(setup, syncCatalog, doctor, restore bool) (codexintegration.CommandAction, bool, error) {
+	selected := make([]codexintegration.CommandAction, 0, 1)
+	if setup {
+		selected = append(selected, codexintegration.CommandSetup)
+	}
+	if syncCatalog {
+		selected = append(selected, codexintegration.CommandSync)
+	}
+	if doctor {
+		selected = append(selected, codexintegration.CommandDoctor)
+	}
+	if restore {
+		selected = append(selected, codexintegration.CommandRestore)
+	}
+	if len(selected) > 1 {
+		return "", false, errors.New("-codex-setup, -codex-sync, -codex-doctor, and -codex-restore are mutually exclusive")
+	}
+	if len(selected) == 0 {
+		return "", false, nil
+	}
+	return selected[0], true, nil
+}
+
+func validateCodexCommandFlags(hasCodexCommand, hasOtherOneShotCommand bool, options codexintegration.CommandOptions) error {
+	if hasCodexCommand && hasOtherOneShotCommand {
+		return errors.New("Codex Integration commands cannot be combined with login or import commands")
+	}
+	if hasCodexCommand {
+		return nil
+	}
+	if options.Apply || options.JSON || options.ProbeModels || options.MigrateOpenCodex || strings.TrimSpace(options.CodexHome) != "" {
+		return errors.New("-apply, -json, -probe-models, -codex-migrate-opencodex, and -codex-home require a Codex Integration command")
+	}
+	return nil
+}
+
+func isCodexJSONInvocation(args []string) bool {
+	hasCommand := false
+	jsonEnabled := false
+	for _, arg := range args {
+		name, value, hasValue := strings.Cut(strings.TrimLeft(arg, "-"), "=")
+		switch name {
+		case "codex-setup", "codex-sync", "codex-doctor", "codex-restore":
+			hasCommand = !hasValue || !strings.EqualFold(value, "false")
+		case "json":
+			jsonEnabled = !hasValue || !strings.EqualFold(value, "false")
+		}
+	}
+	return hasCommand && jsonEnabled
 }
 
 func pluginBootstrapConfigPath(args []string, defaultPath string) string {

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/codexintegration"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
 
@@ -133,5 +134,49 @@ func TestModelCatalogUpdaterPlan(t *testing.T) {
 					tt.localModel, tt.homeEnabled, gotModels, gotCodex, tt.wantModels, tt.wantCodexClient)
 			}
 		})
+	}
+}
+
+func TestSelectCodexCommand(t *testing.T) {
+	action, selected, err := selectCodexCommand(false, false, true, false)
+	if err != nil || !selected || action != codexintegration.CommandDoctor {
+		t.Fatalf("selectCodexCommand() = %q, %t, %v", action, selected, err)
+	}
+	if _, _, err = selectCodexCommand(true, true, false, false); err == nil {
+		t.Fatal("selectCodexCommand() accepted multiple commands")
+	}
+	action, selected, err = selectCodexCommand(false, false, false, false)
+	if err != nil || selected || action != "" {
+		t.Fatalf("empty selectCodexCommand() = %q, %t, %v", action, selected, err)
+	}
+}
+
+func TestValidateCodexCommandFlags(t *testing.T) {
+	if err := validateCodexCommandFlags(true, true, codexintegration.CommandOptions{Action: codexintegration.CommandSetup}); err == nil {
+		t.Fatal("validateCodexCommandFlags() accepted another one-shot command")
+	}
+	if err := validateCodexCommandFlags(false, false, codexintegration.CommandOptions{JSON: true}); err == nil {
+		t.Fatal("validateCodexCommandFlags() accepted -json without a command")
+	}
+	if err := validateCodexCommandFlags(true, false, codexintegration.CommandOptions{Action: codexintegration.CommandSetup}); err != nil {
+		t.Fatalf("validateCodexCommandFlags() error = %v", err)
+	}
+}
+
+func TestIsCodexJSONInvocation(t *testing.T) {
+	tests := []struct {
+		args []string
+		want bool
+	}{
+		{args: []string{"-codex-doctor", "-json"}, want: true},
+		{args: []string{"--json=true", "--codex-setup=true"}, want: true},
+		{args: []string{"-codex-doctor", "-json=false"}, want: false},
+		{args: []string{"-json"}, want: false},
+		{args: []string{"-codex-doctor"}, want: false},
+	}
+	for _, test := range tests {
+		if got := isCodexJSONInvocation(test.args); got != test.want {
+			t.Fatalf("isCodexJSONInvocation(%v) = %t, want %t", test.args, got, test.want)
+		}
 	}
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -27,17 +27,6 @@ codex-integration:
       supports-tools: true
       supports-parallel-tools: true
       supports-web-search: true
-    - slug: "xai/grok-build-0.1"
-      provider: "xai"
-      upstream-model: "grok-build-0.1"
-      display-name: "Grok Build 0.1"
-      visible: true
-      featured: false
-      priority: 50
-      input-modalities: ["text", "image"]
-      supports-tools: true
-      supports-parallel-tools: true
-      supports-web-search: true
     - slug: "antigravity/gemini-3.6-flash"
       provider: "antigravity"
       upstream-model: "gemini-3.6-flash-high"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -251,15 +251,9 @@ codex:
   # Some superstitious users believe request tracking identifiers can be used
   # as evidence for TOS enforcement bans; this option only satisfies those odd concerns.
   identity-confuse: false
-  # TCP/TLS connection timeout. Default: 30 seconds.
-  connect-timeout-seconds: 30
-  # Maximum wait for upstream HTTP or WebSocket response headers. Default: 60 seconds.
-  response-header-timeout-seconds: 60
-  # Maximum wait for the first response body bytes or WebSocket event. Default: 120 seconds.
-  first-event-timeout-seconds: 120
-  # Maximum silence between response body reads or WebSocket events. Default: 900 seconds.
-  stream-idle-timeout-seconds: 900
-  # WebSocket ping cadence. Must be lower than stream-idle-timeout-seconds. Default: 30 seconds.
+  # WebSocket liveness deadline. Ping/pong traffic refreshes it. Default: 900 seconds.
+  websocket-idle-timeout-seconds: 900
+  # WebSocket ping cadence. Must be lower than websocket-idle-timeout-seconds. Default: 30 seconds.
   websocket-ping-interval-seconds: 30
 
 # When true, enable authentication for the WebSocket API (/v1/ws).

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,6 +5,73 @@ host: ""
 # Server port
 port: 8317
 
+# Optional Codex desktop/CLI integration. It remains disabled unless explicitly enabled.
+# Loopback access preserves Codex's built-in openai provider identity and is accepted only
+# when this server is bound to 127.0.0.1, ::1, or localhost.
+codex-integration:
+  enabled: false
+  codex-home: ""
+  loopback-access: true
+  auto-sync: true
+  catalog-file: "cliproxyapi-catalog.json"
+  multi-agent-mode: "v1"
+  models:
+    - slug: "xai/grok-4.5"
+      provider: "xai"
+      upstream-model: "grok-4.5"
+      display-name: "Grok 4.5"
+      visible: true
+      featured: true
+      priority: 2
+      input-modalities: ["text", "image"]
+      supports-tools: true
+      supports-parallel-tools: true
+      supports-web-search: true
+    - slug: "xai/grok-build-0.1"
+      provider: "xai"
+      upstream-model: "grok-build-0.1"
+      display-name: "Grok Build 0.1"
+      visible: true
+      featured: false
+      priority: 50
+      input-modalities: ["text", "image"]
+      supports-tools: true
+      supports-parallel-tools: true
+      supports-web-search: true
+    - slug: "antigravity/gemini-3.6-flash"
+      provider: "antigravity"
+      upstream-model: "gemini-3.6-flash"
+      display-name: "Gemini 3.6 Flash"
+      visible: true
+      featured: true
+      priority: 3
+      input-modalities: ["text", "image"]
+      supports-tools: true
+      supports-parallel-tools: true
+      supports-web-search: false
+    - slug: "antigravity/gemini-3.1-pro"
+      provider: "antigravity"
+      upstream-model: "gemini-pro-agent"
+      display-name: "Gemini 3.1 Pro"
+      visible: true
+      featured: true
+      priority: 4
+      input-modalities: ["text", "image"]
+      supports-tools: true
+      supports-parallel-tools: true
+      supports-web-search: false
+    - slug: "antigravity/claude-opus-4-6-thinking"
+      provider: "antigravity"
+      upstream-model: "claude-opus-4-6-thinking"
+      display-name: "Claude Opus 4.6 Thinking"
+      visible: true
+      featured: true
+      priority: 5
+      input-modalities: ["text", "image"]
+      supports-tools: true
+      supports-parallel-tools: true
+      supports-web-search: false
+
 # TLS settings for HTTPS. When enabled, the server listens with the provided certificate and key.
 tls:
   enable: false

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -40,7 +40,7 @@ codex-integration:
       supports-web-search: true
     - slug: "antigravity/gemini-3.6-flash"
       provider: "antigravity"
-      upstream-model: "gemini-3.6-flash"
+      upstream-model: "gemini-3.6-flash-high"
       display-name: "Gemini 3.6 Flash"
       visible: true
       featured: true

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -251,6 +251,16 @@ codex:
   # Some superstitious users believe request tracking identifiers can be used
   # as evidence for TOS enforcement bans; this option only satisfies those odd concerns.
   identity-confuse: false
+  # TCP/TLS connection timeout. Default: 30 seconds.
+  connect-timeout-seconds: 30
+  # Maximum wait for upstream HTTP or WebSocket response headers. Default: 60 seconds.
+  response-header-timeout-seconds: 60
+  # Maximum wait for the first response body bytes or WebSocket event. Default: 120 seconds.
+  first-event-timeout-seconds: 120
+  # Maximum silence between response body reads or WebSocket events. Default: 900 seconds.
+  stream-idle-timeout-seconds: 900
+  # WebSocket ping cadence. Must be lower than stream-idle-timeout-seconds. Default: 30 seconds.
+  websocket-ping-interval-seconds: 30
 
 # When true, enable authentication for the WebSocket API (/v1/ws).
 ws-auth: true

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -1,0 +1,164 @@
+# Codex desktop and CLI integration
+
+CLIProxyAPI can provide third-party subscription models to Codex desktop and the Codex CLI while preserving Codex's built-in `openai` provider identity. The integration uses the existing CLIProxyAPI process; it does not start a second proxy, a sidecar, or a credential watcher.
+
+```text
+Codex desktop / CLI
+        |
+        | loopback /v1
+        v
+CLIProxyAPI
+   |-- Codex OAuth -> official GPT models
+   |-- xAI OAuth -> Grok models
+   `-- AntiGravity OAuth -> Gemini and Claude models
+```
+
+The lifecycle commands manage one marked root block in Codex's `config.toml`, one complete model catalog, a restore journal, and catalog-cache invalidation. Setup, sync, and restore are previews unless `-apply` is present.
+
+## Model surface
+
+The first five entries are the featured multi-agent models, in this order:
+
+| Codex-visible slug | Upstream route | Featured | Tools | Image input | Hosted web search |
+| --- | --- | --- | --- | --- | --- |
+| `gpt-5.6-sol` | built-in `openai` provider | yes | yes | provider-defined | yes |
+| `xai/grok-4.5` | `xai` / `grok-4.5` | yes | yes | yes | yes |
+| `antigravity/gemini-3.6-flash` | `antigravity` / `gemini-3.6-flash` | yes | yes | yes | no |
+| `antigravity/gemini-3.1-pro` | `antigravity` / `gemini-pro-agent` | yes | yes | yes | no |
+| `antigravity/claude-opus-4-6-thinking` | `antigravity` / `claude-opus-4-6-thinking` | yes | yes | yes | no |
+| `xai/grok-build-0.1` | `xai` / `grok-build-0.1` | no | yes | yes | yes |
+
+Provider-qualified slugs are strict routes. For example, `antigravity/gemini-3.1-pro` fails closed when AntiGravity is unavailable; it is never sent to a same-named model on another provider. The stable slug remains visible in responses even though its upstream target is `gemini-pro-agent`.
+
+The catalog also retains the complete official GPT model surface. Official tasks and models continue to use Codex's built-in `openai` provider rather than a replacement provider name.
+
+## Prerequisites
+
+1. Use a strict loopback listener: `127.0.0.1`, `::1`, or `localhost`.
+2. Log in to every required provider with the same CLIProxyAPI config:
+
+   ```bash
+   ./cli-proxy-api -config config.yaml -codex-login
+   ./cli-proxy-api -config config.yaml -xai-login
+   ./cli-proxy-api -config config.yaml -antigravity-login
+   ```
+
+3. Enable the integration in `config.yaml`. The complete default mapping is in [`config.example.yaml`](../config.example.yaml).
+
+   ```yaml
+   host: "127.0.0.1"
+   port: 8317
+
+   codex-integration:
+     enabled: true
+     loopback-access: true
+     auto-sync: true
+     catalog-file: "cliproxyapi-catalog.json"
+     multi-agent-mode: "v1"
+   ```
+
+When `models` is omitted, the stable default mapping above is used. Keep an explicit `models` list when you want the deployed policy to be self-documenting.
+
+## Setup and migration
+
+Start CLIProxyAPI with the integration-enabled config, then preview setup:
+
+```bash
+./cli-proxy-api -config config.yaml -codex-setup -json
+```
+
+Apply only after reviewing the resolved `config_file` and `catalog_file`:
+
+```bash
+./cli-proxy-api -config config.yaml -codex-setup -apply -json
+```
+
+The command writes only inside the resolved Codex home. Resolution order is `-codex-home`, `codex-integration.codex-home`, `CODEX_HOME`, then the platform default. Use `-codex-home` for isolated rehearsal:
+
+```bash
+temporary_codex_home="$(mktemp -d)"
+./cli-proxy-api -config config.yaml -codex-setup -codex-home "$temporary_codex_home" -apply -json
+CODEX_HOME="$temporary_codex_home" codex debug models
+./cli-proxy-api -config config.yaml -codex-restore -codex-home "$temporary_codex_home" -apply -json
+```
+
+Setup refuses user-owned `openai_base_url` or `model_catalog_json` root keys. To migrate a recognized OpenCodex block, preview and then explicitly apply:
+
+```bash
+./cli-proxy-api -config config.yaml -codex-setup -codex-migrate-opencodex -json
+./cli-proxy-api -config config.yaml -codex-setup -codex-migrate-opencodex -apply -json
+```
+
+This migration recognizes only OpenCodex's known marker. It does not guess ownership of arbitrary configuration. Stop OpenCodex's config writer after the CLIProxyAPI block is applied, then restart Codex so its model cache is rebuilt.
+
+## Routine operations
+
+Preview and apply a catalog refresh:
+
+```bash
+./cli-proxy-api -config config.yaml -codex-sync -json
+./cli-proxy-api -config config.yaml -codex-sync -apply -json
+```
+
+`auto-sync: true` updates an already-installed catalog when the model registry or mapping revision changes. A compile failure or missing mapped model leaves the last-good catalog in place.
+
+Run read-only diagnostics:
+
+```bash
+./cli-proxy-api -config config.yaml -codex-doctor -json
+```
+
+Add explicit, low-output provider requests only during a maintenance window:
+
+```bash
+./cli-proxy-api -config config.yaml -codex-doctor -probe-models -json
+```
+
+Doctor exits with `0` for clean, `1` for warnings, and `2` for a blocking problem. It reports credential metadata and failure categories without printing tokens, email addresses, prompts, or upstream error bodies.
+
+## Failure guide
+
+| Doctor or runtime symptom | Meaning | Action |
+| --- | --- | --- |
+| `config.unmanaged` or ownership conflict | Codex root keys are owned by another configuration | Restore or explicitly migrate the known OpenCodex block; do not delete unrelated keys |
+| `catalog.source_unavailable` | A configured upstream model is absent for its required provider | Refresh that provider login or correct the fixed mapping; the last-good catalog remains active |
+| `catalog.stale` / `cache.restart_required` | Disk catalog or Codex cache predates the current mapping | Run sync with `-apply`, then restart Codex |
+| `oauth.<provider>_missing` | No safe credential metadata was found | Run the corresponding provider login and re-run doctor |
+| `endpoint.models_rejected` | Loopback data-plane authentication or binding is wrong | Confirm `host` is strict loopback, enable `loopback-access`, and restart CLIProxyAPI |
+| HTTP `401` | Provider credential expired or was rejected | Refresh that provider login; do not route the slug to another provider |
+| HTTP `429` | Subscription quota or concurrent connection limit | Wait for reset or reduce concurrency; preserve the provider-qualified route |
+| HTTP `5xx`, first-event timeout, or idle timeout | Upstream or network failure | Retry a read-only request after connectivity recovers; inspect request ID and provider health |
+| WebSocket upgrade unavailable | No request payload was accepted over WebSocket | CLIProxyAPI safely uses the HTTP Responses transport |
+| WebSocket disconnect after request write | Acceptance is ambiguous | CLIProxyAPI returns the error and does not automatically resend, preventing duplicate tool execution |
+| `opencodex.listener_detected` | The old proxy is still running | Finish the cutover checks, then stop its daemon and config watcher |
+
+## Restore
+
+Preview restore before changing the real Codex home:
+
+```bash
+./cli-proxy-api -config config.yaml -codex-restore -json
+./cli-proxy-api -config config.yaml -codex-restore -apply -json
+```
+
+Restore removes the CLIProxyAPI-owned marker block, restores a pre-existing catalog when one was backed up, and preserves user edits made outside the managed block. It moves integration state aside rather than silently overwriting it. Restart Codex after an applied restore.
+
+## OpenCodex retirement checklist
+
+1. Record the current config and catalog hashes, file modes, listener ports, service labels, and credential-file metadata. Never record credential contents.
+2. Complete setup and doctor in a temporary Codex home.
+3. Apply the explicit OpenCodex migration to the real Codex home.
+4. Stop OpenCodex's daemon and credential/config watcher; keep its installation and backups during the observation period.
+5. Restart Codex and verify the five featured models, Grok Build, official GPT history, tools, image input, compact, and a long-running task.
+6. After the observation gate passes, unload the old service permanently. Retain the CLIProxyAPI restore journal and backups for one release cycle.
+
+## Security and capability boundaries
+
+- Loopback bearer access applies only to data-plane model routes. It does not authenticate management routes and is rejected for non-loopback peers, forwarded-header spoofing, wildcard binds, and LAN access.
+- Setup rejects symlinks, uses an exclusive lifecycle lock, writes atomically, and creates new sensitive files with mode `0600`.
+- The first release exposes the explicit stable mappings above. It does not automatically publish every provider model.
+- AntiGravity models do not advertise Codex hosted `web_search`; local browser or MCP tools remain available to the Codex agent.
+- Official GPT image generation and image edit stay on the official Codex path. Third-party catalog entries advertise image input only where configured.
+- Remote Codex clients and OpenCodex sidecar search behavior are outside this integration.
+- Provider subscriptions and OAuth-backed CLI access are governed by each provider's terms and usage limits. Confirm that proxying a subscription into Codex is permitted for your account and organization.
+

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -23,7 +23,7 @@ The first five entries are the featured multi-agent models, in this order:
 | --- | --- | --- | --- | --- | --- |
 | `gpt-5.6-sol` | built-in `openai` provider | yes | yes | provider-defined | yes |
 | `xai/grok-4.5` | `xai` / `grok-4.5` | yes | yes | yes | yes |
-| `antigravity/gemini-3.6-flash` | `antigravity` / `gemini-3.6-flash` | yes | yes | yes | no |
+| `antigravity/gemini-3.6-flash` | `antigravity` / `gemini-3.6-flash-high` | yes | yes | yes | no |
 | `antigravity/gemini-3.1-pro` | `antigravity` / `gemini-pro-agent` | yes | yes | yes | no |
 | `antigravity/claude-opus-4-6-thinking` | `antigravity` / `claude-opus-4-6-thinking` | yes | yes | yes | no |
 | `xai/grok-build-0.1` | `xai` / `grok-build-0.1` | no | yes | yes | yes |
@@ -161,4 +161,3 @@ Restore removes the CLIProxyAPI-owned marker block, restores a pre-existing cata
 - Official GPT image generation and image edit stay on the official Codex path. Third-party catalog entries advertise image input only where configured.
 - Remote Codex clients and OpenCodex sidecar search behavior are outside this integration.
 - Provider subscriptions and OAuth-backed CLI access are governed by each provider's terms and usage limits. Confirm that proxying a subscription into Codex is permitted for your account and organization.
-

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -127,7 +127,8 @@ Doctor exits with `0` for clean, `1` for warnings, and `2` for a blocking proble
 | `endpoint.models_rejected` | Loopback data-plane authentication or binding is wrong | Confirm `host` is strict loopback, enable `loopback-access`, and restart CLIProxyAPI |
 | HTTP `401` | Provider credential expired or was rejected | Refresh that provider login; do not route the slug to another provider |
 | HTTP `429` | Subscription quota or concurrent connection limit | Wait for reset or reduce concurrency; preserve the provider-qualified route |
-| HTTP `5xx`, first-event timeout, or idle timeout | Upstream or network failure | Retry a read-only request after connectivity recovers; inspect request ID and provider health |
+| HTTP `5xx` or request-context cancellation | Upstream, network, or caller cancellation | Retry a read-only request after connectivity recovers; inspect request ID and provider health |
+| WebSocket liveness timeout | No model event and no successful ping/pong traffic within the configured deadline | Check provider connectivity and retry a read-only request |
 | WebSocket upgrade unavailable | No request payload was accepted over WebSocket | CLIProxyAPI safely uses the HTTP Responses transport |
 | WebSocket disconnect after request write | Acceptance is ambiguous | CLIProxyAPI returns the error and does not automatically resend, preventing duplicate tool execution |
 | `opencodex.listener_detected` | The old proxy is still running | Finish the cutover checks, then stop its daemon and config watcher |
@@ -158,6 +159,7 @@ Restore removes the CLIProxyAPI-owned marker block, restores a pre-existing cata
 - Setup rejects symlinks, uses an exclusive lifecycle lock, writes atomically, and creates new sensitive files with mode `0600`.
 - The first release exposes the explicit stable mappings above. It does not automatically publish every provider model.
 - AntiGravity models do not advertise Codex hosted `web_search`; local browser or MCP tools remain available to the Codex agent.
+- HTTP response streams have no proxy-owned first-event or idle deadline; the caller's request context controls cancellation. WebSocket liveness uses ping/pong-refreshed deadlines, which are an intentional exception for reusable connections.
 - Official GPT image generation and image edit stay on the official Codex path. Third-party catalog entries advertise image input only where configured.
 - Remote Codex clients and OpenCodex sidecar search behavior are outside this integration.
 - Provider subscriptions and OAuth-backed CLI access are governed by each provider's terms and usage limits. Confirm that proxying a subscription into Codex is permitted for your account and organization.

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -15,9 +15,11 @@ CLIProxyAPI
 
 The lifecycle commands manage one marked root block in Codex's `config.toml`, one complete model catalog, a restore journal, and catalog-cache invalidation. Setup, sync, and restore are previews unless `-apply` is present.
 
+Setup never rewrites Codex's `model_provider` key or provider tables. Existing provider identities can scope which tasks Codex displays, so preserving them is required for task-history continuity. The doctor reports a preserved non-`openai` provider as an informational check; operators must keep that provider pointed at the intended loopback endpoint.
+
 ## Model surface
 
-The first five entries are the featured multi-agent models, in this order:
+The example configuration places one official model and four third-party models at the front of the multi-agent model surface:
 
 | Codex-visible slug | Upstream route | Featured | Tools | Image input | Hosted web search |
 | --- | --- | --- | --- | --- | --- |
@@ -26,9 +28,10 @@ The first five entries are the featured multi-agent models, in this order:
 | `antigravity/gemini-3.6-flash` | `antigravity` / `gemini-3.6-flash-high` | yes | yes | yes | no |
 | `antigravity/gemini-3.1-pro` | `antigravity` / `gemini-pro-agent` | yes | yes | yes | no |
 | `antigravity/claude-opus-4-6-thinking` | `antigravity` / `claude-opus-4-6-thinking` | yes | yes | yes | no |
-| `xai/grok-build-0.1` | `xai` / `grok-build-0.1` | no | yes | yes | yes |
 
 Provider-qualified slugs are strict routes. For example, `antigravity/gemini-3.1-pro` fails closed when AntiGravity is unavailable; it is never sent to a same-named model on another provider. The stable slug remains visible in responses even though its upstream target is `gemini-pro-agent`.
+
+Configured model mappings may use any native non-Codex provider supported by CLIProxyAPI: `aistudio`, `antigravity`, `claude`, `gemini`, `kimi`, `vertex`, or `xai`. The example keeps four verified third-party models featured; additional models such as Kimi can be added without changing the integration code.
 
 The catalog also retains the complete official GPT model surface. Official tasks and models continue to use Codex's built-in `openai` provider rather than a replacement provider name.
 
@@ -150,7 +153,7 @@ Restore removes the CLIProxyAPI-owned marker block, restores a pre-existing cata
 2. Complete setup and doctor in a temporary Codex home.
 3. Apply the explicit OpenCodex migration to the real Codex home.
 4. Stop OpenCodex's daemon and credential/config watcher; keep its installation and backups during the observation period.
-5. Restart Codex and verify the five featured models, Grok Build, official GPT history, tools, image input, compact, and a long-running task.
+5. Restart Codex and verify the configured featured models, official GPT history, tools, image input, compact, and a long-running task.
 6. After the observation gate passes, unload the old service permanently. Retain the CLIProxyAPI restore journal and backups for one release cycle.
 
 ## Security and capability boundaries

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.2
 	github.com/pierrec/xxHash v0.1.5
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/internal/access/codex_loopback/provider.go
+++ b/internal/access/codex_loopback/provider.go
@@ -1,0 +1,90 @@
+// Package codexloopback provides the opt-in loopback trust boundary used by Codex Integration.
+package codexloopback
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+const (
+	DefaultProviderName = "codex-loopback"
+	LoopbackPrincipal   = "codex-loopback-client"
+)
+
+// Register follows the enabled state of the Codex Integration loopback mode.
+func Register(cfg *sdkconfig.SDKConfig) {
+	if cfg == nil || !cfg.CodexIntegration.Enabled || !cfg.CodexIntegration.LoopbackAccess {
+		sdkaccess.UnregisterProvider(sdkaccess.AccessProviderTypeCodexLoopback)
+		return
+	}
+	sdkaccess.RegisterProvider(sdkaccess.AccessProviderTypeCodexLoopback, NewProvider())
+}
+
+// NewProvider returns a stateless loopback authentication provider.
+func NewProvider() sdkaccess.Provider {
+	return &provider{}
+}
+
+type provider struct{}
+
+func (p *provider) Identifier() string { return DefaultProviderName }
+
+func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.Result, *sdkaccess.AuthError) {
+	if p == nil || r == nil || !remoteAddrIsLoopback(r.RemoteAddr) {
+		return nil, sdkaccess.NewNotHandledError()
+	}
+
+	authorization := strings.TrimSpace(r.Header.Get("Authorization"))
+	if authorization == "" {
+		return nil, sdkaccess.NewNoCredentialsError()
+	}
+	parts := strings.Fields(authorization)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") || strings.TrimSpace(parts[1]) == "" {
+		return nil, sdkaccess.NewInvalidCredentialError()
+	}
+
+	return &sdkaccess.Result{
+		Provider:  DefaultProviderName,
+		Principal: LoopbackPrincipal,
+		Metadata: map[string]string{
+			"source": "loopback-bearer",
+		},
+	}, nil
+}
+
+// ValidateListenerAddr proves that the actual bound listener is loopback-only.
+func ValidateListenerAddr(addr net.Addr) error {
+	if addr == nil {
+		return fmt.Errorf("Codex loopback access: listener address is unavailable")
+	}
+	if tcpAddr, ok := addr.(*net.TCPAddr); ok {
+		if tcpAddr.IP != nil && tcpAddr.IP.IsLoopback() {
+			return nil
+		}
+		return fmt.Errorf("Codex loopback access: listener %q is not loopback-only", addr.String())
+	}
+	host, _, err := net.SplitHostPort(strings.TrimSpace(addr.String()))
+	if err != nil {
+		return fmt.Errorf("Codex loopback access: parse listener %q: %w", addr.String(), err)
+	}
+	ip := net.ParseIP(strings.Trim(host, "[]"))
+	if ip == nil || !ip.IsLoopback() {
+		return fmt.Errorf("Codex loopback access: listener %q is not loopback-only", addr.String())
+	}
+	return nil
+}
+
+func remoteAddrIsLoopback(remoteAddr string) bool {
+	host, _, err := net.SplitHostPort(strings.TrimSpace(remoteAddr))
+	if err != nil {
+		return false
+	}
+	ip := net.ParseIP(strings.Trim(host, "[]"))
+	return ip != nil && ip.IsLoopback()
+}

--- a/internal/access/codex_loopback/provider_test.go
+++ b/internal/access/codex_loopback/provider_test.go
@@ -1,0 +1,78 @@
+package codexloopback
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+)
+
+func TestProviderAuthenticatesBearerOnlyFromSocketLoopback(t *testing.T) {
+	provider := NewProvider()
+	tests := []struct {
+		name       string
+		remoteAddr string
+		auth       string
+		xff        string
+		wantOK     bool
+		wantCode   sdkaccess.AuthErrorCode
+	}{
+		{name: "IPv4 loopback", remoteAddr: "127.0.0.1:50000", auth: "Bearer chatgpt-token", wantOK: true},
+		{name: "IPv6 loopback", remoteAddr: "[::1]:50000", auth: "Bearer chatgpt-token", wantOK: true},
+		{name: "mapped IPv4 loopback", remoteAddr: "[::ffff:127.0.0.1]:50000", auth: "Bearer chatgpt-token", wantOK: true},
+		{name: "LAN denied despite spoofed XFF", remoteAddr: "192.168.1.20:50000", auth: "Bearer chatgpt-token", xff: "127.0.0.1", wantCode: sdkaccess.AuthErrorCodeNotHandled},
+		{name: "loopback without bearer", remoteAddr: "127.0.0.1:50000", wantCode: sdkaccess.AuthErrorCodeNoCredentials},
+		{name: "loopback basic auth denied", remoteAddr: "127.0.0.1:50000", auth: "Basic abc", wantCode: sdkaccess.AuthErrorCodeInvalidCredential},
+		{name: "malformed remote denied", remoteAddr: "localhost", auth: "Bearer chatgpt-token", wantCode: sdkaccess.AuthErrorCodeNotHandled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.RemoteAddr = tt.remoteAddr
+			req.Header.Set("Authorization", tt.auth)
+			req.Header.Set("X-Forwarded-For", tt.xff)
+			result, authErr := provider.Authenticate(context.Background(), req)
+			if tt.wantOK {
+				if authErr != nil || result == nil {
+					t.Fatalf("Authenticate() = %#v, %v", result, authErr)
+				}
+				if result.Principal != LoopbackPrincipal || result.Principal == "chatgpt-token" {
+					t.Fatalf("Principal = %q, want redacted fixed principal", result.Principal)
+				}
+				return
+			}
+			if authErr == nil || authErr.Code != tt.wantCode {
+				t.Fatalf("Authenticate() error = %#v, want code %q", authErr, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestValidateListenerAddr(t *testing.T) {
+	for _, address := range []string{"127.0.0.1:8317", "[::1]:8317", "[::ffff:127.0.0.1]:8317"} {
+		if err := ValidateListenerAddr(testAddr(address)); err != nil {
+			t.Fatalf("ValidateListenerAddr(%q) error = %v", address, err)
+		}
+	}
+	for _, address := range []string{"0.0.0.0:8317", "[::]:8317", "192.168.1.20:8317", "bad"} {
+		if err := ValidateListenerAddr(testAddr(address)); err == nil {
+			t.Fatalf("ValidateListenerAddr(%q) error = nil", address)
+		}
+	}
+	if err := ValidateListenerAddr(nil); err == nil {
+		t.Fatal("ValidateListenerAddr(nil) error = nil")
+	}
+}
+
+type testAddr string
+
+func (a testAddr) Network() string { return "tcp" }
+func (a testAddr) String() string  { return string(a) }
+
+var _ net.Addr = testAddr("")

--- a/internal/access/codex_loopback/reconcile_test.go
+++ b/internal/access/codex_loopback/reconcile_test.go
@@ -1,0 +1,38 @@
+package codexloopback
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+)
+
+func TestRegisterFollowsCodexIntegrationState(t *testing.T) {
+	t.Cleanup(func() { sdkaccess.UnregisterProvider(sdkaccess.AccessProviderTypeCodexLoopback) })
+	cfg := config.DefaultCodexIntegrationConfig()
+	Register(&config.SDKConfig{CodexIntegration: cfg})
+	if hasRegisteredLoopbackProvider() {
+		t.Fatal("disabled integration registered loopback provider")
+	}
+
+	cfg.Enabled = true
+	Register(&config.SDKConfig{CodexIntegration: cfg})
+	if !hasRegisteredLoopbackProvider() {
+		t.Fatal("enabled integration did not register loopback provider")
+	}
+
+	cfg.LoopbackAccess = false
+	Register(&config.SDKConfig{CodexIntegration: cfg})
+	if hasRegisteredLoopbackProvider() {
+		t.Fatal("disabled loopback access left provider registered")
+	}
+}
+
+func hasRegisteredLoopbackProvider() bool {
+	for _, provider := range sdkaccess.RegisteredProviders() {
+		if provider.Identifier() == DefaultProviderName {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/access/reconcile.go
+++ b/internal/access/reconcile.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	codexloopback "github.com/router-for-me/CLIProxyAPI/v7/internal/access/codex_loopback"
 	configaccess "github.com/router-for-me/CLIProxyAPI/v7/internal/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
@@ -86,6 +87,7 @@ func ApplyAccessProviders(manager *sdkaccess.Manager, oldCfg, newCfg *config.Con
 
 	existing := manager.Providers()
 	configaccess.Register(&newCfg.SDKConfig)
+	codexloopback.Register(&newCfg.SDKConfig)
 	providers, added, updated, removed, err := ReconcileProviders(oldCfg, newCfg, existing)
 	if err != nil {
 		log.Errorf("failed to reconcile request auth providers: %v", err)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/access"
+	codexloopback "github.com/router-for-me/CLIProxyAPI/v7/internal/access/codex_loopback"
 	managementHandlers "github.com/router-for-me/CLIProxyAPI/v7/internal/api/handlers/management"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/api/middleware"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
@@ -1712,6 +1713,14 @@ func (s *Server) Start() error {
 	listener, errListen := net.Listen("tcp", addr)
 	if errListen != nil {
 		return fmt.Errorf("failed to start HTTP server: %v", errListen)
+	}
+	if s.cfg != nil && s.cfg.CodexIntegration.Enabled && s.cfg.CodexIntegration.LoopbackAccess {
+		if errLoopback := codexloopback.ValidateListenerAddr(listener.Addr()); errLoopback != nil {
+			if errClose := listener.Close(); errClose != nil {
+				log.Errorf("failed to close listener after Codex loopback validation failure: %v", errClose)
+			}
+			return errLoopback
+		}
 	}
 
 	useTLS := s.cfg != nil && s.cfg.TLS.Enable

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	gin "github.com/gin-gonic/gin"
+	codexloopback "github.com/router-for-me/CLIProxyAPI/v7/internal/access/codex_loopback"
 	managementHandlers "github.com/router-for-me/CLIProxyAPI/v7/internal/api/handlers/management"
 	proxyconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
@@ -177,6 +178,30 @@ func TestHealthz(t *testing.T) {
 			t.Fatalf("expected empty body for HEAD request, got %q", rr.Body.String())
 		}
 	})
+}
+
+func TestCodexLoopbackProviderAppliesOnlyToDataPlane(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "management-secret")
+	server := newTestServer(t)
+	server.accessManager.SetProviders([]sdkaccess.Provider{codexloopback.NewProvider()})
+
+	dataReq := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	dataReq.RemoteAddr = "127.0.0.1:50000"
+	dataReq.Header.Set("Authorization", "Bearer chatgpt-token")
+	dataRR := httptest.NewRecorder()
+	server.engine.ServeHTTP(dataRR, dataReq)
+	if dataRR.Code != http.StatusOK {
+		t.Fatalf("data plane status = %d, want 200; body=%s", dataRR.Code, dataRR.Body.String())
+	}
+
+	managementReq := httptest.NewRequest(http.MethodGet, "/v0/management/config", nil)
+	managementReq.RemoteAddr = "127.0.0.1:50000"
+	managementReq.Header.Set("Authorization", "Bearer chatgpt-token")
+	managementRR := httptest.NewRecorder()
+	server.engine.ServeHTTP(managementRR, managementReq)
+	if managementRR.Code == http.StatusOK {
+		t.Fatalf("Codex loopback bearer authenticated management endpoint: %s", managementRR.Body.String())
+	}
 }
 
 func TestCodexAlphaSearchForwardsRequest(t *testing.T) {

--- a/internal/codexintegration/catalog.go
+++ b/internal/codexintegration/catalog.go
@@ -81,8 +81,9 @@ func CompileCatalog(models []map[string]any, providersForModel ModelProvidersFun
 		return finalizeCatalog(ordered, sourceRevision, integration)
 	}
 
-	if !catalogContainsSlug(official, "gpt-5.6-sol") {
-		return Catalog{}, fmt.Errorf("official Codex model %q is unavailable", "gpt-5.6-sol")
+	officialFeatured := selectOfficialFeaturedModel(official)
+	if officialFeatured == "" {
+		return Catalog{}, fmt.Errorf("official Codex catalog has no visible model")
 	}
 
 	overlays := make([]map[string]any, 0, len(integration.Models))
@@ -97,24 +98,9 @@ func CompileCatalog(models []map[string]any, providersForModel ModelProvidersFun
 		overlays = append(overlays, compileOverlayCatalogEntry(mapping, model, defaultTemplate))
 	}
 
-	featured := []string{"gpt-5.6-sol"}
-	featuredModels := make([]config.CodexIntegrationModel, 0, len(integration.Models))
-	for _, mapping := range integration.Models {
-		if mapping.Visible && mapping.Featured {
-			featuredModels = append(featuredModels, mapping)
-		}
-	}
-	sort.SliceStable(featuredModels, func(i, j int) bool {
-		if featuredModels[i].Priority == featuredModels[j].Priority {
-			return featuredModels[i].Slug < featuredModels[j].Slug
-		}
-		return featuredModels[i].Priority < featuredModels[j].Priority
-	})
-	for _, mapping := range featuredModels {
+	featured := []string{officialFeatured}
+	for _, mapping := range featuredCodexIntegrationModels(integration) {
 		featured = append(featured, mapping.Slug)
-	}
-	if len(featured) != 5 {
-		return Catalog{}, fmt.Errorf("Codex Integration featured surface has %d models, want 5", len(featured))
 	}
 
 	entries := append(official, overlays...)
@@ -127,6 +113,35 @@ func CompileCatalog(models []map[string]any, providersForModel ModelProvidersFun
 		return Catalog{}, err
 	}
 	return catalog, nil
+}
+
+func selectOfficialFeaturedModel(models []map[string]any) string {
+	candidates := make([]map[string]any, 0, len(models))
+	for _, model := range models {
+		if catalogString(model, "visibility") == "hide" {
+			continue
+		}
+		if catalogString(model, "slug") != "" {
+			candidates = append(candidates, model)
+		}
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		leftPriority, rightPriority := catalogInt(candidates[i], "priority"), catalogInt(candidates[j], "priority")
+		if leftPriority == rightPriority {
+			return catalogString(candidates[i], "slug") < catalogString(candidates[j], "slug")
+		}
+		if leftPriority <= 0 {
+			return false
+		}
+		if rightPriority <= 0 {
+			return true
+		}
+		return leftPriority < rightPriority
+	})
+	if len(candidates) == 0 {
+		return ""
+	}
+	return catalogString(candidates[0], "slug")
 }
 
 func parseCatalogTemplates(raw []byte) (map[string]map[string]any, map[string]any, error) {
@@ -372,15 +387,6 @@ func containsProvider(providers []string, target string) bool {
 
 func onlyProvider(providers []string, target string) bool {
 	return len(providers) > 0 && containsProvider(providers, target) && len(providers) == 1
-}
-
-func catalogContainsSlug(models []map[string]any, slug string) bool {
-	for _, model := range models {
-		if catalogString(model, "slug") == slug {
-			return true
-		}
-	}
-	return false
 }
 
 func applyCatalogVisibility(entry map[string]any, id string) {

--- a/internal/codexintegration/catalog.go
+++ b/internal/codexintegration/catalog.go
@@ -1,0 +1,437 @@
+package codexintegration
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+const defaultCatalogTemplate = "gpt-5.5"
+
+// ModelProvidersFunc returns the registered providers for a model ID.
+type ModelProvidersFunc func(string) []string
+
+// Catalog is a complete Codex model catalog plus deterministic diagnostic revisions.
+// Marshal intentionally writes only the client-compatible models payload; revisions
+// are persisted in the integration journal rather than sent to Codex.
+type Catalog struct {
+	Models          []map[string]any
+	Revision        string
+	SourceRevision  uint64
+	MappingRevision string
+}
+
+type catalogPayload struct {
+	Models []map[string]any `json:"models"`
+}
+
+// Marshal returns deterministic, client-compatible catalog JSON.
+func (c Catalog) Marshal() ([]byte, error) {
+	data, err := json.MarshalIndent(catalogPayload{Models: c.Models}, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal Codex catalog: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+// CompileCatalog builds a complete official catalog with stable third-party overlays.
+func CompileCatalog(models []map[string]any, providersForModel ModelProvidersFunc, integration config.CodexIntegrationConfig) (Catalog, error) {
+	rawTemplates, sourceRevision := registry.GetCodexClientModelsSnapshot()
+	templates, defaultTemplate, err := parseCatalogTemplates(rawTemplates)
+	if err != nil {
+		return Catalog{}, err
+	}
+
+	available := make(map[string]map[string]any, len(models))
+	for _, model := range models {
+		id := catalogString(model, "id")
+		if id == "" {
+			continue
+		}
+		available[id] = cloneCatalogMap(model)
+	}
+
+	official := make([]map[string]any, 0, len(models))
+	availableIDs := make([]string, 0, len(available))
+	for id := range available {
+		availableIDs = append(availableIDs, id)
+	}
+	sort.Strings(availableIDs)
+	for _, id := range availableIDs {
+		providers := normalizedProviders(providersForModel, id)
+		if !containsProvider(providers, "codex") {
+			continue
+		}
+		entry := compileOfficialCatalogEntry(id, available[id], templates, defaultTemplate)
+		if !onlyProvider(providers, "codex") {
+			entry["supports_search_tool"] = false
+			delete(entry, "web_search_tool_type")
+		}
+		official = append(official, entry)
+	}
+
+	if !integration.Enabled {
+		ordered := orderCatalogEntries(official, nil)
+		return finalizeCatalog(ordered, sourceRevision, integration)
+	}
+
+	if !catalogContainsSlug(official, "gpt-5.6-sol") {
+		return Catalog{}, fmt.Errorf("official Codex model %q is unavailable", "gpt-5.6-sol")
+	}
+
+	overlays := make([]map[string]any, 0, len(integration.Models))
+	for _, mapping := range integration.Models {
+		if !mapping.Visible {
+			continue
+		}
+		model, ok := available[mapping.UpstreamModel]
+		if !ok || !containsProvider(normalizedProviders(providersForModel, mapping.UpstreamModel), mapping.Provider) {
+			return Catalog{}, fmt.Errorf("Codex Integration model %q target %s/%s is unavailable", mapping.Slug, mapping.Provider, mapping.UpstreamModel)
+		}
+		overlays = append(overlays, compileOverlayCatalogEntry(mapping, model, defaultTemplate))
+	}
+
+	featured := []string{"gpt-5.6-sol"}
+	featuredModels := make([]config.CodexIntegrationModel, 0, len(integration.Models))
+	for _, mapping := range integration.Models {
+		if mapping.Visible && mapping.Featured {
+			featuredModels = append(featuredModels, mapping)
+		}
+	}
+	sort.SliceStable(featuredModels, func(i, j int) bool {
+		if featuredModels[i].Priority == featuredModels[j].Priority {
+			return featuredModels[i].Slug < featuredModels[j].Slug
+		}
+		return featuredModels[i].Priority < featuredModels[j].Priority
+	})
+	for _, mapping := range featuredModels {
+		featured = append(featured, mapping.Slug)
+	}
+	if len(featured) != 5 {
+		return Catalog{}, fmt.Errorf("Codex Integration featured surface has %d models, want 5", len(featured))
+	}
+
+	entries := append(official, overlays...)
+	ordered := orderCatalogEntries(entries, featured)
+	catalog, err := finalizeCatalog(ordered, sourceRevision, integration)
+	if err != nil {
+		return Catalog{}, err
+	}
+	if err = ValidateCatalog(catalog, integration); err != nil {
+		return Catalog{}, err
+	}
+	return catalog, nil
+}
+
+func parseCatalogTemplates(raw []byte) (map[string]map[string]any, map[string]any, error) {
+	var payload catalogPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, nil, fmt.Errorf("decode Codex catalog templates: %w", err)
+	}
+	templates := make(map[string]map[string]any, len(payload.Models))
+	for _, model := range payload.Models {
+		slug := catalogString(model, "slug")
+		if slug != "" {
+			templates[slug] = cloneCatalogMap(model)
+		}
+	}
+	defaultTemplate := templates[defaultCatalogTemplate]
+	if defaultTemplate == nil {
+		return nil, nil, fmt.Errorf("Codex catalog templates missing %q", defaultCatalogTemplate)
+	}
+	return templates, cloneCatalogMap(defaultTemplate), nil
+}
+
+func compileOfficialCatalogEntry(id string, model map[string]any, templates map[string]map[string]any, defaultTemplate map[string]any) map[string]any {
+	entry := cloneCatalogMap(templates[id])
+	if entry == nil {
+		entry = cloneCatalogMap(defaultTemplate)
+		entry["slug"] = id
+		entry["display_name"] = id
+		entry["description"] = id
+		entry["prefer_websockets"] = false
+		entry["service_tiers"] = []any{}
+		delete(entry, "apply_patch_tool_type")
+		delete(entry, "upgrade")
+		delete(entry, "availability_nux")
+	}
+	if displayName := catalogString(model, "display_name"); displayName != "" {
+		entry["display_name"] = displayName
+	}
+	applyCatalogModelMetadata(entry, id, "codex", model)
+	applyCatalogVisibility(entry, id)
+	if catalogString(entry, "visibility") == "list" {
+		entry["multi_agent_version"] = config.DefaultCodexMultiAgentMode
+	}
+	return entry
+}
+
+func compileOverlayCatalogEntry(mapping config.CodexIntegrationModel, model map[string]any, defaultTemplate map[string]any) map[string]any {
+	entry := cloneCatalogMap(defaultTemplate)
+	entry["slug"] = mapping.Slug
+	entry["display_name"] = mapping.DisplayName
+	if catalogString(entry, "display_name") == "" {
+		entry["display_name"] = mapping.Slug
+	}
+	entry["description"] = fmt.Sprintf("%s via %s", entry["display_name"], mapping.Provider)
+	entry["visibility"] = "list"
+	entry["priority"] = mapping.Priority
+	entry["prefer_websockets"] = false
+	entry["multi_agent_version"] = config.DefaultCodexMultiAgentMode
+	entry["supports_parallel_tool_calls"] = mapping.SupportsParallelTools
+	entry["supports_search_tool"] = mapping.SupportsWebSearch
+	entry["service_tiers"] = []any{}
+	delete(entry, "additional_speed_tiers")
+	delete(entry, "apply_patch_tool_type")
+	delete(entry, "availability_nux")
+	delete(entry, "default_service_tier")
+	delete(entry, "upgrade")
+	if !mapping.SupportsWebSearch {
+		delete(entry, "web_search_tool_type")
+	}
+	applyCatalogInputModalities(entry, mapping.InputModalities)
+	applyCatalogModelMetadata(entry, mapping.UpstreamModel, mapping.Provider, model)
+	return entry
+}
+
+func applyCatalogModelMetadata(entry map[string]any, modelID, provider string, model map[string]any) {
+	contextWindow := catalogInt(model, "context_length")
+	if info := registry.LookupModelInfo(modelID, provider); info != nil {
+		if contextWindow <= 0 {
+			contextWindow = info.ContextLength
+		}
+		if info.Thinking != nil {
+			applyCatalogThinking(entry, info.Thinking.Levels)
+		}
+	}
+	if contextWindow > 0 {
+		entry["context_window"] = contextWindow
+		entry["max_context_window"] = contextWindow
+	}
+}
+
+func applyCatalogInputModalities(entry map[string]any, modalities []string) {
+	values := make([]any, 0, 2)
+	seen := make(map[string]struct{}, 2)
+	hasImage := false
+	for _, raw := range modalities {
+		value := strings.ToLower(strings.TrimSpace(raw))
+		if value != "text" && value != "image" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+		hasImage = hasImage || value == "image"
+	}
+	if len(values) > 0 {
+		entry["input_modalities"] = values
+	}
+	if hasImage {
+		entry["supports_image_detail_original"] = true
+	} else {
+		delete(entry, "supports_image_detail_original")
+	}
+}
+
+func applyCatalogThinking(entry map[string]any, rawLevels []string) {
+	levels := make([]any, 0, len(rawLevels))
+	seen := make(map[string]struct{}, len(rawLevels))
+	for _, raw := range rawLevels {
+		level := strings.ToLower(strings.TrimSpace(raw))
+		switch level {
+		case "none", "low", "medium", "high", "xhigh", "max", "ultra":
+		default:
+			continue
+		}
+		if _, ok := seen[level]; ok {
+			continue
+		}
+		seen[level] = struct{}{}
+		levels = append(levels, map[string]any{"effort": level, "description": catalogReasoningDescription(level)})
+	}
+	if len(levels) == 0 {
+		return
+	}
+	defaultLevel := catalogString(levels[0].(map[string]any), "effort")
+	if _, ok := seen["medium"]; ok {
+		defaultLevel = "medium"
+	} else if defaultLevel == "none" && len(levels) > 1 {
+		defaultLevel = catalogString(levels[1].(map[string]any), "effort")
+	}
+	entry["supported_reasoning_levels"] = levels
+	entry["default_reasoning_level"] = defaultLevel
+}
+
+func catalogReasoningDescription(level string) string {
+	switch level {
+	case "none":
+		return "No reasoning"
+	case "low":
+		return "Fast responses with lighter reasoning"
+	case "medium":
+		return "Balances speed and reasoning depth for everyday tasks"
+	case "high":
+		return "Greater reasoning depth for complex problems"
+	case "xhigh":
+		return "Extra high reasoning depth for complex problems"
+	case "max", "ultra":
+		return "Maximum available reasoning depth for complex problems"
+	default:
+		return level
+	}
+}
+
+func orderCatalogEntries(entries []map[string]any, featured []string) []map[string]any {
+	bySlug := make(map[string]map[string]any, len(entries))
+	for _, entry := range entries {
+		slug := catalogString(entry, "slug")
+		if slug != "" {
+			bySlug[slug] = entry
+		}
+	}
+	ordered := make([]map[string]any, 0, len(bySlug))
+	for i, slug := range featured {
+		if entry := bySlug[slug]; entry != nil {
+			entry["priority"] = i + 1
+			ordered = append(ordered, entry)
+			delete(bySlug, slug)
+		}
+	}
+	rest := make([]map[string]any, 0, len(bySlug))
+	for _, entry := range bySlug {
+		rest = append(rest, entry)
+	}
+	sort.SliceStable(rest, func(i, j int) bool {
+		leftPriority, rightPriority := catalogInt(rest[i], "priority"), catalogInt(rest[j], "priority")
+		if leftPriority == rightPriority {
+			return catalogString(rest[i], "slug") < catalogString(rest[j], "slug")
+		}
+		return leftPriority < rightPriority
+	})
+	for i, entry := range rest {
+		entry["priority"] = 100 + i
+		ordered = append(ordered, entry)
+	}
+	return ordered
+}
+
+func finalizeCatalog(models []map[string]any, sourceRevision uint64, integration config.CodexIntegrationConfig) (Catalog, error) {
+	mappingJSON, err := json.Marshal(integration.Models)
+	if err != nil {
+		return Catalog{}, fmt.Errorf("marshal Codex model mappings: %w", err)
+	}
+	mappingHash := sha256.Sum256(mappingJSON)
+	modelsJSON, err := json.Marshal(models)
+	if err != nil {
+		return Catalog{}, fmt.Errorf("marshal compiled Codex models: %w", err)
+	}
+	revisionInput := append([]byte(fmt.Sprintf("%d:", sourceRevision)), mappingHash[:]...)
+	revisionInput = append(revisionInput, modelsJSON...)
+	revisionHash := sha256.Sum256(revisionInput)
+	return Catalog{
+		Models:          models,
+		Revision:        hex.EncodeToString(revisionHash[:]),
+		SourceRevision:  sourceRevision,
+		MappingRevision: hex.EncodeToString(mappingHash[:]),
+	}, nil
+}
+
+func normalizedProviders(providersForModel ModelProvidersFunc, model string) []string {
+	if providersForModel == nil {
+		return nil
+	}
+	raw := providersForModel(model)
+	providers := make([]string, 0, len(raw))
+	for _, provider := range raw {
+		provider = strings.ToLower(strings.TrimSpace(provider))
+		if provider != "" {
+			providers = append(providers, provider)
+		}
+	}
+	sort.Strings(providers)
+	return providers
+}
+
+func containsProvider(providers []string, target string) bool {
+	for _, provider := range providers {
+		if provider == target {
+			return true
+		}
+	}
+	return false
+}
+
+func onlyProvider(providers []string, target string) bool {
+	return len(providers) > 0 && containsProvider(providers, target) && len(providers) == 1
+}
+
+func catalogContainsSlug(models []map[string]any, slug string) bool {
+	for _, model := range models {
+		if catalogString(model, "slug") == slug {
+			return true
+		}
+	}
+	return false
+}
+
+func applyCatalogVisibility(entry map[string]any, id string) {
+	switch strings.TrimSpace(id) {
+	case "grok-imagine-image-quality", "gpt-image-1.5", "gpt-image-2", "grok-imagine-image", "grok-imagine-video", "grok-imagine-video-1.5-preview":
+		entry["visibility"] = "hide"
+	}
+}
+
+func catalogString(model map[string]any, key string) string {
+	value, _ := model[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func catalogInt(model map[string]any, key string) int {
+	switch value := model[key].(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	default:
+		return 0
+	}
+}
+
+func cloneCatalogMap(model map[string]any) map[string]any {
+	if model == nil {
+		return nil
+	}
+	clone := make(map[string]any, len(model))
+	for key, value := range model {
+		clone[key] = cloneCatalogValue(value)
+	}
+	return clone
+}
+
+func cloneCatalogValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneCatalogMap(typed)
+	case []any:
+		clone := make([]any, len(typed))
+		for i, entry := range typed {
+			clone[i] = cloneCatalogValue(entry)
+		}
+		return clone
+	case []string:
+		return append([]string(nil), typed...)
+	default:
+		return value
+	}
+}

--- a/internal/codexintegration/catalog_test.go
+++ b/internal/codexintegration/catalog_test.go
@@ -1,0 +1,145 @@
+package codexintegration
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestCompileCatalogBuildsFeaturedStableSurface(t *testing.T) {
+	integration := config.DefaultCodexIntegrationConfig()
+	integration.Enabled = true
+	models, providers := catalogTestModels()
+
+	catalog, err := CompileCatalog(models, providers, integration)
+	if err != nil {
+		t.Fatalf("CompileCatalog() error = %v", err)
+	}
+
+	wantFeatured := []string{
+		"gpt-5.6-sol",
+		"xai/grok-4.5",
+		"antigravity/gemini-3.6-flash",
+		"antigravity/gemini-3.1-pro",
+		"antigravity/claude-opus-4-6-thinking",
+	}
+	if len(catalog.Models) < len(wantFeatured) {
+		t.Fatalf("len(Models) = %d, want at least %d", len(catalog.Models), len(wantFeatured))
+	}
+	for i, want := range wantFeatured {
+		if got := catalogString(catalog.Models[i], "slug"); got != want {
+			t.Fatalf("Models[%d].slug = %q, want %q", i, got, want)
+		}
+		if got := catalogInt(catalog.Models[i], "priority"); got != i+1 {
+			t.Fatalf("Models[%d].priority = %d, want %d", i, got, i+1)
+		}
+	}
+
+	bySlug := catalogBySlug(catalog.Models)
+	for _, slug := range []string{"gpt-5.5", "gpt-5.4", "xai/grok-build-0.1"} {
+		if bySlug[slug] == nil {
+			t.Fatalf("catalog missing %q", slug)
+		}
+	}
+	if got, _ := bySlug["antigravity/gemini-3.1-pro"]["supports_search_tool"].(bool); got {
+		t.Fatal("AntiGravity Gemini advertises hosted search")
+	}
+	if _, exists := bySlug["gemini-pro-agent"]; exists {
+		t.Fatal("catalog exposed unqualified AntiGravity upstream model")
+	}
+	for _, model := range catalog.Models {
+		if catalogString(model, "visibility") == "list" && catalogString(model, "multi_agent_version") != "v1" {
+			t.Fatalf("model %q multi_agent_version = %#v, want v1", catalogString(model, "slug"), model["multi_agent_version"])
+		}
+	}
+	if catalog.Revision == "" || catalog.SourceRevision == 0 || catalog.MappingRevision == "" {
+		t.Fatalf("catalog revisions incomplete: %#v", catalog)
+	}
+	if err := ValidateCatalog(catalog, integration); err != nil {
+		t.Fatalf("ValidateCatalog() error = %v", err)
+	}
+}
+
+func TestCompileCatalogRejectsMissingMappedUpstream(t *testing.T) {
+	integration := config.DefaultCodexIntegrationConfig()
+	integration.Enabled = true
+	models, providers := catalogTestModels()
+	filtered := models[:0]
+	for _, model := range models {
+		if catalogString(model, "id") != "gemini-pro-agent" {
+			filtered = append(filtered, model)
+		}
+	}
+
+	missingProviders := func(model string) []string {
+		if model == "gemini-pro-agent" {
+			return nil
+		}
+		return providers(model)
+	}
+	if _, err := CompileCatalog(filtered, missingProviders, integration); err == nil {
+		t.Fatal("CompileCatalog() error = nil, want missing upstream error")
+	}
+}
+
+func TestCompileCatalogIsDeterministicAcrossRegistryOrder(t *testing.T) {
+	integration := config.DefaultCodexIntegrationConfig()
+	integration.Enabled = true
+	models, providers := catalogTestModels()
+
+	first, err := CompileCatalog(models, providers, integration)
+	if err != nil {
+		t.Fatalf("CompileCatalog(first) error = %v", err)
+	}
+	for left, right := 0, len(models)-1; left < right; left, right = left+1, right-1 {
+		models[left], models[right] = models[right], models[left]
+	}
+	second, err := CompileCatalog(models, providers, integration)
+	if err != nil {
+		t.Fatalf("CompileCatalog(second) error = %v", err)
+	}
+	firstJSON, err := first.Marshal()
+	if err != nil {
+		t.Fatalf("first.Marshal() error = %v", err)
+	}
+	secondJSON, err := second.Marshal()
+	if err != nil {
+		t.Fatalf("second.Marshal() error = %v", err)
+	}
+	if !bytes.Equal(firstJSON, secondJSON) {
+		t.Fatalf("catalog output changed with registry order\nfirst: %s\nsecond: %s", firstJSON, secondJSON)
+	}
+}
+
+func catalogTestModels() ([]map[string]any, ModelProvidersFunc) {
+	models := []map[string]any{
+		{"id": "gpt-5.5", "display_name": "GPT-5.5"},
+		{"id": "gpt-5.6-sol", "display_name": "GPT-5.6 Sol"},
+		{"id": "gpt-5.4", "display_name": "GPT-5.4"},
+		{"id": "grok-4.5", "display_name": "Grok 4.5", "context_length": 262144},
+		{"id": "grok-build-0.1", "display_name": "Grok Build", "context_length": 262144},
+		{"id": "gemini-3.6-flash", "display_name": "Gemini 3.6 Flash", "context_length": 1048576},
+		{"id": "gemini-pro-agent", "display_name": "Gemini Pro Agent", "context_length": 1048576},
+		{"id": "claude-opus-4-6-thinking", "display_name": "Claude Opus", "context_length": 200000},
+	}
+	providers := map[string][]string{
+		"gpt-5.5":                  {"codex"},
+		"gpt-5.6-sol":              {"codex"},
+		"gpt-5.4":                  {"codex"},
+		"grok-4.5":                 {"xai"},
+		"grok-build-0.1":           {"xai"},
+		"gemini-3.6-flash":         {"antigravity"},
+		"gemini-pro-agent":         {"antigravity"},
+		"claude-opus-4-6-thinking": {"antigravity"},
+	}
+	return models, func(model string) []string { return providers[model] }
+}
+
+func catalogBySlug(models []map[string]any) map[string]map[string]any {
+	result := make(map[string]map[string]any, len(models))
+	for _, model := range models {
+		result[catalogString(model, "slug")] = model
+	}
+	return result
+}

--- a/internal/codexintegration/catalog_test.go
+++ b/internal/codexintegration/catalog_test.go
@@ -37,10 +37,13 @@ func TestCompileCatalogBuildsFeaturedStableSurface(t *testing.T) {
 	}
 
 	bySlug := catalogBySlug(catalog.Models)
-	for _, slug := range []string{"gpt-5.5", "gpt-5.4", "xai/grok-build-0.1"} {
+	for _, slug := range []string{"gpt-5.5", "gpt-5.4"} {
 		if bySlug[slug] == nil {
 			t.Fatalf("catalog missing %q", slug)
 		}
+	}
+	if bySlug["xai/grok-build-0.1"] != nil {
+		t.Fatal("catalog exposed an unconfigured Grok Build model")
 	}
 	if got, _ := bySlug["antigravity/gemini-3.1-pro"]["supports_search_tool"].(bool); got {
 		t.Fatal("AntiGravity Gemini advertises hosted search")
@@ -80,6 +83,37 @@ func TestCompileCatalogRejectsMissingMappedUpstream(t *testing.T) {
 	}
 	if _, err := CompileCatalog(filtered, missingProviders, integration); err == nil {
 		t.Fatal("CompileCatalog() error = nil, want missing upstream error")
+	}
+}
+
+func TestCompileCatalogSupportsAdditionalNativeProvider(t *testing.T) {
+	integration := config.DefaultCodexIntegrationConfig()
+	integration.Enabled = true
+	integration.Models = []config.CodexIntegrationModel{{
+		Slug: "kimi/kimi-for-coding", Provider: "kimi", UpstreamModel: "kimi-for-coding",
+		DisplayName: "Kimi for Coding", Visible: true, Featured: true, Priority: 2,
+		InputModalities: []string{"text"}, SupportsTools: true,
+	}}
+	models, baseProviders := catalogTestModels()
+	models = append(models, map[string]any{
+		"id": "kimi-for-coding", "display_name": "Kimi for Coding", "context_length": 262144,
+	})
+	providers := func(model string) []string {
+		if model == "kimi-for-coding" {
+			return []string{"kimi"}
+		}
+		return baseProviders(model)
+	}
+
+	catalog, err := CompileCatalog(models, providers, integration)
+	if err != nil {
+		t.Fatalf("CompileCatalog() error = %v", err)
+	}
+	if got := catalogString(catalog.Models[1], "slug"); got != "kimi/kimi-for-coding" {
+		t.Fatalf("Models[1].slug = %q, want kimi/kimi-for-coding", got)
+	}
+	if err = ValidateCatalog(catalog, integration); err != nil {
+		t.Fatalf("ValidateCatalog() error = %v", err)
 	}
 }
 

--- a/internal/codexintegration/catalog_test.go
+++ b/internal/codexintegration/catalog_test.go
@@ -119,7 +119,7 @@ func catalogTestModels() ([]map[string]any, ModelProvidersFunc) {
 		{"id": "gpt-5.4", "display_name": "GPT-5.4"},
 		{"id": "grok-4.5", "display_name": "Grok 4.5", "context_length": 262144},
 		{"id": "grok-build-0.1", "display_name": "Grok Build", "context_length": 262144},
-		{"id": "gemini-3.6-flash", "display_name": "Gemini 3.6 Flash", "context_length": 1048576},
+		{"id": "gemini-3.6-flash-high", "display_name": "Gemini 3.6 Flash", "context_length": 1048576},
 		{"id": "gemini-pro-agent", "display_name": "Gemini Pro Agent", "context_length": 1048576},
 		{"id": "claude-opus-4-6-thinking", "display_name": "Claude Opus", "context_length": 200000},
 	}
@@ -129,7 +129,7 @@ func catalogTestModels() ([]map[string]any, ModelProvidersFunc) {
 		"gpt-5.4":                  {"codex"},
 		"grok-4.5":                 {"xai"},
 		"grok-build-0.1":           {"xai"},
-		"gemini-3.6-flash":         {"antigravity"},
+		"gemini-3.6-flash-high":    {"antigravity"},
 		"gemini-pro-agent":         {"antigravity"},
 		"claude-opus-4-6-thinking": {"antigravity"},
 	}

--- a/internal/codexintegration/catalog_validate.go
+++ b/internal/codexintegration/catalog_validate.go
@@ -1,0 +1,77 @@
+package codexintegration
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+// ValidateCatalog applies Codex's base schema checks and integration invariants.
+func ValidateCatalog(catalog Catalog, integration config.CodexIntegrationConfig) error {
+	data, err := catalog.Marshal()
+	if err != nil {
+		return err
+	}
+	if err = registry.ValidateCodexClientModelsJSON(data); err != nil {
+		return fmt.Errorf("validate compiled Codex catalog: %w", err)
+	}
+
+	seenPriorities := make(map[int]string, len(catalog.Models))
+	for i, model := range catalog.Models {
+		slug := catalogString(model, "slug")
+		priority := catalogInt(model, "priority")
+		if priority <= 0 {
+			return fmt.Errorf("compiled Codex catalog model %q has invalid priority %d", slug, priority)
+		}
+		if previous := seenPriorities[priority]; previous != "" {
+			return fmt.Errorf("compiled Codex catalog models %q and %q share priority %d", previous, slug, priority)
+		}
+		seenPriorities[priority] = slug
+		if catalogString(model, "visibility") == "list" && catalogString(model, "multi_agent_version") != config.DefaultCodexMultiAgentMode {
+			return fmt.Errorf("compiled Codex catalog model %q must use multi_agent_version %q", slug, config.DefaultCodexMultiAgentMode)
+		}
+		if strings.HasPrefix(slug, "antigravity/") {
+			if supportsSearch, _ := model["supports_search_tool"].(bool); supportsSearch {
+				return fmt.Errorf("compiled Codex catalog model %q advertises unverified hosted search", slug)
+			}
+		}
+		if i < 5 && priority != i+1 {
+			return fmt.Errorf("compiled Codex catalog featured priority %d is not contiguous", priority)
+		}
+	}
+
+	if integration.Enabled {
+		wantFeatured := []string{"gpt-5.6-sol"}
+		featured := make([]config.CodexIntegrationModel, 0, 4)
+		for _, model := range integration.Models {
+			if model.Visible && model.Featured {
+				featured = append(featured, model)
+			}
+		}
+		sortCodexIntegrationModels(featured)
+		for _, model := range featured {
+			wantFeatured = append(wantFeatured, model.Slug)
+		}
+		if len(wantFeatured) != 5 || len(catalog.Models) < 5 {
+			return fmt.Errorf("compiled Codex catalog featured surface is incomplete")
+		}
+		for i, want := range wantFeatured {
+			if got := catalogString(catalog.Models[i], "slug"); got != want {
+				return fmt.Errorf("compiled Codex catalog featured model %d is %q, want %q", i+1, got, want)
+			}
+		}
+	}
+	return nil
+}
+
+func sortCodexIntegrationModels(models []config.CodexIntegrationModel) {
+	sort.SliceStable(models, func(i, j int) bool {
+		if models[i].Priority == models[j].Priority {
+			return models[i].Slug < models[j].Slug
+		}
+		return models[i].Priority < models[j].Priority
+	})
+}

--- a/internal/codexintegration/catalog_validate.go
+++ b/internal/codexintegration/catalog_validate.go
@@ -19,6 +19,8 @@ func ValidateCatalog(catalog Catalog, integration config.CodexIntegrationConfig)
 		return fmt.Errorf("validate compiled Codex catalog: %w", err)
 	}
 
+	featuredModels := featuredCodexIntegrationModels(integration)
+	featuredCount := 1 + len(featuredModels)
 	seenPriorities := make(map[int]string, len(catalog.Models))
 	for i, model := range catalog.Models {
 		slug := catalogString(model, "slug")
@@ -38,33 +40,42 @@ func ValidateCatalog(catalog Catalog, integration config.CodexIntegrationConfig)
 				return fmt.Errorf("compiled Codex catalog model %q advertises unverified hosted search", slug)
 			}
 		}
-		if i < 5 && priority != i+1 {
+		if i < featuredCount && priority != i+1 {
 			return fmt.Errorf("compiled Codex catalog featured priority %d is not contiguous", priority)
 		}
 	}
 
 	if integration.Enabled {
-		wantFeatured := []string{"gpt-5.6-sol"}
-		featured := make([]config.CodexIntegrationModel, 0, 4)
-		for _, model := range integration.Models {
-			if model.Visible && model.Featured {
-				featured = append(featured, model)
-			}
-		}
-		sortCodexIntegrationModels(featured)
-		for _, model := range featured {
-			wantFeatured = append(wantFeatured, model.Slug)
-		}
-		if len(wantFeatured) != 5 || len(catalog.Models) < 5 {
+		if len(catalog.Models) < featuredCount {
 			return fmt.Errorf("compiled Codex catalog featured surface is incomplete")
 		}
-		for i, want := range wantFeatured {
-			if got := catalogString(catalog.Models[i], "slug"); got != want {
-				return fmt.Errorf("compiled Codex catalog featured model %d is %q, want %q", i+1, got, want)
+		configuredSlugs := make(map[string]struct{}, len(integration.Models))
+		for _, model := range integration.Models {
+			configuredSlugs[model.Slug] = struct{}{}
+		}
+		if first := catalogString(catalog.Models[0], "slug"); first == "" {
+			return fmt.Errorf("compiled Codex catalog has no official featured model")
+		} else if _, configured := configuredSlugs[first]; configured {
+			return fmt.Errorf("compiled Codex catalog first featured model %q is not official", first)
+		}
+		for i, want := range featuredModels {
+			if got := catalogString(catalog.Models[i+1], "slug"); got != want.Slug {
+				return fmt.Errorf("compiled Codex catalog featured model %d is %q, want %q", i+2, got, want.Slug)
 			}
 		}
 	}
 	return nil
+}
+
+func featuredCodexIntegrationModels(integration config.CodexIntegrationConfig) []config.CodexIntegrationModel {
+	featured := make([]config.CodexIntegrationModel, 0, 4)
+	for _, model := range integration.Models {
+		if model.Visible && model.Featured {
+			featured = append(featured, model)
+		}
+	}
+	sortCodexIntegrationModels(featured)
+	return featured
 }
 
 func sortCodexIntegrationModels(models []config.CodexIntegrationModel) {

--- a/internal/codexintegration/catalog_writer.go
+++ b/internal/codexintegration/catalog_writer.go
@@ -1,0 +1,117 @@
+package codexintegration
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	temp, err := os.CreateTemp(dir, ".cliproxyapi-write-*")
+	if err != nil {
+		return fmt.Errorf("create temporary file for %s: %w", path, err)
+	}
+	tempName := temp.Name()
+	defer func() { _ = os.Remove(tempName) }()
+	if err = temp.Chmod(mode.Perm()); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("set temporary file permissions for %s: %w", path, err)
+	}
+	if _, err = temp.Write(data); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("write temporary file for %s: %w", path, err)
+	}
+	if err = temp.Sync(); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("sync temporary file for %s: %w", path, err)
+	}
+	if err = temp.Close(); err != nil {
+		return fmt.Errorf("close temporary file for %s: %w", path, err)
+	}
+	if err = os.Rename(tempName, path); err != nil {
+		return fmt.Errorf("replace %s: %w", path, err)
+	}
+	if err = syncDirectory(dir); err != nil {
+		return err
+	}
+	return nil
+}
+
+func copyFile(source, destination string, mode os.FileMode) error {
+	in, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("open backup source %s: %w", source, err)
+	}
+	defer in.Close()
+	out, err := os.OpenFile(destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode.Perm())
+	if err != nil {
+		return fmt.Errorf("create backup %s: %w", destination, err)
+	}
+	ok := false
+	defer func() {
+		_ = out.Close()
+		if !ok {
+			_ = os.Remove(destination)
+		}
+	}()
+	if _, err = io.Copy(out, in); err != nil {
+		return fmt.Errorf("copy backup %s: %w", destination, err)
+	}
+	if err = out.Sync(); err != nil {
+		return fmt.Errorf("sync backup %s: %w", destination, err)
+	}
+	if err = out.Close(); err != nil {
+		return fmt.Errorf("close backup %s: %w", destination, err)
+	}
+	ok = true
+	return syncDirectory(filepath.Dir(destination))
+}
+
+func moveAside(source, backupDir, label string) (string, error) {
+	if _, err := os.Lstat(source); os.IsNotExist(err) {
+		return "", nil
+	} else if err != nil {
+		return "", fmt.Errorf("inspect %s: %w", source, err)
+	}
+	if err := os.MkdirAll(backupDir, 0o700); err != nil {
+		return "", fmt.Errorf("create backup directory: %w", err)
+	}
+	destination := uniqueBackupPath(backupDir, label)
+	if err := os.Rename(source, destination); err != nil {
+		return "", fmt.Errorf("move %s aside: %w", source, err)
+	}
+	if err := syncDirectory(filepath.Dir(source)); err != nil {
+		return "", err
+	}
+	return destination, syncDirectory(backupDir)
+}
+
+func uniqueBackupPath(dir, label string) string {
+	stamp := time.Now().UTC().Format("20060102T150405.000000000Z")
+	base := filepath.Join(dir, label+"-"+stamp)
+	for suffix := 0; ; suffix++ {
+		candidate := base
+		if suffix > 0 {
+			candidate = fmt.Sprintf("%s-%d", base, suffix)
+		}
+		if _, err := os.Lstat(candidate); errors.Is(err, os.ErrNotExist) {
+			return candidate
+		}
+	}
+}
+
+func syncDirectory(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open directory %s for sync: %w", path, err)
+	}
+	defer dir.Close()
+	if err = dir.Sync(); err != nil {
+		return fmt.Errorf("sync directory %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/codexintegration/catalog_writer.go
+++ b/internal/codexintegration/catalog_writer.go
@@ -9,6 +9,68 @@ import (
 	"time"
 )
 
+type fileSnapshot struct {
+	data   []byte
+	mode   os.FileMode
+	exists bool
+}
+
+func snapshotRegularFile(path string, defaultMode os.FileMode) (fileSnapshot, error) {
+	data, mode, exists, err := readRegularFile(path, defaultMode)
+	if err != nil {
+		return fileSnapshot{}, err
+	}
+	return fileSnapshot{data: data, mode: mode, exists: exists}, nil
+}
+
+func restoreFileSnapshot(path string, snapshot fileSnapshot) error {
+	if snapshot.exists {
+		return atomicWriteFile(path, snapshot.data, snapshot.mode)
+	}
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect rollback target %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return fmt.Errorf("refusing non-regular rollback target %s", path)
+	}
+	if err = os.Remove(path); err != nil {
+		return fmt.Errorf("remove rollback target %s: %w", path, err)
+	}
+	return syncDirectory(filepath.Dir(path))
+}
+
+func restoreMovedAside(original, backup string) error {
+	if backup == "" {
+		return nil
+	}
+	if _, err := os.Lstat(original); err == nil {
+		return fmt.Errorf("refusing to replace rollback target %s", original)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect rollback target %s: %w", original, err)
+	}
+	if err := os.Rename(backup, original); err != nil {
+		return fmt.Errorf("restore %s from %s: %w", original, backup, err)
+	}
+	if err := syncDirectory(filepath.Dir(original)); err != nil {
+		return err
+	}
+	return syncDirectory(filepath.Dir(backup))
+}
+
+func withRollbackError(cause error, rollbackErrors ...error) error {
+	errorsToJoin := []error{cause}
+	for _, rollbackErr := range rollbackErrors {
+		if rollbackErr != nil {
+			errorsToJoin = append(errorsToJoin, fmt.Errorf("rollback failed: %w", rollbackErr))
+		}
+	}
+	return errors.Join(errorsToJoin...)
+}
+
 func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
 	dir := filepath.Dir(path)
 	temp, err := os.CreateTemp(dir, ".cliproxyapi-write-*")
@@ -85,7 +147,7 @@ func moveAside(source, backupDir, label string) (string, error) {
 		return "", fmt.Errorf("move %s aside: %w", source, err)
 	}
 	if err := syncDirectory(filepath.Dir(source)); err != nil {
-		return "", err
+		return destination, err
 	}
 	return destination, syncDirectory(backupDir)
 }

--- a/internal/codexintegration/commands.go
+++ b/internal/codexintegration/commands.go
@@ -1,0 +1,265 @@
+package codexintegration
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+// CommandAction identifies a mutually exclusive Codex Integration command.
+type CommandAction string
+
+const (
+	CommandSetup   CommandAction = "setup"
+	CommandSync    CommandAction = "sync"
+	CommandDoctor  CommandAction = "doctor"
+	CommandRestore CommandAction = "restore"
+)
+
+// CommandOptions controls one-shot Codex Integration commands.
+type CommandOptions struct {
+	Action           CommandAction
+	Apply            bool
+	JSON             bool
+	ProbeModels      bool
+	MigrateOpenCodex bool
+	CodexHome        string
+	HTTPClient       *http.Client
+}
+
+// CommandOutput is the stable machine-readable envelope for lifecycle commands.
+type CommandOutput struct {
+	SchemaVersion   int           `json:"schema_version"`
+	Action          CommandAction `json:"action"`
+	Changed         bool          `json:"changed"`
+	Applied         bool          `json:"applied"`
+	RestartRequired bool          `json:"restart_required"`
+	CatalogRevision string        `json:"catalog_revision,omitempty"`
+	SourceRevision  uint64        `json:"source_revision,omitempty"`
+	MappingRevision string        `json:"mapping_revision,omitempty"`
+	ConfigFile      string        `json:"config_file"`
+	CatalogFile     string        `json:"catalog_file"`
+}
+
+// CommandFailure is the stable machine-readable envelope for command errors.
+type CommandFailure struct {
+	SchemaVersion int           `json:"schema_version"`
+	Action        CommandAction `json:"action"`
+	Status        string        `json:"status"`
+	Error         string        `json:"error"`
+}
+
+// WriteCommandFailure emits a JSON error without including credential contents.
+func WriteCommandFailure(output io.Writer, action CommandAction, err error) error {
+	message := "Codex Integration command failed"
+	if err != nil {
+		message = err.Error()
+	}
+	return writeJSON(output, CommandFailure{SchemaVersion: 1, Action: action, Status: "error", Error: message})
+}
+
+// ValidateCommandOptions rejects ambiguous or nonsensical command combinations.
+func ValidateCommandOptions(options CommandOptions) error {
+	switch options.Action {
+	case CommandSetup, CommandSync, CommandDoctor, CommandRestore:
+	default:
+		return fmt.Errorf("unknown Codex Integration command %q", options.Action)
+	}
+	if options.Action == CommandDoctor && options.Apply {
+		return errors.New("-apply cannot be used with -codex-doctor")
+	}
+	if options.Action != CommandDoctor && options.ProbeModels {
+		return errors.New("-probe-models requires -codex-doctor")
+	}
+	if options.Action != CommandSetup && options.MigrateOpenCodex {
+		return errors.New("-codex-migrate-opencodex requires -codex-setup")
+	}
+	return nil
+}
+
+// RunCommand executes a one-shot command and returns its process exit code.
+func RunCommand(ctx context.Context, cfg *config.Config, options CommandOptions, output io.Writer) (int, error) {
+	if err := ValidateCommandOptions(options); err != nil {
+		return 2, err
+	}
+	if output == nil {
+		output = io.Discard
+	}
+	lifecycle, err := NewLifecycle(cfg, options.CodexHome)
+	if err != nil {
+		return 2, err
+	}
+	models, providers := commandCatalogSource(ctx, lifecycle, options.HTTPClient)
+	if options.Action == CommandDoctor {
+		report := RunDoctor(ctx, lifecycle, models, providers, DoctorOptions{
+			ProbeModels: options.ProbeModels,
+			HTTPClient:  options.HTTPClient,
+		})
+		if options.JSON {
+			err = writeJSON(output, report)
+		} else {
+			err = writeDoctorText(output, report)
+		}
+		return report.ExitCode(), err
+	}
+
+	var result OperationResult
+	switch options.Action {
+	case CommandSetup:
+		result, err = lifecycle.Setup(models, providers, options.Apply, options.MigrateOpenCodex)
+	case CommandSync:
+		result, err = lifecycle.Sync(models, providers, options.Apply)
+	case CommandRestore:
+		result, err = lifecycle.Restore(options.Apply)
+	}
+	if err != nil {
+		return 2, err
+	}
+	envelope := CommandOutput{
+		SchemaVersion: 1, Action: options.Action, Changed: result.Changed, Applied: result.Applied,
+		RestartRequired: result.RestartRequired, CatalogRevision: result.CatalogRevision,
+		SourceRevision: result.SourceRevision, MappingRevision: result.MappingRevision,
+		ConfigFile: lifecycle.Paths.ConfigFile, CatalogFile: lifecycle.Paths.CatalogFile,
+	}
+	if options.JSON {
+		return 0, writeJSON(output, envelope)
+	}
+	mode := "preview"
+	if result.Applied {
+		mode = "applied"
+	} else if !result.Changed {
+		mode = "unchanged"
+	}
+	_, err = fmt.Fprintf(output, "Codex Integration %s: %s\nconfig: %s\ncatalog: %s\nrestart required: %t\n",
+		options.Action, mode, lifecycle.Paths.ConfigFile, lifecycle.Paths.CatalogFile, result.RestartRequired)
+	return 0, err
+}
+
+func writeJSON(output io.Writer, value any) error {
+	encoder := json.NewEncoder(output)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(value)
+}
+
+func commandCatalogSource(ctx context.Context, lifecycle *Lifecycle, client *http.Client) ([]map[string]any, ModelProvidersFunc) {
+	modelsByID := make(map[string]map[string]any)
+	providersByID := make(map[string]map[string]struct{})
+	add := func(provider string, infos []*registry.ModelInfo) {
+		for _, info := range infos {
+			if info == nil || strings.TrimSpace(info.ID) == "" {
+				continue
+			}
+			id := strings.TrimSpace(info.ID)
+			if _, exists := modelsByID[id]; !exists {
+				modelsByID[id] = commandModelMap(info)
+			}
+			if providersByID[id] == nil {
+				providersByID[id] = make(map[string]struct{})
+			}
+			providersByID[id][provider] = struct{}{}
+		}
+	}
+	add("codex", registry.GetCodexProModels())
+	add("xai", registry.GetXAIModels())
+	add("antigravity", registry.GetAntigravityModels())
+
+	liveModels := fetchLiveModelList(ctx, lifecycle.baseURL(), client)
+	for _, model := range liveModels {
+		id, _ := model["id"].(string)
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, exists := modelsByID[id]; !exists {
+			modelsByID[id] = model
+		}
+		for _, mapping := range lifecycle.Config.CodexIntegration.Models {
+			if mapping.UpstreamModel == id {
+				if providersByID[id] == nil {
+					providersByID[id] = make(map[string]struct{})
+				}
+				providersByID[id][mapping.Provider] = struct{}{}
+			}
+		}
+	}
+
+	ids := make([]string, 0, len(modelsByID))
+	for id := range modelsByID {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	models := make([]map[string]any, 0, len(ids))
+	for _, id := range ids {
+		models = append(models, modelsByID[id])
+	}
+	providers := func(model string) []string {
+		set := providersByID[model]
+		result := make([]string, 0, len(set))
+		for provider := range set {
+			result = append(result, provider)
+		}
+		sort.Strings(result)
+		return result
+	}
+	return models, providers
+}
+
+func commandModelMap(info *registry.ModelInfo) map[string]any {
+	model := map[string]any{"id": info.ID, "object": "model", "owned_by": info.OwnedBy}
+	if info.Created > 0 {
+		model["created"] = info.Created
+	}
+	if info.Type != "" {
+		model["type"] = info.Type
+	}
+	if info.DisplayName != "" {
+		model["display_name"] = info.DisplayName
+	}
+	if info.Description != "" {
+		model["description"] = info.Description
+	}
+	if info.ContextLength > 0 {
+		model["context_length"] = info.ContextLength
+	}
+	if info.MaxCompletionTokens > 0 {
+		model["max_completion_tokens"] = info.MaxCompletionTokens
+	}
+	return model
+}
+
+func fetchLiveModelList(ctx context.Context, baseURL string, client *http.Client) []map[string]any {
+	if client == nil {
+		client = &http.Client{Timeout: 3 * time.Second}
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimSuffix(baseURL, "/")+"/models", nil)
+	if err != nil {
+		return nil
+	}
+	request.Header.Set("Authorization", "Bearer codex-integration-local")
+	response, err := client.Do(request)
+	if err != nil {
+		return nil
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil
+	}
+	var payload struct {
+		Data []map[string]any `json:"data"`
+	}
+	decoder := json.NewDecoder(io.LimitReader(response.Body, 4<<20))
+	if err = decoder.Decode(&payload); err != nil {
+		return nil
+	}
+	return payload.Data
+}

--- a/internal/codexintegration/commands.go
+++ b/internal/codexintegration/commands.go
@@ -170,8 +170,9 @@ func commandCatalogSource(ctx context.Context, lifecycle *Lifecycle, client *htt
 		}
 	}
 	add("codex", registry.GetCodexProModels())
-	add("xai", registry.GetXAIModels())
-	add("antigravity", registry.GetAntigravityModels())
+	for _, provider := range config.CodexIntegrationProviders() {
+		add(provider, registry.GetStaticModelDefinitionsByChannel(provider))
+	}
 
 	liveModels := fetchLiveModelList(ctx, lifecycle.baseURL(), client)
 	for _, model := range liveModels {

--- a/internal/codexintegration/config.go
+++ b/internal/codexintegration/config.go
@@ -158,7 +158,35 @@ func operationResultForPlan(plan setupPlan) OperationResult {
 	}
 }
 
-func (l *Lifecycle) applySetup(plan setupPlan, result *OperationResult) error {
+func (l *Lifecycle) applySetup(plan setupPlan, result *OperationResult) (err error) {
+	journalSnapshot, err := snapshotRegularFile(l.Paths.JournalFile, 0o600)
+	if err != nil {
+		return err
+	}
+	configSnapshot := fileSnapshot{data: plan.configOld, mode: plan.configMode, exists: plan.configExists}
+	catalogSnapshot := fileSnapshot{data: plan.catalogOld, mode: 0o600, exists: plan.catalogExists}
+	var configMutated, catalogMutated, journalMutated bool
+	var cacheBackup string
+	defer func() {
+		if err == nil {
+			return
+		}
+		rollbackErrors := make([]error, 0, 4)
+		if journalMutated {
+			rollbackErrors = append(rollbackErrors, restoreFileSnapshot(l.Paths.JournalFile, journalSnapshot))
+		}
+		if configMutated {
+			rollbackErrors = append(rollbackErrors, restoreFileSnapshot(l.Paths.ConfigFile, configSnapshot))
+		}
+		if catalogMutated {
+			rollbackErrors = append(rollbackErrors, restoreFileSnapshot(l.Paths.CatalogFile, catalogSnapshot))
+		}
+		if cacheBackup != "" {
+			rollbackErrors = append(rollbackErrors, restoreMovedAside(l.Paths.CacheFile, cacheBackup))
+		}
+		err = withRollbackError(err, rollbackErrors...)
+	}()
+
 	journal := plan.journal
 	if !plan.journalExists {
 		journal = Journal{
@@ -181,16 +209,18 @@ func (l *Lifecycle) applySetup(plan setupPlan, result *OperationResult) error {
 		}
 	}
 	if !bytes.Equal(plan.catalogOld, plan.catalogData) {
-		if err := atomicWriteFile(l.Paths.CatalogFile, plan.catalogData, 0o600); err != nil {
+		catalogMutated = true
+		if err = atomicWriteFile(l.Paths.CatalogFile, plan.catalogData, 0o600); err != nil {
 			return err
 		}
 	}
 	if !bytes.Equal(plan.configOld, plan.configData) {
-		if err := atomicWriteFile(l.Paths.ConfigFile, plan.configData, plan.configMode); err != nil {
+		configMutated = true
+		if err = atomicWriteFile(l.Paths.ConfigFile, plan.configData, plan.configMode); err != nil {
 			return err
 		}
 	}
-	if _, err := moveAside(l.Paths.CacheFile, l.Paths.BackupDir, "models_cache.json.stale"); err != nil {
+	if cacheBackup, err = moveAside(l.Paths.CacheFile, l.Paths.BackupDir, "models_cache.json.stale"); err != nil {
 		return err
 	}
 	journal.UpdatedAt = time.Now().UTC()
@@ -203,6 +233,7 @@ func (l *Lifecycle) applySetup(plan setupPlan, result *OperationResult) error {
 	if err != nil {
 		return err
 	}
+	journalMutated = true
 	return atomicWriteFile(l.Paths.JournalFile, journalData, 0o600)
 }
 

--- a/internal/codexintegration/config.go
+++ b/internal/codexintegration/config.go
@@ -299,6 +299,9 @@ func removeOpenCodexEntries(input string) string {
 		if index+1 < len(lines) {
 			key := rootAssignmentKey(lines[index+1])
 			if key == "openai_base_url" || key == "model_catalog_json" {
+				if key == "openai_base_url" && len(out) > 0 && isKnownOpenCodexCatalogAssignment(out[len(out)-1]) {
+					out = out[:len(out)-1]
+				}
 				index++
 				continue
 			}
@@ -306,6 +309,21 @@ func removeOpenCodexEntries(input string) string {
 		out = append(out, lines[index])
 	}
 	return strings.Join(out, "")
+}
+
+func isKnownOpenCodexCatalogAssignment(line string) bool {
+	if rootAssignmentKey(line) != "model_catalog_json" {
+		return false
+	}
+	_, rawValue, found := strings.Cut(strings.TrimSpace(line), "=")
+	if !found {
+		return false
+	}
+	value, err := strconv.Unquote(strings.TrimSpace(rawValue))
+	if err != nil {
+		return false
+	}
+	return filepath.Base(value) == "opencodex-catalog.json"
 }
 
 func validateConfigOwnership(input string) error {

--- a/internal/codexintegration/config.go
+++ b/internal/codexintegration/config.go
@@ -140,7 +140,10 @@ func (l *Lifecycle) prepareSetup(models []map[string]any, providers ModelProvide
 	if err != nil {
 		return setupPlan{}, err
 	}
-	changed := !bytes.Equal(oldConfig, newConfig) || !bytes.Equal(oldCatalog, catalogData) || !journalExists
+	journalStale := journalExists && (journal.CatalogRevision != catalog.Revision ||
+		journal.CatalogSourceVersion != catalog.SourceRevision ||
+		journal.MappingRevision != catalog.MappingRevision)
+	changed := !bytes.Equal(oldConfig, newConfig) || !bytes.Equal(oldCatalog, catalogData) || !journalExists || journalStale
 	return setupPlan{
 		catalog: catalog, catalogData: catalogData, configData: newConfig, configMode: configMode,
 		configOld: oldConfig, configExists: configExists, catalogOld: oldCatalog,

--- a/internal/codexintegration/config.go
+++ b/internal/codexintegration/config.go
@@ -1,0 +1,424 @@
+package codexintegration
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+const (
+	ManagedConfigBegin = "# BEGIN CLIProxyAPI Codex Integration"
+	ManagedConfigEnd   = "# END CLIProxyAPI Codex Integration"
+	openCodexMarker    = "# Auto-injected by opencodex"
+)
+
+// OperationResult describes a lifecycle preview or applied transaction.
+type OperationResult struct {
+	Changed          bool
+	Applied          bool
+	RestartRequired  bool
+	CatalogRevision  string
+	SourceRevision   uint64
+	MappingRevision  string
+	ConfigBackupFile string
+}
+
+// Lifecycle manages the Codex config and model catalog as one transaction.
+type Lifecycle struct {
+	Config *config.Config
+	Paths  Paths
+}
+
+type setupPlan struct {
+	catalog       Catalog
+	catalogData   []byte
+	configData    []byte
+	configMode    os.FileMode
+	configOld     []byte
+	configExists  bool
+	catalogOld    []byte
+	catalogExists bool
+	journal       Journal
+	journalExists bool
+	changed       bool
+}
+
+// NewLifecycle validates configuration and resolves all managed paths without writing them.
+func NewLifecycle(cfg *config.Config, explicitHome string) (*Lifecycle, error) {
+	if cfg == nil {
+		return nil, errors.New("Codex integration requires a non-nil config")
+	}
+	if err := cfg.NormalizeCodexIntegration(); err != nil {
+		return nil, err
+	}
+	if !cfg.CodexIntegration.Enabled {
+		return nil, errors.New("Codex integration is disabled")
+	}
+	paths, err := ResolvePaths(explicitHome, cfg.CodexIntegration)
+	if err != nil {
+		return nil, err
+	}
+	return &Lifecycle{Config: cfg, Paths: paths}, nil
+}
+
+// Setup compiles and previews or applies the Codex integration transaction.
+func (l *Lifecycle) Setup(models []map[string]any, providers ModelProvidersFunc, apply, migrateOpenCodex bool) (OperationResult, error) {
+	plan, err := l.prepareSetup(models, providers, migrateOpenCodex)
+	if err != nil {
+		return OperationResult{}, err
+	}
+	result := operationResultForPlan(plan)
+	if !apply || !plan.changed {
+		return result, nil
+	}
+	if err = l.ensureWritePaths(); err != nil {
+		return OperationResult{}, err
+	}
+	release, err := acquireLifecycleLock(l.Paths.LockFile)
+	if err != nil {
+		return OperationResult{}, err
+	}
+	defer release()
+
+	plan, err = l.prepareSetup(models, providers, migrateOpenCodex)
+	if err != nil {
+		return OperationResult{}, err
+	}
+	result = operationResultForPlan(plan)
+	if !plan.changed {
+		return result, nil
+	}
+	if err = l.applySetup(plan, &result); err != nil {
+		return OperationResult{}, err
+	}
+	result.Applied = true
+	result.RestartRequired = true
+	return result, nil
+}
+
+// Sync refreshes an integration previously claimed by Setup.
+func (l *Lifecycle) Sync(models []map[string]any, providers ModelProvidersFunc, apply bool) (OperationResult, error) {
+	if _, exists, err := readJournal(l.Paths.JournalFile); err != nil {
+		return OperationResult{}, err
+	} else if !exists {
+		return OperationResult{}, errors.New("Codex integration is not set up; run setup before sync")
+	}
+	return l.Setup(models, providers, apply, false)
+}
+
+func (l *Lifecycle) prepareSetup(models []map[string]any, providers ModelProvidersFunc, migrateOpenCodex bool) (setupPlan, error) {
+	catalog, err := CompileCatalog(models, providers, l.Config.CodexIntegration)
+	if err != nil {
+		return setupPlan{}, err
+	}
+	catalogData, err := catalog.Marshal()
+	if err != nil {
+		return setupPlan{}, err
+	}
+	oldConfig, configMode, configExists, err := readRegularFile(l.Paths.ConfigFile, 0o600)
+	if err != nil {
+		return setupPlan{}, err
+	}
+	newConfig, err := injectManagedConfig(oldConfig, l.baseURL(), l.Paths.CatalogFile, migrateOpenCodex)
+	if err != nil {
+		return setupPlan{}, err
+	}
+	oldCatalog, _, catalogExists, err := readRegularFile(l.Paths.CatalogFile, 0o600)
+	if err != nil {
+		return setupPlan{}, err
+	}
+	journal, journalExists, err := readJournal(l.Paths.JournalFile)
+	if err != nil {
+		return setupPlan{}, err
+	}
+	changed := !bytes.Equal(oldConfig, newConfig) || !bytes.Equal(oldCatalog, catalogData) || !journalExists
+	return setupPlan{
+		catalog: catalog, catalogData: catalogData, configData: newConfig, configMode: configMode,
+		configOld: oldConfig, configExists: configExists, catalogOld: oldCatalog,
+		catalogExists: catalogExists, journal: journal, journalExists: journalExists, changed: changed,
+	}, nil
+}
+
+func operationResultForPlan(plan setupPlan) OperationResult {
+	return OperationResult{
+		Changed: plan.changed, CatalogRevision: plan.catalog.Revision,
+		SourceRevision: plan.catalog.SourceRevision, MappingRevision: plan.catalog.MappingRevision,
+	}
+}
+
+func (l *Lifecycle) applySetup(plan setupPlan, result *OperationResult) error {
+	journal := plan.journal
+	if !plan.journalExists {
+		journal = Journal{
+			Version: journalVersion, ConfigExisted: plan.configExists,
+			OriginalConfigHash: contentHash(plan.configOld), OriginalConfigMode: uint32(plan.configMode.Perm()),
+			CatalogExisted: plan.catalogExists, OriginalCatalogHash: contentHash(plan.catalogOld),
+		}
+		if plan.configExists {
+			journal.ConfigBackupFile = uniqueBackupPath(l.Paths.BackupDir, "config.toml")
+			if err := copyFile(l.Paths.ConfigFile, journal.ConfigBackupFile, 0o600); err != nil {
+				return err
+			}
+			result.ConfigBackupFile = journal.ConfigBackupFile
+		}
+		if plan.catalogExists {
+			journal.CatalogBackupFile = uniqueBackupPath(l.Paths.BackupDir, filepath.Base(l.Paths.CatalogFile))
+			if err := copyFile(l.Paths.CatalogFile, journal.CatalogBackupFile, 0o600); err != nil {
+				return err
+			}
+		}
+	}
+	if !bytes.Equal(plan.catalogOld, plan.catalogData) {
+		if err := atomicWriteFile(l.Paths.CatalogFile, plan.catalogData, 0o600); err != nil {
+			return err
+		}
+	}
+	if !bytes.Equal(plan.configOld, plan.configData) {
+		if err := atomicWriteFile(l.Paths.ConfigFile, plan.configData, plan.configMode); err != nil {
+			return err
+		}
+	}
+	if _, err := moveAside(l.Paths.CacheFile, l.Paths.BackupDir, "models_cache.json.stale"); err != nil {
+		return err
+	}
+	journal.UpdatedAt = time.Now().UTC()
+	journal.ManagedConfigHash = contentHash(plan.configData)
+	journal.ManagedCatalogHash = contentHash(plan.catalogData)
+	journal.CatalogRevision = plan.catalog.Revision
+	journal.CatalogSourceVersion = plan.catalog.SourceRevision
+	journal.MappingRevision = plan.catalog.MappingRevision
+	journalData, err := marshalJournal(journal)
+	if err != nil {
+		return err
+	}
+	return atomicWriteFile(l.Paths.JournalFile, journalData, 0o600)
+}
+
+func (l *Lifecycle) ensureWritePaths() error {
+	if err := rejectSymlink(l.Paths.Home); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(l.Paths.Home, 0o700); err != nil {
+		return fmt.Errorf("create Codex home: %w", err)
+	}
+	for _, path := range []string{l.Paths.ConfigFile, l.Paths.CatalogFile, l.Paths.CacheFile, l.Paths.StateDir, l.Paths.JournalFile, l.Paths.LockFile, l.Paths.BackupDir} {
+		if err := rejectSymlink(path); err != nil {
+			return err
+		}
+	}
+	if err := os.MkdirAll(l.Paths.BackupDir, 0o700); err != nil {
+		return fmt.Errorf("create Codex integration state: %w", err)
+	}
+	return nil
+}
+
+func (l *Lifecycle) baseURL() string {
+	host := strings.TrimSpace(l.Config.Host)
+	if strings.EqualFold(host, "localhost") {
+		return "http://localhost:" + strconv.Itoa(l.Config.Port) + "/v1"
+	}
+	host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	return "http://" + net.JoinHostPort(host, strconv.Itoa(l.Config.Port)) + "/v1"
+}
+
+func injectManagedConfig(original []byte, baseURL, catalogPath string, migrateOpenCodex bool) ([]byte, error) {
+	eol := "\n"
+	if bytes.Contains(original, []byte("\r\n")) {
+		eol = "\r\n"
+	}
+	normalized := strings.ReplaceAll(string(original), "\r\n", "\n")
+	withoutManaged, _, err := removeManagedBlock(normalized)
+	if err != nil {
+		return nil, err
+	}
+	if migrateOpenCodex {
+		withoutManaged = removeOpenCodexEntries(withoutManaged)
+	}
+	if err = validateConfigOwnership(withoutManaged); err != nil {
+		return nil, err
+	}
+	block := strings.Join([]string{
+		ManagedConfigBegin,
+		"openai_base_url = " + strconv.Quote(baseURL),
+		"model_catalog_json = " + strconv.Quote(catalogPath),
+		ManagedConfigEnd,
+	}, "\n") + "\n"
+	configured := insertRootBlock(withoutManaged, block)
+	if err = validateTOML([]byte(configured)); err != nil {
+		return nil, err
+	}
+	if eol != "\n" {
+		configured = strings.ReplaceAll(configured, "\n", eol)
+	}
+	return []byte(configured), nil
+}
+
+func removeManagedBlock(input string) (string, bool, error) {
+	begin := strings.Index(input, ManagedConfigBegin)
+	end := strings.Index(input, ManagedConfigEnd)
+	if begin < 0 && end < 0 {
+		return input, false, nil
+	}
+	if begin < 0 || end < begin {
+		return "", false, errors.New("malformed CLIProxyAPI Codex Integration marker block")
+	}
+	if strings.Contains(input[begin+len(ManagedConfigBegin):end], ManagedConfigBegin) || strings.Contains(input[end+len(ManagedConfigEnd):], ManagedConfigEnd) {
+		return "", false, errors.New("multiple CLIProxyAPI Codex Integration marker blocks")
+	}
+	end += len(ManagedConfigEnd)
+	if end < len(input) && input[end] == '\n' {
+		end++
+	}
+	// The blank separator before the first TOML table belongs to the managed block.
+	if end < len(input) && input[end] == '\n' {
+		end++
+	}
+	return input[:begin] + input[end:], true, nil
+}
+
+func removeOpenCodexEntries(input string) string {
+	lines := strings.SplitAfter(input, "\n")
+	out := make([]string, 0, len(lines))
+	for index := 0; index < len(lines); index++ {
+		if strings.TrimSpace(lines[index]) != openCodexMarker {
+			out = append(out, lines[index])
+			continue
+		}
+		if index+1 < len(lines) {
+			key := rootAssignmentKey(lines[index+1])
+			if key == "openai_base_url" || key == "model_catalog_json" {
+				index++
+				continue
+			}
+		}
+		out = append(out, lines[index])
+	}
+	return strings.Join(out, "")
+}
+
+func validateConfigOwnership(input string) error {
+	if err := validateTOML([]byte(input)); err != nil {
+		return err
+	}
+	var document map[string]any
+	if strings.TrimSpace(input) != "" {
+		if err := toml.Unmarshal([]byte(input), &document); err != nil {
+			return fmt.Errorf("parse Codex config: %w", err)
+		}
+	}
+	for _, key := range []string{"openai_base_url", "model_catalog_json"} {
+		if _, exists := document[key]; exists {
+			return fmt.Errorf("Codex config root key %q is user-owned; no files were changed", key)
+		}
+	}
+	return nil
+}
+
+func validateTOML(data []byte) error {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil
+	}
+	var document map[string]any
+	if err := toml.Unmarshal(data, &document); err != nil {
+		return fmt.Errorf("parse Codex config TOML: %w", err)
+	}
+	return nil
+}
+
+func insertRootBlock(input, block string) string {
+	lines := strings.SplitAfter(input, "\n")
+	offset := len(input)
+	consumed := 0
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			offset = consumed
+			break
+		}
+		consumed += len(line)
+	}
+	prefix, suffix := input[:offset], input[offset:]
+	if prefix != "" && !strings.HasSuffix(prefix, "\n") {
+		prefix += "\n"
+	}
+	if prefix != "" && !strings.HasSuffix(prefix, "\n\n") {
+		prefix += "\n"
+	}
+	result := prefix + block
+	if suffix != "" && !strings.HasPrefix(suffix, "\n") {
+		result += "\n"
+	}
+	return result + suffix
+}
+
+func rootAssignmentKey(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "[") {
+		return ""
+	}
+	key, _, found := strings.Cut(trimmed, "=")
+	if !found {
+		return ""
+	}
+	return strings.TrimSpace(key)
+}
+
+func readRegularFile(path string, defaultMode os.FileMode) ([]byte, os.FileMode, bool, error) {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil, defaultMode, false, nil
+	}
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("inspect %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, 0, false, fmt.Errorf("refusing symbolic link at %s", path)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, 0, false, fmt.Errorf("refusing non-regular file at %s", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("read %s: %w", path, err)
+	}
+	return data, info.Mode().Perm(), true, nil
+}
+
+func rejectSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing symbolic link at %s", path)
+	}
+	return nil
+}
+
+func acquireLifecycleLock(path string) (func(), error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		if os.IsExist(err) {
+			return nil, fmt.Errorf("Codex integration lock is already held at %s", path)
+		}
+		return nil, fmt.Errorf("acquire Codex integration lock: %w", err)
+	}
+	_, _ = fmt.Fprintf(file, "%d\n", os.Getpid())
+	_ = file.Sync()
+	return func() {
+		_ = file.Close()
+		_ = os.Remove(path)
+	}, nil
+}

--- a/internal/codexintegration/config_test.go
+++ b/internal/codexintegration/config_test.go
@@ -38,6 +38,7 @@ func TestSetupPreservesConfigShapeAndIsIdempotent(t *testing.T) {
 		{name: "comments and table", body: "# user comment\n\n[features]\nmulti_agent = true\n"},
 		{name: "CRLF", body: "# user comment\r\n\r\n[features]\r\nmulti_agent = true\r\n"},
 		{name: "multiple profiles", body: "[profiles.work]\nmodel = \"gpt-5.6-sol\"\n\n[features]\nweb_search = true\n"},
+		{name: "history scoped provider", body: "model_provider = \"custom\"\n\n[model_providers.custom]\nname = \"Existing provider\"\nbase_url = \"http://127.0.0.1:8317/v1\"\nwire_api = \"responses\"\n"},
 	}
 
 	for _, fixture := range fixtures {
@@ -69,6 +70,13 @@ func TestSetupPreservesConfigShapeAndIsIdempotent(t *testing.T) {
 			}
 			if strings.Contains(fixture.body, "\r\n") && bytes.Contains(configured, []byte("\n")) && !bytes.Contains(configured, []byte("\r\n")) {
 				t.Fatal("CRLF style was not preserved")
+			}
+			if fixture.name == "history scoped provider" {
+				for _, preserved := range []string{`model_provider = "custom"`, `[model_providers.custom]`, `name = "Existing provider"`} {
+					if !bytes.Contains(configured, []byte(preserved)) {
+						t.Fatalf("history-scoped provider configuration lost %q: %s", preserved, configured)
+					}
+				}
 			}
 			info, err := os.Stat(lifecycle.Paths.ConfigFile)
 			if err != nil {

--- a/internal/codexintegration/config_test.go
+++ b/internal/codexintegration/config_test.go
@@ -96,6 +96,50 @@ func TestSetupPreservesConfigShapeAndIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestSyncRefreshesStaleJournalMetadata(t *testing.T) {
+	lifecycle := testLifecycle(t)
+	models, providers := catalogTestModels()
+	if _, err := lifecycle.Setup(models, providers, true, false); err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+	journal, exists, err := readJournal(lifecycle.Paths.JournalFile)
+	if err != nil || !exists {
+		t.Fatalf("readJournal() = %#v, %v", journal, err)
+	}
+	journal.CatalogRevision = "stale-catalog"
+	journal.CatalogSourceVersion = 0
+	journal.MappingRevision = "stale-mapping"
+	journalData, err := marshalJournal(journal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = os.WriteFile(lifecycle.Paths.JournalFile, journalData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	preview, err := lifecycle.Sync(models, providers, false)
+	if err != nil || !preview.Changed || preview.Applied {
+		t.Fatalf("Sync(preview) = %#v, %v", preview, err)
+	}
+	applied, err := lifecycle.Sync(models, providers, true)
+	if err != nil || !applied.Changed || !applied.Applied {
+		t.Fatalf("Sync(apply) = %#v, %v", applied, err)
+	}
+	refreshed, exists, err := readJournal(lifecycle.Paths.JournalFile)
+	if err != nil || !exists {
+		t.Fatalf("readJournal(refreshed) = %#v, %v", refreshed, err)
+	}
+	if refreshed.CatalogRevision != applied.CatalogRevision ||
+		refreshed.CatalogSourceVersion != applied.SourceRevision ||
+		refreshed.MappingRevision != applied.MappingRevision {
+		t.Fatalf("refreshed journal = %#v, want operation revisions %#v", refreshed, applied)
+	}
+	second, err := lifecycle.Sync(models, providers, true)
+	if err != nil || second.Changed || second.Applied {
+		t.Fatalf("second Sync() = %#v, %v", second, err)
+	}
+}
+
 func TestSetupRejectsUserOwnedRootKeys(t *testing.T) {
 	lifecycle := testLifecycle(t)
 	if err := os.MkdirAll(lifecycle.Paths.Home, 0o700); err != nil {

--- a/internal/codexintegration/config_test.go
+++ b/internal/codexintegration/config_test.go
@@ -158,27 +158,49 @@ func TestSetupRejectsUserOwnedRootKeys(t *testing.T) {
 }
 
 func TestSetupMigratesOnlyKnownOpenCodexMarker(t *testing.T) {
+	fixtures := map[string]string{
+		"marker before each key":            "# Auto-injected by opencodex\nopenai_base_url = \"http://127.0.0.1:10100/v1\"\n# Auto-injected by opencodex\nmodel_catalog_json = \"/tmp/opencodex-catalog.json\"\n\n[features]\nweb_search = true\n",
+		"catalog immediately before marker": "model_catalog_json = \"/tmp/opencodex-catalog.json\"\n# Auto-injected by opencodex\nopenai_base_url = \"http://127.0.0.1:10100/v1\"\n\n[features]\nweb_search = true\n",
+	}
+	for name, original := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			lifecycle := testLifecycle(t)
+			if err := os.MkdirAll(lifecycle.Paths.Home, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(lifecycle.Paths.ConfigFile, []byte(original), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			models, providers := catalogTestModels()
+			if _, err := lifecycle.Setup(models, providers, false, false); err == nil {
+				t.Fatal("normal Setup() accepted OpenCodex-owned root keys")
+			}
+			if _, err := lifecycle.Setup(models, providers, true, true); err != nil {
+				t.Fatalf("migration Setup() error = %v", err)
+			}
+			configured, err := os.ReadFile(lifecycle.Paths.ConfigFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Contains(configured, []byte("Auto-injected by opencodex")) || !bytes.Contains(configured, []byte(ManagedConfigBegin)) {
+				t.Fatalf("migration result = %s", configured)
+			}
+		})
+	}
+}
+
+func TestSetupMigrationPreservesUnknownCatalogAssignment(t *testing.T) {
 	lifecycle := testLifecycle(t)
 	if err := os.MkdirAll(lifecycle.Paths.Home, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	original := "# Auto-injected by opencodex\nopenai_base_url = \"http://127.0.0.1:10100/v1\"\n# Auto-injected by opencodex\nmodel_catalog_json = \"/tmp/opencodex-catalog.json\"\n\n[features]\nweb_search = true\n"
+	original := "model_catalog_json = \"/tmp/user-catalog.json\"\n# Auto-injected by opencodex\nopenai_base_url = \"http://127.0.0.1:10100/v1\"\n"
 	if err := os.WriteFile(lifecycle.Paths.ConfigFile, []byte(original), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	models, providers := catalogTestModels()
-	if _, err := lifecycle.Setup(models, providers, false, false); err == nil {
-		t.Fatal("normal Setup() accepted OpenCodex-owned root keys")
-	}
-	if _, err := lifecycle.Setup(models, providers, true, true); err != nil {
-		t.Fatalf("migration Setup() error = %v", err)
-	}
-	configured, err := os.ReadFile(lifecycle.Paths.ConfigFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if bytes.Contains(configured, []byte("Auto-injected by opencodex")) || !bytes.Contains(configured, []byte(ManagedConfigBegin)) {
-		t.Fatalf("migration result = %s", configured)
+	if _, err := lifecycle.Setup(models, providers, true, true); err == nil || !strings.Contains(err.Error(), "model_catalog_json") {
+		t.Fatalf("migration Setup() error = %v, want user-owned catalog conflict", err)
 	}
 }
 

--- a/internal/codexintegration/config_test.go
+++ b/internal/codexintegration/config_test.go
@@ -332,6 +332,24 @@ func TestSetupRejectsSymlinkAndHeldLock(t *testing.T) {
 		}
 	})
 
+	t.Run("journal symlink", func(t *testing.T) {
+		lifecycle := testLifecycle(t)
+		if err := os.MkdirAll(lifecycle.Paths.StateDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		target := filepath.Join(t.TempDir(), "journal.json")
+		if err := os.WriteFile(target, []byte(`{"version":1}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, lifecycle.Paths.JournalFile); err != nil {
+			t.Fatal(err)
+		}
+		models, providers := catalogTestModels()
+		if _, err := lifecycle.Setup(models, providers, true, false); err == nil || !strings.Contains(err.Error(), "symbolic link") {
+			t.Fatalf("Setup() error = %v, want journal symlink rejection", err)
+		}
+	})
+
 	t.Run("held lock", func(t *testing.T) {
 		lifecycle := testLifecycle(t)
 		if err := os.MkdirAll(lifecycle.Paths.Home, 0o700); err != nil {
@@ -345,6 +363,110 @@ func TestSetupRejectsSymlinkAndHeldLock(t *testing.T) {
 			t.Fatalf("Setup() error = %v, want lock rejection", err)
 		}
 	})
+}
+
+func TestFileSnapshotRollbackRestoresExistingAndRemovesNewFiles(t *testing.T) {
+	dir := t.TempDir()
+	existingPath := filepath.Join(dir, "existing")
+	newPath := filepath.Join(dir, "new")
+	if err := os.WriteFile(existingPath, []byte("before"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	existing, err := snapshotRegularFile(existingPath, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	missing, err := snapshotRegularFile(newPath, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = os.WriteFile(existingPath, []byte("after"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err = os.WriteFile(newPath, []byte("created"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err = restoreFileSnapshot(existingPath, existing); err != nil {
+		t.Fatal(err)
+	}
+	if err = restoreFileSnapshot(newPath, missing); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(existingPath)
+	if err != nil || string(data) != "before" {
+		t.Fatalf("restored existing = %q, %v", data, err)
+	}
+	info, err := os.Stat(existingPath)
+	if err != nil || info.Mode().Perm() != 0o640 {
+		t.Fatalf("restored mode = %v, %v", info, err)
+	}
+	if _, err = os.Stat(newPath); !os.IsNotExist(err) {
+		t.Fatalf("new file survived rollback: %v", err)
+	}
+}
+
+func TestApplySetupRollsBackWhenFinalJournalWriteFails(t *testing.T) {
+	lifecycle := testLifecycle(t)
+	models, providers := catalogTestModels()
+	plan, err := lifecycle.prepareSetup(models, providers, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = lifecycle.ensureWritePaths(); err != nil {
+		t.Fatal(err)
+	}
+	lifecycle.Paths.JournalFile = filepath.Join(lifecycle.Paths.Home, "missing", "journal.json")
+	var result OperationResult
+	if err = lifecycle.applySetup(plan, &result); err == nil {
+		t.Fatal("applySetup() error = nil, want journal write failure")
+	}
+	for _, path := range []string{lifecycle.Paths.ConfigFile, lifecycle.Paths.CatalogFile} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("transaction left %s behind: %v", path, statErr)
+		}
+	}
+}
+
+func TestApplyRestoreRollsBackWhenCatalogMoveFails(t *testing.T) {
+	lifecycle := testLifecycle(t)
+	models, providers := catalogTestModels()
+	if _, err := lifecycle.Setup(models, providers, true, false); err != nil {
+		t.Fatal(err)
+	}
+	configBefore, err := os.ReadFile(lifecycle.Paths.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalogBefore, err := os.ReadFile(lifecycle.Paths.CatalogFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	journalBefore, err := os.ReadFile(lifecycle.Paths.JournalFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := lifecycle.prepareRestore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	blockedBackupPath := filepath.Join(lifecycle.Paths.Home, "blocked-backups")
+	if err = os.WriteFile(blockedBackupPath, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lifecycle.Paths.BackupDir = blockedBackupPath
+	if err = lifecycle.applyRestore(plan); err == nil {
+		t.Fatal("applyRestore() error = nil, want catalog move failure")
+	}
+	for path, want := range map[string][]byte{
+		lifecycle.Paths.ConfigFile:  configBefore,
+		lifecycle.Paths.CatalogFile: catalogBefore,
+		lifecycle.Paths.JournalFile: journalBefore,
+	} {
+		got, readErr := os.ReadFile(path)
+		if readErr != nil || !bytes.Equal(got, want) {
+			t.Fatalf("rollback mismatch for %s: %q, %v", path, got, readErr)
+		}
+	}
 }
 
 func TestSetupCompileFailureLeavesHomeUntouched(t *testing.T) {

--- a/internal/codexintegration/config_test.go
+++ b/internal/codexintegration/config_test.go
@@ -1,0 +1,315 @@
+package codexintegration
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestSetupPreviewDoesNotWrite(t *testing.T) {
+	lifecycle := testLifecycle(t)
+	models, providers := catalogTestModels()
+	result, err := lifecycle.Setup(models, providers, false, false)
+	if err != nil {
+		t.Fatalf("Setup(preview) error = %v", err)
+	}
+	if !result.Changed || result.Applied {
+		t.Fatalf("Setup(preview) result = %#v", result)
+	}
+	if _, err = os.Stat(lifecycle.Paths.ConfigFile); !os.IsNotExist(err) {
+		t.Fatalf("preview created config: %v", err)
+	}
+	if _, err = os.Stat(lifecycle.Paths.CatalogFile); !os.IsNotExist(err) {
+		t.Fatalf("preview created catalog: %v", err)
+	}
+}
+
+func TestSetupPreservesConfigShapeAndIsIdempotent(t *testing.T) {
+	fixtures := []struct {
+		name string
+		body string
+	}{
+		{name: "empty", body: ""},
+		{name: "comments and table", body: "# user comment\n\n[features]\nmulti_agent = true\n"},
+		{name: "CRLF", body: "# user comment\r\n\r\n[features]\r\nmulti_agent = true\r\n"},
+		{name: "multiple profiles", body: "[profiles.work]\nmodel = \"gpt-5.6-sol\"\n\n[features]\nweb_search = true\n"},
+	}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			lifecycle := testLifecycle(t)
+			if err := os.MkdirAll(lifecycle.Paths.Home, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(lifecycle.Paths.ConfigFile, []byte(fixture.body), 0o640); err != nil {
+				t.Fatal(err)
+			}
+			models, providers := catalogTestModels()
+			result, err := lifecycle.Setup(models, providers, true, false)
+			if err != nil {
+				t.Fatalf("Setup(apply) error = %v", err)
+			}
+			if !result.Applied || !result.RestartRequired {
+				t.Fatalf("Setup(apply) result = %#v", result)
+			}
+			configured, err := os.ReadFile(lifecycle.Paths.ConfigFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Contains(configured, []byte(ManagedConfigBegin)) || !bytes.Contains(configured, []byte(`openai_base_url = "http://127.0.0.1:8317/v1"`)) {
+				t.Fatalf("managed config missing: %s", configured)
+			}
+			if table := bytes.Index(configured, []byte("[features]")); table >= 0 && bytes.Index(configured, []byte(ManagedConfigBegin)) > table {
+				t.Fatalf("managed root keys inserted after table: %s", configured)
+			}
+			if strings.Contains(fixture.body, "\r\n") && bytes.Contains(configured, []byte("\n")) && !bytes.Contains(configured, []byte("\r\n")) {
+				t.Fatal("CRLF style was not preserved")
+			}
+			info, err := os.Stat(lifecycle.Paths.ConfigFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.Mode().Perm() != 0o640 {
+				t.Fatalf("config mode = %o, want 640", info.Mode().Perm())
+			}
+			catalogData, err := os.ReadFile(lifecycle.Paths.CatalogFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err = registry.ValidateCodexClientModelsJSON(catalogData); err != nil {
+				t.Fatalf("written catalog invalid: %v", err)
+			}
+
+			second, err := lifecycle.Setup(models, providers, true, false)
+			if err != nil {
+				t.Fatalf("second Setup() error = %v", err)
+			}
+			if second.Changed || second.Applied {
+				t.Fatalf("second Setup() not idempotent: %#v", second)
+			}
+		})
+	}
+}
+
+func TestSetupRejectsUserOwnedRootKeys(t *testing.T) {
+	lifecycle := testLifecycle(t)
+	if err := os.MkdirAll(lifecycle.Paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lifecycle.Paths.ConfigFile, []byte("openai_base_url = \"https://gateway.example/v1\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	models, providers := catalogTestModels()
+	if _, err := lifecycle.Setup(models, providers, true, false); err == nil || !strings.Contains(err.Error(), "openai_base_url") {
+		t.Fatalf("Setup() error = %v, want ownership conflict", err)
+	}
+	if _, err := os.Stat(lifecycle.Paths.JournalFile); !os.IsNotExist(err) {
+		t.Fatalf("conflict wrote journal: %v", err)
+	}
+}
+
+func TestSetupMigratesOnlyKnownOpenCodexMarker(t *testing.T) {
+	lifecycle := testLifecycle(t)
+	if err := os.MkdirAll(lifecycle.Paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	original := "# Auto-injected by opencodex\nopenai_base_url = \"http://127.0.0.1:10100/v1\"\n# Auto-injected by opencodex\nmodel_catalog_json = \"/tmp/opencodex-catalog.json\"\n\n[features]\nweb_search = true\n"
+	if err := os.WriteFile(lifecycle.Paths.ConfigFile, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	models, providers := catalogTestModels()
+	if _, err := lifecycle.Setup(models, providers, false, false); err == nil {
+		t.Fatal("normal Setup() accepted OpenCodex-owned root keys")
+	}
+	if _, err := lifecycle.Setup(models, providers, true, true); err != nil {
+		t.Fatalf("migration Setup() error = %v", err)
+	}
+	configured, err := os.ReadFile(lifecycle.Paths.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(configured, []byte("Auto-injected by opencodex")) || !bytes.Contains(configured, []byte(ManagedConfigBegin)) {
+		t.Fatalf("migration result = %s", configured)
+	}
+}
+
+func TestRestorePreservesPostSetupUserChanges(t *testing.T) {
+	lifecycle := testLifecycle(t)
+	models, providers := catalogTestModels()
+	if _, err := lifecycle.Setup(models, providers, true, false); err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+	configured, err := os.ReadFile(lifecycle.Paths.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configured = append(configured, []byte("\n[features]\nweb_search = true\n")...)
+	if err = os.WriteFile(lifecycle.Paths.ConfigFile, configured, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	preview, err := lifecycle.Restore(false)
+	if err != nil {
+		t.Fatalf("Restore(preview) error = %v", err)
+	}
+	if !preview.Changed || preview.Applied {
+		t.Fatalf("Restore(preview) = %#v", preview)
+	}
+	if _, err = lifecycle.Restore(true); err != nil {
+		t.Fatalf("Restore(apply) error = %v", err)
+	}
+	restored, err := os.ReadFile(lifecycle.Paths.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(restored, []byte(ManagedConfigBegin)) || !bytes.Contains(restored, []byte("web_search = true")) {
+		t.Fatalf("Restore() result = %s", restored)
+	}
+	if _, err = os.Stat(lifecycle.Paths.CatalogFile); !os.IsNotExist(err) {
+		t.Fatalf("Restore() left catalog: %v", err)
+	}
+	second, err := lifecycle.Restore(true)
+	if err != nil || second.Changed || second.Applied {
+		t.Fatalf("second Restore() = %#v, %v", second, err)
+	}
+}
+
+func TestRestoreReinstatesPreexistingCatalogAndIsIdempotent(t *testing.T) {
+	lifecycle := testLifecycle(t)
+	if err := os.MkdirAll(lifecycle.Paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	originalConfig := []byte("# original\n[features]\nweb_search = true\n")
+	originalCatalog := []byte("user-owned catalog bytes\n")
+	if err := os.WriteFile(lifecycle.Paths.ConfigFile, originalConfig, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lifecycle.Paths.CatalogFile, originalCatalog, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	models, providers := catalogTestModels()
+	if _, err := lifecycle.Setup(models, providers, true, false); err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+	if _, err := lifecycle.Restore(true); err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+	restoredConfig, err := os.ReadFile(lifecycle.Paths.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restoredCatalog, err := os.ReadFile(lifecycle.Paths.CatalogFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(restoredConfig, originalConfig) || !bytes.Equal(restoredCatalog, originalCatalog) {
+		t.Fatalf("restore mismatch: config=%q catalog=%q", restoredConfig, restoredCatalog)
+	}
+	second, err := lifecycle.Restore(true)
+	if err != nil || second.Changed || second.Applied {
+		t.Fatalf("second Restore() = %#v, %v", second, err)
+	}
+}
+
+func TestResolvePathsPrecedence(t *testing.T) {
+	integration := config.DefaultCodexIntegrationConfig()
+	integration.CodexHome = filepath.Join(t.TempDir(), "configured")
+	environmentHome := filepath.Join(t.TempDir(), "environment")
+	explicitHome := filepath.Join(t.TempDir(), "explicit")
+	t.Setenv("CODEX_HOME", environmentHome)
+
+	paths, err := ResolvePaths(explicitHome, integration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if paths.Home != explicitHome {
+		t.Fatalf("explicit home = %q, want %q", paths.Home, explicitHome)
+	}
+	paths, err = ResolvePaths("", integration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if paths.Home != integration.CodexHome {
+		t.Fatalf("configured home = %q, want %q", paths.Home, integration.CodexHome)
+	}
+	integration.CodexHome = ""
+	paths, err = ResolvePaths("", integration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if paths.Home != environmentHome {
+		t.Fatalf("environment home = %q, want %q", paths.Home, environmentHome)
+	}
+}
+
+func TestSetupRejectsSymlinkAndHeldLock(t *testing.T) {
+	t.Run("symlink", func(t *testing.T) {
+		lifecycle := testLifecycle(t)
+		if err := os.MkdirAll(lifecycle.Paths.Home, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		target := filepath.Join(t.TempDir(), "outside.toml")
+		if err := os.WriteFile(target, []byte(""), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, lifecycle.Paths.ConfigFile); err != nil {
+			t.Fatal(err)
+		}
+		models, providers := catalogTestModels()
+		if _, err := lifecycle.Setup(models, providers, true, false); err == nil || !strings.Contains(err.Error(), "symbolic link") {
+			t.Fatalf("Setup() error = %v, want symlink rejection", err)
+		}
+	})
+
+	t.Run("held lock", func(t *testing.T) {
+		lifecycle := testLifecycle(t)
+		if err := os.MkdirAll(lifecycle.Paths.Home, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(lifecycle.Paths.LockFile, []byte("held"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		models, providers := catalogTestModels()
+		if _, err := lifecycle.Setup(models, providers, true, false); err == nil || !strings.Contains(err.Error(), "lock") {
+			t.Fatalf("Setup() error = %v, want lock rejection", err)
+		}
+	})
+}
+
+func TestSetupCompileFailureLeavesHomeUntouched(t *testing.T) {
+	lifecycle := testLifecycle(t)
+	models, providers := catalogTestModels()
+	filtered := models[:0]
+	for _, model := range models {
+		if catalogString(model, "id") != "gemini-pro-agent" {
+			filtered = append(filtered, model)
+		}
+	}
+	if _, err := lifecycle.Setup(filtered, providers, true, false); err == nil {
+		t.Fatal("Setup() error = nil, want compile failure")
+	}
+	if _, err := os.Stat(lifecycle.Paths.Home); !os.IsNotExist(err) {
+		t.Fatalf("compile failure touched home: %v", err)
+	}
+}
+
+func testLifecycle(t *testing.T) *Lifecycle {
+	t.Helper()
+	integration := config.DefaultCodexIntegrationConfig()
+	integration.Enabled = true
+	cfg := &config.Config{
+		SDKConfig: config.SDKConfig{CodexIntegration: integration},
+		Host:      "127.0.0.1",
+		Port:      8317,
+	}
+	lifecycle, err := NewLifecycle(cfg, filepath.Join(t.TempDir(), "codex-home"))
+	if err != nil {
+		t.Fatalf("NewLifecycle() error = %v", err)
+	}
+	return lifecycle
+}

--- a/internal/codexintegration/doctor.go
+++ b/internal/codexintegration/doctor.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
@@ -91,7 +92,7 @@ func RunDoctor(ctx context.Context, lifecycle *Lifecycle, models []map[string]an
 		}
 	}
 	if options.ProbeModels {
-		addModelProbes(ctx, lifecycle, options.HTTPClient, add)
+		addModelProbes(ctx, lifecycle, models, providers, options.HTTPClient, add)
 	}
 
 	report := DoctorReport{SchemaVersion: 1, Checks: checks}
@@ -131,7 +132,19 @@ func addConfigChecks(lifecycle *Lifecycle, checks *[]DoctorCheck, add func(strin
 	if strings.Contains(normalized, openCodexMarker) {
 		add("config", "config.opencodex_marker", DoctorWarning, "Codex config still contains an OpenCodex injection marker.", "Use -codex-setup -codex-migrate-opencodex -apply during the migration window.")
 	}
+	if provider := codexModelProvider(data); provider != "" && provider != "openai" {
+		add("config", "config.model_provider_preserved", DoctorInfo, "Codex uses the existing model provider identity "+provider+".", "Keep this provider identity when it anchors existing task history; CLIProxyAPI does not rewrite model_provider.")
+	}
 	_ = checks
+}
+
+func codexModelProvider(data []byte) string {
+	var document map[string]any
+	if toml.Unmarshal(data, &document) != nil {
+		return ""
+	}
+	provider, _ := document["model_provider"].(string)
+	return strings.ToLower(strings.TrimSpace(provider))
 }
 
 func addListenerChecks(ctx context.Context, lifecycle *Lifecycle, options DoctorOptions, add func(string, string, DoctorSeverity, string, string)) {
@@ -166,7 +179,7 @@ func addCatalogChecks(lifecycle *Lifecycle, models []map[string]any, providers M
 		return
 	}
 	if !hasExpectedFeaturedModels(data, lifecycle.Config.CodexIntegration) {
-		add("catalog", "catalog.featured_mismatch", DoctorBlocking, "The catalog does not contain the required five featured models in order.", "Run -codex-sync after all mapped upstream models are available.")
+		add("catalog", "catalog.featured_mismatch", DoctorBlocking, "The catalog does not contain the configured featured models in order.", "Run -codex-sync after all mapped upstream models are available.")
 		return
 	}
 	expected, compileErr := CompileCatalog(models, providers, lifecycle.Config.CodexIntegration)
@@ -190,25 +203,23 @@ func hasExpectedFeaturedModels(data []byte, integration config.CodexIntegrationC
 	var payload struct {
 		Models []map[string]any `json:"models"`
 	}
-	if json.Unmarshal(data, &payload) != nil || len(payload.Models) < 5 {
+	featured := featuredCodexIntegrationModels(integration)
+	if json.Unmarshal(data, &payload) != nil || len(payload.Models) < 1+len(featured) {
 		return false
 	}
-	want := []string{"gpt-5.6-sol"}
-	featured := make([]config.CodexIntegrationModel, 0, 4)
+	configuredSlugs := make(map[string]struct{}, len(integration.Models))
 	for _, model := range integration.Models {
-		if model.Visible && model.Featured {
-			featured = append(featured, model)
-		}
+		configuredSlugs[model.Slug] = struct{}{}
 	}
-	sortCodexIntegrationModels(featured)
-	for _, model := range featured {
-		want = append(want, model.Slug)
-	}
-	if len(want) != 5 {
+	first, _ := payload.Models[0]["slug"].(string)
+	if first == "" {
 		return false
 	}
-	for index, slug := range want {
-		if current, _ := payload.Models[index]["slug"].(string); current != slug {
+	if _, configured := configuredSlugs[first]; configured {
+		return false
+	}
+	for index, model := range featured {
+		if current, _ := payload.Models[index+1]["slug"].(string); current != model.Slug {
 			return false
 		}
 	}
@@ -247,12 +258,7 @@ func addAuthChecks(lifecycle *Lifecycle, add func(string, string, DoctorSeverity
 			required[mapping.Provider] = true
 		}
 	}
-	if len(lifecycle.Config.CodexKey) > 0 {
-		providers["codex"]++
-	}
-	if len(lifecycle.Config.XAIKey) > 0 {
-		providers["xai"]++
-	}
+	addConfiguredCredentialProviders(lifecycle.Config, providers)
 	names := make([]string, 0, len(required))
 	for provider := range required {
 		names = append(names, provider)
@@ -263,6 +269,37 @@ func addAuthChecks(lifecycle *Lifecycle, add func(string, string, DoctorSeverity
 			add("oauth", "oauth."+provider+"_missing", DoctorBlocking, "No credential metadata was found for provider "+provider+".", "Log in to "+provider+" through CLIProxyAPI, then rerun doctor.")
 		} else {
 			add("oauth", "oauth."+provider+"_present", DoctorInfo, "Credential metadata is present for provider "+provider+".", "")
+		}
+	}
+}
+
+func addConfiguredCredentialProviders(cfg *config.Config, providers map[string]int) {
+	if cfg == nil {
+		return
+	}
+	for _, entry := range cfg.CodexKey {
+		if strings.TrimSpace(entry.APIKey) != "" {
+			providers["codex"]++
+		}
+	}
+	for _, entry := range cfg.XAIKey {
+		if strings.TrimSpace(entry.APIKey) != "" {
+			providers["xai"]++
+		}
+	}
+	for _, entry := range cfg.GeminiKey {
+		if strings.TrimSpace(entry.APIKey) != "" {
+			providers["gemini"]++
+		}
+	}
+	for _, entry := range cfg.ClaudeKey {
+		if strings.TrimSpace(entry.APIKey) != "" {
+			providers["claude"]++
+		}
+	}
+	for _, entry := range cfg.VertexCompatAPIKey {
+		if strings.TrimSpace(entry.APIKey) != "" {
+			providers["vertex"]++
 		}
 	}
 }
@@ -352,13 +389,8 @@ func addEndpointCheck(ctx context.Context, lifecycle *Lifecycle, client *http.Cl
 	add("endpoint", "endpoint.models_ready", DoctorInfo, "The local /v1/models endpoint accepts loopback bearer access.", "")
 }
 
-func addModelProbes(ctx context.Context, lifecycle *Lifecycle, client *http.Client, add func(string, string, DoctorSeverity, string, string)) {
-	targets := []string{"gpt-5.6-sol"}
-	for _, mapping := range lifecycle.Config.CodexIntegration.Models {
-		if mapping.Featured && mapping.Visible {
-			targets = append(targets, mapping.Slug)
-		}
-	}
+func addModelProbes(ctx context.Context, lifecycle *Lifecycle, models []map[string]any, providers ModelProvidersFunc, client *http.Client, add func(string, string, DoctorSeverity, string, string)) {
+	targets := modelProbeTargets(lifecycle, models, providers)
 	for _, model := range targets {
 		payload, _ := json.Marshal(map[string]any{
 			"model": model, "input": "Reply with OK.", "max_output_tokens": 16, "stream": false,
@@ -373,6 +405,23 @@ func addModelProbes(ctx context.Context, lifecycle *Lifecycle, client *http.Clie
 			add("probe", "probe."+codeModel+".ready", DoctorInfo, "The explicit model probe succeeded for "+model+".", "")
 		}
 	}
+}
+
+func modelProbeTargets(lifecycle *Lifecycle, models []map[string]any, providers ModelProvidersFunc) []string {
+	targets := make([]string, 0, 5)
+	officialOnly := lifecycle.Config.CodexIntegration
+	officialOnly.Enabled = false
+	if catalog, err := CompileCatalog(models, providers, officialOnly); err == nil {
+		if official := selectOfficialFeaturedModel(catalog.Models); official != "" {
+			targets = append(targets, official)
+		}
+	}
+	for _, mapping := range lifecycle.Config.CodexIntegration.Models {
+		if mapping.Featured && mapping.Visible {
+			targets = append(targets, mapping.Slug)
+		}
+	}
+	return targets
 }
 
 func endpointRequest(ctx context.Context, client *http.Client, method, url string, body []byte) (int, error) {

--- a/internal/codexintegration/doctor.go
+++ b/internal/codexintegration/doctor.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
 
@@ -164,7 +165,7 @@ func addCatalogChecks(lifecycle *Lifecycle, models []map[string]any, providers M
 		add("catalog", "catalog.invalid", DoctorBlocking, "The managed model catalog is invalid.", "Run -codex-sync; if it fails, keep the last-good catalog and inspect logs.")
 		return
 	}
-	if !hasExpectedFeaturedModels(data) {
+	if !hasExpectedFeaturedModels(data, lifecycle.Config.CodexIntegration) {
 		add("catalog", "catalog.featured_mismatch", DoctorBlocking, "The catalog does not contain the required five featured models in order.", "Run -codex-sync after all mapped upstream models are available.")
 		return
 	}
@@ -185,19 +186,26 @@ func addCatalogChecks(lifecycle *Lifecycle, models []map[string]any, providers M
 	}
 }
 
-func hasExpectedFeaturedModels(data []byte) bool {
+func hasExpectedFeaturedModels(data []byte, integration config.CodexIntegrationConfig) bool {
 	var payload struct {
 		Models []map[string]any `json:"models"`
 	}
 	if json.Unmarshal(data, &payload) != nil || len(payload.Models) < 5 {
 		return false
 	}
-	want := []string{
-		"gpt-5.6-sol",
-		"xai/grok-4.5",
-		"antigravity/gemini-3.6-flash",
-		"antigravity/gemini-3.1-pro",
-		"antigravity/claude-opus-4-6-thinking",
+	want := []string{"gpt-5.6-sol"}
+	featured := make([]config.CodexIntegrationModel, 0, 4)
+	for _, model := range integration.Models {
+		if model.Visible && model.Featured {
+			featured = append(featured, model)
+		}
+	}
+	sortCodexIntegrationModels(featured)
+	for _, model := range featured {
+		want = append(want, model.Slug)
+	}
+	if len(want) != 5 {
+		return false
 	}
 	for index, slug := range want {
 		if current, _ := payload.Models[index]["slug"].(string); current != slug {

--- a/internal/codexintegration/doctor.go
+++ b/internal/codexintegration/doctor.go
@@ -1,0 +1,429 @@
+package codexintegration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+// DoctorSeverity controls both human display and process exit status.
+type DoctorSeverity string
+
+const (
+	DoctorInfo     DoctorSeverity = "info"
+	DoctorWarning  DoctorSeverity = "warning"
+	DoctorBlocking DoctorSeverity = "blocking"
+)
+
+// DoctorCheck is a stable, actionable diagnostic item.
+type DoctorCheck struct {
+	Layer       string         `json:"layer"`
+	Code        string         `json:"code"`
+	Severity    DoctorSeverity `json:"severity"`
+	Message     string         `json:"message"`
+	Remediation string         `json:"remediation,omitempty"`
+}
+
+// DoctorReport is the machine-readable doctor result.
+type DoctorReport struct {
+	SchemaVersion int           `json:"schema_version"`
+	Status        string        `json:"status"`
+	Checks        []DoctorCheck `json:"checks"`
+}
+
+// ExitCode returns 0 for clean, 1 for warning, and 2 for blocking reports.
+func (report DoctorReport) ExitCode() int {
+	exitCode := 0
+	for _, check := range report.Checks {
+		switch check.Severity {
+		case DoctorBlocking:
+			return 2
+		case DoctorWarning:
+			exitCode = 1
+		}
+	}
+	return exitCode
+}
+
+// DoctorOptions controls local endpoint and explicit upstream probes.
+type DoctorOptions struct {
+	ProbeModels        bool
+	HTTPClient         *http.Client
+	OpenCodexAddress   string
+	SkipOpenCodexCheck bool
+}
+
+// RunDoctor performs read-only checks. Upstream requests require ProbeModels.
+func RunDoctor(ctx context.Context, lifecycle *Lifecycle, models []map[string]any, providers ModelProvidersFunc, options DoctorOptions) DoctorReport {
+	checks := make([]DoctorCheck, 0, 24)
+	add := func(layer, code string, severity DoctorSeverity, message, remediation string) {
+		checks = append(checks, DoctorCheck{Layer: layer, Code: code, Severity: severity, Message: message, Remediation: remediation})
+	}
+
+	addConfigChecks(lifecycle, &checks, add)
+	addListenerChecks(ctx, lifecycle, options, add)
+	addCatalogChecks(lifecycle, models, providers, add)
+	addCacheChecks(lifecycle, add)
+	addAuthChecks(lifecycle, add)
+	addEndpointCheck(ctx, lifecycle, options.HTTPClient, add)
+	if !options.SkipOpenCodexCheck {
+		address := strings.TrimSpace(options.OpenCodexAddress)
+		if address == "" {
+			address = "127.0.0.1:10100"
+		}
+		if canDial(ctx, address, 300*time.Millisecond) {
+			add("process", "opencodex.listener_detected", DoctorWarning, "A listener is active on the default OpenCodex port.", "Stop OpenCodex after CLIProxyAPI cutover is verified.")
+		} else {
+			add("process", "opencodex.listener_absent", DoctorInfo, "No listener is active on the default OpenCodex port.", "")
+		}
+	}
+	if options.ProbeModels {
+		addModelProbes(ctx, lifecycle, options.HTTPClient, add)
+	}
+
+	report := DoctorReport{SchemaVersion: 1, Checks: checks}
+	switch report.ExitCode() {
+	case 0:
+		report.Status = "clean"
+	case 1:
+		report.Status = "warning"
+	default:
+		report.Status = "blocking"
+	}
+	return report
+}
+
+func addConfigChecks(lifecycle *Lifecycle, checks *[]DoctorCheck, add func(string, string, DoctorSeverity, string, string)) {
+	data, mode, exists, err := readRegularFile(lifecycle.Paths.ConfigFile, 0o600)
+	if err != nil {
+		add("config", "config.unreadable", DoctorBlocking, "Codex config cannot be read safely.", "Remove symlinks or repair file permissions, then rerun doctor.")
+		return
+	}
+	if !exists {
+		add("config", "config.missing", DoctorBlocking, "Codex config is missing.", "Run -codex-setup, review the preview, then rerun with -apply.")
+		return
+	}
+	if mode.Perm()&0o077 != 0 {
+		add("config", "config.permissions", DoctorWarning, "Codex config is readable by group or other users.", "Restrict the file permissions to the previous mode or 0600.")
+	}
+	normalized := strings.ReplaceAll(string(data), "\r\n", "\n")
+	_, managed, markerErr := removeManagedBlock(normalized)
+	if markerErr != nil {
+		add("config", "config.marker_malformed", DoctorBlocking, "The CLIProxyAPI managed marker block is malformed.", "Restore the marker pair from backup before setup or restore.")
+	} else if managed {
+		add("config", "config.managed", DoctorInfo, "Codex config contains the CLIProxyAPI managed root block.", "")
+	} else {
+		add("config", "config.unmanaged", DoctorBlocking, "Codex config is not managed by CLIProxyAPI.", "Run -codex-setup and apply the reviewed change.")
+	}
+	if strings.Contains(normalized, openCodexMarker) {
+		add("config", "config.opencodex_marker", DoctorWarning, "Codex config still contains an OpenCodex injection marker.", "Use -codex-setup -codex-migrate-opencodex -apply during the migration window.")
+	}
+	_ = checks
+}
+
+func addListenerChecks(ctx context.Context, lifecycle *Lifecycle, options DoctorOptions, add func(string, string, DoctorSeverity, string, string)) {
+	if !lifecycle.Config.CodexIntegration.LoopbackAccess {
+		add("access", "access.loopback_disabled", DoctorBlocking, "Loopback bearer access is disabled.", "Set codex-integration.loopback-access to true.")
+	} else {
+		add("access", "access.loopback_enabled", DoctorInfo, "Loopback bearer access is enabled for data-plane routes.", "")
+	}
+	address := net.JoinHostPort(strings.Trim(lifecycle.Config.Host, "[]"), fmt.Sprintf("%d", lifecycle.Config.Port))
+	if canDial(ctx, address, 500*time.Millisecond) {
+		add("listener", "listener.ready", DoctorInfo, "CLIProxyAPI is accepting loopback connections.", "")
+	} else {
+		add("listener", "listener.unavailable", DoctorBlocking, "CLIProxyAPI is not accepting connections at the configured loopback address.", "Start or restart CLIProxyAPI with the integration-enabled config.")
+	}
+}
+
+func addCatalogChecks(lifecycle *Lifecycle, models []map[string]any, providers ModelProvidersFunc, add func(string, string, DoctorSeverity, string, string)) {
+	data, mode, exists, err := readRegularFile(lifecycle.Paths.CatalogFile, 0o600)
+	if err != nil {
+		add("catalog", "catalog.unreadable", DoctorBlocking, "The managed model catalog cannot be read safely.", "Remove symlinks or repair permissions, then run -codex-sync.")
+		return
+	}
+	if !exists {
+		add("catalog", "catalog.missing", DoctorBlocking, "The managed model catalog is missing.", "Run -codex-setup -apply.")
+		return
+	}
+	if mode.Perm()&0o077 != 0 {
+		add("catalog", "catalog.permissions", DoctorWarning, "The managed catalog is readable by group or other users.", "Restrict catalog permissions to 0600.")
+	}
+	if err = registry.ValidateCodexClientModelsJSON(data); err != nil {
+		add("catalog", "catalog.invalid", DoctorBlocking, "The managed model catalog is invalid.", "Run -codex-sync; if it fails, keep the last-good catalog and inspect logs.")
+		return
+	}
+	if !hasExpectedFeaturedModels(data) {
+		add("catalog", "catalog.featured_mismatch", DoctorBlocking, "The catalog does not contain the required five featured models in order.", "Run -codex-sync after all mapped upstream models are available.")
+		return
+	}
+	expected, compileErr := CompileCatalog(models, providers, lifecycle.Config.CodexIntegration)
+	if compileErr != nil {
+		add("catalog", "catalog.source_unavailable", DoctorBlocking, "At least one configured upstream model is unavailable from the current model source.", "Start CLIProxyAPI, verify provider credentials and model IDs, then rerun doctor.")
+		return
+	}
+	expectedData, marshalErr := expected.Marshal()
+	if marshalErr != nil {
+		add("catalog", "catalog.compile_failed", DoctorBlocking, "The expected catalog could not be encoded.", "Inspect CLIProxyAPI logs and configuration.")
+		return
+	}
+	if !bytes.Equal(data, expectedData) {
+		add("catalog", "catalog.stale", DoctorWarning, "The managed catalog differs from the current model and mapping revisions.", "Run -codex-sync, review the preview, then apply it.")
+	} else {
+		add("catalog", "catalog.current", DoctorInfo, "The managed catalog matches the current model and mapping revisions.", "")
+	}
+}
+
+func hasExpectedFeaturedModels(data []byte) bool {
+	var payload struct {
+		Models []map[string]any `json:"models"`
+	}
+	if json.Unmarshal(data, &payload) != nil || len(payload.Models) < 5 {
+		return false
+	}
+	want := []string{
+		"gpt-5.6-sol",
+		"xai/grok-4.5",
+		"antigravity/gemini-3.6-flash",
+		"antigravity/gemini-3.1-pro",
+		"antigravity/claude-opus-4-6-thinking",
+	}
+	for index, slug := range want {
+		if current, _ := payload.Models[index]["slug"].(string); current != slug {
+			return false
+		}
+	}
+	return true
+}
+
+func addCacheChecks(lifecycle *Lifecycle, add func(string, string, DoctorSeverity, string, string)) {
+	cacheInfo, cacheErr := os.Lstat(lifecycle.Paths.CacheFile)
+	if os.IsNotExist(cacheErr) {
+		add("cache", "cache.absent", DoctorInfo, "Codex has no model cache file; it will rebuild it on launch.", "")
+		return
+	}
+	if cacheErr != nil || cacheInfo.Mode()&os.ModeSymlink != 0 {
+		add("cache", "cache.unsafe", DoctorBlocking, "The Codex model cache path is unsafe or unreadable.", "Remove the cache symlink or repair the path before restarting Codex.")
+		return
+	}
+	catalogInfo, err := os.Stat(lifecycle.Paths.CatalogFile)
+	if err == nil && cacheInfo.ModTime().Before(catalogInfo.ModTime()) {
+		add("cache", "cache.restart_required", DoctorWarning, "The Codex model cache predates the managed catalog.", "Restart Codex to rebuild the model picker cache.")
+	} else {
+		add("cache", "cache.current", DoctorInfo, "The Codex model cache is newer than the managed catalog.", "")
+	}
+}
+
+func addAuthChecks(lifecycle *Lifecycle, add func(string, string, DoctorSeverity, string, string)) {
+	providers, warnings, blocking := scanAuthProviders(lifecycle.Config.AuthDir)
+	for _, message := range blocking {
+		add("oauth", "oauth.storage_unsafe", DoctorBlocking, message, "Repair auth directory ownership, permissions, or symlinks; do not copy token contents into logs.")
+	}
+	for _, message := range warnings {
+		add("oauth", "oauth.storage_warning", DoctorWarning, message, "Restrict credential file permissions to 0600.")
+	}
+	required := map[string]bool{"codex": true}
+	for _, mapping := range lifecycle.Config.CodexIntegration.Models {
+		if mapping.Visible {
+			required[mapping.Provider] = true
+		}
+	}
+	if len(lifecycle.Config.CodexKey) > 0 {
+		providers["codex"]++
+	}
+	if len(lifecycle.Config.XAIKey) > 0 {
+		providers["xai"]++
+	}
+	names := make([]string, 0, len(required))
+	for provider := range required {
+		names = append(names, provider)
+	}
+	sort.Strings(names)
+	for _, provider := range names {
+		if providers[provider] == 0 {
+			add("oauth", "oauth."+provider+"_missing", DoctorBlocking, "No credential metadata was found for provider "+provider+".", "Log in to "+provider+" through CLIProxyAPI, then rerun doctor.")
+		} else {
+			add("oauth", "oauth."+provider+"_present", DoctorInfo, "Credential metadata is present for provider "+provider+".", "")
+		}
+	}
+}
+
+func scanAuthProviders(authDir string) (map[string]int, []string, []string) {
+	providers := make(map[string]int)
+	entries, err := os.ReadDir(authDir)
+	if err != nil {
+		return providers, nil, []string{"The auth directory cannot be read."}
+	}
+	dirInfo, err := os.Lstat(authDir)
+	if err != nil || dirInfo.Mode()&os.ModeSymlink != 0 {
+		return providers, nil, []string{"The auth directory is a symbolic link or cannot be inspected safely."}
+	}
+	dirOwner, hasDirOwner := numericOwner(dirInfo)
+	warnings := make([]string, 0)
+	blocking := make([]string, 0)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(strings.ToLower(entry.Name()), ".json") {
+			continue
+		}
+		path := filepath.Join(authDir, entry.Name())
+		info, statErr := os.Lstat(path)
+		if statErr != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			blocking = append(blocking, "An auth record is a symbolic link or non-regular file.")
+			continue
+		}
+		if owner, ok := numericOwner(info); hasDirOwner && ok && owner != dirOwner {
+			blocking = append(blocking, "An auth record has a different owner from the auth directory.")
+			continue
+		}
+		if info.Mode().Perm()&0o077 != 0 {
+			warnings = append(warnings, "An auth record is readable by group or other users.")
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			blocking = append(blocking, "An auth record cannot be read.")
+			continue
+		}
+		var metadata struct {
+			Type     string `json:"type"`
+			Provider string `json:"provider"`
+		}
+		if json.Unmarshal(data, &metadata) != nil {
+			warnings = append(warnings, "An auth record is not valid JSON metadata.")
+			continue
+		}
+		provider := strings.ToLower(strings.TrimSpace(metadata.Type))
+		if provider == "" {
+			provider = strings.ToLower(strings.TrimSpace(metadata.Provider))
+		}
+		if provider != "" {
+			providers[provider]++
+		}
+	}
+	return providers, deduplicateStrings(warnings), deduplicateStrings(blocking)
+}
+
+func numericOwner(info os.FileInfo) (uint64, bool) {
+	if info == nil || info.Sys() == nil {
+		return 0, false
+	}
+	value := reflect.ValueOf(info.Sys())
+	if value.Kind() == reflect.Pointer {
+		value = value.Elem()
+	}
+	if !value.IsValid() || value.Kind() != reflect.Struct {
+		return 0, false
+	}
+	uid := value.FieldByName("Uid")
+	if !uid.IsValid() || !uid.CanUint() {
+		return 0, false
+	}
+	return uid.Uint(), true
+}
+
+func addEndpointCheck(ctx context.Context, lifecycle *Lifecycle, client *http.Client, add func(string, string, DoctorSeverity, string, string)) {
+	status, err := endpointRequest(ctx, client, http.MethodGet, strings.TrimSuffix(lifecycle.baseURL(), "/")+"/models", nil)
+	if err != nil {
+		add("endpoint", "endpoint.models_unreachable", DoctorBlocking, "The local /v1/models endpoint is unreachable.", "Start CLIProxyAPI and verify the configured port.")
+		return
+	}
+	if status != http.StatusOK {
+		add("endpoint", "endpoint.models_rejected", DoctorBlocking, fmt.Sprintf("The local /v1/models endpoint returned HTTP %d.", status), "Verify loopback access is enabled and restart CLIProxyAPI.")
+		return
+	}
+	add("endpoint", "endpoint.models_ready", DoctorInfo, "The local /v1/models endpoint accepts loopback bearer access.", "")
+}
+
+func addModelProbes(ctx context.Context, lifecycle *Lifecycle, client *http.Client, add func(string, string, DoctorSeverity, string, string)) {
+	targets := []string{"gpt-5.6-sol"}
+	for _, mapping := range lifecycle.Config.CodexIntegration.Models {
+		if mapping.Featured && mapping.Visible {
+			targets = append(targets, mapping.Slug)
+		}
+	}
+	for _, model := range targets {
+		payload, _ := json.Marshal(map[string]any{
+			"model": model, "input": "Reply with OK.", "max_output_tokens": 16, "stream": false,
+		})
+		status, err := endpointRequest(ctx, client, http.MethodPost, strings.TrimSuffix(lifecycle.baseURL(), "/")+"/responses", payload)
+		codeModel := strings.NewReplacer("/", "_", ".", "_").Replace(model)
+		if err != nil {
+			add("probe", "probe."+codeModel+".timeout", DoctorBlocking, "The explicit model probe did not complete for "+model+".", "Check provider connectivity and retry the explicit probe.")
+		} else if status < 200 || status >= 300 {
+			add("probe", "probe."+codeModel+".failed", DoctorBlocking, fmt.Sprintf("The explicit model probe returned HTTP %d for %s.", status, model), "Refresh the provider credential or inspect quota and upstream status.")
+		} else {
+			add("probe", "probe."+codeModel+".ready", DoctorInfo, "The explicit model probe succeeded for "+model+".", "")
+		}
+	}
+}
+
+func endpointRequest(ctx context.Context, client *http.Client, method, url string, body []byte) (int, error) {
+	if client == nil {
+		client = &http.Client{Timeout: 20 * time.Second}
+	}
+	request, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(body))
+	if err != nil {
+		return 0, err
+	}
+	request.Header.Set("Authorization", "Bearer codex-doctor-local")
+	if len(body) > 0 {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return 0, err
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
+	_ = response.Body.Close()
+	return response.StatusCode, nil
+}
+
+func canDial(ctx context.Context, address string, timeout time.Duration) bool {
+	dialer := net.Dialer{Timeout: timeout}
+	connection, err := dialer.DialContext(ctx, "tcp", address)
+	if err != nil {
+		return false
+	}
+	_ = connection.Close()
+	return true
+}
+
+func deduplicateStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func writeDoctorText(output io.Writer, report DoctorReport) error {
+	if _, err := fmt.Fprintf(output, "Codex Integration doctor: %s\n", report.Status); err != nil {
+		return err
+	}
+	for _, check := range report.Checks {
+		if _, err := fmt.Fprintf(output, "[%s] %s: %s\n", check.Severity, check.Code, check.Message); err != nil {
+			return err
+		}
+		if check.Remediation != "" {
+			if _, err := fmt.Fprintf(output, "  fix: %s\n", check.Remediation); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/codexintegration/doctor_test.go
+++ b/internal/codexintegration/doctor_test.go
@@ -1,0 +1,204 @@
+package codexintegration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunDoctorCleanWithoutUpstreamProbes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/v1/models" {
+			t.Fatalf("unexpected request path %q", request.URL.Path)
+		}
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{"object":"list","data":[]}`))
+	}))
+	defer server.Close()
+
+	lifecycle := doctorLifecycle(t, server.URL)
+	writeDoctorCredentials(t, lifecycle.Config.AuthDir)
+	models, providers := catalogTestModels()
+	if _, err := lifecycle.Setup(models, providers, true, false); err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+	report := RunDoctor(context.Background(), lifecycle, models, providers, DoctorOptions{
+		HTTPClient:         server.Client(),
+		SkipOpenCodexCheck: true,
+	})
+	if report.Status != "clean" || report.ExitCode() != 0 {
+		t.Fatalf("RunDoctor() = %#v", report)
+	}
+	for _, check := range report.Checks {
+		if check.Layer == "probe" {
+			t.Fatalf("default doctor sent a model probe: %#v", check)
+		}
+	}
+}
+
+func TestRunDoctorClassifiesProbeFailureWithoutLeakingSecrets(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/v1/models" {
+			_, _ = response.Write([]byte(`{"object":"list","data":[]}`))
+			return
+		}
+		response.WriteHeader(http.StatusTooManyRequests)
+		_, _ = response.Write([]byte(`{"error":"token-secret user@example.com"}`))
+	}))
+	defer server.Close()
+
+	lifecycle := doctorLifecycle(t, server.URL)
+	writeDoctorCredentials(t, lifecycle.Config.AuthDir)
+	models, providers := catalogTestModels()
+	if _, err := lifecycle.Setup(models, providers, true, false); err != nil {
+		t.Fatal(err)
+	}
+	report := RunDoctor(context.Background(), lifecycle, models, providers, DoctorOptions{
+		ProbeModels:        true,
+		HTTPClient:         server.Client(),
+		SkipOpenCodexCheck: true,
+	})
+	if report.ExitCode() != 2 || report.Status != "blocking" {
+		t.Fatalf("RunDoctor() = %#v", report)
+	}
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte("token-secret")) || bytes.Contains(encoded, []byte("user@example.com")) {
+		t.Fatalf("doctor leaked sensitive response data: %s", encoded)
+	}
+}
+
+func TestRunDoctorReportsMissingProviderAndStaleCatalog(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		_, _ = response.Write([]byte(`{"object":"list","data":[]}`))
+	}))
+	defer server.Close()
+	lifecycle := doctorLifecycle(t, server.URL)
+	if err := os.MkdirAll(lifecycle.Config.AuthDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(lifecycle.Config.AuthDir, "codex.json"), []byte(`{"type":"codex"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	models, providers := catalogTestModels()
+	if _, err := lifecycle.Setup(models, providers, true, false); err != nil {
+		t.Fatal(err)
+	}
+	catalog, err := os.ReadFile(lifecycle.Paths.CatalogFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalog = bytes.Replace(catalog, []byte(`"display_name": "Grok 4.5"`), []byte(`"display_name": "Changed"`), 1)
+	if err = os.WriteFile(lifecycle.Paths.CatalogFile, catalog, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	report := RunDoctor(context.Background(), lifecycle, models, providers, DoctorOptions{
+		HTTPClient:         server.Client(),
+		SkipOpenCodexCheck: true,
+	})
+	if report.ExitCode() != 2 {
+		t.Fatalf("RunDoctor().ExitCode() = %d, want 2: %#v", report.ExitCode(), report)
+	}
+	if !doctorHasCode(report, "catalog.stale") || !doctorHasCode(report, "oauth.antigravity_missing") || !doctorHasCode(report, "oauth.xai_missing") {
+		t.Fatalf("missing expected checks: %#v", report.Checks)
+	}
+}
+
+func TestValidateCommandOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		options CommandOptions
+		wantErr bool
+	}{
+		{name: "setup", options: CommandOptions{Action: CommandSetup}},
+		{name: "doctor probe", options: CommandOptions{Action: CommandDoctor, ProbeModels: true}},
+		{name: "doctor apply", options: CommandOptions{Action: CommandDoctor, Apply: true}, wantErr: true},
+		{name: "setup probe", options: CommandOptions{Action: CommandSetup, ProbeModels: true}, wantErr: true},
+		{name: "sync migration", options: CommandOptions{Action: CommandSync, MigrateOpenCodex: true}, wantErr: true},
+		{name: "unknown", options: CommandOptions{Action: "unknown"}, wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateCommandOptions(test.options)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("ValidateCommandOptions() error = %v, wantErr %t", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestRunCommandSetupPreviewIsReadOnlyAndJSONStable(t *testing.T) {
+	models, _ := catalogTestModels()
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		_ = json.NewEncoder(response).Encode(map[string]any{"object": "list", "data": models})
+	}))
+	defer server.Close()
+	lifecycle := doctorLifecycle(t, server.URL)
+	var output bytes.Buffer
+	exitCode, err := RunCommand(context.Background(), lifecycle.Config, CommandOptions{
+		Action: CommandSetup, JSON: true, CodexHome: lifecycle.Paths.Home, HTTPClient: server.Client(),
+	}, &output)
+	if err != nil || exitCode != 0 {
+		t.Fatalf("RunCommand() = %d, %v", exitCode, err)
+	}
+	var envelope CommandOutput
+	if err = json.Unmarshal(output.Bytes(), &envelope); err != nil {
+		t.Fatalf("invalid JSON output %q: %v", output.String(), err)
+	}
+	if envelope.SchemaVersion != 1 || envelope.Action != CommandSetup || !envelope.Changed || envelope.Applied {
+		t.Fatalf("command output = %#v", envelope)
+	}
+	if _, err = os.Stat(lifecycle.Paths.Home); !os.IsNotExist(err) {
+		t.Fatalf("preview touched Codex home: %v", err)
+	}
+}
+
+func doctorLifecycle(t *testing.T, serverURL string) *Lifecycle {
+	t.Helper()
+	lifecycle := testLifecycle(t)
+	host, portText, err := net.SplitHostPort(strings.TrimPrefix(serverURL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle.Config.Host = host
+	lifecycle.Config.Port = port
+	lifecycle.Config.AuthDir = filepath.Join(t.TempDir(), "auth")
+	return lifecycle
+}
+
+func writeDoctorCredentials(t *testing.T, authDir string) {
+	t.Helper()
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, provider := range []string{"codex", "xai", "antigravity"} {
+		body := `{"type":"` + provider + `","token":"secret","email":"user@example.com","expired":"` + time.Now().Add(time.Hour).Format(time.RFC3339) + `"}`
+		if err := os.WriteFile(filepath.Join(authDir, provider+".json"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func doctorHasCode(report DoctorReport, code string) bool {
+	for _, check := range report.Checks {
+		if check.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/codexintegration/doctor_test.go
+++ b/internal/codexintegration/doctor_test.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
 
 func TestRunDoctorCleanWithoutUpstreamProbes(t *testing.T) {
@@ -42,6 +44,25 @@ func TestRunDoctorCleanWithoutUpstreamProbes(t *testing.T) {
 		if check.Layer == "probe" {
 			t.Fatalf("default doctor sent a model probe: %#v", check)
 		}
+	}
+}
+
+func TestRunDoctorReportsPreservedHistoryScopedProvider(t *testing.T) {
+	lifecycle := testLifecycle(t)
+	models, providers := catalogTestModels()
+	if err := os.MkdirAll(lifecycle.Paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	configData := []byte("model_provider = \"custom\"\n\n[model_providers.custom]\nbase_url = \"http://127.0.0.1:8317/v1\"\nwire_api = \"responses\"\n")
+	if err := os.WriteFile(lifecycle.Paths.ConfigFile, configData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := lifecycle.Setup(models, providers, true, false); err != nil {
+		t.Fatal(err)
+	}
+	report := RunDoctor(context.Background(), lifecycle, models, providers, DoctorOptions{SkipOpenCodexCheck: true})
+	if !doctorHasCode(report, "config.model_provider_preserved") {
+		t.Fatalf("doctor did not report the preserved history-scoped provider: %#v", report.Checks)
 	}
 }
 
@@ -224,4 +245,47 @@ func doctorHasCode(report DoctorReport, code string) bool {
 		}
 	}
 	return false
+}
+
+func TestAddAuthChecksAcceptsConfiguredAPIKeys(t *testing.T) {
+	authDir := t.TempDir()
+	lifecycle := testLifecycle(t)
+	lifecycle.Config.AuthDir = authDir
+	lifecycle.Config.CodexIntegration.Models = []config.CodexIntegrationModel{
+		{Slug: "gemini/gemini-3.1-pro", Provider: "gemini", Visible: true},
+		{Slug: "claude/claude-opus-4-6", Provider: "claude", Visible: true},
+		{Slug: "vertex/gemini-3.1-pro", Provider: "vertex", Visible: true},
+	}
+	lifecycle.Config.GeminiKey = []config.GeminiKey{{APIKey: "gemini-key"}}
+	lifecycle.Config.ClaudeKey = []config.ClaudeKey{{APIKey: "claude-key"}}
+	lifecycle.Config.VertexCompatAPIKey = []config.VertexCompatKey{{APIKey: "vertex-key"}}
+
+	checks := make([]DoctorCheck, 0)
+	addAuthChecks(lifecycle, func(layer, code string, severity DoctorSeverity, message, remediation string) {
+		checks = append(checks, DoctorCheck{Layer: layer, Code: code, Severity: severity, Message: message, Remediation: remediation})
+	})
+	report := DoctorReport{Checks: checks}
+	for _, provider := range []string{"gemini", "claude", "vertex"} {
+		if !doctorHasCode(report, "oauth."+provider+"_present") {
+			t.Fatalf("configured %s API key was not recognized: %#v", provider, report.Checks)
+		}
+		if doctorHasCode(report, "oauth."+provider+"_missing") {
+			t.Fatalf("configured %s API key was reported missing: %#v", provider, report.Checks)
+		}
+	}
+}
+
+func TestModelProbeTargetsFollowAvailableOfficialCatalog(t *testing.T) {
+	lifecycle := testLifecycle(t)
+	models, providers := catalogTestModels()
+	filtered := make([]map[string]any, 0, len(models)-1)
+	for _, model := range models {
+		if model["id"] != "gpt-5.6-sol" {
+			filtered = append(filtered, model)
+		}
+	}
+	targets := modelProbeTargets(lifecycle, filtered, providers)
+	if len(targets) == 0 || targets[0] != "gpt-5.5" {
+		t.Fatalf("modelProbeTargets() = %v, want available official model first", targets)
+	}
 }

--- a/internal/codexintegration/doctor_test.go
+++ b/internal/codexintegration/doctor_test.go
@@ -115,6 +115,29 @@ func TestRunDoctorReportsMissingProviderAndStaleCatalog(t *testing.T) {
 	}
 }
 
+func TestExpectedFeaturedModelsFollowConfiguredSlugs(t *testing.T) {
+	lifecycle := testLifecycle(t)
+	models, providers := catalogTestModels()
+	catalog, err := CompileCatalog(models, providers, lifecycle.Config.CodexIntegration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const customSlug = "xai/grok-primary"
+	for index := range lifecycle.Config.CodexIntegration.Models {
+		if lifecycle.Config.CodexIntegration.Models[index].Slug == "xai/grok-4.5" {
+			lifecycle.Config.CodexIntegration.Models[index].Slug = customSlug
+		}
+	}
+	catalog.Models[1]["slug"] = customSlug
+	data, err := catalog.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasExpectedFeaturedModels(data, lifecycle.Config.CodexIntegration) {
+		t.Fatal("configured featured slug was rejected")
+	}
+}
+
 func TestValidateCommandOptions(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/codexintegration/integration_test.go
+++ b/internal/codexintegration/integration_test.go
@@ -101,8 +101,8 @@ func TestCodexIntegrationReleaseGateSetupCatalogRouteDoctorRestore(t *testing.T)
 			t.Fatalf("featured model %d = %q, want %q", index, got, slug)
 		}
 	}
-	if build := bySlug["xai/grok-build-0.1"]; build == nil || catalogInt(build, "priority") <= len(wantFeatured) {
-		t.Fatalf("Grok Build must be visible after featured five: %#v", build)
+	if build := bySlug["xai/grok-build-0.1"]; build != nil {
+		t.Fatalf("unconfigured Grok Build model is visible: %#v", build)
 	}
 	if got := catalogInt(bySlug["antigravity/gemini-3.1-pro"], "context_window"); got != 1048576 {
 		t.Fatalf("Gemini 3.1 Pro context_window = %d, want 1048576", got)
@@ -117,7 +117,6 @@ func TestCodexIntegrationReleaseGateSetupCatalogRouteDoctorRestore(t *testing.T)
 		upstream string
 	}{
 		"xai/grok-4.5":                         {provider: "xai", upstream: "grok-4.5"},
-		"xai/grok-build-0.1":                   {provider: "xai", upstream: "grok-build-0.1"},
 		"antigravity/gemini-3.6-flash":         {provider: "antigravity", upstream: "gemini-3.6-flash-high"},
 		"antigravity/gemini-3.1-pro":           {provider: "antigravity", upstream: "gemini-pro-agent"},
 		"antigravity/claude-opus-4-6-thinking": {provider: "antigravity", upstream: "claude-opus-4-6-thinking"},

--- a/internal/codexintegration/integration_test.go
+++ b/internal/codexintegration/integration_test.go
@@ -118,7 +118,7 @@ func TestCodexIntegrationReleaseGateSetupCatalogRouteDoctorRestore(t *testing.T)
 	}{
 		"xai/grok-4.5":                         {provider: "xai", upstream: "grok-4.5"},
 		"xai/grok-build-0.1":                   {provider: "xai", upstream: "grok-build-0.1"},
-		"antigravity/gemini-3.6-flash":         {provider: "antigravity", upstream: "gemini-3.6-flash"},
+		"antigravity/gemini-3.6-flash":         {provider: "antigravity", upstream: "gemini-3.6-flash-high"},
 		"antigravity/gemini-3.1-pro":           {provider: "antigravity", upstream: "gemini-pro-agent"},
 		"antigravity/claude-opus-4-6-thinking": {provider: "antigravity", upstream: "claude-opus-4-6-thinking"},
 	}

--- a/internal/codexintegration/integration_test.go
+++ b/internal/codexintegration/integration_test.go
@@ -1,0 +1,173 @@
+package codexintegration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestCodexIntegrationReleaseGateSetupCatalogRouteDoctorRestore(t *testing.T) {
+	modelFixture, err := os.ReadFile(filepath.Join("testdata", "e2e", "models.json"))
+	if err != nil {
+		t.Fatalf("read model fixture: %v", err)
+	}
+	var modelRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/v1/models" {
+			response.WriteHeader(http.StatusNotFound)
+			return
+		}
+		gotAuthorization := request.Header.Get("Authorization")
+		if gotAuthorization != "Bearer codex-integration-local" && gotAuthorization != "Bearer codex-doctor-local" {
+			response.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		modelRequests.Add(1)
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write(modelFixture)
+	}))
+	defer server.Close()
+
+	lifecycle := doctorLifecycle(t, server.URL)
+	writeDoctorCredentials(t, lifecycle.Config.AuthDir)
+	originalConfig := []byte("# user-owned configuration\n\n[features]\nmulti_agent = true\n")
+	if err = os.MkdirAll(lifecycle.Paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err = os.WriteFile(lifecycle.Paths.ConfigFile, originalConfig, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var setupOutput bytes.Buffer
+	exitCode, err := RunCommand(context.Background(), lifecycle.Config, CommandOptions{
+		Action: CommandSetup, Apply: true, JSON: true,
+		CodexHome: lifecycle.Paths.Home, HTTPClient: server.Client(),
+	}, &setupOutput)
+	if err != nil || exitCode != 0 {
+		t.Fatalf("setup command = (%d, %v), output=%s", exitCode, err, setupOutput.String())
+	}
+	var setup CommandOutput
+	if err = json.Unmarshal(setupOutput.Bytes(), &setup); err != nil {
+		t.Fatalf("decode setup output: %v", err)
+	}
+	if !setup.Changed || !setup.Applied || !setup.RestartRequired || setup.CatalogRevision == "" || setup.MappingRevision == "" {
+		t.Fatalf("setup output = %#v", setup)
+	}
+	if got := modelRequests.Load(); got != 1 {
+		t.Fatalf("model list requests = %d, want 1", got)
+	}
+
+	configured, err := os.ReadFile(lifecycle.Paths.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(configured, []byte("# user-owned configuration")) ||
+		!bytes.Contains(configured, []byte("multi_agent = true")) ||
+		!bytes.Contains(configured, []byte(ManagedConfigBegin)) {
+		t.Fatalf("managed config did not preserve user configuration:\n%s", configured)
+	}
+	catalogData, err := os.ReadFile(lifecycle.Paths.CatalogFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = registry.ValidateCodexClientModelsJSON(catalogData); err != nil {
+		t.Fatalf("written catalog invalid: %v", err)
+	}
+	var catalogPayload struct {
+		Models []map[string]any `json:"models"`
+	}
+	if err = json.Unmarshal(catalogData, &catalogPayload); err != nil {
+		t.Fatalf("decode catalog: %v", err)
+	}
+	bySlug := catalogBySlug(catalogPayload.Models)
+	wantFeatured := []string{
+		"gpt-5.6-sol",
+		"xai/grok-4.5",
+		"antigravity/gemini-3.6-flash",
+		"antigravity/gemini-3.1-pro",
+		"antigravity/claude-opus-4-6-thinking",
+	}
+	for index, slug := range wantFeatured {
+		if got := catalogString(catalogPayload.Models[index], "slug"); got != slug {
+			t.Fatalf("featured model %d = %q, want %q", index, got, slug)
+		}
+	}
+	if build := bySlug["xai/grok-build-0.1"]; build == nil || catalogInt(build, "priority") <= len(wantFeatured) {
+		t.Fatalf("Grok Build must be visible after featured five: %#v", build)
+	}
+	if got := catalogInt(bySlug["antigravity/gemini-3.1-pro"], "context_window"); got != 1048576 {
+		t.Fatalf("Gemini 3.1 Pro context_window = %d, want 1048576", got)
+	}
+
+	policy, err := NewModelPolicy(lifecycle.Config.CodexIntegration.Models)
+	if err != nil {
+		t.Fatalf("NewModelPolicy() error = %v", err)
+	}
+	wantRoutes := map[string]struct {
+		provider string
+		upstream string
+	}{
+		"xai/grok-4.5":                         {provider: "xai", upstream: "grok-4.5"},
+		"xai/grok-build-0.1":                   {provider: "xai", upstream: "grok-build-0.1"},
+		"antigravity/gemini-3.6-flash":         {provider: "antigravity", upstream: "gemini-3.6-flash"},
+		"antigravity/gemini-3.1-pro":           {provider: "antigravity", upstream: "gemini-pro-agent"},
+		"antigravity/claude-opus-4-6-thinking": {provider: "antigravity", upstream: "claude-opus-4-6-thinking"},
+	}
+	for slug, want := range wantRoutes {
+		mapping, ok := policy.Resolve(slug)
+		if !ok || mapping.Provider != want.provider || mapping.UpstreamModel != want.upstream {
+			t.Fatalf("route %q = %#v, %t; want %s/%s", slug, mapping, ok, want.provider, want.upstream)
+		}
+	}
+	aliases := lifecycle.Config.EffectiveOAuthModelAlias()
+	for slug, want := range wantRoutes {
+		if !hasForcedAlias(aliases[want.provider], slug, want.upstream) {
+			t.Fatalf("forced alias missing for %q -> %s/%s: %#v", slug, want.provider, want.upstream, aliases[want.provider])
+		}
+	}
+
+	models, providers := commandCatalogSource(context.Background(), lifecycle, server.Client())
+	report := RunDoctor(context.Background(), lifecycle, models, providers, DoctorOptions{
+		HTTPClient: server.Client(), SkipOpenCodexCheck: true,
+	})
+	if report.ExitCode() != 0 || report.Status != "clean" {
+		t.Fatalf("doctor report = %#v", report)
+	}
+
+	var restoreOutput bytes.Buffer
+	exitCode, err = RunCommand(context.Background(), lifecycle.Config, CommandOptions{
+		Action: CommandRestore, Apply: true, JSON: true,
+		CodexHome: lifecycle.Paths.Home, HTTPClient: server.Client(),
+	}, &restoreOutput)
+	if err != nil || exitCode != 0 {
+		t.Fatalf("restore command = (%d, %v), output=%s", exitCode, err, restoreOutput.String())
+	}
+	restoredConfig, err := os.ReadFile(lifecycle.Paths.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(restoredConfig, originalConfig) {
+		t.Fatalf("restored config = %q, want %q", restoredConfig, originalConfig)
+	}
+	if _, err = os.Stat(lifecycle.Paths.CatalogFile); !os.IsNotExist(err) {
+		t.Fatalf("restore left managed catalog: %v", err)
+	}
+}
+
+func hasForcedAlias(aliases []config.OAuthModelAlias, slug, upstream string) bool {
+	for _, alias := range aliases {
+		if alias.Alias == slug && alias.Name == upstream && alias.Fork && alias.ForceMapping {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/codexintegration/journal.go
+++ b/internal/codexintegration/journal.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"os"
 	"time"
 )
 
@@ -30,12 +29,12 @@ type Journal struct {
 }
 
 func readJournal(path string) (Journal, bool, error) {
-	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return Journal{}, false, nil
-	}
+	data, _, exists, err := readRegularFile(path, 0o600)
 	if err != nil {
 		return Journal{}, false, fmt.Errorf("read Codex integration journal: %w", err)
+	}
+	if !exists {
+		return Journal{}, false, nil
 	}
 	var journal Journal
 	if err = json.Unmarshal(data, &journal); err != nil {

--- a/internal/codexintegration/journal.go
+++ b/internal/codexintegration/journal.go
@@ -1,0 +1,61 @@
+package codexintegration
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+const journalVersion = 1
+
+// Journal records enough state to audit and safely undo lifecycle writes.
+type Journal struct {
+	Version              int       `json:"version"`
+	UpdatedAt            time.Time `json:"updated_at"`
+	ConfigExisted        bool      `json:"config_existed"`
+	OriginalConfigHash   string    `json:"original_config_hash,omitempty"`
+	ManagedConfigHash    string    `json:"managed_config_hash"`
+	OriginalConfigMode   uint32    `json:"original_config_mode,omitempty"`
+	ConfigBackupFile     string    `json:"config_backup_file,omitempty"`
+	CatalogExisted       bool      `json:"catalog_existed"`
+	OriginalCatalogHash  string    `json:"original_catalog_hash,omitempty"`
+	CatalogBackupFile    string    `json:"catalog_backup_file,omitempty"`
+	ManagedCatalogHash   string    `json:"managed_catalog_hash"`
+	CatalogRevision      string    `json:"catalog_revision"`
+	CatalogSourceVersion uint64    `json:"catalog_source_revision"`
+	MappingRevision      string    `json:"mapping_revision"`
+}
+
+func readJournal(path string) (Journal, bool, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return Journal{}, false, nil
+	}
+	if err != nil {
+		return Journal{}, false, fmt.Errorf("read Codex integration journal: %w", err)
+	}
+	var journal Journal
+	if err = json.Unmarshal(data, &journal); err != nil {
+		return Journal{}, false, fmt.Errorf("decode Codex integration journal: %w", err)
+	}
+	if journal.Version != journalVersion {
+		return Journal{}, false, fmt.Errorf("unsupported Codex integration journal version %d", journal.Version)
+	}
+	return journal, true, nil
+}
+
+func marshalJournal(journal Journal) ([]byte, error) {
+	data, err := json.MarshalIndent(journal, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode Codex integration journal: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func contentHash(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/codexintegration/models.go
+++ b/internal/codexintegration/models.go
@@ -63,10 +63,5 @@ func (p *ModelPolicy) Models() []config.CodexIntegrationModel {
 
 // IsReservedProvider reports whether a slash prefix is owned by Codex Integration.
 func IsReservedProvider(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case "xai", "antigravity":
-		return true
-	default:
-		return false
-	}
+	return config.IsCodexIntegrationProvider(provider)
 }

--- a/internal/codexintegration/models.go
+++ b/internal/codexintegration/models.go
@@ -1,0 +1,72 @@
+// Package codexintegration integrates CLIProxyAPI's model registry and data plane with Codex.
+package codexintegration
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+// ModelPolicy resolves stable Codex-visible model slugs to fixed provider targets.
+type ModelPolicy struct {
+	models []config.CodexIntegrationModel
+	bySlug map[string]config.CodexIntegrationModel
+}
+
+// NewModelPolicy builds an immutable stable model policy.
+func NewModelPolicy(models []config.CodexIntegrationModel) (*ModelPolicy, error) {
+	policy := &ModelPolicy{
+		models: append([]config.CodexIntegrationModel(nil), models...),
+		bySlug: make(map[string]config.CodexIntegrationModel, len(models)),
+	}
+	for i, model := range models {
+		model.Slug = strings.ToLower(strings.TrimSpace(model.Slug))
+		model.Provider = strings.ToLower(strings.TrimSpace(model.Provider))
+		model.UpstreamModel = strings.TrimSpace(model.UpstreamModel)
+		if model.Slug == "" || model.Provider == "" || model.UpstreamModel == "" {
+			return nil, fmt.Errorf("models[%d]: slug, provider, and upstream model are required", i)
+		}
+		if !IsReservedProvider(model.Provider) || !strings.HasPrefix(model.Slug, model.Provider+"/") {
+			return nil, fmt.Errorf("models[%d]: slug %q does not match reserved provider %q", i, model.Slug, model.Provider)
+		}
+		if _, exists := policy.bySlug[model.Slug]; exists {
+			return nil, fmt.Errorf("models[%d]: duplicate slug %q", i, model.Slug)
+		}
+		policy.models[i] = model
+		policy.bySlug[model.Slug] = model
+	}
+	return policy, nil
+}
+
+// Resolve returns the exact provider mapping for a stable slug.
+func (p *ModelPolicy) Resolve(slug string) (config.CodexIntegrationModel, bool) {
+	if p == nil {
+		return config.CodexIntegrationModel{}, false
+	}
+	model, ok := p.bySlug[strings.ToLower(strings.TrimSpace(slug))]
+	return model, ok
+}
+
+// Models returns an independent copy of the stable model policy.
+func (p *ModelPolicy) Models() []config.CodexIntegrationModel {
+	if p == nil {
+		return nil
+	}
+	models := make([]config.CodexIntegrationModel, len(p.models))
+	copy(models, p.models)
+	for i := range models {
+		models[i].InputModalities = append([]string(nil), models[i].InputModalities...)
+	}
+	return models
+}
+
+// IsReservedProvider reports whether a slash prefix is owned by Codex Integration.
+func IsReservedProvider(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "xai", "antigravity":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/codexintegration/models_test.go
+++ b/internal/codexintegration/models_test.go
@@ -1,0 +1,41 @@
+package codexintegration
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestResolveStableModelGemini31Pro(t *testing.T) {
+	policy, err := NewModelPolicy(config.DefaultCodexIntegrationConfig().Models)
+	if err != nil {
+		t.Fatalf("NewModelPolicy() error = %v", err)
+	}
+
+	resolved, ok := policy.Resolve("antigravity/gemini-3.1-pro")
+	if !ok {
+		t.Fatal("Resolve() ok = false, want true")
+	}
+	if resolved.Provider != "antigravity" || resolved.UpstreamModel != "gemini-pro-agent" {
+		t.Fatalf("Resolve() = %#v, want antigravity/gemini-pro-agent", resolved)
+	}
+}
+
+func TestModelPolicyRejectsDuplicateSlug(t *testing.T) {
+	models := config.DefaultCodexIntegrationConfig().Models
+	models = append(models, models[0])
+	if _, err := NewModelPolicy(models); err == nil {
+		t.Fatal("NewModelPolicy() error = nil, want duplicate slug error")
+	}
+}
+
+func TestReservedProviderNamespace(t *testing.T) {
+	for _, provider := range []string{"xai", "antigravity"} {
+		if !IsReservedProvider(provider) {
+			t.Fatalf("IsReservedProvider(%q) = false, want true", provider)
+		}
+	}
+	if IsReservedProvider("teamA") {
+		t.Fatal("IsReservedProvider(teamA) = true, want false")
+	}
+}

--- a/internal/codexintegration/models_test.go
+++ b/internal/codexintegration/models_test.go
@@ -30,7 +30,7 @@ func TestModelPolicyRejectsDuplicateSlug(t *testing.T) {
 }
 
 func TestReservedProviderNamespace(t *testing.T) {
-	for _, provider := range []string{"xai", "antigravity"} {
+	for _, provider := range []string{"aistudio", "antigravity", "claude", "gemini", "kimi", "vertex", "xai"} {
 		if !IsReservedProvider(provider) {
 			t.Fatalf("IsReservedProvider(%q) = false, want true", provider)
 		}

--- a/internal/codexintegration/paths.go
+++ b/internal/codexintegration/paths.go
@@ -1,0 +1,73 @@
+package codexintegration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+const (
+	defaultCodexConfigFile = "config.toml"
+	defaultCodexCacheFile  = "models_cache.json"
+	integrationStateDir    = ".cliproxyapi-codex"
+)
+
+// Paths contains every Codex path managed by the integration lifecycle.
+type Paths struct {
+	Home        string
+	ConfigFile  string
+	CatalogFile string
+	CacheFile   string
+	StateDir    string
+	JournalFile string
+	LockFile    string
+	BackupDir   string
+}
+
+// ResolvePaths applies the documented Codex home precedence without touching disk.
+func ResolvePaths(explicitHome string, integration config.CodexIntegrationConfig) (Paths, error) {
+	home := strings.TrimSpace(explicitHome)
+	if home == "" {
+		home = strings.TrimSpace(integration.CodexHome)
+	}
+	if home == "" {
+		home = strings.TrimSpace(os.Getenv("CODEX_HOME"))
+	}
+	if home == "" {
+		userHome, err := os.UserHomeDir()
+		if err != nil {
+			return Paths{}, fmt.Errorf("resolve user home: %w", err)
+		}
+		home = filepath.Join(userHome, ".codex")
+	}
+	absHome, err := filepath.Abs(home)
+	if err != nil {
+		return Paths{}, fmt.Errorf("resolve Codex home %q: %w", home, err)
+	}
+	absHome = filepath.Clean(absHome)
+	if absHome == string(filepath.Separator) {
+		return Paths{}, fmt.Errorf("Codex home cannot be the filesystem root")
+	}
+
+	catalogName := strings.TrimSpace(integration.CatalogFile)
+	if catalogName == "" {
+		catalogName = config.DefaultCodexCatalogFile
+	}
+	if filepath.IsAbs(catalogName) || filepath.Base(filepath.Clean(catalogName)) != filepath.Clean(catalogName) || catalogName == "." || catalogName == ".." {
+		return Paths{}, fmt.Errorf("Codex catalog %q must be a file name inside Codex home", catalogName)
+	}
+	stateDir := filepath.Join(absHome, integrationStateDir)
+	return Paths{
+		Home:        absHome,
+		ConfigFile:  filepath.Join(absHome, defaultCodexConfigFile),
+		CatalogFile: filepath.Join(absHome, catalogName),
+		CacheFile:   filepath.Join(absHome, defaultCodexCacheFile),
+		StateDir:    stateDir,
+		JournalFile: filepath.Join(stateDir, "journal.json"),
+		LockFile:    filepath.Join(absHome, ".cliproxyapi-codex.lock"),
+		BackupDir:   filepath.Join(stateDir, "backups"),
+	}, nil
+}

--- a/internal/codexintegration/restore.go
+++ b/internal/codexintegration/restore.go
@@ -1,0 +1,123 @@
+package codexintegration
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+)
+
+type restorePlan struct {
+	changed        bool
+	configData     []byte
+	configMode     os.FileMode
+	writeConfig    bool
+	catalogExists  bool
+	restoreCatalog bool
+	journal        Journal
+	journalExists  bool
+}
+
+// Restore removes only integration-owned state and preserves subsequent user edits.
+func (l *Lifecycle) Restore(apply bool) (OperationResult, error) {
+	plan, err := l.prepareRestore()
+	if err != nil {
+		return OperationResult{}, err
+	}
+	result := OperationResult{Changed: plan.changed, RestartRequired: false}
+	if !apply || !plan.changed {
+		return result, nil
+	}
+	if err = l.ensureWritePaths(); err != nil {
+		return OperationResult{}, err
+	}
+	release, err := acquireLifecycleLock(l.Paths.LockFile)
+	if err != nil {
+		return OperationResult{}, err
+	}
+	defer release()
+	plan, err = l.prepareRestore()
+	if err != nil {
+		return OperationResult{}, err
+	}
+	if !plan.changed {
+		return OperationResult{}, nil
+	}
+	if plan.writeConfig {
+		if err = atomicWriteFile(l.Paths.ConfigFile, plan.configData, plan.configMode); err != nil {
+			return OperationResult{}, err
+		}
+	}
+	if plan.restoreCatalog {
+		if plan.journalExists && plan.journal.CatalogExisted && plan.journal.CatalogBackupFile != "" {
+			backup, _, _, readErr := readRegularFile(plan.journal.CatalogBackupFile, 0o600)
+			if readErr != nil {
+				return OperationResult{}, fmt.Errorf("read original catalog backup: %w", readErr)
+			}
+			if err = atomicWriteFile(l.Paths.CatalogFile, backup, 0o600); err != nil {
+				return OperationResult{}, err
+			}
+		} else if _, err = moveAside(l.Paths.CatalogFile, l.Paths.BackupDir, "catalog.restored"); err != nil {
+			return OperationResult{}, err
+		}
+	}
+	if plan.journalExists {
+		if _, err = moveAside(l.Paths.JournalFile, l.Paths.BackupDir, "journal.restored.json"); err != nil {
+			return OperationResult{}, err
+		}
+	}
+	result.Applied = true
+	result.RestartRequired = true
+	return result, nil
+}
+
+func (l *Lifecycle) prepareRestore() (restorePlan, error) {
+	configData, configMode, configExists, err := readRegularFile(l.Paths.ConfigFile, 0o600)
+	if err != nil {
+		return restorePlan{}, err
+	}
+	journal, journalExists, err := readJournal(l.Paths.JournalFile)
+	if err != nil {
+		return restorePlan{}, err
+	}
+	_, _, catalogExists, err := readRegularFile(l.Paths.CatalogFile, 0o600)
+	if err != nil {
+		return restorePlan{}, err
+	}
+	newConfig := configData
+	writeConfig := false
+	managedConfigFound := false
+	if configExists {
+		normalized := bytes.ReplaceAll(configData, []byte("\r\n"), []byte("\n"))
+		stripped, found, removeErr := removeManagedBlock(string(normalized))
+		if removeErr != nil {
+			return restorePlan{}, removeErr
+		}
+		if found {
+			managedConfigFound = true
+			writeConfig = true
+			if journalExists && contentHash(configData) == journal.ManagedConfigHash && journal.ConfigExisted && journal.ConfigBackupFile != "" {
+				newConfig, _, _, err = readRegularFile(journal.ConfigBackupFile, 0o600)
+				if err != nil {
+					return restorePlan{}, fmt.Errorf("read original config backup: %w", err)
+				}
+				if journal.OriginalConfigMode != 0 {
+					configMode = os.FileMode(journal.OriginalConfigMode)
+				}
+			} else {
+				newConfig = []byte(stripped)
+				if bytes.Contains(configData, []byte("\r\n")) {
+					newConfig = bytes.ReplaceAll(newConfig, []byte("\n"), []byte("\r\n"))
+				}
+			}
+			if err = validateTOML(newConfig); err != nil {
+				return restorePlan{}, err
+			}
+		}
+	}
+	restoreCatalog := (journalExists && (catalogExists || journal.CatalogExisted)) || (managedConfigFound && catalogExists)
+	changed := writeConfig || restoreCatalog || journalExists
+	return restorePlan{
+		changed: changed, configData: newConfig, configMode: configMode, writeConfig: writeConfig,
+		catalogExists: catalogExists, restoreCatalog: restoreCatalog, journal: journal, journalExists: journalExists,
+	}, nil
+}

--- a/internal/codexintegration/restore.go
+++ b/internal/codexintegration/restore.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 type restorePlan struct {
@@ -42,32 +43,76 @@ func (l *Lifecycle) Restore(apply bool) (OperationResult, error) {
 	if !plan.changed {
 		return OperationResult{}, nil
 	}
-	if plan.writeConfig {
-		if err = atomicWriteFile(l.Paths.ConfigFile, plan.configData, plan.configMode); err != nil {
-			return OperationResult{}, err
-		}
-	}
-	if plan.restoreCatalog {
-		if plan.journalExists && plan.journal.CatalogExisted && plan.journal.CatalogBackupFile != "" {
-			backup, _, _, readErr := readRegularFile(plan.journal.CatalogBackupFile, 0o600)
-			if readErr != nil {
-				return OperationResult{}, fmt.Errorf("read original catalog backup: %w", readErr)
-			}
-			if err = atomicWriteFile(l.Paths.CatalogFile, backup, 0o600); err != nil {
-				return OperationResult{}, err
-			}
-		} else if _, err = moveAside(l.Paths.CatalogFile, l.Paths.BackupDir, "catalog.restored"); err != nil {
-			return OperationResult{}, err
-		}
-	}
-	if plan.journalExists {
-		if _, err = moveAside(l.Paths.JournalFile, l.Paths.BackupDir, "journal.restored.json"); err != nil {
-			return OperationResult{}, err
-		}
+	if err = l.applyRestore(plan); err != nil {
+		return OperationResult{}, err
 	}
 	result.Applied = true
 	result.RestartRequired = true
 	return result, nil
+}
+
+func (l *Lifecycle) applyRestore(plan restorePlan) (err error) {
+	configSnapshot, err := snapshotRegularFile(l.Paths.ConfigFile, 0o600)
+	if err != nil {
+		return err
+	}
+	catalogSnapshot, err := snapshotRegularFile(l.Paths.CatalogFile, 0o600)
+	if err != nil {
+		return err
+	}
+	journalSnapshot, err := snapshotRegularFile(l.Paths.JournalFile, 0o600)
+	if err != nil {
+		return err
+	}
+	var configMutated, catalogMutated bool
+	var catalogBackup, journalBackup string
+	defer func() {
+		if err == nil {
+			return
+		}
+		rollbackErrors := make([]error, 0, 3)
+		if journalBackup != "" {
+			rollbackErrors = append(rollbackErrors, restoreMovedAside(l.Paths.JournalFile, journalBackup))
+		} else if !journalSnapshot.exists {
+			rollbackErrors = append(rollbackErrors, restoreFileSnapshot(l.Paths.JournalFile, journalSnapshot))
+		}
+		if catalogBackup != "" {
+			rollbackErrors = append(rollbackErrors, restoreMovedAside(l.Paths.CatalogFile, catalogBackup))
+		} else if catalogMutated {
+			rollbackErrors = append(rollbackErrors, restoreFileSnapshot(l.Paths.CatalogFile, catalogSnapshot))
+		}
+		if configMutated {
+			rollbackErrors = append(rollbackErrors, restoreFileSnapshot(l.Paths.ConfigFile, configSnapshot))
+		}
+		err = withRollbackError(err, rollbackErrors...)
+	}()
+
+	if plan.writeConfig {
+		configMutated = true
+		if err = atomicWriteFile(l.Paths.ConfigFile, plan.configData, plan.configMode); err != nil {
+			return err
+		}
+	}
+	if plan.restoreCatalog {
+		if plan.journalExists && plan.journal.CatalogExisted && plan.journal.CatalogBackupFile != "" {
+			backup, readErr := l.readBackup(plan.journal.CatalogBackupFile)
+			if readErr != nil {
+				return fmt.Errorf("read original catalog backup: %w", readErr)
+			}
+			catalogMutated = true
+			if err = atomicWriteFile(l.Paths.CatalogFile, backup, 0o600); err != nil {
+				return err
+			}
+		} else if catalogBackup, err = moveAside(l.Paths.CatalogFile, l.Paths.BackupDir, "catalog.restored"); err != nil {
+			return err
+		}
+	}
+	if plan.journalExists {
+		if journalBackup, err = moveAside(l.Paths.JournalFile, l.Paths.BackupDir, "journal.restored.json"); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (l *Lifecycle) prepareRestore() (restorePlan, error) {
@@ -96,7 +141,7 @@ func (l *Lifecycle) prepareRestore() (restorePlan, error) {
 			managedConfigFound = true
 			writeConfig = true
 			if journalExists && contentHash(configData) == journal.ManagedConfigHash && journal.ConfigExisted && journal.ConfigBackupFile != "" {
-				newConfig, _, _, err = readRegularFile(journal.ConfigBackupFile, 0o600)
+				newConfig, err = l.readBackup(journal.ConfigBackupFile)
 				if err != nil {
 					return restorePlan{}, fmt.Errorf("read original config backup: %w", err)
 				}
@@ -120,4 +165,21 @@ func (l *Lifecycle) prepareRestore() (restorePlan, error) {
 		changed: changed, configData: newConfig, configMode: configMode, writeConfig: writeConfig,
 		catalogExists: catalogExists, restoreCatalog: restoreCatalog, journal: journal, journalExists: journalExists,
 	}, nil
+}
+
+func (l *Lifecycle) readBackup(path string) ([]byte, error) {
+	cleanBackupDir := filepath.Clean(l.Paths.BackupDir)
+	cleanPath := filepath.Clean(path)
+	relative, err := filepath.Rel(cleanBackupDir, cleanPath)
+	if err != nil || relative == "." || relative == ".." || filepath.IsAbs(relative) || len(relative) >= 3 && relative[:3] == ".."+string(filepath.Separator) {
+		return nil, fmt.Errorf("backup path %q is outside the Codex integration backup directory", path)
+	}
+	data, _, exists, err := readRegularFile(cleanPath, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, fmt.Errorf("backup file %q is missing", cleanPath)
+	}
+	return data, nil
 }

--- a/internal/codexintegration/sync.go
+++ b/internal/codexintegration/sync.go
@@ -1,0 +1,176 @@
+package codexintegration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	log "github.com/sirupsen/logrus"
+)
+
+const defaultSyncDebounce = 500 * time.Millisecond
+
+type syncRegistry interface {
+	GetAvailableModels(handlerType string) []map[string]any
+	GetProvidersForModel(modelID string) []string
+	SubscribeHook(hook registry.ModelRegistryHook) func()
+}
+
+// SyncStatus reports the latest auto-sync attempt without exposing credentials.
+type SyncStatus struct {
+	Attempts        uint64
+	LastAttempt     time.Time
+	LastSuccess     time.Time
+	LastError       string
+	CatalogRevision string
+	Applied         bool
+}
+
+// SyncWorker debounces registry and template events into serialized catalog syncs.
+type SyncWorker struct {
+	lifecycle         *Lifecycle
+	registry          syncRegistry
+	debounce          time.Duration
+	events            chan struct{}
+	templateSubscribe func(func(uint64)) func()
+	statusMu          sync.RWMutex
+	status            SyncStatus
+}
+
+// NewSyncWorker creates an auto-sync worker without starting goroutines.
+func NewSyncWorker(cfg *config.Config, source syncRegistry) (*SyncWorker, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("Codex auto-sync requires config")
+	}
+	if source == nil {
+		return nil, fmt.Errorf("Codex auto-sync requires a model registry")
+	}
+	snapshot := cfg.CloneForRuntime()
+	lifecycle, err := NewLifecycle(snapshot, "")
+	if err != nil {
+		return nil, err
+	}
+	return &SyncWorker{
+		lifecycle:         lifecycle,
+		registry:          source,
+		debounce:          defaultSyncDebounce,
+		events:            make(chan struct{}, 1),
+		templateSubscribe: registry.SubscribeCodexClientModelsChanges,
+	}, nil
+}
+
+// Run blocks until context cancellation and owns all registry subscriptions.
+func (worker *SyncWorker) Run(ctx context.Context) {
+	if worker == nil || worker.lifecycle == nil || worker.registry == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	hook := &syncRegistryHook{notify: worker.Notify}
+	cancelRegistry := worker.registry.SubscribeHook(hook)
+	cancelTemplates := func() {}
+	if worker.templateSubscribe != nil {
+		cancelTemplates = worker.templateSubscribe(func(uint64) { worker.Notify() })
+	}
+	defer cancelRegistry()
+	defer cancelTemplates()
+
+	worker.Notify()
+	timer := time.NewTimer(time.Hour)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	defer timer.Stop()
+	pending := false
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-worker.events:
+			if pending && !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(worker.debounce)
+			pending = true
+		case <-timer.C:
+			pending = false
+			worker.syncOnce()
+		}
+	}
+}
+
+// Notify queues a non-blocking, coalesced sync event.
+func (worker *SyncWorker) Notify() {
+	if worker == nil {
+		return
+	}
+	select {
+	case worker.events <- struct{}{}:
+	default:
+	}
+}
+
+// Status returns a race-safe snapshot of the latest auto-sync state.
+func (worker *SyncWorker) Status() SyncStatus {
+	if worker == nil {
+		return SyncStatus{}
+	}
+	worker.statusMu.RLock()
+	defer worker.statusMu.RUnlock()
+	return worker.status
+}
+
+func (worker *SyncWorker) syncOnce() {
+	models := worker.registry.GetAvailableModels("openai")
+	providers := func(model string) []string { return worker.registry.GetProvidersForModel(model) }
+	result, err := worker.lifecycle.Sync(models, providers, true)
+	now := time.Now().UTC()
+	worker.statusMu.Lock()
+	worker.status.Attempts++
+	worker.status.LastAttempt = now
+	worker.status.Applied = false
+	if err != nil {
+		worker.status.LastError = err.Error()
+	} else {
+		worker.status.LastError = ""
+		worker.status.LastSuccess = now
+		worker.status.CatalogRevision = result.CatalogRevision
+		worker.status.Applied = result.Applied
+	}
+	worker.statusMu.Unlock()
+	if err != nil {
+		if strings.Contains(err.Error(), "not set up") {
+			log.Debug("Codex Integration auto-sync is waiting for setup")
+		} else {
+			log.Warnf("Codex Integration auto-sync kept the last-good catalog: %v", err)
+		}
+		return
+	}
+	if result.Applied {
+		log.Infof("Codex Integration auto-sync published catalog revision %s", result.CatalogRevision)
+	}
+}
+
+type syncRegistryHook struct {
+	notify func()
+}
+
+func (hook *syncRegistryHook) OnModelsRegistered(context.Context, string, string, []*registry.ModelInfo) {
+	if hook != nil && hook.notify != nil {
+		hook.notify()
+	}
+}
+
+func (hook *syncRegistryHook) OnModelsUnregistered(context.Context, string, string) {
+	if hook != nil && hook.notify != nil {
+		hook.notify()
+	}
+}

--- a/internal/codexintegration/sync_test.go
+++ b/internal/codexintegration/sync_test.go
@@ -1,0 +1,147 @@
+package codexintegration
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+type fakeSyncRegistry struct {
+	mu        sync.RWMutex
+	models    []map[string]any
+	providers map[string][]string
+	hooks     map[int]registry.ModelRegistryHook
+	nextID    int
+}
+
+func (fake *fakeSyncRegistry) GetAvailableModels(string) []map[string]any {
+	fake.mu.RLock()
+	defer fake.mu.RUnlock()
+	return append([]map[string]any(nil), fake.models...)
+}
+
+func (fake *fakeSyncRegistry) GetProvidersForModel(model string) []string {
+	fake.mu.RLock()
+	defer fake.mu.RUnlock()
+	return append([]string(nil), fake.providers[model]...)
+}
+
+func (fake *fakeSyncRegistry) SubscribeHook(hook registry.ModelRegistryHook) func() {
+	fake.mu.Lock()
+	if fake.hooks == nil {
+		fake.hooks = make(map[int]registry.ModelRegistryHook)
+	}
+	fake.nextID++
+	id := fake.nextID
+	fake.hooks[id] = hook
+	fake.mu.Unlock()
+	return func() {
+		fake.mu.Lock()
+		delete(fake.hooks, id)
+		fake.mu.Unlock()
+	}
+}
+
+func (fake *fakeSyncRegistry) notify() {
+	fake.mu.RLock()
+	hooks := make([]registry.ModelRegistryHook, 0, len(fake.hooks))
+	for _, hook := range fake.hooks {
+		hooks = append(hooks, hook)
+	}
+	fake.mu.RUnlock()
+	for _, hook := range hooks {
+		hook.OnModelsRegistered(context.Background(), "xai", "test", nil)
+	}
+}
+
+func TestSyncWorkerDebouncesEventsAndKeepsLastGood(t *testing.T) {
+	lifecycle := testLifecycle(t)
+	lifecycle.Config.CodexIntegration.CodexHome = lifecycle.Paths.Home
+	models, providerFunc := catalogTestModels()
+	providers := make(map[string][]string)
+	for _, model := range models {
+		id := catalogString(model, "id")
+		providers[id] = providerFunc(id)
+	}
+	fake := &fakeSyncRegistry{models: models, providers: providers}
+	if _, err := lifecycle.Setup(models, providerFunc, true, false); err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+	before, err := os.ReadFile(lifecycle.Paths.CatalogFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker, err := NewSyncWorker(lifecycle.Config, fake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker.debounce = 20 * time.Millisecond
+	worker.templateSubscribe = func(func(uint64)) func() { return func() {} }
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		worker.Run(ctx)
+		close(done)
+	}()
+	waitForSyncAttempts(t, worker, 1)
+
+	for range 50 {
+		fake.notify()
+	}
+	waitForSyncAttempts(t, worker, 2)
+	time.Sleep(60 * time.Millisecond)
+	if attempts := worker.Status().Attempts; attempts != 2 {
+		t.Fatalf("event storm produced %d attempts, want 2 including initial", attempts)
+	}
+
+	fake.mu.Lock()
+	filtered := make([]map[string]any, 0, len(fake.models))
+	for _, model := range fake.models {
+		if catalogString(model, "id") != "gemini-pro-agent" {
+			filtered = append(filtered, model)
+		}
+	}
+	fake.models = filtered
+	fake.mu.Unlock()
+	fake.notify()
+	waitForSyncAttempts(t, worker, 3)
+	if worker.Status().LastError == "" {
+		t.Fatal("missing mapped model did not record sync error")
+	}
+	afterFailure, err := os.ReadFile(lifecycle.Paths.CatalogFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(afterFailure) != string(before) {
+		t.Fatal("failed sync replaced last-good catalog")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SyncWorker did not stop after context cancellation")
+	}
+	beforeAttempts := worker.Status().Attempts
+	fake.notify()
+	time.Sleep(50 * time.Millisecond)
+	if worker.Status().Attempts != beforeAttempts {
+		t.Fatal("stopped SyncWorker processed a later event")
+	}
+}
+
+func waitForSyncAttempts(t *testing.T, worker *SyncWorker, want uint64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if worker.Status().Attempts >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("sync attempts = %d, want at least %d", worker.Status().Attempts, want)
+}

--- a/internal/codexintegration/testdata/e2e/models.json
+++ b/internal/codexintegration/testdata/e2e/models.json
@@ -4,7 +4,7 @@
     {"id": "gpt-5.6-sol", "object": "model", "owned_by": "openai", "display_name": "GPT-5.6 Sol"},
     {"id": "grok-4.5", "object": "model", "owned_by": "xai", "display_name": "Grok 4.5", "context_length": 262144},
     {"id": "grok-build-0.1", "object": "model", "owned_by": "xai", "display_name": "Grok Build", "context_length": 262144},
-    {"id": "gemini-3.6-flash", "object": "model", "owned_by": "antigravity", "display_name": "Gemini 3.6 Flash", "context_length": 1048576},
+    {"id": "gemini-3.6-flash-high", "object": "model", "owned_by": "antigravity", "display_name": "Gemini 3.6 Flash", "context_length": 1048576},
     {"id": "gemini-pro-agent", "object": "model", "owned_by": "antigravity", "display_name": "Gemini Pro Agent", "context_length": 1048576},
     {"id": "claude-opus-4-6-thinking", "object": "model", "owned_by": "antigravity", "display_name": "Claude Opus 4.6 Thinking", "context_length": 200000}
   ]

--- a/internal/codexintegration/testdata/e2e/models.json
+++ b/internal/codexintegration/testdata/e2e/models.json
@@ -1,0 +1,11 @@
+{
+  "object": "list",
+  "data": [
+    {"id": "gpt-5.6-sol", "object": "model", "owned_by": "openai", "display_name": "GPT-5.6 Sol"},
+    {"id": "grok-4.5", "object": "model", "owned_by": "xai", "display_name": "Grok 4.5", "context_length": 262144},
+    {"id": "grok-build-0.1", "object": "model", "owned_by": "xai", "display_name": "Grok Build", "context_length": 262144},
+    {"id": "gemini-3.6-flash", "object": "model", "owned_by": "antigravity", "display_name": "Gemini 3.6 Flash", "context_length": 1048576},
+    {"id": "gemini-pro-agent", "object": "model", "owned_by": "antigravity", "display_name": "Gemini Pro Agent", "context_length": 1048576},
+    {"id": "claude-opus-4-6-thinking", "object": "model", "owned_by": "antigravity", "display_name": "Claude Opus 4.6 Thinking", "context_length": 200000}
+  ]
+}

--- a/internal/config/codex_integration.go
+++ b/internal/config/codex_integration.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"fmt"
+	"net"
+	"path/filepath"
+	"strings"
+)
+
+var codexIntegrationProviders = map[string]struct{}{
+	"antigravity": {},
+	"xai":         {},
+}
+
+// NormalizeCodexIntegration normalizes and validates the optional Codex integration config.
+func (cfg *Config) NormalizeCodexIntegration() error {
+	if cfg == nil {
+		return nil
+	}
+
+	integration := &cfg.CodexIntegration
+	integration.CodexHome = strings.TrimSpace(integration.CodexHome)
+	integration.CatalogFile = strings.TrimSpace(integration.CatalogFile)
+	if integration.CatalogFile == "" {
+		integration.CatalogFile = DefaultCodexCatalogFile
+	}
+	integration.MultiAgentMode = strings.ToLower(strings.TrimSpace(integration.MultiAgentMode))
+	if integration.MultiAgentMode == "" {
+		integration.MultiAgentMode = DefaultCodexMultiAgentMode
+	}
+	if integration.Models == nil {
+		integration.Models = DefaultCodexIntegrationConfig().Models
+	}
+
+	if err := validateCodexCatalogFile(integration.CatalogFile); err != nil {
+		return err
+	}
+	if integration.MultiAgentMode != DefaultCodexMultiAgentMode {
+		return fmt.Errorf("codex-integration.multi-agent-mode: unsupported value %q; only %q is currently verified", integration.MultiAgentMode, DefaultCodexMultiAgentMode)
+	}
+	if integration.Enabled && integration.LoopbackAccess && !isStrictLoopbackHost(cfg.Host) {
+		return fmt.Errorf("codex-integration.loopback-access: host %q is not a strict loopback address", cfg.Host)
+	}
+
+	seen := make(map[string]struct{}, len(integration.Models))
+	featured := 0
+	for i := range integration.Models {
+		model := &integration.Models[i]
+		model.Slug = strings.ToLower(strings.TrimSpace(model.Slug))
+		model.Provider = strings.ToLower(strings.TrimSpace(model.Provider))
+		model.UpstreamModel = strings.TrimSpace(model.UpstreamModel)
+		model.DisplayName = strings.TrimSpace(model.DisplayName)
+
+		if _, ok := codexIntegrationProviders[model.Provider]; !ok {
+			return fmt.Errorf("codex-integration.models[%d].provider: unsupported provider %q", i, model.Provider)
+		}
+		if model.Slug == "" || !strings.HasPrefix(model.Slug, model.Provider+"/") || strings.Count(model.Slug, "/") != 1 {
+			return fmt.Errorf("codex-integration.models[%d].slug: %q must use the reserved %q namespace", i, model.Slug, model.Provider+"/")
+		}
+		if strings.TrimPrefix(model.Slug, model.Provider+"/") == "" {
+			return fmt.Errorf("codex-integration.models[%d].slug: model segment is empty", i)
+		}
+		if model.UpstreamModel == "" {
+			return fmt.Errorf("codex-integration.models[%d].upstream-model: value is required", i)
+		}
+		key := strings.ToLower(model.Slug)
+		if _, ok := seen[key]; ok {
+			return fmt.Errorf("codex-integration.models[%d].slug: duplicate slug %q", i, model.Slug)
+		}
+		seen[key] = struct{}{}
+		if model.Featured {
+			featured++
+		}
+	}
+	if featured > 4 {
+		return fmt.Errorf("codex-integration.models: %d featured third-party models exceed the four slots available after the official GPT model", featured)
+	}
+
+	return nil
+}
+
+func validateCodexCatalogFile(name string) error {
+	if filepath.IsAbs(name) {
+		return fmt.Errorf("codex-integration.catalog-file: absolute paths are not allowed")
+	}
+	clean := filepath.Clean(name)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || filepath.Base(clean) != clean {
+		return fmt.Errorf("codex-integration.catalog-file: %q must be a file name inside CODEX_HOME", name)
+	}
+	return nil
+}
+
+func isStrictLoopbackHost(host string) bool {
+	host = strings.TrimSpace(host)
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/internal/config/codex_integration.go
+++ b/internal/config/codex_integration.go
@@ -79,6 +79,35 @@ func (cfg *Config) NormalizeCodexIntegration() error {
 	return nil
 }
 
+// EffectiveOAuthModelAlias returns user aliases plus the stable Codex Integration
+// mappings. Integration aliases are appended so their provider lock and response
+// identity cannot be shadowed by a user alias with the same client slug.
+func (cfg *Config) EffectiveOAuthModelAlias() map[string][]OAuthModelAlias {
+	if cfg == nil {
+		return nil
+	}
+	out := make(map[string][]OAuthModelAlias, len(cfg.OAuthModelAlias)+2)
+	for channel, aliases := range cfg.OAuthModelAlias {
+		out[channel] = append([]OAuthModelAlias(nil), aliases...)
+	}
+	if !cfg.CodexIntegration.Enabled {
+		return out
+	}
+	for _, model := range cfg.CodexIntegration.Models {
+		if !model.Visible {
+			continue
+		}
+		out[model.Provider] = append(out[model.Provider], OAuthModelAlias{
+			Name:         model.UpstreamModel,
+			Alias:        model.Slug,
+			Fork:         true,
+			DisplayName:  model.DisplayName,
+			ForceMapping: true,
+		})
+	}
+	return out
+}
+
 func validateCodexCatalogFile(name string) error {
 	if filepath.IsAbs(name) {
 		return fmt.Errorf("codex-integration.catalog-file: absolute paths are not allowed")

--- a/internal/config/codex_integration.go
+++ b/internal/config/codex_integration.go
@@ -7,9 +7,32 @@ import (
 	"strings"
 )
 
-var codexIntegrationProviders = map[string]struct{}{
-	"antigravity": {},
-	"xai":         {},
+var codexIntegrationProviders = []string{
+	"aistudio",
+	"antigravity",
+	"claude",
+	"gemini",
+	"kimi",
+	"vertex",
+	"xai",
+}
+
+// CodexIntegrationProviders returns the native non-Codex providers that can be
+// exposed through a provider-qualified Codex model slug.
+func CodexIntegrationProviders() []string {
+	return append([]string(nil), codexIntegrationProviders...)
+}
+
+// IsCodexIntegrationProvider reports whether provider is a native data-plane
+// provider supported by the Codex Integration router.
+func IsCodexIntegrationProvider(provider string) bool {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	for _, candidate := range codexIntegrationProviders {
+		if provider == candidate {
+			return true
+		}
+	}
+	return false
 }
 
 // NormalizeCodexIntegration normalizes and validates the optional Codex integration config.
@@ -51,7 +74,7 @@ func (cfg *Config) NormalizeCodexIntegration() error {
 		model.UpstreamModel = strings.TrimSpace(model.UpstreamModel)
 		model.DisplayName = strings.TrimSpace(model.DisplayName)
 
-		if _, ok := codexIntegrationProviders[model.Provider]; !ok {
+		if !IsCodexIntegrationProvider(model.Provider) {
 			return fmt.Errorf("codex-integration.models[%d].provider: unsupported provider %q", i, model.Provider)
 		}
 		if model.Slug == "" || !strings.HasPrefix(model.Slug, model.Provider+"/") || strings.Count(model.Slug, "/") != 1 {

--- a/internal/config/codex_integration_test.go
+++ b/internal/config/codex_integration_test.go
@@ -17,8 +17,8 @@ func TestParseConfigBytesCodexIntegrationDefaultsRemainDisabled(t *testing.T) {
 	if cfg.CodexIntegration.CatalogFile != DefaultCodexCatalogFile {
 		t.Fatalf("CatalogFile = %q, want %q", cfg.CodexIntegration.CatalogFile, DefaultCodexCatalogFile)
 	}
-	if len(cfg.CodexIntegration.Models) != 5 {
-		t.Fatalf("len(Models) = %d, want 5", len(cfg.CodexIntegration.Models))
+	if len(cfg.CodexIntegration.Models) != 4 {
+		t.Fatalf("len(Models) = %d, want 4", len(cfg.CodexIntegration.Models))
 	}
 }
 
@@ -30,7 +30,6 @@ func TestParseConfigBytesCodexIntegrationStableDefaults(t *testing.T) {
 
 	want := map[string]string{
 		"xai/grok-4.5":                         "grok-4.5",
-		"xai/grok-build-0.1":                   "grok-build-0.1",
 		"antigravity/gemini-3.6-flash":         "gemini-3.6-flash-high",
 		"antigravity/gemini-3.1-pro":           "gemini-pro-agent",
 		"antigravity/claude-opus-4-6-thinking": "claude-opus-4-6-thinking",
@@ -47,6 +46,16 @@ func TestParseConfigBytesCodexIntegrationStableDefaults(t *testing.T) {
 	}
 	if len(want) != 0 {
 		t.Fatalf("missing stable models: %#v", want)
+	}
+}
+
+func TestParseConfigBytesCodexIntegrationAcceptsKimiProvider(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte("host: 127.0.0.1\ncodex-integration:\n  enabled: true\n  models:\n    - slug: kimi/kimi-for-coding\n      provider: kimi\n      upstream-model: kimi-for-coding\n      visible: true\n"))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", err)
+	}
+	if got := cfg.CodexIntegration.Models[0].Provider; got != "kimi" {
+		t.Fatalf("Provider = %q, want kimi", got)
 	}
 }
 
@@ -110,7 +119,7 @@ func TestConfigExampleCodexIntegrationParses(t *testing.T) {
 	if cfg.CodexIntegration.Enabled {
 		t.Fatal("example config enables Codex integration")
 	}
-	if len(cfg.CodexIntegration.Models) != 5 {
-		t.Fatalf("len(example Models) = %d, want 5", len(cfg.CodexIntegration.Models))
+	if len(cfg.CodexIntegration.Models) != 4 {
+		t.Fatalf("len(example Models) = %d, want 4", len(cfg.CodexIntegration.Models))
 	}
 }

--- a/internal/config/codex_integration_test.go
+++ b/internal/config/codex_integration_test.go
@@ -31,7 +31,7 @@ func TestParseConfigBytesCodexIntegrationStableDefaults(t *testing.T) {
 	want := map[string]string{
 		"xai/grok-4.5":                         "grok-4.5",
 		"xai/grok-build-0.1":                   "grok-build-0.1",
-		"antigravity/gemini-3.6-flash":         "gemini-3.6-flash",
+		"antigravity/gemini-3.6-flash":         "gemini-3.6-flash-high",
 		"antigravity/gemini-3.1-pro":           "gemini-pro-agent",
 		"antigravity/claude-opus-4-6-thinking": "claude-opus-4-6-thinking",
 	}

--- a/internal/config/codex_integration_test.go
+++ b/internal/config/codex_integration_test.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseConfigBytesCodexIntegrationDefaultsRemainDisabled(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte("host: \"\"\nport: 8317\n"))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", err)
+	}
+	if cfg.CodexIntegration.Enabled {
+		t.Fatal("CodexIntegration.Enabled = true, want false")
+	}
+	if cfg.CodexIntegration.CatalogFile != DefaultCodexCatalogFile {
+		t.Fatalf("CatalogFile = %q, want %q", cfg.CodexIntegration.CatalogFile, DefaultCodexCatalogFile)
+	}
+	if len(cfg.CodexIntegration.Models) != 5 {
+		t.Fatalf("len(Models) = %d, want 5", len(cfg.CodexIntegration.Models))
+	}
+}
+
+func TestParseConfigBytesCodexIntegrationStableDefaults(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte("host: 127.0.0.1\ncodex-integration:\n  enabled: true\n"))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", err)
+	}
+
+	want := map[string]string{
+		"xai/grok-4.5":                         "grok-4.5",
+		"xai/grok-build-0.1":                   "grok-build-0.1",
+		"antigravity/gemini-3.6-flash":         "gemini-3.6-flash",
+		"antigravity/gemini-3.1-pro":           "gemini-pro-agent",
+		"antigravity/claude-opus-4-6-thinking": "claude-opus-4-6-thinking",
+	}
+	for _, model := range cfg.CodexIntegration.Models {
+		upstream, ok := want[model.Slug]
+		if !ok {
+			t.Fatalf("unexpected stable model %q", model.Slug)
+		}
+		if model.UpstreamModel != upstream {
+			t.Fatalf("model %q upstream = %q, want %q", model.Slug, model.UpstreamModel, upstream)
+		}
+		delete(want, model.Slug)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing stable models: %#v", want)
+	}
+}
+
+func TestParseConfigBytesRejectsInvalidCodexIntegration(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name:    "loopback access with wildcard host",
+			yaml:    "host: 0.0.0.0\ncodex-integration:\n  enabled: true\n",
+			wantErr: "host",
+		},
+		{
+			name:    "duplicate slug",
+			yaml:    "host: 127.0.0.1\ncodex-integration:\n  enabled: true\n  models:\n    - slug: xai/grok\n      provider: xai\n      upstream-model: grok\n      visible: true\n    - slug: xai/grok\n      provider: xai\n      upstream-model: grok-2\n      visible: true\n",
+			wantErr: "models[1].slug",
+		},
+		{
+			name:    "unknown provider",
+			yaml:    "host: 127.0.0.1\ncodex-integration:\n  enabled: true\n  models:\n    - slug: other/model\n      provider: other\n      upstream-model: model\n      visible: true\n",
+			wantErr: "models[0].provider",
+		},
+		{
+			name:    "bare third party slug",
+			yaml:    "host: 127.0.0.1\ncodex-integration:\n  enabled: true\n  models:\n    - slug: grok-4.5\n      provider: xai\n      upstream-model: grok-4.5\n      visible: true\n",
+			wantErr: "models[0].slug",
+		},
+		{
+			name:    "catalog traversal",
+			yaml:    "host: 127.0.0.1\ncodex-integration:\n  enabled: true\n  catalog-file: ../catalog.json\n",
+			wantErr: "catalog-file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseConfigBytes([]byte(tt.yaml))
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ParseConfigBytes() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCloneForRuntimeDeepCopiesCodexIntegrationModels(t *testing.T) {
+	cfg := &Config{SDKConfig: SDKConfig{CodexIntegration: DefaultCodexIntegrationConfig()}}
+	clone := cfg.CloneForRuntime()
+	clone.CodexIntegration.Models[0].Slug = "xai/changed"
+	if cfg.CodexIntegration.Models[0].Slug == clone.CodexIntegration.Models[0].Slug {
+		t.Fatal("CloneForRuntime() shared CodexIntegration.Models backing storage")
+	}
+}
+
+func TestConfigExampleCodexIntegrationParses(t *testing.T) {
+	cfg, err := LoadConfig(filepath.Join("..", "..", "config.example.yaml"))
+	if err != nil {
+		t.Fatalf("LoadConfig(config.example.yaml) error = %v", err)
+	}
+	if cfg.CodexIntegration.Enabled {
+		t.Fatal("example config enables Codex integration")
+	}
+	if len(cfg.CodexIntegration.Models) != 5 {
+		t.Fatalf("len(example Models) = %d, want 5", len(cfg.CodexIntegration.Models))
+	}
+}

--- a/internal/config/codex_websocket_header_defaults_test.go
+++ b/internal/config/codex_websocket_header_defaults_test.go
@@ -37,6 +37,11 @@ func TestLoadConfigOptional_CodexIdentityConfuse(t *testing.T) {
 	configYAML := []byte(`
 codex:
   identity-confuse: true
+  connect-timeout-seconds: 11
+  response-header-timeout-seconds: 22
+  first-event-timeout-seconds: 33
+  stream-idle-timeout-seconds: 44
+  websocket-ping-interval-seconds: 5
 `)
 	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
 		t.Fatalf("failed to write config: %v", err)
@@ -49,5 +54,20 @@ codex:
 
 	if !cfg.Codex.IdentityConfuse {
 		t.Fatalf("IdentityConfuse = false, want true")
+	}
+	if got := cfg.Codex.ConnectTimeoutSeconds; got != 11 {
+		t.Fatalf("ConnectTimeoutSeconds = %d, want 11", got)
+	}
+	if got := cfg.Codex.ResponseHeaderTimeoutSeconds; got != 22 {
+		t.Fatalf("ResponseHeaderTimeoutSeconds = %d, want 22", got)
+	}
+	if got := cfg.Codex.FirstEventTimeoutSeconds; got != 33 {
+		t.Fatalf("FirstEventTimeoutSeconds = %d, want 33", got)
+	}
+	if got := cfg.Codex.StreamIdleTimeoutSeconds; got != 44 {
+		t.Fatalf("StreamIdleTimeoutSeconds = %d, want 44", got)
+	}
+	if got := cfg.Codex.WebsocketPingIntervalSeconds; got != 5 {
+		t.Fatalf("WebsocketPingIntervalSeconds = %d, want 5", got)
 	}
 }

--- a/internal/config/codex_websocket_header_defaults_test.go
+++ b/internal/config/codex_websocket_header_defaults_test.go
@@ -37,10 +37,7 @@ func TestLoadConfigOptional_CodexIdentityConfuse(t *testing.T) {
 	configYAML := []byte(`
 codex:
   identity-confuse: true
-  connect-timeout-seconds: 11
-  response-header-timeout-seconds: 22
-  first-event-timeout-seconds: 33
-  stream-idle-timeout-seconds: 44
+  websocket-idle-timeout-seconds: 44
   websocket-ping-interval-seconds: 5
 `)
 	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
@@ -55,17 +52,8 @@ codex:
 	if !cfg.Codex.IdentityConfuse {
 		t.Fatalf("IdentityConfuse = false, want true")
 	}
-	if got := cfg.Codex.ConnectTimeoutSeconds; got != 11 {
-		t.Fatalf("ConnectTimeoutSeconds = %d, want 11", got)
-	}
-	if got := cfg.Codex.ResponseHeaderTimeoutSeconds; got != 22 {
-		t.Fatalf("ResponseHeaderTimeoutSeconds = %d, want 22", got)
-	}
-	if got := cfg.Codex.FirstEventTimeoutSeconds; got != 33 {
-		t.Fatalf("FirstEventTimeoutSeconds = %d, want 33", got)
-	}
-	if got := cfg.Codex.StreamIdleTimeoutSeconds; got != 44 {
-		t.Fatalf("StreamIdleTimeoutSeconds = %d, want 44", got)
+	if got := cfg.Codex.WebsocketIdleTimeoutSeconds; got != 44 {
+		t.Fatalf("WebsocketIdleTimeoutSeconds = %d, want 44", got)
 	}
 	if got := cfg.Codex.WebsocketPingIntervalSeconds; got != 5 {
 		t.Fatalf("WebsocketPingIntervalSeconds = %d, want 5", got)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -284,7 +284,12 @@ type CodexHeaderDefaults struct {
 
 // CodexConfig configures provider-wide Codex request behavior.
 type CodexConfig struct {
-	IdentityConfuse bool `yaml:"identity-confuse" json:"identity-confuse"`
+	IdentityConfuse              bool `yaml:"identity-confuse" json:"identity-confuse"`
+	ConnectTimeoutSeconds        int  `yaml:"connect-timeout-seconds" json:"connect-timeout-seconds"`
+	ResponseHeaderTimeoutSeconds int  `yaml:"response-header-timeout-seconds" json:"response-header-timeout-seconds"`
+	FirstEventTimeoutSeconds     int  `yaml:"first-event-timeout-seconds" json:"first-event-timeout-seconds"`
+	StreamIdleTimeoutSeconds     int  `yaml:"stream-idle-timeout-seconds" json:"stream-idle-timeout-seconds"`
+	WebsocketPingIntervalSeconds int  `yaml:"websocket-ping-interval-seconds" json:"websocket-ping-interval-seconds"`
 }
 
 // TLSConfig holds HTTPS server settings.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -285,10 +285,7 @@ type CodexHeaderDefaults struct {
 // CodexConfig configures provider-wide Codex request behavior.
 type CodexConfig struct {
 	IdentityConfuse              bool `yaml:"identity-confuse" json:"identity-confuse"`
-	ConnectTimeoutSeconds        int  `yaml:"connect-timeout-seconds" json:"connect-timeout-seconds"`
-	ResponseHeaderTimeoutSeconds int  `yaml:"response-header-timeout-seconds" json:"response-header-timeout-seconds"`
-	FirstEventTimeoutSeconds     int  `yaml:"first-event-timeout-seconds" json:"first-event-timeout-seconds"`
-	StreamIdleTimeoutSeconds     int  `yaml:"stream-idle-timeout-seconds" json:"stream-idle-timeout-seconds"`
+	WebsocketIdleTimeoutSeconds  int  `yaml:"websocket-idle-timeout-seconds" json:"websocket-idle-timeout-seconds"`
 	WebsocketPingIntervalSeconds int  `yaml:"websocket-ping-interval-seconds" json:"websocket-ping-interval-seconds"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -730,7 +730,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		if optional {
 			if os.IsNotExist(err) || errors.Is(err, syscall.EISDIR) {
 				// Missing and optional: return empty config (cloud deploy standby).
-				cfg := &Config{}
+				cfg := &Config{SDKConfig: SDKConfig{CodexIntegration: DefaultCodexIntegrationConfig()}}
 				cfg.NormalizePluginsConfig()
 				return cfg, nil
 			}
@@ -740,7 +740,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	// In cloud deploy mode (optional=true), if file is empty or contains only whitespace, return empty config.
 	if optional && len(data) == 0 {
-		cfg := &Config{}
+		cfg := &Config{SDKConfig: SDKConfig{CodexIntegration: DefaultCodexIntegrationConfig()}}
 		cfg.NormalizePluginsConfig()
 		return cfg, nil
 	}
@@ -748,6 +748,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	// Unmarshal the YAML data into the Config struct.
 	var cfg Config
 	// Set defaults before unmarshal so that absent keys keep defaults.
+	cfg.CodexIntegration = DefaultCodexIntegrationConfig()
 	cfg.Host = "" // Default empty: binds to all interfaces (IPv4 + IPv6)
 	cfg.LoggingToFile = false
 	cfg.LogsMaxTotalSizeMB = 0
@@ -765,7 +766,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	if err = yaml.Unmarshal(data, &cfg); err != nil {
 		if optional {
 			// In cloud deploy mode, if YAML parsing fails, return empty config instead of error.
-			cfgOptional := &Config{}
+			cfgOptional := &Config{SDKConfig: SDKConfig{CodexIntegration: DefaultCodexIntegrationConfig()}}
 			cfgOptional.NormalizePluginsConfig()
 			return cfgOptional, nil
 		}
@@ -855,6 +856,10 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	// Validate raw payload rules and drop invalid entries.
 	cfg.SanitizePayloadRules()
+
+	if errNormalizeCodex := cfg.NormalizeCodexIntegration(); errNormalizeCodex != nil {
+		return nil, errNormalizeCodex
+	}
 
 	// Return the populated configuration struct.
 	return &cfg, nil

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -18,6 +18,7 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 
 	var cfg Config
 	// Keep defaults aligned with LoadConfigOptional.
+	cfg.CodexIntegration = DefaultCodexIntegrationConfig()
 	cfg.Host = "" // Default empty: binds to all interfaces (IPv4 + IPv6)
 	cfg.LoggingToFile = false
 	cfg.LogsMaxTotalSizeMB = 0
@@ -93,6 +94,9 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	cfg.OAuthExcludedModels = NormalizeOAuthExcludedModels(cfg.OAuthExcludedModels)
 	cfg.SanitizeOAuthModelAlias()
 	cfg.SanitizePayloadRules()
+	if err := cfg.NormalizeCodexIntegration(); err != nil {
+		return nil, err
+	}
 
 	return &cfg, nil
 }

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -55,6 +55,79 @@ type SDKConfig struct {
 	// NonStreamKeepAliveInterval controls how often blank lines are emitted for non-streaming responses.
 	// <= 0 disables keep-alives. Value is in seconds.
 	NonStreamKeepAliveInterval int `yaml:"nonstream-keepalive-interval,omitempty" json:"nonstream-keepalive-interval,omitempty"`
+
+	// CodexIntegration configures the optional Codex desktop/CLI integration.
+	// It is disabled by default and runs inside the existing proxy process.
+	CodexIntegration CodexIntegrationConfig `yaml:"codex-integration" json:"codex-integration"`
+}
+
+const (
+	DefaultCodexCatalogFile    = "cliproxyapi-catalog.json"
+	DefaultCodexMultiAgentMode = "v1"
+)
+
+// CodexIntegrationConfig controls Codex catalog generation and local configuration management.
+type CodexIntegrationConfig struct {
+	Enabled        bool                    `yaml:"enabled" json:"enabled"`
+	CodexHome      string                  `yaml:"codex-home,omitempty" json:"codex-home,omitempty"`
+	LoopbackAccess bool                    `yaml:"loopback-access" json:"loopback-access"`
+	AutoSync       bool                    `yaml:"auto-sync" json:"auto-sync"`
+	CatalogFile    string                  `yaml:"catalog-file" json:"catalog-file"`
+	MultiAgentMode string                  `yaml:"multi-agent-mode" json:"multi-agent-mode"`
+	Models         []CodexIntegrationModel `yaml:"models" json:"models"`
+}
+
+// CodexIntegrationModel maps a stable Codex-visible slug to one upstream provider model.
+type CodexIntegrationModel struct {
+	Slug                  string   `yaml:"slug" json:"slug"`
+	Provider              string   `yaml:"provider" json:"provider"`
+	UpstreamModel         string   `yaml:"upstream-model" json:"upstream-model"`
+	DisplayName           string   `yaml:"display-name,omitempty" json:"display-name,omitempty"`
+	Visible               bool     `yaml:"visible" json:"visible"`
+	Featured              bool     `yaml:"featured" json:"featured"`
+	Priority              int      `yaml:"priority,omitempty" json:"priority,omitempty"`
+	InputModalities       []string `yaml:"input-modalities,omitempty" json:"input-modalities,omitempty"`
+	SupportsTools         bool     `yaml:"supports-tools" json:"supports-tools"`
+	SupportsParallelTools bool     `yaml:"supports-parallel-tools" json:"supports-parallel-tools"`
+	SupportsWebSearch     bool     `yaml:"supports-web-search" json:"supports-web-search"`
+}
+
+// DefaultCodexIntegrationConfig returns the stable, opt-in Codex integration policy.
+func DefaultCodexIntegrationConfig() CodexIntegrationConfig {
+	return CodexIntegrationConfig{
+		Enabled:        false,
+		LoopbackAccess: true,
+		AutoSync:       true,
+		CatalogFile:    DefaultCodexCatalogFile,
+		MultiAgentMode: DefaultCodexMultiAgentMode,
+		Models: []CodexIntegrationModel{
+			{
+				Slug: "xai/grok-4.5", Provider: "xai", UpstreamModel: "grok-4.5",
+				DisplayName: "Grok 4.5", Visible: true, Featured: true, Priority: 2,
+				InputModalities: []string{"text", "image"}, SupportsTools: true, SupportsParallelTools: true, SupportsWebSearch: true,
+			},
+			{
+				Slug: "xai/grok-build-0.1", Provider: "xai", UpstreamModel: "grok-build-0.1",
+				DisplayName: "Grok Build 0.1", Visible: true, Priority: 50,
+				InputModalities: []string{"text", "image"}, SupportsTools: true, SupportsParallelTools: true, SupportsWebSearch: true,
+			},
+			{
+				Slug: "antigravity/gemini-3.6-flash", Provider: "antigravity", UpstreamModel: "gemini-3.6-flash",
+				DisplayName: "Gemini 3.6 Flash", Visible: true, Featured: true, Priority: 3,
+				InputModalities: []string{"text", "image"}, SupportsTools: true, SupportsParallelTools: true,
+			},
+			{
+				Slug: "antigravity/gemini-3.1-pro", Provider: "antigravity", UpstreamModel: "gemini-pro-agent",
+				DisplayName: "Gemini 3.1 Pro", Visible: true, Featured: true, Priority: 4,
+				InputModalities: []string{"text", "image"}, SupportsTools: true, SupportsParallelTools: true,
+			},
+			{
+				Slug: "antigravity/claude-opus-4-6-thinking", Provider: "antigravity", UpstreamModel: "claude-opus-4-6-thinking",
+				DisplayName: "Claude Opus 4.6 Thinking", Visible: true, Featured: true, Priority: 5,
+				InputModalities: []string{"text", "image"}, SupportsTools: true, SupportsParallelTools: true,
+			},
+		},
+	}
 }
 
 // StreamingConfig holds server streaming behavior configuration.

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -112,7 +112,7 @@ func DefaultCodexIntegrationConfig() CodexIntegrationConfig {
 				InputModalities: []string{"text", "image"}, SupportsTools: true, SupportsParallelTools: true, SupportsWebSearch: true,
 			},
 			{
-				Slug: "antigravity/gemini-3.6-flash", Provider: "antigravity", UpstreamModel: "gemini-3.6-flash",
+				Slug: "antigravity/gemini-3.6-flash", Provider: "antigravity", UpstreamModel: "gemini-3.6-flash-high",
 				DisplayName: "Gemini 3.6 Flash", Visible: true, Featured: true, Priority: 3,
 				InputModalities: []string{"text", "image"}, SupportsTools: true, SupportsParallelTools: true,
 			},

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -107,11 +107,6 @@ func DefaultCodexIntegrationConfig() CodexIntegrationConfig {
 				InputModalities: []string{"text", "image"}, SupportsTools: true, SupportsParallelTools: true, SupportsWebSearch: true,
 			},
 			{
-				Slug: "xai/grok-build-0.1", Provider: "xai", UpstreamModel: "grok-build-0.1",
-				DisplayName: "Grok Build 0.1", Visible: true, Priority: 50,
-				InputModalities: []string{"text", "image"}, SupportsTools: true, SupportsParallelTools: true, SupportsWebSearch: true,
-			},
-			{
 				Slug: "antigravity/gemini-3.6-flash", Provider: "antigravity", UpstreamModel: "gemini-3.6-flash-high",
 				DisplayName: "Gemini 3.6 Flash", Visible: true, Featured: true, Priority: 3,
 				InputModalities: []string{"text", "image"}, SupportsTools: true, SupportsParallelTools: true,

--- a/internal/registry/codex_client_models.go
+++ b/internal/registry/codex_client_models.go
@@ -27,6 +27,12 @@ type codexClientModelsStore struct {
 
 var codexClientCatalogStore = &codexClientModelsStore{}
 
+var codexClientModelsSubscribers = struct {
+	sync.Mutex
+	nextID      uint64
+	subscribers map[uint64]func(uint64)
+}{subscribers: make(map[uint64]func(uint64))}
+
 func init() {
 	if _, err := loadCodexClientModelsFromBytes(embeddedCodexClientModelsJSON, "embed"); err != nil {
 		log.Warnf("registry: failed to parse embedded codex_client_models.json (Codex client catalog will remain unavailable until a valid remote refresh): %v", err)
@@ -47,6 +53,26 @@ func GetCodexClientModelsSnapshot() ([]byte, uint64) {
 	return append([]byte(nil), codexClientCatalogStore.data...), codexClientCatalogStore.revision
 }
 
+// SubscribeCodexClientModelsChanges observes validated template revisions.
+func SubscribeCodexClientModelsChanges(callback func(uint64)) func() {
+	if callback == nil {
+		return func() {}
+	}
+	codexClientModelsSubscribers.Lock()
+	codexClientModelsSubscribers.nextID++
+	id := codexClientModelsSubscribers.nextID
+	codexClientModelsSubscribers.subscribers[id] = callback
+	codexClientModelsSubscribers.Unlock()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			codexClientModelsSubscribers.Lock()
+			delete(codexClientModelsSubscribers.subscribers, id)
+			codexClientModelsSubscribers.Unlock()
+		})
+	}
+}
+
 func loadCodexClientModelsFromBytes(data []byte, source string) (bool, error) {
 	if err := ValidateCodexClientModelsJSON(data); err != nil {
 		return false, fmt.Errorf("%s: %w", source, err)
@@ -54,13 +80,36 @@ func loadCodexClientModelsFromBytes(data []byte, source string) (bool, error) {
 
 	cloned := append([]byte(nil), data...)
 	codexClientCatalogStore.mu.Lock()
-	defer codexClientCatalogStore.mu.Unlock()
 	if bytes.Equal(codexClientCatalogStore.data, cloned) {
+		codexClientCatalogStore.mu.Unlock()
 		return false, nil
 	}
 	codexClientCatalogStore.data = cloned
 	codexClientCatalogStore.revision++
+	revision := codexClientCatalogStore.revision
+	codexClientCatalogStore.mu.Unlock()
+	notifyCodexClientModelsSubscribers(revision)
 	return true, nil
+}
+
+func notifyCodexClientModelsSubscribers(revision uint64) {
+	codexClientModelsSubscribers.Lock()
+	callbacks := make([]func(uint64), 0, len(codexClientModelsSubscribers.subscribers))
+	for _, callback := range codexClientModelsSubscribers.subscribers {
+		callbacks = append(callbacks, callback)
+	}
+	codexClientModelsSubscribers.Unlock()
+	for _, callback := range callbacks {
+		callback := callback
+		go func() {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					log.Errorf("Codex client model subscriber panic: %v", recovered)
+				}
+			}()
+			callback(revision)
+		}()
+	}
 }
 
 // ValidateCodexClientModelsJSON validates the fields required to serve a

--- a/internal/registry/codex_client_models_test.go
+++ b/internal/registry/codex_client_models_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestEmbeddedCodexClientModelsCatalogIsValid(t *testing.T) {
@@ -179,6 +180,42 @@ func TestRefreshCodexClientModelsKeepsLastValidSnapshot(t *testing.T) {
 				t.Fatalf("revision after failed refresh = %d, want %d", afterRevision, revision)
 			}
 		})
+	}
+}
+
+func TestCodexClientModelSubscribersReceiveChangesAndCanCancel(t *testing.T) {
+	original, _ := GetCodexClientModelsSnapshot()
+	t.Cleanup(func() {
+		if _, err := loadCodexClientModelsFromBytes(original, "test cleanup"); err != nil {
+			t.Fatalf("restore original catalog: %v", err)
+		}
+	})
+	revisions := make(chan uint64, 2)
+	cancel := SubscribeCodexClientModelsChanges(func(revision uint64) { revisions <- revision })
+	t.Cleanup(cancel)
+
+	changedCatalog := testCodexClientCatalog(t, testCodexClientModel("gpt-5.5", 77))
+	changed, err := loadCodexClientModelsFromBytes(changedCatalog, "subscriber test")
+	if err != nil || !changed {
+		t.Fatalf("loadCodexClientModelsFromBytes() = %t, %v", changed, err)
+	}
+	select {
+	case revision := <-revisions:
+		if revision == 0 {
+			t.Fatal("subscriber revision = 0")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for template subscriber")
+	}
+
+	cancel()
+	if _, err = loadCodexClientModelsFromBytes(original, "subscriber cancellation test"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case revision := <-revisions:
+		t.Fatalf("cancelled subscriber received revision %d", revision)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -146,6 +146,9 @@ type ModelRegistry struct {
 	availableModelsCache map[string]availableModelsCacheEntry
 	// hook is an optional callback sink for model registration changes
 	hook ModelRegistryHook
+	// subscribers are independent observers that do not replace the legacy hook.
+	subscribers      map[uint64]ModelRegistryHook
+	nextSubscriberID uint64
 }
 
 // Global model registry instance
@@ -228,42 +231,100 @@ func (r *ModelRegistry) SetHook(hook ModelRegistryHook) {
 	r.hook = hook
 }
 
+// SubscribeHook adds an independent model registry observer and returns an
+// idempotent cancellation function. It preserves the legacy SetHook observer.
+func (r *ModelRegistry) SubscribeHook(hook ModelRegistryHook) func() {
+	if r == nil || hook == nil {
+		return func() {}
+	}
+	r.mutex.Lock()
+	if r.subscribers == nil {
+		r.subscribers = make(map[uint64]ModelRegistryHook)
+	}
+	r.nextSubscriberID++
+	id := r.nextSubscriberID
+	r.subscribers[id] = hook
+	r.mutex.Unlock()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			r.mutex.Lock()
+			delete(r.subscribers, id)
+			r.mutex.Unlock()
+		})
+	}
+}
+
 const defaultModelRegistryHookTimeout = 5 * time.Second
 const modelQuotaExceededWindow = 5 * time.Minute
 
 func (r *ModelRegistry) triggerModelsRegistered(provider, clientID string, models []*ModelInfo) {
-	hook := r.hook
-	if hook == nil {
-		return
+	hooks := make([]ModelRegistryHook, 0, len(r.subscribers)+1)
+	if r.hook != nil {
+		hooks = append(hooks, r.hook)
 	}
-	modelsCopy := cloneModelInfosUnique(models)
-	go func() {
-		defer func() {
-			if recovered := recover(); recovered != nil {
-				log.Errorf("model registry hook OnModelsRegistered panic: %v", recovered)
-			}
+	for _, subscriber := range r.subscribers {
+		hooks = append(hooks, subscriber)
+	}
+	for _, hook := range hooks {
+		hook := hook
+		modelsCopy := cloneModelInfosUnique(models)
+		go func() {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					log.Errorf("model registry hook OnModelsRegistered panic: %v", recovered)
+				}
+			}()
+			ctx, cancel := context.WithTimeout(context.Background(), defaultModelRegistryHookTimeout)
+			defer cancel()
+			hook.OnModelsRegistered(ctx, provider, clientID, modelsCopy)
 		}()
-		ctx, cancel := context.WithTimeout(context.Background(), defaultModelRegistryHookTimeout)
-		defer cancel()
-		hook.OnModelsRegistered(ctx, provider, clientID, modelsCopy)
-	}()
+	}
 }
 
 func (r *ModelRegistry) triggerModelsUnregistered(provider, clientID string) {
-	hook := r.hook
-	if hook == nil {
-		return
+	hooks := make([]ModelRegistryHook, 0, len(r.subscribers)+1)
+	if r.hook != nil {
+		hooks = append(hooks, r.hook)
 	}
-	go func() {
-		defer func() {
-			if recovered := recover(); recovered != nil {
-				log.Errorf("model registry hook OnModelsUnregistered panic: %v", recovered)
-			}
+	for _, subscriber := range r.subscribers {
+		hooks = append(hooks, subscriber)
+	}
+	for _, hook := range hooks {
+		hook := hook
+		go func() {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					log.Errorf("model registry hook OnModelsUnregistered panic: %v", recovered)
+				}
+			}()
+			ctx, cancel := context.WithTimeout(context.Background(), defaultModelRegistryHookTimeout)
+			defer cancel()
+			hook.OnModelsUnregistered(ctx, provider, clientID)
 		}()
-		ctx, cancel := context.WithTimeout(context.Background(), defaultModelRegistryHookTimeout)
-		defer cancel()
-		hook.OnModelsUnregistered(ctx, provider, clientID)
-	}()
+	}
+}
+
+// GetProvidersForModel returns the currently registered provider identifiers for a model.
+func (r *ModelRegistry) GetProvidersForModel(modelID string) []string {
+	if r == nil {
+		return nil
+	}
+	modelID = strings.TrimSpace(modelID)
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	registration := r.models[modelID]
+	if registration == nil {
+		return nil
+	}
+	providers := make([]string, 0, len(registration.Providers))
+	for provider, count := range registration.Providers {
+		if count > 0 {
+			providers = append(providers, provider)
+		}
+	}
+	sort.Strings(providers)
+	return providers
 }
 
 // RegisterClient registers a client and its supported models

--- a/internal/registry/model_registry_hook_test.go
+++ b/internal/registry/model_registry_hook_test.go
@@ -202,3 +202,80 @@ func TestModelRegistryHook_PanicDoesNotAffectRegistry(t *testing.T) {
 		t.Fatal("timeout waiting for OnModelsUnregistered hook call")
 	}
 }
+
+func TestModelRegistrySubscribersPreserveLegacyHookAndCanCancel(t *testing.T) {
+	r := newTestModelRegistry()
+	legacy := &capturingHook{
+		registeredCh:   make(chan registeredCall, 2),
+		unregisteredCh: make(chan unregisteredCall, 2),
+	}
+	subscriber := &capturingHook{
+		registeredCh:   make(chan registeredCall, 2),
+		unregisteredCh: make(chan unregisteredCall, 2),
+	}
+	r.SetHook(legacy)
+	cancel := r.SubscribeHook(subscriber)
+	r.RegisterClient("client-1", "xai", []*ModelInfo{{ID: "grok-4.5"}})
+
+	for name, channel := range map[string]<-chan registeredCall{
+		"legacy": legacy.registeredCh, "subscriber": subscriber.registeredCh,
+	} {
+		select {
+		case call := <-channel:
+			if call.provider != "xai" || call.clientID != "client-1" || len(call.models) != 1 {
+				t.Fatalf("%s call = %#v", name, call)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timeout waiting for %s hook", name)
+		}
+	}
+
+	cancel()
+	cancel()
+	r.RegisterClient("client-2", "xai", []*ModelInfo{{ID: "grok-build-0.1"}})
+	select {
+	case call := <-subscriber.registeredCh:
+		t.Fatalf("cancelled subscriber received %#v", call)
+	case <-time.After(100 * time.Millisecond):
+	}
+	select {
+	case <-legacy.registeredCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("legacy hook stopped after subscriber cancellation")
+	}
+}
+
+type mutatingHook struct {
+	done chan struct{}
+}
+
+func (h *mutatingHook) OnModelsRegistered(_ context.Context, _, _ string, models []*ModelInfo) {
+	if len(models) > 0 {
+		models[0].ID = "mutated"
+	}
+	close(h.done)
+}
+
+func (h *mutatingHook) OnModelsUnregistered(context.Context, string, string) {}
+
+func TestModelRegistrySubscribersReceiveIndependentSnapshots(t *testing.T) {
+	r := newTestModelRegistry()
+	mutator := &mutatingHook{done: make(chan struct{})}
+	observer := &capturingHook{registeredCh: make(chan registeredCall, 1), unregisteredCh: make(chan unregisteredCall, 1)}
+	r.SubscribeHook(mutator)
+	r.SubscribeHook(observer)
+	r.RegisterClient("client-1", "xai", []*ModelInfo{{ID: "grok-4.5"}})
+	select {
+	case <-mutator.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for mutating subscriber")
+	}
+	select {
+	case call := <-observer.registeredCh:
+		if len(call.models) != 1 || call.models[0].ID != "grok-4.5" {
+			t.Fatalf("observer snapshot was mutated: %#v", call.models)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for observer")
+	}
+}

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -39,6 +39,51 @@ func TestAntigravityBuildRequest_SanitizesAntigravityToolSchema(t *testing.T) {
 	assertSchemaSanitizedAndPropertyPreserved(t, params)
 }
 
+func TestAntigravityBuildRequest_NormalizesBooleanToolSchemas(t *testing.T) {
+	body := buildRequestBodyFromRawPayload(t, "gemini-3.1-pro", []byte(`{
+		"request": {
+			"contents": [{"role":"user","parts":[{"text":"use the tool"}]}],
+			"tools": [{"function_declarations": [{
+				"name": "boolean_schema_tool",
+				"parametersJsonSchema": {
+					"type": "object",
+					"properties": {
+						"anything": true,
+						"never": false,
+						"list": {"type":"array","items":false}
+					},
+					"additionalProperties": false
+				}
+			}]}]
+		}
+	}`))
+	parameters, ok := extractFirstFunctionDeclaration(t, body)["parameters"].(map[string]any)
+	if !ok {
+		t.Fatalf("parameters missing: %#v", body)
+	}
+	properties, ok := parameters["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties missing: %#v", parameters)
+	}
+	anything, ok := properties["anything"].(map[string]any)
+	if !ok || len(anything) != 0 {
+		t.Fatalf("true schema = %#v, want empty object", properties["anything"])
+	}
+	never, ok := properties["never"].(map[string]any)
+	if !ok {
+		t.Fatalf("false schema missing: %#v", properties["never"])
+	}
+	neverProperties, _ := never["properties"].(map[string]any)
+	sentinel, _ := neverProperties["__cliproxyapi_never__"].(map[string]any)
+	enum, ok := sentinel["enum"].([]any)
+	if !ok || len(enum) != 0 {
+		t.Fatalf("false schema sentinel = %#v", never)
+	}
+	if _, exists := parameters["additionalProperties"]; exists {
+		t.Fatalf("unsupported additionalProperties reached Antigravity: %#v", parameters)
+	}
+}
+
 func TestAntigravityBuildRequest_SkipsSchemaSanitizationWithoutToolsField(t *testing.T) {
 	body := buildRequestBodyFromRawPayload(t, "gemini-3.1-flash-image", []byte(`{
 		"request": {

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -84,6 +84,29 @@ func TestAntigravityBuildRequest_NormalizesBooleanToolSchemas(t *testing.T) {
 	}
 }
 
+func TestAntigravityBuildRequest_NormalizesTopLevelTrueToolSchema(t *testing.T) {
+	body := buildRequestBodyFromRawPayload(t, "claude-opus-4-6-thinking", []byte(`{
+		"request": {
+			"contents": [{"role":"user","parts":[{"text":"use the tool"}]}],
+			"tools": [{"function_declarations": [{
+				"name": "boolean_schema_tool",
+				"parametersJsonSchema": true
+			}]}]
+		}
+	}`))
+	parameters, ok := extractFirstFunctionDeclaration(t, body)["parameters"].(map[string]any)
+	if !ok {
+		t.Fatalf("parameters missing: %#v", body)
+	}
+	if parameters["type"] != "object" {
+		t.Fatalf("parameters type = %#v, want object", parameters["type"])
+	}
+	required, ok := parameters["required"].([]any)
+	if !ok || len(required) != 1 || required[0] != "reason" {
+		t.Fatalf("parameters required = %#v, want reason placeholder", parameters["required"])
+	}
+}
+
 func TestAntigravityBuildRequest_SkipsSchemaSanitizationWithoutToolsField(t *testing.T) {
 	body := buildRequestBodyFromRawPayload(t, "gemini-3.1-flash-image", []byte(`{
 		"request": {

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -21,23 +21,19 @@ import (
 )
 
 func resetAntigravityCreditsRetryState() {
+	antigravityCreditsHintRefreshByID.Range(func(_, value any) bool {
+		state, ok := value.(*antigravityCreditsHintRefreshState)
+		if !ok || state == nil {
+			return true
+		}
+		state.mu.Lock()
+		state.mu.Unlock()
+		return true
+	})
 	antigravityCreditsFailureByAuth = sync.Map{}
 	antigravityShortCooldownByAuth = sync.Map{}
 	antigravityCreditsBalanceByAuth = sync.Map{}
 	antigravityCreditsHintRefreshByID = sync.Map{}
-}
-
-func waitForAntigravityCreditsRefresh(authID string) {
-	value, ok := antigravityCreditsHintRefreshByID.Load(authID)
-	if !ok {
-		return
-	}
-	state, ok := value.(*antigravityCreditsHintRefreshState)
-	if !ok || state == nil {
-		return
-	}
-	state.mu.Lock()
-	state.mu.Unlock()
 }
 
 type fakeAntigravityKVClient struct {
@@ -655,9 +651,6 @@ func TestEnsureAccessToken_WarmTokenLoadsCreditsHint(t *testing.T) {
 	}))
 
 	token, updatedAuth, err := exec.ensureAccessToken(ctx, auth)
-	t.Cleanup(func() {
-		waitForAntigravityCreditsRefresh(auth.ID)
-	})
 	if err != nil {
 		t.Fatalf("ensureAccessToken() error = %v", err)
 	}

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -27,6 +27,19 @@ func resetAntigravityCreditsRetryState() {
 	antigravityCreditsHintRefreshByID = sync.Map{}
 }
 
+func waitForAntigravityCreditsRefresh(authID string) {
+	value, ok := antigravityCreditsHintRefreshByID.Load(authID)
+	if !ok {
+		return
+	}
+	state, ok := value.(*antigravityCreditsHintRefreshState)
+	if !ok || state == nil {
+		return
+	}
+	state.mu.Lock()
+	state.mu.Unlock()
+}
+
 type fakeAntigravityKVClient struct {
 	values       map[string][]byte
 	getErr       error
@@ -642,6 +655,9 @@ func TestEnsureAccessToken_WarmTokenLoadsCreditsHint(t *testing.T) {
 	}))
 
 	token, updatedAuth, err := exec.ensureAccessToken(ctx, auth)
+	t.Cleanup(func() {
+		waitForAntigravityCreditsRefresh(auth.ID)
+	})
 	if err != nil {
 		t.Fatalf("ensureAccessToken() error = %v", err)
 	}

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1097,14 +1097,8 @@ func (e *CodexExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth
 	if err := e.PrepareRequest(httpReq, auth); err != nil {
 		return nil, err
 	}
-	timeouts := codexTimeoutsFromConfig(e.cfg)
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
-	helps.ConfigureHTTPClientTransportTimeouts(httpClient, timeouts.connect, timeouts.responseHeader)
-	response, err := doCodexHTTPRequest(ctx, httpClient, httpReq, timeouts.responseHeader)
-	if response != nil && response.Body != nil {
-		response.Body = newCodexActivityTimeoutBody(ctx, response.Body, timeouts.firstEvent, timeouts.streamIdle)
-	}
-	return response, err
+	return httpClient.Do(httpReq)
 }
 
 func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
@@ -1186,16 +1180,13 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		AuthType:  authType,
 		AuthValue: authValue,
 	})
-	timeouts := codexTimeoutsFromConfig(e.cfg)
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
-	helps.ConfigureHTTPClientTransportTimeouts(httpClient, timeouts.connect, timeouts.responseHeader)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := doCodexHTTPRequest(ctx, httpClient, httpReq, timeouts.responseHeader)
+	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
 	}
-	httpResp.Body = newCodexActivityTimeoutBody(ctx, httpResp.Body, timeouts.firstEvent, timeouts.streamIdle)
 	defer func() {
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("codex executor: close response body error: %v", errClose)
@@ -1344,16 +1335,13 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 		AuthType:  authType,
 		AuthValue: authValue,
 	})
-	timeouts := codexTimeoutsFromConfig(e.cfg)
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
-	helps.ConfigureHTTPClientTransportTimeouts(httpClient, timeouts.connect, timeouts.responseHeader)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := doCodexHTTPRequest(ctx, httpClient, httpReq, timeouts.responseHeader)
+	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
 	}
-	httpResp.Body = newCodexActivityTimeoutBody(ctx, httpResp.Body, timeouts.firstEvent, timeouts.streamIdle)
 	defer func() {
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("codex executor: close response body error: %v", errClose)
@@ -1463,16 +1451,13 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		AuthValue: authValue,
 	})
 
-	timeouts := codexTimeoutsFromConfig(e.cfg)
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
-	helps.ConfigureHTTPClientTransportTimeouts(httpClient, timeouts.connect, timeouts.responseHeader)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := doCodexHTTPRequest(ctx, httpClient, httpReq, timeouts.responseHeader)
+	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return nil, err
 	}
-	httpResp.Body = newCodexActivityTimeoutBody(ctx, httpResp.Body, timeouts.firstEvent, timeouts.streamIdle)
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		data, readErr := io.ReadAll(httpResp.Body)

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1097,8 +1097,14 @@ func (e *CodexExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth
 	if err := e.PrepareRequest(httpReq, auth); err != nil {
 		return nil, err
 	}
+	timeouts := codexTimeoutsFromConfig(e.cfg)
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
-	return httpClient.Do(httpReq)
+	helps.ConfigureHTTPClientTransportTimeouts(httpClient, timeouts.connect, timeouts.responseHeader)
+	response, err := doCodexHTTPRequest(ctx, httpClient, httpReq, timeouts.responseHeader)
+	if response != nil && response.Body != nil {
+		response.Body = newCodexActivityTimeoutBody(ctx, response.Body, timeouts.firstEvent, timeouts.streamIdle)
+	}
+	return response, err
 }
 
 func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
@@ -1180,13 +1186,16 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		AuthType:  authType,
 		AuthValue: authValue,
 	})
+	timeouts := codexTimeoutsFromConfig(e.cfg)
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
+	helps.ConfigureHTTPClientTransportTimeouts(httpClient, timeouts.connect, timeouts.responseHeader)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := doCodexHTTPRequest(ctx, httpClient, httpReq, timeouts.responseHeader)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
 	}
+	httpResp.Body = newCodexActivityTimeoutBody(ctx, httpResp.Body, timeouts.firstEvent, timeouts.streamIdle)
 	defer func() {
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("codex executor: close response body error: %v", errClose)
@@ -1335,13 +1344,16 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 		AuthType:  authType,
 		AuthValue: authValue,
 	})
+	timeouts := codexTimeoutsFromConfig(e.cfg)
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
+	helps.ConfigureHTTPClientTransportTimeouts(httpClient, timeouts.connect, timeouts.responseHeader)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := doCodexHTTPRequest(ctx, httpClient, httpReq, timeouts.responseHeader)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
 	}
+	httpResp.Body = newCodexActivityTimeoutBody(ctx, httpResp.Body, timeouts.firstEvent, timeouts.streamIdle)
 	defer func() {
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("codex executor: close response body error: %v", errClose)
@@ -1451,13 +1463,16 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		AuthValue: authValue,
 	})
 
+	timeouts := codexTimeoutsFromConfig(e.cfg)
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
+	helps.ConfigureHTTPClientTransportTimeouts(httpClient, timeouts.connect, timeouts.responseHeader)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := doCodexHTTPRequest(ctx, httpClient, httpReq, timeouts.responseHeader)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return nil, err
 	}
+	httpResp.Body = newCodexActivityTimeoutBody(ctx, httpResp.Body, timeouts.firstEvent, timeouts.streamIdle)
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		data, readErr := io.ReadAll(httpResp.Body)

--- a/internal/runtime/executor/codex_timeouts.go
+++ b/internal/runtime/executor/codex_timeouts.go
@@ -1,51 +1,38 @@
 package executor
 
 import (
-	"context"
 	"fmt"
-	"io"
 	"net/http"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
 
 const (
-	codexDefaultConnectTimeout        = 30 * time.Second
-	codexDefaultResponseHeaderTimeout = 60 * time.Second
-	codexDefaultFirstEventTimeout     = 2 * time.Minute
-	codexDefaultStreamIdleTimeout     = 15 * time.Minute
+	codexDefaultWebsocketIdleTimeout  = 15 * time.Minute
 	codexDefaultWebsocketPingInterval = 30 * time.Second
 )
 
 type codexTimeouts struct {
-	connect        time.Duration
-	responseHeader time.Duration
-	firstEvent     time.Duration
-	streamIdle     time.Duration
-	websocketPing  time.Duration
+	websocketIdle time.Duration
+	websocketPing time.Duration
 }
 
+// codexTimeoutsFromConfig only controls websocket liveness. HTTP requests and
+// response bodies remain governed by their request context so long-running
+// streams are never terminated by a proxy-owned deadline.
 func codexTimeoutsFromConfig(cfg *config.Config) codexTimeouts {
 	timeouts := codexTimeouts{
-		connect:        codexDefaultConnectTimeout,
-		responseHeader: codexDefaultResponseHeaderTimeout,
-		firstEvent:     codexDefaultFirstEventTimeout,
-		streamIdle:     codexDefaultStreamIdleTimeout,
-		websocketPing:  codexDefaultWebsocketPingInterval,
+		websocketIdle: codexDefaultWebsocketIdleTimeout,
+		websocketPing: codexDefaultWebsocketPingInterval,
 	}
 	if cfg == nil {
 		return timeouts
 	}
-	timeouts.connect = positiveSecondsOrDefault(cfg.Codex.ConnectTimeoutSeconds, timeouts.connect)
-	timeouts.responseHeader = positiveSecondsOrDefault(cfg.Codex.ResponseHeaderTimeoutSeconds, timeouts.responseHeader)
-	timeouts.firstEvent = positiveSecondsOrDefault(cfg.Codex.FirstEventTimeoutSeconds, timeouts.firstEvent)
-	timeouts.streamIdle = positiveSecondsOrDefault(cfg.Codex.StreamIdleTimeoutSeconds, timeouts.streamIdle)
+	timeouts.websocketIdle = positiveSecondsOrDefault(cfg.Codex.WebsocketIdleTimeoutSeconds, timeouts.websocketIdle)
 	timeouts.websocketPing = positiveSecondsOrDefault(cfg.Codex.WebsocketPingIntervalSeconds, timeouts.websocketPing)
-	if timeouts.websocketPing >= timeouts.streamIdle {
-		timeouts.websocketPing = timeouts.streamIdle / 2
+	if timeouts.websocketPing >= timeouts.websocketIdle {
+		timeouts.websocketPing = timeouts.websocketIdle / 2
 		if timeouts.websocketPing <= 0 {
 			timeouts.websocketPing = time.Second
 		}
@@ -79,154 +66,4 @@ func (codexRequestTimeoutError) RetryAfter() *time.Duration {
 
 func (codexRequestTimeoutError) IsRequestScoped() bool {
 	return true
-}
-
-type codexHTTPResult struct {
-	response *http.Response
-	err      error
-}
-
-// doCodexHTTPRequest bounds the wait for response headers without imposing a
-// total request timeout on long-lived response streams. The request context is
-// canceled when the returned response body is closed.
-func doCodexHTTPRequest(ctx context.Context, client *http.Client, req *http.Request, timeout time.Duration) (*http.Response, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	if client == nil {
-		return nil, fmt.Errorf("codex executor: HTTP client is nil")
-	}
-	if req == nil {
-		return nil, fmt.Errorf("codex executor: HTTP request is nil")
-	}
-
-	requestCtx, cancel := context.WithCancel(ctx)
-	request := req.WithContext(requestCtx)
-	resultCh := make(chan codexHTTPResult)
-	abandoned := make(chan struct{})
-	go func() {
-		response, err := client.Do(request)
-		select {
-		case resultCh <- codexHTTPResult{response: response, err: err}:
-		case <-abandoned:
-			if response != nil && response.Body != nil {
-				_ = response.Body.Close()
-			}
-		}
-	}()
-
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	select {
-	case result := <-resultCh:
-		if result.err != nil {
-			cancel()
-			return nil, result.err
-		}
-		if result.response == nil || result.response.Body == nil {
-			cancel()
-			return result.response, nil
-		}
-		result.response.Body = &cancelOnCloseReadCloser{ReadCloser: result.response.Body, cancel: cancel}
-		return result.response, nil
-	case <-ctx.Done():
-		close(abandoned)
-		cancel()
-		return nil, ctx.Err()
-	case <-timer.C:
-		close(abandoned)
-		cancel()
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		return nil, codexRequestTimeoutError{phase: "response header", timeout: timeout}
-	}
-}
-
-type cancelOnCloseReadCloser struct {
-	io.ReadCloser
-	cancel context.CancelFunc
-	once   sync.Once
-}
-
-func (r *cancelOnCloseReadCloser) Close() error {
-	err := r.ReadCloser.Close()
-	r.once.Do(r.cancel)
-	return err
-}
-
-type codexActivityTimeoutBody struct {
-	body         io.ReadCloser
-	ctx          context.Context
-	firstTimeout time.Duration
-	idleTimeout  time.Duration
-	started      atomic.Bool
-	timedOut     atomic.Bool
-	closeOnce    sync.Once
-}
-
-func newCodexActivityTimeoutBody(ctx context.Context, body io.ReadCloser, firstTimeout, idleTimeout time.Duration) io.ReadCloser {
-	if body == nil {
-		return nil
-	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	return &codexActivityTimeoutBody{
-		body:         body,
-		ctx:          ctx,
-		firstTimeout: firstTimeout,
-		idleTimeout:  idleTimeout,
-	}
-}
-
-func (r *codexActivityTimeoutBody) Read(p []byte) (int, error) {
-	if r.timedOut.Load() {
-		return 0, r.timeoutError()
-	}
-	timeout := r.firstTimeout
-	phase := "first event"
-	if r.started.Load() {
-		timeout = r.idleTimeout
-		phase = "stream idle"
-	}
-	timer := time.AfterFunc(timeout, func() {
-		r.timedOut.Store(true)
-		r.closeOnce.Do(func() { _ = r.body.Close() })
-	})
-	n, err := r.body.Read(p)
-	if !timer.Stop() || r.timedOut.Load() {
-		if ctxErr := r.ctx.Err(); ctxErr != nil {
-			return 0, ctxErr
-		}
-		return 0, codexRequestTimeoutError{phase: phase, timeout: timeout}
-	}
-	if n > 0 {
-		r.started.Store(true)
-	}
-	if err != nil {
-		if ctxErr := r.ctx.Err(); ctxErr != nil {
-			return n, ctxErr
-		}
-	}
-	return n, err
-}
-
-func (r *codexActivityTimeoutBody) Close() error {
-	var err error
-	r.closeOnce.Do(func() { err = r.body.Close() })
-	return err
-}
-
-func (r *codexActivityTimeoutBody) timeoutError() error {
-	if err := r.ctx.Err(); err != nil {
-		return err
-	}
-	phase := "first event"
-	timeout := r.firstTimeout
-	if r.started.Load() {
-		phase = "stream idle"
-		timeout = r.idleTimeout
-	}
-	return codexRequestTimeoutError{phase: phase, timeout: timeout}
 }

--- a/internal/runtime/executor/codex_timeouts.go
+++ b/internal/runtime/executor/codex_timeouts.go
@@ -1,0 +1,232 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+const (
+	codexDefaultConnectTimeout        = 30 * time.Second
+	codexDefaultResponseHeaderTimeout = 60 * time.Second
+	codexDefaultFirstEventTimeout     = 2 * time.Minute
+	codexDefaultStreamIdleTimeout     = 15 * time.Minute
+	codexDefaultWebsocketPingInterval = 30 * time.Second
+)
+
+type codexTimeouts struct {
+	connect        time.Duration
+	responseHeader time.Duration
+	firstEvent     time.Duration
+	streamIdle     time.Duration
+	websocketPing  time.Duration
+}
+
+func codexTimeoutsFromConfig(cfg *config.Config) codexTimeouts {
+	timeouts := codexTimeouts{
+		connect:        codexDefaultConnectTimeout,
+		responseHeader: codexDefaultResponseHeaderTimeout,
+		firstEvent:     codexDefaultFirstEventTimeout,
+		streamIdle:     codexDefaultStreamIdleTimeout,
+		websocketPing:  codexDefaultWebsocketPingInterval,
+	}
+	if cfg == nil {
+		return timeouts
+	}
+	timeouts.connect = positiveSecondsOrDefault(cfg.Codex.ConnectTimeoutSeconds, timeouts.connect)
+	timeouts.responseHeader = positiveSecondsOrDefault(cfg.Codex.ResponseHeaderTimeoutSeconds, timeouts.responseHeader)
+	timeouts.firstEvent = positiveSecondsOrDefault(cfg.Codex.FirstEventTimeoutSeconds, timeouts.firstEvent)
+	timeouts.streamIdle = positiveSecondsOrDefault(cfg.Codex.StreamIdleTimeoutSeconds, timeouts.streamIdle)
+	timeouts.websocketPing = positiveSecondsOrDefault(cfg.Codex.WebsocketPingIntervalSeconds, timeouts.websocketPing)
+	if timeouts.websocketPing >= timeouts.streamIdle {
+		timeouts.websocketPing = timeouts.streamIdle / 2
+		if timeouts.websocketPing <= 0 {
+			timeouts.websocketPing = time.Second
+		}
+	}
+	return timeouts
+}
+
+func positiveSecondsOrDefault(seconds int, fallback time.Duration) time.Duration {
+	if seconds <= 0 {
+		return fallback
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+type codexRequestTimeoutError struct {
+	phase   string
+	timeout time.Duration
+}
+
+func (e codexRequestTimeoutError) Error() string {
+	return fmt.Sprintf("codex executor: upstream %s timeout after %s", e.phase, e.timeout)
+}
+
+func (codexRequestTimeoutError) StatusCode() int {
+	return http.StatusGatewayTimeout
+}
+
+func (codexRequestTimeoutError) RetryAfter() *time.Duration {
+	return nil
+}
+
+func (codexRequestTimeoutError) IsRequestScoped() bool {
+	return true
+}
+
+type codexHTTPResult struct {
+	response *http.Response
+	err      error
+}
+
+// doCodexHTTPRequest bounds the wait for response headers without imposing a
+// total request timeout on long-lived response streams. The request context is
+// canceled when the returned response body is closed.
+func doCodexHTTPRequest(ctx context.Context, client *http.Client, req *http.Request, timeout time.Duration) (*http.Response, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if client == nil {
+		return nil, fmt.Errorf("codex executor: HTTP client is nil")
+	}
+	if req == nil {
+		return nil, fmt.Errorf("codex executor: HTTP request is nil")
+	}
+
+	requestCtx, cancel := context.WithCancel(ctx)
+	request := req.WithContext(requestCtx)
+	resultCh := make(chan codexHTTPResult)
+	abandoned := make(chan struct{})
+	go func() {
+		response, err := client.Do(request)
+		select {
+		case resultCh <- codexHTTPResult{response: response, err: err}:
+		case <-abandoned:
+			if response != nil && response.Body != nil {
+				_ = response.Body.Close()
+			}
+		}
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			cancel()
+			return nil, result.err
+		}
+		if result.response == nil || result.response.Body == nil {
+			cancel()
+			return result.response, nil
+		}
+		result.response.Body = &cancelOnCloseReadCloser{ReadCloser: result.response.Body, cancel: cancel}
+		return result.response, nil
+	case <-ctx.Done():
+		close(abandoned)
+		cancel()
+		return nil, ctx.Err()
+	case <-timer.C:
+		close(abandoned)
+		cancel()
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		return nil, codexRequestTimeoutError{phase: "response header", timeout: timeout}
+	}
+}
+
+type cancelOnCloseReadCloser struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (r *cancelOnCloseReadCloser) Close() error {
+	err := r.ReadCloser.Close()
+	r.once.Do(r.cancel)
+	return err
+}
+
+type codexActivityTimeoutBody struct {
+	body         io.ReadCloser
+	ctx          context.Context
+	firstTimeout time.Duration
+	idleTimeout  time.Duration
+	started      atomic.Bool
+	timedOut     atomic.Bool
+	closeOnce    sync.Once
+}
+
+func newCodexActivityTimeoutBody(ctx context.Context, body io.ReadCloser, firstTimeout, idleTimeout time.Duration) io.ReadCloser {
+	if body == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &codexActivityTimeoutBody{
+		body:         body,
+		ctx:          ctx,
+		firstTimeout: firstTimeout,
+		idleTimeout:  idleTimeout,
+	}
+}
+
+func (r *codexActivityTimeoutBody) Read(p []byte) (int, error) {
+	if r.timedOut.Load() {
+		return 0, r.timeoutError()
+	}
+	timeout := r.firstTimeout
+	phase := "first event"
+	if r.started.Load() {
+		timeout = r.idleTimeout
+		phase = "stream idle"
+	}
+	timer := time.AfterFunc(timeout, func() {
+		r.timedOut.Store(true)
+		r.closeOnce.Do(func() { _ = r.body.Close() })
+	})
+	n, err := r.body.Read(p)
+	if !timer.Stop() || r.timedOut.Load() {
+		if ctxErr := r.ctx.Err(); ctxErr != nil {
+			return 0, ctxErr
+		}
+		return 0, codexRequestTimeoutError{phase: phase, timeout: timeout}
+	}
+	if n > 0 {
+		r.started.Store(true)
+	}
+	if err != nil {
+		if ctxErr := r.ctx.Err(); ctxErr != nil {
+			return n, ctxErr
+		}
+	}
+	return n, err
+}
+
+func (r *codexActivityTimeoutBody) Close() error {
+	var err error
+	r.closeOnce.Do(func() { err = r.body.Close() })
+	return err
+}
+
+func (r *codexActivityTimeoutBody) timeoutError() error {
+	if err := r.ctx.Err(); err != nil {
+		return err
+	}
+	phase := "first event"
+	timeout := r.firstTimeout
+	if r.started.Load() {
+		phase = "stream idle"
+		timeout = r.idleTimeout
+	}
+	return codexRequestTimeoutError{phase: phase, timeout: timeout}
+}

--- a/internal/runtime/executor/codex_timeouts_test.go
+++ b/internal/runtime/executor/codex_timeouts_test.go
@@ -1,138 +1,36 @@
 package executor
 
 import (
-	"bytes"
-	"context"
-	"errors"
-	"io"
-	"net/http"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
 
-type codexRoundTripFunc func(*http.Request) (*http.Response, error)
+func TestCodexTimeoutsOnlyConfigureWebsocketLiveness(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Codex.WebsocketIdleTimeoutSeconds = 44
+	cfg.Codex.WebsocketPingIntervalSeconds = 5
 
-func (f codexRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
-
-func TestDoCodexHTTPRequestTimesOutWaitingForHeaders(t *testing.T) {
-	client := &http.Client{Transport: codexRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		<-req.Context().Done()
-		return nil, req.Context().Err()
-	})}
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.invalid", nil)
-	if err != nil {
-		t.Fatalf("NewRequestWithContext() error = %v", err)
+	timeouts := codexTimeoutsFromConfig(cfg)
+	if timeouts.websocketIdle != 44*time.Second {
+		t.Fatalf("websocketIdle = %s, want 44s", timeouts.websocketIdle)
 	}
-
-	started := time.Now()
-	_, err = doCodexHTTPRequest(context.Background(), client, req, 30*time.Millisecond)
-	if err == nil {
-		t.Fatal("doCodexHTTPRequest() error = nil, want response header timeout")
-	}
-	var timeoutErr codexRequestTimeoutError
-	if !errors.As(err, &timeoutErr) || timeoutErr.phase != "response header" {
-		t.Fatalf("doCodexHTTPRequest() error = %T %v, want response header timeout", err, err)
-	}
-	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
-		t.Fatalf("response header timeout took %s", elapsed)
+	if timeouts.websocketPing != 5*time.Second {
+		t.Fatalf("websocketPing = %s, want 5s", timeouts.websocketPing)
 	}
 }
 
-func TestCodexActivityTimeoutBodyTimesOutBeforeFirstEvent(t *testing.T) {
-	reader, writer := io.Pipe()
-	defer writer.Close()
-	body := newCodexActivityTimeoutBody(context.Background(), reader, 30*time.Millisecond, time.Second)
-	defer body.Close()
+func TestCodexTimeoutsKeepPingBelowIdleDeadline(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Codex.WebsocketIdleTimeoutSeconds = 10
+	cfg.Codex.WebsocketPingIntervalSeconds = 20
 
-	_, err := body.Read(make([]byte, 1))
-	var timeoutErr codexRequestTimeoutError
-	if !errors.As(err, &timeoutErr) || timeoutErr.phase != "first event" {
-		t.Fatalf("Read() error = %T %v, want first event timeout", err, err)
+	timeouts := codexTimeoutsFromConfig(cfg)
+	if timeouts.websocketIdle != 10*time.Second {
+		t.Fatalf("websocketIdle = %s, want 10s", timeouts.websocketIdle)
 	}
-}
-
-func TestCodexActivityTimeoutBodyTimesOutOnMidstreamStall(t *testing.T) {
-	reader, writer := io.Pipe()
-	body := newCodexActivityTimeoutBody(context.Background(), reader, time.Second, 30*time.Millisecond)
-	defer body.Close()
-	go func() {
-		_, _ = writer.Write([]byte("a"))
-	}()
-
-	buffer := make([]byte, 1)
-	if n, err := body.Read(buffer); n != 1 || err != nil {
-		t.Fatalf("first Read() = (%d, %v), want (1, nil)", n, err)
-	}
-	_, err := body.Read(buffer)
-	var timeoutErr codexRequestTimeoutError
-	if !errors.As(err, &timeoutErr) || timeoutErr.phase != "stream idle" {
-		t.Fatalf("second Read() error = %T %v, want stream idle timeout", err, err)
-	}
-	_ = writer.Close()
-}
-
-func TestCodexActivityTimeoutBodyAllowsLongActiveOutput(t *testing.T) {
-	reader, writer := io.Pipe()
-	body := newCodexActivityTimeoutBody(context.Background(), reader, 100*time.Millisecond, 50*time.Millisecond)
-	defer body.Close()
-	go func() {
-		defer writer.Close()
-		for _, chunk := range []string{"one", "two", "three", "four"} {
-			_, _ = writer.Write([]byte(chunk))
-			time.Sleep(20 * time.Millisecond)
-		}
-	}()
-
-	data, err := io.ReadAll(body)
-	if err != nil {
-		t.Fatalf("ReadAll() error = %v", err)
-	}
-	if got, want := string(data), "onetwothreefour"; got != want {
-		t.Fatalf("ReadAll() = %q, want %q", got, want)
-	}
-}
-
-func TestCodexActivityTimeoutBodyPrefersContextDeadline(t *testing.T) {
-	reader, writer := io.Pipe()
-	defer writer.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancel()
-	body := newCodexActivityTimeoutBody(ctx, reader, 40*time.Millisecond, time.Second)
-	defer body.Close()
-
-	_, err := body.Read(make([]byte, 1))
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("Read() error = %v, want context deadline exceeded", err)
-	}
-}
-
-func TestDoCodexHTTPRequestCancelsRequestWhenBodyCloses(t *testing.T) {
-	canceled := make(chan struct{})
-	client := &http.Client{Transport: codexRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		go func() {
-			<-req.Context().Done()
-			close(canceled)
-		}()
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Header:     make(http.Header),
-			Body:       io.NopCloser(bytes.NewBufferString("ok")),
-		}, nil
-	})}
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.invalid", strings.NewReader(""))
-	response, err := doCodexHTTPRequest(context.Background(), client, req, time.Second)
-	if err != nil {
-		t.Fatalf("doCodexHTTPRequest() error = %v", err)
-	}
-	if errClose := response.Body.Close(); errClose != nil {
-		t.Fatalf("Close() error = %v", errClose)
-	}
-	select {
-	case <-canceled:
-	case <-time.After(time.Second):
-		t.Fatal("request context was not canceled when response body closed")
+	if timeouts.websocketPing != 5*time.Second {
+		t.Fatalf("websocketPing = %s, want 5s", timeouts.websocketPing)
 	}
 }

--- a/internal/runtime/executor/codex_timeouts_test.go
+++ b/internal/runtime/executor/codex_timeouts_test.go
@@ -1,0 +1,138 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type codexRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f codexRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestDoCodexHTTPRequestTimesOutWaitingForHeaders(t *testing.T) {
+	client := &http.Client{Transport: codexRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.invalid", nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() error = %v", err)
+	}
+
+	started := time.Now()
+	_, err = doCodexHTTPRequest(context.Background(), client, req, 30*time.Millisecond)
+	if err == nil {
+		t.Fatal("doCodexHTTPRequest() error = nil, want response header timeout")
+	}
+	var timeoutErr codexRequestTimeoutError
+	if !errors.As(err, &timeoutErr) || timeoutErr.phase != "response header" {
+		t.Fatalf("doCodexHTTPRequest() error = %T %v, want response header timeout", err, err)
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("response header timeout took %s", elapsed)
+	}
+}
+
+func TestCodexActivityTimeoutBodyTimesOutBeforeFirstEvent(t *testing.T) {
+	reader, writer := io.Pipe()
+	defer writer.Close()
+	body := newCodexActivityTimeoutBody(context.Background(), reader, 30*time.Millisecond, time.Second)
+	defer body.Close()
+
+	_, err := body.Read(make([]byte, 1))
+	var timeoutErr codexRequestTimeoutError
+	if !errors.As(err, &timeoutErr) || timeoutErr.phase != "first event" {
+		t.Fatalf("Read() error = %T %v, want first event timeout", err, err)
+	}
+}
+
+func TestCodexActivityTimeoutBodyTimesOutOnMidstreamStall(t *testing.T) {
+	reader, writer := io.Pipe()
+	body := newCodexActivityTimeoutBody(context.Background(), reader, time.Second, 30*time.Millisecond)
+	defer body.Close()
+	go func() {
+		_, _ = writer.Write([]byte("a"))
+	}()
+
+	buffer := make([]byte, 1)
+	if n, err := body.Read(buffer); n != 1 || err != nil {
+		t.Fatalf("first Read() = (%d, %v), want (1, nil)", n, err)
+	}
+	_, err := body.Read(buffer)
+	var timeoutErr codexRequestTimeoutError
+	if !errors.As(err, &timeoutErr) || timeoutErr.phase != "stream idle" {
+		t.Fatalf("second Read() error = %T %v, want stream idle timeout", err, err)
+	}
+	_ = writer.Close()
+}
+
+func TestCodexActivityTimeoutBodyAllowsLongActiveOutput(t *testing.T) {
+	reader, writer := io.Pipe()
+	body := newCodexActivityTimeoutBody(context.Background(), reader, 100*time.Millisecond, 50*time.Millisecond)
+	defer body.Close()
+	go func() {
+		defer writer.Close()
+		for _, chunk := range []string{"one", "two", "three", "four"} {
+			_, _ = writer.Write([]byte(chunk))
+			time.Sleep(20 * time.Millisecond)
+		}
+	}()
+
+	data, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if got, want := string(data), "onetwothreefour"; got != want {
+		t.Fatalf("ReadAll() = %q, want %q", got, want)
+	}
+}
+
+func TestCodexActivityTimeoutBodyPrefersContextDeadline(t *testing.T) {
+	reader, writer := io.Pipe()
+	defer writer.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	body := newCodexActivityTimeoutBody(ctx, reader, 40*time.Millisecond, time.Second)
+	defer body.Close()
+
+	_, err := body.Read(make([]byte, 1))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Read() error = %v, want context deadline exceeded", err)
+	}
+}
+
+func TestDoCodexHTTPRequestCancelsRequestWhenBodyCloses(t *testing.T) {
+	canceled := make(chan struct{})
+	client := &http.Client{Transport: codexRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		go func() {
+			<-req.Context().Done()
+			close(canceled)
+		}()
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewBufferString("ok")),
+		}, nil
+	})}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.invalid", strings.NewReader(""))
+	response, err := doCodexHTTPRequest(context.Background(), client, req, time.Second)
+	if err != nil {
+		t.Fatalf("doCodexHTTPRequest() error = %v", err)
+	}
+	if errClose := response.Body.Close(); errClose != nil {
+		t.Fatalf("Close() error = %v", errClose)
+	}
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("request context was not canceled when response body closed")
+	}
+}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -36,7 +36,6 @@ import (
 
 const (
 	codexResponsesWebsocketBetaHeaderValue = "responses_websockets=2026-02-06"
-	codexResponsesWebsocketIdleTimeout     = 5 * time.Minute
 	codexResponsesWebsocketHandshakeTO     = 30 * time.Second
 )
 
@@ -172,6 +171,18 @@ func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, 
 	return conn.WriteMessage(msgType, payload)
 }
 
+func (s *codexWebsocketSession) writeControl(conn *websocket.Conn, msgType int, payload []byte, deadline time.Time) error {
+	if s == nil {
+		return fmt.Errorf("codex websockets executor: session is nil")
+	}
+	if conn == nil {
+		return fmt.Errorf("codex websockets executor: websocket conn is nil")
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	return conn.WriteControl(msgType, payload, deadline)
+}
+
 // sendTerminalWebsocketRead reports whether it invalidated a full channel's connection before waiting.
 func sendTerminalWebsocketRead(ch chan<- codexWebsocketRead, done <-chan struct{}, event codexWebsocketRead, invalidate func()) bool {
 	select {
@@ -193,16 +204,25 @@ func sendTerminalWebsocketRead(ch chan<- codexWebsocketRead, done <-chan struct{
 	return invalidated
 }
 
-func (s *codexWebsocketSession) configureConn(conn *websocket.Conn) {
+func (s *codexWebsocketSession) configureConn(conn *websocket.Conn, idleTimeout time.Duration) {
 	if s == nil || conn == nil {
 		return
 	}
 	s.resetUpstreamDisconnectError(conn)
+	refreshReadDeadline := func() error {
+		return conn.SetReadDeadline(time.Now().Add(idleTimeout))
+	}
 	conn.SetPingHandler(func(appData string) error {
+		if err := refreshReadDeadline(); err != nil {
+			return err
+		}
 		s.writeMu.Lock()
 		defer s.writeMu.Unlock()
 		// Reply pongs from the same write lock to avoid concurrent writes.
 		return conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(10*time.Second))
+	})
+	conn.SetPongHandler(func(string) error {
+		return refreshReadDeadline()
 	})
 	defaultCloseHandler := conn.CloseHandler()
 	conn.SetCloseHandler(func(code int, text string) error {
@@ -404,7 +424,12 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			return resp, statusErr{code: respHS.StatusCode, msg: string(bodyErr)}
 		}
 		helps.RecordAPIWebsocketError(ctx, e.cfg, "dial", errDial)
-		return resp, errDial
+		if ctx != nil && ctx.Err() != nil {
+			return resp, ctx.Err()
+		}
+		// No websocket handshake response means no request payload was sent, so
+		// falling back to HTTP cannot duplicate an accepted request.
+		return e.CodexExecutor.Execute(ctx, auth, req, opts)
 	}
 	recordAPIWebsocketHandshake(ctx, e.cfg, respHS)
 	reporter.StartResponseTTFT()
@@ -434,63 +459,41 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		errSend = mapCodexWebsocketWriteError(sess, conn, errSend)
 		if sess != nil {
 			e.invalidateUpstreamConn(sess, conn, "send_error", errSend)
-			if !shouldRetryCodexWebsocketSend(errSend) {
-				helps.RecordAPIWebsocketError(ctx, e.cfg, "send", errSend)
-				return resp, errSend
-			}
-
-			// Retry once with a fresh websocket connection. This is mainly to handle
-			// upstream closing the socket between sequential requests within the same
-			// execution session.
-			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
-			if errDialRetry == nil && connRetry != nil {
-				conn = connRetry
-				readCh = sess.activate(conn)
-				wsReqBodyRetry := buildCodexWebsocketRequestBody(upstreamBody)
-				helps.RecordAPIWebsocketRequest(ctx, e.cfg, helps.UpstreamRequestLog{
-					URL:       wsURL,
-					Method:    "WEBSOCKET",
-					Headers:   wsHeaders.Clone(),
-					Body:      wsReqBodyRetry,
-					Provider:  e.Identifier(),
-					AuthID:    authID,
-					AuthLabel: authLabel,
-					AuthType:  authType,
-					AuthValue: authValue,
-				})
-				recordAPIWebsocketHandshake(ctx, e.cfg, respHSRetry)
-				reporter.StartResponseTTFT()
-				if errSendRetry := writeCodexWebsocketMessage(sess, conn, wsReqBodyRetry); errSendRetry == nil {
-					wsReqBody = wsReqBodyRetry
-				} else {
-					errSendRetry = mapCodexWebsocketWriteError(sess, connRetry, errSendRetry)
-					e.invalidateUpstreamConn(sess, connRetry, "send_error", errSendRetry)
-					helps.RecordAPIWebsocketError(ctx, e.cfg, "send_retry", errSendRetry)
-					return resp, errSendRetry
-				}
-			} else {
-				closeHTTPResponseBody(respHSRetry, "codex websockets executor: close handshake response body error")
-				helps.RecordAPIWebsocketError(ctx, e.cfg, "dial_retry", errDialRetry)
-				return resp, errDialRetry
-			}
-		} else {
-			helps.RecordAPIWebsocketError(ctx, e.cfg, "send", errSend)
-			return resp, errSend
 		}
+		// A websocket write error can occur after a partial payload write. Never
+		// resend automatically because tool execution may already have started.
+		helps.RecordAPIWebsocketError(ctx, e.cfg, "send", errSend)
+		return resp, errSend
+	}
+	if sess == nil {
+		stopPings := startStandaloneCodexWebsocketPings(conn, codexTimeoutsFromConfig(e.cfg).websocketPing)
+		defer stopPings()
 	}
 
+	timeouts := codexTimeoutsFromConfig(e.cfg)
+	firstEvent := true
 	outputItemsByIndex := make(map[int64][]byte)
 	var outputItemsFallback [][]byte
 	for {
 		if ctx != nil && ctx.Err() != nil {
 			return resp, ctx.Err()
 		}
-		msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, conn, readCh)
+		readTimeout := timeouts.streamIdle
+		readPhase := "stream idle"
+		if firstEvent {
+			readTimeout = timeouts.firstEvent
+			readPhase = "first event"
+		}
+		msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, conn, readCh, readTimeout, readPhase)
 		if errRead != nil {
+			if sess != nil {
+				e.invalidateUpstreamConn(sess, conn, "read_error", errRead)
+			}
 			mappedErr := mapCodexWebsocketReadError(errRead)
 			helps.RecordAPIWebsocketError(ctx, e.cfg, "read", mappedErr)
 			return resp, mappedErr
 		}
+		firstEvent = false
 		if msgType != websocket.TextMessage {
 			if msgType == websocket.BinaryMessage {
 				err = fmt.Errorf("codex websockets executor: unexpected binary message")
@@ -662,7 +665,10 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		if sess != nil {
 			sess.reqMu.Unlock()
 		}
-		return nil, errDial
+		if ctx != nil && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return e.CodexExecutor.ExecuteStream(ctx, auth, req, opts)
 	}
 	recordAPIWebsocketHandshake(ctx, e.cfg, respHS)
 	reporter.StartResponseTTFT()
@@ -681,53 +687,15 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		helps.RecordAPIWebsocketError(ctx, e.cfg, "send", errSend)
 		if sess != nil {
 			e.invalidateUpstreamConn(sess, conn, "send_error", errSend)
-			if !shouldRetryCodexWebsocketSend(errSend) {
-				sess.clearActive(conn, readCh)
-				sess.reqMu.Unlock()
-				return nil, errSend
-			}
-
-			// Retry once with a new websocket connection for the same execution session.
-			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
-			if errDialRetry != nil || connRetry == nil {
-				closeHTTPResponseBody(respHSRetry, "codex websockets executor: close handshake response body error")
-				helps.RecordAPIWebsocketError(ctx, e.cfg, "dial_retry", errDialRetry)
-				sess.clearActive(conn, readCh)
-				sess.reqMu.Unlock()
-				return nil, errDialRetry
-			}
-			conn = connRetry
-			readCh = sess.activate(conn)
-			wsReqBodyRetry := buildCodexWebsocketRequestBody(upstreamBody)
-			helps.RecordAPIWebsocketRequest(ctx, e.cfg, helps.UpstreamRequestLog{
-				URL:       wsURL,
-				Method:    "WEBSOCKET",
-				Headers:   wsHeaders.Clone(),
-				Body:      wsReqBodyRetry,
-				Provider:  e.Identifier(),
-				AuthID:    authID,
-				AuthLabel: authLabel,
-				AuthType:  authType,
-				AuthValue: authValue,
-			})
-			recordAPIWebsocketHandshake(ctx, e.cfg, respHSRetry)
-			reporter.StartResponseTTFT()
-			if errSendRetry := writeCodexWebsocketMessage(sess, conn, wsReqBodyRetry); errSendRetry != nil {
-				errSendRetry = mapCodexWebsocketWriteError(sess, conn, errSendRetry)
-				helps.RecordAPIWebsocketError(ctx, e.cfg, "send_retry", errSendRetry)
-				e.invalidateUpstreamConn(sess, conn, "send_error", errSendRetry)
-				sess.clearActive(conn, readCh)
-				sess.reqMu.Unlock()
-				return nil, errSendRetry
-			}
-			wsReqBody = wsReqBodyRetry
+			sess.clearActive(conn, readCh)
+			sess.reqMu.Unlock()
 		} else {
 			logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, "send_error", errSend)
 			if errClose := conn.Close(); errClose != nil {
 				log.Errorf("codex websockets executor: close websocket error: %v", errClose)
 			}
-			return nil, errSend
 		}
+		return nil, errSend
 	}
 
 	out := make(chan cliproxyexecutor.StreamChunk)
@@ -736,6 +704,10 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		var terminateErr error
 
 		defer close(out)
+		if sess == nil {
+			stopPings := startStandaloneCodexWebsocketPings(conn, codexTimeoutsFromConfig(e.cfg).websocketPing)
+			defer stopPings()
+		}
 		defer func() {
 			if sess != nil {
 				sess.clearActive(conn, readCh)
@@ -762,6 +734,8 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		}
 
 		claudeInputTokens := helps.NewClaudeInputTokenState(from, to, responseFormat, originalPayload)
+		timeouts := codexTimeoutsFromConfig(e.cfg)
+		firstEvent := true
 		var param any
 		outputItemsByIndex := make(map[int64][]byte)
 		var outputItemsFallback [][]byte
@@ -772,7 +746,13 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				_ = send(cliproxyexecutor.StreamChunk{Err: ctx.Err()})
 				return
 			}
-			msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, conn, readCh)
+			readTimeout := timeouts.streamIdle
+			readPhase := "stream idle"
+			if firstEvent {
+				readTimeout = timeouts.firstEvent
+				readPhase = "first event"
+			}
+			msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, conn, readCh, readTimeout, readPhase)
 			if errRead != nil {
 				if sess != nil && ctx != nil && ctx.Err() != nil {
 					terminateReason = "context_done"
@@ -781,6 +761,9 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 					return
 				}
 				mappedErr := mapCodexWebsocketReadError(errRead)
+				if sess != nil {
+					e.invalidateUpstreamConn(sess, conn, "read_error", mappedErr)
+				}
 				terminateReason = "read_error"
 				terminateErr = mappedErr
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "read", mappedErr)
@@ -788,6 +771,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				_ = send(cliproxyexecutor.StreamChunk{Err: mappedErr})
 				return
 			}
+			firstEvent = false
 			if msgType != websocket.TextMessage {
 				if msgType == websocket.BinaryMessage {
 					err = fmt.Errorf("codex websockets executor: unexpected binary message")
@@ -899,8 +883,8 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 }
 
 func (e *CodexWebsocketsExecutor) dialCodexWebsocket(ctx context.Context, auth *cliproxyauth.Auth, wsURL string, headers http.Header) (*websocket.Conn, *http.Response, error) {
-	dialer := newProxyAwareWebsocketDialer(e.cfg, auth)
-	dialer.HandshakeTimeout = codexResponsesWebsocketHandshakeTO
+	timeouts := codexTimeoutsFromConfig(e.cfg)
+	dialer := newProxyAwareWebsocketDialer(e.cfg, auth, timeouts.connect, timeouts.responseHeader)
 	dialer.EnableCompression = true
 	if ctx == nil {
 		ctx = context.Background()
@@ -936,6 +920,9 @@ func mapCodexWebsocketWriteError(sess *codexWebsocketSession, conn *websocket.Co
 	return mapCodexWebsocketReadError(upstreamErr)
 }
 
+// shouldRetryCodexWebsocketSend remains shared with the xAI websocket
+// executor. Codex request payloads deliberately do not use this retry path
+// because a failed write may still have been partially accepted upstream.
 func shouldRetryCodexWebsocketSend(err error) bool {
 	if err == nil {
 		return false
@@ -992,13 +979,22 @@ func buildCodexWebsocketRequestBody(body []byte) []byte {
 	return fallback
 }
 
-func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession, conn *websocket.Conn, readCh chan codexWebsocketRead) (int, []byte, error) {
+func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession, conn *websocket.Conn, readCh chan codexWebsocketRead, timeout time.Duration, phase string) (int, []byte, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if sess == nil {
 		if conn == nil {
 			return 0, nil, fmt.Errorf("codex websockets executor: websocket conn is nil")
 		}
-		_ = conn.SetReadDeadline(time.Now().Add(codexResponsesWebsocketIdleTimeout))
+		_ = conn.SetReadDeadline(time.Now().Add(timeout))
 		msgType, payload, errRead := conn.ReadMessage()
+		if networkErr, ok := errRead.(net.Error); ok && networkErr.Timeout() {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return 0, nil, ctxErr
+			}
+			return 0, nil, codexRequestTimeoutError{phase: phase, timeout: timeout}
+		}
 		return msgType, payload, errRead
 	}
 	if conn == nil {
@@ -1007,10 +1003,17 @@ func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession,
 	if readCh == nil {
 		return 0, nil, fmt.Errorf("codex websockets executor: session read channel is nil")
 	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return 0, nil, ctx.Err()
+		case <-timer.C:
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return 0, nil, ctxErr
+			}
+			return 0, nil, codexRequestTimeoutError{phase: phase, timeout: timeout}
 		case ev, ok := <-readCh:
 			if !ok {
 				return 0, nil, fmt.Errorf("codex websockets executor: session read channel closed")
@@ -1026,13 +1029,21 @@ func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession,
 	}
 }
 
-func newProxyAwareWebsocketDialer(cfg *config.Config, auth *cliproxyauth.Auth) *websocket.Dialer {
+func newProxyAwareWebsocketDialer(cfg *config.Config, auth *cliproxyauth.Auth, timeoutValues ...time.Duration) *websocket.Dialer {
+	connectTimeout := codexDefaultConnectTimeout
+	handshakeTimeout := codexResponsesWebsocketHandshakeTO
+	if len(timeoutValues) > 0 && timeoutValues[0] > 0 {
+		connectTimeout = timeoutValues[0]
+	}
+	if len(timeoutValues) > 1 && timeoutValues[1] > 0 {
+		handshakeTimeout = timeoutValues[1]
+	}
 	dialer := &websocket.Dialer{
 		Proxy:             http.ProxyFromEnvironment,
-		HandshakeTimeout:  codexResponsesWebsocketHandshakeTO,
+		HandshakeTimeout:  handshakeTimeout,
 		EnableCompression: true,
 		NetDialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
+			Timeout:   connectTimeout,
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
 	}
@@ -1668,10 +1679,16 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 			sess.connMu.Lock()
 			sess.readerConn = conn
 			sess.connMu.Unlock()
-			sess.configureConn(conn)
+			sess.configureConn(conn, codexTimeoutsFromConfig(e.cfg).streamIdle)
 			go e.readUpstreamLoop(sess, conn)
 		}
-		return conn, nil, nil
+		// Validate a reused socket before writing the business payload. A failed
+		// control write is safe to reconnect because the request is not sent yet.
+		if errPing := sess.writeControl(conn, websocket.PingMessage, nil, time.Now().Add(10*time.Second)); errPing == nil {
+			return conn, nil, nil
+		} else {
+			e.invalidateUpstreamConn(sess, conn, "preflight_ping_error", errPing)
+		}
 	}
 
 	conn, resp, errDial := e.dialCodexWebsocket(ctx, auth, wsURL, headers)
@@ -1694,7 +1711,7 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 	sess.readerConn = conn
 	sess.connMu.Unlock()
 
-	sess.configureConn(conn)
+	sess.configureConn(conn, codexTimeoutsFromConfig(e.cfg).streamIdle)
 	go e.readUpstreamLoop(sess, conn)
 	logCodexWebsocketConnected(sess.sessionID, authID, wsURL)
 	return conn, resp, nil
@@ -1704,8 +1721,26 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 	if e == nil || sess == nil || conn == nil {
 		return
 	}
+	timeouts := codexTimeoutsFromConfig(e.cfg)
+	pingDone := make(chan struct{})
+	defer close(pingDone)
+	go func() {
+		ticker := time.NewTicker(timeouts.websocketPing)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-pingDone:
+				return
+			case <-ticker.C:
+				if errPing := sess.writeControl(conn, websocket.PingMessage, nil, time.Now().Add(10*time.Second)); errPing != nil {
+					_ = conn.Close()
+					return
+				}
+			}
+		}
+	}()
 	for {
-		_ = conn.SetReadDeadline(time.Now().Add(codexResponsesWebsocketIdleTimeout))
+		_ = conn.SetReadDeadline(time.Now().Add(timeouts.streamIdle))
 		msgType, payload, errRead := conn.ReadMessage()
 		if errRead != nil {
 			invalidate := func() {
@@ -1724,6 +1759,7 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 			}
 			return
 		}
+		_ = conn.SetReadDeadline(time.Now().Add(timeouts.streamIdle))
 
 		if msgType != websocket.TextMessage {
 			if msgType == websocket.BinaryMessage {
@@ -1756,6 +1792,29 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 		case <-done:
 		}
 	}
+}
+
+func startStandaloneCodexWebsocketPings(conn *websocket.Conn, interval time.Duration) func() {
+	if conn == nil || interval <= 0 {
+		return func() {}
+	}
+	done := make(chan struct{})
+	var once sync.Once
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				if err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(10*time.Second)); err != nil {
+					return
+				}
+			}
+		}
+	}()
+	return func() { once.Do(func() { close(done) }) }
 }
 
 func (e *CodexWebsocketsExecutor) invalidateUpstreamConn(sess *codexWebsocketSession, conn *websocket.Conn, reason string, err error) {

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -466,25 +466,20 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		return resp, errSend
 	}
 	if sess == nil {
-		stopPings := startStandaloneCodexWebsocketPings(conn, codexTimeoutsFromConfig(e.cfg).websocketPing)
+		timeouts := codexTimeoutsFromConfig(e.cfg)
+		configureStandaloneCodexWebsocket(conn, timeouts.websocketIdle)
+		stopPings := startStandaloneCodexWebsocketPings(conn, timeouts.websocketPing)
 		defer stopPings()
 	}
 
 	timeouts := codexTimeoutsFromConfig(e.cfg)
-	firstEvent := true
 	outputItemsByIndex := make(map[int64][]byte)
 	var outputItemsFallback [][]byte
 	for {
 		if ctx != nil && ctx.Err() != nil {
 			return resp, ctx.Err()
 		}
-		readTimeout := timeouts.streamIdle
-		readPhase := "stream idle"
-		if firstEvent {
-			readTimeout = timeouts.firstEvent
-			readPhase = "first event"
-		}
-		msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, conn, readCh, readTimeout, readPhase)
+		msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, conn, readCh, timeouts.websocketIdle)
 		if errRead != nil {
 			if sess != nil {
 				e.invalidateUpstreamConn(sess, conn, "read_error", errRead)
@@ -493,7 +488,6 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			helps.RecordAPIWebsocketError(ctx, e.cfg, "read", mappedErr)
 			return resp, mappedErr
 		}
-		firstEvent = false
 		if msgType != websocket.TextMessage {
 			if msgType == websocket.BinaryMessage {
 				err = fmt.Errorf("codex websockets executor: unexpected binary message")
@@ -705,7 +699,9 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 
 		defer close(out)
 		if sess == nil {
-			stopPings := startStandaloneCodexWebsocketPings(conn, codexTimeoutsFromConfig(e.cfg).websocketPing)
+			timeouts := codexTimeoutsFromConfig(e.cfg)
+			configureStandaloneCodexWebsocket(conn, timeouts.websocketIdle)
+			stopPings := startStandaloneCodexWebsocketPings(conn, timeouts.websocketPing)
 			defer stopPings()
 		}
 		defer func() {
@@ -735,7 +731,6 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 
 		claudeInputTokens := helps.NewClaudeInputTokenState(from, to, responseFormat, originalPayload)
 		timeouts := codexTimeoutsFromConfig(e.cfg)
-		firstEvent := true
 		var param any
 		outputItemsByIndex := make(map[int64][]byte)
 		var outputItemsFallback [][]byte
@@ -746,13 +741,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				_ = send(cliproxyexecutor.StreamChunk{Err: ctx.Err()})
 				return
 			}
-			readTimeout := timeouts.streamIdle
-			readPhase := "stream idle"
-			if firstEvent {
-				readTimeout = timeouts.firstEvent
-				readPhase = "first event"
-			}
-			msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, conn, readCh, readTimeout, readPhase)
+			msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, conn, readCh, timeouts.websocketIdle)
 			if errRead != nil {
 				if sess != nil && ctx != nil && ctx.Err() != nil {
 					terminateReason = "context_done"
@@ -771,7 +760,6 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				_ = send(cliproxyexecutor.StreamChunk{Err: mappedErr})
 				return
 			}
-			firstEvent = false
 			if msgType != websocket.TextMessage {
 				if msgType == websocket.BinaryMessage {
 					err = fmt.Errorf("codex websockets executor: unexpected binary message")
@@ -883,8 +871,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 }
 
 func (e *CodexWebsocketsExecutor) dialCodexWebsocket(ctx context.Context, auth *cliproxyauth.Auth, wsURL string, headers http.Header) (*websocket.Conn, *http.Response, error) {
-	timeouts := codexTimeoutsFromConfig(e.cfg)
-	dialer := newProxyAwareWebsocketDialer(e.cfg, auth, timeouts.connect, timeouts.responseHeader)
+	dialer := newProxyAwareWebsocketDialer(e.cfg, auth)
 	dialer.EnableCompression = true
 	if ctx == nil {
 		ctx = context.Background()
@@ -979,7 +966,7 @@ func buildCodexWebsocketRequestBody(body []byte) []byte {
 	return fallback
 }
 
-func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession, conn *websocket.Conn, readCh chan codexWebsocketRead, timeout time.Duration, phase string) (int, []byte, error) {
+func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession, conn *websocket.Conn, readCh chan codexWebsocketRead, timeout time.Duration) (int, []byte, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -993,7 +980,7 @@ func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession,
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return 0, nil, ctxErr
 			}
-			return 0, nil, codexRequestTimeoutError{phase: phase, timeout: timeout}
+			return 0, nil, codexRequestTimeoutError{phase: "websocket idle", timeout: timeout}
 		}
 		return msgType, payload, errRead
 	}
@@ -1003,17 +990,10 @@ func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession,
 	if readCh == nil {
 		return 0, nil, fmt.Errorf("codex websockets executor: session read channel is nil")
 	}
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return 0, nil, ctx.Err()
-		case <-timer.C:
-			if ctxErr := ctx.Err(); ctxErr != nil {
-				return 0, nil, ctxErr
-			}
-			return 0, nil, codexRequestTimeoutError{phase: phase, timeout: timeout}
 		case ev, ok := <-readCh:
 			if !ok {
 				return 0, nil, fmt.Errorf("codex websockets executor: session read channel closed")
@@ -1029,21 +1009,13 @@ func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession,
 	}
 }
 
-func newProxyAwareWebsocketDialer(cfg *config.Config, auth *cliproxyauth.Auth, timeoutValues ...time.Duration) *websocket.Dialer {
-	connectTimeout := codexDefaultConnectTimeout
-	handshakeTimeout := codexResponsesWebsocketHandshakeTO
-	if len(timeoutValues) > 0 && timeoutValues[0] > 0 {
-		connectTimeout = timeoutValues[0]
-	}
-	if len(timeoutValues) > 1 && timeoutValues[1] > 0 {
-		handshakeTimeout = timeoutValues[1]
-	}
+func newProxyAwareWebsocketDialer(cfg *config.Config, auth *cliproxyauth.Auth) *websocket.Dialer {
 	dialer := &websocket.Dialer{
 		Proxy:             http.ProxyFromEnvironment,
-		HandshakeTimeout:  handshakeTimeout,
+		HandshakeTimeout:  codexResponsesWebsocketHandshakeTO,
 		EnableCompression: true,
 		NetDialContext: (&net.Dialer{
-			Timeout:   connectTimeout,
+			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
 	}
@@ -1679,7 +1651,7 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 			sess.connMu.Lock()
 			sess.readerConn = conn
 			sess.connMu.Unlock()
-			sess.configureConn(conn, codexTimeoutsFromConfig(e.cfg).streamIdle)
+			sess.configureConn(conn, codexTimeoutsFromConfig(e.cfg).websocketIdle)
 			go e.readUpstreamLoop(sess, conn)
 		}
 		// Validate a reused socket before writing the business payload. A failed
@@ -1711,7 +1683,7 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 	sess.readerConn = conn
 	sess.connMu.Unlock()
 
-	sess.configureConn(conn, codexTimeoutsFromConfig(e.cfg).streamIdle)
+	sess.configureConn(conn, codexTimeoutsFromConfig(e.cfg).websocketIdle)
 	go e.readUpstreamLoop(sess, conn)
 	logCodexWebsocketConnected(sess.sessionID, authID, wsURL)
 	return conn, resp, nil
@@ -1740,9 +1712,12 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 		}
 	}()
 	for {
-		_ = conn.SetReadDeadline(time.Now().Add(timeouts.streamIdle))
+		_ = conn.SetReadDeadline(time.Now().Add(timeouts.websocketIdle))
 		msgType, payload, errRead := conn.ReadMessage()
 		if errRead != nil {
+			if networkErr, ok := errRead.(net.Error); ok && networkErr.Timeout() {
+				errRead = codexRequestTimeoutError{phase: "websocket idle", timeout: timeouts.websocketIdle}
+			}
 			invalidate := func() {
 				e.invalidateUpstreamConn(sess, conn, "upstream_disconnected", errRead)
 			}
@@ -1759,7 +1734,7 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 			}
 			return
 		}
-		_ = conn.SetReadDeadline(time.Now().Add(timeouts.streamIdle))
+		_ = conn.SetReadDeadline(time.Now().Add(timeouts.websocketIdle))
 
 		if msgType != websocket.TextMessage {
 			if msgType == websocket.BinaryMessage {
@@ -1792,6 +1767,24 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 		case <-done:
 		}
 	}
+}
+
+func configureStandaloneCodexWebsocket(conn *websocket.Conn, idleTimeout time.Duration) {
+	if conn == nil || idleTimeout <= 0 {
+		return
+	}
+	refreshReadDeadline := func() error {
+		return conn.SetReadDeadline(time.Now().Add(idleTimeout))
+	}
+	conn.SetPingHandler(func(appData string) error {
+		if err := refreshReadDeadline(); err != nil {
+			return err
+		}
+		return conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(10*time.Second))
+	})
+	conn.SetPongHandler(func(string) error {
+		return refreshReadDeadline()
+	})
 }
 
 func startStandaloneCodexWebsocketPings(conn *websocket.Conn, interval time.Duration) func() {

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -1452,3 +1452,117 @@ func TestNewProxyAwareWebsocketDialerDirectDisablesProxy(t *testing.T) {
 		t.Fatal("expected websocket proxy function to be nil for direct mode")
 	}
 }
+
+func TestStandaloneCodexWebsocketPingsAreProactive(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	pingReceived := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		conn.SetPingHandler(func(string) error {
+			select {
+			case pingReceived <- struct{}{}:
+			default:
+			}
+			return nil
+		})
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer server.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("Dial() error = %v", err)
+	}
+	stop := startStandaloneCodexWebsocketPings(conn, 20*time.Millisecond)
+	defer stop()
+	defer conn.Close()
+
+	select {
+	case <-pingReceived:
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive proactive websocket ping")
+	}
+}
+
+func TestCodexWebsocketHandshakeTransportFailureFallsBackToHTTP(t *testing.T) {
+	websocketAttempts := make(chan struct{}, 2)
+	httpAttempts := make(chan struct{}, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			websocketAttempts <- struct{}{}
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("response writer does not support hijacking")
+			}
+			conn, _, err := hijacker.Hijack()
+			if err != nil {
+				t.Errorf("Hijack() error = %v", err)
+				return
+			}
+			_ = conn.Close()
+			return
+		}
+		httpAttempts <- struct{}{}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-http\",\"output\":[],\"usage\":{\"input_tokens\":0,\"output_tokens\":0,\"total_tokens\":0}}}\n\n"))
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{Model: "gpt-5-codex", Payload: []byte(`{"model":"gpt-5-codex","input":"hello"}`)}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response")}
+
+	if _, err := exec.Execute(context.Background(), auth, req, opts); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := len(websocketAttempts); got != 1 {
+		t.Fatalf("websocket attempts = %d, want 1", got)
+	}
+	if got := len(httpAttempts); got != 1 {
+		t.Fatalf("HTTP fallback attempts = %d, want 1", got)
+	}
+}
+
+func TestCodexWebsocketPingActivityRenewsIdleDeadline(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		for range 3 {
+			time.Sleep(40 * time.Millisecond)
+			if err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(time.Second)); err != nil {
+				return
+			}
+		}
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.completed"}`)); err != nil {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("Dial() error = %v", err)
+	}
+	defer conn.Close()
+	sess := &codexWebsocketSession{}
+	sess.configureConn(conn, 70*time.Millisecond)
+	_ = conn.SetReadDeadline(time.Now().Add(70 * time.Millisecond))
+
+	_, payload, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage() error = %v; ping activity should renew idle deadline", err)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != "response.completed" {
+		t.Fatalf("message type = %q, want response.completed", got)
+	}
+}

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -1566,3 +1566,37 @@ func TestCodexWebsocketPingActivityRenewsIdleDeadline(t *testing.T) {
 		t.Fatalf("message type = %q, want response.completed", got)
 	}
 }
+
+func TestStandaloneCodexWebsocketPongActivityRenewsIdleDeadline(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		go func() {
+			time.Sleep(180 * time.Millisecond)
+			_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.completed"}`))
+		}()
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer server.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("Dial() error = %v", err)
+	}
+	defer conn.Close()
+	configureStandaloneCodexWebsocket(conn, 70*time.Millisecond)
+	stop := startStandaloneCodexWebsocketPings(conn, 20*time.Millisecond)
+	defer stop()
+
+	_, payload, err := readCodexWebsocketMessage(context.Background(), nil, conn, nil, 70*time.Millisecond)
+	if err != nil {
+		t.Fatalf("ReadMessage() error = %v; pong activity should renew idle deadline", err)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != "response.completed" {
+		t.Fatalf("message type = %q, want response.completed", got)
+	}
+}

--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -24,7 +24,6 @@ type utlsRoundTripper struct {
 	connections map[string]*http2.ClientConn
 	pending     map[string]*sync.Cond
 	dialer      proxy.Dialer
-	connectTO   time.Duration
 }
 
 func newUtlsRoundTripper(proxyURL string) *utlsRoundTripper {
@@ -44,7 +43,7 @@ func newUtlsRoundTripper(proxyURL string) *utlsRoundTripper {
 	}
 }
 
-func (t *utlsRoundTripper) getOrCreateConnection(ctx context.Context, host, addr string) (*http2.ClientConn, error) {
+func (t *utlsRoundTripper) getOrCreateConnection(host, addr string) (*http2.ClientConn, error) {
 	t.mu.Lock()
 
 	if h2Conn, ok := t.connections[host]; ok && h2Conn.CanTakeNewRequest() {
@@ -64,7 +63,7 @@ func (t *utlsRoundTripper) getOrCreateConnection(ctx context.Context, host, addr
 	t.pending[host] = cond
 	t.mu.Unlock()
 
-	h2Conn, err := t.createConnection(ctx, host, addr)
+	h2Conn, err := t.createConnection(host, addr)
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -80,21 +79,10 @@ func (t *utlsRoundTripper) getOrCreateConnection(ctx context.Context, host, addr
 	return h2Conn, nil
 }
 
-func (t *utlsRoundTripper) createConnection(ctx context.Context, host, addr string) (*http2.ClientConn, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	if t.connectTO > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, t.connectTO)
-		defer cancel()
-	}
-	conn, err := dialProxyContext(ctx, t.dialer, "tcp", addr)
+func (t *utlsRoundTripper) createConnection(host, addr string) (*http2.ClientConn, error) {
+	conn, err := t.dialer.Dial("tcp", addr)
 	if err != nil {
 		return nil, err
-	}
-	if deadline, ok := ctx.Deadline(); ok {
-		_ = conn.SetDeadline(deadline)
 	}
 
 	tlsConfig := &tls.Config{ServerName: host}
@@ -104,7 +92,6 @@ func (t *utlsRoundTripper) createConnection(ctx context.Context, host, addr stri
 		conn.Close()
 		return nil, err
 	}
-	_ = conn.SetDeadline(time.Time{})
 
 	tr := &http2.Transport{}
 	h2Conn, err := tr.NewClientConn(tlsConn)
@@ -124,7 +111,7 @@ func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 	addr := net.JoinHostPort(hostname, port)
 
-	h2Conn, err := t.getOrCreateConnection(req.Context(), hostname, addr)
+	h2Conn, err := t.getOrCreateConnection(hostname, addr)
 	if err != nil {
 		return nil, err
 	}
@@ -140,39 +127,6 @@ func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 
 	return resp, nil
-}
-
-type proxyContextDialer interface {
-	DialContext(ctx context.Context, network, address string) (net.Conn, error)
-}
-
-func dialProxyContext(ctx context.Context, dialer proxy.Dialer, network, address string) (net.Conn, error) {
-	if contextDialer, ok := dialer.(proxyContextDialer); ok {
-		return contextDialer.DialContext(ctx, network, address)
-	}
-	type dialResult struct {
-		conn net.Conn
-		err  error
-	}
-	resultCh := make(chan dialResult)
-	abandoned := make(chan struct{})
-	go func() {
-		conn, err := dialer.Dial(network, address)
-		select {
-		case resultCh <- dialResult{conn: conn, err: err}:
-		case <-abandoned:
-			if conn != nil {
-				_ = conn.Close()
-			}
-		}
-	}()
-	select {
-	case result := <-resultCh:
-		return result.conn, result.err
-	case <-ctx.Done():
-		close(abandoned)
-		return nil, ctx.Err()
-	}
 }
 
 // utlsProtectedHosts contains the hosts that should use utls Chrome TLS fingerprint
@@ -236,48 +190,4 @@ func NewUtlsHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyau
 		client.Timeout = timeout
 	}
 	return client
-}
-
-// ConfigureHTTPClientTransportTimeouts applies connection and response-header
-// limits without setting http.Client.Timeout, which would also cap long streams.
-func ConfigureHTTPClientTransportTimeouts(client *http.Client, connectTimeout, responseHeaderTimeout time.Duration) {
-	if client == nil {
-		return
-	}
-	transport := client.Transport
-	if transport == nil {
-		transport = http.DefaultTransport
-	}
-	client.Transport = configureRoundTripperTimeouts(transport, connectTimeout, responseHeaderTimeout)
-}
-
-func configureRoundTripperTimeouts(transport http.RoundTripper, connectTimeout, responseHeaderTimeout time.Duration) http.RoundTripper {
-	switch current := transport.(type) {
-	case *fallbackRoundTripper:
-		clone := *current
-		clone.utls = configureRoundTripperTimeouts(clone.utls, connectTimeout, responseHeaderTimeout)
-		clone.fallback = configureRoundTripperTimeouts(clone.fallback, connectTimeout, responseHeaderTimeout)
-		return &clone
-	case *utlsRoundTripper:
-		current.connectTO = connectTimeout
-		return current
-	case *http.Transport:
-		clone := current.Clone()
-		clone.ResponseHeaderTimeout = responseHeaderTimeout
-		baseDial := clone.DialContext
-		if baseDial == nil {
-			baseDial = (&net.Dialer{}).DialContext
-		}
-		clone.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
-			if connectTimeout <= 0 {
-				return baseDial(ctx, network, address)
-			}
-			dialCtx, cancel := context.WithTimeout(ctx, connectTimeout)
-			defer cancel()
-			return baseDial(dialCtx, network, address)
-		}
-		return clone
-	default:
-		return transport
-	}
 }

--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -24,6 +24,7 @@ type utlsRoundTripper struct {
 	connections map[string]*http2.ClientConn
 	pending     map[string]*sync.Cond
 	dialer      proxy.Dialer
+	connectTO   time.Duration
 }
 
 func newUtlsRoundTripper(proxyURL string) *utlsRoundTripper {
@@ -43,7 +44,7 @@ func newUtlsRoundTripper(proxyURL string) *utlsRoundTripper {
 	}
 }
 
-func (t *utlsRoundTripper) getOrCreateConnection(host, addr string) (*http2.ClientConn, error) {
+func (t *utlsRoundTripper) getOrCreateConnection(ctx context.Context, host, addr string) (*http2.ClientConn, error) {
 	t.mu.Lock()
 
 	if h2Conn, ok := t.connections[host]; ok && h2Conn.CanTakeNewRequest() {
@@ -63,7 +64,7 @@ func (t *utlsRoundTripper) getOrCreateConnection(host, addr string) (*http2.Clie
 	t.pending[host] = cond
 	t.mu.Unlock()
 
-	h2Conn, err := t.createConnection(host, addr)
+	h2Conn, err := t.createConnection(ctx, host, addr)
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -79,10 +80,21 @@ func (t *utlsRoundTripper) getOrCreateConnection(host, addr string) (*http2.Clie
 	return h2Conn, nil
 }
 
-func (t *utlsRoundTripper) createConnection(host, addr string) (*http2.ClientConn, error) {
-	conn, err := t.dialer.Dial("tcp", addr)
+func (t *utlsRoundTripper) createConnection(ctx context.Context, host, addr string) (*http2.ClientConn, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if t.connectTO > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, t.connectTO)
+		defer cancel()
+	}
+	conn, err := dialProxyContext(ctx, t.dialer, "tcp", addr)
 	if err != nil {
 		return nil, err
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
 	}
 
 	tlsConfig := &tls.Config{ServerName: host}
@@ -92,6 +104,7 @@ func (t *utlsRoundTripper) createConnection(host, addr string) (*http2.ClientCon
 		conn.Close()
 		return nil, err
 	}
+	_ = conn.SetDeadline(time.Time{})
 
 	tr := &http2.Transport{}
 	h2Conn, err := tr.NewClientConn(tlsConn)
@@ -111,7 +124,7 @@ func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 	addr := net.JoinHostPort(hostname, port)
 
-	h2Conn, err := t.getOrCreateConnection(hostname, addr)
+	h2Conn, err := t.getOrCreateConnection(req.Context(), hostname, addr)
 	if err != nil {
 		return nil, err
 	}
@@ -127,6 +140,39 @@ func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 
 	return resp, nil
+}
+
+type proxyContextDialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+func dialProxyContext(ctx context.Context, dialer proxy.Dialer, network, address string) (net.Conn, error) {
+	if contextDialer, ok := dialer.(proxyContextDialer); ok {
+		return contextDialer.DialContext(ctx, network, address)
+	}
+	type dialResult struct {
+		conn net.Conn
+		err  error
+	}
+	resultCh := make(chan dialResult)
+	abandoned := make(chan struct{})
+	go func() {
+		conn, err := dialer.Dial(network, address)
+		select {
+		case resultCh <- dialResult{conn: conn, err: err}:
+		case <-abandoned:
+			if conn != nil {
+				_ = conn.Close()
+			}
+		}
+	}()
+	select {
+	case result := <-resultCh:
+		return result.conn, result.err
+	case <-ctx.Done():
+		close(abandoned)
+		return nil, ctx.Err()
+	}
 }
 
 // utlsProtectedHosts contains the hosts that should use utls Chrome TLS fingerprint
@@ -190,4 +236,48 @@ func NewUtlsHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyau
 		client.Timeout = timeout
 	}
 	return client
+}
+
+// ConfigureHTTPClientTransportTimeouts applies connection and response-header
+// limits without setting http.Client.Timeout, which would also cap long streams.
+func ConfigureHTTPClientTransportTimeouts(client *http.Client, connectTimeout, responseHeaderTimeout time.Duration) {
+	if client == nil {
+		return
+	}
+	transport := client.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	client.Transport = configureRoundTripperTimeouts(transport, connectTimeout, responseHeaderTimeout)
+}
+
+func configureRoundTripperTimeouts(transport http.RoundTripper, connectTimeout, responseHeaderTimeout time.Duration) http.RoundTripper {
+	switch current := transport.(type) {
+	case *fallbackRoundTripper:
+		clone := *current
+		clone.utls = configureRoundTripperTimeouts(clone.utls, connectTimeout, responseHeaderTimeout)
+		clone.fallback = configureRoundTripperTimeouts(clone.fallback, connectTimeout, responseHeaderTimeout)
+		return &clone
+	case *utlsRoundTripper:
+		current.connectTO = connectTimeout
+		return current
+	case *http.Transport:
+		clone := current.Clone()
+		clone.ResponseHeaderTimeout = responseHeaderTimeout
+		baseDial := clone.DialContext
+		if baseDial == nil {
+			baseDial = (&net.Dialer{}).DialContext
+		}
+		clone.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+			if connectTimeout <= 0 {
+				return baseDial(ctx, network, address)
+			}
+			dialCtx, cancel := context.WithTimeout(ctx, connectTimeout)
+			defer cancel()
+			return baseDial(dialCtx, network, address)
+		}
+		return clone
+	default:
+		return transport
+	}
 }

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
@@ -475,6 +475,32 @@ func TestConvertOpenAIResponsesRequestToGeminiCleansToolSchemaRequiredFields(t *
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToGeminiNormalizesBooleanToolSchemas(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.1-pro",
+		"input": [
+			{"type":"function_call_output","call_id":"call-1","output":"{\"ok\":false}"},
+			{"role":"user","content":[{"type":"input_text","text":"continue"}]}
+		],
+		"tools": [
+			{"type":"function","name":"anything","parameters":true},
+			{"type":"function","name":"never","parameters":false}
+		]
+	}`
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.1-pro", []byte(inputJSON), false)
+	anything := gjson.GetBytes(output, "tools.0.functionDeclarations.0.parametersJsonSchema")
+	if !anything.IsObject() || len(anything.Map()) != 0 {
+		t.Fatalf("true parameters schema = %s, want {}. Output: %s", anything.Raw, output)
+	}
+	never := gjson.GetBytes(output, "tools.0.functionDeclarations.1.parametersJsonSchema")
+	if enum := never.Get("properties.__cliproxyapi_never__.enum"); !enum.IsArray() || len(enum.Array()) != 0 {
+		t.Fatalf("false parameters schema = %s. Output: %s", never.Raw, output)
+	}
+	if !gjson.GetBytes(output, "contents").IsArray() {
+		t.Fatalf("tool result second turn was dropped. Output: %s", output)
+	}
+}
+
 func validResponsesGPTReasoningSignature() string {
 	raw := make([]byte, 1+8+16+16+32)
 	raw[0] = 0x80

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
@@ -475,32 +475,6 @@ func TestConvertOpenAIResponsesRequestToGeminiCleansToolSchemaRequiredFields(t *
 	}
 }
 
-func TestConvertOpenAIResponsesRequestToGeminiNormalizesBooleanToolSchemas(t *testing.T) {
-	inputJSON := `{
-		"model": "gemini-3.1-pro",
-		"input": [
-			{"type":"function_call_output","call_id":"call-1","output":"{\"ok\":false}"},
-			{"role":"user","content":[{"type":"input_text","text":"continue"}]}
-		],
-		"tools": [
-			{"type":"function","name":"anything","parameters":true},
-			{"type":"function","name":"never","parameters":false}
-		]
-	}`
-	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.1-pro", []byte(inputJSON), false)
-	anything := gjson.GetBytes(output, "tools.0.functionDeclarations.0.parametersJsonSchema")
-	if !anything.IsObject() || len(anything.Map()) != 0 {
-		t.Fatalf("true parameters schema = %s, want {}. Output: %s", anything.Raw, output)
-	}
-	never := gjson.GetBytes(output, "tools.0.functionDeclarations.1.parametersJsonSchema")
-	if enum := never.Get("properties.__cliproxyapi_never__.enum"); !enum.IsArray() || len(enum.Array()) != 0 {
-		t.Fatalf("false parameters schema = %s. Output: %s", never.Raw, output)
-	}
-	if !gjson.GetBytes(output, "contents").IsArray() {
-		t.Fatalf("tool result second turn was dropped. Output: %s", output)
-	}
-}
-
 func validResponsesGPTReasoningSignature() string {
 	raw := make([]byte, 1+8+16+16+32)
 	raw[0] = 0x80

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -34,7 +34,7 @@ func cleanJSONSchema(jsonStr string, addPlaceholder bool) string {
 	// Phase 0: JSON Schema permits boolean schemas, while Gemini requires each
 	// schema position to contain an object. Normalize only schema positions so
 	// boolean values in tool results or request content remain untouched.
-	jsonStr = normalizeBooleanSchemas(jsonStr)
+	jsonStr = normalizeBooleanSchemas(jsonStr, addPlaceholder)
 
 	// Phase 1: Convert and add hints
 	jsonStr = convertRefsToHints(jsonStr)
@@ -219,7 +219,7 @@ func convertEnumValuesToStrings(jsonStr string) string {
 
 const impossibleSchemaProperty = "__cliproxyapi_never__"
 
-func normalizeBooleanSchemas(jsonStr string) string {
+func normalizeBooleanSchemas(jsonStr string, requireRootObjectType bool) string {
 	var root any
 	decoder := json.NewDecoder(strings.NewReader(jsonStr))
 	decoder.UseNumber()
@@ -227,9 +227,9 @@ func normalizeBooleanSchemas(jsonStr string) string {
 		return jsonStr
 	}
 	if isSchemaRoot(root) {
-		root = normalizeSchemaNode(root)
+		root = normalizeSchemaNode(root, requireRootObjectType)
 	} else {
-		normalizeSchemaRootsInPayload(root, nil)
+		normalizeSchemaRootsInPayload(root, nil, requireRootObjectType)
 	}
 	data, err := json.Marshal(root)
 	if err != nil {
@@ -257,20 +257,20 @@ func isSchemaRoot(value any) bool {
 	return false
 }
 
-func normalizeSchemaRootsInPayload(value any, path []string) {
+func normalizeSchemaRootsInPayload(value any, path []string, requireRootObjectType bool) {
 	switch current := value.(type) {
 	case map[string]any:
 		for key, child := range current {
 			childPath := append(path, key)
 			if isPayloadSchemaKey(key, current, path) {
-				current[key] = normalizeSchemaNode(child)
+				current[key] = normalizeSchemaNode(child, requireRootObjectType)
 				continue
 			}
-			normalizeSchemaRootsInPayload(child, childPath)
+			normalizeSchemaRootsInPayload(child, childPath, requireRootObjectType)
 		}
 	case []any:
 		for index := range current {
-			normalizeSchemaRootsInPayload(current[index], path)
+			normalizeSchemaRootsInPayload(current[index], path, requireRootObjectType)
 		}
 	}
 }
@@ -295,37 +295,46 @@ func isPayloadSchemaKey(key string, parent map[string]any, path []string) bool {
 	return false
 }
 
-func normalizeSchemaNode(value any) any {
+func normalizeSchemaNode(value any, requireRootObjectType bool) any {
 	switch schema := value.(type) {
 	case bool:
 		if schema {
+			if requireRootObjectType {
+				return map[string]any{"type": "object"}
+			}
 			return map[string]any{}
 		}
 		return impossibleBooleanSchema()
 	case map[string]any:
+		if requireRootObjectType && len(schema) == 0 {
+			return map[string]any{"type": "object"}
+		}
 		if replacement, replace := simplifyBooleanCombinators(schema); replace {
 			return replacement
+		}
+		if requireRootObjectType && len(schema) == 0 {
+			return map[string]any{"type": "object"}
 		}
 		for key, child := range schema {
 			switch key {
 			case "properties", "patternProperties", "$defs", "definitions", "dependentSchemas":
 				if children, ok := child.(map[string]any); ok {
 					for name, nested := range children {
-						children[name] = normalizeSchemaNode(nested)
+						children[name] = normalizeSchemaNode(nested, false)
 					}
 				}
 			case "items", "contains", "propertyNames", "if", "then", "else", "not":
-				schema[key] = normalizeSchemaNode(child)
+				schema[key] = normalizeSchemaNode(child, false)
 			case "prefixItems", "allOf", "anyOf", "oneOf":
 				if children, ok := child.([]any); ok {
 					for index := range children {
-						children[index] = normalizeSchemaNode(children[index])
+						children[index] = normalizeSchemaNode(children[index], false)
 					}
 				}
 			case "additionalProperties":
 				// A boolean here is a keyword value, not a boolean Schema root.
 				if _, isBoolean := child.(bool); !isBoolean {
-					schema[key] = normalizeSchemaNode(child)
+					schema[key] = normalizeSchemaNode(child, false)
 				}
 			}
 		}

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -2,6 +2,7 @@
 package util
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -30,6 +31,11 @@ func CleanJSONSchemaForGemini(jsonStr string) string {
 
 // cleanJSONSchema performs the core cleaning operations on the JSON schema.
 func cleanJSONSchema(jsonStr string, addPlaceholder bool) string {
+	// Phase 0: JSON Schema permits boolean schemas, while Gemini requires each
+	// schema position to contain an object. Normalize only schema positions so
+	// boolean values in tool results or request content remain untouched.
+	jsonStr = normalizeBooleanSchemas(jsonStr)
+
 	// Phase 1: Convert and add hints
 	jsonStr = convertRefsToHints(jsonStr)
 	jsonStr = convertConstToEnum(jsonStr)
@@ -195,7 +201,7 @@ func convertEnumValuesToStrings(jsonStr string) string {
 			continue
 		}
 
-		var stringVals []string
+		stringVals := make([]string, 0, len(arr.Array()))
 		for _, item := range arr.Array() {
 			stringVals = append(stringVals, item.String())
 		}
@@ -209,6 +215,215 @@ func convertEnumValuesToStrings(jsonStr string) string {
 		jsonStr = string(updated)
 	}
 	return jsonStr
+}
+
+const impossibleSchemaProperty = "__cliproxyapi_never__"
+
+func normalizeBooleanSchemas(jsonStr string) string {
+	var root any
+	decoder := json.NewDecoder(strings.NewReader(jsonStr))
+	decoder.UseNumber()
+	if err := decoder.Decode(&root); err != nil {
+		return jsonStr
+	}
+	if isSchemaRoot(root) {
+		root = normalizeSchemaNode(root)
+	} else {
+		normalizeSchemaRootsInPayload(root, nil)
+	}
+	data, err := json.Marshal(root)
+	if err != nil {
+		return jsonStr
+	}
+	return string(data)
+}
+
+func isSchemaRoot(value any) bool {
+	if _, ok := value.(bool); ok {
+		return true
+	}
+	object, ok := value.(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, key := range []string{
+		"type", "properties", "items", "required", "anyOf", "oneOf", "allOf",
+		"$ref", "$defs", "definitions", "enum", "const", "additionalProperties",
+	} {
+		if _, exists := object[key]; exists {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeSchemaRootsInPayload(value any, path []string) {
+	switch current := value.(type) {
+	case map[string]any:
+		for key, child := range current {
+			childPath := append(path, key)
+			if isPayloadSchemaKey(key, current, path) {
+				current[key] = normalizeSchemaNode(child)
+				continue
+			}
+			normalizeSchemaRootsInPayload(child, childPath)
+		}
+	case []any:
+		for index := range current {
+			normalizeSchemaRootsInPayload(current[index], path)
+		}
+	}
+}
+
+func isPayloadSchemaKey(key string, parent map[string]any, path []string) bool {
+	switch key {
+	case "parametersJsonSchema", "responseJsonSchema", "responseSchema", "input_schema":
+		return true
+	case "schema":
+		typeName, _ := parent["type"].(string)
+		return typeName == "json_schema"
+	case "parameters":
+		if _, hasName := parent["name"]; hasName {
+			return true
+		}
+		for _, segment := range path {
+			if segment == "functionDeclarations" || segment == "function_declarations" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func normalizeSchemaNode(value any) any {
+	switch schema := value.(type) {
+	case bool:
+		if schema {
+			return map[string]any{}
+		}
+		return impossibleBooleanSchema()
+	case map[string]any:
+		if replacement, replace := simplifyBooleanCombinators(schema); replace {
+			return replacement
+		}
+		for key, child := range schema {
+			switch key {
+			case "properties", "patternProperties", "$defs", "definitions", "dependentSchemas":
+				if children, ok := child.(map[string]any); ok {
+					for name, nested := range children {
+						children[name] = normalizeSchemaNode(nested)
+					}
+				}
+			case "items", "contains", "propertyNames", "if", "then", "else", "not":
+				schema[key] = normalizeSchemaNode(child)
+			case "prefixItems", "allOf", "anyOf", "oneOf":
+				if children, ok := child.([]any); ok {
+					for index := range children {
+						children[index] = normalizeSchemaNode(children[index])
+					}
+				}
+			case "additionalProperties":
+				// A boolean here is a keyword value, not a boolean Schema root.
+				if _, isBoolean := child.(bool); !isBoolean {
+					schema[key] = normalizeSchemaNode(child)
+				}
+			}
+		}
+		return schema
+	default:
+		return value
+	}
+}
+
+func simplifyBooleanCombinators(schema map[string]any) (any, bool) {
+	if raw, exists := schema["not"]; exists {
+		if boolean, ok := raw.(bool); ok {
+			if boolean {
+				return impossibleBooleanSchema(), true
+			}
+			delete(schema, "not")
+		}
+	}
+	if raw, exists := schema["allOf"]; exists {
+		if items, ok := raw.([]any); ok {
+			filtered := make([]any, 0, len(items))
+			for _, item := range items {
+				if boolean, isBoolean := item.(bool); isBoolean {
+					if !boolean {
+						return impossibleBooleanSchema(), true
+					}
+					continue
+				}
+				filtered = append(filtered, item)
+			}
+			if len(filtered) == 0 {
+				delete(schema, "allOf")
+			} else {
+				schema["allOf"] = filtered
+			}
+		}
+	}
+	if raw, exists := schema["anyOf"]; exists {
+		if items, ok := raw.([]any); ok {
+			filtered := make([]any, 0, len(items))
+			for _, item := range items {
+				if boolean, isBoolean := item.(bool); isBoolean {
+					if boolean {
+						delete(schema, "anyOf")
+						return schema, false
+					}
+					continue
+				}
+				filtered = append(filtered, item)
+			}
+			if len(filtered) == 0 {
+				return impossibleBooleanSchema(), true
+			}
+			schema["anyOf"] = filtered
+		}
+	}
+	if raw, exists := schema["oneOf"]; exists {
+		if items, ok := raw.([]any); ok {
+			filtered := make([]any, 0, len(items))
+			trueCount := 0
+			for _, item := range items {
+				if boolean, isBoolean := item.(bool); isBoolean {
+					if boolean {
+						trueCount++
+					}
+					continue
+				}
+				filtered = append(filtered, item)
+			}
+			switch {
+			case trueCount == 0 && len(filtered) == 0:
+				return impossibleBooleanSchema(), true
+			case trueCount == 1 && len(filtered) == 0:
+				delete(schema, "oneOf")
+			case trueCount > 0:
+				// "exactly one" with a true branch needs negation to preserve.
+				// Gemini removes negation, so rejecting all inputs is the safe subset.
+				return impossibleBooleanSchema(), true
+			default:
+				schema["oneOf"] = filtered
+			}
+		}
+	}
+	return schema, false
+}
+
+func impossibleBooleanSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			impossibleSchemaProperty: map[string]any{
+				"type":        "string",
+				"enum":        []any{},
+				"description": "No value is accepted by the original boolean false schema.",
+			},
+		},
+		"required": []any{impossibleSchemaProperty},
+	}
 }
 
 func addEnumHints(jsonStr string) string {

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -1089,3 +1089,133 @@ func TestCleanJSONSchemaForAntigravity_UniqueItemsStripped(t *testing.T) {
 		t.Errorf("uniqueItems hint missing in description")
 	}
 }
+
+func TestCleanJSONSchemaBooleanSchemas(t *testing.T) {
+	tests := []struct {
+		name     string
+		clean    func(string) string
+		input    string
+		assertFn func(*testing.T, gjson.Result)
+	}{
+		{
+			name:  "top-level true becomes unconstrained schema object",
+			clean: CleanJSONSchemaForGemini,
+			input: `true`,
+			assertFn: func(t *testing.T, result gjson.Result) {
+				if !result.IsObject() || len(result.Map()) != 0 {
+					t.Fatalf("true schema = %s, want {}", result.Raw)
+				}
+			},
+		},
+		{
+			name:  "top-level false stays unsatisfiable",
+			clean: CleanJSONSchemaForAntigravity,
+			input: `false`,
+			assertFn: func(t *testing.T, result gjson.Result) {
+				property := result.Get("properties." + impossibleSchemaProperty)
+				if !property.Exists() || !property.Get("enum").IsArray() || len(property.Get("enum").Array()) != 0 {
+					t.Fatalf("false schema = %s, want required empty enum sentinel", result.Raw)
+				}
+				if result.Get("required.0").String() != impossibleSchemaProperty {
+					t.Fatalf("false schema required = %s", result.Get("required").Raw)
+				}
+			},
+		},
+		{
+			name:  "nested properties and items",
+			clean: CleanJSONSchemaForGemini,
+			input: `{"type":"object","properties":{"anything":true,"never":false,"list":{"type":"array","items":false}},"required":["anything","never","list"]}`,
+			assertFn: func(t *testing.T, result gjson.Result) {
+				if anything := result.Get("properties.anything"); !anything.IsObject() || len(anything.Map()) != 0 {
+					t.Fatalf("true property = %s", anything.Raw)
+				}
+				for _, path := range []string{"properties.never", "properties.list.items"} {
+					if enum := result.Get(path + ".properties." + impossibleSchemaProperty + ".enum"); !enum.IsArray() || len(enum.Array()) != 0 {
+						t.Fatalf("%s false sentinel = %s", path, result.Get(path).Raw)
+					}
+				}
+			},
+		},
+		{
+			name:  "false anyOf branch is removed",
+			clean: CleanJSONSchemaForGemini,
+			input: `{"anyOf":[false,{"type":"string"}]}`,
+			assertFn: func(t *testing.T, result gjson.Result) {
+				if result.Get("type").String() != "string" {
+					t.Fatalf("anyOf result = %s, want string schema", result.Raw)
+				}
+			},
+		},
+		{
+			name:  "true anyOf branch removes union constraint",
+			clean: CleanJSONSchemaForGemini,
+			input: `{"anyOf":[true,{"type":"string"}]}`,
+			assertFn: func(t *testing.T, result gjson.Result) {
+				if !result.IsObject() || len(result.Map()) != 0 {
+					t.Fatalf("anyOf true result = %s, want {}", result.Raw)
+				}
+			},
+		},
+		{
+			name:  "additionalProperties booleans remain keyword values",
+			clean: CleanJSONSchemaForAntigravity,
+			input: `{"type":"object","properties":{"value":{"type":"string"}},"additionalProperties":false}`,
+			assertFn: func(t *testing.T, result gjson.Result) {
+				if result.Get("properties." + impossibleSchemaProperty).Exists() {
+					t.Fatalf("additionalProperties false became a false schema: %s", result.Raw)
+				}
+				if !strings.Contains(result.Get("description").String(), "No extra properties allowed") {
+					t.Fatalf("additionalProperties false hint missing: %s", result.Raw)
+				}
+			},
+		},
+		{
+			name:  "additionalProperties true is not a true schema root",
+			clean: CleanJSONSchemaForGemini,
+			input: `{"type":"object","properties":{"value":{"type":"string"}},"additionalProperties":true}`,
+			assertFn: func(t *testing.T, result gjson.Result) {
+				if result.Get("properties."+impossibleSchemaProperty).Exists() || result.Get("description").Exists() {
+					t.Fatalf("additionalProperties true changed schema meaning: %s", result.Raw)
+				}
+			},
+		},
+		{
+			name:  "false allOf makes the full schema unsatisfiable",
+			clean: CleanJSONSchemaForGemini,
+			input: `{"type":"object","allOf":[{"properties":{"value":{"type":"string"}}},false]}`,
+			assertFn: func(t *testing.T, result gjson.Result) {
+				if enum := result.Get("properties." + impossibleSchemaProperty + ".enum"); !enum.IsArray() || len(enum.Array()) != 0 {
+					t.Fatalf("allOf false result = %s", result.Raw)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output := test.clean(test.input)
+			if !json.Valid([]byte(output)) {
+				t.Fatalf("cleaned schema is invalid JSON: %s", output)
+			}
+			test.assertFn(t, gjson.Parse(output))
+		})
+	}
+}
+
+func TestCleanJSONSchemaBooleanNormalizationDoesNotTouchToolResults(t *testing.T) {
+	input := `{
+		"request": {
+			"contents": [{"parts": [{"functionResponse": {"response": {"ok": false, "enabled": true}}}]}],
+			"tools": [{"functionDeclarations": [{"name": "lookup", "parameters": true}]}]
+		}
+	}`
+	result := gjson.Parse(CleanJSONSchemaForGemini(input))
+	if result.Get("request.contents.0.parts.0.functionResponse.response.ok").Type != gjson.False ||
+		result.Get("request.contents.0.parts.0.functionResponse.response.enabled").Type != gjson.True {
+		t.Fatalf("tool result booleans changed: %s", result.Raw)
+	}
+	parameters := result.Get("request.tools.0.functionDeclarations.0.parameters")
+	if !parameters.IsObject() || len(parameters.Map()) != 0 {
+		t.Fatalf("tool true schema = %s, want {}", parameters.Raw)
+	}
+}

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -1108,6 +1108,27 @@ func TestCleanJSONSchemaBooleanSchemas(t *testing.T) {
 			},
 		},
 		{
+			name:  "Antigravity top-level true becomes validated object schema",
+			clean: CleanJSONSchemaForAntigravity,
+			input: `true`,
+			assertFn: func(t *testing.T, result gjson.Result) {
+				if result.Get("type").String() != "object" || result.Get("required.0").String() != "reason" {
+					t.Fatalf("Antigravity true schema = %s, want validated object placeholder", result.Raw)
+				}
+			},
+		},
+		{
+			name:  "Antigravity nested empty tool schema becomes validated object schema",
+			clean: CleanJSONSchemaForAntigravity,
+			input: `{"tools":[{"functionDeclarations":[{"name":"run","parametersJsonSchema":{}}]}]}`,
+			assertFn: func(t *testing.T, result gjson.Result) {
+				schema := result.Get("tools.0.functionDeclarations.0.parametersJsonSchema")
+				if schema.Get("type").String() != "object" || schema.Get("required.0").String() != "reason" {
+					t.Fatalf("nested empty schema = %s, want validated object placeholder", schema.Raw)
+				}
+			},
+		},
+		{
 			name:  "top-level false stays unsatisfiable",
 			clean: CleanJSONSchemaForAntigravity,
 			input: `false`,

--- a/internal/util/provider.go
+++ b/internal/util/provider.go
@@ -4,15 +4,52 @@
 package util
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/codexintegration"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	log "github.com/sirupsen/logrus"
 )
 
 const openAICompatibleProviderPrefix = "openai-compatible-"
+
+// ResolveCodexIntegrationModel resolves a stable Codex model slug without changing
+// non-reserved credential prefixes. matched is true for every reserved namespace,
+// including unknown slugs that must fail closed.
+func ResolveCodexIntegrationModel(modelName string, integration *config.CodexIntegrationConfig) (resolved config.CodexIntegrationModel, matched bool, err error) {
+	resolved.UpstreamModel = modelName
+	if integration == nil || !integration.Enabled {
+		return resolved, false, nil
+	}
+
+	parsed := thinking.ParseSuffix(strings.TrimSpace(modelName))
+	baseModel := strings.TrimSpace(parsed.ModelName)
+	provider, _, hasPrefix := strings.Cut(baseModel, "/")
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if !hasPrefix || !codexintegration.IsReservedProvider(provider) {
+		return resolved, false, nil
+	}
+
+	policy, errPolicy := codexintegration.NewModelPolicy(integration.Models)
+	if errPolicy != nil {
+		return resolved, true, fmt.Errorf("invalid Codex Integration model policy: %w", errPolicy)
+	}
+	mapping, ok := policy.Resolve(baseModel)
+	if !ok || !mapping.Visible {
+		return resolved, true, fmt.Errorf("Codex Integration model %q is not configured", baseModel)
+	}
+	if mapping.Provider != provider {
+		return resolved, true, fmt.Errorf("Codex Integration model %q requires provider %q", baseModel, mapping.Provider)
+	}
+	if parsed.HasSuffix {
+		mapping.UpstreamModel += "(" + parsed.RawSuffix + ")"
+	}
+	return mapping, true, nil
+}
 
 // OpenAICompatibleProviderKey returns the internal provider key for an OpenAI-compatible provider.
 func OpenAICompatibleProviderKey(name string) string {

--- a/internal/util/provider_codex_test.go
+++ b/internal/util/provider_codex_test.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestResolveCodexIntegrationModel(t *testing.T) {
+	integration := config.DefaultCodexIntegrationConfig()
+	integration.Enabled = true
+
+	tests := []struct {
+		name         string
+		model        string
+		wantProvider string
+		wantUpstream string
+		wantMatched  bool
+		wantErr      bool
+	}{
+		{name: "grok", model: "xai/grok-4.5", wantProvider: "xai", wantUpstream: "grok-4.5", wantMatched: true},
+		{name: "gemini suffix", model: "antigravity/gemini-3.1-pro(high)", wantProvider: "antigravity", wantUpstream: "gemini-pro-agent(high)", wantMatched: true},
+		{name: "custom credential prefix", model: "teamA/gemini-3.1-pro", wantUpstream: "teamA/gemini-3.1-pro"},
+		{name: "unknown reserved slug", model: "xai/missing", wantMatched: true, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved, matched, err := ResolveCodexIntegrationModel(tt.model, &integration)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveCodexIntegrationModel() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if matched != tt.wantMatched {
+				t.Fatalf("matched = %v, want %v", matched, tt.wantMatched)
+			}
+			if err == nil && (resolved.Provider != tt.wantProvider || resolved.UpstreamModel != tt.wantUpstream) {
+				t.Fatalf("resolved = %#v, want provider=%q upstream=%q", resolved, tt.wantProvider, tt.wantUpstream)
+			}
+		})
+	}
+}
+
+func TestResolveCodexIntegrationModelDisabledPreservesReservedPrefix(t *testing.T) {
+	integration := config.DefaultCodexIntegrationConfig()
+	resolved, matched, err := ResolveCodexIntegrationModel("xai/grok-4.5", &integration)
+	if err != nil || matched || resolved.UpstreamModel != "xai/grok-4.5" {
+		t.Fatalf("ResolveCodexIntegrationModel() = %#v, %v, %v", resolved, matched, err)
+	}
+}

--- a/internal/util/provider_codex_test.go
+++ b/internal/util/provider_codex_test.go
@@ -9,6 +9,9 @@ import (
 func TestResolveCodexIntegrationModel(t *testing.T) {
 	integration := config.DefaultCodexIntegrationConfig()
 	integration.Enabled = true
+	integration.Models = append(integration.Models, config.CodexIntegrationModel{
+		Slug: "kimi/kimi-for-coding", Provider: "kimi", UpstreamModel: "kimi-for-coding", Visible: true,
+	})
 
 	tests := []struct {
 		name         string
@@ -20,6 +23,7 @@ func TestResolveCodexIntegrationModel(t *testing.T) {
 	}{
 		{name: "grok", model: "xai/grok-4.5", wantProvider: "xai", wantUpstream: "grok-4.5", wantMatched: true},
 		{name: "gemini suffix", model: "antigravity/gemini-3.1-pro(high)", wantProvider: "antigravity", wantUpstream: "gemini-pro-agent(high)", wantMatched: true},
+		{name: "kimi", model: "kimi/kimi-for-coding", wantProvider: "kimi", wantUpstream: "kimi-for-coding", wantMatched: true},
 		{name: "custom credential prefix", model: "teamA/gemini-3.1-pro", wantUpstream: "teamA/gemini-3.1-pro"},
 		{name: "unknown reserved slug", model: "xai/missing", wantMatched: true, wantErr: true},
 	}

--- a/sdk/access/types.go
+++ b/sdk/access/types.go
@@ -28,6 +28,9 @@ const (
 	// AccessProviderTypeConfigAPIKey is the built-in provider validating inline API keys.
 	AccessProviderTypeConfigAPIKey = "config-api-key"
 
+	// AccessProviderTypeCodexLoopback accepts Codex bearer credentials only from a loopback socket.
+	AccessProviderTypeCodexLoopback = "codex-loopback"
+
 	// DefaultAccessProviderName is applied when no provider name is supplied.
 	DefaultAccessProviderName = "config-inline"
 )

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -1282,51 +1282,123 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		streamHeaderInitialized = true
 	}
 
-	pendingChunks := make([]coreexecutor.StreamChunk, 0, 1)
-	streamClosedBeforeRead := false
-	streamCanceledBeforeRead := false
-	readInitialStreamChunks := func() {
-		for {
-			var chunk coreexecutor.StreamChunk
-			var ok bool
-			if ctx != nil {
-				select {
-				case <-ctx.Done():
-					streamCanceledBeforeRead = true
-					return
-				case chunk, ok = <-chunks:
-				}
-			} else {
-				chunk, ok = <-chunks
-			}
-			if !ok {
-				streamClosedBeforeRead = true
-				applyStreamHeaderInit()
-				return
-			}
-			pendingChunks = append(pendingChunks, chunk)
-			if chunk.Err != nil {
-				return
-			}
-			if len(chunk.Payload) > 0 {
-				applyStreamHeaderInit()
-				return
-			}
+	bootstrapEligible := func(err error) bool {
+		status := statusFromError(err)
+		if status == 0 {
+			return true
+		}
+		switch status {
+		case http.StatusUnauthorized, http.StatusForbidden, http.StatusPaymentRequired,
+			http.StatusRequestTimeout, http.StatusTooManyRequests:
+			return true
+		default:
+			return status >= http.StatusInternalServerError
 		}
 	}
-	readInitialStreamChunks()
+	streamErrorMessage := func(streamErr error) *interfaces.ErrorMessage {
+		status := http.StatusInternalServerError
+		if se, ok := streamErr.(interface{ StatusCode() int }); ok && se != nil {
+			if code := se.StatusCode(); code > 0 {
+				status = code
+			}
+		}
+		var addon http.Header
+		if he, ok := streamErr.(interface{ Headers() http.Header }); ok && he != nil {
+			if hdr := he.Headers(); hdr != nil {
+				addon = hdr.Clone()
+			}
+		}
+		return &interfaces.ErrorMessage{StatusCode: status, Error: streamErr, Addon: addon}
+	}
+
+	// Resolve bootstrap retries and the first payload synchronously. The returned
+	// header map is therefore final before it becomes visible to the caller and
+	// is never mutated concurrently with HTTP response handling.
+	var firstPayload []byte
+	var initialErr *interfaces.ErrorMessage
+	streamFinished := false
+	streamCanceled := false
+	bootstrapRetries := 0
+	chunkIndex := 0
+	var historyChunks [][]byte
+	maxBootstrapRetries := StreamingBootstrapRetries(h.Cfg)
+	for firstPayload == nil && initialErr == nil && !streamFinished && !streamCanceled {
+		chunk, ok, canceled := nextStreamChunk(ctx, nil, nil, chunks)
+		if canceled {
+			streamCanceled = true
+			break
+		}
+		if !ok {
+			applyStreamHeaderInit()
+			streamFinished = true
+			break
+		}
+		if chunk.Err != nil {
+			streamErr := chunk.Err
+			if bootstrapRetries < maxBootstrapRetries && bootstrapEligible(streamErr) {
+				bootstrapRetries++
+				retryResult, retryErr := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
+				if retryErr == nil {
+					rawStreamHeaders = cloneHeader(retryResult.Headers)
+					baseStreamHeaders = cloneHeader(retryResult.Headers)
+					replaceHeader(upstreamHeaders, downstreamHeadersFromExecutor(rawStreamHeaders, passthroughHeadersEnabled))
+					streamHeaderInitialized = false
+					chunks = retryResult.Chunks
+					continue
+				}
+				streamErr = enrichAuthSelectionError(retryErr, providers, normalizedModel)
+			}
+			initialErr = streamErrorMessage(streamErr)
+			break
+		}
+		if len(chunk.Payload) == 0 {
+			continue
+		}
+
+		applyStreamHeaderInit()
+		payload := cloneBytes(chunk.Payload)
+		if streamInterceptorsActive {
+			executedReq, executedOpts := executedRequest()
+			intercepted := interceptStreamChunk(ctx, interceptorHost, pluginapi.StreamChunkInterceptRequest{
+				SourceFormat:    responseProtocol,
+				Model:           normalizedModel,
+				RequestedModel:  originalRequestedModel,
+				RequestHeaders:  cloneHeader(executedOpts.Headers),
+				ResponseHeaders: cloneHeader(rawStreamHeaders),
+				OriginalRequest: cloneBytes(executedOpts.OriginalRequest),
+				RequestBody:     cloneBytes(executedReq.Payload),
+				Body:            payload,
+				HistoryChunks:   cloneByteSlices(historyChunks),
+				ChunkIndex:      chunkIndex,
+				Metadata:        executedOpts.Metadata,
+			}, execOptions.SkipInterceptorPluginID)
+			applyStreamHeaders(intercepted.Headers)
+			if len(intercepted.Body) > 0 {
+				payload = cloneBytes(intercepted.Body)
+			}
+			chunkIndex++
+			if intercepted.DropChunk {
+				continue
+			}
+		} else {
+			chunkIndex++
+		}
+		if responseProtocol == "openai-response" {
+			if errValidate := validateSSEDataJSON(payload); errValidate != nil {
+				initialErr = &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errValidate}
+				break
+			}
+		}
+		firstPayload = payload
+		streamHeadersCommitted = true
+	}
 
 	go func() {
 		defer close(dataChan)
 		defer close(errChan)
-		if streamCanceledBeforeRead {
+		if streamCanceled {
 			return
 		}
-		sentPayload := false
-		bootstrapRetries := 0
-		chunkIndex := 0
-		var historyChunks [][]byte
-		maxBootstrapRetries := StreamingBootstrapRetries(h.Cfg)
 
 		sendErr := func(msg *interfaces.ErrorMessage) bool {
 			if ctx == nil {
@@ -1354,116 +1426,73 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 			}
 		}
 
-		bootstrapEligible := func(err error) bool {
-			status := statusFromError(err)
-			if status == 0 {
-				return true
+		if initialErr != nil {
+			_ = sendErr(initialErr)
+			return
+		}
+		if firstPayload != nil {
+			if okSendData := sendData(firstPayload); !okSendData {
+				return
 			}
-			switch status {
-			case http.StatusUnauthorized, http.StatusForbidden, http.StatusPaymentRequired,
-				http.StatusRequestTimeout, http.StatusTooManyRequests:
-				return true
-			default:
-				return status >= http.StatusInternalServerError
+			if streamInterceptorsActive {
+				historyChunks = appendStreamInterceptorHistory(historyChunks, firstPayload)
 			}
 		}
+		if streamFinished {
+			return
+		}
 
-	outer:
 		for {
-			for {
-				chunk, ok, canceled := nextStreamChunk(ctx, &pendingChunks, &streamClosedBeforeRead, chunks)
-				if canceled {
-					return
+			chunk, ok, canceled := nextStreamChunk(ctx, nil, nil, chunks)
+			if canceled || !ok {
+				return
+			}
+			if chunk.Err != nil {
+				_ = sendErr(streamErrorMessage(chunk.Err))
+				return
+			}
+			if len(chunk.Payload) == 0 {
+				continue
+			}
+			payload := cloneBytes(chunk.Payload)
+			if streamInterceptorsActive {
+				executedReq, executedOpts := executedRequest()
+				intercepted := interceptStreamChunk(ctx, interceptorHost, pluginapi.StreamChunkInterceptRequest{
+					SourceFormat:    responseProtocol,
+					Model:           normalizedModel,
+					RequestedModel:  originalRequestedModel,
+					RequestHeaders:  cloneHeader(executedOpts.Headers),
+					ResponseHeaders: cloneHeader(rawStreamHeaders),
+					OriginalRequest: cloneBytes(executedOpts.OriginalRequest),
+					RequestBody:     cloneBytes(executedReq.Payload),
+					Body:            payload,
+					HistoryChunks:   cloneByteSlices(historyChunks),
+					ChunkIndex:      chunkIndex,
+					Metadata:        executedOpts.Metadata,
+				}, execOptions.SkipInterceptorPluginID)
+				applyStreamHeaders(intercepted.Headers)
+				if len(intercepted.Body) > 0 {
+					payload = cloneBytes(intercepted.Body)
 				}
-				if !ok {
-					applyStreamHeaderInit()
-					return
+				chunkIndex++
+				if intercepted.DropChunk {
+					continue
 				}
-				if chunk.Err != nil {
-					streamErr := chunk.Err
-					// Safe bootstrap recovery: if the upstream fails before any payload bytes are sent,
-					// retry a few times (to allow auth rotation / transient recovery) and then attempt model fallback.
-					if !sentPayload {
-						if bootstrapRetries < maxBootstrapRetries && bootstrapEligible(streamErr) {
-							bootstrapRetries++
-							retryResult, retryErr := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
-							if retryErr == nil {
-								rawStreamHeaders = cloneHeader(retryResult.Headers)
-								baseStreamHeaders = cloneHeader(retryResult.Headers)
-								replaceHeader(upstreamHeaders, downstreamHeadersFromExecutor(rawStreamHeaders, passthroughHeadersEnabled))
-								streamHeaderInitialized = false
-								streamHeadersCommitted = false
-								pendingChunks = nil
-								streamClosedBeforeRead = false
-								chunks = retryResult.Chunks
-								continue outer
-							}
-							streamErr = enrichAuthSelectionError(retryErr, providers, normalizedModel)
-						}
-					}
-
-					status := http.StatusInternalServerError
-					if se, ok := streamErr.(interface{ StatusCode() int }); ok && se != nil {
-						if code := se.StatusCode(); code > 0 {
-							status = code
-						}
-					}
-					var addon http.Header
-					if he, ok := streamErr.(interface{ Headers() http.Header }); ok && he != nil {
-						if hdr := he.Headers(); hdr != nil {
-							addon = hdr.Clone()
-						}
-					}
-					_ = sendErr(&interfaces.ErrorMessage{StatusCode: status, Error: streamErr, Addon: addon})
+			} else {
+				chunkIndex++
+			}
+			if responseProtocol == "openai-response" {
+				if errValidate := validateSSEDataJSON(payload); errValidate != nil {
+					_ = sendErr(&interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errValidate})
 					return
-				}
-				if len(chunk.Payload) > 0 {
-					applyStreamHeaderInit()
-					payload := cloneBytes(chunk.Payload)
-					if streamInterceptorsActive {
-						executedReq, executedOpts := executedRequest()
-						intercepted := interceptStreamChunk(ctx, interceptorHost, pluginapi.StreamChunkInterceptRequest{
-							SourceFormat:    responseProtocol,
-							Model:           normalizedModel,
-							RequestedModel:  originalRequestedModel,
-							RequestHeaders:  cloneHeader(executedOpts.Headers),
-							ResponseHeaders: cloneHeader(rawStreamHeaders),
-							OriginalRequest: cloneBytes(executedOpts.OriginalRequest),
-							RequestBody:     cloneBytes(executedReq.Payload),
-							Body:            payload,
-							HistoryChunks:   cloneByteSlices(historyChunks),
-							ChunkIndex:      chunkIndex,
-							Metadata:        executedOpts.Metadata,
-						}, execOptions.SkipInterceptorPluginID)
-						applyStreamHeaders(intercepted.Headers)
-						if len(intercepted.Body) > 0 {
-							payload = cloneBytes(intercepted.Body)
-						}
-						chunkIndex++
-						if intercepted.DropChunk {
-							continue
-						}
-					} else {
-						chunkIndex++
-					}
-					if responseProtocol == "openai-response" {
-						if errValidate := validateSSEDataJSON(payload); errValidate != nil {
-							_ = sendErr(&interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errValidate})
-							return
-						}
-					}
-					sentPayload = true
-					streamHeadersCommitted = true
-					if okSendData := sendData(payload); !okSendData {
-						return
-					}
-					if streamInterceptorsActive {
-						historyChunks = appendStreamInterceptorHistory(historyChunks, payload)
-					}
 				}
 			}
-			applyStreamHeaderInit()
-			return
+			if okSendData := sendData(payload); !okSendData {
+				return
+			}
+			if streamInterceptorsActive {
+				historyChunks = appendStreamInterceptorHistory(historyChunks, payload)
+			}
 		}
 	}()
 	return dataChan, upstreamHeaders, errChan

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -1217,19 +1217,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	if err != nil {
 		err = enrichAuthSelectionError(err, providers, normalizedModel)
 		errChan := make(chan *interfaces.ErrorMessage, 1)
-		status := http.StatusInternalServerError
-		if se, ok := err.(interface{ StatusCode() int }); ok && se != nil {
-			if code := se.StatusCode(); code > 0 {
-				status = code
-			}
-		}
-		var addon http.Header
-		if he, ok := err.(interface{ Headers() http.Header }); ok && he != nil {
-			if hdr := he.Headers(); hdr != nil {
-				addon = hdr.Clone()
-			}
-		}
-		errChan <- &interfaces.ErrorMessage{StatusCode: status, Error: err, Addon: addon}
+		errChan <- executionErrorMessage(err)
 		close(errChan)
 		return nil, nil, errChan
 	}
@@ -1295,22 +1283,6 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 			return status >= http.StatusInternalServerError
 		}
 	}
-	streamErrorMessage := func(streamErr error) *interfaces.ErrorMessage {
-		status := http.StatusInternalServerError
-		if se, ok := streamErr.(interface{ StatusCode() int }); ok && se != nil {
-			if code := se.StatusCode(); code > 0 {
-				status = code
-			}
-		}
-		var addon http.Header
-		if he, ok := streamErr.(interface{ Headers() http.Header }); ok && he != nil {
-			if hdr := he.Headers(); hdr != nil {
-				addon = hdr.Clone()
-			}
-		}
-		return &interfaces.ErrorMessage{StatusCode: status, Error: streamErr, Addon: addon}
-	}
-
 	// Resolve bootstrap retries and the first payload synchronously. The returned
 	// header map is therefore final before it becomes visible to the caller and
 	// is never mutated concurrently with HTTP response handling.
@@ -1322,6 +1294,42 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	chunkIndex := 0
 	var historyChunks [][]byte
 	maxBootstrapRetries := StreamingBootstrapRetries(h.Cfg)
+	processPayload := func(rawPayload []byte) ([]byte, bool, error) {
+		applyStreamHeaderInit()
+		payload := cloneBytes(rawPayload)
+		if streamInterceptorsActive {
+			executedReq, executedOpts := executedRequest()
+			intercepted := interceptStreamChunk(ctx, interceptorHost, pluginapi.StreamChunkInterceptRequest{
+				SourceFormat:    responseProtocol,
+				Model:           normalizedModel,
+				RequestedModel:  originalRequestedModel,
+				RequestHeaders:  cloneHeader(executedOpts.Headers),
+				ResponseHeaders: cloneHeader(rawStreamHeaders),
+				OriginalRequest: cloneBytes(executedOpts.OriginalRequest),
+				RequestBody:     cloneBytes(executedReq.Payload),
+				Body:            payload,
+				HistoryChunks:   cloneByteSlices(historyChunks),
+				ChunkIndex:      chunkIndex,
+				Metadata:        executedOpts.Metadata,
+			}, execOptions.SkipInterceptorPluginID)
+			applyStreamHeaders(intercepted.Headers)
+			if len(intercepted.Body) > 0 {
+				payload = cloneBytes(intercepted.Body)
+			}
+			chunkIndex++
+			if intercepted.DropChunk {
+				return nil, true, nil
+			}
+		} else {
+			chunkIndex++
+		}
+		if responseProtocol == "openai-response" {
+			if errValidate := validateSSEDataJSON(payload); errValidate != nil {
+				return nil, false, errValidate
+			}
+		}
+		return payload, false, nil
+	}
 	for firstPayload == nil && initialErr == nil && !streamFinished && !streamCanceled {
 		chunk, ok, canceled := nextStreamChunk(ctx, nil, nil, chunks)
 		if canceled {
@@ -1348,46 +1356,20 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 				}
 				streamErr = enrichAuthSelectionError(retryErr, providers, normalizedModel)
 			}
-			initialErr = streamErrorMessage(streamErr)
+			initialErr = executionErrorMessage(streamErr)
 			break
 		}
 		if len(chunk.Payload) == 0 {
 			continue
 		}
 
-		applyStreamHeaderInit()
-		payload := cloneBytes(chunk.Payload)
-		if streamInterceptorsActive {
-			executedReq, executedOpts := executedRequest()
-			intercepted := interceptStreamChunk(ctx, interceptorHost, pluginapi.StreamChunkInterceptRequest{
-				SourceFormat:    responseProtocol,
-				Model:           normalizedModel,
-				RequestedModel:  originalRequestedModel,
-				RequestHeaders:  cloneHeader(executedOpts.Headers),
-				ResponseHeaders: cloneHeader(rawStreamHeaders),
-				OriginalRequest: cloneBytes(executedOpts.OriginalRequest),
-				RequestBody:     cloneBytes(executedReq.Payload),
-				Body:            payload,
-				HistoryChunks:   cloneByteSlices(historyChunks),
-				ChunkIndex:      chunkIndex,
-				Metadata:        executedOpts.Metadata,
-			}, execOptions.SkipInterceptorPluginID)
-			applyStreamHeaders(intercepted.Headers)
-			if len(intercepted.Body) > 0 {
-				payload = cloneBytes(intercepted.Body)
-			}
-			chunkIndex++
-			if intercepted.DropChunk {
-				continue
-			}
-		} else {
-			chunkIndex++
+		payload, dropped, errProcess := processPayload(chunk.Payload)
+		if errProcess != nil {
+			initialErr = &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errProcess}
+			break
 		}
-		if responseProtocol == "openai-response" {
-			if errValidate := validateSSEDataJSON(payload); errValidate != nil {
-				initialErr = &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errValidate}
-				break
-			}
+		if dropped {
+			continue
 		}
 		firstPayload = payload
 		streamHeadersCommitted = true
@@ -1448,44 +1430,19 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 				return
 			}
 			if chunk.Err != nil {
-				_ = sendErr(streamErrorMessage(chunk.Err))
+				_ = sendErr(executionErrorMessage(chunk.Err))
 				return
 			}
 			if len(chunk.Payload) == 0 {
 				continue
 			}
-			payload := cloneBytes(chunk.Payload)
-			if streamInterceptorsActive {
-				executedReq, executedOpts := executedRequest()
-				intercepted := interceptStreamChunk(ctx, interceptorHost, pluginapi.StreamChunkInterceptRequest{
-					SourceFormat:    responseProtocol,
-					Model:           normalizedModel,
-					RequestedModel:  originalRequestedModel,
-					RequestHeaders:  cloneHeader(executedOpts.Headers),
-					ResponseHeaders: cloneHeader(rawStreamHeaders),
-					OriginalRequest: cloneBytes(executedOpts.OriginalRequest),
-					RequestBody:     cloneBytes(executedReq.Payload),
-					Body:            payload,
-					HistoryChunks:   cloneByteSlices(historyChunks),
-					ChunkIndex:      chunkIndex,
-					Metadata:        executedOpts.Metadata,
-				}, execOptions.SkipInterceptorPluginID)
-				applyStreamHeaders(intercepted.Headers)
-				if len(intercepted.Body) > 0 {
-					payload = cloneBytes(intercepted.Body)
-				}
-				chunkIndex++
-				if intercepted.DropChunk {
-					continue
-				}
-			} else {
-				chunkIndex++
+			payload, dropped, errProcess := processPayload(chunk.Payload)
+			if errProcess != nil {
+				_ = sendErr(&interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errProcess})
+				return
 			}
-			if responseProtocol == "openai-response" {
-				if errValidate := validateSSEDataJSON(payload); errValidate != nil {
-					_ = sendErr(&interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errValidate})
-					return
-				}
+			if dropped {
+				continue
 			}
 			if okSendData := sendData(payload); !okSendData {
 				return

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -741,7 +741,15 @@ func (h *BaseAPIHandler) executeWithAuthManager(ctx context.Context, handlerType
 
 func (h *BaseAPIHandler) executeWithAuthManagerFormats(ctx context.Context, entryProtocol, exitProtocol, modelName string, rawJSON []byte, alt string, allowImageModel bool, execOptions modelExecutionOptions) ([]byte, http.Header, *interfaces.ErrorMessage) {
 	originalRequestedModel := modelName
-	routeDecision := h.applyModelRouter(ctx, entryProtocol, modelName, rawJSON, false, execOptions)
+	var errMsg *interfaces.ErrorMessage
+	modelName, execOptions, errMsg = h.prepareCodexIntegrationExecution(modelName, execOptions)
+	if errMsg != nil {
+		return nil, nil, errMsg
+	}
+	routeDecision := modelRouteDecision{}
+	if !execOptions.StrictForcedProvider {
+		routeDecision = h.applyModelRouter(ctx, entryProtocol, modelName, rawJSON, false, execOptions)
+	}
 	responseProtocol := modelExecutionResponseProtocol(entryProtocol, exitProtocol)
 	if errMsg := validateNativeInteractionsExecution(entryProtocol, execOptions, routeDecision); errMsg != nil {
 		return nil, nil, errMsg
@@ -814,7 +822,15 @@ func (h *BaseAPIHandler) ExecuteCountWithAuthManager(ctx context.Context, handle
 
 func (h *BaseAPIHandler) executeCountWithAuthManager(ctx context.Context, handlerType, modelName string, rawJSON []byte, alt string, execOptions modelExecutionOptions) ([]byte, http.Header, *interfaces.ErrorMessage) {
 	originalRequestedModel := modelName
-	routeDecision := h.applyModelRouter(ctx, handlerType, modelName, rawJSON, false, execOptions)
+	var errMsg *interfaces.ErrorMessage
+	modelName, execOptions, errMsg = h.prepareCodexIntegrationExecution(modelName, execOptions)
+	if errMsg != nil {
+		return nil, nil, errMsg
+	}
+	routeDecision := modelRouteDecision{}
+	if !execOptions.StrictForcedProvider {
+		routeDecision = h.applyModelRouter(ctx, handlerType, modelName, rawJSON, false, execOptions)
+	}
 	if routeDecision.ExecutorPluginID != "" {
 		return h.countWithPluginExecutor(ctx, handlerType, modelName, originalRequestedModel, rawJSON, alt, routeDecision.ExecutorPluginID, execOptions)
 	}
@@ -1139,7 +1155,18 @@ func (h *BaseAPIHandler) executeStreamWithAuthManager(ctx context.Context, handl
 
 func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context, entryProtocol, exitProtocol, modelName string, rawJSON []byte, alt string, allowImageModel bool, execOptions modelExecutionOptions) (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
 	originalRequestedModel := modelName
-	routeDecision := h.applyModelRouter(ctx, entryProtocol, modelName, rawJSON, true, execOptions)
+	var errMsg *interfaces.ErrorMessage
+	modelName, execOptions, errMsg = h.prepareCodexIntegrationExecution(modelName, execOptions)
+	if errMsg != nil {
+		errChan := make(chan *interfaces.ErrorMessage, 1)
+		errChan <- errMsg
+		close(errChan)
+		return nil, nil, errChan
+	}
+	routeDecision := modelRouteDecision{}
+	if !execOptions.StrictForcedProvider {
+		routeDecision = h.applyModelRouter(ctx, entryProtocol, modelName, rawJSON, true, execOptions)
+	}
 	responseProtocol := modelExecutionResponseProtocol(entryProtocol, exitProtocol)
 	if errMsg := validateNativeInteractionsExecution(entryProtocol, execOptions, routeDecision); errMsg != nil {
 		errChan := make(chan *interfaces.ErrorMessage, 1)
@@ -1547,6 +1574,29 @@ func statusFromError(err error) int {
 
 func (h *BaseAPIHandler) getRequestDetails(modelName string) (providers []string, normalizedModel string, err *interfaces.ErrorMessage) {
 	return h.getRequestDetailsWithOptions(modelName, false)
+}
+
+func (h *BaseAPIHandler) prepareCodexIntegrationExecution(modelName string, execOptions modelExecutionOptions) (string, modelExecutionOptions, *interfaces.ErrorMessage) {
+	if h == nil || h.Cfg == nil {
+		return modelName, execOptions, nil
+	}
+	resolved, matched, errResolve := util.ResolveCodexIntegrationModel(modelName, &h.Cfg.CodexIntegration)
+	if !matched {
+		return modelName, execOptions, nil
+	}
+	if errResolve != nil {
+		return modelName, execOptions, &interfaces.ErrorMessage{StatusCode: http.StatusBadRequest, Error: errResolve}
+	}
+	forcedProvider := strings.ToLower(strings.TrimSpace(execOptions.ForcedProvider))
+	if forcedProvider != "" && forcedProvider != resolved.Provider {
+		return modelName, execOptions, &interfaces.ErrorMessage{
+			StatusCode: http.StatusBadRequest,
+			Error:      fmt.Errorf("model %q requires provider %q, not %q", modelName, resolved.Provider, forcedProvider),
+		}
+	}
+	execOptions.ForcedProvider = resolved.Provider
+	execOptions.StrictForcedProvider = true
+	return modelName, execOptions, nil
 }
 
 func validateNativeInteractionsExecution(entryProtocol string, execOptions modelExecutionOptions, routeDecision modelRouteDecision) *interfaces.ErrorMessage {

--- a/sdk/api/handlers/model_execution.go
+++ b/sdk/api/handlers/model_execution.go
@@ -21,6 +21,7 @@ type modelExecutionOptions struct {
 	SkipInterceptorPluginID string
 	SkipRouterPluginID      string
 	ForcedProvider          string
+	StrictForcedProvider    bool
 	AuthSelectionModel      string
 }
 

--- a/sdk/api/handlers/model_execution_test.go
+++ b/sdk/api/handlers/model_execution_test.go
@@ -561,6 +561,45 @@ func TestExecuteProtocolWithAuthManagerUsesForcedProvider(t *testing.T) {
 	}
 }
 
+func TestPrepareCodexIntegrationExecutionForcesStableProvider(t *testing.T) {
+	integration := sdkconfig.DefaultCodexIntegrationConfig()
+	integration.Enabled = true
+	handler := &BaseAPIHandler{Cfg: &sdkconfig.SDKConfig{CodexIntegration: integration}}
+
+	model, opts, errMsg := handler.prepareCodexIntegrationExecution("antigravity/gemini-3.1-pro(high)", modelExecutionOptions{})
+	if errMsg != nil {
+		t.Fatalf("prepareCodexIntegrationExecution() error = %+v", errMsg)
+	}
+	if model != "antigravity/gemini-3.1-pro(high)" {
+		t.Fatalf("model = %q, want stable client slug", model)
+	}
+	if opts.ForcedProvider != "antigravity" {
+		t.Fatalf("ForcedProvider = %q, want antigravity", opts.ForcedProvider)
+	}
+}
+
+func TestPrepareCodexIntegrationExecutionRejectsProviderConflict(t *testing.T) {
+	integration := sdkconfig.DefaultCodexIntegrationConfig()
+	integration.Enabled = true
+	handler := &BaseAPIHandler{Cfg: &sdkconfig.SDKConfig{CodexIntegration: integration}}
+
+	_, _, errMsg := handler.prepareCodexIntegrationExecution("xai/grok-4.5", modelExecutionOptions{ForcedProvider: "codex"})
+	if errMsg == nil || errMsg.StatusCode != http.StatusBadRequest {
+		t.Fatalf("prepareCodexIntegrationExecution() error = %+v, want 400", errMsg)
+	}
+}
+
+func TestPrepareCodexIntegrationExecutionLeavesCustomPrefixUntouched(t *testing.T) {
+	integration := sdkconfig.DefaultCodexIntegrationConfig()
+	integration.Enabled = true
+	handler := &BaseAPIHandler{Cfg: &sdkconfig.SDKConfig{CodexIntegration: integration}}
+
+	model, opts, errMsg := handler.prepareCodexIntegrationExecution("teamA/gemini-3.1-pro", modelExecutionOptions{})
+	if errMsg != nil || model != "teamA/gemini-3.1-pro" || opts.ForcedProvider != "" {
+		t.Fatalf("prepareCodexIntegrationExecution() = %q, %#v, %+v", model, opts, errMsg)
+	}
+}
+
 func TestPreferExecutionProviderMovesPreferredFirst(t *testing.T) {
 	providers := preferExecutionProvider([]string{"gemini", "gemini-interactions", "claude"}, "gemini-interactions")
 	want := []string{"gemini-interactions", "gemini", "claude"}

--- a/sdk/api/handlers/openai/codex_client_models.go
+++ b/sdk/api/handlers/openai/codex_client_models.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/codexintegration"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	log "github.com/sirupsen/logrus"
 )
 
 type codexClientModelsPayload struct {
@@ -35,6 +37,13 @@ var codexClientAllowedReasoningLevels = map[string]struct{}{
 }
 
 func (h *OpenAIAPIHandler) codexClientModelsResponse() map[string]any {
+	if h != nil && h.Cfg != nil && h.Cfg.CodexIntegration.Enabled {
+		catalog, err := codexintegration.CompileCatalog(h.Models(), registry.GetGlobalRegistry().GetModelProviders, h.Cfg.CodexIntegration)
+		if err == nil {
+			return map[string]any{"models": catalog.Models}
+		}
+		log.WithError(err).Warn("Codex Integration catalog compile failed; serving official last-good model surface")
+	}
 	return codexClientModelsResponse(h.Models(), registry.GetGlobalRegistry().GetModelProviders)
 }
 

--- a/sdk/cliproxy/auth/codex_integration_alias_test.go
+++ b/sdk/cliproxy/auth/codex_integration_alias_test.go
@@ -1,0 +1,23 @@
+package auth
+
+import (
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestCodexIntegrationAliasesResolveAndForceResponseMapping(t *testing.T) {
+	cfg := &internalconfig.Config{SDKConfig: internalconfig.SDKConfig{CodexIntegration: internalconfig.DefaultCodexIntegrationConfig()}}
+	cfg.CodexIntegration.Enabled = true
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(cfg)
+	mgr.SetOAuthModelAlias(cfg.EffectiveOAuthModelAlias())
+
+	result := mgr.resolveOAuthModelAliasWithResult(&Auth{Provider: "antigravity"}, "antigravity/gemini-3.1-pro(high)")
+	if result.UpstreamModel != "gemini-pro-agent(high)" {
+		t.Fatalf("UpstreamModel = %q, want gemini-pro-agent(high)", result.UpstreamModel)
+	}
+	if !result.ForceMapping || result.OriginalAlias != "antigravity/gemini-3.1-pro" {
+		t.Fatalf("alias result = %#v, want forced stable response mapping", result)
+	}
+}

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -269,7 +269,7 @@ func (b *Builder) Build() (*Service, error) {
 	// Attach a default RoundTripper provider so providers can opt-in per-auth transports.
 	coreManager.SetRoundTripperProvider(newDefaultRoundTripperProvider())
 	coreManager.SetConfig(b.cfg)
-	coreManager.SetOAuthModelAlias(b.cfg.OAuthModelAlias)
+	coreManager.SetOAuthModelAlias(b.cfg.EffectiveOAuthModelAlias())
 	if pluginHost != nil {
 		coreManager.SetPluginScheduler(pluginHost)
 	}

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	codexloopback "github.com/router-for-me/CLIProxyAPI/v7/internal/access/codex_loopback"
 	configaccess "github.com/router-for-me/CLIProxyAPI/v7/internal/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/api"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
@@ -218,6 +219,7 @@ func (b *Builder) Build() (*Service, error) {
 	}
 
 	configaccess.Register(&b.cfg.SDKConfig)
+	codexloopback.Register(&b.cfg.SDKConfig)
 	pluginHost := b.pluginHost
 	if pluginHost == nil {
 		pluginHost = pluginhost.New()

--- a/sdk/cliproxy/builder_codex_access_test.go
+++ b/sdk/cliproxy/builder_codex_access_test.go
@@ -1,0 +1,42 @@
+package cliproxy
+
+import (
+	"testing"
+
+	codexloopback "github.com/router-for-me/CLIProxyAPI/v7/internal/access/codex_loopback"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+func TestBuilderRegistersCodexLoopbackAccessOnColdStart(t *testing.T) {
+	t.Cleanup(func() {
+		disabled := config.DefaultCodexIntegrationConfig()
+		codexloopback.Register(&config.SDKConfig{CodexIntegration: disabled})
+	})
+	integration := config.DefaultCodexIntegrationConfig()
+	integration.Enabled = true
+	cfg := &config.Config{
+		SDKConfig: config.SDKConfig{CodexIntegration: integration},
+		AuthDir:   t.TempDir(),
+	}
+	manager := sdkaccess.NewManager()
+	_, err := NewBuilder().
+		WithConfig(cfg).
+		WithConfigPath(t.TempDir() + "/config.yaml").
+		WithRequestAccessManager(manager).
+		Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	found := false
+	for _, provider := range manager.Providers() {
+		if provider != nil && provider.Identifier() == codexloopback.DefaultProviderName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("cold-start access manager is missing the Codex loopback provider")
+	}
+}

--- a/sdk/cliproxy/model_registry.go
+++ b/sdk/cliproxy/model_registry.go
@@ -28,3 +28,8 @@ func GlobalModelRegistry() ModelRegistry {
 func SetGlobalModelRegistryHook(hook ModelRegistryHook) {
 	registry.GetGlobalRegistry().SetHook(hook)
 }
+
+// SubscribeGlobalModelRegistryHook adds an observer without replacing the legacy hook.
+func SubscribeGlobalModelRegistryHook(hook ModelRegistryHook) func() {
+	return registry.GetGlobalRegistry().SubscribeHook(hook)
+}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/api"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/codexintegration"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/constant"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/homeplugins"
@@ -87,6 +88,11 @@ type Service struct {
 
 	// authQueueStop cancels the auth update queue processing.
 	authQueueStop context.CancelFunc
+
+	// codexSyncCancel controls the optional Codex catalog auto-sync worker.
+	codexSyncMu      sync.Mutex
+	codexSyncCancel  context.CancelFunc
+	codexSyncRootCtx context.Context
 
 	// authManager handles legacy authentication operations.
 	authManager *sdkAuth.Manager
@@ -1355,6 +1361,7 @@ func (s *Service) applyConfigUpdateWithAuthSynthesis(newCfg *config.Config, synt
 		}
 	}
 	s.syncPluginModelRuntime(ctx)
+	s.configureCodexSyncWorker(nil, newCfg)
 }
 
 func (s *Service) reloadConfigFromWatcher() bool {
@@ -1770,6 +1777,7 @@ func (s *Service) Run(ctx context.Context) error {
 	}
 
 	s.registerModelRefreshCallback()
+	s.configureCodexSyncWorker(ctx, s.cfg)
 
 	// Prefer core auth manager auto refresh if available.
 	if s.coreManager != nil && !homeEnabled {
@@ -1846,6 +1854,7 @@ func (s *Service) Shutdown(ctx context.Context) error {
 			s.authQueueStop()
 			s.authQueueStop = nil
 		}
+		s.configureCodexSyncWorker(context.Background(), nil)
 
 		if errShutdownPprof := s.shutdownPprof(ctx); errShutdownPprof != nil {
 			log.Errorf("failed to stop pprof server: %v", errShutdownPprof)
@@ -1888,6 +1897,36 @@ func (s *Service) Shutdown(ctx context.Context) error {
 		usage.StopDefault()
 	})
 	return shutdownErr
+}
+
+func (s *Service) configureCodexSyncWorker(ctx context.Context, cfg *config.Config) {
+	if s == nil {
+		return
+	}
+	s.codexSyncMu.Lock()
+	defer s.codexSyncMu.Unlock()
+	if ctx != nil {
+		s.codexSyncRootCtx = ctx
+	}
+	if s.codexSyncCancel != nil {
+		s.codexSyncCancel()
+		s.codexSyncCancel = nil
+	}
+	if cfg == nil || !cfg.CodexIntegration.Enabled || !cfg.CodexIntegration.AutoSync {
+		return
+	}
+	rootCtx := s.codexSyncRootCtx
+	if rootCtx == nil {
+		rootCtx = context.Background()
+	}
+	worker, err := codexintegration.NewSyncWorker(cfg, registry.GetGlobalRegistry())
+	if err != nil {
+		log.Warnf("failed to configure Codex Integration auto-sync: %v", err)
+		return
+	}
+	workerCtx, cancel := context.WithCancel(rootCtx)
+	s.codexSyncCancel = cancel
+	go worker.Run(workerCtx)
 }
 
 func (s *Service) ensureAuthDir() error {

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1333,7 +1333,7 @@ func (s *Service) applyConfigUpdateWithAuthSynthesis(newCfg *config.Config, synt
 	s.cfgMu.Unlock()
 	if s.coreManager != nil {
 		s.coreManager.SetConfig(newCfg)
-		s.coreManager.SetOAuthModelAlias(newCfg.OAuthModelAlias)
+		s.coreManager.SetOAuthModelAlias(newCfg.EffectiveOAuthModelAlias())
 	}
 	ctx := coreauth.WithSkipPersist(context.Background())
 	s.syncPluginRuntimeConfig(ctx)

--- a/sdk/cliproxy/service_codex_sync_test.go
+++ b/sdk/cliproxy/service_codex_sync_test.go
@@ -1,0 +1,41 @@
+package cliproxy
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestConfigureCodexSyncWorkerHonorsIntegrationFlags(t *testing.T) {
+	service := &Service{}
+	integration := config.DefaultCodexIntegrationConfig()
+	cfg := &config.Config{
+		SDKConfig: config.SDKConfig{CodexIntegration: integration},
+		Host:      "127.0.0.1",
+		Port:      8317,
+	}
+	service.configureCodexSyncWorker(context.Background(), cfg)
+	if service.codexSyncCancel != nil {
+		t.Fatal("disabled integration started auto-sync")
+	}
+
+	cfg.CodexIntegration.Enabled = true
+	cfg.CodexIntegration.AutoSync = false
+	service.configureCodexSyncWorker(context.Background(), cfg)
+	if service.codexSyncCancel != nil {
+		t.Fatal("auto-sync=false started auto-sync")
+	}
+
+	cfg.CodexIntegration.AutoSync = true
+	cfg.CodexIntegration.CodexHome = filepath.Join(t.TempDir(), "codex-home")
+	service.configureCodexSyncWorker(context.Background(), cfg)
+	if service.codexSyncCancel == nil {
+		t.Fatal("enabled auto-sync did not start worker")
+	}
+	service.configureCodexSyncWorker(context.Background(), nil)
+	if service.codexSyncCancel != nil {
+		t.Fatal("disabling integration did not stop worker")
+	}
+}

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -11,6 +11,8 @@ type SDKConfig = internalconfig.SDKConfig
 type Config = internalconfig.Config
 
 type StreamingConfig = internalconfig.StreamingConfig
+type CodexIntegrationConfig = internalconfig.CodexIntegrationConfig
+type CodexIntegrationModel = internalconfig.CodexIntegrationModel
 type TLSConfig = internalconfig.TLSConfig
 type RemoteManagement = internalconfig.RemoteManagement
 type OAuthModelAlias = internalconfig.OAuthModelAlias
@@ -34,7 +36,12 @@ type TLS = internalconfig.TLSConfig
 
 const (
 	DefaultPanelGitHubRepository = internalconfig.DefaultPanelGitHubRepository
+	DefaultCodexCatalogFile      = internalconfig.DefaultCodexCatalogFile
 )
+
+func DefaultCodexIntegrationConfig() CodexIntegrationConfig {
+	return internalconfig.DefaultCodexIntegrationConfig()
+}
 
 func LoadConfig(configFile string) (*Config, error) { return internalconfig.LoadConfig(configFile) }
 


### PR DESCRIPTION
## Summary

- add an opt-in `codex-integration` mode that generates a complete Codex desktop/CLI model catalog while retaining the official Codex GPT surface
- expose configured native providers through collision-safe slugs such as `xai/grok-4.5`, `antigravity/gemini-3.6-flash`, `antigravity/gemini-3.1-pro`, and `antigravity/claude-opus-4-6-thinking`
- add preview-first `-codex-setup`, `-codex-sync`, `-codex-doctor`, and `-codex-restore` commands with JSON output, backups, journaling, rollback, and auto-sync
- add strict provider-qualified routing, loopback-only data-plane access, and the Codex HTTP/WebSocket compatibility fixes needed by desktop sessions

## Motivation

The proxy `/v1/models` response alone does not fully populate the Codex App/CLI picker. Codex also consumes its client model catalog, so newly available official and third-party models can remain invisible even though the data plane can execute them. This came up in #2994 and #3001.

This integration compiles a local `model_catalog_json` from CLIProxyAPI's validated Codex templates plus configured provider mappings. Official GPT models remain present, while third-party entries are provider-qualified and forced to their declared native provider.

## Safety and compatibility

- disabled by default
- requires a strict loopback listener before enabling loopback bearer access
- lifecycle commands preview unless `-apply` is explicit
- config/catalog writes are atomic and journaled; restore preserves subsequent user edits
- existing `model_provider` and `[model_providers.*]` entries are preserved because Codex can use provider identity to scope existing task history
- no session database mutation and no credential contents in diagnostics
- configured Gemini, Claude, Codex, xAI, and Vertex API keys plus file-backed OAuth metadata are recognized by doctor
- unconfigured reserved slugs fail closed instead of falling through to another provider

## Validation

- `go test ./...`
- `go test -race ./internal/codexintegration ./internal/access/codex_loopback ./internal/registry ./internal/runtime/executor ./sdk/cliproxy ./sdk/api/handlers/...`
- `go vet` on all changed runtime packages
- `go build ./cmd/server`
- `git diff --check`

This is intentionally opened as a draft because it is a broad, cross-layer integration. I can split it into smaller review units if that matches the maintainer workflow better.
