### PR TITLE
feat(signature): identify Kimi thinking signatures and scope Grok as target-only

### DIFF
--- a/internal/signature/grok_validation.go
+++ b/internal/signature/grok_validation.go
@@ -11,12 +11,15 @@ import (
 const (
 	// MaxGrokEncryptedContentLen is a transport safety cap for opaque replay blobs.
 	MaxGrokEncryptedContentLen = 8 * 1024 * 1024
-	// MinGrokEncryptedContentDecodedLen is a deliberately loose floor. The
-	// shortest observed native payload is exactly 50 bytes (grok-composer-2.5-fast),
-	// and those samples share no structure, so 50 is a sampling artifact rather
-	// than a protocol minimum. Sitting on the observed floor would silently reject
-	// a future shorter payload and surface as lost reasoning context, so keep
-	// headroom here and let the entropy check do the real filtering.
+	// MinGrokEncryptedContentDecodedLen is a deliberately loose floor, and the
+	// headroom has already proven necessary. An earlier corpus of 207 samples put
+	// the shortest native payload at exactly 50 bytes, with several samples piled
+	// on that value, which read like a protocol floor; a later 215-sample capture
+	// from grok-4.5 and grok-composer-2.5-fast reached 43 and 48 bytes and moved
+	// it. Both corpora agree there is no structure to anchor on, so the observed
+	// minimum is a sampling artifact that keeps sliding, and sitting on it would
+	// silently reject a future shorter payload as lost reasoning context. Keep the
+	// floor low and let the entropy check do the real filtering.
 	MinGrokEncryptedContentDecodedLen = 32
 	// MinGrokEncryptedContentEntropyRatio rejects obvious non-ciphertext payloads.
 	// Native samples are >= 0.892 against the sample-size entropy ceiling.

--- a/internal/signature/grok_validation.go
+++ b/internal/signature/grok_validation.go
@@ -81,6 +81,15 @@ func InspectGrokEncryptedContent(raw string) (*GrokEncryptedContentInfo, error) 
 			return nil, fmt.Errorf("Grok encrypted_content looks like Gemini thoughtSignature")
 		}
 	}
+	// Kimi emits no envelope either, so the pre-filter above cannot narrow it and
+	// this check has to run unconditionally. Length is the only separator the two
+	// families have: Kimi is fixed at two code-path constants while xAI payload
+	// length tracks reasoning volume continuously at 1-byte granularity. Neither
+	// observed Kimi length appears anywhere in 1027 catalogued signatures or 215
+	// native Grok samples, so rejecting them here costs no real Grok traffic.
+	if IsValidKimiThinkingSignature(sig) {
+		return nil, fmt.Errorf("Grok encrypted_content has a Kimi thinking signature length")
+	}
 
 	decoded, err := decodeGrokEncryptedContent(sig)
 	if err != nil {

--- a/internal/signature/grok_validation_test.go
+++ b/internal/signature/grok_validation_test.go
@@ -333,3 +333,60 @@ func grokEncryptedContentSamplesPath() (string, bool) {
 	}
 	return path, true
 }
+
+func TestSignatureProviderFromModelName_Grok(t *testing.T) {
+	for _, model := range []string{"grok-4.5", "grok-4.5-build", "grok-composer-2.5-fast", "grok-code-fast-1"} {
+		t.Run(model, func(t *testing.T) {
+			if got := SignatureProviderFromModelName(model); got != SignatureProviderGrok {
+				t.Errorf("SignatureProviderFromModelName(%q) = %q, want %q", model, got, SignatureProviderGrok)
+			}
+		})
+	}
+}
+
+// TestDetectSignatureProvider_NeverClassifiesGrok pins the contract that xAI is
+// a target-only family. Its ciphertext carries no envelope, no version byte and
+// no fixed length, so a positive detection rule would necessarily also claim
+// unrelated opaque payloads. Callers establish an xAI target from provenance and
+// then use InspectGrokEncryptedContent as a replay-safety check.
+func TestDetectSignatureProvider_NeverClassifiesGrok(t *testing.T) {
+	path, ok := grokEncryptedContentSamplesPath()
+	if !ok {
+		t.Skip("grok encrypted_content corpus missing; run docs/native-prompt-capture/scripts/harvest-grok-encrypted-content.sh")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read grok corpus: %v", err)
+	}
+	var samples []string
+	if err := json.Unmarshal(raw, &samples); err != nil {
+		var wrapped struct {
+			Samples []string `json:"samples"`
+		}
+		if err := json.Unmarshal(raw, &wrapped); err != nil {
+			t.Fatalf("parse grok corpus: %v", err)
+		}
+		samples = wrapped.Samples
+	}
+	if len(samples) == 0 {
+		t.Skip("grok encrypted_content corpus is empty")
+	}
+	for _, sig := range samples {
+		if got := DetectSignatureProvider(sig); got != SignatureProviderUnknown {
+			t.Fatalf("DetectSignatureProvider = %q, want %q for native encrypted_content", got, SignatureProviderUnknown)
+		}
+	}
+}
+
+// TestDecideSignatureCompatibility_GrokDropsBlock contrasts with the Kimi
+// policy: xAI decrypts the blob and answers 400 for foreign or mutated input, so
+// an incompatible block cannot survive by shedding just its signature.
+func TestDecideSignatureCompatibility_GrokDropsBlock(t *testing.T) {
+	decision := DecideSignatureCompatibility(SignatureProviderGrok, observedFable5Sample, SignatureBlockKindUnknown)
+	if decision.Compatible {
+		t.Fatalf("Claude signature reported compatible with a Grok target")
+	}
+	if decision.Action != SignatureActionDropBlock {
+		t.Errorf("Action = %q, want %q", decision.Action, SignatureActionDropBlock)
+	}
+}

