### PR TITLE
feat(CodeBuddy): add native CodeBuddy session support to OpenAI compatibility

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -502,6 +502,24 @@ nonstream-keepalive-interval: 0
 #       - name: "kimi-k2.5"
 #         alias: "claude-opus-4.66"
 
+# CodeBuddy desktop session (native codebuddy2api-compatible integration)
+# CodeBuddy stores the login session in a .info file.  Set auth-dir or
+# auth-file when the automatic platform-specific discovery is not suitable.
+# The upstream base URL includes /v2; requests are sent to
+# /v2/chat/completions and token refreshes to /v2/plugin/auth/token/refresh.
+# openai-compatibility:
+#   - name: "codebuddy"
+#     auth-type: "codebuddy"
+#     auth-dir: "C:/Users/your-name/AppData/Local/CodeBuddyExtension/Data/Public/auth"
+#     # auth-file: "C:/path/to/account.info" # optional; takes precedence over auth-dir
+#     base-url: "https://copilot.tencent.com/v2"
+#     desensitize: true # optional; obfuscate high-risk harness wording before forwarding
+#     models: # optional; omitted models use CodeBuddy's built-in model catalog
+#       - name: "glm-5.2"
+#         alias: "glm-5.2"
+#       - name: "auto"
+#         alias: "auto"
+
 # Vertex API keys (Vertex-compatible endpoints, base-url is optional)
 # vertex-api-key:
 #   - api-key: "vk-123..."                        # x-goog-api-key header

--- a/internal/api/handlers/management/codebuddy_import.go
+++ b/internal/api/handlers/management/codebuddy_import.go
@@ -1,0 +1,212 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codebuddy"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+)
+
+// ImportCodeBuddyAuth imports a WorkBuddy/CodeBuddy desktop session into the
+// native codebuddy compatibility entry.  The endpoint accepts either a JSON
+// auth-file path or a multipart .info upload, matching the Vertex JSON import
+// workflow without exposing session tokens in the response.
+func (h *Handler) ImportCodeBuddyAuth(c *gin.Context) {
+	if h == nil || h.cfg == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "config unavailable"})
+		return
+	}
+
+	var (
+		authPath   string
+		sessionRaw []byte
+		uploaded   bool
+	)
+	if strings.HasPrefix(strings.ToLower(c.GetHeader("Content-Type")), "multipart/form-data") {
+		fileHeader, errFile := c.FormFile("file")
+		if errFile != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "file required"})
+			return
+		}
+		if !strings.EqualFold(filepath.Ext(fileHeader.Filename), ".info") {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "WorkBuddy session file must use the .info extension"})
+			return
+		}
+		file, errOpen := fileHeader.Open()
+		if errOpen != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("failed to read file: %v", errOpen)})
+			return
+		}
+		sessionRaw, errOpen = io.ReadAll(file)
+		_ = file.Close()
+		if errOpen != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("failed to read file: %v", errOpen)})
+			return
+		}
+		authDir, errDir := util.ResolveAuthDir(h.cfg.AuthDir)
+		if errDir != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("resolve auth directory: %v", errDir)})
+			return
+		}
+		if errMkdir := os.MkdirAll(authDir, 0o700); errMkdir != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("create auth directory: %v", errMkdir)})
+			return
+		}
+		fileName := "workbuddy-" + filepath.Base(fileHeader.Filename)
+		authPath = filepath.Join(authDir, fileName)
+		uploaded = true
+	} else {
+		var body struct {
+			AuthFile string `json:"auth-file"`
+		}
+		if errJSON := c.ShouldBindJSON(&body); errJSON != nil && errJSON != io.EOF {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+		authPath = strings.TrimSpace(body.AuthFile)
+		if authPath == "" {
+			authPath = strings.TrimSpace(c.Query("auth-file"))
+		}
+		if authPath == "" {
+			authPath = strings.TrimSpace(c.PostForm("auth-file"))
+		}
+		authPath = expandCodeBuddyImportPath(authPath)
+	}
+
+	if authPath == "" || !strings.EqualFold(filepath.Ext(authPath), ".info") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "auth-file must point to a .info session file"})
+		return
+	}
+
+	if !uploaded {
+		var errRead error
+		sessionRaw, errRead = os.ReadFile(authPath)
+		if errRead != nil {
+			status := http.StatusBadRequest
+			if !os.IsNotExist(errRead) {
+				status = http.StatusInternalServerError
+			}
+			c.JSON(status, gin.H{"error": fmt.Sprintf("read auth-file: %v", errRead)})
+			return
+		}
+	}
+
+	if errValidate := validateCodeBuddySession(sessionRaw); errValidate != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": errValidate.Error()})
+		return
+	}
+
+	if uploaded {
+		if errWrite := writeCodeBuddyImportFile(authPath, sessionRaw); errWrite != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("save auth-file: %v", errWrite)})
+			return
+		}
+	}
+
+	h.mu.Lock()
+	entryIndex := -1
+	for i := range h.cfg.OpenAICompatibility {
+		entry := &h.cfg.OpenAICompatibility[i]
+		if strings.EqualFold(strings.TrimSpace(entry.AuthType), codebuddy.AuthType) ||
+			strings.EqualFold(strings.TrimSpace(entry.Name), codebuddy.AuthType) ||
+			strings.EqualFold(strings.TrimSpace(entry.Name), "workbuddy") {
+			entryIndex = i
+			break
+		}
+	}
+	if entryIndex == -1 {
+		h.cfg.OpenAICompatibility = append(h.cfg.OpenAICompatibility, config.OpenAICompatibility{
+			Name:        "WorkBuddy",
+			AuthType:    codebuddy.AuthType,
+			BaseURL:     codebuddy.DefaultBackendBaseURL,
+			Desensitize: true,
+		})
+		entryIndex = len(h.cfg.OpenAICompatibility) - 1
+	}
+	entry := &h.cfg.OpenAICompatibility[entryIndex]
+	if strings.TrimSpace(entry.Name) == "" || strings.EqualFold(strings.TrimSpace(entry.Name), codebuddy.AuthType) {
+		entry.Name = "WorkBuddy"
+	}
+	entry.AuthType = codebuddy.AuthType
+	entry.AuthFile = authPath
+	entry.AuthDir = ""
+	if strings.TrimSpace(entry.BaseURL) == "" {
+		entry.BaseURL = codebuddy.DefaultBackendBaseURL
+	}
+	h.cfg.SanitizeOpenAICompatibility()
+	snapshot, ok := h.saveConfigAndSnapshotLocked(c)
+	h.mu.Unlock()
+	if !ok {
+		if uploaded {
+			_ = os.Remove(authPath)
+		}
+		return
+	}
+	h.reloadConfigAfterManagementSaveAsync(context.Background(), snapshot)
+
+	manager, _ := codebuddy.NewCredentialManager(authPath)
+	summary, _ := manager.Summary()
+	c.JSON(http.StatusOK, gin.H{
+		"status":           "ok",
+		"provider":         "workbuddy",
+		"auth-file":        authPath,
+		"nickname":         summary.Nickname,
+		"enterprise":       summary.EnterpriseName,
+		"token-expired":    summary.TokenExpired,
+		"token-expires-at": summary.TokenExpiresAt,
+	})
+}
+
+func validateCodeBuddySession(data []byte) error {
+	var session map[string]any
+	if err := json.Unmarshal(data, &session); err != nil {
+		return fmt.Errorf("invalid WorkBuddy .info JSON: %v", err)
+	}
+	auth, ok := session["auth"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("invalid WorkBuddy session: missing auth object")
+	}
+	accessToken, _ := auth["accessToken"].(string)
+	refreshToken, _ := auth["refreshToken"].(string)
+	if strings.TrimSpace(accessToken) == "" && strings.TrimSpace(refreshToken) == "" {
+		return fmt.Errorf("invalid WorkBuddy session: accessToken/refreshToken missing")
+	}
+	return nil
+}
+
+func expandCodeBuddyImportPath(path string) string {
+	path = strings.TrimSpace(os.ExpandEnv(path))
+	if strings.HasPrefix(path, "~") {
+		if home, errHome := os.UserHomeDir(); errHome == nil {
+			path = filepath.Join(home, strings.TrimLeft(path[1:], `/\\`))
+		}
+	}
+	if path == "" {
+		return ""
+	}
+	if abs, errAbs := filepath.Abs(path); errAbs == nil {
+		path = abs
+	}
+	return filepath.Clean(path)
+}
+
+func writeCodeBuddyImportFile(path string, data []byte) error {
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}

