### PR TITLE
fix(claude): skip context management when thinking is disabled

### DIFF
--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -676,8 +676,51 @@ const claudeCodeContextManagement = `{"edits":[{"type":"clear_thinking_20251015"
 // omitted it. CPA already claims context-management-2025-06-27 in Anthropic-Beta,
 // so a missing body field is an observable inconsistency with the real client. A
 // caller that sent its own object keeps it untouched.
-func injectClaudeCodeContextManagement(payload []byte) []byte {
+func injectClaudeCodeContextManagement(payload []byte) ([]byte, bool) {
 	if gjson.GetBytes(payload, "context_management").Exists() {
+		return payload, false
+	}
+	if gjson.GetBytes(payload, "thinking.type").String() == "disabled" {
+		return payload, false
+	}
+	updated, err := sjson.SetRawBytes(payload, "context_management", []byte(claudeCodeContextManagement))
+	if err != nil {
+		return payload, false
+	}
+	return updated, true
+}
+
+type claudeCodeContextManagementState struct {
+	eligible              bool
+	callerOwned           bool
+	automaticallyInjected bool
+	payloadRuleTouched    bool
+}
+
+// reconcileClaudeCodeContextManagement resolves automatic ownership after all
+// payload rules and forced tool-choice processing have completed.
+func reconcileClaudeCodeContextManagement(payload []byte, state claudeCodeContextManagementState) []byte {
+	thinkingType := gjson.GetBytes(payload, "thinking.type").String()
+	contextManagement := gjson.GetBytes(payload, "context_management")
+
+	if thinkingType == "disabled" {
+		if state.callerOwned || !state.automaticallyInjected || state.payloadRuleTouched {
+			return payload
+		}
+		if contextManagement.Raw != claudeCodeContextManagement {
+			return payload
+		}
+		updated, err := sjson.DeleteBytes(payload, "context_management")
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+
+	if thinkingType != "enabled" && thinkingType != "adaptive" {
+		return payload
+	}
+	if !state.eligible || state.callerOwned || state.payloadRuleTouched || contextManagement.Exists() {
 		return payload
 	}
 	updated, err := sjson.SetRawBytes(payload, "context_management", []byte(claudeCodeContextManagement))

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -13,6 +13,7 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
 )
 
 func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
@@ -79,8 +80,12 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	// Only the Messages endpoint on Anthropic itself was captured; count_tokens
 	// keeps its own shape and other gateways never see this field.
 	diagnosticsState := claudeDiagnosticsRequestState{}
-	if cloaked && isAnthropicUpstreamBase(baseURL) {
-		body = injectClaudeCodeContextManagement(body)
+	contextManagementState := claudeCodeContextManagementState{
+		eligible:    cloaked && isAnthropicUpstreamBase(baseURL),
+		callerOwned: gjson.GetBytes(body, "context_management").Exists(),
+	}
+	if contextManagementState.eligible {
+		body, contextManagementState.automaticallyInjected = injectClaudeCodeContextManagement(body)
 		if oauthToken {
 			body, diagnosticsState = injectClaudeDiagnostics(body, auth, claudeSessionID)
 		}
@@ -88,11 +93,12 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
-	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
+	body, contextManagementState.payloadRuleTouched = helps.ApplyPayloadConfigWithRequestTracked(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers, "context_management")
 	body = ensureModelMaxTokens(body, baseModel)
 
 	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
 	body = disableThinkingIfToolChoiceForced(body)
+	body = reconcileClaudeCodeContextManagement(body, contextManagementState)
 	body = normalizeClaudeSamplingForUpstream(body)
 
 	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -84,8 +84,12 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	// Only the Messages endpoint on Anthropic itself was captured; count_tokens
 	// keeps its own shape and other gateways never see this field.
 	diagnosticsState := claudeDiagnosticsRequestState{}
-	if cloaked && isAnthropicUpstreamBase(baseURL) {
-		body = injectClaudeCodeContextManagement(body)
+	contextManagementState := claudeCodeContextManagementState{
+		eligible:    cloaked && isAnthropicUpstreamBase(baseURL),
+		callerOwned: gjson.GetBytes(body, "context_management").Exists(),
+	}
+	if contextManagementState.eligible {
+		body, contextManagementState.automaticallyInjected = injectClaudeCodeContextManagement(body)
 		if oauthToken {
 			body, diagnosticsState = injectClaudeDiagnostics(body, auth, claudeSessionID)
 		}
@@ -93,11 +97,12 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
-	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
+	body, contextManagementState.payloadRuleTouched = helps.ApplyPayloadConfigWithRequestTracked(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers, "context_management")
 	body = ensureModelMaxTokens(body, baseModel)
 
 	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
 	body = disableThinkingIfToolChoiceForced(body)
+	body = reconcileClaudeCodeContextManagement(body, contextManagementState)
 	body = normalizeClaudeSamplingForUpstream(body)
 
 	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -5368,20 +5368,419 @@ func TestApplyClaudeHeaders_CallerBetasScopedByUpstream(t *testing.T) {
 	}
 }
 
-// TestInjectClaudeCodeContextManagement pins the captured 2.1.220 object and the
-// rule that a caller's own context_management is never overwritten.
+// TestInjectClaudeCodeContextManagement pins the captured 2.1.220 object and
+// the thinking and caller-ownership rules that control automatic injection.
 func TestInjectClaudeCodeContextManagement(t *testing.T) {
 	const captured = `{"edits":[{"type":"clear_thinking_20251015","keep":"all"}]}`
 
-	got := injectClaudeCodeContextManagement([]byte(`{"model":"claude-opus-4-6"}`))
-	if diff := gjson.GetBytes(got, "context_management").Raw; diff != captured {
-		t.Fatalf("context_management = %s, want the captured object %s", diff, captured)
+	for _, test := range []struct {
+		name    string
+		payload string
+	}{
+		{name: "omitted thinking", payload: `{"model":"claude-opus-4-6"}`},
+		{name: "enabled thinking", payload: `{"model":"claude-opus-5","thinking":{"type":"enabled"}}`},
+		{name: "adaptive thinking", payload: `{"model":"claude-opus-5","thinking":{"type":"adaptive"}}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, automaticallyInjected := injectClaudeCodeContextManagement([]byte(test.payload))
+			if !automaticallyInjected {
+				t.Fatal("automatic context_management injection was not reported")
+			}
+			if diff := gjson.GetBytes(got, "context_management").Raw; diff != captured {
+				t.Fatalf("context_management = %s, want the captured object %s", diff, captured)
+			}
+		})
 	}
 
 	callerOwned := []byte(`{"model":"claude-opus-4-6","context_management":{"edits":[]}}`)
