### PR TITLE
feat(session): unify session identity and identify sub-agents from real client signals

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -205,9 +205,16 @@ routing:
   # Non-positive weights exclude the credential while this strategy is active.
   # For OAuth/file credentials, add a top-level numeric "weight" field to the auth JSON.
   # Enable universal session-sticky routing for all clients.
-  # Explicit Claude Code, Codex, OpenCode, and pi session headers are preferred,
-  # followed by prompt_cache_key, Responses conversation IDs, legacy body IDs,
-  # execution or derived session identity, and the existing first-message hash fallback.
+  # All recognized explicit session identifiers (such as X-Gateway-Session-Id,
+  # native Claude Code, Codex, OpenCode, or pi session headers, prompt_cache_key,
+  # Responses conversation IDs, and request body session/conversation IDs) are
+  # bound together as aliases. Only when zero explicit root session identifiers
+  # exist will user metadata, execution session, thread ID, derived session identity,
+  # or the message-content hash fallback be used.
+  # Clients you control can send X-Gateway-Session-Id, X-Gateway-Client,
+  # X-Gateway-Thread-Id and X-Gateway-Parent-Thread-Id to identify sessions explicitly.
+  # Bindings are namespaced per downstream API key, so two callers reusing the
+  # same client session ID never share one credential.
   # Automatic failover is always enabled when bound auth becomes unavailable.
   session-affinity: false # default: false
   # How long session-to-auth bindings are retained. Default: 1h

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	cliproxyhome "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -132,7 +133,7 @@ type codexSearchHomeDispatcher struct {
 
 func (*codexSearchHomeDispatcher) HeartbeatOK() bool { return true }
 
