### PR TITLE
fix(streaming): retry Responses before semantic output

### DIFF
--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -654,18 +654,37 @@ func streamBootstrapPayloadCommitsResponse(responseProtocol string, payload []by
 		return false
 	}
 	if json.Valid(trimmed) {
-		return true
+		return openAIResponsesPayloadCommitsResponse(trimmed)
 	}
 	for _, line := range bytes.Split(payload, []byte("\n")) {
 		line = bytes.TrimSpace(line)
 		if !bytes.HasPrefix(line, []byte("data:")) {
 			continue
 		}
-		if len(bytes.TrimSpace(line[5:])) > 0 {
+		data := bytes.TrimSpace(line[5:])
+		if len(data) == 0 {
+			continue
+		}
+		if bytes.Equal(data, []byte("[DONE]")) || openAIResponsesPayloadCommitsResponse(data) {
 			return true
 		}
 	}
 	return false
+}
+
+func openAIResponsesPayloadCommitsResponse(payload []byte) bool {
+	var event struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return true
+	}
+	switch event.Type {
+	case "response.queued", "response.created", "response.in_progress":
+		return false
+	default:
+		return true
+	}
 }
 
 func validateSSEDataJSON(chunk []byte) error {

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -13,6 +13,11 @@ import (
 	"golang.org/x/net/context"
 )
 
+const (
+	maxResponsesBootstrapPrefixChunks = 32
+	maxResponsesBootstrapPrefixBytes  = 64 << 10
+)
+
 // ExecuteStreamWithAuthManager executes a streaming request via the core auth manager.
 // This path is the only supported execution route.
 // The returned http.Header carries upstream response headers captured before streaming begins.
@@ -387,7 +392,8 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		return payload, true, nil
 	}
 
-	var bootstrapPayload []byte
+	var bootstrapPayloads [][]byte
+	bootstrapPayloadBytes := 0
 	bootstrapChunkIndex := 0
 	var bootstrapHistoryChunks [][]byte
 	var bootstrapStreamErr error
@@ -426,8 +432,15 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 			if !deliverable {
 				continue
 			}
-			bootstrapPayload = payload
-			return
+			bootstrapPayloads = append(bootstrapPayloads, payload)
+			bootstrapPayloadBytes += len(payload)
+			if streamInterceptorsActive {
+				bootstrapHistoryChunks = appendStreamInterceptorHistory(bootstrapHistoryChunks, payload)
+			}
+			if streamBootstrapPayloadCommitsResponse(responseProtocol, payload) ||
+				streamBootstrapPrefixBufferFull(responseProtocol, len(bootstrapPayloads), bootstrapPayloadBytes) {
+				return
+			}
 		}
 	}
 
@@ -478,7 +491,8 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		streamHeaderInitialized = false
 		streamClosedBeforeRead = false
 		bootstrapStreamErr = nil
-		bootstrapPayload = nil
+		bootstrapPayloads = nil
+		bootstrapPayloadBytes = 0
 		bootstrapChunkIndex = 0
 		bootstrapHistoryChunks = nil
 		chunks = retryResult.Chunks
@@ -557,7 +571,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 
 		chunkIndex := bootstrapChunkIndex
 		historyChunks := bootstrapHistoryChunks
-		if bootstrapPayload != nil {
+		for _, bootstrapPayload := range bootstrapPayloads {
 			if okSendData := sendData(bootstrapPayload); !okSendData {
 				completionOutcome = pluginapi.RequestCompletionCanceled
 				completionStatus = 0
@@ -565,9 +579,6 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 					completionErr = ctx.Err()
 				}
 				return
-			}
-			if streamInterceptorsActive {
-				historyChunks = appendStreamInterceptorHistory(historyChunks, bootstrapPayload)
 			}
 		}
 		for {
@@ -627,6 +638,34 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		}
 	}()
 	return dataChan, upstreamHeaders, errChan
+}
+
+func streamBootstrapPrefixBufferFull(responseProtocol string, chunks, bytes int) bool {
+	return responseProtocol == "openai-response" &&
+		(chunks >= maxResponsesBootstrapPrefixChunks || bytes >= maxResponsesBootstrapPrefixBytes)
+}
+
+func streamBootstrapPayloadCommitsResponse(responseProtocol string, payload []byte) bool {
+	if responseProtocol != "openai-response" {
+		return true
+	}
+	trimmed := bytes.TrimSpace(payload)
+	if len(trimmed) == 0 {
+		return false
+	}
+	if json.Valid(trimmed) {
+		return true
+	}
+	for _, line := range bytes.Split(payload, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		if len(bytes.TrimSpace(line[5:])) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func validateSSEDataJSON(chunk []byte) error {

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -18,11 +19,99 @@ const (
 	maxResponsesBootstrapPrefixBytes  = 64 << 10
 )
 
+// StreamBootstrapCommitter freezes a provisional Responses stream at the
+// current upstream attempt before the HTTP response commits its first byte.
+type StreamBootstrapCommitter struct {
+	request     chan struct{}
+	ready       chan struct{}
+	requestOnce sync.Once
+	publishOnce sync.Once
+	mu          sync.Mutex
+	headers     http.Header
+	deferred    bool
+}
+
+func newStreamBootstrapCommitter() *StreamBootstrapCommitter {
+	return &StreamBootstrapCommitter{
+		request: make(chan struct{}),
+		ready:   make(chan struct{}),
+	}
+}
+
+// Commit stops private bootstrap retries and returns the selected attempt's
+// stable downstream headers.
+func (c *StreamBootstrapCommitter) Commit() http.Header {
+	return c.CommitContext(context.Background())
+}
+
+// CommitContext requests a freeze and waits for stable headers until ctx ends.
+func (c *StreamBootstrapCommitter) CommitContext(ctx context.Context) http.Header {
+	if c == nil {
+		return nil
+	}
+	c.requestOnce.Do(func() { close(c.request) })
+	if ctx == nil {
+		return c.Headers()
+	}
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-c.ready:
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return cloneHeader(c.headers)
+	}
+}
+
+// Headers waits for and returns the selected attempt's stable downstream
+// headers without forcing an in-progress bootstrap attempt to commit.
+func (c *StreamBootstrapCommitter) Headers() http.Header {
+	if c == nil {
+		return nil
+	}
+	<-c.ready
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return cloneHeader(c.headers)
+}
+
+func (c *StreamBootstrapCommitter) publish(headers http.Header) {
+	if c == nil {
+		return
+	}
+	c.publishOnce.Do(func() {
+		c.mu.Lock()
+		c.headers = cloneHeader(headers)
+		c.mu.Unlock()
+		close(c.ready)
+	})
+}
+
 // ExecuteStreamWithAuthManager executes a streaming request via the core auth manager.
 // This path is the only supported execution route.
 // The returned http.Header carries upstream response headers captured before streaming begins.
 func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handlerType, modelName string, rawJSON []byte, alt string) (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
 	return h.executeStreamWithAuthManager(ctx, handlerType, modelName, rawJSON, alt, false)
+}
+
+// ExecuteStreamWithAuthManagerBootstrapCommit lets an HTTP Responses endpoint
+// freeze provisional bootstrap when it is ready to commit headers or a heartbeat.
+func (h *BaseAPIHandler) ExecuteStreamWithAuthManagerBootstrapCommit(ctx context.Context, handlerType, modelName string, rawJSON []byte, alt string) (<-chan []byte, <-chan *interfaces.ErrorMessage, *StreamBootstrapCommitter) {
+	committer := newStreamBootstrapCommitter()
+	dataChan, headers, errChan := h.executeStreamWithAuthManagerFormats(
+		ctx,
+		handlerType,
+		handlerType,
+		modelName,
+		rawJSON,
+		alt,
+		false,
+		modelExecutionOptions{StreamBootstrapCommit: committer},
+	)
+	if !committer.deferred {
+		committer.publish(headers)
+	}
+	return dataChan, errChan, committer
 }
 
 // ExecuteImageStreamWithAuthManager executes a streaming OpenAI-compatible image endpoint request.
@@ -315,6 +404,10 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	passthroughHeadersEnabled := PassthroughHeadersEnabled(h.Cfg)
 	interceptorHost := h.interceptorHost()
 	streamInterceptorsActive := streamInterceptorsEnabled(interceptorHost)
+	bootstrapCommitter := execOptions.StreamBootstrapCommit
+	if bootstrapCommitter != nil {
+		bootstrapCommitter.deferred = true
+	}
 	// Resolve immediately available bootstrap retries and header initialization
 	// before returning. A provisional Responses prefix may continue in the stream
 	// goroutine so downstream forwarding and keep-alives can start without waiting
@@ -401,11 +494,8 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	var bootstrapStreamErr error
 	var bootstrapErr *interfaces.ErrorMessage
 	bootstrapPaused := false
-	// A heartbeat may commit HTTP headers before an asynchronous retry finishes.
-	// Keep bootstrap synchronous whenever the selected attempt can change headers.
 	canPauseBootstrap := responseProtocol == "openai-response" &&
-		!passthroughHeadersEnabled &&
-		!streamInterceptorsActive
+		(bootstrapCommitter != nil || (!passthroughHeadersEnabled && !streamInterceptorsActive))
 	readInitialStreamChunks := func(blockAfterPrefix bool) {
 		bootstrapPaused = false
 		for {
@@ -428,6 +518,28 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 					default:
 						bootstrapPaused = true
 						return
+					}
+				}
+			} else if blockAfterPrefix && bootstrapCommitter != nil {
+				select {
+				case <-bootstrapCommitter.request:
+					return
+				default:
+				}
+				if ctx != nil {
+					select {
+					case <-ctx.Done():
+						streamCanceledBeforeRead = true
+						return
+					case <-bootstrapCommitter.request:
+						return
+					case chunk, ok = <-chunks:
+					}
+				} else {
+					select {
+					case <-bootstrapCommitter.request:
+						return
+					case chunk, ok = <-chunks:
 					}
 				}
 			} else if ctx != nil {
@@ -551,6 +663,11 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		}()
 		defer close(dataChan)
 		defer close(errChan)
