### PR TITLE
fix(auth): add rate limiting and jitter for scheduled refreshes

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -187,6 +187,15 @@ video-result-auth-cache-ttl: "3h"
 # When > 0, overrides the default worker count (16).
 # auth-auto-refresh-workers: 16
 
+# Maximum number of scheduled OAuth/file-based auth refreshes per minute.
+# 0 keeps the legacy unlimited behavior. Request-triggered 401 refreshes are not limited.
+# auth-auto-refresh-max-per-minute: 0
+
+# Spread scheduled auth refreshes earlier by a deterministic per-auth offset.
+# This helps avoid synchronized refresh bursts when many credentials expire together.
+# 0 keeps the legacy schedule without jitter.
+# auth-auto-refresh-jitter-seconds: 0
+
 # Quota exceeded behavior
 quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,12 @@ type Config struct {
 	// AuthAutoRefreshWorkers overrides the size of the core auth auto-refresh worker pool.
 	// When <= 0, the default worker count is used.
 	AuthAutoRefreshWorkers int `yaml:"auth-auto-refresh-workers" json:"auth-auto-refresh-workers"`
+	// AuthAutoRefreshMaxPerMinute limits scheduled OAuth/file-based auth refreshes.
+	// When <= 0, scheduled refreshes are not rate limited.
+	AuthAutoRefreshMaxPerMinute int `yaml:"auth-auto-refresh-max-per-minute" json:"auth-auto-refresh-max-per-minute"`
+	// AuthAutoRefreshJitterSeconds spreads scheduled refreshes earlier by a stable,
+	// per-auth offset. When <= 0, scheduled refreshes are not jittered.
+	AuthAutoRefreshJitterSeconds int `yaml:"auth-auto-refresh-jitter-seconds" json:"auth-auto-refresh-jitter-seconds"`
 
 	// RequestRetry defines the retry times when the request failed.
 	RequestRetry int `yaml:"request-retry" json:"request-retry"`

--- a/sdk/cliproxy/auth/auto_refresh_loop.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"container/heap"
 	"context"
+	"hash/fnv"
 	"strings"
 	"sync"
 	"time"
@@ -11,9 +12,11 @@ import (
 )
 
 type authAutoRefreshLoop struct {
-	manager     *Manager
-	interval    time.Duration
-	concurrency int
+	manager      *Manager
+	interval     time.Duration
+	concurrency  int
+	maxPerMinute int
+	jitter       time.Duration
 
 	mu    sync.Mutex
 	queue refreshMinHeap
@@ -25,6 +28,10 @@ type authAutoRefreshLoop struct {
 }
 
 func newAuthAutoRefreshLoop(manager *Manager, interval time.Duration, concurrency int) *authAutoRefreshLoop {
+	return newAuthAutoRefreshLoopWithSmoothing(manager, interval, concurrency, 0, 0)
+}
+
+func newAuthAutoRefreshLoopWithSmoothing(manager *Manager, interval time.Duration, concurrency, maxPerMinute int, jitter time.Duration) *authAutoRefreshLoop {
 	if interval <= 0 {
 		interval = refreshCheckInterval
 	}
@@ -36,13 +43,15 @@ func newAuthAutoRefreshLoop(manager *Manager, interval time.Duration, concurrenc
 		jobBuffer = 64
 	}
 	return &authAutoRefreshLoop{
-		manager:     manager,
-		interval:    interval,
-		concurrency: concurrency,
-		index:       make(map[string]*refreshHeapItem),
-		dirty:       make(map[string]struct{}),
-		wakeCh:      make(chan struct{}, 1),
-		jobs:        make(chan string, jobBuffer),
+		manager:      manager,
+		interval:     interval,
+		concurrency:  concurrency,
+		maxPerMinute: maxPerMinute,
+		jitter:       jitter,
+		index:        make(map[string]*refreshHeapItem),
+		dirty:        make(map[string]struct{}),
+		wakeCh:       make(chan struct{}, 1),
+		jobs:         make(chan string, jobBuffer),
 	}
 }
 
@@ -68,14 +77,21 @@ func (l *authAutoRefreshLoop) run(ctx context.Context) {
 	if workers <= 0 {
 		workers = refreshMaxConcurrency
 	}
+	var rateCh <-chan time.Time
+	var ticker *time.Ticker
+	if spacing := refreshRateInterval(l.maxPerMinute); spacing > 0 {
+		ticker = time.NewTicker(spacing)
+		rateCh = ticker.C
+		defer ticker.Stop()
+	}
 	for i := 0; i < workers; i++ {
-		go l.worker(ctx)
+		go l.worker(ctx, rateCh)
 	}
 
 	l.loop(ctx)
 }
 
-func (l *authAutoRefreshLoop) worker(ctx context.Context) {
+func (l *authAutoRefreshLoop) worker(ctx context.Context, rateCh <-chan time.Time) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -83,6 +99,13 @@ func (l *authAutoRefreshLoop) worker(ctx context.Context) {
 		case authID := <-l.jobs:
 			if authID == "" {
 				continue
+			}
+			if rateCh != nil {
+				select {
+				case <-ctx.Done():
+					return
+				case <-rateCh:
+				}
 			}
 			l.manager.refreshAuth(ctx, authID)
 			l.queueReschedule(authID)
@@ -100,7 +123,7 @@ func (l *authAutoRefreshLoop) rebuild(now time.Time) {
 
 	l.manager.mu.RLock()
 	for id, auth := range l.manager.auths {
-		next, ok := nextRefreshCheckAt(now, auth, l.interval)
+		next, ok := nextRefreshCheckAtWithJitter(now, auth, l.interval, l.jitter)
 		if !ok {
 			continue
 		}
@@ -231,8 +254,8 @@ func (l *authAutoRefreshLoop) handleDueAuth(ctx context.Context, now time.Time, 
 		manager.mu.RUnlock()
 		return
 	}
-	next, shouldSchedule := nextRefreshCheckAt(now, auth, l.interval)
-	shouldRefresh := manager.shouldRefresh(auth, now)
+	next, shouldSchedule := nextRefreshCheckAtWithJitter(now, auth, l.interval, l.jitter)
+	shouldRefresh := manager.shouldRefresh(auth, now) || refreshDueWithJitter(now, auth, l.interval, l.jitter)
 	exec := manager.executors[auth.Provider]
 	manager.mu.RUnlock()
 
@@ -254,7 +277,7 @@ func (l *authAutoRefreshLoop) handleDueAuth(ctx context.Context, now time.Time, 
 	if !manager.markRefreshPending(authID, now) {
 		manager.mu.RLock()
 		auth = manager.auths[authID]
-		next, shouldSchedule = nextRefreshCheckAt(now, auth, l.interval)
+		next, shouldSchedule = nextRefreshCheckAtWithJitter(now, auth, l.interval, l.jitter)
 		manager.mu.RUnlock()
 		if shouldSchedule {
 			l.upsert(authID, next)
@@ -280,7 +303,7 @@ func (l *authAutoRefreshLoop) applyDirty(now time.Time) {
 	for _, authID := range dirty {
 		l.manager.mu.RLock()
 		auth := l.manager.auths[authID]
-		next, ok := nextRefreshCheckAt(now, auth, l.interval)
+		next, ok := nextRefreshCheckAtWithJitter(now, auth, l.interval, l.jitter)
 		l.manager.mu.RUnlock()
 
 		if !ok {
@@ -333,6 +356,65 @@ func (l *authAutoRefreshLoop) remove(authID string) {
 	}
 	heap.Remove(&l.queue, item.index)
 	delete(l.index, authID)
+}
+
+func refreshRateInterval(maxPerMinute int) time.Duration {
+	if maxPerMinute <= 0 {
+		return 0
+	}
+	spacing := time.Minute / time.Duration(maxPerMinute)
+	if spacing < time.Millisecond {
+		return time.Millisecond
+	}
+	return spacing
+}
+
+func nextRefreshCheckAtWithJitter(now time.Time, auth *Auth, interval, maxJitter time.Duration) (time.Time, bool) {
+	next, ok := nextRefreshCheckAt(now, auth, interval)
+	if !ok || !next.After(now) {
+		return next, ok
+	}
+	offset := scheduledRefreshJitter(auth, maxJitter)
+	if offset <= 0 {
+		return next, ok
+	}
+	jittered := next.Add(-offset)
+	if jittered.Before(now) {
+		return now, ok
+	}
+	return jittered, ok
+}
+
+func refreshDueWithJitter(now time.Time, auth *Auth, interval, maxJitter time.Duration) bool {
+	if auth == nil || maxJitter <= 0 {
+		return false
+	}
+	next, ok := nextRefreshCheckAt(now, auth, interval)
+	if !ok || !next.After(now) {
+		return false
+	}
+	offset := scheduledRefreshJitter(auth, maxJitter)
+	return offset > 0 && !next.Add(-offset).After(now)
+}
+
+func scheduledRefreshJitter(auth *Auth, maxJitter time.Duration) time.Duration {
+	if auth == nil || maxJitter <= 0 || !auth.NextRefreshAfter.IsZero() {
+		return 0
+	}
+	if evaluator, hasEvaluator := auth.Runtime.(RefreshEvaluator); hasEvaluator && evaluator != nil {
+		return 0
+	}
+	return deterministicRefreshJitter(auth.ID, maxJitter)
+}
+
+func deterministicRefreshJitter(authID string, maxJitter time.Duration) time.Duration {
+	if strings.TrimSpace(authID) == "" || maxJitter < time.Second {
+		return 0
+	}
+	maxSeconds := uint64(maxJitter / time.Second)
+	hasher := fnv.New64a()
+	_, _ = hasher.Write([]byte(authID))
+	return time.Duration(hasher.Sum64()%(maxSeconds+1)) * time.Second
 }
 
 func nextRefreshCheckAt(now time.Time, auth *Auth, interval time.Duration) (time.Time, bool) {

--- a/sdk/cliproxy/auth/auto_refresh_loop_test.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -9,6 +10,16 @@ import (
 type testRefreshEvaluator struct{}
 
 func (testRefreshEvaluator) ShouldRefresh(time.Time, *Auth) bool { return false }
+
+type pacedRefreshExecutor struct {
+	schedulerProviderTestExecutor
+	refreshed chan string
+}
+
+func (e pacedRefreshExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	e.refreshed <- auth.ID
+	return auth, nil
+}
 
 func setRefreshLeadFactory(t *testing.T, provider string, factory func() *time.Duration) {
 	t.Helper()
@@ -155,5 +166,175 @@ func TestNextRefreshCheckAt_RefreshEvaluatorFallback(t *testing.T) {
 	want := now.Add(interval)
 	if !got.Equal(want) {
 		t.Fatalf("nextRefreshCheckAt() = %s, want %s", got, want)
+	}
+}
+
+func TestRefreshRateInterval(t *testing.T) {
+	testCases := []struct {
+		name         string
+		maxPerMinute int
+		want         time.Duration
+	}{
+		{name: "disabled", maxPerMinute: 0, want: 0},
+		{name: "negative", maxPerMinute: -1, want: 0},
+		{name: "one per minute", maxPerMinute: 1, want: time.Minute},
+		{name: "one per second", maxPerMinute: 60, want: time.Second},
+		{name: "two per second", maxPerMinute: 120, want: 500 * time.Millisecond},
+		{name: "minimum spacing", maxPerMinute: 120000, want: time.Millisecond},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := refreshRateInterval(testCase.maxPerMinute); got != testCase.want {
+				t.Fatalf("refreshRateInterval(%d) = %s, want %s", testCase.maxPerMinute, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestAuthAutoRefreshWorker_SharedRateGatePacesWorkers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	refreshed := make(chan string, 2)
+	manager.RegisterExecutor(pacedRefreshExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "paced-refresh"},
+		refreshed:                     refreshed,
+	})
+	for _, id := range []string{"auth-a", "auth-b"} {
+		if _, errRegister := manager.Register(ctx, &Auth{ID: id, Provider: "paced-refresh"}); errRegister != nil {
+			t.Fatalf("register %s: %v", id, errRegister)
+		}
+	}
+
+	loop := newAuthAutoRefreshLoop(manager, time.Second, 2)
+	rateCh := make(chan time.Time)
+	go loop.worker(ctx, rateCh)
+	go loop.worker(ctx, rateCh)
+	loop.jobs <- "auth-a"
+	loop.jobs <- "auth-b"
+
+	select {
+	case id := <-refreshed:
+		t.Fatalf("refresh %q ran before a rate gate token", id)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	rateCh <- time.Now()
+	select {
+	case <-refreshed:
+	case <-time.After(time.Second):
+		t.Fatal("first refresh did not run after a rate gate token")
+	}
+	select {
+	case id := <-refreshed:
+		t.Fatalf("second refresh %q ran without another rate gate token", id)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	rateCh <- time.Now()
+	select {
+	case <-refreshed:
+	case <-time.After(time.Second):
+		t.Fatal("second refresh did not run after the second rate gate token")
+	}
+}
+
+func TestDeterministicRefreshJitter(t *testing.T) {
+	maxJitter := 10 * time.Minute
+	first := deterministicRefreshJitter("auth-a", maxJitter)
+	if first < 0 || first > maxJitter {
+		t.Fatalf("deterministicRefreshJitter() = %s, want within [0, %s]", first, maxJitter)
+	}
+	if got := deterministicRefreshJitter("auth-a", maxJitter); got != first {
+		t.Fatalf("deterministicRefreshJitter() changed from %s to %s", first, got)
+	}
+	if got := deterministicRefreshJitter("auth-b", maxJitter); got == first {
+		t.Fatalf("deterministicRefreshJitter() returned the same offset %s for distinct auth IDs", got)
+	}
+	if got := deterministicRefreshJitter("", maxJitter); got != 0 {
+		t.Fatalf("deterministicRefreshJitter(empty) = %s, want 0", got)
+	}
+}
+
+func TestNextRefreshCheckAtWithJitter_SpreadsScheduledRefreshEarlier(t *testing.T) {
+	now := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
+	expiry := now.Add(time.Hour)
+	lead := 10 * time.Minute
+	maxJitter := 5 * time.Minute
+	setRefreshLeadFactory(t, "jittered-provider", func() *time.Duration {
+		d := lead
+		return &d
+	})
+
+	auth := &Auth{
+		ID:       "jittered-auth",
+		Provider: "jittered-provider",
+		Metadata: map[string]any{
+			"expires_at": expiry.Format(time.RFC3339),
+		},
+	}
+
+	got, ok := nextRefreshCheckAtWithJitter(now, auth, 15*time.Minute, maxJitter)
+	if !ok {
+		t.Fatal("nextRefreshCheckAtWithJitter() ok = false, want true")
+	}
+	want := expiry.Add(-lead).Add(-deterministicRefreshJitter(auth.ID, maxJitter))
+	if !got.Equal(want) {
+		t.Fatalf("nextRefreshCheckAtWithJitter() = %s, want %s", got, want)
+	}
+
+	jitteredNow := want
+	if !refreshDueWithJitter(jitteredNow, auth, 15*time.Minute, maxJitter) {
+		t.Fatal("refreshDueWithJitter() = false at jittered schedule, want true")
+	}
+}
+
+func TestNextRefreshCheckAtWithJitter_DoesNotAdvanceBackoff(t *testing.T) {
+	now := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
+	nextAfter := now.Add(5 * time.Minute)
+	auth := &Auth{
+		ID:               "backoff-auth",
+		Provider:         "test",
+		NextRefreshAfter: nextAfter,
+		Metadata:         map[string]any{"email": "x@example.com"},
+	}
+
+	got, ok := nextRefreshCheckAtWithJitter(now, auth, time.Minute, 10*time.Minute)
+	if !ok {
+		t.Fatal("nextRefreshCheckAtWithJitter() ok = false, want true")
+	}
+	if !got.Equal(nextAfter) {
+		t.Fatalf("nextRefreshCheckAtWithJitter() = %s, want backoff %s", got, nextAfter)
+	}
+}
+
+func TestNextRefreshCheckAtWithJitter_DisabledKeepsLegacySchedule(t *testing.T) {
+	now := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
+	expiry := now.Add(time.Hour)
+	lead := 10 * time.Minute
+	setRefreshLeadFactory(t, "legacy-jitter-provider", func() *time.Duration {
+		d := lead
+		return &d
+	})
+
+	auth := &Auth{
+		ID:       "legacy-auth",
+		Provider: "legacy-jitter-provider",
+		Metadata: map[string]any{"expires_at": expiry.Format(time.RFC3339)},
+	}
+
+	got, ok := nextRefreshCheckAtWithJitter(now, auth, 15*time.Minute, 0)
+	if !ok {
+		t.Fatal("nextRefreshCheckAtWithJitter() ok = false, want true")
+	}
+	want := expiry.Add(-lead)
+	if !got.Equal(want) {
+		t.Fatalf("nextRefreshCheckAtWithJitter() = %s, want legacy schedule %s", got, want)
+	}
+	if refreshDueWithJitter(want.Add(-time.Second), auth, 15*time.Minute, 0) {
+		t.Fatal("refreshDueWithJitter() = true with jitter disabled")
 	}
 }

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -54,10 +54,18 @@ func (m *Manager) StartAutoRefresh(parent context.Context, interval time.Duratio
 
 	ctx, cancelCtx := context.WithCancel(parent)
 	workers := refreshMaxConcurrency
-	if cfg, ok := m.runtimeConfig.Load().(*internalconfig.Config); ok && cfg != nil && cfg.AuthAutoRefreshWorkers > 0 {
-		workers = cfg.AuthAutoRefreshWorkers
+	maxPerMinute := 0
+	jitter := time.Duration(0)
+	if cfg, ok := m.runtimeConfig.Load().(*internalconfig.Config); ok && cfg != nil {
+		if cfg.AuthAutoRefreshWorkers > 0 {
+			workers = cfg.AuthAutoRefreshWorkers
+		}
+		maxPerMinute = cfg.AuthAutoRefreshMaxPerMinute
+		if cfg.AuthAutoRefreshJitterSeconds > 0 {
+			jitter = time.Duration(cfg.AuthAutoRefreshJitterSeconds) * time.Second
+		}
 	}
-	loop := newAuthAutoRefreshLoop(m, interval, workers)
+	loop := newAuthAutoRefreshLoopWithSmoothing(m, interval, workers, maxPerMinute, jitter)
 
 	m.mu.Lock()
 	m.refreshCancel = cancelCtx


### PR DESCRIPTION
## Summary

- add an optional global per-minute limit for scheduled auth refreshes
- add deterministic per-auth jitter to spread synchronized expiry schedules
- preserve legacy behavior when both settings are zero
- leave request-triggered 401 recovery unaffected

## Motivation

Large credential pools can have many OAuth tokens become refreshable at the same time. The scheduler currently queues all due credentials immediately, and the worker pool can create a concentrated refresh burst against one provider or egress IP.

## Configuration

```yaml
auth-auto-refresh-max-per-minute: 60
auth-auto-refresh-jitter-seconds: 3600
```

Both options default to `0`, preserving existing behavior. Jitter advances scheduled refreshes earlier and does not alter retry backoff or runtime `RefreshEvaluator` schedules.

## Tests

- `go test -race ./sdk/cliproxy/auth`
- `go test ./...`
- `go build -o test-output ./cmd/server`