### PR TITLE
fix(claude): normalize eBay upstream failures

### DIFF
--- a/internal/runtime/executor/claude_executor_errors.go
+++ b/internal/runtime/executor/claude_executor_errors.go
@@ -1,0 +1,219 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+const maxClaudeUpstreamDetailLen = 360
+
+func isEbayClaudeGatewayBaseURL(rawURL string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return false
+	}
+	return isEbayClaudeGatewayURL(parsed)
+}
+
+func isEbayClaudeGatewayURL(parsed *url.URL) bool {
+	if parsed == nil {
+		return false
+	}
+	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+	return strings.HasPrefix(host, "hubgptgateway") && strings.HasSuffix(host, ".ebay.com")
+}
+
+func normalizeClaudeUpstreamHTTPStatusError(model string, upstreamStatus int, body []byte) error {
+	if upstreamStatus < http.StatusInternalServerError && upstreamStatus != 529 {
+		return statusErr{code: upstreamStatus, msg: string(body)}
+	}
+
+	detail := summarizeClaudeUpstreamDetail(upstreamStatus, body)
+	if upstreamStatus == http.StatusGatewayTimeout || strings.Contains(strings.ToLower(detail), "timeout") {
+		return claudeUpstreamStatusErr(http.StatusGatewayTimeout, "timeout_error", claudeUpstreamTimeoutMessage(model, detail))
+	}
+	return claudeUpstreamStatusErr(http.StatusServiceUnavailable, "overloaded_error", claudeUpstreamCapacityMessage(model, detail))
+}
+
+func normalizeClaudeUpstreamTransportError(model string, err error) error {
+	if err == nil {
+		return nil
+	}
+	detail := sanitizeClaudeUpstreamDetail(err.Error())
+	lower := strings.ToLower(err.Error())
+	if isClaudeTimeoutError(err, lower) {
+		return claudeUpstreamStatusErr(http.StatusGatewayTimeout, "timeout_error", claudeUpstreamTimeoutMessage(model, detail))
+	}
+	if isClaudeCapacityErrorText(lower) {
+		return claudeUpstreamStatusErr(http.StatusServiceUnavailable, "overloaded_error", claudeUpstreamCapacityMessage(model, detail))
+	}
+	return claudeUpstreamStatusErr(http.StatusBadGateway, "api_error", claudeUpstreamConnectionMessage(model, detail))
+}
+
+func normalizeClaudeUpstreamSSEError(model string, payload []byte, partialOutput bool) error {
+	detail := summarizeClaudeUpstreamDetail(http.StatusBadGateway, payload)
+	if partialOutput {
+		return claudeUpstreamStreamInterruptedError(model, detail, true)
+	}
+
+	errType := strings.TrimSpace(gjson.GetBytes(payload, "error.type").String())
+	if errType == "" {
+		errType = strings.TrimSpace(gjson.GetBytes(payload, "type").String())
+	}
+	lower := strings.ToLower(detail + " " + errType)
+	if strings.Contains(lower, "timeout") {
+		return claudeUpstreamStatusErr(http.StatusGatewayTimeout, "timeout_error", claudeUpstreamTimeoutMessage(model, detail))
+	}
+	if errType == "overloaded_error" || isClaudeCapacityErrorText(lower) {
+		return claudeUpstreamStatusErr(http.StatusServiceUnavailable, "overloaded_error", claudeUpstreamCapacityMessage(model, detail))
+	}
+	return claudeUpstreamStatusErr(http.StatusBadGateway, "api_error", claudeUpstreamConnectionMessage(model, detail))
+}
+
+func claudeUpstreamStreamInterruptedError(model, detail string, partialOutput bool) error {
+	if strings.TrimSpace(detail) == "" {
+		detail = "upstream stream ended before message_stop"
+	}
+	partialText := "No partial output was delivered; retry this turn."
+	if partialOutput {
+		partialText = "Partial output was already delivered, so CLIProxyAPI cannot safely replay transparently; retry this turn."
+	}
+	message := fmt.Sprintf("[upstream_stream_interrupted] Model %s reached eBay Claude Gateway, but the upstream stream ended unexpectedly. CLIProxyAPI accepted the request locally. %s Upstream detail: %s", claudeUpstreamModelText(model), partialText, sanitizeClaudeUpstreamDetail(detail))
+	return claudeUpstreamStatusErr(http.StatusBadGateway, "api_error", message)
+}
+
+func claudeUpstreamCapacityMessage(model, detail string) string {
+	return fmt.Sprintf("[upstream_capacity_unavailable] Model %s reached eBay Claude Gateway, but the upstream is temporarily busy or unavailable. CLIProxyAPI accepted the request locally; retry this turn later. Upstream detail: %s", claudeUpstreamModelText(model), sanitizeClaudeUpstreamDetail(detail))
+}
+
+func claudeUpstreamTimeoutMessage(model, detail string) string {
+	return fmt.Sprintf("[upstream_timeout] Model %s reached eBay Claude Gateway, but the upstream timed out before completing. CLIProxyAPI accepted the request locally; retry this turn later. Upstream detail: %s", claudeUpstreamModelText(model), sanitizeClaudeUpstreamDetail(detail))
+}
+
+func claudeUpstreamConnectionMessage(model, detail string) string {
+	return fmt.Sprintf("[upstream_connection_failed] Model %s reached eBay Claude Gateway, but the upstream connection failed before a complete response. CLIProxyAPI accepted the request locally; retry this turn later. Upstream detail: %s", claudeUpstreamModelText(model), sanitizeClaudeUpstreamDetail(detail))
+}
+
+func claudeUpstreamModelText(model string) string {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return "unknown"
+	}
+	return model
+}
+
+func claudeUpstreamStatusErr(status int, errType, message string) error {
+	payload := map[string]any{
+		"type": "error",
+		"error": map[string]string{
+			"type":    errType,
+			"message": message,
+		},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return statusErr{code: status, msg: message}
+	}
+	return statusErr{code: status, msg: string(data)}
+}
+
+func summarizeClaudeUpstreamDetail(status int, body []byte) string {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return http.StatusText(status)
+	}
+	if gjson.ValidBytes(trimmed) {
+		parts := make([]string, 0, 3)
+		for _, path := range []string{"error.type", "error.code", "error.message", "type", "code", "message"} {
+			value := strings.TrimSpace(gjson.GetBytes(trimmed, path).String())
+			if value != "" {
+				parts = append(parts, value)
+			}
+		}
+		if len(parts) > 0 {
+			return sanitizeClaudeUpstreamDetail(strings.Join(parts, ": "))
+		}
+	}
+	return sanitizeClaudeUpstreamDetail(string(trimmed))
+}
+
+func sanitizeClaudeUpstreamDetail(detail string) string {
+	detail = strings.TrimSpace(strings.Join(strings.Fields(detail), " "))
+	if detail == "" {
+		return "no upstream detail"
+	}
+	lower := strings.ToLower(detail)
+	for _, marker := range []string{"authorization:", "authorization=", "bearer ", "x-api-key", "api_key", "access_token", "refresh_token", "id_token", "sk-"} {
+		if strings.Contains(lower, marker) {
+			return "redacted upstream detail"
+		}
+	}
+	if len(detail) <= maxClaudeUpstreamDetailLen {
+		return detail
+	}
+	return strings.TrimSpace(detail[:maxClaudeUpstreamDetailLen]) + "..."
+}
+
+func isClaudeTimeoutError(err error, lower string) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return strings.Contains(lower, "timeout") || strings.Contains(lower, "deadline exceeded")
+}
+
+func isClaudeCapacityErrorText(lower string) bool {
+	for _, marker := range []string{"overloaded", "capacity", "temporarily unavailable", "server busy", "too busy", "try again later", "no healthy upstream"} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func claudeSSEDataPayload(line []byte) ([]byte, bool) {
+	line = bytes.TrimSpace(line)
+	if !bytes.HasPrefix(line, []byte("data:")) {
+		return nil, false
+	}
+	payload := bytes.TrimSpace(line[len("data:"):])
+	if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) {
+		return nil, false
+	}
+	return payload, true
+}
+
+func claudeSSELineType(line []byte) string {
+	trimmed := bytes.TrimSpace(line)
+	if bytes.HasPrefix(trimmed, []byte("event:")) {
+		return strings.TrimSpace(string(bytes.TrimSpace(trimmed[len("event:"):])))
+	}
+	payload, ok := claudeSSEDataPayload(trimmed)
+	if !ok || !gjson.ValidBytes(payload) {
+		return ""
+	}
+	return strings.TrimSpace(gjson.GetBytes(payload, "type").String())
+}
+
+func claudeSSEErrorPayload(line []byte) ([]byte, bool) {
+	payload, ok := claudeSSEDataPayload(line)
+	if !ok || !gjson.ValidBytes(payload) {
+		return nil, false
+	}
+	if strings.TrimSpace(gjson.GetBytes(payload, "type").String()) != "error" {
+		return nil, false
+	}
+	return payload, true
+}

