### PR TITLE
feat(plugins): add authenticated model catalog filter

### DIFF
--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -852,6 +852,7 @@ func validPlugin(plugin pluginapi.Plugin) bool {
 		caps.FrontendAuthProvider != nil ||
 		caps.Scheduler != nil ||
 		caps.ModelRouter != nil ||
+		caps.ModelCatalogFilter != nil ||
 		caps.Executor != nil ||
 		caps.RequestTranslator != nil ||
 		caps.RequestNormalizer != nil ||

--- a/internal/pluginhost/model_catalog_filter.go
+++ b/internal/pluginhost/model_catalog_filter.go
@@ -25,6 +25,7 @@ func (h *Host) FilterModelCatalog(ctx context.Context, req pluginapi.ModelCatalo
 		nextReq.Plugin = clonePluginMetadata(record.meta)
 		nextReq.PluginID = record.id
 		nextReq.Models = cloneCatalogModels(current)
+		nextReq.ModelProviders = cloneModelProviders(req.ModelProviders)
 		resp, err := filter.FilterModelCatalog(ctx, nextReq)
 		if err != nil {
 			return pluginapi.ModelCatalogFilterResponse{}, fmt.Errorf("model catalog filter %s: %w", record.id, err)
@@ -36,6 +37,17 @@ func (h *Host) FilterModelCatalog(ctx context.Context, req pluginapi.ModelCatalo
 		handled = true
 	}
 	return pluginapi.ModelCatalogFilterResponse{Handled: handled, Models: current}, nil
+}
+
+func cloneModelProviders(input map[string][]string) map[string][]string {
+	if len(input) == 0 {
+		return map[string][]string{}
+	}
+	out := make(map[string][]string, len(input))
+	for model, providers := range input {
+		out[model] = append([]string(nil), providers...)
+	}
+	return out
 }
 
 func cloneCatalogModels(models []map[string]any) []map[string]any {

--- a/internal/pluginhost/model_catalog_filter.go
+++ b/internal/pluginhost/model_catalog_filter.go
@@ -1,0 +1,54 @@
+package pluginhost
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+// FilterModelCatalog chains active catalog filters in plugin priority order.
+// Errors are returned to the endpoint so an authorization filter fails closed
+// instead of accidentally exposing the unfiltered global catalog.
+func (h *Host) FilterModelCatalog(ctx context.Context, req pluginapi.ModelCatalogFilterRequest) (pluginapi.ModelCatalogFilterResponse, error) {
+	if h == nil {
+		return pluginapi.ModelCatalogFilterResponse{Models: req.Models}, nil
+	}
+	current := cloneCatalogModels(req.Models)
+	handled := false
+	for _, record := range h.activeRecords() {
+		filter := record.plugin.Capabilities.ModelCatalogFilter
+		if filter == nil || h.isPluginFused(record.id) {
+			continue
+		}
+		nextReq := req
+		nextReq.Plugin = clonePluginMetadata(record.meta)
+		nextReq.PluginID = record.id
+		nextReq.Models = cloneCatalogModels(current)
+		resp, err := filter.FilterModelCatalog(ctx, nextReq)
+		if err != nil {
+			return pluginapi.ModelCatalogFilterResponse{}, fmt.Errorf("model catalog filter %s: %w", record.id, err)
+		}
+		if !resp.Handled {
+			continue
+		}
+		current = cloneCatalogModels(resp.Models)
+		handled = true
+	}
+	return pluginapi.ModelCatalogFilterResponse{Handled: handled, Models: current}, nil
+}
+
+func cloneCatalogModels(models []map[string]any) []map[string]any {
+	if len(models) == 0 {
+		return []map[string]any{}
+	}
+	out := make([]map[string]any, 0, len(models))
+	for _, model := range models {
+		copyModel := make(map[string]any, len(model))
+		for key, value := range model {
+			copyModel[key] = value
+		}
+		out = append(out, copyModel)
+	}
+	return out
+}

--- a/internal/pluginhost/model_catalog_filter_test.go
+++ b/internal/pluginhost/model_catalog_filter_test.go
@@ -1,0 +1,72 @@
+package pluginhost
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+type modelCatalogFilterFunc func(context.Context, pluginapi.ModelCatalogFilterRequest) (pluginapi.ModelCatalogFilterResponse, error)
+
+func (fn modelCatalogFilterFunc) FilterModelCatalog(ctx context.Context, req pluginapi.ModelCatalogFilterRequest) (pluginapi.ModelCatalogFilterResponse, error) {
+	return fn(ctx, req)
+}
+
+func TestHostChainsModelCatalogFilters(t *testing.T) {
+	host := newHostWithRecords(
+		capabilityRecord{
+			id:       "second",
+			priority: 1,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				ModelCatalogFilter: modelCatalogFilterFunc(func(_ context.Context, req pluginapi.ModelCatalogFilterRequest) (pluginapi.ModelCatalogFilterResponse, error) {
+					if len(req.Models) != 2 {
+						t.Fatalf("second filter received %d models, want 2", len(req.Models))
+					}
+					return pluginapi.ModelCatalogFilterResponse{Handled: true, Models: req.Models[:1]}, nil
+				}),
+			}},
+		},
+		capabilityRecord{
+			id:       "first",
+			priority: 10,
+			meta:     pluginapi.Metadata{Name: "First"},
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				ModelCatalogFilter: modelCatalogFilterFunc(func(_ context.Context, req pluginapi.ModelCatalogFilterRequest) (pluginapi.ModelCatalogFilterResponse, error) {
+					if req.PluginID != "first" || req.Plugin.Name != "First" {
+						t.Fatalf("plugin context = %q %#v", req.PluginID, req.Plugin)
+					}
+					return pluginapi.ModelCatalogFilterResponse{Handled: true, Models: req.Models[:2]}, nil
+				}),
+			}},
+		},
+	)
+
+	resp, err := host.FilterModelCatalog(context.Background(), pluginapi.ModelCatalogFilterRequest{
+		Models: []map[string]any{{"id": "a"}, {"id": "b"}, {"id": "c"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Handled || len(resp.Models) != 1 || resp.Models[0]["id"] != "a" {
+		t.Fatalf("FilterModelCatalog() = %#v", resp)
+	}
+}
+
+func TestHostModelCatalogFilterFailsClosed(t *testing.T) {
+	host := newHostWithRecords(capabilityRecord{
+		id: "broken",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			ModelCatalogFilter: modelCatalogFilterFunc(func(context.Context, pluginapi.ModelCatalogFilterRequest) (pluginapi.ModelCatalogFilterResponse, error) {
+				return pluginapi.ModelCatalogFilterResponse{}, errors.New("policy unavailable")
+			}),
+		}},
+	})
+
+	if _, err := host.FilterModelCatalog(context.Background(), pluginapi.ModelCatalogFilterRequest{
+		Models: []map[string]any{{"id": "secret"}},
+	}); err == nil {
+		t.Fatal("filter failure must not fall back to the unfiltered catalog")
+	}
+}

--- a/internal/pluginhost/rpc_client.go
+++ b/internal/pluginhost/rpc_client.go
@@ -95,6 +95,9 @@ func registerRPCPlugin(ctx context.Context, host *Host, id string, client plugin
 	if resp.Capabilities.ModelRouter {
 		plugin.Capabilities.ModelRouter = adapter
 	}
+	if resp.Capabilities.ModelCatalogFilter {
+		plugin.Capabilities.ModelCatalogFilter = adapter
+	}
 	if resp.Capabilities.Executor {
 		plugin.Capabilities.Executor = rpcProviderExecutor{rpcPluginAdapter: adapter}
 	}
@@ -371,6 +374,10 @@ func (a *rpcPluginAdapter) RouteModel(ctx context.Context, req pluginapi.ModelRo
 		ModelRouteRequest: req,
 		HostCallbackID:    callbackID,
 	})
+}
+
+func (a *rpcPluginAdapter) FilterModelCatalog(ctx context.Context, req pluginapi.ModelCatalogFilterRequest) (pluginapi.ModelCatalogFilterResponse, error) {
+	return callPlugin[pluginapi.ModelCatalogFilterResponse](ctx, a.client, pluginabi.MethodModelCatalogFilter, req)
 }
 
 func callPluginIdentifier(client pluginClient, method string) string {

--- a/internal/pluginhost/rpc_schema.go
+++ b/internal/pluginhost/rpc_schema.go
@@ -26,6 +26,7 @@ type rpcCapabilities struct {
 	FrontendAuthProviderExclusive bool                         `json:"frontend_auth_provider_exclusive"`
 	Scheduler                     bool                         `json:"scheduler"`
 	ModelRouter                   bool                         `json:"model_router"`
+	ModelCatalogFilter            bool                         `json:"model_catalog_filter"`
 	Executor                      bool                         `json:"executor"`
 	ExecutorModelScope            pluginapi.ExecutorModelScope `json:"executor_model_scope"`
 	ExecutorInputFormats          []string                     `json:"executor_input_formats,omitempty"`
@@ -137,6 +138,7 @@ func rpcCapabilitiesFromPlugin(plugin pluginapi.Plugin) rpcCapabilities {
 		FrontendAuthProviderExclusive: caps.FrontendAuthProvider != nil && caps.FrontendAuthProviderExclusive,
 		Scheduler:                     caps.Scheduler != nil,
 		ModelRouter:                   caps.ModelRouter != nil,
+		ModelCatalogFilter:            caps.ModelCatalogFilter != nil,
 		Executor:                      caps.Executor != nil,
 		ExecutorModelScope:            normalizedExecutorModelScope(caps),
 		ExecutorInputFormats:          append([]string(nil), caps.ExecutorInputFormats...),

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -182,6 +182,32 @@ func (r *ModelRegistry) invalidateAvailableModelsCacheLocked() {
 	clear(r.availableModelsCache)
 }
 
+// GetModelProvidersSnapshot returns the active provider keys for every model.
+// The result is a defensive copy intended for caller-specific model catalog
+// filtering; provider metadata is not added to the public OpenAI response.
+func (r *ModelRegistry) GetModelProvidersSnapshot() map[string][]string {
+	if r == nil {
+		return map[string][]string{}
+	}
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	out := make(map[string][]string, len(r.models))
+	for modelID, registration := range r.models {
+		if registration == nil || len(registration.Providers) == 0 {
+			continue
+		}
+		providers := make([]string, 0, len(registration.Providers))
+		for provider, count := range registration.Providers {
+			if count > 0 {
+				providers = append(providers, provider)
+			}
+		}
+		sort.Strings(providers)
+		out[modelID] = providers
+	}
+	return out
+}
+
 // LookupModelInfo searches dynamic registry (provider-specific > global) then static definitions.
 func LookupModelInfo(modelID string, provider ...string) *ModelInfo {
 	modelID = strings.TrimSpace(modelID)

--- a/sdk/api/handlers/handlers_model_catalog.go
+++ b/sdk/api/handlers/handlers_model_catalog.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+type pluginModelCatalogFilterHost interface {
+	FilterModelCatalog(ctx context.Context, req pluginapi.ModelCatalogFilterRequest) (pluginapi.ModelCatalogFilterResponse, error)
+}
+
+// FilterModelCatalog applies authenticated caller-specific catalog filters.
+func (h *BaseAPIHandler) FilterModelCatalog(c *gin.Context, models []map[string]any) ([]map[string]any, error) {
+	if h == nil || c == nil || h.PluginHost == nil {
+		return models, nil
+	}
+	host, ok := h.PluginHost.(pluginModelCatalogFilterHost)
+	if !ok {
+		return models, nil
+	}
+	metadata := map[string]string{}
+	if raw, exists := c.Get("accessMetadata"); exists {
+		if values, valid := raw.(map[string]string); valid {
+			for key, value := range values {
+				metadata[key] = value
+			}
+		}
+	}
+	resp, err := host.FilterModelCatalog(c.Request.Context(), pluginapi.ModelCatalogFilterRequest{
+		Method:         c.Request.Method,
+		Path:           c.Request.URL.Path,
+		Headers:        c.Request.Header.Clone(),
+		Query:          c.Request.URL.Query(),
+		AccessMetadata: metadata,
+		Models:         models,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("filter model catalog: %w", err)
+	}
+	if !resp.Handled {
+		return models, nil
+	}
+	return resp.Models, nil
+}

--- a/sdk/api/handlers/handlers_model_catalog.go
+++ b/sdk/api/handlers/handlers_model_catalog.go
@@ -13,7 +13,7 @@ type pluginModelCatalogFilterHost interface {
 }
 
 // FilterModelCatalog applies authenticated caller-specific catalog filters.
-func (h *BaseAPIHandler) FilterModelCatalog(c *gin.Context, models []map[string]any) ([]map[string]any, error) {
+func (h *BaseAPIHandler) FilterModelCatalog(c *gin.Context, models []map[string]any, modelProviders map[string][]string) ([]map[string]any, error) {
 	if h == nil || c == nil || h.PluginHost == nil {
 		return models, nil
 	}
@@ -36,6 +36,7 @@ func (h *BaseAPIHandler) FilterModelCatalog(c *gin.Context, models []map[string]
 		Query:          c.Request.URL.Query(),
 		AccessMetadata: metadata,
 		Models:         models,
+		ModelProviders: modelProviders,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("filter model catalog: %w", err)

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -66,7 +66,7 @@ func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 
 	// Get all available models
 	allModels := h.Models()
-	allModels, err := h.FilterModelCatalog(c, allModels)
+	allModels, err := h.FilterModelCatalog(c, allModels, registry.GetGlobalRegistry().GetModelProvidersSnapshot())
 	if err != nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "model catalog unavailable"})
 		return

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -66,6 +66,11 @@ func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 
 	// Get all available models
 	allModels := h.Models()
+	allModels, err := h.FilterModelCatalog(c, allModels)
+	if err != nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "model catalog unavailable"})
+		return
+	}
 
 	// Filter to only include the 4 required fields: id, object, created, owned_by
 	filteredModels := make([]map[string]any, len(allModels))

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -357,7 +357,7 @@ func (h *OpenAIResponsesAPIHandler) Models() []map[string]any {
 // It returns a list of available AI models with their capabilities
 // and specifications in OpenAIResponses-compatible format.
 func (h *OpenAIResponsesAPIHandler) OpenAIResponsesModels(c *gin.Context) {
-	models, err := h.FilterModelCatalog(c, h.Models())
+	models, err := h.FilterModelCatalog(c, h.Models(), registry.GetGlobalRegistry().GetModelProvidersSnapshot())
 	if err != nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "model catalog unavailable"})
 		return

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -357,9 +357,14 @@ func (h *OpenAIResponsesAPIHandler) Models() []map[string]any {
 // It returns a list of available AI models with their capabilities
 // and specifications in OpenAIResponses-compatible format.
 func (h *OpenAIResponsesAPIHandler) OpenAIResponsesModels(c *gin.Context) {
+	models, err := h.FilterModelCatalog(c, h.Models())
+	if err != nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "model catalog unavailable"})
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{
 		"object": "list",
-		"data":   h.Models(),
+		"data":   models,
 	})
 }
 

--- a/sdk/pluginabi/types.go
+++ b/sdk/pluginabi/types.go
@@ -32,6 +32,8 @@ const (
 	MethodSchedulerPick = "scheduler.pick"
 	// MethodModelRoute asks a router plugin to select a plugin executor for a matching request.
 	MethodModelRoute = "model.route"
+	// MethodModelCatalogFilter asks a plugin to filter an authenticated model list.
+	MethodModelCatalogFilter = "model.catalog_filter"
 
 	MethodExecutorIdentifier    = "executor.identifier"
 	MethodExecutorExecute       = "executor.execute"

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -490,6 +490,10 @@ type ModelCatalogFilterRequest struct {
 	Query          url.Values
 	AccessMetadata map[string]string
 	Models         []map[string]any
+	// ModelProviders maps model IDs to the currently available provider keys.
+	// It lets filters apply provider-scoped grants without exposing this
+	// host-internal routing metadata in the OpenAI response body.
+	ModelProviders map[string][]string
 }
 
 // ModelCatalogFilterResponse contains the caller-visible model list.

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -82,6 +82,8 @@ type Capabilities struct {
 	// ModelRouter routes matching requests to a plugin executor, the router's own executor,
 	// or a built-in provider before model-to-provider resolution and auth selection.
 	ModelRouter ModelRouter
+	// ModelCatalogFilter filters model-list responses for the authenticated caller.
+	ModelCatalogFilter ModelCatalogFilter
 	// Executor sends requests to an upstream provider or local backend.
 	Executor ProviderExecutor
 	// ExecutorModelScope declares whether Executor serves static models, OAuth auth models, or both.
@@ -469,6 +471,31 @@ type Scheduler interface {
 // or a built-in provider before model-to-provider resolution and auth selection.
 type ModelRouter interface {
 	RouteModel(context.Context, ModelRouteRequest) (ModelRouteResponse, error)
+}
+
+// ModelCatalogFilter filters the models returned by model discovery endpoints.
+// Filters run after frontend authentication and are chained in plugin priority
+// order. A filter must return Handled=false to leave the current list unchanged.
+type ModelCatalogFilter interface {
+	FilterModelCatalog(context.Context, ModelCatalogFilterRequest) (ModelCatalogFilterResponse, error)
+}
+
+// ModelCatalogFilterRequest describes an authenticated model-list request.
+type ModelCatalogFilterRequest struct {
+	Plugin         Metadata
+	PluginID       string
+	Method         string
+	Path           string
+	Headers        http.Header
+	Query          url.Values
+	AccessMetadata map[string]string
+	Models         []map[string]any
+}
+
+// ModelCatalogFilterResponse contains the caller-visible model list.
+type ModelCatalogFilterResponse struct {
+	Handled bool
+	Models  []map[string]any
 }
 
 // SchedulerPickRequest describes the routing context offered to a scheduler plugin.


### PR DESCRIPTION
## Why

Frontend auth plugins can allow or deny GET /v1/models, but cannot make the returned catalog match the authenticated caller's provider/model ACL. Returning the global registry leaks unavailable model names and breaks client model discovery; denying the endpoint prevents normal OpenAI-compatible clients from discovering their allowed models.

Our concrete deployment uses CPA native api-keys as the single identity source and a frontend-auth plugin for per-key provider/model grants. It needs model discovery to return exactly the granted model subset without introducing a second gateway or key system.

## What

Adds an optional, backwards-compatible ModelCatalogFilter plugin capability and RPC method model.catalog_filter. Filters run after frontend authentication, receive request/access metadata plus the current model list, and chain in plugin priority order. Filter errors fail the model endpoint closed with 503 rather than falling back to the unfiltered global catalog.

Both OpenAI model handlers use the hook. Existing plugins and configurations are unchanged.