### PR TITLE
fix(sdk): preserve custom executors during auth sync

### DIFF
--- a/internal/pluginhost/adapters_executors.go
+++ b/internal/pluginhost/adapters_executors.go
@@ -347,6 +347,11 @@ func (h *Host) HasExecutorCandidateProvider(provider string) bool {
 	return false
 }
 
+// OwnsExecutor reports whether executor is an adapter managed by this host.
+func (h *Host) OwnsExecutor(executor coreauth.ProviderExecutor) bool {
+	return h.ownsExecutor(executor)
+}
+
 func (h *Host) ownsExecutor(executor coreauth.ProviderExecutor) bool {
 	adapter, okAdapter := executor.(*executorAdapter)
 	return okAdapter && adapter != nil && adapter.host == h

--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -904,6 +904,23 @@ func TestRegisterExecutorsPrunesStaleProviderAfterMigration(t *testing.T) {
 	}
 }
 
+func TestOwnsExecutorDistinguishesHostAdapters(t *testing.T) {
+	host := New()
+	owned := &executorAdapter{host: host}
+	foreign := &executorAdapter{host: New()}
+	external := &fakeProviderExecutor{provider: "provider-a"}
+
+	if !host.OwnsExecutor(owned) {
+		t.Fatal("host did not recognize its executor adapter")
+	}
+	if host.OwnsExecutor(foreign) {
+		t.Fatal("host claimed another host's executor adapter")
+	}
+	if host.OwnsExecutor(external) {
+		t.Fatal("host claimed an externally owned executor")
+	}
+}
+
 func TestRegisterExecutorsDoesNotUnregisterStaleProviderOwnedExternally(t *testing.T) {
 	manager := newFakeExecutorManager()
 	exec := &fakeExecutor{identifier: "fallback-provider"}

--- a/sdk/cliproxy/service_executor_registration_test.go
+++ b/sdk/cliproxy/service_executor_registration_test.go
@@ -13,6 +13,9 @@ import (
 )
 
 type serviceTestPluginExecutor struct{}
+type serviceTestSDKExecutor struct{ serviceTestPluginExecutor }
+
+func (serviceTestSDKExecutor) Identifier() string { return "sdk-provider" }
 
 func (serviceTestPluginExecutor) Identifier() string {
 	return "plugin-provider"
@@ -98,6 +101,32 @@ func TestRegisterAvailableExecutors(t *testing.T) {
 	resolved, _ := service.coreManager.Executor("plugin-provider")
 	if _, isPlugin := resolved.(serviceTestPluginExecutor); !isPlugin {
 		t.Fatalf("executor type = %T, want serviceTestPluginExecutor", resolved)
+	}
+}
+
+func TestSyncPluginModelRuntimePreservesSDKExecutorUnlessForced(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	custom := serviceTestSDKExecutor{}
+	manager.RegisterExecutor(custom)
+	auth := &coreauth.Auth{ID: "private-auth", Provider: custom.Identifier()}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatal(err)
+	}
+	service := &Service{cfg: &config.Config{}, coreManager: manager, pluginHost: pluginhost.New()}
+
+	service.syncPluginModelRuntime(context.Background())
+	got, ok := manager.Executor(custom.Identifier())
+	if !ok || got != custom {
+		t.Fatalf("plugin model sync replaced SDK executor with %T", got)
+	}
+
+	service.registerExecutorForAuth(auth, true)
+	got, ok = manager.Executor(custom.Identifier())
+	if !ok {
+		t.Fatal("forced registration removed executor")
+	}
+	if _, replaced := got.(*runtimeexecutor.OpenAICompatExecutor); !replaced {
+		t.Fatalf("forced registration kept %T, want *executor.OpenAICompatExecutor", got)
 	}
 }
 

--- a/sdk/cliproxy/service_executors.go
+++ b/sdk/cliproxy/service_executors.go
@@ -303,10 +303,9 @@ func (s *Service) registerExecutorForAuth(a *coreauth.Auth, forceReplace bool) {
 			return
 		}
 		if !forceReplace {
-			if existingExecutor, hasExecutor := s.coreManager.Executor(providerKey); hasExecutor {
-				if _, isOpenAICompatExecutor := existingExecutor.(*executor.OpenAICompatExecutor); isOpenAICompatExecutor {
-					return
-				}
+			if existingExecutor, hasExecutor := s.coreManager.Executor(providerKey); hasExecutor &&
+				(s.pluginHost == nil || !s.pluginHost.OwnsExecutor(existingExecutor)) {
+				return
 			}
 		}
 		s.coreManager.RegisterExecutor(executor.NewOpenAICompatExecutor(providerKey, cfg))


### PR DESCRIPTION
## Summary

- preserve externally owned SDK executors during nonforced auth synchronization
- keep stale plugin-owned executor cleanup and forced replacement unchanged
- add regression tests for plugin model synchronization and executor ownership

## Problem

An SDK caller can register a custom `ProviderExecutor` before starting the
service. During plugin model synchronization, the service processes auth records
again. For an unknown provider, `registerExecutorForAuth` replaces the caller's
executor with `OpenAICompatExecutor`, even when `forceReplace` is false.

The replacement has no matching OpenAI compatibility configuration, so requests
can fail with `missing provider baseURL` instead of reaching the registered SDK
executor.

## Change

For unknown providers, nonforced synchronization now keeps an executor that is
owned outside the plugin host. A stale plugin-owned adapter still falls through
to the OpenAI-compatible fallback before plugin cleanup removes that adapter.
Forced registration also remains unchanged.

The lifecycle regression test exercises `syncPluginModelRuntime`, which is the
path that exposed the replacement. Ownership tests distinguish adapters managed
by the current plugin host from external executors and adapters owned by another
host.

## Validation

- the lifecycle regression test fails before the fix with
  `*executor.OpenAICompatExecutor` and passes after the fix
- `go test ./internal/pluginhost -run 'TestOwnsExecutorDistinguishesHostAdapters|TestRegisterExecutorsPrunesStaleProviderAfterMigration|TestRegisterExecutorsDoesNotUnregisterStaleProviderOwnedExternally' -count=1`
- `go test ./sdk/cliproxy/... -count=1`
- `go vet ./sdk/cliproxy/...`
- `go build ./...`
- a downstream SDK composition passes its unary, streaming, cancellation, and
  timeout protocol matrix with this commit

## Downside

The plugin host now exposes an ownership query to the SDK service. This keeps the
preservation rule narrow, but it adds one method to the internal host boundary.
