### PR TITLE
feat(plugin): expose host build info callback

### DIFF
--- a/examples/plugin/README.md
+++ b/examples/plugin/README.md
@@ -29,6 +29,21 @@ This directory contains standard dynamic library plugin examples for the CLIProx
 
 Most standard capability examples contain `go/`, `c/`, and `rust/` subdirectories. Specialized examples may provide only the implementation language they need.
 
+## Host Build Info Callback
+
+Native plugins can call `host.build_info` with no request body to identify the running CPA build. The callback returns the standard RPC envelope with this result:
+
+```json
+{
+  "version": "v7.2.105",
+  "commit": "90c2ff90de39908d145be413ee1346fd5a8b7a55"
+}
+```
+
+`version` is the authoritative value for compatibility decisions. `commit` is optional and intended only for diagnostics. Plugins should cache the result and use their conservative compatibility path when the callback is unavailable or the version is invalid; older CPA builds report the callback as unsupported.
+
+Go plugins can use `pluginabi.MethodHostBuildInfo` for the method name and decode the result as `pluginapi.HostBuildInfo`. This callback is additive and does not change the native ABI or registration schema version.
+
 ## Codex Service Tier
 
 `codex-service-tier` declares the request normalization capability. When `fast` is `true`, it sets `service_tier` to `priority` for requests where `req.ToFormat` is `codex` and `req.Model` is `gpt-5.5`.

