### PR TITLE
feat(signature): validate Claude CAIS reasoning signatures

### DIFF
--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -37,9 +37,10 @@ func SanitizeClaudeMessagesSignaturesForModel(payload []byte, targetModel string
 }
 
 // SanitizeClaudeMessagesForClaudeUpstream prepares a Claude /v1/messages body
-// for native Claude upstreams. Invalid thinking blocks are dropped, valid
-// thinking signatures are normalized to Claude provider-native E-form, and
-// tool_use blocks keep only their tool-call payload.
+// for Claude-compatible upstreams. Valid Claude signatures are normalized to
+// provider-native E-form, valid Claude CAIS signatures are kept,
+// incompatible thinking blocks are dropped, and tool_use blocks keep only their
+// tool-call payload.
 func SanitizeClaudeMessagesForClaudeUpstream(payload []byte, targetModel string) ([]byte, SignatureSanitizeReport) {
 	return SanitizeClaudeMessagesSignaturesForTarget(payload, ClaudeMessagesSignatureSanitizeOptions{
 		TargetProvider:                SignatureProviderClaude,
@@ -94,7 +95,7 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 					keptParts = append(keptParts, updatedPart)
 					continue
 				}
-				updatedPart, changed, decisions := sanitizeClaudeToolUseSignature(part, targetProvider, i, j)
+				updatedPart, changed, decisions := sanitizeClaudeToolUseSignature(part, targetProvider, opts.TargetModel, i, j)
 				report.Decisions = append(report.Decisions, decisions...)
 				if changed {
 					messageModified = true
@@ -124,7 +125,7 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 			}
 
 			rawSignature := part.Get("signature").String()
-			decision := DecideSignatureCompatibility(targetProvider, rawSignature, SignatureBlockKindClaudeThinking)
+			decision := DecideSignatureCompatibilityForModel(targetProvider, opts.TargetModel, rawSignature, SignatureBlockKindClaudeThinking)
 			decision.Reason = fmt.Sprintf("messages[%d].content[%d]: %s", i, j, decision.Reason)
 			report.Decisions = append(report.Decisions, decision)
 
@@ -195,7 +196,7 @@ func stripClaudeToolUseSignatureFields(part gjson.Result) (string, bool) {
 	return updated, changed
 }
 
-func sanitizeClaudeToolUseSignature(part gjson.Result, targetProvider SignatureProvider, messageIdx, partIdx int) (string, bool, []SignatureCompatibilityDecision) {
+func sanitizeClaudeToolUseSignature(part gjson.Result, targetProvider SignatureProvider, targetModel string, messageIdx, partIdx int) (string, bool, []SignatureCompatibilityDecision) {
 	updated := part.Raw
 	changed := false
 	var decisions []SignatureCompatibilityDecision
@@ -212,7 +213,7 @@ func sanitizeClaudeToolUseSignature(part gjson.Result, targetProvider SignatureP
 		} else if targetProvider == SignatureProviderGPT {
 			blockKind = SignatureBlockKindGPTReasoning
 		}
-		decision := DecideSignatureCompatibility(targetProvider, sigResult.String(), blockKind)
+		decision := DecideSignatureCompatibilityForModel(targetProvider, targetModel, sigResult.String(), blockKind)
 		decision.Reason = fmt.Sprintf("messages[%d].content[%d].%s: %s", messageIdx, partIdx, sigPath, decision.Reason)
 		decisions = append(decisions, decision)
 

--- a/internal/signature/claude_test.go
+++ b/internal/signature/claude_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/tidwall/gjson"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 func TestStripInvalidClaudeThinkingBlocks_RemovesGPTEncryptedContent(t *testing.T) {
@@ -157,5 +158,484 @@ func TestStripInvalidClaudeThinkingBlocks_KeepsClaudeSignaturePrefixes(t *testin
 	content := gjson.GetBytes(out, "messages.0.content").Array()
 	if len(content) != 2 {
 		t.Fatalf("content length = %d, want 2: %s", len(content), string(out))
+	}
+}
+
+const observedFable5Sample = "CAISqwIKiAEIEBgCKkBHRlRBsNiptQUWfPoOhuQKwi5LnncZVO9bB5jqOs76D7uBtgktML0zqJtNmLHXHHcgD6lk4MQu4QBXzFd1lbC3Mg5jbGF1ZGUtZmFibGUtNTgBQgh0aGlua2luZ1okZDk3NDM5NzUtNGJiMC00OTM2LTllMjgtZDViMGQyMWJkYzQ4EgxCGh+XVFFFeySAjtAaDL/A1LltGu6MMJ+eXSIwsN0oBpDrqLv22UBfkMnTotnIbkvkOyb9xZHgigG6OZVHaI3gThm+maLKmgO5PrFLKlDFYp+YZksy/wKwszJlnLTPzAK+NUlfzagOE1ymtZTXhAYK260XyFYmg/te/C231+Fr/hoX+EJoUBnrn0gD7hqMISOT+TaFEuOXYsN517GfaxgB"
+
+const observedContextID = "d9743975-4bb0-4936-9e28-d5b0d21bdc48"
+
+// claudeCAISParts builds Claude CAIS signatures field by field so tests can
+// assert both the observed layout and the upstream drift the validator must
+// tolerate or reject.
+type claudeCAISParts struct {
+	includeTopEnvelope   bool
+	topEnvelope          uint64
+	includeTopTrailer    bool
+	includeContainer     bool
+	includeChannelBlock  bool
+	includeChannelID     bool
+	channelID            uint64
+	channelIDAsBytes     bool
+	includeChannelVerion bool
+	includeSignature     bool
+	signatureLen         int
+	includeModelText     bool
+	modelText            []byte
+	includeField7        bool
+	blockKind            string
+	contextID            string
+}
+
+// defaultClaudeCAISParts mirrors the layout observed on claude-fable-5 and
+// claude-opus-5 responses.
+func defaultClaudeCAISParts(model string) claudeCAISParts {
+	return claudeCAISParts{
+		includeTopEnvelope:   true,
+		topEnvelope:          2,
+		includeTopTrailer:    true,
+		includeContainer:     true,
+		includeChannelBlock:  true,
+		includeChannelID:     true,
+		channelID:            16,
+		includeChannelVerion: true,
+		includeSignature:     true,
+		signatureLen:         64,
+		includeModelText:     true,
+		modelText:            []byte(model),
+		includeField7:        true,
+		blockKind:            "thinking",
+		contextID:            observedContextID,
+	}
+}
+
+func (p claudeCAISParts) encode() string {
+	var channelBlock []byte
+	if p.includeChannelID {
+		if p.channelIDAsBytes {
+			channelBlock = protowire.AppendTag(channelBlock, 1, protowire.BytesType)
+			channelBlock = protowire.AppendBytes(channelBlock, []byte{0x10})
+		} else {
+			channelBlock = protowire.AppendTag(channelBlock, 1, protowire.VarintType)
+			channelBlock = protowire.AppendVarint(channelBlock, p.channelID)
+		}
+	}
+	if p.includeChannelVerion {
+		channelBlock = protowire.AppendTag(channelBlock, 3, protowire.VarintType)
+		channelBlock = protowire.AppendVarint(channelBlock, 2)
+	}
+	if p.includeSignature {
+		channelBlock = protowire.AppendTag(channelBlock, 5, protowire.BytesType)
+		channelBlock = protowire.AppendBytes(channelBlock, make([]byte, p.signatureLen))
+	}
+	if p.includeModelText {
+		channelBlock = protowire.AppendTag(channelBlock, 6, protowire.BytesType)
+		channelBlock = protowire.AppendBytes(channelBlock, p.modelText)
+	}
+	if p.includeField7 {
+		channelBlock = protowire.AppendTag(channelBlock, 7, protowire.VarintType)
+		channelBlock = protowire.AppendVarint(channelBlock, 1)
+	}
+	if p.blockKind != "" {
+		channelBlock = protowire.AppendTag(channelBlock, 8, protowire.BytesType)
+		channelBlock = protowire.AppendString(channelBlock, p.blockKind)
+	}
+	if p.contextID != "" {
+		channelBlock = protowire.AppendTag(channelBlock, 11, protowire.BytesType)
+		channelBlock = protowire.AppendString(channelBlock, p.contextID)
+	}
+
+	var container []byte
+	if p.includeChannelBlock {
+		container = protowire.AppendTag(container, 1, protowire.BytesType)
+		container = protowire.AppendBytes(container, channelBlock)
+	}
+
+	var payload []byte
+	if p.includeTopEnvelope {
+		payload = protowire.AppendTag(payload, 1, protowire.VarintType)
+		payload = protowire.AppendVarint(payload, p.topEnvelope)
+	}
+	if p.includeContainer {
+		payload = protowire.AppendTag(payload, 2, protowire.BytesType)
+		payload = protowire.AppendBytes(payload, container)
+	}
+	if p.includeTopTrailer {
+		payload = protowire.AppendTag(payload, 3, protowire.VarintType)
+		payload = protowire.AppendVarint(payload, 1)
+	}
+	return base64.StdEncoding.EncodeToString(payload)
+}
+
+func testClaudeCAISSignature(model string) string {
+	return defaultClaudeCAISParts(model).encode()
+}
+
+func TestClaudeCAISSignature_ObservedFable5Sample(t *testing.T) {
+	if !IsValidClaudeCAISSignature(observedFable5Sample) {
+		t.Fatal("IsValidClaudeCAISSignature(observedFable5Sample) = false, want true")
+	}
+
+	info, err := InspectClaudeCAISSignature(observedFable5Sample)
+	if err != nil {
+		t.Fatalf("InspectClaudeCAISSignature failed: %v", err)
+	}
+
+	if info.ModelText != "claude-fable-5" {
+		t.Fatalf("ModelText = %q, want %q", info.ModelText, "claude-fable-5")
+	}
+	if info.BlockKind != "thinking" {
+		t.Fatalf("BlockKind = %q, want %q", info.BlockKind, "thinking")
+	}
+	expectedUUID := "d9743975-4bb0-4936-9e28-d5b0d21bdc48"
+	if info.ContextID != expectedUUID {
+		t.Fatalf("ContextID = %q, want %q", info.ContextID, expectedUUID)
+	}
+	if info.FirstByte != 0x08 {
+		t.Fatalf("FirstByte = 0x%02x, want 0x08", info.FirstByte)
+	}
+}
+
+func TestClaudeCAISSignature_DetectSignatureProvider(t *testing.T) {
+	prefixes := []string{
+		"",
+		"ccmax#",
+		"claude-code-max#",
+		"claude_code_max#",
+		"cais#",
+		"claude-cais#",
+		"claude_cais#",
+		"claude#",
+	}
+	for _, prefix := range prefixes {
+		sig := prefix + observedFable5Sample
+		got := DetectSignatureProvider(sig)
+		if got != SignatureProviderClaude {
+			t.Errorf("DetectSignatureProvider(%q) = %q, want %q", sig, got, SignatureProviderClaude)
+		}
+	}
+}
+
+func TestClaudeCAISSignature_ObservedOpus5Layout(t *testing.T) {
+	signature := testClaudeCAISSignature("claude-opus-5")
+	info, err := InspectClaudeCAISSignature(signature)
+	if err != nil {
+		t.Fatalf("InspectClaudeCAISSignature failed: %v", err)
+	}
+	if info.ModelText != "claude-opus-5" {
+		t.Fatalf("ModelText = %q, want claude-opus-5", info.ModelText)
+	}
+	decision := DecideSignatureCompatibilityForModel(SignatureProviderClaude, "claude-opus-5", signature, SignatureBlockKindClaudeThinking)
+	if !decision.Compatible || decision.NormalizedSignature != signature || decision.DetectedProvider != SignatureProviderClaude {
+		t.Fatalf("same-model opus-5 decision = %+v, want preserved with DetectedProvider=claude", decision)
+	}
+}
+
+func TestClaudeCAISSignature_NotCompatibleWithGemini(t *testing.T) {
+	if normalized, ok := CompatibleSignatureForProvider(SignatureProviderGemini, observedFable5Sample); ok || normalized != "" {
+		t.Fatalf("CompatibleSignatureForProvider(Gemini) = %q, %v; want empty and false", normalized, ok)
+	}
+	if IsSignatureCompatibleWithProvider(SignatureProviderGemini, observedFable5Sample) {
+		t.Fatal("IsSignatureCompatibleWithProvider(Gemini) = true, want false")
+	}
+	if isRecognizedGeminiProviderSignature(observedFable5Sample, SignatureBlockKindUnknown) {
+		t.Fatal("isRecognizedGeminiProviderSignature = true, want false")
+	}
+	if _, err := InspectGeminiThoughtSignature(observedFable5Sample); err == nil {
+		t.Fatal("InspectGeminiThoughtSignature should fail for Claude CAIS signature")
+	}
+}
+
+func TestClaudeCAISSignature_CompatibleWithAllClaudeTargets(t *testing.T) {
+	decision := DecideSignatureCompatibilityForModel(SignatureProviderClaude, "claude-fable-5", observedFable5Sample, SignatureBlockKindClaudeThinking)
+	if !decision.Compatible || decision.Action != SignatureActionPreserve || decision.NormalizedSignature != observedFable5Sample || decision.DetectedProvider != SignatureProviderClaude {
+		t.Fatalf("DecideSignatureCompatibilityForModel(Claude, claude-fable-5) = %+v, want compatible & preserved with DetectedProvider=claude", decision)
+	}
+
+	decisionCase := DecideSignatureCompatibilityForModel(SignatureProviderClaude, "CLAUDE-FABLE-5", observedFable5Sample, SignatureBlockKindClaudeThinking)
+	if !decisionCase.Compatible || decisionCase.Action != SignatureActionPreserve {
+		t.Fatalf("DecideSignatureCompatibilityForModel case-insensitive failed: %+v", decisionCase)
+	}
+
+	decisionDiff := DecideSignatureCompatibilityForModel(SignatureProviderClaude, "claude-opus-5", observedFable5Sample, SignatureBlockKindClaudeThinking)
+	if !decisionDiff.Compatible || decisionDiff.Action != SignatureActionPreserve || decisionDiff.NormalizedSignature != observedFable5Sample {
+		t.Fatalf("DecideSignatureCompatibilityForModel(Claude, claude-opus-5) = %+v, want compatible & preserved", decisionDiff)
+	}
+
+	opus5Sig := testClaudeCAISSignature("claude-opus-5")
+	decisionOpusToOpus48 := DecideSignatureCompatibilityForModel(SignatureProviderClaude, "claude-opus-4-8", opus5Sig, SignatureBlockKindClaudeThinking)
+	if !decisionOpusToOpus48.Compatible || decisionOpusToOpus48.Action != SignatureActionPreserve || decisionOpusToOpus48.NormalizedSignature != opus5Sig {
+		t.Fatalf("DecideSignatureCompatibilityForModel(Claude, claude-opus-4-8) with opus-5 signature = %+v, want compatible & preserved", decisionOpusToOpus48)
+	}
+
+	if normalized, ok := CompatibleSignatureForProvider(SignatureProviderClaude, observedFable5Sample); !ok || normalized != observedFable5Sample {
+		t.Fatalf("CompatibleSignatureForProvider(Claude, observedFable5Sample) = %q, %v; want %q, true", normalized, ok, observedFable5Sample)
+	}
+
+	decisionGemini := DecideSignatureCompatibilityForModel(SignatureProviderGemini, "claude-fable-5", observedFable5Sample, SignatureBlockKindClaudeThinking)
+	if decisionGemini.Compatible {
+		t.Fatalf("DecideSignatureCompatibilityForModel(Gemini, claude-fable-5) = %+v, want incompatible", decisionGemini)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstream_ClaudeCAIS(t *testing.T) {
+	inputSame := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"keep","signature":"` + observedFable5Sample + `"},{"type":"text","text":"answer"}]}]}`)
+
+	outputSame, reportSame := SanitizeClaudeMessagesForClaudeUpstream(inputSame, "claude-fable-5")
+	if reportSame.Preserved != 1 || reportSame.DroppedBlocks != 0 {
+		t.Fatalf("unexpected report for same model: %+v", reportSame)
+	}
+	if got := gjson.GetBytes(outputSame, "messages.0.content.0.signature").String(); got != observedFable5Sample {
+		t.Fatalf("signature = %q, want preserved %q", got, observedFable5Sample)
+	}
+
+	inputTool := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"keep","signature":"` + observedFable5Sample + `"},{"type":"text","text":"answer"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"pwd"},"signature":"` + observedFable5Sample + `"}]}]}`)
+	outputTool, reportTool := SanitizeClaudeMessagesForClaudeUpstream(inputTool, "claude-fable-5")
+	if reportTool.Preserved != 1 {
+		t.Fatalf("unexpected report for tool input: %+v", reportTool)
+	}
+	partsTool := gjson.GetBytes(outputTool, "messages.0.content").Array()
+	if len(partsTool) != 3 {
+		t.Fatalf("content len = %d, want 3", len(partsTool))
+	}
+	if partsTool[0].Get("signature").String() != observedFable5Sample {
+		t.Fatalf("thinking block signature lost: %s", partsTool[0].Raw)
+	}
+	if partsTool[2].Get("signature").Exists() {
+		t.Fatalf("tool_use signature should be stripped: %s", partsTool[2].Raw)
+	}
+
+	inputDiff := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"keep","signature":"` + observedFable5Sample + `"},{"type":"text","text":"answer"}]}]}`)
+	outputDiff, reportDiff := SanitizeClaudeMessagesForClaudeUpstream(inputDiff, "claude-opus-5")
+	if reportDiff.Preserved != 1 || reportDiff.DroppedBlocks != 0 {
+		t.Fatalf("unexpected report for cross model: %+v", reportDiff)
+	}
+	partsDiff := gjson.GetBytes(outputDiff, "messages.0.content").Array()
+	if len(partsDiff) != 2 {
+		t.Fatalf("content len = %d, want 2: %s", len(partsDiff), outputDiff)
+	}
+	if got := partsDiff[0].Get("signature").String(); got != observedFable5Sample {
+		t.Fatalf("thinking signature = %q, want %q", got, observedFable5Sample)
+	}
+}
+
+// TestClaudeCAISSignature_ToleratesUpstreamFieldDrift pins the deliberately
+// structural validation: rejecting a signature drops the whole thinking block,
+// so incidental values observed today must not become hard requirements.
+func TestClaudeCAISSignature_ToleratesUpstreamFieldDrift(t *testing.T) {
+	cases := []struct {
+		name  string
+		parts claudeCAISParts
+	}{
+		{"observed layout", defaultClaudeCAISParts("claude-opus-5")},
+		{"new channel id", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.channelID = 17
+			return p
+		}()},
+		{"new envelope version", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.topEnvelope = 3
+			return p
+		}()},
+		{"no top-level trailer", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.includeTopTrailer = false
+			return p
+		}()},
+		{"no channel version", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.includeChannelVerion = false
+			return p
+		}()},
+		{"longer signature bytes", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.signatureLen = 96
+			return p
+		}()},
+		{"no field 7", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.includeField7 = false
+			return p
+		}()},
+		{"other block kind", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.blockKind = "redacted_thinking"
+			return p
+		}()},
+		{"no block kind", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.blockKind = ""
+			return p
+		}()},
+		{"no context id", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.contextID = ""
+			return p
+		}()},
+		{"unreleased model name", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-6-preview")
+			return p
+		}()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sig := tc.parts.encode()
+			if _, err := InspectClaudeCAISSignature(sig); err != nil {
+				t.Fatalf("InspectClaudeCAISSignature failed: %v", err)
+			}
+			if got := DetectSignatureProviderForBlock(sig, SignatureBlockKindClaudeThinking); got != SignatureProviderClaude {
+				t.Fatalf("DetectSignatureProviderForBlock = %q, want %q", got, SignatureProviderClaude)
+			}
+
+			input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"keep","signature":"` + sig + `"}]}]}`)
+			output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-opus-5")
+			if report.Preserved != 1 || report.DroppedBlocks != 0 {
+				t.Fatalf("report = %+v, want preserved thinking block", report)
+			}
+			if got := gjson.GetBytes(output, "messages.0.content.0.signature").String(); got != sig {
+				t.Fatalf("signature = %q, want preserved %q", got, sig)
+			}
+		})
+	}
+}
+
+func TestClaudeCAISSignature_RejectsMalformedPayloads(t *testing.T) {
+	truncated := func() string {
+		decoded, err := base64.StdEncoding.DecodeString(observedFable5Sample)
+		if err != nil {
+			t.Fatalf("decode observed sample: %v", err)
+		}
+		return base64.StdEncoding.EncodeToString(decoded[:len(decoded)/2])
+	}()
+
+	cases := []struct {
+		name      string
+		signature string
+	}{
+		{"empty", ""},
+		{"whitespace only", "   "},
+		{"not base64", "CAIS!!!not-base64"},
+		{"truncated payload", truncated},
+		// 'E' prefix is the classic Claude form and must not reach CAIS parsing.
+		{"classic claude prefix", base64.StdEncoding.EncodeToString([]byte{0x12, 0x00})},
+		// 'C' prefix but a non-0x08 marker byte, the only way to reach the marker
+		// check (a 'C' prefix constrains the first byte to 0x08-0x0b).
+		{"wrong marker byte", base64.StdEncoding.EncodeToString([]byte{0x0a, 0x00})},
+		{"no container", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.includeContainer = false
+			return p.encode()
+		}()},
+		{"no channel block", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.includeChannelBlock = false
+			return p.encode()
+		}()},
+		{"no channel id", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.includeChannelID = false
+			return p.encode()
+		}()},
+		{"channel id wrong wire type", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.channelIDAsBytes = true
+			return p.encode()
+		}()},
+		{"no signature bytes", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.includeSignature = false
+			return p.encode()
+		}()},
+		{"empty signature bytes", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.signatureLen = 0
+			return p.encode()
+		}()},
+		{"no model text", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.includeModelText = false
+			return p.encode()
+		}()},
+		{"foreign model text", func() string {
+			p := defaultClaudeCAISParts("gemini-3-pro")
+			return p.encode()
+		}()},
+		{"invalid utf-8 model text", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.modelText = []byte{'c', 'l', 'a', 'u', 'd', 'e', '-', 0xff, 0xfe}
+			return p.encode()
+		}()},
+		{"non-uuid context id", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.contextID = "not-a-canonical-uuid-value-000000000"
+			return p.encode()
+		}()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if IsValidClaudeCAISSignature(tc.signature) {
+				t.Fatalf("IsValidClaudeCAISSignature(%q) = true, want false", tc.signature)
+			}
+		})
+	}
+}
+
+// TestClaudeCAISSignature_DoesNotShadowClassicClaudeSignature guards the
+// detection order: CAIS validation runs before classic Claude validation, so it
+// must not claim E/R signatures and change how they are normalized.
+func TestClaudeCAISSignature_DoesNotShadowClassicClaudeSignature(t *testing.T) {
+	classic := testClaudeThinkingSignature()
+	if IsValidClaudeCAISSignature(classic) {
+		t.Fatal("IsValidClaudeCAISSignature(classic Claude signature) = true, want false")
+	}
+	if got := DetectSignatureProviderForBlock(classic, SignatureBlockKindClaudeThinking); got != SignatureProviderClaude {
+		t.Fatalf("DetectSignatureProviderForBlock(classic) = %q, want %q", got, SignatureProviderClaude)
+	}
+
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"keep","signature":"` + classic + `"}]}]}`)
+	output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4-6")
+	if report.Preserved != 1 || report.DroppedBlocks != 0 {
+		t.Fatalf("report = %+v, want preserved classic thinking block", report)
+	}
+	if got := gjson.GetBytes(output, "messages.0.content.0.signature").String(); got != classic {
+		t.Fatalf("signature = %q, want provider-native E-form %q", got, classic)
+	}
+}
+
+// TestClaudeCAISSignature_CachePrefixSurvivesClaudeUpstreamSanitize covers the
+// cached-signature path: cache.GetModelGroup collapses every Claude model to the
+// "claude" prefix, so a CAIS signature reaches the sanitizer as "claude#..." and
+// must be replayed with the prefix stripped instead of being dropped.
+func TestClaudeCAISSignature_CachePrefixSurvivesClaudeUpstreamSanitize(t *testing.T) {
+	for _, prefix := range []string{"claude#", "anthropic#", "cais#", "ccmax#"} {
+		t.Run(prefix, func(t *testing.T) {
+			prefixed := prefix + observedFable5Sample
+			input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"keep","signature":"` + prefixed + `"}]}]}`)
+			output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-fable-5")
+			if report.Preserved != 1 || report.DroppedBlocks != 0 {
+				t.Fatalf("report = %+v, want preserved thinking block", report)
+			}
+			if got := gjson.GetBytes(output, "messages.0.content.0.signature").String(); got != observedFable5Sample {
+				t.Fatalf("signature = %q, want unprefixed %q", got, observedFable5Sample)
+			}
+		})
+	}
+}
+
+func TestCompatibleAntigravityClaudeThinkingSignature_RejectsClaudeCAIS(t *testing.T) {
+	if normalized, ok := CompatibleAntigravityClaudeThinkingSignature(observedFable5Sample); ok || normalized != "" {
+		t.Fatalf("CompatibleAntigravityClaudeThinkingSignature(ClaudeCAIS) = %q, %v; want empty and false", normalized, ok)
+	}
+	if normalized, ok := CompatibleAntigravityClaudeThinkingSignature("ccmax#" + observedFable5Sample); ok || normalized != "" {
+		t.Fatalf("CompatibleAntigravityClaudeThinkingSignature(ccmax#ClaudeCAIS) = %q, %v; want empty and false", normalized, ok)
+	}
+	if normalized, ok := CompatibleAntigravityClaudeThinkingSignature("cais#" + observedFable5Sample); ok || normalized != "" {
+		t.Fatalf("CompatibleAntigravityClaudeThinkingSignature(cais#ClaudeCAIS) = %q, %v; want empty and false", normalized, ok)
+	}
+	if normalized, ok := CompatibleAntigravityClaudeThinkingSignature("claude-cais#" + observedFable5Sample); ok || normalized != "" {
+		t.Fatalf("CompatibleAntigravityClaudeThinkingSignature(claude-cais#ClaudeCAIS) = %q, %v; want empty and false", normalized, ok)
 	}
 }

