### PR TITLE
feat: add native Qwen/DashScope provider support

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -374,6 +374,9 @@ nonstream-keepalive-interval: 0
 #     prefix: "qwen" # optional: require calls like "qwen/qwen3-max" to target this credential
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://dashscope.aliyuncs.com/compatible-mode/v1" # optional: defaults to DashScope
+#     # Token Plan endpoints (subscription-based, different quota rules):
+#     # base-url: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"   # CN token plan
+#     # base-url: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1" # International token plan
 #     headers:
 #       X-Custom-Header: "custom-value"
 #     proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -363,6 +363,27 @@ nonstream-keepalive-interval: 0
 #       - "grok-4.1"             # exclude specific models (exact match)
 #       - "grok-3-*"             # wildcard matching prefix
 
+# Qwen/DashScope API keys (Alibaba Cloud Bailian)
+# Uses the native Qwen executor with OpenAI-compatible chat completions.
+# Automatically sanitizes unsupported OpenAI params (developer role, store, etc.)
+# and translates thinking config to Qwen-native enable_thinking format.
+# Models are loaded from the built-in catalog; the models list is optional for aliasing.
+# qwen-api-key:
+#   - api-key: "sk-..." # DashScope API key from Bailian console
+#     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
+#     prefix: "qwen" # optional: require calls like "qwen/qwen3-max" to target this credential
+#     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
+#     base-url: "https://dashscope.aliyuncs.com/compatible-mode/v1" # optional: defaults to DashScope
+#     headers:
+#       X-Custom-Header: "custom-value"
+#     proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override
+#     models: # optional: override or alias models from the built-in catalog
+#       - name: "qwen3-max"        # upstream model name
+#         alias: "qwen-max"        # client alias mapped to the upstream model
+#         display-name: "Qwen Max" # optional catalog display name
+#     excluded-models:
+#       - "qwen-turbo"             # exclude specific models (exact match)
+
 # Claude API keys
 # claude-api-key:
 #   - api-key: "sk-atSM..." # use the official claude API key, no need to set the base url
@@ -485,7 +506,7 @@ nonstream-keepalive-interval: 0
 # Global OAuth model name aliases (per channel)
 # These aliases rename model IDs for both model listing and request routing.
 # Supported channels: vertex, aistudio, antigravity, claude, codex, kimi, xai.
-# NOTE: Aliases do not apply to gemini-api-key, interactions-api-key, codex-api-key, xai-api-key, claude-api-key, openai-compatibility, or vertex-api-key.
+# NOTE: Aliases do not apply to gemini-api-key, interactions-api-key, codex-api-key, xai-api-key, qwen-api-key, claude-api-key, openai-compatibility, or vertex-api-key.
 # NOTE: Because aliases affect the merged /v1 model list and merged request routing, overlapping
 # client-visible names can become ambiguous across providers. For strict backend pinning, use
 # unique aliases/prefixes or avoid overlapping names.

--- a/internal/api/handlers/management/auth_files_provider_oauth.go
+++ b/internal/api/handlers/management/auth_files_provider_oauth.go
@@ -18,6 +18,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/claude"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/kimi"
+	qwenauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/qwen"
 	xaiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/xai"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
@@ -698,6 +699,102 @@ func (h *Handler) RequestKimiToken(c *gin.Context) {
 	if userCode := strings.TrimSpace(deviceFlow.UserCode); userCode != "" {
 		response["user_code"] = userCode
 	}
+	if deviceFlow.ExpiresIn > 0 {
+		response["expires_in"] = deviceFlow.ExpiresIn
+	}
+	c.JSON(200, response)
+}
+
+// RequestQwenToken initiates the Qianwen OAuth device flow for usage/quota access.
+// The resulting credential (provider "qianwen") is used only for querying account
+// usage and quota, not for model inference.
+func (h *Handler) RequestQwenToken(c *gin.Context) {
+	ctx := context.Background()
+	ctx = PopulateAuthContext(ctx, c)
+
+	state := fmt.Sprintf("qwn-%d", time.Now().UnixNano())
+	qwenAuth := qwenauth.NewQwenAuth(h.cfg)
+
+	deviceFlow, errStartDeviceFlow := qwenAuth.StartDeviceFlow(ctx)
+	if errStartDeviceFlow != nil {
+		log.Errorf("Failed to start Qianwen device flow: %v", errStartDeviceFlow)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate authorization url"})
+		return
+	}
+	authURL := deviceFlow.VerificationURL
+
+	RegisterOAuthSession(state, "qianwen")
+
+	go func() {
+		pollCtx, cancelPoll := context.WithCancel(ctx)
+		defer cancelPoll()
+		go watchOAuthSessionCancel(pollCtx, cancelPoll, state, "qianwen")
+
+		authBundle, errWaitForAuthorization := qwenAuth.WaitForAuthorization(pollCtx, deviceFlow)
+		if errWaitForAuthorization != nil {
+			if !IsOAuthSessionPending(state, "qianwen") {
+				return
+			}
+			SetOAuthSessionError(state, oauthSessionErrorWithCause("Authentication failed", errWaitForAuthorization))
+			return
+		}
+		if !IsOAuthSessionPending(state, "qianwen") {
+			return
+		}
+
+		tokenStorage := qwenAuth.CreateTokenStorage(authBundle)
+
+		metadata := map[string]any{
+			"type":         "qianwen",
+			"access_token": authBundle.TokenData.AccessToken,
+			"token_type":   "Bearer",
+			"timestamp":    time.Now().UnixMilli(),
+		}
+		if strings.TrimSpace(authBundle.TokenData.RefreshToken) != "" {
+			metadata["refresh_token"] = authBundle.TokenData.RefreshToken
+		}
+		if strings.TrimSpace(authBundle.TokenData.ExpiresAt) != "" {
+			metadata["expired"] = authBundle.TokenData.ExpiresAt
+		}
+		if strings.TrimSpace(authBundle.DeviceID) != "" {
+			metadata["device_id"] = strings.TrimSpace(authBundle.DeviceID)
+		}
+		if strings.TrimSpace(authBundle.TokenData.Email) != "" {
+			metadata["email"] = strings.TrimSpace(authBundle.TokenData.Email)
+		}
+		if strings.TrimSpace(authBundle.TokenData.AliyunID) != "" {
+			metadata["aliyun_id"] = strings.TrimSpace(authBundle.TokenData.AliyunID)
+		}
+
+		fileName := fmt.Sprintf("qianwen-%d.json", time.Now().UnixMilli())
+		label := "Qianwen User"
+		if email := strings.TrimSpace(authBundle.TokenData.Email); email != "" {
+			label = email
+		} else if aliyunID := strings.TrimSpace(authBundle.TokenData.AliyunID); aliyunID != "" {
+			label = aliyunID
+		}
+		record := &coreauth.Auth{
+			ID:       fileName,
+			Provider: "qianwen",
+			FileName: fileName,
+			Label:    label,
+			Storage:  tokenStorage,
+			Metadata: metadata,
+		}
+		if errGuard := guardOAuthSessionPendingForSave(state, "qianwen"); errGuard != nil {
+			return
+		}
+		savedPath, errSave := h.saveTokenRecord(ctx, record)
+		if errSave != nil {
+			log.Errorf("Failed to save Qianwen authentication tokens: %v", errSave)
+			SetOAuthSessionError(state, "Failed to save authentication tokens")
+			return
+		}
+		log.Infof("Qianwen authentication successful, token saved to %s", savedPath)
+		CompleteOAuthSession(state)
+	}()
+
+	response := gin.H{"status": "ok", "url": authURL, "state": state, "flow": "device"}
 	if deviceFlow.ExpiresIn > 0 {
 		response["expires_in"] = deviceFlow.ExpiresIn
 	}

--- a/internal/api/handlers/management/config_apikey_disable.go
+++ b/internal/api/handlers/management/config_apikey_disable.go
@@ -81,6 +81,14 @@ func toggleConfigAPIKeyExcludedAll(cfg *config.Config, auth *coreauth.Auth, disa
 			return true, nil
 		}
 	}
