### PR TITLE
fix(claude): honor global cloak disable in model listings

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -163,10 +163,10 @@ save-cooldown-status: false
 transient-error-cooldown-seconds: 0
 
 # When true, globally disable Claude request cloaking (the Claude Code CLI disguise and
-# system prompt replacement), so the original system prompt is passed through to Claude as-is.
-# Individual credentials can still override this: a claude-api-key entry via its "cloak.mode",
-# or a Claude OAuth/token file via a "cloak_mode" value. Default false keeps the per-client
-# "auto" behavior (cloak only non-Claude-Code clients).
+# system prompt replacement) and preserve registered IDs in Claude-compatible model listings.
+# Individual credentials can still override request cloaking via a claude-api-key "cloak.mode"
+# or a Claude OAuth/token-file "cloak_mode" value. The model-list behavior remains global.
+# Default false keeps per-client "auto" request cloaking and encoded non-Claude model IDs.
 disable-claude-cloak-mode: false
 
 # disable-image-generation supports: false (default), true, "chat", or "passthrough".

--- a/internal/api/server_options.go
+++ b/internal/api/server_options.go
@@ -46,6 +46,7 @@ func effectiveSDKConfig(cfg *config.Config) *config.SDKConfig {
 	}
 	sdkCfg := cfg.SDKConfig
 	sdkCfg.CodexOptimizeMultiAgentV2 = cfg.Codex.OptimizeMultiAgentV2
+	sdkCfg.DisableClaudeModelListCloak = cfg.DisableClaudeCloakMode
 	if cfg.CommercialMode {
 		sdkCfg.RequestLog = false
 	}

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -571,7 +571,8 @@ func (s *Server) handleHomeModels(c *gin.Context) {
 	isClaude := isAnthropicModelsRequest(c)
 
 	if isClaude {
-		c.JSON(http.StatusOK, claudemodels.BuildResponse(formatHomeClaudeModels(entries)))
+		cloakModelIDs := s.cfg == nil || !s.cfg.DisableClaudeCloakMode
+		c.JSON(http.StatusOK, buildHomeClaudeModelsResponse(entries, cloakModelIDs))
 		return
 	}
 
@@ -593,6 +594,10 @@ func (s *Server) handleHomeModels(c *gin.Context) {
 		"object": "list",
 		"data":   filtered,
 	})
+}
+
+func buildHomeClaudeModelsResponse(entries []homeModelEntry, cloakModelIDs bool) map[string]any {
+	return claudemodels.BuildResponse(formatHomeClaudeModels(entries), cloakModelIDs)
 }
 
 func formatHomeClaudeModels(entries []homeModelEntry) []map[string]any {

--- a/internal/api/server_sdk_config_test.go
+++ b/internal/api/server_sdk_config_test.go
@@ -14,3 +14,12 @@ func TestEffectiveSDKConfigCopiesCodexOptimizeMultiAgentV2(t *testing.T) {
 		t.Fatalf("CodexOptimizeMultiAgentV2 = false, want true")
 	}
 }
+
+func TestEffectiveSDKConfigCopiesClaudeModelListCloakDisable(t *testing.T) {
+	cfg := &config.Config{DisableClaudeCloakMode: true}
+
+	sdkCfg := effectiveSDKConfig(cfg)
+	if sdkCfg == nil || !sdkCfg.DisableClaudeModelListCloak {
+		t.Fatalf("DisableClaudeModelListCloak = false, want true")
+	}
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1820,6 +1820,28 @@ func TestDecodeHomeModelsKeepsTokenMetadata(t *testing.T) {
 	}
 }
 
