### PR TITLE
feat(plugin-store):  add custom proxy and accelerator support for plugin store

### DIFF
--- a/internal/api/handlers/management/plugin_proxy.go
+++ b/internal/api/handlers/management/plugin_proxy.go
@@ -1,0 +1,195 @@
+package management
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginstore"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
+)
+
+// GetPluginProxy returns the dedicated plugin-store proxy/accelerator setting
+// and the current global proxy-url (for system-proxy UI display).
+func (h *Handler) GetPluginProxy(c *gin.Context) {
+	if h == nil || h.cfg == nil {
+		c.JSON(http.StatusOK, gin.H{
+			"plugin-proxy": config.PluginProxyConfig{Status: config.PluginProxyStatusNone},
+			"proxy-url":    "",
+			"effective":    "",
+			"accelerator":  "",
+		})
+		return
+	}
+
+	h.mu.Lock()
+	pluginProxy := config.NormalizePluginProxyConfig(h.cfg.PluginProxy)
+	proxyURL := strings.TrimSpace(h.cfg.ProxyURL)
+	effective := config.EffectivePluginStoreProxyURL(h.cfg)
+	accelerator := config.EffectivePluginStoreAcceleratorBase(h.cfg)
+	h.mu.Unlock()
+
+	c.JSON(http.StatusOK, gin.H{
+		"plugin-proxy": pluginProxy,
+		"proxy-url":    proxyURL,
+		"effective":    effective,
+		"accelerator":  accelerator,
+	})
+}
+
+// PutPluginProxy updates plugin-proxy url/status/accelerator.
+// Status: -1=direct, 0=none/fallback, 1=custom proxy, 2=system, 3=accelerator.
+// Custom (status=1) requires a valid traditional proxy URL.
+// Accelerator (status=3) requires a valid https accelerator base in accelerator field.
+// Switching modes retains the last values of both fields independently.
+func (h *Handler) PutPluginProxy(c *gin.Context) {
+	if h == nil || h.cfg == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "config unavailable"})
+		return
+	}
+
+	var body struct {
+		Value       *config.PluginProxyConfig `json:"value"`
+		URL         *string                   `json:"url"`
+		Accelerator *string                   `json:"accelerator"`
+		Status      *int                      `json:"status"`
+	}
+	if errBind := c.ShouldBindJSON(&body); errBind != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	if body.Value == nil && body.URL == nil && body.Accelerator == nil && body.Status == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+
+	h.mu.Lock()
+	current := config.NormalizePluginProxyConfig(h.cfg.PluginProxy)
+	next := current
+
+	if body.Value != nil {
+		next.URL = body.Value.URL
+		next.Accelerator = body.Value.Accelerator
+		next.Status = body.Value.Status
+	}
+	if body.URL != nil {
+		next.URL = *body.URL
+	}
+	if body.Accelerator != nil {
+		next.Accelerator = *body.Accelerator
+	}
+	if body.Status != nil {
+		next.Status = *body.Status
+	}
+
+	normalized := config.NormalizePluginProxyConfig(next)
+
+	// Retain last values independently so mode switches do not lose input.
+	if strings.TrimSpace(normalized.URL) == "" {
+		normalized.URL = strings.TrimSpace(current.URL)
+	}
+	if strings.TrimSpace(normalized.Accelerator) == "" {
+		normalized.Accelerator = strings.TrimSpace(current.Accelerator)
+	}
+
+	switch normalized.Status {
+	case config.PluginProxyStatusCustom:
+		url := strings.TrimSpace(normalized.URL)
+		if url == "" {
+			h.mu.Unlock()
+			c.JSON(http.StatusBadRequest, gin.H{"error": "plugin-proxy url is required for custom status"})
+			return
+		}
+		setting, errParse := proxyutil.Parse(url)
+		if errParse != nil || setting.Mode != proxyutil.ModeProxy {
+			h.mu.Unlock()
+			message := "invalid plugin-proxy url"
+			if errParse != nil {
+				message = errParse.Error()
+			}
+			c.JSON(http.StatusBadRequest, gin.H{"error": message})
+			return
+		}
+		normalized.URL = url
+		normalized.Status = config.PluginProxyStatusCustom
+	case config.PluginProxyStatusAccelerator:
+		baseRaw := strings.TrimSpace(normalized.Accelerator)
+		if baseRaw == "" {
+			h.mu.Unlock()
+			c.JSON(http.StatusBadRequest, gin.H{"error": "plugin-proxy accelerator is required for accelerator status"})
+			return
+		}
+		base, errNormalize := pluginstore.NormalizeAcceleratorBase(baseRaw)
+		if errNormalize != nil {
+			h.mu.Unlock()
+			c.JSON(http.StatusBadRequest, gin.H{"error": errNormalize.Error()})
+			return
+		}
+		normalized.Accelerator = base
+		normalized.Status = config.PluginProxyStatusAccelerator
+	default:
+		// PluginProxyStatusNone (0) and PluginProxyStatusSystem (2) require no URL validation.
+		// Any future unknown status values are clamped to None by NormalizePluginProxyConfig.
+	}
+
+	h.cfg.PluginProxy = normalized
+	_ = h.persistLocked(c)
+	h.mu.Unlock()
+}
+
+// ValidatePluginProxyURL checks a candidate plugin-proxy URL without saving.
+// Optional status selects validation mode: 3=accelerator base, otherwise traditional proxy.
+func (h *Handler) ValidatePluginProxyURL(c *gin.Context) {
+	var body struct {
+		URL         *string `json:"url"`
+		Value       *string `json:"value"`
+		Accelerator *string `json:"accelerator"`
+		Status      *int    `json:"status"`
+	}
+	if errBind := c.ShouldBindJSON(&body); errBind != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body", "valid": false})
+		return
+	}
+
+	raw := ""
+	if body.Accelerator != nil {
+		raw = *body.Accelerator
+	} else if body.URL != nil {
+		raw = *body.URL
+	} else if body.Value != nil {
+		raw = *body.Value
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "plugin-proxy url is required", "valid": false})
+		return
+	}
+
+	status := config.PluginProxyStatusCustom
+	if body.Status != nil {
+		status = *body.Status
+	}
+
+	if status == config.PluginProxyStatusAccelerator {
+		base, errNormalize := pluginstore.NormalizeAcceleratorBase(raw)
+		if errNormalize != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": errNormalize.Error(), "valid": false})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"valid": true, "accelerator": base, "status": config.PluginProxyStatusAccelerator})
+		return
+	}
+
+	setting, errParse := proxyutil.Parse(raw)
+	if errParse != nil || setting.Mode != proxyutil.ModeProxy {
+		message := "invalid plugin-proxy url"
+		if errParse != nil {
+			message = errParse.Error()
+		}
+		c.JSON(http.StatusBadRequest, gin.H{"error": message, "valid": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"valid": true, "url": raw, "status": config.PluginProxyStatusCustom})
+}

