### PR TITLE
fix(gemini): drop empty enum values from translated schemas

### DIFF
--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -218,9 +218,15 @@ func convertConstToEnum(jsonStr string) string {
 	return jsonStr
 }
 
-// convertEnumValuesToStrings ensures all enum values use the string representation required by
-// Gemini's proto schema. Tool schemas also require a string type, while response schemas preserve
-// their declared type because the upstream decoder uses it to select the emitted JSON value type.
+// convertEnumValuesToStrings ensures all enum values use the non-empty string representation
+// required by Gemini's proto schema. Tool schemas also require a string type, while response
+// schemas preserve their declared type because the upstream decoder uses it to select the emitted
+// JSON value type.
+//
+// JSON Schema permits null (and occasionally empty strings) in enum arrays for optional values,
+// but Gemini only accepts non-empty strings. gjson.Result.String() renders null as "", which
+// Gemini rejects with "enum[n]: cannot be empty". Skip those entries; if nothing valid remains,
+// delete the enum keyword instead of emitting an empty array.
 func convertEnumValuesToStrings(jsonStr string, forceStringType bool) string {
 	for _, p := range findPaths(jsonStr, "enum") {
 		arr := gjson.Get(jsonStr, p)
@@ -230,7 +236,16 @@ func convertEnumValuesToStrings(jsonStr string, forceStringType bool) string {
 
 		var stringVals []string
 		for _, item := range arr.Array() {
+			// Null and empty entries become invalid Gemini enum values after stringification.
+			if item.Type == gjson.Null || item.String() == "" {
+				continue
+			}
 			stringVals = append(stringVals, item.String())
+		}
+
+		if len(stringVals) == 0 {
+			jsonStr, _ = sjson.Delete(jsonStr, p)
+			continue
 		}
 
 		updated, _ := sjson.SetBytes([]byte(jsonStr), p, stringVals)

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -244,7 +244,14 @@ func convertEnumValuesToStrings(jsonStr string, forceStringType bool) string {
 		}
 
 		if len(stringVals) == 0 {
+			// Drop the invalid enum, but still normalize tool schemas to string type.
+			// Otherwise {"type":"null","enum":[null]} / const:null becomes type:null with no enum.
 			jsonStr, _ = sjson.Delete(jsonStr, p)
+			if forceStringType {
+				parentPath := trimSuffix(p, ".enum")
+				updated, _ := sjson.SetBytes([]byte(jsonStr), joinPath(parentPath, "type"), "string")
+				jsonStr = string(updated)
+			}
 			continue
 		}
 

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -872,6 +872,70 @@ func TestCleanJSONSchemaRemovesEmptyEnumValues(t *testing.T) {
 	}
 }
 
+func TestCleanJSONSchemaForcesStringTypeWhenDroppingEmptyEnums(t *testing.T) {
+	// Tool cleaners force enum parents to string. Dropping an all-invalid enum must
+	// still apply that rewrite so const:null / type:null enums do not leave type:null.
+	input := `{
+		"type":"object",
+		"properties":{
+			"null_enum":{"type":"null","enum":[null,""]},
+			"const_null":{"const":null}
+		}
+	}`
+
+	for _, testCase := range []struct {
+		name          string
+		clean         func(string) string
+		wantEmptyType string
+		wantConstType string
+	}{
+		{
+			name:          "gemini",
+			clean:         CleanJSONSchemaForGemini,
+			wantEmptyType: "string",
+			wantConstType: "string",
+		},
+		{
+			name:          "antigravity",
+			clean:         CleanJSONSchemaForAntigravity,
+			wantEmptyType: "string",
+			wantConstType: "string",
+		},
+		{
+			name:  "antigravity_response",
+			clean: CleanJSONSchemaForAntigravityResponse,
+			// Response path preserves declared types when only enum is dropped.
+			wantEmptyType: "null",
+			// const is converted to enum then dropped; type is not forced.
+			wantConstType: "",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := gjson.Parse(testCase.clean(input))
+
+			if result.Get("properties.null_enum.enum").Exists() {
+				t.Fatalf("null_enum enum was retained: %s", result.Raw)
+			}
+			if result.Get("properties.const_null.enum").Exists() {
+				t.Fatalf("const_null enum was retained: %s", result.Raw)
+			}
+
+			gotEmptyType := result.Get("properties.null_enum.type").String()
+			if gotEmptyType != testCase.wantEmptyType {
+				t.Errorf("null_enum.type = %q, want %q: %s", gotEmptyType, testCase.wantEmptyType, result.Raw)
+			}
+
+			gotConstType := result.Get("properties.const_null.type").String()
+			if gotConstType != testCase.wantConstType {
+				t.Errorf("const_null.type = %q, want %q: %s", gotConstType, testCase.wantConstType, result.Raw)
+			}
+			if result.Get("properties.const_null.const").Exists() {
+				t.Errorf("const keyword should have been converted away: %s", result.Raw)
+			}
+		})
+	}
+}
+
 func TestCleanJSONSchemaForAntigravity_RemovesNullAndEmptyEnumValues(t *testing.T) {
 	// Field-shaped schemas that trigger Gemini "enum[n]: cannot be empty" when null is
 	// listed alongside string enum values (e.g. optional enums from schema generators).

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -834,6 +834,81 @@ func TestCleanJSONSchemaForAntigravityResponsePreservesEnumType(t *testing.T) {
 	}
 }
 
+func TestCleanJSONSchemaRemovesEmptyEnumValues(t *testing.T) {
+	input := `{
+		"type":"object",
+		"properties":{
+			"mixed":{"type":"string","enum":["ready","",null,"done"]},
+			"empty":{"type":"string","enum":["",null]}
+		}
+	}`
+
+	for _, testCase := range []struct {
+		name  string
+		clean func(string) string
+	}{
+		{name: "gemini", clean: CleanJSONSchemaForGemini},
+		{name: "antigravity", clean: CleanJSONSchemaForAntigravity},
+		{name: "antigravity_response", clean: CleanJSONSchemaForAntigravityResponse},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := gjson.Parse(testCase.clean(input))
+			mixed := result.Get("properties.mixed.enum")
+			if !mixed.IsArray() {
+				t.Fatalf("mixed enum was removed: %s", result.Raw)
+			}
+
+			var got []string
+			for _, value := range mixed.Array() {
+				got = append(got, value.String())
+			}
+			if want := []string{"ready", "done"}; !reflect.DeepEqual(got, want) {
+				t.Errorf("mixed enum values = %v, want %v: %s", got, want, result.Raw)
+			}
+			if result.Get("properties.empty.enum").Exists() {
+				t.Errorf("empty-only enum was retained: %s", result.Raw)
+			}
+		})
+	}
+}
+
+func TestCleanJSONSchemaForAntigravity_RemovesNullAndEmptyEnumValues(t *testing.T) {
+	// Field-shaped schemas that trigger Gemini "enum[n]: cannot be empty" when null is
+	// listed alongside string enum values (e.g. optional enums from schema generators).
+	input := `{
+		"type": "object",
+		"properties": {
+			"todos": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"status": {"type": ["string", "null"], "enum": ["pending", "in_progress", "completed", "cancelled", null, ""]}
+					}
+				}
+			},
+			"capability_mode": {"type": ["string", "null"], "enum": ["read-only", "read-write", "execute", "all", null]}
+		}
+	}`
+
+	result := CleanJSONSchemaForAntigravity(input)
+
+	for _, path := range []string{
+		"properties.todos.items.properties.status.enum",
+		"properties.capability_mode.enum",
+	} {
+		values := gjson.Get(result, path).Array()
+		if len(values) != 4 {
+			t.Fatalf("%s contains %d values, want 4: %s", path, len(values), result)
+		}
+		for _, value := range values {
+			if value.Type != gjson.String || value.String() == "" {
+				t.Fatalf("%s contains invalid enum value %q: %s", path, value.Raw, result)
+			}
+		}
+	}
+}
+
 // ============================================================================
 // Format field handling (ad-hoc patch removal)
 // ============================================================================