+	for i := range cfg.QwenKey {
+		entry := &cfg.QwenKey[i]
+		id, _ := idGen.Next("qwen:apikey", entry.APIKey, entry.BaseURL)
+		if id == authID {
+			entry.ExcludedModels = setConfigAPIKeyExcludedAll(entry.ExcludedModels, disable)
+			return true, nil
+		}
+	}
 	for i := range cfg.VertexCompatAPIKey {
 		entry := &cfg.VertexCompatAPIKey[i]
 		id, _ := idGen.Next("vertex:apikey", entry.APIKey, entry.BaseURL, entry.ProxyURL)

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -28,6 +28,11 @@ type xaiKeyWithAuthIndex struct {
 	AuthIndex string `json:"auth-index,omitempty"`
 }
 
+type qwenKeyWithAuthIndex struct {
+	config.QwenKey
+	AuthIndex string `json:"auth-index,omitempty"`
+}
+
 type vertexCompatKeyWithAuthIndex struct {
 	config.VertexCompatKey
 	AuthIndex string `json:"auth-index,omitempty"`
@@ -222,6 +227,35 @@ func (h *Handler) xaiKeysWithAuthIndex() []xaiKeyWithAuthIndex {
 		}
 		out[i] = xaiKeyWithAuthIndex{
 			XAIKey:    entry,
+			AuthIndex: authIndex,
+		}
+	}
+	return out
+}
+
+func (h *Handler) qwenKeysWithAuthIndex() []qwenKeyWithAuthIndex {
+	if h == nil {
+		return nil
+	}
+	liveIndexByID := h.liveAuthIndexByID()
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.cfg == nil {
+		return nil
+	}
+
+	idGen := synthesizer.NewStableIDGenerator()
+	out := make([]qwenKeyWithAuthIndex, len(h.cfg.QwenKey))
+	for i := range h.cfg.QwenKey {
+		entry := h.cfg.QwenKey[i]
+		authIndex := ""
+		if key := strings.TrimSpace(entry.APIKey); key != "" {
+			id, _ := idGen.Next("qwen:apikey", key, entry.BaseURL)
+			authIndex = liveIndexByID[id]
+		}
+		out[i] = qwenKeyWithAuthIndex{
+			QwenKey:   entry,
 			AuthIndex: authIndex,
 		}
 	}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -1544,6 +1544,185 @@ func (h *Handler) DeleteXAIKey(c *gin.Context) {
 	c.JSON(400, gin.H{"error": "missing api-key or index"})
 }
 
+// qwen-api-key: []QwenKey
+func (h *Handler) GetQwenKeys(c *gin.Context) {
+	c.JSON(200, gin.H{"qwen-api-key": h.qwenKeysWithAuthIndex()})
+}
+
+func (h *Handler) PutQwenKeys(c *gin.Context) {
+	data, errRead := c.GetRawData()
+	if errRead != nil {
+		c.JSON(400, gin.H{"error": "failed to read body"})
+		return
+	}
+	var arr []config.QwenKey
+	if errUnmarshal := json.Unmarshal(data, &arr); errUnmarshal != nil {
+		var obj struct {
+			Items []config.QwenKey `json:"items"`
+		}
+		if errObject := json.Unmarshal(data, &obj); errObject != nil || len(obj.Items) == 0 {
+			c.JSON(400, gin.H{"error": "invalid body"})
+			return
+		}
+		arr = obj.Items
+	}
+	filtered := make([]config.QwenKey, 0, len(arr))
+	for i := range arr {
+		entry := arr[i]
+		normalizeCodexKey(&entry)
+		if strings.TrimSpace(entry.APIKey) == "" {
+			continue
+		}
+		if rejectInvalidCredentialWeight(c, fmt.Sprintf("qwen-api-key[%d].weight", i), entry.Weight) {
+			return
+		}
+		filtered = append(filtered, entry)
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.cfg.QwenKey = filtered
+	h.cfg.SanitizeQwenKeys()
+	h.persistLocked(c)
+}
+
+func (h *Handler) PatchQwenKey(c *gin.Context) {
+	type qwenKeyPatch struct {
+		APIKey         *string             `json:"api-key"`
+		Priority       *int                `json:"priority"`
+		Weight         json.RawMessage     `json:"weight"`
+		Prefix         *string             `json:"prefix"`
+		BaseURL        *string             `json:"base-url"`
+		ProxyURL       *string             `json:"proxy-url"`
+		Models         *[]config.QwenModel `json:"models"`
+		Headers        *map[string]string  `json:"headers"`
+		ExcludedModels *[]string           `json:"excluded-models"`
+		DisableCooling *bool               `json:"disable-cooling"`
+	}
+	var body struct {
+		Index *int          `json:"index"`
+		Match *string       `json:"match"`
+		Value *qwenKeyPatch `json:"value"`
+	}
+	if errBind := c.ShouldBindJSON(&body); errBind != nil || body.Value == nil {
+		c.JSON(400, gin.H{"error": "invalid body"})
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	targetIndex := -1
+	if body.Index != nil && *body.Index >= 0 && *body.Index < len(h.cfg.QwenKey) {
+		targetIndex = *body.Index
+	}
+	if targetIndex == -1 && body.Match != nil {
+		match := strings.TrimSpace(*body.Match)
+		for i := range h.cfg.QwenKey {
+			if h.cfg.QwenKey[i].APIKey == match {
+				targetIndex = i
+				break
+			}
+		}
+	}
+	if targetIndex == -1 {
+		c.JSON(404, gin.H{"error": "item not found"})
+		return
+	}
+
+	entry := h.cfg.QwenKey[targetIndex]
+	if body.Value.APIKey != nil {
+		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
+	}
+	if body.Value.Priority != nil {
+		entry.Priority = *body.Value.Priority
+	}
+	if len(body.Value.Weight) > 0 {
+		weight, errWeight := parseCredentialWeightPatch(body.Value.Weight)
+		if errWeight != nil {
+			c.JSON(400, gin.H{"error": errWeight.Error()})
+			return
+		}
+		entry.Weight = weight
+	}
+	if body.Value.Prefix != nil {
+		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
+	}
+	if body.Value.BaseURL != nil {
+		entry.BaseURL = strings.TrimSpace(*body.Value.BaseURL)
+	}
+	if body.Value.ProxyURL != nil {
+		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
+	}
+	if body.Value.Models != nil {
+		entry.Models = append([]config.QwenModel(nil), (*body.Value.Models)...)
+	}
+	if body.Value.Headers != nil {
+		entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
+	}
+	if body.Value.ExcludedModels != nil {
+		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
+	}
+	if body.Value.DisableCooling != nil {
+		entry.DisableCooling = *body.Value.DisableCooling
+	}
+	normalizeCodexKey(&entry)
+	h.cfg.QwenKey[targetIndex] = entry
+	h.cfg.SanitizeQwenKeys()
+	h.persistLocked(c)
+}
+
+func (h *Handler) DeleteQwenKey(c *gin.Context) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if val := strings.TrimSpace(c.Query("api-key")); val != "" {
+		if baseRaw, okBase := c.GetQuery("base-url"); okBase {
+			base := strings.TrimSpace(baseRaw)
+			out := make([]config.QwenKey, 0, len(h.cfg.QwenKey))
+			for _, entry := range h.cfg.QwenKey {
+				if strings.TrimSpace(entry.APIKey) == val && strings.TrimSpace(entry.BaseURL) == base {
+					continue
+				}
+				out = append(out, entry)
+			}
+			h.cfg.QwenKey = out
+			h.cfg.SanitizeQwenKeys()
+			h.persistLocked(c)
+			return
+		}
+
+		matchIndex := -1
+		matchCount := 0
+		for i := range h.cfg.QwenKey {
+			if strings.TrimSpace(h.cfg.QwenKey[i].APIKey) == val {
+				matchCount++
+				if matchIndex == -1 {
+					matchIndex = i
+				}
+			}
+		}
+		if matchCount > 1 {
+			c.JSON(400, gin.H{"error": "multiple items match api-key; base-url is required"})
+			return
+		}
+		if matchIndex != -1 {
+			h.cfg.QwenKey = append(h.cfg.QwenKey[:matchIndex], h.cfg.QwenKey[matchIndex+1:]...)
+		}
+		h.cfg.SanitizeQwenKeys()
+		h.persistLocked(c)
+		return
+	}
+	if idxStr := c.Query("index"); idxStr != "" {
+		var idx int
+		_, errScan := fmt.Sscanf(idxStr, "%d", &idx)
+		if errScan == nil && idx >= 0 && idx < len(h.cfg.QwenKey) {
+			h.cfg.QwenKey = append(h.cfg.QwenKey[:idx], h.cfg.QwenKey[idx+1:]...)
+			h.cfg.SanitizeQwenKeys()
+			h.persistLocked(c)
+			return
+		}
+	}
+	c.JSON(400, gin.H{"error": "missing api-key or index"})
+}
+
 func normalizeOpenAICompatibilityEntry(entry *config.OpenAICompatibility) {
 	if entry == nil {
 		return

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -135,6 +135,11 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PATCH("/xai-api-key", s.mgmt.PatchXAIKey)
 		mgmt.DELETE("/xai-api-key", s.mgmt.DeleteXAIKey)
 
+		mgmt.GET("/qwen-api-key", s.mgmt.GetQwenKeys)
+		mgmt.PUT("/qwen-api-key", s.mgmt.PutQwenKeys)
+		mgmt.PATCH("/qwen-api-key", s.mgmt.PatchQwenKey)
+		mgmt.DELETE("/qwen-api-key", s.mgmt.DeleteQwenKey)
+
 		mgmt.GET("/openai-compatibility", s.mgmt.GetOpenAICompat)
 		mgmt.PUT("/openai-compatibility", s.mgmt.PutOpenAICompat)
 		mgmt.PATCH("/openai-compatibility", s.mgmt.PatchOpenAICompat)

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -174,7 +174,7 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/codex-auth-url", s.mgmt.RequestCodexToken)
 		mgmt.GET("/antigravity-auth-url", s.mgmt.RequestAntigravityToken)
 		mgmt.GET("/kimi-auth-url", s.mgmt.RequestKimiToken)
-		mgmt.GET("/qwen-auth-url", s.mgmt.RequestQwenToken)
+		mgmt.GET("/qianwen-auth-url", s.mgmt.RequestQwenToken)
 		mgmt.GET("/xai-auth-url", s.mgmt.RequestXAIToken)
 		mgmt.GET("/get-auth-status", s.mgmt.GetAuthStatus)
 		mgmt.DELETE("/oauth-session", s.mgmt.CancelAuthSession)

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -174,6 +174,7 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/codex-auth-url", s.mgmt.RequestCodexToken)
 		mgmt.GET("/antigravity-auth-url", s.mgmt.RequestAntigravityToken)
 		mgmt.GET("/kimi-auth-url", s.mgmt.RequestKimiToken)
+		mgmt.GET("/qwen-auth-url", s.mgmt.RequestQwenToken)
 		mgmt.GET("/xai-auth-url", s.mgmt.RequestXAIToken)
 		mgmt.GET("/get-auth-status", s.mgmt.GetAuthStatus)
 		mgmt.DELETE("/oauth-session", s.mgmt.CancelAuthSession)

--- a/internal/auth/qwen/qwen.go
+++ b/internal/auth/qwen/qwen.go
@@ -1,0 +1,336 @@
+package qwen
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// qwenOAuthHost is the Qianwen OAuth server endpoint.
+	qwenOAuthHost = "https://t.qianwenai.com"
+	// qwenDeviceCodeURL is the endpoint for requesting device codes.
+	qwenDeviceCodeURL = qwenOAuthHost + "/cli/device/code"
+	// qwenDeviceTokenURL is the endpoint for polling device authorization.
+	qwenDeviceTokenURL = qwenOAuthHost + "/cli/device/token"
+
+	defaultPollInterval      = 5 * time.Second
+	maxPollDuration          = 15 * time.Minute
+	refreshThresholdSeconds  = 300
+	deviceCodeRequestTimeout = 30 * time.Second
+	// qwenUserAgent mimics the official CLI so the auth server accepts requests.
+	qwenUserAgent = "qianwen-cli/1.0.0"
+)
+
+// QwenAuth handles Qianwen authentication flow.
+type QwenAuth struct {
+	deviceClient *DeviceFlowClient
+	cfg          *config.Config
+}
+
+// NewQwenAuth creates a new QwenAuth service instance.
+func NewQwenAuth(cfg *config.Config) *QwenAuth {
+	return &QwenAuth{
+		deviceClient: NewDeviceFlowClient(cfg),
+		cfg:          cfg,
+	}
+}
+
+// StartDeviceFlow initiates the device flow authentication.
+func (k *QwenAuth) StartDeviceFlow(ctx context.Context) (*DeviceCodeResponse, error) {
+	return k.deviceClient.RequestDeviceCode(ctx)
+}
+
+// WaitForAuthorization polls for user authorization and returns the auth bundle.
+func (k *QwenAuth) WaitForAuthorization(ctx context.Context, deviceCode *DeviceCodeResponse) (*QwenAuthBundle, error) {
+	tokenData, err := k.deviceClient.PollForToken(ctx, deviceCode)
+	if err != nil {
+		return nil, err
+	}
+	return &QwenAuthBundle{
+		TokenData: tokenData,
+		DeviceID:  k.deviceClient.deviceID,
+	}, nil
+}
+
+// CreateTokenStorage creates a new QwenTokenStorage from an auth bundle.
+func (k *QwenAuth) CreateTokenStorage(bundle *QwenAuthBundle) *QwenTokenStorage {
+	storage := &QwenTokenStorage{
+		AccessToken:  bundle.TokenData.AccessToken,
+		RefreshToken: bundle.TokenData.RefreshToken,
+		TokenType:    "Bearer",
+		DeviceID:     strings.TrimSpace(bundle.DeviceID),
+		Email:        bundle.TokenData.Email,
+		AliyunID:     bundle.TokenData.AliyunID,
+		Expired:      bundle.TokenData.ExpiresAt,
+		Type:         "qianwen",
+	}
+	return storage
+}
+
+// DeviceFlowClient handles the OAuth2 device flow for Qianwen.
+type DeviceFlowClient struct {
+	httpClient *http.Client
+	cfg        *config.Config
+	deviceID   string
+}
+
+// NewDeviceFlowClient creates a new device flow client.
+func NewDeviceFlowClient(cfg *config.Config) *DeviceFlowClient {
+	client := &http.Client{Timeout: deviceCodeRequestTimeout}
+	if cfg != nil {
+		client = util.SetProxy(&cfg.SDKConfig, client)
+	}
+	return &DeviceFlowClient{
+		httpClient: client,
+		cfg:        cfg,
+		deviceID:   getOrCreateDeviceID(),
+	}
+}
+
+// getOrCreateDeviceID returns an in-memory device ID for the authentication flow.
+func getOrCreateDeviceID() string {
+	return uuid.New().String()
+}
+
+// deviceCodeEnvelope is the success envelope returned by the device code endpoint.
+type deviceCodeEnvelope struct {
+	Success bool `json:"Success"`
+	Data    struct {
+		Token           string `json:"Token"`
+		VerificationUrl string `json:"VerificationUrl"`
+		ExpiresIn       int    `json:"ExpiresIn"`
+		Interval        int    `json:"Interval"`
+	} `json:"Data"`
+}
+
+// deviceTokenEnvelope is the success envelope returned by the device token endpoint.
+type deviceTokenEnvelope struct {
+	Success bool `json:"Success"`
+	Data    struct {
+		Status      string `json:"Status"`
+		Credentials struct {
+			AccessToken  string `json:"AccessToken"`
+			RefreshToken string `json:"RefreshToken"`
+			ExpireTime   string `json:"ExpireTime"`
+			User         struct {
+				Email        string `json:"Email"`
+				AliyunId     string `json:"AliyunId"`
+				Organization string `json:"Organization"`
+			} `json:"User"`
+		} `json:"Credentials"`
+	} `json:"Data"`
+}
+
+// RequestDeviceCode initiates the device flow by requesting a device code.
+// Qianwen requires PKCE, so a code verifier/challenge pair is generated and the
+// verifier is retained on the returned response for use during polling.
+func (c *DeviceFlowClient) RequestDeviceCode(ctx context.Context) (*DeviceCodeResponse, error) {
+	verifier, challenge, errGen := generatePKCE()
+	if errGen != nil {
+		return nil, fmt.Errorf("qwen: failed to generate PKCE pair: %w", errGen)
+	}
+	reqURL := fmt.Sprintf("%s?client_id=%s&code_challenge=%s&code_challenge_method=S256",
+		qwenDeviceCodeURL, url.QueryEscape(c.deviceID), url.QueryEscape(challenge))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("qwen: failed to create device code request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", qwenUserAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("qwen: device code request failed: %w", err)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("qwen device code: close body error: %v", errClose)
+		}
+	}()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("qwen: failed to read device code response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("qwen: device code request failed with status %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var envelope deviceCodeEnvelope
+	if err = json.Unmarshal(bodyBytes, &envelope); err != nil {
+		return nil, fmt.Errorf("qwen: failed to parse device code response: %w", err)
+	}
+	if !envelope.Success || envelope.Data.Token == "" || envelope.Data.VerificationUrl == "" {
+		return nil, fmt.Errorf("qwen: device code response missing token or verification url")
+	}
+
+	return &DeviceCodeResponse{
+		Token:           envelope.Data.Token,
+		VerificationURL: envelope.Data.VerificationUrl,
+		ExpiresIn:       envelope.Data.ExpiresIn,
+		Interval:        envelope.Data.Interval,
+		CodeVerifier:    verifier,
+	}, nil
+}
+
+// generatePKCE produces a code verifier and its S256 code challenge.
+func generatePKCE() (verifier, challenge string, err error) {
+	buf := make([]byte, 32)
+	if _, err = rand.Read(buf); err != nil {
+		return "", "", err
+	}
+	verifier = base64.RawURLEncoding.EncodeToString(buf)
+	sum := sha256.Sum256([]byte(verifier))
+	challenge = base64.RawURLEncoding.EncodeToString(sum[:])
+	return verifier, challenge, nil
+}
+
+// PollForToken polls the token endpoint until the user authorizes or the device code expires.
+func (c *DeviceFlowClient) PollForToken(ctx context.Context, deviceCode *DeviceCodeResponse) (*QwenTokenData, error) {
+	if deviceCode == nil {
+		return nil, fmt.Errorf("qwen: device code is nil")
+	}
+
+	interval := time.Duration(deviceCode.Interval) * time.Second
+	if interval < defaultPollInterval {
+		interval = defaultPollInterval
+	}
+
+	deadline := time.Now().Add(maxPollDuration)
+	if deviceCode.ExpiresIn > 0 {
+		codeDeadline := time.Now().Add(time.Duration(deviceCode.ExpiresIn) * time.Second)
+		if codeDeadline.Before(deadline) {
+			deadline = codeDeadline
+		}
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("qwen: context cancelled: %w", ctx.Err())
+		case <-ticker.C:
+			if time.Now().After(deadline) {
+				return nil, fmt.Errorf("qwen: device code expired")
+			}
+			token, pollErr, shouldContinue := c.pollDeviceToken(ctx, deviceCode.Token, deviceCode.CodeVerifier)
+			if token != nil {
+				return token, nil
+			}
+			if !shouldContinue {
+				return nil, pollErr
+			}
+		}
+	}
+}
+
+// pollDeviceToken attempts a single poll of the device token endpoint.
+// Returns (token, error, shouldContinue).
+func (c *DeviceFlowClient) pollDeviceToken(ctx context.Context, deviceToken, codeVerifier string) (*QwenTokenData, error, bool) {
+	reqURL := fmt.Sprintf("%s?client_id=%s&token=%s",
+		qwenDeviceTokenURL, url.QueryEscape(c.deviceID), url.QueryEscape(deviceToken))
+	if strings.TrimSpace(codeVerifier) != "" {
+		reqURL += "&code_verifier=" + url.QueryEscape(codeVerifier)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("qwen: failed to create token request: %w", err), false
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", qwenUserAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("qwen: token request failed: %w", err), false
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("qwen device token: close body error: %v", errClose)
+		}
+	}()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("qwen: failed to read token response: %w", err), false
+	}
+
+	var envelope deviceTokenEnvelope
+	if err = json.Unmarshal(bodyBytes, &envelope); err != nil {
+		return nil, fmt.Errorf("qwen: failed to parse token response: %w", err), false
+	}
+
+	status := strings.ToLower(strings.TrimSpace(envelope.Data.Status))
+	switch status {
+	case "complete":
+		creds := envelope.Data.Credentials
+		if creds.AccessToken == "" {
+			return nil, fmt.Errorf("qwen: empty access token in response"), false
+		}
+		aliyunID := creds.User.AliyunId
+		if aliyunID == "" {
+			aliyunID = creds.User.Organization
+		}
+		return &QwenTokenData{
+			AccessToken:  creds.AccessToken,
+			RefreshToken: creds.RefreshToken,
+			ExpiresAt:    normalizeExpireTime(creds.ExpireTime),
+			Email:        creds.User.Email,
+			AliyunID:     aliyunID,
+		}, nil, false
+	case "expired_token":
+		return nil, fmt.Errorf("qwen: device code expired"), false
+	case "access_denied":
+		return nil, fmt.Errorf("qwen: access denied by user"), false
+	case "authorization_pending", "slow_down", "":
+		return nil, nil, true // Continue polling
+	default:
+		return nil, nil, true // Unknown status, keep polling
+	}
+}
+
+// normalizeExpireTime converts Qianwen's ExpireTime to RFC3339 when possible.
+func normalizeExpireTime(expireTime string) string {
+	trimmed := strings.TrimSpace(expireTime)
+	if trimmed == "" {
+		return ""
+	}
+	if _, err := time.Parse(time.RFC3339, trimmed); err == nil {
+		return trimmed
+	}
+	// Qianwen may return a numeric unix timestamp (seconds or milliseconds).
+	if unix, errParse := parseUnixTimestamp(trimmed); errParse == nil {
+		return unix.UTC().Format(time.RFC3339)
+	}
+	return trimmed
+}
+
+func parseUnixTimestamp(value string) (time.Time, error) {
+	var n int64
+	if _, err := fmt.Sscanf(value, "%d", &n); err != nil {
+		return time.Time{}, err
+	}
+	if n <= 0 {
+		return time.Time{}, fmt.Errorf("non-positive timestamp")
+	}
+	// Heuristic: values above 1e12 are milliseconds.
+	if n > 1_000_000_000_000 {
+		return time.UnixMilli(n), nil
+	}
+	return time.Unix(n, 0), nil
+}