--- a/internal/signature/kimi_validation.go
+++ b/internal/signature/kimi_validation.go
@@ -1,0 +1,161 @@
+package signature
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
+// Kimi thinking signatures carry no self-describing envelope. Every byte is
+// indistinguishable from uniform random data: a per-offset scan over 44 samples
+// x 9709 bytes found zero positions below a 4-sigma floor, so there is no magic
+// prefix, version byte, key id or timestamp to anchor on the way GPT (Fernet),
+// Claude (CAIS/protobuf) and Gemini (Tink envelope) all provide.
+//
+// What Kimi does expose is size. The raw signature length is fixed per protocol
+// mode and completely independent of the content it accompanies:
+//
+//	non-streaming : 12946 characters (9709 bytes)
+//	streaming     :  4340 characters (3255 bytes)
+//
+// This is not quantization of a variable payload into buckets. There is no
+// bucketing behaviour at all: a response whose thinking text grew from 6 to
+// 14,803 characters (thinking_tokens 1 -> 6188, output_tokens 29 -> 2709) emits
+// a byte-identical signature length, and a non-streaming response carrying a
+// single thinking token still emits the full 12946. The two values are code-path
+// constants, not size classes.
+//
+// Empirical basis for treating the pair as complete:
+//   - All 8 Kimi models exposed upstream (k2, k2.5, k2.6, k2-thinking, k2.7-code,
+//     k2.7-code-highspeed, k3, k3-256k) x streaming/non-streaming = 16 combinations,
+//     no exceptions.
+//   - Additional paths that produced no third value: thinking budget 128..12000,
+//     absent thinking field, max_tokens truncation mid-thinking, non-English
+//     prompts, 135k-character inputs, multi-turn replay of signed history, tool
+//     calls, tool_result continuation, and the interleaved-thinking beta header.
+//   - Two independent collection paths agree: CPA request logs (57 unique samples)
+//     and the mitmproxy harvest in
+//     .agents/skills/cpa-signature-catalog-and-collection/data/signatures/kimi/
+//     (61 unique samples) both yield exactly {4340, 12946}.
+//
+// Cross-family safety: across 1027 catalog signatures plus 215 native Grok
+// samples, no Claude, Gemini, GPT or Grok value lands on either length. The
+// nearest miss is a 4344-character GPT token, which the gAAAA probe claims long
+// before this check runs.
+//
+// Fragility this check accepts, and why it still runs last: the length pair is
+// an observed regularity, not a protocol contract. Kimi never reads the field
+// back - replaying an empty string, a single character, non-base64 text or a
+// mutated blob all return 200, and omitting the signature entirely also returns
+// 200, because reasoning continuity on that endpoint travels in OpenAI-style
+// reasoning_content instead. A gateway change could therefore move these values
+// without any client-visible error. Running the self-describing validators first
+// bounds the damage: a drift only costs Kimi its own identification and cannot
+// mislabel another provider's signature.
+const (
+	// KimiThinkingSignatureNonStreamingLen is the raw character length Kimi emits
+	// for non-streaming Messages responses.
+	KimiThinkingSignatureNonStreamingLen = 12946
+	// KimiThinkingSignatureStreamingLen is the raw character length Kimi emits in
+	// the streaming signature_delta event.
+	KimiThinkingSignatureStreamingLen = 4340
+)
+
+// KimiThinkingSignatureMode records which upstream code path produced a
+// signature. It is derived from length alone and carries no decoded content.
+type KimiThinkingSignatureMode string
+
+const (
+	KimiThinkingSignatureModeNonStreaming KimiThinkingSignatureMode = "non_streaming"
+	KimiThinkingSignatureModeStreaming    KimiThinkingSignatureMode = "streaming"
+)
+
+// kimiThinkingSignatureLens maps every accepted raw length to the mode that
+// produces it. Keeping this as a package-level map rather than inline constants
+// leaves room for a calibration pass to register a newly observed length without
+// touching the probe itself.
+var kimiThinkingSignatureLens = map[int]KimiThinkingSignatureMode{
+	KimiThinkingSignatureNonStreamingLen: KimiThinkingSignatureModeNonStreaming,
+	KimiThinkingSignatureStreamingLen:    KimiThinkingSignatureModeStreaming,
+}
+
+// MinKimiThinkingSignatureEntropyRatio keeps a same-length attacker-supplied
+// filler from claiming the family. Native samples sit at 0.997+ against the
+// sample-size ceiling, so this floor has multiple sigma of headroom while still
+// rejecting padded or repetitive input.
+const MinKimiThinkingSignatureEntropyRatio = 0.85
+
+// KimiThinkingSignatureInfo describes an accepted Kimi thinking signature.
+type KimiThinkingSignatureInfo struct {
+	RawLen     int
+	DecodedLen int
+	Mode       KimiThinkingSignatureMode
+}
+
+// InspectKimiThinkingSignature validates the transport shape of a Kimi Messages
+// thinking signature.
+//
+// Unlike the Claude, Gemini and GPT validators this proves nothing about the
+// payload: it reports that the value has the size and character class Kimi
+// produces. Because size is the only available signal, this probe must run after
+// every self-describing envelope check has declined, so that a Claude, Gemini or
+// GPT signature can never be captured by a length coincidence.
+func InspectKimiThinkingSignature(raw string) (*KimiThinkingSignatureInfo, error) {
+	sig := strings.TrimSpace(raw)
+	if sig == "" {
+		return nil, fmt.Errorf("empty Kimi thinking signature")
+	}
+	if sig != raw {
+		return nil, fmt.Errorf("Kimi thinking signature has leading or trailing whitespace")
+	}
+	mode, ok := kimiThinkingSignatureLens[len(sig)]
+	if !ok {
+		return nil, fmt.Errorf("invalid Kimi thinking signature: unexpected length %d", len(sig))
+	}
+	if strings.Contains(sig, "=") {
+		return nil, fmt.Errorf("invalid Kimi thinking signature: expected unpadded standard base64")
+	}
+	if index, r, ok := firstInvalidGrokEncryptedContentChar(sig); ok {
+		return nil, fmt.Errorf("invalid Kimi thinking signature: contains non-base64 character U+%04X at byte %d", r, index)
+	}
+	if _, _, ok := SplitSignatureProviderPrefix(sig); ok {
+		return nil, fmt.Errorf("invalid Kimi thinking signature: carries another provider's cache prefix")
+	}
+	// Defense in depth. DetectSignatureProviderForBlock already runs the
+	// self-describing probes first, but this validator is exported and callers
+	// may reach it directly, so a foreign envelope of coincidentally matching
+	// length must not be accepted here either.
+	if maybeSelfDescribingSignatureEnvelope(sig) {
+		if strings.HasPrefix(sig, "gAAAA") {
+			return nil, fmt.Errorf("Kimi thinking signature looks like GPT/Codex reasoning signature")
+		}
+		if IsValidClaudeCAISSignature(sig) {
+			return nil, fmt.Errorf("Kimi thinking signature looks like Claude CAIS thinking signature")
+		}
+		if IsValidClaudeThinkingSignature(sig, ClaudeSignatureValidationOptions{Strict: true}) {
+			return nil, fmt.Errorf("Kimi thinking signature looks like Claude thinking signature")
+		}
+		if IsValidGeminiThoughtSignature(sig, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}) {
+			return nil, fmt.Errorf("Kimi thinking signature looks like Gemini thoughtSignature")
+		}
+	}
+	decoded, err := base64.RawStdEncoding.DecodeString(sig)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Kimi thinking signature: base64 decode failed: %w", err)
+	}
+	if entropyRatio := byteEntropyRatio(decoded); entropyRatio < MinKimiThinkingSignatureEntropyRatio {
+		return nil, fmt.Errorf("invalid Kimi thinking signature: decoded payload entropy ratio %.3f below %.3f", entropyRatio, MinKimiThinkingSignatureEntropyRatio)
+	}
+	return &KimiThinkingSignatureInfo{
+		RawLen:     len(sig),
+		DecodedLen: len(decoded),
+		Mode:       mode,
+	}, nil
+}
+
+// IsValidKimiThinkingSignature reports whether raw has the transport shape of a
+// Kimi thinking signature.
+func IsValidKimiThinkingSignature(raw string) bool {
+	_, err := InspectKimiThinkingSignature(raw)
+	return err == nil
+}

