### PR TITLE
fix(codex): preserve websocket continuity across executor refresh

### DIFF
--- a/internal/runtime/executor/codex_websockets_connection.go
+++ b/internal/runtime/executor/codex_websockets_connection.go
@@ -157,6 +157,18 @@ func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession,
 	}
 }
 
+func codexWebsocketProxyURL(cfg *config.Config, auth *cliproxyauth.Auth) string {
+	if auth != nil {
+		if proxyURL := strings.TrimSpace(auth.ProxyURL); proxyURL != "" {
+			return proxyURL
+		}
+	}
+	if cfg == nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg.ProxyURL)
+}
+
 func newProxyAwareWebsocketDialer(cfg *config.Config, auth *cliproxyauth.Auth) *websocket.Dialer {
 	dialer := &websocket.Dialer{
 		Proxy:             http.ProxyFromEnvironment,
@@ -168,13 +180,7 @@ func newProxyAwareWebsocketDialer(cfg *config.Config, auth *cliproxyauth.Auth) *
 		}).DialContext,
 	}
 
-	proxyURL := ""
-	if auth != nil {
-		proxyURL = strings.TrimSpace(auth.ProxyURL)
-	}
-	if proxyURL == "" && cfg != nil {
-		proxyURL = strings.TrimSpace(cfg.ProxyURL)
-	}
+	proxyURL := codexWebsocketProxyURL(cfg, auth)
 	if proxyURL == "" {
 		return dialer
 	}

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -94,6 +94,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		authLabel = auth.Label
 		authType, authValue = auth.AccountInfo()
 	}
+	connectionKey := codexWebsocketConnectionKey(e.cfg, auth)
 
 	executionSessionID := executionSessionIDFromOptions(opts)
 	var sess *codexWebsocketSession
