### PR TITLE
feat(routing): quota-aware selection, per-subagent session affinity, 529/headerless-429 failover

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -212,6 +212,11 @@ routing:
   session-affinity: false # default: false
   # How long session-to-auth bindings are retained. Default: 1h
   session-affinity-ttl: "1h"
+  # How the session identity used for affinity is derived. Default: "default".
+  # "content-hash" folds a hash of the first message contents into Claude Code
+  # session IDs, so subagents sharing a parent session_id but carrying different
+  # prompts bind to distinct credentials while each conversation stays pinned.
+  session-id-mode: "default" # default, content-hash
 
 # Codex provider behavior.
 codex:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -200,10 +200,13 @@ quota-exceeded:
 
 # Routing strategy for selecting credentials when multiple match.
 routing:
-  strategy: "round-robin" # round-robin (default), weighted-round-robin, fill-first
+  strategy: "round-robin" # round-robin (default), weighted-round-robin, fill-first, quota-aware
   # weighted-round-robin uses each credential's integer weight (default 1, maximum 1,000,000).
   # Non-positive weights exclude the credential while this strategy is active.
   # For OAuth/file credentials, add a top-level numeric "weight" field to the auth JSON.
+  # quota-aware polls the Anthropic OAuth usage endpoint in the background and picks
+  # Claude credentials proportionally to their remaining quota headroom; credentials with
+  # unknown quota fall back to round-robin, and exhausted ones are excluded.
   # Enable universal session-sticky routing for all clients.
   # Explicit Claude Code, Codex, OpenCode, and pi session headers are preferred,
   # followed by prompt_cache_key, Responses conversation IDs, legacy body IDs,

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -288,6 +288,8 @@ func normalizeRoutingStrategy(strategy string) (string, bool) {
 		return "weighted-round-robin", true
 	case "fill-first", "fillfirst", "ff":
 		return "fill-first", true
+	case "quota-aware", "quotaaware", "qa":
+		return "quota-aware", true
 	default:
 		return "", false
 	}

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -203,7 +203,8 @@ type QuotaExceeded struct {
 // RoutingConfig configures how credentials are selected for requests.
 type RoutingConfig struct {
 	// Strategy selects the credential selection strategy.
-	// Supported values: "round-robin" (default), "weighted-round-robin", "fill-first".
+	// Supported values: "round-robin" (default), "weighted-round-robin",
+	// "fill-first", "quota-aware".
 	Strategy string `yaml:"strategy,omitempty" json:"strategy,omitempty"`
 
 	// SessionAffinity enables universal session-sticky routing for all clients.

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -216,6 +216,13 @@ type RoutingConfig struct {
 	// SessionAffinityTTL specifies how long session-to-auth bindings are retained.
 	// Default: 1h. Accepts duration strings like "30m", "1h", "2h30m".
 	SessionAffinityTTL string `yaml:"session-affinity-ttl,omitempty" json:"session-affinity-ttl,omitempty"`
+
+	// SessionIDMode controls how the session identity used for affinity is derived.
+	// "" or "default": current behavior (Claude Code session_id alone).
+	// "content-hash": combine the Claude Code session_id with a hash of the first
+	// message contents, so subagents that share a parent session_id but differ in
+	// prompts bind to distinct auths while each conversation stays pinned.
+	SessionIDMode string `yaml:"session-id-mode,omitempty" json:"session-id-mode,omitempty"`
 }
 
 // OAuthModelAlias defines a model ID alias for a specific channel.

--- a/sdk/cliproxy/auth/conductor_529_failover_test.go
+++ b/sdk/cliproxy/auth/conductor_529_failover_test.go
@@ -1,0 +1,171 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// overloadedError mimics the Claude executor's statusErr for a 529
+// overloaded_error: it exposes a status code but no Retry-After.
+type overloadedError struct {
+	code       int
+	msg        string
+	retryAfter *time.Duration
+}
+
+func (e overloadedError) Error() string              { return e.msg }
+func (e overloadedError) StatusCode() int            { return e.code }
+func (e overloadedError) RetryAfter() *time.Duration { return e.retryAfter }
+
+// withTransientCooldownDefault pins the transient-error cooldown to the legacy
+// default so a sibling test that disabled it cannot leak into these assertions.
+func withTransientCooldownDefault(t *testing.T) {
+	t.Helper()
+	prev := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(0)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prev) })
+}
+
+func newRetryManager(t *testing.T, provider string) *Manager {
+	t.Helper()
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(3, 30*time.Second, 0)
+	if _, errRegister := m.Register(WithSkipPersist(context.Background()), &Auth{
+		ID:       "auth-529",
+		Provider: provider,
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	return m
+}
+
+func TestShouldRetryAfterError_OverloadedIsRetryableWithDefaultWait(t *testing.T) {
+	m := newRetryManager(t, "claude")
+	_, _, maxWait := m.retrySettings()
+
+	errOverloaded := overloadedError{code: statusOverloaded, msg: `{"type":"error","error":{"type":"overloaded_error"}}`}
+	wait, shouldRetry := m.shouldRetryAfterError(errOverloaded, 0, []string{"claude"}, "claude-opus-4", maxWait)
+	if !shouldRetry {
+		t.Fatalf("shouldRetryAfterError(529) = (%v, false), want retry", wait)
+	}
+	if wait != defaultRetryWaitWithoutRetryAfter {
+		t.Fatalf("wait = %v, want %v", wait, defaultRetryWaitWithoutRetryAfter)
+	}
+}
+
+func TestShouldRetryAfterError_TooManyRequestsWithoutRetryAfterUsesDefaultWait(t *testing.T) {
+	m := newRetryManager(t, "claude")
+	_, _, maxWait := m.retrySettings()
+
+	// *Error carries a status but never a Retry-After, matching Anthropic's
+	// headerless OAuth 429.
+	errQuota := &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate_limit_error"}
+	wait, shouldRetry := m.shouldRetryAfterError(errQuota, 0, []string{"claude"}, "claude-opus-4", maxWait)
+	if !shouldRetry {
+		t.Fatalf("shouldRetryAfterError(429, no Retry-After) = (%v, false), want retry", wait)
+	}
+	if wait != defaultRetryWaitWithoutRetryAfter {
+		t.Fatalf("wait = %v, want %v", wait, defaultRetryWaitWithoutRetryAfter)
+	}
+}
+
+func TestShouldRetryAfterError_HonoursRetryAfterWhenPresent(t *testing.T) {
+	m := newRetryManager(t, "claude")
+	_, _, maxWait := m.retrySettings()
+
+	retryAfter := 5 * time.Second
+	errQuota := overloadedError{code: http.StatusTooManyRequests, msg: "rate_limit_error", retryAfter: &retryAfter}
+	wait, shouldRetry := m.shouldRetryAfterError(errQuota, 0, []string{"claude"}, "claude-opus-4", maxWait)
+	if !shouldRetry {
+		t.Fatalf("shouldRetryAfterError(429 with Retry-After) = (%v, false), want retry", wait)
+	}
+	if wait != retryAfter {
+		t.Fatalf("wait = %v, want %v", wait, retryAfter)
+	}
+
+	// A Retry-After beyond the ceiling is still refused.
+	tooLong := maxWait + time.Second
+	errLong := overloadedError{code: http.StatusTooManyRequests, msg: "rate_limit_error", retryAfter: &tooLong}
+	if wait, shouldRetry = m.shouldRetryAfterError(errLong, 0, []string{"claude"}, "claude-opus-4", maxWait); shouldRetry {
+		t.Fatalf("shouldRetryAfterError(Retry-After > maxWait) = (%v, true), want no retry", wait)
+	}
+}
+
+func TestMarkResultOverloadedSetsTransientCooldown(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+	withTransientCooldownDefault(t)
+
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-overloaded",
+		Provider: "claude",
+		Metadata: map[string]any{"type": "claude"},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("Register returned error: %v", errRegister)
+	}
+
+	model := "claude-opus-4"
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: "claude",
+		Model:    model,
+		Success:  false,
+		Error: &Error{
+			Code:       "overloaded_error",
+			Message:    "Overloaded",
+			Retryable:  true,
+			HTTPStatus: statusOverloaded,
+		},
+	})
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil || updated.ModelStates[model] == nil {
+		t.Fatalf("expected model state after 529 failure")
+	}
+	state := updated.ModelStates[model]
+	if state.NextRetryAfter.IsZero() {
+		t.Fatalf("NextRetryAfter is zero after 529; want a transient cooldown")
+	}
+	if !state.NextRetryAfter.After(time.Now()) {
+		t.Fatalf("NextRetryAfter = %v, want a deadline in the future", state.NextRetryAfter)
+	}
+	if state.Quota.Exceeded {
+		t.Fatalf("529 marked the model quota-exceeded; want transient handling only")
+	}
+}
+
+func TestApplyAuthFailureStateOverloadedSetsTransientCooldown(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+	withTransientCooldownDefault(t)
+
+	now := time.Now()
+	auth := &Auth{ID: "auth-overloaded-scoped", Provider: "claude"}
+	applyAuthFailureState(auth, &Error{
+		Code:       "overloaded_error",
+		Message:    "Overloaded",
+		HTTPStatus: statusOverloaded,
+	}, nil, now, false)
+
+	if !auth.NextRetryAfter.After(now) {
+		t.Fatalf("NextRetryAfter = %v, want a deadline after %v", auth.NextRetryAfter, now)
+	}
+	if auth.Quota.Exceeded {
+		t.Fatalf("529 marked the auth quota-exceeded; want transient handling only")
+	}
+	if auth.StatusMessage != "transient upstream error" {
+		t.Fatalf("StatusMessage = %q, want %q", auth.StatusMessage, "transient upstream error")
+	}
+}
+
+func TestStatusCodeFromErrorPreservesOverloaded(t *testing.T) {
+	errOverloaded := overloadedError{code: statusOverloaded, msg: "Overloaded"}
+	if got := statusCodeFromError(errOverloaded); got != statusOverloaded {
+		t.Fatalf("statusCodeFromError() = %d, want %d", got, statusOverloaded)
+	}
+	if isRequestInvalidError(errOverloaded) {
+		t.Fatalf("529 classified as request-invalid; it must stay credential-scoped")
+	}
+}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -17,6 +17,17 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
+// statusOverloaded is the non-standard HTTP status Anthropic returns for
+// overloaded_error. net/http has no constant for it.
+const statusOverloaded = 529
+
+// defaultRetryWaitWithoutRetryAfter is the wait applied to a retryable upstream
+// rejection that carries no usable Retry-After header. Anthropic's OAuth 429 and
+// 529 responses omit both Retry-After and the anthropic-ratelimit-* headers, so
+// without a default the request would fail on its first attempt instead of
+// rolling over to another credential.
+const defaultRetryWaitWithoutRetryAfter = 2 * time.Second
+
 var quotaCooldownDisabled atomic.Bool
 
 var transientErrorCooldownSeconds atomic.Int64
