### PR TITLE
fix(streaming): recover transient Codex streams before commitment

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -268,9 +268,10 @@ nonstream-keepalive-interval: 0
 #   keepalive-seconds: 15   # Default: 0 (disabled). <= 0 disables keep-alives.
 #   bootstrap-retries: 1    # Default: 0 (disabled). Ignored while full recovery is enabled.
 #   recovery:
-#     attempts: 0                         # Additional full-stream attempts. 0 disables recovery.
+#     enabled: false                      # Explicit opt-in. attempts > 0 also enables compatibility mode.
+#     attempts: 0                         # Optional additional-attempt cap. 0 means no cap when enabled.
 #     max-buffer-bytes: 8388608           # Fails open to ordinary streaming above this limit.
-#     max-retry-window-seconds: 20        # Limits when another attempt may start, not active streams.
+#     max-retry-window-seconds: 20        # Retry deadline. Default: 20. Max: 3600.
 #     max-concurrent: 16                  # Saturation fails open without waiting.
 #     initial-backoff-milliseconds: 250
 #     max-backoff-milliseconds: 2000

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -263,10 +263,17 @@ ws-auth: true
 
 # When > 0, emit blank lines every N seconds for non-streaming responses to prevent idle timeouts.
 nonstream-keepalive-interval: 0
-# Streaming behavior (SSE keep-alives + safe bootstrap retries).
+# Streaming behavior (SSE keep-alives + bounded transparent recovery).
 # streaming:
 #   keepalive-seconds: 15   # Default: 0 (disabled). <= 0 disables keep-alives.
-#   bootstrap-retries: 1    # Default: 0 (disabled). Retries before first byte is sent.
+#   bootstrap-retries: 1    # Default: 0 (disabled). Ignored while full recovery is enabled.
+#   recovery:
+#     attempts: 0                         # Additional full-stream attempts. 0 disables recovery.
+#     max-buffer-bytes: 8388608           # Fails open to ordinary streaming above this limit.
+#     max-retry-window-seconds: 20        # Limits when another attempt may start, not active streams.
+#     max-concurrent: 16                  # Saturation fails open without waiting.
+#     initial-backoff-milliseconds: 250
+#     max-backoff-milliseconds: 2000
 
 # Signature cache validation for thinking blocks (Antigravity/Claude).
 # When true (default), cached signatures are preferred and validated.

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -141,6 +141,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	if cfg.MaxRetryCredentials < 0 {
 		cfg.MaxRetryCredentials = 0
 	}
+	cfg.Streaming.NormalizeStreamingConfig()
 
 	cfg.NormalizePluginsConfig()
 	if errResolvePluginsDir := cfg.ResolvePluginsDir(); errResolvePluginsDir != nil && cfg.Plugins.Enabled {

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -87,6 +87,7 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	if cfg.MaxRetryCredentials < 0 {
 		cfg.MaxRetryCredentials = 0
 	}
+	cfg.Streaming.NormalizeStreamingConfig()
 
 	cfg.NormalizePluginsConfig()
 	if errResolvePluginsDir := cfg.ResolvePluginsDir(); errResolvePluginsDir != nil && cfg.Plugins.Enabled {

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -86,19 +86,20 @@ type StreamingConfig struct {
 
 // StreamingRecoveryConfig bounds full-stream transparent recovery.
 type StreamingRecoveryConfig struct {
-	Attempts                   int `yaml:"attempts,omitempty" json:"attempts,omitempty"`
-	MaxBufferBytes             int `yaml:"max-buffer-bytes,omitempty" json:"max-buffer-bytes,omitempty"`
-	MaxRetryWindowSeconds      int `yaml:"max-retry-window-seconds,omitempty" json:"max-retry-window-seconds,omitempty"`
-	MaxConcurrent              int `yaml:"max-concurrent,omitempty" json:"max-concurrent,omitempty"`
-	InitialBackoffMilliseconds int `yaml:"initial-backoff-milliseconds,omitempty" json:"initial-backoff-milliseconds,omitempty"`
-	MaxBackoffMilliseconds     int `yaml:"max-backoff-milliseconds,omitempty" json:"max-backoff-milliseconds,omitempty"`
+	Enabled                    bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Attempts                   int  `yaml:"attempts,omitempty" json:"attempts,omitempty"`
+	MaxBufferBytes             int  `yaml:"max-buffer-bytes,omitempty" json:"max-buffer-bytes,omitempty"`
+	MaxRetryWindowSeconds      int  `yaml:"max-retry-window-seconds,omitempty" json:"max-retry-window-seconds,omitempty"`
+	MaxConcurrent              int  `yaml:"max-concurrent,omitempty" json:"max-concurrent,omitempty"`
+	InitialBackoffMilliseconds int  `yaml:"initial-backoff-milliseconds,omitempty" json:"initial-backoff-milliseconds,omitempty"`
+	MaxBackoffMilliseconds     int  `yaml:"max-backoff-milliseconds,omitempty" json:"max-backoff-milliseconds,omitempty"`
 }
 
 const (
 	defaultStreamingRecoveryMaxBufferBytes             = 8 << 20
 	maxStreamingRecoveryMaxBufferBytes                 = 64 << 20
 	defaultStreamingRecoveryMaxRetryWindowSeconds      = 20
-	maxStreamingRecoveryMaxRetryWindowSeconds          = 300
+	maxStreamingRecoveryMaxRetryWindowSeconds          = 3600
 	defaultStreamingRecoveryMaxConcurrent              = 16
 	maxStreamingRecoveryMaxConcurrent                  = 1024
 	defaultStreamingRecoveryInitialBackoffMilliseconds = 250
@@ -116,9 +117,12 @@ func (c *StreamingConfig) NormalizeStreamingConfig() {
 		c.BootstrapRetries = 0
 	}
 	r := &c.Recovery
-	if r.Attempts <= 0 {
+	if !r.Enabled && r.Attempts <= 0 {
 		r.Attempts = 0
 		return
+	}
+	if r.Attempts < 0 {
+		r.Attempts = 0
 	}
 	if r.Attempts > maxStreamingRecoveryAttempts {
 		r.Attempts = maxStreamingRecoveryAttempts

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -79,4 +79,76 @@ type StreamingConfig struct {
 	// to allow auth rotation / transient recovery.
 	// <= 0 disables bootstrap retries. Default is 0.
 	BootstrapRetries int `yaml:"bootstrap-retries,omitempty" json:"bootstrap-retries,omitempty"`
+
+	// Recovery configures opt-in full-stream buffering and transparent transient recovery.
+	Recovery StreamingRecoveryConfig `yaml:"recovery,omitempty" json:"recovery,omitempty"`
+}
+
+// StreamingRecoveryConfig bounds full-stream transparent recovery.
+type StreamingRecoveryConfig struct {
+	Attempts                   int `yaml:"attempts,omitempty" json:"attempts,omitempty"`
+	MaxBufferBytes             int `yaml:"max-buffer-bytes,omitempty" json:"max-buffer-bytes,omitempty"`
+	MaxRetryWindowSeconds      int `yaml:"max-retry-window-seconds,omitempty" json:"max-retry-window-seconds,omitempty"`
+	MaxConcurrent              int `yaml:"max-concurrent,omitempty" json:"max-concurrent,omitempty"`
+	InitialBackoffMilliseconds int `yaml:"initial-backoff-milliseconds,omitempty" json:"initial-backoff-milliseconds,omitempty"`
+	MaxBackoffMilliseconds     int `yaml:"max-backoff-milliseconds,omitempty" json:"max-backoff-milliseconds,omitempty"`
+}
+
+const (
+	defaultStreamingRecoveryMaxBufferBytes             = 8 << 20
+	maxStreamingRecoveryMaxBufferBytes                 = 64 << 20
+	defaultStreamingRecoveryMaxRetryWindowSeconds      = 20
+	maxStreamingRecoveryMaxRetryWindowSeconds          = 300
+	defaultStreamingRecoveryMaxConcurrent              = 16
+	maxStreamingRecoveryMaxConcurrent                  = 1024
+	defaultStreamingRecoveryInitialBackoffMilliseconds = 250
+	defaultStreamingRecoveryMaxBackoffMilliseconds     = 2000
+	maxStreamingRecoveryBackoffMilliseconds            = 30000
+	maxStreamingRecoveryAttempts                       = 10
+)
+
+// NormalizeStreamingConfig applies bounded defaults while leaving recovery opt-in.
+func (c *StreamingConfig) NormalizeStreamingConfig() {
+	if c == nil {
+		return
+	}
+	if c.BootstrapRetries < 0 {
+		c.BootstrapRetries = 0
+	}
+	r := &c.Recovery
+	if r.Attempts <= 0 {
+		r.Attempts = 0
+		return
+	}
+	if r.Attempts > maxStreamingRecoveryAttempts {
+		r.Attempts = maxStreamingRecoveryAttempts
+	}
+	if r.MaxBufferBytes <= 0 {
+		r.MaxBufferBytes = defaultStreamingRecoveryMaxBufferBytes
+	} else if r.MaxBufferBytes > maxStreamingRecoveryMaxBufferBytes {
+		r.MaxBufferBytes = maxStreamingRecoveryMaxBufferBytes
+	}
+	if r.MaxRetryWindowSeconds <= 0 {
+		r.MaxRetryWindowSeconds = defaultStreamingRecoveryMaxRetryWindowSeconds
+	} else if r.MaxRetryWindowSeconds > maxStreamingRecoveryMaxRetryWindowSeconds {
+		r.MaxRetryWindowSeconds = maxStreamingRecoveryMaxRetryWindowSeconds
+	}
+	if r.MaxConcurrent <= 0 {
+		r.MaxConcurrent = defaultStreamingRecoveryMaxConcurrent
+	} else if r.MaxConcurrent > maxStreamingRecoveryMaxConcurrent {
+		r.MaxConcurrent = maxStreamingRecoveryMaxConcurrent
+	}
+	if r.InitialBackoffMilliseconds <= 0 {
+		r.InitialBackoffMilliseconds = defaultStreamingRecoveryInitialBackoffMilliseconds
+	} else if r.InitialBackoffMilliseconds > maxStreamingRecoveryBackoffMilliseconds {
+		r.InitialBackoffMilliseconds = maxStreamingRecoveryBackoffMilliseconds
+	}
+	if r.MaxBackoffMilliseconds <= 0 {
+		r.MaxBackoffMilliseconds = defaultStreamingRecoveryMaxBackoffMilliseconds
+	} else if r.MaxBackoffMilliseconds > maxStreamingRecoveryBackoffMilliseconds {
+		r.MaxBackoffMilliseconds = maxStreamingRecoveryBackoffMilliseconds
+	}
+	if r.MaxBackoffMilliseconds < r.InitialBackoffMilliseconds {
+		r.MaxBackoffMilliseconds = r.InitialBackoffMilliseconds
+	}
 }

--- a/internal/config/streaming_recovery_test.go
+++ b/internal/config/streaming_recovery_test.go
@@ -1,0 +1,41 @@
+package config
+
+import "testing"
+
+func TestParseConfigBytesStreamingRecoveryDefaults(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte("streaming:\n  recovery:\n    attempts: 2\n"))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes error: %v", err)
+	}
+	r := cfg.Streaming.Recovery
+	if r.Attempts != 2 || r.MaxBufferBytes != 8<<20 || r.MaxRetryWindowSeconds != 20 || r.MaxConcurrent != 16 || r.InitialBackoffMilliseconds != 250 || r.MaxBackoffMilliseconds != 2000 {
+		t.Fatalf("unexpected normalized recovery: %+v", r)
+	}
+}
+
+func TestParseConfigBytesStreamingRecoveryDisabledPreservesZeroValues(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte("streaming:\n  bootstrap-retries: -1\n  recovery:\n    attempts: 0\n"))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes error: %v", err)
+	}
+	if cfg.Streaming.BootstrapRetries != 0 {
+		t.Fatalf("bootstrap retries = %d, want 0", cfg.Streaming.BootstrapRetries)
+	}
+	if got := cfg.Streaming.Recovery; got != (StreamingRecoveryConfig{}) {
+		t.Fatalf("disabled recovery changed subordinate values: %+v", got)
+	}
+}
+
+func TestParseConfigBytesStreamingRecoveryNormalizesBounds(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte("streaming:\n  recovery:\n    attempts: 9223372036854775807\n    max-buffer-bytes: 9223372036854775807\n    max-retry-window-seconds: 9223372036854775807\n    max-concurrent: 9223372036854775807\n    initial-backoff-milliseconds: 9223372036854775807\n    max-backoff-milliseconds: 10\n"))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes error: %v", err)
+	}
+	r := cfg.Streaming.Recovery
+	if r.Attempts != 10 || r.MaxBufferBytes != 64<<20 || r.MaxRetryWindowSeconds != 300 || r.MaxConcurrent != 1024 || r.InitialBackoffMilliseconds != 30000 {
+		t.Fatalf("hard bounds not applied: %+v", r)
+	}
+	if r.MaxBackoffMilliseconds != r.InitialBackoffMilliseconds {
+		t.Fatalf("reversed backoff not clamped: %+v", r)
+	}
+}

--- a/internal/config/streaming_recovery_test.go
+++ b/internal/config/streaming_recovery_test.go
@@ -13,6 +13,20 @@ func TestParseConfigBytesStreamingRecoveryDefaults(t *testing.T) {
 	}
 }
 
