### PR TITLE
fix(auth): ignore stale unauthorized results after credential replacement

### DIFF
--- a/internal/api/handlers/management/auth_files_codex_metadata_test.go
+++ b/internal/api/handlers/management/auth_files_codex_metadata_test.go
@@ -1,0 +1,36 @@
+package management
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
+)
+
+func TestCodexTokenMetadataIncludesCredentialRevision(t *testing.T) {
+	storage := &codex.CodexTokenStorage{
+		IDToken:      "id-token",
+		AccessToken:  "access-token",
+		RefreshToken: "refresh-token",
+		AccountID:    "account-id",
+		LastRefresh:  "2026-07-24T00:00:00Z",
+		Email:        "user@example.com",
+		Expire:       "2026-07-25T00:00:00Z",
+	}
+
+	metadata := codexTokenMetadata(storage)
+	want := map[string]string{
+		"type":          "codex",
+		"id_token":      storage.IDToken,
+		"access_token":  storage.AccessToken,
+		"refresh_token": storage.RefreshToken,
+		"account_id":    storage.AccountID,
+		"last_refresh":  storage.LastRefresh,
+		"email":         storage.Email,
+		"expired":       storage.Expire,
+	}
+	for key, value := range want {
+		if got, _ := metadata[key].(string); got != value {
+			t.Fatalf("metadata[%q] = %q, want %q", key, got, value)
+		}
+	}
+}

--- a/internal/api/handlers/management/auth_files_provider_oauth.go
+++ b/internal/api/handlers/management/auth_files_provider_oauth.go
@@ -193,6 +193,22 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 	c.JSON(200, gin.H{"status": "ok", "url": authURL, "state": state})
 }
 
+func codexTokenMetadata(storage *codex.CodexTokenStorage) map[string]any {
+	if storage == nil {
+		return nil
+	}
+	return map[string]any{
+		"type":          "codex",
+		"id_token":      storage.IDToken,
+		"access_token":  storage.AccessToken,
+		"refresh_token": storage.RefreshToken,
+		"account_id":    storage.AccountID,
+		"last_refresh":  storage.LastRefresh,
+		"email":         storage.Email,
+		"expired":       storage.Expire,
+	}
+}
+
 func (h *Handler) RequestCodexToken(c *gin.Context) {
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
@@ -316,10 +332,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 			Provider: "codex",
 			FileName: fileName,
 			Storage:  tokenStorage,
-			Metadata: map[string]any{
-				"email":      tokenStorage.Email,
-				"account_id": tokenStorage.AccountID,
-			},
+			Metadata: codexTokenMetadata(tokenStorage),
 		}
 		if errGuard := guardOAuthSessionPendingForSave(state, "codex"); errGuard != nil {
 			return

--- a/internal/auth/claude/token.go
+++ b/internal/auth/claude/token.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	baseauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 )
 
@@ -57,6 +58,19 @@ type ClaudeTokenStorage struct {
 // SetMetadata allows external callers to inject metadata into the storage before saving.
 func (ts *ClaudeTokenStorage) SetMetadata(meta map[string]any) {
 	ts.Metadata = meta
+}
+
+// CredentialFingerprintMaterial returns the canonical OAuth credential fields
+// without serializing unrelated storage metadata.
+func (ts *ClaudeTokenStorage) CredentialFingerprintMaterial() baseauth.CredentialFingerprintMaterial {
+	if ts == nil {
+		return baseauth.CredentialFingerprintMaterial{}
+	}
+	return baseauth.CredentialFingerprintMaterial{
+		AccessToken:  ts.AccessToken,
+		RefreshToken: ts.RefreshToken,
+		IDToken:      ts.IDToken,
+	}
 }
 
 // SaveTokenToFile serializes the Claude token storage to a JSON file.

--- a/internal/auth/codex/token.go
+++ b/internal/auth/codex/token.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	baseauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 )
 
