### PR TITLE
fix(claude): drop invalid tool history before upstream

### DIFF
--- a/internal/runtime/executor/antigravity_executor_signature_test.go
+++ b/internal/runtime/executor/antigravity_executor_signature_test.go
@@ -418,6 +418,12 @@ func TestClaudeExecutor_LogsSanitizedClaudeUpstreamSignatures(t *testing.T) {
 					{"type": "text", "text": "hello"},
 					{"type": "tool_use", "id": "call_123", "name": "get_weather", "input": {}, "signature": "` + rawSignature + `"}
 				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{"type": "tool_result", "tool_use_id": "call_123", "content": "sunny"}
+				]
 			}
 		]
 	}`)

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1972,6 +1972,58 @@ func TestClaudeExecutor_ExecuteSanitizesSignaturesBeforeUpstream(t *testing.T) {
 	}
 }
 
+func TestClaudeExecutorExecuteDropsInvalidToolHistoryBeforeUpstream(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-sonnet-4-5","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{
+		"model":"claude-sonnet-4-5",
+		"max_tokens":16,
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"text","text":"old answer"},
+				{"type":"tool_use","id":"toolu_orphan","name":"Read","input":{"path":"old"}}
+			]},
+			{"role":"user","content":[
+				{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aW1n"}},
+				{"type":"tool_result","tool_use_id":"toolu_orphan","content":"late result"},
+				{"type":"text","text":"new question"}
+			]}
+		]
+	}`)
+
+	if _, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-4-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")}); err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	messages := gjson.GetBytes(seenBody, "messages").Array()
+	if len(messages) != 2 {
+		t.Fatalf("messages length = %d, want 2; body=%s", len(messages), seenBody)
+	}
+	assistantParts := messages[0].Get("content").Array()
+	if len(assistantParts) != 1 || assistantParts[0].Get("text").String() != "old answer" {
+		t.Fatalf("assistant content = %s, want old answer only", messages[0].Get("content").Raw)
+	}
+	userParts := messages[1].Get("content").Array()
+	if len(userParts) != 2 || userParts[0].Get("type").String() != "image" || userParts[1].Get("text").String() != "new question" {
+		t.Fatalf("user content = %s, want image then new question", messages[1].Get("content").Raw)
+	}
+}
+
 func TestClaudeExecutor_Execute_InvalidGzipErrorBodyReturnsDecodeMessage(t *testing.T) {
 	testClaudeExecutorInvalidCompressedErrorBody(t, func(executor *ClaudeExecutor, auth *cliproxyauth.Auth, payload []byte) error {
 		_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -14,6 +14,7 @@ type ClaudeMessagesSignatureSanitizeOptions struct {
 	DropEmptyMessages             bool
 	DropToolSignatures            bool
 	DropEmptyThinkingPlaceholders bool
+	DropOrphanToolUse             bool
 }
 
 type SignatureSanitizeReport struct {
@@ -38,9 +39,9 @@ func SanitizeClaudeMessagesSignaturesForModel(payload []byte, targetModel string
 
 // SanitizeClaudeMessagesForClaudeUpstream prepares a Claude /v1/messages body
 // for Claude-compatible upstreams. Valid Claude signatures are normalized to
-// provider-native E-form, valid Claude CAIS signatures are kept,
-// incompatible thinking blocks are dropped, and tool_use blocks keep only their
-// tool-call payload.
+// provider-native E-form, valid Claude CAIS signatures are kept, incompatible
+// thinking blocks are dropped, tool_use blocks keep only their tool-call
+// payload, and invalid tool-call history is removed before reaching Anthropic.
 func SanitizeClaudeMessagesForClaudeUpstream(payload []byte, targetModel string) ([]byte, SignatureSanitizeReport) {
 	return SanitizeClaudeMessagesSignaturesForTarget(payload, ClaudeMessagesSignatureSanitizeOptions{
 		TargetProvider:                SignatureProviderClaude,
@@ -48,6 +49,7 @@ func SanitizeClaudeMessagesForClaudeUpstream(payload []byte, targetModel string)
 		DropEmptyMessages:             true,
 		DropToolSignatures:            true,
 		DropEmptyThinkingPlaceholders: true,
+		DropOrphanToolUse:             true,
 	})
 }
 
@@ -168,11 +170,165 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 		keptMessages = append(keptMessages, message.Raw)
 	}
 
-	if !modified {
-		return payload, report
+	output := payload
+	if modified {
+		output, _ = sjson.SetRawBytes(payload, "messages", []byte("["+strings.Join(keptMessages, ",")+"]"))
 	}
-	output, _ := sjson.SetRawBytes(payload, "messages", []byte("["+strings.Join(keptMessages, ",")+"]"))
+	if opts.DropOrphanToolUse {
+		var droppedToolBlocks int
+		output, droppedToolBlocks = sanitizeClaudeToolHistory(output, opts.DropEmptyMessages)
+		report.DroppedBlocks += droppedToolBlocks
+	}
 	return output, report
+}
+
+func sanitizeClaudeToolHistory(payload []byte, dropEmptyMessages bool) ([]byte, int) {
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.IsArray() {
+		return payload, 0
+	}
+
+	messageResults := messages.Array()
+	dropParts := make([][]bool, len(messageResults))
+	for messageIndex, message := range messageResults {
+		content := message.Get("content")
+		if !content.IsArray() {
+			continue
+		}
+		parts := content.Array()
+		dropParts[messageIndex] = make([]bool, len(parts))
+		for partIndex, part := range parts {
+			switch part.Get("type").String() {
+			case "tool_use", "tool_result":
+				dropParts[messageIndex][partIndex] = true
+			}
+		}
+	}
+
+	type toolBlockRef struct {
+		messageIndex int
+		partIndex    int
+	}
+	for turnStart := 0; turnStart < len(messageResults); {
+		role := messageResults[turnStart].Get("role").String()
+		turnEnd := turnStart + 1
+		for turnEnd < len(messageResults) && messageResults[turnEnd].Get("role").String() == role {
+			turnEnd++
+		}
+		if role != "assistant" || turnEnd >= len(messageResults) || messageResults[turnEnd].Get("role").String() != "user" {
+			turnStart = turnEnd
+			continue
+		}
+
+		userEnd := turnEnd + 1
+		for userEnd < len(messageResults) && messageResults[userEnd].Get("role").String() == "user" {
+			userEnd++
+		}
+		pendingByID := make(map[string][]toolBlockRef)
+		duplicateIDs := make(map[string]struct{})
+		for messageIndex := turnStart; messageIndex < turnEnd; messageIndex++ {
+			content := messageResults[messageIndex].Get("content")
+			if !content.IsArray() {
+				continue
+			}
+			for partIndex, part := range content.Array() {
+				if part.Get("type").String() != "tool_use" {
+					continue
+				}
+				idResult := part.Get("id")
+				if idResult.Type != gjson.String {
+					continue
+				}
+				id := idResult.String()
+				if strings.TrimSpace(id) != "" {
+					if len(pendingByID[id]) > 0 {
+						duplicateIDs[id] = struct{}{}
+					}
+					pendingByID[id] = append(pendingByID[id], toolBlockRef{messageIndex: messageIndex, partIndex: partIndex})
+				}
+			}
+		}
+
+		leadingResults := true
+		for messageIndex := turnEnd; messageIndex < userEnd; messageIndex++ {
+			content := messageResults[messageIndex].Get("content")
+			if !content.IsArray() {
+				leadingResults = false
+				continue
+			}
+			for partIndex, part := range content.Array() {
+				if !leadingResults {
+					continue
+				}
+				if part.Get("type").String() != "tool_result" {
+					leadingResults = false
+					continue
+				}
+				idResult := part.Get("tool_use_id")
+				if idResult.Type != gjson.String {
+					continue
+				}
+				id := idResult.String()
+				if _, duplicate := duplicateIDs[id]; duplicate {
+					continue
+				}
+				pending := pendingByID[id]
+				if strings.TrimSpace(id) == "" || len(pending) == 0 {
+					continue
+				}
+				toolUse := pending[0]
+				pendingByID[id] = pending[1:]
+				dropParts[toolUse.messageIndex][toolUse.partIndex] = false
+				dropParts[messageIndex][partIndex] = false
+			}
+		}
+		turnStart = userEnd
+	}
+
+	droppedBlocks := 0
+	for _, messageDrops := range dropParts {
+		for _, drop := range messageDrops {
+			if drop {
+				droppedBlocks++
+			}
+		}
+	}
+	if droppedBlocks == 0 {
+		return payload, 0
+	}
+
+	keptMessages := make([]string, 0, len(messageResults))
+	for messageIndex, message := range messageResults {
+		content := message.Get("content")
+		messageDrops := dropParts[messageIndex]
+		if !content.IsArray() || len(messageDrops) == 0 {
+			keptMessages = append(keptMessages, message.Raw)
+			continue
+		}
+
+		parts := content.Array()
+		keptParts := make([]string, 0, len(parts))
+		messageChanged := false
+		for partIndex, part := range parts {
+			if messageDrops[partIndex] {
+				messageChanged = true
+				continue
+			}
+			keptParts = append(keptParts, part.Raw)
+		}
+		if !messageChanged {
+			keptMessages = append(keptMessages, message.Raw)
+			continue
+		}
+		if len(keptParts) == 0 && dropEmptyMessages {
+			continue
+		}
+		updated, _ := sjson.SetRaw(message.Raw, "content", "["+strings.Join(keptParts, ",")+"]")
+		keptMessages = append(keptMessages, updated)
+	}
+
+	output, _ := sjson.SetRawBytes(payload, "messages", []byte("["+strings.Join(keptMessages, ",")+"]"))
+	return output, droppedBlocks
 }
 
 func stripClaudeToolUseSignatureFields(part gjson.Result) (string, bool) {

--- a/internal/signature/claude_test.go
+++ b/internal/signature/claude_test.go
@@ -389,9 +389,9 @@ func TestSanitizeClaudeMessagesForClaudeUpstream_ClaudeCAIS(t *testing.T) {
 		t.Fatalf("signature = %q, want preserved %q", got, observedFable5Sample)
 	}
 
-	inputTool := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"keep","signature":"` + observedFable5Sample + `"},{"type":"text","text":"answer"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"pwd"},"signature":"` + observedFable5Sample + `"}]}]}`)
+	inputTool := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"keep","signature":"` + observedFable5Sample + `"},{"type":"text","text":"answer"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"pwd"},"signature":"` + observedFable5Sample + `"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}]}`)
 	outputTool, reportTool := SanitizeClaudeMessagesForClaudeUpstream(inputTool, "claude-fable-5")
