### PR TITLE
feat(usage): expose cache input accounting mode

### DIFF
--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -2161,6 +2161,58 @@ func TestUsageAdapterNormalizesOmittedGenerateToTrue(t *testing.T) {
 	}
 }
 
+func TestUsageAdapterPreservesCacheInputMode(t *testing.T) {
+	var got pluginapi.UsageRecord
+	plugin := usagePluginFunc(func(ctx context.Context, record pluginapi.UsageRecord) {
+		got = record
+	})
+	host := newHostWithRecords(capabilityRecord{
+		id: "usage-cache-input-mode",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			UsagePlugin: plugin,
+		}},
+	})
+	adapter := &usageAdapter{host: host, pluginID: "usage-cache-input-mode"}
+
+	adapter.HandleUsage(context.Background(), coreusage.Record{
+		Provider: "claude",
+		Detail: coreusage.Detail{
+			InputTokens:         100,
+			CacheReadTokens:     40,
+			CacheCreationTokens: 10,
+			CacheInputMode:      coreusage.CacheInputModeSeparate,
+		},
+	})
+	if got.Detail.CacheInputMode != pluginapi.CacheInputModeSeparate {
+		t.Fatalf("plugin cache input mode = %q, want %q", got.Detail.CacheInputMode, pluginapi.CacheInputModeSeparate)
+	}
+}
+
+func TestUsageAdapterNormalizesLegacyCacheInputMode(t *testing.T) {
+	var got pluginapi.UsageRecord
+	plugin := usagePluginFunc(func(ctx context.Context, record pluginapi.UsageRecord) {
+		got = record
+	})
+	host := newHostWithRecords(capabilityRecord{
+		id: "usage-normalize-cache-input-mode",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			UsagePlugin: plugin,
+		}},
+	})
+	adapter := &usageAdapter{host: host, pluginID: "usage-normalize-cache-input-mode"}
+
+	adapter.HandleUsage(context.Background(), coreusage.Record{
+		Provider: "openai",
+		Detail: coreusage.Detail{
+			InputTokens:  10,
+			CachedTokens: 4,
+		},
+	})
+	if got.Detail.CacheInputMode != pluginapi.CacheInputModeIncluded {
+		t.Fatalf("plugin cache input mode = %q, want %q", got.Detail.CacheInputMode, pluginapi.CacheInputModeIncluded)
+	}
+}
+
 func TestUsageAdapterPreservesExplicitGenerateFalse(t *testing.T) {
 	var gotGenerate bool
 	plugin := usagePluginFunc(func(ctx context.Context, record pluginapi.UsageRecord) {

--- a/internal/pluginhost/adapters_usage_translation.go
+++ b/internal/pluginhost/adapters_usage_translation.go
@@ -141,6 +141,7 @@ func (a *usageAdapter) HandleUsage(ctx context.Context, record coreusage.Record)
 			a.host.fusePlugin(a.pluginID, "UsagePlugin.HandleUsage", recovered)
 		}
 	}()
+	usageDetail := coreusage.EnsureTokenBreakdownForProvider(record.Detail, record.Provider, record.ExecutorType)
 	plugin.HandleUsage(ctx, pluginapi.UsageRecord{
 		Provider:        record.Provider,
 		ExecutorType:    record.ExecutorType,
@@ -163,13 +164,14 @@ func (a *usageAdapter) HandleUsage(ctx context.Context, record coreusage.Record)
 			Body:       record.Fail.Body,
 		},
 		Detail: pluginapi.UsageDetail{
-			InputTokens:         record.Detail.InputTokens,
-			OutputTokens:        record.Detail.OutputTokens,
-			ReasoningTokens:     record.Detail.ReasoningTokens,
-			CachedTokens:        record.Detail.CachedTokens,
-			CacheReadTokens:     record.Detail.CacheReadTokens,
-			CacheCreationTokens: record.Detail.CacheCreationTokens,
-			TotalTokens:         record.Detail.TotalTokens,
+			InputTokens:         usageDetail.InputTokens,
+			OutputTokens:        usageDetail.OutputTokens,
+			ReasoningTokens:     usageDetail.ReasoningTokens,
+			CachedTokens:        usageDetail.CachedTokens,
+			CacheReadTokens:     usageDetail.CacheReadTokens,
+			CacheCreationTokens: usageDetail.CacheCreationTokens,
+			CacheInputMode:      pluginapi.CacheInputMode(usageDetail.CacheInputMode),
+			TotalTokens:         usageDetail.TotalTokens,
 		},
 		ResponseHeaders: cloneHeader(record.ResponseHeaders),
 	})

--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -74,6 +74,7 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		CacheReadTokens:        usageDetail.CacheReadTokens,
 		CacheReadTokensPresent: true,
 		CacheCreationTokens:    usageDetail.CacheCreationTokens,
+		CacheInputMode:         usageDetail.CacheInputMode,
 		TotalTokens:            usageDetail.TotalTokens,
 	}
 
@@ -149,14 +150,15 @@ type requestDetail struct {
 }
 
 type tokenStats struct {
-	InputTokens            int64 `json:"input_tokens"`
-	OutputTokens           int64 `json:"output_tokens"`
-	ReasoningTokens        int64 `json:"reasoning_tokens"`
-	CachedTokens           int64 `json:"cached_tokens"`
-	CacheReadTokens        int64 `json:"cache_read_tokens"`
-	CacheReadTokensPresent bool  `json:"cache_read_tokens_present"`
-	CacheCreationTokens    int64 `json:"cache_creation_tokens"`
-	TotalTokens            int64 `json:"total_tokens"`
+	InputTokens            int64                    `json:"input_tokens"`
+	OutputTokens           int64                    `json:"output_tokens"`
+	ReasoningTokens        int64                    `json:"reasoning_tokens"`
+	CachedTokens           int64                    `json:"cached_tokens"`
+	CacheReadTokens        int64                    `json:"cache_read_tokens"`
+	CacheReadTokensPresent bool                     `json:"cache_read_tokens_present"`
+	CacheCreationTokens    int64                    `json:"cache_creation_tokens"`
+	CacheInputMode         coreusage.CacheInputMode `json:"cache_input_mode,omitempty"`
+	TotalTokens            int64                    `json:"total_tokens"`
 }
 
 type failDetail struct {

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -64,6 +64,7 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 		requireIntField(t, payload, "accounting_version", coreusage.TokenAccountingSchemaVersion)
 		requireTokenBreakdown(t, payload, coreusage.TokenAccountingQualityComplete, 30)
 		requireTokensBoolField(t, payload, "cache_read_tokens_present", true)
+		requireStringField(t, requireTokensPayload(t, payload), "cache_input_mode", string(coreusage.CacheInputModeIncluded))
 		requireHeaderField(t, payload, "response_headers", "X-Upstream-Request-Id", []string{"upstream-req-1"})
 		requireHeaderField(t, payload, "response_headers", "Retry-After", []string{"30"})
 		requireBoolField(t, payload, "failed", false)
@@ -163,6 +164,26 @@ func TestUsageQueuePluginPreservesLegacyCachedOnlyUsage(t *testing.T) {
 		requireIntField(t, tokens, "cache_read_tokens", 13)
 		requireIntField(t, tokens, "total_tokens", 13)
 		requireTokenBreakdown(t, payload, coreusage.TokenAccountingQualityUnclassified, 13)
+		requireMissingField(t, tokens, "cache_input_mode")
+	})
+}
+
+func TestUsageQueuePluginOmitsUnknownCacheInputMode(t *testing.T) {
+	withEnabledQueue(t, func() {
+		ctx := internallogging.WithResponseStatusHolder(context.Background())
+		internallogging.SetResponseStatus(ctx, http.StatusOK)
+
+		(&usageQueuePlugin{}).HandleUsage(ctx, coreusage.Record{
+			Provider: "plugin-provider",
+			Model:    "custom-model",
+			Detail: coreusage.Detail{
+				InputTokens: 1,
+				TotalTokens: 1,
+			},
+		})
+
+		tokens := requireTokensPayload(t, popSinglePayload(t))
+		requireMissingField(t, tokens, "cache_input_mode")
 	})
 }
 

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -569,6 +569,18 @@ func hasOpenAIStyleUsageBucketFields(usageNode gjson.Result) bool {
 		usageNode.Get("output_tokens_details.reasoning_tokens").Exists()
 }
 
