### PR TITLE
fix(security): secure credential and config file writes

### DIFF
--- a/internal/api/handlers/management/auth_files_crud.go
+++ b/internal/api/handlers/management/auth_files_crud.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/synthesizer"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -269,8 +270,16 @@ func (h *Handler) writeAuthFile(ctx context.Context, name string, data []byte) e
 	if err != nil {
 		return err
 	}
-	if errWrite := os.WriteFile(dst, data, 0o600); errWrite != nil {
+	file, errOpen := misc.OpenFileForSecureRewrite(dst)
+	if errOpen != nil {
+		return fmt.Errorf("failed to write file: %w", errOpen)
+	}
+	if _, errWrite := file.Write(data); errWrite != nil {
+		_ = file.Close()
 		return fmt.Errorf("failed to write file: %w", errWrite)
+	}
+	if errClose := file.Close(); errClose != nil {
+		return fmt.Errorf("failed to write file: %w", errClose)
 	}
 	if err := h.upsertAuthRecord(ctx, auth); err != nil {
 		return err

--- a/internal/api/handlers/management/auth_files_fields.go
+++ b/internal/api/handlers/management/auth_files_fields.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/credentialweight"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
@@ -174,10 +175,15 @@ func setSourceAuthFileDisabled(path string, disabled bool) error {
 	if errMarshal != nil {
 		return fmt.Errorf("marshal auth file: %w", errMarshal)
 	}
-	if errWrite := os.WriteFile(path, raw, 0o600); errWrite != nil {
+	file, errOpen := misc.OpenFileForSecureRewrite(path)
+	if errOpen != nil {
+		return errOpen
+	}
+	if _, errWrite := file.Write(raw); errWrite != nil {
+		_ = file.Close()
 		return errWrite
 	}
-	return nil
+	return file.Close()
 }
 
 func applyAuthDisabledState(auth *coreauth.Auth, disabled bool) {

--- a/internal/api/handlers/management/auth_files_permissions_unix_test.go
+++ b/internal/api/handlers/management/auth_files_permissions_unix_test.go
@@ -1,0 +1,79 @@
+//go:build unix
+
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestWriteAuthFileSecuresExistingFile(t *testing.T) {
+	authDir := t.TempDir()
+	path := filepath.Join(authDir, "auth.json")
+	if errWrite := os.WriteFile(path, []byte(`{"type":"demo","email":"old@example.com"}`), 0o664); errWrite != nil {
+		t.Fatalf("WriteFile() error = %v", errWrite)
+	}
+	if errChmod := os.Chmod(path, 0o664); errChmod != nil {
+		t.Fatalf("Chmod() error = %v", errChmod)
+	}
+
+	handler := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, coreauth.NewManager(nil, nil, nil))
+	replacement := []byte(`{"type":"demo","email":"new@example.com"}`)
+	if errWrite := handler.writeAuthFile(context.Background(), "auth.json", replacement); errWrite != nil {
+		t.Fatalf("writeAuthFile() error = %v", errWrite)
+	}
+
+	assertAuthFileMode(t, path)
+	persisted, errRead := os.ReadFile(path)
+	if errRead != nil {
+		t.Fatalf("ReadFile() error = %v", errRead)
+	}
+	if got, want := string(persisted), string(replacement); got != want {
+		t.Errorf("saved auth file = %q, want %q", got, want)
+	}
+}
+
+func TestSetSourceAuthFileDisabledSecuresExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "source.json")
+	initial := []byte(`{"type":"gemini-cli","email":"user@example.com","disabled":false}`)
+	if errWrite := os.WriteFile(path, initial, 0o664); errWrite != nil {
+		t.Fatalf("WriteFile() error = %v", errWrite)
+	}
+	if errChmod := os.Chmod(path, 0o664); errChmod != nil {
+		t.Fatalf("Chmod() error = %v", errChmod)
+	}
+
+	if errWrite := setSourceAuthFileDisabled(path, true); errWrite != nil {
+		t.Fatalf("setSourceAuthFileDisabled() error = %v", errWrite)
+	}
+
+	assertAuthFileMode(t, path)
+	persisted, errRead := os.ReadFile(path)
+	if errRead != nil {
+		t.Fatalf("ReadFile() error = %v", errRead)
+	}
+	var metadata map[string]any
+	if errUnmarshal := json.Unmarshal(persisted, &metadata); errUnmarshal != nil {
+		t.Fatalf("Unmarshal() error = %v", errUnmarshal)
+	}
+	if metadata["type"] != "gemini-cli" || metadata["email"] != "user@example.com" || metadata["disabled"] != true {
+		t.Errorf("saved metadata = %#v, want original fields with disabled=true", metadata)
+	}
+}
+
+func assertAuthFileMode(t *testing.T, path string) {
+	t.Helper()
+	info, errStat := os.Stat(path)
+	if errStat != nil {
+		t.Fatalf("Stat() error = %v", errStat)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("file mode = %o, want 0600", got)
+	}
+}

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 	log "github.com/sirupsen/logrus"
@@ -93,7 +94,7 @@ func (h *Handler) GetLatestVersion(c *gin.Context) {
 
 func WriteConfig(path string, data []byte) error {
 	data = config.NormalizeCommentIndentation(data)
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	f, err := misc.OpenFileForSecureRewrite(path)
 	if err != nil {
 		return err
 	}

--- a/internal/auth/claude/token.go
+++ b/internal/auth/claude/token.go
@@ -79,7 +79,7 @@ func (ts *ClaudeTokenStorage) SaveTokenToFile(authFilePath string) error {
 	}
 
 	// Create the token file
-	f, err := os.Create(authFilePath)
+	f, err := misc.OpenFileForSecureRewrite(authFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}

--- a/internal/auth/codex/token.go
+++ b/internal/auth/codex/token.go
@@ -60,7 +60,7 @@ func (ts *CodexTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	f, err := os.Create(authFilePath)
+	f, err := misc.OpenFileForSecureRewrite(authFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}

--- a/internal/auth/kimi/token.go
+++ b/internal/auth/kimi/token.go
@@ -87,7 +87,7 @@ func (ts *KimiTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	f, err := os.Create(authFilePath)
+	f, err := misc.OpenFileForSecureRewrite(authFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}

--- a/internal/auth/vertex/vertex_credentials.go
+++ b/internal/auth/vertex/vertex_credentials.go
@@ -52,7 +52,7 @@ func (s *VertexCredentialStorage) SaveTokenToFile(authFilePath string) error {
 	if err := os.MkdirAll(filepath.Dir(authFilePath), 0o700); err != nil {
 		return fmt.Errorf("vertex credential: create directory failed: %w", err)
 	}
-	f, err := os.Create(authFilePath)
+	f, err := misc.OpenFileForSecureRewrite(authFilePath)
 	if err != nil {
 		return fmt.Errorf("vertex credential: create file failed: %w", err)
 	}

--- a/internal/auth/xai/token.go
+++ b/internal/auth/xai/token.go
@@ -45,7 +45,7 @@ func (ts *TokenStorage) SaveTokenToFile(authFilePath string) error {
 	if errMkdirAll := os.MkdirAll(filepath.Dir(authFilePath), 0o700); errMkdirAll != nil {
 		return fmt.Errorf("xai token storage: create directory: %w", errMkdirAll)
 	}
-	file, err := os.Create(authFilePath)
+	file, err := misc.OpenFileForSecureRewrite(authFilePath)
 	if err != nil {
 		return fmt.Errorf("xai token storage: create token file: %w", err)
 	}

--- a/internal/config/config_yaml.go
+++ b/internal/config/config_yaml.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	"gopkg.in/yaml.v3"
 )
 
@@ -61,7 +62,7 @@ func SaveConfigPreserveComments(configFile string, cfg *Config) error {
 	normalizeCollectionNodeStyles(original.Content[0])
 
 	// Write back.
-	f, err := os.Create(configFile)
+	f, err := misc.OpenFileForSecureRewrite(configFile)
 	if err != nil {
 		return err
 	}
@@ -113,7 +114,7 @@ func SaveConfigPreserveCommentsUpdateNestedScalar(configFile string, path []stri
 			node = next
 		}
 	}
-	f, err := os.Create(configFile)
+	f, err := misc.OpenFileForSecureRewrite(configFile)
 	if err != nil {
 		return err
 	}

--- a/internal/misc/credentials.go
+++ b/internal/misc/credentials.go
@@ -3,6 +3,7 @@ package misc
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -11,6 +12,77 @@ import (
 
 // Separator used to visually group related log lines.
 var credentialSeparator = strings.Repeat("-", 67)
+
+// OpenFileForSecureRewrite opens a secret file, tightens its permissions when possible, and then truncates it.
+func OpenFileForSecureRewrite(path string) (*os.File, error) {
+	return openFileForSecureRewrite(path, os.O_WRONLY|os.O_CREATE)
+}
+
+// OpenExistingFileForSecureRewrite securely rewrites a secret file only when it already exists.
+func OpenExistingFileForSecureRewrite(path string) (*os.File, error) {
+	return openFileForSecureRewrite(path, os.O_WRONLY)
+}
+
+func openFileForSecureRewrite(path string, flags int) (*os.File, error) {
+	file, err := os.OpenFile(path, flags, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open file for secure rewrite: %w", err)
+	}
+	ensureOpenFileMode0600(file)
+	if errTruncate := file.Truncate(0); errTruncate != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("truncate secure file: %w", errTruncate)
+	}
+	return file, nil
+}
+
+// EnsureFileMode0600 tightens an existing secret file's permissions when the filesystem supports it.
+func EnsureFileMode0600(path string) {
+	pathInfo, errLstat := os.Lstat(path)
+	if errLstat != nil {
+		log.WithError(errLstat).Warn("could not inspect secret file for permission hardening")
+		return
+	}
+	if !pathInfo.Mode().IsRegular() {
+		log.Warn("could not restrict permissions of a non-regular secret file")
+		return
+	}
+	if pathInfo.Mode().Perm() == 0o600 {
+		return
+	}
+
+	file, errOpen := os.OpenFile(path, os.O_RDWR, 0)
+	if errOpen != nil {
+		log.WithError(errOpen).Warn("could not open secret file for permission hardening")
+		return
+	}
+	defer func() {
+		if errClose := file.Close(); errClose != nil {
+			log.WithError(errClose).Warn("could not close secret file after permission hardening")
+		}
+	}()
+
+	fileInfo, errStat := file.Stat()
+	if errStat != nil {
+		log.WithError(errStat).Warn("could not inspect open secret file for permission hardening")
+		return
+	}
+	if !os.SameFile(pathInfo, fileInfo) {
+		log.Warn("secret file changed during permission hardening")
+		return
+	}
+	ensureOpenFileMode0600(file)
+}
+
+func ensureOpenFileMode0600(file *os.File) {
+	info, errStat := file.Stat()
+	if errStat == nil && info.Mode().Perm() == 0o600 {
+		return
+	}
+	if errChmod := file.Chmod(0o600); errChmod != nil {
+		log.WithError(errChmod).Warn("could not restrict secret file permissions to 0600")
+	}
+}
 
 // LogSavingCredentials emits a consistent log message when persisting auth material.
 func LogSavingCredentials(path string) {

--- a/internal/misc/credentials_rewrite_test.go
+++ b/internal/misc/credentials_rewrite_test.go
@@ -1,0 +1,34 @@
+package misc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenFileForSecureRewriteTruncatesAndWritesFromOffsetZero(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	if errWrite := os.WriteFile(path, []byte("stale credentials that are longer"), 0o600); errWrite != nil {
+		t.Fatalf("WriteFile() error = %v", errWrite)
+	}
+
+	file, errOpen := OpenFileForSecureRewrite(path)
+	if errOpen != nil {
+		t.Fatalf("OpenFileForSecureRewrite() error = %v", errOpen)
+	}
+	if _, errWrite := file.WriteString("replacement"); errWrite != nil {
+		_ = file.Close()
+		t.Fatalf("WriteString() error = %v", errWrite)
+	}
+	if errClose := file.Close(); errClose != nil {
+		t.Fatalf("Close() error = %v", errClose)
+	}
+
+	contents, errRead := os.ReadFile(path)
+	if errRead != nil {
+		t.Fatalf("ReadFile() error = %v", errRead)
+	}
+	if got, want := string(contents), "replacement"; got != want {
+		t.Errorf("file contents = %q, want %q", got, want)
+	}
+}

--- a/internal/misc/credentials_test.go
+++ b/internal/misc/credentials_test.go
@@ -1,0 +1,57 @@
+//go:build unix
+
+package misc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenFileForSecureRewrite(t *testing.T) {
+	t.Run("creates a new file with mode 0600", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "new-credentials.json")
+
+		file, err := OpenFileForSecureRewrite(path)
+		if err != nil {
+			t.Fatalf("OpenFileForSecureRewrite() error = %v", err)
+		}
+		if errClose := file.Close(); errClose != nil {
+			t.Fatalf("Close() error = %v", errClose)
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("Stat() error = %v", err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Errorf("file mode = %o, want 0600", got)
+		}
+	})
+
+	t.Run("restricts an existing file to mode 0600", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "existing-mode-credentials.json")
+		if err := os.WriteFile(path, []byte("old credentials"), 0o664); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+		if err := os.Chmod(path, 0o664); err != nil {
+			t.Fatalf("Chmod() error = %v", err)
+		}
+
+		file, err := OpenFileForSecureRewrite(path)
+		if err != nil {
+			t.Fatalf("OpenFileForSecureRewrite() error = %v", err)
+		}
+		if errClose := file.Close(); errClose != nil {
+			t.Fatalf("Close() error = %v", errClose)
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("Stat() error = %v", err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Errorf("file mode = %o, want 0600", got)
+		}
+	})
+}

--- a/internal/pluginhost/auth_callbacks.go
+++ b/internal/pluginhost/auth_callbacks.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 )
@@ -293,8 +294,16 @@ func (h *Host) saveAuthFile(ctx context.Context, name string, data []byte) (stri
 	if errBuild != nil {
 		return "", errBuild
 	}
-	if errWrite := os.WriteFile(dst, data, 0o600); errWrite != nil {
+	file, errOpen := misc.OpenFileForSecureRewrite(dst)
+	if errOpen != nil {
+		return "", fmt.Errorf("failed to write auth file: %w", errOpen)
+	}
+	if _, errWrite := file.Write(data); errWrite != nil {
+		_ = file.Close()
 		return "", fmt.Errorf("failed to write auth file: %w", errWrite)
+	}
+	if errClose := file.Close(); errClose != nil {
+		return "", fmt.Errorf("failed to write auth file: %w", errClose)
 	}
 	if errUpsert := h.upsertAuthRecord(ctx, auth); errUpsert != nil {
 		return "", errUpsert

--- a/internal/pluginhost/auth_callbacks_permissions_unix_test.go
+++ b/internal/pluginhost/auth_callbacks_permissions_unix_test.go
@@ -1,0 +1,54 @@
+//go:build unix
+
+package pluginhost
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestHostSaveAuthFileSecuresExistingFile(t *testing.T) {
+	authDir := t.TempDir()
+	path := filepath.Join(authDir, "auth.json")
+	if errWrite := os.WriteFile(path, []byte(`{"type":"demo","email":"old@example.com"}`), 0o664); errWrite != nil {
+		t.Fatalf("WriteFile() error = %v", errWrite)
+	}
+	if errChmod := os.Chmod(path, 0o664); errChmod != nil {
+		t.Fatalf("Chmod() error = %v", errChmod)
+	}
+
+	host := New()
+	host.runtimeConfig = &config.Config{AuthDir: authDir}
+	host.SetAuthManager(coreauth.NewManager(nil, nil, nil))
+	replacement := []byte(`{"type":"demo","email":"new@example.com"}`)
+	savedPath, errSave := host.saveAuthFile(context.Background(), "auth.json", replacement)
+	if errSave != nil {
+		t.Fatalf("saveAuthFile() error = %v", errSave)
+	}
+	if savedPath != path {
+		t.Errorf("saved path = %q, want %q", savedPath, path)
+	}
+
+	info, errStat := os.Stat(path)
+	if errStat != nil {
+		t.Fatalf("Stat() error = %v", errStat)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("file mode = %o, want 0600", got)
+	}
+	persisted, errRead := os.ReadFile(path)
+	if errRead != nil {
+		t.Fatalf("ReadFile() error = %v", errRead)
+	}
+	if got, want := string(persisted), string(replacement); got != want {
+		t.Errorf("saved auth file = %q, want %q", got, want)
+	}
+	if auth, ok := host.currentAuthManager().GetByID("auth.json"); !ok || auth == nil {
+		t.Fatal("saved auth record was not registered")
+	}
+}

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 )
@@ -127,9 +128,10 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 		}
 		if existing, errRead := os.ReadFile(path); errRead == nil {
 			if jsonEqual(existing, raw) {
+				misc.EnsureFileMode0600(path)
 				break
 			}
-			file, errOpen := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600)
+			file, errOpen := misc.OpenFileForSecureRewrite(path)
 			if errOpen != nil {
 				return "", fmt.Errorf("auth filestore: open existing failed: %w", errOpen)
 			}
@@ -144,8 +146,16 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 		} else if !os.IsNotExist(errRead) {
 			return "", fmt.Errorf("auth filestore: read existing failed: %w", errRead)
 		}
-		if errWrite := os.WriteFile(path, raw, 0o600); errWrite != nil {
+		file, errOpen := misc.OpenFileForSecureRewrite(path)
+		if errOpen != nil {
+			return "", fmt.Errorf("auth filestore: write file failed: %w", errOpen)
+		}
+		if _, errWrite := file.Write(raw); errWrite != nil {
+			_ = file.Close()
 			return "", fmt.Errorf("auth filestore: write file failed: %w", errWrite)
+		}
+		if errClose := file.Close(); errClose != nil {
+			return "", fmt.Errorf("auth filestore: write file failed: %w", errClose)
 		}
 	default:
 		return "", fmt.Errorf("auth filestore: nothing to persist for %s", auth.ID)
@@ -307,7 +317,7 @@ func (s *FileTokenStore) readAuthFiles(path, baseDir string) ([]*cliproxyauth.Au
 				if errFetch == nil && strings.TrimSpace(fetchedProjectID) != "" {
 					metadata["project_id"] = strings.TrimSpace(fetchedProjectID)
 					if raw, errMarshal := json.Marshal(metadata); errMarshal == nil {
-						if file, errOpen := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600); errOpen == nil {
+						if file, errOpen := misc.OpenExistingFileForSecureRewrite(path); errOpen == nil {
 							_, _ = file.Write(raw)
 							_ = file.Close()
 						}

--- a/sdk/auth/filestore_permissions_unix_test.go
+++ b/sdk/auth/filestore_permissions_unix_test.go
@@ -1,0 +1,203 @@
+//go:build unix
+
+package auth
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestFileTokenStoreSaveMetadataSecuresExistingFile(t *testing.T) {
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "auth.json")
+	if errWrite := os.WriteFile(path, []byte(`{"type":"demo","email":"old@example.com","disabled":false}`), 0o664); errWrite != nil {
+		t.Fatalf("WriteFile() error = %v", errWrite)
+	}
+	if errChmod := os.Chmod(path, 0o664); errChmod != nil {
+		t.Fatalf("Chmod() error = %v", errChmod)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	auth := &cliproxyauth.Auth{
+		ID:       "auth.json",
+		FileName: "auth.json",
+		Metadata: map[string]any{
+			"type":  "demo",
+			"email": "new@example.com",
+		},
+	}
+
+	if _, errSave := store.Save(context.Background(), auth); errSave != nil {
+		t.Fatalf("Save() error = %v", errSave)
+	}
+
+	info, errStat := os.Stat(path)
+	if errStat != nil {
+		t.Fatalf("Stat() error = %v", errStat)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("file mode = %o, want 0600", got)
+	}
+	persisted, errRead := os.ReadFile(path)
+	if errRead != nil {
+		t.Fatalf("ReadFile() error = %v", errRead)
+	}
+	expected := []byte(`{"type":"demo","email":"new@example.com","disabled":false}`)
+	if !jsonEqual(persisted, expected) {
+		t.Errorf("saved auth file = %s, want JSON equal to %s", persisted, expected)
+	}
+}
+
+func TestFileTokenStoreSaveMetadataSecuresEquivalentExistingFile(t *testing.T) {
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "auth.json")
+	existing := []byte(`{"type":"demo","email":"same@example.com","disabled":false}`)
+	if errWrite := os.WriteFile(path, existing, 0o664); errWrite != nil {
+		t.Fatalf("WriteFile() error = %v", errWrite)
+	}
+	if errChmod := os.Chmod(path, 0o664); errChmod != nil {
+		t.Fatalf("Chmod() error = %v", errChmod)
+	}
+	stableModTime := time.Unix(1_700_000_000, 0)
+	if errChtimes := os.Chtimes(path, stableModTime, stableModTime); errChtimes != nil {
+		t.Fatalf("Chtimes() error = %v", errChtimes)
+	}
+	beforeInfo, errStat := os.Stat(path)
+	if errStat != nil {
+		t.Fatalf("Stat() before Save error = %v", errStat)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	auth := &cliproxyauth.Auth{
+		ID:       "auth.json",
+		FileName: "auth.json",
+		Metadata: map[string]any{
+			"type":  "demo",
+			"email": "same@example.com",
+		},
+	}
+
+	if _, errSave := store.Save(context.Background(), auth); errSave != nil {
+		t.Fatalf("Save() error = %v", errSave)
+	}
+
+	info, errStat := os.Stat(path)
+	if errStat != nil {
+		t.Fatalf("Stat() error = %v", errStat)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("file mode = %o, want 0600", got)
+	}
+	if got, want := info.ModTime(), beforeInfo.ModTime(); !got.Equal(want) {
+		t.Errorf("file mtime = %v, want unchanged %v", got, want)
+	}
+	persisted, errRead := os.ReadFile(path)
+	if errRead != nil {
+		t.Fatalf("ReadFile() error = %v", errRead)
+	}
+	if got, want := string(persisted), string(existing); got != want {
+		t.Errorf("saved auth file = %q, want unchanged %q", got, want)
+	}
+}
+
+func TestFileTokenStoreSaveMetadataCreatesFileWithSecureMode(t *testing.T) {
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "auth.json")
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	auth := &cliproxyauth.Auth{
+		ID:       "auth.json",
+		FileName: "auth.json",
+		Metadata: map[string]any{
+			"type":  "demo",
+			"email": "new@example.com",
+		},
+	}
+
+	if _, errSave := store.Save(context.Background(), auth); errSave != nil {
+		t.Fatalf("Save() error = %v", errSave)
+	}
+
+	info, errStat := os.Stat(path)
+	if errStat != nil {
+		t.Fatalf("Stat() error = %v", errStat)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("file mode = %o, want 0600", got)
+	}
+	persisted, errRead := os.ReadFile(path)
+	if errRead != nil {
+		t.Fatalf("ReadFile() error = %v", errRead)
+	}
+	expected := []byte(`{"type":"demo","email":"new@example.com","disabled":false}`)
+	if !jsonEqual(persisted, expected) {
+		t.Errorf("saved auth file = %s, want JSON equal to %s", persisted, expected)
+	}
+}
+
+func TestFileTokenStoreReadAntigravityProjectIDSecuresExistingFile(t *testing.T) {
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "antigravity.json")
+	existing := []byte(`{"type":"antigravity","access_token":"test-token","email":"user@example.com"}`)
+	if errWrite := os.WriteFile(path, existing, 0o664); errWrite != nil {
+		t.Fatalf("WriteFile() error = %v", errWrite)
+	}
+	if errChmod := os.Chmod(path, 0o664); errChmod != nil {
+		t.Fatalf("Chmod() error = %v", errChmod)
+	}
+
+	previousTransport := http.DefaultClient.Transport
+	http.DefaultClient.Transport = testRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if got, want := req.URL.String(), "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist"; got != want {
+			t.Fatalf("request URL = %q, want %q", got, want)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"cloudaicompanionProject":"project-from-api"}`)),
+			Request:    req,
+		}, nil
+	})
+	t.Cleanup(func() {
+		http.DefaultClient.Transport = previousTransport
+	})
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	auth, errReadAuth := store.readAuthFile(path, baseDir)
+	if errReadAuth != nil {
+		t.Fatalf("readAuthFile() error = %v", errReadAuth)
+	}
+	if auth == nil {
+		t.Fatal("readAuthFile() returned nil auth")
+	}
+	if got, want := auth.Metadata["project_id"], "project-from-api"; got != want {
+		t.Errorf("project_id = %#v, want %q", got, want)
+	}
+
+	info, errStat := os.Stat(path)
+	if errStat != nil {
+		t.Fatalf("Stat() error = %v", errStat)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("file mode = %o, want 0600", got)
+	}
+	persisted, errRead := os.ReadFile(path)
+	if errRead != nil {
+		t.Fatalf("ReadFile() error = %v", errRead)
+	}
+	expected := []byte(`{"type":"antigravity","access_token":"test-token","email":"user@example.com","project_id":"project-from-api"}`)
+	if !jsonEqual(persisted, expected) {
+		t.Errorf("saved auth file = %s, want JSON equal to %s", persisted, expected)
+	}
+}

--- a/sdk/auth/filestore_rewrite_test.go
+++ b/sdk/auth/filestore_rewrite_test.go
@@ -1,0 +1,69 @@
+package auth
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type testRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f testRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestFileTokenStoreReadAntigravityProjectIDDoesNotRecreateDeletedFile(t *testing.T) {
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "antigravity.json")
+	if errWrite := os.WriteFile(path, []byte(`{"type":"antigravity","access_token":"test-token"}`), 0o600); errWrite != nil {
+		t.Fatalf("WriteFile() error = %v", errWrite)
+	}
+
+	requestStarted := make(chan struct{})
+	releaseResponse := make(chan struct{})
+	previousTransport := http.DefaultClient.Transport
+	http.DefaultClient.Transport = testRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		close(requestStarted)
+		<-releaseResponse
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"cloudaicompanionProject":"project-from-api"}`)),
+			Request:    req,
+		}, nil
+	})
+	t.Cleanup(func() {
+		http.DefaultClient.Transport = previousTransport
+	})
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	result := make(chan error, 1)
+	go func() {
+		_, errRead := store.readAuthFile(path, baseDir)
+		result <- errRead
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for project ID request")
+	}
+	if errRemove := os.Remove(path); errRemove != nil {
+		t.Fatalf("Remove() error = %v", errRemove)
+	}
+	close(releaseResponse)
+
+	select {
+	case <-result:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for readAuthFile()")
+	}
+	if _, errStat := os.Stat(path); !os.IsNotExist(errStat) {
+		t.Fatalf("Stat() error = %v, want file to remain absent", errStat)
+	}
+}


### PR DESCRIPTION
## Summary

- harden new and existing credential/config files to mode `0600` on Unix/POSIX filesystems when supported
- attempt permission tightening before truncation without using initial `O_TRUNC`
- warn and preserve the previous write behavior when `chmod` is unsupported or denied
- preserve the `jsonEqual` no-write short-circuit while repairing an insecure mode when possible
- harden the Antigravity `project_id` write-back without recreating a credential deleted during discovery
- cover provider token storage, config persistence, auth filestore, management auth writes, and plugin-host auth writes with focused permission tests

## Compatibility notes

- Unix/POSIX files are hardened to `0600` when the filesystem permits it.
- If permission tightening is unsupported or denied, CLIProxyAPI logs a warning and continues with the existing persistence behavior.
- On Windows, Go `Chmod(0o600)` does not restrict inherited NTFS ACLs. Native Windows ACL hardening is outside this PR.
- Docker and other bind-mounted host files may change to mode `0600` after their first successful save, which may affect other host users, sidecars, NAS tools, or backup jobs that relied on broader access.

## Validation

- [x] focused auth, config, management, plugin-host, SDK, and helper package tests
- [x] `go test -race ./sdk/auth`
- [x] equivalent-JSON content/mtime regression test, repeated 20 times
- [x] deleted Antigravity file no-recreation regression test, repeated 20 times
- [x] `go build -o test-output ./cmd/server`
- [x] `git diff --check`
- [x] `git show --check HEAD`
- [ ] `go test ./...` — three unchanged `internal/runtime/executor` fingerprint-header tests expect `Linux` but receive `MacOS`; the same failures reproduce on the exact `upstream/dev` base `4906ead3` in this environment

Fixes #4672

Supersedes #4673