### PR TITLE
feat(claude): add the Claude Code manual OAuth flow for headless hosts

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -173,6 +173,14 @@ disable-claude-cloak-mode: false
 claude-code:
   # When true, return original model IDs in Anthropic model list responses instead of cloaked IDs.
   disable-cloaking-model-list: false
+  # When true, Claude OAuth logins use the manual flow the native Claude Code CLI falls back to
+  # on headless hosts: the authorization URL points at https://platform.claude.com/oauth/code/callback
+  # instead of http://localhost:54545/callback, and the login is finished by submitting the
+  # "<code>#<state>" pair that page renders (paste it into the management panel's callback field,
+  # or into the --claude-login prompt). Turn this on when the browser used for authorization cannot
+  # reach this server on the callback port, e.g. a headless VPS driven from a laptop browser.
+  # The management endpoint also accepts a per-request override: /v0/management/anthropic-auth-url?manual=1
+  manual-oauth: false
 
 # disable-image-generation supports: false (default), true, "chat", or "passthrough".
 # - true: disable image_generation everywhere (also returns 404 for /v1/images/generations and /v1/images/edits).

--- a/internal/api/handlers/management/auth_files_provider_oauth.go
+++ b/internal/api/handlers/management/auth_files_provider_oauth.go
@@ -58,8 +58,22 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 	// Initialize Claude auth service
 	anthropicAuth := claude.NewClaudeAuth(h.cfg)
 
+	// Manual mode targets Anthropic's hosted callback instead of a local port, so
+	// the authorizing browser never has to reach this host. The user completes the
+	// login by submitting the "<code>#<state>" pair rendered on that page.
+	manual := h.anthropicManualOAuth(c)
+	redirectURI := claude.RedirectURI
+	if manual {
+		redirectURI = claude.ManualRedirectURI
+	}
+
 	// Generate authorization URL (then override redirect_uri to reuse server port)
-	authURL, state, err := anthropicAuth.GenerateAuthURL(state, pkceCodes)
+	var authURL string
+	if manual {
+		authURL, state, err = anthropicAuth.GenerateManualAuthURL(state, pkceCodes)
+	} else {
+		authURL, state, err = anthropicAuth.GenerateAuthURL(state, pkceCodes)
+	}
 	if err != nil {
 		log.Errorf("Failed to generate authorization URL: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate authorization url"})
@@ -68,7 +82,9 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 
 	RegisterOAuthSession(state, "anthropic")
 