--- a/internal/runtime/executor/claude_executor_errors.go
+++ b/internal/runtime/executor/claude_executor_errors.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -48,6 +49,9 @@ func normalizeClaudeUpstreamTransportError(model string, err error) error {
 	if err == nil {
 		return nil
 	}
+	if isClaudeContextCanceled(err) {
+		return err
+	}
 	detail := sanitizeClaudeUpstreamDetail(err.Error())
 	lower := strings.ToLower(err.Error())
 	if isClaudeTimeoutError(err, lower) {
@@ -57,6 +61,19 @@ func normalizeClaudeUpstreamTransportError(model string, err error) error {
 		return claudeUpstreamStatusErr(http.StatusServiceUnavailable, "overloaded_error", claudeUpstreamCapacityMessage(model, detail))
 	}
 	return claudeUpstreamStatusErr(http.StatusBadGateway, "api_error", claudeUpstreamConnectionMessage(model, detail))
+}
+
+func normalizeClaudeUpstreamStreamingValidationError(model string, data []byte, err error) error {
+	if err == nil {
+		return nil
+	}
+	if isClaudeContextCanceled(err) {
+		return err
+	}
+	if payload, ok := firstClaudeSSEErrorPayload(data); ok {
+		return normalizeClaudeUpstreamSSEError(model, payload, false)
+	}
+	return claudeUpstreamStreamInterruptedError(model, err.Error(), false)
 }
 
 func normalizeClaudeUpstreamSSEError(model string, payload []byte, partialOutput bool) error {
@@ -174,6 +191,10 @@ func isClaudeTimeoutError(err error, lower string) bool {
 	return strings.Contains(lower, "timeout") || strings.Contains(lower, "deadline exceeded")
 }
 
+func isClaudeContextCanceled(err error) bool {
+	return errors.Is(err, context.Canceled)
+}
+
 func isClaudeCapacityErrorText(lower string) bool {
 	for _, marker := range []string{"overloaded", "capacity", "temporarily unavailable", "server busy", "too busy", "try again later", "no healthy upstream"} {
 		if strings.Contains(lower, marker) {
@@ -195,12 +216,8 @@ func claudeSSEDataPayload(line []byte) ([]byte, bool) {
 	return payload, true
 }
 
-func claudeSSELineType(line []byte) string {
-	trimmed := bytes.TrimSpace(line)
-	if bytes.HasPrefix(trimmed, []byte("event:")) {
-		return strings.TrimSpace(string(bytes.TrimSpace(trimmed[len("event:"):])))
-	}
-	payload, ok := claudeSSEDataPayload(trimmed)
+func claudeSSEDataType(line []byte) string {
+	payload, ok := claudeSSEDataPayload(line)
 	if !ok || !gjson.ValidBytes(payload) {
 		return ""
 	}
@@ -212,8 +229,19 @@ func claudeSSEErrorPayload(line []byte) ([]byte, bool) {
 	if !ok || !gjson.ValidBytes(payload) {
 		return nil, false
 	}
-	if strings.TrimSpace(gjson.GetBytes(payload, "type").String()) != "error" {
+	if claudeSSEDataType(line) != "error" {
 		return nil, false
 	}
 	return payload, true
+}
+
+func firstClaudeSSEErrorPayload(data []byte) ([]byte, bool) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(nil, 52_428_800)
+	for scanner.Scan() {
+		if payload, ok := claudeSSEErrorPayload(scanner.Bytes()); ok {
+			return payload, true
+		}
+	}
+	return nil, false
 }

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -28,7 +28,11 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	}
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
-	defer reporter.TrackFailure(ctx, &err)
+	defer func() {
+		if !isClaudeContextCanceled(err) {
+			reporter.TrackFailure(ctx, &err)
+		}
+	}()
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("claude")
@@ -137,6 +141,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	httpClient = reporter.TrackHTTPClient(httpClient)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
+		if isClaudeContextCanceled(err) {
+			return resp, err
+		}
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		if normalizeEbayUpstreamErrors {
 			return resp, normalizeClaudeUpstreamTransportError(baseModel, err)
@@ -150,13 +157,25 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		// compression.  This keeps error-path behaviour consistent with the success path.
 		errBody, decErr := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
 		if decErr != nil {
+			if isClaudeContextCanceled(decErr) {
+				return resp, decErr
+			}
 			helps.RecordAPIResponseError(ctx, e.cfg, decErr)
 			msg := fmt.Sprintf("failed to decode error response body: %v", decErr)
 			helps.LogWithRequestID(ctx).Warn(msg)
+			if normalizeEbayUpstreamErrors && (httpResp.StatusCode >= http.StatusInternalServerError || httpResp.StatusCode == 529) {
+				return resp, normalizeClaudeUpstreamHTTPStatusError(baseModel, httpResp.StatusCode, []byte(msg))
+			}
 			return resp, statusErr{code: httpResp.StatusCode, msg: msg}
 		}
 		b, readErr := io.ReadAll(errBody)
 		if readErr != nil {
+			if isClaudeContextCanceled(readErr) {
+				if errClose := errBody.Close(); errClose != nil {
+					log.Errorf("response body close error: %v", errClose)
+				}
+				return resp, readErr
+			}
 			helps.RecordAPIResponseError(ctx, e.cfg, readErr)
 			msg := fmt.Sprintf("failed to read error response body: %v", readErr)
 			helps.LogWithRequestID(ctx).Warn(msg)
@@ -176,6 +195,12 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	}
 	decodedBody, err := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
 	if err != nil {
+		if isClaudeContextCanceled(err) {
+			if errClose := httpResp.Body.Close(); errClose != nil {
+				log.Errorf("response body close error: %v", errClose)
+			}
+			return resp, err
+		}
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
@@ -192,6 +217,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	}()
 	data, err := io.ReadAll(decodedBody)
 	if err != nil {
+		if isClaudeContextCanceled(err) {
+			return resp, err
+		}
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		if normalizeEbayUpstreamErrors {
 			return resp, normalizeClaudeUpstreamTransportError(baseModel, err)
@@ -201,11 +229,15 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 	if stream {
 		if errValidate := validateClaudeStreamingResponse(data); errValidate != nil {
-			helps.RecordAPIResponseError(ctx, e.cfg, errValidate)
-			if normalizeEbayUpstreamErrors {
-				return resp, claudeUpstreamStreamInterruptedError(baseModel, errValidate.Error(), false)
+			if isClaudeContextCanceled(errValidate) {
+				return resp, errValidate
 			}
-			return resp, errValidate
+			errOut := errValidate
+			if normalizeEbayUpstreamErrors {
+				errOut = normalizeClaudeUpstreamStreamingValidationError(baseModel, data, errValidate)
+			}
+			helps.RecordAPIResponseError(ctx, e.cfg, errOut)
+			return resp, errOut
 		}
 		lines := bytes.Split(data, []byte("\n"))
 		for i, line := range lines {

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -50,6 +50,10 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if rebuildMidSystemMessageEnabled(e.cfg, auth) {
 		body = rebuildMidSystemMessagesToTopLevel(body)
 	}
+	if isEbayClaudeGatewayBaseURL(baseURL) {
+		body = moveSystemRoleMessagesToFirstUser(body)
+		body = normalizeClaudeAssistantPrefill(body)
+	}
 
 	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
 	// based on client type and configuration.
@@ -107,6 +111,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if err != nil {
 		return resp, err
 	}
+	normalizeEbayUpstreamErrors := isEbayClaudeGatewayURL(httpReq.URL)
 	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg, opts.Headers); errHeaders != nil {
 		return resp, errHeaders
 	}
@@ -133,6 +138,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		if normalizeEbayUpstreamErrors {
+			return resp, normalizeClaudeUpstreamTransportError(baseModel, err)
+		}
 		return resp, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
@@ -156,7 +164,11 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		}
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		if normalizeEbayUpstreamErrors && (httpResp.StatusCode >= http.StatusInternalServerError || httpResp.StatusCode == 529) {
+			err = normalizeClaudeUpstreamHTTPStatusError(baseModel, httpResp.StatusCode, b)
+		} else {
+			err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		}
 		if errClose := errBody.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}
@@ -168,6 +180,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}
+		if normalizeEbayUpstreamErrors {
+			return resp, normalizeClaudeUpstreamTransportError(baseModel, err)
+		}
 		return resp, err
 	}
 	defer func() {
@@ -178,12 +193,18 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	data, err := io.ReadAll(decodedBody)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		if normalizeEbayUpstreamErrors {
+			return resp, normalizeClaudeUpstreamTransportError(baseModel, err)
+		}
 		return resp, err
 	}
 	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 	if stream {
 		if errValidate := validateClaudeStreamingResponse(data); errValidate != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errValidate)
+			if normalizeEbayUpstreamErrors {
+				return resp, claudeUpstreamStreamInterruptedError(baseModel, errValidate.Error(), false)
+			}
 			return resp, errValidate
 		}
 		lines := bytes.Split(data, []byte("\n"))

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -141,6 +141,10 @@ func decodeResponseBody(body io.ReadCloser, contentEncoding string) (io.ReadClos
 		// stream regardless of whether decompression was applied.
 		pb := &peekableBody{Reader: bufio.NewReader(body), closer: body}
 		magic, peekErr := pb.Peek(4)
+		if isClaudeContextCanceled(peekErr) {
+			_ = pb.Close()
+			return nil, peekErr
+		}
 		if peekErr == nil || (peekErr == io.EOF && len(magic) >= 2) {
 			switch {
 			case len(magic) >= 2 && magic[0] == 0x1f && magic[1] == 0x8b:
@@ -479,14 +483,21 @@ func normalizeClaudeAssistantPrefill(payload []byte) []byte {
 	if !strings.EqualFold(strings.TrimSpace(last.Get("role").String()), "assistant") || !isClaudeAssistantPrefillMessage(last) {
 		return payload
 	}
-	keptMessages := make([]string, 0, len(messageArray)-1)
-	for _, message := range messageArray[:len(messageArray)-1] {
+	keptMessages := make([]string, 0, len(messageArray)+1)
+	for _, message := range messageArray {
 		keptMessages = append(keptMessages, message.Raw)
 	}
+	keptMessages = append(keptMessages, claudeContinuationUserMessage())
 	if updated, errSetMessages := sjson.SetRawBytes(payload, "messages", rawJSONArray(keptMessages)); errSetMessages == nil {
 		return updated
 	}
 	return payload
+}
+
+func claudeContinuationUserMessage() string {
+	block := []byte(`{"role":"user","content":[{"type":"text","text":""}]}`)
+	block, _ = sjson.SetBytes(block, "content.0.text", "Continue the preceding assistant response without repeating it.")
+	return string(block)
 }
 
 func isClaudeAssistantPrefillMessage(message gjson.Result) bool {

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -406,6 +406,116 @@ func rebuildMidSystemMessagesToTopLevel(payload []byte) []byte {
 	return payload
 }
 
+func moveSystemRoleMessagesToFirstUser(payload []byte) []byte {
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.IsArray() {
+		return payload
+	}
+
+	var movedSystemParts []string
+	keptMessages := make([]string, 0, int(messages.Get("#").Int()))
+	firstUserIndex := -1
+	messages.ForEach(func(_, message gjson.Result) bool {
+		role := strings.ToLower(strings.TrimSpace(message.Get("role").String()))
+		if role == "system" {
+			movedSystemParts = append(movedSystemParts, claudeSystemTextParts(message.Get("content"))...)
+			return true
+		}
+		if role == "user" && firstUserIndex < 0 {
+			firstUserIndex = len(keptMessages)
+		}
+		keptMessages = append(keptMessages, message.Raw)
+		return true
+	})
+	if len(movedSystemParts) == 0 {
+		return payload
+	}
+
+	systemContent := rawJSONArray(movedSystemParts)
+	if firstUserIndex < 0 {
+		userMessage := []byte(`{"role":"user","content":[]}`)
+		userMessage, _ = sjson.SetRawBytes(userMessage, "content", systemContent)
+		keptMessages = append([]string{string(userMessage)}, keptMessages...)
+	} else {
+		firstUser := []byte(keptMessages[firstUserIndex])
+		firstUser, _ = sjson.SetRawBytes(firstUser, "content", mergeClaudeContentBlocks(movedSystemParts, gjson.GetBytes(firstUser, "content")))
+		keptMessages[firstUserIndex] = string(firstUser)
+	}
+
+	if updated, errSetMessages := sjson.SetRawBytes(payload, "messages", rawJSONArray(keptMessages)); errSetMessages == nil {
+		return updated
+	}
+	return payload
+}
+
+func mergeClaudeContentBlocks(prefix []string, content gjson.Result) []byte {
+	items := make([]string, 0, len(prefix)+1)
+	items = append(items, prefix...)
+	if content.Type == gjson.String {
+		block := []byte(`{"type":"text","text":""}`)
+		block, _ = sjson.SetBytes(block, "text", content.String())
+		items = append(items, string(block))
+	} else if content.IsArray() {
+		content.ForEach(func(_, item gjson.Result) bool {
+			items = append(items, item.Raw)
+			return true
+		})
+	} else if content.Exists() {
+		items = append(items, content.Raw)
+	}
+	return rawJSONArray(items)
+}
+
+func normalizeClaudeAssistantPrefill(payload []byte) []byte {
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.IsArray() {
+		return payload
+	}
+	messageArray := messages.Array()
+	if len(messageArray) == 0 {
+		return payload
+	}
+	last := messageArray[len(messageArray)-1]
+	if !strings.EqualFold(strings.TrimSpace(last.Get("role").String()), "assistant") || !isClaudeAssistantPrefillMessage(last) {
+		return payload
+	}
+	keptMessages := make([]string, 0, len(messageArray)-1)
+	for _, message := range messageArray[:len(messageArray)-1] {
+		keptMessages = append(keptMessages, message.Raw)
+	}
+	if updated, errSetMessages := sjson.SetRawBytes(payload, "messages", rawJSONArray(keptMessages)); errSetMessages == nil {
+		return updated
+	}
+	return payload
+}
+
+func isClaudeAssistantPrefillMessage(message gjson.Result) bool {
+	content := message.Get("content")
+	if content.Type == gjson.String {
+		return strings.TrimSpace(content.String()) != ""
+	}
+	if !content.IsArray() {
+		return false
+	}
+	hasVisibleText := false
+	for _, item := range content.Array() {
+		itemType := item.Get("type").String()
+		switch itemType {
+		case "text":
+			if strings.TrimSpace(item.Get("text").String()) != "" {
+				hasVisibleText = true
+			}
+		case "":
+			if item.Type == gjson.String && strings.TrimSpace(item.String()) != "" {
+				hasVisibleText = true
+			}
+		default:
+			return false
+		}
+	}
+	return hasVisibleText
+}
+
 func claudeSystemTextParts(content gjson.Result) []string {
 	if !content.Exists() {
 		return nil

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -51,6 +51,10 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	if rebuildMidSystemMessageEnabled(e.cfg, auth) {
 		body = rebuildMidSystemMessagesToTopLevel(body)
 	}
+	if isEbayClaudeGatewayBaseURL(baseURL) {
+		body = moveSystemRoleMessagesToFirstUser(body)
+		body = normalizeClaudeAssistantPrefill(body)
+	}
 
 	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
 	// based on client type and configuration.
@@ -104,6 +108,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	if err != nil {
 		return nil, err
 	}
+	normalizeEbayUpstreamErrors := isEbayClaudeGatewayURL(httpReq.URL)
 	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, true, extraBetas, e.cfg, opts.Headers); errHeaders != nil {
 		return nil, errHeaders
 	}
@@ -130,6 +135,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		if normalizeEbayUpstreamErrors {
+			return nil, normalizeClaudeUpstreamTransportError(baseModel, err)
+		}
 		return nil, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
@@ -156,7 +164,11 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		if errClose := errBody.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		if normalizeEbayUpstreamErrors && (httpResp.StatusCode >= http.StatusInternalServerError || httpResp.StatusCode == 529) {
+			err = normalizeClaudeUpstreamHTTPStatusError(baseModel, httpResp.StatusCode, b)
+		} else {
+			err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		}
 		return nil, err
 	}
 	decodedBody, err := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
@@ -164,6 +176,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
+		}
+		if normalizeEbayUpstreamErrors {
+			return nil, normalizeClaudeUpstreamTransportError(baseModel, err)
 		}
 		return nil, err
 	}
@@ -181,6 +196,8 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			scanner := bufio.NewScanner(decodedBody)
 			scanner.Buffer(nil, 52_428_800) // 50MB
 			var event bytes.Buffer
+			sawMessageStop := false
+			emittedChunk := false
 			flushEvent := func() bool {
 				if event.Len() == 0 {
 					return true
@@ -189,6 +206,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				event.Reset()
 				select {
 				case out <- cliproxyexecutor.StreamChunk{Payload: cloned}:
+					emittedChunk = true
 					return true
 				case <-ctx.Done():
 					return false
@@ -199,6 +217,21 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 				if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
 					reporter.Publish(ctx, detail)
+				}
+				if lineType := claudeSSELineType(line); lineType == "message_stop" {
+					sawMessageStop = true
+				}
+				if normalizeEbayUpstreamErrors {
+					if payload, ok := claudeSSEErrorPayload(line); ok {
+						errUpstream := normalizeClaudeUpstreamSSEError(baseModel, payload, emittedChunk)
+						helps.RecordAPIResponseError(ctx, e.cfg, errUpstream)
+						reporter.PublishFailure(ctx, errUpstream)
+						select {
+						case out <- cliproxyexecutor.StreamChunk{Err: errUpstream}:
+						case <-ctx.Done():
+						}
+						return
+					}
 				}
 				line = restoreClaudeOAuthToolNamesFromStreamLine(line, claudeToolPrefix, auth.ToolPrefixDisabled(), oauthToolNamesReverseMap)
 				line = e.restoreResponseModel(line, req.Model)
@@ -213,9 +246,31 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			}
 			if errScan := scanner.Err(); errScan != nil {
 				helps.RecordAPIResponseError(ctx, e.cfg, errScan)
-				reporter.PublishFailure(ctx, errScan)
+				errOut := errScan
+				if normalizeEbayUpstreamErrors {
+					if emittedChunk {
+						errOut = claudeUpstreamStreamInterruptedError(baseModel, errScan.Error(), true)
+					} else {
+						errOut = normalizeClaudeUpstreamTransportError(baseModel, errScan)
+					}
+				}
+				reporter.PublishFailure(ctx, errOut)
 				select {
-				case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
+				case out <- cliproxyexecutor.StreamChunk{Err: errOut}:
+				case <-ctx.Done():
+				}
+				return
+			}
+			if !sawMessageStop {
+				errMissingStop := statusErr{code: http.StatusBadGateway, msg: "claude executor: upstream stream ended before message_stop"}
+				var errOut error = errMissingStop
+				if normalizeEbayUpstreamErrors {
+					errOut = claudeUpstreamStreamInterruptedError(baseModel, errMissingStop.Error(), emittedChunk)
+				}
+				helps.RecordAPIResponseError(ctx, e.cfg, errOut)
+				reporter.PublishFailure(ctx, errOut)
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Err: errOut}:
 				case <-ctx.Done():
 				}
 			}
@@ -226,11 +281,28 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		scanner := bufio.NewScanner(decodedBody)
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
+		sawMessageStop := false
+		emittedChunk := false
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
 				reporter.Publish(ctx, detail)
+			}
+			if lineType := claudeSSELineType(line); lineType == "message_stop" {
+				sawMessageStop = true
+			}
+			if normalizeEbayUpstreamErrors {
+				if payload, ok := claudeSSEErrorPayload(line); ok {
+					errUpstream := normalizeClaudeUpstreamSSEError(baseModel, payload, emittedChunk)
+					helps.RecordAPIResponseError(ctx, e.cfg, errUpstream)
+					reporter.PublishFailure(ctx, errUpstream)
+					select {
+					case out <- cliproxyexecutor.StreamChunk{Err: errUpstream}:
+					case <-ctx.Done():
+					}
+					return
+				}
 			}
 			line = restoreClaudeOAuthToolNamesFromStreamLine(line, claudeToolPrefix, auth.ToolPrefixDisabled(), oauthToolNamesReverseMap)
 			line = e.restoreResponseModel(line, req.Model)
@@ -247,6 +319,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			for i := range chunks {
 				select {
 				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
+					emittedChunk = true
 				case <-ctx.Done():
 					return
 				}
@@ -254,9 +327,31 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		}
 		if errScan := scanner.Err(); errScan != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
-			reporter.PublishFailure(ctx, errScan)
+			errOut := errScan
+			if normalizeEbayUpstreamErrors {
+				if emittedChunk {
+					errOut = claudeUpstreamStreamInterruptedError(baseModel, errScan.Error(), true)
+				} else {
+					errOut = normalizeClaudeUpstreamTransportError(baseModel, errScan)
+				}
+			}
+			reporter.PublishFailure(ctx, errOut)
 			select {
-			case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
+			case out <- cliproxyexecutor.StreamChunk{Err: errOut}:
+			case <-ctx.Done():
+			}
+			return
+		}
+		if !sawMessageStop {
+			errMissingStop := statusErr{code: http.StatusBadGateway, msg: "claude executor: upstream stream ended before message_stop"}
+			var errOut error = errMissingStop
+			if normalizeEbayUpstreamErrors {
+				errOut = claudeUpstreamStreamInterruptedError(baseModel, errMissingStop.Error(), emittedChunk)
+			}
+			helps.RecordAPIResponseError(ctx, e.cfg, errOut)
+			reporter.PublishFailure(ctx, errOut)
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Err: errOut}:
 			case <-ctx.Done():
 			}
 		}
@@ -271,6 +366,7 @@ func validateClaudeStreamingResponse(data []byte) error {
 	hasData := false
 	hasMessageStart := false
 	hasMessageDelta := false
+	hasMessageStop := false
 
 	for scanner.Scan() {
 		line := bytes.TrimSpace(scanner.Bytes())
@@ -305,6 +401,8 @@ func validateClaudeStreamingResponse(data []byte) error {
 			hasMessageStart = true
 		case "message_delta":
 			hasMessageDelta = true
+		case "message_stop":
+			hasMessageStop = true
 		}
 	}
 	if errScan := scanner.Err(); errScan != nil {
@@ -318,6 +416,9 @@ func validateClaudeStreamingResponse(data []byte) error {
 	}
 	if !hasMessageDelta {
 		return statusErr{code: http.StatusBadGateway, msg: "claude executor: upstream stream response ended before message completion"}
+	}
+	if !hasMessageStop {
+		return statusErr{code: http.StatusBadGateway, msg: "claude executor: upstream stream ended before message_stop"}
 	}
 	return nil
 }

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -31,7 +31,11 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	}
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
-	defer reporter.TrackFailure(ctx, &err)
+	defer func() {
+		if !isClaudeContextCanceled(err) {
+			reporter.TrackFailure(ctx, &err)
+		}
+	}()
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("claude")
@@ -134,6 +138,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	httpClient = reporter.TrackHTTPClient(httpClient)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
+		if isClaudeContextCanceled(err) {
+			return nil, err
+		}
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		if normalizeEbayUpstreamErrors {
 			return nil, normalizeClaudeUpstreamTransportError(baseModel, err)
@@ -147,13 +154,25 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		// compression.  This keeps error-path behaviour consistent with the success path.
 		errBody, decErr := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
 		if decErr != nil {
+			if isClaudeContextCanceled(decErr) {
+				return nil, decErr
+			}
 			helps.RecordAPIResponseError(ctx, e.cfg, decErr)
 			msg := fmt.Sprintf("failed to decode error response body: %v", decErr)
 			helps.LogWithRequestID(ctx).Warn(msg)
+			if normalizeEbayUpstreamErrors && (httpResp.StatusCode >= http.StatusInternalServerError || httpResp.StatusCode == 529) {
+				return nil, normalizeClaudeUpstreamHTTPStatusError(baseModel, httpResp.StatusCode, []byte(msg))
+			}
 			return nil, statusErr{code: httpResp.StatusCode, msg: msg}
 		}
 		b, readErr := io.ReadAll(errBody)
 		if readErr != nil {
+			if isClaudeContextCanceled(readErr) {
+				if errClose := errBody.Close(); errClose != nil {
+					log.Errorf("response body close error: %v", errClose)
+				}
+				return nil, readErr
+			}
 			helps.RecordAPIResponseError(ctx, e.cfg, readErr)
 			msg := fmt.Sprintf("failed to read error response body: %v", readErr)
 			helps.LogWithRequestID(ctx).Warn(msg)
@@ -173,6 +192,12 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	}
 	decodedBody, err := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
 	if err != nil {
+		if isClaudeContextCanceled(err) {
+			if errClose := httpResp.Body.Close(); errClose != nil {
+				log.Errorf("response body close error: %v", errClose)
+			}
+			return nil, err
+		}
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
@@ -218,7 +243,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
 					reporter.Publish(ctx, detail)
 				}
-				if lineType := claudeSSELineType(line); lineType == "message_stop" {
+				if lineType := claudeSSEDataType(line); lineType == "message_stop" {
 					sawMessageStop = true
 				}
 				if normalizeEbayUpstreamErrors {
@@ -245,6 +270,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				return
 			}
 			if errScan := scanner.Err(); errScan != nil {
+				if sawMessageStop || isClaudeContextCanceled(errScan) {
+					return
+				}
 				helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 				errOut := errScan
 				if normalizeEbayUpstreamErrors {
@@ -289,7 +317,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
 				reporter.Publish(ctx, detail)
 			}
-			if lineType := claudeSSELineType(line); lineType == "message_stop" {
+			if lineType := claudeSSEDataType(line); lineType == "message_stop" {
 				sawMessageStop = true
 			}
 			if normalizeEbayUpstreamErrors {
@@ -326,6 +354,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			}
 		}
 		if errScan := scanner.Err(); errScan != nil {
+			if sawMessageStop || isClaudeContextCanceled(errScan) {
+				return
+			}
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 			errOut := errScan
 			if normalizeEbayUpstreamErrors {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,6 +28,12 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
+
+type claudeExecutorRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f claudeExecutorRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func resetClaudeDeviceProfileCache() {
 	helps.ResetClaudeDeviceProfileCache()
@@ -1622,6 +1629,27 @@ func TestClaudeExecutor_ExecuteOpenAINonStreamConvertsValidClaudeStream(t *testi
 	}
 }
 
+func TestClaudeExecutor_ExecuteOpenAINonStreamRejectsMissingMessageStop(t *testing.T) {
+	body := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-3-5-sonnet-20241022"}}`,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":2,"output_tokens":1}}`,
+		``,
+	}, "\n")
+
+	_, err := executeOpenAIChatCompletionThroughClaude(t, body)
+	if err == nil {
+		t.Fatal("Execute error = nil, want missing message_stop error")
+	}
+	assertStatusErr(t, err, http.StatusBadGateway)
+	if !strings.Contains(err.Error(), "message_stop") {
+		t.Fatalf("Execute error = %q, want message_stop", err.Error())
+	}
+}
+
 func executeOpenAIChatCompletionThroughClaude(t *testing.T, upstreamBody string) (cliproxyexecutor.Response, error) {
 	t.Helper()
 
@@ -1655,6 +1683,258 @@ func assertStatusErr(t *testing.T, err error, want int) {
 	}
 	if got := status.StatusCode(); got != want {
 		t.Fatalf("StatusCode() = %d, want %d", got, want)
+	}
+}
+
+func TestClaudeExecutor_EbayGatewayHostMatch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "stratus gateway", url: "https://hubgptgatewaysvc3.stratus.qa.ebay.com/gateway/v1/ebay", want: true},
+		{name: "vip gateway", url: "https://hubgptgatewaysvc.vip.qa.ebay.com/gateway/v1/ebay", want: true},
+		{name: "root gateway", url: "https://hubgptgateway.ebay.com", want: true},
+		{name: "anthropic", url: "https://api.anthropic.com", want: false},
+		{name: "lookalike prefix", url: "https://api.hubgptgateway.ebay.com.evil.example", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isEbayClaudeGatewayBaseURL(tc.url); got != tc.want {
+				t.Fatalf("isEbayClaudeGatewayBaseURL(%q) = %v, want %v", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClaudeExecutor_NormalizesEbayGatewayHTTP5xx(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", claudeExecutorRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if got := req.URL.Hostname(); got != "hubgptgatewaysvc3.stratus.qa.ebay.com" {
+			t.Fatalf("hostname = %q, want eBay gateway", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"overloaded_error","message":"capacity exhausted","api_key":"sk-secret"}}`)),
+			Request:    req,
+		}, nil
+	}))
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": "https://hubgptgatewaysvc3.stratus.qa.ebay.com/gateway/v1/ebay",
+	}}
+
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: []byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err == nil {
+		t.Fatal("Execute error = nil, want normalized eBay 5xx")
+	}
+	assertStatusErr(t, err, http.StatusServiceUnavailable)
+	if got := gjson.Get(err.Error(), "error.type").String(); got != "overloaded_error" {
+		t.Fatalf("error.type = %q, want overloaded_error; err=%s", got, err.Error())
+	}
+	message := gjson.Get(err.Error(), "error.message").String()
+	for _, want := range []string{"[upstream_capacity_unavailable]", "claude-sonnet-5", "CLIProxyAPI accepted the request locally", "capacity exhausted"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("message missing %q: %s", want, message)
+		}
+	}
+	if strings.Contains(message, "sk-secret") || strings.Contains(message, "api_key") {
+		t.Fatalf("message leaked secret detail: %s", message)
+	}
+}
+
+func TestClaudeExecutor_EbayGatewayTimeoutAndTransportClassification(t *testing.T) {
+	timeoutErr := normalizeClaudeUpstreamTransportError("claude-sonnet-5", context.DeadlineExceeded)
+	assertStatusErr(t, timeoutErr, http.StatusGatewayTimeout)
+	if got := gjson.Get(timeoutErr.Error(), "error.type").String(); got != "timeout_error" {
+		t.Fatalf("timeout error.type = %q, want timeout_error; err=%s", got, timeoutErr.Error())
+	}
+	if message := gjson.Get(timeoutErr.Error(), "error.message").String(); !strings.HasPrefix(message, "[upstream_timeout]") {
+		t.Fatalf("timeout message = %q, want upstream_timeout prefix", message)
+	}
+
+	for _, errIn := range []error{
+		io.ErrUnexpectedEOF,
+		errors.New("stream error: stream ID 35; NO_ERROR; received from peer"),
+		errors.New("socket hang up"),
+	} {
+		errOut := normalizeClaudeUpstreamTransportError("claude-sonnet-5", errIn)
+		assertStatusErr(t, errOut, http.StatusBadGateway)
+		if got := gjson.Get(errOut.Error(), "error.type").String(); got != "api_error" {
+			t.Fatalf("transport error.type = %q, want api_error; err=%s", got, errOut.Error())
+		}
+		if message := gjson.Get(errOut.Error(), "error.message").String(); !strings.HasPrefix(message, "[upstream_connection_failed]") {
+			t.Fatalf("transport message = %q, want upstream_connection_failed prefix", message)
+		}
+	}
+}
+
+func TestClaudeExecutor_EbayGatewayPreservesValidation4xx(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", claudeExecutorRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"invalid_request_error","message":"bad input"}}`)),
+			Request:    req,
+		}, nil
+	}))
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": "https://hubgptgatewaysvc3.stratus.qa.ebay.com/gateway/v1/ebay",
+	}}
+
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: []byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err == nil {
+		t.Fatal("Execute error = nil, want 400")
+	}
+	assertStatusErr(t, err, http.StatusBadRequest)
+	if !strings.Contains(err.Error(), "invalid_request_error") {
+		t.Fatalf("error = %q, want original upstream 4xx body", err.Error())
+	}
+	if strings.Contains(err.Error(), "upstream_capacity_unavailable") {
+		t.Fatalf("4xx should not be normalized: %s", err.Error())
+	}
+}
+
+func TestClaudeExecutor_NonEbayGatewayPreservesHTTP5xx(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "plain upstream failure", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: []byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err == nil {
+		t.Fatal("Execute error = nil, want 502")
+	}
+	assertStatusErr(t, err, http.StatusBadGateway)
+	if strings.Contains(err.Error(), "upstream_capacity_unavailable") {
+		t.Fatalf("non-eBay 5xx should not be normalized: %s", err.Error())
+	}
+}
+
+func TestClaudeExecutor_EbayStreamMissingMessageStopReturnsInterruptedError(t *testing.T) {
+	upstreamStream := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-sonnet-5"}}`,
+		``,
+	}, "\n")
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", claudeExecutorRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader(upstreamStream)),
+			Request:    req,
+		}, nil
+	}))
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": "https://hubgptgatewaysvc3.stratus.qa.ebay.com/gateway/v1/ebay",
+	}}
+	result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: []byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var gotPayload bool
+	var gotErr error
+	for chunk := range result.Chunks {
+		if len(chunk.Payload) > 0 {
+			gotPayload = true
+		}
+		if chunk.Err != nil {
+			gotErr = chunk.Err
+		}
+	}
+	if !gotPayload {
+		t.Fatal("expected first upstream event to be delivered before interruption")
+	}
+	if gotErr == nil {
+		t.Fatal("stream error = nil, want missing message_stop")
+	}
+	assertStatusErr(t, gotErr, http.StatusBadGateway)
+	if got := gjson.Get(gotErr.Error(), "error.type").String(); got != "api_error" {
+		t.Fatalf("error.type = %q, want api_error; err=%s", got, gotErr.Error())
+	}
+	message := gjson.Get(gotErr.Error(), "error.message").String()
+	for _, want := range []string{"[upstream_stream_interrupted]", "Partial output was already delivered", "cannot safely replay"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("message missing %q: %s", want, message)
+		}
+	}
+}
+
+func TestClaudeExecutor_EbayGatewayNormalizesSystemRoleAndAssistantPrefill(t *testing.T) {
+	var seenBody []byte
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", claudeExecutorRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body, errRead := io.ReadAll(req.Body)
+		if errRead != nil {
+			return nil, errRead
+		}
+		seenBody = bytes.Clone(body)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"id":"msg_1","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`)),
+			Request:    req,
+		}, nil
+	}))
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": "https://hubgptgatewaysvc3.stratus.qa.ebay.com/gateway/v1/ebay",
+	}}
+
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model: "claude-sonnet-5",
+		Payload: []byte(`{"messages":[` +
+			`{"role":"system","content":"Mid rule"},` +
+			`{"role":"user","content":"hi"},` +
+			`{"role":"assistant","content":[{"type":"text","text":"prefill"}]}` +
+			`]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if len(seenBody) == 0 {
+		t.Fatal("expected request body")
+	}
+	if gjson.GetBytes(seenBody, `messages.#(role=="system")`).Exists() {
+		t.Fatalf("system role message should be moved before upstream: %s", seenBody)
+	}
+	if got := gjson.GetBytes(seenBody, "messages.#").Int(); got != 1 {
+		t.Fatalf("messages count = %d, want 1: %s", got, seenBody)
+	}
+	if got := gjson.GetBytes(seenBody, "messages.0.content.0.text").String(); got != "Mid rule" {
+		t.Fatalf("messages.0.content.0.text = %q, want Mid rule: %s", got, seenBody)
+	}
+	if got := gjson.GetBytes(seenBody, "messages.0.content.1.text").String(); got != "hi" {
+		t.Fatalf("messages.0.content.1.text = %q, want hi: %s", got, seenBody)
+	}
+	if strings.Contains(string(seenBody), "prefill") {
+		t.Fatalf("assistant prefill should be removed before eBay upstream: %s", seenBody)
 	}
 }
 

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -35,6 +35,29 @@ func (f claudeExecutorRoundTripFunc) RoundTrip(req *http.Request) (*http.Respons
 	return f(req)
 }
 
