### PR TITLE
fix(thinking): translate explicit thinking text controls

### DIFF
--- a/internal/runtime/executor/aistudio_executor.go
+++ b/internal/runtime/executor/aistudio_executor.go
@@ -461,7 +461,7 @@ func (e *AIStudioExecutor) translateRequest(ctx context.Context, req cliproxyexe
 	originalPayload := originalPayloadSource
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, stream)
 	payload := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, stream)
-	payload, err := thinking.ApplyThinking(payload, req.Model, from.String(), to.String(), e.Identifier())
+	payload, err := helps.ApplyRequestThinking(payload, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, translatedPayload{}, err
 	}

--- a/internal/runtime/executor/antigravity_executor_execute.go
+++ b/internal/runtime/executor/antigravity_executor_execute.go
@@ -68,7 +68,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, false)
 	translated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false)
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err = helps.ApplyRequestThinking(translated, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -290,7 +290,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, true)
 	translated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, true)
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err = helps.ApplyRequestThinking(translated, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}

--- a/internal/runtime/executor/antigravity_executor_stream.go
+++ b/internal/runtime/executor/antigravity_executor_stream.go
@@ -63,7 +63,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, true)
 	translated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, true)
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err = helps.ApplyRequestThinking(translated, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/executor/antigravity_executor_tokens.go
+++ b/internal/runtime/executor/antigravity_executor_tokens.go
@@ -50,7 +50,7 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 	// Prepare payload once (doesn't depend on baseURL)
 	payload := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false)
 
-	payload, err := thinking.ApplyThinking(payload, req.Model, from.String(), to.String(), e.Identifier())
+	payload, err := helps.ApplyRequestThinking(payload, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}

--- a/internal/runtime/executor/codex_openai_images.go
+++ b/internal/runtime/executor/codex_openai_images.go
@@ -674,7 +674,7 @@ func (e *CodexExecutor) prepareCodexOpenAIImageBody(body []byte, req cliproxyexe
 		mainModel = codexOpenAIImagesMainModel
 	}
 	var errThinking error
-	out, errThinking = thinking.ApplyThinking(out, mainModel, codexOpenAIImageSourceFormat, "codex", e.Identifier())
+	out, errThinking = thinking.ApplyThinkingWithSource(out, body, mainModel, codexOpenAIImageSourceFormat, "codex", e.Identifier())
 	if errThinking != nil {
 		return nil, errThinking
 	}

--- a/internal/runtime/executor/gemini_executor_test.go
+++ b/internal/runtime/executor/gemini_executor_test.go
@@ -671,8 +671,8 @@ func TestGeminiExecutorNativeInteractionsAppliesThinkingSuffix(t *testing.T) {
 	if got := gjson.GetBytes(upstreamBody, "generation_config.thinking_level").String(); got != "high" {
 		t.Fatalf("thinking_level = %q, want high. Body: %s", got, string(upstreamBody))
 	}
-	if got := gjson.GetBytes(upstreamBody, "generation_config.thinking_summaries").String(); got != "auto" {
-		t.Fatalf("thinking_summaries = %q, want auto. Body: %s", got, string(upstreamBody))
+	if gjson.GetBytes(upstreamBody, "generation_config.thinking_summaries").Exists() {
+		t.Fatalf("thinking_summaries should be absent without explicit summary intent. Body: %s", string(upstreamBody))
 	}
 }
 

--- a/internal/runtime/executor/helps/model_capabilities.go
+++ b/internal/runtime/executor/helps/model_capabilities.go
@@ -9,12 +9,12 @@ import (
 // ApplyRequestThinking preserves the registry lookup path unless the auth
 // manager bound an exact configured API-key model definition to this attempt.
 func ApplyRequestThinking(body []byte, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, fromFormat, toFormat, provider string) ([]byte, error) {
+	sourceBody := opts.OriginalRequest
+	if len(sourceBody) == 0 {
+		sourceBody = req.Payload
+	}
 	if modelInfo, ok := cliproxyauth.ResolvedAPIKeyModelInfo(req); ok {
-		sourceBody := opts.OriginalRequest
-		if len(sourceBody) == 0 {
-			sourceBody = req.Payload
-		}
 		return thinking.ApplyThinkingWithModelInfo(body, sourceBody, req.Model, fromFormat, toFormat, provider, modelInfo)
 	}
-	return thinking.ApplyThinking(body, req.Model, fromFormat, toFormat, provider)
+	return thinking.ApplyThinkingWithSource(body, sourceBody, req.Model, fromFormat, toFormat, provider)
 }

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -113,7 +113,7 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 		return resp, fmt.Errorf("kimi executor: failed to set model in payload: %w", err)
 	}
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), "kimi", e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), "kimi", e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -222,7 +222,7 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 		return nil, fmt.Errorf("kimi executor: failed to set model in payload: %w", err)
 	}
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), "kimi", e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), "kimi", e.Identifier())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -165,6 +165,12 @@ func ApplyThinking(body []byte, model string, fromFormat string, toFormat string
 	return applyThinking(body, nil, model, fromFormat, toFormat, providerKey, nil, false)
 }
 
