### PR TITLE
[Withdrawn] Opus 4.8 remains available; no registry change requested

### DIFF
--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -35,6 +35,25 @@ func TestGeminiVertexModelsUseFlashLiteReleaseID(t *testing.T) {
 	t.Fatalf("Vertex models do not contain %q", releaseID)
 }
 
+func TestClaudeModelsIncludeOpus5ReleaseID(t *testing.T) {
+	const releaseID = "claude-opus-5"
+	const displayName = "Claude Opus 5"
+
+	for _, model := range GetClaudeModels() {
+		if model == nil {
+			continue
+		}
+		if model.ID == releaseID {
+			if model.DisplayName != displayName {
+				t.Fatalf("Claude model display name = %q, want %q", model.DisplayName, displayName)
+			}
+			return
+		}
+	}
+
+	t.Fatalf("Claude models do not contain %q", releaseID)
+}
+
 func TestWithXAIBuiltinsIncludesVideoPreviewModel(t *testing.T) {
 	models := WithXAIBuiltins(nil)
 

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -97,29 +97,6 @@
       }
     },
     {
-      "id": "claude-opus-4-8",
-      "object": "model",
-      "created": 1779984000,
-      "owned_by": "anthropic",
-      "type": "claude",
-      "display_name": "Claude Opus 4.8",
-      "description": "Premium model combining maximum intelligence with practical performance",
-      "context_length": 1000000,
-      "max_completion_tokens": 128000,
-      "thinking": {
-        "min": 1024,
-        "max": 128000,
-        "zero_allowed": true,
-        "levels": [
-          "low",
-          "medium",
-          "high",
-          "xhigh",
-          "max"
-        ]
-      }
-    },
-    {
       "id": "claude-opus-5",
       "object": "model",
       "created": 1784038800,


### PR DESCRIPTION
## Withdrawn

This proposal was opened in error and should not be merged.

Claude Opus 4.8 remains publicly available and belongs in this upstream registry. I incorrectly treated my users personal preference to route my his own tools to Opus 5 as evidence that the older model had been retired. No upstream registry removal is requested.