### PR TITLE
fix(kimi): normalize nested deferred tool references

### DIFF
--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -85,6 +85,11 @@ func (e *KimiExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth,
 func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	from := opts.SourceFormat
 	if from.String() == "claude" {
+		normalizedPayload, errNormalize := normalizeKimiClaudeToolResultReferences(req.Payload)
+		if errNormalize != nil {
+			return resp, errNormalize
+		}
+		req.Payload = normalizedPayload
 		auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
 		return e.ClaudeExecutor.Execute(ctx, auth, req, opts)
 	}
@@ -195,6 +200,11 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	from := opts.SourceFormat
 	if from.String() == "claude" {
+		normalizedPayload, errNormalize := normalizeKimiClaudeToolResultReferences(req.Payload)
+		if errNormalize != nil {
+			return nil, errNormalize
+		}
+		req.Payload = normalizedPayload
 		auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
 		return e.ClaudeExecutor.ExecuteStream(ctx, auth, req, opts)
 	}
@@ -336,8 +346,68 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 
 // CountTokens estimates token count for Kimi requests.
 func (e *KimiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if opts.SourceFormat.String() == "claude" {
+		normalizedPayload, errNormalize := normalizeKimiClaudeToolResultReferences(req.Payload)
+		if errNormalize != nil {
+			return cliproxyexecutor.Response{}, errNormalize
+		}
+		req.Payload = normalizedPayload
+	}
 	auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
 	return e.ClaudeExecutor.CountTokens(ctx, auth, req, opts)
+}
+
+func normalizeKimiClaudeToolResultReferences(body []byte) ([]byte, error) {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return body, nil
+	}
+
+	messages := util.GetGJSONBytesNoCopy(body, "messages")
+	if !messages.IsArray() {
+		return body, nil
+	}
+
+	out := body
+	converted := 0
+	for messageIndex, message := range messages.Array() {
+		content := message.Get("content")
+		if !content.IsArray() {
+			continue
+		}
+		for contentIndex, block := range content.Array() {
+			if block.Get("type").String() != "tool_result" {
+				continue
+			}
+			nestedContent := block.Get("content")
+			if !nestedContent.IsArray() {
+				continue
+			}
+			for nestedIndex, nestedBlock := range nestedContent.Array() {
+				if nestedBlock.Get("type").String() != "tool_reference" {
+					continue
+				}
+				toolName := nestedBlock.Get("tool_name").String()
+				if strings.TrimSpace(toolName) == "" {
+					continue
+				}
+				replacement, errText := sjson.SetBytes([]byte(`{"type":"text"}`), "text", toolName)
+				if errText != nil {
+					return body, fmt.Errorf("kimi executor: failed to encode tool reference text: %w", errText)
+				}
+				path := fmt.Sprintf("messages.%d.content.%d.content.%d", messageIndex, contentIndex, nestedIndex)
+				updated, errSet := sjson.SetRawBytes(out, path, replacement)
+				if errSet != nil {
+					return body, fmt.Errorf("kimi executor: failed to normalize nested tool reference: %w", errSet)
+				}
+				out = updated
+				converted++
+			}
+		}
+	}
+	if converted > 0 {
+		log.WithField("converted_tool_references", converted).Debug("kimi executor: normalized unsupported nested tool references")
+	}
+	return out, nil
 }
 
 func normalizeKimiToolMessageLinks(body []byte) ([]byte, error) {

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -14,6 +14,7 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 func TestNewKimiExecutorInitializesDelegatedClaudeConfig(t *testing.T) {
@@ -71,6 +72,171 @@ func TestKimiExecutorClaudeRequestPreservesInternalModelSemantics(t *testing.T) 
 	if got := gjson.GetBytes(response.Payload, "model").String(); got != model {
 		t.Fatalf("response model = %q, want %q", got, model)
 	}
+}
+
+func TestKimiExecutorClaudeRequestConvertsNestedToolReference(t *testing.T) {
+	var upstreamBody []byte
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var errRead error
+		upstreamBody, errRead = io.ReadAll(req.Body)
+		if errRead != nil {
+			return nil, errRead
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"id":"msg_test","type":"message","role":"assistant","model":"k3","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`,
+			)),
+		}, nil
+	}))
+
+	executor := NewKimiExecutor(&config.Config{DisableClaudeCloakMode: true})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"access_token": "test-token"},
+	}
+	payload := kimiClaudeNestedToolReferencePayload(false)
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "kimi-k3",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FormatClaude,
+		OriginalRequest: payload,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	assertKimiNestedToolReferenceNormalized(t, upstreamBody)
+}
+
+func TestKimiExecutorClaudeStreamConvertsNestedToolReference(t *testing.T) {
+	var upstreamBody []byte
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var errRead error
+		upstreamBody, errRead = io.ReadAll(req.Body)
+		if errRead != nil {
+			return nil, errRead
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body: io.NopCloser(strings.NewReader(
+				"event: message_start\n" +
+					`data: {"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","model":"k3","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}` + "\n\n" +
+					"event: message_stop\n" +
+					`data: {"type":"message_stop"}` + "\n\n",
+			)),
+		}, nil
+	}))
+
+	executor := NewKimiExecutor(&config.Config{DisableClaudeCloakMode: true})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"access_token": "test-token"},
+	}
+	payload := kimiClaudeNestedToolReferencePayload(true)
+	result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "kimi-k3",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		Stream:          true,
+		SourceFormat:    sdktranslator.FormatClaude,
+		OriginalRequest: payload,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+	}
+	assertKimiNestedToolReferenceNormalized(t, upstreamBody)
+}
+
+func kimiClaudeNestedToolReferencePayload(stream bool) []byte {
+	payload := []byte(`{
+		"model":"kimi-k3",
+		"max_tokens":256,
+		"messages":[
+			{"role":"user","content":"find tool"},
+			{"role":"assistant","content":[{"type":"tool_use","id":"tu_1","name":"ToolSearch","input":{"query":"x"}}]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"tu_1","content":[
+					{"type":"text","text":"before"},
+					{"type":"tool_reference","tool_name":"SendMessage"},
+					{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aW1n"}}
+				]},
+				{"type":"tool_reference","tool_name":"KeepTopLevel"},
+				{"type":"text","text":"ok now say hi"}
+			]}
+		]
+	}`)
+	if !stream {
+		return payload
+	}
+	out, errSet := sjson.SetBytes(payload, "stream", true)
+	if errSet != nil {
+		panic(errSet)
+	}
+	return out
+}
+
+func assertKimiNestedToolReferenceNormalized(t *testing.T, body []byte) {
+	t.Helper()
+	if got := gjson.GetBytes(body, "messages.2.content.0.content.0.text").String(); got != "before" {
+		t.Fatalf("existing nested text = %q, want before: %s", got, body)
+	}
+	if got := gjson.GetBytes(body, "messages.2.content.0.content.1.type").String(); got != "text" {
+		t.Fatalf("nested reference type = %q, want text: %s", got, body)
+	}
+	if got := gjson.GetBytes(body, "messages.2.content.0.content.1.text").String(); got != "SendMessage" {
+		t.Fatalf("nested reference text = %q, want SendMessage: %s", got, body)
+	}
+	if got := gjson.GetBytes(body, "messages.2.content.0.content.2.type").String(); got != "image" {
+		t.Fatalf("unrelated nested block type = %q, want image: %s", got, body)
+	}
+	if got := gjson.GetBytes(body, "messages.2.content.1.type").String(); got != "tool_reference" {
+		t.Fatalf("top-level reference type = %q, want preserved tool_reference: %s", got, body)
+	}
+	if got := gjson.GetBytes(body, "messages.2.content.1.tool_name").String(); got != "KeepTopLevel" {
+		t.Fatalf("top-level reference tool_name = %q, want KeepTopLevel: %s", got, body)
+	}
+}
+
+func TestKimiExecutorCountTokensConvertsNestedToolReference(t *testing.T) {
+	var upstreamBody []byte
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var errRead error
+		upstreamBody, errRead = io.ReadAll(req.Body)
+		if errRead != nil {
+			return nil, errRead
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"input_tokens":42}`)),
+		}, nil
+	}))
+
+	executor := NewKimiExecutor(&config.Config{DisableClaudeCloakMode: true})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"access_token": "test-token"},
+	}
+	payload := kimiClaudeNestedToolReferencePayload(false)
+	_, err := executor.CountTokens(ctx, auth, cliproxyexecutor.Request{
+		Model:   "kimi-k3",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FormatClaude,
+		OriginalRequest: payload,
+	})
+	if err != nil {
+		t.Fatalf("CountTokens() error = %v", err)
+	}
+	assertKimiNestedToolReferenceNormalized(t, upstreamBody)
 }
 
 func TestKimiExecutorCountTokensUsesCanonicalUpstreamModel(t *testing.T) {


### PR DESCRIPTION
Fixes #4405.

## Problem

Kimi's Anthropic-compatible `/v1/messages` endpoint rejects deferred-tool `tool_reference` blocks when they appear inside `tool_result.content[]`. Claude-format requests bypass Kimi's OpenAI tool-message normalizer and are delegated unchanged to the shared Claude executor, so the unsupported nested block reaches Kimi and returns HTTP 400.

## Change

Before delegating Claude-format Kimi requests:

- convert only nested `tool_result.content[].tool_reference` blocks to ordinary text blocks containing the referenced tool name;
- apply the normalization to both streaming and non-streaming execution;
- preserve existing nested text/image blocks, top-level `tool_reference` blocks, and every unrelated request field;
- leave the original payload allocation untouched when no supported conversion is required.

The compatibility rule remains Kimi-specific. Shared Claude translation behavior is unchanged for providers that support deferred-tool references.

## Verification

- red/green integration coverage for non-streaming `/v1/messages` delegation;
- red/green integration coverage for streaming delegation;
- mixed nested text/reference/image content and top-level-reference preservation;
- `go test ./internal/runtime/executor -count=1`;
- focused `go test -race` on the Kimi Claude delegation paths;
- `go vet ./internal/runtime/executor`;
- `go build -o /tmp/cli-proxy-api-kimi ./cmd/server`;
- `git diff --check`.