+// ApplyThinkingWithSource applies thinking while preserving summary visibility
+// intent extracted from the original client payload before translation.
+func ApplyThinkingWithSource(body, sourceBody []byte, model string, fromFormat string, toFormat string, providerKey string) ([]byte, error) {
+	return applyThinking(body, sourceBody, model, fromFormat, toFormat, providerKey, nil, false)
+}
+
 // ApplyThinkingWithModelInfo applies thinking with the exact configured model
 // definition selected for an API-key execution attempt.
 func ApplyThinkingWithModelInfo(body, sourceBody []byte, model string, fromFormat string, toFormat string, providerKey string, modelInfo *registry.ModelInfo) ([]byte, error) {
@@ -183,6 +189,10 @@ func applyThinking(body, sourceBody []byte, model string, fromFormat string, toF
 	fromFormat = strings.ToLower(strings.TrimSpace(fromFormat))
 	if fromFormat == "" {
 		fromFormat = providerFormat
+	}
+	summaryConfig := ExtractSummaryConfig(body, providerFormat)
+	if len(sourceBody) > 0 {
+		summaryConfig = ExtractSummaryConfig(sourceBody, fromFormat)
 	}
 	// 1. Route check: Get provider applier
 	applier := GetProviderApplier(providerFormat)
@@ -207,11 +217,11 @@ func applyThinking(body, sourceBody []byte, model string, fromFormat string, toF
 	// Unknown models are treated as user-defined so thinking config can still be applied.
 	// The upstream service is responsible for validating the configuration.
 	if IsUserDefinedModel(modelInfo) {
-		return applyUserDefinedModel(body, modelInfo, fromFormat, providerFormat, suffixResult)
+		return applyUserDefinedModel(body, modelInfo, fromFormat, providerFormat, suffixResult, summaryConfig)
 	}
 	if modelInfo.Thinking == nil {
 		config := extractThinkingConfig(body, providerFormat)
-		if hasThinkingConfig(config) {
+		if hasThinkingConfig(config) || summaryConfig.Mode != SummaryUnspecified {
 			log.WithFields(log.Fields{
 				"model":    baseModel,
 				"provider": providerFormat,
@@ -296,8 +306,13 @@ func applyThinking(body, sourceBody []byte, model string, fromFormat string, toF
 		"level":    validated.Level,
 	}).Debug("thinking: processed config to apply |")
 
-	// 6. Apply configuration using provider-specific applier
-	return applier.Apply(body, *validated, modelInfo)
+	// 6. Apply configuration using provider-specific applier, then restore the
+	// source summary intent after suffix processing.
+	applied, err := applier.Apply(body, *validated, modelInfo)
+	if err != nil {
+		return applied, err
+	}
+	return ApplySummaryConfigForModel(applied, providerFormat, baseModel, summaryConfig), nil
 }
 
 func shouldMapConfiguredHighIntent(fromFormat, toFormat string, modelInfo *registry.ModelInfo) bool {
@@ -386,7 +401,7 @@ func parseSuffixToConfig(rawSuffix, provider, model string) ThinkingConfig {
 
 // applyUserDefinedModel applies thinking configuration for user-defined models
 // without ThinkingSupport validation.
-func applyUserDefinedModel(body []byte, modelInfo *registry.ModelInfo, fromFormat, toFormat string, suffixResult SuffixResult) ([]byte, error) {
+func applyUserDefinedModel(body []byte, modelInfo *registry.ModelInfo, fromFormat, toFormat string, suffixResult SuffixResult, summaryConfig SummaryConfig) ([]byte, error) {
 	// Get model ID for logging
 	modelID := ""
 	if modelInfo != nil {
@@ -447,7 +462,11 @@ func applyUserDefinedModel(body []byte, modelInfo *registry.ModelInfo, fromForma
 		"budget":   config.Budget,
 		"level":    config.Level,
 	}).Debug("thinking: processed config to apply |")
-	return applier.Apply(body, config, modelInfo)
+	applied, err := applier.Apply(body, config, modelInfo)
+	if err != nil {
+		return applied, err
+	}
+	return ApplySummaryConfigForModel(applied, toFormat, modelID, summaryConfig), nil
 }
 
 func normalizeUserDefinedConfig(config ThinkingConfig, fromFormat, toFormat string) ThinkingConfig {

--- a/internal/thinking/provider/antigravity/apply.go
+++ b/internal/thinking/provider/antigravity/apply.go
@@ -98,19 +98,19 @@ func (a *Applier) applyLevelFormat(body []byte, config thinking.ThinkingConfig) 
 	result, _ := sjson.DeleteBytes(body, "request.generationConfig.thinkingConfig.thinkingBudget")
 	result, _ = sjson.DeleteBytes(result, "request.generationConfig.thinkingConfig.thinking_budget")
 	result, _ = sjson.DeleteBytes(result, "request.generationConfig.thinkingConfig.thinking_level")
-	// Normalize includeThoughts field name to avoid oneof conflicts in upstream JSON parsing.
+	// Normalize includeThoughts field name and retain only documented booleans.
+	result, _ = sjson.DeleteBytes(result, "request.generationConfig.thinkingConfig.includeThoughts")
 	result, _ = sjson.DeleteBytes(result, "request.generationConfig.thinkingConfig.include_thoughts")
 
 	if config.Mode == thinking.ModeNone {
 		if config.Budget == 0 && config.Level == "" {
 			result, _ = sjson.DeleteBytes(result, "request.generationConfig.thinkingConfig")
-			return result, nil
+			return applyAntigravityIncludeThoughts(result, body), nil
 		}
-		result, _ = sjson.SetBytes(result, "request.generationConfig.thinkingConfig.includeThoughts", false)
 		if config.Level != "" {
 			result, _ = sjson.SetBytes(result, "request.generationConfig.thinkingConfig.thinkingLevel", string(config.Level))
 		}
-		return result, nil
+		return applyAntigravityIncludeThoughts(result, body), nil
 	}
 
 	// Only handle ModeLevel - budget conversion should be done by upper layer
@@ -120,17 +120,7 @@ func (a *Applier) applyLevelFormat(body []byte, config thinking.ThinkingConfig) 
 
 	level := string(config.Level)
 	result, _ = sjson.SetBytes(result, "request.generationConfig.thinkingConfig.thinkingLevel", level)
-
-	// Respect user's explicit includeThoughts setting from original body; default to true if not set
-	// Support both camelCase and snake_case variants
-	includeThoughts := true
-	if inc := gjson.GetBytes(body, "request.generationConfig.thinkingConfig.includeThoughts"); inc.Exists() {
-		includeThoughts = inc.Bool()
-	} else if inc := gjson.GetBytes(body, "request.generationConfig.thinkingConfig.include_thoughts"); inc.Exists() {
-		includeThoughts = inc.Bool()
-	}
-	result, _ = sjson.SetBytes(result, "request.generationConfig.thinkingConfig.includeThoughts", includeThoughts)
-	return result, nil
+	return applyAntigravityIncludeThoughts(result, body), nil
 }
 
 func (a *Applier) applyBudgetFormat(body []byte, config thinking.ThinkingConfig, modelInfo *registry.ModelInfo, isClaude bool) ([]byte, error) {
@@ -138,7 +128,8 @@ func (a *Applier) applyBudgetFormat(body []byte, config thinking.ThinkingConfig,
 	result, _ := sjson.DeleteBytes(body, "request.generationConfig.thinkingConfig.thinkingLevel")
 	result, _ = sjson.DeleteBytes(result, "request.generationConfig.thinkingConfig.thinking_level")
 	result, _ = sjson.DeleteBytes(result, "request.generationConfig.thinkingConfig.thinking_budget")
-	// Normalize includeThoughts field name to avoid oneof conflicts in upstream JSON parsing.
+	// Normalize includeThoughts field name and retain only documented booleans.
+	result, _ = sjson.DeleteBytes(result, "request.generationConfig.thinkingConfig.includeThoughts")
 	result, _ = sjson.DeleteBytes(result, "request.generationConfig.thinkingConfig.include_thoughts")
 
 	budget := config.Budget
@@ -146,46 +137,32 @@ func (a *Applier) applyBudgetFormat(body []byte, config thinking.ThinkingConfig,
 	// Apply Claude-specific constraints first to get the final budget value
 	if isClaude && modelInfo != nil {
 		budget, result = a.normalizeClaudeBudget(budget, result, modelInfo)
-		// Check if budget was removed entirely
+		// Check if the thinking amount was removed entirely. Summary visibility is
+		// independent, so retain an explicit includeThoughts control if present.
 		if budget == -2 {
-			return result, nil
-		}
-	}
-
-	// For ModeNone, always set includeThoughts to false regardless of user setting.
-	// This ensures that when user requests budget=0 (disable thinking output),
-	// the includeThoughts is correctly set to false even if budget is clamped to min.
-	if config.Mode == thinking.ModeNone {
-		result, _ = sjson.SetBytes(result, "request.generationConfig.thinkingConfig.thinkingBudget", budget)
-		result, _ = sjson.SetBytes(result, "request.generationConfig.thinkingConfig.includeThoughts", false)
-		return result, nil
-	}
-
-	// Determine includeThoughts: respect user's explicit setting from original body if provided
-	// Support both camelCase and snake_case variants
-	var includeThoughts bool
-	var userSetIncludeThoughts bool
-	if inc := gjson.GetBytes(body, "request.generationConfig.thinkingConfig.includeThoughts"); inc.Exists() {
-		includeThoughts = inc.Bool()
-		userSetIncludeThoughts = true
-	} else if inc := gjson.GetBytes(body, "request.generationConfig.thinkingConfig.include_thoughts"); inc.Exists() {
-		includeThoughts = inc.Bool()
-		userSetIncludeThoughts = true
-	}
-
-	if !userSetIncludeThoughts {
-		// No explicit setting, use default logic based on mode
-		switch config.Mode {
-		case thinking.ModeAuto:
-			includeThoughts = true
-		default:
-			includeThoughts = budget > 0
+			return applyAntigravityIncludeThoughts(result, body), nil
 		}
 	}
 
 	result, _ = sjson.SetBytes(result, "request.generationConfig.thinkingConfig.thinkingBudget", budget)
-	result, _ = sjson.SetBytes(result, "request.generationConfig.thinkingConfig.includeThoughts", includeThoughts)
-	return result, nil
+	return applyAntigravityIncludeThoughts(result, body), nil
+}
+
+func applyAntigravityIncludeThoughts(result, original []byte) []byte {
+	for _, path := range []string{
+		"request.generationConfig.thinkingConfig.includeThoughts",
+		"request.generationConfig.thinkingConfig.include_thoughts",
+	} {
+		switch value := gjson.GetBytes(original, path); value.Type {
+		case gjson.True:
+			result, _ = sjson.SetBytes(result, "request.generationConfig.thinkingConfig.includeThoughts", true)
+			return result
+		case gjson.False:
+			result, _ = sjson.SetBytes(result, "request.generationConfig.thinkingConfig.includeThoughts", false)
+			return result
+		}
+	}
+	return result
 }
 
 // normalizeClaudeBudget applies Claude-specific constraints to thinking budget.

--- a/internal/thinking/provider/claude/apply.go
+++ b/internal/thinking/provider/claude/apply.go
@@ -87,6 +87,8 @@ func (a *Applier) Apply(body []byte, config thinking.ThinkingConfig, modelInfo *
 	case thinking.ModeNone:
 		result, _ := sjson.SetBytes(body, "thinking.type", "disabled")
 		result, _ = sjson.DeleteBytes(result, "thinking.budget_tokens")
+		// Summary display only applies to an active thinking block.
+		result, _ = sjson.DeleteBytes(result, "thinking.display")
 		result, _ = sjson.DeleteBytes(result, "output_config.effort")
 		if oc := gjson.GetBytes(result, "output_config"); oc.Exists() && oc.IsObject() && len(oc.Map()) == 0 {
 			result, _ = sjson.DeleteBytes(result, "output_config")
@@ -231,6 +233,8 @@ func applyCompatibleClaude(body []byte, config thinking.ThinkingConfig) ([]byte,
 	case thinking.ModeNone:
 		result, _ := sjson.SetBytes(body, "thinking.type", "disabled")
 		result, _ = sjson.DeleteBytes(result, "thinking.budget_tokens")
+		// Summary display only applies to an active thinking block.
+		result, _ = sjson.DeleteBytes(result, "thinking.display")
 		result, _ = sjson.DeleteBytes(result, "output_config.effort")
 		if oc := gjson.GetBytes(result, "output_config"); oc.Exists() && oc.IsObject() && len(oc.Map()) == 0 {
 			result, _ = sjson.DeleteBytes(result, "output_config")

--- a/internal/thinking/provider/gemini/apply.go
+++ b/internal/thinking/provider/gemini/apply.go
@@ -114,27 +114,27 @@ func (a *Applier) applyCompatible(body []byte, config thinking.ThinkingConfig) (
 
 func (a *Applier) applyLevelFormat(body []byte, config thinking.ThinkingConfig) ([]byte, error) {
 	// ModeNone semantics:
-	//   - ModeNone + Budget=0: remove thinkingConfig to disable thinking
-	//   - ModeNone + Budget>0: forced to think but hide output (includeThoughts=false)
-	// ValidateConfig sets config.Level to the lowest level when ModeNone + Budget > 0.
+	//   - ModeNone + Budget=0: remove the thinking amount configuration.
+	//   - ModeNone + Budget>0: clamp to the model's lowest supported amount.
+	// Summary visibility remains independent and is restored only when explicitly set.
 
 	// Remove conflicting fields to avoid both thinkingLevel and thinkingBudget in output
 	result, _ := sjson.DeleteBytes(body, "generationConfig.thinkingConfig.thinkingBudget")
 	result, _ = sjson.DeleteBytes(result, "generationConfig.thinkingConfig.thinking_budget")
 	result, _ = sjson.DeleteBytes(result, "generationConfig.thinkingConfig.thinking_level")
-	// Normalize includeThoughts field name to avoid oneof conflicts in upstream JSON parsing.
+	// Normalize includeThoughts field name and retain only documented booleans.
+	result, _ = sjson.DeleteBytes(result, "generationConfig.thinkingConfig.includeThoughts")
 	result, _ = sjson.DeleteBytes(result, "generationConfig.thinkingConfig.include_thoughts")
 
 	if config.Mode == thinking.ModeNone {
 		if config.Budget == 0 && config.Level == "" {
 			result, _ = sjson.DeleteBytes(result, "generationConfig.thinkingConfig")
-			return result, nil
+			return applyGeminiIncludeThoughts(result, body), nil
 		}
-		result, _ = sjson.SetBytes(result, "generationConfig.thinkingConfig.includeThoughts", false)
 		if config.Level != "" {
 			result, _ = sjson.SetBytes(result, "generationConfig.thinkingConfig.thinkingLevel", string(config.Level))
 		}
-		return result, nil
+		return applyGeminiIncludeThoughts(result, body), nil
 	}
 
 	// Only handle ModeLevel - budget conversion should be done by upper layer
@@ -144,17 +144,7 @@ func (a *Applier) applyLevelFormat(body []byte, config thinking.ThinkingConfig) 
 
 	level := string(config.Level)
 	result, _ = sjson.SetBytes(result, "generationConfig.thinkingConfig.thinkingLevel", level)
-
-	// Respect user's explicit includeThoughts setting from original body; default to true if not set
-	// Support both camelCase and snake_case variants
-	includeThoughts := true
-	if inc := gjson.GetBytes(body, "generationConfig.thinkingConfig.includeThoughts"); inc.Exists() {
-		includeThoughts = inc.Bool()
-	} else if inc := gjson.GetBytes(body, "generationConfig.thinkingConfig.include_thoughts"); inc.Exists() {
-		includeThoughts = inc.Bool()
-	}
-	result, _ = sjson.SetBytes(result, "generationConfig.thinkingConfig.includeThoughts", includeThoughts)
-	return result, nil
+	return applyGeminiIncludeThoughts(result, body), nil
 }
 
 func (a *Applier) applyBudgetFormat(body []byte, config thinking.ThinkingConfig) ([]byte, error) {
@@ -162,43 +152,28 @@ func (a *Applier) applyBudgetFormat(body []byte, config thinking.ThinkingConfig)
 	result, _ := sjson.DeleteBytes(body, "generationConfig.thinkingConfig.thinkingLevel")
 	result, _ = sjson.DeleteBytes(result, "generationConfig.thinkingConfig.thinking_level")
 	result, _ = sjson.DeleteBytes(result, "generationConfig.thinkingConfig.thinking_budget")
-	// Normalize includeThoughts field name to avoid oneof conflicts in upstream JSON parsing.
+	// Normalize includeThoughts field name and retain only documented booleans.
+	result, _ = sjson.DeleteBytes(result, "generationConfig.thinkingConfig.includeThoughts")
 	result, _ = sjson.DeleteBytes(result, "generationConfig.thinkingConfig.include_thoughts")
 
 	budget := config.Budget
+	result, _ = sjson.SetBytes(result, "generationConfig.thinkingConfig.thinkingBudget", budget)
+	return applyGeminiIncludeThoughts(result, body), nil
+}
 
-	// For ModeNone, always set includeThoughts to false regardless of user setting.
-	// This ensures that when user requests budget=0 (disable thinking output),
-	// the includeThoughts is correctly set to false even if budget is clamped to min.
-	if config.Mode == thinking.ModeNone {
-		result, _ = sjson.SetBytes(result, "generationConfig.thinkingConfig.thinkingBudget", budget)
-		result, _ = sjson.SetBytes(result, "generationConfig.thinkingConfig.includeThoughts", false)
-		return result, nil
-	}
-
-	// Determine includeThoughts: respect user's explicit setting from original body if provided
-	// Support both camelCase and snake_case variants
-	var includeThoughts bool
-	var userSetIncludeThoughts bool
-	if inc := gjson.GetBytes(body, "generationConfig.thinkingConfig.includeThoughts"); inc.Exists() {
-		includeThoughts = inc.Bool()
-		userSetIncludeThoughts = true
-	} else if inc := gjson.GetBytes(body, "generationConfig.thinkingConfig.include_thoughts"); inc.Exists() {
-		includeThoughts = inc.Bool()
-		userSetIncludeThoughts = true
-	}
-
-	if !userSetIncludeThoughts {
-		// No explicit setting, use default logic based on mode
-		switch config.Mode {
-		case thinking.ModeAuto:
-			includeThoughts = true
-		default:
-			includeThoughts = budget > 0
+func applyGeminiIncludeThoughts(result, original []byte) []byte {
+	for _, path := range []string{
+		"generationConfig.thinkingConfig.includeThoughts",
+		"generationConfig.thinkingConfig.include_thoughts",
+	} {
+		switch value := gjson.GetBytes(original, path); value.Type {
+		case gjson.True:
+			result, _ = sjson.SetBytes(result, "generationConfig.thinkingConfig.includeThoughts", true)
+			return result
+		case gjson.False:
+			result, _ = sjson.SetBytes(result, "generationConfig.thinkingConfig.includeThoughts", false)
+			return result
 		}
 	}
-
-	result, _ = sjson.SetBytes(result, "generationConfig.thinkingConfig.thinkingBudget", budget)
-	result, _ = sjson.SetBytes(result, "generationConfig.thinkingConfig.includeThoughts", includeThoughts)
-	return result, nil
+	return result
 }

--- a/internal/thinking/provider/interactions/apply.go
+++ b/internal/thinking/provider/interactions/apply.go
@@ -34,11 +34,11 @@ func (a *Applier) Apply(body []byte, config thinking.ThinkingConfig, modelInfo *
 	result := stripInteractionsThinkingFields(body)
 	switch config.Mode {
 	case thinking.ModeLevel:
-		return applyInteractionsLevel(result, body, string(config.Level), modelInfo, "auto"), nil
+		return applyInteractionsLevel(result, body, string(config.Level), modelInfo), nil
 	case thinking.ModeBudget:
-		return applyInteractionsBudget(result, body, config.Budget, modelInfo, "auto"), nil
+		return applyInteractionsBudget(result, body, config.Budget, modelInfo), nil
 	case thinking.ModeAuto:
-		return setInteractionsThinkingSummaries(result, body, "auto"), nil
+		return setInteractionsThinkingSummaries(result, body), nil
 	case thinking.ModeNone:
 		return applyInteractionsNone(result, body, config, modelInfo), nil
 	default:
@@ -46,38 +46,38 @@ func (a *Applier) Apply(body []byte, config thinking.ThinkingConfig, modelInfo *
 	}
 }
 
-func applyInteractionsBudget(result, original []byte, budget int, modelInfo *registry.ModelInfo, summariesFallback string) []byte {
+func applyInteractionsBudget(result, original []byte, budget int, modelInfo *registry.ModelInfo) []byte {
 	level, ok := thinking.ConvertBudgetToLevel(budget)
 	if !ok {
-		return result
+		return setInteractionsThinkingSummaries(result, original)
 	}
 	switch level {
-	case string(thinking.LevelNone):
-		return setInteractionsThinkingSummaries(result, original, "none")
-	case string(thinking.LevelAuto):
-		return setInteractionsThinkingSummaries(result, original, "auto")
+	case string(thinking.LevelNone), string(thinking.LevelAuto):
+		// Thinking amount and summary visibility are independent. Interactions has
+		// no wire-level "none" thinking level, so preserve only explicit summary
+		// intent and otherwise let the target model use its documented default.
+		return setInteractionsThinkingSummaries(result, original)
 	default:
-		return applyInteractionsLevel(result, original, level, modelInfo, summariesFallback)
+		return applyInteractionsLevel(result, original, level, modelInfo)
 	}
 }
 
-func applyInteractionsLevel(result, original []byte, level string, modelInfo *registry.ModelInfo, summariesFallback string) []byte {
+func applyInteractionsLevel(result, original []byte, level string, modelInfo *registry.ModelInfo) []byte {
 	level = normalizeInteractionsLevel(level, modelInfo)
-	if level == "" {
-		return result
+	if level != "" {
+		result, _ = sjson.SetBytes(result, "generation_config.thinking_level", level)
 	}
-	result, _ = sjson.SetBytes(result, "generation_config.thinking_level", level)
-	return setInteractionsThinkingSummaries(result, original, summariesFallback)
+	return setInteractionsThinkingSummaries(result, original)
 }
 
 func applyInteractionsNone(result, original []byte, config thinking.ThinkingConfig, modelInfo *registry.ModelInfo) []byte {
 	if config.Level != "" {
-		result = applyInteractionsLevel(result, original, string(config.Level), modelInfo, "none")
-	} else if config.Budget > 0 {
-		result = applyInteractionsBudget(result, original, config.Budget, modelInfo, "none")
+		return applyInteractionsLevel(result, original, string(config.Level), modelInfo)
 	}
-	result, _ = sjson.SetBytes(result, "generation_config.thinking_summaries", "none")
-	return result
+	if config.Budget > 0 {
+		return applyInteractionsBudget(result, original, config.Budget, modelInfo)
+	}
+	return setInteractionsThinkingSummaries(result, original)
 }
 
 func stripInteractionsThinkingFields(body []byte) []byte {
@@ -104,7 +104,7 @@ func stripInteractionsThinkingFields(body []byte) []byte {
 	return result
 }
 
-func setInteractionsThinkingSummaries(result, original []byte, fallback string) []byte {
+func setInteractionsThinkingSummaries(result, original []byte) []byte {
 	if value, okValue := originalInteractionsThinkingSummaries(original); okValue {
 		result, _ = sjson.SetBytes(result, "generation_config.thinking_summaries", value)
 		return result
@@ -112,16 +112,9 @@ func setInteractionsThinkingSummaries(result, original []byte, fallback string) 
 	if includeThoughts, okValue := originalInteractionsIncludeThoughts(original); okValue {
 		value := "none"
 		if includeThoughts {
-			value = fallback
-			if value == "" {
-				value = "auto"
-			}
+			value = "auto"
 		}
 		result, _ = sjson.SetBytes(result, "generation_config.thinking_summaries", value)
-		return result
-	}
-	if fallback != "" {
-		result, _ = sjson.SetBytes(result, "generation_config.thinking_summaries", fallback)
 	}
 	return result
 }
@@ -132,8 +125,12 @@ func originalInteractionsThinkingSummaries(body []byte) (string, bool) {
 		"generation_config.thinkingSummaries",
 	} {
 		value := gjson.GetBytes(body, path)
-		if value.Exists() && value.Type == gjson.String {
-			return strings.ToLower(strings.TrimSpace(value.String())), true
+		if value.Type != gjson.String {
+			continue
+		}
+		switch normalized := strings.ToLower(strings.TrimSpace(value.String())); normalized {
+		case "auto", "none":
+			return normalized, true
 		}
 	}
 	return "", false
@@ -146,9 +143,11 @@ func originalInteractionsIncludeThoughts(body []byte) (bool, bool) {
 		"generation_config.thinkingConfig.include_thoughts",
 		"generation_config.thinkingConfig.includeThoughts",
 	} {
-		value := gjson.GetBytes(body, path)
-		if value.Exists() {
-			return value.Bool(), true
+		switch value := gjson.GetBytes(body, path); value.Type {
+		case gjson.True:
+			return true, true
+		case gjson.False:
+			return false, true
 		}
 	}
 	return false, false

--- a/internal/thinking/strip.go
+++ b/internal/thinking/strip.go
@@ -47,14 +47,14 @@ func StripThinkingConfig(body []byte, provider string) []byte {
 			"generation_config.thinkingConfig",
 		}
 	case "openai":
-		paths = []string{"reasoning_effort"}
+		paths = []string{"reasoning_effort", "reasoning"}
 	case "kimi":
 		paths = []string{
 			"reasoning_effort",
 			"thinking",
 		}
 	case "codex", "xai":
-		paths = []string{"reasoning.effort"}
+		paths = []string{"reasoning"}
 	default:
 		return body
 	}

--- a/internal/thinking/summary.go
+++ b/internal/thinking/summary.go
@@ -1,0 +1,489 @@
+package thinking
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// SummaryMode represents whether the client explicitly requested reasoning summaries.
+type SummaryMode int
+
+const (
+	SummaryUnspecified SummaryMode = iota
+	SummaryDisabled
+	SummaryEnabled
+)
+
+// SummaryConfig is the provider-neutral reasoning-summary visibility intent.
+// Detail preserves protocols that distinguish auto, concise, and detailed summaries.
+type SummaryConfig struct {
+	Mode   SummaryMode
+	Detail string
+}
+
+// ExtractSummaryConfig reads protocol-specific summary visibility intent.
+//
+// OpenAI Chat is the one protocol where effort implies summaries: chat
+// completions has no summary field of its own, and clients that send
+// reasoning_effort have always received reasoning summaries here, so treating a
+// non-none effort as an explicit request preserves that contract. Every other
+// protocol carries a dedicated summary field, so effort alone means nothing.
+func ExtractSummaryConfig(body []byte, format string) SummaryConfig {
+	normalized := strings.ToLower(strings.TrimSpace(format))
+	// Check the format first so unsupported targets skip whole-body validation.
+	if !summaryFormatSupported(normalized) || len(body) == 0 || !gjson.ValidBytes(body) {
+		return SummaryConfig{}
+	}
+
+	switch normalized {
+	case "openai":
+		if config, ok := extractOpenAIExplicitSummaryConfig(body); ok {
+			return config
+		}
+		if effort := gjson.GetBytes(body, "reasoning_effort"); effort.Type == gjson.String {
+			value := strings.ToLower(strings.TrimSpace(effort.String()))
+			if value == "" {
+				return SummaryConfig{}
+			}
+			if value == "none" {
+				return SummaryConfig{Mode: SummaryDisabled}
+			}
+			return SummaryConfig{Mode: SummaryEnabled, Detail: "auto"}
+		}
+	case "openai-response", "codex":
+		if config, ok := responsesSummaryConfig(body, "reasoning.summary"); ok {
+			return config
+		}
+		if config, ok := responsesSummaryConfig(body, "reasoning.generate_summary"); ok {
+			return config
+		}
+	case "claude":
+		// Anthropic only accepts display alongside active adaptive/manual thinking.
+		if !claudeThinkingAcceptsDisplay(body) {
+			return SummaryConfig{}
+		}
+		if config, ok := claudeSummaryConfig(body, "thinking.display"); ok {
+			return config
+		}
+	case "gemini":
+		if config, ok := firstSummaryBoolConfig(body, []string{
+			"generationConfig.thinkingConfig.includeThoughts",
+			"generationConfig.thinkingConfig.include_thoughts",
+			"generation_config.thinking_config.include_thoughts",
+			"generation_config.thinking_config.includeThoughts",
+		}); ok {
+			return config
+		}
+	case "antigravity":
+		if config, ok := firstSummaryBoolConfig(body, []string{
+			"request.generationConfig.thinkingConfig.includeThoughts",
+			"request.generationConfig.thinkingConfig.include_thoughts",
+			"request.generationConfig.thinking_config.includeThoughts",
+			"request.generationConfig.thinking_config.include_thoughts",
+		}); ok {
+			return config
+		}
+	case "interactions":
+		for _, path := range []string{
+			"generation_config.thinking_summaries",
+			"generation_config.thinkingSummaries",
+		} {
+			if config, ok := interactionsSummaryConfig(body, path); ok {
+				return config
+			}
+		}
+	}
+
+	return SummaryConfig{}
+}
+
+// ClearSummaryConfig removes target visibility controls when the source did not
+// explicitly request thinking text. This prevents a protocol translator's
+// historical default from becoming a new, unintended visibility request.
+func ClearSummaryConfig(body []byte, format string) []byte {
+	normalized := strings.ToLower(strings.TrimSpace(format))
+	if !summaryFormatSupported(normalized) || len(body) == 0 || !gjson.ValidBytes(body) {
+		return body
+	}
+
+	switch normalized {
+	case "claude":
+		body, _ = sjson.DeleteBytes(body, "thinking.display")
+	case "gemini":
+		for _, path := range []string{
+			"generationConfig.thinkingConfig.includeThoughts",
+			"generationConfig.thinkingConfig.include_thoughts",
+			"generation_config.thinking_config.include_thoughts",
+			"generation_config.thinking_config.includeThoughts",
+		} {
+			body, _ = sjson.DeleteBytes(body, path)
+		}
+	case "antigravity":
+		for _, path := range []string{
+			"request.generationConfig.thinkingConfig.includeThoughts",
+			"request.generationConfig.thinkingConfig.include_thoughts",
+			"request.generationConfig.thinking_config.includeThoughts",
+			"request.generation_config.thinking_config.include_thoughts",
+		} {
+			body, _ = sjson.DeleteBytes(body, path)
+		}
+	case "interactions":
+		body, _ = sjson.DeleteBytes(body, "generation_config.thinking_summaries")
+		body, _ = sjson.DeleteBytes(body, "generation_config.thinkingSummaries")
+	case "openai-response", "codex":
+		body, _ = sjson.DeleteBytes(body, "reasoning.summary")
+		body, _ = sjson.DeleteBytes(body, "reasoning.generate_summary")
+		if reasoning := gjson.GetBytes(body, "reasoning"); reasoning.IsObject() && len(reasoning.Map()) == 0 {
+			body, _ = sjson.DeleteBytes(body, "reasoning")
+		}
+	}
+	return body
+}
+
+// ApplySummaryConfig writes canonical summary intent in the target protocol.
+func ApplySummaryConfig(body []byte, format string, config SummaryConfig) []byte {
+	return ApplySummaryConfigForModel(body, format, "", config)
+}
+
+// ApplySummaryConfigForModel writes canonical summary intent in the target
+// protocol and uses target model capabilities when a valid target request must
+// activate thinking before it can request summaries.
+func ApplySummaryConfigForModel(body []byte, format, model string, config SummaryConfig) []byte {
+	normalized := strings.ToLower(strings.TrimSpace(format))
+	if config.Mode == SummaryUnspecified || !summaryFormatSupported(normalized) || len(body) == 0 || !gjson.ValidBytes(body) {
+		return body
+	}
+
+	enabled := config.Mode == SummaryEnabled
+	switch normalized {
+	case "openai":
+		body = applyOpenAIChatSummaryConfig(body, model, enabled)
+	case "claude":
+		// Anthropic documents display as invalid with thinking.type=disabled and
+		// requires it alongside adaptive or enabled thinking. A summary-only
+		// Responses/Gemini/Interactions request is valid at the source because
+		// those APIs have model-default thinking, so activate the target model's
+		// documented thinking mode before writing summarized display.
+		if enabled && !gjson.GetBytes(body, "thinking.type").Exists() {
+			body = enableClaudeThinkingForSummary(body, model)
+		}
+		if !claudeThinkingAcceptsDisplay(body) {
+			return body
+		}
+		value := "omitted"
+		if enabled {
+			value = "summarized"
+		}
+		body, _ = sjson.SetBytes(body, "thinking.display", value)
+	case "gemini":
+		body, _ = sjson.SetBytes(body, "generationConfig.thinkingConfig.includeThoughts", enabled)
+		for _, path := range []string{
+			"generationConfig.thinkingConfig.include_thoughts",
+			"generation_config.thinking_config.include_thoughts",
+			"generation_config.thinking_config.includeThoughts",
+		} {
+			body, _ = sjson.DeleteBytes(body, path)
+		}
+	case "antigravity":
+		body, _ = sjson.SetBytes(body, "request.generationConfig.thinkingConfig.includeThoughts", enabled)
+		for _, path := range []string{
+			"request.generationConfig.thinkingConfig.include_thoughts",
+			"request.generationConfig.thinking_config.include_thoughts",
+			"request.generationConfig.thinking_config.includeThoughts",
+		} {
+			body, _ = sjson.DeleteBytes(body, path)
+		}
+	case "interactions":
+		// Google Interactions only accepts auto or none. OpenAI's concise and
+		// detailed selectors therefore collapse to the supported enabled value.
+		value := "none"
+		if enabled {
+			value = "auto"
+		}
+		body, _ = sjson.SetBytes(body, "generation_config.thinking_summaries", value)
+		body, _ = sjson.DeleteBytes(body, "generation_config.thinkingSummaries")
+	case "openai-response", "codex":
+		if enabled {
+			body, _ = sjson.SetBytes(body, "reasoning.summary", normalizedSummaryDetail(config.Detail))
+			body, _ = sjson.DeleteBytes(body, "reasoning.generate_summary")
+			break
+		}
+		// Omitting the field is the documented way to disable summaries; an
+		// explicit null is not accepted by every Responses-compatible backend.
+		body, _ = sjson.DeleteBytes(body, "reasoning.summary")
+		body, _ = sjson.DeleteBytes(body, "reasoning.generate_summary")
+		if reasoning := gjson.GetBytes(body, "reasoning"); reasoning.IsObject() && len(reasoning.Map()) == 0 {
+			body, _ = sjson.DeleteBytes(body, "reasoning")
+		}
+	}
+	return body
+}
+
+// summaryFormatSupported reports whether a protocol carries summary visibility
+// intent that this package can read or write.
+func summaryFormatSupported(format string) bool {
+	switch format {
+	case "openai", "openai-response", "codex", "claude", "gemini", "antigravity", "interactions":
+		return true
+	default:
+		return false
+	}
+}
+
+// claudeThinkingAcceptsDisplay reports whether the body carries an active
+// thinking block that can hold a display field.
+func claudeThinkingAcceptsDisplay(body []byte) bool {
+	switch strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "thinking.type").String())) {
+	case "adaptive":
+		return true
+	case "enabled":
+		// This runs before ApplyThinking normalizes the request, so a missing
+		// budget_tokens is an unfinished body rather than inactive thinking.
+		// Only an explicit non-positive budget means thinking is off.
+		budget := gjson.GetBytes(body, "thinking.budget_tokens")
+		return budget.Type != gjson.Number || budget.Int() > 0
+	default:
+		return false
+	}
+}
+
+// applyOpenAIChatSummaryConfig writes summary visibility intent for the Chat
+// Completions protocol.
+//
+// Four dialects share this protocol and only OpenAI's is authoritative. OpenAI
+// documents no reasoning-visibility field at all (Chat Completions never returns
+// reasoning text) and rejects unknown body parameters, so reasoning_effort is the
+// only field that is always safe to write here. OpenRouter's documented
+// "reason but hide" bits (reasoning.exclude and its legacy include_reasoning
+// alias) are updated only when the body already carries them, which is exactly
+// when the upstream is known to understand them.
+func applyOpenAIChatSummaryConfig(body []byte, model string, enabled bool) []byte {
+	if gjson.GetBytes(body, "reasoning").IsObject() {
+		body, _ = sjson.SetBytes(body, "reasoning.exclude", !enabled)
+	}
+	if gjson.GetBytes(body, "include_reasoning").IsBool() {
+		body, _ = sjson.SetBytes(body, "include_reasoning", enabled)
+	}
+	if !enabled {
+		// Chat has no portable way to keep reasoning while hiding its summary.
+		// reasoning_effort:"none" would disable reasoning instead of hiding it,
+		// and Google documents that it is not even honored on Gemini 2.5 Pro or
+		// 3 models, so leave the effort the client asked for untouched.
+		return body
+	}
+	effort := gjson.GetBytes(body, "reasoning_effort")
+	if effort.Type != gjson.String || strings.TrimSpace(effort.String()) == "" || strings.EqualFold(strings.TrimSpace(effort.String()), "none") {
+		body, _ = sjson.SetBytes(body, "reasoning_effort", openAIChatSummaryEffort(body, model))
+	}
+	return body
+}
+
+// openAIChatSummaryEffort picks an active reasoning effort that the target model
+// documents. Chat exposes reasoning only while an effort is active, so a summary
+// request has to select one when the client left it unset.
+func openAIChatSummaryEffort(body []byte, model string) string {
+	baseModel := ParseSuffix(model).ModelName
+	if baseModel == "" {
+		baseModel = ParseSuffix(gjson.GetBytes(body, "model").String()).ModelName
+	}
+	modelInfo := registry.LookupModelInfo(baseModel, "openai")
+	if modelInfo == nil || modelInfo.Thinking == nil || len(modelInfo.Thinking.Levels) == 0 {
+		return "medium"
+	}
+
+	levels := make([]string, 0, len(modelInfo.Thinking.Levels))
+	for _, level := range modelInfo.Thinking.Levels {
+		normalized := strings.ToLower(strings.TrimSpace(level))
+		if normalized == "" || normalized == "none" {
+			continue
+		}
+		if normalized == "medium" {
+			return "medium"
+		}
+		levels = append(levels, normalized)
+	}
+	if len(levels) == 0 {
+		return "medium"
+	}
+	return levels[len(levels)/2]
+}
+
+func extractOpenAIExplicitSummaryConfig(body []byte) (SummaryConfig, bool) {
+	// Google's documented Chat Completions extension is the authoritative
+	// explicit visibility control when present, ahead of CPA compatibility
+	// aliases and Chat's reasoning_effort fallback.
+	for _, path := range []string{
+		"extra_body.google.thinking_config.include_thoughts",
+		"extra_body.google.thinking_config.includeThoughts",
+		"extra_body.google.thinkingConfig.include_thoughts",
+		"extra_body.google.thinkingConfig.includeThoughts",
+		"extra_body.extra_body.google.thinking_config.include_thoughts",
+		"extra_body.extra_body.google.thinking_config.includeThoughts",
+		"google.thinking_config.include_thoughts",
+		"google.thinking_config.includeThoughts",
+		"thinking.includeThoughts",
+		"thinking.include_thoughts",
+		"reasoning.includeThoughts",
+		"reasoning.include_thoughts",
+		"generationConfig.thinkingConfig.includeThoughts",
+		"generationConfig.thinkingConfig.include_thoughts",
+		"generation_config.thinking_config.include_thoughts",
+		"generation_config.thinking_config.includeThoughts",
+	} {
+		if config, ok := summaryBoolConfig(body, path); ok {
+			return config, true
+		}
+	}
+
+	for _, path := range []string{
+		"reasoning.summary",
+		"reasoning.generate_summary",
+	} {
+		if config, ok := responsesSummaryConfig(body, path); ok {
+			return config, true
+		}
+	}
+
+	// reasoning.exclude is OpenRouter's documented "reason but hide" bit, not an
+	// OpenAI wire field; include_reasoning is its documented legacy alias
+	// (include_reasoning: false is equivalent to reasoning: {exclude: true}).
+	// Only accept actual JSON booleans.
+	if exclude := gjson.GetBytes(body, "reasoning.exclude"); exclude.IsBool() {
+		if exclude.Bool() {
+			return SummaryConfig{Mode: SummaryDisabled}, true
+		}
+		return SummaryConfig{Mode: SummaryEnabled, Detail: "auto"}, true
+	}
+	if include := gjson.GetBytes(body, "include_reasoning"); include.IsBool() {
+		if include.Bool() {
+			return SummaryConfig{Mode: SummaryEnabled, Detail: "auto"}, true
+		}
+		return SummaryConfig{Mode: SummaryDisabled}, true
+	}
+	// OpenRouter's reasoning.enabled turns reasoning on "with no exclusions", so
+	// it also decides visibility when no dedicated bit was sent.
+	if enabled := gjson.GetBytes(body, "reasoning.enabled"); enabled.IsBool() {
+		if enabled.Bool() {
+			return SummaryConfig{Mode: SummaryEnabled, Detail: "auto"}, true
+		}
+		return SummaryConfig{Mode: SummaryDisabled}, true
+	}
+	return SummaryConfig{}, false
+}
+
+func firstSummaryBoolConfig(body []byte, paths []string) (SummaryConfig, bool) {
+	for _, path := range paths {
+		if config, ok := summaryBoolConfig(body, path); ok {
+			return config, true
+		}
+	}
+	return SummaryConfig{}, false
+}
+
+func summaryBoolConfig(body []byte, path string) (SummaryConfig, bool) {
+	switch value := gjson.GetBytes(body, path); value.Type {
+	case gjson.True:
+		return SummaryConfig{Mode: SummaryEnabled, Detail: "auto"}, true
+	case gjson.False:
+		return SummaryConfig{Mode: SummaryDisabled}, true
+	default:
+		return SummaryConfig{}, false
+	}
+}
+
+func responsesSummaryConfig(body []byte, path string) (SummaryConfig, bool) {
+	value := gjson.GetBytes(body, path)
+	if value.Raw == "" {
+		return SummaryConfig{}, false
+	}
+	if value.Type == gjson.Null {
+		return SummaryConfig{Mode: SummaryDisabled}, true
+	}
+	if value.Type != gjson.String {
+		return SummaryConfig{}, false
+	}
+
+	raw := strings.ToLower(strings.TrimSpace(value.String()))
+	switch raw {
+	case "auto", "concise", "detailed":
+		return SummaryConfig{Mode: SummaryEnabled, Detail: raw}, true
+	case "none":
+		// Compatibility with clients that expose a none enum; the OpenAI wire
+		// representation disables summaries by omitting the field.
+		return SummaryConfig{Mode: SummaryDisabled}, true
+	default:
+		return SummaryConfig{}, false
+	}
+}
+
+func claudeSummaryConfig(body []byte, path string) (SummaryConfig, bool) {
+	value := gjson.GetBytes(body, path)
+	if value.Type != gjson.String {
+		return SummaryConfig{}, false
+	}
+	switch strings.ToLower(strings.TrimSpace(value.String())) {
+	case "summarized":
+		return SummaryConfig{Mode: SummaryEnabled, Detail: "auto"}, true
+	case "omitted":
+		return SummaryConfig{Mode: SummaryDisabled}, true
+	default:
+		return SummaryConfig{}, false
+	}
+}
+
+func interactionsSummaryConfig(body []byte, path string) (SummaryConfig, bool) {
+	value := gjson.GetBytes(body, path)
+	if value.Type != gjson.String {
+		return SummaryConfig{}, false
+	}
+	switch strings.ToLower(strings.TrimSpace(value.String())) {
+	case "auto":
+		return SummaryConfig{Mode: SummaryEnabled, Detail: "auto"}, true
+	case "none":
+		return SummaryConfig{Mode: SummaryDisabled}, true
+	default:
+		return SummaryConfig{}, false
+	}
+}
+
+func enableClaudeThinkingForSummary(body []byte, model string) []byte {
+	baseModel := ParseSuffix(model).ModelName
+	if baseModel == "" {
+		baseModel = ParseSuffix(gjson.GetBytes(body, "model").String()).ModelName
+	}
+	modelInfo := registry.LookupModelInfo(baseModel, "claude")
+	if modelInfo == nil || modelInfo.Thinking == nil {
+		return body
+	}
+
+	if len(modelInfo.Thinking.Levels) > 0 {
+		body, _ = sjson.SetBytes(body, "thinking.type", "adaptive")
+		body, _ = sjson.DeleteBytes(body, "thinking.budget_tokens")
+		return body
+	}
+
+	budget := modelInfo.Thinking.Min
+	if budget <= 0 {
+		return body
+	}
+	if maxTokens := gjson.GetBytes(body, "max_tokens"); maxTokens.Exists() && maxTokens.Int() <= int64(budget) {
+		return body
+	}
+	body, _ = sjson.SetBytes(body, "thinking.type", "enabled")
+	body, _ = sjson.SetBytes(body, "thinking.budget_tokens", budget)
+	return body
+}
+
+func normalizedSummaryDetail(detail string) string {
+	switch strings.ToLower(strings.TrimSpace(detail)) {
+	case "concise":
+		return "concise"
+	case "detailed":
+		return "detailed"
+	default:
+		return "auto"
+	}
+}

--- a/internal/thinking/summary_test.go
+++ b/internal/thinking/summary_test.go
@@ -1,0 +1,211 @@
+package thinking
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestExtractSummaryConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		format     string
+		body       string
+		wantMode   SummaryMode
+		wantDetail string
+	}{
+		{name: "chat effort enables", format: "openai", body: `{"reasoning_effort":"high"}`, wantMode: SummaryEnabled, wantDetail: "auto"},
+		{name: "chat none disables", format: "openai", body: `{"reasoning_effort":"none"}`, wantMode: SummaryDisabled},
+		{name: "chat missing unspecified", format: "openai", body: `{}`, wantMode: SummaryUnspecified},
+		{name: "chat null effort unspecified", format: "openai", body: `{"reasoning_effort":null}`, wantMode: SummaryUnspecified},
+		{name: "chat non-string effort unspecified", format: "openai", body: `{"reasoning_effort":17}`, wantMode: SummaryUnspecified},
+		{name: "chat google extension false overrides effort", format: "openai", body: `{"reasoning_effort":"high","extra_body":{"google":{"thinking_config":{"include_thoughts":false}}}}`, wantMode: SummaryDisabled},
+		{name: "chat google extension true", format: "openai", body: `{"extra_body":{"google":{"thinking_config":{"include_thoughts":true}}}}`, wantMode: SummaryEnabled, wantDetail: "auto"},
+		{name: "chat exclude disables", format: "openai", body: `{"reasoning_effort":"high","reasoning":{"exclude":true}}`, wantMode: SummaryDisabled},
+		{name: "chat exclude false enables", format: "openai", body: `{"reasoning":{"effort":"high","exclude":false}}`, wantMode: SummaryEnabled, wantDetail: "auto"},
+		{name: "chat legacy include_reasoning false disables", format: "openai", body: `{"reasoning_effort":"high","include_reasoning":false}`, wantMode: SummaryDisabled},
+		{name: "chat legacy include_reasoning true enables", format: "openai", body: `{"include_reasoning":true}`, wantMode: SummaryEnabled, wantDetail: "auto"},
+		{name: "chat reasoning enabled false disables", format: "openai", body: `{"reasoning":{"enabled":false}}`, wantMode: SummaryDisabled},
+		{name: "chat reasoning enabled true enables", format: "openai", body: `{"reasoning":{"enabled":true}}`, wantMode: SummaryEnabled, wantDetail: "auto"},
+		{name: "chat exclude wins over include_reasoning", format: "openai", body: `{"reasoning":{"exclude":true},"include_reasoning":true}`, wantMode: SummaryDisabled},
+		{name: "chat non-boolean include_reasoning unspecified", format: "openai", body: `{"include_reasoning":"false"}`, wantMode: SummaryUnspecified},
+		{name: "responses effort alone unspecified", format: "openai-response", body: `{"reasoning":{"effort":"high"}}`, wantMode: SummaryUnspecified},
+		{name: "responses summary auto", format: "openai-response", body: `{"reasoning":{"effort":"high","summary":"auto"}}`, wantMode: SummaryEnabled, wantDetail: "auto"},
+		{name: "responses summary concise", format: "openai-response", body: `{"reasoning":{"summary":"concise"}}`, wantMode: SummaryEnabled, wantDetail: "concise"},
+		{name: "responses summary null", format: "openai-response", body: `{"reasoning":{"summary":null}}`, wantMode: SummaryDisabled},
+		{name: "responses boolean summary invalid", format: "openai-response", body: `{"reasoning":{"summary":true}}`, wantMode: SummaryUnspecified},
+		{name: "responses deprecated generate summary", format: "openai-response", body: `{"reasoning":{"generate_summary":"detailed"}}`, wantMode: SummaryEnabled, wantDetail: "detailed"},
+		{name: "claude summarized", format: "claude", body: `{"thinking":{"type":"adaptive","display":"summarized"}}`, wantMode: SummaryEnabled, wantDetail: "auto"},
+		{name: "claude omitted", format: "claude", body: `{"thinking":{"type":"enabled","budget_tokens":2048,"display":"omitted"}}`, wantMode: SummaryDisabled},
+		{name: "claude display without type is invalid", format: "claude", body: `{"thinking":{"display":"summarized"}}`, wantMode: SummaryUnspecified},
+		{name: "claude display with auto type is invalid", format: "claude", body: `{"thinking":{"type":"auto","display":"summarized"}}`, wantMode: SummaryUnspecified},
+		// ApplySummaryConfig runs before ApplyThinking fills budget_tokens, so an
+		// absent budget must not be read as inactive thinking.
+		{name: "claude enabled display without budget is valid", format: "claude", body: `{"thinking":{"type":"enabled","display":"summarized"}}`, wantMode: SummaryEnabled, wantDetail: "auto"},
+		{name: "claude enabled display with zero budget is invalid", format: "claude", body: `{"thinking":{"type":"enabled","budget_tokens":0,"display":"summarized"}}`, wantMode: SummaryUnspecified},
+		{name: "gemini include true", format: "gemini", body: `{"generationConfig":{"thinkingConfig":{"includeThoughts":true}}}`, wantMode: SummaryEnabled, wantDetail: "auto"},
+		{name: "gemini include false", format: "gemini", body: `{"generationConfig":{"thinkingConfig":{"includeThoughts":false}}}`, wantMode: SummaryDisabled},
+		{name: "antigravity include true", format: "antigravity", body: `{"request":{"generationConfig":{"thinkingConfig":{"includeThoughts":true}}}}`, wantMode: SummaryEnabled, wantDetail: "auto"},
+		{name: "interactions auto", format: "interactions", body: `{"generation_config":{"thinking_summaries":"auto"}}`, wantMode: SummaryEnabled, wantDetail: "auto"},
+		{name: "interactions none", format: "interactions", body: `{"generation_config":{"thinking_summaries":"none"}}`, wantMode: SummaryDisabled},
+		{name: "interactions detailed is invalid", format: "interactions", body: `{"generation_config":{"thinking_summaries":"detailed"}}`, wantMode: SummaryUnspecified},
+		{name: "interactions boolean is invalid", format: "interactions", body: `{"generation_config":{"thinking_summaries":true}}`, wantMode: SummaryUnspecified},
+		{name: "gemini string bool is invalid", format: "gemini", body: `{"generationConfig":{"thinkingConfig":{"includeThoughts":"true"}}}`, wantMode: SummaryUnspecified},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := ExtractSummaryConfig([]byte(test.body), test.format)
+			if got.Mode != test.wantMode || got.Detail != test.wantDetail {
+				t.Fatalf("ExtractSummaryConfig() = %+v, want mode=%v detail=%q", got, test.wantMode, test.wantDetail)
+			}
+		})
+	}
+}
+
+func TestApplySummaryConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		body   string
+		config SummaryConfig
+		path   string
+		want   string
+	}{
+		{name: "chat enabled creates compatibility effort", format: "openai", config: SummaryConfig{Mode: SummaryEnabled}, path: "reasoning_effort", want: "medium"},
+		{name: "chat enabled preserves active effort", format: "openai", body: `{"reasoning_effort":"high"}`, config: SummaryConfig{Mode: SummaryEnabled}, path: "reasoning_effort", want: "high"},
+		// Chat cannot express "reason but hide", so disabling must not fall back to
+		// reasoning_effort:"none", which would disable reasoning altogether.
+		{name: "chat disabled preserves requested effort", format: "openai", body: `{"reasoning_effort":"high"}`, config: SummaryConfig{Mode: SummaryDisabled}, path: "reasoning_effort", want: "high"},
+		{name: "chat disabled sets openrouter exclude when present", format: "openai", body: `{"reasoning":{"effort":"high","exclude":false}}`, config: SummaryConfig{Mode: SummaryDisabled}, path: "reasoning.exclude", want: "true"},
+		{name: "chat enabled clears openrouter exclude when present", format: "openai", body: `{"reasoning":{"effort":"high","exclude":true}}`, config: SummaryConfig{Mode: SummaryEnabled}, path: "reasoning.exclude", want: "false"},
+		{name: "chat disabled updates legacy include_reasoning when present", format: "openai", body: `{"reasoning_effort":"high","include_reasoning":true}`, config: SummaryConfig{Mode: SummaryDisabled}, path: "include_reasoning", want: "false"},
+		{name: "chat disabled invents no openrouter field", format: "openai", body: `{"reasoning_effort":"high"}`, config: SummaryConfig{Mode: SummaryDisabled}, path: "reasoning", want: ""},
+		{name: "claude enabled", format: "claude", body: `{"thinking":{"type":"adaptive"}}`, config: SummaryConfig{Mode: SummaryEnabled}, path: "thinking.display", want: "summarized"},
+		{name: "claude disabled", format: "claude", body: `{"thinking":{"type":"enabled","budget_tokens":2048}}`, config: SummaryConfig{Mode: SummaryDisabled}, path: "thinking.display", want: "omitted"},
+		{name: "gemini enabled", format: "gemini", config: SummaryConfig{Mode: SummaryEnabled}, path: "generationConfig.thinkingConfig.includeThoughts", want: "true"},
+		{name: "gemini disabled", format: "gemini", config: SummaryConfig{Mode: SummaryDisabled}, path: "generationConfig.thinkingConfig.includeThoughts", want: "false"},
+		{name: "antigravity enabled", format: "antigravity", config: SummaryConfig{Mode: SummaryEnabled}, path: "request.generationConfig.thinkingConfig.includeThoughts", want: "true"},
+		{name: "interactions detail collapses to auto", format: "interactions", config: SummaryConfig{Mode: SummaryEnabled, Detail: "detailed"}, path: "generation_config.thinking_summaries", want: "auto"},
+		{name: "interactions disabled", format: "interactions", config: SummaryConfig{Mode: SummaryDisabled}, path: "generation_config.thinking_summaries", want: "none"},
+		{name: "responses concise", format: "openai-response", config: SummaryConfig{Mode: SummaryEnabled, Detail: "concise"}, path: "reasoning.summary", want: "concise"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body := test.body
+			if body == "" {
+				body = `{}`
+			}
+			out := ApplySummaryConfig([]byte(body), test.format, test.config)
+			if got := gjson.GetBytes(out, test.path).String(); got != test.want {
+				t.Fatalf("%s = %q, want %q; body=%s", test.path, got, test.want, out)
+			}
+		})
+	}
+}
+
+func TestApplySummaryConfigNormalizesTargetAliases(t *testing.T) {
+	tests := []struct {
+		format    string
+		body      string
+		canonical string
+		alias     string
+	}{
+		{format: "gemini", body: `{"generationConfig":{"thinkingConfig":{"include_thoughts":true}}}`, canonical: "generationConfig.thinkingConfig.includeThoughts", alias: "generationConfig.thinkingConfig.include_thoughts"},
+		{format: "antigravity", body: `{"request":{"generationConfig":{"thinkingConfig":{"include_thoughts":true}}}}`, canonical: "request.generationConfig.thinkingConfig.includeThoughts", alias: "request.generationConfig.thinkingConfig.include_thoughts"},
+		{format: "interactions", body: `{"generation_config":{"thinkingSummaries":"auto"}}`, canonical: "generation_config.thinking_summaries", alias: "generation_config.thinkingSummaries"},
+	}
+	for _, test := range tests {
+		out := ApplySummaryConfig([]byte(test.body), test.format, SummaryConfig{Mode: SummaryEnabled})
+		if !gjson.GetBytes(out, test.canonical).Exists() {
+			t.Fatalf("%s missing canonical field: %s", test.format, out)
+		}
+		if gjson.GetBytes(out, test.alias).Exists() {
+			t.Fatalf("%s retained alias %s: %s", test.format, test.alias, out)
+		}
+	}
+}
+
+// Anthropic requires thinking.type, and rejects display on a disabled block, so
+// display must never be written unless thinking is already active.
+func TestApplySummaryConfig_ClaudeDisplayRequiresActiveThinking(t *testing.T) {
+	bodies := []string{
+		`{}`,
+		`{"messages":[{"role":"user","content":"hi"}]}`,
+		`{"thinking":{"type":"disabled"}}`,
+	}
+	for _, mode := range []SummaryMode{SummaryEnabled, SummaryDisabled} {
+		for _, body := range bodies {
+			out := ApplySummaryConfig([]byte(body), "claude", SummaryConfig{Mode: mode})
+			if gjson.GetBytes(out, "thinking.display").Exists() {
+				t.Fatalf("mode %v wrote display without active thinking: %s", mode, out)
+			}
+			if !bytes.Equal(out, []byte(body)) {
+				t.Fatalf("mode %v changed body: got %s, want %s", mode, out, body)
+			}
+		}
+	}
+}
+
+func TestApplySummaryConfigForModel_ClaudeSummaryOnlyUsesValidThinkingMode(t *testing.T) {
+	tests := []struct {
+		name       string
+		model      string
+		body       string
+		wantType   string
+		wantBudget int64
+	}{
+		{name: "adaptive model", model: "claude-opus-5", body: `{"model":"claude-opus-5","max_tokens":32000}`, wantType: "adaptive"},
+		{name: "manual model", model: "claude-haiku-4-5-20251001", body: `{"model":"claude-haiku-4-5-20251001","max_tokens":32000}`, wantType: "enabled", wantBudget: 1024},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out := ApplySummaryConfigForModel([]byte(test.body), "claude", test.model, SummaryConfig{Mode: SummaryEnabled})
+			if got := gjson.GetBytes(out, "thinking.type").String(); got != test.wantType {
+				t.Fatalf("thinking.type = %q, want %q; body=%s", got, test.wantType, out)
+			}
+			if got := gjson.GetBytes(out, "thinking.display").String(); got != "summarized" {
+				t.Fatalf("thinking.display = %q, want summarized; body=%s", got, out)
+			}
+			if test.wantBudget > 0 && gjson.GetBytes(out, "thinking.budget_tokens").Int() != test.wantBudget {
+				t.Fatalf("thinking.budget_tokens = %d, want %d; body=%s", gjson.GetBytes(out, "thinking.budget_tokens").Int(), test.wantBudget, out)
+			}
+		})
+	}
+}
+
+func TestApplySummaryConfig_ResponsesNormalizesDeprecatedGenerateSummary(t *testing.T) {
+	out := ApplySummaryConfig([]byte(`{"reasoning":{"generate_summary":"detailed"}}`), "openai-response", SummaryConfig{Mode: SummaryEnabled, Detail: "detailed"})
+	if got := gjson.GetBytes(out, "reasoning.summary").String(); got != "detailed" {
+		t.Fatalf("reasoning.summary = %q, want detailed; body=%s", got, out)
+	}
+	if gjson.GetBytes(out, "reasoning.generate_summary").Exists() {
+		t.Fatalf("deprecated reasoning.generate_summary remained: %s", out)
+	}
+}
+
+func TestApplySummaryConfig_ResponsesDisabledOmitsSummary(t *testing.T) {
+	out := ApplySummaryConfig([]byte(`{"reasoning":{"effort":"high","summary":"auto"}}`), "openai-response", SummaryConfig{Mode: SummaryDisabled})
+	if result := gjson.GetBytes(out, "reasoning.summary"); result.Exists() {
+		t.Fatalf("reasoning.summary = %s, want absent; body=%s", result.Raw, out)
+	}
+	if got := gjson.GetBytes(out, "reasoning.effort").String(); got != "high" {
+		t.Fatalf("reasoning.effort = %q, want high; body=%s", got, out)
+	}
+}
+
+func TestApplySummaryConfig_ResponsesDisabledDropsEmptyReasoning(t *testing.T) {
+	out := ApplySummaryConfig([]byte(`{"model":"gpt-5.4","reasoning":{"summary":"auto"}}`), "openai-response", SummaryConfig{Mode: SummaryDisabled})
+	if gjson.GetBytes(out, "reasoning").Exists() {
+		t.Fatalf("empty reasoning object left behind: %s", out)
+	}
+}
+
+func TestApplySummaryConfig_UnspecifiedLeavesBodyUnchanged(t *testing.T) {
+	body := []byte(`{"thinking":{"type":"adaptive"}}`)
+	if got := ApplySummaryConfig(body, "claude", SummaryConfig{}); !bytes.Equal(got, body) {
+		t.Fatalf("unspecified summary changed body: got %s, want %s", got, body)
+	}
+}

--- a/sdk/translator/registry.go
+++ b/sdk/translator/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -56,6 +57,8 @@ func (r *Registry) SetPluginHooks(hooks PluginHooks) {
 // "model" field is still updated to match the resolved model name so that
 // client-side prefixes (e.g. "copilot/gpt-5-mini") are not leaked upstream.
 func (r *Registry) TranslateRequest(from, to Format, model string, rawJSON []byte, stream bool) []byte {
+	summaryConfig := thinking.ExtractSummaryConfig(rawJSON, from.String())
+
 	r.mu.RLock()
 	var fn RequestTransform
 	if byTarget, ok := r.requests[from]; ok {
@@ -85,7 +88,10 @@ func (r *Registry) TranslateRequest(from, to Format, model string, rawJSON []byt
 			}
 		}
 	}
-	return body
+	if summaryConfig.Mode == thinking.SummaryUnspecified {
+		return thinking.ClearSummaryConfig(body, to.String())
+	}
+	return thinking.ApplySummaryConfigForModel(body, to.String(), model, summaryConfig)
 }
 
 // HasRequestTransformer indicates whether a request translator exists.

--- a/sdk/translator/registry_summary_test.go
+++ b/sdk/translator/registry_summary_test.go
@@ -1,0 +1,115 @@
+package translator
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestRegistryTranslateRequestAppliesSummaryIntent(t *testing.T) {
+	tests := []struct {
+		name       string
+		from       Format
+		to         Format
+		input      string
+		translated string
+		path       string
+		want       string
+		wantExists bool
+	}{
+		{
+			name:       "chat effort enables Claude summary",
+			from:       FormatOpenAI,
+			to:         FormatClaude,
+			input:      `{"reasoning_effort":"high"}`,
+			translated: `{"thinking":{"type":"adaptive"}}`,
+			path:       "thinking.display",
+			want:       "summarized",
+			wantExists: true,
+		},
+		{
+			name:       "responses effort alone leaves Claude display absent",
+			from:       FormatOpenAIResponse,
+			to:         FormatClaude,
+			input:      `{"reasoning":{"effort":"high"}}`,
+			translated: `{"thinking":{"type":"adaptive"}}`,
+			path:       "thinking.display",
+		},
+		{
+			name:       "responses summary enables Claude summary",
+			from:       FormatOpenAIResponse,
+			to:         FormatClaude,
+			input:      `{"reasoning":{"effort":"high","summary":"auto"}}`,
+			translated: `{"thinking":{"type":"adaptive"}}`,
+			path:       "thinking.display",
+			want:       "summarized",
+			wantExists: true,
+		},
+		{
+			name:       "responses null summary disables Gemini summaries",
+			from:       FormatOpenAIResponse,
+			to:         FormatGemini,
+			input:      `{"reasoning":{"effort":"high","summary":null}}`,
+			translated: `{"generationConfig":{"thinkingConfig":{"thinkingLevel":"high"}}}`,
+			path:       "generationConfig.thinkingConfig.includeThoughts",
+			want:       "false",
+			wantExists: true,
+		},
+		{
+			name:       "Google Chat extension overrides effort",
+			from:       FormatOpenAI,
+			to:         FormatGemini,
+			input:      `{"reasoning_effort":"high","extra_body":{"google":{"thinking_config":{"include_thoughts":false}}}}`,
+			translated: `{"generationConfig":{"thinkingConfig":{"thinkingLevel":"high","includeThoughts":true}}}`,
+			path:       "generationConfig.thinkingConfig.includeThoughts",
+			want:       "false",
+			wantExists: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			registry := NewRegistry()
+			registry.Register(test.from, test.to, func(_ string, _ []byte, _ bool) []byte {
+				return []byte(test.translated)
+			}, ResponseTransform{})
+			out := registry.TranslateRequest(test.from, test.to, "model", []byte(test.input), false)
+			result := gjson.GetBytes(out, test.path)
+			if result.Exists() != test.wantExists {
+				t.Fatalf("%s exists = %v, want %v; body=%s", test.path, result.Exists(), test.wantExists, out)
+			}
+			if test.wantExists && result.String() != test.want {
+				t.Fatalf("%s = %q, want %q; body=%s", test.path, result.String(), test.want, out)
+			}
+		})
+	}
+}
+
+func TestRegistryTranslateRequestMakesSummaryOnlyClaudeRequestValid(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(FormatOpenAIResponse, FormatClaude, func(_ string, _ []byte, _ bool) []byte {
+		return []byte(`{"model":"claude-opus-5","max_tokens":32000}`)
+	}, ResponseTransform{})
+	out := registry.TranslateRequest(
+		FormatOpenAIResponse,
+		FormatClaude,
+		"claude-opus-5",
+		[]byte(`{"reasoning":{"summary":"auto"},"input":"hi"}`),
+		false,
+	)
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "adaptive" {
+		t.Fatalf("thinking.type = %q, want adaptive; body=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "thinking.display").String(); got != "summarized" {
+		t.Fatalf("thinking.display = %q, want summarized; body=%s", got, out)
+	}
+}
+
+func TestRegistryTranslateRequestPreservesNativeClaudeMissingDisplay(t *testing.T) {
+	registry := NewRegistry()
+	body := []byte(`{"model":"claude-opus-5","thinking":{"type":"adaptive"}}`)
+	out := registry.TranslateRequest(FormatClaude, FormatClaude, "claude-opus-5", body, true)
+	if gjson.GetBytes(out, "thinking.display").Exists() {
+		t.Fatalf("native Claude request without display gained one: %s", out)
+	}
+}

--- a/test/summary_intent_translation_test.go
+++ b/test/summary_intent_translation_test.go
@@ -1,0 +1,197 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/antigravity"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestSummaryIntentTranslation(t *testing.T) {
+	tests := []struct {
+		name       string
+		from       sdktranslator.Format
+		to         sdktranslator.Format
+		body       string
+		path       string
+		want       string
+		wantExists bool
+	}{
+		{name: "Chat effort enables Claude summary", from: sdktranslator.FormatOpenAI, to: sdktranslator.FormatClaude, body: `{"model":"claude-opus-5","reasoning_effort":"high","messages":[{"role":"user","content":"hi"}]}`, path: "thinking.display", want: "summarized", wantExists: true},
+		// Anthropic rejects display next to a disabled thinking block, so a "none"
+		// effort must leave the field off rather than write "omitted".
+		{name: "Chat none leaves disabled Claude thinking without display", from: sdktranslator.FormatOpenAI, to: sdktranslator.FormatClaude, body: `{"model":"claude-opus-5","reasoning_effort":"none","messages":[{"role":"user","content":"hi"}]}`, path: "thinking.display"},
+		// Anthropic requires thinking.type. For an unregistered target CPA cannot
+		// safely guess adaptive versus manual thinking, so it must not emit an
+		// invalid display-only object. Registered targets are covered below.
+		{name: "Unknown Claude target does not get display only thinking", from: sdktranslator.FormatOpenAI, to: sdktranslator.FormatClaude, body: `{"model":"unregistered-claude-model","reasoning":{"exclude":false},"messages":[{"role":"user","content":"hi"}]}`, path: "thinking"},
+		{name: "Unknown Claude target from Interactions stays valid", from: sdktranslator.FormatInteractions, to: sdktranslator.FormatClaude, body: `{"model":"unregistered-claude-model","generation_config":{"thinking_summaries":"auto"},"input":"hi"}`, path: "thinking"},
+		{name: "Chat none omits Codex summary", from: sdktranslator.FormatOpenAI, to: sdktranslator.FormatCodex, body: `{"model":"gpt-5.4","reasoning_effort":"none","messages":[{"role":"user","content":"hi"}]}`, path: "reasoning.summary"},
+		// The Responses API makes reasoning.summary an explicit opt-in, so an
+		// absent source intent must remain absent when translated to Codex.
+		{name: "Claude absent display leaves Codex summary absent", from: sdktranslator.FormatClaude, to: sdktranslator.FormatCodex, body: `{"model":"gpt-5.4","max_tokens":1024,"thinking":{"type":"adaptive"},"output_config":{"effort":"high"},"messages":[{"role":"user","content":"hi"}]}`, path: "reasoning.summary"},
+		{name: "Gemini absent includeThoughts leaves Codex summary absent", from: sdktranslator.FormatGemini, to: sdktranslator.FormatCodex, body: `{"model":"gpt-5.4","generationConfig":{"thinkingConfig":{"thinkingLevel":"high"}},"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`, path: "reasoning.summary"},
+		{name: "Claude summarized enables Codex summary", from: sdktranslator.FormatClaude, to: sdktranslator.FormatCodex, body: `{"model":"gpt-5.4","max_tokens":1024,"thinking":{"type":"adaptive","display":"summarized"},"output_config":{"effort":"high"},"messages":[{"role":"user","content":"hi"}]}`, path: "reasoning.summary", want: "auto", wantExists: true},
+		{name: "Interactions none omits Codex summary", from: sdktranslator.FormatInteractions, to: sdktranslator.FormatCodex, body: `{"model":"gpt-5.4","generation_config":{"thinking_level":"high","thinking_summaries":"none"},"input":"hi"}`, path: "reasoning.summary"},
+		{name: "Chat effort enables Responses summary", from: sdktranslator.FormatOpenAI, to: sdktranslator.FormatOpenAIResponse, body: `{"model":"gpt-5.4","reasoning_effort":"high","messages":[{"role":"user","content":"hi"}]}`, path: "reasoning.summary", want: "auto", wantExists: true},
+		{name: "Responses summary only enables Chat compatibility effort", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatOpenAI, body: `{"model":"gpt-5.4","reasoning":{"summary":"auto"},"input":"hi"}`, path: "reasoning_effort", want: "medium", wantExists: true},
+		// Chat has no field for "reason but hide": OpenAI documents none and rejects
+		// unknown parameters, so a disabled summary must leave the requested effort
+		// alone instead of turning reasoning off upstream.
+		{name: "Responses disabled summary keeps Chat effort", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatOpenAI, body: `{"model":"gpt-5.4","reasoning":{"effort":"high","summary":null},"input":"hi"}`, path: "reasoning_effort", want: "high", wantExists: true},
+		{name: "Gemini disabled summary keeps Chat effort", from: sdktranslator.FormatGemini, to: sdktranslator.FormatOpenAI, body: `{"model":"gpt-5.4","generationConfig":{"thinkingConfig":{"thinkingLevel":"high","includeThoughts":false}},"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`, path: "reasoning_effort", want: "high", wantExists: true},
+		{name: "Claude omitted display keeps Chat effort", from: sdktranslator.FormatClaude, to: sdktranslator.FormatOpenAI, body: `{"model":"gpt-5.4","thinking":{"type":"adaptive","display":"omitted"},"output_config":{"effort":"high"},"messages":[{"role":"user","content":"hi"}]}`, path: "reasoning_effort", want: "high", wantExists: true},
+		{name: "Chat without effort leaves Claude display absent", from: sdktranslator.FormatOpenAI, to: sdktranslator.FormatClaude, body: `{"model":"claude-opus-5","messages":[{"role":"user","content":"hi"}]}`, path: "thinking.display"},
+		{name: "Responses effort alone leaves Claude display absent", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatClaude, body: `{"model":"claude-opus-5","reasoning":{"effort":"high"},"input":"hi"}`, path: "thinking.display"},
+		{name: "Responses summary enables Claude summary", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatClaude, body: `{"model":"claude-opus-5","reasoning":{"effort":"high","summary":"auto"},"input":"hi"}`, path: "thinking.display", want: "summarized", wantExists: true},
+		{name: "Responses null summary disables Claude summary", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatClaude, body: `{"model":"claude-opus-5","reasoning":{"effort":"high","summary":null},"input":"hi"}`, path: "thinking.display", want: "omitted", wantExists: true},
+		{name: "Chat effort enables Gemini summary", from: sdktranslator.FormatOpenAI, to: sdktranslator.FormatGemini, body: `{"model":"gemini-3.6-flash","reasoning_effort":"high","messages":[{"role":"user","content":"hi"}]}`, path: "generationConfig.thinkingConfig.includeThoughts", want: "true", wantExists: true},
+		{name: "Chat none disables Gemini summary", from: sdktranslator.FormatOpenAI, to: sdktranslator.FormatGemini, body: `{"model":"gemini-3.6-flash","reasoning_effort":"none","messages":[{"role":"user","content":"hi"}]}`, path: "generationConfig.thinkingConfig.includeThoughts", want: "false", wantExists: true},
+		{name: "Chat effort enables Antigravity summary", from: sdktranslator.FormatOpenAI, to: sdktranslator.FormatAntigravity, body: `{"model":"gemini-3.6-flash","reasoning_effort":"high","messages":[{"role":"user","content":"hi"}]}`, path: "request.generationConfig.thinkingConfig.includeThoughts", want: "true", wantExists: true},
+		{name: "Google Chat extension overrides Gemini summary", from: sdktranslator.FormatOpenAI, to: sdktranslator.FormatGemini, body: `{"model":"gemini-3.6-flash","reasoning_effort":"high","extra_body":{"google":{"thinking_config":{"include_thoughts":false}}},"messages":[{"role":"user","content":"hi"}]}`, path: "generationConfig.thinkingConfig.includeThoughts", want: "false", wantExists: true},
+		{name: "Responses effort alone leaves Gemini summary absent", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatGemini, body: `{"model":"gemini-3.6-flash","reasoning":{"effort":"high"},"input":"hi"}`, path: "generationConfig.thinkingConfig.includeThoughts"},
+		{name: "Responses detailed summary enables Gemini summary", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatGemini, body: `{"model":"gemini-3.6-flash","reasoning":{"effort":"high","summary":"detailed"},"input":"hi"}`, path: "generationConfig.thinkingConfig.includeThoughts", want: "true", wantExists: true},
+		{name: "Responses effort alone leaves Antigravity summary absent", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatAntigravity, body: `{"model":"gemini-3.6-flash","reasoning":{"effort":"high"},"input":"hi"}`, path: "request.generationConfig.thinkingConfig.includeThoughts"},
+		{name: "Responses summary enables Antigravity summary", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatAntigravity, body: `{"model":"gemini-3.6-flash","reasoning":{"effort":"high","summary":"auto"},"input":"hi"}`, path: "request.generationConfig.thinkingConfig.includeThoughts", want: "true", wantExists: true},
+		{name: "Chat effort enables Interactions summary", from: sdktranslator.FormatOpenAI, to: sdktranslator.FormatInteractions, body: `{"model":"gemini-3.6-flash","reasoning_effort":"high","messages":[{"role":"user","content":"hi"}]}`, path: "generation_config.thinking_summaries", want: "auto", wantExists: true},
+		{name: "Responses concise summary maps to Interactions auto", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatInteractions, body: `{"model":"gemini-3.6-flash","reasoning":{"effort":"high","summary":"concise"},"input":"hi"}`, path: "generation_config.thinking_summaries", want: "auto", wantExists: true},
+		{name: "Native Claude summarized enables Gemini summary", from: sdktranslator.FormatClaude, to: sdktranslator.FormatGemini, body: `{"model":"claude-opus-5","thinking":{"type":"adaptive","display":"summarized"},"messages":[{"role":"user","content":"hi"}]}`, path: "generationConfig.thinkingConfig.includeThoughts", want: "true", wantExists: true},
+		{name: "Native Gemini disabled omits Claude summary", from: sdktranslator.FormatGemini, to: sdktranslator.FormatClaude, body: `{"model":"gemini-3.6-flash","generationConfig":{"thinkingConfig":{"thinkingLevel":"high","includeThoughts":false}},"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`, path: "thinking.display", want: "omitted", wantExists: true},
+		{name: "Native Gemini absent summary leaves Claude display absent", from: sdktranslator.FormatGemini, to: sdktranslator.FormatClaude, body: `{"model":"gemini-3.6-flash","generationConfig":{"thinkingConfig":{"thinkingLevel":"high"}},"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`, path: "thinking.display"},
+		{name: "Native Interactions auto enables Gemini summary", from: sdktranslator.FormatInteractions, to: sdktranslator.FormatGemini, body: `{"model":"gemini-3.6-flash","generation_config":{"thinking_level":"high","thinking_summaries":"auto"},"input":"hi"}`, path: "generationConfig.thinkingConfig.includeThoughts", want: "true", wantExists: true},
+		{name: "Native Interactions none omits Claude summary", from: sdktranslator.FormatInteractions, to: sdktranslator.FormatClaude, body: `{"model":"claude-opus-5","generation_config":{"thinking_level":"high","thinking_summaries":"none"},"input":"hi"}`, path: "thinking.display", want: "omitted", wantExists: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out := sdktranslator.TranslateRequest(test.from, test.to, "", []byte(test.body), true)
+			result := gjson.GetBytes(out, test.path)
+			if result.Exists() != test.wantExists {
+				t.Fatalf("%s exists = %v, want %v; body=%s", test.path, result.Exists(), test.wantExists, out)
+			}
+			if test.wantExists && result.String() != test.want {
+				t.Fatalf("%s = %q, want %q; body=%s", test.path, result.String(), test.want, out)
+			}
+		})
+	}
+}
+
+func TestSummaryIntentFinalPipeline(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	uid := fmt.Sprintf("summary-final-pipeline-%d", time.Now().UnixNano())
+	reg.RegisterClient(uid, "test", getTestModels())
+	defer reg.UnregisterClient(uid)
+
+	tests := []struct {
+		name       string
+		from       sdktranslator.Format
+		to         sdktranslator.Format
+		model      string
+		body       string
+		path       string
+		want       string
+		wantExists bool
+	}{
+		{name: "Responses summary only activates valid Claude thinking", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatClaude, model: "claude-sonnet-4-6-model", body: `{"model":"claude-sonnet-4-6-model","reasoning":{"summary":"auto"},"input":"hi"}`, path: "thinking.display", want: "summarized", wantExists: true},
+		{name: "Chat summary alias only activates valid Claude thinking", from: sdktranslator.FormatOpenAI, to: sdktranslator.FormatClaude, model: "claude-sonnet-4-6-model", body: `{"model":"claude-sonnet-4-6-model","reasoning":{"exclude":false},"messages":[{"role":"user","content":"hi"}]}`, path: "thinking.display", want: "summarized", wantExists: true},
+		{name: "Interactions summary only activates valid Claude thinking", from: sdktranslator.FormatInteractions, to: sdktranslator.FormatClaude, model: "claude-sonnet-4-6-model", body: `{"model":"claude-sonnet-4-6-model","generation_config":{"thinking_summaries":"auto"},"input":"hi"}`, path: "thinking.display", want: "summarized", wantExists: true},
+		{name: "Claude suffix none removes otherwise enabled display", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatClaude, model: "claude-sonnet-4-6-model(none)", body: `{"model":"claude-sonnet-4-6-model(none)","reasoning":{"summary":"auto"},"input":"hi"}`, path: "thinking.display"},
+		{name: "Claude suffix preserves explicit disabled summary", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatClaude, model: "claude-sonnet-4-6-model(high)", body: `{"model":"claude-sonnet-4-6-model(high)","reasoning":{"summary":null},"input":"hi"}`, path: "thinking.display", want: "omitted", wantExists: true},
+		{name: "Responses effort alone stays omitted on Antigravity", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatAntigravity, model: "antigravity-budget-model", body: `{"model":"antigravity-budget-model","reasoning":{"effort":"medium"},"input":"hi"}`, path: "request.generationConfig.thinkingConfig.includeThoughts"},
+		{name: "Responses summary reaches Antigravity", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatAntigravity, model: "antigravity-budget-model", body: `{"model":"antigravity-budget-model","reasoning":{"effort":"medium","summary":"auto"},"input":"hi"}`, path: "request.generationConfig.thinkingConfig.includeThoughts", want: "true", wantExists: true},
+		{name: "Google Chat extension false survives Gemini applier", from: sdktranslator.FormatOpenAI, to: sdktranslator.FormatGemini, model: "gemini-mixed-model", body: `{"model":"gemini-mixed-model","reasoning_effort":"high","extra_body":{"google":{"thinking_config":{"include_thoughts":false}}},"messages":[{"role":"user","content":"hi"}]}`, path: "generationConfig.thinkingConfig.includeThoughts", want: "false", wantExists: true},
+		{name: "Summary-only control is stripped for non-thinking Gemini model", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatGemini, model: "no-thinking-model", body: `{"model":"no-thinking-model","reasoning":{"summary":"auto"},"input":"hi"}`, path: "generationConfig.thinkingConfig"},
+		{name: "Interactions level alone keeps summaries omitted", from: sdktranslator.FormatInteractions, to: sdktranslator.FormatInteractions, model: "level-model", body: `{"model":"level-model","generation_config":{"thinking_level":"high"},"input":"hi"}`, path: "generation_config.thinking_summaries"},
+		{name: "Interactions auto survives its applier", from: sdktranslator.FormatInteractions, to: sdktranslator.FormatInteractions, model: "level-model", body: `{"model":"level-model","generation_config":{"thinking_level":"high","thinking_summaries":"auto"},"input":"hi"}`, path: "generation_config.thinking_summaries", want: "auto", wantExists: true},
+		{name: "Deprecated Responses detail reaches Codex", from: sdktranslator.FormatOpenAIResponse, to: sdktranslator.FormatCodex, model: "level-model", body: `{"model":"level-model","reasoning":{"effort":"high","generate_summary":"detailed"},"input":"hi"}`, path: "reasoning.summary", want: "detailed", wantExists: true},
+		{name: "Gemini missing includeThoughts stays omitted on Claude", from: sdktranslator.FormatGemini, to: sdktranslator.FormatClaude, model: "claude-sonnet-4-6-model", body: `{"model":"claude-sonnet-4-6-model","generationConfig":{"thinkingConfig":{"thinkingLevel":"high"}},"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`, path: "thinking.display"},
+		{name: "Gemini true includeThoughts reaches Claude", from: sdktranslator.FormatGemini, to: sdktranslator.FormatClaude, model: "claude-sonnet-4-6-model", body: `{"model":"claude-sonnet-4-6-model","generationConfig":{"thinkingConfig":{"thinkingLevel":"high","includeThoughts":true}},"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`, path: "thinking.display", want: "summarized", wantExists: true},
+		{name: "Native Antigravity budget keeps visibility omitted", from: sdktranslator.FormatAntigravity, to: sdktranslator.FormatAntigravity, model: "antigravity-budget-model", body: `{"model":"antigravity-budget-model","request":{"generationConfig":{"thinkingConfig":{"thinkingBudget":8192}},"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`, path: "request.generationConfig.thinkingConfig.includeThoughts"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			baseModel := thinking.ParseSuffix(test.model).ModelName
+			out := sdktranslator.TranslateRequest(test.from, test.to, baseModel, []byte(test.body), true)
+			var err error
+			out, err = thinking.ApplyThinkingWithSource(out, []byte(test.body), test.model, test.from.String(), test.to.String(), test.to.String())
+			if err != nil {
+				t.Fatalf("ApplyThinking() error = %v; body=%s", err, out)
+			}
+			result := gjson.GetBytes(out, test.path)
+			if result.Exists() != test.wantExists {
+				t.Fatalf("%s exists = %v, want %v; body=%s", test.path, result.Exists(), test.wantExists, out)
+			}
+			if test.wantExists && result.String() != test.want {
+				t.Fatalf("%s = %q, want %q; body=%s", test.path, result.String(), test.want, out)
+			}
+			if test.to == sdktranslator.FormatClaude && gjson.GetBytes(out, "thinking.type").String() == "disabled" && gjson.GetBytes(out, "thinking.display").Exists() {
+				t.Fatalf("disabled Claude thinking retained display: %s", out)
+			}
+		})
+	}
+}
+
+func TestNativeClaudeMissingDisplayPreservesSignatureOnlyHistory(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-5","thinking":{"type":"adaptive"},"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"","signature":"opus-signature"}]},{"role":"user","content":"continue"}]}`)
+	out := sdktranslator.TranslateRequest(sdktranslator.FormatClaude, sdktranslator.FormatClaude, "claude-opus-5", body, true)
+	if gjson.GetBytes(out, "thinking.display").Exists() {
+		t.Fatalf("native Claude request without display gained one: %s", out)
+	}
+	if got := gjson.GetBytes(out, "messages").Raw; got != gjson.GetBytes(body, "messages").Raw {
+		t.Fatalf("signature-only history changed: got %s, want %s", got, gjson.GetBytes(body, "messages").Raw)
+	}
+}
+
+// Antigravity wraps Gemini generateContent, where includeThoughts is an
+// independent opt-in. Thinking level/budget changes must preserve explicit
+// booleans and leave an omitted visibility control omitted.
+func TestAntigravityIncludeThoughtsPreservesExplicitness(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	uid := fmt.Sprintf("antigravity-summary-default-%d", time.Now().UnixNano())
+	reg.RegisterClient(uid, "test", getTestModels())
+	defer reg.UnregisterClient(uid)
+
+	const contents = `"contents":[{"role":"user","parts":[{"text":"hi"}]}]`
+	tests := []struct {
+		name       string
+		model      string
+		body       string
+		want       string
+		wantExists bool
+	}{
+		{name: "suffix thinking without intent stays omitted", model: "antigravity-budget-model(medium)", body: `{"request":{` + contents + `}}`},
+		{name: "native budget without intent stays omitted", model: "antigravity-budget-model", body: `{"request":{"generationConfig":{"thinkingConfig":{"thinkingBudget":8192}},` + contents + `}}`},
+		{name: "explicit true is preserved", model: "antigravity-budget-model(medium)", body: `{"request":{"generationConfig":{"thinkingConfig":{"includeThoughts":true}},` + contents + `}}`, want: "true", wantExists: true},
+		{name: "explicit false is preserved", model: "antigravity-budget-model(medium)", body: `{"request":{"generationConfig":{"thinkingConfig":{"includeThoughts":false}},` + contents + `}}`, want: "false", wantExists: true},
+		{name: "explicit snake case false is preserved", model: "antigravity-budget-model(medium)", body: `{"request":{"generationConfig":{"thinkingConfig":{"include_thoughts":false}},` + contents + `}}`, want: "false", wantExists: true},
+		{name: "disabled thinking without summary intent stays omitted", model: "antigravity-budget-model(none)", body: `{"request":{` + contents + `}}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out, err := thinking.ApplyThinking([]byte(test.body), test.model, "antigravity", "antigravity", "antigravity")
+			if err != nil {
+				t.Fatalf("ApplyThinking() error = %v; body=%s", err, out)
+			}
+			result := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts")
+			if result.Exists() != test.wantExists {
+				t.Fatalf("includeThoughts exists = %v, want %v; body=%s", result.Exists(), test.wantExists, out)
+			}
+			if test.wantExists {
+				if got := fmt.Sprintf("%v", result.Bool()); got != test.want {
+					t.Fatalf("includeThoughts = %s, want %s; body=%s", got, test.want, out)
+				}
+			}
+			if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.include_thoughts").Exists() {
+				t.Fatalf("snake_case includeThoughts left in payload: %s", out)
+			}
+		})
+	}
+}

--- a/test/thinking_conversion_test.go
+++ b/test/thinking_conversion_test.go
@@ -1456,25 +1456,30 @@ func TestThinkingE2EMatrix_Body(t *testing.T) {
 			includeThoughts: "false",
 			expectErr:       false,
 		},
-		// Case 31A: reasoning_effort=none with zero allowed → delete thinkingConfig
+		// Case 31A: reasoning_effort=none with zero allowed removes the amount but
+		// preserves Chat's explicit disabled summary intent.
 		{
-			name:        "31A",
-			from:        "openai",
-			to:          "gemini",
-			model:       "gemini-toggle-mixed-model",
-			inputJSON:   `{"model":"gemini-toggle-mixed-model","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"none"}`,
-			expectField: "",
-			expectErr:   false,
+			name:            "31A",
+			from:            "openai",
+			to:              "gemini",
+			model:           "gemini-toggle-mixed-model",
+			inputJSON:       `{"model":"gemini-toggle-mixed-model","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"none"}`,
+			expectField:     "generationConfig.thinkingConfig.includeThoughts",
+			expectValue:     "false",
+			includeThoughts: "false",
+			expectErr:       false,
 		},
-		// Case 31B: reasoning_effort=none with zero allowed to Antigravity → delete thinkingConfig
+		// Case 31B: the same explicit disabled intent survives Antigravity.
 		{
-			name:        "31B",
-			from:        "openai",
-			to:          "antigravity",
-			model:       "gemini-toggle-mixed-model",
-			inputJSON:   `{"model":"gemini-toggle-mixed-model","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"none"}`,
-			expectField: "",
-			expectErr:   false,
+			name:            "31B",
+			from:            "openai",
+			to:              "antigravity",
+			model:           "gemini-toggle-mixed-model",
+			inputJSON:       `{"model":"gemini-toggle-mixed-model","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"none"}`,
+			expectField:     "request.generationConfig.thinkingConfig.includeThoughts",
+			expectValue:     "false",
+			includeThoughts: "false",
+			expectErr:       false,
 		},
 		// Case 31C: reasoning.effort=none with zero allowed → delete thinkingConfig
 		{
@@ -2448,7 +2453,7 @@ func TestThinkingE2EProviderTargets(t *testing.T) {
 			expectValue: "high",
 		},
 
-		// Interactions target: native API uses generation_config.thinking_level and thinking_summaries.
+		// Interactions target: native API uses generation_config.thinking_level and optional thinking_summaries.
 		{
 			name:         "I1",
 			from:         "interactions",
@@ -2461,15 +2466,309 @@ func TestThinkingE2EProviderTargets(t *testing.T) {
 			expectValue2: "auto",
 		},
 		{
-			name:         "I2",
+			name:        "I2",
+			from:        "interactions",
+			to:          "interactions",
+			model:       "level-model(8192)",
+			inputJSON:   `{"model":"level-model(8192)","input":"hi"}`,
+			expectField: "generation_config.thinking_level",
+			expectValue: "medium",
+		},
+		// Responses client against a chat-shaped provider. Because thinking is read
+		// back off the translated body, this pair only works if the request translator
+		// rewrites reasoning.effort as reasoning_effort; nothing else covered it.
+		{
+			name:        "R1",
+			from:        "openai-response",
+			to:          "openai",
+			model:       "level-model",
+			inputJSON:   `{"model":"level-model","input":"hi","reasoning":{"effort":"high"}}`,
+			expectField: "reasoning_effort",
+			expectValue: "high",
+		},
+		{
+			name:        "R2",
+			from:        "openai-response",
+			to:          "openai",
+			model:       "level-model",
+			inputJSON:   `{"model":"level-model","input":"hi","reasoning":{"effort":"none"}}`,
+			expectField: "reasoning_effort",
+			expectValue: "minimal",
+		},
+		{
+			name:         "R3",
+			from:         "openai-response",
+			to:           "kimi",
+			model:        "kimi-toggle-thinking-model",
+			inputJSON:    `{"model":"kimi-toggle-thinking-model","input":"hi","reasoning":{"effort":"high"}}`,
+			expectField:  "thinking.type",
+			expectValue:  "enabled",
+			expectField2: "thinking.effort",
+			expectValue2: "high",
+			expectAbsent: []string{"reasoning_effort"},
+		},
+		{
+			name:            "R4",
+			from:            "openai-response",
+			to:              "antigravity",
+			model:           "antigravity-budget-model",
+			inputJSON:       `{"model":"antigravity-budget-model","input":"hi","reasoning":{"effort":"medium"}}`,
+			expectField:     "request.generationConfig.thinkingConfig.thinkingBudget",
+			expectValue:     "8192",
+			includeThoughts: "true",
+		},
+	}
+
+	runThinkingTests(t, cases)
+}
+
+// TestThinkingE2EInteractionsMatrix covers the Interactions protocol in both
+// directions, which the suffix and body matrices above barely touch.
+//
+// Interactions expresses thinking through generation_config.thinking_level and the
+// independent auto/none generation_config.thinking_summaries control. Compatibility
+// thinking_budget and none/auto level inputs map onto a documented target level. The
+// IN cases drive Interactions
+// as the provider from every client protocol; the OUT cases drive an Interactions
+// client against every provider, so an explicit on/off request has to survive the
+// round trip in both roles.
+func TestThinkingE2EInteractionsMatrix(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	uid := fmt.Sprintf("thinking-e2e-interactions-%d", time.Now().UnixNano())
+
+	reg.RegisterClient(uid, "test", getTestModels())
+	defer reg.UnregisterClient(uid)
+
+	cases := []thinkingTestCase{
+		// Interactions as provider: explicit on from every client protocol.
+		{
+			name:        "IN1",
+			from:        "claude",
+			to:          "interactions",
+			model:       "level-model",
+			inputJSON:   `{"model":"level-model","max_tokens":1024,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"enabled","budget_tokens":10000}}`,
+			expectField: "generation_config.thinking_level",
+			expectValue: "high",
+		},
+		{
+			name:        "IN2",
+			from:        "openai",
+			to:          "interactions",
+			model:       "level-model",
+			inputJSON:   `{"model":"level-model","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"minimal"}`,
+			expectField: "generation_config.thinking_level",
+			expectValue: "minimal",
+		},
+		{
+			name:        "IN3",
+			from:        "openai-response",
+			to:          "interactions",
+			model:       "level-model",
+			inputJSON:   `{"model":"level-model","input":"hi","reasoning":{"effort":"low"}}`,
+			expectField: "generation_config.thinking_level",
+			expectValue: "low",
+		},
+		{
+			name:        "IN4",
+			from:        "gemini",
+			to:          "interactions",
+			model:       "level-model",
+			inputJSON:   `{"model":"level-model","contents":[{"role":"user","parts":[{"text":"hi"}]}],"generationConfig":{"thinkingConfig":{"includeThoughts":true,"thinkingBudget":20000}}}`,
+			expectField: "generation_config.thinking_level",
+			expectValue: "high",
+		},
+		// A level the model does not publish falls back to its highest level.
+		{
+			name:        "IN5",
+			from:        "openai",
+			to:          "interactions",
+			model:       "level-subset-model",
+			inputJSON:   `{"model":"level-subset-model","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"xhigh"}`,
+			expectField: "generation_config.thinking_level",
+			expectValue: "high",
+		},
+		// Interactions cannot fully disable this model, so thinking clamps to the
+		// lowest documented level. Summary visibility remains omitted unless the
+		// source independently requested it.
+		{
+			name:        "IN6",
+			from:        "claude",
+			to:          "interactions",
+			model:       "level-model",
+			inputJSON:   `{"model":"level-model","max_tokens":1024,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"disabled"}}`,
+			expectField: "generation_config.thinking_level",
+			expectValue: "minimal",
+		},
+		{
+			name:        "IN7",
+			from:        "openai",
+			to:          "interactions",
+			model:       "level-model(none)",
+			inputJSON:   `{"model":"level-model(none)","messages":[{"role":"user","content":"hi"}]}`,
+			expectField: "generation_config.thinking_level",
+			expectValue: "minimal",
+		},
+		{
+			name:        "IN8",
+			from:        "interactions",
+			to:          "interactions",
+			model:       "level-model",
+			inputJSON:   `{"model":"level-model","generation_config":{"thinking_level":"none"},"input":"hi"}`,
+			expectField: "generation_config.thinking_level",
+			expectValue: "minimal",
+		},
+		// Interactions supports auto as its only enabled summary selector.
+		{
+			name:         "IN9",
 			from:         "interactions",
 			to:           "interactions",
-			model:        "level-model(8192)",
-			inputJSON:    `{"model":"level-model(8192)","input":"hi"}`,
+			model:        "level-model",
+			inputJSON:    `{"model":"level-model","generation_config":{"thinking_level":"low","thinking_summaries":"auto"},"input":"hi"}`,
 			expectField:  "generation_config.thinking_level",
-			expectValue:  "medium",
+			expectValue:  "low",
 			expectField2: "generation_config.thinking_summaries",
 			expectValue2: "auto",
+		},
+		// A legacy thinking_budget maps onto the level enum.
+		{
+			name:        "IN10",
+			from:        "interactions",
+			to:          "interactions",
+			model:       "level-model",
+			inputJSON:   `{"model":"level-model","generation_config":{"thinking_budget":400},"input":"hi"}`,
+			expectField: "generation_config.thinking_level",
+			expectValue: "minimal",
+		},
+		// Auto on a model without dynamic thinking resolves to the mid-range level,
+		// the same normalization every other target gets.
+		{
+			name:        "IN11",
+			from:        "interactions",
+			to:          "interactions",
+			model:       "level-model",
+			inputJSON:   `{"model":"level-model","generation_config":{"thinking_budget":-1},"input":"hi"}`,
+			expectField: "generation_config.thinking_level",
+			expectValue: "medium",
+		},
+
+		// Interactions as client: explicit on has to reach every provider's own knob.
+		{
+			name:        "OUT1",
+			from:        "interactions",
+			to:          "claude",
+			model:       "claude-budget-model",
+			inputJSON:   `{"model":"claude-budget-model","generation_config":{"thinking_level":"medium"},"input":"hi"}`,
+			expectField: "thinking.budget_tokens",
+			expectValue: "8192",
+		},
+		{
+			name:        "OUT2",
+			from:        "interactions",
+			to:          "openai",
+			model:       "level-model",
+			inputJSON:   `{"model":"level-model","generation_config":{"thinking_level":"high"},"input":"hi"}`,
+			expectField: "reasoning_effort",
+			expectValue: "high",
+		},
+		{
+			name:        "OUT3",
+			from:        "interactions",
+			to:          "codex",
+			model:       "level-model",
+			inputJSON:   `{"model":"level-model","generation_config":{"thinking_level":"low"},"input":"hi"}`,
+			expectField: "reasoning.effort",
+			expectValue: "low",
+		},
+		{
+			name:        "OUT4",
+			from:        "interactions",
+			to:          "gemini",
+			model:       "gemini-budget-model",
+			inputJSON:   `{"model":"gemini-budget-model","generation_config":{"thinking_level":"medium"},"input":"hi"}`,
+			expectField: "generationConfig.thinkingConfig.thinkingBudget",
+			expectValue: "8192",
+		},
+		{
+			name:            "OUT5",
+			from:            "interactions",
+			to:              "antigravity",
+			model:           "antigravity-budget-model",
+			inputJSON:       `{"model":"antigravity-budget-model","generation_config":{"thinking_level":"medium"},"input":"hi"}`,
+			expectField:     "request.generationConfig.thinkingConfig.thinkingBudget",
+			expectValue:     "8192",
+			includeThoughts: "true",
+		},
+		{
+			name:         "OUT6",
+			from:         "interactions",
+			to:           "kimi",
+			model:        "kimi-toggle-thinking-model",
+			inputJSON:    `{"model":"kimi-toggle-thinking-model","generation_config":{"thinking_level":"high"},"input":"hi"}`,
+			expectField:  "thinking.type",
+			expectValue:  "enabled",
+			expectField2: "thinking.effort",
+			expectValue2: "high",
+		},
+		{
+			name:        "OUT7",
+			from:        "interactions",
+			to:          "xai",
+			model:       "xai-level-model",
+			inputJSON:   `{"model":"xai-level-model","generation_config":{"thinking_level":"high"},"input":"hi"}`,
+			expectField: "reasoning.effort",
+			expectValue: "high",
+		},
+		// Interactions as client: explicit off has to reach every provider's own way
+		// of saying no thinking.
+		{
+			name:        "OUT8",
+			from:        "interactions",
+			to:          "claude",
+			model:       "claude-budget-model",
+			inputJSON:   `{"model":"claude-budget-model","generation_config":{"thinking_level":"none"},"input":"hi"}`,
+			expectField: "thinking.type",
+			expectValue: "disabled",
+		},
+		{
+			name:            "OUT9",
+			from:            "interactions",
+			to:              "antigravity",
+			model:           "antigravity-budget-model",
+			inputJSON:       `{"model":"antigravity-budget-model","generation_config":{"thinking_level":"none"},"input":"hi"}`,
+			expectField:     "request.generationConfig.thinkingConfig.thinkingBudget",
+			expectValue:     "0",
+			includeThoughts: "false",
+		},
+		{
+			name:         "OUT10",
+			from:         "interactions",
+			to:           "kimi",
+			model:        "kimi-toggle-thinking-model",
+			inputJSON:    `{"model":"kimi-toggle-thinking-model","generation_config":{"thinking_level":"none"},"input":"hi"}`,
+			expectField:  "thinking.type",
+			expectValue:  "disabled",
+			expectAbsent: []string{"thinking.effort", "reasoning_effort"},
+		},
+		// A level+budget model that allows zero expresses off by dropping
+		// thinkingConfig entirely, so an Interactions client reaches the same shape a
+		// chat or Responses client does.
+		{
+			name:         "OUT11",
+			from:         "interactions",
+			to:           "gemini",
+			model:        "gemini-toggle-mixed-model",
+			inputJSON:    `{"model":"gemini-toggle-mixed-model","generation_config":{"thinking_level":"none"},"input":"hi"}`,
+			expectAbsent: []string{"generationConfig.thinkingConfig"},
+		},
+		// Auto reaches a dynamic-capable provider as dynamic thinking.
+		{
+			name:        "OUT12",
+			from:        "interactions",
+			to:          "gemini",
+			model:       "gemini-budget-model",
+			inputJSON:   `{"model":"gemini-budget-model","generation_config":{"thinking_level":"auto"},"input":"hi"}`,
+			expectField: "generationConfig.thinkingConfig.thinkingBudget",
+			expectValue: "-1",
 		},
 	}
 
@@ -3204,18 +3503,36 @@ func runThinkingTests(t *testing.T, cases []thinkingTestCase) {
 				assertField(tc.expectField3, tc.expectValue3)
 			}
 
-			if tc.includeThoughts != "" && (tc.to == "gemini" || tc.to == "antigravity") {
+			if tc.to == "gemini" || tc.to == "antigravity" {
 				path := "generationConfig.thinkingConfig.includeThoughts"
 				if tc.to == "antigravity" {
 					path = "request.generationConfig.thinkingConfig.includeThoughts"
 				}
-				itVal := gjson.GetBytes(body, path)
-				if !itVal.Exists() {
-					t.Fatalf("expected includeThoughts field not found, body=%s", string(body))
+				wantIncludeThoughts := ""
+				summaryConfig := thinking.ExtractSummaryConfig([]byte(tc.inputJSON), tc.from)
+				switch summaryConfig.Mode {
+				case thinking.SummaryEnabled:
+					wantIncludeThoughts = "true"
+				case thinking.SummaryDisabled:
+					wantIncludeThoughts = "false"
+				default:
+					// Thinking amount does not imply summary visibility. Keep the
+					// provider field absent when the source omitted its summary control.
 				}
-				actual := fmt.Sprintf("%v", itVal.Bool())
-				if actual != tc.includeThoughts {
-					t.Fatalf("includeThoughts: expected %s, got %s, body=%s", tc.includeThoughts, actual, string(body))
+
+				itVal := gjson.GetBytes(body, path)
+				if wantIncludeThoughts == "" {
+					if itVal.Exists() {
+						t.Fatalf("includeThoughts should be absent without summary intent, body=%s", string(body))
+					}
+				} else {
+					if !itVal.Exists() {
+						t.Fatalf("expected includeThoughts field not found, body=%s", string(body))
+					}
+					actual := fmt.Sprintf("%v", itVal.Bool())
+					if actual != wantIncludeThoughts {
+						t.Fatalf("includeThoughts: expected %s, got %s, body=%s", wantIncludeThoughts, actual, string(body))
+					}
 				}
 			}
 		})


### PR DESCRIPTION
## Summary
- translate explicit thinking-text visibility controls across OpenAI Chat/Responses, Claude, Gemini, Antigravity, and Interactions
- preserve explicit enabled/disabled intent independently of thinking effort and model suffixes
- remove translator-produced visibility defaults when the source did not explicitly request thinking text

## Verification
- `go test ./...`
- `go build -o test-output ./cmd/server && rm test-output`
- `git diff --check`