### PR TITLE
feat(registry): add Kimi K3 256K (kimi-k3-256k) to the model catalog

### DIFF
--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -35,6 +35,32 @@ func TestGeminiVertexModelsUseFlashLiteReleaseID(t *testing.T) {
 	t.Fatalf("Vertex models do not contain %q", releaseID)
 }
 
+func TestGetKimiModelsIncludesK3_256K(t *testing.T) {
+	for _, model := range GetKimiModels() {
+		if model == nil || model.ID != "kimi-k3-256k" {
+			continue
+		}
+		if model.ContextLength != 262144 {
+			t.Fatalf("kimi-k3-256k context_length = %d, want 262144 (256K)", model.ContextLength)
+		}
+		if model.Thinking == nil {
+			t.Fatal("kimi-k3-256k thinking config = nil, want levels low/high/max")
+		}
+		wantLevels := map[string]bool{"low": true, "high": true, "max": true}
+		if len(model.Thinking.Levels) != len(wantLevels) {
+			t.Fatalf("kimi-k3-256k thinking levels = %v, want [low high max]", model.Thinking.Levels)
+		}
+		for _, level := range model.Thinking.Levels {
+			if !wantLevels[level] {
+				t.Fatalf("kimi-k3-256k thinking level %q not in [low high max]", level)
+			}
+		}
+		return
+	}
+
+	t.Fatal("Kimi models do not contain kimi-k3-256k")
+}
+
 func TestWithXAIBuiltinsIncludesVideoPreviewModel(t *testing.T) {
 	models := WithXAIBuiltins(nil)
 

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2420,6 +2420,25 @@
           "max"
         ]
       }
+    },
+    {
+      "id": "kimi-k3-256k",
+      "object": "model",
+      "created": 1785110400,
+      "owned_by": "moonshot",
+      "type": "kimi",
+      "display_name": "Kimi K3 256K",
+      "description": "Kimi K3 256K - 256K context version of Kimi K3 delivering the same results within 256K context at reduced quota consumption; supports image input only (no video)",
+      "context_length": 262144,
+      "max_completion_tokens": 65536,
+      "thinking": {
+        "zero_allowed": false,
+        "levels": [
+          "low",
+          "high",
+          "max"
+        ]
+      }
     }
   ],
   "antigravity": [

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -526,6 +526,9 @@ func TestNormalizeKimiUpstreamModel(t *testing.T) {
 		{"kimi-k2.6[1m]", "k2.6"},
 		{"kimi-k3(1024)", "k3(1024)"},
 		{"kimi-k3[1m](1024)", "k3(1024)"},
+		{"kimi-k3-256k", "k3-256k"},
+		{"kimi-k3-256k[1m]", "k3-256k"},
+		{"kimi-k3-256k(high)", "k3-256k(high)"},
 		{"kimi-k2.6(high)", "k2.6(high)"},
 		{"kimi-k2.6[1m](high)", "k2.6(high)"},
 	}


### PR DESCRIPTION
## Summary

Closes #4612

Kimi announced **`k3-256k`** — the 256K-context variant of Kimi K3, and the only K3 model available to Moderato-tier subscriptions. This PR adds it to the embedded Kimi model catalog (`internal/registry/models/models.json`) so CLIProxyAPI clients can discover and select it.

## Change

- **`internal/registry/models/models.json`**: new `kimi-k3-256k` entry in the `kimi` section, mirroring `kimi-k3`:
  - `context_length: 262144` (256K, per the upstream spec)
  - `max_completion_tokens: 65536`
  - thinking levels `low/high/max` with `zero_allowed: false` (matches `reasoning_effort: low/high/max`, default `high` in the Kimi docs)
  - description notes image-only input (no video), per the announcement

## Why no executor changes are needed

The Kimi executor's `normalizeKimiUpstreamModel` strips the `kimi-` prefix (and any `[1m]` context suffix), so `kimi-k3-256k` → upstream model ID `k3-256k`, exactly matching the documented upstream ID. Thinking application is registry-driven via the catalog entry's thinking levels.

## Tests

- New `TestGetKimiModelsIncludesK3_256K` (registry): asserts the catalog entry exists with 256K context length and `low/high/max` thinking levels.
- Extended `TestNormalizeKimiUpstreamModel` (executor): covers `kimi-k3-256k` → `k3-256k`, incl. `[1m]` and thinking-suffix variants.
- `go test ./...`: 85 packages ok, 0 failures.

## Notes

- The embedded `models.json` is the fallback catalog; the live catalog refreshes from `router-for-me/models` (`models.json`). The same entry should be added there so refreshed installs pick it up — flagged here since that repo is separate.