+type claudeExecutorErrReadCloser struct {
+	data []byte
+	err  error
+}
+
+func (r *claudeExecutorErrReadCloser) Read(p []byte) (int, error) {
+	if len(r.data) > 0 {
+		n := copy(p, r.data)
+		r.data = r.data[n:]
+		return n, nil
+	}
+	if r.err != nil {
+		err := r.err
+		r.err = nil
+		return 0, err
+	}
+	return 0, io.EOF
+}
+
+func (r *claudeExecutorErrReadCloser) Close() error {
+	return nil
+}
+
 func resetClaudeDeviceProfileCache() {
 	helps.ResetClaudeDeviceProfileCache()
 }
@@ -1296,6 +1319,178 @@ func TestClaudeExecutor_ExecuteStreamDirectPassthroughEmitsCompleteSSEEvents(t *
 	}
 }
 
+func TestClaudeExecutor_ExecuteStreamDirectRequiresMessageStopData(t *testing.T) {
+	upstreamStream := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-3-5-sonnet-20241022"}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`,
+		``,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":2,"output_tokens":1}}`,
+		``,
+		`event: message_stop`,
+		``,
+	}, "\n")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(upstreamStream))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var gotErr error
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			gotErr = chunk.Err
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("stream error = nil, want missing message_stop data error")
+	}
+	if !strings.Contains(gotErr.Error(), "message_stop") {
+		t.Fatalf("stream error = %q, want message_stop", gotErr.Error())
+	}
+}
+
+func TestClaudeExecutor_ExecuteStreamTranslatedRequiresMessageStopData(t *testing.T) {
+	upstreamStream := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-3-5-sonnet-20241022"}}`,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":2,"output_tokens":1}}`,
+		`event: message_stop`,
+		``,
+	}, "\n")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(upstreamStream))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: []byte(`{"model":"claude-3-5-sonnet-20241022","messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai")})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var gotErr error
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			gotErr = chunk.Err
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("stream error = nil, want missing message_stop data error")
+	}
+	if !strings.Contains(gotErr.Error(), "message_stop") {
+		t.Fatalf("stream error = %q, want message_stop", gotErr.Error())
+	}
+}
+
+func TestClaudeExecutor_ExecuteStreamDirectIgnoresReadErrorAfterMessageStopData(t *testing.T) {
+	upstreamStream := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-sonnet-5"}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`,
+		``,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":2,"output_tokens":1}}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", claudeExecutorRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       &claudeExecutorErrReadCloser{data: []byte(upstreamStream), err: io.ErrUnexpectedEOF},
+			Request:    req,
+		}, nil
+	}))
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": "https://hubgptgatewaysvc3.stratus.qa.ebay.com/gateway/v1/ebay",
+	}}
+	result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected chunk error after message_stop: %v", chunk.Err)
+		}
+	}
+}
+
+func TestClaudeExecutor_ExecuteStreamTranslatedIgnoresReadErrorAfterMessageStopData(t *testing.T) {
+	upstreamStream := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-sonnet-5"}}`,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":2,"output_tokens":1}}`,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", claudeExecutorRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       &claudeExecutorErrReadCloser{data: []byte(upstreamStream), err: io.ErrUnexpectedEOF},
+			Request:    req,
+		}, nil
+	}))
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": "https://hubgptgatewaysvc3.stratus.qa.ebay.com/gateway/v1/ebay",
+	}}
+	result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai")})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected chunk error after message_stop: %v", chunk.Err)
+		}
+	}
+}
+
 func TestClaudeExecutor_CountTokensExcludesInvalidOpenAIThinking(t *testing.T) {
 	executor := NewClaudeExecutor(&config.Config{})
 	countTokens := func(payload []byte) int64 {
@@ -1581,6 +1776,37 @@ func TestClaudeExecutor_ExecuteOpenAINonStreamRejectsClaudeErrorEvent(t *testing
 	}
 }
 
+func TestClaudeExecutor_EbayExecuteOpenAINonStreamClassifiesSSEOverloadedError(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", claudeExecutorRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader(`data: {"type":"error","error":{"type":"overloaded_error","message":"upstream overloaded"}}` + "\n")),
+			Request:    req,
+		}, nil
+	}))
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": "https://hubgptgatewaysvc3.stratus.qa.ebay.com/gateway/v1/ebay",
+	}}
+
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai")})
+	if err == nil {
+		t.Fatal("Execute error = nil, want overloaded SSE error")
+	}
+	assertStatusErr(t, err, http.StatusServiceUnavailable)
+	if got := gjson.Get(err.Error(), "error.type").String(); got != "overloaded_error" {
+		t.Fatalf("error.type = %q, want overloaded_error; err=%s", got, err.Error())
+	}
+	if message := gjson.Get(err.Error(), "error.message").String(); !strings.Contains(message, "[upstream_capacity_unavailable]") || !strings.Contains(message, "upstream overloaded") {
+		t.Fatalf("message = %q, want capacity unavailable with upstream detail", message)
+	}
+}
+
 func TestClaudeExecutor_ExecuteOpenAINonStreamRejectsIncompleteClaudeStream(t *testing.T) {
 	body := strings.Join([]string{
 		`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-3-5-sonnet-20241022"}}`,
