### PR TITLE
feat: stage exact Codex reauthentication

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -25,13 +25,16 @@ import (
 var lastRefreshKeys = []string{"last_refresh", "lastRefresh", "last_refreshed_at", "lastRefreshedAt"}
 
 var (
-	callbackForwardersMu  sync.Mutex
-	callbackForwarders    = make(map[int]*callbackForwarder)
-	authFileEntryMu       sync.Mutex
-	errAuthFileMustBeJSON = errors.New("auth file must be .json")
-	errAuthFileNotFound   = errors.New("auth file not found")
-	errPluginVirtualAuth  = errors.New("plugin virtual auth cannot be modified directly; edit or delete the source auth file")
-	newCodexOAuthService  = func(cfg *config.Config) codexOAuthService { return codex.NewCodexAuth(cfg) }
+	callbackForwardersMu          sync.Mutex
+	callbackForwarders            = make(map[int]*callbackForwarder)
+	authFileEntryMu               sync.Mutex
+	errAuthFileMustBeJSON         = errors.New("auth file must be .json")
+	errAuthFileNotFound           = errors.New("auth file not found")
+	errPluginVirtualAuth          = errors.New("plugin virtual auth cannot be modified directly; edit or delete the source auth file")
+	newCodexOAuthService          = func(cfg *config.Config) codexOAuthService { return codex.NewCodexAuth(cfg) }
+	newCodexOAuthServiceWithProxy = func(cfg *config.Config, proxyURL string) codexOAuthService {
+		return codex.NewCodexAuthWithProxyURL(cfg, proxyURL)
+	}
 )
 
 func extractLastRefreshTimestamp(meta map[string]any) (time.Time, bool) {

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -374,6 +374,11 @@ func (h *Handler) buildAuthFileEntryLocked(auth *coreauth.Auth) gin.H {
 		if info, err := os.Stat(path); err == nil {
 			entry["size"] = info.Size()
 			entry["modtime"] = info.ModTime()
+			if strings.EqualFold(auth.Provider, "codex") && (auth.Disabled || auth.Status == coreauth.StatusDisabled) {
+				if raw, errRead := readBoundedCredential(path); errRead == nil {
+					entry["generation"] = credentialGeneration(raw)
+				}
+			}
 		} else if os.IsNotExist(err) {
 			// Hide credentials removed from disk but still lingering in memory.
 			if !runtimeOnly && (auth.Disabled || auth.Status == coreauth.StatusDisabled || strings.EqualFold(strings.TrimSpace(auth.StatusMessage), "removed via management api")) {

--- a/internal/api/handlers/management/auth_files_crud.go
+++ b/internal/api/handlers/management/auth_files_crud.go
@@ -167,6 +167,7 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 				}
 				deleted++
 				h.removeAuth(ctx, full)
+				h.codexReauthStages.removeTarget(name)
 			}
 		}
 		c.JSON(200, gin.H{"status": "ok", "deleted": deleted})
@@ -375,6 +376,7 @@ func (h *Handler) deleteAuthFileByName(ctx context.Context, name string) (string
 		return filepath.Base(name), http.StatusInternalServerError, errDeleteRecord
 	}
 	h.removeAuthsForPath(ctx, targetPath, targetID)
+	h.codexReauthStages.removeTarget(filepath.Base(name))
 	return filepath.Base(name), http.StatusOK, nil
 }
 

--- a/internal/api/handlers/management/auth_files_crud.go
+++ b/internal/api/handlers/management/auth_files_crud.go
@@ -49,6 +49,8 @@ func (h *Handler) DownloadAuthFile(c *gin.Context) {
 
 // Upload auth file: multipart or raw JSON with ?name=
 func (h *Handler) UploadAuthFile(c *gin.Context) {
+	h.authMutationMu.Lock()
+	defer h.authMutationMu.Unlock()
 	if h.authManager == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
 		return
@@ -130,6 +132,8 @@ func (h *Handler) UploadAuthFile(c *gin.Context) {
 
 // Delete auth files: single by name or all
 func (h *Handler) DeleteAuthFile(c *gin.Context) {
+	h.authMutationMu.Lock()
+	defer h.authMutationMu.Unlock()
 	if h.authManager == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
 		return

--- a/internal/api/handlers/management/auth_files_fields.go
+++ b/internal/api/handlers/management/auth_files_fields.go
@@ -22,6 +22,8 @@ import (
 
 // PatchAuthFileStatus toggles the disabled state of an auth file
 func (h *Handler) PatchAuthFileStatus(c *gin.Context) {
+	h.authMutationMu.Lock()
+	defer h.authMutationMu.Unlock()
 	if h.authManager == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
 		return
@@ -201,6 +203,8 @@ func applyAuthDisabledState(auth *coreauth.Auth, disabled bool) {
 
 // PatchAuthFileFields updates arbitrary metadata fields of an auth file.
 func (h *Handler) PatchAuthFileFields(c *gin.Context) {
+	h.authMutationMu.Lock()
+	defer h.authMutationMu.Unlock()
 	if h.authManager == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
 		return
@@ -696,6 +700,8 @@ func (h *Handler) tokenStoreWithBaseDir() coreauth.Store {
 }
 
 func (h *Handler) saveTokenRecord(ctx context.Context, record *coreauth.Auth) (string, error) {
+	h.authMutationMu.Lock()
+	defer h.authMutationMu.Unlock()
 	if record == nil {
 		return "", fmt.Errorf("token record is nil")
 	}

--- a/internal/api/handlers/management/auth_files_provider_oauth.go
+++ b/internal/api/handlers/management/auth_files_provider_oauth.go
@@ -309,12 +309,17 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 		}
 
 		if reauthTarget != nil {
+			if errGuard := guardOAuthSessionPendingForSave(state, "codex"); errGuard != nil {
+				return
+			}
 			handle, errStage := h.stageCodexReauthCandidate(*reauthTarget, bundle)
 			if errStage != nil {
 				SetOAuthSessionError(state, "Failed to stage replacement credentials")
 				return
 			}
-			completeOAuthSessionWithResult(state, handle)
+			if !completeOAuthSessionWithResult(state, handle) {
+				h.codexReauthStages.discard(handle)
+			}
 			return
 		}
 

--- a/internal/api/handlers/management/auth_files_provider_oauth.go
+++ b/internal/api/handlers/management/auth_files_provider_oauth.go
@@ -213,6 +213,9 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 
 	// Initialize Codex auth service
 	openaiAuth := newCodexOAuthService(h.cfg)
+	if reauthTarget != nil {
+		openaiAuth = newCodexOAuthServiceWithProxy(h.cfg, reauthTarget.ProxyURL)
+	}
 
 	// Generate authorization URL
 	authURL, err := openaiAuth.GenerateAuthURL(state, pkceCodes)

--- a/internal/api/handlers/management/auth_files_provider_oauth.go
+++ b/internal/api/handlers/management/auth_files_provider_oauth.go
@@ -183,6 +183,15 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 func (h *Handler) RequestCodexToken(c *gin.Context) {
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
+	var reauthTarget *codexReauthTarget
+	if c.Request.Method == http.MethodPost {
+		target, errTarget := h.parseCodexReauthTarget(c)
+		if errTarget != nil {
+			writeCodexReauthError(c, errTarget)
+			return
+		}
+		reauthTarget = &target
+	}
 
 	fmt.Println("Initializing Codex authentication...")
 
@@ -213,7 +222,11 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 		return
 	}
 
-	RegisterOAuthSession(state, "codex")
+	if reauthTarget == nil {
+		RegisterOAuthSession(state, "codex")
+	} else {
+		registerOAuthSessionWithMetadata(state, "codex", map[string]any{"mode": "reauth"})
+	}
 
 	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
@@ -293,6 +306,16 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 				digest := sha256.Sum256([]byte(accountID))
 				hashAccountID = hex.EncodeToString(digest[:])[:8]
 			}
+		}
+
+		if reauthTarget != nil {
+			handle, errStage := h.stageCodexReauthCandidate(*reauthTarget, bundle)
+			if errStage != nil {
+				SetOAuthSessionError(state, "Failed to stage replacement credentials")
+				return
+			}
+			completeOAuthSessionWithResult(state, handle)
+			return
 		}
 
 		// Create token storage and persist
@@ -758,7 +781,12 @@ func (h *Handler) GetAuthStatus(c *gin.Context) {
 		return
 	}
 	if completed {
-		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		session, _ := oauthSessions.Get(state)
+		response := gin.H{"status": "ok"}
+		if session.Result != "" {
+			response["stage_handle"] = session.Result
+		}
+		c.JSON(http.StatusOK, response)
 		return
 	}
 	if status != "" {

--- a/internal/api/handlers/management/codex_reauth.go
+++ b/internal/api/handlers/management/codex_reauth.go
@@ -1,0 +1,455 @@
+package management
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/synthesizer"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+const (
+	maxCodexCredentialBytes = 1 << 20
+	codexReauthStageTTL     = 10 * time.Minute
+)
+
+var (
+	errCodexReauthBadRequest = errors.New("invalid reauth request")
+	errCodexReauthNotFound   = errors.New("reauth target not found")
+	errCodexReauthConflict   = errors.New("reauth target changed")
+)
+
+type codexReauthTarget struct {
+	AuthID     string
+	AuthIndex  string
+	FileName   string
+	Path       string
+	Generation string
+	Subject    string
+}
+
+type codexReauthStage struct {
+	Target    codexReauthTarget
+	Path      string
+	ExpiresAt time.Time
+}
+
+type codexReauthStageStore struct {
+	mu     sync.Mutex
+	dir    string
+	stages map[string]codexReauthStage
+}
+
+func newCodexReauthStageStore(cfg *config.Config) *codexReauthStageStore {
+	authDir := ""
+	if cfg != nil {
+		authDir = strings.TrimSpace(cfg.AuthDir)
+	}
+	dir := ""
+	if authDir != "" {
+		dir = filepath.Join(filepath.Dir(authDir), "."+filepath.Base(authDir)+"-codex-reauth")
+	}
+	store := &codexReauthStageStore{dir: dir, stages: make(map[string]codexReauthStage)}
+	store.clearStaleFiles()
+	return store
+}
+
+func (s *codexReauthStageStore) clearStaleFiles() {
+	if s == nil || s.dir == "" {
+		return
+	}
+	info, err := os.Lstat(s.dir)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return
+	}
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.Type().IsRegular() {
+			_ = os.Remove(filepath.Join(s.dir, entry.Name()))
+		}
+	}
+}
+
+func (s *codexReauthStageStore) put(stage codexReauthStage, raw []byte) (string, error) {
+	if s == nil || s.dir == "" {
+		return "", fmt.Errorf("reauth staging unavailable")
+	}
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return "", fmt.Errorf("create reauth staging directory: %w", err)
+	}
+	info, err := os.Lstat(s.dir)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("unsafe reauth staging directory")
+	}
+	if err := os.Chmod(s.dir, 0o700); err != nil {
+		return "", fmt.Errorf("secure reauth staging directory: %w", err)
+	}
+	handle, err := randomHex(32)
+	if err != nil {
+		return "", err
+	}
+	stage.Path = filepath.Join(s.dir, handle)
+	stage.ExpiresAt = time.Now().Add(codexReauthStageTTL)
+	file, err := os.OpenFile(stage.Path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("create staged replacement")
+	}
+	if _, err = file.Write(raw); err == nil {
+		err = file.Sync()
+	}
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		_ = os.Remove(stage.Path)
+		return "", fmt.Errorf("write staged replacement")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.purgeLocked(time.Now())
+	s.stages[handle] = stage
+	time.AfterFunc(codexReauthStageTTL, func() { s.expire(handle) })
+	return handle, nil
+}
+
+func (s *codexReauthStageStore) expire(handle string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	stage, ok := s.stages[handle]
+	if ok && time.Now().After(stage.ExpiresAt) {
+		_ = os.Remove(stage.Path)
+		delete(s.stages, handle)
+	}
+}
+
+func (s *codexReauthStageStore) take(handle string) (codexReauthStage, bool) {
+	if s == nil {
+		return codexReauthStage{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.purgeLocked(time.Now())
+	stage, ok := s.stages[strings.TrimSpace(handle)]
+	if ok {
+		delete(s.stages, strings.TrimSpace(handle))
+	}
+	return stage, ok
+}
+
+func (s *codexReauthStageStore) purgeLocked(now time.Time) {
+	for handle, stage := range s.stages {
+		if now.After(stage.ExpiresAt) {
+			_ = os.Remove(stage.Path)
+			delete(s.stages, handle)
+		}
+	}
+}
+
+func randomHex(bytesCount int) (string, error) {
+	raw := make([]byte, bytesCount)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate reauth handle: %w", err)
+	}
+	return hex.EncodeToString(raw), nil
+}
+
+func credentialGeneration(raw []byte) string {
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+func readBoundedCredential(path string) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > maxCodexCredentialBytes {
+		return nil, fmt.Errorf("unsafe credential file")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	opened, err := f.Stat()
+	if err != nil || !opened.Mode().IsRegular() || !os.SameFile(info, opened) {
+		return nil, fmt.Errorf("unsafe credential file")
+	}
+	raw, err := io.ReadAll(io.LimitReader(f, maxCodexCredentialBytes+1))
+	if err != nil || len(raw) == 0 || len(raw) > maxCodexCredentialBytes {
+		return nil, fmt.Errorf("read bounded credential")
+	}
+	return raw, nil
+}
+
+func (h *Handler) parseCodexReauthTarget(c *gin.Context) (codexReauthTarget, error) {
+	if h == nil || h.authManager == nil || h.cfg == nil || strings.TrimSpace(h.cfg.AuthDir) == "" {
+		return codexReauthTarget{}, errCodexReauthNotFound
+	}
+	var req struct {
+		AuthIndex  string `json:"auth_index"`
+		Generation string `json:"generation"`
+	}
+	decoder := json.NewDecoder(io.LimitReader(c.Request.Body, 4097))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil || decoder.Decode(&struct{}{}) != io.EOF {
+		return codexReauthTarget{}, errCodexReauthBadRequest
+	}
+	req.AuthIndex = strings.TrimSpace(req.AuthIndex)
+	req.Generation = strings.TrimSpace(req.Generation)
+	if req.AuthIndex == "" || len(req.Generation) != sha256.Size*2 {
+		return codexReauthTarget{}, errCodexReauthBadRequest
+	}
+	var target *coreauth.Auth
+	for _, auth := range h.authManager.List() {
+		if auth != nil && lockedAuthIndex(auth) == req.AuthIndex {
+			if target != nil {
+				return codexReauthTarget{}, errCodexReauthConflict
+			}
+			target = auth
+		}
+	}
+	if target == nil {
+		return codexReauthTarget{}, errCodexReauthNotFound
+	}
+	if !strings.EqualFold(target.Provider, "codex") || (!target.Disabled && target.Status != coreauth.StatusDisabled) || isRuntimeOnlyAuth(target) {
+		return codexReauthTarget{}, errCodexReauthConflict
+	}
+	path := strings.TrimSpace(authAttribute(target, coreauth.AttributePath))
+	authDir, err := filepath.Abs(strings.TrimSpace(h.cfg.AuthDir))
+	targetPath, errPath := filepath.Abs(path)
+	rel, errRel := filepath.Rel(authDir, targetPath)
+	if err != nil || errPath != nil || errRel != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return codexReauthTarget{}, errCodexReauthConflict
+	}
+	path = targetPath
+	raw, err := readBoundedCredential(path)
+	if err != nil || credentialGeneration(raw) != req.Generation {
+		return codexReauthTarget{}, errCodexReauthConflict
+	}
+	var metadata map[string]any
+	if json.Unmarshal(raw, &metadata) != nil {
+		return codexReauthTarget{}, errCodexReauthConflict
+	}
+	subject, _ := metadata["account_id"].(string)
+	subject = strings.TrimSpace(subject)
+	name := strings.TrimSpace(target.FileName)
+	if name == "" {
+		name = filepath.Base(path)
+	}
+	if subject == "" || filepath.Base(path) != name {
+		return codexReauthTarget{}, errCodexReauthConflict
+	}
+	return codexReauthTarget{AuthID: target.ID, AuthIndex: req.AuthIndex, FileName: name, Path: path, Generation: req.Generation, Subject: subject}, nil
+}
+
+func writeCodexReauthError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, errCodexReauthNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": "reauth target not found"})
+	case errors.Is(err, errCodexReauthConflict):
+		c.JSON(http.StatusConflict, gin.H{"error": "reauth target changed"})
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid reauth request"})
+	}
+}
+
+func (h *Handler) stageCodexReauthCandidate(target codexReauthTarget, bundle *codex.CodexAuthBundle) (string, error) {
+	if bundle == nil {
+		return "", fmt.Errorf("missing replacement credentials")
+	}
+	storage := newCodexOAuthService(h.cfg).CreateTokenStorage(bundle)
+	if storage == nil || strings.TrimSpace(storage.AccountID) != target.Subject {
+		return "", fmt.Errorf("replacement subject mismatch")
+	}
+	digest := sha256.Sum256([]byte(storage.AccountID))
+	plan := ""
+	if claims, _ := codex.ParseJWTToken(storage.IDToken); claims != nil {
+		plan = strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType)
+	}
+	name := codex.CredentialFileName(storage.Email, plan, hex.EncodeToString(digest[:])[:8], true)
+	if name != target.FileName || filepath.Base(target.Path) != target.FileName {
+		return "", fmt.Errorf("replacement filename mismatch")
+	}
+	for _, auth := range h.authManager.List() {
+		if auth == nil || auth.ID == target.AuthID {
+			continue
+		}
+		if subject, _ := auth.Metadata["account_id"].(string); strings.TrimSpace(subject) == target.Subject {
+			return "", fmt.Errorf("duplicate replacement subject")
+		}
+	}
+	current, err := readBoundedCredential(target.Path)
+	if err != nil || credentialGeneration(current) != target.Generation {
+		return "", fmt.Errorf("reauth target changed")
+	}
+	var retained map[string]any
+	if json.Unmarshal(current, &retained) != nil {
+		return "", fmt.Errorf("reauth target changed")
+	}
+	for _, key := range []string{"id_token", "access_token", "refresh_token", "account_id", "email", "expired", "last_refresh"} {
+		delete(retained, key)
+	}
+	candidate, err := misc.MergeMetadata(storage, nil)
+	if err != nil {
+		return "", fmt.Errorf("serialize replacement credentials")
+	}
+	for key, value := range candidate {
+		retained[key] = value
+	}
+	retained["disabled"] = true
+	retained["type"] = "codex"
+	data := retained
+	raw, err := json.Marshal(data)
+	if err != nil || len(raw) > maxCodexCredentialBytes {
+		return "", fmt.Errorf("serialize replacement credentials")
+	}
+	handle, err := h.codexReauthStages.put(codexReauthStage{Target: target}, raw)
+	if err != nil {
+		return "", err
+	}
+	return handle, nil
+}
+
+func (h *Handler) verifyCodexCandidate(ctx context.Context, auth *coreauth.Auth) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://chatgpt.com/backend-api/codex/models", nil)
+	if err != nil {
+		return err
+	}
+	accessToken, _ := auth.Metadata["access_token"].(string)
+	if strings.TrimSpace(accessToken) == "" {
+		return fmt.Errorf("provider verification failed")
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	if accountID, _ := auth.Metadata["account_id"].(string); accountID != "" {
+		req.Header.Set("Chatgpt-Account-Id", accountID)
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("provider verification failed")
+	}
+	return nil
+}
+
+func (h *Handler) AdoptCodexReauth(c *gin.Context) {
+	var req struct {
+		StageHandle string `json:"stage_handle"`
+	}
+	decoder := json.NewDecoder(io.LimitReader(c.Request.Body, 4097))
+	decoder.DisallowUnknownFields()
+	if decoder.Decode(&req) != nil || decoder.Decode(&struct{}{}) != io.EOF || strings.TrimSpace(req.StageHandle) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid reauth request"})
+		return
+	}
+	stage, ok := h.codexReauthStages.take(req.StageHandle)
+	if !ok {
+		c.JSON(http.StatusConflict, gin.H{"error": "reauth stage unavailable"})
+		return
+	}
+	defer os.Remove(stage.Path)
+	raw, err := readBoundedCredential(stage.Path)
+	if err != nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "reauth stage unavailable"})
+		return
+	}
+	auths, err := synthesizer.SynthesizeAuthFile(&synthesizer.SynthesisContext{Config: h.cfg, AuthDir: filepath.Dir(stage.Target.Path), Now: time.Now()}, stage.Target.Path, raw)
+	if err != nil || len(auths) != 1 {
+		c.JSON(http.StatusConflict, gin.H{"error": "replacement credential invalid"})
+		return
+	}
+	candidate := auths[0]
+	candidate.ID = stage.Target.AuthID
+	candidate.FileName = stage.Target.FileName
+	candidate.Index = stage.Target.AuthIndex
+	if !candidate.Disabled || !strings.EqualFold(candidate.Provider, "codex") || strings.TrimSpace(fmt.Sprint(candidate.Metadata["account_id"])) != stage.Target.Subject {
+		c.JSON(http.StatusConflict, gin.H{"error": "replacement credential invalid"})
+		return
+	}
+	verifyCtx, cancel := context.WithTimeout(c.Request.Context(), 20*time.Second)
+	err = h.verifyCodexReauth(verifyCtx, candidate)
+	cancel()
+	if err != nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "replacement credential verification failed"})
+		return
+	}
+
+	h.authMutationMu.Lock()
+	defer h.authMutationMu.Unlock()
+	target, ok := h.authManager.GetByID(stage.Target.AuthID)
+	current, err := readBoundedCredential(stage.Target.Path)
+	if !ok || err != nil || lockedAuthIndex(target) != stage.Target.AuthIndex || credentialGeneration(current) != stage.Target.Generation {
+		c.JSON(http.StatusConflict, gin.H{"error": "reauth target changed"})
+		return
+	}
+	for _, auth := range h.authManager.List() {
+		if auth != nil && auth.ID != target.ID && strings.TrimSpace(fmt.Sprint(auth.Metadata["account_id"])) == stage.Target.Subject {
+			c.JSON(http.StatusConflict, gin.H{"error": "duplicate replacement subject"})
+			return
+		}
+	}
+	if err := atomicCredentialReplace(stage.Target.Path, raw); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to adopt replacement credential"})
+		return
+	}
+	if _, err = h.authManager.Update(coreauth.WithSkipPersist(c.Request.Context()), candidate); err != nil {
+		_ = atomicCredentialReplace(stage.Target.Path, current)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to adopt replacement credential"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok", "auth_index": stage.Target.AuthIndex, "disabled": true})
+}
+
+func atomicCredentialReplace(path string, raw []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".codex-reauth-")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err = tmp.Chmod(0o600); err == nil {
+		_, err = io.Copy(tmp, bytes.NewReader(raw))
+	}
+	if err == nil {
+		err = tmp.Sync()
+	}
+	if closeErr := tmp.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	if err = os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	if directory, openErr := os.Open(dir); openErr == nil {
+		err = directory.Sync()
+		_ = directory.Close()
+	}
+	return err
+}

