### PR TITLE
fix(antigravity): preserve capped Gemini maxOutputTokens

### DIFF
--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -3,12 +3,14 @@ package executor
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 )
@@ -284,6 +286,158 @@ func TestAntigravityBuildRequest_RejectsMissingProjectID(t *testing.T) {
 	}
 }
 
+func TestAntigravityBuildRequest_CapsMaxOutputTokensWithSchemaSanitization(t *testing.T) {
+	clientID := "test-client-antigravity-cap"
+	modelName := "gemini-test-cap-64-model"
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(clientID, "antigravity", []*registry.ModelInfo{
+		{
+			ID:                  modelName,
+			MaxCompletionTokens: 64,
+		},
+	})
+	t.Cleanup(func() {
+		reg.UnregisterClient(clientID)
+	})
+
+	body := buildRequestBodyFromRawPayload(t, modelName, []byte(`{
+		"request": {
+			"generationConfig": {
+				"maxOutputTokens": 128
+			},
+			"tools": [
+				{
+					"function_declarations": [
+						{
+							"name": "test_tool",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"query": {"type": "string"}
+								}
+							}
+						}
+					]
+				}
+			]
+		}
+	}`))
+
+	generationConfig := extractGenerationConfig(t, body)
+	if got, ok := generationConfig["maxOutputTokens"].(float64); !ok || got != 64 {
+		t.Fatalf("maxOutputTokens = %v, want 64", generationConfig["maxOutputTokens"])
+	}
+}
+
+func TestAntigravityBuildRequest_CapsMaxOutputTokensWithoutSchemaSanitization(t *testing.T) {
+	clientID := "test-client-antigravity-cap-table"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(clientID, "antigravity", []*registry.ModelInfo{
+		{ID: "cap-max-completion-100", MaxCompletionTokens: 100},
+		{ID: "cap-output-limit-200", OutputTokenLimit: 200},
+		{ID: "cap-both-300-500", OutputTokenLimit: 300, MaxCompletionTokens: 500},
+	})
+	t.Cleanup(func() {
+		reg.UnregisterClient(clientID)
+	})
+
+	tests := []struct {
+		name      string
+		modelName string
+		value     string
+		want      float64
+	}{
+		{name: "above max completion tokens", modelName: "cap-max-completion-100", value: "500", want: 100},
+		{name: "below limit", modelName: "cap-max-completion-100", value: "50", want: 50},
+		{name: "at limit", modelName: "cap-max-completion-100", value: "100", want: 100},
+		{name: "very large integer", modelName: "cap-max-completion-100", value: "18446744073709551615", want: 100},
+		{name: "output token limit only", modelName: "cap-output-limit-200", value: "500", want: 200},
+		{name: "output token limit preferred", modelName: "cap-both-300-500", value: "400", want: 300},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := []byte(`{"request":{"generationConfig":{"maxOutputTokens":` + tt.value + `}}}`)
+			body := buildRequestBodyFromRawPayload(t, tt.modelName, payload)
+			generationConfig := extractGenerationConfig(t, body)
+			if got, ok := generationConfig["maxOutputTokens"].(float64); !ok || got != tt.want {
+				t.Errorf("maxOutputTokens = %v, want %v", generationConfig["maxOutputTokens"], tt.want)
+			}
+		})
+	}
+}
+
+func TestAntigravityBuildRequest_CapsClaudeThinkingBudget(t *testing.T) {
+	clientID := "test-client-antigravity-claude-cap"
+	modelName := "claude-test-cap-64-model"
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(clientID, "antigravity", []*registry.ModelInfo{
+		{
+			ID:                  modelName,
+			MaxCompletionTokens: 64,
+			Thinking: &registry.ThinkingSupport{
+				Min: 8,
+				Max: 64,
+			},
+		},
+	})
+	t.Cleanup(func() {
+		reg.UnregisterClient(clientID)
+	})
+
+	tests := []struct {
+		name         string
+		maxOut       int
+		budget       int
+		wantMax      float64
+		wantBudget   float64
+		wantNoConfig bool
+	}{
+		{name: "caps budget below capped output", maxOut: 128, budget: 64, wantMax: 64, wantBudget: 63},
+		{name: "preserves valid lower budget", maxOut: 128, budget: 32, wantMax: 64, wantBudget: 32},
+		{name: "removes config below minimum", maxOut: 8, budget: 8, wantMax: 8, wantNoConfig: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := fmt.Sprintf(`{"request":{"generationConfig":{"maxOutputTokens":%d,"thinkingConfig":{"thinkingBudget":%d}}}}`, tt.maxOut, tt.budget)
+			body := buildRequestBodyFromRawPayload(t, modelName, []byte(payload))
+			generationConfig := extractGenerationConfig(t, body)
+			if got, ok := generationConfig["maxOutputTokens"].(float64); !ok || got != tt.wantMax {
+				t.Errorf("maxOutputTokens = %v, want %v", generationConfig["maxOutputTokens"], tt.wantMax)
+			}
+			tc, ok := generationConfig["thinkingConfig"].(map[string]any)
+			if tt.wantNoConfig {
+				if ok && tc != nil {
+					t.Errorf("thinkingConfig should be removed, got %v", tc)
+				}
+			} else {
+				if !ok || tc == nil {
+					t.Fatalf("thinkingConfig missing or invalid type")
+				}
+				if got, ok := tc["thinkingBudget"].(float64); !ok || got != tt.wantBudget {
+					t.Errorf("thinkingBudget = %v, want %v", tc["thinkingBudget"], tt.wantBudget)
+				}
+			}
+		})
+	}
+}
+
+func extractGenerationConfig(t *testing.T, body map[string]any) map[string]any {
+	t.Helper()
+	request, ok := body["request"].(map[string]any)
+	if !ok {
+		t.Fatalf("request missing or invalid type")
+	}
+	generationConfig, ok := request["generationConfig"].(map[string]any)
+	if !ok {
+		t.Fatalf("generationConfig missing or invalid type")
+	}
+	return generationConfig
+}
+
 func assertNonSchemaRequestPreserved(t *testing.T, body map[string]any) {
 	t.Helper()
 
@@ -315,10 +469,12 @@ func assertNonSchemaRequestPreserved(t *testing.T, body map[string]any) {
 		t.Fatalf("x-extra should be preserved outside schema cleanup path, got=%v", nonSchema["x-extra"])
 	}
 
-	if generationConfig, ok := request["generationConfig"].(map[string]any); ok {
-		if _, ok := generationConfig["maxOutputTokens"]; ok {
-			t.Fatalf("maxOutputTokens should still be removed for non-Claude requests")
-		}
+	generationConfig, ok := request["generationConfig"].(map[string]any)
+	if !ok {
+		t.Fatalf("generationConfig missing or invalid type")
+	}
+	if got, ok := generationConfig["maxOutputTokens"].(float64); !ok || got != 128 {
+		t.Fatalf("maxOutputTokens = %v, want 128", generationConfig["maxOutputTokens"])
 	}
 }
 

--- a/internal/runtime/executor/antigravity_executor_request.go
+++ b/internal/runtime/executor/antigravity_executor_request.go
@@ -58,14 +58,8 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 	}
 	payload = geminiToAntigravity(modelName, payload, projectID, derivedSessionIDs...)
 