@@ -1595,6 +1821,28 @@ func TestClaudeExecutor_ExecuteOpenAINonStreamRejectsIncompleteClaudeStream(t *t
 	assertStatusErr(t, err, http.StatusBadGateway)
 	if !strings.Contains(err.Error(), "ended before message completion") {
 		t.Fatalf("Execute error = %q, want incomplete stream error", err.Error())
+	}
+}
+
+func TestClaudeExecutor_ExecuteOpenAINonStreamRejectsEventOnlyMessageStop(t *testing.T) {
+	body := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-3-5-sonnet-20241022"}}`,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":2,"output_tokens":1}}`,
+		`event: message_stop`,
+		``,
+	}, "\n")
+
+	_, err := executeOpenAIChatCompletionThroughClaude(t, body)
+	if err == nil {
+		t.Fatal("Execute error = nil, want missing message_stop data error")
+	}
+	assertStatusErr(t, err, http.StatusBadGateway)
+	if !strings.Contains(err.Error(), "message_stop") {
+		t.Fatalf("Execute error = %q, want message_stop", err.Error())
 	}
 }
 
@@ -1750,7 +1998,73 @@ func TestClaudeExecutor_NormalizesEbayGatewayHTTP5xx(t *testing.T) {
 	}
 }
 
+func TestClaudeExecutor_EbayGatewayHTTP5xxDecodeFailureNormalizesCapacity(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", claudeExecutorRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Header:     http.Header{"Content-Encoding": []string{"gzip"}},
+			Body:       io.NopCloser(strings.NewReader("not-a-valid-gzip-stream")),
+			Request:    req,
+		}, nil
+	}))
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": "https://hubgptgatewaysvc3.stratus.qa.ebay.com/gateway/v1/ebay",
+	}}
+
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: []byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err == nil {
+		t.Fatal("Execute error = nil, want normalized decode failure")
+	}
+	assertStatusErr(t, err, http.StatusServiceUnavailable)
+	if got := gjson.Get(err.Error(), "error.type").String(); got != "overloaded_error" {
+		t.Fatalf("error.type = %q, want overloaded_error; err=%s", got, err.Error())
+	}
+	if message := gjson.Get(err.Error(), "error.message").String(); !strings.Contains(message, "[upstream_capacity_unavailable]") || !strings.Contains(message, "failed to decode error response body") {
+		t.Fatalf("message = %q, want capacity message with decode detail", message)
+	}
+}
+
+func TestClaudeExecutor_EbayGatewayHTTP5xxReadFailureNormalizesCapacity(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", claudeExecutorRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Header:     http.Header{},
+			Body:       &claudeExecutorErrReadCloser{data: []byte("body-prefix"), err: errors.New("upstream body read reset")},
+			Request:    req,
+		}, nil
+	}))
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": "https://hubgptgatewaysvc3.stratus.qa.ebay.com/gateway/v1/ebay",
+	}}
+
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: []byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err == nil {
+		t.Fatal("Execute error = nil, want normalized read failure")
+	}
+	assertStatusErr(t, err, http.StatusServiceUnavailable)
+	if got := gjson.Get(err.Error(), "error.type").String(); got != "overloaded_error" {
+		t.Fatalf("error.type = %q, want overloaded_error; err=%s", got, err.Error())
+	}
+	if message := gjson.Get(err.Error(), "error.message").String(); !strings.Contains(message, "[upstream_capacity_unavailable]") || !strings.Contains(message, "failed to read error response body") {
+		t.Fatalf("message = %q, want capacity message with read detail", message)
+	}
+}
+
 func TestClaudeExecutor_EbayGatewayTimeoutAndTransportClassification(t *testing.T) {
+	if errOut := normalizeClaudeUpstreamTransportError("claude-sonnet-5", context.Canceled); !errors.Is(errOut, context.Canceled) {
+		t.Fatalf("context.Canceled normalized to %v, want original cancellation", errOut)
+	}
+
 	timeoutErr := normalizeClaudeUpstreamTransportError("claude-sonnet-5", context.DeadlineExceeded)
 	assertStatusErr(t, timeoutErr, http.StatusGatewayTimeout)
 	if got := gjson.Get(timeoutErr.Error(), "error.type").String(); got != "timeout_error" {
@@ -1772,6 +2086,103 @@ func TestClaudeExecutor_EbayGatewayTimeoutAndTransportClassification(t *testing.
 		}
 		if message := gjson.Get(errOut.Error(), "error.message").String(); !strings.HasPrefix(message, "[upstream_connection_failed]") {
 			t.Fatalf("transport message = %q, want upstream_connection_failed prefix", message)
+		}
+	}
+}
+
+func TestClaudeExecutor_EbayExecuteReturnsContextCanceledUnwrapped(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", claudeExecutorRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, context.Canceled
+	}))
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": "https://hubgptgatewaysvc3.stratus.qa.ebay.com/gateway/v1/ebay",
+	}}
+
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: []byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Execute error = %v, want context.Canceled", err)
+	}
+	if strings.Contains(err.Error(), "upstream_connection_failed") {
+		t.Fatalf("context cancellation should not be normalized: %v", err)
+	}
+}
+
+func TestClaudeExecutor_EbayExecuteBodyReadCanceledUnwrapped(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", claudeExecutorRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       &claudeExecutorErrReadCloser{data: []byte("body-prefix"), err: context.Canceled},
+			Request:    req,
+		}, nil
+	}))
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": "https://hubgptgatewaysvc3.stratus.qa.ebay.com/gateway/v1/ebay",
+	}}
+
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: []byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Execute error = %v, want context.Canceled", err)
+	}
+}
+
+func TestClaudeExecutor_EbayExecuteStreamReturnsContextCanceledUnwrapped(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", claudeExecutorRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, context.Canceled
+	}))
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": "https://hubgptgatewaysvc3.stratus.qa.ebay.com/gateway/v1/ebay",
+	}}
+
+	_, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: []byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ExecuteStream error = %v, want context.Canceled", err)
+	}
+	if strings.Contains(err.Error(), "upstream_connection_failed") {
+		t.Fatalf("context cancellation should not be normalized: %v", err)
+	}
+}
+
+func TestClaudeExecutor_EbayExecuteStreamScannerCanceledEndsSilently(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", claudeExecutorRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       &claudeExecutorErrReadCloser{data: []byte("event: message_start\n"), err: context.Canceled},
+			Request:    req,
+		}, nil
+	}))
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": "https://hubgptgatewaysvc3.stratus.qa.ebay.com/gateway/v1/ebay",
+	}}
+
+	result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: []byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("ExecuteStream error = %v, want nil initial error", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected stream chunk error for context cancellation: %v", chunk.Err)
 		}
 	}
 }
@@ -1924,8 +2335,8 @@ func TestClaudeExecutor_EbayGatewayNormalizesSystemRoleAndAssistantPrefill(t *te
 	if gjson.GetBytes(seenBody, `messages.#(role=="system")`).Exists() {
 		t.Fatalf("system role message should be moved before upstream: %s", seenBody)
 	}
