### PR TITLE
feat(executor): opt-in prompt_cache_key for OpenAI-compatible providers

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -446,6 +446,7 @@ nonstream-keepalive-interval: 0
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
 #     disable-cooling: false # optional: per-provider override for auth/model cooldown scheduling
+#     prompt-cache-key: false # optional: inject an upstream prompt_cache_key; a caller key wins, else derive one from the client session
 #     headers:
 #       X-Custom-Header: "custom-value"
 #     api-key-entries:

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -48,6 +48,7 @@ type openAICompatibilityWithAuthIndex struct {
 	Models         []config.OpenAICompatibilityModel        `json:"models,omitempty"`
 	Headers        map[string]string                        `json:"headers,omitempty"`
 	DisableCooling bool                                     `json:"disable-cooling,omitempty"`
+	PromptCacheKey bool                                     `json:"prompt-cache-key,omitempty"`
 	AuthIndex      string                                   `json:"auth-index,omitempty"`
 }
 
@@ -286,6 +287,7 @@ func (h *Handler) openAICompatibilityWithAuthIndex() []openAICompatibilityWithAu
 			Models:         entry.Models,
 			Headers:        entry.Headers,
 			DisableCooling: entry.DisableCooling,
+			PromptCacheKey: entry.PromptCacheKey,
 			AuthIndex:      "",
 		}
 		if len(entry.APIKeyEntries) == 0 {

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -705,6 +705,7 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 		Prefix         *string                             `json:"prefix"`
 		Disabled       *bool                               `json:"disabled"`
 		DisableCooling *bool                               `json:"disable-cooling"`
+		PromptCacheKey *bool                               `json:"prompt-cache-key"`
 		BaseURL        *string                             `json:"base-url"`
 		APIKeyEntries  *[]config.OpenAICompatibilityAPIKey `json:"api-key-entries"`
 		Models         *[]config.OpenAICompatibilityModel  `json:"models"`
@@ -752,6 +753,9 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 	}
 	if body.Value.DisableCooling != nil {
 		entry.DisableCooling = *body.Value.DisableCooling
+	}
+	if body.Value.PromptCacheKey != nil {
+		entry.PromptCacheKey = *body.Value.PromptCacheKey
 	}
 	if body.Value.BaseURL != nil {
 		trimmed := strings.TrimSpace(*body.Value.BaseURL)

--- a/internal/api/handlers/management/config_openai_compat_test.go
+++ b/internal/api/handlers/management/config_openai_compat_test.go
@@ -53,3 +53,43 @@ func TestGetOpenAICompatIncludesDisableCooling(t *testing.T) {
 		t.Fatalf("expected disable-cooling to be present and true, got %#v", body.OpenAICompatibility[0].DisableCooling)
 	}
 }