-	// Cap maxOutputTokens to model's max_completion_tokens from registry
-	if maxOut := gjson.GetBytes(payload, "request.generationConfig.maxOutputTokens"); maxOut.Exists() && maxOut.Type == gjson.Number {
-		if modelInfo := registry.LookupModelInfo(modelName, "antigravity"); modelInfo != nil && modelInfo.MaxCompletionTokens > 0 {
-			if int(maxOut.Int()) > modelInfo.MaxCompletionTokens {
-				payload, _ = sjson.SetBytes(payload, "request.generationConfig.maxOutputTokens", modelInfo.MaxCompletionTokens)
-			}
-		}
-	}
+	payload = capAntigravityMaxOutputTokens(payload, modelName)
+	payload = capAntigravityClaudeThinkingBudget(payload, modelName)
 
 	useAntigravitySchema := strings.Contains(modelName, "claude") || strings.Contains(modelName, "gemini-3-pro") || strings.Contains(modelName, "gemini-3.1-pro")
 	var (
@@ -78,8 +72,6 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 		if strings.Contains(modelName, "claude") {
 			updated, _ := sjson.SetBytes([]byte(payloadStr), "request.toolConfig.functionCallingConfig.mode", "VALIDATED")
 			payloadStr = string(updated)
-		} else {
-			payloadStr, _ = sjson.Delete(payloadStr, "request.generationConfig.maxOutputTokens")
 		}
 
 		payloadStrBytes := applyAntigravityNativeSignatureReplayIfNeeded(modelName, []byte(payloadStr))
@@ -90,8 +82,6 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 	} else {
 		if strings.Contains(modelName, "claude") {
 			payload, _ = sjson.SetBytes(payload, "request.toolConfig.functionCallingConfig.mode", "VALIDATED")
-		} else {
-			payload, _ = sjson.DeleteBytes(payload, "request.generationConfig.maxOutputTokens")
 		}
 
 		payload = applyAntigravityNativeSignatureReplayIfNeeded(modelName, payload)
@@ -291,6 +281,62 @@ func antigravityRequestNeedsSchemaSanitization(payload []byte) bool {
 	}
 	return false
 }