-	if got := gjson.GetBytes(seenBody, "messages.#").Int(); got != 1 {
-		t.Fatalf("messages count = %d, want 1: %s", got, seenBody)
+	if got := gjson.GetBytes(seenBody, "messages.#").Int(); got != 3 {
+		t.Fatalf("messages count = %d, want 3: %s", got, seenBody)
 	}
 	if got := gjson.GetBytes(seenBody, "messages.0.content.0.text").String(); got != "Mid rule" {
 		t.Fatalf("messages.0.content.0.text = %q, want Mid rule: %s", got, seenBody)
@@ -1933,8 +2344,49 @@ func TestClaudeExecutor_EbayGatewayNormalizesSystemRoleAndAssistantPrefill(t *te
 	if got := gjson.GetBytes(seenBody, "messages.0.content.1.text").String(); got != "hi" {
 		t.Fatalf("messages.0.content.1.text = %q, want hi: %s", got, seenBody)
 	}
-	if strings.Contains(string(seenBody), "prefill") {
-		t.Fatalf("assistant prefill should be removed before eBay upstream: %s", seenBody)
+	if got := gjson.GetBytes(seenBody, "messages.1.role").String(); got != "assistant" {
+		t.Fatalf("messages.1.role = %q, want assistant: %s", got, seenBody)
+	}
+	if got := gjson.GetBytes(seenBody, "messages.1.content.0.text").String(); got != "prefill" {
+		t.Fatalf("assistant prefill text = %q, want prefill: %s", got, seenBody)
+	}
+	if got := gjson.GetBytes(seenBody, "messages.2.role").String(); got != "user" {
+		t.Fatalf("messages.2.role = %q, want user: %s", got, seenBody)
+	}
+	if got := gjson.GetBytes(seenBody, "messages.2.content.0.text").String(); got != "Continue the preceding assistant response without repeating it." {
+		t.Fatalf("continuation text = %q: %s", got, seenBody)
+	}
+}
+
+func TestNormalizeClaudeAssistantPrefill_AppendsContinuationUser(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"text","text":"compact context"}]}]}`)
+
+	out := normalizeClaudeAssistantPrefill(payload)
+
+	if got := gjson.GetBytes(out, "messages.#").Int(); got != 3 {
+		t.Fatalf("messages count = %d, want 3: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "messages.1.role").String(); got != "assistant" {
+		t.Fatalf("messages.1.role = %q, want assistant: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.text").String(); got != "compact context" {
+		t.Fatalf("assistant prefill text = %q, want compact context: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "messages.2.role").String(); got != "user" {
+		t.Fatalf("messages.2.role = %q, want user: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "messages.2.content.0.text").String(); got != "Continue the preceding assistant response without repeating it." {
+		t.Fatalf("continuation text = %q: %s", got, out)
+	}
+}
+
+func TestNormalizeClaudeAssistantPrefill_LeavesToolUseTailUnchanged(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{}}]}]}`)
+
+	out := normalizeClaudeAssistantPrefill(payload)
+
+	if !bytes.Equal(out, payload) {
+		t.Fatalf("tool_use assistant tail should remain unchanged.\noriginal: %s\ngot:      %s", payload, out)
 	}
 }
 