--- a/internal/pluginhost/host_callbacks.go
+++ b/internal/pluginhost/host_callbacks.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/buildinfo"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
@@ -97,6 +98,11 @@ func hostCallbackPluginIDFromContext(ctx context.Context) string {
 
 func (h *Host) callFromPlugin(ctx context.Context, method string, request []byte) ([]byte, error) {
 	switch method {
+	case pluginabi.MethodHostBuildInfo:
+		return marshalRPCResult(pluginapi.HostBuildInfo{
+			Version: buildinfo.Version,
+			Commit:  buildinfo.Commit,
+		})
 	case pluginabi.MethodHostModelExecute:
 		return h.callHostModelExecute(ctx, request)
 	case pluginabi.MethodHostModelExecuteStream:

--- a/internal/pluginhost/host_callbacks_test.go
+++ b/internal/pluginhost/host_callbacks_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/buildinfo"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
@@ -32,6 +33,28 @@ func (e *fakeHostModelExecutor) ExecuteModel(ctx context.Context, req handlers.M
 
 func (e *fakeHostModelExecutor) ExecuteModelStream(ctx context.Context, req handlers.ModelExecutionRequest) (handlers.ModelExecutionStream, *interfaces.ErrorMessage) {
 	return e.executeModelStream(ctx, req)
+}
+
+func TestHostBuildInfoCallbackReturnsRunningBuild(t *testing.T) {
+	previousVersion, previousCommit := buildinfo.Version, buildinfo.Commit
+	buildinfo.Version = "v7.2.105-test"
+	buildinfo.Commit = "90c2ff90-test"
+	t.Cleanup(func() {
+		buildinfo.Version = previousVersion
+		buildinfo.Commit = previousCommit
+	})
+
+	rawResp, errCall := New().callFromPlugin(context.Background(), pluginabi.MethodHostBuildInfo, nil)
+	if errCall != nil {
+		t.Fatalf("callFromPlugin() error = %v", errCall)
+	}
+	info, errDecode := decodeRPCEnvelope[pluginapi.HostBuildInfo](rawResp)
+	if errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if info.Version != buildinfo.Version || info.Commit != buildinfo.Commit {
+		t.Fatalf("build info = %#v, want version %q commit %q", info, buildinfo.Version, buildinfo.Commit)
+	}
 }
 
 func TestHostHTTPDoCallbackUsesHostHTTPClient(t *testing.T) {

--- a/sdk/pluginabi/types.go
+++ b/sdk/pluginabi/types.go
@@ -62,6 +62,7 @@ const (
 	MethodManagementRegister = "management.register"
 	MethodManagementHandle   = "management.handle"
 
+	MethodHostBuildInfo          = "host.build_info"
 	MethodHostHTTPDo             = "host.http.do"
 	MethodHostHTTPDoStream       = "host.http.do_stream"
 	MethodHostHTTPStreamRead     = "host.http.stream_read"

--- a/sdk/pluginabi/types_test.go
+++ b/sdk/pluginabi/types_test.go
@@ -48,6 +48,9 @@ func TestMethodNamesAreStable(t *testing.T) {
 	if MethodResponseInterceptStreamChunk != "response.intercept_stream_chunk" {
 		t.Fatalf("MethodResponseInterceptStreamChunk = %q", MethodResponseInterceptStreamChunk)
 	}
+	if MethodHostBuildInfo != "host.build_info" {
+		t.Fatalf("MethodHostBuildInfo = %q", MethodHostBuildInfo)
+	}
 	if MethodHostHTTPDo != "host.http.do" {
 		t.Fatalf("MethodHostHTTPDo = %q", MethodHostHTTPDo)
 	}

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -596,6 +596,14 @@ type HostHTTPClient interface {
 	DoStream(context.Context, HTTPRequest) (HTTPStreamResponse, error)
 }
 
+// HostBuildInfo identifies the running CLIProxyAPI build.
+type HostBuildInfo struct {
+	// Version is the authoritative host version for plugin compatibility decisions.
+	Version string `json:"version"`
+	// Commit is the optional source commit for diagnostics only.
+	Commit string `json:"commit,omitempty"`
+}
+
 // HostModelExecutionRequest describes a model execution request issued through the host.
 type HostModelExecutionRequest struct {
 	// EntryProtocol is the inbound client protocol format.

--- a/sdk/pluginapi/types_test.go
+++ b/sdk/pluginapi/types_test.go
@@ -319,6 +319,25 @@ func TestHostModelTypesPreserveFields(t *testing.T) {
 	}
 }
 
+func TestHostBuildInfoJSONContract(t *testing.T) {
+	info := HostBuildInfo{Version: "v7.2.105", Commit: "90c2ff90"}
+	raw, errMarshal := json.Marshal(info)
+	if errMarshal != nil {
+		t.Fatalf("marshal HostBuildInfo: %v", errMarshal)
+	}
+	if string(raw) != `{"version":"v7.2.105","commit":"90c2ff90"}` {
+		t.Fatalf("HostBuildInfo JSON = %s", raw)
+	}
+
+	withoutCommit, errMarshal := json.Marshal(HostBuildInfo{Version: "dev"})
+	if errMarshal != nil {
+		t.Fatalf("marshal HostBuildInfo without commit: %v", errMarshal)
+	}
+	if string(withoutCommit) != `{"version":"dev"}` {
+		t.Fatalf("HostBuildInfo JSON without commit = %s", withoutCommit)
+	}
+}
+
 func TestSchedulerTypesExposeRoutingFields(t *testing.T) {
 	request := SchedulerPickRequest{
 		Plugin:    Metadata{Name: "scheduler-plugin"},


### PR DESCRIPTION
## Summary

- add the optional `host.build_info` native host callback without changing ABI or schema versions
- expose the callback name and typed `{version, commit}` response through the public plugin SDK
- return the running process's existing linker-populated build metadata and document compatibility/fallback behavior

## Why

Native plugins sometimes need to choose a compatibility path before request handling. Using the host callback table keeps this runtime check inside the plugin protocol and lets older hosts naturally report the additive callback as unsupported.

`version` is authoritative for compatibility decisions. `commit` remains optional and diagnostic-only.

## Verification

- `go test ./sdk/pluginabi ./sdk/pluginapi ./sdk/pluginhost`
- `go test ./internal/pluginhost`
- `go build -o /tmp/cliproxyapi-issue-4611 ./cmd/server`
- real c-shared plugin QA: loaded a dylib through `sdk/pluginhost`, queried `host.build_info` during `plugin.register`, and observed linker-injected `host=v9.9.9-qa commit=4611cafe` in registered metadata

Fixes #4611