--- a/internal/signature/claude_validation.go
+++ b/internal/signature/claude_validation.go
@@ -48,6 +48,65 @@
 // Vertex, Bedrock) and legacy ch=11 signatures. Both single-layer (E) and
 // double-layer (R) encodings are supported. Historical cache-mode modelGroup#
 // prefixes are stripped.
+//
+// # CAIS envelope (newest Claude Code models)
+//
+// Newer Claude Code models wrap the channel block in a CAIS envelope whose
+// decoded payload starts with 0x08 (top-level field 1 varint) instead of 0x12,
+// so the base64 string starts with 'C' instead of 'E'/'R'. The envelope version
+// varint in top-level field 1 is the ONLY structural difference from the layout
+// above; everything below it is unchanged.
+//
+// The channel block itself belongs to a newer schema generation that is shared
+// by both envelopes: channel_id 16, no infra field 2, plus a block kind (field
+// 8) and a context id (field 11). Observed traffic confirms this schema
+// appears under the classic 0x12 envelope too (opus-4-6/4-7/4-8, sonnet-5) and
+// under the CAIS envelope (opus-5, fable-5), so envelope form and channel schema
+// generation vary independently and must not be inferred from each other:
+//
+//	Top-level protobuf
+//	|- Field 1 (varint): envelope version [required marker, observed as 2]
+//	|- Field 2 (bytes): container [required]
+//	|  `- Field 1 (bytes): channel block [required]
+//	|     |- Field 1  (varint): channel_id [required, observed as 16]
+//	|     |- Field 3  (varint): version [optional, observed as 2]
+//	|     |- Field 5  (bytes):  ECDSA signature [required, observed as 64B]
+//	|     |- Field 6  (bytes):  model_text [required, "claude-" prefixed]
+//	|     |- Field 7  (varint): unknown [optional, observed as 1]
+//	|     |- Field 8  (bytes):  block kind [optional, observed as "thinking"]
+//	|     `- Field 11 (bytes):  context id [optional, canonical UUID]
+//	`- Field 3 (varint): trailer [optional, observed as 1]
+//
+// CAIS validation is structural rather than an exact replay of the observed
+// bytes. The payload is an opaque upstream-issued blob and rejecting it drops
+// the whole thinking block, so only the fields that actually identify the format
+// are required: the 0x08 marker, the nested container/channel block, the
+// signature bytes, and the "claude-" model text. Observed-but-incidental values
+// such as channel_id 16 or the "thinking" block kind are recorded for debugging
+// and checked only for wire type, so an upstream field bump cannot silently
+// erase conversation history.
+//
+// # Which provider emits which envelope
+//
+// Three providers serve Claude models, and the envelope depends on the model
+// generation rather than on the provider:
+//
+//   - Claude Code OAuth subscription (Claude Code Max): opus-4-5, sonnet-4-6 and
+//     every later model up to opus-5 and fable-5. Emits the CAIS envelope for
+//     the newest models (opus-5, fable-5) and the single-layer E envelope for the
+//     opus-4-6/4-7/4-8 and sonnet-5 generation — but both carry the same
+//     channel_id 16 channel schema, so only the envelope differs.
+//   - Claude Messages API: the full Claude model range, same envelopes as the
+//     Claude Code OAuth subscription.
+//   - Antigravity: only opus-4-6-think and sonnet-4-6, and always the
+//     double-layer R form on Google infrastructure (infra_google). Antigravity
+//     never issues a CAIS envelope or a single-layer E signature, and its replay
+//     path requires R form, so CompatibleAntigravityClaudeThinkingSignature
+//     rejects CAIS signatures.
+//
+// A single conversation therefore mixes envelopes whenever a user switches model
+// generations or providers, and every form must stay replayable toward the
+// provider that issued it.
 package signature
 
 import (
@@ -515,4 +574,228 @@ func decodeClaudeBytesField(raw []byte, label string) ([]byte, error) {
 		return nil, fmt.Errorf("invalid Claude signature: failed to decode %s: %w", label, protowire.ParseError(n))
 	}
 	return value, nil
+}
+
+// claudeCAISSignatureMarker is the decoded first byte identifying the CAIS
+// envelope (protobuf tag for top-level field 1, varint).
+const claudeCAISSignatureMarker = 0x08
+
+// claudeCAISModelTextPrefix is the model_text prefix that distinguishes a CAIS
+// channel block from an arbitrary protobuf payload.
+const claudeCAISModelTextPrefix = "claude-"
+
+// ClaudeCAISSignatureInfo describes the locally inspected structure of a Claude
+// CAIS thinking signature.
+type ClaudeCAISSignatureInfo struct {
+	FirstByte       byte
+	EnvelopeVersion uint64
+	ChannelID       uint64
+	ModelText       string
+	BlockKind       string
+	ContextID       string
+
+	SignatureLen int
+}
+
+// IsValidClaudeCAISSignature returns whether rawSignature is a valid Claude CAIS
+// thinking signature.
+func IsValidClaudeCAISSignature(rawSignature string) bool {
+	_, err := InspectClaudeCAISSignature(rawSignature)
+	return err == nil
+}
+
+// InspectClaudeCAISSignature decodes and validates a Claude CAIS thinking
+// signature. See the CAIS envelope section in this file's package comment for
+// the layout and for why validation is structural rather than exact.
+func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, error) {
+	sig := stripClaudeSignaturePrefix(rawSignature)
+	if sig == "" {
+		return nil, fmt.Errorf("empty signature")
+	}
+	if len(sig) > MaxClaudeThinkingSignatureLen {
+		return nil, fmt.Errorf("signature exceeds maximum length (%d bytes)", MaxClaudeThinkingSignatureLen)
+	}
+	// A payload whose first byte is 0x08 always base64-encodes to a string
+	// starting with 'C' (0x08>>2 == 2). Checking that first keeps this validator
+	// cheap on the hot paths that probe every signature, since classic Claude
+	// (E/R) and Gemini envelopes are rejected without a base64 decode.
+	if sig[0] != 'C' {
+		return nil, fmt.Errorf("invalid Claude CAIS signature: expected 'C' prefix, got %q", string(sig[0]))
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(sig)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Claude CAIS signature: base64 decode failed: %w", err)
+	}
+	if len(decoded) == 0 {
+		return nil, fmt.Errorf("invalid Claude CAIS signature: empty after decode")
+	}
+	if decoded[0] != claudeCAISSignatureMarker {
+		return nil, fmt.Errorf("invalid Claude CAIS signature: expected first byte 0x%02x, got 0x%02x", claudeCAISSignatureMarker, decoded[0])
+	}
+
+	info := &ClaudeCAISSignatureInfo{FirstByte: decoded[0]}
+
+	var container []byte
+	err = walkClaudeProtobufFields(decoded, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+		switch num {
+		case 1:
+			value, errField := decodeClaudeCAISVarint(raw, typ, "CAIS top-level field 1 envelope version")
+			if errField != nil {
+				return errField
+			}
+			info.EnvelopeVersion = value
+		case 2:
+			value, errField := decodeClaudeCAISBytes(raw, typ, "CAIS top-level field 2 container")
+			if errField != nil {
+				return errField
+			}
+			container = value
+		case 3:
+			if _, errField := decodeClaudeCAISVarint(raw, typ, "CAIS top-level field 3 trailer"); errField != nil {
+				return errField
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if container == nil {
+		return nil, fmt.Errorf("invalid Claude CAIS signature: missing top-level field 2 container")
+	}
+
+	var channelBlock []byte
+	err = walkClaudeProtobufFields(container, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+		if num != 1 {
+			return nil
+		}
+		value, errField := decodeClaudeCAISBytes(raw, typ, "CAIS container field 1 channel block")
+		if errField != nil {
+			return errField
+		}
+		channelBlock = value
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if channelBlock == nil {
+		return nil, fmt.Errorf("invalid Claude CAIS signature: missing container field 1 channel block")
+	}
+
+	var haveChannelID, haveSignatureBytes, haveModelText bool
+	err = walkClaudeProtobufFields(channelBlock, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+		switch num {
+		case 1:
+			value, errField := decodeClaudeCAISVarint(raw, typ, "CAIS channel field 1 channel_id")
+			if errField != nil {
+				return errField
+			}
+			info.ChannelID = value
+			haveChannelID = true
+		case 3:
+			if _, errField := decodeClaudeCAISVarint(raw, typ, "CAIS channel field 3 version"); errField != nil {
+				return errField
+			}
+		case 5:
+			value, errField := decodeClaudeCAISBytes(raw, typ, "CAIS channel field 5 signature bytes")
+			if errField != nil {
+				return errField
+			}
+			if len(value) == 0 {
+				return fmt.Errorf("invalid Claude CAIS signature: channel field 5 signature bytes must not be empty")
+			}
+			info.SignatureLen = len(value)
+			haveSignatureBytes = true
+		case 6:
+			value, errField := decodeClaudeCAISUTF8(raw, typ, "CAIS channel field 6 model_text")
+			if errField != nil {
+				return errField
+			}
+			if !strings.HasPrefix(value, claudeCAISModelTextPrefix) {
+				return fmt.Errorf("invalid Claude CAIS signature: channel field 6 model_text must start with %q, got %q", claudeCAISModelTextPrefix, value)
+			}
+			info.ModelText = value
+			haveModelText = true
+		case 7:
+			if _, errField := decodeClaudeCAISVarint(raw, typ, "CAIS channel field 7"); errField != nil {
+				return errField
+			}
+		case 8:
+			value, errField := decodeClaudeCAISUTF8(raw, typ, "CAIS channel field 8 block kind")
+			if errField != nil {
+				return errField
+			}
+			info.BlockKind = value
+		case 11:
+			value, errField := decodeClaudeCAISUTF8(raw, typ, "CAIS channel field 11 context id")
+			if errField != nil {
+				return errField
+			}
+			if !isCanonicalUUID(value) {
+				return fmt.Errorf("invalid Claude CAIS signature: channel field 11 context id must be a canonical UUID, got %q", value)
+			}
+			info.ContextID = value
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case !haveChannelID:
+		return nil, fmt.Errorf("invalid Claude CAIS signature: missing channel field 1 channel_id")
+	case !haveSignatureBytes:
+		return nil, fmt.Errorf("invalid Claude CAIS signature: missing channel field 5 signature bytes")
+	case !haveModelText:
+		return nil, fmt.Errorf("invalid Claude CAIS signature: missing channel field 6 model_text")
+	}
+
+	return info, nil
+}
+
+func decodeClaudeCAISVarint(raw []byte, typ protowire.Type, label string) (uint64, error) {
+	if typ != protowire.VarintType {
+		return 0, fmt.Errorf("invalid Claude CAIS signature: %s must be varint", label)
+	}
+	return decodeClaudeVarintField(raw, label)
+}
+
+func decodeClaudeCAISBytes(raw []byte, typ protowire.Type, label string) ([]byte, error) {
+	if typ != protowire.BytesType {
+		return nil, fmt.Errorf("invalid Claude CAIS signature: %s must be bytes", label)
+	}
+	return decodeClaudeBytesField(raw, label)
+}
+
+func decodeClaudeCAISUTF8(raw []byte, typ protowire.Type, label string) (string, error) {
+	value, err := decodeClaudeCAISBytes(raw, typ, label)
+	if err != nil {
+		return "", err
+	}
+	if !utf8.Valid(value) {
+		return "", fmt.Errorf("invalid Claude CAIS signature: %s must be valid UTF-8", label)
+	}
+	return string(value), nil
+}
+
+func isCanonicalUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		switch i {
+		case 8, 13, 18, 23:
+			if b != '-' {
+				return false
+			}
+		default:
+			if !((b >= '0' && b <= '9') || (b >= 'a' && b <= 'f') || (b >= 'A' && b <= 'F')) {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/internal/signature/gemini_validation.go
+++ b/internal/signature/gemini_validation.go
@@ -37,11 +37,13 @@
 //     traceable to a prior Gemini model response in the same conversation.
 //   - Opaque-shape tier: for real Gemini signatures, require a non-empty string,
 //     bounded length, successful standard base64 decoding, and a known protobuf
-//     envelope when the caller needs provider compatibility. Observed samples
-//     currently include Gemini 3.x field-2 -> field-1 payloads containing either
-//     versioned opaque state or a provider UUID, plus Gemini 2.5 repeated field-1
-//     payloads. Bare base64 UUID payloads are classified separately and should be
-//     replaced with the bypass sentinel rather than replayed.
+//     envelope when the caller needs provider compatibility. The only known
+//     envelope is the Gemini 3.x field-2 -> field-1 payload, whose body holds
+//     either versioned opaque state or a provider UUID. Gemini 2.5 emitted a
+//     repeated field-1 form; those models are out of scope and their signatures
+//     are no longer a known envelope. Bare base64 UUID payloads are classified
+//     separately and should be replaced with the bypass sentinel rather than
+//     replayed.
 //   - Replay tier: real validation means preserving the exact model part that
 //     came from Gemini, including its thoughtSignature, id/name/function args,
 //     part index, and ordering relative to sibling parallel function calls.
@@ -93,18 +95,22 @@ type GeminiThoughtSignatureValidationOptions struct {
 	// protobuf envelopes observed in Gemini samples. This rejects opaque base64
 	// values such as base64 UUIDs.
 	RequireKnownEnvelope bool
-	// RequireObservedMarker requires the decoded payload to start with 0x12.
-	// Current Gemini 3.x samples show this marker, but Gemini 2.5 samples use a
-	// different protobuf prefix, so this should be used only for narrow Gemini 3
-	// experiments.
+	// RequireObservedMarker requires the decoded payload to start with 0x12. Every
+	// observed Gemini 3.x sample carries this marker, but it is only the outer
+	// protobuf tag, so RequireKnownEnvelope is the stronger check and should be
+	// preferred. This option exists for narrow experiments that want the marker
+	// without the full envelope walk.
 	RequireObservedMarker bool
 }
 
 type GeminiThoughtSignatureEnvelope string
 
 const (
-	GeminiThoughtSignatureEnvelopeUnknown        GeminiThoughtSignatureEnvelope = "unknown"
-	GeminiThoughtSignatureEnvelopeProtobufField1 GeminiThoughtSignatureEnvelope = "protobuf_field_1"
+	GeminiThoughtSignatureEnvelopeUnknown GeminiThoughtSignatureEnvelope = "unknown"
+	// GeminiThoughtSignatureEnvelopeProtobufField2 is the only replay-safe Gemini
+	// envelope. The repeated field-1 form emitted by Gemini 2.5 is no longer
+	// recognized: those models are out of scope, and their signatures now fall
+	// through to the bypass sentinel like any other unknown envelope.
 	GeminiThoughtSignatureEnvelopeProtobufField2 GeminiThoughtSignatureEnvelope = "protobuf_field_2"
 	GeminiThoughtSignatureEnvelopeASCIIUUID      GeminiThoughtSignatureEnvelope = "ascii_uuid"
 )
@@ -168,6 +174,10 @@ func InspectGeminiThoughtSignature(rawSignature string, opts ...GeminiThoughtSig
 	sig := strings.TrimSpace(rawSignature)
 	if sig == "" {
 		return nil, fmt.Errorf("empty Gemini thought signature")
+	}
+
+	if IsValidClaudeCAISSignature(sig) {
+		return nil, fmt.Errorf("invalid Gemini thought signature: detected Claude CAIS signature")
 	}
 
 	if IsGeminiThoughtSignatureBypass(sig) {
@@ -388,19 +398,10 @@ func classifyGeminiThoughtSignatureEnvelope(decoded []byte) (GeminiThoughtSignat
 	if isASCIIUUIDBytes(decoded) {
 		return GeminiThoughtSignatureEnvelopeASCIIUUID, false
 	}
-	switch {
-	case isGeminiField1Envelope(decoded):
-		return GeminiThoughtSignatureEnvelopeProtobufField1, true
-	case isGeminiField2Envelope(decoded):
+	if isGeminiField2Envelope(decoded) {
 		return GeminiThoughtSignatureEnvelopeProtobufField2, true
-	default:
-		return GeminiThoughtSignatureEnvelopeUnknown, false
 	}
-}
-
-func isGeminiField1Envelope(decoded []byte) bool {
-	info, ok := inspectGeminiField1Envelope(decoded)
-	return ok && info.RecordCount > 0
+	return GeminiThoughtSignatureEnvelopeUnknown, false
 }
 
 func isGeminiField2Envelope(decoded []byte) bool {
@@ -409,12 +410,7 @@ func isGeminiField2Envelope(decoded []byte) bool {
 }
 
 func inspectGeminiEnvelope(decoded []byte, envelope GeminiThoughtSignatureEnvelope) (recordCount int, opaquePayloadLen int) {
-	switch envelope {
-	case GeminiThoughtSignatureEnvelopeProtobufField1:
-		if info, ok := inspectGeminiField1Envelope(decoded); ok {
-			return info.RecordCount, info.OpaquePayloadLen
-		}
-	case GeminiThoughtSignatureEnvelopeProtobufField2:
+	if envelope == GeminiThoughtSignatureEnvelopeProtobufField2 {
 		if info, ok := inspectGeminiField2Envelope(decoded); ok {
 			return info.RecordCount, info.OpaquePayloadLen
 		}
@@ -425,26 +421,6 @@ func inspectGeminiEnvelope(decoded []byte, envelope GeminiThoughtSignatureEnvelo
 type geminiEnvelopeInfo struct {
 	RecordCount      int
 	OpaquePayloadLen int
-}
-
-func inspectGeminiField1Envelope(decoded []byte) (geminiEnvelopeInfo, bool) {
-	var info geminiEnvelopeInfo
-	offset := 0
-	for offset < len(decoded) {
-		num, typ, n := protowire.ConsumeTag(decoded[offset:])
-		if n < 0 || num != 1 || typ != protowire.BytesType {
-			return geminiEnvelopeInfo{}, false
-		}
-		offset += n
-		value, n := protowire.ConsumeBytes(decoded[offset:])
-		if n < 0 || !isLikelyGeminiOpaquePayload(value) {
-			return geminiEnvelopeInfo{}, false
-		}
-		info.RecordCount++
-		info.OpaquePayloadLen += len(value)
-		offset += n
-	}
-	return info, offset == len(decoded) && info.RecordCount > 0
 }
 
 func inspectGeminiField2Envelope(decoded []byte) (geminiEnvelopeInfo, bool) {
@@ -490,9 +466,19 @@ func consumeGeminiField2Field1Value(decoded []byte) ([]byte, bool) {
 }
 
 func isLikelyGeminiOpaquePayload(value []byte) bool {
-	// Observed Gemini 2.5 and Gemini 3.x envelopes wrap provider-opaque
-	// payloads that start with an internal version byte 0x01. The bytes after
-	// that are high-entropy provider state and must remain opaque.
+	// The envelope body is a Google Tink primitive output: one prefix-type byte
+	// (0x01 selects the TINK prefix) followed by a four-byte big-endian key id and
+	// then the ciphertext. Only the prefix-type byte is checked here, because it is
+	// a format constant while the key id is key material that Google rotates.
+	// Pinning the key id would reduce false positives to nothing but would reject
+	// every signature the moment a rotation happens, which is the worse failure.
+	// That rotation is observed, not hypothetical: gemini-3.1-flash-lite carries key
+	// id 0x0c39d6c7 in the archived corpus and 0x114d320f in the 2026-07-27 capture,
+	// and the newer id is shared by every Gemini 3.x variant captured that day. The
+	// bytes after the prefix are high-entropy provider state and stay opaque, so this
+	// one format byte is the only anchor available. It leaves a 1/256 false-positive
+	// rate against a caller that reproduces the protobuf envelope but not the key
+	// material; provenance or target scoping, not more byte checks, closes that gap.
 	return len(value) > 0 && value[0] == 0x01
 }
 

--- a/internal/signature/gemini_validation_test.go
+++ b/internal/signature/gemini_validation_test.go
@@ -126,24 +126,35 @@ func TestInspectGeminiThoughtSignature_AcceptsGemini3WrappedUUIDEnvelope(t *test
 	}
 }
 
-func TestInspectGeminiThoughtSignature_AcceptsGemini25Field1Envelope(t *testing.T) {
+// TestInspectGeminiThoughtSignature_RejectsGemini25Field1Envelope pins the removal
+// of the repeated field-1 envelope. Gemini 2.5 is out of scope, so its signatures
+// are no longer a known envelope; they degrade to the bypass sentinel on Gemini
+// model parts instead of being replayed verbatim.
+func TestInspectGeminiThoughtSignature_RejectsGemini25Field1Envelope(t *testing.T) {
 	sig := testGemini25ThoughtSignature([]byte{0x01, 0x8f}, []byte{0x01, 0x90, 0x91})
 
-	info, err := InspectGeminiThoughtSignature(sig, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true})
+	if _, err := InspectGeminiThoughtSignature(sig, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}); err == nil {
+		t.Fatal("Gemini 2.5 field-1 envelope should no longer be a known envelope")
+	}
+
+	info, err := InspectGeminiThoughtSignature(sig)
 	if err != nil {
-		t.Fatalf("Gemini 2.5 field-1 envelope should be known: %v", err)
+		t.Fatalf("inspection without RequireKnownEnvelope should still succeed: %v", err)
 	}
-	if info.Envelope != GeminiThoughtSignatureEnvelopeProtobufField1 {
-		t.Fatalf("Envelope = %q, want %q", info.Envelope, GeminiThoughtSignatureEnvelopeProtobufField1)
+	if info.Envelope != GeminiThoughtSignatureEnvelopeUnknown {
+		t.Fatalf("Envelope = %q, want %q", info.Envelope, GeminiThoughtSignatureEnvelopeUnknown)
 	}
-	if info.HasObservedMarker {
-		t.Fatal("Gemini 2.5 field-1 envelope should not be marked as 0x12")
+	if info.KnownEnvelope {
+		t.Fatal("KnownEnvelope should be false for the retired field-1 envelope")
 	}
-	if info.RecordCount != 2 {
-		t.Fatalf("RecordCount = %d, want 2", info.RecordCount)
+
+	// Gemini model parts still recover through the documented sentinel.
+	decision := DecideSignatureCompatibility(SignatureProviderGemini, sig, SignatureBlockKindGeminiModelPart)
+	if decision.Action != SignatureActionReplaceWithGeminiBypass {
+		t.Fatalf("action = %q, want %q", decision.Action, SignatureActionReplaceWithGeminiBypass)
 	}
-	if info.OpaquePayloadLen != 5 {
-		t.Fatalf("OpaquePayloadLen = %d, want 5", info.OpaquePayloadLen)
+	if decision.ReplacementSignature != GeminiSkipThoughtSignatureValidator {
+		t.Fatalf("replacement = %q, want %q", decision.ReplacementSignature, GeminiSkipThoughtSignatureValidator)
 	}
 }
 

--- a/internal/signature/gpt_validation.go
+++ b/internal/signature/gpt_validation.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 )
 
 const MaxGPTReasoningSignatureLen = 32 * 1024 * 1024
@@ -29,11 +30,16 @@ func InspectGPTReasoningSignature(rawSignature string) (*GPTReasoningSignatureIn
 	if len(sig) > MaxGPTReasoningSignatureLen {
 		return nil, fmt.Errorf("GPT reasoning signature exceeds maximum length (%d bytes)", MaxGPTReasoningSignatureLen)
 	}
-	if index, r, ok := firstInvalidGPTReasoningSignatureChar(sig); ok {
-		return nil, fmt.Errorf("invalid GPT reasoning signature: contains non-base64url character U+%04X at byte %d", r, index)
-	}
+	// The literal prefix is the cheapest discriminator and rejects every other
+	// provider's envelope outright, so it runs before the full charset scan.
+	// Probing this validator is on the hot path for signatures of every provider,
+	// and scanning a multi-kilobyte payload only to reject it on five bytes was
+	// pure waste.
 	if !strings.HasPrefix(sig, "gAAAA") {
 		return nil, fmt.Errorf("invalid GPT reasoning signature: expected gAAAA prefix")
+	}
+	if index, r, ok := firstInvalidGPTReasoningSignatureChar(sig); ok {
+		return nil, fmt.Errorf("invalid GPT reasoning signature: contains non-base64url character U+%04X at byte %d", r, index)
 	}
 
 	decoded, err := decodeGPTReasoningSignature(sig)
@@ -68,14 +74,17 @@ func decodeGPTReasoningSignature(sig string) ([]byte, error) {
 	return nil, fmt.Errorf("invalid GPT reasoning signature: base64url decode failed")
 }
 
+// gptReasoningSignatureCharSet is the base64url alphabet, padding included.
+var gptReasoningSignatureCharSet = base64AlphabetSet("-_=")
+
+// firstInvalidGPTReasoningSignatureChar scans bytes against a lookup table for the
+// same reason as its Grok counterpart: every legal character is ASCII, and a
+// comparison chain mispredicts on nearly every byte of a multi-kilobyte reasoning
+// blob. The offending rune is decoded only for the error message.
 func firstInvalidGPTReasoningSignatureChar(sig string) (int, rune, bool) {
-	for index, r := range sig {
-		switch {
-		case r >= 'A' && r <= 'Z':
-		case r >= 'a' && r <= 'z':
-		case r >= '0' && r <= '9':
-		case r == '-' || r == '_' || r == '=':
-		default:
+	for index := 0; index < len(sig); index++ {
+		if !gptReasoningSignatureCharSet[sig[index]] {
+			r, _ := utf8.DecodeRuneInString(sig[index:])
 			return index, r, true
 		}
 	}

--- a/internal/signature/grok_validation.go
+++ b/internal/signature/grok_validation.go
@@ -5,14 +5,19 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"unicode/utf8"
 )
 
 const (
 	// MaxGrokEncryptedContentLen is a transport safety cap for opaque replay blobs.
 	MaxGrokEncryptedContentLen = 8 * 1024 * 1024
-	// MinGrokEncryptedContentDecodedLen is derived from native Grok CLI captures;
-	// shorter decoded payloads are treated as invalid replay state for xAI upstream.
-	MinGrokEncryptedContentDecodedLen = 50
+	// MinGrokEncryptedContentDecodedLen is a deliberately loose floor. The
+	// shortest observed native payload is exactly 50 bytes (grok-composer-2.5-fast),
+	// and those samples share no structure, so 50 is a sampling artifact rather
+	// than a protocol minimum. Sitting on the observed floor would silently reject
+	// a future shorter payload and surface as lost reasoning context, so keep
+	// headroom here and let the entropy check do the real filtering.
+	MinGrokEncryptedContentDecodedLen = 32
 	// MinGrokEncryptedContentEntropyRatio rejects obvious non-ciphertext payloads.
 	// Native samples are >= 0.892 against the sample-size entropy ceiling.
 	MinGrokEncryptedContentEntropyRatio = 0.85
@@ -25,6 +30,15 @@ type GrokEncryptedContentInfo struct {
 
 // InspectGrokEncryptedContent validates the transport shape of xAI/Grok
 // reasoning or compaction encrypted_content. This does not prove decryptability.
+//
+// This is NOT a provider classifier and must not be used as one. Unlike Claude,
+// Gemini and GPT, xAI emits no self-describing envelope: observed payloads are
+// indistinguishable from uniform random bytes (no magic prefix, no version byte,
+// no fixed suffix, and decoded lengths spread evenly modulo the AES block size).
+// Every high-entropy unpadded standard-base64 blob therefore satisfies the checks
+// below. Callers must establish provenance before asking this question, either
+// from an explicit provider cache prefix or from a confirmed xAI target model,
+// and treat the result as a replay-safety check rather than an identification.
 func InspectGrokEncryptedContent(raw string) (*GrokEncryptedContentInfo, error) {
 	sig := strings.TrimSpace(raw)
 	if sig == "" {
@@ -36,20 +50,36 @@ func InspectGrokEncryptedContent(raw string) (*GrokEncryptedContentInfo, error) 
 	if sig != raw {
 		return nil, fmt.Errorf("Grok encrypted_content has leading or trailing whitespace")
 	}
-	if strings.HasPrefix(sig, "gAAAA") {
-		return nil, fmt.Errorf("Grok encrypted_content looks like GPT/Codex reasoning signature")
-	}
 	if strings.Contains(sig, "=") {
 		return nil, fmt.Errorf("invalid Grok encrypted_content: expected unpadded standard base64")
 	}
 	if index, r, ok := firstInvalidGrokEncryptedContentChar(sig); ok {
 		return nil, fmt.Errorf("invalid Grok encrypted_content: contains non-base64 character U+%04X at byte %d", r, index)
 	}
-	if IsValidClaudeThinkingSignature(sig, ClaudeSignatureValidationOptions{Strict: true}) {
-		return nil, fmt.Errorf("Grok encrypted_content looks like Claude thinking signature")
+	if _, _, ok := SplitSignatureProviderPrefix(sig); ok {
+		return nil, fmt.Errorf("invalid Grok encrypted_content: carries another provider's cache prefix")
 	}
-	if _, err := InspectGeminiThoughtSignature(sig, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}); err == nil {
-		return nil, fmt.Errorf("Grok encrypted_content looks like Gemini thoughtSignature")
+	// Foreign-envelope rejection only has to run for the narrow set of base64
+	// first characters a self-describing envelope can produce. Native xAI
+	// ciphertext is uniformly distributed, so this skips the whole chain for
+	// roughly 92% of real traffic without decoding anything. Every branch below
+	// stays exhaustive for the candidates that do reach it: Claude CAIS in
+	// particular is high-entropy standard base64 that drops its padding whenever
+	// the decoded length is a multiple of 3, so the padding gate above does not
+	// exclude it on its own.
+	if maybeSelfDescribingSignatureEnvelope(sig) {
+		if strings.HasPrefix(sig, "gAAAA") {
+			return nil, fmt.Errorf("Grok encrypted_content looks like GPT/Codex reasoning signature")
+		}
+		if IsValidClaudeThinkingSignature(sig, ClaudeSignatureValidationOptions{Strict: true}) {
+			return nil, fmt.Errorf("Grok encrypted_content looks like Claude thinking signature")
+		}
+		if IsValidClaudeCAISSignature(sig) {
+			return nil, fmt.Errorf("Grok encrypted_content looks like Claude CAIS thinking signature")
+		}
+		if _, err := InspectGeminiThoughtSignature(sig, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}); err == nil {
+			return nil, fmt.Errorf("Grok encrypted_content looks like Gemini thoughtSignature")
+		}
 	}
 
 	decoded, err := decodeGrokEncryptedContent(sig)
@@ -81,14 +111,18 @@ func decodeGrokEncryptedContent(sig string) ([]byte, error) {
 	return decoded, nil
 }
 
+// grokEncryptedContentCharSet is the unpadded standard base64 alphabet.
+var grokEncryptedContentCharSet = base64AlphabetSet("+/")
+
+// firstInvalidGrokEncryptedContentChar scans bytes against a lookup table rather
+// than ranging over runes. Every legal character is ASCII, so rune iteration only
+// adds cost, and the table removes the branch mispredictions that dominated this
+// scan on multi-kilobyte payloads. The offending rune is decoded once, for the
+// error message, so multi-byte input is still reported accurately.
 func firstInvalidGrokEncryptedContentChar(sig string) (int, rune, bool) {
-	for index, r := range sig {
-		switch {
-		case r >= 'A' && r <= 'Z':
-		case r >= 'a' && r <= 'z':
-		case r >= '0' && r <= '9':
-		case r == '+' || r == '/':
-		default:
+	for index := 0; index < len(sig); index++ {
+		if !grokEncryptedContentCharSet[sig[index]] {
+			r, _ := utf8.DecodeRuneInString(sig[index:])
 			return index, r, true
 		}
 	}

--- a/internal/signature/grok_validation_test.go
+++ b/internal/signature/grok_validation_test.go
@@ -90,18 +90,18 @@ func TestInspectGrokEncryptedContent_RejectsGeminiThoughtSignatureEnvelope(t *te
 	}
 }
 
-func TestInspectGrokEncryptedContent_RejectsGemini25Field1Envelope(t *testing.T) {
+// TestInspectGrokEncryptedContent_RetiredGemini25Field1Envelope covers the
+// retired Gemini 2.5 envelope. It is no longer a known Gemini envelope, so the
+// Gemini fast-reject no longer fires for it and it falls to the residual class
+// like any other opaque payload. Recorded here so the change is deliberate rather
+// than an accident of the Gemini validator being narrowed.
+func TestInspectGrokEncryptedContent_RetiredGemini25Field1Envelope(t *testing.T) {
 	sample := testGemini25Field1ThoughtSignatureEnvelope()
-	if !IsValidGeminiThoughtSignature(sample, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}) {
-		t.Fatal("fixture should be a known Gemini field-1 thoughtSignature")
+	if IsValidGeminiThoughtSignature(sample, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}) {
+		t.Fatal("fixture should no longer be a known Gemini thoughtSignature")
 	}
-
-	_, err := InspectGrokEncryptedContent(sample)
-	if err == nil {
-		t.Fatal("expected Gemini field-1 thoughtSignature envelope to be rejected")
-	}
-	if !strings.Contains(err.Error(), "Gemini") {
-		t.Fatalf("error = %q, want Gemini fast-reject detail", err.Error())
+	if _, err := InspectGrokEncryptedContent(sample); err != nil {
+		t.Fatalf("retired envelope should reach the residual transport check, got %v", err)
 	}
 }
 
@@ -135,6 +135,72 @@ func TestInspectGrokEncryptedContent_RejectsAntigravityClaudeThinkingSignature(t
 	}
 	if !strings.Contains(err.Error(), "Claude") {
 		t.Fatalf("error = %q, want Claude fast-reject detail", err.Error())
+	}
+}
+
+// TestInspectGrokEncryptedContent_RejectsClaudeCAISSignature covers the CAIS
+// envelope emitted by the newest Claude Code models. CAIS payloads are
+// high-entropy standard base64 and drop their padding whenever the decoded
+// length is a multiple of 3, so neither the padding gate nor the classic Claude
+// strict check excludes them on their own.
+func TestInspectGrokEncryptedContent_RejectsClaudeCAISSignature(t *testing.T) {
+	cases := []struct {
+		name   string
+		sample string
+	}{
+		{name: "synthetic unpadded", sample: testUnpaddedClaudeCAISSignature()},
+		{name: "observed fable-5", sample: observedFable5Sample},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if strings.Contains(tc.sample, "=") {
+				t.Fatal("fixture must be unpadded so it reaches the Claude CAIS check")
+			}
+			if !IsValidClaudeCAISSignature(tc.sample) {
+				t.Fatal("fixture should be a valid Claude CAIS signature")
+			}
+			if IsValidClaudeThinkingSignature(tc.sample, ClaudeSignatureValidationOptions{Strict: true}) {
+				t.Fatal("CAIS fixture must not also pass classic Claude validation")
+			}
+
+			_, err := InspectGrokEncryptedContent(tc.sample)
+			if err == nil {
+				t.Fatal("expected Claude CAIS signature to be rejected")
+			}
+			if !strings.Contains(err.Error(), "CAIS") {
+				t.Fatalf("error = %q, want Claude CAIS fast-reject detail", err.Error())
+			}
+		})
+	}
+}
+
+// TestInspectGrokEncryptedContent_RejectsProviderCachePrefix keeps provenance
+// envelopes out of the residual class. A prefixed value belongs to whichever
+// provider the prefix names, and must never be replayed to xAI verbatim.
+func TestInspectGrokEncryptedContent_RejectsProviderCachePrefix(t *testing.T) {
+	for _, prefix := range []string{"claude#", "anthropic#", "gemini#", "openai#", "codex#"} {
+		sample := prefix + testUnpaddedClaudeCAISSignature()
+		if _, err := InspectGrokEncryptedContent(sample); err == nil {
+			t.Fatalf("%s prefixed payload should be rejected", prefix)
+		}
+	}
+}
+
+// TestInspectGrokEncryptedContent_ThresholdMargins documents that neither
+// threshold sits on observed data. The shortest observed native payload is 50
+// decoded bytes and the lowest observed entropy ratio is 0.892, so both limits
+// keep headroom for future models rather than fitting the current corpus exactly.
+func TestInspectGrokEncryptedContent_ThresholdMargins(t *testing.T) {
+	const shortestObservedDecodedLen = 50
+	const lowestObservedEntropyRatio = 0.892
+
+	if MinGrokEncryptedContentDecodedLen >= shortestObservedDecodedLen {
+		t.Fatalf("MinGrokEncryptedContentDecodedLen = %d, want below the shortest observed payload (%d) so a shorter future payload is not silently dropped",
+			MinGrokEncryptedContentDecodedLen, shortestObservedDecodedLen)
+	}
+	if MinGrokEncryptedContentEntropyRatio >= lowestObservedEntropyRatio {
+		t.Fatalf("MinGrokEncryptedContentEntropyRatio = %.3f, want below the lowest observed ratio (%.3f)",
+			MinGrokEncryptedContentEntropyRatio, lowestObservedEntropyRatio)
 	}
 }
 
@@ -208,6 +274,20 @@ func testGemini25Field1ThoughtSignatureEnvelope() string {
 
 func testUnpaddedClaudeThinkingSignature() string {
 	return testClaudeThinkingSignatureWithOpaqueLen(35)
+}
+
+// testUnpaddedClaudeCAISSignature builds a CAIS signature whose base64 form
+// carries no "=" padding, which is the shape that used to slip past the Grok
+// unpadded-base64 gate. The model text length is varied because padding depends
+// on the encoded payload length.
+func testUnpaddedClaudeCAISSignature() string {
+	for suffix := 0; suffix < 8; suffix++ {
+		parts := defaultClaudeCAISParts("claude-opus-5" + strings.Repeat("x", suffix))
+		if sample := parts.encode(); !strings.Contains(sample, "=") {
+			return sample
+		}
+	}
+	panic("could not build an unpadded Claude CAIS fixture")
 }
 
 func testUnpaddedAntigravityClaudeThinkingSignature() string {

--- a/internal/signature/provider_compatibility.go
+++ b/internal/signature/provider_compatibility.go
@@ -64,6 +64,65 @@ func SignatureProviderFromModelName(modelName string) SignatureProvider {
 	}
 }
 
+// selfDescribingSignatureFirstChars are the base64 first characters that a
+// self-describing provider envelope can produce. A base64 first character is
+// exactly the first payload byte shifted right by two, so a single character
+// comparison rules out every known envelope without decoding anything:
+//
+//	'C' -> 0x08..0x0b : Claude CAIS (0x08)
+//	'E' -> 0x10..0x13 : Claude single-layer (0x12), Gemini protobuf_field_2 (0x12)
+//	'R' -> 0x44..0x47 : Claude double-layer R (0x45, inner 'E')
+//	'g' -> 0x80..0x83 : GPT Fernet reasoning (0x80)
+//
+// Gemini's ascii_uuid envelope is deliberately absent. Its first byte is the
+// first hex character of the UUID, which spreads over 'M', 'N', 'O', 'Y' and 'Z'
+// depending on the value, and it is never a replay-safe envelope: it resolves to
+// SignatureProviderUnknown whether or not it reaches the validators, and Gemini
+// model parts recover it through the bypass sentinel keyed on block kind. Listing
+// one of its five possible characters would only look like coverage.
+//
+// Any provider added here must also be validated in
+// DetectSignatureProviderForBlock, otherwise its signatures would fall through
+// to the residual class. TestSelfDescribingSignatureFirstChars_CoversEveryKnownEnvelope
+// fails when a replay-safe envelope is missing from this set.
+const selfDescribingSignatureFirstChars = "CERg"
+
+// base64AlphabetSet builds a byte lookup table for the alphanumeric base64 core
+// plus the alphabet-specific characters in extra. Signature charset validation
+// runs over multi-kilobyte payloads, and a comparison chain over base64 text
+// mispredicts on nearly every byte because the characters are effectively random;
+// a single table load is branch-free and measures about an order of magnitude
+// faster on the observed corpora.
+func base64AlphabetSet(extra string) [256]bool {
+	var set [256]bool
+	for c := byte('A'); c <= 'Z'; c++ {
+		set[c] = true
+	}
+	for c := byte('a'); c <= 'z'; c++ {
+		set[c] = true
+	}
+	for c := byte('0'); c <= '9'; c++ {
+		set[c] = true
+	}
+	for i := 0; i < len(extra); i++ {
+		set[extra[i]] = true
+	}
+	return set
+}
+
+// maybeSelfDescribingSignatureEnvelope reports whether rawSignature can possibly
+// be a self-describing provider envelope. It is a structural pre-filter, not a
+// classifier: a false result is conclusive, a true result only narrows the
+// candidate set. Opaque ciphertext that carries no envelope (xAI/Grok
+// encrypted_content) is uniformly distributed over the byte space, so this
+// rejects roughly 92% of it with one comparison and no allocation.
+func maybeSelfDescribingSignatureEnvelope(rawSignature string) bool {
+	if rawSignature == "" {
+		return false
+	}
+	return strings.IndexByte(selfDescribingSignatureFirstChars, rawSignature[0]) >= 0
+}
+
 // DetectSignatureProvider classifies the provider family that can replay
 // rawSignature. It intentionally uses Claude strict validation before Gemini
 // detection because Gemini 3 signatures also decode from an E-prefixed base64
@@ -92,7 +151,7 @@ func DetectSignatureProviderForBlock(rawSignature string, blockKind SignatureBlo
 				return SignatureProviderGemini
 			}
 		case SignatureProviderClaude:
-			if IsValidClaudeThinkingSignature(unprefixed, ClaudeSignatureValidationOptions{Strict: true}) {
+			if IsValidClaudeThinkingSignature(unprefixed, ClaudeSignatureValidationOptions{Strict: true}) || IsValidClaudeCAISSignature(unprefixed) {
 				return SignatureProviderClaude
 			}
 		case SignatureProviderGPT:
@@ -106,11 +165,34 @@ func DetectSignatureProviderForBlock(rawSignature string, blockKind SignatureBlo
 		return SignatureProviderUnknown
 	}
 
+	// The bypass sentinel is a plain literal rather than an envelope, so it must
+	// be matched before the structural pre-filter below rejects it.
 	if IsGeminiThoughtSignatureBypass(sig) {
 		return SignatureProviderGeminiBypass
 	}
+	if !maybeSelfDescribingSignatureEnvelope(sig) {
+		return SignatureProviderUnknown
+	}
+
+	// Probes run from the strongest marker to the weakest:
+	//   1. GPT carries the literal "gAAAA" prefix, which pins both the version
+	//      byte and the high timestamp bytes.
+	//   2. Claude CAIS carries marker 0x08 plus a literal "claude-" model text.
+	//   3. Claude single/double-layer carries marker 0x12 plus the same literal.
+	//   4. Gemini validates wire shape only and has no literal to anchor on, so
+	//      it is the weakest judge and goes last.
+	//
+	// This ordering is defense in depth rather than a correctness requirement:
+	// Claude envelopes carry extra top-level fields beyond the container, which
+	// fails the single-record shape Gemini requires, so the two families stay
+	// separable in either order. TestGeminiEnvelopeNeverClaimsClaudeSignatures
+	// pins that invariant so a looser Gemini envelope check cannot make the
+	// order silently start mattering.
 	if IsValidGPTReasoningSignature(sig) {
 		return SignatureProviderGPT
+	}
+	if IsValidClaudeCAISSignature(sig) {
+		return SignatureProviderClaude
 	}
 	if IsValidClaudeThinkingSignature(sig, ClaudeSignatureValidationOptions{Strict: true}) {
 		return SignatureProviderClaude
@@ -129,6 +211,12 @@ func IsSignatureCompatibleWithProvider(targetProvider SignatureProvider, rawSign
 // DecideSignatureCompatibility returns the safe handling policy for replaying a
 // signed block into targetProvider.
 func DecideSignatureCompatibility(targetProvider SignatureProvider, rawSignature string, blockKind SignatureBlockKind) SignatureCompatibilityDecision {
+	return DecideSignatureCompatibilityForModel(targetProvider, "", rawSignature, blockKind)
+}
+
+// DecideSignatureCompatibilityForModel returns the safe handling policy for replaying a
+// signed block into targetProvider for targetModel.
+func DecideSignatureCompatibilityForModel(targetProvider SignatureProvider, targetModel string, rawSignature string, blockKind SignatureBlockKind) SignatureCompatibilityDecision {
 	targetProvider = normalizeSignatureTargetProvider(targetProvider)
 	if blockKind == "" {
 		blockKind = SignatureBlockKindUnknown
@@ -145,7 +233,7 @@ func DecideSignatureCompatibility(targetProvider SignatureProvider, rawSignature
 		decision.Compatible = true
 		decision.Action = SignatureActionPreserve
 		decision.NormalizedSignature = normalizeCompatibleSignatureForProvider(targetProvider, rawSignature, blockKind)
-		decision.Reason = "signature provider matches target provider"
+		decision.Reason = claudeCompatibleSignatureReason(targetProvider, rawSignature, targetModel)
 		return decision
 	}
 
@@ -191,7 +279,7 @@ func SplitSignatureProviderPrefix(rawSignature string) (SignatureProvider, strin
 // "claude-cache#..." cannot be mistaken for trusted provider provenance.
 func SignatureProviderFromCachePrefix(prefix string) SignatureProvider {
 	switch strings.ToLower(strings.TrimSpace(prefix)) {
-	case "claude", "anthropic":
+	case "claude", "anthropic", "cais", "claude-cais", "claude_cais", "ccmax", "claude-code-max", "claude_code_max":
 		return SignatureProviderClaude
 	case "gemini", "google":
 		return SignatureProviderGemini
@@ -247,6 +335,26 @@ func CompatibleAntigravityClaudeThinkingSignature(rawSignature string) (string, 
 	return normalized, true
 }
 
+// claudeCompatibleSignatureReason explains why a matching signature is
+// replayable. Claude CAIS signatures carry the issuing model inside the payload,
+// so the embedded model and the target model are both reported to make signature
+// decisions traceable in debug logs.
+func claudeCompatibleSignatureReason(targetProvider SignatureProvider, rawSignature, targetModel string) string {
+	const genericReason = "signature provider matches target provider"
+	if targetProvider != SignatureProviderClaude {
+		return genericReason
+	}
+	info, err := InspectClaudeCAISSignature(SignaturePayloadWithoutProviderPrefix(rawSignature))
+	if err != nil {
+		return genericReason
+	}
+	reason := "valid Claude CAIS signature with embedded model " + info.ModelText + " is compatible with any Claude target"
+	if trimmedModel := strings.TrimSpace(targetModel); trimmedModel != "" {
+		reason += ", including target model " + trimmedModel
+	}
+	return reason
+}
+
 func normalizeSignatureTargetProvider(provider SignatureProvider) SignatureProvider {
 	switch provider {
 	case SignatureProviderGeminiBypass:
@@ -273,6 +381,9 @@ func normalizeCompatibleSignatureForProvider(targetProvider SignatureProvider, r
 	payload := SignaturePayloadWithoutProviderPrefix(rawSignature)
 	switch normalizeSignatureTargetProvider(targetProvider) {
 	case SignatureProviderClaude:
+		if IsValidClaudeCAISSignature(payload) {
+			return payload
+		}
 		normalized, err := NormalizeClaudeProviderNativeThinkingSignature(payload)
 		if err != nil {
 			return ""
@@ -294,6 +405,9 @@ func normalizeCompatibleSignatureForProvider(targetProvider SignatureProvider, r
 }
 
 func isRecognizedGeminiProviderSignature(rawSignature string, blockKind SignatureBlockKind) bool {
+	if IsValidClaudeCAISSignature(rawSignature) {
+		return false
+	}
 	if IsValidGeminiThoughtSignature(rawSignature, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}) {
 		return true
 	}

--- a/internal/signature/provider_compatibility_test.go
+++ b/internal/signature/provider_compatibility_test.go
@@ -30,6 +30,143 @@ func testClaudeThinkingSignature() string {
 	return base64.StdEncoding.EncodeToString(payload)
 }
 
+// TestBase64AlphabetSet_MatchesEncoderAlphabets pins the charset lookup tables
+// against the encoders they stand in for. A wrong table would silently accept
+// bytes that are not valid base64, or reject a legal payload character.
+func TestBase64AlphabetSet_MatchesEncoderAlphabets(t *testing.T) {
+	cases := []struct {
+		name     string
+		set      [256]bool
+		alphabet string
+	}{
+		{"grok unpadded std", grokEncryptedContentCharSet, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"},
+		{"gpt base64url", gptReasoningSignatureCharSet, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_="},
+	}
+	for _, tc := range cases {
+		allowed := map[byte]bool{}
+		for i := 0; i < len(tc.alphabet); i++ {
+			allowed[tc.alphabet[i]] = true
+		}
+		for c := 0; c < 256; c++ {
+			want := allowed[byte(c)]
+			if got := tc.set[c]; got != want {
+				t.Errorf("%s: byte 0x%02x (%q) accepted=%v, want %v", tc.name, c, string(rune(c)), got, want)
+			}
+		}
+	}
+}
+
+// replaySafeEnvelopeFixtures returns one fixture per self-describing provider
+// envelope that carries replayable state. Every entry must survive the structural
+// pre-filter, because losing one would silently reclassify that provider.
+func replaySafeEnvelopeFixtures() map[string]struct {
+	sig  string
+	want SignatureProvider
+} {
+	return map[string]struct {
+		sig  string
+		want SignatureProvider
+	}{
+		"claude single-layer E":  {testClaudeThinkingSignature(), SignatureProviderClaude},
+		"claude double-layer R":  {testUnpaddedAntigravityClaudeThinkingSignature(), SignatureProviderClaude},
+		"claude CAIS":            {testClaudeCAISSignature("claude-fable-5"), SignatureProviderClaude},
+		"gemini protobuf field2": {testGeminiThoughtSignatureEnvelope(), SignatureProviderGemini},
+		"gpt fernet":             {testGPTReasoningSignature(), SignatureProviderGPT},
+	}
+}
+
+// TestSelfDescribingSignatureFirstChars_CoversEveryKnownEnvelope guards the
+// structural pre-filter. DetectSignatureProviderForBlock skips every provider
+// validator when maybeSelfDescribingSignatureEnvelope returns false, so an
+// envelope missing from selfDescribingSignatureFirstChars would silently fall
+// through to the residual class. Adding a provider envelope without registering
+// its base64 first character fails here.
+func TestSelfDescribingSignatureFirstChars_CoversEveryKnownEnvelope(t *testing.T) {
+	for name, fixture := range replaySafeEnvelopeFixtures() {
+		if !maybeSelfDescribingSignatureEnvelope(fixture.sig) {
+			t.Errorf("%s: first char %q is not in selfDescribingSignatureFirstChars %q; register it or detection will skip this envelope",
+				name, string(fixture.sig[0]), selfDescribingSignatureFirstChars)
+		}
+	}
+
+	// The pre-filter must not be so wide that it stops filtering. Opaque xAI
+	// ciphertext is the shape it exists to reject.
+	for _, sig := range []string{
+		"K1ZAIbzDbO",
+		"jQDLUr+fD8RFP8nbkkfI",
+		"qcgG7jzxH3D6mlVLBBaKXaG3",
+	} {
+		if maybeSelfDescribingSignatureEnvelope(sig) {
+			t.Errorf("opaque ciphertext %q must not look like a self-describing envelope", sig)
+		}
+	}
+}
+
+// TestGeminiASCIIUUIDIsGateIndependent documents why ascii_uuid is excluded from
+// selfDescribingSignatureFirstChars. Its first byte is the first hex character of
+// the UUID, so the base64 first character spreads over several values, and none of
+// them need to be registered: the envelope is never replay-safe, so it resolves to
+// SignatureProviderUnknown either way and Gemini model parts recover it through the
+// bypass sentinel keyed on block kind.
+func TestGeminiASCIIUUIDIsGateIndependent(t *testing.T) {
+	// First hex digit chosen to land on distinct base64 first characters.
+	for _, uuid := range []string{
+		"09743975-4bb0-4936-9e28-d5b0d21bdc48",
+		"49743975-4bb0-4936-9e28-d5b0d21bdc48",
+		"89743975-4bb0-4936-9e28-d5b0d21bdc48",
+		"a9743975-4bb0-4936-9e28-d5b0d21bdc48",
+		"e9743975-4bb0-4936-9e28-d5b0d21bdc48",
+	} {
+		sig := testGeminiThoughtSignature([]byte(uuid))
+		if got := DetectSignatureProvider(sig); got != SignatureProviderUnknown {
+			t.Errorf("uuid %q: DetectSignatureProvider = %q, want %q regardless of the pre-filter",
+				uuid[:8], got, SignatureProviderUnknown)
+		}
+		decision := DecideSignatureCompatibility(SignatureProviderGemini, sig, SignatureBlockKindGeminiFunctionCall)
+		if decision.Action != SignatureActionReplaceWithGeminiBypass {
+			t.Errorf("uuid %q: action = %q, want %q", uuid[:8], decision.Action, SignatureActionReplaceWithGeminiBypass)
+		}
+	}
+}
+
+// TestDetectSignatureProviderForBlock_ClassifiesEveryKnownEnvelope pins the
+// classification of each envelope so a reordering of the validator chain cannot
+// silently reassign one provider's signatures to another.
+func TestDetectSignatureProviderForBlock_ClassifiesEveryKnownEnvelope(t *testing.T) {
+	for name, fixture := range replaySafeEnvelopeFixtures() {
+		if got := DetectSignatureProvider(fixture.sig); got != fixture.want {
+			t.Errorf("%s: DetectSignatureProvider = %q, want %q", name, got, fixture.want)
+		}
+	}
+}
+
+// TestGeminiEnvelopeNeverClaimsClaudeSignatures pins the invariant that keeps
+// Claude and Gemini separable independently of probe order in
+// DetectSignatureProviderForBlock. Gemini validates wire shape only and has no
+// literal marker, so it is the weakest judge; Claude envelopes survive it solely
+// because they carry extra top-level fields beyond the container and therefore
+// fail Gemini's single-record shape. Loosening the Gemini envelope check would
+// make probe order start mattering, and fails here first.
+func TestGeminiEnvelopeNeverClaimsClaudeSignatures(t *testing.T) {
+	for name, sig := range map[string]string{
+		"single-layer E":        testClaudeThinkingSignature(),
+		"single-layer E opaque": testClaudeThinkingSignatureWithOpaqueLen(64),
+		"double-layer R":        testUnpaddedAntigravityClaudeThinkingSignature(),
+		"CAIS synthetic":        testClaudeCAISSignature("claude-opus-5"),
+		"CAIS observed":         observedFable5Sample,
+	} {
+		if isRecognizedGeminiProviderSignature(sig, SignatureBlockKindUnknown) {
+			t.Errorf("claude %s is claimed by the Gemini envelope check; probe order in DetectSignatureProviderForBlock is now load-bearing", name)
+		}
+		if got := DetectSignatureProvider(sig); got != SignatureProviderClaude {
+			t.Errorf("claude %s: DetectSignatureProvider = %q, want %q", name, got, SignatureProviderClaude)
+		}
+		if _, ok := CompatibleSignatureForProvider(SignatureProviderGemini, sig); ok {
+			t.Errorf("claude %s must not be replayable as a Gemini signature", name)
+		}
+	}
+}
+
 func TestDetectSignatureProvider_UsesProviderPrefix(t *testing.T) {
 	claudeSig := "claude#" + testClaudeThinkingSignature()
 	if got := DetectSignatureProvider(claudeSig); got != SignatureProviderClaude {


### PR DESCRIPTION
This PR adds support for validating Claude CAIS reasoning signatures and updating provider cross-compatibility checks.

### Highlights
- **Claude CAIS Support**: Adds structural detection and validation for Claude CAIS envelope format and Claude reasoning replay.
- **Cross-Provider Misidentification Prevention**: Prevents CAIS signatures from being wrongly identified as Gemini or Grok signatures.
- **Provider Prefilter & Charset Optimization**: Refines provider prefiltering and validates strict charset/format rules for GPT and Grok signatures.
- **Scope Note**: Gemini 2.5 field-1 is intentionally out of scope in this PR.

### Tests Executed
- `gofmt -d` on 10 changed Go files (clean, no output)
- `git diff --check upstream/dev...HEAD` (passed, no whitespace errors)
- `go vet ./internal/signature/...` (passed)
- `go test -count=1 ./internal/signature/...` (passed)
- `go test -count=1 ./internal/cache/... ./internal/runtime/executor/... ./internal/translator/...` (passed)
- `go build -o test-output ./cmd/server && rm test-output` (passed)