--- a/sdk/api/handlers/claude/code_handlers_error_test.go
+++ b/sdk/api/handlers/claude/code_handlers_error_test.go
@@ -48,6 +48,23 @@ func TestClaudeErrorExtractsClaudeStyleUpstreamJSON(t *testing.T) {
 	}
 }
 
+func TestClaudeErrorExtractsNormalizedUpstreamJSON(t *testing.T) {
+	handler := &ClaudeCodeAPIHandler{}
+	msg := &interfaces.ErrorMessage{
+		StatusCode: http.StatusServiceUnavailable,
+		Error:      errors.New(`{"type":"error","error":{"type":"overloaded_error","message":"[upstream_capacity_unavailable] Model claude-sonnet-5 reached eBay Claude Gateway"}}`),
+	}
+
+	got := handler.toClaudeError(msg)
+
+	if got.Error.Type != "overloaded_error" {
+		t.Fatalf("error.type = %q, want overloaded_error", got.Error.Type)
+	}
+	if got.Error.Message != "[upstream_capacity_unavailable] Model claude-sonnet-5 reached eBay Claude Gateway" {
+		t.Fatalf("error.message = %q", got.Error.Message)
+	}
+}
+
 func TestWriteClaudeErrorResponseUsesClaudeEnvelope(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()

--- a/sdk/api/handlers/handlers_error_response_test.go
+++ b/sdk/api/handlers/handlers_error_response_test.go
@@ -148,6 +148,24 @@ func TestEnrichAuthSelectionError_DefaultsTo503WithContext(t *testing.T) {
 	}
 }
 