@@ -828,7 +839,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								shouldSuspendModel = true
 								setModelQuota = true
 							}
-						case 408, 500, 502, 503, 504:
+						case 408, 500, 502, 503, 504, statusOverloaded:
 							state.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
 							state.Unavailable = !state.NextRetryAfter.IsZero()
 						default:
@@ -1655,7 +1666,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		}
 		auth.Quota.NextRecoverAt = next
 		auth.NextRetryAfter = next
-	case 408, 500, 502, 503, 504:
+	case 408, 500, 502, 503, 504, statusOverloaded:
 		auth.StatusMessage = "transient upstream error"
 		auth.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
 		auth.Unavailable = !auth.NextRetryAfter.IsZero()

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -760,14 +760,24 @@ func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []stri
 		}
 		return wait, true
 	}
-	if status != http.StatusTooManyRequests {
+	if status != http.StatusTooManyRequests && status != statusOverloaded {
 		return 0, false
 	}
 	if !m.retryAllowed(attempt, providers) {
 		return 0, false
 	}
+	// Anthropic's 529 overloaded_error and its OAuth 429s carry no Retry-After.
+	// Fall back to a short fixed wait so the request rolls over to another
+	// credential instead of failing on the first attempt.
 	retryAfter := retryAfterFromError(err)
-	if retryAfter == nil || *retryAfter <= 0 || *retryAfter > maxWait {
+	if retryAfter == nil || *retryAfter <= 0 {
+		wait = defaultRetryWaitWithoutRetryAfter
+		if wait > maxWait {
+			wait = maxWait
+		}
+		return wait, true
+	}
+	if *retryAfter > maxWait {
 		return 0, false
 	}
 	return *retryAfter, true

--- a/sdk/cliproxy/auth/quota_selector.go
+++ b/sdk/cliproxy/auth/quota_selector.go
@@ -21,8 +21,12 @@ const (
 	// Retry-After: 0 at 4 accounts x 60s from one IP), and quota percentages
 	// move slowly. Poll gently and tolerate a couple of missed cycles before
 	// treating a snapshot as unknown.
-	quotaRefreshInterval    = 5 * time.Minute
-	quotaStaleAfter         = 30 * time.Minute
+	quotaRefreshInterval = 5 * time.Minute
+	quotaStaleAfter      = 30 * time.Minute
+	// quotaFetchTimeout bounds each background poll via a stop-cancellable
+	// request context (not an http.Client timeout): it keeps a wedged poll
+	// from stalling the refresh loop, and Stop() aborts in-flight requests.
+	// Never on a request path — background credential-quota polling only.
 	quotaFetchTimeout       = 15 * time.Second
 	quotaExhaustedThreshold = 95.0
 
@@ -43,6 +47,13 @@ const (
 	// quotaPollSpacing staggers per-account fetches inside one poll cycle;
 	// the endpoint rate-limits bursts from a single IP.
 	quotaPollSpacing = 3 * time.Second
+
+	// quotaTargetExpiry drops poll targets whose auth has not been offered to
+	// Pick recently (credential removed or token rotated out). Long enough to
+	// ride out cooldown windows where an auth is temporarily filtered from the
+	// candidate slice, short enough that deleted credentials stop consuming
+	// the shared usage-endpoint allowance after a few cycles.
+	quotaTargetExpiry = 15 * time.Minute
 )
 
 // quotaSnapshot captures the last known usage percentages for one auth.
@@ -56,9 +67,13 @@ type quotaSnapshot struct {
 }
 
 // quotaPollTarget is the minimal auth info the background poller needs.
+// lastSeen records when the auth was last offered to Pick, so targets whose
+// credential was removed or rotated out age out instead of being polled
+// forever.
 type quotaPollTarget struct {
-	id    string
-	token string
+	id       string
+	token    string
+	lastSeen time.Time
 }
 
 // QuotaAwareSelector picks auths proportionally to their remaining Anthropic
@@ -90,14 +105,11 @@ type QuotaAwareSelector struct {
 // poller starts lazily on the first Pick and stops via Stop.
 func NewQuotaAwareSelector() *QuotaAwareSelector {
 	return &QuotaAwareSelector{
-		fallback: &RoundRobinSelector{},
-		quotas:   make(map[string]quotaSnapshot),
-		targets:  make(map[string]quotaPollTarget),
-		stopCh:   make(chan struct{}),
-		// This client only fetches credential quota metadata on a background
-		// goroutine, never on a request path, so a bounded timeout is safe and
-		// keeps a wedged poll from stalling the refresh loop indefinitely.
-		httpClient: &http.Client{Timeout: quotaFetchTimeout},
+		fallback:   &RoundRobinSelector{},
+		quotas:     make(map[string]quotaSnapshot),
+		targets:    make(map[string]quotaPollTarget),
+		stopCh:     make(chan struct{}),
+		httpClient: &http.Client{},
 		randFloat:  rand.Float64,
 		now:        time.Now,
 	}
@@ -243,8 +255,12 @@ func (q quotaSnapshot) weeklyUsed(model string) (float64, bool) {
 }
 
 // updatePollTargets records the claude auths (and their bearer tokens) the
-// background poller should query. Called from Pick; cheap map upkeep only.
+// background poller should query, and drops targets whose auth has not been
+// seen for quotaTargetExpiry (credential removed or token rotated out) so the
+// poller does not spend the shared usage-endpoint allowance on dead
+// credentials. Called from Pick; cheap map upkeep only.
 func (s *QuotaAwareSelector) updatePollTargets(auths []*Auth) {
+	now := s.now()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, auth := range auths {
@@ -258,7 +274,13 @@ func (s *QuotaAwareSelector) updatePollTargets(auths []*Auth) {
 		if token == "" {
 			continue
 		}
-		s.targets[auth.ID] = quotaPollTarget{id: auth.ID, token: token}
+		s.targets[auth.ID] = quotaPollTarget{id: auth.ID, token: token, lastSeen: now}
+	}
+	for id, target := range s.targets {
+		if now.Sub(target.lastSeen) > quotaTargetExpiry {
+			delete(s.targets, id)
+			delete(s.quotas, id)
+		}
 	}
 }
 
@@ -349,7 +371,21 @@ func (s *QuotaAwareSelector) refreshAll() time.Duration {
 }
 
 func (s *QuotaAwareSelector) fetchQuota(token string) (quotaSnapshot, int, error) {
-	req, errRequest := http.NewRequest(http.MethodGet, quotaUsageEndpoint, nil)
+	// Bound each poll with a context derived from stopCh rather than an
+	// http.Client timeout (per the repo's no-new-network-timeouts rule): the
+	// deadline keeps a wedged poll from stalling the refresh loop, and Stop()
+	// cancels an in-flight request immediately on shutdown or selector swap.
+	// This never runs on a request path — background quota polling only.
+	ctx, cancel := context.WithDeadline(context.Background(), s.now().Add(quotaFetchTimeout))
+	defer cancel()
+	go func() {
+		select {
+		case <-s.stopCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	req, errRequest := http.NewRequestWithContext(ctx, http.MethodGet, quotaUsageEndpoint, nil)
 	if errRequest != nil {
 		return quotaSnapshot{}, 0, errRequest
 	}

--- a/sdk/cliproxy/auth/quota_selector.go
+++ b/sdk/cliproxy/auth/quota_selector.go
@@ -1,0 +1,403 @@
+package auth
+
+import (
+	"context"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+const (
+	quotaUsageEndpoint = "https://api.anthropic.com/api/oauth/usage"
+	// The usage endpoint is itself rate-limited (observed HTTP 429 with
+	// Retry-After: 0 at 4 accounts x 60s from one IP), and quota percentages
+	// move slowly. Poll gently and tolerate a couple of missed cycles before
+	// treating a snapshot as unknown.
+	quotaRefreshInterval    = 5 * time.Minute
+	quotaStaleAfter         = 30 * time.Minute
+	quotaFetchTimeout       = 15 * time.Second
+	quotaExhaustedThreshold = 95.0
+
+	// Even a stale snapshot is good enough to keep avoiding an exhausted
+	// account: weekly tiers reset on a multi-day cadence, so a reading a few
+	// hours old that says a weekly tier is fully used is still actionable when
+	// everything fresher is unavailable (e.g. during a usage-endpoint
+	// rate-limit window).
+	quotaExclusionMaxAge = 6 * time.Hour
+
+	// Backoff applied to the poll loop after the usage endpoint returns 429.
+	// The endpoint's bucket is shared per-IP across every consumer (other
+	// tooling may query it too), so on 429 the poller must yield hard rather
+	// than keep draining the shared allowance.
+	quotaBackoffInitial = 15 * time.Minute
+	quotaBackoffCap     = 2 * time.Hour
+
+	// quotaPollSpacing staggers per-account fetches inside one poll cycle;
+	// the endpoint rate-limits bursts from a single IP.
+	quotaPollSpacing = 3 * time.Second
+)
+
+// quotaSnapshot captures the last known usage percentages for one auth.
+// Percentages are "percent used"; -1 marks an absent limit.
+type quotaSnapshot struct {
+	fetchedAt time.Time
+	session   float64
+	weeklyAll float64
+	// scoped maps lowercased scope.model.display_name (e.g. "opus") to percent used.
+	scoped map[string]float64
+}
+
+// quotaPollTarget is the minimal auth info the background poller needs.
+type quotaPollTarget struct {
+	id    string
+	token string
+}
+
+// QuotaAwareSelector picks auths proportionally to their remaining Anthropic
+// OAuth quota headroom. Pick performs no I/O: a background goroutine polls the
+// usage endpoint for each claude-provider auth and maintains a per-auth cache.
+// Auths with unknown or stale quota carry zero weight; when every candidate is
+// unknown or exhausted, selection degrades to embedded round-robin behavior.
+type QuotaAwareSelector struct {
+	fallback *RoundRobinSelector
+
+	mu      sync.RWMutex
+	quotas  map[string]quotaSnapshot
+	targets map[string]quotaPollTarget
+	// backoff is the current 429 backoff for the poll loop (0 = healthy).
+	backoff time.Duration
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+	stopCh    chan struct{}
+
+	httpClient *http.Client
+
+	// randFloat and now are injectable for tests.
+	randFloat func() float64
+	now       func() time.Time
+}
+
+// NewQuotaAwareSelector creates a quota-aware selector. The background quota
+// poller starts lazily on the first Pick and stops via Stop.
+func NewQuotaAwareSelector() *QuotaAwareSelector {
+	return &QuotaAwareSelector{
+		fallback: &RoundRobinSelector{},
+		quotas:   make(map[string]quotaSnapshot),
+		targets:  make(map[string]quotaPollTarget),
+		stopCh:   make(chan struct{}),
+		// This client only fetches credential quota metadata on a background
+		// goroutine, never on a request path, so a bounded timeout is safe and
+		// keeps a wedged poll from stalling the refresh loop indefinitely.
+		httpClient: &http.Client{Timeout: quotaFetchTimeout},
+		randFloat:  rand.Float64,
+		now:        time.Now,
+	}
+}
+
+// Pick selects among available auths with probability proportional to quota
+// headroom. It never blocks on network I/O.
+func (s *QuotaAwareSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	now := s.now()
+	available, err := getAvailableAuths(auths, provider, model, now)
+	if err != nil {
+		return nil, err
+	}
+	available = preferCodexWebsocketAuths(ctx, provider, available)
+
+	s.updatePollTargets(auths)
+	s.startOnce.Do(func() { go s.refreshLoop() })
+
+	entry := selectorLogEntry(ctx)
+	weights := make([]float64, len(available))
+	total := 0.0
+	unknowns := make([]*Auth, 0, len(available))
+	for i, candidate := range available {
+		headroom, known := s.headroom(candidate, model, now)
+		if !known {
+			unknowns = append(unknowns, candidate)
+			continue
+		}
+		if headroom < 0 {
+			headroom = 0
+		}
+		weights[i] = headroom
+		total += headroom
+	}
+
+	if total <= 0 {
+		// No weighted candidate. Round-robin over the unknowns only, so
+		// accounts KNOWN to be exhausted on this tier stay excluded even
+		// while fresh quota data is unavailable.
+		if len(unknowns) > 0 && len(unknowns) < len(available) {
+			entry.Debugf("quota-aware: weighting unavailable, round-robin over %d unknown of %d candidates | provider=%s model=%s", len(unknowns), len(available), provider, model)
+			return s.fallback.Pick(ctx, provider, model, opts, unknowns)
+		}
+		entry.Debugf("quota-aware: no candidate with known headroom, degrading to round-robin | provider=%s model=%s candidates=%d", provider, model, len(available))
+		return s.fallback.Pick(ctx, provider, model, opts, auths)
+	}
+
+	r := s.randFloat() * total
+	for i, candidate := range available {
+		if weights[i] <= 0 {
+			continue
+		}
+		r -= weights[i]
+		if r <= 0 {
+			entry.Debugf("quota-aware: selected auth=%s headroom=%.1f/%.1f provider=%s model=%s", candidate.ID, weights[i], total, provider, model)
+			return candidate, nil
+		}
+	}
+	// Floating point edge: fall back to the last positively weighted candidate.
+	for i := len(available) - 1; i >= 0; i-- {
+		if weights[i] > 0 {
+			entry.Debugf("quota-aware: selected auth=%s (tail) provider=%s model=%s", available[i].ID, provider, model)
+			return available[i], nil
+		}
+	}
+	return s.fallback.Pick(ctx, provider, model, opts, auths)
+}
+
+// headroom returns the remaining percentage for the auth on the tier relevant
+// to model, and whether quota data is known and fresh.
+func (s *QuotaAwareSelector) headroom(auth *Auth, model string, now time.Time) (float64, bool) {
+	if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "claude") {
+		return 0, false
+	}
+	s.mu.RLock()
+	snapshot, ok := s.quotas[auth.ID]
+	s.mu.RUnlock()
+	if !ok {
+		return 0, false
+	}
+	age := now.Sub(snapshot.fetchedAt)
+	if age > quotaStaleAfter {
+		// Too old to weight by, but a recent-ish "exhausted" reading on a
+		// WEEKLY tier is still trustworthy for exclusion: weekly limits reset
+		// on a multi-day cadence. The 5h session window is deliberately not
+		// considered here; it may already have reset.
+		if age <= quotaExclusionMaxAge {
+			if used, seen := snapshot.weeklyUsed(model); seen && used >= quotaExhaustedThreshold {
+				return 0, true
+			}
+		}
+		return 0, false
+	}
+
+	effective, seen := snapshot.effectiveUsed(model)
+	if !seen {
+		return 0, false
+	}
+	if effective >= quotaExhaustedThreshold {
+		return 0, true
+	}
+	return 100 - effective, true
+}
+
+// effectiveUsed returns the worst (highest) percent-used across the session
+// window, the all-models weekly limit, and any model-scoped weekly tier whose
+// display name matches the model, plus whether any limit was present at all.
+func (q quotaSnapshot) effectiveUsed(model string) (float64, bool) {
+	weekly, seen := q.weeklyUsed(model)
+	effective := weekly
+	if q.session >= 0 {
+		seen = true
+		if q.session > effective {
+			effective = q.session
+		}
+	}
+	return effective, seen
+}
+
+// weeklyUsed is effectiveUsed without the 5h session window: the worst
+// percent-used across the all-models weekly limit and any matching
+// model-scoped weekly tier.
+func (q quotaSnapshot) weeklyUsed(model string) (float64, bool) {
+	effective := 0.0
+	seen := false
+	if q.weeklyAll >= 0 {
+		seen = true
+		effective = q.weeklyAll
+	}
+	lowerModel := strings.ToLower(model)
+	for tier, pct := range q.scoped {
+		if pct < 0 || tier == "" {
+			continue
+		}
+		if strings.Contains(lowerModel, tier) {
+			seen = true
+			if pct > effective {
+				effective = pct
+			}
+		}
+	}
+	return effective, seen
+}
+
+// updatePollTargets records the claude auths (and their bearer tokens) the
+// background poller should query. Called from Pick; cheap map upkeep only.
+func (s *QuotaAwareSelector) updatePollTargets(auths []*Auth) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, auth := range auths {
+		if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "claude") {
+			continue
+		}
+		token := authMetadataString(auth, "access_token")
+		if token == "" {
+			token = authMetadataString(auth, "accessToken")
+		}
+		if token == "" {
+			continue
+		}
+		s.targets[auth.ID] = quotaPollTarget{id: auth.ID, token: token}
+	}
+}
+
+// Stop terminates the background quota poller.
+func (s *QuotaAwareSelector) Stop() {
+	s.stopOnce.Do(func() { close(s.stopCh) })
+}
+
+func (s *QuotaAwareSelector) refreshLoop() {
+	// Warm the cache immediately, then poll on the interval, backing off
+	// whenever the usage endpoint rate-limits us.
+	wait := s.refreshAll()
+	for {
+		if wait <= 0 {
+			wait = quotaRefreshInterval
+		}
+		select {
+		case <-s.stopCh:
+			return
+		case <-time.After(wait):
+			wait = s.refreshAll()
+		}
+	}
+}
+
+// refreshAll fetches usage for every poll target. It returns the wait before
+// the next cycle: the normal interval on success, or an escalating backoff
+// when the endpoint answers 429 (its per-IP bucket is shared with any other
+// local consumer of the usage endpoint, so we stop draining it immediately).
+func (s *QuotaAwareSelector) refreshAll() time.Duration {
+	s.mu.RLock()
+	targets := make([]quotaPollTarget, 0, len(s.targets))
+	for _, target := range s.targets {
+		targets = append(targets, target)
+	}
+	backoff := s.backoff
+	s.mu.RUnlock()
+
+	rateLimited := false
+	for i, target := range targets {
+		if i > 0 {
+			select {
+			case <-s.stopCh:
+				return quotaRefreshInterval
+			case <-time.After(quotaPollSpacing):
+			}
+		}
+		select {
+		case <-s.stopCh:
+			return quotaRefreshInterval
+		default:
+		}
+		snapshot, status, errFetch := s.fetchQuota(target.token)
+		if status == http.StatusTooManyRequests {
+			// One 429 means the shared bucket is empty; stop the cycle so
+			// other consumers are not starved further.
+			log.Warnf("quota-aware: usage endpoint rate-limited, backing off | auth=%s", target.id)
+			rateLimited = true
+			break
+		}
+		if errFetch != nil {
+			// Keep the previous snapshot; it ages into staleness naturally.
+			log.Debugf("quota-aware: usage fetch failed | auth=%s err=%v", target.id, errFetch)
+			continue
+		}
+		snapshot.fetchedAt = s.now()
+		s.mu.Lock()
+		s.quotas[target.id] = snapshot
+		s.mu.Unlock()
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if rateLimited {
+		if backoff <= 0 {
+			backoff = quotaBackoffInitial
+		} else {
+			backoff *= 2
+			if backoff > quotaBackoffCap {
+				backoff = quotaBackoffCap
+			}
+		}
+		s.backoff = backoff
+		return backoff
+	}
+	s.backoff = 0
+	return quotaRefreshInterval
+}
+
+func (s *QuotaAwareSelector) fetchQuota(token string) (quotaSnapshot, int, error) {
+	req, errRequest := http.NewRequest(http.MethodGet, quotaUsageEndpoint, nil)
+	if errRequest != nil {
+		return quotaSnapshot{}, 0, errRequest
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("anthropic-beta", "oauth-2025-04-20")
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, errDo := s.httpClient.Do(req)
+	if errDo != nil {
+		return quotaSnapshot{}, 0, errDo
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Debugf("quota-aware: close usage response: %v", errClose)
+		}
+	}()
+	body, errRead := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if errRead != nil {
+		return quotaSnapshot{}, resp.StatusCode, errRead
+	}
+	if resp.StatusCode != http.StatusOK {
+		return quotaSnapshot{}, resp.StatusCode, &Error{Code: "quota_usage_http_error", Message: http.StatusText(resp.StatusCode)}
+	}
+	return parseQuotaUsage(body), resp.StatusCode, nil
+}
+
+// parseQuotaUsage extracts percent-used values from an /api/oauth/usage
+// response. Limits arrive as limits[] with kind "session", "weekly_all", or
+// "weekly_scoped" (the latter carrying scope.model.display_name).
+func parseQuotaUsage(body []byte) quotaSnapshot {
+	snapshot := quotaSnapshot{session: -1, weeklyAll: -1, scoped: make(map[string]float64)}
+	gjson.GetBytes(body, "limits").ForEach(func(_, limit gjson.Result) bool {
+		percent := limit.Get("percent")
+		if !percent.Exists() {
+			return true
+		}
+		pct := percent.Float()
+		switch limit.Get("kind").String() {
+		case "session":
+			snapshot.session = pct
+		case "weekly_all":
+			snapshot.weeklyAll = pct
+		case "weekly_scoped":
+			if name := strings.ToLower(strings.TrimSpace(limit.Get("scope.model.display_name").String())); name != "" {
+				snapshot.scoped[name] = pct
+			}
+		}
+		return true
+	})
+	return snapshot
+}

--- a/sdk/cliproxy/auth/quota_selector.go
+++ b/sdk/cliproxy/auth/quota_selector.go
@@ -54,6 +54,13 @@ const (
 	// candidate slice, short enough that deleted credentials stop consuming
 	// the shared usage-endpoint allowance after a few cycles.
 	quotaTargetExpiry = 15 * time.Minute
+
+	// Claude Code fingerprint for usage polls, mirroring the executor's
+	// defaults in internal/runtime/executor/helps/claude_device_profile.go
+	// (not importable here: import cycle). Keep in sync when those bump.
+	quotaPollUserAgent        = "claude-cli/2.1.63 (external, cli)"
+	quotaPollStainlessPackage = "0.74.0"
+	quotaPollStainlessRuntime = "v24.3.0"
 )
 
 // quotaSnapshot captures the last known usage percentages for one auth.
@@ -392,6 +399,17 @@ func (s *QuotaAwareSelector) fetchQuota(token string) (quotaSnapshot, int, error
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("anthropic-beta", "oauth-2025-04-20")
 	req.Header.Set("anthropic-version", "2023-06-01")
+	// Fingerprint as Claude Code like the executor's OAuth request path does —
+	// the usage endpoint aggressively rate-limits generic clients (Go's
+	// default User-Agent draws immediate 429s). Values mirror the executor's
+	// defaults (internal/runtime/executor/helps/claude_device_profile.go);
+	// that package cannot be imported here without an import cycle.
+	req.Header.Set("User-Agent", quotaPollUserAgent)
+	req.Header.Set("X-App", "cli")
+	req.Header.Set("X-Stainless-Package-Version", quotaPollStainlessPackage)
+	req.Header.Set("X-Stainless-Runtime", "node")
+	req.Header.Set("X-Stainless-Runtime-Version", quotaPollStainlessRuntime)
+	req.Header.Set("X-Stainless-Lang", "js")
 
 	resp, errDo := s.httpClient.Do(req)
 	if errDo != nil {

--- a/sdk/cliproxy/auth/quota_selector_test.go
+++ b/sdk/cliproxy/auth/quota_selector_test.go
@@ -176,3 +176,44 @@ func TestParseQuotaUsage(t *testing.T) {
 		t.Fatalf("scoped[opus] = %v, want 97", got)
 	}
 }
+
+func TestQuotaAwareSelector_StalePollTargetsExpire(t *testing.T) {
+	t.Parallel()
+
+	selector := newTestQuotaSelector(3)
+	current := time.Now()
+	selector.now = func() time.Time { return current }
+
+	kept := &Auth{ID: "kept", Provider: "claude", Metadata: map[string]any{"access_token": "tok-kept"}}
+	removed := &Auth{ID: "removed", Provider: "claude", Metadata: map[string]any{"access_token": "tok-removed"}}
+
+	selector.updatePollTargets([]*Auth{kept, removed})
+	selector.setQuota("removed", quotaSnapshot{session: 10, weeklyAll: 10, scoped: map[string]float64{}})
+
+	// The removed credential stops appearing in Pick's auth slice; within the
+	// expiry window it must still be polled (cooldown windows filter auths
+	// temporarily).
+	current = current.Add(quotaTargetExpiry / 2)
+	selector.updatePollTargets([]*Auth{kept})
+	selector.mu.RLock()
+	_, stillThere := selector.targets["removed"]
+	selector.mu.RUnlock()
+	if !stillThere {
+		t.Fatalf("target dropped before quotaTargetExpiry elapsed")
+	}
+
+	// Past the expiry window the target and its cached quota must both go.
+	current = current.Add(quotaTargetExpiry)
+	selector.updatePollTargets([]*Auth{kept})
+	selector.mu.RLock()
+	_, targetLeft := selector.targets["removed"]
+	_, quotaLeft := selector.quotas["removed"]
+	keptTarget, keptThere := selector.targets["kept"]
+	selector.mu.RUnlock()
+	if targetLeft || quotaLeft {
+		t.Fatalf("stale target/quota not expired: target=%v quota=%v", targetLeft, quotaLeft)
+	}
+	if !keptThere || keptTarget.token != "tok-kept" {
+		t.Fatalf("active target must survive expiry sweep")
+	}
+}

--- a/sdk/cliproxy/auth/quota_selector_test.go
+++ b/sdk/cliproxy/auth/quota_selector_test.go
@@ -1,0 +1,178 @@
+package auth
+
+import (
+	"context"
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// newTestQuotaSelector returns a selector whose background poller is disarmed
+// and whose randomness is seeded deterministically.
+func newTestQuotaSelector(seed uint64) *QuotaAwareSelector {
+	s := NewQuotaAwareSelector()
+	s.startOnce.Do(func() {})
+	src := rand.New(rand.NewPCG(seed, seed))
+	s.randFloat = src.Float64
+	return s
+}
+
+func (s *QuotaAwareSelector) setQuota(authID string, snapshot quotaSnapshot) {
+	snapshot.fetchedAt = time.Now()
+	s.mu.Lock()
+	s.quotas[authID] = snapshot
+	s.mu.Unlock()
+}
+
+func TestQuotaAwareSelector_ProportionalDistribution(t *testing.T) {
+	t.Parallel()
+
+	selector := newTestQuotaSelector(42)
+	auths := []*Auth{
+		{ID: "big", Provider: "claude"},
+		{ID: "small", Provider: "claude"},
+	}
+	// big: 10% used everywhere -> 90 headroom; small: 70% used -> 30 headroom.
+	selector.setQuota("big", quotaSnapshot{session: 10, weeklyAll: 10, scoped: map[string]float64{}})
+	selector.setQuota("small", quotaSnapshot{session: 70, weeklyAll: 40, scoped: map[string]float64{}})
+
+	counts := map[string]int{}
+	for i := 0; i < 10000; i++ {
+		got, err := selector.Pick(context.Background(), "claude", "claude-opus-5", cliproxyexecutor.Options{}, auths)
+		if err != nil {
+			t.Fatalf("Pick() #%d error = %v", i, err)
+		}
+		counts[got.ID]++
+	}
+
+	ratio := float64(counts["big"]) / float64(counts["small"])
+	if ratio < 2.5 || ratio > 3.5 {
+		t.Fatalf("pick ratio big/small = %.2f (big=%d small=%d), want ~3.0", ratio, counts["big"], counts["small"])
+	}
+}
+
+func TestQuotaAwareSelector_ZeroHeadroomExcluded(t *testing.T) {
+	t.Parallel()
+
+	selector := newTestQuotaSelector(7)
+	auths := []*Auth{
+		{ID: "healthy", Provider: "claude"},
+		{ID: "exhausted", Provider: "claude"},
+	}
+	selector.setQuota("healthy", quotaSnapshot{session: 20, weeklyAll: 20, scoped: map[string]float64{}})
+	// 96% on the Opus weekly tier: excluded for opus models despite low overall use.
+	selector.setQuota("exhausted", quotaSnapshot{session: 30, weeklyAll: 30, scoped: map[string]float64{"opus": 96}})
+
+	for i := 0; i < 1000; i++ {
+		got, err := selector.Pick(context.Background(), "claude", "claude-opus-5", cliproxyexecutor.Options{}, auths)
+		if err != nil {
+			t.Fatalf("Pick() #%d error = %v", i, err)
+		}
+		if got.ID != "healthy" {
+			t.Fatalf("Pick() #%d selected exhausted auth %q", i, got.ID)
+		}
+	}
+}
+
+func TestQuotaAwareSelector_TierScopedOnlyAffectsMatchingModel(t *testing.T) {
+	t.Parallel()
+
+	selector := newTestQuotaSelector(7)
+	auths := []*Auth{
+		{ID: "opus-full", Provider: "claude"},
+	}
+	selector.setQuota("opus-full", quotaSnapshot{session: 10, weeklyAll: 10, scoped: map[string]float64{"opus": 100}})
+
+	// Non-opus model: the Opus tier limit must not exclude the auth.
+	got, err := selector.Pick(context.Background(), "claude", "claude-opus-5", cliproxyexecutor.Options{}, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if got.ID != "opus-full" {
+		t.Fatalf("Pick() auth.ID = %q, want opus-full", got.ID)
+	}
+
+	// Opus model: same auth is exhausted, so selection degrades to round-robin
+	// (it is the only candidate, so it is still returned via the fallback).
+	got, err = selector.Pick(context.Background(), "claude", "claude-opus-5", cliproxyexecutor.Options{}, auths)
+	if err != nil {
+		t.Fatalf("Pick() opus error = %v", err)
+	}
+	if got.ID != "opus-full" {
+		t.Fatalf("Pick() opus auth.ID = %q, want opus-full via fallback", got.ID)
+	}
+}
+
+func TestQuotaAwareSelector_AllUnknownDegradesToRoundRobin(t *testing.T) {
+	t.Parallel()
+
+	selector := newTestQuotaSelector(1)
+	auths := []*Auth{
+		{ID: "b", Provider: "claude"},
+		{ID: "a", Provider: "claude"},
+		{ID: "c", Provider: "gemini"},
+	}
+	// No quota snapshots at all: every candidate is unknown.
+
+	want := []string{"a", "b", "c", "a", "b"}
+	for i, id := range want {
+		got, err := selector.Pick(context.Background(), "mixed", "some-model", cliproxyexecutor.Options{}, auths)
+		if err != nil {
+			t.Fatalf("Pick() #%d error = %v", i, err)
+		}
+		if got.ID != id {
+			t.Fatalf("Pick() #%d auth.ID = %q, want %q (round-robin order)", i, got.ID, id)
+		}
+	}
+}
+
+func TestQuotaAwareSelector_StaleQuotaCountsAsUnknown(t *testing.T) {
+	t.Parallel()
+
+	selector := newTestQuotaSelector(1)
+	auths := []*Auth{
+		{ID: "a", Provider: "claude"},
+		{ID: "b", Provider: "claude"},
+	}
+	selector.mu.Lock()
+	selector.quotas["a"] = quotaSnapshot{
+		fetchedAt: time.Now().Add(-2 * quotaStaleAfter),
+		session:   0, weeklyAll: 0, scoped: map[string]float64{},
+	}
+	selector.mu.Unlock()
+
+	// "a" has huge headroom but the data is stale, "b" is unknown: both zero
+	// weight, so round-robin order (sorted by ID) must apply.
+	want := []string{"a", "b", "a", "b"}
+	for i, id := range want {
+		got, err := selector.Pick(context.Background(), "claude", "m", cliproxyexecutor.Options{}, auths)
+		if err != nil {
+			t.Fatalf("Pick() #%d error = %v", i, err)
+		}
+		if got.ID != id {
+			t.Fatalf("Pick() #%d auth.ID = %q, want %q", i, got.ID, id)
+		}
+	}
+}
+
+func TestParseQuotaUsage(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"limits":[
+		{"kind":"session","percent":41,"resets_at":"2026-07-29T12:00:00Z"},
+		{"kind":"weekly_all","percent":63},
+		{"kind":"weekly_scoped","percent":97,"scope":{"model":{"display_name":"Opus"}}}
+	]}`)
+	snapshot := parseQuotaUsage(body)
+	if snapshot.session != 41 {
+		t.Fatalf("session = %v, want 41", snapshot.session)
+	}
+	if snapshot.weeklyAll != 63 {
+		t.Fatalf("weeklyAll = %v, want 63", snapshot.weeklyAll)
+	}
+	if got := snapshot.scoped["opus"]; got != 97 {
+		t.Fatalf("scoped[opus] = %v, want 97", got)
+	}
+}

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -683,10 +683,13 @@ func truncateSessionID(id string) string {
 	return id[:8] + "..."
 }
 
-// Stop releases resources held by the selector.
+// Stop releases resources held by the selector and its fallback.
 func (s *SessionAffinitySelector) Stop() {
 	if s.cache != nil {
 		s.cache.Stop()
+	}
+	if stoppable, ok := s.fallback.(StoppableSelector); ok {
+		stoppable.Stop()
 	}
 }
 

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -527,18 +527,33 @@ func availabilityBlock(unavailable, quotaExceeded bool, nextRetryAfter, nextReco
 	return true, blockReasonOther, time.Time{}
 }
 
+// Session ID derivation modes for session affinity.
+const (
+	// SessionIDModeDefault keeps the historical behavior: the Claude Code
+	// session_id alone identifies the session.
+	SessionIDModeDefault = ""
+	// SessionIDModeContentHash combines the Claude Code session_id with a hash
+	// of the first message contents. Subagents that inherit the parent's
+	// session_id but carry different prompts then bind to distinct auths,
+	// while each individual conversation stays pinned.
+	SessionIDModeContentHash = "content-hash"
+)
+
 // SessionAffinitySelector wraps another selector with session-sticky behavior.
 // It extracts session ID from multiple sources and maintains session-to-auth
 // mappings with automatic failover when the bound auth becomes unavailable.
 type SessionAffinitySelector struct {
-	fallback Selector
-	cache    *SessionCache
+	fallback      Selector
+	cache         *SessionCache
+	sessionIDMode string
 }
 
 // SessionAffinityConfig configures the session affinity selector.
 type SessionAffinityConfig struct {
 	Fallback Selector
 	TTL      time.Duration
+	// SessionIDMode selects how session identity is derived; see SessionIDMode* constants.
+	SessionIDMode string
 }
 
 // NewSessionAffinitySelector creates a new session-aware selector.
@@ -558,8 +573,18 @@ func NewSessionAffinitySelectorWithConfig(cfg SessionAffinityConfig) *SessionAff
 		cfg.TTL = time.Hour
 	}
 	return &SessionAffinitySelector{
-		fallback: cfg.Fallback,
-		cache:    NewSessionCache(cfg.TTL),
+		fallback:      cfg.Fallback,
+		cache:         NewSessionCache(cfg.TTL),
+		sessionIDMode: normalizeSessionIDMode(cfg.SessionIDMode),
+	}
+}
+
+func normalizeSessionIDMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case SessionIDModeContentHash:
+		return SessionIDModeContentHash
+	default:
+		return SessionIDModeDefault
 	}
 }
 
@@ -572,7 +597,7 @@ func NewSessionAffinitySelectorWithConfig(cfg SessionAffinityConfig) *SessionAff
 // that may be supported by different auth credentials, and to avoid cross-provider conflicts.
 func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
 	entry := selectorLogEntry(ctx)
-	primaryID, fallbackID := extractSessionIDs(opts.Headers, opts.OriginalRequest, opts.Metadata)
+	primaryID, fallbackID := extractSessionIDsWithMode(opts.Headers, opts.OriginalRequest, opts.Metadata, s.sessionIDMode)
 	if primaryID == "" {
 		entry.Debugf("session-affinity: no session ID extracted, falling back to default selector | provider=%s model=%s", provider, model)
 		return s.fallback.Pick(ctx, provider, model, opts, auths)
@@ -724,11 +749,17 @@ func ExtractSessionID(headers http.Header, payload []byte, metadata map[string]a
 // fallbackID preserves an earlier binding when a stronger body identifier appears
 // later, and lets callers bind both identifiers when both are present.
 func extractSessionIDs(headers http.Header, payload []byte, metadata map[string]any) (string, string) {
+	return extractSessionIDsWithMode(headers, payload, metadata, SessionIDModeDefault)
+}
+
+// extractSessionIDsWithMode is extractSessionIDs with an explicit session ID
+// derivation mode; see the SessionIDMode* constants.
+func extractSessionIDsWithMode(headers http.Header, payload []byte, metadata map[string]any, mode string) (string, string) {
 	if sid := sessionHeaderValue(headers, "X-Claude-Code-Session-Id"); sid != "" {
-		return "claude:" + sid, ""
+		return claudeSessionIDs(sid, payload, mode)
 	}
 	if sid := cliproxysession.ClaudeMetadataSessionID(payload); sid != "" {
-		return "claude:" + sid, ""
+		return claudeSessionIDs(sid, payload, mode)
 	}
 	if sid := sessionHeaderValue(headers, "Session-Id"); sid != "" {
 		return "codex:" + sid, ""
@@ -791,7 +822,40 @@ func extractSessionIDs(headers http.Header, payload []byte, metadata map[string]
 	return extractMessageHashIDs(payload)
 }
 
+// claudeSessionIDs derives the affinity IDs for Claude Code traffic.
+// In content-hash mode the message content hash is folded into the session ID
+// so requests sharing a session_id but carrying different prompts (subagents)
+// get distinct bindings. The short-hash fallback ID preserves the first-turn
+// inherit mechanism from extractMessageHashIDs.
+func claudeSessionIDs(sessionID string, payload []byte, mode string) (string, string) {
+	base := "claude:" + sessionID
+	if mode != SessionIDModeContentHash {
+		return base, ""
+	}
+	// Hash FULL message content, not a truncated prefix: Claude Code subagents
+	// share their first several kilobytes verbatim (system-reminder and
+	// project-context blocks) and diverge only later, so a short prefix hash
+	// collapses every subagent onto one binding.
+	primaryHash, fallbackHash := extractMessageHashIDsLimited(payload, 0)
+	if primaryHash == "" {
+		return base, ""
+	}
+	if fallbackHash == "" {
+		return base + ":" + primaryHash, ""
+	}
+	return base + ":" + primaryHash, base + ":" + fallbackHash
+}
+
+// extractMessageHashIDs keeps the historical 100-char sampling used by the
+// last-resort session-ID fallback in extractSessionIDs.
 func extractMessageHashIDs(payload []byte) (primaryID, fallbackID string) {
+	return extractMessageHashIDsLimited(payload, 100)
+}
+
+// extractMessageHashIDsLimited hashes the system prompt and first user (and
+// assistant) message, each truncated to limit chars; limit <= 0 means no
+// truncation (full content).
+func extractMessageHashIDsLimited(payload []byte, limit int) (primaryID, fallbackID string) {
 	var systemPrompt, firstUserMsg, firstAssistantMsg string
 
 	// OpenAI/Claude messages format
@@ -807,15 +871,15 @@ func extractMessageHashIDs(payload []byte) (primaryID, fallbackID string) {
 			switch role {
 			case "system":
 				if systemPrompt == "" {
-					systemPrompt = truncateString(content, 100)
+					systemPrompt = truncateString(content, limit)
 				}
 			case "user":
 				if firstUserMsg == "" {
-					firstUserMsg = truncateString(content, 100)
+					firstUserMsg = truncateString(content, limit)
 				}
 			case "assistant":
 				if firstAssistantMsg == "" {
-					firstAssistantMsg = truncateString(content, 100)
+					firstAssistantMsg = truncateString(content, limit)
 				}
 			}
 
@@ -833,13 +897,13 @@ func extractMessageHashIDs(payload []byte) (primaryID, fallbackID string) {
 			if topSystem.IsArray() {
 				topSystem.ForEach(func(_, part gjson.Result) bool {
 					if text := part.Get("text").String(); text != "" && systemPrompt == "" {
-						systemPrompt = truncateString(text, 100)
+						systemPrompt = truncateString(text, limit)
 						return false
 					}
 					return true
 				})
 			} else if topSystem.Type == gjson.String {
-				systemPrompt = truncateString(topSystem.String(), 100)
+				systemPrompt = truncateString(topSystem.String(), limit)
 			}
 		}
 	}
@@ -850,7 +914,7 @@ func extractMessageHashIDs(payload []byte) (primaryID, fallbackID string) {
 		if sysInstr.Exists() && sysInstr.IsArray() {
 			sysInstr.ForEach(func(_, part gjson.Result) bool {
 				if text := part.Get("text").String(); text != "" && systemPrompt == "" {
-					systemPrompt = truncateString(text, 100)
+					systemPrompt = truncateString(text, limit)
 					return false
 				}
 				return true
@@ -869,11 +933,11 @@ func extractMessageHashIDs(payload []byte) (primaryID, fallbackID string) {
 					switch role {
 					case "user":
 						if firstUserMsg == "" {
-							firstUserMsg = truncateString(text, 100)
+							firstUserMsg = truncateString(text, limit)
 						}
 					case "model":
 						if firstAssistantMsg == "" {
-							firstAssistantMsg = truncateString(text, 100)
+							firstAssistantMsg = truncateString(text, limit)
 						}
 					}
 					return false
@@ -889,7 +953,7 @@ func extractMessageHashIDs(payload []byte) (primaryID, fallbackID string) {
 	// OpenAI Responses API format (v1/responses)
 	if systemPrompt == "" && firstUserMsg == "" {
 		if instr := gjson.GetBytes(payload, "instructions").String(); instr != "" {
-			systemPrompt = truncateString(instr, 100)
+			systemPrompt = truncateString(instr, limit)
 		}
 
 		input := gjson.GetBytes(payload, "input")
@@ -925,15 +989,15 @@ func extractMessageHashIDs(payload []byte) (primaryID, fallbackID string) {
 				switch role {
 				case "developer", "system":
 					if systemPrompt == "" {
-						systemPrompt = truncateString(text, 100)
+						systemPrompt = truncateString(text, limit)
 					}
 				case "user":
 					if firstUserMsg == "" {
-						firstUserMsg = truncateString(text, 100)
+						firstUserMsg = truncateString(text, limit)
 					}
 				case "assistant":
 					if firstAssistantMsg == "" {
-						firstAssistantMsg = truncateString(text, 100)
+						firstAssistantMsg = truncateString(text, limit)
 					}
 				}
 
@@ -973,7 +1037,8 @@ func computeSessionHash(systemPrompt, userMsg, assistantMsg string) string {
 }
 
 func truncateString(s string, maxLen int) string {
-	if len(s) > maxLen {
+	// maxLen <= 0 means no truncation (full content).
+	if maxLen > 0 && len(s) > maxLen {
 		return s[:maxLen]
 	}
 	return s

--- a/sdk/cliproxy/auth/session_id_mode_test.go
+++ b/sdk/cliproxy/auth/session_id_mode_test.go
@@ -1,0 +1,108 @@
+package auth
+
+import (
+	"fmt"
+	"testing"
+)
+
+func claudeCodeSessionPayload(sessionID, firstUserMsg string) []byte {
+	return []byte(fmt.Sprintf(`{
+		"metadata":{"user_id":"{\"device_id\":\"dev-1\",\"account_uuid\":\"acc-1\",\"session_id\":\"%s\"}"},
+		"system":[{"type":"text","text":"You are a helpful subagent."}],
+		"messages":[{"role":"user","content":"%s"}]
+	}`, sessionID, firstUserMsg))
+}
+
+func TestExtractSessionIDs_ContentHashModeDistinguishesSubagents(t *testing.T) {
+	t.Parallel()
+
+	const sid = "11111111-2222-3333-4444-555555555555"
+	payloadA := claudeCodeSessionPayload(sid, "explore the auth package")
+	payloadB := claudeCodeSessionPayload(sid, "patch the conductor retry loop")
+
+	idA, _ := extractSessionIDsWithMode(nil, payloadA, nil, SessionIDModeContentHash)
+	idB, _ := extractSessionIDsWithMode(nil, payloadB, nil, SessionIDModeContentHash)
+	if idA == "" || idB == "" {
+		t.Fatalf("expected non-empty IDs, got %q and %q", idA, idB)
+	}
+	if idA == idB {
+		t.Fatalf("content-hash mode: distinct prompts under one session_id must yield distinct IDs, both = %q", idA)
+	}
+
+	// Same content must remain stable across calls.
+	idA2, _ := extractSessionIDsWithMode(nil, claudeCodeSessionPayload(sid, "explore the auth package"), nil, SessionIDModeContentHash)
+	if idA != idA2 {
+		t.Fatalf("content-hash mode: identical payloads produced different IDs: %q vs %q", idA, idA2)
+	}
+
+	// Default mode keeps legacy behavior: session_id alone, so both collapse.
+	defA, _ := extractSessionIDsWithMode(nil, payloadA, nil, SessionIDModeDefault)
+	defB, _ := extractSessionIDsWithMode(nil, payloadB, nil, SessionIDModeDefault)
+	if defA != "claude:"+sid || defA != defB {
+		t.Fatalf("default mode changed: got %q and %q, want both %q", defA, defB, "claude:"+sid)
+	}
+}
+
+func TestExtractSessionIDs_ContentHashModeFullContentNotPrefix(t *testing.T) {
+	t.Parallel()
+
+	// Subagent prompts share a long identical prefix (system-reminder and
+	// project-context blocks) and differ only near the end; a truncated prefix
+	// hash would collapse them onto one binding.
+	const sid = "22222222-3333-4444-5555-666666666666"
+	sharedPrefix := ""
+	for i := 0; i < 40; i++ {
+		sharedPrefix += "shared context block line providing project instructions. "
+	}
+	payloadA := claudeCodeSessionPayload(sid, sharedPrefix+"task: explore the auth package")
+	payloadB := claudeCodeSessionPayload(sid, sharedPrefix+"task: patch the retry loop")
+
+	idA, _ := extractSessionIDsWithMode(nil, payloadA, nil, SessionIDModeContentHash)
+	idB, _ := extractSessionIDsWithMode(nil, payloadB, nil, SessionIDModeContentHash)
+	if idA == idB {
+		t.Fatalf("content-hash mode hashed only a prefix: prompts differing after a long shared prefix collapsed to %q", idA)
+	}
+}
+
+func TestExtractSessionIDs_ContentHashModeFallbackInherit(t *testing.T) {
+	t.Parallel()
+
+	const sid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	firstTurn := claudeCodeSessionPayload(sid, "kick off the task")
+	secondTurn := []byte(fmt.Sprintf(`{
+		"metadata":{"user_id":"{\"session_id\":\"%s\"}"},
+		"system":[{"type":"text","text":"You are a helpful subagent."}],
+		"messages":[
+			{"role":"user","content":"kick off the task"},
+			{"role":"assistant","content":"done with step one"}
+		]
+	}`, sid))
+
+	firstPrimary, firstFallback := extractSessionIDsWithMode(nil, firstTurn, nil, SessionIDModeContentHash)
+	if firstFallback != "" {
+		t.Fatalf("first turn should have no fallback ID, got %q", firstFallback)
+	}
+	secondPrimary, secondFallback := extractSessionIDsWithMode(nil, secondTurn, nil, SessionIDModeContentHash)
+	if secondPrimary == firstPrimary {
+		t.Fatalf("second turn primary should include assistant hash and differ from first turn")
+	}
+	if secondFallback != firstPrimary {
+		t.Fatalf("second turn fallback %q must match first turn primary %q to inherit the binding", secondFallback, firstPrimary)
+	}
+}
+
+func TestExtractSessionIDs_ContentHashModeHeaderSession(t *testing.T) {
+	t.Parallel()
+
+	// The explicit Claude Code session header takes the same content-hash
+	// treatment as the metadata session.
+	payloadA := claudeCodeSessionPayload("ignored", "explore the auth package")
+	headers := make(map[string][]string)
+	headers["X-Claude-Code-Session-Id"] = []string{"33333333-4444-5555-6666-777777777777"}
+
+	idHeader, _ := extractSessionIDsWithMode(headers, payloadA, nil, SessionIDModeContentHash)
+	idDefault, _ := extractSessionIDsWithMode(headers, payloadA, nil, SessionIDModeDefault)
+	if idHeader == idDefault {
+		t.Fatalf("content-hash mode should fold message hash into header-derived session ID: %q", idHeader)
+	}
+}

--- a/sdk/cliproxy/service_config.go
+++ b/sdk/cliproxy/service_config.go
@@ -28,6 +28,7 @@ type routingRuntimeState struct {
 	strategy           string
 	sessionAffinity    bool
 	sessionAffinityTTL time.Duration
+	sessionIDMode      string
 }
 
 func normalizedRoutingRuntimeState(cfg *config.Config) routingRuntimeState {
@@ -51,6 +52,10 @@ func normalizedRoutingRuntimeState(cfg *config.Config) routingRuntimeState {
 			state.sessionAffinityTTL = parsed
 		}
 	}
+	switch strings.ToLower(strings.TrimSpace(cfg.Routing.SessionIDMode)) {
+	case coreauth.SessionIDModeContentHash:
+		state.sessionIDMode = coreauth.SessionIDModeContentHash
+	}
 	return state
 }
 
@@ -66,8 +71,9 @@ func newRoutingSelector(state routingRuntimeState) coreauth.Selector {
 	}
 	if state.sessionAffinity {
 		selector = coreauth.NewSessionAffinitySelectorWithConfig(coreauth.SessionAffinityConfig{
-			Fallback: selector,
-			TTL:      state.sessionAffinityTTL,
+			Fallback:      selector,
+			TTL:           state.sessionAffinityTTL,
+			SessionIDMode: state.sessionIDMode,
 		})
 	}
 	return selector

--- a/sdk/cliproxy/service_config.go
+++ b/sdk/cliproxy/service_config.go
@@ -45,6 +45,8 @@ func normalizedRoutingRuntimeState(cfg *config.Config) routingRuntimeState {
 		state.strategy = "weighted-round-robin"
 	case "fill-first", "fillfirst", "ff":
 		state.strategy = "fill-first"
+	case "quota-aware", "quotaaware", "qa":
+		state.strategy = "quota-aware"
 	}
 	state.sessionAffinity = cfg.Routing.SessionAffinity
 	if ttl := strings.TrimSpace(cfg.Routing.SessionAffinityTTL); ttl != "" {
@@ -66,6 +68,8 @@ func newRoutingSelector(state routingRuntimeState) coreauth.Selector {
 		selector = &coreauth.WeightedRoundRobinSelector{}
 	case "fill-first":
 		selector = &coreauth.FillFirstSelector{}
+	case "quota-aware":
+		selector = coreauth.NewQuotaAwareSelector()
 	default:
 		selector = &coreauth.RoundRobinSelector{}
 	}
@@ -210,8 +214,14 @@ func (s *Service) applyManagerConfig(ctx context.Context, commit configCommit) b
 	}
 	routingState := normalizedRoutingRuntimeState(commit.cfg)
 	if s.appliedRoutingState == nil || *s.appliedRoutingState != routingState {
+		previous := s.coreManager.Selector()
 		s.coreManager.SetSelector(newRoutingSelector(routingState))
 		s.appliedRoutingState = &routingState
+		// Release background resources (session cache, quota poller) held by
+		// the replaced selector.
+		if stoppable, ok := previous.(coreauth.StoppableSelector); ok {
+			stoppable.Stop()
+		}
 	}
 	s.applyRetryConfig(commit.cfg)
 	store := s.resolveCooldownStateStore(commit.cfg)


### PR DESCRIPTION
### The problem

I run Claude Code sessions that fan out to 50–100 subagents across several Claude Max accounts. Three compounding issues concentrated all of that load onto a single account and turned rate limits into hard failures:

1. **Subagents inherit the parent's `session_id`** (in `metadata.user_id`), so session affinity binds an entire fan-out to one credential. Observed: 43 of 47 requests on one binding.
2. **Selection is quota-blind.** Round-robin happily picks an account at 100% of its model-scoped weekly limit while another sits at 1%. Model scoping matters: an account measured 75% overall but 100% on one model tier — account-level health checks miss this entirely.
3. **529 and headerless 429 never retry.** Anthropic OAuth-account 429/529 responses carry no `Retry-After`; `shouldRetryAfterError` requires one, so these fail on the first attempt without trying other credentials.

### The changes (3 commits, independently revertable)

- **`fix(auth)`: 529 + headerless-429 failover.** 529 is treated like the other transient upstream errors (cooldown via the existing transient path); a 429/529 with no usable `Retry-After` gets a short default wait instead of `(0, false)`. Existing `Retry-After` behavior unchanged.
- **`feat(routing)`: `session-id-mode: content-hash`.** Opt-in. For Claude Code traffic, the affinity key becomes `session_id + hash(full first message content)`. Subagents (same session_id, different prompts) bind independently; every turn of one conversation still pins to its credential, so per-credential prompt caches stay warm. Full-content hashing is deliberate: subagents share their first few KB verbatim, so prefix hashing collapses them.
- **`feat(routing)`: `strategy: quota-aware`.** A background poller fetches each Claude credential's usage from `/api/oauth/usage` (per model tier) and the selector picks proportionally to remaining headroom. Never argmax (avoids stampeding one account). Pick() does no I/O. Degrades to round-robin when quota is unknown, and only over quota-unknown credentials — known-exhausted ones stay excluded on stale data. The poller backs off hard (15m→2h) if the usage endpoint rate-limits, since that endpoint's per-IP bucket is shared and headerless.

Both new behaviors are opt-in config (`routing.strategy: quota-aware`, `routing.session-id-mode: content-hash`); defaults are unchanged. Composes with session affinity as its fallback selector rather than replacing it.

### Relation to weighted-round-robin

`quota-aware` is a sibling strategy to the recently-merged `weighted-round-robin`, not a replacement: WRR distributes proportionally to static, operator-assigned integer weights, while quota-aware distributes proportionally to live remaining quota headroom fetched from Anthropic's OAuth usage endpoint per Claude credential (session window, weekly-all, and model-scoped weekly tiers). The two share no state — quota-aware is wired only into the `routing.strategy` switch and runs through the existing legacy selector pick path rather than the built-in scheduler fast path, so the WRR scheduler machinery (credential weights, smooth-weighted state, weight validation) is untouched. When quota data is unknown or stale the strategy degrades to round-robin over unknown credentials only, keeping known-exhausted credentials excluded.

One item flagged for maintainer review: the background poller uses a 15s `http.Client` timeout, which sits in tension with the repo's timeouts-only-during-credential-acquisition rule. Rationale (in a code comment): it's background credential-quota polling that never sits on a request path, and an unbounded hang there is worse. Happy to change if you'd prefer a different mechanism.

### Validation (live, 4 Claude Max accounts)

- 8 concurrent requests sharing one `session_id` with distinct prompts: 4 distinct credential bindings (previously 1). Identical repeat request: affinity cache hit on its own binding.
- 16 requests on a model tier where 2 of 4 accounts were exhausted: zero requests to the exhausted accounts, remainder split ~proportional to headroom.
- Observed a live 429 on one credential roll over to another and return 200 to the client (previously a client-visible failure).
- `go build ./...`, `go vet`, package tests green; new tests cover the retry gate, cooldown marking, proportional distribution, tier exclusion, stale-data degradation, and content-hash extraction.

Companion UI PR (quota visibility in the management panel): router-for-me/Cli-Proxy-API-Management-Center#363
