### PR TITLE
feat(openai-compat): 支持可选原生 Responses 协议

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -432,6 +432,7 @@ nonstream-keepalive-interval: 0
 #     disabled: false # optional: set to true to disable this provider without removing it
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
+#     wire-api: "responses" # optional: use the upstream /responses API; omitted or unsupported values keep /chat/completions behavior
 #     disable-cooling: false # optional: per-provider override for auth/model cooldown scheduling
 #     headers:
 #       X-Custom-Header: "custom-value"

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -44,6 +44,7 @@ type openAICompatibilityWithAuthIndex struct {
 	Disabled       bool                                     `json:"disabled"`
 	Prefix         string                                   `json:"prefix,omitempty"`
 	BaseURL        string                                   `json:"base-url"`
+	WireAPI        string                                   `json:"wire-api,omitempty"`
 	APIKeyEntries  []openAICompatibilityAPIKeyWithAuthIndex `json:"api-key-entries,omitempty"`
 	Models         []config.OpenAICompatibilityModel        `json:"models,omitempty"`
 	Headers        map[string]string                        `json:"headers,omitempty"`
@@ -283,6 +284,7 @@ func (h *Handler) openAICompatibilityWithAuthIndex() []openAICompatibilityWithAu
 			Disabled:       entry.Disabled,
 			Prefix:         entry.Prefix,
 			BaseURL:        entry.BaseURL,
+			WireAPI:        entry.WireAPI,
 			Models:         entry.Models,
 			Headers:        entry.Headers,
 			DisableCooling: entry.DisableCooling,

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -706,6 +706,7 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 		Disabled       *bool                               `json:"disabled"`
 		DisableCooling *bool                               `json:"disable-cooling"`
 		BaseURL        *string                             `json:"base-url"`
+		WireAPI        *string                             `json:"wire-api"`
 		APIKeyEntries  *[]config.OpenAICompatibilityAPIKey `json:"api-key-entries"`
 		Models         *[]config.OpenAICompatibilityModel  `json:"models"`
 		Headers        *map[string]string                  `json:"headers"`
@@ -762,6 +763,9 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 			return
 		}
 		entry.BaseURL = trimmed
