### PR TITLE
fix(responses): drop nonstandard keepalive events

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -107,6 +107,11 @@ func (f *responsesSSEFramer) repairFrame(frame []byte) []byte {
 	}
 
 	switch gjson.GetBytes(payload, "type").String() {
+	case "keepalive":
+		// The Codex backend may emit proprietary heartbeat events that are not
+		// part of the public Responses event schema. Drop the complete SSE frame
+		// so strict downstream clients do not attempt to deserialize it.
+		return nil
 	case "response.output_item.done":
 		f.recordOutputItem(payload)
 	case "response.completed":

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -176,6 +176,29 @@ func TestForwardResponsesStreamReassemblesSplitSSEEventChunks(t *testing.T) {
 	}
 }
 
+func TestForwardResponsesStreamDropsNonStandardKeepaliveEvents(t *testing.T) {
+	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
+
+	data := make(chan []byte, 6)
+	errs := make(chan *interfaces.ErrorMessage)
+	data <- []byte("event: keepalive")
+	data <- []byte(`data: {"type":"keepalive","sequence_number":186}`)
+	data <- []byte("\n")
+	data <- []byte("event: response.created")
+	data <- []byte(`data: {"type":"response.created","response":{"id":"resp-1"}}`)
+	data <- []byte("\n")
+	close(data)
+	close(errs)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+
+	got := strings.TrimSuffix(recorder.Body.String(), "\n")
+	want := "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n"
+	if got != want {
+		t.Fatalf("unexpected keepalive filtering.\nGot:  %q\nWant: %q", got, want)
+	}
+}
+
 func TestForwardResponsesStreamPreservesValidFullSSEEventChunks(t *testing.T) {
 	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
 


### PR DESCRIPTION
## Summary

- drop proprietary `keepalive` SSE frames from OpenAI Responses-compatible streams
- add a regression test that replays the split `event:` and `data:` frame sequence
- preserve all standard `response.*` events and existing completed-output repair behavior

## Problem

The Codex backend may emit a heartbeat frame that is not part of the public Responses event schema:

```text
event: keepalive
data: {"type":"keepalive","sequence_number":186}
```

CLIProxyAPI forwarded that frame unchanged through `/v1/responses`. Strict Responses clients then attempted to deserialize the payload as a standard response event and failed with `unknown variant 'keepalive'`, aborting an otherwise successful streaming turn.

## Root cause

`responsesSSEFramer` normalized framing and repaired selected standard events, but passed every other valid JSON event through unchanged. That allowed a private upstream heartbeat to leak across the public Responses compatibility boundary.

## Fix

When the complete SSE frame has a JSON payload with `type: keepalive`, the framer now drops that frame. The filter operates after frame reassembly, so it removes both the `event: keepalive` and `data:` lines without leaving an orphaned SSE event.

## Validation

- `go test ./sdk/api/handlers/openai -run TestForwardResponsesStreamDropsNonStandardKeepaliveEvents -count=1`
- `go test ./sdk/api/handlers/openai -count=1`
- `go build -o /tmp/cliproxyapi-pr-build ./cmd/server`
- local streaming smoke returned a standard `response.completed`
- the previously failing Grok task successfully completed its fan-out using the patched binary

The request logs used for diagnosis were not attached because they contain authentication and conversation data; the regression fixture contains only the redacted protocol frame required to reproduce the bug.
