### PR TITLE
fix(responses): rewrite keepalive events as SSE comments

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -158,6 +158,8 @@ func (f *responsesSSEFramer) repairFrame(frame []byte) []byte {
 	}
 
 	switch eventType {
+	case "keepalive":
+		return []byte(": keep-alive\n\n")
 	case "response.output_item.done":
 		f.recordOutputItem(payload)
 	case "response.completed":

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -107,6 +107,8 @@ func (f *responsesSSEFramer) repairFrame(frame []byte) []byte {
 	}
 
 	switch gjson.GetBytes(payload, "type").String() {
+	case "keepalive":
+		return []byte(": keep-alive\n\n")
 	case "response.output_item.done":
 		f.recordOutputItem(payload)
 	case "response.completed":

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -194,6 +194,31 @@ func TestForwardResponsesStreamPreservesValidFullSSEEventChunks(t *testing.T) {
 	}
 }
 
+func TestForwardResponsesStreamRewritesKeepaliveEventsAsSSEComments(t *testing.T) {
+	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
+
+	data := make(chan []byte, 3)
+	errs := make(chan *interfaces.ErrorMessage)
+	data <- []byte("event: keepalive\ndata: {\"type\":\"keepalive\",\"sequence_number\":1}\n\n")
+	data <- []byte("data: {\"type\":\"keepalive\",\"sequence_number\":2}")
+	data <- []byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"output\":[]}}")
+	close(data)
+	close(errs)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+
+	body := recorder.Body.String()
+	if got := strings.Count(body, ": keep-alive\n\n"); got != 2 {
+		t.Fatalf("expected 2 SSE comment heartbeats, got %d. Body: %q", got, body)
+	}
+	if strings.Contains(body, `"type":"keepalive"`) || strings.Contains(body, "event: keepalive") {
+		t.Fatalf("non-standard keepalive event leaked downstream. Body: %q", body)
+	}
+	if !strings.Contains(body, `"type":"response.completed"`) {
+		t.Fatalf("terminal response event was not preserved. Body: %q", body)
+	}
+}
+
 func TestForwardResponsesStreamBuffersSplitDataPayloadChunks(t *testing.T) {
 	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
 

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -262,6 +262,31 @@ func TestForwardResponsesStreamPreservesValidFullSSEEventChunks(t *testing.T) {
 	}
 }
 
+func TestForwardResponsesStreamRewritesKeepaliveEventsAsSSEComments(t *testing.T) {
+	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
+
+	data := make(chan []byte, 3)
+	errs := make(chan *interfaces.ErrorMessage)
+	data <- []byte("event: keepalive\ndata: {\"type\":\"keepalive\",\"sequence_number\":1}\n\n")
+	data <- []byte("data: {\"type\":\"keepalive\",\"sequence_number\":2}")
+	data <- []byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"output\":[]}}")
+	close(data)
+	close(errs)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+
+	body := recorder.Body.String()
+	if got := strings.Count(body, ": keep-alive\n\n"); got != 2 {
+		t.Fatalf("expected 2 SSE comment heartbeats, got %d. Body: %q", got, body)
+	}
+	if strings.Contains(body, `"type":"keepalive"`) || strings.Contains(body, "event: keepalive") {
+		t.Fatalf("non-standard keepalive event leaked downstream. Body: %q", body)
+	}
+	if !strings.Contains(body, `"type":"response.completed"`) {
+		t.Fatalf("terminal response event was not preserved. Body: %q", body)
+	}
+}
+
 func TestForwardResponsesStreamBuffersSplitDataPayloadChunks(t *testing.T) {
 	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
 


### PR DESCRIPTION
## Summary

- Rewrite upstream Responses events with a top-level `type` of `keepalive` as standards-compliant SSE comments.
- Prevent strict OpenAI Responses clients from rejecting the stream with an unknown event variant while preserving streaming behavior.
- Add regression coverage for both fully framed and delimiterless keepalive chunks, and verify that the following terminal event is preserved.

## Why

Codex upstream can emit heartbeat frames such as:

```text
data: {"type":"keepalive","sequence_number":1}
```

`keepalive` is not an OpenAI Responses stream event type, so strict clients can fail while deserializing it. SSE comments are the protocol-level heartbeat mechanism and are safely ignored by event parsers.

## Testing

- `go test ./sdk/api/handlers/openai -run 'TestForwardResponsesStream(RewritesKeepaliveEventsAsSSEComments|PreservesValidFullSSEEventChunks|ReassemblesSplitSSEEventChunks)$' -count=1 -v`
- `go test ./sdk/api/handlers/openai -count=1`
- `go build -o test-output ./cmd/server && rm test-output`

Full-suite note: `go test ./...` passed all packages except the environment-sensitive WebRTC test `TestPionMediaRelayBridgesAudioAndDataChannel` in `internal/client/codex/live`, where the upstream DataChannel was not created after macOS denied inbound network access to the temporary test binary. This package is outside the change set.
