### PR TITLE
fix(auth): skip token refresh for disabled auths

### DIFF
--- a/sdk/cliproxy/auth/auto_refresh_loop.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop.go
@@ -339,6 +339,14 @@ func nextRefreshCheckAt(now time.Time, auth *Auth, interval time.Duration) (time
 	if auth == nil {
 		return time.Time{}, false
 	}
+	// Skip scheduling refresh for disabled auths. This prevents the
+	// auto-refresh loop from periodically attempting to refresh tokens
+	// for credentials the user has explicitly disabled via the
+	// management panel, which would otherwise produce error logs even
+	// though the auth is correctly excluded from routing.
+	if auth.Disabled || auth.Status == StatusDisabled {
+		return time.Time{}, false
+	}
 	if hasUnauthorizedAuthFailure(auth) {
 		return time.Time{}, false
 	}

--- a/sdk/cliproxy/auth/auto_refresh_loop_test.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop_test.go
@@ -52,13 +52,13 @@ func TestNextRefreshCheckAt_DisabledUnschedule(t *testing.T) {
 		},
 	}
 
+	// Disabled auths must be unscheduled: nextRefreshCheckAt returns ok=false
+	// so the auto-refresh loop never schedules a refresh for them, even if
+	// their token is near expiry. This avoids spurious refresh attempts for
+	// credentials the user has explicitly disabled.
 	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute)
-	if !ok {
-		t.Fatalf("nextRefreshCheckAt() ok = false, want true")
-	}
-	want := expiry.Add(-lead)
-	if !got.Equal(want) {
-		t.Fatalf("nextRefreshCheckAt() = %s, want %s", got, want)
+	if ok {
+		t.Fatalf("nextRefreshCheckAt() ok = true, want false (disabled auth should be unscheduled); got next=%s", got)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -115,6 +115,13 @@ func (m *Manager) shouldRefresh(a *Auth, now time.Time) bool {
 	if a == nil {
 		return false
 	}
+	// Skip refresh for disabled auths (Disabled flag or StatusDisabled).
+	// Disabled credentials are excluded from routing, so refreshing their
+	// tokens is wasteful and produces noisy error logs when the upstream
+	// account is no longer valid.
+	if a.Disabled || a.Status == StatusDisabled {
+		return false
+	}
 	if hasUnauthorizedAuthFailure(a) {
 		return false
 	}

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -441,6 +441,15 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		return nil, errors.New("auth or executor not found")
 	}
 
+	// Re-check disabled state here too: the auth may have been disabled
+	// after a refresh was already queued (e.g. while refresh workers were
+	// busy and the job sat in the buffered channel). Without this guard
+	// the worker would still call exec.Refresh on a just-disabled credential,
+	// producing the exact failure logs this fix is meant to suppress.
+	if auth.Disabled || auth.Status == StatusDisabled {
+		return nil, errors.New("auth is disabled, skipping refresh")
+	}
+
 	// Another request may already have refreshed this credential.
 	if failedAccessToken != "" {
 		if currentToken := authAccessToken(auth); currentToken != "" && currentToken != failedAccessToken {


### PR DESCRIPTION
## Problem

When an auth credential is disabled via the management panel (the `disabled` JSON field set to `true`, or `Status` set to `StatusDisabled`), the **auto-refresh loop still periodically attempts to refresh its token**. For a credential whose upstream account is no longer valid (e.g. revoked OAuth, reused refresh token), this produces repeated noisy error logs such as:

```
refreshed codex, codex-<email>.json, token refresh failed with status 401: refresh_token_reused
Token refresh attempt 1 failed: ... invalid_grant
```

even though the auth is correctly excluded from routing.

## Root cause

Disabled auths are already excluded from **routing**:
- `AvailableProviders()` and `HasProviderAuth()` skip `auth.Disabled || auth.Status == StatusDisabled`
- the selector skips disabled candidates

But the **refresh loop** does not check the disabled state:
- `nextRefreshCheckAt()` (`sdk/cliproxy/auth/auto_refresh_loop.go`) schedules refresh checks for disabled auths
- `shouldRefresh()` (`sdk/cliproxy/auth/conductor_refresh.go`) returns `true` for disabled auths
- `refreshAuth()` then attempts the refresh and logs the failure

## Fix

Add a guard clause at the top of both functions (right after the `nil` check), mirroring the existing `hasUnauthorizedAuthFailure` guard:

```go
if a.Disabled || a.Status == StatusDisabled {
    return false  // (time.Time{}, false) in nextRefreshCheckAt
}
```

This is a pure guard clause — behavior for non-disabled auths is completely unchanged. Disabled credentials no longer get scheduled or refreshed, eliminating the spurious error logs.

## Testing

- Built and ran the patched image locally; the previously-observed `refreshed codex, <disabled-auth>.json, token refresh failed` log lines no longer appear after startup.
- Non-disabled auths continue to refresh normally.
- `AvailableProviders` / `HasProviderAuth` behavior unchanged (they already checked disabled).