### PR TITLE
fix(responses): restore namespaces on custom tool calls

### DIFF
--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -1043,7 +1043,7 @@ func qualifyResponsesNamespaceToolName(namespaceName, childName string) string {
 	return namespaceName + "__" + childName
 }
 
-func splitResponsesQualifiedFunctionCallFromRequest(requestRawJSON []byte, qualifiedName string) (name, namespace string) {
+func splitResponsesQualifiedToolCallFromRequest(requestRawJSON []byte, qualifiedName string) (name, namespace string) {
 	qualifiedName = strings.TrimSpace(qualifiedName)
 	if qualifiedName == "" {
 		return "", ""
@@ -1054,7 +1054,7 @@ func splitResponsesQualifiedFunctionCallFromRequest(requestRawJSON []byte, quali
 	if !ok {
 		return qualifiedName, ""
 	}
-	if descriptor.toolType == "function" && !descriptor.direct {
+	if !descriptor.direct && (descriptor.toolType == "function" || descriptor.toolType == "custom") {
 		return descriptor.childName, descriptor.namespace
 	}
 	return qualifiedName, ""

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
@@ -708,7 +708,7 @@ func TestConvertOpenAIResponsesRequestToClaude_DeduplicatesExpandedToolNames(t *
 	if _, ok := customNames["collaboration__send"]; ok {
 		t.Fatal("final-name collision should keep the top-level function type")
 	}
-	name, namespace := splitResponsesQualifiedFunctionCallFromRequest(raw, "collaboration__send")
+	name, namespace := splitResponsesQualifiedToolCallFromRequest(raw, "collaboration__send")
 	if name != "collaboration__send" || namespace != "" {
 		t.Fatalf("final-name collision namespace = (%q, %q), want (collaboration__send, empty)", name, namespace)
 	}
@@ -825,6 +825,32 @@ func TestConvertOpenAIResponsesRequestToClaude_ReplaysCustomToolCallHistory(t *t
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToClaude_ReplaysNamespacedCustomToolCallHistory(t *testing.T) {
+	raw := []byte(`{
+		"model":"claude-test",
+		"input":[
+			{"type":"additional_tools","tools":[{"type":"namespace","name":"functions","tools":[{"type":"custom","name":"exec"}]}]},
+			{"type":"custom_tool_call","call_id":"call.custom:1","name":"exec","namespace":"functions","input":"pwd"},
+			{"type":"custom_tool_call_output","call_id":"call.custom:1","output":"/workspace"}
+		]
+	}`)
+
+	root := gjson.ParseBytes(ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false))
+	if !root.Get(`tools.#(name=="functions__exec")`).Exists() {
+		t.Fatal("missing qualified namespace custom tool declaration")
+	}
+	toolUse := root.Get("messages.0.content.0")
+	if got := toolUse.Get("name").String(); got != "functions__exec" {
+		t.Fatalf("historical custom tool_use name = %q, want functions__exec", got)
+	}
+	if got := toolUse.Get("input.input").String(); got != "pwd" {
+		t.Fatalf("historical custom tool input = %q, want pwd", got)
+	}
+	if got := root.Get("messages.1.content.0.tool_use_id").String(); got != "call_custom_1" {
+		t.Fatalf("historical custom tool_result id = %q, want call_custom_1", got)
+	}
+}
+
 func TestConvertOpenAIResponsesRequestToClaude_ReplaysNamespacedFunctionCallHistory(t *testing.T) {
 	raw := []byte(`{
 		"model":"claude-test",
@@ -930,7 +956,7 @@ func TestSplitResponsesQualifiedFunctionCallFromAdditionalTools(t *testing.T) {
 		"input":[{"type":"additional_tools","tools":[{"type":"namespace","name":"mcp__node_repl","tools":[{"type":"function","name":"js"}]}]}]
 	}`)
 
-	name, namespace := splitResponsesQualifiedFunctionCallFromRequest(raw, "mcp__node_repl__js")
+	name, namespace := splitResponsesQualifiedToolCallFromRequest(raw, "mcp__node_repl__js")
 	if name != "js" {
 		t.Fatalf("name = %q, want js", name)
 	}

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response.go
@@ -135,8 +135,8 @@ func pickRequestJSON(originalRequestRawJSON, requestRawJSON []byte) []byte {
 	return nil
 }
 
-func applyResponsesFunctionCallNamespaceFields(item []byte, requestRawJSON []byte, qualifiedName string, itemPath string) []byte {
-	name, namespace := splitResponsesQualifiedFunctionCallFromRequest(requestRawJSON, qualifiedName)
+func applyResponsesToolCallNamespaceFields(item []byte, requestRawJSON []byte, qualifiedName string, itemPath string) []byte {
+	name, namespace := splitResponsesQualifiedToolCallFromRequest(requestRawJSON, qualifiedName)
 	namePath := "name"
 	namespacePath := "namespace"
 	if itemPath != "" {
@@ -370,13 +370,12 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 				item = []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"in_progress","input":"","call_id":"","name":""}}`)
 				item, _ = sjson.SetBytes(item, "item.id", fmt.Sprintf("ctc_%s", st.CurrentFCID))
 				item, _ = sjson.SetBytes(item, "item.call_id", st.CurrentFCID)
-				item, _ = sjson.SetBytes(item, "item.name", name)
 			} else {
 				item = []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"in_progress","arguments":"","call_id":"","name":""}}`)
 				item, _ = sjson.SetBytes(item, "item.id", fmt.Sprintf("fc_%s", st.CurrentFCID))
 				item, _ = sjson.SetBytes(item, "item.call_id", st.CurrentFCID)
-				item = applyResponsesFunctionCallNamespaceFields(item, requestForToolMetadata, name, "item")
 			}
+			item = applyResponsesToolCallNamespaceFields(item, requestForToolMetadata, name, "item")
 			item, _ = sjson.SetBytes(item, "sequence_number", nextSeq())
 			item, _ = sjson.SetBytes(item, "output_index", outputIndex)
 			out = append(out, emitEvent("response.output_item.added", item))
@@ -501,7 +500,7 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 				itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("ctc_%s", st.CurrentFCID))
 				itemDone, _ = sjson.SetBytes(itemDone, "item.input", input)
 				itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.CurrentFCID)
-				itemDone, _ = sjson.SetBytes(itemDone, "item.name", st.FuncNames[idx])
+				itemDone = applyResponsesToolCallNamespaceFields(itemDone, requestForToolMetadata, st.FuncNames[idx], "item")
 				out = append(out, emitEvent("response.output_item.done", itemDone))
 			} else {
 				fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
@@ -516,7 +515,7 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 				itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", st.CurrentFCID))
 				itemDone, _ = sjson.SetBytes(itemDone, "item.arguments", args)
 				itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.CurrentFCID)
-				itemDone = applyResponsesFunctionCallNamespaceFields(itemDone, requestForToolMetadata, st.FuncNames[idx], "item")
+				itemDone = applyResponsesToolCallNamespaceFields(itemDone, requestForToolMetadata, st.FuncNames[idx], "item")
 				out = append(out, emitEvent("response.output_item.done", itemDone))
 			}
 			st.InFuncBlock = false
@@ -688,14 +687,14 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 					item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("ctc_%s", callID))
 					item, _ = sjson.SetBytes(item, "input", unwrapCustomToolInput(args))
 					item, _ = sjson.SetBytes(item, "call_id", callID)
-					item, _ = sjson.SetBytes(item, "name", name)
+					item = applyResponsesToolCallNamespaceFields(item, reqBytes, name, "")
 					outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, fmt.Sprintf("arr.%d", st.FuncOutputIndices[idx]), item)
 				} else {
 					item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
 					item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", callID))
 					item, _ = sjson.SetBytes(item, "arguments", args)
 					item, _ = sjson.SetBytes(item, "call_id", callID)
-					item = applyResponsesFunctionCallNamespaceFields(item, reqBytes, name, "")
+					item = applyResponsesToolCallNamespaceFields(item, reqBytes, name, "")
 					outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, fmt.Sprintf("arr.%d", st.FuncOutputIndices[idx]), item)
 				}
 			}