+
+func TestGetOpenAICompatIncludesPromptCacheKey(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	h := NewHandlerWithoutConfigFilePath(&config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{
+			{
+				Name:    "Mimo CN",
+				BaseURL: "https://token-plan-cn.xiaomimimo.com/v1",
+				APIKeyEntries: []config.OpenAICompatibilityAPIKey{
+					{APIKey: "test-key"},
+				},
+				Models: []config.OpenAICompatibilityModel{
+					{Name: "mimo-v2.5", Alias: ""},
+				},
+				PromptCacheKey: true,
+			},
+		},
+	}, nil)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/openai-compatibility", nil)
+	h.GetOpenAICompat(ctx)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	var body struct {
+		OpenAICompatibility []struct {
+			PromptCacheKey *bool `json:"prompt-cache-key"`
+		} `json:"openai-compatibility"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(body.OpenAICompatibility) != 1 {
+		t.Fatalf("expected 1 openai-compatibility entry, got %d", len(body.OpenAICompatibility))
+	}
+	if body.OpenAICompatibility[0].PromptCacheKey == nil || !*body.OpenAICompatibility[0].PromptCacheKey {
+		t.Fatalf("expected prompt-cache-key to be present and true, got %#v", body.OpenAICompatibility[0].PromptCacheKey)
+	}
+}

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -580,6 +580,10 @@ type OpenAICompatibility struct {
 
 	// DisableCooling disables auth/model cooldown scheduling for this provider when true.
 	DisableCooling bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
+
+	// PromptCacheKey, when true, injects an upstream prompt_cache_key (opt-in):
+	// a caller-supplied key wins, otherwise one is derived from the client session.
+	PromptCacheKey bool `yaml:"prompt-cache-key,omitempty" json:"prompt-cache-key,omitempty"`
 }
 
 // OpenAICompatibilityAPIKey represents an API key configuration with optional proxy setting.

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -11,6 +11,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"strconv"
 	"strings"
 	"time"
 
@@ -796,6 +797,13 @@ func (e *OpenAICompatExecutor) resolveCompatComposerSessionID(ctx context.Contex
 func (e *OpenAICompatExecutor) resolveCompatConfig(auth *cliproxyauth.Auth) *config.OpenAICompatibility {
 	if auth == nil || e.cfg == nil {
 		return nil
+	}
+	// Config-synthesized auths carry config_index to disambiguate OpenAI-compatibility
+	// entries that share a name; honor it so we never match the wrong entry.
+	if auth.AuthSourceKind() == cliproxyauth.AuthSourceConfig && auth.Attributes != nil {
+		if index, errIndex := strconv.Atoi(strings.TrimSpace(auth.Attributes[cliproxyauth.AttributeConfigIndex])); errIndex == nil && index >= 0 && index < len(e.cfg.OpenAICompatibility) && !e.cfg.OpenAICompatibility[index].Disabled {
+			return &e.cfg.OpenAICompatibility[index]
+		}
 	}
 	candidates := make([]string, 0, 3)
 	if auth.Attributes != nil {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
@@ -22,6 +23,7 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
@@ -122,6 +124,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
+	translated = e.applyCompatPromptCacheKey(ctx, auth, baseModel, req, opts, translated)
 	if opts.Alt == "responses/compact" {
 		if updated, errDelete := sjson.DeleteBytes(translated, "stream"); errDelete == nil {
 			translated = updated
@@ -323,6 +326,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
+	translated = e.applyCompatPromptCacheKey(ctx, auth, baseModel, req, opts, translated)
 
 	// Request usage data in the final streaming chunk so that token statistics
 	// are captured even when the upstream is an OpenAI-compatible provider.
@@ -743,6 +747,50 @@ func (e *OpenAICompatExecutor) resolveCredentials(auth *cliproxyauth.Auth) (base
 		apiKey = strings.TrimSpace(auth.Attributes["api_key"])
 	}
 	return
+}
+
+func (e *OpenAICompatExecutor) applyCompatPromptCacheKey(ctx context.Context, auth *cliproxyauth.Auth, baseModel string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, body []byte) []byte {
+	compat := e.resolveCompatConfig(auth)
+	if compat == nil || !compat.PromptCacheKey {
+		return body
+	}
+	// Restore a caller key that translation dropped (e.g. openai-response -> chat); it wins over derivation.
+	originalPayload := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		originalPayload = opts.OriginalRequest
+	}
+	callerKey := strings.TrimSpace(gjson.GetBytes(body, "prompt_cache_key").String())
+	if callerKey == "" {
+		callerKey = strings.TrimSpace(gjson.GetBytes(originalPayload, "prompt_cache_key").String())
+	}
+	if callerKey != "" {
+		return helps.SetStringIfDifferent(body, "prompt_cache_key", callerKey)
+	}
+	sessionID, errResolve := e.resolveCompatComposerSessionID(ctx, baseModel, req, opts)
+	if errResolve != nil || sessionID == "" {
+		return body
+	}
+	return helps.SetStringIfDifferent(body, "prompt_cache_key", sessionID)
+}
+
+func (e *OpenAICompatExecutor) resolveCompatComposerSessionID(ctx context.Context, baseModel string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (string, error) {
+	if value := metadataString(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey); value != "" {
+		return value, nil
+	}
+	if value := metadataString(req.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey); value != "" {
+		return value, nil
+	}
+	if derived := helps.DerivedSessionUUID(e.provider, opts.Metadata, req.Metadata); derived != "" {
+		return derived, nil
+	}
+	cached, ok, errCache := helps.ClaudeCodePromptCache(ctx, baseModel, req.Payload, opts.Headers)
+	if errCache != nil {
+		return "", errCache
+	}
+	if ok {
+		return cached.ID, nil
+	}
+	return uuid.NewString(), nil
 }
 
 func (e *OpenAICompatExecutor) resolveCompatConfig(auth *cliproxyauth.Auth) *config.OpenAICompatibility {

--- a/internal/runtime/executor/openai_compat_executor_promptcache_test.go
+++ b/internal/runtime/executor/openai_compat_executor_promptcache_test.go
@@ -1,0 +1,122 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+)
+
+const compatPromptCacheSessionID = "compat-cache-session-1"
+
+func newCompatPromptCacheExecutor(provider string, optIn bool) (*OpenAICompatExecutor, *cliproxyauth.Auth) {
+	executor := NewOpenAICompatExecutor(provider, &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{
+			{Name: provider, PromptCacheKey: optIn},
+		},
+	})
+	auth := &cliproxyauth.Auth{Provider: provider, Attributes: map[string]string{"api_key": "test"}}
+	return executor, auth
+}
+
+func expectedClaudeCodePromptCacheKey(model, sessionID, agentID string) string {
+	executionScope := "claude:" + sessionID + ":agent:" + agentID
+	identity := "cli-proxy-api:codex:claude-code" + "\x00" + model + "\x00" + executionScope
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(identity)).String()
+}
+
+func TestOpenAICompatPromptCacheKeyDerivesDeterministicKeyWhenOptedIn(t *testing.T) {
+	executor, auth := newCompatPromptCacheExecutor("cached-provider", true)
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-oss-120b",
+		Payload: []byte(`{"model":"gpt-oss-120b","messages":[{"role":"user","content":"first"}]}`),
+	}
+	headers := http.Header{}
+	headers.Set(helps.ClaudeCodeSessionHeader, compatPromptCacheSessionID)
+	opts := cliproxyexecutor.Options{Headers: headers}
+	first := executor.applyCompatPromptCacheKey(context.Background(), auth, "gpt-oss-120b", req, opts, []byte(`{"model":"gpt-oss-120b","messages":[]}`))
+	second := executor.applyCompatPromptCacheKey(context.Background(), auth, "gpt-oss-120b", req, opts, []byte(`{"model":"gpt-oss-120b","messages":[]}`))
+	expectedKey := expectedClaudeCodePromptCacheKey("gpt-oss-120b", compatPromptCacheSessionID, helps.ClaudeCodeMainAgentID)
+	if gotKey := gjson.GetBytes(first, "prompt_cache_key").String(); gotKey != expectedKey {
+		t.Fatalf("prompt_cache_key = %q, want %q", gotKey, expectedKey)
+	}
+	if gotKey2 := gjson.GetBytes(second, "prompt_cache_key").String(); gotKey2 != expectedKey {
+		t.Fatalf("prompt_cache_key (second call) = %q, want %q", gotKey2, expectedKey)
+	}
+	if _, errParse := uuid.Parse(expectedKey); errParse != nil {
+		t.Fatalf("derived prompt cache key %q is not a UUID: %v", expectedKey, errParse)
+	}
+}
+
+func TestOpenAICompatPromptCacheKeyOffWhenNotOptedIn(t *testing.T) {
+	executor, auth := newCompatPromptCacheExecutor("uncached-provider", false)
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-oss-120b",
+		Payload: []byte(`{"model":"gpt-oss-120b","messages":[{"role":"user","content":"hi"}]}`),
+	}
+	headers := http.Header{}
+	headers.Set(helps.ClaudeCodeSessionHeader, compatPromptCacheSessionID)
+	opts := cliproxyexecutor.Options{Headers: headers}
+	body := executor.applyCompatPromptCacheKey(context.Background(), auth, "gpt-oss-120b", req, opts, []byte(`{"model":"gpt-oss-120b","messages":[]}`))
+	if gjson.GetBytes(body, "prompt_cache_key").Exists() {
+		t.Fatalf("prompt_cache_key must be absent when opt-in is off, body=%s", body)
+	}
+}
+
+func TestOpenAICompatPromptCacheKeyExplicitKeyWinsOverDerived(t *testing.T) {
+	executor, auth := newCompatPromptCacheExecutor("cached-provider", true)
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-oss-120b",
+		Payload: []byte(`{"model":"gpt-oss-120b","messages":[{"role":"user","content":"hi"}]}`),
+	}
+	headers := http.Header{}
+	headers.Set(helps.ClaudeCodeSessionHeader, compatPromptCacheSessionID)
+	opts := cliproxyexecutor.Options{Headers: headers}
+	const explicitKey = "caller-supplied-key"
+	body := executor.applyCompatPromptCacheKey(context.Background(), auth, "gpt-oss-120b", req, opts, []byte(`{"model":"gpt-oss-120b","prompt_cache_key":"`+explicitKey+`"}`))
+	if got := gjson.GetBytes(body, "prompt_cache_key").String(); got != explicitKey {
+		t.Fatalf("prompt_cache_key = %q, want %q (explicit must win)", got, explicitKey)
+	}
+}
+
+func TestOpenAICompatPromptCacheKeyAbsentSessionFallsBackToRandomUUID(t *testing.T) {
+	executor, auth := newCompatPromptCacheExecutor("cached-provider", true)
+	// No X-Claude-Code-Session-Id header and no metadata.user_id session suffix.
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-oss-120b",
+		Payload: []byte(`{"model":"gpt-oss-120b","messages":[{"role":"user","content":"hi"}]}`),
+	}
+	opts := cliproxyexecutor.Options{Headers: http.Header{}}
+	in := []byte(`{"model":"gpt-oss-120b","messages":[]}`)
+	body := executor.applyCompatPromptCacheKey(context.Background(), auth, "gpt-oss-120b", req, opts, in)
+	gotKey := gjson.GetBytes(body, "prompt_cache_key").String()
+	if gotKey == "" {
+		t.Fatalf("prompt_cache_key must fall back to a random UUID, body=%s", body)
+	}
+	if _, errParse := uuid.Parse(gotKey); errParse != nil {
+		t.Fatalf("fallback prompt_cache_key %q is not a UUID: %v", gotKey, errParse)
+	}
+}
+
+func TestOpenAICompatPromptCacheKeyAgentScopeIsolatesKeys(t *testing.T) {
+	executor, auth := newCompatPromptCacheExecutor("cached-provider", true)
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-oss-120b",
+		Payload: []byte(`{"model":"gpt-oss-120b","messages":[{"role":"user","content":"hello"}]}`),
+	}
+	rootHeaders := http.Header{}
+	rootHeaders.Set(helps.ClaudeCodeSessionHeader, compatPromptCacheSessionID)
+	childHeaders := rootHeaders.Clone()
+	childHeaders.Set(helps.ClaudeCodeAgentHeader, "agent-a")
+	rootKey := gjson.GetBytes(executor.applyCompatPromptCacheKey(context.Background(), auth, "gpt-oss-120b", req, cliproxyexecutor.Options{Headers: rootHeaders}, []byte(`{"model":"gpt-oss-120b","messages":[]}`)), "prompt_cache_key").String()
+	childKey := gjson.GetBytes(executor.applyCompatPromptCacheKey(context.Background(), auth, "gpt-oss-120b", req, cliproxyexecutor.Options{Headers: childHeaders}, []byte(`{"model":"gpt-oss-120b","messages":[]}`)), "prompt_cache_key").String()
+	if rootKey == "" || childKey == "" || rootKey == childKey {
+		t.Fatalf("agent prompt keys are not isolated: root=%q child=%q", rootKey, childKey)
+	}
+}


### PR DESCRIPTION
## Summary
- add an opt-in `prompt-cache-key` flag to `openai-compatibility` entries (default off)
- inject an upstream `prompt_cache_key` in the OpenAI-compatibility executor's `Execute` and `ExecuteStream`: a caller-supplied key wins, otherwise one is derived from the client session
- derive via the same chain as the Codex/xAI executors: `execution_session_id` → Claude Code session-derived key → random UUID
- document the option in `config.example.yaml`
- add unit tests covering opt-in/off, deterministic derivation, explicit-key precedence, random-UUID fallback, and agent-scope isolation

## Motivation
The Codex executor derives a `prompt_cache_key` before sending requests upstream, but the OpenAI-compatibility executor — used by any OpenAI-compatible provider — does not. Prompt caching therefore stays inactive for these providers even when both the client and upstream support it. This closes that gap behind an explicit opt-in; default off avoids HTTP 400 on backends that reject unknown fields.

## Scope
OpenAI-compatibility executor only. No `internal/translator/` changes, no response handling, no routing/affinity behavior, no changes to other executors.

## Validation
- `gofmt -l` on changed files (clean)
- `go vet ./internal/runtime/executor/`
- `go build -o test-output ./cmd/server && rm test-output`
- `go test -run 'TestOpenAICompatPromptCacheKey' ./internal/runtime/executor/`

Closes #4700.