### PR TITLE
fix(store): prevent GitTokenStore data loss from corrupted index

### DIFF
--- a/internal/store/gitstore.go
+++ b/internal/store/gitstore.go
@@ -933,6 +933,11 @@ func (s *GitTokenStore) commitAndPushLocked(message string, relPaths ...string) 
 		Email: "cliproxy@local",
 		When:  time.Now(),
 	}
+	// Save pre-commit HEAD hash for tree integrity validation after commit.
+	prevHeadHash := plumbing.ZeroHash
+	if prevHeadRef, errPrev := repo.Head(); errPrev == nil {
+		prevHeadHash = prevHeadRef.Hash()
+	}
 	commitHash, err := worktree.Commit(message, &git.CommitOptions{
 		Author: signature,
 	})
@@ -941,6 +946,27 @@ func (s *GitTokenStore) commitAndPushLocked(message string, relPaths ...string) 
 			return nil
 		}
 		return fmt.Errorf("git token store: commit: %w", err)
+	}
+	// Guard: refuse to rewrite+force-push if the new commit's tree is
+	// missing files that were present in the previous HEAD tree but are not
+	// part of an intentional deletion by the caller. This prevents a
+	// corrupted local index (e.g. after a failed pull due to packfile
+	// corruption) from causing permanent data loss on the remote.
+	if err := s.validateCommitTree(repo, prevHeadHash, commitHash, relPaths); err != nil {
+		// worktree.Commit already advanced local HEAD to the rejected
+		// commit. Reset branch/index/worktree back to the pre-commit
+		// tip so a later persist still compares against the intact
+		// tree; otherwise the missing files become the new baseline
+		// and a subsequent force-push can still wipe the remote.
+		if prevHeadHash != plumbing.ZeroHash {
+			if resetErr := worktree.Reset(&git.ResetOptions{
+				Commit: prevHeadHash,
+				Mode:   git.HardReset,
+			}); resetErr != nil {
+				return fmt.Errorf("git token store: %w (also failed to reset local HEAD after rejection: %v)", err, resetErr)
+			}
+		}
+		return fmt.Errorf("git token store: %w", err)
 	}
 	headRef, errHead := repo.Head()
 	if errHead != nil {
@@ -1007,6 +1033,76 @@ func (s *GitTokenStore) rewriteHeadAsSingleCommit(repo *git.Repository, branch p
 	}
 	if err := repo.Storer.SetReference(plumbing.NewHashReference(branch, newHash)); err != nil {
 		return fmt.Errorf("git token store: update branch reference: %w", err)
+	}
+	return nil
+}
+
+// validateCommitTree checks that the new commit's tree does not lose files
+// present in the previous HEAD tree due to a corrupted local index. When a
+// failed pull (e.g. packfile not found) leaves the git index in an
+// inconsistent state, worktree.Commit may produce a tree that is missing
+// auth/config files. rewriteHeadAsSingleCommit + Force:true push would then
+// permanently delete those files from the remote. validateCommitTree rejects
+// the commit before any damage reaches the remote.
+//
+// intentionalPaths lists the file paths that the caller explicitly intends to
+// modify or delete. Files missing from the new tree that are NOT in
+// intentionalPaths are treated as accidental data loss and cause rejection.
+func (s *GitTokenStore) validateCommitTree(repo *git.Repository, prevHeadHash, commitHash plumbing.Hash, intentionalPaths []string) error {
+	if prevHeadHash == plumbing.ZeroHash {
+		// No previous HEAD — first commit, nothing to compare against.
+		return nil
+	}
+	prevCommit, err := repo.CommitObject(prevHeadHash)
+	if err != nil {
+		return fmt.Errorf("validate tree: inspect previous commit: %w", err)
+	}
+	prevTree, err := prevCommit.Tree()
+	if err != nil {
+		return fmt.Errorf("validate tree: read previous tree: %w", err)
+	}
+	newCommit, err := repo.CommitObject(commitHash)
+	if err != nil {
+		return fmt.Errorf("validate tree: inspect new commit: %w", err)
+	}
+	newTree, err := newCommit.Tree()
+	if err != nil {
+		return fmt.Errorf("validate tree: read new tree: %w", err)
+	}
+
+	// Collect all file paths present in the new tree.
+	newPaths := make(map[string]struct{})
+	if errFiles := newTree.Files().ForEach(func(f *object.File) error {
+		newPaths[f.Name] = struct{}{}
+		return nil
+	}); errFiles != nil {
+		return fmt.Errorf("validate tree: enumerate new tree files: %w", errFiles)
+	}
+
+	// Build intentSet: file paths the caller explicitly intends to modify or delete.
+	intentSet := make(map[string]struct{}, len(intentionalPaths))
+	for _, p := range intentionalPaths {
+		intentSet[filepath.ToSlash(p)] = struct{}{}
+	}
+
+	// Detect files missing from new tree that are not in the intentSet (accidental data loss).
+	var missing []string
+	if errFiles := prevTree.Files().ForEach(func(f *object.File) error {
+		if _, inNew := newPaths[f.Name]; inNew {
+			return nil
+		}
+		if _, intentional := intentSet[f.Name]; intentional {
+			return nil
+		}
+		missing = append(missing, f.Name)
+		return nil
+	}); errFiles != nil {
+		return fmt.Errorf("validate tree: enumerate previous tree files: %w", errFiles)
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("commit tree is missing %d file(s) present in HEAD (possible index corruption), refusing force push to prevent data loss: %s",
+			len(missing), strings.Join(missing, ", "))
 	}
 	return nil
 }