-	if got := injectClaudeCodeContextManagement(callerOwned); !bytes.Equal(got, callerOwned) {
-		t.Fatalf("caller context_management was modified: %s", got)
+	callerOwnedGot, automaticallyInjected := injectClaudeCodeContextManagement(callerOwned)
+	if automaticallyInjected {
+		t.Error("caller context_management was reported as automatically injected")
 	}
+	if !bytes.Equal(callerOwnedGot, callerOwned) {
+		t.Fatalf("caller context_management was modified: %s", callerOwnedGot)
+	}
+
+	disabledThinking := []byte(`{"model":"claude-opus-5","thinking":{"type":"disabled"}}`)
+	disabledThinkingGot, automaticallyInjected := injectClaudeCodeContextManagement(disabledThinking)
+	if automaticallyInjected {
+		t.Error("disabled thinking context_management was reported as automatically injected")
+	}
+	if !bytes.Equal(disabledThinkingGot, disabledThinking) {
+		t.Errorf("disabled thinking payload was modified: %s", disabledThinkingGot)
+	}
+	if got := gjson.GetBytes(disabledThinkingGot, "context_management"); got.Exists() {
+		t.Errorf("disabled thinking payload has context_management = %s, want absent", got.Raw)
+	}
+}
+
+func TestReconcileClaudeCodeContextManagement(t *testing.T) {
+	withAutomatic := func(thinkingType string) string {
+		return `{"thinking":{"type":"` + thinkingType + `"},"context_management":` + claudeCodeContextManagement + `}`
+	}
+
+	for _, test := range []struct {
+		name    string
+		payload string
+		state   claudeCodeContextManagementState
+		wantRaw string
+	}{
+		{
+			name:    "removes unchanged automatic object when disabled",
+			payload: withAutomatic("disabled"),
+			state:   claudeCodeContextManagementState{eligible: true, automaticallyInjected: true},
+		},
+		{
+			name:    "preserves rule owned automatic object when disabled",
+			payload: withAutomatic("disabled"),
+			state:   claudeCodeContextManagementState{eligible: true, automaticallyInjected: true, payloadRuleTouched: true},
+			wantRaw: claudeCodeContextManagement,
+		},
+		{
+			name:    "preserves changed automatic object when disabled",
+			payload: `{"thinking":{"type":"disabled"},"context_management":{"edits":[{"type":"custom"}]}}`,
+			state:   claudeCodeContextManagementState{eligible: true, automaticallyInjected: true},
+			wantRaw: `{"edits":[{"type":"custom"}]}`,
+		},
+		{
+			name:    "adds automatic object when enabled",
+			payload: `{"thinking":{"type":"enabled"}}`,
+			state:   claudeCodeContextManagementState{eligible: true},
+			wantRaw: claudeCodeContextManagement,
+		},
+		{
+			name:    "adds automatic object when adaptive",
+			payload: `{"thinking":{"type":"adaptive"}}`,
+			state:   claudeCodeContextManagementState{eligible: true},
+			wantRaw: claudeCodeContextManagement,
+		},
+		{
+			name:    "caller ownership prevents addition",
+			payload: `{"thinking":{"type":"enabled"}}`,
+			state:   claudeCodeContextManagementState{eligible: true, callerOwned: true},
+		},
+		{
+			name:    "payload rule ownership prevents addition",
+			payload: `{"thinking":{"type":"enabled"}}`,
+			state:   claudeCodeContextManagementState{eligible: true, payloadRuleTouched: true},
+		},
+		{
+			name:    "ineligible request prevents addition",
+			payload: `{"thinking":{"type":"enabled"}}`,
+		},
+		{
+			name:    "omitted thinking prevents addition",
+			payload: `{}`,
+			state:   claudeCodeContextManagementState{eligible: true},
+		},
+		{
+			name:    "unknown thinking prevents addition",
+			payload: `{"thinking":{"type":"unexpected"}}`,
+			state:   claudeCodeContextManagementState{eligible: true},
+		},
+		{
+			name:    "invalid thinking prevents addition",
+			payload: `{"thinking":{"type":123}}`,
+			state:   claudeCodeContextManagementState{eligible: true},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := reconcileClaudeCodeContextManagement([]byte(test.payload), test.state)
+			if raw := gjson.GetBytes(got, "context_management").Raw; raw != test.wantRaw {
+				t.Fatalf("context_management = %s, want %s; body=%s", raw, test.wantRaw, got)
+			}
+		})
+	}
+}
+
+func TestClaudeExecutorPayloadOverrideDisabledThinking(t *testing.T) {
+	const model = "claude-opus-5"
+	modelRules := []config.PayloadModelRule{{Name: model, Protocol: "claude"}}
+	basePayload := []byte(`{"model":"claude-opus-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}`)
+
+	for _, test := range []struct {
+		name   string
+		stream bool
+	}{
+		{name: "execute"},
+		{name: "execute stream", stream: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.Config{Payload: config.PayloadConfig{Override: []config.PayloadRule{{
+				Models: modelRules,
+				Params: map[string]any{"thinking.type": "disabled"},
+			}}}}
+			upstreamBody := executeClaudeContextManagementRequest(t, cfg, basePayload, test.stream)
+			if got := gjson.GetBytes(upstreamBody, "thinking.type").String(); got != "disabled" {
+				t.Fatalf("final upstream thinking.type = %q, want disabled; body=%s", got, upstreamBody)
+			}
+			if got := gjson.GetBytes(upstreamBody, "context_management"); got.Exists() {
+				t.Errorf("final upstream context_management = %s with disabled thinking, want absent", got.Raw)
+			}
+		})
+	}
+
+	t.Run("caller context management is preserved", func(t *testing.T) {
+		cfg := &config.Config{Payload: config.PayloadConfig{Override: []config.PayloadRule{{
+			Models: modelRules,
+			Params: map[string]any{"thinking.type": "disabled"},
+		}}}}
+		payload := []byte(`{"model":"claude-opus-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}],"context_management":{"edits":[{"type":"caller_owned"}]}}`)
+		upstreamBody := executeClaudeContextManagementRequest(t, cfg, payload, false)
+		if got := gjson.GetBytes(upstreamBody, "context_management.edits.0.type").String(); got != "caller_owned" {
+			t.Fatalf("caller context_management type = %q, want caller_owned; body=%s", got, upstreamBody)
+		}
+	})
+
+	t.Run("payload override replacement is preserved", func(t *testing.T) {
+		cfg := &config.Config{Payload: config.PayloadConfig{Override: []config.PayloadRule{{
+			Models: modelRules,
+			Params: map[string]any{
+				"thinking.type":      "disabled",
+				"context_management": map[string]any{"edits": []any{map[string]any{"type": "payload_rule"}}},
+			},
+		}}}}
+		upstreamBody := executeClaudeContextManagementRequest(t, cfg, basePayload, false)
+		if got := gjson.GetBytes(upstreamBody, "context_management.edits.0.type").String(); got != "payload_rule" {
+			t.Fatalf("payload-rule context_management type = %q, want payload_rule; body=%s", got, upstreamBody)
+		}
+	})
+
+	t.Run("exact automatic value remains payload rule owned", func(t *testing.T) {
+		ownershipConfigs := []struct {
+			name string
+			cfg  *config.Config
+		}{
+			{
+				name: "default",
+				cfg: &config.Config{Payload: config.PayloadConfig{
+					Default: []config.PayloadRule{{
+						Models: modelRules,
+						Params: map[string]any{"context_management": json.RawMessage(claudeCodeContextManagement)},
+					}},
+					Override: []config.PayloadRule{{
+						Models: modelRules,
+						Params: map[string]any{"thinking.type": "disabled"},
+					}},
+				}},
+			},
+			{
+				name: "raw default",
+				cfg: &config.Config{Payload: config.PayloadConfig{
+					DefaultRaw: []config.PayloadRule{{
+						Models: modelRules,
+						Params: map[string]any{"context_management": claudeCodeContextManagement},
+					}},
+					Override: []config.PayloadRule{{
+						Models: modelRules,
+						Params: map[string]any{"thinking.type": "disabled"},
+					}},
+				}},
+			},
+			{
+				name: "override",
+				cfg: &config.Config{Payload: config.PayloadConfig{Override: []config.PayloadRule{{
+					Models: modelRules,
+					Params: map[string]any{
+						"thinking.type":      "disabled",
+						"context_management": json.RawMessage(claudeCodeContextManagement),
+					},
+				}}}},
+			},
+			{
+				name: "raw override",
+				cfg: &config.Config{Payload: config.PayloadConfig{
+					Override: []config.PayloadRule{{
+						Models: modelRules,
+						Params: map[string]any{"thinking.type": "disabled"},
+					}},
+					OverrideRaw: []config.PayloadRule{{
+						Models: modelRules,
+						Params: map[string]any{"context_management": claudeCodeContextManagement},
+					}},
+				}},
+			},
+		}
+		for _, ownership := range ownershipConfigs {
+			for _, stream := range []bool{false, true} {
+				name := ownership.name + " execute"
+				if stream {
+					name += " stream"
+				}
+				t.Run(name, func(t *testing.T) {
+					upstreamBody := executeClaudeContextManagementRequest(t, ownership.cfg, basePayload, stream)
+					if got := gjson.GetBytes(upstreamBody, "thinking.type").String(); got != "disabled" {
+						t.Fatalf("final upstream thinking.type = %q, want disabled; body=%s", got, upstreamBody)
+					}
+					if got := gjson.GetBytes(upstreamBody, "context_management").Raw; got != claudeCodeContextManagement {
+						t.Fatalf("%s context_management = %s, want payload-rule-owned %s; body=%s", ownership.name, got, claudeCodeContextManagement, upstreamBody)
+					}
+				})
+			}
+		}
+	})
+
+	t.Run("payload filter remains effective", func(t *testing.T) {
+		cfg := &config.Config{Payload: config.PayloadConfig{Filter: []config.PayloadFilterRule{{
+			Models: modelRules,
+			Params: []string{"context_management"},
+		}}}}
+		upstreamBody := executeClaudeContextManagementRequest(t, cfg, basePayload, false)
+		if got := gjson.GetBytes(upstreamBody, "context_management"); got.Exists() {
+			t.Fatalf("filtered context_management = %s, want absent", got.Raw)
+		}
+	})
+
+	for _, stream := range []bool{false, true} {
+		name := "forced tool choice retains automatic context management execute"
+		if stream {
+			name += " stream"
+		}
+		t.Run(name, func(t *testing.T) {
+			payload := []byte(`{"model":"claude-opus-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"tool_choice":{"type":"any"}}`)
+			upstreamBody := executeClaudeContextManagementRequest(t, &config.Config{}, payload, stream)
+			if got := gjson.GetBytes(upstreamBody, "thinking"); got.Exists() {
+				t.Fatalf("forced tool choice thinking = %s, want absent", got.Raw)
+			}
+			if got := gjson.GetBytes(upstreamBody, "context_management").Raw; got != claudeCodeContextManagement {
+				t.Fatalf("forced tool choice context_management = %s, want %s", got, claudeCodeContextManagement)
+			}
+			if got := gjson.GetBytes(upstreamBody, "tool_choice.type").String(); got != "any" {
+				t.Fatalf("forced tool_choice.type = %q, want any", got)
+			}
+		})
+	}
+}
+
+func TestClaudeExecutorPayloadOverrideReenablesThinking(t *testing.T) {
+	const model = "claude-opus-5"
+	modelRules := []config.PayloadModelRule{{Name: model, Protocol: "claude"}}
+	basePayload := []byte(`{"model":"claude-opus-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"disabled"}}`)
+
+	for _, test := range []struct {
+		name         string
+		thinkingType string
+		stream       bool
+	}{
+		{name: "execute enabled", thinkingType: "enabled"},
+		{name: "execute adaptive", thinkingType: "adaptive"},
+		{name: "execute stream enabled", thinkingType: "enabled", stream: true},
+		{name: "execute stream adaptive", thinkingType: "adaptive", stream: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.Config{Payload: config.PayloadConfig{Override: []config.PayloadRule{{
+				Models: modelRules,
+				Params: map[string]any{"thinking.type": test.thinkingType},
+			}}}}
+			upstreamBody := executeClaudeContextManagementRequest(t, cfg, basePayload, test.stream)
+			if got := gjson.GetBytes(upstreamBody, "thinking.type").String(); got != test.thinkingType {
+				t.Fatalf("final upstream thinking.type = %q, want %q; body=%s", got, test.thinkingType, upstreamBody)
+			}
+			if got := gjson.GetBytes(upstreamBody, "context_management").Raw; got != claudeCodeContextManagement {
+				t.Fatalf("final upstream context_management = %s, want %s after payload override to %s; body=%s", got, claudeCodeContextManagement, test.thinkingType, upstreamBody)
+			}
+		})
+	}
+
+	for _, stream := range []bool{false, true} {
+		nameSuffix := "execute"
+		if stream {
+			nameSuffix = "execute stream"
+		}
+
+		t.Run("caller context management is preserved after re-enabling "+nameSuffix, func(t *testing.T) {
+			cfg := &config.Config{Payload: config.PayloadConfig{Override: []config.PayloadRule{{
+				Models: modelRules,
+				Params: map[string]any{"thinking.type": "enabled"},
+			}}}}
+			payload := []byte(`{"model":"claude-opus-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"disabled"},"context_management":{"edits":[{"type":"caller_owned"}]}}`)
+			upstreamBody := executeClaudeContextManagementRequest(t, cfg, payload, stream)
+			if got := gjson.GetBytes(upstreamBody, "context_management.edits.0.type").String(); got != "caller_owned" {
+				t.Fatalf("caller context_management type = %q, want caller_owned; body=%s", got, upstreamBody)
+			}
+		})
+
+		t.Run("custom payload rule object is preserved after re-enabling "+nameSuffix, func(t *testing.T) {
+			cfg := &config.Config{Payload: config.PayloadConfig{Override: []config.PayloadRule{{
+				Models: modelRules,
+				Params: map[string]any{
+					"thinking.type":      "adaptive",
+					"context_management": map[string]any{"edits": []any{map[string]any{"type": "payload_rule"}}},
+				},
+			}}}}
+			upstreamBody := executeClaudeContextManagementRequest(t, cfg, basePayload, stream)
+			if got := gjson.GetBytes(upstreamBody, "context_management.edits.0.type").String(); got != "payload_rule" {
+				t.Fatalf("payload-rule context_management type = %q, want payload_rule; body=%s", got, upstreamBody)
+			}
+		})
+
+		t.Run("context management filter remains authoritative after re-enabling "+nameSuffix, func(t *testing.T) {
+			cfg := &config.Config{Payload: config.PayloadConfig{
+				Override: []config.PayloadRule{{
+					Models: modelRules,
+					Params: map[string]any{"thinking.type": "enabled"},
+				}},
+				Filter: []config.PayloadFilterRule{{
+					Models: modelRules,
+					Params: []string{"context_management"},
+				}},
+			}}
+			upstreamBody := executeClaudeContextManagementRequest(t, cfg, basePayload, stream)
+			if got := gjson.GetBytes(upstreamBody, "thinking.type").String(); got != "enabled" {
+				t.Fatalf("final upstream thinking.type = %q, want enabled; body=%s", got, upstreamBody)
+			}
+			if got := gjson.GetBytes(upstreamBody, "context_management"); got.Exists() {
+				t.Fatalf("filtered context_management = %s after re-enabling, want absent; body=%s", got.Raw, upstreamBody)
+			}
+		})
+	}
+}
+
+func executeClaudeContextManagementRequest(t *testing.T, cfg *config.Config, payload []byte, stream bool) []byte {
+	t.Helper()
+
+	var upstreamBody []byte
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var errRead error
+		upstreamBody, errRead = io.ReadAll(req.Body)
+		if errRead != nil {
+			t.Fatal(errRead)
+		}
+		contentType := "application/json"
+		responseBody := `{"id":"msg_test","type":"message","role":"assistant","model":"claude-opus-5","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`
+		if stream {
+			contentType = "text/event-stream"
+			responseBody = "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_test\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-opus-5\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":1,\"output_tokens\":0}}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{contentType}},
+			Body:       io.NopCloser(strings.NewReader(responseBody)),
+			Request:    req,
+		}, nil
+	})
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", http.RoundTripper(transport))
+	executor := NewClaudeExecutor(cfg)
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-payload-rule"}}
+	request := cliproxyexecutor.Request{Model: "claude-opus-5", Payload: payload}
+	options := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude}
+
+	if stream {
+		result, errStream := executor.ExecuteStream(ctx, auth, request, options)
+		if errStream != nil {
+			t.Fatalf("ExecuteStream() error = %v", errStream)
+		}
+		for chunk := range result.Chunks {
+			if chunk.Err != nil {
+				t.Fatalf("stream chunk error = %v", chunk.Err)
+			}
+		}
+		return upstreamBody
+	}
+	if _, errExecute := executor.Execute(ctx, auth, request, options); errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+	return upstreamBody
 }
 
 func TestValidateClaudeCallerSystemBlocksAcceptsTextOnly(t *testing.T) {

--- a/internal/runtime/executor/helps/payload_helpers.go
+++ b/internal/runtime/executor/helps/payload_helpers.go
@@ -26,10 +26,19 @@ func ApplyPayloadConfigWithRoot(cfg *config.Config, model, protocol, root string
 
 // ApplyPayloadConfigWithRequest applies payload config using source protocol and request header gates.
 func ApplyPayloadConfigWithRequest(cfg *config.Config, model, protocol, fromProtocol, root string, payload, original []byte, requestedModel string, requestPath string, headers http.Header) []byte {
+	out, _ := ApplyPayloadConfigWithRequestTracked(cfg, model, protocol, fromProtocol, root, payload, original, requestedModel, requestPath, headers, "")
+	return out
+}
+
+// ApplyPayloadConfigWithRequestTracked applies payload config and reports whether
+// an applied rule targeted trackedPath or one of its descendants.
+func ApplyPayloadConfigWithRequestTracked(cfg *config.Config, model, protocol, fromProtocol, root string, payload, original []byte, requestedModel string, requestPath string, headers http.Header, trackedPath string) ([]byte, bool) {
 	if cfg == nil || len(payload) == 0 {
-		return payload
+		return payload, false
 	}
 	out := payload
+	trackedPath = strings.TrimSpace(trackedPath)
+	trackedPathTouched := false
 
 	// Apply disable-image-generation filtering before payload rules so config payload
 	// overrides can explicitly re-enable image_generation when desired.
@@ -74,6 +83,7 @@ func ApplyPayloadConfigWithRequest(cfg *config.Config, model, protocol, fromProt
 						}
 						out = updated
 						appliedDefaults[resolvedPath] = struct{}{}
+						trackedPathTouched = trackedPathTouched || payloadRuleTargetsPath(resolvedPath, trackedPath)
 					}
 				}
 			}
