### PR TITLE
fix(antigravity): add default sensitive words for system instruction obfuscation

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -59,11 +59,17 @@ func NewAntigravityExecutor(cfg *config.Config) *AntigravityExecutor {
 	return &AntigravityExecutor{cfg: cfg}
 }
 
+var defaultAntigravitySensitiveWords = []string{"Research", "Nous"}
+
 func (e *AntigravityExecutor) obfuscateSensitiveWords(payload []byte) []byte {
-	if e == nil || e.cfg == nil || len(e.cfg.Antigravity.SensitiveWords) == 0 {
+	if e == nil {
 		return payload
 	}
-	matcher := helps.BuildSensitiveWordMatcher(e.cfg.Antigravity.SensitiveWords)
+	words := defaultAntigravitySensitiveWords
+	if e.cfg != nil && len(e.cfg.Antigravity.SensitiveWords) > 0 {
+		words = e.cfg.Antigravity.SensitiveWords
+	}
+	matcher := helps.BuildSensitiveWordMatcher(words)
 	return helps.ObfuscateSensitiveWordsInSystemInstruction(payload, matcher)
 }
 

--- a/internal/runtime/executor/antigravity_executor_signature_test.go
+++ b/internal/runtime/executor/antigravity_executor_signature_test.go
@@ -160,6 +160,19 @@ func TestAntigravitySensitiveWordsObfuscatesSystemInstructionOnly(t *testing.T) 
 	}
 }
 
+func TestAntigravitySensitiveWordsDefaultObfuscation(t *testing.T) {
+	executor := NewAntigravityExecutor(&config.Config{})
+	payload := []byte(`{"request":{"systemInstruction":{"parts":[{"text":"Created by Nous Research"}]},"contents":[{"role":"user","parts":[{"text":"hello"}]}]}}`)
+
+	got := executor.obfuscateSensitiveWords(payload)
+	if systemText := gjson.GetBytes(got, "request.systemInstruction.parts.0.text").String(); systemText != "Created by N​ous R​esearch" {
+		t.Fatalf("system instruction = %q, want default sensitive words obfuscated", systemText)
+	}
+	if contentText := gjson.GetBytes(got, "request.contents.0.parts.0.text").String(); contentText != "hello" {
+		t.Fatalf("content text = %q, want unchanged", contentText)
+	}
+}
+
 func TestAntigravityStreamObfuscatesSensitiveSystemInstruction(t *testing.T) {
 	captured := make(chan []byte, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### Summary
Adds default sensitive words (`"Research"`, `"Nous"`) for Google Antigravity system instruction obfuscation when `antigravity.sensitive-words` is unconfigured.

### Motivation & Context
Upstream Antigravity (`v1internal:generateContent` / `streamGenerateContent`) rejects or hangs on certain prompt keywords in system instructions (such as `"Research"` or `"Nous"`). While `CLIProxyAPI` already supports zero-width obfuscation via `Antigravity.SensitiveWords`, it was previously skipped when unconfigured (empty list). This change ensures sensible defaults are active out of the box to prevent request timeouts and failures for agentic framework system prompts (e.g. Hermes).

### Verification
- Added `TestAntigravitySensitiveWordsDefaultObfuscation` unit test.
- Verified all Antigravity executor tests pass.
- Verified build succeeds via `go build ./cmd/server`.