--- a/internal/api/handlers/management/codebuddy_import_test.go
+++ b/internal/api/handlers/management/codebuddy_import_test.go
@@ -1,0 +1,97 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestImportCodeBuddyAuthByPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	root := t.TempDir()
+	authPath := filepath.Join(root, "desktop.info")
+	writeCodeBuddyTestSession(t, authPath)
+	configPath := filepath.Join(root, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("host: 127.0.0.1\nport: 8317\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg := &config.Config{AuthDir: root}
+	h := NewHandler(cfg, configPath, nil)
+
+	body, _ := json.Marshal(map[string]string{"auth-file": authPath})
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/codebuddy/import", bytes.NewReader(body))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+	h.ImportCodeBuddyAuth(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if len(cfg.OpenAICompatibility) != 1 {
+		t.Fatalf("openai compatibility entries = %d, want 1", len(cfg.OpenAICompatibility))
+	}
+	entry := cfg.OpenAICompatibility[0]
+	if entry.AuthType != "codebuddy" || entry.AuthFile != authPath {
+		t.Fatalf("entry = %#v", entry)
+	}
+	if !strings.Contains(rec.Body.String(), "desktop.info") {
+		t.Fatalf("response did not include imported path: %s", rec.Body.String())
+	}
+}
+
+func TestImportCodeBuddyAuthByUpload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	root := t.TempDir()
+	configPath := filepath.Join(root, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("host: 127.0.0.1\nport: 8317\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg := &config.Config{AuthDir: root}
+	h := NewHandler(cfg, configPath, nil)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", "desktop.info")
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	_, _ = part.Write([]byte(`{"auth":{"accessToken":"access","refreshToken":"refresh"},"account":{"uid":"user"}}`))
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/codebuddy/import", &body)
+	ctx.Request.Header.Set("Content-Type", writer.FormDataContentType())
+	h.ImportCodeBuddyAuth(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	expected := filepath.Join(root, "workbuddy-desktop.info")
+	if _, err := os.Stat(expected); err != nil {
+		t.Fatalf("uploaded session was not saved at %s: %v", expected, err)
+	}
+	if len(cfg.OpenAICompatibility) != 1 || cfg.OpenAICompatibility[0].AuthFile != expected {
+		t.Fatalf("config entry = %#v", cfg.OpenAICompatibility)
+	}
+}
+
+func writeCodeBuddyTestSession(t *testing.T, path string) {
+	t.Helper()
+	data := []byte(`{"auth":{"accessToken":"access","refreshToken":"refresh"},"account":{"uid":"user"}}`)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+}

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -164,6 +164,7 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PATCH("/auth-files/status", s.mgmt.PatchAuthFileStatus)
 		mgmt.PATCH("/auth-files/fields", s.mgmt.PatchAuthFileFields)
 		mgmt.POST("/vertex/import", s.mgmt.ImportVertexCredential)
+		mgmt.POST("/codebuddy/import", s.mgmt.ImportCodeBuddyAuth)
 
 		mgmt.GET("/anthropic-auth-url", s.mgmt.RequestAnthropicToken)
 		mgmt.GET("/codex-auth-url", s.mgmt.RequestCodexToken)

--- a/internal/auth/codebuddy/credentials.go
+++ b/internal/auth/codebuddy/credentials.go
@@ -1,0 +1,470 @@
+// Package codebuddy contains the small credential client needed to call the
+// CodeBuddy desktop extension backend.
+//
+// CodeBuddy stores its session in a JSON .info file rather than exposing a
+// normal API key.  The access token must be accompanied by the account and
+// tenant headers below, and an expired token is refreshed through the same
+// backend before the request is sent.
+package codebuddy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// AuthType is the value used by OpenAI compatibility entries to opt into
+	// CodeBuddy session-file authentication.
+	AuthType = "codebuddy"
+
+	// DefaultBackendBaseURL is the CodeBuddy OpenAI-compatible API base URL.
+	DefaultBackendBaseURL = "https://copilot.tencent.com/v2"
+	// DefaultDomain is sent when the session does not specify a domain.
+	DefaultDomain = "www.codebuddy.cn"
+	// UserAgent identifies native CLIProxyAPI traffic to the CodeBuddy backend.
+	UserAgent = "codebuddy2openai/2.0"
+
+	// AuthDirEnv allows callers to override the platform-specific session path.
+	AuthDirEnv = "CODEBUDDY_AUTH_DIR"
+)
+
+// DefaultModels mirrors the model catalog exposed by codebuddy2api.  A
+// configured OpenAI compatibility entry may override it with its own models.
+var DefaultModels = []string{
+	"glm-5.2",
+	"glm-5.1",
+	"glm-5v-turbo",
+	"kimi-k2.7",
+	"kimi-k2.6",
+	"kimi-k2.5",
+	"deepseek-v4-pro",
+	"deepseek-v4-flash",
+	"minimax-m3-pay",
+	"hy3-preview-agent",
+	"auto",
+}
+
+// ErrAuthFileNotFound indicates that CodeBuddy is not logged in (or its
+// session directory does not exist).  It is intentionally not returned by
+// FindAuthFile so callers can treat an absent desktop login as no provider.
+var ErrAuthFileNotFound = errors.New("codebuddy auth file not found")
+
+type fileState struct {
+	modTime time.Time
+	size    int64
+}
+
+// Manager reads and refreshes one CodeBuddy .info file.  Manager methods are
+// safe for concurrent requests; a single refresh is serialized per file.
+type Manager struct {
+	path       string
+	refreshURL string
+
+	mu      sync.Mutex
+	session map[string]any
+	state   fileState
+}
+
+// NewCredentialManager creates a manager using CodeBuddy's public refresh
+// endpoint derived from DefaultBackendBaseURL.
+func NewCredentialManager(path string) (*Manager, error) {
+	return NewCredentialManagerWithRefreshURL(path, RefreshURLForBaseURL(DefaultBackendBaseURL))
+}
+
+// NewCredentialManagerWithRefreshURL is primarily useful for tests and for
+// deployments using a CodeBuddy-compatible gateway.
+func NewCredentialManagerWithRefreshURL(path, refreshURL string) (*Manager, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, ErrAuthFileNotFound
+	}
+	refreshURL = strings.TrimSpace(refreshURL)
+	if refreshURL == "" {
+		refreshURL = RefreshURLForBaseURL(DefaultBackendBaseURL)
+	}
+	return &Manager{path: path, refreshURL: refreshURL}, nil
+}
+
+// Path returns the source .info path.
+func (m *Manager) Path() string {
+	if m == nil {
+		return ""
+	}
+	return m.path
+}
+
+// GetHeaders returns a fresh set of headers for a backend request and refreshes
+// the access token when it is within one minute of expiry.
+func (m *Manager) GetHeaders(ctx context.Context, client *http.Client) (http.Header, error) {
+	if m == nil {
+		return nil, ErrAuthFileNotFound
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if err := m.loadLocked(); err != nil {
+		return nil, err
+	}
+	if needsRefresh(m.session) {
+		if err := m.refreshLocked(ctx, client); err != nil {
+			return nil, err
+		}
+	}
+	return headersFromSession(m.session), nil
+}
+
+// Refresh forces a refresh of the current session and writes the new auth
+// object back to the original .info file.
+func (m *Manager) Refresh(ctx context.Context, client *http.Client) error {
+	if m == nil {
+		return ErrAuthFileNotFound
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.loadLocked(); err != nil {
+		return err
+	}
+	return m.refreshLocked(ctx, client)
+}
+
+// Summary contains non-secret account information suitable for logs or model
+// registration.  Access and refresh tokens are never included.
+type Summary struct {
+	UID            string
+	Nickname       string
+	EnterpriseName string
+	EnterpriseID   string
+	TokenExpiresAt int64
+	TokenExpired   bool
+}
+
+// Summary returns account metadata without exposing token values.
+func (m *Manager) Summary() (Summary, error) {
+	if m == nil {
+		return Summary{}, ErrAuthFileNotFound
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.loadLocked(); err != nil {
+		return Summary{}, err
+	}
+	account := objectValue(m.session["account"])
+	auth := objectValue(m.session["auth"])
+	expiresAt := integerValue(auth["expiresAt"])
+	return Summary{
+		UID:            stringValue(account["uid"]),
+		Nickname:       stringValue(account["nickname"]),
+		EnterpriseName: stringValue(account["enterpriseName"]),
+		EnterpriseID:   stringValue(account["enterpriseId"]),
+		TokenExpiresAt: expiresAt,
+		TokenExpired:   needsRefresh(m.session),
+	}, nil
+}
+
+func (m *Manager) loadLocked() error {
+	info, errStat := os.Stat(m.path)
+	if errStat != nil {
+		if os.IsNotExist(errStat) {
+			return ErrAuthFileNotFound
+		}
+		return fmt.Errorf("stat CodeBuddy auth file: %w", errStat)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("CodeBuddy auth path is a directory: %s", m.path)
+	}
+	state := fileState{modTime: info.ModTime(), size: info.Size()}
+	if m.session != nil && state == m.state {
+		return nil
+	}
+	raw, errRead := os.ReadFile(m.path)
+	if errRead != nil {
+		return fmt.Errorf("read CodeBuddy auth file: %w", errRead)
+	}
+	var session map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &session); errUnmarshal != nil {
+		return fmt.Errorf("decode CodeBuddy auth file: %w", errUnmarshal)
+	}
+	if len(session) == 0 {
+		return fmt.Errorf("CodeBuddy auth file is empty: %s", m.path)
+	}
+	m.session = session
+	m.state = state
+	return nil
+}
+
+func (m *Manager) refreshLocked(ctx context.Context, client *http.Client) error {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	auth := objectValue(m.session["auth"])
+	headers := headersFromSession(m.session)
+	headers.Set("X-Refresh-Token", stringValue(auth["refreshToken"]))
+	headers.Set("X-Auth-Refresh-Source", "plugin")
+
+	body := strings.NewReader(`{}`)
+	req, errRequest := http.NewRequestWithContext(ctx, http.MethodPost, m.refreshURL, body)
+	if errRequest != nil {
+		return fmt.Errorf("build CodeBuddy token refresh request: %w", errRequest)
+	}
+	req.Header = headers
+	resp, errDo := client.Do(req)
+	if errDo != nil {
+		return fmt.Errorf("refresh CodeBuddy token: %w", errDo)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, errRead := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	if errRead != nil {
+		return fmt.Errorf("read CodeBuddy token refresh response: %w", errRead)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("refresh CodeBuddy token: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	var envelope map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &envelope); errUnmarshal != nil {
+		return fmt.Errorf("decode CodeBuddy token refresh response: %w", errUnmarshal)
+	}
+	if code := integerValue(envelope["code"]); code != 0 {
+		return fmt.Errorf("refresh CodeBuddy token failed: %s", stringValue(envelope["msg"]))
+	}
+	newAuth := objectValue(envelope["data"])
+	if len(newAuth) == 0 || stringValue(newAuth["accessToken"]) == "" {
+		return fmt.Errorf("refresh CodeBuddy token failed: response did not contain accessToken")
+	}
+	if stringValue(newAuth["domain"]) == "" {
+		newAuth["domain"] = stringValue(auth["domain"])
+	}
+	nowMillis := time.Now().UnixMilli()
+	newAuth["lastRefreshTime"] = nowMillis
+	if integerValue(newAuth["expiresAt"]) == 0 {
+		if expiresIn := integerValue(newAuth["expiresIn"]); expiresIn > 0 {
+			newAuth["expiresAt"] = nowMillis + expiresIn*1000
+		}
+	}
+	if integerValue(newAuth["refreshExpiresAt"]) == 0 {
+		if expiresIn := integerValue(newAuth["refreshExpiresIn"]); expiresIn > 0 {
+			newAuth["refreshExpiresAt"] = nowMillis + expiresIn*1000
+		}
+	}
+	m.session["auth"] = newAuth
+	if errWrite := m.writeLocked(); errWrite != nil {
+		return errWrite
+	}
+	return nil
+}
+
+func (m *Manager) writeLocked() error {
+	raw, errMarshal := json.MarshalIndent(m.session, "", "  ")
+	if errMarshal != nil {
+		return fmt.Errorf("encode CodeBuddy auth file: %w", errMarshal)
+	}
+	tmpPath := m.path + ".tmp"
+	if errWrite := os.WriteFile(tmpPath, raw, 0o600); errWrite != nil {
+		return fmt.Errorf("write CodeBuddy auth temp file: %w", errWrite)
+	}
+	if errRename := os.Rename(tmpPath, m.path); errRename != nil {
+		// os.Rename cannot replace an existing file on some Windows versions.
+		// The fallback is limited to the exact credential file and is only used
+		// after the complete replacement contents have been written.
+		if runtime.GOOS == "windows" {
+			if errRemove := os.Remove(m.path); errRemove == nil || os.IsNotExist(errRemove) {
+				if errRetry := os.Rename(tmpPath, m.path); errRetry == nil {
+					m.state = fileState{}
+					return nil
+				}
+			}
+		}
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("replace CodeBuddy auth file: %w", errRename)
+	}
+	m.state = fileState{}
+	return nil
+}
+
+func needsRefresh(session map[string]any) bool {
+	auth := objectValue(session["auth"])
+	if stringValue(auth["accessToken"]) == "" {
+		return true
+	}
+	expiresAt := integerValue(auth["expiresAt"])
+	if expiresAt == 0 {
+		return stringValue(auth["refreshToken"]) != ""
+	}
+	return time.Now().UnixMilli() >= expiresAt-60_000
+}
+
+func headersFromSession(session map[string]any) http.Header {
+	auth := objectValue(session["auth"])
+	account := objectValue(session["account"])
+	domain := stringValue(auth["domain"])
+	if domain == "" {
+		domain = DefaultDomain
+	}
+	h := make(http.Header)
+	h.Set("Content-Type", "application/json")
+	h.Set("Accept", "application/json")
+	h.Set("Authorization", "Bearer "+stringValue(auth["accessToken"]))
+	h.Set("X-User-Id", stringValue(account["uid"]))
+	h.Set("X-Enterprise-Id", stringValue(account["enterpriseId"]))
+	h.Set("X-Tenant-Id", stringValue(account["enterpriseId"]))
+	h.Set("X-Domain", domain)
+	h.Set("User-Agent", UserAgent)
+	return h
+}
+
+func objectValue(value any) map[string]any {
+	if out, ok := value.(map[string]any); ok && out != nil {
+		return out
+	}
+	return map[string]any{}
+}
+
+func stringValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case json.Number:
+		return typed.String()
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	case float32:
+		return strconv.FormatFloat(float64(typed), 'f', -1, 32)
+	case int:
+		return strconv.Itoa(typed)
+	case int64:
+		return strconv.FormatInt(typed, 10)
+	default:
+		return ""
+	}
+}
+
+func integerValue(value any) int64 {
+	switch typed := value.(type) {
+	case int:
+		return int64(typed)
+	case int64:
+		return typed
+	case int32:
+		return int64(typed)
+	case float64:
+		return int64(typed)
+	case json.Number:
+		if parsed, errParse := typed.Int64(); errParse == nil {
+			return parsed
+		}
+	case string:
+		if parsed, errParse := strconv.ParseInt(strings.TrimSpace(typed), 10, 64); errParse == nil {
+			return parsed
+		}
+	}
+	return 0
+}
+
+// FindAuthFile returns the configured .info file, or the first sorted .info
+// file in CodeBuddy's platform-specific session directory.
+func FindAuthFile(authDir, authFile string) (string, error) {
+	if path := expandPath(authFile); path != "" {
+		if info, errStat := os.Stat(path); errStat == nil && !info.IsDir() {
+			return path, nil
+		} else if errStat != nil && !os.IsNotExist(errStat) {
+			return "", errStat
+		}
+		return "", nil
+	}
+	dir := expandPath(authDir)
+	if dir == "" {
+		dir = expandPath(os.Getenv(AuthDirEnv))
+	}
+	if dir == "" {
+		dir = defaultAuthDir()
+	}
+	entries, errReadDir := os.ReadDir(dir)
+	if errReadDir != nil {
+		if os.IsNotExist(errReadDir) {
+			return "", nil
+		}
+		return "", errReadDir
+	}
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".info") {
+			continue
+		}
+		paths = append(paths, filepath.Join(dir, entry.Name()))
+	}
+	sort.Strings(paths)
+	if len(paths) == 0 {
+		return "", nil
+	}
+	return paths[0], nil
+}
+
+func defaultAuthDir() string {
+	home, errHome := os.UserHomeDir()
+	if errHome != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	switch runtime.GOOS {
+	case "windows":
+		local := strings.TrimSpace(os.Getenv("LOCALAPPDATA"))
+		if local == "" {
+			local = filepath.Join(home, "AppData", "Local")
+		}
+		return filepath.Join(local, "CodeBuddyExtension", "Data", "Public", "auth")
+	case "darwin":
+		return filepath.Join(home, "Library", "Application Support", "CodeBuddyExtension", "Data", "Public", "auth")
+	default:
+		dataHome := strings.TrimSpace(os.Getenv("XDG_DATA_HOME"))
+		if dataHome == "" {
+			dataHome = filepath.Join(home, ".local", "share")
+		}
+		return filepath.Join(dataHome, "CodeBuddyExtension", "Data", "Public", "auth")
+	}
+}
+
+// RefreshURLForBaseURL derives the plugin refresh endpoint from a configured
+// CodeBuddy-compatible base URL.
+func RefreshURLForBaseURL(baseURL string) string {
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		baseURL = DefaultBackendBaseURL
+	}
+	u, errParse := url.Parse(baseURL)
+	if errParse != nil || u.Scheme == "" || u.Host == "" {
+		return strings.TrimRight(DefaultBackendBaseURL, "/") + "/plugin/auth/token/refresh"
+	}
+	path := strings.TrimRight(u.Path, "/")
+	if path == "" || path == "/" {
+		path = "/v2"
+	}
+	u.Path = path + "/plugin/auth/token/refresh"
+	u.RawQuery = ""
+	u.Fragment = ""
+	return strings.TrimRight(u.String(), "/")
+}
+
+func expandPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	return filepath.Clean(os.ExpandEnv(path))
+}

