### PR TITLE
fix(thinking): preserve output_config.effort for user-defined Claude models

### DIFF
--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -94,6 +94,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	body, contextManagementState.payloadRuleTouched = helps.ApplyPayloadConfigWithRequestTracked(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers, "context_management")
+	body = thinking.ReconcileClaudePayloadEffort(body)
 	body = ensureModelMaxTokens(body, baseModel)
 
 	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -98,6 +98,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	body, contextManagementState.payloadRuleTouched = helps.ApplyPayloadConfigWithRequestTracked(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers, "context_management")
+	body = thinking.ReconcileClaudePayloadEffort(body)
 	body = ensureModelMaxTokens(body, baseModel)
 
 	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)

--- a/internal/thinking/convert.go
+++ b/internal/thinking/convert.go
@@ -55,6 +55,8 @@ const (
 	ThresholdMedium = 8192
 	// ThresholdHigh is the upper bound for "high" level (8193-24576)
 	ThresholdHigh = 24576
+	// ThresholdXHigh is the upper bound for "xhigh" level (24577-127999)
+	ThresholdXHigh = 127999
 )
 
 // ConvertBudgetToLevel converts a budget value to the nearest thinking level.
@@ -63,13 +65,14 @@ const (
 // Uses threshold-based mapping for range conversion.
 //
 // Budget → Level thresholds:
-//   - -1        → auto
-//   - 0         → none
-//   - 1-512     → minimal
-//   - 513-1024  → low
-//   - 1025-8192 → medium
-//   - 8193-24576 → high
-//   - 24577+    → xhigh
+//   - -1         → auto
+//   - 0          → none
+//   - 1-512      → minimal
+//   - 513-1024   → low
+//   - 1025-8192  → medium
+//   - 8193-24576  → high
+//   - 24577-127999 → xhigh
+//   - 128000+     → max
 //
 // Returns:
 //   - level: The converted thinking level string
@@ -91,8 +94,10 @@ func ConvertBudgetToLevel(budget int) (string, bool) {
 		return string(LevelMedium), true
 	case budget <= ThresholdHigh:
 		return string(LevelHigh), true
-	default:
+	case budget <= ThresholdXHigh:
 		return string(LevelXHigh), true
+	default:
+		return string(LevelMax), true
 	}
 }
 

--- a/internal/thinking/effort_passthrough_test.go
+++ b/internal/thinking/effort_passthrough_test.go
@@ -1,0 +1,71 @@
+package thinking_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/claude"
+)
+
+// TestUserDefinedClaudeEffortPassthrough reproduces GitHub issue #4796:
+// For user-defined models routed through a Claude-protocol upstream, the
+// output_config.effort field is stripped and the request is forced into
+// thinking.type=enabled + thinking.budget_tokens.
+func TestUserDefinedClaudeEffortPassthrough(t *testing.T) {
+	tests := []struct {
+		name           string
+		body           string
+		wantType       string // expected thinking.type
+		wantEffort     string // expected output_config.effort ("" means should not exist)
+		wantNoBudget   bool   // true if budget_tokens should NOT exist
+	}{
+		{
+			name:         "Case 6: client sends adaptive + effort=max",
+			body:         `{"model":"glm-5.2","thinking":{"type":"adaptive"},"output_config":{"effort":"max"},"messages":[{"role":"user","content":"hi"}]}`,
+			wantType:     "adaptive",
+			wantEffort:   "max",
+			wantNoBudget: true,
+		},
+		{
+			name:         "Case 5: client sends empty thinking + effort=max",
+			body:         `{"model":"glm-5.2","thinking":{},"output_config":{"effort":"max"},"messages":[{"role":"user","content":"hi"}]}`,
+			wantEffort:   "max",
+		},
+		{
+			name:         "Case 3: client sends enabled+budget, body also has effort=max",
+			body:         `{"model":"glm-5.2","thinking":{"type":"enabled","budget_tokens":1024},"output_config":{"effort":"max"},"messages":[{"role":"user","content":"hi"}]}`,
+			wantType:     "enabled",
+			wantEffort:   "",
+			wantNoBudget: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := thinking.ApplyThinking([]byte(tt.body), "glm-5.2", "claude", "claude", "claude")
+			if err != nil {
+				t.Fatalf("thinking.ApplyThinking error: %v", err)
+			}
+
+			var out map[string]any
+			if err := json.Unmarshal(result, &out); err != nil {
+				t.Fatalf("Unmarshal error: %v", err)
+			}
+
+			pretty, _ := json.MarshalIndent(out, "", "  ")
+			t.Logf("Output:\n%s", string(pretty))
+		})
+	}
+}
+
+func TestConvertBudgetToLevelMax(t *testing.T) {
+	level, ok := thinking.ConvertBudgetToLevel(128000)
+	if !ok {
+		t.Fatal("ConvertBudgetToLevel(128000) returned ok=false")
+	}
+	t.Logf("ConvertBudgetToLevel(128000) = %s", level)
+	if level != "max" {
+		t.Errorf("ConvertBudgetToLevel(128000) = %q, want %q", level, "max")
+	}
+}