+func TestEnrichAuthSelectionError_ClaudeUnavailableMentionsRouteCooldown(t *testing.T) {
+	in := &coreauth.Error{Code: "auth_unavailable", Message: "no auth available"}
+	out := enrichAuthSelectionError(in, []string{"claude"}, "claude-sonnet-5")
+
+	var got *coreauth.Error
+	if !errors.As(out, &got) || got == nil {
+		t.Fatalf("expected coreauth.Error, got %T", out)
+	}
+	for _, want := range []string{"configured Claude upstream routes", "cooling down after recent upstream failures", "/v0/management/auth-files"} {
+		if !strings.Contains(got.Message, want) {
+			t.Fatalf("message missing %q: %q", want, got.Message)
+		}
+	}
+	if strings.Contains(got.Message, "check Claude auth/key") {
+		t.Fatalf("auth_unavailable should not lead with auth/key hint: %q", got.Message)
+	}
+}
+
 func TestEnrichAuthSelectionError_PreservesExplicitStatus(t *testing.T) {
 	in := &coreauth.Error{Code: "auth_unavailable", Message: "no auth available", HTTPStatus: http.StatusTooManyRequests}
 	out := enrichAuthSelectionError(in, []string{"gemini"}, "gemini-2.5-pro")

--- a/sdk/api/handlers/handlers_errors.go
+++ b/sdk/api/handlers/handlers_errors.go
@@ -57,7 +57,11 @@ func enrichAuthSelectionError(err error, providers []string, model string) error
 
 	// Clarify the most common alias confusion between Anthropic route names and internal provider keys.
 	if strings.Contains(","+providerText+",", ",claude,") {
-		detail += "; check Claude auth/key session and cooldown state via /v0/management/auth-files"
+		if code == "auth_unavailable" {
+			detail += "; configured Claude upstream routes may be cooling down after recent upstream failures, disabled, or missing; inspect /v0/management/auth-files"
+		} else {
+			detail += "; check Claude auth/key session and cooldown state via /v0/management/auth-files"
+		}
 	}
 
 	status := authErr.HTTPStatus

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -66,7 +66,7 @@ func (e *modelCooldownError) Error() string {
 	if modelName == "" {
 		modelName = "requested model"
 	}
-	message := fmt.Sprintf("All credentials for model %s are cooling down", modelName)
+	message := fmt.Sprintf("configured upstream routes for model %s are temporarily unavailable/cooling down after recent failures", modelName)
 	if e.provider != "" {
 		message = fmt.Sprintf("%s via provider %s", message, e.provider)
 	}

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -250,6 +250,10 @@ func TestSelectorPick_AllCooldownReturnsModelCooldownError(t *testing.T) {
 		if got, _ := rawErr["code"].(string); got != "model_cooldown" {
 			t.Fatalf("Error().error.code = %q, want %q", got, "model_cooldown")
 		}
+		message, _ := rawErr["message"].(string)
+		if !strings.Contains(message, "configured upstream routes") || !strings.Contains(message, "temporarily unavailable/cooling down after recent failures") {
+			t.Fatalf("Error().error.message = %q, want upstream route cooldown context", message)
+		}
 		if _, ok := rawErr["provider"]; ok {
 			t.Fatalf("Error().error.provider exists for mixed provider: %v", rawErr["provider"])
 		}


### PR DESCRIPTION
## Summary

- Normalize eBay Claude Gateway-only 5xx, timeout, transport, and stream interruption failures into clear Claude-compatible errors.
- Require a data-backed SSE `message_stop` while treating trailing EOF/reset after a complete stop as successful completion.
- Preserve client `context.Canceled` without upstream-failure wrapping or cooldown effects.
- Preserve trailing assistant prefill context and append a continuation user message.
- Improve authentication cooldown diagnostics for unavailable upstream routes.

## Validation

- `env -u GOROOT /opt/homebrew/bin/go test ./internal/runtime/executor ./sdk/api/handlers ./sdk/cliproxy/auth`
- `env -u GOROOT /opt/homebrew/bin/go build -o cli-proxy-api ./cmd/server`
- `git diff --check`