+	}
+	if body.Value.WireAPI != nil {
+		entry.WireAPI = strings.ToLower(strings.TrimSpace(*body.Value.WireAPI))
 	}
 	if body.Value.APIKeyEntries != nil {
 		for keyIndex := range *body.Value.APIKeyEntries {
@@ -1550,6 +1554,7 @@ func normalizeOpenAICompatibilityEntry(entry *config.OpenAICompatibility) {
 	}
 	// Trim base-url; empty base-url indicates provider should be removed by sanitization
 	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+	entry.WireAPI = strings.ToLower(strings.TrimSpace(entry.WireAPI))
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	existing := make(map[string]struct{}, len(entry.APIKeyEntries))
 	for i := range entry.APIKeyEntries {

--- a/internal/api/handlers/management/config_openai_compat_test.go
+++ b/internal/api/handlers/management/config_openai_compat_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -18,6 +19,7 @@ func TestGetOpenAICompatIncludesDisableCooling(t *testing.T) {
 			{
 				Name:    "Mimo CN",
 				BaseURL: "https://token-plan-cn.xiaomimimo.com/v1",
+				WireAPI: "responses",
 				APIKeyEntries: []config.OpenAICompatibilityAPIKey{
 					{APIKey: "test-key"},
 				},
@@ -40,7 +42,8 @@ func TestGetOpenAICompatIncludesDisableCooling(t *testing.T) {
 
 	var body struct {
 		OpenAICompatibility []struct {
-			DisableCooling *bool `json:"disable-cooling"`
+			DisableCooling *bool  `json:"disable-cooling"`
+			WireAPI        string `json:"wire-api"`
 		} `json:"openai-compatibility"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
@@ -51,5 +54,56 @@ func TestGetOpenAICompatIncludesDisableCooling(t *testing.T) {
 	}
 	if body.OpenAICompatibility[0].DisableCooling == nil || !*body.OpenAICompatibility[0].DisableCooling {
 		t.Fatalf("expected disable-cooling to be present and true, got %#v", body.OpenAICompatibility[0].DisableCooling)
+	}
+	if body.OpenAICompatibility[0].WireAPI != "responses" {
+		t.Fatalf("expected wire-api responses, got %q", body.OpenAICompatibility[0].WireAPI)
+	}
+}
+
+func TestOpenAICompatWireAPIPutAndPatchRoundTrip(t *testing.T) {
+	cfg := &config.Config{}
+	h := &Handler{cfg: cfg, configFilePath: writeTestConfigFile(t)}
+
+	putRec := httptest.NewRecorder()
+	putCtx, _ := gin.CreateTestContext(putRec)
+	putCtx.Request = httptest.NewRequest(http.MethodPut, "/v0/management/openai-compatibility", strings.NewReader(`[{"name":"test","base-url":"https://example.com/v1","wire-api":" ReSpOnSeS "}]`))
+	putCtx.Request.Header.Set("Content-Type", "application/json")
+	h.PutOpenAICompat(putCtx)
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, want 200; body=%s", putRec.Code, putRec.Body.String())
+	}
+	if got := cfg.OpenAICompatibility[0].WireAPI; got != "responses" {
+		t.Fatalf("PUT WireAPI = %q, want responses", got)
+	}
+
+	patchRec := httptest.NewRecorder()
+	patchCtx, _ := gin.CreateTestContext(patchRec)
+	patchCtx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/openai-compatibility", strings.NewReader(`{"index":0,"value":{"wire-api":" FuTuRe-PrOtOcOl "}}`))
+	patchCtx.Request.Header.Set("Content-Type", "application/json")
+	h.PatchOpenAICompat(patchCtx)
+	if patchRec.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d, want 200; body=%s", patchRec.Code, patchRec.Body.String())
+	}
+	if got := cfg.OpenAICompatibility[0].WireAPI; got != "future-protocol" {
+		t.Fatalf("PATCH WireAPI = %q, want future-protocol", got)
+	}
+
+	getRec := httptest.NewRecorder()
+	getCtx, _ := gin.CreateTestContext(getRec)
+	getCtx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/openai-compatibility", nil)
+	h.GetOpenAICompat(getCtx)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want 200; body=%s", getRec.Code, getRec.Body.String())
+	}
+	var body struct {
+		OpenAICompatibility []struct {
+			WireAPI string `json:"wire-api"`
+		} `json:"openai-compatibility"`
+	}
+	if errDecode := json.Unmarshal(getRec.Body.Bytes(), &body); errDecode != nil {
+		t.Fatalf("failed to decode GET response: %v", errDecode)
+	}
+	if got := body.OpenAICompatibility[0].WireAPI; got != "future-protocol" {
+		t.Fatalf("GET WireAPI = %q, want future-protocol", got)
 	}
 }

--- a/internal/api/openai_compat_responses_wire_integration_test.go
+++ b/internal/api/openai_compat_responses_wire_integration_test.go
@@ -1,0 +1,229 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	proxyconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/synthesizer"
+	"github.com/tidwall/gjson"
+)
+
+type openAICompatWireCapturedRequest struct {
+	path          string
+	authorization string
+	body          []byte
+}
+
+func TestOpenAICompatResponsesWireHandlerEndToEnd(t *testing.T) {
+	t.Run("responses JSON preserves Hermes and repository fields", func(t *testing.T) {
+		server, model, requests := newOpenAICompatWireTestServer(t, "responses", false)
+		payload := fmt.Sprintf(`{
+			"model":%q,
+			"instructions":"Keep the response structured.",
+			"input":[
+				{"role":"user","content":[{"type":"input_text","text":"Use the add tool."}]},
+				{"type":"function_call","call_id":"call_1","name":"add","arguments":"{\"a\":1,\"b\":1}"},
+				{"type":"function_call_output","call_id":"call_1","output":"2"},
+				{"role":"user","content":[{"type":"input_text","text":"Return JSON."}]}
+			],
+			"tools":[
+				{"type":"function","name":"add","parameters":{"type":"object","properties":{}}},
+				{"type":"web_search"}
+			],
+			"text":{"format":{"type":"json_schema","name":"answer","strict":true,"schema":{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"],"additionalProperties":false}}},
+			"store":false
+		}`, model)
+
+		recorder := performOpenAICompatWireRequest(t, server, "/v1/responses", payload)
+		captured := <-requests
+		if captured.path != "/v1/responses" {
+			t.Fatalf("upstream path = %q, want /v1/responses", captured.path)
+		}
+		if captured.authorization != "Bearer test-upstream-key" {
+			t.Fatalf("upstream Authorization = %q", captured.authorization)
+		}
+		if gjson.GetBytes(captured.body, "messages").Exists() {
+			t.Fatalf("native Responses request was converted to messages: %s", captured.body)
+		}
+		if got := gjson.GetBytes(captured.body, "input.2.output").String(); got != "2" {
+			t.Fatalf("function_call_output = %q, want 2; body=%s", got, captured.body)
+		}
+		if got := gjson.GetBytes(captured.body, `tools.#(type=="web_search").type`).String(); got != "web_search" {
+			t.Fatalf("web_search tool type = %q, want web_search; body=%s", got, captured.body)
+		}
+		if !gjson.GetBytes(captured.body, "text.format.strict").Bool() {
+			t.Fatalf("strict JSON schema was not preserved: %s", captured.body)
+		}
+		if got := gjson.GetBytes(recorder.Body.Bytes(), "object").String(); got != "response" {
+			t.Fatalf("downstream object = %q, want response; body=%s", got, recorder.Body.String())
+		}
+		if got := gjson.GetBytes(recorder.Body.Bytes(), "output.0.content.0.text").String(); got != `{"answer":"ok"}` {
+			t.Fatalf("downstream output text = %q; body=%s", got, recorder.Body.String())
+		}
+	})
+
+	t.Run("responses SSE preserves Codex Responses Lite input", func(t *testing.T) {
+		server, model, requests := newOpenAICompatWireTestServer(t, "responses", true)
+		payload := fmt.Sprintf(`{
+			"model":%q,
+			"input":[
+				{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"exec","description":"Run a command","format":{"type":"grammar","syntax":"lark","definition":"start: /.+/"}}]},
+				{"role":"user","content":[{"type":"input_text","text":"Run pwd."}]}
+			],
+			"client_metadata":{"ws_request_header_x_openai_internal_codex_responses_lite":"true"},
+			"stream":true
+		}`, model)
+
+		recorder := performOpenAICompatWireRequest(t, server, "/v1/responses", payload)
+		captured := <-requests
+		if captured.path != "/v1/responses" {
+			t.Fatalf("upstream path = %q, want /v1/responses", captured.path)
+		}
+		if got := gjson.GetBytes(captured.body, "input.0.type").String(); got != "additional_tools" {
+			t.Fatalf("input.0.type = %q, want additional_tools; body=%s", got, captured.body)
+		}
+		if got := gjson.GetBytes(captured.body, "input.0.tools.0.type").String(); got != "custom" {
+			t.Fatalf("additional custom tool type = %q, want custom; body=%s", got, captured.body)
+		}
+		if got := recorder.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+			t.Fatalf("downstream Content-Type = %q, want text/event-stream", got)
+		}
+		streamBody := recorder.Body.String()
+		createdIndex := strings.Index(streamBody, "response.created")
+		completedIndex := strings.Index(streamBody, "response.completed")
+		if createdIndex < 0 || completedIndex <= createdIndex {
+			t.Fatalf("downstream SSE event order invalid: %s", streamBody)
+		}
+		if strings.Contains(streamBody, "[DONE]") {
+			t.Fatalf("native Responses stream contains synthetic [DONE]: %s", streamBody)
+		}
+	})
+
+	t.Run("responses without configured wire keeps Chat compatibility", func(t *testing.T) {
+		server, model, requests := newOpenAICompatWireTestServer(t, "", false)
+		payload := fmt.Sprintf(`{"model":%q,"input":"hello"}`, model)
+
+		recorder := performOpenAICompatWireRequest(t, server, "/v1/responses", payload)
+		captured := <-requests
+		if captured.path != "/v1/chat/completions" {
+			t.Fatalf("upstream path = %q, want /v1/chat/completions", captured.path)
+		}
+		if !gjson.GetBytes(captured.body, "messages").Exists() {
+			t.Fatalf("default Responses request was not converted to messages: %s", captured.body)
+		}
+		if got := gjson.GetBytes(recorder.Body.Bytes(), "object").String(); got != "response" {
+			t.Fatalf("downstream object = %q, want response; body=%s", got, recorder.Body.String())
+		}
+	})
+
+	t.Run("configured Responses wire leaves Chat requests unchanged", func(t *testing.T) {
+		server, model, requests := newOpenAICompatWireTestServer(t, "responses", false)
+		payload := fmt.Sprintf(`{"model":%q,"messages":[{"role":"user","content":"hello"}]}`, model)
+
+		recorder := performOpenAICompatWireRequest(t, server, "/v1/chat/completions", payload)
+		captured := <-requests
+		if captured.path != "/v1/chat/completions" {
+			t.Fatalf("upstream path = %q, want /v1/chat/completions", captured.path)
+		}
+		if !gjson.GetBytes(captured.body, "messages").Exists() {
+			t.Fatalf("Chat request lost messages: %s", captured.body)
+		}
+		if got := gjson.GetBytes(recorder.Body.Bytes(), "object").String(); got != "chat.completion" {
+			t.Fatalf("downstream object = %q, want chat.completion; body=%s", got, recorder.Body.String())
+		}
+	})
+}
+
+func newOpenAICompatWireTestServer(t *testing.T, wireAPI string, streamResponse bool) (*Server, string, <-chan openAICompatWireCapturedRequest) {
+	t.Helper()
+
+	requests := make(chan openAICompatWireCapturedRequest, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read upstream request body: %v", errRead)
+		}
+		requests <- openAICompatWireCapturedRequest{
+			path:          r.URL.Path,
+			authorization: r.Header.Get("Authorization"),
+			body:          body,
+		}
+		if streamResponse {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "event: response.created\n")
+			_, _ = io.WriteString(w, "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_wire\",\"status\":\"in_progress\"}}\n\n")
+			_, _ = io.WriteString(w, "event: response.completed\n")
+			_, _ = io.WriteString(w, "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_wire\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":3,\"output_tokens\":1,\"total_tokens\":4}}}\n\n")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/responses") {
+			_, _ = io.WriteString(w, `{"id":"resp_wire","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"{\"answer\":\"ok\"}"}]}],"usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"id":"chatcmpl_wire","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}}`)
+	}))
+	t.Cleanup(upstream.Close)
+
+	model := fmt.Sprintf("wire-e2e-%d", time.Now().UnixNano())
+	providerName := "jiurelay-wire-test"
+	cfg := &proxyconfig.Config{
+		OpenAICompatibility: []proxyconfig.OpenAICompatibility{{
+			Name:    providerName,
+			BaseURL: upstream.URL + "/v1",
+			WireAPI: wireAPI,
+			APIKeyEntries: []proxyconfig.OpenAICompatibilityAPIKey{{
+				APIKey: "test-upstream-key",
+			}},
+			Models: []proxyconfig.OpenAICompatibilityModel{{Name: model, Alias: model}},
+		}},
+	}
+	auths, errSynthesize := synthesizer.NewConfigSynthesizer().Synthesize(&synthesizer.SynthesisContext{
+		Config:      cfg,
+		Now:         time.Unix(0, 0),
+		IDGenerator: synthesizer.NewStableIDGenerator(),
+	})
+	if errSynthesize != nil {
+		t.Fatalf("synthesize OpenAI-compatible auth: %v", errSynthesize)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("synthesized auth count = %d, want 1", len(auths))
+	}
+	credential := auths[0]
+
+	server := newTestServer(t)
+	server.handlers.AuthManager.SetConfig(cfg)
+	server.handlers.AuthManager.RegisterExecutor(runtimeexecutor.NewOpenAICompatExecutor(credential.Provider, cfg))
+	if _, errRegister := server.handlers.AuthManager.Register(context.Background(), credential); errRegister != nil {
+		t.Fatalf("register OpenAI-compatible auth: %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(credential.ID, credential.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(credential.ID)
+	})
+
+	return server, model, requests
+}
+
+func performOpenAICompatWireRequest(t *testing.T, server *Server, path, payload string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodPost, path, strings.NewReader(payload))
+	request.Header.Set("Authorization", "Bearer test-key")
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	server.engine.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("downstream status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	return recorder
+}

--- a/internal/config/config_normalization.go
+++ b/internal/config/config_normalization.go
@@ -113,6 +113,7 @@ func (cfg *Config) SanitizeOpenAICompatibility() {
 		e.Name = strings.TrimSpace(e.Name)
 		e.Prefix = normalizeModelPrefix(e.Prefix)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
+		e.WireAPI = strings.ToLower(strings.TrimSpace(e.WireAPI))
 		e.Headers = NormalizeHeaders(e.Headers)
 		if e.BaseURL == "" {
 			// Skip providers with no base-url; treated as removed

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -537,6 +537,9 @@ type OpenAICompatibility struct {
 	// BaseURL is the base URL for the external OpenAI-compatible API endpoint.
 	BaseURL string `yaml:"base-url" json:"base-url"`
 
+	// WireAPI selects the upstream OpenAI wire protocol when supported.
+	WireAPI string `yaml:"wire-api,omitempty" json:"wire-api,omitempty"`
+
 	// APIKeyEntries defines API keys with optional per-key proxy configuration.
 	APIKeyEntries []OpenAICompatibilityAPIKey `yaml:"api-key-entries,omitempty" json:"api-key-entries,omitempty"`
 

--- a/internal/config/openai_compat_wire_api_test.go
+++ b/internal/config/openai_compat_wire_api_test.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestOpenAICompatibilityWireAPINormalizationAndRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "responses", raw: "  ReSpOnSeS  ", want: "responses"},
+		{name: "unknown preserved", raw: "  FuTuRe-PrOtOcOl  ", want: "future-protocol"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg, errParse := ParseConfigBytes([]byte("openai-compatibility:\n  - name: test\n    base-url: https://example.com/v1\n    wire-api: \"" + test.raw + "\"\n"))
+			if errParse != nil {
+				t.Fatalf("ParseConfigBytes() error = %v", errParse)
+			}
+			if got := cfg.OpenAICompatibility[0].WireAPI; got != test.want {
+				t.Fatalf("WireAPI = %q, want %q", got, test.want)
+			}
+
+			yamlData, errYAML := yaml.Marshal(cfg.OpenAICompatibility[0])
+			if errYAML != nil {
+				t.Fatalf("yaml.Marshal() error = %v", errYAML)
+			}
+			if !strings.Contains(string(yamlData), "wire-api: "+test.want) {
+				t.Fatalf("YAML does not contain normalized wire-api: %s", yamlData)
+			}
+
+			jsonData, errJSON := json.Marshal(cfg.OpenAICompatibility[0])
+			if errJSON != nil {
+				t.Fatalf("json.Marshal() error = %v", errJSON)
+			}
+			var decoded OpenAICompatibility
+			if errUnmarshal := json.Unmarshal(jsonData, &decoded); errUnmarshal != nil {
+				t.Fatalf("json.Unmarshal() error = %v", errUnmarshal)
+			}
+			if decoded.WireAPI != test.want {
+				t.Fatalf("JSON round-trip WireAPI = %q, want %q", decoded.WireAPI, test.want)
+			}
+		})
+	}
+}
+
+func TestOpenAICompatibilityWireAPIOmittedWhenEmpty(t *testing.T) {
+	entry := OpenAICompatibility{Name: "test", BaseURL: "https://example.com/v1"}
+
+	yamlData, errYAML := yaml.Marshal(entry)
+	if errYAML != nil {
+		t.Fatalf("yaml.Marshal() error = %v", errYAML)
+	}
+	if strings.Contains(string(yamlData), "wire-api") {
+		t.Fatalf("empty wire-api should be omitted from YAML: %s", yamlData)
+	}
+
+	jsonData, errJSON := json.Marshal(entry)
+	if errJSON != nil {
+		t.Fatalf("json.Marshal() error = %v", errJSON)
+	}
+	if strings.Contains(string(jsonData), "wire-api") {
+		t.Fatalf("empty wire-api should be omitted from JSON: %s", jsonData)
+	}
+}

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -485,7 +485,7 @@ func (b *StreamUsageBuffer) ObserveOpenAIStream(line []byte) {
 	detail := usage.Detail{}
 	usageOK := false
 	if hasUsageCandidate {
-		usageNode := gjson.GetBytes(payload, "usage")
+		usageNode := openAIStyleUsageNode(payload)
 		if hasOpenAIStyleUsageTokenFields(usageNode) {
 			detail = parseOpenAIStyleUsageNode(usageNode)
 			usageOK = true
@@ -538,13 +538,22 @@ func ParseCodexImageToolUsage(data []byte) (usage.Detail, bool) {
 
 func ParseOpenAIUsage(data []byte) usage.Detail {
 	responseServiceTier := extractResponseServiceTier(data)
-	usageNode := gjson.ParseBytes(data).Get("usage")
+	usageNode := openAIStyleUsageNode(data)
 	if !hasOpenAIStyleUsageTokenFields(usageNode) {
 		return usage.Detail{ResponseServiceTier: responseServiceTier}
 	}
 	detail := parseOpenAIStyleUsageNode(usageNode)
 	detail.ResponseServiceTier = responseServiceTier
 	return detail
+}
+
+func openAIStyleUsageNode(data []byte) gjson.Result {
+	root := gjson.ParseBytes(data)
+	usageNode := root.Get("usage")
+	if hasOpenAIStyleUsageTokenFields(usageNode) {
+		return usageNode
+	}
+	return root.Get("response.usage")
 }
 
 func hasOpenAIStyleUsageTokenFields(usageNode gjson.Result) bool {
@@ -653,7 +662,7 @@ func ParseOpenAIStreamUsage(line []byte) (usage.Detail, bool) {
 		return usage.Detail{}, false
 	}
 	responseServiceTier := extractResponseServiceTier(payload)
-	usageNode := gjson.GetBytes(payload, "usage")
+	usageNode := openAIStyleUsageNode(payload)
 	if !hasOpenAIStyleUsageTokenFields(usageNode) {
 		if responseServiceTier == "" {
 			return usage.Detail{}, false

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -194,6 +194,30 @@ func TestParseOpenAIStreamUsageResponsesFields(t *testing.T) {
 	}
 }
 
+func TestParseOpenAIStreamUsageResponseCompletedFields(t *testing.T) {
+	line := []byte(`data: {"type":"response.completed","response":{"service_tier":"priority","usage":{"input_tokens":8,"output_tokens":5,"total_tokens":13,"input_tokens_details":{"cached_tokens":3},"output_tokens_details":{"reasoning_tokens":2}}}}`)
+	detail, ok := ParseOpenAIStreamUsage(line)
+	if !ok {
+		t.Fatal("ParseOpenAIStreamUsage() ok = false, want true")
+	}
+	if detail.InputTokens != 8 || detail.OutputTokens != 5 || detail.TotalTokens != 13 {
+		t.Fatalf("detail = %+v, want input=8 output=5 total=13", detail)
+	}
+	if detail.CachedTokens != 3 || detail.ReasoningTokens != 2 {
+		t.Fatalf("detail = %+v, want cached=3 reasoning=2", detail)
+	}
+	if detail.ResponseServiceTier != "priority" {
+		t.Fatalf("response service tier = %q, want priority", detail.ResponseServiceTier)
+	}
+
+	var buffer StreamUsageBuffer
+	buffer.ObserveOpenAIStream(line)
+	buffered, bufferedOK := buffer.Detail()
+	if !bufferedOK || buffered != detail {
+		t.Fatalf("StreamUsageBuffer.Detail() = (%+v, %v), want (%+v, true)", buffered, bufferedOK, detail)
+	}
+}
+
 func TestStreamUsageBufferKeepsLastUsage(t *testing.T) {
 	var buffer StreamUsageBuffer
 	buffer.Observe(usage.Detail{}, true)

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -22,6 +22,7 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
@@ -48,6 +49,33 @@ func NewOpenAICompatExecutor(provider string, cfg *config.Config) *OpenAICompatE
 
 // Identifier implements cliproxyauth.ProviderExecutor.
 func (e *OpenAICompatExecutor) Identifier() string { return e.provider }
+
+// RequestToFormat reports the upstream request format used after auth selection.
+func (e *OpenAICompatExecutor) RequestToFormat(_ cliproxyexecutor.Request, opts cliproxyexecutor.Options) sdktranslator.Format {
+	return openAICompatRequestToFormat(false, opts)
+}
+
+// RequestToFormatWithAuth reports the upstream request format for the selected credential.
+func (e *OpenAICompatExecutor) RequestToFormatWithAuth(auth *cliproxyauth.Auth, _ cliproxyexecutor.Request, opts cliproxyexecutor.Options) sdktranslator.Format {
+	return openAICompatRequestToFormat(e.useNativeResponsesWire(auth, opts), opts)
+}
+
+func openAICompatRequestToFormat(nativeResponses bool, opts cliproxyexecutor.Options) sdktranslator.Format {
+	source := opts.SourceFormat.String()
+	if source == openAICompatImageHandlerType || source == "openai-video" {
+		return opts.SourceFormat
+	}
+	if opts.Alt == "responses/compact" {
+		if !opts.Stream {
+			return sdktranslator.FormatOpenAIResponse
+		}
+		return sdktranslator.FormatOpenAI
+	}
+	if nativeResponses {
+		return sdktranslator.FormatOpenAIResponse
+	}
+	return sdktranslator.FormatOpenAI
+}
 
 // PrepareRequest injects OpenAI-compatible credentials into the outgoing HTTP request.
 func (e *OpenAICompatExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth) error {
@@ -100,10 +128,14 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
-	to := sdktranslator.FromString("openai")
+	to := sdktranslator.FormatOpenAI
 	endpoint := "/chat/completions"
+	if e.useNativeResponsesWire(auth, opts) {
+		to = sdktranslator.FormatOpenAIResponse
+		endpoint = "/responses"
+	}
 	if opts.Alt == "responses/compact" {
-		to = sdktranslator.FromString("openai-response")
+		to = sdktranslator.FormatOpenAIResponse
 		endpoint = "/responses/compact"
 	}
 	originalPayloadSource := req.Payload
@@ -306,7 +338,13 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
-	to := sdktranslator.FromString("openai")
+	to := sdktranslator.FormatOpenAI
+	endpoint := "/chat/completions"
+	nativeResponses := e.useNativeResponsesWire(auth, opts)
+	if nativeResponses {
+		to = sdktranslator.FormatOpenAIResponse
+		endpoint = "/responses"
+	}
 	originalPayloadSource := req.Payload
 	if len(opts.OriginalRequest) > 0 {
 		originalPayloadSource = opts.OriginalRequest
@@ -326,10 +364,12 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 
 	// Request usage data in the final streaming chunk so that token statistics
 	// are captured even when the upstream is an OpenAI-compatible provider.
-	translated = helps.SetBoolIfDifferent(translated, "stream_options.include_usage", true)
+	if !nativeResponses {
+		translated = helps.SetBoolIfDifferent(translated, "stream_options.include_usage", true)
+	}
 	reporter.SetTranslatedReasoningEffort(translated, to.String())
 
-	url := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
+	url := strings.TrimSuffix(baseURL, "/") + endpoint
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
 	if err != nil {
 		return nil, err
@@ -395,6 +435,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		claudeInputTokens := helps.NewClaudeInputTokenState(from, to, responseFormat, originalPayload)
 		var param any
 		var streamUsage helps.StreamUsageBuffer
+		nativeTerminalSeen := false
 		defer streamUsage.Publish(ctx, reporter)
 		for scanner.Scan() {
 			line := scanner.Bytes()
@@ -408,6 +449,16 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			if !bytes.HasPrefix(trimmedLine, []byte("data:")) {
 				if bytes.HasPrefix(trimmedLine, []byte(":")) || bytes.HasPrefix(trimmedLine, []byte("event:")) ||
 					bytes.HasPrefix(trimmedLine, []byte("id:")) || bytes.HasPrefix(trimmedLine, []byte("retry:")) {
+					if nativeResponses {
+						chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, bytes.Clone(line), &param, claudeInputTokens)
+						for i := range chunks {
+							select {
+							case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
+							case <-ctx.Done():
+								return
+							}
+						}
+					}
 					continue
 				}
 				if bytes.HasPrefix(trimmedLine, []byte("{")) || bytes.HasPrefix(trimmedLine, []byte("[")) {
@@ -424,13 +475,38 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			}
 
 			// OpenAI-compatible streams must use SSE data lines.
-			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, bytes.Clone(trimmedLine), &param, claudeInputTokens)
+			if nativeResponses {
+				eventData := bytes.TrimSpace(trimmedLine[len("data:"):])
+				if streamErr, _, ok := codexTerminalFailureErr(eventData); ok {
+					helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
+					reporter.PublishFailure(ctx, streamErr)
+					select {
+					case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
+					case <-ctx.Done():
+					}
+					return
+				}
+				switch gjson.GetBytes(eventData, "type").String() {
+				case "response.completed", "response.incomplete":
+					nativeTerminalSeen = true
+				}
+			}
+			translatedLine := bytes.Clone(trimmedLine)
+			if nativeResponses {
+				translatedLine = bytes.Clone(line)
+			}
+			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, translatedLine, &param, claudeInputTokens)
 			for i := range chunks {
 				select {
 				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
 				case <-ctx.Done():
 					return
 				}
+			}
+			if nativeTerminalSeen {
+				streamUsage.Publish(ctx, reporter)
+				reporter.EnsurePublished(ctx)
+				return
 			}
 		}
 		if errScan := scanner.Err(); errScan != nil {
@@ -440,7 +516,16 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
 			case <-ctx.Done():
 			}
-		} else {
+		} else if nativeResponses && !nativeTerminalSeen {
+			streamErr := newOpenAICompatIncompleteStreamError()
+			helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
+			reporter.PublishFailure(ctx, streamErr)
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
+			case <-ctx.Done():
+			}
+			return
+		} else if !nativeResponses {
 			// In case the upstream close the stream without a terminal [DONE] marker.
 			// Feed a synthetic done marker through the translator so pending
 			// response.completed events are still emitted exactly once.
@@ -745,6 +830,17 @@ func (e *OpenAICompatExecutor) resolveCredentials(auth *cliproxyauth.Auth) (base
 	return
 }
 
+func (e *OpenAICompatExecutor) useNativeResponsesWire(auth *cliproxyauth.Auth, opts cliproxyexecutor.Options) bool {
+	if auth == nil || auth.Attributes == nil {
+		return false
+	}
+	return openAICompatUsesNativeResponsesWire(auth.Attributes["wire_api"], opts)
+}
+
+func openAICompatUsesNativeResponsesWire(wireAPI string, opts cliproxyexecutor.Options) bool {
+	return opts.Alt != "responses/compact" && opts.SourceFormat == sdktranslator.FormatOpenAIResponse && strings.EqualFold(strings.TrimSpace(wireAPI), "responses")
+}
+
 func (e *OpenAICompatExecutor) resolveCompatConfig(auth *cliproxyauth.Auth) *config.OpenAICompatibility {
 	if auth == nil || e.cfg == nil {
 		return nil
@@ -786,6 +882,21 @@ type statusErr struct {
 	code       int
 	msg        string
 	retryAfter *time.Duration
+}
+
+type openAICompatIncompleteStreamError struct {
+	statusErr
+}
+
+func newOpenAICompatIncompleteStreamError() openAICompatIncompleteStreamError {
+	return openAICompatIncompleteStreamError{statusErr: statusErr{
+		code: http.StatusRequestTimeout,
+		msg:  "stream error: stream disconnected before completion: stream closed before response.completed or response.incomplete",
+	}}
+}
+
+func (openAICompatIncompleteStreamError) IsRequestScoped() bool {
+	return true
 }
 
 func (e statusErr) Error() string {

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -35,6 +35,7 @@ func TestOpenAICompatExecutorCompactPassthrough(t *testing.T) {
 	auth := &cliproxyauth.Auth{Attributes: map[string]string{
 		"base_url": server.URL + "/v1",
 		"api_key":  "test",
+		"wire_api": "responses",
 	}}
 	payload := []byte(`{"model":"gpt-5.1-codex-max","input":[{"role":"user","content":"hi"}]}`)
 	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{

--- a/internal/runtime/executor/openai_compat_executor_responses_test.go
+++ b/internal/runtime/executor/openai_compat_executor_responses_test.go
@@ -1,0 +1,390 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAICompatExecutorNativeResponsesNonStream(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	responseBody := []byte(`{"id":"resp_1","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4}}`)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(responseBody)
+	}))
+	defer server.Close()
+
+	exec := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+		"wire_api": "responses",
+	}}
+	payload := []byte(`{"model":"grok-4.5","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}],"tools":[{"type":"custom","name":"exec","description":"run","format":{"type":"text"}}]}`)
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "grok-4.5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotPath != "/v1/responses" {
+		t.Fatalf("path = %q, want /v1/responses", gotPath)
+	}
+	if gjson.GetBytes(gotBody, "messages").Exists() {
+		t.Fatalf("native Responses request was converted to Chat Completions: %s", gotBody)
+	}
+	if got := gjson.GetBytes(gotBody, "input.0.type").String(); got != "message" {
+		t.Fatalf("input.0.type = %q, want message; body=%s", got, gotBody)
+	}
+	if got := gjson.GetBytes(gotBody, "tools.0.type").String(); got != "custom" {
+		t.Fatalf("tools.0.type = %q, want custom; body=%s", got, gotBody)
+	}
+	if string(resp.Payload) != string(responseBody) {
+		t.Fatalf("response payload = %s, want unchanged %s", resp.Payload, responseBody)
+	}
+}
+
+func TestOpenAICompatExecutorNativeResponsesRequiresMatchingWireAndSource(t *testing.T) {
+	exec := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	tests := []struct {
+		name       string
+		wireAPI    string
+		source     sdktranslator.Format
+		alt        string
+		wantNative bool
+	}{
+		{name: "responses source and wire", wireAPI: "responses", source: sdktranslator.FormatOpenAIResponse, wantNative: true},
+		{name: "trimmed case insensitive wire", wireAPI: " Responses ", source: sdktranslator.FormatOpenAIResponse, wantNative: true},
+		{name: "empty wire", source: sdktranslator.FormatOpenAIResponse},
+		{name: "unknown wire", wireAPI: "response", source: sdktranslator.FormatOpenAIResponse},
+		{name: "chat source", wireAPI: "responses", source: sdktranslator.FormatOpenAI},
+		{name: "claude source", wireAPI: "responses", source: sdktranslator.FormatClaude},
+		{name: "compact keeps priority", wireAPI: "responses", source: sdktranslator.FormatOpenAIResponse, alt: "responses/compact"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{"wire_api": tt.wireAPI}}
+			got := exec.useNativeResponsesWire(auth, cliproxyexecutor.Options{SourceFormat: tt.source, Alt: tt.alt})
+			if got != tt.wantNative {
+				t.Fatalf("useNativeResponsesWire() = %v, want %v", got, tt.wantNative)
+			}
+		})
+	}
+}
+
+func TestOpenAICompatExecutorRequestToFormatUsesSelectedAuth(t *testing.T) {
+	cfg := &config.Config{OpenAICompatibility: []config.OpenAICompatibility{
+		{Name: "JiuRelay", WireAPI: "responses"},
+	}}
+	exec := NewOpenAICompatExecutor("openai-compatible-jiurelay", cfg)
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse}
+	if got := exec.RequestToFormat(cliproxyexecutor.Request{}, opts); got != sdktranslator.FormatOpenAI {
+		t.Fatalf("RequestToFormat() = %q, want stable fallback %q", got, sdktranslator.FormatOpenAI)
+	}
+	selectedOldAuth := &cliproxyauth.Auth{Attributes: map[string]string{"wire_api": ""}}
+	if got := exec.RequestToFormatWithAuth(selectedOldAuth, cliproxyexecutor.Request{}, opts); got != sdktranslator.FormatOpenAI {
+		t.Fatalf("new cfg with old selected auth = %q, want %q", got, sdktranslator.FormatOpenAI)
+	}
+	cfg.OpenAICompatibility[0].WireAPI = ""
+	selectedNewAuth := &cliproxyauth.Auth{Attributes: map[string]string{"wire_api": "responses"}}
+	if got := exec.RequestToFormatWithAuth(selectedNewAuth, cliproxyexecutor.Request{}, opts); got != sdktranslator.FormatOpenAIResponse {
+		t.Fatalf("old cfg with new selected auth = %q, want %q", got, sdktranslator.FormatOpenAIResponse)
+	}
+
+	tests := []struct {
+		name    string
+		wireAPI string
+		opts    cliproxyexecutor.Options
+		want    sdktranslator.Format
+	}{
+		{name: "native Responses", wireAPI: "responses", opts: cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse}, want: sdktranslator.FormatOpenAIResponse},
+		{name: "unknown wire stays Chat", wireAPI: "response", opts: cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse}, want: sdktranslator.FormatOpenAI},
+		{name: "Chat source stays Chat", wireAPI: "responses", opts: cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI}, want: sdktranslator.FormatOpenAI},
+		{name: "Claude source stays Chat", wireAPI: "responses", opts: cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude}, want: sdktranslator.FormatOpenAI},
+		{name: "nonstream compact stays Responses", wireAPI: "responses", opts: cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, Alt: "responses/compact"}, want: sdktranslator.FormatOpenAIResponse},
+		{name: "stream compact keeps existing Chat behavior", wireAPI: "responses", opts: cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, Alt: "responses/compact", Stream: true}, want: sdktranslator.FormatOpenAI},
+		{name: "images keep source format", wireAPI: "responses", opts: cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-image")}, want: sdktranslator.FromString("openai-image")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{"wire_api": tt.wireAPI}}
+			if got := exec.RequestToFormatWithAuth(auth, cliproxyexecutor.Request{}, tt.opts); got != tt.want {
+				t.Fatalf("RequestToFormatWithAuth() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenAICompatExecutorNonNativeRequestsKeepChatCompletionsWire(t *testing.T) {
+	tests := []struct {
+		name    string
+		wireAPI string
+		source  sdktranslator.Format
+		payload []byte
+	}{
+		{name: "empty wire with Responses source", source: sdktranslator.FormatOpenAIResponse, payload: []byte(`{"model":"grok-4.5","input":"hi"}`)},
+		{name: "unknown wire with Responses source", wireAPI: "response", source: sdktranslator.FormatOpenAIResponse, payload: []byte(`{"model":"grok-4.5","input":"hi"}`)},
+		{name: "Responses wire with Chat source", wireAPI: "responses", source: sdktranslator.FormatOpenAI, payload: []byte(`{"model":"grok-4.5","messages":[{"role":"user","content":"hi"}]}`)},
+		{name: "Responses wire with Claude source", wireAPI: "responses", source: sdktranslator.FormatClaude, payload: []byte(`{"model":"grok-4.5","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath string
+			var gotBody []byte
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotBody, _ = io.ReadAll(r.Body)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+			}))
+			defer server.Close()
+
+			exec := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{
+				"base_url": server.URL + "/v1",
+				"api_key":  "test",
+				"wire_api": tt.wireAPI,
+			}}
+			_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+				Model:   "grok-4.5",
+				Payload: tt.payload,
+			}, cliproxyexecutor.Options{
+				SourceFormat:   tt.source,
+				ResponseFormat: sdktranslator.FormatOpenAI,
+			})
+			if err != nil {
+				t.Fatalf("Execute error: %v", err)
+			}
+			if gotPath != "/v1/chat/completions" {
+				t.Fatalf("path = %q, want /v1/chat/completions", gotPath)
+			}
+			if !gjson.GetBytes(gotBody, "messages").Exists() {
+				t.Fatalf("Chat Completions request has no messages: %s", gotBody)
+			}
+		})
+	}
+}
+
+func TestOpenAICompatExecutorNativeResponsesStreamPreservesSSEFields(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.created\n"))
+		_, _ = w.Write([]byte("id: resp-event-1  \n"))
+		_, _ = w.Write([]byte("retry: 1500\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"status\":\"in_progress\"}}\n\n"))
+		_, _ = w.Write([]byte("event: response.completed\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":3,\"output_tokens\":1,\"total_tokens\":4}}}\n\n"))
+	}))
+	defer server.Close()
+
+	exec := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+		"wire_api": "responses",
+	}}
+	result, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "grok-4.5",
+		Payload: []byte(`{"model":"grok-4.5","input":"hi","stream":true}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var chunks []string
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		chunks = append(chunks, string(chunk.Payload))
+	}
+	if gotPath != "/v1/responses" {
+		t.Fatalf("path = %q, want /v1/responses", gotPath)
+	}
+	if gjson.GetBytes(gotBody, "stream_options").Exists() {
+		t.Fatalf("native Responses request contains Chat stream_options: %s", gotBody)
+	}
+	wantChunks := []string{
+		"event: response.created",
+		"id: resp-event-1  ",
+		"retry: 1500",
+		`data: {"type":"response.created","response":{"id":"resp_1","status":"in_progress"}}`,
+		"event: response.completed",
+		`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4}}}`,
+	}
+	if !slices.Equal(chunks, wantChunks) {
+		t.Fatalf("stream chunks = %#v, want %#v", chunks, wantChunks)
+	}
+	if strings.Contains(strings.Join(chunks, "\n"), "[DONE]") {
+		t.Fatalf("native Responses stream received a synthetic [DONE]: %#v", chunks)
+	}
+}
+
+func TestOpenAICompatExecutorNativeResponsesStreamAcceptsIncompleteTerminal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.incomplete\",\"response\":{\"id\":\"resp_1\",\"status\":\"incomplete\",\"output\":[]}}\n\n"))
+	}))
+	defer server.Close()
+
+	exec := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"base_url": server.URL + "/v1", "wire_api": "responses"}}
+	result, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model: "grok-4.5", Payload: []byte(`{"model":"grok-4.5","input":"hi","stream":true}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("response.incomplete returned stream error: %v", chunk.Err)
+		}
+	}
+}
+
+func TestOpenAICompatExecutorNativeResponsesStreamClosesAfterTerminalWithoutEOF(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"output\":[]}}\n\n"))
+		w.(http.Flusher).Flush()
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	defer func() {
+		close(release)
+		server.Close()
+	}()
+
+	exec := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"base_url": server.URL + "/v1", "wire_api": "responses"}}
+	result, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model: "grok-4.5", Payload: []byte(`{"model":"grok-4.5","input":"hi","stream":true}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	type streamOutcome struct {
+		chunks []string
+		err    error
+	}
+	done := make(chan streamOutcome, 1)
+	go func() {
+		outcome := streamOutcome{}
+		for chunk := range result.Chunks {
+			if chunk.Err != nil {
+				outcome.err = chunk.Err
+				break
+			}
+			outcome.chunks = append(outcome.chunks, string(chunk.Payload))
+		}
+		done <- outcome
+	}()
+
+	select {
+	case outcome := <-done:
+		if outcome.err != nil {
+			t.Fatalf("terminal stream error: %v", outcome.err)
+		}
+		if len(outcome.chunks) != 1 || !strings.Contains(outcome.chunks[0], `"type":"response.completed"`) {
+			t.Fatalf("terminal stream chunks = %#v", outcome.chunks)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("native Responses stream did not close after terminal event")
+	}
+}
+
+func TestOpenAICompatExecutorNativeResponsesStreamRejectsTruncatedEOF(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n"))
+	}))
+	defer server.Close()
+
+	exec := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"base_url": server.URL + "/v1", "wire_api": "responses"}}
+	result, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model: "grok-4.5", Payload: []byte(`{"model":"grok-4.5","input":"hi","stream":true}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	var streamErr error
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			streamErr = chunk.Err
+		}
+	}
+	if streamErr == nil {
+		t.Fatal("truncated native Responses stream error = nil")
+	}
+	if status, ok := streamErr.(interface{ StatusCode() int }); !ok || status.StatusCode() != http.StatusRequestTimeout {
+		t.Fatalf("truncated stream status = %v, want %d", streamErr, http.StatusRequestTimeout)
+	}
+	if scoped, ok := streamErr.(interface{ IsRequestScoped() bool }); !ok || !scoped.IsRequestScoped() {
+		t.Fatalf("truncated stream error is not request-scoped: %T %v", streamErr, streamErr)
+	}
+	if !strings.Contains(streamErr.Error(), "response.completed or response.incomplete") {
+		t.Fatalf("truncated stream error = %q", streamErr.Error())
+	}
+}
+
+func TestOpenAICompatExecutorNativeResponsesStreamSurfacesFailureEvent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: error\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"code\":\"invalid_value\",\"message\":\"bad tools\"}}\n\n"))
+	}))
+	defer server.Close()
+
+	exec := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"base_url": server.URL + "/v1", "wire_api": "responses"}}
+	result, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model: "grok-4.5", Payload: []byte(`{"model":"grok-4.5","input":"hi","stream":true}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	var streamErr error
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			streamErr = chunk.Err
+		}
+	}
+	if streamErr == nil || !strings.Contains(streamErr.Error(), "bad tools") {
+		t.Fatalf("failure event stream error = %v", streamErr)
+	}
+	if status, ok := streamErr.(interface{ StatusCode() int }); !ok || status.StatusCode() != http.StatusBadRequest {
+		t.Fatalf("failure event status = %v, want %d", streamErr, http.StatusBadRequest)
+	}
+}

