### PR TITLE
fix(claude): skip deferred tools for cache control

### DIFF
--- a/internal/runtime/executor/caching_verify_test.go
+++ b/internal/runtime/executor/caching_verify_test.go
@@ -67,6 +67,49 @@ func TestEnsureCacheControl(t *testing.T) {
 		}
 	})
 
+	t.Run("Tools Caching Skips Deferred Tail", func(t *testing.T) {
+		input := []byte(`{
+			"model": "claude-opus-5",
+			"tools": [
+				{"name": "resident", "description": "Resident tool", "input_schema": {"type": "object"}},
+				{"name": "deferred", "description": "Deferred tool", "input_schema": {"type": "object"}, "defer_loading": true}
+			],
+			"messages": [{"role": "user", "content": "Hi"}]
+		}`)
+
+		output := ensureCacheControl(input)
+
+		if got := gjson.GetBytes(output, "tools.0.cache_control.type").String(); got != "ephemeral" {
+			t.Fatalf("resident tool cache_control = %q, want ephemeral; output: %s", got, output)
+		}
+		if gjson.GetBytes(output, "tools.1.cache_control").Exists() {
+			t.Fatalf("deferred tool must not receive cache_control; output: %s", output)
+		}
+	})
+
+	t.Run("Tools Caching Skips When All Tools Deferred", func(t *testing.T) {
+		input := []byte(`{
+			"model": "claude-opus-5",
+			"tools": [
+				{"name": "deferred0", "description": "Deferred tool", "input_schema": {"type": "object"}, "defer_loading": true},
+				{"name": "deferred1", "description": "Deferred tool", "input_schema": {"type": "object"}, "defer_loading": true}
+			],
+			"system": "System prompt",
+			"messages": [{"role": "user", "content": "Hi"}]
+		}`)
+
+		output := ensureCacheControl(input)
+
+		for i := 0; i < 2; i++ {
+			if gjson.GetBytes(output, fmt.Sprintf("tools.%d.cache_control", i)).Exists() {
+				t.Fatalf("deferred tool %d must not receive cache_control; output: %s", i, output)
+			}
+		}
+		if got := gjson.GetBytes(output, "system.0.cache_control.type").String(); got != "ephemeral" {
+			t.Fatalf("system cache_control = %q, want ephemeral; output: %s", got, output)
+		}
+	})
+
 	// Test case 4: Tools and system are INDEPENDENT breakpoints
 	// Per Anthropic docs: Up to 4 breakpoints allowed, tools and system are cached separately
 	t.Run("Independent Cache Breakpoints", func(t *testing.T) {

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -2206,7 +2206,7 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 // ensureCacheControl injects cache_control breakpoints into the payload for optimal prompt caching.
 // According to Anthropic's documentation, cache prefixes are created in order: tools -> system -> messages.
 // This function adds cache_control to:
-// 1. The LAST tool in the tools array (caches all tool definitions)
+// 1. The LAST non-deferred tool in the tools array (caches the eligible tool prefix)
 // 2. The LAST system prompt element
 // 3. The SECOND-TO-LAST user turn (caches conversation history for multi-turn)
 //
@@ -2214,8 +2214,8 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 // This enables up to 90% cost reduction on cached tokens (cache read = 0.1x base price).
 // See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
 func ensureCacheControl(payload []byte) []byte {
-	// 1. Inject cache_control into the LAST tool (caches all tool definitions)
-	// Tools are cached first in the hierarchy, so this is the most important breakpoint.
+	// 1. Inject cache_control into the LAST non-deferred tool.
+	// Deferred tools cannot carry cache_control, so cache the longest eligible tool prefix.
 	payload = injectToolsCacheControl(payload)
 
 	// 2. Inject cache_control into the LAST system prompt element
@@ -2623,8 +2623,9 @@ func injectMessagesCacheControl(payload []byte) []byte {
 	return payload
 }
 
-// injectToolsCacheControl adds cache_control to the last tool in the tools array.
+// injectToolsCacheControl adds cache_control to the last non-deferred tool in the tools array.
 // Per Anthropic docs: "The cache_control parameter on the last tool definition caches all tool definitions."
+// Tools with defer_loading=true cannot carry cache_control, so they are skipped as injection targets.
 // This only adds cache_control if NO tool in the array already has it.
 func injectToolsCacheControl(payload []byte) []byte {
 	tools := gjson.GetBytes(payload, "tools")
@@ -2632,26 +2633,25 @@ func injectToolsCacheControl(payload []byte) []byte {
 		return payload
 	}
 
-	toolCount := int(tools.Get("#").Int())
-	if toolCount == 0 {
-		return payload
-	}
-
-	// Check if ANY tool already has cache_control - if so, don't modify tools
+	// Check if ANY tool already has cache_control - if so, don't modify tools.
+	// At the same time, retain the last tool that is eligible for prompt caching.
 	hasCacheControlInTools := false
-	tools.ForEach(func(_, tool gjson.Result) bool {
+	lastCacheableToolIdx := -1
+	tools.ForEach(func(index, tool gjson.Result) bool {
 		if tool.Get("cache_control").Exists() {
 			hasCacheControlInTools = true
 			return false
 		}
+		if !tool.Get("defer_loading").Bool() {
+			lastCacheableToolIdx = int(index.Int())
+		}
 		return true
 	})
-	if hasCacheControlInTools {
+	if hasCacheControlInTools || lastCacheableToolIdx < 0 {
 		return payload
 	}
 
-	// Add cache_control to the last tool
-	lastToolPath := fmt.Sprintf("tools.%d.cache_control", toolCount-1)
+	lastToolPath := fmt.Sprintf("tools.%d.cache_control", lastCacheableToolIdx)
 	result, err := sjson.SetBytes(payload, lastToolPath, map[string]string{"type": "ephemeral"})
 	if err != nil {
 		log.Warnf("failed to inject cache_control into tools array: %v", err)


### PR DESCRIPTION
## Summary

- avoid injecting `cache_control` onto Claude tools with `defer_loading: true`
- place the automatic tool-cache breakpoint on the last eligible non-deferred tool
- skip tool-cache injection when every tool is deferred while preserving system/message caching
- add regressions for a deferred tail and an all-deferred tool list

## Root cause

`injectToolsCacheControl` always wrote to `tools[len-1]` when no client cache breakpoint existed. Anthropic rejects tools that combine `defer_loading: true` with `cache_control`.

## Validation

- `go test ./internal/runtime/executor -run 'TestEnsureCacheControl' -count=1`
- `go test ./internal/runtime/executor -count=1`
- `go test -race ./internal/runtime/executor -run 'TestEnsureCacheControl' -count=1`
- `go vet ./internal/runtime/executor`
- `go build -o /tmp/cliproxyapi-4561 ./cmd/server`
- `git diff --check`

Fixes #4561
