### PR TITLE
feat(codex): allow per-key disable-image-generation override

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -314,6 +314,10 @@ nonstream-keepalive-interval: 0
 #   - api-key: "sk-atSM..."
 #     prefix: "test" # optional: require calls like "test/gpt-5-codex" to target this credential
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
+#     # optional: per-auth override — when true, never inject/forward image_generation for this credential
+#     # even if the global disable-image-generation is false. Useful for mixed Codex upstreams where some
+#     # providers reject hosted image tools ("Image generation is not enabled for this group").
+#     disable-image-generation: false
 #     base-url: "https://www.example.com" # use the custom codex API endpoint
 #     headers:
 #       X-Custom-Header: "custom-value"

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -412,6 +412,13 @@ type CodexKey struct {
 
 	// DisableCooling disables auth/model cooldown scheduling for this credential when true.
 	DisableCooling bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
+
+	// DisableImageGeneration disables image_generation tool injection/passthrough for this
+	// credential when true. This overrides a global disable-image-generation of false/off so
+	// mixed Codex upstreams can keep image gen enabled globally while excluding providers that
+	// reject hosted image_generation tools (e.g. "Image generation is not enabled for this group").
+	// It cannot re-enable image generation when the global mode is true/chat/passthrough.
+	DisableImageGeneration bool `yaml:"disable-image-generation,omitempty" json:"disable-image-generation,omitempty"`
 }
 
 func (k CodexKey) GetAPIKey() string { return k.APIKey }

--- a/internal/runtime/executor/codex_executor_compact_test.go
+++ b/internal/runtime/executor/codex_executor_compact_test.go
@@ -78,3 +78,45 @@ func TestCodexExecutorCompactAddsDefaultInstructionsWithoutInjectingImageTool(t 
 		})
 	}
 }
+
+func TestCodexExecutorCompact_PerAuthDisableStripsImageToolWithoutInjecting(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","object":"response.compaction","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"base_url": server.URL,
+			"api_key":  "test",
+		},
+		Metadata: map[string]any{"disable_image_generation": true},
+	}
+
+	payload := []byte(`{"model":"gpt-5.4","tools":[{"type":"image_generation"},{"type":"web_search"}],"tool_choice":{"type":"allowed_tools","tools":[{"type":"image_generation"},{"type":"web_search"}]},"input":[{"type":"message","role":"user","content":"history"},{"type":"compaction_trigger"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Alt:          "responses/compact",
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	tools := gjson.GetBytes(gotBody, "tools")
+	if !tools.IsArray() || len(tools.Array()) != 1 || tools.Array()[0].Get("type").String() != "web_search" {
+		t.Fatalf("expected only web_search after per-auth strip, got %s", tools.Raw)
+	}
+	choiceTools := gjson.GetBytes(gotBody, "tool_choice.tools")
+	if !choiceTools.IsArray() || len(choiceTools.Array()) != 1 || choiceTools.Array()[0].Get("type").String() != "web_search" {
+		t.Fatalf("expected allowed_tools pruned, got %s", gjson.GetBytes(gotBody, "tool_choice").Raw)
+	}
+}

--- a/internal/runtime/executor/codex_executor_execute.go
+++ b/internal/runtime/executor/codex_executor_execute.go
@@ -219,6 +219,9 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
+	// Compact must never auto-inject image_generation, but per-key disable still needs to
+	// strip any client/payload-rule image tools before /responses/compact.
+	body = stripCodexImageGenerationIfDisabled(auth, body)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body, _ = sjson.DeleteBytes(body, "stream")
 	body = normalizeCodexInstructions(body)

--- a/internal/runtime/executor/codex_executor_execute.go
+++ b/internal/runtime/executor/codex_executor_execute.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -61,9 +60,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body = normalizeCodexInstructions(body)
-	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
-		body = ensureImageGenerationTool(body, baseModel, auth, opts.Headers)
-	}
+	body = applyCodexImageGenerationPolicy(e.cfg, auth, body, baseModel, opts.Headers)
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 	body = normalizeCodexParallelToolCalls(body, opts.Headers)
 	body, optimizeMultiAgentV2 := helps.OptimizeCodexMultiAgentV2Request(ctx, opts.Headers, body, e.cfg)

--- a/internal/runtime/executor/codex_executor_imagegen_test.go
+++ b/internal/runtime/executor/codex_executor_imagegen_test.go
@@ -422,3 +422,19 @@ func TestExecuteOpenAIImageStream_PerAuthDisableFailsFast(t *testing.T) {
 		t.Fatalf("got err=%v status, want 403", err)
 	}
 }
+
+func TestStripCodexImageGenerationIfDisabled(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"image_generation"},{"type":"function","name":"f1"}],"tool_choice":{"type":"image_generation"}}`)
+	if got := stripCodexImageGenerationIfDisabled(nil, body); string(got) != string(body) {
+		t.Fatalf("nil auth must leave body unchanged")
+	}
+	auth := &cliproxyauth.Auth{Metadata: map[string]any{"disable_image_generation": true}}
+	got := stripCodexImageGenerationIfDisabled(auth, body)
+	tools := gjson.GetBytes(got, "tools")
+	if !tools.IsArray() || len(tools.Array()) != 1 || tools.Array()[0].Get("type").String() != "function" {
+		t.Fatalf("expected only function tool remaining, got %s", tools.Raw)
+	}
+	if gjson.GetBytes(got, "tool_choice").Exists() {
+		t.Fatalf("expected tool_choice removed, got %s", gjson.GetBytes(got, "tool_choice").Raw)
+	}
+}

