### PR TITLE
feat(executor): add configurable Claude cache-control default TTL

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -169,6 +169,13 @@ transient-error-cooldown-seconds: 0
 # "auto" behavior (cloak only non-Claude-Code clients).
 disable-claude-cloak-mode: false
 
+# Default TTL applied to Anthropic prompt-cache breakpoints on Claude requests.
+# Supported values: "5m" or "1h". Unset (default) leaves request bodies untouched.
+# Only cache_control objects with "type": "ephemeral" and a missing or "5m" ttl are
+# rewritten; other TTLs and malformed values are left as-is, and no breakpoint is added
+# or removed. Use "1h" to keep stable prompt prefixes on the extended cache path.
+# cache-control-default-ttl: "1h"
+
 # Claude Code compatibility settings.
 claude-code:
   # When true, return original model IDs in Anthropic model list responses instead of cloaked IDs.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,6 +137,20 @@ type Config struct {
 	// the auth/OAuth token file). Default false preserves the per-client "auto" behavior.
 	DisableClaudeCloakMode bool `yaml:"disable-claude-cloak-mode" json:"disable-claude-cloak-mode"`
 
+	// CacheControlDefaultTTL promotes default Anthropic prompt-cache breakpoints to the
+	// configured TTL before Claude requests are sent upstream.
+	//
+	// Supported values:
+	//   - "" (default): disabled. cache_control blocks are forwarded exactly as-is.
+	//   - "5m": pin default breakpoints to the standard 5-minute TTL explicitly.
+	//   - "1h": promote default breakpoints to the extended 1-hour TTL.
+	//
+	// Only breakpoints whose cache_control is an object with "type": "ephemeral" and a
+	// missing or "5m" ttl are rewritten. Blocks that already carry another ttl and
+	// malformed cache_control values are left untouched, and no breakpoint is added or
+	// removed. Unsupported values are ignored and keep the feature disabled.
+	CacheControlDefaultTTL string `yaml:"cache-control-default-ttl,omitempty" json:"cache-control-default-ttl,omitempty"`
+
 	// OpenAICompatibility defines OpenAI API compatibility configurations for external providers.
 	OpenAICompatibility []OpenAICompatibility `yaml:"openai-compatibility" json:"openai-compatibility"`
 

