### PR TITLE
Add Claude Dialects to 'Who is with us?'

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,10 @@ An HTTP-only Model Context Protocol server that uses a CLIProxyAPI deployment to
 
 Native macOS SwiftUI dashboard for AI subscriptions and coding proxies. It manages official CLIProxyAPI releases end to end (download, verify, supervise, update, and roll back), unifies OAuth accounts and live models, and connects one gateway to Codex, Claude Code/Science, OpenCode, or OpenAI/Anthropic/Gemini clients, with optional LAN access.
 
+### [Claude Dialects](https://github.com/stefandevo/claude-dialects)
+
+Run multiple native-feeling Claude Code commands, each powered by a different model (Codex, GLM, Kimi, Gemini, Grok, MiniMax, DeepSeek, Cursor, Copilot, Claude). Every dialect launches the real Claude Code interface with its own isolated config, history, ports, and an embedded CLIProxyAPI instance linked through the Go SDK — no separate proxy install. macOS only.
+
 > [!NOTE]  
 > If you developed a project based on CLIProxyAPI, please open a PR to add it to this list.
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Native macOS SwiftUI dashboard for AI subscriptions and coding proxies. It manag
 
 ### [Claude Dialects](https://github.com/stefandevo/claude-dialects)
 
-Run multiple native-feeling Claude Code commands, each powered by a different model (Codex, GLM, Kimi, Gemini, Grok, MiniMax, DeepSeek, Cursor, Copilot, Claude). Every dialect launches the real Claude Code interface with its own isolated config, history, ports, and an embedded CLIProxyAPI instance linked through the Go SDK — no separate proxy install. macOS only.
+Run multiple native-feeling Claude Code commands, each powered by a different model (Codex, GLM, Kimi, Gemini, Grok, MiniMax, DeepSeek, Cursor, Copilot, Claude). Every dialect launches the real Claude Code interface with its own isolated config, history, ports, and an embedded CLIProxyAPI instance linked through the Go SDK — no separate proxy install. macOS only. Learn more at [claude-dialects.cc](https://claude-dialects.cc/).
 
 > [!NOTE]  
 > If you developed a project based on CLIProxyAPI, please open a PR to add it to this list.


### PR DESCRIPTION
Adds [Claude Dialects](https://github.com/stefandevo/claude-dialects) ([claude-dialects.cc](https://claude-dialects.cc/)) to the **Who is with us?** list. It runs multiple native-feeling Claude Code commands (each powered by a different model — Codex, GLM, Kimi, Gemini, Grok, MiniMax, DeepSeek, Cursor, Copilot, Claude), embedding a CLIProxyAPI instance directly in the `cc-dialect` binary via the Go SDK — no separate proxy install. macOS only.