### PR TITLE
fix(api): allow Studio model discovery without session

### DIFF
--- a/internal/api/server_middleware.go
+++ b/internal/api/server_middleware.go
@@ -195,6 +195,11 @@ func StudioCorrelationMiddleware() gin.HandlerFunc {
 			return
 		}
 		if len(values) == 0 {
+			if isStudioModelDiscoveryRequest(c) {
+				setRequestCorrelationContext(c, "")
+				c.Next()
+				return
+			}
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "missing Studio inference session ID"})
 			return
 		}
@@ -206,6 +211,18 @@ func StudioCorrelationMiddleware() gin.HandlerFunc {
 		c.Set(studioInferenceSessionContextKey, sessionID)
 		setRequestCorrelationContext(c, sessionID)
 		c.Next()
+	}
+}
+
+func isStudioModelDiscoveryRequest(c *gin.Context) bool {
+	if c == nil || c.Request == nil || c.Request.URL == nil || c.Request.Method != http.MethodGet {
+		return false
+	}
+	switch c.Request.URL.Path {
+	case "/v1/models", "/v1beta/models":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/api/server_middleware.go
+++ b/internal/api/server_middleware.go
@@ -218,12 +218,17 @@ func isStudioModelDiscoveryRequest(c *gin.Context) bool {
 	if c == nil || c.Request == nil || c.Request.URL == nil || c.Request.Method != http.MethodGet {
 		return false
 	}
-	switch c.Request.URL.Path {
+	path := c.Request.URL.Path
+	switch path {
 	case "/v1/models", "/v1beta/models":
 		return true
-	default:
+	}
+	const modelMetadataPrefix = "/v1beta/models/"
+	if !strings.HasPrefix(path, modelMetadataPrefix) {
 		return false
 	}
+	model := strings.TrimPrefix(path, modelMetadataPrefix)
+	return model != "" && !strings.ContainsAny(model, "/:")
 }
 
 func setRequestCorrelationContext(c *gin.Context, sessionID string) {

--- a/internal/api/server_middleware.go
+++ b/internal/api/server_middleware.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/safemode"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -169,4 +171,99 @@ func AuthMiddleware(manager *sdkaccess.Manager) gin.HandlerFunc {
 		}
 		c.AbortWithStatusJSON(statusCode, gin.H{"error": err.Message})
 	}
+}
+
+const studioInferenceSessionContextKey = "studioInferenceSessionID"
+
+// StudioCorrelationMiddleware validates the authenticated Studio integration
+// field before any provider execution starts. Headers from other callers are
+// ignored rather than promoted into usage correlation.
+func StudioCorrelationMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c == nil || c.Request == nil {
+			return
+		}
+		studio := isStudioIntegrationRequest(c)
+		values := c.Request.Header.Values(coreusage.InferenceSessionHeader)
+		if !studio {
+			setRequestCorrelationContext(c, "")
+			c.Next()
+			return
+		}
+		if len(values) > 1 {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "duplicate Studio inference session ID"})
+			return
+		}
+		if len(values) == 0 {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "missing Studio inference session ID"})
+			return
+		}
+		sessionID, err := coreusage.ParseInferenceSessionID(values[0])
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid Studio inference session ID"})
+			return
+		}
+		c.Set(studioInferenceSessionContextKey, sessionID)
+		setRequestCorrelationContext(c, sessionID)
+		c.Next()
+	}
+}
+
+func setRequestCorrelationContext(c *gin.Context, sessionID string) {
+	if c == nil || c.Request == nil {
+		return
+	}
+	requestCtx := c.Request.Context()
+	if sessionID != "" {
+		requestCtx = coreusage.WithInferenceSessionID(requestCtx, sessionID)
+	} else {
+		requestCtx = coreusage.WithoutInferenceSessionID(requestCtx)
+		if c.Keys != nil {
+			delete(c.Keys, studioInferenceSessionContextKey)
+		}
+	}
+	if traceID, errTrace := coreusage.ParseTraceParent(c.GetHeader(coreusage.TraceParentHeader)); errTrace == nil {
+		requestCtx = coreusage.WithTraceID(requestCtx, traceID)
+	}
+	requestCtx = coreusage.EnsureRequestCorrelation(requestCtx)
+	c.Request = c.Request.WithContext(requestCtx)
+}
+
+func isStudioIntegrationRequest(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	if provider, exists := c.Get("accessProvider"); exists && strings.EqualFold(strings.TrimSpace(formatAccessValue(provider)), "studio") {
+		return true
+	}
+	metadata, exists := c.Get("accessMetadata")
+	if !exists {
+		return false
+	}
+	for _, key := range []string{"integration", "source", "client", "caller"} {
+		if value, ok := accessMetadataValue(metadata, key); ok && strings.EqualFold(strings.TrimSpace(value), "studio") {
+			return true
+		}
+	}
+	return false
+}
+
+func accessMetadataValue(metadata any, key string) (string, bool) {
+	switch values := metadata.(type) {
+	case map[string]string:
+		value, ok := values[key]
+		return formatAccessValue(value), ok
+	case map[string]any:
+		value, ok := values[key]
+		return formatAccessValue(value), ok
+	default:
+		return "", false
+	}
+}
+
+func formatAccessValue(value any) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprintf("%v", value))
 }

--- a/internal/api/server_middleware_test.go
+++ b/internal/api/server_middleware_test.go
@@ -42,6 +42,26 @@ func TestStudioCorrelationMiddlewareRejectsMissingSessionForStudio(t *testing.T)
 	}
 }
 
+func TestStudioCorrelationMiddlewareAllowsStudioModelDiscoveryWithoutSession(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, path := range []string{"/v1/models", "/v1beta/models"} {
+		t.Run(path, func(t *testing.T) {
+			ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+			ctx.Request = httptest.NewRequest("GET", "http://example.com"+path, nil)
+			ctx.Set("accessProvider", "studio")
+
+			StudioCorrelationMiddleware()(ctx)
+			if ctx.IsAborted() {
+				t.Fatal("model discovery without a session was rejected")
+			}
+			correlation := coreusage.CorrelationFromContext(ctx.Request.Context())
+			if correlation.InferenceSessionID != "" || correlation.GatewayRequestID == "" {
+				t.Fatalf("model discovery correlation = %+v", correlation)
+			}
+		})
+	}
+}
+
 func TestStudioCorrelationMiddlewareIgnoresUntrustedHeader(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())

