### PR TITLE
feat(antigravity): map OpenAI response_format to generationConfig structured output

### DIFF
--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
@@ -74,6 +74,22 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 		out, _ = sjson.SetBytes(out, "request.generationConfig.maxOutputTokens", maxTok.Num)
 	}
 
+	// Map OpenAI response_format -> Antigravity structured output config. The upstream
+	// honors the legacy generationConfig.responseSchema spelling and ignores
+	// responseJsonSchema, so json_schema is emitted as responseSchema; unsupported JSON
+	// Schema keywords are stripped later by the executor's schema sanitizer.
+	if rf := gjson.GetBytes(rawJSON, "response_format"); rf.Exists() {
+		switch strings.ToLower(strings.TrimSpace(rf.Get("type").String())) {
+		case "json_object":
+			out, _ = sjson.SetBytes(out, "request.generationConfig.responseMimeType", "application/json")
+		case "json_schema":
+			out, _ = sjson.SetBytes(out, "request.generationConfig.responseMimeType", "application/json")
+			if schema := rf.Get("json_schema.schema"); schema.Exists() {
+				out, _ = sjson.SetRawBytes(out, "request.generationConfig.responseSchema", []byte(schema.Raw))
+			}
+		}
+	}
+
 	// Candidate count (OpenAI 'n' parameter)
 	if n := gjson.GetBytes(rawJSON, "n"); n.Exists() && n.Type == gjson.Number {
 		if val := n.Int(); val > 1 {

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request_test.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request_test.go
@@ -314,3 +314,52 @@ func TestConvertOpenAIRequestToAntigravityMapsToolChoiceModes(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertOpenAIRequestToAntigravityMapsResponseFormatJSONObject(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.6-flash-high",
+		"response_format": {"type": "json_object"},
+		"messages": [{"role": "user", "content": "hi"}]
+	}`
+
+	result := ConvertOpenAIRequestToAntigravity("gemini-3.6-flash-high", []byte(inputJSON), false)
+	if got := gjson.GetBytes(result, "request.generationConfig.responseMimeType").String(); got != "application/json" {
+		t.Fatalf("responseMimeType = %q, want application/json. Output: %s", got, result)
+	}
+	if gjson.GetBytes(result, "request.generationConfig.responseSchema").Exists() {
+		t.Fatalf("responseSchema should be absent for json_object. Output: %s", result)
+	}
+}
+
+func TestConvertOpenAIRequestToAntigravityMapsResponseFormatJSONSchema(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.6-flash-high",
+		"response_format": {
+			"type": "json_schema",
+			"json_schema": {
+				"name": "verdict",
+				"schema": {
+					"type": "object",
+					"properties": {"score": {"type": "integer"}},
+					"required": ["score"]
+				}
+			}
+		},
+		"messages": [{"role": "user", "content": "hi"}]
+	}`
+
+	result := ConvertOpenAIRequestToAntigravity("gemini-3.6-flash-high", []byte(inputJSON), false)
+	if got := gjson.GetBytes(result, "request.generationConfig.responseMimeType").String(); got != "application/json" {
+		t.Fatalf("responseMimeType = %q, want application/json. Output: %s", got, result)
+	}
+	schema := gjson.GetBytes(result, "request.generationConfig.responseSchema")
+	if !schema.Exists() {
+		t.Fatalf("responseSchema missing. Output: %s", result)
+	}
+	if got := schema.Get("properties.score.type").String(); got != "integer" {
+		t.Fatalf("responseSchema.properties.score.type = %q, want integer. Output: %s", got, result)
+	}
+	if gjson.GetBytes(result, "request.generationConfig.responseJsonSchema").Exists() {
+		t.Fatalf("responseJsonSchema must not be emitted (upstream ignores it). Output: %s", result)
+	}
+}


### PR DESCRIPTION
## Problem

The OpenAI chat-completions → Antigravity request translator maps `temperature`, `top_p`, `top_k`, `max_tokens`, `thinking`/`reasoning_effort` and `modalities`, but silently drops `response_format`. JSON-mode clients (`response_format: {"type": "json_object"}` or `json_schema`) therefore get markdown-fenced output from Gemini models roughly ~50% of the time on long reasoning-heavy prompts, which breaks strict JSON consumers.

## Fix

Map `response_format` in `ConvertOpenAIRequestToAntigravity`, mirroring the existing gemini openai-responses translator (`applyOpenAIResponsesTextFormatToGemini`):

- `json_object` → `request.generationConfig.responseMimeType = application/json`
- `json_schema` → `responseMimeType` + `request.generationConfig.responseSchema = json_schema.schema`

### Why the legacy `responseSchema` spelling (not `responseJsonSchema`)

Tested directly against both cloudcode-pa upstreams (daily + prod, `v1internal:streamGenerateContent`):

- `generationConfig.responseJsonSchema` is **silently ignored** — free-form markdown still comes back
- `generationConfig.responseSchema` is **enforced** (grammar-constrained decoding) on both endpoints
- `responseMimeType` alone is only a soft hint on long prompts (still ~25% fenced in my tests)

The executor's existing schema sanitizer (`antigravityGenerationSchemaKeys`) already strips unsupported JSON Schema keywords from `generationConfig.responseSchema` before dispatch, so passing the client schema through raw is safe.

## Verification

- Unit tests added for both `json_object` and `json_schema` mapping (asserting `responseJsonSchema` is *not* emitted)
- End-to-end: 3 rounds × 60 concurrent real-world JSON requests (~15k-token prompts, `reasoning_effort: high`) through a deployed build — **0 fenced/invalid outputs**, vs ~50% fenced before the change
- `go test ./internal/translator/antigravity/...` green