+
+func capAntigravityMaxOutputTokens(payload []byte, modelName string) []byte {
+	maxOut := gjson.GetBytes(payload, "request.generationConfig.maxOutputTokens")
+	if !maxOut.Exists() || maxOut.Type != gjson.Number {
+		return payload
+	}
+	modelInfo := registry.LookupModelInfo(modelName, "antigravity")
+	if modelInfo == nil {
+		return payload
+	}
+	limit := modelInfo.OutputTokenLimit
+	if limit <= 0 {
+		limit = modelInfo.MaxCompletionTokens
+	}
+	if limit <= 0 {
+		return payload
+	}
+	if maxOut.Num > float64(limit) {
+		payload, _ = sjson.SetBytes(payload, "request.generationConfig.maxOutputTokens", limit)
+	}
+	return payload
+}
+
+func capAntigravityClaudeThinkingBudget(payload []byte, modelName string) []byte {
+	if !strings.Contains(strings.ToLower(modelName), "claude") {
+		return payload
+	}
+	modelInfo := registry.LookupModelInfo(modelName, "antigravity")
+	if modelInfo == nil {
+		return payload
+	}
+	maxOut := gjson.GetBytes(payload, "request.generationConfig.maxOutputTokens")
+	if !maxOut.Exists() || maxOut.Type != gjson.Number {
+		return payload
+	}
+	maxNum := maxOut.Num
+	maxInt := int64(maxNum)
+	if maxNum <= 0 || float64(maxInt) != maxNum {
+		return payload
+	}
+	budget := gjson.GetBytes(payload, "request.generationConfig.thinkingConfig.thinkingBudget")
+	if !budget.Exists() || budget.Type != gjson.Number {
+		return payload
+	}
+	if budget.Num < maxNum {
+		return payload
+	}
+	newBudget := maxInt - 1
+	if modelInfo.Thinking != nil && modelInfo.Thinking.Min > 0 && newBudget < int64(modelInfo.Thinking.Min) {
+		payload, _ = sjson.DeleteBytes(payload, "request.generationConfig.thinkingConfig")
+		return payload
+	}
+	payload, _ = sjson.SetBytes(payload, "request.generationConfig.thinkingConfig.thinkingBudget", newBudget)
+	return payload
+}
+
 func buildBaseURL(auth *cliproxyauth.Auth) string {
 	if baseURLs := antigravityBaseURLFallbackOrder(auth); len(baseURLs) > 0 {
 		return baseURLs[0]


### PR DESCRIPTION
## Summary

- preserve `request.generationConfig.maxOutputTokens` for Gemini/non-Claude Antigravity requests instead of deleting it after request construction
- keep registry-backed upper-bound enforcement for both schema-sanitized and no-tool requests
- use `OutputTokenLimit` with `MaxCompletionTokens` fallback, matching the Gemini executor's registry semantics
- compare numeric values without narrowing through `int`, so very large JSON integers cannot bypass the cap
- after the final cap, keep Claude `thinkingBudget` strictly below `maxOutputTokens` (or remove an impossible below-minimum thinking config)

## Rationale

Native Antigravity currently accepts and enforces this field for `gemini-3.6-flash-high`:

- `maxOutputTokens: 16` returned HTTP 200 with `finishReason: MAX_TOKENS`
- `maxOutputTokens: 65536` returned HTTP 200 with `finishReason: STOP`
- `maxOutputTokens: 128000` was accepted by the upstream backend

The shared model catalog defines `max_completion_tokens: 65536` for this model, so preserving the field and applying the registry cap matches the native protocol while keeping requests within the configured model limit.

An exact-source local CPA live check confirmed:

- incoming `96` -> Antigravity upstream `96`
- incoming `128000` -> Antigravity upstream `65536`
- streaming incoming `128000` -> Antigravity upstream `65536`

All live requests routed through `provider=antigravity` and returned HTTP 200.

The audit also reproduced a Claude boundary failure: applying thinking first and capping afterward could turn `maxOutputTokens: 128000` plus `thinkingBudget: 64000` into an invalid final pair of `64000`/`64000`. The final request guard now emits `64000`/`63999`, preserving the upstream requirement that max output be strictly greater than the thinking budget.

## Tests

- `go test -race -run 'TestAntigravityBuildRequest_(CapsMaxOutputTokensWithSchemaSanitization|CapsMaxOutputTokensWithoutSchemaSanitization|CapsClaudeThinkingBudget|SkipsSchemaSanitization)' ./internal/runtime/executor/...`
- `go test ./...`
- `go build -o test-output ./cmd/server && rm test-output`
