### PR TITLE
perf: avoid large Gemini and Codex request copies

### DIFF
--- a/internal/runtime/executor/codex_websockets_connection.go
+++ b/internal/runtime/executor/codex_websockets_connection.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -114,13 +113,11 @@ func buildCodexWebsocketRequestBody(body []byte) []byte {
 	// Incremental follow-up turns continue on the same websocket using
 	// `previous_response_id` + incremental `input`, not `response.append`.
 	body = helps.SanitizeCodexInputItemIDs(body)
-	wsReqBody, errSet := sjson.SetBytes(bytes.Clone(body), "type", "response.create")
+	wsReqBody, errSet := sjson.SetBytes(body, "type", "response.create")
 	if errSet == nil && len(wsReqBody) > 0 {
 		return wsReqBody
 	}
-	fallback := bytes.Clone(body)
-	fallback, _ = sjson.SetBytes(fallback, "type", "response.create")
-	return fallback
+	return body
 }
 
 func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession, conn *websocket.Conn, readCh chan codexWebsocketRead) (int, []byte, error) {

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+var benchmarkBuildCodexWebsocketRequestBodyOutput []byte
+
 func TestBuildCodexWebsocketRequestBodyPreservesPreviousResponseID(t *testing.T) {
 	body := []byte(`{"model":"gpt-5-codex","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-1"}]}`)
 
@@ -40,6 +42,16 @@ func TestBuildCodexWebsocketRequestBodyPreservesPreviousResponseID(t *testing.T)
 	}
 	if got := gjson.GetBytes(wsReqBody, "type").String(); got == "response.append" {
 		t.Fatalf("unexpected websocket request type: %s", got)
+	}
+}
+
+func BenchmarkBuildCodexWebsocketRequestBodyLargePayload(b *testing.B) {
+	body := []byte(`{"model":"gpt-5.6","input":[{"type":"message","id":"msg_1","role":"user","content":"` + strings.Repeat("x", 8<<20) + `"}]}`)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(body)))
+	b.ResetTimer()
+	for b.Loop() {
+		benchmarkBuildCodexWebsocketRequestBodyOutput = buildCodexWebsocketRequestBody(body)
 	}
 }
 

--- a/internal/runtime/executor/helps/codex_input_ids.go
+++ b/internal/runtime/executor/helps/codex_input_ids.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -21,7 +22,7 @@ const (
 // reasoning items whose IDs exceed the Codex limit, and deterministically shortens
 // other overlong input item IDs.
 func SanitizeCodexInputItemIDs(body []byte) []byte {
-	input := gjson.GetBytes(body, "input")
+	input := util.GetGJSONBytesNoCopy(body, "input")
 	if !input.IsArray() {
 		return body
 	}

--- a/internal/runtime/executor/helps/codex_input_ids_test.go
+++ b/internal/runtime/executor/helps/codex_input_ids_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+var benchmarkSanitizeCodexInputItemIDsOutput []byte
+
 func TestSanitizeCodexInputItemIDsBoundaries(t *testing.T) {
 	id64 := strings.Repeat("a", 64)
 	id65 := strings.Repeat("b", 65)
@@ -178,5 +180,15 @@ func TestSanitizeCodexInputItemIDsLeavesUnsupportedPayloadsUnchanged(t *testing.
 		if got := string(SanitizeCodexInputItemIDs(body)); got != string(body) {
 			t.Fatalf("payload changed: got=%q want=%q", got, body)
 		}
+	}
+}
+
+func BenchmarkSanitizeCodexInputItemIDsLargeNoopPayload(b *testing.B) {
+	body := []byte(`{"input":[{"type":"message","id":"msg_1","role":"user","content":"` + strings.Repeat("x", 8<<20) + `"}]}`)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(body)))
+	b.ResetTimer()
+	for b.Loop() {
+		benchmarkSanitizeCodexInputItemIDsOutput = SanitizeCodexInputItemIDs(body)
 	}
 }