+func includedCacheInputMode(detail usage.Detail) usage.CacheInputMode {
+	if !hasNonZeroTokenUsage(detail) {
+		return ""
+	}
+	cacheTokens, ok := safeUsageTokenSum(detail.CacheReadTokens, detail.CacheCreationTokens)
+	if !ok || detail.InputTokens < 0 || detail.CachedTokens < 0 ||
+		cacheTokens > detail.InputTokens || detail.CachedTokens > detail.InputTokens {
+		return ""
+	}
+	return usage.CacheInputModeIncluded
+}
+
 func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 	inputNode := usageNode.Get("prompt_tokens")
 	if !inputNode.Exists() {
@@ -608,6 +620,7 @@ func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 	if reasoning.Exists() {
 		detail.ReasoningTokens = reasoning.Int()
 	}
+	detail.CacheInputMode = includedCacheInputMode(detail)
 	if hasOpenAIStyleUsageBucketFields(usageNode) {
 		if inputNode.Exists() && outputNode.Exists() {
 			detail.TokenBreakdown = usage.NewSubsetTokenBreakdown(
@@ -707,6 +720,9 @@ func parseClaudeUsageNode(usageNode gjson.Result) usage.Detail {
 		detail.ReasoningTokens,
 		detail.TotalTokens,
 	)
+	if hasNonZeroTokenUsage(detail) {
+		detail.CacheInputMode = usage.CacheInputModeSeparate
+	}
 	return detail
 }
 
@@ -726,6 +742,7 @@ func parseGeminiFamilyUsageDetail(node gjson.Result) usage.Detail {
 		detail.TokenBreakdown = invalidUsageTokenBreakdown(detail.TotalTokens)
 		return detail
 	}
+	detail.CacheInputMode = includedCacheInputMode(detail)
 	if detail.TotalTokens == 0 {
 		var okTotal bool
 		detail.TotalTokens, okTotal = safeUsageTokenSum(detail.InputTokens, detail.OutputTokens, detail.ReasoningTokens)
@@ -769,6 +786,7 @@ func parseInteractionsUsageDetail(node gjson.Result) usage.Detail {
 	if !cacheRead.Exists() && detail.CachedTokens > 0 {
 		detail.CacheReadTokens = detail.CachedTokens
 	}
+	detail.CacheInputMode = includedCacheInputMode(detail)
 	if detail.TotalTokens == 0 {
 		var okTotal bool
 		detail.TotalTokens, okTotal = safeUsageTokenSum(detail.InputTokens, detail.OutputTokens, detail.ReasoningTokens)

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestParseOpenAIUsageChatCompletions(t *testing.T) {
-	data := []byte(`{"usage":{"prompt_tokens":10,"completion_tokens":6,"total_tokens":16,"prompt_tokens_details":{"cached_tokens":4},"completion_tokens_details":{"reasoning_tokens":5}}}`)
+	data := []byte(`{"usage":{"prompt_tokens":10,"completion_tokens":6,"total_tokens":16,"prompt_tokens_details":{"cached_tokens":4,"cache_write_tokens":2},"completion_tokens_details":{"reasoning_tokens":5}}}`)
 	detail := ParseOpenAIUsage(data)
 	if detail.InputTokens != 10 {
 		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 10)
@@ -29,13 +29,19 @@ func TestParseOpenAIUsageChatCompletions(t *testing.T) {
 	if detail.CacheReadTokens != 4 {
 		t.Fatalf("cache read tokens = %d, want %d", detail.CacheReadTokens, 4)
 	}
+	if detail.CacheCreationTokens != 2 {
+		t.Fatalf("cache creation tokens = %d, want %d", detail.CacheCreationTokens, 2)
+	}
+	if detail.CacheInputMode != usage.CacheInputModeIncluded {
+		t.Fatalf("cache input mode = %q, want included", detail.CacheInputMode)
+	}
 	if detail.ReasoningTokens != 5 {
 		t.Fatalf("reasoning tokens = %d, want %d", detail.ReasoningTokens, 5)
 	}
 	if !detail.TokenBreakdown.Valid() || detail.TokenBreakdown.Quality != usage.TokenAccountingQualityComplete {
 		t.Fatalf("token breakdown = %+v", detail.TokenBreakdown)
 	}
-	if detail.TokenBreakdown.Input.UncachedTokens != 6 || detail.TokenBreakdown.Output.NonReasoningTokens != 1 {
+	if detail.TokenBreakdown.Input.UncachedTokens != 4 || detail.TokenBreakdown.Output.NonReasoningTokens != 1 {
 		t.Fatalf("token breakdown = %+v", detail.TokenBreakdown)
 	}
 }
@@ -129,6 +135,56 @@ func TestParseOpenAIUsageNormalizesCacheCreationAlias(t *testing.T) {
 	detail := ParseOpenAIUsage(data)
 	if detail.CacheCreationTokens != 4 {
 		t.Fatalf("cache creation tokens = %d, want 4", detail.CacheCreationTokens)
+	}
+}
+
+func TestParseOpenAIUsageOmitsIncludedModeWhenCacheExceedsInput(t *testing.T) {
+	detail := ParseOpenAIUsage([]byte(`{"usage":{"prompt_tokens":10,"completion_tokens":1,"total_tokens":11,"prompt_tokens_details":{"cached_tokens":20}}}`))
+	if detail.CacheInputMode != "" {
+		t.Fatalf("cache input mode = %q, want omitted for inconsistent included counters", detail.CacheInputMode)
+	}
+	if detail.TokenBreakdown.Quality != usage.TokenAccountingQualityInconsistent {
+		t.Fatalf("token breakdown quality = %q, want inconsistent", detail.TokenBreakdown.Quality)
+	}
+}
+
+func TestUsageParsersOmitCacheInputModeForAllZeroCounters(t *testing.T) {
+	tests := []struct {
+		name  string
+		parse func() usage.Detail
+	}{
+		{
+			name: "OpenAI",
+			parse: func() usage.Detail {
+				return ParseOpenAIUsage([]byte(`{"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0,"input_tokens_details":{"cached_tokens":0}}}`))
+			},
+		},
+		{
+			name: "Claude",
+			parse: func() usage.Detail {
+				return ParseClaudeUsage([]byte(`{"usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}`))
+			},
+		},
+		{
+			name: "Gemini",
+			parse: func() usage.Detail {
+				return ParseGeminiUsage([]byte(`{"usageMetadata":{"promptTokenCount":0,"candidatesTokenCount":0,"cachedContentTokenCount":0,"totalTokenCount":0}}`))
+			},
+		},
+		{
+			name: "Interactions",
+			parse: func() usage.Detail {
+				return ParseInteractionsUsage([]byte(`{"usage":{"input_tokens":0,"output_tokens":0,"cached_tokens":0,"total_tokens":0}}`))
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			detail := test.parse()
+			if detail.CacheInputMode != "" {
+				t.Fatalf("cache input mode = %q, want omitted for all-zero usage", detail.CacheInputMode)
+			}
+		})
 	}
 }
 
@@ -318,6 +374,9 @@ func TestParseClaudeUsageIncludesCacheTokensInTotal(t *testing.T) {
 	if detail.TotalTokens != 22859 {
 		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 22859)
 	}
+	if detail.CacheInputMode != usage.CacheInputModeSeparate {
+		t.Fatalf("cache input mode = %q, want separate", detail.CacheInputMode)
+	}
 	if detail.TokenBreakdown.Input.TotalTokens != 22606 || detail.TokenBreakdown.Input.UncachedTokens != 3085 {
 		t.Fatalf("token breakdown = %+v", detail.TokenBreakdown)
 	}
@@ -341,6 +400,9 @@ func TestParseGeminiUsageNormalizesCachedContent(t *testing.T) {
 	}
 	if detail.CacheReadTokens != 4 {
 		t.Fatalf("cache read tokens = %d, want 4", detail.CacheReadTokens)
+	}
+	if detail.CacheInputMode != usage.CacheInputModeIncluded {
+		t.Fatalf("cache input mode = %q, want included", detail.CacheInputMode)
 	}
 	if detail.TokenBreakdown.Input.UncachedTokens != 6 || detail.TokenBreakdown.TotalTokens != 12 {
 		t.Fatalf("token breakdown = %+v", detail.TokenBreakdown)
@@ -394,8 +456,18 @@ func TestParseInteractionsUsage(t *testing.T) {
 	if detail.CacheReadTokens != 2 {
 		t.Fatalf("cache read tokens = %d, want 2", detail.CacheReadTokens)
 	}
+	if detail.CacheInputMode != usage.CacheInputModeIncluded {
+		t.Fatalf("cache input mode = %q, want included", detail.CacheInputMode)
+	}
 	if detail.TokenBreakdown.Input.UncachedTokens != 1 || detail.TokenBreakdown.Output.TotalTokens != 9 {
 		t.Fatalf("token breakdown = %+v", detail.TokenBreakdown)
+	}
+}
+
+func TestParseInteractionsUsageOmitsIncludedModeWhenLegacyCacheExceedsInput(t *testing.T) {
+	detail := ParseInteractionsUsage([]byte(`{"usage":{"input_tokens":10,"cached_tokens":20,"cache_read_tokens":2}}`))
+	if detail.CacheInputMode != "" {
+		t.Fatalf("cache input mode = %q, want omitted when legacy cache exceeds input", detail.CacheInputMode)
 	}
 }
 

--- a/sdk/cliproxy/usage/accounting.go
+++ b/sdk/cliproxy/usage/accounting.go
@@ -21,6 +21,7 @@ const (
 	tokenAccountingSemanticsSubset
 	tokenAccountingSemanticsIndependent
 	tokenAccountingSemanticsSeparateReasoning
+	tokenAccountingSemanticsSeparateCache
 )
 
 // TokenInputBreakdown contains mutually exclusive input token buckets.
@@ -185,6 +186,36 @@ func NewIndependentTokenBreakdown(uncachedInput, cacheRead, cacheWrite, nonReaso
 	}
 }
 
+// NewSeparateCacheTokenBreakdown normalizes protocols where cache tokens are
+// separate from uncached input while reasoning remains included in output.
+func NewSeparateCacheTokenBreakdown(uncachedInput, cacheRead, cacheWrite, outputTotal, reasoning, total int64) TokenBreakdown {
+	inputTotal, okInput := nonNegativeSum(uncachedInput, cacheRead, cacheWrite)
+	expectedTotal, okExpected := nonNegativeSum(inputTotal, outputTotal)
+	if !okInput || !okExpected || reasoning < 0 || reasoning > outputTotal {
+		return inconsistentTokenBreakdown(total, expectedTotal)
+	}
+	resolvedTotal, okTotal := resolveAccountingTotal(total, expectedTotal)
+	if !okTotal {
+		return inconsistentTokenBreakdown(total, expectedTotal)
+	}
+	return TokenBreakdown{
+		SchemaVersion: TokenAccountingSchemaVersion,
+		Quality:       TokenAccountingQualityComplete,
+		TotalTokens:   resolvedTotal,
+		Input: TokenInputBreakdown{
+			TotalTokens:      inputTotal,
+			UncachedTokens:   uncachedInput,
+			CacheReadTokens:  cacheRead,
+			CacheWriteTokens: cacheWrite,
+		},
+		Output: TokenOutputBreakdown{
+			TotalTokens:        outputTotal,
+			NonReasoningTokens: outputTotal - reasoning,
+			ReasoningTokens:    reasoning,
+		},
+	}
+}
+
 // NewSeparateReasoningTokenBreakdown normalizes protocols where cache tokens
 // are included in input totals while reasoning is separate from ordinary output.
 func NewSeparateReasoningTokenBreakdown(inputTotal, cacheRead, cacheWrite, nonReasoningOutput, reasoning, total int64) TokenBreakdown {
@@ -246,19 +277,112 @@ func EnsureTokenBreakdown(detail Detail) Detail {
 // direct SDK usage details using the known provider's token semantics. Unknown
 // providers remain unclassified instead of guessing how their buckets overlap.
 func EnsureTokenBreakdownForProvider(detail Detail, provider, executorType string) Detail {
-	if !detail.TokenBreakdown.Valid() {
-		semantics := tokenAccountingSemanticsFor(provider, executorType)
-		if detail.CacheReadTokens == 0 && detail.CachedTokens > 0 && detail.InputTokens == 0 &&
-			detail.OutputTokens == 0 && detail.ReasoningTokens == 0 && detail.CacheCreationTokens == 0 && detail.TotalTokens == 0 &&
-			(semantics == tokenAccountingSemanticsSubset || semantics == tokenAccountingSemanticsSeparateReasoning) {
-			detail.CacheReadTokens = detail.CachedTokens
+	if detail.CacheInputMode == "" && detail.TokenBreakdown == (TokenBreakdown{}) &&
+		detail.InputTokens == 0 && detail.OutputTokens == 0 && detail.ReasoningTokens == 0 &&
+		detail.CachedTokens == 0 && detail.CacheReadTokens == 0 && detail.CacheCreationTokens == 0 &&
+		detail.TotalTokens == 0 {
+		return detail
+	}
+	semantics := tokenAccountingSemanticsForDetail(detail, provider, executorType)
+	hadCanonicalBreakdown := detail.TokenBreakdown.Valid()
+	if !hadCanonicalBreakdown {
+		if detail.CacheReadTokens == 0 && detail.CacheCreationTokens == 0 && detail.CachedTokens > 0 {
+			switch semantics {
+			case tokenAccountingSemanticsIndependent, tokenAccountingSemanticsSeparateCache:
+				detail.CacheReadTokens = detail.CachedTokens
+			case tokenAccountingSemanticsSubset, tokenAccountingSemanticsSeparateReasoning:
+				legacyCacheFitsInput := detail.CachedTokens <= detail.InputTokens
+				legacyCacheIsOnlyUsage := detail.InputTokens == 0 && detail.OutputTokens == 0 &&
+					detail.ReasoningTokens == 0 && detail.TotalTokens == 0
+				if legacyCacheFitsInput || legacyCacheIsOnlyUsage {
+					detail.CacheReadTokens = detail.CachedTokens
+				}
+			}
 		}
 		detail.TokenBreakdown = tokenBreakdownForSemantics(detail, semantics)
+	}
+	if detail.CacheInputMode != "" && !cacheInputModeMatchesCanonicalBreakdown(detail) {
+		detail.CacheInputMode = ""
+	}
+	if detail.CacheInputMode == "" && !hadCanonicalBreakdown && hasTokenAccountingSignal(detail) &&
+		detail.TokenBreakdown.Quality != TokenAccountingQualityInconsistent {
+		detail.CacheInputMode = cacheInputModeForDetail(detail, semantics)
 	}
 	if detail.TotalTokens == 0 {
 		detail.TotalTokens = detail.TokenBreakdown.TotalTokens
 	}
 	return detail
+}
+
+func cacheInputModeMatchesCanonicalBreakdown(detail Detail) bool {
+	breakdown := detail.TokenBreakdown
+	if !breakdown.Valid() || breakdown.Quality == TokenAccountingQualityInconsistent ||
+		!cacheInputModeFitsDetail(detail) {
+		return false
+	}
+	if breakdown.Quality == TokenAccountingQualityUnclassified && breakdown.Input == (TokenInputBreakdown{}) {
+		lowerBound, okLowerBound := unclassifiedTokenLowerBound(detail)
+		return okLowerBound && breakdown.TotalTokens >= lowerBound
+	}
+	if detail.CacheReadTokens != 0 && detail.CacheReadTokens != breakdown.Input.CacheReadTokens {
+		return false
+	}
+	if detail.CacheCreationTokens != 0 && detail.CacheCreationTokens != breakdown.Input.CacheWriteTokens {
+		return false
+	}
+	canonicalCached := breakdown.Input.CacheReadTokens
+	if canonicalCached == 0 {
+		canonicalCached = breakdown.Input.CacheWriteTokens
+	}
+	if detail.CachedTokens != 0 && detail.CachedTokens != canonicalCached {
+		return false
+	}
+	cacheTokens, okCache := nonNegativeSum(breakdown.Input.CacheReadTokens, breakdown.Input.CacheWriteTokens)
+	if !okCache {
+		return false
+	}
+	modeMatches := false
+	switch detail.CacheInputMode {
+	case CacheInputModeIncluded:
+		modeMatches = breakdown.Input.TotalTokens == detail.InputTokens
+	case CacheInputModeSeparate:
+		expectedInput, okInput := nonNegativeSum(detail.InputTokens, cacheTokens)
+		modeMatches = okInput && breakdown.Input.UncachedTokens == detail.InputTokens && breakdown.Input.TotalTokens == expectedInput
+	default:
+		return false
+	}
+	if !modeMatches {
+		return false
+	}
+	if breakdown.Quality == TokenAccountingQualityUnclassified {
+		lowerBound, okLowerBound := unclassifiedTokenLowerBound(detail)
+		return okLowerBound && breakdown.TotalTokens >= lowerBound
+	}
+	return true
+}
+
+func cacheInputModeFitsDetail(detail Detail) bool {
+	cacheTokens, okCache := nonNegativeSum(detail.CacheReadTokens, detail.CacheCreationTokens)
+	if !okCache || detail.InputTokens < 0 || detail.CachedTokens < 0 {
+		return false
+	}
+	if cacheTokens == 0 && detail.CachedTokens > 0 {
+		cacheTokens = detail.CachedTokens
+	}
+	switch detail.CacheInputMode {
+	case CacheInputModeIncluded:
+		return cacheTokens <= detail.InputTokens && detail.CachedTokens <= detail.InputTokens
+	case CacheInputModeSeparate:
+		return true
+	default:
+		return false
+	}
+}
+
+func hasTokenAccountingSignal(detail Detail) bool {
+	return detail.InputTokens != 0 || detail.OutputTokens != 0 || detail.ReasoningTokens != 0 ||
+		detail.CachedTokens != 0 || detail.CacheReadTokens != 0 || detail.CacheCreationTokens != 0 ||
+		detail.TotalTokens != 0 || detail.TokenBreakdown.TotalTokens != 0
 }
 
 func tokenBreakdownForSemantics(detail Detail, semantics tokenAccountingSemantics) TokenBreakdown {
@@ -300,6 +424,15 @@ func tokenBreakdownForSemantics(detail Detail, semantics tokenAccountingSemantic
 			detail.ReasoningTokens,
 			detail.TotalTokens,
 		)
+	case tokenAccountingSemanticsSeparateCache:
+		return NewSeparateCacheTokenBreakdown(
+			detail.InputTokens,
+			detail.CacheReadTokens,
+			detail.CacheCreationTokens,
+			detail.OutputTokens,
+			detail.ReasoningTokens,
+			detail.TotalTokens,
+		)
 	default:
 		total := detail.TotalTokens
 		if total == 0 {
@@ -319,17 +452,84 @@ func unclassifiedTokenLowerBound(detail Detail) (int64, bool) {
 		return 0, false
 	}
 	inputTotal := detail.InputTokens
-	if cacheTokens > inputTotal {
-		inputTotal = cacheTokens
-	}
-	if detail.CachedTokens > inputTotal {
-		inputTotal = detail.CachedTokens
+	if detail.CacheInputMode == CacheInputModeSeparate {
+		if detail.CachedTokens > cacheTokens {
+			cacheTokens = detail.CachedTokens
+		}
+		var okInput bool
+		inputTotal, okInput = nonNegativeSum(inputTotal, cacheTokens)
+		if !okInput {
+			return 0, false
+		}
+	} else {
+		if cacheTokens > inputTotal {
+			inputTotal = cacheTokens
+		}
+		if detail.CachedTokens > inputTotal {
+			inputTotal = detail.CachedTokens
+		}
 	}
 	outputTotal := detail.OutputTokens
 	if detail.ReasoningTokens > outputTotal {
 		outputTotal = detail.ReasoningTokens
 	}
 	return nonNegativeSum(inputTotal, outputTotal)
+}
+
+func cacheInputModeForDetail(detail Detail, semantics tokenAccountingSemantics) CacheInputMode {
+	cacheTokens, okCache := nonNegativeSum(detail.CacheReadTokens, detail.CacheCreationTokens)
+	if !okCache || detail.InputTokens < 0 || detail.CachedTokens < 0 {
+		return ""
+	}
+	if cacheTokens == 0 && detail.CachedTokens > 0 {
+		cacheTokens = detail.CachedTokens
+	} else if cacheTokens > 0 && detail.CachedTokens > 0 {
+		canonicalCached := detail.CacheReadTokens
+		if canonicalCached == 0 {
+			canonicalCached = detail.CacheCreationTokens
+		}
+		if detail.CachedTokens != canonicalCached {
+			return ""
+		}
+	}
+	switch semantics {
+	case tokenAccountingSemanticsSubset, tokenAccountingSemanticsSeparateReasoning:
+		if cacheTokens > detail.InputTokens || detail.CachedTokens > detail.InputTokens {
+			return ""
+		}
+		return CacheInputModeIncluded
+	case tokenAccountingSemanticsIndependent:
+		return CacheInputModeSeparate
+	default:
+		return ""
+	}
+}
+
+func tokenAccountingSemanticsForDetail(detail Detail, provider, executorType string) tokenAccountingSemantics {
+	semantics := tokenAccountingSemanticsFor(provider, executorType)
+	switch detail.CacheInputMode {
+	case CacheInputModeIncluded:
+		switch semantics {
+		case tokenAccountingSemanticsIndependent:
+			return tokenAccountingSemanticsSeparateReasoning
+		case tokenAccountingSemanticsUnknown:
+			if detail.ReasoningTokens == 0 {
+				return tokenAccountingSemanticsSubset
+			}
+		}
+	case CacheInputModeSeparate:
+		switch semantics {
+		case tokenAccountingSemanticsSubset:
+			return tokenAccountingSemanticsSeparateCache
+		case tokenAccountingSemanticsSeparateReasoning:
+			return tokenAccountingSemanticsIndependent
+		case tokenAccountingSemanticsUnknown:
+			if detail.ReasoningTokens == 0 {
+				return tokenAccountingSemanticsSeparateCache
+			}
+		}
+	}
+	return semantics
 }
 
 func tokenAccountingSemanticsFor(provider, executorType string) tokenAccountingSemantics {

--- a/sdk/cliproxy/usage/accounting_test.go
+++ b/sdk/cliproxy/usage/accounting_test.go
@@ -66,6 +66,82 @@ func TestNewUnclassifiedTokenBreakdownDoesNotGuessBuckets(t *testing.T) {
 	}
 }
 
+func TestEnsureTokenBreakdownForProviderPreservesEmptyDetail(t *testing.T) {
+	detail := EnsureTokenBreakdownForProvider(Detail{}, "xai", "")
+	if detail != (Detail{}) {
+		t.Fatalf("detail = %+v, want empty usage detail", detail)
+	}
+}
+
+func TestEnsureTokenBreakdownForProviderRenormalizesNonEmptyInvalidBreakdown(t *testing.T) {
+	legacy := TokenBreakdown{
+		SchemaVersion: 1,
+		Quality:       TokenAccountingQualityComplete,
+	}
+	detail := EnsureTokenBreakdownForProvider(Detail{TokenBreakdown: legacy}, "openai", "")
+	if !detail.TokenBreakdown.Valid() {
+		t.Fatalf("token breakdown remained invalid: %+v", detail.TokenBreakdown)
+	}
+	if detail.TokenBreakdown.SchemaVersion != TokenAccountingSchemaVersion {
+		t.Fatalf("schema version = %d, want %d", detail.TokenBreakdown.SchemaVersion, TokenAccountingSchemaVersion)
+	}
+	if detail.CacheInputMode != "" {
+		t.Fatalf("cache input mode = %q, want omitted for zero-token legacy breakdown", detail.CacheInputMode)
+	}
+}
+
+func TestEnsureTokenBreakdownForProviderHonorsExplicitCacheInputMode(t *testing.T) {
+	tests := []struct {
+		name      string
+		provider  string
+		detail    Detail
+		wantMode  CacheInputMode
+		wantTotal int64
+		wantInput int64
+	}{
+		{
+			name:     "explicit separate overrides OpenAI provider heuristic",
+			provider: "openai",
+			detail: Detail{
+				InputTokens:     100,
+				OutputTokens:    10,
+				CacheReadTokens: 40,
+				CacheInputMode:  CacheInputModeSeparate,
+			},
+			wantMode:  CacheInputModeSeparate,
+			wantTotal: 150,
+			wantInput: 140,
+		},
+		{
+			name:     "explicit included overrides Anthropic provider heuristic",
+			provider: "anthropic",
+			detail: Detail{
+				InputTokens:     100,
+				OutputTokens:    10,
+				CacheReadTokens: 40,
+				CacheInputMode:  CacheInputModeIncluded,
+			},
+			wantMode:  CacheInputModeIncluded,
+			wantTotal: 110,
+			wantInput: 100,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detail := EnsureTokenBreakdownForProvider(tt.detail, tt.provider, "")
+			if detail.CacheInputMode != tt.wantMode {
+				t.Fatalf("cache input mode = %q, want %q", detail.CacheInputMode, tt.wantMode)
+			}
+			if detail.TotalTokens != tt.wantTotal || detail.TokenBreakdown.TotalTokens != tt.wantTotal {
+				t.Fatalf("totals = detail:%d breakdown:%d, want %d", detail.TotalTokens, detail.TokenBreakdown.TotalTokens, tt.wantTotal)
+			}
+			if detail.TokenBreakdown.Input.TotalTokens != tt.wantInput {
+				t.Fatalf("input total = %d, want %d", detail.TokenBreakdown.Input.TotalTokens, tt.wantInput)
+			}
+		})
+	}
+}
+
 func TestEnsureTokenBreakdownForProviderUsesKnownSemantics(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -75,6 +151,7 @@ func TestEnsureTokenBreakdownForProviderUsesKnownSemantics(t *testing.T) {
 		wantTotal    int64
 		wantInput    int64
 		wantOutput   int64
+		wantMode     CacheInputMode
 	}{
 		{
 			name:       "OpenAI subsets cache and reasoning",
@@ -83,6 +160,7 @@ func TestEnsureTokenBreakdownForProviderUsesKnownSemantics(t *testing.T) {
 			wantTotal:  130,
 			wantInput:  100,
 			wantOutput: 30,
+			wantMode:   CacheInputModeIncluded,
 		},
 		{
 			name:         "OpenAI compatible executor takes precedence",
@@ -92,6 +170,7 @@ func TestEnsureTokenBreakdownForProviderUsesKnownSemantics(t *testing.T) {
 			wantTotal:    130,
 			wantInput:    100,
 			wantOutput:   30,
+			wantMode:     CacheInputModeIncluded,
 		},
 		{
 			name:       "Gemini keeps reasoning separate",
@@ -100,6 +179,7 @@ func TestEnsureTokenBreakdownForProviderUsesKnownSemantics(t *testing.T) {
 			wantTotal:  142,
 			wantInput:  100,
 			wantOutput: 42,
+			wantMode:   CacheInputModeIncluded,
 		},
 		{
 			name:       "Claude keeps cache and reasoning independent",
@@ -108,6 +188,7 @@ func TestEnsureTokenBreakdownForProviderUsesKnownSemantics(t *testing.T) {
 			wantTotal:  192,
 			wantInput:  150,
 			wantOutput: 42,
+			wantMode:   CacheInputModeSeparate,
 		},
 	}
 	for _, tt := range tests {
@@ -115,6 +196,9 @@ func TestEnsureTokenBreakdownForProviderUsesKnownSemantics(t *testing.T) {
 			detail := EnsureTokenBreakdownForProvider(tt.detail, tt.provider, tt.executorType)
 			if !detail.TokenBreakdown.Valid() || detail.TokenBreakdown.Quality != TokenAccountingQualityComplete {
 				t.Fatalf("token breakdown = %+v", detail.TokenBreakdown)
+			}
+			if detail.CacheInputMode != tt.wantMode {
+				t.Fatalf("cache input mode = %q, want %q", detail.CacheInputMode, tt.wantMode)
 			}
 			if detail.TotalTokens != tt.wantTotal || detail.TokenBreakdown.TotalTokens != tt.wantTotal ||
 				detail.TokenBreakdown.Input.TotalTokens != tt.wantInput || detail.TokenBreakdown.Output.TotalTokens != tt.wantOutput {
@@ -124,10 +208,55 @@ func TestEnsureTokenBreakdownForProviderUsesKnownSemantics(t *testing.T) {
 	}
 }
 
+func TestEnsureTokenBreakdownForIndependentProviderPromotesLegacyCachedTokens(t *testing.T) {
+	detail := EnsureTokenBreakdownForProvider(Detail{
+		InputTokens:  100,
+		OutputTokens: 30,
+		CachedTokens: 40,
+	}, "anthropic", "")
+
+	if detail.CacheInputMode != CacheInputModeSeparate {
+		t.Fatalf("cache input mode = %q, want %q", detail.CacheInputMode, CacheInputModeSeparate)
+	}
+	if detail.CacheReadTokens != 40 {
+		t.Fatalf("cache read tokens = %d, want promoted legacy value 40", detail.CacheReadTokens)
+	}
+	if detail.TotalTokens != 170 || detail.TokenBreakdown.TotalTokens != 170 {
+		t.Fatalf("totals = detail:%d breakdown:%d, want 170", detail.TotalTokens, detail.TokenBreakdown.TotalTokens)
+	}
+	if detail.TokenBreakdown.Quality != TokenAccountingQualityComplete ||
+		detail.TokenBreakdown.Input.TotalTokens != 140 || detail.TokenBreakdown.Input.CacheReadTokens != 40 {
+		t.Fatalf("token breakdown = %+v", detail.TokenBreakdown)
+	}
+}
+
 func TestEnsureTokenBreakdownForUnknownProviderDoesNotGuessReasoning(t *testing.T) {
 	detail := EnsureTokenBreakdownForProvider(Detail{InputTokens: 100, OutputTokens: 30, ReasoningTokens: 12}, "plugin-provider", "")
+	if detail.CacheInputMode != "" {
+		t.Fatalf("cache input mode = %q, want omitted for unknown provider", detail.CacheInputMode)
+	}
 	if detail.TotalTokens != 130 || detail.TokenBreakdown.Quality != TokenAccountingQualityUnclassified || detail.TokenBreakdown.UnclassifiedTokens != 130 {
 		t.Fatalf("detail = %+v", detail)
+	}
+}
+
+func TestEnsureTokenBreakdownForUnknownProviderHonorsExplicitSeparateCacheMode(t *testing.T) {
+	detail := EnsureTokenBreakdownForProvider(Detail{
+		InputTokens:     100,
+		OutputTokens:    30,
+		ReasoningTokens: 12,
+		CacheReadTokens: 40,
+		CacheInputMode:  CacheInputModeSeparate,
+	}, "plugin-provider", "")
+
+	if detail.CacheInputMode != CacheInputModeSeparate {
+		t.Fatalf("cache input mode = %q, want %q", detail.CacheInputMode, CacheInputModeSeparate)
+	}
+	if detail.TotalTokens != 170 || detail.TokenBreakdown.TotalTokens != 170 {
+		t.Fatalf("totals = detail:%d breakdown:%d, want 170", detail.TotalTokens, detail.TokenBreakdown.TotalTokens)
+	}
+	if detail.TokenBreakdown.Quality != TokenAccountingQualityUnclassified || detail.TokenBreakdown.UnclassifiedTokens != 170 {
+		t.Fatalf("token breakdown = %+v, want reasoning overlap left unclassified", detail.TokenBreakdown)
 	}
 }
 
@@ -148,9 +277,196 @@ func TestEnsureTokenBreakdownForGeminiClassifiesReasoningOnlyUsage(t *testing.T)
 
 func TestEnsureTokenBreakdownPreservesLegacyCachedOnlyUsage(t *testing.T) {
 	detail := EnsureTokenBreakdownForProvider(Detail{CachedTokens: 13}, "openai", "")
+	if detail.CacheInputMode != "" {
+		t.Fatalf("cache input mode = %q, want omitted when cache exceeds input", detail.CacheInputMode)
+	}
 	if detail.TotalTokens != 13 || detail.CacheReadTokens != 13 || detail.TokenBreakdown.Quality != TokenAccountingQualityUnclassified ||
 		detail.TokenBreakdown.UnclassifiedTokens != 13 {
 		t.Fatalf("detail = %+v", detail)
+	}
+}
+
+func TestEnsureTokenBreakdownOmitsIncludedModeWhenLegacyCacheExceedsInput(t *testing.T) {
+	detail := EnsureTokenBreakdownForProvider(Detail{InputTokens: 10, CachedTokens: 20}, "openai", "")
+	if detail.CacheInputMode != "" {
+		t.Fatalf("cache input mode = %q, want omitted when legacy cache exceeds input", detail.CacheInputMode)
+	}
+}
+
+func TestEnsureTokenBreakdownOmitsIncludedModeWhenMixedLegacyCacheExceedsInput(t *testing.T) {
+	detail := EnsureTokenBreakdownForProvider(Detail{
+		InputTokens:     10,
+		CachedTokens:    20,
+		CacheReadTokens: 2,
+	}, "openai", "")
+	if detail.CacheInputMode != "" {
+		t.Fatalf("cache input mode = %q, want omitted when legacy cache exceeds input", detail.CacheInputMode)
+	}
+}
+
+func TestEnsureTokenBreakdownDoesNotInferModeOverExistingCanonicalBreakdown(t *testing.T) {
+	detail := Detail{
+		InputTokens:         10,
+		OutputTokens:        6,
+		CacheReadTokens:     4,
+		CacheCreationTokens: 2,
+		ReasoningTokens:     1,
+		TotalTokens:         16,
+		TokenBreakdown:      NewSubsetTokenBreakdown(10, 4, 2, 6, 1, 16),
+	}
+	detail = EnsureTokenBreakdownForProvider(detail, "anthropic", "")
+	if detail.CacheInputMode != "" {
+		t.Fatalf("cache input mode = %q, want omitted rather than contradicting existing breakdown", detail.CacheInputMode)
+	}
+	if detail.TokenBreakdown.Input.UncachedTokens != 4 {
+		t.Fatalf("token breakdown changed: %+v", detail.TokenBreakdown)
+	}
+}
+
+func TestEnsureTokenBreakdownClearsConflictingExplicitModeOverCanonicalBreakdown(t *testing.T) {
+	canonical := NewSubsetTokenBreakdown(100, 40, 0, 10, 0, 110)
+	detail := EnsureTokenBreakdownForProvider(Detail{
+		InputTokens:     100,
+		OutputTokens:    10,
+		CacheReadTokens: 40,
+		TotalTokens:     110,
+		CacheInputMode:  CacheInputModeSeparate,
+		TokenBreakdown:  canonical,
+	}, "openai", "")
+
+	if detail.CacheInputMode != "" {
+		t.Fatalf("cache input mode = %q, want conflicting mode removed", detail.CacheInputMode)
+	}
+	if detail.TokenBreakdown != canonical || detail.TotalTokens != 110 {
+		t.Fatalf("canonical breakdown changed: detail=%+v", detail)
+	}
+}
+
+func TestEnsureTokenBreakdownClearsModeWhenDetailCacheCountersDisagreeWithCanonical(t *testing.T) {
+	canonical := NewSubsetTokenBreakdown(100, 0, 0, 10, 0, 110)
+	detail := EnsureTokenBreakdownForProvider(Detail{
+		InputTokens:     100,
+		OutputTokens:    10,
+		CacheReadTokens: 40,
+		TotalTokens:     110,
+		CacheInputMode:  CacheInputModeSeparate,
+		TokenBreakdown:  canonical,
+	}, "openai", "")
+
+	if detail.CacheInputMode != "" {
+		t.Fatalf("cache input mode = %q, want removed when detail and canonical cache buckets disagree", detail.CacheInputMode)
+	}
+	if detail.TokenBreakdown != canonical || detail.TotalTokens != 110 {
+		t.Fatalf("canonical breakdown changed: detail=%+v", detail)
+	}
+}
+
+func TestEnsureTokenBreakdownClearsImpossibleExplicitModeAfterDerivation(t *testing.T) {
+	detail := EnsureTokenBreakdownForProvider(Detail{
+		InputTokens:     10,
+		CacheReadTokens: 20,
+		CacheInputMode:  CacheInputModeIncluded,
+	}, "openai", "")
+
+	if detail.CacheInputMode != "" {
+		t.Fatalf("cache input mode = %q, want impossible included mode removed", detail.CacheInputMode)
+	}
+	if detail.TokenBreakdown.Quality != TokenAccountingQualityInconsistent {
+		t.Fatalf("token breakdown quality = %q, want inconsistent; detail=%+v", detail.TokenBreakdown.Quality, detail)
+	}
+}
+
+func TestEnsureTokenBreakdownClearsImpossibleIncludedModeOverUnclassifiedBreakdown(t *testing.T) {
+	canonical := NewUnclassifiedTokenBreakdown(20)
+	detail := EnsureTokenBreakdownForProvider(Detail{
+		InputTokens:     10,
+		CacheReadTokens: 20,
+		TotalTokens:     20,
+		CacheInputMode:  CacheInputModeIncluded,
+		TokenBreakdown:  canonical,
+	}, "openai", "")
+
+	if detail.CacheInputMode != "" {
+		t.Fatalf("cache input mode = %q, want impossible included mode removed", detail.CacheInputMode)
+	}
+	if detail.TokenBreakdown != canonical || detail.TotalTokens != 20 {
+		t.Fatalf("canonical breakdown changed: detail=%+v", detail)
+	}
+}
+
+func TestEnsureTokenBreakdownPreservesIncludedModeForPartialUnclassifiedTotal(t *testing.T) {
+	canonical := NewPartialSubsetTokenBreakdown(10, 0, 0, 0, 0, 15)
+	detail := EnsureTokenBreakdownForProvider(Detail{
+		InputTokens:    10,
+		TotalTokens:    15,
+		CacheInputMode: CacheInputModeIncluded,
+		TokenBreakdown: canonical,
+	}, "openai", "")
+
+	if detail.CacheInputMode != CacheInputModeIncluded {
+		t.Fatalf("cache input mode = %q, want %q for valid partial total", detail.CacheInputMode, CacheInputModeIncluded)
+	}
+	if detail.TokenBreakdown != canonical || detail.TotalTokens != 15 {
+		t.Fatalf("partial canonical breakdown changed: detail=%+v", detail)
+	}
+}
+
+func TestEnsureTokenBreakdownClearsSeparateModeOverPartialIncludedBreakdown(t *testing.T) {
+	canonical := NewPartialSubsetTokenBreakdown(10, 2, 0, 0, 0, 15)
+	detail := EnsureTokenBreakdownForProvider(Detail{
+		InputTokens:     10,
+		CacheReadTokens: 2,
+		TotalTokens:     15,
+		CacheInputMode:  CacheInputModeSeparate,
+		TokenBreakdown:  canonical,
+	}, "openai", "")
+
+	if detail.CacheInputMode != "" {
+		t.Fatalf("cache input mode = %q, want conflicting separate mode removed", detail.CacheInputMode)
+	}
+	if detail.TokenBreakdown != canonical || detail.TotalTokens != 15 {
+		t.Fatalf("partial canonical breakdown changed: detail=%+v", detail)
+	}
+}
+
+func TestEnsureTokenBreakdownMixedLegacyAndCanonicalCacheDisagreementIsModeFree(t *testing.T) {
+	first := EnsureTokenBreakdownForProvider(Detail{
+		InputTokens:     10,
+		CachedTokens:    3,
+		CacheReadTokens: 2,
+	}, "openai", "")
+	second := EnsureTokenBreakdownForProvider(first, "openai", "")
+
+	for name, detail := range map[string]Detail{"first": first, "second": second} {
+		if detail.CacheInputMode != "" {
+			t.Fatalf("%s cache input mode = %q, want omitted for disagreeing cache counters", name, detail.CacheInputMode)
+		}
+		if detail.TokenBreakdown.Input.CacheReadTokens != 2 || detail.TokenBreakdown.Input.UncachedTokens != 8 {
+			t.Fatalf("%s canonical input breakdown = %+v", name, detail.TokenBreakdown.Input)
+		}
+	}
+}
+
+func TestEnsureTokenBreakdownLegacyIncludedCacheIsIdempotent(t *testing.T) {
+	first := EnsureTokenBreakdownForProvider(Detail{
+		InputTokens:  10,
+		CachedTokens: 4,
+	}, "openai", "")
+	second := EnsureTokenBreakdownForProvider(first, "openai", "")
+
+	for name, detail := range map[string]Detail{"first": first, "second": second} {
+		if detail.CacheInputMode != CacheInputModeIncluded {
+			t.Fatalf("%s cache input mode = %q, want %q", name, detail.CacheInputMode, CacheInputModeIncluded)
+		}
+		if detail.CacheReadTokens != 4 || detail.TokenBreakdown.Input.CacheReadTokens != 4 {
+			t.Fatalf("%s cache read tokens = detail:%d breakdown:%d, want 4", name, detail.CacheReadTokens, detail.TokenBreakdown.Input.CacheReadTokens)
+		}
+		if detail.TokenBreakdown.Input.UncachedTokens != 6 || detail.TotalTokens != 10 {
+			t.Fatalf("%s detail = %+v", name, detail)
+		}
+	}
+	if second.TokenBreakdown != first.TokenBreakdown {
+		t.Fatalf("second normalization changed canonical breakdown:\nfirst=%+v\nsecond=%+v", first.TokenBreakdown, second.TokenBreakdown)
 	}
 }
 

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -59,6 +59,15 @@ type Failure struct {
 	Body       string
 }
 
+// CacheInputMode describes whether cache-read and cache-write tokens are already
+// included in InputTokens. The zero value means the producer does not know.
+type CacheInputMode string
+
+const (
+	CacheInputModeIncluded CacheInputMode = "included"
+	CacheInputModeSeparate CacheInputMode = "separate"
+)
+
 // Detail holds the token usage breakdown.
 type Detail struct {
 	InputTokens         int64
@@ -67,6 +76,7 @@ type Detail struct {
 	CachedTokens        int64
 	CacheReadTokens     int64
 	CacheCreationTokens int64
+	CacheInputMode      CacheInputMode
 	TotalTokens         int64
 	TokenBreakdown      TokenBreakdown
 	ResponseServiceTier string
@@ -348,11 +358,13 @@ func (m *Manager) dispatch(item queueItem) {
 	if len(plugins) == 0 {
 		return
 	}
+	record := item.record
+	record.Detail = EnsureTokenBreakdownForProvider(record.Detail, record.Provider, record.ExecutorType)
 	for _, plugin := range plugins {
 		if plugin == nil {
 			continue
 		}
-		safeInvoke(plugin, item.ctx, item.record)
+		safeInvoke(plugin, item.ctx, record)
 	}
 }
 

--- a/sdk/cliproxy/usage/manager_test.go
+++ b/sdk/cliproxy/usage/manager_test.go
@@ -3,6 +3,7 @@ package usage
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 func TestGenerateEnabledDefaultsNilToTrue(t *testing.T) {
@@ -48,5 +49,40 @@ func TestRecordOmittedGenerateIsEnabled(t *testing.T) {
 	}
 	if !GenerateEnabled(record.Generate) {
 		t.Fatalf("GenerateEnabled(omitted) = false, want true")
+	}
+}
+
+type captureUsagePlugin struct {
+	records chan Record
+}
+
+func (p *captureUsagePlugin) HandleUsage(_ context.Context, record Record) {
+	p.records <- record
+}
+
+func TestManagerNormalizesLegacyCacheInputModeBeforePluginFanout(t *testing.T) {
+	manager := NewManager(1)
+	t.Cleanup(manager.Stop)
+	plugin := &captureUsagePlugin{records: make(chan Record, 1)}
+	manager.Register(plugin)
+
+	manager.Publish(context.Background(), Record{
+		Provider: "openai",
+		Detail: Detail{
+			InputTokens:  10,
+			CachedTokens: 4,
+		},
+	})
+
+	select {
+	case record := <-plugin.records:
+		if record.Detail.CacheInputMode != CacheInputModeIncluded {
+			t.Fatalf("cache input mode = %q, want %q", record.Detail.CacheInputMode, CacheInputModeIncluded)
+		}
+		if !record.Detail.TokenBreakdown.Valid() {
+			t.Fatalf("token breakdown = %+v, want valid canonical breakdown", record.Detail.TokenBreakdown)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for usage plugin record")
 	}
 }

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -1303,6 +1303,14 @@ type UsageFailure struct {
 	Body string
 }
 
+// CacheInputMode describes whether cache read/write tokens are included in InputTokens.
+type CacheInputMode string
+
+const (
+	CacheInputModeIncluded CacheInputMode = "included"
+	CacheInputModeSeparate CacheInputMode = "separate"
+)
+
 // UsageDetail contains token accounting counters.
 type UsageDetail struct {
 	// InputTokens is the prompt or input token count.
@@ -1317,6 +1325,8 @@ type UsageDetail struct {
 	CacheReadTokens int64
 	// CacheCreationTokens is the cache creation token count.
 	CacheCreationTokens int64
+	// CacheInputMode reports whether cache tokens are included in InputTokens.
+	CacheInputMode CacheInputMode
 	// TotalTokens is the total token count.
 	TotalTokens int64
 }


### PR DESCRIPTION
## Summary

- expose whether cache read/write tokens are included in `input_tokens` or reported separately
- parse OpenAI-compatible cache-write aliases into `cache_creation_tokens`
- normalize usage once in the core manager before fan-out so in-process plugins, Redis, and dynamic/RPC plugins receive one accounting contract
- retain an idempotent normalization check at the dynamic plugin boundary for direct adapter calls
- propagate the mode through core usage records, Redis payloads, and plugin/RPC usage records
- omit the mode when provider semantics or either legacy or canonical counters cannot establish it safely
- preserve all-zero usage details unchanged instead of inventing a cache mode or canonical token breakdown for media/failure records with no token signal

## Semantics

`cache_input_mode` is additive and has two values:

- `included`: cache read/write buckets are subsets of `input_tokens` (OpenAI-style, Gemini, Interactions)
- `separate`: cache buckets are reported outside `input_tokens` (Claude/Anthropic)

Unknown providers, contradictory counters, all-zero details, and caller-supplied canonical breakdowns without an explicit mode retain the zero value instead of receiving a guessed classification.

When legacy `cached_tokens` and canonical cache-read/write buckets coexist, both representations are validated independently against their containing input total. A valid canonical bucket can no longer mask an impossible legacy count.

## Compatibility

- existing token counters and accounting-v2 breakdowns are unchanged
- Redis uses `omitempty`, so legacy payload shape is unchanged when the mode is unknown
- explicit producer modes remain authoritative
- manager normalization gives every registered plugin the same provider-aware detail
- the adapter check is idempotent and protects direct adapter invocation
- zero-token image/video/failure usage remains `Detail{}`

## Validation

- red/green regressions for mixed legacy/canonical counters in core accounting and Interactions parsing
- red/green regression for manager-wide normalization of a legacy direct-SDK record
- dynamic-plugin adapter regression
- red/green regression preserving all-zero usage detail
- `go test ./sdk/cliproxy/usage ./internal/runtime/executor ./internal/runtime/executor/helps ./internal/pluginhost ./internal/redisqueue ./sdk/pluginapi -count=1`
- focused race tests, count 10
- `go test ./... -count=1`
- `go vet ./sdk/cliproxy/usage ./internal/runtime/executor/helps ./internal/redisqueue ./sdk/pluginapi`
- plugin-host package and race tests pass; its package-wide vet still reports two pre-existing context-cancel warnings in untouched files
- `go build -o /tmp/cli-proxy-api-pr4558 ./cmd/server`
- `git diff --check upstream/dev...HEAD`

This is a focused current-`dev` implementation on top of accounting-v2; it does not carry the unrelated changes currently present in older PR #4193.

Fixes #4483
