### PR TITLE
fix(home): preserve requested usage metadata before auth preparation

### DIFF
--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -622,6 +622,8 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
+		// Enrich before auth preparation so prepare-stage usage records observe the client request.
+		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel)
 		if selection != nil && aliasResult.ForceMapping && responseAlias != "" {
 			aliasResult.OriginalAlias = responseAlias

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -52,6 +52,8 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			selection.End("attempt_bind_failed")
 			return cliproxyexecutor.Response{}, errBind
 		}
+		// Enrich before auth preparation so prepare-stage usage records observe the client request.
+		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 		if rt := m.roundTripperFor(auth); rt != nil {
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)

--- a/sdk/cliproxy/auth/home_execution_paths_test.go
+++ b/sdk/cliproxy/auth/home_execution_paths_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	log "github.com/sirupsen/logrus"
 	logtest "github.com/sirupsen/logrus/hooks/test"
 )
@@ -1201,5 +1203,264 @@ func TestHomeStreamWithoutSourceEndsSelection(t *testing.T) {
 	defer cancelDrain()
 	if errDrain := registry.Drain(drainCtx); errDrain != nil {
 		t.Fatalf("Drain() error = %v", errDrain)
+	}
+}
+
+// homeRequestMetadataSnapshot captures the client request metadata a context carries.
+type homeRequestMetadataSnapshot struct {
+	requestedModel  string
+	reasoningEffort string
+	serviceTier     string
+	generate        bool
+}
+
+func homeRequestMetadataFromContext(ctx context.Context) homeRequestMetadataSnapshot {
+	return homeRequestMetadataSnapshot{
+		requestedModel:  coreusage.RequestedModelAliasFromContext(ctx),
+		reasoningEffort: coreusage.ReasoningEffortFromContext(ctx),
+		serviceTier:     coreusage.ServiceTierFromContext(ctx),
+		generate:        coreusage.GenerateFromContext(ctx),
+	}
+}
+
+// homeRequestMetadataExecutor records the metadata visible at auth preparation and execution.
+type homeRequestMetadataExecutor struct {
+	mu              sync.Mutex
+	prepareMetadata homeRequestMetadataSnapshot
+	executeMetadata homeRequestMetadataSnapshot
+	// prepareErrOnce fails only the first preparation so Home redispatch still terminates.
+	prepareErrOnce error
+	executeErr     error
+}
+
+func (*homeRequestMetadataExecutor) Identifier() string { return "home-execution" }
+
+func (*homeRequestMetadataExecutor) ShouldPrepareRequestAuth(*Auth) bool { return true }
+
+func (e *homeRequestMetadataExecutor) PrepareRequestAuth(ctx context.Context, auth *Auth) (*Auth, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.prepareMetadata = homeRequestMetadataFromContext(ctx)
+	if e.prepareErrOnce != nil {
+		errPrepare := e.prepareErrOnce
+		e.prepareErrOnce = nil
+		return nil, errPrepare
+	}
+	return auth, nil
+}
+
+func (e *homeRequestMetadataExecutor) recordExecution(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.executeMetadata = homeRequestMetadataFromContext(ctx)
+	return e.executeErr
+}
+
+func (e *homeRequestMetadataExecutor) snapshots() (homeRequestMetadataSnapshot, homeRequestMetadataSnapshot) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.prepareMetadata, e.executeMetadata
+}
+
+func (e *homeRequestMetadataExecutor) Execute(ctx context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if errExecute := e.recordExecution(ctx); errExecute != nil {
+		return cliproxyexecutor.Response{}, errExecute
+	}
+	return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+}
+
+func (e *homeRequestMetadataExecutor) ExecuteStream(ctx context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	if errExecute := e.recordExecution(ctx); errExecute != nil {
+		return nil, errExecute
+	}
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("ok")}
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (*homeRequestMetadataExecutor) Refresh(context.Context, *Auth) (*Auth, error) {
+	return nil, nil
+}
+
+func (e *homeRequestMetadataExecutor) CountTokens(ctx context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if errExecute := e.recordExecution(ctx); errExecute != nil {
+		return cliproxyexecutor.Response{}, errExecute
+	}
+	return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+}
+
+func (*homeRequestMetadataExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+// homeRequestMetadataHook buffers every Home result so a synchronous OnResult never blocks execution.
+type homeRequestMetadataHook struct {
+	results chan homeRequestMetadataSnapshot
+}
+
+func newHomeRequestMetadataHook() *homeRequestMetadataHook {
+	return &homeRequestMetadataHook{results: make(chan homeRequestMetadataSnapshot, 8)}
+}
+
+func (*homeRequestMetadataHook) OnAuthRegistered(context.Context, *Auth) {}
+func (*homeRequestMetadataHook) OnAuthUpdated(context.Context, *Auth)    {}
+func (h *homeRequestMetadataHook) OnResult(ctx context.Context, _ Result) {
+	select {
+	case h.results <- homeRequestMetadataFromContext(ctx):
+	default:
+	}
+}
+
+func (h *homeRequestMetadataHook) awaitResult(t *testing.T) homeRequestMetadataSnapshot {
+	t.Helper()
+	select {
+	case snapshot := <-h.results:
+		return snapshot
+	case <-time.After(time.Second):
+		t.Fatal("Home result hook did not run")
+		return homeRequestMetadataSnapshot{}
+	}
+}
+
+func assertHomeRequestMetadata(t *testing.T, got homeRequestMetadataSnapshot, serviceTier string) {
+	t.Helper()
+	want := homeRequestMetadataSnapshot{
+		requestedModel:  "client-model",
+		reasoningEffort: "high",
+		serviceTier:     serviceTier,
+		generate:        false,
+	}
+	if got != want {
+		t.Fatalf("request metadata = %#v, want %#v", got, want)
+	}
+}
+
+func newHomeRequestMetadataManager(t *testing.T, executor *homeRequestMetadataExecutor, hook Hook) *Manager {
+	t.Helper()
+	manager := NewManager(nil, nil, hook)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.PublishHomeDispatch(homeExecutionDispatcher{}, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+	return manager
+}
+
+// homeRequestMetadataOptions mirrors handler-populated metadata. Handlers already derive the
+// OpenAI "auto" default for an omitted tier (see sdk/api/handlers metadata tests); this layer
+// only has to carry whatever the handler resolved.
+func homeRequestMetadataOptions(serviceTier string) cliproxyexecutor.Options {
+	return cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.RequestedModelMetadataKey:  "client-model",
+		cliproxyexecutor.ReasoningEffortMetadataKey: "high",
+		cliproxyexecutor.ServiceTierMetadataKey:     serviceTier,
+		cliproxyexecutor.GenerateMetadataKey:        false,
+	}}
+}
+
+type homeRequestMetadataPath struct {
+	name string
+	run  func(*Manager, cliproxyexecutor.Options) error
+}
+
+func homeExecuteMetadataPath() homeRequestMetadataPath {
+	return homeRequestMetadataPath{
+		name: "execute",
+		run: func(manager *Manager, opts cliproxyexecutor.Options) error {
+			_, errExecute := manager.Execute(context.Background(), []string{"home-execution"}, cliproxyexecutor.Request{Model: "route-model"}, opts)
+			return errExecute
+		},
+	}
+}
+
+func homeCountMetadataPath() homeRequestMetadataPath {
+	return homeRequestMetadataPath{
+		name: "count_tokens",
+		run: func(manager *Manager, opts cliproxyexecutor.Options) error {
+			_, errCount := manager.ExecuteCount(context.Background(), []string{"home-execution"}, cliproxyexecutor.Request{Model: "route-model"}, opts)
+			return errCount
+		},
+	}
+}
+
+func homeStreamMetadataPath() homeRequestMetadataPath {
+	return homeRequestMetadataPath{
+		name: "stream",
+		run: func(manager *Manager, opts cliproxyexecutor.Options) error {
+			opts.Stream = true
+			result, errStream := manager.ExecuteStream(context.Background(), []string{"home-execution"}, cliproxyexecutor.Request{Model: "route-model"}, opts)
+			if errStream != nil {
+				return errStream
+			}
+			for range result.Chunks {
+			}
+			return nil
+		},
+	}
+}
+
+// TestHomeExecutionPropagatesRequestMetadata covers the Home regression from issue #4791: the
+// executor context must carry the client request metadata at auth preparation, at execution, and
+// in the Home result usage record.
+func TestHomeExecutionPropagatesRequestMetadata(t *testing.T) {
+	paths := []homeRequestMetadataPath{homeExecuteMetadataPath(), homeCountMetadataPath(), homeStreamMetadataPath()}
+
+	for _, path := range paths {
+		for _, serviceTier := range []string{"priority", coreusage.AutoServiceTier} {
+			t.Run(path.name+"/"+serviceTier, func(t *testing.T) {
+				executor := &homeRequestMetadataExecutor{}
+				hook := newHomeRequestMetadataHook()
+				manager := newHomeRequestMetadataManager(t, executor, hook)
+
+				if errRun := path.run(manager, homeRequestMetadataOptions(serviceTier)); errRun != nil {
+					t.Fatalf("execution error = %v", errRun)
+				}
+				prepareMetadata, executeMetadata := executor.snapshots()
+				assertHomeRequestMetadata(t, prepareMetadata, serviceTier)
+				assertHomeRequestMetadata(t, executeMetadata, serviceTier)
+				assertHomeRequestMetadata(t, hook.awaitResult(t), serviceTier)
+			})
+		}
+	}
+}
+
+// TestHomeExecutionFailureResultPreservesRequestMetadata keeps the requested tier authoritative in
+// the failure usage record instead of falling back to the upstream or default tier.
+func TestHomeExecutionFailureResultPreservesRequestMetadata(t *testing.T) {
+	paths := []homeRequestMetadataPath{homeExecuteMetadataPath(), homeCountMetadataPath()}
+
+	for _, path := range paths {
+		t.Run(path.name, func(t *testing.T) {
+			executor := &homeRequestMetadataExecutor{
+				executeErr: &Error{HTTPStatus: http.StatusBadRequest, Message: "invalid request"},
+			}
+			hook := newHomeRequestMetadataHook()
+			manager := newHomeRequestMetadataManager(t, executor, hook)
+
+			if errRun := path.run(manager, homeRequestMetadataOptions("priority")); errRun == nil {
+				t.Fatal("execution error = nil, want invalid request")
+			}
+			assertHomeRequestMetadata(t, hook.awaitResult(t), "priority")
+		})
+	}
+}
+
+// TestHomePrepareFailureResultPreservesRequestMetadata covers the prepare_failed Home result paths,
+// which report usage before any executor call happens.
+func TestHomePrepareFailureResultPreservesRequestMetadata(t *testing.T) {
+	paths := []homeRequestMetadataPath{homeExecuteMetadataPath(), homeCountMetadataPath(), homeStreamMetadataPath()}
+
+	for _, path := range paths {
+		t.Run(path.name, func(t *testing.T) {
+			executor := &homeRequestMetadataExecutor{
+				prepareErrOnce: &Error{Code: "prepare_failed", Message: "prepare failed"},
+			}
+			hook := newHomeRequestMetadataHook()
+			manager := newHomeRequestMetadataManager(t, executor, hook)
+
+			_ = path.run(manager, homeRequestMetadataOptions("priority"))
+			prepareMetadata, _ := executor.snapshots()
+			assertHomeRequestMetadata(t, prepareMetadata, "priority")
+			assertHomeRequestMetadata(t, hook.awaitResult(t), "priority")
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- enrich the Home attempt context in `executeHome` with the client request metadata before auth preparation, execution, and Home result reporting, so `Execute` and `ExecuteCount` no longer fall back to usage defaults;
- apply the same enrichment in `executeStreamMixedOnce`, where prepare-stage usage records had an identical gap because enrichment only happened downstream in `executeStreamWithModelPool`, after `prepareHomeRequestAuth` had already reported a `prepare_failed` Home result;
- keep `contextWithRequestedModelAlias` the single bridge from `Options.Metadata` to the usage context, so all four execution paths (`executeMixedOnce`, `executeCountMixedOnce`, `executeHome`, `executeStreamMixedOnce`) now enrich identically and before preparation;
- cover the Home `Execute`, `ExecuteCount`, and `ExecuteStream` paths with regressions asserting the metadata visible at auth preparation, at execution, and in the Home result usage record.

## Production evidence

A Home deployment that bills from the client-requested tier charged the Standard rule for an explicit `service_tier: "priority"` non-streaming `POST /v1/responses` request on v7.2.116 with `CodexExecutor`, because the emitted usage payload contained `{"service_tier":"default"}`.

The value was already wrong when CPA created the usage record: `usageQueuePlugin` serializes `Record.ServiceTier` as-is, and `service_home.go` forwards the queued bytes with `LPUSH usage` without re-marshalling, so neither the queue nor the CPA→Home transport was involved. `UsageReporter` reads `usage.ServiceTierFromContext(ctx)`, which returns `DefaultServiceTier` when the context carries no value.

`response_service_tier` is deliberately not used as a workaround: upstream OpenAI/Codex responses do not reliably report the requested or effective tier, so the client-requested `service_tier` must stay authoritative in usage.

## Validation

- `go test ./sdk/cliproxy/auth -count=1`
- `go test -race ./sdk/cliproxy/auth -run '^(TestHomeExecutionPropagatesRequestMetadata|TestHomeExecutionFailureResultPreservesRequestMetadata|TestHomePrepareFailureResultPreservesRequestMetadata)$' -count=1`
- `go test ./...`
- `go build -o test-output ./cmd/server && rm test-output`

Each production change was verified to be independently required by removing it and re-running the new tests:

| removed change | non-stream cases | stream cases |
| --- | --- | --- |
| `executeHome` enrichment | fail | pass |
| `executeStreamMixedOnce` enrichment | pass | fail |
| neither (both applied) | pass | pass |

Fixes #4791