--- a/internal/store/gitstore_test.go
+++ b/internal/store/gitstore_test.go
@@ -376,6 +376,388 @@ func TestGitTokenStoreRepeatedDeleteDoesNotOverwriteRemoteOnlyChanges(t *testing
 	assertRemoteTreePath(t, remoteDir, "master", "auths/b.json", true)
 }
 
+// TestPersistConfigDoesNotDropAuthAfterStagedIndexDeletion reproduces a production
+// data-loss path: the local index already has a staged auth deletion (for example
+// after a failed pull left the index inconsistent), then PersistConfig only stages
+// config/config.yaml. worktree.Commit uses the full index, so the staged auth
+// deletion is included; rewriteHeadAsSingleCommit + Force push then permanently
+// removes the auth from the remote repository.
+func TestPersistConfigDoesNotDropAuthAfterStagedIndexDeletion(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	remoteDir := setupGitRemoteRepository(t, root, "master",
+		testBranchSpec{name: "master", contents: "remote master branch\n"},
+	)
+	store := NewGitTokenStore(remoteDir, "", "", "")
+	baseDir := filepath.Join(root, "workspace", "auths")
+	store.SetBaseDir(baseDir)
+	if err := store.EnsureRepository(); err != nil {
+		t.Fatalf("EnsureRepository: %v", err)
+	}
+
+	authA := &cliproxyauth.Auth{
+		ID:       "a.json",
+		FileName: "a.json",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex", "access_token": "a-token"},
+	}
+	authB := &cliproxyauth.Auth{
+		ID:       "b.json",
+		FileName: "b.json",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex", "access_token": "b-token"},
+	}
+	if _, err := store.Save(context.Background(), authA); err != nil {
+		t.Fatalf("Save a.json: %v", err)
+	}
+	if _, err := store.Save(context.Background(), authB); err != nil {
+		t.Fatalf("Save b.json: %v", err)
+	}
+	assertRemoteTreePath(t, remoteDir, "master", "auths/a.json", true)
+	assertRemoteTreePath(t, remoteDir, "master", "auths/b.json", true)
+
+	// Seed a config file so PersistConfig has something to commit.
+	workspaceDir := filepath.Join(root, "workspace")
+	configPath := filepath.Join(workspaceDir, "config", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("port: 8317\n"), 0o600); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+	store.mu.Lock()
+	if err := store.commitAndPushLocked("Update config", "config/config.yaml"); err != nil {
+		store.mu.Unlock()
+		t.Fatalf("seed config commit: %v", err)
+	}
+	store.mu.Unlock()
+	assertRemoteTreePath(t, remoteDir, "master", "config/config.yaml", true)
+
+	// Corrupt the local index the way a failed pull/packfile can: stage a deletion
+	// of a.json while leaving b.json and config intact on disk.
+	localRepo, err := git.PlainOpen(workspaceDir)
+	if err != nil {
+		t.Fatalf("open local repo: %v", err)
+	}
+	localWorktree, err := localRepo.Worktree()
+	if err != nil {
+		t.Fatalf("open local worktree: %v", err)
+	}
+	if err := os.Remove(filepath.Join(baseDir, "a.json")); err != nil {
+		t.Fatalf("remove local a.json: %v", err)
+	}
+	if _, err := localWorktree.Remove("auths/a.json"); err != nil {
+		t.Fatalf("stage removal of a.json: %v", err)
+	}
+
+	// PersistConfig only intends to update config.yaml.
+	if err := os.WriteFile(configPath, []byte("port: 8318\n"), 0o600); err != nil {
+		t.Fatalf("update config: %v", err)
+	}
+	if err := store.PersistConfig(context.Background()); err != nil {
+		// After the fix, PersistConfig must refuse rather than force-push data loss.
+		// Either outcome is acceptable as long as remote auths survive:
+		//   - error returned (preferred fail-closed)
+		//   - success with auths preserved
+		t.Logf("PersistConfig returned error (acceptable if fail-closed): %v", err)
+	}
+
+	assertRemoteTreePath(t, remoteDir, "master", "auths/a.json", true)
+	assertRemoteTreePath(t, remoteDir, "master", "auths/b.json", true)
+	assertRemoteTreePath(t, remoteDir, "master", "config/config.yaml", true)
+}
+
+// TestPersistConfigDoesNotDropSiblingAuthsAfterMultiFileIndexCorruption covers the
+// multi-auth wipe observed in production: several auth deletions are already staged
+// in the local index, then a config persist rewrites HEAD and force-pushes.
+func TestPersistConfigDoesNotDropSiblingAuthsAfterMultiFileIndexCorruption(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	remoteDir := setupGitRemoteRepository(t, root, "master",
+		testBranchSpec{name: "master", contents: "remote master branch\n"},
+	)
+	store := NewGitTokenStore(remoteDir, "", "", "")
+	baseDir := filepath.Join(root, "workspace", "auths")
+	store.SetBaseDir(baseDir)
+	if err := store.EnsureRepository(); err != nil {
+		t.Fatalf("EnsureRepository: %v", err)
+	}
+
+	for _, name := range []string{"codex-1.json", "codex-2.json", "codex-3.json", "codex-4.json"} {
+		auth := &cliproxyauth.Auth{
+			ID:       name,
+			FileName: name,
+			Provider: "codex",
+			Metadata: map[string]any{"type": "codex", "access_token": name + "-token"},
+		}
+		if _, err := store.Save(context.Background(), auth); err != nil {
+			t.Fatalf("Save %s: %v", name, err)
+		}
+		assertRemoteTreePath(t, remoteDir, "master", "auths/"+name, true)
+	}
+
+	workspaceDir := filepath.Join(root, "workspace")
+	configPath := filepath.Join(workspaceDir, "config", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("openai-compatibility:\n  - name: demo\n    disabled: false\n"), 0o600); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+	store.mu.Lock()
+	if err := store.commitAndPushLocked("Update config", "config/config.yaml"); err != nil {
+		store.mu.Unlock()
+		t.Fatalf("seed config commit: %v", err)
+	}
+	store.mu.Unlock()
+
+	localRepo, err := git.PlainOpen(workspaceDir)
+	if err != nil {
+		t.Fatalf("open local repo: %v", err)
+	}
+	localWorktree, err := localRepo.Worktree()
+	if err != nil {
+		t.Fatalf("open local worktree: %v", err)
+	}
+	for _, name := range []string{"codex-1.json", "codex-2.json", "codex-3.json", "codex-4.json"} {
+		if err := os.Remove(filepath.Join(baseDir, name)); err != nil {
+			t.Fatalf("remove local %s: %v", name, err)
+		}
+		if _, err := localWorktree.Remove("auths/" + name); err != nil {
+			t.Fatalf("stage removal of %s: %v", name, err)
+		}
+	}
+
+	if err := os.WriteFile(configPath, []byte("openai-compatibility:\n  - name: demo\n    disabled: true\n"), 0o600); err != nil {
+		t.Fatalf("update config: %v", err)
+	}
+	if err := store.PersistConfig(context.Background()); err != nil {
+		t.Logf("PersistConfig returned error (acceptable if fail-closed): %v", err)
+	}
+
+	for _, name := range []string{"codex-1.json", "codex-2.json", "codex-3.json", "codex-4.json"} {
+		assertRemoteTreePath(t, remoteDir, "master", "auths/"+name, true)
+	}
+	assertRemoteTreePath(t, remoteDir, "master", "config/config.yaml", true)
+}
+
+// TestSyncAuthDoesNotDropUnrelatedAuthAfterStagedIndexDeletion covers the non-Remove
+// watcher path ("Sync auth ..."), which is not protected by the Remove-auth guard.
+func TestSyncAuthDoesNotDropUnrelatedAuthAfterStagedIndexDeletion(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	remoteDir := setupGitRemoteRepository(t, root, "master",
+		testBranchSpec{name: "master", contents: "remote master branch\n"},
+	)
+	store := NewGitTokenStore(remoteDir, "", "", "")
+	baseDir := filepath.Join(root, "workspace", "auths")
+	store.SetBaseDir(baseDir)
+	if err := store.EnsureRepository(); err != nil {
+		t.Fatalf("EnsureRepository: %v", err)
+	}
+
+	authKeep := &cliproxyauth.Auth{
+		ID:       "keep.json",
+		FileName: "keep.json",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex", "access_token": "keep"},
+	}
+	authSync := &cliproxyauth.Auth{
+		ID:       "sync.json",
+		FileName: "sync.json",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex", "access_token": "sync-v1"},
+	}
+	if _, err := store.Save(context.Background(), authKeep); err != nil {
+		t.Fatalf("Save keep.json: %v", err)
+	}
+	syncPath, err := store.Save(context.Background(), authSync)
+	if err != nil {
+		t.Fatalf("Save sync.json: %v", err)
+	}
+	assertRemoteTreePath(t, remoteDir, "master", "auths/keep.json", true)
+	assertRemoteTreePath(t, remoteDir, "master", "auths/sync.json", true)
+
+	workspaceDir := filepath.Join(root, "workspace")
+	localRepo, err := git.PlainOpen(workspaceDir)
+	if err != nil {
+		t.Fatalf("open local repo: %v", err)
+	}
+	localWorktree, err := localRepo.Worktree()
+	if err != nil {
+		t.Fatalf("open local worktree: %v", err)
+	}
+	if err := os.Remove(filepath.Join(baseDir, "keep.json")); err != nil {
+		t.Fatalf("remove local keep.json: %v", err)
+	}
+	if _, err := localWorktree.Remove("auths/keep.json"); err != nil {
+		t.Fatalf("stage removal of keep.json: %v", err)
+	}
+
+	// Legitimate content update of sync.json via the Sync auth path.
+	if err := os.WriteFile(syncPath, []byte(`{"type":"codex","access_token":"sync-v2"}`), 0o600); err != nil {
+		t.Fatalf("update sync.json: %v", err)
+	}
+	if err := store.PersistAuthFiles(context.Background(), "Sync auth sync.json", syncPath); err != nil {
+		t.Logf("PersistAuthFiles returned error (acceptable if fail-closed): %v", err)
+	}
+
+	assertRemoteTreePath(t, remoteDir, "master", "auths/keep.json", true)
+	assertRemoteTreePath(t, remoteDir, "master", "auths/sync.json", true)
+}
+
+// TestRejectedCommitResetsLocalHeadSoSecondPersistStillProtectsRemote covers the
+// follow-on failure mode of the tree-integrity guard: worktree.Commit advances
+// local HEAD before validation. If the rejected commit is left as HEAD, the next
+// PersistConfig treats the already-corrupted tree as the baseline, the missing
+// auth is no longer detected, and Force push can still wipe the remote.
+func TestRejectedCommitResetsLocalHeadSoSecondPersistStillProtectsRemote(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	remoteDir := setupGitRemoteRepository(t, root, "master",
+		testBranchSpec{name: "master", contents: "remote master branch\n"},
+	)
+	store := NewGitTokenStore(remoteDir, "", "", "")
+	baseDir := filepath.Join(root, "workspace", "auths")
+	store.SetBaseDir(baseDir)
+	if err := store.EnsureRepository(); err != nil {
+		t.Fatalf("EnsureRepository: %v", err)
+	}
+
+	authA := &cliproxyauth.Auth{
+		ID:       "a.json",
+		FileName: "a.json",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex", "access_token": "a-token"},
+	}
+	authB := &cliproxyauth.Auth{
+		ID:       "b.json",
+		FileName: "b.json",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex", "access_token": "b-token"},
+	}
+	if _, err := store.Save(context.Background(), authA); err != nil {
+		t.Fatalf("Save a.json: %v", err)
+	}
+	if _, err := store.Save(context.Background(), authB); err != nil {
+		t.Fatalf("Save b.json: %v", err)
+	}
+
+	workspaceDir := filepath.Join(root, "workspace")
+	configPath := filepath.Join(workspaceDir, "config", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("port: 8317\n"), 0o600); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+	store.mu.Lock()
+	if err := store.commitAndPushLocked("Update config", "config/config.yaml"); err != nil {
+		store.mu.Unlock()
+		t.Fatalf("seed config commit: %v", err)
+	}
+	store.mu.Unlock()
+
+	localRepo, err := git.PlainOpen(workspaceDir)
+	if err != nil {
+		t.Fatalf("open local repo: %v", err)
+	}
+	preHead, err := localRepo.Head()
+	if err != nil {
+		t.Fatalf("read pre-corruption HEAD: %v", err)
+	}
+	preHeadHash := preHead.Hash()
+
+	localWorktree, err := localRepo.Worktree()
+	if err != nil {
+		t.Fatalf("open local worktree: %v", err)
+	}
+	if err := os.Remove(filepath.Join(baseDir, "a.json")); err != nil {
+		t.Fatalf("remove local a.json: %v", err)
+	}
+	if _, err := localWorktree.Remove("auths/a.json"); err != nil {
+		t.Fatalf("stage removal of a.json: %v", err)
+	}
+
+	if err := os.WriteFile(configPath, []byte("port: 8318\n"), 0o600); err != nil {
+		t.Fatalf("update config first attempt: %v", err)
+	}
+	if err := store.PersistConfig(context.Background()); err == nil {
+		t.Fatal("first PersistConfig: want tree-integrity rejection, got nil")
+	}
+
+	postHead, err := localRepo.Head()
+	if err != nil {
+		t.Fatalf("read post-rejection HEAD: %v", err)
+	}
+	if got := postHead.Hash(); got != preHeadHash {
+		t.Fatalf("local HEAD after rejection = %s, want reset to pre-commit %s", got, preHeadHash)
+	}
+	assertRemoteTreePath(t, remoteDir, "master", "auths/a.json", true)
+	assertRemoteTreePath(t, remoteDir, "master", "auths/b.json", true)
+
+	// Second persist without re-corrupting the index: if the rejected commit had
+	// remained as HEAD, this would treat the missing auth as the new baseline and
+	// force-push the loss. With a proper reset, the config update succeeds and
+	// both auths remain on the remote.
+	if err := os.WriteFile(configPath, []byte("port: 8319\n"), 0o600); err != nil {
+		t.Fatalf("update config second attempt: %v", err)
+	}
+	if err := store.PersistConfig(context.Background()); err != nil {
+		t.Fatalf("second PersistConfig after reset: %v", err)
+	}
+	assertRemoteTreePath(t, remoteDir, "master", "auths/a.json", true)
+	assertRemoteTreePath(t, remoteDir, "master", "auths/b.json", true)
+	assertRemoteTreePath(t, remoteDir, "master", "config/config.yaml", true)
+}
+
+// TestExplicitDeleteStillRemovesOnlyTargetedAuth is the positive control: intentional
+// Delete must still be able to remove exactly the requested auth file.
+func TestExplicitDeleteStillRemovesOnlyTargetedAuth(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	remoteDir := setupGitRemoteRepository(t, root, "master",
+		testBranchSpec{name: "master", contents: "remote master branch\n"},
+	)
+	store := NewGitTokenStore(remoteDir, "", "", "")
+	baseDir := filepath.Join(root, "workspace", "auths")
+	store.SetBaseDir(baseDir)
+	if err := store.EnsureRepository(); err != nil {
+		t.Fatalf("EnsureRepository: %v", err)
+	}
+
+	authA := &cliproxyauth.Auth{
+		ID:       "delete-me.json",
+		FileName: "delete-me.json",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex", "access_token": "a"},
+	}
+	authB := &cliproxyauth.Auth{
+		ID:       "keep-me.json",
+		FileName: "keep-me.json",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex", "access_token": "b"},
+	}
+	pathA, err := store.Save(context.Background(), authA)
+	if err != nil {
+		t.Fatalf("Save delete-me.json: %v", err)
+	}
+	if _, err := store.Save(context.Background(), authB); err != nil {
+		t.Fatalf("Save keep-me.json: %v", err)
+	}
+
+	if err := store.Delete(context.Background(), pathA); err != nil {
+		t.Fatalf("Delete delete-me.json: %v", err)
+	}
+	assertRemoteTreePath(t, remoteDir, "master", "auths/delete-me.json", false)
+	assertRemoteTreePath(t, remoteDir, "master", "auths/keep-me.json", true)
+}
+
 func TestCommitAndPushLockedPushesBeforeRunningGC(t *testing.T) {
 	root := t.TempDir()
 	remoteDir := setupGitRemoteRepository(t, root, "master",


### PR DESCRIPTION
## Summary

After a failed `git pull` (e.g. `packfile not found` on Render Free), the local git index may contain staged deletions of `auths/*.json` / `config/*.yaml` files that the caller did not intentionally remove. When `commitAndPushLocked` is subsequently invoked — most commonly via `PersistConfig` after toggling a provider switch in the management API — `worktree.Commit` builds the new commit tree from the **full index**, so those unintended deletions are included. `rewriteHeadAsSingleCommit` then replaces the entire HEAD tree with this incomplete tree, and `Force: true` push permanently deletes the files from the remote repository.

This caused a real production data-loss incident: `auths/` and `config/` were wiped from the configuration repository, and the in-memory auth list kept serving requests until it was refreshed ~1 hour later, producing a delayed outage (10:06 data loss → 11:06 first 500/503).

Closes #4629.

## Root cause

`commitAndPushLocked` trusts the worktree index. A corrupted index (left behind by a failed pull) silently turns a single-file config persist into a multi-file destructive force push.

## Fix

Add `validateCommitTree`, invoked between `worktree.Commit` and `rewriteHeadAsSingleCommit` / force push:

1. Save the pre-commit HEAD hash before `worktree.Commit` advances HEAD.
2. After commit, compare the previous HEAD tree against the new commit tree.
3. Files present in the previous tree but missing from the new tree, and **not** in the caller-intended `relPaths`, are treated as accidental data loss.
4. Reject the operation (fail-closed) before any rewrite or force push reaches the remote.

This preserves the existing single-commit-history and force-push design — it only blocks the destructive push when the tree integrity check fails. Intentional deletions (e.g. `Delete` passing the target path in `relPaths`) continue to work.

### Resetting local HEAD after a rejected commit

`worktree.Commit` advances local HEAD *before* `validateCommitTree` runs. If the rejected commit were left as HEAD, the missing files would become the new baseline, and a later `PersistConfig` would no longer detect the loss — the follow-on force-push could still wipe the remote. On rejection we hard-reset branch/index/worktree back to the pre-commit tip (`prevHeadHash`), so the next persist still compares against the intact tree. The remote is never touched on the rejected path.

## What's protected

- `PersistConfig` updating `config/config.yaml` no longer drops unrelated `auths/*.json`.
- `PersistAuthFiles("Sync auth …")` no longer drops unrelated auths (the `Sync` path is not covered by the existing `Remove auth` watcher guard).
- Multi-file index corruption (the production scenario where several codex auths were staged for deletion) is rejected.
- Explicit `Delete` still removes only the targeted auth (positive control).
- A rejected commit no longer poisons the local baseline; a second persist after rejection still protects the remote.

## Tests

Regression tests in `internal/store/gitstore_test.go`:

- `TestPersistConfigDoesNotDropAuthAfterStagedIndexDeletion` — single-auth index corruption + config persist.
- `TestPersistConfigDoesNotDropSiblingAuthsAfterMultiFileIndexCorruption` — four-auth index corruption (production scenario).
- `TestSyncAuthDoesNotDropUnrelatedAuthAfterStagedIndexDeletion` — `Sync auth` watcher path with unrelated auth staged for deletion.
- `TestExplicitDeleteStillRemovesOnlyTargetedAuth` — positive control ensuring intentional delete still works.
- `TestRejectedCommitResetsLocalHeadSoSecondPersistStillProtectsRemote` — after a rejection, local HEAD is reset to the pre-commit tip and a second persist succeeds without dropping the auth.

All assertions verify the **remote** bare tree (via `assertRemoteTreePath`), not just local state, so they prove the force push did not wipe the files.

```
go test ./internal/store/ -timeout 180s
```

Result: `ok github.com/router-for-me/CLIProxyAPI/v7/internal/store` (all tests pass, including the existing watcher-removal and branch-checkout suites).

## Notes / follow-ups

This PR is a minimal, fail-closed safety net. The reset on rejection restores branch/index/worktree to the pre-commit tip but does not attempt deeper self-healing (e.g. re-cloning after `packfile not found`, or repairing the pull failure that seeds the corruption). Those are left for maintainer discussion to keep the data-loss fix narrowly scoped.