### PR TITLE
fix(auth): adapt refresh lead to token lifetime

### DIFF
--- a/sdk/cliproxy/auth/auto_refresh_loop.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop.go
@@ -347,8 +347,11 @@ func nextRefreshCheckAt(now time.Time, auth *Auth, interval time.Duration) (time
 		return time.Time{}, false
 	}
 
-	if !auth.NextRefreshAfter.IsZero() && now.Before(auth.NextRefreshAfter) {
-		return auth.NextRefreshAfter, true
+	if !auth.NextRefreshAfter.IsZero() {
+		if now.Before(auth.NextRefreshAfter) {
+			return auth.NextRefreshAfter, true
+		}
+		return now, true
 	}
 
 	if evaluator, ok := auth.Runtime.(RefreshEvaluator); ok && evaluator != nil {
@@ -397,7 +400,7 @@ func nextRefreshCheckAt(now time.Time, auth *Auth, interval time.Duration) (time
 		return time.Time{}, false
 	}
 	if hasExpiry && !expiry.IsZero() {
-		dueAt := expiry.Add(-*lead)
+		dueAt := expiry.Add(-effectiveRefreshLead(*lead, lastRefresh, expiry))
 		if !dueAt.After(now) {
 			return now, true
 		}

--- a/sdk/cliproxy/auth/auto_refresh_loop_test.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop_test.go
@@ -139,6 +139,54 @@ func TestNextRefreshCheckAt_ProviderLead_Expiry(t *testing.T) {
 	}
 }
 
+func TestNextRefreshCheckAt_ProviderLeadCapsAtHalfObservedLifetime(t *testing.T) {
+	now := time.Date(2026, 6, 25, 0, 0, 0, 0, time.UTC)
+	lead := 5 * 24 * time.Hour
+	setRefreshLeadFactory(t, "short-lived-provider", func() *time.Duration {
+		d := lead
+		return &d
+	})
+
+	tests := []struct {
+		name     string
+		lifetime time.Duration
+		wantDue  time.Time
+	}{
+		{
+			name:     "three day token uses half lifetime",
+			lifetime: 72 * time.Hour,
+			wantDue:  now.Add(36 * time.Hour),
+		},
+		{
+			name:     "ten day token keeps provider lead",
+			lifetime: 10 * 24 * time.Hour,
+			wantDue:  now.Add(5 * 24 * time.Hour),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auth := &Auth{
+				ID:              "short-lived-auth",
+				Provider:        "short-lived-provider",
+				LastRefreshedAt: now,
+				Metadata: map[string]any{
+					"email":      "x@example.com",
+					"expires_at": now.Add(tt.lifetime).Format(time.RFC3339),
+				},
+			}
+
+			got, ok := nextRefreshCheckAt(now, auth, time.Minute)
+			if !ok {
+				t.Fatal("nextRefreshCheckAt() ok = false, want true")
+			}
+			if !got.Equal(tt.wantDue) {
+				t.Fatalf("nextRefreshCheckAt() = %s, want %s", got, tt.wantDue)
+			}
+		})
+	}
+}
+
 func TestNextRefreshCheckAt_RefreshEvaluatorFallback(t *testing.T) {
 	now := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
 	interval := 15 * time.Minute

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -118,8 +118,8 @@ func (m *Manager) shouldRefresh(a *Auth, now time.Time) bool {
 	if hasUnauthorizedAuthFailure(a) {
 		return false
 	}
-	if !a.NextRefreshAfter.IsZero() && now.Before(a.NextRefreshAfter) {
-		return false
+	if !a.NextRefreshAfter.IsZero() {
+		return !now.Before(a.NextRefreshAfter)
 	}
 	if evaluator, ok := a.Runtime.(RefreshEvaluator); ok && evaluator != nil {
 		return evaluator.ShouldRefresh(now, a)
@@ -161,7 +161,7 @@ func (m *Manager) shouldRefresh(a *Auth, now time.Time) bool {
 		return false
 	}
 	if hasExpiry && !expiry.IsZero() {
-		return time.Until(expiry) <= *lead
+		return expiry.Sub(now) <= effectiveRefreshLead(*lead, lastRefresh, expiry)
 	}
 	if !lastRefresh.IsZero() {
 		return now.Sub(lastRefresh) >= *lead
@@ -441,6 +441,7 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		}
 	}
 
+	previousExpiry, hadPreviousExpiry := auth.ExpirationTime()
 	cloned := auth.Clone()
 	updated, err := exec.Refresh(ctx, cloned)
 	if err != nil && errors.Is(err, context.Canceled) {
@@ -493,7 +494,13 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 	}
 	updated.UpdatedAt = now
 	modelsToResume := clearUnauthorizedModelStates(updated, now)
-	if m.shouldRefresh(updated, now) {
+	expiryDidNotAdvance := false
+	if hadPreviousExpiry {
+		if refreshedExpiry, okExpiry := updated.ExpirationTime(); okExpiry {
+			expiryDidNotAdvance = !refreshedExpiry.After(previousExpiry)
+		}
+	}
+	if expiryDidNotAdvance || m.shouldRefresh(updated, now) {
 		updated.NextRefreshAfter = now.Add(refreshIneffectiveBackoff)
 	}
 	saved, errUpdate := m.Update(ctx, updated)

--- a/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
@@ -45,6 +45,117 @@ func (e unauthorizedRefreshTestExecutor) Refresh(ctx context.Context, auth *Auth
 	return nil, errors.New("token refresh failed with status 401: invalid_grant")
 }
 
+type shortLivedRefreshTestExecutor struct {
+	schedulerProviderTestExecutor
+	lifetime time.Duration
+}
+
+func (e shortLivedRefreshTestExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	now := time.Now().UTC()
+	auth.Metadata["last_refresh"] = now.Format(time.RFC3339Nano)
+	auth.Metadata["expired"] = now.Add(e.lifetime).Format(time.RFC3339Nano)
+	return auth, nil
+}
+
+func TestManager_RefreshAuthShortLivedTokenDoesNotEnterIneffectiveBackoff(t *testing.T) {
+	const provider = "short-lived-refresh"
+	lead := 5 * 24 * time.Hour
+	setRefreshLeadFactory(t, provider, func() *time.Duration {
+		d := lead
+		return &d
+	})
+
+	ctx := context.Background()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(shortLivedRefreshTestExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: provider},
+		lifetime:                      72 * time.Hour,
+	})
+
+	auth := &Auth{
+		ID:       "short-lived-refresh-auth",
+		Provider: provider,
+		Metadata: map[string]any{
+			"email":        "x@example.com",
+			"expired":      time.Now().Add(-time.Minute).Format(time.RFC3339Nano),
+			"last_refresh": time.Now().Add(-72 * time.Hour).Format(time.RFC3339Nano),
+		},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	manager.refreshAuth(ctx, auth.ID)
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatalf("expected auth %q after refresh", auth.ID)
+	}
+	if !updated.NextRefreshAfter.IsZero() {
+		t.Fatalf("NextRefreshAfter = %s, want zero after an effective short-lived refresh", updated.NextRefreshAfter)
+	}
+	now := time.Now()
+	if manager.shouldRefresh(updated, now) {
+		t.Fatal("short-lived refreshed token remained immediately refreshable")
+	}
+	next, shouldSchedule := nextRefreshCheckAt(now, updated, time.Minute)
+	if !shouldSchedule {
+		t.Fatal("short-lived refreshed token was removed from the refresh schedule")
+	}
+	if !next.After(now.Add(30*time.Hour)) || !next.Before(now.Add(42*time.Hour)) {
+		t.Fatalf("next refresh = %s, want approximately halfway through the 72h lifetime", next)
+	}
+}
+
+func TestManager_RefreshAuthUnchangedFutureExpiryUsesIneffectiveBackoff(t *testing.T) {
+	const provider = "unchanged-future-expiry"
+	lead := 5 * 24 * time.Hour
+	setRefreshLeadFactory(t, provider, func() *time.Duration {
+		d := lead
+		return &d
+	})
+
+	ctx := context.Background()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(schedulerProviderTestExecutor{provider: provider})
+	now := time.Now().UTC()
+	expiry := now.Add(72 * time.Hour)
+	auth := &Auth{
+		ID:       "unchanged-future-expiry-auth",
+		Provider: provider,
+		Metadata: map[string]any{
+			"email":        "x@example.com",
+			"expired":      expiry.Format(time.RFC3339Nano),
+			"last_refresh": now.Add(-time.Hour).Format(time.RFC3339Nano),
+		},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	manager.refreshAuth(ctx, auth.ID)
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatalf("expected auth %q after refresh", auth.ID)
+	}
+	remaining := time.Until(updated.NextRefreshAfter)
+	if remaining < 20*time.Second || remaining > 40*time.Second {
+		t.Fatalf("NextRefreshAfter = %s, want ineffective-refresh backoff near 30s", updated.NextRefreshAfter)
+	}
+	afterGate := updated.NextRefreshAfter.Add(time.Second)
+	if !manager.shouldRefresh(updated, afterGate) {
+		t.Fatal("unchanged expiry stopped being refreshable after ineffective-refresh gate elapsed")
+	}
+	next, shouldSchedule := nextRefreshCheckAt(afterGate, updated, time.Minute)
+	if !shouldSchedule || next.After(afterGate) {
+		t.Fatalf("nextRefreshCheckAt() = (%s, %v), want immediate retry after elapsed ineffective gate", next, shouldSchedule)
+	}
+}
+
 func TestManager_RefreshAuthUnauthorizedFailureStopsAutoRefreshRetry(t *testing.T) {
 	ctx := context.Background()
 	manager := NewManager(nil, &RoundRobinSelector{}, nil)

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -667,6 +667,20 @@ func ProviderRefreshLead(provider string, runtime any) *time.Duration {
 	return nil
 }
 
+// effectiveRefreshLead caps a provider's static lead at half of the observed
+// credential lifetime. This prevents short-lived credentials from remaining
+// permanently inside a refresh window that is longer than the token lifetime.
+func effectiveRefreshLead(providerLead time.Duration, lastRefresh, expiry time.Time) time.Duration {
+	if providerLead <= 0 || lastRefresh.IsZero() || expiry.IsZero() || !expiry.After(lastRefresh) {
+		return providerLead
+	}
+	halfLifetime := expiry.Sub(lastRefresh) / 2
+	if halfLifetime > 0 && halfLifetime < providerLead {
+		return halfLifetime
+	}
+	return providerLead
+}
+
 func parseTimeValue(v any) (time.Time, bool) {
 	switch value := v.(type) {
 	case string:


### PR DESCRIPTION
## Summary

- cap a provider refresh lead at half of the observed credential lifetime
- use the same effective lead in scheduling and runtime refresh predicates
- retain the existing ineffective-refresh backoff when a refresh does not advance expiry
- make an elapsed `NextRefreshAfter` gate immediately eligible instead of reclassifying the unchanged token

## Problem

Codex declares a five-day refresh lead. A refreshed credential whose lifetime is shorter than five days remains inside that window immediately, so the manager can refresh it every 30 seconds.

```text
remaining lifetime = 72h
provider lead      = 120h
72h <= 120h        => refresh again immediately
```

## Fix

For a genuinely renewed token:

```text
effective lead = min(provider lead, (expiry - last refresh) / 2)
```

- 10-day lifetime: five-day lead, unchanged
- 3-day lifetime: 36-hour lead
- missing/invalid lifetime: existing provider behavior

A refresh that leaves the old expiry unchanged still receives the existing 30-second ineffective-refresh gate. Once that gate elapses, both the predicate and scheduler retry immediately; they do not reinterpret the old remaining lifetime as a newly issued token.

Explicit `refresh_interval` overrides remain unchanged.

## Validation

- scheduler coverage for three-day and ten-day lifetimes
- end-to-end successful 72-hour refresh coverage
- unchanged future expiry coverage before and after the ineffective-refresh gate
- `go test ./sdk/cliproxy/auth -count=1`
- focused race tests
- `go vet ./sdk/cliproxy/auth`
- `go build -o /tmp/pr4570-server ./cmd/server`
- `git diff --check upstream/dev...HEAD`

Closes #3992
