### PR TITLE
feat(openai-compat): add Azure OpenAI deployment mode

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -471,6 +471,19 @@ nonstream-keepalive-interval: 0
 #         alias: "claude-opus-4.66"
 #       - name: "kimi-k2.5"
 #         alias: "claude-opus-4.66"
+#
+#   # Azure OpenAI uses a deployment path, api-version query parameter, and api-key header.
+#   # The client-facing alias, upstream request model, and Azure deployment may differ.
+#   - name: "azure-openai"
+#     base-url: "https://example-resource.openai.azure.com"
+#     azure:
+#       deployment: "production-gpt-5"      # Azure deployment name (URL-escaped in requests)
+#       api-version: "2025-04-01-preview"
+#     api-key-entries:
+#       - api-key: "${AZURE_OPENAI_API_KEY}"
+#     models:
+#       - name: "gpt-5"
+#         alias: "azure-gpt-5"
 
 # Vertex API keys (Vertex-compatible endpoints, base-url is optional)
 # vertex-api-key:

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -44,6 +44,7 @@ type openAICompatibilityWithAuthIndex struct {
 	Disabled       bool                                     `json:"disabled"`
 	Prefix         string                                   `json:"prefix,omitempty"`
 	BaseURL        string                                   `json:"base-url"`
+	Azure          *config.OpenAICompatibilityAzure         `json:"azure,omitempty"`
 	APIKeyEntries  []openAICompatibilityAPIKeyWithAuthIndex `json:"api-key-entries,omitempty"`
 	Models         []config.OpenAICompatibilityModel        `json:"models,omitempty"`
 	Headers        map[string]string                        `json:"headers,omitempty"`
@@ -283,6 +284,7 @@ func (h *Handler) openAICompatibilityWithAuthIndex() []openAICompatibilityWithAu
 			Disabled:       entry.Disabled,
 			Prefix:         entry.Prefix,
 			BaseURL:        entry.BaseURL,
+			Azure:          entry.Azure,
 			Models:         entry.Models,
 			Headers:        entry.Headers,
 			DisableCooling: entry.DisableCooling,

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -706,6 +706,7 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 		Disabled       *bool                               `json:"disabled"`
 		DisableCooling *bool                               `json:"disable-cooling"`
 		BaseURL        *string                             `json:"base-url"`
+		Azure          *config.OpenAICompatibilityAzure    `json:"azure"`
 		APIKeyEntries  *[]config.OpenAICompatibilityAPIKey `json:"api-key-entries"`
 		Models         *[]config.OpenAICompatibilityModel  `json:"models"`
 		Headers        *map[string]string                  `json:"headers"`
@@ -762,6 +763,12 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 			return
 		}
 		entry.BaseURL = trimmed
