### PR TITLE
fix(auth): retry transient upstream overload (503/529)

### DIFF
--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -741,6 +741,16 @@ func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []stri
 		}
 		return wait, true
 	}
+	if isTransientOverloadStatus(status) {
+		if !m.retryAllowed(attempt, providers) {
+			return 0, false
+		}
+		overloadWait := transientOverloadBackoff(attempt)
+		if overloadWait > maxWait {
+			overloadWait = maxWait
+		}
+		return overloadWait, true
+	}
 	if status != http.StatusTooManyRequests {
 		return 0, false
 	}
@@ -752,6 +762,41 @@ func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []stri
 		return 0, false
 	}
 	return *retryAfter, true
+}
+
+// statusOverloaded is the non-standard 529 upstreams such as Anthropic return
+// as "overloaded_error". Like 503 it signals a transient capacity dip rather
+// than a problem with the request or the credential.
+const statusOverloaded = 529
+
+// transientOverloadMaxBackoff caps the per-attempt overload backoff so a high
+// request-retry setting cannot turn a capacity dip into a multi-minute stall.
+const transientOverloadMaxBackoff = 8 * time.Second
+
+// isTransientOverloadStatus reports whether a status describes upstream
+// capacity exhaustion that is worth retrying on the same credential. Rotating
+// credentials does not help here, so these are deliberately kept separate from
+// the quota/cooldown path above.
+func isTransientOverloadStatus(status int) bool {
+	return status == http.StatusServiceUnavailable || status == statusOverloaded
+}
+
+// transientOverloadBackoff returns how long to wait before the given retry
+// attempt for a transient overload. Unlike 429, these responses rarely carry a
+// Retry-After hint, so the schedule doubles from one second up to
+// transientOverloadMaxBackoff instead of relying on the provider.
+func transientOverloadBackoff(attempt int) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+	wait := time.Second
+	for i := 0; i < attempt && wait < transientOverloadMaxBackoff; i++ {
+		wait *= 2
+	}
+	if wait > transientOverloadMaxBackoff {
+		wait = transientOverloadMaxBackoff
+	}
+	return wait
 }
 
 // cooldownWaitJitterCap bounds the random jitter added to cooldown waits so a

--- a/sdk/cliproxy/auth/overload_retry_test.go
+++ b/sdk/cliproxy/auth/overload_retry_test.go
@@ -1,0 +1,113 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// overloadManager returns a manager holding one registered anthropic credential
+// with request-retry enabled, which is what retryAllowed consults.
+func overloadManager(t *testing.T, retry int) *Manager {
+	t.Helper()
+	manager := NewManager(nil, nil, nil)
+	manager.SetRetryConfig(retry, time.Minute, 0)
+	auth := &Auth{
+		ID:       "auth-overload",
+		Provider: "anthropic",
+		Metadata: map[string]any{"type": "anthropic"},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("Register returned error: %v", errRegister)
+	}
+	return manager
+}
+
+func overloadError(status int) *Error {
+	return &Error{
+		Code:       "overloaded_error",
+		Message:    "Overloaded",
+		HTTPStatus: status,
+	}
+}
+
+// A 529 carries no Retry-After header, so before the transient-overload branch
+// existed it fell through the 429 gate and surfaced to the caller unretried.
+func TestShouldRetryAfterErrorRetriesTransientOverload(t *testing.T) {
+	manager := overloadManager(t, 10)
+	providers := []string{"anthropic"}
+
+	for _, status := range []int{529, http.StatusServiceUnavailable} {
+		wait, ok := manager.shouldRetryAfterError(overloadError(status), 0, providers, "claude-opus-5", time.Minute)
+		if !ok {
+			t.Fatalf("status %d: expected retry, got none", status)
+		}
+		if wait != time.Second {
+			t.Fatalf("status %d: expected 1s first backoff, got %v", status, wait)
+		}
+	}
+}
+
+func TestShouldRetryAfterErrorOverloadBackoffDoublesAndCaps(t *testing.T) {
+	manager := overloadManager(t, 10)
+	providers := []string{"anthropic"}
+
+	want := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second, 8 * time.Second}
+	for attempt, expected := range want {
+		wait, ok := manager.shouldRetryAfterError(overloadError(529), attempt, providers, "claude-opus-5", time.Minute)
+		if !ok {
+			t.Fatalf("attempt %d: expected retry, got none", attempt)
+		}
+		if wait != expected {
+			t.Fatalf("attempt %d: expected %v, got %v", attempt, expected, wait)
+		}
+	}
+}
+
+// The computed backoff must never exceed the configured ceiling.
+func TestShouldRetryAfterErrorOverloadClampsToMaxWait(t *testing.T) {
+	manager := overloadManager(t, 10)
+
+	wait, ok := manager.shouldRetryAfterError(overloadError(529), 5, []string{"anthropic"}, "claude-opus-5", 500*time.Millisecond)
+	if !ok {
+		t.Fatalf("expected retry, got none")
+	}
+	if wait != 500*time.Millisecond {
+		t.Fatalf("expected wait clamped to 500ms, got %v", wait)
+	}
+}
+
+// request-retry still bounds how many overload retries are handed out.
+func TestShouldRetryAfterErrorOverloadHonoursRequestRetry(t *testing.T) {
+	manager := overloadManager(t, 2)
+	providers := []string{"anthropic"}
+
+	if _, ok := manager.shouldRetryAfterError(overloadError(529), 1, providers, "claude-opus-5", time.Minute); !ok {
+		t.Fatalf("attempt 1 is within request-retry=2, expected retry")
+	}
+	if _, ok := manager.shouldRetryAfterError(overloadError(529), 2, providers, "claude-opus-5", time.Minute); ok {
+		t.Fatalf("attempt 2 exhausts request-retry=2, expected no retry")
+	}
+}
+
+// Statuses that are not capacity related must keep falling through untouched.
+func TestShouldRetryAfterErrorLeavesNonOverloadStatuses(t *testing.T) {
+	manager := overloadManager(t, 10)
+	providers := []string{"anthropic"}
+
+	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusInternalServerError, http.StatusBadGateway} {
+		if _, ok := manager.shouldRetryAfterError(overloadError(status), 0, providers, "claude-opus-5", time.Minute); ok {
+			t.Fatalf("status %d: expected no retry from the overload branch", status)
+		}
+	}
+}
+
+// 429 keeps its Retry-After driven behaviour: no hint means no retry.
+func TestShouldRetryAfterErrorTooManyRequestsStillNeedsRetryAfter(t *testing.T) {
+	manager := overloadManager(t, 10)
+
+	if _, ok := manager.shouldRetryAfterError(overloadError(http.StatusTooManyRequests), 0, []string{"anthropic"}, "claude-opus-5", time.Minute); ok {
+		t.Fatalf("429 without Retry-After should not retry")
+	}
+}


