### PR TITLE
fix(util): drop null and empty enum values for Gemini schemas

### DIFF
--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -197,7 +197,18 @@ func convertEnumValuesToStrings(jsonStr string) string {
 
 		var stringVals []string
 		for _, item := range arr.Array() {
+			// JSON Schema permits null in enum arrays for optional values, but
+			// Gemini's enum field only accepts non-empty strings. gjson renders
+			// null as an empty string, which Gemini rejects during request validation.
+			if item.Type == gjson.Null || item.String() == "" {
+				continue
+			}
 			stringVals = append(stringVals, item.String())
+		}
+
+		if len(stringVals) == 0 {
+			jsonStr, _ = sjson.Delete(jsonStr, p)
+			continue
 		}
 
 		// Always update enum values to strings and set type to "string"

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -870,6 +870,41 @@ func TestCleanJSONSchemaForAntigravity_BooleanEnumToString(t *testing.T) {
 	}
 }
 
+func TestCleanJSONSchemaForAntigravity_RemovesNullAndEmptyEnumValues(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"todos": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"status": {"type": ["string", "null"], "enum": ["pending", "in_progress", "completed", "cancelled", null, ""]}
+					}
+				}
+			},
+			"capability_mode": {"type": ["string", "null"], "enum": ["read-only", "read-write", "execute", "all", null]}
+		}
+	}`
+
+	result := CleanJSONSchemaForAntigravity(input)
+
+	for _, path := range []string{
+		"properties.todos.items.properties.status.enum",
+		"properties.capability_mode.enum",
+	} {
+		values := gjson.Get(result, path).Array()
+		if len(values) != 4 {
+			t.Fatalf("%s contains %d values, want 4: %s", path, len(values), result)
+		}
+		for _, value := range values {
+			if value.Type != gjson.String || value.String() == "" {
+				t.Fatalf("%s contains invalid enum value %q: %s", path, value.Raw, result)
+			}
+		}
+	}
+}
+
 func TestCleanJSONSchemaForGemini_RemovesGeminiUnsupportedMetadataFields(t *testing.T) {
 	input := `{
 		"$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
### Problem

Gemini rejects a request with `enum[n]: cannot be empty` (HTTP 400) whenever a tool schema declares an optional enum the JSON Schema way, i.e. with `null` listed among the allowed values:

```json
{
  "status": {
    "type": ["string", "null"],
    "enum": ["pending", "in_progress", "completed", "cancelled", null]
  }
}
```

This shape is not exotic — it is what several schema generators emit for an optional enum field (for example Rust's `schemars` for `Option<SomeEnum>`), so any client whose tool definitions contain a nullable enum hits the 400 and the whole request fails, not just the affected property.

### Cause

`convertEnumValuesToStrings` in `internal/util/gemini_schema.go` normalizes every enum entry with `gjson.Result.String()`. For a JSON `null` that returns `""`, so the empty string is written straight back into the enum array and forwarded to Gemini, which only accepts non-empty strings there.

### Fix

- Skip `null` and empty entries while normalizing.
- If nothing valid remains after filtering, delete the `enum` keyword instead of emitting an empty array, so the property degrades to a plain typed field rather than an invalid empty enum.

`convertEnumValuesToStrings` runs before `addEnumHints`, so the hint text generated downstream no longer picks up empty values either — no separate change needed there.

### Tests

Adds `TestCleanJSONSchemaForAntigravity_RemovesNullAndEmptyEnumValues`, built from two schemas that actually triggered the 400 in the field: a nullable `todos[].status` and a nullable `capability_mode`. It asserts the filtered enums keep exactly their valid values and that no entry is a non-string or an empty string.

### Verification

- `go test ./internal/util -count=1` — ok
- `go build -o test-output ./cmd/server` — ok
- `gofmt` — clean on both changed files
