### PR TITLE
feat(routing): allow manual credential selection

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -196,6 +196,9 @@ quota-exceeded:
 # Routing strategy for selecting credentials when multiple match.
 routing:
   strategy: "round-robin" # round-robin (default), fill-first
+  # Allow authenticated clients to pin one credential with X-CPA-Auth-Index.
+  # Disabled by default. Requests carrying the header are rejected unless enabled.
+  allow-auth-index-header: false
   # Enable universal session-sticky routing for all clients.
   # Session IDs are extracted from: metadata.user_id (Claude Code session format),
   # X-Session-ID, Session_id (Codex), X-Client-Request-Id (PI), conversation_id,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -76,6 +76,8 @@ var corsExposedResponseHeadersJoined = strings.Join(corsExposedResponseHeaders, 
 const (
 	exampleAPIKeyManagementPath = "/management.html"
 	exampleAPIKeyManagementURL  = "/management.html?safe-mode=configure"
+	authIndexSelectionHeader    = "X-CPA-Auth-Index"
+	authIndexSelectionGinKey    = "cpa_auth_selection_id"
 )
 
 type serverOptionConfig struct {
@@ -243,6 +245,8 @@ type Server struct {
 	wsRoutes      map[string]struct{}
 	wsAuthChanged func(bool, bool)
 	wsAuthEnabled atomic.Bool
+	// authIndexHeaderEnabled gates per-request credential selection.
+	authIndexHeaderEnabled atomic.Bool
 
 	// management handler
 	mgmt *managementHandlers.Handler
@@ -349,6 +353,7 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 		exampleAPIKeySafeModeEnabled: optionState.exampleAPIKeySafeMode,
 	}
 	s.wsAuthEnabled.Store(cfg.WebsocketAuth)
+	s.authIndexHeaderEnabled.Store(cfg.Routing.AllowAuthIndexHeader)
 	s.exampleAPIKeySafeModeActive.Store(s.exampleAPIKeySafeModeRequired(cfg))
 	s.handlers.SetPluginHost(optionState.pluginHost)
 	if optionState.pluginHost != nil {
@@ -529,7 +534,7 @@ func (s *Server) setupRoutes() {
 
 	// OpenAI compatible API routes
 	v1 := s.engine.Group("/v1")
-	v1.Use(AuthMiddleware(s.accessManager))
+	v1.Use(AuthMiddleware(s.accessManager), s.authIndexSelectionMiddleware())
 	{
 		v1.GET("/models", s.unifiedModelsHandler(openaiHandlers, claudeCodeHandlers))
 		v1.POST("/chat/completions", openaiHandlers.ChatCompletions)
@@ -555,7 +560,7 @@ func (s *Server) setupRoutes() {
 	}
 
 	openaiV1 := s.engine.Group("/openai/v1")
-	openaiV1.Use(AuthMiddleware(s.accessManager))
+	openaiV1.Use(AuthMiddleware(s.accessManager), s.authIndexSelectionMiddleware())
 	{
 		openaiV1.POST("/videos", openaiHandlers.VideosCreate)
 		openaiV1.GET("/videos/:video_id/content", openaiHandlers.VideosContent)
@@ -564,7 +569,7 @@ func (s *Server) setupRoutes() {
 
 	// Codex CLI direct route aliases (chatgpt_base_url compatible)
 	codexDirect := s.engine.Group("/backend-api/codex")
-	codexDirect.Use(AuthMiddleware(s.accessManager))
+	codexDirect.Use(AuthMiddleware(s.accessManager), s.authIndexSelectionMiddleware())
 	{
 		codexDirect.GET("/responses", openaiResponsesHandlers.ResponsesWebsocket)
 		codexDirect.POST("/responses", openaiResponsesHandlers.Responses)
@@ -574,7 +579,7 @@ func (s *Server) setupRoutes() {
 
 	// Gemini compatible API routes
 	v1beta := s.engine.Group("/v1beta")
-	v1beta.Use(AuthMiddleware(s.accessManager))
+	v1beta.Use(AuthMiddleware(s.accessManager), s.authIndexSelectionMiddleware())
 	{
 		v1beta.GET("/models", s.geminiModelsHandler(geminiHandlers))
 		v1beta.POST("/interactions", geminiHandlers.Interactions)
@@ -762,6 +767,9 @@ func (s *Server) codexAlphaSearch(c *gin.Context) {
 		return
 	}
 	selectionOpts := coreexecutor.Options{Headers: selectionHeaders, OriginalRequest: body}
+	if authID := selectedAuthIDFromGin(c); authID != "" {
+		selectionOpts.Metadata = map[string]any{coreexecutor.PinnedAuthMetadataKey: authID}
+	}
 	var selection *auth.HomeDispatchSelection
 	var selected *auth.Auth
 	if s.handlers.AuthManager.HomeEnabled() {
@@ -1909,6 +1917,60 @@ func corsMiddleware() gin.HandlerFunc {
 	}
 }
 
+func (s *Server) authIndexSelectionMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authIndex := strings.TrimSpace(c.GetHeader(authIndexSelectionHeader))
+		if authIndex == "" {
+			c.Next()
+			return
+		}
+
+		// This is a proxy control header and must never reach an upstream provider.
+		c.Request.Header.Del(authIndexSelectionHeader)
+
+		if !s.authIndexHeaderEnabled.Load() {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "auth index selection is disabled"})
+			return
+		}
+
+		selected := s.authByIndex(authIndex)
+		if selected == nil {
+			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "auth index not found"})
+			return
+		}
+
+		c.Set(authIndexSelectionGinKey, selected.ID)
+		ctx := handlers.WithPinnedAuthID(c.Request.Context(), selected.ID)
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	}
+}
+
+func (s *Server) authByIndex(authIndex string) *auth.Auth {
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" || s == nil || s.handlers == nil || s.handlers.AuthManager == nil {
+		return nil
+	}
+	for _, candidate := range s.handlers.AuthManager.List() {
+		if candidate != nil && candidate.EnsureIndex() == authIndex {
+			return candidate
+		}
+	}
+	return nil
+}
+
+func selectedAuthIDFromGin(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	value, ok := c.Get(authIndexSelectionGinKey)
+	if !ok {
+		return ""
+	}
+	authID, _ := value.(string)
+	return strings.TrimSpace(authID)
+}
+
 func (s *Server) applyAccessConfig(oldCfg, newCfg *config.Config) bool {
 	if s == nil || s.accessManager == nil || newCfg == nil {
 		return false
@@ -2059,6 +2121,7 @@ func (s *Server) UpdateClientsContext(ctx context.Context, cfg *config.Config) b
 		}
 	}
 	s.wsAuthEnabled.Store(cfg.WebsocketAuth)
+	s.authIndexHeaderEnabled.Store(cfg.Routing.AllowAuthIndexHeader)
 	if oldCfg != nil && s.wsAuthChanged != nil && oldCfg.WebsocketAuth != cfg.WebsocketAuth {
 		s.wsAuthChanged(oldCfg.WebsocketAuth, cfg.WebsocketAuth)
 	}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -39,6 +39,35 @@ type codexSearchCaptureExecutor struct {
 	responseBody io.ReadCloser
 }
 
+type authSelectionCaptureExecutor struct {
+	authIDs []string
+	headers []http.Header
+}
+
+func (e *authSelectionCaptureExecutor) Identifier() string { return "manual-selection-test" }
+
+func (e *authSelectionCaptureExecutor) Execute(_ context.Context, selected *auth.Auth, _ coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+	e.authIDs = append(e.authIDs, selected.ID)
+	e.headers = append(e.headers, opts.Headers.Clone())
+	return coreexecutor.Response{Payload: []byte(`{"ok":true}`)}, nil
+}
+
+func (e *authSelectionCaptureExecutor) ExecuteStream(context.Context, *auth.Auth, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *authSelectionCaptureExecutor) Refresh(_ context.Context, selected *auth.Auth) (*auth.Auth, error) {
+	return selected, nil
+}
+
+func (e *authSelectionCaptureExecutor) CountTokens(context.Context, *auth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *authSelectionCaptureExecutor) HttpRequest(context.Context, *auth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (e *codexSearchCaptureExecutor) Identifier() string { return "codex" }
 
 func (e *codexSearchCaptureExecutor) Execute(context.Context, *auth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
@@ -521,6 +550,120 @@ func TestCodexAlphaSearchForwardsRequest(t *testing.T) {
 	}
 	if _, errParse := time.Parse("20060102150405", parts[0]); errParse != nil {
 		t.Fatalf("trace timestamp = %q: %v", parts[0], errParse)
+	}
+}
+
+func TestAuthIndexHeaderRequiresOptIn(t *testing.T) {
+	server := newTestServer(t)
+	credential := &auth.Auth{
+		ID:       "codex-manual",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Metadata: map[string]any{"access_token": "codex-token"},
+	}
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register Codex auth: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"query":"GPT-5.6"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set(authIndexSelectionHeader, credential.EnsureIndex())
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "auth index selection is disabled") {
+		t.Fatalf("body = %q, want disabled error", rr.Body.String())
+	}
+}
+
+func TestAuthIndexHeaderPinsCredential(t *testing.T) {
+	server := newTestServer(t)
+	server.authIndexHeaderEnabled.Store(true)
+	executor := &authSelectionCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+
+	var selected *auth.Auth
+	for _, credential := range []*auth.Auth{
+		{
+			ID:       "codex-auto-first",
+			Provider: executor.Identifier(),
+			Status:   auth.StatusActive,
+		},
+		{
+			ID:       "codex-manual-target",
+			Provider: executor.Identifier(),
+			Status:   auth.StatusActive,
+		},
+	} {
+		if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+			t.Fatalf("register Codex auth %s: %v", credential.ID, err)
+		}
+		registry.GetGlobalRegistry().RegisterClient(credential.ID, credential.Provider, []*registry.ModelInfo{{ID: "manual-selection-model"}})
+		t.Cleanup(func() {
+			registry.GetGlobalRegistry().UnregisterClient(credential.ID)
+		})
+		if credential.ID == "codex-manual-target" {
+			selected = credential
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"manual-selection-model","input":"hello"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(authIndexSelectionHeader, selected.EnsureIndex())
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if got := executor.authIDs; len(got) != 1 || got[0] != selected.ID {
+		t.Fatalf("selected auth IDs = %v, want [%s]", got, selected.ID)
+	}
+	if got := executor.headers[0].Get(authIndexSelectionHeader); got != "" {
+		t.Fatalf("upstream received proxy control header %q", got)
+	}
+}
+
+func TestAuthIndexHeaderDoesNotFallback(t *testing.T) {
+	server := newTestServer(t)
+	server.authIndexHeaderEnabled.Store(true)
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+
+	unavailable := &auth.Auth{
+		ID:       "codex-unavailable",
+		Provider: "codex",
+		Status:   auth.StatusDisabled,
+		Disabled: true,
+		Metadata: map[string]any{"access_token": "token-disabled"},
+	}
+	available := &auth.Auth{
+		ID:       "codex-available",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Metadata: map[string]any{"access_token": "token-active"},
+	}
+	for _, credential := range []*auth.Auth{unavailable, available} {
+		if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+			t.Fatalf("register Codex auth %s: %v", credential.ID, err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"query":"GPT-5.6"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set(authIndexSelectionHeader, unavailable.EnsureIndex())
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusServiceUnavailable, rr.Body.String())
+	}
+	if len(executor.authIDs) != 0 {
+		t.Fatalf("selected auth IDs = %v, want none", executor.authIDs)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -370,6 +370,10 @@ type RoutingConfig struct {
 	// Supported values: "round-robin" (default), "fill-first".
 	Strategy string `yaml:"strategy,omitempty" json:"strategy,omitempty"`
 
+	// AllowAuthIndexHeader lets authenticated clients pin one credential by sending
+	// X-CPA-Auth-Index. When false, requests carrying the header are rejected.
+	AllowAuthIndexHeader bool `yaml:"allow-auth-index-header,omitempty" json:"allow-auth-index-header,omitempty"`
+
 	// SessionAffinity enables universal session-sticky routing for all clients.
 	// Session IDs are extracted from multiple sources:
 	// metadata.user_id (Claude Code session format), X-Session-ID, Session_id (Codex),

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -586,6 +586,9 @@ func (h *BaseAPIHandler) GetContextWithCancel(handler interfaces.APIHandler, c *
 			parentCtx = logging.WithRequestID(parentCtx, requestID)
 		}
 	}
+	if pinnedAuthID := pinnedAuthIDFromContext(requestCtx); pinnedAuthID != "" {
+		parentCtx = WithPinnedAuthID(parentCtx, pinnedAuthID)
+	}
 	newCtx, cancel := context.WithCancel(parentCtx)
 
 	endpoint := ""


### PR DESCRIPTION
## Summary

- add opt-in `routing.allow-auth-index-header`
- let authenticated clients pin one credential with `X-CPA-Auth-Index`
- preserve existing round-robin behavior when the header is omitted
- reject disabled or unknown selections and never silently fall back from an unavailable pinned credential
- strip the proxy control header before forwarding upstream

## Why

Embedders need per-session manual account selection without disabling automatic routing for other requests. This keeps auth lifecycle and provider adaptation inside CLIProxyAPI while exposing one small selection control to callers.

## Validation

- `go test ./...`
- `go build -o test-output ./cmd/server`