--- a/internal/runtime/executor/claude_cache_control_ttl_test.go
+++ b/internal/runtime/executor/claude_cache_control_ttl_test.go
@@ -1,0 +1,404 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	xxHash64 "github.com/pierrec/xxHash/xxHash64"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+// collectCacheControlTTLs returns the ttl value of every cache_control block in
+// Anthropic evaluation order (tools → system → messages). Blocks without a ttl are
+// reported as an empty string so callers can assert on default breakpoints too.
+func collectCacheControlTTLs(t *testing.T, payload []byte) []string {
+	t.Helper()
+
+	ttls := make([]string, 0, 8)
+	appendBlock := func(item gjson.Result) {
+		cc := item.Get("cache_control")
+		if !cc.Exists() {
+			return
+		}
+		ttls = append(ttls, cc.Get("ttl").String())
+	}
+
+	gjson.GetBytes(payload, "tools").ForEach(func(_, item gjson.Result) bool {
+		appendBlock(item)
+		return true
+	})
+	gjson.GetBytes(payload, "system").ForEach(func(_, item gjson.Result) bool {
+		appendBlock(item)
+		return true
+	})
+	gjson.GetBytes(payload, "messages").ForEach(func(_, msg gjson.Result) bool {
+		content := msg.Get("content")
+		if !content.IsArray() {
+			return true
+		}
+		content.ForEach(func(_, item gjson.Result) bool {
+			appendBlock(item)
+			return true
+		})
+		return true
+	})
+	return ttls
+}
+
+func assertAllCacheControlTTLs(t *testing.T, payload []byte, want string) {
+	t.Helper()
+
+	ttls := collectCacheControlTTLs(t, payload)
+	if len(ttls) == 0 {
+		t.Fatalf("expected at least one cache_control block in body: %s", string(payload))
+	}
+	for i, got := range ttls {
+		if got != want {
+			t.Fatalf("cache_control[%d].ttl = %q, want %q\nbody: %s", i, got, want, string(payload))
+		}
+	}
+}
+
+func TestPromoteDefaultCacheControlTTL_PromotesToolsSystemAndMessages(t *testing.T) {
+	payload := []byte(`{
+		"tools": [{"name":"t1","cache_control":{"type":"ephemeral"}}],
+		"system": [{"type":"text","text":"s1","cache_control":{"type":"ephemeral"}}],
+		"messages": [{"role":"user","content":[{"type":"text","text":"u1","cache_control":{"type":"ephemeral"}}]}]
+	}`)
+
+	out := promoteDefaultCacheControlTTL(payload, "1h")
+
+	assertAllCacheControlTTLs(t, out, "1h")
+	if got := len(collectCacheControlTTLs(t, out)); got != 3 {
+		t.Fatalf("cache_control block count = %d, want 3", got)
+	}
+	if got := countCacheControls(out); got != countCacheControls(payload) {
+		t.Fatalf("breakpoint count changed: %d -> %d", countCacheControls(payload), got)
+	}
+}
+
+func TestPromoteDefaultCacheControlTTL_PromotesInjectedBreakpoints(t *testing.T) {
+	input := []byte(`{"model":"claude-3-5-sonnet","tools":[{"name":"t1","input_schema":{"type":"object"}},{"name":"t2","input_schema":{"type":"object"}}],"system":"long system prompt","messages":[{"role":"user","content":[{"type":"text","text":"u1"}]},{"role":"assistant","content":[{"type":"text","text":"a1"}]},{"role":"user","content":[{"type":"text","text":"u2"}]}]}`)
+
+	out := promoteDefaultCacheControlTTL(ensureCacheControl(input), "1h")
+
+	assertAllCacheControlTTLs(t, out, "1h")
+}
+
+func TestPromoteDefaultCacheControlTTL_LeavesExistingOneHourBlocksUntouched(t *testing.T) {
+	payload := []byte(`{"tools":[{"name":"t1","cache_control":{"type":"ephemeral","ttl":"1h"}}],"system":[{"type":"text","text":"s1","cache_control":{"type":"ephemeral","ttl":"1h"}}],"messages":[{"role":"user","content":[{"type":"text","text":"u1","cache_control":{"type":"ephemeral","ttl":"1h"}}]}]}`)
+
+	out := promoteDefaultCacheControlTTL(payload, "1h")
+
+	if !bytes.Equal(out, payload) {
+		t.Fatalf("promoteDefaultCacheControlTTL altered bytes for already-1h blocks.\noriginal: %s\ngot:      %s", payload, out)
+	}
+}
+
+func TestPromoteDefaultCacheControlTTL_PromotesExplicitFiveMinuteBlocks(t *testing.T) {
+	payload := []byte(`{"system":[{"type":"text","text":"s1","cache_control":{"type":"ephemeral","ttl":"5m"}}],"messages":[{"role":"user","content":[{"type":"text","text":"u1","cache_control":{"type":"ephemeral","ttl":"5m"}}]}]}`)
+
+	out := promoteDefaultCacheControlTTL(payload, "1h")
+
+	assertAllCacheControlTTLs(t, out, "1h")
+}
+
+func TestPromoteDefaultCacheControlTTL_LeavesMalformedAndForeignBlocksUntouched(t *testing.T) {
+	payload := []byte(`{"tools":[{"name":"t1","cache_control":"ephemeral"},{"name":"t2","cache_control":["ephemeral"]},{"name":"t3","cache_control":{"type":"persistent"}},{"name":"t4","cache_control":{"type":123}}],"system":[{"type":"text","text":"s1","cache_control":{"type":"ephemeral","ttl":"30m"}},{"type":"text","text":"s2","cache_control":{"type":"ephemeral","ttl":300}}],"messages":[{"role":"user","content":"plain string content"}]}`)
+
+	out := promoteDefaultCacheControlTTL(payload, "1h")
+
+	if !bytes.Equal(out, payload) {
+		t.Fatalf("promoteDefaultCacheControlTTL altered malformed or foreign cache_control values.\noriginal: %s\ngot:      %s", payload, out)
+	}
+}
+
+func TestPromoteDefaultCacheControlTTL_DisabledTTLKeepsPayloadByteIdentical(t *testing.T) {
+	payload := []byte(`{"tools":[{"name":"t1","cache_control":{"type":"ephemeral"}}],"system":[{"type":"text","text":"<system-reminder>foo & bar</system-reminder>","cache_control":{"type":"ephemeral"}}],"messages":[{"role":"user","content":[{"type":"text","text":"u1","cache_control":{"type":"ephemeral"}}]}]}`)
+
+	out := promoteDefaultCacheControlTTL(payload, "")
+
+	if !bytes.Equal(out, payload) {
+		t.Fatalf("disabled promotion must keep the payload byte-identical.\noriginal: %s\ngot:      %s", payload, out)
+	}
+}
+
+func TestPromoteDefaultCacheControlTTL_NormalizeKeepsPromotedBlocks(t *testing.T) {
+	payload := []byte(`{
+		"tools": [{"name":"t1","cache_control":{"type":"ephemeral"}}],
+		"system": [{"type":"text","text":"s1","cache_control":{"type":"ephemeral"}}],
+		"messages": [{"role":"user","content":[{"type":"text","text":"u1","cache_control":{"type":"ephemeral","ttl":"1h"}}]}]
+	}`)
+
+	promoted := promoteDefaultCacheControlTTL(payload, "1h")
+	out := normalizeCacheControlTTL(promoted)
+
+	// Without promotion the leading default blocks would force the trailing 1h block
+	// to be downgraded; after promotion the ordering constraint is already satisfied.
+	assertAllCacheControlTTLs(t, out, "1h")
+	if !bytes.Equal(out, promoted) {
+		t.Fatalf("normalizeCacheControlTTL downgraded promoted blocks.\npromoted: %s\ngot:      %s", promoted, out)
+	}
+}
+
+func TestPromoteDefaultCacheControlTTL_NormalizeStillRepairsOrderingAfterMalformedBlock(t *testing.T) {
+	payload := []byte(`{
+		"tools": [{"name":"t1","cache_control":"ephemeral"}],
+		"system": [{"type":"text","text":"s1","cache_control":{"type":"ephemeral"}}]
+	}`)
+
+	out := normalizeCacheControlTTL(promoteDefaultCacheControlTTL(payload, "1h"))
+
+	if got := gjson.GetBytes(out, "tools.0.cache_control").String(); got != "ephemeral" {
+		t.Fatalf("malformed tools.0.cache_control = %q, want it untouched", got)
+	}
+	if gjson.GetBytes(out, "system.0.cache_control.ttl").Exists() {
+		t.Fatalf("system.0.cache_control.ttl must be stripped after a malformed 5m-equivalent block: %s", string(out))
+	}
+}
+
+func TestPromoteDefaultCacheControlTTL_AfterEnforceLimitKeepsMaxFourBreakpoints(t *testing.T) {
+	payload := []byte(`{
+		"tools": [
+			{"name":"t1","cache_control":{"type":"ephemeral"}},
+			{"name":"t2","cache_control":{"type":"ephemeral"}}
+		],
+		"system": [
+			{"type":"text","text":"s1","cache_control":{"type":"ephemeral"}},
+			{"type":"text","text":"s2","cache_control":{"type":"ephemeral"}}
+		],
+		"messages": [
+			{"role":"user","content":[{"type":"text","text":"u1","cache_control":{"type":"ephemeral"}}]},
+			{"role":"user","content":[{"type":"text","text":"u2","cache_control":{"type":"ephemeral"}}]}
+		]
+	}`)
+
+	limited := enforceCacheControlLimit(payload, 4)
+	if got := countCacheControls(limited); got != 4 {
+		t.Fatalf("cache_control count after enforce = %d, want 4", got)
+	}
+
+	out := promoteDefaultCacheControlTTL(limited, "1h")
+
+	if got := countCacheControls(out); got != 4 {
+		t.Fatalf("cache_control count after promotion = %d, want 4", got)
+	}
+	assertAllCacheControlTTLs(t, out, "1h")
+}
+
+func TestClaudeCacheControlDefaultTTL_ResolvesSupportedValuesOnly(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *config.Config
+		want string
+	}{
+		{name: "nil config", cfg: nil, want: ""},
+		{name: "unset", cfg: &config.Config{}, want: ""},
+		{name: "one hour", cfg: &config.Config{CacheControlDefaultTTL: "1h"}, want: "1h"},
+		{name: "five minutes", cfg: &config.Config{CacheControlDefaultTTL: "5m"}, want: "5m"},
+		{name: "padded and uppercase", cfg: &config.Config{CacheControlDefaultTTL: "  1H "}, want: "1h"},
+		{name: "unsupported duration", cfg: &config.Config{CacheControlDefaultTTL: "2h"}, want: ""},
+		{name: "garbage", cfg: &config.Config{CacheControlDefaultTTL: "yes"}, want: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := claudeCacheControlDefaultTTL(tc.cfg); got != tc.want {
+				t.Fatalf("claudeCacheControlDefaultTTL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClaudeExecutor_ExecutePromotesCacheControlTTL(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-3-5-sonnet","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{CacheControlDefaultTTL: "1h"})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(seenBody) == 0 {
+		t.Fatal("expected request body to be captured")
+	}
+	if got := countCacheControls(seenBody); got > 4 {
+		t.Fatalf("cache_control count = %d, want <= 4", got)
+	}
+	assertAllCacheControlTTLs(t, seenBody, "1h")
+}
+
+func TestClaudeExecutor_ExecuteStreamPromotesCacheControlTTL(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{CacheControlDefaultTTL: "1h"})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected chunk error: %v", chunk.Err)
+		}
+	}
+	if len(seenBody) == 0 {
+		t.Fatal("expected request body to be captured")
+	}
+	if got := countCacheControls(seenBody); got > 4 {
+		t.Fatalf("cache_control count = %d, want <= 4", got)
+	}
+	assertAllCacheControlTTLs(t, seenBody, "1h")
+}
+
+func TestClaudeExecutor_CountTokensUpstreamPromotesCacheControlTTL(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"input_tokens":7}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{CacheControlDefaultTTL: "1h"})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"tools":[{"name":"t1","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral"}}],"messages":[{"role":"user","content":[{"type":"text","text":"hi","cache_control":{"type":"ephemeral"}}]}]}`)
+
+	_, err := executor.countTokensUpstream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("countTokensUpstream() error = %v", err)
+	}
+	if len(seenBody) == 0 {
+		t.Fatal("expected request body to be captured")
+	}
+	if got := countCacheControls(seenBody); got > 4 {
+		t.Fatalf("cache_control count = %d, want <= 4", got)
+	}
+	assertAllCacheControlTTLs(t, seenBody, "1h")
+}
+
+func TestClaudeExecutor_ExecuteWithoutCacheControlDefaultTTLKeepsDefaultBreakpoints(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-3-5-sonnet","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(seenBody) == 0 {
+		t.Fatal("expected request body to be captured")
+	}
+	assertAllCacheControlTTLs(t, seenBody, "")
+}
+
+func TestClaudeExecutor_CCHSigningCoversPromotedCacheControlTTL(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-3-5-sonnet","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{
+		CacheControlDefaultTTL: "1h",
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey:                 "key-123",
+			BaseURL:                server.URL,
+			ExperimentalCCHSigning: true,
+		}},
+	})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(seenBody) == 0 {
+		t.Fatal("expected request body to be captured")
+	}
+	assertAllCacheControlTTLs(t, seenBody, "1h")
+
+	billingPattern := regexp.MustCompile(`(x-anthropic-billing-header:[^"]*?\bcch=)([0-9a-f]{5})(;)`)
+	match := billingPattern.FindSubmatch(seenBody)
+	if match == nil {
+		t.Fatalf("expected signed billing header in body: %s", string(seenBody))
+	}
+	actualCCH := string(match[2])
+	unsignedBody := billingPattern.ReplaceAll(seenBody, []byte(`${1}00000${3}`))
+	wantCCH := fmt.Sprintf("%05x", xxHash64.Checksum(unsignedBody, claudeCCHSeed)&0xFFFFF)
+	if actualCCH != wantCCH {
+		t.Fatalf("cch = %q, want %q — signature must cover the promoted cache_control TTL\nbody: %s", actualCCH, wantCCH, string(seenBody))
+	}
+}

--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -592,6 +592,107 @@ func normalizeCacheControlTTL(payload []byte) []byte {
 	return payload
 }
 
+// claudeCacheControlDefaultTTL resolves the configured default cache_control TTL.
+//
+// An empty string means the promotion step is disabled and request bodies are left
+// byte-identical. Unsupported values are ignored (the feature stays disabled) instead
+// of being forwarded upstream, mirroring how other optional string settings degrade to
+// their safe default.
+func claudeCacheControlDefaultTTL(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	switch strings.ToLower(strings.TrimSpace(cfg.CacheControlDefaultTTL)) {
+	case "5m":
+		return "5m"
+	case "1h":
+		return "1h"
+	default:
+		return ""
+	}
+}
+
+// promoteDefaultCacheControlTTL rewrites default ephemeral cache_control blocks so they
+// use the requested TTL, walking the Anthropic evaluation order: tools → system → messages.
+//
+// A block is eligible when cache_control is an object with "type": "ephemeral" and its
+// ttl is either missing or "5m" (the implicit default). Malformed cache_control values,
+// other block types, and explicit TTLs the proxy does not own are left untouched, and no
+// breakpoint is ever added or removed — enforceCacheControlLimit stays the single
+// authority for the max-4 constraint.
+//
+// It must run after enforceCacheControlLimit and before normalizeCacheControlTTL so the
+// ordering constraint of prompt-caching-scope-2026-01-05 is still applied to the promoted
+// blocks, and before CCH signing so the signature covers the final body.
+func promoteDefaultCacheControlTTL(payload []byte, ttl string) []byte {
+	if ttl == "" || len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return payload
+	}
+
+	original := payload
+	modified := false
+
+	processBlock := func(path string, obj gjson.Result) {
+		cc := obj.Get("cache_control")
+		if !cc.Exists() || !cc.IsObject() {
+			return
+		}
+		blockType := cc.Get("type")
+		if blockType.Type != gjson.String || blockType.String() != "ephemeral" {
+			return
+		}
+		current := cc.Get("ttl")
+		if current.Exists() && (current.Type != gjson.String || current.String() != "5m") {
+			return
+		}
+		if current.Type == gjson.String && current.String() == ttl {
+			return
+		}
+		updated, errSet := sjson.SetBytes(payload, path+".cache_control.ttl", ttl)
+		if errSet != nil {
+			return
+		}
+		payload = updated
+		modified = true
+	}
+
+	tools := gjson.GetBytes(payload, "tools")
+	if tools.IsArray() {
+		tools.ForEach(func(idx, item gjson.Result) bool {
+			processBlock(fmt.Sprintf("tools.%d", int(idx.Int())), item)
+			return true
+		})
+	}
+
+	system := gjson.GetBytes(payload, "system")
+	if system.IsArray() {
+		system.ForEach(func(idx, item gjson.Result) bool {
+			processBlock(fmt.Sprintf("system.%d", int(idx.Int())), item)
+			return true
+		})
+	}
+
+	messages := gjson.GetBytes(payload, "messages")
+	if messages.IsArray() {
+		messages.ForEach(func(msgIdx, msg gjson.Result) bool {
+			content := msg.Get("content")
+			if !content.IsArray() {
+				return true
+			}
+			content.ForEach(func(itemIdx, item gjson.Result) bool {
+				processBlock(fmt.Sprintf("messages.%d.content.%d", int(msgIdx.Int()), int(itemIdx.Int())), item)
+				return true
+			})
+			return true
+		})
+	}
+
+	if !modified {
+		return original
+	}
+	return payload
+}
+
 // enforceCacheControlLimit removes excess cache_control blocks from a payload
 // so the total does not exceed the Anthropic API limit (currently 4).
 //

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -78,6 +78,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	// already sends multiple cache_control blocks.
 	body = enforceCacheControlLimit(body, 4)
 
