### PR TITLE
fix(vertex): restore Gemini 3.1 Pro preview ID

### DIFF
--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -35,6 +35,27 @@ func TestGeminiVertexModelsUseFlashLiteReleaseID(t *testing.T) {
 	t.Fatalf("Vertex models do not contain %q", releaseID)
 }
 
+func TestGeminiVertexModelsUse31ProPreviewID(t *testing.T) {
+	const previewID = "gemini-3.1-pro-preview"
+	const bareID = "gemini-3.1-pro"
+
+	foundPreview := false
+	for _, model := range GetGeminiVertexModels() {
+		if model == nil {
+			continue
+		}
+		if model.ID == bareID {
+			t.Fatalf("Vertex model ID = %q, want preview ID %q", model.ID, previewID)
+		}
+		if model.ID == previewID {
+			foundPreview = true
+		}
+	}
+	if !foundPreview {
+		t.Fatalf("Vertex models do not contain %q", previewID)
+	}
+}
+
 func TestWithXAIBuiltinsIncludesVideoPreviewModel(t *testing.T) {
 	models := WithXAIBuiltins(nil)
 

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -700,15 +700,15 @@
       }
     },
     {
-      "id": "gemini-3.1-pro",
+      "id": "gemini-3.1-pro-preview",
       "object": "model",
       "created": 1771459200,
       "owned_by": "google",
       "type": "gemini",
-      "display_name": "Gemini 3.1 Pro",
-      "name": "models/gemini-3.1-pro",
+      "display_name": "Gemini 3.1 Pro Preview",
+      "name": "models/gemini-3.1-pro-preview",
       "version": "3.1",
-      "description": "Gemini 3.1 Pro",
+      "description": "Gemini 3.1 Pro Preview",
       "inputTokenLimit": 1048576,
       "outputTokenLimit": 65536,
       "supportedGenerationMethods": [


### PR DESCRIPTION
## Summary

- restore the embedded Vertex catalog ID from `gemini-3.1-pro` to `gemini-3.1-pro-preview`
- keep the model resource name and user-facing metadata consistent
- add a regression test against `GetGeminiVertexModels()` so the bare ID cannot return

## Root cause

The Vertex executor uses the selected model ID verbatim in the publisher-model URL. The embedded catalog had renamed Gemini 3.1 Pro to the bare `gemini-3.1-pro`, while Google still exposes the preview resource ID, causing affected Vertex requests to return 404.

Remote catalog companion: https://github.com/router-for-me/models/pull/28

## Validation

- `go test ./internal/registry -count=1`
- `go vet ./internal/registry`
- `go build -o /dev/null ./cmd/server`
- `python3 -m json.tool internal/registry/models/models.json`
- embedded and remote Vertex entries compared for exact parity

Fixes #4555