--- a/internal/signature/kimi_validation_test.go
+++ b/internal/signature/kimi_validation_test.go
@@ -1,0 +1,370 @@
+package signature
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// kimiSignatureCorpusPath locates the harvested Kimi signature corpus. The
+// corpus lives with the collection skill that produced it and is not tracked in
+// this repository, matching how the Grok and Gemini native corpora are handled:
+// tests that need real traffic skip when it is absent rather than committing
+// captured payloads.
+func kimiSignatureCorpusPath() (string, bool) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", false
+	}
+	repo := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	path := filepath.Join(repo, ".agents", "skills", "cpa-signature-catalog-and-collection", "data", "signatures", "kimi", "samples.json")
+	if _, err := os.Stat(path); err != nil {
+		return path, false
+	}
+	return path, true
+}
+
+// masterSignatureCatalogPath locates the cross-provider signature catalog from
+// the same collection skill.
+func masterSignatureCatalogPath() (string, bool) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", false
+	}
+	repo := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	path := filepath.Join(repo, ".agents", "skills", "cpa-signature-catalog-and-collection", "data", "master_signatures_catalog.json")
+	if _, err := os.Stat(path); err != nil {
+		return path, false
+	}
+	return path, true
+}
+
+const kimiCorpusSkipReason = "kimi signature corpus missing; see .agents/skills/cpa-signature-catalog-and-collection"
+
+func loadKimiCorpus(t *testing.T) []string {
+	t.Helper()
+	path, ok := kimiSignatureCorpusPath()
+	if !ok {
+		t.Skip(kimiCorpusSkipReason)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read kimi corpus: %v", err)
+	}
+	var doc struct {
+		Samples []struct {
+			Signature string `json:"signature"`
+		} `json:"samples"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse kimi corpus: %v", err)
+	}
+	out := make([]string, 0, len(doc.Samples))
+	for _, sample := range doc.Samples {
+		if sample.Signature != "" {
+			out = append(out, sample.Signature)
+		}
+	}
+	if len(out) == 0 {
+		t.Skip(kimiCorpusSkipReason)
+	}
+	return out
+}
+
+// synthesizeKimiSignature builds a signature-shaped payload of the requested
+// decoded size from a seeded PRNG. Kimi identification rests entirely on raw
+// length plus the payload being high-entropy unpadded base64, and none of that
+// requires captured traffic, so the contract tests below run everywhere instead
+// of depending on a local corpus.
+func synthesizeKimiSignature(t *testing.T, decodedLen int, seed int64) string {
+	t.Helper()
+	buf := make([]byte, decodedLen)
+	prng := rand.New(rand.NewSource(seed))
+	if _, err := prng.Read(buf); err != nil {
+		t.Fatalf("synthesize payload: %v", err)
+	}
+	return base64.RawStdEncoding.EncodeToString(buf)
+}
+
+// TestKimiThinkingSignatureLengths_MatchDecodedSizes pins the arithmetic that
+// makes the two constants reachable at all: unpadded base64 of 9709 and 3255
+// bytes is exactly 12946 and 4340 characters. A future edit that changes one
+// constant without the other would otherwise produce a length no real payload
+// can have.
+func TestKimiThinkingSignatureLengths_MatchDecodedSizes(t *testing.T) {
+	tests := []struct {
+		name       string
+		decodedLen int
+		wantRawLen int
+	}{
+		{"non streaming", 9709, KimiThinkingSignatureNonStreamingLen},
+		{"streaming", 3255, KimiThinkingSignatureStreamingLen},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sig := synthesizeKimiSignature(t, tc.decodedLen, 1)
+			if len(sig) != tc.wantRawLen {
+				t.Fatalf("raw length = %d, want %d", len(sig), tc.wantRawLen)
+			}
+			info, err := InspectKimiThinkingSignature(sig)
+			if err != nil {
+				t.Fatalf("synthesized payload rejected: %v", err)
+			}
+			if info.DecodedLen != tc.decodedLen {
+				t.Errorf("DecodedLen = %d, want %d", info.DecodedLen, tc.decodedLen)
+			}
+		})
+	}
+}
+
+func TestInspectKimiThinkingSignature_ReportsMode(t *testing.T) {
+	tests := []struct {
+		name       string
+		decodedLen int
+		wantMode   KimiThinkingSignatureMode
+	}{
+		{"non streaming", 9709, KimiThinkingSignatureModeNonStreaming},
+		{"streaming", 3255, KimiThinkingSignatureModeStreaming},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			info, err := InspectKimiThinkingSignature(synthesizeKimiSignature(t, tc.decodedLen, 7))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if info.Mode != tc.wantMode {
+				t.Errorf("Mode = %q, want %q", info.Mode, tc.wantMode)
+			}
+		})
+	}
+}
+
+// TestInspectKimiThinkingSignature_RejectsNeighbouringLengths is the core
+// negative test for a size-only probe: one character in either direction must
+// fall out of the family.
+func TestInspectKimiThinkingSignature_RejectsNeighbouringLengths(t *testing.T) {
+	for _, decodedLen := range []int{9709, 3255} {
+		native := synthesizeKimiSignature(t, decodedLen, 3)
+		for _, tc := range []struct {
+			name string
+			sig  string
+		}{
+			{"one character short", native[:len(native)-1]},
+			{"one character long", native + "A"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				if IsValidKimiThinkingSignature(tc.sig) {
+					t.Errorf("length %d accepted as Kimi signature", len(tc.sig))
+				}
+			})
+		}
+	}
+}
+
+func TestInspectKimiThinkingSignature_RejectsMalformedInput(t *testing.T) {
+	native := synthesizeKimiSignature(t, 3255, 5)
+	tests := []struct {
+		name string
+		sig  string
+	}{
+		{"empty", ""},
+		{"whitespace only", "   "},
+		{"leading whitespace", " " + native},
+		{"trailing whitespace", native + " "},
+		{"padded base64", native[:len(native)-2] + "=="},
+		{"non base64 character", native[:len(native)-1] + "!"},
+		{"provider cache prefix", "claude#" + native},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if IsValidKimiThinkingSignature(tc.sig) {
+				t.Errorf("malformed input accepted as Kimi signature")
+			}
+		})
+	}
+}
+
+// TestInspectKimiThinkingSignature_RejectsLowEntropyFiller pins the one attack a
+// length check alone cannot survive: a caller that knows the constant and pads
+// to it with structured bytes.
+func TestInspectKimiThinkingSignature_RejectsLowEntropyFiller(t *testing.T) {
+	for _, length := range []int{KimiThinkingSignatureStreamingLen, KimiThinkingSignatureNonStreamingLen} {
+		if IsValidKimiThinkingSignature(strings.Repeat("A", length)) {
+			t.Errorf("repeated-character filler of length %d accepted as Kimi signature", length)
+		}
+	}
+}
+
+// TestInspectKimiThinkingSignature_RejectsSelfDescribingEnvelope guards the
+// exported entry point. DetectSignatureProviderForBlock already runs the
+// envelope probes first, but callers can reach this validator directly, so a
+// foreign envelope must not be accepted here on length alone.
+func TestInspectKimiThinkingSignature_RejectsSelfDescribingEnvelope(t *testing.T) {
+	if IsValidKimiThinkingSignature(observedFable5Sample) {
+		t.Errorf("Claude CAIS sample accepted as Kimi signature")
+	}
+}
+
+// TestDetectSignatureProvider_KimiRunsAfterEnvelopeProbes pins the ordering
+// invariant. Kimi's base64 is uniformly distributed, so roughly 6% of real
+// signatures start with one of the "CERg" envelope characters; those must still
+// resolve to Kimi after the envelope probes decline, and a real envelope must
+// never be captured by the size probe.
+func TestDetectSignatureProvider_KimiRunsAfterEnvelopeProbes(t *testing.T) {
+	if got := DetectSignatureProvider(observedFable5Sample); got != SignatureProviderClaude {
+		t.Fatalf("DetectSignatureProvider = %q, want %q for a Claude CAIS sample", got, SignatureProviderClaude)
+	}
+
+	var checked int
+	for seed := int64(0); seed < 200 && checked < 3; seed++ {
+		sig := synthesizeKimiSignature(t, 3255, seed)
+		if !maybeSelfDescribingSignatureEnvelope(sig) {
+			continue
+		}
+		checked++
+		if got := DetectSignatureProvider(sig); got != SignatureProviderKimi {
+			t.Fatalf("DetectSignatureProvider = %q, want %q for an envelope-prefixed Kimi payload", got, SignatureProviderKimi)
+		}
+	}
+	if checked == 0 {
+		t.Skip("no synthesized payload landed on an envelope first character")
+	}
+}
+
+func TestInspectGrokEncryptedContent_RejectsKimiLengths(t *testing.T) {
+	for _, decodedLen := range []int{9709, 3255} {
+		sig := synthesizeKimiSignature(t, decodedLen, 11)
+		if IsValidGrokEncryptedContent(sig) {
+			t.Errorf("Kimi-length payload (%d bytes) accepted as Grok encrypted_content", decodedLen)
+		}
+	}
+}
+
+func TestSignatureProviderFromModelName_Kimi(t *testing.T) {
+	tests := []struct {
+		model string
+		want  SignatureProvider
+	}{
+		{"kimi-k3", SignatureProviderKimi},
+		{"kimi-k3-256k", SignatureProviderKimi},
+		{"kimi-k2.7-code-highspeed", SignatureProviderKimi},
+		{"k3", SignatureProviderKimi},
+		{"k2-thinking", SignatureProviderKimi},
+		{"moonshot-v1-128k", SignatureProviderKimi},
+		{"claude-opus-5", SignatureProviderClaude},
+		{"gemini-3.6-flash", SignatureProviderGemini},
+		{"gpt-5.6-sol", SignatureProviderGPT},
+	}
+	for _, tc := range tests {
+		t.Run(tc.model, func(t *testing.T) {
+			if got := SignatureProviderFromModelName(tc.model); got != tc.want {
+				t.Errorf("SignatureProviderFromModelName(%q) = %q, want %q", tc.model, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDecideSignatureCompatibility_KimiDropsSignatureNotBlock encodes the
+// measured upstream behaviour: Kimi returns 200 for a mutated, truncated,
+// non-base64 or entirely absent thinking signature, so a foreign signature costs
+// the field rather than the reasoning text.
+func TestDecideSignatureCompatibility_KimiDropsSignatureNotBlock(t *testing.T) {
+	decision := DecideSignatureCompatibility(SignatureProviderKimi, observedFable5Sample, SignatureBlockKindClaudeThinking)
+	if decision.Compatible {
+		t.Fatalf("Claude signature reported compatible with a Kimi target")
+	}
+	if decision.Action != SignatureActionDropSignature {
+		t.Errorf("Action = %q, want %q", decision.Action, SignatureActionDropSignature)
+	}
+}
+
+func TestDecideSignatureCompatibility_KimiPreservesNativeSignature(t *testing.T) {
+	native := synthesizeKimiSignature(t, 9709, 13)
+	decision := DecideSignatureCompatibility(SignatureProviderKimi, native, SignatureBlockKindClaudeThinking)
+	if !decision.Compatible {
+		t.Fatalf("Kimi-shaped signature reported incompatible with a Kimi target: %s", decision.Reason)
+	}
+	if decision.Action != SignatureActionPreserve {
+		t.Errorf("Action = %q, want %q", decision.Action, SignatureActionPreserve)
+	}
+	if decision.NormalizedSignature != native {
+		t.Errorf("NormalizedSignature was rewritten for a Kimi signature")
+	}
+}
+
+// TestInspectKimiThinkingSignature_NativeCorpus validates the synthesized
+// contract above against real harvested traffic when the corpus is available.
+func TestInspectKimiThinkingSignature_NativeCorpus(t *testing.T) {
+	modes := map[KimiThinkingSignatureMode]int{}
+	for _, sig := range loadKimiCorpus(t) {
+		info, err := InspectKimiThinkingSignature(sig)
+		if err != nil {
+			t.Fatalf("native Kimi signature (len %d) rejected: %v", len(sig), err)
+		}
+		if got := DetectSignatureProvider(sig); got != SignatureProviderKimi {
+			t.Fatalf("DetectSignatureProvider = %q, want %q", got, SignatureProviderKimi)
+		}
+		modes[info.Mode]++
+	}
+	if modes[KimiThinkingSignatureModeNonStreaming] == 0 || modes[KimiThinkingSignatureModeStreaming] == 0 {
+		t.Fatalf("corpus does not cover both modes: %v", modes)
+	}
+}
+
+// TestDetectSignatureProvider_KimiProbeDoesNotDisturbCatalog replays the whole
+// cross-provider catalog to prove the size probe changed nothing for the
+// self-describing families and never claims a Grok payload.
+func TestDetectSignatureProvider_KimiProbeDoesNotDisturbCatalog(t *testing.T) {
+	path, ok := masterSignatureCatalogPath()
+	if !ok {
+		t.Skip("signature catalog missing; see .agents/skills/cpa-signature-catalog-and-collection")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read signature catalog: %v", err)
+	}
+	var doc struct {
+		Records []struct {
+			FullSignature   string `json:"full_signature"`
+			ClaimedProvider string `json:"claimed_provider"`
+		} `json:"records"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse signature catalog: %v", err)
+	}
+
+	matrix := map[string]map[SignatureProvider]int{}
+	for _, record := range doc.Records {
+		if record.FullSignature == "" {
+			continue
+		}
+		detected := DetectSignatureProvider(record.FullSignature)
+		if matrix[record.ClaimedProvider] == nil {
+			matrix[record.ClaimedProvider] = map[SignatureProvider]int{}
+		}
+		matrix[record.ClaimedProvider][detected]++
+	}
+	if len(matrix) == 0 {
+		t.Skip("signature catalog has no usable records")
+	}
+
+	for claimed, row := range matrix {
+		t.Logf("%-8s -> %v", claimed, row)
+		if captured := row[SignatureProviderKimi]; captured > 0 {
+			t.Errorf("%d %s signatures captured by the Kimi size probe", captured, claimed)
+		}
+	}
+	// xAI stays in the residual class by contract: its ciphertext carries no
+	// envelope and no fixed length, so any positive claim would also capture
+	// unrelated opaque payloads.
+	for detected, count := range matrix["grok"] {
+		if detected != SignatureProviderUnknown {
+			t.Errorf("%d grok signatures classified as %q, want %q", count, detected, SignatureProviderUnknown)
+		}
+	}
+}