@@ -994,7 +993,7 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 				item, _ = sjson.SetBytes(item, "id", outputItem.id)
 				item, _ = sjson.SetBytes(item, "input", unwrapCustomToolInput(outputItem.args.String()))
 				item, _ = sjson.SetBytes(item, "call_id", outputItem.callID)
-				item, _ = sjson.SetBytes(item, "name", outputItem.name)
+				item = applyResponsesToolCallNamespaceFields(item, reqBytes, outputItem.name, "")
 				break
 			}
 			args := outputItem.args.String()
@@ -1005,7 +1004,7 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 			item, _ = sjson.SetBytes(item, "id", outputItem.id)
 			item, _ = sjson.SetBytes(item, "arguments", args)
 			item, _ = sjson.SetBytes(item, "call_id", outputItem.callID)
-			item = applyResponsesFunctionCallNamespaceFields(item, reqBytes, outputItem.name, "")
+			item = applyResponsesToolCallNamespaceFields(item, reqBytes, outputItem.name, "")
 		}
 		if len(item) > 0 {
 			outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, fmt.Sprintf("arr.%d", outputItem.outputIndex), item)

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
@@ -1050,6 +1050,96 @@ func TestConvertClaudeResponseToOpenAIResponses_CustomToolEmptyInputMatchesNonSt
 	}
 }
 
