### PR TITLE
fix(codex-api): stop force-injecting built-in model IDs

### DIFF
--- a/sdk/cliproxy/config_model_display_name_test.go
+++ b/sdk/cliproxy/config_model_display_name_test.go
@@ -68,31 +68,20 @@ func TestBuildConfigModelsDisplayName(t *testing.T) {
 	}
 }
 
-func TestBuildCodexConfigModelsPreservesBuiltinDisplayNames(t *testing.T) {
-	models := buildCodexConfigModels(&config.CodexKey{Models: []config.CodexModel{
-		{Name: "gpt-image-1.5", DisplayName: "Configured Image 1.5"},
-		{Name: "gpt-image-2", DisplayName: "Configured Image 2"},
-	}})
+func TestBuildCodexConfigModelsOnlyIncludesConfiguredModels(t *testing.T) {
+	models := buildCodexConfigModels(&config.CodexKey{Models: []config.CodexModel{{
+		Name: "upstream-codex", Alias: "configured-codex",
+	}}})
 
-	wantDisplayNames := map[string]string{
-		"gpt-image-1.5": "Configured Image 1.5",
-		"gpt-image-2":   "Configured Image 2",
+	if len(models) != 1 {
+		t.Fatalf("model count = %d, want 1", len(models))
 	}
-	for _, model := range models {
-		wantDisplayName, ok := wantDisplayNames[model.ID]
-		if !ok {
-			continue
-		}
-		if model.DisplayName != wantDisplayName {
-			t.Errorf("%s DisplayName = %q, want %q", model.ID, model.DisplayName, wantDisplayName)
-		}
-		if model.Object != "model" || model.OwnedBy != "openai" || model.Type != "openai" || model.Created != 1704067200 || model.Version != model.ID || model.UserDefined {
-			t.Errorf("%s builtin metadata was not preserved: %#v", model.ID, model)
-		}
-		delete(wantDisplayNames, model.ID)
+	if models[0].ID != "configured-codex" {
+		t.Fatalf("model ID = %q, want configured-codex", models[0].ID)
 	}
-	for modelID := range wantDisplayNames {
-		t.Errorf("missing builtin model %s", modelID)
+
+	if models := buildCodexConfigModels(&config.CodexKey{}); len(models) != 0 {
+		t.Fatalf("model count without configuration = %d, want 0", len(models))
 	}
 }
 

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -113,6 +113,17 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 		}
 		models = applyExcludedModels(models, excluded)
 	case "codex":
+		if authKind == "apikey" {
+			if entry := s.resolveConfigCodexKey(a); entry != nil {
+				models = buildCodexConfigModels(entry)
+				excluded = entry.ExcludedModels
+			} else {
+				models = nil
+			}
+			models = applyExcludedModels(models, excluded)
+			break
+		}
+
 		codexPlanType := ""
 		if a.Attributes != nil {
 			codexPlanType = strings.TrimSpace(a.Attributes["plan_type"])
@@ -128,14 +139,6 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 			models = registry.GetCodexFreeModels()
 		default:
 			models = registry.GetCodexProModels()
-		}
-		if entry := s.resolveConfigCodexKey(a); entry != nil {
-			if len(entry.Models) > 0 {
-				models = buildCodexConfigModels(entry)
-			}
-			if authKind == "apikey" {
-				excluded = entry.ExcludedModels
-			}
 		}
 		models = applyExcludedModels(models, excluded)
 	case "kimi":
@@ -774,7 +777,7 @@ func buildCodexConfigModels(entry *config.CodexKey) []*ModelInfo {
 		return nil
 	}
 
-	models := registry.WithCodexBuiltins(buildConfigModels(entry.Models, "openai", "openai"))
+	models := buildConfigModels(entry.Models, "openai", "openai")
 	configuredDisplayNames := make(map[string]string, len(entry.Models))
 	seenConfiguredModels := make(map[string]struct{}, len(entry.Models))
 	for i := range entry.Models {


### PR DESCRIPTION
Updates Codex API key model registration to expose only explicitly configured models, removing the forced injection of gpt-image-1.5 and gpt-image-2. Codex OAuth model behavior remains unchanged.