-	isWebUI := isWebUIRequest(c)
+	// The local callback forwarder only helps the local-redirect flow; the manual
+	// flow never redirects to this host.
+	isWebUI := isWebUIRequest(c) && !manual
 	var forwarder *callbackForwarder
 	if isWebUI {
 		targetURL, errTarget := h.managementCallbackURL("/anthropic/callback")
@@ -142,7 +158,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 		code := strings.Split(rawCode, "#")[0]
 
 		// Exchange code for tokens using internal auth service
-		bundle, errExchange := anthropicAuth.ExchangeCodeForTokens(ctx, code, state, pkceCodes)
+		bundle, errExchange := anthropicAuth.ExchangeCodeForTokensWithRedirect(ctx, code, state, redirectURI, pkceCodes)
 		if errExchange != nil {
 			authErr := claude.NewAuthenticationError(claude.ErrCodeExchangeFailed, errExchange)
 			log.Errorf("Failed to exchange authorization code for tokens: %v", authErr)
@@ -190,7 +206,23 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 		CompleteOAuthSession(state)
 	}()
 
-	c.JSON(200, gin.H{"status": "ok", "url": authURL, "state": state})
+	c.JSON(200, gin.H{"status": "ok", "url": authURL, "state": state, "manual": manual})
+}
+
+// anthropicManualOAuth reports whether the Claude login should use Anthropic's
+// hosted callback. The "manual" query parameter overrides the configured default
+// so the flow can be selected per request without editing the config.
+func (h *Handler) anthropicManualOAuth(c *gin.Context) bool {
+	raw := strings.TrimSpace(c.Query("manual"))
+	if raw == "" {
+		return h.cfg != nil && h.cfg.ClaudeCode.ManualOAuth
+	}
+	switch strings.ToLower(raw) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func (h *Handler) RequestCodexToken(c *gin.Context) {

--- a/internal/api/handlers/management/oauth_callback.go
+++ b/internal/api/handlers/management/oauth_callback.go
@@ -53,22 +53,34 @@ func (h *Handler) handleOAuthCallback(c *gin.Context, req oauthCallbackRequest) 
 	errMsg := strings.TrimSpace(req.Error)
 
 	if rawRedirect := strings.TrimSpace(req.RedirectURL); rawRedirect != "" {
-		u, errParse := url.Parse(rawRedirect)
-		if errParse != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid redirect_url"})
-			return
-		}
-		q := u.Query()
-		if state == "" {
-			state = strings.TrimSpace(q.Get("state"))
-		}
-		if code == "" {
-			code = strings.TrimSpace(q.Get("code"))
-		}
-		if errMsg == "" {
-			errMsg = strings.TrimSpace(q.Get("error"))
+		// The manual Claude flow hands the user a bare "<code>#<state>" pair rendered
+		// by Anthropic's hosted callback instead of a callback URL, so accept it in
+		// the same field.
+		if manualCode, manualState, isManual := parseManualCodePair(rawRedirect); isManual {
+			if state == "" {
+				state = manualState
+			}
+			if code == "" {
+				code = manualCode
+			}
+		} else {
+			u, errParse := url.Parse(rawRedirect)
+			if errParse != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid redirect_url"})
+				return
+			}
+			q := u.Query()
+			if state == "" {
+				state = strings.TrimSpace(q.Get("state"))
+			}
+			if code == "" {
+				code = strings.TrimSpace(q.Get("code"))
+			}
 			if errMsg == "" {
-				errMsg = strings.TrimSpace(q.Get("error_description"))
+				errMsg = strings.TrimSpace(q.Get("error"))
+				if errMsg == "" {
+					errMsg = strings.TrimSpace(q.Get("error_description"))
+				}
 			}
 		}
 	}
@@ -135,6 +147,25 @@ func (h *Handler) handleOAuthCallback(c *gin.Context, req oauthCallbackRequest) 
 	}
 
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+// parseManualCodePair splits the "<code>#<state>" pair Anthropic's hosted OAuth
+// callback page renders for manual logins. Anything carrying URL syntax is left
+// to the callback-URL parser instead.
+func parseManualCodePair(raw string) (code, state string, ok bool) {
+	if strings.Contains(raw, "://") || strings.ContainsAny(raw, "?&") {
+		return "", "", false
+	}
+	idx := strings.Index(raw, "#")
+	if idx <= 0 {
+		return "", "", false
+	}
+	code = strings.TrimSpace(raw[:idx])
+	state = strings.TrimSpace(raw[idx+1:])
+	if code == "" || state == "" {
+		return "", "", false
+	}
+	return code, state, true
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/api/handlers/management/oauth_callback_manual_test.go
+++ b/internal/api/handlers/management/oauth_callback_manual_test.go
@@ -1,0 +1,64 @@
+package management
+
+import "testing"
+
+func TestParseManualCodePair(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantCode  string
+		wantState string
+		wantOK    bool
+	}{
+		{
+			name:   "bare code without state",
+			raw:    "ac_01ABCdef-123",
+			wantOK: false,
+		},
+		{
+			name:      "code and state",
+			raw:       "ac_01ABCdef-123#z0lAE_ru8ATNwBc1inRpt40wFm8axKj3-8uQSQdIq5Q",
+			wantCode:  "ac_01ABCdef-123",
+			wantState: "z0lAE_ru8ATNwBc1inRpt40wFm8axKj3-8uQSQdIq5Q",
+			wantOK:    true,
+		},
+		{
+			name:   "callback url is not a manual pair",
+			raw:    "http://localhost:54545/callback?code=abc&state=def",
+			wantOK: false,
+		},
+		{
+			name:   "callback url with fragment is not a manual pair",
+			raw:    "http://localhost:54545/callback?code=abc#def",
+			wantOK: false,
+		},
+		{
+			name:   "empty state",
+			raw:    "abc#",
+			wantOK: false,
+		},
+		{
+			name:   "empty code",
+			raw:    "#def",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, state, ok := parseManualCodePair(tt.raw)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if code != tt.wantCode {
+				t.Fatalf("code = %q, want %q", code, tt.wantCode)
+			}
+			if state != tt.wantState {
+				t.Fatalf("state = %q, want %q", state, tt.wantState)
+			}
+		})
+	}
+}