--- a/internal/watcher/diff/openai_compat.go
+++ b/internal/watcher/diff/openai_compat.go
@@ -65,9 +65,12 @@ func describeOpenAICompatibilityUpdate(oldEntry, newEntry config.OpenAICompatibi
 	newKeyCount := countAPIKeys(newEntry)
 	oldModelCount := countOpenAIModels(oldEntry.Models)
 	newModelCount := countOpenAIModels(newEntry.Models)
-	details := make([]string, 0, 3)
+	details := make([]string, 0, 4)
 	if oldEntry.Disabled != newEntry.Disabled {
 		details = append(details, fmt.Sprintf("disabled %t -> %t", oldEntry.Disabled, newEntry.Disabled))
+	}
+	if oldEntry.WireAPI != newEntry.WireAPI {
+		details = append(details, fmt.Sprintf("wire-api %q -> %q", oldEntry.WireAPI, newEntry.WireAPI))
 	}
 	if oldKeyCount != newKeyCount {
 		details = append(details, fmt.Sprintf("api-keys %d -> %d", oldKeyCount, newKeyCount))

--- a/internal/watcher/diff/openai_compat_test.go
+++ b/internal/watcher/diff/openai_compat_test.go
@@ -67,6 +67,26 @@ func TestDiffOpenAICompatibility_RemovedAndUnchanged(t *testing.T) {
 	expectContains(t, changes, "provider removed: provider-a (api-keys=1, models=1)")
 }
 
+func TestDiffOpenAICompatibility_WireAPIVisibleWithoutSecrets(t *testing.T) {
+	oldList := []config.OpenAICompatibility{{
+		Name:          "provider-a",
+		APIKeyEntries: []config.OpenAICompatibilityAPIKey{{APIKey: "old-secret-key"}},
+	}}
+	newList := []config.OpenAICompatibility{{
+		Name:          "provider-a",
+		WireAPI:       "responses",
+		APIKeyEntries: []config.OpenAICompatibilityAPIKey{{APIKey: "new-secret-key"}},
+	}}
+
+	changes := DiffOpenAICompatibility(oldList, newList)
+	expectContains(t, changes, `provider updated: provider-a (wire-api "" -> "responses")`)
+	for _, change := range changes {
+		if strings.Contains(change, "old-secret-key") || strings.Contains(change, "new-secret-key") {
+			t.Fatalf("diff leaked API key material: %s", change)
+		}
+	}
+}
+
 func TestOpenAICompatKeyFallbacks(t *testing.T) {
 	entry := config.OpenAICompatibility{
 		BaseURL: "http://base",

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -273,6 +273,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 		}
 		internalProviderKey := util.OpenAICompatibleProviderKey(providerName)
 		base := strings.TrimSpace(compat.BaseURL)
+		wireAPI := strings.ToLower(strings.TrimSpace(compat.WireAPI))
 		disableCooling := compat.DisableCooling
 
 		// Handle new APIKeyEntries format (preferred)
@@ -295,6 +296,9 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 			}
 			if compat.Priority != 0 {
 				attrs["priority"] = strconv.Itoa(compat.Priority)
+			}
+			if wireAPI != "" {
+				attrs["wire_api"] = wireAPI
 			}
 			addWeightToAttrs(entry.Weight, attrs)
 			if key != "" {
@@ -338,6 +342,9 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 			}
 			if compat.Priority != 0 {
 				attrs["priority"] = strconv.Itoa(compat.Priority)
+			}
+			if wireAPI != "" {
+				attrs["wire_api"] = wireAPI
 			}
 			if hash := diff.ComputeOpenAICompatModelsHash(compat.Models); hash != "" {
 				attrs["models_hash"] = hash

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -543,6 +543,55 @@ func TestConfigSynthesizer_OpenAICompat_UsesNamespacedProviderKey(t *testing.T) 
 	}
 }
 
+func TestConfigSynthesizer_OpenAICompat_WireAPI(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			OpenAICompatibility: []config.OpenAICompatibility{
+				{
+					Name:          "with-key",
+					BaseURL:       "https://with-key.example.com/v1",
+					WireAPI:       " ReSpOnSeS ",
+					APIKeyEntries: []config.OpenAICompatibilityAPIKey{{APIKey: "test-key"}},
+				},
+				{
+					Name:    "without-key",
+					BaseURL: "https://without-key.example.com/v1",
+					WireAPI: " FuTuRe-PrOtOcOl ",
+				},
+				{
+					Name:          "default-wire",
+					BaseURL:       "https://default.example.com/v1",
+					APIKeyEntries: []config.OpenAICompatibilityAPIKey{{APIKey: "default-key"}},
+				},
+			},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 3 {
+		t.Fatalf("expected 3 auths, got %d", len(auths))
+	}
+	byCompatName := make(map[string]*coreauth.Auth, len(auths))
+	for _, auth := range auths {
+		byCompatName[auth.Attributes["compat_name"]] = auth
+	}
+	if got := byCompatName["with-key"].Attributes["wire_api"]; got != "responses" {
+		t.Fatalf("with-key wire_api = %q, want responses", got)
+	}
+	if got := byCompatName["without-key"].Attributes["wire_api"]; got != "future-protocol" {
+		t.Fatalf("without-key wire_api = %q, want future-protocol", got)
+	}
+	if _, ok := byCompatName["default-wire"].Attributes["wire_api"]; ok {
+		t.Fatal("empty wire-api should not synthesize a wire_api attribute")
+	}
+}
+
 func TestConfigSynthesizer_VertexCompat(t *testing.T) {
 	synth := NewConfigSynthesizer()
 	ctx := &SynthesisContext{

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -160,16 +160,20 @@ type requestToFormatResolver interface {
 	RequestToFormat(req cliproxyexecutor.Request, opts cliproxyexecutor.Options) sdktranslator.Format
 }
 
+type requestToFormatWithAuthResolver interface {
+	RequestToFormatWithAuth(auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) sdktranslator.Format
+}
+
 func isRequestTerminatedError(err error) bool {
 	var terminated *cliproxyexecutor.RequestTerminatedError
 	return errors.As(err, &terminated) && terminated != nil
 }
 
-func applyRequestAfterAuthInterceptor(ctx context.Context, executor ProviderExecutor, provider string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, requestedModel string) (cliproxyexecutor.Request, cliproxyexecutor.Options, error) {
+func applyRequestAfterAuthInterceptor(ctx context.Context, executor ProviderExecutor, auth *Auth, provider string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, requestedModel string) (cliproxyexecutor.Request, cliproxyexecutor.Options, error) {
 	if opts.RequestAfterAuthInterceptor == nil {
 		return req, opts, nil
 	}
-	toFormat := requestToFormat(provider, executor, req, opts)
+	toFormat := requestToFormat(provider, executor, auth, req, opts)
 	resp := opts.RequestAfterAuthInterceptor(ctx, cliproxyexecutor.RequestAfterAuthInterceptRequest{
 		SourceFormat:   opts.SourceFormat,
 		ToFormat:       toFormat,
@@ -195,7 +199,14 @@ func applyRequestAfterAuthInterceptor(ctx context.Context, executor ProviderExec
 	return req, opts, nil
 }
 
-func requestToFormat(provider string, executor ProviderExecutor, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) sdktranslator.Format {
+func requestToFormat(provider string, executor ProviderExecutor, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) sdktranslator.Format {
+	resolverWithAuth, okWithAuth := executor.(requestToFormatWithAuthResolver)
+	if okWithAuth && resolverWithAuth != nil {
+		formatRequestTo := resolverWithAuth.RequestToFormatWithAuth(auth, req, opts)
+		if formatRequestTo != "" {
+			return formatRequestTo
+		}
+	}
 	resolver, ok := executor.(requestToFormatResolver)
 	if ok && resolver != nil {
 		formatRequestTo := resolver.RequestToFormat(req, opts)
@@ -326,7 +337,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			}
 			execOpts := opts
 			var errIntercept error
-			execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, executor, auth, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
 			if errIntercept != nil {
 				return cliproxyexecutor.Response{}, errIntercept
 			}
@@ -443,7 +454,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			}
 			execOpts := opts
 			var errIntercept error
-			execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, executor, auth, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
 			if errIntercept != nil {
 				return cliproxyexecutor.Response{}, errIntercept
 			}

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -91,7 +91,7 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			execOpts := opts
 			execOpts.ExecutionLifecycle = selection
 			var errIntercept error
-			execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, selection.Executor, selection.Provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, selection.Executor, preparedAuth, selection.Provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
 			if errIntercept != nil {
 				releaseAttempt()
 				selection.End("request_intercepted")

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -196,7 +196,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		}
 		execOpts := opts
 		var errIntercept error
-		execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(ctx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+		execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(ctx, executor, auth, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
 		if errIntercept != nil {
 			return nil, errIntercept
 		}

--- a/sdk/cliproxy/auth/request_to_format_auth_test.go
+++ b/sdk/cliproxy/auth/request_to_format_auth_test.go
@@ -1,0 +1,186 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+type selectedAuthFormatExecutor struct {
+	id string
+
+	mu      sync.Mutex
+	authIDs []string
+}
+
+func (e *selectedAuthFormatExecutor) Identifier() string { return e.id }
+
+func (*selectedAuthFormatExecutor) RequestToFormat(cliproxyexecutor.Request, cliproxyexecutor.Options) sdktranslator.Format {
+	return sdktranslator.FormatGemini
+}
+
+func (e *selectedAuthFormatExecutor) RequestToFormatWithAuth(auth *Auth, _ cliproxyexecutor.Request, opts cliproxyexecutor.Options) sdktranslator.Format {
+	if auth != nil {
+		e.mu.Lock()
+		e.authIDs = append(e.authIDs, auth.ID)
+		e.mu.Unlock()
+	}
+	if auth != nil && auth.Attributes["wire_api"] == "responses" && opts.SourceFormat == sdktranslator.FormatOpenAIResponse {
+		return sdktranslator.FormatOpenAIResponse
+	}
+	return sdktranslator.FormatOpenAI
+}
+
+func (*selectedAuthFormatExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{Payload: []byte(`{"ok":true}`)}, nil
+}
+
+func (*selectedAuthFormatExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.completed"}`)}
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (*selectedAuthFormatExecutor) Refresh(context.Context, *Auth) (*Auth, error) { return nil, nil }
+
+func (*selectedAuthFormatExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{Payload: []byte(`{"usage":{"total_tokens":1}}`)}, nil
+}
+
+func (*selectedAuthFormatExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (e *selectedAuthFormatExecutor) selectedAuthIDs() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.authIDs...)
+}
+
+func TestRequestToFormatPrefersSelectedAuthResolver(t *testing.T) {
+	exec := &selectedAuthFormatExecutor{id: "format-auth"}
+	auth := &Auth{ID: "selected-auth", Attributes: map[string]string{"wire_api": "responses"}}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse}
+	if got := requestToFormat(exec.Identifier(), exec, auth, cliproxyexecutor.Request{}, opts); got != sdktranslator.FormatOpenAIResponse {
+		t.Fatalf("requestToFormat() = %q, want %q", got, sdktranslator.FormatOpenAIResponse)
+	}
+	if got := exec.selectedAuthIDs(); len(got) != 1 || got[0] != auth.ID {
+		t.Fatalf("selected auth IDs = %v, want [%s]", got, auth.ID)
+	}
+}
+
+func TestManagerRequestAfterAuthInterceptorUsesSelectedAuthForFormat(t *testing.T) {
+	const (
+		provider = "format-auth-manager"
+		model    = "format-model"
+	)
+	exec := &selectedAuthFormatExecutor{id: provider}
+	auth := &Auth{ID: "selected-manager-auth", Provider: provider, Status: StatusActive, Attributes: map[string]string{"wire_api": "responses"}}
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(exec)
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	globalRegistry := registry.GetGlobalRegistry()
+	globalRegistry.RegisterClient(auth.ID, provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { globalRegistry.UnregisterClient(auth.ID) })
+	manager.RefreshSchedulerEntry(auth.ID)
+
+	var mu sync.Mutex
+	var formats []sdktranslator.Format
+	interceptor := func(_ context.Context, request cliproxyexecutor.RequestAfterAuthInterceptRequest) cliproxyexecutor.RequestAfterAuthInterceptResponse {
+		mu.Lock()
+		formats = append(formats, request.ToFormat)
+		mu.Unlock()
+		return cliproxyexecutor.RequestAfterAuthInterceptResponse{}
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, RequestAfterAuthInterceptor: interceptor}
+	req := cliproxyexecutor.Request{Model: model, Payload: []byte(`{"model":"format-model","input":"hi"}`)}
+
+	if _, errExecute := manager.Execute(context.Background(), []string{provider}, req, opts); errExecute != nil {
+		t.Fatalf("Execute error: %v", errExecute)
+	}
+	if _, errCount := manager.ExecuteCount(context.Background(), []string{provider}, req, opts); errCount != nil {
+		t.Fatalf("ExecuteCount error: %v", errCount)
+	}
+	streamResult, errStream := manager.ExecuteStream(context.Background(), []string{provider}, req, opts)
+	if errStream != nil {
+		t.Fatalf("ExecuteStream error: %v", errStream)
+	}
+	for chunk := range streamResult.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+	}
+
+	mu.Lock()
+	gotFormats := append([]sdktranslator.Format(nil), formats...)
+	mu.Unlock()
+	if len(gotFormats) != 3 {
+		t.Fatalf("interceptor formats = %v, want three calls", gotFormats)
+	}
+	for _, format := range gotFormats {
+		if format != sdktranslator.FormatOpenAIResponse {
+			t.Fatalf("interceptor format = %q, want %q; all=%v", format, sdktranslator.FormatOpenAIResponse, gotFormats)
+		}
+	}
+	if gotAuthIDs := exec.selectedAuthIDs(); len(gotAuthIDs) != 3 {
+		t.Fatalf("selected auth IDs = %v, want three calls", gotAuthIDs)
+	} else {
+		for _, authID := range gotAuthIDs {
+			if authID != auth.ID {
+				t.Fatalf("selected auth ID = %q, want %q", authID, auth.ID)
+			}
+		}
+	}
+}
+
+type selectedAuthFormatHomeDispatcher struct{}
+
+func (selectedAuthFormatHomeDispatcher) HeartbeatOK() bool { return true }
+
+func (selectedAuthFormatHomeDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+	return json.Marshal(homeAuthDispatchResponse{Auth: Auth{
+		ID:         "selected-home-auth",
+		Provider:   "format-auth-home",
+		Status:     StatusActive,
+		Attributes: map[string]string{"wire_api": "responses"},
+	}})
+}
+
+func (selectedAuthFormatHomeDispatcher) AbortAmbiguousDispatch() {}
+
+func TestHomeRequestAfterAuthInterceptorUsesSelectedAuthForFormat(t *testing.T) {
+	exec := &selectedAuthFormatExecutor{id: "format-auth-home"}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.PublishHomeDispatch(selectedAuthFormatHomeDispatcher{}, executionregistry.New(), 1)
+	manager.RegisterExecutor(exec)
+
+	var gotFormat sdktranslator.Format
+	interceptor := func(_ context.Context, request cliproxyexecutor.RequestAfterAuthInterceptRequest) cliproxyexecutor.RequestAfterAuthInterceptResponse {
+		gotFormat = request.ToFormat
+		return cliproxyexecutor.RequestAfterAuthInterceptResponse{}
+	}
+	_, errExecute := manager.Execute(context.Background(), []string{exec.Identifier()}, cliproxyexecutor.Request{
+		Model: "format-model", Payload: []byte(`{"model":"format-model","input":"hi"}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, RequestAfterAuthInterceptor: interceptor})
+	if errExecute != nil {
+		t.Fatalf("Execute error: %v", errExecute)
+	}
+	if gotFormat != sdktranslator.FormatOpenAIResponse {
+		t.Fatalf("Home interceptor format = %q, want %q", gotFormat, sdktranslator.FormatOpenAIResponse)
+	}
+	if gotAuthIDs := exec.selectedAuthIDs(); len(gotAuthIDs) != 1 || gotAuthIDs[0] != "selected-home-auth" {
+		t.Fatalf("Home selected auth IDs = %v, want [selected-home-auth]", gotAuthIDs)
+	}
+}


### PR DESCRIPTION
## Summary

- add an opt-in `wire-api: responses` setting to `openai-compatibility`
- route only inbound Responses requests to the upstream `/responses` endpoint while keeping Chat/Claude inputs on `/chat/completions`
- preserve native Responses JSON and SSE fields, terminal semantics, and nested usage accounting
- keep default, unknown-value, and `/responses/compact` behavior unchanged

## Why this is different from #4297 and #4460

Those issues correctly recommend `codex-api-key` for **Responses-only** upstreams. This change targets hybrid OpenAI-compatible providers that expose both Chat Completions and Responses with the same credential and model namespace.

Configuring the same hybrid credential twice under `openai-compatibility` and `codex-api-key` creates duplicate model/auth routing and forces clients to use separate aliases. The provider-level wire switch instead selects the native upstream protocol from the inbound request format:

```yaml
openai-compatibility:
  - name: hybrid-provider
    base-url: https://provider.example/v1
    wire-api: responses
```

- inbound `/v1/responses` -> upstream `/responses`
- inbound Chat/Claude -> upstream `/chat/completions`

Omitting `wire-api`, or setting an unsupported value, preserves the existing Chat Completions behavior.

## Correctness details

- selected-auth attributes are the request-level source of truth for both interceptor `ToFormat` and the actual upstream endpoint, avoiding hot-reload mismatch windows
- native Responses streams preserve `event`, `id`, `retry`, and `data` lines without synthetic `[DONE]`
- `response.completed` and `response.incomplete` close the downstream stream immediately, even if the upstream keeps the TCP connection open
- truncated streams and explicit failure events are reported as errors rather than successful requests
- usage parsing supports `response.completed.response.usage`

## Validation

- `go test ./... -count=1`
- targeted package tests for API, executor, config, watcher, management, and auth
- targeted `go test -race` for native Responses streaming and selected-auth format resolution
- `go build -o <temporary>/cli-proxy-api ./cmd/server`
- `gofmt -w .`
- `git diff --check`