+	// Promote default ephemeral breakpoints to the configured cache TTL (opt-in, no-op when unset).
+	body = promoteDefaultCacheControlTTL(body, claudeCacheControlDefaultTTL(e.cfg))
+
 	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
 	// A 1h-TTL block must not appear after a 5m-TTL block in evaluation order (tools→system→messages).
 	body = normalizeCacheControlTTL(body)

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -76,6 +76,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	// Enforce Anthropic's cache_control block limit (max 4 breakpoints per request).
 	body = enforceCacheControlLimit(body, 4)
 
+	// Promote default ephemeral breakpoints to the configured cache TTL (opt-in, no-op when unset).
+	body = promoteDefaultCacheControlTTL(body, claudeCacheControlDefaultTTL(e.cfg))
+
 	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
 	body = normalizeCacheControlTTL(body)
 

--- a/internal/runtime/executor/claude_executor_tokens.go
+++ b/internal/runtime/executor/claude_executor_tokens.go
@@ -133,6 +133,7 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 
 	// Keep count_tokens requests compatible with Anthropic cache-control constraints too.
 	body = enforceCacheControlLimit(body, 4)
+	body = promoteDefaultCacheControlTTL(body, claudeCacheControlDefaultTTL(e.cfg))
 	body = normalizeCacheControlTTL(body)
 
 	// Extract betas from body and convert to header (for count_tokens too)

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -54,6 +54,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.DisableClaudeCloakMode != newCfg.DisableClaudeCloakMode {
 		changes = append(changes, fmt.Sprintf("disable-claude-cloak-mode: %t -> %t", oldCfg.DisableClaudeCloakMode, newCfg.DisableClaudeCloakMode))
 	}