--- a/internal/auth/codebuddy/credentials_test.go
+++ b/internal/auth/codebuddy/credentials_test.go
@@ -1,0 +1,179 @@
+package codebuddy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestManagerGetHeaders(t *testing.T) {
+	path := writeTestSession(t, map[string]any{
+		"accessToken":  "access-token",
+		"refreshToken": "refresh-token",
+		"expiresAt":    time.Now().Add(time.Hour).UnixMilli(),
+		"domain":       "tenant.example.com",
+	})
+
+	manager, err := NewCredentialManager(path)
+	if err != nil {
+		t.Fatalf("NewCredentialManager() error = %v", err)
+	}
+	headers, err := manager.GetHeaders(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("GetHeaders() error = %v", err)
+	}
+
+	want := map[string]string{
+		"Authorization":   "Bearer access-token",
+		"X-User-Id":       "user-1",
+		"X-Enterprise-Id": "enterprise-1",
+		"X-Tenant-Id":     "enterprise-1",
+		"X-Domain":        "tenant.example.com",
+		"User-Agent":      UserAgent,
+	}
+	for key, value := range want {
+		if got := headers.Get(key); got != value {
+			t.Errorf("header %s = %q, want %q", key, got, value)
+		}
+	}
+	if got := headers.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+}
+
+func TestFindAuthFile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestSessionAt(t, filepath.Join(dir, "z-account.info"), map[string]any{
+		"accessToken": "z",
+	})
+	writeTestSessionAt(t, filepath.Join(dir, "a-account.info"), map[string]any{
+		"accessToken": "a",
+	})
+	if err := os.WriteFile(filepath.Join(dir, "ignored.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write ignored file: %v", err)
+	}
+
+	got, err := FindAuthFile(dir, "")
+	if err != nil {
+		t.Fatalf("FindAuthFile() error = %v", err)
+	}
+	if want := filepath.Join(dir, "a-account.info"); got != want {
+		t.Fatalf("FindAuthFile() = %q, want %q", got, want)
+	}
+
+	exact := filepath.Join(dir, "z-account.info")
+	got, err = FindAuthFile(dir, exact)
+	if err != nil {
+		t.Fatalf("FindAuthFile(exact) error = %v", err)
+	}
+	if got != exact {
+		t.Fatalf("FindAuthFile(exact) = %q, want %q", got, exact)
+	}
+}
+
+func TestManagerRefreshesAndWritesSession(t *testing.T) {
+	path := writeTestSession(t, map[string]any{
+		"accessToken":  "old-access",
+		"refreshToken": "old-refresh",
+		"expiresAt":    time.Now().Add(-time.Minute).UnixMilli(),
+		"domain":       "tenant.example.com",
+	})
+
+	var refreshRequestHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/plugin/auth/token/refresh" {
+			t.Errorf("refresh path = %q", r.URL.Path)
+		}
+		refreshRequestHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":0,"data":{"accessToken":"new-access","refreshToken":"new-refresh","expiresAt":4102444800000,"domain":"refreshed.example.com"}}`))
+	}))
+	defer server.Close()
+
+	manager, err := NewCredentialManagerWithRefreshURL(path, server.URL+"/v2/plugin/auth/token/refresh")
+	if err != nil {
+		t.Fatalf("NewCredentialManagerWithRefreshURL() error = %v", err)
+	}
+	headers, err := manager.GetHeaders(context.Background(), server.Client())
+	if err != nil {
+		t.Fatalf("GetHeaders() error = %v", err)
+	}
+	if got := headers.Get("Authorization"); got != "Bearer new-access" {
+		t.Fatalf("Authorization = %q, want refreshed token", got)
+	}
+	if got := headers.Get("X-Domain"); got != "refreshed.example.com" {
+		t.Fatalf("X-Domain = %q, want refreshed domain", got)
+	}
+	if got := refreshRequestHeaders.Get("X-Refresh-Token"); got != "old-refresh" {
+		t.Fatalf("X-Refresh-Token = %q, want old-refresh", got)
+	}
+	if got := refreshRequestHeaders.Get("X-Auth-Refresh-Source"); got != "plugin" {
+		t.Fatalf("X-Auth-Refresh-Source = %q, want plugin", got)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read refreshed auth file: %v", err)
+	}
+	var session map[string]any
+	if err := json.Unmarshal(raw, &session); err != nil {
+		t.Fatalf("decode refreshed auth file: %v", err)
+	}
+	auth, ok := session["auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("refreshed auth object missing: %s", raw)
+	}
+	if got, _ := auth["accessToken"].(string); got != "new-access" {
+		t.Fatalf("written accessToken = %q, want new-access", got)
+	}
+}
+
+func TestRefreshURLForBaseURL(t *testing.T) {
+	tests := []struct {
+		baseURL string
+		want    string
+	}{
+		{baseURL: "https://copilot.tencent.com/v2", want: "https://copilot.tencent.com/v2/plugin/auth/token/refresh"},
+		{baseURL: "https://gateway.example/api/v1/", want: "https://gateway.example/api/v1/plugin/auth/token/refresh"},
+	}
+	for _, tt := range tests {
+		if got := RefreshURLForBaseURL(tt.baseURL); got != tt.want {
+			t.Errorf("RefreshURLForBaseURL(%q) = %q, want %q", tt.baseURL, got, tt.want)
+		}
+	}
+}
+
+func writeTestSession(t *testing.T, auth map[string]any) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "account.info")
+	writeTestSessionAt(t, path, auth)
+	return path
+}
+
+func writeTestSessionAt(t *testing.T, path string, auth map[string]any) {
+	t.Helper()
+	session := map[string]any{
+		"account": map[string]any{
+			"uid":          "user-1",
+			"enterpriseId": "enterprise-1",
+			"nickname":     "Test User",
+		},
+		"auth": auth,
+	}
+	raw, err := json.Marshal(session)
+	if err != nil {
+		t.Fatalf("marshal test session: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write test session: %v", err)
+	}
+	if !strings.HasSuffix(path, ".info") {
+		t.Fatalf("test session path must use .info: %s", path)
+	}
+}

