### PR TITLE
fix(antigravity): preserve tools in non-stream responses

### DIFF
--- a/internal/translator/antigravity/openai/responses/antigravity_openai-responses_response.go
+++ b/internal/translator/antigravity/openai/responses/antigravity_openai-responses_response.go
@@ -21,13 +21,11 @@ func ConvertAntigravityResponseToOpenAIResponsesNonStream(ctx context.Context, m
 		rawJSON = []byte(responseResult.Raw)
 	}
 
-	requestResult := gjson.GetBytes(originalRequestRawJSON, "request")
-	if responseResult.Exists() {
+	if requestResult := gjson.GetBytes(originalRequestRawJSON, "request"); requestResult.Exists() {
 		originalRequestRawJSON = []byte(requestResult.Raw)
 	}
 
-	requestResult = gjson.GetBytes(requestRawJSON, "request")
-	if responseResult.Exists() {
+	if requestResult := gjson.GetBytes(requestRawJSON, "request"); requestResult.Exists() {
 		requestRawJSON = []byte(requestResult.Raw)
 	}
 

--- a/internal/translator/antigravity/openai/responses/antigravity_openai-responses_response_test.go
+++ b/internal/translator/antigravity/openai/responses/antigravity_openai-responses_response_test.go
@@ -1,0 +1,158 @@
+package responses
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertAntigravityResponseToOpenAIResponsesNonStream_PreservesOpenAITools(
+	t *testing.T,
+) {
+	// Original OpenAI request without the Antigravity "request" wrapper.
+	originalReq := []byte(`{
+		"model": "gemini-3.6-flash",
+		"tools": [
+			{
+				"type": "function",
+				"name": "get_weather",
+				"description": "Get current weather",
+				"parameters": {
+					"type": "object",
+					"properties": {
+						"location": {
+							"type": "string"
+						}
+					},
+					"required": ["location"],
+					"additionalProperties": false
+				},
+				"strict": true
+			}
+		]
+	}`)
+
+	// Translated Antigravity/Gemini request wrapped in "request".
+	translatedReq := []byte(`{
+		"request": {
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"name": "get_weather",
+							"description": "Get current weather",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"location": {
+										"type": "string"
+									}
+								},
+								"required": ["location"]
+							}
+						}
+					]
+				}
+			]
+		}
+	}`)
+
+	// Antigravity upstream response wrapped in "response".
+	rawResp := []byte(`{
+		"response": {
+			"candidates": [
+				{
+					"content": {
+						"parts": [
+							{
+								"functionCall": {
+									"name": "get_weather",
+									"args": {
+										"location": "Tokyo"
+									}
+								}
+							}
+						],
+						"role": "model"
+					},
+					"finishReason": "STOP"
+				}
+			]
+		}
+	}`)
+
+	out := ConvertAntigravityResponseToOpenAIResponsesNonStream(
+		context.Background(),
+		"gemini-3.6-flash",
+		originalReq,
+		translatedReq,
+		rawResp,
+		nil,
+	)
+
+	if !gjson.ValidBytes(out) {
+		t.Fatalf("expected valid JSON response, got: %s", out)
+	}
+
+	tool := gjson.GetBytes(out, "tools.0")
+	if !tool.Exists() {
+		t.Fatalf("expected tools[0] in response, got: %s", out)
+	}
+
+	if got := tool.Get("type").String(); got != "function" {
+		t.Fatalf(
+			"expected tools[0].type to be %q, got %q; response: %s",
+			"function",
+			got,
+			out,
+		)
+	}
+
+	if got := tool.Get("name").String(); got != "get_weather" {
+		t.Fatalf(
+			"expected tools[0].name to be %q, got %q; response: %s",
+			"get_weather",
+			got,
+			out,
+		)
+	}
+
+	if tool.Get("functionDeclarations").Exists() {
+		t.Fatalf(
+			"Gemini-native functionDeclarations leaked into OpenAI response: %s",
+			tool.Raw,
+		)
+	}
+
+	if got := tool.Get("parameters.type").String(); got != "object" {
+		t.Fatalf(
+			"expected OpenAI parameters schema, got: %s",
+			tool.Raw,
+		)
+	}
+
+	if !tool.Get("strict").Bool() {
+		t.Fatalf("expected strict=true to be preserved: %s", tool.Raw)
+	}
+
+	functionCall := gjson.GetBytes(
+		out,
+		`output.#(type=="function_call")`,
+	)
+
+	if !functionCall.Exists() {
+		t.Fatalf(
+			"expected OpenAI function_call output, got: %s",
+			out,
+		)
+	}
+
+	if got := functionCall.Get("name").String(); got != "get_weather" {
+		t.Fatalf(
+			"expected function call name %q, got %q",
+			"get_weather",
+			got,
+		)
+	}
+}


### PR DESCRIPTION
Closes #4780

## Summary

Fix Antigravity non-stream Responses request unwrapping.

The converter checked `responseResult.Exists()` when deciding whether to unwrap request payloads. This could clear the original OpenAI request and cause Gemini-native `functionDeclarations` to be copied into `response.tools`.

## Changes

- Check `requestResult.Exists()` before unwrapping request payloads
- Preserve OpenAI tool definitions in non-stream Responses
- Add regression coverage for the affected request shape

## Verification

- Added a regression test that fails before the fix and passes afterward
- `go test -count=1 -v ./internal/translator/antigravity/openai/responses`
- `go test ./...`
- `go build -o /tmp/cliproxyapi-build-test ./cmd/server`
- Verified with a real non-stream `/v1/responses` request
- Verified that `response.tools[0].type == "function"`
- Verified that Gemini-native `functionDeclarations` no longer leak into the response