### PR TITLE
fix(handlers): surface pending terminal error in streaming peek loops

### DIFF
--- a/sdk/api/handlers/gemini/gemini_handlers.go
+++ b/sdk/api/handlers/gemini/gemini_handlers.go
@@ -219,6 +219,18 @@ func (h *GeminiAPIHandler) handleStreamGenerateContent(c *gin.Context, modelName
 			return
 		case chunk, ok := <-dataChan:
 			if !ok {
+				// A terminal error may already be buffered on errChan: the producer sends it
+				// before closing both channels, so both select cases can be ready here.
+				// Surface the error instead of finalizing a successful stream.
+				if errMsg, okPendingErr := handlers.PendingStreamError(errChan); okPendingErr {
+					h.WriteErrorResponse(c, errMsg)
+					if errMsg != nil {
+						cliCancel(errMsg.Error)
+					} else {
+						cliCancel(nil)
+					}
+					return
+				}
 				// Closed without data
 				if alt == "" {
 					setSSEHeaders()

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -500,6 +500,18 @@ func (h *OpenAIAPIHandler) handleStreamingResponse(c *gin.Context, rawJSON []byt
 			return
 		case chunk, ok := <-dataChan:
 			if !ok {
+				// A terminal error may already be buffered on errChan: the producer sends it
+				// before closing both channels, so both select cases can be ready here.
+				// Surface the error instead of finalizing a successful stream.
+				if errMsg, okPendingErr := handlers.PendingStreamError(errChan); okPendingErr {
+					h.WriteErrorResponse(c, errMsg)
+					if errMsg != nil {
+						cliCancel(errMsg.Error)
+					} else {
+						cliCancel(nil)
+					}
+					return
+				}
 				// Stream closed without data? Send DONE or just headers.
 				setSSEHeaders()
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
@@ -607,6 +619,18 @@ func (h *OpenAIAPIHandler) handleCompletionsStreamingResponse(c *gin.Context, ra
 			return
 		case chunk, ok := <-dataChan:
 			if !ok {
+				// A terminal error may already be buffered on errChan: the producer sends it
+				// before closing both channels, so both select cases can be ready here.
+				// Surface the error instead of finalizing a successful stream.
+				if errMsg, okPendingErr := handlers.PendingStreamError(errChan); okPendingErr {
+					h.WriteErrorResponse(c, errMsg)
+					if errMsg != nil {
+						cliCancel(errMsg.Error)
+					} else {
+						cliCancel(nil)
+					}
+					return
+				}
 				setSSEHeaders()
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 				_, _ = fmt.Fprintf(c.Writer, "data: [DONE]\n\n")

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -1229,6 +1229,19 @@ func (h *OpenAIAPIHandler) streamRoutedImages(c *gin.Context, imageReq []byte, i
 			return
 		case chunk, ok := <-dataChan:
 			if !ok {
+				// A terminal error may already be buffered on errChan: the producer sends it
+				// before closing both channels, so both select cases can be ready here.
+				// Surface the error instead of finalizing a successful stream.
+				if errMsg, okPendingErr := handlers.PendingStreamError(errChan); okPendingErr {
+					stopKeepAlive()
+					h.WriteErrorResponse(c, errMsg)
+					if errMsg != nil {
+						cliCancel(errMsg.Error)
+					} else {
+						cliCancel(nil)
+					}
+					return
+				}
 				stopKeepAlive()
 				setImagesSSEHeaders(c)
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
@@ -1357,6 +1370,19 @@ func (h *OpenAIAPIHandler) streamOpenAICompatImages(c *gin.Context, compatReq []
 			return
 		case chunk, ok := <-dataChan:
 			if !ok {
+				// A terminal error may already be buffered on errChan: the producer sends it
+				// before closing both channels, so both select cases can be ready here.
+				// Surface the error instead of finalizing a successful stream.
+				if errMsg, okPendingErr := handlers.PendingStreamError(errChan); okPendingErr {
+					stopKeepAlive()
+					h.WriteErrorResponse(c, errMsg)
+					if errMsg != nil {
+						cliCancel(errMsg.Error)
+					} else {
+						cliCancel(nil)
+					}
+					return
+				}
 				stopKeepAlive()
 				setImagesSSEHeaders(c)
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
@@ -1794,6 +1820,19 @@ func (h *OpenAIAPIHandler) streamImagesFromResponses(c *gin.Context, responsesRe
 			return
 		case chunk, ok := <-dataChan:
 			if !ok {
+				// A terminal error may already be buffered on errChan: the producer sends it
+				// before closing both channels, so both select cases can be ready here.
+				// Surface the error instead of finalizing a successful stream.
+				if errMsg, okPendingErr := handlers.PendingStreamError(errChan); okPendingErr {
+					stopKeepAlive()
+					h.WriteErrorResponse(c, errMsg)
+					if errMsg != nil {
+						cliCancel(errMsg.Error)
+					} else {
+						cliCancel(nil)
+					}
+					return
+				}
 				stopKeepAlive()
 				setImagesSSEHeaders(c)
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -517,6 +517,18 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 			return
 		case chunk, ok := <-dataChan:
 			if !ok {
+				// A terminal error may already be buffered on errChan: the producer sends it
+				// before closing both channels, so both select cases can be ready here.
+				// Surface the error instead of finalizing a successful stream.
+				if errMsg, okPendingErr := handlers.PendingStreamError(errChan); okPendingErr {
+					h.WriteErrorResponse(c, errMsg)
+					if errMsg != nil {
+						cliCancel(errMsg.Error)
+					} else {
+						cliCancel(nil)
+					}
+					return
+				}
 				// Stream closed without data? Send headers and done.
 				setSSEHeaders()
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)

--- a/sdk/api/handlers/stream_forwarder.go
+++ b/sdk/api/handlers/stream_forwarder.go
@@ -29,6 +29,24 @@ type StreamForwardOptions struct {
 	WriteKeepAlive func()
 }
 
+// PendingStreamError performs a non-blocking receive on errs so callers can surface a
+// terminal error that the producer buffered before closing the data channel. It reports
+// (nil, false) when no error is pending.
+func PendingStreamError(errs <-chan *interfaces.ErrorMessage) (*interfaces.ErrorMessage, bool) {
+	if errs == nil {
+		return nil, false
+	}
+	select {
+	case errMsg, ok := <-errs:
+		if !ok {
+			return nil, false
+		}
+		return errMsg, true
+	default:
+		return nil, false
+	}
+}
+
 func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage, opts StreamForwardOptions) {
 	if c == nil {
 		return

--- a/sdk/api/handlers/stream_forwarder_test.go
+++ b/sdk/api/handlers/stream_forwarder_test.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+)
+
+func TestPendingStreamErrorReturnsBufferedError(t *testing.T) {
+	wantErr := &interfaces.ErrorMessage{
+		StatusCode: http.StatusBadGateway,
+		Error:      errors.New("upstream failed before sending any payload"),
+	}
+	// The producer buffers the terminal error and then closes both channels, so a
+	// consumer that observes the closed data channel can still drain the error here.
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	errs <- wantErr
+	close(errs)
+
+	gotErr, ok := PendingStreamError(errs)
+	if !ok {
+		t.Fatal("expected a pending stream error")
+	}
+	if gotErr != wantErr {
+		t.Fatalf("pending error = %v, want %v", gotErr, wantErr)
+	}
+}
+
+func TestPendingStreamErrorReportsNoErrorForClosedChannel(t *testing.T) {
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	close(errs)
+
+	if gotErr, ok := PendingStreamError(errs); ok {
+		t.Fatalf("pending error = %v, want none", gotErr)
+	}
+}
+
+func TestPendingStreamErrorReportsNoErrorForOpenChannel(t *testing.T) {
+	errs := make(chan *interfaces.ErrorMessage, 1)
+
+	if gotErr, ok := PendingStreamError(errs); ok {
+		t.Fatalf("pending error = %v, want none", gotErr)
+	}
+}
+
+func TestPendingStreamErrorReportsNoErrorForNilChannel(t *testing.T) {
+	if gotErr, ok := PendingStreamError(nil); ok {
+		t.Fatalf("pending error = %v, want none", gotErr)
+	}
+}


### PR DESCRIPTION
Fixes #4710

## Problem

When upstream fails before sending any payload byte, the producer in `executeStreamWithAuthManager` buffers the terminal error on `errChan` (cap 1) and then closes `errChan` and `dataChan` back to back. A peek loop that reaches its `select` after the producer has finished sees **both** cases ready; Go picks pseudo-randomly, and the `dataChan`-closed branch never drains `errChan` before finalizing — so roughly half of those requests commit SSE headers and return **HTTP 200 + `data: [DONE]`**, discarding the upstream 502/429/auth error.

The `bootstrapErr` path (`handlers_stream.go:543`) makes this readily reachable: `bootstrapErr` is computed synchronously *before* the goroutine starts, so the goroutine only does a buffered send plus two closes — there is no I/O in it to lose the race on.

## Fix

`sdk/api/handlers/claude/code_handlers.go:269` already guards exactly this branch with `pendingClaudeStreamError`, and `ForwardStream` (`stream_forwarder.go:70-96`) does the same non-blocking drain inline. This promotes that pattern to one shared helper and applies it to the seven remaining peek loops:

```go
// sdk/api/handlers/stream_forwarder.go
func PendingStreamError(errs <-chan *interfaces.ErrorMessage) (*interfaces.ErrorMessage, bool)
```

| File | Function |
|------|----------|
| `sdk/api/handlers/openai/openai_handlers.go` | `handleStreamingResponse`, `handleCompletionsStreamingResponse` |
| `sdk/api/handlers/openai/openai_responses_handlers.go` | `handleStreamingResponse` |
| `sdk/api/handlers/openai/openai_images_handlers.go` | `streamRoutedImages`, `streamOpenAICompatImages`, `streamImagesFromResponses` |
| `sdk/api/handlers/gemini/gemini_handlers.go` | `handleStreamGenerateContent` |

Each site drains a pending terminal error **before** any `setSSEHeaders()` / `WriteUpstreamHeaders` / `[DONE]` write, so the error is still reportable as a proper HTTP status. The image handlers call `stopKeepAlive()` first, matching their own `errChan` arm. At peek time `streamStarted` is always `false`, so `WriteErrorResponse` is the correct path.

The Claude handler's local `pendingClaudeStreamError` is intentionally left alone so its existing test isn't churned — happy to deduplicate it into `PendingStreamError` in a follow-up if you'd prefer.

## Behaviour change

Only on the path that previously lost the error. A stream that genuinely closes with no data and no error still emits `[DONE]` exactly as before — `PendingStreamError` is a non-blocking receive, so it never waits and never changes the clean-close path.

## Verification

- `go build -o test-output ./cmd/server` — OK
- `go test ./sdk/...` — all packages pass
- New `sdk/api/handlers/stream_forwarder_test.go`: buffered-then-closed channel yields the error; closed-empty, open-empty and nil channels all report no error
- `gofmt` clean on all changed files
- Modelling the producer's exact send/close ordering over 20000 runs (Go 1.26.5): before this change the error is swallowed as HTTP 200 + `[DONE]` **49.7%** of the time when the producer completes before the consumer selects; after, **0%**. When the consumer blocks in `select` first the buffered send hands off directly and both versions are correct — which is why the bug is intermittent rather than constant.

No changes under `internal/translator/` and `AGENTS.md` is untouched.