--- a/internal/api/handlers/management/codex_reauth.go
+++ b/internal/api/handlers/management/codex_reauth.go
@@ -22,6 +22,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/synthesizer"
+	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
@@ -144,17 +145,26 @@ func (s *codexReauthStageStore) expire(handle string) {
 }
 
 func (s *codexReauthStageStore) take(handle string) (codexReauthStage, bool) {
-	if s == nil {
+	handle = strings.TrimSpace(handle)
+	decoded, err := hex.DecodeString(handle)
+	if s == nil || err != nil || len(decoded) != 32 || hex.EncodeToString(decoded) != handle {
 		return codexReauthStage{}, false
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.purgeLocked(time.Now())
-	stage, ok := s.stages[strings.TrimSpace(handle)]
+	stage, ok := s.stages[handle]
 	if ok {
-		delete(s.stages, strings.TrimSpace(handle))
+		delete(s.stages, handle)
 	}
 	return stage, ok
+}
+
+func (s *codexReauthStageStore) discard(handle string) {
+	stage, ok := s.take(handle)
+	if ok {
+		_ = os.Remove(stage.Path)
+	}
 }
 
 func (s *codexReauthStageStore) removeTarget(fileName string) {
@@ -192,6 +202,19 @@ func randomHex(bytesCount int) (string, error) {
 func credentialGeneration(raw []byte) string {
 	sum := sha256.Sum256(raw)
 	return hex.EncodeToString(sum[:])
+}
+
+func credentialIdentityGeneration(raw []byte) (string, error) {
+	var document map[string]any
+	if json.Unmarshal(raw, &document) != nil {
+		return "", errCodexReauthConflict
+	}
+	delete(document, "disabled")
+	canonical, err := json.Marshal(document)
+	if err != nil {
+		return "", errCodexReauthConflict
+	}
+	return credentialGeneration(canonical), nil
 }
 
 func readBoundedCredential(path string) ([]byte, error) {
@@ -236,6 +259,9 @@ func (h *Handler) parseCodexReauthTarget(c *gin.Context) (codexReauthTarget, err
 	if req.AuthIndex == "" || len(req.Generation) != sha256.Size*2 {
 		return codexReauthTarget{}, errCodexReauthBadRequest
 	}
+	if _, ok := h.tokenStoreWithBaseDir().(*sdkAuth.FileTokenStore); !ok {
+		return codexReauthTarget{}, errCodexReauthConflict
+	}
 	var target *coreauth.Auth
 	for _, auth := range h.authManager.List() {
 		if auth != nil && lockedAuthIndex(auth) == req.AuthIndex {
@@ -254,11 +280,14 @@ func (h *Handler) parseCodexReauthTarget(c *gin.Context) (codexReauthTarget, err
 	path := strings.TrimSpace(authAttribute(target, coreauth.AttributePath))
 	authDir, err := filepath.Abs(strings.TrimSpace(h.cfg.AuthDir))
 	targetPath, errPath := filepath.Abs(path)
-	rel, errRel := filepath.Rel(authDir, targetPath)
-	if err != nil || errPath != nil || errRel != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	physicalAuthDir, errAuthPhysical := filepath.EvalSymlinks(authDir)
+	physicalTarget, errTargetPhysical := filepath.EvalSymlinks(targetPath)
+	rel, errRel := filepath.Rel(physicalAuthDir, physicalTarget)
+	if err != nil || errPath != nil || errAuthPhysical != nil || errTargetPhysical != nil || errRel != nil ||
+		rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return codexReauthTarget{}, errCodexReauthConflict
 	}
-	path = targetPath
+	path = physicalTarget
 	raw, err := readBoundedCredential(path)
 	if err != nil || credentialGeneration(raw) != req.Generation {
 		return codexReauthTarget{}, errCodexReauthConflict
@@ -304,7 +333,8 @@ func (h *Handler) stageCodexReauthCandidate(target codexReauthTarget, bundle *co
 		plan = strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType)
 	}
 	name := codex.CredentialFileName(storage.Email, plan, hex.EncodeToString(digest[:])[:8], true)
-	if name != target.FileName || filepath.Base(target.Path) != target.FileName {
+	legacyName := codex.CredentialFileName(storage.Email, plan, "", true)
+	if (name != target.FileName && legacyName != target.FileName) || filepath.Base(target.Path) != target.FileName {
 		return "", fmt.Errorf("replacement filename mismatch")
 	}
 	for _, auth := range h.authManager.List() {
@@ -378,7 +408,7 @@ func (h *Handler) AdoptCodexReauth(c *gin.Context) {
 	}
 	decoder := json.NewDecoder(io.LimitReader(c.Request.Body, 4097))
 	decoder.DisallowUnknownFields()
-	if decoder.Decode(&req) != nil || decoder.Decode(&struct{}{}) != io.EOF || strings.TrimSpace(req.StageHandle) == "" {
+	if h == nil || h.authManager == nil || h.codexReauthStages == nil || decoder.Decode(&req) != nil || decoder.Decode(&struct{}{}) != io.EOF || strings.TrimSpace(req.StageHandle) == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid reauth request"})
 		return
 	}
@@ -428,21 +458,27 @@ func (h *Handler) AdoptCodexReauth(c *gin.Context) {
 			return
 		}
 	}
-	if err := atomicCredentialReplace(stage.Target.Path, raw); err != nil {
+	if err := atomicCredentialReplace(stage.Target.Path, stage.Target.Generation, raw); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to adopt replacement credential"})
 		return
 	}
 	if err = h.updateCodexReauth(c.Request.Context(), candidate); err != nil {
-		_ = atomicCredentialReplace(stage.Target.Path, current)
+		_ = atomicCredentialReplace(stage.Target.Path, credentialGeneration(raw), current)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to adopt replacement credential"})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"status": "ok", "auth_index": stage.Target.AuthIndex, "disabled": true})
+	identityGeneration, err := credentialIdentityGeneration(raw)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to adopt replacement credential"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok", "auth_index": stage.Target.AuthIndex, "disabled": true, "generation": identityGeneration})
 }
 
 func (h *Handler) VerifyCodexReauth(c *gin.Context) {
 	var req struct {
-		AuthIndex string `json:"auth_index"`
+		AuthIndex  string `json:"auth_index"`
+		Generation string `json:"generation"`
 	}
 	decoder := json.NewDecoder(io.LimitReader(c.Request.Body, 4097))
 	decoder.DisallowUnknownFields()
@@ -451,6 +487,11 @@ func (h *Handler) VerifyCodexReauth(c *gin.Context) {
 		return
 	}
 	req.AuthIndex = strings.TrimSpace(req.AuthIndex)
+	req.Generation = strings.TrimSpace(req.Generation)
+	if h == nil || h.authManager == nil || len(req.Generation) != sha256.Size*2 {
+		c.JSON(http.StatusConflict, gin.H{"error": "reauth target changed"})
+		return
+	}
 	var target *coreauth.Auth
 	for _, auth := range h.authManager.List() {
 		if auth != nil && lockedAuthIndex(auth) == req.AuthIndex {
@@ -465,8 +506,15 @@ func (h *Handler) VerifyCodexReauth(c *gin.Context) {
 		c.JSON(http.StatusConflict, gin.H{"error": "reauth target changed"})
 		return
 	}
+	path := strings.TrimSpace(authAttribute(target, coreauth.AttributePath))
+	raw, err := readBoundedCredential(path)
+	identityGeneration, errIdentity := credentialIdentityGeneration(raw)
+	if err != nil || errIdentity != nil || identityGeneration != req.Generation {
+		c.JSON(http.StatusConflict, gin.H{"error": "reauth target changed"})
+		return
+	}
 	verifyCtx, cancel := context.WithTimeout(c.Request.Context(), 20*time.Second)
-	err := h.verifyCodexReauth(verifyCtx, target)
+	err = h.verifyCodexReauth(verifyCtx, target)
 	cancel()
 	if err != nil {
 		c.JSON(http.StatusConflict, gin.H{"error": "replacement credential verification failed"})
@@ -475,7 +523,7 @@ func (h *Handler) VerifyCodexReauth(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "auth_index": req.AuthIndex, "disabled": false})
 }
 
-func atomicCredentialReplace(path string, raw []byte) error {
+func atomicCredentialReplace(path, expectedGeneration string, raw []byte) error {
 	dir := filepath.Dir(path)
 	tmp, err := os.CreateTemp(dir, ".codex-reauth-")
 	if err != nil {
@@ -494,6 +542,10 @@ func atomicCredentialReplace(path string, raw []byte) error {
 	}
 	if err != nil {
 		return err
+	}
+	current, err := readBoundedCredential(path)
+	if err != nil || credentialGeneration(current) != expectedGeneration {
+		return errCodexReauthConflict
 	}
 	if err = os.Rename(tmpPath, path); err != nil {
 		return err

--- a/internal/api/handlers/management/codex_reauth.go
+++ b/internal/api/handlers/management/codex_reauth.go
@@ -45,6 +45,7 @@ type codexReauthTarget struct {
 	Path       string
 	Generation string
 	Subject    string
+	ProxyURL   string
 }
 
 type codexReauthStage struct {
@@ -175,7 +176,7 @@ func (s *codexReauthStageStore) removeTarget(fileName string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for handle, stage := range s.stages {
-		if stage.Target.FileName == fileName {
+		if filepath.Base(stage.Target.FileName) == fileName {
 			_ = os.Remove(stage.Path)
 			delete(s.stages, handle)
 		}
@@ -302,10 +303,10 @@ func (h *Handler) parseCodexReauthTarget(c *gin.Context) (codexReauthTarget, err
 	if name == "" {
 		name = filepath.Base(path)
 	}
-	if subject == "" || filepath.Base(path) != name {
+	if subject == "" || filepath.Base(path) != filepath.Base(name) {
 		return codexReauthTarget{}, errCodexReauthConflict
 	}
-	return codexReauthTarget{AuthID: target.ID, AuthIndex: req.AuthIndex, FileName: name, Path: path, Generation: req.Generation, Subject: subject}, nil
+	return codexReauthTarget{AuthID: target.ID, AuthIndex: req.AuthIndex, FileName: name, Path: path, Generation: req.Generation, Subject: subject, ProxyURL: target.ProxyURL}, nil
 }
 
 func writeCodexReauthError(c *gin.Context, err error) {
@@ -323,7 +324,7 @@ func (h *Handler) stageCodexReauthCandidate(target codexReauthTarget, bundle *co
 	if bundle == nil {
 		return "", fmt.Errorf("missing replacement credentials")
 	}
-	storage := newCodexOAuthService(h.cfg).CreateTokenStorage(bundle)
+	storage := newCodexOAuthServiceWithProxy(h.cfg, target.ProxyURL).CreateTokenStorage(bundle)
 	if storage == nil || strings.TrimSpace(storage.AccountID) != target.Subject {
 		return "", fmt.Errorf("replacement subject mismatch")
 	}
@@ -334,7 +335,8 @@ func (h *Handler) stageCodexReauthCandidate(target codexReauthTarget, bundle *co
 	}
 	name := codex.CredentialFileName(storage.Email, plan, hex.EncodeToString(digest[:])[:8], true)
 	legacyName := codex.CredentialFileName(storage.Email, plan, "", true)
-	if (name != target.FileName && legacyName != target.FileName) || filepath.Base(target.Path) != target.FileName {
+	targetBase := filepath.Base(target.FileName)
+	if (name != targetBase && legacyName != targetBase) || filepath.Base(target.Path) != targetBase {
 		return "", fmt.Errorf("replacement filename mismatch")
 	}
 	for _, auth := range h.authManager.List() {

--- a/internal/api/handlers/management/codex_reauth.go
+++ b/internal/api/handlers/management/codex_reauth.go
@@ -31,9 +31,10 @@ const (
 )
 
 var (
-	errCodexReauthBadRequest = errors.New("invalid reauth request")
-	errCodexReauthNotFound   = errors.New("reauth target not found")
-	errCodexReauthConflict   = errors.New("reauth target changed")
+	errCodexReauthBadRequest   = errors.New("invalid reauth request")
+	errCodexReauthNotFound     = errors.New("reauth target not found")
+	errCodexReauthConflict     = errors.New("reauth target changed")
+	codexReauthVerificationURL = "https://chatgpt.com/backend-api/codex/models"
 )
 
 type codexReauthTarget struct {
@@ -154,6 +155,21 @@ func (s *codexReauthStageStore) take(handle string) (codexReauthStage, bool) {
 		delete(s.stages, strings.TrimSpace(handle))
 	}
 	return stage, ok
+}
+
+func (s *codexReauthStageStore) removeTarget(fileName string) {
+	if s == nil {
+		return
+	}
+	fileName = filepath.Base(strings.TrimSpace(fileName))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for handle, stage := range s.stages {
+		if stage.Target.FileName == fileName {
+			_ = os.Remove(stage.Path)
+			delete(s.stages, handle)
+		}
+	}
 }
 
 func (s *codexReauthStageStore) purgeLocked(now time.Time) {
@@ -332,7 +348,7 @@ func (h *Handler) stageCodexReauthCandidate(target codexReauthTarget, bundle *co
 }
 
 func (h *Handler) verifyCodexCandidate(ctx context.Context, auth *coreauth.Auth) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://chatgpt.com/backend-api/codex/models", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, codexReauthVerificationURL, nil)
 	if err != nil {
 		return err
 	}
@@ -345,7 +361,7 @@ func (h *Handler) verifyCodexCandidate(ctx context.Context, auth *coreauth.Auth)
 		req.Header.Set("Chatgpt-Account-Id", accountID)
 	}
 	req.Header.Set("Accept", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := (&http.Client{Transport: h.apiCallTransport(auth), Timeout: 20 * time.Second}).Do(req)
 	if err != nil {
 		return err
 	}
@@ -416,12 +432,47 @@ func (h *Handler) AdoptCodexReauth(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to adopt replacement credential"})
 		return
 	}
-	if _, err = h.authManager.Update(coreauth.WithSkipPersist(c.Request.Context()), candidate); err != nil {
+	if err = h.updateCodexReauth(c.Request.Context(), candidate); err != nil {
 		_ = atomicCredentialReplace(stage.Target.Path, current)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to adopt replacement credential"})
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "auth_index": stage.Target.AuthIndex, "disabled": true})
+}
+
+func (h *Handler) VerifyCodexReauth(c *gin.Context) {
+	var req struct {
+		AuthIndex string `json:"auth_index"`
+	}
+	decoder := json.NewDecoder(io.LimitReader(c.Request.Body, 4097))
+	decoder.DisallowUnknownFields()
+	if decoder.Decode(&req) != nil || decoder.Decode(&struct{}{}) != io.EOF {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid reauth request"})
+		return
+	}
+	req.AuthIndex = strings.TrimSpace(req.AuthIndex)
+	var target *coreauth.Auth
+	for _, auth := range h.authManager.List() {
+		if auth != nil && lockedAuthIndex(auth) == req.AuthIndex {
+			if target != nil {
+				c.JSON(http.StatusConflict, gin.H{"error": "reauth target changed"})
+				return
+			}
+			target = auth
+		}
+	}
+	if target == nil || !strings.EqualFold(target.Provider, "codex") || target.Disabled || target.Status == coreauth.StatusDisabled || isRuntimeOnlyAuth(target) {
+		c.JSON(http.StatusConflict, gin.H{"error": "reauth target changed"})
+		return
+	}
+	verifyCtx, cancel := context.WithTimeout(c.Request.Context(), 20*time.Second)
+	err := h.verifyCodexReauth(verifyCtx, target)
+	cancel()
+	if err != nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "replacement credential verification failed"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok", "auth_index": req.AuthIndex, "disabled": false})
 }
 
 func atomicCredentialReplace(path string, raw []byte) error {

--- a/internal/api/handlers/management/codex_reauth_test.go
+++ b/internal/api/handlers/management/codex_reauth_test.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -17,6 +18,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
@@ -236,6 +238,14 @@ func TestCodexReauthStageExpiryIsSingleUseAndRemovesSecretFile(t *testing.T) {
 
 func TestCodexReauthPostEnableVerificationRequiresExactEnabledCodex(t *testing.T) {
 	h, router, target, _ := newCodexReauthTestHandler(t)
+	raw, err := os.ReadFile(target.Attributes["path"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	generation, err := credentialIdentityGeneration(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
 	verified := 0
 	h.verifyCodexReauth = func(_ context.Context, auth *coreauth.Auth) error {
 		verified++
@@ -247,7 +257,7 @@ func TestCodexReauthPostEnableVerificationRequiresExactEnabledCodex(t *testing.T
 	router.POST("/codex-reauth/verify", h.VerifyCodexReauth)
 
 	call := func() *httptest.ResponseRecorder {
-		req := httptest.NewRequest(http.MethodPost, "/codex-reauth/verify", strings.NewReader(`{"auth_index":"`+target.Index+`"}`))
+		req := httptest.NewRequest(http.MethodPost, "/codex-reauth/verify", strings.NewReader(`{"auth_index":"`+target.Index+`","generation":"`+generation+`"}`))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -269,6 +279,92 @@ func TestCodexReauthPostEnableVerificationRequiresExactEnabledCodex(t *testing.T
 	}
 	if verified != 1 {
 		t.Fatalf("verification calls = %d, want 1", verified)
+	}
+	if err := os.WriteFile(target.Attributes["path"], []byte(`{"type":"codex","account_id":"acct-1","access_token":"newer","disabled":false}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if w := call(); w.Code != http.StatusConflict {
+		t.Fatalf("changed generation status = %d, want conflict", w.Code)
+	}
+}
+
+func TestCodexReauthVerifyWithoutManagerFailsClosed(t *testing.T) {
+	h, router, target, generation := newCodexReauthTestHandler(t)
+	h.authManager = nil
+	router.POST("/codex-reauth/verify", h.VerifyCodexReauth)
+	req := httptest.NewRequest(http.MethodPost, "/codex-reauth/verify", strings.NewReader(`{"auth_index":"`+target.Index+`","generation":"`+generation+`"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want conflict", w.Code)
+	}
+}
+
+func TestCodexReauthStartRejectsNonFileStoreAndSymlinkEscape(t *testing.T) {
+	h, router, target, generation := newCodexReauthTestHandler(t)
+	router.POST("/codex-auth-url", h.RequestCodexToken)
+	h.tokenStore = &memoryAuthStore{}
+	request := func() int {
+		req := httptest.NewRequest(http.MethodPost, "/codex-auth-url", strings.NewReader(`{"auth_index":"`+target.Index+`","generation":"`+generation+`"}`))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w.Code
+	}
+	if got := request(); got != http.StatusConflict {
+		t.Fatalf("non-file store status = %d, want conflict", got)
+	}
+
+	h.tokenStore = sdkAuth.NewFileTokenStore()
+	escape := t.TempDir()
+	outside := filepath.Join(escape, target.FileName)
+	raw, err := os.ReadFile(target.Attributes["path"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = os.WriteFile(outside, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(h.cfg.AuthDir, "escape")
+	if err = os.Symlink(escape, link); err != nil {
+		t.Fatal(err)
+	}
+	target.Attributes["path"] = filepath.Join(link, target.FileName)
+	if _, err = h.authManager.Update(coreauth.WithSkipPersist(context.Background()), target); err != nil {
+		t.Fatal(err)
+	}
+	if got := request(); got != http.StatusConflict {
+		t.Fatalf("symlink escape status = %d, want conflict", got)
+	}
+}
+
+func TestCodexReauthAcceptsExactLegacyFilename(t *testing.T) {
+	h, _, target, generation := newCodexReauthTestHandler(t)
+	legacy := codex.CredentialFileName("replacement@example.test", "", "", true)
+	legacyPath := filepath.Join(h.cfg.AuthDir, legacy)
+	if err := os.Rename(target.Attributes["path"], legacyPath); err != nil {
+		t.Fatal(err)
+	}
+	target.FileName, target.Attributes["path"] = legacy, legacyPath
+	bundle := &codex.CodexAuthBundle{TokenData: codex.CodexTokenData{IDToken: "test", AccessToken: "replacement", Email: "replacement@example.test", AccountID: "acct-1"}}
+	spec := codexReauthTarget{AuthID: target.ID, AuthIndex: target.Index, FileName: legacy, Path: legacyPath, Generation: generation, Subject: "acct-1"}
+	if _, err := h.stageCodexReauthCandidate(spec, bundle); err != nil {
+		t.Fatalf("legacy target rejected: %v", err)
+	}
+}
+
+func TestAtomicCredentialReplaceRequiresExpectedGeneration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "credential.json")
+	original := []byte(`{"value":"original"}`)
+	newer := []byte(`{"value":"newer"}`)
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicCredentialReplace(path, credentialGeneration([]byte("stale")), newer); err == nil {
+		t.Fatal("stale expected generation replaced the credential")
+	}
+	raw, _ := os.ReadFile(path)
+	if !bytes.Equal(raw, original) {
+		t.Fatal("credential changed after compare failure")
 	}
 }
 

--- a/internal/api/handlers/management/codex_reauth_test.go
+++ b/internal/api/handlers/management/codex_reauth_test.go
@@ -5,12 +5,14 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
@@ -159,6 +161,172 @@ func TestCodexReauthChangedTargetDoesNotAdopt(t *testing.T) {
 	raw, _ := os.ReadFile(targetSpec.Path)
 	if !strings.Contains(string(raw), "newer") || strings.Contains(string(raw), "replacement") {
 		t.Fatal("changed target was overwritten")
+	}
+}
+
+func TestCodexReauthVerificationFailureKeepsOriginalAndCleansStage(t *testing.T) {
+	h, router, target, generation := newCodexReauthTestHandler(t)
+	h.verifyCodexReauth = func(context.Context, *coreauth.Auth) error { return errors.New("unavailable") }
+	router.POST("/codex-reauth", h.AdoptCodexReauth)
+	targetSpec := codexReauthTarget{AuthID: target.ID, AuthIndex: target.Index, FileName: target.FileName, Path: target.Attributes["path"], Generation: generation, Subject: "acct-1"}
+	bundle := &codex.CodexAuthBundle{TokenData: codex.CodexTokenData{IDToken: "test", AccessToken: "replacement", Email: "replacement@example.test", AccountID: "acct-1"}}
+	handle, err := h.stageCodexReauthCandidate(targetSpec, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stage := h.codexReauthStages.stages[handle]
+
+	req := httptest.NewRequest(http.MethodPost, "/codex-reauth", strings.NewReader(`{"stage_handle":"`+handle+`"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want conflict", w.Code)
+	}
+	raw, err := os.ReadFile(targetSpec.Path)
+	if err != nil || !strings.Contains(string(raw), `"access_token":"old"`) {
+		t.Fatal("original credential changed after failed verification")
+	}
+	if _, err = os.Stat(stage.Path); !os.IsNotExist(err) {
+		t.Fatal("failed candidate was not removed")
+	}
+}
+
+func TestCodexReauthRuntimeUpdateFailureRollsBackOriginal(t *testing.T) {
+	h, router, target, generation := newCodexReauthTestHandler(t)
+	h.verifyCodexReauth = func(context.Context, *coreauth.Auth) error { return nil }
+	h.updateCodexReauth = func(context.Context, *coreauth.Auth) error { return errors.New("update failed") }
+	router.POST("/codex-reauth", h.AdoptCodexReauth)
+	targetSpec := codexReauthTarget{AuthID: target.ID, AuthIndex: target.Index, FileName: target.FileName, Path: target.Attributes["path"], Generation: generation, Subject: "acct-1"}
+	bundle := &codex.CodexAuthBundle{TokenData: codex.CodexTokenData{IDToken: "test", AccessToken: "replacement", Email: "replacement@example.test", AccountID: "acct-1"}}
+	handle, err := h.stageCodexReauthCandidate(targetSpec, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/codex-reauth", strings.NewReader(`{"stage_handle":"`+handle+`"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want internal error", w.Code)
+	}
+	raw, err := os.ReadFile(targetSpec.Path)
+	if err != nil || !strings.Contains(string(raw), `"access_token":"old"`) || strings.Contains(string(raw), "replacement") {
+		t.Fatal("original credential was not restored")
+	}
+}
+
+func TestCodexReauthStageExpiryIsSingleUseAndRemovesSecretFile(t *testing.T) {
+	h, _, target, generation := newCodexReauthTestHandler(t)
+	targetSpec := codexReauthTarget{AuthID: target.ID, AuthIndex: target.Index, FileName: target.FileName, Path: target.Attributes["path"], Generation: generation, Subject: "acct-1"}
+	bundle := &codex.CodexAuthBundle{TokenData: codex.CodexTokenData{IDToken: "test", AccessToken: "replacement", Email: "replacement@example.test", AccountID: "acct-1"}}
+	handle, err := h.stageCodexReauthCandidate(targetSpec, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stage := h.codexReauthStages.stages[handle]
+	stage.ExpiresAt = time.Now().Add(-time.Second)
+	h.codexReauthStages.stages[handle] = stage
+	if _, ok := h.codexReauthStages.take(handle); ok {
+		t.Fatal("expired stage was accepted")
+	}
+	if _, err = os.Stat(stage.Path); !os.IsNotExist(err) {
+		t.Fatal("expired stage secret file was not removed")
+	}
+}
+
+func TestCodexReauthPostEnableVerificationRequiresExactEnabledCodex(t *testing.T) {
+	h, router, target, _ := newCodexReauthTestHandler(t)
+	verified := 0
+	h.verifyCodexReauth = func(_ context.Context, auth *coreauth.Auth) error {
+		verified++
+		if auth.Index != target.Index {
+			t.Fatal("wrong auth verified")
+		}
+		return nil
+	}
+	router.POST("/codex-reauth/verify", h.VerifyCodexReauth)
+
+	call := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/codex-reauth/verify", strings.NewReader(`{"auth_index":"`+target.Index+`"}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w
+	}
+	if w := call(); w.Code != http.StatusConflict {
+		t.Fatalf("disabled status = %d, want conflict", w.Code)
+	}
+	if verified != 0 {
+		t.Fatal("disabled credential reached provider verification")
+	}
+	target.Disabled = false
+	target.Status = coreauth.StatusActive
+	if _, err := h.authManager.Update(coreauth.WithSkipPersist(context.Background()), target); err != nil {
+		t.Fatal(err)
+	}
+	if w := call(); w.Code != http.StatusOK || w.Body.String() != `{"auth_index":"`+target.Index+`","disabled":false,"status":"ok"}` {
+		t.Fatalf("enabled verification response = %d %s", w.Code, w.Body.String())
+	}
+	if verified != 1 {
+		t.Fatalf("verification calls = %d, want 1", verified)
+	}
+}
+
+func TestCodexReauthDeleteRemovesOnlyMatchingStages(t *testing.T) {
+	h, router, target, generation := newCodexReauthTestHandler(t)
+	router.DELETE("/auth-files", h.DeleteAuthFile)
+	targetSpec := codexReauthTarget{AuthID: target.ID, AuthIndex: target.Index, FileName: target.FileName, Path: target.Attributes["path"], Generation: generation, Subject: "acct-1"}
+	bundle := &codex.CodexAuthBundle{TokenData: codex.CodexTokenData{IDToken: "test", AccessToken: "replacement", Email: "replacement@example.test", AccountID: "acct-1"}}
+	handle, err := h.stageCodexReauthCandidate(targetSpec, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stage := h.codexReauthStages.stages[handle]
+
+	req := httptest.NewRequest(http.MethodDelete, "/auth-files?name="+target.FileName, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete status = %d; body=%s", w.Code, w.Body.String())
+	}
+	if _, ok := h.codexReauthStages.take(handle); ok {
+		t.Fatal("deleted account retained staged reauth")
+	}
+	if _, err = os.Stat(stage.Path); !os.IsNotExist(err) {
+		t.Fatal("deleted account retained staged secret file")
+	}
+}
+
+type failingRoundTripper struct{}
+
+func (failingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("direct transport used")
+}
+
+func TestCodexReauthVerificationUsesConfiguredTransport(t *testing.T) {
+	used := false
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		used = true
+		if r.Header.Get("Authorization") != "Bearer replacement-access" || r.Header.Get("Chatgpt-Account-Id") != "acct-1" {
+			t.Fatal("provider verification headers are incomplete")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer proxy.Close()
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = failingRoundTripper{}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+	oldURL := codexReauthVerificationURL
+	codexReauthVerificationURL = "http://provider.example.test/models"
+	t.Cleanup(func() { codexReauthVerificationURL = oldURL })
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{SDKConfig: config.SDKConfig{ProxyURL: proxy.URL}}, coreauth.NewManager(nil, nil, nil))
+	auth := &coreauth.Auth{Metadata: map[string]any{"access_token": "replacement-access", "account_id": "acct-1"}}
+	if err := h.verifyCodexCandidate(context.Background(), auth); err != nil {
+		t.Fatalf("verify candidate: %v", err)
+	}
+	if !used {
+		t.Fatal("configured transport was not used")
 	}
 }
 

--- a/internal/api/handlers/management/codex_reauth_test.go
+++ b/internal/api/handlers/management/codex_reauth_test.go
@@ -352,6 +352,52 @@ func TestCodexReauthAcceptsExactLegacyFilename(t *testing.T) {
 	}
 }
 
+func TestCodexReauthStartAcceptsContainedNestedTarget(t *testing.T) {
+	h, router, target, generation := newCodexReauthTestHandler(t)
+	router.POST("/codex-auth-url", h.RequestCodexToken)
+	nested := filepath.Join(h.cfg.AuthDir, "team")
+	if err := os.Mkdir(nested, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	nestedPath := filepath.Join(nested, filepath.Base(target.FileName))
+	if err := os.Rename(target.Attributes["path"], nestedPath); err != nil {
+		t.Fatal(err)
+	}
+	target.FileName = filepath.Join("team", filepath.Base(target.FileName))
+	target.Attributes["path"] = nestedPath
+	if _, err := h.authManager.Update(coreauth.WithSkipPersist(context.Background()), target); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/codex-auth-url", strings.NewReader(`{"auth_index":"`+target.Index+`","generation":"`+generation+`"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("nested target status = %d; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestCodexReauthStartUsesExactTargetProxy(t *testing.T) {
+	h, router, target, generation := newCodexReauthTestHandler(t)
+	target.ProxyURL = "direct"
+	if _, err := h.authManager.Update(coreauth.WithSkipPersist(context.Background()), target); err != nil {
+		t.Fatal(err)
+	}
+	usedProxy := ""
+	original := newCodexOAuthServiceWithProxy
+	newCodexOAuthServiceWithProxy = func(_ *config.Config, proxyURL string) codexOAuthService {
+		usedProxy = proxyURL
+		return &fakeCodexOAuthService{}
+	}
+	t.Cleanup(func() { newCodexOAuthServiceWithProxy = original })
+	router.POST("/codex-auth-url", h.RequestCodexToken)
+	req := httptest.NewRequest(http.MethodPost, "/codex-auth-url", strings.NewReader(`{"auth_index":"`+target.Index+`","generation":"`+generation+`"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK || usedProxy != "direct" {
+		t.Fatalf("status/proxy = %d/%q, want 200/direct", w.Code, usedProxy)
+	}
+}
+
 func TestAtomicCredentialReplaceRequiresExpectedGeneration(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "credential.json")
 	original := []byte(`{"value":"original"}`)
@@ -447,7 +493,12 @@ func newCodexReauthTestHandler(t *testing.T) (*Handler, *gin.Engine, *coreauth.A
 	target, _ = manager.GetByID(target.ID)
 	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
 	original := newCodexOAuthService
+	originalWithProxy := newCodexOAuthServiceWithProxy
 	newCodexOAuthService = func(*config.Config) codexOAuthService { return &fakeCodexOAuthService{} }
-	t.Cleanup(func() { newCodexOAuthService = original })
+	newCodexOAuthServiceWithProxy = func(*config.Config, string) codexOAuthService { return &fakeCodexOAuthService{} }
+	t.Cleanup(func() {
+		newCodexOAuthService = original
+		newCodexOAuthServiceWithProxy = originalWithProxy
+	})
 	return h, gin.New(), target, credentialGeneration(raw)
 }

--- a/internal/api/handlers/management/codex_reauth_test.go
+++ b/internal/api/handlers/management/codex_reauth_test.go
@@ -1,0 +1,189 @@
+package management
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestCodexReauthStartRequiresExactDisabledGeneration(t *testing.T) {
+	h, router, target, generation := newCodexReauthTestHandler(t)
+	router.POST("/codex-auth-url", h.RequestCodexToken)
+
+	for _, test := range []struct {
+		name       string
+		body       string
+		wantStatus int
+	}{
+		{"exact target", `{"auth_index":"` + target.Index + `","generation":"` + generation + `"}`, http.StatusOK},
+		{"wrong generation", `{"auth_index":"` + target.Index + `","generation":"` + strings.Repeat("0", 64) + `"}`, http.StatusConflict},
+		{"missing target", `{"auth_index":"missing","generation":"` + generation + `"}`, http.StatusNotFound},
+		{"extra field", `{"auth_index":"` + target.Index + `","generation":"` + generation + `","email":"x@example.test"}`, http.StatusBadRequest},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/codex-auth-url", strings.NewReader(test.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			if w.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d; body=%s", w.Code, test.wantStatus, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestCodexReauthCandidateStagesDisabledWithoutRuntimeRegistration(t *testing.T) {
+	h, _, target, generation := newCodexReauthTestHandler(t)
+	bundle := &codex.CodexAuthBundle{TokenData: codex.CodexTokenData{
+		IDToken: "test-id-token", AccessToken: "test-access", RefreshToken: "test-refresh",
+		Email: "replacement@example.test", AccountID: "acct-1",
+	}}
+	targetSpec := codexReauthTarget{AuthID: target.ID, AuthIndex: target.Index, FileName: target.FileName, Path: target.Attributes["path"], Generation: generation, Subject: "acct-1"}
+
+	handle, err := h.stageCodexReauthCandidate(targetSpec, bundle)
+	if err != nil {
+		t.Fatalf("stage candidate: %v", err)
+	}
+	if strings.TrimSpace(handle) == "" {
+		t.Fatal("stage handle is empty")
+	}
+	if got := len(h.authManager.List()); got != 1 {
+		t.Fatalf("runtime auth count = %d, want original only", got)
+	}
+	stage, ok := h.codexReauthStages.take(handle)
+	if !ok {
+		t.Fatal("staged candidate is missing")
+	}
+	defer os.Remove(stage.Path)
+	if filepath.Dir(stage.Path) == filepath.Dir(targetSpec.Path) {
+		t.Fatal("candidate was staged in live auth directory")
+	}
+	raw, err := os.ReadFile(stage.Path)
+	if err != nil {
+		t.Fatalf("read staged candidate: %v", err)
+	}
+	var stored map[string]any
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		t.Fatalf("decode staged candidate: %v", err)
+	}
+	if stored["disabled"] != true || stored["type"] != "codex" {
+		t.Fatalf("candidate disabled/type = %#v/%#v, want true/codex", stored["disabled"], stored["type"])
+	}
+}
+
+func TestCodexReauthRejectsSubjectOrRename(t *testing.T) {
+	h, _, target, generation := newCodexReauthTestHandler(t)
+	base := codexReauthTarget{AuthID: target.ID, AuthIndex: target.Index, FileName: target.FileName, Path: target.Attributes["path"], Generation: generation, Subject: "acct-1"}
+	bundle := &codex.CodexAuthBundle{TokenData: codex.CodexTokenData{IDToken: "test", AccessToken: "access", AccountID: "acct-2", Email: "x@example.test"}}
+	if _, err := h.stageCodexReauthCandidate(base, bundle); err == nil {
+		t.Fatal("subject mismatch was accepted")
+	}
+	bundle.TokenData.AccountID = "acct-1"
+	base.FileName = "renamed.json"
+	if _, err := h.stageCodexReauthCandidate(base, bundle); err == nil {
+		t.Fatal("renamed target was accepted")
+	}
+}
+
+func TestCodexReauthAdoptsVerifiedCandidateOnceAndKeepsDisabled(t *testing.T) {
+	h, router, target, generation := newCodexReauthTestHandler(t)
+	h.verifyCodexReauth = func(context.Context, *coreauth.Auth) error { return nil }
+	router.POST("/codex-reauth", h.AdoptCodexReauth)
+	bundle := &codex.CodexAuthBundle{TokenData: codex.CodexTokenData{
+		IDToken: "test-id-token", AccessToken: "replacement-access", RefreshToken: "replacement-refresh",
+		Email: "replacement@example.test", AccountID: "acct-1",
+	}}
+	targetSpec := codexReauthTarget{AuthID: target.ID, AuthIndex: target.Index, FileName: target.FileName, Path: target.Attributes["path"], Generation: generation, Subject: "acct-1"}
+	handle, err := h.stageCodexReauthCandidate(targetSpec, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	callAdopt := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/codex-reauth", strings.NewReader(`{"stage_handle":"`+handle+`"}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w
+	}
+	if w := callAdopt(); w.Code != http.StatusOK {
+		t.Fatalf("adopt status = %d; body=%s", w.Code, w.Body.String())
+	}
+	updated, ok := h.authManager.GetByID(target.ID)
+	if !ok || !updated.Disabled || updated.Metadata["access_token"] != "replacement-access" || updated.Index != target.Index {
+		t.Fatalf("adopted runtime auth = %#v", updated)
+	}
+	raw, err := os.ReadFile(targetSpec.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "replacement-access") || !strings.Contains(string(raw), `"disabled":true`) {
+		t.Fatal("adopted file is not the verified disabled candidate")
+	}
+	if w := callAdopt(); w.Code != http.StatusConflict {
+		t.Fatalf("replay status = %d, want %d", w.Code, http.StatusConflict)
+	}
+}
+
+func TestCodexReauthChangedTargetDoesNotAdopt(t *testing.T) {
+	h, router, target, generation := newCodexReauthTestHandler(t)
+	h.verifyCodexReauth = func(context.Context, *coreauth.Auth) error { return nil }
+	router.POST("/codex-reauth", h.AdoptCodexReauth)
+	targetSpec := codexReauthTarget{AuthID: target.ID, AuthIndex: target.Index, FileName: target.FileName, Path: target.Attributes["path"], Generation: generation, Subject: "acct-1"}
+	bundle := &codex.CodexAuthBundle{TokenData: codex.CodexTokenData{IDToken: "test", AccessToken: "replacement", Email: "replacement@example.test", AccountID: "acct-1"}}
+	handle, err := h.stageCodexReauthCandidate(targetSpec, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(targetSpec.Path, []byte(`{"type":"codex","account_id":"acct-1","access_token":"newer","disabled":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/codex-reauth", strings.NewReader(`{"stage_handle":"`+handle+`"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want conflict; body=%s", w.Code, w.Body.String())
+	}
+	raw, _ := os.ReadFile(targetSpec.Path)
+	if !strings.Contains(string(raw), "newer") || strings.Contains(string(raw), "replacement") {
+		t.Fatal("changed target was overwritten")
+	}
+}
+
+func newCodexReauthTestHandler(t *testing.T) (*Handler, *gin.Engine, *coreauth.Auth, string) {
+	t.Helper()
+	authDir := filepath.Join(t.TempDir(), "auths")
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256([]byte("acct-1"))
+	name := codex.CredentialFileName("replacement@example.test", "", hex.EncodeToString(digest[:])[:8], true)
+	path := filepath.Join(authDir, name)
+	raw := []byte(`{"type":"codex","account_id":"acct-1","access_token":"old","disabled":true}`)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	target := &coreauth.Auth{ID: name, Provider: "codex", FileName: name, Disabled: true, Status: coreauth.StatusDisabled, Attributes: map[string]string{"path": path}, Metadata: map[string]any{"account_id": "acct-1"}}
+	if _, err := manager.Register(coreauth.WithSkipPersist(context.Background()), target); err != nil {
+		t.Fatal(err)
+	}
+	target, _ = manager.GetByID(target.ID)
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+	original := newCodexOAuthService
+	newCodexOAuthService = func(*config.Config) codexOAuthService { return &fakeCodexOAuthService{} }
+	t.Cleanup(func() { newCodexOAuthService = original })
+	return h, gin.New(), target, credentialGeneration(raw)
+}

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -63,6 +63,7 @@ type Handler struct {
 	pluginReleaseCache      map[string]pluginReleaseCacheEntry
 	codexReauthStages       *codexReauthStageStore
 	verifyCodexReauth       func(context.Context, *coreauth.Auth) error
+	updateCodexReauth       func(context.Context, *coreauth.Auth) error
 }
 
 type configReloadSnapshot struct {
@@ -86,6 +87,10 @@ func NewHandler(cfg *config.Config, configFilePath string, manager *coreauth.Man
 		codexReauthStages:   newCodexReauthStageStore(cfg),
 	}
 	h.verifyCodexReauth = h.verifyCodexCandidate
+	h.updateCodexReauth = func(ctx context.Context, auth *coreauth.Auth) error {
+		_, err := h.authManager.Update(coreauth.WithSkipPersist(ctx), auth)
+		return err
+	}
 	h.startAttemptCleanup()
 	return h
 }

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -41,6 +41,7 @@ type Handler struct {
 	cfg                     *config.Config
 	configFilePath          string
 	mu                      sync.Mutex
+	authMutationMu          sync.Mutex
 	reloadMu                sync.Mutex
 	reloadGeneration        uint64
 	appliedReloadGeneration uint64
@@ -60,6 +61,8 @@ type Handler struct {
 	pluginStoreHTTPClient   pluginstore.HTTPDoer
 	pluginReleaseCacheMu    sync.Mutex
 	pluginReleaseCache      map[string]pluginReleaseCacheEntry
+	codexReauthStages       *codexReauthStageStore
+	verifyCodexReauth       func(context.Context, *coreauth.Auth) error
 }
 
 type configReloadSnapshot struct {
@@ -80,7 +83,9 @@ func NewHandler(cfg *config.Config, configFilePath string, manager *coreauth.Man
 		tokenStore:          sdkAuth.GetTokenStore(),
 		allowRemoteOverride: envSecret != "",
 		envSecret:           envSecret,
+		codexReauthStages:   newCodexReauthStageStore(cfg),
 	}
+	h.verifyCodexReauth = h.verifyCodexCandidate
 	h.startAttemptCleanup()
 	return h
 }

--- a/internal/api/handlers/management/oauth_sessions.go
+++ b/internal/api/handlers/management/oauth_sessions.go
@@ -154,10 +154,10 @@ func (s *oauthSessionStore) Complete(state string) {
 	s.CompleteWithResult(state, "")
 }
 
-func (s *oauthSessionStore) CompleteWithResult(state, result string) {
+func (s *oauthSessionStore) CompleteWithResult(state, result string) bool {
 	state = strings.TrimSpace(state)
 	if state == "" {
-		return
+		return false
 	}
 	now := time.Now()
 
@@ -167,14 +167,19 @@ func (s *oauthSessionStore) CompleteWithResult(state, result string) {
 	s.purgeExpiredLocked(now)
 	session, ok := s.sessions[state]
 	if !ok || session.Completed {
-		return
+		return false
 	}
 	session.Status = ""
 	session.Metadata = nil
 	session.Result = strings.TrimSpace(result)
 	session.Completed = true
-	session.ExpiresAt = now.Add(s.completedTTL)
+	retention := s.completedTTL
+	if session.Result != "" && retention < codexReauthStageTTL {
+		retention = codexReauthStageTTL
+	}
+	session.ExpiresAt = now.Add(retention)
 	s.sessions[state] = session
+	return true
 }
 
 func (s *oauthSessionStore) CompleteProvider(provider string, source string) int {
@@ -286,8 +291,8 @@ func SetOAuthSessionError(state, message string) { oauthSessions.SetError(state,
 
 func CompleteOAuthSession(state string) { oauthSessions.Complete(state) }
 
-func completeOAuthSessionWithResult(state, result string) {
-	oauthSessions.CompleteWithResult(state, result)
+func completeOAuthSessionWithResult(state, result string) bool {
+	return oauthSessions.CompleteWithResult(state, result)
 }
 
 func CompleteOAuthSessionsByProvider(provider string) int {

--- a/internal/api/handlers/management/oauth_sessions.go
+++ b/internal/api/handlers/management/oauth_sessions.go
@@ -35,6 +35,7 @@ type oauthSession struct {
 	Status    string
 	Source    string
 	Metadata  map[string]any
+	Result    string
 	Completed bool
 	CreatedAt time.Time
 	ExpiresAt time.Time
@@ -71,6 +72,10 @@ func (s *oauthSessionStore) purgeExpiredLocked(now time.Time) {
 }
 
 func (s *oauthSessionStore) Register(state, provider string) {
+	s.RegisterWithMetadata(state, provider, nil)
+}
+
+func (s *oauthSessionStore) RegisterWithMetadata(state, provider string, metadata map[string]any) {
 	state = strings.TrimSpace(state)
 	provider = strings.ToLower(strings.TrimSpace(provider))
 	if state == "" || provider == "" {
@@ -86,6 +91,7 @@ func (s *oauthSessionStore) Register(state, provider string) {
 		Provider:  provider,
 		Status:    "",
 		Source:    oauthSessionSourceBuiltin,
+		Metadata:  cloneOAuthSessionMetadata(metadata),
 		CreatedAt: now,
 		ExpiresAt: now.Add(s.ttl),
 	}
@@ -145,6 +151,10 @@ func (s *oauthSessionStore) SetError(state, message string) {
 }
 
 func (s *oauthSessionStore) Complete(state string) {
+	s.CompleteWithResult(state, "")
+}
+
+func (s *oauthSessionStore) CompleteWithResult(state, result string) {
 	state = strings.TrimSpace(state)
 	if state == "" {
 		return
@@ -161,6 +171,7 @@ func (s *oauthSessionStore) Complete(state string) {
 	}
 	session.Status = ""
 	session.Metadata = nil
+	session.Result = strings.TrimSpace(result)
 	session.Completed = true
 	session.ExpiresAt = now.Add(s.completedTTL)
 	s.sessions[state] = session
@@ -263,6 +274,10 @@ var oauthSessions = newOAuthSessionStore(oauthSessionTTL)
 
 func RegisterOAuthSession(state, provider string) { oauthSessions.Register(state, provider) }
 
+func registerOAuthSessionWithMetadata(state, provider string, metadata map[string]any) {
+	oauthSessions.RegisterWithMetadata(state, provider, metadata)
+}
+
 func RegisterPluginOAuthSession(state, provider string, metadata map[string]any) error {
 	return oauthSessions.RegisterPlugin(state, provider, metadata)
 }
@@ -270,6 +285,10 @@ func RegisterPluginOAuthSession(state, provider string, metadata map[string]any)
 func SetOAuthSessionError(state, message string) { oauthSessions.SetError(state, message) }
 
 func CompleteOAuthSession(state string) { oauthSessions.Complete(state) }
+
+func completeOAuthSessionWithResult(state, result string) {
+	oauthSessions.CompleteWithResult(state, result)
+}
 
 func CompleteOAuthSessionsByProvider(provider string) int {
 	return oauthSessions.CompleteProvider(provider, oauthSessionSourceBuiltin)

--- a/internal/api/handlers/management/oauth_sessions_test.go
+++ b/internal/api/handlers/management/oauth_sessions_test.go
@@ -342,3 +342,23 @@ func replaceOAuthSessionStoreForTest(t *testing.T, store *oauthSessionStore) {
 		oauthSessions = original
 	})
 }
+
+func TestOAuthSessionResultSurvivesStageLifetimeAndCancelledCompletionFails(t *testing.T) {
+	store := newOAuthSessionStore(30 * time.Minute)
+	store.Register("result-state", "codex")
+	if !store.CompleteWithResult("result-state", strings.Repeat("a", 64)) {
+		t.Fatal("pending result was not completed")
+	}
+	session, ok := store.Get("result-state")
+	if !ok || time.Until(session.ExpiresAt) < codexReauthStageTTL-time.Second {
+		t.Fatal("result-bearing session expires before its stage")
+	}
+
+	store.Register("cancelled-state", "codex")
+	if !store.Cancel("cancelled-state") {
+		t.Fatal("session was not cancelled")
+	}
+	if store.CompleteWithResult("cancelled-state", strings.Repeat("b", 64)) {
+		t.Fatal("cancelled session accepted a staged result")
+	}
+}

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -167,6 +167,8 @@ func (s *Server) registerManagementRoutes() {
 
 		mgmt.GET("/anthropic-auth-url", s.mgmt.RequestAnthropicToken)
 		mgmt.GET("/codex-auth-url", s.mgmt.RequestCodexToken)
+		mgmt.POST("/codex-auth-url", s.mgmt.RequestCodexToken)
+		mgmt.POST("/codex-reauth", s.mgmt.AdoptCodexReauth)
 		mgmt.GET("/antigravity-auth-url", s.mgmt.RequestAntigravityToken)
 		mgmt.GET("/kimi-auth-url", s.mgmt.RequestKimiToken)
 		mgmt.GET("/xai-auth-url", s.mgmt.RequestXAIToken)

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -169,6 +169,7 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/codex-auth-url", s.mgmt.RequestCodexToken)
 		mgmt.POST("/codex-auth-url", s.mgmt.RequestCodexToken)
 		mgmt.POST("/codex-reauth", s.mgmt.AdoptCodexReauth)
+		mgmt.POST("/codex-reauth/verify", s.mgmt.VerifyCodexReauth)
 		mgmt.GET("/antigravity-auth-url", s.mgmt.RequestAntigravityToken)
 		mgmt.GET("/kimi-auth-url", s.mgmt.RequestKimiToken)
 		mgmt.GET("/xai-auth-url", s.mgmt.RequestXAIToken)


### PR DESCRIPTION
## Why

Ordinary Codex OAuth saves a newly derived credential directly into the watched auth directory. That is unsafe for automatic reauthentication: it cannot prove which disabled credential is being replaced and may create an active duplicate or silently change identity.

## Contract

- `POST /codex-auth-url` optionally accepts an exact disabled Codex `auth_index` plus credential `generation`; existing `GET /codex-auth-url` and ordinary OAuth behavior are unchanged.
- The callback keeps the candidate disabled outside the watched auth directory and returns only an opaque, single-use, expiring stage handle through the existing status poll.
- `POST /codex-reauth` rechecks generation/path/subject, verifies the candidate with its configured proxy, rejects duplicate or filename drift, atomically replaces only the exact target, and returns the new disabled generation.
- The caller explicitly enables through the existing auth-file status API, then confirms exact identity and provider usability with `POST /codex-reauth/verify`.

## Boundaries and failure behavior

- Staged reauthentication is intentionally supported only by the file token store; non-file stores fail closed. Candidates never enter the watched live directory before adoption.
- State, PKCE, and stage handles use existing secure randomness. Handles are bounded, restart-invalidated, short-lived, and cleaned on cancellation, failure, expiry, deletion, or success.
- Adoption preserves the exact auth reference and stays disabled. Runtime synchronization failure atomically restores the original disabled credential; post-enable uncertainty remains recoverable by disabling that exact account again.
- Credential values are never returned or logged. This PR adds no browser automation, passwords, TOTP material, or provider-specific credentials.

## Validation at `4cd5589a465d4fb4bc3c5d59170a49ce6c302d51`

- `go test ./internal/api/handlers/management` — passed
- `go test -race ./internal/api/handlers/management` — passed
- `go test ./...` — passed
- `go build -o test-output ./cmd/server && rm test-output` — passed
- `gofmt -l` on all changed Go files, `git diff --check`, and a changed-file secret scan — clean