### PR TITLE
fix(translator): accept reasoning in OpenAI-to-Claude responses

### DIFF
--- a/internal/translator/openai/claude/openai_claude_response.go
+++ b/internal/translator/openai/claude/openai_claude_response.go
@@ -166,7 +166,7 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 		}
 
 		// Handle reasoning content delta
-		if reasoning := delta.Get("reasoning_content"); reasoning.Exists() {
+		if reasoning := openAIReasoningNode(delta); reasoning.Exists() {
 			for _, reasoningText := range collectOpenAIReasoningTexts(reasoning) {
 				if reasoningText == "" {
 					continue
@@ -427,7 +427,7 @@ func convertOpenAINonStreamingToAnthropic(rawJSON []byte) [][]byte {
 	if choices := root.Get("choices"); choices.Exists() && choices.IsArray() && len(choices.Array()) > 0 {
 		choice := choices.Array()[0] // Take first choice
 
-		reasoningNode := choice.Get("message.reasoning_content")
+		reasoningNode := openAIReasoningNode(choice.Get("message"))
 		for _, reasoningText := range collectOpenAIReasoningTexts(reasoningNode) {
 			if reasoningText == "" {
 				continue
@@ -513,6 +513,14 @@ func (p *ConvertOpenAIResponseToAnthropicParams) toolContentBlockIndex(openAIToo
 	p.NextContentBlockIndex++
 	p.ToolCallBlockIndexes[openAIToolIndex] = idx
 	return idx
+}
+
+func openAIReasoningNode(node gjson.Result) gjson.Result {
+	reasoning := node.Get("reasoning_content")
+	if !reasoning.Exists() || reasoning.String() == "" {
+		reasoning = node.Get("reasoning")
+	}
+	return reasoning
 }
 
 func collectOpenAIReasoningTexts(node gjson.Result) []string {
@@ -711,7 +719,7 @@ func ConvertOpenAIResponseToClaudeNonStream(_ context.Context, _ string, origina
 				}
 			}
 
-			if reasoning := message.Get("reasoning_content"); reasoning.Exists() {
+			if reasoning := openAIReasoningNode(message); reasoning.Exists() {
 				for _, reasoningText := range collectOpenAIReasoningTexts(reasoning) {
 					if reasoningText == "" {
 						continue

--- a/internal/translator/openai/claude/openai_claude_response_test.go
+++ b/internal/translator/openai/claude/openai_claude_response_test.go
@@ -383,3 +383,78 @@ func TestStreamingTool_StopReasonMixedSuppressedAndValid(t *testing.T) {
 		t.Fatalf("stop_reason = %q, want %q", got, "tool_use")
 	}
 }
+
+func TestConvertOpenAIResponseToClaude_StreamReasoningFields(t *testing.T) {
+	tests := []struct {
+		name  string
+		chunk string
+	}{
+		{
+			name:  "reasoning",
+			chunk: `{"id":"c1","model":"m","choices":[{"index":0,"delta":{"role":"assistant","reasoning":"think step by step"},"finish_reason":null}]}`,
+		},
+		{
+			name:  "reasoning_content",
+			chunk: `{"id":"c1","model":"m","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"think step by step"},"finish_reason":null}]}`,
+		},
+		{
+			name:  "reasoning_content preferred",
+			chunk: `{"id":"c1","model":"m","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"think step by step","reasoning":"do not use"},"finish_reason":null}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			events := runStream(t, streamReq,
+				tt.chunk,
+				`{"id":"c1","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+			)
+
+			var thinking string
+			for _, event := range events {
+				if event.Type == "content_block_delta" && gjson.Get(event.Payload, "delta.type").String() == "thinking_delta" {
+					thinking += gjson.Get(event.Payload, "delta.thinking").String()
+				}
+			}
+			if thinking != "think step by step" {
+				t.Fatalf("thinking = %q, want %q (events=%+v)", thinking, "think step by step", events)
+			}
+		})
+	}
+}
+
+func TestConvertOpenAIResponseToClaudeNonStream_ReasoningFields(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "reasoning",
+			raw:  `{"id":"c1","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"answer","reasoning":"think step by step"},"finish_reason":"stop"}]}`,
+		},
+		{
+			name: "reasoning_content",
+			raw:  `{"id":"c1","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"answer","reasoning_content":"think step by step"},"finish_reason":"stop"}]}`,
+		},
+		{
+			name: "reasoning_content preferred",
+			raw:  `{"id":"c1","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"answer","reasoning_content":"think step by step","reasoning":"do not use"},"finish_reason":"stop"}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := ConvertOpenAIResponseToClaudeNonStream(context.Background(), "m", nil, nil, []byte(tt.raw), nil)
+
+			var thinking string
+			for _, block := range gjson.GetBytes(out, "content").Array() {
+				if block.Get("type").String() == "thinking" {
+					thinking += block.Get("thinking").String()
+				}
+			}
+			if thinking != "think step by step" {
+				t.Fatalf("thinking = %q, want %q (output=%s)", thinking, "think step by step", out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #4154

## Summary

- accept OpenAI-compatible response reasoning from `delta.reasoning` and `message.reasoning` when `reasoning_content` is absent or empty
- preserve `reasoning_content` as the preferred field when both fields are populated
- apply the fallback to streaming and both non-streaming OpenAI-to-Claude conversion paths

This intentionally does not add the provider-specific `data` envelope handling from #4511; it only aligns this translator with the existing Chat Completions-to-Responses `reasoning_content` -> `reasoning` fallback.

## Tests

- `go test ./internal/translator/openai/claude -run 'ReasoningFields' -count=1`
- `go test ./internal/translator/openai/claude -count=1`
- `go build -o /tmp/cliproxyapi-issue-4154 ./cmd/server`

## Manual QA

Ran a minimal Go driver through the exported translator functions using upstream payloads with only `reasoning`:

```text
non-stream thinking: "manual non-stream reasoning"
stream thinking_delta: "manual stream reasoning" (5 SSE events)
```

## Risk

Low and translator-local. Populated `reasoning_content` retains precedence; `reasoning` is consulted only when the existing field is missing or empty. Provider-specific response envelopes and `reasoning_details` are unchanged.
