### PR TITLE
fix(proxy): classify canceled and timed-out upstream requests

### DIFF
--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -302,9 +302,9 @@ func (s *Server) codexAlphaSearch(c *gin.Context) {
 		selected, err = s.handlers.AuthManager.SelectAuthByKind(ctx, "codex", selectionModel, auth.AuthKindOAuth, selectionOpts)
 	}
 	if err != nil {
-		status := http.StatusServiceUnavailable
-		if statusError, ok := err.(interface{ StatusCode() int }); ok && statusError.StatusCode() > 0 {
-			status = statusError.StatusCode()
+		status := coreexecutor.StatusCodeFromError(err)
+		if status == 0 {
+			status = http.StatusServiceUnavailable
 		}
 		for _, value := range auth.SafeResponseHeaders(err).Values("Retry-After") {
 			c.Writer.Header().Add("Retry-After", value)
@@ -381,7 +381,7 @@ func (s *Server) codexAlphaSearch(c *gin.Context) {
 		if selection != nil {
 			selection.End("attempt_canceled")
 		}
-		c.JSON(http.StatusRequestTimeout, gin.H{"error": errCtx.Error()})
+		c.JSON(coreexecutor.StatusCodeFromError(errCtx), gin.H{"error": errCtx.Error()})
 		return
 	}
 	resp, err := s.handlers.AuthManager.HttpRequest(ctx, selected, req)
@@ -390,7 +390,11 @@ func (s *Server) codexAlphaSearch(c *gin.Context) {
 			selection.End("request_failed")
 		}
 		helps.RecordAPIResponseError(ctx, s.cfg, err)
-		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		status := coreexecutor.StatusCodeFromError(err)
+		if status == 0 {
+			status = http.StatusBadGateway
+		}
+		c.JSON(status, gin.H{"error": err.Error()})
 		return
 	}
 	closeResponseBody := func() error {
@@ -414,7 +418,11 @@ func (s *Server) codexAlphaSearch(c *gin.Context) {
 	upstreamBody, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, s.cfg, err)
-		c.JSON(http.StatusBadGateway, gin.H{"error": "Failed to read Codex search response"})
+		status := coreexecutor.StatusCodeFromError(err)
+		if status == 0 {
+			status = http.StatusBadGateway
+		}
+		c.JSON(status, gin.H{"error": "Failed to read Codex search response"})
 		return
 	}
 	helps.AppendAPIResponseChunk(ctx, s.cfg, upstreamBody)

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -3,7 +3,6 @@ package helps
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +15,7 @@ import (
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -286,10 +286,7 @@ func failFromErrors(errs ...error) usage.Failure {
 		fail := usage.Failure{
 			Body: strings.TrimSpace(err.Error()),
 		}
-		var se interface{ StatusCode() int }
-		if errors.As(err, &se) && se != nil {
-			fail.StatusCode = se.StatusCode()
-		}
+		fail.StatusCode = cliproxyexecutor.StatusCodeFromError(err)
 		return fail
 	}
 	return usage.Failure{}

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -2,6 +2,7 @@ package helps
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -10,6 +11,24 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 )
+
+func TestFailFromErrorsClassifiesContextErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{name: "canceled", err: fmt.Errorf("Post upstream: %w", context.Canceled), wantStatus: 499},
+		{name: "deadline exceeded", err: fmt.Errorf("Post upstream: %w", context.DeadlineExceeded), wantStatus: http.StatusGatewayTimeout},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := failFromErrors(test.err).StatusCode; got != test.wantStatus {
+				t.Fatalf("failFromErrors() status = %d, want %d", got, test.wantStatus)
+			}
+		})
+	}
+}
 
 func TestParseOpenAIUsageChatCompletions(t *testing.T) {
 	data := []byte(`{"usage":{"prompt_tokens":10,"completion_tokens":6,"total_tokens":16,"prompt_tokens_details":{"cached_tokens":4},"completion_tokens_details":{"reasoning_tokens":5}}}`)

--- a/sdk/api/handlers/handlers_error_response_test.go
+++ b/sdk/api/handlers/handlers_error_response_test.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -164,6 +166,32 @@ func TestWriteErrorResponse_AddonHeadersEnabled(t *testing.T) {
 	}
 	if got := recorder.Header().Get("Access-Control-Expose-Headers"); got != "x-cpa-trace-id" {
 		t.Fatalf("Access-Control-Expose-Headers = %q, want CPA value", got)
+	}
+}
+
+type wrappedStatusError struct {
+	status int
+}
+
+func (e wrappedStatusError) Error() string   { return http.StatusText(e.status) }
+func (e wrappedStatusError) StatusCode() int { return e.status }
+
+func TestExecutionErrorMessageClassifiesContextErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{name: "canceled", err: fmt.Errorf("upstream request: %w", context.Canceled), wantStatus: 499},
+		{name: "deadline exceeded", err: fmt.Errorf("upstream request: %w", context.DeadlineExceeded), wantStatus: http.StatusGatewayTimeout},
+		{name: "custom status takes precedence", err: fmt.Errorf("upstream request: %w", wrappedStatusError{status: http.StatusTeapot}), wantStatus: http.StatusTeapot},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := executionErrorMessage(test.err).StatusCode; got != test.wantStatus {
+				t.Fatalf("executionErrorMessage() status = %d, want %d", got, test.wantStatus)
+			}
+		})
 	}
 }
 

