### PR TITLE
fix(antigravity): preserve Gemini thoughts before trailing carriers

### DIFF
--- a/internal/runtime/executor/antigravity_executor_signature_test.go
+++ b/internal/runtime/executor/antigravity_executor_signature_test.go
@@ -327,6 +327,25 @@ func TestAntigravityExecutor_GeminiTargetPreservesGeminiThinkingCarrier(t *testi
 	}
 }
 
+func TestAntigravityExecutor_GeminiTargetPreservesUnsignedThoughtBeforePreviousCarrier(t *testing.T) {
+	inner := protowire.AppendTag(nil, 1, protowire.BytesType)
+	inner = protowire.AppendBytes(inner, []byte{0x01, 0x0c, 0x39, 0xd6, 0xc7, 0x34})
+	encoded := protowire.AppendTag(nil, 2, protowire.BytesType)
+	encoded = protowire.AppendBytes(encoded, inner)
+	validSignature := base64.StdEncoding.EncodeToString(encoded)
+	carrier := "cpa-gemini-carrier-v1:previous:text:" + base64.RawStdEncoding.EncodeToString([]byte(validSignature))
+	payload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"hidden reasoning"},{"type":"text","text":"visible answer"},{"type":"thinking","thinking":"","signature":"` + carrier + `"}]}]}`)
+
+	output, err := validateAntigravityRequestSignatures(context.Background(), "gemini-3.1-pro-preview", sdktranslator.FormatClaude, payload)
+	if err != nil {
+		t.Fatalf("validateAntigravityRequestSignatures() error = %v", err)
+	}
+	content := gjson.GetBytes(output, "messages.0.content").Array()
+	if len(content) != 3 || content[0].Get("thinking").String() != "hidden reasoning" || content[2].Get("signature").String() != carrier {
+		t.Fatalf("unsigned thought and previous carrier were not preserved: %s", output)
+	}
+}
+
 func TestAntigravityExecutor_StrictBypassStripsInvalidSignature(t *testing.T) {
 	previousCache := cache.SignatureCacheEnabled()
 	previousStrict := cache.SignatureBypassStrictMode()

--- a/internal/translator/antigravity/claude/antigravity_claude_request.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request.go
@@ -436,10 +436,11 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 						// Skip unsigned thinking blocks instead of converting them to text.
 						isUnsigned := !hasResolvedThinkingSignature(modelName, signature)
 
-						// If unsigned, skip entirely (don't convert to text)
-						// Claude requires assistant messages to start with thinking blocks when thinking is enabled
-						// Converting to text would break this requirement
-						if isUnsigned {
+						// If unsigned, skip entirely (don't convert to text), unless a tagged
+						// trailing carrier binds the following native semantic part.
+						// Claude requires assistant messages to start with thinking blocks when thinking is enabled.
+						// Converting other unsigned thinking to text would break this requirement.
+						if isUnsigned && !geminiClaudeUnsignedThoughtHasFollowingPreviousCarrier(contentResults, j) {
 							logDroppedAntigravityThinkingSignature(modelName, i, j, thinkingText, signatureResult)
 							enableThoughtTranslate = false
 							continue

--- a/internal/translator/antigravity/claude/antigravity_claude_request_test.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request_test.go
@@ -112,6 +112,30 @@ func assertSignatureDebugDoesNotLeak(t *testing.T, hook *test.Hook, forbidden st
 	}
 }
 
+func TestConvertClaudeRequestToAntigravity_PreservesUnsignedThoughtBeforePreviousCarrier(t *testing.T) {
+	validSignature := testGeminiEPrefixSignature(t)
+	previousText := encodeGeminiClaudeCarrierSignature(validSignature, geminiClaudeCarrierPrevious, geminiClaudeCarrierText)
+	input := []byte(`{"model":"gemini-3.1-pro-preview","messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"hidden reasoning"},{"type":"text","text":"visible answer"},{"type":"thinking","thinking":"","signature":"` + previousText + `"}]},{"role":"user","content":[{"type":"text","text":"continue"}]}]}`)
+
+	output := ConvertClaudeRequestToAntigravity("gemini-3.1-pro-preview", input, false)
+	parts := gjson.GetBytes(output, "request.contents.0.parts").Array()
+	if len(parts) != 2 {
+		t.Fatalf("part count = %d, want thought and visible text; output=%s", len(parts), output)
+	}
+	if got := parts[0].Get("text").String(); got != "hidden reasoning" || !parts[0].Get("thought").Bool() {
+		t.Fatalf("thought part was not preserved: %s", output)
+	}
+	if parts[0].Get("thoughtSignature").Exists() {
+		t.Fatalf("thought part should remain unsigned: %s", output)
+	}
+	if got := parts[1].Get("text").String(); got != "visible answer" {
+		t.Fatalf("visible text = %q, want visible answer; output=%s", got, output)
+	}
+	if got := parts[1].Get("thoughtSignature").String(); got != validSignature {
+		t.Fatalf("visible text signature = %q, want %q; output=%s", got, validSignature, output)
+	}
+}
+
 func TestConvertClaudeRequestToAntigravity_StripsClaudeCodeAttribution(t *testing.T) {
 	inputJSON := []byte(`{
 		"model": "claude-sonnet-4-5",

--- a/internal/translator/antigravity/claude/signature_validation.go
+++ b/internal/translator/antigravity/claude/signature_validation.go
@@ -105,6 +105,21 @@ func geminiClaudeCarrierMatchesAdjacent(blocks []gjson.Result, index int, direct
 	return false
 }
 
+func geminiClaudeUnsignedThoughtHasFollowingPreviousCarrier(blocks []gjson.Result, index int) bool {
+	if index+2 >= len(blocks) {
+		return false
+	}
+	targetKind := geminiClaudeSemanticTargetKind(blocks[index+1])
+	carrier := blocks[index+2]
+	if targetKind == "" || carrier.Get("type").String() != "thinking" || strings.TrimSpace(carrier.Get("thinking").String()) != "" {
+		return false
+	}
+	_, direction, carrierTargetKind, marked, ok := decodeGeminiClaudeCarrierSignature(carrier.Get("signature").String())
+	return marked && ok && direction == geminiClaudeCarrierPrevious &&
+		(carrierTargetKind == geminiClaudeCarrierAny || carrierTargetKind == targetKind) &&
+		geminiClaudeCarrierMatchesAdjacent(blocks, index+2, direction, carrierTargetKind)
+}
+
 // StripEmptySignatureThinkingBlocks removes thinking blocks whose signatures
 // are empty or not valid Claude thinking signatures. These usually come from
 // proxy-generated responses where no real Claude signature exists.
@@ -138,7 +153,9 @@ func StripInvalidGeminiSignatureThinkingBlocks(payload []byte) []byte {
 			if block.Get("type").String() == "thinking" {
 				rawSignature := strings.TrimSpace(block.Get("signature").String())
 				thinkingText := strings.TrimSpace(block.Get("thinking").String())
-				if rawSignature == "" && thinkingText != "" && (pendingCarrierTargetKind == geminiClaudeCarrierAny || pendingCarrierTargetKind == geminiClaudeCarrierText) {
+				hasPendingTextCarrier := pendingCarrierTargetKind == geminiClaudeCarrierAny || pendingCarrierTargetKind == geminiClaudeCarrierText
+				hasFollowingCarrier := geminiClaudeUnsignedThoughtHasFollowingPreviousCarrier(contentBlocks, blockIndex)
+				if rawSignature == "" && thinkingText != "" && (hasPendingTextCarrier || hasFollowingCarrier) {
 					pendingCarrierTargetKind = ""
 					contentItems = append(contentItems, []byte(block.Raw))
 					continue

--- a/internal/translator/antigravity/claude/signature_validation_test.go
+++ b/internal/translator/antigravity/claude/signature_validation_test.go
@@ -37,6 +37,24 @@ func TestStripInvalidGeminiSignatureThinkingBlocksPreservesMarkedNonEmptyThinkin
 	}
 }
 
+func TestStripInvalidGeminiSignatureThinkingBlocksPreservesUnsignedThoughtBeforePreviousCarrier(t *testing.T) {
+	validSignature := testGeminiEPrefixSignature(t)
+	previousText := encodeGeminiClaudeCarrierSignature(validSignature, geminiClaudeCarrierPrevious, geminiClaudeCarrierText)
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"hidden reasoning"},{"type":"text","text":"visible answer"},{"type":"thinking","thinking":"","signature":"` + previousText + `"}]}]}`)
+
+	out := StripInvalidGeminiSignatureThinkingBlocks(input)
+	content := gjson.GetBytes(out, "messages.0.content").Array()
+	if len(content) != 3 {
+		t.Fatalf("content count = %d, want unsigned thought, text, and previous carrier; output=%s", len(content), out)
+	}
+	if got := content[0].Get("thinking").String(); got != "hidden reasoning" {
+		t.Fatalf("thinking text = %q, want hidden reasoning; output=%s", got, out)
+	}
+	if got := content[2].Get("signature").String(); got != previousText {
+		t.Fatalf("carrier signature = %q, want %q; output=%s", got, previousText, out)
+	}
+}
+
 func TestStripInvalidGeminiSignatureThinkingBlocksDropsMismatchedDirectionalThinking(t *testing.T) {
 	validSignature := testGeminiEPrefixSignature(t)
 	nextFunction := encodeGeminiClaudeCarrierSignature(validSignature, geminiClaudeCarrierNext, geminiClaudeCarrierFunction)


### PR DESCRIPTION
## Summary

- preserve unsigned Gemini thought text when CPA\u2019s following semantic block is immediately followed by a valid `previous`-direction signature carrier
- apply the same narrow carrier look-ahead in the adjacent Claude-to-Antigravity request translator so direct translation cannot drop the thought a second time
- retain the carrier envelope through validation, then rebind its native signature to the visible Gemini part as before

Fixes #4628

## Tests

- `go test ./internal/translator/antigravity/claude -count=1`
- `go test ./internal/runtime/executor -run Antigravity -count=1`
- `go build -o /tmp/cliproxyapi-issue-4628 ./cmd/server`
- manual request/translator driver using `[unsigned thought, text, previous:text carrier]`: `thought_chars=34`, non-empty thought matched input, visible signature preserved, two native parts emitted

The regressions cover the pre-translation strip, direct request translation, and executor integration. The focused tests failed before the fix with the thought block removed.

## Risk

Low and localized. The carve-out requires the exact three-block shape and a decodable, provider-compatible tagged carrier whose `previous` direction and target kind match the immediately preceding semantic block. Invalid, untagged, misplaced, and unrelated unsigned thinking blocks retain existing drop behavior. Existing valid signature/carrier tests pass unchanged.