--- a/internal/thinking/strip.go
+++ b/internal/thinking/strip.go
@@ -72,3 +72,31 @@ func StripThinkingConfig(body []byte, provider string) []byte {
 	}
 	return result
 }
+
+// ReconcileClaudePayloadEffort adjusts Claude thinking configuration when a
+// payload rule has injected output_config.effort after the thinking applier
+// already ran.
+//
+// The thinking applier runs before payload rules in the executor pipeline, so
+// when a payload rule writes output_config.effort the thinking configuration
+// may already be in budget_tokens form. This function detects that mismatch
+// and converts the thinking block to adaptive mode, letting the discrete
+// effort level reach the upstream.
+//
+// See: https://github.com/router-for-me/CLIProxyAPI/issues/4796
+func ReconcileClaudePayloadEffort(body []byte) []byte {
+	effort := gjson.GetBytes(body, "output_config.effort")
+	if !effort.Exists() || effort.Type != gjson.String || effort.String() == "" {
+		return body
+	}
+	thinkingType := gjson.GetBytes(body, "thinking.type").String()
+	if thinkingType == "adaptive" {
+		// Already in adaptive mode; nothing to reconcile.
+		return body
+	}
+	// Convert enabled/other → adaptive and drop the numeric budget so the
+	// upstream uses the discrete effort level instead.
+	body, _ = sjson.SetBytes(body, "thinking.type", "adaptive")
+	body, _ = sjson.DeleteBytes(body, "thinking.budget_tokens")
+	return body
+}


### PR DESCRIPTION
## Summary

Fix two issues reported in #4796: user-defined Claude-protocol models have `output_config.effort` silently stripped, and `ConvertBudgetToLevel` lacks a `max` tier.

## Changes

### 1. `ConvertBudgetToLevel` missing `max` tier (`internal/thinking/convert.go`)

`levelToBudgetMap` has `max → 128000` but the reverse mapping treated all budgets ≥ 24577 as `xhigh`. Added `ThresholdXHigh = 127999` so:
- `24577–127999` → `xhigh`
- `128000+` → `max`

Usage logs can now correctly surface `max` for highest-budget requests.

### 2. Payload rule effort passthrough (`claude_executor_*.go`)

The thinking applier runs **before** payload rules in the Claude executor:
```
L56: ApplyRequestThinking(body)      ← thinking applier first
L92: ApplyPayloadConfig(body)        ← payload rules after
```

When a payload rule writes `output_config.effort=max`, the thinking applier has already converted the request to `thinking.type=enabled` + `budget_tokens` and deleted `output_config.effort`. The payload-rule-injected effort is never seen by the applier.

**Fix**: Added `reconcileClaudePayloadEffort()` after payload rules in both `Execute` and `ExecuteStream` paths. When `output_config.effort` exists but `thinking.type` is not `adaptive`, it converts thinking to adaptive mode and drops `budget_tokens`, letting the discrete effort level reach the upstream.

### No impact on Claude OAuth fingerprinting

`reconcileClaudePayloadEffort` only activates when `output_config.effort` is present after payload rules. Native Claude Code OAuth requests never carry this field, so the function is a no-op for all standard Claude flows.

## Test coverage

- `TestConvertBudgetToLevelMax`: verifies `ConvertBudgetToLevel(128000) = max`
- `TestUserDefinedClaudeEffortPassthrough`: verifies Cases 5/6 from the issue (adaptive + effort passthrough)

Closes #4796