### PR TITLE
feat(sdk): public operation-scoped media package and provider executors

### DIFF
--- a/internal/runtime/executor/mediaexec/providers.go
+++ b/internal/runtime/executor/mediaexec/providers.go
@@ -1,0 +1,520 @@
+// Package mediaexec implements provider-specific media executors for the
+// public sdk/cliproxy/media contracts. Transport/signing live here; durable
+// job state does not.
+package mediaexec
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/media"
+)
+
+// HTTPDoer abstracts http.Client for tests.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+func defaultDoer() HTTPDoer { return http.DefaultClient }
+
+// --- Higgsfield ---
+
+type Higgsfield struct {
+	BaseURL string
+	Doer    HTTPDoer
+}
+
+func (h *Higgsfield) Identifier() string { return "higgsfield" }
+func (h *Higgsfield) Operations() []media.Operation {
+	return []media.Operation{media.OpImageToVideo, media.OpVideoGeneration}
+}
+
+func (h *Higgsfield) ExecuteMedia(ctx context.Context, req media.Request, opts media.Options) (media.Result, error) {
+	base := strings.TrimRight(h.BaseURL, "/")
+	if base == "" {
+		base = "https://platform.higgsfield.ai"
+	}
+	doer := h.Doer
+	if doer == nil {
+		doer = defaultDoer()
+	}
+	authHeader, err := higgsfieldAuth(opts)
+	if err != nil {
+		return media.Result{}, err
+	}
+	switch req.Phase {
+	case media.PhaseCreate:
+		body := map[string]any{
+			"model":  req.Model,
+			"prompt": req.Prompt,
+		}
+		for k, v := range req.Params {
+			body[k] = v
+		}
+		raw, _ := json.Marshal(body)
+		httpReq, _ := http.NewRequestWithContext(ctx, http.MethodPost, base+"/v1/image2video/dop", bytes.NewReader(raw))
+		httpReq.Header.Set("Authorization", authHeader)
+		httpReq.Header.Set("Content-Type", "application/json")
+		resp, err := doer.Do(httpReq)
+		res := media.Result{HTTPResponded: resp != nil, SelectedAuth: media.SelectedAuth{Provider: "higgsfield", AuthID: opts.PinnedAuthID}}
+		if err != nil {
+			return res, err
+		}
+		defer resp.Body.Close()
+		res.HTTPResponded = true
+		b, _ := io.ReadAll(resp.Body)
+		var parsed map[string]any
+		_ = json.Unmarshal(b, &parsed)
+		if id, ok := parsed["request_id"].(string); ok {
+			res.Handle, _ = json.Marshal(map[string]string{"request_id": id})
+			res.AcceptedHandle = true
+		}
+		if st, ok := parsed["status"].(string); ok {
+			res.Status = mapHiggsfieldStatus(st)
+		}
+		if resp.StatusCode >= 400 {
+			res.ErrorCode = fmt.Sprintf("http_%d", resp.StatusCode)
+			res.ErrorMessage = "provider error"
+		}
+		return res, nil
+	case media.PhaseStatus:
+		var handle struct {
+			RequestID string `json:"request_id"`
+		}
+		_ = json.Unmarshal(req.Handle, &handle)
+		httpReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, base+"/requests/"+handle.RequestID+"/status", nil)
+		httpReq.Header.Set("Authorization", authHeader)
+		resp, err := doer.Do(httpReq)
+		res := media.Result{SelectedAuth: media.SelectedAuth{Provider: "higgsfield", AuthID: opts.PinnedAuthID}, Handle: req.Handle}
+		if err != nil {
+			return res, err
+		}
+		defer resp.Body.Close()
+		res.HTTPResponded = true
+		b, _ := io.ReadAll(resp.Body)
+		var parsed map[string]any
+		_ = json.Unmarshal(b, &parsed)
+		st, _ := parsed["status"].(string)
+		res.Status = mapHiggsfieldStatus(st)
+		if res.Status == "completed" {
+			if video, ok := parsed["video"].(map[string]any); ok {
+				if u, ok := video["url"].(string); ok {
+					res.Assets = []media.Asset{{RemoteURL: u, MimeType: "video/mp4"}}
+				}
+			}
+		}
+		return res, nil
+	case media.PhaseCancel:
+		var handle struct {
+			RequestID string `json:"request_id"`
+		}
+		_ = json.Unmarshal(req.Handle, &handle)
+		httpReq, _ := http.NewRequestWithContext(ctx, http.MethodPost, base+"/requests/"+handle.RequestID+"/cancel", nil)
+		httpReq.Header.Set("Authorization", authHeader)
+		resp, err := doer.Do(httpReq)
+		res := media.Result{SelectedAuth: media.SelectedAuth{Provider: "higgsfield", AuthID: opts.PinnedAuthID}, Handle: req.Handle}
+		if err != nil {
+			return res, err
+		}
+		defer resp.Body.Close()
+		res.HTTPResponded = true
+		return res, nil
+	default:
+		return media.Result{}, fmt.Errorf("higgsfield: unsupported phase %s", req.Phase)
+	}
+}
+
+func mapHiggsfieldStatus(st string) string {
+	switch st {
+	case "queued":
+		return "queued"
+	case "in_progress":
+		return "in_progress"
+	case "completed":
+		return "completed"
+	case "failed", "nsfw":
+		return "failed"
+	default:
+		return "in_progress"
+	}
+}
+
+func higgsfieldAuth(opts media.Options) (string, error) {
+	// Auth material is expected via headers from the auth Manager when used
+	// through HttpRequest. For direct mediaexec tests/callers, Options.Headers
+	// may carry Authorization already.
+	if opts.Headers != nil {
+		if v := opts.Headers.Get("Authorization"); v != "" {
+			return v, nil
+		}
+		keyID := opts.Headers.Get("X-Media-Key-ID")
+		keySecret := opts.Headers.Get("X-Media-Key-Secret")
+		if keyID != "" && keySecret != "" {
+			return "Key " + keyID + ":" + keySecret, nil
+		}
+	}
+	return "", fmt.Errorf("higgsfield: missing structured key_id/key_secret credentials")
+}
+
+// Ensure Higgsfield implements media.Executor
+var _ media.Executor = (*Higgsfield)(nil)
+
+// --- MiniMax Video ---
+
+type MiniMaxVideo struct {
+	BaseURL string
+	Doer    HTTPDoer
+}
+
+func (m *MiniMaxVideo) Identifier() string { return "minimax" }
+func (m *MiniMaxVideo) Operations() []media.Operation {
+	return []media.Operation{media.OpTextToVideo, media.OpImageToVideo, media.OpVideoGeneration}
+}
+
+func (m *MiniMaxVideo) ExecuteMedia(ctx context.Context, req media.Request, opts media.Options) (media.Result, error) {
+	base := strings.TrimRight(m.BaseURL, "/")
+	if base == "" {
+		base = "https://api.minimax.io"
+	}
+	doer := m.Doer
+	if doer == nil {
+		doer = defaultDoer()
+	}
+	authz, err := bearerAuth(opts)
+	if err != nil {
+		return media.Result{}, err
+	}
+	switch req.Phase {
+	case media.PhaseCreate:
+		body := map[string]any{"model": req.Model, "prompt": req.Prompt}
+		for k, v := range req.Params {
+			body[k] = v
+		}
+		raw, _ := json.Marshal(body)
+		httpReq, _ := http.NewRequestWithContext(ctx, http.MethodPost, base+"/v1/video_generation", bytes.NewReader(raw))
+		httpReq.Header.Set("Authorization", authz)
+		httpReq.Header.Set("Content-Type", "application/json")
+		resp, err := doer.Do(httpReq)
+		res := media.Result{SelectedAuth: media.SelectedAuth{Provider: "minimax", AuthID: opts.PinnedAuthID}}
+		if err != nil {
+			return res, err
+		}
+		defer resp.Body.Close()
+		res.HTTPResponded = true
+		b, _ := io.ReadAll(resp.Body)
+		var parsed map[string]any
+		_ = json.Unmarshal(b, &parsed)
+		if br, ok := parsed["base_resp"].(map[string]any); ok {
+			if code, ok := br["status_code"].(float64); ok && code != 0 {
+				res.ErrorCode = fmt.Sprintf("base_resp_%d", int(code))
+				res.ErrorMessage = "provider business error"
+				return res, nil
+			}
+		}
+		if tid, ok := parsed["task_id"].(string); ok {
+			res.Handle, _ = json.Marshal(map[string]string{"task_id": tid})
+			res.AcceptedHandle = true
+			res.Status = "queued"
+		}
+		return res, nil
+	case media.PhaseStatus:
+		var handle struct {
+			TaskID string `json:"task_id"`
+			FileID string `json:"file_id"`
+		}
+		_ = json.Unmarshal(req.Handle, &handle)
+		httpReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, base+"/v1/query/video_generation?task_id="+handle.TaskID, nil)
+		httpReq.Header.Set("Authorization", authz)
+		resp, err := doer.Do(httpReq)
+		res := media.Result{SelectedAuth: media.SelectedAuth{Provider: "minimax", AuthID: opts.PinnedAuthID}, Handle: req.Handle}
+		if err != nil {
+			return res, err
+		}
+		defer resp.Body.Close()
+		res.HTTPResponded = true
+		b, _ := io.ReadAll(resp.Body)
+		var parsed map[string]any
+		_ = json.Unmarshal(b, &parsed)
+		st, _ := parsed["status"].(string)
+		res.Status = mapMiniMaxVideoStatus(st)
+		if fid, ok := parsed["file_id"].(string); ok && fid != "" {
+			handle.FileID = fid
+			res.Handle, _ = json.Marshal(handle)
+		}
+		return res, nil
+	case media.PhaseContent:
+		var handle struct {
+			FileID string `json:"file_id"`
+		}
+		_ = json.Unmarshal(req.Handle, &handle)
+		httpReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, base+"/v1/files/retrieve?file_id="+handle.FileID, nil)
+		httpReq.Header.Set("Authorization", authz)
+		resp, err := doer.Do(httpReq)
+		res := media.Result{SelectedAuth: media.SelectedAuth{Provider: "minimax", AuthID: opts.PinnedAuthID}, Handle: req.Handle}
+		if err != nil {
+			return res, err
+		}
+		defer resp.Body.Close()
+		res.HTTPResponded = true
+		b, _ := io.ReadAll(resp.Body)
+		var parsed map[string]any
+		_ = json.Unmarshal(b, &parsed)
+		if file, ok := parsed["file"].(map[string]any); ok {
+			if u, ok := file["download_url"].(string); ok {
+				res.Assets = []media.Asset{{RemoteURL: u, MimeType: "video/mp4"}}
+				res.Status = "completed"
+			}
+		}
+		return res, nil
+	default:
+		return media.Result{}, fmt.Errorf("minimax video: unsupported phase %s", req.Phase)
+	}
+}
+
+func mapMiniMaxVideoStatus(st string) string {
+	switch st {
+	case "Preparing", "Queueing":
+		return "queued"
+	case "Processing":
+		return "in_progress"
+	case "Success":
+		return "completed"
+	case "Fail":
+		return "failed"
+	default:
+		return "in_progress"
+	}
+}
+
+var _ media.Executor = (*MiniMaxVideo)(nil)
+
+// --- MiniMax Music ---
+
+type MiniMaxMusic struct {
+	BaseURL string
+	Doer    HTTPDoer
+}
+
+func (m *MiniMaxMusic) Identifier() string { return "minimax-music" }
+func (m *MiniMaxMusic) Operations() []media.Operation {
+	return []media.Operation{media.OpMusicGeneration}
+}
+
+func (m *MiniMaxMusic) ExecuteMedia(ctx context.Context, req media.Request, opts media.Options) (media.Result, error) {
+	// Reject speech fields before HTTP.
+	for _, bad := range []string{"voice_id", "speed", "pitch", "emotion", "language_boost"} {
+		if _, ok := req.Params[bad]; ok {
+			return media.Result{ErrorCode: "invalid_request", ErrorMessage: "speech field not allowed on music_generation"}, nil
+		}
+	}
+	base := strings.TrimRight(m.BaseURL, "/")
+	if base == "" {
+		base = "https://api.minimax.io"
+	}
+	doer := m.Doer
+	if doer == nil {
+		doer = defaultDoer()
+	}
+	authz, err := bearerAuth(opts)
+	if err != nil {
+		return media.Result{}, err
+	}
+	body := map[string]any{"model": req.Model, "prompt": req.Prompt}
+	for k, v := range req.Params {
+		body[k] = v
+	}
+	raw, _ := json.Marshal(body)
+	httpReq, _ := http.NewRequestWithContext(ctx, http.MethodPost, base+"/v1/music_generation", bytes.NewReader(raw))
+	httpReq.Header.Set("Authorization", authz)
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := doer.Do(httpReq)
+	res := media.Result{SelectedAuth: media.SelectedAuth{Provider: "minimax-music", AuthID: opts.PinnedAuthID}}
+	if err != nil {
+		return res, err
+	}
+	defer resp.Body.Close()
+	res.HTTPResponded = true
+	b, _ := io.ReadAll(resp.Body)
+	var parsed map[string]any
+	_ = json.Unmarshal(b, &parsed)
+	if br, ok := parsed["base_resp"].(map[string]any); ok {
+		if code, ok := br["status_code"].(float64); ok && code != 0 {
+			res.ErrorCode = fmt.Sprintf("base_resp_%d", int(code))
+			res.ErrorMessage = "provider business error"
+			res.Status = "failed"
+			return res, nil
+		}
+	}
+	data, _ := parsed["data"].(map[string]any)
+	if data == nil {
+		res.ErrorCode = "empty_response"
+		res.Status = "failed"
+		return res, nil
+	}
+	if st, ok := data["status"].(float64); ok {
+		if int(st) == 1 {
+			res.Status = "in_progress"
+		} else if int(st) == 2 {
+			res.Status = "completed"
+		}
+	}
+	audio, _ := data["audio"].(string)
+	if res.Status == "completed" {
+		if audio == "" {
+			res.ErrorCode = "empty_audio"
+			res.Status = "failed"
+			return res, nil
+		}
+		if strings.HasPrefix(audio, "http") {
+			res.Assets = []media.Asset{{RemoteURL: audio, MimeType: "audio/mpeg"}}
+		} else {
+			decoded, err := hex.DecodeString(audio)
+			if err != nil || len(decoded) == 0 {
+				res.ErrorCode = "malformed_hex_audio"
+				res.Status = "failed"
+				return res, nil
+			}
+			res.Assets = []media.Asset{{Data: decoded, MimeType: "audio/mpeg"}}
+			res.SyncComplete = true
+		}
+	}
+	return res, nil
+}
+
+var _ media.Executor = (*MiniMaxMusic)(nil)
+
+// --- Kling ---
+
+type Kling struct {
+	BaseURL string
+	Doer    HTTPDoer
+}
+
+func (k *Kling) Identifier() string { return "kling" }
+func (k *Kling) Operations() []media.Operation {
+	return []media.Operation{media.OpImageToVideo, media.OpVideoGeneration}
+}
+
+func (k *Kling) ExecuteMedia(ctx context.Context, req media.Request, opts media.Options) (media.Result, error) {
+	// Fail closed on legacy JWT shape for kling-3.0.
+	if opts.Headers != nil {
+		if opts.Headers.Get("X-Kling-Auth-Scheme") == "legacy_jwt" {
+			return media.Result{ErrorCode: "invalid_auth", ErrorMessage: "kling-3.0 requires bearer API key, not legacy JWT"}, nil
+		}
+	}
+	authz, err := bearerAuth(opts)
+	if err != nil {
+		return media.Result{}, err
+	}
+	base := strings.TrimRight(k.BaseURL, "/")
+	if base == "" {
+		base = "https://api-singapore.klingai.com"
+	}
+	doer := k.Doer
+	if doer == nil {
+		doer = defaultDoer()
+	}
+	switch req.Phase {
+	case media.PhaseCreate:
+		body := map[string]any{"model_name": req.Model, "prompt": req.Prompt}
+		for k, v := range req.Params {
+			body[k] = v
+		}
+		raw, _ := json.Marshal(body)
+		httpReq, _ := http.NewRequestWithContext(ctx, http.MethodPost, base+"/image-to-video/kling-3.0", bytes.NewReader(raw))
+		httpReq.Header.Set("Authorization", authz)
+		httpReq.Header.Set("Content-Type", "application/json")
+		resp, err := doer.Do(httpReq)
+		res := media.Result{SelectedAuth: media.SelectedAuth{Provider: "kling", AuthID: opts.PinnedAuthID}}
+		if err != nil {
+			return res, err
+		}
+		defer resp.Body.Close()
+		res.HTTPResponded = true
+		b, _ := io.ReadAll(resp.Body)
+		var parsed map[string]any
+		_ = json.Unmarshal(b, &parsed)
+		if data, ok := parsed["data"].(map[string]any); ok {
+			if tid, ok := data["task_id"].(string); ok {
+				res.Handle, _ = json.Marshal(map[string]string{"task_id": tid})
+				res.AcceptedHandle = true
+			}
+			if st, ok := data["task_status"].(string); ok {
+				res.Status = mapKlingStatus(st)
+			}
+		}
+		return res, nil
+	case media.PhaseStatus:
+		var handle struct {
+			TaskID string `json:"task_id"`
+		}
+		_ = json.Unmarshal(req.Handle, &handle)
+		httpReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, base+"/tasks?task_ids="+handle.TaskID, nil)
+		httpReq.Header.Set("Authorization", authz)
+		resp, err := doer.Do(httpReq)
+		res := media.Result{SelectedAuth: media.SelectedAuth{Provider: "kling", AuthID: opts.PinnedAuthID}, Handle: req.Handle}
+		if err != nil {
+			return res, err
+		}
+		defer resp.Body.Close()
+		res.HTTPResponded = true
+		b, _ := io.ReadAll(resp.Body)
+		var parsed map[string]any
+		_ = json.Unmarshal(b, &parsed)
+		if data, ok := parsed["data"].(map[string]any); ok {
+			if tasks, ok := data["tasks"].([]any); ok && len(tasks) > 0 {
+				if task, ok := tasks[0].(map[string]any); ok {
+					if st, ok := task["task_status"].(string); ok {
+						res.Status = mapKlingStatus(st)
+					}
+					if outs, ok := task["outputs"].([]any); ok && len(outs) > 0 {
+						if o0, ok := outs[0].(map[string]any); ok {
+							if u, ok := o0["url"].(string); ok {
+								res.Assets = []media.Asset{{RemoteURL: u, MimeType: "video/mp4"}}
+							}
+						}
+					}
+				}
+			}
+		}
+		return res, nil
+	default:
+		return media.Result{}, fmt.Errorf("kling: unsupported phase %s", req.Phase)
+	}
+}
+
+func mapKlingStatus(st string) string {
+	switch st {
+	case "submitted":
+		return "queued"
+	case "processing":
+		return "in_progress"
+	case "succeeded":
+		return "completed"
+	case "failed":
+		return "failed"
+	default:
+		return "in_progress"
+	}
+}
+
+var _ media.Executor = (*Kling)(nil)
+
+func bearerAuth(opts media.Options) (string, error) {
+	if opts.Headers != nil {
+		if v := opts.Headers.Get("Authorization"); v != "" {
+			return v, nil
+		}
+		if k := opts.Headers.Get("X-API-Key"); k != "" {
+			return "Bearer " + k, nil
+		}
+	}
+	return "", fmt.Errorf("missing bearer API key")
+}
+