--- a/sdk/api/handlers/handlers_errors.go
+++ b/sdk/api/handlers/handlers_errors.go
@@ -10,19 +10,12 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"golang.org/x/net/context"
 )
 
 func statusFromError(err error) int {
-	if err == nil {
-		return 0
-	}
-	if se, ok := err.(interface{ StatusCode() int }); ok && se != nil {
-		if code := se.StatusCode(); code > 0 {
-			return code
-		}
-	}
-	return 0
+	return coreexecutor.StatusCodeFromError(err)
 }
 
 func isAuthSelectionUnavailable(err error) bool {

--- a/sdk/api/handlers/handlers_execution.go
+++ b/sdk/api/handlers/handlers_execution.go
@@ -302,11 +302,9 @@ func executionErrorMessage(err error) *interfaces.ErrorMessage {
 			Headers:        terminated.ResponseHeaders(),
 		}
 	}
-	status := http.StatusInternalServerError
-	if se, ok := err.(interface{ StatusCode() int }); ok && se != nil {
-		if code := se.StatusCode(); code > 0 {
-			status = code
-		}
+	status := coreexecutor.StatusCodeFromError(err)
+	if status == 0 {
+		status = http.StatusInternalServerError
 	}
 	var addon http.Header
 	if he, ok := err.(interface{ Headers() http.Header }); ok && he != nil {

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1107,17 +1107,7 @@ func errorString(err error) string {
 }
 
 func statusCodeFromError(err error) int {
-	if err == nil {
-		return 0
-	}
-	type statusCoder interface {
-		StatusCode() int
-	}
-	var sc statusCoder
-	if errors.As(err, &sc) && sc != nil {
-		return sc.StatusCode()
-	}
-	return 0
+	return cliproxyexecutor.StatusCodeFromError(err)
 }
 
 func isRequestScopedError(err error) bool {
@@ -1142,7 +1132,8 @@ func resultErrorFromError(err error) *Error {
 	if resultErr.HTTPStatus == 0 {
 		resultErr.HTTPStatus = statusCodeFromError(err)
 	}
-	if isRequestScopedError(err) || isRequestInvalidError(err) {
+	_, contextError := cliproxyexecutor.ContextErrorStatus(err)
+	if contextError || isRequestScopedError(err) || isRequestInvalidError(err) {
 		resultErr.Code = requestScopedErrorCode
 	}
 	return resultErr

--- a/sdk/cliproxy/auth/context_error_test.go
+++ b/sdk/cliproxy/auth/context_error_test.go
@@ -1,0 +1,59 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestResultErrorFromErrorClassifiesContextErrorsAsRequestScoped(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{name: "canceled", err: fmt.Errorf("Post upstream: %w", context.Canceled), wantStatus: 499},
+		{name: "deadline exceeded", err: fmt.Errorf("Post upstream: %w", context.DeadlineExceeded), wantStatus: http.StatusGatewayTimeout},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := resultErrorFromError(test.err)
+			if got.HTTPStatus != test.wantStatus {
+				t.Fatalf("HTTPStatus = %d, want %d", got.HTTPStatus, test.wantStatus)
+			}
+			if !got.IsRequestScoped() {
+				t.Fatalf("IsRequestScoped() = false, want true: %+v", got)
+			}
+		})
+	}
+}
+
+func TestMarkResultDoesNotCoolDownContextErrors(t *testing.T) {
+	for _, err := range []error{context.Canceled, context.DeadlineExceeded} {
+		manager := NewManager(nil, nil, nil)
+		auth := &Auth{ID: "context-error-auth", Provider: "openai-compat"}
+		if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+			t.Fatalf("Register() error = %v", errRegister)
+		}
+
+		manager.MarkResult(context.Background(), Result{
+			AuthID:   auth.ID,
+			Provider: auth.Provider,
+			Model:    "test-model",
+			Success:  false,
+			Error:    resultErrorFromError(err),
+		})
+
+		updated, ok := manager.GetByID(auth.ID)
+		if !ok || updated == nil {
+			t.Fatal("GetByID() did not return registered auth")
+		}
+		if state := updated.ModelStates["test-model"]; state != nil {
+			t.Fatalf("context error created cooldown model state: %+v", state)
+		}
+		if updated.Unavailable || !updated.NextRetryAfter.IsZero() {
+			t.Fatalf("context error cooled auth: unavailable=%v nextRetryAfter=%v", updated.Unavailable, updated.NextRetryAfter)
+		}
+	}
+}

--- a/sdk/cliproxy/executor/errors.go
+++ b/sdk/cliproxy/executor/errors.go
@@ -1,0 +1,42 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"net/http"
+)
+
+// StatusClientClosedRequest is the de facto HTTP status used when the client
+// closes a request before the server can produce a response.
+const StatusClientClosedRequest = 499
+
+// StatusCodeFromError returns an explicit StatusError code when present, then
+// classifies context cancellation and deadline errors that may be wrapped by
+// HTTP transports. Explicit status errors take precedence over context causes.
+func StatusCodeFromError(err error) int {
+	if err == nil {
+		return 0
+	}
+	var statusErr StatusError
+	if errors.As(err, &statusErr) && statusErr != nil {
+		if status := statusErr.StatusCode(); status > 0 {
+			return status
+		}
+	}
+	status, _ := ContextErrorStatus(err)
+	return status
+}
+
+// ContextErrorStatus classifies context termination errors for downstream HTTP
+// responses. The boolean reports whether err contains a recognized context
+// cause.
+func ContextErrorStatus(err error) (int, bool) {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return StatusClientClosedRequest, true
+	case errors.Is(err, context.DeadlineExceeded):
+		return http.StatusGatewayTimeout, true
+	default:
+		return 0, false
+	}
+}


