### PR TITLE
feat(plugins): allow scheduler plugins to exclude auth candidates

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1864,6 +1864,43 @@ func (m *Manager) pickViaBuiltinScheduler(ctx context.Context, strategy schedule
 	}
 }
 
+func schedulerExcludedAuthIDs(candidates []*Auth, requested []string) map[string]struct{} {
+	if len(requested) == 0 || len(candidates) == 0 {
+		return nil
+	}
+	candidateIDs := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if candidate != nil && strings.TrimSpace(candidate.ID) != "" {
+			candidateIDs[candidate.ID] = struct{}{}
+		}
+	}
+	excluded := make(map[string]struct{}, len(requested))
+	for _, authID := range requested {
+		authID = strings.TrimSpace(authID)
+		if _, ok := candidateIDs[authID]; ok {
+			excluded[authID] = struct{}{}
+		}
+	}
+	if len(excluded) == 0 {
+		return nil
+	}
+	return excluded
+}
+
+func schedulerTriedWithExcluded(tried map[string]struct{}, excluded map[string]struct{}) map[string]struct{} {
+	if len(excluded) == 0 {
+		return tried
+	}
+	merged := make(map[string]struct{}, len(tried)+len(excluded))
+	for authID := range tried {
+		merged[authID] = struct{}{}
+	}
+	for authID := range excluded {
+		merged[authID] = struct{}{}
+	}
+	return merged
+}
+
 func (m *Manager) pickViaPluginScheduler(ctx context.Context, scheduler PluginScheduler, provider string, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}, candidates []*Auth) (*Auth, bool, error) {
 	if scheduler == nil || len(candidates) == 0 {
 		return nil, false, nil
@@ -1885,18 +1922,30 @@ func (m *Manager) pickViaPluginScheduler(ctx context.Context, scheduler PluginSc
 	if errPick != nil {
 		return nil, true, errPick
 	}
+	excluded := schedulerExcludedAuthIDs(candidates, resp.ExcludedAuthIDs)
 	if !handled || !resp.Handled {
-		return nil, false, nil
+		if len(excluded) == 0 {
+			return nil, false, nil
+		}
+		return m.pickViaBuiltinScheduler(ctx, schedulerStrategyCurrent, providerKey, providers, model, opts, schedulerTriedWithExcluded(tried, excluded))
 	}
 	if selected := pickSchedulerAuthByID(candidates, resp.AuthID); selected != nil {
-		return selected, true, nil
+		if _, isExcluded := excluded[selected.ID]; !isExcluded {
+			return selected, true, nil
+		}
 	}
 
 	strategy, okStrategy := builtinSchedulerStrategy(resp.DelegateBuiltin)
-	if !okStrategy {
-		return nil, false, nil
+	if okStrategy {
+		return m.pickViaBuiltinScheduler(ctx, strategy, providerKey, providers, model, opts, schedulerTriedWithExcluded(tried, excluded))
 	}
-	return m.pickViaBuiltinScheduler(ctx, strategy, providerKey, providers, model, opts, tried)
+	if len(excluded) != 0 {
+		// The plugin filtered candidates without selecting one. Re-run CPA's
+		// currently configured native scheduler with the exclusions treated as
+		// request-local tried auths, preserving fill-first/round-robin semantics.
+		return m.pickViaBuiltinScheduler(ctx, schedulerStrategyCurrent, providerKey, providers, model, opts, schedulerTriedWithExcluded(tried, excluded))
+	}
+	return nil, false, nil
 }
 
 func (m *Manager) authSupportsRouteModel(registryRef *registry.ModelRegistry, auth *Auth, routeModel string) bool {

--- a/sdk/cliproxy/auth/scheduler_exclusions_test.go
+++ b/sdk/cliproxy/auth/scheduler_exclusions_test.go
@@ -1,0 +1,50 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+func TestManagerPluginSchedulerExclusionsPreserveFillFirst(t *testing.T) {
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.executors["gemini"] = schedulerTestExecutor{}
+	for _, authID := range []string{"auth-a", "auth-b"} {
+		if _, errRegister := manager.Register(context.Background(), &Auth{ID: authID, Provider: "gemini"}); errRegister != nil {
+			t.Fatalf("Register(%s) error = %v", authID, errRegister)
+		}
+	}
+
+	manager.SetPluginScheduler(&fakePluginScheduler{
+		resp:    pluginapi.SchedulerPickResponse{Handled: true, ExcludedAuthIDs: []string{"auth-a"}},
+		handled: true,
+	})
+	got, _, errPick := manager.pickNext(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("pickNext() error = %v", errPick)
+	}
+	if got == nil || got.ID != "auth-b" {
+		t.Fatalf("pickNext() auth = %#v, want auth-b after auth-a exclusion", got)
+	}
+}
+
+func TestManagerPluginSchedulerAllExclusionsFailClosed(t *testing.T) {
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.executors["gemini"] = schedulerTestExecutor{}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "auth-a", Provider: "gemini"}); errRegister != nil {
+		t.Fatalf("Register(auth-a) error = %v", errRegister)
+	}
+	manager.SetPluginScheduler(&fakePluginScheduler{
+		resp:    pluginapi.SchedulerPickResponse{Handled: true, ExcludedAuthIDs: []string{"auth-a"}},
+		handled: true,
+	})
+	got, _, errPick := manager.pickNext(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil)
+	if got != nil {
+		t.Fatalf("pickNext() auth = %#v, want nil when all candidates are excluded", got)
+	}
+	if errPick == nil {
+		t.Fatal("pickNext() error = nil, want an unavailable-auth error")
+	}
+}

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -515,6 +515,10 @@ type SchedulerAuthCandidate struct {
 type SchedulerPickResponse struct {
 	// AuthID identifies the selected auth record.
 	AuthID string
+	// ExcludedAuthIDs asks the host to omit these otherwise-valid candidates,
+	// then apply its current native scheduling strategy to the remainder.
+	// The host must ignore IDs that are not in the original candidate set.
+	ExcludedAuthIDs []string
 	// DelegateBuiltin asks the host to use a named built-in scheduler.
 	DelegateBuiltin string
 	// Handled reports whether the plugin made a scheduling decision.


### PR DESCRIPTION
## Summary
- add `ExcludedAuthIDs` to scheduler-plugin responses
- validate exclusions against the host candidate set
- rerun the currently configured native scheduler with excluded IDs treated as request-local tried auths

This lets a scheduler plugin temporarily remove rate-limited credentials without forcing round-robin or reimplementing `first-fill`.

## Behavior
- no exclusions: existing behavior is unchanged
- exclusions with `first-fill`: CPA picks the next native first-fill candidate
- all candidates excluded: selection fails closed instead of retrying an excluded auth

## Tests
- `go test ./sdk/cliproxy/auth ./sdk/pluginapi`
- `go test -race ./sdk/cliproxy/auth ./sdk/pluginapi`
- adds focused tests for first-fill exclusion and all-candidate exclusion