### PR TITLE
fix(auth): bound credential-acquisition HTTP calls

### DIFF
--- a/internal/auth/claude/anthropic_auth.go
+++ b/internal/auth/claude/anthropic_auth.go
@@ -29,6 +29,10 @@ const (
 
 	claudeRefreshMinBackoff = 5 * time.Second
 	claudeRefreshMaxBackoff = 5 * time.Minute
+
+	// claudeCredentialRequestTimeout bounds a single credential-acquisition exchange
+	// with the OAuth endpoint. It does not apply to upstream API traffic.
+	claudeCredentialRequestTimeout = 60 * time.Second
 )
 
 var (
@@ -340,7 +344,12 @@ func (o *ClaudeAuth) RefreshTokens(ctx context.Context, refreshToken string) (*C
 	}
 
 	result, err, _ := claudeRefreshGroup.Do(refreshToken, func() (interface{}, error) {
-		return o.refreshTokensSingleFlight(context.WithoutCancel(ctx), refreshToken)
+		// The refresh is shared by every waiter, so it must not be cancelled by the
+		// caller that happened to trigger it. Replace the discarded deadline with an
+		// explicit one so a stalled endpoint cannot wedge the refresh indefinitely.
+		refreshCtx, cancelRefresh := context.WithTimeout(context.WithoutCancel(ctx), claudeCredentialRequestTimeout)
+		defer cancelRefresh()
+		return o.refreshTokensSingleFlight(refreshCtx, refreshToken)
 	})
 	if err != nil {
 		return nil, err

--- a/internal/auth/claude/utls_transport.go
+++ b/internal/auth/claude/utls_transport.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	tls "github.com/refraction-networking/utls"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
@@ -14,6 +15,11 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/proxy"
 )
+
+// claudeConnectSetupTimeout bounds connection establishment only: the TLS handshake
+// and the HTTP/2 preface. It is cleared once the connection is ready, so streaming
+// over an established connection remains unbounded.
+const claudeConnectSetupTimeout = 30 * time.Second
 
 // utlsRoundTripper implements http.RoundTripper using utls with Chrome fingerprint
 // to bypass Cloudflare's TLS fingerprinting on Anthropic domains.
@@ -104,6 +110,14 @@ func (t *utlsRoundTripper) createConnection(host, addr string) (*http2.ClientCon
 		return nil, err
 	}
 
+	// Bound setup only. Without this the handshake can block forever against an
+	// endpoint that accepts the connection and then stalls, because this transport
+	// honours neither http.Client.Timeout nor the request context until the HTTP/2
+	// connection exists.
+	if errDeadline := conn.SetDeadline(time.Now().Add(claudeConnectSetupTimeout)); errDeadline != nil {
+		log.Debugf("utls: failed to set connection setup deadline for %s: %v", addr, errDeadline)
+	}
+
 	tlsConfig := &tls.Config{ServerName: host}
 	tlsConn := tls.UClient(conn, tlsConfig, tls.HelloChrome_Auto)
 
@@ -117,6 +131,12 @@ func (t *utlsRoundTripper) createConnection(host, addr string) (*http2.ClientCon
 	if err != nil {
 		tlsConn.Close()
 		return nil, err
+	}
+
+	// Clear the setup deadline: the connection is pooled and reused for streaming
+	// responses, which must not be time-bounded.
+	if errDeadline := conn.SetDeadline(time.Time{}); errDeadline != nil {
+		log.Debugf("utls: failed to clear connection setup deadline for %s: %v", addr, errDeadline)
 	}
 
 	return h2Conn, nil
@@ -156,7 +176,10 @@ func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 // for Anthropic domains by using utls with Chrome fingerprint.
 // It accepts optional SDK configuration for proxy settings.
 func NewAnthropicHttpClient(cfg *config.SDKConfig) *http.Client {
+	// This client is only used for credential acquisition (OAuth token exchange and
+	// refresh), so a request timeout is appropriate here.
 	return &http.Client{
+		Timeout:   claudeCredentialRequestTimeout,
 		Transport: newUtlsRoundTripper(cfg),
 	}
 }

--- a/internal/auth/codex/openai_auth.go
+++ b/internal/auth/codex/openai_auth.go
@@ -26,6 +26,10 @@ const (
 	TokenURL    = "https://auth.openai.com/oauth/token"
 	ClientID    = "app_EMoamEEZ73f0CkXaXp7hrann"
 	RedirectURI = "http://localhost:1455/auth/callback"
+
+	// codexCredentialRequestTimeout bounds a single credential-acquisition exchange
+	// with the OAuth endpoint. It does not apply to upstream API traffic.
+	codexCredentialRequestTimeout = 60 * time.Second
 )
 
 // CodexAuth handles the OpenAI OAuth2 authentication flow.
@@ -56,7 +60,9 @@ func NewCodexAuthWithProxyURL(cfg *config.Config, proxyURL string) *CodexAuth {
 	}
 	sdkCfg.ProxyURL = effectiveProxyURL
 	return &CodexAuth{
-		httpClient: util.SetProxy(&sdkCfg, &http.Client{}),
+		// This client is only used for credential acquisition (OAuth token exchange
+		// and refresh), so a request timeout is appropriate here.
+		httpClient: util.SetProxy(&sdkCfg, &http.Client{Timeout: codexCredentialRequestTimeout}),
 	}
 }
 
@@ -195,7 +201,12 @@ func (o *CodexAuth) RefreshTokens(ctx context.Context, refreshToken string) (*Co
 	}
 
 	result, err, _ := codexRefreshGroup.Do(refreshToken, func() (interface{}, error) {
-		return o.refreshTokensSingleFlight(context.WithoutCancel(ctx), refreshToken)
+		// The refresh is shared by every waiter, so it must not be cancelled by the
+		// caller that happened to trigger it. Replace the discarded deadline with an
+		// explicit one so a stalled endpoint cannot wedge the refresh indefinitely.
+		refreshCtx, cancelRefresh := context.WithTimeout(context.WithoutCancel(ctx), codexCredentialRequestTimeout)
+		defer cancelRefresh()
+		return o.refreshTokensSingleFlight(refreshCtx, refreshToken)
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #4712

## Problem

`RefreshTokens` can block forever against an OAuth endpoint that accepts the connection and then stops responding. Two bounds are missing at once:

1. `context.WithoutCancel(ctx)` (`anthropic_auth.go:343`, `openai_auth.go:198`) discards the caller's deadline — correct in intent, since the refresh is shared by every waiter and must not die with one caller — but nothing replaces it.
2. Neither auth `http.Client` sets `Timeout`.

The Claude path is the worst case: `NewAnthropicHttpClient` uses the custom utls round tripper, and `createConnection` dials and handshakes with no deadline and no context. That transport honours neither `http.Client.Timeout` nor `req.Context()` until the HTTP/2 connection exists, so **neither** usual bound can interrupt a stalled handshake.

Since refresh holds a per-auth mutex and one of a limited number of refresh workers, a few stalled endpoints exhaust the pool and block 401-recovery request goroutines even after clients disconnect.

## Fix

Bounds **credential acquisition only**, which `AGENTS.md` explicitly permits:

> Timeouts are allowed only during credential acquisition; after an upstream connection is established, do not set timeouts for any subsequent network behavior.

- **`RefreshTokens` (claude + codex)** — wrap the uncancellable context with an explicit 60s deadline. `context.WithoutCancel` is kept, so single-flight semantics are unchanged: one caller going away still cannot cancel the shared refresh.
- **`NewAnthropicHttpClient` / `CodexAuth.httpClient`** — set `Client.Timeout`. Both clients are used *exclusively* for OAuth token exchange and refresh (`NewAnthropicHttpClient`'s only caller is `anthropic_auth.go:174`), never for upstream API traffic.
- **`utls createConnection`** — set a 30s connection deadline covering the TLS handshake and HTTP/2 preface, then **clear it** (`SetDeadline(time.Time{})`) before returning the pooled `*http2.ClientConn`.

That last point matters because `newUtlsRoundTripper` is also used by `internal/runtime/executor/helps/utls_client.go` on the upstream request path. Clearing the deadline means only connection *establishment* is bounded — streaming over an established connection remains unbounded, exactly as the AGENTS.md rule requires.

## Verification

- `go build -o test-output ./cmd/server` — OK
- `go test ./internal/auth/...` — all packages pass
- `go vet ./internal/auth/claude/... ./internal/auth/codex/...` — clean
- `gofmt` clean on all changed files

Behavioural checks against a listener that accepts TCP and never speaks TLS:

| | before | after |
|---|---|---|
| `createConnection` | never returns — test harness panics at 50s with the goroutine parked in `utls.(*Conn).readHandshakeBytes` | returns at 30s with `i/o timeout` |

And for the context path, a `RoundTripper` that blocks until its request context is done, called as `RefreshTokens(ctxWith500msDeadline, token)` — the 500ms deadline is stripped by `WithoutCancel`, and the call now returns at the client timeout instead of hanging.

No changes under `internal/translator/` and `AGENTS.md` is untouched.

The 60s / 30s values are chosen to be well clear of a normal token exchange; happy to adjust them or move them into config if you'd prefer.
