### PR TITLE
fix: fall back to manual OAuth callback when callback port is busy

### DIFF
--- a/internal/api/handlers/management/auth_files_oauth_callback.go
+++ b/internal/api/handlers/management/auth_files_oauth_callback.go
@@ -24,6 +24,8 @@ type callbackForwarder struct {
 	done     chan struct{}
 }
 
+var startWebUICallbackForwarder = startCallbackForwarder
+
 func isWebUIRequest(c *gin.Context) bool {
 	raw := strings.TrimSpace(c.Query("is_webui"))
 	if raw == "" {
@@ -95,6 +97,18 @@ func startCallbackForwarder(port int, provider, targetBase string) (*callbackFor
 	log.Infof("callback forwarder for %s listening on %s", provider, addr)
 
 	return forwarder, nil
+}
+
+func startOptionalWebUICallbackForwarder(port int, provider, targetBase string) *callbackForwarder {
+	forwarder, err := startWebUICallbackForwarder(port, provider, targetBase)
+	if err != nil {
+		log.WithError(err).Warnf(
+			"callback forwarder for %s is unavailable; continuing with manual callback submission",
+			provider,
+		)
+		return nil
+	}
+	return forwarder
 }
 
 func stopCallbackForwarderInstance(port int, forwarder *callbackForwarder) {

--- a/internal/api/handlers/management/auth_files_provider_oauth.go
+++ b/internal/api/handlers/management/auth_files_provider_oauth.go
@@ -77,12 +77,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "callback server unavailable"})
 			return
 		}
-		var errStart error
-		if forwarder, errStart = startCallbackForwarder(anthropicCallbackPort, "anthropic", targetURL); errStart != nil {
-			log.WithError(errStart).Error("failed to start anthropic callback forwarder")
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to start callback server"})
-			return
-		}
+		forwarder = startOptionalWebUICallbackForwarder(anthropicCallbackPort, "anthropic", targetURL)
 	}
 
 	go func() {
@@ -237,12 +232,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "callback server unavailable"})
 			return
 		}
-		var errStart error
-		if forwarder, errStart = startCallbackForwarder(codexCallbackPort, "codex", targetURL); errStart != nil {
-			log.WithError(errStart).Error("failed to start codex callback forwarder")
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to start callback server"})
-			return
-		}
+		forwarder = startOptionalWebUICallbackForwarder(codexCallbackPort, "codex", targetURL)
 	}
 
 	go func() {
@@ -370,12 +360,7 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "callback server unavailable"})
 			return
 		}
-		var errStart error
-		if forwarder, errStart = startCallbackForwarder(antigravity.CallbackPort, "antigravity", targetURL); errStart != nil {
-			log.WithError(errStart).Error("failed to start antigravity callback forwarder")
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to start callback server"})
-			return
-		}
+		forwarder = startOptionalWebUICallbackForwarder(antigravity.CallbackPort, "antigravity", targetURL)
 	}
 
 	go func() {

--- a/internal/api/handlers/management/oauth_codex_concurrency_test.go
+++ b/internal/api/handlers/management/oauth_codex_concurrency_test.go
@@ -3,6 +3,7 @@ package management
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -73,6 +74,45 @@ func TestRequestCodexTokenCompletionKeepsConcurrentSessionPending(t *testing.T) 
 	if !IsOAuthSessionPending(secondState, "codex") {
 		t.Fatalf("expected concurrent codex session %s to remain pending after %s completed", secondState, firstState)
 	}
+}
+
+func TestRequestCodexTokenWebUIAllowsManualCallbackWhenForwarderIsUnavailable(t *testing.T) {
+	originalNewCodexOAuthService := newCodexOAuthService
+	originalStartWebUICallbackForwarder := startWebUICallbackForwarder
+	newCodexOAuthService = func(cfg *config.Config) codexOAuthService {
+		return &fakeCodexOAuthService{}
+	}
+	startWebUICallbackForwarder = func(int, string, string) (*callbackForwarder, error) {
+		return nil, errors.New("listen tcp 0.0.0.0:1455: bind: address already in use")
+	}
+	defer func() {
+		newCodexOAuthService = originalNewCodexOAuthService
+		startWebUICallbackForwarder = originalStartWebUICallbackForwarder
+	}()
+
+	authDir := filepath.Join(t.TempDir(), "auths")
+	handler := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir, Port: 18317}, nil)
+	router := gin.New()
+	router.GET("/codex-auth-url", handler.RequestCodexToken)
+
+	req := httptest.NewRequest(http.MethodGet, "/codex-auth-url?is_webui=true", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var payload struct {
+		State string `json:"state"`
+		URL   string `json:"url"`
+	}
+	if errDecode := json.Unmarshal(w.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode codex auth URL response: %v", errDecode)
+	}
+	if payload.State == "" || payload.URL == "" {
+		t.Fatalf("expected OAuth URL and state, got %+v", payload)
+	}
+	CompleteOAuthSession(payload.State)
 }
 
 func requestCodexTokenState(t *testing.T, router http.Handler) string {


### PR DESCRIPTION
## What changed

- Make Web UI OAuth callback forwarding best-effort for Codex, Anthropic, and Antigravity.
- Continue returning the authorization URL and state when the provider callback port is already occupied.
- Add a regression test covering the Codex Web UI flow with port `1455` unavailable.

## Root cause

The Web UI path treated a callback-forwarder bind failure as fatal. On hosts running another proxy that already owns Codex callback port `1455`, CPA returned `failed to start callback server` before the user could authorize. The management UI already supports manual callback URL submission, so the bind failure does not need to abort OAuth.

## User impact

Remote administrators can start OAuth normally and, when automatic forwarding is unavailable, paste the final `http://localhost:...` callback URL into the management page. Existing automatic forwarding remains unchanged whenever the port is free.

## Validation

- `go test ./internal/api/handlers/management`
- `go test -p=1 ./...`