--- a/internal/runtime/executor/codex_executor_imagegen_test.go
+++ b/internal/runtime/executor/codex_executor_imagegen_test.go
@@ -438,3 +438,23 @@ func TestStripCodexImageGenerationIfDisabled(t *testing.T) {
 		t.Fatalf("expected tool_choice removed, got %s", gjson.GetBytes(got, "tool_choice").Raw)
 	}
 }
+
+func TestCodexAuthImageGenerationDisabledErr_IsRequestScoped(t *testing.T) {
+	auth := &cliproxyauth.Auth{Metadata: map[string]any{"disable_image_generation": true}}
+	err := codexAuthImageGenerationDisabledErr(auth)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// Must expose StatusCode for conductor status routing.
+	if se, ok := err.(interface{ StatusCode() int }); !ok || se.StatusCode() != http.StatusForbidden {
+		t.Fatalf("StatusCode() = %v, want 403", se)
+	}
+	// Must expose IsRequestScoped so MarkResult skips cooldown.
+	if rs, ok := err.(interface{ IsRequestScoped() bool }); !ok || !rs.IsRequestScoped() {
+		t.Fatal("expected IsRequestScoped() true to avoid credential cooldown")
+	}
+	// Must NOT be a permanent/cooldown 403 — conductor should failover to next credential.
+	if _, ok := err.(error); !ok {
+		t.Fatal("must implement error")
+	}
+}

--- a/internal/runtime/executor/codex_executor_imagegen_test.go
+++ b/internal/runtime/executor/codex_executor_imagegen_test.go
@@ -439,7 +439,7 @@ func TestStripCodexImageGenerationIfDisabled(t *testing.T) {
 	}
 }
 
-func TestCodexAuthImageGenerationDisabledErr_IsRequestScoped(t *testing.T) {
+func TestCodexAuthImageGenerationDisabledErr_AvailabilityNeutral(t *testing.T) {
 	auth := &cliproxyauth.Auth{Metadata: map[string]any{"disable_image_generation": true}}
 	err := codexAuthImageGenerationDisabledErr(auth)
 	if err == nil {
@@ -449,12 +449,12 @@ func TestCodexAuthImageGenerationDisabledErr_IsRequestScoped(t *testing.T) {
 	if se, ok := err.(interface{ StatusCode() int }); !ok || se.StatusCode() != http.StatusForbidden {
 		t.Fatalf("StatusCode() = %v, want 403", se)
 	}
-	// Must expose IsRequestScoped so MarkResult skips cooldown.
-	if rs, ok := err.(interface{ IsRequestScoped() bool }); !ok || !rs.IsRequestScoped() {
-		t.Fatal("expected IsRequestScoped() true to avoid credential cooldown")
+	// Must expose AvailabilityNeutral so MarkResult skips cooldown while preserving failover.
+	if an, ok := err.(interface{ AvailabilityNeutral() bool }); !ok || !an.AvailabilityNeutral() {
+		t.Fatal("expected AvailabilityNeutral() true to avoid credential cooldown without stopping failover")
 	}
-	// Must NOT be a permanent/cooldown 403 — conductor should failover to next credential.
-	if _, ok := err.(error); !ok {
-		t.Fatal("must implement error")
+	// Must NOT be request-scoped (that would stop failover).
+	if rs, ok := err.(interface{ IsRequestScoped() bool }); ok && rs.IsRequestScoped() {
+		t.Fatal("must not be request-scoped — that would prevent failover to next credential")
 	}
 }

--- a/internal/runtime/executor/codex_executor_imagegen_test.go
+++ b/internal/runtime/executor/codex_executor_imagegen_test.go
@@ -355,3 +355,70 @@ func TestApplyCodexImageGenerationPolicy_GlobalChatDoesNotInject(t *testing.T) {
 		t.Fatalf("expected no tools injection in chat mode, got %s", gjson.GetBytes(result, "tools").Raw)
 	}
 }
+
+func TestCodexAuthImageGenerationDisabledErr(t *testing.T) {
+	if err := codexAuthImageGenerationDisabledErr(nil); err != nil {
+		t.Fatalf("nil auth must allow image generation, got %v", err)
+	}
+	if err := codexAuthImageGenerationDisabledErr(&cliproxyauth.Auth{}); err != nil {
+		t.Fatalf("auth without override must allow image generation, got %v", err)
+	}
+	auth := &cliproxyauth.Auth{Metadata: map[string]any{"disable_image_generation": true}}
+	err := codexAuthImageGenerationDisabledErr(auth)
+	if err == nil {
+		t.Fatal("expected error for disabled image-generation auth")
+	}
+	se, ok := err.(interface{ StatusCode() int })
+	if !ok {
+		t.Fatalf("error %T does not expose StatusCode()", err)
+	}
+	if got := se.StatusCode(); got != http.StatusForbidden {
+		t.Fatalf("StatusCode() = %d, want %d", got, http.StatusForbidden)
+	}
+}
+
+func TestExecuteOpenAIImage_PerAuthDisableFailsFast(t *testing.T) {
+	exec := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{"disable_image_generation": true},
+		Attributes: map[string]string{
+			"api_key":  "sk-test",
+			"base_url": "http://127.0.0.1:1",
+		},
+	}
+	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-image-2",
+		Payload: []byte(`{"model":"gpt-image-2","prompt":"a cat"}`),
+	}, codexOpenAIImageTestOptions(codexImagesGenerationsPath, false))
+	if err == nil {
+		t.Fatal("expected per-auth image disable to reject /v1/images path")
+	}
+	se, ok := err.(interface{ StatusCode() int })
+	if !ok || se.StatusCode() != http.StatusForbidden {
+		t.Fatalf("got err=%v status, want 403", err)
+	}
+}
+
+func TestExecuteOpenAIImageStream_PerAuthDisableFailsFast(t *testing.T) {
+	exec := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{"disable-image-generation": true},
+		Attributes: map[string]string{
+			"api_key":  "sk-test",
+			"base_url": "http://127.0.0.1:1",
+		},
+	}
+	_, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-image-2",
+		Payload: []byte(`{"model":"gpt-image-2","prompt":"a cat","stream":true}`),
+	}, codexOpenAIImageTestOptions(codexImagesGenerationsPath, true))
+	if err == nil {
+		t.Fatal("expected per-auth image disable to reject streaming /v1/images path")
+	}
+	se, ok := err.(interface{ StatusCode() int })
+	if !ok || se.StatusCode() != http.StatusForbidden {
+		t.Fatalf("got err=%v status, want 403", err)
+	}
+}