@@ -105,6 +115,7 @@ func ApplyPayloadConfigWithRequest(cfg *config.Config, model, protocol, fromProt
 						}
 						out = updated
 						appliedDefaults[resolvedPath] = struct{}{}
+						trackedPathTouched = trackedPathTouched || payloadRuleTargetsPath(resolvedPath, trackedPath)
 					}
 				}
 			}
@@ -120,7 +131,11 @@ func ApplyPayloadConfigWithRequest(cfg *config.Config, model, protocol, fromProt
 						continue
 					}
 					for _, resolvedPath := range resolvePayloadRulePaths(out, fullPath) {
-						out = setPayloadValueIfDifferent(out, resolvedPath, value)
+						var applied bool
+						out, applied = setPayloadValueIfDifferentTracked(out, resolvedPath, value)
+						if applied {
+							trackedPathTouched = trackedPathTouched || payloadRuleTargetsPath(resolvedPath, trackedPath)
+						}
 					}
 				}
 			}
@@ -140,7 +155,11 @@ func ApplyPayloadConfigWithRequest(cfg *config.Config, model, protocol, fromProt
 						continue
 					}
 					for _, resolvedPath := range resolvePayloadRulePaths(out, fullPath) {
-						out = SetRawIfDifferent(out, resolvedPath, rawValue)
+						var applied bool
+						out, applied = setPayloadRawValueIfDifferentTracked(out, resolvedPath, rawValue)
+						if applied {
+							trackedPathTouched = trackedPathTouched || payloadRuleTargetsPath(resolvedPath, trackedPath)
+						}
 					}
 				}
 			}
