### PR TITLE
feat(routing): session-affinity max-requests with per-model/provider rules

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -212,6 +212,21 @@ routing:
   session-affinity: false # default: false
   # How long session-to-auth bindings are retained. Default: 1h
   session-affinity-ttl: "1h"
+  # Max sticky requests per session→auth binding before rebind (global default).
+  # Only applies when session-affinity is true.
+  # <=0 (omit, 0, or -1): unlimited. Rebind also happens when TTL expires (whichever first).
+  #
+  # NOTE: rebind calls the same routing.strategy selector again. With fill-first,
+  # that still returns the first available credential, so max-requests rarely
+  # rotates accounts unless the current one is unavailable (cooldown/quota/disabled).
+  # Prefer round-robin or weighted-round-robin when using max-requests for rotation.
+  session-affinity-max-requests: -1
+  # Optional per-model / per-provider overrides. More specific wins:
+  # provider+model > model-only > provider-only > global default.
+  # session-affinity-rules:
+  #   - model: "grok-4.5"
+  #     provider: "xai"       # optional
+  #     max-requests: 20
 
 # Codex provider behavior.
 codex:

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -216,6 +216,29 @@ type RoutingConfig struct {
 	// SessionAffinityTTL specifies how long session-to-auth bindings are retained.
 	// Default: 1h. Accepts duration strings like "30m", "1h", "2h30m".
 	SessionAffinityTTL string `yaml:"session-affinity-ttl,omitempty" json:"session-affinity-ttl,omitempty"`
+
+	// SessionAffinityMaxRequests caps sticky picks per session→auth binding (global default).
+	// Values <= 0 mean unlimited (-1 recommended). Model/provider overrides live in SessionAffinityRules.
+	// Only effective when SessionAffinity is true. With strategy fill-first, rebind still picks the
+	// first available auth, so max-requests rarely rotates credentials unless the current one is unavailable.
+	SessionAffinityMaxRequests int `yaml:"session-affinity-max-requests,omitempty" json:"session-affinity-max-requests,omitempty"`
+
+	// SessionAffinityRules optionally override max-requests (and later affinity knobs) per model/provider.
+	// More specific matches win: provider+model > model-only > provider-only > global default.
+	SessionAffinityRules []SessionAffinityRule `yaml:"session-affinity-rules,omitempty" json:"session-affinity-rules,omitempty"`
+}
+
+// SessionAffinityRule overrides session-affinity limits for matching traffic.
+// At least one of Provider or Model should be set; empty rules are ignored.
+type SessionAffinityRule struct {
+	// Provider matches the execution provider (case-insensitive), e.g. "xai".
+	Provider string `yaml:"provider,omitempty" json:"provider,omitempty"`
+
+	// Model matches the client-visible model name after thinking-suffix stripping (case-insensitive).
+	Model string `yaml:"model,omitempty" json:"model,omitempty"`
+
+	// MaxRequests caps sticky picks for matching traffic. Values <= 0 mean unlimited.
+	MaxRequests int `yaml:"max-requests,omitempty" json:"max-requests,omitempty"`
 }
 
 // OAuthModelAlias defines a model ID alias for a specific channel.

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -531,14 +531,18 @@ func availabilityBlock(unavailable, quotaExceeded bool, nextRetryAfter, nextReco
 // It extracts session ID from multiple sources and maintains session-to-auth
 // mappings with automatic failover when the bound auth becomes unavailable.
 type SessionAffinitySelector struct {
-	fallback Selector
-	cache    *SessionCache
+	fallback    Selector
+	cache       *SessionCache
+	maxRequests int
+	rules       []SessionAffinityRuleLimit
 }
 
 // SessionAffinityConfig configures the session affinity selector.
 type SessionAffinityConfig struct {
-	Fallback Selector
-	TTL      time.Duration
+	Fallback    Selector
+	TTL         time.Duration
+	MaxRequests int // <=0 unlimited; overridden by Rules when matched
+	Rules       []SessionAffinityRuleLimit
 }
 
 // NewSessionAffinitySelector creates a new session-aware selector.
@@ -558,8 +562,10 @@ func NewSessionAffinitySelectorWithConfig(cfg SessionAffinityConfig) *SessionAff
 		cfg.TTL = time.Hour
 	}
 	return &SessionAffinitySelector{
-		fallback: cfg.Fallback,
-		cache:    NewSessionCache(cfg.TTL),
+		fallback:    cfg.Fallback,
+		cache:       NewSessionCache(cfg.TTL),
+		maxRequests: normalizeSessionAffinityMaxRequests(cfg.MaxRequests),
+		rules:       CompileSessionAffinityRules(cfg.Rules),
 	}
 }
 
@@ -588,6 +594,7 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		return nil, err
 	}
 
+	maxRequests := resolveSessionAffinityMaxRequests(s.maxRequests, s.rules, provider, model)
 	cacheKey := provider + "::" + primaryID + "::" + model
 	fallbackKey := ""
 	if fallbackID != "" && fallbackID != primaryID {
@@ -600,31 +607,45 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		}
 		s.cache.Set(cacheKey, authID)
 	}
