### PR TITLE
docs: add Codex server compaction fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,10 @@ Native macOS SwiftUI dashboard for AI subscriptions and coding proxies. It manag
 
 Run multiple native-feeling Claude Code commands, each powered by a different model (Codex, GLM, Kimi, Gemini, Grok, MiniMax, DeepSeek, Cursor, Copilot, Claude). Every dialect launches the real Claude Code interface with its own isolated config, history, ports, and an embedded CLIProxyAPI instance linked through the Go SDK — no separate proxy install. macOS only. Learn more at [claude-dialects.cc](https://claude-dialects.cc/).
 
+### [CLIProxyAPI Codex Server Compaction](https://github.com/sumeirsoni/CLIProxyAPI-Codex-Server-Compaction)
+
+Maintained CLIProxyAPI fork adding opt-in OpenAI Codex server-side compaction for Claude Code sessions routed to compatible GPT/Codex models. It persists compatibility-scoped opaque artifacts for replay, fails open, and documents installation, security, maintenance, and rollback. OpenAI artifacts are not compatible with actual Anthropic Claude models.
+
 > [!NOTE]  
 > If you developed a project based on CLIProxyAPI, please open a PR to add it to this list.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -258,6 +258,10 @@ VS Code 扩展，可将你的 Claude、ChatGPT/Codex、Antigravity、Grok 和 Ki
 
 运行多个具有原生体验的 Claude Code 命令，每个命令由不同的模型（Codex、GLM、Kimi、Gemini、Grok、MiniMax、DeepSeek、Cursor、Copilot、Claude）驱动。每个命令都会启动真正的 Claude Code 界面，并拥有独立的配置、历史记录、端口，以及通过 Go SDK 连接的嵌入式 CLIProxyAPI 实例，无需单独安装代理。仅支持 macOS。详情请访问 [claude-dialects.cc](https://claude-dialects.cc/)。
 
+### [CLIProxyAPI Codex Server Compaction](https://github.com/sumeirsoni/CLIProxyAPI-Codex-Server-Compaction)
+
+一个持续维护的 CLIProxyAPI 分支，为路由到兼容 GPT/Codex 模型的 Claude Code 会话增加可选的 OpenAI Codex 服务端压缩。它按兼容范围持久化不透明压缩产物以便复用，异常时自动回退到原始请求，并提供安装、安全、维护和回滚文档。OpenAI 压缩产物不能由真正的 Anthropic Claude 模型使用。
+
 > [!NOTE]  
 > 如果你开发了基于 CLIProxyAPI 的项目，请提交一个 PR（拉取请求）将其添加到此列表中。
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -257,6 +257,10 @@ macOSネイティブのSwiftUI製AIサブスクリプションダッシュボー
 
 ネイティブ同様の操作感を持つ複数のClaude Codeコマンドを実行し、それぞれを異なるモデル（Codex、GLM、Kimi、Gemini、Grok、MiniMax、DeepSeek、Cursor、Copilot、Claude）で動作させます。各コマンドは、独立した設定、履歴、ポート、およびGo SDKで連携した組み込みCLIProxyAPIインスタンスを備えた本物のClaude Codeインターフェースを起動するため、プロキシを別途インストールする必要はありません。macOSのみ対応。詳細は[claude-dialects.cc](https://claude-dialects.cc/)をご覧ください。
 
+### [CLIProxyAPI Codex Server Compaction](https://github.com/sumeirsoni/CLIProxyAPI-Codex-Server-Compaction)
+
+継続的にメンテナンスされている CLIProxyAPI フォークで、互換性のある GPT/Codex モデルへルーティングされる Claude Code セッションに、オプトインの OpenAI Codex サーバーサイドコンパクションを追加します。互換性スコープごとに不透明なコンパクション成果物を永続化して再利用し、障害時は元のリクエストへフェイルオープンします。インストール、セキュリティ、保守、ロールバックの文書も含まれます。OpenAI の成果物は実際の Anthropic Claude モデルとは互換性がありません。
+
 > [!NOTE]
 > CLIProxyAPIをベースにプロジェクトを開発した場合は、PRを送ってこのリストに追加してください。
 


### PR DESCRIPTION
## Summary

- add CLIProxyAPI Codex Server Compaction to the related-projects list
- synchronize the entry across English, Chinese, and Japanese READMEs
- clarify that the fork targets Claude Code sessions routed to compatible GPT/Codex models and does not make OpenAI artifacts compatible with Anthropic Claude

## Scope

Documentation only. No source, configuration, or workflow files are changed.