--- a/internal/config/codebuddy_test.go
+++ b/internal/config/codebuddy_test.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codebuddy"
+)
+
+func TestSanitizeOpenAICompatibilityCodeBuddyDefaults(t *testing.T) {
+	cfg := &Config{OpenAICompatibility: []OpenAICompatibility{{
+		Name:     "  codebuddy  ",
+		AuthType: " CodeBuddy ",
+	}}}
+	cfg.SanitizeOpenAICompatibility()
+
+	entry := cfg.OpenAICompatibility[0]
+	if entry.Name != "codebuddy" {
+		t.Fatalf("Name = %q, want codebuddy", entry.Name)
+	}
+	if entry.AuthType != codebuddy.AuthType {
+		t.Fatalf("AuthType = %q, want %q", entry.AuthType, codebuddy.AuthType)
+	}
+	if entry.BaseURL != codebuddy.DefaultBackendBaseURL {
+		t.Fatalf("BaseURL = %q, want %q", entry.BaseURL, codebuddy.DefaultBackendBaseURL)
+	}
+	if len(entry.Models) != len(codebuddy.DefaultModels) {
+		t.Fatalf("model count = %d, want %d", len(entry.Models), len(codebuddy.DefaultModels))
+	}
+	for i, model := range entry.Models {
+		if model.Name != codebuddy.DefaultModels[i] || model.Alias != codebuddy.DefaultModels[i] {
+			t.Errorf("model[%d] = %#v, want name/alias %q", i, model, codebuddy.DefaultModels[i])
+		}
+	}
+}

--- a/internal/config/config_normalization.go
+++ b/internal/config/config_normalization.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codebuddy"
 	sdkpluginstore "github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginstore"
 )
 