--- a/internal/signature/provider_compatibility.go
+++ b/internal/signature/provider_compatibility.go
@@ -10,6 +10,9 @@ const (
 	SignatureProviderGemini       SignatureProvider = "gemini"
 	SignatureProviderGeminiBypass SignatureProvider = "gemini_bypass"
 	SignatureProviderGPT          SignatureProvider = "gpt"
+	// SignatureProviderKimi is identified by fixed signature size rather than by
+	// an envelope. See kimi_validation.go for the empirical basis and its limits.
+	SignatureProviderKimi SignatureProvider = "kimi"
 )
 
 type SignatureBlockKind string
@@ -59,6 +62,11 @@ func SignatureProviderFromModelName(modelName string) SignatureProvider {
 		strings.HasPrefix(lower, "o3"),
 		strings.HasPrefix(lower, "o4"):
 		return SignatureProviderGPT
+	case strings.Contains(lower, "kimi"),
+		strings.Contains(lower, "moonshot"),
+		strings.HasPrefix(lower, "k2"),
+		strings.HasPrefix(lower, "k3"):
+		return SignatureProviderKimi
 	default:
 		return SignatureProviderUnknown
 	}
@@ -170,10 +178,6 @@ func DetectSignatureProviderForBlock(rawSignature string, blockKind SignatureBlo
 	if IsGeminiThoughtSignatureBypass(sig) {
 		return SignatureProviderGeminiBypass
 	}
-	if !maybeSelfDescribingSignatureEnvelope(sig) {
-		return SignatureProviderUnknown
-	}
-
 	// Probes run from the strongest marker to the weakest:
 	//   1. GPT carries the literal "gAAAA" prefix, which pins both the version
 	//      byte and the high timestamp bytes.
@@ -188,17 +192,33 @@ func DetectSignatureProviderForBlock(rawSignature string, blockKind SignatureBlo
 	// separable in either order. TestGeminiEnvelopeNeverClaimsClaudeSignatures
 	// pins that invariant so a looser Gemini envelope check cannot make the
 	// order silently start mattering.
-	if IsValidGPTReasoningSignature(sig) {
-		return SignatureProviderGPT
+	//
+	// The envelope pre-filter gates only the envelope probes. A blob that cannot
+	// be an envelope skips straight to the size probe below rather than returning
+	// early, because Kimi's uniformly distributed base64 starts with one of
+	// "CERg" about 6% of the time and would otherwise be dropped by whichever
+	// side of the gate it happened to land on.
+	if maybeSelfDescribingSignatureEnvelope(sig) {
+		if IsValidGPTReasoningSignature(sig) {
+			return SignatureProviderGPT
+		}
+		if IsValidClaudeCAISSignature(sig) {
+			return SignatureProviderClaude
+		}
+		if IsValidClaudeThinkingSignature(sig, ClaudeSignatureValidationOptions{Strict: true}) {
+			return SignatureProviderClaude
+		}
+		if isRecognizedGeminiProviderSignature(sig, blockKind) {
+			return SignatureProviderGemini
+		}
 	}
-	if IsValidClaudeCAISSignature(sig) {
-		return SignatureProviderClaude
-	}
-	if IsValidClaudeThinkingSignature(sig, ClaudeSignatureValidationOptions{Strict: true}) {
-		return SignatureProviderClaude
-	}
-	if isRecognizedGeminiProviderSignature(sig, blockKind) {
-		return SignatureProviderGemini
+	// Kimi carries no envelope, so it can only be claimed once every
+	// self-describing probe above has declined. Ordering it last means a length
+	// coincidence can never capture another provider's signature, and a future
+	// drift in Kimi's sizes costs Kimi its own identification rather than
+	// corrupting a neighbouring family.
+	if IsValidKimiThinkingSignature(sig) {
+		return SignatureProviderKimi
 	}
 	return SignatureProviderUnknown
 }
@@ -254,6 +274,15 @@ func DecideSignatureCompatibilityForModel(targetProvider SignatureProvider, targ
 	case SignatureProviderGPT:
 		decision.Action = SignatureActionDropBlock
 		decision.Reason = "GPT reasoning encrypted_content cannot be synthesized from another provider signature"
+	case SignatureProviderKimi:
+		// Kimi is the only target that can keep the reasoning text when the
+		// signature does not match. Its Messages endpoint never reads the field
+		// back: a mutated, truncated, non-base64 or absent signature all return
+		// 200, because reasoning continuity there travels in OpenAI-style
+		// reasoning_content instead. Dropping the block would discard recoverable
+		// thinking text for no upstream benefit, so drop only the signature.
+		decision.Action = SignatureActionDropSignature
+		decision.Reason = "Kimi does not validate replayed thinking signatures, so the block survives without one"
 	default:
 		decision.Action = SignatureActionNoCompatibleReplacement
 		decision.Reason = "unknown target provider"
@@ -372,6 +401,8 @@ func signatureProviderMatchesTarget(target, detected SignatureProvider) bool {
 		return detected == SignatureProviderClaude
 	case SignatureProviderGPT:
 		return detected == SignatureProviderGPT
+	case SignatureProviderKimi:
+		return detected == SignatureProviderKimi
 	default:
 		return false
 	}
@@ -398,6 +429,10 @@ func normalizeCompatibleSignatureForProvider(targetProvider SignatureProvider, r
 		}
 	case SignatureProviderGPT:
 		if IsValidGPTReasoningSignature(payload) {
+			return payload
+		}
+	case SignatureProviderKimi:
+		if IsValidKimiThinkingSignature(payload) {
 			return payload
 		}
 	}

--- a/internal/signature/provider_compatibility.go
+++ b/internal/signature/provider_compatibility.go
@@ -13,6 +13,13 @@ const (
 	// SignatureProviderKimi is identified by fixed signature size rather than by
 	// an envelope. See kimi_validation.go for the empirical basis and its limits.
 	SignatureProviderKimi SignatureProvider = "kimi"
+	// SignatureProviderGrok is a target-only family. DetectSignatureProvider never
+	// returns it: xAI emits no envelope, no version byte and no fixed length, and
+	// its ciphertext is statistically indistinguishable from uniform random bytes,
+	// so any positive claim would also capture every other opaque blob. Grok
+	// handling is provenance-first - establish the target from the model or route,
+	// then use InspectGrokEncryptedContent as a replay-safety shape check.
+	SignatureProviderGrok SignatureProvider = "grok"
 )
 
 type SignatureBlockKind string
@@ -67,6 +74,8 @@ func SignatureProviderFromModelName(modelName string) SignatureProvider {
 		strings.HasPrefix(lower, "k2"),
 		strings.HasPrefix(lower, "k3"):
 		return SignatureProviderKimi
+	case strings.Contains(lower, "grok"):
+		return SignatureProviderGrok
 	default:
 		return SignatureProviderUnknown
 	}
@@ -283,6 +292,12 @@ func DecideSignatureCompatibilityForModel(targetProvider SignatureProvider, targ
 		// thinking text for no upstream benefit, so drop only the signature.
 		decision.Action = SignatureActionDropSignature
 		decision.Reason = "Kimi does not validate replayed thinking signatures, so the block survives without one"
+	case SignatureProviderGrok:
+		// xAI decrypts encrypted_content and rejects the request with 400
+		// "Could not decrypt" when the blob is foreign or mutated, so a
+		// non-matching value has to leave with the block.
+		decision.Action = SignatureActionDropBlock
+		decision.Reason = "xAI verifies encrypted_content on replay and rejects foreign or mutated blobs"
 	default:
 		decision.Action = SignatureActionNoCompatibleReplacement
 		decision.Reason = "unknown target provider"
@@ -404,6 +419,9 @@ func signatureProviderMatchesTarget(target, detected SignatureProvider) bool {
 	case SignatureProviderKimi:
 		return detected == SignatureProviderKimi
 	default:
+		// SignatureProviderGrok is deliberately absent. Detection never yields it,
+		// so a Grok target must decide replay safety from provenance plus
+		// InspectGrokEncryptedContent rather than from a detected-provider match.
 		return false
 	}
 }


### PR DESCRIPTION
## Why

`internal/signature` could name every reasoning-carrier family it meets except two, and the resulting `unknown` was not harmless.

**Kimi** returns a `signature` on every thinking block but carries no envelope, no version byte and no marker, so every probe declined and the block fell through to the unknown path. On the API-key compat route (`claude_executor.go` sanitizes whenever `preserveEmpty` is set, regardless of target) an unknown target drops the whole thinking block. That is the worst possible outcome for Kimi specifically: its thinking **text** is the only carrier of reasoning, so dropping the block destroys the chain while the signature it was protecting turns out to be inert.

**Grok** has the opposite problem. Its `encrypted_content` is statistically indistinguishable from uniform random bytes, so no honest positive claim exists — but the family still needs a name for target-side decisions, and the codebase had no way to say "this is a Grok target, and detection must never assert it."

## What the classifier now knows

**Kimi is identified by fixed size, not by structure.** Measured across 8 models × streaming/non-streaming (16 combinations), the signature only ever takes two values: **4340 characters (3255 bytes) when streaming, 12946 characters (9709 bytes) otherwise**. Length is independent of model, prompt and reasoning length — it is a constant chosen by the serialization path, not a quantization bucket. `kimi_validation.go` pins both sizes with a decoded-length assertion so a future edit cannot silently desync them, and adds an entropy floor to reject same-length low-entropy filler.

The probe is deliberately **ordered last**, after every self-describing envelope check. A size coincidence can then never capture another provider's signature, and if Kimi's sizes ever drift the cost is Kimi losing its own identification rather than corrupting a neighbour.

This required moving the envelope pre-filter from an early `return unknown` to gating only the envelope probes. Kimi's uniformly distributed base64 begins with one of `C`/`E`/`R`/`g` about 6% of the time, so the old shape dropped those blobs on whichever side of the gate they happened to land.

**Grok becomes a target-only family.** `DetectSignatureProvider` never returns it and `signatureProviderMatchesTarget` deliberately omits it, so replay safety for a Grok target stays provenance-first: establish the target from the model or route, then use `InspectGrokEncryptedContent` as a shape check.

## Behavioural impact

Verified against the full local signature corpus. Classification of existing families is **byte-for-byte unchanged**: claude 274/274, gpt 380/380, gemini 141/149 (the 8 misses are retired `gemini-2.5-*` field-1 blobs and predate this change). The only classification difference is that some previously-`unknown` blobs are now named `kimi`.

Two intentional changes:

1. **Kimi target keeps the block.** `SignatureActionDropSignature` instead of falling through to the unknown default that drops the entire block. Kimi's Messages endpoint never reads the field back — replayed, truncated, mutated, non-base64 and absent signatures all return 200 — so removing only the signature is lossless, while dropping the block discards recoverable thinking text for no upstream benefit.

2. **Grok validation rejects Kimi lengths.** `InspectGrokEncryptedContent` now refuses the two Kimi sizes. Grok payloads do span that range, so this trades a rare false reject (lost reasoning context, a degradation) against replaying a foreign blob to xAI (a hard 400 `Could not decrypt`). No collision appears in the 215-sample Grok corpus.

Grok target behaviour is unchanged: the new `DropBlock` decision matches what the previous `default` branch already did.

Also corrects the `MinGrokEncryptedContentDecodedLen` comment. An earlier 207-sample corpus put the shortest payload at exactly 50 bytes with several samples piled there, which read like a protocol floor; a later 215-sample capture from `grok-4.5` and `grok-composer-2.5-fast` reached 43 and 48 bytes. The observed minimum keeps sliding, which is the argument for keeping the floor loose rather than tightening it.

## Tests

Two layers. Synthetic tests always run and pin the contracts that do not depend on captured traffic — decoded-length arithmetic, off-by-one rejection at both sizes, malformed input, low-entropy filler, envelope-probe ordering, and the invariant that the Kimi probe cannot disturb the existing catalog. Corpus tests skip cleanly when the harvested samples are absent, following the existing convention in this package; no real signatures are committed.

```
go build ./cmd/server                  ok
go test ./internal/signature/...       ok
go test ./...                          ok
gofmt -l internal/                     clean
```

Both commits build and test independently, so `git bisect` stays usable.