-
-	if cachedAuthID, ok := s.cache.GetAndRefresh(cacheKey); ok {
-		for _, auth := range available {
-			if auth.ID == cachedAuthID {
-				bind(auth.ID)
-				entry.Infof("session-affinity: cache hit | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
-				return auth, nil
-			}
+	rebind := func(reason string) (*Auth, error) {
+		s.cache.InvalidateAliasGroup(cacheKey)
+		if fallbackKey != "" {
+			s.cache.InvalidateAliasGroup(fallbackKey)
 		}
-		// Cached auth not available, reselect via fallback selector for even distribution
-		auth, err := s.fallback.Pick(ctx, provider, model, opts, auths)
-		if err != nil {
-			return nil, err
+		auth, errPick := s.fallback.Pick(ctx, provider, model, opts, auths)
+		if errPick != nil {
+			return nil, errPick
 		}
 		bind(auth.ID)
-		entry.Infof("session-affinity: cache hit but auth unavailable, reselected | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
+		entry.Infof("session-affinity: %s | session=%s auth=%s provider=%s model=%s", reason, truncateSessionID(primaryID), auth.ID, provider, model)
 		return auth, nil
 	}
 
+	if cachedAuthID, hits, ok := s.cache.GetAndRefreshWithHits(cacheKey); ok {
+		if sessionAffinityMaxRequestsExceeded(maxRequests, hits) {
+			return rebind(fmt.Sprintf("max-requests reached (hits=%d max=%d), rebinding", hits, maxRequests))
+		}
+		for _, auth := range available {
+			if auth.ID == cachedAuthID {
+				if fallbackKey != "" {
+					bind(auth.ID)
+				}
+				entry.Infof("session-affinity: cache hit | session=%s auth=%s provider=%s model=%s hits=%d", truncateSessionID(primaryID), auth.ID, provider, model, hits)
+				return auth, nil
+			}
+		}
+		return rebind("cache hit but auth unavailable, reselected")
+	}
+
 	if fallbackKey != "" {
-		if cachedAuthID, ok := s.cache.Get(fallbackKey); ok {
+		if cachedAuthID, hits, ok := s.cache.GetAndRefreshWithHits(fallbackKey); ok {
+			if sessionAffinityMaxRequestsExceeded(maxRequests, hits) {
+				return rebind(fmt.Sprintf("max-requests reached via fallback (hits=%d max=%d), rebinding", hits, maxRequests))
+			}
 			for _, auth := range available {
 				if auth.ID == cachedAuthID {
 					bind(auth.ID)
-					entry.Infof("session-affinity: fallback cache hit | session=%s fallback=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model)
+					entry.Infof("session-affinity: fallback cache hit | session=%s fallback=%s auth=%s provider=%s model=%s hits=%d", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model, hits)
 					return auth, nil
 				}
 			}

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -594,7 +594,6 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		return nil, err
 	}
 
-	maxRequests := resolveSessionAffinityMaxRequests(s.maxRequests, s.rules, provider, model)
 	cacheKey := provider + "::" + primaryID + "::" + model
 	fallbackKey := ""
 	if fallbackID != "" && fallbackID != primaryID {
@@ -620,13 +619,17 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		entry.Infof("session-affinity: %s | session=%s auth=%s provider=%s model=%s", reason, truncateSessionID(primaryID), auth.ID, provider, model)
 		return auth, nil
 	}
+	maxRequestsFor := func(auth *Auth) int {
+		return s.resolveMaxRequests(provider, model, auth)
+	}
 
 	if cachedAuthID, hits, ok := s.cache.GetAndRefreshWithHits(cacheKey); ok {
-		if sessionAffinityMaxRequestsExceeded(maxRequests, hits) {
-			return rebind(fmt.Sprintf("max-requests reached (hits=%d max=%d), rebinding", hits, maxRequests))
-		}
 		for _, auth := range available {
 			if auth.ID == cachedAuthID {
+				maxRequests := maxRequestsFor(auth)
+				if sessionAffinityMaxRequestsExceeded(maxRequests, hits) {
+					return rebind(fmt.Sprintf("max-requests reached (hits=%d max=%d), rebinding", hits, maxRequests))
+				}
 				if fallbackKey != "" {
 					bind(auth.ID)
 				}
@@ -639,11 +642,12 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 
 	if fallbackKey != "" {
 		if cachedAuthID, hits, ok := s.cache.GetAndRefreshWithHits(fallbackKey); ok {
-			if sessionAffinityMaxRequestsExceeded(maxRequests, hits) {
-				return rebind(fmt.Sprintf("max-requests reached via fallback (hits=%d max=%d), rebinding", hits, maxRequests))
-			}
 			for _, auth := range available {
 				if auth.ID == cachedAuthID {
+					maxRequests := maxRequestsFor(auth)
+					if sessionAffinityMaxRequestsExceeded(maxRequests, hits) {
+						return rebind(fmt.Sprintf("max-requests reached via fallback (hits=%d max=%d), rebinding", hits, maxRequests))
+					}
 					bind(auth.ID)
 					entry.Infof("session-affinity: fallback cache hit | session=%s fallback=%s auth=%s provider=%s model=%s hits=%d", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model, hits)
 					return auth, nil
@@ -659,6 +663,19 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	bind(auth.ID)
 	entry.Infof("session-affinity: cache miss, new binding | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
 	return auth, nil
+}
+
+// resolveMaxRequests picks the effective max-requests for this pick.
+// When the routing key is "mixed", rules are matched against the bound auth's
+// execution provider (e.g. "xai") so provider-specific overrides are not skipped.
+func (s *SessionAffinitySelector) resolveMaxRequests(provider, model string, auth *Auth) int {
+	ruleProvider := provider
+	if strings.EqualFold(strings.TrimSpace(provider), "mixed") && auth != nil {
+		if key := executorKeyFromAuth(auth); key != "" {
+			ruleProvider = key
+		}
+	}
+	return resolveSessionAffinityMaxRequests(s.maxRequests, s.rules, ruleProvider, model)
 }
 
 func selectorLogEntry(ctx context.Context) *log.Entry {

--- a/sdk/cliproxy/auth/session_affinity_max_requests_test.go
+++ b/sdk/cliproxy/auth/session_affinity_max_requests_test.go
@@ -1,0 +1,178 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestSessionAffinitySelector_MaxRequestsRebinds(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback:    &RoundRobinSelector{},
+		TTL:         time.Minute,
+		MaxRequests: 2,
+	})
+	defer selector.Stop()
+
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"metadata":{"user_id":"user_xxx_account__session_max-req-0001-0000-0000-0000-000000000001"}}`),
+	}
+
+	first, err := selector.Pick(context.Background(), "xai", "grok-4.5", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick #1 error = %v", err)
+	}
+	second, err := selector.Pick(context.Background(), "xai", "grok-4.5", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick #2 error = %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("Pick #2 auth = %q, want sticky %q", second.ID, first.ID)
+	}
+
+	third, err := selector.Pick(context.Background(), "xai", "grok-4.5", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick #3 error = %v", err)
+	}
+	if third.ID == first.ID {
+		t.Fatalf("Pick #3 should rebind after max-requests=2, still got %q", third.ID)
+	}
+}
+
+// Fill-first rebind still returns the first available credential, so max-requests
+// does not rotate accounts while that credential remains available. This is
+// intentional fill-first semantics, not a max-requests bug.
+func TestSessionAffinitySelector_MaxRequestsFillFirstDoesNotRotateWhileFirstAvailable(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback:    &FillFirstSelector{},
+		TTL:         time.Minute,
+		MaxRequests: 2,
+	})
+	defer selector.Stop()
+
+	// IDs sort so fill-first always prefers auth-a while both are available.
+	auths := []*Auth{{ID: "auth-b"}, {ID: "auth-a"}}
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"metadata":{"user_id":"user_xxx_account__session_max-req-fill-0000-0000-0000-000000000010"}}`),
+	}
+
+	first, err := selector.Pick(context.Background(), "xai", "grok-4.5", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick #1 error = %v", err)
+	}
+	if first.ID != "auth-a" {
+		t.Fatalf("Pick #1 auth = %q, want auth-a (fill-first first available)", first.ID)
+	}
+
+	for i := 0; i < 5; i++ {
+		got, errPick := selector.Pick(context.Background(), "xai", "grok-4.5", opts, auths)
+		if errPick != nil {
+			t.Fatalf("Pick #%d error = %v", i+2, errPick)
+		}
+		if got.ID != first.ID {
+			t.Fatalf("Pick #%d auth = %q, want sticky fill-first %q (max-requests rebind must not rotate while first is available)", i+2, got.ID, first.ID)
+		}
+	}
+}
+
+func TestSessionAffinitySelector_MaxRequestsUnlimitedDefault(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback:    &RoundRobinSelector{},
+		TTL:         time.Minute,
+		MaxRequests: -1,
+	})
+	defer selector.Stop()
+
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"metadata":{"user_id":"user_xxx_account__session_max-req-unlim-0000-0000-0000-000000000002"}}`),
+	}
+
+	first, err := selector.Pick(context.Background(), "xai", "grok-4.5", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick #1 error = %v", err)
+	}
+	for i := 0; i < 20; i++ {
+		got, errPick := selector.Pick(context.Background(), "xai", "grok-4.5", opts, auths)
+		if errPick != nil {
+			t.Fatalf("Pick #%d error = %v", i+2, errPick)
+		}
+		if got.ID != first.ID {
+			t.Fatalf("Pick #%d auth = %q, want sticky %q with unlimited max-requests", i+2, got.ID, first.ID)
+		}
+	}
+}
+
+func TestSessionAffinitySelector_ModelRuleOverridesGlobal(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback:    &RoundRobinSelector{},
+		TTL:         time.Minute,
+		MaxRequests: -1,
+		Rules: []SessionAffinityRuleLimit{
+			{Provider: "xai", Model: "grok-4.5", MaxRequests: 1},
+		},
+	})
+	defer selector.Stop()
+
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	grokOpts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"metadata":{"user_id":"user_xxx_account__session_rule-grok-0000-0000-0000-000000000003"}}`),
+	}
+	otherOpts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"metadata":{"user_id":"user_xxx_account__session_rule-other-0000-0000-0000-000000000004"}}`),
+	}
+
+	firstGrok, err := selector.Pick(context.Background(), "xai", "grok-4.5", grokOpts, auths)
+	if err != nil {
+		t.Fatalf("grok Pick #1 error = %v", err)
+	}
+	secondGrok, err := selector.Pick(context.Background(), "xai", "grok-4.5", grokOpts, auths)
+	if err != nil {
+		t.Fatalf("grok Pick #2 error = %v", err)
+	}
+	if secondGrok.ID == firstGrok.ID {
+		t.Fatalf("grok should rebind after max-requests=1 rule, still got %q", secondGrok.ID)
+	}
+
+	firstOther, err := selector.Pick(context.Background(), "claude", "claude-3", otherOpts, auths)
+	if err != nil {
+		t.Fatalf("other Pick #1 error = %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		got, errPick := selector.Pick(context.Background(), "claude", "claude-3", otherOpts, auths)
+		if errPick != nil {
+			t.Fatalf("other Pick #%d error = %v", i+2, errPick)
+		}
+		if got.ID != firstOther.ID {
+			t.Fatalf("other model should stay sticky under global unlimited, got %q want %q", got.ID, firstOther.ID)
+		}
+	}
+}
+
+func TestSessionCache_GetAndRefreshWithHitsIncrements(t *testing.T) {
+	t.Parallel()
+
+	cache := NewSessionCache(time.Minute)
+	defer cache.Stop()
+	cache.Set("s1", "auth-a")
+
+	_, hits, ok := cache.GetAndRefreshWithHits("s1")
+	if !ok || hits != 2 {
+		t.Fatalf("after Set(hits=1) first refresh hits = %d ok=%v, want 2 true", hits, ok)
+	}
+	_, hits, ok = cache.GetAndRefreshWithHits("s1")
+	if !ok || hits != 3 {
+		t.Fatalf("second refresh hits = %d ok=%v, want 3 true", hits, ok)
+	}
+}

--- a/sdk/cliproxy/auth/session_affinity_max_requests_test.go
+++ b/sdk/cliproxy/auth/session_affinity_max_requests_test.go
@@ -160,6 +160,76 @@ func TestSessionAffinitySelector_ModelRuleOverridesGlobal(t *testing.T) {
 	}
 }
 
+func TestSessionAffinitySelector_MixedRouteHonorsProviderRule(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback:    &RoundRobinSelector{},
+		TTL:         time.Minute,
+		MaxRequests: -1,
+		Rules: []SessionAffinityRuleLimit{
+			{Provider: "xai", MaxRequests: 1},
+		},
+	})
+	defer selector.Stop()
+
+	auths := []*Auth{
+		{ID: "auth-a", Provider: "xai"},
+		{ID: "auth-b", Provider: "xai"},
+	}
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"metadata":{"user_id":"user_xxx_account__session_mixed-xai-0000-0000-0000-000000000005"}}`),
+	}
+
+	first, err := selector.Pick(context.Background(), "mixed", "grok-4.5", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick #1 error = %v", err)
+	}
+	second, err := selector.Pick(context.Background(), "mixed", "grok-4.5", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick #2 error = %v", err)
+	}
+	if second.ID == first.ID {
+		t.Fatalf("mixed route should honor provider:xai max-requests=1 and rebind, still got %q", second.ID)
+	}
+}
+
+func TestSessionAffinitySelector_MixedRouteIgnoresOtherProviderRule(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback:    &RoundRobinSelector{},
+		TTL:         time.Minute,
+		MaxRequests: -1,
+		Rules: []SessionAffinityRuleLimit{
+			{Provider: "claude", MaxRequests: 1},
+		},
+	})
+	defer selector.Stop()
+
+	auths := []*Auth{
+		{ID: "auth-a", Provider: "xai"},
+		{ID: "auth-b", Provider: "xai"},
+	}
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"metadata":{"user_id":"user_xxx_account__session_mixed-other-0000-0000-0000-000000000006"}}`),
+	}
+
+	first, err := selector.Pick(context.Background(), "mixed", "grok-4.5", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick #1 error = %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		got, errPick := selector.Pick(context.Background(), "mixed", "grok-4.5", opts, auths)
+		if errPick != nil {
+			t.Fatalf("Pick #%d error = %v", i+2, errPick)
+		}
+		if got.ID != first.ID {
+			t.Fatalf("mixed route bound to xai must ignore claude provider rule, got %q want sticky %q", got.ID, first.ID)
+		}
+	}
+}
+
 func TestSessionCache_GetAndRefreshWithHitsIncrements(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/cliproxy/auth/session_affinity_rules.go
+++ b/sdk/cliproxy/auth/session_affinity_rules.go
@@ -1,0 +1,92 @@
+package auth
+
+import (
+	"strings"
+)
+
+// SessionAffinityRuleLimit is a compiled max-requests override for matching traffic.
+type SessionAffinityRuleLimit struct {
+	Provider    string
+	Model       string
+	MaxRequests int
+}
+
+// normalizeSessionAffinityMaxRequests maps config values to runtime form.
+// Values <= 0 mean unlimited and are stored as -1.
+func normalizeSessionAffinityMaxRequests(maxRequests int) int {
+	if maxRequests <= 0 {
+		return -1
+	}
+	return maxRequests
+}
+
+// CompileSessionAffinityRules normalizes rules (provider/model keys, max-requests) and drops empty entries.
+func CompileSessionAffinityRules(rules []SessionAffinityRuleLimit) []SessionAffinityRuleLimit {
+	return compileSessionAffinityRules(rules)
+}
+
+// compileSessionAffinityRules normalizes rules and drops empty entries.
+func compileSessionAffinityRules(rules []SessionAffinityRuleLimit) []SessionAffinityRuleLimit {
+	if len(rules) == 0 {
+		return nil
+	}
+	out := make([]SessionAffinityRuleLimit, 0, len(rules))
+	for _, rule := range rules {
+		provider := strings.ToLower(strings.TrimSpace(rule.Provider))
+		model := strings.ToLower(strings.TrimSpace(canonicalModelKey(rule.Model)))
+		if provider == "" && model == "" {
+			continue
+		}
+		out = append(out, SessionAffinityRuleLimit{
+			Provider:    provider,
+			Model:       model,
+			MaxRequests: normalizeSessionAffinityMaxRequests(rule.MaxRequests),
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// resolveSessionAffinityMaxRequests picks the most specific matching rule, else the global default.
+// Specificity: provider+model > model-only > provider-only > global.
+func resolveSessionAffinityMaxRequests(global int, rules []SessionAffinityRuleLimit, provider, model string) int {
+	global = normalizeSessionAffinityMaxRequests(global)
+	if len(rules) == 0 {
+		return global
+	}
+
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	model = strings.ToLower(strings.TrimSpace(canonicalModelKey(model)))
+
+	bestScore := 0
+	best := global
+	for _, rule := range rules {
+		score := 0
+		if rule.Provider != "" {
+			if rule.Provider != provider {
+				continue
+			}
+			score += 2
+		}
+		if rule.Model != "" {
+			if rule.Model != model {
+				continue
+			}
+			score += 4
+		}
+		if score == 0 {
+			continue
+		}
+		if score > bestScore {
+			bestScore = score
+			best = rule.MaxRequests
+		}
+	}
+	return best
+}
+
+func sessionAffinityMaxRequestsExceeded(maxRequests, hits int) bool {
+	return maxRequests > 0 && hits > maxRequests
+}

--- a/sdk/cliproxy/auth/session_affinity_rules_test.go
+++ b/sdk/cliproxy/auth/session_affinity_rules_test.go
@@ -1,0 +1,72 @@
+package auth
+
+import "testing"
+
+func TestNormalizeSessionAffinityMaxRequests(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   int
+		want int
+	}{
+		{in: -1, want: -1},
+		{in: 0, want: -1},
+		{in: -99, want: -1},
+		{in: 1, want: 1},
+		{in: 20, want: 20},
+	}
+	for _, tc := range cases {
+		if got := normalizeSessionAffinityMaxRequests(tc.in); got != tc.want {
+			t.Fatalf("normalizeSessionAffinityMaxRequests(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestResolveSessionAffinityMaxRequests_Specificity(t *testing.T) {
+	t.Parallel()
+
+	rules := []SessionAffinityRuleLimit{
+		{Provider: "xai", MaxRequests: 5},
+		{Model: "grok-4.5", MaxRequests: 10},
+		{Provider: "xai", Model: "grok-4.5", MaxRequests: 20},
+		{Provider: "claude", Model: "claude-3", MaxRequests: 3},
+	}
+	compiled := compileSessionAffinityRules(rules)
+
+	cases := []struct {
+		name     string
+		provider string
+		model    string
+		global   int
+		want     int
+	}{
+		{name: "provider+model wins", provider: "xai", model: "grok-4.5", global: -1, want: 20},
+		{name: "model-only", provider: "other", model: "grok-4.5", global: -1, want: 10},
+		{name: "provider-only", provider: "xai", model: "grok-3", global: -1, want: 5},
+		{name: "global fallback", provider: "gemini", model: "gemini-2.5", global: 7, want: 7},
+		{name: "global unlimited", provider: "gemini", model: "gemini-2.5", global: -1, want: -1},
+		{name: "thinking suffix stripped", provider: "xai", model: "grok-4.5(high)", global: -1, want: 20},
+		{name: "case insensitive", provider: "XAI", model: "Grok-4.5", global: -1, want: 20},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveSessionAffinityMaxRequests(tc.global, compiled, tc.provider, tc.model)
+			if got != tc.want {
+				t.Fatalf("resolve = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSessionAffinityMaxRequestsExceeded(t *testing.T) {
+	t.Parallel()
+	if sessionAffinityMaxRequestsExceeded(-1, 100) {
+		t.Fatal("unlimited should never exceed")
+	}
+	if sessionAffinityMaxRequestsExceeded(3, 3) {
+		t.Fatal("hits==max should still allow the Nth sticky pick")
+	}
+	if !sessionAffinityMaxRequestsExceeded(3, 4) {
+		t.Fatal("hits>max should rebind")
+	}
+}

--- a/sdk/cliproxy/auth/session_cache.go
+++ b/sdk/cliproxy/auth/session_cache.go
@@ -13,6 +13,7 @@ type sessionEntry struct {
 	authID    string
 	expiresAt time.Time
 	aliases   []string
+	hits      int // sticky picks served by this binding (shared across aliases)
 }
 
 // SessionCache provides TTL-based session to auth mapping with automatic cleanup.
@@ -71,25 +72,36 @@ func (c *SessionCache) Get(sessionID string) (string, bool) {
 
 // GetAndRefresh retrieves the auth ID bound to a session and refreshes the TTL
 // for every identifier known to represent the same logical session.
+// Each successful refresh increments the binding hit counter.
 func (c *SessionCache) GetAndRefresh(sessionID string) (string, bool) {
+	authID, _, ok := c.GetAndRefreshWithHits(sessionID)
+	return authID, ok
+}
+
+// GetAndRefreshWithHits is like GetAndRefresh but also returns the hit count after increment.
+func (c *SessionCache) GetAndRefreshWithHits(sessionID string) (authID string, hits int, ok bool) {
 	if sessionID == "" {
-		return "", false
+		return "", 0, false
 	}
 	now := time.Now()
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	entry, ok := c.entries[sessionID]
-	if !ok {
-		return "", false
+	entry, found := c.entries[sessionID]
+	if !found {
+		return "", 0, false
 	}
 	if !now.Before(entry.expiresAt) {
 		c.removeAliasGroupLocked(entry)
-		return "", false
+		return "", 0, false
 	}
 
+	nextHits := entry.hits + 1
+	if nextHits <= 0 {
+		nextHits = 1
+	}
 	aliases := compactSessionAliases(mergeSessionAliases([]string{sessionID}, entry.aliases...))
-	c.replaceAliasGroupsLocked(entry.authID, now.Add(c.ttl), aliases, entry)
-	return entry.authID, true
+	c.replaceAliasGroupsLocked(entry.authID, now.Add(c.ttl), aliases, nextHits, entry)
+	return entry.authID, nextHits, true
 }
 
 // Set binds a session to an auth ID with TTL refresh. Existing aliases for the
@@ -99,6 +111,7 @@ func (c *SessionCache) Set(sessionID, authID string) {
 }
 
 // SetAliases binds multiple identifiers for one logical session to an auth ID.
+// A new auth binding starts at hits=1. Refreshing the same authID preserves hits.
 func (c *SessionCache) SetAliases(authID string, sessionIDs ...string) {
 	if authID == "" {
 		return
@@ -109,6 +122,8 @@ func (c *SessionCache) SetAliases(authID string, sessionIDs ...string) {
 
 	aliases := mergeSessionAliases(nil, sessionIDs...)
 	previousGroups := make([]sessionEntry, 0, len(sessionIDs))
+	hits := 1
+	sameAuthHits := 0
 	for _, sessionID := range sessionIDs {
 		entry, ok := c.entries[sessionID]
 		if !ok {
@@ -120,19 +135,42 @@ func (c *SessionCache) SetAliases(authID string, sessionIDs ...string) {
 		}
 		previousGroups = append(previousGroups, entry)
 		aliases = mergeSessionAliases(aliases, entry.aliases...)
+		if entry.authID == authID && entry.hits > sameAuthHits {
+			sameAuthHits = entry.hits
+		}
+	}
+	if sameAuthHits > 0 {
+		hits = sameAuthHits
 	}
 	aliases = compactSessionAliases(aliases)
 	if len(aliases) == 0 {
 		return
 	}
-	c.replaceAliasGroupsLocked(authID, now.Add(c.ttl), aliases, previousGroups...)
+	c.replaceAliasGroupsLocked(authID, now.Add(c.ttl), aliases, hits, previousGroups...)
 }
 
-func (c *SessionCache) replaceAliasGroupsLocked(authID string, expiresAt time.Time, aliases []string, previousGroups ...sessionEntry) {
+// InvalidateAliasGroup removes every alias for the logical session containing sessionID.
+func (c *SessionCache) InvalidateAliasGroup(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[sessionID]
+	if !ok {
+		return
+	}
+	c.removeAliasGroupLocked(entry)
+}
+
+func (c *SessionCache) replaceAliasGroupsLocked(authID string, expiresAt time.Time, aliases []string, hits int, previousGroups ...sessionEntry) {
 	for _, previous := range previousGroups {
 		c.removeAliasGroupLocked(previous)
 	}
-	entry := sessionEntry{authID: authID, expiresAt: expiresAt, aliases: aliases}
+	if hits <= 0 {
+		hits = 1
+	}
+	entry := sessionEntry{authID: authID, expiresAt: expiresAt, aliases: aliases, hits: hits}
 	for _, alias := range aliases {
 		c.entries[alias] = entry
 	}

--- a/sdk/cliproxy/service_config.go
+++ b/sdk/cliproxy/service_config.go
@@ -2,6 +2,7 @@ package cliproxy
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,15 +26,19 @@ type configCommit struct {
 }
 
 type routingRuntimeState struct {
-	strategy           string
-	sessionAffinity    bool
-	sessionAffinityTTL time.Duration
+	strategy                   string
+	sessionAffinity            bool
+	sessionAffinityTTL         time.Duration
+	sessionAffinityMaxRequests int
+	sessionAffinityRulesKey    string
+	sessionAffinityRules       []coreauth.SessionAffinityRuleLimit
 }
 
 func normalizedRoutingRuntimeState(cfg *config.Config) routingRuntimeState {
 	state := routingRuntimeState{
-		strategy:           "round-robin",
-		sessionAffinityTTL: time.Hour,
+		strategy:                   "round-robin",
+		sessionAffinityTTL:         time.Hour,
+		sessionAffinityMaxRequests: -1,
 	}
 	if cfg == nil {
 		return state
@@ -51,7 +56,44 @@ func normalizedRoutingRuntimeState(cfg *config.Config) routingRuntimeState {
 			state.sessionAffinityTTL = parsed
 		}
 	}
+	if cfg.Routing.SessionAffinityMaxRequests > 0 {
+		state.sessionAffinityMaxRequests = cfg.Routing.SessionAffinityMaxRequests
+	} else {
+		state.sessionAffinityMaxRequests = -1
+	}
+	if len(cfg.Routing.SessionAffinityRules) > 0 {
+		raw := make([]coreauth.SessionAffinityRuleLimit, 0, len(cfg.Routing.SessionAffinityRules))
+		for _, rule := range cfg.Routing.SessionAffinityRules {
+			raw = append(raw, coreauth.SessionAffinityRuleLimit{
+				Provider:    rule.Provider,
+				Model:       rule.Model,
+				MaxRequests: rule.MaxRequests,
+			})
+		}
+		rules := coreauth.CompileSessionAffinityRules(raw)
+		state.sessionAffinityRules = rules
+		var keyBuilder strings.Builder
+		for i, rule := range rules {
+			if i > 0 {
+				keyBuilder.WriteByte('|')
+			}
+			keyBuilder.WriteString(rule.Provider)
+			keyBuilder.WriteByte('/')
+			keyBuilder.WriteString(rule.Model)
+			keyBuilder.WriteByte('=')
+			keyBuilder.WriteString(strconv.Itoa(rule.MaxRequests))
+		}
+		state.sessionAffinityRulesKey = keyBuilder.String()
+	}
 	return state
+}
+
+func routingRuntimeStateEqual(left, right routingRuntimeState) bool {
+	return left.strategy == right.strategy &&
+		left.sessionAffinity == right.sessionAffinity &&
+		left.sessionAffinityTTL == right.sessionAffinityTTL &&
+		left.sessionAffinityMaxRequests == right.sessionAffinityMaxRequests &&
+		left.sessionAffinityRulesKey == right.sessionAffinityRulesKey
 }
 
 func newRoutingSelector(state routingRuntimeState) coreauth.Selector {
@@ -66,8 +108,10 @@ func newRoutingSelector(state routingRuntimeState) coreauth.Selector {
 	}
 	if state.sessionAffinity {
 		selector = coreauth.NewSessionAffinitySelectorWithConfig(coreauth.SessionAffinityConfig{
-			Fallback: selector,
-			TTL:      state.sessionAffinityTTL,
+			Fallback:    selector,
+			TTL:         state.sessionAffinityTTL,
+			MaxRequests: state.sessionAffinityMaxRequests,
+			Rules:       state.sessionAffinityRules,
 		})
 	}
 	return selector
@@ -203,7 +247,7 @@ func (s *Service) applyManagerConfig(ctx context.Context, commit configCommit) b
 		return false
 	}
 	routingState := normalizedRoutingRuntimeState(commit.cfg)
-	if s.appliedRoutingState == nil || *s.appliedRoutingState != routingState {
+	if s.appliedRoutingState == nil || !routingRuntimeStateEqual(*s.appliedRoutingState, routingState) {
 		s.coreManager.SetSelector(newRoutingSelector(routingState))
 		s.appliedRoutingState = &routingState
 	}

--- a/sdk/cliproxy/service_config_weight_test.go
+++ b/sdk/cliproxy/service_config_weight_test.go
@@ -19,6 +19,71 @@ func TestWeightedRoundRobinRoutingSelector(t *testing.T) {
 	}
 }
 
+func TestNormalizedRoutingRuntimeState_SessionAffinityRulesKeyStable(t *testing.T) {
+	t.Parallel()
+
+	withSuffix := normalizedRoutingRuntimeState(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{
+			SessionAffinity: true,
+			SessionAffinityRules: []internalconfig.SessionAffinityRule{
+				{Provider: "XAI", Model: "grok-4.5(high)", MaxRequests: 10},
+			},
+		},
+	})
+	withoutSuffix := normalizedRoutingRuntimeState(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{
+			SessionAffinity: true,
+			SessionAffinityRules: []internalconfig.SessionAffinityRule{
+				{Provider: "xai", Model: "grok-4.5", MaxRequests: 10},
+			},
+		},
+	})
+
+	if withSuffix.sessionAffinityRulesKey == "" {
+		t.Fatal("expected non-empty rules key")
+	}
+	if withSuffix.sessionAffinityRulesKey != withoutSuffix.sessionAffinityRulesKey {
+		t.Fatalf("rules key mismatch: %q vs %q", withSuffix.sessionAffinityRulesKey, withoutSuffix.sessionAffinityRulesKey)
+	}
+	if !routingRuntimeStateEqual(withSuffix, withoutSuffix) {
+		t.Fatal("thinking-suffix-only model change should not rebuild routing state")
+	}
+	if len(withSuffix.sessionAffinityRules) != 1 {
+		t.Fatalf("compiled rules len = %d, want 1", len(withSuffix.sessionAffinityRules))
+	}
+	if got := withSuffix.sessionAffinityRules[0].Model; got != "grok-4.5" {
+		t.Fatalf("compiled model = %q, want grok-4.5", got)
+	}
+}
+
+func TestNormalizedRoutingRuntimeState_SessionAffinityRulesOrderMatters(t *testing.T) {
+	t.Parallel()
+
+	// Equal-specificity order is preserved intentionally (first match wins at equal score).
+	left := normalizedRoutingRuntimeState(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{
+			SessionAffinityRules: []internalconfig.SessionAffinityRule{
+				{Model: "a", MaxRequests: 1},
+				{Model: "b", MaxRequests: 2},
+			},
+		},
+	})
+	right := normalizedRoutingRuntimeState(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{
+			SessionAffinityRules: []internalconfig.SessionAffinityRule{
+				{Model: "b", MaxRequests: 2},
+				{Model: "a", MaxRequests: 1},
+			},
+		},
+	})
+	if left.sessionAffinityRulesKey == right.sessionAffinityRulesKey {
+		t.Fatal("rule order should affect rules key (equal-specificity first-match semantics)")
+	}
+	if routingRuntimeStateEqual(left, right) {
+		t.Fatal("reordered equal-specificity rules should be treated as a routing change")
+	}
+}
+
 func TestServiceRejectsInvalidCredentialWeightConfigCommit(t *testing.T) {
 	originalCfg := &internalconfig.Config{}
 	service := &Service{cfg: originalCfg}

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -19,6 +19,7 @@ type PayloadConfig = internalconfig.PayloadConfig
 type PayloadRule = internalconfig.PayloadRule
 type PayloadFilterRule = internalconfig.PayloadFilterRule
 type PayloadModelRule = internalconfig.PayloadModelRule
+type SessionAffinityRule = internalconfig.SessionAffinityRule
 
 type GeminiKey = internalconfig.GeminiKey
 type CodexKey = internalconfig.CodexKey


### PR DESCRIPTION
## Summary

Add **session-affinity max-requests** so sticky session→auth bindings can rebind after a request cap, with optional **per-provider / per-model** overrides.

## Motivation

Session affinity keeps a client on the same credential for continuity, but long-lived sessions can pin traffic to one account indefinitely (until TTL expires or the auth becomes unavailable). Operators need a way to:

- Soft-rotate credentials after N sticky picks
- Apply different caps for specific models/providers (e.g. expensive models vs cheap ones)

without turning off session affinity entirely.

## Changes

### Config

- `routing.session-affinity-max-requests` — global default (`<=0` / omit / `-1` = unlimited)
- `routing.session-affinity-rules[]` — optional overrides:
  - `provider` (optional)
  - `model` (optional; thinking-suffix stripped for matching)
  - `max-requests`

**Match specificity (most specific wins):**  
`provider+model` > `model-only` > `provider-only` > global default

Equal-specificity rules keep declaration order (first match wins at equal score).

### Runtime

- Session cache tracks **hit count** per binding (shared across session aliases)
- On sticky cache hit, if `hits > max-requests`, invalidate the binding and re-pick via the fallback selector, then rebind
- Rebind also still occurs when the bound auth is unavailable (existing behavior)
- Hot-reload: routing state equality includes max-requests + compiled rules key so config changes rebuild the selector

### Docs / example

- `config.example.yaml` documents the new knobs and the **fill-first + max-requests** interaction

## Behavior notes / caveats

> **Rebind uses the same `routing.strategy` selector.**  
> With **`fill-first`**, rebind still returns the first available credential, so **max-requests rarely rotates accounts** unless the current one is unavailable (cooldown / quota / disabled).  
> Prefer **`round-robin`** or **`weighted-round-robin`** when using max-requests for intentional rotation.

Only effective when `routing.session-affinity: true`.

### Example

```yaml
routing:
  strategy: round-robin
  session-affinity: true
  session-affinity-ttl: "1h"
  session-affinity-max-requests: -1   # unlimited global default
  session-affinity-rules:
    - model: "grok-4.5"
      provider: "xai"       # optional
      max-requests: 20
```

## Test plan

- [x] Unit: max-requests rebinds under round-robin after N sticky picks
- [x] Unit: fill-first does **not** rotate while first auth remains available (documented intentional)
- [x] Unit: per-model / per-provider rule resolution specificity
- [x] Unit: rules key stable across thinking-suffix / case normalization; order matters at equal specificity
- [ ] Manual: enable session-affinity + max-requests with RR/WRR, confirm log lines for rebind (`max-requests reached`) and hit counters on cache hits
- [ ] Manual: hot-reload change of max-requests / rules rebuilds routing without restart

## Files

- `internal/config/config_types.go` — config types
- `config.example.yaml` — example + caveats
- `sdk/cliproxy/auth/session_cache.go` — hit counting + alias-group invalidate
- `sdk/cliproxy/auth/session_affinity_rules.go` — compile / resolve
- `sdk/cliproxy/auth/selector.go` — max-requests rebind path
- `sdk/cliproxy/service_config.go` — wire config → selector + hot-reload equality
- tests for rules, max-requests, and routing state