@@ -112,8 +113,19 @@ func (cfg *Config) SanitizeOpenAICompatibility() {
 	for i := range cfg.OpenAICompatibility {
 		e := cfg.OpenAICompatibility[i]
 		e.Name = strings.TrimSpace(e.Name)
+		e.AuthType = strings.ToLower(strings.TrimSpace(e.AuthType))
+		e.AuthDir = strings.TrimSpace(e.AuthDir)
+		e.AuthFile = strings.TrimSpace(e.AuthFile)
+		if e.AuthType == codebuddy.AuthType && len(e.Models) == 0 {
+			for _, modelName := range codebuddy.DefaultModels {
+				e.Models = append(e.Models, OpenAICompatibilityModel{Name: modelName, Alias: modelName})
+			}
+		}
 		e.Prefix = normalizeModelPrefix(e.Prefix)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
+		if e.BaseURL == "" && e.AuthType == codebuddy.AuthType {
+			e.BaseURL = codebuddy.DefaultBackendBaseURL
+		}
 		e.Headers = NormalizeHeaders(e.Headers)
 		if e.BaseURL == "" {
 			// Skip providers with no base-url; treated as removed

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -571,6 +571,23 @@ type OpenAICompatibility struct {
 	// Name is the identifier for this OpenAI compatibility configuration.
 	Name string `yaml:"name" json:"name"`
 
+	// AuthType selects a provider-specific credential mechanism.  The built-in
+	// "codebuddy" value reads a CodeBuddy desktop .info session file while
+	// retaining the normal OpenAI-compatible request/response pipeline.
+	AuthType string `yaml:"auth-type,omitempty" json:"auth-type,omitempty"`
+
+	// AuthDir optionally overrides the directory searched for provider session
+	// files.  It is used by AuthType=codebuddy.
+	AuthDir string `yaml:"auth-dir,omitempty" json:"auth-dir,omitempty"`
+
+	// AuthFile optionally selects one exact provider session file.  It is used
+	// by AuthType=codebuddy and takes precedence over AuthDir.
+	AuthFile string `yaml:"auth-file,omitempty" json:"auth-file,omitempty"`
+
+	// Desensitize enables the lightweight CodeBuddy content-filter mitigation
+	// for system/developer text and tool descriptions.
+	Desensitize bool `yaml:"desensitize,omitempty" json:"desensitize,omitempty"`
+
 	// Priority controls selection preference when multiple providers or credentials match.
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`

--- a/internal/runtime/executor/codebuddy_support.go
+++ b/internal/runtime/executor/codebuddy_support.go
@@ -1,0 +1,484 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codebuddy"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+type codeBuddyRuntime struct {
+	mu       sync.Mutex
+	managers map[string]*codebuddy.Manager
+}
+
+func (e *OpenAICompatExecutor) isCodeBuddyAuth(auth *cliproxyauth.Auth) bool {
+	if auth != nil && auth.Attributes != nil {
+		if strings.EqualFold(strings.TrimSpace(auth.Attributes["auth_type"]), codebuddy.AuthType) {
+			return true
+		}
+	}
+	return strings.EqualFold(e.provider, util.OpenAICompatibleProviderKey(codebuddy.AuthType))
+}
+
+func (e *OpenAICompatExecutor) codeBuddyManager(auth *cliproxyauth.Auth) (*codebuddy.Manager, error) {
+	if auth == nil || auth.Attributes == nil {
+		return nil, codebuddy.ErrAuthFileNotFound
+	}
+	path := strings.TrimSpace(auth.Attributes["codebuddy_auth_file"])
+	if path == "" {
+		return nil, codebuddy.ErrAuthFileNotFound
+	}
+	baseURL := strings.TrimSpace(auth.Attributes["base_url"])
+	if baseURL == "" {
+		baseURL = codebuddy.DefaultBackendBaseURL
+	}
+	key := path + "\x00" + baseURL
+	e.codeBuddy.mu.Lock()
+	defer e.codeBuddy.mu.Unlock()
+	if e.codeBuddy.managers == nil {
+		e.codeBuddy.managers = make(map[string]*codebuddy.Manager)
+	}
+	if manager := e.codeBuddy.managers[key]; manager != nil {
+		return manager, nil
+	}
+	manager, errManager := codebuddy.NewCredentialManagerWithRefreshURL(path, codebuddy.RefreshURLForBaseURL(baseURL))
+	if errManager != nil {
+		return nil, errManager
+	}
+	e.codeBuddy.managers[key] = manager
+	return manager, nil
+}
+
+// prepareProviderRequest adds either regular OpenAI-compatible credentials or
+// the complete CodeBuddy session header set.  client is used for refreshes so
+// the same per-auth proxy policy applies to token refresh and generation.
+func (e *OpenAICompatExecutor) prepareProviderRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request, client *http.Client, apiKey string) error {
+	if req == nil {
+		return nil
+	}
+	if e.isCodeBuddyAuth(auth) {
+		manager, errManager := e.codeBuddyManager(auth)
+		if errManager != nil {
+			return errManager
+		}
+		headers, errHeaders := manager.GetHeaders(ctx, client)
+		if errHeaders != nil {
+			return errHeaders
+		}
+		for key, values := range headers {
+			// Keep request-specific representation headers selected by the
+			// executor (notably multipart Content-Type and streaming Accept).
+			// Authentication headers must always come from the current session.
+			if (strings.EqualFold(key, "Content-Type") || strings.EqualFold(key, "Accept")) && req.Header.Get(key) != "" {
+				continue
+			}
+			req.Header.Del(key)
+			for _, value := range values {
+				req.Header.Add(key, value)
+			}
+		}
+	} else if strings.TrimSpace(apiKey) != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	if auth != nil {
+		util.ApplyCustomHeadersFromAttrs(req, auth.Attributes)
+	}
+	if e.isCodeBuddyAuth(auth) {
+		req.Header.Set("User-Agent", codebuddy.UserAgent)
+	}
+	return nil
+}
+
+func forceCodeBuddyStreamPayload(payload []byte, auth *cliproxyauth.Auth, enabled bool) []byte {
+	if !enabled || auth == nil || auth.Attributes == nil ||
+		!strings.EqualFold(strings.TrimSpace(auth.Attributes["auth_type"]), codebuddy.AuthType) {
+		return payload
+	}
+	payload = helps.SetBoolIfDifferent(payload, "stream", true)
+	return helps.SetBoolIfDifferent(payload, "stream_options.include_usage", true)
+}
+
+// sanitizeCodeBuddyChatPayload mirrors codebuddy2api's allow-list.  It keeps
+// the backend request stable when a source protocol carries fields that are
+// meaningful to the client but not accepted by CodeBuddy's chat endpoint.
+func sanitizeCodeBuddyChatPayload(payload []byte, auth *cliproxyauth.Auth, compatDesensitize bool) []byte {
+	if auth == nil || auth.Attributes == nil ||
+		!strings.EqualFold(strings.TrimSpace(auth.Attributes["auth_type"]), codebuddy.AuthType) {
+		return payload
+	}
+	var body map[string]json.RawMessage
+	if errUnmarshal := json.Unmarshal(payload, &body); errUnmarshal != nil {
+		return payload
+	}
+	allowed := map[string]struct{}{
+		"model": {}, "messages": {}, "tools": {}, "tool_choice": {},
+		"temperature": {}, "max_tokens": {}, "max_completion_tokens": {},
+		"top_p": {}, "stream": {}, "stream_options": {}, "stop": {},
+		"presence_penalty": {}, "frequency_penalty": {}, "n": {},
+		"response_format": {}, "seed": {}, "user": {}, "reasoning_effort": {},
+		"verbosity": {}, "reasoning_summary": {},
+	}
+	for key := range body {
+		if _, ok := allowed[key]; !ok {
+			delete(body, key)
+		}
+	}
+	if compatDesensitize {
+		desensitizeCodeBuddyBody(body)
+	}
+	encoded, errMarshal := json.Marshal(body)
+	if errMarshal != nil {
+		return payload
+	}
+	return encoded
+}
+
+var codeBuddySensitivePattern = func() *regexp.Regexp {
+	terms := []string{
+		"DoS", "DDoS", "exploit", "credential testing", "credential stuffing",
+		"supply chain compromise", "supply-chain compromise", "detection evasion",
+		"C2 frameworks", "C2 framework", "command and control", "malicious purposes",
+		"malicious intent", "mass targeting", "brute force", "brute-force",
+		"privilege escalation", "reverse shell", "remote code execution", "SQL injection",
+		"XSS", "CSRF", "phishing", "malware", "ransomware", "keylogger", "rootkit",
+		"backdoor", "botnet", "zero-day", "0day", "vulnerability", "vulnerabilities",
+		"red teaming", "red-teaming", "sandbox", "sandboxing", "sandboxed", "unsandboxed",
+		"escalated privileges", "escalated", "escalation", "destructive action",
+		"destructive command", "destructive", "attack", "attacks", "cybersecurity",
+		"security review", "exploit development", "hacking", "penetration testing",
+		"penetration test", "injection", "weaponize", "weaponized", "harmful", "dangerous",
+		"abuse", "abusive", "illegal", "terrorist", "terrorism", "bomb", "weapon",
+		"weapons", "drug", "drugs", "narcotic", "suicide", "self-harm", "murder",
+		"kill", "violence", "violent", "Claude Code", "Claude Opus", "Claude Sonnet",
+		"Claude Haiku", "Claude Fable", "Anthropic", "Co-Authored-By", "noreply@anthropic.com",
+	}
+	sort.Slice(terms, func(i, j int) bool { return len(terms[i]) > len(terms[j]) })
+	parts := make([]string, 0, len(terms))
+	for _, term := range terms {
+		parts = append(parts, regexp.QuoteMeta(term))
+	}
+	return regexp.MustCompile("(?i)" + strings.Join(parts, "|"))
+}()
+
+func desensitizeCodeBuddyText(text string) string {
+	if text == "" {
+		return text
+	}
+	return codeBuddySensitivePattern.ReplaceAllStringFunc(text, func(match string) string {
+		if len(match) < 2 {
+			return match
+		}
+		return match[:1] + "\u200b" + match[1:]
+	})
+}
+
+func desensitizeCodeBuddyBody(body map[string]json.RawMessage) {
+	var messages []map[string]any
+	if raw, ok := body["messages"]; ok && json.Unmarshal(raw, &messages) == nil {
+		for _, message := range messages {
+			role, _ := message["role"].(string)
+			if role != "system" && role != "developer" && !(role == "user" && looksLikeCodeBuddyHarnessUser(message["content"])) {
+				continue
+			}
+			message["content"] = desensitizeCodeBuddyContent(role, message["content"])
+		}
+		if encoded, errMarshal := json.Marshal(messages); errMarshal == nil {
+			body["messages"] = encoded
+		}
+	}
+	if raw, ok := body["tools"]; ok {
+		var tools []any
+		if json.Unmarshal(raw, &tools) == nil {
+			desensitizeCodeBuddyValue(tools)
+			if encoded, errMarshal := json.Marshal(tools); errMarshal == nil {
+				body["tools"] = encoded
+			}
+		}
+	}
+}
+
+func desensitizeCodeBuddyContent(role string, content any) any {
+	switch typed := content.(type) {
+	case string:
+		return desensitizeCodeBuddyHarnessText(role, typed)
+	case []any:
+		for i := range typed {
+			if block, ok := typed[i].(map[string]any); ok && block["type"] == "text" {
+				block["text"] = desensitizeCodeBuddyHarnessText(role, fmt.Sprint(block["text"]))
+			}
+		}
+	}
+	return content
+}
+
+func desensitizeCodeBuddyHarnessText(role, text string) string {
+	if compacted, ok := compactCodeBuddyHarnessText(role, text); ok {
+		return desensitizeCodeBuddyText(compacted)
+	}
+	return desensitizeCodeBuddyText(pruneCodeBuddyRuntimeFragments(role, text))
+}
+
+func compactCodeBuddyHarnessText(role, text string) (string, bool) {
+	if role == "system" {
+		if strings.Contains(text, "You are Claude Code") {
+			return "You are a coding assistant. Be precise, helpful, concise, and safe. Use available tools when needed, follow repository instructions, and keep the user informed.", true
+		}
+		if strings.Contains(text, "You are a coding agent running in the Codex CLI") || strings.Contains(text, "# How you work") {
+			return "You are a coding assistant in Codex CLI. Be precise, helpful, concise, and safe. Use available tools when needed, follow repository instructions, and keep the user informed.", true
+		}
+		if strings.Contains(text, "<permissions instructions>") || strings.Contains(text, "Filesystem sandboxing defines which files can be read or written.") {
+			return "Runtime permissions apply: filesystem access may be sandboxed, network may be restricted, and some commands may require user approval.", true
+		}
+		if strings.Contains(text, "<skills_instructions>") || strings.Contains(text, "### Available skills") || strings.Contains(text, "### How to use skills") {
+			return "Runtime skill metadata is available. Use relevant skills only when explicitly requested or clearly applicable.", true
+		}
+	}
+	if role == "user" && looksLikeCodeBuddyHarnessUser(text) {
+		return "Repository instructions and environment context are provided. Follow repository guidance while answering the user's actual request.", true
+	}
+	return "", false
+}
+
+func pruneCodeBuddyRuntimeFragments(role, text string) string {
+	replacements := []struct {
+		start       string
+		end         string
+		replacement string
+	}{
+		{"<environment_context>", "</environment_context>", "Environment context is provided by the harness."},
+		{"<permissions instructions>", "</permissions instructions>", "Runtime permissions apply: filesystem access may be sandboxed, network may be restricted, and some commands may require user approval."},
+		{"<collaboration_mode>", "</collaboration_mode>", "Collaboration mode instructions are provided by the harness."},
+		{"<skills_instructions>", "</skills_instructions>", "Runtime skill metadata is available. Use relevant skills only when explicitly requested or clearly applicable."},
+		{"<plugins_instructions>", "</plugins_instructions>", "Runtime plugin metadata is available when relevant."},
+		{"<system-reminder>", "</system-reminder>", "Runtime reminder context is provided by the harness."},
+	}
+	for _, item := range replacements {
+		for {
+			start := strings.Index(text, item.start)
+			if start < 0 {
+				break
+			}
+			relEnd := strings.Index(text[start+len(item.start):], item.end)
+			if relEnd < 0 {
+				break
+			}
+			end := start + len(item.start) + relEnd + len(item.end)
+			text = text[:start] + "\n\n" + item.replacement + "\n\n" + text[end:]
+		}
+	}
+	for _, marker := range []string{
+		"The following deferred tools are now available via ToolSearch.",
+		"Available agent types for the Agent tool:",
+		"The following skills are available for use with the Skill tool:",
+		"## MCP Server Instructions",
+	} {
+		if index := strings.Index(text, marker); index >= 0 {
+			text = strings.TrimSpace(text[:index] + "\n\nRuntime tool, agent, skill, and MCP metadata is available separately.")
+		}
+	}
+	if role == "user" && looksLikeCodeBuddyHarnessUser(text) {
+		return "Repository instructions and durable user context are provided. Follow repository guidance while answering the user's actual request."
+	}
+	return strings.TrimSpace(text)
+}
+
+func desensitizeCodeBuddyValue(value any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, item := range typed {
+			if key == "description" || key == "title" {
+				delete(typed, key)
+				continue
+			}
+			desensitizeCodeBuddyValue(item)
+		}
+	case []any:
+		for _, item := range typed {
+			desensitizeCodeBuddyValue(item)
+		}
+	}
+}
+
+func looksLikeCodeBuddyHarnessUser(content any) bool {
+	text := ""
+	switch typed := content.(type) {
+	case string:
+		text = typed
+	case []any:
+		var parts []string
+		for _, item := range typed {
+			if block, ok := item.(map[string]any); ok && block["type"] == "text" {
+				parts = append(parts, fmt.Sprint(block["text"]))
+			}
+		}
+		text = strings.Join(parts, "")
+	}
+	for _, marker := range []string{"# AGENTS.md instructions", "<environment_context>", "<permissions instructions>", "<collaboration_mode>", "<skills_instructions>", "<system-reminder>", "# claudeMd"} {
+		if strings.Contains(text, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+type codeBuddyToolCall struct {
+	ID        string
+	Name      string
+	Arguments string
+}
+
+// collectCodeBuddyStream converts the backend's mandatory Chat SSE response
+// into one regular Chat completion for a client that did not request stream.
+func collectCodeBuddyStream(raw []byte) ([]byte, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if json.Valid(trimmed) {
+		return trimmed, nil
+	}
+	var content strings.Builder
+	toolCalls := make(map[int]*codeBuddyToolCall)
+	model := "unknown"
+	finishReason := ""
+	var usage map[string]any
+	seenEvent := false
+	for _, line := range bytes.Split(raw, []byte{'\n'}) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		data := bytes.TrimSpace(line[len("data:"):])
+		if bytes.Equal(data, []byte("[DONE]")) {
+			break
+		}
+		var chunk map[string]any
+		if errUnmarshal := json.Unmarshal(data, &chunk); errUnmarshal != nil {
+			continue
+		}
+		seenEvent = true
+		if value, ok := chunk["model"].(string); ok && value != "" {
+			model = value
+		}
+		if value, ok := chunk["usage"].(map[string]any); ok {
+			usage = value
+		}
+		choices, _ := chunk["choices"].([]any)
+		for _, rawChoice := range choices {
+			choice, _ := rawChoice.(map[string]any)
+			if choice == nil {
+				continue
+			}
+			if value, ok := choice["finish_reason"].(string); ok && value != "" {
+				finishReason = value
+			}
+			delta, _ := choice["delta"].(map[string]any)
+			if delta == nil {
+				continue
+			}
+			if value, ok := delta["content"].(string); ok {
+				content.WriteString(value)
+			}
+			rawCalls, _ := delta["tool_calls"].([]any)
+			for _, rawCall := range rawCalls {
+				call, _ := rawCall.(map[string]any)
+				if call == nil {
+					continue
+				}
+				index := intValue(call["index"])
+				slot := toolCalls[index]
+				if slot == nil {
+					slot = &codeBuddyToolCall{}
+					toolCalls[index] = slot
+				}
+				if value, ok := call["id"].(string); ok && value != "" {
+					slot.ID = value
+				}
+				fn, _ := call["function"].(map[string]any)
+				if fn == nil {
+					continue
+				}
+				if value, ok := fn["name"].(string); ok && value != "" {
+					slot.Name = value
+				}
+				if value, ok := fn["arguments"].(string); ok {
+					slot.Arguments += value
+				}
+			}
+		}
+	}
+	if !seenEvent {
+		return nil, fmt.Errorf("CodeBuddy upstream returned neither JSON nor SSE data")
+	}
+
+	orderedIndexes := make([]int, 0, len(toolCalls))
+	for index := range toolCalls {
+		orderedIndexes = append(orderedIndexes, index)
+	}
+	sort.Ints(orderedIndexes)
+	var encodedToolCalls []any
+	for _, index := range orderedIndexes {
+		call := toolCalls[index]
+		encodedToolCalls = append(encodedToolCalls, map[string]any{
+			"id":   call.ID,
+			"type": "function",
+			"function": map[string]any{
+				"name":      call.Name,
+				"arguments": call.Arguments,
+			},
+		})
+	}
+	message := map[string]any{"role": "assistant", "content": nil}
+	if content.Len() > 0 {
+		message["content"] = content.String()
+	}
+	if len(encodedToolCalls) > 0 {
+		message["tool_calls"] = encodedToolCalls
+		if finishReason == "" {
+			finishReason = "tool_calls"
+		}
+	}
+	if finishReason == "" {
+		finishReason = "stop"
+	}
+	result := map[string]any{
+		"id":      "chatcmpl-" + strings.ReplaceAll(uuid.NewString(), "-", ""),
+		"object":  "chat.completion",
+		"created": 0,
+		"model":   model,
+		"choices": []any{map[string]any{"index": 0, "message": message, "finish_reason": finishReason}},
+	}
+	if usage != nil {
+		result["usage"] = usage
+	} else {
+		result["usage"] = map[string]any{"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+	}
+	return json.Marshal(result)
+}
+
+func intValue(value any) int {
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case float64:
+		return int(typed)
+	case json.Number:
+		if parsed, errParse := typed.Int64(); errParse == nil {
+			return int(parsed)
+		}
+	case string:
+		var parsed int
+		_, _ = fmt.Sscanf(typed, "%d", &parsed)
+		return parsed
+	}
+	return 0
+}

--- a/internal/runtime/executor/codebuddy_support_test.go
+++ b/internal/runtime/executor/codebuddy_support_test.go
@@ -1,0 +1,210 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestCodeBuddyExecuteAggregatesSSEAndInjectsSessionHeaders(t *testing.T) {
+	authPath := writeExecutorCodeBuddySession(t, time.Now().Add(time.Hour).UnixMilli())
+	var (
+		gotBody    []byte
+		gotHeaders http.Header
+		mu         sync.Mutex
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		gotBody = body
+		gotHeaders = r.Header.Clone()
+		mu.Unlock()
+		if r.URL.Path != "/v2/chat/completions" {
+			t.Errorf("upstream path = %q, want /v2/chat/completions", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chunk-1\",\"model\":\"glm-5.2\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"hello \"},\"finish_reason\":null}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chunk-2\",\"model\":\"glm-5.2\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"world\"},\"finish_reason\":null}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chunk-3\",\"model\":\"glm-5.2\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call-1\",\"type\":\"function\",\"function\":{\"name\":\"lookup\",\"arguments\":\"{\\\"q\\\":\\\"\"}}]},\"finish_reason\":null}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chunk-4\",\"model\":\"glm-5.2\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"hello\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chunk-5\",\"model\":\"glm-5.2\",\"choices\":[],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":4,\"total_tokens\":7}}\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	executor, auth := newCodeBuddyExecutor(t, server.URL+"/v2", authPath)
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "glm-5.2",
+		Payload: []byte(`{"model":"glm-5.2","messages":[{"role":"system","content":"Claude Code exploit"},{"role":"user","content":"hello"}],"tools":[{"type":"function","function":{"name":"lookup","description":"dangerous exploit development","parameters":{"type":"object","properties":{"q":{"type":"string","description":"exploit"}}}}}],"metadata":{"must_drop":true}}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatOpenAI,
+		ResponseFormat: sdktranslator.FormatOpenAI,
+		Stream:         false,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	mu.Lock()
+	body := append([]byte(nil), gotBody...)
+	headers := gotHeaders.Clone()
+	mu.Unlock()
+	if got := headers.Get("Authorization"); got != "Bearer access-token" {
+		t.Errorf("Authorization = %q, want session token", got)
+	}
+	if got := headers.Get("X-User-Id"); got != "user-1" {
+		t.Errorf("X-User-Id = %q, want user-1", got)
+	}
+	if got := headers.Get("X-Enterprise-Id"); got != "enterprise-1" {
+		t.Errorf("X-Enterprise-Id = %q, want enterprise-1", got)
+	}
+	if got := headers.Get("X-Tenant-Id"); got != "enterprise-1" {
+		t.Errorf("X-Tenant-Id = %q, want enterprise-1", got)
+	}
+	if got := headers.Get("X-Domain"); got != "www.codebuddy.cn" {
+		t.Errorf("X-Domain = %q, want default domain", got)
+	}
+	if got := headers.Get("User-Agent"); got != "codebuddy2openai/2.0" {
+		t.Errorf("User-Agent = %q, want CodeBuddy user agent", got)
+	}
+	if !gjson.GetBytes(body, "stream").Bool() {
+		t.Fatalf("upstream stream = false; body=%s", body)
+	}
+	if !gjson.GetBytes(body, "stream_options.include_usage").Bool() {
+		t.Fatalf("upstream stream_options.include_usage = false; body=%s", body)
+	}
+	if gjson.GetBytes(body, "metadata").Exists() {
+		t.Fatalf("unsupported metadata was forwarded: %s", body)
+	}
+	if gjson.GetBytes(body, "tools.0.function.description").Exists() || gjson.GetBytes(body, "tools.0.function.parameters.properties.q.description").Exists() {
+		t.Fatalf("tool metadata was not stripped: %s", body)
+	}
+	if got := gjson.GetBytes(body, "messages.0.content").String(); !strings.Contains(got, "C\u200blaude Code") {
+		t.Fatalf("desensitize did not alter system content: %s", body)
+	}
+
+	if got := gjson.GetBytes(resp.Payload, "choices.0.message.content").String(); got != "hello world" {
+		t.Errorf("aggregated content = %q, want hello world; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "choices.0.message.tool_calls.0.function.name").String(); got != "lookup" {
+		t.Errorf("tool name = %q, want lookup; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "choices.0.message.tool_calls.0.function.arguments").String(); got != `{"q":"hello"}` {
+		t.Errorf("tool arguments = %q, want complete JSON; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "choices.0.finish_reason").String(); got != "tool_calls" {
+		t.Errorf("finish_reason = %q, want tool_calls", got)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 7 {
+		t.Errorf("usage.total_tokens = %d, want 7", got)
+	}
+}
+
+func TestCodeBuddyExecuteStreamForcesSSE(t *testing.T) {
+	authPath := writeExecutorCodeBuddySession(t, time.Now().Add(time.Hour).UnixMilli())
+	var gotBody []byte
+	var gotHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		gotHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chunk-1\",\"model\":\"glm-5.2\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"ok\"},\"finish_reason\":null}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chunk-2\",\"model\":\"glm-5.2\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	executor, auth := newCodeBuddyExecutor(t, server.URL+"/v2", authPath)
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "glm-5.2",
+		Payload: []byte(`{"model":"glm-5.2","messages":[{"role":"user","content":"hello"}],"stream":false}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatOpenAI,
+		ResponseFormat: sdktranslator.FormatOpenAI,
+		Stream:         true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	chunks := 0
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+		chunks++
+	}
+	if chunks == 0 {
+		t.Fatal("ExecuteStream() returned no chunks")
+	}
+	if !gjson.GetBytes(gotBody, "stream").Bool() {
+		t.Fatalf("upstream stream = false; body=%s", gotBody)
+	}
+	if got := gotHeaders.Get("Accept"); got != "text/event-stream" {
+		t.Errorf("Accept = %q, want text/event-stream", got)
+	}
+	if got := gotHeaders.Get("Authorization"); got != "Bearer access-token" {
+		t.Errorf("Authorization = %q, want session token", got)
+	}
+}
+
+func newCodeBuddyExecutor(t *testing.T, baseURL, authPath string) (*OpenAICompatExecutor, *cliproxyauth.Auth) {
+	t.Helper()
+	name := "codebuddy"
+	executor := NewOpenAICompatExecutor("openai-compatible-codebuddy", &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:        name,
+			AuthType:    "codebuddy",
+			BaseURL:     baseURL,
+			Desensitize: true,
+		}},
+	})
+	return executor, &cliproxyauth.Auth{
+		ID:       "codebuddy-test",
+		Provider: "openai-compatible-codebuddy",
+		Attributes: map[string]string{
+			"auth_type":           "codebuddy",
+			"codebuddy_auth_file": authPath,
+			"base_url":            baseURL,
+			"compat_name":         name,
+			"provider_key":        "openai-compatible-codebuddy",
+		},
+	}
+}
+
+func writeExecutorCodeBuddySession(t *testing.T, expiresAt int64) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "account.info")
+	session := map[string]any{
+		"account": map[string]any{
+			"uid":          "user-1",
+			"enterpriseId": "enterprise-1",
+		},
+		"auth": map[string]any{
+			"accessToken":  "access-token",
+			"refreshToken": "refresh-token",
+			"expiresAt":    expiresAt,
+		},
+	}
+	raw, err := json.Marshal(session)
+	if err != nil {
+		t.Fatalf("marshal CodeBuddy session: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write CodeBuddy session: %v", err)
+	}
+	return path
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codebuddy"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
@@ -40,8 +41,9 @@ const (
 // It performs request/response translation and executes against the provider base URL
 // using per-auth credentials (API key) and per-auth HTTP transport (proxy) from context.
 type OpenAICompatExecutor struct {
-	provider string
-	cfg      *config.Config
+	provider  string
+	cfg       *config.Config
+	codeBuddy codeBuddyRuntime
 }
 
 // NewOpenAICompatExecutor creates an executor bound to a provider key (e.g., "openrouter").
@@ -55,6 +57,12 @@ func (e *OpenAICompatExecutor) Identifier() string { return e.provider }
 // PrepareRequest injects OpenAI-compatible credentials into the outgoing HTTP request.
 func (e *OpenAICompatExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth) error {
 	if req == nil {
+		return nil
+	}
+	if e.isCodeBuddyAuth(auth) {
+		if errPrepare := e.prepareProviderRequest(req.Context(), auth, req, http.DefaultClient, ""); errPrepare != nil {
+			return errPrepare
+		}
 		return nil
 	}
 	_, apiKey := e.resolveCredentials(auth)
@@ -78,10 +86,14 @@ func (e *OpenAICompatExecutor) HttpRequest(ctx context.Context, auth *cliproxyau
 		ctx = req.Context()
 	}
 	httpReq := req.WithContext(ctx)
-	if err := e.PrepareRequest(httpReq, auth); err != nil {
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	if e.isCodeBuddyAuth(auth) {
+		if err := e.prepareProviderRequest(ctx, auth, httpReq, httpClient, ""); err != nil {
+			return nil, err
+		}
+	} else if err := e.PrepareRequest(httpReq, auth); err != nil {
 		return nil, err
 	}
-	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	return httpClient.Do(httpReq)
 }
 
@@ -114,8 +126,9 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		originalPayloadSource = opts.OriginalRequest
 	}
 	originalPayload := originalPayloadSource
-	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, opts.Stream)
-	translated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, opts.Stream)
+	upstreamStream := opts.Stream || e.isCodeBuddyAuth(auth)
+	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, upstreamStream)
+	translated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, upstreamStream)
 
 	translated, err = helps.ApplyRequestThinking(translated, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
@@ -140,6 +153,11 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		}
 		translated = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "openai compat executor", translated)
 	}
+	compat := e.resolveCompatConfig(auth)
+	if e.isCodeBuddyAuth(auth) {
+		translated = sanitizeCodeBuddyChatPayload(translated, auth, compat != nil && compat.Desensitize)
+		translated = forceCodeBuddyStreamPayload(translated, auth, true)
+	}
 	reporter.SetTranslatedReasoningEffort(translated, to.String())
 
 	url := strings.TrimSuffix(baseURL, "/") + endpoint
@@ -148,15 +166,12 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		return resp, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	if apiKey != "" {
-		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-	}
 	httpReq.Header.Set("User-Agent", "cli-proxy-openai-compat")
-	var attrs map[string]string
-	if auth != nil {
-		attrs = auth.Attributes
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient = reporter.TrackHTTPClient(httpClient)
+	if errPrepare := e.prepareProviderRequest(ctx, auth, httpReq, httpClient, apiKey); errPrepare != nil {
+		return resp, errPrepare
 	}
-	util.ApplyCustomHeadersFromAttrs(httpReq, attrs)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -175,8 +190,6 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		AuthValue: authValue,
 	})
 
-	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	httpClient = reporter.TrackHTTPClient(httpClient)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
@@ -199,6 +212,13 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
+	}
+	if e.isCodeBuddyAuth(auth) {
+		if collected, errCollect := collectCodeBuddyStream(body); errCollect != nil {
+			return resp, errCollect
+		} else {
+			body = collected
+		}
 	}
 	helps.AppendAPIResponseChunk(ctx, e.cfg, body)
 	reporter.Publish(ctx, helps.ParseOpenAIUsage(body))
@@ -239,15 +259,12 @@ func (e *OpenAICompatExecutor) executeImages(ctx context.Context, auth *cliproxy
 		return resp, err
 	}
 	httpReq.Header.Set("Content-Type", contentType)
-	if apiKey != "" {
-		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-	}
 	httpReq.Header.Set("User-Agent", "cli-proxy-openai-compat")
-	var attrs map[string]string
-	if auth != nil {
-		attrs = auth.Attributes
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient = reporter.TrackHTTPClient(httpClient)
+	if errPrepare := e.prepareProviderRequest(ctx, auth, httpReq, httpClient, apiKey); errPrepare != nil {
+		return resp, errPrepare
 	}
-	util.ApplyCustomHeadersFromAttrs(httpReq, attrs)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -266,8 +283,6 @@ func (e *OpenAICompatExecutor) executeImages(ctx context.Context, auth *cliproxy
 		AuthValue: authValue,
 	})
 
-	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	httpClient = reporter.TrackHTTPClient(httpClient)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
@@ -344,6 +359,11 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			return nil, err
 		}
 	}
+	compat := e.resolveCompatConfig(auth)
+	if e.isCodeBuddyAuth(auth) {
+		translated = sanitizeCodeBuddyChatPayload(translated, auth, compat != nil && compat.Desensitize)
+		translated = forceCodeBuddyStreamPayload(translated, auth, true)
+	}
 
 	// Request usage data in the final streaming chunk so that token statistics
 	// are captured even when the upstream is an OpenAI-compatible provider.
@@ -356,17 +376,14 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		return nil, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	if apiKey != "" {
-		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-	}
 	httpReq.Header.Set("User-Agent", "cli-proxy-openai-compat")
-	var attrs map[string]string
-	if auth != nil {
-		attrs = auth.Attributes
-	}
-	util.ApplyCustomHeadersFromAttrs(httpReq, attrs)
 	httpReq.Header.Set("Accept", "text/event-stream")
 	httpReq.Header.Set("Cache-Control", "no-cache")
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient = reporter.TrackHTTPClient(httpClient)
+	if errPrepare := e.prepareProviderRequest(ctx, auth, httpReq, httpClient, apiKey); errPrepare != nil {
+		return nil, errPrepare
+	}
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -385,8 +402,6 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		AuthValue: authValue,
 	})
 
-	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	httpClient = reporter.TrackHTTPClient(httpClient)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
@@ -522,15 +537,12 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 	httpReq.Header.Set("Content-Type", contentType)
 	httpReq.Header.Set("Accept", "text/event-stream")
 	httpReq.Header.Set("Cache-Control", "no-cache")
-	if apiKey != "" {
-		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-	}
 	httpReq.Header.Set("User-Agent", "cli-proxy-openai-compat")
-	var attrs map[string]string
-	if auth != nil {
-		attrs = auth.Attributes
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient = reporter.TrackHTTPClient(httpClient)
+	if errPrepare := e.prepareProviderRequest(ctx, auth, httpReq, httpClient, apiKey); errPrepare != nil {
+		return nil, errPrepare
 	}
-	util.ApplyCustomHeadersFromAttrs(httpReq, attrs)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -549,8 +561,6 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 		AuthValue: authValue,
 	})
 
-	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	httpClient = reporter.TrackHTTPClient(httpClient)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
@@ -642,6 +652,17 @@ func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyau
 // Refresh is a no-op for API-key based compatibility providers.
 func (e *OpenAICompatExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
 	log.Debugf("openai compat executor: refresh called")
+	if e.isCodeBuddyAuth(auth) {
+		manager, errManager := e.codeBuddyManager(auth)
+		if errManager != nil {
+			return auth, errManager
+		}
+		client := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 15*time.Second)
+		if errRefresh := manager.Refresh(ctx, client); errRefresh != nil {
+			return auth, errRefresh
+		}
+		return auth, nil
+	}
 	if refreshed, handled, err := helps.RefreshAuthViaHome(ctx, e.cfg, auth); handled {
 		return refreshed, err
 	}
@@ -818,6 +839,9 @@ func (e *OpenAICompatExecutor) resolveCredentials(auth *cliproxyauth.Auth) (base
 	if auth.Attributes != nil {
 		baseURL = strings.TrimSpace(auth.Attributes["base_url"])
 		apiKey = strings.TrimSpace(auth.Attributes["api_key"])
+	}
+	if e.isCodeBuddyAuth(auth) && baseURL == "" {
+		baseURL = codebuddy.DefaultBackendBaseURL
 	}
 	return
 }

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codebuddy"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/constant"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
@@ -272,6 +273,12 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 		if compat.Disabled {
 			continue
 		}
+		if strings.EqualFold(strings.TrimSpace(compat.AuthType), codebuddy.AuthType) {
+			if auth := s.synthesizeCodeBuddy(ctx, compat, i); auth != nil {
+				out = append(out, auth)
+			}
+			continue
+		}
 		prefix := strings.TrimSpace(compat.Prefix)
 		providerName := strings.ToLower(strings.TrimSpace(compat.Name))
 		if providerName == "" {
@@ -369,6 +376,87 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 		}
 	}
 	return out
+}
+
+// synthesizeCodeBuddy creates the single runtime auth record backed by the
+// CodeBuddy desktop session file.  The request executor rereads that file so a
+// desktop-side token refresh becomes visible without copying token material
+// into CLIProxyAPI's own auth directory.
+func (s *ConfigSynthesizer) synthesizeCodeBuddy(ctx *SynthesisContext, compat *config.OpenAICompatibility, configIndex int) *coreauth.Auth {
+	if ctx == nil || ctx.Config == nil || compat == nil {
+		return nil
+	}
+	authFile, errFind := codebuddy.FindAuthFile(compat.AuthDir, compat.AuthFile)
+	if errFind != nil || strings.TrimSpace(authFile) == "" {
+		return nil
+	}
+
+	providerName := strings.ToLower(strings.TrimSpace(compat.Name))
+	if providerName == "" {
+		providerName = codebuddy.AuthType
+	}
+	providerKey := util.OpenAICompatibleProviderKey(providerName)
+	baseURL := strings.TrimSpace(compat.BaseURL)
+	if baseURL == "" {
+		baseURL = codebuddy.DefaultBackendBaseURL
+	}
+	id, token := ctx.IDGenerator.Next("openai-compatibility:"+providerName, authFile, baseURL)
+	attrs := map[string]string{
+		"source":              fmt.Sprintf("config:%s[%s]", providerName, token),
+		"base_url":            baseURL,
+		"compat_name":         compat.Name,
+		"provider_key":        providerKey,
+		"config_index":        strconv.Itoa(configIndex),
+		"auth_type":           codebuddy.AuthType,
+		"auth_kind":           coreauth.AuthKindOAuth,
+		"codebuddy_auth_file": authFile,
+	}
+	if hash := diff.ComputeOpenAICompatModelsHash(compat.Models); hash != "" {
+		attrs["models_hash"] = hash
+	}
+	if compat.Priority != 0 {
+		attrs["priority"] = strconv.Itoa(compat.Priority)
+	}
+	addConfigHeadersToAttrs(compat.Headers, attrs)
+
+	metadata := map[string]any{}
+	if compat.DisableCooling {
+		metadata["disable_cooling"] = true
+	}
+	if manager, errManager := codebuddy.NewCredentialManager(authFile); errManager == nil {
+		if summary, errSummary := manager.Summary(); errSummary == nil {
+			if summary.UID != "" {
+				metadata["email"] = summary.UID
+			}
+			if summary.TokenExpiresAt > 0 {
+				metadata["expires_at"] = summary.TokenExpiresAt
+			}
+			if summary.Nickname != "" {
+				metadata["nickname"] = summary.Nickname
+			}
+		}
+	}
+	label := strings.TrimSpace(compat.Name)
+	if label == "" {
+		label = codebuddy.AuthType
+	}
+	if nickname, ok := metadata["nickname"].(string); ok && nickname != "" {
+		label = nickname
+	}
+	if len(metadata) == 0 {
+		metadata = nil
+	}
+	return &coreauth.Auth{
+		ID:         id,
+		Provider:   providerKey,
+		Label:      label,
+		Prefix:     strings.TrimSpace(compat.Prefix),
+		Status:     coreauth.StatusActive,
+		Attributes: attrs,
+		Metadata:   metadata,
+		CreatedAt:  ctx.Now,
+		UpdatedAt:  ctx.Now,
+	}
 }
 
 // synthesizeVertexCompat creates Auth entries for Vertex-compatible providers.

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -1,6 +1,9 @@
 package synthesizer
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -557,6 +560,69 @@ func TestConfigSynthesizer_OpenAICompat_UsesNamespacedProviderKey(t *testing.T) 
 	}
 	if auth.Attributes["config_index"] != "0" {
 		t.Fatalf("config_index = %q, want 0", auth.Attributes["config_index"])
+	}
+}
+
+func TestConfigSynthesizer_CodeBuddySessionFile(t *testing.T) {
+	authPath := filepath.Join(t.TempDir(), "codebuddy.info")
+	session := map[string]any{
+		"account": map[string]any{
+			"uid":          "user-42",
+			"nickname":     "CodeBuddy User",
+			"enterpriseId": "enterprise-42",
+		},
+		"auth": map[string]any{
+			"accessToken":  "access-token",
+			"refreshToken": "refresh-token",
+			"expiresAt":    time.Now().Add(time.Hour).UnixMilli(),
+		},
+	}
+	raw, errMarshal := json.Marshal(session)
+	if errMarshal != nil {
+		t.Fatalf("marshal session: %v", errMarshal)
+	}
+	if errWrite := os.WriteFile(authPath, raw, 0o600); errWrite != nil {
+		t.Fatalf("write session: %v", errWrite)
+	}
+
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:     "codebuddy",
+			AuthType: "codebuddy",
+			AuthFile: authPath,
+			BaseURL:  "https://copilot.tencent.com/v2",
+			Prefix:   "cb",
+		}}},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, errSynthesize := synth.Synthesize(ctx)
+	if errSynthesize != nil {
+		t.Fatalf("Synthesize() error = %v", errSynthesize)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("auth count = %d, want 1", len(auths))
+	}
+	auth := auths[0]
+	if auth.Provider != "openai-compatible-codebuddy" {
+		t.Fatalf("provider = %q, want openai-compatible-codebuddy", auth.Provider)
+	}
+	if auth.Label != "CodeBuddy User" {
+		t.Fatalf("label = %q, want CodeBuddy User", auth.Label)
+	}
+	if auth.Prefix != "cb" {
+		t.Fatalf("prefix = %q, want cb", auth.Prefix)
+	}
+	if auth.Attributes["auth_type"] != "codebuddy" {
+		t.Fatalf("auth_type = %q, want codebuddy", auth.Attributes["auth_type"])
+	}
+	if auth.Attributes["codebuddy_auth_file"] != authPath {
+		t.Fatalf("codebuddy_auth_file = %q, want %q", auth.Attributes["codebuddy_auth_file"], authPath)
+	}
+	if got, _ := auth.Metadata["email"].(string); got != "user-42" {
+		t.Fatalf("metadata email = %q, want user-42", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR adds native CodeBuddy/WorkBuddy desktop session support to CLIProxyAPI.

CodeBuddy sessions are read from the desktop `.info` file and exposed through the existing `openai-compatibility` pipeline. This does not create a separate WorkBuddy service or replace the existing Management Center UI.

## What Changed

- Added `auth-type: codebuddy` support for OpenAI compatibility providers.
- Added CodeBuddy `.info` session discovery on Windows, macOS, and Linux.
- Added support for an explicit `auth-file` or `auth-dir`.
- Added automatic access-token refresh using the refresh token stored in the `.info` file.
- Added CodeBuddy-specific request headers and authentication handling.
- Added CodeBuddy model defaults when no model list is configured.
- Added optional request desensitization for CodeBuddy compatibility.
- Added a management API for importing and validating `.info` files.
- Kept WorkBuddy visible through the existing `openai-compatibility` management API.
- No custom or standalone management panel is included in this PR.

## Configuration

The minimal configuration is:

```yaml
openai-compatibility:
  - name: "WorkBuddy"
    auth-type: "codebuddy"
    base-url: "https://copilot.tencent.com/v2"
```

When no path is configured, CLIProxyAPI automatically searches the platform-specific CodeBuddy session directory.

If multiple `.info` files exist, configure one exact file:

```yaml
openai-compatibility:
  - name: "WorkBuddy"
    auth-type: "codebuddy"
    auth-file: "/absolute/path/to/account.info"
    base-url: "https://copilot.tencent.com/v2"
```

## Default Session Paths

### Windows

```text
%LOCALAPPDATA%\CodeBuddyExtension\Data\Public\auth\*.info
```

Usually:

```text
C:\Users\<username>\AppData\Local\CodeBuddyExtension\Data\Public\auth\*.info
```

### macOS

```text
~/Library/Application Support/CodeBuddyExtension/Data/Public/auth/*.info
```

Example:

```text
/Users/<username>/Library/Application Support/CodeBuddyExtension/Data/Public/auth/account.info
```

### Linux

If `XDG_DATA_HOME` is set:

```text
$XDG_DATA_HOME/CodeBuddyExtension/Data/Public/auth/*.info
```

Otherwise:

```text
~/.local/share/CodeBuddyExtension/Data/Public/auth/*.info
```

Example:

```text
/home/<username>/.local/share/CodeBuddyExtension/Data/Public/auth/account.info
```

The `CODEBUDDY_AUTH_DIR` environment variable can also be used to override automatic discovery.

## Importing a Session

The user must first log in through the official CodeBuddy/WorkBuddy desktop client. CLIProxyAPI does not collect the user's password or implement a separate interactive OAuth login flow.

After the desktop client creates the `.info` file, users can import it through the management API.

### Import an Existing File

```bash
curl -X POST http://127.0.0.1:8317/v0/management/codebuddy/import \
  -H "Authorization: Bearer <management-password>" \
  -H "Content-Type: application/json" \
  --data '{"auth-file":"/home/<username>/.local/share/CodeBuddyExtension/Data/Public/auth/account.info"}'
```

macOS example:

```bash
curl -X POST http://127.0.0.1:8317/v0/management/codebuddy/import \
  -H "Authorization: Bearer <management-password>" \
  -H "Content-Type: application/json" \
  --data '{"auth-file":"/Users/<username>/Library/Application Support/CodeBuddyExtension/Data/Public/auth/account.info"}'
```

The import endpoint also accepts `~` and environment variables in the supplied path.

### Upload the File

```bash
curl -X POST http://127.0.0.1:8317/v0/management/codebuddy/import \
  -H "Authorization: Bearer <management-password>" \
  -F "file=@/path/to/account.info"
```

Uploaded files are saved into the configured CLIProxyAPI auth directory with a `workbuddy-` prefix and restrictive file permissions.

## Verifying the Configuration

Check the existing Management Center API:

```bash
curl http://127.0.0.1:8317/v0/management/openai-compatibility \
  -H "Authorization: Bearer <management-password>"
```

The response should contain an entry similar to:

```json
{
  "name": "WorkBuddy",
  "auth-type": "codebuddy",
  "auth-file": "/path/to/account.info"
}
```

The existing Management Center displays this provider through its normal OpenAI Compatibility section. This repository does not contain the Management Center frontend source, so no dedicated WorkBuddy import button is added here.

## Security Notes

- The `.info` file contains session credentials and must be treated as a secret.
- Do not commit or share `.info` files.
- Access tokens are not returned by the management API.
- Token refreshes are written back to the original `.info` file.
- The management API should remain bound to localhost unless remote access is explicitly secured.

## Testing

Passed:

```text
go test ./internal/api/handlers/management ./internal/auth/codebuddy ./internal/config ./internal/watcher/synthesizer
go test ./internal/runtime/executor -run 'CodeBuddy' -count=1
```
