### PR TITLE
fix(auth): cap upstream 429 Retry-After so quota resets are picked up

### DIFF
--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -93,6 +93,25 @@ func recoverableFailureRetryAfter(now time.Time, disableCooling bool) time.Time 
 	return nextTransientErrorRetryAfter(now)
 }
 
+// cappedUpstreamRetryAfter bounds a single upstream 429 Retry-After hint to the
+// ceiling the proxy already uses for its own quota backoff (quotaBackoffMax).
+// Upstreams occasionally return multi-day windows (e.g. a weekly ChatGPT quota
+// reset). Honoring them verbatim parks the credential in cooldown long after a
+// manual reset or window rollover made it usable again, and nothing re-probes it
+// before that window expires — so the proxy keeps 429ing until a restart clears
+// the in-memory cooldown. Capping the hint keeps the credential re-probing, so
+// an upstream reset is picked up without a service restart. Hints at or below
+// the ceiling are honored unchanged; non-positive values collapse to zero.
+func cappedUpstreamRetryAfter(retryAfter time.Duration) time.Duration {
+	if retryAfter <= 0 {
+		return 0
+	}
+	if retryAfter > quotaBackoffMax {
+		return quotaBackoffMax
+	}
+	return retryAfter
+}
+
 // SetConfig updates the runtime config snapshot used by request-time helpers.
 // Callers should provide the latest config on reload so per-credential alias mapping stays in sync.
 func (m *Manager) SetConfig(cfg *internalconfig.Config) {
@@ -811,7 +830,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							backoffLevel := state.Quota.BackoffLevel
 							if !disableCooling {
 								if result.RetryAfter != nil {
-									next = now.Add(*result.RetryAfter)
+									next = now.Add(cappedUpstreamRetryAfter(*result.RetryAfter))
 								} else {
 									next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
 								}
@@ -1648,7 +1667,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		var next time.Time
 		if !disableCooling {
 			if retryAfter != nil {
-				next = now.Add(*retryAfter)
+				next = now.Add(cappedUpstreamRetryAfter(*retryAfter))
 			} else {
 				next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
 			}

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -308,3 +308,78 @@ func TestJitteredCooldownWaitBounds(t *testing.T) {
 		t.Fatalf("expected sub-4ns wait to stay unchanged, got %v", got)
 	}
 }
+
+func TestCappedUpstreamRetryAfter(t *testing.T) {
+	if got := cappedUpstreamRetryAfter(0); got != 0 {
+		t.Fatalf("expected zero hint to collapse to 0, got %v", got)
+	}
+	if got := cappedUpstreamRetryAfter(-time.Second); got != 0 {
+		t.Fatalf("expected negative hint to collapse to 0, got %v", got)
+	}
+	belowCap := quotaBackoffMax - time.Minute
+	if got := cappedUpstreamRetryAfter(belowCap); got != belowCap {
+		t.Fatalf("expected below-cap hint honored, got %v", got)
+	}
+	if got := cappedUpstreamRetryAfter(quotaBackoffMax); got != quotaBackoffMax {
+		t.Fatalf("expected at-cap hint honored, got %v", got)
+	}
+	aboveCap := quotaBackoffMax + 24*time.Hour
+	if got := cappedUpstreamRetryAfter(aboveCap); got != quotaBackoffMax {
+		t.Fatalf("expected above-cap hint capped at %v, got %v", quotaBackoffMax, got)
+	}
+}
+
+func TestApplyAuthFailureStateCapsUpstreamRetryAfter(t *testing.T) {
+	now := time.Now()
+	quotaErr := &Error{Code: "rate_limit", Message: "quota", HTTPStatus: http.StatusTooManyRequests}
+
+	// A multi-day upstream reset hint (e.g. weekly ChatGPT quota) must not park
+	// the credential past the proxy's own backoff ceiling.
+	auth := &Auth{ID: "auth-capped-retry-after"}
+	huge := 7 * 24 * time.Hour
+	applyAuthFailureState(auth, quotaErr, &huge, now, false)
+	want := now.Add(quotaBackoffMax)
+	if !auth.Quota.NextRecoverAt.Equal(want) {
+		t.Fatalf("expected cooldown capped at %v, got %v", want, auth.Quota.NextRecoverAt)
+	}
+	if !auth.NextRetryAfter.Equal(want) {
+		t.Fatalf("expected NextRetryAfter capped at %v, got %v", want, auth.NextRetryAfter)
+	}
+	if blocked, _, _ := isAuthBlockedForModel(auth, "", want.Add(time.Nanosecond)); blocked {
+		t.Fatal("auth did not auto-recover after capped retry deadline")
+	}
+}
+
+func quotaResultWithRetryAfter(authID, model string, retryAfter time.Duration) Result {
+	result := quotaResult(authID, model)
+	result.RetryAfter = &retryAfter
+	return result
+}
+
+func TestMarkResultCapsUpstreamRetryAfter(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-capped-retry-after-model",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex"},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("Register returned error: %v", errRegister)
+	}
+
+	huge := 7 * 24 * time.Hour
+	manager.MarkResult(context.Background(), quotaResultWithRetryAfter(auth.ID, "gpt-5", huge))
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil || updated.ModelStates["gpt-5"] == nil {
+		t.Fatalf("expected model state after failure")
+	}
+	state := updated.ModelStates["gpt-5"]
+	if state.Quota.NextRecoverAt.After(time.Now().Add(quotaBackoffMax)) {
+		t.Fatalf("expected cooldown capped at %v, got %v", time.Now().Add(quotaBackoffMax), state.Quota.NextRecoverAt)
+	}
+	if blocked, _, _ := isAuthBlockedForModel(updated, "gpt-5", state.Quota.NextRecoverAt.Add(time.Nanosecond)); blocked {
+		t.Fatal("auth did not auto-recover after capped retry deadline")
+	}
+}


### PR DESCRIPTION
Fixes #4724.

## Problem

A single upstream 429 `Retry-After` can be huge — ChatGPT returned `561635` (~156h, a weekly quota window) on our instance. Both 429 cooldown paths honored that hint verbatim:

- per-model `MarkResult` path (`conductor_cooldown.go`)
- `applyAuthFailureState` (`conductor_cooldown.go`)

That parked every credential for days, and nothing re-probes a credential while its cooldown window is open. So when the account was reset upstream (manual reset-credit, or the window rolling over), the proxy kept returning `429 model_cooldown` until a `systemctl restart cliproxyapi` cleared the in-memory cooldown.

The proxy already caps its own quota backoff at `quotaBackoffMax = 30 * time.Minute` (`conductor_refresh.go`), so re-probing at that cadence is exactly what a healthy setup already does.

## Fix

Cap the honored upstream `Retry-After` at `quotaBackoffMax` (30 min) in both 429 cooldown paths. Hints at or below the cap are honored unchanged; the credential now re-probes within half an hour, so an upstream reset is picked up without a restart.

## Notes

- The management endpoint `POST /v0/management/reset-quota` (v7.2.100+) remains the immediate operational escape hatch for a manual reset.
- Huge `Retry-After` values still work through the retry/wait path (`conductor_selection.go`), which is already bounded by `maxWait`.

## Tests

- `TestCappedUpstreamRetryAfter` — helper edges (zero, negative, below-cap, at-cap, above-cap).
- `TestApplyAuthFailureStateCapsUpstreamRetryAfter` — 7-day hint → capped at 30 min, and auto-recovers after the capped deadline.
- `TestMarkResultCapsUpstreamRetryAfter` — per-model path: 7-day hint → capped at 30 min, auto-recovers.

`go build ./...` and `go test ./sdk/cliproxy/auth/...` pass.