### PR DESCRIPTION
## Summary

- add one shared error classifier that preserves explicit/wrapped `StatusCode()` errors, then maps wrapped `context.Canceled` to HTTP 499 and `context.DeadlineExceeded` to HTTP 504;
- use it in the central API execution/stream paths, Codex alpha search route, auth result conversion, and upstream usage failure accounting;
- mark context termination results request-scoped so they remain observable but do not cool down healthy credentials/models.

Fixes #4601

## Root cause

Provider transports return raw or wrapped context errors (commonly `*url.Error`). The handler paths defaulted statusless errors to 500/503, while usage accounting recorded status 0. Auth result conversion also treated them as ordinary recoverable upstream failures, creating a cooldown despite the credential remaining healthy.

## Tests

Regression tests were added first and failed on the unpatched tree with:

- handler statuses `500`, expected `499` / `504`;
- usage status `0`, expected `499` / `504`;
- auth result status `0` and a one-minute model cooldown;
- wrapped custom status `500`, expected the explicit status.

Passing verification on this commit:

```text
go test ./sdk/api/handlers ./internal/runtime/executor/helps ./sdk/cliproxy/auth \
  -run 'Test(ExecutionErrorMessageClassifiesContextErrors|FailFromErrorsClassifiesContextErrors|ResultErrorFromErrorClassifiesContextErrorsAsRequestScoped|MarkResultDoesNotCoolDownContextErrors)$' -count=1
PASS

go test ./sdk/cliproxy/executor ./sdk/cliproxy/auth ./sdk/api/handlers \
  ./internal/runtime/executor/helps ./internal/runtime/executor ./internal/api -count=1
PASS

go build -o /tmp/cliproxyapi-issue-4601 ./cmd/server
PASS

git diff --check
PASS
```

## Manual QA

A minimal `httptest.Server` driver issued real `http.Client.Do` requests, waited until each request reached the server, and then canceled the client context or allowed its deadline to expire. Both returned real `*url.Error` values:

```text
canceled: type=*url.Error errors.Is=true status=499 error="Post \"http://127.0.0.1:59621\": context canceled"
deadline: type=*url.Error errors.Is=true status=504 error="Post \"http://127.0.0.1:59623\": context deadline exceeded"
```

## Risks

- 499 is non-standard but is the established client-closed-request convention requested by the issue.
- Deadline failures now remain visible as 504 while being availability-neutral. This deliberately avoids credential cooldown because a context deadline describes the request boundary, not credential health.
- Explicit `StatusCode()` errors always take precedence, including when wrapped, preserving provider/plugin-defined behavior.