--- a/internal/auth/claude/anthropic_auth.go
+++ b/internal/auth/claude/anthropic_auth.go
@@ -34,6 +34,18 @@ const (
 	RedirectURI      = "http://localhost:54545/callback"
 	ClaudeOAuthScope = "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
 
+	// ManualAuthURL is the claude.com entry point the native Claude Code CLI opens
+	// for subscription logins. It 307-redirects to AuthURL with the query preserved,
+	// so both endpoints accept the same parameters.
+	ManualAuthURL = "https://claude.com/cai/oauth/authorize"
+	// ManualRedirectURI is the Anthropic-hosted callback the native CLI uses when it
+	// cannot bind a local port. That page renders "<code>#<state>" for the user to
+	// paste back, so the browser never has to reach this host.
+	ManualRedirectURI = "https://platform.claude.com/oauth/code/callback"
+	// ManualOAuthScope is the scope set Claude Code 2.1.223 requests on the manual
+	// path: ClaudeOAuthScope plus the API-key creation scope.
+	ManualOAuthScope = "org:create_api_key " + ClaudeOAuthScope
+
 	claudeRefreshMinBackoff       = 5 * time.Second
 	claudeRefreshMaxBackoff       = 5 * time.Minute
 	claudeRefreshTimeout          = 30 * time.Second
@@ -317,22 +329,56 @@ func (o *ClaudeAuth) inspectOAuthAccount(ctx context.Context, accessToken string
 //   - string: The state parameter for verification
 //   - error: An error if PKCE codes are missing or URL generation fails
 func (o *ClaudeAuth) GenerateAuthURL(state string, pkceCodes *PKCECodes) (string, string, error) {
+	return buildAuthURL(AuthURL, RedirectURI, ClaudeOAuthScope, state, pkceCodes)
+}
+
+// GenerateManualAuthURL creates the authorization URL the native Claude Code CLI
+// opens when it cannot bind a local callback port. Anthropic hosts the redirect
+// target and renders "<code>#<state>" on it, so the login completes by pasting
+// that pair back instead of by an inbound request to this host.
+//
+// Parameters:
+//   - state: A random state parameter for CSRF protection
+//   - pkceCodes: The PKCE codes for secure code exchange
+//
+// Returns:
+//   - string: The complete authorization URL
+//   - string: The state parameter for verification
+//   - error: An error if PKCE codes are missing or URL generation fails
+func (o *ClaudeAuth) GenerateManualAuthURL(state string, pkceCodes *PKCECodes) (string, string, error) {
+	return buildAuthURL(ManualAuthURL, ManualRedirectURI, ManualOAuthScope, state, pkceCodes)
+}
+
+func buildAuthURL(endpoint, redirectURI, scope, state string, pkceCodes *PKCECodes) (string, string, error) {
 	if pkceCodes == nil {
 		return "", "", fmt.Errorf("PKCE codes are required")
 	}
 
-	params := url.Values{
-		"code":                  {"true"},
-		"client_id":             {ClientID},
-		"response_type":         {"code"},
-		"redirect_uri":          {RedirectURI},
-		"scope":                 {ClaudeOAuthScope},
-		"code_challenge":        {pkceCodes.CodeChallenge},
-		"code_challenge_method": {"S256"},
-		"state":                 {state},
+	// Parameter order reproduces the sequence Claude Code 2.1.223 appends to its
+	// URLSearchParams. url.Values.Encode would sort the keys alphabetically and
+	// emit a query that no native client ever sends.
+	params := [][2]string{
+		{"code", "true"},
+		{"client_id", ClientID},
+		{"response_type", "code"},
+		{"redirect_uri", redirectURI},
+		{"scope", scope},
+		{"code_challenge", pkceCodes.CodeChallenge},
+		{"code_challenge_method", "S256"},
+		{"state", state},
 	}
 
-	authURL := fmt.Sprintf("%s?%s", AuthURL, params.Encode())
+	var query strings.Builder
+	for i, param := range params {
+		if i > 0 {
+			query.WriteByte('&')
+		}
+		query.WriteString(url.QueryEscape(param[0]))
+		query.WriteByte('=')
+		query.WriteString(url.QueryEscape(param[1]))
+	}
+
+	authURL := fmt.Sprintf("%s?%s", endpoint, query.String())
 	return authURL, state, nil
 }
 
@@ -368,8 +414,31 @@ func (c *ClaudeAuth) parseCodeAndState(code string) (parsedCode, parsedState str
 //   - *ClaudeAuthBundle: The complete authentication bundle with tokens
 //   - error: An error if token exchange fails
 func (o *ClaudeAuth) ExchangeCodeForTokens(ctx context.Context, code, state string, pkceCodes *PKCECodes) (*ClaudeAuthBundle, error) {
+	return o.ExchangeCodeForTokensWithRedirect(ctx, code, state, RedirectURI, pkceCodes)
+}
+
+// ExchangeCodeForTokensWithRedirect exchanges an authorization code for tokens
+// using an explicit redirect_uri. Anthropic binds the code to the redirect_uri
+// that produced it, so callers must pass the same value they put in the
+// authorization URL: RedirectURI for the local-callback flow, ManualRedirectURI
+// for the manual Claude Code flow.
+//
+// Parameters:
+//   - ctx: The context for the request
+//   - code: The authorization code received from OAuth callback
+//   - state: The state parameter for verification
+//   - redirectURI: The redirect_uri used to obtain the code
+//   - pkceCodes: The PKCE codes for secure verification
+//
+// Returns:
+//   - *ClaudeAuthBundle: The complete authentication bundle with tokens
+//   - error: An error if token exchange fails
+func (o *ClaudeAuth) ExchangeCodeForTokensWithRedirect(ctx context.Context, code, state, redirectURI string, pkceCodes *PKCECodes) (*ClaudeAuthBundle, error) {
 	if pkceCodes == nil {
 		return nil, fmt.Errorf("PKCE codes are required for token exchange")
+	}
+	if strings.TrimSpace(redirectURI) == "" {
+		redirectURI = RedirectURI
 	}
 	newCode, newState := o.parseCodeAndState(code)
 
@@ -379,7 +448,7 @@ func (o *ClaudeAuth) ExchangeCodeForTokens(ctx context.Context, code, state stri
 	reqBody := authorizationCodeExchangeRequest{
 		GrantType:    "authorization_code",
 		Code:         newCode,
-		RedirectURI:  RedirectURI,
+		RedirectURI:  redirectURI,
 		ClientID:     ClientID,
 		CodeVerifier: pkceCodes.CodeVerifier,
 		State:        state,

--- a/internal/auth/claude/anthropic_manual_auth_test.go
+++ b/internal/auth/claude/anthropic_manual_auth_test.go
@@ -1,0 +1,164 @@
+package claude
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+// The expected values mirror the authorization URL Claude Code 2.1.223 opens when
+// it cannot bind a local callback port.
+func TestGenerateManualAuthURLMatchesNativeClaudeCodeFlow(t *testing.T) {
+	auth := &ClaudeAuth{}
+
+	rawURL, state, err := auth.GenerateManualAuthURL("state-value", &PKCECodes{CodeChallenge: "challenge", CodeVerifier: "verifier"})
+	if err != nil {
+		t.Fatalf("GenerateManualAuthURL() error = %v", err)
+	}
+	if state != "state-value" {
+		t.Fatalf("state = %q, want state-value", state)
+	}
+
+	parsed, errParse := url.Parse(rawURL)
+	if errParse != nil {
+		t.Fatal(errParse)
+	}
+	if got := parsed.Scheme + "://" + parsed.Host + parsed.Path; got != ManualAuthURL {
+		t.Fatalf("authorize endpoint = %q, want %q", got, ManualAuthURL)
+	}
+
+	want := map[string]string{
+		"code":                  "true",
+		"client_id":             ClientID,
+		"response_type":         "code",
+		"redirect_uri":          ManualRedirectURI,
+		"scope":                 "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload",
+		"code_challenge":        "challenge",
+		"code_challenge_method": "S256",
+		"state":                 "state-value",
+	}
+	q := parsed.Query()
+	for name, wantValue := range want {
+		if got := q.Get(name); got != wantValue {
+			t.Fatalf("%s = %q, want %q", name, got, wantValue)
+		}
+	}
+	if len(q) != len(want) {
+		t.Fatalf("query = %v, want exactly %d parameters", q, len(want))
+	}
+
+	// Byte-for-byte match against a URL captured from Claude Code 2.1.223, with the
+	// per-login challenge and state substituted. url.Values.Encode would sort the
+	// keys alphabetically and produce a query no native client ever sends.
+	wantURL := ManualAuthURL + "?code=true" +
+		"&client_id=" + ClientID +
+		"&response_type=code" +
+		"&redirect_uri=https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback" +
+		"&scope=org%3Acreate_api_key+user%3Aprofile+user%3Ainference+user%3Asessions%3Aclaude_code+user%3Amcp_servers+user%3Afile_upload" +
+		"&code_challenge=challenge" +
+		"&code_challenge_method=S256" +
+		"&state=state-value"
+	if rawURL != wantURL {
+		t.Fatalf("authorize URL =\n%s\nwant\n%s", rawURL, wantURL)
+	}
+}
+
+// The local-callback flow must keep its own redirect_uri and scope.
+func TestGenerateAuthURLKeepsLocalCallbackFlow(t *testing.T) {
+	auth := &ClaudeAuth{}
+
+	rawURL, _, err := auth.GenerateAuthURL("state-value", &PKCECodes{CodeChallenge: "challenge"})
+	if err != nil {
+		t.Fatalf("GenerateAuthURL() error = %v", err)
+	}
+	parsed, errParse := url.Parse(rawURL)
+	if errParse != nil {
+		t.Fatal(errParse)
+	}
+	if got := parsed.Scheme + "://" + parsed.Host + parsed.Path; got != AuthURL {
+		t.Fatalf("authorize endpoint = %q, want %q", got, AuthURL)
+	}
+	if got := parsed.Query().Get("redirect_uri"); got != RedirectURI {
+		t.Fatalf("redirect_uri = %q, want %q", got, RedirectURI)
+	}
+	if got := parsed.Query().Get("scope"); got != ClaudeOAuthScope {
+		t.Fatalf("scope = %q, want %q", got, ClaudeOAuthScope)
+	}
+}
+
+// Anthropic binds the code to the redirect_uri that produced it, so the manual
+// exchange must send the hosted callback and split the pasted "<code>#<state>".
+func TestExchangeCodeForTokensWithRedirectUsesManualRedirect(t *testing.T) {
+	var tokenBody []byte
+
+	auth := &ClaudeAuth{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch req.URL.String() {
+				case TokenURL:
+					body, errRead := io.ReadAll(req.Body)
+					if errRead != nil {
+						t.Fatal(errRead)
+					}
+					tokenBody = body
+					return jsonResponse(req, `{"access_token":"access","refresh_token":"refresh","expires_in":28800}`), nil
+				case ProfileURL:
+					return jsonResponse(req, `{"account":{"uuid":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","email":"user@example.com"},"organization":{"uuid":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","name":"Example Org"}}`), nil
+				case RolesURL:
+					return jsonResponse(req, `{"roles":["claude_code_user"]}`), nil
+				default:
+					t.Fatalf("unexpected OAuth request URL %s", req.URL)
+					return nil, nil
+				}
+			}),
+		},
+	}
+
+	if _, err := auth.ExchangeCodeForTokensWithRedirect(t.Context(), "auth-code#state-value", "state-value", ManualRedirectURI, &PKCECodes{CodeVerifier: "verifier"}); err != nil {
+		t.Fatalf("ExchangeCodeForTokensWithRedirect() error = %v", err)
+	}
+
+	wantBody := `{"grant_type":"authorization_code","code":"auth-code","redirect_uri":"` + ManualRedirectURI + `","client_id":"` + ClientID + `","code_verifier":"verifier","state":"state-value"}`
+	if got := string(tokenBody); got != wantBody {
+		t.Fatalf("exchange body = %q, want %q", got, wantBody)
+	}
+}
+
+// An empty redirect_uri falls back to the local callback so existing callers keep
+// their behavior.
+func TestExchangeCodeForTokensWithRedirectDefaultsToLocalCallback(t *testing.T) {
+	var tokenBody []byte
+
+	auth := &ClaudeAuth{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch req.URL.String() {
+				case TokenURL:
+					body, errRead := io.ReadAll(req.Body)
+					if errRead != nil {
+						t.Fatal(errRead)
+					}
+					tokenBody = body
+					return jsonResponse(req, `{"access_token":"access","refresh_token":"refresh","expires_in":28800}`), nil
+				case ProfileURL:
+					return jsonResponse(req, `{"account":{"uuid":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","email":"user@example.com"},"organization":{"uuid":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","name":"Example Org"}}`), nil
+				case RolesURL:
+					return jsonResponse(req, `{"roles":["claude_code_user"]}`), nil
+				default:
+					t.Fatalf("unexpected OAuth request URL %s", req.URL)
+					return nil, nil
+				}
+			}),
+		},
+	}
+
+	if _, err := auth.ExchangeCodeForTokensWithRedirect(t.Context(), "auth-code", "state-value", "", &PKCECodes{CodeVerifier: "verifier"}); err != nil {
+		t.Fatalf("ExchangeCodeForTokensWithRedirect() error = %v", err)
+	}
+
+	wantBody := `{"grant_type":"authorization_code","code":"auth-code","redirect_uri":"` + RedirectURI + `","client_id":"` + ClientID + `","code_verifier":"verifier","state":"state-value"}`
+	if got := string(tokenBody); got != wantBody {
+		t.Fatalf("exchange body = %q, want %q", got, wantBody)
+	}
+}

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -67,6 +67,13 @@ type SDKConfig struct {
 type ClaudeCodeConfig struct {
 	// DisableCloakingModelList disables model ID cloaking in Anthropic model list responses.
 	DisableCloakingModelList bool `yaml:"disable-cloaking-model-list" json:"disable-cloaking-model-list"`
+
+	// ManualOAuth switches Claude logins to the manual flow the native Claude Code
+	// CLI uses on headless hosts: the authorization URL points at Anthropic's hosted
+	// callback instead of http://localhost:54545/callback, and the login is completed
+	// by pasting the "<code>#<state>" pair that page renders. Required when the
+	// browser used for authorization cannot reach this host on the callback port.
+	ManualOAuth bool `yaml:"manual-oauth" json:"manual-oauth"`
 }
 
 // StreamingConfig holds server streaming behavior configuration.

--- a/sdk/auth/claude.go
+++ b/sdk/auth/claude.go
@@ -61,6 +61,12 @@ func (a *ClaudeAuthenticator) Login(ctx context.Context, cfg *config.Config, opt
 		return nil, fmt.Errorf("claude state generation failed: %w", err)
 	}
 
+	// The manual flow authorizes against Anthropic's hosted callback, so this host
+	// never receives an inbound redirect and no local callback server is needed.
+	if cfg.ClaudeCode.ManualOAuth {
+		return a.loginManual(ctx, cfg, opts, state, pkceCodes)
+	}
+
 	oauthServer := claude.NewOAuthServer(callbackPort)
 	if err = oauthServer.Start(); err != nil {
 		if strings.Contains(err.Error(), "already in use") {
@@ -188,7 +194,51 @@ waitForCallback:
 	log.Debug("Claude authorization code received; exchanging for tokens")
 	log.Debugf("Code: %s, State: %s", result.Code[:min(20, len(result.Code))], state)
 
-	authBundle, err := authSvc.ExchangeCodeForTokens(ctx, result.Code, state, pkceCodes)
+	return a.completeLogin(ctx, authSvc, result.Code, state, claude.RedirectURI, pkceCodes)
+}
+
+// loginManual runs the manual Claude Code OAuth flow. The user opens the printed
+// authorization URL, and Anthropic's hosted callback renders a "<code>#<state>"
+// pair that is pasted back here, so no local callback port is bound.
+func (a *ClaudeAuthenticator) loginManual(ctx context.Context, cfg *config.Config, opts *LoginOptions, state string, pkceCodes *claude.PKCECodes) (*coreauth.Auth, error) {
+	authSvc := claude.NewClaudeAuth(cfg)
+
+	authURL, returnedState, err := authSvc.GenerateManualAuthURL(state, pkceCodes)
+	if err != nil {
+		return nil, fmt.Errorf("claude authorization url generation failed: %w", err)
+	}
+	state = returnedState
+
+	if !opts.NoBrowser && browser.IsAvailable() {
+		if errOpen := browser.OpenURL(authURL); errOpen != nil {
+			log.Warnf("Failed to open browser automatically: %v", errOpen)
+		}
+	}
+	fmt.Printf("Visit the following URL to continue authentication:\n%s\n", authURL)
+
+	if opts.Prompt == nil {
+		return nil, fmt.Errorf("claude manual oauth requires an interactive prompt")
+	}
+	input, errPrompt := opts.Prompt("Paste the code shown after authorization (<code>#<state>): ")
+	if errPrompt != nil {
+		return nil, errPrompt
+	}
+	code := strings.TrimSpace(input)
+	if code == "" {
+		return nil, claude.NewAuthenticationError(claude.ErrCodeExchangeFailed, fmt.Errorf("empty authorization code"))
+	}
+	if _, pastedState, found := strings.Cut(code, "#"); found && strings.TrimSpace(pastedState) != state {
+		log.Errorf("State mismatch: expected %s, got %s", state, strings.TrimSpace(pastedState))
+		return nil, claude.NewAuthenticationError(claude.ErrInvalidState, fmt.Errorf("state mismatch"))
+	}
+
+	return a.completeLogin(ctx, authSvc, code, state, claude.ManualRedirectURI, pkceCodes)
+}
+
+// completeLogin exchanges an authorization code and shapes the resulting tokens
+// into the credential record shared by both Claude login flows.
+func (a *ClaudeAuthenticator) completeLogin(ctx context.Context, authSvc *claude.ClaudeAuth, code, state, redirectURI string, pkceCodes *claude.PKCECodes) (*coreauth.Auth, error) {
+	authBundle, err := authSvc.ExchangeCodeForTokensWithRedirect(ctx, code, state, redirectURI, pkceCodes)
 	if err != nil {
 		log.Errorf("Token exchange failed: %v", err)
 		return nil, claude.NewAuthenticationError(claude.ErrCodeExchangeFailed, err)


### PR DESCRIPTION
## Problem

Claude login always targets `http://localhost:54545/callback`, so the browser used for authorization has to reach the proxy host on that port. When the proxy runs on a headless VPS and the browser runs on a laptop, that redirect goes nowhere. The control panel's "paste the callback URL" field is the only way through today, and it depends on the user salvaging a URL from a navigation failure.

## What the native client does

Claude Code 2.1.223 already handles this. When it cannot bind a local port it authorizes against `https://claude.com/cai/oauth/authorize` with `redirect_uri=https://platform.claude.com/oauth/code/callback`, and that Anthropic-hosted page renders a `<code>#<state>` pair the user pastes back. From the shipped binary:

```
CLAUDE_AI_AUTHORIZE_URL: https://claude.com/cai/oauth/authorize
MANUAL_REDIRECT_URL:     https://platform.claude.com/oauth/code/callback
TOKEN_URL:               https://platform.claude.com/v1/oauth/token
scope (manual):          org:create_api_key + the existing five
```

`claude.com/cai/oauth/authorize` 307-redirects to the current `AuthURL` with the query preserved, so the only functional difference is `redirect_uri` — and Anthropic binds the code to the `redirect_uri` that produced it, which is why the existing constant cannot simply be reused.

The refresh path needs no change: the native client sends the five-scope set on refresh, which is exactly what `refreshTokensSingleFlight` already sends.

## Changes

- `internal/auth/claude`: add `ManualAuthURL` / `ManualRedirectURI` / `ManualOAuthScope` and `GenerateManualAuthURL`. `buildAuthURL` is factored out so both flows share one construction path.
- `internal/auth/claude`: add `ExchangeCodeForTokensWithRedirect`. `ExchangeCodeForTokens` keeps its signature and delegates with `RedirectURI`, so no caller changes.
- `internal/config`: add `claude-code.manual-oauth`, default `false`. `GET /v0/management/anthropic-auth-url?manual=1|0` overrides it per request.
- `internal/api/handlers/management`: manual mode skips the local callback forwarder, and the existing `oauth-callback` `redirect_url` field also accepts a bare `<code>#<state>` pair. That keeps the current control panel working unchanged — no frontend release needed.
- `sdk/auth`: `--claude-login` prompts for the pasted pair in manual mode instead of binding a callback port.

Default behavior is unchanged: with `manual-oauth` unset, the generated URL, `redirect_uri`, scope and exchange body are byte-identical to before.

## Testing

- `go test ./...` passes.
- New tests assert the manual authorization URL's exact parameter set, that the local flow keeps its own endpoint/redirect/scope, that the manual exchange body carries the hosted redirect and splits the pasted `<code>#<state>`, that an empty `redirectURI` falls back to the local callback, and that `parseManualCodePair` rejects callback URLs.
- Manually verified against a running instance: the generated URL matches the native client's parameter set, Anthropic 307-redirects it as expected, and submitting a `<code>#<state>` pair through the existing panel field reaches `platform.claude.com/v1/oauth/token` (a deliberately invalid code returns `400 invalid_grant`, confirming the endpoint, body shape and state handling).