### PR TITLE
fix(antigravity): strip propertyNames inside a property named "properties"

### DIFF
--- a/internal/runtime/executor/antigravity_schema_sanitize_test.go
+++ b/internal/runtime/executor/antigravity_schema_sanitize_test.go
@@ -456,3 +456,115 @@ func TestSanitizeAntigravityRequestSchemasIsIdempotent(t *testing.T) {
 		}
 	}
 }
+
+// propertyNamesShapes are the two nestings reported against the private Gemini backend, which
+// rejects the standard JSON Schema keyword "propertyNames" with an unknown-field 400.
+var propertyNamesShapes = map[string]string{
+	// An object nested in an array item.
+	"arrayItem": `{"type":"object","properties":{"records":{"type":"array","items":{"type":"object",` +
+		`"properties":{"name":{"type":"string"}},"propertyNames":{"type":"string"}}}}}`,
+	// A dynamic map declared by a property that is itself named "properties".
+	"propertyNamedProperties": `{"type":"object","properties":{"properties":{"type":"object",` +
+		`"propertyNames":{"type":"string"}}}}`,
+}
+
+// TestSanitizeAntigravityRequestSchemasStripsPropertyNamesEverywhere covers every payload location
+// that can carry a schema, in both spellings of the declarations container. A location that keeps
+// "propertyNames" sends a request the backend rejects before inference.
+func TestSanitizeAntigravityRequestSchemasStripsPropertyNamesEverywhere(t *testing.T) {
+	for shapeName, schema := range propertyNamesShapes {
+		for _, declContainer := range []string{"functionDeclarations", "function_declarations"} {
+			for _, genContainer := range antigravityGenerationConfigContainers {
+				name := shapeName + "_" + declContainer + "_" + strings.TrimPrefix(genContainer, "request.")
+				t.Run(name, func(t *testing.T) {
+					decl := `"name":"t"`
+					for _, k := range antigravityDeclarationSchemaKeys {
+						decl += `,"` + k + `":` + schema
+					}
+					gen := ""
+					for i, k := range antigravityGenerationSchemaKeys {
+						if i > 0 {
+							gen += ","
+						}
+						gen += `"` + k + `":` + schema
+					}
+					payload := `{"request":{"tools":[{"` + declContainer + `":[{` + decl + `}]}],"` +
+						strings.TrimPrefix(genContainer, "request.") + `":{` + gen + `}}}`
+
+					for _, useAntigravitySchema := range []bool{false, true} {
+						got := sanitizeAntigravityRequestSchemas(payload, useAntigravitySchema)
+						if strings.Contains(got, `"propertyNames"`) {
+							t.Errorf("antigravity=%v: propertyNames reaches upstream: %s", useAntigravitySchema, got)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+// TestSanitizeAntigravityRequestSchemasKeepsPropertyNamesInHistory pins the boundary of the fix:
+// only schema locations may be rewritten. A functionCall argument or a property named
+// "propertyNames" is data and must survive untouched.
+func TestSanitizeAntigravityRequestSchemasKeepsPropertyNamesInHistory(t *testing.T) {
+	payload := `{"request":{
+		"contents":[{"role":"model","parts":[{"functionCall":{"name":"t","args":{
+			"propertyNames":"keep-me",
+			"properties":{"propertyNames":"keep-me-too"}
+		}}}]}],
+		"tools":[{"functionDeclarations":[{"name":"t","parameters":{"type":"object","properties":{
+			"propertyNames":{"type":"string"},
+			"properties":{"type":"object","propertyNames":{"type":"string"}}
+		}}}]}]
+	}}`
+
+	for _, useAntigravitySchema := range []bool{false, true} {
+		got := sanitizeAntigravityRequestSchemas(payload, useAntigravitySchema)
+
+		before := gjson.Get(payload, "request.contents")
+		after := gjson.Get(got, "request.contents")
+		if before.Raw != after.Raw {
+			t.Errorf("antigravity=%v: history was mutated.\nbefore: %s\nafter:  %s", useAntigravitySchema, before.Raw, after.Raw)
+		}
+
+		schema := gjson.Get(got, "request.tools.0.functionDeclarations.0.parameters")
+		if !schema.Get("properties.propertyNames").Exists() {
+			t.Errorf("antigravity=%v: property named propertyNames was removed: %s", useAntigravitySchema, schema.Raw)
+		}
+		if schema.Get("properties.properties.propertyNames").Exists() {
+			t.Errorf("antigravity=%v: propertyNames keyword survived inside a property named properties: %s", useAntigravitySchema, schema.Raw)
+		}
+	}
+}
+
+// TestAntigravityBuildRequestStripsPropertyNamesFromOutboundBody asserts on the body that actually
+// leaves the executor, so a later transformation cannot reintroduce the keyword unnoticed.
+func TestAntigravityBuildRequestStripsPropertyNamesFromOutboundBody(t *testing.T) {
+	for shapeName, schema := range propertyNamesShapes {
+		for _, modelName := range []string{"gemini-3.1-pro", "claude-opus-4-6"} {
+			t.Run(shapeName+"_"+modelName, func(t *testing.T) {
+				payload := []byte(`{"request":{
+					"contents":[{"role":"model","parts":[{"functionCall":{"name":"t","args":{"propertyNames":"keep-me"}}}]}],
+					"tools":[{"function_declarations":[{"name":"t","parametersJsonSchema":` + schema + `}]}],
+					"generationConfig":{"responseSchema":` + schema + `}
+				}}`)
+
+				body := buildRequestBodyFromRawPayload(t, modelName, payload)
+				encoded, errMarshal := json.Marshal(body)
+				if errMarshal != nil {
+					t.Fatal(errMarshal)
+				}
+
+				for _, path := range []string{"request.tools", "request.generationConfig"} {
+					if node := gjson.GetBytes(encoded, path); strings.Contains(node.Raw, `"propertyNames"`) {
+						t.Errorf("%s still carries propertyNames: %s", path, node.Raw)
+					}
+				}
+				args := gjson.GetBytes(encoded, "request.contents.0.parts.0.functionCall.args")
+				if args.Get("propertyNames").String() != "keep-me" {
+					t.Errorf("functionCall argument named propertyNames was rewritten: %s", args.Raw)
+				}
+			})
+		}
+	}
+}

--- a/internal/translator/antigravity/claude/antigravity_claude_request_test.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request_test.go
@@ -3365,3 +3365,59 @@ func TestConvertClaudeRequestToAntigravity_ToolAndThinking_NoExistingSystem(t *t
 		t.Errorf("Interleaved thinking hint should be in created systemInstruction, got: %v", sysInstruction.Raw)
 	}
 }
+
+// TestConvertClaudeRequestToAntigravityStripsPropertyNames covers the reported ingress route: a
+// Claude Messages request carrying MCP-style tool schemas. The private Gemini backend rejects the
+// standard JSON Schema keyword "propertyNames" with an unknown-field 400 before inference, so it
+// must not survive translation. Both reported nestings are exercised, including the one where the
+// keyword sits inside a property that is itself named "properties".
+func TestConvertClaudeRequestToAntigravityStripsPropertyNames(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "claude-sonnet-4-5",
+		"messages": [{"role": "user", "content": "hi"}],
+		"tools": [
+			{
+				"name": "notion-create-pages",
+				"input_schema": {
+					"type": "object",
+					"properties": {
+						"records": {
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {"name": {"type": "string"}},
+								"propertyNames": {"type": "string"}
+							}
+						}
+					}
+				}
+			},
+			{
+				"name": "notion-update-page",
+				"input_schema": {
+					"type": "object",
+					"properties": {
+						"properties": {"type": "object", "propertyNames": {"type": "string"}}
+					}
+				}
+			}
+		]
+	}`)
+
+	output := ConvertClaudeRequestToAntigravity("claude-sonnet-4-5", inputJSON, false)
+
+	decls := gjson.GetBytes(output, "request.tools.0.functionDeclarations")
+	if !decls.IsArray() || len(decls.Array()) != 2 {
+		t.Fatalf("expected two function declarations, got: %s", decls.Raw)
+	}
+	if strings.Contains(decls.Raw, `"propertyNames"`) {
+		t.Errorf("propertyNames survived translation: %s", decls.Raw)
+	}
+	// The declarations must still be usable, not emptied out by the cleaning.
+	if !decls.Get("0.parametersJsonSchema.properties.records.items.properties.name").Exists() {
+		t.Errorf("array item property was lost: %s", decls.Get("0").Raw)
+	}
+	if !decls.Get("1.parametersJsonSchema.properties.properties").Exists() {
+		t.Errorf("property named properties was lost: %s", decls.Get("1").Raw)
+	}
+}

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -707,8 +707,40 @@ func setRawAt(jsonStr, path, value string) string {
 	return string(result)
 }
 
+// schemaNameMapKeywords are the schema keywords whose value maps author-chosen names to
+// subschemas. A key directly under one of them is a name, never a schema keyword.
+var schemaNameMapKeywords = map[string]struct{}{
+	"properties":        {},
+	"patternProperties": {},
+	"dependentSchemas":  {},
+	"$defs":             {},
+	"definitions":       {},
+}
+
+// isPropertyDefinition reports whether path points at a map whose keys are names chosen by the
+// tool author, so a key spelled like a schema keyword there must be preserved.
+//
+// A trailing ".properties" is not enough to tell: a tool may declare a property named
+// "properties", and the schema for that property then sits at a path ending in ".properties" while
+// being an ordinary schema node. Classifying it as a name map skipped every cleaning pass inside
+// it, so unsupported keywords such as "propertyNames" reached the private Gemini backend, which
+// rejects unknown fields with a 400.
+//
+// Each name-map keyword at the end of the path therefore flips the answer, because the node it
+// names is a map only when its own parent is a schema: "properties" is a map,
+// "properties.properties" the schema of a property named "properties", and
+// "properties.properties.properties" that schema's own map. Only the trailing run matters, so any
+// prefix the caller nests the schema under is ignored.
 func isPropertyDefinition(path string) bool {
-	return path == "properties" || strings.HasSuffix(path, ".properties")
+	segments := splitGJSONPath(path)
+	trailing := 0
+	for i := len(segments) - 1; i >= 0; i-- {
+		if _, ok := schemaNameMapKeywords[unescapeGJSONPathKey(segments[i])]; !ok {
+			break
+		}
+		trailing++
+	}
+	return trailing%2 == 1
 }
 
 func descriptionPath(parentPath string) string {

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -1198,3 +1198,93 @@ func TestCleanJSONSchemaForAntigravity_UniqueItemsStripped(t *testing.T) {
 		t.Errorf("uniqueItems hint missing in description")
 	}
 }
+
+// TestIsPropertyDefinitionDistinguishesPropertyNamedProperties covers the classification that
+// decides whether a key spelled like a schema keyword is a keyword or an author-chosen name.
+// Matching a trailing ".properties" alone mistook the schema of a property named "properties" for
+// a property map, which disabled cleaning inside it.
+func TestIsPropertyDefinitionDistinguishesPropertyNamedProperties(t *testing.T) {
+	for path, want := range map[string]bool{
+		"":                                    false,
+		"properties":                          true,
+		"properties.properties":               false,
+		"properties.properties.properties":    true,
+		"properties.records.items.properties": true,
+		"properties.records.items":            false,
+		// Any prefix the caller nests the schema under must not change the answer.
+		"schema.properties": true,
+		"request.tools.0.functionDeclarations.0.parameters":                       false,
+		"request.tools.0.functionDeclarations.0.parameters.properties":            true,
+		"request.tools.0.functionDeclarations.0.parameters.properties.properties": false,
+		// $defs and patternProperties are name maps for the same reason as properties.
+		"$defs":                          true,
+		"$defs.properties":               false,
+		"properties.$defs":               false,
+		"properties.a.patternProperties": true,
+		"properties.patternProperties":   false,
+	} {
+		if got := isPropertyDefinition(path); got != want {
+			t.Errorf("isPropertyDefinition(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+// TestCleanJSONSchemaStripsPropertyNamesUnderPropertyNamedProperties covers the reported failure:
+// the private Gemini backend rejects "propertyNames" with an unknown-field 400, and MCP tool
+// schemas place it inside a property that is itself named "properties".
+func TestCleanJSONSchemaStripsPropertyNamesUnderPropertyNamedProperties(t *testing.T) {
+	shapes := map[string]string{
+		// Nested in an array item, alongside the item's own properties map.
+		"arrayItem": `{"type":"object","properties":{"records":{"type":"array","items":{"type":"object",` +
+			`"properties":{"name":{"type":"string"}},"propertyNames":{"type":"string"}}}}}`,
+		// A dynamic map declared by a property named "properties".
+		"propertyNamedProperties": `{"type":"object","properties":{"properties":{"type":"object",` +
+			`"propertyNames":{"type":"string"}}}}`,
+		// Both shapes combined, as the reported tool schemas did.
+		"combined": `{"type":"object","properties":{"pages":{"type":"array","items":{"type":"object",` +
+			`"properties":{"properties":{"type":"object","propertyNames":{"type":"string"},` +
+			`"additionalProperties":true}},"propertyNames":{"type":"string"}}}}}`,
+	}
+
+	for name, schema := range shapes {
+		for cleaner, clean := range map[string]func(string) string{
+			"antigravity":         CleanJSONSchemaForAntigravity,
+			"gemini":              CleanJSONSchemaForGemini,
+			"antigravityResponse": CleanJSONSchemaForAntigravityResponse,
+		} {
+			got := clean(schema)
+			if strings.Contains(got, `"propertyNames"`) {
+				t.Errorf("%s/%s: propertyNames survived cleaning: %s", name, cleaner, got)
+			}
+			if strings.Contains(got, `"additionalProperties"`) {
+				t.Errorf("%s/%s: additionalProperties survived cleaning: %s", name, cleaner, got)
+			}
+		}
+	}
+}
+
+// TestCleanJSONSchemaKeepsPropertiesNamedLikeKeywords guards the other half of the rule: a schema
+// may legitimately declare properties named after schema keywords, and those must survive.
+func TestCleanJSONSchemaKeepsPropertiesNamedLikeKeywords(t *testing.T) {
+	input := `{"type":"object","properties":{
+		"propertyNames":{"type":"string"},
+		"patternProperties":{"type":"string"},
+		"properties":{"type":"object","properties":{"propertyNames":{"type":"string"}}}
+	}}`
+
+	for cleaner, clean := range map[string]func(string) string{
+		"antigravity": CleanJSONSchemaForAntigravity,
+		"gemini":      CleanJSONSchemaForGemini,
+	} {
+		got := gjson.Parse(clean(input))
+		for _, path := range []string{
+			"properties.propertyNames",
+			"properties.patternProperties",
+			"properties.properties.properties.propertyNames",
+		} {
+			if !got.Get(path).Exists() {
+				t.Errorf("%s: property %s was removed: %s", cleaner, path, got.Raw)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #4754.

## Root cause

The cleaner in `internal/util/gemini_schema.go` already lists `propertyNames` as unsupported. It never ran on the failing schemas because every cleaning pass is skipped for nodes classified as property maps, and that classification was:

```go
return path == "properties" || strings.HasSuffix(path, ".properties")
```

A tool may declare a property literally **named `properties`** — Notion's page tools do. The schema for that property then sits at `...properties.properties`, matches the suffix, and was mistaken for a property map, so nothing inside it was cleaned. The upstream error names exactly that node:

```
Unknown name "propertyNames" at
'request.tools[0].function_declarations[1].parameters.properties[0].value':
Cannot find field.
```

The gap suspected in the issue — a missing egress location — was not the cause. `sanitizeAntigravityRequestSchemas` already covers both declaration-container spellings, every parameter/result schema key, and the generation-config schemas. The same latent bug also let `additionalProperties`, `format`, `$id`, `x-*`, `nullable` and `title` through inside such a node.

## Fix

Replace the suffix match with a parity check over the trailing run of name-map keywords (`properties`, `patternProperties`, `dependentSchemas`, `$defs`, `definitions`). The node a keyword names is a map only when its own parent is a schema, so `properties` is a map, `properties.properties` is the schema of a property named `properties`, and a third repetition is a map again.

Only the trailing run is inspected, which keeps the check prefix-agnostic. That matters because call sites pass different prefixes: the executor cleans a schema wrapped one level down (`schema.…`), while other callers hand over whole documents (`request.tools.0.…`). An earlier attempt that replayed the path from the root broke both.

Codex/OpenAI egress is untouched: `internal/translator/codex/` calls no `CleanJSONSchema*` helper — it converts `input_schema` via its own `normalizeToolParameters`, in non-strict tool mode — so the changed function is unreachable from that route and this shape keeps working there.

## Verification

**Direct backend A/B, byte-exact.** Took the payload CPA actually emitted and re-inserted only `propertyNames`:

| Variant | Result |
| --- | --- |
| Control — exactly what CPA emits | `200`, `"text": "OK"` |
| Invalid — only `propertyNames` added back | `400`, unknown-field parse error at `function_declarations[1].parameters.properties[0].value` |

The rejection is parser-level and model-independent: across four models the invalid variant was always `400`, while the control never was — it got past the parser into model resolution and quota (`200`/`404`/`429`/`500`/`503`).

**Live end-to-end** through a local instance built from this commit, sending a Claude Messages request that carries both reported nestings at once:

| Requested model | HTTP | Upstream model | Tool mode | `propertyNames` outbound |
| --- | --- | --- | --- | --- |
| gemini-3.5-flash | 200 | gemini-3-flash-agent | – | no |
| gemini-3.1-pro-preview | 200 | gemini-pro-agent | – | no |
| gemini-3.1-pro-low | 200 | gemini-3.1-pro-low | – | no |
| claude-haiku-4-5 | 200 | gemini-3-flash | – | no |
| claude-opus-4-6 | 200 | claude-opus-4-6-thinking | VALIDATED | no |
| claude-sonnet-4-6 | 200 | claude-sonnet-4-6 | VALIDATED | no |

Both cleaner variants are covered. Request logs confirm `provider=antigravity`, final `Status: 200`, `propertyNames` present in the inbound client body and absent from the outbound upstream request, with both declarations structurally intact.

**Tests.** The new regression tests fail before this commit and pass after:

- `isPropertyDefinition` classification, including the prefixed and repeated-segment cases
- both reported nestings, across all three cleaners
- properties legitimately named `propertyNames` / `patternProperties` / `properties` are preserved
- every declaration schema key and generation-config schema, in both container spellings
- the emitted body from `buildRequest`, so a later transformation cannot reintroduce the keyword unnoticed
- `functionCall` arguments and conversation history are not rewritten
- the Claude Messages ingress route through the Antigravity translator

`gofmt` clean, `go vet` clean, `go build ./cmd/server` OK, full `go test ./...` green (88 packages).