### PR DESCRIPTION
## Problem

`Manager.shouldRetryAfterError` gates every retry behind a single status check:

https://github.com/router-for-me/CLIProxyAPI/blob/main/sdk/cliproxy/auth/conductor_selection.go#L744-L746

```go
if status != http.StatusTooManyRequests {
    return 0, false
}
```

Anything that is not `429` returns early, so the `for attempt := 0; ; attempt++` loops in `conductor_execution.go` (`Execute`, `ExecuteCount`, `ExecuteStream`) break on the very first failure. `request-retry` therefore has no effect on `503 Service Unavailable` or on the non-standard `529` that Anthropic returns as `overloaded_error`.

Both statuses describe a transient capacity dip upstream rather than a bad request or a bad credential, and providers document them as retryable — Anthropic's [errors reference](https://docs.claude.com/en/api/errors) lists `529 overloaded_error` and asks clients to retry with backoff. The proxy already knows about `529`; `sdk/api/handlers/claude/code_handlers.go` maps it to `overloaded_error` when shaping the response, it just never retries it.

The existing hint-driven path cannot cover these, because unlike `429` they rarely carry a `Retry-After` header, so `retryAfterFromError` returns `nil` and the retry is dropped even if the status check is relaxed.

Measured on an Anthropic OAuth deployment: `529` accounted for ~0.4% of `claude-opus-5` requests over a day, and every one of them surfaced to the client unretried.

## Change

Add a transient-overload branch ahead of the `429` gate:

- applies to `503` and `529` only
- retries on the **same** credential — upstream capacity is not credential-specific, so rotation is deliberately not attempted and the quota/cooldown path above is left untouched
- bounded exponential backoff: `1s`, doubling, capped at `8s`, so a high `request-retry` cannot turn a capacity dip into a multi-minute stall
- still gated by `retryAllowed`, so `request-retry` and any per-auth `RequestRetryOverride` keep bounding the attempts
- still clamped to `maxWait` (`max-retry-interval`)

`429` behaviour is unchanged and still requires a `Retry-After` hint.

## Tests

New `sdk/cliproxy/auth/overload_retry_test.go` covers the retry decision, the backoff schedule and its cap, the `maxWait` clamp, `request-retry` bounding, that unrelated statuses (`400`, `401`, `500`, `502`) are untouched, and that `429` still needs its hint.

Without the source change 4 of the 6 fail; with it the package is green:

```
--- FAIL: TestShouldRetryAfterErrorRetriesTransientOverload
--- FAIL: TestShouldRetryAfterErrorOverloadBackoffDoublesAndCaps
--- FAIL: TestShouldRetryAfterErrorOverloadClampsToMaxWait
--- FAIL: TestShouldRetryAfterErrorOverloadHonoursRequestRetry
```

```
$ go test ./sdk/cliproxy/auth/
ok      github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth

$ gofmt -l sdk/cliproxy/auth/ && go vet ./sdk/cliproxy/auth/ && go build ./...
```

All pre-existing `shouldRetryAfterError` tests still pass.

## Notes for review

Two judgement calls worth a second opinion:

- **`8s` cap.** Chosen so `request-retry: 10` cannot produce a multi-minute stall. Happy to make it a config knob instead if you would rather not hard-code it.
- **Clamp vs reject at `maxWait`.** The `429` path *rejects* when `Retry-After` exceeds `maxWait`; this branch *clamps*, since the wait is self-computed rather than provider-supplied and rejecting our own backoff for exceeding a ceiling seemed wrong. Easy to flip for consistency if you prefer.