### PR TITLE
fix(openai): emit response.failed for terminal stream errors

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -46,10 +46,16 @@ func writeResponsesSSEChunk(w io.Writer, chunk []byte) {
 }
 
 type responsesSSEFramer struct {
-	pending              []byte
-	outputItems          map[int][]byte
-	outputOrder          []int
-	unindexedOutputItems [][]byte
+	pending               []byte
+	outputItems           map[int][]byte
+	outputOrder           []int
+	unindexedOutputItems  [][]byte
+	responseID            string
+	responseObject        []byte
+	requestJSON           []byte
+	lastSequenceNumber    int
+	hasLastSequenceNumber bool
+	terminalEventSeen     bool
 }
 
 func (f *responsesSSEFramer) WriteChunk(w io.Writer, chunk []byte) {
@@ -106,16 +112,49 @@ func (f *responsesSSEFramer) repairFrame(frame []byte) []byte {
 		return frame
 	}
 
-	switch gjson.GetBytes(payload, "type").String() {
+	eventType := gjson.GetBytes(payload, "type").String()
+	f.recordResponseMetadata(payload, eventType)
+
+	switch eventType {
 	case "response.output_item.done":
 		f.recordOutputItem(payload)
 	case "response.completed":
+		f.terminalEventSeen = true
 		repaired := f.repairCompletedPayload(payload)
 		if !bytes.Equal(repaired, payload) {
 			return responsesSSEFrameWithData(frame, repaired)
 		}
+	case "response.incomplete", "response.failed":
+		f.terminalEventSeen = true
 	}
 	return frame
+}
+
+func (f *responsesSSEFramer) recordResponseMetadata(payload []byte, eventType string) {
+	response := gjson.GetBytes(payload, "response")
+	if response.IsObject() && (len(f.responseObject) == 0 || eventType == "response.created") {
+		f.responseObject = append(f.responseObject[:0], response.Raw...)
+	}
+	if responseID := response.Get("id").String(); responseID != "" {
+		f.responseID = responseID
+	}
+	sequenceNumber := gjson.GetBytes(payload, "sequence_number")
+	if !sequenceNumber.Exists() {
+		return
+	}
+	value := int(sequenceNumber.Int())
+	if !f.hasLastSequenceNumber || value > f.lastSequenceNumber {
+		f.lastSequenceNumber = value
+		f.hasLastSequenceNumber = true
+	}
+}
+
+func (f *responsesSSEFramer) terminalMetadata() (string, int, []byte) {
+	responseObject := f.failedResponseObject()
+	if !f.hasLastSequenceNumber {
+		return f.responseID, 0, responseObject
+	}
+	return f.responseID, f.lastSequenceNumber + 1, responseObject
 }
 
 func responsesSSEDataPayload(frame []byte) ([]byte, bool) {
@@ -178,13 +217,9 @@ func (f *responsesSSEFramer) recordOutputItem(payload []byte) {
 	f.unindexedOutputItems = append(f.unindexedOutputItems, append([]byte(nil), item.Raw...))
 }
 
-func (f *responsesSSEFramer) repairCompletedPayload(payload []byte) []byte {
+func (f *responsesSSEFramer) recordedOutputJSON() []byte {
 	if len(f.outputOrder) == 0 && len(f.unindexedOutputItems) == 0 {
-		return payload
-	}
-	output := gjson.GetBytes(payload, "response.output")
-	if output.Exists() && (!output.IsArray() || len(output.Array()) > 0) {
-		return payload
+		return nil
 	}
 
 	var outputJSON bytes.Buffer
@@ -211,8 +246,169 @@ func (f *responsesSSEFramer) repairCompletedPayload(payload []byte) []byte {
 		written++
 	}
 	outputJSON.WriteByte(']')
+	return outputJSON.Bytes()
+}
 
-	repaired, err := sjson.SetRawBytes(payload, "response.output", outputJSON.Bytes())
+type responsesJSONFieldKind uint8
+
+const (
+	responsesJSONFieldRaw responsesJSONFieldKind = iota
+	responsesJSONFieldBoolean
+	responsesJSONFieldConversation
+)
+
+type responsesJSONFieldPolicy struct {
+	field    string
+	fallback string
+	kind     responsesJSONFieldKind
+}
+
+func applyResponsesJSONFieldPolicy(response, request []byte, policy responsesJSONFieldPolicy) []byte {
+	responseValue := gjson.GetBytes(response, policy.field)
+	switch policy.kind {
+	case responsesJSONFieldBoolean:
+		if responseValue.Type == gjson.True || responseValue.Type == gjson.False {
+			return response
+		}
+	case responsesJSONFieldConversation:
+		conversationID := responseValue.Get("id")
+		if (responseValue.IsObject() && conversationID.Type == gjson.String && conversationID.String() != "") || responseValue.Raw == "null" {
+			return response
+		}
+	default:
+		if responseValue.Exists() {
+			return response
+		}
+	}
+
+	requestValue := gjson.GetBytes(request, policy.field)
+	switch policy.kind {
+	case responsesJSONFieldBoolean:
+		if requestValue.Type == gjson.True || requestValue.Type == gjson.False {
+			updated, err := sjson.SetBytes(response, policy.field, requestValue.Bool())
+			if err == nil {
+				return updated
+			}
+			return response
+		}
+	case responsesJSONFieldConversation:
+		conversationID := ""
+		if requestValue.Type == gjson.String {
+			conversationID = requestValue.String()
+		} else if id := requestValue.Get("id"); requestValue.IsObject() && id.Type == gjson.String {
+			conversationID = id.String()
+		}
+		if conversationID != "" {
+			value := []byte(`{"id":""}`)
+			value, _ = sjson.SetBytes(value, "id", conversationID)
+			updated, err := sjson.SetRawBytes(response, policy.field, value)
+			if err == nil {
+				return updated
+			}
+			return response
+		}
+	default:
+		if requestValue.Exists() {
+			updated, err := sjson.SetRawBytes(response, policy.field, []byte(requestValue.Raw))
+			if err == nil {
+				return updated
+			}
+			return response
+		}
+	}
+
+	if policy.fallback == "" {
+		if policy.kind == responsesJSONFieldConversation && responseValue.Exists() {
+			updated, err := sjson.DeleteBytes(response, policy.field)
+			if err == nil {
+				return updated
+			}
+		}
+		return response
+	}
+	var (
+		updated []byte
+		err     error
+	)
+	if policy.kind == responsesJSONFieldBoolean {
+		updated, err = sjson.SetBytes(response, policy.field, policy.fallback == "true")
+	} else {
+		updated, err = sjson.SetRawBytes(response, policy.field, []byte(policy.fallback))
+	}
+	if err != nil {
+		return response
+	}
+	return updated
+}
+
+func (f *responsesSSEFramer) failedResponseObject() []byte {
+	response := append([]byte(nil), f.responseObject...)
+	if !json.Valid(response) || !gjson.ParseBytes(response).IsObject() {
+		response = []byte("{}")
+	}
+	if f.responseID != "" && !gjson.GetBytes(response, "id").Exists() {
+		if updated, err := sjson.SetBytes(response, "id", f.responseID); err == nil {
+			response = updated
+		}
+	}
+	policies := []responsesJSONFieldPolicy{
+		{field: "created_at", fallback: "0"},
+		{field: "error", fallback: "null"},
+		{field: "incomplete_details", fallback: "null"},
+		{field: "instructions", fallback: "null"},
+		{field: "metadata", fallback: "null"},
+		{field: "model", fallback: `""`},
+		{field: "object", fallback: `"response"`},
+		{field: "output", fallback: "[]"},
+		{field: "parallel_tool_calls", fallback: "true", kind: responsesJSONFieldBoolean},
+		{field: "temperature", fallback: "null"},
+		{field: "tool_choice", fallback: `"auto"`},
+		{field: "tools", fallback: "[]"},
+		{field: "top_p", fallback: "null"},
+		{field: "background", fallback: "false"},
+		{field: "status", fallback: `"failed"`},
+		{field: "text", fallback: `{"format":{"type":"text"}}`},
+		{field: "usage", fallback: "null"},
+		{field: "store", fallback: "true", kind: responsesJSONFieldBoolean},
+		{field: "conversation", kind: responsesJSONFieldConversation},
+		{field: "max_output_tokens"},
+		{field: "max_tool_calls"},
+		{field: "previous_response_id"},
+		{field: "prompt"},
+		{field: "prompt_cache_key"},
+		{field: "prompt_cache_options"},
+		{field: "prompt_cache_retention"},
+		{field: "reasoning"},
+		{field: "safety_identifier"},
+		{field: "service_tier"},
+		{field: "top_logprobs"},
+		{field: "truncation"},
+		{field: "user"},
+	}
+	for _, policy := range policies {
+		response = applyResponsesJSONFieldPolicy(response, f.requestJSON, policy)
+	}
+	if outputJSON := f.recordedOutputJSON(); len(outputJSON) > 0 {
+		output := gjson.GetBytes(response, "output")
+		if !output.Exists() || !output.IsArray() || len(output.Array()) == 0 {
+			if updated, err := sjson.SetRawBytes(response, "output", outputJSON); err == nil {
+				response = updated
+			}
+		}
+	}
+	return response
+}
+
+func (f *responsesSSEFramer) repairCompletedPayload(payload []byte) []byte {
+	outputJSON := f.recordedOutputJSON()
+	if len(outputJSON) == 0 {
+		return payload
+	}
+	output := gjson.GetBytes(payload, "response.output")
+	if output.Exists() && (!output.IsArray() || len(output.Array()) > 0) {
+		return payload
+	}
+	repaired, err := sjson.SetRawBytes(payload, "response.output", outputJSON)
 	if err != nil {
 		return payload
 	}
@@ -493,7 +689,7 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 		c.Header("Connection", "keep-alive")
 		c.Header("Access-Control-Allow-Origin", "*")
 	}
-	framer := &responsesSSEFramer{}
+	framer := &responsesSSEFramer{requestJSON: append([]byte(nil), rawJSON...)}
 
 	// Peek at the first chunk
 	for {
@@ -551,7 +747,7 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flush
 		},
 		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) {
 			framer.Flush(c.Writer)
-			if errMsg == nil {
+			if errMsg == nil || framer.terminalEventSeen {
 				return
 			}
 			status := http.StatusInternalServerError
@@ -562,8 +758,9 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flush
 			if errMsg.Error != nil && errMsg.Error.Error() != "" {
 				errText = errMsg.Error.Error()
 			}
-			chunk := handlers.BuildOpenAIResponsesStreamErrorChunk(status, errText, 0)
-			_, _ = fmt.Fprintf(c.Writer, "\nevent: error\ndata: %s\n\n", string(chunk))
+			responseID, sequenceNumber, responseObject := framer.terminalMetadata()
+			chunk := handlers.BuildOpenAIResponsesFailedStreamChunk(status, errText, responseID, sequenceNumber, responseObject)
+			_, _ = fmt.Fprintf(c.Writer, "\nevent: response.failed\ndata: %s\n\n", string(chunk))
 		},
 		WriteDone: func() {
 			framer.Flush(c.Writer)

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_error_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_error_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -11,9 +12,10 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	"github.com/tidwall/gjson"
 )
 
-func TestForwardResponsesStreamTerminalErrorUsesResponsesErrorChunk(t *testing.T) {
+func TestForwardResponsesStreamTerminalErrorUsesResponseFailedEvent(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
 	h := NewOpenAIResponsesAPIHandler(base)
@@ -27,17 +29,289 @@ func TestForwardResponsesStreamTerminalErrorUsesResponsesErrorChunk(t *testing.T
 		t.Fatalf("expected gin writer to implement http.Flusher")
 	}
 
+	framer := &responsesSSEFramer{requestJSON: []byte(`{"model":"gpt-test","instructions":"test instructions","metadata":{"source":"test"},"parallel_tool_calls":true,"temperature":0.5,"tool_choice":"auto","tools":[],"top_p":0.9,"text":{"format":{"type":"text"}},"max_output_tokens":128,"conversation":"conv_test"}`)}
+	framer.WriteChunk(c.Writer, []byte("event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":4,\"response\":{\"id\":\"resp_test\",\"object\":\"response\",\"created_at\":123,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"output\":[]}}\n\n"))
+	framer.WriteChunk(c.Writer, []byte("event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":5,\"output_index\":0,\"item\":{\"id\":\"msg_test\",\"type\":\"message\",\"status\":\"completed\",\"role\":\"assistant\",\"content\":[]}}\n\n"))
+
 	data := make(chan []byte)
 	errs := make(chan *interfaces.ErrorMessage, 1)
 	errs <- &interfaces.ErrorMessage{StatusCode: http.StatusInternalServerError, Error: errors.New("unexpected EOF")}
 	close(errs)
 
-	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, framer)
 	body := recorder.Body.String()
-	if !strings.Contains(body, `"type":"error"`) {
-		t.Fatalf("expected responses error chunk, got: %q", body)
+	if !strings.Contains(body, "event: response.failed\n") {
+		t.Fatalf("expected response.failed terminal event, got: %q", body)
 	}
-	if strings.Contains(body, `"error":{`) {
-		t.Fatalf("expected streaming error chunk (top-level type), got HTTP error body: %q", body)
+	if !strings.Contains(body, `"type":"response.failed"`) {
+		t.Fatalf("expected response.failed payload, got: %q", body)
+	}
+	if strings.Contains(body, "event: error\n") {
+		t.Fatalf("unexpected generic error event: %q", body)
+	}
+	failedAt := strings.Index(body, "event: response.failed\n")
+	payload, ok := responsesSSEDataPayload([]byte(body[failedAt:]))
+	if !ok {
+		t.Fatalf("expected response.failed data payload, got: %q", body)
+	}
+	var responseFields map[string]json.RawMessage
+	responsePayload := gjson.GetBytes(payload, "response")
+	if err := json.Unmarshal([]byte(responsePayload.Raw), &responseFields); err != nil {
+		t.Fatalf("unmarshal response: %v; payload=%s", err, payload)
+	}
+	for _, field := range []string{"id", "created_at", "error", "incomplete_details", "instructions", "metadata", "model", "object", "output", "parallel_tool_calls", "temperature", "tool_choice", "tools", "top_p", "usage", "store"} {
+		if _, exists := responseFields[field]; !exists {
+			t.Fatalf("required response field %q is missing; payload=%s", field, payload)
+		}
+	}
+	if _, exists := responseFields["output_text"]; exists {
+		t.Fatalf("non-native output_text field was added; payload=%s", payload)
+	}
+	if got := gjson.GetBytes(payload, "response.id").String(); got != "resp_test" {
+		t.Fatalf("response id = %q, want %q; payload=%s", got, "resp_test", payload)
+	}
+	if got := gjson.GetBytes(payload, "response.error.code").String(); got != "server_error" {
+		t.Fatalf("error code = %q, want %q; payload=%s", got, "server_error", payload)
+	}
+	if got := gjson.GetBytes(payload, "sequence_number").Int(); got != 6 {
+		t.Fatalf("sequence_number = %d, want 6; payload=%s", got, payload)
+	}
+	if got := gjson.GetBytes(payload, "response.created_at").Int(); got != 123 {
+		t.Fatalf("created_at = %d, want 123; payload=%s", got, payload)
+	}
+	if got := gjson.GetBytes(payload, "response.model").String(); got != "gpt-test" {
+		t.Fatalf("model = %q, want %q; payload=%s", got, "gpt-test", payload)
+	}
+	if !gjson.GetBytes(payload, "response.parallel_tool_calls").Bool() {
+		t.Fatalf("parallel_tool_calls was not preserved; payload=%s", payload)
+	}
+	if got := gjson.GetBytes(payload, "response.tool_choice").String(); got != "auto" {
+		t.Fatalf("tool_choice = %q, want %q; payload=%s", got, "auto", payload)
+	}
+	if !gjson.GetBytes(payload, "response.tools").IsArray() || !gjson.GetBytes(payload, "response.text").IsObject() {
+		t.Fatalf("response schema fields were not populated; payload=%s", payload)
+	}
+	if got := gjson.GetBytes(payload, "response.output.0.id").String(); got != "msg_test" {
+		t.Fatalf("output item id = %q, want %q; payload=%s", got, "msg_test", payload)
+	}
+	if got := gjson.GetBytes(payload, "response.instructions").String(); got != "test instructions" {
+		t.Fatalf("instructions = %q, want %q; payload=%s", got, "test instructions", payload)
+	}
+	if got := gjson.GetBytes(payload, "response.conversation.id").String(); got != "conv_test" {
+		t.Fatalf("conversation id = %q, want conv_test; payload=%s", got, payload)
+	}
+	if got := gjson.GetBytes(payload, "response.temperature").Float(); got != 0.5 {
+		t.Fatalf("temperature = %v, want 0.5; payload=%s", got, payload)
+	}
+	if !gjson.GetBytes(payload, "response.store").Bool() {
+		t.Fatalf("store default was not populated; payload=%s", payload)
+	}
+	if got := gjson.GetBytes(payload, "response.max_output_tokens").Int(); got != 128 {
+		t.Fatalf("max_output_tokens = %d, want 128; payload=%s", got, payload)
+	}
+	if gjson.GetBytes(payload, "response.service_tier").Exists() {
+		t.Fatalf("optional service_tier was synthesized; payload=%s", payload)
+	}
+	if got := gjson.GetBytes(payload, "response.top_p").Float(); got != 0.9 {
+		t.Fatalf("top_p = %v, want 0.9; payload=%s", got, payload)
+	}
+}
+
+func TestResponsesSSEFramerFailedResponseStorePrecedence(t *testing.T) {
+	tests := []struct {
+		name           string
+		requestJSON    string
+		responseObject string
+		want           bool
+	}{
+		{name: "api default", requestJSON: `{"model":"gpt-test"}`, responseObject: `{"id":"resp_test"}`, want: true},
+		{name: "null uses default", requestJSON: `{"model":"gpt-test","store":null}`, responseObject: `{"id":"resp_test"}`, want: true},
+		{name: "request false", requestJSON: `{"model":"gpt-test","store":false}`, responseObject: `{"id":"resp_test"}`, want: false},
+		{name: "request true", requestJSON: `{"model":"gpt-test","store":true}`, responseObject: `{"id":"resp_test"}`, want: true},
+		{name: "response wins", requestJSON: `{"model":"gpt-test","store":true}`, responseObject: `{"id":"resp_test","store":false}`, want: false},
+		{name: "invalid response uses request", requestJSON: `{"model":"gpt-test","store":false}`, responseObject: `{"id":"resp_test","store":null}`, want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			framer := &responsesSSEFramer{
+				responseID:     "resp_test",
+				responseObject: []byte(test.responseObject),
+				requestJSON:    []byte(test.requestJSON),
+			}
+			response := framer.failedResponseObject()
+			store := gjson.GetBytes(response, "store")
+			if store.Type != gjson.True && store.Type != gjson.False {
+				t.Fatalf("store = %s, want boolean; response=%s", store.Raw, response)
+			}
+			if got := store.Bool(); got != test.want {
+				t.Fatalf("store = %v, want %v; response=%s", got, test.want, response)
+			}
+		})
+	}
+}
+
+func TestResponsesSSEFramerFailedResponseParallelToolCallsPrecedence(t *testing.T) {
+	tests := []struct {
+		name           string
+		requestJSON    string
+		responseObject string
+		want           bool
+	}{
+		{name: "api default", requestJSON: `{"model":"gpt-test"}`, responseObject: `{"id":"resp_test"}`, want: true},
+		{name: "null uses default", requestJSON: `{"model":"gpt-test","parallel_tool_calls":null}`, responseObject: `{"id":"resp_test"}`, want: true},
+		{name: "request false", requestJSON: `{"model":"gpt-test","parallel_tool_calls":false}`, responseObject: `{"id":"resp_test"}`, want: false},
+		{name: "request true", requestJSON: `{"model":"gpt-test","parallel_tool_calls":true}`, responseObject: `{"id":"resp_test"}`, want: true},
+		{name: "response wins", requestJSON: `{"model":"gpt-test","parallel_tool_calls":true}`, responseObject: `{"id":"resp_test","parallel_tool_calls":false}`, want: false},
+		{name: "invalid response uses request", requestJSON: `{"model":"gpt-test","parallel_tool_calls":false}`, responseObject: `{"id":"resp_test","parallel_tool_calls":null}`, want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			framer := &responsesSSEFramer{
+				responseID:     "resp_test",
+				responseObject: []byte(test.responseObject),
+				requestJSON:    []byte(test.requestJSON),
+			}
+			response := framer.failedResponseObject()
+			parallelToolCalls := gjson.GetBytes(response, "parallel_tool_calls")
+			if parallelToolCalls.Type != gjson.True && parallelToolCalls.Type != gjson.False {
+				t.Fatalf("parallel_tool_calls = %s, want boolean; response=%s", parallelToolCalls.Raw, response)
+			}
+			if got := parallelToolCalls.Bool(); got != test.want {
+				t.Fatalf("parallel_tool_calls = %v, want %v; response=%s", got, test.want, response)
+			}
+		})
+	}
+}
+
+func TestResponsesSSEFramerFailedResponseConversationNormalization(t *testing.T) {
+	tests := []struct {
+		name           string
+		requestJSON    string
+		responseObject string
+		wantID         string
+		wantNull       bool
+	}{
+		{name: "absent", requestJSON: `{"model":"gpt-test"}`, responseObject: `{"id":"resp_test"}`},
+		{name: "request id string", requestJSON: `{"model":"gpt-test","conversation":"conv_string"}`, responseObject: `{"id":"resp_test"}`, wantID: "conv_string"},
+		{name: "request object", requestJSON: `{"model":"gpt-test","conversation":{"id":"conv_object","extra":"drop"}}`, responseObject: `{"id":"resp_test"}`, wantID: "conv_object"},
+		{name: "response wins", requestJSON: `{"model":"gpt-test","conversation":"conv_request"}`, responseObject: `{"id":"resp_test","conversation":{"id":"conv_response"}}`, wantID: "conv_response"},
+		{name: "response null wins", requestJSON: `{"model":"gpt-test","conversation":"conv_request"}`, responseObject: `{"id":"resp_test","conversation":null}`, wantNull: true},
+		{name: "invalid request omitted", requestJSON: `{"model":"gpt-test","conversation":false}`, responseObject: `{"id":"resp_test"}`},
+		{name: "numeric request id omitted", requestJSON: `{"model":"gpt-test","conversation":{"id":123}}`, responseObject: `{"id":"resp_test"}`},
+		{name: "invalid response uses request", requestJSON: `{"model":"gpt-test","conversation":"conv_request"}`, responseObject: `{"id":"resp_test","conversation":{"id":123}}`, wantID: "conv_request"},
+		{name: "invalid response omitted", requestJSON: `{"model":"gpt-test"}`, responseObject: `{"id":"resp_test","conversation":false}`},
+		{name: "invalid response and request omitted", requestJSON: `{"model":"gpt-test","conversation":{"id":123}}`, responseObject: `{"id":"resp_test","conversation":{"id":456}}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			framer := &responsesSSEFramer{
+				responseID:     "resp_test",
+				responseObject: []byte(test.responseObject),
+				requestJSON:    []byte(test.requestJSON),
+			}
+			response := framer.failedResponseObject()
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal(response, &fields); err != nil {
+				t.Fatalf("unmarshal response: %v; response=%s", err, response)
+			}
+			conversationRaw, exists := fields["conversation"]
+			if test.wantNull {
+				if !exists || string(conversationRaw) != "null" {
+					t.Fatalf("conversation = %s, want null; response=%s", conversationRaw, response)
+				}
+				return
+			}
+			if test.wantID == "" {
+				if exists {
+					t.Fatalf("conversation = %s, want omitted; response=%s", conversationRaw, response)
+				}
+				return
+			}
+			conversation := gjson.GetBytes(response, "conversation")
+			if !conversation.IsObject() {
+				t.Fatalf("conversation = %s, want object; response=%s", conversation.Raw, response)
+			}
+			if got := conversation.Get("id").String(); got != test.wantID {
+				t.Fatalf("conversation id = %q, want %q; response=%s", got, test.wantID, response)
+			}
+			if conversation.Get("extra").Exists() {
+				t.Fatalf("request-only conversation fields were preserved; response=%s", response)
+			}
+		})
+	}
+}
+
+func TestForwardResponsesStreamTerminalErrorPreservesMixedOutputOrder(t *testing.T) {
+	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
+	framer := &responsesSSEFramer{requestJSON: []byte(`{"model":"gpt-test","store":false}`)}
+	framer.WriteChunk(c.Writer, []byte("event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":1,\"response\":{\"id\":\"resp_test\",\"output\":[]}}\n\n"))
+	framer.WriteChunk(c.Writer, []byte("event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":2,\"item\":{\"type\":\"message\",\"id\":\"msg-1\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"done\"}]}}\n\n"))
+	framer.WriteChunk(c.Writer, []byte("event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":3,\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"fc-1\",\"call_id\":\"call-1\",\"name\":\"shell\",\"arguments\":\"{}\",\"status\":\"completed\"}}\n\n"))
+
+	data := make(chan []byte)
+	close(data)
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	errs <- &interfaces.ErrorMessage{StatusCode: http.StatusInternalServerError, Error: errors.New("unexpected EOF")}
+	close(errs)
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, framer)
+
+	body := recorder.Body.String()
+	failedAt := strings.LastIndex(body, "event: response.failed\n")
+	if failedAt < 0 {
+		t.Fatalf("expected response.failed event; body=%q", body)
+	}
+	payload, ok := responsesSSEDataPayload([]byte(body[failedAt:]))
+	if !ok {
+		t.Fatalf("expected response.failed data payload; body=%q", body)
+	}
+	output := gjson.GetBytes(payload, "response.output")
+	if !output.IsArray() || len(output.Array()) != 2 {
+		t.Fatalf("output = %s, want 2 items; payload=%s", output.Raw, payload)
+	}
+	if got := gjson.GetBytes(payload, "response.output.0.id").String(); got != "fc-1" {
+		t.Fatalf("first output id = %q, want fc-1; payload=%s", got, payload)
+	}
+	if got := gjson.GetBytes(payload, "response.output.1.id").String(); got != "msg-1" {
+		t.Fatalf("second output id = %q, want msg-1; payload=%s", got, payload)
+	}
+	if got := gjson.GetBytes(payload, "sequence_number").Int(); got != 4 {
+		t.Fatalf("sequence_number = %d, want 4; payload=%s", got, payload)
+	}
+}
+
+func TestForwardResponsesStreamTerminalErrorDoesNotDuplicateTerminalEvent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, terminalType := range []string{"response.completed", "response.incomplete", "response.failed"} {
+		t.Run(terminalType, func(t *testing.T) {
+			base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+			h := NewOpenAIResponsesAPIHandler(base)
+
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+			flusher, ok := c.Writer.(http.Flusher)
+			if !ok {
+				t.Fatalf("expected gin writer to implement http.Flusher")
+			}
+
+			status := strings.TrimPrefix(terminalType, "response.")
+			framer := &responsesSSEFramer{}
+			framer.WriteChunk(c.Writer, []byte("event: "+terminalType+"\ndata: {\"type\":\""+terminalType+"\",\"sequence_number\":4,\"response\":{\"id\":\"resp_test\",\"status\":\""+status+"\"}}\n\n"))
+
+			data := make(chan []byte)
+			errs := make(chan *interfaces.ErrorMessage, 1)
+			errs <- &interfaces.ErrorMessage{StatusCode: http.StatusInternalServerError, Error: errors.New("unexpected EOF")}
+			close(errs)
+
+			h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, framer)
+			body := recorder.Body.String()
+			terminalCount := 0
+			for _, candidate := range []string{"response.completed", "response.incomplete", "response.failed"} {
+				terminalCount += strings.Count(body, `"type":"`+candidate+`"`)
+			}
+			if terminalCount != 1 {
+				t.Fatalf("terminal event count = %d, want 1; body=%q", terminalCount, body)
+			}
+		})
 	}
 }

--- a/sdk/api/handlers/openai_responses_stream_error.go
+++ b/sdk/api/handlers/openai_responses_stream_error.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/google/uuid"
+	"github.com/tidwall/sjson"
 )
 
 type openAIResponsesStreamErrorChunk struct {
@@ -116,4 +119,113 @@ func BuildOpenAIResponsesStreamErrorChunk(status int, errText string, sequenceNu
 		return data
 	}
 	return []byte(`{"type":"error","code":"internal_server_error","message":"internal error","sequence_number":0}`)
+}
+
+type openAIResponsesFailedError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func openAIResponsesFailedErrorCode(status int, code string) string {
+	switch strings.TrimSpace(code) {
+	case "server_error", "rate_limit_exceeded", "invalid_prompt", "data_residency_mismatch", "bio_policy", "vector_store_timeout",
+		"invalid_image", "invalid_image_format", "invalid_base64_image", "invalid_image_url", "image_too_large", "image_too_small",
+		"image_parse_error", "image_content_policy_violation", "invalid_image_mode", "image_file_too_large",
+		"unsupported_image_media_type", "empty_image_file", "failed_to_download_image", "image_file_not_found":
+		return strings.TrimSpace(code)
+	}
+	switch status {
+	case http.StatusTooManyRequests:
+		return "rate_limit_exceeded"
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusRequestTimeout:
+		return "server_error"
+	}
+	if status >= http.StatusBadRequest && status < http.StatusInternalServerError {
+		return "invalid_prompt"
+	}
+	return "server_error"
+}
+
+type openAIResponsesFailedResponse struct {
+	ID     string                     `json:"id"`
+	Object string                     `json:"object"`
+	Status string                     `json:"status"`
+	Output []any                      `json:"output"`
+	Error  openAIResponsesFailedError `json:"error"`
+}
+
+type openAIResponsesFailedChunk struct {
+	Type           string          `json:"type"`
+	SequenceNumber int             `json:"sequence_number"`
+	Response       json.RawMessage `json:"response"`
+}
+
+func buildOpenAIResponsesFailedResponse(responseObject []byte, responseID string, streamErr openAIResponsesStreamErrorChunk) json.RawMessage {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(responseObject, &fields); err == nil && fields != nil {
+		response := append([]byte(nil), responseObject...)
+		var currentID string
+		_ = json.Unmarshal(fields["id"], &currentID)
+		var errSet error
+		if strings.TrimSpace(currentID) == "" {
+			response, errSet = sjson.SetBytes(response, "id", responseID)
+		}
+		if errSet == nil {
+			response, errSet = sjson.SetBytes(response, "object", "response")
+		}
+		if errSet == nil {
+			response, errSet = sjson.SetBytes(response, "status", "failed")
+		}
+		if errSet == nil {
+			errorJSON, _ := json.Marshal(openAIResponsesFailedError{Code: streamErr.Code, Message: streamErr.Message})
+			response, errSet = sjson.SetRawBytes(response, "error", errorJSON)
+		}
+		if errSet == nil {
+			if _, ok := fields["output"]; !ok {
+				response, errSet = sjson.SetRawBytes(response, "output", []byte("[]"))
+			}
+		}
+		if errSet == nil && json.Valid(response) {
+			return response
+		}
+	}
+
+	response, _ := json.Marshal(openAIResponsesFailedResponse{
+		ID:     responseID,
+		Object: "response",
+		Status: "failed",
+		Output: []any{},
+		Error: openAIResponsesFailedError{
+			Code:    streamErr.Code,
+			Message: streamErr.Message,
+		},
+	})
+	return response
+}
+
+// BuildOpenAIResponsesFailedStreamChunk builds a terminal response.failed event payload.
+func BuildOpenAIResponsesFailedStreamChunk(status int, errText, responseID string, sequenceNumber int, responseObject []byte) []byte {
+	if strings.TrimSpace(responseID) == "" {
+		responseID = "resp_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	}
+	if sequenceNumber < 0 {
+		sequenceNumber = 0
+	}
+	errorChunk := BuildOpenAIResponsesStreamErrorChunk(status, errText, 0)
+	var streamErr openAIResponsesStreamErrorChunk
+	if err := json.Unmarshal(errorChunk, &streamErr); err != nil {
+		streamErr.Code = "internal_server_error"
+		streamErr.Message = http.StatusText(http.StatusInternalServerError)
+	}
+	streamErr.Code = openAIResponsesFailedErrorCode(status, streamErr.Code)
+
+	data, err := json.Marshal(openAIResponsesFailedChunk{
+		Type:           "response.failed",
+		SequenceNumber: sequenceNumber,
+		Response:       buildOpenAIResponsesFailedResponse(responseObject, responseID, streamErr),
+	})
+	if err == nil {
+		return data
+	}
+	return []byte(`{"type":"response.failed","sequence_number":0,"response":{"id":"resp_error","object":"response","status":"failed","output":[],"error":{"code":"server_error","message":"internal error"}}}`)
 }

--- a/sdk/api/handlers/openai_responses_stream_error_test.go
+++ b/sdk/api/handlers/openai_responses_stream_error_test.go
@@ -46,3 +46,136 @@ func TestBuildOpenAIResponsesStreamErrorChunkExtractsHTTPErrorBody(t *testing.T)
 		t.Fatalf("message = %v, want %q", payload["message"], "oops")
 	}
 }
+
+func TestOpenAIResponsesFailedErrorCode(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		code   string
+		want   string
+	}{
+		{name: "transport failure", status: http.StatusInternalServerError, code: "internal_server_error", want: "server_error"},
+		{name: "transport timeout", status: http.StatusRequestTimeout, code: "request_timeout", want: "server_error"},
+		{name: "authentication failure", status: http.StatusUnauthorized, code: "invalid_api_key", want: "server_error"},
+		{name: "permission failure", status: http.StatusForbidden, code: "permission_denied", want: "server_error"},
+		{name: "model not found", status: http.StatusNotFound, code: "model_not_found", want: "invalid_prompt"},
+		{name: "overloaded", status: http.StatusServiceUnavailable, code: "server_overloaded", want: "server_error"},
+		{name: "rate limit", status: http.StatusTooManyRequests, code: "rate_limit_exceeded", want: "rate_limit_exceeded"},
+		{name: "bad request", status: http.StatusBadRequest, code: "invalid_request_error", want: "invalid_prompt"},
+		{name: "image code", status: http.StatusBadRequest, code: "invalid_image", want: "invalid_image"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := openAIResponsesFailedErrorCode(test.status, test.code); got != test.want {
+				t.Fatalf("code = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestBuildOpenAIResponsesFailedStreamChunkServerFailures(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		errText string
+	}{
+		{
+			name:    "request timeout",
+			status:  http.StatusRequestTimeout,
+			errText: "stream error: stream disconnected before completion: stream closed before response.completed",
+		},
+		{
+			name:    "authentication failure",
+			status:  http.StatusUnauthorized,
+			errText: `{"error":{"type":"authentication_error","code":"invalid_api_key","message":"upstream credential rejected"}}`,
+		},
+		{
+			name:    "permission failure",
+			status:  http.StatusForbidden,
+			errText: `{"error":{"type":"permission_error","code":"permission_denied","message":"upstream permission denied"}}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			chunk := BuildOpenAIResponsesFailedStreamChunk(test.status, test.errText, "resp_failure", 2, nil)
+			var payload struct {
+				Response struct {
+					Error openAIResponsesFailedError `json:"error"`
+				} `json:"response"`
+			}
+			if err := json.Unmarshal(chunk, &payload); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if payload.Response.Error.Code != "server_error" {
+				t.Fatalf("error code = %q, want server_error", payload.Response.Error.Code)
+			}
+		})
+	}
+}
+
+func TestBuildOpenAIResponsesFailedStreamChunk(t *testing.T) {
+	chunk := BuildOpenAIResponsesFailedStreamChunk(
+		http.StatusServiceUnavailable,
+		`{"error":{"message":"Our servers are currently overloaded.","code":"server_overloaded"}}`,
+		"resp_fallback",
+		7,
+		[]byte(`{"id":"resp_test","object":"response","created_at":123,"status":"in_progress","model":"gpt-test","output":[],"parallel_tool_calls":true,"tool_choice":"auto","tools":[],"text":{"format":{"type":"text"}}}`),
+	)
+
+	var payload struct {
+		Type           string `json:"type"`
+		SequenceNumber int    `json:"sequence_number"`
+		Response       struct {
+			ID                string         `json:"id"`
+			Object            string         `json:"object"`
+			CreatedAt         int64          `json:"created_at"`
+			Status            string         `json:"status"`
+			Model             string         `json:"model"`
+			Output            []any          `json:"output"`
+			ParallelToolCalls bool           `json:"parallel_tool_calls"`
+			ToolChoice        string         `json:"tool_choice"`
+			Tools             []any          `json:"tools"`
+			Text              map[string]any `json:"text"`
+			Error             struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(chunk, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if payload.Type != "response.failed" {
+		t.Fatalf("type = %q, want %q", payload.Type, "response.failed")
+	}
+	if payload.SequenceNumber != 7 {
+		t.Fatalf("sequence_number = %d, want 7", payload.SequenceNumber)
+	}
+	if payload.Response.Status != "failed" {
+		t.Fatalf("status = %q, want %q", payload.Response.Status, "failed")
+	}
+	if payload.Response.Object != "response" {
+		t.Fatalf("object = %q, want %q", payload.Response.Object, "response")
+	}
+	if payload.Response.ID != "resp_test" {
+		t.Fatalf("response id = %q, want %q", payload.Response.ID, "resp_test")
+	}
+	if payload.Response.CreatedAt != 123 || payload.Response.Model != "gpt-test" {
+		t.Fatalf("response metadata was not preserved: %#v", payload.Response)
+	}
+	if !payload.Response.ParallelToolCalls || payload.Response.ToolChoice != "auto" {
+		t.Fatalf("response tool settings were not preserved: %#v", payload.Response)
+	}
+	if payload.Response.Tools == nil || payload.Response.Text == nil {
+		t.Fatalf("response schema fields were not preserved: %#v", payload.Response)
+	}
+	if payload.Response.Output == nil || len(payload.Response.Output) != 0 {
+		t.Fatalf("output = %#v, want empty array", payload.Response.Output)
+	}
+	if payload.Response.Error.Code != "server_error" {
+		t.Fatalf("error code = %q, want %q", payload.Response.Error.Code, "server_error")
+	}
+	if payload.Response.Error.Message != "Our servers are currently overloaded." {
+		t.Fatalf("error message = %q", payload.Response.Error.Message)
+	}
+}


### PR DESCRIPTION
## Summary

- emit a terminal `response.failed` SSE event when a Responses stream fails after streaming has started
- reuse the existing error normalization logic for status codes and upstream error bodies
- include the standard `sequence_number` field and a failed response payload
- add regression tests for the payload and handler output

## Problem

The Responses handler currently emits only a generic `event: error` frame for terminal forwarding errors. `error` is not a terminal response lifecycle event, so downstream Responses consumers can observe an HTTP 200 stream that ends without either `response.completed` or `response.failed`. Gateways that validate terminal events then report the stream as incomplete and lose the structured upstream error.

OpenAI documents `response.failed` as the event emitted when a response fails: https://platform.openai.com/docs/api-reference/responses-streaming/response/failed

This change affects only errors raised after a Responses stream has started. Successful streams, non-streaming responses, and pre-stream HTTP errors are unchanged.

## Verification

- `go test ./sdk/api/handlers ./sdk/api/handlers/openai`
- all packages except `internal/client/codex/live` pass
- `go build -o test-output ./cmd/server && rm test-output`

`go test ./...` has one unrelated failure in `TestPionMediaRelayBridgesAudioAndDataChannel`. The same failure reproduces on an unmodified `upstream/main` worktree (`upstream DataChannel was not created`).