-	if reportTool.Preserved != 1 {
+	if reportTool.Preserved != 1 || reportTool.DroppedBlocks != 0 {
 		t.Fatalf("unexpected report for tool input: %+v", reportTool)
 	}
 	partsTool := gjson.GetBytes(outputTool, "messages.0.content").Array()

--- a/internal/signature/provider_compatibility_test.go
+++ b/internal/signature/provider_compatibility_test.go
@@ -416,7 +416,7 @@ func TestSanitizeClaudeMessagesSignaturesForModel_DropsEmptyAssistantMessage(t *
 }
 
 func TestSanitizeClaudeMessagesForClaudeUpstream_DropsInvalidThinkingAndCleansToolUse(t *testing.T) {
-	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"drop me","signature":""},{"type":"text","text":"answer"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"git status"},"signature":"bad","thoughtSignature":"bad2","thought_signature":"bad3","model":"claude-sonnet-4-5","extra_content":{"google":{"thought_signature":"bad4"}}}]}]}`)
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"drop me","signature":""},{"type":"text","text":"answer"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"git status"},"signature":"bad","thoughtSignature":"bad2","thought_signature":"bad3","model":"claude-sonnet-4-5","extra_content":{"google":{"thought_signature":"bad4"}}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}]}`)
 
 	output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4-5")
 	if report.DroppedBlocks != 1 {
@@ -446,6 +446,273 @@ func TestSanitizeClaudeMessagesForClaudeUpstream_DropsInvalidThinkingAndCleansTo
 		if toolUse.Get(path).Exists() {
 			t.Fatalf("tool_use.%s should be removed: %s", path, toolUse.Raw)
 		}
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamPreservesValidParallelToolHistory(t *testing.T) {
+	input := []byte(`{"messages":[
+		{"role":"assistant","content":[
+			{"type":"text","text":"running tools"},
+			{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"a"}},
+			{"type":"tool_use","id":"toolu_2","name":"Read","input":{"path":"b"}}
+		]},
+		{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"toolu_2","content":"b"},
+			{"type":"tool_result","tool_use_id":"toolu_1","content":"a"},
+			{"type":"text","text":"continue"}
+		]}
+	]}`)
+
+	output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4-5")
+	if report.DroppedBlocks != 0 {
+		t.Fatalf("DroppedBlocks = %d, want 0; report=%+v", report.DroppedBlocks, report)
+	}
+	if string(output) != string(input) {
+		t.Fatalf("valid tool history changed:\n got: %s\nwant: %s", output, input)
+	}
+	if &output[0] != &input[0] {
+		t.Fatal("valid tool history was copied")
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamPairsAcrossConsecutiveSameRoleMessages(t *testing.T) {
+	input := []byte(`{"messages":[
+		{"role":"assistant","content":[
+			{"type":"text","text":"running tools"},
+			{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"a"}}
+		]},
+		{"role":"assistant","content":[
+			{"type":"tool_use","id":"toolu_2","name":"Read","input":{"path":"b"}}
+		]},
+		{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"toolu_1","content":"a"}
+		]},
+		{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"toolu_2","content":"b"},
+			{"type":"text","text":"continue"}
+		]}
+	]}`)
+
+	output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4-5")
+	if report.DroppedBlocks != 0 {
+		t.Fatalf("DroppedBlocks = %d, want 0; report=%+v", report.DroppedBlocks, report)
+	}
+	if string(output) != string(input) {
+		t.Fatalf("valid split logical turn changed:\n got: %s\nwant: %s", output, input)
+	}
+	if &output[0] != &input[0] {
+		t.Fatal("valid split logical turn was copied")
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamStopsSplitResultsAfterText(t *testing.T) {
+	input := []byte(`{"messages":[
+		{"role":"assistant","content":[
+			{"type":"text","text":"running"},
+			{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"a"}},
+			{"type":"tool_use","id":"toolu_2","name":"Read","input":{"path":"b"}}
+		]},
+		{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"toolu_1","content":"a"},
+			{"type":"text","text":"tool two was cancelled"}
+		]},
+		{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"toolu_2","content":"late"}
+		]}
+	]}`)
+
+	output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4-5")
+	if report.DroppedBlocks != 2 {
+		t.Fatalf("DroppedBlocks = %d, want 2; report=%+v", report.DroppedBlocks, report)
+	}
+	messages := gjson.GetBytes(output, "messages").Array()
+	if len(messages) != 2 {
+		t.Fatalf("messages length = %d, want 2 after empty trailing user message removal: %s", len(messages), output)
+	}
+	assistantParts := messages[0].Get("content").Array()
+	if len(assistantParts) != 2 || assistantParts[1].Get("id").String() != "toolu_1" {
+		t.Fatalf("assistant content = %s, want text plus toolu_1", messages[0].Get("content").Raw)
+	}
+	userParts := messages[1].Get("content").Array()
+	if len(userParts) != 2 || userParts[0].Get("tool_use_id").String() != "toolu_1" || userParts[1].Get("text").String() != "tool two was cancelled" {
+		t.Fatalf("user content = %s, want toolu_1 result then text", messages[1].Get("content").Raw)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamRequiresExactToolUseIDs(t *testing.T) {
+	input := []byte(`{"messages":[
+		{"role":"assistant","content":[
+			{"type":"text","text":"running"},
+			{"type":"tool_use","id":" toolu_1 ","name":"Read","input":{"path":"a"}}
+		]},
+		{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"toolu_1","content":"a"},
+			{"type":"text","text":"continue"}
+		]}
+	]}`)
+
+	output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4-5")
+	if report.DroppedBlocks != 2 {
+		t.Fatalf("DroppedBlocks = %d, want 2 for non-identical raw IDs; report=%+v", report.DroppedBlocks, report)
+	}
+	messages := gjson.GetBytes(output, "messages").Array()
+	if len(messages) != 2 {
+		t.Fatalf("messages length = %d, want 2: %s", len(messages), output)
+	}
+	if got := messages[0].Get("content.#").Int(); got != 1 || messages[0].Get("content.0.text").String() != "running" {
+		t.Fatalf("assistant content = %s, want only running text", messages[0].Get("content").Raw)
+	}
+	if got := messages[1].Get("content.#").Int(); got != 1 || messages[1].Get("content.0.text").String() != "continue" {
+		t.Fatalf("user content = %s, want only continue text", messages[1].Get("content").Raw)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamRejectsNonStringToolUseIDs(t *testing.T) {
+	input := []byte(`{"messages":[
+		{"role":"assistant","content":[
+			{"type":"text","text":"running"},
+			{"type":"tool_use","id":1,"name":"Read","input":{"path":"a"}}
+		]},
+		{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"1","content":"a"},
+			{"type":"text","text":"continue"}
+		]}
+	]}`)
+
+	output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4-5")
+	if report.DroppedBlocks != 2 {
+		t.Fatalf("DroppedBlocks = %d, want 2 for non-string tool_use.id; report=%+v", report.DroppedBlocks, report)
+	}
+	messages := gjson.GetBytes(output, "messages").Array()
+	if len(messages) != 2 || messages[0].Get("content.#").Int() != 1 || messages[1].Get("content.#").Int() != 1 {
+		t.Fatalf("sanitized messages = %s, want only the two text blocks", output)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamRejectsDuplicateToolUseIDs(t *testing.T) {
+	input := []byte(`{"messages":[
+		{"role":"assistant","content":[
+			{"type":"text","text":"running"},
+			{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"a"}},
+			{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"b"}}
+		]},
+		{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"toolu_1","content":"a"},
+			{"type":"tool_result","tool_use_id":"toolu_1","content":"b"},
+			{"type":"text","text":"continue"}
+		]}
+	]}`)
+
+	output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4-5")
+	if report.DroppedBlocks != 4 {
+		t.Fatalf("DroppedBlocks = %d, want all four ambiguous duplicate-ID blocks dropped; report=%+v", report.DroppedBlocks, report)
+	}
+	messages := gjson.GetBytes(output, "messages").Array()
+	if len(messages) != 2 || messages[0].Get("content.#").Int() != 1 || messages[1].Get("content.#").Int() != 1 {
+		t.Fatalf("sanitized messages = %s, want only the two text blocks", output)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamDropsOrphanToolUsesAndResults(t *testing.T) {
+	input := []byte(`{"messages":[
+		{"role":"assistant","content":[
+			{"type":"text","text":"answer"},
+			{"type":"tool_use","id":"toolu_orphan","name":"Read","input":{"path":"a"}}
+		]},
+		{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"toolu_stale","content":"stale"},
+			{"type":"text","text":"new question"}
+		]}
+	]}`)
+
+	output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4-5")
+	if report.DroppedBlocks != 2 {
+		t.Fatalf("DroppedBlocks = %d, want 2; report=%+v", report.DroppedBlocks, report)
+	}
+	if got := gjson.GetBytes(output, "messages.0.content.#").Int(); got != 1 {
+		t.Fatalf("assistant content length = %d, want 1: %s", got, output)
+	}
+	if got := gjson.GetBytes(output, "messages.0.content.0.text").String(); got != "answer" {
+		t.Fatalf("assistant text = %q, want answer: %s", got, output)
+	}
+	if got := gjson.GetBytes(output, "messages.1.content.#").Int(); got != 1 {
+		t.Fatalf("user content length = %d, want 1: %s", got, output)
+	}
+	if got := gjson.GetBytes(output, "messages.1.content.0.text").String(); got != "new question" {
+		t.Fatalf("user text = %q, want new question: %s", got, output)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamRequiresLeadingToolResults(t *testing.T) {
+	input := []byte(`{"messages":[
+		{"role":"assistant","content":[
+			{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"a"}}
+		]},
+		{"role":"user","content":[
+			{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aW1n"}},
+			{"type":"tool_result","tool_use_id":"toolu_1","content":"late"},
+			{"type":"text","text":"continue"}
+		]}
+	]}`)
+
+	output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4-5")
+	if report.DroppedBlocks != 2 {
+		t.Fatalf("DroppedBlocks = %d, want 2; report=%+v", report.DroppedBlocks, report)
+	}
+	messages := gjson.GetBytes(output, "messages").Array()
+	if len(messages) != 1 {
+		t.Fatalf("messages length = %d, want 1: %s", len(messages), output)
+	}
+	parts := messages[0].Get("content").Array()
+	if len(parts) != 2 || parts[0].Get("type").String() != "image" || parts[1].Get("text").String() != "continue" {
+		t.Fatalf("remaining user content = %s, want image then text", messages[0].Get("content").Raw)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamDropsOnlyUnmatchedParallelToolUse(t *testing.T) {
+	input := []byte(`{"messages":[
+		{"role":"assistant","content":[
+			{"type":"text","text":"running"},
+			{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"a"}},
+			{"type":"tool_use","id":"toolu_2","name":"Read","input":{"path":"b"}}
+		]},
+		{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"toolu_1","content":"a"},
+			{"type":"text","text":"tool two was cancelled"}
+		]}
+	]}`)
+
+	output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4-5")
+	if report.DroppedBlocks != 1 {
+		t.Fatalf("DroppedBlocks = %d, want 1; report=%+v", report.DroppedBlocks, report)
+	}
+	if got := gjson.GetBytes(output, "messages.0.content.1.id").String(); got != "toolu_1" {
+		t.Fatalf("remaining tool_use id = %q, want toolu_1: %s", got, output)
+	}
+	if gjson.GetBytes(output, "messages.0.content.2").Exists() {
+		t.Fatalf("unmatched parallel tool_use was preserved: %s", output)
+	}
+	if got := gjson.GetBytes(output, "messages.1.content.0.tool_use_id").String(); got != "toolu_1" {
+		t.Fatalf("matching tool_result id = %q, want toolu_1: %s", got, output)
+	}
+}
+
+func TestSanitizeClaudeMessagesSignaturesForTargetPreservesOrphanToolHistoryByDefault(t *testing.T) {
+	input := []byte(`{"messages":[
+		{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{}}]},
+		{"role":"user","content":[{"type":"text","text":"no result"}]}
+	]}`)
+
+	output, report := SanitizeClaudeMessagesSignaturesForTarget(input, ClaudeMessagesSignatureSanitizeOptions{
+		TargetProvider:    SignatureProviderClaude,
+		TargetModel:       "claude-sonnet-4-5",
+		DropEmptyMessages: true,
+	})
+	if report.DroppedBlocks != 0 {
+		t.Fatalf("DroppedBlocks = %d, want 0; report=%+v", report.DroppedBlocks, report)
+	}
+	if string(output) != string(input) {
+		t.Fatalf("generic signature sanitizer changed tool history:\n got: %s\nwant: %s", output, input)
 	}
 }
 


### PR DESCRIPTION
Fixes #4112.

## Problem

Anthropic rejects stale or malformed Claude message history when:

- an assistant `tool_use` has no matching result in the immediately following user message;
- a user `tool_result` references no tool call in the previous assistant message; or
- a `tool_result` appears after text or image content instead of in the leading result block group.

The existing Claude-upstream sanitizer removed incompatible reasoning signatures but forwarded those structurally invalid tool blocks unchanged, producing HTTP 400 before model execution.

## Change

Enable tool-history repair only in `SanitizeClaudeMessagesForClaudeUpstream`:

- pair assistant tool calls with leading results in the immediately following user message;
- preserve valid parallel tool calls and allow their results in any order;
- remove unmatched calls, stale results, blank IDs, wrong-role tool blocks, and results appearing after non-result content;
- remove messages left empty by that repair;
- retain the existing signature sanitizer behavior and preserve an unchanged payload without copying it when history is already valid.

Other provider compatibility paths keep their existing behavior because the new option is disabled by default.

## Verification

- red/green sanitizer regressions for orphan calls/results, late results, partial parallel matches, and valid parallel history;
- outbound `ClaudeExecutor` regression confirming invalid blocks are absent from the Anthropic request body;
- existing Claude signature logging fixture updated to use valid paired tool history;
- `go test ./internal/signature ./internal/runtime/executor -count=1`;
- focused `go test -race` for the sanitizer and Claude executor paths;
- `go vet ./internal/signature ./internal/runtime/executor`;
- required `go build -o test-output ./cmd/server && rm test-output`;
- `git diff --check`.
