### PR TITLE
fix(codex): preserve minimal reasoning in multi-agent models

### DIFF
--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
@@ -340,7 +340,7 @@ func codexReasoningMetadata(metadata map[string]any) ([]string, string) {
 func normalizeCodexReasoningEffort(effort string) string {
 	effort = strings.ToLower(strings.TrimSpace(effort))
 	switch effort {
-	case "none", "low", "medium", "high", "xhigh", "max", "ultra":
+	case "none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra":
 		return effort
 	default:
 		return ""

--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2_test.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2_test.go
@@ -59,7 +59,7 @@ func TestCodexSpawnAgentModelsFromSourcesIncludesModelMetadata(t *testing.T) {
 	t.Parallel()
 
 	catalog := []byte(`{"models":[
-		{"slug":"model-template","display_name":"Template","description":"Template model.","default_reasoning_level":"low","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"}],"service_tiers":[{"id":"priority"}],"priority":1},
+		{"slug":"model-template","display_name":"Template","description":"Template model.","default_reasoning_level":"low","supported_reasoning_levels":[{"effort":"minimal"},{"effort":"low"},{"effort":"medium"}],"service_tiers":[{"id":"priority"}],"priority":1},
 		{"slug":"gpt-5.5","display_name":"Default","description":"Default model.","default_reasoning_level":"medium","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"}],"service_tiers":[{"id":"priority"}],"priority":2}
 	]}`)
 	available := []map[string]any{
@@ -74,7 +74,7 @@ func TestCodexSpawnAgentModelsFromSourcesIncludesModelMetadata(t *testing.T) {
 		return &registry.ModelInfo{
 			Description: "Dynamic model.",
 			Thinking: &registry.ThinkingSupport{
-				Levels: []string{"none", "low", "medium", "high"},
+				Levels: []string{"none", "minimal", "low", "medium", "high"},
 			},
 		}
 	}
@@ -86,6 +86,9 @@ func TestCodexSpawnAgentModelsFromSourcesIncludesModelMetadata(t *testing.T) {
 	if got := models[0]; got.id != "model-template" || got.description != "Template model." || got.defaultReasoningEffort != "low" {
 		t.Fatalf("template model = %+v", got)
 	}
+	if got := strings.Join(models[0].reasoningEfforts, ","); got != "minimal,low,medium" {
+		t.Fatalf("template reasoning efforts = %q", got)
+	}
 	if got := strings.Join(models[0].serviceTiers, ","); got != "priority" {
 		t.Fatalf("template service tiers = %q, want priority", got)
 	}
@@ -93,7 +96,7 @@ func TestCodexSpawnAgentModelsFromSourcesIncludesModelMetadata(t *testing.T) {
 	if custom.id != "custom-model" || custom.description != "Dynamic model." {
 		t.Fatalf("custom model = %+v", custom)
 	}
-	if got := strings.Join(custom.reasoningEfforts, ","); got != "none,low,medium,high" {
+	if got := strings.Join(custom.reasoningEfforts, ","); got != "none,minimal,low,medium,high" {
 		t.Fatalf("custom reasoning efforts = %q", got)
 	}
 	if custom.defaultReasoningEffort != "medium" {


### PR DESCRIPTION
## Summary

- preserve `minimal` when normalizing Codex multi-agent v2 model metadata
- retain the level for both catalog templates and dynamically discovered registry models
- add regression coverage for both metadata sources

## Root cause

Current `dev` already preserves `minimal` in the main Codex client model catalog. The remaining multi-agent v2 normalization allowlist still omitted it, so spawn-agent model metadata erased a level declared by either the catalog or active registry.

## Validation

- `go test ./internal/client/codex/optimize-multi-agent-v2 ./internal/client/codex/models ./internal/api -count=1`
- `go vet ./internal/client/codex/optimize-multi-agent-v2 ./internal/client/codex/models ./internal/api`
- `go test ./...`
- `go build -o test-output ./cmd/server && rm test-output`
- `git diff --check upstream/dev...HEAD`

Fixes #4542