--- a/internal/runtime/executor/codex_executor_imagegen_test.go
+++ b/internal/runtime/executor/codex_executor_imagegen_test.go
@@ -286,3 +286,72 @@ func TestEnsureImageGenerationTool_FreeCodexAuthDoesNotInjectTool(t *testing.T) 
 		t.Fatalf("expected no tools for free codex auth, got %s", gjson.GetBytes(result, "tools").Raw)
 	}
 }
+
+func TestShouldInjectImageGeneration_GlobalModes(t *testing.T) {
+	if !shouldInjectImageGeneration(nil, nil) {
+		t.Fatal("nil cfg should inject")
+	}
+	if !shouldInjectImageGeneration(&config.Config{}, nil) {
+		t.Fatal("Off mode should inject")
+	}
+	cfgAll := &config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}}
+	if shouldInjectImageGeneration(cfgAll, nil) {
+		t.Fatal("All mode must not inject")
+	}
+	cfgChat := &config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationChat}}
+	if shouldInjectImageGeneration(cfgChat, nil) {
+		t.Fatal("Chat mode must not inject")
+	}
+}
+
+func TestShouldInjectImageGeneration_PerAuthOverride(t *testing.T) {
+	cfgOff := &config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationOff}}
+	auth := &cliproxyauth.Auth{Metadata: map[string]any{"disable_image_generation": true}}
+	if shouldInjectImageGeneration(cfgOff, auth) {
+		t.Fatal("per-auth override must block injection when global is Off")
+	}
+	authFalse := &cliproxyauth.Auth{Metadata: map[string]any{"disable_image_generation": false}}
+	if !shouldInjectImageGeneration(cfgOff, authFalse) {
+		t.Fatal("false override must be treated as unset")
+	}
+}
+
+func TestApplyCodexImageGenerationPolicy_PerAuthOverrideStripsClientTool(t *testing.T) {
+	cfgOff := &config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationOff}}
+	auth := &cliproxyauth.Auth{Metadata: map[string]any{"disable-image-generation": true}}
+	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"image_generation","output_format":"png"},{"type":"function","name":"f1"}],"tool_choice":{"type":"image_generation"}}`)
+	result := applyCodexImageGenerationPolicy(cfgOff, auth, body, "gpt-5.4", nil)
+
+	tools := gjson.GetBytes(result, "tools")
+	if !tools.IsArray() || len(tools.Array()) != 1 {
+		t.Fatalf("expected only function tool remaining, got %s", tools.Raw)
+	}
+	if tools.Array()[0].Get("type").String() != "function" {
+		t.Fatalf("expected remaining tool type=function, got %s", tools.Array()[0].Get("type").String())
+	}
+	if gjson.GetBytes(result, "tool_choice").Exists() {
+		t.Fatalf("expected tool_choice removed, got %s", gjson.GetBytes(result, "tool_choice").Raw)
+	}
+}
+
+func TestApplyCodexImageGenerationPolicy_InjectsWhenEnabled(t *testing.T) {
+	cfgOff := &config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationOff}}
+	body := []byte(`{"model":"gpt-5.4","input":"draw a cat"}`)
+	result := applyCodexImageGenerationPolicy(cfgOff, nil, body, "gpt-5.4", nil)
+	tools := gjson.GetBytes(result, "tools")
+	if !tools.IsArray() || len(tools.Array()) != 1 {
+		t.Fatalf("expected injected image_generation tool, got %s", tools.Raw)
+	}
+	if tools.Array()[0].Get("type").String() != "image_generation" {
+		t.Fatalf("expected type=image_generation, got %s", tools.Array()[0].Get("type").String())
+	}
+}
+
+func TestApplyCodexImageGenerationPolicy_GlobalChatDoesNotInject(t *testing.T) {
+	cfgChat := &config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationChat}}
+	body := []byte(`{"model":"gpt-5.4","input":"draw a cat"}`)
+	result := applyCodexImageGenerationPolicy(cfgChat, nil, body, "gpt-5.4", nil)
+	if gjson.GetBytes(result, "tools").Exists() {
+		t.Fatalf("expected no tools injection in chat mode, got %s", gjson.GetBytes(result, "tools").Raw)
+	}
+}

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -448,16 +448,17 @@ func codexAuthImageGenerationDisabledErr(auth *cliproxyauth.Auth) error {
 	return imageGenDisabledErr{}
 }
 
-// imageGenDisabledErr is a request-scoped sentinel for per-key image_generation opt-out.
-// It carries 403 so the auth conductor treats it like a normal upstream 403 for failover,
-// but RequestScopedError prevents the credential from being cooled down.
+// imageGenDisabledErr is a sentinel for per-key image_generation opt-out.
+// It carries 403 so the auth conductor treats it like a normal upstream 403 for failover
+// (isRequestInvalidError returns false for 403). AvailabilityNeutral prevents the credential
+// from being cooled down via recordAvailabilityNeutralResult in MarkResult.
 type imageGenDisabledErr struct{}
 
 func (imageGenDisabledErr) Error() string {
 	return "image generation disabled for this credential (codex-api-key.disable-image-generation=true)"
 }
-func (imageGenDisabledErr) StatusCode() int       { return http.StatusForbidden }
-func (imageGenDisabledErr) IsRequestScoped() bool { return true }
+func (imageGenDisabledErr) StatusCode() int           { return http.StatusForbidden }
+func (imageGenDisabledErr) AvailabilityNeutral() bool { return true }
 
 // stripCodexImageGenerationIfDisabled strips image_generation tools/tool_choice when this
 // credential has opted out. Unlike applyCodexImageGenerationPolicy it never injects tools,

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -448,6 +448,16 @@ func codexAuthImageGenerationDisabledErr(auth *cliproxyauth.Auth) error {
 	}
 }
 
+// stripCodexImageGenerationIfDisabled strips image_generation tools/tool_choice when this
+// credential has opted out. Unlike applyCodexImageGenerationPolicy it never injects tools,
+// so it is safe for paths such as /responses/compact that must not auto-add hosted tools.
+func stripCodexImageGenerationIfDisabled(auth *cliproxyauth.Auth, body []byte) []byte {
+	if auth == nil || !auth.DisableImageGenerationOverride() {
+		return body
+	}
+	return helps.StripImageGenerationTools(body)
+}
+
 func ensureImageGenerationTool(body []byte, baseModel string, auth *cliproxyauth.Auth, headers http.Header) []byte {
 	if isCodexResponsesLiteRequest(body, headers) {
 		return body

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -438,15 +438,26 @@ func applyCodexImageGenerationPolicy(cfg *config.Config, auth *cliproxyauth.Auth
 // has opted out of hosted image_generation. Image endpoints (/v1/images/*) still build a
 // Responses payload with tool_choice image_generation; rejecting early lets the auth manager
 // try another credential in a mixed pool instead of sending a guaranteed-upstream-403 request.
+//
+// The returned error implements RequestScopedError so MarkResult skips cooldown for this
+// credential — the opt-out is a local policy decision, not an upstream failure.
 func codexAuthImageGenerationDisabledErr(auth *cliproxyauth.Auth) error {
 	if auth == nil || !auth.DisableImageGenerationOverride() {
 		return nil
 	}
-	return statusErr{
-		code: http.StatusForbidden,
-		msg:  "image generation disabled for this credential (codex-api-key.disable-image-generation=true)",
-	}
+	return imageGenDisabledErr{}
 }
+
+// imageGenDisabledErr is a request-scoped sentinel for per-key image_generation opt-out.
+// It carries 403 so the auth conductor treats it like a normal upstream 403 for failover,
+// but RequestScopedError prevents the credential from being cooled down.
+type imageGenDisabledErr struct{}
+
+func (imageGenDisabledErr) Error() string {
+	return "image generation disabled for this credential (codex-api-key.disable-image-generation=true)"
+}
+func (imageGenDisabledErr) StatusCode() int       { return http.StatusForbidden }
+func (imageGenDisabledErr) IsRequestScoped() bool { return true }
 
 // stripCodexImageGenerationIfDisabled strips image_generation tools/tool_choice when this
 // credential has opted out. Unlike applyCodexImageGenerationPolicy it never injects tools,

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -434,6 +434,20 @@ func applyCodexImageGenerationPolicy(cfg *config.Config, auth *cliproxyauth.Auth
 	return body
 }
 
+// codexAuthImageGenerationDisabledErr returns a failover-friendly error when this credential
+// has opted out of hosted image_generation. Image endpoints (/v1/images/*) still build a
+// Responses payload with tool_choice image_generation; rejecting early lets the auth manager
+// try another credential in a mixed pool instead of sending a guaranteed-upstream-403 request.
+func codexAuthImageGenerationDisabledErr(auth *cliproxyauth.Auth) error {
+	if auth == nil || !auth.DisableImageGenerationOverride() {
+		return nil
+	}
+	return statusErr{
+		code: http.StatusForbidden,
+		msg:  "image generation disabled for this credential (codex-api-key.disable-image-generation=true)",
+	}
+}
+
 func ensureImageGenerationTool(body []byte, baseModel string, auth *cliproxyauth.Auth, headers http.Header) []byte {
 	if isCodexResponsesLiteRequest(body, headers) {
 		return body

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -408,6 +408,32 @@ func isCodexResponsesLiteRequest(body []byte, headers http.Header) bool {
 	return value.Type == gjson.True || value.Type == gjson.String && strings.EqualFold(strings.TrimSpace(value.String()), "true")
 }
 
+// shouldInjectImageGeneration reports whether the built-in image_generation tool may be
+// auto-injected for this request. Global disable-image-generation modes other than Off never
+// inject. When the global mode is Off, a per-auth disable_image_generation override still blocks injection.
+func shouldInjectImageGeneration(cfg *config.Config, auth *cliproxyauth.Auth) bool {
+	if cfg != nil && cfg.DisableImageGeneration != config.DisableImageGenerationOff {
+		return false
+	}
+	if auth != nil && auth.DisableImageGenerationOverride() {
+		return false
+	}
+	return true
+}
+
+// applyCodexImageGenerationPolicy applies per-auth image_generation policy after the global
+// payload config has already run. When this credential opts out, strip any remaining
+// image_generation tools/tool_choice that the client or prior stages may have left in place.
+func applyCodexImageGenerationPolicy(cfg *config.Config, auth *cliproxyauth.Auth, body []byte, baseModel string, headers http.Header) []byte {
+	if auth != nil && auth.DisableImageGenerationOverride() {
+		return helps.StripImageGenerationTools(body)
+	}
+	if shouldInjectImageGeneration(cfg, auth) {
+		return ensureImageGenerationTool(body, baseModel, auth, headers)
+	}
+	return body
+}
+
 func ensureImageGenerationTool(body []byte, baseModel string, auth *cliproxyauth.Auth, headers http.Header) []byte {
 	if isCodexResponsesLiteRequest(body, headers) {
 		return body

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -61,9 +60,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = normalizeCodexInstructions(body)
-	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
-		body = ensureImageGenerationTool(body, baseModel, auth, opts.Headers)
-	}
+	body = applyCodexImageGenerationPolicy(e.cfg, auth, body, baseModel, opts.Headers)
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 	body = normalizeCodexParallelToolCalls(body, opts.Headers)
 	body, optimizeMultiAgentV2 := helps.OptimizeCodexMultiAgentV2Request(ctx, opts.Headers, body, e.cfg)

--- a/internal/runtime/executor/codex_openai_images.go
+++ b/internal/runtime/executor/codex_openai_images.go
@@ -82,6 +82,9 @@ func (e *CodexExecutor) resolveGPTImage2BaseModel() string {
 }
 
 func (e *CodexExecutor) executeOpenAIImage(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	if errDisabled := codexAuthImageGenerationDisabledErr(auth); errDisabled != nil {
+		return resp, errDisabled
+	}
 	if directEndpoint := codexDirectOpenAIImageEndpoint(req, opts); directEndpoint != "" {
 		return e.executeDirectOpenAIImage(ctx, auth, req, opts, directEndpoint)
 	}
@@ -179,6 +182,9 @@ func (e *CodexExecutor) executeOpenAIImage(ctx context.Context, auth *cliproxyau
 }
 
 func (e *CodexExecutor) executeOpenAIImageStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	if errDisabled := codexAuthImageGenerationDisabledErr(auth); errDisabled != nil {
+		return nil, errDisabled
+	}
 	if directEndpoint := codexDirectOpenAIImageEndpoint(req, opts); directEndpoint != "" {
 		return e.executeDirectOpenAIImageStream(ctx, auth, req, opts, directEndpoint)
 	}
@@ -316,6 +322,9 @@ func (e *CodexExecutor) executeOpenAIImageStream(ctx context.Context, auth *clip
 }
 
 func (e *CodexExecutor) executeDirectOpenAIImage(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, endpointPath string) (resp cliproxyexecutor.Response, err error) {
+	if errDisabled := codexAuthImageGenerationDisabledErr(auth); errDisabled != nil {
+		return resp, errDisabled
+	}
 	body, contentType, model, errPrepare := codexPrepareDirectOpenAIImageBody(req, opts, false)
 	if errPrepare != nil {
 		return resp, errPrepare
@@ -377,6 +386,9 @@ func (e *CodexExecutor) executeDirectOpenAIImage(ctx context.Context, auth *clip
 }
 
 func (e *CodexExecutor) executeDirectOpenAIImageStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, endpointPath string) (_ *cliproxyexecutor.StreamResult, err error) {
+	if errDisabled := codexAuthImageGenerationDisabledErr(auth); errDisabled != nil {
+		return nil, errDisabled
+	}
 	body, contentType, model, errPrepare := codexPrepareDirectOpenAIImageBody(req, opts, true)
 	if errPrepare != nil {
 		return nil, errPrepare

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/gorilla/websocket"
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -59,9 +58,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body = normalizeCodexInstructions(body)
-	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
-		body = ensureImageGenerationTool(body, baseModel, auth, opts.Headers)
-	}
+	body = applyCodexImageGenerationPolicy(e.cfg, auth, body, baseModel, opts.Headers)
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex websockets executor", body)
 	body = normalizeCodexWebsocketParallelToolCalls(body, opts.Headers)
 	body, optimizeMultiAgentV2 := helps.OptimizeCodexMultiAgentV2Request(ctx, opts.Headers, body, e.cfg)

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/gorilla/websocket"
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -56,9 +55,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = normalizeCodexInstructions(body)
-	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
-		body = ensureImageGenerationTool(body, baseModel, auth, opts.Headers)
-	}
+	body = applyCodexImageGenerationPolicy(e.cfg, auth, body, baseModel, opts.Headers)
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex websockets executor", body)
 	body = normalizeCodexWebsocketParallelToolCalls(body, opts.Headers)
 	body, optimizeMultiAgentV2 := helps.OptimizeCodexMultiAgentV2Request(ctx, opts.Headers, body, e.cfg)

--- a/internal/runtime/executor/helps/payload_helpers.go
+++ b/internal/runtime/executor/helps/payload_helpers.go
@@ -783,8 +783,49 @@ func removeToolChoiceFromPayload(payload []byte, toolChoicePath string, toolType
 				return updated
 			}
 		}
+		return payload
+	}
+	// Responses API allowed_tools form:
+	//   {"type":"allowed_tools","tools":[{"type":"image_generation"}, ...]}
+	// Prune matching nested tool entries; drop the whole tool_choice if nothing remains.
+	if strings.EqualFold(choiceType, "allowed_tools") {
+		return pruneAllowedToolsChoice(payload, toolChoicePath, choice, toolType)
 	}
 	return payload
+}
+
+func pruneAllowedToolsChoice(payload []byte, toolChoicePath string, choice gjson.Result, toolType string) []byte {
+	tools := choice.Get("tools")
+	if !tools.Exists() || !tools.IsArray() {
+		return payload
+	}
+	toolItems := tools.Array()
+	filtered := make([][]byte, 0, len(toolItems))
+	removed := false
+	for _, tool := range toolItems {
+		if strings.EqualFold(strings.TrimSpace(tool.Get("type").String()), toolType) ||
+			strings.EqualFold(strings.TrimSpace(tool.Get("name").String()), toolType) {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, []byte(tool.Raw))
+	}
+	if !removed {
+		return payload
+	}
+	if len(filtered) == 0 {
+		updated, errDel := sjson.DeleteBytes(payload, toolChoicePath)
+		if errDel == nil {
+			return updated
+		}
+		return payload
+	}
+	toolsPath := toolChoicePath + ".tools"
+	updated, errSet := sjson.SetRawBytes(payload, toolsPath, JoinRawJSONArray(filtered))
+	if errSet != nil {
+		return payload
+	}
+	return updated
 }
 
 func removeToolTypeFromToolsArray(payload []byte, toolsPath string, toolType string) []byte {

--- a/internal/runtime/executor/helps/payload_helpers.go
+++ b/internal/runtime/executor/helps/payload_helpers.go
@@ -718,6 +718,14 @@ func payloadQueryTermMatches(item gjson.Result, term string) bool {
 	return gjson.GetBytes(wrapped, "#("+term+")").Exists()
 }
 
+// StripImageGenerationTools removes image_generation tool entries and matching tool_choice
+// from a codex/openai-style payload (tools at the top level).
+func StripImageGenerationTools(payload []byte) []byte {
+	payload = removeToolTypeFromPayloadWithRoot(payload, "", "image_generation")
+	payload = removeToolChoiceFromPayloadWithRoot(payload, "", "image_generation")
+	return payload
+}
+
 func removeToolTypeFromPayloadWithRoot(payload []byte, root string, toolType string) []byte {
 	if len(payload) == 0 {
 		return payload

--- a/internal/runtime/executor/helps/payload_helpers_disable_image_generation_test.go
+++ b/internal/runtime/executor/helps/payload_helpers_disable_image_generation_test.go
@@ -338,3 +338,37 @@ func TestApplyPayloadConfigWithRequest_PayloadConditionsSkipRule(t *testing.T) {
 		})
 	}
 }
+
+func TestStripImageGenerationTools_PrunesAllowedToolsChoice(t *testing.T) {
+	payload := []byte(`{"tools":[{"type":"image_generation"},{"type":"web_search"}],"tool_choice":{"type":"allowed_tools","mode":"auto","tools":[{"type":"image_generation"},{"type":"web_search"}]}}`)
+	out := StripImageGenerationTools(payload)
+
+	tools := gjson.GetBytes(out, "tools")
+	if !tools.IsArray() || len(tools.Array()) != 1 || tools.Array()[0].Get("type").String() != "web_search" {
+		t.Fatalf("expected only web_search tool remaining, got %s", tools.Raw)
+	}
+
+	choiceTools := gjson.GetBytes(out, "tool_choice.tools")
+	if !choiceTools.IsArray() || len(choiceTools.Array()) != 1 {
+		t.Fatalf("expected tool_choice.tools pruned to 1 entry, got %s", choiceTools.Raw)
+	}
+	if got := choiceTools.Array()[0].Get("type").String(); got != "web_search" {
+		t.Fatalf("expected remaining allowed tool type=web_search, got %q", got)
+	}
+	if got := gjson.GetBytes(out, "tool_choice.type").String(); got != "allowed_tools" {
+		t.Fatalf("expected tool_choice.type=allowed_tools, got %q", got)
+	}
+}
+
+func TestStripImageGenerationTools_RemovesAllowedToolsChoiceWhenEmpty(t *testing.T) {
+	payload := []byte(`{"tools":[{"type":"image_generation"}],"tool_choice":{"type":"allowed_tools","tools":[{"type":"image_generation"}]}}`)
+	out := StripImageGenerationTools(payload)
+
+	tools := gjson.GetBytes(out, "tools")
+	if tools.Exists() && tools.IsArray() && len(tools.Array()) != 0 {
+		t.Fatalf("expected tools empty or absent after strip, got %s", tools.Raw)
+	}
+	if gjson.GetBytes(out, "tool_choice").Exists() {
+		t.Fatalf("expected tool_choice removed when allowed_tools becomes empty, got %s", gjson.GetBytes(out, "tool_choice").Raw)
+	}
+}

--- a/internal/watcher/synthesizer/codex_disable_image_generation_test.go
+++ b/internal/watcher/synthesizer/codex_disable_image_generation_test.go
@@ -1,0 +1,52 @@
+package synthesizer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestSynthesizeCodexKeys_DisableImageGeneration(t *testing.T) {
+	s := NewConfigSynthesizer()
+	cfg := &config.Config{
+		CodexKey: []config.CodexKey{
+			{APIKey: "sk-test-image-off", DisableImageGeneration: true},
+			{APIKey: "sk-test-image-default"},
+		},
+	}
+	auths, err := s.Synthesize(&SynthesisContext{Config: cfg, Now: time.Now(), IDGenerator: NewStableIDGenerator()})
+	if err != nil {
+		t.Fatalf("Synthesize error: %v", err)
+	}
+	var foundDisabled, foundDefault bool
+	for _, a := range auths {
+		if a == nil || a.Provider != "codex" {
+			continue
+		}
+		key := a.Attributes["api_key"]
+		switch key {
+		case "sk-test-image-off":
+			foundDisabled = true
+			if a.Metadata == nil || a.Metadata["disable_image_generation"] != true {
+				t.Fatalf("expected disable_image_generation=true metadata, got %#v", a.Metadata)
+			}
+			if !a.DisableImageGenerationOverride() {
+				t.Fatal("expected DisableImageGenerationOverride() true")
+			}
+		case "sk-test-image-default":
+			foundDefault = true
+			if a.Metadata != nil {
+				if _, ok := a.Metadata["disable_image_generation"]; ok {
+					t.Fatalf("default key must not set disable_image_generation, got %#v", a.Metadata)
+				}
+			}
+			if a.DisableImageGenerationOverride() {
+				t.Fatal("default key override must be false")
+			}
+		}
+	}
+	if !foundDisabled || !foundDefault {
+		t.Fatalf("missing auths disabled=%v default=%v total=%d", foundDisabled, foundDefault, len(auths))
+	}
+}

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -203,6 +203,9 @@ func (s *ConfigSynthesizer) synthesizeCodexStyleKeys(ctx *SynthesisContext, entr
 		if entry.DisableCooling {
 			metadata["disable_cooling"] = true
 		}
+		if entry.DisableImageGeneration {
+			metadata["disable_image_generation"] = true
+		}
 		if entry.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(entry.Priority)
 		}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -875,6 +875,20 @@ func (m *Manager) recordExecutionResult(ctx context.Context, result Result, auth
 	m.reportHomeResult(ctx, result, auth)
 }
 
+// recordExecResultAware records an execution result with awareness of availability-neutral errors.
+// When the original error is availability-neutral, it records without changing credential availability.
+func (m *Manager) recordExecResultAware(ctx context.Context, result Result, auth *Auth, ephemeral bool, execErr error) {
+	if ephemeral {
+		m.reportHomeResult(ctx, result, auth)
+		return
+	}
+	if isAvailabilityNeutralError(execErr) {
+		m.recordAvailabilityNeutralResult(ctx, result)
+		return
+	}
+	m.MarkResult(ctx, result)
+}
+
 // reportHomeResult only observes a Home dispatch result and never updates local auth state.
 func (m *Manager) reportHomeResult(ctx context.Context, result Result, auth *Auth) {
 	if m == nil || result.AuthID == "" {
@@ -1111,6 +1125,28 @@ func isRequestScopedError(err error) bool {
 	}
 	requestErr, ok := errors.AsType[cliproxyexecutor.RequestScopedError](err)
 	return ok && requestErr != nil && requestErr.IsRequestScoped()
+}
+
+// isAvailabilityNeutralError reports whether err implements AvailabilityNeutral.
+// Availability-neutral errors should not change credential availability (no cooldown)
+// while still allowing failover to the next credential.
+func isAvailabilityNeutralError(err error) bool {
+	if err == nil {
+		return false
+	}
+	an, ok := errors.AsType[cliproxyexecutor.AvailabilityNeutral](err)
+	return ok && an != nil && an.AvailabilityNeutral()
+}
+
+// markResultForExecError records an execution result. If the original executor error
+// is availability-neutral, the result is recorded without changing credential availability
+// (no cooldown, no suspension). Otherwise, the standard MarkResult path applies.
+func (m *Manager) markResultForExecError(ctx context.Context, result Result, execErr error) {
+	if isAvailabilityNeutralError(execErr) {
+		m.recordAvailabilityNeutralResult(ctx, result)
+		return
+	}
+	m.MarkResult(ctx, result)
 }
 
 func resultErrorFromError(err error) *Error {

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -327,7 +327,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
 				}
-				m.MarkResult(execCtx, result)
+				m.markResultForExecError(execCtx, result, errExec)
 				if isRequestInvalidError(errExec) {
 					return cliproxyexecutor.Response{}, errExec
 				}
@@ -444,7 +444,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				// count_tokens route and return a generic endpoint 404. Record
 				// the failure for hooks and metrics without suspending a model
 				// that remains usable through the messages endpoint.
-				if isCountTokensEndpointNotFoundError(errExec, execReq.Model) {
+				if isCountTokensEndpointNotFoundError(errExec, execReq.Model) || isAvailabilityNeutralError(errExec) {
 					m.recordAvailabilityNeutralResult(execCtx, result)
 				} else {
 					m.MarkResult(execCtx, result)

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -224,7 +224,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			rerr := resultErrorFromError(errStream)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
 			result.RetryAfter = retryAfterFromError(errStream)
-			m.recordExecutionResult(ctx, result, auth, ephemeralResult)
+			m.recordExecResultAware(ctx, result, auth, ephemeralResult, errStream)
 			if isRequestInvalidError(errStream) {
 				return nil, errStream
 			}

--- a/sdk/cliproxy/auth/disable_image_generation_override_test.go
+++ b/sdk/cliproxy/auth/disable_image_generation_override_test.go
@@ -1,0 +1,21 @@
+package auth
+
+import "testing"
+
+func TestDisableImageGenerationOverride(t *testing.T) {
+	if (&Auth{}).DisableImageGenerationOverride() {
+		t.Fatal("nil metadata must be false")
+	}
+	if (&Auth{Metadata: map[string]any{"disable_image_generation": false}}).DisableImageGenerationOverride() {
+		t.Fatal("false must be treated as unset/false")
+	}
+	if !(&Auth{Metadata: map[string]any{"disable_image_generation": true}}).DisableImageGenerationOverride() {
+		t.Fatal("snake_case true must be honored")
+	}
+	if !(&Auth{Metadata: map[string]any{"disable-image-generation": true}}).DisableImageGenerationOverride() {
+		t.Fatal("kebab-case true must be honored")
+	}
+	if !(&Auth{Metadata: map[string]any{"disable_image_generation": "true"}}).DisableImageGenerationOverride() {
+		t.Fatal("string true must be honored")
+	}
+}

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -459,6 +459,25 @@ func (a *Auth) DisableCoolingOverride() (bool, bool) {
 	return false, false
 }
 
+// DisableImageGenerationOverride returns whether this auth forces image_generation off.
+// The value is read from metadata key "disable_image_generation" (or "disable-image-generation").
+//
+// Like DisableCoolingOverride, this is intentionally "true-only": a false metadata value is
+// treated as unset so the global disable-image-generation mode remains authoritative.
+func (a *Auth) DisableImageGenerationOverride() bool {
+	if a == nil || a.Metadata == nil {
+		return false
+	}
+	for _, key := range []string{"disable_image_generation", "disable-image-generation"} {
+		if val, ok := a.Metadata[key]; ok {
+			if parsed, okParse := parseBoolAny(val); okParse {
+				return parsed
+			}
+		}
+	}
+	return false
+}
+
 // ToolPrefixDisabled returns whether the proxy_ tool name prefix should be
 // skipped for this auth. When true, tool names are sent to Anthropic unchanged.
 // The value is read from metadata key "tool_prefix_disabled" (or "tool-prefix-disabled").

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -170,3 +170,12 @@ type RequestScopedError interface {
 	error
 	IsRequestScoped() bool
 }
+
+// AvailabilityNeutral marks an error that should not change credential availability
+// (no cooldown, no suspension) while still allowing the auth manager to failover
+// to the next credential. Unlike RequestScopedError, AvailabilityNeutral does not
+// stop the failover loop.
+type AvailabilityNeutral interface {
+	error
+	AvailabilityNeutral() bool
+}


### PR DESCRIPTION
## Summary
- Add per-credential `disable-image-generation` on `codex-api-key` entries (true-only override, same pattern as `disable-cooling`).
- When set, that Codex credential skips auto-injection of the hosted `image_generation` tool and strips client-provided `image_generation` tools/`tool_choice`, even if the global `disable-image-generation` is `false`.
- Global modes `true` / `chat` / `passthrough` remain authoritative and cannot be re-enabled by a per-key flag.

## Why
Mixed Codex API-key upstreams often include providers that reject hosted image tools with:
`403 Image generation is not enabled for this group`
while others support them. The global switch alone forces either "inject for everyone" or "disable for everyone". Per-key override lets operators keep image gen enabled globally and opt out only the unsupported credentials.

## Usage
```yaml
disable-image-generation: false   # keep global image gen on

codex-api-key:
  - api-key: "sk-supported..."
    base-url: "https://supported.example/v1"
  - api-key: "sk-no-image..."
    base-url: "https://no-image.example/v1"
    disable-image-generation: true  # opt out this credential only
```

OAuth/auth-file credentials can set the same via metadata:
`disable_image_generation: true` or `disable-image-generation: true`.

## Test plan
- [x] `go test ./sdk/cliproxy/auth/ -run TestDisableImageGenerationOverride`
- [x] `go test ./internal/runtime/executor/ -run "ImageGeneration|ApplyCodexImageGeneration"`
- [x] `go test ./internal/watcher/synthesizer/ -run DisableImageGeneration`
- [x] `go test ./internal/runtime/executor/helps/ -run DisableImageGeneration`
- [x] package tests for auth / synthesizer / executor / helps
- [x] `go build -o test-output ./cmd/server`