### PR TITLE
fix(xai): guard opt-in x_search collision

### DIFF
--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -541,16 +541,21 @@ func sanitizeXAIResponsesBody(body []byte, model string) []byte {
 }
 
 // ensureXAINativeXSearchTool appends {"type":"x_search"} when the final tools
-// list does not already include native X Search. When tool_choice restricts the
-// model to allowed_tools, x_search is also added there (without duplicates) so
-// Grok can select the injected tool. When injection is enabled, HTTP and websocket
-// executors both prepare payloads through prepareResponsesRequestTo, so this runs
-// once before the body is submitted upstream.
+// list does not already include native X Search or a client function named
+// web_search. When tool_choice restricts the model to allowed_tools, x_search
+// is also added there (without duplicates) so Grok can select the injected
+// tool. When injection is enabled, HTTP and websocket executors both prepare
+// payloads through prepareResponsesRequestTo, so this runs once before the body
+// is submitted upstream.
 func ensureXAINativeXSearchTool(body []byte) []byte {
 	if !gjson.ValidBytes(body) {
 		return body
 	}
-	if !xaiRequestHasNativeXSearch(body) {
+	hasNativeXSearch := xaiRequestHasNativeXSearch(body)
+	if xaiRequestHasClientWebSearchTool(body) && !hasNativeXSearch {
+		return body
+	}
+	if !hasNativeXSearch {
 		tools := gjson.GetBytes(body, "tools")
 		if !tools.Exists() || !tools.IsArray() {
 			body, _ = sjson.SetRawBytes(body, "tools", []byte(`[{"type":"x_search"}]`))
@@ -559,6 +564,26 @@ func ensureXAINativeXSearchTool(body []byte) []byte {
 		}
 	}
 	return ensureXAINativeXSearchAllowedTools(body)
+}
+
+// xaiRequestHasClientWebSearchTool reports whether the request already exposes
+// a local function or custom tool named web_search. Injecting native x_search
+// beside it makes both tools collide on xAI's upstream web_search name.
+func xaiRequestHasClientWebSearchTool(body []byte) bool {
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.IsArray() {
+		return false
+	}
+	for _, tool := range tools.Array() {
+		toolType := strings.TrimSpace(tool.Get("type").String())
+		if toolType != xaiFunctionToolType && toolType != xaiCustomToolType {
+			continue
+		}
+		if strings.TrimSpace(tool.Get("name").String()) == xaiWebSearchToolType {
+			return true
+		}
+	}
+	return false
 }
 
 // ensureXAINativeXSearchAllowedTools appends x_search to tool_choice.tools when

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -662,10 +662,12 @@ func TestXAIExecutorPrepareHonorsInjectXSearchConfig(t *testing.T) {
 	tests := []struct {
 		name        string
 		cfg         *config.Config
+		toolName    string
 		wantXSearch bool
 	}{
-		{name: "default disabled", cfg: &config.Config{}, wantXSearch: false},
-		{name: "explicitly enabled", cfg: &config.Config{XAI: config.XAIConfig{InjectXSearch: true}}, wantXSearch: true},
+		{name: "default disabled", cfg: &config.Config{}, toolName: "lookup", wantXSearch: false},
+		{name: "explicitly enabled", cfg: &config.Config{XAI: config.XAIConfig{InjectXSearch: true}}, toolName: "lookup", wantXSearch: true},
+		{name: "client web search collision", cfg: &config.Config{XAI: config.XAIConfig{InjectXSearch: true}}, toolName: "web_search", wantXSearch: false},
 	}
 
 	for _, tt := range tests {
@@ -675,12 +677,12 @@ func TestXAIExecutorPrepareHonorsInjectXSearchConfig(t *testing.T) {
 			exec := NewXAIExecutor(tt.cfg)
 			prepared, errPrepare := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
 				Model: "grok-4.5",
-				Payload: []byte(`{
+				Payload: []byte(fmt.Sprintf(`{
 					"model":"grok-4.5",
 					"input":"search the web",
-					"tools":[{"type":"function","name":"web_search","parameters":{"type":"object"}}],
-					"tool_choice":{"type":"allowed_tools","tools":[{"type":"function","name":"web_search"}]}
-				}`),
+					"tools":[{"type":"function","name":%q,"parameters":{"type":"object"}}],
+					"tool_choice":{"type":"allowed_tools","tools":[{"type":"function","name":%q}]}
+				}`, tt.toolName, tt.toolName)),
 			}, cliproxyexecutor.Options{
 				SourceFormat: sdktranslator.FormatOpenAIResponse,
 				Stream:       false,
@@ -697,8 +699,8 @@ func TestXAIExecutorPrepareHonorsInjectXSearchConfig(t *testing.T) {
 			if len(tools) != 1+wantXSearchCount {
 				t.Fatalf("tools length = %d, want %d; body=%s", len(tools), 1+wantXSearchCount, prepared.body)
 			}
-			if got := tools[0].Get("name").String(); got != "web_search" {
-				t.Fatalf("client web_search tool missing; body=%s", prepared.body)
+			if got := tools[0].Get("name").String(); got != tt.toolName {
+				t.Fatalf("client tool name = %q, want %q; body=%s", got, tt.toolName, prepared.body)
 			}
 			xSearchTools := 0
 			for _, tool := range tools {
@@ -799,6 +801,60 @@ func TestEnsureXAINativeXSearchTool(t *testing.T) {
 	}
 	if xSearchAllowed != 1 {
 		t.Fatalf("allowed_tools x_search count = %d, want 1; body=%s", xSearchAllowed, out)
+	}
+}
+
+func TestEnsureXAINativeXSearchToolPreservesClientWebSearchTool(t *testing.T) {
+	t.Parallel()
+
+	for _, toolType := range []string{xaiFunctionToolType, xaiCustomToolType} {
+		t.Run(toolType, func(t *testing.T) {
+			body := []byte(fmt.Sprintf(`{
+				"tools":[{"type":%q,"name":"web_search","parameters":{"type":"object"}}],
+				"tool_choice":{"type":"allowed_tools","tools":[{"type":%q,"name":"web_search"}]}
+			}`, toolType, toolType))
+			out := ensureXAINativeXSearchTool(body)
+
+			tools := gjson.GetBytes(out, "tools").Array()
+			if len(tools) != 1 {
+				t.Fatalf("tools length = %d, want 1 client web_search tool only; body=%s", len(tools), out)
+			}
+			if got := tools[0].Get("type").String(); got != toolType {
+				t.Fatalf("tools.0.type = %q, want %q; body=%s", got, toolType, out)
+			}
+			if xaiRequestHasNativeXSearch(out) {
+				t.Fatalf("native x_search was injected beside client web_search tool: %s", out)
+			}
+			allowed := gjson.GetBytes(out, "tool_choice.tools").Array()
+			if len(allowed) != 1 || allowed[0].Get("name").String() != "web_search" {
+				t.Fatalf("allowed tools = %#v, want only client web_search tool; body=%s", allowed, out)
+			}
+		})
+	}
+}
+
+func TestEnsureXAINativeXSearchToolSyncsExplicitNativeToolWithClientWebSearch(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"tools":[
+			{"type":"function","name":"web_search","parameters":{"type":"object"}},
+			{"type":"x_search"}
+		],
+		"tool_choice":{"type":"allowed_tools","tools":[{"type":"function","name":"web_search"}]}
+	}`)
+	out := ensureXAINativeXSearchTool(body)
+
+	tools := gjson.GetBytes(out, "tools").Array()
+	if len(tools) != 2 {
+		t.Fatalf("tools length = %d, want explicit client and native tools unchanged; body=%s", len(tools), out)
+	}
+	allowed := gjson.GetBytes(out, "tool_choice.tools").Array()
+	if len(allowed) != 2 {
+		t.Fatalf("allowed tools length = %d, want client web_search plus explicit x_search; body=%s", len(allowed), out)
+	}
+	if got := allowed[1].Get("type").String(); got != "x_search" {
+		t.Fatalf("allowed tools native type = %q, want x_search; body=%s", got, out)
 	}
 }
 


### PR DESCRIPTION
## Summary

- harden the opt-in `xai.inject-x-search` path against a caller-owned function/custom tool named `web_search`
- skip injected native `x_search` only for that collision
- retain opt-in injection for non-conflicting requests
- retain `allowed_tools` synchronization when callers explicitly provide both tools

## Scope

Current `dev` already makes native `x_search` injection configurable and disabled by default. This PR does not add or change that switch. It only protects callers that explicitly enable injection from creating two tools that xAI exposes under the same upstream `web_search` name.

## Validation

- `go test ./internal/runtime/executor -run 'Test(XAIExecutorPrepareHonorsInjectXSearchConfig|EnsureXAINativeXSearchToolPreservesClientWebSearchTool|EnsureXAINativeXSearchToolSyncsExplicitNativeToolWithClientWebSearch)$' -count=1`
- `go test ./internal/runtime/executor -count=1`
- `go test -race ./internal/runtime/executor -run 'Test(XAIExecutorPrepareHonorsInjectXSearchConfig|EnsureXAINativeXSearchToolPreservesClientWebSearchTool|EnsureXAINativeXSearchToolSyncsExplicitNativeToolWithClientWebSearch)$' -count=1`
- `go vet ./internal/runtime/executor`
- `go build -o test-output ./cmd/server`
- `git diff --check`

Fixes #4339