@@ -41,6 +42,19 @@ type CodexTokenStorage struct {
 // SetMetadata allows external callers to inject metadata into the storage before saving.
 func (ts *CodexTokenStorage) SetMetadata(meta map[string]any) {
 	ts.Metadata = meta
+}
+
+// CredentialFingerprintMaterial returns the canonical OAuth credential fields
+// without serializing unrelated storage metadata.
+func (ts *CodexTokenStorage) CredentialFingerprintMaterial() baseauth.CredentialFingerprintMaterial {
+	if ts == nil {
+		return baseauth.CredentialFingerprintMaterial{}
+	}
+	return baseauth.CredentialFingerprintMaterial{
+		AccessToken:  ts.AccessToken,
+		RefreshToken: ts.RefreshToken,
+		IDToken:      ts.IDToken,
+	}
 }
 
 // SaveTokenToFile serializes the Codex token storage to a JSON file.

--- a/internal/auth/models.go
+++ b/internal/auth/models.go
@@ -15,3 +15,26 @@ type TokenStorage interface {
 	//   - error: An error if the save operation fails, nil otherwise
 	SaveTokenToFile(authFilePath string) error
 }
+
+// CredentialFingerprintMaterial exposes credential fields to the runtime only
+// for one-way revision fingerprinting. Values must never be logged or persisted
+// outside their existing token storage.
+type CredentialFingerprintMaterial struct {
+	APIKey       string
+	AccessToken  string
+	RefreshToken string
+	IDToken      string
+	Opaque       string
+}
+
+// CredentialFingerprintSource is an optional token-storage capability used to
+// compare storage-backed and metadata-backed revisions consistently.
+type CredentialFingerprintSource interface {
+	CredentialFingerprintMaterial() CredentialFingerprintMaterial
+}
+
+// CredentialSnapshotSource lets mutable token storage return its serialized
+// data, host metadata, and fingerprint material from one generation.
+type CredentialSnapshotSource interface {
+	CredentialSnapshot() ([]byte, map[string]any, CredentialFingerprintMaterial)
+}

--- a/internal/auth/models.go
+++ b/internal/auth/models.go
@@ -38,3 +38,9 @@ type CredentialFingerprintSource interface {
 type CredentialSnapshotSource interface {
 	CredentialSnapshot() ([]byte, map[string]any, CredentialFingerprintMaterial)
 }
+
+// CredentialPersistenceSnapshotSource lets mutable token storage detach an
+// independent copy before persistence runs outside the auth-manager lock.
+type CredentialPersistenceSnapshotSource interface {
+	CredentialPersistenceSnapshot() TokenStorage
+}

--- a/internal/pluginhost/auth_provider.go
+++ b/internal/pluginhost/auth_provider.go
@@ -541,9 +541,15 @@ func pluginCredentialFingerprintMaterial(raw []byte, metadata map[string]any) ba
 	return baseauth.CredentialFingerprintMaterial{Opaque: string(canonical)}
 }
 
+type pluginCredentialHeaderEntry struct {
+	source    string
+	value     any
+	canonical string
+}
+
 func pluginCredentialMetadata(metadata map[string]any) map[string]any {
 	out := make(map[string]any)
-	credentialHeaders := make(map[string]any)
+	credentialHeaders := make(map[string][]pluginCredentialHeaderEntry)
 	keys := make([]string, 0, len(metadata))
 	for key := range metadata {
 		keys = append(keys, key)
@@ -553,8 +559,19 @@ func pluginCredentialMetadata(metadata map[string]any) map[string]any {
 		value := metadata[key]
 		if pluginCredentialHeaderContainer(key) {
 			if filtered, ok := filterPluginCredentialHeaders(value); ok {
-				for header, credential := range filtered {
-					credentialHeaders[header] = credential
+				source := normalizePluginMetadataKey(key)
+				for header, credentials := range filtered {
+					for _, credential := range credentials {
+						canonical, errMarshal := json.Marshal(credential)
+						if errMarshal != nil {
+							canonical = []byte(fmt.Sprintf("%T:%v", credential, credential))
+						}
+						credentialHeaders[header] = append(credentialHeaders[header], pluginCredentialHeaderEntry{
+							source:    source,
+							value:     credential,
+							canonical: string(canonical),
+						})
+					}
 				}
 			}
 			continue
@@ -570,11 +587,44 @@ func pluginCredentialMetadata(metadata map[string]any) map[string]any {
 			out[key] = filtered
 		}
 	}
-	if len(credentialHeaders) > 0 {
-		out["headers"] = credentialHeaders
+	if canonicalHeaders := canonicalPluginCredentialHeaders(credentialHeaders); len(canonicalHeaders) > 0 {
+		out["headers"] = canonicalHeaders
 	}
 	if len(out) == 0 {
 		return nil
+	}
+	return out
+}
+
+func canonicalPluginCredentialHeaders(entries map[string][]pluginCredentialHeaderEntry) map[string]any {
+	out := make(map[string]any, len(entries))
+	for header, candidates := range entries {
+		values := make(map[string]any)
+		pairs := make(map[string]pluginCredentialHeaderEntry)
+		for _, candidate := range candidates {
+			values[candidate.canonical] = candidate.value
+			pairs[candidate.source+"\x00"+candidate.canonical] = candidate
+		}
+		if len(values) == 1 {
+			for _, value := range values {
+				out[header] = value
+			}
+			continue
+		}
+		keys := make([]string, 0, len(pairs))
+		for key := range pairs {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		collisions := make([]map[string]any, 0, len(keys))
+		for _, key := range keys {
+			candidate := pairs[key]
+			collisions = append(collisions, map[string]any{
+				"source": candidate.source,
+				"value":  candidate.value,
+			})
+		}
+		out[header] = collisions
 	}
 	return out
 }
@@ -597,7 +647,7 @@ func filterPluginCredentialMetadata(value any) (any, bool) {
 	}
 }
 
-func filterPluginCredentialHeaders(value any) (map[string]any, bool) {
+func filterPluginCredentialHeaders(value any) (map[string][]any, bool) {
 	headers := reflect.ValueOf(value)
 	if !headers.IsValid() || headers.Kind() != reflect.Map || headers.Type().Key().Kind() != reflect.String {
 		return nil, false
@@ -608,13 +658,14 @@ func filterPluginCredentialHeaders(value any) (map[string]any, bool) {
 		keys = append(keys, iter.Key().String())
 	}
 	sort.Strings(keys)
-	out := make(map[string]any)
+	out := make(map[string][]any)
 	for _, key := range keys {
 		if !pluginCredentialHeaderName(key) {
 			continue
 		}
 		value := headers.MapIndex(reflect.ValueOf(key).Convert(headers.Type().Key()))
-		out[normalizePluginMetadataKey(key)] = value.Interface()
+		canonicalKey := normalizePluginMetadataKey(key)
+		out[canonicalKey] = append(out[canonicalKey], value.Interface())
 	}
 	return out, len(out) > 0
 }

--- a/internal/pluginhost/auth_provider.go
+++ b/internal/pluginhost/auth_provider.go
@@ -549,6 +549,7 @@ type pluginCredentialHeaderEntry struct {
 
 func pluginCredentialMetadata(metadata map[string]any) map[string]any {
 	out := make(map[string]any)
+	credentialValues := make(map[string][]pluginCredentialHeaderEntry)
 	credentialHeaders := make(map[string][]pluginCredentialHeaderEntry)
 	keys := make([]string, 0, len(metadata))
 	for key := range metadata {
@@ -580,12 +581,24 @@ func pluginCredentialMetadata(metadata map[string]any) map[string]any {
 			continue
 		}
 		if pluginCredentialMetadataKey(key) {
-			out[normalizePluginMetadataKey(key)] = value
+			canonical, errMarshal := json.Marshal(value)
+			if errMarshal != nil {
+				canonical = []byte(fmt.Sprintf("%T:%v", value, value))
+			}
+			canonicalKey := normalizePluginMetadataKey(key)
+			credentialValues[canonicalKey] = append(credentialValues[canonicalKey], pluginCredentialHeaderEntry{
+				source:    strings.ToLower(strings.TrimSpace(key)),
+				value:     value,
+				canonical: string(canonical),
+			})
 			continue
 		}
 		if filtered, ok := filterPluginCredentialMetadata(value); ok {
 			out[key] = filtered
 		}
+	}
+	for key, value := range canonicalPluginCredentialHeaders(credentialValues) {
+		out[key] = value
 	}
 	if canonicalHeaders := canonicalPluginCredentialHeaders(credentialHeaders); len(canonicalHeaders) > 0 {
 		out["headers"] = canonicalHeaders

--- a/internal/pluginhost/auth_provider.go
+++ b/internal/pluginhost/auth_provider.go
@@ -434,6 +434,20 @@ func (s *pluginTokenStorage) CredentialSnapshot() ([]byte, map[string]any, basea
 	return payload, metadata, fingerprint
 }
 
+func (s *pluginTokenStorage) CredentialPersistenceSnapshot() baseauth.TokenStorage {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	snapshot := &pluginTokenStorage{
+		provider: s.provider,
+		rawJSON:  bytes.Clone(s.rawJSON),
+		meta:     cloneInterceptorMetadata(s.meta),
+	}
+	s.mu.RUnlock()
+	return snapshot
+}
+
 func (s *pluginTokenStorage) credentialSnapshot() ([]byte, map[string]any, baseauth.CredentialFingerprintMaterial, error) {
 	if s == nil {
 		return nil, nil, baseauth.CredentialFingerprintMaterial{}, fmt.Errorf("plugin token storage is nil")
@@ -599,7 +613,7 @@ func pluginCredentialHeaderName(key string) bool {
 
 func pluginCredentialMetadataKey(key string) bool {
 	switch normalizePluginMetadataKey(key) {
-	case "apikey", "accesstoken", "refreshtoken", "idtoken",
+	case "apikey", "apitoken", "accesstoken", "refreshtoken", "idtoken",
 		"token", "authtoken", "bearertoken", "sessiontoken",
 		"secret", "clientsecret", "password", "credential", "credentials",
 		"privatekey", "authorization", "cookie", "sessioncookie":

--- a/internal/pluginhost/auth_provider.go
+++ b/internal/pluginhost/auth_provider.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -542,10 +543,19 @@ func pluginCredentialFingerprintMaterial(raw []byte, metadata map[string]any) ba
 
 func pluginCredentialMetadata(metadata map[string]any) map[string]any {
 	out := make(map[string]any)
-	for key, value := range metadata {
+	credentialHeaders := make(map[string]any)
+	keys := make([]string, 0, len(metadata))
+	for key := range metadata {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		value := metadata[key]
 		if pluginCredentialHeaderContainer(key) {
 			if filtered, ok := filterPluginCredentialHeaders(value); ok {
-				out[key] = filtered
+				for header, credential := range filtered {
+					credentialHeaders[header] = credential
+				}
 			}
 			continue
 		}
@@ -553,12 +563,15 @@ func pluginCredentialMetadata(metadata map[string]any) map[string]any {
 			continue
 		}
 		if pluginCredentialMetadataKey(key) {
-			out[key] = value
+			out[normalizePluginMetadataKey(key)] = value
 			continue
 		}
 		if filtered, ok := filterPluginCredentialMetadata(value); ok {
 			out[key] = filtered
 		}
+	}
+	if len(credentialHeaders) > 0 {
+		out["headers"] = credentialHeaders
 	}
 	if len(out) == 0 {
 		return nil
@@ -589,13 +602,19 @@ func filterPluginCredentialHeaders(value any) (map[string]any, bool) {
 	if !headers.IsValid() || headers.Kind() != reflect.Map || headers.Type().Key().Kind() != reflect.String {
 		return nil, false
 	}
-	out := make(map[string]any)
+	keys := make([]string, 0, headers.Len())
 	iter := headers.MapRange()
 	for iter.Next() {
-		key := iter.Key().String()
-		if pluginCredentialHeaderName(key) {
-			out[key] = iter.Value().Interface()
+		keys = append(keys, iter.Key().String())
+	}
+	sort.Strings(keys)
+	out := make(map[string]any)
+	for _, key := range keys {
+		if !pluginCredentialHeaderName(key) {
+			continue
 		}
+		value := headers.MapIndex(reflect.ValueOf(key).Convert(headers.Type().Key()))
+		out[normalizePluginMetadataKey(key)] = value.Interface()
 	}
 	return out, len(out) > 0
 }

--- a/internal/pluginhost/auth_provider.go
+++ b/internal/pluginhost/auth_provider.go
@@ -10,8 +10,10 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
+	baseauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
@@ -412,6 +414,7 @@ func (h *Host) AuthDataToCoreAuth(data pluginapi.AuthData, path, fileName string
 }
 
 type pluginTokenStorage struct {
+	mu       sync.RWMutex
 	provider string
 	rawJSON  []byte
 	meta     map[string]any
@@ -421,17 +424,41 @@ func (s *pluginTokenStorage) SetMetadata(meta map[string]any) {
 	if s == nil {
 		return
 	}
-	s.meta = cloneAnyMap(meta)
+	s.mu.Lock()
+	s.meta = cloneInterceptorMetadata(meta)
+	s.mu.Unlock()
+}
+
+func (s *pluginTokenStorage) CredentialSnapshot() ([]byte, map[string]any, baseauth.CredentialFingerprintMaterial) {
+	payload, metadata, fingerprint, _ := s.credentialSnapshot()
+	return payload, metadata, fingerprint
+}
+
+func (s *pluginTokenStorage) credentialSnapshot() ([]byte, map[string]any, baseauth.CredentialFingerprintMaterial, error) {
+	if s == nil {
+		return nil, nil, baseauth.CredentialFingerprintMaterial{}, fmt.Errorf("plugin token storage is nil")
+	}
+	s.mu.RLock()
+	rawJSON := bytes.Clone(s.rawJSON)
+	metadata := cloneInterceptorMetadata(s.meta)
+	provider := s.provider
+	s.mu.RUnlock()
+
+	fingerprint := pluginCredentialFingerprintMaterial(rawJSON, metadata)
+	payload, errPayload := mergedStorageJSON(rawJSON, metadata, provider)
+	if errPayload != nil {
+		return nil, metadata, fingerprint, errPayload
+	}
+	return payload, metadata, fingerprint, nil
+}
+
+func (s *pluginTokenStorage) CredentialFingerprintMaterial() baseauth.CredentialFingerprintMaterial {
+	_, _, fingerprint, _ := s.credentialSnapshot()
+	return fingerprint
 }
 
 func (s *pluginTokenStorage) RawJSON() []byte {
-	if s == nil {
-		return nil
-	}
-	payload, errPayload := mergedStorageJSON(s.rawJSON, s.meta, s.provider)
-	if errPayload != nil {
-		return nil
-	}
+	payload, _, _ := s.CredentialSnapshot()
 	return payload
 }
 
@@ -439,9 +466,9 @@ func (s *pluginTokenStorage) SaveTokenToFile(path string) error {
 	if s == nil {
 		return fmt.Errorf("plugin token storage is nil")
 	}
-	payload, errPayload := mergedStorageJSON(s.rawJSON, s.meta, s.provider)
-	if errPayload != nil {
-		return errPayload
+	payload, _, _, errSnapshot := s.credentialSnapshot()
+	if errSnapshot != nil {
+		return errSnapshot
 	}
 	if len(bytes.TrimSpace(payload)) == 0 {
 		return fmt.Errorf("plugin token storage payload is empty")
@@ -473,6 +500,137 @@ func jsonPayloadEqual(left, right []byte) bool {
 		return false
 	}
 	return reflect.DeepEqual(leftValue, rightValue)
+}
+
+func pluginCredentialFingerprintMaterial(raw []byte, metadata map[string]any) baseauth.CredentialFingerprintMaterial {
+	parts := make(map[string]any, 2)
+	trimmedRaw := bytes.TrimSpace(raw)
+	if len(trimmedRaw) > 0 {
+		var storage any
+		if errUnmarshal := json.Unmarshal(trimmedRaw, &storage); errUnmarshal == nil {
+			parts["storage"] = storage
+		} else {
+			parts["storage"] = string(trimmedRaw)
+		}
+	}
+	if credentialMetadata := pluginCredentialMetadata(metadata); len(credentialMetadata) > 0 {
+		parts["metadata"] = credentialMetadata
+	}
+	if len(parts) == 0 {
+		return baseauth.CredentialFingerprintMaterial{}
+	}
+	canonical, errMarshal := json.Marshal(parts)
+	if errMarshal != nil {
+		return baseauth.CredentialFingerprintMaterial{Opaque: string(trimmedRaw)}
+	}
+	return baseauth.CredentialFingerprintMaterial{Opaque: string(canonical)}
+}
+
+func pluginCredentialMetadata(metadata map[string]any) map[string]any {
+	out := make(map[string]any)
+	for key, value := range metadata {
+		if pluginCredentialHeaderContainer(key) {
+			if filtered, ok := filterPluginCredentialHeaders(value); ok {
+				out[key] = filtered
+			}
+			continue
+		}
+		if pluginNonCredentialMetadataContainer(key) {
+			continue
+		}
+		if pluginCredentialMetadataKey(key) {
+			out[key] = value
+			continue
+		}
+		if filtered, ok := filterPluginCredentialMetadata(value); ok {
+			out[key] = filtered
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func filterPluginCredentialMetadata(value any) (any, bool) {
+	switch typed := value.(type) {
+	case map[string]any:
+		filtered := pluginCredentialMetadata(typed)
+		return filtered, len(filtered) > 0
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			if filtered, ok := filterPluginCredentialMetadata(item); ok {
+				out = append(out, filtered)
+			}
+		}
+		return out, len(out) > 0
+	default:
+		return nil, false
+	}
+}
+
+func filterPluginCredentialHeaders(value any) (map[string]any, bool) {
+	headers := reflect.ValueOf(value)
+	if !headers.IsValid() || headers.Kind() != reflect.Map || headers.Type().Key().Kind() != reflect.String {
+		return nil, false
+	}
+	out := make(map[string]any)
+	iter := headers.MapRange()
+	for iter.Next() {
+		key := iter.Key().String()
+		if pluginCredentialHeaderName(key) {
+			out[key] = iter.Value().Interface()
+		}
+	}
+	return out, len(out) > 0
+}
+
+func pluginCredentialHeaderName(key string) bool {
+	normalized := normalizePluginMetadataKey(key)
+	if pluginCredentialMetadataKey(normalized) {
+		return true
+	}
+	return strings.Contains(normalized, "authorization") ||
+		strings.Contains(normalized, "apikey") ||
+		strings.Contains(normalized, "token") ||
+		strings.Contains(normalized, "secret")
+}
+
+func pluginCredentialMetadataKey(key string) bool {
+	switch normalizePluginMetadataKey(key) {
+	case "apikey", "accesstoken", "refreshtoken", "idtoken",
+		"token", "authtoken", "bearertoken", "sessiontoken",
+		"secret", "clientsecret", "password", "credential", "credentials",
+		"privatekey", "authorization", "cookie", "sessioncookie":
+		return true
+	default:
+		return false
+	}
+}
+
+func pluginCredentialHeaderContainer(key string) bool {
+	switch normalizePluginMetadataKey(key) {
+	case "headers", "requestheaders":
+		return true
+	default:
+		return false
+	}
+}
+
+func pluginNonCredentialMetadataContainer(key string) bool {
+	switch normalizePluginMetadataKey(key) {
+	case "responseheaders":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizePluginMetadataKey(key string) string {
+	key = strings.ToLower(strings.TrimSpace(key))
+	replacer := strings.NewReplacer("-", "", "_", "", " ", "")
+	return replacer.Replace(key)
 }
 
 func mergedStorageJSON(raw []byte, metadata map[string]any, provider string) ([]byte, error) {

--- a/internal/pluginhost/auth_provider_test.go
+++ b/internal/pluginhost/auth_provider_test.go
@@ -431,6 +431,30 @@ func TestPluginTokenStorageFingerprintIgnoresHostMetadata(t *testing.T) {
 	}
 }
 
+func TestPluginTokenStorageFingerprintCanonicalizesCredentialHeaderNames(t *testing.T) {
+	storage := &pluginTokenStorage{
+		provider: "plugin-provider",
+		rawJSON:  []byte(`{"provider_state":"stable"}`),
+	}
+	storage.SetMetadata(map[string]any{
+		"headers": map[string]any{
+			"Authorization": "Bearer same-token",
+		},
+	})
+	before := storage.CredentialFingerprintMaterial()
+
+	storage.SetMetadata(map[string]any{
+		"REQUEST_HEADERS": map[string]any{
+			"authorization": "Bearer same-token",
+		},
+	})
+	after := storage.CredentialFingerprintMaterial()
+
+	if before != after {
+		t.Fatalf("equivalent credential header casing changed fingerprint: before=%#v after=%#v", before, after)
+	}
+}
+
 func TestPluginTokenStorageFingerprintIncludesMetadataCredentialHeaders(t *testing.T) {
 	for _, header := range []string{"Authorization", "X-API-Key", "X-Access-Token", "X-Client-Secret"} {
 		t.Run(header, func(t *testing.T) {

--- a/internal/pluginhost/auth_provider_test.go
+++ b/internal/pluginhost/auth_provider_test.go
@@ -431,6 +431,36 @@ func TestPluginTokenStorageFingerprintIgnoresHostMetadata(t *testing.T) {
 	}
 }
 
+func TestPluginTokenStorageFingerprintPreservesCollidingCredentialHeaders(t *testing.T) {
+	storage := &pluginTokenStorage{
+		provider: "plugin-provider",
+		rawJSON:  []byte(`{"provider_state":"stable"}`),
+	}
+	storage.SetMetadata(map[string]any{
+		"headers": map[string]any{
+			"Authorization": "Bearer first-token",
+		},
+		"requestHeaders": map[string]any{
+			"authorization": "Bearer stable-second-token",
+		},
+	})
+	before := storage.CredentialFingerprintMaterial()
+
+	storage.SetMetadata(map[string]any{
+		"headers": map[string]any{
+			"Authorization": "Bearer rotated-first-token",
+		},
+		"requestHeaders": map[string]any{
+			"authorization": "Bearer stable-second-token",
+		},
+	})
+	after := storage.CredentialFingerprintMaterial()
+
+	if before == after {
+		t.Fatal("rotating one colliding credential-header source did not change the fingerprint")
+	}
+}
+
 func TestPluginTokenStorageFingerprintCanonicalizesCredentialHeaderNames(t *testing.T) {
 	storage := &pluginTokenStorage{
 		provider: "plugin-provider",

--- a/internal/pluginhost/auth_provider_test.go
+++ b/internal/pluginhost/auth_provider_test.go
@@ -461,19 +461,46 @@ func TestPluginTokenStorageFingerprintIncludesMetadataCredentialHeaders(t *testi
 	}
 }
 
-func TestPluginTokenStorageFingerprintIncludesMetadataToken(t *testing.T) {
+func TestPluginTokenStoragePersistenceSnapshotIsDetached(t *testing.T) {
 	storage := &pluginTokenStorage{
 		provider: "plugin-provider",
 		rawJSON:  []byte(`{"provider_state":"stable"}`),
 	}
-	storage.SetMetadata(map[string]any{"token": "old-token", "note": "same"})
+	storage.SetMetadata(map[string]any{"token": "replacement-token"})
 
-	before := storage.CredentialFingerprintMaterial()
-	storage.SetMetadata(map[string]any{"token": "new-token", "note": "same"})
-	after := storage.CredentialFingerprintMaterial()
+	detached, ok := storage.CredentialPersistenceSnapshot().(*pluginTokenStorage)
+	if !ok || detached == nil {
+		t.Fatalf("persistence snapshot = %T, want detached plugin storage", detached)
+	}
+	detached.SetMetadata(map[string]any{"token": "stale-refresh-token"})
 
-	if before == after {
-		t.Fatal("metadata token replacement did not change credential fingerprint material")
+	_, originalMetadata, _ := storage.CredentialSnapshot()
+	if got, _ := originalMetadata["token"].(string); got != "replacement-token" {
+		t.Fatalf("original storage token = %q, want replacement token", got)
+	}
+	_, detachedMetadata, _ := detached.CredentialSnapshot()
+	if got, _ := detachedMetadata["token"].(string); got != "stale-refresh-token" {
+		t.Fatalf("detached storage token = %q, want stale refresh token", got)
+	}
+}
+
+func TestPluginTokenStorageFingerprintIncludesMetadataToken(t *testing.T) {
+	for _, key := range []string{"token", "api_token", "apiToken"} {
+		t.Run(key, func(t *testing.T) {
+			storage := &pluginTokenStorage{
+				provider: "plugin-provider",
+				rawJSON:  []byte(`{"provider_state":"stable"}`),
+			}
+			storage.SetMetadata(map[string]any{key: "old-token", "note": "same"})
+
+			before := storage.CredentialFingerprintMaterial()
+			storage.SetMetadata(map[string]any{key: "new-token", "note": "same"})
+			after := storage.CredentialFingerprintMaterial()
+
+			if before == after {
+				t.Fatalf("metadata %s replacement did not change credential fingerprint material", key)
+			}
+		})
 	}
 }
 

--- a/internal/pluginhost/auth_provider_test.go
+++ b/internal/pluginhost/auth_provider_test.go
@@ -538,6 +538,28 @@ func TestPluginTokenStoragePersistenceSnapshotIsDetached(t *testing.T) {
 	}
 }
 
+func TestPluginTokenStorageFingerprintPreservesCollidingTopLevelCredentialKeys(t *testing.T) {
+	storage := &pluginTokenStorage{
+		provider: "plugin-provider",
+		rawJSON:  []byte(`{"provider_state":"stable"}`),
+	}
+	storage.SetMetadata(map[string]any{
+		"apiToken":  "first-token",
+		"api_token": "stable-second-token",
+	})
+	before := storage.CredentialFingerprintMaterial()
+
+	storage.SetMetadata(map[string]any{
+		"apiToken":  "rotated-first-token",
+		"api_token": "stable-second-token",
+	})
+	after := storage.CredentialFingerprintMaterial()
+
+	if before == after {
+		t.Fatal("rotating one colliding top-level credential alias did not change the fingerprint")
+	}
+}
+
 func TestPluginTokenStorageFingerprintIncludesMetadataToken(t *testing.T) {
 	for _, key := range []string{"token", "api_token", "apiToken"} {
 		t.Run(key, func(t *testing.T) {

--- a/internal/pluginhost/auth_provider_test.go
+++ b/internal/pluginhost/auth_provider_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	baseauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 )
@@ -368,6 +369,111 @@ func TestPluginTokenStorageMergesRawMetadataAndProviderType(t *testing.T) {
 	}
 	if decoded["old"] != "override" || decoded["new"] != "value" || decoded["type"] != "plugin-provider" {
 		t.Fatalf("saved token decoded = %#v, want merged metadata and provider type", decoded)
+	}
+}
+
+func TestPluginTokenStorageSnapshotsMatchingMetadataAndStorage(t *testing.T) {
+	storage := &pluginTokenStorage{
+		provider: "plugin-provider",
+		rawJSON:  []byte(`{"token":"secret"}`),
+	}
+	storage.SetMetadata(map[string]any{
+		"access_token": "current-token",
+		"nested":       map[string]any{"note": "current"},
+	})
+
+	source, ok := any(storage).(interface {
+		CredentialSnapshot() ([]byte, map[string]any, baseauth.CredentialFingerprintMaterial)
+	})
+	if !ok {
+		t.Fatalf("plugin token storage = %T, want credential snapshot source", storage)
+	}
+	raw, metadata, _ := source.CredentialSnapshot()
+
+	var decoded map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &decoded); errUnmarshal != nil {
+		t.Fatalf("credential snapshot decode error = %v", errUnmarshal)
+	}
+	if decoded["access_token"] != metadata["access_token"] {
+		t.Fatalf("credential snapshot storage=%#v metadata=%#v, want matching generation", decoded, metadata)
+	}
+	metadata["access_token"] = "mutated"
+	metadata["nested"].(map[string]any)["note"] = "mutated"
+	_, current, _ := source.CredentialSnapshot()
+	if current["access_token"] != "current-token" || current["nested"].(map[string]any)["note"] != "current" {
+		t.Fatalf("credential snapshot metadata aliases storage state: %#v", current)
+	}
+}
+
+func TestPluginTokenStorageFingerprintIgnoresHostMetadata(t *testing.T) {
+	storage := &pluginTokenStorage{
+		provider: "plugin-provider",
+		rawJSON:  []byte(`{ "token": "secret", "refresh_token": "refresh" }`),
+	}
+	source, ok := any(storage).(baseauth.CredentialFingerprintSource)
+	if !ok {
+		t.Fatalf("plugin token storage = %T, want credential fingerprint source", storage)
+	}
+	before := source.CredentialFingerprintMaterial()
+	if before == (baseauth.CredentialFingerprintMaterial{}) {
+		t.Fatal("credential fingerprint material is empty")
+	}
+
+	storage.SetMetadata(map[string]any{
+		"note":     "changed",
+		"disabled": true,
+		"prefix":   "changed",
+		"headers":  map[string]any{"X-Trace-ID": "changed"},
+	})
+	after := source.CredentialFingerprintMaterial()
+	if before != after {
+		t.Fatalf("host metadata changed credential fingerprint material: before=%#v after=%#v", before, after)
+	}
+}
+
+func TestPluginTokenStorageFingerprintIncludesMetadataCredentialHeaders(t *testing.T) {
+	for _, header := range []string{"Authorization", "X-API-Key", "X-Access-Token", "X-Client-Secret"} {
+		t.Run(header, func(t *testing.T) {
+			storage := &pluginTokenStorage{
+				provider: "plugin-provider",
+				rawJSON:  []byte(`{"provider_state":"stable"}`),
+			}
+			storage.SetMetadata(map[string]any{
+				"headers": map[string]any{
+					header:       "old-credential",
+					"X-Trace-ID": "stable",
+				},
+			})
+
+			before := storage.CredentialFingerprintMaterial()
+			storage.SetMetadata(map[string]any{
+				"headers": map[string]any{
+					header:       "new-credential",
+					"X-Trace-ID": "stable",
+				},
+			})
+			after := storage.CredentialFingerprintMaterial()
+
+			if before == after {
+				t.Fatalf("metadata %s replacement did not change credential fingerprint material", header)
+			}
+		})
+	}
+}
+
+func TestPluginTokenStorageFingerprintIncludesMetadataToken(t *testing.T) {
+	storage := &pluginTokenStorage{
+		provider: "plugin-provider",
+		rawJSON:  []byte(`{"provider_state":"stable"}`),
+	}
+	storage.SetMetadata(map[string]any{"token": "old-token", "note": "same"})
+
+	before := storage.CredentialFingerprintMaterial()
+	storage.SetMetadata(map[string]any{"token": "new-token", "note": "same"})
+	after := storage.CredentialFingerprintMaterial()
+
+	if before == after {
+		t.Fatal("metadata token replacement did not change credential fingerprint material")
 	}
 }
 

--- a/internal/store/gitstore.go
+++ b/internal/store/gitstore.go
@@ -702,6 +702,11 @@ func (s *GitTokenStore) idFor(path, baseDir string) string {
 	return rel
 }
 
+// ResolveAuthPersistenceTarget returns the exact path Save would use.
+func (s *GitTokenStore) ResolveAuthPersistenceTarget(auth *cliproxyauth.Auth) (string, error) {
+	return s.resolveAuthPath(auth)
+}
+
 func (s *GitTokenStore) resolveAuthPath(auth *cliproxyauth.Auth) (string, error) {
 	if auth == nil {
 		return "", fmt.Errorf("auth filestore: auth is nil")

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -518,6 +518,11 @@ func (s *ObjectTokenStore) prefixedKey(key string) string {
 	return strings.TrimLeft(s.cfg.Prefix+"/"+key, "/")
 }
 
+// ResolveAuthPersistenceTarget returns the exact path Save would use.
+func (s *ObjectTokenStore) ResolveAuthPersistenceTarget(auth *cliproxyauth.Auth) (string, error) {
+	return s.resolveAuthPath(auth)
+}
+
 func (s *ObjectTokenStore) resolveAuthPath(auth *cliproxyauth.Auth) (string, error) {
 	if auth == nil {
 		return "", fmt.Errorf("object store: auth is nil")

--- a/internal/store/postgresstore.go
+++ b/internal/store/postgresstore.go
@@ -589,6 +589,11 @@ func (s *PostgresStore) deleteConfigRecord(ctx context.Context) error {
 	return nil
 }
 
+// ResolveAuthPersistenceTarget returns the exact path Save would use.
+func (s *PostgresStore) ResolveAuthPersistenceTarget(auth *cliproxyauth.Auth) (string, error) {
+	return s.resolveAuthPath(auth)
+}
+
 func (s *PostgresStore) resolveAuthPath(auth *cliproxyauth.Auth) (string, error) {
 	if auth == nil {
 		return "", fmt.Errorf("postgres store: auth is nil")

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -404,6 +404,11 @@ func (s *FileTokenStore) idFor(path, baseDir string) string {
 	return id
 }
 
+// ResolveAuthPersistenceTarget returns the exact path Save would use.
+func (s *FileTokenStore) ResolveAuthPersistenceTarget(auth *cliproxyauth.Auth) (string, error) {
+	return s.resolveAuthPath(auth)
+}
+
 func (s *FileTokenStore) resolveAuthPath(auth *cliproxyauth.Auth) (string, error) {
 	if auth == nil {
 		return "", fmt.Errorf("auth filestore: auth is nil")

--- a/sdk/auth/filestore_test.go
+++ b/sdk/auth/filestore_test.go
@@ -87,6 +87,24 @@ func TestExtractAccessToken(t *testing.T) {
 	}
 }
 
+func TestFileTokenStoreResolveAuthPersistenceTargetPreservesRelativeSubdirectories(t *testing.T) {
+	store := NewFileTokenStore()
+	root := t.TempDir()
+	store.SetBaseDir(root)
+
+	target, errResolve := store.ResolveAuthPersistenceTarget(&cliproxyauth.Auth{
+		ID:       "runtime-id",
+		FileName: filepath.Join("new", "auth.json"),
+	})
+	if errResolve != nil {
+		t.Fatalf("ResolveAuthPersistenceTarget: %v", errResolve)
+	}
+	want := filepath.Join(root, "new", "auth.json")
+	if target != want {
+		t.Fatalf("resolved target = %q, want %q", target, want)
+	}
+}
+
 func TestFileTokenStoreSaveExistingMetadataSetsFileAttributes(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/sdk/cliproxy/auth/antigravity_credits_test.go
+++ b/sdk/cliproxy/auth/antigravity_credits_test.go
@@ -17,12 +17,22 @@ import (
 
 type antigravityCreditsFallbackExecutor struct {
 	streamCreditsRequested []bool
+	executeStarted         chan struct{}
+	executeRelease         chan struct{}
 }
 
 func (e *antigravityCreditsFallbackExecutor) Identifier() string { return "antigravity" }
 
-func (e *antigravityCreditsFallbackExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
-	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusNotImplemented, Message: "Execute not implemented"}
+func (e *antigravityCreditsFallbackExecutor) Execute(ctx context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if e.executeStarted == nil {
+		return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusNotImplemented, Message: "Execute not implemented"}
+	}
+	if !AntigravityCreditsRequested(ctx) {
+		return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusServiceUnavailable, Message: "standard quota exhausted"}
+	}
+	close(e.executeStarted)
+	<-e.executeRelease
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusUnauthorized, Message: "old token unauthorized"}
 }
 
 func (e *antigravityCreditsFallbackExecutor) ExecuteStream(ctx context.Context, _ *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
@@ -125,6 +135,84 @@ func TestManagerExecuteStream_AntigravityCreditsFallbackAfterBootstrap429(t *tes
 	}
 	if executor.streamCreditsRequested[0] || !executor.streamCreditsRequested[1] {
 		t.Fatalf("credits flags = %v, want [false true]", executor.streamCreditsRequested)
+	}
+}
+
+func TestManagerExecute_AntigravityCreditsFallbackIgnoresLateUnauthorizedAfterMutableCredentialReplacement(t *testing.T) {
+	const (
+		authID = "ag-credits-mutable-replacement"
+		model  = "claude-opus-4-6-thinking"
+	)
+	storage := &mutableCredentialSnapshotStorage{metadata: map[string]any{"token": "old-token"}}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{AntigravityCredits: true},
+	})
+	manager.SetRetryConfig(0, 0, 1)
+	executor := &antigravityCreditsFallbackExecutor{
+		executeStarted: make(chan struct{}),
+		executeRelease: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+	registry.GetGlobalRegistry().RegisterClient(authID, "antigravity", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(authID) })
+	if _, errRegister := manager.Register(context.Background(), &Auth{
+		ID:       authID,
+		Provider: "antigravity",
+		Status:   StatusActive,
+		Metadata: map[string]any{"token": "old-token"},
+		Storage:  storage,
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	executeDone := make(chan error, 1)
+	go func() {
+		_, errExecute := manager.Execute(context.Background(), []string{"antigravity"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+		executeDone <- errExecute
+	}()
+	select {
+	case <-executor.executeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("credits fallback did not start")
+	}
+
+	replacement := &Auth{
+		ID:       authID,
+		Provider: "antigravity",
+		Status:   StatusActive,
+		Metadata: map[string]any{"token": "replacement-token"},
+		Storage:  storage,
+		ModelStates: map[string]*ModelState{
+			model: {Status: StatusActive},
+		},
+	}
+	if _, errUpdate := manager.Update(context.Background(), replacement); errUpdate != nil {
+		t.Fatalf("update replacement: %v", errUpdate)
+	}
+	close(executor.executeRelease)
+	select {
+	case errExecute := <-executeDone:
+		if errExecute == nil {
+			t.Fatal("Execute() error = nil, want exhausted fallback")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Execute() did not finish")
+	}
+
+	current, okCurrent := manager.GetByID(authID)
+	if !okCurrent || current == nil {
+		t.Fatal("replacement auth missing")
+	}
+	if token, _ := current.Metadata["token"].(string); token != "replacement-token" {
+		t.Fatalf("replacement token = %q, want replacement-token", token)
+	}
+	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+		t.Fatalf("late unauthorized result changed replacement auth: %#v", current)
+	}
+	state := current.ModelStates[model]
+	if state == nil || state.Status != StatusActive || state.Unavailable || state.LastError != nil || state.StatusMessage != "" {
+		t.Fatalf("late unauthorized result changed replacement model state: %#v", state)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -60,6 +60,8 @@ type Result struct {
 
 	credentialFingerprint    [sha256.Size]byte
 	hasCredentialFingerprint bool
+	credentialGeneration     uint64
+	hasCredentialGeneration  bool
 }
 
 // Selector chooses an auth candidate for execution.
@@ -115,6 +117,7 @@ type Manager struct {
 	mu                        sync.RWMutex
 	configCooldownMu          sync.Mutex
 	auths                     map[string]*Auth
+	authGeneration            atomic.Uint64
 	scheduler                 *authScheduler
 	// pluginScheduler runs outside m.mu before falling back to native selection.
 	pluginScheduler PluginScheduler

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -56,6 +57,9 @@ type Result struct {
 	RetryAfter *time.Duration
 	// Error describes the failure when Success is false.
 	Error *Error
+
+	credentialFingerprint    [sha256.Size]byte
+	hasCredentialFingerprint bool
 }
 
 // Selector chooses an auth candidate for execution.

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -62,6 +62,7 @@ type Result struct {
 	hasCredentialFingerprint bool
 	credentialGeneration     uint64
 	hasCredentialGeneration  bool
+	credentialRevisionScope  authCredentialRevisionScope
 }
 
 // Selector chooses an auth candidate for execution.

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1,16 +1,21 @@
 package auth
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"reflect"
 	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
 
+	baseauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
@@ -690,6 +695,361 @@ func cooldownReason(statusMessage string, quota QuotaState, lastErr *Error) stri
 	return ""
 }
 
+func authServiceAccountCredential(auth *Auth) string {
+	if auth == nil || auth.Metadata == nil {
+		return ""
+	}
+	raw, ok := auth.Metadata["service_account"]
+	if !ok || raw == nil {
+		return ""
+	}
+	encoded, errMarshal := json.Marshal(raw)
+	if errMarshal != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+func authRawJSONCredential(auth *Auth) string {
+	if auth == nil || auth.Storage == nil {
+		return ""
+	}
+	source, ok := auth.Storage.(interface{ RawJSON() []byte })
+	if !ok {
+		return ""
+	}
+	raw := bytes.TrimSpace(source.RawJSON())
+	if len(raw) == 0 {
+		return ""
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if errDecode := decoder.Decode(&value); errDecode != nil {
+		return string(raw)
+	}
+	var trailing any
+	if errTrailing := decoder.Decode(&trailing); errTrailing != io.EOF {
+		return string(raw)
+	}
+	canonical, errMarshal := json.Marshal(value)
+	if errMarshal != nil {
+		return string(raw)
+	}
+	return string(canonical)
+}
+
+func authCredentialHeaderMaterial(auth *Auth) []string {
+	if auth == nil || len(auth.Attributes) == 0 {
+		return nil
+	}
+	material := make([]string, 0)
+	for key, value := range auth.Attributes {
+		if !strings.HasPrefix(key, "header:") {
+			continue
+		}
+		name := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(key, "header:")))
+		if !authHeaderCarriesCredential(name) {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		material = append(material, name+"="+value)
+	}
+	sort.Strings(material)
+	return material
+}
+
+func authHeaderCarriesCredential(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	switch {
+	case strings.Contains(name, "authorization"),
+		strings.Contains(name, "api-key"),
+		strings.Contains(name, "apikey"),
+		strings.Contains(name, "api_key"),
+		strings.Contains(name, "token"),
+		strings.Contains(name, "secret"),
+		name == "cookie":
+		return true
+	default:
+		return false
+	}
+}
+
+func authCredentialFingerprint(auth *Auth) ([sha256.Size]byte, bool) {
+	if auth == nil {
+		return [sha256.Size]byte{}, false
+	}
+	firstCredential := func(values ...string) string {
+		for _, value := range values {
+			if value = strings.TrimSpace(value); value != "" {
+				return value
+			}
+		}
+		return ""
+	}
+	material := baseauth.CredentialFingerprintMaterial{
+		APIKey: firstCredential(
+			authAttribute(auth, AttributeAPIKey),
+			authMetadataString(auth, AttributeAPIKey),
+		),
+		AccessToken: authAccessToken(auth),
+		RefreshToken: firstCredential(
+			authMetadataString(auth, "refresh_token"),
+			authMetadataString(auth, "refreshToken"),
+		),
+		IDToken: firstCredential(
+			authMetadataString(auth, "id_token"),
+			authMetadataString(auth, "idToken"),
+		),
+	}
+	storageHasCredential := false
+	if source, ok := auth.Storage.(baseauth.CredentialFingerprintSource); ok && source != nil {
+		stored := source.CredentialFingerprintMaterial()
+		stored.APIKey = strings.TrimSpace(stored.APIKey)
+		stored.AccessToken = strings.TrimSpace(stored.AccessToken)
+		stored.RefreshToken = strings.TrimSpace(stored.RefreshToken)
+		stored.IDToken = strings.TrimSpace(stored.IDToken)
+		stored.Opaque = strings.TrimSpace(stored.Opaque)
+		storageHasCredential = stored != (baseauth.CredentialFingerprintMaterial{})
+		if material.APIKey == "" {
+			material.APIKey = stored.APIKey
+		}
+		if material.AccessToken == "" {
+			material.AccessToken = stored.AccessToken
+		}
+		if material.RefreshToken == "" {
+			material.RefreshToken = stored.RefreshToken
+		}
+		if material.IDToken == "" {
+			material.IDToken = stored.IDToken
+		}
+		material.Opaque = stored.Opaque
+	}
+
+	kind := auth.AuthKind()
+	if kind == "" {
+		switch {
+		case material.APIKey != "":
+			kind = AuthKindAPIKey
+		case material.AccessToken != "" || material.RefreshToken != "" || material.IDToken != "":
+			kind = AuthKindOAuth
+		}
+	}
+	parts := []string{
+		"provider=" + strings.ToLower(strings.TrimSpace(auth.Provider)),
+		"kind=" + kind,
+	}
+	credentialCount := 0
+	appendCredential := func(name, value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		parts = append(parts, name+"="+value)
+		credentialCount++
+	}
+
+	switch kind {
+	case AuthKindAPIKey:
+		appendCredential("api_key", material.APIKey)
+	case AuthKindOAuth:
+		appendCredential("access_token", material.AccessToken)
+		appendCredential("refresh_token", material.RefreshToken)
+		appendCredential("id_token", material.IDToken)
+	default:
+		appendCredential("api_key", material.APIKey)
+		appendCredential("access_token", material.AccessToken)
+		appendCredential("refresh_token", material.RefreshToken)
+		appendCredential("id_token", material.IDToken)
+	}
+	for _, header := range authCredentialHeaderMaterial(auth) {
+		appendCredential("header", header)
+	}
+	appendCredential("service_account", authServiceAccountCredential(auth))
+	appendCredential("opaque_storage", material.Opaque)
+	if !storageHasCredential {
+		appendCredential("raw_storage_json", authRawJSONCredential(auth))
+	}
+	if credentialCount == 0 {
+		return [sha256.Size]byte{}, false
+	}
+	return sha256.Sum256([]byte(strings.Join(parts, "\x00"))), true
+}
+
+func sameCredentialRevision(left, right *Auth, sameGeneration bool) bool {
+	leftFingerprint, leftOK := authCredentialFingerprint(left)
+	rightFingerprint, rightOK := authCredentialFingerprint(right)
+	if leftOK || rightOK {
+		return leftOK && rightOK && leftFingerprint == rightFingerprint
+	}
+	return sameGeneration
+}
+
+func sameReferenceValue(left, right any) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	leftValue := reflect.ValueOf(left)
+	rightValue := reflect.ValueOf(right)
+	if leftValue.Type() != rightValue.Type() {
+		return false
+	}
+	switch leftValue.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+		return leftValue.Pointer() == rightValue.Pointer()
+	default:
+		if leftValue.Comparable() {
+			return leftValue.Interface() == rightValue.Interface()
+		}
+		return false
+	}
+}
+
+func refreshLifecycleUnchanged(current, before *Auth) bool {
+	if current == nil || before == nil {
+		return false
+	}
+	return current.Disabled == before.Disabled &&
+		current.Status == before.Status &&
+		current.StatusMessage == before.StatusMessage &&
+		current.Unavailable == before.Unavailable &&
+		current.NextRetryAfter.Equal(before.NextRetryAfter) &&
+		reflect.DeepEqual(current.Quota, before.Quota) &&
+		reflect.DeepEqual(current.LastError, before.LastError) &&
+		reflect.DeepEqual(current.ModelStates, before.ModelStates)
+}
+
+func mergeRefreshMetadata(current, before, refreshed map[string]any) map[string]any {
+	merged := make(map[string]any, len(current)+len(refreshed))
+	for key, value := range current {
+		merged[key] = value
+	}
+	keys := make(map[string]struct{}, len(before)+len(refreshed))
+	for key := range before {
+		keys[key] = struct{}{}
+	}
+	for key := range refreshed {
+		keys[key] = struct{}{}
+	}
+	for key := range keys {
+		beforeValue, beforeOK := before[key]
+		refreshedValue, refreshedOK := refreshed[key]
+		if beforeOK == refreshedOK && reflect.DeepEqual(beforeValue, refreshedValue) {
+			continue
+		}
+		currentValue, currentOK := current[key]
+		if currentOK != beforeOK || !reflect.DeepEqual(currentValue, beforeValue) {
+			continue
+		}
+		if refreshedOK {
+			merged[key] = refreshedValue
+		} else {
+			delete(merged, key)
+		}
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+func mergeRefreshAttributes(current, before, refreshed map[string]string) map[string]string {
+	merged := make(map[string]string, len(current)+len(refreshed))
+	for key, value := range current {
+		merged[key] = value
+	}
+	keys := make(map[string]struct{}, len(before)+len(refreshed))
+	for key := range before {
+		keys[key] = struct{}{}
+	}
+	for key := range refreshed {
+		keys[key] = struct{}{}
+	}
+	for key := range keys {
+		beforeValue, beforeOK := before[key]
+		refreshedValue, refreshedOK := refreshed[key]
+		if beforeOK == refreshedOK && beforeValue == refreshedValue {
+			continue
+		}
+		currentValue, currentOK := current[key]
+		if currentOK != beforeOK || currentValue != beforeValue {
+			continue
+		}
+		if refreshedOK {
+			merged[key] = refreshedValue
+		} else {
+			delete(merged, key)
+		}
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+func mergeCredentialRefresh(current, before, refreshed *Auth) *Auth {
+	if current == nil {
+		return nil
+	}
+	merged := current.Clone()
+	if before == nil || refreshed == nil {
+		return merged
+	}
+	merged.Metadata = mergeRefreshMetadata(current.Metadata, before.Metadata, refreshed.Metadata)
+	merged.Attributes = mergeRefreshAttributes(current.Attributes, before.Attributes, refreshed.Attributes)
+	if current.Prefix == before.Prefix && refreshed.Prefix != before.Prefix {
+		merged.Prefix = refreshed.Prefix
+	}
+	if current.FileName == before.FileName && refreshed.FileName != before.FileName {
+		merged.FileName = refreshed.FileName
+	}
+	if current.Label == before.Label && refreshed.Label != before.Label {
+		merged.Label = refreshed.Label
+	}
+	if current.ProxyURL == before.ProxyURL && refreshed.ProxyURL != before.ProxyURL {
+		merged.ProxyURL = refreshed.ProxyURL
+	}
+	if current.Disabled == before.Disabled && refreshed.Disabled != before.Disabled {
+		merged.Disabled = refreshed.Disabled
+	}
+	if current.Unavailable == before.Unavailable && refreshed.Unavailable != before.Unavailable {
+		merged.Unavailable = refreshed.Unavailable
+	}
+	if current.Status == before.Status && refreshed.Status != before.Status {
+		merged.Status = refreshed.Status
+	}
+	if current.StatusMessage == before.StatusMessage && refreshed.StatusMessage != before.StatusMessage {
+		merged.StatusMessage = refreshed.StatusMessage
+	}
+	if current.NextRetryAfter.Equal(before.NextRetryAfter) && !refreshed.NextRetryAfter.Equal(before.NextRetryAfter) {
+		merged.NextRetryAfter = refreshed.NextRetryAfter
+	}
+	if reflect.DeepEqual(current.Quota, before.Quota) && !reflect.DeepEqual(refreshed.Quota, before.Quota) {
+		merged.Quota = refreshed.Quota
+	}
+	if reflect.DeepEqual(current.LastError, before.LastError) && !reflect.DeepEqual(refreshed.LastError, before.LastError) {
+		merged.LastError = cloneError(refreshed.LastError)
+	}
+	if reflect.DeepEqual(current.ModelStates, before.ModelStates) && !reflect.DeepEqual(refreshed.ModelStates, before.ModelStates) {
+		merged.ModelStates = refreshed.Clone().ModelStates
+	}
+	// applyCredentialRefresh has already verified that the current credential
+	// revision still matches before. Equivalent hot reloads may replace the
+	// storage object for noncredential changes, so pointer identity is not an
+	// ownership signal here.
+	if !sameReferenceValue(refreshed.Storage, before.Storage) {
+		merged.Storage = refreshed.Storage
+	}
+	if sameReferenceValue(current.Runtime, before.Runtime) && !sameReferenceValue(refreshed.Runtime, before.Runtime) {
+		merged.Runtime = refreshed.Runtime
+	}
+	return merged
+}
+
 // MarkResult records an execution result and notifies hooks.
 func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	if result.AuthID == "" {
@@ -703,6 +1063,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	setModelQuota := false
 	var authSnapshot *Auth
 	cooldownStateChanged := false
+	suppressErrorEvent := false
 
 	m.mu.Lock()
 	if auth, ok := m.auths[result.AuthID]; ok && auth != nil {
@@ -719,7 +1080,16 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			auth.Failed++
 		}
 
-		if result.Success {
+		staleCredentialResult := false
+		if result.hasCredentialFingerprint {
+			currentFingerprint, okFingerprint := authCredentialFingerprint(auth)
+			staleCredentialResult = !okFingerprint || currentFingerprint != result.credentialFingerprint
+		}
+		staleUnauthorizedResult := staleCredentialResult && !result.Success && isUnauthorizedError(result.Error)
+		if staleUnauthorizedResult {
+			authSnapshot = auth.Clone()
+			suppressErrorEvent = true
+		} else if result.Success {
 			if result.Model != "" {
 				state := ensureModelState(auth, result.Model)
 				resetModelState(state, now)
@@ -879,11 +1249,116 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	}
 
 	m.hook.OnResult(ctx, result)
-	m.publishErrorEvent(result, authSnapshot)
+	if !suppressErrorEvent {
+		m.publishErrorEvent(result, authSnapshot)
+	}
+}
+
+type authCredentialRevision struct {
+	fingerprint    [sha256.Size]byte
+	hasFingerprint bool
+}
+
+func captureAuthCredentialRevision(auth *Auth) authCredentialRevision {
+	fingerprint, ok := authCredentialFingerprint(auth)
+	return authCredentialRevision{fingerprint: fingerprint, hasFingerprint: ok}
+}
+
+type executionCredentialStorage struct {
+	rawJSON     []byte
+	fingerprint baseauth.CredentialFingerprintMaterial
+}
+
+func (s *executionCredentialStorage) RawJSON() []byte {
+	if s == nil {
+		return nil
+	}
+	return bytes.Clone(s.rawJSON)
+}
+
+func (s *executionCredentialStorage) CredentialFingerprintMaterial() baseauth.CredentialFingerprintMaterial {
+	if s == nil {
+		return baseauth.CredentialFingerprintMaterial{}
+	}
+	return s.fingerprint
+}
+
+func (*executionCredentialStorage) SaveTokenToFile(string) error {
+	return errors.New("execution credential snapshot is read-only")
+}
+
+func cloneCredentialMetadataValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		cloned := make(map[string]any, len(typed))
+		for key, item := range typed {
+			cloned[key] = cloneCredentialMetadataValue(item)
+		}
+		return cloned
+	case []any:
+		cloned := make([]any, len(typed))
+		for i, item := range typed {
+			cloned[i] = cloneCredentialMetadataValue(item)
+		}
+		return cloned
+	case map[string]string:
+		cloned := make(map[string]string, len(typed))
+		for key, item := range typed {
+			cloned[key] = item
+		}
+		return cloned
+	case []string:
+		cloned := make([]string, len(typed))
+		copy(cloned, typed)
+		return cloned
+	default:
+		return value
+	}
+}
+
+func snapshotAuthCredential(auth *Auth) (*Auth, authCredentialRevision) {
+	snapshot := auth.Clone()
+	if snapshot == nil {
+		return nil, authCredentialRevision{}
+	}
+
+	if source, ok := snapshot.Storage.(baseauth.CredentialSnapshotSource); ok && source != nil {
+		rawJSON, metadata, fingerprint := source.CredentialSnapshot()
+		if metadata == nil {
+			snapshot.Metadata = nil
+		} else {
+			snapshot.Metadata = cloneCredentialMetadataValue(metadata).(map[string]any)
+		}
+		snapshot.Storage = &executionCredentialStorage{
+			rawJSON:     bytes.Clone(rawJSON),
+			fingerprint: fingerprint,
+		}
+	} else {
+		var fingerprint baseauth.CredentialFingerprintMaterial
+		if source, okFingerprint := snapshot.Storage.(baseauth.CredentialFingerprintSource); okFingerprint && source != nil {
+			fingerprint = source.CredentialFingerprintMaterial()
+		}
+		if source, okRawJSON := snapshot.Storage.(interface{ RawJSON() []byte }); okRawJSON {
+			snapshot.Storage = &executionCredentialStorage{
+				rawJSON:     bytes.Clone(source.RawJSON()),
+				fingerprint: fingerprint,
+			}
+		}
+	}
+	if serviceAccount, ok := snapshot.Metadata["service_account"]; ok {
+		snapshot.Metadata["service_account"] = cloneCredentialMetadataValue(serviceAccount)
+	}
+	return snapshot, captureAuthCredentialRevision(snapshot)
 }
 
 func (m *Manager) recordExecutionResult(ctx context.Context, result Result, auth *Auth, ephemeral bool) {
+	m.recordExecutionResultWithRevision(ctx, result, auth, ephemeral, captureAuthCredentialRevision(auth))
+}
+
+func (m *Manager) recordExecutionResultWithRevision(ctx context.Context, result Result, auth *Auth, ephemeral bool, revision authCredentialRevision) {
 	if !ephemeral {
+		result.credentialFingerprint = revision.fingerprint
+		result.hasCredentialFingerprint = revision.hasFingerprint
 		m.MarkResult(ctx, result)
 		return
 	}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1094,12 +1094,12 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			staleCredentialResult = auth.credentialGeneration == 0 || auth.credentialGeneration != result.credentialGeneration
 		}
 		staleSuccessfulResult := staleCredentialResult && result.Success
-		staleUnauthorizedResult := staleCredentialResult && !result.Success && isUnauthorizedError(result.Error)
-		if staleSuccessfulResult || staleUnauthorizedResult {
+		staleAvailabilityFailure := staleCredentialResult && !result.Success && isCredentialScopedAvailabilityError(result.Error)
+		if staleSuccessfulResult || staleAvailabilityFailure {
 			// Keep request metrics, but never let a superseded credential change
 			// availability owned by its replacement.
 			authSnapshot = auth.Clone()
-			suppressErrorEvent = staleUnauthorizedResult
+			suppressErrorEvent = staleAvailabilityFailure
 		} else if result.Success {
 			if modelKey != "" {
 				state := ensureModelState(auth, modelKey)
@@ -1857,6 +1857,18 @@ func retryAfterFromError(err error) *time.Duration {
 	}
 	value := *retryAfter
 	return &value
+}
+
+func isCredentialScopedAvailabilityError(err *Error) bool {
+	if isUnauthorizedError(err) {
+		return true
+	}
+	switch statusCodeFromResult(err) {
+	case http.StatusPaymentRequired, http.StatusForbidden, http.StatusTooManyRequests:
+		return true
+	default:
+		return false
+	}
 }
 
 func statusCodeFromResult(err *Error) int {

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -755,7 +755,7 @@ func authCredentialHeaderMaterial(auth *Auth) []string {
 			continue
 		}
 		name := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(key, "header:")))
-		if !authHeaderCarriesCredential(name) {
+		if !authHeaderCarriesCredential(name) && !authHeaderCarriesAuthorizationScope(name) {
 			continue
 		}
 		value = strings.TrimSpace(value)
@@ -784,6 +784,24 @@ func authHeaderCarriesCredential(name string) bool {
 	}
 }
 
+func authHeaderCarriesAuthorizationScope(name string) bool {
+	normalized := normalizeAuthorizationScopeHeaderName(name)
+	switch normalized {
+	case "organization", "organisation", "project", "tenant", "workspace", "team", "subscription",
+		"openaiorganization", "openaiproject", "chatgptaccountid", "xgooguserproject":
+		return true
+	}
+	for _, suffix := range []string{
+		"organizationid", "organisationid", "projectid", "accountid",
+		"tenantid", "workspaceid", "teamid", "subscriptionid",
+	} {
+		if strings.HasSuffix(normalized, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
 func authCredentialEndpoint(auth *Auth) string {
 	if auth == nil {
 		return ""
@@ -796,9 +814,6 @@ func authCredentialEndpoint(auth *Auth) string {
 			// Both executors resolve metadata base_url only when the attribute is absent.
 			endpoint = strings.TrimSpace(authMetadataString(auth, "base_url"))
 		}
-	}
-	if provider == "xai" {
-		endpoint = authXAIEffectiveChatEndpoint(auth, endpoint)
 	}
 	return normalizeCredentialEndpoint(endpoint)
 }
@@ -1064,6 +1079,28 @@ func authCredentialFingerprint(auth *Auth) ([sha256.Size]byte, bool) {
 	return sha256.Sum256([]byte(strings.Join(parts, "\x00"))), true
 }
 
+type authCredentialRevisionScope uint8
+
+const (
+	authCredentialRevisionScopeDefault authCredentialRevisionScope = iota
+	authCredentialRevisionScopeXAIHTTPChat
+)
+
+func authCredentialFingerprintForScope(auth *Auth, scope authCredentialRevisionScope) ([sha256.Size]byte, bool) {
+	fingerprint, ok := authCredentialFingerprint(auth)
+	if !ok || scope != authCredentialRevisionScopeXAIHTTPChat || auth == nil ||
+		!strings.EqualFold(strings.TrimSpace(auth.Provider), "xai") {
+		return fingerprint, ok
+	}
+	route := normalizeCredentialEndpoint(authXAIEffectiveChatEndpoint(auth, authCredentialEndpoint(auth)))
+	scoped := make([]byte, 0, sha256.Size+len(route)+24)
+	scoped = append(scoped, fingerprint[:]...)
+	scoped = append(scoped, 0)
+	scoped = append(scoped, "xai_http_chat_route="...)
+	scoped = append(scoped, route...)
+	return sha256.Sum256(scoped), true
+}
+
 func sameCredentialRevision(left, right *Auth, sameGeneration bool) bool {
 	leftFingerprint, leftOK := authCredentialFingerprint(left)
 	rightFingerprint, rightOK := authCredentialFingerprint(right)
@@ -1267,7 +1304,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 
 		staleCredentialResult := false
 		if result.hasCredentialFingerprint {
-			currentFingerprint, okFingerprint := authCredentialFingerprint(auth)
+			currentFingerprint, okFingerprint := authCredentialFingerprintForScope(auth, result.credentialRevisionScope)
 			staleCredentialResult = !okFingerprint || currentFingerprint != result.credentialFingerprint
 		} else if result.hasCredentialGeneration {
 			staleCredentialResult = auth.credentialGeneration == 0 || auth.credentialGeneration != result.credentialGeneration
@@ -1448,15 +1485,99 @@ type authCredentialRevision struct {
 	fingerprint    [sha256.Size]byte
 	hasFingerprint bool
 	generation     uint64
+	scope          authCredentialRevisionScope
 }
 
 func captureAuthCredentialRevision(auth *Auth) authCredentialRevision {
-	fingerprint, ok := authCredentialFingerprint(auth)
+	return captureAuthCredentialRevisionWithScope(auth, authCredentialRevisionScopeDefault)
+}
+
+func captureAuthCredentialRevisionWithScope(auth *Auth, scope authCredentialRevisionScope) authCredentialRevision {
+	fingerprint, ok := authCredentialFingerprintForScope(auth, scope)
 	var generation uint64
 	if auth != nil {
 		generation = auth.credentialGeneration
 	}
-	return authCredentialRevision{fingerprint: fingerprint, hasFingerprint: ok, generation: generation}
+	return authCredentialRevision{fingerprint: fingerprint, hasFingerprint: ok, generation: generation, scope: scope}
+}
+
+func captureAuthCredentialRevisionForExecution(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) authCredentialRevision {
+	scope := authCredentialRevisionScopeForExecution(ctx, auth, req, opts)
+	return captureAuthCredentialRevisionWithScope(auth, scope)
+}
+
+func authCredentialRevisionScopeForExecution(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) authCredentialRevisionScope {
+	if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "xai") {
+		return authCredentialRevisionScopeDefault
+	}
+	if opts.Alt == "responses/compact" || authXAIExecutionIsMedia(req, opts) {
+		return authCredentialRevisionScopeDefault
+	}
+	if cliproxyexecutor.RequiredUpstreamWebsocket(ctx) ||
+		(cliproxyexecutor.DownstreamWebsocket(ctx) && authXAIWebsocketsEnabled(auth)) {
+		return authCredentialRevisionScopeDefault
+	}
+	return authCredentialRevisionScopeXAIHTTPChat
+}
+
+func authXAIExecutionIsMedia(req cliproxyexecutor.Request, opts cliproxyexecutor.Options) bool {
+	for _, format := range []string{opts.SourceFormat.String(), req.Format.String()} {
+		switch strings.ToLower(strings.TrimSpace(format)) {
+		case "openai-image", "openai-video":
+			return true
+		}
+	}
+	for _, metadata := range []map[string]any{opts.Metadata, req.Metadata} {
+		path := strings.ToLower(strings.TrimSpace(authExecutionMetadataString(metadata, cliproxyexecutor.RequestPathMetadataKey)))
+		if path == "" {
+			continue
+		}
+		if parsed, errParse := url.Parse(path); errParse == nil && parsed.Path != "" {
+			path = strings.ToLower(strings.TrimSpace(parsed.Path))
+		}
+		if strings.Contains(path, "/images/") || strings.HasSuffix(path, "/images") ||
+			strings.Contains(path, "/videos/") || strings.HasSuffix(path, "/videos") {
+			return true
+		}
+	}
+	return false
+}
+
+func authExecutionMetadataString(metadata map[string]any, key string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	switch value := metadata[key].(type) {
+	case string:
+		return value
+	case []byte:
+		return string(value)
+	default:
+		return ""
+	}
+}
+
+func authXAIWebsocketsEnabled(auth *Auth) bool {
+	if auth == nil {
+		return false
+	}
+	if raw := strings.TrimSpace(authAttribute(auth, "websockets")); raw != "" {
+		if parsed, errParse := strconv.ParseBool(raw); errParse == nil {
+			return parsed
+		}
+	}
+	if auth.Metadata == nil {
+		return false
+	}
+	switch value := auth.Metadata["websockets"].(type) {
+	case bool:
+		return value
+	case string:
+		parsed, errParse := strconv.ParseBool(strings.TrimSpace(value))
+		return errParse == nil && parsed
+	default:
+		return false
+	}
 }
 
 type executionCredentialStorage struct {
@@ -1546,6 +1667,14 @@ func snapshotAuthCredential(auth *Auth) (*Auth, authCredentialRevision) {
 	return snapshot, captureAuthCredentialRevision(snapshot)
 }
 
+func snapshotAuthCredentialForExecution(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*Auth, authCredentialRevision) {
+	snapshot, _ := snapshotAuthCredential(auth)
+	if snapshot == nil {
+		return nil, authCredentialRevision{}
+	}
+	return snapshot, captureAuthCredentialRevisionForExecution(ctx, snapshot, req, opts)
+}
+
 func (m *Manager) recordExecutionResult(ctx context.Context, result Result, auth *Auth, ephemeral bool) {
 	m.recordExecutionResultWithRevision(ctx, result, auth, ephemeral, captureAuthCredentialRevision(auth))
 }
@@ -1556,6 +1685,7 @@ func (m *Manager) recordExecutionResultWithRevision(ctx context.Context, result 
 		result.hasCredentialFingerprint = revision.hasFingerprint
 		result.credentialGeneration = revision.generation
 		result.hasCredentialGeneration = revision.generation != 0
+		result.credentialRevisionScope = revision.scope
 		m.MarkResult(ctx, result)
 		return
 	}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1090,6 +1090,8 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 		if result.hasCredentialFingerprint {
 			currentFingerprint, okFingerprint := authCredentialFingerprint(auth)
 			staleCredentialResult = !okFingerprint || currentFingerprint != result.credentialFingerprint
+		} else if result.hasCredentialGeneration {
+			staleCredentialResult = auth.credentialGeneration == 0 || auth.credentialGeneration != result.credentialGeneration
 		}
 		staleSuccessfulResult := staleCredentialResult && result.Success
 		staleUnauthorizedResult := staleCredentialResult && !result.Success && isUnauthorizedError(result.Error)
@@ -1266,11 +1268,16 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 type authCredentialRevision struct {
 	fingerprint    [sha256.Size]byte
 	hasFingerprint bool
+	generation     uint64
 }
 
 func captureAuthCredentialRevision(auth *Auth) authCredentialRevision {
 	fingerprint, ok := authCredentialFingerprint(auth)
-	return authCredentialRevision{fingerprint: fingerprint, hasFingerprint: ok}
+	var generation uint64
+	if auth != nil {
+		generation = auth.credentialGeneration
+	}
+	return authCredentialRevision{fingerprint: fingerprint, hasFingerprint: ok, generation: generation}
 }
 
 type executionCredentialStorage struct {
@@ -1368,6 +1375,8 @@ func (m *Manager) recordExecutionResultWithRevision(ctx context.Context, result 
 	if !ephemeral {
 		result.credentialFingerprint = revision.fingerprint
 		result.hasCredentialFingerprint = revision.hasFingerprint
+		result.credentialGeneration = revision.generation
+		result.hasCredentialGeneration = revision.generation != 0
 		m.MarkResult(ctx, result)
 		return
 	}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1088,10 +1088,13 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			currentFingerprint, okFingerprint := authCredentialFingerprint(auth)
 			staleCredentialResult = !okFingerprint || currentFingerprint != result.credentialFingerprint
 		}
+		staleSuccessfulResult := staleCredentialResult && result.Success
 		staleUnauthorizedResult := staleCredentialResult && !result.Success && isUnauthorizedError(result.Error)
-		if staleUnauthorizedResult {
+		if staleSuccessfulResult || staleUnauthorizedResult {
+			// Keep request metrics, but never let a superseded credential change
+			// availability owned by its replacement.
 			authSnapshot = auth.Clone()
-			suppressErrorEvent = true
+			suppressErrorEvent = staleUnauthorizedResult
 		} else if result.Success {
 			if modelKey != "" {
 				state := ensureModelState(auth, modelKey)

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -855,21 +855,33 @@ func authCredentialFingerprint(auth *Auth) ([sha256.Size]byte, bool) {
 		credentialCount++
 	}
 
-	switch kind {
-	case AuthKindAPIKey:
-		appendCredential("api_key", material.APIKey)
-	case AuthKindOAuth:
-		// Some OAuth-classified credentials execute with Attributes["api_key"]
-		// (for example Claude), so that material remains revision-authoritative.
-		appendCredential("api_key", material.APIKey)
-		appendCredential("access_token", material.AccessToken)
+	if strings.EqualFold(strings.TrimSpace(auth.Provider), "kimi") {
+		// Kimi prefers access_token (metadata, then attributes) before api_key.
+		// Fingerprint the credential it will execute with, plus refresh identity.
+		if material.AccessToken != "" {
+			appendCredential("access_token", material.AccessToken)
+		} else {
+			appendCredential("api_key", material.APIKey)
+		}
 		appendCredential("refresh_token", material.RefreshToken)
 		appendCredential("id_token", material.IDToken)
-	default:
-		appendCredential("api_key", material.APIKey)
-		appendCredential("access_token", material.AccessToken)
-		appendCredential("refresh_token", material.RefreshToken)
-		appendCredential("id_token", material.IDToken)
+	} else {
+		switch kind {
+		case AuthKindAPIKey:
+			appendCredential("api_key", material.APIKey)
+		case AuthKindOAuth:
+			// Some OAuth-classified credentials execute with Attributes["api_key"]
+			// (for example Claude), so that material remains revision-authoritative.
+			appendCredential("api_key", material.APIKey)
+			appendCredential("access_token", material.AccessToken)
+			appendCredential("refresh_token", material.RefreshToken)
+			appendCredential("id_token", material.IDToken)
+		default:
+			appendCredential("api_key", material.APIKey)
+			appendCredential("access_token", material.AccessToken)
+			appendCredential("refresh_token", material.RefreshToken)
+			appendCredential("id_token", material.IDToken)
+		}
 	}
 	for _, header := range authCredentialHeaderMaterial(auth) {
 		appendCredential("header", header)

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -859,6 +859,9 @@ func authCredentialFingerprint(auth *Auth) ([sha256.Size]byte, bool) {
 	case AuthKindAPIKey:
 		appendCredential("api_key", material.APIKey)
 	case AuthKindOAuth:
+		// Some OAuth-classified credentials execute with Attributes["api_key"]
+		// (for example Claude), so that material remains revision-authoritative.
+		appendCredential("api_key", material.APIKey)
 		appendCredential("access_token", material.AccessToken)
 		appendCredential("refresh_token", material.RefreshToken)
 		appendCredential("id_token", material.IDToken)

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -783,17 +783,78 @@ func authHeaderCarriesCredential(name string) bool {
 }
 
 func authCredentialEndpoint(auth *Auth) string {
-	endpoint := strings.TrimRight(strings.TrimSpace(authAttribute(auth, "base_url")), "/")
+	if auth == nil {
+		return ""
+	}
+	endpoint := strings.TrimSpace(authAttribute(auth, "base_url"))
+	if endpoint == "" && strings.EqualFold(strings.TrimSpace(auth.Provider), "antigravity") {
+		// Antigravity resolves metadata base_url only when the attribute is absent.
+		endpoint = strings.TrimSpace(authMetadataString(auth, "base_url"))
+	}
 	if endpoint == "" {
 		return ""
 	}
 	parsed, errParse := url.Parse(endpoint)
 	if errParse != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return endpoint
+		return strings.TrimRight(endpoint, "/")
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	parsed.Host = strings.ToLower(parsed.Host)
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	parsed.RawPath = strings.TrimRight(parsed.RawPath, "/")
 	return parsed.String()
+}
+
+func normalizeAuthorizationScopeHeaderName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	replacer := strings.NewReplacer("-", "", "_", "", " ", "")
+	return replacer.Replace(name)
+}
+
+func authCustomHeaderValues(auth *Auth, normalizedName string) []string {
+	if auth == nil || len(auth.Attributes) == 0 || normalizedName == "" {
+		return nil
+	}
+	unique := make(map[string]struct{})
+	for key, value := range auth.Attributes {
+		if !strings.HasPrefix(key, "header:") {
+			continue
+		}
+		name := strings.TrimPrefix(key, "header:")
+		if normalizeAuthorizationScopeHeaderName(name) != normalizedName {
+			continue
+		}
+		if value = strings.TrimSpace(value); value != "" {
+			unique[value] = struct{}{}
+		}
+	}
+	values := make([]string, 0, len(unique))
+	for value := range unique {
+		values = append(values, value)
+	}
+	sort.Strings(values)
+	return values
+}
+
+func authAuthorizationScopeMaterial(auth *Auth) []string {
+	if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return nil
+	}
+	if customAccounts := authCustomHeaderValues(auth, "chatgptaccountid"); len(customAccounts) > 0 {
+		material := make([]string, 0, len(customAccounts))
+		for _, accountID := range customAccounts {
+			material = append(material, "account_header="+accountID)
+		}
+		return material
+	}
+	// The Codex executor suppresses its metadata account header for API-key auth.
+	if strings.TrimSpace(authAttribute(auth, AttributeAPIKey)) != "" {
+		return nil
+	}
+	if accountID := strings.TrimSpace(authMetadataString(auth, "account_id")); accountID != "" {
+		return []string{"account_id=" + accountID}
+	}
+	return nil
 }
 
 func authCredentialFingerprint(auth *Auth) ([sha256.Size]byte, bool) {
@@ -862,6 +923,9 @@ func authCredentialFingerprint(auth *Auth) ([sha256.Size]byte, bool) {
 	}
 	if endpoint := authCredentialEndpoint(auth); endpoint != "" {
 		parts = append(parts, "endpoint="+endpoint)
+	}
+	for _, scope := range authAuthorizationScopeMaterial(auth) {
+		parts = append(parts, "scope="+scope)
 	}
 	credentialCount := 0
 	appendCredential := func(name, value string) {

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -837,22 +837,51 @@ func authCustomHeaderValues(auth *Auth, normalizedName string) []string {
 }
 
 func authAuthorizationScopeMaterial(auth *Auth) []string {
-	if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+	if auth == nil {
 		return nil
 	}
-	if customAccounts := authCustomHeaderValues(auth, "chatgptaccountid"); len(customAccounts) > 0 {
-		material := make([]string, 0, len(customAccounts))
-		for _, accountID := range customAccounts {
-			material = append(material, "account_header="+accountID)
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	switch provider {
+	case "codex":
+		if customAccounts := authCustomHeaderValues(auth, "chatgptaccountid"); len(customAccounts) > 0 {
+			material := make([]string, 0, len(customAccounts))
+			for _, accountID := range customAccounts {
+				material = append(material, "account_header="+accountID)
+			}
+			return material
 		}
-		return material
-	}
-	// The Codex executor suppresses its metadata account header for API-key auth.
-	if strings.TrimSpace(authAttribute(auth, AttributeAPIKey)) != "" {
-		return nil
-	}
-	if accountID := strings.TrimSpace(authMetadataString(auth, "account_id")); accountID != "" {
-		return []string{"account_id=" + accountID}
+		// The Codex executor suppresses its metadata account header for API-key auth.
+		if strings.TrimSpace(authAttribute(auth, AttributeAPIKey)) != "" {
+			return nil
+		}
+		if accountID := strings.TrimSpace(authMetadataString(auth, "account_id")); accountID != "" {
+			return []string{"account_id=" + accountID}
+		}
+	case "antigravity":
+		if projectID := strings.TrimSpace(authMetadataString(auth, "project_id")); projectID != "" {
+			return []string{"project_id=" + projectID}
+		}
+	case "vertex":
+		// Vertex bypasses project/location when it can execute through its API-key path.
+		if strings.TrimSpace(authAttribute(auth, AttributeAPIKey)) != "" ||
+			strings.TrimSpace(authMetadataString(auth, "access_token")) != "" {
+			return nil
+		}
+		projectID := strings.TrimSpace(authMetadataString(auth, "project_id"))
+		if projectID == "" {
+			projectID = strings.TrimSpace(authMetadataString(auth, "project"))
+		}
+		if projectID == "" {
+			return nil
+		}
+		location := strings.TrimSpace(authMetadataString(auth, "location"))
+		if location == "" {
+			location = "us-central1"
+		}
+		return []string{
+			"project_id=" + projectID,
+			"location=" + location,
+		}
 	}
 	return nil
 }
@@ -1954,7 +1983,7 @@ func retryAfterFromError(err error) *time.Duration {
 }
 
 func isCredentialScopedAvailabilityError(err *Error) bool {
-	if isUnauthorizedError(err) {
+	if isUnauthorizedError(err) || isInvalidGrantResultError(err) {
 		return true
 	}
 	switch statusCodeFromResult(err) {

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -787,9 +787,12 @@ func authCredentialEndpoint(auth *Auth) string {
 		return ""
 	}
 	endpoint := strings.TrimSpace(authAttribute(auth, "base_url"))
-	if endpoint == "" && strings.EqualFold(strings.TrimSpace(auth.Provider), "antigravity") {
-		// Antigravity resolves metadata base_url only when the attribute is absent.
-		endpoint = strings.TrimSpace(authMetadataString(auth, "base_url"))
+	if endpoint == "" {
+		switch strings.ToLower(strings.TrimSpace(auth.Provider)) {
+		case "antigravity", "xai":
+			// Both executors resolve metadata base_url only when the attribute is absent.
+			endpoint = strings.TrimSpace(authMetadataString(auth, "base_url"))
+		}
 	}
 	if endpoint == "" {
 		return ""

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1,18 +1,22 @@
 package auth
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
+	baseauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
@@ -693,6 +697,361 @@ func cooldownReason(statusMessage string, quota QuotaState, lastErr *Error) stri
 	return ""
 }
 
+func authServiceAccountCredential(auth *Auth) string {
+	if auth == nil || auth.Metadata == nil {
+		return ""
+	}
+	raw, ok := auth.Metadata["service_account"]
+	if !ok || raw == nil {
+		return ""
+	}
+	encoded, errMarshal := json.Marshal(raw)
+	if errMarshal != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+func authRawJSONCredential(auth *Auth) string {
+	if auth == nil || auth.Storage == nil {
+		return ""
+	}
+	source, ok := auth.Storage.(interface{ RawJSON() []byte })
+	if !ok {
+		return ""
+	}
+	raw := bytes.TrimSpace(source.RawJSON())
+	if len(raw) == 0 {
+		return ""
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if errDecode := decoder.Decode(&value); errDecode != nil {
+		return string(raw)
+	}
+	var trailing any
+	if errTrailing := decoder.Decode(&trailing); errTrailing != io.EOF {
+		return string(raw)
+	}
+	canonical, errMarshal := json.Marshal(value)
+	if errMarshal != nil {
+		return string(raw)
+	}
+	return string(canonical)
+}
+
+func authCredentialHeaderMaterial(auth *Auth) []string {
+	if auth == nil || len(auth.Attributes) == 0 {
+		return nil
+	}
+	material := make([]string, 0)
+	for key, value := range auth.Attributes {
+		if !strings.HasPrefix(key, "header:") {
+			continue
+		}
+		name := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(key, "header:")))
+		if !authHeaderCarriesCredential(name) {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		material = append(material, name+"="+value)
+	}
+	sort.Strings(material)
+	return material
+}
+
+func authHeaderCarriesCredential(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	switch {
+	case strings.Contains(name, "authorization"),
+		strings.Contains(name, "api-key"),
+		strings.Contains(name, "apikey"),
+		strings.Contains(name, "api_key"),
+		strings.Contains(name, "token"),
+		strings.Contains(name, "secret"),
+		name == "cookie":
+		return true
+	default:
+		return false
+	}
+}
+
+func authCredentialFingerprint(auth *Auth) ([sha256.Size]byte, bool) {
+	if auth == nil {
+		return [sha256.Size]byte{}, false
+	}
+	firstCredential := func(values ...string) string {
+		for _, value := range values {
+			if value = strings.TrimSpace(value); value != "" {
+				return value
+			}
+		}
+		return ""
+	}
+	material := baseauth.CredentialFingerprintMaterial{
+		APIKey: firstCredential(
+			authAttribute(auth, AttributeAPIKey),
+			authMetadataString(auth, AttributeAPIKey),
+		),
+		AccessToken: authAccessToken(auth),
+		RefreshToken: firstCredential(
+			authMetadataString(auth, "refresh_token"),
+			authMetadataString(auth, "refreshToken"),
+		),
+		IDToken: firstCredential(
+			authMetadataString(auth, "id_token"),
+			authMetadataString(auth, "idToken"),
+		),
+	}
+	storageHasCredential := false
+	if source, ok := auth.Storage.(baseauth.CredentialFingerprintSource); ok && source != nil {
+		stored := source.CredentialFingerprintMaterial()
+		stored.APIKey = strings.TrimSpace(stored.APIKey)
+		stored.AccessToken = strings.TrimSpace(stored.AccessToken)
+		stored.RefreshToken = strings.TrimSpace(stored.RefreshToken)
+		stored.IDToken = strings.TrimSpace(stored.IDToken)
+		stored.Opaque = strings.TrimSpace(stored.Opaque)
+		storageHasCredential = stored != (baseauth.CredentialFingerprintMaterial{})
+		if material.APIKey == "" {
+			material.APIKey = stored.APIKey
+		}
+		if material.AccessToken == "" {
+			material.AccessToken = stored.AccessToken
+		}
+		if material.RefreshToken == "" {
+			material.RefreshToken = stored.RefreshToken
+		}
+		if material.IDToken == "" {
+			material.IDToken = stored.IDToken
+		}
+		material.Opaque = stored.Opaque
+	}
+
+	kind := auth.AuthKind()
+	if kind == "" {
+		switch {
+		case material.APIKey != "":
+			kind = AuthKindAPIKey
+		case material.AccessToken != "" || material.RefreshToken != "" || material.IDToken != "":
+			kind = AuthKindOAuth
+		}
+	}
+	parts := []string{
+		"provider=" + strings.ToLower(strings.TrimSpace(auth.Provider)),
+		"kind=" + kind,
+	}
+	credentialCount := 0
+	appendCredential := func(name, value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		parts = append(parts, name+"="+value)
+		credentialCount++
+	}
+
+	switch kind {
+	case AuthKindAPIKey:
+		appendCredential("api_key", material.APIKey)
+	case AuthKindOAuth:
+		appendCredential("access_token", material.AccessToken)
+		appendCredential("refresh_token", material.RefreshToken)
+		appendCredential("id_token", material.IDToken)
+	default:
+		appendCredential("api_key", material.APIKey)
+		appendCredential("access_token", material.AccessToken)
+		appendCredential("refresh_token", material.RefreshToken)
+		appendCredential("id_token", material.IDToken)
+	}
+	for _, header := range authCredentialHeaderMaterial(auth) {
+		appendCredential("header", header)
+	}
+	appendCredential("service_account", authServiceAccountCredential(auth))
+	appendCredential("opaque_storage", material.Opaque)
+	if !storageHasCredential {
+		appendCredential("raw_storage_json", authRawJSONCredential(auth))
+	}
+	if credentialCount == 0 {
+		return [sha256.Size]byte{}, false
+	}
+	return sha256.Sum256([]byte(strings.Join(parts, "\x00"))), true
+}
+
+func sameCredentialRevision(left, right *Auth, sameGeneration bool) bool {
+	leftFingerprint, leftOK := authCredentialFingerprint(left)
+	rightFingerprint, rightOK := authCredentialFingerprint(right)
+	if leftOK || rightOK {
+		return leftOK && rightOK && leftFingerprint == rightFingerprint
+	}
+	return sameGeneration
+}
+
+func sameReferenceValue(left, right any) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	leftValue := reflect.ValueOf(left)
+	rightValue := reflect.ValueOf(right)
+	if leftValue.Type() != rightValue.Type() {
+		return false
+	}
+	switch leftValue.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+		return leftValue.Pointer() == rightValue.Pointer()
+	default:
+		if leftValue.Comparable() {
+			return leftValue.Interface() == rightValue.Interface()
+		}
+		return false
+	}
+}
+
+func refreshLifecycleUnchanged(current, before *Auth) bool {
+	if current == nil || before == nil {
+		return false
+	}
+	return current.Disabled == before.Disabled &&
+		current.Status == before.Status &&
+		current.StatusMessage == before.StatusMessage &&
+		current.Unavailable == before.Unavailable &&
+		current.NextRetryAfter.Equal(before.NextRetryAfter) &&
+		reflect.DeepEqual(current.Quota, before.Quota) &&
+		reflect.DeepEqual(current.LastError, before.LastError) &&
+		reflect.DeepEqual(current.ModelStates, before.ModelStates)
+}
+
+func mergeRefreshMetadata(current, before, refreshed map[string]any) map[string]any {
+	merged := make(map[string]any, len(current)+len(refreshed))
+	for key, value := range current {
+		merged[key] = value
+	}
+	keys := make(map[string]struct{}, len(before)+len(refreshed))
+	for key := range before {
+		keys[key] = struct{}{}
+	}
+	for key := range refreshed {
+		keys[key] = struct{}{}
+	}
+	for key := range keys {
+		beforeValue, beforeOK := before[key]
+		refreshedValue, refreshedOK := refreshed[key]
+		if beforeOK == refreshedOK && reflect.DeepEqual(beforeValue, refreshedValue) {
+			continue
+		}
+		currentValue, currentOK := current[key]
+		if currentOK != beforeOK || !reflect.DeepEqual(currentValue, beforeValue) {
+			continue
+		}
+		if refreshedOK {
+			merged[key] = refreshedValue
+		} else {
+			delete(merged, key)
+		}
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+func mergeRefreshAttributes(current, before, refreshed map[string]string) map[string]string {
+	merged := make(map[string]string, len(current)+len(refreshed))
+	for key, value := range current {
+		merged[key] = value
+	}
+	keys := make(map[string]struct{}, len(before)+len(refreshed))
+	for key := range before {
+		keys[key] = struct{}{}
+	}
+	for key := range refreshed {
+		keys[key] = struct{}{}
+	}
+	for key := range keys {
+		beforeValue, beforeOK := before[key]
+		refreshedValue, refreshedOK := refreshed[key]
+		if beforeOK == refreshedOK && beforeValue == refreshedValue {
+			continue
+		}
+		currentValue, currentOK := current[key]
+		if currentOK != beforeOK || currentValue != beforeValue {
+			continue
+		}
+		if refreshedOK {
+			merged[key] = refreshedValue
+		} else {
+			delete(merged, key)
+		}
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+func mergeCredentialRefresh(current, before, refreshed *Auth) *Auth {
+	if current == nil {
+		return nil
+	}
+	merged := current.Clone()
+	if before == nil || refreshed == nil {
+		return merged
+	}
+	merged.Metadata = mergeRefreshMetadata(current.Metadata, before.Metadata, refreshed.Metadata)
+	merged.Attributes = mergeRefreshAttributes(current.Attributes, before.Attributes, refreshed.Attributes)
+	if current.Prefix == before.Prefix && refreshed.Prefix != before.Prefix {
+		merged.Prefix = refreshed.Prefix
+	}
+	if current.FileName == before.FileName && refreshed.FileName != before.FileName {
+		merged.FileName = refreshed.FileName
+	}
+	if current.Label == before.Label && refreshed.Label != before.Label {
+		merged.Label = refreshed.Label
+	}
+	if current.ProxyURL == before.ProxyURL && refreshed.ProxyURL != before.ProxyURL {
+		merged.ProxyURL = refreshed.ProxyURL
+	}
+	if current.Disabled == before.Disabled && refreshed.Disabled != before.Disabled {
+		merged.Disabled = refreshed.Disabled
+	}
+	if current.Unavailable == before.Unavailable && refreshed.Unavailable != before.Unavailable {
+		merged.Unavailable = refreshed.Unavailable
+	}
+	if current.Status == before.Status && refreshed.Status != before.Status {
+		merged.Status = refreshed.Status
+	}
+	if current.StatusMessage == before.StatusMessage && refreshed.StatusMessage != before.StatusMessage {
+		merged.StatusMessage = refreshed.StatusMessage
+	}
+	if current.NextRetryAfter.Equal(before.NextRetryAfter) && !refreshed.NextRetryAfter.Equal(before.NextRetryAfter) {
+		merged.NextRetryAfter = refreshed.NextRetryAfter
+	}
+	if reflect.DeepEqual(current.Quota, before.Quota) && !reflect.DeepEqual(refreshed.Quota, before.Quota) {
+		merged.Quota = refreshed.Quota
+	}
+	if reflect.DeepEqual(current.LastError, before.LastError) && !reflect.DeepEqual(refreshed.LastError, before.LastError) {
+		merged.LastError = cloneError(refreshed.LastError)
+	}
+	if reflect.DeepEqual(current.ModelStates, before.ModelStates) && !reflect.DeepEqual(refreshed.ModelStates, before.ModelStates) {
+		merged.ModelStates = refreshed.Clone().ModelStates
+	}
+	// applyCredentialRefresh has already verified that the current credential
+	// revision still matches before. Equivalent hot reloads may replace the
+	// storage object for noncredential changes, so pointer identity is not an
+	// ownership signal here.
+	if !sameReferenceValue(refreshed.Storage, before.Storage) {
+		merged.Storage = refreshed.Storage
+	}
+	if sameReferenceValue(current.Runtime, before.Runtime) && !sameReferenceValue(refreshed.Runtime, before.Runtime) {
+		merged.Runtime = refreshed.Runtime
+	}
+	return merged
+}
+
 // MarkResult records an execution result and notifies hooks.
 func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	if result.AuthID == "" {
@@ -707,6 +1066,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	setModelQuota := false
 	var authSnapshot *Auth
 	cooldownStateChanged := false
+	suppressErrorEvent := false
 
 	m.mu.Lock()
 	if auth, ok := m.auths[result.AuthID]; ok && auth != nil {
@@ -723,7 +1083,16 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			auth.Failed++
 		}
 
-		if result.Success {
+		staleCredentialResult := false
+		if result.hasCredentialFingerprint {
+			currentFingerprint, okFingerprint := authCredentialFingerprint(auth)
+			staleCredentialResult = !okFingerprint || currentFingerprint != result.credentialFingerprint
+		}
+		staleUnauthorizedResult := staleCredentialResult && !result.Success && isUnauthorizedError(result.Error)
+		if staleUnauthorizedResult {
+			authSnapshot = auth.Clone()
+			suppressErrorEvent = true
+		} else if result.Success {
 			if modelKey != "" {
 				state := ensureModelState(auth, modelKey)
 				resetModelState(state, now)
@@ -883,11 +1252,116 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	}
 
 	m.hook.OnResult(ctx, result)
-	m.publishErrorEvent(result, authSnapshot)
+	if !suppressErrorEvent {
+		m.publishErrorEvent(result, authSnapshot)
+	}
+}
+
+type authCredentialRevision struct {
+	fingerprint    [sha256.Size]byte
+	hasFingerprint bool
+}
+
+func captureAuthCredentialRevision(auth *Auth) authCredentialRevision {
+	fingerprint, ok := authCredentialFingerprint(auth)
+	return authCredentialRevision{fingerprint: fingerprint, hasFingerprint: ok}
+}
+
+type executionCredentialStorage struct {
+	rawJSON     []byte
+	fingerprint baseauth.CredentialFingerprintMaterial
+}
+
+func (s *executionCredentialStorage) RawJSON() []byte {
+	if s == nil {
+		return nil
+	}
+	return bytes.Clone(s.rawJSON)
+}
+
+func (s *executionCredentialStorage) CredentialFingerprintMaterial() baseauth.CredentialFingerprintMaterial {
+	if s == nil {
+		return baseauth.CredentialFingerprintMaterial{}
+	}
+	return s.fingerprint
+}
+
+func (*executionCredentialStorage) SaveTokenToFile(string) error {
+	return errors.New("execution credential snapshot is read-only")
+}
+
+func cloneCredentialMetadataValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		cloned := make(map[string]any, len(typed))
+		for key, item := range typed {
+			cloned[key] = cloneCredentialMetadataValue(item)
+		}
+		return cloned
+	case []any:
+		cloned := make([]any, len(typed))
+		for i, item := range typed {
+			cloned[i] = cloneCredentialMetadataValue(item)
+		}
+		return cloned
+	case map[string]string:
+		cloned := make(map[string]string, len(typed))
+		for key, item := range typed {
+			cloned[key] = item
+		}
+		return cloned
+	case []string:
+		cloned := make([]string, len(typed))
+		copy(cloned, typed)
+		return cloned
+	default:
+		return value
+	}
+}
+
+func snapshotAuthCredential(auth *Auth) (*Auth, authCredentialRevision) {
+	snapshot := auth.Clone()
+	if snapshot == nil {
+		return nil, authCredentialRevision{}
+	}
+
+	if source, ok := snapshot.Storage.(baseauth.CredentialSnapshotSource); ok && source != nil {
+		rawJSON, metadata, fingerprint := source.CredentialSnapshot()
+		if metadata == nil {
+			snapshot.Metadata = nil
+		} else {
+			snapshot.Metadata = cloneCredentialMetadataValue(metadata).(map[string]any)
+		}
+		snapshot.Storage = &executionCredentialStorage{
+			rawJSON:     bytes.Clone(rawJSON),
+			fingerprint: fingerprint,
+		}
+	} else {
+		var fingerprint baseauth.CredentialFingerprintMaterial
+		if source, okFingerprint := snapshot.Storage.(baseauth.CredentialFingerprintSource); okFingerprint && source != nil {
+			fingerprint = source.CredentialFingerprintMaterial()
+		}
+		if source, okRawJSON := snapshot.Storage.(interface{ RawJSON() []byte }); okRawJSON {
+			snapshot.Storage = &executionCredentialStorage{
+				rawJSON:     bytes.Clone(source.RawJSON()),
+				fingerprint: fingerprint,
+			}
+		}
+	}
+	if serviceAccount, ok := snapshot.Metadata["service_account"]; ok {
+		snapshot.Metadata["service_account"] = cloneCredentialMetadataValue(serviceAccount)
+	}
+	return snapshot, captureAuthCredentialRevision(snapshot)
 }
 
 func (m *Manager) recordExecutionResult(ctx context.Context, result Result, auth *Auth, ephemeral bool) {
+	m.recordExecutionResultWithRevision(ctx, result, auth, ephemeral, captureAuthCredentialRevision(auth))
+}
+
+func (m *Manager) recordExecutionResultWithRevision(ctx context.Context, result Result, auth *Auth, ephemeral bool, revision authCredentialRevision) {
 	if !ephemeral {
+		result.credentialFingerprint = revision.fingerprint
+		result.hasCredentialFingerprint = revision.hasFingerprint
 		m.MarkResult(ctx, result)
 		return
 	}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -12,12 +12,14 @@ import (
 	"net/url"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
 	baseauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth"
+	xaiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/xai"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
@@ -786,14 +788,23 @@ func authCredentialEndpoint(auth *Auth) string {
 	if auth == nil {
 		return ""
 	}
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
 	endpoint := strings.TrimSpace(authAttribute(auth, "base_url"))
 	if endpoint == "" {
-		switch strings.ToLower(strings.TrimSpace(auth.Provider)) {
+		switch provider {
 		case "antigravity", "xai":
 			// Both executors resolve metadata base_url only when the attribute is absent.
 			endpoint = strings.TrimSpace(authMetadataString(auth, "base_url"))
 		}
 	}
+	if provider == "xai" {
+		endpoint = authXAIEffectiveChatEndpoint(auth, endpoint)
+	}
+	return normalizeCredentialEndpoint(endpoint)
+}
+
+func normalizeCredentialEndpoint(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
 	if endpoint == "" {
 		return ""
 	}
@@ -806,6 +817,48 @@ func authCredentialEndpoint(auth *Auth) string {
 	parsed.Path = strings.TrimRight(parsed.Path, "/")
 	parsed.RawPath = strings.TrimRight(parsed.RawPath, "/")
 	return parsed.String()
+}
+
+func authXAIEffectiveChatEndpoint(auth *Auth, baseURL string) string {
+	baseURL = strings.TrimSpace(baseURL)
+	if authXAIUsingAPI(auth) {
+		if baseURL == "" {
+			return xaiauth.DefaultAPIBaseURL
+		}
+		return baseURL
+	}
+	if baseURL != "" && normalizeCredentialEndpoint(baseURL) != normalizeCredentialEndpoint(xaiauth.DefaultAPIBaseURL) {
+		return baseURL
+	}
+	return xaiauth.CLIChatProxyBaseURL
+}
+
+func authXAIUsingAPI(auth *Auth) bool {
+	if auth == nil {
+		return true
+	}
+	if raw := strings.TrimSpace(authAttribute(auth, "using_api")); raw != "" {
+		if parsed, errParse := strconv.ParseBool(raw); errParse == nil {
+			return parsed
+		}
+	}
+	if auth.Metadata != nil {
+		raw, ok := auth.Metadata["using_api"]
+		if ok && raw != nil {
+			switch value := raw.(type) {
+			case bool:
+				return value
+			case string:
+				if parsed, errParse := strconv.ParseBool(strings.TrimSpace(value)); errParse == nil {
+					return parsed
+				}
+			}
+		}
+	}
+	if kind := strings.TrimSpace(authAttribute(auth, "auth_kind")); kind != "" {
+		return !strings.EqualFold(kind, AuthKindOAuth)
+	}
+	return !strings.EqualFold(strings.TrimSpace(authMetadataString(auth, "auth_kind")), AuthKindOAuth)
 }
 
 func normalizeAuthorizationScopeHeaderName(name string) string {

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"reflect"
 	"sort"
 	"strings"
@@ -781,6 +782,20 @@ func authHeaderCarriesCredential(name string) bool {
 	}
 }
 
+func authCredentialEndpoint(auth *Auth) string {
+	endpoint := strings.TrimRight(strings.TrimSpace(authAttribute(auth, "base_url")), "/")
+	if endpoint == "" {
+		return ""
+	}
+	parsed, errParse := url.Parse(endpoint)
+	if errParse != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return endpoint
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.Host = strings.ToLower(parsed.Host)
+	return parsed.String()
+}
+
 func authCredentialFingerprint(auth *Auth) ([sha256.Size]byte, bool) {
 	if auth == nil {
 		return [sha256.Size]byte{}, false
@@ -844,6 +859,9 @@ func authCredentialFingerprint(auth *Auth) ([sha256.Size]byte, bool) {
 	parts := []string{
 		"provider=" + strings.ToLower(strings.TrimSpace(auth.Provider)),
 		"kind=" + kind,
+	}
+	if endpoint := authCredentialEndpoint(auth); endpoint != "" {
+		parts = append(parts, "endpoint="+endpoint)
 	}
 	credentialCount := 0
 	appendCredential := func(name, value string) {

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -349,7 +349,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			if !restoreExecutionModel {
 				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel)
 			}
-			requestAuth, credentialRevision := snapshotAuthCredential(auth)
+			requestAuth, credentialRevision := snapshotAuthCredentialForExecution(execCtx, auth, execReq, execOpts)
 			resp, errExec := executor.Execute(execCtx, requestAuth, execReq, execOpts)
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
@@ -358,7 +358,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(execCtx, auth, errExec, didRefreshOnUnauthorized); okRefresh {
 					auth = refreshed
 					didRefreshOnUnauthorized = true
-					requestAuth, credentialRevision = snapshotAuthCredential(auth)
+					requestAuth, credentialRevision = snapshotAuthCredentialForExecution(execCtx, auth, execReq, execOpts)
 					resp, errExec = executor.Execute(execCtx, requestAuth, execReq, execOpts)
 					if errExec != nil {
 						if errCtx := execCtx.Err(); errCtx != nil {

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -327,7 +327,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				return cliproxyexecutor.Response{}, errCancel
 			}
 			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: resultErrorFromError(errPrepare)}
-			m.MarkResult(execCtx, result)
+			m.recordExecutionResult(execCtx, result, auth, false)
 			lastErr = errPrepare
 			continue
 		}
@@ -349,7 +349,8 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			if !restoreExecutionModel {
 				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel)
 			}
-			resp, errExec := executor.Execute(execCtx, auth, execReq, execOpts)
+			requestAuth, credentialRevision := snapshotAuthCredential(auth)
+			resp, errExec := executor.Execute(execCtx, requestAuth, execReq, execOpts)
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
 					return cliproxyexecutor.Response{}, errCtx
@@ -357,7 +358,8 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(execCtx, auth, errExec, didRefreshOnUnauthorized); okRefresh {
 					auth = refreshed
 					didRefreshOnUnauthorized = true
-					resp, errExec = executor.Execute(execCtx, auth, execReq, execOpts)
+					requestAuth, credentialRevision = snapshotAuthCredential(auth)
+					resp, errExec = executor.Execute(execCtx, requestAuth, execReq, execOpts)
 					if errExec != nil {
 						if errCtx := execCtx.Err(); errCtx != nil {
 							return cliproxyexecutor.Response{}, errCtx
@@ -374,14 +376,14 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
 				}
-				m.MarkResult(execCtx, result)
+				m.recordExecutionResultWithRevision(execCtx, result, auth, false, credentialRevision)
 				if isRequestInvalidError(errExec) {
 					return cliproxyexecutor.Response{}, errExec
 				}
 				authErr = errExec
 				continue
 			}
-			m.MarkResult(execCtx, result)
+			m.recordExecutionResultWithRevision(execCtx, result, auth, false, credentialRevision)
 			attemptAliasResult := resolveAttemptAliasResult(routing, auth, routeModel, upstreamModel, aliasResult)
 			rewriteForceMappedResponse(&resp, attemptAliasResult)
 			return resp, nil
@@ -454,7 +456,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				return cliproxyexecutor.Response{}, errCancel
 			}
 			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: resultErrorFromError(errPrepare)}
-			m.MarkResult(execCtx, result)
+			m.recordExecutionResult(execCtx, result, auth, false)
 			lastErr = errPrepare
 			continue
 		}
@@ -476,7 +478,8 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			if !restoreExecutionModel {
 				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel)
 			}
-			resp, errExec := executor.CountTokens(execCtx, auth, execReq, execOpts)
+			requestAuth, credentialRevision := snapshotAuthCredential(auth)
+			resp, errExec := executor.CountTokens(execCtx, requestAuth, execReq, execOpts)
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
 					return cliproxyexecutor.Response{}, errCtx
@@ -484,7 +487,8 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(execCtx, auth, errExec, didRefreshOnUnauthorized); okRefresh {
 					auth = refreshed
 					didRefreshOnUnauthorized = true
-					resp, errExec = executor.CountTokens(execCtx, auth, execReq, execOpts)
+					requestAuth, credentialRevision = snapshotAuthCredential(auth)
+					resp, errExec = executor.CountTokens(execCtx, requestAuth, execReq, execOpts)
 					if errExec != nil {
 						if errCtx := execCtx.Err(); errCtx != nil {
 							return cliproxyexecutor.Response{}, errCtx
@@ -508,7 +512,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				if isCountTokensEndpointNotFoundError(errExec, execReq.Model) {
 					m.recordAvailabilityNeutralResult(execCtx, result)
 				} else {
-					m.MarkResult(execCtx, result)
+					m.recordExecutionResultWithRevision(execCtx, result, auth, false, credentialRevision)
 				}
 				if isRequestInvalidError(errExec) {
 					return cliproxyexecutor.Response{}, errExec
@@ -516,7 +520,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				authErr = errExec
 				continue
 			}
-			m.MarkResult(execCtx, result)
+			m.recordExecutionResultWithRevision(execCtx, result, auth, false, credentialRevision)
 			attemptAliasResult := resolveAttemptAliasResult(routing, auth, routeModel, upstreamModel, aliasResult)
 			rewriteForceMappedResponse(&resp, attemptAliasResult)
 			return resp, nil
@@ -655,7 +659,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 				m.reportHomeResult(execCtx, result, auth)
 				releaseAttempt()
 			} else {
-				m.MarkResult(execCtx, result)
+				m.recordExecutionResult(execCtx, result, auth, false)
 			}
 			lastErr = errPrepare
 			if selection != nil {

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -905,7 +905,7 @@ func (m *Manager) prepareRequestAuth(ctx context.Context, executor ProviderExecu
 
 	updated, errPrepare := preparer.PrepareRequestAuth(ctx, target)
 	if errPrepare != nil {
-		return auth, errPrepare
+		return target, errPrepare
 	}
 	if updated == nil {
 		return target, nil

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1114,7 +1114,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			resultModel := m.stateModelForExecution(c.auth, routeModel, upstreamModel, pooled)
 			execReq := req
 			execReq.Model = upstreamModel
-			requestAuth, credentialRevision := snapshotAuthCredential(c.auth)
+			requestAuth, credentialRevision := snapshotAuthCredentialForExecution(creditsCtx, c.auth, execReq, creditsOpts)
 			resp, errExec := c.executor.Execute(creditsCtx, requestAuth, execReq, creditsOpts)
 			result := Result{AuthID: c.auth.ID, Provider: c.provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1114,17 +1114,18 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			resultModel := m.stateModelForExecution(c.auth, routeModel, upstreamModel, pooled)
 			execReq := req
 			execReq.Model = upstreamModel
-			resp, errExec := c.executor.Execute(creditsCtx, c.auth, execReq, creditsOpts)
+			requestAuth, credentialRevision := snapshotAuthCredential(c.auth)
+			resp, errExec := c.executor.Execute(creditsCtx, requestAuth, execReq, creditsOpts)
 			result := Result{AuthID: c.auth.ID, Provider: c.provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
 				}
-				m.MarkResult(creditsCtx, result)
+				m.recordExecutionResultWithRevision(creditsCtx, result, c.auth, false, credentialRevision)
 				continue
 			}
-			m.MarkResult(creditsCtx, result)
+			m.recordExecutionResultWithRevision(creditsCtx, result, c.auth, false, credentialRevision)
 			attemptAliasResult := resolveAttemptAliasResult(routing, c.auth, routeModel, upstreamModel, aliasResult)
 			rewriteForceMappedResponse(&resp, attemptAliasResult)
 			return resp, true, nil

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -365,23 +365,46 @@ func persistenceTargetsMatch(left, right string) bool {
 	if leftClean == rightClean {
 		return true
 	}
-	if filepath.IsAbs(leftClean) != filepath.IsAbs(rightClean) {
-		return filepath.Base(leftClean) == filepath.Base(rightClean)
+	if filepath.IsAbs(leftClean) == filepath.IsAbs(rightClean) {
+		return false
 	}
-	return false
+
+	relativeTarget := leftClean
+	absoluteTarget := rightClean
+	if filepath.IsAbs(leftClean) {
+		relativeTarget, absoluteTarget = rightClean, leftClean
+	}
+	if relativeTarget == "." || relativeTarget == ".." ||
+		strings.HasPrefix(relativeTarget, ".."+string(filepath.Separator)) ||
+		filepath.VolumeName(relativeTarget) != "" {
+		return false
+	}
+	suffix := string(filepath.Separator) + relativeTarget
+	if filepath.Separator == '\\' {
+		absoluteTarget = strings.ToLower(absoluteTarget)
+		suffix = strings.ToLower(suffix)
+	}
+	return strings.HasSuffix(absoluteTarget, suffix)
 }
 
-func authOwnsPersistenceTarget(auth *Auth, target string) bool {
+func (m *Manager) authPersistenceTarget(auth *Auth) string {
+	if m != nil {
+		if resolver, ok := m.store.(PersistenceTargetResolver); ok && resolver != nil {
+			if target, errResolve := resolver.ResolveAuthPersistenceTarget(auth); errResolve == nil {
+				if target = strings.TrimSpace(target); target != "" {
+					return target
+				}
+			}
+		}
+	}
+	return authPersistenceDeleteID(auth, "")
+}
+
+func (m *Manager) authOwnsPersistenceTarget(auth *Auth, target string) bool {
 	if auth == nil {
 		return false
 	}
-	if path := authAttribute(auth, AttributePath); path != "" {
-		return persistenceTargetsMatch(path, target)
-	}
-	if fileName := strings.TrimSpace(auth.FileName); fileName != "" {
-		return persistenceTargetsMatch(fileName, target)
-	}
-	return persistenceTargetsMatch(auth.ID, target)
+	return persistenceTargetsMatch(m.authPersistenceTarget(auth), target)
 }
 
 func (m *Manager) persistenceTargetOwner(ctx context.Context, target string) (*Auth, *Auth) {
@@ -391,7 +414,7 @@ func (m *Manager) persistenceTargetOwner(ctx context.Context, target string) (*A
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	for _, owner := range m.auths {
-		if authOwnsPersistenceTarget(owner, target) && m.shouldPersistAuth(ctx, owner) {
+		if m.authOwnsPersistenceTarget(owner, target) && m.shouldPersistAuth(ctx, owner) {
 			return owner, cloneAuthForConditionalPersistence(owner)
 		}
 	}

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -64,6 +64,15 @@ func (m *Manager) UnregisterExecutor(provider string) {
 	m.mu.Unlock()
 }
 
+func syncAuthStorageMetadata(auth *Auth) {
+	if auth == nil || auth.Storage == nil {
+		return
+	}
+	if setter, ok := auth.Storage.(interface{ SetMetadata(map[string]any) }); ok && setter != nil {
+		setter.SetMetadata(auth.Metadata)
+	}
+}
+
 // Register inserts a new auth entry into the manager.
 func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 	if auth == nil {
@@ -80,6 +89,7 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 	if m.cooldownDisabledForAuth(auth) || auth.Disabled || auth.Status == StatusDisabled {
 		clearedCooldown = clearCooldownStateForAuth(auth, now)
 	}
+	syncAuthStorageMetadata(auth)
 	auth.EnsureIndex()
 	authClone := auth.Clone()
 	m.mu.Lock()
@@ -102,17 +112,29 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 
 // Update replaces an existing auth entry and notifies hooks.
 func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
+	updated, _, errUpdate := m.updateAuth(ctx, auth, nil)
+	return updated, errUpdate
+}
+
+// updateAuth replaces auth only while expectedCurrent still owns its ID. A nil
+// expectedCurrent preserves the unconditional Update behavior.
+func (m *Manager) updateAuth(ctx context.Context, auth, expectedCurrent *Auth) (*Auth, bool, error) {
 	if auth == nil || auth.ID == "" {
-		return nil, nil
+		return nil, false, nil
 	}
 	if errWeight := ValidateAuthWeight(auth); errWeight != nil {
-		return nil, fmt.Errorf("update auth: %w", errWeight)
+		return nil, false, fmt.Errorf("update auth: %w", errWeight)
 	}
 	m.mu.Lock()
 	existing, ok := m.auths[auth.ID]
 	if !ok || existing == nil {
 		m.mu.Unlock()
-		return nil, nil
+		return nil, false, nil
+	}
+	if expectedCurrent != nil && existing != expectedCurrent {
+		current := existing.Clone()
+		m.mu.Unlock()
+		return current, false, nil
 	}
 	if !auth.indexAssigned && auth.Index == "" {
 		auth.Index = existing.Index
@@ -131,23 +153,51 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	if m.cooldownDisabledForAuth(auth) || auth.Disabled || auth.Status == StatusDisabled {
 		clearedCooldown = clearCooldownStateForAuth(auth, now)
 	}
+	syncAuthStorageMetadata(auth)
 	auth.EnsureIndex()
 	authClone := auth.Clone()
 	m.auths[auth.ID] = authClone
+	persistedWithCAS := expectedCurrent != nil
 	m.mu.Unlock()
+	if persistedWithCAS {
+		m.persistConditionalUpdate(ctx, auth, authClone)
+	}
 	if !shouldDeferAPIKeyModelAliasRebuild(ctx) {
 		m.rebuildAPIKeyModelAliasFromRuntimeConfig()
 	}
-	if m.scheduler != nil {
-		m.scheduler.upsertAuth(authClone)
+	if persistedWithCAS {
+		// Persistence can outlive this generation. Publish the update only while
+		// authClone still owns the runtime ID so a concurrent replacement cannot
+		// be overwritten in the scheduler or returned to a retrying request.
+		m.mu.RLock()
+		current := m.auths[auth.ID]
+		if current != authClone {
+			var currentClone *Auth
+			if current != nil {
+				currentClone = current.Clone()
+			}
+			m.mu.RUnlock()
+			return currentClone, false, nil
+		}
+		if m.scheduler != nil {
+			m.scheduler.upsertAuth(authClone)
+		}
+		if loop := m.refreshLoop; loop != nil {
+			loop.queueReschedule(auth.ID)
+		}
+		m.mu.RUnlock()
+	} else {
+		if m.scheduler != nil {
+			m.scheduler.upsertAuth(authClone)
+		}
+		m.queueRefreshReschedule(auth.ID)
+		_ = m.persist(ctx, auth)
 	}
-	m.queueRefreshReschedule(auth.ID)
-	_ = m.persist(ctx, auth)
 	m.hook.OnAuthUpdated(ctx, auth.Clone())
 	if clearedCooldown {
 		m.persistCooldownStates(ctx)
 	}
-	return auth.Clone(), nil
+	return auth.Clone(), true, nil
 }
 
 // Remove deletes an auth from runtime state without persisting.
@@ -245,6 +295,101 @@ func (m *Manager) Load(ctx context.Context) error {
 	return nil
 }
 
+// shouldPersistAuth reports whether auth persistence is enabled for this record.
+func (m *Manager) shouldPersistAuth(ctx context.Context, auth *Auth) bool {
+	if m == nil || m.store == nil || auth == nil || shouldSkipPersist(ctx) {
+		return false
+	}
+	if ValidateAuthWeight(auth) != nil {
+		return false
+	}
+	if IsConfigAPIKeyAuth(auth) || IsPluginVirtualAuth(auth) {
+		return false
+	}
+	if auth.Attributes != nil {
+		if v := strings.ToLower(strings.TrimSpace(auth.Attributes["runtime_only"])); v == "true" {
+			return false
+		}
+	}
+	return auth.Metadata != nil
+}
+
+func authPersistenceDeleteID(auth *Auth, savedID string) string {
+	if savedID = strings.TrimSpace(savedID); savedID != "" {
+		return savedID
+	}
+	if auth == nil {
+		return ""
+	}
+	if path := authAttribute(auth, AttributePath); path != "" {
+		return path
+	}
+	if fileName := strings.TrimSpace(auth.FileName); fileName != "" {
+		return fileName
+	}
+	return strings.TrimSpace(auth.ID)
+}
+
+// persistConditionalUpdate persists a CAS-owned auth without holding the
+// manager-wide auth lock. If ownership changes while I/O is in flight, the
+// current same-ID generation is persisted again. If ownership disappears, the
+// stale save is deleted; a new owner that appears during cleanup is then
+// re-persisted so deletion cannot erase a legitimate replacement.
+func (m *Manager) persistConditionalUpdate(ctx context.Context, auth, owner *Auth) {
+	if auth == nil || owner == nil || auth.ID == "" || !m.shouldPersistAuth(ctx, auth) {
+		return
+	}
+	candidate := auth.Clone()
+	candidateOwner := owner
+	staleSavedID := ""
+	for {
+		savedID, errPersist := m.store.Save(ctx, candidate)
+		if errPersist != nil {
+			return
+		}
+		savedID = authPersistenceDeleteID(candidate, savedID)
+		if staleSavedID != "" && staleSavedID != savedID {
+			if errDelete := m.store.Delete(ctx, staleSavedID); errDelete != nil {
+				return
+			}
+		}
+		staleSavedID = ""
+
+		m.mu.RLock()
+		current := m.auths[auth.ID]
+		if current == candidateOwner {
+			m.mu.RUnlock()
+			return
+		}
+		if current != nil && m.shouldPersistAuth(ctx, current) {
+			candidate = current.Clone()
+			candidateOwner = current
+			staleSavedID = savedID
+			m.mu.RUnlock()
+			continue
+		}
+		m.mu.RUnlock()
+
+		deleteID := savedID
+		if deleteID == "" {
+			return
+		}
+		if errDelete := m.store.Delete(ctx, deleteID); errDelete != nil {
+			return
+		}
+
+		m.mu.RLock()
+		current = m.auths[auth.ID]
+		if current == nil || !m.shouldPersistAuth(ctx, current) {
+			m.mu.RUnlock()
+			return
+		}
+		candidate = current.Clone()
+		candidateOwner = current
+		m.mu.RUnlock()
+	}
+}
+
 func (m *Manager) persist(ctx context.Context, auth *Auth) error {
 	if m.store == nil || auth == nil {
 		return nil
@@ -252,22 +397,7 @@ func (m *Manager) persist(ctx context.Context, auth *Auth) error {
 	if errWeight := ValidateAuthWeight(auth); errWeight != nil {
 		return fmt.Errorf("persist auth: %w", errWeight)
 	}
-	if shouldSkipPersist(ctx) {
-		return nil
-	}
-	if IsConfigAPIKeyAuth(auth) {
-		return nil
-	}
-	if auth.Attributes != nil {
-		if v := strings.ToLower(strings.TrimSpace(auth.Attributes["runtime_only"])); v == "true" {
-			return nil
-		}
-	}
-	if IsPluginVirtualAuth(auth) {
-		return nil
-	}
-	// Skip persistence when metadata is absent (e.g., runtime-only auths).
-	if auth.Metadata == nil {
+	if !m.shouldPersistAuth(ctx, auth) {
 		return nil
 	}
 	_, err := m.store.Save(ctx, auth)

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -181,6 +181,11 @@ func (m *Manager) updateAuth(ctx context.Context, auth, expectedCurrent *Auth) (
 		persistenceCandidate = cloneAuthForConditionalPersistence(auth)
 	}
 	m.auths[auth.ID] = authClone
+	if persistedWithCAS && m.scheduler != nil {
+		// Publish the CAS-owned generation before remote persistence so a slow
+		// store cannot leave concurrent requests selecting the superseded auth.
+		m.scheduler.upsertAuth(authClone)
+	}
 	m.mu.Unlock()
 	if persistedWithCAS {
 		m.persistConditionalUpdate(ctx, persistenceCandidate, authClone)
@@ -201,9 +206,6 @@ func (m *Manager) updateAuth(ctx context.Context, auth, expectedCurrent *Auth) (
 			}
 			m.mu.RUnlock()
 			return currentClone, false, nil
-		}
-		if m.scheduler != nil {
-			m.scheduler.upsertAuth(authClone)
 		}
 		if loop := m.refreshLoop; loop != nil {
 			loop.queueReschedule(auth.ID)

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	baseauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
 
@@ -71,6 +72,21 @@ func syncAuthStorageMetadata(auth *Auth) {
 	if setter, ok := auth.Storage.(interface{ SetMetadata(map[string]any) }); ok && setter != nil {
 		setter.SetMetadata(auth.Metadata)
 	}
+}
+
+func cloneAuthForConditionalPersistence(auth *Auth) *Auth {
+	candidate := auth.Clone()
+	if candidate == nil || candidate.Storage == nil {
+		return candidate
+	}
+	source, ok := candidate.Storage.(baseauth.CredentialPersistenceSnapshotSource)
+	if !ok || source == nil {
+		return candidate
+	}
+	if storage := source.CredentialPersistenceSnapshot(); storage != nil {
+		candidate.Storage = storage
+	}
+	return candidate
 }
 
 // Register inserts a new auth entry into the manager.
@@ -158,11 +174,15 @@ func (m *Manager) updateAuth(ctx context.Context, auth, expectedCurrent *Auth) (
 	auth.EnsureIndex()
 	auth.credentialGeneration = m.authGeneration.Add(1)
 	authClone := auth.Clone()
-	m.auths[auth.ID] = authClone
 	persistedWithCAS := expectedCurrent != nil
+	var persistenceCandidate *Auth
+	if persistedWithCAS {
+		persistenceCandidate = cloneAuthForConditionalPersistence(auth)
+	}
+	m.auths[auth.ID] = authClone
 	m.mu.Unlock()
 	if persistedWithCAS {
-		m.persistConditionalUpdate(ctx, auth, authClone)
+		m.persistConditionalUpdate(ctx, persistenceCandidate, authClone)
 	}
 	if !shouldDeferAPIKeyModelAliasRebuild(ctx) {
 		m.rebuildAPIKeyModelAliasFromRuntimeConfig()
@@ -365,7 +385,7 @@ func (m *Manager) persistConditionalUpdate(ctx context.Context, auth, owner *Aut
 			return
 		}
 		if current != nil && m.shouldPersistAuth(ctx, current) {
-			candidate = current.Clone()
+			candidate = cloneAuthForConditionalPersistence(current)
 			candidateOwner = current
 			staleSavedID = savedID
 			m.mu.RUnlock()
@@ -387,7 +407,7 @@ func (m *Manager) persistConditionalUpdate(ctx context.Context, auth, owner *Aut
 			m.mu.RUnlock()
 			return
 		}
-		candidate = current.Clone()
+		candidate = cloneAuthForConditionalPersistence(current)
 		candidateOwner = current
 		m.mu.RUnlock()
 	}

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -64,6 +64,15 @@ func (m *Manager) UnregisterExecutor(provider string) {
 	m.mu.Unlock()
 }
 
+func syncAuthStorageMetadata(auth *Auth) {
+	if auth == nil || auth.Storage == nil {
+		return
+	}
+	if setter, ok := auth.Storage.(interface{ SetMetadata(map[string]any) }); ok && setter != nil {
+		setter.SetMetadata(auth.Metadata)
+	}
+}
+
 // Register inserts a new auth entry into the manager.
 func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 	if auth == nil {
@@ -80,6 +89,7 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 	if m.cooldownDisabledForAuth(auth) || auth.Disabled || auth.Status == StatusDisabled {
 		cooldownStateChanged = clearCooldownStateForAuth(auth, now) || cooldownStateChanged
 	}
+	syncAuthStorageMetadata(auth)
 	auth.EnsureIndex()
 	authClone := auth.Clone()
 	m.mu.Lock()
@@ -102,17 +112,29 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 
 // Update replaces an existing auth entry and notifies hooks.
 func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
+	updated, _, errUpdate := m.updateAuth(ctx, auth, nil)
+	return updated, errUpdate
+}
+
+// updateAuth replaces auth only while expectedCurrent still owns its ID. A nil
+// expectedCurrent preserves the unconditional Update behavior.
+func (m *Manager) updateAuth(ctx context.Context, auth, expectedCurrent *Auth) (*Auth, bool, error) {
 	if auth == nil || auth.ID == "" {
-		return nil, nil
+		return nil, false, nil
 	}
 	if errWeight := ValidateAuthWeight(auth); errWeight != nil {
-		return nil, fmt.Errorf("update auth: %w", errWeight)
+		return nil, false, fmt.Errorf("update auth: %w", errWeight)
 	}
 	m.mu.Lock()
 	existing, ok := m.auths[auth.ID]
 	if !ok || existing == nil {
 		m.mu.Unlock()
-		return nil, nil
+		return nil, false, nil
+	}
+	if expectedCurrent != nil && existing != expectedCurrent {
+		current := existing.Clone()
+		m.mu.Unlock()
+		return current, false, nil
 	}
 	if !auth.indexAssigned && auth.Index == "" {
 		auth.Index = existing.Index
@@ -131,23 +153,51 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	if m.cooldownDisabledForAuth(auth) || auth.Disabled || auth.Status == StatusDisabled {
 		cooldownStateChanged = clearCooldownStateForAuth(auth, now) || cooldownStateChanged
 	}
+	syncAuthStorageMetadata(auth)
 	auth.EnsureIndex()
 	authClone := auth.Clone()
 	m.auths[auth.ID] = authClone
+	persistedWithCAS := expectedCurrent != nil
 	m.mu.Unlock()
+	if persistedWithCAS {
+		m.persistConditionalUpdate(ctx, auth, authClone)
+	}
 	if !shouldDeferAPIKeyModelAliasRebuild(ctx) {
 		m.rebuildAPIKeyModelAliasFromRuntimeConfig()
 	}
-	if m.scheduler != nil {
-		m.scheduler.upsertAuth(authClone)
+	if persistedWithCAS {
+		// Persistence can outlive this generation. Publish the update only while
+		// authClone still owns the runtime ID so a concurrent replacement cannot
+		// be overwritten in the scheduler or returned to a retrying request.
+		m.mu.RLock()
+		current := m.auths[auth.ID]
+		if current != authClone {
+			var currentClone *Auth
+			if current != nil {
+				currentClone = current.Clone()
+			}
+			m.mu.RUnlock()
+			return currentClone, false, nil
+		}
+		if m.scheduler != nil {
+			m.scheduler.upsertAuth(authClone)
+		}
+		if loop := m.refreshLoop; loop != nil {
+			loop.queueReschedule(auth.ID)
+		}
+		m.mu.RUnlock()
+	} else {
+		if m.scheduler != nil {
+			m.scheduler.upsertAuth(authClone)
+		}
+		m.queueRefreshReschedule(auth.ID)
+		_ = m.persist(ctx, auth)
 	}
-	m.queueRefreshReschedule(auth.ID)
-	_ = m.persist(ctx, auth)
 	m.hook.OnAuthUpdated(ctx, auth.Clone())
 	if cooldownStateChanged {
 		m.persistCooldownStates(ctx)
 	}
-	return auth.Clone(), nil
+	return auth.Clone(), true, nil
 }
 
 // Remove deletes an auth from runtime state without persisting.
@@ -245,6 +295,101 @@ func (m *Manager) Load(ctx context.Context) error {
 	return nil
 }
 
+// shouldPersistAuth reports whether auth persistence is enabled for this record.
+func (m *Manager) shouldPersistAuth(ctx context.Context, auth *Auth) bool {
+	if m == nil || m.store == nil || auth == nil || shouldSkipPersist(ctx) {
+		return false
+	}
+	if ValidateAuthWeight(auth) != nil {
+		return false
+	}
+	if IsConfigAPIKeyAuth(auth) || IsPluginVirtualAuth(auth) {
+		return false
+	}
+	if auth.Attributes != nil {
+		if v := strings.ToLower(strings.TrimSpace(auth.Attributes["runtime_only"])); v == "true" {
+			return false
+		}
+	}
+	return auth.Metadata != nil
+}
+
+func authPersistenceDeleteID(auth *Auth, savedID string) string {
+	if savedID = strings.TrimSpace(savedID); savedID != "" {
+		return savedID
+	}
+	if auth == nil {
+		return ""
+	}
+	if path := authAttribute(auth, AttributePath); path != "" {
+		return path
+	}
+	if fileName := strings.TrimSpace(auth.FileName); fileName != "" {
+		return fileName
+	}
+	return strings.TrimSpace(auth.ID)
+}
+
+// persistConditionalUpdate persists a CAS-owned auth without holding the
+// manager-wide auth lock. If ownership changes while I/O is in flight, the
+// current same-ID generation is persisted again. If ownership disappears, the
+// stale save is deleted; a new owner that appears during cleanup is then
+// re-persisted so deletion cannot erase a legitimate replacement.
+func (m *Manager) persistConditionalUpdate(ctx context.Context, auth, owner *Auth) {
+	if auth == nil || owner == nil || auth.ID == "" || !m.shouldPersistAuth(ctx, auth) {
+		return
+	}
+	candidate := auth.Clone()
+	candidateOwner := owner
+	staleSavedID := ""
+	for {
+		savedID, errPersist := m.store.Save(ctx, candidate)
+		if errPersist != nil {
+			return
+		}
+		savedID = authPersistenceDeleteID(candidate, savedID)
+		if staleSavedID != "" && staleSavedID != savedID {
+			if errDelete := m.store.Delete(ctx, staleSavedID); errDelete != nil {
+				return
+			}
+		}
+		staleSavedID = ""
+
+		m.mu.RLock()
+		current := m.auths[auth.ID]
+		if current == candidateOwner {
+			m.mu.RUnlock()
+			return
+		}
+		if current != nil && m.shouldPersistAuth(ctx, current) {
+			candidate = current.Clone()
+			candidateOwner = current
+			staleSavedID = savedID
+			m.mu.RUnlock()
+			continue
+		}
+		m.mu.RUnlock()
+
+		deleteID := savedID
+		if deleteID == "" {
+			return
+		}
+		if errDelete := m.store.Delete(ctx, deleteID); errDelete != nil {
+			return
+		}
+
+		m.mu.RLock()
+		current = m.auths[auth.ID]
+		if current == nil || !m.shouldPersistAuth(ctx, current) {
+			m.mu.RUnlock()
+			return
+		}
+		candidate = current.Clone()
+		candidateOwner = current
+		m.mu.RUnlock()
+	}
+}
+
 func (m *Manager) persist(ctx context.Context, auth *Auth) error {
 	if m.store == nil || auth == nil {
 		return nil
@@ -252,22 +397,7 @@ func (m *Manager) persist(ctx context.Context, auth *Auth) error {
 	if errWeight := ValidateAuthWeight(auth); errWeight != nil {
 		return fmt.Errorf("persist auth: %w", errWeight)
 	}
-	if shouldSkipPersist(ctx) {
-		return nil
-	}
-	if IsConfigAPIKeyAuth(auth) {
-		return nil
-	}
-	if auth.Attributes != nil {
-		if v := strings.ToLower(strings.TrimSpace(auth.Attributes["runtime_only"])); v == "true" {
-			return nil
-		}
-	}
-	if IsPluginVirtualAuth(auth) {
-		return nil
-	}
-	// Skip persistence when metadata is absent (e.g., runtime-only auths).
-	if auth.Metadata == nil {
+	if !m.shouldPersistAuth(ctx, auth) {
 		return nil
 	}
 	_, err := m.store.Save(ctx, auth)

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -91,6 +91,7 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 	}
 	syncAuthStorageMetadata(auth)
 	auth.EnsureIndex()
+	auth.credentialGeneration = m.authGeneration.Add(1)
 	authClone := auth.Clone()
 	m.mu.Lock()
 	m.auths[auth.ID] = authClone
@@ -155,6 +156,7 @@ func (m *Manager) updateAuth(ctx context.Context, auth, expectedCurrent *Auth) (
 	}
 	syncAuthStorageMetadata(auth)
 	auth.EnsureIndex()
+	auth.credentialGeneration = m.authGeneration.Add(1)
 	authClone := auth.Clone()
 	m.auths[auth.ID] = authClone
 	persistedWithCAS := expectedCurrent != nil
@@ -283,6 +285,7 @@ func (m *Manager) Load(ctx context.Context) error {
 			continue
 		}
 		auth.EnsureIndex()
+		auth.credentialGeneration = m.authGeneration.Add(1)
 		m.auths[auth.ID] = auth.Clone()
 	}
 	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -353,6 +354,76 @@ func authPersistenceDeleteID(auth *Auth, savedID string) string {
 	return strings.TrimSpace(auth.ID)
 }
 
+func persistenceTargetsMatch(left, right string) bool {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == "" || right == "" {
+		return false
+	}
+	leftClean := filepath.Clean(left)
+	rightClean := filepath.Clean(right)
+	if leftClean == rightClean {
+		return true
+	}
+	if filepath.IsAbs(leftClean) != filepath.IsAbs(rightClean) {
+		return filepath.Base(leftClean) == filepath.Base(rightClean)
+	}
+	return false
+}
+
+func authOwnsPersistenceTarget(auth *Auth, target string) bool {
+	if auth == nil {
+		return false
+	}
+	if path := authAttribute(auth, AttributePath); path != "" {
+		return persistenceTargetsMatch(path, target)
+	}
+	if fileName := strings.TrimSpace(auth.FileName); fileName != "" {
+		return persistenceTargetsMatch(fileName, target)
+	}
+	return persistenceTargetsMatch(auth.ID, target)
+}
+
+func (m *Manager) persistenceTargetOwner(ctx context.Context, target string) (*Auth, *Auth) {
+	if m == nil || strings.TrimSpace(target) == "" {
+		return nil, nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, owner := range m.auths {
+		if authOwnsPersistenceTarget(owner, target) && m.shouldPersistAuth(ctx, owner) {
+			return owner, cloneAuthForConditionalPersistence(owner)
+		}
+	}
+	return nil, nil
+}
+
+// reconcilePersistenceTarget makes a stale save target reflect its current
+// runtime owner. The owner is rechecked after each store operation so a rename,
+// removal, or cross-ID target reuse that races with I/O is repaired rather than
+// having a newer credential deleted.
+func (m *Manager) reconcilePersistenceTarget(ctx context.Context, target string) error {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return nil
+	}
+	for {
+		owner, candidate := m.persistenceTargetOwner(ctx, target)
+		if owner == nil {
+			if errDelete := m.store.Delete(ctx, target); errDelete != nil {
+				return errDelete
+			}
+		} else if _, errSave := m.store.Save(ctx, candidate); errSave != nil {
+			return errSave
+		}
+
+		currentOwner, _ := m.persistenceTargetOwner(ctx, target)
+		if currentOwner == owner {
+			return nil
+		}
+	}
+}
+
 // persistConditionalUpdate persists a CAS-owned auth without holding the
 // manager-wide auth lock. If ownership changes while I/O is in flight, the
 // current same-ID generation is persisted again. If ownership disappears, the
@@ -372,7 +443,7 @@ func (m *Manager) persistConditionalUpdate(ctx context.Context, auth, owner *Aut
 		}
 		savedID = authPersistenceDeleteID(candidate, savedID)
 		if staleSavedID != "" && staleSavedID != savedID {
-			if errDelete := m.store.Delete(ctx, staleSavedID); errDelete != nil {
+			if errDelete := m.reconcilePersistenceTarget(ctx, staleSavedID); errDelete != nil {
 				return
 			}
 		}
@@ -397,7 +468,7 @@ func (m *Manager) persistConditionalUpdate(ctx context.Context, auth, owner *Aut
 		if deleteID == "" {
 			return
 		}
-		if errDelete := m.store.Delete(ctx, deleteID); errDelete != nil {
+		if errDelete := m.reconcilePersistenceTarget(ctx, deleteID); errDelete != nil {
 			return
 		}
 

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -355,6 +355,10 @@ func authPersistenceDeleteID(auth *Auth, savedID string) string {
 }
 
 func persistenceTargetsMatch(left, right string) bool {
+	return persistenceTargetsMatchWithCaseFold(left, right, filepath.Separator == '\\')
+}
+
+func persistenceTargetsMatchWithCaseFold(left, right string, caseInsensitive bool) bool {
 	left = strings.TrimSpace(left)
 	right = strings.TrimSpace(right)
 	if left == "" || right == "" {
@@ -362,6 +366,10 @@ func persistenceTargetsMatch(left, right string) bool {
 	}
 	leftClean := filepath.Clean(left)
 	rightClean := filepath.Clean(right)
+	if caseInsensitive {
+		leftClean = strings.ToLower(leftClean)
+		rightClean = strings.ToLower(rightClean)
+	}
 	if leftClean == rightClean {
 		return true
 	}
@@ -379,12 +387,7 @@ func persistenceTargetsMatch(left, right string) bool {
 		filepath.VolumeName(relativeTarget) != "" {
 		return false
 	}
-	suffix := string(filepath.Separator) + relativeTarget
-	if filepath.Separator == '\\' {
-		absoluteTarget = strings.ToLower(absoluteTarget)
-		suffix = strings.ToLower(suffix)
-	}
-	return strings.HasSuffix(absoluteTarget, suffix)
+	return strings.HasSuffix(absoluteTarget, string(filepath.Separator)+relativeTarget)
 }
 
 func (m *Manager) authPersistenceTarget(auth *Auth) string {

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -346,7 +346,12 @@ func authAccessToken(auth *Auth) string {
 	if token := authMetadataString(auth, "access_token"); token != "" {
 		return token
 	}
-	return authMetadataString(auth, "accessToken")
+	if token := authMetadataString(auth, "accessToken"); token != "" {
+		return token
+	}
+	// Kimi executes with Attributes["access_token"] when metadata does not
+	// carry an access token, so that fallback is credential-revision material.
+	return authAttribute(auth, "access_token")
 }
 
 func authHasRefreshCredential(auth *Auth) bool {

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -484,6 +484,56 @@ func (m *Manager) refreshAuth(ctx context.Context, id string) {
 	_, _ = m.refreshAuthForRequest(ctx, id, "")
 }
 
+func (m *Manager) applyCredentialRefresh(ctx context.Context, before, expectedGeneration, refreshed *Auth, now time.Time) (*Auth, []string, bool, error) {
+	if m == nil || before == nil || expectedGeneration == nil || refreshed == nil {
+		return nil, nil, false, nil
+	}
+	for {
+		m.mu.RLock()
+		currentGeneration := m.auths[before.ID]
+		var current *Auth
+		if currentGeneration != nil {
+			current = currentGeneration.Clone()
+		}
+		m.mu.RUnlock()
+		if current == nil {
+			return nil, nil, false, nil
+		}
+		if !sameCredentialRevision(before, current, currentGeneration == expectedGeneration) {
+			return current, nil, false, nil
+		}
+
+		merged := mergeCredentialRefresh(current, before, refreshed)
+		if merged.Runtime == nil {
+			merged.Runtime = current.Runtime
+		}
+		merged.LastRefreshedAt = now
+		merged.NextRefreshAfter = time.Time{}
+		merged.UpdatedAt = now
+		var modelsToResume []string
+		if refreshLifecycleUnchanged(current, before) && refreshLifecycleUnchanged(refreshed, before) {
+			merged.LastError = nil
+			merged.StatusMessage = ""
+			merged.Unavailable = false
+			if merged.Status == StatusError {
+				merged.Status = StatusActive
+			}
+			modelsToResume = clearUnauthorizedModelStates(merged, now)
+		}
+		if m.shouldRefresh(merged, now) {
+			merged.NextRefreshAfter = now.Add(refreshIneffectiveBackoff)
+		}
+
+		saved, applied, errUpdate := m.updateAuth(ctx, merged, currentGeneration)
+		if applied {
+			return saved, modelsToResume, true, errUpdate
+		}
+		if errUpdate != nil || saved == nil {
+			return saved, nil, false, errUpdate
+		}
+	}
+}
+
 // refreshAuthForRequest performs a synchronous credential refresh for the given auth.
 // failedAccessToken lets concurrent callers reuse a refresh that already replaced the
 // access token that produced the unauthorized response.
@@ -526,7 +576,8 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		}
 	}
 
-	cloned := auth.Clone()
+	beforeRefresh, _ := snapshotAuthCredential(auth)
+	cloned := beforeRefresh.Clone()
 	updated, err := exec.Refresh(ctx, cloned)
 	if err != nil && errors.Is(err, context.Canceled) {
 		log.Debugf("refresh canceled for %s, %s", auth.Provider, auth.ID)
@@ -538,7 +589,13 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		unauthorized := isUnauthorizedError(err)
 		shouldReschedule := false
 		m.mu.Lock()
-		if current := m.auths[id]; current != nil {
+		current := m.auths[id]
+		if current != nil && !sameCredentialRevision(beforeRefresh, current, current == auth) {
+			replacement := current.Clone()
+			m.mu.Unlock()
+			return replacement, nil
+		}
+		if current != nil {
 			current.LastError = refreshErrorFromError(err)
 			if unauthorized {
 				current.NextRefreshAfter = time.Time{}
@@ -563,25 +620,13 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 	if updated == nil {
 		updated = cloned
 	}
-	// Preserve runtime created by the executor during Refresh.
-	// If executor didn't set one, fall back to the previous runtime.
-	if updated.Runtime == nil {
-		updated.Runtime = auth.Runtime
+	saved, modelsToResume, applied, errUpdate := m.applyCredentialRefresh(ctx, beforeRefresh, auth, updated, now)
+	if !applied {
+		if saved != nil {
+			return saved, nil
+		}
+		return nil, errUpdate
 	}
-	updated.LastRefreshedAt = now
-	updated.NextRefreshAfter = time.Time{}
-	updated.LastError = nil
-	updated.StatusMessage = ""
-	updated.Unavailable = false
-	if updated.Status == StatusError {
-		updated.Status = StatusActive
-	}
-	updated.UpdatedAt = now
-	modelsToResume := clearUnauthorizedModelStates(updated, now)
-	if m.shouldRefresh(updated, now) {
-		updated.NextRefreshAfter = now.Add(refreshIneffectiveBackoff)
-	}
-	saved, errUpdate := m.Update(ctx, updated)
 	for _, model := range modelsToResume {
 		registry.GetGlobalRegistry().ResumeClientModel(id, model)
 	}

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -484,6 +484,56 @@ func (m *Manager) refreshAuth(ctx context.Context, id string) {
 	_, _ = m.refreshAuthForRequest(ctx, id, "")
 }
 
+func (m *Manager) applyCredentialRefresh(ctx context.Context, before, expectedGeneration, refreshed *Auth, now time.Time) (*Auth, []string, bool, error) {
+	if m == nil || before == nil || expectedGeneration == nil || refreshed == nil {
+		return nil, nil, false, nil
+	}
+	for {
+		m.mu.RLock()
+		currentGeneration := m.auths[before.ID]
+		var current *Auth
+		if currentGeneration != nil {
+			current = currentGeneration.Clone()
+		}
+		m.mu.RUnlock()
+		if current == nil {
+			return nil, nil, false, nil
+		}
+		if !sameCredentialRevision(before, current, currentGeneration == expectedGeneration) {
+			return current, nil, false, nil
+		}
+
+		merged := mergeCredentialRefresh(current, before, refreshed)
+		if merged.Runtime == nil {
+			merged.Runtime = current.Runtime
+		}
+		merged.LastRefreshedAt = now
+		merged.NextRefreshAfter = time.Time{}
+		merged.UpdatedAt = now
+		var modelsToResume []string
+		if refreshLifecycleUnchanged(current, before) && refreshLifecycleUnchanged(refreshed, before) {
+			merged.LastError = nil
+			merged.StatusMessage = ""
+			merged.Unavailable = false
+			if merged.Status == StatusError {
+				merged.Status = StatusActive
+			}
+			modelsToResume = clearUnauthorizedModelStates(merged, now)
+		}
+		if m.shouldRefresh(merged, now) {
+			merged.NextRefreshAfter = now.Add(refreshIneffectiveBackoff)
+		}
+
+		saved, applied, errUpdate := m.updateAuth(ctx, merged, currentGeneration)
+		if applied {
+			return saved, modelsToResume, true, errUpdate
+		}
+		if errUpdate != nil || saved == nil {
+			return saved, nil, false, errUpdate
+		}
+	}
+}
+
 // refreshAuthForRequest performs a synchronous credential refresh for the given auth.
 // failedAccessToken lets concurrent callers reuse a refresh that already replaced the
 // access token that produced the unauthorized response.
@@ -528,7 +578,8 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		}
 	}
 
-	cloned := auth.Clone()
+	beforeRefresh, _ := snapshotAuthCredential(auth)
+	cloned := beforeRefresh.Clone()
 	updated, err := exec.Refresh(ctx, cloned)
 	if err != nil && errors.Is(err, context.Canceled) {
 		log.Debugf("refresh canceled for %s, %s", auth.Provider, auth.ID)
@@ -540,7 +591,13 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		unauthorized := isUnauthorizedError(err)
 		shouldReschedule := false
 		m.mu.Lock()
-		if current := m.auths[id]; current != nil {
+		current := m.auths[id]
+		if current != nil && !sameCredentialRevision(beforeRefresh, current, current == auth) {
+			replacement := current.Clone()
+			m.mu.Unlock()
+			return replacement, nil
+		}
+		if current != nil {
 			current.LastError = refreshErrorFromError(err)
 			if unauthorized {
 				current.NextRefreshAfter = time.Time{}
@@ -565,25 +622,13 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 	if updated == nil {
 		updated = cloned
 	}
-	// Preserve runtime created by the executor during Refresh.
-	// If executor didn't set one, fall back to the previous runtime.
-	if updated.Runtime == nil {
-		updated.Runtime = auth.Runtime
+	saved, modelsToResume, applied, errUpdate := m.applyCredentialRefresh(ctx, beforeRefresh, auth, updated, now)
+	if !applied {
+		if saved != nil {
+			return saved, nil
+		}
+		return nil, errUpdate
 	}
-	updated.LastRefreshedAt = now
-	updated.NextRefreshAfter = time.Time{}
-	updated.LastError = nil
-	updated.StatusMessage = ""
-	updated.Unavailable = false
-	if updated.Status == StatusError {
-		updated.Status = StatusActive
-	}
-	updated.UpdatedAt = now
-	modelsToResume := clearUnauthorizedModelStates(updated, now)
-	if m.shouldRefresh(updated, now) {
-		updated.NextRefreshAfter = now.Add(refreshIneffectiveBackoff)
-	}
-	saved, errUpdate := m.Update(ctx, updated)
 	for _, model := range modelsToResume {
 		registry.GetGlobalRegistry().ResumeClientModel(id, model)
 	}

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -182,6 +182,7 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 	}
 
 	var snapshot *Auth
+	persistCooldownState := false
 	now := time.Now()
 
 	m.mu.Lock()
@@ -224,6 +225,7 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 			if errPersist := m.persist(ctx, auth); errPersist != nil {
 				logEntryWithRequestID(ctx).WithField("auth_id", auth.ID).Warnf("failed to persist auth changes during model state reconciliation: %v", errPersist)
 			}
+			persistCooldownState = m.cooldownStore != nil
 			snapshot = auth.Clone()
 		}
 	}
@@ -231,6 +233,9 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 
 	if m.scheduler != nil && snapshot != nil {
 		m.scheduler.upsertAuth(snapshot)
+	}
+	if snapshot != nil && persistCooldownState {
+		m.persistCooldownStates(ctx)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -113,7 +113,7 @@ func readStreamBootstrap(ctx context.Context, ch <-chan cliproxyexecutor.StreamC
 	}
 }
 
-func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, resultModel string, headers http.Header, buffered []cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk, aliasResult OAuthModelAliasResult, ephemeralResult bool) *cliproxyexecutor.StreamResult {
+func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, resultModel string, headers http.Header, buffered []cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk, aliasResult OAuthModelAliasResult, credentialRevision authCredentialRevision, ephemeralResult bool) *cliproxyexecutor.StreamResult {
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {
 		defer close(out)
@@ -127,7 +127,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 			if chunk.Err != nil && !failed {
 				failed = true
 				rerr := resultErrorFromError(chunk.Err)
-				m.recordExecutionResult(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}, auth, ephemeralResult)
+				m.recordExecutionResultWithRevision(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}, auth, ephemeralResult, credentialRevision)
 			}
 			if !forward {
 				return false
@@ -184,7 +184,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 			}
 		}
 		if !failed && (ephemeralResult || claudeOAuthRequestCancellation(ctx, auth, nil) == nil) {
-			m.recordExecutionResult(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: true}, auth, ephemeralResult)
+			m.recordExecutionResultWithRevision(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: true}, auth, ephemeralResult, credentialRevision)
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: headers, Chunks: out}
@@ -227,7 +227,8 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		if errCtx := ctx.Err(); errCtx != nil {
 			return nil, errCtx
 		}
-		streamResult, errStream := executor.ExecuteStream(ctx, auth, execReq, execOpts)
+		requestAuth, credentialRevision := snapshotAuthCredential(auth)
+		streamResult, errStream := executor.ExecuteStream(ctx, requestAuth, execReq, execOpts)
 		if errStream != nil {
 			if errCtx := ctx.Err(); errCtx != nil {
 				return nil, errCtx
@@ -249,7 +250,8 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 					m.replaceHomeExecutionLifecycleAuth(execOpts.ExecutionLifecycle, auth)
 					publishSelectedAuthMetadata(execOpts.Metadata, auth)
 					didRefreshOnUnauthorized = true
-					streamResult, errStream = executor.ExecuteStream(ctx, auth, execReq, execOpts)
+					requestAuth, credentialRevision = snapshotAuthCredential(auth)
+					streamResult, errStream = executor.ExecuteStream(ctx, requestAuth, execReq, execOpts)
 					if errStream != nil {
 						if errCtx := ctx.Err(); errCtx != nil {
 							return nil, errCtx
@@ -268,7 +270,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			rerr := resultErrorFromError(errStream)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
 			result.RetryAfter = retryAfterFromError(errStream)
-			m.recordExecutionResult(ctx, result, auth, ephemeralResult)
+			m.recordExecutionResultWithRevision(ctx, result, auth, ephemeralResult, credentialRevision)
 			if isRequestInvalidError(errStream) {
 				return nil, errStream
 			}
@@ -302,7 +304,8 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 					m.replaceHomeExecutionLifecycleAuth(execOpts.ExecutionLifecycle, auth)
 					publishSelectedAuthMetadata(execOpts.Metadata, auth)
 					didRefreshOnUnauthorized = true
-					retryStream, retryErr := executor.ExecuteStream(ctx, auth, execReq, execOpts)
+					requestAuth, credentialRevision = snapshotAuthCredential(auth)
+					retryStream, retryErr := executor.ExecuteStream(ctx, requestAuth, execReq, execOpts)
 					retryStream, retryErr = validateStreamResult(retryStream, retryErr)
 					if retryErr != nil {
 						if errCtx := ctx.Err(); errCtx != nil {
@@ -328,7 +331,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				rerr := resultErrorFromError(bootstrapErr)
 				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
-				m.recordExecutionResult(ctx, result, auth, ephemeralResult)
+				m.recordExecutionResultWithRevision(ctx, result, auth, ephemeralResult, credentialRevision)
 				discardStreamChunks(streamResult.Chunks)
 				return nil, bootstrapErr
 			}
@@ -336,7 +339,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				rerr := resultErrorFromError(bootstrapErr)
 				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
-				m.recordExecutionResult(ctx, result, auth, ephemeralResult)
+				m.recordExecutionResultWithRevision(ctx, result, auth, ephemeralResult, credentialRevision)
 				discardStreamChunks(streamResult.Chunks)
 				lastErr = bootstrapErr
 				continue
@@ -344,7 +347,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			rerr := resultErrorFromError(bootstrapErr)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
 			result.RetryAfter = retryAfterFromError(bootstrapErr)
-			m.recordExecutionResult(ctx, result, auth, ephemeralResult)
+			m.recordExecutionResultWithRevision(ctx, result, auth, ephemeralResult, credentialRevision)
 			discardStreamChunks(streamResult.Chunks)
 			return nil, newStreamBootstrapError(bootstrapErr, streamResult.Headers)
 		}
@@ -352,7 +355,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		if closed && len(buffered) == 0 {
 			emptyErr := &Error{Code: "empty_stream", Message: "upstream stream closed before first payload", Retryable: true}
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: emptyErr}
-			m.recordExecutionResult(ctx, result, auth, ephemeralResult)
+			m.recordExecutionResultWithRevision(ctx, result, auth, ephemeralResult, credentialRevision)
 			if idx < len(execModels)-1 {
 				lastErr = emptyErr
 				continue
@@ -367,7 +370,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			remaining = closedCh
 		}
 		attemptAliasResult := resolveAttemptAliasResult(routing, auth, routeModel, execModel, aliasResult)
-		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, buffered, remaining, attemptAliasResult, ephemeralResult), nil
+		return m.wrapStreamResult(ctx, requestAuth, provider, resultModel, streamResult.Headers, buffered, remaining, attemptAliasResult, credentialRevision, ephemeralResult), nil
 	}
 	if lastErr == nil {
 		lastErr = &Error{Code: "auth_not_found", Message: "no upstream model available"}

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -227,7 +227,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		if errCtx := ctx.Err(); errCtx != nil {
 			return nil, errCtx
 		}
-		requestAuth, credentialRevision := snapshotAuthCredential(auth)
+		requestAuth, credentialRevision := snapshotAuthCredentialForExecution(ctx, auth, execReq, execOpts)
 		streamResult, errStream := executor.ExecuteStream(ctx, requestAuth, execReq, execOpts)
 		if errStream != nil {
 			if errCtx := ctx.Err(); errCtx != nil {
@@ -250,7 +250,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 					m.replaceHomeExecutionLifecycleAuth(execOpts.ExecutionLifecycle, auth)
 					publishSelectedAuthMetadata(execOpts.Metadata, auth)
 					didRefreshOnUnauthorized = true
-					requestAuth, credentialRevision = snapshotAuthCredential(auth)
+					requestAuth, credentialRevision = snapshotAuthCredentialForExecution(ctx, auth, execReq, execOpts)
 					streamResult, errStream = executor.ExecuteStream(ctx, requestAuth, execReq, execOpts)
 					if errStream != nil {
 						if errCtx := ctx.Err(); errCtx != nil {
@@ -304,7 +304,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 					m.replaceHomeExecutionLifecycleAuth(execOpts.ExecutionLifecycle, auth)
 					publishSelectedAuthMetadata(execOpts.Metadata, auth)
 					didRefreshOnUnauthorized = true
-					requestAuth, credentialRevision = snapshotAuthCredential(auth)
+					requestAuth, credentialRevision = snapshotAuthCredentialForExecution(ctx, auth, execReq, execOpts)
 					retryStream, retryErr := executor.ExecuteStream(ctx, requestAuth, execReq, execOpts)
 					retryStream, retryErr = validateStreamResult(retryStream, retryErr)
 					if retryErr != nil {

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -11,6 +11,7 @@ import (
 	baseauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth"
 	claudeauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/claude"
 	codexauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
+	xaiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/xai"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/redisqueue"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -2382,6 +2383,104 @@ func TestRefreshAuthForRequestAppliesRefreshReturnedScalarFields(t *testing.T) {
 	}
 	if !current.Disabled || current.Status != StatusDisabled || current.StatusMessage != "disabled by provider refresh" {
 		t.Fatalf("refresh lifecycle fields were dropped: %#v", current)
+	}
+}
+
+func TestAuthCredentialFingerprintUsesXAIEffectiveChatRoute(t *testing.T) {
+	left := &Auth{
+		Provider: "xai",
+		Metadata: map[string]any{
+			"access_token":  "stable-token",
+			"refresh_token": "stable-refresh-token",
+			"base_url":      xaiauth.DefaultAPIBaseURL,
+			"using_api":     true,
+			"auth_kind":     "oauth",
+		},
+	}
+	right := left.Clone()
+	right.Metadata["using_api"] = false
+
+	leftFingerprint, leftOK := authCredentialFingerprint(left)
+	rightFingerprint, rightOK := authCredentialFingerprint(right)
+	if !leftOK || !rightOK {
+		t.Fatalf("fingerprint availability = (%t, %t), want both true", leftOK, rightOK)
+	}
+	if leftFingerprint == rightFingerprint {
+		t.Fatal("changing xAI's effective chat route did not change credential revision")
+	}
+}
+
+func TestAuthCredentialFingerprintIgnoresXAIUsingAPIForCustomEndpoint(t *testing.T) {
+	left := &Auth{
+		Provider: "xai",
+		Metadata: map[string]any{
+			"access_token":  "stable-token",
+			"refresh_token": "stable-refresh-token",
+			"base_url":      "https://custom-xai.example.com/v1",
+			"using_api":     true,
+			"auth_kind":     "oauth",
+		},
+	}
+	right := left.Clone()
+	right.Metadata["using_api"] = false
+
+	leftFingerprint, leftOK := authCredentialFingerprint(left)
+	rightFingerprint, rightOK := authCredentialFingerprint(right)
+	if !leftOK || !rightOK {
+		t.Fatalf("fingerprint availability = (%t, %t), want both true", leftOK, rightOK)
+	}
+	if leftFingerprint != rightFingerprint {
+		t.Fatal("xAI using_api changed revision despite an explicit custom endpoint selecting the same route")
+	}
+}
+
+func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterXAIRouteReplacement(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	oldAuth := &Auth{
+		ID:       "xai-chat-route.json",
+		Provider: "xai",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token":  "stable-token",
+			"refresh_token": "stable-refresh-token",
+			"base_url":      xaiauth.DefaultAPIBaseURL,
+			"using_api":     true,
+			"auth_kind":     "oauth",
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), oldAuth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	selected, okSelected := m.GetByID(oldAuth.ID)
+	if !okSelected || selected == nil {
+		t.Fatal("selected auth missing")
+	}
+
+	replacement := selected.Clone()
+	replacement.Metadata["using_api"] = false
+	if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   oldAuth.ID,
+		Provider: oldAuth.Provider,
+		Model:    "grok-test",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "old xAI route unauthorized"},
+	}, selected, false)
+
+	current, okCurrent := m.GetByID(oldAuth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("replacement auth missing")
+	}
+	if got, ok := current.Metadata["using_api"].(bool); !ok || got {
+		t.Fatalf("current xAI using_api = %#v, want false", current.Metadata["using_api"])
+	}
+	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+		t.Fatalf("stale xAI route result changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("stale xAI route result created model states: %#v", current.ModelStates)
 	}
 }
 

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -1410,38 +1410,54 @@ func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterCredentialReplacement
 	}
 }
 
-func TestRecordExecutionResultAppliesStaleQuotaFailureAfterTokenRotation(t *testing.T) {
-	m := NewManager(nil, nil, nil)
-	oldAuth := &Auth{
-		ID:       "codex-quota.json",
-		Provider: "codex",
-		Status:   StatusActive,
-		Metadata: map[string]any{"access_token": "old-access-token"},
-	}
-	if _, err := m.Register(context.Background(), oldAuth); err != nil {
-		t.Fatalf("Register: %v", err)
-	}
-	selected, _ := m.GetByID(oldAuth.ID)
-	replacement := selected.Clone()
-	replacement.Metadata["access_token"] = "rotated-access-token"
-	if _, err := m.Update(context.Background(), replacement); err != nil {
-		t.Fatalf("Update replacement: %v", err)
-	}
+func TestRecordExecutionResultIgnoresStaleAvailabilityFailureAfterTokenRotation(t *testing.T) {
+	for _, statusCode := range []int{
+		http.StatusPaymentRequired,
+		http.StatusForbidden,
+		http.StatusTooManyRequests,
+	} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			m := NewManager(nil, nil, nil)
+			oldAuth := &Auth{
+				ID:       "codex-stale-availability.json",
+				Provider: "codex",
+				Status:   StatusActive,
+				Metadata: map[string]any{"access_token": "old-access-token"},
+			}
+			if _, err := m.Register(context.Background(), oldAuth); err != nil {
+				t.Fatalf("Register: %v", err)
+			}
+			selected, _ := m.GetByID(oldAuth.ID)
+			replacement := selected.Clone()
+			replacement.Metadata["access_token"] = "rotated-access-token"
+			if _, err := m.Update(context.Background(), replacement); err != nil {
+				t.Fatalf("Update replacement: %v", err)
+			}
 
-	m.recordExecutionResult(context.Background(), Result{
-		AuthID:   oldAuth.ID,
-		Provider: oldAuth.Provider,
-		Model:    "gpt-test",
-		Error:    &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"},
-	}, selected, false)
+			m.recordExecutionResult(context.Background(), Result{
+				AuthID:   oldAuth.ID,
+				Provider: oldAuth.Provider,
+				Model:    "gpt-test",
+				Error:    &Error{HTTPStatus: statusCode, Message: http.StatusText(statusCode)},
+			}, selected, false)
 
-	current, _ := m.GetByID(oldAuth.ID)
-	if current == nil || current.Status != StatusError || current.LastError == nil {
-		t.Fatalf("quota result from pre-rotation request was not applied: %#v", current)
-	}
-	state := current.ModelStates["gpt-test"]
-	if state == nil || !state.Quota.Exceeded {
-		t.Fatalf("quota model state missing: %#v", state)
+			current, _ := m.GetByID(oldAuth.ID)
+			if current == nil {
+				t.Fatal("replacement auth missing")
+			}
+			if got := authAccessToken(current); got != "rotated-access-token" {
+				t.Fatalf("current access token = %q, want rotated token", got)
+			}
+			if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+				t.Fatalf("stale %d result changed replacement auth: %#v", statusCode, current)
+			}
+			if len(current.ModelStates) != 0 {
+				t.Fatalf("stale %d result created model states: %#v", statusCode, current.ModelStates)
+			}
+			if current.Failed != 1 {
+				t.Fatalf("failed count = %d, want request counted without changing availability", current.Failed)
+			}
+		})
 	}
 }
 
@@ -2287,6 +2303,55 @@ func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterAPIKeyReplacement(t *
 	}
 	if len(current.ModelStates) != 0 {
 		t.Fatalf("stale API-key result created model states: %#v", current.ModelStates)
+	}
+}
+
+func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterKimiAttributeTokenRotation(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	oldAuth := &Auth{
+		ID:       "kimi-attribute-token.json",
+		Provider: "kimi",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"access_token": "old-attribute-token",
+		},
+		Metadata: map[string]any{
+			"refresh_token": "stable-refresh-token",
+		},
+	}
+	if _, err := m.Register(context.Background(), oldAuth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	selected, okSelected := m.GetByID(oldAuth.ID)
+	if !okSelected || selected == nil {
+		t.Fatal("selected auth missing")
+	}
+
+	replacement := selected.Clone()
+	replacement.Attributes["access_token"] = "replacement-attribute-token"
+	if _, err := m.Update(context.Background(), replacement); err != nil {
+		t.Fatalf("Update replacement: %v", err)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   oldAuth.ID,
+		Provider: oldAuth.Provider,
+		Model:    "kimi-test",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "old Kimi token unauthorized"},
+	}, selected, false)
+
+	current, okCurrent := m.GetByID(oldAuth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("current auth missing")
+	}
+	if got := authAttribute(current, "access_token"); got != "replacement-attribute-token" {
+		t.Fatalf("current attribute access token = %q, want replacement token", got)
+	}
+	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+		t.Fatalf("stale Kimi result changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("stale Kimi result created model states: %#v", current.ModelStates)
 	}
 }
 

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -883,6 +883,17 @@ func TestConditionalUpdateDoesNotPublishStaleOwnerAfterReplacement(t *testing.T)
 	}
 }
 
+func TestPersistenceTargetsMatchCaseInsensitiveAbsolutePaths(t *testing.T) {
+	left := filepath.Join(string(filepath.Separator), "Credentials", "Auth.json")
+	right := filepath.Join(string(filepath.Separator), "credentials", "auth.json")
+	if !persistenceTargetsMatchWithCaseFold(left, right, true) {
+		t.Fatalf("case-insensitive absolute targets %q and %q should match", left, right)
+	}
+	if persistenceTargetsMatchWithCaseFold(left, right, false) {
+		t.Fatalf("case-sensitive absolute targets %q and %q unexpectedly match", left, right)
+	}
+}
+
 func TestConditionalUpdateRemovesStaleTargetAcrossRelativeSubdirectoryRename(t *testing.T) {
 	store := &targetTrackingCredentialStore{root: t.TempDir()}
 	manager := NewManager(store, nil, nil)

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -1,0 +1,2295 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	baseauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth"
+	claudeauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/claude"
+	codexauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/redisqueue"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type opaqueCredentialStorage struct{}
+
+func (*opaqueCredentialStorage) SaveTokenToFile(string) error { return nil }
+
+type rawJSONCredentialStorage struct {
+	payload []byte
+}
+
+func (*rawJSONCredentialStorage) SaveTokenToFile(string) error { return nil }
+
+func (s *rawJSONCredentialStorage) RawJSON() []byte {
+	if s == nil {
+		return nil
+	}
+	return append([]byte(nil), s.payload...)
+}
+
+type coherentCredentialSnapshotStorage struct {
+	payload  []byte
+	metadata map[string]any
+}
+
+func (*coherentCredentialSnapshotStorage) SaveTokenToFile(string) error { return nil }
+
+func (s *coherentCredentialSnapshotStorage) RawJSON() []byte {
+	if s == nil {
+		return nil
+	}
+	return append([]byte(nil), s.payload...)
+}
+
+func (s *coherentCredentialSnapshotStorage) CredentialSnapshot() ([]byte, map[string]any, baseauth.CredentialFingerprintMaterial) {
+	if s == nil {
+		return nil, nil, baseauth.CredentialFingerprintMaterial{}
+	}
+	metadata := make(map[string]any, len(s.metadata))
+	for key, value := range s.metadata {
+		metadata[key] = value
+	}
+	payload := append([]byte(nil), s.payload...)
+	return payload, metadata, baseauth.CredentialFingerprintMaterial{Opaque: string(payload)}
+}
+
+type mutableCredentialSnapshotStorage struct {
+	mu       sync.RWMutex
+	metadata map[string]any
+}
+
+func (*mutableCredentialSnapshotStorage) SaveTokenToFile(string) error { return nil }
+
+func (s *mutableCredentialSnapshotStorage) SetMetadata(metadata map[string]any) {
+	s.mu.Lock()
+	s.metadata = cloneCredentialMetadataValue(metadata).(map[string]any)
+	s.mu.Unlock()
+}
+
+func (s *mutableCredentialSnapshotStorage) CredentialSnapshot() ([]byte, map[string]any, baseauth.CredentialFingerprintMaterial) {
+	s.mu.RLock()
+	metadata := cloneCredentialMetadataValue(s.metadata).(map[string]any)
+	s.mu.RUnlock()
+	token, _ := metadata["token"].(string)
+	return []byte(token), metadata, baseauth.CredentialFingerprintMaterial{Opaque: token}
+}
+
+type blockedMetadataPersistenceStore struct {
+	blockNext chan struct{}
+	blocked   chan struct{}
+	release   chan struct{}
+}
+
+func (*blockedMetadataPersistenceStore) List(context.Context) ([]*Auth, error) { return nil, nil }
+func (*blockedMetadataPersistenceStore) Delete(context.Context, string) error  { return nil }
+
+func (s *blockedMetadataPersistenceStore) Save(_ context.Context, auth *Auth) (string, error) {
+	select {
+	case <-s.blockNext:
+		close(s.blocked)
+		<-s.release
+	default:
+	}
+	if setter, ok := auth.Storage.(interface{ SetMetadata(map[string]any) }); ok {
+		setter.SetMetadata(auth.Metadata)
+	}
+	return auth.ID, nil
+}
+
+type fingerprintedRawJSONCredentialStorage struct {
+	payload  []byte
+	material baseauth.CredentialFingerprintMaterial
+}
+
+func (*fingerprintedRawJSONCredentialStorage) SaveTokenToFile(string) error { return nil }
+
+func (s *fingerprintedRawJSONCredentialStorage) RawJSON() []byte {
+	if s == nil {
+		return nil
+	}
+	return append([]byte(nil), s.payload...)
+}
+
+func (s *fingerprintedRawJSONCredentialStorage) CredentialFingerprintMaterial() baseauth.CredentialFingerprintMaterial {
+	if s == nil {
+		return baseauth.CredentialFingerprintMaterial{}
+	}
+	return s.material
+}
+
+type orderedCredentialStore struct {
+	mu             sync.Mutex
+	blockNext      bool
+	blocked        bool
+	concurrentSeen bool
+	blockedSave    chan struct{}
+	releaseSave    chan struct{}
+	concurrentSave chan struct{}
+	lastPersisted  *Auth
+	lastDeletedID  string
+}
+
+func (*orderedCredentialStore) List(context.Context) ([]*Auth, error) { return nil, nil }
+
+func (s *orderedCredentialStore) Save(_ context.Context, auth *Auth) (string, error) {
+	s.mu.Lock()
+	if s.blockNext {
+		s.blockNext = false
+		s.blocked = true
+		blockedSave := s.blockedSave
+		releaseSave := s.releaseSave
+		s.mu.Unlock()
+
+		close(blockedSave)
+		<-releaseSave
+
+		s.mu.Lock()
+		s.blocked = false
+		s.lastPersisted = auth.Clone()
+		s.mu.Unlock()
+		return orderedCredentialStoreSaveID(auth), nil
+	}
+	if s.blocked && !s.concurrentSeen {
+		s.concurrentSeen = true
+		close(s.concurrentSave)
+	}
+	s.lastPersisted = auth.Clone()
+	s.mu.Unlock()
+	return orderedCredentialStoreSaveID(auth), nil
+}
+
+func orderedCredentialStoreSaveID(auth *Auth) string {
+	if auth == nil {
+		return ""
+	}
+	if auth.FileName != "" {
+		return auth.FileName
+	}
+	return auth.ID
+}
+
+func (s *orderedCredentialStore) Delete(_ context.Context, id string) error {
+	s.mu.Lock()
+	s.lastPersisted = nil
+	s.lastDeletedID = id
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *orderedCredentialStore) blockNextSave() {
+	s.mu.Lock()
+	s.blockNext = true
+	s.blockedSave = make(chan struct{})
+	s.releaseSave = make(chan struct{})
+	s.concurrentSave = make(chan struct{})
+	s.mu.Unlock()
+}
+
+func (s *orderedCredentialStore) lastAuth() *Auth {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastPersisted.Clone()
+}
+
+func (s *orderedCredentialStore) lastDeleteID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastDeletedID
+}
+
+type targetTrackingCredentialStore struct {
+	mu          sync.Mutex
+	blockNext   bool
+	blockedSave chan struct{}
+	releaseSave chan struct{}
+	persisted   map[string]*Auth
+}
+
+func (*targetTrackingCredentialStore) List(context.Context) ([]*Auth, error) { return nil, nil }
+
+func (s *targetTrackingCredentialStore) Save(_ context.Context, auth *Auth) (string, error) {
+	target := orderedCredentialStoreSaveID(auth)
+	s.mu.Lock()
+	if s.blockNext {
+		s.blockNext = false
+		blockedSave := s.blockedSave
+		releaseSave := s.releaseSave
+		s.mu.Unlock()
+
+		close(blockedSave)
+		<-releaseSave
+
+		s.mu.Lock()
+	}
+	if s.persisted == nil {
+		s.persisted = make(map[string]*Auth)
+	}
+	s.persisted[target] = auth.Clone()
+	s.mu.Unlock()
+	return target, nil
+}
+
+func (s *targetTrackingCredentialStore) Delete(_ context.Context, id string) error {
+	s.mu.Lock()
+	delete(s.persisted, id)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *targetTrackingCredentialStore) blockNextSaveCall() {
+	s.mu.Lock()
+	s.blockNext = true
+	s.blockedSave = make(chan struct{})
+	s.releaseSave = make(chan struct{})
+	s.mu.Unlock()
+}
+
+func (s *targetTrackingCredentialStore) authAt(target string) *Auth {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.persisted[target].Clone()
+}
+
+type blockingUnauthorizedCredentialExecutor struct {
+	started  chan struct{}
+	release  chan struct{}
+	provider string
+}
+
+func (e *blockingUnauthorizedCredentialExecutor) Identifier() string {
+	if e.provider != "" {
+		return e.provider
+	}
+	return "codex"
+}
+
+func (e *blockingUnauthorizedCredentialExecutor) Execute(ctx context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	select {
+	case <-e.started:
+	default:
+		close(e.started)
+	}
+	select {
+	case <-e.release:
+		return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusUnauthorized, Message: "old token unauthorized"}
+	case <-ctx.Done():
+		return cliproxyexecutor.Response{}, ctx.Err()
+	}
+}
+
+func (e *blockingUnauthorizedCredentialExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func (e *blockingUnauthorizedCredentialExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *blockingUnauthorizedCredentialExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func (e *blockingUnauthorizedCredentialExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func TestExecuteIgnoresFailureFromCredentialReplacedInFlight(t *testing.T) {
+	executor := &blockingUnauthorizedCredentialExecutor{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+	m.SetRetryConfig(0, 0, 1)
+	auth := &Auth{
+		ID:       "codex-inflight.json",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{"access_token": "old-access-token"},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "gpt-test"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	m.RefreshSchedulerEntry(auth.ID)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := m.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-test"}, cliproxyexecutor.Options{})
+		done <- err
+	}()
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("execution did not start")
+	}
+
+	current, _ := m.GetByID(auth.ID)
+	replacement := current.Clone()
+	replacement.Metadata["access_token"] = "new-access-token"
+	if _, err := m.Update(context.Background(), replacement); err != nil {
+		t.Fatalf("Update replacement: %v", err)
+	}
+	close(executor.release)
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Execute error = nil, want old credential unauthorized")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("execution did not finish")
+	}
+
+	current, _ = m.GetByID(auth.ID)
+	if current == nil || current.Status != StatusActive || current.Unavailable || current.LastError != nil {
+		t.Fatalf("in-flight old failure changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("in-flight old failure created model state: %#v", current.ModelStates)
+	}
+}
+
+type lateUnauthorizedStreamCredentialExecutor struct {
+	provider string
+	release  chan struct{}
+}
+
+func (e *lateUnauthorizedStreamCredentialExecutor) Identifier() string { return e.provider }
+
+func (*lateUnauthorizedStreamCredentialExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func (e *lateUnauthorizedStreamCredentialExecutor) ExecuteStream(ctx context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	chunks := make(chan cliproxyexecutor.StreamChunk, 2)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("started")}
+	go func() {
+		defer close(chunks)
+		select {
+		case <-e.release:
+			chunks <- cliproxyexecutor.StreamChunk{Err: &Error{HTTPStatus: http.StatusUnauthorized, Message: "old stream unauthorized"}}
+		case <-ctx.Done():
+		}
+	}()
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *lateUnauthorizedStreamCredentialExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (*lateUnauthorizedStreamCredentialExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func (*lateUnauthorizedStreamCredentialExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func TestExecuteCapturesOpaquePluginCredentialBeforeDispatch(t *testing.T) {
+	const provider = "opaque-plugin"
+	executor := &blockingUnauthorizedCredentialExecutor{
+		started:  make(chan struct{}),
+		release:  make(chan struct{}),
+		provider: provider,
+	}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+	m.SetRetryConfig(0, 0, 1)
+	storage := &rawJSONCredentialStorage{payload: []byte(`{"token":"old-token"}`)}
+	auth := &Auth{ID: "opaque-plugin-inflight.json", Provider: provider, Status: StatusActive, Storage: storage}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "plugin-model"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	m.RefreshSchedulerEntry(auth.ID)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := m.Execute(context.Background(), []string{provider}, cliproxyexecutor.Request{Model: "plugin-model"}, cliproxyexecutor.Options{})
+		done <- err
+	}()
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("execution did not start")
+	}
+
+	storage.payload = []byte(`{"token":"new-token"}`)
+	current, _ := m.GetByID(auth.ID)
+	if _, err := m.Update(context.Background(), current.Clone()); err != nil {
+		t.Fatalf("Update replacement: %v", err)
+	}
+	close(executor.release)
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Execute error = nil, want old credential unauthorized")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("execution did not finish")
+	}
+
+	current, _ = m.GetByID(auth.ID)
+	if current == nil || current.Status != StatusActive || current.Unavailable || current.LastError != nil {
+		t.Fatalf("in-flight old failure changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("in-flight old failure created model state: %#v", current.ModelStates)
+	}
+}
+
+func TestConditionalUpdatePersistsBeforeReplacementTakesOwnership(t *testing.T) {
+	store := &orderedCredentialStore{}
+	m := NewManager(store, nil, nil)
+	auth := &Auth{
+		ID:       "refresh-persist-race.json",
+		Provider: "opaque-plugin",
+		Metadata: map[string]any{"access_token": "old-token"},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	m.mu.RLock()
+	expectedCurrent := m.auths[auth.ID]
+	m.mu.RUnlock()
+	if expectedCurrent == nil {
+		t.Fatal("registered auth missing")
+	}
+
+	refreshed := expectedCurrent.Clone()
+	refreshed.Metadata["access_token"] = "refreshed-old-token"
+	replacement := expectedCurrent.Clone()
+	replacement.Metadata["access_token"] = "replacement-token"
+
+	store.blockNextSave()
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, _, err := m.updateAuth(context.Background(), refreshed, expectedCurrent)
+		refreshDone <- err
+	}()
+	select {
+	case <-store.blockedSave:
+	case <-time.After(time.Second):
+		t.Fatal("refresh persistence did not block")
+	}
+
+	replacementDone := make(chan error, 1)
+	go func() {
+		_, err := m.Update(context.Background(), replacement)
+		replacementDone <- err
+	}()
+	select {
+	case <-store.concurrentSave:
+	case <-time.After(250 * time.Millisecond):
+	}
+	close(store.releaseSave)
+
+	select {
+	case err := <-refreshDone:
+		if err != nil {
+			t.Fatalf("conditional update: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("conditional update did not finish")
+	}
+	select {
+	case err := <-replacementDone:
+		if err != nil {
+			t.Fatalf("replacement update: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("replacement update did not finish")
+	}
+
+	persisted := store.lastAuth()
+	if got := authMetadataString(persisted, "access_token"); got != "replacement-token" {
+		t.Fatalf("last persisted access token = %q, want replacement token", got)
+	}
+}
+
+func TestUpdateSynchronizesMutableCredentialStorageBeforePublication(t *testing.T) {
+	store := &blockedMetadataPersistenceStore{
+		blockNext: make(chan struct{}),
+		blocked:   make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+	storage := &mutableCredentialSnapshotStorage{metadata: map[string]any{"token": "old-token"}}
+	m := NewManager(store, &RoundRobinSelector{}, nil)
+	auth := &Auth{
+		ID:       "plugin-metadata-patch.json",
+		Provider: "opaque-plugin",
+		Metadata: map[string]any{"token": "old-token"},
+		Storage:  storage,
+	}
+	if _, err := m.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	patched, _ := m.GetByID(auth.ID)
+	patched.Metadata["token"] = "new-token"
+	close(store.blockNext)
+	updateDone := make(chan error, 1)
+	go func() {
+		_, err := m.Update(context.Background(), patched)
+		updateDone <- err
+	}()
+	select {
+	case <-store.blocked:
+	case <-time.After(time.Second):
+		t.Fatal("persistence did not block")
+	}
+
+	published, ok := m.GetByID(auth.ID)
+	if !ok || published == nil {
+		t.Fatal("published auth missing")
+	}
+	execution, _ := snapshotAuthCredential(published)
+	if token, _ := execution.Metadata["token"].(string); token != "new-token" {
+		t.Fatalf("dispatch snapshot token = %q, want new-token", token)
+	}
+
+	close(store.release)
+	select {
+	case err := <-updateDone:
+		if err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Update did not finish")
+	}
+}
+
+func TestConditionalUpdateDoesNotPublishStaleOwnerAfterReplacement(t *testing.T) {
+	store := &orderedCredentialStore{}
+	m := NewManager(store, &RoundRobinSelector{}, nil)
+	auth := &Auth{
+		ID:       "refresh-publish-race.json",
+		Provider: "opaque-plugin",
+		Metadata: map[string]any{"access_token": "old-token"},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	m.mu.RLock()
+	expectedCurrent := m.auths[auth.ID]
+	m.mu.RUnlock()
+	if expectedCurrent == nil {
+		t.Fatal("registered auth missing")
+	}
+	refreshed := expectedCurrent.Clone()
+	refreshed.Metadata["access_token"] = "refreshed-old-token"
+	replacement := expectedCurrent.Clone()
+	replacement.Metadata["access_token"] = "replacement-token"
+
+	type updateResult struct {
+		auth    *Auth
+		applied bool
+		err     error
+	}
+	store.blockNextSave()
+	refreshDone := make(chan updateResult, 1)
+	go func() {
+		updated, applied, err := m.updateAuth(context.Background(), refreshed, expectedCurrent)
+		refreshDone <- updateResult{auth: updated, applied: applied, err: err}
+	}()
+	select {
+	case <-store.blockedSave:
+	case <-time.After(time.Second):
+		t.Fatal("refresh persistence did not block")
+	}
+
+	if _, err := m.Update(context.Background(), replacement); err != nil {
+		t.Fatalf("Update replacement: %v", err)
+	}
+	close(store.releaseSave)
+
+	var got updateResult
+	select {
+	case got = <-refreshDone:
+	case <-time.After(time.Second):
+		t.Fatal("conditional update did not finish")
+	}
+	if got.err != nil {
+		t.Fatalf("conditional update: %v", got.err)
+	}
+	if got.applied {
+		t.Fatal("conditional update reported stale owner as applied")
+	}
+	if token := authMetadataString(got.auth, "access_token"); token != "replacement-token" {
+		t.Fatalf("conditional update returned token %q, want replacement token", token)
+	}
+
+	picked, errPick := m.scheduler.pickSingle(context.Background(), auth.Provider, "", cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("scheduler pick: %v", errPick)
+	}
+	if token := authMetadataString(picked, "access_token"); token != "replacement-token" {
+		t.Fatalf("scheduler published token %q, want replacement token", token)
+	}
+}
+
+func TestConditionalUpdateRemovesStaleTargetAfterReplacementRename(t *testing.T) {
+	store := &targetTrackingCredentialStore{}
+	m := NewManager(store, nil, nil)
+	auth := &Auth{
+		ID:       "stable-runtime-id",
+		FileName: "old-credential.json",
+		Provider: "opaque-plugin",
+		Metadata: map[string]any{"access_token": "old-token"},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	m.mu.RLock()
+	expectedCurrent := m.auths[auth.ID]
+	m.mu.RUnlock()
+	if expectedCurrent == nil {
+		t.Fatal("registered auth missing")
+	}
+
+	refreshed := expectedCurrent.Clone()
+	refreshed.Metadata["access_token"] = "refreshed-old-token"
+	store.blockNextSaveCall()
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, _, err := m.updateAuth(context.Background(), refreshed, expectedCurrent)
+		refreshDone <- err
+	}()
+	select {
+	case <-store.blockedSave:
+	case <-time.After(time.Second):
+		t.Fatal("refresh persistence did not block")
+	}
+
+	replacement := expectedCurrent.Clone()
+	replacement.FileName = "new-credential.json"
+	replacement.Metadata["access_token"] = "replacement-token"
+	if _, err := m.Update(context.Background(), replacement); err != nil {
+		t.Fatalf("replacement update: %v", err)
+	}
+	close(store.releaseSave)
+
+	select {
+	case err := <-refreshDone:
+		if err != nil {
+			t.Fatalf("conditional update: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("conditional update did not finish")
+	}
+
+	if persisted := store.authAt(auth.FileName); persisted != nil {
+		t.Fatalf("stale target %q remains persisted: %#v", auth.FileName, persisted)
+	}
+	persisted := store.authAt(replacement.FileName)
+	if got := authMetadataString(persisted, "access_token"); got != "replacement-token" {
+		t.Fatalf("replacement target token = %q, want replacement token", got)
+	}
+}
+
+func TestConditionalUpdateDoesNotRecreateRemovedAuth(t *testing.T) {
+	store := &orderedCredentialStore{}
+	m := NewManager(store, nil, nil)
+	auth := &Auth{
+		ID:       "runtime-refresh-delete-id",
+		FileName: "refresh-persist-delete-race.json",
+		Provider: "opaque-plugin",
+		Metadata: map[string]any{"access_token": "old-token"},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	m.mu.RLock()
+	expectedCurrent := m.auths[auth.ID]
+	m.mu.RUnlock()
+	if expectedCurrent == nil {
+		t.Fatal("registered auth missing")
+	}
+	refreshed := expectedCurrent.Clone()
+	refreshed.Metadata["access_token"] = "refreshed-token"
+
+	store.blockNextSave()
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, _, err := m.updateAuth(context.Background(), refreshed, expectedCurrent)
+		refreshDone <- err
+	}()
+	select {
+	case <-store.blockedSave:
+	case <-time.After(time.Second):
+		t.Fatal("refresh persistence did not block")
+	}
+
+	if err := store.Delete(context.Background(), auth.ID); err != nil {
+		t.Fatalf("external delete: %v", err)
+	}
+	m.Remove(context.Background(), auth.ID)
+	close(store.releaseSave)
+
+	select {
+	case err := <-refreshDone:
+		if err != nil {
+			t.Fatalf("conditional update: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("conditional update did not finish")
+	}
+	if persisted := store.lastAuth(); persisted != nil {
+		t.Fatalf("removed auth was recreated by stale refresh save: %#v", persisted)
+	}
+	if got := store.lastDeleteID(); got != auth.FileName {
+		t.Fatalf("stale save cleanup deleted %q, want saved target %q", got, auth.FileName)
+	}
+	if _, ok := m.GetByID(auth.ID); ok {
+		t.Fatal("removed auth returned to runtime state")
+	}
+}
+
+func TestConditionalUpdatePersistenceDoesNotBlockOtherAuthAccess(t *testing.T) {
+	store := &orderedCredentialStore{}
+	m := NewManager(store, nil, nil)
+	refreshAuth := &Auth{
+		ID:       "refresh-persist-unrelated-access.json",
+		Provider: "opaque-plugin",
+		Metadata: map[string]any{"access_token": "old-token"},
+	}
+	otherAuth := &Auth{
+		ID:       "other-auth.json",
+		Provider: "other-provider",
+		Metadata: map[string]any{"access_token": "other-token"},
+	}
+	if _, err := m.Register(context.Background(), refreshAuth); err != nil {
+		t.Fatalf("Register refresh auth: %v", err)
+	}
+	if _, err := m.Register(context.Background(), otherAuth); err != nil {
+		t.Fatalf("Register other auth: %v", err)
+	}
+
+	m.mu.RLock()
+	expectedCurrent := m.auths[refreshAuth.ID]
+	m.mu.RUnlock()
+	if expectedCurrent == nil {
+		t.Fatal("registered refresh auth missing")
+	}
+	refreshed := expectedCurrent.Clone()
+	refreshed.Metadata["access_token"] = "refreshed-token"
+
+	store.blockNextSave()
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, _, err := m.updateAuth(context.Background(), refreshed, expectedCurrent)
+		refreshDone <- err
+	}()
+	select {
+	case <-store.blockedSave:
+	case <-time.After(time.Second):
+		t.Fatal("refresh persistence did not block")
+	}
+
+	released := false
+	defer func() {
+		if !released {
+			close(store.releaseSave)
+		}
+	}()
+	lookupDone := make(chan *Auth, 1)
+	go func() {
+		auth, _ := m.GetByID(otherAuth.ID)
+		lookupDone <- auth
+	}()
+	select {
+	case got := <-lookupDone:
+		if got == nil || got.ID != otherAuth.ID {
+			t.Fatalf("other auth lookup = %#v, want %q", got, otherAuth.ID)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("blocked persistence held the global auth lock")
+	}
+
+	close(store.releaseSave)
+	released = true
+	select {
+	case err := <-refreshDone:
+		if err != nil {
+			t.Fatalf("conditional update: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("conditional update did not finish")
+	}
+}
+
+func TestSnapshotAuthCredentialFreezesOpaquePluginStorage(t *testing.T) {
+	storage := &rawJSONCredentialStorage{payload: []byte(`{"token":"old-token"}`)}
+	auth := &Auth{Provider: "opaque-plugin", Storage: storage}
+
+	snapshot, revision := snapshotAuthCredential(auth)
+	storage.payload = []byte(`{"token":"new-token"}`)
+
+	source, ok := snapshot.Storage.(interface{ RawJSON() []byte })
+	if !ok {
+		t.Fatalf("snapshot storage = %T, want RawJSON source", snapshot.Storage)
+	}
+	if got := string(source.RawJSON()); got != `{"token":"old-token"}` {
+		t.Fatalf("snapshot storage = %s, want old credential", got)
+	}
+	if revision != captureAuthCredentialRevision(snapshot) {
+		t.Fatal("snapshot credential and revision diverged")
+	}
+	if revision == captureAuthCredentialRevision(auth) {
+		t.Fatal("snapshot revision still tracks mutable storage")
+	}
+}
+
+func TestSnapshotAuthCredentialUsesCoherentStorageGeneration(t *testing.T) {
+	storage := &coherentCredentialSnapshotStorage{
+		payload:  []byte(`{"token":"new-token"}`),
+		metadata: map[string]any{"access_token": "new-token"},
+	}
+	auth := &Auth{
+		Provider: "opaque-plugin",
+		Metadata: map[string]any{"access_token": "old-token"},
+		Storage:  storage,
+	}
+
+	snapshot, _ := snapshotAuthCredential(auth)
+
+	if got := snapshot.Metadata["access_token"]; got != "new-token" {
+		t.Fatalf("snapshot access token = %v, want metadata from storage generation", got)
+	}
+	source, ok := snapshot.Storage.(interface{ RawJSON() []byte })
+	if !ok {
+		t.Fatalf("snapshot storage = %T, want RawJSON source", snapshot.Storage)
+	}
+	if got := string(source.RawJSON()); got != `{"token":"new-token"}` {
+		t.Fatalf("snapshot storage = %s, want matching storage generation", got)
+	}
+}
+
+func TestCredentialFingerprintPrefersStorageMaterialOverRawSerialization(t *testing.T) {
+	material := baseauth.CredentialFingerprintMaterial{APIKey: "provider-owned-secret"}
+	first := &Auth{
+		Provider: "opaque-plugin",
+		Storage: &fingerprintedRawJSONCredentialStorage{
+			payload:  []byte(`{"note":"first","token":"provider-owned-secret"}`),
+			material: material,
+		},
+	}
+	second := &Auth{
+		Provider: "opaque-plugin",
+		Storage: &fingerprintedRawJSONCredentialStorage{
+			payload:  []byte(`{"note":"second","token":"provider-owned-secret"}`),
+			material: material,
+		},
+	}
+
+	firstFingerprint, firstOK := authCredentialFingerprint(first)
+	secondFingerprint, secondOK := authCredentialFingerprint(second)
+	if !firstOK || !secondOK {
+		t.Fatal("credential fingerprint missing")
+	}
+	if firstFingerprint != secondFingerprint {
+		t.Fatal("noncredential storage metadata changed credential fingerprint")
+	}
+}
+
+func TestSnapshotAuthCredentialDeepCopiesServiceAccount(t *testing.T) {
+	serviceAccount := map[string]any{
+		"project_id":  "shared-project",
+		"private_key": "old-private-key",
+		"scopes":      []any{"scope-a", map[string]any{"audience": "old-audience"}},
+	}
+	auth := &Auth{
+		Provider: "vertex",
+		Metadata: map[string]any{"service_account": serviceAccount},
+	}
+
+	snapshot, revision := snapshotAuthCredential(auth)
+	serviceAccount["private_key"] = "new-private-key"
+	serviceAccount["scopes"].([]any)[1].(map[string]any)["audience"] = "new-audience"
+
+	gotServiceAccount, ok := snapshot.Metadata["service_account"].(map[string]any)
+	if !ok {
+		t.Fatalf("snapshot service account = %T, want map[string]any", snapshot.Metadata["service_account"])
+	}
+	if got := gotServiceAccount["private_key"]; got != "old-private-key" {
+		t.Fatalf("snapshot private key = %v, want old-private-key", got)
+	}
+	gotScopes := gotServiceAccount["scopes"].([]any)
+	if got := gotScopes[1].(map[string]any)["audience"]; got != "old-audience" {
+		t.Fatalf("snapshot nested audience = %v, want old-audience", got)
+	}
+	if revision != captureAuthCredentialRevision(snapshot) {
+		t.Fatal("snapshot service account and revision diverged")
+	}
+	if revision == captureAuthCredentialRevision(auth) {
+		t.Fatal("snapshot revision still tracks mutable service-account metadata")
+	}
+}
+
+func TestExecuteStreamIgnoresLateFailureFromReplacedOpaqueCredential(t *testing.T) {
+	const provider = "opaque-stream-plugin"
+	executor := &lateUnauthorizedStreamCredentialExecutor{provider: provider, release: make(chan struct{})}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+	m.SetRetryConfig(0, 0, 1)
+	storage := &rawJSONCredentialStorage{payload: []byte(`{"token":"old-token"}`)}
+	auth := &Auth{ID: "opaque-stream-inflight.json", Provider: provider, Status: StatusActive, Storage: storage}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "plugin-model"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	m.RefreshSchedulerEntry(auth.ID)
+
+	stream, err := m.ExecuteStream(context.Background(), []string{provider}, cliproxyexecutor.Request{Model: "plugin-model"}, cliproxyexecutor.Options{Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream: %v", err)
+	}
+	storage.payload = []byte(`{"token":"new-token"}`)
+	current, _ := m.GetByID(auth.ID)
+	if _, err := m.Update(context.Background(), current.Clone()); err != nil {
+		t.Fatalf("Update replacement: %v", err)
+	}
+	close(executor.release)
+	for range stream.Chunks {
+	}
+
+	current, _ = m.GetByID(auth.ID)
+	if current == nil || current.Status != StatusActive || current.Unavailable || current.LastError != nil {
+		t.Fatalf("late old stream failure changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("late old stream failure created model state: %#v", current.ModelStates)
+	}
+}
+
+func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterCredentialReplacement(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	oldAuth := &Auth{
+		ID:       "codex-same-file.json",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token":  "old-access-token",
+			"refresh_token": "old-refresh-token",
+		},
+	}
+	if _, err := m.Register(context.Background(), oldAuth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	selected, ok := m.GetByID(oldAuth.ID)
+	if !ok || selected == nil {
+		t.Fatal("selected auth missing")
+	}
+
+	replacement := selected.Clone()
+	replacement.Metadata["access_token"] = "new-access-token"
+	replacement.Metadata["refresh_token"] = "new-refresh-token"
+	if _, err := m.Update(context.Background(), replacement); err != nil {
+		t.Fatalf("Update replacement: %v", err)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   oldAuth.ID,
+		Provider: oldAuth.Provider,
+		Model:    "gpt-test",
+		Error: &Error{
+			HTTPStatus: http.StatusUnauthorized,
+			Message:    "old token unauthorized",
+		},
+	}, selected, false)
+
+	current, ok := m.GetByID(oldAuth.ID)
+	if !ok || current == nil {
+		t.Fatal("current auth missing")
+	}
+	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+		t.Fatalf("stale result changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("stale result created model states: %#v", current.ModelStates)
+	}
+	if current.Failed != 1 {
+		t.Fatalf("failed count = %d, want request counted without changing availability", current.Failed)
+	}
+}
+
+func TestRecordExecutionResultAppliesStaleQuotaFailureAfterTokenRotation(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	oldAuth := &Auth{
+		ID:       "codex-quota.json",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{"access_token": "old-access-token"},
+	}
+	if _, err := m.Register(context.Background(), oldAuth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	selected, _ := m.GetByID(oldAuth.ID)
+	replacement := selected.Clone()
+	replacement.Metadata["access_token"] = "rotated-access-token"
+	if _, err := m.Update(context.Background(), replacement); err != nil {
+		t.Fatalf("Update replacement: %v", err)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   oldAuth.ID,
+		Provider: oldAuth.Provider,
+		Model:    "gpt-test",
+		Error:    &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"},
+	}, selected, false)
+
+	current, _ := m.GetByID(oldAuth.ID)
+	if current == nil || current.Status != StatusError || current.LastError == nil {
+		t.Fatalf("quota result from pre-rotation request was not applied: %#v", current)
+	}
+	state := current.ModelStates["gpt-test"]
+	if state == nil || !state.Quota.Exceeded {
+		t.Fatalf("quota model state missing: %#v", state)
+	}
+}
+
+func TestRecordExecutionResultAppliesStaleSuccessAfterTokenRotation(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	now := time.Now()
+	oldAuth := &Auth{
+		ID:       "codex-success.json",
+		Provider: "codex",
+		Status:   StatusError,
+		Metadata: map[string]any{"access_token": "old-access-token"},
+		ModelStates: map[string]*ModelState{
+			"gpt-test": {
+				Status:         StatusError,
+				Unavailable:    true,
+				StatusMessage:  "transient failure",
+				LastError:      &Error{HTTPStatus: http.StatusServiceUnavailable, Message: "transient failure"},
+				NextRetryAfter: now.Add(time.Minute),
+			},
+		},
+	}
+	if _, err := m.Register(context.Background(), oldAuth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	selected, _ := m.GetByID(oldAuth.ID)
+	replacement := selected.Clone()
+	replacement.Metadata["access_token"] = "rotated-access-token"
+	if _, err := m.Update(context.Background(), replacement); err != nil {
+		t.Fatalf("Update replacement: %v", err)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   oldAuth.ID,
+		Provider: oldAuth.Provider,
+		Model:    "gpt-test",
+		Success:  true,
+	}, selected, false)
+
+	current, _ := m.GetByID(oldAuth.ID)
+	if current == nil || current.Status != StatusActive || current.LastError != nil || current.Unavailable {
+		t.Fatalf("success from pre-rotation request was not applied: %#v", current)
+	}
+	state := current.ModelStates["gpt-test"]
+	if state == nil || state.Status != StatusActive || state.Unavailable || state.LastError != nil {
+		t.Fatalf("success did not clear model state: %#v", state)
+	}
+}
+
+func TestRecordExecutionResultSuppressesStaleUnauthorizedErrorEvent(t *testing.T) {
+	withEnabledErrorQueue(t)
+	subscriber, unsubscribe := redisqueue.SubscribeErrors()
+	defer unsubscribe()
+
+	m := NewManager(nil, nil, nil)
+	oldAuth := &Auth{
+		ID:       "codex-stale-event.json",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{"access_token": "old-access-token"},
+	}
+	if _, err := m.Register(WithSkipPersist(context.Background()), oldAuth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	selected, _ := m.GetByID(oldAuth.ID)
+	replacement := selected.Clone()
+	replacement.Metadata["access_token"] = "new-access-token"
+	if _, err := m.Update(WithSkipPersist(context.Background()), replacement); err != nil {
+		t.Fatalf("Update replacement: %v", err)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   oldAuth.ID,
+		Provider: oldAuth.Provider,
+		Model:    "gpt-test",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "old token unauthorized"},
+	}, selected, false)
+
+	select {
+	case payload := <-subscriber:
+		t.Fatalf("stale unauthorized error event was published: %s", payload)
+	default:
+	}
+}
+
+func TestRecordExecutionResultStillAppliesToCurrentCredential(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "codex-current.json",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{"access_token": "current-access-token"},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	selected, _ := m.GetByID(auth.ID)
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    "gpt-test",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	}, selected, false)
+
+	current, _ := m.GetByID(auth.ID)
+	if current == nil || current.Status != StatusError || current.LastError == nil {
+		t.Fatalf("current credential failure was not applied: %#v", current)
+	}
+}
+
+func TestReconcileRegistryModelStatesPersistsClearedCooldown(t *testing.T) {
+	store := &recordingCooldownStateStore{}
+	m := NewManager(nil, nil, nil)
+	m.SetCooldownStateStore(store)
+	now := time.Now()
+	auth := &Auth{
+		ID:       "codex-relogin.json",
+		Provider: "codex",
+		Status:   StatusError,
+		Metadata: map[string]any{"access_token": "new-token"},
+		ModelStates: map[string]*ModelState{
+			"gpt-test": {
+				Unavailable:    true,
+				Status:         StatusError,
+				StatusMessage:  "unauthorized",
+				NextRetryAfter: now.Add(30 * time.Minute),
+				LastError:      &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+				UpdatedAt:      now,
+			},
+		},
+	}
+	if _, err := m.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "gpt-test"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+
+	m.persistCooldownStates(context.Background())
+	store.mu.Lock()
+	before := store.saveCount.Load()
+	beforeRecords := cloneCooldownStateRecords(store.records)
+	store.mu.Unlock()
+	if len(beforeRecords) == 0 {
+		t.Fatal("expected persisted unauthorized cooldown before reconciliation")
+	}
+
+	m.ReconcileRegistryModelStates(context.Background(), auth.ID)
+
+	store.mu.Lock()
+	after := store.saveCount.Load()
+	afterRecords := cloneCooldownStateRecords(store.records)
+	store.mu.Unlock()
+	if after <= before {
+		t.Fatalf("cooldown saves = %d, want greater than %d after reconciliation", after, before)
+	}
+	if len(afterRecords) != 0 {
+		t.Fatalf("persisted cooldown records = %#v, want cleared", afterRecords)
+	}
+}
+
+type blockingCredentialRefreshExecutor struct {
+	identifier           string
+	started              chan struct{}
+	release              chan struct{}
+	refreshedAccessToken string
+	refreshErr           error
+	mutate               func(*Auth)
+}
+
+func (e *blockingCredentialRefreshExecutor) Identifier() string {
+	if e.identifier != "" {
+		return e.identifier
+	}
+	return "codex"
+}
+
+func (e *blockingCredentialRefreshExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *blockingCredentialRefreshExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func (e *blockingCredentialRefreshExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	close(e.started)
+	select {
+	case <-e.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	if e.refreshErr != nil {
+		return nil, e.refreshErr
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	auth.Metadata["access_token"] = e.refreshedAccessToken
+	if e.mutate != nil {
+		e.mutate(auth)
+	}
+	return auth, nil
+}
+
+func (e *blockingCredentialRefreshExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *blockingCredentialRefreshExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func TestRefreshAuthForRequestDiscardsStaleResultAfterCredentialReplacement(t *testing.T) {
+	tests := []struct {
+		name           string
+		refreshedToken string
+		refreshErr     error
+	}{
+		{
+			name:           "successful old refresh",
+			refreshedToken: "refreshed-old-access-token",
+		},
+		{
+			name:       "failed old refresh",
+			refreshErr: &Error{HTTPStatus: http.StatusUnauthorized, Message: "old refresh token unauthorized"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &blockingCredentialRefreshExecutor{
+				started:              make(chan struct{}),
+				release:              make(chan struct{}),
+				refreshedAccessToken: tt.refreshedToken,
+				refreshErr:           tt.refreshErr,
+			}
+			m := NewManager(nil, nil, nil)
+			m.RegisterExecutor(executor)
+			auth := &Auth{
+				ID:       "codex-refresh-race.json",
+				Provider: "codex",
+				Status:   StatusActive,
+				Metadata: map[string]any{
+					"access_token":  "old-access-token",
+					"refresh_token": "old-refresh-token",
+				},
+			}
+			if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+				t.Fatalf("Register: %v", errRegister)
+			}
+
+			type refreshResult struct {
+				auth *Auth
+				err  error
+			}
+			done := make(chan refreshResult, 1)
+			go func() {
+				refreshed, errRefresh := m.refreshAuthForRequest(context.Background(), auth.ID, "old-access-token")
+				done <- refreshResult{auth: refreshed, err: errRefresh}
+			}()
+
+			select {
+			case <-executor.started:
+			case <-time.After(time.Second):
+				t.Fatal("refresh did not start")
+			}
+
+			current, okCurrent := m.GetByID(auth.ID)
+			if !okCurrent || current == nil {
+				t.Fatal("current auth missing before replacement")
+			}
+			replacement := current.Clone()
+			replacement.Metadata["access_token"] = "replacement-access-token"
+			replacement.Metadata["refresh_token"] = "replacement-refresh-token"
+			if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+				t.Fatalf("Update replacement: %v", errUpdate)
+			}
+			close(executor.release)
+
+			var got refreshResult
+			select {
+			case got = <-done:
+			case <-time.After(time.Second):
+				t.Fatal("refresh did not finish")
+			}
+			if got.err != nil {
+				t.Fatalf("stale refresh returned error: %v", got.err)
+			}
+			if got.auth == nil || authAccessToken(got.auth) != "replacement-access-token" {
+				t.Fatalf("refresh returned %#v, want replacement credential", got.auth)
+			}
+
+			current, okCurrent = m.GetByID(auth.ID)
+			if !okCurrent || current == nil {
+				t.Fatal("current auth missing after refresh")
+			}
+			if gotToken := authAccessToken(current); gotToken != "replacement-access-token" {
+				t.Fatalf("current access token = %q, want replacement token", gotToken)
+			}
+			if gotRefresh := authMetadataString(current, "refresh_token"); gotRefresh != "replacement-refresh-token" {
+				t.Fatalf("current refresh token = %q, want replacement token", gotRefresh)
+			}
+			if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+				t.Fatalf("stale refresh changed replacement state: %#v", current)
+			}
+		})
+	}
+}
+
+func TestRefreshAuthForRequestFreezesOpaqueCredentialRevision(t *testing.T) {
+	const provider = "opaque-refresh-plugin"
+	executor := &blockingCredentialRefreshExecutor{
+		identifier: provider,
+		started:    make(chan struct{}),
+		release:    make(chan struct{}),
+		refreshErr: &Error{HTTPStatus: http.StatusUnauthorized, Message: "old plugin token unauthorized"},
+	}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+	storage := &rawJSONCredentialStorage{payload: []byte(`{"token":"old-token"}`)}
+	auth := &Auth{ID: "opaque-refresh-race.json", Provider: provider, Status: StatusActive, Storage: storage}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+
+	type refreshResult struct {
+		auth *Auth
+		err  error
+	}
+	done := make(chan refreshResult, 1)
+	go func() {
+		refreshed, errRefresh := m.refreshAuthForRequest(context.Background(), auth.ID, "")
+		done <- refreshResult{auth: refreshed, err: errRefresh}
+	}()
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not start")
+	}
+
+	storage.payload = []byte(`{"token":"new-token"}`)
+	current, okCurrent := m.GetByID(auth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("current auth missing before replacement")
+	}
+	if _, errUpdate := m.Update(context.Background(), current.Clone()); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+	close(executor.release)
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("stale refresh returned error: %v", got.err)
+		}
+		if got.auth == nil {
+			t.Fatal("stale refresh returned nil replacement auth")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not finish")
+	}
+	current, _ = m.GetByID(auth.ID)
+	if current == nil || current.Status != StatusActive || current.Unavailable || current.LastError != nil {
+		t.Fatalf("stale refresh changed replacement auth: %#v", current)
+	}
+}
+
+func TestRefreshAuthForRequestAppliesStorageOnlyRefresh(t *testing.T) {
+	const provider = "opaque-refresh-plugin"
+	release := make(chan struct{})
+	close(release)
+	executor := &blockingCredentialRefreshExecutor{
+		identifier:           provider,
+		started:              make(chan struct{}),
+		release:              release,
+		refreshedAccessToken: "unchanged-access-token",
+		mutate: func(auth *Auth) {
+			auth.Storage = &rawJSONCredentialStorage{payload: []byte(`{"token":"new-token"}`)}
+		},
+	}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "opaque-refresh-storage.json",
+		Provider: provider,
+		Status:   StatusActive,
+		Storage:  &rawJSONCredentialStorage{payload: []byte(`{"token":"old-token"}`)},
+		Metadata: map[string]any{"access_token": "unchanged-access-token"},
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+
+	refreshed, errRefresh := m.refreshAuthForRequest(context.Background(), auth.ID, "")
+	if errRefresh != nil {
+		t.Fatalf("refreshAuthForRequest: %v", errRefresh)
+	}
+	if refreshed == nil {
+		t.Fatal("refreshAuthForRequest returned nil auth")
+	}
+	source, okSource := refreshed.Storage.(interface{ RawJSON() []byte })
+	if !okSource {
+		t.Fatalf("refreshed storage = %T, want RawJSON source", refreshed.Storage)
+	}
+	if got := string(source.RawJSON()); got != `{"token":"new-token"}` {
+		t.Fatalf("refreshed storage = %s, want new plugin credential", got)
+	}
+}
+
+func TestRefreshAuthForRequestMergesAcrossUnrelatedAuthUpdate(t *testing.T) {
+	executor := &blockingCredentialRefreshExecutor{
+		started:              make(chan struct{}),
+		release:              make(chan struct{}),
+		refreshedAccessToken: "refreshed-access-token",
+	}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "codex-refresh-unrelated-update.json",
+		Provider: "codex",
+		Status:   StatusActive,
+		Prefix:   "old-prefix",
+		ProxyURL: "http://proxy-old.example:8080",
+		Metadata: map[string]any{
+			"access_token":  "old-access-token",
+			"refresh_token": "refresh-token",
+			"routing_hint":  "old-hint",
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+
+	type refreshResult struct {
+		auth *Auth
+		err  error
+	}
+	done := make(chan refreshResult, 1)
+	go func() {
+		refreshed, errRefresh := m.refreshAuthForRequest(context.Background(), auth.ID, "old-access-token")
+		done <- refreshResult{auth: refreshed, err: errRefresh}
+	}()
+
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not start")
+	}
+
+	current, okCurrent := m.GetByID(auth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("current auth missing before unrelated update")
+	}
+	unrelated := current.Clone()
+	unrelated.Prefix = "new-prefix"
+	unrelated.ProxyURL = "http://proxy-new.example:8080"
+	unrelated.Metadata["routing_hint"] = "new-hint"
+	if _, errUpdate := m.Update(context.Background(), unrelated); errUpdate != nil {
+		t.Fatalf("Update unrelated fields: %v", errUpdate)
+	}
+	close(executor.release)
+
+	var got refreshResult
+	select {
+	case got = <-done:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not finish")
+	}
+	if got.err != nil {
+		t.Fatalf("refresh error = %v", got.err)
+	}
+	if got.auth == nil || authAccessToken(got.auth) != "refreshed-access-token" {
+		t.Fatalf("refresh returned %#v, want refreshed credential", got.auth)
+	}
+
+	current, okCurrent = m.GetByID(auth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("current auth missing after refresh")
+	}
+	if gotToken := authAccessToken(current); gotToken != "refreshed-access-token" {
+		t.Fatalf("current access token = %q, want refreshed token", gotToken)
+	}
+	if current.Prefix != "new-prefix" || current.ProxyURL != "http://proxy-new.example:8080" {
+		t.Fatalf("unrelated fields were overwritten: prefix=%q proxy=%q", current.Prefix, current.ProxyURL)
+	}
+	if gotHint := authMetadataString(current, "routing_hint"); gotHint != "new-hint" {
+		t.Fatalf("routing_hint = %q, want unrelated update preserved", gotHint)
+	}
+}
+
+func TestRefreshAuthForRequestMergesStorageAcrossEquivalentReload(t *testing.T) {
+	const provider = "opaque-refresh-plugin"
+	executor := &blockingCredentialRefreshExecutor{
+		identifier: provider,
+		started:    make(chan struct{}),
+		release:    make(chan struct{}),
+		mutate: func(auth *Auth) {
+			auth.Storage = &fingerprintedRawJSONCredentialStorage{
+				payload:  []byte(`{"token":"refreshed-token","note":"refresh-result"}`),
+				material: baseauth.CredentialFingerprintMaterial{Opaque: "refreshed-token"},
+			}
+		},
+	}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "opaque-refresh-equivalent-reload.json",
+		Provider: provider,
+		Status:   StatusActive,
+		ProxyURL: "http://old-proxy.example:8080",
+		Metadata: map[string]any{"note": "old-note"},
+		Storage: &fingerprintedRawJSONCredentialStorage{
+			payload:  []byte(`{"token":"old-token","note":"old-note"}`),
+			material: baseauth.CredentialFingerprintMaterial{Opaque: "old-token"},
+		},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	type refreshResult struct {
+		auth *Auth
+		err  error
+	}
+	refreshDone := make(chan refreshResult, 1)
+	go func() {
+		refreshed, err := m.refreshAuthForRequest(context.Background(), auth.ID, "")
+		refreshDone <- refreshResult{auth: refreshed, err: err}
+	}()
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not start")
+	}
+
+	current, _ := m.GetByID(auth.ID)
+	reloaded := current.Clone()
+	reloaded.ProxyURL = "http://new-proxy.example:8080"
+	reloaded.Metadata["note"] = "reloaded-note"
+	reloaded.Storage = &fingerprintedRawJSONCredentialStorage{
+		payload:  []byte(`{"token":"old-token","note":"reloaded-note"}`),
+		material: baseauth.CredentialFingerprintMaterial{Opaque: "old-token"},
+	}
+	if _, err := m.Update(context.Background(), reloaded); err != nil {
+		t.Fatalf("equivalent hot reload: %v", err)
+	}
+	close(executor.release)
+
+	var result refreshResult
+	select {
+	case result = <-refreshDone:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not finish")
+	}
+	if result.err != nil {
+		t.Fatalf("refreshAuthForRequest: %v", result.err)
+	}
+	if result.auth == nil {
+		t.Fatal("refreshAuthForRequest returned nil auth")
+	}
+	source, ok := result.auth.Storage.(interface{ RawJSON() []byte })
+	if !ok {
+		t.Fatalf("refreshed storage = %T, want RawJSON source", result.auth.Storage)
+	}
+	if got := string(source.RawJSON()); got != `{"token":"refreshed-token","note":"refresh-result"}` {
+		t.Fatalf("refreshed storage = %s, want refresh-returned credential", got)
+	}
+	if result.auth.ProxyURL != "http://new-proxy.example:8080" {
+		t.Fatalf("proxy URL = %q, want concurrent reload value", result.auth.ProxyURL)
+	}
+	if got := authMetadataString(result.auth, "note"); got != "reloaded-note" {
+		t.Fatalf("note = %q, want concurrent reload value", got)
+	}
+}
+
+func TestRefreshAuthForRequestPreservesConcurrentAvailabilityState(t *testing.T) {
+	executor := &blockingCredentialRefreshExecutor{
+		started:              make(chan struct{}),
+		release:              make(chan struct{}),
+		refreshedAccessToken: "refreshed-access-token",
+	}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "codex-refresh-concurrent-state.json",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token":  "old-access-token",
+			"refresh_token": "refresh-token",
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+
+	type refreshResult struct {
+		auth *Auth
+		err  error
+	}
+	done := make(chan refreshResult, 1)
+	go func() {
+		refreshed, errRefresh := m.refreshAuthForRequest(context.Background(), auth.ID, "old-access-token")
+		done <- refreshResult{auth: refreshed, err: errRefresh}
+	}()
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not start")
+	}
+
+	current, okCurrent := m.GetByID(auth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("current auth missing before state update")
+	}
+	now := time.Now()
+	current.Status = StatusError
+	current.Unavailable = true
+	current.StatusMessage = "quota exhausted"
+	current.LastError = &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"}
+	current.ModelStates = map[string]*ModelState{
+		"gpt-test": {
+			Status:         StatusError,
+			Unavailable:    true,
+			StatusMessage:  "quota exhausted",
+			LastError:      &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"},
+			NextRetryAfter: now.Add(time.Minute),
+			Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: now.Add(time.Minute)},
+		},
+	}
+	if _, errUpdate := m.Update(context.Background(), current); errUpdate != nil {
+		t.Fatalf("Update concurrent state: %v", errUpdate)
+	}
+	close(executor.release)
+
+	var got refreshResult
+	select {
+	case got = <-done:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not finish")
+	}
+	if got.err != nil {
+		t.Fatalf("refresh error = %v", got.err)
+	}
+	current, okCurrent = m.GetByID(auth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("current auth missing after refresh")
+	}
+	if gotToken := authAccessToken(current); gotToken != "refreshed-access-token" {
+		t.Fatalf("current access token = %q, want refreshed token", gotToken)
+	}
+	if current.Status != StatusError || !current.Unavailable || current.LastError == nil || current.LastError.StatusCode() != http.StatusTooManyRequests {
+		t.Fatalf("concurrent availability state was cleared: %#v", current)
+	}
+	state := current.ModelStates["gpt-test"]
+	if state == nil || !state.Quota.Exceeded || state.LastError == nil || state.LastError.StatusCode() != http.StatusTooManyRequests {
+		t.Fatalf("concurrent model state was cleared: %#v", state)
+	}
+}
+
+func TestRefreshAuthForRequestAppliesRefreshReturnedScalarFields(t *testing.T) {
+	executor := &blockingCredentialRefreshExecutor{
+		started:              make(chan struct{}),
+		release:              make(chan struct{}),
+		refreshedAccessToken: "refreshed-access-token",
+		mutate: func(auth *Auth) {
+			auth.Prefix = "refreshed-prefix"
+			auth.ProxyURL = "http://refreshed-proxy.example:8080"
+			auth.Label = "refreshed-label"
+			auth.Disabled = true
+			auth.Unavailable = true
+			auth.Status = StatusDisabled
+			auth.StatusMessage = "disabled by provider refresh"
+		},
+	}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "codex-refresh-scalars.json",
+		Provider: "codex",
+		Status:   StatusActive,
+		Prefix:   "old-prefix",
+		ProxyURL: "http://old-proxy.example:8080",
+		Label:    "old-label",
+		Metadata: map[string]any{
+			"access_token":  "old-access-token",
+			"refresh_token": "refresh-token",
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+
+	type refreshResult struct {
+		auth *Auth
+		err  error
+	}
+	done := make(chan refreshResult, 1)
+	go func() {
+		refreshed, errRefresh := m.refreshAuthForRequest(context.Background(), auth.ID, "old-access-token")
+		done <- refreshResult{auth: refreshed, err: errRefresh}
+	}()
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not start")
+	}
+	close(executor.release)
+
+	var got refreshResult
+	select {
+	case got = <-done:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not finish")
+	}
+	if got.err != nil {
+		t.Fatalf("refresh error = %v", got.err)
+	}
+	current, okCurrent := m.GetByID(auth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("current auth missing after refresh")
+	}
+	if authAccessToken(current) != "refreshed-access-token" {
+		t.Fatalf("access token = %q, want refreshed token", authAccessToken(current))
+	}
+	if current.Prefix != "refreshed-prefix" || current.ProxyURL != "http://refreshed-proxy.example:8080" || current.Label != "refreshed-label" {
+		t.Fatalf("refresh scalar fields were dropped: prefix=%q proxy=%q label=%q", current.Prefix, current.ProxyURL, current.Label)
+	}
+	if !current.Disabled || current.Status != StatusDisabled || current.StatusMessage != "disabled by provider refresh" {
+		t.Fatalf("refresh lifecycle fields were dropped: %#v", current)
+	}
+}
+
+func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterAPIKeyReplacement(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	oldAuth := &Auth{
+		ID:       "openai-api-key.json",
+		Provider: "openai-compatibility",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			AttributeAPIKey: "old-api-key",
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), oldAuth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	selected, okSelected := m.GetByID(oldAuth.ID)
+	if !okSelected || selected == nil {
+		t.Fatal("selected auth missing")
+	}
+
+	replacement := selected.Clone()
+	replacement.Attributes[AttributeAPIKey] = "replacement-api-key"
+	if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   oldAuth.ID,
+		Provider: oldAuth.Provider,
+		Model:    "gpt-test",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "old API key unauthorized"},
+	}, selected, false)
+
+	current, okCurrent := m.GetByID(oldAuth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("current auth missing")
+	}
+	if gotKey := authAttribute(current, AttributeAPIKey); gotKey != "replacement-api-key" {
+		t.Fatalf("current API key = %q, want replacement key", gotKey)
+	}
+	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+		t.Fatalf("stale API-key result changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("stale API-key result created model states: %#v", current.ModelStates)
+	}
+}
+
+func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterCustomAuthorizationHeaderReplacement(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	const authID = "openai-custom-authorization.json"
+	oldAuth := &Auth{
+		ID:       authID,
+		Provider: "openai-compatibility",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			AttributeAPIKey:        "stable-config-key",
+			"header:Authorization": "Bearer old-upstream-token",
+			"header:X-Trace-ID":    "stable-trace",
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), oldAuth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	selected, okSelected := m.GetByID(authID)
+	if !okSelected || selected == nil {
+		t.Fatal("selected auth missing")
+	}
+
+	replacement := selected.Clone()
+	replacement.Attributes["header:Authorization"] = "Bearer replacement-upstream-token"
+	if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   authID,
+		Provider: oldAuth.Provider,
+		Model:    "gpt-test",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "old custom header unauthorized"},
+	}, selected, false)
+
+	current, okCurrent := m.GetByID(authID)
+	if !okCurrent || current == nil {
+		t.Fatal("current auth missing")
+	}
+	if got := current.Attributes["header:Authorization"]; got != "Bearer replacement-upstream-token" {
+		t.Fatalf("current Authorization header = %q, want replacement token", got)
+	}
+	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+		t.Fatalf("stale custom-header result changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("stale custom-header result created model states: %#v", current.ModelStates)
+	}
+}
+
+func TestCredentialFingerprintTracksAuthenticationCustomHeaders(t *testing.T) {
+	for _, header := range []string{"Authorization", "x-api-key", "X-Goog-Api-Key", "X-Auth-Token"} {
+		t.Run(header, func(t *testing.T) {
+			left := &Auth{
+				Provider: "openai-compatibility",
+				Attributes: map[string]string{
+					AttributeAPIKey:    "stable-config-key",
+					"header:" + header: "credential-a",
+				},
+			}
+			right := left.Clone()
+			right.Attributes["header:"+header] = "credential-b"
+
+			leftFingerprint, leftOK := authCredentialFingerprint(left)
+			rightFingerprint, rightOK := authCredentialFingerprint(right)
+			if !leftOK || !rightOK {
+				t.Fatalf("credential fingerprint availability = left:%v right:%v", leftOK, rightOK)
+			}
+			if leftFingerprint == rightFingerprint {
+				t.Fatalf("%s change did not change credential fingerprint", header)
+			}
+		})
+	}
+
+	left := &Auth{
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			AttributeAPIKey:        "stable-config-key",
+			"header:Authorization": "Bearer same-token",
+			"header:X-API-Key":     "same-api-key",
+		},
+	}
+	right := &Auth{
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			AttributeAPIKey:        "stable-config-key",
+			"header:authorization": "Bearer same-token",
+			"header:x-api-key":     "same-api-key",
+		},
+	}
+	leftFingerprint, leftOK := authCredentialFingerprint(left)
+	rightFingerprint, rightOK := authCredentialFingerprint(right)
+	if !leftOK || !rightOK {
+		t.Fatalf("credential fingerprint availability = left:%v right:%v", leftOK, rightOK)
+	}
+	if leftFingerprint != rightFingerprint {
+		t.Fatal("header-name casing changed credential fingerprint")
+	}
+}
+
+func TestCredentialFingerprintIgnoresNonCredentialCustomHeaders(t *testing.T) {
+	left := &Auth{
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			AttributeAPIKey:     "stable-config-key",
+			"header:X-Trace-ID": "trace-a",
+		},
+	}
+	right := left.Clone()
+	right.Attributes["header:X-Trace-ID"] = "trace-b"
+
+	leftFingerprint, leftOK := authCredentialFingerprint(left)
+	rightFingerprint, rightOK := authCredentialFingerprint(right)
+	if !leftOK || !rightOK {
+		t.Fatalf("credential fingerprint availability = left:%v right:%v", leftOK, rightOK)
+	}
+	if leftFingerprint != rightFingerprint {
+		t.Fatal("noncredential custom header changed credential fingerprint")
+	}
+}
+
+func TestCredentialFingerprintCanonicalizesRawStorageJSON(t *testing.T) {
+	left := &Auth{
+		Provider: "plugin-provider",
+		Storage:  &rawJSONCredentialStorage{payload: []byte(`{"token":"same-token","nested":{"b":2,"a":1}}`)},
+	}
+	right := &Auth{
+		Provider: "plugin-provider",
+		Storage:  &rawJSONCredentialStorage{payload: []byte(" { \n  \"nested\": {\"a\": 1, \"b\": 2}, \n  \"token\": \"same-token\" \n} ")},
+	}
+
+	leftFingerprint, leftOK := authCredentialFingerprint(left)
+	rightFingerprint, rightOK := authCredentialFingerprint(right)
+	if !leftOK || !rightOK {
+		t.Fatalf("raw storage fingerprint availability = left:%v right:%v", leftOK, rightOK)
+	}
+	if leftFingerprint != rightFingerprint {
+		t.Fatalf("equivalent raw JSON fingerprints differ: %x != %x", leftFingerprint, rightFingerprint)
+	}
+}
+
+func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterOpaquePluginCredentialReplacement(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	const authID = "plugin-opaque-credential.json"
+	oldAuth := &Auth{
+		ID:       authID,
+		Provider: "plugin-provider",
+		Status:   StatusActive,
+		Metadata: map[string]any{"type": "plugin-provider", "token": "old-token"},
+		Storage: &rawJSONCredentialStorage{payload: []byte(
+			`{"type":"plugin-provider","token":"old-token","scope":"shared"}`,
+		)},
+	}
+	if _, errRegister := m.Register(context.Background(), oldAuth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	selected, okSelected := m.GetByID(authID)
+	if !okSelected || selected == nil {
+		t.Fatal("selected plugin auth missing")
+	}
+
+	replacement := &Auth{
+		ID:       authID,
+		Provider: "plugin-provider",
+		Status:   StatusActive,
+		Metadata: map[string]any{"type": "plugin-provider", "token": "new-token"},
+		Storage: &rawJSONCredentialStorage{payload: []byte(
+			`{"scope":"shared","token":"new-token","type":"plugin-provider"}`,
+		)},
+	}
+	if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   authID,
+		Provider: "plugin-provider",
+		Model:    "plugin-model",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "old plugin token unauthorized"},
+	}, selected, false)
+
+	current, okCurrent := m.GetByID(authID)
+	if !okCurrent || current == nil {
+		t.Fatal("current plugin auth missing")
+	}
+	if gotToken, _ := current.Metadata["token"].(string); gotToken != "new-token" {
+		t.Fatalf("current plugin token = %q, want new-token", gotToken)
+	}
+	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+		t.Fatalf("stale plugin unauthorized result changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("stale plugin unauthorized result created model states: %#v", current.ModelStates)
+	}
+}
+
+func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterVertexServiceAccountReplacement(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	const authID = "vertex-shared-project.json"
+	oldAuth := &Auth{
+		ID:       authID,
+		Provider: "vertex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"type":       "vertex",
+			"project_id": "shared-project",
+			"service_account": map[string]any{
+				"type":           "service_account",
+				"project_id":     "shared-project",
+				"client_email":   "vertex@example.com",
+				"private_key_id": "old-key-id",
+				"private_key":    "old-private-key",
+			},
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), oldAuth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	selected, okSelected := m.GetByID(authID)
+	if !okSelected || selected == nil {
+		t.Fatal("selected Vertex auth missing")
+	}
+
+	replacement := oldAuth.Clone()
+	replacement.Metadata["service_account"] = map[string]any{
+		"type":           "service_account",
+		"project_id":     "shared-project",
+		"client_email":   "vertex@example.com",
+		"private_key_id": "new-key-id",
+		"private_key":    "new-private-key",
+	}
+	if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   authID,
+		Provider: "vertex",
+		Model:    "gemini-test",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "old Vertex key unauthorized"},
+	}, selected, false)
+
+	current, okCurrent := m.GetByID(authID)
+	if !okCurrent || current == nil {
+		t.Fatal("current Vertex auth missing")
+	}
+	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+		t.Fatalf("stale Vertex unauthorized result changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("stale Vertex unauthorized result created model states: %#v", current.ModelStates)
+	}
+}
+
+func TestRecordExecutionResultIgnoresStaleUnauthorizedWhenReplacementFingerprintMissing(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	oldAuth := &Auth{
+		ID:       "opaque-replacement.json",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"type":         "codex",
+			"access_token": "old-access-token",
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), oldAuth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	selected, okSelected := m.GetByID(oldAuth.ID)
+	if !okSelected || selected == nil {
+		t.Fatal("selected auth missing")
+	}
+	if _, okFingerprint := authCredentialFingerprint(selected); !okFingerprint {
+		t.Fatal("selected auth lacks credential fingerprint")
+	}
+
+	replacement := &Auth{
+		ID:       oldAuth.ID,
+		Provider: oldAuth.Provider,
+		Status:   StatusActive,
+		Metadata: map[string]any{"email": "replacement@example.com"},
+		Storage:  &opaqueCredentialStorage{},
+	}
+	if _, okFingerprint := authCredentialFingerprint(replacement); okFingerprint {
+		t.Fatal("replacement unexpectedly has a credential fingerprint")
+	}
+	if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   oldAuth.ID,
+		Provider: oldAuth.Provider,
+		Model:    "gpt-test",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "old credential unauthorized"},
+	}, selected, false)
+
+	current, okCurrent := m.GetByID(oldAuth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("current auth missing")
+	}
+	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+		t.Fatalf("stale unauthorized result changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("stale unauthorized result created model states: %#v", current.ModelStates)
+	}
+}
+
+func TestCredentialFingerprintMatchesStorageAndMetadataOAuth(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		storage  any
+	}{
+		{
+			name:     "Claude",
+			provider: "claude",
+			storage: &claudeauth.ClaudeTokenStorage{
+				AccessToken:  "access-token",
+				RefreshToken: "refresh-token",
+				IDToken:      "id-token",
+			},
+		},
+		{
+			name:     "Codex",
+			provider: "codex",
+			storage: &codexauth.CodexTokenStorage{
+				AccessToken:  "access-token",
+				RefreshToken: "refresh-token",
+				IDToken:      "id-token",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storageAuth := &Auth{
+				Provider: tt.provider,
+				Metadata: map[string]any{"email": "user@example.com"},
+			}
+			switch storage := tt.storage.(type) {
+			case *claudeauth.ClaudeTokenStorage:
+				storageAuth.Storage = storage
+			case *codexauth.CodexTokenStorage:
+				storageAuth.Storage = storage
+			default:
+				t.Fatalf("unsupported test storage %T", storage)
+			}
+			metadataAuth := &Auth{
+				Provider: tt.provider,
+				Metadata: map[string]any{
+					"type":          tt.provider,
+					"access_token":  "access-token",
+					"refresh_token": "refresh-token",
+					"id_token":      "id-token",
+				},
+			}
+
+			storageFingerprint, okStorage := authCredentialFingerprint(storageAuth)
+			metadataFingerprint, okMetadata := authCredentialFingerprint(metadataAuth)
+			if !okStorage || !okMetadata {
+				t.Fatalf("fingerprint availability = storage:%v metadata:%v", okStorage, okMetadata)
+			}
+			if storageFingerprint != metadataFingerprint {
+				t.Fatalf("storage and metadata fingerprints differ: %x != %x", storageFingerprint, metadataFingerprint)
+			}
+		})
+	}
+}
+
+func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterStorageBackedOAuthReplacement(t *testing.T) {
+	tests := []struct {
+		name       string
+		provider   string
+		newStorage any
+	}{
+		{
+			name:     "Claude",
+			provider: "claude",
+			newStorage: &claudeauth.ClaudeTokenStorage{
+				AccessToken:  "new-access-token",
+				RefreshToken: "new-refresh-token",
+				IDToken:      "new-id-token",
+			},
+		},
+		{
+			name:     "Codex",
+			provider: "codex",
+			newStorage: &codexauth.CodexTokenStorage{
+				AccessToken:  "new-access-token",
+				RefreshToken: "new-refresh-token",
+				IDToken:      "new-id-token",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewManager(nil, nil, nil)
+			oldAuth := &Auth{
+				ID:       tt.provider + "-storage-relogin.json",
+				Provider: tt.provider,
+				Status:   StatusActive,
+				Metadata: map[string]any{
+					"type":          tt.provider,
+					"access_token":  "old-access-token",
+					"refresh_token": "old-refresh-token",
+					"id_token":      "old-id-token",
+				},
+			}
+			if _, errRegister := m.Register(context.Background(), oldAuth); errRegister != nil {
+				t.Fatalf("Register: %v", errRegister)
+			}
+			selected, okSelected := m.GetByID(oldAuth.ID)
+			if !okSelected || selected == nil {
+				t.Fatal("selected auth missing")
+			}
+
+			replacement := &Auth{
+				ID:       oldAuth.ID,
+				Provider: tt.provider,
+				Status:   StatusActive,
+				Metadata: map[string]any{"email": "user@example.com"},
+			}
+			switch storage := tt.newStorage.(type) {
+			case *claudeauth.ClaudeTokenStorage:
+				replacement.Storage = storage
+			case *codexauth.CodexTokenStorage:
+				replacement.Storage = storage
+			default:
+				t.Fatalf("unsupported test storage %T", storage)
+			}
+			if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+				t.Fatalf("Update replacement: %v", errUpdate)
+			}
+
+			m.recordExecutionResult(context.Background(), Result{
+				AuthID:   oldAuth.ID,
+				Provider: tt.provider,
+				Model:    "model-test",
+				Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "old credential unauthorized"},
+			}, selected, false)
+
+			current, okCurrent := m.GetByID(oldAuth.ID)
+			if !okCurrent || current == nil {
+				t.Fatal("current auth missing")
+			}
+			if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+				t.Fatalf("stale storage-backed result changed replacement auth: %#v", current)
+			}
+			if len(current.ModelStates) != 0 {
+				t.Fatalf("stale storage-backed result created model states: %#v", current.ModelStates)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -2271,6 +2271,175 @@ func TestRefreshAuthForRequestAppliesRefreshReturnedScalarFields(t *testing.T) {
 	}
 }
 
+func TestAuthCredentialFingerprintUsesAntigravityAttributeEndpointPrecedence(t *testing.T) {
+	left := &Auth{
+		Provider: "antigravity",
+		Attributes: map[string]string{
+			"base_url": "https://attribute.example.com",
+		},
+		Metadata: map[string]any{
+			"access_token": "stable-token",
+			"base_url":     "https://old-metadata.example.com",
+		},
+	}
+	right := left.Clone()
+	right.Metadata["base_url"] = "https://new-metadata.example.com"
+
+	leftFingerprint, leftOK := authCredentialFingerprint(left)
+	rightFingerprint, rightOK := authCredentialFingerprint(right)
+	if !leftOK || !rightOK {
+		t.Fatalf("fingerprint availability = (%t, %t), want both true", leftOK, rightOK)
+	}
+	if leftFingerprint != rightFingerprint {
+		t.Fatal("shadowed Antigravity metadata base_url changed credential revision")
+	}
+}
+
+func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterAntigravityMetadataBaseURLReplacement(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	oldAuth := &Auth{
+		ID:       "antigravity-metadata-base-url.json",
+		Provider: "antigravity",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token": "stable-token",
+			"base_url":     "https://old-antigravity.example.com",
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), oldAuth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	selected, okSelected := m.GetByID(oldAuth.ID)
+	if !okSelected || selected == nil {
+		t.Fatal("selected auth missing")
+	}
+
+	replacement := selected.Clone()
+	replacement.Metadata["base_url"] = "https://replacement-antigravity.example.com"
+	if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   oldAuth.ID,
+		Provider: oldAuth.Provider,
+		Model:    "gemini-test",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "old Antigravity endpoint unauthorized"},
+	}, selected, false)
+
+	current, okCurrent := m.GetByID(oldAuth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("current auth missing")
+	}
+	if gotEndpoint := authMetadataString(current, "base_url"); gotEndpoint != "https://replacement-antigravity.example.com" {
+		t.Fatalf("current metadata base_url = %q, want replacement endpoint", gotEndpoint)
+	}
+	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+		t.Fatalf("stale metadata-endpoint result changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("stale metadata-endpoint result created model states: %#v", current.ModelStates)
+	}
+}
+
+func TestAuthCredentialFingerprintIgnoresCodexMetadataAccountForAPIKeyAuth(t *testing.T) {
+	left := &Auth{
+		Provider: "codex",
+		Attributes: map[string]string{
+			AttributeAPIKey: "stable-api-key",
+		},
+		Metadata: map[string]any{"account_id": "old-account"},
+	}
+	right := left.Clone()
+	right.Metadata["account_id"] = "new-account"
+
+	leftFingerprint, leftOK := authCredentialFingerprint(left)
+	rightFingerprint, rightOK := authCredentialFingerprint(right)
+	if !leftOK || !rightOK {
+		t.Fatalf("fingerprint availability = (%t, %t), want both true", leftOK, rightOK)
+	}
+	if leftFingerprint != rightFingerprint {
+		t.Fatal("Codex API-key auth fingerprint included an unsent metadata account_id")
+	}
+}
+
+func TestAuthCredentialFingerprintUsesCodexCustomAccountHeaderPrecedence(t *testing.T) {
+	left := &Auth{
+		Provider: "codex",
+		Attributes: map[string]string{
+			"header:ChatGPT-Account-ID": "custom-account",
+		},
+		Metadata: map[string]any{
+			"access_token": "stable-token",
+			"account_id":   "old-metadata-account",
+		},
+	}
+	right := left.Clone()
+	right.Metadata["account_id"] = "new-metadata-account"
+
+	leftFingerprint, leftOK := authCredentialFingerprint(left)
+	rightFingerprint, rightOK := authCredentialFingerprint(right)
+	if !leftOK || !rightOK {
+		t.Fatalf("fingerprint availability = (%t, %t), want both true", leftOK, rightOK)
+	}
+	if leftFingerprint != rightFingerprint {
+		t.Fatal("shadowed Codex metadata account_id changed credential revision")
+	}
+
+	right.Attributes["header:ChatGPT-Account-ID"] = "rotated-custom-account"
+	rotatedFingerprint, rotatedOK := authCredentialFingerprint(right)
+	if !rotatedOK || rotatedFingerprint == leftFingerprint {
+		t.Fatal("rotating effective Codex custom account header did not change credential revision")
+	}
+}
+
+func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterCodexAccountReplacement(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	oldAuth := &Auth{
+		ID:       "codex-account-scope.json",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token": "stable-token",
+			"account_id":   "old-account",
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), oldAuth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	selected, okSelected := m.GetByID(oldAuth.ID)
+	if !okSelected || selected == nil {
+		t.Fatal("selected auth missing")
+	}
+
+	replacement := selected.Clone()
+	replacement.Metadata["account_id"] = "replacement-account"
+	if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   oldAuth.ID,
+		Provider: oldAuth.Provider,
+		Model:    "gpt-test",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "old Codex account unauthorized"},
+	}, selected, false)
+
+	current, okCurrent := m.GetByID(oldAuth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("current auth missing")
+	}
+	if gotAccount := authMetadataString(current, "account_id"); gotAccount != "replacement-account" {
+		t.Fatalf("current account_id = %q, want replacement account", gotAccount)
+	}
+	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+		t.Fatalf("stale account-scope result changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("stale account-scope result created model states: %#v", current.ModelStates)
+	}
+}
+
 func TestAuthCredentialFingerprintCanonicalizesBaseURL(t *testing.T) {
 	left := &Auth{
 		Provider: "openai-compatibility",

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -298,6 +298,39 @@ func (e *blockingUnauthorizedCredentialExecutor) HttpRequest(context.Context, *A
 	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
 }
 
+type blockingSuccessfulCredentialExecutor struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (*blockingSuccessfulCredentialExecutor) Identifier() string { return "codex" }
+
+func (e *blockingSuccessfulCredentialExecutor) Execute(ctx context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	close(e.started)
+	select {
+	case <-e.release:
+		return cliproxyexecutor.Response{Payload: []byte("old credential succeeded")}, nil
+	case <-ctx.Done():
+		return cliproxyexecutor.Response{}, ctx.Err()
+	}
+}
+
+func (*blockingSuccessfulCredentialExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func (*blockingSuccessfulCredentialExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (*blockingSuccessfulCredentialExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func (*blockingSuccessfulCredentialExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
 func TestExecuteIgnoresFailureFromCredentialReplacedInFlight(t *testing.T) {
 	executor := &blockingUnauthorizedCredentialExecutor{
 		started: make(chan struct{}),
@@ -1061,48 +1094,117 @@ func TestRecordExecutionResultAppliesStaleQuotaFailureAfterTokenRotation(t *test
 	}
 }
 
-func TestRecordExecutionResultAppliesStaleSuccessAfterTokenRotation(t *testing.T) {
+func TestExecuteStaleSuccessDoesNotClearReplacementCooldown(t *testing.T) {
+	previousDisableCooling := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisableCooling) })
+
+	const model = "gpt-stale-success-replacement"
+	executor := &blockingSuccessfulCredentialExecutor{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
 	m := NewManager(nil, nil, nil)
-	now := time.Now()
+	m.RegisterExecutor(executor)
+	m.SetRetryConfig(0, 0, 1)
 	oldAuth := &Auth{
-		ID:       "codex-success.json",
+		ID:       "codex-stale-success.json",
 		Provider: "codex",
-		Status:   StatusError,
+		Status:   StatusActive,
 		Metadata: map[string]any{"access_token": "old-access-token"},
-		ModelStates: map[string]*ModelState{
-			"gpt-test": {
-				Status:         StatusError,
-				Unavailable:    true,
-				StatusMessage:  "transient failure",
-				LastError:      &Error{HTTPStatus: http.StatusServiceUnavailable, Message: "transient failure"},
-				NextRetryAfter: now.Add(time.Minute),
-			},
-		},
 	}
 	if _, err := m.Register(context.Background(), oldAuth); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
-	selected, _ := m.GetByID(oldAuth.ID)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(oldAuth.ID, oldAuth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(oldAuth.ID) })
+	m.RefreshSchedulerEntry(oldAuth.ID)
+
+	type executionResult struct {
+		response cliproxyexecutor.Response
+		err      error
+	}
+	done := make(chan executionResult, 1)
+	go func() {
+		response, err := m.Execute(
+			context.Background(),
+			[]string{oldAuth.Provider},
+			cliproxyexecutor.Request{Model: model},
+			cliproxyexecutor.Options{},
+		)
+		done <- executionResult{response: response, err: err}
+	}()
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("old credential execution did not start")
+	}
+
+	selected, ok := m.GetByID(oldAuth.ID)
+	if !ok || selected == nil {
+		t.Fatal("selected old credential missing")
+	}
 	replacement := selected.Clone()
-	replacement.Metadata["access_token"] = "rotated-access-token"
+	replacement.Metadata["access_token"] = "replacement-access-token"
 	if _, err := m.Update(context.Background(), replacement); err != nil {
 		t.Fatalf("Update replacement: %v", err)
 	}
-
+	currentReplacement, ok := m.GetByID(oldAuth.ID)
+	if !ok || currentReplacement == nil {
+		t.Fatal("replacement credential missing")
+	}
 	m.recordExecutionResult(context.Background(), Result{
 		AuthID:   oldAuth.ID,
 		Provider: oldAuth.Provider,
-		Model:    "gpt-test",
-		Success:  true,
-	}, selected, false)
+		Model:    model,
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "replacement token unauthorized"},
+	}, currentReplacement, false)
 
-	current, _ := m.GetByID(oldAuth.ID)
-	if current == nil || current.Status != StatusActive || current.LastError != nil || current.Unavailable {
-		t.Fatalf("success from pre-rotation request was not applied: %#v", current)
+	afterReplacementFailure, _ := m.GetByID(oldAuth.ID)
+	state := afterReplacementFailure.ModelStates[model]
+	if state == nil || !state.Unavailable || state.Status != StatusError || state.NextRetryAfter.IsZero() {
+		t.Fatalf("replacement credential did not enter cooldown: %#v", state)
 	}
-	state := current.ModelStates["gpt-test"]
-	if state == nil || state.Status != StatusActive || state.Unavailable || state.LastError != nil {
-		t.Fatalf("success did not clear model state: %#v", state)
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("registry model count after replacement 401 = %d, want 0", count)
+	}
+
+	close(executor.release)
+	select {
+	case result := <-done:
+		if result.err != nil {
+			t.Fatalf("old credential execution returned error: %v", result.err)
+		}
+		if got := string(result.response.Payload); got != "old credential succeeded" {
+			t.Fatalf("old credential response = %q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("old credential execution did not finish")
+	}
+
+	current, ok := m.GetByID(oldAuth.ID)
+	if !ok || current == nil {
+		t.Fatal("replacement credential missing after stale success")
+	}
+	if got := authAccessToken(current); got != "replacement-access-token" {
+		t.Fatalf("current access token = %q, want replacement token", got)
+	}
+	if current.Status != StatusError || !current.Unavailable || current.LastError == nil {
+		t.Fatalf("stale old success cleared replacement auth cooldown: %#v", current)
+	}
+	state = current.ModelStates[model]
+	if state == nil || !state.Unavailable || state.Status != StatusError || state.LastError == nil || state.NextRetryAfter.IsZero() {
+		t.Fatalf("stale old success cleared replacement model cooldown: %#v", state)
+	}
+	if state.LastError.HTTPStatus != http.StatusUnauthorized {
+		t.Fatalf("replacement model error status = %d, want 401", state.LastError.HTTPStatus)
+	}
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("stale old success resumed replacement registry model; count = %d", count)
+	}
+	if current.Success != 1 || current.Failed != 1 {
+		t.Fatalf("request counters = success %d, failed %d; want 1 and 1", current.Success, current.Failed)
 	}
 }
 

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -1939,6 +1939,53 @@ func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterAPIKeyReplacement(t *
 	}
 }
 
+func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterOAuthKindAPIKeyReplacement(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	oldAuth := &Auth{
+		ID:       "claude-oauth-api-key.json",
+		Provider: "claude",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			AttributeAuthKind: AuthKindOAuth,
+			AttributeAPIKey:   "sk-ant-oat-old",
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), oldAuth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	selected, okSelected := m.GetByID(oldAuth.ID)
+	if !okSelected || selected == nil {
+		t.Fatal("selected auth missing")
+	}
+
+	replacement := selected.Clone()
+	replacement.Attributes[AttributeAPIKey] = "sk-ant-oat-replacement"
+	if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   oldAuth.ID,
+		Provider: oldAuth.Provider,
+		Model:    "claude-test",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "old OAuth-shaped API key unauthorized"},
+	}, selected, false)
+
+	current, okCurrent := m.GetByID(oldAuth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("current auth missing")
+	}
+	if gotKey := authAttribute(current, AttributeAPIKey); gotKey != "sk-ant-oat-replacement" {
+		t.Fatalf("current API key = %q, want replacement key", gotKey)
+	}
+	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+		t.Fatalf("stale OAuth-shaped API-key result changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("stale OAuth-shaped API-key result created model states: %#v", current.ModelStates)
+	}
+}
+
 func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterCustomAuthorizationHeaderReplacement(t *testing.T) {
 	m := NewManager(nil, nil, nil)
 	const authID = "openai-custom-authorization.json"

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -2317,6 +2317,56 @@ func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterAPIKeyReplacement(t *
 	}
 }
 
+func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterKimiMetadataTokenRotationWithAPIKey(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	oldAuth := &Auth{
+		ID:       "kimi-metadata-token-with-api-key.json",
+		Provider: "kimi",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			AttributeAPIKey: "stable-api-key",
+		},
+		Metadata: map[string]any{
+			"access_token":  "old-metadata-token",
+			"refresh_token": "stable-refresh-token",
+		},
+	}
+	if _, err := m.Register(context.Background(), oldAuth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	selected, okSelected := m.GetByID(oldAuth.ID)
+	if !okSelected || selected == nil {
+		t.Fatal("selected auth missing")
+	}
+
+	replacement := selected.Clone()
+	replacement.Metadata["access_token"] = "replacement-metadata-token"
+	if _, err := m.Update(context.Background(), replacement); err != nil {
+		t.Fatalf("Update replacement: %v", err)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   oldAuth.ID,
+		Provider: oldAuth.Provider,
+		Model:    "kimi-test",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "old Kimi metadata token unauthorized"},
+	}, selected, false)
+
+	current, okCurrent := m.GetByID(oldAuth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("current auth missing")
+	}
+	if got := authMetadataString(current, "access_token"); got != "replacement-metadata-token" {
+		t.Fatalf("current metadata access token = %q, want replacement token", got)
+	}
+	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+		t.Fatalf("stale Kimi metadata-token result changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("stale Kimi metadata-token result created model states: %#v", current.ModelStates)
+	}
+}
+
 func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterKimiAttributeTokenRotation(t *testing.T) {
 	m := NewManager(nil, nil, nil)
 	oldAuth := &Auth{

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -2326,6 +2326,78 @@ func TestRefreshAuthForRequestAppliesRefreshReturnedScalarFields(t *testing.T) {
 	}
 }
 
+func TestAuthCredentialFingerprintUsesXAIAttributeEndpointPrecedence(t *testing.T) {
+	left := &Auth{
+		Provider: "xai",
+		Attributes: map[string]string{
+			"base_url": "https://attribute.xai.example.com",
+		},
+		Metadata: map[string]any{
+			"access_token": "stable-token",
+			"base_url":     "https://old-metadata.xai.example.com",
+		},
+	}
+	right := left.Clone()
+	right.Metadata["base_url"] = "https://new-metadata.xai.example.com"
+
+	leftFingerprint, leftOK := authCredentialFingerprint(left)
+	rightFingerprint, rightOK := authCredentialFingerprint(right)
+	if !leftOK || !rightOK {
+		t.Fatalf("fingerprint availability = (%t, %t), want both true", leftOK, rightOK)
+	}
+	if leftFingerprint != rightFingerprint {
+		t.Fatal("shadowed xAI metadata base_url changed credential revision")
+	}
+}
+
+func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterXAIMetadataBaseURLReplacement(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	oldAuth := &Auth{
+		ID:       "xai-metadata-endpoint.json",
+		Provider: "xai",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token":  "stable-xai-token",
+			"refresh_token": "stable-xai-refresh-token",
+			"base_url":      "https://old-xai.example.com",
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), oldAuth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	selected, okSelected := m.GetByID(oldAuth.ID)
+	if !okSelected || selected == nil {
+		t.Fatal("selected auth missing")
+	}
+
+	replacement := selected.Clone()
+	replacement.Metadata["base_url"] = "https://replacement-xai.example.com"
+	if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   oldAuth.ID,
+		Provider: oldAuth.Provider,
+		Model:    "grok-test",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "old xAI endpoint unauthorized"},
+	}, selected, false)
+
+	current, okCurrent := m.GetByID(oldAuth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("replacement auth missing")
+	}
+	if got := authMetadataString(current, "base_url"); got != "https://replacement-xai.example.com" {
+		t.Fatalf("current xAI metadata base_url = %q, want replacement endpoint", got)
+	}
+	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+		t.Fatalf("stale xAI endpoint result changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("stale xAI endpoint result created model states: %#v", current.ModelStates)
+	}
+}
+
 func TestAuthCredentialFingerprintUsesAntigravityAttributeEndpointPrecedence(t *testing.T) {
 	left := &Auth{
 		Provider: "antigravity",

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"net/http"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -244,6 +245,7 @@ func (s *orderedCredentialStore) lastDeleteID() string {
 
 type targetTrackingCredentialStore struct {
 	mu               sync.Mutex
+	root             string
 	blockNext        bool
 	blockedSave      chan struct{}
 	releaseSave      chan struct{}
@@ -255,8 +257,16 @@ type targetTrackingCredentialStore struct {
 
 func (*targetTrackingCredentialStore) List(context.Context) ([]*Auth, error) { return nil, nil }
 
-func (s *targetTrackingCredentialStore) Save(_ context.Context, auth *Auth) (string, error) {
+func (s *targetTrackingCredentialStore) ResolveAuthPersistenceTarget(auth *Auth) (string, error) {
 	target := orderedCredentialStoreSaveID(auth)
+	if s.root != "" && !filepath.IsAbs(target) {
+		target = filepath.Join(s.root, target)
+	}
+	return target, nil
+}
+
+func (s *targetTrackingCredentialStore) Save(_ context.Context, auth *Auth) (string, error) {
+	target, _ := s.ResolveAuthPersistenceTarget(auth)
 	s.mu.Lock()
 	if s.blockNext {
 		s.blockNext = false
@@ -870,6 +880,68 @@ func TestConditionalUpdateDoesNotPublishStaleOwnerAfterReplacement(t *testing.T)
 	}
 	if token := authMetadataString(picked, "access_token"); token != "replacement-token" {
 		t.Fatalf("scheduler published token %q, want replacement token", token)
+	}
+}
+
+func TestConditionalUpdateRemovesStaleTargetAcrossRelativeSubdirectoryRename(t *testing.T) {
+	store := &targetTrackingCredentialStore{root: t.TempDir()}
+	manager := NewManager(store, nil, nil)
+	original := &Auth{
+		ID:       "subdirectory-rename-runtime-id",
+		FileName: filepath.Join("old", "auth.json"),
+		Provider: "opaque-plugin",
+		Metadata: map[string]any{"access_token": "old-token"},
+	}
+	if _, errRegister := manager.Register(context.Background(), original); errRegister != nil {
+		t.Fatalf("Register original: %v", errRegister)
+	}
+
+	manager.mu.RLock()
+	expectedCurrent := manager.auths[original.ID]
+	manager.mu.RUnlock()
+	if expectedCurrent == nil {
+		t.Fatal("registered original auth missing")
+	}
+
+	refreshed := expectedCurrent.Clone()
+	refreshed.Metadata["access_token"] = "refreshed-old-token"
+	store.blockAfterNextSaveCall()
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, _, errUpdate := manager.updateAuth(context.Background(), refreshed, expectedCurrent)
+		refreshDone <- errUpdate
+	}()
+	select {
+	case <-store.blockedAfterSave:
+	case <-time.After(time.Second):
+		t.Fatal("stale conditional save did not reach the persisted boundary")
+	}
+
+	replacement := expectedCurrent.Clone()
+	replacement.FileName = filepath.Join("new", "auth.json")
+	replacement.Metadata["access_token"] = "replacement-token"
+	if _, errUpdate := manager.Update(WithSkipPersist(context.Background()), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+	close(store.releaseAfterSave)
+
+	select {
+	case errUpdate := <-refreshDone:
+		if errUpdate != nil {
+			t.Fatalf("conditional update: %v", errUpdate)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("conditional update did not finish")
+	}
+
+	oldTarget := filepath.Join(store.root, original.FileName)
+	if persisted := store.authAt(oldTarget); persisted != nil {
+		t.Fatalf("stale subdirectory target %q remains persisted: %#v", oldTarget, persisted)
+	}
+	newTarget := filepath.Join(store.root, replacement.FileName)
+	persistedReplacement := store.authAt(newTarget)
+	if token := authMetadataString(persistedReplacement, "access_token"); token != "replacement-token" {
+		t.Fatalf("replacement target token = %q, want replacement token", token)
 	}
 }
 

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -1472,6 +1472,61 @@ func TestRecordExecutionResultIgnoresStaleAvailabilityFailureAfterTokenRotation(
 	}
 }
 
+func TestRecordExecutionResultIgnoresStaleInvalidGrantAfterTokenRotation(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	oldAuth := &Auth{
+		ID:       "codex-stale-invalid-grant.json",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token":  "old-access-token",
+			"refresh_token": "old-refresh-token",
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), oldAuth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	selected, okSelected := m.GetByID(oldAuth.ID)
+	if !okSelected || selected == nil {
+		t.Fatal("selected auth missing")
+	}
+
+	replacement := selected.Clone()
+	replacement.Metadata["access_token"] = "replacement-access-token"
+	replacement.Metadata["refresh_token"] = "replacement-refresh-token"
+	if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   oldAuth.ID,
+		Provider: oldAuth.Provider,
+		Model:    "gpt-test",
+		Error: &Error{
+			HTTPStatus: http.StatusBadRequest,
+			Code:       "invalid_grant",
+			Message:    "old refresh token invalid_grant",
+		},
+	}, selected, false)
+
+	current, okCurrent := m.GetByID(oldAuth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("replacement auth missing")
+	}
+	if got := authAccessToken(current); got != "replacement-access-token" {
+		t.Fatalf("current access token = %q, want replacement token", got)
+	}
+	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+		t.Fatalf("stale invalid_grant changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("stale invalid_grant created model states: %#v", current.ModelStates)
+	}
+	if current.Failed != 1 {
+		t.Fatalf("failed count = %d, want request counted without changing availability", current.Failed)
+	}
+}
+
 func TestExecuteStaleSuccessDoesNotClearReplacementCooldown(t *testing.T) {
 	previousDisableCooling := quotaCooldownDisabled.Load()
 	quotaCooldownDisabled.Store(false)
@@ -2892,6 +2947,153 @@ func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterOpaquePluginCredentia
 	}
 	if len(current.ModelStates) != 0 {
 		t.Fatalf("stale plugin unauthorized result created model states: %#v", current.ModelStates)
+	}
+}
+
+func TestRecordExecutionResultIgnoresStaleForbiddenAfterAuthorizationScopeReplacement(t *testing.T) {
+	cases := []struct {
+		name   string
+		auth   *Auth
+		mutate func(*Auth)
+		assert func(*testing.T, *Auth)
+	}{
+		{
+			name: "Antigravity project",
+			auth: &Auth{
+				ID:       "antigravity-project-scope.json",
+				Provider: "antigravity",
+				Status:   StatusActive,
+				Metadata: map[string]any{
+					"access_token": "stable-antigravity-token",
+					"project_id":   "old-project",
+				},
+			},
+			mutate: func(auth *Auth) {
+				auth.Metadata["project_id"] = "replacement-project"
+			},
+			assert: func(t *testing.T, auth *Auth) {
+				t.Helper()
+				if got := authMetadataString(auth, "project_id"); got != "replacement-project" {
+					t.Fatalf("current Antigravity project_id = %q, want replacement project", got)
+				}
+			},
+		},
+		{
+			name: "Vertex project",
+			auth: &Auth{
+				ID:       "vertex-project-scope.json",
+				Provider: "vertex",
+				Status:   StatusActive,
+				Metadata: map[string]any{
+					"project_id": "old-project",
+					"location":   "us-east1",
+					"service_account": map[string]any{
+						"type":           "service_account",
+						"client_email":   "vertex@example.com",
+						"private_key_id": "stable-key-id",
+						"private_key":    "stable-private-key",
+					},
+				},
+			},
+			mutate: func(auth *Auth) {
+				auth.Metadata["project_id"] = "replacement-project"
+			},
+			assert: func(t *testing.T, auth *Auth) {
+				t.Helper()
+				if got := authMetadataString(auth, "project_id"); got != "replacement-project" {
+					t.Fatalf("current Vertex project_id = %q, want replacement project", got)
+				}
+			},
+		},
+		{
+			name: "Vertex location",
+			auth: &Auth{
+				ID:       "vertex-location-scope.json",
+				Provider: "vertex",
+				Status:   StatusActive,
+				Metadata: map[string]any{
+					"project_id": "stable-project",
+					"location":   "us-east1",
+					"service_account": map[string]any{
+						"type":           "service_account",
+						"client_email":   "vertex@example.com",
+						"private_key_id": "stable-key-id",
+						"private_key":    "stable-private-key",
+					},
+				},
+			},
+			mutate: func(auth *Auth) {
+				auth.Metadata["location"] = "europe-west1"
+			},
+			assert: func(t *testing.T, auth *Auth) {
+				t.Helper()
+				if got := authMetadataString(auth, "location"); got != "europe-west1" {
+					t.Fatalf("current Vertex location = %q, want replacement location", got)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewManager(nil, nil, nil)
+			if _, errRegister := m.Register(context.Background(), tc.auth); errRegister != nil {
+				t.Fatalf("Register: %v", errRegister)
+			}
+			selected, okSelected := m.GetByID(tc.auth.ID)
+			if !okSelected || selected == nil {
+				t.Fatal("selected auth missing")
+			}
+			replacement := selected.Clone()
+			tc.mutate(replacement)
+			if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+				t.Fatalf("Update replacement: %v", errUpdate)
+			}
+
+			m.recordExecutionResult(context.Background(), Result{
+				AuthID:   tc.auth.ID,
+				Provider: tc.auth.Provider,
+				Model:    "scope-test-model",
+				Error:    &Error{HTTPStatus: http.StatusForbidden, Message: "old authorization scope forbidden"},
+			}, selected, false)
+
+			current, okCurrent := m.GetByID(tc.auth.ID)
+			if !okCurrent || current == nil {
+				t.Fatal("replacement auth missing")
+			}
+			tc.assert(t, current)
+			if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+				t.Fatalf("stale scope failure changed replacement auth: %#v", current)
+			}
+			if len(current.ModelStates) != 0 {
+				t.Fatalf("stale scope failure created model states: %#v", current.ModelStates)
+			}
+		})
+	}
+}
+
+func TestAuthCredentialFingerprintIgnoresVertexScopeForAPIKeyAuth(t *testing.T) {
+	left := &Auth{
+		Provider: "vertex",
+		Attributes: map[string]string{
+			AttributeAPIKey: "stable-api-key",
+		},
+		Metadata: map[string]any{
+			"project_id": "old-project",
+			"location":   "us-east1",
+		},
+	}
+	right := left.Clone()
+	right.Metadata["project_id"] = "replacement-project"
+	right.Metadata["location"] = "europe-west1"
+
+	leftFingerprint, leftOK := authCredentialFingerprint(left)
+	rightFingerprint, rightOK := authCredentialFingerprint(right)
+	if !leftOK || !rightOK {
+		t.Fatalf("fingerprint availability = (%t, %t), want both true", leftOK, rightOK)
+	}
+	if leftFingerprint != rightFingerprint {
+		t.Fatal("Vertex API-key fingerprint included unused service-account project/location scope")
 	}
 }
 

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -79,6 +79,46 @@ func (s *mutableCredentialSnapshotStorage) CredentialSnapshot() ([]byte, map[str
 	return []byte(token), metadata, baseauth.CredentialFingerprintMaterial{Opaque: token}
 }
 
+func (s *mutableCredentialSnapshotStorage) CredentialPersistenceSnapshot() baseauth.TokenStorage {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	metadata := cloneCredentialMetadataValue(s.metadata).(map[string]any)
+	s.mu.RUnlock()
+	return &mutableCredentialSnapshotStorage{metadata: metadata}
+}
+
+type conditionalStorageMutationStore struct {
+	blocked chan struct{}
+	release chan struct{}
+	mutated chan struct{}
+	finish  chan struct{}
+	once    sync.Once
+}
+
+func (*conditionalStorageMutationStore) List(context.Context) ([]*Auth, error) { return nil, nil }
+func (*conditionalStorageMutationStore) Delete(context.Context, string) error  { return nil }
+
+func (s *conditionalStorageMutationStore) Save(_ context.Context, auth *Auth) (string, error) {
+	blocked := false
+	s.once.Do(func() {
+		blocked = true
+		close(s.blocked)
+	})
+	if blocked {
+		<-s.release
+		if setter, ok := auth.Storage.(interface{ SetMetadata(map[string]any) }); ok {
+			setter.SetMetadata(auth.Metadata)
+		}
+		close(s.mutated)
+		<-s.finish
+	} else if setter, ok := auth.Storage.(interface{ SetMetadata(map[string]any) }); ok {
+		setter.SetMetadata(auth.Metadata)
+	}
+	return auth.ID, nil
+}
+
 type blockedMetadataPersistenceStore struct {
 	blockNext chan struct{}
 	blocked   chan struct{}
@@ -537,6 +577,87 @@ func TestExecuteCapturesOpaquePluginCredentialBeforeDispatch(t *testing.T) {
 	}
 	if len(current.ModelStates) != 0 {
 		t.Fatalf("in-flight old failure created model state: %#v", current.ModelStates)
+	}
+}
+
+func TestConditionalPersistenceDoesNotMutateReplacementStorage(t *testing.T) {
+	store := &conditionalStorageMutationStore{
+		blocked: make(chan struct{}),
+		release: make(chan struct{}),
+		mutated: make(chan struct{}),
+		finish:  make(chan struct{}),
+	}
+	storage := &mutableCredentialSnapshotStorage{metadata: map[string]any{"token": "old-token"}}
+	manager := NewManager(store, nil, nil)
+	auth := &Auth{
+		ID:       "conditional-storage-detach.json",
+		Provider: "opaque-plugin",
+		Status:   StatusActive,
+		Metadata: map[string]any{"token": "old-token"},
+		Storage:  storage,
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+
+	manager.mu.RLock()
+	expectedCurrent := manager.auths[auth.ID]
+	manager.mu.RUnlock()
+	if expectedCurrent == nil {
+		t.Fatal("registered auth missing")
+	}
+	refreshed := expectedCurrent.Clone()
+	refreshed.Metadata["token"] = "stale-refresh-token"
+
+	updateDone := make(chan error, 1)
+	go func() {
+		_, _, errUpdate := manager.updateAuth(context.Background(), refreshed, expectedCurrent)
+		updateDone <- errUpdate
+	}()
+	select {
+	case <-store.blocked:
+	case <-time.After(time.Second):
+		t.Fatal("conditional persistence did not block")
+	}
+
+	current, ok := manager.GetByID(auth.ID)
+	if !ok || current == nil {
+		t.Fatal("refreshed auth missing")
+	}
+	replacement := current.Clone()
+	replacement.Metadata["token"] = "replacement-token"
+	if _, errUpdate := manager.Update(WithSkipPersist(context.Background()), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+
+	close(store.release)
+	select {
+	case <-store.mutated:
+	case <-time.After(time.Second):
+		t.Fatal("conditional persistence did not reach metadata mutation")
+	}
+
+	current, ok = manager.GetByID(auth.ID)
+	if !ok || current == nil {
+		t.Fatal("replacement auth missing")
+	}
+	source, okSnapshot := current.Storage.(baseauth.CredentialSnapshotSource)
+	if !okSnapshot || source == nil {
+		t.Fatalf("replacement storage = %T, want credential snapshot source", current.Storage)
+	}
+	_, metadata, _ := source.CredentialSnapshot()
+	observedToken, _ := metadata["token"].(string)
+	close(store.finish)
+	select {
+	case errUpdate := <-updateDone:
+		if errUpdate != nil {
+			t.Fatalf("conditional update: %v", errUpdate)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("conditional update did not finish")
+	}
+	if observedToken != "replacement-token" {
+		t.Fatalf("replacement storage token during stale save = %q, want replacement token", observedToken)
 	}
 }
 

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -243,11 +243,14 @@ func (s *orderedCredentialStore) lastDeleteID() string {
 }
 
 type targetTrackingCredentialStore struct {
-	mu          sync.Mutex
-	blockNext   bool
-	blockedSave chan struct{}
-	releaseSave chan struct{}
-	persisted   map[string]*Auth
+	mu               sync.Mutex
+	blockNext        bool
+	blockedSave      chan struct{}
+	releaseSave      chan struct{}
+	blockAfterNext   bool
+	blockedAfterSave chan struct{}
+	releaseAfterSave chan struct{}
+	persisted        map[string]*Auth
 }
 
 func (*targetTrackingCredentialStore) List(context.Context) ([]*Auth, error) { return nil, nil }
@@ -270,6 +273,15 @@ func (s *targetTrackingCredentialStore) Save(_ context.Context, auth *Auth) (str
 		s.persisted = make(map[string]*Auth)
 	}
 	s.persisted[target] = auth.Clone()
+	if s.blockAfterNext {
+		s.blockAfterNext = false
+		blockedAfterSave := s.blockedAfterSave
+		releaseAfterSave := s.releaseAfterSave
+		s.mu.Unlock()
+		close(blockedAfterSave)
+		<-releaseAfterSave
+		return target, nil
+	}
 	s.mu.Unlock()
 	return target, nil
 }
@@ -286,6 +298,14 @@ func (s *targetTrackingCredentialStore) blockNextSaveCall() {
 	s.blockNext = true
 	s.blockedSave = make(chan struct{})
 	s.releaseSave = make(chan struct{})
+	s.mu.Unlock()
+}
+
+func (s *targetTrackingCredentialStore) blockAfterNextSaveCall() {
+	s.mu.Lock()
+	s.blockAfterNext = true
+	s.blockedAfterSave = make(chan struct{})
+	s.releaseAfterSave = make(chan struct{})
 	s.mu.Unlock()
 }
 
@@ -850,6 +870,83 @@ func TestConditionalUpdateDoesNotPublishStaleOwnerAfterReplacement(t *testing.T)
 	}
 	if token := authMetadataString(picked, "access_token"); token != "replacement-token" {
 		t.Fatalf("scheduler published token %q, want replacement token", token)
+	}
+}
+
+func TestConditionalUpdateDoesNotDeleteTargetReusedByAnotherAuth(t *testing.T) {
+	store := &targetTrackingCredentialStore{}
+	manager := NewManager(store, nil, nil)
+	original := &Auth{
+		ID:       "renamed-runtime-id",
+		FileName: "reused-credential.json",
+		Provider: "opaque-plugin",
+		Metadata: map[string]any{"access_token": "old-token"},
+	}
+	if _, errRegister := manager.Register(context.Background(), original); errRegister != nil {
+		t.Fatalf("Register original: %v", errRegister)
+	}
+
+	manager.mu.RLock()
+	expectedCurrent := manager.auths[original.ID]
+	manager.mu.RUnlock()
+	if expectedCurrent == nil {
+		t.Fatal("registered original auth missing")
+	}
+
+	refreshed := expectedCurrent.Clone()
+	refreshed.Metadata["access_token"] = "refreshed-old-token"
+	store.blockAfterNextSaveCall()
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, _, errUpdate := manager.updateAuth(context.Background(), refreshed, expectedCurrent)
+		refreshDone <- errUpdate
+	}()
+	select {
+	case <-store.blockedAfterSave:
+	case <-time.After(time.Second):
+		t.Fatal("stale conditional save did not reach the persisted boundary")
+	}
+
+	replacement := expectedCurrent.Clone()
+	replacement.FileName = "renamed-credential.json"
+	replacement.Metadata["access_token"] = "replacement-token"
+	if _, errUpdate := manager.Update(WithSkipPersist(context.Background()), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+
+	reused := &Auth{
+		ID:       "different-runtime-id",
+		FileName: original.FileName,
+		Provider: "other-provider",
+		Metadata: map[string]any{"access_token": "different-owner-token"},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), reused); errRegister != nil {
+		t.Fatalf("Register target reuser: %v", errRegister)
+	}
+	if _, errSave := store.Save(context.Background(), reused); errSave != nil {
+		t.Fatalf("Persist target reuser: %v", errSave)
+	}
+
+	close(store.releaseAfterSave)
+	select {
+	case errUpdate := <-refreshDone:
+		if errUpdate != nil {
+			t.Fatalf("conditional update: %v", errUpdate)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("conditional update did not finish")
+	}
+
+	persistedReuser := store.authAt(original.FileName)
+	if persistedReuser == nil || persistedReuser.ID != reused.ID {
+		t.Fatalf("reused target owner = %#v, want auth %q", persistedReuser, reused.ID)
+	}
+	if token := authMetadataString(persistedReuser, "access_token"); token != "different-owner-token" {
+		t.Fatalf("reused target token = %q, want different owner token", token)
+	}
+	persistedReplacement := store.authAt(replacement.FileName)
+	if token := authMetadataString(persistedReplacement, "access_token"); token != "replacement-token" {
+		t.Fatalf("renamed replacement token = %q, want replacement token", token)
 	}
 }
 

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/redisqueue"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 )
 
 type opaqueCredentialStorage struct{}
@@ -2386,15 +2388,14 @@ func TestRefreshAuthForRequestAppliesRefreshReturnedScalarFields(t *testing.T) {
 	}
 }
 
-func TestAuthCredentialFingerprintUsesXAIEffectiveChatRoute(t *testing.T) {
+func TestAuthCredentialFingerprintIgnoresXAIUsingAPIOutsideExecutionScope(t *testing.T) {
 	left := &Auth{
 		Provider: "xai",
 		Metadata: map[string]any{
-			"access_token":  "stable-token",
-			"refresh_token": "stable-refresh-token",
-			"base_url":      xaiauth.DefaultAPIBaseURL,
-			"using_api":     true,
-			"auth_kind":     "oauth",
+			"access_token": "stable-token",
+			"base_url":     xaiauth.DefaultAPIBaseURL,
+			"using_api":    true,
+			"auth_kind":    "oauth",
 		},
 	}
 	right := left.Clone()
@@ -2405,8 +2406,8 @@ func TestAuthCredentialFingerprintUsesXAIEffectiveChatRoute(t *testing.T) {
 	if !leftOK || !rightOK {
 		t.Fatalf("fingerprint availability = (%t, %t), want both true", leftOK, rightOK)
 	}
-	if leftFingerprint == rightFingerprint {
-		t.Fatal("changing xAI's effective chat route did not change credential revision")
+	if leftFingerprint != rightFingerprint {
+		t.Fatal("xAI using_api changed the auth-global fingerprint outside request transport scope")
 	}
 }
 
@@ -2414,11 +2415,10 @@ func TestAuthCredentialFingerprintIgnoresXAIUsingAPIForCustomEndpoint(t *testing
 	left := &Auth{
 		Provider: "xai",
 		Metadata: map[string]any{
-			"access_token":  "stable-token",
-			"refresh_token": "stable-refresh-token",
-			"base_url":      "https://custom-xai.example.com/v1",
-			"using_api":     true,
-			"auth_kind":     "oauth",
+			"access_token": "stable-token",
+			"base_url":     "https://custom-xai.example.com/v1",
+			"using_api":    true,
+			"auth_kind":    "oauth",
 		},
 	}
 	right := left.Clone()
@@ -2434,53 +2434,193 @@ func TestAuthCredentialFingerprintIgnoresXAIUsingAPIForCustomEndpoint(t *testing
 	}
 }
 
-func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterXAIRouteReplacement(t *testing.T) {
+func TestExecuteIgnoresStaleUnauthorizedAfterXAIHTTPChatRouteReplacement(t *testing.T) {
+	executor := &blockingUnauthorizedCredentialExecutor{
+		started:  make(chan struct{}),
+		release:  make(chan struct{}),
+		provider: "xai",
+	}
 	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+	m.SetRetryConfig(0, 0, 1)
 	oldAuth := &Auth{
 		ID:       "xai-chat-route.json",
 		Provider: "xai",
 		Status:   StatusActive,
 		Metadata: map[string]any{
-			"access_token":  "stable-token",
-			"refresh_token": "stable-refresh-token",
-			"base_url":      xaiauth.DefaultAPIBaseURL,
-			"using_api":     true,
-			"auth_kind":     "oauth",
+			"access_token": "stable-token",
+			"base_url":     xaiauth.DefaultAPIBaseURL,
+			"using_api":    true,
+			"auth_kind":    "oauth",
 		},
 	}
 	if _, errRegister := m.Register(context.Background(), oldAuth); errRegister != nil {
 		t.Fatalf("Register: %v", errRegister)
 	}
-	selected, okSelected := m.GetByID(oldAuth.ID)
-	if !okSelected || selected == nil {
-		t.Fatal("selected auth missing")
+	registry.GetGlobalRegistry().RegisterClient(oldAuth.ID, oldAuth.Provider, []*registry.ModelInfo{{ID: "grok-test"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(oldAuth.ID) })
+	m.RefreshSchedulerEntry(oldAuth.ID)
+
+	done := make(chan error, 1)
+	go func() {
+		_, errExecute := m.Execute(context.Background(), []string{"xai"}, cliproxyexecutor.Request{Model: "grok-test"}, cliproxyexecutor.Options{})
+		done <- errExecute
+	}()
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("xAI chat execution did not start")
 	}
 
+	selected, _ := m.GetByID(oldAuth.ID)
 	replacement := selected.Clone()
 	replacement.Metadata["using_api"] = false
 	if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
 		t.Fatalf("Update replacement: %v", errUpdate)
 	}
-
-	m.recordExecutionResult(context.Background(), Result{
-		AuthID:   oldAuth.ID,
-		Provider: oldAuth.Provider,
-		Model:    "grok-test",
-		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "old xAI route unauthorized"},
-	}, selected, false)
-
-	current, okCurrent := m.GetByID(oldAuth.ID)
-	if !okCurrent || current == nil {
-		t.Fatal("replacement auth missing")
+	close(executor.release)
+	select {
+	case errExecute := <-done:
+		if errExecute == nil {
+			t.Fatal("Execute error = nil, want old route unauthorized")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("xAI chat execution did not finish")
 	}
-	if got, ok := current.Metadata["using_api"].(bool); !ok || got {
-		t.Fatalf("current xAI using_api = %#v, want false", current.Metadata["using_api"])
-	}
-	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
-		t.Fatalf("stale xAI route result changed replacement auth: %#v", current)
+
+	current, _ := m.GetByID(oldAuth.ID)
+	if current == nil || current.Status != StatusActive || current.Unavailable || current.LastError != nil {
+		t.Fatalf("stale xAI chat-route failure changed replacement auth: %#v", current)
 	}
 	if len(current.ModelStates) != 0 {
-		t.Fatalf("stale xAI route result created model states: %#v", current.ModelStates)
+		t.Fatalf("stale xAI chat-route failure created model state: %#v", current.ModelStates)
+	}
+}
+
+func TestExecuteAppliesUnauthorizedAcrossXAINonChatUsingAPIToggle(t *testing.T) {
+	cases := []struct {
+		name string
+		opts cliproxyexecutor.Options
+	}{
+		{
+			name: "image format",
+			opts: cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-image")},
+		},
+		{
+			name: "video request path",
+			opts: cliproxyexecutor.Options{Metadata: map[string]any{cliproxyexecutor.RequestPathMetadataKey: "/v1/videos/generations"}},
+		},
+		{
+			name: "compact",
+			opts: cliproxyexecutor.Options{Alt: "responses/compact"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			executor := &blockingUnauthorizedCredentialExecutor{
+				started:  make(chan struct{}),
+				release:  make(chan struct{}),
+				provider: "xai",
+			}
+			m := NewManager(nil, nil, nil)
+			m.RegisterExecutor(executor)
+			m.SetRetryConfig(0, 0, 1)
+			auth := &Auth{
+				ID:       "xai-non-chat-" + strings.NewReplacer(" ", "-").Replace(tc.name) + ".json",
+				Provider: "xai",
+				Status:   StatusActive,
+				Metadata: map[string]any{
+					"access_token": "stable-token",
+					"base_url":     xaiauth.DefaultAPIBaseURL,
+					"using_api":    true,
+					"auth_kind":    "oauth",
+				},
+			}
+			if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+				t.Fatalf("Register: %v", errRegister)
+			}
+			registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "grok-test"}})
+			t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+			m.RefreshSchedulerEntry(auth.ID)
+
+			done := make(chan error, 1)
+			go func() {
+				_, errExecute := m.Execute(context.Background(), []string{"xai"}, cliproxyexecutor.Request{Model: "grok-test"}, tc.opts)
+				done <- errExecute
+			}()
+			select {
+			case <-executor.started:
+			case <-time.After(time.Second):
+				t.Fatal("xAI non-chat execution did not start")
+			}
+
+			selected, _ := m.GetByID(auth.ID)
+			replacement := selected.Clone()
+			replacement.Metadata["using_api"] = false
+			if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+				t.Fatalf("Update replacement: %v", errUpdate)
+			}
+			close(executor.release)
+			select {
+			case errExecute := <-done:
+				if errExecute == nil {
+					t.Fatal("Execute error = nil, want unauthorized")
+				}
+			case <-time.After(time.Second):
+				t.Fatal("xAI non-chat execution did not finish")
+			}
+
+			current, _ := m.GetByID(auth.ID)
+			if current == nil || current.Status != StatusError || !current.Unavailable || current.LastError == nil || current.LastError.StatusCode() != http.StatusUnauthorized {
+				t.Fatalf("non-chat unauthorized result was incorrectly suppressed: %#v", current)
+			}
+		})
+	}
+}
+
+func TestExecuteStreamAppliesUnauthorizedAcrossXAIWebsocketUsingAPIToggle(t *testing.T) {
+	executor := &lateUnauthorizedStreamCredentialExecutor{provider: "xai", release: make(chan struct{})}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+	m.SetRetryConfig(0, 0, 1)
+	auth := &Auth{
+		ID:       "xai-websocket-route.json",
+		Provider: "xai",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token": "stable-token",
+			"base_url":     xaiauth.DefaultAPIBaseURL,
+			"using_api":    true,
+			"auth_kind":    "oauth",
+			"websockets":   true,
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "grok-test"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	m.RefreshSchedulerEntry(auth.ID)
+
+	ctx := cliproxyexecutor.WithDownstreamWebsocket(context.Background())
+	streamResult, errStream := m.ExecuteStream(ctx, []string{"xai"}, cliproxyexecutor.Request{Model: "grok-test"}, cliproxyexecutor.Options{Stream: true})
+	if errStream != nil {
+		t.Fatalf("ExecuteStream: %v", errStream)
+	}
+	current, _ := m.GetByID(auth.ID)
+	replacement := current.Clone()
+	replacement.Metadata["using_api"] = false
+	if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+	close(executor.release)
+	for range streamResult.Chunks {
+	}
+
+	current, _ = m.GetByID(auth.ID)
+	if current == nil || current.Status != StatusError || !current.Unavailable || current.LastError == nil || current.LastError.StatusCode() != http.StatusUnauthorized {
+		t.Fatalf("websocket unauthorized result was incorrectly suppressed: %#v", current)
 	}
 }
 
@@ -2982,6 +3122,75 @@ func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterOAuthKindAPIKeyReplac
 	}
 	if len(current.ModelStates) != 0 {
 		t.Fatalf("stale OAuth-shaped API-key result created model states: %#v", current.ModelStates)
+	}
+}
+
+func TestRecordExecutionResultIgnoresStaleForbiddenAfterAuthorizationScopeHeaderReplacement(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	const authID = "openai-organization-scope.json"
+	oldAuth := &Auth{
+		ID:       authID,
+		Provider: "openai-compatibility",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			AttributeAPIKey:              "stable-api-key",
+			"header:OpenAI-Organization": "org-old",
+			"header:X-Trace-ID":          "stable-trace",
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), oldAuth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	selected, _ := m.GetByID(authID)
+	replacement := selected.Clone()
+	replacement.Attributes["header:OpenAI-Organization"] = "org-replacement"
+	if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   authID,
+		Provider: oldAuth.Provider,
+		Model:    "gpt-test",
+		Error:    &Error{HTTPStatus: http.StatusForbidden, Message: "old organization forbidden"},
+	}, selected, false)
+
+	current, _ := m.GetByID(authID)
+	if current == nil || current.Status != StatusActive || current.Unavailable || current.LastError != nil {
+		t.Fatalf("stale organization-scope failure changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("stale organization-scope failure created model state: %#v", current.ModelStates)
+	}
+}
+
+func TestCredentialFingerprintTracksAuthorizationScopeCustomHeaders(t *testing.T) {
+	for _, header := range []string{
+		"OpenAI-Organization",
+		"OpenAI-Project",
+		"X-Goog-User-Project",
+		"X-Tenant-ID",
+		"X-Workspace-ID",
+	} {
+		t.Run(header, func(t *testing.T) {
+			left := &Auth{
+				Provider: "openai-compatibility",
+				Attributes: map[string]string{
+					AttributeAPIKey:    "stable-api-key",
+					"header:" + header: "scope-a",
+				},
+			}
+			right := left.Clone()
+			right.Attributes["header:"+header] = "scope-b"
+			leftFingerprint, leftOK := authCredentialFingerprint(left)
+			rightFingerprint, rightOK := authCredentialFingerprint(right)
+			if !leftOK || !rightOK {
+				t.Fatalf("fingerprint availability = (%t, %t), want both true", leftOK, rightOK)
+			}
+			if leftFingerprint == rightFingerprint {
+				t.Fatalf("%s change did not change credential revision", header)
+			}
+		})
 	}
 }
 

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -388,6 +388,67 @@ func TestExecuteIgnoresFailureFromCredentialReplacedInFlight(t *testing.T) {
 	}
 }
 
+func TestExecuteIgnoresLateUnauthorizedFromOpaqueGenerationAfterAPIKeyReplacement(t *testing.T) {
+	executor := &blockingUnauthorizedCredentialExecutor{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+	m.SetRetryConfig(0, 0, 1)
+	auth := &Auth{
+		ID:       "opaque-generation-inflight.json",
+		Provider: "codex",
+		Status:   StatusActive,
+		Storage:  &opaqueCredentialStorage{},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "gpt-test"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	m.RefreshSchedulerEntry(auth.ID)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := m.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-test"}, cliproxyexecutor.Options{})
+		done <- err
+	}()
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("execution did not start")
+	}
+
+	current, _ := m.GetByID(auth.ID)
+	replacement := current.Clone()
+	replacement.Storage = nil
+	replacement.Attributes = map[string]string{AttributeAPIKey: "replacement-api-key"}
+	if _, err := m.Update(context.Background(), replacement); err != nil {
+		t.Fatalf("Update replacement: %v", err)
+	}
+	close(executor.release)
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Execute error = nil, want old opaque credential unauthorized")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("execution did not finish")
+	}
+
+	current, _ = m.GetByID(auth.ID)
+	if gotKey := authAttribute(current, AttributeAPIKey); gotKey != "replacement-api-key" {
+		t.Fatalf("current API key = %q, want replacement key", gotKey)
+	}
+	if current == nil || current.Status != StatusActive || current.Unavailable || current.LastError != nil {
+		t.Fatalf("late opaque-generation failure changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("late opaque-generation failure created model state: %#v", current.ModelStates)
+	}
+}
+
 type lateUnauthorizedStreamCredentialExecutor struct {
 	provider string
 	release  chan struct{}

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -2271,6 +2271,74 @@ func TestRefreshAuthForRequestAppliesRefreshReturnedScalarFields(t *testing.T) {
 	}
 }
 
+func TestAuthCredentialFingerprintCanonicalizesBaseURL(t *testing.T) {
+	left := &Auth{
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			AttributeAPIKey: "stable-api-key",
+			"base_url":      "HTTPS://API.EXAMPLE.COM/v1/",
+		},
+	}
+	right := left.Clone()
+	right.Attributes["base_url"] = "https://api.example.com/v1"
+
+	leftFingerprint, leftOK := authCredentialFingerprint(left)
+	rightFingerprint, rightOK := authCredentialFingerprint(right)
+	if !leftOK || !rightOK {
+		t.Fatalf("fingerprint availability = (%t, %t), want both true", leftOK, rightOK)
+	}
+	if leftFingerprint != rightFingerprint {
+		t.Fatal("equivalent base_url casing/trailing slash changed credential revision")
+	}
+}
+
+func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterBaseURLReplacement(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	oldAuth := &Auth{
+		ID:       "openai-base-url.json",
+		Provider: "openai-compatibility",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			AttributeAPIKey: "stable-api-key",
+			"base_url":      "https://old-api.example.com/v1",
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), oldAuth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	selected, okSelected := m.GetByID(oldAuth.ID)
+	if !okSelected || selected == nil {
+		t.Fatal("selected auth missing")
+	}
+
+	replacement := selected.Clone()
+	replacement.Attributes["base_url"] = "https://replacement-api.example.com/v1"
+	if _, errUpdate := m.Update(context.Background(), replacement); errUpdate != nil {
+		t.Fatalf("Update replacement: %v", errUpdate)
+	}
+
+	m.recordExecutionResult(context.Background(), Result{
+		AuthID:   oldAuth.ID,
+		Provider: oldAuth.Provider,
+		Model:    "gpt-test",
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "old endpoint unauthorized"},
+	}, selected, false)
+
+	current, okCurrent := m.GetByID(oldAuth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("current auth missing")
+	}
+	if gotEndpoint := authAttribute(current, "base_url"); gotEndpoint != "https://replacement-api.example.com/v1" {
+		t.Fatalf("current base_url = %q, want replacement endpoint", gotEndpoint)
+	}
+	if current.Status != StatusActive || current.Unavailable || current.LastError != nil || current.StatusMessage != "" {
+		t.Fatalf("stale endpoint result changed replacement auth: %#v", current)
+	}
+	if len(current.ModelStates) != 0 {
+		t.Fatalf("stale endpoint result created model states: %#v", current.ModelStates)
+	}
+}
+
 func TestRecordExecutionResultIgnoresStaleUnauthorizedAfterAPIKeyReplacement(t *testing.T) {
 	m := NewManager(nil, nil, nil)
 	oldAuth := &Auth{

--- a/sdk/cliproxy/auth/credential_replacement_test.go
+++ b/sdk/cliproxy/auth/credential_replacement_test.go
@@ -813,6 +813,65 @@ func TestUpdateSynchronizesMutableCredentialStorageBeforePublication(t *testing.
 	}
 }
 
+func TestConditionalUpdatePublishesSchedulerBeforePersistenceCompletes(t *testing.T) {
+	store := &orderedCredentialStore{}
+	manager := NewManager(store, &RoundRobinSelector{}, nil)
+	auth := &Auth{
+		ID:       "refresh-scheduler-before-persist.json",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{"access_token": "old-access-token"},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+
+	manager.mu.RLock()
+	expectedCurrent := manager.auths[auth.ID]
+	manager.mu.RUnlock()
+	if expectedCurrent == nil {
+		t.Fatal("registered auth missing")
+	}
+	refreshed := expectedCurrent.Clone()
+	refreshed.Metadata["access_token"] = "refreshed-access-token"
+
+	store.blockNextSave()
+	updateDone := make(chan error, 1)
+	go func() {
+		_, _, errUpdate := manager.updateAuth(context.Background(), refreshed, expectedCurrent)
+		updateDone <- errUpdate
+	}()
+	select {
+	case <-store.blockedSave:
+	case <-time.After(time.Second):
+		t.Fatal("conditional persistence did not block")
+	}
+
+	picked, errPick := manager.scheduler.pickSingle(
+		context.Background(),
+		auth.Provider,
+		"",
+		cliproxyexecutor.Options{},
+		nil,
+	)
+	if errPick != nil {
+		t.Fatalf("scheduler pick while persistence blocked: %v", errPick)
+	}
+	if got := authAccessToken(picked); got != "refreshed-access-token" {
+		t.Fatalf("scheduler token while persistence blocked = %q, want refreshed token", got)
+	}
+
+	close(store.releaseSave)
+	select {
+	case errUpdate := <-updateDone:
+		if errUpdate != nil {
+			t.Fatalf("conditional update: %v", errUpdate)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("conditional update did not finish")
+	}
+}
+
 func TestConditionalUpdateDoesNotPublishStaleOwnerAfterReplacement(t *testing.T) {
 	store := &orderedCredentialStore{}
 	m := NewManager(store, &RoundRobinSelector{}, nil)

--- a/sdk/cliproxy/auth/request_auth_prepare_test.go
+++ b/sdk/cliproxy/auth/request_auth_prepare_test.go
@@ -131,6 +131,49 @@ func (e *requestPrepareExecutor) HttpRequest(context.Context, *Auth, *http.Reque
 	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "http not implemented"}
 }
 
+type replacementPrepareFailureExecutor struct {
+	shouldCalls atomic.Int32
+	selected    chan struct{}
+	release     chan struct{}
+}
+
+func (*replacementPrepareFailureExecutor) Identifier() string { return "antigravity" }
+
+func (e *replacementPrepareFailureExecutor) ShouldPrepareRequestAuth(*Auth) bool {
+	if e.shouldCalls.Add(1) == 1 {
+		close(e.selected)
+		<-e.release
+	}
+	return true
+}
+
+func (*replacementPrepareFailureExecutor) PrepareRequestAuth(_ context.Context, auth *Auth) (*Auth, error) {
+	if got := authMetadataString(auth, "access_token"); got != "replacement-token" {
+		return nil, &Error{HTTPStatus: http.StatusInternalServerError, Message: "preparer did not receive replacement auth"}
+	}
+	return nil, &Error{HTTPStatus: http.StatusUnauthorized, Message: "replacement preparation unauthorized"}
+}
+
+func (*replacementPrepareFailureExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusInternalServerError, Message: "execute should not run"}
+}
+
+func (*replacementPrepareFailureExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, &Error{HTTPStatus: http.StatusInternalServerError, Message: "stream should not run"}
+}
+
+func (*replacementPrepareFailureExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (*replacementPrepareFailureExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusInternalServerError, Message: "count should not run"}
+}
+
+func (*replacementPrepareFailureExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "http not implemented"}
+}
+
 type homeRequestPrepareDispatcher struct {
 	calls atomic.Int32
 }
@@ -348,6 +391,76 @@ func assertHomeExecutionResultStateUnchanged(t *testing.T, manager *Manager, sto
 	}
 	if results := hook.Results(); len(results) != 1 {
 		t.Fatalf("Home execution hook results = %#v, want exactly one ephemeral result", results)
+	}
+}
+
+func TestPrepareRequestAuthFailureUsesReplacementRevision(t *testing.T) {
+	const model = "gemini-3.1-pro"
+	executor := &replacementPrepareFailureExecutor{
+		selected: make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	manager.SetRetryConfig(0, 0, 1)
+
+	auth := &Auth{
+		ID:       "prepare-replacement-revision",
+		Provider: "antigravity",
+		Status:   StatusActive,
+		Metadata: map[string]any{"access_token": "old-token"},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	manager.RefreshSchedulerEntry(auth.ID)
+
+	done := make(chan error, 1)
+	go func() {
+		_, errExecute := manager.Execute(context.Background(), []string{auth.Provider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+		done <- errExecute
+	}()
+	select {
+	case <-executor.selected:
+	case <-time.After(time.Second):
+		t.Fatal("request auth selection did not reach preparation")
+	}
+
+	current, ok := manager.GetByID(auth.ID)
+	if !ok || current == nil {
+		t.Fatal("selected auth disappeared")
+	}
+	replacement := current.Clone()
+	replacement.Metadata["access_token"] = "replacement-token"
+	if _, errUpdate := manager.Update(WithSkipPersist(context.Background()), replacement); errUpdate != nil {
+		t.Fatalf("update replacement: %v", errUpdate)
+	}
+	close(executor.release)
+
+	select {
+	case errExecute := <-done:
+		if errExecute == nil {
+			t.Fatal("Execute error = nil, want preparation unauthorized")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("execution did not finish")
+	}
+
+	current, ok = manager.GetByID(auth.ID)
+	if !ok || current == nil {
+		t.Fatal("replacement auth disappeared")
+	}
+	if got := authMetadataString(current, "access_token"); got != "replacement-token" {
+		t.Fatalf("current access token = %q, want replacement token", got)
+	}
+	if current.Status != StatusError || !current.Unavailable || current.LastError == nil {
+		t.Fatalf("replacement preparation failure was not recorded: %#v", current)
+	}
+	state := current.ModelStates[model]
+	if state == nil || state.Status != StatusError || !state.Unavailable || state.LastError == nil {
+		t.Fatalf("replacement model preparation failure was not recorded: %#v", current.ModelStates)
 	}
 }
 

--- a/sdk/cliproxy/auth/store.go
+++ b/sdk/cliproxy/auth/store.go
@@ -11,3 +11,11 @@ type Store interface {
 	// Delete removes the auth record identified by id.
 	Delete(ctx context.Context, id string) error
 }
+
+// PersistenceTargetResolver resolves the exact store identity that Save would
+// use for an auth record without performing I/O. Stores with a configurable
+// base directory should implement this so stale-target reconciliation compares
+// complete paths rather than ambiguous basenames.
+type PersistenceTargetResolver interface {
+	ResolveAuthPersistenceTarget(auth *Auth) (string, error)
+}

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -96,8 +96,9 @@ type Auth struct {
 	Success int64 `json:"-"`
 	Failed  int64 `json:"-"`
 
-	recentRequests recentRequestRing `json:"-"`
-	indexAssigned  bool              `json:"-"`
+	recentRequests       recentRequestRing `json:"-"`
+	indexAssigned        bool              `json:"-"`
+	credentialGeneration uint64            `json:"-"`
 }
 
 const (


### PR DESCRIPTION
## Summary

- bind internally recorded execution results to the credential revision that actually ran;
- ignore stale unauthorized failures after same-ID credential replacement;
- prevent stale successes from clearing cooldown/unavailability owned by a newer replacement credential or resuming its registry model;
- guard in-flight credential refreshes against replacement races;
- merge successful refresh credential changes onto the latest unrelated auth fields while preserving concurrent quota, cooldown, and operator state;
- fingerprint API keys, OAuth tokens, Vertex service accounts, credential-bearing custom headers, and opaque plugin credential storage;
- fingerprint executable API-key material even on explicitly OAuth-classified credentials whose request path consumes `Attributes["api_key"]`;
- retain the exact current credential revision when request preparation fails;
- detach mutable plugin token storage before conditional persistence leaves the manager lock;
- reconcile stale persistence targets against their current cross-ID runtime owner before cleanup;
- resolve relative persistence targets through each concrete store's configured base directory before ownership comparison;
- fingerprint plugin `api_token` / `apiToken` metadata aliases;
- canonicalize plugin credential-header names and `headers` / `requestHeaders` containers before hashing;
- suppress stale credential-scoped 402, 403, and 429 availability failures after replacement;
- fingerprint Kimi's executable `Attributes["access_token"]` fallback when metadata has no access token;
- case-fold Windows persistence targets before absolute-path equality checks;
- preserve every distinct colliding plugin credential-header source/value in the revision;
- preserve every distinct colliding top-level plugin credential alias source/value in the revision;
- fingerprint the credential Kimi actually selects when access-token and API-key fields coexist;
- bind credential revisions to the normalized upstream `base_url` endpoint used for execution;
- resolve Antigravity metadata `base_url` only when the attribute endpoint is absent;
- resolve xAI metadata `base_url` only when the attribute endpoint is absent;
- bind xAI's effective HTTP chat-route identity only to request revisions for actual HTTP chat dispatches;
- publish CAS-owned refreshed credentials to the scheduler before conditional persistence;
- bind Codex OAuth results to the effective account authorization scope while respecting API-key and custom-header precedence;
- suppress stale OAuth `invalid_grant` failures after same-ID credential replacement;
- bind Antigravity and Vertex service-account results to the effective project/location authorization scope while excluding Vertex API-key mode;
- suppress stale unauthorized Redis error events;
- persist cooldown cleanup when replacement credentials clear stale model state.

## Root cause

A same-filename re-login preserves the auth ID. An older request or refresh can finish after the replacement and previously mutate whichever credential currently occupied that ID.

Execution results now carry the one-way credential revision fingerprint captured from the exact immutable credential snapshot used for dispatch. Refresh application uses credential-aware, generation-checked three-way merging:

- credential revision changed: discard the old refresh result;
- credential unchanged, unrelated fields changed: apply only the refresh credential delta;
- concurrent availability state changed: preserve the newer quota/cooldown/operator state.

For execution results, stale unauthorized failures are suppressed because they describe the superseded credential. Stale successful requests still count toward request metrics, but cannot clear replacement-owned auth/model cooldown state, clear model quota, or call `ResumeClientModel`. Current-revision quota and transient failures retain the existing shared account/model semantics; credential-scoped 401, 402, 403, 429, and `invalid_grant` results from a superseded revision are observation-only.

Transport-dependent revision material is captured at the request boundary. In particular, xAI's `using_api` chat-route identity is included only for HTTP chat dispatches; media, `/responses/compact`, and WebSocket results retain the auth-global revision because those transports do not use the CLI chat proxy.

## Credential coverage

- API keys in auth attributes or metadata;
- OAuth fields in runtime metadata;
- Kimi access tokens stored in auth attributes when metadata carries only refresh state;
- Claude and Codex OAuth tokens retained only in token storage;
- Vertex service-account JSON;
- effective Antigravity project and Vertex service-account project/location authorization scope;
- custom `header:*` credentials such as `Authorization`, API-key, token, secret, and cookie headers;
- authorization- and quota-scope custom headers such as `OpenAI-Organization`, `OpenAI-Project`, `X-Goog-User-Project`, and account/tenant/workspace/project ID forms;
- canonical JSON from plugin or custom storage exposing `RawJSON()`.

Core and plugin credential-header names are canonicalized case-insensitively and sorted before hashing; plugin `headers` and `requestHeaders` map to one request-header fingerprint container. Authorization- and quota-scope headers also participate in the revision, while ordinary tracing and presentation headers remain excluded, so changes such as `X-Trace-ID` do not invalidate in-flight results. Equivalent JSON formatting produces the same revision. Credential material is included only in a one-way SHA-256 fingerprint and is never logged or exposed.

## Regression coverage

The stale-success ordering regression is execution-level and deterministic:

1. an old credential request is held in flight;
2. the same auth ID is replaced with a new access token;
3. the replacement records its own 401 and enters model cooldown/registry suspension;
4. the old request succeeds late;
5. the replacement remains error/unavailable, retains its 401 cooldown, and its registry model remains suspended.

This regression failed before `d8b3e28c` because the late old success reset the replacement to active and resumed the registry model. It passes with the fix. Existing regressions continue to cover stale 401 suppression, current-revision success, shared quota failures, custom-header rotation, storage-backed credentials, plugin credentials, Vertex credentials, streaming dispatch, and refresh/persistence races.

A second deterministic regression covers an explicitly OAuth-classified Claude credential whose executable request secret lives in `Attributes["api_key"]`: after same-ID key replacement, a late 401 from the old key must not suspend or cool down the replacement. It fails before `de9c2868` and passes with it.

A third execution-level regression covers the reverse asymmetric case: an unfingerprintable opaque `TokenStorage` request remains in flight, a fingerprintable API-key replacement takes ownership of the same auth ID, and the old request returns 401 late. Auth generations now provide the fallback identity only when no credential fingerprint exists, so the replacement remains active. The regression fails before `9d8ed1d6` and passes with it.

Three follow-up regressions in `2e124571` cover the remaining boundaries:

- a same-ID replacement lands after selection but before request preparation; a replacement-owned preparation 401 is recorded against the replacement revision rather than the selected predecessor;
- a stale conditional plugin save is held between publication and metadata injection; its detached persistence snapshot cannot rewrite the replacement's live token storage;
- rotating plugin metadata under `api_token` or `apiToken` changes the credential fingerprint even when `StorageJSON` remains stable.

A final cross-ID persistence regression in `54b8c9a3` holds a stale conditional save after it writes the old target, renames the original auth, installs a different auth ID at the old target, and then resumes cleanup. Stale-target reconciliation now persists whichever current runtime auth owns that target—or deletes it only when no owner remains—and rechecks ownership after I/O. The different auth's credential remains persisted; the regression fails before the fix and passes with it.

The path-identity regression in `ef916426` moves a same-ID credential from `old/auth.json` to `new/auth.json` under a configured store root while a stale save remains in flight. `FileTokenStore`, Git, object, and Postgres stores now expose their exact resolved persistence target through an optional resolver contract; reconciliation compares those complete paths rather than the shared basename. The stale old-subdirectory record is deleted and the new target retains the replacement credential. The regression fails before the resolver change and passes with it.

The plugin-header canonicalization regression in `105ffcd0` reloads the same credential as `headers.Authorization` and `REQUEST_HEADERS.authorization` with an unchanged value. Both representations now produce the same credential revision, while the existing rotation regressions still prove that changing the header value changes the revision. The equivalence regression fails before canonicalization and passes with it.

The stale-availability regression in `99a38f49` rotates a same-ID access token and then records late 402, 403, and 429 results from the predecessor. Request failure metrics remain counted, but the replacement stays active with no auth/model cooldown or quota state. The same commit adds a Kimi regression where a stable metadata refresh token accompanies a rotated `Attributes["access_token"]`; the late old 401 is suppressed because the executable attribute token now participates in the revision. Both regressions fail before the fix and pass with it.

Two normalization regressions in `140bb232` cover the remaining exact-head findings. `TestPersistenceTargetsMatchCaseInsensitiveAbsolutePaths` proves Windows-style case folding occurs before absolute-path equality, preventing cleanup from deleting the replacement through an alternate path spelling. `TestPluginTokenStorageFingerprintPreservesCollidingCredentialHeaders` supplies different credential values under `headers.Authorization` and `requestHeaders.authorization`, rotates only the first source, and requires the revision to change. Equivalent single-value casing/container aliases still collapse to the same fingerprint, while conflicting source/value pairs are retained deterministically. Both regressions fail before the fix and pass with it.


Two alias-selection regressions in `33d22c53` close the next review boundary. `TestPluginTokenStorageFingerprintPreservesCollidingTopLevelCredentialKeys` supplies different values under `apiToken` and `api_token`, rotates only one source, and requires the revision to change instead of dropping the colliding alias. `TestRecordExecutionResultIgnoresStaleUnauthorizedAfterKimiMetadataTokenRotationWithAPIKey` keeps a stable API key while rotating the metadata access token that Kimi actually prefers; the late old 401 cannot suspend the replacement. Both regressions fail before the fix and pass with it.

The endpoint regression in `98956ef6` keeps an OpenAI-compatible API key stable while replacing only `Attributes["base_url"]`, then records a late 401 from the old endpoint. The replacement remains active because the normalized execution endpoint now participates in revision identity. `TestAuthCredentialFingerprintCanonicalizesBaseURL` additionally proves equivalent scheme/host casing and a trailing slash do not create false revision drift. The stale-endpoint regression fails before the fix and both tests pass afterward.


The authorization-scope regressions in `8daeec34` cover both exact-head findings and their precedence boundaries. `TestRecordExecutionResultIgnoresStaleUnauthorizedAfterAntigravityMetadataBaseURLReplacement` rotates only Antigravity's metadata fallback endpoint, while `TestAuthCredentialFingerprintUsesAntigravityAttributeEndpointPrecedence` proves a present attribute endpoint shadows metadata. `TestRecordExecutionResultIgnoresStaleUnauthorizedAfterCodexAccountReplacement` rotates only the OAuth `account_id`; companion tests prove API-key auth omits that metadata scope and a custom `ChatGPT-Account-ID` header overrides it. The two stale-result regressions fail before the fix; all five cases pass afterward.

The provider-scope regressions in `c1f77f30` close the latest review boundary. `TestRecordExecutionResultIgnoresStaleInvalidGrantAfterTokenRotation` rotates the same-ID OAuth access/refresh tokens and then records a late HTTP 400 `invalid_grant`; the replacement remains active while the failed-request metric is retained. `TestRecordExecutionResultIgnoresStaleForbiddenAfterAuthorizationScopeReplacement` covers Antigravity `project_id`, Vertex service-account `project_id`, and Vertex `location` changes under stable credentials; late 403 results from each predecessor are suppressed. `TestAuthCredentialFingerprintIgnoresVertexScopeForAPIKeyAuth` proves unused service-account scope does not create revision drift when Vertex executes through its API-key path. All affected cases fail before the fix and pass afterward.

The xAI endpoint regression in `6fd65d76` keeps OAuth tokens stable while replacing only metadata `base_url`, then records a late 401 from the old endpoint. `TestAuthCredentialFingerprintUsesXAIAttributeEndpointPrecedence` proves an explicit attribute endpoint continues to shadow metadata. The stale-result case fails before the fix; both tests pass afterward.

The scheduler-publication regression in `27b5e62f` blocks conditional persistence after a request-triggered refresh has taken CAS ownership, then selects through the built-in scheduler before releasing the store. `TestConditionalUpdatePublishesSchedulerBeforePersistenceCompletes` requires that concurrent selection already sees the refreshed token. The existing replacement-ownership regression continues to prove a later same-ID replacement wins and is not overwritten. The new regression fails before the fix and passes afterward.

The request-scoped routing regressions in `55ef9579` retain stable xAI credentials while changing `using_api`. `TestExecuteIgnoresStaleUnauthorizedAfterXAIHTTPChatRouteReplacement` proves a late 401 from the superseded HTTP chat route is ignored. `TestExecuteAppliesUnauthorizedAcrossXAINonChatUsingAPIToggle` covers image, video, and `/responses/compact` requests, and `TestExecuteStreamAppliesUnauthorizedAcrossXAIWebsocketUsingAPIToggle` covers WebSocket dispatch; because those transports do not change route, their failures remain current and are applied. The same commit adds `TestRecordExecutionResultIgnoresStaleForbiddenAfterAuthorizationScopeHeaderReplacement` plus scope-header family coverage for organization, project, account, tenant, workspace, team, subscription, and user-project headers. All affected cases fail before the fix and pass afterward.

## Validation

- rebased onto current `dev` (`189776aa`);
- focused stale-success regression: passed;
- focused stale-success race regression: **20/20 passed**;
- focused OAuth-shaped API-key stale-401 regression: **20/20 passed under `-race`**;
- focused opaque-generation → API-key replacement regression: **20/20 passed under `-race`**;
- focused preparation-revision and conditional-persistence regressions: **20/20 passed under `-race`**;
- focused plugin persistence-snapshot and `api_token` fingerprint regressions: **20/20 passed under `-race`**;
- focused cross-ID target-reuse and adjacent conditional-cleanup regressions: **20/20 passed under `-race`**;
- focused relative-subdirectory target-resolution regression and adjacent cleanup cases: **20/20 passed under `-race`**;
- focused plugin header-name/container canonicalization and adjacent fingerprint regressions: **20/20 passed under `-race`**;
- focused stale 402/403/429 and Kimi attribute-token regressions with adjacent stale-result cases: **20/20 passed under `-race`**;
- focused Windows path-case and colliding plugin-header regressions with adjacent canonicalization cases: **20/20 passed under `-race`**;
- focused colliding top-level plugin-alias and Kimi selected-credential regressions: **20/20 passed under `-race`**;
- focused normalized-endpoint and stale-endpoint result regressions: **20/20 passed under `-race`**;
- focused Antigravity metadata-endpoint and Codex authorization-scope regressions with precedence controls: **20/20 passed under `-race`**;
- focused stale `invalid_grant` and Antigravity/Vertex project-scope regressions with the Vertex API-key precedence control: **20/20 passed under `-race`**;
- focused xAI metadata-endpoint regression with attribute-precedence control: **20/20 passed under `-race`**;
- focused scheduler-before-persistence regression with replacement-ownership controls: **20/20 passed under `-race`**;
- focused authorization-scope-header and request-scoped xAI chat/media/compact/WebSocket regressions: **20/20 passed under `-race`**;
- full `sdk/auth` and `internal/store` packages: passed normally and under `-race`;
- full `sdk/cliproxy/auth` and `internal/pluginhost` packages: passed normally and under `-race`;
- `go test ./... -count=1`: passed;
- `go vet ./sdk/cliproxy/auth ./sdk/auth ./internal/store ./internal/api/handlers/management ./internal/auth/claude ./internal/auth/codex`: passed;
- `go build -o test-output ./cmd/server && rm test-output`: passed;
- `git diff --check upstream/dev...HEAD`: passed;
- Go conflict-marker scan: clean.

Related: #4123. The backend credential-replacement race is reproduced independently by this PR.














