### PR TITLE
fix(auth): preserve prefixed API-key model capabilities / 修复带前缀 API Key 模型的能力路由

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -289,6 +289,8 @@ nonstream-keepalive-interval: 0
 #       - name: "gemini-2.5-flash" # upstream model name
 #         alias: "gemini-flash"    # client alias mapped to the upstream model
 #         display-name: "Gemini Flash" # optional catalog display name
+#         thinking:                  # optional: exact thinking capability for this configured model
+#           levels: ["high", "medium", "low", "none", "auto"]
 #     excluded-models:
 #       - "gemini-2.5-pro"     # exclude specific models from this provider (exact match)
 #       - "gemini-2.5-*"       # wildcard matching prefix (e.g. gemini-2.5-flash, gemini-2.5-pro)
@@ -311,6 +313,8 @@ nonstream-keepalive-interval: 0
 #     models:
 #       - name: "gemini-2.5-flash" # upstream model name
 #         alias: "native-gemini-flash" # client alias mapped to the upstream model
+#         thinking:
+#           levels: ["high", "medium", "low", "none", "auto"]
 #     excluded-models:
 #       - "gemini-2.5-pro"
 
@@ -329,6 +333,8 @@ nonstream-keepalive-interval: 0
 #         alias: "codex-latest" # client alias mapped to the upstream model
 #         display-name: "Codex Latest" # optional catalog display name
 #         force-mapping: true    # optional: rewrite response model fields back to the alias
+#         thinking:
+#           levels: ["xhigh", "high", "medium", "low"]
 #     excluded-models:
 #       - "gpt-5.1"         # exclude specific models (exact match)
 #       - "gpt-5-*"         # wildcard matching prefix (e.g. gpt-5-medium, gpt-5-codex)
@@ -372,6 +378,8 @@ nonstream-keepalive-interval: 0
 #         alias: "claude-sonnet-latest"      # client alias mapped to the upstream model
 #         display-name: "Claude Sonnet"      # optional catalog display name
 #         force-mapping: true                 # optional: rewrite response model fields back to the alias
+#         thinking:
+#           levels: ["max", "xhigh", "high", "medium", "low", "minimal", "none", "auto"]
 #     excluded-models:
 #       - "claude-opus-4-5-20251101" # exclude specific models (exact match)
 #       - "claude-3-*"               # wildcard matching prefix (e.g. claude-3-7-sonnet-20250219)
@@ -468,6 +476,8 @@ nonstream-keepalive-interval: 0
 #         display-name: "Vertex Flash"            # optional catalog display name
 #       - name: "gemini-2.5-pro"
 #         alias: "vertex-pro"
+#         thinking:
+#           levels: ["high", "medium", "low", "none", "auto"]
 #     excluded-models:                            # optional: models to exclude from listing
 #       - "imagen-3.0-generate-002"
 #       - "imagen-*"

--- a/internal/api/handlers/management/auth_files_fields.go
+++ b/internal/api/handlers/management/auth_files_fields.go
@@ -73,7 +73,7 @@ func (h *Handler) PatchAuthFileStatus(c *gin.Context) {
 		return
 	}
 
-	if coreauth.IsConfigAPIKeyAuth(targetAuth) {
+	if coreauth.IsConfigAPIKeyAuth(targetAuth) && targetAuth.AuthKind() == coreauth.AuthKindAPIKey {
 		h.mu.Lock()
 		handled, errToggle := toggleConfigAPIKeyExcludedAll(h.cfg, targetAuth, *req.Disabled)
 		if errToggle != nil {

--- a/internal/api/handlers/management/config_apikey_disable_test.go
+++ b/internal/api/handlers/management/config_apikey_disable_test.go
@@ -1,8 +1,13 @@
 package management
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/synthesizer"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -80,5 +85,38 @@ func TestToggleConfigAPIKeyExcludedAll_Codex(t *testing.T) {
 	}
 	if len(cfg.CodexKey[0].ExcludedModels) != 0 {
 		t.Fatalf("expected excluded-models cleared, got %#v", cfg.CodexKey[0].ExcludedModels)
+	}
+}
+
+func TestPatchAuthFileStatus_KeylessOpenAICompatibility(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	auth := &coreauth.Auth{
+		ID:       "openai-compatibility:keyless",
+		Provider: "openai-compatibility:keyless",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"compat_name": "keyless",
+			"source":      "config:keyless[abc]",
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{}, manager)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/status", strings.NewReader(`{"name":"openai-compatibility:keyless","disabled":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+
+	h.PatchAuthFileStatus(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil || !updated.Disabled || updated.Status != coreauth.StatusDisabled {
+		t.Fatalf("updated auth = %#v, want disabled runtime auth", updated)
 	}
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1510,14 +1510,22 @@ func TestModelsWithClientVersionReturnsCodexCatalog(t *testing.T) {
 			ContextLength: 123456,
 			Thinking:      &registry.ThinkingSupport{Levels: []string{"none", "minimal", "low", "medium", "unsupported", "high", "xhigh"}},
 		},
-		{ID: "grok-imagine-image-quality", Object: "model", OwnedBy: "xai", Type: "openai"},
-		{ID: "gpt-image-2", Object: "model", OwnedBy: "openai", Type: "openai"},
-		{ID: "grok-imagine-image", Object: "model", OwnedBy: "xai", Type: "openai"},
-		{ID: "grok-imagine-video", Object: "model", OwnedBy: "xai", Type: "openai"},
-		{ID: "grok-imagine-video-1.5-preview", Object: "model", OwnedBy: "xai", Type: "openai"},
+	})
+	codexBuiltinClientID := clientID + "-codex-builtins"
+	modelRegistry.RegisterClient(codexBuiltinClientID, "codex", []*registry.ModelInfo{
+		{ID: "gpt-image-2", Object: "model", OwnedBy: "openai", Type: "openai", SupportsImageAPI: true, ChatDisabled: true},
+	})
+	xaiBuiltinClientID := clientID + "-xai-builtins"
+	modelRegistry.RegisterClient(xaiBuiltinClientID, "xai", []*registry.ModelInfo{
+		{ID: "grok-imagine-image-quality", Object: "model", OwnedBy: "xai", Type: "xai", SupportsImageAPI: true, ChatDisabled: true},
+		{ID: "grok-imagine-image", Object: "model", OwnedBy: "xai", Type: "xai", SupportsImageAPI: true, ChatDisabled: true},
+		{ID: "grok-imagine-video", Object: "model", OwnedBy: "xai", Type: "xai", ChatDisabled: true},
+		{ID: "grok-imagine-video-1.5-preview", Object: "model", OwnedBy: "xai", Type: "xai", ChatDisabled: true},
 	})
 	t.Cleanup(func() {
 		modelRegistry.UnregisterClient(clientID)
+		modelRegistry.UnregisterClient(codexBuiltinClientID)
+		modelRegistry.UnregisterClient(xaiBuiltinClientID)
 	})
 
 	server := newTestServer(t)

--- a/internal/client/codex/models/models.go
+++ b/internal/client/codex/models/models.go
@@ -57,21 +57,24 @@ func buildCodexClientModels(models []map[string]any, providersForModel Providers
 			continue
 		}
 
+		info, supportsChat, hasDynamicInfo := lookupCodexClientModelInfo(id)
 		if template, ok := templates[id]; ok {
 			entry := cloneCodexClientModelMap(template)
 			applyCodexClientDisplayName(entry, model)
+			applyCodexClientEndpointMetadata(entry, info, supportsChat)
+			if hasDynamicInfo {
+				applyCodexClientThinkingMetadata(entry, info.Thinking)
+			}
 			applyCodexClientSearchToolSupport(entry, id, true, providersForModel)
 			sanitizeCodexClientReasoningMetadata(entry)
-			applyCodexClientVisibilityOverride(entry, id)
 			result = append(result, entry)
 			continue
 		}
 
 		entry := cloneCodexClientModelMap(defaultTemplate)
-		applyCodexClientModelMetadata(entry, id, model, optimizeMultiAgentV2)
+		applyCodexClientModelMetadata(entry, id, model, info, supportsChat, optimizeMultiAgentV2)
 		applyCodexClientSearchToolSupport(entry, id, false, providersForModel)
 		sanitizeCodexClientReasoningMetadata(entry)
-		applyCodexClientVisibilityOverride(entry, id)
 		result = append(result, entry)
 	}
 
@@ -210,9 +213,7 @@ func applyCodexClientSearchToolSupport(entry map[string]any, id string, template
 	}
 }
 
-func applyCodexClientModelMetadata(entry map[string]any, id string, model map[string]any, optimizeMultiAgentV2 bool) {
-	info := registry.LookupModelInfo(id)
-
+func applyCodexClientModelMetadata(entry map[string]any, id string, model map[string]any, info *registry.ModelInfo, supportsChat bool, optimizeMultiAgentV2 bool) {
 	displayName := stringModelValue(model, "display_name")
 	description := stringModelValue(model, "description")
 	contextWindow := intModelValue(model, "context_length")
@@ -227,13 +228,7 @@ func applyCodexClientModelMetadata(entry map[string]any, id string, model map[st
 		if info.ContextLength > 0 {
 			contextWindow = info.ContextLength
 		}
-		if info.Type == registry.OpenAIImageModelType {
-			entry["visibility"] = "hide"
-			delete(entry, "input_modalities")
-			delete(entry, "supports_image_detail_original")
-		} else {
-			applyCodexClientInputModalitiesMetadata(entry, info.SupportedInputModalities)
-		}
+		applyCodexClientEndpointMetadata(entry, info, supportsChat)
 		applyCodexClientThinkingMetadata(entry, info.Thinking)
 	}
 
@@ -269,11 +264,31 @@ func applyCodexClientModelMetadata(entry map[string]any, id string, model map[st
 	}
 }
 
-func applyCodexClientVisibilityOverride(entry map[string]any, id string) {
-	switch strings.TrimSpace(id) {
-	case "grok-imagine-image-quality", "gpt-image-1.5", "gpt-image-2", "grok-imagine-image", "grok-imagine-video", "grok-imagine-video-1.5-preview":
-		entry["visibility"] = "hide"
+func lookupCodexClientModelInfo(id string) (*registry.ModelInfo, bool, bool) {
+	info, supportsChat := registry.GetGlobalRegistry().GetCatalogModelInfo(id)
+	if info != nil {
+		return info, supportsChat, true
 	}
+
+	info = registry.LookupStaticModelInfo(id)
+	if info == nil {
+		return nil, false, false
+	}
+	capabilities, _ := registry.LookupModelEndpointCapabilities(id)
+	return info, capabilities.Chat, false
+}
+
+func applyCodexClientEndpointMetadata(entry map[string]any, info *registry.ModelInfo, supportsChat bool) {
+	if info == nil {
+		return
+	}
+	if !supportsChat {
+		entry["visibility"] = "hide"
+		delete(entry, "input_modalities")
+		delete(entry, "supports_image_detail_original")
+		return
+	}
+	applyCodexClientInputModalitiesMetadata(entry, info.SupportedInputModalities)
 }
 
 func applyCodexClientInputModalitiesMetadata(entry map[string]any, modalities []string) {

--- a/internal/client/codex/models/models_test.go
+++ b/internal/client/codex/models/models_test.go
@@ -9,6 +9,7 @@ import (
 func TestCodexClientModelsResponse_InputModalitiesFromRegistry(t *testing.T) {
 	modelID := "mimo-v2.5-pro-codex-test"
 	textOnlyModelID := "mimo-text-only-codex-test"
+	sharedImageModelID := "compat-shared-image-codex-test"
 	modelRegistry := registry.GetGlobalRegistry()
 	modelRegistry.RegisterClient("codex-input-modalities-test", "openai-compatibility", []*registry.ModelInfo{
 		{
@@ -41,6 +42,13 @@ func TestCodexClientModelsResponse_InputModalitiesFromRegistry(t *testing.T) {
 			OwnedBy: "mimo",
 			Type:    registry.OpenAIImageModelType,
 		},
+		{
+			ID:               sharedImageModelID,
+			Object:           "model",
+			OwnedBy:          "mimo",
+			Type:             "openai-compatibility",
+			SupportsImageAPI: true,
+		},
 	})
 	t.Cleanup(func() {
 		modelRegistry.UnregisterClient("codex-input-modalities-test")
@@ -57,6 +65,7 @@ func TestCodexClientModelsResponse_InputModalitiesFromRegistry(t *testing.T) {
 	var textOnlyEntry map[string]any
 	var mixedEntry map[string]any
 	var imageEntry map[string]any
+	var sharedImageEntry map[string]any
 	for _, entry := range models {
 		slug := stringModelValue(entry, "slug")
 		switch slug {
@@ -68,6 +77,8 @@ func TestCodexClientModelsResponse_InputModalitiesFromRegistry(t *testing.T) {
 			mixedEntry = entry
 		case "compat-image-only-codex-test":
 			imageEntry = entry
+		case sharedImageModelID:
+			sharedImageEntry = entry
 		}
 	}
 	if visionEntry == nil {
@@ -127,6 +138,306 @@ func TestCodexClientModelsResponse_InputModalitiesFromRegistry(t *testing.T) {
 	if _, exists := imageEntry["input_modalities"]; exists {
 		t.Fatalf("image endpoint model should not expose input_modalities from registry: %#v", imageEntry["input_modalities"])
 	}
+	if sharedImageEntry == nil {
+		t.Fatalf("expected codex entry for %q", sharedImageModelID)
+	}
+	if got, _ := sharedImageEntry["visibility"].(string); got == "hide" {
+		t.Fatalf("shared image-capable model visibility = %q, want visible", got)
+	}
+}
+
+func TestCodexClientModelsResponse_SharedImageAliasPrefersChatRegistration(t *testing.T) {
+	const modelID = "gpt-image-2"
+
+	for _, imageFirst := range []bool{false, true} {
+		name := "chat-first"
+		if imageFirst {
+			name = "image-first"
+		}
+		t.Run(name, func(t *testing.T) {
+			modelRegistry := registry.GetGlobalRegistry()
+			chatClientID := "codex-shared-chat-" + name
+			imageClientID := "codex-shared-image-" + name
+			chat := &registry.ModelInfo{
+				ID:                       modelID,
+				Object:                   "model",
+				OwnedBy:                  "chat-owner",
+				Type:                     "openai-compatibility",
+				DisplayName:              "Shared Chat Model",
+				Description:              "Chat metadata",
+				ContextLength:            123456,
+				SupportedInputModalities: []string{"text", "image"},
+				Thinking:                 &registry.ThinkingSupport{Levels: []string{"low", "high"}},
+			}
+			image := &registry.ModelInfo{
+				ID:          modelID,
+				Object:      "model",
+				OwnedBy:     "image-owner",
+				Type:        registry.OpenAIImageModelType,
+				DisplayName: "Image-only Model",
+				Description: "Image metadata",
+			}
+			registerChat := func() {
+				modelRegistry.RegisterClient(chatClientID, "openai-compatibility", []*registry.ModelInfo{chat})
+			}
+			registerImage := func() {
+				modelRegistry.RegisterClient(imageClientID, "codex", []*registry.ModelInfo{image})
+			}
+			if imageFirst {
+				registerImage()
+				registerChat()
+			} else {
+				registerChat()
+				registerImage()
+			}
+			t.Cleanup(func() {
+				modelRegistry.UnregisterClient(chatClientID)
+				modelRegistry.UnregisterClient(imageClientID)
+			})
+
+			entry := codexClientModelTestEntry(t, modelRegistry, modelID)
+			if got := stringModelValue(entry, "display_name"); got != "Shared Chat Model" {
+				t.Fatalf("shared display_name = %q, want chat metadata", got)
+			}
+			if got := stringModelValue(entry, "visibility"); got == "hide" {
+				t.Fatalf("shared visibility = %q, want visible chat route", got)
+			}
+			modalities, ok := entry["input_modalities"].([]any)
+			if !ok || len(modalities) != 2 || modalities[0] != "text" || modalities[1] != "image" {
+				t.Fatalf("shared input_modalities = %#v, want chat metadata", entry["input_modalities"])
+			}
+			levels, ok := entry["supported_reasoning_levels"].([]any)
+			if !ok || len(levels) != 2 {
+				t.Fatalf("shared supported_reasoning_levels = %#v, want chat metadata", entry["supported_reasoning_levels"])
+			}
+			high, ok := levels[1].(map[string]any)
+			if !ok || stringModelValue(high, "effort") != "high" {
+				t.Fatalf("shared supported_reasoning_levels = %#v, want high effort", entry["supported_reasoning_levels"])
+			}
+
+			modelRegistry.UnregisterClient(chatClientID)
+
+			entry = codexClientModelTestEntry(t, modelRegistry, modelID)
+			if got := stringModelValue(entry, "display_name"); got != "Image-only Model" {
+				t.Fatalf("remaining display_name = %q, want image metadata", got)
+			}
+			if got := stringModelValue(entry, "visibility"); got != "hide" {
+				t.Fatalf("remaining visibility = %q, want hidden image-only route", got)
+			}
+			if _, exists := entry["input_modalities"]; exists {
+				t.Fatalf("image-only route input_modalities = %#v, want omitted", entry["input_modalities"])
+			}
+		})
+	}
+}
+
+func TestCodexClientModelsResponse_HardcodedImageIDWithChatOnlyRouteIsVisible(t *testing.T) {
+	const (
+		clientID = "codex-hardcoded-chat-only-test"
+		modelID  = "gpt-image-2"
+	)
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(clientID, "openai-compatibility", []*registry.ModelInfo{{
+		ID:          modelID,
+		Object:      "model",
+		OwnedBy:     "chat-owner",
+		Type:        "openai-compatibility",
+		DisplayName: "Chat-only Alias",
+	}})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	info, supportsChat := modelRegistry.GetCatalogModelInfo(modelID)
+	if !supportsChat || info == nil || info.SupportsImageAPI {
+		t.Fatalf("chat-only aggregate = %#v, supportsChat=%v", info, supportsChat)
+	}
+	entry := codexClientModelTestEntry(t, modelRegistry, modelID)
+	if got := stringModelValue(entry, "visibility"); got == "hide" {
+		t.Fatalf("chat-only hardcoded alias visibility = %q, want visible", got)
+	}
+	if got := stringModelValue(entry, "display_name"); got != "Chat-only Alias" {
+		t.Fatalf("chat-only hardcoded alias display_name = %q", got)
+	}
+}
+
+func TestCodexClientModelsResponse_TemplateSlugUsesAggregateChatCapability(t *testing.T) {
+	const (
+		modelID       = "gpt-5.5"
+		imageClientID = "codex-template-image-only"
+		chatClientID  = "codex-template-chat"
+	)
+	assertReasoningLevels := func(t *testing.T, entry map[string]any, expected ...string) {
+		t.Helper()
+		levels, ok := entry["supported_reasoning_levels"].([]any)
+		if !ok || len(levels) != len(expected) {
+			t.Fatalf("supported_reasoning_levels = %#v, want %v", entry["supported_reasoning_levels"], expected)
+		}
+		for i, expectedLevel := range expected {
+			level, ok := levels[i].(map[string]any)
+			if !ok || stringModelValue(level, "effort") != expectedLevel {
+				t.Fatalf("supported_reasoning_levels = %#v, want %v", entry["supported_reasoning_levels"], expected)
+			}
+		}
+	}
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(imageClientID)
+	modelRegistry.UnregisterClient(chatClientID)
+	modelRegistry.RegisterClient(imageClientID, "codex", []*registry.ModelInfo{{
+		ID:               modelID,
+		Type:             "openai",
+		DisplayName:      "Template Image Alias",
+		SupportsImageAPI: true,
+		ChatDisabled:     true,
+	}})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(imageClientID)
+		modelRegistry.UnregisterClient(chatClientID)
+	})
+
+	entry := codexClientModelTestEntry(t, modelRegistry, modelID)
+	if got := stringModelValue(entry, "visibility"); got != "hide" {
+		t.Fatalf("image-only template visibility = %q, want hide", got)
+	}
+	if _, exists := entry["input_modalities"]; exists {
+		t.Fatalf("image-only template input_modalities = %#v, want omitted", entry["input_modalities"])
+	}
+	if _, exists := entry["supports_image_detail_original"]; exists {
+		t.Fatalf("image-only template supports_image_detail_original = %#v, want omitted", entry["supports_image_detail_original"])
+	}
+
+	modelRegistry.RegisterClient(chatClientID, "codex", []*registry.ModelInfo{{
+		ID:                       modelID,
+		Type:                     "openai",
+		DisplayName:              "Template Chat Alias",
+		SupportedInputModalities: []string{"text", "image"},
+		Thinking:                 &registry.ThinkingSupport{Levels: []string{"low", "high"}},
+	}})
+	entry = codexClientModelTestEntry(t, modelRegistry, modelID)
+	if got := stringModelValue(entry, "visibility"); got == "hide" {
+		t.Fatalf("shared template visibility = %q, want visible chat route", got)
+	}
+	if got := stringModelValue(entry, "display_name"); got != "Template Chat Alias" {
+		t.Fatalf("shared template display_name = %q, want chat metadata", got)
+	}
+	modalities, ok := entry["input_modalities"].([]any)
+	if !ok || len(modalities) != 2 || modalities[0] != "text" || modalities[1] != "image" {
+		t.Fatalf("shared template input_modalities = %#v, want [text image]", entry["input_modalities"])
+	}
+	assertReasoningLevels(t, entry, "low", "high")
+	if got := stringModelValue(entry, "default_reasoning_level"); got != "low" {
+		t.Fatalf("configured default_reasoning_level = %q, want low", got)
+	}
+
+	modelRegistry.RegisterClient(chatClientID, "codex", []*registry.ModelInfo{{
+		ID:                       modelID,
+		Type:                     "openai",
+		DisplayName:              "Template Chat Alias",
+		SupportedInputModalities: []string{"text", "image"},
+	}})
+	entry = codexClientModelTestEntry(t, modelRegistry, modelID)
+	assertReasoningLevels(t, entry, "low", "medium", "high", "xhigh")
+	if got := stringModelValue(entry, "default_reasoning_level"); got != "medium" {
+		t.Fatalf("template default_reasoning_level = %q, want medium", got)
+	}
+}
+
+func TestCodexClientModelsResponse_NativeImageAliasUsesNonChatMetadata(t *testing.T) {
+	const (
+		clientID = "codex-native-image-alias-test"
+		modelID  = "tenant/public-image"
+	)
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(clientID, "xai", []*registry.ModelInfo{{
+		ID:               modelID,
+		Object:           "model",
+		OwnedBy:          "xai",
+		Type:             "xai",
+		DisplayName:      "Public Image",
+		SupportsImageAPI: true,
+		ChatDisabled:     true,
+	}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+	entry := codexClientModelTestEntry(t, modelRegistry, modelID)
+	if got := stringModelValue(entry, "visibility"); got != "hide" {
+		t.Fatalf("native image alias visibility = %q, want hide", got)
+	}
+	if _, exists := entry["input_modalities"]; exists {
+		t.Fatalf("native image alias input_modalities = %#v, want omitted", entry["input_modalities"])
+	}
+}
+
+func TestCodexClientModelsResponse_SharedImageAliasSuspensionTransitions(t *testing.T) {
+	const (
+		chatClientID  = "codex-shared-suspension-chat-test"
+		imageClientID = "codex-shared-suspension-image-test"
+		modelID       = "gpt-image-2"
+	)
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(chatClientID, "openai-compatibility", []*registry.ModelInfo{{
+		ID:          modelID,
+		Object:      "model",
+		OwnedBy:     "chat-owner",
+		Type:        "openai-compatibility",
+		DisplayName: "Suspension Chat Model",
+	}})
+	modelRegistry.RegisterClient(imageClientID, "openai-compatibility", []*registry.ModelInfo{{
+		ID:               modelID,
+		Object:           "model",
+		OwnedBy:          "image-owner",
+		Type:             registry.OpenAIImageModelType,
+		DisplayName:      "Suspension Image Model",
+		SupportsImageAPI: true,
+	}})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(chatClientID)
+		modelRegistry.UnregisterClient(imageClientID)
+	})
+
+	modelRegistry.SuspendClientModel(chatClientID, modelID, "model_not_supported")
+	entry := codexClientModelTestEntry(t, modelRegistry, modelID)
+	if got := stringModelValue(entry, "visibility"); got != "hide" {
+		t.Fatalf("chat-suspended visibility = %q, want hidden image-only route", got)
+	}
+	if got := stringModelValue(entry, "display_name"); got != "Suspension Image Model" {
+		t.Fatalf("chat-suspended display_name = %q, want image metadata", got)
+	}
+
+	modelRegistry.ResumeClientModel(chatClientID, modelID)
+	entry = codexClientModelTestEntry(t, modelRegistry, modelID)
+	if got := stringModelValue(entry, "visibility"); got == "hide" {
+		t.Fatalf("resumed chat visibility = %q, want visible", got)
+	}
+	if got := stringModelValue(entry, "display_name"); got != "Suspension Chat Model" {
+		t.Fatalf("resumed chat display_name = %q, want chat metadata", got)
+	}
+
+	modelRegistry.SuspendClientModel(imageClientID, modelID, "model_not_supported")
+	info, supportsChat := modelRegistry.GetCatalogModelInfo(modelID)
+	if !supportsChat || info == nil || info.SupportsImageAPI {
+		t.Fatalf("image-suspended aggregate = %#v, supportsChat=%v", info, supportsChat)
+	}
+	entry = codexClientModelTestEntry(t, modelRegistry, modelID)
+	if got := stringModelValue(entry, "visibility"); got == "hide" {
+		t.Fatalf("image-suspended chat visibility = %q, want visible", got)
+	}
+}
+
+func codexClientModelTestEntry(t *testing.T, modelRegistry *registry.ModelRegistry, modelID string) map[string]any {
+	t.Helper()
+	response := BuildResponse(modelRegistry.GetAvailableModels("openai"), nil, false)
+	models, ok := response["models"].([]map[string]any)
+	if !ok {
+		t.Fatalf("models type = %T, want []map[string]any", response["models"])
+	}
+	for _, entry := range models {
+		if stringModelValue(entry, "slug") == modelID {
+			return entry
+		}
+	}
+	t.Fatalf("expected Codex client entry for %q", modelID)
+	return nil
 }
 
 func TestCodexClientModelsResponse_AppliesDisplayNameToTemplateModel(t *testing.T) {
@@ -298,12 +609,12 @@ func TestApplyCodexClientModelMetadataPreservesMultiAgentVersionWhenDisabled(t *
 	entry := map[string]any{"multi_agent_version": "v1"}
 	model := map[string]any{"id": "custom-model"}
 
-	applyCodexClientModelMetadata(entry, "custom-model", model, false)
+	applyCodexClientModelMetadata(entry, "custom-model", model, nil, false, false)
 	if got := entry["multi_agent_version"]; got != "v1" {
 		t.Fatalf("disabled multi_agent_version = %#v, want preserved v1", got)
 	}
 
-	applyCodexClientModelMetadata(entry, "custom-model", model, true)
+	applyCodexClientModelMetadata(entry, "custom-model", model, nil, false, true)
 	if got := entry["multi_agent_version"]; got != "v2" {
 		t.Fatalf("enabled multi_agent_version = %#v, want v2", got)
 	}

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -368,6 +368,9 @@ type ClaudeModel struct {
 
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// Thinking configures the thinking/reasoning capability for this model.
+	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
 func (m ClaudeModel) GetName() string { return m.Name }
@@ -377,6 +380,8 @@ func (m ClaudeModel) GetAlias() string { return m.Alias }
 func (m ClaudeModel) GetDisplayName() string { return m.DisplayName }
 
 func (m ClaudeModel) GetForceMapping() bool { return m.ForceMapping }
+
+func (m ClaudeModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }
 
 // CodexKey represents the configuration for a Codex API key,
 // including the API key itself and an optional base URL for the API endpoint.
@@ -431,6 +436,9 @@ type CodexModel struct {
 
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// Thinking configures the thinking/reasoning capability for this model.
+	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
 func (m CodexModel) GetName() string { return m.Name }
@@ -440,6 +448,8 @@ func (m CodexModel) GetAlias() string { return m.Alias }
 func (m CodexModel) GetDisplayName() string { return m.DisplayName }
 
 func (m CodexModel) GetForceMapping() bool { return m.ForceMapping }
+
+func (m CodexModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }
 
 // XAIKey uses the Codex API key structure for native xAI execution.
 type XAIKey = CodexKey
@@ -496,6 +506,9 @@ type GeminiModel struct {
 
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// Thinking configures the thinking/reasoning capability for this model.
+	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
 func (m GeminiModel) GetName() string { return m.Name }
@@ -505,6 +518,8 @@ func (m GeminiModel) GetAlias() string { return m.Alias }
 func (m GeminiModel) GetDisplayName() string { return m.DisplayName }
 
 func (m GeminiModel) GetForceMapping() bool { return m.ForceMapping }
+
+func (m GeminiModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }
 
 // OpenAICompatibility represents the configuration for OpenAI API compatibility
 // with external providers, allowing model aliases to be routed through OpenAI API format.
@@ -584,3 +599,5 @@ func (m OpenAICompatibilityModel) GetAlias() string { return m.Alias }
 func (m OpenAICompatibilityModel) GetDisplayName() string { return m.DisplayName }
 
 func (m OpenAICompatibilityModel) GetForceMapping() bool { return m.ForceMapping }
+
+func (m OpenAICompatibilityModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }

--- a/internal/config/vertex_compat.go
+++ b/internal/config/vertex_compat.go
@@ -1,6 +1,10 @@
 package config
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
 
 // VertexCompatKey represents the configuration for Vertex AI-compatible API keys.
 // This supports third-party services that use Vertex AI-style endpoint paths
@@ -56,12 +60,18 @@ type VertexCompatModel struct {
 
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// Thinking configures the thinking/reasoning capability for this model.
+	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
 func (m VertexCompatModel) GetName() string        { return m.Name }
 func (m VertexCompatModel) GetAlias() string       { return m.Alias }
 func (m VertexCompatModel) GetDisplayName() string { return m.DisplayName }
 func (m VertexCompatModel) GetForceMapping() bool  { return m.ForceMapping }
+func (m VertexCompatModel) GetThinking() *registry.ThinkingSupport {
+	return m.Thinking
+}
 
 // SanitizeVertexCompatKeys deduplicates and normalizes Vertex-compatible API key credentials.
 func (cfg *Config) SanitizeVertexCompatKeys() {

--- a/internal/modelconfig/model_info.go
+++ b/internal/modelconfig/model_info.go
@@ -1,0 +1,135 @@
+package modelconfig
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+)
+
+// ResolveModelInfo returns a private model-info snapshot for a configured
+// API-key model. Static capabilities are inherited from the suffix-free
+// upstream model name and explicit configuration takes precedence.
+func ResolveModelInfo(name, modelType string, support *registry.ThinkingSupport) *registry.ModelInfo {
+	return ResolveModelInfoForProvider(name, modelType, modelType, support)
+}
+
+// ResolveModelInfoForProvider returns configured model metadata while keeping
+// provider-scoped endpoint capabilities separate from the public model type.
+func ResolveModelInfoForProvider(name, modelType, provider string, support *registry.ThinkingSupport) *registry.ModelInfo {
+	trimmedName := strings.TrimSpace(name)
+	baseName := strings.TrimSpace(thinking.ParseSuffix(trimmedName).ModelName)
+	info := registry.LookupStaticModelInfo(baseName)
+	if info == nil {
+		info = &registry.ModelInfo{}
+	}
+	modelType = strings.TrimSpace(modelType)
+	RebindModelInfo(info, baseName, trimmedName)
+	info.Type = modelType
+	// Endpoint capabilities are provider-specific; only native providers may
+	// inherit them from their own static catalog entries.
+	info.SupportsImageAPI, info.SupportsVideoAPI, info.ChatDisabled = staticEndpointCapabilities(baseName, provider)
+	if support != nil {
+		info.Thinking = NormalizeThinkingSupport(support)
+	}
+	info.UserDefined = false
+	return info
+}
+
+// RebindModelInfo updates every public model identity field while preserving
+// the remaining private metadata snapshot.
+func RebindModelInfo(info *registry.ModelInfo, oldID, newID string) {
+	if info == nil {
+		return
+	}
+	oldID = strings.TrimSpace(oldID)
+	newID = strings.TrimSpace(newID)
+	if newID == "" {
+		return
+	}
+	info.ID = newID
+	info.Name = rebindResourceName(info.Name, oldID, newID)
+}
+
+func rebindResourceName(name, oldID, newID string) string {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" || oldID == "" || strings.EqualFold(oldID, newID) {
+		return name
+	}
+	if strings.EqualFold(trimmed, oldID) {
+		return newID
+	}
+	lowerName := strings.ToLower(trimmed)
+	lowerSuffix := "/" + strings.ToLower(oldID)
+	if strings.HasSuffix(lowerName, lowerSuffix) {
+		return trimmed[:len(trimmed)-len(oldID)] + newID
+	}
+	return name
+}
+
+func staticEndpointCapabilities(modelName, provider string) (supportsImageAPI, supportsVideoAPI, chatDisabled bool) {
+	channel := ""
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "codex":
+		channel = "codex"
+	case "xai":
+		channel = "xai"
+	}
+	if channel == "" {
+		return false, false, false
+	}
+	info := registry.LookupStaticModelInfoByChannel(modelName, channel)
+	if info != nil {
+		return info.SupportsImageAPI, info.SupportsVideoAPI, info.ChatDisabled
+	}
+	return false, false, false
+}
+
+// NormalizeThinkingSupport clones and normalizes configured reasoning levels.
+func NormalizeThinkingSupport(raw *registry.ThinkingSupport) *registry.ThinkingSupport {
+	if raw == nil {
+		return nil
+	}
+	normalized := *raw
+	normalized.Levels = nil
+	seen := make(map[string]struct{}, len(raw.Levels))
+	for _, value := range raw.Levels {
+		level := strings.ToLower(strings.TrimSpace(value))
+		if level == "" {
+			continue
+		}
+		if _, exists := seen[level]; exists {
+			continue
+		}
+		seen[level] = struct{}{}
+		normalized.Levels = append(normalized.Levels, level)
+		switch level {
+		case "none":
+			normalized.ZeroAllowed = true
+		case "auto":
+			normalized.DynamicAllowed = true
+		}
+	}
+	return &normalized
+}
+
+// NormalizeModalities returns unique lower-case configured modalities.
+func NormalizeModalities(raw []string) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	seen := make(map[string]struct{}, len(raw))
+	for _, value := range raw {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/modelconfig/model_info_test.go
+++ b/internal/modelconfig/model_info_test.go
@@ -1,0 +1,107 @@
+package modelconfig
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestResolveModelInfoUsesSuffixFreeStaticCapabilities(t *testing.T) {
+	static := registry.LookupStaticModelInfo("gpt-5.6-luna")
+	if static == nil || static.Thinking == nil {
+		t.Fatal("gpt-5.6-luna static thinking metadata is unavailable")
+	}
+
+	info := ResolveModelInfo("gpt-5.6-luna(high)", "openai", nil)
+	if info.ID != "gpt-5.6-luna(high)" {
+		t.Fatalf("model ID = %q, want configured name", info.ID)
+	}
+	if info.Thinking == nil || len(info.Thinking.Levels) != len(static.Thinking.Levels) {
+		t.Fatalf("thinking = %+v, want static capabilities %+v", info.Thinking, static.Thinking)
+	}
+}
+
+func TestResolveModelInfoNormalizesConfiguredCapabilities(t *testing.T) {
+	info := ResolveModelInfo("custom", "claude", &registry.ThinkingSupport{
+		Levels: []string{" XHIGH ", "xhigh", "none", "AUTO"},
+	})
+	if got, want := len(info.Thinking.Levels), 3; got != want {
+		t.Fatalf("thinking levels = %v, want %d unique levels", info.Thinking.Levels, want)
+	}
+	if !info.Thinking.ZeroAllowed || !info.Thinking.DynamicAllowed {
+		t.Fatalf("thinking flags = %+v, want none/auto flags", info.Thinking)
+	}
+	if got := NormalizeModalities([]string{" TEXT ", "image", "text"}); len(got) != 2 || got[0] != "text" || got[1] != "image" {
+		t.Fatalf("modalities = %v, want [text image]", got)
+	}
+}
+
+func TestResolveModelInfoDoesNotLeakStaticImageAPIToOtherProviders(t *testing.T) {
+	static := registry.LookupStaticModelInfo("gpt-image-2")
+	if static == nil || !static.SupportsImageAPI {
+		t.Fatal("gpt-image-2 static image capability is unavailable")
+	}
+
+	for _, modelType := range []string{"claude", "gemini", "vertex"} {
+		t.Run(modelType, func(t *testing.T) {
+			info := ResolveModelInfo("gpt-image-2", modelType, nil)
+			if info.SupportsImageAPI {
+				t.Fatalf("%s model inherited provider-specific image API support", modelType)
+			}
+			if info.ChatDisabled {
+				t.Fatalf("%s model inherited provider-specific chat exclusion", modelType)
+			}
+		})
+	}
+}
+
+func TestResolveModelInfoPreservesNativeStaticImageAPI(t *testing.T) {
+	tests := []struct {
+		name      string
+		model     string
+		modelType string
+		provider  string
+		want      bool
+	}{
+		{name: "codex public type", model: "gpt-image-2", modelType: "openai", provider: "codex", want: true},
+		{name: "codex native", model: "gpt-image-2", modelType: "codex", provider: "codex", want: true},
+		{name: "xai native", model: "grok-imagine-image", modelType: "xai", provider: "xai", want: true},
+		{name: "xai cannot inherit codex", model: "gpt-image-2", modelType: "xai", provider: "xai"},
+		{name: "codex cannot inherit xai", model: "grok-imagine-image", modelType: "codex", provider: "codex"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			info := ResolveModelInfoForProvider(tc.model, tc.modelType, tc.provider, nil)
+			if info.SupportsImageAPI != tc.want {
+				t.Fatalf("%s image API support = %t, want %t", tc.modelType, info.SupportsImageAPI, tc.want)
+			}
+			if info.ChatDisabled != tc.want {
+				t.Fatalf("%s chat-disabled capability = %t, want %t", tc.modelType, info.ChatDisabled, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveModelInfoPreservesNativeStaticVideoAPI(t *testing.T) {
+	info := ResolveModelInfoForProvider("grok-imagine-video", "xai", "xai", nil)
+	if !info.SupportsVideoAPI || !info.ChatDisabled {
+		t.Fatalf("xAI video metadata = %+v, want video-only execution", info)
+	}
+	if info.SupportsImageAPI {
+		t.Fatal("xAI video model unexpectedly supports image execution")
+	}
+
+	foreign := ResolveModelInfoForProvider("grok-imagine-video", "claude", "claude", nil)
+	if foreign.SupportsVideoAPI || foreign.ChatDisabled {
+		t.Fatalf("Claude model inherited xAI video capability: %+v", foreign)
+	}
+}
+
+func TestRebindModelInfoUpdatesResourceName(t *testing.T) {
+	info := &registry.ModelInfo{ID: "gemini-2.5-flash", Name: "models/gemini-2.5-flash"}
+	RebindModelInfo(info, info.ID, "tenant/public-flash")
+	if info.ID != "tenant/public-flash" || info.Name != "models/tenant/public-flash" {
+		t.Fatalf("rebound identity = %#v, want tenant alias in ID and resource name", info)
+	}
+}

--- a/internal/pluginhost/adapters.go
+++ b/internal/pluginhost/adapters.go
@@ -117,8 +117,8 @@ type AuthModelResult struct {
 	Err      error
 }
 
-func pluginModelInfoToRegistryModelInfo(model pluginapi.ModelInfo) *registry.ModelInfo {
-	return &registry.ModelInfo{
+func pluginModelInfoToRegistryModelInfo(model pluginapi.ModelInfo, provider string) *registry.ModelInfo {
+	info := &registry.ModelInfo{
 		ID:                         model.ID,
 		Object:                     model.Object,
 		Created:                    model.Created,
@@ -139,6 +139,12 @@ func pluginModelInfoToRegistryModelInfo(model pluginapi.ModelInfo) *registry.Mod
 		Thinking:                   pluginThinkingSupportToRegistryThinkingSupport(model.Thinking),
 		UserDefined:                model.UserDefined,
 	}
+	if static := registry.LookupStaticModelInfoByChannel(info.ID, provider); static != nil {
+		info.SupportsImageAPI = static.SupportsImageAPI
+		info.SupportsVideoAPI = static.SupportsVideoAPI
+		info.ChatDisabled = static.ChatDisabled
+	}
+	return info
 }
 
 func pluginThinkingSupportToRegistryThinkingSupport(thinking *pluginapi.ThinkingSupport) *registry.ThinkingSupport {
@@ -269,7 +275,7 @@ func (h *Host) RegisterModels(ctx context.Context, modelRegistry modelRegistry) 
 
 		models := make([]*registry.ModelInfo, 0, len(resp.Models))
 		for _, item := range resp.Models {
-			model := pluginModelInfoToRegistryModelInfo(item)
+			model := pluginModelInfoToRegistryModelInfo(item, provider)
 			if model == nil || strings.TrimSpace(model.ID) == "" {
 				continue
 			}
@@ -352,7 +358,7 @@ func (h *Host) ModelsForAuth(ctx context.Context, auth *coreauth.Auth) AuthModel
 		}
 		models := make([]*registry.ModelInfo, 0, len(resp.Models))
 		for _, item := range resp.Models {
-			model := pluginModelInfoToRegistryModelInfo(item)
+			model := pluginModelInfoToRegistryModelInfo(item, respProvider)
 			if model != nil {
 				model.ID = strings.TrimSpace(model.ID)
 			}

--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -52,7 +52,7 @@ func TestPluginModelInfoToRegistryModelInfoClonesThinkingAndSlices(t *testing.T)
 		UserDefined: true,
 	}
 
-	got := pluginModelInfoToRegistryModelInfo(model)
+	got := pluginModelInfoToRegistryModelInfo(model, "plugin")
 	if got.ID != model.ID || got.Object != model.Object || got.Created != model.Created || got.OwnedBy != model.OwnedBy || got.Type != model.Type ||
 		got.DisplayName != model.DisplayName || got.Name != model.Name || got.Version != model.Version || got.Description != model.Description ||
 		got.InputTokenLimit != int(model.InputTokenLimit) || got.OutputTokenLimit != int(model.OutputTokenLimit) ||
@@ -75,6 +75,16 @@ func TestPluginModelInfoToRegistryModelInfoClonesThinkingAndSlices(t *testing.T)
 		got.SupportedInputModalities[0] != "text" || got.SupportedOutputModalities[0] != "image" ||
 		got.Thinking.Levels[0] != "low" {
 		t.Fatalf("converted model kept aliases to plugin slices: %#v", got)
+	}
+}
+
+func TestPluginModelInfoToRegistryModelInfoInheritsProviderEndpointCapabilities(t *testing.T) {
+	got := pluginModelInfoToRegistryModelInfo(pluginapi.ModelInfo{ID: "grok-imagine-video"}, "xai")
+	if got == nil || !got.SupportsVideoAPI || !got.ChatDisabled {
+		t.Fatalf("converted xAI video model = %#v, want video-only endpoint metadata", got)
+	}
+	if got.SupportsImageAPI {
+		t.Fatal("converted xAI video model unexpectedly supports image execution")
 	}
 }
 

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -133,77 +133,89 @@ func normalizeAntigravityCapabilityModelID(modelID string) string {
 
 func codexBuiltinImage15ModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          codexBuiltinImage15ModelID,
-		Object:      "model",
-		Created:     1704067200, // 2024-01-01
-		OwnedBy:     "openai",
-		Type:        "openai",
-		DisplayName: "GPT Image 1.5",
-		Version:     codexBuiltinImage15ModelID,
+		ID:               codexBuiltinImage15ModelID,
+		Object:           "model",
+		Created:          1704067200, // 2024-01-01
+		OwnedBy:          "openai",
+		Type:             "openai",
+		DisplayName:      "GPT Image 1.5",
+		Version:          codexBuiltinImage15ModelID,
+		SupportsImageAPI: true,
+		ChatDisabled:     true,
 	}
 }
 
 func codexBuiltinImageModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          codexBuiltinImageModelID,
-		Object:      "model",
-		Created:     1704067200, // 2024-01-01
-		OwnedBy:     "openai",
-		Type:        "openai",
-		DisplayName: "GPT Image 2",
-		Version:     codexBuiltinImageModelID,
+		ID:               codexBuiltinImageModelID,
+		Object:           "model",
+		Created:          1704067200, // 2024-01-01
+		OwnedBy:          "openai",
+		Type:             "openai",
+		DisplayName:      "GPT Image 2",
+		Version:          codexBuiltinImageModelID,
+		SupportsImageAPI: true,
+		ChatDisabled:     true,
 	}
 }
 
 func xaiBuiltinImageModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          xaiBuiltinImageModelID,
-		Object:      "model",
-		Created:     1735689600, // 2025-01-01
-		OwnedBy:     "xai",
-		Type:        "xai",
-		DisplayName: "Grok Imagine Image",
-		Name:        xaiBuiltinImageModelID,
-		Description: "xAI Grok image generation model.",
+		ID:               xaiBuiltinImageModelID,
+		Object:           "model",
+		Created:          1735689600, // 2025-01-01
+		OwnedBy:          "xai",
+		Type:             "xai",
+		DisplayName:      "Grok Imagine Image",
+		Name:             xaiBuiltinImageModelID,
+		Description:      "xAI Grok image generation model.",
+		SupportsImageAPI: true,
+		ChatDisabled:     true,
 	}
 }
 
 func xaiBuiltinImageQualityModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          xaiBuiltinImageQualityModelID,
-		Object:      "model",
-		Created:     1735689600, // 2025-01-01
-		OwnedBy:     "xai",
-		Type:        "xai",
-		DisplayName: "Grok Imagine Image Quality",
-		Name:        xaiBuiltinImageQualityModelID,
-		Description: "xAI Grok higher-fidelity image generation model.",
+		ID:               xaiBuiltinImageQualityModelID,
+		Object:           "model",
+		Created:          1735689600, // 2025-01-01
+		OwnedBy:          "xai",
+		Type:             "xai",
+		DisplayName:      "Grok Imagine Image Quality",
+		Name:             xaiBuiltinImageQualityModelID,
+		Description:      "xAI Grok higher-fidelity image generation model.",
+		SupportsImageAPI: true,
+		ChatDisabled:     true,
 	}
 }
 
 func xaiBuiltinVideoModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          xaiBuiltinVideoModelID,
-		Object:      "model",
-		Created:     1735689600, // 2025-01-01
-		OwnedBy:     "xai",
-		Type:        "xai",
-		DisplayName: "Grok Imagine Video",
-		Name:        xaiBuiltinVideoModelID,
-		Description: "xAI Grok video generation model.",
+		ID:               xaiBuiltinVideoModelID,
+		Object:           "model",
+		Created:          1735689600, // 2025-01-01
+		OwnedBy:          "xai",
+		Type:             "xai",
+		DisplayName:      "Grok Imagine Video",
+		Name:             xaiBuiltinVideoModelID,
+		Description:      "xAI Grok video generation model.",
+		SupportsVideoAPI: true,
+		ChatDisabled:     true,
 	}
 }
 
 func xaiBuiltinVideo15PreviewModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          xaiBuiltinVideo15PreviewModelID,
-		Object:      "model",
-		Created:     1735689600, // 2025-01-01
-		OwnedBy:     "xai",
-		Type:        "xai",
-		DisplayName: "Grok Imagine Video 1.5 Preview",
-		Name:        xaiBuiltinVideo15PreviewModelID,
-		Description: "xAI Grok preview video generation model.",
+		ID:               xaiBuiltinVideo15PreviewModelID,
+		Object:           "model",
+		Created:          1735689600, // 2025-01-01
+		OwnedBy:          "xai",
+		Type:             "xai",
+		DisplayName:      "Grok Imagine Video 1.5 Preview",
+		Name:             xaiBuiltinVideo15PreviewModelID,
+		Description:      "xAI Grok preview video generation model.",
+		SupportsVideoAPI: true,
+		ChatDisabled:     true,
 	}
 }
 
@@ -301,11 +313,28 @@ func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 	}
 }
 
+// LookupStaticModelInfoByChannel searches one provider channel for an exact model ID.
+func LookupStaticModelInfoByChannel(modelID, channel string) *ModelInfo {
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return nil
+	}
+	for _, info := range GetStaticModelDefinitionsByChannel(channel) {
+		if info != nil && strings.EqualFold(strings.TrimSpace(info.ID), modelID) {
+			return cloneModelInfo(info)
+		}
+	}
+	return nil
+}
+
 // LookupStaticModelInfo searches all static model definitions for a model by ID.
 // Returns nil if no matching model is found.
 func LookupStaticModelInfo(modelID string) *ModelInfo {
 	if modelID == "" {
 		return nil
+	}
+	if builtin := lookupBuiltinModelInfo(modelID); builtin != nil {
+		return builtin
 	}
 
 	data := getModels()
@@ -328,4 +357,23 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 	}
 
 	return nil
+}
+
+func lookupBuiltinModelInfo(modelID string) *ModelInfo {
+	switch strings.ToLower(strings.TrimSpace(modelID)) {
+	case codexBuiltinImage15ModelID:
+		return codexBuiltinImage15ModelInfo()
+	case codexBuiltinImageModelID:
+		return codexBuiltinImageModelInfo()
+	case xaiBuiltinImageModelID:
+		return xaiBuiltinImageModelInfo()
+	case xaiBuiltinImageQualityModelID:
+		return xaiBuiltinImageQualityModelInfo()
+	case xaiBuiltinVideoModelID:
+		return xaiBuiltinVideoModelInfo()
+	case xaiBuiltinVideo15PreviewModelID:
+		return xaiBuiltinVideo15PreviewModelInfo()
+	default:
+		return nil
+	}
 }

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -50,6 +50,60 @@ func TestWithXAIBuiltinsIncludesVideoPreviewModel(t *testing.T) {
 	t.Fatalf("expected xAI builtin model %s", xaiBuiltinVideo15PreviewModelID)
 }
 
+func TestImageBuiltinsAdvertiseImageAPI(t *testing.T) {
+	tests := []struct {
+		name   string
+		models []*ModelInfo
+		ids    []string
+	}{
+		{
+			name:   "codex",
+			models: WithCodexBuiltins(nil),
+			ids:    []string{codexBuiltinImage15ModelID, codexBuiltinImageModelID},
+		},
+		{
+			name:   "xai",
+			models: WithXAIBuiltins(nil),
+			ids:    []string{xaiBuiltinImageModelID, xaiBuiltinImageQualityModelID},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			byID := make(map[string]*ModelInfo, len(tc.models))
+			for _, model := range tc.models {
+				if model != nil {
+					byID[model.ID] = model
+				}
+			}
+			for _, id := range tc.ids {
+				model := byID[id]
+				if model == nil || !model.SupportsImageAPI {
+					t.Fatalf("model %q = %+v, want image API support", id, model)
+				}
+			}
+		})
+	}
+}
+
+func TestVideoBuiltinsAdvertiseVideoAPI(t *testing.T) {
+	byID := make(map[string]*ModelInfo)
+	for _, model := range WithXAIBuiltins(nil) {
+		if model != nil {
+			byID[model.ID] = model
+		}
+	}
+	for _, id := range []string{xaiBuiltinVideoModelID, xaiBuiltinVideo15PreviewModelID} {
+		model := byID[id]
+		if model == nil || !model.SupportsVideoAPI || !model.ChatDisabled {
+			t.Fatalf("model %q = %+v, want video-only API support", id, model)
+		}
+		if model.SupportsImageAPI {
+			t.Fatalf("model %q unexpectedly supports image execution", id)
+		}
+	}
+}
+
 func TestAntigravityWebSearchModelForRequiresRequestedModelCapability(t *testing.T) {
 	registryRef := GetGlobalRegistry()
 	registryRef.RegisterClient("test-antigravity-websearch-route", "antigravity", []*ModelInfo{

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -15,13 +15,42 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// OpenAIImageModelType marks models that are callable through OpenAI-compatible image endpoints.
+// OpenAIImageModelType marks image-only models that must not be routed through chat endpoints.
 const OpenAIImageModelType = "openai-image"
 
 const (
 	DefaultClaudeMaxInputTokens  = 200000
 	DefaultClaudeMaxOutputTokens = 64000
 )
+
+// ModelExecutionKind identifies the endpoint family used to execute a model.
+type ModelExecutionKind uint8
+
+const (
+	ModelExecutionAny ModelExecutionKind = iota
+	ModelExecutionChat
+	ModelExecutionImage
+	ModelExecutionVideo
+)
+
+// ModelEndpointCapabilities reports the endpoint families exposed by a model.
+type ModelEndpointCapabilities struct {
+	Chat  bool
+	Image bool
+	Video bool
+}
+
+// ModelExecutionSnapshot describes the providers that expose an exact dynamic
+// model registration through one endpoint family.
+type ModelExecutionSnapshot struct {
+	Supported bool
+	Providers map[string]bool
+}
+
+// ProviderSupports reports whether the snapshot includes execution support from provider.
+func (s ModelExecutionSnapshot) ProviderSupports(provider string) bool {
+	return s.Providers[strings.ToLower(strings.TrimSpace(provider))]
+}
 
 // ModelInfo represents information about an available model
 type ModelInfo struct {
@@ -62,6 +91,15 @@ type ModelInfo struct {
 	// SupportsWebSearch indicates this Antigravity model is listed by
 	// fetchAvailableModels.webSearchModelIds and can execute native googleSearch.
 	SupportsWebSearch bool `json:"supports_web_search,omitempty"`
+	// SupportsImageAPI indicates that the model is callable through OpenAI-compatible image endpoints.
+	// Unlike OpenAIImageModelType, this may also be true for a chat-capable shared alias.
+	SupportsImageAPI bool `json:"-"`
+	// SupportsVideoAPI indicates that the model is callable through OpenAI-compatible video endpoints.
+	// This may also be true for a chat-capable shared alias.
+	SupportsVideoAPI bool `json:"-"`
+	// ChatDisabled marks models that must not be advertised or selected for chat endpoints.
+	// The default false value preserves chat support for existing model definitions.
+	ChatDisabled bool `json:"-"`
 
 	// Thinking holds provider-specific reasoning/thinking budget capabilities.
 	// This is optional and currently used for Gemini thinking budget normalization.
@@ -195,6 +233,164 @@ func LookupModelInfo(modelID string, provider ...string) *ModelInfo {
 		return cloneModelInfo(info)
 	}
 	return cloneModelInfo(LookupStaticModelInfo(modelID))
+}
+
+// LookupModelEndpointCapabilities returns exact dynamic aggregate capabilities,
+// falling back to an exact static definition only when no dynamic registration exists.
+func LookupModelEndpointCapabilities(modelID string) (ModelEndpointCapabilities, bool) {
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return ModelEndpointCapabilities{}, false
+	}
+	if info, supportsChat := GetGlobalRegistry().GetCatalogModelInfo(modelID); info != nil {
+		return modelEndpointCapabilities(info, supportsChat), true
+	}
+	info := LookupStaticModelInfo(modelID)
+	if info == nil {
+		return ModelEndpointCapabilities{}, false
+	}
+	return modelEndpointCapabilities(info, modelInfoSupportsChat(info)), true
+}
+
+// ModelSupportsImageAPI reports whether an exact model registration exposes image endpoints.
+func ModelSupportsImageAPI(modelID string) bool {
+	capabilities, found := LookupModelEndpointCapabilities(modelID)
+	return found && capabilities.Image
+}
+
+// ModelIsImageOnly reports whether modelID is available exclusively through
+// OpenAI-compatible image endpoints.
+func ModelIsImageOnly(modelID string) bool {
+	capabilities, found := LookupModelEndpointCapabilities(modelID)
+	return found && capabilities.Image && !capabilities.Chat
+}
+
+// GetCatalogModelInfo returns aggregate metadata for the catalog-participating model.
+// Chat-capable metadata takes precedence over endpoint-only metadata, while image/video
+// capabilities are aggregated across participating client registrations. Non-quota suspensions are
+// excluded; quota suspensions retain existing catalog visibility. The second result
+// reports whether at least one participating registration can serve chat endpoints.
+func (r *ModelRegistry) GetCatalogModelInfo(modelID string) (*ModelInfo, bool) {
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return nil, false
+	}
+
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	return r.catalogModelInfoLocked(modelID)
+}
+
+func (r *ModelRegistry) catalogModelInfoLocked(modelID string) (*ModelInfo, bool) {
+	registration := r.models[modelID]
+	if registration == nil {
+		return nil, false
+	}
+
+	var chatClientID string
+	var chatInfo *ModelInfo
+	var nonChatClientID string
+	var nonChatInfo *ModelInfo
+	supportsImageAPI := false
+	supportsVideoAPI := false
+	hasCurrentClientInfo := false
+
+	for clientID, infos := range r.clientModelInfos {
+		info := infos[modelID]
+		if info == nil || !r.clientHasModelLocked(clientID, modelID) {
+			continue
+		}
+		hasCurrentClientInfo = true
+		// Quota suspensions retain the model in catalogs during recovery windows.
+		if reason, suspended := registration.SuspendedClients[clientID]; suspended && !strings.EqualFold(strings.TrimSpace(reason), "quota") {
+			continue
+		}
+
+		if info.Type == OpenAIImageModelType || info.SupportsImageAPI {
+			supportsImageAPI = true
+		}
+		if info.SupportsVideoAPI {
+			supportsVideoAPI = true
+		}
+		if !modelInfoSupportsChat(info) {
+			if nonChatInfo == nil || clientID < nonChatClientID {
+				nonChatClientID = clientID
+				nonChatInfo = info
+			}
+			continue
+		}
+		if chatInfo == nil || clientID < chatClientID {
+			chatClientID = clientID
+			chatInfo = info
+		}
+	}
+
+	selected := chatInfo
+	supportsChat := selected != nil
+	if selected == nil {
+		selected = nonChatInfo
+	}
+	if selected == nil && !hasCurrentClientInfo {
+		// Keep registries assembled without per-client metadata usable.
+		selected = registration.Info
+		supportsChat = modelInfoSupportsChat(selected)
+		if selected != nil && (selected.Type == OpenAIImageModelType || selected.SupportsImageAPI) {
+			supportsImageAPI = true
+		}
+		if selected != nil && selected.SupportsVideoAPI {
+			supportsVideoAPI = true
+		}
+	}
+	if selected == nil {
+		return nil, false
+	}
+
+	result := cloneModelInfo(selected)
+	result.SupportsImageAPI = supportsImageAPI
+	result.SupportsVideoAPI = supportsVideoAPI
+	return result, supportsChat
+}
+
+func modelInfoSupportsChat(info *ModelInfo) bool {
+	return info != nil && info.Type != OpenAIImageModelType && !info.ChatDisabled
+}
+
+func modelEndpointCapabilities(info *ModelInfo, supportsChat bool) ModelEndpointCapabilities {
+	if info == nil {
+		return ModelEndpointCapabilities{}
+	}
+	return ModelEndpointCapabilities{
+		Chat:  supportsChat,
+		Image: info.Type == OpenAIImageModelType || info.SupportsImageAPI,
+		Video: info.SupportsVideoAPI,
+	}
+}
+
+func modelInfoSupportsExecution(info *ModelInfo, kind ModelExecutionKind) bool {
+	if info == nil {
+		return false
+	}
+	switch kind {
+	case ModelExecutionAny:
+		return true
+	case ModelExecutionChat:
+		return modelInfoSupportsChat(info)
+	case ModelExecutionImage:
+		return info.Type == OpenAIImageModelType || info.SupportsImageAPI
+	case ModelExecutionVideo:
+		return info.SupportsVideoAPI
+	default:
+		return false
+	}
+}
+
+func (r *ModelRegistry) clientHasModelLocked(clientID, modelID string) bool {
+	for _, registeredModelID := range r.clientModels[clientID] {
+		if registeredModelID == modelID {
+			return true
+		}
+	}
+	return false
 }
 
 // ModelOverrideHeaders returns models.json config.override_header for the model, if any.
@@ -801,6 +997,123 @@ func (r *ModelRegistry) ClientSupportsModel(clientID, modelID string) bool {
 	return false
 }
 
+// ClientModelSupportsExecution reports whether a specific client registration
+// exposes modelID through the requested endpoint family.
+func (r *ModelRegistry) ClientModelSupportsExecution(clientID, modelID string, kind ModelExecutionKind) bool {
+	clientID = strings.TrimSpace(clientID)
+	modelID = strings.TrimSpace(modelID)
+	if clientID == "" || modelID == "" {
+		return false
+	}
+
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	return r.clientModelSupportsExecutionLocked(clientID, modelID, kind)
+}
+
+func (r *ModelRegistry) clientModelSupportsExecutionLocked(clientID, modelID string, kind ModelExecutionKind) bool {
+	registered := false
+	for _, id := range r.clientModels[clientID] {
+		if strings.EqualFold(strings.TrimSpace(id), modelID) {
+			registered = true
+			break
+		}
+	}
+	if !registered {
+		return false
+	}
+	infos := r.clientModelInfos[clientID]
+	for id, info := range infos {
+		if !strings.EqualFold(strings.TrimSpace(id), modelID) {
+			continue
+		}
+		if info == nil {
+			return kind == ModelExecutionAny || kind == ModelExecutionChat
+		}
+		return modelInfoSupportsExecution(info, kind)
+	}
+	return kind == ModelExecutionAny || kind == ModelExecutionChat
+}
+
+// ProviderModelSupportsExecution reports whether any client registered under
+// provider exposes modelID through the requested endpoint family.
+func (r *ModelRegistry) ProviderModelSupportsExecution(provider, modelID string, kind ModelExecutionKind) bool {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	modelID = strings.TrimSpace(modelID)
+	if provider == "" || modelID == "" {
+		return false
+	}
+
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	for clientID, clientProvider := range r.clientProviders {
+		if clientProvider != provider {
+			continue
+		}
+		if r.clientModelSupportsExecutionLocked(clientID, modelID, kind) {
+			return true
+		}
+	}
+	return false
+}
+
+// LookupModelExecutionSnapshot returns execution support aggregated from every client
+// for one exact dynamic model registration. Suspension and cooldown state do not alter
+// the registration's declared endpoint capabilities.
+func (r *ModelRegistry) LookupModelExecutionSnapshot(modelID string, kind ModelExecutionKind) (ModelExecutionSnapshot, bool) {
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return ModelExecutionSnapshot{}, false
+	}
+
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	registration, found := r.models[modelID]
+	if !found || registration == nil || registration.Count <= 0 {
+		return ModelExecutionSnapshot{}, false
+	}
+
+	snapshot := ModelExecutionSnapshot{Providers: make(map[string]bool)}
+	for clientID, registeredModels := range r.clientModels {
+		registered := false
+		for _, registeredModelID := range registeredModels {
+			if strings.TrimSpace(registeredModelID) == modelID {
+				registered = true
+				break
+			}
+		}
+		if !registered {
+			continue
+		}
+
+		info := r.clientModelInfos[clientID][modelID]
+		if !modelInfoSupportsExecution(info, kind) {
+			continue
+		}
+		snapshot.Supported = true
+		if provider := strings.ToLower(strings.TrimSpace(r.clientProviders[clientID])); provider != "" {
+			snapshot.Providers[provider] = true
+		}
+	}
+	return snapshot, true
+}
+
+// ClientModelSupportsImageAPI reports whether a specific client registration
+// exposes modelID through OpenAI-compatible image endpoints.
+func (r *ModelRegistry) ClientModelSupportsImageAPI(clientID, modelID string) bool {
+	return r.ClientModelSupportsExecution(clientID, modelID, ModelExecutionImage)
+}
+
+// ClientModelSupportsChat reports whether a specific client registration can
+// serve modelID through chat endpoints. Registrations without metadata retain
+// the legacy chat-capable default.
+func (r *ModelRegistry) ClientModelSupportsChat(clientID, modelID string) bool {
+	return r.ClientModelSupportsExecution(clientID, modelID, ModelExecutionChat)
+}
+
 // GetAvailableModels returns all models that have at least one available client
 // Parameters:
 //   - handlerType: The handler type to filter models for (e.g., "openai", "claude", "gemini")
@@ -839,7 +1152,7 @@ func (r *ModelRegistry) buildAvailableModelsLocked(handlerType string, now time.
 	models := make([]map[string]any, 0, len(r.models))
 	var expiresAt time.Time
 
-	for _, registration := range r.models {
+	for modelID, registration := range r.models {
 		availableClients := registration.Count
 
 		expiredClients := 0
@@ -874,7 +1187,8 @@ func (r *ModelRegistry) buildAvailableModelsLocked(handlerType string, now time.
 		}
 
 		if effectiveClients > 0 || (availableClients > 0 && (expiredClients > 0 || cooldownSuspended > 0) && otherSuspended == 0) {
-			model := r.convertModelToMap(registration.Info, handlerType)
+			info, _ := r.catalogModelInfoLocked(modelID)
+			model := r.convertModelToMap(info, handlerType)
 			if model != nil {
 				models = append(models, model)
 			}

--- a/internal/registry/model_registry_catalog_test.go
+++ b/internal/registry/model_registry_catalog_test.go
@@ -1,0 +1,304 @@
+package registry
+
+import "testing"
+
+func TestGetCatalogModelInfoPrefersChatRegistration(t *testing.T) {
+	for _, imageFirst := range []bool{false, true} {
+		name := "chat-first"
+		if imageFirst {
+			name = "image-first"
+		}
+		t.Run(name, func(t *testing.T) {
+			r := newTestModelRegistry()
+			registerSharedCatalogTestModel(r, imageFirst)
+
+			info, supportsChat := r.GetCatalogModelInfo("shared-catalog-model")
+			if !supportsChat {
+				t.Fatal("expected shared model to support chat")
+			}
+			if info == nil {
+				t.Fatal("expected aggregate model metadata")
+			}
+			if info.Type != "openai-compatibility" || info.DisplayName != "Chat Model" {
+				t.Fatalf("aggregate metadata = %#v, want chat registration", info)
+			}
+			if !info.SupportsImageAPI {
+				t.Fatal("expected aggregate image API capability")
+			}
+			if info.Thinking == nil || len(info.Thinking.Levels) != 2 || info.Thinking.Levels[1] != "high" {
+				t.Fatalf("aggregate thinking = %#v, want chat thinking metadata", info.Thinking)
+			}
+			if len(info.SupportedInputModalities) != 2 || info.SupportedInputModalities[1] != "image" {
+				t.Fatalf("aggregate input modalities = %#v, want chat modalities", info.SupportedInputModalities)
+			}
+
+			r.UnregisterClient("chat-client")
+
+			info, supportsChat = r.GetCatalogModelInfo("shared-catalog-model")
+			if supportsChat {
+				t.Fatal("expected image-only model after unregistering the last chat client")
+			}
+			if info == nil || info.Type != OpenAIImageModelType || info.DisplayName != "Image Model" {
+				t.Fatalf("remaining metadata = %#v, want image-only registration", info)
+			}
+			if !info.SupportsImageAPI {
+				t.Fatal("expected remaining image API capability")
+			}
+		})
+	}
+}
+
+func TestGetAvailableModelsPrefersChatRegistrationMetadata(t *testing.T) {
+	for _, imageFirst := range []bool{false, true} {
+		name := "chat-first"
+		if imageFirst {
+			name = "image-first"
+		}
+		t.Run(name, func(t *testing.T) {
+			r := newTestModelRegistry()
+			registerSharedCatalogTestModel(r, imageFirst)
+
+			model := onlyAvailableCatalogTestModel(t, r)
+			if got := model["type"]; got != "openai-compatibility" {
+				t.Fatalf("shared model type = %#v, want chat type", got)
+			}
+			if got := model["display_name"]; got != "Chat Model" {
+				t.Fatalf("shared display_name = %#v, want chat metadata", got)
+			}
+			if got := model["context_length"]; got != 123456 {
+				t.Fatalf("shared context_length = %#v, want chat metadata", got)
+			}
+
+			r.UnregisterClient("chat-client")
+
+			model = onlyAvailableCatalogTestModel(t, r)
+			if got := model["type"]; got != OpenAIImageModelType {
+				t.Fatalf("remaining model type = %#v, want image-only type", got)
+			}
+			if got := model["display_name"]; got != "Image Model" {
+				t.Fatalf("remaining display_name = %#v, want image metadata", got)
+			}
+		})
+	}
+}
+
+func TestCatalogModelInfoSkipsNonQuotaSuspendedRegistrations(t *testing.T) {
+	r := newTestModelRegistry()
+	registerSharedCatalogTestModel(r, false)
+
+	r.SuspendClientModel("chat-client", "shared-catalog-model", "model_not_supported")
+	info, supportsChat := r.GetCatalogModelInfo("shared-catalog-model")
+	if supportsChat || info == nil || info.DisplayName != "Image Model" {
+		t.Fatalf("chat-suspended aggregate = %#v, supportsChat=%v", info, supportsChat)
+	}
+	if got := onlyAvailableCatalogTestModel(t, r)["display_name"]; got != "Image Model" {
+		t.Fatalf("chat-suspended available metadata = %#v, want image metadata", got)
+	}
+
+	r.ResumeClientModel("chat-client", "shared-catalog-model")
+	info, supportsChat = r.GetCatalogModelInfo("shared-catalog-model")
+	if !supportsChat || info == nil || info.DisplayName != "Chat Model" || !info.SupportsImageAPI {
+		t.Fatalf("resumed aggregate = %#v, supportsChat=%v", info, supportsChat)
+	}
+
+	r.SuspendClientModel("image-client", "shared-catalog-model", "model_not_supported")
+	info, supportsChat = r.GetCatalogModelInfo("shared-catalog-model")
+	if !supportsChat || info == nil || info.DisplayName != "Chat Model" {
+		t.Fatalf("image-suspended aggregate = %#v, supportsChat=%v", info, supportsChat)
+	}
+	if info.SupportsImageAPI {
+		t.Fatal("image capability should exclude the non-quota suspended image registration")
+	}
+	if got := onlyAvailableCatalogTestModel(t, r)["display_name"]; got != "Chat Model" {
+		t.Fatalf("image-suspended available metadata = %#v, want chat metadata", got)
+	}
+
+	r.SuspendClientModel("chat-client", "shared-catalog-model", "model_not_supported")
+	info, supportsChat = r.GetCatalogModelInfo("shared-catalog-model")
+	if supportsChat || info != nil {
+		t.Fatalf("all-suspended aggregate = %#v, supportsChat=%v, want unavailable", info, supportsChat)
+	}
+	if models := r.GetAvailableModels("openai"); len(models) != 0 {
+		t.Fatalf("all-suspended available models = %#v, want none", models)
+	}
+
+	r.ResumeClientModel("chat-client", "shared-catalog-model")
+	r.ResumeClientModel("image-client", "shared-catalog-model")
+	r.SuspendClientModel("chat-client", "shared-catalog-model", "quota")
+	info, supportsChat = r.GetCatalogModelInfo("shared-catalog-model")
+	if !supportsChat || info == nil || info.DisplayName != "Chat Model" || !info.SupportsImageAPI {
+		t.Fatalf("quota-suspended aggregate = %#v, supportsChat=%v", info, supportsChat)
+	}
+}
+
+func TestGetCatalogModelInfoTreatsProviderBuiltinsAsNonChat(t *testing.T) {
+	tests := []struct {
+		provider string
+		model    *ModelInfo
+	}{
+		{
+			provider: "codex",
+			model:    codexBuiltinImageModelInfo(),
+		},
+		{
+			provider: "xai",
+			model:    xaiBuiltinImageModelInfo(),
+		},
+		{
+			provider: "xai",
+			model:    xaiBuiltinVideoModelInfo(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.provider+"/"+tc.model.ID, func(t *testing.T) {
+			r := newTestModelRegistry()
+			r.RegisterClient("builtin-client", tc.provider, []*ModelInfo{tc.model})
+
+			info, supportsChat := r.GetCatalogModelInfo(tc.model.ID)
+			if supportsChat {
+				t.Fatalf("builtin %q unexpectedly supports chat", tc.model.ID)
+			}
+			if info == nil || info.ID != tc.model.ID {
+				t.Fatalf("builtin metadata = %#v, want %q", info, tc.model.ID)
+			}
+		})
+	}
+}
+
+func TestGetCatalogModelInfoAggregatesVideoCapabilityAcrossSharedAlias(t *testing.T) {
+	r := newTestModelRegistry()
+	const modelID = "shared-video-catalog-model"
+	r.RegisterClient("shared-video-chat", "xai", []*ModelInfo{{
+		ID:          modelID,
+		Type:        "xai",
+		DisplayName: "Chat Model",
+	}})
+	r.RegisterClient("shared-video-endpoint", "xai", []*ModelInfo{{
+		ID:               modelID,
+		Type:             "xai",
+		DisplayName:      "Video Model",
+		SupportsVideoAPI: true,
+		ChatDisabled:     true,
+	}})
+
+	info, supportsChat := r.GetCatalogModelInfo(modelID)
+	if info == nil || !supportsChat || !info.SupportsVideoAPI || info.DisplayName != "Chat Model" {
+		t.Fatalf("shared video aggregate = %#v, supportsChat=%v", info, supportsChat)
+	}
+	if !r.ClientModelSupportsExecution("shared-video-chat", modelID, ModelExecutionChat) {
+		t.Fatal("chat registration lost chat execution")
+	}
+	if r.ClientModelSupportsExecution("shared-video-chat", modelID, ModelExecutionVideo) {
+		t.Fatal("chat-only registration unexpectedly supports video")
+	}
+	if !r.ClientModelSupportsExecution("shared-video-endpoint", modelID, ModelExecutionVideo) {
+		t.Fatal("video registration lost video execution")
+	}
+	if r.ClientModelSupportsExecution("shared-video-endpoint", modelID, ModelExecutionChat) {
+		t.Fatal("video-only registration unexpectedly supports chat")
+	}
+}
+
+func TestLookupModelExecutionSnapshot(t *testing.T) {
+	r := newTestModelRegistry()
+	const modelID = "shared-provider-execution-model"
+
+	if snapshot, found := r.LookupModelExecutionSnapshot(modelID, ModelExecutionImage); found || snapshot.Supported {
+		t.Fatalf("unregistered model = %#v, found %v; want empty, false", snapshot, found)
+	}
+
+	r.RegisterClient("compat-image", "openai-compatibility", []*ModelInfo{{
+		ID:               modelID,
+		Type:             OpenAIImageModelType,
+		SupportsImageAPI: true,
+		ChatDisabled:     true,
+	}})
+	snapshot, found := r.LookupModelExecutionSnapshot(modelID, ModelExecutionImage)
+	if !found || !snapshot.Supported || snapshot.ProviderSupports("xai") || !snapshot.ProviderSupports("openai-compatibility") {
+		t.Fatalf("compatibility image registration = %#v, found %v", snapshot, found)
+	}
+	if snapshot, found = r.LookupModelExecutionSnapshot("tenant/"+modelID, ModelExecutionImage); found || snapshot.Supported {
+		t.Fatalf("different exact model ID = %#v, found %v; want empty, false", snapshot, found)
+	}
+
+	r.RegisterClient("xai-chat", "xai", []*ModelInfo{{
+		ID:   modelID,
+		Type: "xai",
+	}})
+	snapshot, found = r.LookupModelExecutionSnapshot(modelID, ModelExecutionImage)
+	if !found || !snapshot.Supported || snapshot.ProviderSupports("xai") || !snapshot.ProviderSupports("openai-compatibility") {
+		t.Fatalf("xAI chat plus compatibility image registration = %#v, found %v", snapshot, found)
+	}
+
+	r.RegisterClient("xai-image", "xai", []*ModelInfo{{
+		ID:               modelID,
+		Type:             "xai",
+		SupportsImageAPI: true,
+		ChatDisabled:     true,
+	}})
+	snapshot, found = r.LookupModelExecutionSnapshot(modelID, ModelExecutionImage)
+	if !found || !snapshot.Supported || !snapshot.ProviderSupports("xai") || !snapshot.ProviderSupports("openai-compatibility") {
+		t.Fatalf("shared image registration = %#v, found %v", snapshot, found)
+	}
+	r.SuspendClientModel("xai-image", modelID, "model_not_supported")
+	r.SetModelQuotaExceeded("compat-image", modelID)
+	snapshot, found = r.LookupModelExecutionSnapshot(modelID, ModelExecutionImage)
+	if !found || !snapshot.Supported || !snapshot.ProviderSupports("xai") || !snapshot.ProviderSupports("openai-compatibility") {
+		t.Fatalf("suspended and cooling registrations = %#v, found %v; want declared capabilities", snapshot, found)
+	}
+
+	r.UnregisterClient("xai-image")
+	r.UnregisterClient("xai-chat")
+	r.UnregisterClient("compat-image")
+	if snapshot, found = r.LookupModelExecutionSnapshot(modelID, ModelExecutionImage); found || snapshot.Supported {
+		t.Fatalf("removed model = %#v, found %v; want empty, false", snapshot, found)
+	}
+}
+
+func registerSharedCatalogTestModel(r *ModelRegistry, imageFirst bool) {
+	chat := &ModelInfo{
+		ID:                        "shared-catalog-model",
+		Object:                    "model",
+		OwnedBy:                   "chat-owner",
+		Type:                      "openai-compatibility",
+		DisplayName:               "Chat Model",
+		Description:               "Chat metadata",
+		ContextLength:             123456,
+		SupportedInputModalities:  []string{"text", "image"},
+		SupportedOutputModalities: []string{"text"},
+		Thinking:                  &ThinkingSupport{Levels: []string{"low", "high"}},
+	}
+	image := &ModelInfo{
+		ID:                        "shared-catalog-model",
+		Object:                    "model",
+		OwnedBy:                   "image-owner",
+		Type:                      OpenAIImageModelType,
+		DisplayName:               "Image Model",
+		Description:               "Image metadata",
+		SupportedOutputModalities: []string{"image"},
+	}
+
+	registerChat := func() {
+		r.RegisterClient("chat-client", "openai-compatibility", []*ModelInfo{chat})
+	}
+	registerImage := func() {
+		r.RegisterClient("image-client", "openai-compatibility", []*ModelInfo{image})
+	}
+	if imageFirst {
+		registerImage()
+		registerChat()
+		return
+	}
+	registerChat()
+	registerImage()
+}
+
+func onlyAvailableCatalogTestModel(t *testing.T, r *ModelRegistry) map[string]any {
+	t.Helper()
+	models := r.GetAvailableModels("openai")
+	if len(models) != 1 {
+		t.Fatalf("available models = %#v, want one model", models)
+	}
+	return models[0]
+}

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -43,7 +43,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, stream)
 	body = helps.SetStringIfDifferent(body, "model", upstreamModel)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -44,7 +44,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, true)
 	body = helps.SetStringIfDifferent(body, "model", upstreamModel)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1816,6 +1816,26 @@ func TestEnforceCacheControlLimit_ToolOnlyPayloadStillRespectsLimit(t *testing.T
 	}
 }
 
+func TestClaudeExecutor_CountTokensValidatesSuffixThinkingLocally(t *testing.T) {
+	executor := NewClaudeExecutor(&config.Config{})
+	payload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")}
+
+	if _, err := executor.CountTokens(context.Background(), nil, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-4-6(high)",
+		Payload: payload,
+	}, opts); err != nil {
+		t.Fatalf("CountTokens() valid suffix error = %v", err)
+	}
+
+	if _, err := executor.CountTokens(context.Background(), nil, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-4-6(xhigh)",
+		Payload: payload,
+	}, opts); err == nil {
+		t.Fatal("CountTokens() unsupported suffix error = nil")
+	}
+}
+
 func TestClaudeExecutor_ExecuteSanitizesSignaturesBeforeUpstream(t *testing.T) {
 	var seenBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/executor/claude_executor_tokens.go
+++ b/internal/runtime/executor/claude_executor_tokens.go
@@ -26,6 +26,11 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	// Use streaming translation to preserve function calling, except for claude.
 	stream := from != to
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, stream)
+	var errThinking error
+	body, errThinking = helps.ApplyRequestThinking(body, auth, req, opts, from.String(), to.String(), e.Identifier())
+	if errThinking != nil {
+		return cliproxyexecutor.Response{}, errThinking
+	}
 	if rebuildMidSystemMessageEnabled(e.cfg, auth) {
 		body = rebuildMidSystemMessagesToTopLevel(body)
 	}
@@ -113,6 +118,11 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 	stream := from != to
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, stream)
 	body = helps.SetStringIfDifferent(body, "model", upstreamModel)
+	var errThinking error
+	body, errThinking = helps.ApplyRequestThinking(body, auth, req, opts, from.String(), to.String(), e.Identifier())
+	if errThinking != nil {
+		return cliproxyexecutor.Response{}, errThinking
+	}
 	if rebuildMidSystemMessageEnabled(e.cfg, auth) {
 		body = rebuildMidSystemMessagesToTopLevel(body)
 	}

--- a/internal/runtime/executor/codex_executor_execute.go
+++ b/internal/runtime/executor/codex_executor_execute.go
@@ -45,7 +45,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -214,7 +214,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -46,7 +46,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/executor/codex_executor_tokens.go
+++ b/internal/runtime/executor/codex_executor_tokens.go
@@ -23,7 +23,7 @@ func (e *CodexExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth
 	to := sdktranslator.FromString("codex")
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
-	body, err := thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err := helps.ApplyRequestThinking(body, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -46,7 +46,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -46,7 +46,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -148,7 +148,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, false)
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -261,7 +261,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, true)
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +391,7 @@ func (e *GeminiExecutor) executeInteractions(ctx context.Context, auth *cliproxy
 	if gjson.GetBytes(body, "model").Exists() && targetName != "" {
 		body = helps.SetStringIfDifferent(body, "model", targetName)
 	}
-	body, err = applyGeminiInteractionsThinking(body, req.Model)
+	body, err = applyGeminiInteractionsThinking(body, auth, req, opts)
 	if err != nil {
 		return resp, err
 	}
@@ -467,7 +467,7 @@ func (e *GeminiExecutor) executeInteractionsStream(ctx context.Context, auth *cl
 	if gjson.GetBytes(body, "model").Exists() && targetName != "" {
 		body = helps.SetStringIfDifferent(body, "model", targetName)
 	}
-	body, err = applyGeminiInteractionsThinking(body, req.Model)
+	body, err = applyGeminiInteractionsThinking(body, auth, req, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -621,7 +621,7 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	to := sdktranslator.FromString("gemini")
 	translatedReq := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false)
 
-	translatedReq, err := thinking.ApplyThinking(translatedReq, req.Model, from.String(), to.String(), e.Identifier())
+	translatedReq, err := helps.ApplyRequestThinking(translatedReq, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}
@@ -801,8 +801,12 @@ func isNativeInteractionsAuth(auth *cliproxyauth.Auth) bool {
 	return strings.EqualFold(strings.TrimSpace(auth.Provider), "gemini-interactions")
 }
 
-func applyGeminiInteractionsThinking(body []byte, model string) ([]byte, error) {
-	return thinking.ApplyThinking(body, model, sdktranslator.FormatInteractions.String(), sdktranslator.FormatInteractions.String(), "gemini")
+func applyGeminiInteractionsThinking(body []byte, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) ([]byte, error) {
+	fromFormat := opts.SourceFormat.String()
+	if strings.TrimSpace(fromFormat) == "" {
+		fromFormat = sdktranslator.FormatInteractions.String()
+	}
+	return helps.ApplyRequestThinking(body, auth, req, opts, fromFormat, sdktranslator.FormatInteractions.String(), "gemini")
 }
 
 func applyGeminiInteractionsRevisionHeader(req *http.Request) {

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -456,7 +456,7 @@ func (e *GeminiVertexExecutor) executeWithAPIKey(ctx context.Context, auth *clip
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, false)
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -717,7 +717,7 @@ func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, true)
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}
@@ -945,7 +945,7 @@ func (e *GeminiVertexExecutor) countTokensWithAPIKey(ctx context.Context, auth *
 
 	translatedReq := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false)
 
-	translatedReq, err := thinking.ApplyThinking(translatedReq, req.Model, from.String(), to.String(), e.Identifier())
+	translatedReq, err := helps.ApplyRequestThinking(translatedReq, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}

--- a/internal/runtime/executor/helps/model_capabilities.go
+++ b/internal/runtime/executor/helps/model_capabilities.go
@@ -1,0 +1,30 @@
+package helps
+
+import (
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// ResolveAPIKeyModelInfo returns the exact configured model definition bound by
+// the auth manager to this API-key execution attempt.
+func ResolveAPIKeyModelInfo(auth *cliproxyauth.Auth, req cliproxyexecutor.Request) (*registry.ModelInfo, bool) {
+	if auth == nil {
+		return nil, false
+	}
+	return cliproxyauth.ResolvedAPIKeyModelInfo(req)
+}
+
+// ApplyRequestThinking preserves the existing registry path unless the auth
+// manager selected an exact configured API-key model definition.
+func ApplyRequestThinking(body []byte, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, fromFormat, toFormat, provider string) ([]byte, error) {
+	if modelInfo, ok := ResolveAPIKeyModelInfo(auth, req); ok {
+		sourceBody := opts.OriginalRequest
+		if len(sourceBody) == 0 {
+			sourceBody = req.Payload
+		}
+		return thinking.ApplyThinkingWithModelInfo(body, sourceBody, req.Model, fromFormat, toFormat, provider, modelInfo)
+	}
+	return thinking.ApplyThinking(body, req.Model, fromFormat, toFormat, provider)
+}

--- a/internal/runtime/executor/helps/model_capabilities_test.go
+++ b/internal/runtime/executor/helps/model_capabilities_test.go
@@ -1,0 +1,208 @@
+package helps_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	helpers "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/claude"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+type capabilityTestExecutor struct {
+	seenModel string
+	resolved  bool
+}
+
+func (e *capabilityTestExecutor) Identifier() string { return "claude" }
+
+func (e *capabilityTestExecutor) Execute(_ context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.seenModel = req.Model
+	_, e.resolved = helpers.ResolveAPIKeyModelInfo(auth, req)
+	out, err := applyCapabilityTestThinking(auth, req, opts)
+	return cliproxyexecutor.Response{Payload: out}, err
+}
+
+func (e *capabilityTestExecutor) ExecuteStream(_ context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.seenModel = req.Model
+	_, e.resolved = helpers.ResolveAPIKeyModelInfo(auth, req)
+	out, err := applyCapabilityTestThinking(auth, req, opts)
+	if err != nil {
+		return nil, err
+	}
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: out}
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (*capabilityTestExecutor) Refresh(_ context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *capabilityTestExecutor) CountTokens(_ context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.seenModel = req.Model
+	_, e.resolved = helpers.ResolveAPIKeyModelInfo(auth, req)
+	out, err := applyCapabilityTestThinking(auth, req, opts)
+	return cliproxyexecutor.Response{Payload: out}, err
+}
+
+func (*capabilityTestExecutor) HttpRequest(context.Context, *cliproxyauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func applyCapabilityTestThinking(auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) ([]byte, error) {
+	translated := []byte(`{"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}}`)
+	return helpers.ApplyRequestThinking(translated, auth, req, opts, opts.SourceFormat.String(), "claude", "claude")
+}
+
+func TestApplyRequestThinkingUsesSelectedPrefixedAPIKeyModel(t *testing.T) {
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{
+		SDKConfig: internalconfig.SDKConfig{ForceModelPrefix: true},
+		ClaudeKey: []internalconfig.ClaudeKey{{
+			APIKey: "test-key",
+			Prefix: "tenant",
+			Models: []internalconfig.ClaudeModel{{
+				Name: "claude-upstream", Alias: "claude-public",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"high"}},
+			}},
+		}},
+	})
+	executor := &capabilityTestExecutor{}
+	manager.RegisterExecutor(executor)
+	auth := &cliproxyauth.Auth{
+		ID:       "prefixed-claude-key",
+		Provider: "claude",
+		Prefix:   "tenant",
+		Attributes: map[string]string{
+			cliproxyauth.AttributeAuthKind: cliproxyauth.AuthKindAPIKey,
+			cliproxyauth.AttributeAPIKey:   "test-key",
+			cliproxyauth.AttributeSource:   "config:claude[0]",
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{
+		ID: "tenant/claude-public", Type: "claude",
+	}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(auth.ID) })
+
+	source := []byte(`{"model":"tenant/claude-public","reasoning_effort":"xhigh"}`)
+	req := cliproxyexecutor.Request{Model: "tenant/claude-public", Payload: source}
+	opts := cliproxyexecutor.Options{OriginalRequest: source, SourceFormat: sdktranslator.FormatOpenAI}
+
+	resp, err := manager.Execute(context.Background(), []string{"claude"}, req, opts)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	assertCapabilityExecution(t, executor, resp.Payload)
+
+	countResp, err := manager.ExecuteCount(context.Background(), []string{"claude"}, req, opts)
+	if err != nil {
+		t.Fatalf("ExecuteCount() error = %v", err)
+	}
+	assertCapabilityExecution(t, executor, countResp.Payload)
+
+	stream, err := manager.ExecuteStream(context.Background(), []string{"claude"}, req, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	var streamPayload []byte
+	for chunk := range stream.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+		streamPayload = append(streamPayload, chunk.Payload...)
+	}
+	assertCapabilityExecution(t, executor, streamPayload)
+}
+
+func assertCapabilityExecution(t *testing.T, executor *capabilityTestExecutor, payload []byte) {
+	t.Helper()
+	if executor.seenModel != "claude-upstream" {
+		t.Fatalf("executor model = %q, want claude-upstream", executor.seenModel)
+	}
+	if !executor.resolved {
+		t.Fatal("executor request did not receive the selected model capability")
+	}
+	if got := gjson.GetBytes(payload, "output_config.effort").String(); got != "high" {
+		t.Fatalf("output effort = %q, want high; body=%s", got, payload)
+	}
+}
+
+func TestApplyRequestThinkingKeepsLegacyPathWithoutBinding(t *testing.T) {
+	req := cliproxyexecutor.Request{Model: "claude-upstream", Payload: []byte(`{"reasoning_effort":"xhigh"}`)}
+	opts := cliproxyexecutor.Options{OriginalRequest: req.Payload}
+	translated := []byte(`{"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}}`)
+	auth := &cliproxyauth.Auth{Provider: "claude", Attributes: map[string]string{
+		cliproxyauth.AttributeAuthKind: cliproxyauth.AuthKindOAuth,
+	}}
+
+	out, err := helpers.ApplyRequestThinking(translated, auth, req, opts, "openai", "claude", "claude")
+	if err != nil {
+		t.Fatalf("ApplyRequestThinking() error = %v", err)
+	}
+	want, wantErr := thinking.ApplyThinking(translated, req.Model, "openai", "claude", "claude")
+	if wantErr != nil {
+		t.Fatalf("ApplyThinking() error = %v", wantErr)
+	}
+	if !bytes.Equal(out, want) {
+		t.Fatalf("helper output = %s, want legacy output %s", out, want)
+	}
+}
+
+func TestAuthSelectionOnlyModelDoesNotBindConfiguredCapabilities(t *testing.T) {
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{ClaudeKey: []internalconfig.ClaudeKey{{
+		APIKey: "test-key",
+		Prefix: "tenant",
+		Models: []internalconfig.ClaudeModel{{
+			Name: "claude-upstream", Alias: "claude-public",
+			Thinking: &registry.ThinkingSupport{Levels: []string{"high"}},
+		}},
+	}}})
+	executor := &capabilityTestExecutor{}
+	manager.RegisterExecutor(executor)
+	auth := &cliproxyauth.Auth{
+		ID: "selection-only-auth", Provider: "claude", Prefix: "tenant",
+		Attributes: map[string]string{
+			cliproxyauth.AttributeAPIKey: "test-key",
+			cliproxyauth.AttributeSource: "config:claude[test]",
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "tenant/claude-public"}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(auth.ID) })
+
+	req := cliproxyexecutor.Request{Model: "plugin-execution-model", Payload: []byte(`{"reasoning_effort":"xhigh"}`)}
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: req.Payload,
+		SourceFormat:    sdktranslator.FormatOpenAI,
+		Metadata: map[string]any{
+			cliproxyexecutor.AuthSelectionModelMetadataKey: "tenant/claude-public",
+		},
+	}
+	if _, err := manager.Execute(context.Background(), []string{"claude"}, req, opts); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if executor.seenModel != "plugin-execution-model" {
+		t.Fatalf("executor model = %q, want plugin-execution-model", executor.seenModel)
+	}
+	if executor.resolved {
+		t.Fatal("auth-selection-only model unexpectedly bound configured capabilities")
+	}
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -114,7 +114,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, opts.Stream)
 	translated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, opts.Stream)
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err = helps.ApplyRequestThinking(translated, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -315,7 +315,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, true)
 	translated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, true)
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err = helps.ApplyRequestThinking(translated, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}
@@ -587,7 +587,7 @@ func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyau
 
 	modelForCounting := baseModel
 
-	translated, err := thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err := helps.ApplyRequestThinking(translated, auth, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}

--- a/internal/runtime/executor/xai_executor_execute.go
+++ b/internal/runtime/executor/xai_executor_execute.go
@@ -33,7 +33,7 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 	baseURL := xaiChatBaseURL(auth)
 	logXAIResolvedBaseURL(ctx, baseURL)
 
-	prepared, err := e.prepareResponsesRequest(ctx, req, opts, true)
+	prepared, err := e.prepareResponsesRequest(ctx, auth, req, opts, true)
 	if err != nil {
 		return resp, err
 	}
@@ -131,7 +131,7 @@ func (e *XAIExecutor) executeCompactRequest(ctx context.Context, auth *cliproxya
 	baseURL := xaiCompactBaseURL(auth)
 	logXAIResolvedBaseURL(ctx, baseURL)
 
-	prepared, err := e.prepareResponsesRequestTo(ctx, req, opts, false, sdktranslator.FormatOpenAIResponse)
+	prepared, err := e.prepareResponsesRequestTo(ctx, auth, req, opts, false, sdktranslator.FormatOpenAIResponse)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/runtime/executor/xai_executor_media.go
+++ b/internal/runtime/executor/xai_executor_media.go
@@ -17,11 +17,13 @@ import (
 )
 
 func (e *XAIExecutor) executeImages(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, endpointPath string) (resp cliproxyexecutor.Response, err error) {
-	model := strings.TrimSpace(gjson.GetBytes(req.Payload, "model").String())
-	if model == "" {
-		model = strings.TrimSpace(req.Model)
+	// req.Model is credential-scoped and alias-resolved; the payload can still
+	// contain the client-facing alias or provider-prefixed model.
+	resolvedModel := strings.TrimSpace(req.Model)
+	if resolvedModel == "" {
+		resolvedModel = strings.TrimSpace(gjson.GetBytes(req.Payload, "model").String())
 	}
-	reporter := helps.NewExecutorUsageReporter(ctx, e, model, auth)
+	reporter := helps.NewExecutorUsageReporter(ctx, e, resolvedModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
 
 	token, baseURL := xaiCreds(auth)
@@ -34,6 +36,9 @@ func (e *XAIExecutor) executeImages(ctx context.Context, auth *cliproxyauth.Auth
 	}
 
 	payload := normalizeXAIImageRefs(req.Payload)
+	if resolvedModel != "" {
+		payload = helps.SetStringIfDifferent(payload, "model", resolvedModel)
+	}
 	url := strings.TrimSuffix(baseURL, "/") + endpointPath
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
@@ -74,9 +79,11 @@ func (e *XAIExecutor) executeImages(ctx context.Context, auth *cliproxyauth.Auth
 }
 
 func (e *XAIExecutor) executeVideos(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
-	model := strings.TrimSpace(gjson.GetBytes(req.Payload, "model").String())
+	// req.Model is credential-scoped and alias-resolved; the payload can still
+	// contain the client-facing alias or provider-prefixed model.
+	model := strings.TrimSpace(req.Model)
 	if model == "" {
-		model = strings.TrimSpace(req.Model)
+		model = strings.TrimSpace(gjson.GetBytes(req.Payload, "model").String())
 	}
 	reporter := helps.NewExecutorUsageReporter(ctx, e, model, auth)
 	defer reporter.TrackFailure(ctx, &err)
@@ -88,6 +95,9 @@ func (e *XAIExecutor) executeVideos(ctx context.Context, auth *cliproxyauth.Auth
 	logXAIResolvedBaseURL(ctx, baseURL)
 
 	payload := normalizeXAIImageRefs(req.Payload)
+	if model != "" {
+		payload = helps.SetStringIfDifferent(payload, "model", model)
+	}
 	method := http.MethodPost
 	endpointPath := xaiVideosGenerationsPath
 	var body io.Reader = bytes.NewReader(payload)

--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -54,11 +54,11 @@ type xaiClientToolKey struct {
 	toolType  string
 }
 
-func (e *XAIExecutor) prepareResponsesRequest(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) (*xaiPreparedRequest, error) {
-	return e.prepareResponsesRequestTo(ctx, req, opts, stream, sdktranslator.FormatCodex)
+func (e *XAIExecutor) prepareResponsesRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) (*xaiPreparedRequest, error) {
+	return e.prepareResponsesRequestTo(ctx, auth, req, opts, stream, sdktranslator.FormatCodex)
 }
 
-func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool, to sdktranslator.Format) (*xaiPreparedRequest, error) {
+func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool, to sdktranslator.Format) (*xaiPreparedRequest, error) {
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
@@ -73,7 +73,7 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	body = preserveXAIResponsesOutputControls(body, req.Payload, from)
 
 	var err error
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), e.Identifier(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, auth, req, opts, from.String(), e.Identifier(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/executor/xai_executor_stream.go
+++ b/internal/runtime/executor/xai_executor_stream.go
@@ -27,7 +27,7 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 	baseURL := xaiChatBaseURL(auth)
 	logXAIResolvedBaseURL(ctx, baseURL)
 
-	prepared, err := e.prepareResponsesRequest(ctx, req, opts, true)
+	prepared, err := e.prepareResponsesRequest(ctx, auth, req, opts, true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -20,6 +20,7 @@ import (
 	xaiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/xai"
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -347,7 +348,7 @@ func TestXAIExecutorPrepareResponsesRequestRewritesCodexAgentMessage(t *testing.
 			"internal_chat_message_metadata_passthrough":{"turn_id":"019f92c3-6772-7213-8aac-8bd154d528f1"}
 		}]
 	}`)
-	prepared, errPrepare := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+	prepared, errPrepare := exec.prepareResponsesRequest(context.Background(), nil, cliproxyexecutor.Request{
 		Model:   "grok-4.5",
 		Payload: payload,
 	}, cliproxyexecutor.Options{
@@ -673,7 +674,7 @@ func TestXAIExecutorPrepareHonorsInjectXSearchConfig(t *testing.T) {
 			t.Parallel()
 
 			exec := NewXAIExecutor(tt.cfg)
-			prepared, errPrepare := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+			prepared, errPrepare := exec.prepareResponsesRequest(context.Background(), nil, cliproxyexecutor.Request{
 				Model: "grok-4.5",
 				Payload: []byte(`{
 					"model":"grok-4.5",
@@ -854,7 +855,7 @@ func TestXAIExecutorPrepareDropsOrphanedToolChoiceBeforeXSearchInject(t *testing
 	t.Parallel()
 
 	exec := NewXAIExecutor(&config.Config{XAI: config.XAIConfig{InjectXSearch: true}})
-	prepared, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+	prepared, err := exec.prepareResponsesRequest(context.Background(), nil, cliproxyexecutor.Request{
 		Model: "grok-4.5",
 		// image_generation is stripped by normalizeXAITools; without pruning, the
 		// forced choice would survive next to the injected x_search tool.
@@ -962,7 +963,7 @@ func TestXAIExecutorPrepareResponsesRequestPreservesSupportedOutputControls(t *t
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			prepared, errPrepare := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+			prepared, errPrepare := exec.prepareResponsesRequest(context.Background(), nil, cliproxyexecutor.Request{
 				Model:   "grok-4.5",
 				Payload: tt.payload,
 			}, cliproxyexecutor.Options{
@@ -1000,7 +1001,7 @@ func TestXAIExecutorPrepareResponsesRequestDropsPayloadStopOverride(t *testing.T
 			},
 		},
 	})
-	prepared, errPrepare := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+	prepared, errPrepare := exec.prepareResponsesRequest(context.Background(), nil, cliproxyexecutor.Request{
 		Model:   "grok-4.5",
 		Payload: []byte(`{"model":"grok-4.5","input":"hello"}`),
 	}, cliproxyexecutor.Options{
@@ -1073,7 +1074,7 @@ func TestXAIExecutorPrepareResponsesRequestAddsObjectTypeToRootUnionBranches(t *
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			prepared, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+			prepared, err := exec.prepareResponsesRequest(context.Background(), nil, cliproxyexecutor.Request{
 				Model:   "grok-4.5",
 				Payload: tt.payload,
 			}, cliproxyexecutor.Options{
@@ -1124,7 +1125,7 @@ func TestXAIExecutorPrepareAllowedToolsSyncsInjectedXSearch(t *testing.T) {
 	t.Parallel()
 
 	exec := NewXAIExecutor(&config.Config{XAI: config.XAIConfig{InjectXSearch: true}})
-	prepared, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+	prepared, err := exec.prepareResponsesRequest(context.Background(), nil, cliproxyexecutor.Request{
 		Model: "grok-4.5",
 		// Only image_generation remains after client filtering of tool_search-like
 		// tools is not relevant here: normalizeXAITools drops image_generation and
@@ -1769,7 +1770,7 @@ func TestXAIExecutorComposerSessionIsolation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prepared, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+			prepared, err := exec.prepareResponsesRequest(context.Background(), nil, cliproxyexecutor.Request{
 				Model:   tt.model,
 				Payload: tt.payload,
 			}, cliproxyexecutor.Options{
@@ -2039,7 +2040,7 @@ func TestXAIExecutorCompactClearsReplayBeforePostCompactTurn(t *testing.T) {
 
 	postCompactPayload := []byte(`{"model":"grok-4.3","prompt_cache_key":"compact-session","input":[{"type":"compaction","encrypted_content":""},{"type":"message","role":"user","content":[{"type":"input_text","text":"after compact"}]}]}`)
 	postCompactPayload, _ = sjson.SetBytes(postCompactPayload, "input.0.encrypted_content", compactEncryptedContent)
-	prepared, errPrepare := exec.prepareResponsesRequest(ctx, cliproxyexecutor.Request{
+	prepared, errPrepare := exec.prepareResponsesRequest(ctx, nil, cliproxyexecutor.Request{
 		Model:   "grok-4.3",
 		Payload: postCompactPayload,
 	}, cliproxyexecutor.Options{
@@ -2621,8 +2622,8 @@ func TestXAIExecutorExecuteImagesUsesImagesEndpointAndPublishesUsage(t *testing.
 	}
 
 	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
-		Model:   "image-model-alias",
-		Payload: []byte(`{"model":"grok-imagine-image-quality","prompt":"draw"}`),
+		Model:   requestedModel,
+		Payload: []byte(`{"model":"public-image","prompt":"draw"}`),
 	}, cliproxyexecutor.Options{
 		SourceFormat: sdktranslator.FromString("openai-image"),
 		Metadata: map[string]any{
@@ -2671,6 +2672,99 @@ func TestXAIExecutorExecuteImagesUsesImagesEndpointAndPublishesUsage(t *testing.
 	assertNoAdditionalXAIUsageRecord(t, plugin.records)
 }
 
+func TestXAIExecutorExecuteImagesUsesResolvedAPIKeyModel(t *testing.T) {
+	const (
+		upstreamModel = "grok-imagine-image"
+		publicAlias   = "public-image"
+		apiKey        = "xai-image-key"
+	)
+
+	tests := []struct {
+		name       string
+		prefix     string
+		routeModel string
+	}{
+		{name: "alias", routeModel: publicAlias},
+		{name: "provider prefix", prefix: "tenant", routeModel: "tenant/" + publicAlias},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody []byte
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var errRead error
+				gotBody, errRead = io.ReadAll(r.Body)
+				if errRead != nil {
+					t.Fatalf("read body: %v", errRead)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"created":123,"data":[{"b64_json":"AA=="}]}`))
+			}))
+			defer server.Close()
+
+			cfg := &config.Config{XAIKey: []config.XAIKey{{
+				APIKey:  apiKey,
+				Prefix:  tt.prefix,
+				BaseURL: server.URL,
+				Models: []config.XAIModel{{
+					Name:  upstreamModel,
+					Alias: publicAlias,
+				}},
+			}}}
+			manager := cliproxyauth.NewManager(nil, nil, nil)
+			manager.SetConfig(cfg)
+			manager.RegisterExecutor(NewXAIExecutor(cfg))
+
+			auth := &cliproxyauth.Auth{
+				ID:       "xai-image-" + strings.ReplaceAll(tt.name, " ", "-"),
+				Provider: "xai",
+				Prefix:   tt.prefix,
+				Status:   cliproxyauth.StatusActive,
+				Attributes: map[string]string{
+					cliproxyauth.AttributeAPIKey: apiKey,
+					cliproxyauth.AttributeSource: "config:xai[test]",
+					"base_url":                   server.URL,
+				},
+			}
+			if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+				t.Fatalf("register auth: %v", errRegister)
+			}
+
+			modelRegistry := registry.GetGlobalRegistry()
+			modelRegistry.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{
+				ID:               tt.routeModel,
+				Type:             "xai",
+				SupportsImageAPI: true,
+			}})
+			t.Cleanup(func() {
+				modelRegistry.UnregisterClient(auth.ID)
+			})
+			manager.RefreshSchedulerEntry(auth.ID)
+
+			_, errExecute := manager.Execute(context.Background(), []string{"xai"}, cliproxyexecutor.Request{
+				Model:   tt.routeModel,
+				Payload: []byte(`{"model":"` + tt.routeModel + `","prompt":"draw"}`),
+			}, cliproxyexecutor.Options{
+				SourceFormat: sdktranslator.FromString("openai-image"),
+				Metadata: map[string]any{
+					cliproxyexecutor.ImageExecutionMetadataKey: true,
+					cliproxyexecutor.RequestPathMetadataKey:    "/v1/images/generations",
+				},
+			})
+			if errExecute != nil {
+				t.Fatalf("Execute() error = %v", errExecute)
+			}
+
+			if got := gjson.GetBytes(gotBody, "model").String(); got != upstreamModel {
+				t.Fatalf("upstream model = %q, want %q; body=%s", got, upstreamModel, string(gotBody))
+			}
+			if got := gjson.GetBytes(gotBody, "prompt").String(); got != "draw" {
+				t.Fatalf("upstream prompt = %q, want draw; body=%s", got, string(gotBody))
+			}
+		})
+	}
+}
+
 func TestXAIExecutorExecuteImagesPublishesFailureUsage(t *testing.T) {
 	const requestedModel = "grok-imagine-image-quality"
 
@@ -2695,7 +2789,7 @@ func TestXAIExecutorExecuteImagesPublishesFailureUsage(t *testing.T) {
 	}
 
 	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
-		Model:   "image-model-alias",
+		Model:   requestedModel,
 		Payload: []byte(`{"model":"grok-imagine-image-quality","prompt":"draw"}`),
 	}, cliproxyexecutor.Options{
 		SourceFormat: sdktranslator.FromString("openai-image"),
@@ -2993,7 +3087,7 @@ func TestXAIExecutorExecuteVideosCreate(t *testing.T) {
 
 	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
 		Model:   requestedModel,
-		Payload: []byte(`{"model":"grok-imagine-video","prompt":"animate","duration":4}`),
+		Payload: []byte(`{"model":"tenant/public-video","prompt":"animate","duration":4}`),
 	}, cliproxyexecutor.Options{
 		SourceFormat: sdktranslator.FromString("openai-video"),
 		Metadata: map[string]any{
@@ -3063,8 +3157,8 @@ func TestXAIExecutorExecuteVideosPublishesFailureUsage(t *testing.T) {
 	}
 
 	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
-		Model:   "video-model-alias",
-		Payload: []byte(`{"model":"grok-imagine-video-failure","prompt":"animate"}`),
+		Model:   requestedModel,
+		Payload: []byte(`{"model":"video-model-alias","prompt":"animate"}`),
 	}, cliproxyexecutor.Options{
 		SourceFormat: sdktranslator.FromString("openai-video"),
 	})
@@ -3123,9 +3217,15 @@ func TestXAIExecutorExecuteVideosPublishesRequestBuildFailureUsage(t *testing.T)
 func TestXAIExecutorExecuteVideosRetrieve(t *testing.T) {
 	var gotPath string
 	var gotMethod string
+	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		gotMethod = r.Method
+		var errRead error
+		gotBody, errRead = io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read body: %v", errRead)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"status":"done","video":{"url":"https://vidgen.x.ai/video.mp4","duration":6},"model":"grok-imagine-video","progress":100}`))
 	}))
@@ -3153,6 +3253,9 @@ func TestXAIExecutorExecuteVideosRetrieve(t *testing.T) {
 	}
 	if gotPath != "/videos/vid_123" {
 		t.Fatalf("path = %q, want /videos/vid_123", gotPath)
+	}
+	if len(gotBody) != 0 {
+		t.Fatalf("body = %q, want empty", string(gotBody))
 	}
 	if gjson.GetBytes(resp.Payload, "video.url").String() != "https://vidgen.x.ai/video.mp4" {
 		t.Fatalf("payload = %s", string(resp.Payload))
@@ -3772,11 +3875,11 @@ func TestXAIExecutorComposerReusesClaudeCodeSession(t *testing.T) {
 	req := cliproxyexecutor.Request{Model: "grok-composer-2.5-fast", Payload: payload}
 	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude, Stream: true}
 
-	first, err := exec.prepareResponsesRequest(context.Background(), req, opts, true)
+	first, err := exec.prepareResponsesRequest(context.Background(), nil, req, opts, true)
 	if err != nil {
 		t.Fatalf("prepareResponsesRequest first error: %v", err)
 	}
-	second, err := exec.prepareResponsesRequest(context.Background(), req, opts, true)
+	second, err := exec.prepareResponsesRequest(context.Background(), nil, req, opts, true)
 	if err != nil {
 		t.Fatalf("prepareResponsesRequest second error: %v", err)
 	}

--- a/internal/runtime/executor/xai_executor_tokens.go
+++ b/internal/runtime/executor/xai_executor_tokens.go
@@ -14,7 +14,7 @@ import (
 
 // CountTokens estimates token count for xAI Responses requests.
 func (e *XAIExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
-	prepared, err := e.prepareResponsesRequest(ctx, req, opts, false)
+	prepared, err := e.prepareResponsesRequest(ctx, auth, req, opts, false)
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}

--- a/internal/runtime/executor/xai_websockets_executor.go
+++ b/internal/runtime/executor/xai_websockets_executor.go
@@ -470,7 +470,7 @@ func (e *XAIWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliprox
 		baseURL = xaiauth.DefaultAPIBaseURL
 	}
 
-	prepared, err := e.prepareResponsesWebsocketRequest(ctx, req, opts)
+	prepared, err := e.prepareResponsesWebsocketRequest(ctx, auth, req, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -1026,8 +1026,8 @@ func xaiBareWebsocketErrorStatus(payload []byte) int {
 	return http.StatusInternalServerError
 }
 
-func (e *XAIWebsocketsExecutor) prepareResponsesWebsocketRequest(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*xaiPreparedRequest, error) {
-	prepared, err := e.prepareResponsesRequest(ctx, req, opts, true)
+func (e *XAIWebsocketsExecutor) prepareResponsesWebsocketRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*xaiPreparedRequest, error) {
+	prepared, err := e.prepareResponsesRequest(ctx, auth, req, opts, true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -162,7 +162,20 @@ func IsUserDefinedModel(modelInfo *registry.ModelInfo) bool {
 //	// Without suffix - uses body config
 //	result, err := thinking.ApplyThinking(body, "gemini-2.5-pro", "gemini", "gemini", "gemini")
 func ApplyThinking(body []byte, model string, fromFormat string, toFormat string, providerKey string) ([]byte, error) {
+	return applyThinking(body, nil, model, fromFormat, toFormat, providerKey, nil, false)
+}
+
+// ApplyThinkingWithModelInfo applies thinking with the exact configured model
+// definition selected for an API-key execution attempt.
+func ApplyThinkingWithModelInfo(body, sourceBody []byte, model string, fromFormat string, toFormat string, providerKey string, modelInfo *registry.ModelInfo) ([]byte, error) {
+	return applyThinking(body, sourceBody, model, fromFormat, toFormat, providerKey, modelInfo, true)
+}
+
+func applyThinking(body, sourceBody []byte, model string, fromFormat string, toFormat string, providerKey string, resolvedModelInfo *registry.ModelInfo, modelInfoResolved bool) ([]byte, error) {
 	providerFormat := strings.ToLower(strings.TrimSpace(toFormat))
+	if modelInfoResolved && providerFormat == "openai-response" {
+		providerFormat = "codex"
+	}
 	providerKey = strings.ToLower(strings.TrimSpace(providerKey))
 	if providerKey == "" {
 		providerKey = providerFormat
@@ -185,7 +198,10 @@ func ApplyThinking(body []byte, model string, fromFormat string, toFormat string
 	suffixResult := ParseSuffix(model)
 	baseModel := suffixResult.ModelName
 	// Use provider-specific lookup to handle capability differences across providers.
-	modelInfo := registry.LookupModelInfo(baseModel, providerKey)
+	modelInfo := resolvedModelInfo
+	if !modelInfoResolved {
+		modelInfo = registry.LookupModelInfo(baseModel, providerKey)
+	}
 
 	// 3. Model capability check
 	// Unknown models are treated as user-defined so thinking config can still be applied.
@@ -221,7 +237,12 @@ func ApplyThinking(body []byte, model string, fromFormat string, toFormat string
 			"level":    config.Level,
 		}).Debug("thinking: config from model suffix |")
 	} else {
-		config = extractThinkingConfig(body, providerFormat)
+		if modelInfoResolved && len(sourceBody) > 0 {
+			config = extractSourceThinkingConfig(sourceBody, fromFormat)
+		}
+		if !hasThinkingConfig(config) {
+			config = extractThinkingConfig(body, providerFormat)
+		}
 		if hasThinkingConfig(config) {
 			log.WithFields(log.Fields{
 				"provider": providerFormat,
@@ -239,6 +260,9 @@ func ApplyThinking(body []byte, model string, fromFormat string, toFormat string
 			"model":    modelInfo.ID,
 		}).Debug("thinking: no config found, passthrough |")
 		return body, nil
+	}
+	if modelInfoResolved && config.Mode == ModeLevel && modelInfo != nil && modelInfo.Thinking != nil && !isSameProviderFamily(fromFormat, providerFormat) {
+		config.Level = mapConfiguredHighIntent(config.Level, modelInfo)
 	}
 
 	// 5. Validate and normalize configuration
@@ -274,6 +298,36 @@ func ApplyThinking(body []byte, model string, fromFormat string, toFormat string
 
 	// 6. Apply configuration using provider-specific applier
 	return applier.Apply(body, *validated, modelInfo)
+}
+
+func mapConfiguredHighIntent(level ThinkingLevel, modelInfo *registry.ModelInfo) ThinkingLevel {
+	if modelInfo == nil || modelInfo.Thinking == nil || len(modelInfo.Thinking.Levels) == 0 {
+		return level
+	}
+	level = ThinkingLevel(strings.ToLower(strings.TrimSpace(string(level))))
+	var candidates []ThinkingLevel
+	switch level {
+	case LevelXHigh:
+		candidates = []ThinkingLevel{LevelXHigh, LevelMax, LevelHigh}
+	case LevelMax:
+		candidates = []ThinkingLevel{LevelMax, LevelXHigh, LevelHigh}
+	default:
+		return level
+	}
+	for _, candidate := range candidates {
+		if isLevelSupported(string(candidate), modelInfo.Thinking.Levels) {
+			return candidate
+		}
+	}
+	return level
+}
+
+func extractSourceThinkingConfig(body []byte, provider string) ThinkingConfig {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "openai-response" {
+		return extractCodexConfig(body)
+	}
+	return extractThinkingConfig(body, provider)
 }
 
 // parseSuffixToConfig converts a raw suffix string to ThinkingConfig.

--- a/internal/thinking/apply_configured_api_key_test.go
+++ b/internal/thinking/apply_configured_api_key_test.go
@@ -1,0 +1,161 @@
+package thinking_test
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/claude"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/codex"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/gemini"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/interactions"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/openai"
+	"github.com/tidwall/gjson"
+)
+
+func TestApplyThinkingWithModelInfoMapsCrossFamilyHighIntent(t *testing.T) {
+	tests := []struct {
+		name      string
+		source    string
+		supported []string
+		want      string
+	}{
+		{"xhigh stays xhigh", "xhigh", []string{"high", "max", "xhigh"}, "xhigh"},
+		{"xhigh prefers max", "xhigh", []string{"high", "max"}, "max"},
+		{"xhigh falls back to high", "xhigh", []string{"high"}, "high"},
+		{"max falls back to xhigh", "max", []string{"high", "xhigh"}, "xhigh"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			modelInfo := &registry.ModelInfo{
+				ID:       "tenant/claude-upstream",
+				Type:     "claude",
+				Thinking: &registry.ThinkingSupport{Levels: tc.supported},
+			}
+			body := []byte(`{"thinking":{"type":"adaptive"},"output_config":{"effort":"low"}}`)
+			source := []byte(`{"reasoning_effort":"` + tc.source + `"}`)
+			out, err := thinking.ApplyThinkingWithModelInfo(body, source, "claude-upstream", "openai", "claude", "claude", modelInfo)
+			if err != nil {
+				t.Fatalf("ApplyThinkingWithModelInfo() error = %v", err)
+			}
+			if got := gjson.GetBytes(out, "output_config.effort").String(); got != tc.want {
+				t.Fatalf("output effort = %q, want %q; body=%s", got, tc.want, out)
+			}
+		})
+	}
+}
+
+func TestApplyThinkingWithModelInfoClampsUnsupportedCrossFamilyHighIntent(t *testing.T) {
+	modelInfo := &registry.ModelInfo{
+		ID:       "tenant/claude-upstream",
+		Type:     "claude",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"low", "medium"}},
+	}
+	body := []byte(`{"thinking":{"type":"adaptive"},"output_config":{"effort":"low"}}`)
+	source := []byte(`{"reasoning_effort":"xhigh"}`)
+	out, err := thinking.ApplyThinkingWithModelInfo(body, source, "claude-upstream", "openai", "claude", "claude", modelInfo)
+	if err != nil {
+		t.Fatalf("ApplyThinkingWithModelInfo() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "output_config.effort").String(); got != "medium" {
+		t.Fatalf("output effort = %q, want medium; body=%s", got, out)
+	}
+}
+
+func TestApplyThinkingWithModelInfoKeepsSameFamilyValidationStrict(t *testing.T) {
+	modelInfo := &registry.ModelInfo{
+		ID:       "tenant/openai-upstream",
+		Type:     "openai",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}},
+	}
+	body := []byte(`{"reasoning_effort":"xhigh"}`)
+	if _, err := thinking.ApplyThinkingWithModelInfo(body, body, "openai-upstream", "openai", "openai", "openai", modelInfo); err == nil {
+		t.Fatal("ApplyThinkingWithModelInfo() error = nil, want unsupported xhigh error")
+	}
+}
+
+func TestApplyThinkingWithModelInfoUsesOriginalResponsesEffort(t *testing.T) {
+	modelInfo := &registry.ModelInfo{
+		ID:       "tenant/claude-upstream",
+		Type:     "claude",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"high", "max"}},
+	}
+	body := []byte(`{"thinking":{"type":"adaptive"},"output_config":{"effort":"low"}}`)
+	source := []byte(`{"reasoning":{"effort":"xhigh"}}`)
+	out, err := thinking.ApplyThinkingWithModelInfo(body, source, "claude-upstream", "openai-response", "claude", "claude", modelInfo)
+	if err != nil {
+		t.Fatalf("ApplyThinkingWithModelInfo() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "output_config.effort").String(); got != "max" {
+		t.Fatalf("output effort = %q, want max; body=%s", got, out)
+	}
+}
+
+func TestApplyThinkingWithModelInfoUsesResponsesTargetApplier(t *testing.T) {
+	modelInfo := &registry.ModelInfo{
+		ID:       "tenant/codex-upstream",
+		Type:     "codex",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"high", "xhigh"}},
+	}
+	body := []byte(`{"reasoning":{"effort":"high"}}`)
+	source := []byte(`{"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}}`)
+	out, err := thinking.ApplyThinkingWithModelInfo(body, source, "codex-upstream", "claude", "openai-response", "codex", modelInfo)
+	if err != nil {
+		t.Fatalf("ApplyThinkingWithModelInfo() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "reasoning.effort").String(); got != "xhigh" {
+		t.Fatalf("reasoning effort = %q, want xhigh; body=%s", got, out)
+	}
+}
+
+func TestApplyThinkingWithModelInfoCrossFormatMatrix(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		source     string
+		from       string
+		to         string
+		modelType  string
+		supported  []string
+		resultPath string
+		want       string
+	}{
+		{
+			name: "claude to openai", body: `{"reasoning_effort":"low"}`,
+			source: `{"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}}`,
+			from:   "claude", to: "openai", modelType: "openai", supported: []string{"high", "xhigh"},
+			resultPath: "reasoning_effort", want: "xhigh",
+		},
+		{
+			name: "gemini to interactions", body: `{"generation_config":{"thinking_level":"low"}}`,
+			source: `{"generationConfig":{"thinkingConfig":{"thinkingLevel":"xhigh"}}}`,
+			from:   "gemini", to: "interactions", modelType: "interactions", supported: []string{"high", "max"},
+			resultPath: "generation_config.thinking_level", want: "max",
+		},
+		{
+			name: "interactions to claude", body: `{"thinking":{"type":"adaptive"},"output_config":{"effort":"low"}}`,
+			source: `{"generation_config":{"thinking_level":"xhigh"}}`,
+			from:   "interactions", to: "claude", modelType: "claude", supported: []string{"high"},
+			resultPath: "output_config.effort", want: "high",
+		},
+		{
+			name: "openai to gemini", body: `{"generationConfig":{"thinkingConfig":{"thinkingLevel":"low"}}}`,
+			source: `{"reasoning_effort":"xhigh"}`,
+			from:   "openai", to: "gemini", modelType: "gemini", supported: []string{"high"},
+			resultPath: "generationConfig.thinkingConfig.thinkingLevel", want: "high",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			modelInfo := &registry.ModelInfo{ID: "upstream", Type: tc.modelType, Thinking: &registry.ThinkingSupport{Levels: tc.supported}}
+			out, err := thinking.ApplyThinkingWithModelInfo([]byte(tc.body), []byte(tc.source), "upstream", tc.from, tc.to, tc.to, modelInfo)
+			if err != nil {
+				t.Fatalf("ApplyThinkingWithModelInfo() error = %v", err)
+			}
+			if got := gjson.GetBytes(out, tc.resultPath).String(); got != tc.want {
+				t.Fatalf("%s = %q, want %q; body=%s", tc.resultPath, got, tc.want, out)
+			}
+		})
+	}
+}

--- a/internal/watcher/diff/model_hash.go
+++ b/internal/watcher/diff/model_hash.go
@@ -4,11 +4,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/modelconfig"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
 
 // ComputeOpenAICompatModelsHash returns a stable hash for OpenAI-compat models.
@@ -21,7 +22,12 @@ func ComputeOpenAICompatModelsHash(models []config.OpenAICompatibilityModel) str
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("image=%t", model.Image))
+			out(configuredModelHashKey(name, alias, model.DisplayName, configuredModelHashMetadata{
+				Thinking:         model.Thinking,
+				Image:            model.Image,
+				InputModalities:  model.InputModalities,
+				OutputModalities: model.OutputModalities,
+			}))
 		}
 	})
 	return hashJoined(keys)
@@ -36,7 +42,7 @@ func ComputeVertexCompatModelsHash(models []config.VertexCompatModel) string {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
+			out(configuredModelHashKey(name, alias, model.DisplayName, configuredModelHashMetadata{Thinking: model.Thinking}))
 		}
 	})
 	return hashJoined(keys)
@@ -51,7 +57,7 @@ func ComputeClaudeModelsHash(models []config.ClaudeModel) string {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
+			out(configuredModelHashKey(name, alias, model.DisplayName, configuredModelHashMetadata{Thinking: model.Thinking}))
 		}
 	})
 	return hashJoined(keys)
@@ -66,7 +72,10 @@ func ComputeCodexModelsHash(models []config.CodexModel) string {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping))
+			out(configuredModelHashKey(name, alias, model.DisplayName, configuredModelHashMetadata{
+				Thinking:     model.Thinking,
+				ForceMapping: model.ForceMapping,
+			}))
 		}
 	})
 	return hashJoined(keys)
@@ -81,10 +90,42 @@ func ComputeGeminiModelsHash(models []config.GeminiModel) string {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
+			out(configuredModelHashKey(name, alias, model.DisplayName, configuredModelHashMetadata{Thinking: model.Thinking}))
 		}
 	})
 	return hashJoined(keys)
+}
+
+type configuredModelHashMetadata struct {
+	Thinking         *registry.ThinkingSupport
+	Image            bool
+	ForceMapping     bool
+	InputModalities  []string
+	OutputModalities []string
+}
+
+func configuredModelHashKey(name, alias, displayName string, metadata configuredModelHashMetadata) string {
+	payload := struct {
+		Name             string                    `json:"name"`
+		Alias            string                    `json:"alias"`
+		DisplayName      string                    `json:"display_name,omitempty"`
+		Thinking         *registry.ThinkingSupport `json:"thinking,omitempty"`
+		Image            bool                      `json:"image,omitempty"`
+		ForceMapping     bool                      `json:"force_mapping,omitempty"`
+		InputModalities  []string                  `json:"input_modalities,omitempty"`
+		OutputModalities []string                  `json:"output_modalities,omitempty"`
+	}{
+		Name:             strings.ToLower(strings.TrimSpace(name)),
+		Alias:            strings.ToLower(strings.TrimSpace(alias)),
+		DisplayName:      strings.TrimSpace(displayName),
+		Thinking:         metadata.Thinking,
+		Image:            metadata.Image,
+		ForceMapping:     metadata.ForceMapping,
+		InputModalities:  modelconfig.NormalizeModalities(metadata.InputModalities),
+		OutputModalities: modelconfig.NormalizeModalities(metadata.OutputModalities),
+	}
+	data, _ := json.Marshal(payload)
+	return string(data)
 }
 
 // ComputeExcludedModelsHash returns a normalized hash for excluded model lists.

--- a/internal/watcher/diff/model_hash_test.go
+++ b/internal/watcher/diff/model_hash_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
 
 func TestComputeOpenAICompatModelsHash_Deterministic(t *testing.T) {
@@ -33,6 +34,50 @@ func TestComputeOpenAICompatModelsHash_IncludesImageFlag(t *testing.T) {
 	}
 	if textModel == imageModel {
 		t.Fatal("hash should change when image flag changes")
+	}
+}
+
+func TestComputeOpenAICompatModelsHash_IncludesModalities(t *testing.T) {
+	base := config.OpenAICompatibilityModel{Name: "model", Alias: "public"}
+	withInput := base
+	withInput.InputModalities = []string{"text", "image"}
+	withOutput := base
+	withOutput.OutputModalities = []string{"text", "image"}
+
+	baseHash := ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{base})
+	inputHash := ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{withInput})
+	outputHash := ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{withOutput})
+	if baseHash == "" || baseHash == inputHash || baseHash == outputHash || inputHash == outputHash {
+		t.Fatalf("modality hashes must be distinct: base=%q input=%q output=%q", baseHash, inputHash, outputHash)
+	}
+
+	normalized := withInput
+	normalized.InputModalities = []string{" TEXT ", "image", "text"}
+	if got := ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{normalized}); got != inputHash {
+		t.Fatalf("normalized modality hash = %q, want %q", got, inputHash)
+	}
+}
+
+func TestConfiguredModelHashesIncludeThinking(t *testing.T) {
+	low := &registry.ThinkingSupport{Levels: []string{"low"}}
+	high := &registry.ThinkingSupport{Levels: []string{"high"}}
+	tests := []struct {
+		name string
+		low  string
+		high string
+	}{
+		{"openai-compatibility", ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "model", Thinking: low}}), ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "model", Thinking: high}})},
+		{"gemini", ComputeGeminiModelsHash([]config.GeminiModel{{Name: "model", Thinking: low}}), ComputeGeminiModelsHash([]config.GeminiModel{{Name: "model", Thinking: high}})},
+		{"claude", ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "model", Thinking: low}}), ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "model", Thinking: high}})},
+		{"codex", ComputeCodexModelsHash([]config.CodexModel{{Name: "model", Thinking: low}}), ComputeCodexModelsHash([]config.CodexModel{{Name: "model", Thinking: high}})},
+		{"vertex", ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "model", Thinking: low}}), ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "model", Thinking: high}})},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.low == "" || tc.high == "" || tc.low == tc.high {
+				t.Fatalf("thinking hashes = %q / %q, want distinct non-empty values", tc.low, tc.high)
+			}
+		})
 	}
 }
 

--- a/internal/watcher/diff/models_summary.go
+++ b/internal/watcher/diff/models_summary.go
@@ -41,7 +41,7 @@ func SummarizeGeminiModels(models []config.GeminiModel) GeminiModelsSummary {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
+			out(configuredModelHashKey(name, alias, model.DisplayName, configuredModelHashMetadata{Thinking: model.Thinking}))
 		}
 	})
 	return GeminiModelsSummary{
@@ -62,7 +62,7 @@ func SummarizeClaudeModels(models []config.ClaudeModel) ClaudeModelsSummary {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
+			out(configuredModelHashKey(name, alias, model.DisplayName, configuredModelHashMetadata{Thinking: model.Thinking}))
 		}
 	})
 	return ClaudeModelsSummary{
@@ -83,11 +83,10 @@ func SummarizeCodexModels(models []config.CodexModel) CodexModelsSummary {
 			if name == "" && alias == "" {
 				continue
 			}
-			forceMapping := "false"
-			if model.ForceMapping {
-				forceMapping = "true"
-			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|force-mapping=" + forceMapping)
+			out(configuredModelHashKey(name, alias, model.DisplayName, configuredModelHashMetadata{
+				Thinking:     model.Thinking,
+				ForceMapping: model.ForceMapping,
+			}))
 		}
 	})
 	return CodexModelsSummary{
@@ -111,7 +110,7 @@ func SummarizeVertexModels(models []config.VertexCompatModel) VertexModelsSummar
 		if alias != "" {
 			name = alias
 		}
-		names = append(names, name+"|"+strings.TrimSpace(model.DisplayName))
+		names = append(names, configuredModelHashKey(name, "", model.DisplayName, configuredModelHashMetadata{Thinking: model.Thinking}))
 	}
 	if len(names) == 0 {
 		return VertexModelsSummary{}

--- a/sdk/api/handlers/handlers_execution.go
+++ b/sdk/api/handlers/handlers_execution.go
@@ -34,6 +34,14 @@ func (h *BaseAPIHandler) ExecuteImageWithAuthManager(ctx context.Context, handle
 	return h.executeWithAuthManager(ctx, handlerType, modelName, rawJSON, alt, true)
 }
 
+// ExecuteImageWithAuthManagerForProvider executes an image endpoint request
+// using only credentials registered for provider.
+func (h *BaseAPIHandler) ExecuteImageWithAuthManagerForProvider(ctx context.Context, handlerType, provider, modelName string, rawJSON []byte, alt string) ([]byte, http.Header, *interfaces.ErrorMessage) {
+	return h.executeWithAuthManagerFormats(ctx, handlerType, handlerType, modelName, rawJSON, alt, true, modelExecutionOptions{
+		ForcedProvider: provider,
+	})
+}
+
 func (h *BaseAPIHandler) executeWithAuthManager(ctx context.Context, handlerType, modelName string, rawJSON []byte, alt string, allowImageModel bool) ([]byte, http.Header, *interfaces.ErrorMessage) {
 	return h.executeWithAuthManagerFormats(ctx, handlerType, handlerType, modelName, rawJSON, alt, allowImageModel, modelExecutionOptions{})
 }
@@ -42,7 +50,7 @@ func (h *BaseAPIHandler) executeWithAuthManagerFormats(ctx context.Context, entr
 	originalRequestedModel := modelName
 	routeDecision := h.applyModelRouter(ctx, entryProtocol, modelName, rawJSON, false, execOptions)
 	responseProtocol := modelExecutionResponseProtocol(entryProtocol, exitProtocol)
-	if errMsg := validateNativeInteractionsExecution(entryProtocol, execOptions, routeDecision); errMsg != nil {
+	if errMsg := validateRequiredProviderExecution(entryProtocol, execOptions, routeDecision); errMsg != nil {
 		return nil, nil, errMsg
 	}
 	if routeDecision.ExecutorPluginID != "" {
@@ -55,6 +63,12 @@ func (h *BaseAPIHandler) executeWithAuthManagerFormats(ctx context.Context, entr
 	providers = adjustExecutionProvidersForEntryProtocol(entryProtocol, providers)
 	reqMeta := requestExecutionMetadata(ctx)
 	reqMeta[coreexecutor.RequestedModelMetadataKey] = originalRequestedModel
+	if allowImageModel {
+		reqMeta[coreexecutor.ImageExecutionMetadataKey] = true
+	}
+	if entryProtocol == "openai-video" {
+		reqMeta[coreexecutor.VideoExecutionMetadataKey] = true
+	}
 	addAuthSelectionModelMetadata(reqMeta, execOptions.AuthSelectionModel)
 	addModelExecutionSourceMetadata(reqMeta, execOptions.InternalSource)
 	setReasoningEffortMetadata(reqMeta, entryProtocol, normalizedModel, rawJSON)
@@ -121,6 +135,9 @@ func (h *BaseAPIHandler) executeCountWithAuthManager(ctx context.Context, handle
 	providers = adjustExecutionProvidersForEntryProtocol(handlerType, providers)
 	reqMeta := requestExecutionMetadata(ctx)
 	reqMeta[coreexecutor.RequestedModelMetadataKey] = originalRequestedModel
+	if handlerType == "openai-video" {
+		reqMeta[coreexecutor.VideoExecutionMetadataKey] = true
+	}
 	addAuthSelectionModelMetadata(reqMeta, execOptions.AuthSelectionModel)
 	setReasoningEffortMetadata(reqMeta, handlerType, normalizedModel, rawJSON)
 	setServiceTierMetadata(reqMeta, rawJSON)

--- a/sdk/api/handlers/handlers_model_router_test.go
+++ b/sdk/api/handlers/handlers_model_router_test.go
@@ -6,11 +6,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
@@ -193,6 +195,150 @@ func TestHandlerModelRouterRoutesBeforeRequestDetails(t *testing.T) {
 	}
 	if host.lastOptions.Metadata[coreexecutor.RequestedModelMetadataKey] != originalModel {
 		t.Fatalf("requested model metadata = %#v, want original model", host.lastOptions.Metadata[coreexecutor.RequestedModelMetadataKey])
+	}
+}
+
+func TestImageRequiredProviderRejectsConflictingModelRouterTargets(t *testing.T) {
+	const model = "shared-native-image"
+	tests := []struct {
+		name     string
+		response pluginapi.ModelRouteResponse
+	}{
+		{
+			name: "plugin executor",
+			response: pluginapi.ModelRouteResponse{
+				Handled:    true,
+				TargetKind: pluginapi.ModelRouteTargetExecutor,
+				Target:     "image-plugin",
+			},
+		},
+		{
+			name: "different provider",
+			response: pluginapi.ModelRouteResponse{
+				Handled:    true,
+				TargetKind: pluginapi.ModelRouteTargetProvider,
+				Target:     "openai-compatibility",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			host := &handlerDirectExecutorRouteHost{}
+			host.hasRouters = true
+			host.route = func(context.Context, pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+				return tc.response, true
+			}
+			handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+			handler.SetModelRouterHost(host)
+
+			body, _, errMsg := handler.ExecuteImageWithAuthManagerForProvider(
+				context.Background(),
+				"openai-image",
+				"xai",
+				model,
+				[]byte(`{"model":"shared-native-image","prompt":"draw"}`),
+				"",
+			)
+			if body != nil || errMsg == nil || errMsg.StatusCode != http.StatusBadRequest {
+				t.Fatalf("ExecuteImageWithAuthManagerForProvider() = %q, %#v; want BadRequest", body, errMsg)
+			}
+			if errMsg.Error == nil || !strings.Contains(errMsg.Error.Error(), "requires native xai execution") {
+				t.Fatalf("error = %v, want required xAI provider context", errMsg.Error)
+			}
+			if host.lastPluginID != "" {
+				t.Fatalf("conflicting plugin executor was invoked with %q", host.lastPluginID)
+			}
+		})
+	}
+}
+
+func TestImageRequiredProviderUsesSameProviderModelRouterTarget(t *testing.T) {
+	const (
+		originalModel = "native-image-original"
+		targetModel   = "native-image-target"
+	)
+	tests := []struct {
+		name        string
+		targetModel string
+		wantModel   string
+	}{
+		{
+			name:        "target model",
+			targetModel: targetModel,
+			wantModel:   targetModel,
+		},
+		{
+			name:      "no target model",
+			wantModel: originalModel,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			executor := &modelExecutionCaptureExecutor{provider: "xai"}
+			manager := coreauth.NewManager(nil, nil, nil)
+			manager.RegisterExecutor(executor)
+			authID := "model-router-required-provider-" + strings.ReplaceAll(tc.name, " ", "-")
+			auth := &coreauth.Auth{
+				ID:       authID,
+				Provider: "xai",
+				Status:   coreauth.StatusActive,
+			}
+			if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+				t.Fatalf("manager.Register(): %v", errRegister)
+			}
+			models := []*registry.ModelInfo{{
+				ID:               originalModel,
+				SupportsImageAPI: true,
+				ChatDisabled:     true,
+			}}
+			if tc.targetModel != "" {
+				models = append(models, &registry.ModelInfo{
+					ID:               tc.targetModel,
+					SupportsImageAPI: true,
+					ChatDisabled:     true,
+				})
+			}
+			modelRegistry := registry.GetGlobalRegistry()
+			modelRegistry.RegisterClient(authID, auth.Provider, models)
+			manager.RefreshSchedulerEntry(authID)
+			t.Cleanup(func() {
+				modelRegistry.UnregisterClient(authID)
+			})
+
+			host := &handlerDirectExecutorRouteHost{}
+			host.hasRouters = true
+			host.route = func(context.Context, pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+				return pluginapi.ModelRouteResponse{
+					Handled:     true,
+					TargetKind:  pluginapi.ModelRouteTargetProvider,
+					Target:      "xai",
+					TargetModel: tc.targetModel,
+				}, true
+			}
+			handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+			handler.SetModelRouterHost(host)
+
+			body, _, errMsg := handler.ExecuteImageWithAuthManagerForProvider(
+				context.Background(),
+				"openai-image",
+				"xai",
+				originalModel,
+				[]byte(`{"model":"native-image-original","prompt":"draw"}`),
+				"",
+			)
+			if errMsg != nil {
+				t.Fatalf("ExecuteImageWithAuthManagerForProvider() error = %+v", errMsg)
+			}
+			if string(body) != "model-execution-ok" {
+				t.Fatalf("body = %q, want model-execution-ok", body)
+			}
+			gotReq, _ := executor.captured()
+			if gotReq.Model != tc.wantModel {
+				t.Fatalf("executor model = %q, want %q", gotReq.Model, tc.wantModel)
+			}
+		})
 	}
 }
 

--- a/sdk/api/handlers/handlers_request_details_test.go
+++ b/sdk/api/handlers/handlers_request_details_test.go
@@ -178,6 +178,55 @@ func TestValidateImageOnlyModel_AllowsImageEndpoints(t *testing.T) {
 	}
 }
 
+func TestValidateImageOnlyModelRejectsRegisteredNativeAlias(t *testing.T) {
+	const (
+		clientID = "native-image-alias-request-details"
+		modelID  = "tenant/public-image"
+	)
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(clientID)
+	modelRegistry.RegisterClient(clientID, "xai", []*registry.ModelInfo{{
+		ID:               modelID,
+		Type:             "xai",
+		SupportsImageAPI: true,
+		ChatDisabled:     true,
+	}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, coreauth.NewManager(nil, nil, nil))
+	if errMsg := handler.validateImageOnlyModel(modelID, false); errMsg == nil {
+		t.Fatalf("validateImageOnlyModel(%q, false) = nil, want image-only error", modelID)
+	}
+	if errMsg := handler.validateImageOnlyModel(modelID, true); errMsg != nil {
+		t.Fatalf("validateImageOnlyModel(%q, true) = %+v, want nil", modelID, errMsg)
+	}
+}
+
+func TestValidateImageOnlyModelPrefersExactDynamicChatRegistration(t *testing.T) {
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, coreauth.NewManager(nil, nil, nil))
+	modelRegistry := registry.GetGlobalRegistry()
+
+	for _, provider := range []string{"claude", "gemini", "vertex"} {
+		t.Run(provider, func(t *testing.T) {
+			clientID := "dynamic-chat-static-image-base-" + provider
+			modelID := provider + "/gpt-image-2"
+			modelRegistry.UnregisterClient(clientID)
+			modelRegistry.RegisterClient(clientID, provider, []*registry.ModelInfo{{
+				ID:   modelID,
+				Type: provider,
+			}})
+			t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+			if isOpenAIImageOnlyModel(modelID) {
+				t.Fatalf("exact dynamic chat model %q was shadowed by static image base", modelID)
+			}
+			if errMsg := handler.validateImageOnlyModel(modelID, false); errMsg != nil {
+				t.Fatalf("validateImageOnlyModel(%q, false) = %+v, want chat-capable exact registration", modelID, errMsg)
+			}
+		})
+	}
+}
+
 func TestIsOpenAIImageOnlyModel(t *testing.T) {
 	tests := []struct {
 		model string

--- a/sdk/api/handlers/handlers_routing.go
+++ b/sdk/api/handlers/handlers_routing.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/router-for-me/CLIProxyAPI/v7/internal/constant"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -98,24 +99,32 @@ func (h *BaseAPIHandler) getRequestDetails(modelName string) (providers []string
 	return h.getRequestDetailsWithOptions(modelName, false)
 }
 
-func validateNativeInteractionsExecution(entryProtocol string, execOptions modelExecutionOptions, routeDecision modelRouteDecision) *interfaces.ErrorMessage {
+func validateRequiredProviderExecution(entryProtocol string, execOptions modelExecutionOptions, routeDecision modelRouteDecision) *interfaces.ErrorMessage {
 	forcedProvider := strings.ToLower(strings.TrimSpace(execOptions.ForcedProvider))
-	if forcedProvider == "" || entryProtocol != Interactions {
+	if forcedProvider == "" {
 		return nil
 	}
-	if routeDecision.ExecutorPluginID != "" {
+	routeProvider := strings.ToLower(strings.TrimSpace(routeDecision.Provider))
+	if routeDecision.ExecutorPluginID == "" && (routeProvider == "" || routeProvider == forcedProvider) {
+		return nil
+	}
+	if entryProtocol == Interactions {
 		return nativeInteractionsExecutionError()
 	}
-	if routeProvider := strings.ToLower(strings.TrimSpace(routeDecision.Provider)); routeProvider != "" && routeProvider != forcedProvider {
-		return nativeInteractionsExecutionError()
-	}
-	return nil
+	return requiredProviderExecutionError(forcedProvider)
 }
 
 func nativeInteractionsExecutionError() *interfaces.ErrorMessage {
 	return &interfaces.ErrorMessage{
 		StatusCode: http.StatusBadRequest,
 		Error:      fmt.Errorf("agent is only supported for native interactions execution"),
+	}
+}
+
+func requiredProviderExecutionError(provider string) *interfaces.ErrorMessage {
+	return &interfaces.ErrorMessage{
+		StatusCode: http.StatusBadRequest,
+		Error:      fmt.Errorf("request requires native %s execution, but the model router selected a different target", provider),
 	}
 }
 
@@ -131,7 +140,10 @@ func (h *BaseAPIHandler) providersForExecution(modelName, originalRequestedModel
 		if routeProvider := strings.ToLower(strings.TrimSpace(routeDecision.Provider)); routeProvider != "" && routeProvider != forcedProvider {
 			return nil, "", nativeInteractionsExecutionError()
 		}
-		normalizedModel := strings.TrimSpace(modelName)
+		normalizedModel := strings.TrimSpace(routeDecision.Model)
+		if normalizedModel == "" {
+			normalizedModel = strings.TrimSpace(modelName)
+		}
 		if normalizedModel == "" {
 			normalizedModel = strings.TrimSpace(originalRequestedModel)
 		}
@@ -220,12 +232,12 @@ func (h *BaseAPIHandler) validateImageOnlyModel(modelName string, allowImageMode
 }
 
 func isOpenAIImageOnlyModel(model string) bool {
-	switch strings.ToLower(strings.TrimSpace(routeModelBaseName(model))) {
-	case "gpt-image-1.5", "gpt-image-2", "grok-imagine-image", "grok-imagine-image-quality":
-		return true
-	default:
-		return false
+	model = strings.TrimSpace(model)
+	if capabilities, found := registry.LookupModelEndpointCapabilities(model); found {
+		return capabilities.Image && !capabilities.Chat
 	}
+	baseModel := routeModelBaseName(model)
+	return baseModel != model && registry.ModelIsImageOnly(baseModel)
 }
 
 func routeModelBaseName(model string) string {

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -232,7 +232,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		routeDecision = h.applyModelRouter(ctx, entryProtocol, modelName, rawJSON, true, execOptions)
 	}
 	responseProtocol := modelExecutionResponseProtocol(entryProtocol, exitProtocol)
-	if errMsg := validateNativeInteractionsExecution(entryProtocol, execOptions, routeDecision); errMsg != nil {
+	if errMsg := validateRequiredProviderExecution(entryProtocol, execOptions, routeDecision); errMsg != nil {
 		errChan := make(chan *interfaces.ErrorMessage, 1)
 		errChan <- errMsg
 		close(errChan)
@@ -251,6 +251,12 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	providers = adjustExecutionProvidersForEntryProtocol(entryProtocol, providers)
 	reqMeta := requestExecutionMetadata(ctx)
 	reqMeta[coreexecutor.RequestedModelMetadataKey] = originalRequestedModel
+	if allowImageModel {
+		reqMeta[coreexecutor.ImageExecutionMetadataKey] = true
+	}
+	if entryProtocol == "openai-video" {
+		reqMeta[coreexecutor.VideoExecutionMetadataKey] = true
+	}
 	addAuthSelectionModelMetadata(reqMeta, execOptions.AuthSelectionModel)
 	addModelExecutionSourceMetadata(reqMeta, execOptions.InternalSource)
 	setReasoningEffortMetadata(reqMeta, entryProtocol, normalizedModel, rawJSON)

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -204,7 +204,7 @@ func imagesModelBase(model string) string {
 	return strings.ToLower(strings.TrimSpace(baseModel))
 }
 
-func isXAIImagesModel(model string) bool {
+func isBuiltinXAIImagesModel(model string) bool {
 	prefix, baseModel := imagesModelParts(model)
 	baseModel = strings.ToLower(strings.TrimSpace(baseModel))
 	if baseModel != defaultXAIImagesModel && baseModel != xaiImagesQualityModel {
@@ -215,29 +215,68 @@ func isXAIImagesModel(model string) bool {
 	return prefix == "" || prefix == "xai" || prefix == "x-ai" || prefix == "grok"
 }
 
-func isSupportedImagesModel(model string) bool {
-	if isCodexImagesToolModel(model) {
-		return true
+type imagesModelKind uint8
+
+const (
+	imagesModelUnsupported imagesModelKind = iota
+	imagesModelCodex
+	imagesModelXAI
+	imagesModelOpenAICompat
+)
+
+type imagesModelClassification struct {
+	kind    imagesModelKind
+	dynamic bool
+}
+
+func classifyImagesModel(model string) imagesModelClassification {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return imagesModelClassification{}
 	}
-	return isXAIImagesModel(model) || isOpenAICompatImagesModel(model)
+
+	snapshot, found := registry.GetGlobalRegistry().LookupModelExecutionSnapshot(model, registry.ModelExecutionImage)
+	if found {
+		switch {
+		case snapshot.ProviderSupports("xai"):
+			return imagesModelClassification{kind: imagesModelXAI, dynamic: true}
+		case snapshot.ProviderSupports("codex"):
+			return imagesModelClassification{kind: imagesModelCodex, dynamic: true}
+		case snapshot.Supported:
+			return imagesModelClassification{kind: imagesModelOpenAICompat, dynamic: true}
+		default:
+			return imagesModelClassification{dynamic: true}
+		}
+	}
+
+	baseModel := imagesModelBase(model)
+	if baseModel == gptImage15Model || baseModel == defaultImagesToolModel {
+		return imagesModelClassification{kind: imagesModelCodex}
+	}
+	if isBuiltinXAIImagesModel(model) {
+		return imagesModelClassification{kind: imagesModelXAI}
+	}
+	return imagesModelClassification{}
+}
+
+func isXAIImagesModel(model string) bool {
+	return classifyImagesModel(model).kind == imagesModelXAI
+}
+
+func isSupportedImagesModel(model string) bool {
+	return classifyImagesModel(model).kind != imagesModelUnsupported
 }
 
 func isCodexImagesToolModel(model string) bool {
-	baseModel := imagesModelBase(model)
-	return baseModel == gptImage15Model || baseModel == defaultImagesToolModel
+	return classifyImagesModel(model).kind == imagesModelCodex
 }
 
 func isOpenAICompatImagesModel(model string) bool {
-	model = strings.TrimSpace(model)
-	if model == "" {
-		return false
-	}
-	info := registry.LookupModelInfo(model)
-	return info != nil && info.Type == registry.OpenAIImageModelType
+	return classifyImagesModel(model).kind == imagesModelOpenAICompat
 }
 
-func rejectUnsupportedImagesModel(c *gin.Context, model string) bool {
-	if isSupportedImagesModel(model) {
+func rejectUnsupportedImagesModel(c *gin.Context, model string, classification imagesModelClassification) bool {
+	if classification.kind != imagesModelUnsupported {
 		return false
 	}
 
@@ -258,9 +297,19 @@ func normalizeImagesResponseFormat(responseFormat string) string {
 }
 
 func canonicalXAIImagesModel(model string) string {
-	baseModel := imagesModelBase(model)
-	if baseModel == xaiImagesQualityModel {
-		return xaiImagesQualityModel
+	return canonicalXAIImagesModelForClassification(model, classifyImagesModel(model))
+}
+
+func canonicalXAIImagesModelForClassification(model string, classification imagesModelClassification) string {
+	if classification.kind == imagesModelXAI && classification.dynamic {
+		return strings.TrimSpace(model)
+	}
+	if classification.kind == imagesModelXAI && isBuiltinXAIImagesModel(model) {
+		baseModel := imagesModelBase(model)
+		if baseModel == xaiImagesQualityModel {
+			return xaiImagesQualityModel
+		}
+		return defaultXAIImagesModel
 	}
 	return defaultXAIImagesModel
 }
@@ -321,9 +370,9 @@ func xaiImagesRef(imageURL string) []byte {
 	return ref
 }
 
-func buildXAIImagesBaseRequest(model string, prompt string, responseFormat string, aspectRatio string, resolution string, n int64) []byte {
+func buildXAIImagesBaseRequest(model string, classification imagesModelClassification, prompt string, responseFormat string, aspectRatio string, resolution string, n int64) []byte {
 	req := []byte(`{}`)
-	req, _ = sjson.SetBytes(req, "model", canonicalXAIImagesModel(model))
+	req, _ = sjson.SetBytes(req, "model", canonicalXAIImagesModelForClassification(model, classification))
 	req, _ = sjson.SetBytes(req, "prompt", strings.TrimSpace(prompt))
 	req, _ = sjson.SetBytes(req, "response_format", normalizeImagesResponseFormat(responseFormat))
 	if aspectRatio != "" {
@@ -338,7 +387,7 @@ func buildXAIImagesBaseRequest(model string, prompt string, responseFormat strin
 	return req
 }
 
-func buildXAIImagesGenerationsRequest(rawJSON []byte, model string, responseFormat string) []byte {
+func buildXAIImagesGenerationsRequest(rawJSON []byte, model string, classification imagesModelClassification, responseFormat string) []byte {
 	prompt := strings.TrimSpace(gjson.GetBytes(rawJSON, "prompt").String())
 	size := strings.TrimSpace(gjson.GetBytes(rawJSON, "size").String())
 	aspectRatio := xaiImagesAspectRatio(gjson.GetBytes(rawJSON, "aspect_ratio").String(), "")
@@ -351,11 +400,11 @@ func buildXAIImagesGenerationsRequest(rawJSON []byte, model string, responseForm
 	if v := gjson.GetBytes(rawJSON, "n"); v.Exists() && v.Type == gjson.Number {
 		n = v.Int()
 	}
-	return buildXAIImagesBaseRequest(model, prompt, responseFormat, aspectRatio, resolution, n)
+	return buildXAIImagesBaseRequest(model, classification, prompt, responseFormat, aspectRatio, resolution, n)
 }
 
-func buildXAIImagesEditRequest(model string, prompt string, images []string, responseFormat string, aspectRatio string, resolution string, n int64) []byte {
-	req := buildXAIImagesBaseRequest(model, prompt, responseFormat, aspectRatio, resolution, n)
+func buildXAIImagesEditRequest(model string, classification imagesModelClassification, prompt string, images []string, responseFormat string, aspectRatio string, resolution string, n int64) []byte {
+	req := buildXAIImagesBaseRequest(model, classification, prompt, responseFormat, aspectRatio, resolution, n)
 	trimmedImages := make([]string, 0, len(images))
 	for _, img := range images {
 		if strings.TrimSpace(img) != "" {
@@ -607,7 +656,8 @@ func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 	if imageModel == "" {
 		imageModel = defaultImagesToolModel
 	}
-	if rejectUnsupportedImagesModel(c, imageModel) {
+	classification := classifyImagesModel(imageModel)
+	if rejectUnsupportedImagesModel(c, imageModel, classification) {
 		return
 	}
 
@@ -628,17 +678,17 @@ func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 	}
 	stream := gjson.GetBytes(rawJSON, "stream").Bool()
 
-	if isCodexImagesToolModel(imageModel) {
+	if classification.kind == imagesModelCodex {
 		imageReq := buildOpenAICompatImagesJSONRequest(rawJSON, imageModel, stream)
 		h.handleRoutedImages(c, imageReq, imageModel, stream)
 		return
 	}
-	if isXAIImagesModel(imageModel) {
-		xaiReq := buildXAIImagesGenerationsRequest(rawJSON, imageModel, responseFormat)
+	if classification.kind == imagesModelXAI {
+		xaiReq := buildXAIImagesGenerationsRequest(rawJSON, imageModel, classification, responseFormat)
 		h.handleXAIImages(c, xaiReq, responseFormat, "image_generation", stream)
 		return
 	}
-	if isOpenAICompatImagesModel(imageModel) {
+	if classification.kind == imagesModelOpenAICompat {
 		compatReq := buildOpenAICompatImagesJSONRequest(rawJSON, imageModel, stream)
 		h.handleOpenAICompatImages(c, compatReq, imageModel, responseFormat, "image_generation", stream)
 		return
@@ -721,7 +771,8 @@ func (h *OpenAIAPIHandler) imagesEditsFromMultipart(c *gin.Context) {
 	if imageModel == "" {
 		imageModel = defaultImagesToolModel
 	}
-	if rejectUnsupportedImagesModel(c, imageModel) {
+	classification := classifyImagesModel(imageModel)
+	if rejectUnsupportedImagesModel(c, imageModel, classification) {
 		return
 	}
 
@@ -773,7 +824,7 @@ func (h *OpenAIAPIHandler) imagesEditsFromMultipart(c *gin.Context) {
 	}
 	stream := parseBoolField(c.PostForm("stream"), false)
 
-	if isCodexImagesToolModel(imageModel) {
+	if classification.kind == imagesModelCodex {
 		imageReq, contentType, errBuild := buildOpenAICompatImagesMultipartRequest(form, imageModel, stream)
 		if errBuild != nil {
 			c.JSON(http.StatusBadRequest, handlers.ErrorResponse{
@@ -788,16 +839,16 @@ func (h *OpenAIAPIHandler) imagesEditsFromMultipart(c *gin.Context) {
 		h.handleRoutedImages(c, imageReq, imageModel, stream)
 		return
 	}
-	if isXAIImagesModel(imageModel) {
+	if classification.kind == imagesModelXAI {
 		aspectRatio := xaiImagesAspectRatio(c.PostForm("aspect_ratio"), "")
 		aspectRatio = xaiImagesAspectRatioFromSize(c.PostForm("size"), aspectRatio)
 		resolution := xaiImagesResolution(c.PostForm("resolution"), c.PostForm("size"), "")
 		n := parseIntField(c.PostForm("n"), 0)
-		xaiReq := buildXAIImagesEditRequest(imageModel, prompt, images, responseFormat, aspectRatio, resolution, n)
+		xaiReq := buildXAIImagesEditRequest(imageModel, classification, prompt, images, responseFormat, aspectRatio, resolution, n)
 		h.handleXAIImages(c, xaiReq, responseFormat, "image_edit", stream)
 		return
 	}
-	if isOpenAICompatImagesModel(imageModel) {
+	if classification.kind == imagesModelOpenAICompat {
 		compatReq, contentType, errBuild := buildOpenAICompatImagesMultipartRequest(form, imageModel, stream)
 		if errBuild != nil {
 			c.JSON(http.StatusBadRequest, handlers.ErrorResponse{
@@ -894,7 +945,8 @@ func (h *OpenAIAPIHandler) imagesEditsFromJSON(c *gin.Context) {
 	if imageModel == "" {
 		imageModel = defaultImagesToolModel
 	}
-	if rejectUnsupportedImagesModel(c, imageModel) {
+	classification := classifyImagesModel(imageModel)
+	if rejectUnsupportedImagesModel(c, imageModel, classification) {
 		return
 	}
 
@@ -915,12 +967,12 @@ func (h *OpenAIAPIHandler) imagesEditsFromJSON(c *gin.Context) {
 	}
 	stream := gjson.GetBytes(rawJSON, "stream").Bool()
 
-	if isCodexImagesToolModel(imageModel) {
+	if classification.kind == imagesModelCodex {
 		imageReq := buildOpenAICompatImagesJSONRequest(rawJSON, imageModel, stream)
 		h.handleRoutedImages(c, imageReq, imageModel, stream)
 		return
 	}
-	if isXAIImagesModel(imageModel) {
+	if classification.kind == imagesModelXAI {
 		images := collectXAIImagesFromJSON(rawJSON)
 		if len(images) == 0 {
 			c.JSON(http.StatusBadRequest, handlers.ErrorResponse{
@@ -932,11 +984,11 @@ func (h *OpenAIAPIHandler) imagesEditsFromJSON(c *gin.Context) {
 			return
 		}
 		aspectRatio, resolution, n := xaiImagesEditOptionsFromJSON(rawJSON)
-		xaiReq := buildXAIImagesEditRequest(imageModel, prompt, images, responseFormat, aspectRatio, resolution, n)
+		xaiReq := buildXAIImagesEditRequest(imageModel, classification, prompt, images, responseFormat, aspectRatio, resolution, n)
 		h.handleXAIImages(c, xaiReq, responseFormat, "image_edit", stream)
 		return
 	}
-	if isOpenAICompatImagesModel(imageModel) {
+	if classification.kind == imagesModelOpenAICompat {
 		compatReq := buildOpenAICompatImagesJSONRequest(rawJSON, imageModel, stream)
 		h.handleOpenAICompatImages(c, compatReq, imageModel, responseFormat, "image_edit", stream)
 		return
@@ -1133,7 +1185,7 @@ func (h *OpenAIAPIHandler) handleOpenAICompatImages(c *gin.Context, compatReq []
 		h.streamOpenAICompatImages(c, compatReq, imageModel)
 		return
 	}
-	h.collectImagesWithModel(c, compatReq, imageModel, responseFormat)
+	h.collectImagesWithModel(c, compatReq, imageModel, responseFormat, "")
 }
 
 func (h *OpenAIAPIHandler) handleRoutedImages(c *gin.Context, imageReq []byte, imageModel string, stream bool) {
@@ -1142,6 +1194,13 @@ func (h *OpenAIAPIHandler) handleRoutedImages(c *gin.Context, imageReq []byte, i
 		return
 	}
 	h.collectRoutedImages(c, imageReq, imageModel)
+}
+
+func (h *OpenAIAPIHandler) executeImageRequest(cliCtx context.Context, model string, imageReq []byte, requiredProvider string) ([]byte, http.Header, *interfaces.ErrorMessage) {
+	if requiredProvider == "" {
+		return h.ExecuteImageWithAuthManager(cliCtx, xaiImagesHandlerType, model, imageReq, "")
+	}
+	return h.ExecuteImageWithAuthManagerForProvider(cliCtx, xaiImagesHandlerType, requiredProvider, model, imageReq, "")
 }
 
 func (h *OpenAIAPIHandler) collectRoutedImages(c *gin.Context, imageReq []byte, imageModel string) {
@@ -1391,17 +1450,17 @@ func (h *OpenAIAPIHandler) streamOpenAICompatImages(c *gin.Context, compatReq []
 
 func (h *OpenAIAPIHandler) collectXAIImages(c *gin.Context, xaiReq []byte, responseFormat string) {
 	model := strings.TrimSpace(gjson.GetBytes(xaiReq, "model").String())
-	h.collectImagesWithModel(c, xaiReq, model, responseFormat)
+	h.collectImagesWithModel(c, xaiReq, model, responseFormat, "xai")
 }
 
-func (h *OpenAIAPIHandler) collectImagesWithModel(c *gin.Context, imageReq []byte, model string, responseFormat string) {
+func (h *OpenAIAPIHandler) collectImagesWithModel(c *gin.Context, imageReq []byte, model string, responseFormat string, requiredProvider string) {
 	c.Header("Content-Type", "application/json")
 
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
 	stopKeepAlive := h.StartNonStreamingKeepAlive(c, cliCtx)
 
 	model = strings.TrimSpace(model)
-	resp, upstreamHeaders, errMsg := h.ExecuteImageWithAuthManager(cliCtx, xaiImagesHandlerType, model, imageReq, "")
+	resp, upstreamHeaders, errMsg := h.executeImageRequest(cliCtx, model, imageReq, requiredProvider)
 	stopKeepAlive()
 	if errMsg != nil {
 		h.WriteErrorResponse(c, errMsg)
@@ -1428,10 +1487,10 @@ func (h *OpenAIAPIHandler) collectImagesWithModel(c *gin.Context, imageReq []byt
 
 func (h *OpenAIAPIHandler) streamXAIImages(c *gin.Context, xaiReq []byte, responseFormat string, streamPrefix string) {
 	model := strings.TrimSpace(gjson.GetBytes(xaiReq, "model").String())
-	h.streamImagesWithModel(c, xaiReq, model, responseFormat, streamPrefix)
+	h.streamImagesWithModel(c, xaiReq, model, responseFormat, streamPrefix, "xai")
 }
 
-func (h *OpenAIAPIHandler) streamImagesWithModel(c *gin.Context, imageReq []byte, model string, responseFormat string, streamPrefix string) {
+func (h *OpenAIAPIHandler) streamImagesWithModel(c *gin.Context, imageReq []byte, model string, responseFormat string, streamPrefix string, requiredProvider string) {
 	flusher, ok := c.Writer.(http.Flusher)
 	if !ok {
 		c.JSON(http.StatusInternalServerError, handlers.ErrorResponse{
@@ -1452,7 +1511,7 @@ func (h *OpenAIAPIHandler) streamImagesWithModel(c *gin.Context, imageReq []byte
 	}
 	resultChan := make(chan imageStreamResult, 1)
 	go func() {
-		resp, upstreamHeaders, errMsg := h.ExecuteImageWithAuthManager(cliCtx, xaiImagesHandlerType, model, imageReq, "")
+		resp, upstreamHeaders, errMsg := h.executeImageRequest(cliCtx, model, imageReq, requiredProvider)
 		resultChan <- imageStreamResult{resp: resp, upstreamHeaders: upstreamHeaders, errMsg: errMsg}
 	}()
 

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -9,12 +10,15 @@ import (
 	"net/http/httptest"
 	"net/textproto"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 	"github.com/tidwall/gjson"
 )
@@ -35,6 +39,78 @@ func performImagesEndpointRequest(t *testing.T, endpointPath string, contentType
 	return resp
 }
 
+type capturedImageExecution struct {
+	authID  string
+	model   string
+	payload []byte
+}
+
+type imageAuthCaptureExecutor struct {
+	identifier string
+	mu         sync.Mutex
+	executions []capturedImageExecution
+}
+
+func (e *imageAuthCaptureExecutor) Identifier() string {
+	if e != nil && e.identifier != "" {
+		return e.identifier
+	}
+	return "xai"
+}
+
+func (e *imageAuthCaptureExecutor) Execute(_ context.Context, auth *coreauth.Auth, req coreexecutor.Request, _ coreexecutor.Options) (coreexecutor.Response, error) {
+	e.capture(auth, req)
+	return coreexecutor.Response{Payload: []byte(`{"created":123,"data":[{"b64_json":"AA=="}]}`)}, nil
+}
+
+func (e *imageAuthCaptureExecutor) capture(auth *coreauth.Auth, req coreexecutor.Request) {
+	authID := ""
+	if auth != nil {
+		authID = auth.ID
+	}
+	e.mu.Lock()
+	e.executions = append(e.executions, capturedImageExecution{
+		authID:  authID,
+		model:   req.Model,
+		payload: append([]byte(nil), req.Payload...),
+	})
+	e.mu.Unlock()
+}
+
+func (e *imageAuthCaptureExecutor) ExecuteStream(_ context.Context, auth *coreauth.Auth, req coreexecutor.Request, _ coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	e.capture(auth, req)
+	chunks := make(chan coreexecutor.StreamChunk, 1)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"type\":\"image_generation.completed\"}\n\n")}
+	close(chunks)
+	return &coreexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (*imageAuthCaptureExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (*imageAuthCaptureExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, &coreauth.Error{Code: "not_implemented", Message: "CountTokens not implemented"}
+}
+
+func (*imageAuthCaptureExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, &coreauth.Error{Code: "not_implemented", Message: "HttpRequest not implemented"}
+}
+
+func (e *imageAuthCaptureExecutor) Executions() []capturedImageExecution {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]capturedImageExecution, len(e.executions))
+	for i := range e.executions {
+		out[i] = capturedImageExecution{
+			authID:  e.executions[i].authID,
+			model:   e.executions[i].model,
+			payload: append([]byte(nil), e.executions[i].payload...),
+		}
+	}
+	return out
+}
+
 func assertUnsupportedImagesModelResponse(t *testing.T, resp *httptest.ResponseRecorder, model string) {
 	t.Helper()
 
@@ -52,6 +128,14 @@ func assertUnsupportedImagesModelResponse(t *testing.T, resp *httptest.ResponseR
 	}
 }
 
+func assertImagesModelClassification(t *testing.T, model string, wantKind imagesModelKind, wantDynamic bool) {
+	t.Helper()
+	got := classifyImagesModel(model)
+	if got.kind != wantKind || got.dynamic != wantDynamic {
+		t.Fatalf("classifyImagesModel(%q) = %+v, want kind %d dynamic %v", model, got, wantKind, wantDynamic)
+	}
+}
+
 func TestImagesModelValidationAllowsGPTImageAndXAIModels(t *testing.T) {
 	for _, model := range []string{"gpt-image-1.5", "codex/gpt-image-1.5", "gpt-image-2", "codex/gpt-image-2", "grok-imagine-image", "xai/grok-imagine-image", "grok-imagine-image-quality", "xai/grok-imagine-image-quality"} {
 		if !isSupportedImagesModel(model) {
@@ -66,29 +150,267 @@ func TestImagesModelValidationAllowsGPTImageAndXAIModels(t *testing.T) {
 	}
 }
 
+func TestImagesModelClassifierDynamicPrecedenceMatrix(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	legacyModels := []struct {
+		id           string
+		fallbackKind imagesModelKind
+	}{
+		{id: defaultXAIImagesModel, fallbackKind: imagesModelXAI},
+		{id: xaiImagesQualityModel, fallbackKind: imagesModelXAI},
+		{id: gptImage15Model, fallbackKind: imagesModelCodex},
+		{id: defaultImagesToolModel, fallbackKind: imagesModelCodex},
+	}
+
+	t.Run("compatibility registrations override legacy basenames", func(t *testing.T) {
+		const clientID = "compatibility-legacy-image-names"
+		models := make([]*registry.ModelInfo, 0, len(legacyModels))
+		for _, model := range legacyModels {
+			models = append(models, &registry.ModelInfo{
+				ID:               model.id,
+				Type:             registry.OpenAIImageModelType,
+				SupportsImageAPI: true,
+				ChatDisabled:     true,
+			})
+		}
+		modelRegistry.RegisterClient(clientID, "openai-compatibility", models)
+		defer modelRegistry.UnregisterClient(clientID)
+		for _, model := range legacyModels {
+			assertImagesModelClassification(t, model.id, imagesModelOpenAICompat, true)
+		}
+
+		modelRegistry.UnregisterClient(clientID)
+		for _, model := range legacyModels {
+			assertImagesModelClassification(t, model.id, model.fallbackKind, false)
+		}
+	})
+
+	t.Run("chat-only registrations suppress legacy basenames", func(t *testing.T) {
+		const clientID = "chat-only-legacy-image-names"
+		models := make([]*registry.ModelInfo, 0, len(legacyModels))
+		for _, model := range legacyModels {
+			models = append(models, &registry.ModelInfo{
+				ID:   model.id,
+				Type: "openai-compatibility",
+			})
+		}
+		modelRegistry.RegisterClient(clientID, "openai-compatibility", models)
+		defer modelRegistry.UnregisterClient(clientID)
+
+		for _, model := range legacyModels {
+			assertImagesModelClassification(t, model.id, imagesModelUnsupported, true)
+		}
+	})
+
+	t.Run("native xai wins a shared Codex-name registration", func(t *testing.T) {
+		const (
+			modelID        = defaultImagesToolModel
+			xaiClientID    = "shared-codex-name-xai"
+			compatClientID = "shared-codex-name-compat"
+		)
+		imageInfo := func(modelType string) *registry.ModelInfo {
+			return &registry.ModelInfo{
+				ID:               modelID,
+				Type:             modelType,
+				SupportsImageAPI: true,
+				ChatDisabled:     true,
+			}
+		}
+		modelRegistry.RegisterClient(compatClientID, "openai-compatibility", []*registry.ModelInfo{imageInfo(registry.OpenAIImageModelType)})
+		modelRegistry.RegisterClient(xaiClientID, "xai", []*registry.ModelInfo{imageInfo("xai")})
+		defer modelRegistry.UnregisterClient(compatClientID)
+		defer modelRegistry.UnregisterClient(xaiClientID)
+
+		assertImagesModelClassification(t, modelID, imagesModelXAI, true)
+	})
+
+	t.Run("native Codex wins an xai-name registration", func(t *testing.T) {
+		const (
+			modelID        = defaultXAIImagesModel
+			codexClientID  = "shared-xai-name-codex"
+			compatClientID = "shared-xai-name-compat"
+		)
+		modelRegistry.RegisterClient(compatClientID, "openai-compatibility", []*registry.ModelInfo{{
+			ID:               modelID,
+			Type:             registry.OpenAIImageModelType,
+			SupportsImageAPI: true,
+			ChatDisabled:     true,
+		}})
+		modelRegistry.RegisterClient(codexClientID, "codex", []*registry.ModelInfo{{
+			ID:               modelID,
+			Type:             "codex",
+			SupportsImageAPI: true,
+			ChatDisabled:     true,
+		}})
+		defer modelRegistry.UnregisterClient(compatClientID)
+		defer modelRegistry.UnregisterClient(codexClientID)
+
+		assertImagesModelClassification(t, modelID, imagesModelCodex, true)
+	})
+}
+
+func TestCodexImagesToolClassifierDefersToRegisteredXAI(t *testing.T) {
+	const clientID = "xai-codex-name-collision"
+	models := []string{
+		gptImage15Model,
+		"tenant/" + defaultImagesToolModel,
+	}
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(clientID)
+	for _, model := range models {
+		if !isCodexImagesToolModel(model) {
+			t.Fatalf("isCodexImagesToolModel(%q) = false before xAI registration, want true", model)
+		}
+	}
+	modelRegistry.RegisterClient(clientID, "xai", []*registry.ModelInfo{
+		{
+			ID:               models[0],
+			SupportsImageAPI: true,
+			ChatDisabled:     true,
+		},
+		{
+			ID:               models[1],
+			SupportsImageAPI: true,
+			ChatDisabled:     true,
+		},
+	})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	for _, model := range models {
+		if isCodexImagesToolModel(model) {
+			t.Fatalf("isCodexImagesToolModel(%q) = true after xAI registration, want false", model)
+		}
+	}
+}
+
 func TestImagesModelValidationAllowsOpenAICompatImageModels(t *testing.T) {
 	modelRegistry := registry.GetGlobalRegistry()
 	clientID := "test-openai-compat-image-model-validation"
+	shadowClientID := "test-openai-compat-image-model-validation-shadow"
 	modelRegistry.RegisterClient(clientID, "openai-compatibility", []*registry.ModelInfo{
 		{ID: "compat-image-model", Object: "model", OwnedBy: "compat", Type: registry.OpenAIImageModelType},
+		{ID: "tenant/compat-image-model", Object: "model", OwnedBy: "compat", Type: registry.OpenAIImageModelType},
+		{ID: "compat-shared-model", Object: "model", OwnedBy: "compat", Type: "openai-compatibility", SupportsImageAPI: true},
 		{ID: "compat-chat-model", Object: "model", OwnedBy: "compat", Type: "openai-compatibility"},
 	})
+	modelRegistry.RegisterClient(shadowClientID, "openai-compatibility", []*registry.ModelInfo{
+		{ID: "compat-shared-model", Object: "model", OwnedBy: "chat", Type: "openai"},
+	})
 	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(shadowClientID)
 		modelRegistry.UnregisterClient(clientID)
 	})
 
 	if !isSupportedImagesModel("compat-image-model") {
 		t.Fatal("expected configured openai-compatibility image model to be supported")
 	}
+	if !isSupportedImagesModel("tenant/compat-image-model") {
+		t.Fatal("expected prefixed openai-compatibility image model to be supported")
+	}
+	if !isSupportedImagesModel("compat-shared-model") {
+		t.Fatal("expected image-capable provider registration to remain visible after a chat-only registration")
+	}
+	if isXAIImagesModel("compat-image-model") || !isOpenAICompatImagesModel("compat-image-model") {
+		t.Fatal("expected configured openai-compatibility image model to retain compatibility request handling")
+	}
 	if isSupportedImagesModel("compat-chat-model") {
 		t.Fatal("expected non-image openai-compatibility model to be rejected")
 	}
 }
 
+func TestRegisteredXAIImagesModelRequiresProviderSpecificImageCapability(t *testing.T) {
+	const (
+		modelID        = "shared-xai-chat-compat-image"
+		xaiClientID    = "shared-xai-chat-client"
+		compatClientID = "shared-compat-image-client"
+	)
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(xaiClientID, "xai", []*registry.ModelInfo{{
+		ID:   modelID,
+		Type: "xai",
+	}})
+	modelRegistry.RegisterClient(compatClientID, "openai-compatibility", []*registry.ModelInfo{{
+		ID:               modelID,
+		Type:             registry.OpenAIImageModelType,
+		SupportsImageAPI: true,
+		ChatDisabled:     true,
+	}})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(compatClientID)
+		modelRegistry.UnregisterClient(xaiClientID)
+	})
+
+	if isXAIImagesModel(modelID) {
+		t.Fatalf("isXAIImagesModel(%q) = true, want xAI chat registration ignored", modelID)
+	}
+	if !isOpenAICompatImagesModel(modelID) {
+		t.Fatalf("isOpenAICompatImagesModel(%q) = false, want compatibility image route", modelID)
+	}
+}
+
+func TestRegisteredXAIImagesModelAggregatesProviderClients(t *testing.T) {
+	tests := []struct {
+		name       string
+		imageFirst bool
+	}{
+		{name: "image then chat", imageFirst: true},
+		{name: "chat then image", imageFirst: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			modelID := "shared-xai-image-" + strings.ReplaceAll(tc.name, " ", "-")
+			imageClientID := modelID + "-image"
+			chatClientID := modelID + "-chat"
+			modelRegistry := registry.GetGlobalRegistry()
+			registerImage := func() {
+				modelRegistry.RegisterClient(imageClientID, "xai", []*registry.ModelInfo{{
+					ID:               modelID,
+					Type:             "xai",
+					SupportsImageAPI: true,
+					ChatDisabled:     true,
+				}})
+			}
+			registerChat := func() {
+				modelRegistry.RegisterClient(chatClientID, "xai", []*registry.ModelInfo{{
+					ID:   modelID,
+					Type: "xai",
+				}})
+			}
+			if tc.imageFirst {
+				registerImage()
+				registerChat()
+			} else {
+				registerChat()
+				registerImage()
+			}
+			t.Cleanup(func() {
+				modelRegistry.UnregisterClient(chatClientID)
+				modelRegistry.UnregisterClient(imageClientID)
+			})
+
+			if !isXAIImagesModel(modelID) {
+				t.Fatalf("isXAIImagesModel(%q) = false after %s", modelID, tc.name)
+			}
+			if got := canonicalXAIImagesModel(modelID); got != modelID {
+				t.Fatalf("canonicalXAIImagesModel(%q) = %q, want exact route", modelID, got)
+			}
+
+			modelRegistry.UnregisterClient(imageClientID)
+			if isXAIImagesModel(modelID) {
+				t.Fatalf("isXAIImagesModel(%q) = true after image client removal", modelID)
+			}
+		})
+	}
+}
+
 func TestBuildXAIImagesGenerationsRequest(t *testing.T) {
 	rawJSON := []byte(`{"model":"xai/grok-imagine-image-quality","prompt":"abstract art","aspect_ratio":"landscape","resolution":"2k","n":2,"response_format":"url"}`)
+	model := "xai/grok-imagine-image-quality"
 
-	req := buildXAIImagesGenerationsRequest(rawJSON, "xai/grok-imagine-image-quality", "url")
+	req := buildXAIImagesGenerationsRequest(rawJSON, model, classifyImagesModel(model), "url")
 
 	if got := gjson.GetBytes(req, "model").String(); got != "grok-imagine-image-quality" {
 		t.Fatalf("model = %q, want grok-imagine-image-quality", got)
@@ -111,7 +433,8 @@ func TestBuildXAIImagesGenerationsRequest(t *testing.T) {
 }
 
 func TestBuildXAIImagesEditRequest(t *testing.T) {
-	req := buildXAIImagesEditRequest("grok-imagine-image", "edit it", []string{"data:image/png;base64,AA==", "https://example.com/image.png"}, "b64_json", "3:2", "1k", 0)
+	model := "grok-imagine-image"
+	req := buildXAIImagesEditRequest(model, classifyImagesModel(model), "edit it", []string{"data:image/png;base64,AA==", "https://example.com/image.png"}, "b64_json", "3:2", "1k", 0)
 
 	if got := gjson.GetBytes(req, "model").String(); got != "grok-imagine-image" {
 		t.Fatalf("model = %q, want grok-imagine-image", got)
@@ -131,7 +454,8 @@ func TestBuildXAIImagesEditRequest(t *testing.T) {
 }
 
 func TestBuildXAIImagesEditRequestSingleImage(t *testing.T) {
-	req := buildXAIImagesEditRequest("grok-imagine-image", "edit it", []string{"https://example.com/image.png"}, "url", "", "", 0)
+	model := "grok-imagine-image"
+	req := buildXAIImagesEditRequest(model, classifyImagesModel(model), "edit it", []string{"https://example.com/image.png"}, "url", "", "", 0)
 
 	if got := gjson.GetBytes(req, "image.type").String(); got != "image_url" {
 		t.Fatalf("image.type = %q, want image_url", got)
@@ -141,6 +465,536 @@ func TestBuildXAIImagesEditRequestSingleImage(t *testing.T) {
 	}
 	if gjson.GetBytes(req, "images").Exists() {
 		t.Fatalf("single image edit must use image object: %s", string(req))
+	}
+}
+
+func TestNativeXAIImageAliasUsesXAIRequestNormalization(t *testing.T) {
+	const (
+		prefix        = "tenant"
+		publicAlias   = "public-image"
+		routeAlias    = prefix + "/" + publicAlias
+		upstreamModel = xaiImagesQualityModel
+		apiKey        = "xai-image-handler-key"
+		authID        = "xai-image-handler-alias-auth"
+		compatAuthID  = "compat-image-handler-alias-auth"
+	)
+
+	executor := &imageAuthCaptureExecutor{}
+	compatExecutor := &imageAuthCaptureExecutor{identifier: "openai-compatibility"}
+	manager := coreauth.NewManager(nil, &coreauth.RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(executor)
+	manager.RegisterExecutor(compatExecutor)
+	manager.SetConfig(&sdkconfig.Config{XAIKey: []sdkconfig.XAIKey{{
+		APIKey: apiKey,
+		Prefix: prefix,
+		Models: []sdkconfig.XAIModel{{
+			Name:  upstreamModel,
+			Alias: publicAlias,
+		}},
+	}}})
+	auth := &coreauth.Auth{
+		ID:       authID,
+		Provider: "xai",
+		Prefix:   prefix,
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			coreauth.AttributeAPIKey: apiKey,
+			coreauth.AttributeSource: "config:xai[test]",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("manager.Register(): %v", errRegister)
+	}
+	compatAuth := &coreauth.Auth{
+		ID:       compatAuthID,
+		Provider: "openai-compatibility",
+		Status:   coreauth.StatusActive,
+	}
+	if _, errRegister := manager.Register(context.Background(), compatAuth); errRegister != nil {
+		t.Fatalf("manager.Register(compat): %v", errRegister)
+	}
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(authID, auth.Provider, []*registry.ModelInfo{{
+		ID:               routeAlias,
+		Type:             "xai",
+		SupportsImageAPI: true,
+		ChatDisabled:     true,
+	}})
+	modelRegistry.RegisterClient(compatAuthID, compatAuth.Provider, []*registry.ModelInfo{{
+		ID:               routeAlias,
+		Type:             registry.OpenAIImageModelType,
+		SupportsImageAPI: true,
+		ChatDisabled:     true,
+	}})
+	manager.RefreshSchedulerEntry(authID)
+	manager.RefreshSchedulerEntry(compatAuthID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(compatAuthID)
+		modelRegistry.UnregisterClient(authID)
+	})
+
+	if !isXAIImagesModel(routeAlias) {
+		t.Fatalf("isXAIImagesModel(%q) = false, want native xAI registration", routeAlias)
+	}
+	if isOpenAICompatImagesModel(routeAlias) {
+		t.Fatalf("isOpenAICompatImagesModel(%q) = true, want native xAI request handling", routeAlias)
+	}
+	if got := canonicalXAIImagesModel(routeAlias); got != routeAlias {
+		t.Fatalf("canonicalXAIImagesModel(%q) = %q, want public route for auth mapping", routeAlias, got)
+	}
+
+	handler := NewOpenAIAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager))
+	generationResp := performImagesEndpointRequest(
+		t,
+		imagesGenerationsPath,
+		"application/json",
+		strings.NewReader(`{"model":"`+routeAlias+`","prompt":"draw","size":"1792x1024"}`),
+		handler.ImagesGenerations,
+	)
+	if generationResp.Code != http.StatusOK {
+		t.Fatalf("generation status = %d, want %d: %s", generationResp.Code, http.StatusOK, generationResp.Body.String())
+	}
+
+	var editBody bytes.Buffer
+	writer := multipart.NewWriter(&editBody)
+	if errWrite := writer.WriteField("model", routeAlias); errWrite != nil {
+		t.Fatalf("write model field: %v", errWrite)
+	}
+	if errWrite := writer.WriteField("prompt", "edit"); errWrite != nil {
+		t.Fatalf("write prompt field: %v", errWrite)
+	}
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition", multipart.FileContentDisposition("image", "image.png"))
+	header.Set("Content-Type", "image/png")
+	part, errCreate := writer.CreatePart(header)
+	if errCreate != nil {
+		t.Fatalf("create image field: %v", errCreate)
+	}
+	if _, errWrite := part.Write([]byte("png-data")); errWrite != nil {
+		t.Fatalf("write image field: %v", errWrite)
+	}
+	if errClose := writer.Close(); errClose != nil {
+		t.Fatalf("close multipart writer: %v", errClose)
+	}
+	editResp := performImagesEndpointRequest(t, imagesEditsPath, writer.FormDataContentType(), &editBody, handler.ImagesEdits)
+	if editResp.Code != http.StatusOK {
+		t.Fatalf("edit status = %d, want %d: %s", editResp.Code, http.StatusOK, editResp.Body.String())
+	}
+
+	jsonEditResp := performImagesEndpointRequest(
+		t,
+		imagesEditsPath,
+		"application/json",
+		strings.NewReader(`{"model":"`+routeAlias+`","prompt":"edit JSON","images":[{"image_url":"https://example.com/input-1.png"},{"image_url":"https://example.com/input-2.png"}],"size":"1024x1536"}`),
+		handler.ImagesEdits,
+	)
+	if jsonEditResp.Code != http.StatusOK {
+		t.Fatalf("JSON edit status = %d, want %d: %s", jsonEditResp.Code, http.StatusOK, jsonEditResp.Body.String())
+	}
+
+	streamResp := performImagesEndpointRequest(
+		t,
+		imagesGenerationsPath,
+		"application/json",
+		strings.NewReader(`{"model":"`+routeAlias+`","prompt":"draw stream","stream":true}`),
+		handler.ImagesGenerations,
+	)
+	if streamResp.Code != http.StatusOK {
+		t.Fatalf("stream generation status = %d, want %d: %s", streamResp.Code, http.StatusOK, streamResp.Body.String())
+	}
+
+	executions := executor.Executions()
+	if len(executions) != 4 {
+		t.Fatalf("xAI execution count = %d, want 4", len(executions))
+	}
+	if executions := compatExecutor.Executions(); len(executions) != 0 {
+		t.Fatalf("compatibility executions = %#v, want none while native xAI registration exists", executions)
+	}
+	for i, execution := range executions {
+		if execution.authID != authID || execution.model != upstreamModel {
+			t.Fatalf("execution %d = auth %q model %q, want %q %q", i, execution.authID, execution.model, authID, upstreamModel)
+		}
+		if got := gjson.GetBytes(execution.payload, "model").String(); got != routeAlias {
+			t.Fatalf("execution %d payload model = %q, want route alias %q", i, got, routeAlias)
+		}
+	}
+	if got := gjson.GetBytes(executions[0].payload, "aspect_ratio").String(); got != "16:9" {
+		t.Fatalf("generation aspect_ratio = %q, want 16:9; body=%s", got, executions[0].payload)
+	}
+	if got := gjson.GetBytes(executions[0].payload, "resolution").String(); got != "1k" {
+		t.Fatalf("generation resolution = %q, want 1k; body=%s", got, executions[0].payload)
+	}
+	if got := gjson.GetBytes(executions[1].payload, "image.type").String(); got != "image_url" {
+		t.Fatalf("edit image.type = %q, want image_url; body=%s", got, executions[1].payload)
+	}
+	if got := gjson.GetBytes(executions[1].payload, "image.url").String(); !strings.HasPrefix(got, "data:image/png;base64,") {
+		t.Fatalf("edit image.url = %q, want image/png data URL", got)
+	}
+	if got := gjson.GetBytes(executions[2].payload, "images.0.url").String(); got != "https://example.com/input-1.png" {
+		t.Fatalf("JSON edit images.0.url = %q, want first source URL; body=%s", got, executions[2].payload)
+	}
+	if got := gjson.GetBytes(executions[2].payload, "images.1.url").String(); got != "https://example.com/input-2.png" {
+		t.Fatalf("JSON edit images.1.url = %q, want second source URL; body=%s", got, executions[2].payload)
+	}
+	if got := gjson.GetBytes(executions[2].payload, "aspect_ratio").String(); got != "2:3" {
+		t.Fatalf("JSON edit aspect_ratio = %q, want 2:3; body=%s", got, executions[2].payload)
+	}
+
+	modelRegistry.UnregisterClient(authID)
+	compatResp := performImagesEndpointRequest(
+		t,
+		imagesGenerationsPath,
+		"application/json",
+		strings.NewReader(`{"model":"`+routeAlias+`","prompt":"draw compat","size":"1024x1024"}`),
+		handler.ImagesGenerations,
+	)
+	if compatResp.Code != http.StatusOK {
+		t.Fatalf("compatibility generation status = %d, want %d: %s", compatResp.Code, http.StatusOK, compatResp.Body.String())
+	}
+	compatExecutions := compatExecutor.Executions()
+	if len(compatExecutions) != 1 {
+		t.Fatalf("compatibility execution count = %d, want 1 after xAI removal", len(compatExecutions))
+	}
+	if got := gjson.GetBytes(compatExecutions[0].payload, "size").String(); got != "1024x1024" {
+		t.Fatalf("compatibility size = %q, want 1024x1024; body=%s", got, compatExecutions[0].payload)
+	}
+	if gjson.GetBytes(compatExecutions[0].payload, "aspect_ratio").Exists() {
+		t.Fatalf("compatibility payload received xAI normalization: %s", compatExecutions[0].payload)
+	}
+}
+
+func TestOpenAICompatImageAliasesOverrideBuiltinXAINames(t *testing.T) {
+	for _, modelID := range []string{defaultXAIImagesModel, xaiImagesQualityModel} {
+		t.Run(modelID, func(t *testing.T) {
+			authID := "compat-builtin-xai-name-" + modelID
+			executor := &imageAuthCaptureExecutor{identifier: "openai-compatibility"}
+			manager := coreauth.NewManager(nil, &coreauth.RoundRobinSelector{}, nil)
+			manager.RegisterExecutor(executor)
+			auth := &coreauth.Auth{
+				ID:       authID,
+				Provider: "openai-compatibility",
+				Status:   coreauth.StatusActive,
+			}
+			if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+				t.Fatalf("manager.Register(): %v", errRegister)
+			}
+
+			modelRegistry := registry.GetGlobalRegistry()
+			modelRegistry.RegisterClient(authID, auth.Provider, []*registry.ModelInfo{{
+				ID:               modelID,
+				Type:             registry.OpenAIImageModelType,
+				SupportsImageAPI: true,
+				ChatDisabled:     true,
+			}})
+			manager.RefreshSchedulerEntry(authID)
+			t.Cleanup(func() {
+				modelRegistry.UnregisterClient(authID)
+			})
+
+			assertImagesModelClassification(t, modelID, imagesModelOpenAICompat, true)
+			handler := NewOpenAIAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager))
+
+			generationResp := performImagesEndpointRequest(
+				t,
+				imagesGenerationsPath,
+				"application/json",
+				strings.NewReader(`{"model":"`+modelID+`","prompt":"draw","size":"1024x1024"}`),
+				handler.ImagesGenerations,
+			)
+			if generationResp.Code != http.StatusOK {
+				t.Fatalf("generation status = %d, want %d: %s", generationResp.Code, http.StatusOK, generationResp.Body.String())
+			}
+
+			var editBody bytes.Buffer
+			writer := multipart.NewWriter(&editBody)
+			if errWrite := writer.WriteField("model", modelID); errWrite != nil {
+				t.Fatalf("write model field: %v", errWrite)
+			}
+			if errWrite := writer.WriteField("prompt", "edit"); errWrite != nil {
+				t.Fatalf("write prompt field: %v", errWrite)
+			}
+			header := make(textproto.MIMEHeader)
+			header.Set("Content-Disposition", multipart.FileContentDisposition("image", "image.png"))
+			header.Set("Content-Type", "image/png")
+			part, errCreate := writer.CreatePart(header)
+			if errCreate != nil {
+				t.Fatalf("create image field: %v", errCreate)
+			}
+			if _, errWrite := part.Write([]byte("png-data")); errWrite != nil {
+				t.Fatalf("write image field: %v", errWrite)
+			}
+			if errClose := writer.Close(); errClose != nil {
+				t.Fatalf("close multipart writer: %v", errClose)
+			}
+			editResp := performImagesEndpointRequest(t, imagesEditsPath, writer.FormDataContentType(), &editBody, handler.ImagesEdits)
+			if editResp.Code != http.StatusOK {
+				t.Fatalf("multipart edit status = %d, want %d: %s", editResp.Code, http.StatusOK, editResp.Body.String())
+			}
+
+			jsonEditResp := performImagesEndpointRequest(
+				t,
+				imagesEditsPath,
+				"application/json",
+				strings.NewReader(`{"model":"`+modelID+`","prompt":"edit JSON","images":[{"image_url":"https://example.com/input.png"}],"size":"1024x1536"}`),
+				handler.ImagesEdits,
+			)
+			if jsonEditResp.Code != http.StatusOK {
+				t.Fatalf("JSON edit status = %d, want %d: %s", jsonEditResp.Code, http.StatusOK, jsonEditResp.Body.String())
+			}
+
+			streamResp := performImagesEndpointRequest(
+				t,
+				imagesGenerationsPath,
+				"application/json",
+				strings.NewReader(`{"model":"`+modelID+`","prompt":"draw stream","stream":true}`),
+				handler.ImagesGenerations,
+			)
+			if streamResp.Code != http.StatusOK {
+				t.Fatalf("stream generation status = %d, want %d: %s", streamResp.Code, http.StatusOK, streamResp.Body.String())
+			}
+
+			executions := executor.Executions()
+			if len(executions) != 4 {
+				t.Fatalf("compatibility execution count = %d, want 4", len(executions))
+			}
+			for i, execution := range executions {
+				if execution.authID != authID || execution.model != modelID {
+					t.Fatalf("execution %d = auth %q model %q, want %q %q", i, execution.authID, execution.model, authID, modelID)
+				}
+			}
+			if got := gjson.GetBytes(executions[0].payload, "size").String(); got != "1024x1024" {
+				t.Fatalf("compatibility size = %q, want 1024x1024; body=%s", got, executions[0].payload)
+			}
+			if gjson.GetBytes(executions[0].payload, "aspect_ratio").Exists() {
+				t.Fatalf("compatibility generation received xAI normalization: %s", executions[0].payload)
+			}
+			if !bytes.Contains(executions[1].payload, []byte(`name="image"; filename="image.png"`)) {
+				t.Fatalf("compatibility edit did not preserve multipart image: %s", executions[1].payload)
+			}
+			if gjson.ValidBytes(executions[1].payload) {
+				t.Fatalf("compatibility edit was normalized to xAI JSON: %s", executions[1].payload)
+			}
+			if got := gjson.GetBytes(executions[2].payload, "images.0.image_url").String(); got != "https://example.com/input.png" {
+				t.Fatalf("compatibility JSON edit image = %q, want source URL; body=%s", got, executions[2].payload)
+			}
+			if gjson.GetBytes(executions[2].payload, "aspect_ratio").Exists() {
+				t.Fatalf("compatibility JSON edit received xAI normalization: %s", executions[2].payload)
+			}
+			if !gjson.GetBytes(executions[3].payload, "stream").Bool() {
+				t.Fatalf("compatibility stream flag missing: %s", executions[3].payload)
+			}
+
+			modelRegistry.UnregisterClient(authID)
+			assertImagesModelClassification(t, modelID, imagesModelXAI, false)
+		})
+	}
+}
+
+func TestNativeXAIImageAliasTakesPrecedenceOverCodexName(t *testing.T) {
+	const (
+		prefix        = "tenant"
+		publicAlias   = defaultImagesToolModel
+		routeAlias    = prefix + "/" + publicAlias
+		upstreamModel = xaiImagesQualityModel
+		apiKey        = "xai-codex-name-collision-key"
+		authID        = "xai-codex-name-collision-auth"
+	)
+
+	executor := &imageAuthCaptureExecutor{}
+	manager := coreauth.NewManager(nil, &coreauth.RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(executor)
+	manager.SetConfig(&sdkconfig.Config{XAIKey: []sdkconfig.XAIKey{{
+		APIKey: apiKey,
+		Prefix: prefix,
+		Models: []sdkconfig.XAIModel{{
+			Name:  upstreamModel,
+			Alias: publicAlias,
+		}},
+	}}})
+	auth := &coreauth.Auth{
+		ID:       authID,
+		Provider: "xai",
+		Prefix:   prefix,
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			coreauth.AttributeAPIKey: apiKey,
+			coreauth.AttributeSource: "config:xai[codex-name-collision]",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("manager.Register(): %v", errRegister)
+	}
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(authID, auth.Provider, []*registry.ModelInfo{{
+		ID:               routeAlias,
+		Type:             "xai",
+		SupportsImageAPI: true,
+		ChatDisabled:     true,
+	}})
+	manager.RefreshSchedulerEntry(authID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(authID)
+	})
+
+	if isCodexImagesToolModel(routeAlias) {
+		t.Fatalf("isCodexImagesToolModel(%q) = true, want exact xAI registration precedence", routeAlias)
+	}
+
+	handler := NewOpenAIAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager))
+	generationResp := performImagesEndpointRequest(
+		t,
+		imagesGenerationsPath,
+		"application/json",
+		strings.NewReader(`{"model":"`+routeAlias+`","prompt":"draw","size":"1792x1024"}`),
+		handler.ImagesGenerations,
+	)
+	if generationResp.Code != http.StatusOK {
+		t.Fatalf("generation status = %d, want %d: %s", generationResp.Code, http.StatusOK, generationResp.Body.String())
+	}
+
+	var editBody bytes.Buffer
+	writer := multipart.NewWriter(&editBody)
+	if errWrite := writer.WriteField("model", routeAlias); errWrite != nil {
+		t.Fatalf("write model field: %v", errWrite)
+	}
+	if errWrite := writer.WriteField("prompt", "edit"); errWrite != nil {
+		t.Fatalf("write prompt field: %v", errWrite)
+	}
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition", multipart.FileContentDisposition("image", "image.png"))
+	header.Set("Content-Type", "image/png")
+	part, errCreate := writer.CreatePart(header)
+	if errCreate != nil {
+		t.Fatalf("create image field: %v", errCreate)
+	}
+	if _, errWrite := part.Write([]byte("png-data")); errWrite != nil {
+		t.Fatalf("write image field: %v", errWrite)
+	}
+	if errClose := writer.Close(); errClose != nil {
+		t.Fatalf("close multipart writer: %v", errClose)
+	}
+	editResp := performImagesEndpointRequest(t, imagesEditsPath, writer.FormDataContentType(), &editBody, handler.ImagesEdits)
+	if editResp.Code != http.StatusOK {
+		t.Fatalf("edit status = %d, want %d: %s", editResp.Code, http.StatusOK, editResp.Body.String())
+	}
+
+	jsonEditResp := performImagesEndpointRequest(
+		t,
+		imagesEditsPath,
+		"application/json",
+		strings.NewReader(`{"model":"`+routeAlias+`","prompt":"edit JSON","images":[{"image_url":"https://example.com/input.png"}]}`),
+		handler.ImagesEdits,
+	)
+	if jsonEditResp.Code != http.StatusOK {
+		t.Fatalf("JSON edit status = %d, want %d: %s", jsonEditResp.Code, http.StatusOK, jsonEditResp.Body.String())
+	}
+
+	streamResp := performImagesEndpointRequest(
+		t,
+		imagesGenerationsPath,
+		"application/json",
+		strings.NewReader(`{"model":"`+routeAlias+`","prompt":"draw stream","stream":true}`),
+		handler.ImagesGenerations,
+	)
+	if streamResp.Code != http.StatusOK {
+		t.Fatalf("stream generation status = %d, want %d: %s", streamResp.Code, http.StatusOK, streamResp.Body.String())
+	}
+
+	executions := executor.Executions()
+	if len(executions) != 4 {
+		t.Fatalf("xAI execution count = %d, want 4", len(executions))
+	}
+	for i, execution := range executions {
+		if execution.authID != authID || execution.model != upstreamModel {
+			t.Fatalf("execution %d = auth %q model %q, want %q %q", i, execution.authID, execution.model, authID, upstreamModel)
+		}
+		if got := gjson.GetBytes(execution.payload, "model").String(); got != routeAlias {
+			t.Fatalf("execution %d payload model = %q, want route alias %q", i, got, routeAlias)
+		}
+	}
+	if got := gjson.GetBytes(executions[0].payload, "aspect_ratio").String(); got != "16:9" {
+		t.Fatalf("generation aspect_ratio = %q, want 16:9; body=%s", got, executions[0].payload)
+	}
+	if got := gjson.GetBytes(executions[1].payload, "image.url").String(); !strings.HasPrefix(got, "data:image/png;base64,") {
+		t.Fatalf("multipart edit payload was not normalized to xAI JSON: %s", executions[1].payload)
+	}
+	if got := gjson.GetBytes(executions[2].payload, "image.url").String(); got != "https://example.com/input.png" {
+		t.Fatalf("JSON edit image.url = %q, want source URL; body=%s", got, executions[2].payload)
+	}
+}
+
+func TestRegisteredLegacyShapedXAIImageRoutePreservesPrefixForAuthSelection(t *testing.T) {
+	const (
+		prefix        = "xai"
+		upstreamModel = xaiImagesQualityModel
+		routeModel    = prefix + "/" + upstreamModel
+		apiKey        = "xai-prefixed-image-key"
+		authID        = "xai-prefixed-image-auth"
+	)
+
+	if got := canonicalXAIImagesModel(routeModel); got != upstreamModel {
+		t.Fatalf("unregistered canonicalXAIImagesModel(%q) = %q, want legacy shorthand %q", routeModel, got, upstreamModel)
+	}
+
+	executor := &imageAuthCaptureExecutor{}
+	manager := coreauth.NewManager(nil, &coreauth.RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(executor)
+	manager.SetConfig(&sdkconfig.Config{
+		SDKConfig: sdkconfig.SDKConfig{ForceModelPrefix: true},
+		XAIKey: []sdkconfig.XAIKey{{
+			APIKey: apiKey,
+			Prefix: prefix,
+			Models: []sdkconfig.XAIModel{{
+				Name:  upstreamModel,
+				Alias: upstreamModel,
+			}},
+		}},
+	})
+	auth := &coreauth.Auth{
+		ID:       authID,
+		Provider: "xai",
+		Prefix:   prefix,
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			coreauth.AttributeAPIKey: apiKey,
+			coreauth.AttributeSource: "config:xai[prefixed]",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("manager.Register(): %v", errRegister)
+	}
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(authID, auth.Provider, []*registry.ModelInfo{{
+		ID:               routeModel,
+		Type:             "xai",
+		SupportsImageAPI: true,
+		ChatDisabled:     true,
+	}})
+	manager.RefreshSchedulerEntry(authID)
+	t.Cleanup(func() { modelRegistry.UnregisterClient(authID) })
+
+	if got := canonicalXAIImagesModel(routeModel); got != routeModel {
+		t.Fatalf("registered canonicalXAIImagesModel(%q) = %q, want exact public route", routeModel, got)
+	}
+
+	handler := NewOpenAIAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager))
+	resp := performImagesEndpointRequest(
+		t,
+		imagesGenerationsPath,
+		"application/json",
+		strings.NewReader(`{"model":"`+routeModel+`","prompt":"draw"}`),
+		handler.ImagesGenerations,
+	)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	executions := executor.Executions()
+	if len(executions) != 1 {
+		t.Fatalf("execution count = %d, want 1", len(executions))
+	}
+	if got := executions[0]; got.authID != authID || got.model != upstreamModel || gjson.GetBytes(got.payload, "model").String() != routeModel {
+		t.Fatalf("execution = auth %q model %q payload %s, want %q %q with exact route", got.authID, got.model, got.payload, authID, upstreamModel)
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_videos_handlers.go
+++ b/sdk/api/handlers/openai/openai_videos_handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -144,7 +145,7 @@ func videosModelBase(model string) string {
 	return strings.ToLower(strings.TrimSpace(baseModel))
 }
 
-func isXAIVideosModel(model string) bool {
+func isBuiltinXAIVideosModel(model string) bool {
 	prefix, baseModel := imagesModelParts(model)
 	baseModel = strings.ToLower(strings.TrimSpace(baseModel))
 	if baseModel != defaultXAIVideosModel && baseModel != xaiVideos15PreviewModel {
@@ -153,6 +154,13 @@ func isXAIVideosModel(model string) bool {
 
 	prefix = strings.ToLower(strings.TrimSpace(prefix))
 	return prefix == "" || prefix == "xai" || prefix == "x-ai" || prefix == "grok"
+}
+
+func isXAIVideosModel(model string) bool {
+	if capabilities, found := registry.LookupModelEndpointCapabilities(model); found {
+		return capabilities.Video
+	}
+	return isBuiltinXAIVideosModel(model)
 }
 
 func isSoraVideosModel(model string) bool {
@@ -196,11 +204,16 @@ func canonicalXAIVideosModel(model string) string {
 	if isSoraVideosModel(model) {
 		return defaultXAIVideosModel
 	}
-	switch videosModelBase(model) {
-	case defaultXAIVideosModel:
-		return defaultXAIVideosModel
-	case xaiVideos15PreviewModel:
-		return xaiVideos15PreviewModel
+	if isBuiltinXAIVideosModel(model) {
+		switch videosModelBase(model) {
+		case defaultXAIVideosModel:
+			return defaultXAIVideosModel
+		case xaiVideos15PreviewModel:
+			return xaiVideos15PreviewModel
+		}
+	}
+	if capabilities, found := registry.LookupModelEndpointCapabilities(model); found && capabilities.Video {
+		return strings.TrimSpace(model)
 	}
 	return defaultXAIVideosModel
 }

--- a/sdk/api/handlers/openai/openai_videos_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_videos_handlers_test.go
@@ -126,6 +126,15 @@ func (e *videoAuthCaptureExecutor) Models() []string {
 	return out
 }
 
+func testXAIVideoModelInfo(modelID string) *registry.ModelInfo {
+	return &registry.ModelInfo{
+		ID:               modelID,
+		Type:             "xai",
+		SupportsVideoAPI: true,
+		ChatDisabled:     true,
+	}
+}
+
 func resetVideoAuthBindingsForTest(t *testing.T) {
 	t.Helper()
 	previous := videoAuthBindings
@@ -151,7 +160,7 @@ func newVideoAuthBindingTestHandler(t *testing.T, executor *videoAuthCaptureExec
 		if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
 			t.Fatalf("manager.Register(%s): %v", authID, errRegister)
 		}
-		registry.GetGlobalRegistry().RegisterClient(authID, auth.Provider, []*registry.ModelInfo{{ID: defaultXAIVideosModel}})
+		registry.GetGlobalRegistry().RegisterClient(authID, auth.Provider, []*registry.ModelInfo{testXAIVideoModelInfo(defaultXAIVideosModel)})
 		manager.RefreshSchedulerEntry(authID)
 	}
 	t.Cleanup(func() {
@@ -190,6 +199,71 @@ func TestVideosModelValidationAllowsXAIVideoModel(t *testing.T) {
 	}
 	if isSupportedVideosModel("codex/grok-imagine-video-1.5-preview") {
 		t.Fatal("expected codex/grok-imagine-video-1.5-preview to be rejected")
+	}
+}
+
+func TestXAIVideosNativeConfiguredAliasSelectsVideoAuthAndResolvesUpstreamModel(t *testing.T) {
+	const (
+		alias       = "tenant/public-video"
+		apiKey      = "video-key"
+		videoAuthID = "video-handler-alias-auth"
+		chatAuthID  = "chat-handler-alias-auth"
+	)
+	executor := &videoAuthCaptureExecutor{requestID: "video-handler-alias"}
+	manager := coreauth.NewManager(nil, &coreauth.RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(executor)
+	manager.SetConfig(&sdkconfig.Config{XAIKey: []sdkconfig.XAIKey{{
+		APIKey: apiKey,
+		Models: []sdkconfig.XAIModel{{
+			Name:  defaultXAIVideosModel,
+			Alias: alias,
+		}},
+	}}})
+
+	auths := []*coreauth.Auth{
+		{
+			ID:       chatAuthID,
+			Provider: "xai",
+			Status:   coreauth.StatusActive,
+		},
+		{
+			ID:       videoAuthID,
+			Provider: "xai",
+			Status:   coreauth.StatusActive,
+			Attributes: map[string]string{
+				coreauth.AttributeAPIKey: apiKey,
+				coreauth.AttributeSource: "config:xai[test]",
+			},
+		},
+	}
+	modelRegistry := registry.GetGlobalRegistry()
+	for _, auth := range auths {
+		if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+			t.Fatalf("manager.Register(%s): %v", auth.ID, errRegister)
+		}
+		info := &registry.ModelInfo{ID: alias, Type: "xai"}
+		if auth.ID == videoAuthID {
+			info = testXAIVideoModelInfo(alias)
+		}
+		modelRegistry.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{info})
+		manager.RefreshSchedulerEntry(auth.ID)
+	}
+	t.Cleanup(func() {
+		for _, auth := range auths {
+			modelRegistry.UnregisterClient(auth.ID)
+		}
+	})
+
+	handler := NewOpenAIAPIHandler(apihandlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager))
+	resp := performVideosEndpointRequest(t, http.MethodPost, xaiVideosGenerationsAPI, "application/json", strings.NewReader(`{"model":"`+alias+`","prompt":"make a video"}`), handler.XAIVideosGenerations)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if got := executor.AuthIDs(); len(got) != 1 || got[0] != videoAuthID {
+		t.Fatalf("selected auths = %v, want [%s]", got, videoAuthID)
+	}
+	if got := executor.Models(); len(got) != 1 || got[0] != defaultXAIVideosModel {
+		t.Fatalf("execution models = %v, want [%s]", got, defaultXAIVideosModel)
 	}
 }
 
@@ -546,7 +620,8 @@ func TestVideosContentUsesSelectedAuthProxyForDownload(t *testing.T) {
 	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
 		t.Fatalf("manager.Register() error = %v", errRegister)
 	}
-	registry.GetGlobalRegistry().RegisterClient(authID, auth.Provider, []*registry.ModelInfo{{ID: defaultXAIVideosModel}})
+	registry.GetGlobalRegistry().RegisterClient(authID, auth.Provider, []*registry.ModelInfo{testXAIVideoModelInfo(defaultXAIVideosModel)})
+	manager.RefreshSchedulerEntry(authID)
 	t.Cleanup(func() {
 		registry.GetGlobalRegistry().UnregisterClient(authID)
 	})
@@ -756,7 +831,7 @@ func TestXAIVideosNativeRetrieveUsesBoundModel(t *testing.T) {
 		if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
 			t.Fatalf("manager.Register(%s): %v", entry.authID, errRegister)
 		}
-		registry.GetGlobalRegistry().RegisterClient(entry.authID, auth.Provider, []*registry.ModelInfo{{ID: entry.model}})
+		registry.GetGlobalRegistry().RegisterClient(entry.authID, auth.Provider, []*registry.ModelInfo{testXAIVideoModelInfo(entry.model)})
 		manager.RefreshSchedulerEntry(entry.authID)
 	}
 	t.Cleanup(func() {

--- a/sdk/cliproxy/auth/api_key_model_capabilities.go
+++ b/sdk/cliproxy/auth/api_key_model_capabilities.go
@@ -1,0 +1,250 @@
+package auth
+
+import (
+	"strings"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/modelconfig"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+)
+
+type apiKeyModelExecutionKind = registry.ModelExecutionKind
+
+const (
+	apiKeyModelExecutionAny   = registry.ModelExecutionAny
+	apiKeyModelExecutionChat  = registry.ModelExecutionChat
+	apiKeyModelExecutionImage = registry.ModelExecutionImage
+	apiKeyModelExecutionVideo = registry.ModelExecutionVideo
+)
+
+type apiKeyModelCapabilityRoute struct {
+	upstreamModel string
+	modelInfo     *registry.ModelInfo
+	executionKind apiKeyModelExecutionKind
+	configAlias   string
+	forceMapping  bool
+}
+
+type apiKeyModelCapabilityTable map[string]map[string][]apiKeyModelCapabilityRoute
+
+type apiKeyModelRoutingSnapshot struct {
+	config       *internalconfig.Config
+	aliases      apiKeyModelAliasTable
+	capabilities apiKeyModelCapabilityTable
+}
+
+func (m *Manager) loadAPIKeyModelRouting() *apiKeyModelRoutingSnapshot {
+	if m == nil {
+		return &apiKeyModelRoutingSnapshot{config: &internalconfig.Config{}}
+	}
+	snapshot, _ := m.apiKeyModelRouting.Load().(*apiKeyModelRoutingSnapshot)
+	if snapshot == nil {
+		return &apiKeyModelRoutingSnapshot{config: &internalconfig.Config{}}
+	}
+	return snapshot
+}
+
+func compileAPIKeyModelCapabilities[T interface {
+	GetName() string
+	GetAlias() string
+	GetThinking() *registry.ThinkingSupport
+}](out map[string][]apiKeyModelCapabilityRoute, models []T, modelType string) {
+	for i := range models {
+		name := strings.TrimSpace(models[i].GetName())
+		alias := strings.TrimSpace(models[i].GetAlias())
+		if name == "" {
+			name = alias
+		}
+		if name == "" {
+			continue
+		}
+		if alias == "" {
+			alias = name
+		}
+		modelInfo := modelconfig.ResolveModelInfo(name, modelType, models[i].GetThinking())
+		if modelInfo.Thinking == nil && !modelInfo.SupportsImageAPI && !modelInfo.SupportsVideoAPI {
+			continue
+		}
+		addAPIKeyModelCapabilityRoute(out, alias, name, modelInfo, apiKeyModelExecutionKindForModelInfo(modelInfo), false)
+	}
+}
+
+func compileOpenAICompatModelCapabilities(out map[string][]apiKeyModelCapabilityRoute, models []internalconfig.OpenAICompatibilityModel) {
+	for i := range models {
+		model := models[i]
+		name := strings.TrimSpace(model.Name)
+		alias := strings.TrimSpace(model.Alias)
+		if name == "" {
+			name = alias
+		}
+		if name == "" {
+			continue
+		}
+		if alias == "" {
+			alias = name
+		}
+
+		executionKind := apiKeyModelExecutionChat
+		if model.Image {
+			executionKind = apiKeyModelExecutionImage
+		}
+
+		modelInfo := modelconfig.ResolveModelInfoForProvider(name, "openai", "openai-compatibility", model.Thinking)
+		modelInfo.SupportsImageAPI = model.Image
+		modelInfo.ChatDisabled = model.Image
+		if !model.Image && modelInfo.Thinking == nil {
+			modelInfo.Thinking = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+		}
+		modelInfo.SupportedInputModalities = modelconfig.NormalizeModalities(model.InputModalities)
+		modelInfo.SupportedOutputModalities = modelconfig.NormalizeModalities(model.OutputModalities)
+		addAPIKeyModelCapabilityRoute(out, alias, name, modelInfo, executionKind, model.ForceMapping)
+	}
+}
+
+func addAPIKeyModelCapabilityRoute(out map[string][]apiKeyModelCapabilityRoute, alias, name string, modelInfo *registry.ModelInfo, executionKind apiKeyModelExecutionKind, forceMapping bool) {
+	if out == nil || strings.TrimSpace(name) == "" || modelInfo == nil {
+		return
+	}
+	route := apiKeyModelCapabilityRoute{
+		upstreamModel: strings.TrimSpace(name),
+		modelInfo:     modelInfo,
+		executionKind: executionKind,
+		configAlias:   strings.TrimSpace(alias),
+		forceMapping:  forceMapping,
+	}
+	seenKeys := make(map[string]struct{})
+	for _, routeModel := range []string{alias, name} {
+		_, candidates := modelAliasLookupCandidates(routeModel)
+		for _, candidate := range candidates {
+			key := strings.ToLower(strings.TrimSpace(candidate))
+			if key == "" {
+				continue
+			}
+			if _, exists := seenKeys[key]; exists {
+				continue
+			}
+			seenKeys[key] = struct{}{}
+			duplicate := false
+			for _, existing := range out[key] {
+				if strings.EqualFold(existing.upstreamModel, route.upstreamModel) && existing.executionKind == route.executionKind {
+					duplicate = true
+					break
+				}
+			}
+			if !duplicate {
+				out[key] = append(out[key], route)
+			}
+		}
+	}
+}
+
+func lookupAPIKeyModelCapability(snapshot *apiKeyModelRoutingSnapshot, auth *Auth, routeModel, upstreamModel string, executionKind apiKeyModelExecutionKind) (apiKeyModelCapabilityRoute, bool, bool) {
+	if snapshot == nil || !IsConfigAPIKeyAuth(auth) {
+		return apiKeyModelCapabilityRoute{}, false, false
+	}
+	byRoute := snapshot.capabilities[strings.TrimSpace(auth.ID)]
+	if len(byRoute) == 0 {
+		return apiKeyModelCapabilityRoute{}, false, false
+	}
+
+	requestedModel := rewriteModelForAuth(routeModel, auth)
+	_, candidates := modelAliasLookupCandidates(requestedModel)
+	configured := false
+	for _, candidate := range candidates {
+		routes := byRoute[strings.ToLower(strings.TrimSpace(candidate))]
+		if route, matched, compatible := matchAPIKeyModelCapabilityRoute(routes, upstreamModel, executionKind); compatible {
+			return route, true, true
+		} else if matched {
+			configured = true
+		}
+	}
+	return apiKeyModelCapabilityRoute{}, configured, false
+}
+
+func matchAPIKeyModelCapabilityRoute(routes []apiKeyModelCapabilityRoute, upstreamModel string, executionKind apiKeyModelExecutionKind) (apiKeyModelCapabilityRoute, bool, bool) {
+	upstreamModel = strings.TrimSpace(upstreamModel)
+	route, exactMatched, exactCompatible := selectAPIKeyModelCapabilityRoute(routes, executionKind, func(route apiKeyModelCapabilityRoute) bool {
+		return strings.EqualFold(route.upstreamModel, upstreamModel)
+	})
+	if exactCompatible {
+		return route, true, true
+	}
+	upstreamBase := strings.TrimSpace(thinking.ParseSuffix(upstreamModel).ModelName)
+	route, fallbackMatched, fallbackCompatible := selectAPIKeyModelCapabilityRoute(routes, executionKind, func(route apiKeyModelCapabilityRoute) bool {
+		routeResult := thinking.ParseSuffix(route.upstreamModel)
+		return !routeResult.HasSuffix && strings.EqualFold(strings.TrimSpace(routeResult.ModelName), upstreamBase)
+	})
+	return route, exactMatched || fallbackMatched, fallbackCompatible
+}
+
+func selectAPIKeyModelCapabilityRoute(routes []apiKeyModelCapabilityRoute, executionKind apiKeyModelExecutionKind, matches func(apiKeyModelCapabilityRoute) bool) (apiKeyModelCapabilityRoute, bool, bool) {
+	matched := false
+	for _, route := range routes {
+		if !matches(route) {
+			continue
+		}
+		matched = true
+		if executionKind == apiKeyModelExecutionAny || route.executionKind == apiKeyModelExecutionAny || route.executionKind == executionKind {
+			return route, true, true
+		}
+	}
+	return apiKeyModelCapabilityRoute{}, matched, false
+}
+
+func apiKeyModelExecutionKindForModelInfo(info *registry.ModelInfo) apiKeyModelExecutionKind {
+	if info == nil || !info.ChatDisabled {
+		return apiKeyModelExecutionAny
+	}
+	if info.SupportsImageAPI || info.Type == registry.OpenAIImageModelType {
+		return apiKeyModelExecutionImage
+	}
+	if info.SupportsVideoAPI {
+		return apiKeyModelExecutionVideo
+	}
+	return apiKeyModelExecutionAny
+}
+
+func filterAPIKeyModelCandidates(snapshot *apiKeyModelRoutingSnapshot, auth *Auth, routeModel string, candidates []string, executionKind apiKeyModelExecutionKind) []string {
+	if len(candidates) == 0 || !isOpenAICompatAPIKeyAuth(auth) {
+		return candidates
+	}
+	out := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		_, configured, compatible := lookupAPIKeyModelCapability(snapshot, auth, routeModel, candidate, executionKind)
+		if !configured || compatible {
+			out = append(out, candidate)
+		}
+	}
+	return out
+}
+
+func aliasResultForAPIKeyModelCandidate(snapshot *apiKeyModelRoutingSnapshot, auth *Auth, routeModel, upstreamModel string, executionKind apiKeyModelExecutionKind, fallback OAuthModelAliasResult) OAuthModelAliasResult {
+	if !isOpenAICompatAPIKeyAuth(auth) {
+		return fallback
+	}
+	route, configured, compatible := lookupAPIKeyModelCapability(snapshot, auth, routeModel, upstreamModel, executionKind)
+	if !configured || !compatible {
+		return fallback
+	}
+	requestedModel := rewriteModelForAuth(routeModel, auth)
+	_, requestedCandidates := modelAliasLookupCandidates(requestedModel)
+	matchedAlias := false
+	for _, candidate := range requestedCandidates {
+		if strings.EqualFold(strings.TrimSpace(candidate), route.configAlias) {
+			matchedAlias = true
+			break
+		}
+	}
+	if !matchedAlias {
+		return fallback
+	}
+	result := fallback
+	result.UpstreamModel = upstreamModel
+	result.ForceMapping = route.forceMapping
+	result.OriginalAlias = ""
+	if route.forceMapping {
+		result.OriginalAlias = oauthModelAliasForceMappingResponseModel(route.configAlias)
+	}
+	return result
+}

--- a/sdk/cliproxy/auth/api_key_model_capability_binding_test.go
+++ b/sdk/cliproxy/auth/api_key_model_capability_binding_test.go
@@ -1,0 +1,516 @@
+package auth
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/modelconfig"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestAttachResolvedAPIKeyModelInfoPrefersExactConfiguredSuffix(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "configured-suffix-auth",
+		Provider: "claude",
+		Prefix:   "tenant",
+		Attributes: map[string]string{
+			AttributeAuthKind: AuthKindAPIKey,
+			AttributeAPIKey:   "test-key",
+			AttributeSource:   "config:claude[0]",
+		},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	m.SetConfig(&internalconfig.Config{ClaudeKey: []internalconfig.ClaudeKey{{
+		APIKey: "test-key",
+		Prefix: "tenant",
+		Models: []internalconfig.ClaudeModel{
+			{Name: "model", Alias: "public", Thinking: thinkingLevels("high")},
+			{Name: "model(low)", Alias: "public-low", Thinking: thinkingLevels("low")},
+		},
+	}}})
+
+	req := m.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, auth, "tenant/public-low", "model(low)")
+	info, ok := ResolvedAPIKeyModelInfo(req)
+	if !ok || info.Thinking == nil || len(info.Thinking.Levels) != 1 || info.Thinking.Levels[0] != "low" {
+		t.Fatalf("resolved model info = %+v, want exact suffixed definition", info)
+	}
+}
+
+func thinkingLevels(levels ...string) *registry.ThinkingSupport {
+	return &registry.ThinkingSupport{Levels: levels}
+}
+
+func TestCompileAPIKeyModelCapabilitiesUsesAliasAsUpstreamFallback(t *testing.T) {
+	routes := make(map[string][]apiKeyModelCapabilityRoute)
+	compileAPIKeyModelCapabilities(routes, []internalconfig.ClaudeModel{{
+		Alias:    "public",
+		Thinking: thinkingLevels("high"),
+	}}, "claude")
+
+	got := routes["public"]
+	if len(got) != 1 || got[0].upstreamModel != "public" || got[0].modelInfo == nil || got[0].modelInfo.ID != "public" {
+		t.Fatalf("alias-only capability routes = %+v, want public upstream capability", got)
+	}
+}
+
+func TestCompileOpenAICompatModelCapabilitiesUsesAliasAsUpstreamFallback(t *testing.T) {
+	routes := make(map[string][]apiKeyModelCapabilityRoute)
+	compileOpenAICompatModelCapabilities(routes, []internalconfig.OpenAICompatibilityModel{{
+		Alias:    "public",
+		Image:    true,
+		Thinking: thinkingLevels("high"),
+	}})
+
+	got := routes["public"]
+	if len(got) != 1 || got[0].upstreamModel != "public" || got[0].executionKind != apiKeyModelExecutionImage || got[0].modelInfo == nil || got[0].modelInfo.ID != "public" || got[0].modelInfo.Thinking == nil || !got[0].modelInfo.SupportsImageAPI {
+		t.Fatalf("alias-only OpenAI-compatible routes = %+v, want public image/thinking capability", got)
+	}
+}
+
+func TestCompileOpenAICompatModelCapabilitiesUsesExplicitImageFlag(t *testing.T) {
+	routes := make(map[string][]apiKeyModelCapabilityRoute)
+	compileOpenAICompatModelCapabilities(routes, []internalconfig.OpenAICompatibilityModel{{
+		Name: "gpt-image-2", Alias: "chat-alias", Thinking: thinkingLevels("high"),
+	}})
+
+	got := routes["chat-alias"]
+	if len(got) != 1 || got[0].modelInfo == nil {
+		t.Fatalf("compiled routes = %+v, want one chat capability", got)
+	}
+	if got[0].executionKind != apiKeyModelExecutionChat || got[0].modelInfo.SupportsImageAPI {
+		t.Fatalf("chat capability = %+v, want explicit non-image route", got[0])
+	}
+}
+
+func TestCompiledNonImageProviderCapabilitiesDoNotInheritStaticImageAPI(t *testing.T) {
+	tests := []struct {
+		name      string
+		modelType string
+		compile   func(map[string][]apiKeyModelCapabilityRoute)
+	}{
+		{
+			name: "claude", modelType: "claude",
+			compile: func(routes map[string][]apiKeyModelCapabilityRoute) {
+				compileAPIKeyModelCapabilities(routes, []internalconfig.ClaudeModel{{
+					Name: "gpt-image-2", Alias: "public", Thinking: thinkingLevels("high"),
+				}}, "claude")
+			},
+		},
+		{
+			name: "gemini", modelType: "gemini",
+			compile: func(routes map[string][]apiKeyModelCapabilityRoute) {
+				compileAPIKeyModelCapabilities(routes, []internalconfig.GeminiModel{{
+					Name: "gpt-image-2", Alias: "public", Thinking: thinkingLevels("high"),
+				}}, "gemini")
+			},
+		},
+		{
+			name: "vertex", modelType: "gemini",
+			compile: func(routes map[string][]apiKeyModelCapabilityRoute) {
+				compileAPIKeyModelCapabilities(routes, []internalconfig.VertexCompatModel{{
+					Name: "gpt-image-2", Alias: "public", Thinking: thinkingLevels("high"),
+				}}, "gemini")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			routes := make(map[string][]apiKeyModelCapabilityRoute)
+			tc.compile(routes)
+			got := routes["public"]
+			if len(got) != 1 || got[0].modelInfo == nil {
+				t.Fatalf("compiled routes = %+v, want one capability", got)
+			}
+			if got[0].modelInfo.Type != tc.modelType {
+				t.Fatalf("model type = %q, want %q", got[0].modelInfo.Type, tc.modelType)
+			}
+			if got[0].modelInfo.SupportsImageAPI {
+				t.Fatalf("%s capability inherited provider-specific image API support", tc.name)
+			}
+		})
+	}
+}
+
+func TestStaticImageCapabilityIsProviderScopedDuringPerAuthSelection(t *testing.T) {
+	tests := []struct {
+		name      string
+		provider  string
+		model     string
+		modelType string
+		wantImage bool
+		wantChat  bool
+	}{
+		{name: "claude", provider: "claude", model: "gpt-image-2", modelType: "claude", wantChat: true},
+		{name: "gemini", provider: "gemini", model: "gpt-image-2", modelType: "gemini", wantChat: true},
+		{name: "vertex", provider: "vertex", model: "gpt-image-2", modelType: "vertex", wantChat: true},
+		{name: "xai", provider: "xai", model: "grok-imagine-image", modelType: "xai", wantImage: true},
+		{name: "codex", provider: "codex", model: "gpt-image-2", modelType: "codex", wantImage: true},
+		{name: "xai foreign image", provider: "xai", model: "gpt-image-2", modelType: "xai", wantChat: true},
+		{name: "codex foreign image", provider: "codex", model: "grok-imagine-image", modelType: "codex", wantChat: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			const alias = "provider-scoped-image-alias"
+			auth := &Auth{ID: "provider-scoped-image-" + tc.name, Provider: tc.provider}
+			info := modelconfig.ResolveModelInfo(tc.model, tc.modelType, nil)
+			info.ID = alias
+
+			registryRef := registry.GetGlobalRegistry()
+			registryRef.UnregisterClient(auth.ID)
+			registryRef.RegisterClient(auth.ID, tc.provider, []*registry.ModelInfo{info})
+			t.Cleanup(func() {
+				registryRef.UnregisterClient(auth.ID)
+			})
+
+			manager := NewManager(nil, nil, nil)
+			imageOpts := cliproxyexecutor.Options{Metadata: map[string]any{cliproxyexecutor.ImageExecutionMetadataKey: true}}
+			if got := manager.authSupportsExecutionModel(registryRef, auth, alias, imageOpts); got != tc.wantImage {
+				t.Fatalf("image selection eligibility = %t, want %t", got, tc.wantImage)
+			}
+			if got := manager.authSupportsExecutionModel(registryRef, auth, alias, cliproxyexecutor.Options{}); got != tc.wantChat {
+				t.Fatalf("chat selection eligibility = %t, want %t", got, tc.wantChat)
+			}
+		})
+	}
+}
+
+func TestOpenAICompatChatAliasSuffixFallsBackToUnsuffixedCapability(t *testing.T) {
+	const (
+		alias    = "shared"
+		upstream = "upstream"
+	)
+	routes := make(map[string][]apiKeyModelCapabilityRoute)
+	compileOpenAICompatModelCapabilities(routes, []internalconfig.OpenAICompatibilityModel{
+		{Name: upstream, Alias: alias},
+		{Name: upstream + "(high)", Alias: alias, Image: true},
+	})
+	auth := &Auth{
+		ID:       "suffix-fallback-auth",
+		Provider: "openai-compatibility:pool",
+		Attributes: map[string]string{
+			AttributeAPIKey: "key",
+			AttributeSource: "config:pool[test]",
+			"compat_name":   "pool",
+		},
+	}
+	snapshot := &apiKeyModelRoutingSnapshot{
+		capabilities: apiKeyModelCapabilityTable{auth.ID: routes},
+	}
+
+	route, configured, compatible := lookupAPIKeyModelCapability(
+		snapshot,
+		auth,
+		alias+"(high)",
+		upstream+"(high)",
+		apiKeyModelExecutionChat,
+	)
+	if !configured || !compatible || route.upstreamModel != upstream || route.executionKind != apiKeyModelExecutionChat {
+		t.Fatalf("chat capability = (%+v, %t, %t), want unsuffixed chat fallback", route, configured, compatible)
+	}
+	candidates := filterAPIKeyModelCandidates(snapshot, auth, alias+"(high)", []string{upstream + "(high)"}, apiKeyModelExecutionChat)
+	if len(candidates) != 1 || candidates[0] != upstream+"(high)" {
+		t.Fatalf("chat candidates = %v, want suffixed request routed through unsuffixed chat capability", candidates)
+	}
+
+	_, configured, compatible = matchAPIKeyModelCapabilityRoute([]apiKeyModelCapabilityRoute{{
+		upstreamModel: upstream + "(high)",
+		executionKind: apiKeyModelExecutionImage,
+	}}, upstream+"(high)", apiKeyModelExecutionChat)
+	if !configured || compatible {
+		t.Fatalf("incompatible exact route = (configured %t, compatible %t), want configured but incompatible", configured, compatible)
+	}
+}
+
+func TestEndpointSpecificForceMappingPreservesDirectUpstreamRequest(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "force-mapping-direct-auth",
+		Provider: "openai-compatibility:compat",
+		Prefix:   "tenant",
+		Attributes: map[string]string{
+			AttributeAPIKey: "key", AttributeSource: "config:compat[test]",
+			"compat_name": "compat", "provider_key": "openai-compatibility:compat",
+		},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	m.SetConfig(&internalconfig.Config{OpenAICompatibility: []internalconfig.OpenAICompatibility{{
+		Name: "compat", Prefix: "tenant",
+		Models: []internalconfig.OpenAICompatibilityModel{{Name: "upstream", Alias: "public", ForceMapping: true}},
+	}}})
+
+	directFallback := m.resolveExecutionAliasResult(auth, "tenant/upstream")
+	direct := aliasResultForAPIKeyModelCandidate(m.loadAPIKeyModelRouting(), auth, "tenant/upstream", "upstream", apiKeyModelExecutionChat, directFallback)
+	if direct.ForceMapping || direct.OriginalAlias != "" {
+		t.Fatalf("direct upstream result = %+v, want passthrough", direct)
+	}
+
+	aliasFallback := m.resolveExecutionAliasResult(auth, "tenant/public")
+	alias := aliasResultForAPIKeyModelCandidate(m.loadAPIKeyModelRouting(), auth, "tenant/public", "upstream", apiKeyModelExecutionChat, aliasFallback)
+	if !alias.ForceMapping || alias.OriginalAlias != "public" {
+		t.Fatalf("alias result = %+v, want force-mapped public alias", alias)
+	}
+}
+
+func TestOpenAICompatConfiguredModelFallsBackToStaticThinking(t *testing.T) {
+	const upstream = "gpt-5.6-luna"
+	static := registry.LookupStaticModelInfo(upstream)
+	if static == nil || static.Thinking == nil {
+		t.Fatalf("static model %s has no thinking metadata", upstream)
+	}
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "static-thinking-auth",
+		Provider: "openai-compatibility:compat",
+		Attributes: map[string]string{
+			AttributeAPIKey: "key", AttributeSource: "config:compat[test]",
+			"compat_name": "compat", "provider_key": "openai-compatibility:compat",
+		},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	m.SetConfig(&internalconfig.Config{OpenAICompatibility: []internalconfig.OpenAICompatibility{{
+		Name: "compat", Models: []internalconfig.OpenAICompatibilityModel{{Name: upstream, Alias: "public"}},
+	}}})
+	req := m.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, auth, "public", upstream)
+	info, ok := ResolvedAPIKeyModelInfo(req)
+	if !ok || info.Thinking == nil {
+		t.Fatalf("resolved model info = %+v, want static thinking metadata", info)
+	}
+	if got, want := strings.Join(info.Thinking.Levels, ","), strings.Join(static.Thinking.Levels, ","); got != want {
+		t.Fatalf("thinking levels = %q, want static levels %q", got, want)
+	}
+}
+
+func TestConfiguredThinkingBindsAcrossAPIKeyProviders(t *testing.T) {
+	support := thinkingLevels(" XHIGH ", "high", "none", "auto", "high")
+	tests := []struct {
+		name     string
+		provider string
+		attrs    map[string]string
+		config   *internalconfig.Config
+		wantType string
+	}{
+		{
+			name: "gemini", provider: "gemini", wantType: "gemini",
+			config: &internalconfig.Config{GeminiKey: []internalconfig.GeminiKey{{APIKey: "key", Models: []internalconfig.GeminiModel{{Name: "upstream", Alias: "public", Thinking: support}}}}},
+		},
+		{
+			name: "interactions", provider: "gemini-interactions", wantType: "interactions",
+			config: &internalconfig.Config{InteractionsKey: []internalconfig.GeminiKey{{APIKey: "key", Models: []internalconfig.GeminiModel{{Name: "upstream", Alias: "public", Thinking: support}}}}},
+		},
+		{
+			name: "claude", provider: "claude", wantType: "claude",
+			config: &internalconfig.Config{ClaudeKey: []internalconfig.ClaudeKey{{APIKey: "key", Models: []internalconfig.ClaudeModel{{Name: "upstream", Alias: "public", Thinking: support}}}}},
+		},
+		{
+			name: "codex", provider: "codex", wantType: "codex",
+			config: &internalconfig.Config{CodexKey: []internalconfig.CodexKey{{APIKey: "key", Models: []internalconfig.CodexModel{{Name: "upstream", Alias: "public", Thinking: support}}}}},
+		},
+		{
+			name: "xai", provider: "xai", wantType: "xai",
+			config: &internalconfig.Config{XAIKey: []internalconfig.XAIKey{{APIKey: "key", Models: []internalconfig.XAIModel{{Name: "upstream", Alias: "public", Thinking: support}}}}},
+		},
+		{
+			name: "vertex", provider: "vertex", wantType: "gemini",
+			config: &internalconfig.Config{VertexCompatAPIKey: []internalconfig.VertexCompatKey{{APIKey: "key", Models: []internalconfig.VertexCompatModel{{Name: "upstream", Alias: "public", Thinking: support}}}}},
+		},
+		{
+			name: "openai compatibility", provider: "openai-compatibility:compat", wantType: "openai",
+			attrs:  map[string]string{"compat_name": "compat", "provider_key": "openai-compatibility:compat"},
+			config: &internalconfig.Config{OpenAICompatibility: []internalconfig.OpenAICompatibility{{Name: "compat", Models: []internalconfig.OpenAICompatibilityModel{{Name: "upstream", Alias: "public", Thinking: support}}}}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewManager(nil, nil, nil)
+			attrs := map[string]string{
+				AttributeAPIKey: "key",
+				AttributeSource: "config:" + tc.name + "[test]",
+			}
+			for key, value := range tc.attrs {
+				attrs[key] = value
+			}
+			auth := &Auth{ID: "auth-" + tc.name, Provider: tc.provider, Prefix: "tenant", Attributes: attrs}
+			if _, err := m.Register(context.Background(), auth); err != nil {
+				t.Fatalf("Register() error = %v", err)
+			}
+			m.SetConfig(tc.config)
+
+			req := m.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, auth, "tenant/public", "upstream")
+			info, ok := ResolvedAPIKeyModelInfo(req)
+			if !ok || info.Thinking == nil {
+				t.Fatalf("resolved model info = %+v, want configured thinking", info)
+			}
+			if info.Type != tc.wantType {
+				t.Fatalf("model type = %q, want %q", info.Type, tc.wantType)
+			}
+			wantLevels := []string{"xhigh", "high", "none", "auto"}
+			if len(info.Thinking.Levels) != len(wantLevels) {
+				t.Fatalf("thinking levels = %v, want %v", info.Thinking.Levels, wantLevels)
+			}
+			for i := range wantLevels {
+				if info.Thinking.Levels[i] != wantLevels[i] {
+					t.Fatalf("thinking levels = %v, want %v", info.Thinking.Levels, wantLevels)
+				}
+			}
+			if !info.Thinking.ZeroAllowed || !info.Thinking.DynamicAllowed {
+				t.Fatalf("thinking flags = %+v, want none/auto support", info.Thinking)
+			}
+		})
+	}
+}
+
+func TestConfiguredThinkingPreservesStaticModelMetadata(t *testing.T) {
+	static := registry.LookupStaticModelInfo("claude-opus-4-6")
+	if static == nil || static.MaxCompletionTokens == 0 {
+		t.Fatal("static claude-opus-4-6 metadata is unavailable")
+	}
+	info := modelconfig.ResolveModelInfo("claude-opus-4-6", "claude", thinkingLevels("high"))
+	if info.MaxCompletionTokens != static.MaxCompletionTokens || info.ContextLength != static.ContextLength {
+		t.Fatalf("configured metadata = %+v, want static limits preserved", info)
+	}
+}
+
+func TestConfiguredThinkingIsAuthScopedAndReloaded(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	authHigh := &Auth{ID: "auth-high", Provider: "claude", Attributes: map[string]string{AttributeAPIKey: "high-key", AttributeSource: "config:claude[high]"}}
+	authLow := &Auth{ID: "auth-low", Provider: "claude", Attributes: map[string]string{AttributeAPIKey: "low-key", AttributeSource: "config:claude[low]"}}
+	for _, auth := range []*Auth{authHigh, authLow} {
+		if _, err := m.Register(context.Background(), auth); err != nil {
+			t.Fatalf("Register(%s) error = %v", auth.ID, err)
+		}
+	}
+	setConfig := func(highLevel string) {
+		m.SetConfig(&internalconfig.Config{ClaudeKey: []internalconfig.ClaudeKey{
+			{APIKey: "high-key", Models: []internalconfig.ClaudeModel{{Name: "upstream", Alias: "public", Thinking: thinkingLevels(highLevel)}}},
+			{APIKey: "low-key", Models: []internalconfig.ClaudeModel{{Name: "upstream", Alias: "public", Thinking: thinkingLevels("low")}}},
+		}})
+	}
+	assertLevel := func(auth *Auth, want string) {
+		t.Helper()
+		req := m.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, auth, "public", "upstream")
+		info, ok := ResolvedAPIKeyModelInfo(req)
+		if !ok || info.Thinking == nil || len(info.Thinking.Levels) != 1 || info.Thinking.Levels[0] != want {
+			t.Fatalf("auth %s thinking = %+v, want %s", auth.ID, info, want)
+		}
+	}
+
+	setConfig("high")
+	assertLevel(authHigh, "high")
+	assertLevel(authLow, "low")
+	previousRouting := m.loadAPIKeyModelRouting()
+	setConfig("xhigh")
+	assertLevel(authHigh, "xhigh")
+	assertLevel(authLow, "low")
+	previousReq := attachResolvedAPIKeyModelInfo(previousRouting, cliproxyexecutor.Request{}, authHigh, "public", "upstream", apiKeyModelExecutionChat)
+	previousInfo, ok := ResolvedAPIKeyModelInfo(previousReq)
+	if !ok || previousInfo.Thinking == nil || len(previousInfo.Thinking.Levels) != 1 || previousInfo.Thinking.Levels[0] != "high" {
+		t.Fatalf("previous routing snapshot changed after reload: %+v", previousInfo)
+	}
+}
+
+func TestSetConfigSnapshotsCallerOwnedConfig(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth", Provider: "claude", Attributes: map[string]string{AttributeAPIKey: "key", AttributeSource: "config:claude[0]"}}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	cfg := &internalconfig.Config{ClaudeKey: []internalconfig.ClaudeKey{{
+		APIKey: "key",
+		Models: []internalconfig.ClaudeModel{{Name: "upstream", Alias: "public", Thinking: thinkingLevels("high")}},
+	}}}
+	m.SetConfig(cfg)
+
+	cfg.ClaudeKey[0].Models[0].Thinking.Levels[0] = "low"
+	req := m.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, auth, "public", "upstream")
+	info, ok := ResolvedAPIKeyModelInfo(req)
+	if !ok || info.Thinking == nil || len(info.Thinking.Levels) != 1 || info.Thinking.Levels[0] != "high" {
+		t.Fatalf("configured thinking changed after caller mutation: %+v", info)
+	}
+}
+
+func TestConfiguredThinkingDoesNotBindOAuthAuth(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "oauth", Provider: "claude", Attributes: map[string]string{AttributeAuthKind: AuthKindOAuth, AttributeSource: "config:claude[oauth]"}}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	m.SetConfig(&internalconfig.Config{ClaudeKey: []internalconfig.ClaudeKey{{APIKey: "key", Models: []internalconfig.ClaudeModel{{Name: "upstream", Alias: "public", Thinking: thinkingLevels("high")}}}}})
+	req := m.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, auth, "public", "upstream")
+	if _, ok := ResolvedAPIKeyModelInfo(req); ok {
+		t.Fatal("OAuth auth unexpectedly received configured API-key capabilities")
+	}
+}
+
+func TestOpenAICompatAliasPoolBindsSelectedCandidateCapabilities(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID: "compat-pool", Provider: "openai-compatibility:pool", Prefix: "tenant",
+		Attributes: map[string]string{
+			AttributeAPIKey: "key", AttributeSource: "config:pool[test]",
+			"compat_name": "pool", "provider_key": "openai-compatibility:pool",
+		},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	m.SetConfig(&internalconfig.Config{OpenAICompatibility: []internalconfig.OpenAICompatibility{{
+		Name: "pool", Prefix: "tenant",
+		Models: []internalconfig.OpenAICompatibilityModel{
+			{Name: "upstream-a", Alias: "shared", Thinking: thinkingLevels("high")},
+			{Name: "upstream-b", Alias: "shared", Thinking: thinkingLevels("low")},
+		},
+	}}})
+
+	for upstream, want := range map[string]string{"upstream-a": "high", "upstream-b": "low"} {
+		req := m.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, auth, "tenant/shared", upstream)
+		info, ok := ResolvedAPIKeyModelInfo(req)
+		if !ok || info.Thinking == nil || len(info.Thinking.Levels) != 1 || info.Thinking.Levels[0] != want {
+			t.Fatalf("upstream %s thinking = %+v, want %s", upstream, info, want)
+		}
+	}
+}
+
+func TestKeylessOpenAICompatConfigAuthResolvesPrefixedAlias(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		SDKConfig: internalconfig.SDKConfig{ForceModelPrefix: true},
+		OpenAICompatibility: []internalconfig.OpenAICompatibility{{
+			Name: "keyless", Prefix: "tenant",
+			Models: []internalconfig.OpenAICompatibilityModel{{Name: "upstream", Alias: "public"}},
+		}},
+	})
+	auth := &Auth{
+		ID:       "keyless-openai-compat",
+		Provider: "openai-compatibility:keyless",
+		Prefix:   "tenant",
+		Attributes: map[string]string{
+			"compat_name":   "keyless",
+			"provider_key":  "keyless",
+			AttributeSource: "config:keyless[0]",
+		},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	if got := m.applyAPIKeyModelAlias(auth, "public"); got != "upstream" {
+		t.Fatalf("resolved upstream model = %q, want upstream", got)
+	}
+	req := m.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, auth, "tenant/public", "upstream")
+	info, ok := ResolvedAPIKeyModelInfo(req)
+	if !ok || info.Thinking == nil || len(info.Thinking.Levels) != 3 {
+		t.Fatalf("keyless configured capability = %+v, want openai-compatibility defaults", info)
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -135,9 +135,9 @@ type Manager struct {
 	// oauthModelAlias stores global OAuth model alias mappings (alias -> upstream name) keyed by channel.
 	oauthModelAlias atomic.Value
 
-	// apiKeyModelAlias caches resolved model alias mappings for API-key auths.
-	// Keyed by auth.ID, value is alias(lower) -> upstream model (including suffix).
-	apiKeyModelAlias atomic.Value
+	// apiKeyModelRouting atomically publishes API-key aliases and exact configured
+	// capabilities from the same config snapshot.
+	apiKeyModelRouting atomic.Value
 
 	// modelPoolOffsets tracks per-auth alias pool rotation state.
 	modelPoolOffsets map[string]int
@@ -181,7 +181,7 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 	}
 	// atomic.Value requires non-nil initial value.
 	manager.runtimeConfig.Store(&internalconfig.Config{})
-	manager.apiKeyModelAlias.Store(apiKeyModelAliasTable(nil))
+	manager.apiKeyModelRouting.Store(&apiKeyModelRoutingSnapshot{config: &internalconfig.Config{}})
 	defaultInFlightConfig, errInFlightConfig := HomeInFlightPublisherConfigFromConfig(internalconfig.DefaultCredentialInFlightConfig())
 	if errInFlightConfig == nil {
 		manager.ApplyHomeInFlightPublisherConfig(defaultInFlightConfig)

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -87,7 +87,7 @@ func nextTransientErrorRetryAfter(now time.Time) time.Time {
 }
 
 // SetConfig updates the runtime config snapshot used by request-time helpers.
-// Callers should provide the latest config on reload so per-credential alias mapping stays in sync.
+// Callers should provide the latest config on reload so per-credential model routing stays in sync.
 func (m *Manager) SetConfig(cfg *internalconfig.Config) {
 	if m == nil {
 		return
@@ -114,6 +114,7 @@ func (m *Manager) setConfigSnapshotLocked(cfg *internalconfig.Config) bool {
 	if cfg == nil {
 		cfg = &internalconfig.Config{}
 	}
+	cfg = cfg.CloneForRuntime()
 	m.mu.RLock()
 	oldCooldownStore := m.cooldownStore
 	m.mu.RUnlock()

--- a/sdk/cliproxy/auth/conductor_endpoint_capabilities_test.go
+++ b/sdk/cliproxy/auth/conductor_endpoint_capabilities_test.go
@@ -1,0 +1,129 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func TestManagerBuiltinSchedulerSharedAliasNeverSelectsImageOnlyAuthForChat(t *testing.T) {
+	const (
+		provider = "shared-endpoint-fast-path"
+		modelID  = "shared-endpoint-model"
+	)
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(schedulerProviderTestExecutor{provider: provider})
+	modelRegistry := registry.GetGlobalRegistry()
+
+	registrations := []struct {
+		id   string
+		info *registry.ModelInfo
+	}{
+		{
+			id: "shared-endpoint-chat-auth",
+			info: &registry.ModelInfo{
+				ID:   modelID,
+				Type: provider,
+			},
+		},
+		{
+			id: "shared-endpoint-image-auth",
+			info: &registry.ModelInfo{
+				ID:               modelID,
+				Type:             registry.OpenAIImageModelType,
+				SupportsImageAPI: true,
+				ChatDisabled:     true,
+			},
+		},
+	}
+	for _, registration := range registrations {
+		auth := &Auth{ID: registration.id, Provider: provider, Status: StatusActive}
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("Register(%s): %v", registration.id, err)
+		}
+		modelRegistry.RegisterClient(registration.id, provider, []*registry.ModelInfo{registration.info})
+		manager.RefreshSchedulerEntry(registration.id)
+	}
+	t.Cleanup(func() {
+		for _, registration := range registrations {
+			modelRegistry.UnregisterClient(registration.id)
+		}
+	})
+
+	for attempt := 0; attempt < 4; attempt++ {
+		selected, _, _, errPick := manager.pickNextMixed(context.Background(), []string{provider}, modelID, cliproxyexecutor.Options{}, nil)
+		if errPick != nil {
+			t.Fatalf("pickNextMixed() attempt %d: %v", attempt, errPick)
+		}
+		if selected == nil || selected.ID != "shared-endpoint-chat-auth" {
+			t.Fatalf("pickNextMixed() attempt %d selected %#v, want chat auth", attempt, selected)
+		}
+	}
+}
+
+func TestManagerSelectsVideoOnlyAuthForVideoExecution(t *testing.T) {
+	const (
+		provider = "shared-video-selection"
+		modelID  = "shared-video-selection-model"
+	)
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(schedulerProviderTestExecutor{provider: provider})
+	modelRegistry := registry.GetGlobalRegistry()
+
+	registrations := []struct {
+		id   string
+		info *registry.ModelInfo
+	}{
+		{
+			id:   "shared-video-chat-auth",
+			info: &registry.ModelInfo{ID: modelID, Type: provider},
+		},
+		{
+			id: "shared-video-endpoint-auth",
+			info: &registry.ModelInfo{
+				ID:               modelID,
+				Type:             provider,
+				SupportsVideoAPI: true,
+				ChatDisabled:     true,
+			},
+		},
+	}
+	for _, registration := range registrations {
+		auth := &Auth{ID: registration.id, Provider: provider, Status: StatusActive}
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("Register(%s): %v", registration.id, err)
+		}
+		modelRegistry.RegisterClient(registration.id, provider, []*registry.ModelInfo{registration.info})
+		manager.RefreshSchedulerEntry(registration.id)
+	}
+	t.Cleanup(func() {
+		for _, registration := range registrations {
+			modelRegistry.UnregisterClient(registration.id)
+		}
+	})
+
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-video"),
+		Metadata: map[string]any{
+			cliproxyexecutor.VideoExecutionMetadataKey: true,
+		},
+	}
+	selected, _, _, errPick := manager.pickNextMixed(context.Background(), []string{provider}, modelID, opts, nil)
+	if errPick != nil {
+		t.Fatalf("pickNextMixed(video): %v", errPick)
+	}
+	if selected == nil || selected.ID != "shared-video-endpoint-auth" {
+		t.Fatalf("pickNextMixed(video) selected %#v, want video auth", selected)
+	}
+
+	selected, _, _, errPick = manager.pickNextMixed(context.Background(), []string{provider}, modelID, cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("pickNextMixed(chat): %v", errPick)
+	}
+	if selected == nil || selected.ID != "shared-video-chat-auth" {
+		t.Fatalf("pickNextMixed(chat) selected %#v, want chat auth", selected)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	cliproxysession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
@@ -259,6 +260,67 @@ func mergeRequestHeaders(current, updates http.Header, clear []string) http.Head
 	return out
 }
 
+func imageExecutionFromOptions(opts cliproxyexecutor.Options) bool {
+	value, _ := opts.Metadata[cliproxyexecutor.ImageExecutionMetadataKey].(bool)
+	return value
+}
+
+func videoExecutionFromOptions(opts cliproxyexecutor.Options) bool {
+	value, _ := opts.Metadata[cliproxyexecutor.VideoExecutionMetadataKey].(bool)
+	return value || strings.EqualFold(strings.TrimSpace(opts.SourceFormat.String()), "openai-video")
+}
+
+func modelExecutionKindFromOptions(opts cliproxyexecutor.Options) apiKeyModelExecutionKind {
+	if imageExecutionFromOptions(opts) {
+		return apiKeyModelExecutionImage
+	}
+	if videoExecutionFromOptions(opts) {
+		return apiKeyModelExecutionVideo
+	}
+	return apiKeyModelExecutionChat
+}
+
+func modelExecutionKindName(kind apiKeyModelExecutionKind) string {
+	switch kind {
+	case apiKeyModelExecutionImage:
+		return "image"
+	case apiKeyModelExecutionVideo:
+		return "video"
+	default:
+		return "chat"
+	}
+}
+
+const resolvedAPIKeyModelInfoMetadataKey = "cliproxy.resolved_api_key_model_info"
+
+// ResolvedAPIKeyModelInfo returns the configured model definition selected for
+// this API-key execution attempt.
+func ResolvedAPIKeyModelInfo(req cliproxyexecutor.Request) (*registry.ModelInfo, bool) {
+	modelInfo, ok := req.Metadata[resolvedAPIKeyModelInfoMetadataKey].(*registry.ModelInfo)
+	if !ok || modelInfo == nil {
+		return nil, false
+	}
+	return modelInfo, true
+}
+
+func (m *Manager) attachResolvedAPIKeyModelInfo(req cliproxyexecutor.Request, auth *Auth, routeModel, upstreamModel string) cliproxyexecutor.Request {
+	return attachResolvedAPIKeyModelInfo(m.loadAPIKeyModelRouting(), req, auth, routeModel, upstreamModel, apiKeyModelExecutionChat)
+}
+
+func attachResolvedAPIKeyModelInfo(routing *apiKeyModelRoutingSnapshot, req cliproxyexecutor.Request, auth *Auth, routeModel, upstreamModel string, executionKind apiKeyModelExecutionKind) cliproxyexecutor.Request {
+	route, _, compatible := lookupAPIKeyModelCapability(routing, auth, routeModel, upstreamModel, executionKind)
+	if !compatible || route.modelInfo == nil {
+		return req
+	}
+	metadata := make(map[string]any, len(req.Metadata)+1)
+	for key, value := range req.Metadata {
+		metadata[key] = value
+	}
+	metadata[resolvedAPIKeyModelInfoMetadataKey] = route.modelInfo
+	req.Metadata = metadata
+	return req
+}
+
 func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int) (cliproxyexecutor.Response, error) {
 	if len(providers) == 0 {
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
@@ -302,8 +364,11 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		}
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 
-		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel, modelExecutionKindFromOptions(opts))
 		if len(models) == 0 {
+			if homeMode {
+				homeAuthCount++
+			}
 			continue
 		}
 		attempted[auth.ID] = struct{}{}
@@ -329,6 +394,9 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
 			if errIntercept != nil {
 				return cliproxyexecutor.Response{}, errIntercept
+			}
+			if !restoreExecutionModel {
+				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel, modelExecutionKindFromOptions(execOpts))
 			}
 			resp, errExec := executor.Execute(execCtx, auth, execReq, execOpts)
 			if errExec != nil {
@@ -360,7 +428,8 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				continue
 			}
 			m.MarkResult(execCtx, result)
-			rewriteForceMappedResponse(&resp, aliasResult)
+			responseAliasResult := aliasResultForAPIKeyModelCandidate(routing, auth, routeModel, upstreamModel, modelExecutionKindFromOptions(execOpts), aliasResult)
+			rewriteForceMappedResponse(&resp, responseAliasResult)
 			return resp, nil
 		}
 		if authErr != nil {
@@ -419,8 +488,11 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		}
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 
-		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel, modelExecutionKindFromOptions(opts))
 		if len(models) == 0 {
+			if homeMode {
+				homeAuthCount++
+			}
 			continue
 		}
 		attempted[auth.ID] = struct{}{}
@@ -446,6 +518,9 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
 			if errIntercept != nil {
 				return cliproxyexecutor.Response{}, errIntercept
+			}
+			if !restoreExecutionModel {
+				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel, modelExecutionKindFromOptions(execOpts))
 			}
 			resp, errExec := executor.CountTokens(execCtx, auth, execReq, execOpts)
 			if errExec != nil {
@@ -485,7 +560,8 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				continue
 			}
 			m.MarkResult(execCtx, result)
-			rewriteForceMappedResponse(&resp, aliasResult)
+			responseAliasResult := aliasResultForAPIKeyModelCandidate(routing, auth, routeModel, upstreamModel, modelExecutionKindFromOptions(execOpts), aliasResult)
+			rewriteForceMappedResponse(&resp, responseAliasResult)
 			return resp, nil
 		}
 		if authErr != nil {
@@ -553,6 +629,28 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			}
 			return nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 		}
+		if selection != nil {
+			upstreamModel := ""
+			if auth.Attributes != nil {
+				upstreamModel = auth.Attributes[homeUpstreamModelAttributeKey]
+			}
+			if homeAuthKnownIneligibleForExecution(auth, routeModel, upstreamModel, opts) {
+				if _, seen := tried[auth.ID]; seen {
+					selection.End("repeated_auth")
+					if lastErr != nil {
+						return nil, lastErr
+					}
+					return nil, repeatedHomeAuthError()
+				}
+				tried[auth.ID] = struct{}{}
+				if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "execution_ineligible"); errEnd != nil {
+					return nil, errEnd
+				}
+				lastErr = &Error{Code: "auth_not_found", Message: "selected auth does not support " + modelExecutionKindName(modelExecutionKindFromOptions(opts)) + " execution"}
+				homeAuthCount++
+				continue
+			}
+		}
 
 		entry := logEntryWithRequestID(ctx)
 		debugLogAuthSelection(entry, auth, provider, routeModel)
@@ -579,7 +677,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
-		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel, modelExecutionKindFromOptions(opts))
 		if selection != nil && aliasResult.ForceMapping && responseAlias != "" {
 			aliasResult.OriginalAlias = responseAlias
 		}
@@ -589,6 +687,8 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 				if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "no_execution_models"); errEnd != nil {
 					return nil, errEnd
 				}
+				lastErr = &Error{Code: "auth_not_found", Message: "no execution models available"}
+				homeAuthCount++
 			}
 			continue
 		}
@@ -628,7 +728,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			models = models[:1]
 			pooled = false
 		}
-		streamResult, errStream := m.executeStreamWithModelPool(execCtx, executor, auth, provider, execReq, execOpts, routeModel, streamExecutionModel, models, pooled, aliasResult, !homeMode, selection != nil)
+		streamResult, errStream := m.executeStreamWithModelPool(execCtx, executor, auth, provider, execReq, execOpts, routeModel, streamExecutionModel, models, pooled, aliasResult, routing, !homeMode, selection != nil)
 		if errStream != nil {
 			if selection != nil {
 				releaseAttempt()

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -13,6 +13,7 @@ import (
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	modelregistry "github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	log "github.com/sirupsen/logrus"
@@ -162,6 +163,31 @@ func repeatedHomeAuthError() *Error {
 		Message:    "home returned a previously tried auth",
 		HTTPStatus: http.StatusServiceUnavailable,
 	}
+}
+
+func homeAuthKnownIneligibleForExecution(auth *Auth, routeModel, upstreamModel string, opts cliproxyexecutor.Options) bool {
+	if auth == nil {
+		return false
+	}
+	executionKind := modelExecutionKindFromOptions(opts)
+	registryRef := modelregistry.GetGlobalRegistry()
+	seen := make(map[string]struct{}, 2)
+	for _, model := range []string{routeModel, upstreamModel} {
+		model = canonicalModelKey(model)
+		key := strings.ToLower(strings.TrimSpace(model))
+		if key == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		if !registryRef.ClientSupportsModel(auth.ID, model) {
+			continue
+		}
+		return !registryRef.ClientModelSupportsExecution(auth.ID, model, executionKind)
+	}
+	return false
 }
 
 type homeAuthDispatchResponse struct {
@@ -1045,7 +1071,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 		}
 		c.auth = preparedAuth
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth)
-		models, pooled, aliasResult := m.executionModelCandidatesWithAlias(c.auth, routeModel)
+		models, pooled, aliasResult, _ := m.executionModelCandidatesWithAlias(c.auth, routeModel)
 		if len(models) == 0 {
 			continue
 		}
@@ -1099,11 +1125,11 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 		}
 		c.auth = preparedAuth
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth)
-		models, pooled, aliasResult := m.executionModelCandidatesWithAlias(c.auth, routeModel)
+		models, pooled, aliasResult, routing := m.executionModelCandidatesWithAlias(c.auth, routeModel)
 		if len(models) == 0 {
 			continue
 		}
-		result, errStream := m.executeStreamWithModelPool(creditsCtx, c.executor, c.auth, c.provider, req, creditsOpts, routeModel, "", models, pooled, aliasResult, true, false)
+		result, errStream := m.executeStreamWithModelPool(creditsCtx, c.executor, c.auth, c.provider, req, creditsOpts, routeModel, "", models, pooled, aliasResult, routing, true, false)
 		if errStream != nil {
 			continue
 		}

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/tidwall/sjson"
@@ -38,6 +40,26 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			}
 			return cliproxyexecutor.Response{}, repeatedHomeAuthError()
 		}
+		if !homeSelectionMatchesProviders(selection, providers) {
+			tried[auth.ID] = struct{}{}
+			if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "provider_mismatch"); errEnd != nil {
+				return cliproxyexecutor.Response{}, errEnd
+			}
+			lastErr = homeProviderMismatchError(selection.Provider, providers)
+			continue
+		}
+		upstreamModel := ""
+		if auth.Attributes != nil {
+			upstreamModel = auth.Attributes[homeUpstreamModelAttributeKey]
+		}
+		if homeAuthKnownIneligibleForExecution(auth, routeModel, upstreamModel, opts) {
+			tried[auth.ID] = struct{}{}
+			if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "execution_ineligible"); errEnd != nil {
+				return cliproxyexecutor.Response{}, errEnd
+			}
+			lastErr = &Error{Code: "auth_not_found", Message: "selected auth does not support " + modelExecutionKindName(modelExecutionKindFromOptions(opts)) + " execution"}
+			continue
+		}
 		entry := logEntryWithRequestID(ctx)
 		debugLogAuthSelection(entry, auth, selection.Provider, routeModel)
 		if errRuntimeAuth := m.bindHomeSelectionRuntimeAuth(ctx, opts, selection); errRuntimeAuth != nil {
@@ -55,7 +77,7 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
-		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel, modelExecutionKindFromOptions(opts))
 		if aliasResult.ForceMapping && responseAlias != "" {
 			aliasResult.OriginalAlias = responseAlias
 		}
@@ -97,6 +119,9 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 				selection.End("request_intercepted")
 				return cliproxyexecutor.Response{}, errIntercept
 			}
+			if !restoreExecutionModel {
+				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, preparedAuth, routeModel, upstreamModel, modelExecutionKindFromOptions(execOpts))
+			}
 			if errCtx := execCtx.Err(); errCtx != nil {
 				releaseAttempt()
 				selection.End("attempt_canceled")
@@ -113,7 +138,8 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			if errExecute == nil {
 				m.reportHomeResult(execCtx, result, preparedAuth)
 				releaseAttempt()
-				rewriteForceMappedResponse(&response, aliasResult)
+				responseAliasResult := aliasResultForAPIKeyModelCandidate(routing, preparedAuth, routeModel, upstreamModel, modelExecutionKindFromOptions(execOpts), aliasResult)
+				rewriteForceMappedResponse(&response, responseAliasResult)
 				if !m.retainHomeWebsocketSelection(ctx, opts, routeModel, selection) {
 					selection.End("completed")
 				}
@@ -136,6 +162,32 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 		if errCtx := execCtx.Err(); errCtx != nil && ctx != nil && ctx.Err() != nil {
 			return cliproxyexecutor.Response{}, errCtx
 		}
+	}
+}
+
+func homeSelectionMatchesProviders(selection *HomeDispatchSelection, providers []string) bool {
+	provider := ""
+	executorProvider := ""
+	if selection != nil {
+		provider = strings.ToLower(strings.TrimSpace(selection.Provider))
+		if selection.Executor != nil {
+			executorProvider = strings.ToLower(strings.TrimSpace(selection.Executor.Identifier()))
+		}
+	}
+	for _, candidate := range providers {
+		candidate = strings.ToLower(strings.TrimSpace(candidate))
+		if candidate == "home" || candidate == provider || candidate == executorProvider {
+			return true
+		}
+	}
+	return false
+}
+
+func homeProviderMismatchError(provider string, providers []string) *Error {
+	return &Error{
+		Code:       "provider_mismatch",
+		Message:    fmt.Sprintf("home selected provider %q, but request requires provider %q", strings.TrimSpace(provider), strings.Join(providers, ", ")),
+		HTTPStatus: http.StatusServiceUnavailable,
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_models.go
+++ b/sdk/cliproxy/auth/conductor_models.go
@@ -12,7 +12,11 @@ import (
 )
 
 func (m *Manager) lookupAPIKeyUpstreamModel(authID, requestedModel string) string {
-	if m == nil {
+	return lookupAPIKeyUpstreamModel(m.loadAPIKeyModelRouting(), authID, requestedModel)
+}
+
+func lookupAPIKeyUpstreamModel(snapshot *apiKeyModelRoutingSnapshot, authID, requestedModel string) string {
+	if snapshot == nil {
 		return ""
 	}
 	authID = strings.TrimSpace(authID)
@@ -23,11 +27,7 @@ func (m *Manager) lookupAPIKeyUpstreamModel(authID, requestedModel string) strin
 	if requestedModel == "" {
 		return ""
 	}
-	table, _ := m.apiKeyModelAlias.Load().(apiKeyModelAliasTable)
-	if table == nil {
-		return ""
-	}
-	byAlias := table[authID]
+	byAlias := snapshot.aliases[authID]
 	if len(byAlias) == 0 {
 		return ""
 	}
@@ -46,7 +46,7 @@ func isAPIKeyAuth(auth *Auth) bool {
 	if auth == nil {
 		return false
 	}
-	return auth.AuthKind() == AuthKindAPIKey
+	return auth.AuthKind() == AuthKindAPIKey || IsConfigAPIKeyAuth(auth)
 }
 
 func isOpenAICompatAPIKeyAuth(auth *Auth) bool {
@@ -126,14 +126,17 @@ func rotateStrings(values []string, offset int) []string {
 }
 
 func (m *Manager) resolveOpenAICompatUpstreamModelPool(auth *Auth, requestedModel string) []string {
-	if m == nil || !isOpenAICompatAPIKeyAuth(auth) {
+	return resolveOpenAICompatUpstreamModelPool(m.loadAPIKeyModelRouting().config, auth, requestedModel)
+}
+
+func resolveOpenAICompatUpstreamModelPool(cfg *internalconfig.Config, auth *Auth, requestedModel string) []string {
+	if !isOpenAICompatAPIKeyAuth(auth) {
 		return nil
 	}
 	requestedModel = strings.TrimSpace(requestedModel)
 	if requestedModel == "" {
 		return nil
 	}
-	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
 	if cfg == nil {
 		cfg = &internalconfig.Config{}
 	}
@@ -155,6 +158,7 @@ func preserveRequestedModelSuffix(requestedModel, resolved string) string {
 }
 
 func (m *Manager) executionModelCandidates(auth *Auth, routeModel string) []string {
+	routing := m.loadAPIKeyModelRouting()
 	if auth != nil && auth.Attributes != nil {
 		if homeModel := strings.TrimSpace(auth.Attributes[homeUpstreamModelAttributeKey]); homeModel != "" {
 			return []string{homeModel}
@@ -162,14 +166,14 @@ func (m *Manager) executionModelCandidates(auth *Auth, routeModel string) []stri
 	}
 	requestedModel := rewriteModelForAuth(routeModel, auth)
 	requestedModel = m.applyOAuthModelAlias(auth, requestedModel)
-	if pool := m.resolveOpenAICompatUpstreamModelPool(auth, requestedModel); len(pool) > 0 {
+	if pool := resolveOpenAICompatUpstreamModelPool(routing.config, auth, requestedModel); len(pool) > 0 {
 		if len(pool) == 1 {
 			return pool
 		}
 		offset := m.nextModelPoolOffset(openAICompatModelPoolKey(auth, requestedModel), len(pool))
 		return rotateStrings(pool, offset)
 	}
-	resolved := m.applyAPIKeyModelAlias(auth, requestedModel)
+	resolved := m.applyAPIKeyModelAliasWithRouting(routing, auth, requestedModel)
 	if strings.TrimSpace(resolved) == "" {
 		resolved = requestedModel
 	}
@@ -244,14 +248,17 @@ func (m *Manager) preparedExecutionModels(auth *Auth, routeModel string) ([]stri
 	return m.filterExecutionModels(auth, routeModel, candidates, pooled), pooled
 }
 
-func (m *Manager) preparedExecutionModelsWithAlias(auth *Auth, routeModel string) ([]string, bool, OAuthModelAliasResult) {
-	candidates, pooled, aliasResult := m.executionModelCandidatesWithAlias(auth, routeModel)
-	return m.filterExecutionModels(auth, routeModel, candidates, pooled), pooled, aliasResult
+func (m *Manager) preparedExecutionModelsWithAlias(auth *Auth, routeModel string, executionKind apiKeyModelExecutionKind) ([]string, bool, OAuthModelAliasResult, *apiKeyModelRoutingSnapshot) {
+	candidates, _, aliasResult, routing := m.executionModelCandidatesWithAlias(auth, routeModel)
+	candidates = filterAPIKeyModelCandidates(routing, auth, routeModel, candidates, executionKind)
+	pooled := len(candidates) > 1
+	return m.filterExecutionModels(auth, routeModel, candidates, pooled), pooled, aliasResult, routing
 }
 
-func (m *Manager) executionModelCandidatesWithAlias(auth *Auth, routeModel string) ([]string, bool, OAuthModelAliasResult) {
+func (m *Manager) executionModelCandidatesWithAlias(auth *Auth, routeModel string) ([]string, bool, OAuthModelAliasResult, *apiKeyModelRoutingSnapshot) {
+	routing := m.loadAPIKeyModelRouting()
 	requestedModel := rewriteModelForAuth(routeModel, auth)
-	aliasResult := m.resolveExecutionAliasResultForRequested(auth, requestedModel)
+	aliasResult := m.resolveExecutionAliasResultForRequestedWithRouting(routing, auth, requestedModel)
 	if aliasResult.ForceMapping && auth != nil && auth.Attributes != nil && strings.EqualFold(strings.TrimSpace(auth.Attributes[homeForceMappingAttributeKey]), "true") {
 		aliasResult.OriginalAlias = strings.TrimSpace(routeModel)
 	}
@@ -264,7 +271,7 @@ func (m *Manager) executionModelCandidatesWithAlias(auth *Auth, routeModel strin
 		}
 	}
 	if len(candidates) == 0 {
-		if pool := m.resolveOpenAICompatUpstreamModelPool(auth, upstreamModel); len(pool) > 0 {
+		if pool := resolveOpenAICompatUpstreamModelPool(routing.config, auth, upstreamModel); len(pool) > 0 {
 			if len(pool) == 1 {
 				candidates = pool
 			} else {
@@ -272,7 +279,7 @@ func (m *Manager) executionModelCandidatesWithAlias(auth *Auth, routeModel strin
 				candidates = rotateStrings(pool, offset)
 			}
 		} else {
-			resolved := m.applyAPIKeyModelAlias(auth, upstreamModel)
+			resolved := m.applyAPIKeyModelAliasWithRouting(routing, auth, upstreamModel)
 			if strings.TrimSpace(resolved) == "" {
 				resolved = upstreamModel
 			}
@@ -280,7 +287,7 @@ func (m *Manager) executionModelCandidatesWithAlias(auth *Auth, routeModel strin
 		}
 	}
 	pooled := len(candidates) > 1
-	return candidates, pooled, aliasResult
+	return candidates, pooled, aliasResult, routing
 }
 
 func (m *Manager) resolveExecutionAliasResult(auth *Auth, routeModel string) OAuthModelAliasResult {
@@ -289,11 +296,15 @@ func (m *Manager) resolveExecutionAliasResult(auth *Auth, routeModel string) OAu
 }
 
 func (m *Manager) resolveExecutionAliasResultForRequested(auth *Auth, requestedModel string) OAuthModelAliasResult {
+	return m.resolveExecutionAliasResultForRequestedWithRouting(m.loadAPIKeyModelRouting(), auth, requestedModel)
+}
+
+func (m *Manager) resolveExecutionAliasResultForRequestedWithRouting(routing *apiKeyModelRoutingSnapshot, auth *Auth, requestedModel string) OAuthModelAliasResult {
 	if result := homeForceMappingAliasResult(auth, requestedModel); result.ForceMapping {
 		return result
 	}
-	if auth != nil && auth.AuthKind() == AuthKindAPIKey {
-		return m.resolveAPIKeyModelAliasWithResult(auth, requestedModel)
+	if isAPIKeyAuth(auth) {
+		return resolveAPIKeyModelAliasWithResult(routing.config, auth, requestedModel)
 	}
 	return m.applyOAuthModelAliasWithResult(auth, requestedModel)
 }
@@ -320,7 +331,7 @@ func homeForceMappingAliasResult(auth *Auth, requestedModel string) OAuthModelAl
 }
 
 func executionAliasPoolModel(auth *Auth, requestedModel string, aliasResult OAuthModelAliasResult) string {
-	if auth != nil && auth.AuthKind() == AuthKindAPIKey {
+	if isAPIKeyAuth(auth) {
 		if strings.TrimSpace(requestedModel) != "" {
 			return requestedModel
 		}
@@ -332,14 +343,17 @@ func executionAliasPoolModel(auth *Auth, requestedModel string, aliasResult OAut
 }
 
 func (m *Manager) resolveAPIKeyModelAliasWithResult(auth *Auth, requestedModel string) OAuthModelAliasResult {
-	if m == nil || auth == nil {
+	return resolveAPIKeyModelAliasWithResult(m.loadAPIKeyModelRouting().config, auth, requestedModel)
+}
+
+func resolveAPIKeyModelAliasWithResult(cfg *internalconfig.Config, auth *Auth, requestedModel string) OAuthModelAliasResult {
+	if auth == nil {
 		return OAuthModelAliasResult{}
 	}
 	requestedModel = strings.TrimSpace(requestedModel)
 	if requestedModel == "" {
 		return OAuthModelAliasResult{}
 	}
-	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
 	if cfg == nil {
 		cfg = &internalconfig.Config{}
 	}
@@ -444,7 +458,7 @@ func (m *Manager) rebuildAPIKeyModelAliasFromRuntimeConfig() {
 	m.rebuildAPIKeyModelAliasLocked(cfg)
 }
 
-// RefreshAPIKeyModelAlias rebuilds the API-key model alias table from the current runtime config.
+// RefreshAPIKeyModelAlias rebuilds API-key model aliases and configured capabilities.
 func (m *Manager) RefreshAPIKeyModelAlias() {
 	m.rebuildAPIKeyModelAliasFromRuntimeConfig()
 }
@@ -458,6 +472,7 @@ func (m *Manager) rebuildAPIKeyModelAliasLocked(cfg *internalconfig.Config) {
 	}
 
 	out := make(apiKeyModelAliasTable)
+	capabilities := make(apiKeyModelCapabilityTable)
 	for _, auth := range m.auths {
 		if auth == nil {
 			continue
@@ -465,36 +480,43 @@ func (m *Manager) rebuildAPIKeyModelAliasLocked(cfg *internalconfig.Config) {
 		if strings.TrimSpace(auth.ID) == "" {
 			continue
 		}
-		if auth.AuthKind() != AuthKindAPIKey {
+		if !isAPIKeyAuth(auth) {
 			continue
 		}
 
 		byAlias := make(map[string]string)
+		byCapability := make(map[string][]apiKeyModelCapabilityRoute)
 		provider := strings.ToLower(strings.TrimSpace(auth.Provider))
 		switch provider {
 		case "gemini":
 			if entry := resolveGeminiAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
+				compileAPIKeyModelCapabilities(byCapability, entry.Models, "gemini")
 			}
 		case "gemini-interactions":
 			if entry := resolveInteractionsAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
+				compileAPIKeyModelCapabilities(byCapability, entry.Models, "interactions")
 			}
 		case "claude":
 			if entry := resolveClaudeAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
+				compileAPIKeyModelCapabilities(byCapability, entry.Models, "claude")
 			}
 		case "codex":
 			if entry := resolveCodexAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
+				compileAPIKeyModelCapabilities(byCapability, entry.Models, "codex")
 			}
 		case "xai":
 			if entry := resolveXAIAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
+				compileAPIKeyModelCapabilities(byCapability, entry.Models, "xai")
 			}
 		case "vertex":
 			if entry := resolveVertexAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
+				compileAPIKeyModelCapabilities(byCapability, entry.Models, "gemini")
 			}
 		default:
 			// OpenAI-compat uses config selection from auth.Attributes.
@@ -507,16 +529,24 @@ func (m *Manager) rebuildAPIKeyModelAliasLocked(cfg *internalconfig.Config) {
 			if compatName != "" || strings.EqualFold(strings.TrimSpace(auth.Provider), "openai-compatibility") {
 				if entry := resolveOpenAICompatConfig(cfg, providerKey, compatName, auth.Provider); entry != nil {
 					compileAPIKeyModelAliasForModels(byAlias, entry.Models)
+					compileOpenAICompatModelCapabilities(byCapability, entry.Models)
 				}
 			}
 		}
 
 		if len(byAlias) > 0 {
-			out[auth.ID] = byAlias
+			out[strings.TrimSpace(auth.ID)] = byAlias
+		}
+		if len(byCapability) > 0 {
+			capabilities[strings.TrimSpace(auth.ID)] = byCapability
 		}
 	}
 
-	m.apiKeyModelAlias.Store(out)
+	m.apiKeyModelRouting.Store(&apiKeyModelRoutingSnapshot{
+		config:       cfg,
+		aliases:      out,
+		capabilities: capabilities,
+	})
 }
 
 func compileAPIKeyModelAliasForModels[T interface {
@@ -581,11 +611,15 @@ func rewriteModelForAuth(model string, auth *Auth) string {
 }
 
 func (m *Manager) applyAPIKeyModelAlias(auth *Auth, requestedModel string) string {
-	if m == nil || auth == nil {
+	return m.applyAPIKeyModelAliasWithRouting(m.loadAPIKeyModelRouting(), auth, requestedModel)
+}
+
+func (m *Manager) applyAPIKeyModelAliasWithRouting(routing *apiKeyModelRoutingSnapshot, auth *Auth, requestedModel string) string {
+	if auth == nil {
 		return requestedModel
 	}
 
-	if auth.AuthKind() != AuthKindAPIKey {
+	if !isAPIKeyAuth(auth) {
 		return requestedModel
 	}
 
@@ -595,13 +629,13 @@ func (m *Manager) applyAPIKeyModelAlias(auth *Auth, requestedModel string) strin
 	}
 
 	// Fast path: lookup per-auth mapping table (keyed by auth.ID).
-	if resolved := m.lookupAPIKeyUpstreamModel(auth.ID, requestedModel); resolved != "" {
+	if resolved := lookupAPIKeyUpstreamModel(routing, auth.ID, requestedModel); resolved != "" {
 		return resolved
 	}
 
 	// Slow path: scan config for the matching credential entry and resolve alias.
 	// This acts as a safety net if mappings are stale or auth.ID is missing.
-	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	cfg := routing.config
 	if cfg == nil {
 		cfg = &internalconfig.Config{}
 	}

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -439,26 +439,44 @@ func builtinSchedulerStrategy(delegate string) (schedulerStrategy, bool) {
 	}
 }
 
-func (m *Manager) pickViaBuiltinScheduler(ctx context.Context, strategy schedulerStrategy, provider string, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, bool, error) {
+func (m *Manager) pickViaBuiltinScheduler(ctx context.Context, strategy schedulerStrategy, provider string, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}, candidates []*Auth) (*Auth, bool, error) {
 	if m == nil || m.scheduler == nil {
 		return nil, false, nil
 	}
+	allowed := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if candidate != nil && strings.TrimSpace(candidate.ID) != "" {
+			allowed[candidate.ID] = struct{}{}
+		}
+	}
+	restrictedTried := make(map[string]struct{}, len(tried))
+	for authID := range tried {
+		restrictedTried[authID] = struct{}{}
+	}
+	m.mu.RLock()
+	for authID := range m.auths {
+		if _, ok := allowed[authID]; !ok {
+			restrictedTried[authID] = struct{}{}
+		}
+	}
+	m.mu.RUnlock()
+
 	providerKey := strings.ToLower(strings.TrimSpace(provider))
 	disallowFreeAuth := disallowFreeAuthFromMetadata(opts.Metadata)
 	for {
 		var selected *Auth
 		var errPick error
 		if providerKey == "mixed" {
-			selected, _, errPick = m.scheduler.pickMixedWithStrategy(ctx, providers, model, opts, tried, strategy)
+			selected, _, errPick = m.scheduler.pickMixedWithStrategy(ctx, providers, model, opts, restrictedTried, strategy)
 			if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
 				m.syncScheduler()
-				selected, _, errPick = m.scheduler.pickMixedWithStrategy(ctx, providers, model, opts, tried, strategy)
+				selected, _, errPick = m.scheduler.pickMixedWithStrategy(ctx, providers, model, opts, restrictedTried, strategy)
 			}
 		} else {
-			selected, errPick = m.scheduler.pickSingleWithStrategy(ctx, providerKey, model, opts, tried, strategy)
+			selected, errPick = m.scheduler.pickSingleWithStrategy(ctx, providerKey, model, opts, restrictedTried, strategy)
 			if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
 				m.syncScheduler()
-				selected, errPick = m.scheduler.pickSingleWithStrategy(ctx, providerKey, model, opts, tried, strategy)
+				selected, errPick = m.scheduler.pickSingleWithStrategy(ctx, providerKey, model, opts, restrictedTried, strategy)
 			}
 		}
 		if errPick != nil {
@@ -467,11 +485,12 @@ func (m *Manager) pickViaBuiltinScheduler(ctx context.Context, strategy schedule
 		if selected == nil {
 			return nil, true, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
 		}
+		if _, ok := allowed[selected.ID]; !ok {
+			restrictedTried[selected.ID] = struct{}{}
+			continue
+		}
 		if disallowFreeAuth && isFreeCodexAuth(selected) {
-			if tried == nil {
-				tried = make(map[string]struct{})
-			}
-			tried[selected.ID] = struct{}{}
+			restrictedTried[selected.ID] = struct{}{}
 			continue
 		}
 		return selected, true, nil
@@ -510,7 +529,7 @@ func (m *Manager) pickViaPluginScheduler(ctx context.Context, scheduler PluginSc
 	if !okStrategy {
 		return nil, false, nil
 	}
-	return m.pickViaBuiltinScheduler(ctx, strategy, providerKey, providers, model, opts, tried)
+	return m.pickViaBuiltinScheduler(ctx, strategy, providerKey, providers, model, opts, tried, candidates)
 }
 
 func (m *Manager) authSupportsRouteModel(registryRef *registry.ModelRegistry, auth *Auth, routeModel string) bool {
@@ -526,6 +545,31 @@ func (m *Manager) authSupportsRouteModel(registryRef *registry.ModelRegistry, au
 	}
 	selectionKey := m.selectionModelKeyForAuth(auth, routeModel)
 	return selectionKey != "" && selectionKey != routeKey && registryRef.ClientSupportsModel(auth.ID, selectionKey)
+}
+
+func (m *Manager) authSupportsExecutionModel(registryRef *registry.ModelRegistry, auth *Auth, routeModel string, opts cliproxyexecutor.Options) bool {
+	if !m.authSupportsRouteModel(registryRef, auth, routeModel) {
+		return false
+	}
+	if registryRef == nil || auth == nil {
+		return true
+	}
+	executionKind := modelExecutionKindFromOptions(opts)
+	supportsExecution := func(modelID string) bool {
+		return registryRef.ClientModelSupportsExecution(auth.ID, modelID, executionKind)
+	}
+	routeKey := canonicalModelKey(routeModel)
+	if routeKey != "" && supportsExecution(routeKey) {
+		return true
+	}
+	selectionKey := m.selectionModelKeyForAuth(auth, routeModel)
+	if selectionKey != "" && selectionKey != routeKey && supportsExecution(selectionKey) {
+		return true
+	}
+	if routeKey == "" && selectionKey == "" {
+		return executionKind == apiKeyModelExecutionChat
+	}
+	return false
 }
 
 func (m *Manager) normalizeProviders(providers []string) []string {
@@ -965,7 +1009,7 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		if _, used := tried[candidate.ID]; used {
 			continue
 		}
-		if modelKey != "" && !m.authSupportsRouteModel(registryRef, candidate, model) {
+		if modelKey != "" && !m.authSupportsExecutionModel(registryRef, candidate, model, opts) {
 			continue
 		}
 		candidates = append(candidates, candidate)
@@ -1078,6 +1122,29 @@ func (m *Manager) SelectHomeAuthByKind(ctx context.Context, provider string, mod
 		if errSelection != nil {
 			return nil, errSelection
 		}
+		selectionAuth := selection.CloneAuthForRoute(model)
+		upstreamModel := ""
+		if selectionAuth != nil && selectionAuth.Attributes != nil {
+			upstreamModel = selectionAuth.Attributes[homeUpstreamModelAttributeKey]
+		}
+		if homeAuthKnownIneligibleForExecution(selectionAuth, model, upstreamModel, opts) {
+			authID := ""
+			if selectionAuth != nil {
+				authID = strings.TrimSpace(selectionAuth.ID)
+			}
+			if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "execution_ineligible"); errEnd != nil {
+				return nil, errEnd
+			}
+			if authID == "" {
+				return nil, &Error{Code: "auth_not_found", Message: "selected auth has no ID"}
+			}
+			if _, alreadyTried := tried[authID]; alreadyTried {
+				return nil, repeatedHomeAuthError()
+			}
+			tried[authID] = struct{}{}
+			homeAuthCount++
+			continue
+		}
 		providerMatches := strings.TrimSpace(provider) == "" || strings.EqualFold(strings.TrimSpace(selection.Provider), strings.TrimSpace(provider))
 		kindMatches := selection.Auth != nil && selection.Auth.AuthKind() == requiredKind
 		if providerMatches && kindMatches {
@@ -1112,10 +1179,11 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 		return auth, exec, err
 	}
 
-	if m.hasPluginScheduler() || !m.useSchedulerFastPath() {
+	if modelExecutionKindFromOptions(opts) != apiKeyModelExecutionChat || m.hasPluginScheduler() || !m.useSchedulerFastPath() {
 		return m.pickNextLegacy(ctx, provider, model, opts, tried)
 	}
 	if strings.TrimSpace(model) != "" {
+		registryRef := registry.GetGlobalRegistry()
 		m.mu.RLock()
 		for _, candidate := range m.auths {
 			if candidate == nil || executorKeyFromAuth(candidate) != provider || candidate.Disabled {
@@ -1124,7 +1192,8 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 			if _, used := tried[candidate.ID]; used {
 				continue
 			}
-			if m.routeAwareSelectionRequired(candidate, model) {
+			routeSupported := m.authSupportsRouteModel(registryRef, candidate, model)
+			if m.routeAwareSelectionRequired(candidate, model) || (routeSupported && !m.authSupportsExecutionModel(registryRef, candidate, model, opts)) {
 				m.mu.RUnlock()
 				return m.pickNextLegacy(ctx, provider, model, opts, tried)
 			}
@@ -1224,7 +1293,7 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		if _, ok := m.executors[providerKey]; !ok {
 			continue
 		}
-		if modelKey != "" && !m.authSupportsRouteModel(registryRef, candidate, model) {
+		if modelKey != "" && !m.authSupportsExecutionModel(registryRef, candidate, model, opts) {
 			continue
 		}
 		candidates = append(candidates, candidate)
@@ -1276,7 +1345,7 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 		return m.pickNextViaHome(ctx, model, opts, tried)
 	}
 
-	if m.hasPluginScheduler() || !m.useSchedulerFastPath() {
+	if modelExecutionKindFromOptions(opts) != apiKeyModelExecutionChat || m.hasPluginScheduler() || !m.useSchedulerFastPath() {
 		return m.pickNextMixedLegacy(ctx, providers, model, opts, tried)
 	}
 
@@ -1300,6 +1369,7 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 		return nil, nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
 	if strings.TrimSpace(model) != "" {
+		registryRef := registry.GetGlobalRegistry()
 		providerSet := make(map[string]struct{}, len(eligibleProviders))
 		for _, providerKey := range eligibleProviders {
 			providerSet[providerKey] = struct{}{}
@@ -1315,7 +1385,8 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 			if _, used := tried[candidate.ID]; used {
 				continue
 			}
-			if m.routeAwareSelectionRequired(candidate, model) {
+			routeSupported := m.authSupportsRouteModel(registryRef, candidate, model)
+			if m.routeAwareSelectionRequired(candidate, model) || (routeSupported && !m.authSupportsExecutionModel(registryRef, candidate, model, opts)) {
 				m.mu.RUnlock()
 				return m.pickNextMixedLegacy(ctx, providers, model, opts, tried)
 			}

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -180,7 +180,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 	return &cliproxyexecutor.StreamResult{Headers: headers, Chunks: out}
 }
 
-func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor ProviderExecutor, auth *Auth, provider string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, routeModel, executionModel string, execModels []string, pooled bool, aliasResult OAuthModelAliasResult, allowRetry bool, ephemeralResult bool) (*cliproxyexecutor.StreamResult, error) {
+func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor ProviderExecutor, auth *Auth, provider string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, routeModel, executionModel string, execModels []string, pooled bool, aliasResult OAuthModelAliasResult, routing *apiKeyModelRoutingSnapshot, allowRetry bool, ephemeralResult bool) (*cliproxyexecutor.StreamResult, error) {
 	if executor == nil {
 		return nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
@@ -202,6 +202,9 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		}
 		if errCtx := ctx.Err(); errCtx != nil {
 			return nil, errCtx
+		}
+		if executionModel == "" {
+			execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, execModel, modelExecutionKindFromOptions(execOpts))
 		}
 		streamResult, errStream := executor.ExecuteStream(ctx, auth, execReq, execOpts)
 		if errStream != nil {
@@ -304,7 +307,8 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			close(closedCh)
 			remaining = closedCh
 		}
-		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, buffered, remaining, aliasResult, ephemeralResult), nil
+		responseAliasResult := aliasResultForAPIKeyModelCandidate(routing, auth, routeModel, execModel, modelExecutionKindFromOptions(execOpts), aliasResult)
+		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, buffered, remaining, responseAliasResult, ephemeralResult), nil
 	}
 	if lastErr == nil {
 		lastErr = &Error{Code: "auth_not_found", Message: "no upstream model available"}

--- a/sdk/cliproxy/auth/config_apikey.go
+++ b/sdk/cliproxy/auth/config_apikey.go
@@ -1,15 +1,19 @@
 package auth
 
-// IsConfigAPIKeyAuth reports whether the auth entry is synthesized from config *-api-key lists.
+// IsConfigAPIKeyAuth reports whether the auth entry is synthesized from a
+// configured API-key provider, including keyless OpenAI-compatible entries.
 func IsConfigAPIKeyAuth(auth *Auth) bool {
 	if auth == nil {
-		return false
-	}
-	if auth.AuthKind() != AuthKindAPIKey {
 		return false
 	}
 	if auth.AuthSourceKind() != AuthSourceConfig {
 		return false
 	}
-	return authAttribute(auth, AttributeAPIKey) != ""
+	switch auth.AuthKind() {
+	case AuthKindAPIKey:
+		return authAttribute(auth, AttributeAPIKey) != ""
+	case AuthKindOAuth:
+		return false
+	}
+	return auth.Attributes != nil && authAttribute(auth, "compat_name") != ""
 }

--- a/sdk/cliproxy/auth/config_apikey_test.go
+++ b/sdk/cliproxy/auth/config_apikey_test.go
@@ -30,4 +30,14 @@ func TestIsConfigAPIKeyAuth(t *testing.T) {
 	}) {
 		t.Fatal("expected config api key auth")
 	}
+	if !IsConfigAPIKeyAuth(&Auth{
+		ID:       "openai-compatibility:keyless",
+		Provider: "openai-compatibility:keyless",
+		Attributes: map[string]string{
+			"compat_name": "keyless",
+			"source":      "config:keyless[abc]",
+		},
+	}) {
+		t.Fatal("expected keyless openai-compatibility config auth")
+	}
 }

--- a/sdk/cliproxy/auth/home_retry_loop_test.go
+++ b/sdk/cliproxy/auth/home_retry_loop_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
@@ -96,5 +99,255 @@ func TestManagerExecuteHomeStopsWhenDispatchRepeatsTriedAuth(t *testing.T) {
 	}
 	if got := dispatcher.calls.Load(); got != 2 {
 		t.Fatalf("home dispatch calls = %d, want 2", got)
+	}
+}
+
+type imageHomeDispatcher struct {
+	counts []int
+}
+
+func (d *imageHomeDispatcher) HeartbeatOK() bool { return true }
+
+func (d *imageHomeDispatcher) RPopAuth(_ context.Context, model, _ string, _ http.Header, count int) ([]byte, error) {
+	d.counts = append(d.counts, count)
+	authID := map[int]string{1: "home-chat", 2: "home-image-failing", 3: "home-image-ready"}[count]
+	raw, _ := json.Marshal(homeAuthDispatchResponse{
+		Model: model,
+		Auth:  Auth{ID: authID, Provider: "home-image-test", Status: StatusActive},
+	})
+	return raw, nil
+}
+
+func (*imageHomeDispatcher) AbortAmbiguousDispatch() {}
+
+type imageHomeExecutor struct {
+	authIDs []string
+}
+
+func (e *imageHomeExecutor) Identifier() string { return "home-image-test" }
+
+func (e *imageHomeExecutor) Execute(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.authIDs = append(e.authIDs, auth.ID)
+	if auth.ID == "home-image-failing" {
+		return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusBadGateway, Message: "image upstream failed"}
+	}
+	return cliproxyexecutor.Response{Payload: []byte(auth.ID)}, nil
+}
+
+func (e *imageHomeExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+
+func (e *imageHomeExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) { return auth, nil }
+
+func (e *imageHomeExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *imageHomeExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestManagerExecuteHomeSkipsKnownChatOnlyImageAuth(t *testing.T) {
+	dispatcher := &imageHomeDispatcher{}
+	oldCurrentHomeDispatcher := currentHomeDispatcher
+	currentHomeDispatcher = func() homeAuthDispatcher { return dispatcher }
+	t.Cleanup(func() { currentHomeDispatcher = oldCurrentHomeDispatcher })
+
+	const model = "shared-image"
+	registryRef := registry.GetGlobalRegistry()
+	registryRef.RegisterClient("home-chat", "home-image-test", []*registry.ModelInfo{{ID: model}})
+	registryRef.RegisterClient("home-image-failing", "home-image-test", []*registry.ModelInfo{{ID: model, SupportsImageAPI: true}})
+	registryRef.RegisterClient("home-image-ready", "home-image-test", []*registry.ModelInfo{{ID: model, SupportsImageAPI: true}})
+	t.Cleanup(func() {
+		registryRef.UnregisterClient("home-chat")
+		registryRef.UnregisterClient("home-image-failing")
+		registryRef.UnregisterClient("home-image-ready")
+	})
+
+	executor := &imageHomeExecutor{}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetHomeExecutionRegistry(executionregistry.New())
+	manager.RegisterExecutor(executor)
+	resp, err := manager.Execute(context.Background(), []string{"home-image-test"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{
+		Metadata: map[string]any{cliproxyexecutor.ImageExecutionMetadataKey: true},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := string(resp.Payload); got != "home-image-ready" {
+		t.Fatalf("Execute() payload = %q, want home-image-ready", got)
+	}
+	if got, want := dispatcher.counts, []int{1, 2, 3}; !slices.Equal(got, want) {
+		t.Fatalf("home dispatch counts = %v, want %v", got, want)
+	}
+	if got, want := executor.authIDs, []string{"home-image-failing", "home-image-ready"}; !slices.Equal(got, want) {
+		t.Fatalf("executor auth IDs = %v, want %v", got, want)
+	}
+}
+
+type providerConstrainedHomeDispatcher struct {
+	providers []string
+	counts    []int
+}
+
+func (d *providerConstrainedHomeDispatcher) HeartbeatOK() bool { return true }
+
+func (d *providerConstrainedHomeDispatcher) RPopAuth(_ context.Context, model, _ string, _ http.Header, count int) ([]byte, error) {
+	d.counts = append(d.counts, count)
+	if count <= 0 || count > len(d.providers) {
+		return nil, repeatedHomeAuthError()
+	}
+	provider := d.providers[count-1]
+	raw, _ := json.Marshal(homeAuthDispatchResponse{
+		Model: model,
+		Auth: Auth{
+			ID:       "home-" + provider,
+			Provider: provider,
+			Status:   StatusActive,
+		},
+	})
+	return raw, nil
+}
+
+func (*providerConstrainedHomeDispatcher) AbortAmbiguousDispatch() {}
+
+type providerConstrainedHomeExecutor struct {
+	provider string
+	authIDs  []string
+}
+
+func (e *providerConstrainedHomeExecutor) Identifier() string { return e.provider }
+
+func (e *providerConstrainedHomeExecutor) Execute(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.authIDs = append(e.authIDs, auth.ID)
+	return cliproxyexecutor.Response{Payload: []byte(e.provider)}, nil
+}
+
+func (*providerConstrainedHomeExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+
+func (*providerConstrainedHomeExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (*providerConstrainedHomeExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (*providerConstrainedHomeExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestManagerExecuteHomeHonorsRequiredProvider(t *testing.T) {
+	dispatcher := &providerConstrainedHomeDispatcher{providers: []string{"openai-compatibility", "xai"}}
+	oldCurrentHomeDispatcher := currentHomeDispatcher
+	currentHomeDispatcher = func() homeAuthDispatcher { return dispatcher }
+	t.Cleanup(func() { currentHomeDispatcher = oldCurrentHomeDispatcher })
+
+	compatExecutor := &providerConstrainedHomeExecutor{provider: "openai-compatibility"}
+	xaiExecutor := &providerConstrainedHomeExecutor{provider: "xai"}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetHomeExecutionRegistry(executionregistry.New())
+	manager.RegisterExecutor(compatExecutor)
+	manager.RegisterExecutor(xaiExecutor)
+
+	resp, err := manager.Execute(context.Background(), []string{"xai"}, cliproxyexecutor.Request{Model: "shared-native-image"}, cliproxyexecutor.Options{
+		Metadata: map[string]any{cliproxyexecutor.ImageExecutionMetadataKey: true},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := string(resp.Payload); got != "xai" {
+		t.Fatalf("Execute() payload = %q, want xai", got)
+	}
+	if got, want := dispatcher.counts, []int{1, 2}; !slices.Equal(got, want) {
+		t.Fatalf("home dispatch counts = %v, want %v", got, want)
+	}
+	if len(compatExecutor.authIDs) != 0 {
+		t.Fatalf("compatibility executor auth IDs = %v, want none", compatExecutor.authIDs)
+	}
+	if got, want := xaiExecutor.authIDs, []string{"home-xai"}; !slices.Equal(got, want) {
+		t.Fatalf("xAI executor auth IDs = %v, want %v", got, want)
+	}
+}
+
+func TestManagerExecuteHomeRequiredProviderMismatchIsExplained(t *testing.T) {
+	dispatcher := &providerConstrainedHomeDispatcher{providers: []string{"openai-compatibility", "openai-compatibility"}}
+	oldCurrentHomeDispatcher := currentHomeDispatcher
+	currentHomeDispatcher = func() homeAuthDispatcher { return dispatcher }
+	t.Cleanup(func() { currentHomeDispatcher = oldCurrentHomeDispatcher })
+
+	compatExecutor := &providerConstrainedHomeExecutor{provider: "openai-compatibility"}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetHomeExecutionRegistry(executionregistry.New())
+	manager.RegisterExecutor(compatExecutor)
+
+	_, err := manager.Execute(context.Background(), []string{"xai"}, cliproxyexecutor.Request{Model: "shared-native-image"}, cliproxyexecutor.Options{
+		Metadata: map[string]any{cliproxyexecutor.ImageExecutionMetadataKey: true},
+	})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want provider mismatch")
+	}
+	if statusCodeFromError(err) != http.StatusServiceUnavailable {
+		t.Fatalf("Execute() status = %d, want %d (%v)", statusCodeFromError(err), http.StatusServiceUnavailable, err)
+	}
+	if !strings.Contains(err.Error(), `selected provider "openai-compatibility"`) || !strings.Contains(err.Error(), `requires provider "xai"`) {
+		t.Fatalf("Execute() error = %q, want selected and required providers", err)
+	}
+	if len(compatExecutor.authIDs) != 0 {
+		t.Fatalf("compatibility executor auth IDs = %v, want none", compatExecutor.authIDs)
+	}
+}
+
+func TestHomeImageEligibilityPrefersRequestedModelRegistration(t *testing.T) {
+	const authID = "home-shared-route"
+	registryRef := registry.GetGlobalRegistry()
+	registryRef.RegisterClient(authID, "home-image-test", []*registry.ModelInfo{
+		{ID: "public-model"},
+		{ID: "upstream-model", SupportsImageAPI: true},
+	})
+	t.Cleanup(func() { registryRef.UnregisterClient(authID) })
+
+	opts := cliproxyexecutor.Options{Metadata: map[string]any{cliproxyexecutor.ImageExecutionMetadataKey: true}}
+	if !homeAuthKnownIneligibleForExecution(&Auth{ID: authID}, "public-model", "upstream-model", opts) {
+		t.Fatal("chat-only requested model registration must not inherit upstream image capability")
+	}
+	if homeAuthKnownIneligibleForExecution(&Auth{ID: authID}, "missing-public-model", "upstream-model", opts) {
+		t.Fatal("upstream image registration should be used when the requested model is not registered")
+	}
+}
+
+func TestHomeEndpointEligibilitySeparatesChatAndVideo(t *testing.T) {
+	const modelID = "home-shared-video"
+	registryRef := registry.GetGlobalRegistry()
+	registryRef.RegisterClient("home-video-only", "home-video-test", []*registry.ModelInfo{{
+		ID:               modelID,
+		SupportsVideoAPI: true,
+		ChatDisabled:     true,
+	}})
+	registryRef.RegisterClient("home-chat-only", "home-video-test", []*registry.ModelInfo{{ID: modelID}})
+	t.Cleanup(func() {
+		registryRef.UnregisterClient("home-video-only")
+		registryRef.UnregisterClient("home-chat-only")
+	})
+
+	chatOpts := cliproxyexecutor.Options{}
+	videoOpts := cliproxyexecutor.Options{Metadata: map[string]any{cliproxyexecutor.VideoExecutionMetadataKey: true}}
+	if !homeAuthKnownIneligibleForExecution(&Auth{ID: "home-video-only"}, modelID, "", chatOpts) {
+		t.Fatal("video-only Home auth must be ineligible for chat execution")
+	}
+	if homeAuthKnownIneligibleForExecution(&Auth{ID: "home-video-only"}, modelID, "", videoOpts) {
+		t.Fatal("video-only Home auth must remain eligible for video execution")
+	}
+	if !homeAuthKnownIneligibleForExecution(&Auth{ID: "home-chat-only"}, modelID, "", videoOpts) {
+		t.Fatal("chat-only Home auth must be ineligible for video execution")
+	}
+	if homeAuthKnownIneligibleForExecution(&Auth{ID: "home-chat-only"}, modelID, "", chatOpts) {
+		t.Fatal("chat-only Home auth must remain eligible for chat execution")
 	}
 }

--- a/sdk/cliproxy/auth/openai_compat_pool_test.go
+++ b/sdk/cliproxy/auth/openai_compat_pool_test.go
@@ -9,7 +9,9 @@ import (
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 )
 
 const openAICompatPoolProviderKey = "openai-compatible-pool"
@@ -185,17 +187,35 @@ func newOpenAICompatPoolTestManager(t *testing.T, alias string, models []interna
 		Provider: openAICompatPoolProviderKey,
 		Status:   StatusActive,
 		Attributes: map[string]string{
-			"api_key":      "test-key",
-			"compat_name":  "pool",
-			"provider_key": openAICompatPoolProviderKey,
+			"api_key":       "test-key",
+			"compat_name":   "pool",
+			"provider_key":  openAICompatPoolProviderKey,
+			AttributeSource: "config:pool[test]",
 		},
 	}
 	if _, err := m.Register(context.Background(), auth); err != nil {
 		t.Fatalf("register auth: %v", err)
 	}
 
+	supportsImage := false
+	hasChatModel := false
+	for i := range models {
+		if models[i].Image {
+			supportsImage = true
+		} else {
+			hasChatModel = true
+		}
+	}
+	modelType := "openai-compatibility"
+	if supportsImage && !hasChatModel {
+		modelType = registry.OpenAIImageModelType
+	}
 	reg := registry.GetGlobalRegistry()
-	reg.RegisterClient(auth.ID, openAICompatPoolProviderKey, []*registry.ModelInfo{{ID: alias}})
+	reg.RegisterClient(auth.ID, openAICompatPoolProviderKey, []*registry.ModelInfo{{
+		ID:               alias,
+		Type:             modelType,
+		SupportsImageAPI: supportsImage,
+	}})
 	t.Cleanup(func() {
 		reg.UnregisterClient(auth.ID)
 	})
@@ -215,6 +235,423 @@ func readOpenAICompatStreamPayload(t *testing.T, streamResult *cliproxyexecutor.
 		payload = append(payload, chunk.Payload...)
 	}
 	return string(payload)
+}
+
+func TestManagerExecutePrefixedOpenAICompatImageModel(t *testing.T) {
+	const alias = "tenant/image-public"
+	executor := &openAICompatPoolExecutor{id: openAICompatPoolProviderKey}
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		SDKConfig: internalconfig.SDKConfig{ForceModelPrefix: true},
+		OpenAICompatibility: []internalconfig.OpenAICompatibility{{
+			Name:   "pool",
+			Prefix: "tenant",
+			Models: []internalconfig.OpenAICompatibilityModel{{
+				Name: "upstream-image", Alias: "image-public", Image: true,
+			}},
+		}},
+	})
+	m.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "prefixed-image-auth",
+		Provider: openAICompatPoolProviderKey,
+		Prefix:   "tenant",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"api_key":       "test-key",
+			"compat_name":   "pool",
+			"provider_key":  openAICompatPoolProviderKey,
+			AttributeSource: "config:pool[test]",
+		},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, openAICompatPoolProviderKey, []*registry.ModelInfo{{
+		ID: alias, Type: registry.OpenAIImageModelType,
+	}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	resp, err := m.Execute(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, cliproxyexecutor.Options{
+		Metadata: map[string]any{cliproxyexecutor.ImageExecutionMetadataKey: true},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := string(resp.Payload); got != "upstream-image" {
+		t.Fatalf("upstream model = %q, want upstream-image", got)
+	}
+}
+
+func TestManagerFiltersPrefixedOpenAICompatAliasPoolByEndpoint(t *testing.T) {
+	const alias = "tenant/public"
+	executor := &openAICompatPoolExecutor{id: openAICompatPoolProviderKey}
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{OpenAICompatibility: []internalconfig.OpenAICompatibility{{
+		Name:   "pool",
+		Prefix: "tenant",
+		Models: []internalconfig.OpenAICompatibilityModel{
+			{Name: "chat-upstream", Alias: "public"},
+			{Name: "image-upstream", Alias: "public", Image: true},
+		},
+	}}})
+	m.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "prefixed-mixed-image-auth",
+		Provider: openAICompatPoolProviderKey,
+		Prefix:   "tenant",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			AttributeAPIKey: "test-key",
+			"compat_name":   "pool",
+			"provider_key":  openAICompatPoolProviderKey,
+			AttributeSource: "config:pool[test]",
+		},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, openAICompatPoolProviderKey, []*registry.ModelInfo{{
+		ID: alias, Type: "openai-compatibility", SupportsImageAPI: true,
+	}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	chatCandidates, chatPooled, _, _ := m.preparedExecutionModelsWithAlias(auth, alias, apiKeyModelExecutionChat)
+	if len(chatCandidates) != 1 || chatCandidates[0] != "chat-upstream" || chatPooled {
+		t.Fatalf("chat candidates = %v, pooled = %t; want one non-pooled chat candidate", chatCandidates, chatPooled)
+	}
+	imageCandidates, imagePooled, _, _ := m.preparedExecutionModelsWithAlias(auth, alias, apiKeyModelExecutionImage)
+	if len(imageCandidates) != 1 || imageCandidates[0] != "image-upstream" || imagePooled {
+		t.Fatalf("image candidates = %v, pooled = %t; want one non-pooled image candidate", imageCandidates, imagePooled)
+	}
+
+	chatResp, err := m.Execute(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("chat Execute() error = %v", err)
+	}
+	if got := string(chatResp.Payload); got != "chat-upstream" {
+		t.Fatalf("chat upstream model = %q, want chat-upstream", got)
+	}
+
+	imageResp, err := m.Execute(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, cliproxyexecutor.Options{
+		Metadata: map[string]any{cliproxyexecutor.ImageExecutionMetadataKey: true},
+	})
+	if err != nil {
+		t.Fatalf("image Execute() error = %v", err)
+	}
+	if got := string(imageResp.Payload); got != "image-upstream" {
+		t.Fatalf("image upstream model = %q, want image-upstream", got)
+	}
+
+	countResp, err := m.ExecuteCount(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("chat ExecuteCount() error = %v", err)
+	}
+	if got := string(countResp.Payload); got != "chat-upstream" {
+		t.Fatalf("count upstream model = %q, want chat-upstream", got)
+	}
+
+	stream, err := m.ExecuteStream(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, cliproxyexecutor.Options{
+		Metadata: map[string]any{cliproxyexecutor.ImageExecutionMetadataKey: true},
+	})
+	if err != nil {
+		t.Fatalf("image ExecuteStream() error = %v", err)
+	}
+	if got := readOpenAICompatStreamPayload(t, stream); got != "image-upstream" {
+		t.Fatalf("stream upstream model = %q, want image-upstream", got)
+	}
+}
+
+func TestManagerThinkingErrorFallsThroughOpenAICompatAliasPool(t *testing.T) {
+	const (
+		alias         = "shared"
+		highUpstream  = "upstream-high"
+		lowUpstream   = "upstream-low"
+		requested     = alias + "(low)"
+		highExecution = highUpstream + "(low)"
+		lowExecution  = lowUpstream + "(low)"
+	)
+	highModel := internalconfig.OpenAICompatibilityModel{
+		Name:     highUpstream,
+		Alias:    alias,
+		Thinking: thinkingLevels("high"),
+	}
+	lowModel := internalconfig.OpenAICompatibilityModel{
+		Name:     lowUpstream,
+		Alias:    alias,
+		Thinking: thinkingLevels("low"),
+	}
+	thinkingErr := thinking.NewThinkingError(thinking.ErrLevelNotSupported, `level "low" not supported, valid levels: high`)
+	if isRequestInvalidError(thinkingErr) {
+		t.Fatal("ThinkingError unexpectedly classified as a terminal request error")
+	}
+
+	tests := []struct {
+		name       string
+		models     []internalconfig.OpenAICompatibilityModel
+		wantModels []string
+	}{
+		{
+			name:       "high first",
+			models:     []internalconfig.OpenAICompatibilityModel{highModel, lowModel},
+			wantModels: []string{highExecution, lowExecution},
+		},
+		{
+			name:       "low first",
+			models:     []internalconfig.OpenAICompatibilityModel{lowModel, highModel},
+			wantModels: []string{lowExecution},
+		},
+	}
+	operations := []struct {
+		name string
+		run  func(*testing.T, *Manager) (string, error)
+		got  func(*openAICompatPoolExecutor) []string
+	}{
+		{
+			name: "execute",
+			run: func(_ *testing.T, manager *Manager) (string, error) {
+				resp, err := manager.Execute(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: requested}, cliproxyexecutor.Options{})
+				return string(resp.Payload), err
+			},
+			got: (*openAICompatPoolExecutor).ExecuteModels,
+		},
+		{
+			name: "count",
+			run: func(_ *testing.T, manager *Manager) (string, error) {
+				resp, err := manager.ExecuteCount(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: requested}, cliproxyexecutor.Options{})
+				return string(resp.Payload), err
+			},
+			got: (*openAICompatPoolExecutor).CountModels,
+		},
+		{
+			name: "stream",
+			run: func(t *testing.T, manager *Manager) (string, error) {
+				stream, err := manager.ExecuteStream(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: requested}, cliproxyexecutor.Options{})
+				if err != nil {
+					return "", err
+				}
+				return readOpenAICompatStreamPayload(t, stream), nil
+			},
+			got: (*openAICompatPoolExecutor).StreamModels,
+		},
+	}
+
+	for _, operation := range operations {
+		t.Run(operation.name, func(t *testing.T) {
+			for _, tc := range tests {
+				t.Run(tc.name, func(t *testing.T) {
+					executor := &openAICompatPoolExecutor{
+						id:                openAICompatPoolProviderKey,
+						executeErrors:     map[string]error{highExecution: thinkingErr},
+						countErrors:       map[string]error{highExecution: thinkingErr},
+						streamFirstErrors: map[string]error{highExecution: thinkingErr},
+					}
+					manager := newOpenAICompatPoolTestManager(t, alias, tc.models, executor)
+
+					payload, err := operation.run(t, manager)
+					if err != nil {
+						t.Fatalf("%s() error = %v", operation.name, err)
+					}
+					if payload != lowExecution {
+						t.Fatalf("%s() payload = %q, want %q", operation.name, payload, lowExecution)
+					}
+					gotModels := operation.got(executor)
+					if strings.Join(gotModels, ",") != strings.Join(tc.wantModels, ",") {
+						t.Fatalf("%s() models = %v, want %v", operation.name, gotModels, tc.wantModels)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestManagerImageExecutionExcludesChatOnlyAuthRegistrations(t *testing.T) {
+	const (
+		model         = "shared-image-model"
+		chatProvider  = "claude"
+		imageProvider = "openai-compatible-image"
+	)
+	selector := &trackingSelector{}
+	chatExecutor := &openAICompatPoolExecutor{id: chatProvider}
+	imageExecutor := &openAICompatPoolExecutor{id: imageProvider}
+	m := NewManager(nil, selector, nil)
+	m.SetConfig(&internalconfig.Config{
+		ClaudeKey: []internalconfig.ClaudeKey{{
+			APIKey: "chat-key",
+			Models: []internalconfig.ClaudeModel{{Name: model}},
+		}},
+		OpenAICompatibility: []internalconfig.OpenAICompatibility{{
+			Name: "image",
+			Models: []internalconfig.OpenAICompatibilityModel{{
+				Name: "image-upstream", Alias: model, Image: true,
+			}},
+		}},
+	})
+	m.RegisterExecutor(chatExecutor)
+	m.RegisterExecutor(imageExecutor)
+
+	chatAuth := &Auth{
+		ID:       "chat-only-auth",
+		Provider: chatProvider,
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			AttributeAPIKey: "chat-key",
+			AttributeSource: "config:claude[0]",
+		},
+	}
+	imageAuth := &Auth{
+		ID:       "image-auth",
+		Provider: imageProvider,
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			AttributeAPIKey: "image-key",
+			AttributeSource: "config:openai-compatibility[image]",
+			"compat_name":   "image",
+			"provider_key":  imageProvider,
+		},
+	}
+	for _, auth := range []*Auth{chatAuth, imageAuth} {
+		if _, err := m.Register(context.Background(), auth); err != nil {
+			t.Fatalf("Register(%s) error = %v", auth.ID, err)
+		}
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(chatAuth.ID, chatProvider, []*registry.ModelInfo{{ID: model, Type: "openai-compatibility"}})
+	reg.RegisterClient(imageAuth.ID, imageProvider, []*registry.ModelInfo{{ID: model, Type: registry.OpenAIImageModelType, SupportsImageAPI: true}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(chatAuth.ID)
+		reg.UnregisterClient(imageAuth.ID)
+	})
+
+	resp, err := m.Execute(context.Background(), []string{chatProvider, imageProvider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{
+		Metadata: map[string]any{cliproxyexecutor.ImageExecutionMetadataKey: true},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := string(resp.Payload); got != "image-upstream" {
+		t.Fatalf("upstream model = %q, want image-upstream", got)
+	}
+	if got := selector.lastAuthID; len(got) != 1 || got[0] != imageAuth.ID {
+		t.Fatalf("selector candidates = %v, want only %s", got, imageAuth.ID)
+	}
+	if got := chatExecutor.ExecuteModels(); len(got) != 0 {
+		t.Fatalf("chat-only executor calls = %v, want none", got)
+	}
+
+	pluginScheduler := &fakePluginScheduler{
+		resp:    pluginapi.SchedulerPickResponse{Handled: true, DelegateBuiltin: pluginapi.SchedulerBuiltinFillFirst},
+		handled: true,
+	}
+	m.SetPluginScheduler(pluginScheduler)
+	resp, err = m.Execute(context.Background(), []string{chatProvider, imageProvider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{
+		Metadata: map[string]any{cliproxyexecutor.ImageExecutionMetadataKey: true},
+	})
+	if err != nil {
+		t.Fatalf("Execute() with delegated scheduler error = %v", err)
+	}
+	if got := string(resp.Payload); got != "image-upstream" {
+		t.Fatalf("delegated scheduler upstream model = %q, want image-upstream", got)
+	}
+	if got := pluginScheduler.requests; len(got) != 1 || len(got[0].Candidates) != 1 || got[0].Candidates[0].ID != imageAuth.ID {
+		t.Fatalf("delegated scheduler candidates = %+v, want only %s", got, imageAuth.ID)
+	}
+}
+
+func TestManagerUsesEndpointSpecificForceMappingForSharedOpenAICompatAlias(t *testing.T) {
+	const alias = "shared"
+	executor := &openAICompatPoolExecutor{
+		id: openAICompatPoolProviderKey,
+		executePayloads: map[string][]byte{
+			"chat-upstream":  []byte(`{"model":"chat-upstream"}`),
+			"image-upstream": []byte(`{"model":"image-upstream"}`),
+		},
+		streamPayloads: map[string][]cliproxyexecutor.StreamChunk{
+			"chat-upstream":  {{Payload: []byte(`{"model":"chat-upstream"}`)}},
+			"image-upstream": {{Payload: []byte(`{"model":"image-upstream"}`)}},
+		},
+	}
+	m := newOpenAICompatPoolTestManager(t, alias, []internalconfig.OpenAICompatibilityModel{
+		{Name: "chat-upstream", Alias: alias, ForceMapping: true},
+		{Name: "image-upstream", Alias: alias, Image: true},
+	}, executor)
+
+	chatResp, err := m.Execute(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("chat Execute() error = %v", err)
+	}
+	if got := string(chatResp.Payload); got != `{"model":"shared"}` {
+		t.Fatalf("chat payload = %s, want force-mapped alias", got)
+	}
+
+	imageOpts := cliproxyexecutor.Options{Metadata: map[string]any{cliproxyexecutor.ImageExecutionMetadataKey: true}}
+	imageResp, err := m.Execute(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, imageOpts)
+	if err != nil {
+		t.Fatalf("image Execute() error = %v", err)
+	}
+	if got := string(imageResp.Payload); got != `{"model":"image-upstream"}` {
+		t.Fatalf("image payload = %s, want upstream model without force mapping", got)
+	}
+
+	chatStream, err := m.ExecuteStream(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("chat ExecuteStream() error = %v", err)
+	}
+	if got := readOpenAICompatStreamPayload(t, chatStream); got != `{"model":"shared"}` {
+		t.Fatalf("chat stream payload = %s, want force-mapped alias", got)
+	}
+
+	imageStream, err := m.ExecuteStream(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, imageOpts)
+	if err != nil {
+		t.Fatalf("image ExecuteStream() error = %v", err)
+	}
+	if got := readOpenAICompatStreamPayload(t, imageStream); got != `{"model":"image-upstream"}` {
+		t.Fatalf("image stream payload = %s, want upstream model without force mapping", got)
+	}
+}
+
+func TestManagerMatchesDuplicateOpenAICompatUpstreamByEndpointKind(t *testing.T) {
+	orders := []struct {
+		name   string
+		models []internalconfig.OpenAICompatibilityModel
+	}{
+		{name: "chat first", models: []internalconfig.OpenAICompatibilityModel{
+			{Name: "shared-upstream", Alias: "shared"},
+			{Name: "shared-upstream", Alias: "shared", Image: true},
+		}},
+		{name: "image first", models: []internalconfig.OpenAICompatibilityModel{
+			{Name: "shared-upstream", Alias: "shared", Image: true},
+			{Name: "shared-upstream", Alias: "shared"},
+		}},
+	}
+
+	for _, tc := range orders {
+		t.Run(tc.name, func(t *testing.T) {
+			executor := &openAICompatPoolExecutor{id: openAICompatPoolProviderKey}
+			m := newOpenAICompatPoolTestManager(t, "shared", tc.models, executor)
+
+			for _, test := range []struct {
+				name     string
+				metadata map[string]any
+			}{
+				{name: "chat"},
+				{name: "image", metadata: map[string]any{cliproxyexecutor.ImageExecutionMetadataKey: true}},
+			} {
+				t.Run(test.name, func(t *testing.T) {
+					resp, err := m.Execute(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: "shared"}, cliproxyexecutor.Options{Metadata: test.metadata})
+					if err != nil {
+						t.Fatalf("Execute() error = %v", err)
+					}
+					if got := string(resp.Payload); got != "shared-upstream" {
+						t.Fatalf("upstream model = %q, want shared-upstream", got)
+					}
+				})
+			}
+		})
+	}
 }
 
 func TestManagerExecuteCount_OpenAICompatAliasPoolStopsOnInvalidRequest(t *testing.T) {

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -48,6 +48,10 @@ const (
 	DerivedSessionIDMetadataKey = "derived_session_id"
 	// CallerScopeMetadataKey isolates inferred session identities between downstream callers.
 	CallerScopeMetadataKey = "caller_scope"
+	// ImageExecutionMetadataKey marks requests dispatched from an image endpoint.
+	ImageExecutionMetadataKey = "image_execution"
+	// VideoExecutionMetadataKey marks requests dispatched from a video endpoint.
+	VideoExecutionMetadataKey = "video_execution"
 )
 
 // Request encapsulates the translated payload that will be sent to a provider executor.

--- a/sdk/cliproxy/openai_compat_config_models_test.go
+++ b/sdk/cliproxy/openai_compat_config_models_test.go
@@ -66,6 +66,26 @@ func TestBuildOpenAICompatibilityConfigModels_InputModalities(t *testing.T) {
 	}
 }
 
+func TestBuildOpenAICompatibilityConfigModelsInheritsSuffixedStaticThinking(t *testing.T) {
+	static := registry.LookupStaticModelInfo("gpt-5.6-luna")
+	if static == nil || static.Thinking == nil {
+		t.Fatal("gpt-5.6-luna static thinking metadata is unavailable")
+	}
+	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
+		Name: "compat",
+		Models: []config.OpenAICompatibilityModel{{
+			Name:  "gpt-5.6-luna(high)",
+			Alias: "public-luna",
+		}},
+	})
+	if len(models) != 1 || models[0].Thinking == nil {
+		t.Fatalf("models = %+v, want inherited static thinking", models)
+	}
+	if got, want := len(models[0].Thinking.Levels), len(static.Thinking.Levels); got != want {
+		t.Fatalf("thinking levels = %v, want %v", models[0].Thinking.Levels, static.Thinking.Levels)
+	}
+}
+
 func joinModalities(modalities []string) string {
 	if len(modalities) == 0 {
 		return ""

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	internalregistry "github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
@@ -78,6 +79,8 @@ func TestRegisterModelsForAuth_OpenAICompatibilityImageModelType(t *testing.T) {
 					Models: []config.OpenAICompatibilityModel{
 						{Name: "upstream-image", Alias: "compat-image", Image: true},
 						{Name: "upstream-chat", Alias: "compat-chat"},
+						{Name: "upstream-shared-image", Alias: "compat-shared", Image: true},
+						{Name: "upstream-shared-chat", Alias: "compat-shared", Thinking: &internalregistry.ThinkingSupport{Levels: []string{"high"}}, InputModalities: []string{"text", "image"}},
 					},
 				},
 			},
@@ -105,6 +108,7 @@ func TestRegisterModelsForAuth_OpenAICompatibilityImageModelType(t *testing.T) {
 	models := modelRegistry.GetModelsForClient(auth.ID)
 	var imageModel *internalregistry.ModelInfo
 	var chatModel *internalregistry.ModelInfo
+	var sharedModel *internalregistry.ModelInfo
 	for _, model := range models {
 		if model == nil {
 			continue
@@ -114,6 +118,8 @@ func TestRegisterModelsForAuth_OpenAICompatibilityImageModelType(t *testing.T) {
 			imageModel = model
 		case "compat-chat":
 			chatModel = model
+		case "compat-shared":
+			sharedModel = model
 		}
 	}
 	if imageModel == nil {
@@ -121,6 +127,9 @@ func TestRegisterModelsForAuth_OpenAICompatibilityImageModelType(t *testing.T) {
 	}
 	if imageModel.Type != internalregistry.OpenAIImageModelType {
 		t.Fatalf("image model type = %q, want %q", imageModel.Type, internalregistry.OpenAIImageModelType)
+	}
+	if !imageModel.SupportsImageAPI {
+		t.Fatal("expected image model to support the image API")
 	}
 	if imageModel.Thinking != nil {
 		t.Fatalf("image model thinking = %+v, want nil", imageModel.Thinking)
@@ -133,6 +142,478 @@ func TestRegisterModelsForAuth_OpenAICompatibilityImageModelType(t *testing.T) {
 	}
 	if chatModel.Thinking == nil {
 		t.Fatal("expected chat model to keep default thinking support")
+	}
+	if sharedModel == nil || sharedModel.Type != "openai-compatibility" || !sharedModel.SupportsImageAPI {
+		t.Fatalf("shared alias model = %+v, want chat-visible image-capable registration", sharedModel)
+	}
+	if sharedModel.Thinking == nil || len(sharedModel.Thinking.Levels) != 1 || sharedModel.Thinking.Levels[0] != "high" {
+		t.Fatalf("shared alias thinking = %+v, want chat metadata", sharedModel.Thinking)
+	}
+	if got := strings.Join(sharedModel.SupportedInputModalities, ","); got != "text,image" {
+		t.Fatalf("shared alias input modalities = %q, want text,image", got)
+	}
+}
+
+func TestBuildAPIKeyConfigModelsPrefersConfiguredThinking(t *testing.T) {
+	configured := &internalregistry.ThinkingSupport{Levels: []string{"xhigh", "high"}}
+	tests := []struct {
+		name  string
+		build func() []*ModelInfo
+	}{
+		{name: "claude", build: func() []*ModelInfo {
+			return buildClaudeConfigModels(&config.ClaudeKey{Models: []internalconfig.ClaudeModel{{Name: "custom-model", Alias: "public-model", Thinking: configured}}})
+		}},
+		{name: "codex", build: func() []*ModelInfo {
+			return buildCodexConfigModels(&config.CodexKey{Models: []internalconfig.CodexModel{{Name: "custom-model", Alias: "public-model", Thinking: configured}}})
+		}},
+		{name: "xai", build: func() []*ModelInfo {
+			return buildXAIConfigModels(&config.XAIKey{Models: []internalconfig.XAIModel{{Name: "custom-model", Alias: "public-model", Thinking: configured}}})
+		}},
+		{name: "gemini", build: func() []*ModelInfo {
+			return buildGeminiConfigModels(&config.GeminiKey{Models: []internalconfig.GeminiModel{{Name: "custom-model", Alias: "public-model", Thinking: configured}}})
+		}},
+		{name: "vertex", build: func() []*ModelInfo {
+			return buildVertexCompatConfigModels(&config.VertexCompatKey{Models: []config.VertexCompatModel{{Name: "custom-model", Alias: "public-model", Thinking: configured}}})
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got *ModelInfo
+			for _, info := range tc.build() {
+				if info != nil && info.ID == "public-model" {
+					got = info
+					break
+				}
+			}
+			if got == nil || got.Thinking == nil || strings.Join(got.Thinking.Levels, ",") != "xhigh,high" {
+				t.Fatalf("registered model = %+v, want configured thinking levels", got)
+			}
+		})
+	}
+}
+
+func TestBuildGeminiStyleConfigModelsRebindsStaticResourceName(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func() []*ModelInfo
+	}{
+		{
+			name: "gemini",
+			build: func() []*ModelInfo {
+				return buildGeminiConfigModels(&config.GeminiKey{Models: []internalconfig.GeminiModel{{
+					Name: "gemini-2.5-flash", Alias: "public-flash",
+				}}})
+			},
+		},
+		{
+			name: "vertex",
+			build: func() []*ModelInfo {
+				return buildVertexCompatConfigModels(&config.VertexCompatKey{Models: []config.VertexCompatModel{{
+					Name: "gemini-2.5-flash", Alias: "public-flash",
+				}}})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			models := tc.build()
+			if len(models) != 1 || models[0] == nil {
+				t.Fatalf("registered models = %#v, want one configured alias", models)
+			}
+			if models[0].ID != "public-flash" || models[0].Name != "models/public-flash" {
+				t.Fatalf("configured identity = %#v, want alias-bound Gemini resource name", models[0])
+			}
+		})
+	}
+}
+
+func TestBuildNonImageProviderConfigModelsDoNotInheritStaticImageAPI(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func() []*ModelInfo
+	}{
+		{name: "claude", build: func() []*ModelInfo {
+			return buildClaudeConfigModels(&config.ClaudeKey{Models: []internalconfig.ClaudeModel{{Name: "gpt-image-2", Alias: "public-image"}}})
+		}},
+		{name: "gemini", build: func() []*ModelInfo {
+			return buildGeminiConfigModels(&config.GeminiKey{Models: []internalconfig.GeminiModel{{Name: "gpt-image-2", Alias: "public-image"}}})
+		}},
+		{name: "vertex", build: func() []*ModelInfo {
+			return buildVertexCompatConfigModels(&config.VertexCompatKey{Models: []config.VertexCompatModel{{Name: "gpt-image-2", Alias: "public-image"}}})
+		}},
+		{name: "xai foreign image", build: func() []*ModelInfo {
+			return buildXAIConfigModels(&config.XAIKey{Models: []internalconfig.XAIModel{{Name: "gpt-image-2", Alias: "public-image"}}})
+		}},
+		{name: "codex foreign image", build: func() []*ModelInfo {
+			return buildCodexConfigModels(&config.CodexKey{Models: []internalconfig.CodexModel{{Name: "grok-imagine-image", Alias: "public-image"}}})
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			models := tc.build()
+			var configured *ModelInfo
+			for _, model := range models {
+				if model != nil && model.ID == "public-image" {
+					configured = model
+					break
+				}
+			}
+			if configured == nil {
+				t.Fatalf("registered models = %+v, want configured alias", models)
+			}
+			if configured.SupportsImageAPI {
+				t.Fatalf("%s model inherited provider-specific image API support", tc.name)
+			}
+		})
+	}
+}
+
+func TestBuildOpenAICompatibilityConfigModelsFallsBackToStaticThinking(t *testing.T) {
+	const upstream = "gpt-5.6-luna"
+	static := internalregistry.LookupStaticModelInfo(upstream)
+	if static == nil || static.Thinking == nil {
+		t.Fatalf("static model %s has no thinking metadata", upstream)
+	}
+	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
+		Name:   "compat",
+		Models: []config.OpenAICompatibilityModel{{Name: upstream, Alias: "public-model"}},
+	})
+	if len(models) != 1 || models[0] == nil || models[0].Thinking == nil {
+		t.Fatalf("registered models = %+v, want static thinking metadata", models)
+	}
+	if got, want := strings.Join(models[0].Thinking.Levels, ","), strings.Join(static.Thinking.Levels, ","); got != want {
+		t.Fatalf("thinking levels = %q, want static levels %q", got, want)
+	}
+}
+
+func TestBuildOpenAICompatibilityImageModelUsesSuffixFreeStaticCapabilities(t *testing.T) {
+	const upstream = "gpt-5.6-luna(high)"
+	static := internalregistry.LookupStaticModelInfo("gpt-5.6-luna")
+	if static == nil || static.Thinking == nil {
+		t.Fatal("gpt-5.6-luna static thinking metadata is unavailable")
+	}
+	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
+		Name: "compat",
+		Models: []config.OpenAICompatibilityModel{{
+			Name: upstream, Alias: "public-image", Image: true,
+		}},
+	})
+	if len(models) != 1 || models[0] == nil || models[0].Thinking == nil || !models[0].SupportsImageAPI {
+		t.Fatalf("registered models = %+v, want static thinking and image support", models)
+	}
+	if got, want := strings.Join(models[0].Thinking.Levels, ","), strings.Join(static.Thinking.Levels, ","); got != want {
+		t.Fatalf("thinking levels = %q, want %q", got, want)
+	}
+}
+
+func TestBuildNativeImageConfigModelsUsesAliasAsUpstreamFallback(t *testing.T) {
+	tests := []struct {
+		name    string
+		modelID string
+		build   func() []*ModelInfo
+	}{
+		{
+			name:    "codex",
+			modelID: "gpt-image-2",
+			build: func() []*ModelInfo {
+				return buildCodexConfigModels(&config.CodexKey{Models: []internalconfig.CodexModel{{Alias: "gpt-image-2"}}})
+			},
+		},
+		{
+			name:    "xai",
+			modelID: "grok-imagine-image",
+			build: func() []*ModelInfo {
+				return buildXAIConfigModels(&config.XAIKey{Models: []internalconfig.XAIModel{{Alias: "grok-imagine-image"}}})
+			},
+		},
+		{
+			name:    "xai public alias",
+			modelID: "public-image",
+			build: func() []*ModelInfo {
+				return buildXAIConfigModels(&config.XAIKey{Models: []internalconfig.XAIModel{{
+					Name: "grok-imagine-image", Alias: "public-image",
+				}}})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var configured *ModelInfo
+			for _, model := range tc.build() {
+				if model != nil && model.ID == tc.modelID {
+					configured = model
+					break
+				}
+			}
+			if configured == nil || !configured.SupportsImageAPI {
+				t.Fatalf("registered model = %+v, want alias-only static image support", configured)
+			}
+		})
+	}
+}
+
+func TestRegisterModelsForAuth_NativeImageAliasRemainsNonChat(t *testing.T) {
+	tests := []struct {
+		name      string
+		provider  string
+		upstream  string
+		configure func(*config.Config, config.CodexKey)
+	}{
+		{
+			name:     "codex",
+			provider: "codex",
+			upstream: "gpt-image-2",
+			configure: func(cfg *config.Config, entry config.CodexKey) {
+				cfg.CodexKey = []config.CodexKey{entry}
+			},
+		},
+		{
+			name:     "xai",
+			provider: "xai",
+			upstream: "grok-imagine-image",
+			configure: func(cfg *config.Config, entry config.CodexKey) {
+				cfg.XAIKey = []config.XAIKey{entry}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			const (
+				apiKey = "test-key"
+				prefix = "tenant"
+				alias  = "public-image"
+			)
+			cfg := &config.Config{SDKConfig: config.SDKConfig{ForceModelPrefix: true}}
+			tc.configure(cfg, config.CodexKey{
+				APIKey: apiKey,
+				Prefix: prefix,
+				Models: []internalconfig.CodexModel{{Name: tc.upstream, Alias: alias}},
+			})
+			service := &Service{cfg: cfg}
+			auth := &coreauth.Auth{
+				ID:       "auth-native-image-alias-" + tc.name,
+				Provider: tc.provider,
+				Prefix:   prefix,
+				Status:   coreauth.StatusActive,
+				Attributes: map[string]string{
+					"auth_kind": "apikey",
+					"api_key":   apiKey,
+				},
+			}
+
+			modelRegistry := internalregistry.GetGlobalRegistry()
+			modelRegistry.UnregisterClient(auth.ID)
+			t.Cleanup(func() { modelRegistry.UnregisterClient(auth.ID) })
+			service.registerModelsForAuth(context.Background(), auth)
+
+			modelID := prefix + "/" + alias
+			info, supportsChat := modelRegistry.GetCatalogModelInfo(modelID)
+			if info == nil || !info.SupportsImageAPI || !info.ChatDisabled {
+				t.Fatalf("registered model = %#v, want native image-only metadata", info)
+			}
+			if supportsChat || modelRegistry.ClientModelSupportsChat(auth.ID, modelID) {
+				t.Fatalf("native image alias %q unexpectedly supports chat", modelID)
+			}
+			if !modelRegistry.ClientModelSupportsImageAPI(auth.ID, modelID) {
+				t.Fatalf("native image alias %q lost image execution support", modelID)
+			}
+		})
+	}
+}
+
+func TestRegisterModelsForAuth_NativeVideoAliasesRemainVideoOnly(t *testing.T) {
+	tests := []struct {
+		name       string
+		configure  func(*config.Config)
+		attributes map[string]string
+	}{
+		{
+			name: "api-key alias and prefix",
+			configure: func(cfg *config.Config) {
+				cfg.XAIKey = []config.XAIKey{{
+					APIKey: "test-key",
+					Prefix: "tenant",
+					Models: []internalconfig.CodexModel{{
+						Name:  "grok-imagine-video",
+						Alias: "public-video",
+					}},
+				}}
+			},
+			attributes: map[string]string{
+				"auth_kind": "apikey",
+				"api_key":   "test-key",
+			},
+		},
+		{
+			name: "oauth alias and prefix",
+			configure: func(cfg *config.Config) {
+				cfg.OAuthModelAlias = map[string][]internalconfig.OAuthModelAlias{
+					"xai": {{
+						Name:  "grok-imagine-video",
+						Alias: "public-video",
+					}},
+				}
+			},
+			attributes: map[string]string{"auth_kind": "oauth"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{SDKConfig: config.SDKConfig{ForceModelPrefix: true}}
+			tc.configure(cfg)
+			service := &Service{cfg: cfg}
+			auth := &coreauth.Auth{
+				ID:         "auth-native-video-" + strings.ReplaceAll(tc.name, " ", "-"),
+				Provider:   "xai",
+				Prefix:     "tenant",
+				Status:     coreauth.StatusActive,
+				Attributes: tc.attributes,
+			}
+
+			modelRegistry := internalregistry.GetGlobalRegistry()
+			modelRegistry.UnregisterClient(auth.ID)
+			t.Cleanup(func() { modelRegistry.UnregisterClient(auth.ID) })
+			service.registerModelsForAuth(context.Background(), auth)
+
+			const modelID = "tenant/public-video"
+			info, supportsChat := modelRegistry.GetCatalogModelInfo(modelID)
+			if info == nil || !info.SupportsVideoAPI || !info.ChatDisabled {
+				t.Fatalf("registered model = %#v, want native video-only metadata", info)
+			}
+			if supportsChat || modelRegistry.ClientModelSupportsChat(auth.ID, modelID) {
+				t.Fatalf("native video alias %q unexpectedly supports chat", modelID)
+			}
+			if !modelRegistry.ClientModelSupportsExecution(auth.ID, modelID, internalregistry.ModelExecutionVideo) {
+				t.Fatalf("native video alias %q lost video execution support", modelID)
+			}
+			if modelRegistry.ClientModelSupportsImageAPI(auth.ID, modelID) {
+				t.Fatalf("native video alias %q unexpectedly supports image execution", modelID)
+			}
+		})
+	}
+}
+
+func TestRegisterModelsForAuth_NativeAliasOnlyImageModelWithPrefix(t *testing.T) {
+	tests := []struct {
+		name      string
+		provider  string
+		modelID   string
+		configure func(*config.Config, config.CodexKey)
+	}{
+		{
+			name:     "codex",
+			provider: "codex",
+			modelID:  "gpt-image-2",
+			configure: func(cfg *config.Config, entry config.CodexKey) {
+				cfg.CodexKey = []config.CodexKey{entry}
+			},
+		},
+		{
+			name:     "xai",
+			provider: "xai",
+			modelID:  "grok-imagine-image",
+			configure: func(cfg *config.Config, entry config.CodexKey) {
+				cfg.XAIKey = []config.XAIKey{entry}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			const (
+				apiKey = "test-key"
+				prefix = "tenant"
+			)
+			cfg := &config.Config{SDKConfig: config.SDKConfig{ForceModelPrefix: true}}
+			tc.configure(cfg, config.CodexKey{
+				APIKey: apiKey,
+				Prefix: prefix,
+				Models: []internalconfig.CodexModel{{Alias: tc.modelID}},
+			})
+			service := &Service{cfg: cfg}
+			auth := &coreauth.Auth{
+				ID:       "auth-native-alias-only-" + tc.name,
+				Provider: tc.provider,
+				Prefix:   prefix,
+				Status:   coreauth.StatusActive,
+				Attributes: map[string]string{
+					"auth_kind": "apikey",
+					"api_key":   apiKey,
+				},
+			}
+
+			modelRegistry := internalregistry.GetGlobalRegistry()
+			modelRegistry.UnregisterClient(auth.ID)
+			t.Cleanup(func() { modelRegistry.UnregisterClient(auth.ID) })
+			service.registerModelsForAuth(context.Background(), auth)
+
+			prefixedModel := prefix + "/" + tc.modelID
+			if !modelRegistry.ClientSupportsModel(auth.ID, prefixedModel) {
+				t.Fatalf("prefixed alias-only model %q is not selectable", prefixedModel)
+			}
+			if !modelRegistry.ClientModelSupportsImageAPI(auth.ID, prefixedModel) {
+				t.Fatalf("prefixed alias-only model %q does not support image execution", prefixedModel)
+			}
+		})
+	}
+}
+
+func TestRegisterModelsForAuth_OpenAICompatibilityImageModelWithPrefix(t *testing.T) {
+	service := &Service{
+		cfg: &config.Config{
+			SDKConfig: config.SDKConfig{ForceModelPrefix: true},
+			OpenAICompatibility: []config.OpenAICompatibility{{
+				Name:    "images",
+				Prefix:  "tenant",
+				BaseURL: "https://example.com/v1",
+				Models: []config.OpenAICompatibilityModel{{
+					Name: "upstream-image", Alias: "compat-image", Image: true,
+				}},
+			}},
+		},
+	}
+	auth := &coreauth.Auth{
+		ID:       "auth-openai-compat-prefixed-image",
+		Provider: "openai-compatibility",
+		Prefix:   "tenant",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind":    "api_key",
+			"api_key":      "test-key",
+			"compat_name":  "images",
+			"provider_key": "images",
+		},
+	}
+
+	modelRegistry := internalregistry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(auth.ID)
+	t.Cleanup(func() { modelRegistry.UnregisterClient(auth.ID) })
+	service.registerModelsForAuth(context.Background(), auth)
+
+	var info *internalregistry.ModelInfo
+	for _, candidate := range modelRegistry.GetModelsForClient(auth.ID) {
+		if candidate != nil && candidate.ID == "tenant/compat-image" {
+			info = candidate
+			break
+		}
+	}
+	if info == nil {
+		t.Fatal("expected prefixed image model to be registered")
+	}
+	if info.Type != internalregistry.OpenAIImageModelType {
+		t.Fatalf("prefixed image model type = %q, want %q", info.Type, internalregistry.OpenAIImageModelType)
+	}
+	if !info.SupportsImageAPI {
+		t.Fatal("expected prefixed image model to support the image API")
+	}
+	if !modelRegistry.ClientSupportsModel(auth.ID, "tenant/compat-image") {
+		t.Fatal("prefixed image model is not selectable for its configured auth")
 	}
 }
 

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/constant"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/modelconfig"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
@@ -577,7 +578,7 @@ func applyModelPrefixes(models []*ModelInfo, prefix string, forceModelPrefix boo
 			addModel(model)
 		}
 		clone := *model
-		clone.ID = trimmedPrefix + "/" + baseID
+		modelconfig.RebindModelInfo(&clone, baseID, trimmedPrefix+"/"+baseID)
 		addModel(&clone)
 	}
 	return out
@@ -631,9 +632,10 @@ type modelEntry interface {
 	GetName() string
 	GetAlias() string
 	GetDisplayName() string
+	GetThinking() *registry.ThinkingSupport
 }
 
-func buildConfiguredModelInfo(model modelEntry, ownedBy, modelType string, created int64, fallbackDisplayName string, userDefined bool) *ModelInfo {
+func buildConfiguredModelInfo(model modelEntry, ownedBy, modelType, provider string, created int64, fallbackDisplayName string, userDefined bool) *ModelInfo {
 	name := strings.TrimSpace(model.GetName())
 	alias := strings.TrimSpace(model.GetAlias())
 	if alias == "" {
@@ -642,6 +644,9 @@ func buildConfiguredModelInfo(model modelEntry, ownedBy, modelType string, creat
 	if alias == "" {
 		return nil
 	}
+	if name == "" {
+		name = alias
+	}
 	displayName := strings.TrimSpace(model.GetDisplayName())
 	if displayName == "" {
 		displayName = fallbackDisplayName
@@ -649,15 +654,15 @@ func buildConfiguredModelInfo(model modelEntry, ownedBy, modelType string, creat
 	if displayName == "" {
 		displayName = alias
 	}
-	return &ModelInfo{
-		ID:          alias,
-		Object:      "model",
-		Created:     created,
-		OwnedBy:     ownedBy,
-		Type:        modelType,
-		DisplayName: displayName,
-		UserDefined: userDefined,
-	}
+	info := modelconfig.ResolveModelInfoForProvider(name, modelType, provider, model.GetThinking())
+	modelconfig.RebindModelInfo(info, name, alias)
+	info.Object = "model"
+	info.Created = created
+	info.OwnedBy = ownedBy
+	info.Type = modelType
+	info.DisplayName = displayName
+	info.UserDefined = userDefined
+	return info
 }
 
 func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []*ModelInfo {
@@ -665,53 +670,64 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		return nil
 	}
 	now := time.Now().Unix()
-	models := make([]*ModelInfo, 0, len(compat.Models))
+	type aliasGroup struct {
+		firstIndex int
+		chatIndex  int
+		image      bool
+	}
+	groups := make(map[string]*aliasGroup)
+	order := make([]string, 0, len(compat.Models))
 	for i := range compat.Models {
 		model := compat.Models[i]
-		modelType := "openai-compatibility"
-		if model.Image {
-			modelType = registry.OpenAIImageModelType
+		modelID := strings.TrimSpace(model.Alias)
+		if modelID == "" {
+			modelID = strings.TrimSpace(model.Name)
 		}
-		info := buildConfiguredModelInfo(model, compat.Name, modelType, now, strings.TrimSpace(model.Alias), false)
+		if modelID == "" {
+			continue
+		}
+		key := strings.ToLower(modelID)
+		group := groups[key]
+		if group == nil {
+			group = &aliasGroup{firstIndex: i, chatIndex: -1}
+			groups[key] = group
+			order = append(order, key)
+		}
+		if model.Image {
+			group.image = true
+		} else if group.chatIndex < 0 {
+			group.chatIndex = i
+		}
+	}
+
+	models := make([]*ModelInfo, 0, len(order))
+	for _, key := range order {
+		group := groups[key]
+		modelIndex := group.firstIndex
+		if group.chatIndex >= 0 {
+			modelIndex = group.chatIndex
+		}
+		model := compat.Models[modelIndex]
+		info := buildConfiguredModelInfo(model, compat.Name, "openai-compatibility", "openai-compatibility", now, strings.TrimSpace(model.Alias), false)
 		if info == nil {
 			continue
 		}
-		thinking := model.Thinking
-		if thinking == nil && !model.Image {
-			thinking = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+		info.SupportsImageAPI = group.image
+		if group.image && group.chatIndex < 0 {
+			info.Type = registry.OpenAIImageModelType
+			info.ChatDisabled = true
 		}
-		info.Thinking = thinking
-		info.SupportedInputModalities = normalizeCompatConfigModalities(model.InputModalities)
-		info.SupportedOutputModalities = normalizeCompatConfigModalities(model.OutputModalities)
+		if info.Thinking == nil && !model.Image {
+			info.Thinking = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+		}
+		info.SupportedInputModalities = modelconfig.NormalizeModalities(model.InputModalities)
+		info.SupportedOutputModalities = modelconfig.NormalizeModalities(model.OutputModalities)
 		models = append(models, info)
 	}
 	return models
 }
 
-func normalizeCompatConfigModalities(raw []string) []string {
-	if len(raw) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(raw))
-	seen := make(map[string]struct{}, len(raw))
-	for _, item := range raw {
-		modality := strings.ToLower(strings.TrimSpace(item))
-		if modality == "" {
-			continue
-		}
-		if _, exists := seen[modality]; exists {
-			continue
-		}
-		seen[modality] = struct{}{}
-		out = append(out, modality)
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
-func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*ModelInfo {
+func buildConfigModels[T modelEntry](models []T, ownedBy, modelType, provider string) []*ModelInfo {
 	if len(models) == 0 {
 		return nil
 	}
@@ -720,8 +736,7 @@ func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*M
 	seen := make(map[string]struct{}, len(models))
 	for i := range models {
 		model := models[i]
-		name := strings.TrimSpace(model.GetName())
-		info := buildConfiguredModelInfo(model, ownedBy, modelType, now, name, true)
+		info := buildConfiguredModelInfo(model, ownedBy, modelType, provider, now, strings.TrimSpace(model.GetName()), true)
 		if info == nil {
 			continue
 		}
@@ -731,11 +746,6 @@ func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*M
 			continue
 		}
 		seen[key] = struct{}{}
-		if name != "" {
-			if upstream := registry.LookupStaticModelInfo(name); upstream != nil && upstream.Thinking != nil {
-				info.Thinking = upstream.Thinking
-			}
-		}
 		out = append(out, info)
 	}
 	return out
@@ -745,28 +755,28 @@ func buildVertexCompatConfigModels(entry *config.VertexCompatKey) []*ModelInfo {
 	if entry == nil {
 		return nil
 	}
-	return buildConfigModels(entry.Models, "google", "vertex")
+	return buildConfigModels(entry.Models, "google", "vertex", "vertex")
 }
 
 func buildGeminiConfigModels(entry *config.GeminiKey) []*ModelInfo {
 	if entry == nil {
 		return nil
 	}
-	return buildConfigModels(entry.Models, "google", "gemini")
+	return buildConfigModels(entry.Models, "google", "gemini", "gemini")
 }
 
 func buildClaudeConfigModels(entry *config.ClaudeKey) []*ModelInfo {
 	if entry == nil {
 		return nil
 	}
-	return buildConfigModels(entry.Models, "anthropic", "claude")
+	return buildConfigModels(entry.Models, "anthropic", "claude", "claude")
 }
 
 func buildXAIConfigModels(entry *config.XAIKey) []*ModelInfo {
 	if entry == nil {
 		return nil
 	}
-	return buildConfigModels(entry.Models, "xai", "xai")
+	return buildConfigModels(entry.Models, "xai", "xai", "xai")
 }
 
 func buildCodexConfigModels(entry *config.CodexKey) []*ModelInfo {
@@ -774,7 +784,7 @@ func buildCodexConfigModels(entry *config.CodexKey) []*ModelInfo {
 		return nil
 	}
 
-	models := registry.WithCodexBuiltins(buildConfigModels(entry.Models, "openai", "openai"))
+	models := registry.WithCodexBuiltins(buildConfigModels(entry.Models, "openai", "openai", "codex"))
 	configuredDisplayNames := make(map[string]string, len(entry.Models))
 	seenConfiguredModels := make(map[string]struct{}, len(entry.Models))
 	for i := range entry.Models {
@@ -806,32 +816,6 @@ func buildCodexConfigModels(entry *config.CodexKey) []*ModelInfo {
 		}
 	}
 	return models
-}
-
-func rewriteModelInfoName(name, oldID, newID string) string {
-	trimmed := strings.TrimSpace(name)
-	if trimmed == "" {
-		return name
-	}
-	oldID = strings.TrimSpace(oldID)
-	newID = strings.TrimSpace(newID)
-	if oldID == "" || newID == "" {
-		return name
-	}
-	if strings.EqualFold(oldID, newID) {
-		return name
-	}
-	if strings.EqualFold(trimmed, oldID) {
-		return newID
-	}
-	if strings.HasSuffix(trimmed, "/"+oldID) {
-		prefix := strings.TrimSuffix(trimmed, oldID)
-		return prefix + newID
-	}
-	if trimmed == "models/"+oldID {
-		return "models/" + newID
-	}
-	return name
 }
 
 func applyOAuthModelAlias(cfg *config.Config, provider, authKind string, models []*ModelInfo) []*ModelInfo {
@@ -964,12 +948,9 @@ func applyOAuthModelAliasEntries(aliases []config.OAuthModelAlias, models []*Mod
 			}
 			seen[aliasKey] = struct{}{}
 			clone := *model
-			clone.ID = mappedID
+			modelconfig.RebindModelInfo(&clone, id, mappedID)
 			if entry.displayName != "" {
 				clone.DisplayName = entry.displayName
-			}
-			if clone.Name != "" {
-				clone.Name = rewriteModelInfoName(clone.Name, id, mappedID)
 			}
 			out = append(out, &clone)
 			addedAlias = true


### PR DESCRIPTION
## Summary

Configured provider models can be exposed with a prefix while executors send the unprefixed upstream model name. A global registry lookup cannot identify the exact auth, configured upstream entry, or endpoint kind selected for one attempt, so prefixed requests could receive unrelated static capabilities.

This change:

- compiles config-backed aliases and model capabilities into one immutable routing snapshot keyed by auth ID
- binds the exact configured model definition to each selected upstream attempt
- adds configured thinking support for Gemini, Interactions, Claude, Codex, xAI, and Vertex-compatible API-key providers
- applies the same exact per-auth binding to OpenAI-compatible providers, including keyless configured entries
- resolves configured catalog and execution metadata through one suffix-free static-capability path
- preserves prefixed OpenAI-compatible `image: true` discovery and provider-scoped native Codex/xAI image and video capabilities
- filters local and plugin-scheduler candidates by the exact auth registration and requested chat, image, or video endpoint
- keeps OAuth and unbound requests on the existing registry-based thinking path when no exact configured-model binding exists

## Failure Examples Without This Change

A prefixed API-key request can select the correct upstream model but fail to match its configured capabilities during execution.

For example, with `force-model-prefix: true`, provider prefix `sp-anthropic`, and configured model `claude-opus-4-6`, a client request for `sp-anthropic/claude-opus-4-6` reaches the executor as `claude-opus-4-6`. A global lookup can miss the provider-specific thinking levels, causing `xhigh` or `max` to be mapped, rejected, or removed using unrelated metadata.

A suffixed configured upstream such as `gpt-5.6-luna(high)` can also lose static `xhigh` and `max` catalog capabilities if static lookup uses the suffixed name while execution uses the base name.

Likewise, when image-capable, video-capable, and chat-only registrations expose the same model ID, aggregate validation alone can admit the request and then select an auth that does not support the requested endpoint. Selection must check the exact client registration.

## Implementation

- Builds one immutable routing snapshot keyed by auth ID from a deep-cloned runtime config.
- Carries the selected configured model metadata through candidate selection and execution.
- Uses one configured-model resolver for suffix-free static lookup, explicit thinking overrides, modality normalization, and provider-scoped endpoint capabilities.
- Maps cross-family high intent using `xhigh -> xhigh, max, high` and `max -> max, xhigh, high`.
- Keeps same-family validation strict and preserves the legacy registry-based thinking path when no configured model is resolved.
- Supports config-backed OpenAI-compatible routing even when the configured provider does not require an API key.
- Restricts chat, image, and video candidates before normal local scheduling and plugin-delegated built-in scheduling.
- Validates known Home-dispatched registrations before executor entry and advances the Home count when the selected auth does not support the requested endpoint.
- Preserves native Codex and xAI image/video-only metadata through aliases and prefixes while keeping shared chat-capable registrations visible in model catalogs.
- Includes thinking and endpoint-related model metadata in watcher hashes so capability-only edits reload correctly.

## Validation

- `go test ./... -count=1`
- targeted `go test -race` across registry, thinking, executor helpers, and auth routing
- `go build ./cmd/server`
- stream, non-stream, token-count, repeated alias pool, prefix, hot-reload, catalog, plugin scheduler, image routing, and video routing regression tests

Supersedes #4215. This pull request contains the same final change rebased onto the latest `dev` branch.