### PR TITLE
fix(kimi): map K2.7 Code aliases to canonical IDs

### DIFF
--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -106,7 +106,7 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, false)
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, bytes.Clone(req.Payload), false)
 
-	// Strip kimi- prefix and any [1m] suffix for upstream API
+	// Normalize the CLIProxyAPI model ID to the Kimi Code upstream model ID.
 	upstreamModel := normalizeKimiUpstreamModel(baseModel)
 	body, err = sjson.SetBytes(body, "model", upstreamModel)
 	if err != nil {
@@ -215,7 +215,7 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, true)
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, bytes.Clone(req.Payload), true)
 
-	// Strip kimi- prefix and any [1m] suffix for upstream API
+	// Normalize the CLIProxyAPI model ID to the Kimi Code upstream model ID.
 	upstreamModel := normalizeKimiUpstreamModel(baseModel)
 	body, err = sjson.SetBytes(body, "model", upstreamModel)
 	if err != nil {
@@ -786,10 +786,10 @@ func stripKimiPrefix(model string) string {
 	return model
 }
 
-// normalizeKimiUpstreamModel returns the canonical upstream model ID for Kimi.
+// normalizeKimiUpstreamModel returns the canonical Kimi Code upstream model ID.
 // It strips the CLIProxyAPI "kimi-" prefix and any Claude Code "[1m]" context
-// suffix while preserving a trailing thinking suffix (e.g. "(1024)"), so that
-// the upstream API receives IDs such as "k3(1024)" instead of "kimi-k3[1m](1024)".
+// suffix, maps K2.7 Code variants to their official Kimi Code IDs, and preserves
+// a trailing thinking suffix (e.g. "(1024)").
 func normalizeKimiUpstreamModel(model string) string {
 	model = strings.TrimSpace(model)
 	parsed := thinking.ParseSuffix(model)
@@ -798,6 +798,12 @@ func normalizeKimiUpstreamModel(model string) string {
 		base = base[:len(base)-len("[1m]")]
 	}
 	normalized := strings.ToLower(stripKimiPrefix(strings.TrimSpace(base)))
+	switch normalized {
+	case "k2.7-code":
+		normalized = "kimi-for-coding"
+	case "k2.7-code-highspeed":
+		normalized = "kimi-for-coding-highspeed"
+	}
 	if parsed.HasSuffix {
 		return normalized + "(" + parsed.RawSuffix + ")"
 	}

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -524,8 +524,13 @@ func TestNormalizeKimiUpstreamModel(t *testing.T) {
 		{"k3", "k3"},
 		{"kimi-k2.6", "k2.6"},
 		{"kimi-k2.6[1m]", "k2.6"},
+		{"kimi-k2.7-code", "kimi-for-coding"},
+		{"Kimi-K2.7-Code", "kimi-for-coding"},
+		{"kimi-k2.7-code-highspeed", "kimi-for-coding-highspeed"},
+		{"Kimi-K2.7-Code-HighSpeed", "kimi-for-coding-highspeed"},
 		{"kimi-k3(1024)", "k3(1024)"},
 		{"kimi-k3[1m](1024)", "k3(1024)"},
+		{"kimi-k2.7-code-highspeed(low)", "kimi-for-coding-highspeed(low)"},
 		{"kimi-k2.6(high)", "k2.6(high)"},
 		{"kimi-k2.6[1m](high)", "k2.6(high)"},
 	}


### PR DESCRIPTION
## Summary

Map the K2.7 Code aliases used by CLIProxyAPI to the official Kimi Code upstream IDs.

- kimi-k2.7-code maps to kimi-for-coding
- kimi-k2.7-code-highspeed maps to kimi-for-coding-highspeed
- preserve existing generic normalization for K2.6, K3, context suffixes, and thinking suffixes

## Why

The existing normalizer only strips the kimi- prefix, producing k2.7-code and k2.7-code-highspeed. Those are not the canonical IDs for the Kimi Code endpoint, so a HighSpeed request may not reach the official HighSpeed route.

## Tests

- go test ./internal/runtime/executor -run TestNormalizeKimiUpstreamModel

Closes #4605