### PR TITLE
fix(responses): flatten nested Chat Completions tools on Responses echo

### DIFF
--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -119,7 +119,7 @@ func buildResponsesCompletedEvent(st *oaiToResponsesState, requestRawJSON []byte
 			completed, _ = sjson.SetBytes(completed, "response.tool_choice", v.Value())
 		}
 		if v := req.Get("tools"); v.Exists() {
-			completed, _ = sjson.SetBytes(completed, "response.tools", v.Value())
+			completed, _ = sjson.SetBytes(completed, "response.tools", toolsForOpenAIResponsesEcho(v))
 		}
 		if v := req.Get("top_logprobs"); v.Exists() {
 			completed, _ = sjson.SetBytes(completed, "response.top_logprobs", v.Int())
@@ -774,8 +774,14 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 		if v := req.Get("tool_choice"); v.Exists() {
 			resp, _ = sjson.SetBytes(resp, "tool_choice", v.Value())
 		}
-		if v := req.Get("tools"); v.Exists() {
-			resp, _ = sjson.SetBytes(resp, "tools", v.Value())
+		// Prefer original Responses request for tools echo when available;
+		// always normalize nested Chat Completions shape → Responses flat.
+		toolsRaw := requestRawJSON
+		if len(requestForNamespace) > 0 && gjson.GetBytes(requestForNamespace, "tools").Exists() {
+			toolsRaw = requestForNamespace
+		}
+		if v := gjson.GetBytes(toolsRaw, "tools"); v.Exists() {
+			resp, _ = sjson.SetBytes(resp, "tools", toolsForOpenAIResponsesEcho(v))
 		}
 		if v := req.Get("top_logprobs"); v.Exists() {
 			resp, _ = sjson.SetBytes(resp, "top_logprobs", v.Int())

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -503,6 +503,149 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_OmitsTop
 	}
 }
 
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_FlattensNestedChatTools(t *testing.T) {
+	// When only the translated Chat Completions request is available, tools echo
+	// must still be Responses-flat (top-level name + parameters).
+	translatedRequest := []byte(`{
+		"model":"gpt-5-6-sol-max",
+		"tools":[{
+			"type":"function",
+			"function":{
+				"name":"mcp_jbcontext_code_search",
+				"description":"Search code via jbcontext MCP",
+				"parameters":{"type":"object","properties":{"query":{"type":"string"}},"additionalProperties":false}
+			}
+		}]
+	}`)
+	raw := []byte(`{"id":"chatcmpl_tools_flat","object":"chat.completion","created":1773896263,"model":"model","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`)
+
+	resp := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "model", nil, translatedRequest, raw, nil)
+	tool0 := gjson.GetBytes(resp, "tools.0")
+	if !tool0.Exists() {
+		t.Fatalf("tools[0] missing: %s", resp)
+	}
+	if tool0.Get("function").Exists() {
+		t.Fatalf("tools[0] still nested under function: %s", tool0.Raw)
+	}
+	if got := tool0.Get("name").String(); got != "mcp_jbcontext_code_search" {
+		t.Fatalf("tools[0].name = %q, want mcp_jbcontext_code_search; tool=%s", got, tool0.Raw)
+	}
+	if !tool0.Get("parameters").Exists() {
+		t.Fatalf("tools[0].parameters missing: %s", tool0.Raw)
+	}
+	if got := tool0.Get("description").String(); got != "Search code via jbcontext MCP" {
+		t.Fatalf("tools[0].description = %q; tool=%s", got, tool0.Raw)
+	}
+}
+
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_PrefersOriginalFlatTools(t *testing.T) {
+	originalRequest := []byte(`{
+		"model":"gpt-5-6-sol-max",
+		"tools":[{"type":"function","name":"flat_tool","description":"flat","parameters":{"type":"object","properties":{}}}]
+	}`)
+	translatedRequest := []byte(`{
+		"model":"gpt-5-6-sol-max",
+		"tools":[{"type":"function","function":{"name":"flat_tool","description":"nested","parameters":{"type":"object","properties":{}}}}]
+	}`)
+	raw := []byte(`{"id":"chatcmpl_tools_orig","object":"chat.completion","created":1773896263,"model":"model","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+
+	resp := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "model", originalRequest, translatedRequest, raw, nil)
+	tool0 := gjson.GetBytes(resp, "tools.0")
+	if tool0.Get("function").Exists() {
+		t.Fatalf("tools[0] nested: %s", tool0.Raw)
+	}
+	if got := tool0.Get("description").String(); got != "flat" {
+		t.Fatalf("expected original flat tools echo, got description=%q tool=%s", got, tool0.Raw)
+	}
+}
+
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_StreamCompletedFlattensNestedChatTools(t *testing.T) {
+	t.Parallel()
+
+	// Stream path only sees the translated Chat Completions request when original is absent.
+	translatedRequest := []byte(`{
+		"model":"gpt-5-6-sol-max",
+		"tools":[{
+			"type":"function",
+			"function":{
+				"name":"mcp_jbcontext_code_search",
+				"description":"Search code via jbcontext MCP",
+				"parameters":{"type":"object","properties":{"query":{"type":"string"}}}
+			}
+		}]
+	}`)
+	chunks := []string{
+		`data: {"id":"chatcmpl_tools_stream","object":"chat.completion.chunk","created":1773896263,"model":"model","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl_tools_stream","object":"chat.completion.chunk","created":1773896263,"model":"model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`,
+		`data: [DONE]`,
+	}
+
+	var param any
+	var completed gjson.Result
+	for _, line := range chunks {
+		for _, chunk := range ConvertOpenAIChatCompletionsResponseToOpenAIResponses(context.Background(), "model", nil, translatedRequest, []byte(line), &param) {
+			event, data := parseOpenAIResponsesSSEEvent(t, chunk)
+			if event == "response.completed" {
+				completed = data
+			}
+		}
+	}
+	if !completed.Exists() {
+		t.Fatal("expected response.completed event")
+	}
+	tool0 := completed.Get("response.tools.0")
+	if !tool0.Exists() {
+		t.Fatalf("response.tools[0] missing: %s", completed.Raw)
+	}
+	if tool0.Get("function").Exists() {
+		t.Fatalf("response.tools[0] still nested: %s", tool0.Raw)
+	}
+	if got := tool0.Get("name").String(); got != "mcp_jbcontext_code_search" {
+		t.Fatalf("response.tools[0].name=%q; tool=%s", got, tool0.Raw)
+	}
+	if !tool0.Get("parameters").Exists() {
+		t.Fatalf("response.tools[0].parameters missing: %s", tool0.Raw)
+	}
+}
+
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_StreamCompletedPrefersOriginalFlatTools(t *testing.T) {
+	t.Parallel()
+
+	originalRequest := []byte(`{
+		"model":"gpt-5-6-sol-max",
+		"tools":[{"type":"function","name":"flat_tool","description":"flat","parameters":{"type":"object","properties":{}}}]
+	}`)
+	translatedRequest := []byte(`{
+		"model":"gpt-5-6-sol-max",
+		"tools":[{"type":"function","function":{"name":"flat_tool","description":"nested","parameters":{"type":"object","properties":{}}}}]
+	}`)
+	chunks := []string{
+		`data: {"id":"chatcmpl_tools_stream_orig","object":"chat.completion.chunk","created":1773896263,"model":"model","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+	}
+
+	var param any
+	var completed gjson.Result
+	for _, line := range chunks {
+		for _, chunk := range ConvertOpenAIChatCompletionsResponseToOpenAIResponses(context.Background(), "model", originalRequest, translatedRequest, []byte(line), &param) {
+			event, data := parseOpenAIResponsesSSEEvent(t, chunk)
+			if event == "response.completed" {
+				completed = data
+			}
+		}
+	}
+	if !completed.Exists() {
+		t.Fatal("expected response.completed event")
+	}
+	tool0 := completed.Get("response.tools.0")
+	if tool0.Get("function").Exists() {
+		t.Fatalf("response.tools[0] nested: %s", tool0.Raw)
+	}
+	if got := tool0.Get("description").String(); got != "flat" {
+		t.Fatalf("expected original flat tools on stream completed, got description=%q tool=%s", got, tool0.Raw)
+	}
+}
+
 func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_RestoresNamespaceFunctionCall(t *testing.T) {
 	originalRequest := []byte(`{
 		"model":"deepseek-v4-flash",

--- a/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
@@ -313,6 +313,64 @@ func pickRequestJSON(originalRequestRawJSON, requestRawJSON []byte) []byte {
 	return nil
 }
 
+// toolsForOpenAIResponsesEcho returns tools in OpenAI Responses flat shape.
+// Chat Completions nested {"type":"function","function":{"name","parameters",...}}
+// is flattened to {"type":"function","name","parameters",...} so clients like
+// Junie (kotlinx.serialization) see required top-level name/parameters.
+// Already-flat Responses tools and non-function tools pass through.
+func toolsForOpenAIResponsesEcho(tools gjson.Result) interface{} {
+	if !tools.Exists() || !tools.IsArray() {
+		return tools.Value()
+	}
+	out := make([]interface{}, 0, len(tools.Array()))
+	tools.ForEach(func(_, tool gjson.Result) bool {
+		out = append(out, flattenChatCompletionsToolToResponses(tool))
+		return true
+	})
+	return out
+}
+
+func flattenChatCompletionsToolToResponses(tool gjson.Result) interface{} {
+	if !tool.IsObject() {
+		return tool.Value()
+	}
+	toolType := strings.TrimSpace(tool.Get("type").String())
+	nested := tool.Get("function")
+	if (toolType == "function" || toolType == "") && nested.Exists() && nested.IsObject() {
+		topName := strings.TrimSpace(tool.Get("name").String())
+		hasTopParams := tool.Get("parameters").Exists()
+		if topName == "" || !hasTopParams {
+			flat := []byte(`{"type":"function"}`)
+			name := topName
+			if name == "" {
+				name = strings.TrimSpace(nested.Get("name").String())
+			}
+			if name != "" {
+				flat, _ = sjson.SetBytes(flat, "name", name)
+			}
+			description := tool.Get("description")
+			if !description.Exists() || description.String() == "" {
+				description = nested.Get("description")
+			}
+			if description.Exists() && description.String() != "" {
+				flat, _ = sjson.SetBytes(flat, "description", description.String())
+			}
+			parameters := tool.Get("parameters")
+			if !parameters.Exists() {
+				parameters = nested.Get("parameters")
+			}
+			if !parameters.Exists() {
+				parameters = nested.Get("parametersJsonSchema")
+			}
+			if parameters.Exists() {
+				flat, _ = sjson.SetRawBytes(flat, "parameters", []byte(parameters.Raw))
+			}
+			return gjson.ParseBytes(flat).Value()
+		}
+	}
+	return tool.Value()
+}
+
 func applyResponsesFunctionCallNamespaceFields(item []byte, requestRawJSON []byte, qualifiedName string, itemPath string) []byte {
 	name, namespace := splitResponsesQualifiedFunctionCallFromRequest(requestRawJSON, qualifiedName)
 	namePath := "name"

--- a/internal/translator/openai/openai/responses/openai_openai-responses_tools_echo_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_tools_echo_test.go
@@ -1,0 +1,159 @@
+package responses
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestToolsForOpenAIResponsesEcho_FlattensNestedChatFunction(t *testing.T) {
+	t.Parallel()
+
+	tools := gjson.Parse(`[{
+		"type":"function",
+		"function":{
+			"name":"search",
+			"description":"find things",
+			"parameters":{"type":"object","properties":{"q":{"type":"string"}},"required":["q"]}
+		}
+	}]`)
+
+	out := toolsForOpenAIResponsesEcho(tools)
+	raw, ok := encodeEchoTools(t, out)
+	if !ok {
+		return
+	}
+	tool0 := gjson.Parse(raw).Get("0")
+	if tool0.Get("function").Exists() {
+		t.Fatalf("still nested: %s", tool0.Raw)
+	}
+	if got := tool0.Get("name").String(); got != "search" {
+		t.Fatalf("name=%q, want search; tool=%s", got, tool0.Raw)
+	}
+	if got := tool0.Get("description").String(); got != "find things" {
+		t.Fatalf("description=%q; tool=%s", got, tool0.Raw)
+	}
+	if !tool0.Get("parameters.properties.q").Exists() {
+		t.Fatalf("parameters missing: %s", tool0.Raw)
+	}
+}
+
+func TestToolsForOpenAIResponsesEcho_UsesParametersJSONSchemaFallback(t *testing.T) {
+	t.Parallel()
+
+	tools := gjson.Parse(`[{
+		"type":"function",
+		"function":{
+			"name":"legacy",
+			"parametersJsonSchema":{"type":"object","properties":{"x":{"type":"number"}}}
+		}
+	}]`)
+
+	out := toolsForOpenAIResponsesEcho(tools)
+	raw, ok := encodeEchoTools(t, out)
+	if !ok {
+		return
+	}
+	tool0 := gjson.Parse(raw).Get("0")
+	if tool0.Get("function").Exists() {
+		t.Fatalf("still nested: %s", tool0.Raw)
+	}
+	if got := tool0.Get("name").String(); got != "legacy" {
+		t.Fatalf("name=%q; tool=%s", got, tool0.Raw)
+	}
+	if !tool0.Get("parameters.properties.x").Exists() {
+		t.Fatalf("parametersJsonSchema not lifted: %s", tool0.Raw)
+	}
+}
+
+func TestToolsForOpenAIResponsesEcho_PreservesAlreadyFlatFunction(t *testing.T) {
+	t.Parallel()
+
+	tools := gjson.Parse(`[{
+		"type":"function",
+		"name":"flat_already",
+		"description":"ok",
+		"parameters":{"type":"object","properties":{}}
+	}]`)
+
+	out := toolsForOpenAIResponsesEcho(tools)
+	raw, ok := encodeEchoTools(t, out)
+	if !ok {
+		return
+	}
+	tool0 := gjson.Parse(raw).Get("0")
+	if tool0.Get("function").Exists() {
+		t.Fatalf("unexpected nested function: %s", tool0.Raw)
+	}
+	if got := tool0.Get("name").String(); got != "flat_already" {
+		t.Fatalf("name=%q; tool=%s", got, tool0.Raw)
+	}
+	if got := tool0.Get("description").String(); got != "ok" {
+		t.Fatalf("description=%q; tool=%s", got, tool0.Raw)
+	}
+}
+
+func TestToolsForOpenAIResponsesEcho_LeavesNonFunctionToolsUntouched(t *testing.T) {
+	t.Parallel()
+
+	tools := gjson.Parse(`[{
+		"type":"web_search",
+		"search_context_size":"medium"
+	}]`)
+
+	out := toolsForOpenAIResponsesEcho(tools)
+	raw, ok := encodeEchoTools(t, out)
+	if !ok {
+		return
+	}
+	tool0 := gjson.Parse(raw).Get("0")
+	if got := tool0.Get("type").String(); got != "web_search" {
+		t.Fatalf("type=%q; tool=%s", got, tool0.Raw)
+	}
+	if got := tool0.Get("search_context_size").String(); got != "medium" {
+		t.Fatalf("search_context_size=%q; tool=%s", got, tool0.Raw)
+	}
+	if tool0.Get("name").Exists() {
+		t.Fatalf("unexpected name on non-function tool: %s", tool0.Raw)
+	}
+}
+
+func TestToolsForOpenAIResponsesEcho_MixedArray(t *testing.T) {
+	t.Parallel()
+
+	tools := gjson.Parse(`[
+		{"type":"function","function":{"name":"nested_one","parameters":{"type":"object","properties":{}}}},
+		{"type":"function","name":"flat_two","parameters":{"type":"object","properties":{}}},
+		{"type":"file_search","vector_store_ids":["vs_1"]}
+	]`)
+
+	out := toolsForOpenAIResponsesEcho(tools)
+	raw, ok := encodeEchoTools(t, out)
+	if !ok {
+		return
+	}
+	arr := gjson.Parse(raw)
+	if n := len(arr.Array()); n != 3 {
+		t.Fatalf("len=%d, want 3; %s", n, raw)
+	}
+	if arr.Get("0.function").Exists() || arr.Get("0.name").String() != "nested_one" {
+		t.Fatalf("tools[0] not flattened: %s", arr.Get("0").Raw)
+	}
+	if arr.Get("1.name").String() != "flat_two" {
+		t.Fatalf("tools[1] broken: %s", arr.Get("1").Raw)
+	}
+	if arr.Get("2.type").String() != "file_search" {
+		t.Fatalf("tools[2] broken: %s", arr.Get("2").Raw)
+	}
+}
+
+func encodeEchoTools(t *testing.T, out interface{}) (string, bool) {
+	t.Helper()
+	b, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal echo tools: %v (%T)", err, out)
+		return "", false
+	}
+	return string(b), true
+}


### PR DESCRIPTION
Fixes #4530

## Summary

When `/v1/responses` is bridged through an OpenAI Chat Completions upstream (`openai-compatibility`), CLIProxyAPI echoes `tools` into the Responses response from the **translated** request. That echo kept the nested Chat Completions shape:

```json
{"type":"function","function":{"name":"...","parameters":{...}}}
```

Strict Responses clients expect the flat OpenAI Responses shape:

```json
{"type":"function","name":"...","parameters":{...}}
```

Symptom on HTTP 200 (JetBrains Junie / Matterhorn kotlinx.serialization, and any schema-strict Responses client):

```text
Fields [name, parameters] are required for type with serial name 'function',
but they were missing at path: $.tools[0]
```

This is **not** a local Junie quirk and **not** an upstream-provider bug: Chat Completions backends typically do not return `tools` at all; CPA re-injects them. Every Responses client behind openai-compat translation is exposed.

## What changed

| File | Change |
|------|--------|
| `openai_openai-responses_tools.go` | `toolsForOpenAIResponsesEcho` / `flattenChatCompletionsToolToResponses` — nested → flat; flat + non-function pass through; `parametersJsonSchema` fallback |
| `openai_openai-responses_response.go` | NonStream: prefer original Responses tools when present, always normalize; Stream `response.completed`: normalize via the same helper |
| `openai_openai-responses_response_test.go` | NonStream + stream regression tests |
| `openai_openai-responses_tools_echo_test.go` | Unit coverage for flatten / passthrough / mixed arrays |

Request-path translation (Responses flat → Chat Completions nested) is **unchanged**.

## Why this shape

OpenAI documents two different tool encodings:

- **Responses**: top-level `name` + `parameters` on `type=function`
- **Chat Completions**: nested `function.{name,parameters}`

CPA already converts flat → nested on the way to openai-compat upstreams. The reverse echo forgot to convert back, so clients that deserialize `response.tools` as Responses tools fail after a successful completion.

## Compatibility

- Additive normalization only on the Responses response echo path
- Already-flat tools stay flat
- Built-in / non-function tools (`web_search`, `file_search`, …) are left untouched
- No config flag; behavior matches the Responses schema clients already assume

## Test plan

- [x] `go test -count=1 ./internal/translator/openai/openai/responses/ -run 'ToolsForOpenAIResponsesEcho|FlattensNestedChatTools|PrefersOriginalFlatTools|StreamCompleted'`
- [x] `go test -count=1 ./internal/translator/openai/openai/responses/`
- [x] `go build -o test-output ./cmd/server && rm test-output`
- [x] Manual: `POST /v1/responses` with one flat function tool against an openai-compat alias → `$.tools[0]` has top-level `name`/`parameters` and no nested `function`
- [ ] CI green on this PR

### Focused cases added

1. NonStream: only translated nested tools → flattened
2. NonStream: original flat + translated nested → original preferred
3. Stream `response.completed`: nested tools → flattened
4. Stream `response.completed`: original flat preferred
5. Unit: nested, `parametersJsonSchema`, already-flat, non-function, mixed array

## Reviewer notes

- Entry points: NonStream tools echo and `buildResponsesCompletedEvent` tools echo in `openai_openai-responses_response.go`
- Helper lives next to the existing Responses↔Chat tool converters in `openai_openai-responses_tools.go`
- Per `AGENTS.md` translator-only policy: filed #4530 with repro + intended implementation; this PR is the concrete patch + tests for maintainers to merge

## Before / after

**Before**
```json
{"type":"function","function":{"name":"mcp_jbcontext_code_search","parameters":{...}}}
```

**After**
```json
{"type":"function","name":"mcp_jbcontext_code_search","parameters":{...},"description":"..."}
```