### PR TITLE
fix(codex): route priority stream requests from HTTP downstreams onto the websocket transport

### DIFF
--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -137,11 +137,13 @@ func (e *CodexAutoExecutor) UpstreamDisconnectChan(sessionID string) <-chan erro
 // bridged here. Only auths explicitly marked websockets=true participate.
 //
 // The function is intentionally side-effect free: it mirrors only the request
-// translation and payload-rule resolution needed for the routing decision,
-// while ExecuteStream keeps ownership of the complete websocket normalization
-// and session lifecycle.
+// translation, thinking application, and payload-rule resolution needed for the
+// routing decision — in the same order the HTTP and websocket executors resolve
+// the payload — while ExecuteStream keeps ownership of the complete websocket
+// normalization and session lifecycle. OpenAI image requests are excluded so
+// they keep their specialized HTTP execution path.
 func codexPriorityWebsocketEligible(cfg *config.Config, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) bool {
-	if !codexWebsocketsEnabled(auth) {
+	if !codexWebsocketsEnabled(auth) || isCodexOpenAIImageRequest(opts) {
 		return false
 	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
@@ -152,6 +154,10 @@ func codexPriorityWebsocketEligible(cfg *config.Config, auth *cliproxyauth.Auth,
 		originalPayload = opts.OriginalRequest
 	}
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, true)
+	body, errThinking := thinking.ApplyThinking(body, req.Model, from.String(), to.String(), "codex")
+	if errThinking != nil {
+		return false
+	}
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRequest(cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -149,6 +149,13 @@ func codexPriorityWebsocketEligible(cfg *config.Config, auth *cliproxyauth.Auth,
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("codex")
+	if !codexPayloadRulesConfigured(cfg) {
+		// Without payload rules the resolved tier equals the translated
+		// payload's tier: thinking application and image-generation filtering
+		// never touch service_tier, so the full resolution pass is skipped.
+		body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
+		return gjson.GetBytes(body, "service_tier").String() == "priority"
+	}
 	originalPayload := req.Payload
 	if len(opts.OriginalRequest) > 0 {
 		originalPayload = opts.OriginalRequest
@@ -162,6 +169,14 @@ func codexPriorityWebsocketEligible(cfg *config.Config, auth *cliproxyauth.Auth,
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRequest(cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	return gjson.GetBytes(body, "service_tier").String() == "priority"
+}
+
+func codexPayloadRulesConfigured(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	payload := cfg.Payload
+	return len(payload.Default) > 0 || len(payload.DefaultRaw) > 0 || len(payload.Override) > 0 || len(payload.OverrideRaw) > 0 || len(payload.Filter) > 0
 }
 
 func codexWebsocketsEnabled(auth *cliproxyauth.Auth) bool {

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -142,6 +142,15 @@ func (e *CodexAutoExecutor) UpstreamDisconnectChan(sessionID string) <-chan erro
 // the payload — while ExecuteStream keeps ownership of the complete websocket
 // normalization and session lifecycle. OpenAI image requests are excluded so
 // they keep their specialized HTTP execution path.
+//
+// The probe deliberately reuses the plugin-backed translation pipeline:
+// request-normalizer plugins (e.g. examples/plugin/codex-service-tier) inject
+// service_tier through those hooks, so bypassing them would hide plugin-set
+// priority from the routing decision. Normalize hooks already run more than
+// once per request via translateCodexRequestPair (original + active payload),
+// so idempotent hooks are an existing contract; if a hook still diverges
+// between probe and execution, only the transport choice is affected — the
+// payload sent upstream is always the executor's own resolution.
 func codexPriorityWebsocketEligible(cfg *config.Config, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) bool {
 	if !codexWebsocketsEnabled(auth) || isCodexOpenAIImageRequest(opts) {
 		return false

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -10,8 +10,12 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
 )
 
 // CodexWebsocketsExecutor executes Codex Responses requests using a WebSocket transport.
@@ -87,6 +91,9 @@ func (e *CodexAutoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyaut
 	if cliproxyexecutor.RequiredUpstreamWebsocket(ctx) {
 		return nil, cliproxyexecutor.NewUpstreamWebsocketReplayRequiredError()
 	}
+	if codexPriorityWebsocketEligible(e.wsExec.cfg, auth, req, opts) {
+		return e.wsExec.ExecuteStream(ctx, auth, req, opts)
+	}
 	return e.httpExec.ExecuteStream(ctx, auth, req, opts)
 }
 
@@ -116,6 +123,39 @@ func (e *CodexAutoExecutor) UpstreamDisconnectChan(sessionID string) <-chan erro
 		return nil
 	}
 	return e.wsExec.UpstreamDisconnectChan(sessionID)
+}
+
+// codexPriorityWebsocketEligible reports whether a streaming request from an
+// HTTP/SSE downstream should be routed to the upstream websocket transport
+// because its resolved payload requests service_tier=priority.
+//
+// The ChatGPT Codex backend applies priority (fast mode) scheduling only on the
+// Responses websocket transport; the same payload sent over HTTP POST is served
+// at the standard tier even though it carries service_tier=priority. The
+// official Codex CLI always uses the websocket transport, so priority requests
+// from HTTP downstreams silently lose their fast-mode intent unless they are
+// bridged here. Only auths explicitly marked websockets=true participate.
+//
+// The function is intentionally side-effect free: it mirrors only the request
+// translation and payload-rule resolution needed for the routing decision,
+// while ExecuteStream keeps ownership of the complete websocket normalization
+// and session lifecycle.
+func codexPriorityWebsocketEligible(cfg *config.Config, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) bool {
+	if !codexWebsocketsEnabled(auth) {
+		return false
+	}
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("codex")
+	originalPayload := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		originalPayload = opts.OriginalRequest
+	}
+	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, true)
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	requestPath := helps.PayloadRequestPath(opts)
+	body = helps.ApplyPayloadConfigWithRequest(cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
+	return gjson.GetBytes(body, "service_tier").String() == "priority"
 }
 
 func codexWebsocketsEnabled(auth *cliproxyauth.Auth) bool {

--- a/internal/runtime/executor/codex_websockets_executor_priority_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_priority_test.go
@@ -305,6 +305,72 @@ func TestCodexAutoExecutorDownstreamWebsocketDispatchUnchanged(t *testing.T) {
 	}
 }
 
+// A payload rule gated on reasoning.effort — materialized from a thinking
+// suffix such as "gpt-5.4(high)" — must be evaluated after ApplyThinking,
+// mirroring the order the HTTP and websocket executors resolve the payload.
+func TestCodexAutoExecutorThinkingSuffixPriorityRuleUsesUpstreamWebsocket(t *testing.T) {
+	transport := newCodexPriorityTransportTestServer(t)
+	exec := NewCodexAutoExecutor(&config.Config{
+		SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll},
+		Payload: config.PayloadConfig{Override: []config.PayloadRule{{
+			Models: []config.PayloadModelRule{{
+				Name:     "gpt-5.4",
+				Protocol: "codex",
+				Match:    []map[string]any{{"reasoning.effort": "high"}},
+			}},
+			Params: map[string]any{"service_tier": "priority"},
+		}}},
+	})
+	result, err := exec.ExecuteStream(context.Background(), transport.auth(true), cliproxyexecutor.Request{
+		Model:   "gpt-5.4(high)",
+		Payload: []byte(`{"model":"gpt-5.4(high)","input":"active"}`),
+	}, priorityStreamOptions())
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	drainCodexPriorityStream(t, result)
+
+	select {
+	case body := <-transport.wsBodies:
+		if got := gjson.GetBytes(body, "service_tier").String(); got != "priority" {
+			t.Fatalf("websocket service_tier = %q, want priority; body=%s", got, body)
+		}
+		if got := gjson.GetBytes(body, "reasoning.effort").String(); got != "high" {
+			t.Fatalf("websocket reasoning.effort = %q, want high; body=%s", got, body)
+		}
+		if got := gjson.GetBytes(body, "model").String(); got != "gpt-5.4" {
+			t.Fatalf("websocket model = %q, want gpt-5.4; body=%s", got, body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for thinking-suffix websocket request")
+	}
+	select {
+	case body := <-transport.httpBodies:
+		t.Fatalf("unexpected HTTP request: %s", body)
+	default:
+	}
+}
+
+// OpenAI image requests have a specialized HTTP execution path and must never
+// be routed onto the websocket transport, even when priority is requested.
+func TestCodexPriorityWebsocketEligibleExcludesImageRequests(t *testing.T) {
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"websockets": "true"}}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-image"),
+		Stream:       true,
+		Metadata: map[string]any{
+			cliproxyexecutor.RequestPathMetadataKey: "/v1/images/generations",
+		},
+	}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-image-2",
+		Payload: []byte(`{"model":"gpt-image-2","prompt":"a cat","service_tier":"priority"}`),
+	}
+	if codexPriorityWebsocketEligible(emptyPriorityTestConfig(), auth, req, opts) {
+		t.Fatal("image requests must stay on the specialized HTTP path")
+	}
+}
+
 // Non-streaming execution is intentionally out of scope for the priority
 // websocket bridge; this locks the dispatch so the change stays stream-only.
 func TestCodexAutoExecutorPriorityNonStreamExecuteUsesHTTP(t *testing.T) {

--- a/internal/runtime/executor/codex_websockets_executor_priority_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_priority_test.go
@@ -1,0 +1,328 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+// codexPriorityTransportTestServer accepts both websocket upgrades and plain
+// HTTP requests on the same address and records which transport served each
+// request, so tests can assert the CodexAutoExecutor dispatch decision.
+type codexPriorityTransportTestServer struct {
+	server     *httptest.Server
+	wsBodies   chan []byte
+	httpBodies chan []byte
+}
+
+func newCodexPriorityTransportTestServer(t *testing.T) *codexPriorityTransportTestServer {
+	t.Helper()
+	transport := &codexPriorityTransportTestServer{
+		wsBodies:   make(chan []byte, 4),
+		httpBodies: make(chan []byte, 4),
+	}
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	transport.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if websocket.IsWebSocketUpgrade(r) {
+			conn, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				t.Errorf("upgrade websocket: %v", err)
+				return
+			}
+			defer func() { _ = conn.Close() }()
+			_, body, err := conn.ReadMessage()
+			if err != nil {
+				t.Errorf("read websocket request: %v", err)
+				return
+			}
+			transport.wsBodies <- bytes.Clone(body)
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.completed","response":{"id":"resp_ws","output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`)); err != nil {
+				t.Errorf("write websocket completion: %v", err)
+			}
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read HTTP request: %v", err)
+			return
+		}
+		transport.httpBodies <- body
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_http\",\"output\":[],\"usage\":{\"input_tokens\":0,\"output_tokens\":0,\"total_tokens\":0}}}\n\n"))
+	}))
+	t.Cleanup(transport.server.Close)
+	return transport
+}
+
+func (s *codexPriorityTransportTestServer) auth(websockets bool) *cliproxyauth.Auth {
+	return &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":    "test",
+		"base_url":   s.server.URL,
+		"websockets": strconv.FormatBool(websockets),
+	}}
+}
+
+func drainCodexPriorityStream(t *testing.T, result *cliproxyexecutor.StreamResult) {
+	t.Helper()
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+	}
+}
+
+func priorityStreamOptions() cliproxyexecutor.Options {
+	return cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	}
+}
+
+func emptyPriorityTestConfig() *config.Config {
+	return &config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}}
+}
+
+func TestCodexAutoExecutorPriorityPayloadUsesUpstreamWebsocket(t *testing.T) {
+	transport := newCodexPriorityTransportTestServer(t)
+	exec := NewCodexAutoExecutor(emptyPriorityTestConfig())
+	result, err := exec.ExecuteStream(context.Background(), transport.auth(true), cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":"active","service_tier":"priority","previous_response_id":"resp_previous"}`),
+	}, priorityStreamOptions())
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	drainCodexPriorityStream(t, result)
+
+	select {
+	case body := <-transport.wsBodies:
+		if got := gjson.GetBytes(body, "type").String(); got != "response.create" {
+			t.Fatalf("websocket request type = %q, want response.create; body=%s", got, body)
+		}
+		if got := gjson.GetBytes(body, "service_tier").String(); got != "priority" {
+			t.Fatalf("websocket service_tier = %q, want priority; body=%s", got, body)
+		}
+		if got := gjson.GetBytes(body, "model").String(); got != "gpt-5.4" {
+			t.Fatalf("websocket model = %q, want gpt-5.4; body=%s", got, body)
+		}
+		if got := gjson.GetBytes(body, "input.0.content.0.text").String(); got != "active" {
+			t.Fatalf("websocket input = %q, want active translated payload; body=%s", got, body)
+		}
+		if got := gjson.GetBytes(body, "previous_response_id").String(); got != "resp_previous" {
+			t.Fatalf("websocket previous_response_id = %q, want preserved ID; body=%s", got, body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for websocket priority request")
+	}
+	select {
+	case body := <-transport.httpBodies:
+		t.Fatalf("unexpected HTTP request: %s", body)
+	default:
+	}
+}
+
+// This mirrors the payload-override recipe shipped in config.example.yaml
+// (gpt-5.4-fast -> service_tier: priority) and verifies the resolved rule
+// routes the request onto the upstream websocket transport.
+func TestCodexAutoExecutorExampleFastAliasOverrideUsesUpstreamWebsocket(t *testing.T) {
+	transport := newCodexPriorityTransportTestServer(t)
+	exec := NewCodexAutoExecutor(&config.Config{
+		SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll},
+		Payload: config.PayloadConfig{Default: []config.PayloadRule{{
+			Models: []config.PayloadModelRule{{Name: "gpt-5.4-fast", Protocol: "codex"}},
+			Params: map[string]any{"service_tier": "priority"},
+		}}},
+	})
+	opts := priorityStreamOptions()
+	opts.Metadata = map[string]any{cliproxyexecutor.RequestedModelMetadataKey: "gpt-5.4-fast"}
+	opts.OriginalRequest = []byte(`{"model":"gpt-5.4-fast","input":"original"}`)
+	result, err := exec.ExecuteStream(context.Background(), transport.auth(true), cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":"active"}`),
+	}, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	drainCodexPriorityStream(t, result)
+
+	select {
+	case body := <-transport.wsBodies:
+		if got := gjson.GetBytes(body, "service_tier").String(); got != "priority" {
+			t.Fatalf("websocket service_tier = %q, want priority; body=%s", got, body)
+		}
+		if got := gjson.GetBytes(body, "model").String(); got != "gpt-5.4" {
+			t.Fatalf("websocket model = %q, want resolved gpt-5.4; body=%s", got, body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for websocket override request")
+	}
+	select {
+	case body := <-transport.httpBodies:
+		t.Fatalf("unexpected HTTP request: %s", body)
+	default:
+	}
+}
+
+// This mirrors Claude ingress and verifies a from-protocol: claude override is
+// applied before the transport eligibility decision.
+func TestCodexAutoExecutorClaudePriorityOverrideUsesUpstreamWebsocket(t *testing.T) {
+	transport := newCodexPriorityTransportTestServer(t)
+	exec := NewCodexAutoExecutor(&config.Config{
+		SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll},
+		Payload: config.PayloadConfig{Override: []config.PayloadRule{{
+			Models: []config.PayloadModelRule{{
+				Name:         "gpt-5.4",
+				Protocol:     "codex",
+				FromProtocol: "claude",
+			}},
+			Params: map[string]any{"service_tier": "priority"},
+		}}},
+	})
+	originalRequest := []byte(`{"model":"gpt-5.4","max_tokens":64,"stream":true,"messages":[{"role":"user","content":"original"}]}`)
+	opts := cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FromString("claude"),
+		OriginalRequest: originalRequest,
+		Stream:          true,
+	}
+	result, err := exec.ExecuteStream(context.Background(), transport.auth(true), cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","max_tokens":64,"stream":true,"messages":[{"role":"user","content":"active"}]}`),
+	}, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	drainCodexPriorityStream(t, result)
+
+	select {
+	case body := <-transport.wsBodies:
+		if got := gjson.GetBytes(body, "service_tier").String(); got != "priority" {
+			t.Fatalf("websocket service_tier = %q, want priority; body=%s", got, body)
+		}
+		if got := gjson.GetBytes(body, "input.0.content.0.text").String(); got != "active" {
+			t.Fatalf("websocket input = %q, want active Claude message; body=%s", got, body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Claude websocket priority request")
+	}
+	select {
+	case body := <-transport.httpBodies:
+		t.Fatalf("unexpected HTTP request: %s", body)
+	default:
+	}
+}
+
+func TestCodexAutoExecutorStandardStreamUsesHTTP(t *testing.T) {
+	transport := newCodexPriorityTransportTestServer(t)
+	exec := NewCodexAutoExecutor(emptyPriorityTestConfig())
+	result, err := exec.ExecuteStream(context.Background(), transport.auth(true), cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":"hello"}`),
+	}, priorityStreamOptions())
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	drainCodexPriorityStream(t, result)
+
+	select {
+	case body := <-transport.httpBodies:
+		if gjson.GetBytes(body, "service_tier").Exists() {
+			t.Fatalf("unexpected HTTP service_tier: %s", body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for HTTP request")
+	}
+	select {
+	case body := <-transport.wsBodies:
+		t.Fatalf("unexpected websocket request: %s", body)
+	default:
+	}
+}
+
+func TestCodexAutoExecutorPriorityWithoutWebsocketsAttributeUsesHTTP(t *testing.T) {
+	transport := newCodexPriorityTransportTestServer(t)
+	exec := NewCodexAutoExecutor(emptyPriorityTestConfig())
+	result, err := exec.ExecuteStream(context.Background(), transport.auth(false), cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":"hello","service_tier":"priority"}`),
+	}, priorityStreamOptions())
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	drainCodexPriorityStream(t, result)
+
+	select {
+	case body := <-transport.httpBodies:
+		if got := gjson.GetBytes(body, "service_tier").String(); got != "priority" {
+			t.Fatalf("HTTP service_tier = %q, want priority; body=%s", got, body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for HTTP request")
+	}
+	select {
+	case body := <-transport.wsBodies:
+		t.Fatalf("unexpected websocket request: %s", body)
+	default:
+	}
+}
+
+func TestCodexAutoExecutorDownstreamWebsocketDispatchUnchanged(t *testing.T) {
+	transport := newCodexPriorityTransportTestServer(t)
+	exec := NewCodexAutoExecutor(emptyPriorityTestConfig())
+	result, err := exec.ExecuteStream(cliproxyexecutor.WithDownstreamWebsocket(context.Background()), transport.auth(true), cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":"hello","previous_response_id":"resp_previous"}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response"), Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	drainCodexPriorityStream(t, result)
+
+	select {
+	case body := <-transport.wsBodies:
+		if got := gjson.GetBytes(body, "previous_response_id").String(); got != "resp_previous" {
+			t.Fatalf("downstream websocket previous_response_id = %q, want preserved ID; body=%s", got, body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for downstream websocket request")
+	}
+	select {
+	case body := <-transport.httpBodies:
+		t.Fatalf("unexpected HTTP request: %s", body)
+	default:
+	}
+}
+
+// Non-streaming execution is intentionally out of scope for the priority
+// websocket bridge; this locks the dispatch so the change stays stream-only.
+func TestCodexAutoExecutorPriorityNonStreamExecuteUsesHTTP(t *testing.T) {
+	transport := newCodexPriorityTransportTestServer(t)
+	exec := NewCodexAutoExecutor(emptyPriorityTestConfig())
+	_, _ = exec.Execute(context.Background(), transport.auth(true), cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":"hello","service_tier":"priority"}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response")})
+
+	select {
+	case <-transport.httpBodies:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for HTTP request")
+	}
+	select {
+	case body := <-transport.wsBodies:
+		t.Fatalf("unexpected websocket request: %s", body)
+	default:
+	}
+}


### PR DESCRIPTION
Fixes #4586

## Problem

The ChatGPT Codex backend applies priority (fast mode) scheduling only on the Responses websocket transport. The same payload sent over HTTP POST `/responses` is accepted but served at the standard tier. Measured on one Team OAuth credential with a fixed workload: websocket + `service_tier=priority` runs at **1.55×** standard throughput (85.0 vs 54.9 TPS, matching the official fast-mode description), while HTTP POST + `service_tier=priority` runs at **0.97×** — no effect.

`CodexAutoExecutor.ExecuteStream` selects the websocket executor only when the downstream itself is a websocket. Every HTTP/SSE downstream (OpenAI-compat, Claude, Gemini format clients) therefore always takes the HTTP upstream, and any priority intent — whether sent by the client, injected via the `config.example.yaml` `gpt-5.4-fast`/`gpt-5.5-fast` payload-override example, or set by the `examples/plugin/codex-service-tier` plugin — is silently lost. Users cannot observe this because the upstream echoes `service_tier: default/auto` unconditionally (#1933, #4355).

Full analysis and measurements: #4586.

## Change

When a streaming request from an HTTP/SSE downstream **resolves to `service_tier: "priority"`** (after request translation and payload-rule application — the same resolution the HTTP executor performs) **and the selected auth has `websockets: true`**, dispatch it to the existing `CodexWebsocketsExecutor` instead of the HTTP executor.

- `codexPriorityWebsocketEligible` is side-effect free and mirrors only the translation + payload-rule resolution needed for the routing decision; the websocket executor keeps full ownership of normalization and session lifecycle, so the websocket path behaves exactly as it does for downstream-websocket clients today.
- No new config key. Both gating signals already exist and default to off: auths without `websockets: true` and requests without resolved priority are completely unaffected.
- Dispatch order is unchanged for existing branches: downstream-websocket first, then the replay-required guard, then the new priority check, then HTTP.

Out of scope (unchanged on purpose): non-streaming `Execute`, downstream-websocket dispatch, `CountTokens`, `/responses/compact`, auth selection/scheduling. This PR intentionally contains only the stream dispatch change and its regression tests.

Relationship to #3562: that PR proposes a config-gated general preference for the upstream websocket on all Responses requests. This change is narrower and orthogonal — it only bridges the specific case where the transport determines whether the requested tier is honored at all. If maintainers prefer this behind a config key as well, happy to adjust.

## Tests

`internal/runtime/executor/codex_websockets_executor_priority_test.go` — a dual-transport `httptest` server (websocket upgrade + HTTP on one address) asserts the dispatch decision:

- client-sent `service_tier: priority` (openai-responses) → websocket, payload intact (`response.create`, model, input, `previous_response_id`)
- the `config.example.yaml` fast-alias payload-override recipe → websocket
- `from-protocol: claude` override → websocket (Claude ingress)
- no priority → HTTP (no behavior change)
- priority but auth `websockets: false` → HTTP with `service_tier` preserved (no behavior change)
- downstream websocket dispatch unchanged
- non-streaming `Execute` with priority stays on HTTP (locks the stream-only scope)

## Validation

```bash
gofmt -l internal/runtime/executor/codex_websockets_executor.go internal/runtime/executor/codex_websockets_executor_priority_test.go
go build -o test-output ./cmd/server && rm test-output
go test ./internal/runtime/executor/ -count=1
go test ./sdk/api/handlers/openai/ ./sdk/cliproxy/... -count=1
```

All pass locally (Go 1.26.0). Production soak: this change (in site-patch form) has been serving real Claude Code traffic through a New API → CLIProxyAPI chain since 2026-07-25; 3×3 alternating benchmark through the full chain reproduces 1.55× (Fast 85.8/83.4/85.8 vs Standard 51.4/56.7/56.7 TPS), with upstream websocket hits confirmed in logs for every priority request and zero regressions on standard traffic.
