### PR TITLE
feat(codex): expose model output capacity

### DIFF
--- a/internal/client/codex/models/models.go
+++ b/internal/client/codex/models/models.go
@@ -59,6 +59,7 @@ func buildCodexClientModels(models []map[string]any, providersForModel Providers
 		if template, ok := templates[id]; ok {
 			entry := cloneCodexClientModelMap(template)
 			applyCodexClientDisplayName(entry, model)
+			applyCodexClientOutputCapacity(entry, id, model)
 			applyCodexClientSearchToolSupport(entry, id, true, providersForModel)
 			sanitizeCodexClientReasoningMetadata(entry)
 			applyCodexClientVisibilityOverride(entry, id)
@@ -68,6 +69,7 @@ func buildCodexClientModels(models []map[string]any, providersForModel Providers
 
 		entry := cloneCodexClientModelMap(defaultTemplate)
 		applyCodexClientModelMetadata(entry, id, model, optimizeMultiAgentV2)
+		applyCodexClientOutputCapacity(entry, id, model)
 		applyCodexClientSearchToolSupport(entry, id, false, providersForModel)
 		sanitizeCodexClientReasoningMetadata(entry)
 		applyCodexClientVisibilityOverride(entry, id)
@@ -179,6 +181,25 @@ func applyCodexClientDisplayName(entry map[string]any, model map[string]any) {
 	if displayName := stringModelValue(model, "display_name"); displayName != "" {
 		entry["display_name"] = displayName
 	}
+}
+
+func applyCodexClientOutputCapacity(entry map[string]any, id string, model map[string]any) {
+	maxOutputTokens := intModelValue(model, "max_completion_tokens")
+	if maxOutputTokens <= 0 {
+		maxOutputTokens = intModelValue(model, "outputTokenLimit")
+	}
+	if info := registry.LookupModelInfo(id); info != nil {
+		if info.MaxCompletionTokens > 0 {
+			maxOutputTokens = info.MaxCompletionTokens
+		} else if info.OutputTokenLimit > 0 {
+			maxOutputTokens = info.OutputTokenLimit
+		}
+	}
+	if maxOutputTokens > 0 {
+		entry["max_output_tokens"] = maxOutputTokens
+		return
+	}
+	delete(entry, "max_output_tokens")
 }
 
 func applyCodexClientSearchToolSupport(entry map[string]any, id string, templateModel bool, providersForModel ProvidersForModelFunc) {

--- a/internal/client/codex/models/models_test.go
+++ b/internal/client/codex/models/models_test.go
@@ -143,6 +143,67 @@ func TestCodexClientModelsResponse_AppliesDisplayNameToTemplateModel(t *testing.
 	}
 }
 
+func TestCodexClientModelsResponse_ExposesKnownOutputCapacity(t *testing.T) {
+	const (
+		templateModelID    = "gpt-5.5"
+		synthesizedModelID = "output-capacity-synthesized-test"
+		fallbackModelID    = "output-capacity-fallback-test"
+		unknownModelID     = "output-capacity-unknown-test"
+		clientID           = "output-capacity-test-client"
+	)
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(clientID, "openai-compatibility", []*registry.ModelInfo{
+		{
+			ID:                  templateModelID,
+			MaxCompletionTokens: 64000,
+		},
+		{
+			ID:                  synthesizedModelID,
+			MaxCompletionTokens: 32000,
+		},
+		{
+			ID:               fallbackModelID,
+			OutputTokenLimit: 16000,
+		},
+		{
+			ID: unknownModelID,
+		},
+	})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	resp := BuildResponse([]map[string]any{
+		{"id": templateModelID},
+		{"id": synthesizedModelID},
+		{"id": fallbackModelID},
+		{"id": unknownModelID},
+	}, nil, false)
+	models, ok := resp["models"].([]map[string]any)
+	if !ok {
+		t.Fatalf("models type = %T, want []map[string]any", resp["models"])
+	}
+
+	bySlug := make(map[string]map[string]any, len(models))
+	for _, model := range models {
+		bySlug[stringModelValue(model, "slug")] = model
+	}
+
+	for modelID, want := range map[string]int{
+		templateModelID:    64000,
+		synthesizedModelID: 32000,
+		fallbackModelID:    16000,
+	} {
+		if got := intModelValue(bySlug[modelID], "max_output_tokens"); got != want {
+			t.Errorf("%s max_output_tokens = %d, want %d", modelID, got, want)
+		}
+	}
+	if _, exists := bySlug[unknownModelID]["max_output_tokens"]; exists {
+		t.Fatalf("unknown capacity must be omitted: %#v", bySlug[unknownModelID])
+	}
+}
+
 func TestCodexClientModelsResponse_DisablesSearchToolForSynthesizedModels(t *testing.T) {
 	resp := BuildResponse([]map[string]any{
 		{"id": "custom-openai-compatible-model"},


### PR DESCRIPTION
## Summary

- expose `max_output_tokens` in Codex client model entries when the registry has an authoritative positive output limit
- support both `MaxCompletionTokens` and `OutputTokenLimit`
- apply the metadata consistently to template-backed and synthesized entries
- omit the field when capacity is unknown

## Why

The catalog already publishes input-context capacity, but clients cannot reserve output headroom without a machine-readable output ceiling. The registry already owns this value, so the catalog can expose it without client-specific defaults or model-name heuristics.

This is metadata only. It does **not** forward `max_output_tokens` in requests; the Codex request path continues to omit that unsupported parameter.

## Validation

- `go test ./internal/client/codex/models ./sdk/api/handlers/openai`
- server build from `./cmd/server`
- `git diff --check`

Closes #4607

## Privacy

The implementation and tests use synthetic model identifiers only. No credentials, account identifiers, local paths, logs, or conversation content are included.