--- a/internal/runtime/executor/openai_responses_signature.go
+++ b/internal/runtime/executor/openai_responses_signature.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
 func sanitizeOpenAIResponsesReasoningEncryptedContent(ctx context.Context, provider string, body []byte) []byte {
-	inputResult := gjson.GetBytes(body, "input")
+	inputResult := util.GetGJSONBytesNoCopy(body, "input")
 	if !inputResult.Exists() || !inputResult.IsArray() {
 		return body
 	}

--- a/internal/runtime/executor/openai_responses_signature_test.go
+++ b/internal/runtime/executor/openai_responses_signature_test.go
@@ -3,10 +3,13 @@ package executor
 import (
 	"context"
 	"encoding/base64"
+	"strings"
 	"testing"
 
 	"github.com/tidwall/gjson"
 )
+
+var benchmarkSanitizeOpenAIResponsesReasoningOutput []byte
 
 func validOpenAIResponsesReasoningEncryptedContentForTest() string {
 	payload := make([]byte, 1+8+16+16+32)
@@ -76,5 +79,15 @@ func TestSanitizeOpenAIResponsesReasoningEncryptedContent_NoopReturnsOriginalBod
 	}
 	if len(got) > 0 && len(body) > 0 && &got[0] != &body[0] {
 		t.Fatalf("noop path should return the original body slice")
+	}
+}
+
+func BenchmarkSanitizeOpenAIResponsesReasoningEncryptedContentLargeNoopPayload(b *testing.B) {
+	body := []byte(`{"store":false,"input":[{"type":"message","role":"user","content":"` + strings.Repeat("x", 8<<20) + `"}]}`)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(body)))
+	b.ResetTimer()
+	for b.Loop() {
+		benchmarkSanitizeOpenAIResponsesReasoningOutput = sanitizeOpenAIResponsesReasoningEncryptedContent(context.Background(), "benchmark", body)
 	}
 }

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -12,11 +13,11 @@ import (
 func ConvertOpenAIResponsesRequestToCodex(modelName string, inputRawJSON []byte, _ bool) []byte {
 	rawJSON := inputRawJSON
 
-	inputResult := gjson.GetBytes(rawJSON, "input")
+	inputResult := util.GetGJSONBytesNoCopy(rawJSON, "input")
 	if inputResult.Type == gjson.String {
 		input, _ := sjson.SetBytes([]byte(`[{"type":"message","role":"user","content":[{"type":"input_text","text":""}]}]`), "0.content.0.text", inputResult.String())
 		rawJSON, _ = sjson.SetRawBytes(rawJSON, "input", input)
-		inputResult = gjson.GetBytes(rawJSON, "input")
+		inputResult = util.GetGJSONBytesNoCopy(rawJSON, "input")
 	}
 
 	rawJSON = setCodexRequiredBool(rawJSON, "stream", true)

--- a/internal/translator/gemini/gemini/gemini_gemini_request.go
+++ b/internal/translator/gemini/gemini/gemini_gemini_request.go
@@ -24,7 +24,7 @@ import (
 func ConvertGeminiRequestToGemini(_ string, inputRawJSON []byte, _ bool) []byte {
 	rawJSON := inputRawJSON
 	// Fast path: if no contents field, only attach safety settings
-	contents := gjson.GetBytes(rawJSON, "contents")
+	contents := util.GetGJSONBytesNoCopy(rawJSON, "contents")
 	if !contents.Exists() {
 		return common.AttachDefaultSafetySettings(rawJSON, "safetySettings")
 	}
@@ -134,7 +134,7 @@ func ConvertGeminiRequestToGemini(_ string, inputRawJSON []byte, _ bool) []byte 
 // For the immediately following user/function turn containing functionResponse
 // parts, any empty name is replaced with the corresponding call name.
 func backfillEmptyFunctionResponseNames(data []byte) []byte {
-	contents := gjson.GetBytes(data, "contents")
+	contents := util.GetGJSONBytesNoCopy(data, "contents")
 	if !contents.Exists() {
 		return data
 	}

--- a/internal/translator/gemini/gemini/gemini_gemini_request_test.go
+++ b/internal/translator/gemini/gemini/gemini_gemini_request_test.go
@@ -1,10 +1,63 @@
 package gemini
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/tidwall/gjson"
 )
+
+const largeInlineDataSize = 20 << 20
+
+var largeInlineDataBenchmarkOutput []byte
+
+func TestConvertGeminiRequestToGeminiReusesLargeNormalizedPayload(t *testing.T) {
+	input := largeInlineDataGeminiRequest(true)
+
+	result := testing.Benchmark(func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			output := ConvertGeminiRequestToGemini("gemini-test", input, false)
+			if &output[0] != &input[0] {
+				b.Fatal("normalized request should reuse the input payload")
+			}
+			largeInlineDataBenchmarkOutput = output
+		}
+	})
+
+	if allocated := result.AllocedBytesPerOp(); allocated >= 1<<20 {
+		t.Fatalf("normalized 20 MiB inlineData request allocated %d bytes/op, want less than 1 MiB", allocated)
+	}
+}
+
+func BenchmarkConvertGeminiRequestToGeminiLargeInlineData(b *testing.B) {
+	for _, test := range []struct {
+		name                  string
+		includeSafetySettings bool
+	}{
+		{name: "normalized_passthrough", includeSafetySettings: true},
+		{name: "attach_default_safety", includeSafetySettings: false},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			input := largeInlineDataGeminiRequest(test.includeSafetySettings)
+			b.ReportAllocs()
+			b.SetBytes(int64(len(input)))
+			b.ResetTimer()
+			for b.Loop() {
+				largeInlineDataBenchmarkOutput = ConvertGeminiRequestToGemini("gemini-test", input, false)
+			}
+		})
+	}
+}
+
+func largeInlineDataGeminiRequest(includeSafetySettings bool) []byte {
+	prefix := `{"contents":[{"role":"user","parts":[{"inlineData":{"mimeType":"video/mp4","data":"`
+	suffix := `"}}]}]`
+	if includeSafetySettings {
+		suffix += `,"safetySettings":[]`
+	}
+	return []byte(prefix + strings.Repeat("A", largeInlineDataSize) + suffix + `}`)
+}
 
 func TestBackfillEmptyFunctionResponseNames_Single(t *testing.T) {
 	input := []byte(`{


### PR DESCRIPTION
## Summary

- use no-copy GJSON views for Gemini `contents` scans
- add a 20 MiB Gemini inline-data allocation regression benchmark
- use no-copy GJSON views across the Codex Responses request translator, reasoning-signature sanitizer, and input-ID sanitizer
- remove a redundant full-body clone from Codex WebSocket `response.create` wrapping
- add 8 MiB Codex allocation regression benchmarks

Related to #3947.

## Gemini allocation results

| Scenario | Before | After |
| --- | ---: | ---: |
| Normalized passthrough | 41,959,707 B/op | 2 B/op |
| Attach default safety settings | — | ~20,983,500 B/op |

The Gemini passthrough path now reuses the original payload. The safety-injection path retains one full-size allocation for the final request body.

## Codex allocation results

8 MiB payload, `-benchmem -benchtime=1x`:

| Scenario | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Responses → Codex normalized request | 8,397,024 B/op | 224 B/op | 99.997% |
| Reasoning encrypted-content sanitizer, no-op | 8,396,896 B/op | 96 B/op | 99.999% |
| Input-ID sanitizer, no-op | 8,396,880 B/op | 80 B/op | 99.999% |
| WebSocket request wrapping | 25,195,864 B/op | 8,396,944 B/op | 66.7% |

The WebSocket path retains one full-size allocation for the final `response.create` request body.

## Verification

- `go test ./...`
- targeted Gemini 20 MiB allocation benchmark
- targeted Codex 8 MiB allocation benchmarks
- `git diff --check`
- dual-axis standards/spec review

Live upstream Codex network traffic was not exercised.