@@ -163,12 +182,13 @@ func ApplyPayloadConfigWithRequest(cfg *config.Config, model, protocol, fromProt
 							continue
 						}
 						out = updated
+						trackedPathTouched = trackedPathTouched || payloadRuleTargetsPath(resolvedPath, trackedPath)
 					}
 				}
 			}
 		}
 	}
-	return out
+	return out, trackedPathTouched
 }
 
 func isImagesEndpointRequestPath(path string) bool {
@@ -487,6 +507,13 @@ func buildPayloadPath(root, path string) string {
 		p = p[1:]
 	}
 	return r + "." + p
+}
+
+func payloadRuleTargetsPath(path, trackedPath string) bool {
+	if trackedPath == "" {
+		return false
+	}
+	return path == trackedPath || strings.HasPrefix(path, trackedPath+".")
 }
 
 func resolvePayloadRulePaths(payload []byte, path string) []string {
@@ -809,43 +836,60 @@ func removeToolTypeFromToolsArray(payload []byte, toolsPath string, toolType str
 }
 
 func setPayloadValueIfDifferent(payload []byte, path string, value any) []byte {
+	updated, _ := setPayloadValueIfDifferentTracked(payload, path, value)
+	return updated
+}
+
+func setPayloadValueIfDifferentTracked(payload []byte, path string, value any) ([]byte, bool) {
 	current := gjson.GetBytes(payload, path)
 	switch typed := value.(type) {
 	case string:
 		if current.Type == gjson.String && current.String() == typed {
-			return payload
+			return payload, true
 		}
 	case bool:
 		if (typed && current.Type == gjson.True) || (!typed && current.Type == gjson.False) {
-			return payload
+			return payload, true
 		}
 	case nil:
 		if current.Raw == "null" {
-			return payload
+			return payload, true
 		}
 	default:
 		expectedJSON, errSet := sjson.SetBytes([]byte(`{}`), "value", value)
 		if errSet != nil {
-			return payload
+			return payload, false
 		}
 		expected := gjson.GetBytes(expectedJSON, "value")
 		if expected.Raw == "" {
-			return payload
+			return payload, false
 		}
 		if len(current.Indexes) == 0 && current.Raw == expected.Raw {
-			return payload
+			return payload, true
 		}
 		updated, errSet := sjson.SetRawBytes(payload, path, []byte(expected.Raw))
 		if errSet != nil {
-			return payload
+			return payload, false
 		}
-		return updated
+		return updated, true
 	}
 	updated, errSet := sjson.SetBytes(payload, path, value)
 	if errSet != nil {
-		return payload
+		return payload, false
 	}
-	return updated
+	return updated, true
+}
+
+func setPayloadRawValueIfDifferentTracked(payload []byte, path string, value []byte) ([]byte, bool) {
+	current := gjson.GetBytes(payload, path)
+	if current.Exists() && len(current.Indexes) == 0 && current.Raw == string(value) {
+		return payload, true
+	}
+	updated, errSet := sjson.SetRawBytes(payload, path, value)
+	if errSet != nil {
+		return payload, false
+	}
+	return updated, true
 }
 
 func payloadRawValue(value any) ([]byte, bool) {

--- a/internal/runtime/executor/helps/payload_mutations_test.go
+++ b/internal/runtime/executor/helps/payload_mutations_test.go
@@ -92,6 +92,101 @@ func TestApplyPayloadConfigReusesCanonicalOverrides(t *testing.T) {
 	}
 }
 
+func TestApplyPayloadConfigWithRequestTrackedReportsContextManagementTouches(t *testing.T) {
+	const automatic = `{"edits":[{"type":"clear_thinking_20251015","keep":"all"}]}`
+	modelRules := []config.PayloadModelRule{{Name: "claude-opus-5", Protocol: "claude"}}
+	originalWithoutContextManagement := []byte(`{"model":"claude-opus-5"}`)
+
+	for _, test := range []struct {
+		name          string
+		payload       string
+		original      []byte
+		payloadConfig config.PayloadConfig
+		wantTouched   bool
+	}{
+		{
+			name:     "default",
+			payload:  `{"model":"claude-opus-5"}`,
+			original: originalWithoutContextManagement,
+			payloadConfig: config.PayloadConfig{Default: []config.PayloadRule{{
+				Models: modelRules,
+				Params: map[string]any{"context_management": map[string]any{"edits": []any{map[string]any{"type": "default"}}}},
+			}}},
+			wantTouched: true,
+		},
+		{
+			name:     "raw default",
+			payload:  `{"model":"claude-opus-5"}`,
+			original: originalWithoutContextManagement,
+			payloadConfig: config.PayloadConfig{DefaultRaw: []config.PayloadRule{{
+				Models: modelRules,
+				Params: map[string]any{"context_management": `{"edits":[{"type":"raw_default"}]}`},
+			}}},
+			wantTouched: true,
+		},
+		{
+			name:    "canonical descendant override",
+			payload: `{"model":"claude-opus-5","context_management":` + automatic + `}`,
+			payloadConfig: config.PayloadConfig{Override: []config.PayloadRule{{
+				Models: modelRules,
+				Params: map[string]any{"context_management.edits.0.keep": "all"},
+			}}},
+			wantTouched: true,
+		},
+		{
+			name:    "identical raw override",
+			payload: `{"model":"claude-opus-5","context_management":` + automatic + `}`,
+			payloadConfig: config.PayloadConfig{OverrideRaw: []config.PayloadRule{{
+				Models: modelRules,
+				Params: map[string]any{"context_management": automatic},
+			}}},
+			wantTouched: true,
+		},
+		{
+			name:    "filter already absent",
+			payload: `{"model":"claude-opus-5"}`,
+			payloadConfig: config.PayloadConfig{Filter: []config.PayloadFilterRule{{
+				Models: modelRules,
+				Params: []string{"context_management"},
+			}}},
+			wantTouched: true,
+		},
+		{
+			name:    "unrelated override",
+			payload: `{"model":"claude-opus-5"}`,
+			payloadConfig: config.PayloadConfig{Override: []config.PayloadRule{{
+				Models: modelRules,
+				Params: map[string]any{"thinking.type": "enabled"},
+			}}},
+		},
+		{
+			name:    "nonmatching override",
+			payload: `{"model":"claude-opus-5"}`,
+			payloadConfig: config.PayloadConfig{Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "other-model", Protocol: "claude"}},
+				Params: map[string]any{"context_management": map[string]any{"edits": []any{}}},
+			}}},
+		},
+		{
+			name:     "default skipped for caller owned field",
+			payload:  `{"model":"claude-opus-5","context_management":{"edits":[{"type":"caller"}]}}`,
+			original: []byte(`{"model":"claude-opus-5","context_management":{"edits":[{"type":"caller"}]}}`),
+			payloadConfig: config.PayloadConfig{Default: []config.PayloadRule{{
+				Models: modelRules,
+				Params: map[string]any{"context_management": map[string]any{"edits": []any{map[string]any{"type": "default"}}}},
+			}}},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.Config{Payload: test.payloadConfig}
+			_, touched := ApplyPayloadConfigWithRequestTracked(cfg, "claude-opus-5", "claude", "claude", "", []byte(test.payload), test.original, "claude-opus-5", "", nil, "context_management")
+			if touched != test.wantTouched {
+				t.Fatalf("context_management touched = %t, want %t", touched, test.wantTouched)
+			}
+		})
+	}
+}
+
 func TestApplyPayloadConfigProjectionOverrideWritesEveryMatch(t *testing.T) {
 	cfg := &config.Config{Payload: config.PayloadConfig{
 		Override: []config.PayloadRule{{


### PR DESCRIPTION
## Summary

Fixes #4784.

Keep Claude Code `context_management` consistent with the final thinking
state after payload configuration.

The executor now handles both directions:

- removes only its untouched automatic `clear_thinking_20251015` object
  when final thinking becomes disabled;
- adds the automatic object when payload rules re-enable thinking and
  neither the caller nor a payload rule owns the field.

## Changes

- Skip initial automatic injection when thinking is already disabled.
- Track successful executor injection.
- Track caller ownership of `context_management`.
- Track applied payload rules targeting `context_management` or descendants.
- Preserve the existing payload-rule API through a compatibility wrapper.
- Reconcile the final payload after payload rules and forced-tool-choice handling.
- Preserve caller-provided, default-provided, override-provided, raw-rule-provided,
  and filtered values.
- Apply identical behavior to normal and streaming execution.
- Preserve existing payload-rule order and condition semantics.

## Tests

Added coverage for:

- directly disabled thinking;
- payload-rule transitions to disabled;
- disabled-to-enabled and disabled-to-adaptive transitions;
- normal and streaming execution;
- caller-owned context management;
- default and raw-default ownership;
- override and raw-override ownership;
- descendant-path ownership;
- exact same-value rule ownership;
- payload filters, including an already-absent field;
- omitted, enabled, adaptive, unknown, and invalid thinking states;
- forced tool choice;
- focused race detection.

## Validation

- Focused executor race tests: passed
- Focused payload-helper race tests: passed
- Payload-helper package tests: passed
- Server build: passed
- `gofmt`: passed
- `git diff --check`: passed
- Independent code, Go, and security reviews: no blocking findings

Three environment-sensitive fingerprint tests fail identically without
these changes and are unrelated to this pull request.