--- a/internal/auth/qwen/token.go
+++ b/internal/auth/qwen/token.go
@@ -1,0 +1,133 @@
+// Package qwen provides authentication and token management for the Qianwen
+// platform (Alibaba Cloud Bailian) usage/billing API. It implements the OAuth2
+// device authorization grant flow used by `qianwen login` to obtain an access
+// token that can query account usage and quota.
+//
+// NOTE: This OAuth credential is used ONLY for usage/quota queries against the
+// Qianwen gateway (cli.qianwenai.com). Model inference uses separate DashScope
+// API keys (sk-sp-...) configured via qwen-api-key and is handled elsewhere.
+package qwen
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
+)
+
+// QwenTokenStorage stores OAuth2 token information for Qianwen API authentication.
+type QwenTokenStorage struct {
+	// AccessToken is the OAuth2 access token used for authenticating API requests.
+	AccessToken string `json:"access_token"`
+	// RefreshToken is the OAuth2 refresh token (may be empty; Qianwen has no
+	// public refresh endpoint, expiry is handled by re-login).
+	RefreshToken string `json:"refresh_token,omitempty"`
+	// TokenType is the type of token, typically "Bearer".
+	TokenType string `json:"token_type"`
+	// DeviceID is the persistent device identifier (client_id) used during the flow.
+	DeviceID string `json:"device_id,omitempty"`
+	// Email is the authorized account email, when provided.
+	Email string `json:"email,omitempty"`
+	// AliyunID is the authorized Aliyun account identifier, when provided.
+	AliyunID string `json:"aliyun_id,omitempty"`
+	// Expired is the RFC3339 timestamp when the access token expires.
+	Expired string `json:"expired,omitempty"`
+	// Type indicates the authentication provider type, always "qianwen" for this storage.
+	Type string `json:"type"`
+
+	// Metadata holds arbitrary key-value pairs injected via hooks.
+	// It is not exported to JSON directly to allow flattening during serialization.
+	Metadata map[string]any `json:"-"`
+}
+
+// SetMetadata allows external callers to inject metadata into the storage before saving.
+func (ts *QwenTokenStorage) SetMetadata(meta map[string]any) {
+	ts.Metadata = meta
+}
+
+// QwenTokenData holds the raw OAuth token response from Qianwen.
+type QwenTokenData struct {
+	// AccessToken is the OAuth2 access token.
+	AccessToken string `json:"access_token"`
+	// RefreshToken is the OAuth2 refresh token.
+	RefreshToken string `json:"refresh_token"`
+	// ExpiresAt is the RFC3339 timestamp when the token expires.
+	ExpiresAt string `json:"expires_at"`
+	// Email is the authorized account email.
+	Email string `json:"email"`
+	// AliyunID is the authorized Aliyun account identifier.
+	AliyunID string `json:"aliyun_id"`
+}
+
+// QwenAuthBundle bundles authentication data for storage.
+type QwenAuthBundle struct {
+	// TokenData contains the OAuth token information.
+	TokenData *QwenTokenData
+	// DeviceID is the device identifier used during OAuth device flow.
+	DeviceID string
+}
+
+// DeviceCodeResponse represents Qianwen's device code response.
+type DeviceCodeResponse struct {
+	// Token is the device flow polling token.
+	Token string `json:"token"`
+	// VerificationURL is the URL where the user authorizes the device.
+	VerificationURL string `json:"verification_url"`
+	// ExpiresIn is the number of seconds until the device code expires.
+	ExpiresIn int `json:"expires_in"`
+	// Interval is the minimum number of seconds to wait between polling requests.
+	Interval int `json:"interval"`
+	// CodeVerifier is the PKCE verifier preserved from init and sent when polling.
+	CodeVerifier string `json:"-"`
+}
+
+// SaveTokenToFile serializes the Qwen token storage to a JSON file.
+func (ts *QwenTokenStorage) SaveTokenToFile(authFilePath string) error {
+	misc.LogSavingCredentials(authFilePath)
+	ts.Type = "qianwen"
+
+	if err := os.MkdirAll(filepath.Dir(authFilePath), 0700); err != nil {
+		return fmt.Errorf("failed to create directory: %v", err)
+	}
+
+	f, err := os.Create(authFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to create token file: %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	data, errMerge := misc.MergeMetadata(ts, ts.Metadata)
+	if errMerge != nil {
+		return fmt.Errorf("failed to merge metadata: %w", errMerge)
+	}
+
+	encoder := json.NewEncoder(f)
+	encoder.SetIndent("", "  ")
+	if err = encoder.Encode(data); err != nil {
+		return fmt.Errorf("failed to write token to file: %w", err)
+	}
+	return nil
+}
+
+// IsExpired checks if the token has expired.
+func (ts *QwenTokenStorage) IsExpired() bool {
+	if ts.Expired == "" {
+		return false // No expiry set, assume valid
+	}
+	t, err := time.Parse(time.RFC3339, ts.Expired)
+	if err != nil {
+		return true // Has expiry string but can't parse
+	}
+	return time.Now().Add(time.Duration(refreshThresholdSeconds) * time.Second).After(t)
+}
+
+// NeedsRefresh checks if the token should be refreshed. Qianwen has no public
+// refresh endpoint, so this reports false; expired tokens require re-login.
+func (ts *QwenTokenStorage) NeedsRefresh() bool {
+	return false
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,6 +112,9 @@ type Config struct {
 	// XAIKey defines xAI API key configurations using the same structure as Codex API keys.
 	XAIKey []XAIKey `yaml:"xai-api-key" json:"xai-api-key"`
 
+	// QwenKey defines Qwen/DashScope API key configurations using the same structure as Codex API keys.
+	QwenKey []QwenKey `yaml:"qwen-api-key" json:"qwen-api-key"`
+
 	// XAI configures provider-wide xAI request behavior.
 	XAI XAIConfig `yaml:"xai" json:"xai"`
 

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -162,6 +162,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	// Sanitize xAI keys: drop entries without base-url
 	cfg.SanitizeXAIKeys()
 
+	// Sanitize Qwen keys: drop entries with empty API keys
+	cfg.SanitizeQwenKeys()
+
 	// Sanitize Codex header defaults.
 	cfg.SanitizeCodexHeaderDefaults()
 

--- a/internal/config/config_normalization.go
+++ b/internal/config/config_normalization.go
@@ -141,6 +141,15 @@ func (cfg *Config) SanitizeXAIKeys() {
 	cfg.XAIKey = sanitizeCodexKeyEntries(cfg.XAIKey)
 }
 
+// SanitizeQwenKeys removes Qwen API key entries with empty API keys.
+// It applies the same normalization rules as codex-api-key.
+func (cfg *Config) SanitizeQwenKeys() {
+	if cfg == nil {
+		return
+	}
+	cfg.QwenKey = sanitizeCodexKeyEntries(cfg.QwenKey)
+}
+
 func sanitizeCodexKeyEntries(entries []CodexKey) []CodexKey {
 	if len(entries) == 0 {
 		return entries

--- a/internal/config/config_normalization.go
+++ b/internal/config/config_normalization.go
@@ -142,12 +142,12 @@ func (cfg *Config) SanitizeXAIKeys() {
 }
 
 // SanitizeQwenKeys removes Qwen API key entries with empty API keys.
-// It applies the same normalization rules as codex-api-key.
+// Unlike Codex/xAI, Qwen has a default base URL so base-url is optional.
 func (cfg *Config) SanitizeQwenKeys() {
 	if cfg == nil {
 		return
 	}
-	cfg.QwenKey = sanitizeCodexKeyEntries(cfg.QwenKey)
+	cfg.QwenKey = sanitizeQwenKeyEntries(cfg.QwenKey)
 }
 
 func sanitizeCodexKeyEntries(entries []CodexKey) []CodexKey {
@@ -162,6 +162,27 @@ func sanitizeCodexKeyEntries(entries []CodexKey) []CodexKey {
 		e.Headers = NormalizeHeaders(e.Headers)
 		e.ExcludedModels = NormalizeExcludedModels(e.ExcludedModels)
 		if e.BaseURL == "" {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// sanitizeQwenKeyEntries normalizes Qwen key entries, filtering on API key
+// instead of base URL since Qwen has a built-in default endpoint.
+func sanitizeQwenKeyEntries(entries []QwenKey) []QwenKey {
+	if len(entries) == 0 {
+		return entries
+	}
+	out := make([]QwenKey, 0, len(entries))
+	for i := range entries {
+		e := entries[i]
+		e.Prefix = normalizeModelPrefix(e.Prefix)
+		e.BaseURL = strings.TrimSpace(e.BaseURL)
+		e.Headers = NormalizeHeaders(e.Headers)
+		e.ExcludedModels = NormalizeExcludedModels(e.ExcludedModels)
+		if strings.TrimSpace(e.APIKey) == "" {
 			continue
 		}
 		out = append(out, e)

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -455,6 +455,12 @@ type XAIKey = CodexKey
 // XAIModel uses the Codex model mapping structure for xAI models.
 type XAIModel = CodexModel
 
+// QwenKey uses the Codex API key structure for native Qwen/DashScope execution.
+type QwenKey = CodexKey
+
+// QwenModel uses the Codex model mapping structure for Qwen models.
+type QwenModel = CodexModel
+
 // GeminiKey represents the configuration for a Gemini API key,
 // including optional overrides for upstream base URL, proxy routing, and headers.
 type GeminiKey struct {

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -99,6 +99,7 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	cfg.SanitizeVertexCompatKeys()
 	cfg.SanitizeCodexKeys()
 	cfg.SanitizeXAIKeys()
+	cfg.SanitizeQwenKeys()
 	cfg.SanitizeCodexHeaderDefaults()
 	cfg.SanitizeClaudeHeaderDefaults()
 	cfg.SanitizeClaudeKeys()

--- a/internal/config/weight.go
+++ b/internal/config/weight.go
@@ -31,6 +31,7 @@ func validateCredentialWeightYAML(data []byte) error {
 	families := map[string]struct{}{
 		"gemini-api-key": {}, "interactions-api-key": {}, "claude-api-key": {},
 		"vertex-api-key": {}, "codex-api-key": {}, "xai-api-key": {},
+		"qwen-api-key": {},
 	}
 	for index := 0; root != nil && root.Kind == yaml.MappingNode && index+1 < len(root.Content); index += 2 {
 		name := root.Content[index].Value
@@ -139,6 +140,11 @@ func (cfg *Config) ValidateCredentialWeights() error {
 	for index := range cfg.XAIKey {
 		if errValidate := ValidateCredentialWeight(cfg.XAIKey[index].Weight); errValidate != nil {
 			return fmt.Errorf("xai-api-key[%d].weight: %w", index, errValidate)
+		}
+	}
+	for index := range cfg.QwenKey {
+		if errValidate := ValidateCredentialWeight(cfg.QwenKey[index].Weight); errValidate != nil {
+			return fmt.Errorf("qwen-api-key[%d].weight: %w", index, errValidate)
 		}
 	}
 	for providerIndex := range cfg.OpenAICompatibility {

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -326,6 +326,7 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 		data.Kimi,
 		data.Antigravity,
 		data.XAI,
+		data.Qwen,
 	}
 	for _, models := range allModels {
 		for _, m := range models {

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -28,6 +28,7 @@ type staticModelsJSON struct {
 	Kimi        []*ModelInfo `json:"kimi"`
 	Antigravity []*ModelInfo `json:"antigravity"`
 	XAI         []*ModelInfo `json:"xai"`
+	Qwen        []*ModelInfo `json:"qwen"`
 }
 
 // GetClaudeModels returns the standard Claude model definitions.
@@ -108,6 +109,11 @@ func AntigravityWebSearchModelFor(modelID string) string {
 // GetXAIModels returns the standard xAI Grok model definitions.
 func GetXAIModels() []*ModelInfo {
 	return WithXAIBuiltins(cloneModelInfos(getModels().XAI))
+}
+
+// GetQwenModels returns the standard Qwen/DashScope model definitions.
+func GetQwenModels() []*ModelInfo {
+	return cloneModelInfos(getModels().Qwen)
 }
 
 // WithCodexBuiltins injects hard-coded Codex-only model definitions that should
@@ -296,6 +302,8 @@ func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 		return GetAntigravityModels()
 	case "xai", "x-ai", "grok":
 		return GetXAIModels()
+	case "qwen", "dashscope", "bailian", "tongyi":
+		return GetQwenModels()
 	default:
 		return nil
 	}

--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -215,6 +215,7 @@ func detectChangedProviders(oldData, newData *staticModelsJSON) []string {
 		{"kimi", oldData.Kimi, newData.Kimi},
 		{"antigravity", oldData.Antigravity, newData.Antigravity},
 		{"xai", oldData.XAI, newData.XAI},
+		{"qwen", oldData.Qwen, newData.Qwen},
 	}
 
 	seen := make(map[string]bool, len(sections))
@@ -335,6 +336,7 @@ func validateModelsCatalog(data *staticModelsJSON) error {
 		{name: "kimi", models: data.Kimi},
 		{name: "antigravity", models: data.Antigravity},
 		{name: "xai", models: data.XAI},
+		{name: "qwen", models: data.Qwen},
 	}
 
 	for _, section := range requiredSections {

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2833,6 +2833,25 @@
   ],
   "qwen": [
     {
+      "id": "qwen3.8-max-preview",
+      "object": "model",
+      "created": 1753000000,
+      "owned_by": "alibaba",
+      "type": "qwen",
+      "display_name": "Qwen3.8 Max Preview",
+      "description": "Qwen3.8 flagship preview with enhanced agentic and reasoning capabilities",
+      "context_length": 131072,
+      "max_completion_tokens": 32768,
+      "thinking": {
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
       "id": "qwen3.7-max",
       "object": "model",
       "created": 1752000000,
@@ -2842,6 +2861,63 @@
       "description": "Qwen3.7 flagship model for agentic coding and complex reasoning",
       "context_length": 131072,
       "max_completion_tokens": 32768,
+      "thinking": {
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "qwen3.7-plus",
+      "object": "model",
+      "created": 1752000000,
+      "owned_by": "alibaba",
+      "type": "qwen",
+      "display_name": "Qwen3.7 Plus",
+      "description": "Qwen3.7 balanced performance-cost model",
+      "context_length": 131072,
+      "max_completion_tokens": 32768,
+      "thinking": {
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "qwen3.6-plus",
+      "object": "model",
+      "created": 1750000000,
+      "owned_by": "alibaba",
+      "type": "qwen",
+      "display_name": "Qwen3.6 Plus",
+      "description": "Qwen3.6 balanced model with hybrid thinking support",
+      "context_length": 131072,
+      "max_completion_tokens": 32768,
+      "thinking": {
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "qwen3.6-flash",
+      "object": "model",
+      "created": 1750000000,
+      "owned_by": "alibaba",
+      "type": "qwen",
+      "display_name": "Qwen3.6 Flash",
+      "description": "Qwen3.6 fast and cost-effective model",
+      "context_length": 131072,
+      "max_completion_tokens": 16384,
       "thinking": {
         "zero_allowed": true,
         "levels": [

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2830,5 +2830,113 @@
       "context_length": 200000,
       "max_completion_tokens": 32768
     }
+  ],
+  "qwen": [
+    {
+      "id": "qwen3.7-max",
+      "object": "model",
+      "created": 1752000000,
+      "owned_by": "alibaba",
+      "type": "qwen",
+      "display_name": "Qwen3.7 Max",
+      "description": "Qwen3.7 flagship model for agentic coding and complex reasoning",
+      "context_length": 131072,
+      "max_completion_tokens": 32768,
+      "thinking": {
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "qwen3-max",
+      "object": "model",
+      "created": 1750000000,
+      "owned_by": "alibaba",
+      "type": "qwen",
+      "display_name": "Qwen3 Max",
+      "description": "Qwen3 flagship model with hybrid thinking support",
+      "context_length": 131072,
+      "max_completion_tokens": 32768,
+      "thinking": {
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "qwen3-coder-plus",
+      "object": "model",
+      "created": 1750000000,
+      "owned_by": "alibaba",
+      "type": "qwen",
+      "display_name": "Qwen3 Coder Plus",
+      "description": "Qwen3 coding-optimized model",
+      "context_length": 131072,
+      "max_completion_tokens": 32768,
+      "thinking": {
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "qwen3-coder-next",
+      "object": "model",
+      "created": 1752000000,
+      "owned_by": "alibaba",
+      "type": "qwen",
+      "display_name": "Qwen3 Coder Next",
+      "description": "Qwen3 next-generation coding model",
+      "context_length": 131072,
+      "max_completion_tokens": 32768,
+      "thinking": {
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "qwen-plus",
+      "object": "model",
+      "created": 1750000000,
+      "owned_by": "alibaba",
+      "type": "qwen",
+      "display_name": "Qwen Plus",
+      "description": "Qwen balanced performance-cost model",
+      "context_length": 131072,
+      "max_completion_tokens": 16384,
+      "thinking": {
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "qwen-turbo",
+      "object": "model",
+      "created": 1750000000,
+      "owned_by": "alibaba",
+      "type": "qwen",
+      "display_name": "Qwen Turbo",
+      "description": "Qwen fast and cost-effective model",
+      "context_length": 131072,
+      "max_completion_tokens": 16384
+    }
   ]
 }

--- a/internal/runtime/executor/helps/thinking_providers.go
+++ b/internal/runtime/executor/helps/thinking_providers.go
@@ -8,5 +8,6 @@ import (
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/interactions"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/kimi"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/openai"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/qwen"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/xai"
 )

--- a/internal/runtime/executor/qwen_executor.go
+++ b/internal/runtime/executor/qwen_executor.go
@@ -1,0 +1,424 @@
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const (
+	// qwenDefaultBaseURL is the default DashScope OpenAI-compatible endpoint.
+	qwenDefaultBaseURL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+)
+
+// QwenExecutor is a stateless executor for Qwen/DashScope API using
+// OpenAI-compatible chat completions with Qwen-specific sanitization.
+type QwenExecutor struct {
+	cfg *config.Config
+}
+
+// NewQwenExecutor creates a new Qwen executor.
+func NewQwenExecutor(cfg *config.Config) *QwenExecutor {
+	return &QwenExecutor{cfg: cfg}
+}
+
+// Identifier returns the executor identifier.
+func (e *QwenExecutor) Identifier() string { return "qwen" }
+
+// PrepareRequest injects Qwen credentials into the outgoing HTTP request.
+func (e *QwenExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth) error {
+	if req == nil {
+		return nil
+	}
+	_, apiKey := e.resolveCredentials(auth)
+	if strings.TrimSpace(apiKey) != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(req, attrs)
+	return nil
+}
+
+// HttpRequest injects Qwen credentials into the request and executes it.
+func (e *QwenExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, fmt.Errorf("qwen executor: request is nil")
+	}
+	if ctx == nil {
+		ctx = req.Context()
+	}
+	httpReq := req.WithContext(ctx)
+	if err := e.PrepareRequest(httpReq, auth); err != nil {
+		return nil, err
+	}
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	return httpClient.Do(httpReq)
+}
+
+// Execute performs a non-streaming chat completion request to Qwen/DashScope.
+func (e *QwenExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+
+	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
+	defer reporter.TrackFailure(ctx, &err)
+
+	baseURL, apiKey := e.resolveCredentials(auth)
+	if baseURL == "" {
+		baseURL = qwenDefaultBaseURL
+	}
+	if apiKey == "" {
+		err = statusErr{code: http.StatusUnauthorized, msg: "qwen executor: missing API key"}
+		return
+	}
+
+	from := opts.SourceFormat
+	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
+	to := sdktranslator.FromString("openai")
+	originalPayloadSource := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		originalPayloadSource = opts.OriginalRequest
+	}
+	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayloadSource, false)
+	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false)
+
+	body, err = thinking.ApplyThinking(body, req.Model, from.String(), "qwen", e.Identifier())
+	if err != nil {
+		return resp, err
+	}
+
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	requestPath := helps.PayloadRequestPath(opts)
+	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
+	body = sanitizeQwenPayload(body)
+	reporter.SetTranslatedReasoningEffort(body, e.Identifier())
+
+	url := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	httpReq.Header.Set("User-Agent", "cli-proxy-qwen")
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(httpReq, attrs)
+	var authID, authLabel, authType, authValue string
+	if auth != nil {
+		authID = auth.ID
+		authLabel = auth.Label
+		authType, authValue = auth.AccountInfo()
+	}
+	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+		URL:       url,
+		Method:    http.MethodPost,
+		Headers:   httpReq.Header.Clone(),
+		Body:      body,
+		Provider:  e.Identifier(),
+		AuthID:    authID,
+		AuthLabel: authLabel,
+		AuthType:  authType,
+		AuthValue: authValue,
+	})
+
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient = reporter.TrackHTTPClient(httpClient)
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("qwen executor: close response body error: %v", errClose)
+		}
+	}()
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b, _ := io.ReadAll(httpResp.Body)
+		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return resp, err
+	}
+	data, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
+	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
+	reporter.Publish(ctx, helps.ParseOpenAIUsage(data))
+	reporter.EnsurePublished(ctx)
+	var param any
+	out := sdktranslator.TranslateNonStream(ctx, to, responseFormat, req.Model, opts.OriginalRequest, body, data, &param)
+	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
+	return resp, nil
+}
+
+// ExecuteStream performs a streaming chat completion request to Qwen/DashScope.
+func (e *QwenExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+
+	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
+	defer reporter.TrackFailure(ctx, &err)
+
+	baseURL, apiKey := e.resolveCredentials(auth)
+	if baseURL == "" {
+		baseURL = qwenDefaultBaseURL
+	}
+	if apiKey == "" {
+		err = statusErr{code: http.StatusUnauthorized, msg: "qwen executor: missing API key"}
+		return nil, err
+	}
+
+	from := opts.SourceFormat
+	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
+	to := sdktranslator.FromString("openai")
+	originalPayloadSource := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		originalPayloadSource = opts.OriginalRequest
+	}
+	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayloadSource, true)
+	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, true)
+
+	body, err = thinking.ApplyThinking(body, req.Model, from.String(), "qwen", e.Identifier())
+	if err != nil {
+		return nil, err
+	}
+
+	body = helps.SetBoolIfDifferent(body, "stream_options.include_usage", true)
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	requestPath := helps.PayloadRequestPath(opts)
+	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
+	body = sanitizeQwenPayload(body)
+	reporter.SetTranslatedReasoningEffort(body, e.Identifier())
+
+	url := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	httpReq.Header.Set("User-Agent", "cli-proxy-qwen")
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(httpReq, attrs)
+	httpReq.Header.Set("Accept", "text/event-stream")
+	httpReq.Header.Set("Cache-Control", "no-cache")
+	var authID, authLabel, authType, authValue string
+	if auth != nil {
+		authID = auth.ID
+		authLabel = auth.Label
+		authType, authValue = auth.AccountInfo()
+	}
+	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+		URL:       url,
+		Method:    http.MethodPost,
+		Headers:   httpReq.Header.Clone(),
+		Body:      body,
+		Provider:  e.Identifier(),
+		AuthID:    authID,
+		AuthLabel: authLabel,
+		AuthType:  authType,
+		AuthValue: authValue,
+	})
+
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient = reporter.TrackHTTPClient(httpClient)
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return nil, err
+	}
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b, _ := io.ReadAll(httpResp.Body)
+		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("qwen executor: close response body error: %v", errClose)
+		}
+		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return nil, err
+	}
+	out := make(chan cliproxyexecutor.StreamChunk)
+	go func() {
+		defer close(out)
+		defer func() {
+			if errClose := httpResp.Body.Close(); errClose != nil {
+				log.Errorf("qwen executor: close response body error: %v", errClose)
+			}
+		}()
+		scanner := bufio.NewScanner(httpResp.Body)
+		scanner.Buffer(nil, 52_428_800) // 50MB
+		claudeInputTokens := helps.NewClaudeInputTokenState(from, to, responseFormat, originalPayloadSource)
+		var param any
+		var streamUsage helps.StreamUsageBuffer
+		defer streamUsage.Publish(ctx, reporter)
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
+			streamUsage.ObserveOpenAIStream(line)
+			trimmedLine := bytes.TrimSpace(line)
+			if len(trimmedLine) == 0 {
+				continue
+			}
+			if !bytes.HasPrefix(trimmedLine, []byte("data:")) {
+				if bytes.HasPrefix(trimmedLine, []byte(":")) || bytes.HasPrefix(trimmedLine, []byte("event:")) ||
+					bytes.HasPrefix(trimmedLine, []byte("id:")) || bytes.HasPrefix(trimmedLine, []byte("retry:")) {
+					continue
+				}
+				if bytes.HasPrefix(trimmedLine, []byte("{")) || bytes.HasPrefix(trimmedLine, []byte("[")) {
+					streamErr := statusErr{code: http.StatusBadGateway, msg: string(trimmedLine)}
+					helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
+					reporter.PublishFailure(ctx, streamErr)
+					select {
+					case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
+					case <-ctx.Done():
+					}
+					return
+				}
+				continue
+			}
+			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, body, bytes.Clone(trimmedLine), &param, claudeInputTokens)
+			for i := range chunks {
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+		if errScan := scanner.Err(); errScan != nil {
+			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
+			reporter.PublishFailure(ctx, errScan)
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
+			case <-ctx.Done():
+			}
+		} else {
+			// Feed a synthetic done marker in case upstream closes without [DONE].
+			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, body, []byte("data: [DONE]"), &param, claudeInputTokens)
+			for i := range chunks {
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+		streamUsage.Publish(ctx, reporter)
+		reporter.EnsurePublished(ctx)
+	}()
+	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+// CountTokens estimates token count for a Qwen request.
+func (e *QwenExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+
+	from := opts.SourceFormat
+	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
+	to := sdktranslator.FromString("openai")
+	translated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false)
+
+	translated, err := thinking.ApplyThinking(translated, req.Model, from.String(), "qwen", e.Identifier())
+	if err != nil {
+		return cliproxyexecutor.Response{}, err
+	}
+
+	enc, err := helps.TokenizerForModel(baseModel)
+	if err != nil {
+		return cliproxyexecutor.Response{}, fmt.Errorf("qwen executor: tokenizer init failed: %w", err)
+	}
+
+	count, err := helps.CountOpenAIChatTokens(enc, translated)
+	if err != nil {
+		return cliproxyexecutor.Response{}, fmt.Errorf("qwen executor: token counting failed: %w", err)
+	}
+
+	usageJSON := helps.BuildOpenAIUsageJSON(count)
+	translatedUsage := sdktranslator.TranslateTokenCount(ctx, to, responseFormat, count, usageJSON)
+	return cliproxyexecutor.Response{Payload: translatedUsage}, nil
+}
+
+// Refresh is a no-op for API-key based Qwen providers.
+func (e *QwenExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	log.Debugf("qwen executor: refresh called")
+	if refreshed, handled, err := helps.RefreshAuthViaHome(ctx, e.cfg, auth); handled {
+		return refreshed, err
+	}
+	return auth, nil
+}
+
+func (e *QwenExecutor) resolveCredentials(auth *cliproxyauth.Auth) (baseURL, apiKey string) {
+	if auth == nil {
+		return "", ""
+	}
+	if auth.Attributes != nil {
+		baseURL = strings.TrimSpace(auth.Attributes["base_url"])
+		apiKey = strings.TrimSpace(auth.Attributes["api_key"])
+	}
+	return
+}
+
+// sanitizeQwenPayload rewrites an OpenAI-format payload for Qwen/DashScope compatibility.
+//
+// Qwen's OpenAI-compatible endpoint rejects several OpenAI-native features:
+//   - "developer" role is not supported; rewrite to "system"
+//   - "store" parameter is not supported; remove it
+//   - "background" and "webhook_config" are not supported; remove them
+func sanitizeQwenPayload(body []byte) []byte {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return body
+	}
+
+	// Rewrite developer role to system in messages array.
+	messages := gjson.GetBytes(body, "messages")
+	if messages.IsArray() {
+		arr := messages.Array()
+		for i, msg := range arr {
+			if msg.Get("role").String() == "developer" {
+				var err error
+				body, err = sjson.SetBytes(body, fmt.Sprintf("messages.%d.role", i), "system")
+				if err != nil {
+					log.Warnf("qwen executor: failed to rewrite developer role at messages.%d: %v", i, err)
+				}
+			}
+		}
+	}
+
+	// Remove unsupported OpenAI-native parameters.
+	for _, field := range []string{"store", "background", "webhook_config"} {
+		if gjson.GetBytes(body, field).Exists() {
+			if updated, errDelete := sjson.DeleteBytes(body, field); errDelete == nil {
+				body = updated
+			}
+		}
+	}
+
+	return body
+}

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -422,6 +422,8 @@ func extractThinkingConfig(body []byte, provider string) ThinkingConfig {
 		return extractCodexConfig(body)
 	case "kimi":
 		return extractKimiConfig(body)
+	case "qwen":
+		return extractQwenConfig(body)
 	default:
 		return ThinkingConfig{}
 	}
@@ -720,6 +722,23 @@ func extractKimiConfig(body []byte) ThinkingConfig {
 		return ThinkingConfig{}
 	}
 
+	return extractOpenAIConfig(body)
+}
+
+// extractQwenConfig extracts thinking configuration for Qwen/DashScope models.
+//
+// Qwen accepts both enable_thinking (native boolean) and reasoning_effort
+// (OpenAI-compatible input). Native enable_thinking takes priority.
+func extractQwenConfig(body []byte) ThinkingConfig {
+	// Native Qwen format: enable_thinking boolean
+	if v := gjson.GetBytes(body, "enable_thinking"); v.Exists() {
+		if v.Bool() {
+			return ThinkingConfig{Mode: ModeAuto, Budget: -1}
+		}
+		return ThinkingConfig{Mode: ModeNone, Budget: 0}
+	}
+
+	// OpenAI-compatible input: reasoning_effort
 	return extractOpenAIConfig(body)
 }
 

--- a/internal/thinking/provider/qwen/apply.go
+++ b/internal/thinking/provider/qwen/apply.go
@@ -1,0 +1,178 @@
+// Package qwen implements thinking configuration for Qwen/DashScope models.
+//
+// Qwen models use enable_thinking (boolean) as the primary thinking toggle.
+// Newer models (qwen3.7+) also accept reasoning_effort for intensity control,
+// but the canonical Qwen format is enable_thinking.
+// The top-level reasoning_effort field from OpenAI format is removed and
+// translated to the Qwen-native enable_thinking parameter.
+package qwen
+
+import (
+	"fmt"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// Applier implements thinking.ProviderApplier for Qwen models.
+//
+// Qwen-specific behavior:
+//   - Enabled thinking: enable_thinking=true
+//   - Disabled thinking: enable_thinking=false
+//   - Removes reasoning_effort from the final payload (not Qwen-native)
+//   - Supports budget-to-level conversion for unified pipeline
+type Applier struct{}
+
+var _ thinking.ProviderApplier = (*Applier)(nil)
+
+// NewApplier creates a new Qwen thinking applier.
+func NewApplier() *Applier {
+	return &Applier{}
+}
+
+func init() {
+	thinking.RegisterProvider("qwen", NewApplier())
+}
+
+// Apply applies thinking configuration to Qwen request body.
+//
+// Expected output format (enabled):
+//
+//	{
+//	  "enable_thinking": true
+//	}
+//
+// Expected output format (disabled):
+//
+//	{
+//	  "enable_thinking": false
+//	}
+func (a *Applier) Apply(body []byte, config thinking.ThinkingConfig, modelInfo *registry.ModelInfo) ([]byte, error) {
+	if thinking.IsUserDefinedModel(modelInfo) {
+		return applyCompatibleQwen(body, config)
+	}
+	if modelInfo.Thinking == nil {
+		// Model does not support thinking; strip any thinking params.
+		return stripThinkingParams(body)
+	}
+
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		body = []byte(`{}`)
+	}
+
+	switch config.Mode {
+	case thinking.ModeLevel:
+		if config.Level == "" {
+			return body, nil
+		}
+		if config.Level == thinking.LevelNone {
+			return applyDisabledThinking(body)
+		}
+		return applyEnabledThinking(body)
+	case thinking.ModeNone:
+		// Respect clamped fallback level for models that cannot disable thinking.
+		if config.Level != "" && config.Level != thinking.LevelNone {
+			return applyEnabledThinking(body)
+		}
+		return applyDisabledThinking(body)
+	case thinking.ModeBudget:
+		level, ok := thinking.ConvertBudgetToLevel(config.Budget)
+		if !ok {
+			return body, nil
+		}
+		if level == string(thinking.LevelNone) {
+			return applyDisabledThinking(body)
+		}
+		return applyEnabledThinking(body)
+	case thinking.ModeAuto:
+		// Auto mode: enable thinking and let the model decide intensity.
+		return applyEnabledThinking(body)
+	default:
+		return body, nil
+	}
+}
+
+// applyCompatibleQwen applies thinking config for user-defined Qwen models.
+func applyCompatibleQwen(body []byte, config thinking.ThinkingConfig) ([]byte, error) {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		body = []byte(`{}`)
+	}
+
+	switch config.Mode {
+	case thinking.ModeLevel:
+		if config.Level == "" {
+			return body, nil
+		}
+		if config.Level == thinking.LevelNone {
+			return applyDisabledThinking(body)
+		}
+		return applyEnabledThinking(body)
+	case thinking.ModeNone:
+		if config.Level == "" || config.Level == thinking.LevelNone {
+			return applyDisabledThinking(body)
+		}
+		return applyEnabledThinking(body)
+	case thinking.ModeAuto:
+		return applyEnabledThinking(body)
+	case thinking.ModeBudget:
+		level, ok := thinking.ConvertBudgetToLevel(config.Budget)
+		if !ok {
+			return body, nil
+		}
+		if level == string(thinking.LevelNone) {
+			return applyDisabledThinking(body)
+		}
+		return applyEnabledThinking(body)
+	default:
+		return body, nil
+	}
+}
+
+func applyEnabledThinking(body []byte) ([]byte, error) {
+	result, errDelete := sjson.DeleteBytes(body, "reasoning_effort")
+	if errDelete != nil {
+		return body, fmt.Errorf("qwen thinking: failed to clear reasoning_effort: %w", errDelete)
+	}
+	result, errSet := sjson.SetBytes(result, "enable_thinking", true)
+	if errSet != nil {
+		return body, fmt.Errorf("qwen thinking: failed to set enable_thinking: %w", errSet)
+	}
+	return result, nil
+}
+
+func applyDisabledThinking(body []byte) ([]byte, error) {
+	result, errDelete := sjson.DeleteBytes(body, "reasoning_effort")
+	if errDelete != nil {
+		return body, fmt.Errorf("qwen thinking: failed to clear reasoning_effort: %w", errDelete)
+	}
+	result, errSet := sjson.SetBytes(result, "enable_thinking", false)
+	if errSet != nil {
+		return body, fmt.Errorf("qwen thinking: failed to set enable_thinking: %w", errSet)
+	}
+	return result, nil
+}
+
+// stripThinkingParams removes all thinking-related parameters from the payload.
+func stripThinkingParams(body []byte) ([]byte, error) {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return body, nil
+	}
+	result := body
+	if gjson.GetBytes(result, "reasoning_effort").Exists() {
+		var err error
+		result, err = sjson.DeleteBytes(result, "reasoning_effort")
+		if err != nil {
+			return body, err
+		}
+	}
+	if gjson.GetBytes(result, "enable_thinking").Exists() {
+		var err error
+		result, err = sjson.DeleteBytes(result, "enable_thinking")
+		if err != nil {
+			return body, err
+		}
+	}
+	return result, nil
+}

--- a/internal/thinking/provider/qwen/apply.go
+++ b/internal/thinking/provider/qwen/apply.go
@@ -70,11 +70,11 @@ func (a *Applier) Apply(body []byte, config thinking.ThinkingConfig, modelInfo *
 		if config.Level == thinking.LevelNone {
 			return applyDisabledThinking(body)
 		}
-		return applyEnabledThinking(body)
+		return applyEnabledThinking(body, string(config.Level))
 	case thinking.ModeNone:
 		// Respect clamped fallback level for models that cannot disable thinking.
 		if config.Level != "" && config.Level != thinking.LevelNone {
-			return applyEnabledThinking(body)
+			return applyEnabledThinking(body, string(config.Level))
 		}
 		return applyDisabledThinking(body)
 	case thinking.ModeBudget:
@@ -85,10 +85,10 @@ func (a *Applier) Apply(body []byte, config thinking.ThinkingConfig, modelInfo *
 		if level == string(thinking.LevelNone) {
 			return applyDisabledThinking(body)
 		}
-		return applyEnabledThinking(body)
+		return applyEnabledThinking(body, level)
 	case thinking.ModeAuto:
 		// Auto mode: enable thinking and let the model decide intensity.
-		return applyEnabledThinking(body)
+		return applyEnabledThinking(body, "")
 	default:
 		return body, nil
 	}
@@ -108,14 +108,14 @@ func applyCompatibleQwen(body []byte, config thinking.ThinkingConfig) ([]byte, e
 		if config.Level == thinking.LevelNone {
 			return applyDisabledThinking(body)
 		}
-		return applyEnabledThinking(body)
+		return applyEnabledThinking(body, string(config.Level))
 	case thinking.ModeNone:
 		if config.Level == "" || config.Level == thinking.LevelNone {
 			return applyDisabledThinking(body)
 		}
-		return applyEnabledThinking(body)
+		return applyEnabledThinking(body, string(config.Level))
 	case thinking.ModeAuto:
-		return applyEnabledThinking(body)
+		return applyEnabledThinking(body, "")
 	case thinking.ModeBudget:
 		level, ok := thinking.ConvertBudgetToLevel(config.Budget)
 		if !ok {
@@ -124,22 +124,45 @@ func applyCompatibleQwen(body []byte, config thinking.ThinkingConfig) ([]byte, e
 		if level == string(thinking.LevelNone) {
 			return applyDisabledThinking(body)
 		}
-		return applyEnabledThinking(body)
+		return applyEnabledThinking(body, level)
 	default:
 		return body, nil
 	}
 }
 
-func applyEnabledThinking(body []byte) ([]byte, error) {
-	result, errDelete := sjson.DeleteBytes(body, "reasoning_effort")
-	if errDelete != nil {
-		return body, fmt.Errorf("qwen thinking: failed to clear reasoning_effort: %w", errDelete)
-	}
-	result, errSet := sjson.SetBytes(result, "enable_thinking", true)
+// applyEnabledThinking enables thinking and, when a concrete intensity level is
+// provided, also emits reasoning_effort so newer Qwen models (qwen3.7+) honor the
+// requested intensity instead of collapsing every level to a bare enable flag.
+func applyEnabledThinking(body []byte, level string) ([]byte, error) {
+	result, errSet := sjson.SetBytes(body, "enable_thinking", true)
 	if errSet != nil {
 		return body, fmt.Errorf("qwen thinking: failed to set enable_thinking: %w", errSet)
 	}
+	if isQwenIntensityLevel(level) {
+		result, errSet = sjson.SetBytes(result, "reasoning_effort", level)
+		if errSet != nil {
+			return body, fmt.Errorf("qwen thinking: failed to set reasoning_effort: %w", errSet)
+		}
+		return result, nil
+	}
+	// No concrete intensity: drop any stale reasoning_effort so the model decides.
+	if gjson.GetBytes(result, "reasoning_effort").Exists() {
+		if deleted, errDel := sjson.DeleteBytes(result, "reasoning_effort"); errDel == nil {
+			result = deleted
+		}
+	}
 	return result, nil
+}
+
+// isQwenIntensityLevel reports whether a level maps to a concrete reasoning_effort
+// value understood by newer Qwen models.
+func isQwenIntensityLevel(level string) bool {
+	switch level {
+	case string(thinking.LevelLow), string(thinking.LevelMedium), string(thinking.LevelHigh):
+		return true
+	default:
+		return false
+	}
 }
 
 func applyDisabledThinking(body []byte) ([]byte, error) {

--- a/internal/thinking/strip.go
+++ b/internal/thinking/strip.go
@@ -53,6 +53,11 @@ func StripThinkingConfig(body []byte, provider string) []byte {
 			"reasoning_effort",
 			"thinking",
 		}
+	case "qwen":
+		paths = []string{
+			"reasoning_effort",
+			"enable_thinking",
+		}
 	case "codex", "xai":
 		paths = []string{"reasoning.effort"}
 	default:

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -349,6 +349,46 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 		}
 	}
 
+	if len(oldCfg.QwenKey) != len(newCfg.QwenKey) {
+		changes = append(changes, fmt.Sprintf("qwen-api-key count: %d -> %d", len(oldCfg.QwenKey), len(newCfg.QwenKey)))
+	} else {
+		for i := range oldCfg.QwenKey {
+			o := oldCfg.QwenKey[i]
+			n := newCfg.QwenKey[i]
+			if strings.TrimSpace(o.BaseURL) != strings.TrimSpace(n.BaseURL) {
+				changes = append(changes, fmt.Sprintf("qwen[%d].base-url: %s -> %s", i, formatURL(o.BaseURL), formatURL(n.BaseURL)))
+			}
+			if strings.TrimSpace(o.ProxyURL) != strings.TrimSpace(n.ProxyURL) {
+				changes = append(changes, fmt.Sprintf("qwen[%d].proxy-url: %s -> %s", i, formatProxyURL(o.ProxyURL), formatProxyURL(n.ProxyURL)))
+			}
+			if strings.TrimSpace(o.Prefix) != strings.TrimSpace(n.Prefix) {
+				changes = append(changes, fmt.Sprintf("qwen[%d].prefix: %s -> %s", i, strings.TrimSpace(o.Prefix), strings.TrimSpace(n.Prefix)))
+			}
+			if o.Priority != n.Priority {
+				changes = append(changes, fmt.Sprintf("qwen[%d].priority: %d -> %d", i, o.Priority, n.Priority))
+			}
+			if o.DisableCooling != n.DisableCooling {
+				changes = append(changes, fmt.Sprintf("qwen[%d].disable-cooling: %t -> %t", i, o.DisableCooling, n.DisableCooling))
+			}
+			if strings.TrimSpace(o.APIKey) != strings.TrimSpace(n.APIKey) {
+				changes = append(changes, fmt.Sprintf("qwen[%d].api-key: updated", i))
+			}
+			if !equalStringMap(o.Headers, n.Headers) {
+				changes = append(changes, fmt.Sprintf("qwen[%d].headers: updated", i))
+			}
+			oldModels := SummarizeCodexModels(o.Models)
+			newModels := SummarizeCodexModels(n.Models)
+			if oldModels.hash != newModels.hash {
+				changes = append(changes, fmt.Sprintf("qwen[%d].models: updated (%d -> %d entries)", i, oldModels.count, newModels.count))
+			}
+			oldExcluded := SummarizeExcludedModels(o.ExcludedModels)
+			newExcluded := SummarizeExcludedModels(n.ExcludedModels)
+			if oldExcluded.hash != newExcluded.hash {
+				changes = append(changes, fmt.Sprintf("qwen[%d].excluded-models: updated (%d -> %d entries)", i, oldExcluded.count, newExcluded.count))
+			}
+		}
+	}
+
 	if entries, _ := DiffOAuthExcludedModelChanges(oldCfg.OAuthExcludedModels, newCfg.OAuthExcludedModels); len(entries) > 0 {
 		changes = append(changes, entries...)
 	}

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -52,6 +52,8 @@ func (s *ConfigSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth,
 	out = append(out, s.synthesizeCodexKeys(ctx)...)
 	// xAI API Keys
 	out = append(out, s.synthesizeXAIKeys(ctx)...)
+	// Qwen API Keys
+	out = append(out, s.synthesizeQwenKeys(ctx)...)
 	// OpenAI-compat
 	out = append(out, s.synthesizeOpenAICompat(ctx)...)
 	// Vertex-compat
@@ -194,6 +196,11 @@ func (s *ConfigSynthesizer) synthesizeCodexKeys(ctx *SynthesisContext) []*coreau
 // synthesizeXAIKeys creates Auth entries for xAI API keys.
 func (s *ConfigSynthesizer) synthesizeXAIKeys(ctx *SynthesisContext) []*coreauth.Auth {
 	return s.synthesizeCodexStyleKeys(ctx, ctx.Config.XAIKey, "xai")
+}
+
+// synthesizeQwenKeys creates Auth entries for Qwen/DashScope API keys.
+func (s *ConfigSynthesizer) synthesizeQwenKeys(ctx *SynthesisContext) []*coreauth.Auth {
+	return s.synthesizeCodexStyleKeys(ctx, ctx.Config.QwenKey, "qwen")
 }
 
 func (s *ConfigSynthesizer) synthesizeCodexStyleKeys(ctx *SynthesisContext, entries []config.CodexKey, provider string) []*coreauth.Auth {

--- a/sdk/cliproxy/auth/conductor_models.go
+++ b/sdk/cliproxy/auth/conductor_models.go
@@ -366,6 +366,10 @@ func (m *Manager) resolveAPIKeyModelAliasWithResult(auth *Auth, requestedModel s
 		if entry := resolveXAIAPIKeyConfig(cfg, auth); entry != nil {
 			models = asModelAliasEntries(entry.Models)
 		}
+	case "qwen":
+		if entry := resolveQwenAPIKeyConfig(cfg, auth); entry != nil {
+			models = asModelAliasEntries(entry.Models)
+		}
 	case "vertex":
 		if entry := resolveVertexAPIKeyConfig(cfg, auth); entry != nil {
 			models = asModelAliasEntries(entry.Models)
@@ -490,6 +494,10 @@ func (m *Manager) rebuildAPIKeyModelAliasLocked(cfg *internalconfig.Config) {
 			}
 		case "xai":
 			if entry := resolveXAIAPIKeyConfig(cfg, auth); entry != nil {
+				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
+			}
+		case "qwen":
+			if entry := resolveQwenAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
 			}
 		case "vertex":
@@ -619,6 +627,8 @@ func (m *Manager) applyAPIKeyModelAlias(auth *Auth, requestedModel string) strin
 		upstreamModel = resolveUpstreamModelForCodexAPIKey(cfg, auth, requestedModel)
 	case "xai":
 		upstreamModel = resolveUpstreamModelForXAIAPIKey(cfg, auth, requestedModel)
+	case "qwen":
+		upstreamModel = resolveUpstreamModelForQwenAPIKey(cfg, auth, requestedModel)
 	case "vertex":
 		upstreamModel = resolveUpstreamModelForVertexAPIKey(cfg, auth, requestedModel)
 	default:
@@ -712,6 +722,13 @@ func resolveXAIAPIKeyConfig(cfg *internalconfig.Config, auth *Auth) *internalcon
 	return resolveAPIKeyConfig(cfg.XAIKey, auth)
 }
 
+func resolveQwenAPIKeyConfig(cfg *internalconfig.Config, auth *Auth) *internalconfig.QwenKey {
+	if cfg == nil {
+		return nil
+	}
+	return resolveAPIKeyConfig(cfg.QwenKey, auth)
+}
+
 func resolveVertexAPIKeyConfig(cfg *internalconfig.Config, auth *Auth) *internalconfig.VertexCompatKey {
 	if cfg == nil {
 		return nil
@@ -753,6 +770,14 @@ func resolveUpstreamModelForCodexAPIKey(cfg *internalconfig.Config, auth *Auth, 
 
 func resolveUpstreamModelForXAIAPIKey(cfg *internalconfig.Config, auth *Auth, requestedModel string) string {
 	entry := resolveXAIAPIKeyConfig(cfg, auth)
+	if entry == nil {
+		return ""
+	}
+	return resolveModelAliasFromConfigModels(requestedModel, asModelAliasEntries(entry.Models))
+}
+
+func resolveUpstreamModelForQwenAPIKey(cfg *internalconfig.Config, auth *Auth, requestedModel string) string {
+	entry := resolveQwenAPIKeyConfig(cfg, auth)
 	if entry == nil {
 		return ""
 	}

--- a/sdk/cliproxy/qwen_models.go
+++ b/sdk/cliproxy/qwen_models.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -18,7 +17,6 @@ const (
 	// qwenDefaultModelBaseURL is the default DashScope OpenAI-compatible endpoint
 	// used for model discovery when an auth has no explicit base_url.
 	qwenDefaultModelBaseURL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
-	qwenModelsFetchTimeout  = 20 * time.Second
 )
 
 // qwenModelsResponse is the OpenAI-compatible /models listing returned by DashScope.
@@ -51,15 +49,16 @@ func (s *Service) fetchQwenModelsForAuth(ctx context.Context, auth *coreauth.Aut
 		baseURL = qwenDefaultModelBaseURL
 	}
 
-	fetchCtx, cancel := context.WithTimeout(ctx, qwenModelsFetchTimeout)
-	defer cancel()
-
-	client := &http.Client{Timeout: qwenModelsFetchTimeout}
+	// Model discovery uses the caller's context without an added timeout, matching
+	// normal upstream execution (repo policy permits timeouts only for credential
+	// acquisition). A slow /models endpoint must not silently drop to the static
+	// catalog after a fixed deadline.
+	client := &http.Client{}
 	if transport, _, errProxy := proxyutil.BuildHTTPTransport(qwenModelFetchProxyURL(s, auth)); errProxy == nil && transport != nil {
 		client.Transport = transport
 	}
 
-	req, errReq := http.NewRequestWithContext(fetchCtx, http.MethodGet, strings.TrimRight(baseURL, "/")+"/models", nil)
+	req, errReq := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+"/models", nil)
 	if errReq != nil {
 		log.Debugf("qwen model fetch: build request: %v", errReq)
 		return nil
@@ -180,13 +179,15 @@ func isQwenNonTextModel(modelID string) bool {
 }
 
 // qwenModelSupportsThinking applies a heuristic for hybrid-thinking Qwen text models.
-// Qwen3.x and newer chat models support enable_thinking; legacy/turbo models do not.
+// Qwen3.x and newer chat models support enable_thinking; legacy/turbo models do not,
+// so turbo is deliberately excluded to match the static catalog (qwen-turbo has no
+// thinking support) and avoid advertising reasoning the upstream will reject.
 func qwenModelSupportsThinking(modelID string) bool {
 	lower := strings.ToLower(modelID)
 	if strings.HasPrefix(lower, "qwen3") {
 		return true
 	}
-	thinkingFamilies := []string{"-max", "-plus", "-flash", "-coder", "-turbo"}
+	thinkingFamilies := []string{"-max", "-plus", "-flash", "-coder"}
 	for _, family := range thinkingFamilies {
 		if strings.Contains(lower, family) && strings.HasPrefix(lower, "qwen") {
 			return true

--- a/sdk/cliproxy/qwen_models.go
+++ b/sdk/cliproxy/qwen_models.go
@@ -1,0 +1,196 @@
+package cliproxy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// qwenDefaultModelBaseURL is the default DashScope OpenAI-compatible endpoint
+	// used for model discovery when an auth has no explicit base_url.
+	qwenDefaultModelBaseURL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+	qwenModelsFetchTimeout  = 20 * time.Second
+)
+
+// qwenModelsResponse is the OpenAI-compatible /models listing returned by DashScope.
+type qwenModelsResponse struct {
+	Data []struct {
+		ID      string `json:"id"`
+		Object  string `json:"object"`
+		Created int64  `json:"created"`
+		OwnedBy string `json:"owned_by"`
+	} `json:"data"`
+}
+
+// fetchQwenModelsForAuth discovers available models from a Qwen/DashScope endpoint
+// using the OpenAI-compatible GET /models API. Returns nil when the fetch fails or
+// yields no models so callers can fall back to the static catalog.
+func (s *Service) fetchQwenModelsForAuth(ctx context.Context, auth *coreauth.Auth) []*ModelInfo {
+	if auth == nil {
+		return nil
+	}
+	apiKey := ""
+	baseURL := ""
+	if auth.Attributes != nil {
+		apiKey = strings.TrimSpace(auth.Attributes["api_key"])
+		baseURL = strings.TrimSpace(auth.Attributes["base_url"])
+	}
+	if apiKey == "" {
+		return nil
+	}
+	if baseURL == "" {
+		baseURL = qwenDefaultModelBaseURL
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, qwenModelsFetchTimeout)
+	defer cancel()
+
+	client := &http.Client{Timeout: qwenModelsFetchTimeout}
+	if transport, _, errProxy := proxyutil.BuildHTTPTransport(qwenModelFetchProxyURL(s, auth)); errProxy == nil && transport != nil {
+		client.Transport = transport
+	}
+
+	req, errReq := http.NewRequestWithContext(fetchCtx, http.MethodGet, strings.TrimRight(baseURL, "/")+"/models", nil)
+	if errReq != nil {
+		log.Debugf("qwen model fetch: build request: %v", errReq)
+		return nil
+	}
+	req.Close = true
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "cli-proxy-qwen")
+
+	resp, errDo := client.Do(req)
+	if errDo != nil {
+		log.Debugf("qwen model fetch: request failed: %v", errDo)
+		return nil
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Debugf("qwen model fetch: close response body: %v", errClose)
+		}
+	}()
+	body, errRead := io.ReadAll(resp.Body)
+	if errRead != nil {
+		log.Debugf("qwen model fetch: read body: %v", errRead)
+		return nil
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		log.Debugf("qwen model fetch: unexpected status %d", resp.StatusCode)
+		return nil
+	}
+
+	return parseQwenModelsResponse(body)
+}
+
+func qwenModelFetchProxyURL(s *Service, auth *coreauth.Auth) string {
+	if auth != nil {
+		if proxyURL := strings.TrimSpace(auth.ProxyURL); proxyURL != "" {
+			return proxyURL
+		}
+	}
+	if s != nil && s.cfg != nil {
+		return strings.TrimSpace(s.cfg.ProxyURL)
+	}
+	return ""
+}
+
+// parseQwenModelsResponse converts a DashScope /models listing into ModelInfo entries.
+// Non-text models (image/audio/video generation) are skipped since the Qwen executor
+// only routes chat completions.
+func parseQwenModelsResponse(body []byte) []*ModelInfo {
+	var parsed qwenModelsResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		log.Debugf("qwen model fetch: parse response: %v", err)
+		return nil
+	}
+	if len(parsed.Data) == 0 {
+		return nil
+	}
+
+	models := make([]*ModelInfo, 0, len(parsed.Data))
+	seen := make(map[string]struct{}, len(parsed.Data))
+	for _, item := range parsed.Data {
+		id := strings.TrimSpace(item.ID)
+		if id == "" {
+			continue
+		}
+		if isQwenNonTextModel(id) {
+			continue
+		}
+		key := strings.ToLower(id)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		ownedBy := strings.TrimSpace(item.OwnedBy)
+		if ownedBy == "" || ownedBy == "system" {
+			ownedBy = "alibaba"
+		}
+		info := &ModelInfo{
+			ID:          id,
+			Object:      "model",
+			Created:     item.Created,
+			OwnedBy:     ownedBy,
+			Type:        "qwen",
+			DisplayName: id,
+		}
+		if qwenModelSupportsThinking(id) {
+			info.Thinking = &registry.ThinkingSupport{
+				ZeroAllowed: true,
+				Levels:      []string{"low", "medium", "high"},
+			}
+		}
+		models = append(models, info)
+	}
+	if len(models) == 0 {
+		return nil
+	}
+	return models
+}
+
+// isQwenNonTextModel reports whether a model ID is a non-text generation model
+// (image/video/audio) that should not be routed through chat completions.
+func isQwenNonTextModel(modelID string) bool {
+	lower := strings.ToLower(modelID)
+	nonTextPrefixes := []string{
+		"qwen-image",
+		"wan2.",
+		"wan-",
+		"qwen-audio",
+		"qwen-tts",
+		"qwen-video",
+	}
+	for _, prefix := range nonTextPrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// qwenModelSupportsThinking applies a heuristic for hybrid-thinking Qwen text models.
+// Qwen3.x and newer chat models support enable_thinking; legacy/turbo models do not.
+func qwenModelSupportsThinking(modelID string) bool {
+	lower := strings.ToLower(modelID)
+	if strings.HasPrefix(lower, "qwen3") {
+		return true
+	}
+	thinkingFamilies := []string{"-max", "-plus", "-flash", "-coder", "-turbo"}
+	for _, family := range thinkingFamilies {
+		if strings.Contains(lower, family) && strings.HasPrefix(lower, "qwen") {
+			return true
+		}
+	}
+	return false
+}

--- a/sdk/cliproxy/service_executors.go
+++ b/sdk/cliproxy/service_executors.go
@@ -190,6 +190,7 @@ func baselineExecutorAuths() []*coreauth.Auth {
 		"antigravity",
 		"kimi",
 		"xai",
+		"qwen",
 		"openai-compatibility",
 	}
 	auths := make([]*coreauth.Auth, 0, len(providers))
@@ -291,6 +292,8 @@ func (s *Service) registerExecutorForAuth(a *coreauth.Auth, forceReplace bool) {
 			}
 		}
 		s.coreManager.RegisterExecutor(executor.NewXAIAutoExecutor(cfg))
+	case "qwen":
+		s.coreManager.RegisterExecutor(executor.NewQwenExecutor(cfg))
 	default:
 		providerKey := strings.ToLower(strings.TrimSpace(a.Provider))
 		if providerKey == "" {

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -153,7 +153,10 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 		}
 		models = applyExcludedModels(models, excluded)
 	case "qwen":
-		models = registry.GetQwenModels()
+		models = s.fetchQwenModelsForAuth(ctx, a)
+		if len(models) == 0 {
+			models = registry.GetQwenModels()
+		}
 		if entry := s.resolveConfigQwenKey(a); entry != nil {
 			if len(entry.Models) > 0 {
 				models = buildQwenConfigModels(entry)

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -152,6 +152,17 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 			}
 		}
 		models = applyExcludedModels(models, excluded)
+	case "qwen":
+		models = registry.GetQwenModels()
+		if entry := s.resolveConfigQwenKey(a); entry != nil {
+			if len(entry.Models) > 0 {
+				models = buildQwenConfigModels(entry)
+			}
+			if authKind == "apikey" {
+				excluded = entry.ExcludedModels
+			}
+		}
+		models = applyExcludedModels(models, excluded)
 	default:
 		// Handle OpenAI-compatibility providers by name using config
 		if s.cfg != nil {
@@ -467,6 +478,13 @@ func (s *Service) resolveConfigXAIKey(auth *coreauth.Auth) *config.XAIKey {
 	return resolveConfigCodexStyleKey(auth, s.cfg.XAIKey)
 }
 
+func (s *Service) resolveConfigQwenKey(auth *coreauth.Auth) *config.QwenKey {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	return resolveConfigCodexStyleKey(auth, s.cfg.QwenKey)
+}
+
 func resolveConfigCodexStyleKey(auth *coreauth.Auth, entries []config.CodexKey) *config.CodexKey {
 	if auth == nil {
 		return nil
@@ -767,6 +785,13 @@ func buildXAIConfigModels(entry *config.XAIKey) []*ModelInfo {
 		return nil
 	}
 	return buildConfigModels(entry.Models, "xai", "xai")
+}
+
+func buildQwenConfigModels(entry *config.QwenKey) []*ModelInfo {
+	if entry == nil {
+		return nil
+	}
+	return buildConfigModels(entry.Models, "alibaba", "qwen")
 }
 
 func buildCodexConfigModels(entry *config.CodexKey) []*ModelInfo {

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -159,7 +159,7 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 		}
 		if entry := s.resolveConfigQwenKey(a); entry != nil {
 			if len(entry.Models) > 0 {
-				models = buildQwenConfigModels(entry)
+				models = mergeQwenConfigModels(models, entry)
 			}
 			if authKind == "apikey" {
 				excluded = entry.ExcludedModels
@@ -485,7 +485,46 @@ func (s *Service) resolveConfigQwenKey(auth *coreauth.Auth) *config.QwenKey {
 	if s == nil || s.cfg == nil {
 		return nil
 	}
-	return resolveConfigCodexStyleKey(auth, s.cfg.QwenKey)
+	return resolveConfigQwenStyleKey(auth, s.cfg.QwenKey)
+}
+
+// resolveConfigQwenStyleKey matches a Qwen config entry for an auth. Unlike the
+// generic codex-style resolver, a blank config base-url is NOT treated as a
+// wildcard when the auth carries an explicit base_url: an exact base-url match is
+// preferred, and the blank-default entry is only used for blank-base auths. This
+// keeps a key configured for both the default DashScope endpoint and a custom
+// (e.g. token-plan) endpoint from resolving to the wrong entry's models.
+func resolveConfigQwenStyleKey(auth *coreauth.Auth, entries []config.QwenKey) *config.QwenKey {
+	if auth == nil {
+		return nil
+	}
+	var attrKey, attrBase string
+	if auth.Attributes != nil {
+		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
+		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
+	}
+	var blankBaseMatch *config.QwenKey
+	for i := range entries {
+		entry := &entries[i]
+		cfgKey := strings.TrimSpace(entry.APIKey)
+		cfgBase := strings.TrimSpace(entry.BaseURL)
+		if attrKey != "" && !strings.EqualFold(cfgKey, attrKey) {
+			continue
+		}
+		if cfgBase == "" {
+			if blankBaseMatch == nil {
+				blankBaseMatch = entry
+			}
+			continue
+		}
+		if attrBase != "" && strings.EqualFold(cfgBase, attrBase) {
+			return entry
+		}
+	}
+	if attrBase == "" {
+		return blankBaseMatch
+	}
+	return nil
 }
 
 func resolveConfigCodexStyleKey(auth *coreauth.Auth, entries []config.CodexKey) *config.CodexKey {
@@ -795,6 +834,35 @@ func buildQwenConfigModels(entry *config.QwenKey) []*ModelInfo {
 		return nil
 	}
 	return buildConfigModels(entry.Models, "alibaba", "qwen")
+}
+
+// mergeQwenConfigModels appends configured alias models into the discovered /
+// built-in catalog instead of replacing it, so aliasing one model does not stop
+// the credential from advertising the remaining built-in models.
+func mergeQwenConfigModels(base []*ModelInfo, entry *config.QwenKey) []*ModelInfo {
+	configured := buildQwenConfigModels(entry)
+	if len(configured) == 0 {
+		return base
+	}
+	seen := make(map[string]struct{}, len(base)+len(configured))
+	for _, m := range base {
+		if m != nil {
+			seen[strings.ToLower(strings.TrimSpace(m.ID))] = struct{}{}
+		}
+	}
+	out := append([]*ModelInfo(nil), base...)
+	for _, m := range configured {
+		if m == nil {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(m.ID))
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, m)
+	}
+	return out
 }
 
 func buildCodexConfigModels(entry *config.CodexKey) []*ModelInfo {

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -23,6 +23,7 @@ type PayloadModelRule = internalconfig.PayloadModelRule
 type GeminiKey = internalconfig.GeminiKey
 type CodexKey = internalconfig.CodexKey
 type XAIKey = internalconfig.XAIKey
+type QwenKey = internalconfig.QwenKey
 type XAIModel = internalconfig.XAIModel
 type ClaudeKey = internalconfig.ClaudeKey
 type VertexCompatKey = internalconfig.VertexCompatKey


### PR DESCRIPTION
## Summary

Add a native **Qwen/DashScope (Alibaba Cloud Bailian)** provider with two separate credential paths:
- **`qwen` provider** — DashScope API keys (`sk-...` / `sk-sp-...`) for model **inference**
- **`qianwen` OAuth provider** — device-flow login for querying account **Token Plan usage/quota**

## Inference (`qwen-api-key`)

- `OpenAICompatExecutor`-style `QwenExecutor` with Qwen-specific sanitization:
  - Rewrites `developer` role → `system` (DashScope rejects `developer`)
  - Strips unsupported params: `store`, `background`, `webhook_config`
- Qwen thinking applier using `enable_thinking` (Qwen-native) instead of `reasoning_effort`
- **Dynamic model discovery** from DashScope `GET /models` (no static catalog dependency); filters non-text models (image/audio/video)
- Config: `qwen-api-key` section (multi-key round-robin, weight, priority, prefix, proxy)
- Management CRUD: `GET/PUT/PATCH/DELETE /qwen-api-key`

## Usage/Quota OAuth (`qianwen`)

- OAuth2 **device flow with PKCE** (required by the Qianwen auth server; plain device flow returns 400)
  - Init `POST t.qianwenai.com/cli/device/code`, poll `/cli/device/token`
- `RequestQwenToken` handler + `GET /qianwen-auth-url` route; saves a `qianwen-{ts}.json` auth file
- No upstream refresh endpoint; expired tokens require re-login

## Verified live

- Inference: chat completion + thinking enable/disable + developer-role sanitization
- Dynamic models: 15 text models auto-registered
- OAuth: device flow returns valid verification URL; Token Plan **team edition** credits queried via BSS gateway (`DescribeFrInstances`)

## Note on personal edition

The personal Token Plan (5h/7d rate-limit quota) is **not exposed** via the OAuth/CLI gateway — confirmed against the open-source `qianwen-cli` (`usage summary` only returns the team edition). Personal-edition details are viewable only in the Bailian console.