+func TestBuildHomeClaudeModelsResponseHonorsCloakFlag(t *testing.T) {
+	entries := []homeModelEntry{{id: "gpt-4o", displayName: "GPT 4o"}}
+
+	cloaked := buildHomeClaudeModelsResponse(entries, true)
+	cloakedData, ok := cloaked["data"].([]map[string]any)
+	if !ok || len(cloakedData) != 1 {
+		t.Fatalf("cloaked data = %#v, want one model", cloaked["data"])
+	}
+	if got, _ := cloakedData[0]["id"].(string); got != "claude-fable-5-dd-o4-tpg" {
+		t.Fatalf("cloaked id = %q, want claude-fable-5-dd-o4-tpg", got)
+	}
+
+	uncloaked := buildHomeClaudeModelsResponse(entries, false)
+	uncloakedData, ok := uncloaked["data"].([]map[string]any)
+	if !ok || len(uncloakedData) != 1 {
+		t.Fatalf("uncloaked data = %#v, want one model", uncloaked["data"])
+	}
+	if got, _ := uncloakedData[0]["id"].(string); got != "gpt-4o" {
+		t.Fatalf("uncloaked id = %q, want gpt-4o", got)
+	}
+}
+
 func TestHomeModelsAuthStatus(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/internal/client/claude/models/models.go
+++ b/internal/client/claude/models/models.go
@@ -9,12 +9,15 @@ import (
 const claudeDDModelPrefix = "claude-fable-5-dd-"
 
 // BuildResponse builds an Anthropic model response from available models.
-func BuildResponse(availableModels []map[string]any) map[string]any {
+// When cloakModelIDs is false, registered model IDs are preserved as-is.
+func BuildResponse(availableModels []map[string]any, cloakModelIDs bool) map[string]any {
 	models := make([]map[string]any, len(availableModels))
 	for i, model := range availableModels {
 		models[i] = cloneModel(model)
-		if id, ok := models[i]["id"].(string); ok {
-			models[i]["id"] = EnsureClaudeModelIDPrefix(id)
+		if cloakModelIDs {
+			if id, ok := models[i]["id"].(string); ok {
+				models[i]["id"] = EnsureClaudeModelIDPrefix(id)
+			}
 		}
 	}
 

--- a/internal/client/claude/models/models_test.go
+++ b/internal/client/claude/models/models_test.go
@@ -10,7 +10,7 @@ func TestBuildResponse(t *testing.T) {
 		{"id": "claude-b", "display_name": "Beta"},
 	}
 
-	response := BuildResponse(availableModels)
+	response := BuildResponse(availableModels, true)
 	models, ok := response["data"].([]map[string]any)
 	if !ok {
 		t.Fatalf("data type = %T, want []map[string]any", response["data"])
@@ -51,8 +51,39 @@ func TestBuildResponse(t *testing.T) {
 	}
 }
 
+func TestBuildResponseWithoutModelIDCloak(t *testing.T) {
+	availableModels := []map[string]any{
+		{"id": "gpt-4o", "display_name": "Alpha"},
+		{"id": "claude-sonnet-5", "display_name": "Beta"},
+	}
+
+	response := BuildResponse(availableModels, false)
+	models, ok := response["data"].([]map[string]any)
+	if !ok {
+		t.Fatalf("data type = %T, want []map[string]any", response["data"])
+	}
+	wantIDs := []string{"gpt-4o", "claude-sonnet-5"}
+	if len(models) != len(wantIDs) {
+		t.Fatalf("len(data) = %d, want %d", len(models), len(wantIDs))
+	}
+	for i, want := range wantIDs {
+		if got, _ := models[i]["id"].(string); got != want {
+			t.Fatalf("data[%d].id = %q, want %q", i, got, want)
+		}
+	}
+	if got := response["first_id"]; got != wantIDs[0] {
+		t.Fatalf("first_id = %v, want %q", got, wantIDs[0])
+	}
+	if got := response["last_id"]; got != wantIDs[len(wantIDs)-1] {
+		t.Fatalf("last_id = %v, want %q", got, wantIDs[len(wantIDs)-1])
+	}
+	if got := availableModels[0]["id"]; got != "gpt-4o" {
+		t.Fatalf("BuildResponse mutated input id to %v", got)
+	}
+}
+
 func TestBuildResponseEmpty(t *testing.T) {
-	response := BuildResponse(nil)
+	response := BuildResponse(nil, true)
 	models, ok := response["data"].([]map[string]any)
 	if !ok {
 		t.Fatalf("data type = %T, want []map[string]any", response["data"])

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,12 +126,12 @@ type Config struct {
 	// These are used as fallbacks when the client does not send its own headers.
 	ClaudeHeaderDefaults ClaudeHeaderDefaults `yaml:"claude-header-defaults" json:"claude-header-defaults"`
 
-	// DisableClaudeCloakMode globally disables Claude request cloaking when true.
-	// Cloaking disguises requests as the official Claude Code CLI and replaces the
-	// system prompt. When true, every Claude credential defaults to no cloaking
-	// ("never"); a specific credential can still re-enable or override it via its own
-	// cloak settings (the per claude-api-key "cloak" block, or a "cloak_mode" value in
-	// the auth/OAuth token file). Default false preserves the per-client "auto" behavior.
+	// DisableClaudeCloakMode globally disables Claude request cloaking and model-list ID cloaking when true.
+	// Request cloaking disguises requests as the official Claude Code CLI and replaces the
+	// system prompt. When true, every Claude credential defaults to no request cloaking
+	// ("never"); a specific credential can still re-enable or override request cloaking via
+	// its own cloak settings. Claude-compatible model listings preserve registered IDs while
+	// the global disable is active. Default false preserves the existing cloaked behavior.
 	DisableClaudeCloakMode bool `yaml:"disable-claude-cloak-mode" json:"disable-claude-cloak-mode"`
 
 	// OpenAICompatibility defines OpenAI API compatibility configurations for external providers.

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -45,6 +45,10 @@ type SDKConfig struct {
 	// CodexOptimizeMultiAgentV2 mirrors the provider-wide runtime setting for API handlers.
 	CodexOptimizeMultiAgentV2 bool `yaml:"-" json:"-"`
 
+	// DisableClaudeModelListCloak mirrors the global Claude cloak disable for API handlers.
+	// It is runtime-only because the user-facing setting lives on Config.
+	DisableClaudeModelListCloak bool `yaml:"-" json:"-"`
+
 	// APIKeys is a list of keys for authenticating clients to this proxy server.
 	APIKeys []string `yaml:"api-keys" json:"api-keys"`
 

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -154,7 +154,8 @@ func rewriteClaudeDDModelInBody(rawJSON []byte) []byte {
 // Parameters:
 //   - c: The Gin context for the request.
 func (h *ClaudeCodeAPIHandler) ClaudeModels(c *gin.Context) {
-	c.JSON(http.StatusOK, claudemodels.BuildResponse(h.Models()))
+	cloakModelIDs := h.Cfg == nil || !h.Cfg.DisableClaudeModelListCloak
+	c.JSON(http.StatusOK, claudemodels.BuildResponse(h.Models(), cloakModelIDs))
 }
 
 // handleNonStreamingResponse handles non-streaming content generation requests for Claude models.

--- a/sdk/api/handlers/claude/code_handlers_model_test.go
+++ b/sdk/api/handlers/claude/code_handlers_model_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 	"github.com/tidwall/gjson"
 )
 
@@ -44,6 +45,40 @@ func TestClaudeModelsResponseUsesConfiguredDisplayName(t *testing.T) {
 		}
 	}
 	t.Fatalf("model %q not found in response", modelID)
+}
+
+func TestClaudeModelsResponseHonorsGlobalCloakDisable(t *testing.T) {
+	const clientID = "claude-model-cloak-disable-test"
+	const modelID = "gpt-model-cloak-disable-test"
+	registryRef := registry.GetGlobalRegistry()
+	registryRef.RegisterClient(clientID, "claude", []*registry.ModelInfo{{
+		ID: modelID, Object: "model", OwnedBy: "test", DisplayName: "Uncloaked Model",
+	}})
+	t.Cleanup(func() {
+		registryRef.UnregisterClient(clientID)
+	})
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	handler := NewClaudeCodeAPIHandler(&handlers.BaseAPIHandler{
+		Cfg: &sdkconfig.SDKConfig{DisableClaudeModelListCloak: true},
+	})
+	handler.ClaudeModels(ctx)
+
+	var response struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if errUnmarshal := json.Unmarshal(recorder.Body.Bytes(), &response); errUnmarshal != nil {
+		t.Fatalf("decode response: %v", errUnmarshal)
+	}
+	for _, model := range response.Data {
+		if model.ID == modelID {
+			return
+		}
+	}
+	t.Fatalf("raw model %q not found in response: %s", modelID, recorder.Body.String())
 }
 
 func TestRewriteClaudeDDModelInBody(t *testing.T) {


### PR DESCRIPTION
## Summary

- make `disable-claude-cloak-mode: true` preserve registered model IDs in Claude-compatible model listings
- retain the current encoded-ID behavior by default
- apply the same behavior to normal SDK-backed and Home-backed model-list handlers
- preserve sorting, pagination metadata, and input immutability

## Root cause

The global setting disabled Claude request cloaking, but `internal/client/claude/models.BuildResponse` still unconditionally rewrote every non-Claude model ID through `EnsureClaudeModelIDPrefix`.

## Validation

- `go test ./...`
- `go build -o test-output ./cmd/server && rm test-output`
- independent Codex review: no actionable findings
- `git diff --check upstream/dev...HEAD`

Fixes #4473
