### PR TITLE
feat(registry): add gemini-3.5-flash-lite and gemini-3.6-flash to gemini/aistudio providers

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -520,6 +520,66 @@
           "high"
         ]
       }
+    },
+    {
+      "id": "gemini-3.5-flash-lite",
+      "object": "model",
+      "created": 1782864000,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.5 Flash Lite",
+      "name": "models/gemini-3.5-flash-lite",
+      "version": "3.5",
+      "description": "Gemini 3.5 Flash Lite",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "gemini-3.6-flash",
+      "object": "model",
+      "created": 1782864000,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.6 Flash",
+      "name": "models/gemini-3.6-flash",
+      "version": "3.6",
+      "description": "Gemini 3.6 Flash",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     }
   ],
   "vertex": [
@@ -1361,6 +1421,66 @@
       "name": "models/gemini-3.5-flash",
       "version": "3.5",
       "description": "Our most intelligent model built for speed, combining frontier intelligence with superior search and grounding.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "gemini-3.5-flash-lite",
+      "object": "model",
+      "created": 1782864000,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.5 Flash Lite",
+      "name": "models/gemini-3.5-flash-lite",
+      "version": "3.5",
+      "description": "Gemini 3.5 Flash Lite",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "gemini-3.6-flash",
+      "object": "model",
+      "created": 1782864000,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.6 Flash",
+      "name": "models/gemini-3.6-flash",
+      "version": "3.6",
+      "description": "Gemini 3.6 Flash",
       "inputTokenLimit": 1048576,
       "outputTokenLimit": 65536,
       "supportedGenerationMethods": [


### PR DESCRIPTION
## Summary

Adds `gemini-3.5-flash-lite` and `gemini-3.6-flash` to the `gemini` and `aistudio` provider sections of `internal/registry/models/models.json` (4 entries total).

Related: #4521 (which requests `gemini-3.5-flash-lite` for the Antigravity provider — this PR covers the AI Studio API key side; per #4494 the Antigravity remote model list refresh may already handle that channel).

## Verification (2026-07-23, against Google Generative Language API with an AI Studio key)

- `GET /v1beta/models` includes both `models/gemini-3.5-flash-lite` and `models/gemini-3.6-flash`
- `generateContent` returns 200 for both (`modelVersion` echoes `gemini-3.5-flash-lite` / `gemini-3.6-flash`; both are thinking models — 3.6-flash needs a reasoning budget, e.g. `maxOutputTokens: 600` yielded `thoughtsTokenCount: 65`)
- Official metadata for both: `inputTokenLimit: 1048576`, `outputTokenLimit: 65536`, methods `generateContent / countTokens / createCachedContent / batchGenerateContent`
- Routing itself already works: explicitly listing the model under a `gemini-api-key` entry's `models:` in `config.yaml` serves requests fine (tested end-to-end on v7.2.95) — this is purely a registry omission.

## Notes on entry contents

- Token limits, generation methods, `display_name`/`description` follow Google's official model metadata.
- The `thinking` block mirrors the existing `gemini-3.5-flash` entry (min 128 / max 32768 / dynamic / 4 levels), consistent with same-generation entries.
- `vertex` / `antigravity` sections intentionally untouched (Vertex availability not verified by me; Antigravity uses the remote list).

---

中文摘要：為 `gemini` 與 `aistudio` 渠道補上 `gemini-3.5-flash-lite` 與 `gemini-3.6-flash` 的 registry 條目。已用 AI Studio key 直打 Google API 驗證兩模型均在 ListModels 且 generateContent 200；config 明列 workaround 可路由，證明僅缺 registry 條目。條目欄位依官方 metadata，thinking 區塊比照 `gemini-3.5-flash`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Urwca7VJSNPjrnJWJ2SrSs