### PR TITLE
fix(claude): align forced tool choice with native thinking

### DIFF
--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -96,8 +96,8 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body, contextManagementState.payloadRuleTouched = helps.ApplyPayloadConfigWithRequestTracked(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers, "context_management")
 	body = ensureModelMaxTokens(body, baseModel)
 
-	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
-	body = disableThinkingIfToolChoiceForced(body)
+	// Normalize Claude Code fingerprints and manual-thinking tool choices.
+	body = normalizeClaudeToolChoiceForThinking(body, cloaked)
 	body = reconcileClaudeCodeContextManagement(body, contextManagementState)
 	body = normalizeClaudeSamplingForUpstream(body)
 

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -349,23 +349,25 @@ func extractAndRemoveBetas(body []byte) ([]string, []byte) {
 	return betas, body
 }
 
-// disableThinkingIfToolChoiceForced checks if tool_choice forces tool use and disables thinking.
-// Anthropic API does not allow thinking when tool_choice is set to "any" or a specific tool.
-// See: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#important-considerations
-func disableThinkingIfToolChoiceForced(body []byte) []byte {
+// normalizeClaudeToolChoiceForThinking follows Claude Code's tool-choice policy
+// when cloaking constructs that fingerprint. Manual thinking is handled for all
+// callers because Anthropic only accepts auto/none in that mode.
+func normalizeClaudeToolChoiceForThinking(body []byte, claudeCodeFingerprint bool) []byte {
 	toolChoiceType := gjson.GetBytes(body, "tool_choice.type").String()
-	// "auto" is allowed with thinking, but "any" or "tool" (specific tool) are not
-	if toolChoiceType == "any" || toolChoiceType == "tool" {
-		// Remove thinking configuration entirely to avoid API error
-		body, _ = sjson.DeleteBytes(body, "thinking")
-		// Adaptive thinking may also set output_config.effort; remove it to avoid
-		// leaking thinking controls when tool_choice forces tool use.
-		body, _ = sjson.DeleteBytes(body, "output_config.effort")
-		if oc := gjson.GetBytes(body, "output_config"); oc.Exists() && oc.IsObject() && len(oc.Map()) == 0 {
-			body, _ = sjson.DeleteBytes(body, "output_config")
-		}
+	thinkingType := gjson.GetBytes(body, "thinking.type").String()
+	manualThinking := thinkingType == "enabled"
+	forcedTool := toolChoiceType == "tool" || toolChoiceType == "any"
+	manualThinkingWithForcedTool := manualThinking && forcedTool
+	fingerprintedNamedTool := claudeCodeFingerprint && toolChoiceType == "tool" && thinkingType != "disabled"
+	if !manualThinkingWithForcedTool && !fingerprintedNamedTool {
+		return body
 	}
-	return body
+
+	updated, err := sjson.SetRawBytes(body, "tool_choice", []byte(`{"type":"auto"}`))
+	if err != nil {
+		return body
+	}
+	return updated
 }
 
 // normalizeClaudeSamplingForUpstream keeps Anthropic message requests valid.

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -100,8 +100,8 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body, contextManagementState.payloadRuleTouched = helps.ApplyPayloadConfigWithRequestTracked(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers, "context_management")
 	body = ensureModelMaxTokens(body, baseModel)
 
-	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
-	body = disableThinkingIfToolChoiceForced(body)
+	// Normalize Claude Code fingerprints and manual-thinking tool choices.
+	body = normalizeClaudeToolChoiceForThinking(body, cloaked)
 	body = reconcileClaudeCodeContextManagement(body, contextManagementState)
 	body = normalizeClaudeSamplingForUpstream(body)
 

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -4452,13 +4452,88 @@ func TestNormalizeClaudeSamplingForUpstream_NoThinkingRemovesTemperatureAndTopP(
 	}
 }
 
-func TestNormalizeClaudeSamplingForUpstream_AfterForcedToolChoiceRemovesTemperature(t *testing.T) {
+func TestNormalizeClaudeToolChoiceForThinking(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		payload   string
+		uncloaked bool
+		want      string
+	}{
+		{
+			name:    "adaptive thinking demotes named tool to auto",
+			payload: `{"thinking":{"type":"adaptive"},"output_config":{"effort":"max"},"tool_choice":{"type":"tool","name":"Read","disable_parallel_tool_use":true}}`,
+			want:    `{"thinking":{"type":"adaptive"},"output_config":{"effort":"max"},"tool_choice":{"type":"auto"}}`,
+		},
+		{
+			name:    "enabled thinking demotes named tool to auto",
+			payload: `{"thinking":{"type":"enabled","budget_tokens":2048},"tool_choice":{"type":"tool","name":"Read"}}`,
+			want:    `{"thinking":{"type":"enabled","budget_tokens":2048},"tool_choice":{"type":"auto"}}`,
+		},
+		{
+			name:    "omitted thinking uses Claude Code active default",
+			payload: `{"output_config":{"effort":"high"},"tool_choice":{"type":"tool","name":"Read"}}`,
+			want:    `{"output_config":{"effort":"high"},"tool_choice":{"type":"auto"}}`,
+		},
+		{
+			name:    "disabled thinking preserves named tool",
+			payload: `{"thinking":{"type":"disabled"},"output_config":{"effort":"high"},"tool_choice":{"type":"tool","name":"Read"}}`,
+			want:    `{"thinking":{"type":"disabled"},"output_config":{"effort":"high"},"tool_choice":{"type":"tool","name":"Read"}}`,
+		},
+		{
+			name:      "uncloaked adaptive thinking preserves named tool",
+			payload:   `{"thinking":{"type":"adaptive"},"tool_choice":{"type":"tool","name":"Read"}}`,
+			uncloaked: true,
+			want:      `{"thinking":{"type":"adaptive"},"tool_choice":{"type":"tool","name":"Read"}}`,
+		},
+		{
+			name:      "manual thinking demotes any to native valid auto without cloak",
+			payload:   `{"thinking":{"type":"enabled","budget_tokens":2048},"tool_choice":{"type":"any","disable_parallel_tool_use":true}}`,
+			uncloaked: true,
+			want:      `{"thinking":{"type":"enabled","budget_tokens":2048},"tool_choice":{"type":"auto"}}`,
+		},
+		{
+			name:    "disabled thinking preserves any",
+			payload: `{"thinking":{"type":"disabled"},"output_config":{"effort":"high"},"tool_choice":{"type":"any"}}`,
+			want:    `{"thinking":{"type":"disabled"},"output_config":{"effort":"high"},"tool_choice":{"type":"any"}}`,
+		},
+		{
+			name:    "adaptive thinking preserves supported any",
+			payload: `{"thinking":{"type":"adaptive"},"output_config":{"effort":"max","format":{"type":"json_schema"}},"tool_choice":{"type":"any"}}`,
+			want:    `{"thinking":{"type":"adaptive"},"output_config":{"effort":"max","format":{"type":"json_schema"}},"tool_choice":{"type":"any"}}`,
+		},
+		{
+			name:    "unknown non-disabled thinking mode is active",
+			payload: `{"thinking":{"type":"future"},"tool_choice":{"type":"tool","name":"Read"}}`,
+			want:    `{"thinking":{"type":"future"},"tool_choice":{"type":"auto"}}`,
+		},
+		{
+			name:    "auto tool choice is preserved",
+			payload: `{"thinking":{"type":"adaptive"},"tool_choice":{"type":"auto","disable_parallel_tool_use":true}}`,
+			want:    `{"thinking":{"type":"adaptive"},"tool_choice":{"type":"auto","disable_parallel_tool_use":true}}`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := normalizeClaudeToolChoiceForThinking([]byte(test.payload), !test.uncloaked)
+			if string(got) != test.want {
+				t.Fatalf("normalizeClaudeToolChoiceForThinking() = %s, want %s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeClaudeSamplingForUpstream_AfterToolChoiceNormalizationLeavesAnyUntouched(t *testing.T) {
 	payload := []byte(`{"temperature":0,"thinking":{"type":"adaptive"},"output_config":{"effort":"max"},"tool_choice":{"type":"any"}}`)
-	out := disableThinkingIfToolChoiceForced(payload)
+	out := normalizeClaudeToolChoiceForThinking(payload, true)
 	out = normalizeClaudeSamplingForUpstream(out)
 
-	if gjson.GetBytes(out, "thinking").Exists() {
-		t.Fatalf("thinking should be removed when tool_choice forces tool use")
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "adaptive" {
+		t.Fatalf("thinking.type = %q, want adaptive", got)
+	}
+	if got := gjson.GetBytes(out, "output_config.effort").String(); got != "max" {
+		t.Fatalf("output_config.effort = %q, want max", got)
+	}
+	if got := gjson.GetBytes(out, "tool_choice.type").String(); got != "any" {
+		t.Fatalf("tool_choice.type = %q, want any", got)
 	}
 	if gjson.GetBytes(out, "temperature").Exists() {
 		t.Fatalf("temperature should be removed")
@@ -5632,21 +5707,135 @@ func TestClaudeExecutorPayloadOverrideDisabledThinking(t *testing.T) {
 	})
 
 	for _, stream := range []bool{false, true} {
-		name := "forced tool choice retains automatic context management execute"
+		nameSuffix := "execute"
+		if stream {
+			nameSuffix = "execute stream"
+		}
+
+		t.Run("non-native any shape is not normalized "+nameSuffix, func(t *testing.T) {
+			payload := []byte(`{"model":"claude-opus-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"tool_choice":{"type":"any"}}`)
+			upstreamBody := executeClaudeContextManagementRequest(t, &config.Config{}, payload, stream)
+			if got := gjson.GetBytes(upstreamBody, "thinking.type").String(); got != "adaptive" {
+				t.Fatalf("thinking.type = %q, want adaptive; body=%s", got, upstreamBody)
+			}
+			if got := gjson.GetBytes(upstreamBody, "context_management").Raw; got != claudeCodeContextManagement {
+				t.Fatalf("tool_choice any context_management = %s, want %s", got, claudeCodeContextManagement)
+			}
+			if got := gjson.GetBytes(upstreamBody, "tool_choice.type").String(); got != "any" {
+				t.Fatalf("tool_choice.type = %q, want any", got)
+			}
+		})
+
+		for _, toolChoice := range []struct {
+			name string
+			raw  string
+		}{
+			{name: "any", raw: `{"type":"any"}`},
+			{name: "named tool", raw: `{"type":"tool","name":"Read"}`},
+		} {
+			t.Run("disabled thinking preserves "+toolChoice.name+" "+nameSuffix, func(t *testing.T) {
+				payload := []byte(`{"model":"claude-opus-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"disabled"},"tool_choice":` + toolChoice.raw + `}`)
+				upstreamBody := executeClaudeContextManagementRequest(t, &config.Config{}, payload, stream)
+				if got := gjson.GetBytes(upstreamBody, "thinking.type").String(); got != "disabled" {
+					t.Fatalf("thinking.type = %q, want disabled; body=%s", got, upstreamBody)
+				}
+				if got := gjson.GetBytes(upstreamBody, "context_management"); got.Exists() {
+					t.Fatalf("disabled thinking context_management = %s, want absent", got.Raw)
+				}
+				if got := gjson.GetBytes(upstreamBody, "tool_choice.type").String(); got != gjson.Get(toolChoice.raw, "type").String() {
+					t.Fatalf("tool_choice.type = %q; body=%s", got, upstreamBody)
+				}
+				if wantName := gjson.Get(toolChoice.raw, "name").String(); wantName != "" {
+					if got := gjson.GetBytes(upstreamBody, "tool_choice.name").String(); got != wantName {
+						t.Fatalf("tool_choice.name = %q, want %q; body=%s", got, wantName, upstreamBody)
+					}
+				}
+			})
+		}
+
+		t.Run("payload override disabled preserves any "+nameSuffix, func(t *testing.T) {
+			cfg := &config.Config{Payload: config.PayloadConfig{Override: []config.PayloadRule{{
+				Models: modelRules,
+				Params: map[string]any{"thinking.type": "disabled"},
+			}}}}
+			payload := []byte(`{"model":"claude-opus-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}],"tool_choice":{"type":"any"}}`)
+			upstreamBody := executeClaudeContextManagementRequest(t, cfg, payload, stream)
+			if got := gjson.GetBytes(upstreamBody, "thinking.type").String(); got != "disabled" {
+				t.Fatalf("thinking.type = %q, want disabled; body=%s", got, upstreamBody)
+			}
+			if got := gjson.GetBytes(upstreamBody, "context_management"); got.Exists() {
+				t.Fatalf("payload-disabled context_management = %s, want absent", got.Raw)
+			}
+			if got := gjson.GetBytes(upstreamBody, "tool_choice.type").String(); got != "any" {
+				t.Fatalf("tool_choice.type = %q, want any", got)
+			}
+		})
+	}
+}
+
+func TestClaudeExecutorNativeNamedToolChoiceFingerprint(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		thinkingJSON string
+		wantThinking string
+		wantEffort   string
+	}{
+		{name: "adaptive", thinkingJSON: `,"thinking":{"type":"adaptive"}`, wantThinking: "adaptive", wantEffort: "high"},
+		{name: "enabled normalized by Opus 5", thinkingJSON: `,"thinking":{"type":"enabled","budget_tokens":2048}`, wantThinking: "adaptive", wantEffort: "medium"},
+		{name: "omitted", wantEffort: "high"},
+	} {
+		for _, stream := range []bool{false, true} {
+			name := test.name + " execute"
+			if stream {
+				name += " stream"
+			}
+			t.Run(name, func(t *testing.T) {
+				payload := []byte(`{"model":"claude-opus-5","max_tokens":4096,"messages":[{"role":"user","content":"hi"}],"output_config":{"effort":"high"},"tool_choice":{"type":"tool","name":"Read","disable_parallel_tool_use":true}` + test.thinkingJSON + `}`)
+				upstreamBody := executeClaudeContextManagementRequest(t, &config.Config{}, payload, stream)
+				if got := gjson.GetBytes(upstreamBody, "tool_choice.type").String(); got != "auto" {
+					t.Fatalf("tool_choice.type = %q, want auto; body=%s", got, upstreamBody)
+				}
+				if got := gjson.GetBytes(upstreamBody, "tool_choice.name"); got.Exists() {
+					t.Fatalf("demoted tool_choice.name = %s, want absent", got.Raw)
+				}
+				if got := gjson.GetBytes(upstreamBody, "tool_choice.disable_parallel_tool_use"); got.Exists() {
+					t.Fatalf("demoted disable_parallel_tool_use = %s, want absent", got.Raw)
+				}
+				thinking := gjson.GetBytes(upstreamBody, "thinking")
+				if test.wantThinking == "" {
+					if thinking.Exists() {
+						t.Fatalf("thinking = %s, want absent", thinking.Raw)
+					}
+				} else if got := thinking.Get("type").String(); got != test.wantThinking {
+					t.Fatalf("thinking.type = %q, want %q", got, test.wantThinking)
+				}
+				if got := gjson.GetBytes(upstreamBody, "context_management").Raw; got != claudeCodeContextManagement {
+					t.Fatalf("context_management = %s, want %s", got, claudeCodeContextManagement)
+				}
+				if got := gjson.GetBytes(upstreamBody, "output_config.effort").String(); got != test.wantEffort {
+					t.Fatalf("output_config.effort = %q, want %q", got, test.wantEffort)
+				}
+			})
+		}
+	}
+
+	for _, stream := range []bool{false, true} {
+		name := "cloak disabled preserves adaptive named tool execute"
 		if stream {
 			name += " stream"
 		}
 		t.Run(name, func(t *testing.T) {
-			payload := []byte(`{"model":"claude-opus-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"tool_choice":{"type":"any"}}`)
-			upstreamBody := executeClaudeContextManagementRequest(t, &config.Config{}, payload, stream)
-			if got := gjson.GetBytes(upstreamBody, "thinking"); got.Exists() {
-				t.Fatalf("forced tool choice thinking = %s, want absent", got.Raw)
+			payload := []byte(`{"model":"claude-opus-5","max_tokens":4096,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"tool_choice":{"type":"tool","name":"Read"}}`)
+			cfg := &config.Config{DisableClaudeCloakMode: true}
+			upstreamBody := executeClaudeContextManagementRequest(t, cfg, payload, stream)
+			if got := gjson.GetBytes(upstreamBody, "tool_choice.type").String(); got != "tool" {
+				t.Fatalf("tool_choice.type = %q, want tool; body=%s", got, upstreamBody)
 			}
-			if got := gjson.GetBytes(upstreamBody, "context_management").Raw; got != claudeCodeContextManagement {
-				t.Fatalf("forced tool choice context_management = %s, want %s", got, claudeCodeContextManagement)
+			if got := gjson.GetBytes(upstreamBody, "tool_choice.name").String(); got != "Read" {
+				t.Fatalf("tool_choice.name = %q, want Read; body=%s", got, upstreamBody)
 			}
-			if got := gjson.GetBytes(upstreamBody, "tool_choice.type").String(); got != "any" {
-				t.Fatalf("forced tool_choice.type = %q, want any", got)
+			if got := gjson.GetBytes(upstreamBody, "context_management"); got.Exists() {
+				t.Fatalf("uncloaked context_management = %s, want absent", got.Raw)
 			}
 		})
 	}
@@ -5687,6 +5876,24 @@ func TestClaudeExecutorPayloadOverrideReenablesThinking(t *testing.T) {
 		if stream {
 			nameSuffix = "execute stream"
 		}
+
+		t.Run("manual thinking override demotes any to auto "+nameSuffix, func(t *testing.T) {
+			cfg := &config.Config{Payload: config.PayloadConfig{Override: []config.PayloadRule{{
+				Models: modelRules,
+				Params: map[string]any{"thinking.type": "enabled"},
+			}}}}
+			payload := []byte(`{"model":"claude-opus-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"disabled"},"tool_choice":{"type":"any","disable_parallel_tool_use":true}}`)
+			upstreamBody := executeClaudeContextManagementRequest(t, cfg, payload, stream)
+			if got := gjson.GetBytes(upstreamBody, "thinking.type").String(); got != "enabled" {
+				t.Fatalf("thinking.type = %q, want enabled; body=%s", got, upstreamBody)
+			}
+			if got := gjson.GetBytes(upstreamBody, "tool_choice").Raw; got != `{"type":"auto"}` {
+				t.Fatalf("tool_choice = %s, want native-valid auto; body=%s", got, upstreamBody)
+			}
+			if got := gjson.GetBytes(upstreamBody, "context_management").Raw; got != claudeCodeContextManagement {
+				t.Fatalf("context_management = %s, want %s", got, claudeCodeContextManagement)
+			}
+		})
 
 		t.Run("caller context management is preserved after re-enabling "+nameSuffix, func(t *testing.T) {
 			cfg := &config.Config{Payload: config.PayloadConfig{Override: []config.PayloadRule{{


### PR DESCRIPTION
## Summary

Follow up to #4785 by reproducing the tool-choice decision in the native Claude Code request builder.

Claude Code 2.1.220 and 2.1.221 treat thinking as active unless it is explicitly disabled. When active thinking is combined with a named forced tool, the client replaces the complete tool choice with `{"type":"auto"}`. With explicit disabled thinking, the named forced tool is preserved and automatic `context_management` remains absent.

## Changes

- Replace CPA's blanket forced-tool thinking deletion with the native named-tool transformation.
- For cloaked `tool_choice.type: tool` with non-disabled thinking, replace the complete tool choice with `{"type":"auto"}`.
- Preserve thinking, `output_config.effort`, and automatic `context_management` during that transformation.
- Preserve named forced tools when thinking is explicitly disabled.
- Normalize translated `tool_choice.type: any` to `auto` only with manual `thinking.type: enabled`, because Anthropic permits only `auto`/`none` in manual mode; preserve supported adaptive and disabled `any` shapes.
- Apply the same request preparation to normal and streaming execution.

## Pipeline and translator scope

The normalization intentionally runs **after** cross-protocol translation, canonical thinking application, cloaking, and payload rules. When cloaking constructs a Claude Code fingerprint, this makes the final Anthropic wire shape authoritative regardless of whether the caller used Claude Messages, OpenAI Chat Completions, OpenAI Responses, or Interactions. Explicit `cloak=never` requests preserve supported adaptive/default forced-tool behavior; the manual-thinking validity rule still applies because Anthropic rejects forced tool choices in manual mode. The named-tool fingerprint is intentionally not restricted to `api.anthropic.com`: it is a Claude Code client-side request-builder decision made before upstream transport/base-URL selection. Custom Claude-compatible gateways receive it only when cloak is enabled and can preserve their native forced-tool semantics with `cloak=never`.

For example, a translated OpenAI forced function first becomes Claude `tool_choice.type: tool`. If the final cloaked Claude request has non-disabled thinking, the executor then applies the same request-builder decision as Claude Code and emits `tool_choice: {"type":"auto"}`. This loss of the source protocol's forced-tool guarantee is intentional when the operator enables the fingerprint: final Claude Code parity takes precedence at the upstream wire boundary.

A translated `required` choice may become Claude `tool_choice.type: any`. Claude Code does not actively construct that shape. Anthropic manual thinking (`thinking.type: enabled`) permits only `auto`/`none`, so the executor converts that translated non-native combination to the native-valid `auto` shape. Adaptive thinking officially supports forced tool use and therefore keeps `any`; disabled thinking also keeps it.

## Native evidence

The installed signed Anthropic binaries contain equivalent request-builder logic:

- Claude Code 2.1.220: SHA-256 `8addc857f3fe64d5a0368af9ee50321b50afb4a6918ba3ef018ab84f5dbbe081`
- Claude Code 2.1.221: SHA-256 `7a181f36ed0fc4fbac6cee4ecf2b615eff93d8b434221fff5d7c878dc5ebf380`

Recovered behavior, with minified local names omitted:

```js
hasThinking =
  thinkingConfig.type !== "disabled" &&
  !disableThinkingEnv

if (toolChoice?.type === "tool" && hasThinking) {
  toolChoice = { type: "auto" }
}

contextManagement = hasThinking
  ? { edits: [{ type: "clear_thinking_20251015", keep: "all" }] }
  : undefined
```

Both binaries contain one native `toolChoice:{type:"tool"...}` construction and one snake-case `tool_choice:{type:"tool"...}` construction. Neither contains a `toolChoice:{type:"any"...}` or `tool_choice:{type:"any"...}` construction. The remaining `type:"any"` strings are embedded schema/API-documentation text, and the CLI exposes no tool-choice input. The `enabled + any` conversion is therefore explicitly a post-translation native-validity rule, not a claim that Claude Code constructs `any`.

The isolated Claude Code 2.1.221 OAuth client and shared `127.0.0.1:28082` MITM remain healthy. A bounded native OAuth flow already confirmed that explicit disabled thinking omits `context_management`, retains the context-management beta, and succeeds with HTTP 200. A direct OAuth probe through the same isolated profile additionally confirmed that Claude Sonnet 4.5 returns HTTP 400 `invalid_request_error` for manual `thinking.type: enabled` plus `tool_choice.type: any`: `Thinking may not be enabled when tool_choice forces tool use.` This matches the [official thinking/tool-use constraint](https://platform.claude.com/docs/en/build-with-claude/thinking#thinking-with-tool-use).

## Tests

Added coverage for:

- adaptive, enabled, omitted, disabled, and non-disabled unknown thinking states;
- exact named-tool demotion shape (`{"type":"auto"}`);
- preservation of thinking and effort during demotion;
- preservation of disabled thinking and named tool identity;
- manual `enabled + any` demotion to exact `auto`, while adaptive/disabled `any` remain unchanged;
- explicit cloak disable preserving adaptive named forced tools in normal and streaming paths;
- payload overrides that disable or re-enable thinking, including normal and streaming `enabled + any` integration;
- normal and streaming executor paths;
- context-management presence/absence.

## Validation

- `gofmt`: passed
- executor/helper package tests: passed
- focused race tests: passed
- executor/helper `go vet`: passed
- server build: passed
- `git diff --check`: passed
- `go test ./... -count=1`: passed