@@ -130,12 +131,12 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	var respHS *http.Response
 	var errDial error
 	if cliproxyexecutor.RequiredUpstreamWebsocket(ctx) {
-		conn, closer = existingWebsocketSessionConn(sess, authID, wsURL)
+		conn, closer = existingWebsocketSessionConn(sess, authID, wsURL, connectionKey)
 		if conn == nil {
 			return resp, cliproxyexecutor.NewUpstreamWebsocketReplayRequiredError()
 		}
 	} else {
-		conn, closer, respHS, errDial = e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
+		conn, closer, respHS, errDial = e.ensureUpstreamConnWithConnectionKey(ctx, auth, sess, authID, wsURL, wsHeaders, connectionKey)
 	}
 	if errDial != nil {
 		bodyErr := websocketHandshakeBody(respHS)
@@ -203,7 +204,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			// Retry once with a fresh websocket connection. This is mainly to handle
 			// upstream closing the socket between sequential requests within the same
 			// execution session.
-			connRetry, closerRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
+			connRetry, closerRetry, respHSRetry, errDialRetry := e.ensureUpstreamConnWithConnectionKey(ctx, auth, sess, authID, wsURL, wsHeaders, connectionKey)
 			if errDialRetry == nil && connRetry != nil {
 				previousConn, previousReadCh := conn, readCh
 				conn = connRetry

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -104,6 +104,30 @@ func (e *CodexAutoExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.
 	return e.httpExec.CountTokens(ctx, auth, req, opts)
 }
 
+func (e *CodexAutoExecutor) CanHandoffExecutionSessionsTo(replacement cliproxyauth.ProviderExecutor) bool {
+	next, ok := replacement.(*CodexAutoExecutor)
+	if !ok || e == nil || next == nil || e.wsExec == nil || next.wsExec == nil {
+		return false
+	}
+	store := e.wsExec.store
+	if store == nil {
+		store = globalCodexWebsocketSessionStore
+	}
+	nextStore := next.wsExec.store
+	if nextStore == nil {
+		nextStore = globalCodexWebsocketSessionStore
+	}
+	var cfg *config.Config
+	if e.wsExec.CodexExecutor != nil {
+		cfg = e.wsExec.cfg
+	}
+	var nextCfg *config.Config
+	if next.wsExec.CodexExecutor != nil {
+		nextCfg = next.wsExec.cfg
+	}
+	return store == nextStore && codexWebsocketConfigConnectionKey(cfg) == codexWebsocketConfigConnectionKey(nextCfg)
+}
+
 func (e *CodexAutoExecutor) CloseExecutionSession(sessionID string) {
 	if e == nil || e.wsExec == nil {
 		return

--- a/internal/runtime/executor/codex_websockets_executor_store_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_store_test.go
@@ -1,8 +1,10 @@
 package executor
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
@@ -38,4 +40,175 @@ func TestCodexWebsocketsExecutor_CloseAllReleasesSessions(t *testing.T) {
 	}
 
 	exec2.CloseExecutionSession(sessionID)
+}
+
+func TestCodexAutoExecutorReplacementPreservesSharedSessionStore(t *testing.T) {
+	server, _ := newWebsocketTargetServer(t)
+	defer server.Close()
+
+	sessionID := "test-session-store-survives-manager-replace"
+	globalCodexWebsocketSessionStore.mu.Lock()
+	delete(globalCodexWebsocketSessionStore.sessions, sessionID)
+	globalCodexWebsocketSessionStore.mu.Unlock()
+
+	firstConfig := &config.Config{RequestRetry: 1}
+	secondConfig := &config.Config{RequestRetry: 2}
+	first := NewCodexAutoExecutor(firstConfig)
+	second := NewCodexAutoExecutor(secondConfig)
+	auth := &cliproxyauth.Auth{
+		ID:       "codex-auth",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"access_token": "oauth-token",
+			"account_id":   "account-a",
+		},
+	}
+	sess := first.wsExec.getOrCreateSession(sessionID)
+	if sess == nil {
+		t.Fatal("expected session to be created")
+	}
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, physical := newCloseCountingWebsocketConn(t, wsURL)
+	sess.connMu.Lock()
+	sess.conn = conn
+	sess.connCloser = newWebsocketConnectionCloser(conn)
+	sess.wsURL = wsURL
+	sess.authID = auth.ID
+	sess.connectionKey = codexWebsocketConnectionKey(firstConfig, auth)
+	sess.readerConn = conn
+	sess.connMu.Unlock()
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(first)
+	manager.RegisterExecutor(second)
+
+	globalCodexWebsocketSessionStore.mu.Lock()
+	_, stillPresent := globalCodexWebsocketSessionStore.sessions[sessionID]
+	globalCodexWebsocketSessionStore.mu.Unlock()
+	if !stillPresent {
+		t.Fatal("expected shared websocket session to survive executor replacement")
+	}
+	if got := physical.closes.Load(); got != 0 {
+		t.Fatalf("physical websocket closes after executor replacement = %d, want 0", got)
+	}
+	wantConnectionKey := codexWebsocketConnectionKey(secondConfig, auth)
+	gotConn, gotCloser := existingWebsocketSessionConn(sess, auth.ID, wsURL, wantConnectionKey)
+	if gotConn != conn || gotCloser != sess.connCloser {
+		t.Fatal("replacement executor could not reuse the preserved websocket session")
+	}
+
+	second.CloseExecutionSession(sessionID)
+	if got := physical.closes.Load(); got != 1 {
+		t.Fatalf("physical websocket closes after explicit session close = %d, want 1", got)
+	}
+}
+
+func TestCodexAutoExecutorReplacementPreservesOAuthSessionWhenUnrelatedAPIKeyChanges(t *testing.T) {
+	server, _ := newWebsocketTargetServer(t)
+	defer server.Close()
+
+	sessionID := "test-session-store-ignores-unrelated-api-key-change"
+	globalCodexWebsocketSessionStore.mu.Lock()
+	delete(globalCodexWebsocketSessionStore.sessions, sessionID)
+	globalCodexWebsocketSessionStore.mu.Unlock()
+
+	firstConfig := &config.Config{CodexKey: []config.CodexKey{{
+		APIKey:     "unrelated-key-a",
+		BaseURL:    "https://api.example.test/v1",
+		Websockets: true,
+	}}}
+	secondConfig := &config.Config{CodexKey: []config.CodexKey{{
+		APIKey:     "unrelated-key-b",
+		BaseURL:    "https://api.example.test/v1",
+		Websockets: true,
+	}}}
+	first := NewCodexAutoExecutor(firstConfig)
+	second := NewCodexAutoExecutor(secondConfig)
+	auth := &cliproxyauth.Auth{
+		ID:       "oauth-auth",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"access_token": "oauth-token",
+			"account_id":   "account-a",
+		},
+	}
+	sess := first.wsExec.getOrCreateSession(sessionID)
+	if sess == nil {
+		t.Fatal("expected session to be created")
+	}
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, physical := newCloseCountingWebsocketConn(t, wsURL)
+	sess.connMu.Lock()
+	sess.conn = conn
+	sess.connCloser = newWebsocketConnectionCloser(conn)
+	sess.wsURL = wsURL
+	sess.authID = auth.ID
+	sess.connectionKey = codexWebsocketConnectionKey(firstConfig, auth)
+	sess.readerConn = conn
+	sess.connMu.Unlock()
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(first)
+	manager.RegisterExecutor(second)
+
+	globalCodexWebsocketSessionStore.mu.Lock()
+	_, stillPresent := globalCodexWebsocketSessionStore.sessions[sessionID]
+	globalCodexWebsocketSessionStore.mu.Unlock()
+	if !stillPresent {
+		t.Fatal("unrelated API-key change removed OAuth websocket session")
+	}
+	if got := physical.closes.Load(); got != 0 {
+		t.Fatalf("physical websocket closes after unrelated API-key change = %d, want 0", got)
+	}
+	wantConnectionKey := codexWebsocketConnectionKey(secondConfig, auth)
+	gotConn, _ := existingWebsocketSessionConn(sess, auth.ID, wsURL, wantConnectionKey)
+	if gotConn != conn {
+		t.Fatal("replacement executor could not reuse OAuth session after unrelated API-key change")
+	}
+
+	second.CloseExecutionSession(sessionID)
+}
+
+func TestCodexAutoExecutorReplacementClosesSessionsWhenConnectionConfigChanges(t *testing.T) {
+	server, _ := newWebsocketTargetServer(t)
+	defer server.Close()
+
+	sessionID := "test-session-store-closes-on-connection-config-change"
+	globalCodexWebsocketSessionStore.mu.Lock()
+	delete(globalCodexWebsocketSessionStore.sessions, sessionID)
+	globalCodexWebsocketSessionStore.mu.Unlock()
+
+	first := NewCodexAutoExecutor(&config.Config{SDKConfig: config.SDKConfig{
+		ProxyURL: "http://proxy-a.example:8080",
+	}})
+	second := NewCodexAutoExecutor(&config.Config{SDKConfig: config.SDKConfig{
+		ProxyURL: "http://proxy-b.example:8080",
+	}})
+	sess := first.wsExec.getOrCreateSession(sessionID)
+	if sess == nil {
+		t.Fatal("expected session to be created")
+	}
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, physical := newCloseCountingWebsocketConn(t, wsURL)
+	sess.connMu.Lock()
+	sess.conn = conn
+	sess.connCloser = newWebsocketConnectionCloser(conn)
+	sess.wsURL = wsURL
+	sess.authID = "codex-auth"
+	sess.readerConn = conn
+	sess.connMu.Unlock()
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(first)
+	manager.RegisterExecutor(second)
+
+	globalCodexWebsocketSessionStore.mu.Lock()
+	_, stillPresent := globalCodexWebsocketSessionStore.sessions[sessionID]
+	globalCodexWebsocketSessionStore.mu.Unlock()
+	if stillPresent {
+		t.Fatal("websocket session survived incompatible executor connection settings")
+	}
+	if got := physical.closes.Load(); got != 1 {
+		t.Fatalf("physical websocket closes after incompatible executor replacement = %d, want 1", got)
+	}
 }

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -500,6 +500,165 @@ func TestExistingWebsocketSessionConnRequiresMatchingHealthyConnection(t *testin
 	}
 }
 
