### PR TITLE
fix(antigravity): ignore staged Hub versions for UA spoofing

### DIFF
--- a/internal/misc/antigravity_version.go
+++ b/internal/misc/antigravity_version.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -30,6 +31,16 @@ var (
 
 type antigravityHubUpdaterManifest struct {
 	Version string `yaml:"version"`
+	// StagingPercentage is kept as a raw node because upstream manifests are not
+	// guaranteed to use a plain integer, and a malformed value must not discard an
+	// otherwise valid version. See parseAntigravityStagingPercentage.
+	StagingPercentage yaml.Node `yaml:"stagingPercentage"`
+}
+
+// antigravityVersionCandidate is a parsed Hub updater manifest after validation.
+type antigravityVersionCandidate struct {
+	version           string
+	stagingPercentage *int
 }
 
 var (
@@ -70,7 +81,7 @@ func runAntigravityVersionUpdater(ctx context.Context) {
 }
 
 func refreshAntigravityVersion(ctx context.Context) {
-	version, errFetch := fetchAntigravityLatestVersion(ctx)
+	candidate, errFetch := fetchAntigravityLatestVersion(ctx)
 
 	antigravityVersionMu.Lock()
 	defer antigravityVersionMu.Unlock()
@@ -78,9 +89,27 @@ func refreshAntigravityVersion(ctx context.Context) {
 	now := time.Now()
 
 	if errFetch == nil {
-		cachedAntigravityVersion = version
+		// Align with electron-updater staged rollout: clients always see the latest
+		// manifest version, but only fully released builds are adopted for UA spoofing.
+		released, stagingPercentage := antigravityManifestIsClientReleased(candidate.stagingPercentage)
+		if !released {
+			antigravityVersionExpiry = now.Add(antigravityVersionCacheTTL)
+			fields := log.Fields{
+				"version":            candidate.version,
+				"staging_percentage": stagingPercentage,
+				"cached_version":     cachedAntigravityVersion,
+			}
+			if cachedAntigravityVersion == "" {
+				cachedAntigravityVersion = antigravityFallbackVersion
+				fields["cached_version"] = cachedAntigravityVersion
+			}
+			log.WithFields(fields).Info("antigravity Hub latest is still staged; keeping client-aligned version")
+			return
+		}
+
+		cachedAntigravityVersion = candidate.version
 		antigravityVersionExpiry = now.Add(antigravityVersionCacheTTL)
-		log.WithField("version", version).Info("fetched latest antigravity version")
+		log.WithField("version", candidate.version).Info("fetched latest antigravity version")
 		return
 	}
 
@@ -92,6 +121,62 @@ func refreshAntigravityVersion(ctx context.Context) {
 	}
 
 	log.WithError(errFetch).Debug("failed to refresh antigravity version, keeping cached value")
+}
+
+// antigravityManifestIsClientReleased reports whether a Hub updater manifest should
+// be treated as generally available to real clients, along with the effective rollout
+// percentage behind the decision (100 when the manifest omits stagingPercentage).
+// Returning the percentage keeps callers from dereferencing the pointer themselves.
+//
+// electron-updater always fetches the latest.yml entry, but only installs it when
+// stagingPercentage is absent/fully rolled out, or the local .updaterId is inside
+// the staged cohort. CPA cannot honestly claim membership in a minority staged
+// cohort for all traffic, so only fully released versions are used for UA imitation.
+func antigravityManifestIsClientReleased(stagingPercentage *int) (bool, int) {
+	if stagingPercentage == nil {
+		return true, 100
+	}
+	return *stagingPercentage >= 100, *stagingPercentage
+}
+
+// parseAntigravityStagingPercentage interprets the manifest stagingPercentage field
+// the way electron-updater does: the raw value goes through an integer parse, and an
+// unusable value is warned about rather than treated as fatal. Returning nil means
+// "no staged rollout", i.e. the version is fully released.
+//
+// Values are clamped instead of rejected because electron-updater compares a
+// per-install ratio against stagingPercentage/100: anything above 100 matches every
+// client, and anything below 0 matches none. Rejecting the manifest instead would
+// throw away a version that already passed validation.
+func parseAntigravityStagingPercentage(node yaml.Node) *int {
+	// Kind 0 means the key was absent; !!null means it was present but empty.
+	if node.Kind == 0 || node.Tag == "!!null" {
+		return nil
+	}
+
+	raw := strings.TrimSpace(node.Value)
+	if raw == "" {
+		log.Warn("antigravity Hub updater manifest has a non-scalar stagingPercentage; treating version as fully released")
+		return nil
+	}
+
+	parsed, errParse := strconv.ParseFloat(raw, 64)
+	if errParse != nil {
+		log.WithField("staging_percentage", raw).Warn("antigravity Hub updater manifest has an unparsable stagingPercentage; treating version as fully released")
+		return nil
+	}
+
+	percentage := int(parsed)
+	switch {
+	case percentage > 100:
+		log.WithField("staging_percentage", raw).Warn("antigravity Hub updater manifest stagingPercentage above 100; clamping to 100")
+		percentage = 100
+	case percentage < 0:
+		log.WithField("staging_percentage", raw).Warn("antigravity Hub updater manifest stagingPercentage below 0; clamping to 0")
+		percentage = 0
+	}
+
+	return &percentage
 }
 
 // AntigravityLatestVersion returns the cached antigravity version refreshed by StartAntigravityVersionUpdater.
@@ -194,7 +279,7 @@ func AntigravityVersionFromUserAgent(userAgent string) string {
 	return rest
 }
 
-func fetchAntigravityLatestVersion(ctx context.Context) (string, error) {
+func fetchAntigravityLatestVersion(ctx context.Context) (antigravityVersionCandidate, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -203,17 +288,17 @@ func fetchAntigravityLatestVersion(ctx context.Context) (string, error) {
 	return fetchAntigravityHubLatestManifestVersion(ctx, client)
 }
 
-func fetchAntigravityHubLatestManifestVersion(ctx context.Context, client *http.Client) (string, error) {
+func fetchAntigravityHubLatestManifestVersion(ctx context.Context, client *http.Client) (antigravityVersionCandidate, error) {
 	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodGet, antigravityHubLatestManifestURL, nil)
 	if errReq != nil {
-		return "", fmt.Errorf("build antigravity Hub updater manifest request: %w", errReq)
+		return antigravityVersionCandidate{}, fmt.Errorf("build antigravity Hub updater manifest request: %w", errReq)
 	}
 	httpReq.Header.Set("User-Agent", "electron-builder")
 	httpReq.Header.Set("Cache-Control", "no-cache")
 
 	resp, errDo := client.Do(httpReq)
 	if errDo != nil {
-		return "", fmt.Errorf("fetch antigravity Hub updater manifest: %w", errDo)
+		return antigravityVersionCandidate{}, fmt.Errorf("fetch antigravity Hub updater manifest: %w", errDo)
 	}
 	defer func() {
 		if errClose := resp.Body.Close(); errClose != nil {
@@ -222,27 +307,30 @@ func fetchAntigravityHubLatestManifestVersion(ctx context.Context, client *http.
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("antigravity Hub updater manifest returned status %d", resp.StatusCode)
+		return antigravityVersionCandidate{}, fmt.Errorf("antigravity Hub updater manifest returned status %d", resp.StatusCode)
 	}
 
 	raw, errRead := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if errRead != nil {
-		return "", fmt.Errorf("read antigravity Hub updater manifest: %w", errRead)
+		return antigravityVersionCandidate{}, fmt.Errorf("read antigravity Hub updater manifest: %w", errRead)
 	}
 
 	var manifest antigravityHubUpdaterManifest
 	if errDecode := yaml.Unmarshal(raw, &manifest); errDecode != nil {
-		return "", fmt.Errorf("decode antigravity Hub updater manifest: %w", errDecode)
+		return antigravityVersionCandidate{}, fmt.Errorf("decode antigravity Hub updater manifest: %w", errDecode)
 	}
 
 	version := strings.TrimSpace(manifest.Version)
 	if version == "" {
-		return "", errors.New("antigravity Hub updater manifest returned empty version")
+		return antigravityVersionCandidate{}, errors.New("antigravity Hub updater manifest returned empty version")
 	}
 	if !isValidAntigravitySemVersion(version) {
-		return "", fmt.Errorf("antigravity Hub updater manifest returned invalid version %q", version)
+		return antigravityVersionCandidate{}, fmt.Errorf("antigravity Hub updater manifest returned invalid version %q", version)
 	}
-	return version, nil
+	return antigravityVersionCandidate{
+		version:           version,
+		stagingPercentage: parseAntigravityStagingPercentage(manifest.StagingPercentage),
+	}, nil
 }
 
 func isValidAntigravitySemVersion(version string) bool {

--- a/internal/misc/antigravity_version_test.go
+++ b/internal/misc/antigravity_version_test.go
@@ -113,12 +113,37 @@ func TestFetchAntigravityLatestVersionUsesHubManifest(t *testing.T) {
 	restore := overrideAntigravityVersionURLsForTest(t, server.URL+"/hub/latest-arm64-mac.yml")
 	defer restore()
 
-	version, errFetch := fetchAntigravityLatestVersion(context.Background())
+	candidate, errFetch := fetchAntigravityLatestVersion(context.Background())
 	if errFetch != nil {
 		t.Fatalf("fetchAntigravityLatestVersion() error = %v", errFetch)
 	}
-	if version != "2.2.1" {
-		t.Fatalf("fetchAntigravityLatestVersion() = %q, want %q", version, "2.2.1")
+	if candidate.version != "2.2.1" {
+		t.Fatalf("fetchAntigravityLatestVersion() version = %q, want %q", candidate.version, "2.2.1")
+	}
+	if candidate.stagingPercentage != nil {
+		t.Fatalf("fetchAntigravityLatestVersion() stagingPercentage = %v, want nil", *candidate.stagingPercentage)
+	}
+}
+
+func TestFetchAntigravityLatestVersionParsesStagingPercentage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = w.Write([]byte("version: 2.4.2\nstagingPercentage: 10\npath: Antigravity-arm64-mac.zip\n"))
+	}))
+	defer server.Close()
+
+	restore := overrideAntigravityVersionURLsForTest(t, server.URL+"/hub/latest-arm64-mac.yml")
+	defer restore()
+
+	candidate, errFetch := fetchAntigravityLatestVersion(context.Background())
+	if errFetch != nil {
+		t.Fatalf("fetchAntigravityLatestVersion() error = %v", errFetch)
+	}
+	if candidate.version != "2.4.2" {
+		t.Fatalf("version = %q, want %q", candidate.version, "2.4.2")
+	}
+	if candidate.stagingPercentage == nil || *candidate.stagingPercentage != 10 {
+		t.Fatalf("stagingPercentage = %v, want 10", candidate.stagingPercentage)
 	}
 }
 
@@ -134,5 +159,130 @@ func TestFetchAntigravityLatestVersionReturnsHubManifestError(t *testing.T) {
 	_, errFetch := fetchAntigravityLatestVersion(context.Background())
 	if errFetch == nil {
 		t.Fatal("fetchAntigravityLatestVersion() error = nil, want error")
+	}
+}
+
+func TestAntigravityManifestIsClientReleased(t *testing.T) {
+	intPtr := func(v int) *int { return &v }
+
+	cases := []struct {
+		name              string
+		stagingPercentage *int
+		wantReleased      bool
+		wantPercentage    int
+	}{
+		{name: "absent", stagingPercentage: nil, wantReleased: true, wantPercentage: 100},
+		{name: "full", stagingPercentage: intPtr(100), wantReleased: true, wantPercentage: 100},
+		{name: "partial", stagingPercentage: intPtr(10), wantReleased: false, wantPercentage: 10},
+		{name: "zero", stagingPercentage: intPtr(0), wantReleased: false, wantPercentage: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			released, percentage := antigravityManifestIsClientReleased(tc.stagingPercentage)
+			if released != tc.wantReleased {
+				t.Fatalf("released = %v, want %v", released, tc.wantReleased)
+			}
+			if percentage != tc.wantPercentage {
+				t.Fatalf("percentage = %d, want %d", percentage, tc.wantPercentage)
+			}
+		})
+	}
+}
+
+func TestFetchAntigravityLatestVersionToleratesOddStagingPercentage(t *testing.T) {
+	intPtr := func(v int) *int { return &v }
+
+	cases := []struct {
+		name string
+		body string
+		want *int
+	}{
+		{name: "quoted integer", body: "version: 2.4.2\nstagingPercentage: \"10\"\n", want: intPtr(10)},
+		{name: "float truncates", body: "version: 2.4.2\nstagingPercentage: 99.9\n", want: intPtr(99)},
+		{name: "above range clamps", body: "version: 2.4.2\nstagingPercentage: 150\n", want: intPtr(100)},
+		{name: "below range clamps", body: "version: 2.4.2\nstagingPercentage: -5\n", want: intPtr(0)},
+		{name: "garbage ignored", body: "version: 2.4.2\nstagingPercentage: soon\n", want: nil},
+		{name: "empty ignored", body: "version: 2.4.2\nstagingPercentage:\n", want: nil},
+		{name: "non-scalar ignored", body: "version: 2.4.2\nstagingPercentage:\n  mac: 10\n", want: nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/yaml")
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+
+			restore := overrideAntigravityVersionURLsForTest(t, server.URL+"/hub/latest-arm64-mac.yml")
+			defer restore()
+
+			candidate, errFetch := fetchAntigravityLatestVersion(context.Background())
+			if errFetch != nil {
+				t.Fatalf("fetchAntigravityLatestVersion() error = %v, want the version to survive a malformed stagingPercentage", errFetch)
+			}
+			if candidate.version != "2.4.2" {
+				t.Fatalf("version = %q, want %q", candidate.version, "2.4.2")
+			}
+			switch {
+			case tc.want == nil && candidate.stagingPercentage != nil:
+				t.Fatalf("stagingPercentage = %d, want nil", *candidate.stagingPercentage)
+			case tc.want != nil && candidate.stagingPercentage == nil:
+				t.Fatalf("stagingPercentage = nil, want %d", *tc.want)
+			case tc.want != nil && *candidate.stagingPercentage != *tc.want:
+				t.Fatalf("stagingPercentage = %d, want %d", *candidate.stagingPercentage, *tc.want)
+			}
+		})
+	}
+}
+
+func TestRefreshAntigravityVersionKeepsStableWhenLatestIsStaged(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = w.Write([]byte("version: 2.4.2\nstagingPercentage: 10\npath: Antigravity-arm64-mac.zip\n"))
+	}))
+	defer server.Close()
+
+	restoreURL := overrideAntigravityVersionURLsForTest(t, server.URL+"/hub/latest-arm64-mac.yml")
+	defer restoreURL()
+	// Seed a cached version that differs from antigravityFallbackVersion, otherwise
+	// "kept the cached value" and "silently fell back" are indistinguishable.
+	restoreCache := overrideAntigravityVersionCacheForTest(t, "2.3.0", time.Time{})
+	defer restoreCache()
+
+	before := time.Now()
+	refreshAntigravityVersion(context.Background())
+
+	if got := AntigravityLatestVersion(); got != "2.3.0" {
+		t.Fatalf("AntigravityLatestVersion() = %q, want %q while latest is staged", got, "2.3.0")
+	}
+
+	// The staged path must also extend the cache window; otherwise the next
+	// AntigravityLatestVersion() call reads the stale cache and returns the fallback.
+	antigravityVersionMu.RLock()
+	expiry := antigravityVersionExpiry
+	antigravityVersionMu.RUnlock()
+	if !expiry.After(before) {
+		t.Fatalf("antigravityVersionExpiry = %v, want it extended past %v", expiry, before)
+	}
+}
+
+func TestRefreshAntigravityVersionAdoptsFullyReleasedLatest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = w.Write([]byte("version: 2.4.2\nstagingPercentage: 100\npath: Antigravity-arm64-mac.zip\n"))
+	}))
+	defer server.Close()
+
+	restoreURL := overrideAntigravityVersionURLsForTest(t, server.URL+"/hub/latest-arm64-mac.yml")
+	defer restoreURL()
+	restoreCache := overrideAntigravityVersionCacheForTest(t, "2.2.1", time.Time{})
+	defer restoreCache()
+
+	refreshAntigravityVersion(context.Background())
+
+	if got := AntigravityLatestVersion(); got != "2.4.2" {
+		t.Fatalf("AntigravityLatestVersion() = %q, want %q after full release", got, "2.4.2")
 	}
 }


### PR DESCRIPTION
## Summary
- Parse Hub auto-updater `latest.yml` `stagingPercentage` alongside `version`.
- Adopt a fetched version for Antigravity UA spoofing only when the release is generally available (`stagingPercentage` absent or `>= 100`).
- While a version is still staged, keep the previous client-aligned cache and extend its TTL so request UAs do not jump ahead of real Hub installs (currently `2.4.2` is at 10% staging while most clients remain on `2.2.1`).

## Context
The Hub updater always returns the latest candidate manifest. electron-updater clients only install it when they are in the staged cohort (or the release is fully rolled out). CPA previously treated `version` as immediately usable for UA imitation, which could advertise a still-staged build.

## Test plan
- [x] `go test ./internal/misc/ -count=1 -run 'Antigravity|FetchAntigravity|RefreshAntigravity'`
- [x] Covered: absent/full/partial/zero staging, odd parse forms, staged refresh keeps stable + TTL, full release adopts latest
- [ ] Confirm live Hub `latest-arm64-mac.yml` still reports staged latest and CPA UA remains on last fully released/fallback version after deploy