+func TestConvertClaudeResponseToOpenAIResponses_RestoresNamespaceCustomToolCall(t *testing.T) {
+	originalRequest := []byte(`{
+		"model":"gpt-test",
+		"input":[{"type":"additional_tools","role":"developer","tools":[{
+			"type":"namespace",
+			"name":"functions",
+			"tools":[{"type":"custom","name":"exec"}]
+		}]}]
+	}`)
+	chunks := [][]byte{
+		[]byte(`data: {"type":"message_start","message":{"id":"msg_custom_namespace","usage":{"input_tokens":1,"output_tokens":0}}}`),
+		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call_exec","name":"functions__exec","input":{}}}`),
+		[]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"input\":\"pwd\"}"}}`),
+		[]byte(`data: {"type":"content_block_stop","index":0}`),
+		[]byte(`data: {"type":"message_stop"}`),
+	}
+
+	var param any
+	var added, done, completed gjson.Result
+	for _, chunk := range chunks {
+		for _, output := range ConvertClaudeResponseToOpenAIResponses(context.Background(), "claude-test", originalRequest, nil, chunk, &param) {
+			event, data := parseClaudeResponsesSSEEvent(t, output)
+			switch event {
+			case "response.output_item.added":
+				if data.Get("item.type").String() == "custom_tool_call" {
+					added = data
+				}
+			case "response.output_item.done":
+				if data.Get("item.type").String() == "custom_tool_call" {
+					done = data
+				}
+			case "response.completed":
+				completed = data
+			}
+		}
+	}
+
+	for _, tc := range []struct {
+		label string
+		item  gjson.Result
+	}{
+		{"added", added.Get("item")},
+		{"done", done.Get("item")},
+		{"completed", completed.Get("response.output.0")},
+	} {
+		if !tc.item.Exists() {
+			t.Fatalf("missing %s custom tool item", tc.label)
+		}
+		if got := tc.item.Get("name").String(); got != "exec" {
+			t.Errorf("%s name = %q, want exec", tc.label, got)
+		}
+		if got := tc.item.Get("namespace").String(); got != "functions" {
+			t.Errorf("%s namespace = %q, want functions", tc.label, got)
+		}
+	}
+}
+
+func TestConvertClaudeResponseToOpenAIResponsesNonStream_RestoresNamespaceCustomToolCall(t *testing.T) {
+	originalRequest := []byte(`{
+		"model":"gpt-test",
+		"input":[{"type":"additional_tools","role":"developer","tools":[{
+			"type":"namespace",
+			"name":"functions",
+			"tools":[{"type":"custom","name":"exec"}]
+		}]}]
+	}`)
+	raw := []byte(strings.Join([]string{
+		`data: {"type":"message_start","message":{"id":"msg_custom_namespace_nonstream","usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call_exec","name":"functions__exec","input":{}}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"input\":\"pwd\"}"}}`,
+		`data: {"type":"content_block_stop","index":0}`,
+		`data: {"type":"message_stop"}`,
+	}, "\n"))
+
+	root := gjson.ParseBytes(ConvertClaudeResponseToOpenAIResponsesNonStream(context.Background(), "claude-test", originalRequest, nil, raw, nil))
+	item := root.Get("output.0")
+	if got := item.Get("type").String(); got != "custom_tool_call" {
+		t.Fatalf("non-stream output type = %q, want custom_tool_call; output=%s", got, root.Raw)
+	}
+	if got := item.Get("name").String(); got != "exec" {
+		t.Errorf("non-stream name = %q, want exec", got)
+	}
+	if got := item.Get("namespace").String(); got != "functions" {
+		t.Errorf("non-stream namespace = %q, want functions", got)
+	}
+	if got := item.Get("input").String(); got != "pwd" {
+		t.Errorf("non-stream input = %q, want pwd", got)
+	}
+}
+
 func TestConvertClaudeResponseToOpenAIResponses_RestoresNamespaceFunctionCall(t *testing.T) {
 	originalRequest := []byte(`{
 		"model":"gpt-test",


### PR DESCRIPTION
## Summary

- restore `name` and `namespace` for namespaced Responses custom tool calls translated through Claude
- apply the restoration to streaming added/done/completed items and non-stream output
- preserve the namespace when replaying custom tool call/output history

## Problem

Responses Lite places Codex's freeform `exec` tool under the `functions` namespace in `input[].additional_tools`. The Claude request translator correctly flattens that declaration to `functions__exec`, but the response translator returned a `custom_tool_call` with that flattened name and no namespace. Codex could not route it and reported:

```text
unsupported custom tool call: functions__exec
```

This change extends the existing function-call namespace restoration to custom tool calls, yielding `name: "exec"` and `namespace: "functions"` while retaining `type: "custom_tool_call"` and its freeform input.

## Validation

- `go test ./internal/translator/claude/openai/responses -count=1`
- `go test ./internal/translator/... -count=1`
- `go vet ./internal/translator/claude/openai/responses`
- live Codex 0.147.0 tool-loop test through a locally built patched CPA and the keelcode plugin: Codex executed `printf codex-tool-loop-fixed`, captured the expected output, and produced no `unsupported custom tool call` error

The full repository test run still has three pre-existing, environment-dependent failures in `internal/runtime/executor` where tests expect `X-Stainless-Os: Linux` but the local device profile reports `MacOS`; all translator tests pass.
