### PR TITLE
fix(claude): preserve Retry-After quota cooldown

### DIFF
--- a/internal/runtime/executor/claude_executor_beta_policy_test.go
+++ b/internal/runtime/executor/claude_executor_beta_policy_test.go
@@ -256,7 +256,7 @@ func TestClassifyClaudeUpstreamError_FastModeCreditsIsRequestScoped(t *testing.T
 		[]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Fast mode requires usage credits"}}`),
 	}
 	for _, body := range bodies {
-		err := classifyClaudeUpstreamError(http.StatusTooManyRequests, body)
+		err := classifyClaudeUpstreamError(http.StatusTooManyRequests, nil, body)
 
 		scoped, ok := err.(cliproxyexecutor.RequestScopedError)
 		if !ok || !scoped.IsRequestScoped() {
@@ -281,7 +281,7 @@ func TestClassifyClaudeUpstreamError_RealRateLimitStaysCredentialScoped(t *testi
 		[]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"This organization has exceeded its usage limit."}}`),
 	}
 	for _, body := range cases {
-		err := classifyClaudeUpstreamError(http.StatusTooManyRequests, body)
+		err := classifyClaudeUpstreamError(http.StatusTooManyRequests, nil, body)
 		if scoped, ok := err.(cliproxyexecutor.RequestScopedError); ok && scoped.IsRequestScoped() {
 			t.Fatalf("genuine rate limit was misclassified as request-scoped: %s", body)
 		}
@@ -292,7 +292,7 @@ func TestClassifyClaudeUpstreamError_OtherStatusesUnaffected(t *testing.T) {
 	body := []byte(`{"error":{"message":"Usage credits are required for fast mode."}}`)
 	// Only 429 carries the entitlement refusal; a 500 mentioning it is still a
 	// credential-scoped failure worth rotating away from.
-	err := classifyClaudeUpstreamError(http.StatusInternalServerError, body)
+	err := classifyClaudeUpstreamError(http.StatusInternalServerError, nil, body)
 	if scoped, ok := err.(cliproxyexecutor.RequestScopedError); ok && scoped.IsRequestScoped() {
 		t.Fatal("non-429 status was misclassified as request-scoped")
 	}

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -176,7 +176,8 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 			helps.RecordAPIResponseError(ctx, e.cfg, decErr)
 			msg := fmt.Sprintf("failed to decode error response body: %v", decErr)
 			helps.LogWithRequestID(ctx).Warn(msg)
-			return resp, wrapClaudeFastRequestError(fastRequest, httpResp.StatusCode, statusErr{code: httpResp.StatusCode, msg: msg})
+			upstreamErr := classifyClaudeUpstreamError(httpResp.StatusCode, httpResp.Header, []byte(msg))
+			return resp, wrapClaudeFastRequestError(fastRequest, httpResp.StatusCode, upstreamErr)
 		}
 		b, readErr := io.ReadAll(errBody)
 		if readErr != nil {
@@ -193,7 +194,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		if fastRequest {
 			return resp, newClaudeFastDirectResponseError(httpResp, b)
 		}
-		return resp, classifyClaudeUpstreamError(httpResp.StatusCode, b)
+		return resp, classifyClaudeUpstreamError(httpResp.StatusCode, httpResp.Header, b)
 	}
 	decodedBody, err := decodeResponseBody(httpResp.Body, claudeResponseContentEncoding(httpResp.Header))
 	if err != nil {

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -12,7 +12,9 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/andybalholm/brotli"
 	"github.com/google/uuid"
@@ -271,12 +273,30 @@ func (claudeEntitlementError) IsRequestScoped() bool {
 // next one, which returns the same 429. A single speed:"fast" request would walk
 // the whole Claude pool and cool down every credential, all of which remain
 // perfectly healthy for ordinary traffic. The refusal belongs to the request.
-func classifyClaudeUpstreamError(statusCode int, body []byte) error {
-	err := statusErr{code: statusCode, msg: string(body)}
+func classifyClaudeUpstreamError(statusCode int, headers http.Header, body []byte) error {
+	err := statusErr{
+		code:       statusCode,
+		msg:        string(body),
+		retryAfter: parseClaudeRetryAfterHeader(statusCode, headers),
+	}
 	if statusCode == http.StatusTooManyRequests && claudeBodyIndicatesFastModeCredits(body) {
 		return claudeEntitlementError{err}
 	}
 	return err
+}
+
+// parseClaudeRetryAfterHeader reads Anthropic's integer delta-seconds quota hint.
+func parseClaudeRetryAfterHeader(statusCode int, headers http.Header) *time.Duration {
+	if statusCode != http.StatusTooManyRequests || headers == nil {
+		return nil
+	}
+	raw := strings.TrimSpace(headers.Get("Retry-After"))
+	seconds, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil || seconds > uint64(time.Duration(1<<63-1)/time.Second) {
+		return nil
+	}
+	retryAfter := time.Duration(seconds) * time.Second
+	return &retryAfter
 }
 
 // claudeBodyIndicatesFastModeCredits matches Anthropic's fast-mode entitlement

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -175,7 +175,8 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			helps.RecordAPIResponseError(ctx, e.cfg, decErr)
 			msg := fmt.Sprintf("failed to decode error response body: %v", decErr)
 			helps.LogWithRequestID(ctx).Warn(msg)
-			return nil, wrapClaudeFastRequestError(fastRequest, httpResp.StatusCode, statusErr{code: httpResp.StatusCode, msg: msg})
+			upstreamErr := classifyClaudeUpstreamError(httpResp.StatusCode, httpResp.Header, []byte(msg))
+			return nil, wrapClaudeFastRequestError(fastRequest, httpResp.StatusCode, upstreamErr)
 		}
 		b, readErr := io.ReadAll(errBody)
 		if readErr != nil {
@@ -192,7 +193,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		if fastRequest {
 			return nil, newClaudeFastDirectResponseError(httpResp, b)
 		}
-		return nil, classifyClaudeUpstreamError(httpResp.StatusCode, b)
+		return nil, classifyClaudeUpstreamError(httpResp.StatusCode, httpResp.Header, b)
 	}
 	decodedBody, err := decodeResponseBody(httpResp.Body, claudeResponseContentEncoding(httpResp.Header))
 	if err != nil {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -3063,6 +3063,153 @@ func TestClaudeExecutor_ExecuteSanitizesSignaturesBeforeUpstream(t *testing.T) {
 	}
 }
 
+func TestClaudeExecutor_HTTPErrorRetryAfter(t *testing.T) {
+	const retryAfterSeconds = 124633
+	const errorBody = `{"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your account's rate limit. Please try again later."}}`
+
+	testCases := []struct {
+		name       string
+		compressed bool
+		invoke     func(context.Context, *ClaudeExecutor, *cliproxyauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) error
+	}{
+		{
+			name: "execute",
+			invoke: func(ctx context.Context, executor *ClaudeExecutor, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) error {
+				_, err := executor.Execute(ctx, auth, req, opts)
+				return err
+			},
+		},
+		{
+			name:       "execute stream",
+			compressed: true,
+			invoke: func(ctx context.Context, executor *ClaudeExecutor, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) error {
+				_, err := executor.ExecuteStream(ctx, auth, req, opts)
+				return err
+			},
+		},
+		{
+			name: "count tokens",
+			invoke: func(ctx context.Context, executor *ClaudeExecutor, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) error {
+				_, err := executor.CountTokens(ctx, auth, req, opts)
+				return err
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				body := []byte(errorBody)
+				header := http.Header{
+					"Content-Type": {"application/json"},
+					"Retry-After":  {"124633"},
+				}
+				if testCase.compressed {
+					var compressed bytes.Buffer
+					writer := gzip.NewWriter(&compressed)
+					if _, errWrite := writer.Write(body); errWrite != nil {
+						t.Fatal(errWrite)
+					}
+					if errClose := writer.Close(); errClose != nil {
+						t.Fatal(errClose)
+					}
+					body = compressed.Bytes()
+					header.Set("Content-Encoding", "gzip")
+				}
+				return &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Header:     header,
+					Body:       io.NopCloser(bytes.NewReader(body)),
+					Request:    req,
+				}, nil
+			})
+			ctx := context.WithValue(t.Context(), "cliproxy.roundtripper", http.RoundTripper(transport))
+			auth := &cliproxyauth.Auth{
+				ID:         "claude-retry-after-" + strings.ReplaceAll(testCase.name, " ", "-"),
+				Attributes: map[string]string{"api_key": "sk-ant-oat-retry-after"},
+				Metadata:   claudeOAuthTestMetadata(),
+			}
+			request := cliproxyexecutor.Request{
+				Model:   "claude-opus-5",
+				Payload: []byte(`{"model":"claude-opus-5","max_tokens":16,"messages":[{"role":"user","content":"reply OK"}]}`),
+			}
+			options := cliproxyexecutor.Options{
+				Stream:         testCase.name == "execute stream",
+				SourceFormat:   sdktranslator.FormatClaude,
+				ResponseFormat: sdktranslator.FormatClaude,
+			}
+
+			err := testCase.invoke(ctx, NewClaudeExecutor(&config.Config{}), auth, request, options)
+			if err == nil {
+				t.Fatal("Claude executor error = nil, want 429")
+			}
+			var statusError interface{ StatusCode() int }
+			if !errors.As(err, &statusError) || statusError.StatusCode() != http.StatusTooManyRequests {
+				t.Fatalf("Claude executor error = %T %v, want status 429", err, err)
+			}
+			var retryError interface{ RetryAfter() *time.Duration }
+			if !errors.As(err, &retryError) || retryError.RetryAfter() == nil {
+				t.Fatalf("Claude executor error = %T %v, want RetryAfter", err, err)
+			}
+			if got, want := *retryError.RetryAfter(), retryAfterSeconds*time.Second; got != want {
+				t.Fatalf("RetryAfter() = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestClaudeExecutor_HTTPErrorRetryAfterIgnoresAbsentOrInvalidValues(t *testing.T) {
+	testCases := []struct {
+		name       string
+		status     int
+		retryAfter string
+	}{
+		{name: "absent", status: http.StatusTooManyRequests},
+		{name: "not an integer", status: http.StatusTooManyRequests, retryAfter: "later"},
+		{name: "negative", status: http.StatusTooManyRequests, retryAfter: "-1"},
+		{name: "overflow", status: http.StatusTooManyRequests, retryAfter: "9223372036854775807"},
+		{name: "non rate limit", status: http.StatusServiceUnavailable, retryAfter: "60"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				header := http.Header{"Content-Type": {"application/json"}}
+				if testCase.retryAfter != "" {
+					header.Set("Retry-After", testCase.retryAfter)
+				}
+				return &http.Response{
+					StatusCode: testCase.status,
+					Header:     header,
+					Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"quota"}}`)),
+					Request:    req,
+				}, nil
+			})
+			ctx := context.WithValue(t.Context(), "cliproxy.roundtripper", http.RoundTripper(transport))
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "sk-ant-oat-invalid-retry-after"}, Metadata: claudeOAuthTestMetadata()}
+			request := cliproxyexecutor.Request{
+				Model:   "claude-opus-5",
+				Payload: []byte(`{"model":"claude-opus-5","max_tokens":16,"messages":[{"role":"user","content":"reply OK"}]}`),
+			}
+
+			_, err := NewClaudeExecutor(&config.Config{}).Execute(ctx, auth, request, cliproxyexecutor.Options{
+				SourceFormat:   sdktranslator.FormatClaude,
+				ResponseFormat: sdktranslator.FormatClaude,
+			})
+			if err == nil {
+				t.Fatal("Claude executor error = nil, want upstream error")
+			}
+			var retryError interface{ RetryAfter() *time.Duration }
+			if !errors.As(err, &retryError) {
+				t.Fatalf("Claude executor error = %T %v, want RetryAfter provider", err, err)
+			}
+			if got := retryError.RetryAfter(); got != nil {
+				t.Fatalf("RetryAfter() = %v, want nil", *got)
+			}
+		})
+	}
+}
+
 func TestClaudeExecutor_Execute_InvalidGzipErrorBodyReturnsDecodeMessage(t *testing.T) {
 	testClaudeExecutorInvalidCompressedErrorBody(t, func(executor *ClaudeExecutor, auth *cliproxyauth.Auth, payload []byte) error {
 		_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{

--- a/internal/runtime/executor/claude_executor_tokens.go
+++ b/internal/runtime/executor/claude_executor_tokens.go
@@ -252,7 +252,7 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 			helps.RecordAPIResponseError(ctx, e.cfg, decErr)
 			msg := fmt.Sprintf("failed to decode error response body: %v", decErr)
 			helps.LogWithRequestID(ctx).Warn(msg)
-			return cliproxyexecutor.Response{}, statusErr{code: resp.StatusCode, msg: msg}
+			return cliproxyexecutor.Response{}, classifyClaudeUpstreamError(resp.StatusCode, resp.Header, []byte(msg))
 		}
 		b, readErr := io.ReadAll(errBody)
 		if readErr != nil {
@@ -265,7 +265,7 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 		if errClose := errBody.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}
-		return cliproxyexecutor.Response{}, statusErr{code: resp.StatusCode, msg: string(b)}
+		return cliproxyexecutor.Response{}, classifyClaudeUpstreamError(resp.StatusCode, resp.Header, b)
 	}
 	decodedBody, err := decodeResponseBody(resp.Body, claudeResponseContentEncoding(resp.Header))
 	if err != nil {

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -400,6 +401,71 @@ func TestManager_MaxRetryCredentials_LimitsCrossCredentialRetries(t *testing.T) 
 				t.Fatalf("expected 2 calls with max-retry-credentials=0, got %d", calls)
 			}
 		})
