### PR TITLE
fix(responses): preserve combined assistant tool turns

### DIFF
--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -10,10 +10,12 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	responsesconverter "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/openai/openai/responses"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 func TestNewKimiExecutorInitializesDelegatedClaudeConfig(t *testing.T) {
@@ -238,6 +240,90 @@ func TestKimiExecutorClaudeStreamForwardsAnthropicBetaAndLogsUpstream(t *testing
 		if !strings.Contains(apiResponseText, want) {
 			t.Fatalf("API_RESPONSE = %q, want %q", apiResponseText, want)
 		}
+	}
+}
+
+func TestKimiNativeAssistantMessageSurvivesResponsesRoundTrip(t *testing.T) {
+	responsesRequest := []byte(`{
+		"model":"kimi-k3",
+		"instructions":"system instructions",
+		"tools":[{
+			"type":"function",
+			"name":"exec_command",
+			"parameters":{"type":"object","properties":{"cmd":{"type":"string"}},"required":["cmd"]}
+		}]
+	}`)
+	chatRequest := []byte(`{
+		"model":"kimi-k3",
+		"messages":[{"role":"system","content":"system instructions"}],
+		"tools":[{
+			"type":"function",
+			"function":{"name":"exec_command","parameters":{"type":"object","properties":{"cmd":{"type":"string"}},"required":["cmd"]}}
+		}]
+	}`)
+	chatResponse := []byte(`{
+		"id":"chatcmpl-roundtrip",
+		"object":"chat.completion",
+		"created":1,
+		"model":"kimi-k3",
+		"choices":[{
+			"index":0,
+			"message":{
+				"role":"assistant",
+				"reasoning_content":"inspect the next step",
+				"content":"Step 1 completed; continue to step 2.",
+				"tool_calls":[{
+					"id":"call_1",
+					"type":"function",
+					"function":{"name":"exec_command","arguments":"{\"cmd\":\"printf step-2\"}"}
+				}]
+			},
+			"finish_reason":"tool_calls"
+		}]
+	}`)
+
+	responsesResult := responsesconverter.ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(
+		context.Background(), "kimi-k3", responsesRequest, chatRequest, chatResponse, nil,
+	)
+	output := gjson.GetBytes(responsesResult, "output")
+	if !output.Exists() || !output.IsArray() {
+		t.Fatalf("Responses output is missing: %s", responsesResult)
+	}
+
+	nextRequest := []byte(`{"model":"kimi-k3","instructions":"system instructions","input":[]}`)
+	var err error
+	nextRequest, err = sjson.SetRawBytes(nextRequest, "input", []byte(output.Raw))
+	if err != nil {
+		t.Fatalf("set Responses history: %v", err)
+	}
+	nextRequest, err = sjson.SetRawBytes(nextRequest, "input.-1", []byte(`{
+		"type":"function_call_output",
+		"call_id":"call_1",
+		"output":"step-2"
+	}`))
+	if err != nil {
+		t.Fatalf("append tool output: %v", err)
+	}
+
+	roundTripped := responsesconverter.ConvertOpenAIResponsesRequestToOpenAIChatCompletions("kimi-k3", nextRequest, false)
+	roundTripped, err = normalizeKimiToolMessageLinks(roundTripped)
+	if err != nil {
+		t.Fatalf("normalizeKimiToolMessageLinks() error = %v", err)
+	}
+
+	messages := gjson.GetBytes(roundTripped, "messages").Array()
+	if len(messages) != 3 {
+		t.Fatalf("messages length = %d, want 3; output=%s", len(messages), roundTripped)
+	}
+	assistant := messages[1]
+	if got := assistant.Get("reasoning_content").String(); got != "inspect the next step" {
+		t.Fatalf("assistant reasoning_content = %q; output=%s", got, roundTripped)
+	}
+	if got := assistant.Get("content.0.text").String(); got != "Step 1 completed; continue to step 2." {
+		t.Fatalf("assistant content = %q; output=%s", got, roundTripped)
+	}
+	if got := assistant.Get("tool_calls.0.id").String(); got != "call_1" {
+		t.Fatalf("assistant tool call id = %q; output=%s", got, roundTripped)
 	}
 }
 

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -84,16 +84,36 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			pendingReasoningContent = ""
 			return reasoningContent
 		}
