### PR TITLE
fix(codex): hydrate missing function output IDs from SSE events

### DIFF
--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -49,6 +49,35 @@ func TestCodexExecutorExecute_EmptyStreamCompletionOutputUsesOutputItemDone(t *t
 	}
 }
 
+func TestCodexExecutorExecute_HydratesFunctionCallIDFromOutputItemDone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_123","type":"function_call","call_id":"call_123","name":"weather","arguments":"{\"city\":\"Shanghai\"}","status":"completed"}}` + "\n"))
+		_, _ = w.Write([]byte(`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","model":"gpt-5.5","output":[{"id":null,"type":"function_call","call_id":"call_123","name":"weather","arguments":"{\"city\":\"Shanghai\"}"}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"Call weather"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := gjson.GetBytes(resp.Payload, "output.0.id").String(); got != "fc_123" {
+		t.Fatalf("output function_call id = %q, want fc_123; payload=%s", got, resp.Payload)
+	}
+}
+
 func TestCodexExecutorExecuteSurfacesTerminalStreamError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/internal/runtime/executor/codex_executor_terminal.go
+++ b/internal/runtime/executor/codex_executor_terminal.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,8 +30,8 @@ func (codexIncompleteStreamError) IsRequestScoped() bool {
 }
 
 // Streamed Codex responses may emit response.output_item.done events while leaving
-// response.completed.response.output empty. Keep the stream path aligned with the
-// already-patched non-stream path by reconstructing response.output from those items.
+// response.completed.response.output empty, or with item IDs omitted. Keep the stream
+// path aligned with the completed item events, which contain the authoritative items.
 func collectCodexOutputItemDone(eventData []byte, outputItemsByIndex map[int64][]byte, outputItemsFallback *[][]byte) {
 	itemResult := gjson.GetBytes(eventData, "item")
 	if !itemResult.Exists() || itemResult.Type != gjson.JSON {
@@ -46,9 +47,11 @@ func collectCodexOutputItemDone(eventData []byte, outputItemsByIndex map[int64][
 
 func patchCodexCompletedOutput(eventData []byte, outputItemsByIndex map[int64][]byte, outputItemsFallback [][]byte) []byte {
 	outputResult := gjson.GetBytes(eventData, "response.output")
-	shouldPatchOutput := (!outputResult.Exists() || !outputResult.IsArray() || len(outputResult.Array()) == 0) && (len(outputItemsByIndex) > 0 || len(outputItemsFallback) > 0)
-	if !shouldPatchOutput {
+	if len(outputItemsByIndex) == 0 && len(outputItemsFallback) == 0 {
 		return eventData
+	}
+	if outputResult.Exists() && outputResult.IsArray() && len(outputResult.Array()) > 0 {
+		return hydrateCodexCompletedOutputIDs(eventData, outputResult.Array(), outputItemsByIndex, outputItemsFallback)
 	}
 
 	indexes := make([]int64, 0, len(outputItemsByIndex))
@@ -89,6 +92,51 @@ func patchCodexCompletedOutput(eventData []byte, outputItemsByIndex map[int64][]
 
 	completedDataPatched, _ := sjson.SetRawBytes(eventData, "response.output", outputArray)
 	return completedDataPatched
+}
+
+// hydrateCodexCompletedOutputIDs fills only missing output item IDs. Some compatible
+// Codex backends omit IDs in response.completed but include them in the matching
+// response.output_item.done event. Leaving populated IDs untouched preserves a
+// backend's final representation whenever it is complete.
+func hydrateCodexCompletedOutputIDs(eventData []byte, outputItems []gjson.Result, outputItemsByIndex map[int64][]byte, outputItemsFallback [][]byte) []byte {
+	patched := eventData
+	for index, outputItem := range outputItems {
+		if strings.TrimSpace(outputItem.Get("id").String()) != "" {
+			continue
+		}
+
+		doneItem := codexCompletedOutputItemDone(index, outputItem, outputItemsByIndex, outputItemsFallback)
+		if len(doneItem) == 0 {
+			continue
+		}
+		id := strings.TrimSpace(gjson.GetBytes(doneItem, "id").String())
+		if id == "" {
+			continue
+		}
+		if updated, err := sjson.SetBytes(patched, "response.output."+strconv.Itoa(index)+".id", id); err == nil {
+			patched = updated
+		}
+	}
+	return patched
+}
+
+func codexCompletedOutputItemDone(index int, outputItem gjson.Result, outputItemsByIndex map[int64][]byte, outputItemsFallback [][]byte) []byte {
+	if item, ok := outputItemsByIndex[int64(index)]; ok {
+		return item
+	}
+
+	outputType := outputItem.Get("type").String()
+	outputCallID := outputItem.Get("call_id").String()
+	for _, item := range outputItemsFallback {
+		if outputType != "" && gjson.GetBytes(item, "type").String() != outputType {
+			continue
+		}
+		if outputCallID != "" && gjson.GetBytes(item, "call_id").String() != outputCallID {
+			continue
+		}
+		return item
+	}
+	return nil
 }
 
 func codexTerminalStreamContextLengthErr(eventData []byte) (statusErr, bool) {


### PR DESCRIPTION
## Summary

Fixes a compatibility gap in the Codex HTTP executor for Responses-style SSE streams.

Some compatible upstreams send a complete function-call item in `response.output_item.done`, then repeat the same item in `response.completed` with `id: null`.

CLIProxyAPI already buffers completed output items to rebuild an empty terminal `response.output`. This change also fills **only a missing terminal item ID** from that buffered item.

## Behavior

- Match the completed item by `output_index` first.
- Use the existing type and `call_id` fallback only when an output index is unavailable.
- Preserve a non-empty terminal `id`.
- Preserve every other field in the terminal output item.
- Retain the existing full reconstruction path for an empty terminal output array.

## Regression Test

Adds a non-streaming Responses test with:

```text
response.output_item.done: item.id = fc_123
response.completed:         response.output[0].id = null
```

The translated response is asserted to contain `output[0].id == fc_123`.

## Verification

```bash
go test ./internal/runtime/executor -run TestCodex -count=1
```

Fixes #4622