+func TestExistingWebsocketSessionConnRequiresMatchingConnectionKey(t *testing.T) {
+	conn := &websocket.Conn{}
+	closer := newWebsocketConnectionCloser(conn)
+	sess := &codexWebsocketSession{
+		conn:          conn,
+		connCloser:    closer,
+		authID:        "auth-a",
+		wsURL:         "ws://example.test/responses",
+		connectionKey: "settings-a",
+	}
+	sess.resetUpstreamDisconnectError(conn)
+
+	if gotConn, gotCloser := existingWebsocketSessionConn(sess, "auth-a", "ws://example.test/responses", "settings-a"); gotConn != conn || gotCloser != closer {
+		t.Fatal("matching connection settings were not reusable")
+	}
+	if got, _ := existingWebsocketSessionConn(sess, "auth-a", "ws://example.test/responses", "settings-b"); got != nil {
+		t.Fatal("websocket session matched incompatible connection settings")
+	}
+}
+
+func TestCodexWebsocketConnectionKeyTracksStableSettings(t *testing.T) {
+	baseConfig := &config.Config{
+		SDKConfig: config.SDKConfig{ProxyURL: "http://global-proxy.example:8080"},
+		CodexHeaderDefaults: config.CodexHeaderDefaults{
+			UserAgent:    "codex-test/1",
+			BetaFeatures: "feature-a",
+		},
+		RequestRetry: 1,
+	}
+	baseAuth := &cliproxyauth.Auth{
+		ID:       "codex-auth",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"header:X-Route": "route-a",
+		},
+		Metadata: map[string]any{
+			"access_token": "token-a",
+			"account_id":   "account-a",
+		},
+	}
+	baseKey := codexWebsocketConnectionKey(baseConfig, baseAuth)
+
+	tests := []struct {
+		name     string
+		mutate   func(*config.Config, *cliproxyauth.Auth)
+		wantSame bool
+	}{
+		{
+			name: "access token rotation keeps socket identity",
+			mutate: func(_ *config.Config, auth *cliproxyauth.Auth) {
+				auth.Metadata["access_token"] = "token-b"
+			},
+			wantSame: true,
+		},
+		{
+			name: "unrelated retry config keeps socket identity",
+			mutate: func(cfg *config.Config, _ *cliproxyauth.Auth) {
+				cfg.RequestRetry = 9
+			},
+			wantSame: true,
+		},
+		{
+			name: "global proxy changes socket identity",
+			mutate: func(cfg *config.Config, _ *cliproxyauth.Auth) {
+				cfg.ProxyURL = "http://other-global-proxy.example:8080"
+			},
+		},
+		{
+			name: "auth proxy changes socket identity",
+			mutate: func(_ *config.Config, auth *cliproxyauth.Auth) {
+				auth.ProxyURL = "http://auth-proxy.example:8080"
+			},
+		},
+		{
+			name: "user agent default changes socket identity",
+			mutate: func(cfg *config.Config, _ *cliproxyauth.Auth) {
+				cfg.CodexHeaderDefaults.UserAgent = "codex-test/2"
+			},
+		},
+		{
+			name: "beta default changes socket identity",
+			mutate: func(cfg *config.Config, _ *cliproxyauth.Auth) {
+				cfg.CodexHeaderDefaults.BetaFeatures = "feature-b"
+			},
+		},
+		{
+			name: "identity confuse activation changes socket identity",
+			mutate: func(cfg *config.Config, _ *cliproxyauth.Auth) {
+				cfg.Codex.IdentityConfuse = true
+				cfg.Routing.SessionAffinity = true
+			},
+		},
+		{
+			name: "custom header changes socket identity",
+			mutate: func(_ *config.Config, auth *cliproxyauth.Auth) {
+				auth.Attributes["header:X-Route"] = "route-b"
+			},
+		},
+		{
+			name: "account changes socket identity",
+			mutate: func(_ *config.Config, auth *cliproxyauth.Auth) {
+				auth.Metadata["account_id"] = "account-b"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := *baseConfig
+			auth := baseAuth.Clone()
+			tt.mutate(&cfg, auth)
+			got := codexWebsocketConnectionKey(&cfg, auth)
+			if tt.wantSame && got != baseKey {
+				t.Fatalf("connection key changed: got %q, want %q", got, baseKey)
+			}
+			if !tt.wantSame && got == baseKey {
+				t.Fatalf("connection key did not change from %q", baseKey)
+			}
+		})
+	}
+
+	t.Run("API key rotation changes socket identity", func(t *testing.T) {
+		auth := &cliproxyauth.Auth{
+			ID:       "codex-api-key-auth",
+			Provider: "codex",
+			Attributes: map[string]string{
+				"api_key": "api-key-a",
+			},
+		}
+		firstKey := codexWebsocketConnectionKey(baseConfig, auth)
+		auth.Attributes["api_key"] = "api-key-b"
+		secondKey := codexWebsocketConnectionKey(baseConfig, auth)
+		if secondKey == firstKey {
+			t.Fatalf("connection key did not change after API-key rotation: %q", firstKey)
+		}
+	})
+
+	t.Run("API key handshake takes precedence over explicit OAuth kind", func(t *testing.T) {
+		auth := &cliproxyauth.Auth{
+			ID:       "codex-mixed-auth",
+			Provider: "codex",
+			Attributes: map[string]string{
+				cliproxyauth.AttributeAuthKind: cliproxyauth.AuthKindOAuth,
+				"api_key":                      "api-key-a",
+			},
+			Metadata: map[string]any{"access_token": "oauth-token"},
+		}
+		if !codexAuthUsesAPIKey(auth) {
+			t.Fatal("test auth does not use API-key handshake")
+		}
+		firstKey := codexWebsocketConnectionKey(baseConfig, auth)
+		auth.Attributes["api_key"] = "api-key-b"
+		secondKey := codexWebsocketConnectionKey(baseConfig, auth)
+		if secondKey == firstKey {
+			t.Fatalf("connection key did not change after mixed-shape API-key rotation: %q", firstKey)
+		}
+	})
+}
+
 func TestCodexAutoExecutorRequiredUpstreamWebsocketRejectsHTTPFallback(t *testing.T) {
 	exec := NewCodexAutoExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
 	auth := &cliproxyauth.Auth{

--- a/internal/runtime/executor/codex_websockets_session.go
+++ b/internal/runtime/executor/codex_websockets_session.go
@@ -2,13 +2,17 @@ package executor
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"net/http"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	log "github.com/sirupsen/logrus"
@@ -56,6 +60,7 @@ type codexWebsocketSession struct {
 	connCloser      *websocketConnectionCloser
 	wsURL           string
 	authID          string
+	connectionKey   string
 	lifecycleBindMu sync.Mutex
 	lifecycle       cliproxyexecutor.ExecutionLifecycle
 	lifecycleModel  string
@@ -272,6 +277,7 @@ func (s *codexWebsocketSession) detachConnection(conn *websocket.Conn, lifecycle
 		closer = s.connCloser
 		s.conn = nil
 		s.connCloser = nil
+		s.connectionKey = ""
 		if s.readerConn == conn {
 			s.readerConn = nil
 		}
@@ -296,7 +302,93 @@ func closeWebsocketAfterBindFailure(sess *codexWebsocketSession, conn *websocket
 	}
 }
 
-func websocketSessionTargetChanged(sess *codexWebsocketSession, authID string, wsURL string) bool {
+func codexWebsocketConfigConnectionKey(cfg *config.Config) string {
+	var parts strings.Builder
+	proxyURL := ""
+	userAgent := ""
+	betaFeatures := ""
+	if cfg != nil {
+		proxyURL = strings.TrimSpace(cfg.ProxyURL)
+		userAgent = strings.TrimSpace(cfg.CodexHeaderDefaults.UserAgent)
+		betaFeatures = strings.TrimSpace(cfg.CodexHeaderDefaults.BetaFeatures)
+	}
+	appendCodexWebsocketConnectionKeyPart(&parts, "proxy", proxyURL)
+	appendCodexWebsocketConnectionKeyPart(&parts, "user-agent", userAgent)
+	appendCodexWebsocketConnectionKeyPart(&parts, "beta-features", betaFeatures)
+	appendCodexWebsocketConnectionKeyPart(&parts, "identity-confuse", strconv.FormatBool(codexIdentityConfuseEnabled(cfg)))
+	return codexWebsocketConnectionKeyHash(parts.String())
+}
+
+func codexWebsocketConnectionKey(cfg *config.Config, auth *cliproxyauth.Auth) string {
+	var parts strings.Builder
+	appendCodexWebsocketConnectionKeyPart(&parts, "config", codexWebsocketConfigConnectionKey(cfg))
+	appendCodexWebsocketConnectionKeyPart(&parts, "proxy", codexWebsocketProxyURL(cfg, auth))
+	if auth == nil {
+		return codexWebsocketConnectionKeyHash(parts.String())
+	}
+	authKind := strings.TrimSpace(auth.AuthKind())
+	appendCodexWebsocketConnectionKeyPart(&parts, "auth-kind", authKind)
+	if codexAuthUsesAPIKey(auth) {
+		apiKey := strings.TrimSpace(auth.Attributes["api_key"])
+		appendCodexWebsocketConnectionKeyPart(&parts, "api-key-fingerprint", codexWebsocketConnectionKeyHash(apiKey))
+	}
+	accountID := ""
+	if auth.Metadata != nil {
+		accountID, _ = auth.Metadata["account_id"].(string)
+	}
+	appendCodexWebsocketConnectionKeyPart(&parts, "account-id", strings.TrimSpace(accountID))
+
+	headerParts := make([]string, 0)
+	for key, value := range auth.Attributes {
+		if !strings.HasPrefix(key, "header:") {
+			continue
+		}
+		name := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(key, "header:")))
+		value = strings.TrimSpace(value)
+		if name == "" || value == "" {
+			continue
+		}
+		headerParts = append(headerParts, name+"\x00"+value)
+	}
+	sort.Strings(headerParts)
+	for _, headerPart := range headerParts {
+		appendCodexWebsocketConnectionKeyPart(&parts, "header", headerPart)
+	}
+	return codexWebsocketConnectionKeyHash(parts.String())
+}
+
+func appendCodexWebsocketConnectionKeyPart(parts *strings.Builder, name string, value string) {
+	if parts == nil {
+		return
+	}
+	parts.WriteString(name)
+	parts.WriteByte('=')
+	parts.WriteString(strconv.Itoa(len(value)))
+	parts.WriteByte(':')
+	parts.WriteString(value)
+	parts.WriteByte('\n')
+}
+
+func codexWebsocketConnectionKeyHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return fmt.Sprintf("%x", sum)
+}
+
+func requestedWebsocketConnectionKey(connectionKeys []string) string {
+	if len(connectionKeys) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(connectionKeys[0])
+}
+
+func websocketSessionTargetMatches(sess *codexWebsocketSession, authID string, wsURL string, connectionKey string) bool {
+	return sess != nil &&
+		strings.TrimSpace(sess.authID) == strings.TrimSpace(authID) &&
+		strings.TrimSpace(sess.wsURL) == strings.TrimSpace(wsURL) &&
+		strings.TrimSpace(sess.connectionKey) == strings.TrimSpace(connectionKey)
+}
+
+func websocketSessionTargetChanged(sess *codexWebsocketSession, authID string, wsURL string, connectionKeys ...string) bool {
 	if sess == nil {
 		return false
 	}
@@ -306,19 +398,19 @@ func websocketSessionTargetChanged(sess *codexWebsocketSession, authID string, w
 	if strings.TrimSpace(sess.authID) == "" && strings.TrimSpace(sess.wsURL) == "" {
 		return false
 	}
-	return strings.TrimSpace(sess.authID) != strings.TrimSpace(authID) || strings.TrimSpace(sess.wsURL) != strings.TrimSpace(wsURL)
+	return !websocketSessionTargetMatches(sess, authID, wsURL, requestedWebsocketConnectionKey(connectionKeys))
 }
 
-func existingWebsocketSessionConn(sess *codexWebsocketSession, authID string, wsURL string) (*websocket.Conn, *websocketConnectionCloser) {
+func existingWebsocketSessionConn(sess *codexWebsocketSession, authID string, wsURL string, connectionKeys ...string) (*websocket.Conn, *websocketConnectionCloser) {
 	if sess == nil {
 		return nil, nil
 	}
 	sess.connMu.Lock()
 	conn := sess.conn
 	closer := sess.connCloser
-	matches := conn != nil && closer != nil &&
-		strings.TrimSpace(sess.authID) == strings.TrimSpace(authID) &&
-		strings.TrimSpace(sess.wsURL) == strings.TrimSpace(wsURL)
+	matches := conn != nil && closer != nil && websocketSessionTargetMatches(
+		sess, authID, wsURL, requestedWebsocketConnectionKey(connectionKeys),
+	)
 	sess.connMu.Unlock()
 	if !matches || sess.upstreamDisconnectError(conn) != nil {
 		return nil, nil
@@ -326,7 +418,7 @@ func existingWebsocketSessionConn(sess *codexWebsocketSession, authID string, ws
 	return conn, closer
 }
 
-func detachMismatchedWebsocketSessionConn(sess *codexWebsocketSession, authID string, wsURL string) (*websocket.Conn, *websocketConnectionCloser, string, string, cliproxyexecutor.ExecutionLifecycle) {
+func detachMismatchedWebsocketSessionConn(sess *codexWebsocketSession, authID string, wsURL string, connectionKeys ...string) (*websocket.Conn, *websocketConnectionCloser, string, string, cliproxyexecutor.ExecutionLifecycle) {
 	if sess == nil {
 		return nil, nil, "", "", nil
 	}
@@ -334,7 +426,7 @@ func detachMismatchedWebsocketSessionConn(sess *codexWebsocketSession, authID st
 	sess.connMu.Lock()
 	defer sess.connMu.Unlock()
 	conn := sess.conn
-	if conn == nil || (strings.TrimSpace(sess.authID) == strings.TrimSpace(authID) && strings.TrimSpace(sess.wsURL) == strings.TrimSpace(wsURL)) {
+	if conn == nil || websocketSessionTargetMatches(sess, authID, wsURL, requestedWebsocketConnectionKey(connectionKeys)) {
 		return nil, nil, "", "", nil
 	}
 
@@ -346,6 +438,7 @@ func detachMismatchedWebsocketSessionConn(sess *codexWebsocketSession, authID st
 	sess.lifecycleModel = ""
 	sess.conn = nil
 	sess.connCloser = nil
+	sess.connectionKey = ""
 	if sess.readerConn == conn {
 		sess.readerConn = nil
 	}
@@ -456,11 +549,15 @@ func (e *CodexWebsocketsExecutor) UpstreamDisconnectChan(sessionID string) <-cha
 }
 
 func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *cliproxyauth.Auth, sess *codexWebsocketSession, authID string, wsURL string, headers http.Header) (*websocket.Conn, *websocketConnectionCloser, *http.Response, error) {
+	return e.ensureUpstreamConnWithConnectionKey(ctx, auth, sess, authID, wsURL, headers, codexWebsocketConnectionKey(e.cfg, auth))
+}
+
+func (e *CodexWebsocketsExecutor) ensureUpstreamConnWithConnectionKey(ctx context.Context, auth *cliproxyauth.Auth, sess *codexWebsocketSession, authID string, wsURL string, headers http.Header, connectionKey string) (*websocket.Conn, *websocketConnectionCloser, *http.Response, error) {
 	if sess == nil {
 		return e.dialCodexWebsocket(ctx, auth, wsURL, headers)
 	}
 
-	if staleConn, staleCloser, staleAuthID, staleWSURL, staleLifecycle := detachMismatchedWebsocketSessionConn(sess, authID, wsURL); staleConn != nil {
+	if staleConn, staleCloser, staleAuthID, staleWSURL, staleLifecycle := detachMismatchedWebsocketSessionConn(sess, authID, wsURL, connectionKey); staleConn != nil {
 		logCodexWebsocketDisconnected(sess.sessionID, staleAuthID, staleWSURL, "target_changed", nil)
 		if staleCloser != nil {
 			if errClose := staleCloser.Close(); errClose != nil {
@@ -507,6 +604,7 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 	sess.connCloser = closer
 	sess.wsURL = wsURL
 	sess.authID = authID
+	sess.connectionKey = connectionKey
 	sess.readerConn = conn
 	sess.connMu.Unlock()
 
@@ -602,6 +700,7 @@ func (e *CodexWebsocketsExecutor) invalidateUpstreamConnWithNotify(sess *codexWe
 	sess.lifecycleModel = ""
 	sess.conn = nil
 	sess.connCloser = nil
+	sess.connectionKey = ""
 	if sess.readerConn == conn {
 		sess.readerConn = nil
 	}
@@ -693,6 +792,7 @@ func closeCodexWebsocketSession(sess *codexWebsocketSession, reason string) {
 	sess.lifecycleModel = ""
 	sess.conn = nil
 	sess.connCloser = nil
+	sess.connectionKey = ""
 	if sess.readerConn == conn {
 		sess.readerConn = nil
 	}

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -89,6 +89,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	authID = auth.ID
 	authLabel = auth.Label
 	authType, authValue = auth.AccountInfo()
+	connectionKey := codexWebsocketConnectionKey(e.cfg, auth)
 
 	executionSessionID := executionSessionIDFromOptions(opts)
 	var sess *codexWebsocketSession
@@ -125,7 +126,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	var respHS *http.Response
 	var errDial error
 	if cliproxyexecutor.RequiredUpstreamWebsocket(ctx) {
-		conn, closer = existingWebsocketSessionConn(sess, authID, wsURL)
+		conn, closer = existingWebsocketSessionConn(sess, authID, wsURL, connectionKey)
 		if conn == nil {
 			if sess != nil {
 				sess.reqMu.Unlock()
@@ -133,7 +134,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			return nil, cliproxyexecutor.NewUpstreamWebsocketReplayRequiredError()
 		}
 	} else {
-		conn, closer, respHS, errDial = e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
+		conn, closer, respHS, errDial = e.ensureUpstreamConnWithConnectionKey(ctx, auth, sess, authID, wsURL, wsHeaders, connectionKey)
 	}
 	var upstreamHeaders http.Header
 	if respHS != nil {
@@ -205,7 +206,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			}
 
 			// Retry once with a new websocket connection for the same execution session.
-			connRetry, closerRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
+			connRetry, closerRetry, respHSRetry, errDialRetry := e.ensureUpstreamConnWithConnectionKey(ctx, auth, sess, authID, wsURL, wsHeaders, connectionKey)
 			if errDialRetry != nil || connRetry == nil {
 				closeHTTPResponseBody(respHSRetry, "codex websockets executor: close handshake response body error")
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "dial_retry", errDialRetry)

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -42,6 +42,12 @@ type ExecutionSessionCloser interface {
 	CloseExecutionSession(sessionID string)
 }
 
+// executionSessionHandoff lets a replaced executor preserve sessions that the
+// replacement can continue through a shared runtime store.
+type executionSessionHandoff interface {
+	CanHandoffExecutionSessionsTo(replacement ProviderExecutor) bool
+}
+
 // Result captures execution outcome used to adjust auth state.
 type Result struct {
 	// AuthID references the auth that produced this result.

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -47,6 +47,9 @@ func (m *Manager) RegisterExecutor(executor ProviderExecutor) {
 	if replaced == nil || replaced == executor {
 		return
 	}
+	if handoff, ok := replaced.(executionSessionHandoff); ok && handoff != nil && handoff.CanHandoffExecutionSessionsTo(executor) {
+		return
+	}
 	if closer, ok := replaced.(ExecutionSessionCloser); ok && closer != nil {
 		closer.CloseExecutionSession(CloseAllExecutionSessionsID)
 	}


### PR DESCRIPTION
## Summary

- preserve Codex WebSocket sessions across compatible executor refreshes
- reconnect when the effective proxy, headers, identity mode, account, or selected credential changes
- ignore unrelated configured API keys when evaluating an OAuth session
- keep explicit session close, auth removal, and true close-all cleanup unchanged

## Root cause

Starting with v7.2.96, replacing a Codex executor closed every session in the shared WebSocket store. A follow-up request carrying `previous_response_id` then opened a different upstream socket, where the response ID did not exist.

```text
turn 1 uses socket A
executor refresh closes A
turn 2 opens socket B with previous_response_id from A
previous_response_not_found
```

The old and replacement `CodexAutoExecutor` instances intentionally share the global session store. This patch hands sessions across replacement only when their connection identity is compatible.

## Connection compatibility

The per-session connection key includes:

- global and per-auth proxy route
- Codex User-Agent and beta headers
- effective `identity-confuse` mode
- account ID
- custom auth headers
- selected API-key revision, when the session uses an API key
- auth ID and upstream WebSocket URL

Provider-level handoff compares only settings that affect every Codex socket. Rotating an unrelated configured API key no longer closes OAuth sessions. Rotating the API key actually used by a session still changes its per-session connection key and reconnects.

Ordinary OAuth access-token rotation preserves an established socket.

## Validation

- real WebSocket regression tests with a physical close counter
- compatible replacement: zero closes and shared session retained
- proxy/header/identity or selected API-key change: old socket closes
- unrelated configured API-key change: OAuth socket remains reusable
- explicit session close and true close-all: one physical close
- `go test ./internal/runtime/executor ./sdk/cliproxy/auth -count=1`
- focused race tests
- `go vet ./internal/runtime/executor ./sdk/cliproxy/auth`
- `go build -o /tmp/pr4569-server ./cmd/server`
- `git diff --check upstream/dev...HEAD`

Fixes #4524