+		defer func() {
+			if bootstrapCommitter != nil {
+				bootstrapCommitter.publish(downstreamHeadersAfterInterceptors(baseStreamHeaders, rawStreamHeaders, passthroughHeadersEnabled))
+			}
+		}()
 		if streamCanceledBeforeRead {
 			completionOutcome = pluginapi.RequestCompletionCanceled
 			completionStatus = 0
@@ -590,6 +707,10 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 			// Keep the provisional prefix private until semantic output commits the
 			// response or a bootstrap failure selects a clean retry.
 			resolveBootstrap(true)
+		}
+		if bootstrapCommitter != nil {
+			applyStreamHeaderInit()
+			bootstrapCommitter.publish(downstreamHeadersAfterInterceptors(baseStreamHeaders, rawStreamHeaders, passthroughHeadersEnabled))
 		}
 		if bootstrapErr != nil {
 			completionOutcome = pluginapi.RequestCompletionFailed

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -315,8 +315,10 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	passthroughHeadersEnabled := PassthroughHeadersEnabled(h.Cfg)
 	interceptorHost := h.interceptorHost()
 	streamInterceptorsActive := streamInterceptorsEnabled(interceptorHost)
-	// Resolve bootstrap retries and header initialization before returning so the
-	// returned header snapshot is never modified by the stream goroutine.
+	// Resolve immediately available bootstrap retries and header initialization
+	// before returning. A provisional Responses prefix may continue in the stream
+	// goroutine so downstream forwarding and keep-alives can start without waiting
+	// for the next upstream chunk. The returned header snapshot remains immutable.
 	rawStreamHeaders := cloneHeader(streamResult.Headers)
 	baseStreamHeaders := cloneHeader(streamResult.Headers)
 	chunks := streamResult.Chunks
@@ -398,11 +400,32 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	var bootstrapHistoryChunks [][]byte
 	var bootstrapStreamErr error
 	var bootstrapErr *interfaces.ErrorMessage
-	readInitialStreamChunks := func() {
+	bootstrapPaused := false
+	readInitialStreamChunks := func(blockAfterPrefix bool) {
+		bootstrapPaused = false
 		for {
 			var chunk coreexecutor.StreamChunk
 			var ok bool
-			if ctx != nil {
+			if !blockAfterPrefix && responseProtocol == "openai-response" && len(bootstrapPayloads) > 0 {
+				if ctx != nil {
+					select {
+					case <-ctx.Done():
+						streamCanceledBeforeRead = true
+						return
+					case chunk, ok = <-chunks:
+					default:
+						bootstrapPaused = true
+						return
+					}
+				} else {
+					select {
+					case chunk, ok = <-chunks:
+					default:
+						bootstrapPaused = true
+						return
+					}
+				}
+			} else if ctx != nil {
 				select {
 				case <-ctx.Done():
 					streamCanceledBeforeRead = true
@@ -462,46 +485,50 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	if h.AuthManager.HomeEnabled() {
 		maxBootstrapRetries = 0
 	}
-	for bootstrapRetries := 0; !streamCanceledBeforeRead; {
-		readInitialStreamChunks()
-		if streamCanceledBeforeRead || bootstrapErr != nil || bootstrapStreamErr == nil {
-			break
-		}
-		if bootstrapRetries >= maxBootstrapRetries || !bootstrapEligible(bootstrapStreamErr) {
-			bootstrapErr = executionErrorMessage(bootstrapStreamErr)
-			break
-		}
-		bootstrapRetries++
-		retryResult, retryErr := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
-		if retryErr != nil {
-			originalBootstrapErr := executionErrorMessage(bootstrapStreamErr)
-			if isAuthSelectionUnavailable(retryErr) && originalBootstrapErr.StatusCode >= http.StatusInternalServerError {
-				bootstrapErr = originalBootstrapErr
-			} else {
-				bootstrapErr = executionErrorMessage(enrichAuthSelectionError(retryErr, providers, normalizedModel))
+	bootstrapRetries := 0
+	resolveBootstrap := func(blockAfterPrefix bool) {
+		for !streamCanceledBeforeRead {
+			readInitialStreamChunks(blockAfterPrefix)
+			if bootstrapPaused || streamCanceledBeforeRead || bootstrapErr != nil || bootstrapStreamErr == nil {
+				return
 			}
-			break
-		}
-		if retryResult == nil {
-			bootstrapErr = executionErrorMessage(fmt.Errorf("auth manager returned nil stream"))
-			break
-		}
-		rawStreamHeaders = cloneHeader(retryResult.Headers)
-		baseStreamHeaders = cloneHeader(retryResult.Headers)
-		streamHeaderInitialized = false
-		streamClosedBeforeRead = false
-		bootstrapStreamErr = nil
-		bootstrapPayloads = nil
-		bootstrapPayloadBytes = 0
-		bootstrapChunkIndex = 0
-		bootstrapHistoryChunks = nil
-		chunks = retryResult.Chunks
-		if chunks == nil {
-			closed := make(chan coreexecutor.StreamChunk)
-			close(closed)
-			chunks = closed
+			if bootstrapRetries >= maxBootstrapRetries || !bootstrapEligible(bootstrapStreamErr) {
+				bootstrapErr = executionErrorMessage(bootstrapStreamErr)
+				return
+			}
+			bootstrapRetries++
+			retryResult, retryErr := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
+			if retryErr != nil {
+				originalBootstrapErr := executionErrorMessage(bootstrapStreamErr)
+				if isAuthSelectionUnavailable(retryErr) && originalBootstrapErr.StatusCode >= http.StatusInternalServerError {
+					bootstrapErr = originalBootstrapErr
+				} else {
+					bootstrapErr = executionErrorMessage(enrichAuthSelectionError(retryErr, providers, normalizedModel))
+				}
+				return
+			}
+			if retryResult == nil {
+				bootstrapErr = executionErrorMessage(fmt.Errorf("auth manager returned nil stream"))
+				return
+			}
+			rawStreamHeaders = cloneHeader(retryResult.Headers)
+			baseStreamHeaders = cloneHeader(retryResult.Headers)
+			streamHeaderInitialized = false
+			streamClosedBeforeRead = false
+			bootstrapStreamErr = nil
+			bootstrapPayloads = nil
+			bootstrapPayloadBytes = 0
+			bootstrapChunkIndex = 0
+			bootstrapHistoryChunks = nil
+			chunks = retryResult.Chunks
+			if chunks == nil {
+				closed := make(chan coreexecutor.StreamChunk)
+				close(closed)
+				chunks = closed
+			}
 		}
 	}
+	resolveBootstrap(false)
 
 	upstreamHeaders := downstreamHeadersAfterInterceptors(baseStreamHeaders, rawStreamHeaders, passthroughHeadersEnabled)
 	if upstreamHeaders == nil && (passthroughHeadersEnabled || streamInterceptorsActive) {
@@ -554,6 +581,11 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 			}
 		}
 
+		if bootstrapPaused {
+			// Keep the provisional prefix private until semantic output commits the
+			// response or a bootstrap failure selects a clean retry.
+			resolveBootstrap(true)
+		}
 		if bootstrapErr != nil {
 			completionOutcome = pluginapi.RequestCompletionFailed
 			if bootstrapErr.DirectResponse {

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -401,12 +401,17 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	var bootstrapStreamErr error
 	var bootstrapErr *interfaces.ErrorMessage
 	bootstrapPaused := false
+	// A heartbeat may commit HTTP headers before an asynchronous retry finishes.
+	// Keep bootstrap synchronous whenever the selected attempt can change headers.
+	canPauseBootstrap := responseProtocol == "openai-response" &&
+		!passthroughHeadersEnabled &&
+		!streamInterceptorsActive
 	readInitialStreamChunks := func(blockAfterPrefix bool) {
 		bootstrapPaused = false
 		for {
 			var chunk coreexecutor.StreamChunk
 			var ok bool
-			if !blockAfterPrefix && responseProtocol == "openai-response" && len(bootstrapPayloads) > 0 {
+			if !blockAfterPrefix && canPauseBootstrap && len(bootstrapPayloads) > 0 {
 				if ctx != nil {
 					select {
 					case <-ctx.Done():

--- a/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -626,6 +627,89 @@ func TestExecuteStreamWithAuthManager_RetriesAfterOpenAIResponsesProvisionalLife
 	want := []string{
 		"event: response.created",
 		`data: {"type":"response.created","sequence_number":0,"response":{"id":"resp-2","status":"in_progress"}}`,
+		`data: {"type":"response.completed","response":{"id":"resp-2","output":[]}}`,
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("forwarded chunks = %#v, want only successful attempt %#v", got, want)
+	}
+}
+
+func TestExecuteStreamWithAuthManager_UsesRetryHeadersAfterOpenAIResponsesProvisionalFailure(t *testing.T) {
+	allowFirstAttemptFailure := make(chan struct{})
+	firstAttemptPrefixConsumed := make(chan struct{})
+	executor := &bootstrapStreamExecutor{stream: func(_ context.Context, call int) (*coreexecutor.StreamResult, error) {
+		if call == 1 {
+			chunks := make(chan coreexecutor.StreamChunk)
+			go func() {
+				chunks <- coreexecutor.StreamChunk{Payload: []byte("event: response.created")}
+				chunks <- coreexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.created","response":{"id":"resp-1","status":"in_progress"}}`)}
+				close(firstAttemptPrefixConsumed)
+				<-allowFirstAttemptFailure
+				chunks <- coreexecutor.StreamChunk{Err: &coreauth.Error{
+					Code:       "upstream_closed",
+					Message:    "stream closed before response.completed",
+					HTTPStatus: http.StatusRequestTimeout,
+				}}
+				close(chunks)
+			}()
+			return &coreexecutor.StreamResult{
+				Headers: http.Header{"X-Upstream-Attempt": {"1"}},
+				Chunks:  chunks,
+			}, nil
+		}
+
+		chunks := make(chan coreexecutor.StreamChunk, 2)
+		chunks <- coreexecutor.StreamChunk{Payload: []byte("event: response.created")}
+		chunks <- coreexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.completed","response":{"id":"resp-2","output":[]}}`)}
+		close(chunks)
+		return &coreexecutor.StreamResult{
+			Headers: http.Header{"X-Upstream-Attempt": {fmt.Sprintf("%d", call)}},
+			Chunks:  chunks,
+		}, nil
+	}}
+	handler, _ := registerBootstrapExecutor(t, executor)
+	handler.Cfg.PassthroughHeaders = true
+
+	type streamResult struct {
+		data    <-chan []byte
+		headers http.Header
+		errs    <-chan *interfaces.ErrorMessage
+	}
+	resultChan := make(chan streamResult, 1)
+	go func() {
+		dataChan, upstreamHeaders, errChan := handler.ExecuteStreamWithAuthManager(
+			context.Background(),
+			"openai-response",
+			"bootstrap-model",
+			[]byte(`{"model":"bootstrap-model","input":"hello"}`),
+			"",
+		)
+		resultChan <- streamResult{data: dataChan, headers: upstreamHeaders, errs: errChan}
+	}()
+
+	<-firstAttemptPrefixConsumed
+	select {
+	case result := <-resultChan:
+		t.Fatalf("stream returned stale headers before retry selection: %#v", result.headers)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(allowFirstAttemptFailure)
+	result := <-resultChan
+
+	if got := result.headers.Get("X-Upstream-Attempt"); got != "2" {
+		t.Fatalf("upstream attempt header = %q, want successful retry attempt", got)
+	}
+	var got []string
+	for chunk := range result.data {
+		got = append(got, string(chunk))
+	}
+	for msg := range result.errs {
+		if msg != nil {
+			t.Fatalf("unexpected stream error: %+v", msg)
+		}
+	}
+	want := []string{
+		"event: response.created",
 		`data: {"type":"response.completed","response":{"id":"resp-2","output":[]}}`,
 	}
 	if strings.Join(got, "\n") != strings.Join(want, "\n") {

--- a/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -555,6 +555,96 @@ func TestExecuteStreamWithAuthManager_RetriesAfterDroppedBootstrapPayload(t *tes
 	}
 }
 
+func TestExecuteStreamWithAuthManager_RetriesAfterOpenAIResponsesEventPrefixOnly(t *testing.T) {
+	executor := &bootstrapStreamExecutor{stream: func(_ context.Context, call int) (*coreexecutor.StreamResult, error) {
+		chunks := make(chan coreexecutor.StreamChunk, 3)
+		chunks <- coreexecutor.StreamChunk{Payload: []byte("event: response.created")}
+		if call == 1 {
+			chunks <- coreexecutor.StreamChunk{Err: &coreauth.Error{
+				Code:       "upstream_closed",
+				Message:    "stream closed before response.completed",
+				HTTPStatus: http.StatusRequestTimeout,
+			}}
+		} else {
+			chunks <- coreexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.completed","response":{"id":"resp-2","output":[]}}`)}
+		}
+		close(chunks)
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}}
+	handler, _ := registerBootstrapExecutor(t, executor)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(
+		context.Background(),
+		"openai-response",
+		"bootstrap-model",
+		[]byte(`{"model":"bootstrap-model","input":"hello"}`),
+		"",
+	)
+
+	var got []string
+	for chunk := range dataChan {
+		got = append(got, string(chunk))
+	}
+	for msg := range errChan {
+		if msg != nil {
+			t.Fatalf("unexpected stream error: %+v", msg)
+		}
+	}
+	if executor.Calls() != 2 {
+		t.Fatalf("stream attempts = %d, want retry after prefix-only failure", executor.Calls())
+	}
+	want := []string{
+		"event: response.created",
+		`data: {"type":"response.completed","response":{"id":"resp-2","output":[]}}`,
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("forwarded chunks = %#v, want only successful attempt %#v", got, want)
+	}
+}
+
+func TestExecuteStreamWithAuthManager_BoundsOpenAIResponsesPrefixBuffer(t *testing.T) {
+	executor := &bootstrapStreamExecutor{stream: func(_ context.Context, _ int) (*coreexecutor.StreamResult, error) {
+		chunks := make(chan coreexecutor.StreamChunk, 128)
+		for index := 0; index < 128; index++ {
+			chunks <- coreexecutor.StreamChunk{Payload: []byte(": queued heartbeat")}
+		}
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}}
+	handler, _ := registerBootstrapExecutor(t, executor)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type streamResult struct {
+		data <-chan []byte
+		errs <-chan *interfaces.ErrorMessage
+	}
+	results := make(chan streamResult, 1)
+	go func() {
+		dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(
+			ctx,
+			"openai-response",
+			"bootstrap-model",
+			[]byte(`{"model":"bootstrap-model","input":"hello"}`),
+			"",
+		)
+		results <- streamResult{data: dataChan, errs: errChan}
+	}()
+
+	var result streamResult
+	select {
+	case result = <-results:
+	case <-time.After(time.Second):
+		cancel()
+		<-results
+		t.Fatal("prefix-only Responses stream kept bootstrap blocked without a bound")
+	}
+	cancel()
+	for range result.data {
+	}
+	for range result.errs {
+	}
+}
+
 func TestExecuteStreamWithAuthManager_CancelDuringSynchronousBootstrap(t *testing.T) {
 	started := make(chan struct{})
 	executor := &bootstrapStreamExecutor{stream: func(_ context.Context, _ int) (*coreexecutor.StreamResult, error) {

--- a/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -676,6 +676,60 @@ func TestExecuteStreamWithAuthManager_BoundsOpenAIResponsesPrefixBuffer(t *testi
 	}
 }
 
+func TestExecuteStreamWithAuthManager_ReturnsAfterAvailableOpenAIResponsesProvisionalPrefix(t *testing.T) {
+	chunks := make(chan coreexecutor.StreamChunk, 3)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("event: response.created")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.created","response":{"id":"resp-1","status":"in_progress"}}`)}
+	executor := &bootstrapStreamExecutor{stream: func(_ context.Context, _ int) (*coreexecutor.StreamResult, error) {
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}}
+	handler, _ := registerBootstrapExecutor(t, executor)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type streamResult struct {
+		data <-chan []byte
+		errs <-chan *interfaces.ErrorMessage
+	}
+	results := make(chan streamResult, 1)
+	go func() {
+		dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(
+			ctx,
+			"openai-response",
+			"bootstrap-model",
+			[]byte(`{"model":"bootstrap-model","input":"hello"}`),
+			"",
+		)
+		results <- streamResult{data: dataChan, errs: errChan}
+	}()
+
+	var result streamResult
+	select {
+	case result = <-results:
+	case <-time.After(time.Second):
+		cancel()
+		<-results
+		t.Fatal("provisional Responses prefix kept bootstrap blocked waiting for another upstream chunk")
+	}
+
+	chunks <- coreexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.completed","response":{"id":"resp-1","output":[]}}`)}
+	close(chunks)
+	var got []string
+	for chunk := range result.data {
+		got = append(got, string(chunk))
+	}
+	for range result.errs {
+	}
+	want := []string{
+		"event: response.created",
+		`data: {"type":"response.created","response":{"id":"resp-1","status":"in_progress"}}`,
+		`data: {"type":"response.completed","response":{"id":"resp-1","output":[]}}`,
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("forwarded chunks = %#v, want complete delayed stream %#v", got, want)
+	}
+}
+
 func TestExecuteStreamWithAuthManager_CancelDuringSynchronousBootstrap(t *testing.T) {
 	started := make(chan struct{})
 	executor := &bootstrapStreamExecutor{stream: func(_ context.Context, _ int) (*coreexecutor.StreamResult, error) {

--- a/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -555,17 +555,47 @@ func TestExecuteStreamWithAuthManager_RetriesAfterDroppedBootstrapPayload(t *tes
 	}
 }
 
-func TestExecuteStreamWithAuthManager_RetriesAfterOpenAIResponsesEventPrefixOnly(t *testing.T) {
+func TestStreamBootstrapPayloadCommitsResponse_OpenAIResponsesLifecycle(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    bool
+	}{
+		{name: "event prefix only", payload: "event: response.created", want: false},
+		{name: "queued raw JSON", payload: `{"type":"response.queued"}`, want: false},
+		{name: "created SSE data", payload: `data: {"type":"response.created"}`, want: false},
+		{name: "in progress SSE data", payload: `data: {"type":"response.in_progress"}`, want: false},
+		{name: "output delta", payload: `data: {"type":"response.output_text.delta","delta":"hello"}`, want: true},
+		{name: "completed", payload: `data: {"type":"response.completed"}`, want: true},
+		{name: "failed", payload: `data: {"type":"response.failed"}`, want: true},
+		{name: "done marker", payload: "data: [DONE]", want: true},
+		{name: "unknown event", payload: `data: {"type":"response.future_event"}`, want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := streamBootstrapPayloadCommitsResponse("openai-response", []byte(test.payload)); got != test.want {
+				t.Fatalf("streamBootstrapPayloadCommitsResponse() = %t, want %t", got, test.want)
+			}
+		})
+	}
+	if !streamBootstrapPayloadCommitsResponse("openai", []byte("event: response.created")) {
+		t.Fatal("non-Responses protocols must retain first-payload commitment")
+	}
+}
+
+func TestExecuteStreamWithAuthManager_RetriesAfterOpenAIResponsesProvisionalLifecycleFrame(t *testing.T) {
 	executor := &bootstrapStreamExecutor{stream: func(_ context.Context, call int) (*coreexecutor.StreamResult, error) {
-		chunks := make(chan coreexecutor.StreamChunk, 3)
+		chunks := make(chan coreexecutor.StreamChunk, 4)
 		chunks <- coreexecutor.StreamChunk{Payload: []byte("event: response.created")}
 		if call == 1 {
+			chunks <- coreexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.created","sequence_number":0,"response":{"id":"resp-1","status":"in_progress"}}`)}
 			chunks <- coreexecutor.StreamChunk{Err: &coreauth.Error{
 				Code:       "upstream_closed",
 				Message:    "stream closed before response.completed",
 				HTTPStatus: http.StatusRequestTimeout,
 			}}
 		} else {
+			chunks <- coreexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.created","sequence_number":0,"response":{"id":"resp-2","status":"in_progress"}}`)}
 			chunks <- coreexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.completed","response":{"id":"resp-2","output":[]}}`)}
 		}
 		close(chunks)
@@ -591,10 +621,11 @@ func TestExecuteStreamWithAuthManager_RetriesAfterOpenAIResponsesEventPrefixOnly
 		}
 	}
 	if executor.Calls() != 2 {
-		t.Fatalf("stream attempts = %d, want retry after prefix-only failure", executor.Calls())
+		t.Fatalf("stream attempts = %d, want retry after provisional lifecycle failure", executor.Calls())
 	}
 	want := []string{
 		"event: response.created",
+		`data: {"type":"response.created","sequence_number":0,"response":{"id":"resp-2","status":"in_progress"}}`,
 		`data: {"type":"response.completed","response":{"id":"resp-2","output":[]}}`,
 	}
 	if strings.Join(got, "\n") != strings.Join(want, "\n") {

--- a/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -717,6 +717,152 @@ func TestExecuteStreamWithAuthManager_UsesRetryHeadersAfterOpenAIResponsesProvis
 	}
 }
 
+func TestExecuteStreamWithAuthManagerBootstrapCommit_PreservesPrivateRetryHeaders(t *testing.T) {
+	allowFirstAttemptFailure := make(chan struct{})
+	retryStarted := make(chan struct{})
+	retryChunks := make(chan coreexecutor.StreamChunk, 1)
+	executor := &bootstrapStreamExecutor{stream: func(_ context.Context, call int) (*coreexecutor.StreamResult, error) {
+		if call == 1 {
+			chunks := make(chan coreexecutor.StreamChunk, 3)
+			chunks <- coreexecutor.StreamChunk{Payload: []byte("event: response.created")}
+			chunks <- coreexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.created","response":{"id":"resp-1","status":"in_progress"}}`)}
+			go func() {
+				<-allowFirstAttemptFailure
+				chunks <- coreexecutor.StreamChunk{Err: &coreauth.Error{
+					Code:       "upstream_closed",
+					Message:    "stream closed before response.completed",
+					HTTPStatus: http.StatusRequestTimeout,
+				}}
+				close(chunks)
+			}()
+			return &coreexecutor.StreamResult{
+				Headers: http.Header{"X-Upstream-Attempt": {"1"}},
+				Chunks:  chunks,
+			}, nil
+		}
+		retryChunks <- coreexecutor.StreamChunk{Payload: []byte("event: response.created")}
+		close(retryStarted)
+		return &coreexecutor.StreamResult{
+			Headers: http.Header{"X-Upstream-Attempt": {fmt.Sprintf("%d", call)}},
+			Chunks:  retryChunks,
+		}, nil
+	}}
+	handler, _ := registerBootstrapExecutor(t, executor)
+	handler.Cfg.PassthroughHeaders = true
+	handler.SetPluginHost(&handlerInterceptorTestHost{
+		interceptStreamChunk: func(_ context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+			headers := cloneHeader(req.ResponseHeaders)
+			if req.ChunkIndex == pluginapi.StreamChunkHeaderInitIndex {
+				headers.Set("X-Selected-Attempt", headers.Get("X-Upstream-Attempt"))
+			}
+			return pluginapi.StreamChunkInterceptResponse{Headers: headers, Body: cloneBytes(req.Body)}
+		},
+	})
+
+	dataChan, errChan, committer := handler.ExecuteStreamWithAuthManagerBootstrapCommit(
+		context.Background(),
+		"openai-response",
+		"bootstrap-model",
+		[]byte(`{"model":"bootstrap-model","input":"hello"}`),
+		"",
+	)
+	close(allowFirstAttemptFailure)
+	<-retryStarted
+
+	committedHeaders := committer.Commit()
+	if got := committedHeaders.Get("X-Upstream-Attempt"); got != "2" {
+		t.Fatalf("committed upstream attempt header = %q, want successful retry attempt", got)
+	}
+	if got := committedHeaders.Get("X-Selected-Attempt"); got != "2" {
+		t.Fatalf("interceptor selected-attempt header = %q, want retry attempt 2", got)
+	}
+	retryChunks <- coreexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.completed","response":{"id":"resp-2","output":[]}}`)}
+	close(retryChunks)
+	var got []string
+	for chunk := range dataChan {
+		got = append(got, string(chunk))
+	}
+	for msg := range errChan {
+		if msg != nil {
+			t.Fatalf("unexpected stream error: %+v", msg)
+		}
+	}
+	want := []string{
+		"event: response.created",
+		`data: {"type":"response.completed","response":{"id":"resp-2","output":[]}}`,
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("forwarded chunks = %#v, want only successful attempt %#v", got, want)
+	}
+}
+
+func TestExecuteStreamWithAuthManagerBootstrapCommit_FreezesRetryAtFirstByte(t *testing.T) {
+	afterCommit := make(chan coreexecutor.StreamChunk, 1)
+	executor := &bootstrapStreamExecutor{stream: func(_ context.Context, call int) (*coreexecutor.StreamResult, error) {
+		if call > 1 {
+			return nil, fmt.Errorf("unexpected retry after bootstrap commit: call %d", call)
+		}
+		chunks := make(chan coreexecutor.StreamChunk, 3)
+		chunks <- coreexecutor.StreamChunk{Payload: []byte("event: response.created")}
+		chunks <- coreexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.created","response":{"id":"resp-1","status":"in_progress"}}`)}
+		go func() {
+			chunk := <-afterCommit
+			chunks <- chunk
+			close(chunks)
+		}()
+		return &coreexecutor.StreamResult{
+			Headers: http.Header{"X-Upstream-Attempt": {"1"}},
+			Chunks:  chunks,
+		}, nil
+	}}
+	handler, _ := registerBootstrapExecutor(t, executor)
+	handler.Cfg.PassthroughHeaders = true
+
+	dataChan, errChan, committer := handler.ExecuteStreamWithAuthManagerBootstrapCommit(
+		context.Background(),
+		"openai-response",
+		"bootstrap-model",
+		[]byte(`{"model":"bootstrap-model","input":"hello"}`),
+		"",
+	)
+	headers := committer.Commit()
+	if got := headers.Get("X-Upstream-Attempt"); got != "1" {
+		t.Fatalf("committed upstream attempt header = %q, want 1", got)
+	}
+	if got := committer.Commit().Get("X-Upstream-Attempt"); got != "1" {
+		t.Fatalf("second commit upstream attempt header = %q, want stable snapshot", got)
+	}
+	afterCommit <- coreexecutor.StreamChunk{Err: &coreauth.Error{
+		Code:       "upstream_closed",
+		Message:    "stream closed after downstream heartbeat",
+		HTTPStatus: http.StatusRequestTimeout,
+	}}
+
+	var got []string
+	for chunk := range dataChan {
+		got = append(got, string(chunk))
+	}
+	var streamErr *interfaces.ErrorMessage
+	for msg := range errChan {
+		if msg != nil {
+			streamErr = msg
+		}
+	}
+	if streamErr == nil || streamErr.StatusCode != http.StatusRequestTimeout {
+		t.Fatalf("stream error = %+v, want terminal 408 after commit", streamErr)
+	}
+	if executor.Calls() != 1 {
+		t.Fatalf("stream attempts = %d, want no retry after bootstrap commit", executor.Calls())
+	}
+	want := []string{
+		"event: response.created",
+		`data: {"type":"response.created","response":{"id":"resp-1","status":"in_progress"}}`,
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("forwarded chunks = %#v, want committed first attempt prefix %#v", got, want)
+	}
+}
+
 func TestExecuteStreamWithAuthManager_BoundsOpenAIResponsesPrefixBuffer(t *testing.T) {
 	executor := &bootstrapStreamExecutor{stream: func(_ context.Context, _ int) (*coreexecutor.StreamResult, error) {
 		chunks := make(chan coreexecutor.StreamChunk, 128)

--- a/sdk/api/handlers/model_execution.go
+++ b/sdk/api/handlers/model_execution.go
@@ -22,6 +22,7 @@ type modelExecutionOptions struct {
 	SkipRouterPluginID      string
 	ForcedProvider          string
 	AuthSelectionModel      string
+	StreamBootstrapCommit   *StreamBootstrapCommitter
 }
 
 // ProtocolExecutionRequest describes a route-level model execution request with explicit protocols.

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -486,7 +486,7 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 	// New core execution path
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
-	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
+	dataChan, errChan, bootstrapCommitter := h.ExecuteStreamWithAuthManagerBootstrapCommit(cliCtx, h.HandlerType(), modelName, rawJSON, "")
 
 	framer := &responsesSSEFramer{}
 	h.forwardInitialResponsesStream(
@@ -495,7 +495,8 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 		func(err error) { cliCancel(err) },
 		dataChan,
 		errChan,
-		upstreamHeaders,
+		func() http.Header { return bootstrapCommitter.CommitContext(c.Request.Context()) },
+		bootstrapCommitter.Headers,
 		framer,
 		handlers.StreamingKeepAliveInterval(h.Cfg),
 	)
@@ -507,7 +508,8 @@ func (h *OpenAIResponsesAPIHandler) forwardInitialResponsesStream(
 	cancel func(error),
 	dataChan <-chan []byte,
 	errChan <-chan *interfaces.ErrorMessage,
-	upstreamHeaders http.Header,
+	commitHeaders func() http.Header,
+	selectedHeaders func() http.Header,
 	framer *responsesSSEFramer,
 	keepAliveInterval time.Duration,
 ) {
@@ -544,6 +546,9 @@ func (h *OpenAIResponsesAPIHandler) forwardInitialResponsesStream(
 				continue
 			}
 			// Upstream failed immediately. Return proper error status and JSON.
+			if selectedHeaders != nil {
+				handlers.WriteUpstreamHeaders(c.Writer.Header(), selectedHeaders())
+			}
 			h.WriteErrorResponse(c, errMsg)
 			if errMsg != nil {
 				cancel(errMsg.Error)
@@ -552,7 +557,21 @@ func (h *OpenAIResponsesAPIHandler) forwardInitialResponsesStream(
 			}
 			return
 		case chunk, ok := <-dataChan:
+			var upstreamHeaders http.Header
+			if selectedHeaders != nil {
+				upstreamHeaders = selectedHeaders()
+			}
 			if !ok {
+				select {
+				case errMsg, okErr := <-errChan:
+					if okErr && errMsg != nil {
+						handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+						h.WriteErrorResponse(c, errMsg)
+						cancel(errMsg.Error)
+						return
+					}
+				default:
+				}
 				// Stream closed without data? Send headers and done.
 				setSSEHeaders()
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
@@ -575,6 +594,14 @@ func (h *OpenAIResponsesAPIHandler) forwardInitialResponsesStream(
 			h.forwardResponsesStream(c, flusher, cancel, dataChan, errChan, framer)
 			return
 		case <-keepAliveC:
+			var upstreamHeaders http.Header
+			if commitHeaders != nil {
+				upstreamHeaders = commitHeaders()
+			}
+			if err := c.Request.Context().Err(); err != nil {
+				cancel(err)
+				return
+			}
 			setSSEHeaders()
 			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 			_, _ = c.Writer.Write([]byte(": keep-alive\n\n"))

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net/http"
 	"sort"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	. "github.com/router-for-me/CLIProxyAPI/v7/internal/constant"
@@ -487,19 +488,54 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
 	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
 
+	framer := &responsesSSEFramer{}
+	h.forwardInitialResponsesStream(
+		c,
+		flusher,
+		func(err error) { cliCancel(err) },
+		dataChan,
+		errChan,
+		upstreamHeaders,
+		framer,
+		handlers.StreamingKeepAliveInterval(h.Cfg),
+	)
+}
+
+func (h *OpenAIResponsesAPIHandler) forwardInitialResponsesStream(
+	c *gin.Context,
+	flusher http.Flusher,
+	cancel func(error),
+	dataChan <-chan []byte,
+	errChan <-chan *interfaces.ErrorMessage,
+	upstreamHeaders http.Header,
+	framer *responsesSSEFramer,
+	keepAliveInterval time.Duration,
+) {
 	setSSEHeaders := func() {
 		c.Header("Content-Type", "text/event-stream")
 		c.Header("Cache-Control", "no-cache")
 		c.Header("Connection", "keep-alive")
 		c.Header("Access-Control-Allow-Origin", "*")
 	}
-	framer := &responsesSSEFramer{}
+	var keepAlive *time.Ticker
+	var keepAliveC <-chan time.Time
+	if keepAliveInterval > 0 {
+		keepAlive = time.NewTicker(keepAliveInterval)
+		keepAliveC = keepAlive.C
+	}
+	stopKeepAlive := func() {
+		if keepAlive != nil {
+			keepAlive.Stop()
+			keepAlive = nil
+			keepAliveC = nil
+		}
+	}
+	defer stopKeepAlive()
 
-	// Peek at the first chunk
 	for {
 		select {
 		case <-c.Request.Context().Done():
-			cliCancel(c.Request.Context().Err())
+			cancel(c.Request.Context().Err())
 			return
 		case errMsg, ok := <-errChan:
 			if !ok {
@@ -510,9 +546,9 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 			// Upstream failed immediately. Return proper error status and JSON.
 			h.WriteErrorResponse(c, errMsg)
 			if errMsg != nil {
-				cliCancel(errMsg.Error)
+				cancel(errMsg.Error)
 			} else {
-				cliCancel(nil)
+				cancel(nil)
 			}
 			return
 		case chunk, ok := <-dataChan:
@@ -522,7 +558,7 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 				_, _ = c.Writer.Write([]byte("\n"))
 				flusher.Flush()
-				cliCancel(nil)
+				cancel(nil)
 				return
 			}
 
@@ -535,7 +571,16 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 			flusher.Flush()
 
 			// Continue
-			h.forwardResponsesStream(c, flusher, func(err error) { cliCancel(err) }, dataChan, errChan, framer)
+			stopKeepAlive()
+			h.forwardResponsesStream(c, flusher, cancel, dataChan, errChan, framer)
+			return
+		case <-keepAliveC:
+			setSSEHeaders()
+			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+			_, _ = c.Writer.Write([]byte(": keep-alive\n\n"))
+			flusher.Flush()
+			stopKeepAlive()
+			h.forwardResponsesStream(c, flusher, cancel, dataChan, errChan, framer)
 			return
 		}
 	}

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -11,10 +12,74 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	"github.com/tidwall/gjson"
 )
+
+type responsesBootstrapTestExecutor struct {
+	chunks <-chan coreexecutor.StreamChunk
+	mu     sync.Mutex
+	calls  int
+}
+
+func (e *responsesBootstrapTestExecutor) Identifier() string { return "responses-bootstrap-test" }
+
+func (e *responsesBootstrapTestExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *responsesBootstrapTestExecutor) ExecuteStream(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	e.mu.Lock()
+	e.calls++
+	e.mu.Unlock()
+	return &coreexecutor.StreamResult{
+		Headers: http.Header{"X-Upstream-Attempt": {"1"}},
+		Chunks:  e.chunks,
+	}, nil
+}
+
+func (e *responsesBootstrapTestExecutor) Calls() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.calls
+}
+
+func (e *responsesBootstrapTestExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *responsesBootstrapTestExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *responsesBootstrapTestExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+type responsesBootstrapInterceptorHost struct{}
+
+func (*responsesBootstrapInterceptorHost) InterceptRequestBeforeAuth(_ context.Context, req pluginapi.RequestInterceptRequest) pluginapi.RequestInterceptResponse {
+	return pluginapi.RequestInterceptResponse{Headers: req.Headers, Body: req.Body}
+}
+
+func (*responsesBootstrapInterceptorHost) InterceptRequestAfterAuth(_ context.Context, req pluginapi.RequestInterceptRequest) pluginapi.RequestInterceptResponse {
+	return pluginapi.RequestInterceptResponse{Headers: req.Headers, Body: req.Body}
+}
+
+func (*responsesBootstrapInterceptorHost) InterceptResponse(_ context.Context, req pluginapi.ResponseInterceptRequest) pluginapi.ResponseInterceptResponse {
+	return pluginapi.ResponseInterceptResponse{Headers: req.ResponseHeaders, Body: req.Body}
+}
+
+func (*responsesBootstrapInterceptorHost) InterceptStreamChunk(_ context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+	headers := req.ResponseHeaders.Clone()
+	headers.Set("X-Stream-Interceptor", "active")
+	return pluginapi.StreamChunkInterceptResponse{Headers: headers, Body: req.Body}
+}
 
 func newResponsesStreamTestHandler(t *testing.T) (*OpenAIResponsesAPIHandler, *httptest.ResponseRecorder, *gin.Context, http.Flusher) {
 	t.Helper()
@@ -46,6 +111,26 @@ func (w *signalingResponseWriter) Flush() {
 	w.once.Do(func() { close(w.flushed) })
 }
 
+func newResponsesBootstrapEndpointHandler(t *testing.T, cfg *sdkconfig.SDKConfig, chunks <-chan coreexecutor.StreamChunk) (*OpenAIResponsesAPIHandler, *responsesBootstrapTestExecutor) {
+	t.Helper()
+	const model = "responses-bootstrap-endpoint-model"
+	manager := coreauth.NewManager(nil, nil, nil)
+	executor := &responsesBootstrapTestExecutor{chunks: chunks}
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{
+		ID:       "responses-bootstrap-endpoint-auth",
+		Provider: executor.Identifier(),
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"email": "responses-bootstrap@example.com"},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("manager.Register(): %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	return NewOpenAIResponsesAPIHandler(handlers.NewBaseAPIHandlers(cfg, manager)), executor
+}
+
 func TestForwardResponsesStreamSeparatesDataOnlySSEChunks(t *testing.T) {
 	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
 
@@ -74,6 +159,97 @@ func TestForwardResponsesStreamSeparatesDataOnlySSEChunks(t *testing.T) {
 	}
 }
 
+func TestResponsesBootstrapCommitStartsKeepAliveWithObservableHeaders(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        *sdkconfig.SDKConfig
+		pluginHost handlers.PluginInterceptorHost
+		header     string
+		value      string
+	}{
+		{
+			name:   "passthrough headers",
+			cfg:    &sdkconfig.SDKConfig{PassthroughHeaders: true, Streaming: sdkconfig.StreamingConfig{BootstrapRetries: 1}},
+			header: "X-Upstream-Attempt",
+			value:  "1",
+		},
+		{
+			name:       "stream interceptor headers",
+			cfg:        &sdkconfig.SDKConfig{Streaming: sdkconfig.StreamingConfig{BootstrapRetries: 1}},
+			pluginHost: &responsesBootstrapInterceptorHost{},
+			header:     "X-Stream-Interceptor",
+			value:      "active",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			chunks := make(chan coreexecutor.StreamChunk, 3)
+			chunks <- coreexecutor.StreamChunk{Payload: []byte("event: response.created")}
+			chunks <- coreexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.created","response":{"id":"resp-1","status":"in_progress"}}`)}
+			h, executor := newResponsesBootstrapEndpointHandler(t, test.cfg, chunks)
+			if test.pluginHost != nil {
+				h.SetPluginHost(test.pluginHost)
+			}
+
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+			writer := &signalingResponseWriter{ResponseWriter: c.Writer, flushed: make(chan struct{})}
+			c.Writer = writer
+
+			data, errs, committer := h.ExecuteStreamWithAuthManagerBootstrapCommit(
+				context.Background(),
+				h.HandlerType(),
+				"responses-bootstrap-endpoint-model",
+				[]byte(`{"model":"responses-bootstrap-endpoint-model","input":"hello"}`),
+				"",
+			)
+			go func() {
+				<-writer.flushed
+				chunks <- coreexecutor.StreamChunk{Err: &coreauth.Error{
+					Code:       "upstream_closed",
+					Message:    "stream failed after heartbeat commit",
+					HTTPStatus: http.StatusRequestTimeout,
+				}}
+				close(chunks)
+			}()
+
+			var canceled error
+			h.forwardInitialResponsesStream(
+				c,
+				writer,
+				func(err error) { canceled = err },
+				data,
+				errs,
+				committer.Commit,
+				committer.Headers,
+				&responsesSSEFramer{},
+				10*time.Millisecond,
+			)
+
+			if canceled == nil || !strings.Contains(canceled.Error(), "stream failed after heartbeat commit") {
+				t.Fatalf("stream cancel error = %v, want post-commit upstream failure", canceled)
+			}
+			if got := recorder.Header().Get(test.header); got != test.value {
+				t.Fatalf("%s = %q, want %q", test.header, got, test.value)
+			}
+			body := recorder.Body.String()
+			keepAliveIndex := strings.Index(body, ": keep-alive\n\n")
+			createdIndex := strings.Index(body, "event: response.created")
+			if keepAliveIndex < 0 || createdIndex < 0 || keepAliveIndex >= createdIndex {
+				t.Fatalf("expected keep-alive before provisional Responses prefix, got %q", body)
+			}
+			if !strings.Contains(body, "event: error") || !strings.Contains(body, `"type":"error"`) {
+				t.Fatalf("expected post-commit Responses SSE error, got %q", body)
+			}
+			if executor.Calls() != 1 {
+				t.Fatalf("stream attempts = %d, want no redispatch after heartbeat commit", executor.Calls())
+			}
+		})
+	}
+}
+
 func TestForwardInitialResponsesStreamEmitsKeepAliveBeforeFirstData(t *testing.T) {
 	h, recorder, c, _ := newResponsesStreamTestHandler(t)
 	writer := &signalingResponseWriter{ResponseWriter: c.Writer, flushed: make(chan struct{})}
@@ -95,7 +271,8 @@ func TestForwardInitialResponsesStreamEmitsKeepAliveBeforeFirstData(t *testing.T
 		func(err error) { canceled = err },
 		data,
 		errs,
-		nil,
+		func() http.Header { return nil },
+		func() http.Header { return nil },
 		&responsesSSEFramer{},
 		10*time.Millisecond,
 	)
@@ -138,7 +315,8 @@ func TestForwardInitialResponsesStreamUsesSSEErrorAfterKeepAlive(t *testing.T) {
 		func(err error) { canceled = err },
 		data,
 		errs,
-		nil,
+		func() http.Header { return nil },
+		func() http.Header { return nil },
 		&responsesSSEFramer{},
 		10*time.Millisecond,
 	)
@@ -157,6 +335,41 @@ func TestForwardInitialResponsesStreamUsesSSEErrorAfterKeepAlive(t *testing.T) {
 	}
 	if strings.Contains(body, `"error":{`) {
 		t.Fatalf("unexpected non-streaming JSON error after committed keep-alive: %q", body)
+	}
+}
+
+func TestForwardInitialResponsesStreamPrefersPendingErrorWhenDataCloses(t *testing.T) {
+	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
+	data := make(chan []byte)
+	close(data)
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	errs <- &interfaces.ErrorMessage{
+		StatusCode: http.StatusBadGateway,
+		Error:      errors.New("bootstrap failed before commit"),
+	}
+	close(errs)
+
+	var canceled error
+	h.forwardInitialResponsesStream(
+		c,
+		flusher,
+		func(err error) { canceled = err },
+		data,
+		errs,
+		func() http.Header { return nil },
+		func() http.Header { return nil },
+		&responsesSSEFramer{},
+		0,
+	)
+
+	if canceled == nil || canceled.Error() != "bootstrap failed before commit" {
+		t.Fatalf("cancel error = %v, want pending bootstrap failure", canceled)
+	}
+	if recorder.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", recorder.Code)
+	}
+	if !strings.Contains(recorder.Body.String(), "bootstrap failed before commit") {
+		t.Fatalf("expected JSON bootstrap error, got %q", recorder.Body.String())
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -1,10 +1,13 @@
 package openai
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
@@ -32,6 +35,17 @@ func newResponsesStreamTestHandler(t *testing.T) (*OpenAIResponsesAPIHandler, *h
 	return h, recorder, c, flusher
 }
 
+type signalingResponseWriter struct {
+	gin.ResponseWriter
+	flushed chan struct{}
+	once    sync.Once
+}
+
+func (w *signalingResponseWriter) Flush() {
+	w.ResponseWriter.Flush()
+	w.once.Do(func() { close(w.flushed) })
+}
+
 func TestForwardResponsesStreamSeparatesDataOnlySSEChunks(t *testing.T) {
 	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
 
@@ -57,6 +71,92 @@ func TestForwardResponsesStreamSeparatesDataOnlySSEChunks(t *testing.T) {
 	expectedPart2 := "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"output\":[{\"type\":\"function_call\",\"arguments\":\"{}\"}]}}"
 	if parts[1] != expectedPart2 {
 		t.Errorf("unexpected second event.\nGot: %q\nWant: %q", parts[1], expectedPart2)
+	}
+}
+
+func TestForwardInitialResponsesStreamEmitsKeepAliveBeforeFirstData(t *testing.T) {
+	h, recorder, c, _ := newResponsesStreamTestHandler(t)
+	writer := &signalingResponseWriter{ResponseWriter: c.Writer, flushed: make(chan struct{})}
+	c.Writer = writer
+
+	data := make(chan []byte)
+	errs := make(chan *interfaces.ErrorMessage)
+	go func() {
+		<-writer.flushed
+		data <- []byte(`data: {"type":"response.completed","response":{"id":"resp-1","output":[]}}`)
+		close(data)
+		close(errs)
+	}()
+
+	var canceled error
+	h.forwardInitialResponsesStream(
+		c,
+		writer,
+		func(err error) { canceled = err },
+		data,
+		errs,
+		nil,
+		&responsesSSEFramer{},
+		10*time.Millisecond,
+	)
+
+	if canceled != nil {
+		t.Fatalf("stream canceled with error: %v", canceled)
+	}
+	if got := recorder.Header().Get("Content-Type"); got != "text/event-stream" {
+		t.Fatalf("content type = %q, want text/event-stream", got)
+	}
+	body := recorder.Body.String()
+	keepAliveIndex := strings.Index(body, ": keep-alive\n\n")
+	dataIndex := strings.Index(body, "data: {")
+	if keepAliveIndex < 0 || dataIndex < 0 || keepAliveIndex >= dataIndex {
+		t.Fatalf("expected keep-alive before delayed first data chunk, got %q", body)
+	}
+}
+
+func TestForwardInitialResponsesStreamUsesSSEErrorAfterKeepAlive(t *testing.T) {
+	h, recorder, c, _ := newResponsesStreamTestHandler(t)
+	writer := &signalingResponseWriter{ResponseWriter: c.Writer, flushed: make(chan struct{})}
+	c.Writer = writer
+
+	data := make(chan []byte)
+	errs := make(chan *interfaces.ErrorMessage)
+	go func() {
+		<-writer.flushed
+		errs <- &interfaces.ErrorMessage{
+			StatusCode: http.StatusBadGateway,
+			Error:      errors.New("upstream failed after bootstrap"),
+		}
+		close(data)
+		close(errs)
+	}()
+
+	var canceled error
+	h.forwardInitialResponsesStream(
+		c,
+		writer,
+		func(err error) { canceled = err },
+		data,
+		errs,
+		nil,
+		&responsesSSEFramer{},
+		10*time.Millisecond,
+	)
+
+	if canceled == nil || canceled.Error() != "upstream failed after bootstrap" {
+		t.Fatalf("cancel error = %v, want upstream bootstrap failure", canceled)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want committed streaming status 200", recorder.Code)
+	}
+	body := recorder.Body.String()
+	if !strings.Contains(body, ": keep-alive\n\n") ||
+		!strings.Contains(body, "event: error") ||
+		!strings.Contains(body, `"type":"error"`) {
+		t.Fatalf("expected keep-alive followed by Responses SSE error, got %q", body)
+	}
+	if strings.Contains(body, `"error":{`) {
+		t.Fatalf("unexpected non-streaming JSON error after committed keep-alive: %q", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

- keep OpenAI Responses SSE prefixes and provisional lifecycle events inside the bounded synchronous bootstrap window;
- treat `response.queued`, `response.created`, and `response.in_progress` as retryable even after their complete JSON payload arrives;
- commit on the first output-bearing event, terminal event, `[DONE]`, or unknown event;
- discard buffered chunks from a failed attempt and replay only the successful attempt in order.

Refs #4527.

## Root cause

Streaming bootstrap originally treated every non-empty translated chunk as the point of no return. The first fix kept split `event:` prefixes retryable, but a complete provisional frame still committed because any non-empty `data:` payload was considered semantic:

```text
event: response.created
data: {"type":"response.created", ...}
```

If the upstream disconnected after that frame but before output or a terminal event, the client had still received no usable response content, yet `streaming.bootstrap-retries` was disabled.

The commitment rule is now event-aware only for the OpenAI Responses protocol. Provisional lifecycle events remain buffered under the existing 32-chunk / 64 KiB cap. All other protocols retain their existing first-deliverable-payload behavior. Broader recovery after semantic output remains outside this PR.

## Tests

Added coverage for:

1. provisional lifecycle classification for raw JSON and SSE `data:` frames;
2. output-bearing, terminal, `[DONE]`, and unknown events committing the response;
3. attempt 1 emitting a complete `response.created` frame and then a 408-style error;
4. attempt 2 succeeding, with only its buffered lifecycle and terminal frames reaching downstream;
5. the existing bounded prefix buffer and split-SSE behavior.

Validation:

```bash
go test ./sdk/api/handlers/... ./sdk/cliproxy/auth -count=1
go test -race ./sdk/api/handlers -run 'Test(StreamBootstrapPayloadCommitsResponse_OpenAIResponsesLifecycle|ExecuteStreamWithAuthManager_(RetriesAfterOpenAIResponsesProvisionalLifecycleFrame|BoundsOpenAIResponsesPrefixBuffer|AllowsSplitOpenAIResponsesSSEEventLines|RetriesAfterDroppedBootstrapPayload))$' -count=1
go vet ./sdk/api/handlers/... ./sdk/cliproxy/auth
go build -o test-output ./cmd/server && rm test-output
git diff --check
```