-func (d *codexSearchHomeDispatcher) RPopAuth(_ context.Context, model string, _ string, _ http.Header, _ int) ([]byte, error) {
+func (d *codexSearchHomeDispatcher) RPopAuth(_ context.Context, model string, _ cliproxyhome.DispatchSession, _ http.Header, _ int) ([]byte, error) {
 	d.calls.Add(1)
 	return json.Marshal(map[string]any{
 		"model":      model,
@@ -156,7 +157,7 @@ func (*codexSearchHomeDispatcher) AbortAmbiguousDispatch() {}
 type codexSearchBusyHomeDispatcher struct{}
 
 func (*codexSearchBusyHomeDispatcher) HeartbeatOK() bool { return true }
-func (*codexSearchBusyHomeDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (*codexSearchBusyHomeDispatcher) RPopAuth(context.Context, string, cliproxyhome.DispatchSession, http.Header, int) ([]byte, error) {
 	return []byte(`{"error":{"type":"credential_concurrency_exceeded","message":"busy","retry_after_ms":750}}`), nil
 }
 func (*codexSearchBusyHomeDispatcher) AbortAmbiguousDispatch() {}

--- a/internal/client/codex/live/live_test.go
+++ b/internal/client/codex/live/live_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	cpahome "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -98,7 +99,7 @@ type homeDispatcher struct {
 
 func (*homeDispatcher) HeartbeatOK() bool { return true }
 
-func (d *homeDispatcher) RPopAuth(_ context.Context, model string, _ string, _ http.Header, _ int) ([]byte, error) {
+func (d *homeDispatcher) RPopAuth(_ context.Context, model string, _ cpahome.DispatchSession, _ http.Header, _ int) ([]byte, error) {
 	d.model = model
 	return json.Marshal(map[string]any{
 		"model":      model,

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -207,9 +207,14 @@ type RoutingConfig struct {
 	Strategy string `yaml:"strategy,omitempty" json:"strategy,omitempty"`
 
 	// SessionAffinity enables universal session-sticky routing for all clients.
-	// Explicit Claude Code, Codex, OpenCode, and pi session headers are preferred,
-	// followed by prompt_cache_key, Responses conversation IDs, legacy body IDs,
-	// execution or derived session identity, and the existing message-content hash fallback.
+	// All recognized explicit session identifiers (such as X-Gateway-Session-Id,
+	// native Claude Code, Codex, OpenCode, or pi session headers, prompt_cache_key,
+	// Responses conversation IDs, and request body session/conversation IDs) are
+	// bound together as aliases. Only when zero explicit root session identifiers
+	// exist will user metadata, execution session, thread ID, derived session identity,
+	// or the message-content hash fallback be used.
+	// Bindings are namespaced per downstream API key, so two callers reusing the
+	// same client session ID never share one credential.
 	// Automatic failover is always enabled when bound auth becomes unavailable.
 	SessionAffinity bool `yaml:"session-affinity,omitempty" json:"session-affinity,omitempty"`
 

--- a/internal/home/client.go
+++ b/internal/home/client.go
@@ -1216,21 +1216,26 @@ func queryToLowerMap(query url.Values) map[string]string {
 	return out
 }
 
-func newAuthDispatchRequest(requestedModel string, sessionID string, headers http.Header, count int) authDispatchRequest {
+func newAuthDispatchRequest(requestedModel string, session DispatchSession, headers http.Header, count int) authDispatchRequest {
 	if count <= 0 {
 		count = 1
 	}
-	return authDispatchRequest{
+	req := authDispatchRequest{
 		Type:                "auth",
 		Model:               requestedModel,
 		Count:               count,
 		ConcurrencyProtocol: 1,
-		SessionID:           strings.TrimSpace(sessionID),
+		SessionID:           strings.TrimSpace(session.ID),
 		Headers:             headersToLowerMap(headers),
 	}
+	if req.SessionID != "" {
+		session.ID = req.SessionID
+		req.Session = &session
+	}
+	return req
 }
 
-func (c *Client) RPopAuth(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int) ([]byte, error) {
+func (c *Client) RPopAuth(ctx context.Context, requestedModel string, session DispatchSession, headers http.Header, count int) ([]byte, error) {
 	if c == nil || c.dispatchFenced.Load() {
 		return nil, ErrDispatchFenced
 	}
@@ -1244,7 +1249,7 @@ func (c *Client) RPopAuth(ctx context.Context, requestedModel string, sessionID 
 	if requestedModel == "" {
 		return nil, fmt.Errorf("home: requested model is empty")
 	}
-	req := newAuthDispatchRequest(requestedModel, sessionID, headers, count)
+	req := newAuthDispatchRequest(requestedModel, session, headers, count)
 	keyBytes, errMarshal := json.Marshal(&req)
 	if errMarshal != nil {
 		return nil, errMarshal

--- a/internal/home/client_test.go
+++ b/internal/home/client_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestAuthDispatchRequestIncludesCount(t *testing.T) {
-	req := newAuthDispatchRequest("gpt-5.4", "session-1", http.Header{"Authorization": {"Bearer test"}}, 2)
+	req := newAuthDispatchRequest("gpt-5.4", DispatchSession{ID: "session-1"}, http.Header{"Authorization": {"Bearer test"}}, 2)
 
 	raw, err := json.Marshal(&req)
 	if err != nil {
@@ -46,7 +46,7 @@ func TestAuthDispatchRequestIncludesCount(t *testing.T) {
 }
 
 func TestAuthDispatchRequestDefaultsCountToOne(t *testing.T) {
-	req := newAuthDispatchRequest("gpt-5.4", "", nil, 0)
+	req := newAuthDispatchRequest("gpt-5.4", DispatchSession{}, nil, 0)
 
 	if req.Count != 1 {
 		t.Fatalf("count = %d, want 1", req.Count)
@@ -1648,7 +1648,7 @@ func TestRPopAuthLeavesCompleteServerErrorDeterministic(t *testing.T) {
 	})
 	client.heartbeatOK.Store(true)
 
-	_, errRPop := client.RPopAuth(context.Background(), "gpt-5.4", "", nil, 1)
+	_, errRPop := client.RPopAuth(context.Background(), "gpt-5.4", DispatchSession{}, nil, 1)
 	if errRPop == nil {
 		t.Fatal("RPopAuth() error = nil, want server failure")
 	}
@@ -1695,7 +1695,7 @@ func TestRPopAuthRejectsPreCanceledContextBeforeRequest(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, errRPop := client.RPopAuth(ctx, "gpt-5.4", "", nil, 1)
+	_, errRPop := client.RPopAuth(ctx, "gpt-5.4", DispatchSession{}, nil, 1)
 	if !errors.Is(errRPop, context.Canceled) {
 		t.Fatalf("RPopAuth() error = %v, want context.Canceled", errRPop)
 	}
@@ -1711,7 +1711,7 @@ func TestRPopAuthMarksRequestReadThenCloseAmbiguous(t *testing.T) {
 	client, requestRead, release := newBlockingRPopTestClient(t)
 	result := make(chan error, 1)
 	go func() {
-		_, errRPop := client.RPopAuth(context.Background(), "gpt-5.4", "", nil, 1)
+		_, errRPop := client.RPopAuth(context.Background(), "gpt-5.4", DispatchSession{}, nil, 1)
 		result <- errRPop
 	}()
 	select {
@@ -1764,7 +1764,7 @@ func TestRPopAuthLeavesHELLOSetupInterruptionDeterministic(t *testing.T) {
 	client := New(config.HomeConfig{Enabled: true, Host: host, Port: port, DisableClusterDiscovery: true})
 	t.Cleanup(client.Close)
 
-	_, errRPop := client.RPopAuth(context.Background(), "gpt-5.4", "", nil, 1)
+	_, errRPop := client.RPopAuth(context.Background(), "gpt-5.4", DispatchSession{}, nil, 1)
 	if errRPop == nil {
 		t.Fatal("RPopAuth() error = nil, want setup interruption")
 	}
@@ -1837,7 +1837,7 @@ func TestAbortAmbiguousDispatchClosesBlockedRPopWithoutWaitingForResponse(t *tes
 	client.heartbeatOK.Store(true)
 	result := make(chan error, 1)
 	go func() {
-		_, errRPop := client.RPopAuth(context.Background(), "gpt-5.4", "", nil, 1)
+		_, errRPop := client.RPopAuth(context.Background(), "gpt-5.4", DispatchSession{}, nil, 1)
 		result <- errRPop
 	}()
 	select {
@@ -1884,7 +1884,7 @@ func TestAbortAmbiguousDispatchClosesBlockedRPopWithoutWaitingForResponse(t *tes
 func TestRPopAuthLeavesPreSendFailureDeterministic(t *testing.T) {
 	client := New(config.HomeConfig{Enabled: true, Host: "127.0.0.1", Port: 6379})
 
-	_, errRPop := client.RPopAuth(context.Background(), "", "", nil, 1)
+	_, errRPop := client.RPopAuth(context.Background(), "", DispatchSession{}, nil, 1)
 	if errRPop == nil {
 		t.Fatal("RPopAuth() error = nil, want requested model validation failure")
 	}
@@ -1922,7 +1922,7 @@ func TestAbortAmbiguousDispatchFencesConcurrentRPop(t *testing.T) {
 		workers.Add(1)
 		go func() {
 			defer workers.Done()
-			_, errRPop := client.RPopAuth(context.Background(), "gpt-5.4", "", nil, 1)
+			_, errRPop := client.RPopAuth(context.Background(), "gpt-5.4", DispatchSession{}, nil, 1)
 			errs <- errRPop
 		}()
 	}

--- a/internal/home/dispatch_session_test.go
+++ b/internal/home/dispatch_session_test.go
@@ -1,0 +1,86 @@
+package home
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Home versions that predate the structured session object read session_id,
+// so both representations have to travel together.
+func TestAuthDispatchRequestCarriesStructuredSessionAndLegacyID(t *testing.T) {
+	req := newAuthDispatchRequest("gpt-5.4", DispatchSession{
+		ID:             "pck:cache-1",
+		Aliases:        []string{"conv:conv_1"},
+		Source:         "prompt_cache_key",
+		Confidence:     "medium",
+		Scope:          "session",
+		ClientType:     "codex",
+		ThreadID:       "thread-1",
+		ParentThreadID: "thread-0",
+		ClientProvided: true,
+	}, nil, 1)
+
+	raw, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("marshal auth dispatch request: %v", err)
+	}
+	var payload struct {
+		SessionID string `json:"session_id"`
+		Session   *struct {
+			ID             string   `json:"id"`
+			Aliases        []string `json:"aliases"`
+			Source         string   `json:"source"`
+			Confidence     string   `json:"confidence"`
+			Scope          string   `json:"scope"`
+			ClientType     string   `json:"client_type"`
+			ThreadID       string   `json:"thread_id"`
+			ParentThreadID string   `json:"parent_thread_id"`
+			ClientProvided bool     `json:"client_provided"`
+		} `json:"session"`
+	}
+	if errUnmarshal := json.Unmarshal(raw, &payload); errUnmarshal != nil {
+		t.Fatalf("unmarshal auth dispatch request: %v", errUnmarshal)
+	}
+
+	if payload.SessionID != "pck:cache-1" {
+		t.Fatalf("session_id = %q, want pck:cache-1", payload.SessionID)
+	}
+	if payload.Session == nil {
+		t.Fatal("session object is missing")
+	}
+	if payload.Session.ID != "pck:cache-1" {
+		t.Fatalf("session.id = %q, want pck:cache-1", payload.Session.ID)
+	}
+	if len(payload.Session.Aliases) != 1 || payload.Session.Aliases[0] != "conv:conv_1" {
+		t.Fatalf("session.aliases = %#v, want [conv:conv_1]", payload.Session.Aliases)
+	}
+	if payload.Session.Source != "prompt_cache_key" || payload.Session.Confidence != "medium" ||
+		payload.Session.Scope != "session" || payload.Session.ClientType != "codex" {
+		t.Fatalf("session classification = %#v, want the identity CPA resolved", payload.Session)
+	}
+	if payload.Session.ThreadID != "thread-1" || payload.Session.ParentThreadID != "thread-0" {
+		t.Fatalf("session thread fields = %#v, want thread-1/thread-0", payload.Session)
+	}
+	if !payload.Session.ClientProvided {
+		t.Fatal("session.client_provided = false, want true")
+	}
+}
+
+func TestAuthDispatchRequestOmitsSessionWhenUnresolved(t *testing.T) {
+	req := newAuthDispatchRequest("gpt-5.4", DispatchSession{ClientType: "openai-sdk"}, nil, 1)
+
+	raw, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("marshal auth dispatch request: %v", err)
+	}
+	var payload map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &payload); errUnmarshal != nil {
+		t.Fatalf("unmarshal auth dispatch request: %v", errUnmarshal)
+	}
+	if _, exists := payload["session"]; exists {
+		t.Fatalf("session object was sent without a resolved session: %v", payload["session"])
+	}
+	if _, exists := payload["session_id"]; exists {
+		t.Fatalf("session_id was sent without a resolved session: %v", payload["session_id"])
+	}
+}

--- a/internal/home/requests.go
+++ b/internal/home/requests.go
@@ -2,13 +2,42 @@ package home
 
 import "time"
 
+// DispatchSession describes the session identity CPA resolved for a request.
+// CPA sees the full HTTP request, so its classification is authoritative; Home
+// validates the bounded values instead of re-deriving them from headers.
+type DispatchSession struct {
+	// ID is the canonical namespaced session identifier CPA routed on.
+	ID string `json:"id"`
+	// Aliases lists other identifiers addressing the same session, such as a
+	// Responses conversation ID observed alongside a prompt_cache_key. They let
+	// Home reconcile sessions that different CPA nodes saw through different signals.
+	Aliases []string `json:"aliases,omitempty"`
+	// Source names the signal the identifier came from.
+	Source string `json:"source,omitempty"`
+	// Confidence reports how strongly the identifier represents one conversation.
+	Confidence string `json:"confidence,omitempty"`
+	// Scope reports whether the identifier addresses a session, thread, user, or transport.
+	Scope string `json:"scope,omitempty"`
+	// ClientType names the detected downstream client.
+	ClientType string `json:"client_type,omitempty"`
+	// ThreadID and ParentThreadID are observability fields for sub-agent and fork
+	// relationships. They never replace the root session.
+	ThreadID       string `json:"thread_id,omitempty"`
+	ParentThreadID string `json:"parent_thread_id,omitempty"`
+	// ClientProvided reports whether the client sent the identifier itself.
+	ClientProvided bool `json:"client_provided,omitempty"`
+}
+
 type authDispatchRequest struct {
-	Type                string            `json:"type"`
-	Model               string            `json:"model"`
-	Count               int               `json:"count"`
-	ConcurrencyProtocol int               `json:"concurrency_protocol,omitempty"`
-	SessionID           string            `json:"session_id,omitempty"`
-	Headers             map[string]string `json:"headers,omitempty"`
+	Type                string `json:"type"`
+	Model               string `json:"model"`
+	Count               int    `json:"count"`
+	ConcurrencyProtocol int    `json:"concurrency_protocol,omitempty"`
+	// SessionID stays for Home versions that predate the structured session object.
+	SessionID string `json:"session_id,omitempty"`
+	// Session carries the structured identity. Older Home versions ignore it.
+	Session *DispatchSession  `json:"session,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
 }
 
 type modelsRequest struct {

--- a/internal/home/requests.go
+++ b/internal/home/requests.go
@@ -24,6 +24,13 @@ type DispatchSession struct {
 	// relationships. They never replace the root session.
 	ThreadID       string `json:"thread_id,omitempty"`
 	ParentThreadID string `json:"parent_thread_id,omitempty"`
+	// RequestKind, ThreadSource and TurnID are observability fields the client
+	// reported about this request: what kind of work it is (a conversation turn
+	// versus compaction, title generation or other housekeeping), where the thread
+	// came from, and which client turn it belongs to. They never affect routing.
+	RequestKind  string `json:"request_kind,omitempty"`
+	ThreadSource string `json:"thread_source,omitempty"`
+	TurnID       string `json:"turn_id,omitempty"`
 	// ClientProvided reports whether the client sent the identifier itself.
 	ClientProvided bool `json:"client_provided,omitempty"`
 }

--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -3459,3 +3459,49 @@ func (failingReadCloser) Read(p []byte) (int, error) {
 func (failingReadCloser) Close() error {
 	return nil
 }
+
+// TestUsageAdapterForwardsSessionObservations covers the session fields plugins
+// need to attribute a record to a conversation. They are a plain field copy, so
+// without this test a dropped line would silently publish empty values.
+func TestUsageAdapterForwardsSessionObservations(t *testing.T) {
+	var got pluginapi.UsageSession
+	plugin := usagePluginFunc(func(_ context.Context, record pluginapi.UsageRecord) {
+		got = record.Session
+	})
+	host := newHostWithRecords(capabilityRecord{
+		id: "usage-session",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			UsagePlugin: plugin,
+		}},
+	})
+	adapter := &usageAdapter{host: host, pluginID: "usage-session"}
+
+	want := coreusage.SessionInfo{
+		ID:             "codex:019fa90b",
+		Source:         "client_native_header",
+		Confidence:     "high",
+		Scope:          "session",
+		ClientType:     "codex",
+		ThreadID:       "thread-child",
+		ParentThreadID: "thread-root",
+		RequestKind:    "compact",
+		ThreadSource:   "subagent",
+		TurnID:         "turn-1",
+	}
+	adapter.HandleUsage(context.Background(), coreusage.Record{Provider: "openai", Model: "gpt-5.4", Session: want})
+
+	if got != (pluginapi.UsageSession{
+		ID:             want.ID,
+		Source:         want.Source,
+		Confidence:     want.Confidence,
+		Scope:          want.Scope,
+		ClientType:     want.ClientType,
+		ThreadID:       want.ThreadID,
+		ParentThreadID: want.ParentThreadID,
+		RequestKind:    want.RequestKind,
+		ThreadSource:   want.ThreadSource,
+		TurnID:         want.TurnID,
+	}) {
+		t.Fatalf("plugin session = %#v, want all fields forwarded from %#v", got, want)
+	}
+}

--- a/internal/pluginhost/adapters_usage_translation.go
+++ b/internal/pluginhost/adapters_usage_translation.go
@@ -172,6 +172,15 @@ func (a *usageAdapter) HandleUsage(ctx context.Context, record coreusage.Record)
 			TotalTokens:         record.Detail.TotalTokens,
 		},
 		ResponseHeaders: cloneHeader(record.ResponseHeaders),
+		Session: pluginapi.UsageSession{
+			ID:             record.Session.ID,
+			Source:         record.Session.Source,
+			Confidence:     record.Session.Confidence,
+			Scope:          record.Session.Scope,
+			ClientType:     record.Session.ClientType,
+			ThreadID:       record.Session.ThreadID,
+			ParentThreadID: record.Session.ParentThreadID,
+		},
 	})
 }
 

--- a/internal/pluginhost/adapters_usage_translation.go
+++ b/internal/pluginhost/adapters_usage_translation.go
@@ -180,6 +180,9 @@ func (a *usageAdapter) HandleUsage(ctx context.Context, record coreusage.Record)
 			ClientType:     record.Session.ClientType,
 			ThreadID:       record.Session.ThreadID,
 			ParentThreadID: record.Session.ParentThreadID,
+			RequestKind:    record.Session.RequestKind,
+			ThreadSource:   record.Session.ThreadSource,
+			TurnID:         record.Session.TurnID,
 		},
 	})
 }

--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -126,6 +126,9 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		ClientType:          strings.TrimSpace(sessionInfo.ClientType),
 		ThreadID:            strings.TrimSpace(sessionInfo.ThreadID),
 		ParentThreadID:      strings.TrimSpace(sessionInfo.ParentThreadID),
+		RequestKind:         strings.TrimSpace(sessionInfo.RequestKind),
+		ThreadSource:        strings.TrimSpace(sessionInfo.ThreadSource),
+		TurnID:              strings.TrimSpace(sessionInfo.TurnID),
 	})
 	if err != nil {
 		return
@@ -148,13 +151,19 @@ type queuedUsageDetail struct {
 	ReasoningEffort   string                   `json:"reasoning_effort"`
 	// Session fields group requests into one client conversation. They are omitted
 	// when no session could be resolved, so older consumers stay unaffected.
-	SessionID           string `json:"session_id,omitempty"`
-	SessionSource       string `json:"session_source,omitempty"`
-	SessionConfidence   string `json:"session_confidence,omitempty"`
-	SessionScope        string `json:"session_scope,omitempty"`
-	ClientType          string `json:"client_type,omitempty"`
-	ThreadID            string `json:"thread_id,omitempty"`
-	ParentThreadID      string `json:"parent_thread_id,omitempty"`
+	SessionID         string `json:"session_id,omitempty"`
+	SessionSource     string `json:"session_source,omitempty"`
+	SessionConfidence string `json:"session_confidence,omitempty"`
+	SessionScope      string `json:"session_scope,omitempty"`
+	ClientType        string `json:"client_type,omitempty"`
+	ThreadID          string `json:"thread_id,omitempty"`
+	ParentThreadID    string `json:"parent_thread_id,omitempty"`
+	// RequestKind, ThreadSource and TurnID let a session timeline separate real
+	// conversation turns from housekeeping requests such as compaction or title
+	// generation, and group the upstream requests belonging to one client turn.
+	RequestKind         string `json:"request_kind,omitempty"`
+	ThreadSource        string `json:"thread_source,omitempty"`
+	TurnID              string `json:"turn_id,omitempty"`
 	ServiceTier         string `json:"service_tier"`
 	ResponseServiceTier string `json:"response_service_tier,omitempty"`
 }

--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -65,6 +65,10 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 	}
 	responseServiceTier := strings.TrimSpace(record.ResponseServiceTier)
 	clientRequestMetadata := internallogging.GetClientRequestMetadata(ctx)
+	sessionInfo := record.Session
+	if sessionInfo.IsZero() {
+		sessionInfo = coreusage.SessionInfoFromContext(ctx)
+	}
 
 	usageDetail := coreusage.EnsureTokenBreakdownForProvider(record.Detail, record.Provider, record.ExecutorType)
 	tokens := tokenStats{
@@ -115,6 +119,13 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		ReasoningEffort:     reasoningEffort,
 		ServiceTier:         serviceTier,
 		ResponseServiceTier: responseServiceTier,
+		SessionID:           strings.TrimSpace(sessionInfo.ID),
+		SessionSource:       strings.TrimSpace(sessionInfo.Source),
+		SessionConfidence:   strings.TrimSpace(sessionInfo.Confidence),
+		SessionScope:        strings.TrimSpace(sessionInfo.Scope),
+		ClientType:          strings.TrimSpace(sessionInfo.ClientType),
+		ThreadID:            strings.TrimSpace(sessionInfo.ThreadID),
+		ParentThreadID:      strings.TrimSpace(sessionInfo.ParentThreadID),
 	})
 	if err != nil {
 		return
@@ -124,19 +135,28 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 
 type queuedUsageDetail struct {
 	requestDetail
-	AccountingVersion   int                      `json:"accounting_version"`
-	TokenBreakdown      coreusage.TokenBreakdown `json:"token_breakdown"`
-	Provider            string                   `json:"provider"`
-	ExecutorType        string                   `json:"executor_type"`
-	Model               string                   `json:"model"`
-	Alias               string                   `json:"alias"`
-	Endpoint            string                   `json:"endpoint"`
-	AuthType            string                   `json:"auth_type"`
-	APIKey              string                   `json:"api_key"`
-	RequestID           string                   `json:"request_id"`
-	ReasoningEffort     string                   `json:"reasoning_effort"`
-	ServiceTier         string                   `json:"service_tier"`
-	ResponseServiceTier string                   `json:"response_service_tier,omitempty"`
+	AccountingVersion int                      `json:"accounting_version"`
+	TokenBreakdown    coreusage.TokenBreakdown `json:"token_breakdown"`
+	Provider          string                   `json:"provider"`
+	ExecutorType      string                   `json:"executor_type"`
+	Model             string                   `json:"model"`
+	Alias             string                   `json:"alias"`
+	Endpoint          string                   `json:"endpoint"`
+	AuthType          string                   `json:"auth_type"`
+	APIKey            string                   `json:"api_key"`
+	RequestID         string                   `json:"request_id"`
+	ReasoningEffort   string                   `json:"reasoning_effort"`
+	// Session fields group requests into one client conversation. They are omitted
+	// when no session could be resolved, so older consumers stay unaffected.
+	SessionID           string `json:"session_id,omitempty"`
+	SessionSource       string `json:"session_source,omitempty"`
+	SessionConfidence   string `json:"session_confidence,omitempty"`
+	SessionScope        string `json:"session_scope,omitempty"`
+	ClientType          string `json:"client_type,omitempty"`
+	ThreadID            string `json:"thread_id,omitempty"`
+	ParentThreadID      string `json:"parent_thread_id,omitempty"`
+	ServiceTier         string `json:"service_tier"`
+	ResponseServiceTier string `json:"response_service_tier,omitempty"`
 }
 
 type requestDetail struct {

--- a/internal/redisqueue/plugin_session_test.go
+++ b/internal/redisqueue/plugin_session_test.go
@@ -21,6 +21,9 @@ func TestUsageQueuePluginPayloadIncludesSessionFields(t *testing.T) {
 				ClientType:     "codex",
 				ThreadID:       "thread-1",
 				ParentThreadID: "thread-0",
+				RequestKind:    "compact",
+				ThreadSource:   "subagent",
+				TurnID:         "019fa90b-3234-73d2-a061-0622e5f8c57c",
 			},
 		})
 
@@ -32,6 +35,10 @@ func TestUsageQueuePluginPayloadIncludesSessionFields(t *testing.T) {
 		requireStringField(t, payload, "client_type", "codex")
 		requireStringField(t, payload, "thread_id", "thread-1")
 		requireStringField(t, payload, "parent_thread_id", "thread-0")
+		// Home folds housekeeping requests out of a session timeline using these.
+		requireStringField(t, payload, "request_kind", "compact")
+		requireStringField(t, payload, "thread_source", "subagent")
+		requireStringField(t, payload, "turn_id", "019fa90b-3234-73d2-a061-0622e5f8c57c")
 	})
 }
 
@@ -65,6 +72,7 @@ func TestUsageQueuePluginOmitsSessionFieldsWhenUnresolved(t *testing.T) {
 		for _, field := range []string{
 			"session_id", "session_source", "session_confidence",
 			"session_scope", "client_type", "thread_id", "parent_thread_id",
+			"request_kind", "thread_source", "turn_id",
 		} {
 			requireMissingField(t, payload, field)
 		}

--- a/internal/redisqueue/plugin_session_test.go
+++ b/internal/redisqueue/plugin_session_test.go
@@ -1,0 +1,72 @@
+package redisqueue
+
+import (
+	"context"
+	"testing"
+
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+func TestUsageQueuePluginPayloadIncludesSessionFields(t *testing.T) {
+	withEnabledQueue(t, func() {
+		plugin := &usageQueuePlugin{}
+		plugin.HandleUsage(context.Background(), coreusage.Record{
+			Provider: "openai",
+			Model:    "gpt-5.4",
+			Session: coreusage.SessionInfo{
+				ID:             "codex:019f7e3b",
+				Source:         "client_native_header",
+				Confidence:     "high",
+				Scope:          "session",
+				ClientType:     "codex",
+				ThreadID:       "thread-1",
+				ParentThreadID: "thread-0",
+			},
+		})
+
+		payload := popSinglePayload(t)
+		requireStringField(t, payload, "session_id", "codex:019f7e3b")
+		requireStringField(t, payload, "session_source", "client_native_header")
+		requireStringField(t, payload, "session_confidence", "high")
+		requireStringField(t, payload, "session_scope", "session")
+		requireStringField(t, payload, "client_type", "codex")
+		requireStringField(t, payload, "thread_id", "thread-1")
+		requireStringField(t, payload, "parent_thread_id", "thread-0")
+	})
+}
+
+// Executors that build their reporter before the identity is known still get the
+// session from the request context.
+func TestUsageQueuePluginFallsBackToContextSession(t *testing.T) {
+	withEnabledQueue(t, func() {
+		ctx := coreusage.WithSessionInfo(context.Background(), coreusage.SessionInfo{
+			ID:         "claude:cc-1",
+			Source:     "client_native_header",
+			Confidence: "high",
+			Scope:      "session",
+			ClientType: "claude-code",
+		})
+
+		plugin := &usageQueuePlugin{}
+		plugin.HandleUsage(ctx, coreusage.Record{Provider: "claude", Model: "claude-test"})
+
+		payload := popSinglePayload(t)
+		requireStringField(t, payload, "session_id", "claude:cc-1")
+		requireStringField(t, payload, "client_type", "claude-code")
+	})
+}
+
+func TestUsageQueuePluginOmitsSessionFieldsWhenUnresolved(t *testing.T) {
+	withEnabledQueue(t, func() {
+		plugin := &usageQueuePlugin{}
+		plugin.HandleUsage(context.Background(), coreusage.Record{Provider: "openai", Model: "gpt-5.4"})
+
+		payload := popSinglePayload(t)
+		for _, field := range []string{
+			"session_id", "session_source", "session_confidence",
+			"session_scope", "client_type", "thread_id", "parent_thread_id",
+		} {
+			requireMissingField(t, payload, field)
+		}
+	})
+}

--- a/internal/runtime/executor/helps/claude_code_session.go
+++ b/internal/runtime/executor/helps/claude_code_session.go
@@ -3,12 +3,12 @@ package helps
 import (
 	"context"
 	"net/http"
-	"regexp"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/tidwall/gjson"
+
+	cliproxysession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
 )
 
 const (
@@ -16,8 +16,6 @@ const (
 	ClaudeCodeAgentHeader   = "X-Claude-Code-Agent-Id"
 	ClaudeCodeMainAgentID   = "main"
 )
-
-var claudeCodeSessionSuffixPattern = regexp.MustCompile(`_session_([a-f0-9-]+)$`)
 
 // ExtractClaudeCodeSessionID resolves a Claude Code session ID, preferring X-Claude-Code-Session-Id over payload metadata.
 func ExtractClaudeCodeSessionID(ctx context.Context, payload []byte, headers http.Header) string {
@@ -76,21 +74,10 @@ func headerValueCaseInsensitive(headers http.Header, name string) string {
 	return ""
 }
 
+// extractClaudeCodeSessionIDFromPayload delegates to the shared parser so the
+// JSON and legacy metadata.user_id formats have a single implementation.
 func extractClaudeCodeSessionIDFromPayload(payload []byte) string {
-	if len(payload) == 0 {
-		return ""
-	}
-	userID := gjson.GetBytes(payload, "metadata.user_id").String()
-	if userID == "" {
-		return ""
-	}
-	if matches := claudeCodeSessionSuffixPattern.FindStringSubmatch(userID); len(matches) >= 2 {
-		return matches[1]
-	}
-	if len(userID) > 0 && userID[0] == '{' {
-		return strings.TrimSpace(gjson.Get(userID, "session_id").String())
-	}
-	return ""
+	return cliproxysession.ClaudeMetadataSessionID(payload)
 }
 
 // ClaudeCodePromptCache derives a deterministic upstream prompt_cache_key for one Claude Code agent.

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -33,6 +33,7 @@ type UsageReporter struct {
 	source       string
 	reasoning    string
 	serviceTier  string
+	session      usage.SessionInfo
 	generate     bool
 	requestedAt  time.Time
 	ttftMu       sync.RWMutex
@@ -72,6 +73,7 @@ func NewUsageReporter(ctx context.Context, provider, model string, auth *cliprox
 		authType:    resolveUsageAuthType(auth),
 		reasoning:   usage.ReasoningEffortFromContext(ctx),
 		serviceTier: usage.ServiceTierFromContext(ctx),
+		session:     usage.SessionInfoFromContext(ctx),
 		generate:    usage.GenerateFromContext(ctx),
 	}
 	if auth != nil {
@@ -268,6 +270,7 @@ func (r *UsageReporter) buildRecordForModel(model string, detail usage.Detail, f
 		ReasoningEffort:     r.reasoning,
 		ServiceTier:         r.serviceTier,
 		ResponseServiceTier: strings.TrimSpace(detail.ResponseServiceTier),
+		Session:             r.session,
 		Generate:            usage.GenerateFlag(r.generate),
 		RequestedAt:         r.requestedAt,
 		Latency:             r.latency(),

--- a/internal/runtime/executor/home_codex_terminal_test.go
+++ b/internal/runtime/executor/home_codex_terminal_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"encoding/json"
+	cliproxyhome "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -22,7 +23,7 @@ type terminalCodexHomeDispatcher struct {
 }
 
 func (*terminalCodexHomeDispatcher) HeartbeatOK() bool { return true }
-func (d *terminalCodexHomeDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (d *terminalCodexHomeDispatcher) RPopAuth(context.Context, string, cliproxyhome.DispatchSession, http.Header, int) ([]byte, error) {
 	d.calls.Add(1)
 	return json.Marshal(d.auth)
 }

--- a/internal/runtime/executor/websocket_session_target_test.go
+++ b/internal/runtime/executor/websocket_session_target_test.go
@@ -664,7 +664,7 @@ type websocketHomeDispatcher struct {
 
 func (d websocketHomeDispatcher) HeartbeatOK() bool { return true }
 
-func (d websocketHomeDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (d websocketHomeDispatcher) RPopAuth(context.Context, string, internalhome.DispatchSession, http.Header, int) ([]byte, error) {
 	return json.Marshal(map[string]any{"auth": map[string]any{
 		"id":       "home-websocket-auth",
 		"provider": d.provider,
@@ -687,7 +687,7 @@ type accountedWebsocketHomeDispatcher struct {
 
 func (*accountedWebsocketHomeDispatcher) HeartbeatOK() bool { return true }
 
-func (d *accountedWebsocketHomeDispatcher) RPopAuth(_ context.Context, model string, _ string, _ http.Header, _ int) ([]byte, error) {
+func (d *accountedWebsocketHomeDispatcher) RPopAuth(_ context.Context, model string, _ internalhome.DispatchSession, _ http.Header, _ int) ([]byte, error) {
 	call := d.calls.Add(1)
 	if call > 1 && d.releases.Load() != call-1 {
 		d.before.Store(false)
@@ -912,7 +912,7 @@ type codex426RetryDispatcher struct {
 
 func (d *codex426RetryDispatcher) HeartbeatOK() bool { return true }
 
-func (d *codex426RetryDispatcher) RPopAuth(_ context.Context, model string, _ string, _ http.Header, _ int) ([]byte, error) {
+func (d *codex426RetryDispatcher) RPopAuth(_ context.Context, model string, _ internalhome.DispatchSession, _ http.Header, _ int) ([]byte, error) {
 	call := int(d.calls.Add(1))
 	if call > len(d.baseURLs) {
 		return nil, fmt.Errorf("unexpected Home dispatch %d", call)

--- a/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	cpahome "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -649,7 +650,7 @@ type handlerAccountedHomeDispatcher struct {
 }
 
 func (*handlerAccountedHomeDispatcher) HeartbeatOK() bool { return true }
-func (d *handlerAccountedHomeDispatcher) RPopAuth(_ context.Context, model string, _ string, _ http.Header, _ int) ([]byte, error) {
+func (d *handlerAccountedHomeDispatcher) RPopAuth(_ context.Context, model string, _ cpahome.DispatchSession, _ http.Header, _ int) ([]byte, error) {
 	d.calls.Add(1)
 	return json.Marshal(map[string]any{
 		"concurrency": map[string]any{"accounted": true, "credential_id": "handler-cred", "model": model},

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	cpahome "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -38,7 +39,7 @@ type homeResponsesWebsocketDispatcher struct {
 
 func (*homeResponsesWebsocketDispatcher) HeartbeatOK() bool { return true }
 
-func (d *homeResponsesWebsocketDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (d *homeResponsesWebsocketDispatcher) RPopAuth(context.Context, string, cpahome.DispatchSession, http.Header, int) ([]byte, error) {
 	d.calls.Add(1)
 	return json.Marshal(coreauth.Auth{
 		ID:       "home-responses-websocket-auth",

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -897,6 +897,9 @@ func sessionInfoFromOptions(opts cliproxyexecutor.Options) coreusage.SessionInfo
 		ClientType:     identity.ClientType,
 		ThreadID:       identity.ThreadID,
 		ParentThreadID: identity.ParentThreadID,
+		RequestKind:    identity.RequestKind,
+		ThreadSource:   identity.ThreadSource,
+		TurnID:         identity.TurnID,
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -717,6 +717,7 @@ func withHomeAuthCount(opts cliproxyexecutor.Options, count int) cliproxyexecuto
 	if count <= 0 {
 		count = 1
 	}
+	ensureHomeDispatchSessionState(opts.Metadata)
 	meta := make(map[string]any, len(opts.Metadata)+1)
 	for k, v := range opts.Metadata {
 		meta[k] = v
@@ -878,7 +879,25 @@ func contextWithRequestedModelAlias(ctx context.Context, opts cliproxyexecutor.O
 	if generate, ok := generateFromOptions(opts); ok {
 		ctx = coreusage.WithGenerate(ctx, generate)
 	}
-	return ctx
+	return coreusage.WithSessionInfo(ctx, sessionInfoFromOptions(opts))
+}
+
+// sessionInfoFromOptions reuses the identity resolved once per request so usage
+// records report the same session the request was routed on.
+func sessionInfoFromOptions(opts cliproxyexecutor.Options) coreusage.SessionInfo {
+	if dispatchSession, ok := homeDispatchSessionFromMetadata(opts.Metadata); ok {
+		return sessionInfoFromHomeDispatch(dispatchSession)
+	}
+	identity := sessionIdentityFromOptions(opts)
+	return coreusage.SessionInfo{
+		ID:             identity.ID,
+		Source:         identity.Source,
+		Confidence:     identity.Confidence,
+		Scope:          identity.Scope,
+		ClientType:     identity.ClientType,
+		ThreadID:       identity.ThreadID,
+		ParentThreadID: identity.ParentThreadID,
+	}
 }
 
 func requestedModelAliasFromOptions(opts cliproxyexecutor.Options, fallback string) string {

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -19,7 +19,8 @@ import (
 )
 
 const (
-	homeAuthCountMetadataKey = "__cliproxy_home_auth_count"
+	homeAuthCountMetadataKey       = "__cliproxy_home_auth_count"
+	homeDispatchSessionMetadataKey = "__cliproxy_home_dispatch_session"
 	// CloseAllExecutionSessionsID asks an executor to release all active execution sessions.
 	// Executors that do not support this marker may ignore it.
 	CloseAllExecutionSessionsID = "__all_execution_sessions__"
@@ -176,7 +177,7 @@ type homeAuthDispatchResponse struct {
 
 type homeAuthDispatcher interface {
 	HeartbeatOK() bool
-	RPopAuth(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int) ([]byte, error)
+	RPopAuth(ctx context.Context, requestedModel string, session home.DispatchSession, headers http.Header, count int) ([]byte, error)
 	AbortAmbiguousDispatch()
 }
 
@@ -196,14 +197,28 @@ func setHomeUserAPIKeyOnGinContext(ctx context.Context, apiKey string) {
 	ginCtx.Set("userApiKey", apiKey)
 }
 
-func homeDispatchHeaders(ctx context.Context, headers http.Header) http.Header {
-	apiKey, ok := homeQueryCredentialFromContext(ctx)
-	if !ok {
+// homeDispatchHeaders prepares the header snapshot sent with the auth dispatch RPC.
+// These headers never reach the upstream provider.
+//
+// CPA sees the full request and applies the full client priority order, so its
+// canonical session is authoritative. Publishing it as X-Session-ID keeps a Home
+// version that re-extracts the session from headers on the same identifier CPA
+// routed on locally, instead of a weaker header the client also happened to send.
+func homeDispatchHeaders(ctx context.Context, headers http.Header, canonicalSessionID string) http.Header {
+	apiKey, hasAPIKey := homeQueryCredentialFromContext(ctx)
+	canonicalSessionID = strings.TrimSpace(canonicalSessionID)
+	if !hasAPIKey && canonicalSessionID == "" {
 		return headers
 	}
 	out := headers.Clone()
 	if out == nil {
 		out = http.Header{}
+	}
+	if canonicalSessionID != "" {
+		out.Set("X-Session-ID", canonicalSessionID)
+	}
+	if !hasAPIKey {
+		return out
 	}
 	if out.Get("Authorization") != "" || out.Get("X-Goog-Api-Key") != "" || out.Get("X-Api-Key") != "" {
 		return out
@@ -267,6 +282,50 @@ func contextStringValue(raw any) string {
 	default:
 		return ""
 	}
+}
+
+type homeDispatchSessionState struct {
+	mu      sync.RWMutex
+	session home.DispatchSession
+}
+
+func ensureHomeDispatchSessionState(meta map[string]any) *homeDispatchSessionState {
+	if meta == nil {
+		return nil
+	}
+	if state, ok := meta[homeDispatchSessionMetadataKey].(*homeDispatchSessionState); ok && state != nil {
+		return state
+	}
+	state := &homeDispatchSessionState{}
+	meta[homeDispatchSessionMetadataKey] = state
+	return state
+}
+
+func publishHomeDispatchSessionMetadata(meta map[string]any, session home.DispatchSession) {
+	if session.ID == "" {
+		return
+	}
+	state := ensureHomeDispatchSessionState(meta)
+	if state == nil {
+		return
+	}
+	state.mu.Lock()
+	state.session = session
+	state.mu.Unlock()
+}
+
+func homeDispatchSessionFromMetadata(meta map[string]any) (home.DispatchSession, bool) {
+	if meta == nil {
+		return home.DispatchSession{}, false
+	}
+	state, ok := meta[homeDispatchSessionMetadataKey].(*homeDispatchSessionState)
+	if !ok || state == nil {
+		return home.DispatchSession{}, false
+	}
+	state.mu.RLock()
+	session := state.session
+	state.mu.RUnlock()
+	return session, session.ID != ""
 }
 
 func homeExecutionSessionIDFromMetadata(meta map[string]any) string {
@@ -693,6 +752,7 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 		return nil, errRetained
 	}
 	if retainedOK {
+		publishHomeDispatchSessionMetadata(opts.Metadata, retained.dispatchSession)
 		return retained, nil
 	}
 	if sessionID := homeExecutionSessionIDFromMetadata(opts.Metadata); sessionID != "" {
@@ -717,9 +777,10 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 		return nil, &Error{Code: "home_unavailable", Message: "home execution registry unavailable", Retryable: true, HTTPStatus: http.StatusServiceUnavailable}
 	}
 
-	sessionID := m.homeDispatchSessionID(opts)
-	dispatchHeaders := homeDispatchHeaders(ctx, opts.Headers)
-	raw, errRPop := client.RPopAuth(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata))
+	dispatchSession := m.homeDispatchSession(opts)
+	publishHomeDispatchSessionMetadata(opts.Metadata, dispatchSession)
+	dispatchHeaders := homeDispatchHeaders(ctx, opts.Headers, dispatchSession.ID)
+	raw, errRPop := client.RPopAuth(ctx, requestedModel, dispatchSession, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata))
 	if errRPop != nil {
 		if home.IsAmbiguousDispatchError(errRPop) {
 			client.AbortAmbiguousDispatch()
@@ -874,6 +935,7 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 		endScope()
 		return nil, &Error{Code: "home_unavailable", Message: "home execution registry unavailable", Retryable: true, HTTPStatus: http.StatusServiceUnavailable}
 	}
+	selection.dispatchSession = dispatchSession
 	if envelope.Present {
 		selection.accountedModel = envelope.Tuple.Model
 	}

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	"github.com/tidwall/sjson"
 )
 
@@ -55,6 +57,13 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
+		// Usage sinks read the session from the execution context. The dispatch path
+		// publishes the exact canonical Home session into request metadata first.
+		sessionInfo := sessionInfoFromOptions(opts)
+		if selection.dispatchSession.ID != "" {
+			sessionInfo = sessionInfoFromHomeDispatch(selection.dispatchSession)
+		}
+		execCtx = coreusage.WithSessionInfo(execCtx, sessionInfo)
 		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
 		if aliasResult.ForceMapping && responseAlias != "" {
 			aliasResult.OriginalAlias = responseAlias
@@ -136,6 +145,18 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 		if errCtx := execCtx.Err(); errCtx != nil && ctx != nil && ctx.Err() != nil {
 			return cliproxyexecutor.Response{}, errCtx
 		}
+	}
+}
+
+func sessionInfoFromHomeDispatch(session home.DispatchSession) coreusage.SessionInfo {
+	return coreusage.SessionInfo{
+		ID:             session.ID,
+		Source:         session.Source,
+		Confidence:     session.Confidence,
+		Scope:          session.Scope,
+		ClientType:     session.ClientType,
+		ThreadID:       session.ThreadID,
+		ParentThreadID: session.ParentThreadID,
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -157,6 +157,9 @@ func sessionInfoFromHomeDispatch(session home.DispatchSession) coreusage.Session
 		ClientType:     session.ClientType,
 		ThreadID:       session.ThreadID,
 		ParentThreadID: session.ParentThreadID,
+		RequestKind:    session.RequestKind,
+		ThreadSource:   session.ThreadSource,
+		TurnID:         session.TurnID,
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math/rand/v2"
 	"net/http"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -224,12 +225,27 @@ func (m *Manager) SetSelector(selector Selector) {
 		selector = &RoundRobinSelector{}
 	}
 	m.mu.Lock()
+	oldSelector := m.selector
 	m.selector = selector
 	m.mu.Unlock()
 	if m.scheduler != nil {
 		m.scheduler.setSelector(selector)
 		m.syncScheduler()
 	}
+	if oldSelector != nil && !sameSelector(oldSelector, selector) {
+		if stopper, ok := oldSelector.(interface{ Stop() }); ok {
+			stopper.Stop()
+		}
+	}
+}
+
+func sameSelector(left, right Selector) bool {
+	leftValue := reflect.ValueOf(left)
+	rightValue := reflect.ValueOf(right)
+	if !leftValue.IsValid() || !rightValue.IsValid() || leftValue.Type() != rightValue.Type() {
+		return false
+	}
+	return leftValue.Comparable() && leftValue.Equal(rightValue)
 }
 
 // Selector returns the current credential selector.

--- a/sdk/cliproxy/auth/conductor_selection_test.go
+++ b/sdk/cliproxy/auth/conductor_selection_test.go
@@ -1,0 +1,78 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type mockStoppableSelector struct {
+	stopped bool
+}
+
+func (m *mockStoppableSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	if len(auths) > 0 {
+		return auths[0], nil
+	}
+	return nil, nil
+}
+
+func (m *mockStoppableSelector) Stop() {
+	m.stopped = true
+}
+
+func TestManager_SetSelector_StopsOldSessionAffinitySelector(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	oldSel := NewSessionAffinitySelector(&RoundRobinSelector{})
+	m.SetSelector(oldSel)
+
+	newSel := &RoundRobinSelector{}
+	m.SetSelector(newSel)
+
+	select {
+	case <-oldSel.cache.stopCh:
+		// Success: old SessionAffinitySelector was stopped
+	default:
+		t.Fatal("expected old SessionAffinitySelector to be stopped")
+	}
+
+	// Test with mockStoppableSelector as well
+	mockOld := &mockStoppableSelector{}
+	m.SetSelector(mockOld)
+
+	mockNew := &mockStoppableSelector{}
+	m.SetSelector(mockNew)
+
+	if !mockOld.stopped {
+		t.Fatal("expected mockOld selector to be stopped")
+	}
+	if mockNew.stopped {
+		t.Fatal("expected mockNew selector to not be stopped")
+	}
+}
+
+func TestManager_SetSelector_SameSelectorNotStopped(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	sel := NewSessionAffinitySelector(&RoundRobinSelector{})
+	m.SetSelector(sel)
+
+	// Setting the same selector instance again
+	m.SetSelector(sel)
+
+	select {
+	case <-sel.cache.stopCh:
+		t.Fatal("expected selector to NOT be stopped when re-set with the same instance")
+	default:
+		// Success: still open
+	}
+
+	// Test with mockStoppableSelector
+	mockSel := &mockStoppableSelector{}
+	m.SetSelector(mockSel)
+	m.SetSelector(mockSel)
+
+	if mockSel.stopped {
+		t.Fatal("expected mockSel to NOT be stopped when re-set with the same instance")
+	}
+}

--- a/sdk/cliproxy/auth/home_concurrency_test.go
+++ b/sdk/cliproxy/auth/home_concurrency_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"net/http"
 	"os"
 	"strings"
@@ -28,7 +29,7 @@ type fixtureHomeDispatcher struct {
 
 func (d *fixtureHomeDispatcher) HeartbeatOK() bool { return true }
 
-func (d *fixtureHomeDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (d *fixtureHomeDispatcher) RPopAuth(context.Context, string, home.DispatchSession, http.Header, int) ([]byte, error) {
 	if len(d.payloads) == 0 {
 		return d.payload, nil
 	}
@@ -60,7 +61,7 @@ type busyHomeRetryDispatcher struct {
 
 func (*busyHomeRetryDispatcher) HeartbeatOK() bool { return true }
 
-func (d *busyHomeRetryDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (d *busyHomeRetryDispatcher) RPopAuth(context.Context, string, home.DispatchSession, http.Header, int) ([]byte, error) {
 	d.calls.Add(1)
 	return []byte(`{"error":{"type":"credential_concurrency_exceeded","message":"busy","retryable":true,"retry_after_ms":20000}}`), nil
 }

--- a/sdk/cliproxy/auth/home_dispatch_headers_test.go
+++ b/sdk/cliproxy/auth/home_dispatch_headers_test.go
@@ -28,7 +28,7 @@ func TestHomeDispatchHeadersAddsQueryKeyCredential(t *testing.T) {
 	ctx := context.WithValue(context.Background(), "gin", ginCtx)
 	headers := http.Header{"User-Agent": {"client"}}
 
-	got := homeDispatchHeaders(ctx, headers)
+	got := homeDispatchHeaders(ctx, headers, "")
 
 	if got.Get("X-Goog-Api-Key") != "12345" {
 		t.Fatalf("X-Goog-Api-Key = %q, want %q", got.Get("X-Goog-Api-Key"), "12345")
@@ -46,7 +46,7 @@ func TestHomeDispatchHeadersAddsQueryCredentialFromAccessMetadata(t *testing.T) 
 	ctx := context.WithValue(context.Background(), "gin", ginCtx)
 	headers := http.Header{"User-Agent": {"client"}}
 
-	got := homeDispatchHeaders(ctx, headers)
+	got := homeDispatchHeaders(ctx, headers, "")
 
 	if got.Get("X-Goog-Api-Key") != "12345" {
 		t.Fatalf("X-Goog-Api-Key = %q, want %q", got.Get("X-Goog-Api-Key"), "12345")
@@ -61,7 +61,7 @@ func TestHomeDispatchHeadersKeepsExistingCredentialHeader(t *testing.T) {
 	ctx := context.WithValue(context.Background(), "gin", ginCtx)
 	headers := http.Header{"X-Goog-Api-Key": {"header-key"}}
 
-	got := homeDispatchHeaders(ctx, headers)
+	got := homeDispatchHeaders(ctx, headers, "")
 
 	if got.Get("X-Goog-Api-Key") != "header-key" {
 		t.Fatalf("X-Goog-Api-Key = %q, want %q", got.Get("X-Goog-Api-Key"), "header-key")
@@ -76,7 +76,7 @@ func TestHomeDispatchHeadersIgnoresHeaderCredentialSource(t *testing.T) {
 	ctx := context.WithValue(context.Background(), "gin", ginCtx)
 	headers := http.Header{"Authorization": {"Bearer 12345"}}
 
-	got := homeDispatchHeaders(ctx, headers)
+	got := homeDispatchHeaders(ctx, headers, "")
 
 	if got.Get("X-Goog-Api-Key") != "" {
 		t.Fatalf("X-Goog-Api-Key = %q, want empty", got.Get("X-Goog-Api-Key"))

--- a/sdk/cliproxy/auth/home_dispatch_session_test.go
+++ b/sdk/cliproxy/auth/home_dispatch_session_test.go
@@ -1,0 +1,189 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"testing"
+
+	internalhome "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type dispatchSessionCaptureDispatcher struct {
+	mu       sync.Mutex
+	sessions []internalhome.DispatchSession
+	headers  []http.Header
+}
+
+func (*dispatchSessionCaptureDispatcher) HeartbeatOK() bool { return true }
+
+func (d *dispatchSessionCaptureDispatcher) RPopAuth(_ context.Context, _ string, session internalhome.DispatchSession, headers http.Header, _ int) ([]byte, error) {
+	d.mu.Lock()
+	d.sessions = append(d.sessions, session)
+	d.headers = append(d.headers, headers.Clone())
+	d.mu.Unlock()
+	return json.Marshal(homeAuthDispatchResponse{Auth: Auth{
+		ID:       "home-dispatch-session-auth",
+		Provider: "home-dispatch-session",
+		Status:   StatusActive,
+	}})
+}
+
+func (*dispatchSessionCaptureDispatcher) AbortAmbiguousDispatch() {}
+
+func (d *dispatchSessionCaptureDispatcher) last() (internalhome.DispatchSession, http.Header) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if len(d.sessions) == 0 {
+		return internalhome.DispatchSession{}, nil
+	}
+	return d.sessions[len(d.sessions)-1], d.headers[len(d.headers)-1]
+}
+
+func dispatchOnce(t *testing.T, manager *Manager, opts cliproxyexecutor.Options) {
+	t.Helper()
+	selection, err := manager.pickHomeDispatchSelection(context.Background(), "gpt-test", opts)
+	if err != nil {
+		t.Fatalf("pickHomeDispatchSelection() error = %v", err)
+	}
+	selection.End("test_complete")
+}
+
+func newDispatchSessionManager(t *testing.T) (*Manager, *dispatchSessionCaptureDispatcher) {
+	t.Helper()
+	dispatcher := &dispatchSessionCaptureDispatcher{}
+	manager := newHomeSelectionTestManager(t, dispatcher)
+	manager.RegisterExecutor(schedulerTestExecutor{provider: "home-dispatch-session"})
+	return manager, dispatcher
+}
+
+func TestHomeDispatchSendsStructuredIdentity(t *testing.T) {
+	manager, dispatcher := newDispatchSessionManager(t)
+
+	dispatchOnce(t, manager, cliproxyexecutor.Options{
+		Headers:         http.Header{"User-Agent": {"codex_exec/0.144.6"}, "Session-Id": {"019f7e3b"}, "Thread-Id": {"019f7e3b"}},
+		OriginalRequest: []byte(`{"prompt_cache_key":"019f7e3b"}`),
+	})
+
+	session, _ := dispatcher.last()
+	if session.ID != "codex:019f7e3b" {
+		t.Fatalf("session.ID = %q, want codex:019f7e3b", session.ID)
+	}
+	if session.Source == "" || session.Confidence == "" || session.Scope == "" {
+		t.Fatalf("session classification is incomplete: %#v", session)
+	}
+	if session.ClientType != "codex" {
+		t.Fatalf("session.ClientType = %q, want codex", session.ClientType)
+	}
+	if session.ThreadID != "019f7e3b" {
+		t.Fatalf("session.ThreadID = %q, want 019f7e3b", session.ThreadID)
+	}
+	if !session.ClientProvided {
+		t.Fatal("session.ClientProvided = false, want true")
+	}
+}
+
+// A CPA node that only ever sees the conversation ID must still tell Home about
+// the prompt cache key it was canonicalized onto, otherwise Home sees two sessions.
+func TestHomeDispatchSendsAliasesForCanonicalizedSessions(t *testing.T) {
+	manager, dispatcher := newDispatchSessionManager(t)
+
+	dispatchOnce(t, manager, cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"prompt_cache_key":"cache-1","conversation":{"id":"conv_1"}}`),
+	})
+	combined, _ := dispatcher.last()
+	if combined.ID != "pck:cache-1" {
+		t.Fatalf("combined session.ID = %q, want pck:cache-1", combined.ID)
+	}
+	if len(combined.Aliases) != 1 || combined.Aliases[0] != "conv:conv_1" {
+		t.Fatalf("combined session.Aliases = %#v, want [conv:conv_1]", combined.Aliases)
+	}
+
+	dispatchOnce(t, manager, cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"conversation":{"id":"conv_1"}}`),
+	})
+	conversationOnly, _ := dispatcher.last()
+	if conversationOnly.ID != "pck:cache-1" {
+		t.Fatalf("conversation-only session.ID = %q, want the canonical pck:cache-1", conversationOnly.ID)
+	}
+	if !containsString(conversationOnly.Aliases, "conv:conv_1") {
+		t.Fatalf("conversation-only session.Aliases = %#v, want the observed conv:conv_1", conversationOnly.Aliases)
+	}
+}
+
+// Home receives every recognized identifier while the representative ID remains
+// available through the legacy X-Session-ID compatibility header.
+func TestHomeDispatchPublishesRepresentativeAndAliases(t *testing.T) {
+	manager, dispatcher := newDispatchSessionManager(t)
+
+	dispatchOnce(t, manager, cliproxyexecutor.Options{
+		Headers: http.Header{
+			"X-Claude-Code-Session-Id": {"strong-session"},
+			"X-Session-Id":             {"weak-session"},
+		},
+		OriginalRequest: []byte(`{"conversation_id":"body-session"}`),
+	})
+
+	session, headers := dispatcher.last()
+	if session.ID != "claude:strong-session" {
+		t.Fatalf("session.ID = %q, want claude:strong-session", session.ID)
+	}
+	wantAliases := []string{"header:weak-session", "conv:body-session"}
+	if !equalSessionAliases(session.Aliases, wantAliases) {
+		t.Fatalf("session.Aliases = %#v, want %#v", session.Aliases, wantAliases)
+	}
+	if got := headers.Get("X-Session-ID"); got != "claude:strong-session" {
+		t.Fatalf("dispatch X-Session-ID = %q, want the canonical claude:strong-session", got)
+	}
+	if got := headers.Get("X-Claude-Code-Session-Id"); got != "strong-session" {
+		t.Fatalf("dispatch X-Claude-Code-Session-Id = %q, want the original client value", got)
+	}
+}
+
+func TestHomeDispatchCanonicalAliasesAreCallerScoped(t *testing.T) {
+	manager, dispatcher := newDispatchSessionManager(t)
+
+	dispatchOnce(t, manager, cliproxyexecutor.Options{
+		Metadata:        map[string]any{cliproxyexecutor.CallerScopeMetadataKey: "caller-a"},
+		OriginalRequest: []byte(`{"prompt_cache_key":"shared-cache","conversation":{"id":"caller-a"}}`),
+	})
+	dispatchOnce(t, manager, cliproxyexecutor.Options{
+		Metadata:        map[string]any{cliproxyexecutor.CallerScopeMetadataKey: "caller-b"},
+		OriginalRequest: []byte(`{"prompt_cache_key":"shared-cache","conversation":{"id":"caller-b"}}`),
+	})
+	dispatchOnce(t, manager, cliproxyexecutor.Options{
+		Metadata:        map[string]any{cliproxyexecutor.CallerScopeMetadataKey: "caller-b"},
+		OriginalRequest: []byte(`{"conversation":{"id":"caller-a"}}`),
+	})
+
+	session, _ := dispatcher.last()
+	if session.ID != "conv:caller-a" {
+		t.Fatalf("caller B inherited caller A canonical session: got %q, want conv:caller-a", session.ID)
+	}
+}
+
+func TestHomeDispatchLeavesHeadersAloneWithoutASession(t *testing.T) {
+	manager, dispatcher := newDispatchSessionManager(t)
+	original := http.Header{"X-Session-Id": {"   "}}
+
+	dispatchOnce(t, manager, cliproxyexecutor.Options{Headers: original})
+
+	session, headers := dispatcher.last()
+	if session.ID != "" {
+		t.Fatalf("session.ID = %q, want empty", session.ID)
+	}
+	if got := headers.Get("X-Session-ID"); got != "   " {
+		t.Fatalf("dispatch X-Session-ID = %q, want the untouched client value", got)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/sdk/cliproxy/auth/home_execution_paths_test.go
+++ b/sdk/cliproxy/auth/home_execution_paths_test.go
@@ -22,7 +22,7 @@ type homeExecutionDispatcher struct{}
 
 func (homeExecutionDispatcher) HeartbeatOK() bool { return true }
 
-func (homeExecutionDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (homeExecutionDispatcher) RPopAuth(context.Context, string, home.DispatchSession, http.Header, int) ([]byte, error) {
 	return json.Marshal(homeAuthDispatchResponse{Auth: Auth{ID: "home-auth", Provider: "home-execution", Status: StatusActive}})
 }
 
@@ -163,7 +163,7 @@ type homeOAuthLoggingDispatcher struct{}
 
 func (homeOAuthLoggingDispatcher) HeartbeatOK() bool { return true }
 
-func (homeOAuthLoggingDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (homeOAuthLoggingDispatcher) RPopAuth(context.Context, string, home.DispatchSession, http.Header, int) ([]byte, error) {
 	return json.Marshal(homeAuthDispatchResponse{Auth: Auth{
 		ID:       "home-auth",
 		Provider: "home-execution",
@@ -255,7 +255,7 @@ type retainingHomeExecutionDispatcher struct {
 
 func (d *retainingHomeExecutionDispatcher) HeartbeatOK() bool { return true }
 
-func (d *retainingHomeExecutionDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (d *retainingHomeExecutionDispatcher) RPopAuth(context.Context, string, home.DispatchSession, http.Header, int) ([]byte, error) {
 	d.calls.Add(1)
 	return json.Marshal(homeAuthDispatchResponse{Auth: Auth{
 		ID:       "home-auth",
@@ -329,7 +329,7 @@ type changingHomeTargetDispatcher struct {
 }
 
 func (d *changingHomeTargetDispatcher) HeartbeatOK() bool { return true }
-func (d *changingHomeTargetDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (d *changingHomeTargetDispatcher) RPopAuth(context.Context, string, home.DispatchSession, http.Header, int) ([]byte, error) {
 	if d.calls.Add(1) == 2 && d.firstSelection != nil {
 		d.oldEndedBeforeRPop.Store(!d.firstSelection.Active())
 	}
@@ -399,7 +399,7 @@ type unpinnedTargetChangeDispatcher struct {
 }
 
 func (d *unpinnedTargetChangeDispatcher) HeartbeatOK() bool { return true }
-func (d *unpinnedTargetChangeDispatcher) RPopAuth(_ context.Context, _ string, _ string, _ http.Header, _ int) ([]byte, error) {
+func (d *unpinnedTargetChangeDispatcher) RPopAuth(_ context.Context, _ string, _ home.DispatchSession, _ http.Header, _ int) ([]byte, error) {
 	call := d.calls.Add(1)
 	if call == 2 && d.first != nil {
 		d.oldClosedBeforeDispatch.Store(!d.first.Active() && d.closeCalls.Load() == 1)
@@ -490,7 +490,7 @@ type lifecycleRetryDispatcher struct {
 }
 
 func (d *lifecycleRetryDispatcher) HeartbeatOK() bool { return true }
-func (d *lifecycleRetryDispatcher) RPopAuth(_ context.Context, _ string, _ string, _ http.Header, _ int) ([]byte, error) {
+func (d *lifecycleRetryDispatcher) RPopAuth(_ context.Context, _ string, _ home.DispatchSession, _ http.Header, _ int) ([]byte, error) {
 	if d.calls.Add(1) == 2 && d.executor.first != nil {
 		d.firstEndedBeforeRedispatch.Store(!d.executor.first.Active() && d.executor.firstCtx.Err() != nil)
 	}
@@ -753,7 +753,7 @@ type homePerSelectionDispatcher struct {
 }
 
 func (*homePerSelectionDispatcher) HeartbeatOK() bool { return true }
-func (d *homePerSelectionDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (d *homePerSelectionDispatcher) RPopAuth(context.Context, string, home.DispatchSession, http.Header, int) ([]byte, error) {
 	call := d.calls.Add(1)
 	if call == 2 && d.first != nil {
 		d.firstEndedBefore2.Store(!d.first.Active())
@@ -894,7 +894,7 @@ type accountedHomeExecutionDispatcher struct {
 }
 
 func (*accountedHomeExecutionDispatcher) HeartbeatOK() bool { return true }
-func (d *accountedHomeExecutionDispatcher) RPopAuth(_ context.Context, model string, _ string, _ http.Header, _ int) ([]byte, error) {
+func (d *accountedHomeExecutionDispatcher) RPopAuth(_ context.Context, model string, _ home.DispatchSession, _ http.Header, _ int) ([]byte, error) {
 	index := int(d.calls.Add(1)) - 1
 	if index >= len(d.auths) {
 		return nil, home.ErrAuthNotFound

--- a/sdk/cliproxy/auth/home_force_mapping_test.go
+++ b/sdk/cliproxy/auth/home_force_mapping_test.go
@@ -112,7 +112,7 @@ type accountedAliasTargetDispatcher struct {
 
 func (*accountedAliasTargetDispatcher) HeartbeatOK() bool { return true }
 
-func (d *accountedAliasTargetDispatcher) RPopAuth(_ context.Context, model string, _ string, _ http.Header, _ int) ([]byte, error) {
+func (d *accountedAliasTargetDispatcher) RPopAuth(_ context.Context, model string, _ internalhome.DispatchSession, _ http.Header, _ int) ([]byte, error) {
 	call := d.calls.Add(1)
 	if call == 2 {
 		d.releasedBeforeSecondRPop.Store(d.releases.Load() == 1)
@@ -179,7 +179,7 @@ type authSelectionAliasDispatcher struct {
 
 func (*authSelectionAliasDispatcher) HeartbeatOK() bool { return true }
 
-func (d *authSelectionAliasDispatcher) RPopAuth(_ context.Context, model string, _ string, _ http.Header, _ int) ([]byte, error) {
+func (d *authSelectionAliasDispatcher) RPopAuth(_ context.Context, model string, _ internalhome.DispatchSession, _ http.Header, _ int) ([]byte, error) {
 	d.mu.Lock()
 	d.models = append(d.models, model)
 	d.mu.Unlock()
@@ -269,7 +269,7 @@ type forceMappingAliasChangeDispatcher struct {
 
 func (*forceMappingAliasChangeDispatcher) HeartbeatOK() bool { return true }
 
-func (d *forceMappingAliasChangeDispatcher) RPopAuth(_ context.Context, _ string, _ string, _ http.Header, _ int) ([]byte, error) {
+func (d *forceMappingAliasChangeDispatcher) RPopAuth(_ context.Context, _ string, _ internalhome.DispatchSession, _ http.Header, _ int) ([]byte, error) {
 	if d.calls.Add(1) == 2 {
 		d.releasedBeforeSecondRPop.Store(d.releases.Load() == 1)
 	}
@@ -392,7 +392,7 @@ type ackOrderedRouteDispatcher struct {
 
 func (*ackOrderedRouteDispatcher) HeartbeatOK() bool { return true }
 
-func (d *ackOrderedRouteDispatcher) RPopAuth(_ context.Context, model string, _ string, _ http.Header, _ int) ([]byte, error) {
+func (d *ackOrderedRouteDispatcher) RPopAuth(_ context.Context, model string, _ internalhome.DispatchSession, _ http.Header, _ int) ([]byte, error) {
 	call := d.calls.Add(1)
 	if call == 2 {
 		d.ackedBeforeSecondRPop.Store(d.acks.Load() == 1)
@@ -505,7 +505,7 @@ type prefixedRetainedRouteDispatcher struct {
 
 func (*prefixedRetainedRouteDispatcher) HeartbeatOK() bool { return true }
 
-func (d *prefixedRetainedRouteDispatcher) RPopAuth(_ context.Context, model string, _ string, _ http.Header, _ int) ([]byte, error) {
+func (d *prefixedRetainedRouteDispatcher) RPopAuth(_ context.Context, model string, _ internalhome.DispatchSession, _ http.Header, _ int) ([]byte, error) {
 	d.mu.Lock()
 	d.models = append(d.models, model)
 	d.mu.Unlock()

--- a/sdk/cliproxy/auth/home_in_flight_publisher_test.go
+++ b/sdk/cliproxy/auth/home_in_flight_publisher_test.go
@@ -202,7 +202,7 @@ func TestHomeInFlightPublisherPinsLifetimeRegistry(t *testing.T) {
 type homeInFlightModelDispatcher struct{}
 
 func (homeInFlightModelDispatcher) HeartbeatOK() bool { return true }
-func (homeInFlightModelDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (homeInFlightModelDispatcher) RPopAuth(context.Context, string, home.DispatchSession, http.Header, int) ([]byte, error) {
 	return json.Marshal(homeAuthDispatchResponse{
 		Model: "final-upstream-model",
 		Auth:  Auth{ID: "home-auth", Provider: "home-execution", Status: StatusActive},

--- a/sdk/cliproxy/auth/home_retry_loop_test.go
+++ b/sdk/cliproxy/auth/home_retry_loop_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"net/http"
 	"sync/atomic"
 	"testing"
@@ -21,7 +22,7 @@ func (d *repeatedHomeAuthDispatcher) HeartbeatOK() bool {
 	return true
 }
 
-func (d *repeatedHomeAuthDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (d *repeatedHomeAuthDispatcher) RPopAuth(context.Context, string, home.DispatchSession, http.Header, int) ([]byte, error) {
 	d.calls.Add(1)
 	raw, _ := json.Marshal(homeAuthDispatchResponse{
 		Auth: Auth{

--- a/sdk/cliproxy/auth/home_selected_auth_callback_test.go
+++ b/sdk/cliproxy/auth/home_selected_auth_callback_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"net/http"
 	"sync/atomic"
 	"testing"
@@ -17,7 +18,7 @@ type selectedAuthCallbackDispatcher struct {
 }
 
 func (*selectedAuthCallbackDispatcher) HeartbeatOK() bool { return true }
-func (d *selectedAuthCallbackDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (d *selectedAuthCallbackDispatcher) RPopAuth(context.Context, string, home.DispatchSession, http.Header, int) ([]byte, error) {
 	if d.calls.Add(1) > 2 {
 		return json.Marshal(homeErrorEnvelope{Error: &homeErrorDetail{Code: homeRequestRetryExceededErrorCode, Message: "no more auths"}})
 	}

--- a/sdk/cliproxy/auth/home_selection.go
+++ b/sdk/cliproxy/auth/home_selection.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
 )
 
@@ -141,6 +142,7 @@ type HomeDispatchSelection struct {
 	Executor ProviderExecutor
 	Provider string
 
+	dispatchSession  home.DispatchSession
 	scope            *executionregistry.Scope
 	accountedModel   string
 	resources        *executionResources

--- a/sdk/cliproxy/auth/home_selection_test.go
+++ b/sdk/cliproxy/auth/home_selection_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"net/http"
 	"sync/atomic"
 	"testing"
@@ -116,7 +117,7 @@ func (d *gatedHomeDispatcher) HeartbeatOK() bool {
 	return true
 }
 
-func (d *gatedHomeDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (d *gatedHomeDispatcher) RPopAuth(context.Context, string, home.DispatchSession, http.Header, int) ([]byte, error) {
 	d.rpop.Add(1)
 	return nil, errors.New("old Home dispatcher was used")
 }

--- a/sdk/cliproxy/auth/home_session_alias.go
+++ b/sdk/cliproxy/auth/home_session_alias.go
@@ -2,11 +2,13 @@ package auth
 
 import (
 	"container/list"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
@@ -33,10 +35,35 @@ type homeSessionAliasCache struct {
 	ops              uint64
 }
 
-func (c *homeSessionAliasCache) canonical(primary, fallback string, ttl time.Duration, now time.Time) string {
-	primary = strings.TrimSpace(primary)
-	fallback = strings.TrimSpace(fallback)
-	if primary == "" {
+func (c *homeSessionAliasCache) canonicalForCaller(callerScope string, aliases []string, ttl time.Duration, now time.Time) string {
+	callerScope = strings.TrimSpace(callerScope)
+	if callerScope == "" {
+		return c.canonical(aliases, ttl, now)
+	}
+	suffix := "\x00caller:" + callerScope
+	scopedAliases := make([]string, 0, len(aliases))
+	for _, alias := range aliases {
+		if alias = strings.TrimSpace(alias); alias != "" {
+			scopedAliases = append(scopedAliases, alias+suffix)
+		}
+	}
+	canonical := c.canonical(scopedAliases, ttl, now)
+	return strings.TrimSuffix(canonical, suffix)
+}
+
+func (c *homeSessionAliasCache) canonical(aliases []string, ttl time.Duration, now time.Time) string {
+	cleaned := make([]string, 0, len(aliases))
+	seenInput := make(map[string]struct{}, len(aliases))
+	for _, a := range aliases {
+		a = strings.TrimSpace(a)
+		if a != "" {
+			if _, ok := seenInput[a]; !ok {
+				seenInput[a] = struct{}{}
+				cleaned = append(cleaned, a)
+			}
+		}
+	}
+	if len(cleaned) == 0 {
 		return ""
 	}
 	if ttl <= 0 {
@@ -51,44 +78,49 @@ func (c *homeSessionAliasCache) canonical(primary, fallback string, ttl time.Dur
 		c.cleanupLocked(now)
 	}
 
-	canonical := primary
-	aliases := mergeSessionAliases(nil, primary, fallback)
-	previousGroups := make(map[string]homeSessionAliasEntry, 2)
-	remember := func(entry homeSessionAliasEntry) {
-		previousGroups[entry.canonical] = entry
+	previousGroups := make(map[string]homeSessionAliasEntry)
+	var matchedCanonicals []string
+	matchedCanonicalSet := make(map[string]struct{})
+
+	allAliases := mergeSessionAliases(nil, cleaned...)
+
+	canonicalFromLiveAlias := false
+	for _, a := range cleaned {
+		if existing, ok := c.entryLocked(a, now); ok {
+			canonicalFromLiveAlias = true
+			previousGroups[existing.canonical] = existing
+			allAliases = mergeSessionAliases(allAliases, existing.aliases...)
+			if _, ok := matchedCanonicalSet[existing.canonical]; !ok {
+				matchedCanonicalSet[existing.canonical] = struct{}{}
+				matchedCanonicals = append(matchedCanonicals, existing.canonical)
+			}
+		}
 	}
 
-	primaryFound := false
-	canonicalFromLiveAlias := false
-	if existing, ok := c.entryLocked(primary, now); ok {
-		primaryFound = true
-		canonicalFromLiveAlias = true
-		canonical = existing.canonical
-		remember(existing)
-		aliases = mergeSessionAliases(aliases, existing.aliases...)
-	}
-	if fallback != "" && fallback != primary {
-		if existing, ok := c.entryLocked(fallback, now); ok {
-			canonicalFromLiveAlias = true
-			if !primaryFound {
-				canonical = existing.canonical
-			}
-			remember(existing)
-			aliases = mergeSessionAliases(aliases, existing.aliases...)
+	for _, canon := range matchedCanonicals {
+		if existing, ok := c.groupLocked(canon, now); ok {
+			previousGroups[existing.canonical] = existing
+			allAliases = mergeSessionAliases(allAliases, existing.aliases...)
 		}
 	}
-	if canonicalFromLiveAlias {
-		if existing, ok := c.groupLocked(canonical, now); ok {
-			remember(existing)
-			aliases = mergeSessionAliases(aliases, existing.aliases...)
-		}
+
+	var canonical string
+	if len(matchedCanonicals) == 0 {
+		canonical = cleaned[0]
+	} else if len(matchedCanonicals) == 1 {
+		canonical = matchedCanonicals[0]
+	} else {
+		sort.Strings(matchedCanonicals)
+		canonical = matchedCanonicals[0]
 	}
+
 	if !canonicalFromLiveAlias {
 		if _, ok := c.groupLocked(canonical, now); ok {
 			return canonical
 		}
 	}
-	aliases = compactHomeSessionAliases(mergeSessionAliases(aliases, canonical))
+
+	allAliases = compactHomeSessionAliases(mergeSessionAliases(allAliases, canonical))
 	for _, previous := range previousGroups {
 		c.removeGroupLocked(previous)
 	}
@@ -96,7 +128,7 @@ func (c *homeSessionAliasCache) canonical(primary, fallback string, ttl time.Dur
 	c.setGroupLocked(homeSessionAliasEntry{
 		canonical: canonical,
 		expiresAt: now.Add(ttl),
-		aliases:   aliases,
+		aliases:   allAliases,
 	})
 	c.enforceLimitLocked(homeSessionAliasSoftLimit)
 	return canonical
@@ -233,11 +265,39 @@ func homeSessionAliasTTL(cfg *internalconfig.Config) time.Duration {
 	return parsed
 }
 
-func (m *Manager) homeDispatchSessionID(opts cliproxyexecutor.Options) string {
-	primary, fallback := extractSessionIDs(opts.Headers, opts.OriginalRequest, opts.Metadata)
-	if primary == "" || m == nil {
-		return primary
+// homeDispatchSession resolves the canonical session Home should route on, together
+// with the structured identity and aliases Home needs to reconcile the same session
+// across CPA nodes that observed it through different signals.
+func (m *Manager) homeDispatchSession(opts cliproxyexecutor.Options) home.DispatchSession {
+	identity := sessionIdentityFromOptions(opts)
+	session := home.DispatchSession{
+		ID:             identity.ID,
+		Aliases:        identity.Aliases,
+		Source:         identity.Source,
+		Confidence:     identity.Confidence,
+		Scope:          identity.Scope,
+		ClientType:     identity.ClientType,
+		ThreadID:       identity.ThreadID,
+		ParentThreadID: identity.ParentThreadID,
+		ClientProvided: identity.ClientProvided,
 	}
+	if session.ID == "" || m == nil {
+		return session
+	}
+	observedIDs := identity.IDs()
 	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
-	return m.homeSessionAliases.canonical(primary, fallback, homeSessionAliasTTL(cfg), time.Now())
+	callerScope := optionsMetadataString(opts, cliproxyexecutor.CallerScopeMetadataKey)
+	canonical := m.homeSessionAliases.canonicalForCaller(callerScope, observedIDs, homeSessionAliasTTL(cfg), time.Now())
+	if canonical == "" {
+		return session
+	}
+	session.ID = canonical
+	aliases := make([]string, 0, len(observedIDs)-1)
+	for _, id := range observedIDs {
+		if id != canonical {
+			aliases = append(aliases, id)
+		}
+	}
+	session.Aliases = aliases
+	return session
 }

--- a/sdk/cliproxy/auth/home_session_alias.go
+++ b/sdk/cliproxy/auth/home_session_alias.go
@@ -279,6 +279,9 @@ func (m *Manager) homeDispatchSession(opts cliproxyexecutor.Options) home.Dispat
 		ClientType:     identity.ClientType,
 		ThreadID:       identity.ThreadID,
 		ParentThreadID: identity.ParentThreadID,
+		RequestKind:    identity.RequestKind,
+		ThreadSource:   identity.ThreadSource,
+		TurnID:         identity.TurnID,
 		ClientProvided: identity.ClientProvided,
 	}
 	if session.ID == "" || m == nil {

--- a/sdk/cliproxy/auth/home_session_alias_test.go
+++ b/sdk/cliproxy/auth/home_session_alias_test.go
@@ -40,6 +40,48 @@ func (d *sessionAliasCaptureDispatcher) sessionIDs() []string {
 	return append([]string(nil), d.sessions...)
 }
 
+// TestHomeDispatchSessionCarriesObservations verifies the observation fields reach
+// Home. Home builds session timelines from this payload and cannot re-derive them,
+// because the RESP auth dispatch never sees the original request body or headers.
+func TestHomeDispatchSessionCarriesObservations(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{
+		Home:    internalconfig.HomeConfig{Enabled: true},
+		Routing: internalconfig.RoutingConfig{SessionAffinityTTL: "1h"},
+	})
+
+	const root = "019fa90b-31a4-7841-b252-0a2d5dafbbdc"
+	const childThread = "019fa90b-3219-73d2-9aad-9de97611969e"
+	const turnID = "019fa90b-3234-73d2-a061-0622e5f8c57c"
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{
+			"Session-Id":               {root},
+			"Thread-Id":                {childThread},
+			"X-Codex-Parent-Thread-Id": {root},
+			"X-Codex-Turn-Metadata": {`{"session_id":"` + root + `","thread_id":"` + childThread +
+				`","turn_id":"` + turnID + `","request_kind":"compact","thread_source":"subagent"}`},
+			"User-Agent": {"codex_exec/0.145.0 (Mac OS 26.5.2; arm64)"},
+		},
+	}
+
+	session := manager.homeDispatchSession(opts)
+	if session.ID != "codex:"+root {
+		t.Fatalf("session.ID = %q, want codex:%s", session.ID, root)
+	}
+	for _, tc := range []struct{ name, got, want string }{
+		{"RequestKind", session.RequestKind, "compact"},
+		{"ThreadSource", session.ThreadSource, "subagent"},
+		{"TurnID", session.TurnID, turnID},
+		{"ThreadID", session.ThreadID, childThread},
+		{"ParentThreadID", session.ParentThreadID, root},
+		{"ClientType", session.ClientType, "codex"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("session.%s = %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
 func TestHomeSessionAliasCacheClearsWhenConfiguredTTLChanges(t *testing.T) {
 	manager := NewManager(nil, nil, nil)
 	manager.SetConfig(&internalconfig.Config{

--- a/sdk/cliproxy/auth/home_session_alias_test.go
+++ b/sdk/cliproxy/auth/home_session_alias_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"net/http"
 	"sync"
 	"testing"
@@ -20,9 +21,9 @@ type sessionAliasCaptureDispatcher struct {
 
 func (*sessionAliasCaptureDispatcher) HeartbeatOK() bool { return true }
 
-func (d *sessionAliasCaptureDispatcher) RPopAuth(_ context.Context, _ string, sessionID string, _ http.Header, _ int) ([]byte, error) {
+func (d *sessionAliasCaptureDispatcher) RPopAuth(_ context.Context, _ string, session home.DispatchSession, _ http.Header, _ int) ([]byte, error) {
 	d.mu.Lock()
-	d.sessions = append(d.sessions, sessionID)
+	d.sessions = append(d.sessions, session.ID)
 	d.mu.Unlock()
 	return json.Marshal(homeAuthDispatchResponse{Auth: Auth{
 		ID:       "home-session-alias-auth",
@@ -51,10 +52,10 @@ func TestHomeSessionAliasCacheClearsWhenConfiguredTTLChanges(t *testing.T) {
 	conversationOnly := cliproxyexecutor.Options{OriginalRequest: []byte(
 		`{"conversation":{"id":"ttl-conversation"}}`,
 	)}
-	if got := manager.homeDispatchSessionID(combined); got != "pck:ttl-prompt" {
+	if got := manager.homeDispatchSession(combined).ID; got != "pck:ttl-prompt" {
 		t.Fatalf("combined canonical = %q, want pck:ttl-prompt", got)
 	}
-	if got := manager.homeDispatchSessionID(conversationOnly); got != "pck:ttl-prompt" {
+	if got := manager.homeDispatchSession(conversationOnly).ID; got != "pck:ttl-prompt" {
 		t.Fatalf("conversation canonical before reload = %q, want existing prompt canonical", got)
 	}
 
@@ -62,7 +63,7 @@ func TestHomeSessionAliasCacheClearsWhenConfiguredTTLChanges(t *testing.T) {
 		Home:    internalconfig.HomeConfig{Enabled: true},
 		Routing: internalconfig.RoutingConfig{SessionAffinityTTL: "1m"},
 	})
-	if got := manager.homeDispatchSessionID(conversationOnly); got != "conv:ttl-conversation" {
+	if got := manager.homeDispatchSession(conversationOnly).ID; got != "conv:ttl-conversation" {
 		t.Fatalf("conversation canonical after TTL change = %q, want cleared alias cache", got)
 	}
 }
@@ -137,7 +138,7 @@ func TestHomeSessionAliasCachePrimaryAccessRefreshesWholeAliasGroup(t *testing.T
 	const primary = "pck:shared-cache-bucket"
 	const fallback = "conv:conversation-session"
 
-	if got := cache.canonical(primary, fallback, time.Minute, now); got != primary {
+	if got := cache.canonical([]string{primary, fallback}, time.Minute, now); got != primary {
 		t.Fatalf("initial canonical = %q, want %q", got, primary)
 	}
 	cache.mu.Lock()
@@ -146,10 +147,10 @@ func TestHomeSessionAliasCachePrimaryAccessRefreshesWholeAliasGroup(t *testing.T
 	cache.entries[fallback] = fallbackEntry
 	cache.mu.Unlock()
 
-	if got := cache.canonical(primary, "", time.Minute, now.Add(10*time.Second)); got != primary {
+	if got := cache.canonical([]string{primary}, time.Minute, now.Add(10*time.Second)); got != primary {
 		t.Fatalf("primary-only canonical = %q, want %q", got, primary)
 	}
-	if got := cache.canonical(fallback, "", time.Minute, now.Add(20*time.Second)); got != primary {
+	if got := cache.canonical([]string{fallback}, time.Minute, now.Add(20*time.Second)); got != primary {
 		t.Fatalf("fallback canonical after active primary traffic = %q, want %q", got, primary)
 	}
 }
@@ -161,16 +162,16 @@ func TestHomeSessionAliasCacheSharedPromptKeyPreservesConversationAliases(t *tes
 	const conversationA = "conv:conversation-a"
 	const conversationB = "conv:conversation-b"
 
-	if got := cache.canonical(promptKey, conversationA, time.Minute, now); got != promptKey {
+	if got := cache.canonical([]string{promptKey, conversationA}, time.Minute, now); got != promptKey {
 		t.Fatalf("conversation A canonical = %q, want %q", got, promptKey)
 	}
-	if got := cache.canonical(promptKey, conversationB, time.Minute, now.Add(time.Second)); got != promptKey {
+	if got := cache.canonical([]string{promptKey, conversationB}, time.Minute, now.Add(time.Second)); got != promptKey {
 		t.Fatalf("conversation B canonical = %q, want %q", got, promptKey)
 	}
-	if got := cache.canonical(conversationA, "", time.Minute, now.Add(2*time.Second)); got != promptKey {
+	if got := cache.canonical([]string{conversationA}, time.Minute, now.Add(2*time.Second)); got != promptKey {
 		t.Fatalf("conversation A alias canonical = %q, want %q", got, promptKey)
 	}
-	if got := cache.canonical(conversationB, "", time.Minute, now.Add(3*time.Second)); got != promptKey {
+	if got := cache.canonical([]string{conversationB}, time.Minute, now.Add(3*time.Second)); got != promptKey {
 		t.Fatalf("conversation B alias canonical = %q, want %q", got, promptKey)
 	}
 }
@@ -180,10 +181,10 @@ func TestHomeSessionAliasCacheConversationIDContainingPromptMarkerRemainsStable(
 	now := time.Now()
 	const promptKey = "pck:shared-cache-bucket"
 	const conversation = "conv:a::pck:b"
-	if got := cache.canonical(promptKey, conversation, time.Minute, now); got != promptKey {
+	if got := cache.canonical([]string{promptKey, conversation}, time.Minute, now); got != promptKey {
 		t.Fatalf("combined canonical = %q, want %q", got, promptKey)
 	}
-	if got := cache.canonical(conversation, "", time.Minute, now.Add(time.Second)); got != promptKey {
+	if got := cache.canonical([]string{conversation}, time.Minute, now.Add(time.Second)); got != promptKey {
 		t.Fatalf("conversation-only canonical = %q, want %q", got, promptKey)
 	}
 }
@@ -194,7 +195,7 @@ func TestHomeSessionAliasCacheSharedPromptKeyCapsStableAliasesByRecency(t *testi
 	const promptKey = "pck:shared-cache-bucket"
 	for index := 0; index < 128; index++ {
 		conversation := fmt.Sprintf("conv:conversation-%03d", index)
-		cache.canonical(promptKey, conversation, time.Minute, now.Add(time.Duration(index)*time.Second))
+		cache.canonical([]string{promptKey, conversation}, time.Minute, now.Add(time.Duration(index)*time.Second))
 	}
 
 	cache.mu.Lock()
@@ -217,7 +218,7 @@ func TestHomeSessionAliasCacheRotatingPrimaryEvictsObsoleteAliases(t *testing.T)
 	wantCanonical := "pck:cache-00"
 	for index := 0; index < 16; index++ {
 		primary := fmt.Sprintf("pck:cache-%02d", index)
-		if got := cache.canonical(primary, fallback, time.Minute, now.Add(time.Duration(index)*time.Second)); got != wantCanonical {
+		if got := cache.canonical([]string{primary, fallback}, time.Minute, now.Add(time.Duration(index)*time.Second)); got != wantCanonical {
 			t.Fatalf("canonical at index %d = %q, want %q", index, got, wantCanonical)
 		}
 	}
@@ -249,10 +250,10 @@ func TestHomeSessionAliasCacheDoesNotReconnectCompactedCanonicalAlias(t *testing
 	const currentPrompt = "pck:cache-b"
 	const conversation = "conv:conversation-session"
 
-	if got := cache.canonical(obsoletePrompt, conversation, time.Minute, now); got != obsoletePrompt {
+	if got := cache.canonical([]string{obsoletePrompt, conversation}, time.Minute, now); got != obsoletePrompt {
 		t.Fatalf("initial canonical = %q, want %q", got, obsoletePrompt)
 	}
-	if got := cache.canonical(currentPrompt, conversation, time.Minute, now.Add(time.Second)); got != obsoletePrompt {
+	if got := cache.canonical([]string{currentPrompt, conversation}, time.Minute, now.Add(time.Second)); got != obsoletePrompt {
 		t.Fatalf("rotated canonical = %q, want stable %q", got, obsoletePrompt)
 	}
 
@@ -263,7 +264,7 @@ func TestHomeSessionAliasCacheDoesNotReconnectCompactedCanonicalAlias(t *testing
 	}
 	cache.mu.Unlock()
 
-	if got := cache.canonical(obsoletePrompt, "", time.Minute, now.Add(2*time.Second)); got != obsoletePrompt {
+	if got := cache.canonical([]string{obsoletePrompt}, time.Minute, now.Add(2*time.Second)); got != obsoletePrompt {
 		t.Fatalf("obsolete prompt canonical = %q, want standalone %q", got, obsoletePrompt)
 	}
 
@@ -278,8 +279,48 @@ func TestHomeSessionAliasCacheDoesNotReconnectCompactedCanonicalAlias(t *testing
 	if !conversationOK || !currentOK || !sameHomeSessionAliasGroup(conversationEntry, currentEntry) {
 		t.Fatalf("live aliases were disconnected: conversation=%#v current=%#v", conversationEntry, currentEntry)
 	}
-	if got := cache.canonical(conversation, "", time.Minute, now.Add(3*time.Second)); got != obsoletePrompt {
+	if got := cache.canonical([]string{conversation}, time.Minute, now.Add(3*time.Second)); got != obsoletePrompt {
 		t.Fatalf("live conversation canonical = %q, want %q", got, obsoletePrompt)
+	}
+}
+
+func TestHomeSessionAliasCacheConflictCanonicalIsInputOrderIndependent(t *testing.T) {
+	resolve := func(aliases []string) string {
+		var cache homeSessionAliasCache
+		now := time.Now()
+		cache.canonical([]string{"session:z"}, time.Minute, now)
+		cache.canonical([]string{"session:a"}, time.Minute, now)
+		return cache.canonical(aliases, time.Minute, now.Add(time.Second))
+	}
+
+	forward := resolve([]string{"session:z", "session:a"})
+	reverse := resolve([]string{"session:a", "session:z"})
+	if forward != reverse {
+		t.Fatalf("conflicting groups resolved by input order: forward=%q reverse=%q", forward, reverse)
+	}
+	if forward != "session:a" {
+		t.Fatalf("conflicting groups resolved to %q, want stable session:a", forward)
+	}
+}
+
+func TestHomeSessionAliasCacheIsolatesCallerScopes(t *testing.T) {
+	var cache homeSessionAliasCache
+	now := time.Now()
+	shared := "pck:shared-cache"
+	callerAConversation := "conv:caller-a"
+	callerBConversation := "conv:caller-b"
+
+	if got := cache.canonicalForCaller("caller-a", []string{shared, callerAConversation}, time.Minute, now); got != shared {
+		t.Fatalf("caller A canonical = %q, want %q", got, shared)
+	}
+	if got := cache.canonicalForCaller("caller-b", []string{shared, callerBConversation}, time.Minute, now); got != shared {
+		t.Fatalf("caller B canonical = %q, want %q", got, shared)
+	}
+	if got := cache.canonicalForCaller("caller-a", []string{callerAConversation}, time.Minute, now.Add(time.Second)); got != shared {
+		t.Fatalf("caller A conversation canonical = %q, want %q", got, shared)
+	}
+	if got := cache.canonicalForCaller("caller-b", []string{callerAConversation}, time.Minute, now.Add(time.Second)); got != callerAConversation {
+		t.Fatalf("caller B inherited caller A alias: got %q, want %q", got, callerAConversation)
 	}
 }
 
@@ -287,9 +328,9 @@ func TestHomeSessionAliasCacheSoftLimitEvictsOldestTouchedGroup(t *testing.T) {
 	var cache homeSessionAliasCache
 	now := time.Now()
 	const oldest = "session:zzzz-oldest"
-	cache.canonical(oldest, "", time.Hour, now)
+	cache.canonical([]string{oldest}, time.Hour, now)
 	for index := 0; index < homeSessionAliasSoftLimit; index++ {
-		cache.canonical(fmt.Sprintf("session:%05d", index), "", time.Hour, now)
+		cache.canonical([]string{fmt.Sprintf("session:%05d", index)}, time.Hour, now)
 	}
 
 	cache.mu.Lock()
@@ -309,7 +350,7 @@ func TestHomeSessionAliasCacheEnforcesSoftLimit(t *testing.T) {
 	var cache homeSessionAliasCache
 	now := time.Now()
 	for i := 0; i < homeSessionAliasSoftLimit+32; i++ {
-		cache.canonical(fmt.Sprintf("session:%05d", i), "", time.Hour, now.Add(time.Duration(i)*time.Nanosecond))
+		cache.canonical([]string{fmt.Sprintf("session:%05d", i)}, time.Hour, now.Add(time.Duration(i)*time.Nanosecond))
 	}
 
 	cache.mu.Lock()

--- a/sdk/cliproxy/auth/home_websocket_reuse_test.go
+++ b/sdk/cliproxy/auth/home_websocket_reuse_test.go
@@ -220,7 +220,7 @@ func (d *homeAuthTransportErrorDispatcher) HeartbeatOK() bool {
 	return true
 }
 
-func (d *homeAuthTransportErrorDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (d *homeAuthTransportErrorDispatcher) RPopAuth(context.Context, string, home.DispatchSession, http.Header, int) ([]byte, error) {
 	return nil, d.err
 }
 

--- a/sdk/cliproxy/auth/request_auth_prepare_test.go
+++ b/sdk/cliproxy/auth/request_auth_prepare_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"net/http"
 	"reflect"
 	"strings"
@@ -137,7 +138,7 @@ type homeRequestPrepareDispatcher struct {
 
 func (*homeRequestPrepareDispatcher) HeartbeatOK() bool { return true }
 
-func (d *homeRequestPrepareDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+func (d *homeRequestPrepareDispatcher) RPopAuth(context.Context, string, home.DispatchSession, http.Header, int) ([]byte, error) {
 	if d.calls.Add(1) > 1 {
 		return json.Marshal(homeErrorEnvelope{Error: &homeErrorDetail{Code: homeRequestRetryExceededErrorCode, Message: "no more Home auths"}})
 	}

--- a/sdk/cliproxy/auth/scheduler_test.go
+++ b/sdk/cliproxy/auth/scheduler_test.go
@@ -94,7 +94,7 @@ func (d *authKindHomeDispatcher) HeartbeatOK() bool {
 	return true
 }
 
-func (d *authKindHomeDispatcher) RPopAuth(_ context.Context, _ string, _ string, _ http.Header, count int) ([]byte, error) {
+func (d *authKindHomeDispatcher) RPopAuth(_ context.Context, _ string, _ home.DispatchSession, _ http.Header, count int) ([]byte, error) {
 	d.counts = append(d.counts, count)
 	if count < 1 || count > len(d.auths) {
 		return nil, home.ErrAuthNotFound

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 	"math"
 	"net/http"
 	"sort"
@@ -14,7 +13,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/tidwall/gjson"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/credentialweight"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
@@ -530,9 +528,12 @@ func availabilityBlock(unavailable, quotaExceeded bool, nextRetryAfter, nextReco
 // SessionAffinitySelector wraps another selector with session-sticky behavior.
 // It extracts session ID from multiple sources and maintains session-to-auth
 // mappings with automatic failover when the bound auth becomes unavailable.
+const sessionAffinityResolutionLockStripes = 256
+
 type SessionAffinitySelector struct {
-	fallback Selector
-	cache    *SessionCache
+	fallback        Selector
+	cache           *SessionCache
+	resolutionLocks [sessionAffinityResolutionLockStripes]sync.Mutex
 }
 
 // SessionAffinityConfig configures the session affinity selector.
@@ -564,18 +565,31 @@ func NewSessionAffinitySelectorWithConfig(cfg SessionAffinityConfig) *SessionAff
 }
 
 // Pick selects an auth with session affinity when possible.
-// Explicit Claude Code, Codex, OpenCode, pi, and request-body session signals
-// precede execution metadata, stable derived identity, and the legacy hash fallback.
+// All recognized explicit session signals in the same request act as aliases
+// for the same logical session. Fallback identities are considered only when no
+// explicit root session exists.
 //
-// Note: The cache key includes provider, session ID, and model to handle cases where
-// a session uses multiple models (e.g., gemini-2.5-pro and gemini-3-flash-preview)
-// that may be supported by different auth credentials, and to avoid cross-provider conflicts.
+// Note: The cache key includes the caller scope, provider, model, and session ID.
+// Caller scope keeps two downstream API keys that reuse the same client session ID
+// on separate bindings; provider and model handle sessions that span several models
+// supported by different credentials. The client type is deliberately not part of
+// the key: it is detected per request, so a request that arrives without the usual
+// headers would otherwise split an active session onto a second binding.
 func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
 	entry := selectorLogEntry(ctx)
-	primaryID, fallbackID := extractSessionIDs(opts.Headers, opts.OriginalRequest, opts.Metadata)
-	if primaryID == "" {
+	identity := sessionIdentityFromOptions(opts)
+	ids := identity.IDs()
+	if len(ids) == 0 {
 		entry.Debugf("session-affinity: no session ID extracted, falling back to default selector | provider=%s model=%s", provider, model)
 		return s.fallback.Pick(ctx, provider, model, opts, auths)
+	}
+
+	primaryID := identity.ID
+	callerScope := optionsMetadataString(opts, cliproxyexecutor.CallerScopeMetadataKey)
+
+	cacheKeys := make([]string, 0, len(ids))
+	for _, id := range ids {
+		cacheKeys = append(cacheKeys, sessionCacheKey(callerScope, provider, model, id))
 	}
 
 	now := time.Now()
@@ -587,57 +601,117 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	if err != nil {
 		return nil, err
 	}
-
-	cacheKey := provider + "::" + primaryID + "::" + model
-	fallbackKey := ""
-	if fallbackID != "" && fallbackID != primaryID {
-		fallbackKey = provider + "::" + fallbackID + "::" + model
-	}
-	bind := func(authID string) {
-		if fallbackKey != "" {
-			s.cache.SetAliases(authID, cacheKey, fallbackKey)
-			return
+	availableByID := make(map[string]*Auth, len(available))
+	for _, auth := range available {
+		if auth != nil && auth.ID != "" {
+			availableByID[auth.ID] = auth
 		}
-		s.cache.Set(cacheKey, authID)
 	}
 
-	if cachedAuthID, ok := s.cache.GetAndRefresh(cacheKey); ok {
-		for _, auth := range available {
-			if auth.ID == cachedAuthID {
-				bind(auth.ID)
-				entry.Infof("session-affinity: cache hit | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
-				return auth, nil
+	for {
+		snapshot := s.cache.bindingSnapshot(cacheKeys)
+		lockKeys := sessionAffinityResolutionLockKeys(cacheKeys, snapshot.groupLockKeys)
+		heldLocks, unlock := s.lockSessionAffinityResolution(lockKeys)
+
+		current := s.cache.bindingSnapshot(cacheKeys)
+		currentLockKeys := sessionAffinityResolutionLockKeys(cacheKeys, current.groupLockKeys)
+		if !sessionAffinityResolutionLocksCover(heldLocks, currentLockKeys) {
+			unlock()
+			continue
+		}
+
+		var selected *Auth
+		resolution := "miss"
+		switch len(current.authIDs) {
+		case 0:
+			selected, err = s.fallback.Pick(ctx, provider, model, opts, auths)
+		case 1:
+			selected = availableByID[current.authIDs[0]]
+			if selected != nil {
+				resolution = "hit"
+				break
 			}
+			resolution = "unavailable"
+			selected, err = s.fallback.Pick(ctx, provider, model, opts, auths)
+		default:
+			resolution = "conflict"
+			selected, err = s.fallback.Pick(ctx, provider, model, opts, auths)
 		}
-		// Cached auth not available, reselect via fallback selector for even distribution
-		auth, err := s.fallback.Pick(ctx, provider, model, opts, auths)
 		if err != nil {
+			unlock()
 			return nil, err
 		}
-		bind(auth.ID)
-		entry.Infof("session-affinity: cache hit but auth unavailable, reselected | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
-		return auth, nil
-	}
+		s.cache.SetAliases(selected.ID, cacheKeys...)
+		unlock()
 
-	if fallbackKey != "" {
-		if cachedAuthID, ok := s.cache.Get(fallbackKey); ok {
-			for _, auth := range available {
-				if auth.ID == cachedAuthID {
-					bind(auth.ID)
-					entry.Infof("session-affinity: fallback cache hit | session=%s fallback=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model)
-					return auth, nil
-				}
-			}
+		switch resolution {
+		case "hit":
+			entry.Infof("session-affinity: cache hit | session=%s aliases=%d auth=%s provider=%s model=%s", truncateSessionID(primaryID), len(ids), selected.ID, provider, model)
+		case "unavailable":
+			entry.Infof("session-affinity: cache hit but auth unavailable, reselected | session=%s aliases=%d auth=%s provider=%s model=%s", truncateSessionID(primaryID), len(ids), selected.ID, provider, model)
+		case "conflict":
+			entry.Warnf("session-affinity: alias group conflict detected, reselecting | aliases=%d auth_count=%d provider=%s model=%s", len(ids), len(current.authIDs), provider, model)
+			entry.Infof("session-affinity: resolved alias group conflict with new binding | session=%s aliases=%d auth=%s provider=%s model=%s", truncateSessionID(primaryID), len(ids), selected.ID, provider, model)
+		default:
+			entry.Infof("session-affinity: cache miss, new binding | session=%s aliases=%d auth=%s provider=%s model=%s", truncateSessionID(primaryID), len(ids), selected.ID, provider, model)
+		}
+		return selected, nil
+	}
+}
+
+func sessionAffinityResolutionLockKeys(cacheKeys, groupLockKeys []string) []string {
+	keys := make([]string, 0, len(cacheKeys)+len(groupLockKeys))
+	for _, key := range cacheKeys {
+		keys = append(keys, "alias\x00"+key)
+	}
+	for _, key := range groupLockKeys {
+		keys = append(keys, "group\x00"+key)
+	}
+	return keys
+}
+
+func sessionAffinityResolutionLockIndex(key string) int {
+	const (
+		offset32 = uint32(2166136261)
+		prime32  = uint32(16777619)
+	)
+	hash := offset32
+	for index := 0; index < len(key); index++ {
+		hash ^= uint32(key[index])
+		hash *= prime32
+	}
+	return int(hash % sessionAffinityResolutionLockStripes)
+}
+
+func (s *SessionAffinitySelector) lockSessionAffinityResolution(keys []string) ([sessionAffinityResolutionLockStripes]bool, func()) {
+	var held [sessionAffinityResolutionLockStripes]bool
+	indices := make([]int, 0, len(keys))
+	for _, key := range keys {
+		index := sessionAffinityResolutionLockIndex(key)
+		if held[index] {
+			continue
+		}
+		held[index] = true
+		indices = append(indices, index)
+	}
+	sort.Ints(indices)
+	for _, index := range indices {
+		s.resolutionLocks[index].Lock()
+	}
+	return held, func() {
+		for index := len(indices) - 1; index >= 0; index-- {
+			s.resolutionLocks[indices[index]].Unlock()
 		}
 	}
+}
 
-	auth, err := s.fallback.Pick(ctx, provider, model, opts, auths)
-	if err != nil {
-		return nil, err
+func sessionAffinityResolutionLocksCover(held [sessionAffinityResolutionLockStripes]bool, keys []string) bool {
+	for _, key := range keys {
+		if !held[sessionAffinityResolutionLockIndex(key)] {
+			return false
+		}
 	}
-	bind(auth.ID)
-	entry.Infof("session-affinity: cache miss, new binding | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
-	return auth, nil
+	return true
 }
 
 func selectorLogEntry(ctx context.Context) *log.Entry {
@@ -673,361 +747,53 @@ func (s *SessionAffinitySelector) InvalidateAuth(authID string) {
 	}
 }
 
-// normalizedSessionCandidate validates an explicit client-provided session signal.
-// It keeps opaque printable IDs intact while rejecting values that are unsafe or
-// implausibly large for routing keys and logs.
-func normalizedSessionCandidate(raw string) string {
-	return cliproxysession.NormalizeExplicitID(raw)
+// sessionCacheKeyParts is the number of "::" separated fields in a session cache key.
+const sessionCacheKeyParts = 4
+
+// sessionCacheKey builds a session binding key namespaced by caller scope, provider
+// and model. The session ID is placed last so it can be recovered exactly even when
+// an opaque client identifier itself contains the "::" separator.
+func sessionCacheKey(callerScope, provider, model, sessionID string) string {
+	return strings.Join([]string{callerScope, provider, model, sessionID}, "::")
 }
 
-func sessionHeaderValue(headers http.Header, name string) string {
-	if headers == nil {
+// sessionCacheKeySessionID recovers the session ID from a key built by sessionCacheKey.
+func sessionCacheKeySessionID(key string) string {
+	parts := strings.SplitN(key, "::", sessionCacheKeyParts)
+	if len(parts) < sessionCacheKeyParts {
 		return ""
 	}
-	if value := normalizedSessionCandidate(headers.Get(name)); value != "" {
-		return value
-	}
-	for key, values := range headers {
-		if !strings.EqualFold(key, name) {
-			continue
-		}
-		for _, raw := range values {
-			if value := normalizedSessionCandidate(raw); value != "" {
-				return value
-			}
-		}
-	}
-	return ""
+	return parts[sessionCacheKeyParts-1]
 }
 
-// ExtractSessionID extracts a session identifier from explicit client signals,
-// then falls back to execution metadata, derived identity, and message history.
-// Priority order:
-//  1. X-Claude-Code-Session-Id
-//  2. Claude Code metadata.user_id session
-//  3. Session-Id / Session_id (Codex and compatible clients)
-//  4. X-Session-ID
-//  5. X-Session-Affinity (OpenCode)
-//  6. X-Client-Request-Id (pi Responses)
-//  7. session_id / sessionId
-//  8. prompt_cache_key, with conversation / conversation.id as an alias
-//  9. metadata.user_id and conversation_id legacy body fields
-//  10. explicit execution session metadata
-//  11. stable context-derived session identity
-//  12. stable hash from initial message content
+// sessionIdentityFromOptions returns the identity resolved once per request by
+// session.Enrich, and extracts it on demand for direct SDK callers that bypass Enrich.
+func sessionIdentityFromOptions(opts cliproxyexecutor.Options) cliproxysession.Identity {
+	if identity, ok := cliproxysession.FromMetadata(opts.Metadata); ok {
+		return identity
+	}
+	return cliproxysession.Extract(opts.Headers, opts.OriginalRequest, opts.Metadata)
+}
+
+func optionsMetadataString(opts cliproxyexecutor.Options, key string) string {
+	if opts.Metadata == nil {
+		return ""
+	}
+	value, _ := opts.Metadata[key].(string)
+	return strings.TrimSpace(value)
+}
+
+// ExtractSessionID returns the representative session identifier selected for
+// display and compatibility. Affinity routing uses every ID returned by Identity.IDs.
 func ExtractSessionID(headers http.Header, payload []byte, metadata map[string]any) string {
-	primary, _ := extractSessionIDs(headers, payload, metadata)
-	return primary
+	return cliproxysession.Extract(headers, payload, metadata).ID
 }
 
-// extractSessionIDs returns (primaryID, fallbackID) for session affinity.
-// fallbackID preserves an earlier binding when a stronger body identifier appears
-// later, and lets callers bind both identifiers when both are present.
+// extractSessionIDs returns the representative ID and first alias for compatibility.
+// SessionAffinitySelector routes on the full identifier set instead.
 func extractSessionIDs(headers http.Header, payload []byte, metadata map[string]any) (string, string) {
-	if sid := sessionHeaderValue(headers, "X-Claude-Code-Session-Id"); sid != "" {
-		return "claude:" + sid, ""
-	}
-	if sid := cliproxysession.ClaudeMetadataSessionID(payload); sid != "" {
-		return "claude:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "Session-Id"); sid != "" {
-		return "codex:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "Session_id"); sid != "" {
-		return "codex:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Session-ID"); sid != "" {
-		return "header:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Session-Affinity"); sid != "" {
-		return "affinity:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Client-Request-Id"); sid != "" {
-		return "clientreq:" + sid, ""
-	}
-
-	if len(payload) > 0 {
-		for _, path := range []string{"session_id", "sessionId"} {
-			if sid := normalizedSessionCandidate(gjson.GetBytes(payload, path).String()); sid != "" {
-				return "session:" + sid, ""
-			}
-		}
-
-		conversationID := ""
-		conversation := gjson.GetBytes(payload, "conversation")
-		if sid := normalizedSessionCandidate(conversation.Get("id").String()); sid != "" {
-			conversationID = "conv:" + sid
-		} else if conversation.Type == gjson.String {
-			if sid := normalizedSessionCandidate(conversation.String()); sid != "" {
-				conversationID = "conv:" + sid
-			}
-		}
-		if sid := normalizedSessionCandidate(gjson.GetBytes(payload, "prompt_cache_key").String()); sid != "" {
-			return "pck:" + sid, conversationID
-		}
-		if conversationID != "" {
-			return conversationID, ""
-		}
-
-		if userID := normalizedSessionCandidate(gjson.GetBytes(payload, "metadata.user_id").String()); userID != "" {
-			return "user:" + userID, ""
-		}
-		if conversationID := normalizedSessionCandidate(gjson.GetBytes(payload, "conversation_id").String()); conversationID != "" {
-			return "conv:" + conversationID, ""
-		}
-	}
-
-	if executionID, ok := metadata[cliproxyexecutor.ExecutionSessionMetadataKey].(string); ok {
-		if executionID = normalizedSessionCandidate(executionID); executionID != "" {
-			return "execution:" + executionID, ""
-		}
-	}
-	if derivedID := normalizedSessionCandidate(cliproxysession.DerivedID(metadata)); derivedID != "" {
-		return "derived:" + derivedID, ""
-	}
-	if len(payload) == 0 {
-		return "", ""
-	}
-	return extractMessageHashIDs(payload)
-}
-
-func extractMessageHashIDs(payload []byte) (primaryID, fallbackID string) {
-	var systemPrompt, firstUserMsg, firstAssistantMsg string
-
-	// OpenAI/Claude messages format
-	messages := gjson.GetBytes(payload, "messages")
-	if messages.Exists() && messages.IsArray() {
-		messages.ForEach(func(_, msg gjson.Result) bool {
-			role := msg.Get("role").String()
-			content := extractMessageContent(msg.Get("content"))
-			if content == "" {
-				return true
-			}
-
-			switch role {
-			case "system":
-				if systemPrompt == "" {
-					systemPrompt = truncateString(content, 100)
-				}
-			case "user":
-				if firstUserMsg == "" {
-					firstUserMsg = truncateString(content, 100)
-				}
-			case "assistant":
-				if firstAssistantMsg == "" {
-					firstAssistantMsg = truncateString(content, 100)
-				}
-			}
-
-			if systemPrompt != "" && firstUserMsg != "" && firstAssistantMsg != "" {
-				return false
-			}
-			return true
-		})
-	}
-
-	// Claude API: top-level "system" field (array or string)
-	if systemPrompt == "" {
-		topSystem := gjson.GetBytes(payload, "system")
-		if topSystem.Exists() {
-			if topSystem.IsArray() {
-				topSystem.ForEach(func(_, part gjson.Result) bool {
-					if text := part.Get("text").String(); text != "" && systemPrompt == "" {
-						systemPrompt = truncateString(text, 100)
-						return false
-					}
-					return true
-				})
-			} else if topSystem.Type == gjson.String {
-				systemPrompt = truncateString(topSystem.String(), 100)
-			}
-		}
-	}
-
-	// Gemini format
-	if systemPrompt == "" && firstUserMsg == "" {
-		sysInstr := gjson.GetBytes(payload, "systemInstruction.parts")
-		if sysInstr.Exists() && sysInstr.IsArray() {
-			sysInstr.ForEach(func(_, part gjson.Result) bool {
-				if text := part.Get("text").String(); text != "" && systemPrompt == "" {
-					systemPrompt = truncateString(text, 100)
-					return false
-				}
-				return true
-			})
-		}
-
-		contents := gjson.GetBytes(payload, "contents")
-		if contents.Exists() && contents.IsArray() {
-			contents.ForEach(func(_, msg gjson.Result) bool {
-				role := msg.Get("role").String()
-				msg.Get("parts").ForEach(func(_, part gjson.Result) bool {
-					text := part.Get("text").String()
-					if text == "" {
-						return true
-					}
-					switch role {
-					case "user":
-						if firstUserMsg == "" {
-							firstUserMsg = truncateString(text, 100)
-						}
-					case "model":
-						if firstAssistantMsg == "" {
-							firstAssistantMsg = truncateString(text, 100)
-						}
-					}
-					return false
-				})
-				if firstUserMsg != "" && firstAssistantMsg != "" {
-					return false
-				}
-				return true
-			})
-		}
-	}
-
-	// OpenAI Responses API format (v1/responses)
-	if systemPrompt == "" && firstUserMsg == "" {
-		if instr := gjson.GetBytes(payload, "instructions").String(); instr != "" {
-			systemPrompt = truncateString(instr, 100)
-		}
-
-		input := gjson.GetBytes(payload, "input")
-		if input.Exists() && input.IsArray() {
-			input.ForEach(func(_, item gjson.Result) bool {
-				itemType := item.Get("type").String()
-				if itemType == "reasoning" {
-					return true
-				}
-				// Skip non-message typed items (function_call, function_call_output, etc.)
-				// but allow items with no type that have a role (inline message format).
-				if itemType != "" && itemType != "message" {
-					return true
-				}
-
-				role := item.Get("role").String()
-				if itemType == "" && role == "" {
-					return true
-				}
-
-				// Handle both string content and array content (multimodal).
-				content := item.Get("content")
-				var text string
-				if content.Type == gjson.String {
-					text = content.String()
-				} else {
-					text = extractResponsesAPIContent(content)
-				}
-				if text == "" {
-					return true
-				}
-
-				switch role {
-				case "developer", "system":
-					if systemPrompt == "" {
-						systemPrompt = truncateString(text, 100)
-					}
-				case "user":
-					if firstUserMsg == "" {
-						firstUserMsg = truncateString(text, 100)
-					}
-				case "assistant":
-					if firstAssistantMsg == "" {
-						firstAssistantMsg = truncateString(text, 100)
-					}
-				}
-
-				if firstUserMsg != "" && firstAssistantMsg != "" {
-					return false
-				}
-				return true
-			})
-		}
-	}
-
-	if systemPrompt == "" && firstUserMsg == "" {
-		return "", ""
-	}
-
-	shortHash := computeSessionHash(systemPrompt, firstUserMsg, "")
-	if firstAssistantMsg == "" {
-		return shortHash, ""
-	}
-
-	fullHash := computeSessionHash(systemPrompt, firstUserMsg, firstAssistantMsg)
-	return fullHash, shortHash
-}
-
-func computeSessionHash(systemPrompt, userMsg, assistantMsg string) string {
-	h := fnv.New64a()
-	if systemPrompt != "" {
-		h.Write([]byte("sys:" + systemPrompt + "\n"))
-	}
-	if userMsg != "" {
-		h.Write([]byte("usr:" + userMsg + "\n"))
-	}
-	if assistantMsg != "" {
-		h.Write([]byte("ast:" + assistantMsg + "\n"))
-	}
-	return fmt.Sprintf("msg:%016x", h.Sum64())
-}
-
-func truncateString(s string, maxLen int) string {
-	if len(s) > maxLen {
-		return s[:maxLen]
-	}
-	return s
-}
-
-// extractMessageContent extracts text content from a message content field.
-// Handles both string content and array content (multimodal messages).
-// For array content, extracts text from all text-type elements.
-func extractMessageContent(content gjson.Result) string {
-	// String content: "Hello world"
-	if content.Type == gjson.String {
-		return content.String()
-	}
-
-	// Array content: [{"type":"text","text":"Hello"},{"type":"image",...}]
-	if content.IsArray() {
-		var texts []string
-		content.ForEach(func(_, part gjson.Result) bool {
-			// Handle Claude format: {"type":"text","text":"content"}
-			if part.Get("type").String() == "text" {
-				if text := part.Get("text").String(); text != "" {
-					texts = append(texts, text)
-				}
-			}
-			// Handle OpenAI format: {"type":"text","text":"content"}
-			// Same structure as Claude, already handled above
-			return true
-		})
-		if len(texts) > 0 {
-			return strings.Join(texts, " ")
-		}
-	}
-
-	return ""
-}
-
-func extractResponsesAPIContent(content gjson.Result) string {
-	if !content.IsArray() {
-		return ""
-	}
-	var texts []string
-	content.ForEach(func(_, part gjson.Result) bool {
-		partType := part.Get("type").String()
-		if partType == "input_text" || partType == "output_text" || partType == "text" {
-			if text := part.Get("text").String(); text != "" {
-				texts = append(texts, text)
-			}
-		}
-		return true
-	})
-	if len(texts) > 0 {
-		return strings.Join(texts, " ")
-	}
-	return ""
+	identity := cliproxysession.Extract(headers, payload, metadata)
+	return identity.ID, identity.FallbackID()
 }
 
 // extractSessionID is kept for backward compatibility.

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -16,6 +17,40 @@ import (
 	cliproxysession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 )
+
+type firstPickBlockingSelector struct {
+	mu           sync.Mutex
+	calls        int
+	firstEntered chan struct{}
+	releaseFirst chan struct{}
+}
+
+func newFirstPickBlockingSelector() *firstPickBlockingSelector {
+	return &firstPickBlockingSelector{
+		firstEntered: make(chan struct{}),
+		releaseFirst: make(chan struct{}),
+	}
+}
+
+func (s *firstPickBlockingSelector) Pick(_ context.Context, _, _ string, _ cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	s.mu.Lock()
+	call := s.calls
+	s.calls++
+	if call == 0 {
+		close(s.firstEntered)
+	}
+	s.mu.Unlock()
+	if call == 0 {
+		<-s.releaseFirst
+	}
+	return auths[call%len(auths)], nil
+}
+
+func (s *firstPickBlockingSelector) Calls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
 
 func TestFillFirstSelectorPick_Deterministic(t *testing.T) {
 	t.Parallel()
@@ -923,33 +958,33 @@ func TestSessionAffinitySelector_FailoverWhenAuthUnavailable(t *testing.T) {
 	}
 }
 
-func TestExtractSessionID_ClaudeCodePriorityOverHeader(t *testing.T) {
+func TestExtractSessionIDUsesClaudeCodeAsRepresentativeWithGenericAlias(t *testing.T) {
 	t.Parallel()
 
-	// Claude Code metadata.user_id remains higher priority than a generic X-Session-ID header.
 	headers := make(http.Header)
 	headers.Set("X-Session-ID", "header-session-id")
-
 	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_ac980658-63bd-4fb3-97ba-8da64cb1e344"}}`)
 
-	got := ExtractSessionID(headers, payload, nil)
+	identity := cliproxysession.Extract(headers, payload, nil)
 	want := "claude:ac980658-63bd-4fb3-97ba-8da64cb1e344"
-	if got != want {
-		t.Errorf("ExtractSessionID() = %q, want %q (Claude Code should have highest priority over header)", got, want)
+	if identity.ID != want {
+		t.Errorf("identity.ID = %q, want representative %q", identity.ID, want)
+	}
+	if !containsString(identity.Aliases, "header:header-session-id") {
+		t.Fatalf("identity.Aliases = %#v, want generic header alias", identity.Aliases)
 	}
 }
 
-func TestExtractSessionID_ClaudeCodePriorityOverIdempotencyKey(t *testing.T) {
+func TestExtractSessionIDIgnoresIdempotencyKey(t *testing.T) {
 	t.Parallel()
 
-	// Claude Code metadata.user_id should have highest priority, even when idempotency_key is present
 	metadata := map[string]any{"idempotency_key": "idem-12345"}
 	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_ac980658-63bd-4fb3-97ba-8da64cb1e344"}}`)
 
 	got := ExtractSessionID(nil, payload, metadata)
 	want := "claude:ac980658-63bd-4fb3-97ba-8da64cb1e344"
 	if got != want {
-		t.Errorf("ExtractSessionID() = %q, want %q (Claude Code should have highest priority over idempotency_key)", got, want)
+		t.Errorf("ExtractSessionID() = %q, want %q", got, want)
 	}
 }
 
@@ -992,17 +1027,19 @@ func TestExtractSessionID_ClientRequestIDHeader(t *testing.T) {
 	}
 }
 
-func TestExtractSessionID_CodexSessionIDPriorityOverClientRequestID(t *testing.T) {
+func TestExtractSessionIDUsesCodexAsRepresentativeWithClientRequestAlias(t *testing.T) {
 	t.Parallel()
 
 	headers := make(http.Header)
 	headers.Set("X-Client-Request-Id", "pi-session-123")
 	headers.Set("Session_id", "codex-session-456")
 
-	got := ExtractSessionID(headers, nil, nil)
-	want := "codex:codex-session-456"
-	if got != want {
-		t.Errorf("ExtractSessionID() = %q, want %q (Session_id should take priority over X-Client-Request-Id)", got, want)
+	identity := cliproxysession.Extract(headers, nil, nil)
+	if identity.ID != "codex:codex-session-456" {
+		t.Errorf("identity.ID = %q, want Codex representative", identity.ID)
+	}
+	if !containsString(identity.Aliases, "clientreq:pi-session-123") {
+		t.Fatalf("identity.Aliases = %#v, want client request alias", identity.Aliases)
 	}
 }
 
@@ -1020,7 +1057,7 @@ func TestExtractSessionID_IdempotencyKey(t *testing.T) {
 	}
 }
 
-func TestExtractSessionID_DerivedSessionAndExplicitPriority(t *testing.T) {
+func TestExtractSessionIDFallbacksAndRepresentativeID(t *testing.T) {
 	t.Parallel()
 
 	metadata := map[string]any{cliproxyexecutor.DerivedSessionIDMetadataKey: "ctx:v1:derived-root"}
@@ -1042,9 +1079,14 @@ func TestExtractSessionID_DerivedSessionAndExplicitPriority(t *testing.T) {
 		t.Fatalf("ExtractSessionID() = %q, want explicit body session", got)
 	}
 
-	userPayload := []byte(`{"metadata":{"user_id":"explicit-user"},"conversation_id":"explicit-conversation","messages":[{"role":"user","content":"hello"}]}`)
-	if got := ExtractSessionID(nil, userPayload, metadata); got != "user:explicit-user" {
-		t.Fatalf("ExtractSessionID() = %q, want explicit metadata.user_id", got)
+	sessionWithUserPayload := []byte(`{"metadata":{"user_id":"explicit-user"},"conversation_id":"explicit-conversation","messages":[{"role":"user","content":"hello"}]}`)
+	if got := ExtractSessionID(nil, sessionWithUserPayload, metadata); got != "conv:explicit-conversation" {
+		t.Fatalf("ExtractSessionID() = %q, want conv:explicit-conversation over bare user_id", got)
+	}
+
+	bareUserPayload := []byte(`{"metadata":{"user_id":"explicit-user"},"messages":[{"role":"user","content":"hello"}]}`)
+	if got := ExtractSessionID(nil, bareUserPayload, metadata); got != "user:explicit-user" {
+		t.Fatalf("ExtractSessionID() = %q, want explicit metadata.user_id fallback", got)
 	}
 
 	lowercaseHeaders := http.Header{"x-session-id": []string{" lowercase-session "}}
@@ -1342,13 +1384,171 @@ func TestSessionAffinitySelector_ThreeScenarios(t *testing.T) {
 	})
 }
 
+func TestSessionAffinitySelectorReusesExistingGenericAlias(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &RoundRobinSelector{},
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	provider := "test-generic-first"
+
+	// The generic affinity header establishes the initial binding.
+	req1Opts := cliproxyexecutor.Options{
+		Headers: http.Header{"X-Session-Affinity": {"aff-1"}},
+	}
+	pick1, err := selector.Pick(context.Background(), provider, "gpt-test", req1Opts, auths)
+	if err != nil {
+		t.Fatalf("req1 Pick() error = %v", err)
+	}
+
+	// A combined request reuses that binding and joins all identifiers.
+	req2Opts := cliproxyexecutor.Options{
+		Headers: http.Header{
+			"X-Claude-Code-Session-Id": {"claude-1"},
+			"X-Session-Affinity":       {"aff-1"},
+		},
+		OriginalRequest: []byte(`{"conversation_id":"conv-1"}`),
+	}
+	pick2, err := selector.Pick(context.Background(), provider, "gpt-test", req2Opts, auths)
+	if err != nil {
+		t.Fatalf("req2 Pick() error = %v", err)
+	}
+	if pick2.ID != pick1.ID {
+		t.Fatalf("combined request changed auth from %q to %q", pick1.ID, pick2.ID)
+	}
+
+	// The newly joined Claude identifier reuses the same auth.
+	req3Opts := cliproxyexecutor.Options{
+		Headers: http.Header{"X-Claude-Code-Session-Id": {"claude-1"}},
+	}
+	pick3, err := selector.Pick(context.Background(), provider, "gpt-test", req3Opts, auths)
+	if err != nil {
+		t.Fatalf("req3 Pick() error = %v", err)
+	}
+	if pick3.ID != pick1.ID {
+		t.Fatalf("claude-only request changed auth from %q to %q", pick1.ID, pick3.ID)
+	}
+
+	// The newly joined body identifier also reuses the same auth.
+	req4Opts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"conversation_id":"conv-1"}`),
+	}
+	pick4, err := selector.Pick(context.Background(), provider, "gpt-test", req4Opts, auths)
+	if err != nil {
+		t.Fatalf("req4 Pick() error = %v", err)
+	}
+	if pick4.ID != pick1.ID {
+		t.Fatalf("body-only request changed auth from %q to %q", pick1.ID, pick4.ID)
+	}
+}
+
+func TestSessionAffinitySelectorFirstMultiIdentifierBindsAllKeys(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &RoundRobinSelector{},
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	provider := "test-multi-bind-first"
+
+	firstOpts := cliproxyexecutor.Options{
+		Headers: http.Header{
+			"X-Claude-Code-Session-Id": {"cc-100"},
+			"Session-Id":               {"cx-100"},
+		},
+		OriginalRequest: []byte(`{"prompt_cache_key":"pck-100"}`),
+	}
+	firstPick, err := selector.Pick(context.Background(), provider, "gpt-test", firstOpts, auths)
+	if err != nil {
+		t.Fatalf("first Pick() error = %v", err)
+	}
+
+	// Test each single identifier alone
+	for _, singleOpts := range []cliproxyexecutor.Options{
+		{Headers: http.Header{"X-Claude-Code-Session-Id": {"cc-100"}}},
+		{Headers: http.Header{"Session-Id": {"cx-100"}}},
+		{OriginalRequest: []byte(`{"prompt_cache_key":"pck-100"}`)},
+	} {
+		pick, errPick := selector.Pick(context.Background(), provider, "gpt-test", singleOpts, auths)
+		if errPick != nil {
+			t.Fatalf("single identifier Pick() error = %v", errPick)
+		}
+		if pick.ID != firstPick.ID {
+			t.Fatalf("single identifier got %q, want %q", pick.ID, firstPick.ID)
+		}
+	}
+}
+
+func TestSessionAffinitySelectorAliasGroupConflictReselectsAndMergesSymmetrically(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &RoundRobinSelector{},
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	provider := "test-conflict-merge"
+
+	// Bind alias 1 to auth-a
+	opts1 := cliproxyexecutor.Options{Headers: http.Header{"X-Session-Affinity": {"aff-conflict"}}}
+	pick1, err := selector.Pick(context.Background(), provider, "gpt-test", opts1, auths)
+	if err != nil {
+		t.Fatalf("opts1 Pick() error = %v", err)
+	}
+
+	// Bind alias 2 to auth-b
+	opts2 := cliproxyexecutor.Options{Headers: http.Header{"X-Claude-Code-Session-Id": {"cc-conflict"}}}
+	pick2, err := selector.Pick(context.Background(), provider, "gpt-test", opts2, auths)
+	if err != nil {
+		t.Fatalf("opts2 Pick() error = %v", err)
+	}
+	if pick1.ID == pick2.ID {
+		t.Fatalf("expected different auths initially, both got %q", pick1.ID)
+	}
+
+	// Combined request triggers conflict resolution
+	combinedOpts := cliproxyexecutor.Options{
+		Headers: http.Header{
+			"X-Session-Affinity":       {"aff-conflict"},
+			"X-Claude-Code-Session-Id": {"cc-conflict"},
+		},
+	}
+	combinedPick, err := selector.Pick(context.Background(), provider, "gpt-test", combinedOpts, auths)
+	if err != nil {
+		t.Fatalf("combined Pick() error = %v", err)
+	}
+
+	// Subsequent single alias requests must both yield combinedPick.ID
+	pick1After, err := selector.Pick(context.Background(), provider, "gpt-test", opts1, auths)
+	if err != nil {
+		t.Fatalf("opts1 after Pick() error = %v", err)
+	}
+	if pick1After.ID != combinedPick.ID {
+		t.Fatalf("alias 1 after merge got %q, want %q", pick1After.ID, combinedPick.ID)
+	}
+
+	pick2After, err := selector.Pick(context.Background(), provider, "gpt-test", opts2, auths)
+	if err != nil {
+		t.Fatalf("opts2 after Pick() error = %v", err)
+	}
+	if pick2After.ID != combinedPick.ID {
+		t.Fatalf("alias 2 after merge got %q, want %q", pick2After.ID, combinedPick.ID)
+	}
+}
+
 func TestSessionAffinitySelectorBodyIdentifierTransitionsPreserveBinding(t *testing.T) {
 	t.Parallel()
 
 	bothPayload := []byte(`{"conversation":{"id":"conversation-session"},"prompt_cache_key":"shared-cache-bucket"}`)
-	primaryID, fallbackID := extractSessionIDs(nil, bothPayload, nil)
-	if primaryID != "pck:shared-cache-bucket" || fallbackID != "conv:conversation-session" {
-		t.Fatalf("extractSessionIDs() = (%q, %q), want prompt-cache primary with conversation fallback", primaryID, fallbackID)
+	representativeID, aliasID := extractSessionIDs(nil, bothPayload, nil)
+	if representativeID != "pck:shared-cache-bucket" || aliasID != "conv:conversation-session" {
+		t.Fatalf("extractSessionIDs() = (%q, %q), want prompt-cache representative with conversation alias", representativeID, aliasID)
 	}
 
 	for _, tt := range []struct {
@@ -1425,7 +1625,7 @@ func TestSessionAffinitySelectorPrimaryTrafficKeepsConversationAliasAlive(t *tes
 	if err != nil {
 		t.Fatalf("combined Pick() error = %v", err)
 	}
-	conversationKey := provider + "::conv:conversation-session::" + model
+	conversationKey := sessionCacheKey("", provider, model, "conv:conversation-session")
 	selector.cache.mu.Lock()
 	conversationEntry := selector.cache.entries[conversationKey]
 	conversationEntry.expiresAt = time.Now().Add(-time.Second)
@@ -1513,9 +1713,9 @@ func TestSessionAffinitySelectorConversationIDContainingPromptMarkerRemainsStabl
 func TestSessionCacheSharedPromptKeyCapsStableAliasesByRecency(t *testing.T) {
 	cache := NewSessionCache(time.Minute)
 	defer cache.Stop()
-	const promptKey = "openai::pck:shared-cache-bucket::gpt-test"
+	promptKey := sessionCacheKey("", "openai", "gpt-test", "pck:shared-cache-bucket")
 	for index := 0; index < 128; index++ {
-		conversation := fmt.Sprintf("openai::conv:conversation-%03d::gpt-test", index)
+		conversation := sessionCacheKey("", "openai", "gpt-test", fmt.Sprintf("conv:conversation-%03d", index))
 		cache.SetAliases("auth-a", promptKey, conversation)
 	}
 
@@ -1524,10 +1724,10 @@ func TestSessionCacheSharedPromptKeyCapsStableAliasesByRecency(t *testing.T) {
 	if len(cache.entries) > 65 {
 		t.Fatalf("cache entries = %d, want one prompt key plus at most 64 stable aliases", len(cache.entries))
 	}
-	if _, ok := cache.entries["openai::conv:conversation-127::gpt-test"]; !ok {
+	if _, ok := cache.entries[sessionCacheKey("", "openai", "gpt-test", "conv:conversation-127")]; !ok {
 		t.Fatal("newest conversation alias was not retained")
 	}
-	if _, ok := cache.entries["openai::conv:conversation-000::gpt-test"]; ok {
+	if _, ok := cache.entries[sessionCacheKey("", "openai", "gpt-test", "conv:conversation-000")]; ok {
 		t.Fatal("oldest conversation alias was retained after stable-alias cap")
 	}
 }
@@ -1536,13 +1736,13 @@ func TestSessionCacheRotatingPrimaryEvictsObsoleteAliases(t *testing.T) {
 	cache := NewSessionCache(time.Minute)
 	defer cache.Stop()
 
-	const fallback = "openai::conv:conversation-session::gpt-test"
+	fallback := sessionCacheKey("", "openai", "gpt-test", "conv:conversation-session")
 	for index := 0; index < 16; index++ {
-		primary := fmt.Sprintf("openai::pck:cache-%02d::gpt-test", index)
+		primary := sessionCacheKey("", "openai", "gpt-test", fmt.Sprintf("pck:cache-%02d", index))
 		cache.SetAliases("auth-a", primary, fallback)
 	}
-	latest := "openai::pck:cache-15::gpt-test"
-	oldest := "openai::pck:cache-00::gpt-test"
+	latest := sessionCacheKey("", "openai", "gpt-test", "pck:cache-15")
+	oldest := sessionCacheKey("", "openai", "gpt-test", "pck:cache-00")
 
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()
@@ -1850,6 +2050,124 @@ func TestSessionAffinitySelector_Concurrent(t *testing.T) {
 	}
 }
 
+func TestSessionAffinitySelectorConcurrentFirstPickUsesOneAuth(t *testing.T) {
+	fallback := newFirstPickBlockingSelector()
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: fallback,
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}, {ID: "auth-c"}}
+	opts := cliproxyexecutor.Options{Headers: http.Header{"X-Session-ID": {"cold-session"}}}
+	type pickResult struct {
+		auth *Auth
+		err  error
+	}
+	const goroutines = 128
+	results := make(chan pickResult, goroutines)
+
+	go func() {
+		auth, errPick := selector.Pick(context.Background(), "openai", "gpt-test", opts, auths)
+		results <- pickResult{auth: auth, err: errPick}
+	}()
+	<-fallback.firstEntered
+
+	for index := 1; index < goroutines; index++ {
+		go func() {
+			auth, errPick := selector.Pick(context.Background(), "openai", "gpt-test", opts, auths)
+			results <- pickResult{auth: auth, err: errPick}
+		}()
+	}
+	for index := 0; index < 1000 && fallback.Calls() == 1; index++ {
+		runtime.Gosched()
+	}
+	close(fallback.releaseFirst)
+
+	selectedID := ""
+	for index := 0; index < goroutines; index++ {
+		result := <-results
+		if result.err != nil {
+			t.Fatalf("concurrent cold Pick() error = %v", result.err)
+		}
+		if result.auth == nil {
+			t.Fatal("concurrent cold Pick() returned nil auth")
+		}
+		if selectedID == "" {
+			selectedID = result.auth.ID
+		}
+		if result.auth.ID != selectedID {
+			t.Fatalf("concurrent cold Pick() returned auth %q and %q for one session", selectedID, result.auth.ID)
+		}
+	}
+	if calls := fallback.Calls(); calls != 1 {
+		t.Fatalf("fallback Pick() calls = %d, want 1 atomic first binding", calls)
+	}
+}
+
+func TestSessionAffinitySelectorConcurrentOverlappingAliasesUseOneAuth(t *testing.T) {
+	fallback := newFirstPickBlockingSelector()
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: fallback,
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	left := cliproxyexecutor.Options{Headers: http.Header{
+		"X-Claude-Code-Session-Id": {"alias-a"},
+		"X-Session-Affinity":       {"shared-alias"},
+	}}
+	right := cliproxyexecutor.Options{Headers: http.Header{
+		"X-Session-Affinity": {"shared-alias"},
+		"Session-Id":         {"alias-c"},
+	}}
+	type pickResult struct {
+		auth *Auth
+		err  error
+	}
+	results := make(chan pickResult, 2)
+	go func() {
+		auth, errPick := selector.Pick(context.Background(), "openai", "gpt-test", left, auths)
+		results <- pickResult{auth: auth, err: errPick}
+	}()
+	<-fallback.firstEntered
+	go func() {
+		auth, errPick := selector.Pick(context.Background(), "openai", "gpt-test", right, auths)
+		results <- pickResult{auth: auth, err: errPick}
+	}()
+	for index := 0; index < 1000 && fallback.Calls() == 1; index++ {
+		runtime.Gosched()
+	}
+	close(fallback.releaseFirst)
+
+	first := <-results
+	second := <-results
+	if first.err != nil || second.err != nil {
+		t.Fatalf("overlapping alias Pick() errors = (%v, %v)", first.err, second.err)
+	}
+	if first.auth == nil || second.auth == nil || first.auth.ID != second.auth.ID {
+		t.Fatalf("overlapping alias Picks = (%v, %v), want one auth", first.auth, second.auth)
+	}
+	if calls := fallback.Calls(); calls != 1 {
+		t.Fatalf("fallback Pick() calls = %d, want 1 for overlapping cold aliases", calls)
+	}
+
+	for name, opts := range map[string]cliproxyexecutor.Options{
+		"left":   {Headers: http.Header{"X-Claude-Code-Session-Id": {"alias-a"}}},
+		"shared": {Headers: http.Header{"X-Session-Affinity": {"shared-alias"}}},
+		"right":  {Headers: http.Header{"Session-Id": {"alias-c"}}},
+	} {
+		picked, errPick := selector.Pick(context.Background(), "openai", "gpt-test", opts, auths)
+		if errPick != nil {
+			t.Fatalf("%s alias Pick() error = %v", name, errPick)
+		}
+		if picked.ID != first.auth.ID {
+			t.Fatalf("%s alias Pick() = %q, want %q", name, picked.ID, first.auth.ID)
+		}
+	}
+}
+
 func TestExtractSessionIDNativeSignals(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -1910,7 +2228,7 @@ func TestExtractSessionIDNativeSignals(t *testing.T) {
 	}
 }
 
-func TestExtractSessionIDNativeSignalPriority(t *testing.T) {
+func TestExtractSessionIDNativeSignalsRepresentativeID(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
@@ -1919,7 +2237,7 @@ func TestExtractSessionIDNativeSignalPriority(t *testing.T) {
 		want    string
 	}{
 		{
-			name: "claude header beats metadata",
+			name: "claude header representative before metadata",
 			headers: http.Header{
 				"X-Claude-Code-Session-Id": []string{"header-session"},
 			},
@@ -1927,7 +2245,7 @@ func TestExtractSessionIDNativeSignalPriority(t *testing.T) {
 			want:    "claude:header-session",
 		},
 		{
-			name: "claude metadata beats codex header",
+			name: "claude metadata representative before codex header",
 			headers: http.Header{
 				"Session-Id": []string{"codex-session"},
 			},
@@ -1935,7 +2253,7 @@ func TestExtractSessionIDNativeSignalPriority(t *testing.T) {
 			want:    "claude:22222222-2222-4222-8222-222222222222",
 		},
 		{
-			name: "codex header beats x session id and prompt key",
+			name: "codex header representative before x session id and prompt key",
 			headers: http.Header{
 				"Session-Id":   []string{"codex-session"},
 				"X-Session-Id": []string{"generic-session"},
@@ -1944,7 +2262,7 @@ func TestExtractSessionIDNativeSignalPriority(t *testing.T) {
 			want:    "codex:codex-session",
 		},
 		{
-			name: "x session id beats affinity",
+			name: "x session id representative before affinity",
 			headers: http.Header{
 				"X-Session-Id":       []string{"generic-session"},
 				"X-Session-Affinity": []string{"affinity-session"},
@@ -1952,12 +2270,12 @@ func TestExtractSessionIDNativeSignalPriority(t *testing.T) {
 			want: "header:generic-session",
 		},
 		{
-			name:    "prompt cache key beats conversation id",
+			name:    "prompt cache key representative before conversation id",
 			payload: `{"conversation":{"id":"conversation-session"},"prompt_cache_key":"shared-cache-bucket"}`,
 			want:    "pck:shared-cache-bucket",
 		},
 		{
-			name: "client request id beats body fallbacks",
+			name: "client request id representative before body session",
 			headers: http.Header{
 				"X-Client-Request-Id": []string{"client-session"},
 			},
@@ -2006,7 +2324,7 @@ func TestExtractSessionIDRejectsInvalidExplicitSignals(t *testing.T) {
 			want:    "",
 		},
 		{
-			name: "invalid stronger signal falls through",
+			name: "invalid signal is omitted while valid signal remains",
 			headers: http.Header{
 				"X-Claude-Code-Session-Id": []string{"bad\nsession"},
 				"Session-Id":               []string{"valid-codex"},

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -1014,32 +1014,41 @@ func TestExtractSessionID_CodexSessionIDHeader(t *testing.T) {
 	}
 }
 
-func TestExtractSessionID_ClientRequestIDHeader(t *testing.T) {
+// TestExtractSessionID_ClientRequestIDHeaderIsLastResort verifies the header still
+// provides affinity for a client that sends nothing else, while never competing
+// with a real root identifier. Live captures show it follows the current thread: a
+// Codex sub-agent sends its own thread identifier there while session-id stays on
+// the root, so it must not join the root alias group when a root exists.
+func TestExtractSessionID_ClientRequestIDHeaderIsLastResort(t *testing.T) {
 	t.Parallel()
 
 	headers := make(http.Header)
 	headers.Set("X-Client-Request-Id", "pi-session-123")
 
-	got := ExtractSessionID(headers, nil, nil)
-	want := "clientreq:pi-session-123"
-	if got != want {
-		t.Errorf("ExtractSessionID() with X-Client-Request-Id = %q, want %q", got, want)
+	if got := ExtractSessionID(headers, nil, nil); got != "clientreq:pi-session-123" {
+		t.Errorf("ExtractSessionID() with only X-Client-Request-Id = %q, want clientreq:pi-session-123", got)
 	}
 }
 
-func TestExtractSessionIDUsesCodexAsRepresentativeWithClientRequestAlias(t *testing.T) {
+// TestExtractSessionIDKeepsThreadIdentifiersOutOfTheAliasGroup mirrors a captured
+// Codex sub-agent turn, where x-client-request-id carries the child thread. The
+// alias group must stay the root session only, otherwise every sub-agent adds a
+// throwaway alias to it.
+func TestExtractSessionIDKeepsThreadIdentifiersOutOfTheAliasGroup(t *testing.T) {
 	t.Parallel()
 
 	headers := make(http.Header)
-	headers.Set("X-Client-Request-Id", "pi-session-123")
+	headers.Set("X-Client-Request-Id", "child-thread-123")
 	headers.Set("Session_id", "codex-session-456")
 
 	identity := cliproxysession.Extract(headers, nil, nil)
 	if identity.ID != "codex:codex-session-456" {
 		t.Errorf("identity.ID = %q, want Codex representative", identity.ID)
 	}
-	if !containsString(identity.Aliases, "clientreq:pi-session-123") {
-		t.Fatalf("identity.Aliases = %#v, want client request alias", identity.Aliases)
+	for _, id := range identity.IDs() {
+		if strings.Contains(id, "child-thread-123") {
+			t.Fatalf("identity.IDs() = %#v, want no thread identifier", identity.IDs())
+		}
 	}
 }
 
@@ -1442,6 +1451,63 @@ func TestSessionAffinitySelectorReusesExistingGenericAlias(t *testing.T) {
 	}
 	if pick4.ID != pick1.ID {
 		t.Fatalf("body-only request changed auth from %q to %q", pick1.ID, pick4.ID)
+	}
+}
+
+// TestSessionAffinitySelectorOpenCodeSubagentReusesParentAuth covers the captured
+// OpenCode convention: a sub-agent gets its own X-Session-Id and reports the root
+// in X-Parent-Session-Id. Without reading the parent header the child looks like an
+// unrelated session and lands on a different credential, losing the parent's cache.
+func TestSessionAffinitySelectorOpenCodeSubagentReusesParentAuth(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &RoundRobinSelector{},
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	provider := "test-opencode-subagent"
+	userAgent := "opencode/1.18.4 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14"
+
+	parentOpts := cliproxyexecutor.Options{
+		Headers: http.Header{
+			"X-Session-Id":       {"ses_root"},
+			"X-Session-Affinity": {"ses_root"},
+			"User-Agent":         {userAgent},
+		},
+	}
+	parentPick, err := selector.Pick(context.Background(), provider, "gpt-test", parentOpts, auths)
+	if err != nil {
+		t.Fatalf("parent Pick() error = %v", err)
+	}
+
+	// Two concurrent sub-agents must both land on the parent's credential.
+	for _, child := range []string{"ses_child_a", "ses_child_b"} {
+		childOpts := cliproxyexecutor.Options{
+			Headers: http.Header{
+				"X-Session-Id":        {child},
+				"X-Session-Affinity":  {child},
+				"X-Parent-Session-Id": {"ses_root"},
+				"User-Agent":          {userAgent},
+			},
+		}
+		childPick, errChild := selector.Pick(context.Background(), provider, "gpt-test", childOpts, auths)
+		if errChild != nil {
+			t.Fatalf("subagent %s Pick() error = %v", child, errChild)
+		}
+		if childPick.ID != parentPick.ID {
+			t.Fatalf("subagent %s picked auth %q, want the parent auth %q", child, childPick.ID, parentPick.ID)
+		}
+	}
+
+	// The parent keeps its binding after the sub-agents joined the alias group.
+	parentAgain, err := selector.Pick(context.Background(), provider, "gpt-test", parentOpts, auths)
+	if err != nil {
+		t.Fatalf("parent re-Pick() error = %v", err)
+	}
+	if parentAgain.ID != parentPick.ID {
+		t.Fatalf("parent auth changed from %q to %q after subagents bound", parentPick.ID, parentAgain.ID)
 	}
 }
 
@@ -2275,12 +2341,13 @@ func TestExtractSessionIDNativeSignalsRepresentativeID(t *testing.T) {
 			want:    "pck:shared-cache-bucket",
 		},
 		{
-			name: "client request id representative before body session",
+			// A real root identifier wins, so the body prompt_cache_key stays representative.
+			name: "client request id does not outrank the body prompt cache key",
 			headers: http.Header{
 				"X-Client-Request-Id": []string{"client-session"},
 			},
 			payload: `{"prompt_cache_key":"prompt-session","conversation":{"id":"conversation-session"}}`,
-			want:    "clientreq:client-session",
+			want:    "pck:prompt-session",
 		},
 	}
 
@@ -2410,5 +2477,84 @@ func TestSessionAffinitySelectorUsesRequestPayloadWhenOriginalRequestMissing(t *
 	}
 	if second.ID != first.ID {
 		t.Fatalf("request-only conversation changed auth from %q to %q", first.ID, second.ID)
+	}
+}
+
+// TestSessionAffinitySelectorManySubagentsKeepParentBinding covers the interaction
+// between the OpenCode parent alias and maxStableSessionAliases. Every sub-agent
+// adds two identifiers to the parent's alias group, so a long-lived session can
+// exceed the per-group alias cap. The parent must not be rebound when that happens,
+// and an early sub-agent whose own aliases were squeezed out must still resolve.
+func TestSessionAffinitySelectorManySubagentsKeepParentBinding(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &RoundRobinSelector{},
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}, {ID: "auth-c"}}
+	provider := "test-opencode-many-subagents"
+	userAgent := "opencode/1.18.4 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14"
+
+	openCodeOpts := func(session, parent string) cliproxyexecutor.Options {
+		headers := http.Header{
+			"X-Session-Id":       {session},
+			"X-Session-Affinity": {session},
+			"User-Agent":         {userAgent},
+		}
+		if parent != "" {
+			headers.Set("X-Parent-Session-Id", parent)
+		}
+		return cliproxyexecutor.Options{Headers: headers}
+	}
+
+	parentOpts := openCodeOpts("ses_root", "")
+	parentPick, err := selector.Pick(context.Background(), provider, "gpt-test", parentOpts, auths)
+	if err != nil {
+		t.Fatalf("parent Pick() error = %v", err)
+	}
+
+	// Well past maxStableSessionAliases worth of sub-agent identifiers.
+	const subagents = 60
+	for index := 0; index < subagents; index++ {
+		child := fmt.Sprintf("ses_child_%02d", index)
+		pick, errChild := selector.Pick(context.Background(), provider, "gpt-test", openCodeOpts(child, "ses_root"), auths)
+		if errChild != nil {
+			t.Fatalf("subagent #%d Pick() error = %v", index, errChild)
+		}
+		if pick.ID != parentPick.ID {
+			t.Fatalf("subagent #%d picked auth %q, want the parent auth %q", index, pick.ID, parentPick.ID)
+		}
+	}
+
+	parentAgain, err := selector.Pick(context.Background(), provider, "gpt-test", parentOpts, auths)
+	if err != nil {
+		t.Fatalf("parent re-Pick() error = %v", err)
+	}
+	if parentAgain.ID != parentPick.ID {
+		t.Fatalf("parent auth changed from %q to %q after %d subagents", parentPick.ID, parentAgain.ID, subagents)
+	}
+
+	// The first sub-agent's own identifiers were squeezed out of the group, but it
+	// still sends the parent header, so it resolves back to the same credential.
+	earlyPick, err := selector.Pick(context.Background(), provider, "gpt-test", openCodeOpts("ses_child_00", "ses_root"), auths)
+	if err != nil {
+		t.Fatalf("early subagent Pick() error = %v", err)
+	}
+	if earlyPick.ID != parentPick.ID {
+		t.Fatalf("early subagent picked auth %q, want the parent auth %q", earlyPick.ID, parentPick.ID)
+	}
+
+	// An unrelated session must stay a separate alias group.
+	otherPick, err := selector.Pick(context.Background(), provider, "gpt-test", openCodeOpts("ses_other_root", ""), auths)
+	if err != nil {
+		t.Fatalf("unrelated session Pick() error = %v", err)
+	}
+	if otherPick.ID == parentPick.ID {
+		t.Fatalf("unrelated session shares auth %q with the parent group", otherPick.ID)
+	}
+	if stats := selector.cache.Stats(); stats.Groups != 2 {
+		t.Fatalf("cache groups = %d, want 2 distinct sessions (stats %+v)", stats.Groups, stats)
 	}
 }

--- a/sdk/cliproxy/auth/session_cache.go
+++ b/sdk/cliproxy/auth/session_cache.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"container/list"
 	"strings"
 	"sync"
 	"time"
@@ -8,34 +9,132 @@ import (
 
 const maxStableSessionAliases = 64
 
+// defaultSessionCacheEntries bounds how many session identifiers one process keeps
+// bound at once. Without it a client can retain memory for a whole TTL window by
+// sending many distinct, individually valid session IDs.
+const defaultSessionCacheEntries = 8192
+
 // sessionEntry stores an auth binding, its identifier aliases, and expiration.
+// group is a process-unique identifier for the alias set, so an entry read through
+// one alias can be matched against the authoritative group it belongs to.
 type sessionEntry struct {
 	authID    string
 	expiresAt time.Time
 	aliases   []string
+	group     uint64
 }
 
-// SessionCache provides TTL-based session to auth mapping with automatic cleanup.
+// SessionCacheStats reports session cache occupancy for diagnostics.
+type SessionCacheStats struct {
+	// Entries counts bound identifiers, including aliases of the same session.
+	Entries int
+	// Groups counts distinct logical sessions.
+	Groups int
+	// Evictions counts groups dropped because the capacity bound was reached.
+	Evictions uint64
+}
+
+type sessionBindingSnapshot struct {
+	authIDs       []string
+	groupLockKeys []string
+}
+
+// SessionCache provides TTL-based session to auth mapping with automatic cleanup
+// and a bounded number of retained sessions.
 type SessionCache struct {
-	mu      sync.RWMutex
-	entries map[string]sessionEntry
-	ttl     time.Duration
-	stopCh  chan struct{}
+	mu         sync.RWMutex
+	entries    map[string]sessionEntry
+	groups     map[uint64]sessionEntry
+	order      *list.List
+	elements   map[uint64]*list.Element
+	nextGroup  uint64
+	maxEntries int
+	evictions  uint64
+	ttl        time.Duration
+	stopCh     chan struct{}
+	stopOnce   sync.Once
 }
 
-// NewSessionCache creates a cache with the specified TTL.
+// NewSessionCache creates a cache with the specified TTL and the default capacity bound.
 // A background goroutine periodically cleans expired entries.
 func NewSessionCache(ttl time.Duration) *SessionCache {
+	return NewSessionCacheWithLimit(ttl, defaultSessionCacheEntries)
+}
+
+// NewSessionCacheWithLimit creates a cache with the specified TTL and capacity bound.
+// A non-positive maxEntries selects the default bound.
+func NewSessionCacheWithLimit(ttl time.Duration, maxEntries int) *SessionCache {
 	if ttl <= 0 {
 		ttl = 30 * time.Minute
 	}
+	if maxEntries <= 0 {
+		maxEntries = defaultSessionCacheEntries
+	}
 	c := &SessionCache{
-		entries: make(map[string]sessionEntry),
-		ttl:     ttl,
-		stopCh:  make(chan struct{}),
+		entries:    make(map[string]sessionEntry),
+		groups:     make(map[uint64]sessionEntry),
+		order:      list.New(),
+		elements:   make(map[uint64]*list.Element),
+		maxEntries: maxEntries,
+		ttl:        ttl,
+		stopCh:     make(chan struct{}),
 	}
 	go c.cleanupLoop()
 	return c
+}
+
+// Stats reports current occupancy and the cumulative capacity eviction count.
+func (c *SessionCache) Stats() SessionCacheStats {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return SessionCacheStats{
+		Entries:   len(c.entries),
+		Groups:    len(c.groups),
+		Evictions: c.evictions,
+	}
+}
+
+// bindingSnapshot returns the live auth bindings and stable lock identities for
+// the alias groups reached through sessionIDs. It does not refresh their TTL.
+func (c *SessionCache) bindingSnapshot(sessionIDs []string) sessionBindingSnapshot {
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	snapshot := sessionBindingSnapshot{
+		authIDs:       make([]string, 0, len(sessionIDs)),
+		groupLockKeys: make([]string, 0, len(sessionIDs)),
+	}
+	seenAuthIDs := make(map[string]struct{}, len(sessionIDs))
+	seenGroups := make(map[uint64]struct{}, len(sessionIDs))
+	for _, sessionID := range sessionIDs {
+		entry, ok := c.entries[sessionID]
+		if !ok {
+			continue
+		}
+		if !now.Before(entry.expiresAt) {
+			c.removeAliasGroupLocked(entry)
+			continue
+		}
+		if _, seen := seenAuthIDs[entry.authID]; !seen && entry.authID != "" {
+			seenAuthIDs[entry.authID] = struct{}{}
+			snapshot.authIDs = append(snapshot.authIDs, entry.authID)
+		}
+		if _, seen := seenGroups[entry.group]; seen {
+			continue
+		}
+		seenGroups[entry.group] = struct{}{}
+		groupLockKey := ""
+		for _, alias := range entry.aliases {
+			if alias != "" && (groupLockKey == "" || alias < groupLockKey) {
+				groupLockKey = alias
+			}
+		}
+		if groupLockKey != "" {
+			snapshot.groupLockKeys = append(snapshot.groupLockKeys, groupLockKey)
+		}
+	}
+	return snapshot
 }
 
 // Get retrieves the auth ID bound to a session, if still valid.
@@ -132,20 +231,53 @@ func (c *SessionCache) replaceAliasGroupsLocked(authID string, expiresAt time.Ti
 	for _, previous := range previousGroups {
 		c.removeAliasGroupLocked(previous)
 	}
-	entry := sessionEntry{authID: authID, expiresAt: expiresAt, aliases: aliases}
+	c.nextGroup++
+	entry := sessionEntry{authID: authID, expiresAt: expiresAt, aliases: aliases, group: c.nextGroup}
 	for _, alias := range aliases {
 		c.entries[alias] = entry
 	}
+	c.groups[entry.group] = entry
+	c.elements[entry.group] = c.order.PushBack(entry.group)
+	c.enforceLimitLocked()
 }
 
 func (c *SessionCache) removeAliasGroupLocked(entry sessionEntry) {
-	for _, alias := range entry.aliases {
-		current, ok := c.entries[alias]
-		if !ok || current.authID != entry.authID || !current.expiresAt.Equal(entry.expiresAt) ||
-			!equalSessionAliases(current.aliases, entry.aliases) {
+	current, ok := c.groups[entry.group]
+	if !ok || current.group != entry.group {
+		return
+	}
+	for _, alias := range current.aliases {
+		if mapped, exists := c.entries[alias]; exists && mapped.group == current.group {
+			delete(c.entries, alias)
+		}
+	}
+	delete(c.groups, current.group)
+	if element, exists := c.elements[current.group]; exists {
+		c.order.Remove(element)
+		delete(c.elements, current.group)
+	}
+}
+
+// enforceLimitLocked drops the least recently bound sessions once the cache exceeds
+// its capacity bound. Every hit refreshes a group, so active sessions survive.
+func (c *SessionCache) enforceLimitLocked() {
+	if c.maxEntries <= 0 {
+		return
+	}
+	for len(c.entries) > c.maxEntries {
+		oldest := c.order.Front()
+		if oldest == nil {
+			return
+		}
+		group, _ := oldest.Value.(uint64)
+		entry, ok := c.groups[group]
+		if !ok {
+			c.order.Remove(oldest)
+			delete(c.elements, group)
 			continue
 		}
-		delete(c.entries, alias)
+		c.removeAliasGroupLocked(entry)
+		c.evictions++
 	}
 }
 
@@ -184,8 +316,7 @@ func isLocalPromptCacheSessionAlias(alias string) bool {
 	if strings.HasPrefix(alias, "pck:") {
 		return true
 	}
-	_, sessionAndModel, ok := strings.Cut(alias, "::")
-	return ok && strings.HasPrefix(sessionAndModel, "pck:")
+	return strings.HasPrefix(sessionCacheKeySessionID(alias), "pck:")
 }
 
 func equalSessionAliases(left, right []string) bool {
@@ -229,28 +360,24 @@ func (c *SessionCache) Invalidate(sessionID string) {
 		return
 	}
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	entry, ok := c.entries[sessionID]
-	delete(c.entries, sessionID)
-	if ok {
-		for _, alias := range entry.aliases {
-			if alias == sessionID {
-				continue
-			}
-			current, exists := c.entries[alias]
-			if !exists || current.authID != entry.authID {
-				continue
-			}
-			filtered := make([]string, 0, len(current.aliases))
-			for _, candidate := range current.aliases {
-				if candidate != sessionID {
-					filtered = append(filtered, candidate)
-				}
-			}
-			current.aliases = filtered
-			c.entries[alias] = current
+	if !ok {
+		delete(c.entries, sessionID)
+		return
+	}
+	c.removeAliasGroupLocked(entry)
+
+	remaining := make([]string, 0, len(entry.aliases))
+	for _, alias := range entry.aliases {
+		if alias != sessionID {
+			remaining = append(remaining, alias)
 		}
 	}
-	c.mu.Unlock()
+	if len(remaining) == 0 {
+		return
+	}
+	c.replaceAliasGroupsLocked(entry.authID, entry.expiresAt, remaining)
 }
 
 // InvalidateAuth removes all sessions bound to a specific auth ID.
@@ -260,21 +387,23 @@ func (c *SessionCache) InvalidateAuth(authID string) {
 		return
 	}
 	c.mu.Lock()
-	for sid, entry := range c.entries {
+	stale := make([]sessionEntry, 0, len(c.groups))
+	for _, entry := range c.groups {
 		if entry.authID == authID {
-			delete(c.entries, sid)
+			stale = append(stale, entry)
 		}
+	}
+	for _, entry := range stale {
+		c.removeAliasGroupLocked(entry)
 	}
 	c.mu.Unlock()
 }
 
 // Stop terminates the background cleanup goroutine.
 func (c *SessionCache) Stop() {
-	select {
-	case <-c.stopCh:
-	default:
+	c.stopOnce.Do(func() {
 		close(c.stopCh)
-	}
+	})
 }
 
 func (c *SessionCache) cleanupLoop() {
@@ -293,10 +422,14 @@ func (c *SessionCache) cleanupLoop() {
 func (c *SessionCache) cleanup() {
 	now := time.Now()
 	c.mu.Lock()
-	for sid, entry := range c.entries {
+	expired := make([]sessionEntry, 0, len(c.groups))
+	for _, entry := range c.groups {
 		if !now.Before(entry.expiresAt) {
-			delete(c.entries, sid)
+			expired = append(expired, entry)
 		}
+	}
+	for _, entry := range expired {
+		c.removeAliasGroupLocked(entry)
 	}
 	c.mu.Unlock()
 }

--- a/sdk/cliproxy/auth/session_cache_test.go
+++ b/sdk/cliproxy/auth/session_cache_test.go
@@ -1,0 +1,32 @@
+package auth
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSessionCache_ConcurrentStop(t *testing.T) {
+	cache := NewSessionCache(10 * time.Minute)
+	const goroutines = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			cache.Stop()
+		}()
+	}
+	wg.Wait()
+
+	select {
+	case <-cache.stopCh:
+		// Expected: channel is closed
+	default:
+		t.Fatal("expected stopCh to be closed")
+	}
+
+	// Additional call after goroutines finish should also be safe and non-panicking
+	cache.Stop()
+}

--- a/sdk/cliproxy/auth/session_execution_paths_test.go
+++ b/sdk/cliproxy/auth/session_execution_paths_test.go
@@ -1,0 +1,137 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+// sessionCapturingExecutor records the session each execution path puts on the
+// executor context, which is where usage reporters read it from.
+type sessionCapturingExecutor struct {
+	homeExecutionExecutor
+	seen coreusage.SessionInfo
+}
+
+func (e *sessionCapturingExecutor) Execute(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.seen = coreusage.SessionInfoFromContext(ctx)
+	return e.homeExecutionExecutor.Execute(ctx, auth, req, opts)
+}
+
+func (e *sessionCapturingExecutor) CountTokens(ctx context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.seen = coreusage.SessionInfoFromContext(ctx)
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *sessionCapturingExecutor) ExecuteStream(ctx context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.seen = coreusage.SessionInfoFromContext(ctx)
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("ok")}
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+// Home dispatch builds its own attempt context. It has to publish the routed
+// session too, or usage records from Home deployments carry no session at all.
+func TestHomeExecutionPublishesSessionToExecutorContext(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*Manager, cliproxyexecutor.Options) error
+	}{
+		{
+			name: "execute",
+			run: func(manager *Manager, opts cliproxyexecutor.Options) error {
+				_, err := manager.Execute(context.Background(), []string{"home-execution"}, cliproxyexecutor.Request{Model: "model-a"}, opts)
+				return err
+			},
+		},
+		{
+			name: "count_tokens",
+			run: func(manager *Manager, opts cliproxyexecutor.Options) error {
+				_, err := manager.ExecuteCount(context.Background(), []string{"home-execution"}, cliproxyexecutor.Request{Model: "model-a"}, opts)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.PublishHomeDispatch(homeExecutionDispatcher{}, executionregistry.New(), 1)
+			executor := &sessionCapturingExecutor{}
+			manager.RegisterExecutor(executor)
+
+			opts := cliproxyexecutor.Options{Headers: http.Header{
+				"X-Session-Id": {"ses_home"},
+				"User-Agent":   {"opencode/1.18.3"},
+			}}
+			if err := tt.run(manager, opts); err != nil {
+				t.Fatalf("%s error = %v", tt.name, err)
+			}
+
+			if executor.seen.ID != "header:ses_home" {
+				t.Fatalf("session ID on the executor context = %q, want header:ses_home", executor.seen.ID)
+			}
+			if executor.seen.ClientType != "opencode" {
+				t.Fatalf("client type = %q, want opencode", executor.seen.ClientType)
+			}
+		})
+	}
+}
+
+func TestHomeExecutionUsageReusesCanonicalDispatchSession(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.PublishHomeDispatch(homeExecutionDispatcher{}, executionregistry.New(), 1)
+	executor := &sessionCapturingExecutor{}
+	manager.RegisterExecutor(executor)
+
+	combined := cliproxyexecutor.Options{OriginalRequest: []byte(`{"prompt_cache_key":"cache-1","conversation":{"id":"conv-1"}}`)}
+	if _, errExecute := manager.Execute(context.Background(), []string{"home-execution"}, cliproxyexecutor.Request{Model: "model-a"}, combined); errExecute != nil {
+		t.Fatalf("combined Execute() error = %v", errExecute)
+	}
+	if executor.seen.ID != "pck:cache-1" {
+		t.Fatalf("combined usage session ID = %q, want pck:cache-1", executor.seen.ID)
+	}
+
+	conversationOnly := cliproxyexecutor.Options{OriginalRequest: []byte(`{"conversation":{"id":"conv-1"}}`)}
+	if _, errExecute := manager.Execute(context.Background(), []string{"home-execution"}, cliproxyexecutor.Request{Model: "model-a"}, conversationOnly); errExecute != nil {
+		t.Fatalf("conversation-only Execute() error = %v", errExecute)
+	}
+	if executor.seen.ID != "pck:cache-1" {
+		t.Fatalf("conversation-only usage session ID = %q, want routed pck:cache-1", executor.seen.ID)
+	}
+}
+
+func TestHomeStreamUsageReusesCanonicalDispatchSession(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.PublishHomeDispatch(homeExecutionDispatcher{}, executionregistry.New(), 1)
+	executor := &sessionCapturingExecutor{}
+	manager.RegisterExecutor(executor)
+
+	execute := func(opts cliproxyexecutor.Options) {
+		t.Helper()
+		result, errStream := manager.ExecuteStream(context.Background(), []string{"home-execution"}, cliproxyexecutor.Request{Model: "model-a"}, opts)
+		if errStream != nil {
+			t.Fatalf("ExecuteStream() error = %v", errStream)
+		}
+		for range result.Chunks {
+		}
+	}
+
+	execute(cliproxyexecutor.Options{OriginalRequest: []byte(`{"prompt_cache_key":"cache-1","conversation":{"id":"conv-1"}}`)})
+	if executor.seen.ID != "pck:cache-1" {
+		t.Fatalf("combined stream usage session ID = %q, want pck:cache-1", executor.seen.ID)
+	}
+	execute(cliproxyexecutor.Options{OriginalRequest: []byte(`{"conversation":{"id":"conv-1"}}`)})
+	if executor.seen.ID != "pck:cache-1" {
+		t.Fatalf("conversation-only stream usage session ID = %q, want routed pck:cache-1", executor.seen.ID)
+	}
+}

--- a/sdk/cliproxy/auth/session_identity_test.go
+++ b/sdk/cliproxy/auth/session_identity_test.go
@@ -1,0 +1,236 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	cliproxysession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
+)
+
+func newIdentityTestSelector(t *testing.T) *SessionAffinitySelector {
+	t.Helper()
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &RoundRobinSelector{},
+		TTL:      time.Minute,
+	})
+	t.Cleanup(selector.Stop)
+	return selector
+}
+
+func callerOptions(callerScope string, headers http.Header) cliproxyexecutor.Options {
+	opts := cliproxyexecutor.Options{Headers: headers}
+	if callerScope != "" {
+		opts.Metadata = map[string]any{cliproxyexecutor.CallerScopeMetadataKey: cliproxysession.CallerScope(callerScope)}
+	}
+	return opts
+}
+
+// Two downstream API keys may legitimately reuse the same client session ID.
+// They must not share one upstream binding.
+func TestSessionAffinityIsolatesCallersSharingASessionID(t *testing.T) {
+	selector := newIdentityTestSelector(t)
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	headers := http.Header{"X-Session-Id": {"ses_shared"}}
+
+	firstCaller, err := selector.Pick(context.Background(), "openai", "gpt-test", callerOptions("api-key-one", headers), auths)
+	if err != nil {
+		t.Fatalf("first caller Pick() error = %v", err)
+	}
+	secondCaller, err := selector.Pick(context.Background(), "openai", "gpt-test", callerOptions("api-key-two", headers), auths)
+	if err != nil {
+		t.Fatalf("second caller Pick() error = %v", err)
+	}
+	if secondCaller.ID == firstCaller.ID {
+		t.Fatalf("both callers bound to %q; the shared raw session ID leaked across callers", firstCaller.ID)
+	}
+
+	repeat, err := selector.Pick(context.Background(), "openai", "gpt-test", callerOptions("api-key-one", headers), auths)
+	if err != nil {
+		t.Fatalf("repeat Pick() error = %v", err)
+	}
+	if repeat.ID != firstCaller.ID {
+		t.Fatalf("same caller re-bound to %q, want %q", repeat.ID, firstCaller.ID)
+	}
+}
+
+func TestSessionAffinityKeepsUnauthenticatedCallersOnOneBinding(t *testing.T) {
+	selector := newIdentityTestSelector(t)
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	headers := http.Header{"X-Session-Id": {"ses_anonymous"}}
+
+	first, err := selector.Pick(context.Background(), "openai", "gpt-test", callerOptions("", headers), auths)
+	if err != nil {
+		t.Fatalf("first Pick() error = %v", err)
+	}
+	second, err := selector.Pick(context.Background(), "openai", "gpt-test", callerOptions("", headers), auths)
+	if err != nil {
+		t.Fatalf("second Pick() error = %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("binding changed from %q to %q without a caller scope", first.ID, second.ID)
+	}
+}
+
+// The identity resolved by Enrich must be the one the selector routes on,
+// so local routing, Home dispatch and usage never disagree.
+func TestSessionAffinityReusesEnrichedIdentity(t *testing.T) {
+	selector := newIdentityTestSelector(t)
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+
+	req := cliproxyexecutor.Request{Payload: []byte(`{"prompt_cache_key":"cache-1","conversation":{"id":"conv_1"}}`)}
+	opts := cliproxyexecutor.Options{Headers: http.Header{"X-Claude-Code-Session-Id": {"cc-1"}}}
+	_, opts = cliproxysession.Enrich(req, opts)
+	opts.OriginalRequest = req.Payload
+
+	picked, err := selector.Pick(context.Background(), "claude", "claude-test", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+
+	if _, ok := cliproxysession.FromMetadata(opts.Metadata); !ok {
+		t.Fatal("options metadata is missing the session identity")
+	}
+	wantKey := sessionCacheKey("", "claude", "claude-test", "claude:cc-1")
+	bound, ok := selector.cache.Get(wantKey)
+	if !ok {
+		t.Fatalf("no binding stored under %q", wantKey)
+	}
+	if bound != picked.ID {
+		t.Fatalf("binding = %q, want %q", bound, picked.ID)
+	}
+}
+
+func TestSessionIdentityFromOptionsFallsBackToExtraction(t *testing.T) {
+	opts := cliproxyexecutor.Options{Headers: http.Header{"X-Session-Id": {"ses_direct"}}}
+
+	if got := sessionIdentityFromOptions(opts).ID; got != "header:ses_direct" {
+		t.Fatalf("ID = %q, want header:ses_direct", got)
+	}
+}
+
+func TestSessionCacheKeyRoundTripsOpaqueSessionIDs(t *testing.T) {
+	tests := []string{"pck:cache-1", "conv:a::pck:b", "claude:11111111-1111-4111-8111-111111111111", ""}
+
+	for _, sessionID := range tests {
+		key := sessionCacheKey("scope", "openai", "gpt-test", sessionID)
+		if got := sessionCacheKeySessionID(key); got != sessionID {
+			t.Fatalf("sessionCacheKeySessionID(%q) = %q, want %q", key, got, sessionID)
+		}
+	}
+}
+
+// An opaque conversation ID may itself contain the prompt-cache marker.
+// It must not be mistaken for a prompt cache alias.
+func TestIsLocalPromptCacheSessionAliasUsesTheSessionSegment(t *testing.T) {
+	promptKey := sessionCacheKey("", "openai", "gpt-test", "pck:cache-1")
+	if !isLocalPromptCacheSessionAlias(promptKey) {
+		t.Fatalf("%q was not detected as a prompt cache alias", promptKey)
+	}
+	opaqueConversation := sessionCacheKey("", "openai", "gpt-test", "conv:a::pck:b")
+	if isLocalPromptCacheSessionAlias(opaqueConversation) {
+		t.Fatalf("%q was misdetected as a prompt cache alias", opaqueConversation)
+	}
+}
+
+func TestSessionCacheEnforcesCapacityBoundWithLRUEviction(t *testing.T) {
+	const limit = 8
+	cache := NewSessionCacheWithLimit(time.Minute, limit)
+	defer cache.Stop()
+
+	for index := 0; index < limit*4; index++ {
+		cache.Set(fmt.Sprintf("session-%03d", index), "auth-a")
+	}
+
+	stats := cache.Stats()
+	if stats.Entries > limit {
+		t.Fatalf("entries = %d, want at most %d", stats.Entries, limit)
+	}
+	if stats.Evictions == 0 {
+		t.Fatal("evictions = 0, want the capacity bound to have evicted older sessions")
+	}
+	if _, ok := cache.Get("session-000"); ok {
+		t.Fatal("the oldest session survived the capacity bound")
+	}
+	if _, ok := cache.Get(fmt.Sprintf("session-%03d", limit*4-1)); !ok {
+		t.Fatal("the newest session was evicted")
+	}
+}
+
+func TestSessionCacheCapacityBoundKeepsRefreshedSessions(t *testing.T) {
+	const limit = 4
+	cache := NewSessionCacheWithLimit(time.Minute, limit)
+	defer cache.Stop()
+
+	cache.Set("hot-session", "auth-a")
+	for index := 0; index < limit*3; index++ {
+		cache.Set(fmt.Sprintf("cold-%03d", index), "auth-b")
+		if _, ok := cache.GetAndRefresh("hot-session"); !ok {
+			t.Fatalf("hot session was evicted after %d cold sessions despite being refreshed", index+1)
+		}
+	}
+}
+
+func TestSessionCacheCapacityBoundDropsWholeAliasGroups(t *testing.T) {
+	const limit = 4
+	cache := NewSessionCacheWithLimit(time.Minute, limit)
+	defer cache.Stop()
+
+	cache.SetAliases("auth-a", "pck:first", "conv:first")
+	for index := 0; index < limit*2; index++ {
+		cache.SetAliases("auth-b", fmt.Sprintf("pck:filler-%03d", index), fmt.Sprintf("conv:filler-%03d", index))
+	}
+
+	if _, ok := cache.Get("pck:first"); ok {
+		t.Fatal("evicted group left its primary identifier bound")
+	}
+	if _, ok := cache.Get("conv:first"); ok {
+		t.Fatal("evicted group left its alias bound")
+	}
+	if stats := cache.Stats(); stats.Entries > limit {
+		t.Fatalf("entries = %d, want at most %d", stats.Entries, limit)
+	}
+}
+
+func TestSessionCacheInvalidateKeepsSiblingAliasesBound(t *testing.T) {
+	cache := NewSessionCache(time.Minute)
+	defer cache.Stop()
+
+	cache.SetAliases("auth-a", "pck:cache-1", "conv:conv-1")
+	cache.Invalidate("pck:cache-1")
+
+	if _, ok := cache.Get("pck:cache-1"); ok {
+		t.Fatal("invalidated identifier is still bound")
+	}
+	authID, ok := cache.Get("conv:conv-1")
+	if !ok {
+		t.Fatal("sibling alias lost its binding")
+	}
+	if authID != "auth-a" {
+		t.Fatalf("sibling alias bound to %q, want auth-a", authID)
+	}
+}
+
+func TestSessionCacheInvalidateAuthClearsEveryAlias(t *testing.T) {
+	cache := NewSessionCache(time.Minute)
+	defer cache.Stop()
+
+	cache.SetAliases("auth-a", "pck:cache-1", "conv:conv-1")
+	cache.Set("session-b", "auth-b")
+	cache.InvalidateAuth("auth-a")
+
+	for _, alias := range []string{"pck:cache-1", "conv:conv-1"} {
+		if _, ok := cache.Get(alias); ok {
+			t.Fatalf("%q survived InvalidateAuth", alias)
+		}
+	}
+	if _, ok := cache.Get("session-b"); !ok {
+		t.Fatal("an unrelated auth binding was cleared")
+	}
+	if stats := cache.Stats(); stats.Groups != 1 {
+		t.Fatalf("groups = %d, want 1", stats.Groups)
+	}
+}

--- a/sdk/cliproxy/auth/session_info_mapping_test.go
+++ b/sdk/cliproxy/auth/session_info_mapping_test.go
@@ -1,0 +1,91 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	cliproxysession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+// TestSessionInfoFromOptionsCopiesEveryIdentityField guards the identity-to-usage
+// mapping. It is a plain field copy, so a dropped line would silently report an
+// empty session on every usage record and request log instead of failing.
+func TestSessionInfoFromOptionsCopiesEveryIdentityField(t *testing.T) {
+	t.Parallel()
+
+	const root = "019fa90b-31a4-7841-b252-0a2d5dafbbdc"
+	const childThread = "019fa90b-3219-73d2-9aad-9de97611969e"
+	const turnID = "019fa90b-3234-73d2-a061-0622e5f8c57c"
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{
+			"Session-Id":               {root},
+			"Thread-Id":                {childThread},
+			"X-Codex-Parent-Thread-Id": {root},
+			"X-Codex-Turn-Metadata": {`{"turn_id":"` + turnID +
+				`","request_kind":"compact","thread_source":"subagent"}`},
+			"User-Agent": {"codex_exec/0.145.0 (Mac OS 26.5.2; arm64)"},
+		},
+	}
+	identity := cliproxysession.Extract(opts.Headers, nil, nil)
+
+	got := sessionInfoFromOptions(opts)
+	want := coreusage.SessionInfo{
+		ID:             identity.ID,
+		Source:         identity.Source,
+		Confidence:     identity.Confidence,
+		Scope:          identity.Scope,
+		ClientType:     identity.ClientType,
+		ThreadID:       identity.ThreadID,
+		ParentThreadID: identity.ParentThreadID,
+		RequestKind:    identity.RequestKind,
+		ThreadSource:   identity.ThreadSource,
+		TurnID:         identity.TurnID,
+	}
+	if got != want {
+		t.Fatalf("sessionInfoFromOptions() = %#v, want %#v", got, want)
+	}
+	// Guard against the identity itself being empty, which would make the
+	// comparison above pass for the wrong reason.
+	if got.RequestKind != "compact" || got.ThreadSource != "subagent" || got.TurnID != turnID {
+		t.Fatalf("observations not resolved: %#v", got)
+	}
+}
+
+// TestSessionInfoFromHomeDispatchCopiesEveryField guards the same mapping on the
+// Home path, where the session arrives already resolved from the dispatch reply.
+func TestSessionInfoFromHomeDispatchCopiesEveryField(t *testing.T) {
+	t.Parallel()
+
+	session := home.DispatchSession{
+		ID:             "codex:root",
+		Source:         "client_native_header",
+		Confidence:     "high",
+		Scope:          "session",
+		ClientType:     "codex",
+		ThreadID:       "thread-child",
+		ParentThreadID: "thread-root",
+		RequestKind:    "title",
+		ThreadSource:   "subagent",
+		TurnID:         "turn-1",
+	}
+
+	got := sessionInfoFromHomeDispatch(session)
+	want := coreusage.SessionInfo{
+		ID:             session.ID,
+		Source:         session.Source,
+		Confidence:     session.Confidence,
+		Scope:          session.Scope,
+		ClientType:     session.ClientType,
+		ThreadID:       session.ThreadID,
+		ParentThreadID: session.ParentThreadID,
+		RequestKind:    session.RequestKind,
+		ThreadSource:   session.ThreadSource,
+		TurnID:         session.TurnID,
+	}
+	if got != want {
+		t.Fatalf("sessionInfoFromHomeDispatch() = %#v, want %#v", got, want)
+	}
+}

--- a/sdk/cliproxy/auth/session_usage_context_test.go
+++ b/sdk/cliproxy/auth/session_usage_context_test.go
@@ -1,0 +1,55 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	cliproxysession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+// Usage sinks must report the identity the request was routed on, so a usage
+// timeline and a routing decision can never disagree about the session.
+func TestContextCarriesTheRoutedSessionToUsageSinks(t *testing.T) {
+	req := cliproxyexecutor.Request{Payload: []byte(`{"prompt_cache_key":"cache-1"}`)}
+	opts := cliproxyexecutor.Options{Headers: http.Header{
+		"User-Agent":               {"claude-cli/2.1.193 (external, sdk-cli)"},
+		"X-App":                    {"cli"},
+		"Anthropic-Beta":           {"claude-code-20250219"},
+		"X-Claude-Code-Session-Id": {"cc-1"},
+		"X-Gateway-Thread-Id":      {"thread-1"},
+	}}
+	_, opts = cliproxysession.Enrich(req, opts)
+
+	ctx := contextWithRequestedModelAlias(context.Background(), opts, "claude-test")
+
+	info := coreusage.SessionInfoFromContext(ctx)
+	if info.ID != "claude:cc-1" {
+		t.Fatalf("session ID = %q, want claude:cc-1", info.ID)
+	}
+	if info.Source != cliproxysession.SourceClientNativeHeader {
+		t.Fatalf("session source = %q, want %q", info.Source, cliproxysession.SourceClientNativeHeader)
+	}
+	if info.Confidence != cliproxysession.ConfidenceHigh {
+		t.Fatalf("session confidence = %q, want %q", info.Confidence, cliproxysession.ConfidenceHigh)
+	}
+	if info.Scope != cliproxysession.ScopeSession {
+		t.Fatalf("session scope = %q, want %q", info.Scope, cliproxysession.ScopeSession)
+	}
+	if info.ClientType != cliproxysession.ClientTypeClaudeCode {
+		t.Fatalf("client type = %q, want %q", info.ClientType, cliproxysession.ClientTypeClaudeCode)
+	}
+	if info.ThreadID != "thread-1" {
+		t.Fatalf("thread ID = %q, want thread-1", info.ThreadID)
+	}
+}
+
+func TestContextOmitsSessionWhenNoneWasResolved(t *testing.T) {
+	ctx := contextWithRequestedModelAlias(context.Background(), cliproxyexecutor.Options{}, "gpt-test")
+
+	if info := coreusage.SessionInfoFromContext(ctx); !info.IsZero() {
+		t.Fatalf("session info = %#v, want zero value", info)
+	}
+}

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -48,6 +48,8 @@ const (
 	DerivedSessionIDMetadataKey = "derived_session_id"
 	// CallerScopeMetadataKey isolates inferred session identities between downstream callers.
 	CallerScopeMetadataKey = "caller_scope"
+	// SessionIdentityMetadataKey stores the structured session identity extracted once per request.
+	SessionIdentityMetadataKey = "session_identity"
 )
 
 // Request encapsulates the translated payload that will be sent to a provider executor.

--- a/sdk/cliproxy/session/client_type.go
+++ b/sdk/cliproxy/session/client_type.go
@@ -67,7 +67,9 @@ func declaredClientType(headers http.Header) string {
 func isClaudeCode(headers http.Header, userAgent string) bool {
 	claudeCLI := strings.HasPrefix(userAgent, "claude-cli/")
 	sessionHeader := rawHeader(headers, "X-Claude-Code-Session-Id") != ""
-	cliApp := strings.EqualFold(strings.TrimSpace(rawHeader(headers, "X-App")), "cli")
+	// Background requests report "cli-bg" instead of "cli".
+	xApp := strings.TrimSpace(rawHeader(headers, "X-App"))
+	cliApp := strings.EqualFold(xApp, "cli") || strings.EqualFold(xApp, "cli-bg")
 	anthropicBeta := rawHeader(headers, "Anthropic-Beta") != ""
 
 	signals := 0

--- a/sdk/cliproxy/session/client_type.go
+++ b/sdk/cliproxy/session/client_type.go
@@ -1,0 +1,114 @@
+package session
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Client types reported alongside a session identity. They describe which
+// downstream tool sent the request and are never used as session identifiers.
+const (
+	ClientTypeClaudeCode   = "claude-code"
+	ClientTypeCodex        = "codex"
+	ClientTypeOpenCode     = "opencode"
+	ClientTypeOpenAISDK    = "openai-sdk"
+	ClientTypeAnthropicSDK = "anthropic-sdk"
+	ClientTypeGoogleGenAI  = "google-genai"
+	ClientTypeVercelAI     = "vercel-ai"
+)
+
+// clientTypeMaxLength bounds a client-declared X-Gateway-Client value.
+const clientTypeMaxLength = 64
+
+// DetectClientType identifies the downstream client from corroborating request
+// signals. A User-Agent alone never confirms a coding agent: agent detection also
+// requires a matching native header, because any application can copy a User-Agent.
+// An unrecognised client returns an empty string rather than a guess.
+func DetectClientType(headers http.Header) string {
+	if headers == nil {
+		return ""
+	}
+	if declared := declaredClientType(headers); declared != "" {
+		return declared
+	}
+
+	userAgent := strings.ToLower(strings.TrimSpace(rawHeader(headers, "User-Agent")))
+	switch {
+	case isClaudeCode(headers, userAgent):
+		return ClientTypeClaudeCode
+	case isCodex(headers, userAgent):
+		return ClientTypeCodex
+	case strings.Contains(userAgent, "opencode/"):
+		return ClientTypeOpenCode
+	case strings.HasPrefix(userAgent, "ai/") || strings.Contains(userAgent, " ai-sdk/"):
+		return ClientTypeVercelAI
+	case strings.HasPrefix(userAgent, "openai/"):
+		return ClientTypeOpenAISDK
+	case strings.HasPrefix(userAgent, "anthropic/"):
+		return ClientTypeAnthropicSDK
+	case strings.Contains(userAgent, "google-genai") || rawHeader(headers, "X-Goog-Api-Client") != "":
+		return ClientTypeGoogleGenAI
+	}
+	return ""
+}
+
+// declaredClientType returns a sanitized X-Gateway-Client value. The header is
+// self-declared, so it only labels observability output and never grants trust.
+func declaredClientType(headers http.Header) string {
+	declared := strings.TrimSpace(NormalizeExplicitID(rawHeader(headers, "X-Gateway-Client")))
+	if declared == "" || len(declared) > clientTypeMaxLength {
+		return ""
+	}
+	return strings.ToLower(declared)
+}
+
+// isClaudeCode requires two independent Claude Code signals so that a plain
+// Anthropic SDK request is never reported as the Claude Code client.
+func isClaudeCode(headers http.Header, userAgent string) bool {
+	claudeCLI := strings.HasPrefix(userAgent, "claude-cli/")
+	sessionHeader := rawHeader(headers, "X-Claude-Code-Session-Id") != ""
+	cliApp := strings.EqualFold(strings.TrimSpace(rawHeader(headers, "X-App")), "cli")
+	anthropicBeta := rawHeader(headers, "Anthropic-Beta") != ""
+
+	signals := 0
+	for _, present := range []bool{claudeCLI, sessionHeader, cliApp && anthropicBeta} {
+		if present {
+			signals++
+		}
+	}
+	return signals >= 2
+}
+
+// isCodex accepts the Codex CLI User-Agent family or a Codex-specific header.
+func isCodex(headers http.Header, userAgent string) bool {
+	if strings.HasPrefix(userAgent, "codex") {
+		return true
+	}
+	for _, name := range []string{"X-Codex-Turn-Metadata", "X-Codex-Window-Id", "X-Codex-Parent-Thread-Id"} {
+		if rawHeader(headers, name) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// rawHeader reads a header case-insensitively without applying session ID validation.
+func rawHeader(headers http.Header, name string) string {
+	if headers == nil {
+		return ""
+	}
+	if value := strings.TrimSpace(headers.Get(name)); value != "" {
+		return value
+	}
+	for key, values := range headers {
+		if !strings.EqualFold(key, name) {
+			continue
+		}
+		for _, value := range values {
+			if value = strings.TrimSpace(value); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}

--- a/sdk/cliproxy/session/client_type_test.go
+++ b/sdk/cliproxy/session/client_type_test.go
@@ -37,6 +37,18 @@ func TestDetectClientType(t *testing.T) {
 			want:    "",
 		},
 		{
+			// Background requests report cli-bg. With a stripped User-Agent the
+			// X-App/Anthropic-Beta pair is one of only two available signals, so a
+			// strict "cli" comparison would drop detection to a single signal.
+			name: "claude code background requests report cli-bg",
+			headers: http.Header{
+				"X-App":                    {"cli-bg"},
+				"Anthropic-Beta":           {"claude-code-20250219"},
+				"X-Claude-Code-Session-Id": {"11111111-1111-4111-8111-111111111111"},
+			},
+			want: ClientTypeClaudeCode,
+		},
+		{
 			name: "anthropic sdk is not claude code",
 			headers: http.Header{
 				"User-Agent":        {"Anthropic/Python 0.40.0"},

--- a/sdk/cliproxy/session/client_type_test.go
+++ b/sdk/cliproxy/session/client_type_test.go
@@ -1,0 +1,110 @@
+package session
+
+import (
+	"net/http"
+	"testing"
+)
+
+// User-Agent values below are the ones captured from the real clients.
+func TestDetectClientType(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers http.Header
+		want    string
+	}{
+		{
+			name: "claude code cli sends corroborating signals",
+			headers: http.Header{
+				"User-Agent":               {"claude-cli/2.1.193 (external, sdk-cli)"},
+				"X-App":                    {"cli"},
+				"Anthropic-Beta":           {"claude-code-20250219,interleaved-thinking-2025-05-14"},
+				"X-Claude-Code-Session-Id": {"11111111-1111-4111-8111-111111111111"},
+			},
+			want: ClientTypeClaudeCode,
+		},
+		{
+			name: "claude code without the cli user agent still matches on two signals",
+			headers: http.Header{
+				"X-App":                    {"cli"},
+				"Anthropic-Beta":           {"claude-code-20250219"},
+				"X-Claude-Code-Session-Id": {"11111111-1111-4111-8111-111111111111"},
+			},
+			want: ClientTypeClaudeCode,
+		},
+		{
+			name:    "claude cli user agent alone is not enough",
+			headers: http.Header{"User-Agent": {"claude-cli/2.1.193 (external, sdk-cli)"}},
+			want:    "",
+		},
+		{
+			name: "anthropic sdk is not claude code",
+			headers: http.Header{
+				"User-Agent":        {"Anthropic/Python 0.40.0"},
+				"Anthropic-Version": {"2023-06-01"},
+				"X-Stainless-Lang":  {"python"},
+			},
+			want: ClientTypeAnthropicSDK,
+		},
+		{
+			name:    "codex cli",
+			headers: http.Header{"User-Agent": {"codex_exec/0.144.6"}},
+			want:    ClientTypeCodex,
+		},
+		{
+			name:    "codex identified by its own header",
+			headers: http.Header{"X-Codex-Turn-Metadata": {`{"turn_id":"t"}`}},
+			want:    ClientTypeCodex,
+		},
+		{
+			name:    "opencode cli",
+			headers: http.Header{"User-Agent": {"opencode/1.18.3 ai-sdk/provider-utils/3.0.1 runtime/bun/1.2"}},
+			want:    ClientTypeOpenCode,
+		},
+		{
+			name:    "vercel ai sdk",
+			headers: http.Header{"User-Agent": {"ai/5.0.26 ai-sdk/provider-utils/3.0.1 runtime/node.js/22"}},
+			want:    ClientTypeVercelAI,
+		},
+		{
+			name:    "openai sdk",
+			headers: http.Header{"User-Agent": {"OpenAI/JS 6.26.0"}},
+			want:    ClientTypeOpenAISDK,
+		},
+		{
+			name:    "google gen ai sdk",
+			headers: http.Header{"X-Goog-Api-Client": {"google-genai-sdk/1.0.0 gl-python/3.12"}},
+			want:    ClientTypeGoogleGenAI,
+		},
+		{
+			name:    "declared gateway client wins",
+			headers: http.Header{"X-Gateway-Client": {"Kimi-Code"}, "User-Agent": {"OpenAI/JS 6.26.0"}},
+			want:    "kimi-code",
+		},
+		{
+			name:    "unknown client is not guessed",
+			headers: http.Header{"User-Agent": {"curl/8.4.0"}},
+			want:    "",
+		},
+		{
+			name:    "no headers",
+			headers: nil,
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetectClientType(tt.headers); got != tt.want {
+				t.Fatalf("DetectClientType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectClientTypeRejectsUnsafeDeclaredValue(t *testing.T) {
+	headers := http.Header{"X-Gateway-Client": {"bad\nvalue"}, "User-Agent": {"opencode/1.18.3"}}
+
+	if got := DetectClientType(headers); got != ClientTypeOpenCode {
+		t.Fatalf("DetectClientType() = %q, want %q", got, ClientTypeOpenCode)
+	}
+}

--- a/sdk/cliproxy/session/enrich_identity_test.go
+++ b/sdk/cliproxy/session/enrich_identity_test.go
@@ -1,0 +1,104 @@
+package session
+
+import (
+	"net/http"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestEnrichStoresIdentityInRequestAndOptions(t *testing.T) {
+	req := cliproxyexecutor.Request{Payload: []byte(`{"prompt_cache_key":"cache-1","conversation":{"id":"conv_1"}}`)}
+	opts := cliproxyexecutor.Options{}
+
+	req, opts = Enrich(req, opts)
+
+	optionIdentity, ok := FromMetadata(opts.Metadata)
+	if !ok {
+		t.Fatal("options metadata is missing the session identity")
+	}
+	requestIdentity, ok := FromMetadata(req.Metadata)
+	if !ok {
+		t.Fatal("request metadata is missing the session identity")
+	}
+	if optionIdentity.ID != "pck:cache-1" {
+		t.Fatalf("ID = %q, want pck:cache-1", optionIdentity.ID)
+	}
+	if optionIdentity.FallbackID() != "conv:conv_1" {
+		t.Fatalf("FallbackID() = %q, want conv:conv_1", optionIdentity.FallbackID())
+	}
+	if requestIdentity.ID != optionIdentity.ID {
+		t.Fatalf("request identity %q differs from option identity %q", requestIdentity.ID, optionIdentity.ID)
+	}
+}
+
+func TestEnrichSuppressesDerivedIdentityForNewExplicitHeaders(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	tests := map[string]struct {
+		headers http.Header
+		wantID  string
+	}{
+		"gateway session": {
+			headers: http.Header{"X-Gateway-Session-Id": {"gw-1"}},
+			wantID:  "gateway:gw-1",
+		},
+		"opencode session": {
+			headers: http.Header{"X-Opencode-Session": {"ses_1"}},
+			wantID:  "opencode:ses_1",
+		},
+		"thread only": {
+			headers: http.Header{"Thread-Id": {"thread-1"}},
+			wantID:  "thread:thread-1",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			req := cliproxyexecutor.Request{Payload: payload}
+			opts := cliproxyexecutor.Options{Headers: tt.headers}
+
+			req, opts = Enrich(req, opts)
+
+			if _, exists := opts.Metadata[cliproxyexecutor.DerivedSessionIDMetadataKey]; exists {
+				t.Fatal("derived identity was computed despite an explicit client session signal")
+			}
+			identity, ok := FromMetadata(opts.Metadata)
+			if !ok {
+				t.Fatal("options metadata is missing the session identity")
+			}
+			if identity.ID != tt.wantID {
+				t.Fatalf("ID = %q, want %q", identity.ID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestEnrichDerivesIdentityWhenClientSendsNoSessionSignal(t *testing.T) {
+	req := cliproxyexecutor.Request{Payload: []byte(`{"messages":[{"role":"user","content":"hello"}]}`)}
+	opts := cliproxyexecutor.Options{}
+
+	_, opts = Enrich(req, opts)
+
+	derived, _ := opts.Metadata[cliproxyexecutor.DerivedSessionIDMetadataKey].(string)
+	if derived == "" {
+		t.Fatal("derived identity was not computed for a request without session signals")
+	}
+	identity, ok := FromMetadata(opts.Metadata)
+	if !ok {
+		t.Fatal("options metadata is missing the session identity")
+	}
+	if identity.ID != "derived:"+derived {
+		t.Fatalf("ID = %q, want derived:%s", identity.ID, derived)
+	}
+	if identity.Source != SourceDerived {
+		t.Fatalf("Source = %q, want %q", identity.Source, SourceDerived)
+	}
+}
+
+func TestEnrichLeavesNoIdentityWhenNothingIsKnown(t *testing.T) {
+	_, opts := Enrich(cliproxyexecutor.Request{}, cliproxyexecutor.Options{})
+
+	if _, ok := FromMetadata(opts.Metadata); ok {
+		t.Fatal("an identity was stored for a request with no session signals at all")
+	}
+}

--- a/sdk/cliproxy/session/extract.go
+++ b/sdk/cliproxy/session/extract.go
@@ -16,9 +16,14 @@ const gatewaySessionHeader = "X-Gateway-Session-Id"
 
 // threadHeaders and parentThreadHeaders are observability signals. They describe a
 // thread or sub-agent inside a conversation and never replace a root session.
+//
+// Claude Code sends X-Claude-Code-Agent-Id only for sub-agents: the main agent
+// omits it entirely, so its presence identifies a sub-agent request. The parent
+// header appears one level deeper still, because a depth-1 sub-agent's parent is
+// the main agent, which has no agent identifier of its own.
 var (
-	threadHeaders       = []string{"X-Gateway-Thread-Id", "Thread-Id", "Thread_id"}
-	parentThreadHeaders = []string{"X-Gateway-Parent-Thread-Id", "X-Codex-Parent-Thread-Id", "X-Parent-Session-Id"}
+	threadHeaders       = []string{"X-Gateway-Thread-Id", "Thread-Id", "Thread_id", "X-Claude-Code-Agent-Id"}
+	parentThreadHeaders = []string{"X-Gateway-Parent-Thread-Id", "X-Codex-Parent-Thread-Id", "X-Claude-Code-Parent-Agent-Id", "X-Parent-Session-Id"}
 )
 
 // Extract resolves one structured session identity from explicit client signals,
@@ -36,17 +41,69 @@ var (
 //  5. stable hash from initial message content
 func Extract(headers http.Header, payload []byte, metadata map[string]any) Identity {
 	identity := extractRoot(headers, payload, metadata)
-	if identity.ID == "" {
-		return Identity{
-			ClientType:     DetectClientType(headers),
-			ThreadID:       firstHeaderValue(headers, threadHeaders...),
-			ParentThreadID: firstHeaderValue(headers, parentThreadHeaders...),
-		}
-	}
 	identity.ClientType = DetectClientType(headers)
 	identity.ThreadID = firstHeaderValue(headers, threadHeaders...)
 	identity.ParentThreadID = firstHeaderValue(headers, parentThreadHeaders...)
+	attachTurnObservations(&identity, headers)
 	return identity
+}
+
+// codexTurnMetadataHeader carries Codex per-turn observability fields as a JSON
+// object. It is never a session identifier: turn_id changes every turn, and the
+// session and thread identifiers it repeats are already read from their own headers.
+const codexTurnMetadataHeader = "X-Codex-Turn-Metadata"
+
+// codexTurnMetadataMaxBytes bounds how much client-supplied JSON is parsed.
+const codexTurnMetadataMaxBytes = 4096
+
+// observationValueMaxLength bounds enum-like observation values so a client cannot
+// push arbitrary length into logs and Home payloads.
+const observationValueMaxLength = 64
+
+// RequestKindBackground marks work a client runs outside the foreground conversation.
+// Codex reports its own kinds verbatim (turn, compact, review, title, prewarm, ...);
+// Claude Code only distinguishes background requests, via X-App.
+const RequestKindBackground = "background"
+
+// attachTurnObservations fills the observation-only fields describing what kind of
+// request this is and where the thread came from. These never affect routing.
+func attachTurnObservations(identity *Identity, headers http.Header) {
+	if headers == nil {
+		return
+	}
+	if strings.EqualFold(strings.TrimSpace(rawHeader(headers, "X-App")), "cli-bg") {
+		identity.RequestKind = RequestKindBackground
+	}
+
+	raw := rawHeader(headers, codexTurnMetadataHeader)
+	if raw == "" || len(raw) > codexTurnMetadataMaxBytes || !gjson.Valid(raw) {
+		return
+	}
+	parsed := gjson.Parse(raw)
+	if kind := normalizeObservationValue(parsed.Get("request_kind").String()); kind != "" {
+		identity.RequestKind = kind
+	}
+	if source := normalizeObservationValue(parsed.Get("thread_source").String()); source != "" {
+		identity.ThreadSource = source
+	}
+	if turnID := NormalizeExplicitID(parsed.Get("turn_id").String()); turnID != "" {
+		identity.TurnID = turnID
+	}
+}
+
+// normalizeObservationValue accepts a short enum-like token and rejects anything
+// that could corrupt a log line or grow a payload.
+func normalizeObservationValue(raw string) string {
+	value := strings.TrimSpace(raw)
+	if value == "" || len(value) > observationValueMaxLength {
+		return ""
+	}
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f {
+			return ""
+		}
+	}
+	return value
 }
 
 type rawSignal struct {
@@ -146,10 +203,15 @@ func extractExplicitRootSignals(headers http.Header, payload []byte) []rawSignal
 	appendHeader("X-Opencode-Session", "opencode:", SourceClientNativeHeader, ConfidenceHigh)
 	appendHeader("X-Session-ID", "header:", SourceClientNativeHeader, ConfidenceHigh)
 	appendHeader("X-Session-Affinity", "affinity:", SourceClientNativeHeader, ConfidenceHigh)
-	appendHeader("X-Client-Request-Id", "clientreq:", SourceClientRequestID, ConfidenceMedium)
+	// OpenCode gives a sub-agent its own X-Session-Id and puts the root session in
+	// X-Parent-Session-Id, the opposite of the Claude Code and Codex convention.
+	// Collecting the parent under the same "header:" prefix as X-Session-Id makes a
+	// child request join the parent's alias group, so sub-agents reuse the parent's
+	// credential instead of being routed as an unrelated session.
+	appendHeader("X-Parent-Session-Id", "header:", SourceClientNativeHeader, ConfidenceHigh)
 
 	if len(payload) == 0 {
-		return signals
+		return appendClientRequestFallback(signals, headers)
 	}
 	for _, path := range []string{"session_id", "sessionId"} {
 		if sid := NormalizeExplicitID(gjson.GetBytes(payload, path).String()); sid != "" {
@@ -173,7 +235,27 @@ func extractExplicitRootSignals(headers http.Header, payload []byte) []rawSignal
 	if sid := NormalizeExplicitID(gjson.GetBytes(payload, "conversation_id").String()); sid != "" {
 		signals = append(signals, rawSignal{"conv:" + sid, SourceBodyConversation, ConfidenceHigh, ScopeSession})
 	}
-	return signals
+	return appendClientRequestFallback(signals, headers)
+}
+
+// appendClientRequestFallback uses X-Client-Request-Id only when the request
+// carries no other explicit root identifier.
+//
+// The header tracks the current thread rather than the root session: a Codex
+// sub-agent sends its own thread identifier there while session-id stays on the
+// root. Collecting it unconditionally would add one throwaway alias per sub-agent
+// to the root alias group. Every observed client that sends it also sends
+// session-id or prompt_cache_key with the same value, so it is only reached by a
+// client that sends nothing else, where it is the one signal available.
+func appendClientRequestFallback(signals []rawSignal, headers http.Header) []rawSignal {
+	if len(signals) > 0 {
+		return signals
+	}
+	sid := HeaderValue(headers, "X-Client-Request-Id")
+	if sid == "" {
+		return signals
+	}
+	return append(signals, rawSignal{"clientreq:" + sid, SourceClientRequestID, ConfidenceMedium, ScopeSession})
 }
 
 func clientIdentity(id, source, confidence, scope string) Identity {

--- a/sdk/cliproxy/session/extract.go
+++ b/sdk/cliproxy/session/extract.go
@@ -1,0 +1,468 @@
+package session
+
+import (
+	"fmt"
+	"hash/fnv"
+	"net/http"
+	"strings"
+
+	"github.com/tidwall/gjson"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// gatewaySessionHeader is the unified session header CPA asks controllable clients to send.
+const gatewaySessionHeader = "X-Gateway-Session-Id"
+
+// threadHeaders and parentThreadHeaders are observability signals. They describe a
+// thread or sub-agent inside a conversation and never replace a root session.
+var (
+	threadHeaders       = []string{"X-Gateway-Thread-Id", "Thread-Id", "Thread_id"}
+	parentThreadHeaders = []string{"X-Gateway-Parent-Thread-Id", "X-Codex-Parent-Thread-Id", "X-Parent-Session-Id"}
+)
+
+// Extract resolves one structured session identity from explicit client signals,
+// then falls back to execution metadata, derived identity, and message history.
+//
+// All valid explicit root session signals in the same request are collected as
+// aliases for the same logical session. The first signal collected becomes the
+// representative Identity.ID, and all additional signals are placed in Identity.Aliases.
+//
+// When no explicit root session signal exists, Extract falls back to:
+//  1. bare metadata.user_id (user scope fallback)
+//  2. explicit execution session metadata
+//  3. thread-id header (thread scope fallback)
+//  4. stable context-derived session identity
+//  5. stable hash from initial message content
+func Extract(headers http.Header, payload []byte, metadata map[string]any) Identity {
+	identity := extractRoot(headers, payload, metadata)
+	if identity.ID == "" {
+		return Identity{
+			ClientType:     DetectClientType(headers),
+			ThreadID:       firstHeaderValue(headers, threadHeaders...),
+			ParentThreadID: firstHeaderValue(headers, parentThreadHeaders...),
+		}
+	}
+	identity.ClientType = DetectClientType(headers)
+	identity.ThreadID = firstHeaderValue(headers, threadHeaders...)
+	identity.ParentThreadID = firstHeaderValue(headers, parentThreadHeaders...)
+	return identity
+}
+
+type rawSignal struct {
+	id         string
+	source     string
+	confidence string
+	scope      string
+}
+
+func extractRoot(headers http.Header, payload []byte, metadata map[string]any) Identity {
+	signals := extractExplicitRootSignals(headers, payload)
+	if len(signals) > 0 {
+		seen := make(map[string]struct{}, len(signals))
+		var deduplicated []rawSignal
+		for _, s := range signals {
+			if _, ok := seen[s.id]; !ok {
+				seen[s.id] = struct{}{}
+				deduplicated = append(deduplicated, s)
+			}
+		}
+
+		if len(deduplicated) > 0 {
+			rep := deduplicated[0]
+			aliases := make([]string, 0, len(deduplicated)-1)
+			for _, s := range deduplicated[1:] {
+				aliases = append(aliases, s.id)
+			}
+			return Identity{
+				ID:             rep.id,
+				Aliases:        aliases,
+				Source:         rep.source,
+				Confidence:     rep.confidence,
+				Scope:          rep.scope,
+				ClientProvided: true,
+			}
+		}
+	}
+
+	if len(payload) > 0 {
+		if userID := NormalizeExplicitID(gjson.GetBytes(payload, "metadata.user_id").String()); userID != "" {
+			return clientIdentity("user:"+userID, SourceLegacyMetadataUser, ConfidenceLow, ScopeUser)
+		}
+	}
+
+	if executionID, ok := metadata[cliproxyexecutor.ExecutionSessionMetadataKey].(string); ok {
+		if executionID = NormalizeExplicitID(executionID); executionID != "" {
+			return Identity{
+				ID:         "execution:" + executionID,
+				Source:     SourceExecutionSession,
+				Confidence: ConfidenceHigh,
+				Scope:      ScopeTransport,
+			}
+		}
+	}
+	if threadID := firstHeaderValue(headers, threadHeaders...); threadID != "" {
+		return clientIdentity("thread:"+threadID, SourceClientNativeHeader, ConfidenceMedium, ScopeThread)
+	}
+	if derivedID := NormalizeExplicitID(DerivedID(metadata)); derivedID != "" {
+		return Identity{
+			ID:         "derived:" + derivedID,
+			Source:     SourceDerived,
+			Confidence: ConfidenceMedium,
+			Scope:      ScopeSession,
+		}
+	}
+	if len(payload) == 0 {
+		return Identity{}
+	}
+	primary, fallback := extractMessageHashIDs(payload)
+	if primary == "" {
+		return Identity{}
+	}
+	return Identity{
+		ID:         primary,
+		Aliases:    nonEmptyAliases(fallback),
+		Source:     SourceMessageHash,
+		Confidence: ConfidenceLow,
+		Scope:      ScopeSession,
+	}
+}
+
+func extractExplicitRootSignals(headers http.Header, payload []byte) []rawSignal {
+	signals := make([]rawSignal, 0, 13)
+	appendHeader := func(name, prefix, source, confidence string) {
+		if sid := HeaderValue(headers, name); sid != "" {
+			signals = append(signals, rawSignal{prefix + sid, source, confidence, ScopeSession})
+		}
+	}
+
+	appendHeader(gatewaySessionHeader, "gateway:", SourceGatewayHeader, ConfidenceHigh)
+	appendHeader("X-Claude-Code-Session-Id", "claude:", SourceClientNativeHeader, ConfidenceHigh)
+	if sid := ClaudeMetadataSessionID(payload); sid != "" {
+		signals = append(signals, rawSignal{"claude:" + sid, SourceMetadataUserID, ConfidenceHigh, ScopeSession})
+	}
+	appendHeader("Session-Id", "codex:", SourceClientNativeHeader, ConfidenceHigh)
+	appendHeader("Session_id", "codex:", SourceClientNativeHeader, ConfidenceHigh)
+	appendHeader("X-Opencode-Session", "opencode:", SourceClientNativeHeader, ConfidenceHigh)
+	appendHeader("X-Session-ID", "header:", SourceClientNativeHeader, ConfidenceHigh)
+	appendHeader("X-Session-Affinity", "affinity:", SourceClientNativeHeader, ConfidenceHigh)
+	appendHeader("X-Client-Request-Id", "clientreq:", SourceClientRequestID, ConfidenceMedium)
+
+	if len(payload) == 0 {
+		return signals
+	}
+	for _, path := range []string{"session_id", "sessionId"} {
+		if sid := NormalizeExplicitID(gjson.GetBytes(payload, path).String()); sid != "" {
+			signals = append(signals, rawSignal{"session:" + sid, SourceBodySession, ConfidenceHigh, ScopeSession})
+		}
+	}
+	if sid := NormalizeExplicitID(gjson.GetBytes(payload, "metadata.session_id").String()); sid != "" {
+		signals = append(signals, rawSignal{"session:" + sid, SourceBodySession, ConfidenceMedium, ScopeSession})
+	}
+	if sid := NormalizeExplicitID(gjson.GetBytes(payload, "prompt_cache_key").String()); sid != "" {
+		signals = append(signals, rawSignal{"pck:" + sid, SourcePromptCacheKey, ConfidenceMedium, ScopeSession})
+	}
+	conversation := gjson.GetBytes(payload, "conversation")
+	if sid := NormalizeExplicitID(conversation.Get("id").String()); sid != "" {
+		signals = append(signals, rawSignal{"conv:" + sid, SourceBodyConversation, ConfidenceHigh, ScopeSession})
+	} else if conversation.Type == gjson.String {
+		if sid := NormalizeExplicitID(conversation.String()); sid != "" {
+			signals = append(signals, rawSignal{"conv:" + sid, SourceBodyConversation, ConfidenceHigh, ScopeSession})
+		}
+	}
+	if sid := NormalizeExplicitID(gjson.GetBytes(payload, "conversation_id").String()); sid != "" {
+		signals = append(signals, rawSignal{"conv:" + sid, SourceBodyConversation, ConfidenceHigh, ScopeSession})
+	}
+	return signals
+}
+
+func clientIdentity(id, source, confidence, scope string) Identity {
+	return Identity{
+		ID:             id,
+		Source:         source,
+		Confidence:     confidence,
+		Scope:          scope,
+		ClientProvided: true,
+	}
+}
+
+func nonEmptyAliases(aliases ...string) []string {
+	out := make([]string, 0, len(aliases))
+	for _, alias := range aliases {
+		if alias != "" {
+			out = append(out, alias)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// HeaderValue returns the first valid explicit identifier stored under name.
+// Header names are compared case-insensitively and invalid values are skipped.
+func HeaderValue(headers http.Header, name string) string {
+	if headers == nil {
+		return ""
+	}
+	if value := NormalizeExplicitID(headers.Get(name)); value != "" {
+		return value
+	}
+	for key, values := range headers {
+		if !strings.EqualFold(key, name) {
+			continue
+		}
+		for _, raw := range values {
+			if value := NormalizeExplicitID(raw); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func firstHeaderValue(headers http.Header, names ...string) string {
+	for _, name := range names {
+		if value := HeaderValue(headers, name); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func extractMessageHashIDs(payload []byte) (primaryID, fallbackID string) {
+	var systemPrompt, firstUserMsg, firstAssistantMsg string
+
+	// OpenAI/Claude messages format
+	messages := gjson.GetBytes(payload, "messages")
+	if messages.Exists() && messages.IsArray() {
+		messages.ForEach(func(_, msg gjson.Result) bool {
+			role := msg.Get("role").String()
+			content := extractMessageContent(msg.Get("content"))
+			if content == "" {
+				return true
+			}
+
+			switch role {
+			case "system":
+				if systemPrompt == "" {
+					systemPrompt = truncateString(content, 100)
+				}
+			case "user":
+				if firstUserMsg == "" {
+					firstUserMsg = truncateString(content, 100)
+				}
+			case "assistant":
+				if firstAssistantMsg == "" {
+					firstAssistantMsg = truncateString(content, 100)
+				}
+			}
+
+			if systemPrompt != "" && firstUserMsg != "" && firstAssistantMsg != "" {
+				return false
+			}
+			return true
+		})
+	}
+
+	// Claude API: top-level "system" field (array or string)
+	if systemPrompt == "" {
+		topSystem := gjson.GetBytes(payload, "system")
+		if topSystem.Exists() {
+			if topSystem.IsArray() {
+				topSystem.ForEach(func(_, part gjson.Result) bool {
+					if text := part.Get("text").String(); text != "" && systemPrompt == "" {
+						systemPrompt = truncateString(text, 100)
+						return false
+					}
+					return true
+				})
+			} else if topSystem.Type == gjson.String {
+				systemPrompt = truncateString(topSystem.String(), 100)
+			}
+		}
+	}
+
+	// Gemini format
+	if systemPrompt == "" && firstUserMsg == "" {
+		sysInstr := gjson.GetBytes(payload, "systemInstruction.parts")
+		if sysInstr.Exists() && sysInstr.IsArray() {
+			sysInstr.ForEach(func(_, part gjson.Result) bool {
+				if text := part.Get("text").String(); text != "" && systemPrompt == "" {
+					systemPrompt = truncateString(text, 100)
+					return false
+				}
+				return true
+			})
+		}
+
+		contents := gjson.GetBytes(payload, "contents")
+		if contents.Exists() && contents.IsArray() {
+			contents.ForEach(func(_, msg gjson.Result) bool {
+				role := msg.Get("role").String()
+				msg.Get("parts").ForEach(func(_, part gjson.Result) bool {
+					text := part.Get("text").String()
+					if text == "" {
+						return true
+					}
+					switch role {
+					case "user":
+						if firstUserMsg == "" {
+							firstUserMsg = truncateString(text, 100)
+						}
+					case "model":
+						if firstAssistantMsg == "" {
+							firstAssistantMsg = truncateString(text, 100)
+						}
+					}
+					return false
+				})
+				if firstUserMsg != "" && firstAssistantMsg != "" {
+					return false
+				}
+				return true
+			})
+		}
+	}
+
+	// OpenAI Responses API format (v1/responses)
+	if systemPrompt == "" && firstUserMsg == "" {
+		if instr := gjson.GetBytes(payload, "instructions").String(); instr != "" {
+			systemPrompt = truncateString(instr, 100)
+		}
+
+		input := gjson.GetBytes(payload, "input")
+		if input.Exists() && input.IsArray() {
+			input.ForEach(func(_, item gjson.Result) bool {
+				itemType := item.Get("type").String()
+				if itemType == "reasoning" {
+					return true
+				}
+				// Skip non-message typed items (function_call, function_call_output, etc.)
+				// but allow items with no type that have a role (inline message format).
+				if itemType != "" && itemType != "message" {
+					return true
+				}
+
+				role := item.Get("role").String()
+				if itemType == "" && role == "" {
+					return true
+				}
+
+				// Handle both string content and array content (multimodal).
+				content := item.Get("content")
+				var text string
+				if content.Type == gjson.String {
+					text = content.String()
+				} else {
+					text = extractResponsesAPIContent(content)
+				}
+				if text == "" {
+					return true
+				}
+
+				switch role {
+				case "developer", "system":
+					if systemPrompt == "" {
+						systemPrompt = truncateString(text, 100)
+					}
+				case "user":
+					if firstUserMsg == "" {
+						firstUserMsg = truncateString(text, 100)
+					}
+				case "assistant":
+					if firstAssistantMsg == "" {
+						firstAssistantMsg = truncateString(text, 100)
+					}
+				}
+
+				if firstUserMsg != "" && firstAssistantMsg != "" {
+					return false
+				}
+				return true
+			})
+		}
+	}
+
+	if systemPrompt == "" && firstUserMsg == "" {
+		return "", ""
+	}
+
+	shortHash := computeSessionHash(systemPrompt, firstUserMsg, "")
+	if firstAssistantMsg == "" {
+		return shortHash, ""
+	}
+
+	fullHash := computeSessionHash(systemPrompt, firstUserMsg, firstAssistantMsg)
+	return fullHash, shortHash
+}
+
+func computeSessionHash(systemPrompt, userMsg, assistantMsg string) string {
+	h := fnv.New64a()
+	if systemPrompt != "" {
+		h.Write([]byte("sys:" + systemPrompt + "\n"))
+	}
+	if userMsg != "" {
+		h.Write([]byte("usr:" + userMsg + "\n"))
+	}
+	if assistantMsg != "" {
+		h.Write([]byte("ast:" + assistantMsg + "\n"))
+	}
+	return fmt.Sprintf("msg:%016x", h.Sum64())
+}
+
+func truncateString(s string, maxLen int) string {
+	if len(s) > maxLen {
+		return s[:maxLen]
+	}
+	return s
+}
+
+// extractMessageContent extracts text content from a message content field.
+// Handles both string content and array content (multimodal messages).
+// For array content, extracts text from all text-type elements.
+func extractMessageContent(content gjson.Result) string {
+	// String content: "Hello world"
+	if content.Type == gjson.String {
+		return content.String()
+	}
+
+	// Array content: [{"type":"text","text":"Hello"},{"type":"image",...}]
+	if content.IsArray() {
+		var texts []string
+		content.ForEach(func(_, part gjson.Result) bool {
+			// Claude and OpenAI share the {"type":"text","text":"content"} shape.
+			if part.Get("type").String() == "text" {
+				if text := part.Get("text").String(); text != "" {
+					texts = append(texts, text)
+				}
+			}
+			return true
+		})
+		if len(texts) > 0 {
+			return strings.Join(texts, " ")
+		}
+	}
+
+	return ""
+}
+
+func extractResponsesAPIContent(content gjson.Result) string {
+	if !content.IsArray() {
+		return ""
+	}
+	var texts []string
+	content.ForEach(func(_, part gjson.Result) bool {
+		partType := part.Get("type").String()
+		if partType == "input_text" || partType == "output_text" || partType == "text" {
+			if text := part.Get("text").String(); text != "" {
+				texts = append(texts, text)
+			}
+		}
+		return true
+	})
+	if len(texts) > 0 {
+		return strings.Join(texts, " ")
+	}
+	return ""
+}

--- a/sdk/cliproxy/session/extract_test.go
+++ b/sdk/cliproxy/session/extract_test.go
@@ -1,0 +1,336 @@
+package session
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestExtractClassificationAndAliases(t *testing.T) {
+	claudeUserID := `{"device_id":"d","account_uuid":"","session_id":"11111111-1111-4111-8111-111111111111"}`
+
+	tests := []struct {
+		name           string
+		headers        http.Header
+		payload        string
+		metadata       map[string]any
+		wantID         string
+		wantAliases    []string
+		wantSource     string
+		wantConfidence string
+		wantScope      string
+	}{
+		{
+			name:           "multiple explicit headers collected as representative ID and aliases",
+			headers:        http.Header{"X-Gateway-Session-Id": {"gw-1"}, "X-Claude-Code-Session-Id": {"cc-1"}, "Session-Id": {"cx-1"}},
+			wantID:         "gateway:gw-1",
+			wantAliases:    []string{"claude:cc-1", "codex:cx-1"},
+			wantSource:     SourceGatewayHeader,
+			wantConfidence: ConfidenceHigh,
+			wantScope:      ScopeSession,
+		},
+		{
+			name:           "claude code header and metadata collected as representative ID and aliases",
+			headers:        http.Header{"X-Claude-Code-Session-Id": {"cc-1"}},
+			payload:        `{"metadata":{"user_id":` + quote(claudeUserID) + `}}`,
+			wantID:         "claude:cc-1",
+			wantAliases:    []string{"claude:11111111-1111-4111-8111-111111111111"},
+			wantSource:     SourceClientNativeHeader,
+			wantConfidence: ConfidenceHigh,
+			wantScope:      ScopeSession,
+		},
+		{
+			name:           "claude code metadata only",
+			payload:        `{"metadata":{"user_id":` + quote(claudeUserID) + `}}`,
+			wantID:         "claude:11111111-1111-4111-8111-111111111111",
+			wantSource:     SourceMetadataUserID,
+			wantConfidence: ConfidenceHigh,
+			wantScope:      ScopeSession,
+		},
+		{
+			name:           "claude code legacy metadata suffix",
+			payload:        `{"metadata":{"user_id":"user_abc_account__session_11111111-1111-4111-8111-111111111111"}}`,
+			wantID:         "claude:11111111-1111-4111-8111-111111111111",
+			wantSource:     SourceMetadataUserID,
+			wantConfidence: ConfidenceHigh,
+			wantScope:      ScopeSession,
+		},
+		{
+			name:           "codex hyphenated session header with prompt cache key alias",
+			headers:        http.Header{"Session-Id": {"019f7e3b"}, "Thread-Id": {"019f7e3b"}},
+			payload:        `{"prompt_cache_key":"019f7e3b"}`,
+			wantID:         "codex:019f7e3b",
+			wantAliases:    []string{"pck:019f7e3b"},
+			wantSource:     SourceClientNativeHeader,
+			wantConfidence: ConfidenceHigh,
+			wantScope:      ScopeSession,
+		},
+		{
+			name:           "opencode session header and generic header aliases",
+			headers:        http.Header{"X-Opencode-Session": {"ses_a"}, "X-Session-Id": {"ses_b"}},
+			wantID:         "opencode:ses_a",
+			wantAliases:    []string{"header:ses_b"},
+			wantSource:     SourceClientNativeHeader,
+			wantConfidence: ConfidenceHigh,
+			wantScope:      ScopeSession,
+		},
+		{
+			name:           "opencode generic and affinity headers",
+			headers:        http.Header{"X-Session-Id": {"ses_c"}, "X-Session-Affinity": {"ses_c"}},
+			wantID:         "header:ses_c",
+			wantAliases:    []string{"affinity:ses_c"},
+			wantSource:     SourceClientNativeHeader,
+			wantConfidence: ConfidenceHigh,
+			wantScope:      ScopeSession,
+		},
+		{
+			name:           "affinity header alone",
+			headers:        http.Header{"X-Session-Affinity": {"ses_d"}},
+			wantID:         "affinity:ses_d",
+			wantSource:     SourceClientNativeHeader,
+			wantConfidence: ConfidenceHigh,
+			wantScope:      ScopeSession,
+		},
+		{
+			name:           "pi responses client request id",
+			headers:        http.Header{"X-Client-Request-Id": {"pi-1"}},
+			wantID:         "clientreq:pi-1",
+			wantSource:     SourceClientRequestID,
+			wantConfidence: ConfidenceMedium,
+			wantScope:      ScopeSession,
+		},
+		{
+			name:           "body metadata session id",
+			payload:        `{"metadata":{"session_id":"meta-1"}}`,
+			wantID:         "session:meta-1",
+			wantSource:     SourceBodySession,
+			wantConfidence: ConfidenceMedium,
+			wantScope:      ScopeSession,
+		},
+		{
+			name:           "prompt cache key keeps conversation alias",
+			payload:        `{"prompt_cache_key":"cache-1","conversation":{"id":"conv_1"}}`,
+			wantID:         "pck:cache-1",
+			wantAliases:    []string{"conv:conv_1"},
+			wantSource:     SourcePromptCacheKey,
+			wantConfidence: ConfidenceMedium,
+			wantScope:      ScopeSession,
+		},
+		{
+			name:           "conversation string form",
+			payload:        `{"conversation":"conv_2"}`,
+			wantID:         "conv:conv_2",
+			wantSource:     SourceBodyConversation,
+			wantConfidence: ConfidenceHigh,
+			wantScope:      ScopeSession,
+		},
+		{
+			name:           "bare metadata user id is user scope fallback",
+			payload:        `{"metadata":{"user_id":"user_123"}}`,
+			wantID:         "user:user_123",
+			wantSource:     SourceLegacyMetadataUser,
+			wantConfidence: ConfidenceLow,
+			wantScope:      ScopeUser,
+		},
+		{
+			name:           "bare metadata user id is omitted when conversation_id exists",
+			payload:        `{"conversation_id":"conv-123","metadata":{"user_id":"user_123"}}`,
+			wantID:         "conv:conv-123",
+			wantAliases:    nil,
+			wantSource:     SourceBodyConversation,
+			wantConfidence: ConfidenceHigh,
+			wantScope:      ScopeSession,
+		},
+		{
+			name:           "execution metadata fallback when no root session exists",
+			metadata:       map[string]any{cliproxyexecutor.ExecutionSessionMetadataKey: "exec-1"},
+			wantID:         "execution:exec-1",
+			wantSource:     SourceExecutionSession,
+			wantConfidence: ConfidenceHigh,
+			wantScope:      ScopeTransport,
+		},
+		{
+			name:           "thread header fallback when no root session exists",
+			headers:        http.Header{"Thread-Id": {"thread-1"}},
+			wantID:         "thread:thread-1",
+			wantSource:     SourceClientNativeHeader,
+			wantConfidence: ConfidenceMedium,
+			wantScope:      ScopeThread,
+		},
+		{
+			name:           "derived identity fallback",
+			metadata:       map[string]any{cliproxyexecutor.DerivedSessionIDMetadataKey: "ctx:v1:abc"},
+			payload:        `{"messages":[{"role":"user","content":"hello"}]}`,
+			wantID:         "derived:ctx:v1:abc",
+			wantSource:     SourceDerived,
+			wantConfidence: ConfidenceMedium,
+			wantScope:      ScopeSession,
+		},
+		{
+			name:           "message hash low confidence fallback",
+			payload:        `{"messages":[{"role":"user","content":"hello"}]}`,
+			wantID:         "msg:",
+			wantSource:     SourceMessageHash,
+			wantConfidence: ConfidenceLow,
+			wantScope:      ScopeSession,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Extract(tt.headers, []byte(tt.payload), tt.metadata)
+			if tt.wantID == "msg:" {
+				if !strings.HasPrefix(got.ID, "msg:") {
+					t.Fatalf("ID = %q, want msg: prefix", got.ID)
+				}
+			} else if got.ID != tt.wantID {
+				t.Fatalf("ID = %q, want %q", got.ID, tt.wantID)
+			}
+			if !equalStrings(got.Aliases, tt.wantAliases) {
+				t.Fatalf("Aliases = %#v, want %#v", got.Aliases, tt.wantAliases)
+			}
+			if got.Source != tt.wantSource {
+				t.Fatalf("Source = %q, want %q", got.Source, tt.wantSource)
+			}
+			if got.Confidence != tt.wantConfidence {
+				t.Fatalf("Confidence = %q, want %q", got.Confidence, tt.wantConfidence)
+			}
+			if got.Scope != tt.wantScope {
+				t.Fatalf("Scope = %q, want %q", got.Scope, tt.wantScope)
+			}
+		})
+	}
+}
+
+func TestExtractCapturesThreadsWithoutOverridingRootSession(t *testing.T) {
+	headers := http.Header{
+		"Session-Id":                 {"root-1"},
+		"Thread-Id":                  {"thread-1"},
+		"X-Codex-Parent-Thread-Id":   {"thread-parent"},
+		"X-Codex-Turn-Metadata":      {`{"turn_id":"turn-1"}`},
+		"X-Gateway-Parent-Thread-Id": {"gateway-parent"},
+	}
+
+	got := Extract(headers, nil, map[string]any{cliproxyexecutor.ExecutionSessionMetadataKey: "transport-1"})
+
+	if got.ID != "codex:root-1" {
+		t.Fatalf("ID = %q, want codex:root-1", got.ID)
+	}
+	if got.Scope != ScopeSession {
+		t.Fatalf("Scope = %q, want %q", got.Scope, ScopeSession)
+	}
+	for _, id := range got.IDs() {
+		if id == "thread:thread-1" || id == "execution:transport-1" {
+			t.Fatalf("non-root identifier %q was added as a session alias", id)
+		}
+	}
+	if got.ThreadID != "thread-1" {
+		t.Fatalf("ThreadID = %q, want thread-1", got.ThreadID)
+	}
+	// X-Gateway-Parent-Thread-Id is listed first, so the unified protocol wins.
+	if got.ParentThreadID != "gateway-parent" {
+		t.Fatalf("ParentThreadID = %q, want gateway-parent", got.ParentThreadID)
+	}
+	if got.ClientType != ClientTypeCodex {
+		t.Fatalf("ClientType = %q, want %q", got.ClientType, ClientTypeCodex)
+	}
+}
+
+func TestExtractReportsThreadsWithoutAnySession(t *testing.T) {
+	got := Extract(http.Header{"X-Gateway-Thread-Id": {"thread-only"}}, nil, nil)
+
+	if got.ID != "thread:thread-only" {
+		t.Fatalf("ID = %q, want thread:thread-only", got.ID)
+	}
+	if got.ThreadID != "thread-only" {
+		t.Fatalf("ThreadID = %q, want thread-only", got.ThreadID)
+	}
+}
+
+func TestExtractRejectsUnsafeExplicitIdentifiers(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers http.Header
+	}{
+		{name: "control character", headers: http.Header{"X-Gateway-Session-Id": {"bad\nvalue"}}},
+		{name: "oversized", headers: http.Header{"X-Gateway-Session-Id": {strings.Repeat("a", 257)}}},
+		{name: "blank", headers: http.Header{"X-Gateway-Session-Id": {"   "}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Extract(tt.headers, nil, nil); got.ID != "" {
+				t.Fatalf("ID = %q, want empty", got.ID)
+			}
+		})
+	}
+}
+
+func TestExtractSkipsInvalidMultiValueHeaderEntries(t *testing.T) {
+	headers := http.Header{"X-Session-Id": {"bad\nvalue", "good-value"}}
+
+	if got := Extract(headers, nil, nil); got.ID != "header:good-value" {
+		t.Fatalf("ID = %q, want header:good-value", got.ID)
+	}
+}
+
+func TestExtractHeaderNamesAreCaseInsensitive(t *testing.T) {
+	headers := http.Header{}
+	headers["x-claude-code-session-id"] = []string{"cc-lower"}
+
+	if got := Extract(headers, nil, nil); got.ID != "claude:cc-lower" {
+		t.Fatalf("ID = %q, want claude:cc-lower", got.ID)
+	}
+}
+
+func TestExtractReturnsEmptyIdentityWithoutSignals(t *testing.T) {
+	got := Extract(nil, nil, nil)
+
+	if !got.IsZero() {
+		t.Fatalf("Extract() = %#v, want zero identity", got)
+	}
+	if got.FallbackID() != "" {
+		t.Fatalf("FallbackID() = %q, want empty", got.FallbackID())
+	}
+	if len(got.IDs()) != 0 {
+		t.Fatalf("IDs() = %#v, want empty", got.IDs())
+	}
+}
+
+func TestIdentityIDsDeduplication(t *testing.T) {
+	identity := Identity{
+		ID:      "claude:cc-1",
+		Aliases: []string{"affinity:aff-1", "claude:cc-1", "conv:conv-1", "affinity:aff-1", "  "},
+	}
+	got := identity.IDs()
+	want := []string{"claude:cc-1", "affinity:aff-1", "conv:conv-1"}
+	if !equalStrings(got, want) {
+		t.Fatalf("Identity.IDs() = %#v, want %#v", got, want)
+	}
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func quote(value string) string {
+	var builder strings.Builder
+	builder.WriteByte('"')
+	for _, r := range value {
+		if r == '"' || r == '\\' {
+			builder.WriteByte('\\')
+		}
+		builder.WriteRune(r)
+	}
+	builder.WriteByte('"')
+	return builder.String()
+}

--- a/sdk/cliproxy/session/extract_test.go
+++ b/sdk/cliproxy/session/extract_test.go
@@ -94,11 +94,37 @@ func TestExtractClassificationAndAliases(t *testing.T) {
 			wantScope:      ScopeSession,
 		},
 		{
-			name:           "pi responses client request id",
+			// The header tracks the current thread, so a real root identifier always
+			// wins and the header contributes no alias. pi sends prompt_cache_key
+			// with the same value, which is what routing uses instead.
+			name:           "client request id yields to a real root identifier",
+			headers:        http.Header{"X-Client-Request-Id": {"pi-1"}},
+			payload:        `{"prompt_cache_key":"pi-1"}`,
+			wantID:         "pck:pi-1",
+			wantAliases:    nil,
+			wantSource:     SourcePromptCacheKey,
+			wantConfidence: ConfidenceMedium,
+			wantScope:      ScopeSession,
+		},
+		{
+			// A client that sends nothing else still gets affinity from it.
+			name:           "client request id is the last-resort root",
 			headers:        http.Header{"X-Client-Request-Id": {"pi-1"}},
 			wantID:         "clientreq:pi-1",
 			wantSource:     SourceClientRequestID,
 			wantConfidence: ConfidenceMedium,
+			wantScope:      ScopeSession,
+		},
+		{
+			// OpenCode sub-agent: its own session plus the root in the parent header.
+			// The parent shares the "header:" prefix so both requests land in one
+			// alias group and therefore on one credential.
+			name:           "opencode subagent joins the parent session alias group",
+			headers:        http.Header{"X-Session-Id": {"ses_child"}, "X-Session-Affinity": {"ses_child"}, "X-Parent-Session-Id": {"ses_root"}},
+			wantID:         "header:ses_child",
+			wantAliases:    []string{"affinity:ses_child", "header:ses_root"},
+			wantSource:     SourceClientNativeHeader,
+			wantConfidence: ConfidenceHigh,
 			wantScope:      ScopeSession,
 		},
 		{
@@ -308,6 +334,233 @@ func TestIdentityIDsDeduplication(t *testing.T) {
 	if !equalStrings(got, want) {
 		t.Fatalf("Identity.IDs() = %#v, want %#v", got, want)
 	}
+}
+
+// TestExtractOpenCodeSubagentSharesRootIdentifier locks in the routing outcome:
+// the parent and its sub-agent must share at least one identifier so the affinity
+// cache resolves them to a single credential.
+func TestExtractOpenCodeSubagentSharesRootIdentifier(t *testing.T) {
+	parent := Extract(http.Header{
+		"X-Session-Id":       {"ses_root"},
+		"X-Session-Affinity": {"ses_root"},
+		"User-Agent":         {"opencode/1.18.4 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14"},
+	}, nil, nil)
+	child := Extract(http.Header{
+		"X-Session-Id":        {"ses_child"},
+		"X-Session-Affinity":  {"ses_child"},
+		"X-Parent-Session-Id": {"ses_root"},
+		"User-Agent":          {"opencode/1.18.4 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14"},
+	}, nil, nil)
+
+	shared := ""
+	for _, parentID := range parent.IDs() {
+		for _, childID := range child.IDs() {
+			if parentID == childID {
+				shared = parentID
+			}
+		}
+	}
+	if shared == "" {
+		t.Fatalf("parent %v and subagent %v share no identifier, so they would bind to different credentials", parent.IDs(), child.IDs())
+	}
+	if child.ParentThreadID != "ses_root" {
+		t.Fatalf("ParentThreadID = %q, want ses_root", child.ParentThreadID)
+	}
+	if child.ThreadID != "" {
+		t.Fatalf("ThreadID = %q, want empty: OpenCode reports no thread header", child.ThreadID)
+	}
+}
+
+// TestExtractClaudeCodeSubagentThreads mirrors a captured depth-2 Claude Code run:
+// every level repeats the root session, the main agent sends no agent identifier,
+// and the parent identifier only appears from depth 2 onwards.
+func TestExtractClaudeCodeSubagentThreads(t *testing.T) {
+	const root = "5fea96b2-0000-4000-8000-000000000000"
+	base := func() http.Header {
+		return http.Header{
+			"X-Claude-Code-Session-Id": {root},
+			"X-App":                    {"cli"},
+			"Anthropic-Beta":           {"claude-code-20250219"},
+			"User-Agent":               {"claude-cli/2.1.220 (external, sdk-cli)"},
+		}
+	}
+
+	main := Extract(base(), nil, nil)
+	if main.ID != "claude:"+root {
+		t.Fatalf("main ID = %q, want claude:%s", main.ID, root)
+	}
+	if main.ThreadID != "" || main.ParentThreadID != "" {
+		t.Fatalf("main agent reported thread %q parent %q, want both empty", main.ThreadID, main.ParentThreadID)
+	}
+
+	depth1Headers := base()
+	depth1Headers.Set("X-Claude-Code-Agent-Id", "a0f476550f303bf2d")
+	depth1 := Extract(depth1Headers, nil, nil)
+	if depth1.ID != "claude:"+root {
+		t.Fatalf("depth-1 ID = %q, want claude:%s", depth1.ID, root)
+	}
+	if depth1.ThreadID != "a0f476550f303bf2d" {
+		t.Fatalf("depth-1 ThreadID = %q, want a0f476550f303bf2d", depth1.ThreadID)
+	}
+	if depth1.ParentThreadID != "" {
+		t.Fatalf("depth-1 ParentThreadID = %q, want empty", depth1.ParentThreadID)
+	}
+
+	depth2Headers := base()
+	depth2Headers.Set("X-Claude-Code-Agent-Id", "a15f3b017b93ec1d8")
+	depth2Headers.Set("X-Claude-Code-Parent-Agent-Id", "a0f476550f303bf2d")
+	depth2 := Extract(depth2Headers, nil, nil)
+	if depth2.ID != "claude:"+root {
+		t.Fatalf("depth-2 ID = %q, want claude:%s", depth2.ID, root)
+	}
+	if depth2.ThreadID != "a15f3b017b93ec1d8" {
+		t.Fatalf("depth-2 ThreadID = %q, want a15f3b017b93ec1d8", depth2.ThreadID)
+	}
+	if depth2.ParentThreadID != "a0f476550f303bf2d" {
+		t.Fatalf("depth-2 ParentThreadID = %q, want a0f476550f303bf2d", depth2.ParentThreadID)
+	}
+}
+
+// TestExtractCodexSubagentKeepsRootSession mirrors a captured Codex sub-agent turn:
+// session-id and prompt_cache_key stay on the root while thread-id moves to the
+// child, and x-client-request-id follows the thread rather than the session.
+func TestExtractCodexSubagentKeepsRootSession(t *testing.T) {
+	const root = "019fa90b-31a4-7841-b252-0a2d5dafbbdc"
+	const childThread = "019fa90b-3219-73d2-9aad-9de97611969e"
+
+	got := Extract(http.Header{
+		"Session-Id":               {root},
+		"Thread-Id":                {childThread},
+		"X-Codex-Parent-Thread-Id": {root},
+		"X-Client-Request-Id":      {childThread},
+		"X-Openai-Subagent":        {"collab_spawn"},
+		"User-Agent":               {"codex_exec/0.145.0 (Mac OS 26.5.2; arm64)"},
+	}, []byte(`{"prompt_cache_key":"`+root+`"}`), nil)
+
+	if got.ID != "codex:"+root {
+		t.Fatalf("ID = %q, want codex:%s", got.ID, root)
+	}
+	if got.ThreadID != childThread {
+		t.Fatalf("ThreadID = %q, want %s", got.ThreadID, childThread)
+	}
+	if got.ParentThreadID != root {
+		t.Fatalf("ParentThreadID = %q, want %s", got.ParentThreadID, root)
+	}
+	for _, id := range got.IDs() {
+		if strings.Contains(id, childThread) {
+			t.Fatalf("thread identifier %q leaked into the root alias group %v", id, got.IDs())
+		}
+	}
+}
+
+// TestExtractWithoutAnyRootSignalStaysZero pins the contract that observation
+// fields never manufacture a session. A request with no root identifier must still
+// report IsZero and contribute no routing identifier, even when the client type,
+// turn metadata and request kind are all recognised.
+func TestExtractWithoutAnyRootSignalStaysZero(t *testing.T) {
+	got := Extract(http.Header{
+		"User-Agent":            {"codex_exec/0.145.0 (Mac OS 26.5.2; arm64)"},
+		"X-Codex-Turn-Metadata": {`{"request_kind":"prewarm","thread_source":"user","turn_id":"019fa90b-3234-73d2-a061-0622e5f8c57c"}`},
+		"X-App":                 {"cli-bg"},
+	}, nil, nil)
+
+	if !got.IsZero() {
+		t.Fatalf("IsZero() = false for identity %#v, want true", got)
+	}
+	if got.ID != "" {
+		t.Fatalf("ID = %q, want empty", got.ID)
+	}
+	if ids := got.IDs(); len(ids) != 0 {
+		t.Fatalf("IDs() = %#v, want none: observation fields must not create a routing key", ids)
+	}
+	// The observations are still reported for logging.
+	if got.ClientType != ClientTypeCodex {
+		t.Fatalf("ClientType = %q, want %q", got.ClientType, ClientTypeCodex)
+	}
+	if got.RequestKind != "prewarm" {
+		t.Fatalf("RequestKind = %q, want prewarm", got.RequestKind)
+	}
+}
+
+// TestExtractTurnObservations covers the observation-only fields: they are read
+// from what the client reports, bounded, and never promoted to a session alias.
+func TestExtractTurnObservations(t *testing.T) {
+	const root = "019fa90b-31a4-7841-b252-0a2d5dafbbdc"
+	const childThread = "019fa90b-3219-73d2-9aad-9de97611969e"
+	const turnID = "019fa90b-3234-73d2-a061-0622e5f8c57c"
+
+	t.Run("codex subagent turn", func(t *testing.T) {
+		metadata := `{"installation_id":"i","session_id":"` + root + `","thread_id":"` + childThread +
+			`","turn_id":"` + turnID + `","request_kind":"turn","parent_thread_id":"` + root +
+			`","subagent_kind":"thread_spawn","thread_source":"subagent"}`
+		got := Extract(http.Header{
+			"Session-Id":            {root},
+			"Thread-Id":             {childThread},
+			"X-Codex-Turn-Metadata": {metadata},
+			"User-Agent":            {"codex_exec/0.145.0 (Mac OS 26.5.2; arm64)"},
+		}, nil, nil)
+
+		if got.RequestKind != "turn" {
+			t.Fatalf("RequestKind = %q, want turn", got.RequestKind)
+		}
+		if got.ThreadSource != "subagent" {
+			t.Fatalf("ThreadSource = %q, want subagent", got.ThreadSource)
+		}
+		if got.TurnID != turnID {
+			t.Fatalf("TurnID = %q, want %s", got.TurnID, turnID)
+		}
+		for _, id := range got.IDs() {
+			if strings.Contains(id, turnID) {
+				t.Fatalf("turn identifier leaked into the alias group %v", got.IDs())
+			}
+		}
+	})
+
+	t.Run("codex housekeeping kinds are reported verbatim", func(t *testing.T) {
+		for _, kind := range []string{"compact", "review", "title", "prewarm"} {
+			got := Extract(http.Header{
+				"Session-Id":            {root},
+				"X-Codex-Turn-Metadata": {`{"request_kind":"` + kind + `","thread_source":"user"}`},
+			}, nil, nil)
+			if got.RequestKind != kind {
+				t.Fatalf("RequestKind = %q, want %q", got.RequestKind, kind)
+			}
+		}
+	})
+
+	t.Run("claude code background", func(t *testing.T) {
+		got := Extract(http.Header{
+			"X-Claude-Code-Session-Id": {root},
+			"X-App":                    {"cli-bg"},
+			"Anthropic-Beta":           {"claude-code-20250219"},
+		}, nil, nil)
+		if got.RequestKind != RequestKindBackground {
+			t.Fatalf("RequestKind = %q, want %q", got.RequestKind, RequestKindBackground)
+		}
+	})
+
+	t.Run("hostile metadata is rejected", func(t *testing.T) {
+		cases := []struct{ name, metadata string }{
+			{"not json", `not-json`},
+			{"control characters", `{"request_kind":"tu\u0001rn"}`},
+			{"oversized value", `{"request_kind":"` + strings.Repeat("k", observationValueMaxLength+1) + `"}`},
+			{"oversized payload", `{"request_kind":"turn","pad":"` + strings.Repeat("p", codexTurnMetadataMaxBytes) + `"}`},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				got := Extract(http.Header{
+					"Session-Id":            {root},
+					"X-Codex-Turn-Metadata": {tc.metadata},
+				}, nil, nil)
+				if got.ID != "codex:"+root {
+					t.Fatalf("ID = %q, want codex:%s", got.ID, root)
+				}
+				if got.RequestKind != "" {
+					t.Fatalf("RequestKind = %q, want empty", got.RequestKind)
+				}
+			})
+		}
+	})
 }
 
 func equalStrings(left, right []string) bool {

--- a/sdk/cliproxy/session/identity.go
+++ b/sdk/cliproxy/session/identity.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 	"unicode"
@@ -93,8 +94,37 @@ func DerivedID(metadata map[string]any) string {
 	return strings.TrimSpace(value)
 }
 
-// Enrich derives a session identity once and places it in both request and option metadata.
+// Enrich resolves the session identity once and places it, together with the
+// derived identity it may depend on, in both request and option metadata.
+// Every later stage reads the stored identity instead of re-extracting it.
 func Enrich(req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Request, cliproxyexecutor.Options) {
+	req, opts = enrichDerivedIdentity(req, opts)
+	return attachIdentity(req, opts)
+}
+
+// FromMetadata returns the identity stored by Enrich, if present.
+func FromMetadata(metadata map[string]any) (Identity, bool) {
+	if metadata == nil {
+		return Identity{}, false
+	}
+	identity, ok := metadata[cliproxyexecutor.SessionIdentityMetadataKey].(Identity)
+	return identity, ok
+}
+
+// attachIdentity extracts the session identity and stores it for later stages.
+func attachIdentity(req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Request, cliproxyexecutor.Options) {
+	identity := Extract(opts.Headers, opts.OriginalRequest, opts.Metadata)
+	if identity.IsZero() && identity.ClientType == "" && identity.ThreadID == "" && identity.ParentThreadID == "" {
+		req.Metadata = metadataWithoutKey(req.Metadata, cliproxyexecutor.SessionIdentityMetadataKey)
+		opts.Metadata = metadataWithoutKey(opts.Metadata, cliproxyexecutor.SessionIdentityMetadataKey)
+		return req, opts
+	}
+	req.Metadata = metadataWithValue(req.Metadata, cliproxyexecutor.SessionIdentityMetadataKey, identity)
+	opts.Metadata = metadataWithValue(opts.Metadata, cliproxyexecutor.SessionIdentityMetadataKey, identity)
+	return req, opts
+}
+
+func enrichDerivedIdentity(req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Request, cliproxyexecutor.Options) {
 	payload := opts.OriginalRequest
 	if len(payload) == 0 && len(req.Payload) > 0 {
 		opts.OriginalRequest = bytes.Clone(req.Payload)
@@ -131,47 +161,19 @@ func Enrich(req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (clipro
 	return req, opts
 }
 
-func hasExplicitSession(headers map[string][]string, payload []byte) bool {
-	for _, header := range []string{"X-Claude-Code-Session-Id", "X-Session-ID", "Session-Id", "Session_id", "X-Session-Affinity", "X-Client-Request-Id"} {
-		if NormalizeExplicitID(headerValue(headers, header)) != "" {
-			return true
-		}
+// hasExplicitSession reports whether the client already identified the session,
+// in which case no context-derived identity is computed.
+func hasExplicitSession(headers http.Header, payload []byte) bool {
+	if len(extractExplicitRootSignals(headers, payload)) > 0 {
+		return true
+	}
+	if firstHeaderValue(headers, threadHeaders...) != "" {
+		return true
 	}
 	if len(payload) == 0 {
 		return false
 	}
-	root := gjson.ParseBytes(payload)
-	for _, path := range []string{"session_id", "sessionId", "conversation_id", "prompt_cache_key"} {
-		if NormalizeExplicitID(root.Get(path).String()) != "" {
-			return true
-		}
-	}
-	if ClaudeMetadataSessionID(payload) != "" {
-		return true
-	}
-	userID := strings.TrimSpace(root.Get("metadata.user_id").String())
-	if NormalizeExplicitID(userID) != "" {
-		return true
-	}
-	conversation := root.Get("conversation")
-	if NormalizeExplicitID(conversation.Get("id").String()) != "" {
-		return true
-	}
-	return conversation.Type == gjson.String && NormalizeExplicitID(conversation.String()) != ""
-}
-
-func headerValue(headers map[string][]string, name string) string {
-	for key, values := range headers {
-		if !strings.EqualFold(key, name) {
-			continue
-		}
-		for _, value := range values {
-			if normalized := NormalizeExplicitID(value); normalized != "" {
-				return normalized
-			}
-		}
-	}
-	return ""
+	return NormalizeExplicitID(gjson.GetBytes(payload, "metadata.user_id").String()) != ""
 }
 
 // DeriveID builds a stable identity from leading instructions and the first complete user input.

--- a/sdk/cliproxy/session/identity_types.go
+++ b/sdk/cliproxy/session/identity_types.go
@@ -1,0 +1,116 @@
+package session
+
+import "strings"
+
+// Confidence classifies how much a session identifier can be trusted to
+// represent one client conversation.
+const (
+	// ConfidenceHigh marks identifiers a client sends explicitly for one conversation.
+	ConfidenceHigh = "high"
+	// ConfidenceMedium marks identifiers that usually track a conversation but are
+	// documented for another purpose, or that CPA inferred from stable request context.
+	ConfidenceMedium = "medium"
+	// ConfidenceLow marks identifiers that only approximate a conversation.
+	ConfidenceLow = "low"
+)
+
+// Scope records what a session identifier actually addresses.
+const (
+	// ScopeSession addresses one client conversation.
+	ScopeSession = "session"
+	// ScopeThread addresses one thread or sub-agent inside a conversation.
+	ScopeThread = "thread"
+	// ScopeUser addresses an end user rather than a conversation.
+	ScopeUser = "user"
+	// ScopeTransport addresses one long-lived downstream connection.
+	ScopeTransport = "transport"
+)
+
+// Source records which signal produced a session identifier.
+const (
+	// SourceGatewayHeader is the unified X-Gateway-Session-Id protocol.
+	SourceGatewayHeader = "gateway_header"
+	// SourceClientNativeHeader is a session header a coding agent sends natively.
+	SourceClientNativeHeader = "client_native_header"
+	// SourceMetadataUserID is a Claude Code session parsed out of metadata.user_id.
+	SourceMetadataUserID = "metadata_user_id"
+	// SourceClientRequestID is the pi Responses x-client-request-id header.
+	SourceClientRequestID = "client_request_id"
+	// SourceBodySession is an explicit session field in the request body.
+	SourceBodySession = "body_session"
+	// SourcePromptCacheKey is the Responses prompt_cache_key field.
+	SourcePromptCacheKey = "prompt_cache_key"
+	// SourceBodyConversation is a Responses conversation reference.
+	SourceBodyConversation = "body_conversation"
+	// SourceLegacyMetadataUser is a bare metadata.user_id value.
+	SourceLegacyMetadataUser = "legacy_metadata_user"
+	// SourceExecutionSession is a downstream execution session owned by CPA.
+	SourceExecutionSession = "execution_session"
+	// SourceDerived is the stable identity derived from request context.
+	SourceDerived = "derived"
+	// SourceMessageHash is the legacy first-message hash fallback.
+	SourceMessageHash = "message_hash"
+)
+
+// Identity describes one extracted client session, its provenance, and the
+// related identifiers that address the same logical conversation.
+// The representative ID is stored in ID, and any additional explicit
+// session aliases are stored in Aliases. Routing operations must inspect
+// all IDs returned by IDs().
+type Identity struct {
+	// ID is the representative namespaced session identifier used for display and compatibility.
+	ID string
+	// Aliases lists other identifiers known to address the same session.
+	Aliases []string
+	// Source names the signal the representative identifier came from.
+	Source string
+	// Confidence reports how strongly the representative identifier represents one conversation.
+	Confidence string
+	// Scope reports what the representative identifier addresses.
+	Scope string
+	// ClientType names the detected downstream client, when it is unambiguous.
+	ClientType string
+	// ThreadID carries the current thread or sub-agent identifier, for observability.
+	ThreadID string
+	// ParentThreadID carries the parent thread identifier, for observability.
+	ParentThreadID string
+	// ClientProvided reports whether the client sent the representative identifier itself.
+	ClientProvided bool
+}
+
+// IsZero reports whether no session identifier could be extracted.
+func (i Identity) IsZero() bool {
+	return i.ID == ""
+}
+
+// FallbackID returns the first alias, if present, for compatibility.
+func (i Identity) FallbackID() string {
+	if len(i.Aliases) == 0 {
+		return ""
+	}
+	return i.Aliases[0]
+}
+
+// IDs returns the deduplicated representative identifier and all aliases.
+func (i Identity) IDs() []string {
+	id := strings.TrimSpace(i.ID)
+	if id == "" {
+		return nil
+	}
+	out := make([]string, 0, 1+len(i.Aliases))
+	seen := make(map[string]struct{}, 1+len(i.Aliases))
+	out = append(out, id)
+	seen[id] = struct{}{}
+	for _, alias := range i.Aliases {
+		alias = strings.TrimSpace(alias)
+		if alias == "" {
+			continue
+		}
+		if _, ok := seen[alias]; ok {
+			continue
+		}
+		seen[alias] = struct{}{}
+		out = append(out, alias)
+	}
+	return out
+}

--- a/sdk/cliproxy/session/identity_types.go
+++ b/sdk/cliproxy/session/identity_types.go
@@ -34,7 +34,13 @@ const (
 	SourceClientNativeHeader = "client_native_header"
 	// SourceMetadataUserID is a Claude Code session parsed out of metadata.user_id.
 	SourceMetadataUserID = "metadata_user_id"
-	// SourceClientRequestID is the pi Responses x-client-request-id header.
+	// SourceClientRequestID is the x-client-request-id header, used only when a
+	// request carries no other explicit root identifier.
+	//
+	// Live captures show the header tracks the current thread, not the root session:
+	// a Codex sub-agent sends its own thread identifier there while session-id stays
+	// on the root. Collecting it alongside a real root identifier would add one
+	// throwaway alias per sub-agent to the root alias group, so it is a last resort.
 	SourceClientRequestID = "client_request_id"
 	// SourceBodySession is an explicit session field in the request body.
 	SourceBodySession = "body_session"
@@ -74,6 +80,17 @@ type Identity struct {
 	ThreadID string
 	// ParentThreadID carries the parent thread identifier, for observability.
 	ParentThreadID string
+	// RequestKind names what the client is doing, when it says so: Codex reports
+	// turn, compact, review, title, prewarm and similar, and Claude Code reports
+	// background work. It lets a session timeline separate real conversation turns
+	// from housekeeping requests. Observability only.
+	RequestKind string
+	// ThreadSource names where the thread came from, when the client says so:
+	// user, subagent, fork and similar. Observability only.
+	ThreadSource string
+	// TurnID identifies one client turn, which may span several upstream requests.
+	// It changes every turn and is never a session identifier. Observability only.
+	TurnID string
 	// ClientProvided reports whether the client sent the representative identifier itself.
 	ClientProvided bool
 }

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -51,6 +51,32 @@ type Record struct {
 	Detail      Detail
 	// ResponseHeaders stores a snapshot of upstream response headers for usage sinks.
 	ResponseHeaders http.Header
+	// Session describes the client conversation this request belongs to.
+	Session SessionInfo
+}
+
+// SessionInfo carries the session identity resolved once per request so usage
+// records can be grouped into a conversation timeline. It mirrors the routing
+// identity rather than re-deriving one, so observation and routing never disagree.
+type SessionInfo struct {
+	// ID is the canonical namespaced session identifier used for routing.
+	ID string
+	// Source names the signal the identifier came from.
+	Source string
+	// Confidence reports how strongly the identifier represents one conversation.
+	Confidence string
+	// Scope reports whether the identifier addresses a session, thread, user, or transport.
+	Scope string
+	// ClientType names the detected downstream client.
+	ClientType string
+	// ThreadID and ParentThreadID describe sub-agent and fork relationships.
+	ThreadID       string
+	ParentThreadID string
+}
+
+// IsZero reports whether no session information was resolved.
+func (s SessionInfo) IsZero() bool {
+	return s == SessionInfo{}
 }
 
 // Failure holds HTTP failure metadata for an upstream request attempt.
@@ -76,6 +102,7 @@ type requestedModelAliasContextKey struct{}
 type reasoningEffortContextKey struct{}
 type serviceTierContextKey struct{}
 type generateContextKey struct{}
+type sessionInfoContextKey struct{}
 
 // WithRequestedModelAlias stores the client-requested model name for usage sinks.
 func WithRequestedModelAlias(ctx context.Context, alias string) context.Context {
@@ -103,6 +130,26 @@ func RequestedModelAliasFromContext(ctx context.Context) string {
 	default:
 		return ""
 	}
+}
+
+// WithSessionInfo stores the resolved session identity for usage sinks.
+func WithSessionInfo(ctx context.Context, info SessionInfo) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if info.IsZero() {
+		return ctx
+	}
+	return context.WithValue(ctx, sessionInfoContextKey{}, info)
+}
+
+// SessionInfoFromContext returns the session identity stored in ctx.
+func SessionInfoFromContext(ctx context.Context) SessionInfo {
+	if ctx == nil {
+		return SessionInfo{}
+	}
+	info, _ := ctx.Value(sessionInfoContextKey{}).(SessionInfo)
+	return info
 }
 
 // WithReasoningEffort stores the client-requested reasoning effort for usage sinks.

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -72,6 +72,13 @@ type SessionInfo struct {
 	// ThreadID and ParentThreadID describe sub-agent and fork relationships.
 	ThreadID       string
 	ParentThreadID string
+	// RequestKind names what the client reported this request is: a conversation
+	// turn, or housekeeping such as compaction, title generation or background work.
+	RequestKind string
+	// ThreadSource names where the thread came from: user, subagent, fork.
+	ThreadSource string
+	// TurnID identifies one client turn, which may span several upstream requests.
+	TurnID string
 }
 
 // IsZero reports whether no session information was resolved.

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -1344,6 +1344,26 @@ type UsageRecord struct {
 	Detail UsageDetail
 	// ResponseHeaders contains selected upstream response headers.
 	ResponseHeaders http.Header
+	// Session describes the client conversation this request belongs to.
+	Session UsageSession
+}
+
+// UsageSession describes the client session a usage record belongs to. It mirrors
+// the identity the request was routed on, so usage timelines and routing agree.
+type UsageSession struct {
+	// ID is the canonical namespaced session identifier.
+	ID string
+	// Source names the signal the identifier came from.
+	Source string
+	// Confidence reports how strongly the identifier represents one conversation.
+	Confidence string
+	// Scope reports whether the identifier addresses a session, thread, user, or transport.
+	Scope string
+	// ClientType names the detected downstream client.
+	ClientType string
+	// ThreadID and ParentThreadID describe sub-agent and fork relationships.
+	ThreadID       string
+	ParentThreadID string
 }
 
 // UsageFailure describes an upstream or executor failure.

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -1364,6 +1364,13 @@ type UsageSession struct {
 	// ThreadID and ParentThreadID describe sub-agent and fork relationships.
 	ThreadID       string
 	ParentThreadID string
+	// RequestKind names what the client reported this request is: a conversation
+	// turn, or housekeeping such as compaction, title generation or background work.
+	RequestKind string
+	// ThreadSource names where the thread came from: user, subagent, fork.
+	ThreadSource string
+	// TurnID identifies one client turn, which may span several upstream requests.
+	TurnID string
 }
 
 // UsageFailure describes an upstream or executor failure.


### PR DESCRIPTION
Two commits. The first unifies session extraction and affinity routing; the second
identifies sub-agents from signals captured off real clients.

## Why

`#4554` landed native client session signals. Two follow-up problems remained.

Routing still treated every recognized session identifier as a separate session,
so a request that arrived through a different signal than the one that created the
binding started a second binding on another credential. And sub-agent traffic was
not identified at all, because the headers that carry it were never read.

To find out what clients actually send, rather than infer it, requests from
**Claude Code 2.1.220**, **Codex 0.145.0**, **OpenCode 1.18.4** and **pi 0.82.1**
were captured against a local gateway that replies with each client's own
sub-agent tool, so a real child agent request is observed. Three different
conventions turned up.

## Commit 1 — unified extraction and alias affinity

Every recognized explicit root identifier in one request is treated as an alias of
the same session, so a request seen through any of them resolves to one binding.
Thread, user, transport, derived and message-hash fallbacks stay isolated from
explicit roots. Local bindings are namespaced by caller, provider and model. Cold
and overlapping alias groups resolve atomically under striped alias/group locks,
conflicts merge symmetrically, and unavailable auths rebind. The cache is bounded
by TTL and LRU. Home receives both the legacy session ID and structured identity
metadata. Confidence stays observational and never affects routing.

## Commit 2 — sub-agent identification

**Claude Code** repeats the root session at every depth and marks a sub-agent with
`X-Claude-Code-Agent-Id`, which the main agent omits entirely. The parent
identifier only appears from depth 2, because a depth-1 sub-agent's parent is the
main agent and has none of its own:

```
main agent    session=5fea96b2…  agent=-                  parent=-
subagent d1   session=5fea96b2…  agent=a0f476550f303bf2d  parent=-
subagent d2   session=5fea96b2…  agent=a15f3b017b93ec1d8  parent=a0f476550f303bf2d
```

Neither header was read, so thread identity was always empty for Claude Code.
Both now feed `ThreadID`/`ParentThreadID`.

**OpenCode** inverts the convention: a sub-agent gets its own `X-Session-Id` and
reports the root in `X-Parent-Session-Id`, so it was routed as an unrelated
session and lost the parent's prompt cache. The parent is now collected under the
same `header:` prefix as `X-Session-Id`, so a child joins the parent's alias group
and reuses its credential.

**Codex** was already correct: `session-id` stays on the root while `thread-id`
moves to the child. But `x-client-request-id` follows the thread, not the session,
so collecting it as an unconditional root added one throwaway alias per sub-agent
to the root alias group. It is now a last resort, still providing affinity for a
client that sends nothing else.

**pi** exposes no sub-agent tool at this version.

Claude Code also reports background work as `X-App: cli-bg`, which a strict `cli`
comparison dropped, costing one of the two signals header-only detection needs.

Codex reports per-turn observations in `X-Codex-Turn-Metadata`. `RequestKind`,
`ThreadSource` and `TurnID` carry them to Home, usage records and request logs so a
session timeline can separate real conversation turns from compaction, title
generation and other housekeeping, and can group the upstream requests belonging
to one client turn. They are observation only, never enter a routing key, and
client-supplied JSON is bounded and rejected on control characters.

## Compatibility

New wire fields are additive and `omitempty`. Home reads the auth dispatch and
usage payloads with gjson, which ignores unknown fields, so a new CPA runs against
an older Home with no ordering constraint. This was verified by reading Home's
decoders, not by an end-to-end run against a live Home.

## Verification

`gofmt` clean, builds, and the full suite passes (86 packages). Under `-race` the
only failing packages are `internal/runtime/executor` and `internal/watcher`,
which fail identically on an unmodified tree.

Every changed production file was reverted individually to confirm a test fails or
the build breaks, including the field-copy paths into Home and usage that would
otherwise publish empty values silently. Two cases are worth calling out:

- an OpenCode sub-agent must pick the parent's credential — reverting the
  extraction change makes it pick a different one
- a parent with 60 sub-agents exceeds the per-group alias cap; the parent keeps its
  binding, and an early sub-agent whose own aliases were squeezed out still
  resolves through the parent header

The one change that alters routing rather than only observation is the OpenCode
parent alias. Its semantics were verified on OpenCode only.