+	}
+	if body.Value.Azure != nil {
+		entry.Azure = &config.OpenAICompatibilityAzure{
+			Deployment: strings.TrimSpace(body.Value.Azure.Deployment),
+			APIVersion: strings.TrimSpace(body.Value.Azure.APIVersion),
+		}
 	}
 	if body.Value.APIKeyEntries != nil {
 		for keyIndex := range *body.Value.APIKeyEntries {
@@ -1550,6 +1557,10 @@ func normalizeOpenAICompatibilityEntry(entry *config.OpenAICompatibility) {
 	}
 	// Trim base-url; empty base-url indicates provider should be removed by sanitization
 	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+	if entry.Azure != nil {
+		entry.Azure.Deployment = strings.TrimSpace(entry.Azure.Deployment)
+		entry.Azure.APIVersion = strings.TrimSpace(entry.Azure.APIVersion)
+	}
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	existing := make(map[string]struct{}, len(entry.APIKeyEntries))
 	for i := range entry.APIKeyEntries {

--- a/internal/api/handlers/management/config_openai_compat_test.go
+++ b/internal/api/handlers/management/config_openai_compat_test.go
@@ -4,11 +4,58 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
+
+func TestOpenAICompatAzureManagementRoundTrip(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	h := NewHandler(&config.Config{OpenAICompatibility: []config.OpenAICompatibility{{
+		Name:    "azure",
+		BaseURL: "https://resource.openai.azure.com",
+		Azure: &config.OpenAICompatibilityAzure{
+			Deployment: "old-deployment",
+			APIVersion: "2024-10-21",
+		},
+	}}}, writeTestConfigFile(t), nil)
+
+	patchRec := httptest.NewRecorder()
+	patchCtx, _ := gin.CreateTestContext(patchRec)
+	patchCtx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/openai-compatibility", strings.NewReader(`{
+		"name":"azure",
+		"value":{"azure":{"deployment":" new-deployment ","api-version":" 2025-04-01-preview "}}
+	}`))
+	patchCtx.Request.Header.Set("Content-Type", "application/json")
+	h.PatchOpenAICompat(patchCtx)
+	if patchRec.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d, body = %s", patchRec.Code, patchRec.Body.String())
+	}
+
+	getRec := httptest.NewRecorder()
+	getCtx, _ := gin.CreateTestContext(getRec)
+	getCtx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/openai-compatibility", nil)
+	h.GetOpenAICompat(getCtx)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, body = %s", getRec.Code, getRec.Body.String())
+	}
+	var body struct {
+		OpenAICompatibility []config.OpenAICompatibility `json:"openai-compatibility"`
+	}
+	if err := json.Unmarshal(getRec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode GET response: %v", err)
+	}
+	if len(body.OpenAICompatibility) != 1 || body.OpenAICompatibility[0].Azure == nil {
+		t.Fatalf("azure management response = %#v", body.OpenAICompatibility)
+	}
+	azure := body.OpenAICompatibility[0].Azure
+	if azure.Deployment != "new-deployment" || azure.APIVersion != "2025-04-01-preview" {
+		t.Fatalf("azure = %#v", azure)
+	}
+}
 
 func TestGetOpenAICompatIncludesDisableCooling(t *testing.T) {
 	t.Setenv("MANAGEMENT_PASSWORD", "")

--- a/internal/config/config_normalization.go
+++ b/internal/config/config_normalization.go
@@ -113,6 +113,10 @@ func (cfg *Config) SanitizeOpenAICompatibility() {
 		e.Name = strings.TrimSpace(e.Name)
 		e.Prefix = normalizeModelPrefix(e.Prefix)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
+		if e.Azure != nil {
+			e.Azure.Deployment = strings.TrimSpace(e.Azure.Deployment)
+			e.Azure.APIVersion = strings.TrimSpace(e.Azure.APIVersion)
+		}
 		e.Headers = NormalizeHeaders(e.Headers)
 		if e.BaseURL == "" {
 			// Skip providers with no base-url; treated as removed

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -567,6 +567,9 @@ type OpenAICompatibility struct {
 	// APIKeyEntries defines API keys with optional per-key proxy configuration.
 	APIKeyEntries []OpenAICompatibilityAPIKey `yaml:"api-key-entries,omitempty" json:"api-key-entries,omitempty"`
 
+	// Azure enables Azure OpenAI deployment-based Chat Completions requests.
+	Azure *OpenAICompatibilityAzure `yaml:"azure,omitempty" json:"azure,omitempty"`
+
 	// Models defines the model configurations including aliases for routing.
 	Models []OpenAICompatibilityModel `yaml:"models" json:"models"`
 
@@ -575,6 +578,15 @@ type OpenAICompatibility struct {
 
 	// DisableCooling disables auth/model cooldown scheduling for this provider when true.
 	DisableCooling bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
+}
+
+// OpenAICompatibilityAzure configures Azure OpenAI's deployment-based Chat Completions endpoint.
+type OpenAICompatibilityAzure struct {
+	// Deployment is the Azure OpenAI deployment name used in the request path.
+	Deployment string `yaml:"deployment" json:"deployment"`
+
+	// APIVersion is sent as the Azure OpenAI api-version query parameter.
+	APIVersion string `yaml:"api-version" json:"api-version"`
 }
 
 // OpenAICompatibilityAPIKey represents an API key configuration with optional proxy setting.

--- a/internal/config/openai_compat_azure_test.go
+++ b/internal/config/openai_compat_azure_test.go
@@ -1,0 +1,38 @@
+package config
+
+import "testing"
+
+func TestParseConfigBytesNormalizesOpenAICompatibilityAzure(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte(`openai-compatibility:
+  - name: azure
+    base-url: " https://resource.openai.azure.com/ "
+    azure:
+      deployment: " production/chat v1 "
+      api-version: " 2025-04-01-preview "
+    models:
+      - name: upstream-model
+        alias: public-model
+`))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes error: %v", err)
+	}
+	if len(cfg.OpenAICompatibility) != 1 {
+		t.Fatalf("provider count = %d, want 1", len(cfg.OpenAICompatibility))
+	}
+	got := cfg.OpenAICompatibility[0]
+	if got.BaseURL != "https://resource.openai.azure.com/" {
+		t.Fatalf("base-url = %q", got.BaseURL)
+	}
+	if got.Azure == nil {
+		t.Fatal("azure config is nil")
+	}
+	if got.Azure.Deployment != "production/chat v1" {
+		t.Fatalf("deployment = %q", got.Azure.Deployment)
+	}
+	if got.Azure.APIVersion != "2025-04-01-preview" {
+		t.Fatalf("api-version = %q", got.Azure.APIVersion)
+	}
+	if got.Models[0].Name != "upstream-model" || got.Models[0].Alias != "public-model" {
+		t.Fatalf("model mapping = %#v", got.Models[0])
+	}
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -11,6 +11,8 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -55,9 +57,7 @@ func (e *OpenAICompatExecutor) PrepareRequest(req *http.Request, auth *cliproxya
 		return nil
 	}
 	_, apiKey := e.resolveCredentials(auth)
-	if strings.TrimSpace(apiKey) != "" {
-		req.Header.Set("Authorization", "Bearer "+apiKey)
-	}
+	e.applyAuthentication(req, auth, apiKey)
 	var attrs map[string]string
 	if auth != nil {
 		attrs = auth.Attributes
@@ -130,15 +130,16 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	}
 	reporter.SetTranslatedReasoningEffort(translated, to.String())
 
-	url := strings.TrimSuffix(baseURL, "/") + endpoint
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
+	requestURL, err := e.buildRequestURL(auth, baseURL, endpoint)
+	if err != nil {
+		return resp, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, bytes.NewReader(translated))
 	if err != nil {
 		return resp, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	if apiKey != "" {
-		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-	}
+	e.applyAuthentication(httpReq, auth, apiKey)
 	httpReq.Header.Set("User-Agent", "cli-proxy-openai-compat")
 	var attrs map[string]string
 	if auth != nil {
@@ -152,7 +153,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		authType, authValue = auth.AccountInfo()
 	}
 	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
-		URL:       url,
+		URL:       requestURL,
 		Method:    http.MethodPost,
 		Headers:   httpReq.Header.Clone(),
 		Body:      translated,
@@ -329,15 +330,16 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	translated = helps.SetBoolIfDifferent(translated, "stream_options.include_usage", true)
 	reporter.SetTranslatedReasoningEffort(translated, to.String())
 
-	url := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
+	requestURL, err := e.buildRequestURL(auth, baseURL, "/chat/completions")
+	if err != nil {
+		return nil, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, bytes.NewReader(translated))
 	if err != nil {
 		return nil, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	if apiKey != "" {
-		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-	}
+	e.applyAuthentication(httpReq, auth, apiKey)
 	httpReq.Header.Set("User-Agent", "cli-proxy-openai-compat")
 	var attrs map[string]string
 	if auth != nil {
@@ -353,7 +355,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		authType, authValue = auth.AccountInfo()
 	}
 	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
-		URL:       url,
+		URL:       requestURL,
 		Method:    http.MethodPost,
 		Headers:   httpReq.Header.Clone(),
 		Body:      translated,
@@ -745,12 +747,60 @@ func (e *OpenAICompatExecutor) resolveCredentials(auth *cliproxyauth.Auth) (base
 	return
 }
 
+func (e *OpenAICompatExecutor) applyAuthentication(req *http.Request, auth *cliproxyauth.Auth, apiKey string) {
+	if req == nil || strings.TrimSpace(apiKey) == "" {
+		return
+	}
+	compat := e.resolveCompatConfig(auth)
+	if compat != nil && compat.Azure != nil {
+		req.Header.Del("Authorization")
+		req.Header.Set("api-key", apiKey)
+		return
+	}
+	req.Header.Del("api-key")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+}
+
+func (e *OpenAICompatExecutor) buildRequestURL(auth *cliproxyauth.Auth, baseURL, endpoint string) (string, error) {
+	compat := e.resolveCompatConfig(auth)
+	if endpoint != "/chat/completions" || compat == nil || compat.Azure == nil {
+		return strings.TrimSuffix(baseURL, "/") + endpoint, nil
+	}
+
+	deployment := strings.TrimSpace(compat.Azure.Deployment)
+	if deployment == "" {
+		return "", fmt.Errorf("openai compat executor: azure deployment is required")
+	}
+	apiVersion := strings.TrimSpace(compat.Azure.APIVersion)
+	if apiVersion == "" {
+		return "", fmt.Errorf("openai compat executor: azure api-version is required")
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("openai compat executor: invalid azure base URL: %w", err)
+	}
+	basePath := strings.TrimSuffix(u.Path, "/")
+	baseEscapedPath := strings.TrimSuffix(u.EscapedPath(), "/")
+	u.Path = basePath + "/openai/deployments/" + deployment + "/chat/completions"
+	u.RawPath = baseEscapedPath + "/openai/deployments/" + url.PathEscape(deployment) + "/chat/completions"
+	query := u.Query()
+	query.Set("api-version", apiVersion)
+	u.RawQuery = query.Encode()
+	return u.String(), nil
+}
+
 func (e *OpenAICompatExecutor) resolveCompatConfig(auth *cliproxyauth.Auth) *config.OpenAICompatibility {
 	if auth == nil || e.cfg == nil {
 		return nil
 	}
 	candidates := make([]string, 0, 3)
 	if auth.Attributes != nil {
+		if index, err := strconv.Atoi(strings.TrimSpace(auth.Attributes["config_index"])); err == nil && index >= 0 && index < len(e.cfg.OpenAICompatibility) {
+			compat := &e.cfg.OpenAICompatibility[index]
+			if !compat.Disabled {
+				return compat
+			}
+		}
 		if v := strings.TrimSpace(auth.Attributes["compat_name"]); v != "" {
 			candidates = append(candidates, v)
 		}

--- a/internal/runtime/executor/openai_compat_executor_azure_test.go
+++ b/internal/runtime/executor/openai_compat_executor_azure_test.go
@@ -1,0 +1,119 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAICompatExecutorAzureChatCompletions(t *testing.T) {
+	requests := make(chan *http.Request, 2)
+	bodies := make(chan []byte, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		requests <- r.Clone(context.Background())
+		bodies <- body
+		w.Header().Set("Content-Type", "application/json")
+		if gjson.GetBytes(body, "stream").Bool() {
+			_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl_1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n")
+			return
+		}
+		_, _ = io.WriteString(w, `{"id":"chatcmpl_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{OpenAICompatibility: []config.OpenAICompatibility{{
+		Name:    "azure-openai",
+		BaseURL: server.URL + "/gateway?tenant=one",
+		Azure: &config.OpenAICompatibilityAzure{
+			Deployment: "production/chat v1",
+			APIVersion: "2025-04-01 preview",
+		},
+	}}}
+	executor := NewOpenAICompatExecutor("openai-compatible-azure-openai", cfg)
+	auth := &cliproxyauth.Auth{Provider: "openai-compatible-azure-openai", Attributes: map[string]string{
+		"base_url":     server.URL + "/gateway?tenant=one",
+		"api_key":      "azure-secret",
+		"config_index": "0",
+	}}
+	request := cliproxyexecutor.Request{
+		Model:   "upstream-model",
+		Payload: []byte(`{"model":"upstream-model","messages":[{"role":"user","content":"hi"}]}`),
+	}
+	options := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai")}
+
+	if _, err := executor.Execute(context.Background(), auth, request, options); err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	assertAzureOpenAIRequest(t, <-requests, <-bodies)
+
+	options.Stream = true
+	request.Payload = []byte(`{"model":"upstream-model","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+	stream, err := executor.ExecuteStream(context.Background(), auth, request, options)
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	for chunk := range stream.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+	}
+	assertAzureOpenAIRequest(t, <-requests, <-bodies)
+}
+
+func assertAzureOpenAIRequest(t *testing.T, req *http.Request, body []byte) {
+	t.Helper()
+	wantRequestURI := "/gateway/openai/deployments/production%2Fchat%20v1/chat/completions?api-version=2025-04-01+preview&tenant=one"
+	if req.RequestURI != wantRequestURI {
+		t.Fatalf("RequestURI = %q, want %q", req.RequestURI, wantRequestURI)
+	}
+	if got := req.Header.Get("api-key"); got != "azure-secret" {
+		t.Fatalf("api-key = %q, want azure-secret", got)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want empty", got)
+	}
+	if got := gjson.GetBytes(body, "model").String(); got != "upstream-model" {
+		t.Fatalf("request model = %q, want upstream-model", got)
+	}
+	t.Logf("request evidence: %s api-key=%q authorization=%q model=%q", req.RequestURI, req.Header.Get("api-key"), req.Header.Get("Authorization"), gjson.GetBytes(body, "model").String())
+}
+
+func TestOpenAICompatExecutorStandardChatCompletionsRegression(t *testing.T) {
+	requestSeen := make(chan *http.Request, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestSeen <- r.Clone(context.Background())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"chatcmpl_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`)
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatible-standard", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"base_url": server.URL + "/v1", "api_key": "standard-secret"}}
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "standard-model",
+		Payload: []byte(`{"model":"standard-model","messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai")})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	got := <-requestSeen
+	if got.RequestURI != "/v1/chat/completions" {
+		t.Fatalf("RequestURI = %q, want /v1/chat/completions", got.RequestURI)
+	}
+	if authHeader := got.Header.Get("Authorization"); authHeader != "Bearer standard-secret" {
+		t.Fatalf("Authorization = %q, want Bearer standard-secret", authHeader)
+	}
+	if apiKey := got.Header.Get("api-key"); apiKey != "" {
+		t.Fatalf("api-key = %q, want empty", apiKey)
+	}
+}

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -28,6 +28,7 @@ type ClaudeKey = internalconfig.ClaudeKey
 type VertexCompatKey = internalconfig.VertexCompatKey
 type VertexCompatModel = internalconfig.VertexCompatModel
 type OpenAICompatibility = internalconfig.OpenAICompatibility
+type OpenAICompatibilityAzure = internalconfig.OpenAICompatibilityAzure
 type OpenAICompatibilityAPIKey = internalconfig.OpenAICompatibilityAPIKey
 type OpenAICompatibilityModel = internalconfig.OpenAICompatibilityModel
 

--- a/sdk/config/openai_compat_azure_test.go
+++ b/sdk/config/openai_compat_azure_test.go
@@ -1,0 +1,17 @@
+package config
+
+import "testing"
+
+func TestOpenAICompatibilityAzureSDKExposure(t *testing.T) {
+	cfg := Config{OpenAICompatibility: []OpenAICompatibility{{
+		Name:    "azure",
+		BaseURL: "https://resource.openai.azure.com",
+		Azure: &OpenAICompatibilityAzure{
+			Deployment: "deployment-one",
+			APIVersion: "2025-04-01-preview",
+		},
+	}}}
+	if cfg.OpenAICompatibility[0].Azure.Deployment != "deployment-one" {
+		t.Fatalf("deployment = %q", cfg.OpenAICompatibility[0].Azure.Deployment)
+	}
+}


### PR DESCRIPTION
## Summary
- add an optional `azure` mode to `openai-compatibility` with independently configurable deployment and API version
- construct Azure deployment Chat Completions URLs with an escaped deployment path and encoded `api-version`, preserving existing base query parameters
- authenticate Azure requests with `api-key` while retaining Bearer authentication for existing OpenAI-compatible providers
- round-trip Azure settings through normalization, management GET/PATCH/persistence, and the public SDK config aliases
- document a complete Azure OpenAI configuration and add streaming/non-streaming plus non-Azure regressions

Fixes #4268

## Tests
- `go test -v ./internal/runtime/executor -run 'TestOpenAICompatExecutor(Azure|Standard)' -count=1`
- `go test ./internal/config ./internal/api/handlers/management ./sdk/config -count=1`
- `go test ./... -count=1`
- `go build -o /tmp/cliproxyapi-issue-4268 ./cmd/server`

## Manual QA
The credential-free `httptest` driver exercised both non-streaming and streaming request construction through the real executor. Both produced:

```text
/gateway/openai/deployments/production%2Fchat%20v1/chat/completions?api-version=2025-04-01+preview&tenant=one
api-key="azure-secret"
authorization=""
model="upstream-model"
```

The paired standard-provider regression produced `/v1/chat/completions`, `Authorization: Bearer standard-secret`, and no `api-key` header.

## Known risks
- Azure mode is intentionally scoped to Chat Completions. Existing image and Responses Compact endpoint construction remains unchanged.
- No live Azure credentials were used; request construction and transport behavior were validated against a local HTTP server.