+		appendPendingReasoningContent := func(reasoningContent string) {
+			pendingReasoningContent = mergeOpenAIResponsesReasoningContent(pendingReasoningContent, reasoningContent)
+		}
 		flushPendingToolCalls := func() {
 			if len(pendingToolCalls) == 0 {
 				return
 			}
-			assistantMessage := []byte(`{"role":"assistant","tool_calls":[]}`)
-			assistantMessage, _ = sjson.SetBytes(assistantMessage, "tool_calls", pendingToolCalls)
-			if reasoningContent := takePendingReasoningContent(); reasoningContent != "" {
-				assistantMessage, _ = sjson.SetBytes(assistantMessage, "reasoning_content", reasoningContent)
+			reasoningContent := takePendingReasoningContent()
+			mergedIntoPreviousAssistant := false
+			if len(messages) > 0 {
+				lastIndex := len(messages) - 1
+				lastMessage := gjson.ParseBytes(messages[lastIndex])
+				if lastMessage.Get("role").String() == "assistant" && !lastMessage.Get("tool_calls").Exists() {
+					assistantMessage, _ := sjson.SetBytes(messages[lastIndex], "tool_calls", pendingToolCalls)
+					mergedReasoning := mergeOpenAIResponsesReasoningContent(lastMessage.Get("reasoning_content").String(), reasoningContent)
+					if mergedReasoning != "" {
+						assistantMessage, _ = sjson.SetBytes(assistantMessage, "reasoning_content", mergedReasoning)
+					}
+					messages[lastIndex] = assistantMessage
+					mergedIntoPreviousAssistant = true
+				}
 			}
-			appendMessage(assistantMessage)
+			if !mergedIntoPreviousAssistant {
+				assistantMessage := []byte(`{"role":"assistant","tool_calls":[]}`)
+				assistantMessage, _ = sjson.SetBytes(assistantMessage, "tool_calls", pendingToolCalls)
+				if reasoningContent != "" {
+					assistantMessage, _ = sjson.SetBytes(assistantMessage, "reasoning_content", reasoningContent)
+				}
+				appendMessage(assistantMessage)
+			}
 			for _, id := range pendingToolCallIDs {
 				if strings.TrimSpace(id) == "" {
 					continue
@@ -189,12 +209,10 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				}
 
 				if role == "assistant" {
-					reasoningContent := item.Get("reasoning_content").String()
-					if reasoningContent == "" {
-						reasoningContent = takePendingReasoningContent()
-					} else {
-						pendingReasoningContent = ""
-					}
+					reasoningContent := mergeOpenAIResponsesReasoningContent(
+						takePendingReasoningContent(),
+						item.Get("reasoning_content").String(),
+					)
 					if reasoningContent != "" {
 						message, _ = sjson.SetBytes(message, "reasoning_content", reasoningContent)
 					}
@@ -203,14 +221,10 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				appendRegularMessage(message)
 
 			case "reasoning":
-				reasoningContent := collectOpenAIResponsesReasoningContent(item)
-				if pendingReasoningContent == "" {
-					pendingReasoningContent = reasoningContent
-				} else {
-					pendingReasoningContent += reasoningContent
-				}
+				appendPendingReasoningContent(collectOpenAIResponsesReasoningContent(item))
 
 			case "function_call":
+				appendPendingReasoningContent(item.Get("reasoning_content").String())
 				// Buffer consecutive function calls and emit them as one assistant message.
 				toolCall := []byte(`{"id":"","type":"function","function":{"name":"","arguments":""}}`)
 
@@ -257,6 +271,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				}
 
 			case "custom_tool_call":
+				appendPendingReasoningContent(item.Get("reasoning_content").String())
 				// Codex freeform tool call replay: wrap the raw input so it
 				// matches the {"input": string} function shape used when
 				// converting custom tool definitions.
@@ -489,4 +504,23 @@ func collectOpenAIResponsesReasoningContent(item gjson.Result) string {
 		return "[reasoning unavailable]"
 	}
 	return reasoningText.String()
+}
+
+func mergeOpenAIResponsesReasoningContent(existing, incoming string) string {
+	existingTrimmed := strings.TrimSpace(existing)
+	incomingTrimmed := strings.TrimSpace(incoming)
+	switch {
+	case existingTrimmed == "":
+		return incoming
+	case incomingTrimmed == "":
+		return existing
+	case existingTrimmed == "[reasoning unavailable]":
+		return incoming
+	case incomingTrimmed == "[reasoning unavailable]":
+		return existing
+	case existingTrimmed == incomingTrimmed:
+		return existing
+	default:
+		return existing + "\n\n" + incoming
+	}
 }

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -110,6 +110,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				lastMessage := gjson.ParseBytes(messages[lastIndex])
 				if lastMessage.Get("role").String() == "assistant" &&
 					!lastMessage.Get("tool_calls").Exists() &&
+					pendingToolCallProvenance != "" &&
 					messageProvenances[lastIndex] == pendingToolCallProvenance {
 					assistantMessage, _ := sjson.SetBytes(messages[lastIndex], "tool_calls", pendingToolCalls)
 					mergedReasoning := mergeOpenAIResponsesReasoningContent(lastMessage.Get("reasoning_content").String(), reasoningContent)

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -1,6 +1,7 @@
 package responses
 
 import (
+	"strconv"
 	"strings"
 
 	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
@@ -35,8 +36,14 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 	root := gjson.ParseBytes(rawJSON)
 
 	messages := make([][]byte, 0)
+	messageProvenances := make([]string, 0)
 	appendMessage := func(message []byte) {
 		messages = append(messages, message)
+		messageProvenances = append(messageProvenances, "")
+	}
+	appendMessageWithProvenance := func(message []byte, provenance string) {
+		messages = append(messages, message)
+		messageProvenances = append(messageProvenances, provenance)
 	}
 
 	// Set model name
@@ -75,9 +82,14 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 
 		pendingToolCalls := make([]interface{}, 0)
 		pendingToolCallIDs := make([]string, 0)
+		pendingToolCallProvenance := ""
 		pendingReasoningContent := ""
 		awaitingToolOutputs := make(map[string]struct{})
-		deferredMessages := make([][]byte, 0)
+		type deferredMessage struct {
+			raw        []byte
+			provenance string
+		}
+		deferredMessages := make([]deferredMessage, 0)
 
 		takePendingReasoningContent := func() string {
 			reasoningContent := pendingReasoningContent
@@ -96,7 +108,9 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			if len(messages) > 0 {
 				lastIndex := len(messages) - 1
 				lastMessage := gjson.ParseBytes(messages[lastIndex])
-				if lastMessage.Get("role").String() == "assistant" && !lastMessage.Get("tool_calls").Exists() {
+				if lastMessage.Get("role").String() == "assistant" &&
+					!lastMessage.Get("tool_calls").Exists() &&
+					messageProvenances[lastIndex] == pendingToolCallProvenance {
 					assistantMessage, _ := sjson.SetBytes(messages[lastIndex], "tool_calls", pendingToolCalls)
 					mergedReasoning := mergeOpenAIResponsesReasoningContent(lastMessage.Get("reasoning_content").String(), reasoningContent)
 					if mergedReasoning != "" {
@@ -112,7 +126,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				if reasoningContent != "" {
 					assistantMessage, _ = sjson.SetBytes(assistantMessage, "reasoning_content", reasoningContent)
 				}
-				appendMessage(assistantMessage)
+				appendMessageWithProvenance(assistantMessage, pendingToolCallProvenance)
 			}
 			for _, id := range pendingToolCallIDs {
 				if strings.TrimSpace(id) == "" {
@@ -122,10 +136,11 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			}
 			pendingToolCalls = pendingToolCalls[:0]
 			pendingToolCallIDs = pendingToolCallIDs[:0]
+			pendingToolCallProvenance = ""
 		}
 		flushDeferredMessages := func() {
 			for _, message := range deferredMessages {
-				appendMessage(message)
+				appendMessageWithProvenance(message.raw, message.provenance)
 			}
 			deferredMessages = deferredMessages[:0]
 		}
@@ -137,14 +152,14 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			}
 			return false
 		}
-		appendRegularMessage := func(message []byte) {
+		appendRegularMessage := func(message []byte, provenance string) {
 			// Keep tool-call adjacency strict for providers that require
 			// assistant(tool_calls) -> tool(tool_call_id) with no message in between.
 			if hasAwaitingToolOutput() {
-				deferredMessages = append(deferredMessages, message)
+				deferredMessages = append(deferredMessages, deferredMessage{raw: message, provenance: provenance})
 				return
 			}
-			appendMessage(message)
+			appendMessageWithProvenance(message, provenance)
 		}
 		appendPendingReasoningMessage := func() {
 			reasoningContent := takePendingReasoningContent()
@@ -153,7 +168,16 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			}
 			message := []byte(`{"role":"assistant","content":"","reasoning_content":""}`)
 			message, _ = sjson.SetBytes(message, "reasoning_content", reasoningContent)
-			appendRegularMessage(message)
+			appendRegularMessage(message, "")
+		}
+		preparePendingToolCall := func(item gjson.Result) {
+			provenance := openAIResponsesOutputItemProvenance(item)
+			if len(pendingToolCalls) > 0 && provenance != pendingToolCallProvenance {
+				flushPendingToolCalls()
+			}
+			if len(pendingToolCalls) == 0 {
+				pendingToolCallProvenance = provenance
+			}
 		}
 
 		for _, item := range inputItems {
@@ -218,12 +242,13 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 					}
 				}
 
-				appendRegularMessage(message)
+				appendRegularMessage(message, openAIResponsesOutputItemProvenance(item))
 
 			case "reasoning":
 				appendPendingReasoningContent(collectOpenAIResponsesReasoningContent(item))
 
 			case "function_call":
+				preparePendingToolCall(item)
 				appendPendingReasoningContent(item.Get("reasoning_content").String())
 				// Buffer consecutive function calls and emit them as one assistant message.
 				toolCall := []byte(`{"id":"","type":"function","function":{"name":"","arguments":""}}`)
@@ -271,6 +296,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				}
 
 			case "custom_tool_call":
+				preparePendingToolCall(item)
 				appendPendingReasoningContent(item.Get("reasoning_content").String())
 				// Codex freeform tool call replay: wrap the raw input so it
 				// matches the {"input": string} function shape used when
@@ -523,4 +549,41 @@ func mergeOpenAIResponsesReasoningContent(existing, incoming string) string {
 	default:
 		return existing + "\n\n" + incoming
 	}
+}
+
+func openAIResponsesOutputItemProvenance(item gjson.Result) string {
+	itemID := strings.TrimSpace(item.Get("id").String())
+	switch item.Get("type").String() {
+	case "message":
+		return parseOpenAIResponsesOutputItemProvenance(itemID, "msg_", 1)
+	case "function_call":
+		return parseOpenAIResponsesOutputItemProvenance(itemID, "fc_", 2)
+	case "custom_tool_call":
+		return parseOpenAIResponsesOutputItemProvenance(itemID, "ctc_", 2)
+	default:
+		return ""
+	}
+}
+
+func parseOpenAIResponsesOutputItemProvenance(itemID, prefix string, trailingIndexes int) string {
+	if !strings.HasPrefix(itemID, prefix) {
+		return ""
+	}
+	remainder := strings.TrimPrefix(itemID, prefix)
+	indexes := make([]string, trailingIndexes)
+	for i := trailingIndexes - 1; i >= 0; i-- {
+		separator := strings.LastIndexByte(remainder, '_')
+		if separator <= 0 {
+			return ""
+		}
+		indexes[i] = remainder[separator+1:]
+		if _, err := strconv.Atoi(indexes[i]); err != nil {
+			return ""
+		}
+		remainder = remainder[:separator]
+	}
+	if remainder == "" {
+		return ""
+	}
+	return remainder + "\x00" + indexes[0]
 }

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
@@ -333,6 +333,123 @@ func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_AttachesReasoningT
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_MergesAssistantTextAndToolCalls(t *testing.T) {
+	raw := []byte(`{
+		"input": [
+			{
+				"type": "reasoning",
+				"id": "rs_tool",
+				"summary": [{"type": "summary_text", "text": "tool reasoning"}]
+			},
+			{
+				"type": "message",
+				"role": "assistant",
+				"content": [{"type": "output_text", "text": "I will inspect the next step."}]
+			},
+			{"type":"function_call","call_id":"call_1","name":"exec_command","arguments":"{\"cmd\":\"pwd\"}"},
+			{"type":"function_call_output","call_id":"call_1","output":"ok"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("kimi-k3", raw, true)
+
+	if got := gjson.GetBytes(out, "messages.#").Int(); got != 2 {
+		t.Fatalf("messages count = %d, want 2; output=%s", got, out)
+	}
+	assistant := gjson.GetBytes(out, "messages.0")
+	if got := assistant.Get("content.0.text").String(); got != "I will inspect the next step." {
+		t.Fatalf("assistant content = %q; output=%s", got, out)
+	}
+	if got := assistant.Get("reasoning_content").String(); got != "tool reasoning" {
+		t.Fatalf("assistant reasoning_content = %q; output=%s", got, out)
+	}
+	if got := assistant.Get("tool_calls.0.id").String(); got != "call_1" {
+		t.Fatalf("assistant tool call id = %q, want call_1; output=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "messages.1.tool_call_id").String(); got != "call_1" {
+		t.Fatalf("tool message call id = %q, want call_1; output=%s", got, out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_DeduplicatesReasoningWhenMergingAssistantTextAndToolCalls(t *testing.T) {
+	raw := []byte(`{
+		"input": [
+			{
+				"type":"message",
+				"role":"assistant",
+				"content":"I will inspect the file.",
+				"reasoning_content":"same reasoning"
+			},
+			{
+				"type":"function_call",
+				"call_id":"call_1",
+				"name":"exec_command",
+				"arguments":"{\"cmd\":\"pwd\"}",
+				"reasoning_content":"same reasoning"
+			},
+			{"type":"function_call_output","call_id":"call_1","output":"ok"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("kimi-k3", raw, true)
+
+	if got := gjson.GetBytes(out, "messages.#").Int(); got != 2 {
+		t.Fatalf("messages count = %d, want 2; output=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "messages.0.reasoning_content").String(); got != "same reasoning" {
+		t.Fatalf("assistant reasoning_content = %q, want one copy; output=%s", got, out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_PreservesDistinctReasoningWhenMergingAssistantTextAndToolCalls(t *testing.T) {
+	raw := []byte(`{
+		"input": [
+			{
+				"type":"message",
+				"role":"assistant",
+				"content":"I will inspect the file.",
+				"reasoning_content":"message reasoning"
+			},
+			{
+				"type":"function_call",
+				"call_id":"call_1",
+				"name":"exec_command",
+				"arguments":"{\"cmd\":\"pwd\"}",
+				"reasoning_content":"tool reasoning"
+			},
+			{"type":"function_call_output","call_id":"call_1","output":"ok"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("kimi-k3", raw, true)
+
+	if got := gjson.GetBytes(out, "messages.0.reasoning_content").String(); got != "message reasoning\n\ntool reasoning" {
+		t.Fatalf("assistant reasoning_content = %q; output=%s", got, out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_DoesNotMergeToolCallsAcrossUserBoundary(t *testing.T) {
+	raw := []byte(`{
+		"input": [
+			{"type":"message","role":"assistant","content":"First answer."},
+			{"type":"message","role":"user","content":"New turn."},
+			{"type":"function_call","call_id":"call_1","name":"exec_command","arguments":"{\"cmd\":\"pwd\"}"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("kimi-k3", raw, true)
+
+	if got := gjson.GetBytes(out, "messages.#").Int(); got != 3 {
+		t.Fatalf("messages count = %d, want 3; output=%s", got, out)
+	}
+	if gjson.GetBytes(out, "messages.0.tool_calls").Exists() {
+		t.Fatalf("tool calls crossed the user boundary; output=%s", out)
+	}
+	if got := gjson.GetBytes(out, "messages.2.tool_calls.0.id").String(); got != "call_1" {
+		t.Fatalf("new assistant tool call id = %q; output=%s", got, out)
+	}
+}
+
 func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_KeepsReasoningBeforeUserMessage(t *testing.T) {
 	raw := []byte(`{
 		"input": [

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
@@ -343,10 +343,11 @@ func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_MergesAssistantTex
 			},
 			{
 				"type": "message",
+				"id": "msg_resp_tool_0",
 				"role": "assistant",
 				"content": [{"type": "output_text", "text": "I will inspect the next step."}]
 			},
-			{"type":"function_call","call_id":"call_1","name":"exec_command","arguments":"{\"cmd\":\"pwd\"}"},
+			{"type":"function_call","id":"fc_resp_tool_0_0","call_id":"call_1","name":"exec_command","arguments":"{\"cmd\":\"pwd\"}"},
 			{"type":"function_call_output","call_id":"call_1","output":"ok"}
 		]
 	}`)
@@ -371,17 +372,41 @@ func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_MergesAssistantTex
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_DoesNotMergeUnknownProvenance(t *testing.T) {
+	raw := []byte(`{
+		"input": [
+			{"type":"message","id":"msg_1","role":"assistant","content":"choice zero"},
+			{"type":"function_call","id":"fc_1","call_id":"call_1","name":"exec_command","arguments":"{\"cmd\":\"pwd\"}"},
+			{"type":"function_call_output","call_id":"call_1","output":"ok"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("kimi-k3", raw, true)
+
+	if got := gjson.GetBytes(out, "messages.#").Int(); got != 3 {
+		t.Fatalf("messages count = %d, want 3; output=%s", got, out)
+	}
+	if gjson.GetBytes(out, "messages.0.tool_calls").Exists() {
+		t.Fatalf("unknown-provenance tool call merged into assistant message; output=%s", out)
+	}
+	if got := gjson.GetBytes(out, "messages.1.tool_calls.0.id").String(); got != "call_1" {
+		t.Fatalf("separate assistant tool call id = %q, want call_1; output=%s", got, out)
+	}
+}
+
 func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_DeduplicatesReasoningWhenMergingAssistantTextAndToolCalls(t *testing.T) {
 	raw := []byte(`{
 		"input": [
 			{
 				"type":"message",
+				"id":"msg_resp_reasoning_0",
 				"role":"assistant",
 				"content":"I will inspect the file.",
 				"reasoning_content":"same reasoning"
 			},
 			{
 				"type":"function_call",
+				"id":"fc_resp_reasoning_0_0",
 				"call_id":"call_1",
 				"name":"exec_command",
 				"arguments":"{\"cmd\":\"pwd\"}",
@@ -406,12 +431,14 @@ func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_PreservesDistinctR
 		"input": [
 			{
 				"type":"message",
+				"id":"msg_resp_reasoning_0",
 				"role":"assistant",
 				"content":"I will inspect the file.",
 				"reasoning_content":"message reasoning"
 			},
 			{
 				"type":"function_call",
+				"id":"fc_resp_reasoning_0_0",
 				"call_id":"call_1",
 				"name":"exec_command",
 				"arguments":"{\"cmd\":\"pwd\"}",

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -67,6 +67,18 @@ func emitRespEvent(event string, payload []byte) []byte {
 	return translatorcommon.SSEEventData(event, payload)
 }
 
+func openAIResponsesToolItemID(responseID, stateKey string, custom bool) string {
+	prefix := "fc_"
+	if custom {
+		prefix = "ctc_"
+	}
+	return prefix + responseID + "_" + strings.ReplaceAll(stateKey, ":", "_")
+}
+
+func openAIResponsesNonStreamToolItemID(responseID string, choiceIndex, toolIndex int64, custom bool) string {
+	return openAIResponsesToolItemID(responseID, fmt.Sprintf("%d:%d", choiceIndex, toolIndex), custom)
+}
+
 func buildResponsesCompletedEvent(st *oaiToResponsesState, requestRawJSON []byte, nextSeq func() int) []byte {
 	completed := []byte(`{"type":"response.completed","sequence_number":0,"response":{"id":"","object":"response","created_at":0,"status":"completed","background":false,"error":null}}`)
 	completed, _ = sjson.SetBytes(completed, "sequence_number", nextSeq())
@@ -173,7 +185,7 @@ func buildResponsesCompletedEvent(st *oaiToResponsesState, requestRawJSON []byte
 			name := st.FuncNames[key]
 			if st.FuncItemCustom[key] {
 				item := []byte(`{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}`)
-				item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("ctc_%s", callID))
+				item, _ = sjson.SetBytes(item, "id", openAIResponsesToolItemID(st.ResponseID, key, true))
 				item, _ = sjson.SetBytes(item, "input", unwrapCustomToolInput(args))
 				item, _ = sjson.SetBytes(item, "call_id", callID)
 				item, _ = sjson.SetBytes(item, "name", name)
@@ -181,7 +193,7 @@ func buildResponsesCompletedEvent(st *oaiToResponsesState, requestRawJSON []byte
 				continue
 			}
 			item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
-			item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", callID))
+			item, _ = sjson.SetBytes(item, "id", openAIResponsesToolItemID(st.ResponseID, key, false))
 			item, _ = sjson.SetBytes(item, "arguments", args)
 			item, _ = sjson.SetBytes(item, "call_id", callID)
 			item = applyResponsesFunctionCallNamespaceFields(item, requestRawJSON, name, "")
@@ -325,7 +337,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 			o := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"in_progress","input":"","call_id":"","name":""}}`)
 			o, _ = sjson.SetBytes(o, "sequence_number", nextSeq())
 			o, _ = sjson.SetBytes(o, "output_index", outputIndex)
-			o, _ = sjson.SetBytes(o, "item.id", fmt.Sprintf("ctc_%s", callID))
+			o, _ = sjson.SetBytes(o, "item.id", openAIResponsesToolItemID(st.ResponseID, key, true))
 			o, _ = sjson.SetBytes(o, "item.call_id", callID)
 			o, _ = sjson.SetBytes(o, "item.name", name)
 			out = append(out, emitRespEvent("response.output_item.added", o))
@@ -333,7 +345,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 			o := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"in_progress","arguments":"","call_id":"","name":""}}`)
 			o, _ = sjson.SetBytes(o, "sequence_number", nextSeq())
 			o, _ = sjson.SetBytes(o, "output_index", outputIndex)
-			o, _ = sjson.SetBytes(o, "item.id", fmt.Sprintf("fc_%s", callID))
+			o, _ = sjson.SetBytes(o, "item.id", openAIResponsesToolItemID(st.ResponseID, key, false))
 			o, _ = sjson.SetBytes(o, "item.call_id", callID)
 			o = applyResponsesFunctionCallNamespaceFields(o, requestForNamespace, name, "item")
 			out = append(out, emitRespEvent("response.output_item.added", o))
@@ -350,10 +362,9 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 		}
 		args := argsBuf.String()
 		delta := args[st.FuncArgsSent[key]:]
-		callID := st.FuncCallIDs[key]
 		ad := []byte(`{"type":"response.function_call_arguments.delta","sequence_number":0,"item_id":"","output_index":0,"delta":""}`)
 		ad, _ = sjson.SetBytes(ad, "sequence_number", nextSeq())
-		ad, _ = sjson.SetBytes(ad, "item_id", fmt.Sprintf("fc_%s", callID))
+		ad, _ = sjson.SetBytes(ad, "item_id", openAIResponsesToolItemID(st.ResponseID, key, false))
 		ad, _ = sjson.SetBytes(ad, "output_index", st.FuncOutputIx[key])
 		ad, _ = sjson.SetBytes(ad, "delta", delta)
 		out = append(out, emitRespEvent("response.function_call_arguments.delta", ad))
@@ -651,7 +662,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 							input := unwrapCustomToolInput(args)
 							inputDone := []byte(`{"type":"response.custom_tool_call_input.done","sequence_number":0,"item_id":"","output_index":0,"input":""}`)
 							inputDone, _ = sjson.SetBytes(inputDone, "sequence_number", nextSeq())
-							inputDone, _ = sjson.SetBytes(inputDone, "item_id", fmt.Sprintf("ctc_%s", callID))
+							inputDone, _ = sjson.SetBytes(inputDone, "item_id", openAIResponsesToolItemID(st.ResponseID, key, true))
 							inputDone, _ = sjson.SetBytes(inputDone, "output_index", outputIndex)
 							inputDone, _ = sjson.SetBytes(inputDone, "input", input)
 							out = append(out, emitRespEvent("response.custom_tool_call_input.done", inputDone))
@@ -659,7 +670,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 							itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}}`)
 							itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
 							itemDone, _ = sjson.SetBytes(itemDone, "output_index", outputIndex)
-							itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("ctc_%s", callID))
+							itemDone, _ = sjson.SetBytes(itemDone, "item.id", openAIResponsesToolItemID(st.ResponseID, key, true))
 							itemDone, _ = sjson.SetBytes(itemDone, "item.input", input)
 							itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", callID)
 							itemDone, _ = sjson.SetBytes(itemDone, "item.name", st.FuncNames[key])
@@ -670,7 +681,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 						}
 						fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
 						fcDone, _ = sjson.SetBytes(fcDone, "sequence_number", nextSeq())
-						fcDone, _ = sjson.SetBytes(fcDone, "item_id", fmt.Sprintf("fc_%s", callID))
+						fcDone, _ = sjson.SetBytes(fcDone, "item_id", openAIResponsesToolItemID(st.ResponseID, key, false))
 						fcDone, _ = sjson.SetBytes(fcDone, "output_index", outputIndex)
 						fcDone, _ = sjson.SetBytes(fcDone, "arguments", args)
 						out = append(out, emitRespEvent("response.function_call_arguments.done", fcDone))
@@ -678,7 +689,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 						itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}}`)
 						itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
 						itemDone, _ = sjson.SetBytes(itemDone, "output_index", outputIndex)
-						itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", callID))
+						itemDone, _ = sjson.SetBytes(itemDone, "item.id", openAIResponsesToolItemID(st.ResponseID, key, false))
 						itemDone, _ = sjson.SetBytes(itemDone, "item.arguments", args)
 						itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", callID)
 						itemDone = applyResponsesFunctionCallNamespaceFields(itemDone, requestForNamespace, st.FuncNames[key], "item")
@@ -843,7 +854,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 						args := tc.Get("function.arguments").String()
 						if _, isCustomTool := customToolNames[name]; isCustomTool {
 							item := []byte(`{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}`)
-							item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("ctc_%s", callID))
+							item, _ = sjson.SetBytes(item, "id", openAIResponsesNonStreamToolItemID(id, choice.Get("index").Int(), tcIndex.Int(), true))
 							item, _ = sjson.SetBytes(item, "input", unwrapCustomToolInput(args))
 							item, _ = sjson.SetBytes(item, "call_id", callID)
 							item, _ = sjson.SetBytes(item, "name", name)
@@ -851,7 +862,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 							return true
 						}
 						item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
-						item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", callID))
+						item, _ = sjson.SetBytes(item, "id", openAIResponsesNonStreamToolItemID(id, choice.Get("index").Int(), tcIndex.Int(), false))
 						item, _ = sjson.SetBytes(item, "arguments", args)
 						item, _ = sjson.SetBytes(item, "call_id", callID)
 						item = applyResponsesFunctionCallNamespaceFields(item, requestForNamespace, name, "")

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -846,18 +846,21 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 				// Function/tool calls
 				if tcs := msg.Get("tool_calls"); tcs.Exists() && tcs.IsArray() {
 					customToolNames := responsesCustomToolNames(requestForNamespace)
-					tcs.ForEach(func(tcIndex, tc gjson.Result) bool {
+					toolIndex := int64(0)
+					tcs.ForEach(func(_, tc gjson.Result) bool {
+						currentToolIndex := toolIndex
+						toolIndex++
 						callID := tc.Get("id").String()
 						if callID == "" {
 							// Providers may omit tool_call ids; synthesize one so the
 							// function_call item stays usable for Codex round-trips.
-							callID = fmt.Sprintf("call_%s_%d_%d", id, choice.Get("index").Int(), tcIndex.Int())
+							callID = fmt.Sprintf("call_%s_%d_%d", id, choice.Get("index").Int(), currentToolIndex)
 						}
 						name := tc.Get("function.name").String()
 						args := tc.Get("function.arguments").String()
 						if _, isCustomTool := customToolNames[name]; isCustomTool {
 							item := []byte(`{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}`)
-							item, _ = sjson.SetBytes(item, "id", openAIResponsesNonStreamToolItemID(id, choice.Get("index").Int(), tcIndex.Int(), true))
+							item, _ = sjson.SetBytes(item, "id", openAIResponsesNonStreamToolItemID(id, choice.Get("index").Int(), currentToolIndex, true))
 							item, _ = sjson.SetBytes(item, "input", unwrapCustomToolInput(args))
 							item, _ = sjson.SetBytes(item, "call_id", callID)
 							item, _ = sjson.SetBytes(item, "name", name)
@@ -865,7 +868,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 							return true
 						}
 						item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
-						item, _ = sjson.SetBytes(item, "id", openAIResponsesNonStreamToolItemID(id, choice.Get("index").Int(), tcIndex.Int(), false))
+						item, _ = sjson.SetBytes(item, "id", openAIResponsesNonStreamToolItemID(id, choice.Get("index").Int(), currentToolIndex, false))
 						item, _ = sjson.SetBytes(item, "arguments", args)
 						item, _ = sjson.SetBytes(item, "call_id", callID)
 						item = applyResponsesFunctionCallNamespaceFields(item, requestForNamespace, name, "")

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -373,6 +373,9 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 
 	if !st.Started {
 		st.ResponseID = root.Get("id").String()
+		if st.ResponseID == "" {
+			st.ResponseID = fmt.Sprintf("resp_%x_%d", time.Now().UnixNano(), atomic.AddUint64(&responseIDCounter, 1))
+		}
 		st.Created = root.Get("created").Int()
 		// reset aggregation state for a new streaming response
 		st.MsgTextBuf = make(map[int]*strings.Builder)

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -337,8 +337,8 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_MultiChoiceToolCa
 
 func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_MixedMessageAndToolUseDistinctOutputIndexes(t *testing.T) {
 	in := []string{
-		`data: {"id":"resp_mixed","object":"chat.completion.chunk","created":1773896263,"model":"model","choices":[{"index":0,"delta":{"role":"assistant","content":"hello","reasoning_content":null,"tool_calls":null},"finish_reason":null},{"index":1,"delta":{"role":"assistant","content":null,"reasoning_content":null,"tool_calls":[{"index":0,"id":"call_choice1","type":"function","function":{"name":"read","arguments":""}}]},"finish_reason":null}]}`,
-		`data: {"id":"resp_mixed","object":"chat.completion.chunk","created":1773896263,"model":"model","choices":[{"index":0,"delta":{"role":null,"content":null,"reasoning_content":null,"tool_calls":null},"finish_reason":"stop"},{"index":1,"delta":{"role":null,"content":null,"reasoning_content":null,"tool_calls":[{"index":0,"function":{"arguments":"{\"filePath\":\"C:\\\\repo\\\\README.md\",\"limit\":20,\"offset\":1}"}}]},"finish_reason":"tool_calls"}],"usage":{"completion_tokens":10,"total_tokens":20,"prompt_tokens":10}}`,
+		`data: {"id":"","object":"chat.completion.chunk","created":1773896263,"model":"model","choices":[{"index":0,"delta":{"role":"assistant","content":"hello","reasoning_content":null,"tool_calls":null},"finish_reason":null},{"index":1,"delta":{"role":"assistant","content":null,"reasoning_content":null,"tool_calls":[{"index":0,"id":"call_choice1","type":"function","function":{"name":"read","arguments":""}}]},"finish_reason":null}]}`,
+		`data: {"id":"","object":"chat.completion.chunk","created":1773896263,"model":"model","choices":[{"index":0,"delta":{"role":null,"content":null,"reasoning_content":null,"tool_calls":null},"finish_reason":"stop"},{"index":1,"delta":{"role":null,"content":null,"reasoning_content":null,"tool_calls":[{"index":0,"function":{"arguments":"{\"filePath\":\"C:\\\\repo\\\\README.md\",\"limit\":20,\"offset\":1}"}}]},"finish_reason":"tool_calls"}],"usage":{"completion_tokens":10,"total_tokens":20,"prompt_tokens":10}}`,
 		`data: [DONE]`,
 	}
 
@@ -352,6 +352,8 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_MixedMessageAndTo
 
 	var messageOutputIndex int64 = -1
 	var toolOutputIndex int64 = -1
+	var messageItemID string
+	var toolItemID string
 	var completed gjson.Result
 
 	for _, chunk := range out {
@@ -365,11 +367,11 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_MixedMessageAndTo
 		}
 		switch data.Get("item.type").String() {
 		case "message":
-			if data.Get("item.id").String() == "msg_resp_mixed_0" {
-				messageOutputIndex = data.Get("output_index").Int()
-			}
+			messageItemID = data.Get("item.id").String()
+			messageOutputIndex = data.Get("output_index").Int()
 		case "function_call":
 			if data.Get("item.call_id").String() == "call_choice1" {
+				toolItemID = data.Get("item.id").String()
 				toolOutputIndex = data.Get("output_index").Int()
 			}
 		}
@@ -386,6 +388,16 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_MixedMessageAndTo
 	}
 	if !completed.Exists() {
 		t.Fatal("did not find response.completed event")
+	}
+	responseID := completed.Get("response.id").String()
+	if responseID == "" {
+		t.Fatal("streaming response did not synthesize an id")
+	}
+	if messageItemID != "msg_"+responseID+"_0" {
+		t.Fatalf("message item id = %q, want provenance for response %q", messageItemID, responseID)
+	}
+	if toolItemID != "fc_"+responseID+"_1_0" {
+		t.Fatalf("tool item id = %q, want provenance for response %q", toolItemID, responseID)
 	}
 
 	nextRequest := []byte(`{"model":"gpt-5.4","input":[]}`)

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -2,6 +2,7 @@ package responses
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -598,6 +599,83 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_OmitsTop
 	}
 	if got := data.Get("output.0.content.0.text").String(); got != "ping" {
 		t.Fatalf("output text = %q, want %q; response=%s", got, "ping", resp)
+	}
+}
+
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ParallelToolCallIDsAreUnique(t *testing.T) {
+	tests := []struct {
+		name       string
+		request    []byte
+		toolName   string
+		itemType   string
+		itemPrefix string
+	}{
+		{
+			name:       "function tools",
+			request:    []byte(`{"model":"model"}`),
+			toolName:   "lookup",
+			itemType:   "function_call",
+			itemPrefix: "fc_",
+		},
+		{
+			name:       "custom tools",
+			request:    []byte(`{"model":"model","tools":[{"type":"custom","name":"exec"}]}`),
+			toolName:   "exec",
+			itemType:   "custom_tool_call",
+			itemPrefix: "ctc_",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := []byte(`{
+				"id":"resp_parallel",
+				"object":"chat.completion",
+				"created":1,
+				"model":"model",
+				"choices":[{
+					"index":2,
+					"message":{"role":"assistant","tool_calls":[
+						{"id":"call_a","type":"function","function":{"name":"","arguments":"{}"}},
+						{"id":"call_b","type":"function","function":{"name":"","arguments":"{}"}}
+					]},
+					"finish_reason":"tool_calls"
+				}]
+			}`)
+			var err error
+			raw, err = sjson.SetBytes(raw, "choices.0.message.tool_calls.0.function.name", tt.toolName)
+			if err != nil {
+				t.Fatalf("set first tool name: %v", err)
+			}
+			raw, err = sjson.SetBytes(raw, "choices.0.message.tool_calls.1.function.name", tt.toolName)
+			if err != nil {
+				t.Fatalf("set second tool name: %v", err)
+			}
+
+			resp := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(
+				context.Background(), "model", tt.request, tt.request, raw, nil,
+			)
+			outputs := gjson.GetBytes(resp, "output").Array()
+			if len(outputs) != 2 {
+				t.Fatalf("output count = %d, want 2; response=%s", len(outputs), resp)
+			}
+			for i, wantCallID := range []string{"call_a", "call_b"} {
+				item := outputs[i]
+				if got := item.Get("type").String(); got != tt.itemType {
+					t.Fatalf("output.%d type = %q, want %q; response=%s", i, got, tt.itemType, resp)
+				}
+				wantItemID := tt.itemPrefix + "resp_parallel_2_" + strconv.Itoa(i)
+				if got := item.Get("id").String(); got != wantItemID {
+					t.Fatalf("output.%d id = %q, want %q; response=%s", i, got, wantItemID, resp)
+				}
+				if got := item.Get("call_id").String(); got != wantCallID {
+					t.Fatalf("output.%d call_id = %q, want %q; response=%s", i, got, wantCallID, resp)
+				}
+			}
+			if gjson.GetBytes(resp, "output.0.id").String() == gjson.GetBytes(resp, "output.1.id").String() {
+				t.Fatalf("parallel tool item ids are duplicated; response=%s", resp)
+			}
+		})
 	}
 }
 

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 func parseOpenAIResponsesSSEEvent(t *testing.T, chunk []byte) (string, gjson.Result) {
@@ -443,6 +444,57 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_ToolCallCompleted
 	}
 	if got := completed.Get("response.output.1.arguments").String(); !strings.Contains(got, "北京") {
 		t.Fatalf("response function call arguments = %q, want Beijing argument", got)
+	}
+}
+
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_StreamingRoundTripKeepsCombinedAssistantTurn(t *testing.T) {
+	in := []string{
+		`data: {"id":"resp_round_trip","object":"chat.completion.chunk","created":1,"model":"kimi-k3","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"inspect the next step","content":null},"finish_reason":null}]}`,
+		`data: {"id":"resp_round_trip","object":"chat.completion.chunk","created":1,"model":"kimi-k3","choices":[{"index":0,"delta":{"role":"assistant","content":"Step 1 completed; continue to step 2."},"finish_reason":null}]}`,
+		`data: {"id":"resp_round_trip","object":"chat.completion.chunk","created":1,"model":"kimi-k3","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"exec_command","arguments":""}}]},"finish_reason":null}]}`,
+		`data: {"id":"resp_round_trip","object":"chat.completion.chunk","created":1,"model":"kimi-k3","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"cmd\":\"printf step-2\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+		`data: [DONE]`,
+	}
+	request := []byte(`{"model":"kimi-k3","reasoning":{"effort":"max"}}`)
+
+	var param any
+	var completed gjson.Result
+	for _, line := range in {
+		for _, chunk := range ConvertOpenAIChatCompletionsResponseToOpenAIResponses(context.Background(), "kimi-k3", request, request, []byte(line), &param) {
+			event, data := parseOpenAIResponsesSSEEvent(t, chunk)
+			if event == "response.completed" {
+				completed = data
+			}
+		}
+	}
+	if !completed.Exists() {
+		t.Fatal("expected response.completed event")
+	}
+
+	nextRequest := []byte(`{"model":"kimi-k3","input":[]}`)
+	var err error
+	nextRequest, err = sjson.SetRawBytes(nextRequest, "input", []byte(completed.Get("response.output").Raw))
+	if err != nil {
+		t.Fatalf("set Responses output history: %v", err)
+	}
+	nextRequest, err = sjson.SetRawBytes(nextRequest, "input.-1", []byte(`{"type":"function_call_output","call_id":"call_1","output":"step-2"}`))
+	if err != nil {
+		t.Fatalf("append function call output: %v", err)
+	}
+
+	roundTripped := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("kimi-k3", nextRequest, true)
+	if got := gjson.GetBytes(roundTripped, "messages.#").Int(); got != 2 {
+		t.Fatalf("messages count after streaming round-trip = %d, want 2; output=%s", got, roundTripped)
+	}
+	assistant := gjson.GetBytes(roundTripped, "messages.0")
+	if got := assistant.Get("content.0.text").String(); got != "Step 1 completed; continue to step 2." {
+		t.Fatalf("assistant content = %q; output=%s", got, roundTripped)
+	}
+	if got := assistant.Get("reasoning_content").String(); got != "inspect the next step" {
+		t.Fatalf("assistant reasoning_content = %q; output=%s", got, roundTripped)
+	}
+	if got := assistant.Get("tool_calls.0.id").String(); got != "call_1" {
+		t.Fatalf("assistant tool call id = %q; output=%s", got, roundTripped)
 	}
 }
 

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -352,9 +352,14 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_MixedMessageAndTo
 
 	var messageOutputIndex int64 = -1
 	var toolOutputIndex int64 = -1
+	var completed gjson.Result
 
 	for _, chunk := range out {
 		ev, data := parseOpenAIResponsesSSEEvent(t, chunk)
+		if ev == "response.completed" {
+			completed = data
+			continue
+		}
 		if ev != "response.output_item.added" {
 			continue
 		}
@@ -378,6 +383,26 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_MixedMessageAndTo
 	}
 	if messageOutputIndex == toolOutputIndex {
 		t.Fatalf("expected distinct output indexes for message and tool call, both got %d", messageOutputIndex)
+	}
+	if !completed.Exists() {
+		t.Fatal("did not find response.completed event")
+	}
+
+	nextRequest := []byte(`{"model":"gpt-5.4","input":[]}`)
+	var err error
+	nextRequest, err = sjson.SetRawBytes(nextRequest, "input", []byte(completed.Get("response.output").Raw))
+	if err != nil {
+		t.Fatalf("set Responses history: %v", err)
+	}
+	roundTripped := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("gpt-5.4", nextRequest, false)
+	if got := gjson.GetBytes(roundTripped, "messages.#").Int(); got != 2 {
+		t.Fatalf("round-trip messages count = %d, want 2; output=%s", got, roundTripped)
+	}
+	if gjson.GetBytes(roundTripped, "messages.0.tool_calls").Exists() {
+		t.Fatalf("choice 1 tool call merged into choice 0 message; output=%s", roundTripped)
+	}
+	if got := gjson.GetBytes(roundTripped, "messages.1.tool_calls.0.id").String(); got != "call_choice1" {
+		t.Fatalf("separate tool-call message id = %q, want call_choice1; output=%s", got, roundTripped)
 	}
 }
 
@@ -709,15 +734,15 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_CustomToolNameArr
 		if got := tc.got.Get(tc.path + ".type").String(); got != "custom_tool_call" {
 			t.Fatalf("%s type = %q, want custom_tool_call", tc.label, got)
 		}
-		if got := tc.got.Get(tc.path + ".id").String(); got != "ctc_call_exec" {
-			t.Fatalf("%s id = %q, want ctc_call_exec", tc.label, got)
+		if got := tc.got.Get(tc.path + ".id").String(); got != "ctc_chatcmpl_custom_late_name_0_0" {
+			t.Fatalf("%s id = %q, want ctc_chatcmpl_custom_late_name_0_0", tc.label, got)
 		}
 		if got := tc.got.Get(tc.path + ".name").String(); got != "exec" {
 			t.Fatalf("%s name = %q, want exec", tc.label, got)
 		}
 	}
-	if got := inputDone.Get("item_id").String(); got != "ctc_call_exec" {
-		t.Fatalf("custom input done item_id = %q, want ctc_call_exec", got)
+	if got := inputDone.Get("item_id").String(); got != "ctc_chatcmpl_custom_late_name_0_0" {
+		t.Fatalf("custom input done item_id = %q, want ctc_chatcmpl_custom_late_name_0_0", got)
 	}
 	if got := inputDone.Get("input").String(); got != "pwd" {
 		t.Fatalf("custom input done input = %q, want pwd", got)
@@ -762,8 +787,8 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_CustomToolNameAnd
 		if got := tc.got.Get(tc.path + ".type").String(); got != "custom_tool_call" {
 			t.Fatalf("%s type = %q, want custom_tool_call", tc.label, got)
 		}
-		if got := tc.got.Get(tc.path + ".id").String(); got != "ctc_"+wantCallID {
-			t.Fatalf("%s id = %q, want %q", tc.label, got, "ctc_"+wantCallID)
+		if got := tc.got.Get(tc.path + ".id").String(); got != "ctc_chatcmpl_custom_missing_fields_0_0" {
+			t.Fatalf("%s id = %q, want ctc_chatcmpl_custom_missing_fields_0_0", tc.label, got)
 		}
 		if got := tc.got.Get(tc.path + ".call_id").String(); got != wantCallID {
 			t.Fatalf("%s call_id = %q, want %q", tc.label, got, wantCallID)
@@ -822,7 +847,11 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_ToolCallIDMayArri
 				}
 			}
 
-			wantItemID := "fc_" + tt.wantCallID
+			responseID := "chatcmpl_late_id"
+			if tt.name == "missing id" {
+				responseID = "chatcmpl_missing_id"
+			}
+			wantItemID := "fc_" + responseID + "_0_0"
 			if got := added.Get("item.id").String(); got != wantItemID {
 				t.Fatalf("added item id = %q, want %q; events=%v", got, wantItemID, events)
 			}


### PR DESCRIPTION
## What changed

- preserve a Responses assistant turn containing reasoning, visible text, and one or more function calls as one Chat Completions assistant message
- keep user-message boundaries intact when flushing pending tool calls
- merge duplicate reasoning safely while preserving distinct reasoning content
- add translator, streaming round-trip, and Kimi executor regression coverage

## Why

The Responses request translator currently reconstructs this normalized output sequence:

```text
reasoning -> message -> function_call(s)
```

as two adjacent Chat Completions assistant messages:

```text
assistant(content + reasoning_content)
assistant(tool_calls)
```

That changes the original assistant turn semantics and can cause an upstream model to treat the first message as a completed reply instead of continuing the tool-use turn. The converter now reconstructs the sequence atomically as:

```text
assistant(content + reasoning_content + tool_calls) -> tool
```

## Validation

- `go test ./internal/translator/openai/openai/responses`
- `go test ./internal/runtime/executor -run '^TestKimiNativeAssistantMessageSurvivesResponsesRoundTrip$'`
- `go build -o <temporary-path>/cli-proxy-api ./cmd/server`
- `git diff --check origin/dev...HEAD`

Fixes #4676
