### PR TITLE
fix: 嵌套流式执行遵守路由插件跳过标记

### DIFF
--- a/sdk/api/handlers/handlers_context.go
+++ b/sdk/api/handlers/handlers_context.go
@@ -54,8 +54,11 @@ func (h *BaseAPIHandler) PrepareStreamModelRoute(ctx context.Context, handlerTyp
 	return ctx, hasOverride
 }
 
-func preparedModelRouteFromContext(ctx context.Context) (modelRouteDecision, bool) {
-	if ctx == nil {
+func preparedModelRouteFromContext(ctx context.Context, skipRouterPluginID string) (modelRouteDecision, bool) {
+	// A host.model.execute_stream callback is a nested execution. Its caller is
+	// excluded from model routing, so an outer prepared route cannot be reused:
+	// it may point straight back at that caller.
+	if ctx == nil || strings.TrimSpace(skipRouterPluginID) != "" {
 		return modelRouteDecision{}, false
 	}
 	decision, ok := ctx.Value(preparedModelRouteContextKey{}).(modelRouteDecision)

--- a/sdk/api/handlers/handlers_model_router_test.go
+++ b/sdk/api/handlers/handlers_model_router_test.go
@@ -93,6 +93,20 @@ type handlerDirectExecutorRouteHost struct {
 	stream       func(context.Context, string, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error)
 }
 
+type handlerSkipAwareDirectExecutorRouteHost struct {
+	handlerDirectExecutorRouteHost
+	routeSkip string
+}
+
+func (h *handlerSkipAwareDirectExecutorRouteHost) RouteModelExcept(ctx context.Context, req pluginapi.ModelRouteRequest, skipPluginID string) (pluginapi.ModelRouteResponse, bool) {
+	h.routeSkip = skipPluginID
+	return pluginapi.ModelRouteResponse{}, false
+}
+
+func (h *handlerSkipAwareDirectExecutorRouteHost) HasModelRoutersExcept(string) bool {
+	return h != nil && h.hasRouters
+}
+
 func (h *handlerDirectExecutorRouteHost) ExecutePluginExecutor(ctx context.Context, pluginID string, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
 	h.lastPluginID = pluginID
 	h.lastRequest = req
@@ -493,6 +507,42 @@ func TestPrepareStreamModelRouteReusesDecisionDuringExecution(t *testing.T) {
 	}
 	if host.lastPluginID != targetPluginID {
 		t.Fatalf("plugin id = %q, want %q", host.lastPluginID, targetPluginID)
+	}
+}
+
+func TestExecuteModelStreamDoesNotReusePreparedRouteWhenRouterPluginSkipped(t *testing.T) {
+	const originalModel = "prepared-router-model"
+	const mappedModel = "mapped-upstream-model"
+	const originPluginID = "origin-plugin"
+	host := &handlerSkipAwareDirectExecutorRouteHost{}
+	host.hasRouters = true
+	host.route = func(context.Context, pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: originPluginID}, true
+	}
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(host)
+	body := []byte(`{"model":"prepared-router-model","stream":true}`)
+	ctx, routedToPlugin := handler.PrepareStreamModelRoute(context.Background(), "openai-response", originalModel, body)
+	if !routedToPlugin {
+		t.Fatal("PrepareStreamModelRoute() did not detect plugin executor route")
+	}
+
+	_, errMsg := handler.ExecuteModelStream(ctx, ModelExecutionRequest{
+		EntryProtocol:      "openai-response",
+		ExitProtocol:       "openai-response",
+		Model:              mappedModel,
+		Stream:             true,
+		Body:               []byte(`{"model":"mapped-upstream-model","stream":true}`),
+		SkipRouterPluginID: originPluginID,
+	})
+	if host.routeSkip != originPluginID {
+		t.Fatalf("router skip id = %q, want %q", host.routeSkip, originPluginID)
+	}
+	if host.lastPluginID == originPluginID {
+		t.Fatalf("plugin executor %q was re-entered despite SkipRouterPluginID", host.lastPluginID)
+	}
+	if errMsg == nil {
+		t.Fatal("ExecuteModelStream() error = nil, want normal provider resolution failure with empty auth manager")
 	}
 }
 

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -227,7 +227,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManager(ctx context.Context, handl
 
 func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context, entryProtocol, exitProtocol, modelName string, rawJSON []byte, alt string, allowImageModel bool, execOptions modelExecutionOptions) (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
 	originalRequestedModel := modelName
-	routeDecision, preparedRoute := preparedModelRouteFromContext(ctx)
+	routeDecision, preparedRoute := preparedModelRouteFromContext(ctx, execOptions.SkipRouterPluginID)
 	if !preparedRoute {
 		routeDecision = h.applyModelRouter(ctx, entryProtocol, modelName, rawJSON, true, execOptions)
 	}


### PR DESCRIPTION
## 变更摘要

- 当嵌套模型执行携带 `SkipRouterPluginID` 时，丢弃外层 prepared stream route
- 重新执行模型路由并排除 callback 调用方，避免 self-routing 插件递归调用自身
- 保持顶层 WebSocket 请求复用 prepared route 的现有行为不变
- 增加集成回归测试，覆盖 prepared route、嵌套 `ExecuteModelStream` 与 router skip 的组合

## 根因与影响

Codex Responses WebSocket handler 会把外层模型路由决定保存在 context 中。插件 executor 通过 `host.model.execute_stream` 转发请求时会继承该 context，并正确设置 `SkipRouterPluginID`；但 stream handler 在应用 skip 之前直接复用了缓存。

如果缓存指向 callback 调用方，每一次嵌套执行都会重新进入同一个插件，持续创建 plugin stream、callback context、channel、goroutine，并反复复制完整请求体。最终表现为请求长时间等待、CPA CPU/内存快速上涨，严重时进程失去响应或被 OOM killer 终止。

完整触发条件、受影响版本、调用链和影响分析见 #4770。

## 修复方式

把非空 `SkipRouterPluginID` 视为嵌套执行边界：外层 prepared route 对嵌套请求不再有效，因此重新运行 model router，并把调用方插件排除在外。

不携带 router skip 的顶层 WebSocket 请求仍然复用 prepared route，避免重复计算路由。

Fixes #4770

Supersedes #4532。旧 PR 基于拆分前的单体 handler 文件，目前存在合并冲突，且没有覆盖该组合的回归测试。

## 测试

以下验证已通过：

- `go test ./sdk/api/handlers -run '^(TestExecuteModelStreamDoesNotReusePreparedRouteWhenRouterPluginSkipped|TestPrepareStreamModelRouteReusesDecisionDuringExecution|TestExecuteModelPropagatesRouterSkipPluginID)$' -count=1 -v`
- `go test ./sdk/api/handlers ./internal/pluginhost -count=1`
- `go build -o test-output ./cmd/server`
- `git diff --check`
- GitHub Actions：build、translator path guard、AGENTS.md guard 全部通过

`go test ./... -count=1` 中，本次改动及相关 package 均通过；但在 macOS arm64 上仍有 3 个位于未改动 `internal/runtime/executor` package 的既有架构期望失败：

- `TestApplyClaudeHeaders_DisableDeviceProfileStabilization`
- `TestApplyClaudeHeaders_LegacyModePreservesConfiguredUserAgentOverrideForClaudeClients`
- `TestClaudeExecutor_NonClaudeRequestUsesClaudeCode220CLIFingerprint`

三项均报告 `X-Stainless-Arch = "arm64", want "x64"`，与本 PR 修改的 handler 路由逻辑无关。