+	if strings.TrimSpace(oldCfg.CacheControlDefaultTTL) != strings.TrimSpace(newCfg.CacheControlDefaultTTL) {
+		changes = append(changes, fmt.Sprintf("cache-control-default-ttl: %s -> %s", strings.TrimSpace(oldCfg.CacheControlDefaultTTL), strings.TrimSpace(newCfg.CacheControlDefaultTTL)))
+	}
 	if oldCfg.ClaudeCode.DisableCloakingModelList != newCfg.ClaudeCode.DisableCloakingModelList {
 		changes = append(changes, fmt.Sprintf("claude-code.disable-cloaking-model-list: %t -> %t", oldCfg.ClaudeCode.DisableCloakingModelList, newCfg.ClaudeCode.DisableCloakingModelList))
 	}

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -136,6 +136,18 @@ func TestBuildConfigChangeDetails_CodexLiveMediaRelay(t *testing.T) {
 	}
 }
 
+func TestBuildConfigChangeDetails_CacheControlDefaultTTL(t *testing.T) {
+	oldCfg := &config.Config{}
+	newCfg := &config.Config{CacheControlDefaultTTL: "1h"}
+
+	details := BuildConfigChangeDetails(oldCfg, newCfg)
+	expectContains(t, details, "cache-control-default-ttl:  -> 1h")
+
+	if changed := BuildConfigChangeDetails(newCfg, newCfg); len(changed) != 0 {
+		t.Fatalf("expected no change entries for identical configs, got %v", changed)
+	}
+}
+
 func TestBuildConfigChangeDetails_GeminiVertexHeaders(t *testing.T) {
 	oldCfg := &config.Config{
 		GeminiKey: []config.GeminiKey{


### PR DESCRIPTION
## Summary

Adds an opt-in global option, `cache-control-default-ttl`, that promotes default
Anthropic prompt-cache breakpoints on Claude requests to an explicit TTL before the
body is sent upstream. The default (unset) keeps every request byte-identical to
today's behavior.

Closes #3398

## Motivation

Per #3398, the proxy already injects and repairs `cache_control` breakpoints, but both
the injected blocks and the bare `{"type": "ephemeral"}` blocks that clients send carry
no `ttl`, so they land on Anthropic's default 5-minute cache path. For long-lived,
stable prefixes (tool definitions and system prompts) that means the prefix keeps
expiring between turns and gets re-written on every cache miss, which costs cache-write
tokens repeatedly instead of amortizing one write over a longer window.

There is a second, sharper effect that #3398 calls out: `normalizeCacheControlTTL()`
treats any default block as a 5m anchor, so a single bare block early in evaluation
order (tools -> system -> messages) downgrades every later `ttl: "1h"` block a client
did ask for. The extended 1h cache TTL is generally available and needs no beta header,
so there is no reason a proxy-repaired request has to stay on the 5m path.

## Implementation

- New helper `promoteDefaultCacheControlTTL(payload []byte, ttl string) []byte` walks
  the Anthropic evaluation order (tools -> system -> messages).
- Promotion predicate, exactly as proposed in #3398: `cache_control` must be an object
  with `"type": "ephemeral"` and a `ttl` that is either absent or `"5m"`. Malformed or
  non-object `cache_control` values, other block types, and any other explicit TTL are
  left untouched. No breakpoint is ever added or removed - `enforceCacheControlLimit`
  remains the single authority for the max-4 constraint.
- Pipeline position in all three Claude request paths:
  `ensureCacheControl` -> `enforceCacheControlLimit(body, 4)` -> **promote** ->
  `normalizeCacheControlTTL` -> CCH signing. Running before normalization keeps the
  prompt-caching-scope-2026-01-05 ordering repair authoritative; running before signing
  keeps the CCH fingerprint over the final mutated body.
- All three paths that mutate a Claude request body independently are wired: streaming
  (`ExecuteStream`), non-streaming (`Execute`), and the upstream count-tokens path
  (`countTokensUpstream`).
- Config: global string field `cache-control-default-ttl`. Supported values are `"5m"`
  and `"1h"`; unset disables the feature. Unsupported values are ignored and keep the
  feature disabled, matching how other optional string settings in this repo degrade to
  their safe default at the consumption site (for example `gpt-image-2-base-model` and
  `video-result-auth-cache-ttl`). The option is also surfaced in the hot-reload config
  change log and documented in `config.example.yaml` (commented out by default).

## Testing

New tests in `internal/runtime/executor/claude_cache_control_ttl_test.go`:

- bare `cache_control` blocks across tools + system + messages are all promoted, and the
  breakpoint count is unchanged;
- breakpoints injected by `ensureCacheControl` are promoted;
- blocks that already carry `ttl: "1h"` are left byte-identical;
- explicit `ttl: "5m"` blocks are promoted;
- malformed / non-object `cache_control`, non-ephemeral types, non-string `ttl`, and
  foreign TTLs such as `"30m"` are left byte-identical;
- with the option unset, the payload is byte-identical (zero behavior change);
- promote -> `normalizeCacheControlTTL` produces no downgrade (ordering compatibility),
  while ordering repair still wins when a malformed 5m-equivalent block precedes a
  promoted block;
- `enforceCacheControlLimit(body, 4)` -> promote still yields exactly 4 breakpoints;
- config resolution accepts only `""`, `"5m"`, `"1h"` (trim/case tolerant) and rejects
  values like `"2h"`;
- end-to-end executor tests for the stream, non-stream, and count-tokens paths assert
  the upstream body carries the promoted TTL and stays within 4 breakpoints;
- an end-to-end test asserts the CCH signature verifies against the final body after
  promotion, i.e. signing happens after all cache-control mutation.

Also added a `BuildConfigChangeDetails` case for the new option.

Commands run: `go build ./...`, `go vet` and `go test` for
`internal/runtime/executor`, `internal/config`, and `internal/watcher/diff`.

## Backward compatibility

`cache-control-default-ttl` defaults to the empty string, in which case
`promoteDefaultCacheControlTTL` returns the original byte slice and the request body is
unchanged - no new field, no reordered keys, and therefore no change to CCH signatures
for existing deployments. The max-4 limit and the TTL ordering normalization keep their
current semantics whether or not the option is set.

## Relation to #2533

This is deliberately a single feature with a global-only configuration surface. It does
not add per-credential overrides, which is where the earlier attempt in #2533 stalled on
tri-state override correctness; per-credential scoping can be layered on later if
maintainers want it.