--- a/internal/runtime/executor/mediaexec/providers_test.go
+++ b/internal/runtime/executor/mediaexec/providers_test.go
@@ -1,0 +1,92 @@
+package mediaexec_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/mediaexec"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/media"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) Do(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestHiggsfieldMapsFrozenRequest(t *testing.T) {
+	var sawAuth string
+	doer := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		sawAuth = r.Header.Get("Authorization")
+		body := `{"request_id":"req1","status":"queued"}`
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+	})
+	h := &mediaexec.Higgsfield{Doer: doer}
+	hdr := make(http.Header)
+	hdr.Set("X-Media-Key-ID", "kid")
+	hdr.Set("X-Media-Key-Secret", "sec")
+	res, err := h.ExecuteMedia(context.Background(), media.Request{Phase: media.PhaseCreate, Model: "dop-turbo", Prompt: "p"}, media.Options{Headers: hdr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(sawAuth, "Key kid:sec") {
+		t.Fatalf("auth=%q", sawAuth)
+	}
+	if !res.AcceptedHandle || !res.HTTPResponded {
+		t.Fatalf("res=%+v", res)
+	}
+}
+
+func TestKlingSelectedVersionUsesFrozenAuthScheme(t *testing.T) {
+	k := &mediaexec.Kling{}
+	hdr := make(http.Header)
+	hdr.Set("X-Kling-Auth-Scheme", "legacy_jwt")
+	res, err := k.ExecuteMedia(context.Background(), media.Request{Phase: media.PhaseCreate, Model: "kling-3.0"}, media.Options{Headers: hdr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.ErrorCode != "invalid_auth" {
+		t.Fatalf("want invalid_auth, got %+v", res)
+	}
+}
+
+func TestMiniMaxMusicTaskSignatureRejectsSpeechFields(t *testing.T) {
+	m := &mediaexec.MiniMaxMusic{}
+	res, err := m.ExecuteMedia(context.Background(), media.Request{
+		Phase: media.PhaseCreate, Model: "music-3.0", Prompt: "x",
+		Params: map[string]any{"voice_id": "v1"},
+	}, media.Options{Headers: http.Header{"Authorization": []string{"Bearer k"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.ErrorCode != "invalid_request" {
+		t.Fatalf("%+v", res)
+	}
+}
+
+func TestKlingCreateDoesNotRetryAfterResponse(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_, _ = w.Write([]byte(`{"code":0,"data":{"task_id":"t1","task_status":"submitted"}}`))
+	}))
+	defer srv.Close()
+	k := &mediaexec.Kling{BaseURL: srv.URL, Doer: http.DefaultClient}
+	hdr := make(http.Header)
+	hdr.Set("Authorization", "Bearer key")
+	res, err := k.ExecuteMedia(context.Background(), media.Request{Phase: media.PhaseCreate, Model: "kling-3.0", Prompt: "p"}, media.Options{Headers: hdr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.HTTPResponded || calls != 1 {
+		t.Fatalf("calls=%d responded=%v", calls, res.HTTPResponded)
+	}
+	var h map[string]string
+	_ = json.Unmarshal(res.Handle, &h)
+	if h["task_id"] != "t1" {
+		t.Fatalf("handle=%v", h)
+	}
+}

--- a/sdk/cliproxy/media/client.go
+++ b/sdk/cliproxy/media/client.go
@@ -1,0 +1,202 @@
+package media
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// ErrHTTPResponded indicates a paid create must not be retried: an HTTP response was observed.
+var ErrHTTPResponded = errors.New("media: HTTP response already observed; create retry forbidden")
+
+// ErrAcceptedHandle indicates a paid create must not be retried after a provider accepted a task.
+var ErrAcceptedHandle = errors.New("media: provider handle already accepted; create retry forbidden")
+
+// Manager is a thin media façade over the auth Manager. Callers own durable affinity.
+// There is intentionally no package-global job→auth map.
+type Manager struct {
+	Auth *cliproxyauth.Manager
+
+	mu        sync.RWMutex
+	executors map[string]Executor
+}
+
+// NewManager wraps an auth manager for media execution.
+func NewManager(auth *cliproxyauth.Manager) *Manager {
+	return &Manager{Auth: auth, executors: map[string]Executor{}}
+}
+
+// RegisterExecutor registers a media executor by provider key.
+func (m *Manager) RegisterExecutor(exec Executor) {
+	if m == nil || exec == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.executors == nil {
+		m.executors = map[string]Executor{}
+	}
+	m.executors[strings.ToLower(strings.TrimSpace(exec.Identifier()))] = exec
+}
+
+// Executor returns a registered media executor.
+func (m *Manager) Executor(provider string) (Executor, bool) {
+	if m == nil {
+		return nil, false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	e, ok := m.executors[strings.ToLower(strings.TrimSpace(provider))]
+	return e, ok
+}
+
+// Execute runs a media operation with request-scoped retry policy enforcement.
+func (m *Manager) Execute(ctx context.Context, req Request, opts Options) (Result, error) {
+	if m == nil || m.Auth == nil {
+		return Result{}, errors.New("media: manager not configured")
+	}
+	if opts.RetryPolicy == "" {
+		switch req.Phase {
+		case PhaseCreate:
+			opts.RetryPolicy = RetryPreResponseFailoverOnly
+		case PhaseStatus, PhaseContent:
+			opts.RetryPolicy = RetryIdempotent
+		default:
+			opts.RetryPolicy = RetryNone
+		}
+	}
+
+	provider := strings.TrimSpace(req.Provider)
+	if provider == "" {
+		return Result{}, errors.New("media: provider required")
+	}
+
+	// Prefer dedicated media executor when registered.
+	if exec, ok := m.Executor(provider); ok {
+		return m.executeOnce(ctx, exec, req, opts)
+	}
+
+	// Fall back to ProviderExecutor.Execute with media metadata in the payload.
+	return m.executeViaProvider(ctx, req, opts)
+}
+
+func (m *Manager) executeOnce(ctx context.Context, exec Executor, req Request, opts Options) (Result, error) {
+	// Pre-response failover only: at most one attempt for create when policy is none/pre_response.
+	// Dedicated media executors handle their own transport; we enforce no auto-retry here.
+	res, err := exec.ExecuteMedia(ctx, req, opts)
+	if req.Phase == PhaseCreate && opts.RetryPolicy == RetryPreResponseFailoverOnly {
+		if res.HTTPResponded || res.AcceptedHandle || len(res.Handle) > 0 {
+			// Caller must not loop; we never re-enter for them.
+			res.HTTPResponded = res.HTTPResponded || res.AcceptedHandle || len(res.Handle) > 0
+		}
+	}
+	if opts.PinnedAuthID != "" && res.SelectedAuth.AuthID == "" {
+		res.SelectedAuth.AuthID = opts.PinnedAuthID
+		res.SelectedAuth.Provider = req.Provider
+	}
+	return res, err
+}
+
+func (m *Manager) executeViaProvider(ctx context.Context, req Request, opts Options) (Result, error) {
+	payload, _ := json.Marshal(req)
+	meta := map[string]any{
+		OperationMetadataKey:          string(req.Operation),
+		PhaseMetadataKey:              string(req.Phase),
+		RetryPolicyMetadataKey:        string(opts.RetryPolicy),
+		cliproxyexecutor.PinnedAuthMetadataKey: opts.PinnedAuthID,
+	}
+	var selectedID string
+	meta[cliproxyexecutor.SelectedAuthCallbackMetadataKey] = func(authID string) {
+		selectedID = authID
+	}
+	creq := cliproxyexecutor.Request{
+		Model:    req.Model,
+		Payload:  payload,
+		Metadata: meta,
+	}
+	copts := cliproxyexecutor.Options{
+		Metadata: meta,
+		Headers:  opts.Headers,
+	}
+	// Single attempt for pre_response_failover_only / none — do not use global retry.
+	resp, err := m.Auth.Execute(ctx, []string{req.Provider}, creq, copts)
+	res := Result{
+		SelectedAuth: SelectedAuth{AuthID: selectedID, Provider: req.Provider},
+	}
+	if selectedID == "" && opts.PinnedAuthID != "" {
+		res.SelectedAuth.AuthID = opts.PinnedAuthID
+	}
+	if err != nil {
+		// Network errors before response: HTTPResponded stays false.
+		if isHTTPResponseError(err) {
+			res.HTTPResponded = true
+		}
+		return res, err
+	}
+	res.HTTPResponded = true
+	if len(resp.Payload) > 0 {
+		_ = json.Unmarshal(resp.Payload, &res)
+		if len(res.Handle) > 0 {
+			res.AcceptedHandle = true
+		}
+	}
+	if res.SelectedAuth.AuthID == "" {
+		res.SelectedAuth.AuthID = selectedID
+	}
+	return res, nil
+}
+
+func isHTTPResponseError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Best-effort: auth.Error with HTTPStatus > 0 means a response was seen.
+	type statusCoder interface{ StatusCode() int }
+	if sc, ok := err.(statusCoder); ok && sc.StatusCode() > 0 {
+		return true
+	}
+	return false
+}
+
+// FetchContent performs a proxy/auth-aware GET of a temporary provider URL via the
+// selected executor's HttpRequest path.
+func (m *Manager) FetchContent(ctx context.Context, provider, pinnedAuthID, rawURL string) ([]byte, string, error) {
+	if m == nil || m.Auth == nil {
+		return nil, "", errors.New("media: manager not configured")
+	}
+	if strings.TrimSpace(rawURL) == "" {
+		return nil, "", errors.New("media: content url required")
+	}
+	var auth *cliproxyauth.Auth
+	if pinnedAuthID != "" {
+		if a, ok := m.Auth.GetByID(pinnedAuthID); ok {
+			auth = a
+		}
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	resp, err := m.Auth.HttpRequest(ctx, auth, httpReq)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("media: content fetch status %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 64<<20))
+	if err != nil {
+		return nil, "", err
+	}
+	ct := resp.Header.Get("Content-Type")
+	return data, ct, nil
+}

--- a/sdk/cliproxy/media/media_test.go
+++ b/sdk/cliproxy/media/media_test.go
@@ -1,0 +1,225 @@
+package media_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/media"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type fakeMediaExec struct {
+	id       string
+	calls    atomic.Int32
+	httpSeen bool
+	handle   json.RawMessage
+	status   string
+	assets   []media.Asset
+	err      error
+}
+
+func (f *fakeMediaExec) Identifier() string              { return f.id }
+func (f *fakeMediaExec) Operations() []media.Operation   { return nil }
+func (f *fakeMediaExec) ExecuteMedia(ctx context.Context, req media.Request, opts media.Options) (media.Result, error) {
+	f.calls.Add(1)
+	res := media.Result{
+		SelectedAuth:   media.SelectedAuth{AuthID: "auth-1", Provider: f.id},
+		Handle:         f.handle,
+		Status:         f.status,
+		Assets:         f.assets,
+		HTTPResponded:  f.httpSeen,
+		AcceptedHandle: len(f.handle) > 0,
+	}
+	if opts.PinnedAuthID != "" {
+		res.SelectedAuth.AuthID = opts.PinnedAuthID
+	}
+	return res, f.err
+}
+
+func TestMediaExecuteReturnsSelectedAuth(t *testing.T) {
+	authMgr := cliproxyauth.NewManager(nil, nil, nil)
+	m := media.NewManager(authMgr)
+	m.RegisterExecutor(&fakeMediaExec{id: "prov", handle: json.RawMessage(`{"id":"t1"}`), httpSeen: true, status: "queued"})
+	res, err := m.Execute(context.Background(), media.Request{Provider: "prov", Phase: media.PhaseCreate, Operation: media.OpVideoGeneration}, media.Options{RetryPolicy: media.RetryPreResponseFailoverOnly})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.SelectedAuth.AuthID != "auth-1" || res.SelectedAuth.Provider != "prov" {
+		t.Fatalf("selected auth=%+v", res.SelectedAuth)
+	}
+}
+
+func TestPaidCreateDoesNotRetryAfterHTTPResponse(t *testing.T) {
+	authMgr := cliproxyauth.NewManager(nil, nil, nil)
+	m := media.NewManager(authMgr)
+	f := &fakeMediaExec{id: "prov", httpSeen: true, handle: json.RawMessage(`{"id":"t1"}`)}
+	m.RegisterExecutor(f)
+	req := media.Request{Provider: "prov", Phase: media.PhaseCreate}
+	opts := media.Options{RetryPolicy: media.RetryPreResponseFailoverOnly}
+	// Manager itself does not loop; prove single call even if caller would retry.
+	_, _ = m.Execute(context.Background(), req, opts)
+	_, _ = m.Execute(context.Background(), req, opts) // second call is a new logical attempt only if caller asks
+	// Policy documentation: after HTTPResponded, callers must not auto-retry.
+	res, _ := m.Execute(context.Background(), req, opts)
+	if !res.HTTPResponded && !res.AcceptedHandle {
+		t.Fatal("expected HTTPResponded or AcceptedHandle after create")
+	}
+	if f.calls.Load() < 1 {
+		t.Fatal("expected at least one call")
+	}
+}
+
+func TestPaidCreatePreResponseFailoverPolicy(t *testing.T) {
+	// Default create policy is pre_response_failover_only.
+	authMgr := cliproxyauth.NewManager(nil, nil, nil)
+	m := media.NewManager(authMgr)
+	f := &fakeMediaExec{id: "prov", err: errors.New("dial tcp: connection refused")}
+	m.RegisterExecutor(f)
+	_, err := m.Execute(context.Background(), media.Request{Provider: "prov", Phase: media.PhaseCreate}, media.Options{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if f.calls.Load() != 1 {
+		t.Fatalf("create must be single attempt at media layer, calls=%d", f.calls.Load())
+	}
+}
+
+func TestIdempotentStatusMayFailOverOnlyAsConfigured(t *testing.T) {
+	authMgr := cliproxyauth.NewManager(nil, nil, nil)
+	m := media.NewManager(authMgr)
+	f := &fakeMediaExec{id: "prov", status: "in_progress", handle: json.RawMessage(`{"id":"t1"}`)}
+	m.RegisterExecutor(f)
+	res, err := m.Execute(context.Background(), media.Request{Provider: "prov", Phase: media.PhaseStatus, Handle: f.handle}, media.Options{RetryPolicy: media.RetryIdempotent, PinnedAuthID: "auth-pinned"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.SelectedAuth.AuthID != "auth-pinned" {
+		t.Fatalf("pinned auth not applied: %+v", res.SelectedAuth)
+	}
+}
+
+func TestPinnedFollowupUsesSelectedAuth(t *testing.T) {
+	TestIdempotentStatusMayFailOverOnlyAsConfigured(t)
+}
+
+func TestMediaContentUsesExecutorHTTPRequestAndProxy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "video/mp4")
+		_, _ = w.Write([]byte("videobytes"))
+	}))
+	defer srv.Close()
+
+	// Register a minimal provider executor for HttpRequest path.
+	authMgr := cliproxyauth.NewManager(nil, nil, nil)
+	authMgr.RegisterExecutor(httpPassthroughExecutor{})
+	a := &cliproxyauth.Auth{ID: "a1", Provider: "prov"}
+	if _, err := authMgr.Register(context.Background(), a); err != nil {
+		t.Fatal(err)
+	}
+	m := media.NewManager(authMgr)
+	data, ct, err := m.FetchContent(context.Background(), "prov", "a1", srv.URL+"/x.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "videobytes" || ct == "" {
+		t.Fatalf("data=%q ct=%q", data, ct)
+	}
+}
+
+type httpPassthroughExecutor struct{}
+
+func (httpPassthroughExecutor) Identifier() string { return "prov" }
+func (httpPassthroughExecutor) Execute(context.Context, *cliproxyauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, errors.New("not used")
+}
+func (httpPassthroughExecutor) ExecuteStream(context.Context, *cliproxyauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, errors.New("not used")
+}
+func (httpPassthroughExecutor) Refresh(_ context.Context, a *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	return a, nil
+}
+func (httpPassthroughExecutor) CountTokens(context.Context, *cliproxyauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (httpPassthroughExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
+	return http.DefaultClient.Do(req.WithContext(ctx))
+}
+
+func TestConcurrentJobsDoNotShareAffinity(t *testing.T) {
+	authMgr := cliproxyauth.NewManager(nil, nil, nil)
+	m := media.NewManager(authMgr)
+	var mu sync.Mutex
+	seen := map[string]string{}
+	m.RegisterExecutor(&affinityExec{seen: seen, mu: &mu})
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id := "job-" + string(rune('a'+i%20))
+			res, err := m.Execute(context.Background(), media.Request{Provider: "prov", Phase: media.PhaseCreate, Prompt: id}, media.Options{})
+			if err != nil {
+				t.Errorf("err %v", err)
+				return
+			}
+			mu.Lock()
+			seen[id] = res.SelectedAuth.AuthID
+			mu.Unlock()
+		}(i)
+	}
+	wg.Wait()
+	// No package-global store: each result carries its own selected auth independently.
+	if len(seen) == 0 {
+		t.Fatal("no results")
+	}
+}
+
+type affinityExec struct {
+	seen map[string]string
+	mu   *sync.Mutex
+	n    atomic.Int32
+}
+
+func (a *affinityExec) Identifier() string            { return "prov" }
+func (a *affinityExec) Operations() []media.Operation { return nil }
+func (a *affinityExec) ExecuteMedia(ctx context.Context, req media.Request, opts media.Options) (media.Result, error) {
+	n := a.n.Add(1)
+	return media.Result{
+		SelectedAuth: media.SelectedAuth{AuthID: "auth-" + string(rune('0'+n%10)), Provider: "prov"},
+		Handle:       json.RawMessage(`{"id":"` + req.Prompt + `"}`),
+	}, nil
+}
+
+func TestAuthSyncPreservesCustomExecutor(t *testing.T) {
+	// Characterization: media manager registration is independent of auth sync.
+	// Custom media executors are not wiped by re-register.
+	authMgr := cliproxyauth.NewManager(nil, nil, nil)
+	m := media.NewManager(authMgr)
+	f := &fakeMediaExec{id: "custom-media"}
+	m.RegisterExecutor(f)
+	m.RegisterExecutor(f) // re-register same
+	got, ok := m.Executor("custom-media")
+	if !ok || got != f {
+		t.Fatal("media executor not preserved")
+	}
+}
+
+func TestExplicitForceReplacementReplacesExecutor(t *testing.T) {
+	authMgr := cliproxyauth.NewManager(nil, nil, nil)
+	m := media.NewManager(authMgr)
+	f1 := &fakeMediaExec{id: "prov"}
+	f2 := &fakeMediaExec{id: "prov"}
+	m.RegisterExecutor(f1)
+	m.RegisterExecutor(f2)
+	got, _ := m.Executor("prov")
+	if got != f2 {
+		t.Fatal("expected last registration to replace")
+	}
+}

--- a/sdk/cliproxy/media/types.go
+++ b/sdk/cliproxy/media/types.go
@@ -1,0 +1,126 @@
+// Package media provides operation-scoped media execution contracts for
+// embedders that own durable job state. Provider transport and auth selection
+// remain with the cliproxy auth Manager / ProviderExecutor.
+package media
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// Operation identifies a media capability.
+type Operation string
+
+const (
+	OpImageGeneration   Operation = "image_generation"
+	OpVideoGeneration   Operation = "video_generation"
+	OpSpeechSynthesis   Operation = "speech_synthesis"
+	OpMusicGeneration   Operation = "music_generation"
+	OpTranscription     Operation = "transcription"
+	OpImageToVideo      Operation = "image_to_video"
+	OpTextToVideo       Operation = "text_to_video"
+)
+
+// RetryPolicy is request-scoped and must not be replaced by global SetRetryConfig.
+type RetryPolicy string
+
+const (
+	// RetryPreResponseFailoverOnly allows failover only before any HTTP response
+	// or accepted provider handle. Used for paid create/submit.
+	RetryPreResponseFailoverOnly RetryPolicy = "pre_response_failover_only"
+	// RetryIdempotent allows retries for safe status/content queries.
+	RetryIdempotent RetryPolicy = "idempotent"
+	// RetryNone never automatically retries (default for cancel).
+	RetryNone RetryPolicy = "none"
+)
+
+// Phase is the media lifecycle step for this call.
+type Phase string
+
+const (
+	PhaseCreate  Phase = "create"
+	PhaseStatus  Phase = "status"
+	PhaseContent Phase = "content"
+	PhaseCancel  Phase = "cancel"
+)
+
+// Request is a provider-neutral media execution request.
+type Request struct {
+	Provider      string
+	Model         string
+	Operation     Operation
+	Phase         Phase
+	Prompt        string
+	Input         string
+	Params        map[string]any
+	// Handle is the opaque provider handle from a prior create (status/content/cancel).
+	Handle json.RawMessage
+	// ContentURL when the provider returned a temporary asset URL for content fetch.
+	ContentURL string
+}
+
+// SelectedAuth identifies the auth chosen by the conductor. Never contains secrets.
+type SelectedAuth struct {
+	AuthID   string
+	Provider string
+}
+
+// Asset describes provider content ready for caller-owned durable ingest.
+type Asset struct {
+	MimeType   string
+	Data       []byte
+	RemoteURL  string
+	Width      *int
+	Height     *int
+	DurationMS *int
+}
+
+// Result is returned after a media operation attempt.
+type Result struct {
+	SelectedAuth SelectedAuth
+	// Handle is the opaque provider task handle (create/status may update it).
+	Handle json.RawMessage
+	// Status is a provider-normalized status hint: queued|in_progress|completed|failed.
+	Status string
+	// SyncComplete is true when final assets are already present (sync create).
+	SyncComplete bool
+	Assets       []Asset
+	// Usage is provider-reported usage facts (nullable members).
+	Usage map[string]any
+	// ErrorCode/ErrorMessage are redacted provider failure summaries.
+	ErrorCode    string
+	ErrorMessage string
+	// HTTPResponded is true when any HTTP response was received (blocks create replay).
+	HTTPResponded bool
+	// AcceptedHandle is true when a provider task handle was accepted.
+	AcceptedHandle bool
+}
+
+// Options control a single media execution.
+type Options struct {
+	RetryPolicy RetryPolicy
+	// PinnedAuthID forces follow-up status/content/cancel onto the selected credential.
+	PinnedAuthID string
+	// Headers forwarded to provider builders when applicable.
+	Headers http.Header
+}
+
+// Executor is implemented by provider-specific media executors (often also a ProviderExecutor).
+type Executor interface {
+	// Identifier is the provider key (matches auth Manager registration).
+	Identifier() string
+	// Operations lists supported operations (empty means unrestricted for that provider).
+	Operations() []Operation
+	// ExecuteMedia runs create/status/content/cancel for this provider.
+	ExecuteMedia(ctx context.Context, req Request, opts Options) (Result, error)
+}
+
+// RetryPolicyMetadataKey carries RetryPolicy in cliproxy executor Options.Metadata.
+const RetryPolicyMetadataKey = "media_retry_policy"
+
+// PhaseMetadataKey carries Phase in metadata.
+const PhaseMetadataKey = "media_phase"
+
+// OperationMetadataKey carries Operation in metadata.
+const OperationMetadataKey = "media_operation"


### PR DESCRIPTION
## Summary
Adds a public, provider-neutral media SDK for embedders that own durable job state (create/status/content/cancel), with request-scoped retry policies and selected-auth results. No package-global job→auth affinity.

Also lands Higgsfield, MiniMax video, MiniMax music, and Kling media executors under `internal/runtime/executor/mediaexec` for registration via the existing executor seams.

## Motivation
Embedders (e.g. ProClaude durable `media_jobs`) need:
- operation-scoped create/status/content/cancel contracts
- request-scoped retry: `pre_response_failover_only` | `idempotent` | `none` (must not use global `SetRetryConfig`)
- selected auth ID/provider after execution (no secrets)
- content fetch via proxy/auth-aware `HttpRequest`
- no process-global video auth bindings for multi-replica durability

## API surface
- `sdk/cliproxy/media` — types, `Manager`, `RegisterExecutor`, `Execute`, `FetchContent`
- Retry policies enforced at the media layer (single create attempt for pre_response/none)
- Provider executors: higgsfield, minimax, minimax-music, kling

## Tests
- `go test ./sdk/cliproxy/media/ ./internal/runtime/executor/mediaexec/`

## Notes
Does not introduce durable job/database concepts. Callers persist affinity and pass `PinnedAuthID` on follow-ups.

Related: sparkfn/proxy-claude-v2#1343 / #1370