--- a/internal/api/server_middleware_test.go
+++ b/internal/api/server_middleware_test.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+func TestStudioCorrelationMiddlewareAcceptsAuthenticatedStudioHeader(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("POST", "http://example.com/v1/chat/completions", nil)
+	ctx.Request.Header.Set(coreusage.InferenceSessionHeader, "studio-session")
+	ctx.Request.Header.Set(coreusage.TraceParentHeader, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	ctx.Set("accessProvider", "studio")
+
+	StudioCorrelationMiddleware()(ctx)
+	value, exists := ctx.Get(studioInferenceSessionContextKey)
+	if !exists || value != "studio-session" {
+		t.Fatalf("stored Studio session = %v, want studio-session", value)
+	}
+	correlation := coreusage.CorrelationFromContext(ctx.Request.Context())
+	if correlation.InferenceSessionID != "studio-session" || correlation.GatewayRequestID == "" || correlation.TraceID != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("request context correlation = %+v", correlation)
+	}
+}
+
+func TestStudioCorrelationMiddlewareRejectsMissingSessionForStudio(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("POST", "http://example.com/v1/chat/completions", nil)
+	ctx.Set("accessProvider", "studio")
+
+	StudioCorrelationMiddleware()(ctx)
+	if !ctx.IsAborted() {
+		t.Fatal("missing Studio session was not rejected")
+	}
+	if ctx.Writer.Status() != 400 {
+		t.Fatalf("status = %d, want 400", ctx.Writer.Status())
+	}
+}
+
+func TestStudioCorrelationMiddlewareIgnoresUntrustedHeader(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("POST", "http://example.com/v1/chat/completions", nil)
+	requestContext := coreusage.WithInferenceSessionID(ctx.Request.Context(), "inherited-session")
+	ctx.Request = ctx.Request.WithContext(requestContext)
+	ctx.Request.Header.Set(coreusage.InferenceSessionHeader, "untrusted-session")
+	ctx.Set(studioInferenceSessionContextKey, "stale-session")
+
+	StudioCorrelationMiddleware()(ctx)
+	if ctx.IsAborted() {
+		t.Fatal("untrusted header was rejected instead of ignored")
+	}
+	if _, exists := ctx.Get(studioInferenceSessionContextKey); exists {
+		t.Fatal("untrusted header or stale Studio state was promoted to correlation")
+	}
+	if sessionID := coreusage.InferenceSessionIDFromContext(ctx.Request.Context()); sessionID != "" {
+		t.Fatalf("inherited session ID = %q, want empty", sessionID)
+	}
+}
+
+func TestStudioCorrelationMiddlewareRejectsMalformedSession(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("POST", "http://example.com/v1/chat/completions", nil)
+	ctx.Request.Header.Set(coreusage.InferenceSessionHeader, "bad session")
+	ctx.Set("accessProvider", "studio")
+
+	StudioCorrelationMiddleware()(ctx)
+	if !ctx.IsAborted() || ctx.Writer.Status() != 400 {
+		t.Fatalf("malformed session status=%d aborted=%v", ctx.Writer.Status(), ctx.IsAborted())
+	}
+}
+
+func TestStudioCorrelationMiddlewareIgnoresDuplicateHeaderForUntrustedCaller(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("POST", "http://example.com/v1/chat/completions", nil)
+	ctx.Request.Header.Add(coreusage.InferenceSessionHeader, "one")
+	ctx.Request.Header.Add(coreusage.InferenceSessionHeader, "two")
+
+	StudioCorrelationMiddleware()(ctx)
+	if ctx.IsAborted() {
+		t.Fatal("duplicate untrusted header was rejected")
+	}
+}
+
+func TestStudioCorrelationMiddlewareRejectsDuplicateHeaderForStudio(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("POST", "http://example.com/v1/chat/completions", nil)
+	ctx.Request.Header.Add(coreusage.InferenceSessionHeader, "one")
+	ctx.Request.Header.Add(coreusage.InferenceSessionHeader, "two")
+	ctx.Set("accessProvider", "studio")
+
+	StudioCorrelationMiddleware()(ctx)
+	if !ctx.IsAborted() || ctx.Writer.Status() != 400 {
+		t.Fatalf("duplicate Studio header status=%d aborted=%v", ctx.Writer.Status(), ctx.IsAborted())
+	}
+}
+
+func TestStudioCorrelationMiddlewareRecognizesStudioMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("POST", "http://example.com/v1/chat/completions", nil)
+	ctx.Request.Header.Set(coreusage.InferenceSessionHeader, "studio-session")
+	ctx.Set("accessMetadata", map[string]string{"integration": "studio"})
+
+	StudioCorrelationMiddleware()(ctx)
+	if value, exists := ctx.Get(studioInferenceSessionContextKey); !exists || value != "studio-session" {
+		t.Fatalf("stored Studio session = %v, want studio-session", value)
+	}
+}

--- a/internal/api/server_middleware_test.go
+++ b/internal/api/server_middleware_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -59,6 +60,34 @@ func TestStudioCorrelationMiddlewareAllowsStudioModelDiscoveryWithoutSession(t *
 				t.Fatalf("model discovery correlation = %+v", correlation)
 			}
 		})