+func TestParseConfigBytesStreamingRecoveryDurationOnly(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte("streaming:\n  recovery:\n    enabled: true\n    attempts: 0\n    max-retry-window-seconds: 600\n"))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes error: %v", err)
+	}
+	r := cfg.Streaming.Recovery
+	if !r.Enabled || r.Attempts != 0 || r.MaxRetryWindowSeconds != 600 {
+		t.Fatalf("unexpected duration-only recovery: %+v", r)
+	}
+	if r.MaxBufferBytes != 8<<20 || r.MaxConcurrent != 16 || r.InitialBackoffMilliseconds != 250 || r.MaxBackoffMilliseconds != 2000 {
+		t.Fatalf("duration-only defaults not applied: %+v", r)
+	}
+}
+
 func TestParseConfigBytesStreamingRecoveryDisabledPreservesZeroValues(t *testing.T) {
 	cfg, err := ParseConfigBytes([]byte("streaming:\n  bootstrap-retries: -1\n  recovery:\n    attempts: 0\n"))
 	if err != nil {
@@ -32,7 +46,7 @@ func TestParseConfigBytesStreamingRecoveryNormalizesBounds(t *testing.T) {
 		t.Fatalf("ParseConfigBytes error: %v", err)
 	}
 	r := cfg.Streaming.Recovery
-	if r.Attempts != 10 || r.MaxBufferBytes != 64<<20 || r.MaxRetryWindowSeconds != 300 || r.MaxConcurrent != 1024 || r.InitialBackoffMilliseconds != 30000 {
+	if r.Attempts != 10 || r.MaxBufferBytes != 64<<20 || r.MaxRetryWindowSeconds != 3600 || r.MaxConcurrent != 1024 || r.InitialBackoffMilliseconds != 30000 {
 		t.Fatalf("hard bounds not applied: %+v", r)
 	}
 	if r.MaxBackoffMilliseconds != r.InitialBackoffMilliseconds {

--- a/internal/runtime/executor/codex_executor_recovery_test.go
+++ b/internal/runtime/executor/codex_executor_recovery_test.go
@@ -1,0 +1,95 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	internalsse "github.com/router-for-me/CLIProxyAPI/v7/internal/sse"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func TestCodexSSEScannerSplitsSafelyGluedFrames(t *testing.T) {
+	scanner := internalsse.NewLineScanner(strings.NewReader(`data: {"type":"response.created"}data: {"type":"response.completed"}`), 1<<20)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, string(scanner.Bytes()))
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scanner error: %v", err)
+	}
+	if len(lines) != 2 || !strings.Contains(lines[0], "response.created") || !strings.Contains(lines[1], "response.completed") {
+		t.Fatalf("lines = %q, want two safely split frames", lines)
+	}
+}
+
+func TestCodexStreamCommitmentLifecycleClassification(t *testing.T) {
+	for eventType, want := range map[string]cliproxyexecutor.StreamCommitment{
+		"response.created":           cliproxyexecutor.StreamCommitmentProvisional,
+		"response.in_progress":       cliproxyexecutor.StreamCommitmentProvisional,
+		"response.queued":            cliproxyexecutor.StreamCommitmentProvisional,
+		"response.output_text.delta": cliproxyexecutor.StreamCommitmentSemantic,
+		"response.completed":         cliproxyexecutor.StreamCommitmentTerminal,
+		"response.incomplete":        cliproxyexecutor.StreamCommitmentTerminal,
+	} {
+		if got := codexStreamCommitment(eventType); got != want {
+			t.Errorf("codexStreamCommitment(%q) = %d, want %d", eventType, got, want)
+		}
+	}
+}
+
+func TestCodexExecutorStreamCommitmentClassification(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-test\"}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\",\"item_id\":\"item_1\",\"output_index\":0,\"content_index\":0}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	result, err := executor.ExecuteStream(context.Background(), &cliproxyauth.Auth{Attributes: map[string]string{"base_url": server.URL, "api_key": "test"}}, cliproxyexecutor.Request{
+		Model:   "gpt-test",
+		Payload: []byte(`{"model":"gpt-test","messages":[{"role":"user","content":"hello"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude"), ResponseFormat: sdktranslator.FromString("claude"), Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	seen := map[cliproxyexecutor.StreamCommitment]bool{}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream error: %v", chunk.Err)
+		}
+		if len(chunk.Payload) > 0 {
+			seen[chunk.Commitment] = true
+		}
+	}
+	for _, commitment := range []cliproxyexecutor.StreamCommitment{cliproxyexecutor.StreamCommitmentProvisional, cliproxyexecutor.StreamCommitmentSemantic, cliproxyexecutor.StreamCommitmentTerminal} {
+		if !seen[commitment] {
+			t.Fatalf("missing commitment %d; seen=%v", commitment, seen)
+		}
+	}
+}
+
+func TestCodexTerminalGenericServerErrorsRemainBadGateway(t *testing.T) {
+	for name, event := range map[string][]byte{
+		"error":           []byte(`{"type":"error","error":{"type":"server_error","message":"try again"}}`),
+		"response.failed": []byte(`{"type":"response.failed","response":{"error":{"type":"server_error","message":"try again"}}}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			err, _, ok := codexTerminalFailureErr(event)
+			if !ok {
+				t.Fatal("event was not classified as terminal failure")
+			}
+			if err.StatusCode() != http.StatusBadGateway {
+				t.Fatalf("status = %d, want 502", err.StatusCode())
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"io"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	internalsse "github.com/router-for-me/CLIProxyAPI/v7/internal/sse"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -18,6 +18,17 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
+
+func codexStreamCommitment(eventType string) cliproxyexecutor.StreamCommitment {
+	switch eventType {
+	case "response.created", "response.in_progress", "response.queued":
+		return cliproxyexecutor.StreamCommitmentProvisional
+	case "response.completed", "response.incomplete":
+		return cliproxyexecutor.StreamCommitmentTerminal
+	default:
+		return cliproxyexecutor.StreamCommitmentSemantic
+	}
+}
 
 func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	if opts.Alt == "responses/compact" {
@@ -134,8 +145,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				log.Errorf("codex executor: close response body error: %v", errClose)
 			}
 		}()
-		scanner := bufio.NewScanner(httpResp.Body)
-		scanner.Buffer(nil, 52_428_800) // 50MB
+		scanner := internalsse.NewLineScanner(httpResp.Body, 52_428_800) // 50MB
 		claudeInputTokens := helps.NewClaudeInputTokenState(from, to, responseFormat, originalPayload)
 		var param any
 		outputItemsByIndex := make(map[int64][]byte)
@@ -145,12 +155,14 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			translatedLine := bytes.Clone(line)
 			terminalSuccess := false
+			commitment := cliproxyexecutor.StreamCommitmentUnknown
 
 			if bytes.HasPrefix(line, dataTag) {
 				data := bytes.TrimSpace(line[5:])
 				data = helps.RestoreCodexMultiAgentV2Response(data, optimizeMultiAgentV2)
 				translatedLine = append([]byte("data: "), data...)
 				eventType := gjson.GetBytes(data, "type").String()
+				commitment = codexStreamCommitment(eventType)
 				if streamErr, terminalBody, ok := codexTerminalFailureErr(data); ok {
 					if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, streamErr.StatusCode(), terminalBody); errClearReplay != nil {
 						helps.RecordAPIResponseError(ctx, e.cfg, errClearReplay)
@@ -190,7 +202,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, originalPayload, body, translatedLine, &param, claudeInputTokens)
 			for i := range chunks {
 				select {
-				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
+				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i], Commitment: commitment}:
 				case <-ctx.Done():
 					return
 				}

--- a/internal/sse/framer.go
+++ b/internal/sse/framer.go
@@ -1,0 +1,107 @@
+// Package sse provides bounded, JSON-aware Server-Sent Events framing helpers.
+package sse
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+
+	"github.com/tidwall/gjson"
+)
+
+// LineScanner scans SSE fields and separates safely glued JSON data frames.
+type LineScanner struct {
+	scanner *bufio.Scanner
+	pending [][]byte
+	current []byte
+}
+
+// NewLineScanner creates a scanner with a bounded pending token size.
+func NewLineScanner(reader io.Reader, maxTokenBytes int) *LineScanner {
+	scanner := bufio.NewScanner(reader)
+	if maxTokenBytes > 0 {
+		scanner.Buffer(nil, maxTokenBytes)
+	}
+	return &LineScanner{scanner: scanner}
+}
+
+// Scan advances to the next SSE field line.
+func (s *LineScanner) Scan() bool {
+	for len(s.pending) == 0 {
+		if !s.scanner.Scan() {
+			return false
+		}
+		normalized := NormalizeGluedFrames(s.scanner.Bytes())
+		for _, line := range bytes.Split(normalized, []byte("\n")) {
+			line = bytes.TrimSuffix(line, []byte("\r"))
+			if len(line) > 0 {
+				s.pending = append(s.pending, bytes.Clone(line))
+			}
+		}
+	}
+	s.current = s.pending[0]
+	s.pending = s.pending[1:]
+	return true
+}
+
+// Bytes returns the current field line.
+func (s *LineScanner) Bytes() []byte { return s.current }
+
+// Err returns the underlying scanner error.
+func (s *LineScanner) Err() error { return s.scanner.Err() }
+
+// NormalizeGluedFrames safely separates adjacent SSE fields when the preceding
+// data field contains complete JSON. It iterates so three or more glued frames
+// are normalized without splitting marker-like text inside JSON strings.
+func NormalizeGluedFrames(chunk []byte) []byte {
+	if len(chunk) == 0 {
+		return chunk
+	}
+	for {
+		normalized := normalizeGluedPass(chunk)
+		if bytes.Equal(normalized, chunk) {
+			return normalized
+		}
+		chunk = normalized
+	}
+}
+
+func normalizeGluedPass(chunk []byte) []byte {
+	chunk = safeReplaceGlued(chunk, []byte("}event:"), []byte("}\n\nevent:"))
+	chunk = safeReplaceGlued(chunk, []byte("}\r\nevent:"), []byte("}\r\n\r\nevent:"))
+	chunk = safeReplaceGlued(chunk, []byte("}data:"), []byte("}\ndata:"))
+	chunk = safeReplaceGlued(chunk, []byte("}\r\ndata:"), []byte("}\r\ndata:"))
+	return chunk
+}
+
+func safeReplaceGlued(chunk, old, replacement []byte) []byte {
+	for searchFrom := 0; searchFrom < len(chunk); {
+		relative := bytes.Index(chunk[searchFrom:], old)
+		if relative < 0 {
+			return chunk
+		}
+		idx := searchFrom + relative
+		lineStart := bytes.LastIndexByte(chunk[:idx], '\n') + 1
+		part := bytes.TrimSuffix(chunk[lineStart:idx+1], []byte("\r"))
+		jsonData, ok := extractData(part)
+		if ok && len(jsonData) > 0 && gjson.ValidBytes(jsonData) {
+			out := make([]byte, 0, len(chunk)-len(old)+len(replacement))
+			out = append(out, chunk[:idx]...)
+			out = append(out, replacement...)
+			out = append(out, chunk[idx+len(old):]...)
+			return out
+		}
+		searchFrom = idx + len(old)
+	}
+	return chunk
+}
+
+func extractData(line []byte) ([]byte, bool) {
+	if data, ok := bytes.CutPrefix(line, []byte("data: ")); ok {
+		return data, true
+	}
+	if data, ok := bytes.CutPrefix(line, []byte("data:")); ok {
+		return data, true
+	}
+	return nil, false
+}

--- a/internal/sse/framer.go
+++ b/internal/sse/framer.go
@@ -4,9 +4,8 @@ package sse
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"io"
-
-	"github.com/tidwall/gjson"
 )
 
 // LineScanner scans SSE fields and separates safely glued JSON data frames.
@@ -51,57 +50,116 @@ func (s *LineScanner) Bytes() []byte { return s.current }
 func (s *LineScanner) Err() error { return s.scanner.Err() }
 
 // NormalizeGluedFrames safely separates adjacent SSE fields when the preceding
-// data field contains complete JSON. It iterates so three or more glued frames
-// are normalized without splitting marker-like text inside JSON strings.
+// data field contains complete JSON. It scans each data value once so inputs
+// containing many glued frames are processed linearly.
 func NormalizeGluedFrames(chunk []byte) []byte {
 	if len(chunk) == 0 {
 		return chunk
 	}
-	for {
-		normalized := normalizeGluedPass(chunk)
-		if bytes.Equal(normalized, chunk) {
-			return normalized
+
+	var out []byte
+	cursor := 0
+	changed := false
+	for cursor < len(chunk) {
+		dataStart := nextDataFieldStart(chunk, cursor)
+		if dataStart < 0 {
+			if !changed {
+				return chunk
+			}
+			out = append(out, chunk[cursor:]...)
+			break
 		}
-		chunk = normalized
+		out = append(out, chunk[cursor:dataStart]...)
+
+		jsonStart := dataStart + len("data:")
+		for jsonStart < len(chunk) && (chunk[jsonStart] == ' ' || chunk[jsonStart] == '\t') {
+			jsonStart++
+		}
+		jsonEnd, ok := completeJSONValueEnd(chunk, jsonStart)
+		if !ok {
+			if !changed {
+				return chunk
+			}
+			out = append(out, chunk[dataStart:]...)
+			break
+		}
+		out = append(out, chunk[dataStart:jsonEnd]...)
+		cursor = jsonEnd
+
+		switch {
+		case bytes.HasPrefix(chunk[cursor:], []byte("data:")):
+			out = append(out, '\n')
+			changed = true
+		case bytes.HasPrefix(chunk[cursor:], []byte("event:")):
+			out = append(out, '\n', '\n')
+			changed = true
+		case bytes.HasPrefix(chunk[cursor:], []byte("\r\ndata:")):
+			out = append(out, '\r', '\n')
+			cursor += 2
+		case bytes.HasPrefix(chunk[cursor:], []byte("\r\nevent:")):
+			out = append(out, '\r', '\n', '\r', '\n')
+			cursor += 2
+			changed = true
+		default:
+			if cursor < len(chunk) {
+				out = append(out, chunk[cursor])
+				cursor++
+			}
+		}
 	}
+	if !changed {
+		return chunk
+	}
+	return out
 }
 
-func normalizeGluedPass(chunk []byte) []byte {
-	chunk = safeReplaceGlued(chunk, []byte("}event:"), []byte("}\n\nevent:"))
-	chunk = safeReplaceGlued(chunk, []byte("}\r\nevent:"), []byte("}\r\n\r\nevent:"))
-	chunk = safeReplaceGlued(chunk, []byte("}data:"), []byte("}\ndata:"))
-	chunk = safeReplaceGlued(chunk, []byte("}\r\ndata:"), []byte("}\r\ndata:"))
-	return chunk
+func nextDataFieldStart(chunk []byte, from int) int {
+	if from < len(chunk) && bytes.HasPrefix(chunk[from:], []byte("data:")) {
+		return from
+	}
+	if relative := bytes.Index(chunk[from:], []byte("\ndata:")); relative >= 0 {
+		return from + relative + 1
+	}
+	return -1
 }
 
-func safeReplaceGlued(chunk, old, replacement []byte) []byte {
-	for searchFrom := 0; searchFrom < len(chunk); {
-		relative := bytes.Index(chunk[searchFrom:], old)
-		if relative < 0 {
-			return chunk
+func completeJSONValueEnd(data []byte, start int) (int, bool) {
+	if start >= len(data) || (data[start] != '{' && data[start] != '[') {
+		return 0, false
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(data); i++ {
+		current := data[i]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch current {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
 		}
-		idx := searchFrom + relative
-		lineStart := bytes.LastIndexByte(chunk[:idx], '\n') + 1
-		part := bytes.TrimSuffix(chunk[lineStart:idx+1], []byte("\r"))
-		jsonData, ok := extractData(part)
-		if ok && len(jsonData) > 0 && gjson.ValidBytes(jsonData) {
-			out := make([]byte, 0, len(chunk)-len(old)+len(replacement))
-			out = append(out, chunk[:idx]...)
-			out = append(out, replacement...)
-			out = append(out, chunk[idx+len(old):]...)
-			return out
+		switch current {
+		case '"':
+			inString = true
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+			if depth == 0 {
+				end := i + 1
+				return end, json.Valid(data[start:end])
+			}
+			if depth < 0 {
+				return 0, false
+			}
 		}
-		searchFrom = idx + len(old)
 	}
-	return chunk
-}
-
-func extractData(line []byte) ([]byte, bool) {
-	if data, ok := bytes.CutPrefix(line, []byte("data: ")); ok {
-		return data, true
-	}
-	if data, ok := bytes.CutPrefix(line, []byte("data:")); ok {
-		return data, true
-	}
-	return nil, false
+	return 0, false
 }

--- a/internal/sse/framer_test.go
+++ b/internal/sse/framer_test.go
@@ -1,7 +1,9 @@
 package sse
 
 import (
+	"bytes"
 	"io"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -51,6 +53,38 @@ func TestNormalizeGluedFramesSkipsInStringEventMarkerThenSplitsRealBoundary(t *t
 	want := "data: {\"text\":\"literal }event: marker\",\"n\":1}\n\nevent: response.completed"
 	if got := string(NormalizeGluedFrames(input)); got != want {
 		t.Fatalf("normalized = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeGluedFramesManyFrames(t *testing.T) {
+	const frameCount = 5000
+	var input strings.Builder
+	for i := 0; i < frameCount; i++ {
+		input.WriteString(`data: {"n":`)
+		input.WriteString(strconv.Itoa(i))
+		input.WriteByte('}')
+	}
+	got := NormalizeGluedFrames([]byte(input.String()))
+	if count := bytes.Count(got, []byte("\ndata:")); count != frameCount-1 {
+		t.Fatalf("normalized boundaries = %d, want %d", count, frameCount-1)
+	}
+	if !bytes.HasSuffix(got, []byte(`data: {"n":4999}`)) {
+		t.Fatalf("normalized output lost final frame")
+	}
+}
+
+func BenchmarkNormalizeGluedFramesMany(b *testing.B) {
+	var input strings.Builder
+	for i := 0; i < 1000; i++ {
+		input.WriteString(`data: {"n":`)
+		input.WriteString(strconv.Itoa(i))
+		input.WriteByte('}')
+	}
+	payload := []byte(input.String())
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	for i := 0; i < b.N; i++ {
+		_ = NormalizeGluedFrames(payload)
 	}
 }
 

--- a/internal/sse/framer_test.go
+++ b/internal/sse/framer_test.go
@@ -1,0 +1,100 @@
+package sse
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+type chunkReader struct {
+	chunks [][]byte
+}
+
+func (r *chunkReader) Read(p []byte) (int, error) {
+	if len(r.chunks) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(p, r.chunks[0])
+	r.chunks[0] = r.chunks[0][n:]
+	if len(r.chunks[0]) == 0 {
+		r.chunks = r.chunks[1:]
+	}
+	return n, nil
+}
+
+func TestNormalizeGluedFramesThreeOrMore(t *testing.T) {
+	input := []byte(`data: {"n":1}data: {"n":2}data: {"n":3}`)
+	got := string(NormalizeGluedFrames(input))
+	want := "data: {\"n\":1}\ndata: {\"n\":2}\ndata: {\"n\":3}"
+	if got != want {
+		t.Fatalf("normalized = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeGluedFramesPreservesMarkerInsideJSONString(t *testing.T) {
+	input := []byte(`data: {"text":"literal }data: marker"}`)
+	if got := string(NormalizeGluedFrames(input)); got != string(input) {
+		t.Fatalf("normalized JSON string marker: %q", got)
+	}
+}
+
+func TestNormalizeGluedFramesSkipsInStringDataMarkerThenSplitsRealBoundary(t *testing.T) {
+	input := []byte(`data: {"text":"literal }data: marker","n":1}data: {"n":2}`)
+	want := "data: {\"text\":\"literal }data: marker\",\"n\":1}\ndata: {\"n\":2}"
+	if got := string(NormalizeGluedFrames(input)); got != want {
+		t.Fatalf("normalized = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeGluedFramesSkipsInStringEventMarkerThenSplitsRealBoundary(t *testing.T) {
+	input := []byte(`data: {"text":"literal }event: marker","n":1}event: response.completed`)
+	want := "data: {\"text\":\"literal }event: marker\",\"n\":1}\n\nevent: response.completed"
+	if got := string(NormalizeGluedFrames(input)); got != want {
+		t.Fatalf("normalized = %q, want %q", got, want)
+	}
+}
+
+func TestLineScannerHandlesSplitEventAndDataFields(t *testing.T) {
+	reader := &chunkReader{chunks: [][]byte{[]byte("eve"), []byte("nt: response.created\r\nda"), []byte("ta: {\"n\":"), []byte("1}\r\n\r\n")}}
+	scanner := NewLineScanner(reader, 1024)
+	var got []string
+	for scanner.Scan() {
+		got = append(got, string(scanner.Bytes()))
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scanner error: %v", err)
+	}
+	if len(got) != 2 || got[0] != "event: response.created" || got[1] != `data: {"n":1}` {
+		t.Fatalf("split fields = %q", got)
+	}
+}
+
+func TestLineScannerHandlesCRLFAndPartialFinalFrame(t *testing.T) {
+	scanner := NewLineScanner(strings.NewReader("event: response.created\r\ndata: {\"n\":1}\r\n\r\ndata: {\"n\":2}"), 1024)
+	var got []string
+	for scanner.Scan() {
+		got = append(got, string(scanner.Bytes()))
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scanner error: %v", err)
+	}
+	want := []string{"event: response.created", `data: {"n":1}`, `data: {"n":2}`}
+	if len(got) != len(want) {
+		t.Fatalf("lines = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("line %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestLineScannerBoundsPendingToken(t *testing.T) {
+	scanner := NewLineScanner(strings.NewReader(strings.Repeat("x", 128)), 32)
+	if scanner.Scan() {
+		t.Fatal("oversized token unexpectedly scanned")
+	}
+	if scanner.Err() == nil {
+		t.Fatal("expected bounded scanner error")
+	}
+}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -93,6 +93,15 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.NonStreamKeepAliveInterval != newCfg.NonStreamKeepAliveInterval {
 		changes = append(changes, fmt.Sprintf("nonstream-keepalive-interval: %d -> %d", oldCfg.NonStreamKeepAliveInterval, newCfg.NonStreamKeepAliveInterval))
 	}
+	if oldCfg.Streaming.KeepAliveSeconds != newCfg.Streaming.KeepAliveSeconds {
+		changes = append(changes, fmt.Sprintf("streaming.keepalive-seconds: %d -> %d", oldCfg.Streaming.KeepAliveSeconds, newCfg.Streaming.KeepAliveSeconds))
+	}
+	if oldCfg.Streaming.BootstrapRetries != newCfg.Streaming.BootstrapRetries {
+		changes = append(changes, fmt.Sprintf("streaming.bootstrap-retries: %d -> %d", oldCfg.Streaming.BootstrapRetries, newCfg.Streaming.BootstrapRetries))
+	}
+	if !reflect.DeepEqual(oldCfg.Streaming.Recovery, newCfg.Streaming.Recovery) {
+		changes = append(changes, "streaming.recovery: updated")
+	}
 
 	// Quota-exceeded behavior
 	if oldCfg.QuotaExceeded.SwitchProject != newCfg.QuotaExceeded.SwitchProject {

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -146,6 +146,25 @@ func StreamingBootstrapRetries(cfg *config.SDKConfig) int {
 	return retries
 }
 
+// StreamRecoveryPolicy returns a request-scoped snapshot of normalized streaming recovery configuration.
+func StreamRecoveryPolicy(cfg *config.SDKConfig) coreexecutor.StreamRecoveryPolicy {
+	if cfg == nil {
+		return coreexecutor.StreamRecoveryPolicy{}
+	}
+	streaming := cfg.Streaming
+	streaming.NormalizeStreamingConfig()
+	recovery := streaming.Recovery
+	return coreexecutor.StreamRecoveryPolicy{
+		BootstrapRetries: StreamingBootstrapRetries(cfg),
+		Attempts:         recovery.Attempts,
+		MaxBufferBytes:   recovery.MaxBufferBytes,
+		MaxRetryWindow:   time.Duration(recovery.MaxRetryWindowSeconds) * time.Second,
+		MaxConcurrent:    recovery.MaxConcurrent,
+		InitialBackoff:   time.Duration(recovery.InitialBackoffMilliseconds) * time.Millisecond,
+		MaxBackoff:       time.Duration(recovery.MaxBackoffMilliseconds) * time.Millisecond,
+	}
+}
+
 // PassthroughHeadersEnabled returns whether upstream response headers should be forwarded to clients.
 // Default is false.
 func PassthroughHeadersEnabled(cfg *config.SDKConfig) bool {

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -156,6 +156,7 @@ func StreamRecoveryPolicy(cfg *config.SDKConfig) coreexecutor.StreamRecoveryPoli
 	recovery := streaming.Recovery
 	return coreexecutor.StreamRecoveryPolicy{
 		BootstrapRetries: StreamingBootstrapRetries(cfg),
+		Enabled:          recovery.Enabled,
 		Attempts:         recovery.Attempts,
 		MaxBufferBytes:   recovery.MaxBufferBytes,
 		MaxRetryWindow:   time.Duration(recovery.MaxRetryWindowSeconds) * time.Second,

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -275,6 +275,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		Headers:                     modelExecutionHeaders(ctx, execOptions.Headers),
 		Query:                       modelExecutionQuery(ctx, execOptions.Query),
 		RequestAfterAuthInterceptor: h.requestAfterAuthInterceptor(afterAuthCapture, lifecycle.requestID(), execOptions.SkipInterceptorPluginID),
+		StreamRecovery:              StreamRecoveryPolicy(h.Cfg),
 	}
 	opts.Metadata = reqMeta
 	var interceptErr *interfaces.ErrorMessage
@@ -431,62 +432,10 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		}
 	}
 
-	bootstrapEligible := func(err error) bool {
-		status := statusFromError(err)
-		if status == 0 {
-			return true
-		}
-		switch status {
-		case http.StatusUnauthorized, http.StatusForbidden, http.StatusPaymentRequired,
-			http.StatusRequestTimeout, http.StatusTooManyRequests:
-			return true
-		default:
-			return status >= http.StatusInternalServerError
-		}
-	}
-
-	maxBootstrapRetries := StreamingBootstrapRetries(h.Cfg)
-	if h.AuthManager.HomeEnabled() {
-		maxBootstrapRetries = 0
-	}
-	for bootstrapRetries := 0; !streamCanceledBeforeRead; {
-		readInitialStreamChunks()
-		if streamCanceledBeforeRead || bootstrapErr != nil || bootstrapStreamErr == nil {
-			break
-		}
-		if bootstrapRetries >= maxBootstrapRetries || !bootstrapEligible(bootstrapStreamErr) {
-			bootstrapErr = executionErrorMessage(bootstrapStreamErr)
-			break
-		}
-		bootstrapRetries++
-		retryResult, retryErr := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
-		if retryErr != nil {
-			originalBootstrapErr := executionErrorMessage(bootstrapStreamErr)
-			if isAuthSelectionUnavailable(retryErr) && originalBootstrapErr.StatusCode >= http.StatusInternalServerError {
-				bootstrapErr = originalBootstrapErr
-			} else {
-				bootstrapErr = executionErrorMessage(enrichAuthSelectionError(retryErr, providers, normalizedModel))
-			}
-			break
-		}
-		if retryResult == nil {
-			bootstrapErr = executionErrorMessage(fmt.Errorf("auth manager returned nil stream"))
-			break
-		}
-		rawStreamHeaders = cloneHeader(retryResult.Headers)
-		baseStreamHeaders = cloneHeader(retryResult.Headers)
-		streamHeaderInitialized = false
-		streamClosedBeforeRead = false
-		bootstrapStreamErr = nil
-		bootstrapPayload = nil
-		bootstrapChunkIndex = 0
-		bootstrapHistoryChunks = nil
-		chunks = retryResult.Chunks
-		if chunks == nil {
-			closed := make(chan coreexecutor.StreamChunk)
-			close(closed)
-			chunks = closed
-		}
+	readInitialStreamChunks()
+	if bootstrapStreamErr != nil {
+		bootstrapStreamErr = enrichAuthSelectionError(bootstrapStreamErr, providers, normalizedModel)
+		bootstrapErr = executionErrorMessage(bootstrapStreamErr)
 	}
 
 	upstreamHeaders := downstreamHeadersAfterInterceptors(baseStreamHeaders, rawStreamHeaders, passthroughHeadersEnabled)

--- a/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -513,7 +513,7 @@ func registerBootstrapExecutor(t *testing.T, executor *bootstrapStreamExecutor) 
 	return NewBaseAPIHandlers(&sdkconfig.SDKConfig{Streaming: sdkconfig.StreamingConfig{BootstrapRetries: 1}}, manager), manager
 }
 
-func TestExecuteStreamWithAuthManager_RetriesAfterDroppedBootstrapPayload(t *testing.T) {
+func TestExecuteStreamWithAuthManager_DoesNotRetryAfterDroppedCommittedPayload(t *testing.T) {
 	executor := &bootstrapStreamExecutor{stream: func(_ context.Context, call int) (*coreexecutor.StreamResult, error) {
 		chunks := make(chan coreexecutor.StreamChunk, 2)
 		if call == 1 {
@@ -539,19 +539,23 @@ func TestExecuteStreamWithAuthManager_RetriesAfterDroppedBootstrapPayload(t *tes
 	for chunk := range dataChan {
 		got = append(got, chunk...)
 	}
+	var gotErr *interfaces.ErrorMessage
 	for msg := range errChan {
 		if msg != nil {
-			t.Fatalf("unexpected stream error: %+v", msg)
+			gotErr = msg
 		}
 	}
-	if string(got) != "ok" {
-		t.Fatalf("stream payload = %q, want ok", got)
+	if len(got) != 0 {
+		t.Fatalf("stream payload = %q, want empty", got)
 	}
-	if executor.Calls() != 2 {
-		t.Fatalf("stream attempts = %d, want 2", executor.Calls())
+	if gotErr == nil || gotErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("stream error = %+v, want 401", gotErr)
 	}
-	if strings.Join(intercepted, ",") != "drop,ok" {
-		t.Fatalf("intercepted payloads = %v, want [drop ok] without double interception", intercepted)
+	if executor.Calls() != 1 {
+		t.Fatalf("stream attempts = %d, want 1", executor.Calls())
+	}
+	if strings.Join(intercepted, ",") != "drop" {
+		t.Fatalf("intercepted payloads = %v, want [drop]", intercepted)
 	}
 }
 
@@ -676,7 +680,7 @@ func TestExecuteStreamWithAuthManager_HomeBootstrapFailureDoesNotRedispatch(t *t
 	registry.SetReleaseSink(releaseSink.MarkDirty)
 	dispatcher := &handlerAccountedHomeDispatcher{}
 	manager.PublishHomeDispatch(dispatcher, registry, 1)
-	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{Streaming: sdkconfig.StreamingConfig{BootstrapRetries: 1}}, manager)
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{Streaming: sdkconfig.StreamingConfig{BootstrapRetries: 1, Recovery: sdkconfig.StreamingRecoveryConfig{Attempts: 1, MaxBufferBytes: 1024, MaxRetryWindowSeconds: 5, MaxConcurrent: 1, InitialBackoffMilliseconds: 1, MaxBackoffMilliseconds: 1}}}, manager)
 	handler.SetPluginHost(&handlerInterceptorTestHost{interceptStreamChunk: func(_ context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
 		return pluginapi.StreamChunkInterceptResponse{Body: cloneBytes(req.Body), DropChunk: string(req.Body) == "drop"}
 	}})

--- a/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -511,6 +512,37 @@ func registerBootstrapExecutor(t *testing.T, executor *bootstrapStreamExecutor) 
 		registry.GetGlobalRegistry().UnregisterClient(authRetry.ID)
 	})
 	return NewBaseAPIHandlers(&sdkconfig.SDKConfig{Streaming: sdkconfig.StreamingConfig{BootstrapRetries: 1}}, manager), manager
+}
+
+func TestExecuteStreamWithAuthManager_BootstrapRetriesAfterProvisionalFailure(t *testing.T) {
+	executor := &bootstrapStreamExecutor{stream: func(_ context.Context, call int) (*coreexecutor.StreamResult, error) {
+		chunks := make(chan coreexecutor.StreamChunk, 2)
+		if call == 1 {
+			chunks <- coreexecutor.StreamChunk{Payload: []byte("provisional"), Commitment: coreexecutor.StreamCommitmentProvisional}
+			chunks <- coreexecutor.StreamChunk{Err: &coreauth.Error{HTTPStatus: http.StatusBadGateway, Message: "temporary"}}
+		} else {
+			chunks <- coreexecutor.StreamChunk{Payload: []byte("ok"), Commitment: coreexecutor.StreamCommitmentSemantic}
+		}
+		close(chunks)
+		return &coreexecutor.StreamResult{Headers: http.Header{"X-Upstream-Attempt": {strconv.Itoa(call)}}, Chunks: chunks}, nil
+	}}
+	handler, _ := registerBootstrapExecutor(t, executor)
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", "bootstrap-model", []byte(`{"model":"bootstrap-model"}`), "")
+	var got []byte
+	for chunk := range dataChan {
+		got = append(got, chunk...)
+	}
+	for msg := range errChan {
+		if msg != nil {
+			t.Fatalf("unexpected stream error: %+v", msg)
+		}
+	}
+	if string(got) != "ok" {
+		t.Fatalf("payload = %q, want only winning attempt", got)
+	}
+	if executor.Calls() != 2 {
+		t.Fatalf("calls=%d, want retry attempt", executor.Calls())
+	}
 }
 
 func TestExecuteStreamWithAuthManager_DoesNotRetryAfterDroppedCommittedPayload(t *testing.T) {

--- a/sdk/api/handlers/handlers_stream_recovery_integration_test.go
+++ b/sdk/api/handlers/handlers_stream_recovery_integration_test.go
@@ -1,0 +1,111 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+func newCodexRecoveryIntegrationHandler(t *testing.T, upstreamURL string, recovery sdkconfig.StreamingRecoveryConfig) *BaseAPIHandler {
+	t.Helper()
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(runtimeexecutor.NewCodexExecutor(&internalconfig.Config{}))
+	auth := &coreauth.Auth{ID: "codex-recovery-auth", Provider: "codex", Status: coreauth.StatusActive, Attributes: map[string]string{"base_url": upstreamURL, "api_key": "test"}}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "gpt-test"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	manager.RefreshSchedulerEntry(auth.ID)
+	return NewBaseAPIHandlers(&sdkconfig.SDKConfig{Streaming: sdkconfig.StreamingConfig{Recovery: recovery}}, manager)
+}
+
+func TestExecuteStreamWithAuthManagerCodexTerminalServerErrorRecovers(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempt := requests.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		if attempt == 1 {
+			_, _ = w.Write([]byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"losing-response\",\"model\":\"gpt-test\"}}\n\n"))
+			_, _ = w.Write([]byte("data: {\"type\":\"error\",\"error\":{\"type\":\"server_error\",\"message\":\"temporary\"}}\n\n"))
+			return
+		}
+		_, _ = w.Write([]byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"winning-response\",\"model\":\"gpt-test\"}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_text.delta\",\"delta\":\"recovered\",\"item_id\":\"item_1\",\"output_index\":0,\"content_index\":0}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"winning-response\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n"))
+	}))
+	defer server.Close()
+
+	handler := newCodexRecoveryIntegrationHandler(t, server.URL, sdkconfig.StreamingRecoveryConfig{Attempts: 1, MaxBufferBytes: 1 << 20, MaxRetryWindowSeconds: 5, MaxConcurrent: 1, InitialBackoffMilliseconds: 1, MaxBackoffMilliseconds: 1})
+	data, _, errs := handler.ExecuteStreamWithAuthManager(context.Background(), "claude", "gpt-test", []byte(`{"model":"gpt-test","messages":[{"role":"user","content":"hello"}],"stream":true}`), "")
+	var output strings.Builder
+	for chunk := range data {
+		output.Write(chunk)
+	}
+	for streamErr := range errs {
+		if streamErr != nil {
+			t.Fatalf("stream error: %+v", streamErr)
+		}
+	}
+	got := output.String()
+	if requests.Load() != 2 {
+		t.Fatalf("upstream requests = %d, want 2", requests.Load())
+	}
+	if strings.Contains(got, "losing-response") {
+		t.Fatalf("losing attempt leaked: %s", got)
+	}
+	if strings.Count(got, `"type":"message_start"`) != 1 {
+		t.Fatalf("message_start count = %d; output=%s", strings.Count(got, `"type":"message_start"`), got)
+	}
+	if !strings.Contains(got, "recovered") || !strings.Contains(got, `"type":"message_stop"`) {
+		t.Fatalf("winning stream incomplete: %s", got)
+	}
+}
+
+func TestExecuteStreamWithAuthManagerRecoveryCancellationPreventsSecondRequest(t *testing.T) {
+	var requests atomic.Int32
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"cancel-response\",\"model\":\"gpt-test\"}}\n\n"))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	handler := newCodexRecoveryIntegrationHandler(t, server.URL, sdkconfig.StreamingRecoveryConfig{Attempts: 1, MaxBufferBytes: 1 << 20, MaxRetryWindowSeconds: 5, MaxConcurrent: 1, InitialBackoffMilliseconds: 1, MaxBackoffMilliseconds: 1})
+	ctx, cancel := context.WithCancel(context.Background())
+	returned := make(chan struct{})
+	go func() {
+		data, _, errs := handler.ExecuteStreamWithAuthManager(ctx, "claude", "gpt-test", []byte(`{"model":"gpt-test","messages":[{"role":"user","content":"hello"}],"stream":true}`), "")
+		if data != nil {
+			for range data {
+			}
+		}
+		if errs != nil {
+			for range errs {
+			}
+		}
+		close(returned)
+	}()
+	<-started
+	cancel()
+	<-returned
+	if requests.Load() != 1 {
+		t.Fatalf("upstream requests = %d, want 1", requests.Load())
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -131,6 +131,7 @@ type Manager struct {
 	requestRetry        atomic.Int32
 	maxRetryCredentials atomic.Int32
 	maxRetryInterval    atomic.Int64
+	recoveryInFlight    atomic.Int32
 
 	// oauthModelAlias stores global OAuth model alias mappings (alias -> upstream name) keyed by channel.
 	oauthModelAlias atomic.Value

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -109,7 +109,7 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
 	req, opts = cliproxysession.Enrich(req, opts)
-	if opts.StreamRecovery.Attempts > 0 && !m.HomeEnabled() {
+	if streamRecoveryEnabled(opts.StreamRecovery) && !m.HomeEnabled() {
 		if m.acquireStreamRecovery(opts.StreamRecovery.MaxConcurrent) {
 			state := &streamRecoveryState{
 				policy:    opts.StreamRecovery,
@@ -144,7 +144,7 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	var lastErr error
 	var firstBootstrapErr *streamBootstrapError
 	legacyBootstrapRetries := opts.StreamRecovery.BootstrapRetries
-	if opts.StreamRecovery.Attempts > 0 {
+	if streamRecoveryEnabled(opts.StreamRecovery) {
 		legacyBootstrapRetries = 0
 	}
 	retryModel := authSelectionModelFromOptions(opts, req.Model)

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
@@ -108,6 +109,26 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
 	req, opts = cliproxysession.Enrich(req, opts)
+	if opts.StreamRecovery.Attempts > 0 && !m.HomeEnabled() {
+		if m.acquireStreamRecovery(opts.StreamRecovery.MaxConcurrent) {
+			state := &streamRecoveryState{
+				policy:    opts.StreamRecovery,
+				started:   time.Now(),
+				remaining: opts.StreamRecovery.Attempts,
+				release: func() {
+					m.recoveryInFlight.Add(-1)
+				},
+			}
+			defer func() {
+				if !state.holdUntilDrain {
+					state.releaseSlot()
+				}
+			}()
+			ctx = context.WithValue(ctx, streamRecoveryContextKey{}, state)
+		} else {
+			logEntryWithRequestID(ctx).WithFields(log.Fields{"provider": strings.Join(providers, ","), "model": req.Model, "reason": "saturated", "buffered_bytes": 0, "elapsed": time.Duration(0), "max_concurrent": opts.StreamRecovery.MaxConcurrent}).Debug("stream recovery saturated; using ordinary streaming")
+		}
+	}
 	if m.HomeEnabled() {
 		if unlockSession := m.lockHomeWebsocketSession(ctx, opts); unlockSession != nil {
 			defer unlockSession()
@@ -121,6 +142,11 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
 	var lastErr error
+	var firstBootstrapErr *streamBootstrapError
+	legacyBootstrapRetries := opts.StreamRecovery.BootstrapRetries
+	if opts.StreamRecovery.Attempts > 0 {
+		legacyBootstrapRetries = 0
+	}
 	retryModel := authSelectionModelFromOptions(opts, req.Model)
 	for attempt := 0; ; attempt++ {
 		result, errStream := m.executeStreamMixedOnce(ctx, normalized, req, opts, maxRetryCredentials)
@@ -131,6 +157,15 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 			return nil, errStream
 		}
 		lastErr = errStream
+		var bootstrapErr *streamBootstrapError
+		if errors.As(errStream, &bootstrapErr) && bootstrapErr != nil {
+			if firstBootstrapErr == nil {
+				firstBootstrapErr = bootstrapErr
+			}
+			if attempt < legacyBootstrapRetries {
+				continue
+			}
+		}
 		wait, shouldRetry := m.shouldRetryAfterError(errStream, attempt, normalized, retryModel, maxWait)
 		if !shouldRetry {
 			break
@@ -140,6 +175,13 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 		}
 	}
 	if lastErr != nil {
+		if firstBootstrapErr != nil && shouldRetrySchedulerPick(lastErr) {
+			status := statusCodeFromError(firstBootstrapErr.cause)
+			if status == 0 || status >= http.StatusInternalServerError {
+				return streamErrorResult(firstBootstrapErr.Headers(), firstBootstrapErr.cause), nil
+			}
+			return streamErrorResult(nil, lastErr), nil
+		}
 		if hasAntigravityProvider(normalized) && shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
 			if result, ok, errCredits := m.tryAntigravityCreditsExecuteStream(ctx, req, opts); errCredits != nil {
 				return nil, errCredits

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -20,12 +20,13 @@ import (
 type streamRecoveryContextKey struct{}
 
 type streamRecoveryState struct {
-	policy         cliproxyexecutor.StreamRecoveryPolicy
-	started        time.Time
-	remaining      int
-	releaseOnce    sync.Once
-	release        func()
-	holdUntilDrain bool
+	policy                     cliproxyexecutor.StreamRecoveryPolicy
+	started                    time.Time
+	remaining                  int
+	releaseOnce                sync.Once
+	release                    func()
+	holdUntilDrain             bool
+	releaseAfterFirstRemaining bool
 }
 
 func (s *streamRecoveryState) releaseSlot() {
@@ -330,6 +331,8 @@ func (m *Manager) executeStreamWithRecovery(ctx context.Context, executor Provid
 			buffered, remaining, terminal, failOpenReason, errStream = collectRecoveryAttempt(ctx, streamResult, state.policy.MaxBufferBytes)
 			if errStream == nil {
 				if failOpenReason != "" {
+					state.holdUntilDrain = true
+					state.releaseAfterFirstRemaining = true
 					log.WithFields(log.Fields{"provider": provider, "model": model, "attempt": attempt, "reason": failOpenReason, "buffered_bytes": bufferedStreamBytes(buffered), "elapsed": time.Since(state.started)}).Debug("stream recovery failed open to ordinary streaming")
 					return streamResult, buffered, remaining, nil
 				}
@@ -359,10 +362,10 @@ func (m *Manager) executeStreamWithRecovery(ctx context.Context, executor Provid
 }
 
 func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, resultModel string, headers http.Header, buffered []cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk, aliasResult OAuthModelAliasResult, ephemeralResult bool) *cliproxyexecutor.StreamResult {
-	return m.wrapStreamResultWithDone(ctx, auth, provider, resultModel, headers, buffered, remaining, aliasResult, ephemeralResult, nil)
+	return m.wrapStreamResultWithDone(ctx, auth, provider, resultModel, headers, buffered, remaining, aliasResult, ephemeralResult, nil, false)
 }
 
-func (m *Manager) wrapStreamResultWithDone(ctx context.Context, auth *Auth, provider, resultModel string, headers http.Header, buffered []cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk, aliasResult OAuthModelAliasResult, ephemeralResult bool, done func()) *cliproxyexecutor.StreamResult {
+func (m *Manager) wrapStreamResultWithDone(ctx context.Context, auth *Auth, provider, resultModel string, headers http.Header, buffered []cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk, aliasResult OAuthModelAliasResult, ephemeralResult bool, done func(), releaseAfterFirstRemaining bool) *cliproxyexecutor.StreamResult {
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {
 		defer close(out)
@@ -427,10 +430,15 @@ func (m *Manager) wrapStreamResultWithDone(ctx context.Context, auth *Auth, prov
 				return
 			}
 		}
+		remainingIndex := 0
 		for chunk := range remaining {
 			if ok := emit(chunk); !ok {
 				discardStreamChunks(remaining)
 				return
+			}
+			remainingIndex++
+			if releaseAfterFirstRemaining && remainingIndex == 1 && done != nil {
+				done()
 			}
 		}
 		if tail := finishForceMappedStreamChunks(rewriter); len(tail) > 0 {
@@ -493,7 +501,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				continue
 			}
 			if recoveryState.holdUntilDrain {
-				return m.wrapStreamResultWithDone(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, buffered, remaining, aliasResult, ephemeralResult, recoveryState.releaseSlot), nil
+				return m.wrapStreamResultWithDone(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, buffered, remaining, aliasResult, ephemeralResult, recoveryState.releaseSlot, recoveryState.releaseAfterFirstRemaining), nil
 			}
 			return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, buffered, remaining, aliasResult, ephemeralResult), nil
 		}

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -59,14 +59,23 @@ func streamRecoveryFromContext(ctx context.Context) *streamRecoveryState {
 	return state
 }
 
+func streamRecoveryEnabled(policy cliproxyexecutor.StreamRecoveryPolicy) bool {
+	return policy.Attempts > 0 || (policy.Enabled && policy.MaxRetryWindow > 0)
+}
+
 func (s *streamRecoveryState) canRetry() bool {
-	if s == nil || s.remaining <= 0 {
+	if s == nil || !streamRecoveryEnabled(s.policy) {
 		return false
 	}
 	if s.policy.MaxRetryWindow > 0 && time.Since(s.started) >= s.policy.MaxRetryWindow {
 		return false
 	}
-	s.remaining--
+	if s.policy.Attempts > 0 {
+		if s.remaining <= 0 {
+			return false
+		}
+		s.remaining--
+	}
 	return true
 }
 
@@ -544,7 +553,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			continue
 		}
 
-		buffered, closed, bootstrapErr := readStreamBootstrap(ctx, streamResult.Chunks, execOpts.StreamRecovery.Attempts <= 0 && execOpts.StreamRecovery.BootstrapRetries > 0)
+		buffered, closed, bootstrapErr := readStreamBootstrap(ctx, streamResult.Chunks, !streamRecoveryEnabled(execOpts.StreamRecovery) && execOpts.StreamRecovery.BootstrapRetries > 0)
 		if bootstrapErr != nil {
 			if errCtx := ctx.Err(); errCtx != nil {
 				discardStreamChunks(streamResult.Chunks)
@@ -564,7 +573,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 						streamResult = &cliproxyexecutor.StreamResult{}
 					} else {
 						streamResult = retryStream
-						buffered, closed, bootstrapErr = readStreamBootstrap(ctx, streamResult.Chunks, execOpts.StreamRecovery.Attempts <= 0 && execOpts.StreamRecovery.BootstrapRetries > 0)
+						buffered, closed, bootstrapErr = readStreamBootstrap(ctx, streamResult.Chunks, !streamRecoveryEnabled(execOpts.StreamRecovery) && execOpts.StreamRecovery.BootstrapRetries > 0)
 					}
 				}
 			}

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -234,7 +234,7 @@ func streamErrorResult(headers http.Header, err error) *cliproxyexecutor.StreamR
 	}
 }
 
-func readStreamBootstrap(ctx context.Context, ch <-chan cliproxyexecutor.StreamChunk) ([]cliproxyexecutor.StreamChunk, bool, error) {
+func readStreamBootstrap(ctx context.Context, ch <-chan cliproxyexecutor.StreamChunk, bufferProvisional bool) ([]cliproxyexecutor.StreamChunk, bool, error) {
 	if ch == nil {
 		return nil, true, nil
 	}
@@ -254,15 +254,21 @@ func readStreamBootstrap(ctx context.Context, ch <-chan cliproxyexecutor.StreamC
 			chunk, ok = <-ch
 		}
 		if !ok {
-			if len(buffered) > 0 {
+			if bufferProvisional && len(buffered) > 0 {
 				return nil, false, &Error{Code: "incomplete_stream", Message: "upstream stream closed after provisional framing", Retryable: true, HTTPStatus: http.StatusBadGateway}
 			}
-			return nil, true, nil
+			return buffered, true, nil
 		}
 		if chunk.Err != nil {
 			return nil, false, chunk.Err
 		}
 		buffered = append(buffered, chunk)
+		if !bufferProvisional {
+			if len(chunk.Payload) > 0 {
+				return buffered, false, nil
+			}
+			continue
+		}
 		switch chunk.Commitment {
 		case cliproxyexecutor.StreamCommitmentProvisional:
 			continue
@@ -538,7 +544,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			continue
 		}
 
-		buffered, closed, bootstrapErr := readStreamBootstrap(ctx, streamResult.Chunks)
+		buffered, closed, bootstrapErr := readStreamBootstrap(ctx, streamResult.Chunks, execOpts.StreamRecovery.Attempts <= 0 && execOpts.StreamRecovery.BootstrapRetries > 0)
 		if bootstrapErr != nil {
 			if errCtx := ctx.Err(); errCtx != nil {
 				discardStreamChunks(streamResult.Chunks)
@@ -558,7 +564,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 						streamResult = &cliproxyexecutor.StreamResult{}
 					} else {
 						streamResult = retryStream
-						buffered, closed, bootstrapErr = readStreamBootstrap(ctx, streamResult.Chunks)
+						buffered, closed, bootstrapErr = readStreamBootstrap(ctx, streamResult.Chunks, execOpts.StreamRecovery.Attempts <= 0 && execOpts.StreamRecovery.BootstrapRetries > 0)
 					}
 				}
 			}

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -2,11 +2,173 @@ package auth
 
 import (
 	"context"
+	"errors"
+	"io"
+	"math"
+	"math/rand"
+	"net"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
+
+type streamRecoveryContextKey struct{}
+
+type streamRecoveryState struct {
+	policy         cliproxyexecutor.StreamRecoveryPolicy
+	started        time.Time
+	remaining      int
+	releaseOnce    sync.Once
+	release        func()
+	holdUntilDrain bool
+}
+
+func (s *streamRecoveryState) releaseSlot() {
+	if s == nil || s.release == nil {
+		return
+	}
+	s.releaseOnce.Do(s.release)
+}
+
+func (m *Manager) acquireStreamRecovery(maxConcurrent int) bool {
+	if m == nil || maxConcurrent <= 0 {
+		return false
+	}
+	for {
+		current := m.recoveryInFlight.Load()
+		if current >= int32(maxConcurrent) {
+			return false
+		}
+		if m.recoveryInFlight.CompareAndSwap(current, current+1) {
+			return true
+		}
+	}
+}
+
+func streamRecoveryFromContext(ctx context.Context) *streamRecoveryState {
+	if ctx == nil {
+		return nil
+	}
+	state, _ := ctx.Value(streamRecoveryContextKey{}).(*streamRecoveryState)
+	return state
+}
+
+func (s *streamRecoveryState) canRetry() bool {
+	if s == nil || s.remaining <= 0 {
+		return false
+	}
+	if s.policy.MaxRetryWindow > 0 && time.Since(s.started) >= s.policy.MaxRetryWindow {
+		return false
+	}
+	s.remaining--
+	return true
+}
+
+func streamRecoveryBackoff(ctx context.Context, policy cliproxyexecutor.StreamRecoveryPolicy, retry int) error {
+	ceiling := policy.InitialBackoff
+	for i := 1; i < retry && ceiling < policy.MaxBackoff; i++ {
+		if ceiling > policy.MaxBackoff/2 {
+			ceiling = policy.MaxBackoff
+		} else {
+			ceiling *= 2
+		}
+	}
+	if ceiling <= 0 {
+		return nil
+	}
+	var delay time.Duration
+	if int64(ceiling) == math.MaxInt64 {
+		delay = time.Duration(rand.Int63())
+	} else {
+		delay = time.Duration(rand.Int63n(int64(ceiling) + 1))
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func streamRecoveryReason(err error) string {
+	if err == nil {
+		return "none"
+	}
+	if statusCodeFromError(err) != 0 {
+		return "http_status"
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return "unexpected_eof"
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return "transport"
+	}
+	return "stream_error"
+}
+
+func isEligibleStreamRecoveryError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	status := statusCodeFromError(err)
+	switch status {
+	case http.StatusRequestTimeout, http.StatusInternalServerError, http.StatusBadGateway,
+		http.StatusServiceUnavailable, http.StatusGatewayTimeout, 529:
+		return true
+	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound,
+		http.StatusRequestEntityTooLarge, http.StatusUnprocessableEntity, http.StatusTooManyRequests:
+		return false
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Temporary()
+}
+
+func cloneStreamChunk(chunk cliproxyexecutor.StreamChunk) cliproxyexecutor.StreamChunk {
+	chunk.Payload = append([]byte(nil), chunk.Payload...)
+	return chunk
+}
+
+func closedStreamChunks() <-chan cliproxyexecutor.StreamChunk {
+	ch := make(chan cliproxyexecutor.StreamChunk)
+	close(ch)
+	return ch
+}
+
+func prependStreamChunk(ctx context.Context, first cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk) <-chan cliproxyexecutor.StreamChunk {
+	out := make(chan cliproxyexecutor.StreamChunk, 1)
+	out <- first
+	go func() {
+		defer close(out)
+		for chunk := range remaining {
+			select {
+			case <-ctx.Done():
+				discardStreamChunks(remaining)
+				return
+			case out <- chunk:
+			}
+		}
+	}()
+	return out
+}
+
+func bufferedStreamBytes(chunks []cliproxyexecutor.StreamChunk) int {
+	total := 0
+	for _, chunk := range chunks {
+		total += len(chunk.Payload)
+	}
+	return total
+}
 
 func discardStreamChunks(ch <-chan cliproxyexecutor.StreamChunk) {
 	if ch == nil {
@@ -91,22 +253,122 @@ func readStreamBootstrap(ctx context.Context, ch <-chan cliproxyexecutor.StreamC
 			chunk, ok = <-ch
 		}
 		if !ok {
-			return buffered, true, nil
+			if len(buffered) > 0 {
+				return nil, false, &Error{Code: "incomplete_stream", Message: "upstream stream closed after provisional framing", Retryable: true, HTTPStatus: http.StatusBadGateway}
+			}
+			return nil, true, nil
 		}
 		if chunk.Err != nil {
 			return nil, false, chunk.Err
 		}
 		buffered = append(buffered, chunk)
-		if len(chunk.Payload) > 0 {
+		switch chunk.Commitment {
+		case cliproxyexecutor.StreamCommitmentProvisional:
+			continue
+		case cliproxyexecutor.StreamCommitmentSemantic, cliproxyexecutor.StreamCommitmentTerminal:
 			return buffered, false, nil
+		default:
+			if len(chunk.Payload) > 0 {
+				return buffered, false, nil
+			}
+		}
+	}
+}
+
+func collectRecoveryAttempt(ctx context.Context, streamResult *cliproxyexecutor.StreamResult, maxBufferBytes int) (buffered []cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk, terminal bool, failOpenReason string, err error) {
+	if streamResult == nil || streamResult.Chunks == nil {
+		return nil, nil, false, "", &Error{Code: "empty_stream", Message: "upstream stream has no source", Retryable: true}
+	}
+	bufferedBytes := 0
+	for {
+		select {
+		case <-ctx.Done():
+			discardStreamChunks(streamResult.Chunks)
+			return nil, nil, false, "", ctx.Err()
+		case chunk, ok := <-streamResult.Chunks:
+			if !ok {
+				if terminal {
+					return buffered, closedStreamChunks(), true, "", nil
+				}
+				return nil, nil, false, "", &Error{Code: requestScopedErrorCode, Message: "upstream stream closed before terminal completion", Retryable: true, HTTPStatus: http.StatusRequestTimeout}
+			}
+			if chunk.Err != nil {
+				discardStreamChunks(streamResult.Chunks)
+				return nil, nil, false, "", chunk.Err
+			}
+			if chunk.Commitment == cliproxyexecutor.StreamCommitmentUnknown && len(chunk.Payload) > 0 {
+				return buffered, prependStreamChunk(ctx, chunk, streamResult.Chunks), false, "unknown_commitment", nil
+			}
+			if maxBufferBytes > 0 && len(chunk.Payload) > maxBufferBytes-bufferedBytes {
+				return buffered, prependStreamChunk(ctx, chunk, streamResult.Chunks), false, "buffer_overflow", nil
+			}
+			cloned := cloneStreamChunk(chunk)
+			buffered = append(buffered, cloned)
+			bufferedBytes += len(cloned.Payload)
+			if chunk.Commitment == cliproxyexecutor.StreamCommitmentTerminal {
+				terminal = true
+			}
+		}
+	}
+}
+
+func (m *Manager) executeStreamWithRecovery(ctx context.Context, executor ProviderExecutor, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, provider, model string) (*cliproxyexecutor.StreamResult, []cliproxyexecutor.StreamChunk, <-chan cliproxyexecutor.StreamChunk, error) {
+	state := streamRecoveryFromContext(ctx)
+	if state == nil {
+		return nil, nil, nil, nil
+	}
+	attempt := 0
+	log.WithFields(log.Fields{"provider": provider, "model": model, "reason": "enabled", "buffered_bytes": 0, "elapsed": time.Duration(0), "max_attempts": state.policy.Attempts + 1, "max_buffer_bytes": state.policy.MaxBufferBytes}).Debug("stream recovery started")
+	for {
+		attempt++
+		streamResult, errStream := executor.ExecuteStream(ctx, auth, req, opts)
+		if errStream == nil {
+			var failOpenReason string
+			var terminal bool
+			var buffered []cliproxyexecutor.StreamChunk
+			var remaining <-chan cliproxyexecutor.StreamChunk
+			buffered, remaining, terminal, failOpenReason, errStream = collectRecoveryAttempt(ctx, streamResult, state.policy.MaxBufferBytes)
+			if errStream == nil {
+				if failOpenReason != "" {
+					log.WithFields(log.Fields{"provider": provider, "model": model, "attempt": attempt, "reason": failOpenReason, "buffered_bytes": bufferedStreamBytes(buffered), "elapsed": time.Since(state.started)}).Debug("stream recovery failed open to ordinary streaming")
+					return streamResult, buffered, remaining, nil
+				}
+				if terminal {
+					state.holdUntilDrain = true
+					log.WithFields(log.Fields{"provider": provider, "model": model, "attempt": attempt, "reason": "terminal_success", "buffered_bytes": bufferedStreamBytes(buffered), "elapsed": time.Since(state.started)}).Debug("stream recovery succeeded")
+					return streamResult, buffered, remaining, nil
+				}
+			}
+		}
+		if errCtx := ctx.Err(); errCtx != nil {
+			return nil, nil, nil, errCtx
+		}
+		if !isEligibleStreamRecoveryError(errStream) || !state.canRetry() {
+			log.WithFields(log.Fields{"provider": provider, "model": model, "attempt": attempt, "reason": streamRecoveryReason(errStream), "status": statusCodeFromError(errStream), "buffered_bytes": 0, "elapsed": time.Since(state.started)}).Debug("stream recovery exhausted")
+			return streamResult, nil, nil, errStream
+		}
+		log.WithFields(log.Fields{"provider": provider, "model": model, "attempt": attempt, "reason": streamRecoveryReason(errStream), "status": statusCodeFromError(errStream), "buffered_bytes": 0, "elapsed": time.Since(state.started)}).Debug("retrying recoverable stream")
+		if errWait := streamRecoveryBackoff(ctx, state.policy, attempt); errWait != nil {
+			return nil, nil, nil, errWait
+		}
+		if state.policy.MaxRetryWindow > 0 && time.Since(state.started) >= state.policy.MaxRetryWindow {
+			log.WithFields(log.Fields{"provider": provider, "model": model, "attempt": attempt, "reason": "retry_window_exhausted", "status": statusCodeFromError(errStream), "buffered_bytes": 0, "elapsed": time.Since(state.started)}).Debug("stream recovery exhausted")
+			return streamResult, nil, nil, errStream
 		}
 	}
 }
 
 func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, resultModel string, headers http.Header, buffered []cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk, aliasResult OAuthModelAliasResult, ephemeralResult bool) *cliproxyexecutor.StreamResult {
+	return m.wrapStreamResultWithDone(ctx, auth, provider, resultModel, headers, buffered, remaining, aliasResult, ephemeralResult, nil)
+}
+
+func (m *Manager) wrapStreamResultWithDone(ctx context.Context, auth *Auth, provider, resultModel string, headers http.Header, buffered []cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk, aliasResult OAuthModelAliasResult, ephemeralResult bool, done func()) *cliproxyexecutor.StreamResult {
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {
 		defer close(out)
+		if done != nil {
+			defer done()
+		}
 		var failed bool
 		forward := true
 		var rewriter *StreamRewriter
@@ -114,6 +376,10 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 			rewriter = NewStreamRewriter(StreamRewriteOptions{RewriteModel: aliasResult.OriginalAlias})
 		}
 		emit := func(chunk cliproxyexecutor.StreamChunk) bool {
+			if ctx != nil && ctx.Err() != nil {
+				forward = false
+				return false
+			}
 			if chunk.Err != nil && !failed {
 				failed = true
 				rerr := resultErrorFromError(chunk.Err)
@@ -173,7 +439,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 				return
 			}
 		}
-		if !failed {
+		if !failed && (ctx == nil || ctx.Err() == nil) {
 			m.recordExecutionResult(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: true}, auth, ephemeralResult)
 		}
 	}()
@@ -202,6 +468,34 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		}
 		if errCtx := ctx.Err(); errCtx != nil {
 			return nil, errCtx
+		}
+		if recoveryState := streamRecoveryFromContext(ctx); recoveryState != nil {
+			streamResult, buffered, remaining, errRecovery := m.executeStreamWithRecovery(ctx, executor, auth, execReq, execOpts, provider, resultModel)
+			if errRecovery != nil && ctx.Err() == nil && allowRetry {
+				if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(ctx, auth, errRecovery, didRefreshOnUnauthorized); okRefresh {
+					auth = refreshed
+					didRefreshOnUnauthorized = true
+					streamResult, buffered, remaining, errRecovery = m.executeStreamWithRecovery(ctx, executor, auth, execReq, execOpts, provider, resultModel)
+				}
+			}
+			if errRecovery != nil {
+				if errCtx := ctx.Err(); errCtx != nil {
+					return nil, errCtx
+				}
+				rerr := resultErrorFromError(errRecovery)
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
+				result.RetryAfter = retryAfterFromError(errRecovery)
+				m.recordExecutionResult(ctx, result, auth, ephemeralResult)
+				if isRequestScopedError(errRecovery) || isRequestInvalidError(errRecovery) {
+					return nil, errRecovery
+				}
+				lastErr = errRecovery
+				continue
+			}
+			if recoveryState.holdUntilDrain {
+				return m.wrapStreamResultWithDone(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, buffered, remaining, aliasResult, ephemeralResult, recoveryState.releaseSlot), nil
+			}
+			return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, buffered, remaining, aliasResult, ephemeralResult), nil
 		}
 		streamResult, errStream := executor.ExecuteStream(ctx, auth, execReq, execOpts)
 		if errStream != nil {

--- a/sdk/cliproxy/auth/conductor_stream_recovery_test.go
+++ b/sdk/cliproxy/auth/conductor_stream_recovery_test.go
@@ -1,0 +1,494 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type recoverySequenceExecutor struct {
+	mu       sync.Mutex
+	attempts [][]cliproxyexecutor.StreamChunk
+	calls    int
+	authIDs  []string
+	notify   chan int
+}
+
+func (e *recoverySequenceExecutor) Identifier() string { return "codex" }
+
+func (e *recoverySequenceExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *recoverySequenceExecutor) ExecuteStream(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.mu.Lock()
+	call := e.calls
+	e.calls++
+	if auth != nil {
+		e.authIDs = append(e.authIDs, auth.ID)
+	}
+	attempt := append([]cliproxyexecutor.StreamChunk(nil), e.attempts[call]...)
+	notify := e.notify
+	e.mu.Unlock()
+	if notify != nil {
+		notify <- call + 1
+	}
+	chunks := make(chan cliproxyexecutor.StreamChunk, len(attempt))
+	for _, chunk := range attempt {
+		chunks <- chunk
+	}
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Headers: http.Header{"X-Attempt": {string(rune('1' + call))}}, Chunks: chunks}, nil
+}
+
+func (e *recoverySequenceExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+func (e *recoverySequenceExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (e *recoverySequenceExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestExecuteStreamWithRecoveryDiscardsFailedAttempt(t *testing.T) {
+	executor := &recoverySequenceExecutor{attempts: [][]cliproxyexecutor.StreamChunk{
+		{
+			{Payload: []byte("losing-start"), Commitment: cliproxyexecutor.StreamCommitmentProvisional},
+			{Payload: []byte("losing-text"), Commitment: cliproxyexecutor.StreamCommitmentSemantic},
+			{Err: &Error{HTTPStatus: http.StatusBadGateway, Message: "server error"}},
+		},
+		{
+			{Payload: []byte("winning-start"), Commitment: cliproxyexecutor.StreamCommitmentProvisional},
+			{Payload: []byte("winning-text"), Commitment: cliproxyexecutor.StreamCommitmentSemantic},
+			{Payload: []byte("winning-stop"), Commitment: cliproxyexecutor.StreamCommitmentTerminal},
+		},
+	}}
+	policy := cliproxyexecutor.StreamRecoveryPolicy{
+		Attempts:       1,
+		MaxBufferBytes: 1024,
+		MaxRetryWindow: time.Second,
+		InitialBackoff: time.Nanosecond,
+		MaxBackoff:     time.Nanosecond,
+	}
+	ctx := context.WithValue(context.Background(), streamRecoveryContextKey{}, &streamRecoveryState{policy: policy, started: time.Now(), remaining: 1})
+	result, buffered, remaining, err := (&Manager{}).executeStreamWithRecovery(ctx, executor, &Auth{}, cliproxyexecutor.Request{}, cliproxyexecutor.Options{}, "codex", "gpt-test")
+	if err != nil {
+		t.Fatalf("executeStreamWithRecovery error: %v", err)
+	}
+	if got := result.Headers.Get("X-Attempt"); got != "2" {
+		t.Fatalf("winning header = %q, want 2", got)
+	}
+	if executor.calls != 2 {
+		t.Fatalf("calls = %d, want 2", executor.calls)
+	}
+	var got string
+	for _, chunk := range buffered {
+		got += string(chunk.Payload)
+	}
+	for chunk := range remaining {
+		got += string(chunk.Payload)
+	}
+	if got != "winning-startwinning-textwinning-stop" {
+		t.Fatalf("winning payload = %q", got)
+	}
+}
+
+func TestManagerExecuteStreamRecoveryReturnsOnlyWinningAttempt(t *testing.T) {
+	executor := &recoverySequenceExecutor{attempts: [][]cliproxyexecutor.StreamChunk{
+		{
+			{Payload: []byte("losing"), Commitment: cliproxyexecutor.StreamCommitmentSemantic},
+			{Err: &Error{HTTPStatus: http.StatusBadGateway, Message: "server error"}},
+		},
+		{
+			{Payload: []byte("winning"), Commitment: cliproxyexecutor.StreamCommitmentSemantic},
+			{Payload: []byte("done"), Commitment: cliproxyexecutor.StreamCommitmentTerminal},
+		},
+	}}
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &Auth{ID: "recovery-auth", Provider: "codex", Status: StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "gpt-test"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	manager.RefreshSchedulerEntry(auth.ID)
+
+	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-test"}, cliproxyexecutor.Options{Stream: true, StreamRecovery: cliproxyexecutor.StreamRecoveryPolicy{
+		Attempts:       1,
+		MaxBufferBytes: 1024,
+		MaxRetryWindow: time.Second,
+		MaxConcurrent:  1,
+		InitialBackoff: time.Nanosecond,
+		MaxBackoff:     time.Nanosecond,
+	}})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	var got string
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream error: %v", chunk.Err)
+		}
+		got += string(chunk.Payload)
+	}
+	if got != "winningdone" {
+		t.Fatalf("payload = %q, want winningdone", got)
+	}
+	if result.Headers.Get("X-Attempt") != "2" {
+		t.Fatalf("headers = %v, want winning attempt", result.Headers)
+	}
+}
+
+func TestManagerExecuteStreamRecoveryRetriesPinnedAuthOnly(t *testing.T) {
+	executor := &recoverySequenceExecutor{attempts: [][]cliproxyexecutor.StreamChunk{
+		{{Err: &Error{HTTPStatus: http.StatusBadGateway, Message: "temporary"}}},
+		{{Payload: []byte("ok"), Commitment: cliproxyexecutor.StreamCommitmentTerminal}},
+	}}
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	for _, id := range []string{"pinned-auth", "other-auth"} {
+		auth := &Auth{ID: id, Provider: "codex", Status: StatusActive}
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register %s: %v", id, err)
+		}
+		registry.GetGlobalRegistry().RegisterClient(id, "codex", []*registry.ModelInfo{{ID: "pinned-model"}})
+		t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(id) })
+	}
+	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "pinned-model"}, cliproxyexecutor.Options{Stream: true, Metadata: map[string]any{cliproxyexecutor.PinnedAuthMetadataKey: "pinned-auth"}, StreamRecovery: cliproxyexecutor.StreamRecoveryPolicy{
+		Attempts: 1, MaxBufferBytes: 1024, MaxRetryWindow: time.Second, MaxConcurrent: 1, InitialBackoff: time.Nanosecond, MaxBackoff: time.Nanosecond,
+	}})
+	if err != nil {
+		t.Fatalf("ExecuteStream: %v", err)
+	}
+	for range result.Chunks {
+	}
+	if len(executor.authIDs) != 2 || executor.authIDs[0] != "pinned-auth" || executor.authIDs[1] != "pinned-auth" {
+		t.Fatalf("auth attempts = %v, want pinned auth twice", executor.authIDs)
+	}
+}
+
+func TestRecoveryExhaustedIncompleteStreamPreservesRequestScopeWithoutCooldownOrFallback(t *testing.T) {
+	executor := &recoverySequenceExecutor{attempts: [][]cliproxyexecutor.StreamChunk{
+		{{Payload: []byte("start-1"), Commitment: cliproxyexecutor.StreamCommitmentProvisional}},
+		{{Payload: []byte("start-2"), Commitment: cliproxyexecutor.StreamCommitmentProvisional}},
+	}}
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	for _, id := range []string{"aa-incomplete-auth", "zz-backup-auth"} {
+		auth := &Auth{ID: id, Provider: "codex", Status: StatusActive}
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register auth: %v", err)
+		}
+		registry.GetGlobalRegistry().RegisterClient(id, "codex", []*registry.ModelInfo{{ID: "incomplete-model"}})
+		t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(id) })
+		manager.RefreshSchedulerEntry(id)
+	}
+	_, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "incomplete-model"}, cliproxyexecutor.Options{Stream: true, StreamRecovery: cliproxyexecutor.StreamRecoveryPolicy{
+		Attempts: 1, MaxBufferBytes: 1024, MaxRetryWindow: time.Second, MaxConcurrent: 1, InitialBackoff: time.Nanosecond, MaxBackoff: time.Nanosecond,
+	}})
+	if err == nil || statusCodeFromError(err) != http.StatusRequestTimeout {
+		t.Fatalf("error = %v, want request-scoped 408", err)
+	}
+	if !isRequestScopedError(err) {
+		t.Fatalf("error is not request scoped: %v", err)
+	}
+	if executor.calls != 2 || len(executor.authIDs) != 2 || executor.authIDs[0] != "aa-incomplete-auth" || executor.authIDs[1] != "aa-incomplete-auth" {
+		t.Fatalf("attempts=%d auths=%v, want two attempts on primary only", executor.calls, executor.authIDs)
+	}
+	updated, ok := manager.GetByID("aa-incomplete-auth")
+	if !ok {
+		t.Fatal("auth missing")
+	}
+	state := updated.ModelStates["incomplete-model"]
+	if state != nil && (state.Unavailable || !state.NextRetryAfter.IsZero()) {
+		t.Fatalf("request-scoped incomplete stream cooled model: %+v", state)
+	}
+}
+
+func TestRecoveryExhaustedGenericServerErrorAppliesCooldown(t *testing.T) {
+	executor := &recoverySequenceExecutor{attempts: [][]cliproxyexecutor.StreamChunk{
+		{{Err: &Error{HTTPStatus: http.StatusBadGateway, Message: "temporary-1"}}},
+		{{Err: &Error{HTTPStatus: http.StatusBadGateway, Message: "temporary-2"}}},
+	}}
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &Auth{ID: "server-error-auth", Provider: "codex", Status: StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "server-error-model"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	manager.RefreshSchedulerEntry(auth.ID)
+	_, _ = manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "server-error-model"}, cliproxyexecutor.Options{Stream: true, StreamRecovery: cliproxyexecutor.StreamRecoveryPolicy{
+		Attempts: 1, MaxBufferBytes: 1024, MaxRetryWindow: time.Second, MaxConcurrent: 1, InitialBackoff: time.Nanosecond, MaxBackoff: time.Nanosecond,
+	}})
+	if executor.calls != 2 {
+		t.Fatalf("calls = %d, want 2", executor.calls)
+	}
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("auth missing")
+	}
+	state := updated.ModelStates["server-error-model"]
+	if state == nil || !state.Unavailable || state.NextRetryAfter.IsZero() {
+		t.Fatalf("generic 502 exhaustion did not cool model: %+v", state)
+	}
+}
+
+func TestRecoverySlotHeldUntilBufferedResultDrained(t *testing.T) {
+	executor := &recoverySequenceExecutor{attempts: [][]cliproxyexecutor.StreamChunk{
+		{{Payload: []byte("first"), Commitment: cliproxyexecutor.StreamCommitmentTerminal}},
+		{{Payload: []byte("second"), Commitment: cliproxyexecutor.StreamCommitmentUnknown}},
+	}}
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &Auth{ID: "slot-auth", Provider: "codex", Status: StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "slot-model"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	manager.RefreshSchedulerEntry(auth.ID)
+	policy := cliproxyexecutor.StreamRecoveryPolicy{Attempts: 1, MaxBufferBytes: 1024, MaxRetryWindow: time.Second, MaxConcurrent: 1, InitialBackoff: time.Nanosecond, MaxBackoff: time.Nanosecond}
+
+	first, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "slot-model"}, cliproxyexecutor.Options{Stream: true, StreamRecovery: policy})
+	if err != nil {
+		t.Fatalf("first ExecuteStream: %v", err)
+	}
+	if got := manager.recoveryInFlight.Load(); got != 1 {
+		t.Fatalf("recovery slots = %d, want 1 before drain", got)
+	}
+	second, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "slot-model"}, cliproxyexecutor.Options{Stream: true, StreamRecovery: policy})
+	if err != nil {
+		t.Fatalf("second ExecuteStream: %v", err)
+	}
+	for range second.Chunks {
+	}
+	if got := manager.recoveryInFlight.Load(); got != 1 {
+		t.Fatalf("recovery slots = %d, want first slot still held", got)
+	}
+	for range first.Chunks {
+	}
+	deadline := time.Now().Add(time.Second)
+	for manager.recoveryInFlight.Load() != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := manager.recoveryInFlight.Load(); got != 0 {
+		t.Fatalf("recovery slots = %d, want 0 after drain", got)
+	}
+}
+
+func TestReadStreamBootstrapWaitsThroughProvisionalChunks(t *testing.T) {
+	chunks := make(chan cliproxyexecutor.StreamChunk, 2)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("start"), Commitment: cliproxyexecutor.StreamCommitmentProvisional}
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("text"), Commitment: cliproxyexecutor.StreamCommitmentSemantic}
+	close(chunks)
+	buffered, closed, err := readStreamBootstrap(context.Background(), chunks)
+	if err != nil || closed || len(buffered) != 2 {
+		t.Fatalf("buffered=%v closed=%v err=%v", buffered, closed, err)
+	}
+}
+
+func TestReadStreamBootstrapProvisionalOnlyCloseFails(t *testing.T) {
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("start"), Commitment: cliproxyexecutor.StreamCommitmentProvisional}
+	close(chunks)
+	_, _, err := readStreamBootstrap(context.Background(), chunks)
+	if err == nil {
+		t.Fatal("expected provisional-only stream failure")
+	}
+}
+
+func TestCollectRecoveryAttemptOverflowFailsOpenExactlyOnce(t *testing.T) {
+	chunks := make(chan cliproxyexecutor.StreamChunk, 3)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("abc"), Commitment: cliproxyexecutor.StreamCommitmentProvisional}
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("def"), Commitment: cliproxyexecutor.StreamCommitmentSemantic}
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("ghi"), Commitment: cliproxyexecutor.StreamCommitmentTerminal}
+	close(chunks)
+	buffered, remaining, terminal, failOpen, err := collectRecoveryAttempt(context.Background(), &cliproxyexecutor.StreamResult{Chunks: chunks}, 5)
+	if err != nil || terminal || failOpen != "buffer_overflow" {
+		t.Fatalf("terminal=%v failOpen=%v err=%v", terminal, failOpen, err)
+	}
+	if gotBytes := bufferedStreamBytes(buffered); gotBytes > 5 {
+		t.Fatalf("buffered bytes = %d, exceeds limit", gotBytes)
+	}
+	var got string
+	for _, chunk := range buffered {
+		got += string(chunk.Payload)
+	}
+	for chunk := range remaining {
+		got += string(chunk.Payload)
+	}
+	if got != "abcdefghi" {
+		t.Fatalf("payload = %q, want abcdefghi", got)
+	}
+}
+
+type cancelBufferingExecutor struct {
+	started chan struct{}
+}
+
+func (e *cancelBufferingExecutor) Identifier() string { return "codex" }
+func (e *cancelBufferingExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (e *cancelBufferingExecutor) ExecuteStream(ctx context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	chunks := make(chan cliproxyexecutor.StreamChunk)
+	go func() {
+		defer close(chunks)
+		chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("start"), Commitment: cliproxyexecutor.StreamCommitmentProvisional}
+		close(e.started)
+		<-ctx.Done()
+	}()
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+func (e *cancelBufferingExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+func (e *cancelBufferingExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (e *cancelBufferingExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestRecoveryCancellationDuringBufferingDoesNotCooldown(t *testing.T) {
+	executor := &cancelBufferingExecutor{started: make(chan struct{})}
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &Auth{ID: "cancel-auth", Provider: "codex", Status: StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "cancel-model"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	manager.RefreshSchedulerEntry(auth.ID)
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := manager.ExecuteStream(ctx, []string{"codex"}, cliproxyexecutor.Request{Model: "cancel-model"}, cliproxyexecutor.Options{Stream: true, StreamRecovery: cliproxyexecutor.StreamRecoveryPolicy{Attempts: 1, MaxBufferBytes: 1024, MaxRetryWindow: time.Second, MaxConcurrent: 1, InitialBackoff: time.Second, MaxBackoff: time.Second}})
+		resultCh <- err
+	}()
+	<-executor.started
+	cancel()
+	if err := <-resultCh; err != context.Canceled {
+		t.Fatalf("ExecuteStream error = %v, want context.Canceled", err)
+	}
+	if got := manager.recoveryInFlight.Load(); got != 0 {
+		t.Fatalf("recovery slots = %d after cancellation, want 0", got)
+	}
+	manager.mu.RLock()
+	updated := manager.auths[auth.ID].Clone()
+	manager.mu.RUnlock()
+	if updated.Failed != 0 || updated.Unavailable || !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("cancellation changed auth availability: %+v", updated)
+	}
+	if state := updated.ModelStates["cancel-model"]; state != nil && (state.Unavailable || !state.NextRetryAfter.IsZero()) {
+		t.Fatalf("cancellation cooled model: %+v", state)
+	}
+}
+
+func TestRecoveryCancellationDuringBackoffDoesNotRetryOrCooldown(t *testing.T) {
+	executor := &recoverySequenceExecutor{notify: make(chan int, 2), attempts: [][]cliproxyexecutor.StreamChunk{
+		{{Err: &Error{HTTPStatus: http.StatusBadGateway, Message: "temporary"}}},
+		{{Payload: []byte("unexpected"), Commitment: cliproxyexecutor.StreamCommitmentTerminal}},
+	}}
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &Auth{ID: "backoff-auth", Provider: "codex", Status: StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "backoff-model"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	manager.RefreshSchedulerEntry(auth.ID)
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := manager.ExecuteStream(ctx, []string{"codex"}, cliproxyexecutor.Request{Model: "backoff-model"}, cliproxyexecutor.Options{Stream: true, StreamRecovery: cliproxyexecutor.StreamRecoveryPolicy{Attempts: 1, MaxBufferBytes: 1024, MaxRetryWindow: 2 * time.Hour, MaxConcurrent: 1, InitialBackoff: time.Hour, MaxBackoff: time.Hour}})
+		resultCh <- err
+	}()
+	if call := <-executor.notify; call != 1 {
+		t.Fatalf("first call = %d", call)
+	}
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+	if err := <-resultCh; err != context.Canceled {
+		t.Fatalf("ExecuteStream error = %v, want context.Canceled", err)
+	}
+	executor.mu.Lock()
+	calls := executor.calls
+	executor.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("stream calls = %d, want 1", calls)
+	}
+	manager.mu.RLock()
+	updated := manager.auths[auth.ID].Clone()
+	manager.mu.RUnlock()
+	if updated.Failed != 0 {
+		t.Fatalf("cancellation recorded %d failures", updated.Failed)
+	}
+}
+
+func TestCollectRecoveryAttemptOverflowPreservesLaterError(t *testing.T) {
+	laterErr := &Error{HTTPStatus: http.StatusBadGateway, Message: "later failure"}
+	chunks := make(chan cliproxyexecutor.StreamChunk, 3)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("abc"), Commitment: cliproxyexecutor.StreamCommitmentProvisional}
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("def"), Commitment: cliproxyexecutor.StreamCommitmentSemantic}
+	chunks <- cliproxyexecutor.StreamChunk{Err: laterErr}
+	close(chunks)
+	buffered, remaining, _, failOpen, err := collectRecoveryAttempt(context.Background(), &cliproxyexecutor.StreamResult{Chunks: chunks}, 5)
+	if err != nil || failOpen != "buffer_overflow" || bufferedStreamBytes(buffered) != 3 {
+		t.Fatalf("buffered=%d failOpen=%v err=%v", bufferedStreamBytes(buffered), failOpen, err)
+	}
+	first := <-remaining
+	if string(first.Payload) != "def" {
+		t.Fatalf("overflow chunk = %q, want def", first.Payload)
+	}
+	second := <-remaining
+	if second.Err != laterErr {
+		t.Fatalf("later error = %v, want %v", second.Err, laterErr)
+	}
+}
+
+func TestStreamRecoveryBudgetAndWindow(t *testing.T) {
+	state := &streamRecoveryState{policy: cliproxyexecutor.StreamRecoveryPolicy{MaxRetryWindow: time.Second}, started: time.Now(), remaining: 1}
+	if !state.canRetry() || state.canRetry() {
+		t.Fatal("attempt budget was not enforced exactly")
+	}
+	state = &streamRecoveryState{policy: cliproxyexecutor.StreamRecoveryPolicy{MaxRetryWindow: time.Nanosecond}, started: time.Now().Add(-time.Second), remaining: 1}
+	if state.canRetry() {
+		t.Fatal("retry started after retry window")
+	}
+}
+
+func TestStreamRecoveryGateIsNonblocking(t *testing.T) {
+	manager := &Manager{}
+	if !manager.acquireStreamRecovery(1) {
+		t.Fatal("first acquisition failed")
+	}
+	if manager.acquireStreamRecovery(1) {
+		t.Fatal("saturated acquisition unexpectedly succeeded")
+	}
+	manager.recoveryInFlight.Add(-1)
+	if !manager.acquireStreamRecovery(1) {
+		t.Fatal("slot was not released")
+	}
+	manager.recoveryInFlight.Add(-1)
+}
+
+func TestStreamRecoveryBackoffHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := streamRecoveryBackoff(ctx, cliproxyexecutor.StreamRecoveryPolicy{InitialBackoff: time.Second, MaxBackoff: time.Second}, 1)
+	if err != context.Canceled {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_stream_recovery_test.go
+++ b/sdk/cliproxy/auth/conductor_stream_recovery_test.go
@@ -14,9 +14,10 @@ import (
 type recoverySequenceExecutor struct {
 	mu       sync.Mutex
 	attempts [][]cliproxyexecutor.StreamChunk
-	calls    int
-	authIDs  []string
-	notify   chan int
+	calls            int
+	authIDs          []string
+	recoveryContexts []bool
+	notify           chan int
 }
 
 func (e *recoverySequenceExecutor) Identifier() string { return "codex" }
@@ -282,6 +283,56 @@ func TestRecoverySlotHeldUntilBufferedResultDrained(t *testing.T) {
 	}
 	if got := manager.recoveryInFlight.Load(); got != 0 {
 		t.Fatalf("recovery slots = %d, want 0 after drain", got)
+	}
+}
+
+func TestRecoveryOverflowHoldsSlotThroughRetainedPrefixAndOverflowChunk(t *testing.T) {
+	executor := &recoverySequenceExecutor{attempts: [][]cliproxyexecutor.StreamChunk{{
+		{Payload: []byte("abc"), Commitment: cliproxyexecutor.StreamCommitmentProvisional},
+		{Payload: []byte("def"), Commitment: cliproxyexecutor.StreamCommitmentSemantic},
+		{Payload: []byte("tail"), Commitment: cliproxyexecutor.StreamCommitmentTerminal},
+	}}}
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &Auth{ID: "overflow-slot-auth", Provider: "codex", Status: StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "overflow-slot-model"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	manager.RefreshSchedulerEntry(auth.ID)
+
+	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "overflow-slot-model"}, cliproxyexecutor.Options{Stream: true, StreamRecovery: cliproxyexecutor.StreamRecoveryPolicy{
+		Attempts: 1, MaxBufferBytes: 5, MaxRetryWindow: time.Second, MaxConcurrent: 1, InitialBackoff: time.Nanosecond, MaxBackoff: time.Nanosecond,
+	}})
+	if err != nil {
+		t.Fatalf("ExecuteStream: %v", err)
+	}
+	if got := manager.recoveryInFlight.Load(); got != 1 {
+		t.Fatalf("recovery slots = %d before prefix drain, want 1", got)
+	}
+	if chunk := <-result.Chunks; string(chunk.Payload) != "abc" {
+		t.Fatalf("prefix chunk = %q, want abc", chunk.Payload)
+	}
+	if got := manager.recoveryInFlight.Load(); got != 1 {
+		t.Fatalf("recovery slots = %d before overflow chunk, want 1", got)
+	}
+	if chunk := <-result.Chunks; string(chunk.Payload) != "def" {
+		t.Fatalf("overflow chunk = %q, want def", chunk.Payload)
+	}
+	deadline := time.Now().Add(time.Second)
+	for manager.recoveryInFlight.Load() != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := manager.recoveryInFlight.Load(); got != 0 {
+		t.Fatalf("recovery slots = %d after overflow prefix drain, want 0", got)
+	}
+	var tail string
+	for chunk := range result.Chunks {
+		tail += string(chunk.Payload)
+	}
+	if tail != "tail" {
+		t.Fatalf("ordinary tail = %q, want tail", tail)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_stream_recovery_test.go
+++ b/sdk/cliproxy/auth/conductor_stream_recovery_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 type recoverySequenceExecutor struct {
 	mu               sync.Mutex
 	attempts         [][]cliproxyexecutor.StreamChunk
+	directErrors     []error
 	calls            int
 	authIDs          []string
 	recoveryContexts []bool
@@ -34,11 +36,21 @@ func (e *recoverySequenceExecutor) ExecuteStream(ctx context.Context, auth *Auth
 	if auth != nil {
 		e.authIDs = append(e.authIDs, auth.ID)
 	}
-	attempt := append([]cliproxyexecutor.StreamChunk(nil), e.attempts[call]...)
+	var attempt []cliproxyexecutor.StreamChunk
+	if call < len(e.attempts) {
+		attempt = append(attempt, e.attempts[call]...)
+	}
+	var directErr error
+	if call < len(e.directErrors) {
+		directErr = e.directErrors[call]
+	}
 	notify := e.notify
 	e.mu.Unlock()
 	if notify != nil {
 		notify <- call + 1
+	}
+	if directErr != nil {
+		return nil, directErr
 	}
 	chunks := make(chan cliproxyexecutor.StreamChunk, len(attempt))
 	for _, chunk := range attempt {
@@ -98,6 +110,97 @@ func TestExecuteStreamWithRecoveryDiscardsFailedAttempt(t *testing.T) {
 	}
 	if got != "winning-startwinning-textwinning-stop" {
 		t.Fatalf("winning payload = %q", got)
+	}
+}
+
+func TestManagerExecuteStreamRecoveryRetriesSynchronousTransientStatuses(t *testing.T) {
+	for _, status := range []int{http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			executor := &recoverySequenceExecutor{
+				attempts: [][]cliproxyexecutor.StreamChunk{
+					nil,
+					{{Payload: []byte("winning"), Commitment: cliproxyexecutor.StreamCommitmentTerminal}},
+				},
+				directErrors: []error{
+					&Error{Code: "server_is_overloaded", Message: "temporary upstream capacity", HTTPStatus: status},
+					nil,
+				},
+			}
+			manager := NewManager(nil, nil, nil)
+			manager.RegisterExecutor(executor)
+			authID := "synchronous-recovery-auth-" + strconv.Itoa(status)
+			model := "synchronous-recovery-model-" + strconv.Itoa(status)
+			auth := &Auth{ID: authID, Provider: "codex", Status: StatusActive}
+			if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+				t.Fatalf("register auth: %v", errRegister)
+			}
+			registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+			t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+			manager.RefreshSchedulerEntry(auth.ID)
+
+			result, errExecute := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{Stream: true, StreamRecovery: cliproxyexecutor.StreamRecoveryPolicy{
+				Attempts: 1, MaxBufferBytes: 1024, MaxRetryWindow: time.Second, MaxConcurrent: 1, InitialBackoff: time.Nanosecond, MaxBackoff: time.Nanosecond,
+			}})
+			if errExecute != nil {
+				t.Fatalf("ExecuteStream: %v", errExecute)
+			}
+			var payload string
+			for chunk := range result.Chunks {
+				if chunk.Err != nil {
+					t.Fatalf("stream error: %v", chunk.Err)
+				}
+				payload += string(chunk.Payload)
+			}
+			if payload != "winning" {
+				t.Fatalf("payload = %q, want winning", payload)
+			}
+			if got := result.Headers.Get("X-Attempt"); got != "2" {
+				t.Fatalf("winning header = %q, want 2", got)
+			}
+			if executor.calls != 2 {
+				t.Fatalf("calls = %d, want 2", executor.calls)
+			}
+			if len(executor.authIDs) != 2 || executor.authIDs[0] != authID || executor.authIDs[1] != authID {
+				t.Fatalf("auth attempts = %v, want %q twice", executor.authIDs, authID)
+			}
+			updated, ok := manager.GetByID(authID)
+			if !ok {
+				t.Fatal("auth missing")
+			}
+			if updated.Unavailable || updated.Status != StatusActive || updated.Failed != 0 {
+				t.Fatalf("recovered direct error changed auth availability: %+v", updated)
+			}
+		})
+	}
+}
+
+func TestExecuteStreamWithRecoveryPreservesSynchronousErrorOnExhaustion(t *testing.T) {
+	firstErr := &Error{Code: "server_is_overloaded", Message: "first temporary overload", HTTPStatus: http.StatusBadGateway}
+	finalErr := &Error{Code: "server_is_overloaded", Message: "final structured overload", HTTPStatus: http.StatusServiceUnavailable}
+	executor := &recoverySequenceExecutor{
+		attempts:     make([][]cliproxyexecutor.StreamChunk, 2),
+		directErrors: []error{firstErr, finalErr},
+	}
+	policy := cliproxyexecutor.StreamRecoveryPolicy{
+		Attempts:       1,
+		MaxBufferBytes: 1024,
+		MaxRetryWindow: time.Second,
+		InitialBackoff: time.Nanosecond,
+		MaxBackoff:     time.Nanosecond,
+	}
+	ctx := context.WithValue(context.Background(), streamRecoveryContextKey{}, &streamRecoveryState{policy: policy, started: time.Now(), remaining: 1})
+	result, buffered, remaining, errRecovery := (&Manager{}).executeStreamWithRecovery(ctx, executor, &Auth{}, cliproxyexecutor.Request{}, cliproxyexecutor.Options{}, "codex", "gpt-test")
+	if errRecovery != finalErr {
+		t.Fatalf("error = %v, want final structured error %v", errRecovery, finalErr)
+	}
+	if result != nil || buffered != nil || remaining != nil {
+		t.Fatalf("exhausted direct error returned stream state: result=%v buffered=%v remaining=%v", result, buffered, remaining)
+	}
+	if statusCodeFromError(errRecovery) != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", statusCodeFromError(errRecovery))
+	}
+	if executor.calls != 2 {
+		t.Fatalf("calls = %d, want 2", executor.calls)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_stream_recovery_test.go
+++ b/sdk/cliproxy/auth/conductor_stream_recovery_test.go
@@ -354,12 +354,36 @@ func TestRecoveryOverflowHoldsSlotThroughRetainedPrefixAndOverflowChunk(t *testi
 	}
 }
 
+func TestReadStreamBootstrapDefaultForwardsProvisionalImmediately(t *testing.T) {
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("start"), Commitment: cliproxyexecutor.StreamCommitmentProvisional}
+	type bootstrapResult struct {
+		buffered []cliproxyexecutor.StreamChunk
+		closed   bool
+		err      error
+	}
+	resultCh := make(chan bootstrapResult, 1)
+	go func() {
+		buffered, closed, err := readStreamBootstrap(context.Background(), chunks, false)
+		resultCh <- bootstrapResult{buffered: buffered, closed: closed, err: err}
+	}()
+	select {
+	case result := <-resultCh:
+		if result.err != nil || result.closed || len(result.buffered) != 1 || string(result.buffered[0].Payload) != "start" {
+			t.Fatalf("buffered=%v closed=%v err=%v", result.buffered, result.closed, result.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("default bootstrap blocked on provisional lifecycle chunk")
+	}
+	close(chunks)
+}
+
 func TestReadStreamBootstrapWaitsThroughProvisionalChunks(t *testing.T) {
 	chunks := make(chan cliproxyexecutor.StreamChunk, 2)
 	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("start"), Commitment: cliproxyexecutor.StreamCommitmentProvisional}
 	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("text"), Commitment: cliproxyexecutor.StreamCommitmentSemantic}
 	close(chunks)
-	buffered, closed, err := readStreamBootstrap(context.Background(), chunks)
+	buffered, closed, err := readStreamBootstrap(context.Background(), chunks, true)
 	if err != nil || closed || len(buffered) != 2 {
 		t.Fatalf("buffered=%v closed=%v err=%v", buffered, closed, err)
 	}
@@ -369,7 +393,7 @@ func TestReadStreamBootstrapProvisionalOnlyCloseFails(t *testing.T) {
 	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
 	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("start"), Commitment: cliproxyexecutor.StreamCommitmentProvisional}
 	close(chunks)
-	_, _, err := readStreamBootstrap(context.Background(), chunks)
+	_, _, err := readStreamBootstrap(context.Background(), chunks, true)
 	if err == nil {
 		t.Fatal("expected provisional-only stream failure")
 	}

--- a/sdk/cliproxy/auth/conductor_stream_recovery_test.go
+++ b/sdk/cliproxy/auth/conductor_stream_recovery_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 type recoverySequenceExecutor struct {
-	mu       sync.Mutex
-	attempts [][]cliproxyexecutor.StreamChunk
+	mu               sync.Mutex
+	attempts         [][]cliproxyexecutor.StreamChunk
 	calls            int
 	authIDs          []string
 	recoveryContexts []bool
@@ -26,10 +26,11 @@ func (e *recoverySequenceExecutor) Execute(context.Context, *Auth, cliproxyexecu
 	return cliproxyexecutor.Response{}, nil
 }
 
-func (e *recoverySequenceExecutor) ExecuteStream(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+func (e *recoverySequenceExecutor) ExecuteStream(ctx context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
 	e.mu.Lock()
 	call := e.calls
 	e.calls++
+	e.recoveryContexts = append(e.recoveryContexts, streamRecoveryFromContext(ctx) != nil)
 	if auth != nil {
 		e.authIDs = append(e.authIDs, auth.ID)
 	}
@@ -287,11 +288,14 @@ func TestRecoverySlotHeldUntilBufferedResultDrained(t *testing.T) {
 }
 
 func TestRecoveryOverflowHoldsSlotThroughRetainedPrefixAndOverflowChunk(t *testing.T) {
-	executor := &recoverySequenceExecutor{attempts: [][]cliproxyexecutor.StreamChunk{{
-		{Payload: []byte("abc"), Commitment: cliproxyexecutor.StreamCommitmentProvisional},
-		{Payload: []byte("def"), Commitment: cliproxyexecutor.StreamCommitmentSemantic},
-		{Payload: []byte("tail"), Commitment: cliproxyexecutor.StreamCommitmentTerminal},
-	}}}
+	executor := &recoverySequenceExecutor{attempts: [][]cliproxyexecutor.StreamChunk{
+		{
+			{Payload: []byte("abc"), Commitment: cliproxyexecutor.StreamCommitmentProvisional},
+			{Payload: []byte("def"), Commitment: cliproxyexecutor.StreamCommitmentSemantic},
+			{Payload: []byte("tail"), Commitment: cliproxyexecutor.StreamCommitmentTerminal},
+		},
+		{{Payload: []byte("second"), Commitment: cliproxyexecutor.StreamCommitmentUnknown}},
+	}}
 	manager := NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
 	auth := &Auth{ID: "overflow-slot-auth", Provider: "codex", Status: StatusActive}
@@ -302,14 +306,28 @@ func TestRecoveryOverflowHoldsSlotThroughRetainedPrefixAndOverflowChunk(t *testi
 	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
 	manager.RefreshSchedulerEntry(auth.ID)
 
-	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "overflow-slot-model"}, cliproxyexecutor.Options{Stream: true, StreamRecovery: cliproxyexecutor.StreamRecoveryPolicy{
-		Attempts: 1, MaxBufferBytes: 5, MaxRetryWindow: time.Second, MaxConcurrent: 1, InitialBackoff: time.Nanosecond, MaxBackoff: time.Nanosecond,
-	}})
+	policy := cliproxyexecutor.StreamRecoveryPolicy{Attempts: 1, MaxBufferBytes: 5, MaxRetryWindow: time.Second, MaxConcurrent: 1, InitialBackoff: time.Nanosecond, MaxBackoff: time.Nanosecond}
+	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "overflow-slot-model"}, cliproxyexecutor.Options{Stream: true, StreamRecovery: policy})
 	if err != nil {
 		t.Fatalf("ExecuteStream: %v", err)
 	}
 	if got := manager.recoveryInFlight.Load(); got != 1 {
 		t.Fatalf("recovery slots = %d before prefix drain, want 1", got)
+	}
+	second, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "overflow-slot-model"}, cliproxyexecutor.Options{Stream: true, StreamRecovery: policy})
+	if err != nil {
+		t.Fatalf("second ExecuteStream: %v", err)
+	}
+	for range second.Chunks {
+	}
+	executor.mu.Lock()
+	recoveryContexts := append([]bool(nil), executor.recoveryContexts...)
+	executor.mu.Unlock()
+	if len(recoveryContexts) != 2 || !recoveryContexts[0] || recoveryContexts[1] {
+		t.Fatalf("recovery contexts = %v, want [true false] while overflow slot is held", recoveryContexts)
+	}
+	if got := manager.recoveryInFlight.Load(); got != 1 {
+		t.Fatalf("recovery slots = %d after gated second request, want 1", got)
 	}
 	if chunk := <-result.Chunks; string(chunk.Payload) != "abc" {
 		t.Fatalf("prefix chunk = %q, want abc", chunk.Payload)

--- a/sdk/cliproxy/auth/conductor_stream_recovery_test.go
+++ b/sdk/cliproxy/auth/conductor_stream_recovery_test.go
@@ -174,6 +174,72 @@ func TestManagerExecuteStreamRecoveryRetriesSynchronousTransientStatuses(t *test
 	}
 }
 
+func TestManagerExecuteStreamRecoveryRetriesUntilWindowWithoutAttemptCap(t *testing.T) {
+	executor := &recoverySequenceExecutor{
+		attempts: [][]cliproxyexecutor.StreamChunk{
+			nil,
+			nil,
+			{{Payload: []byte("winning"), Commitment: cliproxyexecutor.StreamCommitmentTerminal}},
+		},
+		directErrors: []error{
+			&Error{Code: "server_is_overloaded", Message: "first temporary overload", HTTPStatus: http.StatusBadGateway},
+			&Error{Code: "server_is_overloaded", Message: "second temporary overload", HTTPStatus: http.StatusServiceUnavailable},
+			nil,
+		},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &Auth{ID: "duration-recovery-auth", Provider: "codex", Status: StatusActive}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	model := "duration-recovery-model"
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	manager.RefreshSchedulerEntry(auth.ID)
+
+	result, errExecute := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{Stream: true, StreamRecovery: cliproxyexecutor.StreamRecoveryPolicy{
+		Enabled: true, MaxBufferBytes: 1024, MaxRetryWindow: time.Second, MaxConcurrent: 1, InitialBackoff: time.Nanosecond, MaxBackoff: time.Nanosecond,
+	}})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream: %v", errExecute)
+	}
+	var payload string
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream error: %v", chunk.Err)
+		}
+		payload += string(chunk.Payload)
+	}
+	if payload != "winning" {
+		t.Fatalf("payload = %q, want winning", payload)
+	}
+	if executor.calls != 3 {
+		t.Fatalf("calls = %d, want 3", executor.calls)
+	}
+}
+
+func TestStreamRecoveryEligibilitySeparatesTransientUpstreamFromRateLimits(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "upstream bad gateway", err: &Error{HTTPStatus: http.StatusBadGateway}, want: true},
+		{name: "upstream unavailable", err: &Error{HTTPStatus: http.StatusServiceUnavailable}, want: true},
+		{name: "rate limit", err: &Error{HTTPStatus: http.StatusTooManyRequests}, want: false},
+		{name: "authentication", err: &Error{HTTPStatus: http.StatusUnauthorized}, want: false},
+		{name: "client cancellation", err: context.Canceled, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isEligibleStreamRecoveryError(tt.err); got != tt.want {
+				t.Fatalf("isEligibleStreamRecoveryError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExecuteStreamWithRecoveryPreservesSynchronousErrorOnExhaustion(t *testing.T) {
 	firstErr := &Error{Code: "server_is_overloaded", Message: "first temporary overload", HTTPStatus: http.StatusBadGateway}
 	finalErr := &Error{Code: "server_is_overloaded", Message: "final structured overload", HTTPStatus: http.StatusServiceUnavailable}
@@ -569,7 +635,7 @@ func TestRecoveryCancellationDuringBufferingDoesNotCooldown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	resultCh := make(chan error, 1)
 	go func() {
-		_, err := manager.ExecuteStream(ctx, []string{"codex"}, cliproxyexecutor.Request{Model: "cancel-model"}, cliproxyexecutor.Options{Stream: true, StreamRecovery: cliproxyexecutor.StreamRecoveryPolicy{Attempts: 1, MaxBufferBytes: 1024, MaxRetryWindow: time.Second, MaxConcurrent: 1, InitialBackoff: time.Second, MaxBackoff: time.Second}})
+		_, err := manager.ExecuteStream(ctx, []string{"codex"}, cliproxyexecutor.Request{Model: "cancel-model"}, cliproxyexecutor.Options{Stream: true, StreamRecovery: cliproxyexecutor.StreamRecoveryPolicy{Enabled: true, MaxBufferBytes: 1024, MaxRetryWindow: time.Second, MaxConcurrent: 1, InitialBackoff: time.Second, MaxBackoff: time.Second}})
 		resultCh <- err
 	}()
 	<-executor.started
@@ -655,13 +721,25 @@ func TestCollectRecoveryAttemptOverflowPreservesLaterError(t *testing.T) {
 }
 
 func TestStreamRecoveryBudgetAndWindow(t *testing.T) {
-	state := &streamRecoveryState{policy: cliproxyexecutor.StreamRecoveryPolicy{MaxRetryWindow: time.Second}, started: time.Now(), remaining: 1}
+	state := &streamRecoveryState{policy: cliproxyexecutor.StreamRecoveryPolicy{Attempts: 1, MaxRetryWindow: time.Second}, started: time.Now(), remaining: 1}
 	if !state.canRetry() || state.canRetry() {
 		t.Fatal("attempt budget was not enforced exactly")
 	}
-	state = &streamRecoveryState{policy: cliproxyexecutor.StreamRecoveryPolicy{MaxRetryWindow: time.Nanosecond}, started: time.Now().Add(-time.Second), remaining: 1}
+	state = &streamRecoveryState{policy: cliproxyexecutor.StreamRecoveryPolicy{Attempts: 1, MaxRetryWindow: time.Nanosecond}, started: time.Now().Add(-time.Second), remaining: 1}
 	if state.canRetry() {
 		t.Fatal("retry started after retry window")
+	}
+	state = &streamRecoveryState{policy: cliproxyexecutor.StreamRecoveryPolicy{Enabled: true, MaxRetryWindow: time.Second}, started: time.Now()}
+	if !state.canRetry() || !state.canRetry() {
+		t.Fatal("duration-only recovery unexpectedly enforced an attempt cap")
+	}
+	state.started = time.Now().Add(-2 * time.Second)
+	if state.canRetry() {
+		t.Fatal("duration-only recovery started after retry window")
+	}
+	state = &streamRecoveryState{policy: cliproxyexecutor.StreamRecoveryPolicy{Enabled: true}, started: time.Now()}
+	if state.canRetry() {
+		t.Fatal("duration-only recovery started without a retry window")
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_unauthorized_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_unauthorized_refresh_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -156,6 +157,37 @@ func newUnauthorizedRefreshFixture(t *testing.T, refreshFail bool) (*Manager, *u
 	}
 
 	return m, executor, primary, backup, model
+}
+
+func TestManager_ExecuteStreamRecoveryRefreshesUnauthorizedWithoutChargingBudget(t *testing.T) {
+	m, executor, primary, backup, model := newUnauthorizedRefreshFixture(t, false)
+	result, err := m.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{Stream: true, StreamRecovery: cliproxyexecutor.StreamRecoveryPolicy{
+		Attempts:       1,
+		MaxBufferBytes: 1024,
+		MaxRetryWindow: time.Second,
+		MaxConcurrent:  1,
+		InitialBackoff: time.Nanosecond,
+		MaxBackoff:     time.Nanosecond,
+	}})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream error: %v", chunk.Err)
+		}
+	}
+	if got := executor.RefreshCalls(); got != 1 {
+		t.Fatalf("Refresh calls = %d, want 1", got)
+	}
+	if got := executor.StreamCalls(); len(got) != 2 || got[0] != primary.ID || got[1] != primary.ID {
+		t.Fatalf("Stream calls = %v, want refreshed primary twice", got)
+	}
+	for _, id := range executor.StreamCalls() {
+		if id == backup.ID {
+			t.Fatalf("backup auth used during refresh recovery")
+		}
+	}
 }
 
 func TestManager_Execute_UnauthorizedRefreshesCurrentAuthBeforeFallback(t *testing.T) {

--- a/sdk/cliproxy/auth/response_model_rewriter.go
+++ b/sdk/cliproxy/auth/response_model_rewriter.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"bytes"
 
+	internalsse "github.com/router-for-me/CLIProxyAPI/v7/internal/sse"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -74,14 +75,14 @@ func (r *StreamRewriter) RewriteChunk(chunk []byte) []byte {
 	if len(r.pendingBuf) > 0 {
 		combined := make([]byte, 0, len(r.pendingBuf)+1+len(chunk))
 		combined = append(combined, r.pendingBuf...)
-		if combined[len(combined)-1] != '\n' {
+		if combined[len(combined)-1] != '\n' && bytes.HasPrefix(bytes.TrimSpace(r.pendingBuf), []byte("event:")) && bytes.HasPrefix(bytes.TrimSpace(chunk), []byte("data:")) {
 			combined = append(combined, '\n')
 		}
 		combined = append(combined, chunk...)
 		chunk = combined
 		r.pendingBuf = nil
 	}
-	chunk = normalizeGluedSSEEvents(chunk)
+	chunk = internalsse.NormalizeGluedFrames(chunk)
 
 	if len(chunk) > maxPendingBufSize {
 		return chunk
@@ -204,54 +205,7 @@ func extractSSEDataLine(line []byte) (prefix []byte, jsonData []byte, ok bool) {
 }
 
 func normalizeGluedSSEEvents(chunk []byte) []byte {
-	if len(chunk) == 0 {
-		return chunk
-	}
-	// Antigravity/Gemini translators emit event frames without trailing blank lines.
-	// When multiple frames are buffered back-to-back they can glue as "...}event:...".
-	// Only split when the bytes before the glue close a valid SSE data JSON object.
-	chunk = safeReplaceGlued(chunk, []byte("}event:"), []byte("}\n\nevent:"))
-	chunk = safeReplaceGlued(chunk, []byte("}\r\nevent:"), []byte("}\r\n\r\nevent:"))
-	// Codex executor emits one "data: {json}" chunk per SSE line without trailing newlines.
-	// Buffered chunks can glue as "...}data:...".
-	chunk = safeReplaceGlued(chunk, []byte("}data:"), []byte("}\ndata:"))
-	chunk = safeReplaceGlued(chunk, []byte("}\r\ndata:"), []byte("}\r\ndata:"))
-	return chunk
-}
-
-func safeReplaceGlued(chunk []byte, old, new []byte) []byte {
-	if len(old) == 0 || len(chunk) == 0 {
-		return chunk
-	}
-	if !bytes.Contains(chunk, old) {
-		return chunk
-	}
-	var result []byte
-	remaining := chunk
-	for {
-		idx := bytes.Index(remaining, old)
-		if idx == -1 {
-			result = append(result, remaining...)
-			break
-		}
-		lineStart := bytes.LastIndexByte(remaining[:idx], '\n')
-		var part []byte
-		if lineStart == -1 {
-			part = remaining[:idx+1]
-		} else {
-			part = remaining[lineStart+1 : idx+1]
-		}
-		_, jsonData, ok := extractSSEDataLine(part)
-		if ok && len(jsonData) > 0 && gjson.ValidBytes(jsonData) {
-			result = append(result, remaining[:idx]...)
-			result = append(result, new...)
-			remaining = remaining[idx+len(old):]
-			continue
-		}
-		result = append(result, remaining[:idx+len(old)]...)
-		remaining = remaining[idx+len(old):]
-	}
-	return result
+	return internalsse.NormalizeGluedFrames(chunk)
 }
 
 // Finish flushes any buffered partial SSE data at the end of a stream.
@@ -263,7 +217,7 @@ func (r *StreamRewriter) Finish() []byte {
 	copy(buf, r.pendingBuf)
 	buf[len(r.pendingBuf)] = '\n'
 	buf[len(r.pendingBuf)+1] = '\n'
-	buf = normalizeGluedSSEEvents(buf)
+	buf = internalsse.NormalizeGluedFrames(buf)
 	r.pendingBuf = nil
 	out := r.RewriteChunk(buf)
 	if len(r.pendingBuf) > 0 {

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"time"
 
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 )
@@ -161,6 +162,26 @@ type Options struct {
 	RequestAfterAuthInterceptor RequestAfterAuthInterceptor
 	// ExecutionLifecycle owns Home-dispatched execution resources. Executors must not add it to request metadata.
 	ExecutionLifecycle ExecutionLifecycle
+	// StreamRecovery is an immutable request-scoped snapshot of streaming retry policy.
+	StreamRecovery StreamRecoveryPolicy
+}
+
+// StreamRecoveryPolicy bounds pre-commit streaming retries.
+type StreamRecoveryPolicy struct {
+	// BootstrapRetries preserves legacy retries before semantic stream commitment.
+	BootstrapRetries int
+	// Attempts is the number of additional full-stream attempts.
+	Attempts int
+	// MaxBufferBytes bounds retained translated output before recovery fails open.
+	MaxBufferBytes int
+	// MaxRetryWindow limits when a new attempt may begin.
+	MaxRetryWindow time.Duration
+	// MaxConcurrent limits simultaneous full-buffer recovery requests.
+	MaxConcurrent int
+	// InitialBackoff is the first retry delay ceiling.
+	InitialBackoff time.Duration
+	// MaxBackoff caps retry delay growth.
+	MaxBackoff time.Duration
 }
 
 // ResponseFormatOrSource returns the response target format for an execution.
@@ -181,12 +202,28 @@ type Response struct {
 	Headers http.Header
 }
 
+// StreamCommitment describes whether a stream chunk commits downstream-visible semantics.
+type StreamCommitment uint8
+
+const (
+	// StreamCommitmentUnknown preserves conservative first-payload behavior for existing executors.
+	StreamCommitmentUnknown StreamCommitment = iota
+	// StreamCommitmentProvisional is administrative framing that may be withheld safely.
+	StreamCommitmentProvisional
+	// StreamCommitmentSemantic contains user-visible content or tool semantics.
+	StreamCommitmentSemantic
+	// StreamCommitmentTerminal completes a valid stream response.
+	StreamCommitmentTerminal
+)
+
 // StreamChunk represents a single streaming payload unit emitted by provider executors.
 type StreamChunk struct {
 	// Payload is the raw provider chunk payload.
 	Payload []byte
 	// Err reports any terminal error encountered while producing chunks.
 	Err error
+	// Commitment classifies downstream commitment. Unknown is conservative for compatibility.
+	Commitment StreamCommitment
 }
 
 // StreamResult wraps the streaming response, providing both the chunk channel

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -170,7 +170,10 @@ type Options struct {
 type StreamRecoveryPolicy struct {
 	// BootstrapRetries preserves legacy retries before semantic stream commitment.
 	BootstrapRetries int
-	// Attempts is the number of additional full-stream attempts.
+	// Enabled allows duration-only recovery when Attempts is zero.
+	Enabled bool
+	// Attempts is the number of additional full-stream attempts. Zero means no
+	// attempt limit when Enabled is true.
 	Attempts int
 	// MaxBufferBytes bounds retained translated output before recovery fails open.
 	MaxBufferBytes int

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -11,6 +11,7 @@ type SDKConfig = internalconfig.SDKConfig
 type Config = internalconfig.Config
 
 type StreamingConfig = internalconfig.StreamingConfig
+type StreamingRecoveryConfig = internalconfig.StreamingRecoveryConfig
 type ClaudeCodeConfig = internalconfig.ClaudeCodeConfig
 type TLSConfig = internalconfig.TLSConfig
 type RemoteManagement = internalconfig.RemoteManagement


### PR DESCRIPTION
## Summary

- add opt-in, bounded full-stream recovery for transient Codex/OpenAI Responses failures;
- buffer translated output until terminal success and release only the winning attempt;
- retry the same selected auth/model route before normal cooldown and fallback accounting;
- preserve one-time unauthorized refresh, request cancellation, pinned auth, Home dispatch behavior, and legacy bootstrap compatibility;
- add a shared bounded SSE framer that handles split, CRLF, glued, and in-string marker edge cases;
- move streaming retry ownership into the conductor so handlers and interceptors never observe losing attempts.

Fixes #4642.

## Why this matters

When Codex is reachable but transiently returns 502/503/504 or ends a stream before completion, normal cooldown accounting can make immediate client retries fail locally with `503 auth_unavailable`. Duration-bounded recovery keeps the original request inside CPA, retries the same route, and exposes only the winning response until the configured deadline or client cancellation. Rate limits, authentication failures, and invalid requests remain excluded.

## Root cause

Codex `response.created` is translated into Claude `message_start`, and the existing bootstrap layers treated the first non-empty translated chunk as irreversible commitment. A later HTTP-200 terminal SSE `server_error` was therefore surfaced as 502 instead of being recoverable inside the proxy. Normal transient failure accounting could then place the only credential/model into a 60-second cooldown, causing immediate Claude Code retries to return `503 auth_unavailable` when the configured retry wait ceiling was shorter.

## Behavior

When recovery is enabled explicitly or with a positive attempt cap:

1. the conductor acquires a nonblocking bounded recovery slot;
2. translated chunks are retained until a valid terminal event;
3. eligible 408/500/502/503/504/529, generic terminal `server_error`, incomplete EOF, and temporary transport failures may retry within one request-scoped budget;
4. retries remain on the selected route before normal failure accounting;
5. a successful attempt replaces all losing chunks and headers;
6. cancellation stops buffering/backoff without cooling the credential;
7. generic 502 exhaustion receives normal cooldown/fallback handling, while request-scoped incomplete-stream 408 remains availability-neutral;
8. byte overflow or concurrency saturation fails open to ordinary streaming and permanently disables replay for that request.

No timeout is added to an established upstream connection. `max-retry-window-seconds` only limits whether another attempt may begin.

## Configuration

Recovery is disabled by default:

```yaml
streaming:
  recovery:
    enabled: false
    attempts: 0 # no attempt cap when enabled; positive values retain compatibility mode
    max-buffer-bytes: 8388608
    max-retry-window-seconds: 20 # retry-start deadline; maximum 3600
    max-concurrent: 16
    initial-backoff-milliseconds: 250
    max-backoff-milliseconds: 2000
```

All numeric settings are normalized to explicit safe upper bounds before `time.Duration` or atomic-counter conversion.

## Safety properties

- no replay after downstream bytes;
- no losing attempt reaches response interceptors or client history;
- exact shared attempt/deadline budget across model/auth selection;
- bounded retained bytes and concurrent buffered responses;
- overflow chunk is forwarded exactly once without cloning it before the cap check;
- recovery slot remains held until the buffered response is drained or canceled;
- one-time 401 refresh does not consume the transient recovery budget;
- Home dispatch does not enable recovery or redispatch;
- existing executors remain conservative through zero-value `StreamCommitmentUnknown`.

## Tests

Added coverage for:

- config defaults, bounds, duration-only mode, cloning, diff output, and extreme-value normalization;
- generic Codex `error` / `response.failed` server errors and stream commitments;
- queued/created/in-progress lifecycle events as provisional;
- three-or-more glued SSE events, CRLF, split input, partial final frames, in-string `}data:`/`}event:` markers followed by real boundaries, and scanner limits;
- losing-attempt discard and winning headers/chunks only;
- cancellation during buffering and backoff with no cooldown or second request;
- recovery-enabled unauthorized refresh;
- exact attempt/window budget, pinned auth, Home disablement, concurrency gate lifetime, overflow ordering, and overflow followed by a later visible error;
- request-scoped incomplete 408 exhaustion without cooldown/fallback;
- generic 502 exhaustion with normal cooldown;
- real `BaseAPIHandler` + `CodexExecutor` + `httptest.Server` two-attempt Claude recovery, proving one downstream `message_start`, no losing response ID, no error event, and a complete winning stream.

Validation performed on current `upstream/dev` (`c9417c8a`):

```text
go test ./... -count=1 -timeout=15m
PASS

go test -race ./internal/sse ./sdk/cliproxy/auth ./sdk/api/handlers \
  -run 'Test.*(Recovery|SSE|Cancellation|Overflow|Unauthorized|Slot|Home|Pinned)' -count=1
PASS

go vet ./internal/sse ./internal/config ./internal/runtime/executor \
  ./sdk/cliproxy/auth ./sdk/api/handlers/...
PASS

go build -o test-output ./cmd/server && rm test-output
PASS

git diff --check
PASS
```

## Related work

- #4634 was closed as not planned. This PR does not add provider/model circuit state or fail-fast admission; it continues CPA's request-completion priority with bounded retries only inside the active request.
- #4580 provides narrower syntactic-prefix bootstrap recovery and overlaps the same bootstrap ownership. If #4580 lands first, this branch should rebase onto it and retain that default-path fix; the two should not merge independently without reconciliation.
- #4459 provides the shared pre-first-chunk keep-alive helper needed when full recovery intentionally delays the first semantic response. To avoid duplicating that active contribution, this PR is draft pending maintainer direction on stacking/rebasing; it should not merge with `streaming.keepalive-seconds` enabled until the two are reconciled.
- #4584 covers HTTP 503/529 retry policy and has separate conductor integration concerns.
- #3229 covers capacity-specific Codex SSE classification.
- #4635 preserves HTTP non-2xx Codex response headers and `Retry-After`; this PR does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)