### PR TITLE
fix(gemini): strip Codex encrypted marker from tool schemas

### DIFF
--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -474,6 +474,7 @@ func removeUnsupportedKeywords(jsonStr string) string {
 		"$schema", "$defs", "definitions", "const", "$ref", "$id", "additionalProperties",
 		"propertyNames", "patternProperties", // Gemini doesn't support these schema keywords
 		"$comment", "enumDescriptions", "enumTitles", "prefill", "deprecated", // Schema metadata fields unsupported by Gemini
+		"encrypted", // Client-side encryption marker (Codex multi-agent v2); not a JSON Schema keyword, Gemini rejects it
 	)
 
 	deletePaths := make([]string, 0)

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -1049,6 +1049,59 @@ func TestCleanJSONSchemaForGemini_RemovesGeminiUnsupportedMetadataFields(t *test
 	compareJSON(t, expected, result)
 }
 
+func TestCleanJSONSchemaForGemini_RemovesEncryptedMarker(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"arg": {
+				"type": "string",
+				"description": "some arg",
+				"encrypted": true
+			},
+			"nested": {
+				"type": "object",
+				"properties": {
+					"deep": {
+						"type": "string",
+						"encrypted": false
+					}
+				}
+			},
+			"encrypted": {
+				"type": "boolean",
+				"description": "a property actually named encrypted must be preserved"
+			}
+		},
+		"required": ["arg"]
+	}`
+
+	expected := `{
+		"type": "object",
+		"properties": {
+			"arg": {
+				"type": "string",
+				"description": "some arg"
+			},
+			"nested": {
+				"type": "object",
+				"properties": {
+					"deep": {
+						"type": "string"
+					}
+				}
+			},
+			"encrypted": {
+				"type": "boolean",
+				"description": "a property actually named encrypted must be preserved"
+			}
+		},
+		"required": ["arg"]
+	}`
+
+	result := CleanJSONSchemaForGemini(input)
+	compareJSON(t, expected, result)
+}
+
 func TestRemoveExtensionFields(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- strip the non-JSON-Schema `encrypted` marker before sending tool schemas to Gemini
- preserve a legitimate tool property actually named `encrypted`
- add a focused regression test for nested marker removal and property preservation

## Root cause
Codex multi-agent v2 can attach `encrypted: true|false` to property schema objects. Gemini rejects that unknown field in `function_declarations[].parameters` with HTTP 400. The common schema cleaner already protects names under a `properties` map, so adding `encrypted` to the unsupported-keyword list removes only the marker sibling, not an argument named `encrypted`.

## Verification
- `go test ./internal/util/ -run CleanJSONSchemaForGemini -count=1 -v`
- `go test ./internal/util/ -count=1`
- `go vet ./internal/util/`
- live `/v1/responses` request through Gemini Flash returned HTTP 200; echoed schema omitted the marker and retained the real `encrypted` property