### PR TITLE
fix(codex): keep websocket sessions alive

### DIFF
--- a/internal/runtime/executor/codex_websockets_connection.go
+++ b/internal/runtime/executor/codex_websockets_connection.go
@@ -25,8 +25,19 @@ import (
 const (
 	codexResponsesWebsocketBetaHeaderValue = "responses_websockets=2026-02-06"
 	codexResponsesWebsocketIdleTimeout     = 5 * time.Minute
+	codexResponsesWebsocketPingInterval    = 30 * time.Second
+	codexResponsesWebsocketPingWriteTO     = 10 * time.Second
 	codexResponsesWebsocketHandshakeTO     = 30 * time.Second
 )
+
+func configureCodexWebsocketPongHandler(conn *websocket.Conn, idleTimeout time.Duration) {
+	if conn == nil || idleTimeout <= 0 {
+		return
+	}
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(idleTimeout))
+	})
+}
 
 func (e *CodexWebsocketsExecutor) dialCodexWebsocket(ctx context.Context, auth *cliproxyauth.Auth, wsURL string, headers http.Header) (*websocket.Conn, *websocketConnectionCloser, *http.Response, error) {
 	dialer := newProxyAwareWebsocketDialer(e.cfg, auth)

--- a/internal/runtime/executor/codex_websockets_heartbeat_test.go
+++ b/internal/runtime/executor/codex_websockets_heartbeat_test.go
@@ -1,0 +1,169 @@
+package executor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestCodexWebsocketHeartbeatSendsPingsAndStopsWithConnection(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	pingSeen := make(chan struct{}, 4)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, errUpgrade := upgrader.Upgrade(w, r, nil)
+		if errUpgrade != nil {
+			t.Errorf("upgrade websocket: %v", errUpgrade)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		conn.SetPingHandler(func(appData string) error {
+			select {
+			case pingSeen <- struct{}{}:
+			default:
+			}
+			return conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(time.Second))
+		})
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, errDial := websocket.DefaultDialer.Dial(wsURL, nil)
+	if errDial != nil {
+		t.Fatalf("dial websocket: %v", errDial)
+	}
+	closer := newWebsocketConnectionCloser(conn)
+	stopped := closer.startHeartbeat(10*time.Millisecond, time.Second, nil)
+	if duplicate := closer.startHeartbeat(10*time.Millisecond, time.Second, nil); duplicate != stopped {
+		t.Fatal("starting heartbeat twice returned a different stop channel")
+	}
+
+	select {
+	case <-pingSeen:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for heartbeat ping")
+	}
+	if errClose := closer.Close(); errClose != nil {
+		t.Fatalf("close websocket: %v", errClose)
+	}
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("heartbeat did not stop after connection close")
+	}
+}
+
+func TestCodexWebsocketHeartbeatReportsPingFailure(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	serverConn := make(chan *websocket.Conn, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, errUpgrade := upgrader.Upgrade(w, r, nil)
+		if errUpgrade != nil {
+			t.Errorf("upgrade websocket: %v", errUpgrade)
+			return
+		}
+		serverConn <- conn
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, errDial := websocket.DefaultDialer.Dial(wsURL, nil)
+	if errDial != nil {
+		t.Fatalf("dial websocket: %v", errDial)
+	}
+	defer func() { _ = conn.Close() }()
+	peer := <-serverConn
+	defer func() { _ = peer.Close() }()
+
+	var callbackCalls atomic.Int32
+	heartbeatErr := make(chan error, 1)
+	closer := newWebsocketConnectionCloser(conn)
+	stopped := closer.startHeartbeat(10*time.Millisecond, time.Second, func(err error) {
+		callbackCalls.Add(1)
+		heartbeatErr <- err
+	})
+	if errClose := conn.Close(); errClose != nil {
+		t.Fatalf("close raw websocket: %v", errClose)
+	}
+
+	select {
+	case errHeartbeat := <-heartbeatErr:
+		if errHeartbeat == nil || !strings.Contains(errHeartbeat.Error(), "heartbeat ping failed") {
+			t.Fatalf("heartbeat error = %v, want wrapped ping failure", errHeartbeat)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for heartbeat error callback")
+	}
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("heartbeat did not stop after ping failure")
+	}
+	if got := callbackCalls.Load(); got != 1 {
+		t.Fatalf("heartbeat callback calls = %d, want 1", got)
+	}
+}
+
+func TestCodexWebsocketHeartbeatPongExtendsReadDeadline(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, errUpgrade := upgrader.Upgrade(w, r, nil)
+		if errUpgrade != nil {
+			t.Errorf("upgrade websocket: %v", errUpgrade)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		writeDone := make(chan struct{})
+		go func() {
+			defer close(writeDone)
+			time.Sleep(500 * time.Millisecond)
+			if errWrite := conn.WriteMessage(websocket.TextMessage, []byte("ready")); errWrite != nil {
+				t.Errorf("write websocket message: %v", errWrite)
+			}
+		}()
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				<-writeDone
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, errDial := websocket.DefaultDialer.Dial(wsURL, nil)
+	if errDial != nil {
+		t.Fatalf("dial websocket: %v", errDial)
+	}
+	closer := newWebsocketConnectionCloser(conn)
+	defer func() { _ = closer.Close() }()
+
+	idleTimeout := 200 * time.Millisecond
+	configureCodexWebsocketPongHandler(conn, idleTimeout)
+	if errDeadline := conn.SetReadDeadline(time.Now().Add(idleTimeout)); errDeadline != nil {
+		t.Fatalf("set initial read deadline: %v", errDeadline)
+	}
+	closer.startHeartbeat(30*time.Millisecond, time.Second, nil)
+
+	msgType, payload, errRead := conn.ReadMessage()
+	if errRead != nil {
+		t.Fatalf("read websocket message after initial deadline: %v", errRead)
+	}
+	if msgType != websocket.TextMessage || string(payload) != "ready" {
+		t.Fatalf("websocket message = type %d payload %q, want text ready", msgType, payload)
+	}
+}

--- a/internal/runtime/executor/codex_websockets_session.go
+++ b/internal/runtime/executor/codex_websockets_session.go
@@ -24,16 +24,23 @@ var globalCodexWebsocketSessionStore = &codexWebsocketSessionStore{
 }
 
 type websocketConnectionCloser struct {
-	conn *websocket.Conn
-	once sync.Once
-	err  error
+	conn             *websocket.Conn
+	once             sync.Once
+	heartbeatOnce    sync.Once
+	done             chan struct{}
+	heartbeatStopped chan struct{}
+	err              error
 }
 
 func newWebsocketConnectionCloser(conn *websocket.Conn) *websocketConnectionCloser {
 	if conn == nil {
 		return nil
 	}
-	return &websocketConnectionCloser{conn: conn}
+	return &websocketConnectionCloser{
+		conn:             conn,
+		done:             make(chan struct{}),
+		heartbeatStopped: make(chan struct{}),
+	}
 }
 
 func (c *websocketConnectionCloser) Close() error {
@@ -41,9 +48,43 @@ func (c *websocketConnectionCloser) Close() error {
 		return nil
 	}
 	c.once.Do(func() {
+		close(c.done)
 		c.err = c.conn.Close()
 	})
 	return c.err
+}
+
+func (c *websocketConnectionCloser) startHeartbeat(interval time.Duration, writeTimeout time.Duration, onError func(error)) <-chan struct{} {
+	if c == nil || c.conn == nil || interval <= 0 || writeTimeout <= 0 {
+		return nil
+	}
+	c.heartbeatOnce.Do(func() {
+		go func() {
+			defer close(c.heartbeatStopped)
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-c.done:
+					return
+				case <-ticker.C:
+					errWrite := c.conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(writeTimeout))
+					if errWrite == nil {
+						continue
+					}
+					errHeartbeat := fmt.Errorf("codex websocket heartbeat ping failed: %w", errWrite)
+					if onError != nil {
+						onError(errHeartbeat)
+					}
+					if errClose := c.Close(); errClose != nil {
+						log.Debugf("codex websockets executor: close after heartbeat error: %v", errClose)
+					}
+					return
+				}
+			}
+		}()
+	})
+	return c.heartbeatStopped
 }
 
 type codexWebsocketSession struct {
@@ -189,6 +230,7 @@ func (s *codexWebsocketSession) configureConn(conn *websocket.Conn) {
 		return
 	}
 	s.resetUpstreamDisconnectError(conn)
+	configureCodexWebsocketPongHandler(conn, codexResponsesWebsocketIdleTimeout)
 	conn.SetPingHandler(func(appData string) error {
 		s.writeMu.Lock()
 		defer s.writeMu.Unlock()
@@ -457,7 +499,12 @@ func (e *CodexWebsocketsExecutor) UpstreamDisconnectChan(sessionID string) <-cha
 
 func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *cliproxyauth.Auth, sess *codexWebsocketSession, authID string, wsURL string, headers http.Header) (*websocket.Conn, *websocketConnectionCloser, *http.Response, error) {
 	if sess == nil {
-		return e.dialCodexWebsocket(ctx, auth, wsURL, headers)
+		conn, closer, resp, errDial := e.dialCodexWebsocket(ctx, auth, wsURL, headers)
+		if errDial == nil && conn != nil && closer != nil {
+			configureCodexWebsocketPongHandler(conn, codexResponsesWebsocketIdleTimeout)
+			closer.startHeartbeat(codexResponsesWebsocketPingInterval, codexResponsesWebsocketPingWriteTO, nil)
+		}
+		return conn, closer, resp, errDial
 	}
 
 	if staleConn, staleCloser, staleAuthID, staleWSURL, staleLifecycle := detachMismatchedWebsocketSessionConn(sess, authID, wsURL); staleConn != nil {
@@ -484,6 +531,12 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 			sess.connMu.Unlock()
 			sess.configureConn(conn)
 			go e.readUpstreamLoop(sess, conn)
+		}
+		if closer != nil {
+			closer.startHeartbeat(codexResponsesWebsocketPingInterval, codexResponsesWebsocketPingWriteTO, func(errHeartbeat error) {
+				sess.setUpstreamDisconnectError(conn, errHeartbeat)
+				e.invalidateUpstreamConn(sess, conn, "heartbeat_failed", errHeartbeat)
+			})
 		}
 		return conn, closer, nil, nil
 	}
@@ -512,6 +565,10 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 
 	sess.configureConn(conn)
 	go e.readUpstreamLoop(sess, conn)
+	closer.startHeartbeat(codexResponsesWebsocketPingInterval, codexResponsesWebsocketPingWriteTO, func(errHeartbeat error) {
+		sess.setUpstreamDisconnectError(conn, errHeartbeat)
+		e.invalidateUpstreamConn(sess, conn, "heartbeat_failed", errHeartbeat)
+	})
 	logCodexWebsocketConnected(sess.sessionID, authID, wsURL)
 	return conn, closer, resp, nil
 }


### PR DESCRIPTION
## Summary

- send a WebSocket Ping control frame every 30 seconds on Codex upstream connections
- refresh the existing five-minute read deadline whenever a Pong is received
- stop the per-connection heartbeat on close and invalidate reusable sessions immediately when a Ping write fails

## Motivation

Codex upstream WebSocket sessions can be quiet between turns. HTTP/SOCKS relays and other intermediaries may reap those idle connections before CPA's five-minute read deadline. The next request then surfaces a `broken pipe`, `unexpected EOF`, or abnormal WebSocket close even though the original upgrade succeeded.

The existing code responds to server Ping frames but does not proactively send Ping frames, and Pong frames do not extend the current read deadline.

## Validation

- `go test -race ./internal/runtime/executor -run TestCodexWebsocketHeartbeat -count=3`
- `go test ./...`
- `go build -o /tmp/cliproxyapi-ws-heartbeat-build ./cmd/server`
- staging A/B through an HTTP proxy, SSH local forward, xray, and VMess outbound:
  - unmodified CPA `7.2.102`: the reused upstream connection closed during idle after about 199 seconds with WebSocket `1006 unexpected EOF`
  - patched build: the same connection remained reusable after 330 seconds idle and completed a second response; logs showed one upstream connection and a final normal `session_closed`

No configuration or public API changes are required.