--- a/internal/api/handlers/management/plugin_proxy_test.go
+++ b/internal/api/handlers/management/plugin_proxy_test.go
@@ -1,0 +1,158 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestGetPluginProxy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	configPath := writePluginProxyTestConfig(t, "proxy-url: http://system:1\nplugin-proxy:\n  url: socks5://custom:1080\n  status: 2\n")
+	cfg, errLoad := config.LoadConfig(configPath)
+	if errLoad != nil {
+		t.Fatalf("LoadConfig: %v", errLoad)
+	}
+
+	h := &Handler{cfg: cfg, configFilePath: configPath}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/plugin-proxy", nil)
+	h.GetPluginProxy(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", recorder.Code, recorder.Body.String())
+	}
+	var payload map[string]any
+	if errDecode := json.Unmarshal(recorder.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode: %v", errDecode)
+	}
+	if payload["effective"] != "http://system:1" {
+		t.Fatalf("effective = %#v", payload["effective"])
+	}
+	if payload["accelerator"] != "" {
+		t.Fatalf("accelerator = %#v", payload["accelerator"])
+	}
+}
+
+func TestPutPluginProxyCustomRetainsValueAcrossModeChanges(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	configPath := writePluginProxyTestConfig(t, "proxy-url: http://system:1\n")
+	cfg, errLoad := config.LoadConfig(configPath)
+	if errLoad != nil {
+		t.Fatalf("LoadConfig: %v", errLoad)
+	}
+	h := &Handler{cfg: cfg, configFilePath: configPath}
+
+	putPluginProxy(t, h, `{"value":{"status":1,"url":"socks5://user:pass@127.0.0.1:1080"}}`, http.StatusOK)
+	if got := config.EffectivePluginStoreProxyURL(h.cfg); got != "socks5://user:pass@127.0.0.1:1080" {
+		t.Fatalf("effective custom proxy = %q", got)
+	}
+
+	putPluginProxy(t, h, `{"status":0}`, http.StatusOK)
+	if h.cfg.PluginProxy.URL != "socks5://user:pass@127.0.0.1:1080" {
+		t.Fatalf("custom URL was not retained: %q", h.cfg.PluginProxy.URL)
+	}
+	if got := config.EffectivePluginStoreProxyURL(h.cfg); got != "http://system:1" {
+		t.Fatalf("effective none/fallback proxy = %q, expected global proxy-url", got)
+	}
+
+	putPluginProxy(t, h, `{"status":-1}`, http.StatusOK)
+	if got := config.EffectivePluginStoreProxyURL(h.cfg); got != "" {
+		t.Fatalf("effective direct proxy = %q, expected empty (direct)", got)
+	}
+
+	putPluginProxy(t, h, `{"status":2}`, http.StatusOK)
+	if got := config.EffectivePluginStoreProxyURL(h.cfg); got != "http://system:1" {
+		t.Fatalf("effective system proxy = %q", got)
+	}
+}
+
+func TestPutPluginProxyAccelerator(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	configPath := writePluginProxyTestConfig(t, "proxy-url: http://system:1\n")
+	cfg, errLoad := config.LoadConfig(configPath)
+	if errLoad != nil {
+		t.Fatalf("LoadConfig: %v", errLoad)
+	}
+	h := &Handler{cfg: cfg, configFilePath: configPath}
+
+	putPluginProxy(t, h, `{"value":{"status":3,"accelerator":"https://gh-proxy.com"}}`, http.StatusOK)
+	if got := config.EffectivePluginStoreProxyURL(h.cfg); got != "" {
+		t.Fatalf("accelerator mode proxy = %q", got)
+	}
+	if got := config.EffectivePluginStoreAcceleratorBase(h.cfg); got != "https://gh-proxy.com/" {
+		t.Fatalf("accelerator base = %q", got)
+	}
+}
+
+func TestNewPluginStoreClientBypassesEnvironmentProxy(t *testing.T) {
+	h := &Handler{}
+	for _, status := range []int{config.PluginProxyStatusDirect, config.PluginProxyStatusAccelerator} {
+		client := h.newPluginStoreClient("http://environment-proxy:8080", "", "", status, nil)
+		httpClient, okHTTPClient := client.HTTPClient.(*http.Client)
+		if !okHTTPClient {
+			t.Fatalf("status %d HTTPClient = %T, want *http.Client", status, client.HTTPClient)
+		}
+		transport, okTransport := httpClient.Transport.(*http.Transport)
+		if !okTransport {
+			t.Fatalf("status %d transport = %T, want *http.Transport", status, httpClient.Transport)
+		}
+		if transport.Proxy != nil {
+			t.Fatalf("status %d transport uses proxy; want direct transport", status)
+		}
+	}
+}
+
+func TestValidatePluginProxyURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &Handler{}
+
+	validatePluginProxy(t, h, `{"url":"ftp://invalid"}`, http.StatusBadRequest)
+	validatePluginProxy(t, h, `{"url":"https://proxy.example:8443"}`, http.StatusOK)
+	validatePluginProxy(t, h, `{"status":3,"accelerator":"socks5://invalid"}`, http.StatusBadRequest)
+	validatePluginProxy(t, h, `{"status":3,"accelerator":"https://gh-proxy.com"}`, http.StatusOK)
+}
+
+func writePluginProxyTestConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if errWrite := os.WriteFile(path, []byte(content), 0o600); errWrite != nil {
+		t.Fatalf("write config: %v", errWrite)
+	}
+	return path
+}
+
+func putPluginProxy(t *testing.T, h *Handler, body string, wantStatus int) {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/plugin-proxy", bytes.NewBufferString(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	h.PutPluginProxy(c)
+	if recorder.Code != wantStatus {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, wantStatus, recorder.Body.String())
+	}
+}
+
+func validatePluginProxy(t *testing.T, h *Handler, body string, wantStatus int) {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/plugin-proxy/validate", bytes.NewBufferString(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	h.ValidatePluginProxyURL(c)
+	if recorder.Code != wantStatus {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, wantStatus, recorder.Body.String())
+	}
+}

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -19,6 +19,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginstore"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
@@ -130,7 +131,7 @@ type sourcedPlugin struct {
 }
 
 func (h *Handler) ListPluginStore(c *gin.Context) {
-	pluginsEnabled, pluginsDir, proxyURL, sourceConfigs, storeAuth, configs, host := h.pluginStoreSnapshot()
+	pluginsEnabled, pluginsDir, proxyURL, acceleratorBase, pluginProxyStatus, sourceConfigs, storeAuth, configs, host := h.pluginStoreSnapshot()
 	resolvedPluginsDir, errResolvePluginsDir := config.ResolvePluginsDir(pluginsDir)
 	if errResolvePluginsDir != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "plugin_directory_invalid", "message": errResolvePluginsDir.Error()})
@@ -142,7 +143,7 @@ func (h *Handler) ListPluginStore(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "plugin_store_source_invalid", "message": errSources.Error()})
 		return
 	}
-	plugins, sourceErrors := h.fetchSourcedPlugins(c.Request.Context(), proxyURL, storeAuth, sources)
+	plugins, sourceErrors := h.fetchSourcedPlugins(c.Request.Context(), proxyURL, acceleratorBase, pluginProxyStatus, storeAuth, sources)
 	if len(plugins) == 0 && len(sourceErrors) > 0 {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "plugin_store_registry_failed", "message": sourceErrors[0].Message})
 		return
@@ -157,7 +158,7 @@ func (h *Handler) ListPluginStore(c *gin.Context) {
 	for _, item := range plugins {
 		latestInput = append(latestInput, item.plugin)
 	}
-	client := h.newPluginStoreClient(proxyURL, "", storeAuth)
+	client := h.newPluginStoreClient(proxyURL, acceleratorBase, "", pluginProxyStatus, storeAuth)
 	latestVersions := h.latestPluginVersions(c.Request.Context(), client, latestInput)
 	pluginSourceCounts := make(map[string]int, len(plugins))
 	for _, item := range plugins {
@@ -235,8 +236,11 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "message": errVersionRequest.Error()})
 		return
 	}
-	installCtx := c.Request.Context()
-	pluginsEnabled, pluginsDir, proxyURL, sourceConfigs, storeAuth, configs, host := h.pluginStoreSnapshot()
+	// Plugin downloads can take longer than the browser request lifetime.
+	// Detach from client cancellation without imposing a post-connection
+	// network deadline (per AGENTS.md timeout policy).
+	installCtx := context.WithoutCancel(c.Request.Context())
+	pluginsEnabled, pluginsDir, proxyURL, acceleratorBase, pluginProxyStatus, sourceConfigs, storeAuth, configs, host := h.pluginStoreSnapshot()
 	resolvedPluginsDir, errResolvePluginsDir := config.ResolvePluginsDir(pluginsDir)
 	if errResolvePluginsDir != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "plugin_directory_invalid", "message": errResolvePluginsDir.Error()})
