### PR TITLE
fix(claude): preserve advisor server tools for OAuth

### DIFF
--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -4635,6 +4635,18 @@ func TestRemapOAuthToolNames_TypedCustomUsesMCPAlias(t *testing.T) {
 	}
 }
 
+func TestRemapOAuthToolNames_AdvisorServerToolRemainsNative(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"advisor_20260301","name":"advisor","model":"claude-opus-5"}]}`)
+	out, reverseMap := remapOAuthToolNamesWithOptions(body, claudeMCPAliasOptions{secret: "caller-secret"})
+
+	if !bytes.Equal(out, body) {
+		t.Fatalf("advisor server tool was rewritten:\n got: %s\nwant: %s", out, body)
+	}
+	if len(reverseMap) != 0 {
+		t.Fatalf("reverseMap = %v, want empty", reverseMap)
+	}
+}
+
 func TestRemapOAuthToolNames_MCPAliasAvoidsClientCollision(t *testing.T) {
 	const secret = "credential-secret"
 	initialCandidate := helps.ClaudeMCPToolAlias(secret, "fetch_url", 0)

--- a/internal/runtime/executor/helps/claude_builtin_tools.go
+++ b/internal/runtime/executor/helps/claude_builtin_tools.go
@@ -27,6 +27,7 @@ func newClaudeBuiltinToolRegistry() map[string]bool {
 func IsClaudeServerToolType(toolType string) bool {
 	toolType = strings.ToLower(strings.TrimSpace(toolType))
 	for _, prefix := range []string{
+		"advisor_",
 		"bash_",
 		"code_execution_",
 		"computer_",

--- a/internal/runtime/executor/helps/claude_builtin_tools_test.go
+++ b/internal/runtime/executor/helps/claude_builtin_tools_test.go
@@ -32,7 +32,7 @@ func TestClaudeBuiltinToolRegistry_AugmentsKnownTypedBuiltinsFromBody(t *testing
 }
 
 func TestIsClaudeServerToolType(t *testing.T) {
-	for _, toolType := range []string{"web_search_20250305", "code_execution_20250522", "tool_search_tool_regex_20251119"} {
+	for _, toolType := range []string{"advisor_20260301", "web_search_20250305", "code_execution_20250522", "tool_search_tool_regex_20251119"} {
 		if !IsClaudeServerToolType(toolType) {
 			t.Fatalf("IsClaudeServerToolType(%q) = false, want true", toolType)
 		}


### PR DESCRIPTION
## Summary

- Treat Anthropic `advisor_*` definitions as native server tools during Claude OAuth request normalization.
- Preserve their `type`, `name`, and server-tool fields instead of rewriting them as MCP aliases.
- Add unit coverage at both the server-tool registry and OAuth remapping layers.

## Problem

Claude Code 2.1.224 can send `advisor_20260301`, which is a native Anthropic server tool and does not carry a custom `input_schema`. The OAuth remapper did not recognize the `advisor_` prefix, rewrote the definition as a custom MCP tool, and removed `type`. Anthropic then rejected the request with `tools.<index>.custom.input_schema: Field required`.

## Tests

- `go test -count=1 ./internal/runtime/executor/helps -run "^TestIsClaudeServerToolType$"`
- `go test -count=1 ./internal/runtime/executor -run "^TestRemapOAuthToolNames_AdvisorServerToolRemainsNative$"`
- `go build -o test-output ./cmd/server` from a standalone clone

The full executor suite also reports three platform-fingerprint expectation failures on the unchanged base commit in this local WSL environment: the tests expect `Linux`, while the stable device profile emits `MacOS`.