### PR TITLE
fix(security): write credential and config files with 0600

### DIFF
--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 	log "github.com/sirupsen/logrus"
@@ -93,7 +94,7 @@ func (h *Handler) GetLatestVersion(c *gin.Context) {
 
 func WriteConfig(path string, data []byte) error {
 	data = config.NormalizeCommentIndentation(data)
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	f, err := misc.CreateSecretFile(path)
 	if err != nil {
 		return err
 	}

--- a/internal/auth/claude/token.go
+++ b/internal/auth/claude/token.go
@@ -67,7 +67,7 @@ func (ts *ClaudeTokenStorage) SaveTokenToFile(authFilePath string) error {
 	}
 
 	// Create the token file
-	f, err := os.Create(authFilePath)
+	f, err := misc.CreateSecretFile(authFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}

--- a/internal/auth/codex/token.go
+++ b/internal/auth/codex/token.go
@@ -60,7 +60,7 @@ func (ts *CodexTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	f, err := os.Create(authFilePath)
+	f, err := misc.CreateSecretFile(authFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}

--- a/internal/auth/kimi/token.go
+++ b/internal/auth/kimi/token.go
@@ -87,7 +87,7 @@ func (ts *KimiTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	f, err := os.Create(authFilePath)
+	f, err := misc.CreateSecretFile(authFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}

--- a/internal/auth/vertex/vertex_credentials.go
+++ b/internal/auth/vertex/vertex_credentials.go
@@ -52,7 +52,7 @@ func (s *VertexCredentialStorage) SaveTokenToFile(authFilePath string) error {
 	if err := os.MkdirAll(filepath.Dir(authFilePath), 0o700); err != nil {
 		return fmt.Errorf("vertex credential: create directory failed: %w", err)
 	}
-	f, err := os.Create(authFilePath)
+	f, err := misc.CreateSecretFile(authFilePath)
 	if err != nil {
 		return fmt.Errorf("vertex credential: create file failed: %w", err)
 	}

--- a/internal/auth/xai/token.go
+++ b/internal/auth/xai/token.go
@@ -45,7 +45,7 @@ func (ts *TokenStorage) SaveTokenToFile(authFilePath string) error {
 	if errMkdirAll := os.MkdirAll(filepath.Dir(authFilePath), 0o700); errMkdirAll != nil {
 		return fmt.Errorf("xai token storage: create directory: %w", errMkdirAll)
 	}
-	file, err := os.Create(authFilePath)
+	file, err := misc.CreateSecretFile(authFilePath)
 	if err != nil {
 		return fmt.Errorf("xai token storage: create token file: %w", err)
 	}

--- a/internal/config/config_yaml.go
+++ b/internal/config/config_yaml.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	"gopkg.in/yaml.v3"
 )
 
@@ -61,7 +62,7 @@ func SaveConfigPreserveComments(configFile string, cfg *Config) error {
 	normalizeCollectionNodeStyles(original.Content[0])
 
 	// Write back.
-	f, err := os.Create(configFile)
+	f, err := misc.CreateSecretFile(configFile)
 	if err != nil {
 		return err
 	}
@@ -113,7 +114,7 @@ func SaveConfigPreserveCommentsUpdateNestedScalar(configFile string, path []stri
 			node = next
 		}
 	}
-	f, err := os.Create(configFile)
+	f, err := misc.CreateSecretFile(configFile)
 	if err != nil {
 		return err
 	}

--- a/internal/misc/credentials.go
+++ b/internal/misc/credentials.go
@@ -3,6 +3,7 @@ package misc
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -11,6 +12,26 @@ import (
 
 // Separator used to visually group related log lines.
 var credentialSeparator = strings.Repeat("-", 67)
+
+// SecretFileMode is the permission used for files holding secrets (OAuth tokens,
+// API keys, management keys). Only the owning user may read or write them.
+const SecretFileMode os.FileMode = 0o600
+
+// CreateSecretFile truncates or creates path with SecretFileMode. Unlike os.Create
+// it never depends on the process umask, and it also tightens the mode of files
+// that already exist with wider permissions.
+func CreateSecretFile(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, SecretFileMode)
+	if err != nil {
+		return nil, err
+	}
+	// O_CREATE only applies the mode to newly created files; re-apply it so an
+	// existing world-readable file gets fixed on the next write.
+	if err = f.Chmod(SecretFileMode); err != nil && !os.IsPermission(err) {
+		log.Debugf("failed to tighten permissions on %s: %v", path, err)
+	}
+	return f, nil
+}
 
 // LogSavingCredentials emits a consistent log message when persisting auth material.
 func LogSavingCredentials(path string) {

--- a/internal/misc/credentials_test.go
+++ b/internal/misc/credentials_test.go
@@ -1,0 +1,56 @@
+//go:build unix
+
+package misc
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestCreateSecretFile checks that secret files end up owner-only regardless of
+// the process umask, and that a file already on disk with a wider mode is
+// tightened rather than left as-is.
+func TestCreateSecretFile(t *testing.T) {
+	defer syscall.Umask(syscall.Umask(0o002))
+	dir := t.TempDir()
+
+	cases := []struct {
+		name    string
+		prepare os.FileMode // 0 means the file does not exist yet
+	}{
+		{name: "fresh"},
+		{name: "existing-group-readable", prepare: 0o664},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, tc.name+".json")
+			if tc.prepare != 0 {
+				if err := os.WriteFile(path, []byte("{}"), tc.prepare); err != nil {
+					t.Fatalf("prepare: %v", err)
+				}
+				if err := os.Chmod(path, tc.prepare); err != nil {
+					t.Fatalf("prepare chmod: %v", err)
+				}
+			}
+
+			f, err := CreateSecretFile(path)
+			if err != nil {
+				t.Fatalf("CreateSecretFile: %v", err)
+			}
+			if err = f.Close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("stat: %v", err)
+			}
+			if got := info.Mode().Perm(); got != SecretFileMode {
+				t.Fatalf("mode = %o, want %o", got, SecretFileMode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #4672.

## Problem

`os.Create` requests mode `0666` and defers to the process umask, so auth token files and `config.yaml` land as `-rw-rw-r--` (umask 002) or `-rw-r--r--` (umask 022) — readable by every local user. These files hold OAuth refresh tokens, the `api-keys` list, and the `remote-management.secret-key` hash.

It is also inconsistent within the codebase: the `os.MkdirAll(..., 0700)` right above each write, `sdk/auth/filestore.go`, and `internal/store/*` all already use owner-only modes.

## Change

Add `misc.CreateSecretFile`, a drop-in replacement for `os.Create` for secret-bearing files, and use it in the five token stores plus the three config writers.

Two details worth reviewing:

- **Explicit `Chmod` after open.** `O_CREATE` only applies the mode to newly created files. Token files are rewritten in place on every refresh, so without the `Chmod` an existing deployment would keep its world-readable files indefinitely — the fix would only help fresh installs. `os.IsPermission` errors are tolerated so a file owned by another user (e.g. a root-managed config) still writes rather than hard-failing.
- **Placement in `internal/misc`.** That package has no internal imports, so `internal/config` can use it without an import cycle, and the auth packages already import it for `LogSavingCredentials`.

## Verification

```
go build ./...
go vet ./internal/misc/ ./internal/auth/... ./internal/config/ ./internal/api/handlers/management/
go test ./internal/misc/ -run TestCreateSecretFile
```

All clean. The added test runs under `umask 002` and covers both paths: a fresh file is created `0600`, and a pre-existing `0664` file is tightened to `0600`. It is `//go:build unix` since `syscall.Umask` is not available on Windows.

I have not exercised the full OAuth login flow end to end — the change is confined to how the file handle is opened, and the callers are otherwise untouched.