+	}
+}
+
+func TestManager_Execute_RetryAfterCooldownFallsBackImmediately(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	const retryAfter = 124633 * time.Second
+	m := NewManager(nil, nil, nil)
+	executor := &authFallbackExecutor{
+		id: "claude",
+		executeErrors: map[string]error{
+			"aa-rate-limited-auth": &retryAfterStatusError{
+				status:     http.StatusTooManyRequests,
+				message:    "quota exhausted",
+				retryAfter: retryAfter,
+			},
+		},
+	}
+	m.RegisterExecutor(executor)
+
+	model := "claude-opus-5-retry-after"
+	rateLimitedAuth := &Auth{ID: "aa-rate-limited-auth", Provider: "claude"}
+	fallbackAuth := &Auth{ID: "bb-fallback-auth", Provider: "claude"}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(rateLimitedAuth.ID, rateLimitedAuth.Provider, []*registry.ModelInfo{{ID: model}})
+	reg.RegisterClient(fallbackAuth.ID, fallbackAuth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(rateLimitedAuth.ID)
+		reg.UnregisterClient(fallbackAuth.ID)
+	})
+	if _, errRegister := m.Register(t.Context(), rateLimitedAuth); errRegister != nil {
+		t.Fatalf("register rate-limited auth: %v", errRegister)
+	}
+	if _, errRegister := m.Register(t.Context(), fallbackAuth); errRegister != nil {
+		t.Fatalf("register fallback auth: %v", errRegister)
+	}
+
+	startedAt := time.Now()
+	resp, errExecute := m.Execute(t.Context(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	finishedAt := time.Now()
+	if errExecute != nil {
+		t.Fatalf("Execute() error = %v, want fallback success", errExecute)
+	}
+	if got := string(resp.Payload); got != fallbackAuth.ID {
+		t.Fatalf("Execute() payload = %q, want %q", got, fallbackAuth.ID)
+	}
+	if got, want := executor.ExecuteCalls(), []string{rateLimitedAuth.ID, fallbackAuth.ID}; !slices.Equal(got, want) {
+		t.Fatalf("Execute() auth calls = %v, want %v", got, want)
+	}
+
+	updated, ok := m.GetByID(rateLimitedAuth.ID)
+	if !ok || updated == nil {
+		t.Fatal("rate-limited auth is missing")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || !state.Unavailable || !state.Quota.Exceeded {
+		t.Fatalf("rate-limited model state = %#v, want unavailable quota state", state)
+	}
+	if state.NextRetryAfter.Before(startedAt.Add(retryAfter)) || state.NextRetryAfter.After(finishedAt.Add(retryAfter)) {
+		t.Fatalf("NextRetryAfter = %v, want request time + %v", state.NextRetryAfter, retryAfter)
+	}
+	if !state.Quota.NextRecoverAt.Equal(state.NextRetryAfter) {
+		t.Fatalf("quota recovery = %v, want NextRetryAfter %v", state.Quota.NextRecoverAt, state.NextRetryAfter)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve Anthropic's integer `Retry-After` delta-seconds on Claude HTTP 429 errors;
- carry the hint through `Execute`, `ExecuteStream`, and upstream `count_tokens`, including compressed error-body decode paths;
- let the existing auth conductor apply the provider deadline to the throttled credential while immediately failing over to another available credential;
- ignore absent, malformed, negative, overflowed, and non-429 values so existing cooldown behavior remains unchanged.

## Production evidence

A retained Claude OAuth request log from v7.2.115 showed a gzip-compressed 429 with `Retry-After: 124633`, matching the upstream seven-day reset deadline. CPA selected a second OAuth credential 63 ms after receiving the 429 and completed successfully, confirming that failover already worked while the first credential's provider cooldown was lost.

The regression uses that observed `124633`-second value and covers the gzip streaming path seen in the log. Credentials, request payload, and account identifiers are omitted.

## Validation

- `go test ./internal/runtime/executor ./sdk/cliproxy/auth -count=1`
- `go test -race ./internal/runtime/executor ./sdk/cliproxy/auth -run '^(TestClaudeExecutor_HTTPErrorRetryAfter|TestManager_Execute_RetryAfterCooldownFallsBackImmediately)$' -count=1`
- `go test ./...`
- `go build -o test-output ./cmd/server && rm test-output`

Fixes #4761