### PR DESCRIPTION
### Problem

Gemini rejects tool/request schemas with:

```text
enum[n]: cannot be empty
```

(HTTP 400) whenever an enum array contains `null` or empty string values. This shape is common for optional enums produced by schema generators (for example listing `null` next to string members). The whole request fails, not just the affected property.

### Cause

`convertEnumValuesToStrings` in `internal/util/gemini_schema.go` normalizes every enum entry with `gjson.Result.String()`. For JSON `null` that returns `""`, so the empty string is written back into the enum array and forwarded to Gemini, which only accepts **non-empty** strings there.

### Fix

In the current two-arg API `convertEnumValuesToStrings(jsonStr, forceStringType)`:

- Skip `null` and empty-string entries while normalizing
- If nothing valid remains, **delete** the `enum` keyword instead of emitting an empty array
- Preserve order of remaining values
- Leave `forceStringType` behavior unchanged (tools still force `type: string`; response schemas keep declared types)

`convertEnumValuesToStrings` runs before `addEnumHints`, so downstream hint text no longer picks up empty values either.

### Relation to #4545

This PR implements the **same fix intent** as #4545 by @RsLuna7, rebased onto the current `forceStringType` API.

#4545 still targets the older one-arg signature and is currently **merge-conflicted (`dirty`)** against `dev`. This PR is a clean port for maintainers to land without resolving that conflict first. Please close #4545 as superseded if this merges (or the reverse if you prefer cherry-picking from there).

Credit for the original diagnosis and approach: **@RsLuna7** / #4545.

### Tests

- `TestCleanJSONSchemaRemovesEmptyEnumValues` — mixed enum keeps valid values; empty-only enum is removed; covered for Gemini / Antigravity / Antigravity response cleaners
- `TestCleanJSONSchemaForAntigravity_RemovesNullAndEmptyEnumValues` — field-shaped nullable enums (`todos[].status`, `capability_mode`) matching real tool schemas

### Verification

- `gofmt` clean on both files
- `go test ./internal/util -count=1` — pass

### Production evidence

The same filtering logic was applied on a deployment based on release **v7.2.110** (where `gemini_schema.go` matches current `dev` for this function). Previously failing requests that returned Gemini `enum[n]: cannot be empty` (HTTP 400) returned **HTTP 200** after the change; Gemini tool-calling paths (`gemini-3-flash` and related) succeeded end-to-end.

### Notes

- Small, boundary-clear compatibility fix; no protocol surface change beyond dropping invalid enum members Gemini would reject anyway.
- Scope limited to `internal/util/gemini_schema.go` + tests.