@@ -248,7 +252,7 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "plugin_store_source_invalid", "message": errSources.Error()})
 		return
 	}
-	source, plugin, client, okPlugin := h.findPluginStoreInstallTarget(installCtx, proxyURL, storeAuth, sources, id, c.Query("source"), c)
+	source, plugin, client, okPlugin := h.findPluginStoreInstallTarget(installCtx, proxyURL, acceleratorBase, pluginProxyStatus, storeAuth, sources, id, c.Query("source"), c)
 	if !okPlugin {
 		return
 	}
@@ -495,25 +499,27 @@ func pluginStoreManifestYAMLNode(manifest pluginstore.Manifest) (*yaml.Node, err
 	return &node, nil
 }
 
-func (h *Handler) pluginStoreSnapshot() (bool, string, string, []string, []pluginstore.AuthConfig, map[string]config.PluginInstanceConfig, *pluginhost.Host) {
+func (h *Handler) pluginStoreSnapshot() (bool, string, string, string, int, []string, []pluginstore.AuthConfig, map[string]config.PluginInstanceConfig, *pluginhost.Host) {
 	if h == nil {
-		return false, "plugins", "", nil, nil, map[string]config.PluginInstanceConfig{}, nil
+		return false, "plugins", "", "", config.PluginProxyStatusNone, nil, nil, map[string]config.PluginInstanceConfig{}, nil
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.cfg == nil {
-		return false, "plugins", "", nil, nil, map[string]config.PluginInstanceConfig{}, nil
+		return false, "plugins", "", "", config.PluginProxyStatusNone, nil, nil, map[string]config.PluginInstanceConfig{}, nil
 	}
 	pluginsEnabled := h.cfg.Plugins.Enabled
 	pluginsDir := normalizedPluginsDir(h.cfg.Plugins.Dir)
-	proxyURL := strings.TrimSpace(h.cfg.ProxyURL)
+	proxyURL := config.EffectivePluginStoreProxyURL(h.cfg)
+	acceleratorBase := config.EffectivePluginStoreAcceleratorBase(h.cfg)
+	pluginProxyStatus := config.NormalizePluginProxyConfig(h.cfg.PluginProxy).Status
 	sourceConfigs := append([]string(nil), h.cfg.Plugins.StoreSources...)
 	storeAuth := append([]pluginstore.AuthConfig(nil), h.cfg.Plugins.StoreAuth...)
 	configs := make(map[string]config.PluginInstanceConfig, len(h.cfg.Plugins.Configs))
 	for id, item := range h.cfg.Plugins.Configs {
 		configs[id] = item
 	}
-	return pluginsEnabled, pluginsDir, proxyURL, sourceConfigs, storeAuth, configs, h.pluginHost
+	return pluginsEnabled, pluginsDir, proxyURL, acceleratorBase, pluginProxyStatus, sourceConfigs, storeAuth, configs, h.pluginHost
 }
 
 func (h *Handler) pluginStoreSources(sourceConfigs []string) ([]pluginstore.Source, error) {
@@ -525,8 +531,9 @@ func (h *Handler) pluginStoreSources(sourceConfigs []string) ([]pluginstore.Sour
 	return pluginstore.NormalizeSources(sourceConfigs)
 }
 
-func (h *Handler) newPluginStoreClient(proxyURL string, registryURL string, storeAuth []pluginstore.AuthConfig) pluginstore.Client {
+func (h *Handler) newPluginStoreClient(proxyURL string, acceleratorBase string, registryURL string, pluginProxyStatus int, storeAuth []pluginstore.AuthConfig) pluginstore.Client {
 	registryURL = strings.TrimSpace(registryURL)
+	acceleratorBase = strings.TrimSpace(acceleratorBase)
 	var httpClient pluginstore.HTTPDoer
 	if h != nil {
 		httpClient = h.pluginStoreHTTPClient
@@ -535,20 +542,33 @@ func (h *Handler) newPluginStoreClient(proxyURL string, registryURL string, stor
 		registryURL = pluginstore.DefaultRegistryURL
 	}
 	if httpClient != nil {
-		return pluginstore.Client{HTTPClient: httpClient, RegistryURL: registryURL, Auth: storeAuth}
+		return pluginstore.Client{HTTPClient: httpClient, RegistryURL: registryURL, AcceleratorBase: acceleratorBase, Auth: storeAuth}
 	}
-	client := &http.Client{}
-	if strings.TrimSpace(proxyURL) != "" {
+	client := &http.Client{
+		// Plugin downloads are bounded by the install context.
+		Timeout: 0,
+	}
+	if pluginProxyStatus == config.PluginProxyStatusDirect || pluginProxyStatus == config.PluginProxyStatusAccelerator {
+		// Direct mode and accelerator mode must not use any traditional
+		// proxy. Install a direct transport that clones http.DefaultTransport
+		// (so idle-conn timeout, TLS handshake timeout, HTTP/2 upgrade, etc.
+		// are preserved) with the proxy function cleared, so inherited
+		// HTTP_PROXY/HTTPS_PROXY environment variables are bypassed. A bare
+		// &http.Transport{Proxy: nil} would drop the default connection
+		// management settings. Accelerator only rewrites artifact URLs;
+		// registry/API calls still go direct.
+		client.Transport = proxyutil.NewDirectTransport()
+	} else if strings.TrimSpace(proxyURL) != "" {
 		util.SetProxy(&sdkconfig.SDKConfig{ProxyURL: strings.TrimSpace(proxyURL)}, client)
 	}
-	return pluginstore.Client{HTTPClient: client, RegistryURL: registryURL, Auth: storeAuth}
+	return pluginstore.Client{HTTPClient: client, RegistryURL: registryURL, AcceleratorBase: acceleratorBase, Auth: storeAuth}
 }
 
-func (h *Handler) fetchSourcedPlugins(ctx context.Context, proxyURL string, storeAuth []pluginstore.AuthConfig, sources []pluginstore.Source) ([]sourcedPlugin, []pluginStoreSourceErr) {
+func (h *Handler) fetchSourcedPlugins(ctx context.Context, proxyURL string, acceleratorBase string, pluginProxyStatus int, storeAuth []pluginstore.AuthConfig, sources []pluginstore.Source) ([]sourcedPlugin, []pluginStoreSourceErr) {
 	plugins := make([]sourcedPlugin, 0)
 	sourceErrors := make([]pluginStoreSourceErr, 0)
 	for _, source := range sources {
-		client := h.newPluginStoreClient(proxyURL, source.URL, storeAuth)
+		client := h.newPluginStoreClient(proxyURL, acceleratorBase, source.URL, pluginProxyStatus, storeAuth)
 		registry, errRegistry := client.FetchRegistry(ctx)
 		if errRegistry != nil {
 			sourceErrors = append(sourceErrors, pluginStoreSourceErr{
@@ -566,14 +586,14 @@ func (h *Handler) fetchSourcedPlugins(ctx context.Context, proxyURL string, stor
 	return plugins, sourceErrors
 }
 
-func (h *Handler) findPluginStoreInstallTarget(ctx context.Context, proxyURL string, storeAuth []pluginstore.AuthConfig, sources []pluginstore.Source, id string, requestedSourceID string, c *gin.Context) (pluginstore.Source, pluginstore.Plugin, pluginstore.Client, bool) {
+func (h *Handler) findPluginStoreInstallTarget(ctx context.Context, proxyURL string, acceleratorBase string, pluginProxyStatus int, storeAuth []pluginstore.AuthConfig, sources []pluginstore.Source, id string, requestedSourceID string, c *gin.Context) (pluginstore.Source, pluginstore.Plugin, pluginstore.Client, bool) {
 	requestedSourceID = strings.TrimSpace(requestedSourceID)
 	if requestedSourceID != "" {
 		for _, source := range sources {
 			if source.ID != requestedSourceID {
 				continue
 			}
-			client := h.newPluginStoreClient(proxyURL, source.URL, storeAuth)
+			client := h.newPluginStoreClient(proxyURL, acceleratorBase, source.URL, pluginProxyStatus, storeAuth)
 			registry, errRegistry := client.FetchRegistry(ctx)
 			if errRegistry != nil {
 				c.JSON(http.StatusBadGateway, gin.H{"error": "plugin_store_registry_failed", "message": errRegistry.Error()})
@@ -590,7 +610,7 @@ func (h *Handler) findPluginStoreInstallTarget(ctx context.Context, proxyURL str
 		return pluginstore.Source{}, pluginstore.Plugin{}, pluginstore.Client{}, false
 	}
 
-	plugins, sourceErrors := h.fetchSourcedPlugins(ctx, proxyURL, storeAuth, sources)
+	plugins, sourceErrors := h.fetchSourcedPlugins(ctx, proxyURL, acceleratorBase, pluginProxyStatus, storeAuth, sources)
 	matches := make([]sourcedPlugin, 0)
 	for _, item := range plugins {
 		if item.plugin.ID == id {
@@ -614,7 +634,7 @@ func (h *Handler) findPluginStoreInstallTarget(ctx context.Context, proxyURL str
 		return pluginstore.Source{}, pluginstore.Plugin{}, pluginstore.Client{}, false
 	}
 	match := matches[0]
-	return match.source, match.plugin, h.newPluginStoreClient(proxyURL, match.source.URL, storeAuth), true
+	return match.source, match.plugin, h.newPluginStoreClient(proxyURL, acceleratorBase, match.source.URL, pluginProxyStatus, storeAuth), true
 }
 
 func sourcedPluginSources(plugins []sourcedPlugin) []pluginstore.Source {

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -65,6 +65,11 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PATCH("/proxy-url", s.mgmt.PutProxyURL)
 		mgmt.DELETE("/proxy-url", s.mgmt.DeleteProxyURL)
 
+		mgmt.GET("/plugin-proxy", s.mgmt.GetPluginProxy)
+		mgmt.PUT("/plugin-proxy", s.mgmt.PutPluginProxy)
+		mgmt.PATCH("/plugin-proxy", s.mgmt.PutPluginProxy)
+		mgmt.POST("/plugin-proxy/validate", s.mgmt.ValidatePluginProxyURL)
+
 		mgmt.POST("/api-call", s.mgmt.APICall)
 
 		mgmt.GET("/quota-exceeded/switch-project", s.mgmt.GetSwitchProject)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,9 @@ type Config struct {
 	// Plugins configures dynamic plugin discovery and per-plugin settings.
 	Plugins PluginsConfig `yaml:"plugins" json:"plugins"`
 
+	// PluginProxy configures proxy or accelerator for plugin store operations.
+	PluginProxy PluginProxyConfig `yaml:"plugin-proxy" json:"plugin-proxy"`
+
 	// AuthDir is the directory where authentication token files are stored.
 	AuthDir string `yaml:"auth-dir" json:"-"`
 

--- a/internal/config/config_normalization.go
+++ b/internal/config/config_normalization.go
@@ -30,6 +30,7 @@ func (cfg *Config) NormalizePluginsConfig() {
 	if cfg.Plugins.Configs == nil {
 		cfg.Plugins.Configs = map[string]PluginInstanceConfig{}
 	}
+	cfg.NormalizePluginProxy()
 }
 
 // SanitizeCodexHeaderDefaults trims surrounding whitespace from the
@@ -294,4 +295,84 @@ func NormalizeOAuthExcludedModels(entries map[string][]string) map[string][]stri
 		return nil
 	}
 	return out
+}
+
+// NormalizePluginProxy normalizes plugin-proxy url/status.
+func (cfg *Config) NormalizePluginProxy() {
+	if cfg == nil {
+		return
+	}
+	cfg.PluginProxy = NormalizePluginProxyConfig(cfg.PluginProxy)
+}
+
+// NormalizePluginProxyConfig returns a normalized plugin-proxy setting.
+// Known status values: -1 (direct), 0 (none/fallback), 1 (custom), 2 (system), 3 (accelerator).
+// Unknown values are clamped to 0 (none).
+func NormalizePluginProxyConfig(raw PluginProxyConfig) PluginProxyConfig {
+	out := PluginProxyConfig{
+		URL:         strings.TrimSpace(raw.URL),
+		Accelerator: strings.TrimSpace(raw.Accelerator),
+	}
+	switch raw.Status {
+	case PluginProxyStatusDirect:
+		out.Status = PluginProxyStatusDirect
+	case PluginProxyStatusCustom:
+		out.Status = PluginProxyStatusCustom
+	case PluginProxyStatusSystem:
+		out.Status = PluginProxyStatusSystem
+	case PluginProxyStatusAccelerator:
+		out.Status = PluginProxyStatusAccelerator
+	default:
+		out.Status = PluginProxyStatusNone
+	}
+	return out
+}
+
+// EffectivePluginStoreProxyURL returns the outbound proxy URL used by plugin-store
+// list/install clients. Empty means direct connection (no traditional proxy).
+//
+// Status semantics:
+//   - -1 (direct): always return empty (direct connection, bypass global proxy)
+//   - 0  (none):  fall back to the global proxy-url when present (legacy behavior)
+//   - 1  (custom): return PluginProxy.URL
+//   - 2  (system): return the global proxy-url
+//   - 3  (accelerator): return empty (accelerator rewrites URLs, does not proxy)
+func EffectivePluginStoreProxyURL(cfg *Config) string {
+	if cfg == nil {
+		return ""
+	}
+	pluginProxy := NormalizePluginProxyConfig(cfg.PluginProxy)
+	switch pluginProxy.Status {
+	case PluginProxyStatusSystem:
+		return strings.TrimSpace(cfg.ProxyURL)
+	case PluginProxyStatusCustom:
+		return strings.TrimSpace(pluginProxy.URL)
+	case PluginProxyStatusNone:
+		// Fall back to the global proxy-url so legacy configs that never set
+		// plugin-proxy continue to work through the system proxy.
+		return strings.TrimSpace(cfg.ProxyURL)
+	default:
+		// direct / accelerator: do not apply a traditional proxy.
+		return ""
+	}
+}
+
+// EffectivePluginStoreAcceleratorBase returns the web accelerator base used by
+// plugin-store list/install clients. Empty means no URL rewriting.
+// The base is expected to be an absolute https URL; callers rewrite GitHub
+// resource URLs as base + original absolute URL.
+func EffectivePluginStoreAcceleratorBase(cfg *Config) string {
+	if cfg == nil {
+		return ""
+	}
+	pluginProxy := NormalizePluginProxyConfig(cfg.PluginProxy)
+	if pluginProxy.Status != PluginProxyStatusAccelerator {
+		return ""
+	}
+	return strings.TrimSpace(pluginProxy.Accelerator)
+}
+
+// EffectivePluginProxyURL preserves the existing method-based API for compatibility.
+func (cfg *Config) EffectivePluginProxyURL() string {
+	return EffectivePluginStoreProxyURL(cfg)
 }

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -629,3 +629,43 @@ func (m OpenAICompatibilityModel) GetDisplayName() string { return m.DisplayName
 func (m OpenAICompatibilityModel) GetForceMapping() bool { return m.ForceMapping }
 
 func (m OpenAICompatibilityModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }
+
+// PluginProxyConfig is the dedicated outbound proxy/accelerator for plugin-store traffic.
+// It is independent from the global proxy-url used by OAuth/providers/API calls.
+//
+// Status:
+//   - -1 (direct): no proxy, connect directly even when a global proxy-url is set
+//   - 0 (none): unset/default; fall back to the global proxy-url when present (legacy behavior)
+//   - 1 (custom): use PluginProxy.URL as socks/http/https proxy
+//   - 2 (system): reuse config.yaml proxy-url
+//   - 3 (accelerator): rewrite GitHub resource URLs as prefix + original URL
+//
+// URL keeps the last user-provided custom/accelerator value so re-enabling
+// either mode does not lose input.
+type PluginProxyConfig struct {
+	// URL is the last custom proxy URL (traditional proxy only).
+	// Accelerator uses a separate field.
+	URL string `yaml:"url,omitempty" json:"url"`
+	// Accelerator is the web accelerator base used when status=3.
+	// Example: https://gh-proxy.com
+	Accelerator string `yaml:"accelerator,omitempty" json:"accelerator"`
+	// Status is -1=direct, 0=none, 1=custom, 2=system, 3=accelerator.
+	// Omit empty is removed to ensure status is explicitly serialized.
+	Status int `yaml:"status" json:"status"`
+}
+
+// Plugin-proxy status values (selection is encoded by status only).
+const (
+	// PluginProxyStatusDirect means connect directly, bypassing the global proxy-url.
+	PluginProxyStatusDirect = -1
+	// PluginProxyStatusNone means unset/default: fall back to the global proxy-url
+	// when present, otherwise connect directly. Preserves legacy behavior for
+	// configs that never set plugin-proxy.
+	PluginProxyStatusNone = 0
+	// PluginProxyStatusCustom means use PluginProxy.URL as a traditional outbound proxy.
+	PluginProxyStatusCustom = 1
+	// PluginProxyStatusSystem means reuse the global proxy-url.
+	PluginProxyStatusSystem = 2
+	// PluginProxyStatusAccelerator means rewrite GitHub resource URLs with PluginProxy.URL as a web accelerator prefix.
+	PluginProxyStatusAccelerator = 3
+)

--- a/internal/pluginstore/accelerator.go
+++ b/internal/pluginstore/accelerator.go
@@ -1,0 +1,175 @@
+package pluginstore
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// githubAcceleratorHosts are absolute http/https hosts whose resources can be
+// fetched through a web accelerator prefix (for example https://gh-proxy.com/).
+// This covers GitHub releases, raw content, archive downloads, and Gist raw
+// files. GitHub REST API (api.github.com) is excluded to avoid shared-IP rate
+// limits that break release metadata lookups during install.
+var githubAcceleratorHosts = map[string]struct{}{
+	"github.com":                                {},
+	"www.github.com":                            {},
+	"raw.githubusercontent.com":                 {},
+	"gist.github.com":                           {},
+	"gist.githubusercontent.com":                {},
+	"codeload.github.com":                       {},
+	"objects.githubusercontent.com":             {},
+	"media.githubusercontent.com":               {},
+	"cloud.githubusercontent.com":               {},
+	"camo.githubusercontent.com":                {},
+	"user-images.githubusercontent.com":         {},
+	"private-user-images.githubusercontent.com": {},
+	"release-assets.githubusercontent.com":      {},
+	"github-releases.githubusercontent.com":     {},
+	"github-cloud.githubusercontent.com":        {},
+	"github.githubassets.com":                   {},
+}
+
+// NormalizeAcceleratorBase validates and normalizes a web accelerator base URL.
+// The result always ends with a single trailing slash so callers can safely
+// concatenate the original absolute resource URL. Only https bases are allowed;
+// http accelerators would rewrite artifact URLs to plaintext requests that
+// validatePluginStoreRequestURL rejects unless an allow-insecure auth rule is
+// also present, so rejecting early gives a clear error message.
+func NormalizeAcceleratorBase(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("accelerator url is required")
+	}
+	parsed, errParse := url.Parse(raw)
+	if errParse != nil {
+		return "", fmt.Errorf("invalid accelerator url: %w", errParse)
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "https" {
+		return "", fmt.Errorf("invalid accelerator url: scheme must be https")
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("invalid accelerator url: credentials are not allowed")
+	}
+	if strings.TrimSpace(parsed.Host) == "" {
+		return "", fmt.Errorf("invalid accelerator url: host is required")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("invalid accelerator url: query and fragment are not allowed")
+	}
+	// Reject accidental path that already embeds a full URL; the accelerator
+	// base should be a pure prefix endpoint.
+	path := parsed.EscapedPath()
+	if strings.Contains(path, "://") {
+		return "", fmt.Errorf("invalid accelerator url: path must not embed a full URL")
+	}
+	parsed.Scheme = scheme
+	parsed.Host = strings.ToLower(parsed.Host)
+	if path == "" || path == "/" {
+		parsed.Path = "/"
+		parsed.RawPath = ""
+	} else if !strings.HasSuffix(path, "/") {
+		// Append the trailing slash directly to Path and clear RawPath so
+		// url.String() correctly re-encodes the result. Touching only RawPath
+		// (or leaving it out-of-sync with Path) would cause url.String() to
+		// drop RawPath when it is not a valid encoding of Path, producing a
+		// base without the trailing slash — which then concatenates to the
+		// original absolute URL without a path separator.
+		parsed.Path += "/"
+		parsed.RawPath = ""
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+// IsGitHubAcceleratorURL reports whether requestURL points at a GitHub-hosted
+// resource that can be rewritten through a web accelerator.
+// Only https URLs are eligible: rewriting an http GitHub artifact through an
+// https accelerator would mask the original scheme and bypass the
+// allow-insecure guard in validatePluginStoreRequestURL. api.github.com is
+// intentionally excluded because public accelerators share egress IPs and
+// commonly hit GitHub REST API secondary rate limits (403), which breaks
+// release metadata lookups used by plugin install.
+func IsGitHubAcceleratorURL(requestURL string) bool {
+	requestURL = strings.TrimSpace(requestURL)
+	if requestURL == "" {
+		return false
+	}
+	parsed, errParse := url.Parse(requestURL)
+	if errParse != nil {
+		return false
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "https" {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return false
+	}
+	if host == "api.github.com" {
+		return false
+	}
+	if _, ok := githubAcceleratorHosts[host]; ok {
+		return true
+	}
+	// Catch additional githubusercontent / githubassets subdomains.
+	// Do not match bare api.github.com (handled above) or arbitrary *.github.com
+	// API-like hosts; only www/github.com content hosts are listed explicitly.
+	if strings.HasSuffix(host, ".githubusercontent.com") ||
+		strings.HasSuffix(host, ".githubassets.com") {
+		return true
+	}
+	return false
+}
+
+// ApplyAcceleratorBase rewrites GitHub resource URLs by prefixing acceleratorBase.
+// Non-GitHub URLs and already-rewritten URLs are returned unchanged.
+func ApplyAcceleratorBase(acceleratorBase, requestURL string) (string, error) {
+	base, errBase := NormalizeAcceleratorBase(acceleratorBase)
+	if errBase != nil {
+		return "", errBase
+	}
+	requestURL = strings.TrimSpace(requestURL)
+	if requestURL == "" {
+		return "", fmt.Errorf("request url is required")
+	}
+	if strings.HasPrefix(requestURL, base) {
+		return requestURL, nil
+	}
+	if !IsGitHubAcceleratorURL(requestURL) {
+		return requestURL, nil
+	}
+	parsed, errParse := url.Parse(requestURL)
+	if errParse != nil {
+		return "", fmt.Errorf("invalid request url: %w", errParse)
+	}
+	if parsed.User != nil {
+		// Keep auth validation elsewhere; do not send credential-bearing URLs
+		// through a public web accelerator.
+		return requestURL, nil
+	}
+	// gh-proxy style services expect the full original absolute URL after the base.
+	return base + requestURL, nil
+}
+
+// AcceleratorHostFromBase returns the host of a normalized accelerator base.
+// Used by tests and diagnostics.
+func AcceleratorHostFromBase(acceleratorBase string) (string, error) {
+	base, errBase := NormalizeAcceleratorBase(acceleratorBase)
+	if errBase != nil {
+		return "", errBase
+	}
+	parsed, errParse := url.Parse(base)
+	if errParse != nil {
+		return "", errParse
+	}
+	host, _, errSplit := net.SplitHostPort(parsed.Host)
+	if errSplit != nil {
+		host = parsed.Host
+	}
+	return strings.ToLower(host), nil
+}

--- a/internal/pluginstore/accelerator_test.go
+++ b/internal/pluginstore/accelerator_test.go
@@ -1,0 +1,67 @@
+package pluginstore
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeAcceleratorBase(t *testing.T) {
+	t.Parallel()
+
+	base, err := NormalizeAcceleratorBase("https://gh-proxy.com")
+	if err != nil {
+		t.Fatalf("NormalizeAcceleratorBase() error = %v", err)
+	}
+	if base != "https://gh-proxy.com/" {
+		t.Fatalf("NormalizeAcceleratorBase() = %q", base)
+	}
+}
+
+func TestNormalizeAcceleratorBaseRejectsHTTP(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NormalizeAcceleratorBase("http://gh-proxy.com"); err == nil {
+		t.Fatal("NormalizeAcceleratorBase() error = nil, want rejection for http accelerator")
+	}
+}
+
+func TestApplyAcceleratorBasePreservesTokenQuery(t *testing.T) {
+	t.Parallel()
+
+	rewritten, err := ApplyAcceleratorBase(
+		"https://gh-proxy.com",
+		"https://objects.githubusercontent.com/github-production-release-asset/file.zip?token=temp-github-token",
+	)
+	if err != nil {
+		t.Fatalf("ApplyAcceleratorBase() error = %v", err)
+	}
+	want := "https://gh-proxy.com/https://objects.githubusercontent.com/github-production-release-asset/file.zip?token=temp-github-token"
+	if rewritten != want {
+		t.Fatalf("ApplyAcceleratorBase() = %q, want %q", rewritten, want)
+	}
+	if !strings.Contains(rewritten, "token=temp-github-token") {
+		t.Fatalf("rewritten URL lost token query: %q", rewritten)
+	}
+}
+
+func TestApplyAcceleratorBaseSkipsGitHubAPI(t *testing.T) {
+	t.Parallel()
+
+	apiURL := "https://api.github.com/repos/owner/repo/releases/latest"
+	rewritten, err := ApplyAcceleratorBase("https://gh-proxy.com", apiURL)
+	if err != nil {
+		t.Fatalf("ApplyAcceleratorBase() error = %v", err)
+	}
+	if rewritten != apiURL {
+		t.Fatalf("ApplyAcceleratorBase() = %q, want original API URL", rewritten)
+	}
+	if !IsGitHubAcceleratorURL("https://github.com/owner/repo/releases/download/v1/x.zip") {
+		t.Fatal("expected github.com release URL to be accelerator-eligible")
+	}
+	if IsGitHubAcceleratorURL(apiURL) {
+		t.Fatal("api.github.com must not be accelerator-eligible")
+	}
+	if IsGitHubAcceleratorURL("http://github.com/owner/repo/releases/download/v1/x.zip") {
+		t.Fatal("http github.com URL must not be accelerator-eligible (would bypass allow-insecure)")
+	}
+}

--- a/internal/pluginstore/auth.go
+++ b/internal/pluginstore/auth.go
@@ -315,8 +315,16 @@ func validatePluginStoreRequestURL(auth []AuthConfig, requestURL string, kind st
 	if parsed.User != nil {
 		return fmt.Errorf("plugin store url must not contain credentials")
 	}
-	if hasSensitiveQueryParameter(parsed) {
-		return fmt.Errorf("plugin store url contains sensitive query parameter")
+	// Artifact downloads may carry ephemeral signed query parameters such as
+	// GitHub release CDN ?token=... values, so sensitive query keys are only
+	// checked for non-artifact (registry/metadata) requests. Declared URLs are
+	// also independently validated via hasSensitiveQueryParameter at parse time,
+	// but applying the check here again covers runtime redirect targets so
+	// long-lived secrets never reach the wire for registry/metadata requests.
+	if kind != RequestKindArtifact {
+		if hasSensitiveQueryParameter(parsed) {
+			return fmt.Errorf("plugin store url contains sensitive query parameter")
+		}
 	}
 	if strings.EqualFold(parsed.Scheme, "http") && !allowInsecurePluginStoreURL(auth, requestURL, kind) {
 		return fmt.Errorf("insecure plugin store url requires matching allow-insecure auth rule")

--- a/internal/pluginstore/auth_test.go
+++ b/internal/pluginstore/auth_test.go
@@ -378,6 +378,23 @@ func TestPluginStoreRequestURLRejectsCredentials(t *testing.T) {
 	}
 }
 
+func TestPluginStoreRequestURLRejectsSensitiveRegistryQuery(t *testing.T) {
+	errValidate := validatePluginStoreRequestURL(nil, "https://registry.example/store.json?token=long-lived-secret", RequestKindRegistry)
+	if errValidate == nil {
+		t.Fatal("validatePluginStoreRequestURL() error = nil, want sensitive registry query rejection")
+	}
+	if strings.Contains(errValidate.Error(), "long-lived-secret") {
+		t.Fatalf("validatePluginStoreRequestURL() error leaked query value: %v", errValidate)
+	}
+}
+
+func TestPluginStoreRequestURLAllowsSignedArtifactQuery(t *testing.T) {
+	errValidate := validatePluginStoreRequestURL(nil, "https://objects.githubusercontent.com/release.zip?token=temporary", RequestKindArtifact)
+	if errValidate != nil {
+		t.Fatalf("validatePluginStoreRequestURL() error = %v, want signed artifact query allowed", errValidate)
+	}
+}
+
 func TestResolvedAuthExpiryRejectsAuthenticatedRequest(t *testing.T) {
 	auth := []ResolvedAuthConfig{{
 		Match:   "https://downloads.example/private/",

--- a/internal/pluginstore/github.go
+++ b/internal/pluginstore/github.go
@@ -17,14 +17,18 @@ import (
 
 const userAgent = "CLIProxyAPI"
 const maxPluginStoreRedirects = 10
+const maxPluginStoreArtifactAttempts = 3
 
 // HTTPDoer abstracts the HTTP client used to execute requests.
 type HTTPDoer = httpfetch.Doer
 
 type Client struct {
-	HTTPClient            HTTPDoer
-	RegistryURL           string
-	UserAgent             string
+	HTTPClient  HTTPDoer
+	RegistryURL string
+	UserAgent   string
+	// AcceleratorBase, when set, rewrites GitHub resource URLs as base + original URL
+	// (web download accelerator). It is independent from HTTPClient proxy transport.
+	AcceleratorBase       string
 	Auth                  []AuthConfig
 	ResolvedAuth          []ResolvedAuthConfig
 	ResolvedAuthExpiresAt time.Time
@@ -143,8 +147,42 @@ func (c Client) releaseAssetAPIAuthenticated(apiURL string) bool {
 }
 
 func (c Client) get(ctx context.Context, requestURL string, accept string, kind string, maxSize int64) ([]byte, error) {
+	attempts := 1
+	if kind == RequestKindArtifact {
+		attempts = maxPluginStoreArtifactAttempts
+	}
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		data, errGet := c.getOnce(ctx, requestURL, accept, kind, maxSize)
+		if errGet == nil {
+			return data, nil
+		}
+		lastErr = errGet
+		if ctx.Err() != nil || attempt == attempts || !retryablePluginStoreArtifactError(errGet) {
+			return nil, errGet
+		}
+		log.WithError(errGet).WithFields(log.Fields{
+			"kind":    kind,
+			"attempt": attempt,
+		}).Warn("plugin store artifact download interrupted, retrying")
+	}
+	return nil, lastErr
+}
+
+func (c Client) getOnce(ctx context.Context, requestURL string, accept string, kind string, maxSize int64) ([]byte, error) {
 	currentURL := strings.TrimSpace(requestURL)
 	for redirects := 0; ; redirects++ {
+		// Accelerators are for downloadable GitHub artifact resources
+		// (releases/raw/CDN). Never rewrite registry, metadata, or API
+		// requests: public accelerators share egress IPs and frequently
+		// return GitHub 403 secondary rate limits for non-CDN endpoints.
+		if base := strings.TrimSpace(c.AcceleratorBase); base != "" && kind == RequestKindArtifact {
+			rewritten, errRewrite := ApplyAcceleratorBase(base, currentURL)
+			if errRewrite != nil {
+				return nil, errRewrite
+			}
+			currentURL = rewritten
+		}
 		if errURL := validatePluginStoreRequestURL(c.Auth, currentURL, kind); errURL != nil {
 			return nil, errURL
 		}
@@ -159,6 +197,17 @@ func (c Client) get(ctx context.Context, requestURL string, accept string, kind 
 		if errAuth != nil {
 			return nil, errAuth
 		}
+		host := ""
+		if parsedURL, errParse := url.Parse(currentURL); errParse == nil {
+			host = parsedURL.Host
+		}
+		log.WithFields(log.Fields{
+			"kind":          kind,
+			"host":          host,
+			"accelerated":   strings.TrimSpace(c.AcceleratorBase) != "" && strings.HasPrefix(currentURL, strings.TrimSpace(c.AcceleratorBase)),
+			"authenticated": authenticated,
+			"redirect":      redirects,
+		}).Debug("plugin store request")
 		resp, errDo := pluginStoreGetNoRedirect(ctx, c.httpClient(), currentURL, headers)
 		if authenticated {
 			for name := range headers {
@@ -187,6 +236,25 @@ func (c Client) get(ctx context.Context, requestURL string, accept string, kind 
 		}
 		return readPluginStoreResponse(resp, maxSize, authenticated)
 	}
+}
+
+func retryablePluginStoreArtifactError(err error) bool {
+	// Only DeadlineExceeded is immediately fatal; context.Canceled from
+	// mid-read interruptions should still be retried because get() already
+	// checks ctx.Err() before entering the retry loop — if the outer context
+	// were actually canceled, get() would have returned before calling us.
+	if err == nil || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	// Match the underlying cause rather than the wrapped prefix: real network
+	// errors surface as "read response: read tcp 10.0.0.1:1->10.0.0.2:443: read:
+	// connection reset by peer", which does not contain the literal
+	// "read response: connection reset" substring. Match the cause tokens so
+	// transient interrupted reads are retried regardless of the wrapping.
+	return strings.Contains(message, "unexpected eof") ||
+		strings.Contains(message, "connection reset") ||
+		strings.Contains(message, "context canceled")
 }
 
 func (c Client) httpClient() HTTPDoer {

--- a/internal/pluginstore/install_test.go
+++ b/internal/pluginstore/install_test.go
@@ -5,10 +5,13 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -355,6 +358,142 @@ func TestInstallUsesLatestReleaseVersion(t *testing.T) {
 	}
 }
 
+func TestDownloadAssetFollowsGitHubRedirectWithTokenQuery(t *testing.T) {
+	artifact := []byte("artifact-data")
+	cdn := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("token") == "" {
+			t.Fatalf("expected token query on CDN request, got %s", r.URL.String())
+		}
+		_, _ = w.Write(artifact)
+	}))
+	t.Cleanup(cdn.Close)
+
+	origin := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, cdn.URL+"/github-production-release-asset/file.zip?token=temp-github-token&filename=file.zip", http.StatusFound)
+	}))
+	t.Cleanup(origin.Close)
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	httpClient := origin.Client()
+	httpClient.Transport = transport
+
+	client := Client{HTTPClient: httpClient}
+	data, errDownload := client.DownloadAsset(context.Background(), ReleaseAsset{
+		Name:               "sample-provider_0.2.0_darwin_arm64.zip",
+		BrowserDownloadURL: origin.URL + "/releases/download/v0.2.0/sample-provider_0.2.0_darwin_arm64.zip",
+	})
+	if errDownload != nil {
+		t.Fatalf("DownloadAsset() error = %v", errDownload)
+	}
+	if string(data) != string(artifact) {
+		t.Fatalf("DownloadAsset() = %q, want artifact-data", data)
+	}
+}
+
+type recordingHTTPDoer struct {
+	requests []string
+	handler  func(req *http.Request, n int) (*http.Response, error)
+}
+
+func (d *recordingHTTPDoer) Do(req *http.Request) (*http.Response, error) {
+	n := len(d.requests)
+	d.requests = append(d.requests, req.URL.String())
+	return d.handler(req, n)
+}
+
+func TestDownloadAssetAcceleratorFollowsRedirectWithTokenQuery(t *testing.T) {
+	artifact := []byte("artifact-data")
+	accelBase := "https://gh-proxy.example/"
+	doer := &recordingHTTPDoer{
+		handler: func(req *http.Request, n int) (*http.Response, error) {
+			switch n {
+			case 0:
+				wantPrefix := accelBase + "https://github.com/"
+				if !strings.HasPrefix(req.URL.String(), wantPrefix) {
+					return nil, fmt.Errorf("unexpected first URL %s", req.URL.String())
+				}
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header: http.Header{
+						"Location": []string{"https://objects.githubusercontent.com/github-production-release-asset/file.zip?token=temp-github-token"},
+					},
+					Body:    io.NopCloser(strings.NewReader("")),
+					Request: req,
+				}, nil
+			case 1:
+				want := accelBase + "https://objects.githubusercontent.com/github-production-release-asset/file.zip?token=temp-github-token"
+				if req.URL.String() != want {
+					return nil, fmt.Errorf("unexpected second URL %s, want %s", req.URL.String(), want)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(string(artifact))),
+					Request:    req,
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected extra request %d: %s", n, req.URL.String())
+			}
+		},
+	}
+
+	client := Client{
+		HTTPClient:      doer,
+		AcceleratorBase: accelBase,
+	}
+	data, errDownload := client.DownloadAsset(context.Background(), ReleaseAsset{
+		Name:               "sample-provider_0.2.0_darwin_arm64.zip",
+		BrowserDownloadURL: "https://github.com/owner/repo/releases/download/v0.2.0/sample-provider_0.2.0_darwin_arm64.zip",
+	})
+	if errDownload != nil {
+		t.Fatalf("DownloadAsset() error = %v; requests=%v", errDownload, doer.requests)
+	}
+	if string(data) != string(artifact) {
+		t.Fatalf("DownloadAsset() = %q, want artifact-data; requests=%v", data, doer.requests)
+	}
+}
+
+func TestFetchLatestReleaseDoesNotUseAcceleratorForAPI(t *testing.T) {
+	accelBase := "https://gh-proxy.example/"
+	var seen []string
+	doer := &recordingHTTPDoer{
+		handler: func(req *http.Request, n int) (*http.Response, error) {
+			seen = append(seen, req.URL.String())
+			if strings.HasPrefix(req.URL.String(), accelBase) {
+				return nil, fmt.Errorf("api request must not use accelerator: %s", req.URL.String())
+			}
+			if req.URL.String() != "https://api.github.com/repos/owner/repo/releases/latest" {
+				return nil, fmt.Errorf("unexpected URL %s", req.URL.String())
+			}
+			body := `{"tag_name":"v1.2.3","assets":[{"name":"x.zip","browser_download_url":"https://github.com/owner/repo/releases/download/v1.2.3/x.zip"}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		},
+	}
+	client := Client{HTTPClient: doer, AcceleratorBase: accelBase}
+	release, err := client.FetchLatestRelease(context.Background(), Plugin{
+		ID:          "sample",
+		Name:        "Sample",
+		Description: "d",
+		Author:      "owner",
+		Repository:  "https://github.com/owner/repo",
+		Install:     InstallPlan{Type: InstallTypeGitHubRelease},
+	})
+	if err != nil {
+		t.Fatalf("FetchLatestRelease() error = %v; seen=%v", err, seen)
+	}
+	if release.TagName != "v1.2.3" {
+		t.Fatalf("TagName = %q", release.TagName)
+	}
+	if len(seen) != 1 || seen[0] != "https://api.github.com/repos/owner/repo/releases/latest" {
+		t.Fatalf("seen = %v", seen)
+	}
+}
+
 func TestDownloadAssetFallsBackToReleaseAssetAPIURLWhenBrowserDownloadURLEmpty(t *testing.T) {
 	apiURL := "https://api.github.com/repos/author-name/cliproxy-sample-provider-plugin/releases/assets/1"
 	client := Client{HTTPClient: mapHTTPDoer{
@@ -675,6 +814,40 @@ func TestDownloadArtifactEnforcesDeclaredSizeDuringRead(t *testing.T) {
 	}
 }
 
+func TestDownloadArtifactRetriesInterruptedResponse(t *testing.T) {
+	t.Parallel()
+
+	checksum := sha256.Sum256([]byte("artifact-data"))
+	client := Client{HTTPClient: &interruptedResponseHTTPDoer{}}
+	data, errDownload := client.DownloadArtifact(context.Background(), Artifact{
+		GOOS: "linux", GOARCH: "amd64", URL: "https://downloads.example/sample-provider.zip", SHA256: hex.EncodeToString(checksum[:]),
+	})
+	if errDownload != nil {
+		t.Fatalf("DownloadArtifact() error = %v", errDownload)
+	}
+	if string(data) != "artifact-data" {
+		t.Fatalf("DownloadArtifact() = %q, want artifact-data", data)
+	}
+}
+
+func TestDownloadArtifactDoesNotRetryCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	checksum := sha256.Sum256([]byte("artifact-data"))
+	client := &countingCanceledHTTPDoer{}
+	_, errDownload := (Client{HTTPClient: client}).DownloadArtifact(ctx, Artifact{
+		GOOS: "linux", GOARCH: "amd64", URL: "https://downloads.example/sample-provider.zip", SHA256: hex.EncodeToString(checksum[:]),
+	})
+	if !errors.Is(errDownload, context.Canceled) {
+		t.Fatalf("DownloadArtifact() error = %v, want context canceled", errDownload)
+	}
+	if client.calls != 1 {
+		t.Fatalf("HTTP calls = %d, want 1", client.calls)
+	}
+}
+
 func TestInstallRejectsInvalidLatestReleaseTag(t *testing.T) {
 	t.Parallel()
 
@@ -762,6 +935,42 @@ func (c singleResponseHTTPDoer) Do(req *http.Request) (*http.Response, error) {
 type trackingReadCloser struct {
 	data   []byte
 	offset int
+}
+
+type interruptedResponseHTTPDoer struct {
+	calls int
+}
+
+func (c *interruptedResponseHTTPDoer) Do(req *http.Request) (*http.Response, error) {
+	c.calls++
+	body := io.NopCloser(strings.NewReader("artifact-data"))
+	if c.calls == 1 {
+		body = io.NopCloser(&errorAfterReader{data: []byte("partial"), err: context.Canceled})
+	}
+	return &http.Response{StatusCode: http.StatusOK, Body: body, Header: make(http.Header), Request: req}, nil
+}
+
+type countingCanceledHTTPDoer struct {
+	calls int
+}
+
+func (c *countingCanceledHTTPDoer) Do(req *http.Request) (*http.Response, error) {
+	c.calls++
+	return nil, req.Context().Err()
+}
+
+type errorAfterReader struct {
+	data []byte
+	err  error
+}
+
+func (r *errorAfterReader) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, r.err
+	}
+	n := copy(p, r.data)
+	r.data = r.data[n:]
+	return n, nil
 }
 
 func (r *trackingReadCloser) Read(p []byte) (int, error) {


### PR DESCRIPTION
# Plugin Store: Custom Proxy and Web Accelerator Support

## Background
The CLIProxyAPI plugin store fetches plugin manifests and artifacts from GitHub repositories (registry JSON, release archives, raw content, and GitHub CDN).
For deployments in mainland China, GitHub is frequently slow or unreachable, making plugin discovery, download, and update fail without a relay. Users behind restrictive network policies face the same problem.

A global proxy (`proxy-url`) can tunnel everything, but that makes all request (the registry metadata and API calls) share the same proxy egress IP, which triggers GitHub 403 secondary rate limits that block the entire deployment.

Plugin Store proxy support solves this by letting each admin choose a routing strategy:

- `custom` — dedicated proxy for plugin traffic only (clean IP, no rate limit)
- `system` — reuse the global proxy-url (simpler setup)
- `accelerator` — rewrite GitHub download URLs through a prefix (e.g. `ghproxy`) so artifact downloads bypass GitHub direct access entirely; registry and API calls still go direct, avoiding 403s
- `none` — unset/default; fall back to the global proxy-url when present, otherwise connect directly. Preserves legacy behavior for configs that never set `plugin-proxy`.
- `direct` — connect directly, bypassing the global proxy-url even when one is set


<img width="1594" height="416" alt="timeout" src="https://github.com/user-attachments/assets/c78a9804-2f69-4524-810b-4d5fa7d46ef8" />

<img width="1161" height="689" alt="403" src="https://github.com/user-attachments/assets/811a3ab4-470a-420d-93c6-a09e812b4f7f" />

## Summary
This PR adds backend support for plugin store proxy configuration so toolbars and management UIs can control how plugin list/install traffic is routed. It also introduces a web accelerator mode that rewrites GitHub resource URLs (releases, raw, CDN) through a configurable prefix, independent of the global OAuth/proxy setup.

### Backend Dependency
This backend change supported by frontend PR [Cli-Proxy-API-Management-Center#366](https://github.com/router-for-me/Cli-Proxy-API-Management-Center/pull/366) to be merged and deployed.

### Related Issues
- Backend PR: https://github.com/router-for-me/Cli-Proxy-API-Management-Center/pull/366


## What This Enables
- **Management endpoints** — `GET`/`PUT`/`PATCH` `/v0/management/plugin-proxy` to read or update the proxy mode, plus a `POST` validate helper. - **Status-based routing** — the `plugin-proxy` config chooses between `direct`, `none` (fallback), `custom` (dedicated HTTP(S)/SOCKS proxy), `system` (reuse global proxy-url), or `accelerator` (rewrite GitHub artifact URLs through a prefix).
- **Accelerator safety** — accelerator rewriting targets only download artifact URLs (GitHub releases, raw, CDN). Registry, metadata, and API requests are never rewritten, avoiding GitHub 403 secondary rate limits that shared proxy egress IPs otherwise trigger.

## Design Decisions

- `PluginProxyConfig.Status int` is serialized as `json:"status"` (without `omitempty`) so a value of `0` (none) is never ambiguous after round-trip.
- The PUT handler only validates `url` / `accelerator` for `custom` and `accelerator` modes; `direct`/`none`/`system` go through unvalidated. The default case in the status switch explicitly maps so a future extension does not silently skip validation. 
- Normalization clamps unknown status values to `none` (0) rather than passing them through as-is. `direct` (-1) is preserved as a first-class status.
- `none` (0, the zero value) means "unset/default": it falls back to the global `proxy-url` when present, so legacy configs that never set `plugin-proxy` keep using the system proxy. `direct` (-1) is the explicit "no proxy, connect directly" choice.
- Runtime artifact/resource URLs are allowed to carry temporary signed query parameters such as GitHub CDN `?token=`. Registry and manifest URLs still delete sensitive query keys so long-lived credentials are never stored.
- Artifact downloads retry on transient connection errors (unexpected EOF, connection reset) up to 3 attempts.  `context.Canceled` / `context.DeadlineExceeded` fail immediately without retry.

<img width="1501" height="661" alt="success" src="https://github.com/user-attachments/assets/7c1dc786-24f0-4895-bd95-6e43dc65c46e" />