+	}
+}
+
+func TestStudioCorrelationMiddlewareAllowsStudioModelMetadataWithoutSession(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("GET", "http://example.com/v1beta/models/gemini-2.5-flash", nil)
+	ctx.Set("accessProvider", "studio")
+
+	StudioCorrelationMiddleware()(ctx)
+	if ctx.IsAborted() {
+		t.Fatal("model metadata without a session was rejected")
+	}
+	correlation := coreusage.CorrelationFromContext(ctx.Request.Context())
+	if correlation.InferenceSessionID != "" || correlation.GatewayRequestID == "" {
+		t.Fatalf("model metadata correlation = %+v", correlation)
+	}
+}
+
+func TestStudioCorrelationMiddlewareRejectsMissingSessionForStudioGenerationRoute(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("POST", "http://example.com/v1beta/models/gemini-2.5-flash:generateContent", nil)
+	ctx.Set("accessProvider", "studio")
+
+	StudioCorrelationMiddleware()(ctx)
+	if !ctx.IsAborted() || ctx.Writer.Status() != http.StatusBadRequest {
+		t.Fatalf("generation route status=%d aborted=%v", ctx.Writer.Status(), ctx.IsAborted())
 	}
 }
 

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -59,7 +59,7 @@ func (s *Server) setupRoutes() {
 
 	// OpenAI compatible API routes
 	v1 := s.engine.Group("/v1")
-	v1.Use(AuthMiddleware(s.accessManager))
+	v1.Use(AuthMiddleware(s.accessManager), StudioCorrelationMiddleware())
 	{
 		v1.GET("/models", s.unifiedModelsHandler(openaiHandlers, claudeCodeHandlers))
 		v1.POST("/chat/completions", openaiHandlers.ChatCompletions)
@@ -85,7 +85,7 @@ func (s *Server) setupRoutes() {
 	}
 
 	openaiV1 := s.engine.Group("/openai/v1")
-	openaiV1.Use(AuthMiddleware(s.accessManager))
+	openaiV1.Use(AuthMiddleware(s.accessManager), StudioCorrelationMiddleware())
 	{
 		openaiV1.POST("/videos", openaiHandlers.VideosCreate)
 		openaiV1.GET("/videos/:video_id/content", openaiHandlers.VideosContent)
@@ -94,7 +94,7 @@ func (s *Server) setupRoutes() {
 
 	// Codex CLI direct route aliases (chatgpt_base_url compatible)
 	codexDirect := s.engine.Group("/backend-api/codex")
-	codexDirect.Use(AuthMiddleware(s.accessManager))
+	codexDirect.Use(AuthMiddleware(s.accessManager), StudioCorrelationMiddleware())
 	{
 		codexDirect.GET("/responses", openaiResponsesHandlers.ResponsesWebsocket)
 		codexDirect.POST("/responses", openaiResponsesHandlers.Responses)
@@ -104,7 +104,7 @@ func (s *Server) setupRoutes() {
 
 	// Gemini compatible API routes
 	v1beta := s.engine.Group("/v1beta")
-	v1beta.Use(AuthMiddleware(s.accessManager))
+	v1beta.Use(AuthMiddleware(s.accessManager), StudioCorrelationMiddleware())
 	{
 		v1beta.GET("/models", s.geminiModelsHandler(geminiHandlers))
 		v1beta.POST("/interactions", geminiHandlers.Interactions)
@@ -509,7 +509,7 @@ func (s *Server) AttachWebsocketRoute(path string, handler http.Handler) {
 		c.Abort()
 	}
 
-	s.engine.GET(trimmed, conditionalAuth, finalHandler)
+	s.engine.GET(trimmed, conditionalAuth, StudioCorrelationMiddleware(), finalHandler)
 }
 
 // isAnthropicModelsRequest reports whether a /v1/models request should be served in

--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -2204,6 +2204,32 @@ func TestUsageAdapterPreservesExplicitGenerateFalse(t *testing.T) {
 	}
 }
 
+func TestUsageAdapterPropagatesCorrelationFields(t *testing.T) {
+	var got pluginapi.UsageRecord
+	plugin := usagePluginFunc(func(ctx context.Context, record pluginapi.UsageRecord) {
+		got = record
+	})
+	host := newHostWithRecords(capabilityRecord{
+		id: "usage-correlation",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			UsagePlugin: plugin,
+		}},
+	})
+	adapter := &usageAdapter{host: host, pluginID: "usage-correlation"}
+	adapter.HandleUsage(context.Background(), coreusage.Record{
+		Provider:           "provider",
+		InferenceSessionID: "studio-session",
+		GatewayRequestID:   "gateway-request",
+		ProviderRequestID:  "provider-request",
+		AttemptID:          "attempt",
+		EventID:            "event",
+		TraceID:            "4bf92f3577b34da6a3ce929d0e0e4736",
+	})
+	if got.UsageSchemaVersion == 0 || got.InferenceSessionID != "studio-session" || got.GatewayRequestID != "gateway-request" || got.ProviderRequestID != "provider-request" || got.AttemptID != "attempt" || got.EventID != "event" || got.TraceID == "" {
+		t.Fatalf("plugin usage record lost correlation: %+v", got)
+	}
+}
+
 func TestUsageManagerRegisterNamedReplacesWithoutDuplicateDispatch(t *testing.T) {
 	manager := coreusage.NewManager(0)
 	defer manager.Stop()

--- a/internal/pluginhost/adapters_usage_translation.go
+++ b/internal/pluginhost/adapters_usage_translation.go
@@ -10,6 +10,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginabi"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	log "github.com/sirupsen/logrus"
@@ -142,22 +143,29 @@ func (a *usageAdapter) HandleUsage(ctx context.Context, record coreusage.Record)
 		}
 	}()
 	plugin.HandleUsage(ctx, pluginapi.UsageRecord{
-		Provider:        record.Provider,
-		ExecutorType:    record.ExecutorType,
-		Model:           record.Model,
-		Alias:           record.Alias,
-		APIKey:          record.APIKey,
-		AuthID:          record.AuthID,
-		AuthIndex:       record.AuthIndex,
-		AuthType:        record.AuthType,
-		Source:          record.Source,
-		ReasoningEffort: record.ReasoningEffort,
-		ServiceTier:     record.ServiceTier,
-		Generate:        coreusage.GenerateEnabled(record.Generate),
-		RequestedAt:     record.RequestedAt,
-		Latency:         record.Latency,
-		TTFT:            record.TTFT,
-		Failed:          record.Failed,
+		Provider:           record.Provider,
+		ExecutorType:       record.ExecutorType,
+		Model:              record.Model,
+		Alias:              record.Alias,
+		APIKey:             record.APIKey,
+		AuthID:             record.AuthID,
+		AuthIndex:          record.AuthIndex,
+		AuthType:           record.AuthType,
+		Source:             record.Source,
+		UsageSchemaVersion: pluginabi.UsageSchemaVersion,
+		InferenceSessionID: record.InferenceSessionID,
+		GatewayRequestID:   record.GatewayRequestID,
+		ProviderRequestID:  record.ProviderRequestID,
+		AttemptID:          record.AttemptID,
+		EventID:            record.EventID,
+		TraceID:            record.TraceID,
+		ReasoningEffort:    record.ReasoningEffort,
+		ServiceTier:        record.ServiceTier,
+		Generate:           coreusage.GenerateEnabled(record.Generate),
+		RequestedAt:        record.RequestedAt,
+		Latency:            record.Latency,
+		TTFT:               record.TTFT,
+		Failed:             record.Failed,
 		Failure: pluginapi.UsageFailure{
 			StatusCode: record.Fail.StatusCode,
 			Body:       record.Fail.Body,

--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -24,6 +24,7 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 	if !Enabled() || !UsageStatisticsEnabled() {
 		return
 	}
+	record = coreusage.NormalizeRecord(ctx, record)
 
 	timestamp := record.RequestedAt
 	if timestamp.IsZero() {
@@ -109,6 +110,12 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		ExecutorType:        executorType,
 		Model:               modelName,
 		Alias:               aliasName,
+		InferenceSessionID:  record.InferenceSessionID,
+		GatewayRequestID:    record.GatewayRequestID,
+		ProviderRequestID:   record.ProviderRequestID,
+		AttemptID:           record.AttemptID,
+		EventID:             record.EventID,
+		TraceID:             record.TraceID,
 		Endpoint:            resolveEndpoint(ctx),
 		AuthType:            authType,
 		APIKey:              apiKey,
@@ -131,6 +138,12 @@ type queuedUsageDetail struct {
 	ExecutorType        string                   `json:"executor_type"`
 	Model               string                   `json:"model"`
 	Alias               string                   `json:"alias"`
+	InferenceSessionID  string                   `json:"inference_session_id"`
+	GatewayRequestID    string                   `json:"gateway_request_id"`
+	ProviderRequestID   string                   `json:"provider_request_id,omitempty"`
+	AttemptID           string                   `json:"attempt_id,omitempty"`
+	EventID             string                   `json:"event_id"`
+	TraceID             string                   `json:"trace_id"`
 	Endpoint            string                   `json:"endpoint"`
 	AuthType            string                   `json:"auth_type"`
 	APIKey              string                   `json:"api_key"`

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -259,6 +259,26 @@ func TestUsageQueuePluginAsyncUsesRecordResponseHeaders(t *testing.T) {
 	})
 }
 
+func TestUsageQueuePluginPayloadIncludesCorrelationFields(t *testing.T) {
+	withEnabledQueue(t, func() {
+		ctx := coreusage.WithInferenceSessionID(context.Background(), "studio-session")
+		ctx = coreusage.WithGatewayRequestID(ctx, "gateway-request")
+		ctx = coreusage.WithTraceID(ctx, "4bf92f3577b34da6a3ce929d0e0e4736")
+
+		(&usageQueuePlugin{}).HandleUsage(ctx, coreusage.Record{
+			Provider: "openai",
+			Model:    "gpt-5.4",
+		})
+
+		payload := popSinglePayload(t)
+		requireStringField(t, payload, "inference_session_id", "studio-session")
+		requireStringField(t, payload, "gateway_request_id", "gateway-request")
+		requireStringField(t, payload, "trace_id", "4bf92f3577b34da6a3ce929d0e0e4736")
+		requireNonEmptyStringField(t, payload, "attempt_id")
+		requireNonEmptyStringField(t, payload, "event_id")
+	})
+}
+
 func TestUsageQueuePluginPayloadIncludesStableFieldsAndFailureAndGinRequestID(t *testing.T) {
 	withEnabledQueue(t, func() {
 		ctx := internallogging.WithRequestID(context.Background(), "gin-request-id")
@@ -433,6 +453,22 @@ func requireStringField(t *testing.T, payload map[string]json.RawMessage, key, w
 	}
 	if got != want {
 		t.Fatalf("%s = %q, want %q", key, got, want)
+	}
+}
+
+func requireNonEmptyStringField(t *testing.T, payload map[string]json.RawMessage, key string) {
+	t.Helper()
+
+	raw, ok := payload[key]
+	if !ok {
+		t.Fatalf("payload missing %q", key)
+	}
+	var got string
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", key, err)
+	}
+	if got == "" {
+		t.Fatalf("%s is empty", key)
 	}
 }
 

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -22,26 +22,30 @@ import (
 )
 
 type UsageReporter struct {
-	provider        string
-	executorType    string
-	model           string
-	alias           string
-	authID          string
-	authIndex       string
-	authMu          sync.RWMutex
-	accessTokenHash string
-	authType        string
-	apiKey          string
-	source          string
-	reasoning       string
-	serviceTier     string
-	generate        bool
-	requestedAt     time.Time
-	ttftMu          sync.RWMutex
-	ttft            time.Duration
-	ttftStart       time.Time
-	ttftSet         bool
-	once            sync.Once
+	provider           string
+	executorType       string
+	model              string
+	alias              string
+	authID             string
+	authIndex          string
+	authMu             sync.RWMutex
+	accessTokenHash    string
+	authType           string
+	apiKey             string
+	source             string
+	reasoning          string
+	serviceTier        string
+	generate           bool
+	inferenceSessionID string
+	gatewayRequestID   string
+	traceID            string
+	attemptID          string
+	requestedAt        time.Time
+	ttftMu             sync.RWMutex
+	ttft               time.Duration
+	ttftStart          time.Time
+	ttftSet            bool
+	once               sync.Once
 }
 
 type usageExecutor interface {
@@ -59,22 +63,32 @@ func NewExecutorUsageReporter(ctx context.Context, executor usageExecutor, model
 }
 
 func NewUsageReporter(ctx context.Context, provider, model string, auth *cliproxyauth.Auth) *UsageReporter {
+	ctx = usage.EnsureRequestCorrelation(ctx)
 	apiKey := APIKeyFromContext(ctx)
 	alias := usage.RequestedModelAliasFromContext(ctx)
 	if alias == "" {
 		alias = model
 	}
+	correlation := usage.CorrelationFromContext(ctx)
+	attemptID := correlation.AttemptID
+	if attemptID == "" {
+		attemptID = usage.NewAttemptID()
+	}
 	reporter := &UsageReporter{
-		provider:    provider,
-		model:       model,
-		alias:       strings.TrimSpace(alias),
-		requestedAt: time.Now(),
-		apiKey:      apiKey,
-		source:      resolveUsageSource(auth, apiKey),
-		authType:    resolveUsageAuthType(auth),
-		reasoning:   usage.ReasoningEffortFromContext(ctx),
-		serviceTier: usage.ServiceTierFromContext(ctx),
-		generate:    usage.GenerateFromContext(ctx),
+		provider:           provider,
+		model:              model,
+		alias:              strings.TrimSpace(alias),
+		requestedAt:        time.Now(),
+		apiKey:             apiKey,
+		source:             resolveUsageSource(auth, apiKey),
+		authType:           resolveUsageAuthType(auth),
+		reasoning:          usage.ReasoningEffortFromContext(ctx),
+		serviceTier:        usage.ServiceTierFromContext(ctx),
+		generate:           usage.GenerateFromContext(ctx),
+		inferenceSessionID: correlation.InferenceSessionID,
+		gatewayRequestID:   correlation.GatewayRequestID,
+		traceID:            correlation.TraceID,
+		attemptID:          attemptID,
 	}
 	if auth != nil {
 		reporter.authID = auth.ID
@@ -259,6 +273,12 @@ func (r *UsageReporter) EnsurePublished(ctx context.Context) {
 
 func (r *UsageReporter) publishRecord(ctx context.Context, record usage.Record) {
 	record.ResponseHeaders = internallogging.GetResponseHeaders(ctx)
+	if record.ProviderRequestID == "" {
+		record.ProviderRequestID = usage.ProviderRequestIDFromContext(ctx)
+	}
+	if record.ProviderRequestID == "" {
+		record.ProviderRequestID = usage.ProviderRequestIDFromHeaders(record.ResponseHeaders)
+	}
 	usage.PublishRecord(ctx, record)
 }
 
@@ -283,6 +303,10 @@ func (r *UsageReporter) buildRecordForModel(model string, detail usage.Detail, f
 		Model:               model,
 		Alias:               r.alias,
 		Source:              r.source,
+		InferenceSessionID:  r.inferenceSessionID,
+		GatewayRequestID:    r.gatewayRequestID,
+		AttemptID:           r.attemptID,
+		TraceID:             r.traceID,
 		APIKey:              r.apiKey,
 		AuthID:              r.authID,
 		AuthIndex:           r.authIndex,

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -588,6 +588,33 @@ func TestNewExecutorUsageReporterIncludesExecutorType(t *testing.T) {
 	}
 }
 
+func TestUsageReporterCarriesStudioCorrelationAcrossRecordModels(t *testing.T) {
+	ctx := usage.WithInferenceSessionID(context.Background(), "studio-session")
+	ctx = usage.WithGatewayRequestID(ctx, "gateway-request")
+	ctx = usage.WithTraceID(ctx, "4bf92f3577b34da6a3ce929d0e0e4736")
+	reporter := NewUsageReporter(ctx, "openai", "gpt-5.4", nil)
+
+	first := reporter.buildRecord(usage.Detail{TotalTokens: 3}, false)
+	second := reporter.buildRecordForModel("gpt-5.4-mini", usage.Detail{TotalTokens: 4}, false, usage.Failure{})
+	for _, record := range []usage.Record{first, second} {
+		if record.InferenceSessionID != "studio-session" {
+			t.Fatalf("inference session ID = %q", record.InferenceSessionID)
+		}
+		if record.GatewayRequestID != "gateway-request" {
+			t.Fatalf("gateway request ID = %q", record.GatewayRequestID)
+		}
+		if record.TraceID != "4bf92f3577b34da6a3ce929d0e0e4736" {
+			t.Fatalf("trace ID = %q", record.TraceID)
+		}
+		if record.AttemptID == "" {
+			t.Fatal("attempt ID is empty")
+		}
+	}
+	if first.AttemptID != second.AttemptID {
+		t.Fatalf("additional model changed attempt ID: %q != %q", first.AttemptID, second.AttemptID)
+	}
+}
+
 func TestUsageReporterBuildRecordIncludesReasoningEffort(t *testing.T) {
 	ctx := usage.WithReasoningEffort(context.Background(), "medium")
 	reporter := NewUsageReporter(ctx, "openai", "gpt-5.4", nil)

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -410,6 +410,28 @@ func (h *BaseAPIHandler) GetContextWithCancel(handler interfaces.APIHandler, c *
 			parentCtx = logging.WithRequestID(parentCtx, requestID)
 		}
 	}
+	if requestCtx != nil {
+		if sessionID := coreusage.InferenceSessionIDFromContext(requestCtx); sessionID != "" {
+			parentCtx = coreusage.WithInferenceSessionID(parentCtx, sessionID)
+		}
+		if gatewayRequestID := coreusage.GatewayRequestIDFromContext(requestCtx); gatewayRequestID != "" {
+			parentCtx = coreusage.WithGatewayRequestID(parentCtx, gatewayRequestID)
+		}
+		if traceID := coreusage.TraceIDFromContext(requestCtx); traceID != "" {
+			parentCtx = coreusage.WithTraceID(parentCtx, traceID)
+		}
+	}
+	if c != nil && c.Request != nil {
+		if value, exists := c.Get("studioInferenceSessionID"); exists {
+			if sessionID, ok := value.(string); ok && coreusage.InferenceSessionIDFromContext(parentCtx) == "" {
+				parentCtx = coreusage.WithInferenceSessionID(parentCtx, sessionID)
+			}
+		}
+		if traceID, errTrace := coreusage.ParseTraceParent(c.GetHeader(coreusage.TraceParentHeader)); errTrace == nil && coreusage.TraceIDFromContext(parentCtx) == "" {
+			parentCtx = coreusage.WithTraceID(parentCtx, traceID)
+		}
+	}
+	parentCtx = coreusage.EnsureRequestCorrelation(parentCtx)
 	newCtx, cancel := context.WithCancel(parentCtx)
 
 	endpoint := ""

--- a/sdk/api/handlers/handlers_metadata_test.go
+++ b/sdk/api/handlers/handlers_metadata_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	coresession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 	"golang.org/x/net/context"
 )
@@ -35,6 +36,47 @@ func TestGetContextWithCancelCapturesClientRequestMetadata(t *testing.T) {
 	}
 	if metadata.UserAgent != "test-client/1.0" {
 		t.Fatalf("UserAgent = %q", metadata.UserAgent)
+	}
+}
+
+func TestGetContextWithCancelPropagatesRequestCorrelation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	request := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	requestCtx := coreusage.WithInferenceSessionID(request.Context(), "studio-session")
+	requestCtx = coreusage.WithGatewayRequestID(requestCtx, "gateway-request")
+	requestCtx = coreusage.WithTraceID(requestCtx, "4bf92f3577b34da6a3ce929d0e0e4736")
+	ginCtx.Request = request.WithContext(requestCtx)
+
+	handler := &BaseAPIHandler{Cfg: &config.SDKConfig{}}
+	ctx, cancel := handler.GetContextWithCancel(nil, ginCtx, context.Background())
+	defer cancel()
+
+	correlation := coreusage.CorrelationFromContext(ctx)
+	if correlation.InferenceSessionID != "studio-session" || correlation.GatewayRequestID != "gateway-request" || correlation.TraceID != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("correlation = %+v", correlation)
+	}
+}
+
+func TestGetContextWithCancelRequestCorrelationOverridesParent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	request := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	requestCtx := coreusage.WithInferenceSessionID(request.Context(), "request-session")
+	requestCtx = coreusage.WithGatewayRequestID(requestCtx, "request-gateway")
+	requestCtx = coreusage.WithTraceID(requestCtx, "4bf92f3577b34da6a3ce929d0e0e4736")
+	ginCtx.Request = request.WithContext(requestCtx)
+
+	parentCtx := coreusage.WithInferenceSessionID(context.Background(), "parent-session")
+	parentCtx = coreusage.WithGatewayRequestID(parentCtx, "parent-gateway")
+	parentCtx = coreusage.WithTraceID(parentCtx, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	handler := &BaseAPIHandler{Cfg: &config.SDKConfig{}}
+	ctx, cancel := handler.GetContextWithCancel(nil, ginCtx, parentCtx)
+	defer cancel()
+
+	correlation := coreusage.CorrelationFromContext(ctx)
+	if correlation.InferenceSessionID != "request-session" || correlation.GatewayRequestID != "request-gateway" || correlation.TraceID != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("request correlation did not override parent: %+v", correlation)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -36,6 +36,7 @@ func claudeOAuthRequestCancellation(ctx context.Context, auth *Auth, err error) 
 // Execute performs a non-streaming execution using the configured selector and executor.
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	ctx = coreusage.EnsureRequestCorrelation(ctx)
 	req, opts = cliproxysession.Enrich(req, opts)
 	normalized := m.normalizeProviders(providers)
 	if len(normalized) == 0 {
@@ -81,6 +82,7 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	ctx = coreusage.EnsureRequestCorrelation(ctx)
 	req, opts = cliproxysession.Enrich(req, opts)
 	normalized := m.normalizeProviders(providers)
 	if len(normalized) == 0 {
@@ -120,6 +122,7 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 // ExecuteStream performs a streaming execution using the configured selector and executor.
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	ctx = coreusage.EnsureRequestCorrelation(ctx)
 	req, opts = cliproxysession.Enrich(req, opts)
 	if m.HomeEnabled() {
 		if unlockSession := m.lockHomeWebsocketSession(ctx, opts); unlockSession != nil {

--- a/sdk/cliproxy/usage/correlation.go
+++ b/sdk/cliproxy/usage/correlation.go
@@ -1,0 +1,354 @@
+package usage
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+	"unicode"
+
+	"github.com/google/uuid"
+)
+
+const (
+	// InferenceSessionHeader is the authenticated Studio integration header.
+	InferenceSessionHeader = "X-CLIProxy-Studio-Inference-Session-ID"
+	// TraceParentHeader is the W3C trace context header.
+	TraceParentHeader = "traceparent"
+	// MaxCorrelationIDLength bounds opaque identifiers accepted at the gateway boundary.
+	MaxCorrelationIDLength = 256
+)
+
+var correlationSequence atomic.Uint64
+
+type contextKey uint8
+
+const (
+	inferenceSessionIDContextKey contextKey = iota
+	gatewayRequestIDContextKey
+	providerRequestIDContextKey
+	attemptIDContextKey
+	eventIDContextKey
+	traceIDContextKey
+)
+
+// Correlation contains identifiers with deliberately different scopes.
+type Correlation struct {
+	InferenceSessionID string
+	GatewayRequestID   string
+	ProviderRequestID  string
+	AttemptID          string
+	EventID            string
+	TraceID            string
+}
+
+// ValidateInferenceSessionID validates a Studio-issued opaque session identifier
+// without changing its value.
+func ValidateInferenceSessionID(value string) error {
+	return validateOpaqueID(value, "inference session ID")
+}
+
+// ValidateOpaqueID validates an opaque identifier received from an integration.
+func ValidateOpaqueID(value, name string) error {
+	return validateOpaqueID(value, name)
+}
+
+func validateOpaqueID(value, name string) error {
+	if name == "" {
+		name = "identifier"
+	}
+	if value == "" {
+		return fmt.Errorf("%s is empty", name)
+	}
+	if len(value) > MaxCorrelationIDLength {
+		return fmt.Errorf("%s exceeds %d bytes", name, MaxCorrelationIDLength)
+	}
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%s is blank", name)
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) || unicode.IsSpace(character) {
+			return fmt.Errorf("%s contains whitespace or control characters", name)
+		}
+	}
+	return nil
+}
+
+// ParseInferenceSessionID validates and returns the exact supplied value.
+func ParseInferenceSessionID(value string) (string, error) {
+	if err := ValidateInferenceSessionID(value); err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
+// ParseTraceParent returns the W3C trace ID from a valid traceparent header.
+// Invalid or unsupported traceparent values return an error so callers can
+// generate a fresh trace rather than forwarding an untrusted value.
+func ParseTraceParent(value string) (string, error) {
+	parts := strings.Split(value, "-")
+	if len(parts) != 4 || parts[0] != "00" || len(parts[1]) != 32 || len(parts[2]) != 16 || len(parts[3]) != 2 {
+		return "", errors.New("invalid traceparent format")
+	}
+	if parts[1] != strings.ToLower(parts[1]) || !isLowerHex(parts[1]) || !isLowerHex(parts[2]) || !isLowerHex(parts[3]) {
+		return "", errors.New("traceparent must use lowercase hexadecimal values")
+	}
+	if strings.Trim(parts[1], "0") == "" || strings.Trim(parts[2], "0") == "" {
+		return "", errors.New("traceparent contains an all-zero identifier")
+	}
+	return parts[1], nil
+}
+
+func isLowerHex(value string) bool {
+	for _, character := range value {
+		if (character < '0' || character > '9') && (character < 'a' || character > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// NewGatewayRequestID creates an identifier for one inbound gateway request.
+func NewGatewayRequestID() string { return newUUID() }
+
+// NewAttemptID creates an identifier for one physical provider attempt.
+func NewAttemptID() string { return newUUID() }
+
+// NewEventID creates an identifier that must remain stable for one usage event.
+func NewEventID() string { return newUUID() }
+
+// NewTraceID creates a W3C-compatible 32-character lowercase trace ID.
+func NewTraceID() string {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err == nil {
+		if strings.Trim(hex.EncodeToString(raw[:]), "0") != "" {
+			return hex.EncodeToString(raw[:])
+		}
+	}
+	sequence := correlationSequence.Add(1)
+	return fmt.Sprintf("%032x", uint64(time.Now().UnixNano())^sequence)
+}
+
+func newUUID() string {
+	if generated, err := uuid.NewRandom(); err == nil {
+		return generated.String()
+	}
+	sequence := correlationSequence.Add(1)
+	return fmt.Sprintf("fallback-%d-%d", time.Now().UnixNano(), sequence)
+}
+
+// WithInferenceSessionID stores a validated Studio session ID in ctx. Invalid
+// values are ignored; gateway boundaries should use ParseInferenceSessionID to
+// return a client-visible validation error.
+func WithInferenceSessionID(ctx context.Context, value string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if ValidateInferenceSessionID(value) != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, inferenceSessionIDContextKey, value)
+}
+
+// InferenceSessionIDFromContext returns the exact validated Studio session ID.
+func InferenceSessionIDFromContext(ctx context.Context) string {
+	return stringFromContext(ctx, inferenceSessionIDContextKey)
+}
+
+// WithoutInferenceSessionID hides any inherited Studio session ID while
+// preserving the rest of the context and its cancellation behavior.
+func WithoutInferenceSessionID(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return withoutInferenceSessionIDContext{Context: ctx}
+}
+
+type withoutInferenceSessionIDContext struct {
+	context.Context
+}
+
+func (ctx withoutInferenceSessionIDContext) Value(key any) any {
+	if key == inferenceSessionIDContextKey {
+		return nil
+	}
+	return ctx.Context.Value(key)
+}
+
+// WithGatewayRequestID stores a gateway request ID in ctx.
+func WithGatewayRequestID(ctx context.Context, value string) context.Context {
+	return withOpaqueContext(ctx, gatewayRequestIDContextKey, value, "gateway request ID")
+}
+
+// GatewayRequestIDFromContext returns the gateway request ID stored in ctx.
+func GatewayRequestIDFromContext(ctx context.Context) string {
+	return stringFromContext(ctx, gatewayRequestIDContextKey)
+}
+
+// WithProviderRequestID stores a validated provider request ID in ctx.
+func WithProviderRequestID(ctx context.Context, value string) context.Context {
+	return withOpaqueContext(ctx, providerRequestIDContextKey, value, "provider request ID")
+}
+
+// ProviderRequestIDFromContext returns the provider request ID stored in ctx.
+func ProviderRequestIDFromContext(ctx context.Context) string {
+	return stringFromContext(ctx, providerRequestIDContextKey)
+}
+
+// WithAttemptID stores an attempt ID in ctx.
+func WithAttemptID(ctx context.Context, value string) context.Context {
+	return withOpaqueContext(ctx, attemptIDContextKey, value, "attempt ID")
+}
+
+// AttemptIDFromContext returns the provider attempt ID stored in ctx.
+func AttemptIDFromContext(ctx context.Context) string {
+	return stringFromContext(ctx, attemptIDContextKey)
+}
+
+// WithEventID stores an event ID in ctx.
+func WithEventID(ctx context.Context, value string) context.Context {
+	return withOpaqueContext(ctx, eventIDContextKey, value, "event ID")
+}
+
+// EventIDFromContext returns the usage event ID stored in ctx.
+func EventIDFromContext(ctx context.Context) string {
+	return stringFromContext(ctx, eventIDContextKey)
+}
+
+// WithTraceID stores a valid W3C trace ID in ctx.
+func WithTraceID(ctx context.Context, value string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if len(value) != 32 || value != strings.ToLower(value) || !isLowerHex(value) || strings.Trim(value, "0") == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, traceIDContextKey, value)
+}
+
+// TraceIDFromContext returns the W3C trace ID stored in ctx.
+func TraceIDFromContext(ctx context.Context) string {
+	return stringFromContext(ctx, traceIDContextKey)
+}
+
+func withOpaqueContext(ctx context.Context, key contextKey, value, name string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if validateOpaqueID(value, name) != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, key, value)
+}
+
+func stringFromContext(ctx context.Context, key contextKey) string {
+	if ctx == nil {
+		return ""
+	}
+	value, _ := ctx.Value(key).(string)
+	return value
+}
+
+// CorrelationFromContext copies the currently known identifiers from ctx.
+func CorrelationFromContext(ctx context.Context) Correlation {
+	return Correlation{
+		InferenceSessionID: InferenceSessionIDFromContext(ctx),
+		GatewayRequestID:   GatewayRequestIDFromContext(ctx),
+		ProviderRequestID:  ProviderRequestIDFromContext(ctx),
+		AttemptID:          AttemptIDFromContext(ctx),
+		EventID:            EventIDFromContext(ctx),
+		TraceID:            TraceIDFromContext(ctx),
+	}
+}
+
+// EnsureRequestCorrelation returns a context with stable gateway and trace IDs.
+// Existing values are preserved, so retries and nested execution do not create
+// new request or trace identities.
+func EnsureRequestCorrelation(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if GatewayRequestIDFromContext(ctx) == "" {
+		ctx = WithGatewayRequestID(ctx, NewGatewayRequestID())
+	}
+	if TraceIDFromContext(ctx) == "" {
+		ctx = WithTraceID(ctx, NewTraceID())
+	}
+	return ctx
+}
+
+// ProviderRequestIDFromHeaders extracts only provider-assigned response IDs.
+// x-client-request-id is intentionally excluded because it is a caller-facing
+// request header and has different semantics.
+func ProviderRequestIDFromHeaders(headers http.Header) string {
+	if headers == nil {
+		return ""
+	}
+	for _, name := range []string{
+		"X-Provider-Request-Id",
+		"X-Request-Id",
+		"Request-Id",
+		"Anthropic-Request-Id",
+		"X-Amzn-RequestId",
+		"X-Goog-Request-Id",
+	} {
+		for _, value := range headers.Values(name) {
+			if ValidateOpaqueID(value, "provider request ID") == nil {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+// NormalizeRecord fills identifiers from ctx and creates IDs that are missing
+// from legacy callers. It returns a new record value and never mutates input
+// maps or headers.
+func NormalizeRecord(ctx context.Context, record Record) Record {
+	correlation := CorrelationFromContext(ctx)
+	if record.InferenceSessionID == "" {
+		record.InferenceSessionID = correlation.InferenceSessionID
+	}
+	if record.GatewayRequestID == "" {
+		record.GatewayRequestID = correlation.GatewayRequestID
+	}
+	if record.ProviderRequestID == "" {
+		record.ProviderRequestID = correlation.ProviderRequestID
+	}
+	if record.AttemptID == "" && hasProviderAttempt(record) {
+		record.AttemptID = correlation.AttemptID
+		if record.AttemptID == "" {
+			record.AttemptID = NewAttemptID()
+		}
+	}
+	if record.EventID == "" {
+		record.EventID = correlation.EventID
+		if record.EventID == "" {
+			record.EventID = NewEventID()
+		}
+	}
+	if record.TraceID == "" {
+		record.TraceID = correlation.TraceID
+		if record.TraceID == "" {
+			record.TraceID = NewTraceID()
+		}
+	}
+	if record.GatewayRequestID == "" {
+		record.GatewayRequestID = NewGatewayRequestID()
+	}
+	if record.ProviderRequestID == "" {
+		record.ProviderRequestID = ProviderRequestIDFromHeaders(record.ResponseHeaders)
+	}
+	return record
+}
+
+func hasProviderAttempt(record Record) bool {
+	return strings.TrimSpace(record.Provider) != "" ||
+		strings.TrimSpace(record.ExecutorType) != "" ||
+		strings.TrimSpace(record.Model) != ""
+}

--- a/sdk/cliproxy/usage/correlation_test.go
+++ b/sdk/cliproxy/usage/correlation_test.go
@@ -1,0 +1,110 @@
+package usage
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestParseInferenceSessionIDPreservesExactValue(t *testing.T) {
+	want := "studio-session_01"
+	got, err := ParseInferenceSessionID(want)
+	if err != nil {
+		t.Fatalf("ParseInferenceSessionID() error = %v", err)
+	}
+	if got != want {
+		t.Fatalf("ParseInferenceSessionID() = %q, want %q", got, want)
+	}
+}
+
+func TestParseInferenceSessionIDRejectsMalformedValues(t *testing.T) {
+	cases := []string{"", " ", "studio session", "studio\nsession", strings.Repeat("x", MaxCorrelationIDLength+1)}
+	for _, value := range cases {
+		t.Run(value, func(t *testing.T) {
+			if _, err := ParseInferenceSessionID(value); err == nil {
+				t.Fatalf("ParseInferenceSessionID(%q) returned nil error", value)
+			}
+		})
+	}
+}
+
+func TestParseTraceParentReturnsW3CTraceID(t *testing.T) {
+	got, err := ParseTraceParent("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	if err != nil {
+		t.Fatalf("ParseTraceParent() error = %v", err)
+	}
+	if got != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("ParseTraceParent() = %q", got)
+	}
+}
+
+func TestEnsureRequestCorrelationPreservesExistingIDs(t *testing.T) {
+	ctx := WithInferenceSessionID(context.Background(), "studio-session")
+	ctx = WithGatewayRequestID(ctx, "gateway-request")
+	ctx = WithTraceID(ctx, "4bf92f3577b34da6a3ce929d0e0e4736")
+	ensured := EnsureRequestCorrelation(ctx)
+	correlation := CorrelationFromContext(ensured)
+	if correlation.InferenceSessionID != "studio-session" {
+		t.Fatalf("inference session ID = %q", correlation.InferenceSessionID)
+	}
+	if correlation.GatewayRequestID != "gateway-request" {
+		t.Fatalf("gateway request ID = %q", correlation.GatewayRequestID)
+	}
+	if correlation.TraceID != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("trace ID = %q", correlation.TraceID)
+	}
+}
+
+func TestWithoutInferenceSessionIDPreservesOtherCorrelation(t *testing.T) {
+	ctx := WithInferenceSessionID(context.Background(), "studio-session")
+	ctx = WithGatewayRequestID(ctx, "gateway-request")
+	ctx = WithTraceID(ctx, "4bf92f3577b34da6a3ce929d0e0e4736")
+	cleared := WithoutInferenceSessionID(ctx)
+	correlation := CorrelationFromContext(cleared)
+	if correlation.InferenceSessionID != "" {
+		t.Fatalf("inference session ID = %q, want empty", correlation.InferenceSessionID)
+	}
+	if correlation.GatewayRequestID != "gateway-request" || correlation.TraceID != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("other correlation fields changed: %+v", correlation)
+	}
+}
+
+func TestNormalizeRecordCreatesDistinctAttemptAndStableEventIDs(t *testing.T) {
+	ctx := WithInferenceSessionID(context.Background(), "studio-session")
+	first := NormalizeRecord(ctx, Record{Provider: "openai", Model: "gpt-5.4"})
+	if first.InferenceSessionID != "studio-session" {
+		t.Fatalf("inference session ID = %q", first.InferenceSessionID)
+	}
+	if first.GatewayRequestID == "" || first.AttemptID == "" || first.EventID == "" || first.TraceID == "" {
+		t.Fatalf("missing generated correlation IDs: %+v", first)
+	}
+	second := NormalizeRecord(ctx, first)
+	if second.EventID != first.EventID {
+		t.Fatalf("event ID changed from %q to %q", first.EventID, second.EventID)
+	}
+	if second.AttemptID != first.AttemptID {
+		t.Fatalf("attempt ID changed from %q to %q", first.AttemptID, second.AttemptID)
+	}
+}
+
+func TestNormalizeRecordDoesNotFabricateAttemptBeforeProviderDispatch(t *testing.T) {
+	record := NormalizeRecord(context.Background(), Record{})
+	if record.AttemptID != "" {
+		t.Fatalf("attempt ID = %q, want empty", record.AttemptID)
+	}
+	if record.EventID == "" || record.GatewayRequestID == "" || record.TraceID == "" {
+		t.Fatalf("missing non-attempt IDs: %+v", record)
+	}
+}
+
+func TestProviderRequestIDFromHeadersExcludesClientRequestID(t *testing.T) {
+	headers := http.Header{
+		"X-Client-Request-Id": []string{"client-request"},
+		"X-Request-Id":        []string{"provider-request"},
+		"Authorization":       []string{"Bearer secret"},
+	}
+	if got := ProviderRequestIDFromHeaders(headers); got != "provider-request" {
+		t.Fatalf("ProviderRequestIDFromHeaders() = %q", got)
+	}
+}

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -32,6 +32,18 @@ type Record struct {
 	AccessTokenSHA256 string
 	AuthType          string
 	Source            string
+	// InferenceSessionID is the Studio-issued logical inference session identity.
+	InferenceSessionID string
+	// GatewayRequestID identifies the inbound request handled by this gateway.
+	GatewayRequestID string
+	// ProviderRequestID identifies the provider-assigned request when available.
+	ProviderRequestID string
+	// AttemptID identifies one physical provider attempt and changes on retries.
+	AttemptID string
+	// EventID is stable for this terminal usage event across delivery retries.
+	EventID string
+	// TraceID is a W3C-compatible distributed trace identifier.
+	TraceID string
 	// ReasoningEffort stores the translated upstream thinking level for request event logs.
 	ReasoningEffort string
 	// ServiceTier stores the client-requested service tier.
@@ -313,6 +325,7 @@ func (m *Manager) Publish(ctx context.Context, record Record) {
 	if m == nil {
 		return
 	}
+	record = NormalizeRecord(ctx, record)
 	// ensure worker is running even if Start was not called explicitly
 	m.Start(context.Background())
 	m.mu.Lock()

--- a/sdk/pluginabi/types.go
+++ b/sdk/pluginabi/types.go
@@ -8,6 +8,9 @@ const (
 	// SchemaVersion tracks the RPC JSON contract exchanged at plugin.register.
 	// Version 2 adds request lifecycle completion and active request termination.
 	SchemaVersion uint32 = 2
+	// UsageSchemaVersion tracks the usage.handle payload independently from the
+	// broader plugin registration schema.
+	UsageSchemaVersion uint32 = 1
 )
 
 const (

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -1323,6 +1323,20 @@ type UsageRecord struct {
 	AuthType string
 	// Source identifies the request source or integration.
 	Source string
+	// UsageSchemaVersion identifies the usage.handle payload schema.
+	UsageSchemaVersion uint32 `json:"usageSchemaVersion,omitempty"`
+	// InferenceSessionID is the Studio-issued logical inference session identity.
+	InferenceSessionID string `json:"inferenceSessionId,omitempty"`
+	// GatewayRequestID identifies the inbound request handled by the gateway.
+	GatewayRequestID string `json:"gatewayRequestId,omitempty"`
+	// ProviderRequestID identifies the provider-assigned request when available.
+	ProviderRequestID string `json:"providerRequestId,omitempty"`
+	// AttemptID identifies one physical provider attempt.
+	AttemptID string `json:"attemptId,omitempty"`
+	// EventID is stable for this terminal usage event across delivery retries.
+	EventID string `json:"eventId,omitempty"`
+	// TraceID is a W3C-compatible distributed trace identifier.
+	TraceID string `json:"traceId,omitempty"`
 	// ReasoningEffort records the requested reasoning effort.
 	ReasoningEffort string
 	// ServiceTier records the requested or reported service tier.

--- a/sdk/pluginapi/types_test.go
+++ b/sdk/pluginapi/types_test.go
@@ -30,6 +30,34 @@ var _ StreamChunkInterceptor = (*compileTimePlugin)(nil)
 var _ ThinkingApplier = (*compileTimePlugin)(nil)
 var _ UsagePlugin = (*compileTimePlugin)(nil)
 var _ CommandLinePlugin = (*compileTimePlugin)(nil)
+
+func TestUsageRecordCorrelationJSONUsesStableNames(t *testing.T) {
+	raw, errMarshal := json.Marshal(UsageRecord{
+		UsageSchemaVersion: 1,
+		InferenceSessionID: "studio-session",
+		GatewayRequestID:   "gateway-request",
+		ProviderRequestID:  "provider-request",
+		AttemptID:          "attempt",
+		EventID:            "event",
+		TraceID:            "4bf92f3577b34da6a3ce929d0e0e4736",
+	})
+	if errMarshal != nil {
+		t.Fatalf("json.Marshal() error = %v", errMarshal)
+	}
+	for _, field := range []string{"usageSchemaVersion", "inferenceSessionId", "gatewayRequestId", "providerRequestId", "attemptId", "eventId", "traceId"} {
+		if !strings.Contains(string(raw), `"`+field+`"`) {
+			t.Fatalf("JSON payload missing %q: %s", field, raw)
+		}
+	}
+	var decoded UsageRecord
+	if errUnmarshal := json.Unmarshal(raw, &decoded); errUnmarshal != nil {
+		t.Fatalf("json.Unmarshal() error = %v", errUnmarshal)
+	}
+	if decoded.InferenceSessionID != "studio-session" || decoded.GatewayRequestID != "gateway-request" || decoded.ProviderRequestID != "provider-request" || decoded.AttemptID != "attempt" || decoded.EventID != "event" || decoded.TraceID == "" {
+		t.Fatalf("decoded correlation = %+v", decoded)
+	}
+}
+
 var _ ManagementAPI = (*compileTimePlugin)(nil)
 var _ ManagementHandler = (*compileTimePlugin)(nil)
 


### PR DESCRIPTION
## Summary

- Allow Studio `GET /v1/models` and `GET /v1beta/models` requests without an inference-session header.
- Keep generation routes fail-closed when the Studio inference-session header is missing.
- Add middleware coverage for both model-discovery endpoints, including correlation context behavior.
- Rebase the original implementation commits onto current upstream `dev`; the two genuine conflicts were resolved by retaining both upstream usage fields and Studio correlation fields without changing the intended behavior.

This supersedes closed PR #4730, which was closed after the Codex P2 finding that model discovery was incorrectly rejected without a Studio session header.

## Validation

- `gofmt -w` on all Go files in the implementation diff: passed.
- `git diff --check`: passed.
- `go test -count=1 ./internal/api`: passed.
- `go build -o /tmp/cliproxyapi-server-rebased ./cmd/server`: passed.
- `go test ./...`: fails only in the upstream-dev baseline's `internal/runtime/executor` package because these three environment-sensitive tests report `X-Stainless-Os = "MacOS"`, want `"Linux"`:
  - `TestApplyClaudeHeaders_DisableDeviceProfileStabilization`
  - `TestApplyClaudeHeaders_LegacyModePreservesConfiguredUserAgentOverrideForClaudeClients`
  - `TestClaudeExecutor_NonClaudeRequestUsesClaudeCode220CLIFingerprint`

The same three failures reproduce on upstream `dev` at `a4a87735a296c009f3a92619a87a257f483f8840`; no other full-suite failures were observed.
