### PR TITLE
feat(cliproxy): add ranked auth selection and pinned one-shot execution

### DIFF
--- a/sdk/cliproxy/auth/conductor_execution_once.go
+++ b/sdk/cliproxy/auth/conductor_execution_once.go
@@ -104,8 +104,10 @@ type ExecuteWithAuthOnceRequest struct {
 	Options cliproxyexecutor.Options
 	// RedirectPolicy optionally constrains redirects for the executor's HTTP
 	// client. Empty keeps the executor's own behavior, which is what every
-	// existing caller gets today. Enforcement is only possible while the
-	// manager-installed transport is in effect; see redirectPolicyRoundTripper.
+	// existing caller gets today. Enforcement is best effort here because the
+	// executor owns its http.Client; it holds only while the manager-installed
+	// transport is in effect (see onceRoundTripper). DoHTTPOnce owns the client
+	// itself and is therefore the path with the unconditional guarantee.
 	RedirectPolicy HTTPRedirectPolicy
 }
 
@@ -249,8 +251,14 @@ func (m *Manager) ExecuteWithAuthOnce(ctx context.Context, in ExecuteWithAuthOnc
 	return resp, facts, nil
 }
 
-// DoHTTPOnce injects the credentials of the supplied auth into req and performs
-// exactly one policed HTTP attempt.
+// DoHTTPOnce resolves a persisted credential by ID, refreshes and prepares it,
+// and then performs exactly one policed HTTP attempt against the supplied target.
+//
+// It is the raw-HTTP twin of ExecuteWithAuthOnce and shares its lifecycle: the ID
+// must name a durable auth (Home runtime/session auths are rejected with
+// auth_not_durable before any network I/O), the credential is refreshed under the
+// existing per-auth refresh lock, and request preparation runs under the existing
+// per-auth prepare lock. Selection never runs and nothing is ever replayed.
 //
 // Credential injection reuses the registered executor's RequestPreparer through
 // PrepareHttpRequest, and the proxy chain is resolved with the same priority the
@@ -265,31 +273,10 @@ func (m *Manager) ExecuteWithAuthOnce(ctx context.Context, in ExecuteWithAuthOnc
 //
 // The response body is not read or closed; the caller owns it. Exactly one
 // execution result is marked: success is HTTP 2xx alone, so a 3xx is never
-// marked as success.
+// marked as success. An empty RedirectPolicy means HTTPRedirectDeny.
 //
-// An empty policy means HTTPRedirectDeny.
-func (m *Manager) DoHTTPOnce(ctx context.Context, auth *Auth, req *http.Request, policy HTTPRedirectPolicy) (*http.Response, HTTPAttemptFacts, error) {
-	var facts HTTPAttemptFacts
-	if m == nil {
-		return nil, facts, &Error{Code: "provider_not_found", Message: "manager is nil"}
-	}
-	if auth == nil {
-		return nil, facts, &Error{Code: "auth_not_found", Message: "auth is nil"}
-	}
-	if req == nil {
-		return nil, facts, &Error{Code: "invalid_request", Message: "http request is nil"}
-	}
-	return m.httpOnce(ctx, auth, req, "", policy)
-}
-
-// HTTPOnce resolves a persisted credential by ID, refreshes and prepares it, and
-// then performs exactly one policed HTTP attempt against the supplied target.
-//
-// It is DoHTTPOnce plus the credential lifecycle: the ID must name a durable
-// auth (Home runtime/session auths are rejected with auth_not_durable before any
-// network I/O), the credential is refreshed under the existing per-auth refresh
-// lock, and request preparation runs under the existing per-auth prepare lock.
-func (m *Manager) HTTPOnce(ctx context.Context, in HTTPOnceRequest) (*http.Response, HTTPAttemptFacts, error) {
+// It never returns an *Auth, request headers or any other credential material.
+func (m *Manager) DoHTTPOnce(ctx context.Context, in HTTPOnceRequest) (*http.Response, HTTPAttemptFacts, error) {
 	var facts HTTPAttemptFacts
 	if m == nil {
 		return nil, facts, &Error{Code: "provider_not_found", Message: "manager is nil"}
@@ -342,6 +329,15 @@ func (m *Manager) HTTPOnce(ctx context.Context, in HTTPOnceRequest) (*http.Respo
 // httpOnce injects credentials, performs one policed attempt and marks once.
 func (m *Manager) httpOnce(ctx context.Context, auth *Auth, req *http.Request, model string, policy HTTPRedirectPolicy) (*http.Response, HTTPAttemptFacts, error) {
 	var facts HTTPAttemptFacts
+	if m == nil {
+		return nil, facts, &Error{Code: "provider_not_found", Message: "manager is nil"}
+	}
+	if auth == nil {
+		return nil, facts, &Error{Code: "auth_not_found", Message: "auth is nil"}
+	}
+	if req == nil {
+		return nil, facts, &Error{Code: "invalid_request", Message: "http request is nil"}
+	}
 	if errPolicy := validateRedirectPolicy(policy); errPolicy != nil {
 		return nil, facts, errPolicy
 	}

--- a/sdk/cliproxy/auth/conductor_execution_once.go
+++ b/sdk/cliproxy/auth/conductor_execution_once.go
@@ -30,8 +30,11 @@ import (
 //     preparation, no result marking and reports no attempt facts.
 //
 // ExecuteWithAuthOnce and DoHTTPOnce keep the lifecycle and drop every replay
-// vector the manager owns, and they report typed attempt facts so a caller can
-// tell "definitely not sent" from "may have been sent".
+// vector the manager owns, and both report typed attempt facts. How much those
+// facts can claim differs by entry point: only DoHTTPOnce owns the http.Client,
+// so only there can RequestWritten be false and mean "definitely not sent". On
+// ExecuteWithAuthOnce a provider executor owns the client, so the facts describe
+// what was observed and RequestWritten is never false.
 //
 // The two differ in how far the guarantee reaches, and the difference is a
 // boundary rather than a gap in effort. DoHTTPOnce performs the request itself,
@@ -58,7 +61,12 @@ const (
 	HTTPRedirectDeny HTTPRedirectPolicy = "deny"
 	// HTTPRedirectSameOriginSafe follows at most maxSameOriginSafeRedirectHops
 	// redirects, and only for a bodyless GET or HEAD request whose target keeps
-	// the same HTTPS origin. Credential headers are stripped before following.
+	// the same HTTPS origin. Credential headers are stripped before following, so
+	// every hop after the first is unauthenticated even though the origin is
+	// unchanged. That makes this policy suitable for following a signed URL or an
+	// asset redirect, and unsuitable for polling an endpoint that requires the
+	// credential on the followed hop - there the redirect target returns 401/403
+	// rather than the resource.
 	HTTPRedirectSameOriginSafe HTTPRedirectPolicy = "same_origin_safe"
 )
 
@@ -305,7 +313,11 @@ func (m *Manager) ExecuteWithAuthOnce(ctx context.Context, in ExecuteWithAuthOnc
 // The response body is not read or closed; the caller owns it. A redirect the
 // policy refuses is returned as the unfollowed 3xx response together with a
 // redirect_denied error, so a caller that branches on the error alone cannot read
-// a refused attempt as a success. An empty RedirectPolicy means HTTPRedirectDeny.
+// a refused 3xx as a success - with one degenerate exception: a 3xx carrying no
+// Location header is not a followable redirect at all and is returned as a plain
+// (3xx, nil error) result, like any other non-2xx status. A caller that must not
+// treat any non-2xx as success should branch on the status code, not on the error.
+// An empty RedirectPolicy means HTTPRedirectDeny.
 //
 // Exactly one execution result is recorded, and the recording is classified
 // because a raw HTTP call addresses arbitrary endpoints rather than a model

--- a/sdk/cliproxy/auth/conductor_execution_once.go
+++ b/sdk/cliproxy/auth/conductor_execution_once.go
@@ -1,0 +1,918 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptrace"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
+	log "github.com/sirupsen/logrus"
+)
+
+// This file adds the one-shot execution primitives. They exist because the two
+// execution entry points the manager already offers sit on opposite sides of a
+// gap that a non-idempotent (paid) upstream create cannot straddle:
+//
+//   - Manager.Execute owns the full lifecycle (selection, refresh, request
+//     preparation, interceptors, result marking) but replays: an outer attempt
+//     loop, an inner credential-hop loop, a post-401 re-execute and a model pool
+//     loop can each invoke a provider executor more than once per call.
+//   - Manager.HttpRequest never replays, but performs no refresh, no request
+//     preparation, no result marking and reports no attempt facts.
+//
+// ExecuteWithAuthOnce and DoHTTPOnce keep the lifecycle and drop every replay
+// vector, and they report typed attempt facts so a caller can tell "definitely
+// not sent" from "may have been sent".
+
+// maxSameOriginSafeRedirectHops bounds HTTPRedirectSameOriginSafe redirect following.
+const maxSameOriginSafeRedirectHops = 3
+
+// HTTPRedirectPolicy names the redirect contract applied to a one-shot request.
+type HTTPRedirectPolicy string
+
+const (
+	// HTTPRedirectDeny never follows a redirect and surfaces the 3xx response to
+	// the caller instead. This is the required policy for a non-idempotent create.
+	HTTPRedirectDeny HTTPRedirectPolicy = "deny"
+	// HTTPRedirectSameOriginSafe follows at most maxSameOriginSafeRedirectHops
+	// redirects, and only for a bodyless GET or HEAD request whose target keeps
+	// the same HTTPS origin. Credential headers are stripped before following.
+	HTTPRedirectSameOriginSafe HTTPRedirectPolicy = "same_origin_safe"
+)
+
+// normalizedRedirectPolicy trims and lower-cases a caller supplied policy value.
+func normalizedRedirectPolicy(policy HTTPRedirectPolicy) HTTPRedirectPolicy {
+	return HTTPRedirectPolicy(strings.ToLower(strings.TrimSpace(string(policy))))
+}
+
+// validateRedirectPolicy reports whether the supplied policy is understood.
+// An empty policy is accepted; each caller documents what it means for that path.
+func validateRedirectPolicy(policy HTTPRedirectPolicy) error {
+	switch normalizedRedirectPolicy(policy) {
+	case "", HTTPRedirectDeny, HTTPRedirectSameOriginSafe:
+		return nil
+	default:
+		return &Error{Code: "invalid_redirect_policy", Message: "redirect policy is invalid", HTTPStatus: http.StatusBadRequest}
+	}
+}
+
+// HTTPAttemptFacts reports what is known about the upstream attempt a one-shot
+// call made. It exists so a caller of a paid create can distinguish "definitely
+// not sent" from "may have been sent" without parsing an error string.
+//
+// The facts are derived from the transport the manager installed and from
+// net/http/httptrace. When neither source reports anything - which happens when
+// a host supplied RoundTripper ignores httptrace - RequestWritten is reported as
+// true for any attempt that reached the executor, because an ambiguous "may have
+// been sent" is safe while a false "not sent" causes a double charge.
+type HTTPAttemptFacts struct {
+	// RequestCount counts upstream requests observed by the manager transport,
+	// including redirect hops. It stays 0 when the attempt never dispatched.
+	RequestCount uint32
+	// RequestWritten reports whether any request byte may have reached the wire.
+	RequestWritten bool
+	// ResponseStarted reports whether upstream response headers were received.
+	ResponseStarted bool
+	// StatusCode is the observed upstream status, or the status carried by the
+	// executor error when the transport was not manager visible. It is 0 when
+	// no status is known.
+	StatusCode int
+}
+
+// ExecuteWithAuthOnceRequest describes a single pinned, non-replayed execution.
+type ExecuteWithAuthOnceRequest struct {
+	// AuthID identifies a manager-persisted credential. Selection never runs.
+	AuthID string
+	// Provider optionally overrides the executor key derived from the auth.
+	// Leave it empty to use the same resolution the retrying path uses.
+	Provider string
+	// Model optionally overrides the routing model. Empty falls back to the
+	// auth-selection model metadata and then to Request.Model.
+	Model string
+	// Request is the canonical executor request.
+	Request cliproxyexecutor.Request
+	// Options are the canonical executor options.
+	Options cliproxyexecutor.Options
+	// RedirectPolicy optionally constrains redirects for the executor's HTTP
+	// client. Empty keeps the executor's own behavior, which is what every
+	// existing caller gets today. Enforcement is only possible while the
+	// manager-installed transport is in effect; see redirectPolicyRoundTripper.
+	RedirectPolicy HTTPRedirectPolicy
+}
+
+// HTTPOnceRequest describes a single pinned, non-replayed raw HTTP call.
+type HTTPOnceRequest struct {
+	// AuthID identifies a manager-persisted credential.
+	AuthID string
+	// Model is recorded with the execution result. It may be empty.
+	Model string
+	// Method is the HTTP method. Empty defaults to GET.
+	Method string
+	// URL is the absolute upstream URL.
+	URL string
+	// Header carries request headers applied before credential injection.
+	Header http.Header
+	// Body is the request payload. A body-bearing request is never replayed.
+	Body []byte
+	// RedirectPolicy constrains redirect handling. Empty means HTTPRedirectDeny.
+	RedirectPolicy HTTPRedirectPolicy
+}
+
+// ExecuteWithAuthOnce executes a request against exactly one persisted credential
+// and invokes its registered provider executor exactly once.
+//
+// It reuses the manager's existing lifecycle - proactive refresh under the
+// per-auth refresh lock, request preparation under the per-auth prepare lock,
+// alias and force-mapping resolution, the RequestAfterAuthInterceptor seam and
+// MarkResult - while entering none of the retry machinery: no attempt loop, no
+// credential hop, no post-401 re-execute, and a model pool collapsed to its
+// first entry exactly as the Home execution path does.
+//
+// MarkResult is called at most once. It is not called at all when the failure
+// happened before the credential was exercised: unknown or non-durable auth,
+// unregistered executor, refresh failure, or an interceptor termination.
+//
+// It never returns an *Auth, headers or any other credential material.
+func (m *Manager) ExecuteWithAuthOnce(ctx context.Context, in ExecuteWithAuthOnceRequest) (cliproxyexecutor.Response, HTTPAttemptFacts, error) {
+	var facts HTTPAttemptFacts
+	if m == nil {
+		return cliproxyexecutor.Response{}, facts, &Error{Code: "provider_not_found", Message: "manager is nil"}
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if errPolicy := validateRedirectPolicy(in.RedirectPolicy); errPolicy != nil {
+		return cliproxyexecutor.Response{}, facts, errPolicy
+	}
+
+	auth, executor, providerKey, errResolve := m.resolveDurableAuthForOnce(in.AuthID, in.Provider)
+	if errResolve != nil {
+		return cliproxyexecutor.Response{}, facts, errResolve
+	}
+
+	refreshed, errRefresh := m.refreshAuthForOnce(ctx, auth)
+	if errRefresh != nil {
+		// Fail closed: a credential that could not be refreshed must not be spent
+		// on a paid attempt. refreshAuthForRequest already recorded the credential
+		// state, so this path deliberately does not mark a second result.
+		return cliproxyexecutor.Response{}, facts, errRefresh
+	}
+	auth = refreshed
+
+	routeModel := strings.TrimSpace(in.Model)
+	if routeModel == "" {
+		routeModel = authSelectionModelFromOptions(in.Options, in.Request.Model)
+	}
+	executionModel, restoreExecutionModel := executionModelForAuthSelection(in.Options, in.Request.Model)
+	opts := ensureRequestedModelMetadata(in.Options, routeModel)
+	publishSelectedAuthMetadata(opts.Metadata, auth)
+
+	recorder := newOnceAttemptRecorder()
+	execCtx := m.onceExecutionContext(ctx, auth, opts, routeModel, in.RedirectPolicy, recorder)
+
+	models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel)
+	if len(models) == 0 {
+		// The pinned credential is cooling for this model. The retrying path would
+		// hop to another credential here; a pinned one-shot fails closed instead.
+		return cliproxyexecutor.Response{}, facts, &Error{Code: "auth_unavailable", Message: "auth is unavailable for model: " + routeModel, HTTPStatus: http.StatusServiceUnavailable}
+	}
+	if len(models) > 1 {
+		// A model pool is a replay vector: the retrying path invokes the executor
+		// once per pooled model. Collapse it exactly as the Home path does.
+		models = models[:1]
+		pooled = false
+	}
+	upstreamModel := models[0]
+	resultModel := m.stateModelForExecution(auth, routeModel, upstreamModel, pooled)
+
+	marker := &onceResultMarker{}
+
+	var errPrepare error
+	auth, errPrepare = m.prepareRequestAuth(execCtx, executor, auth)
+	if errPrepare != nil {
+		if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errPrepare); errCancel != nil {
+			return cliproxyexecutor.Response{}, facts, errCancel
+		}
+		marker.mark(execCtx, m, Result{AuthID: auth.ID, Provider: providerKey, Model: routeModel, Success: false, Error: resultErrorFromError(errPrepare)})
+		return cliproxyexecutor.Response{}, facts, errPrepare
+	}
+
+	execReq := in.Request
+	execReq.Model = upstreamModel
+	if restoreExecutionModel {
+		execReq.Model = executionModel
+	}
+	execOpts := opts
+	var errIntercept error
+	execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, executor, providerKey, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+	if errIntercept != nil {
+		// The interceptor terminated before the executor ran; nothing was spent.
+		return cliproxyexecutor.Response{}, facts, errIntercept
+	}
+	if !restoreExecutionModel {
+		execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel)
+	}
+
+	recorder.markDispatched()
+	resp, errExec := executor.Execute(execCtx, auth, execReq, execOpts)
+	facts = recorder.facts()
+	if facts.StatusCode == 0 {
+		facts.StatusCode = statusCodeFromError(errExec)
+	}
+
+	if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
+		return cliproxyexecutor.Response{}, facts, errCancel
+	}
+
+	result := Result{AuthID: auth.ID, Provider: providerKey, Model: resultModel, Success: errExec == nil}
+	if errExec != nil {
+		result.Error = resultErrorFromError(errExec)
+		if retryAfter := retryAfterFromError(errExec); retryAfter != nil {
+			result.RetryAfter = retryAfter
+		}
+	}
+	marker.mark(execCtx, m, result)
+	if errExec != nil {
+		return cliproxyexecutor.Response{}, facts, errExec
+	}
+
+	rewriteForceMappedResponse(&resp, resolveAttemptAliasResult(routing, auth, routeModel, upstreamModel, aliasResult))
+	return resp, facts, nil
+}
+
+// DoHTTPOnce injects the credentials of the supplied auth into req and performs
+// exactly one policed HTTP attempt.
+//
+// Credential injection reuses the registered executor's RequestPreparer through
+// PrepareHttpRequest, and the proxy chain is resolved with the same priority the
+// shared executor helper uses (auth proxy, then runtime config proxy, then the
+// context or per-auth RoundTripper, then the default transport). The client
+// itself is manager owned because redirect policy cannot be expressed any other
+// way: provider executors construct their own http.Client and none of them sets
+// CheckRedirect, so the default client would follow up to ten hops, replay a
+// body on 307/308 whenever GetBody is set, and carry executor-injected api-key
+// style headers cross-host - net/http only strips Authorization, Cookie and
+// WWW-Authenticate. Both of those are disqualifying for a paid create.
+//
+// The response body is not read or closed; the caller owns it. Exactly one
+// execution result is marked: success is HTTP 2xx alone, so a 3xx is never
+// marked as success.
+//
+// An empty policy means HTTPRedirectDeny.
+func (m *Manager) DoHTTPOnce(ctx context.Context, auth *Auth, req *http.Request, policy HTTPRedirectPolicy) (*http.Response, HTTPAttemptFacts, error) {
+	var facts HTTPAttemptFacts
+	if m == nil {
+		return nil, facts, &Error{Code: "provider_not_found", Message: "manager is nil"}
+	}
+	if auth == nil {
+		return nil, facts, &Error{Code: "auth_not_found", Message: "auth is nil"}
+	}
+	if req == nil {
+		return nil, facts, &Error{Code: "invalid_request", Message: "http request is nil"}
+	}
+	return m.httpOnce(ctx, auth, req, "", policy)
+}
+
+// HTTPOnce resolves a persisted credential by ID, refreshes and prepares it, and
+// then performs exactly one policed HTTP attempt against the supplied target.
+//
+// It is DoHTTPOnce plus the credential lifecycle: the ID must name a durable
+// auth (Home runtime/session auths are rejected with auth_not_durable before any
+// network I/O), the credential is refreshed under the existing per-auth refresh
+// lock, and request preparation runs under the existing per-auth prepare lock.
+func (m *Manager) HTTPOnce(ctx context.Context, in HTTPOnceRequest) (*http.Response, HTTPAttemptFacts, error) {
+	var facts HTTPAttemptFacts
+	if m == nil {
+		return nil, facts, &Error{Code: "provider_not_found", Message: "manager is nil"}
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if errPolicy := validateRedirectPolicy(in.RedirectPolicy); errPolicy != nil {
+		return nil, facts, errPolicy
+	}
+	if strings.TrimSpace(in.URL) == "" {
+		return nil, facts, &Error{Code: "invalid_request", Message: "http request url is empty", HTTPStatus: http.StatusBadRequest}
+	}
+
+	auth, executor, _, errResolve := m.resolveDurableAuthForOnce(in.AuthID, "")
+	if errResolve != nil {
+		return nil, facts, errResolve
+	}
+
+	refreshed, errRefresh := m.refreshAuthForOnce(ctx, auth)
+	if errRefresh != nil {
+		return nil, facts, errRefresh
+	}
+	auth = refreshed
+
+	prepared, errPrepare := m.prepareRequestAuth(ctx, executor, auth)
+	if errPrepare != nil {
+		return nil, facts, errPrepare
+	}
+	auth = prepared
+
+	method := strings.TrimSpace(in.Method)
+	if method == "" {
+		method = http.MethodGet
+	}
+	var body io.Reader
+	if in.Body != nil {
+		body = bytes.NewReader(in.Body)
+	}
+	req, errRequest := http.NewRequestWithContext(ctx, method, in.URL, body)
+	if errRequest != nil {
+		return nil, facts, errRequest
+	}
+	if in.Header != nil {
+		req.Header = in.Header.Clone()
+	}
+	return m.httpOnce(ctx, auth, req, in.Model, in.RedirectPolicy)
+}
+
+// httpOnce injects credentials, performs one policed attempt and marks once.
+func (m *Manager) httpOnce(ctx context.Context, auth *Auth, req *http.Request, model string, policy HTTPRedirectPolicy) (*http.Response, HTTPAttemptFacts, error) {
+	var facts HTTPAttemptFacts
+	if errPolicy := validateRedirectPolicy(policy); errPolicy != nil {
+		return nil, facts, errPolicy
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	normalized := normalizedRedirectPolicy(policy)
+	if normalized == "" {
+		normalized = HTTPRedirectDeny
+	}
+
+	recorder := newOnceAttemptRecorder()
+	tracedCtx := httptrace.WithClientTrace(ctx, recorder.clientTrace())
+	httpReq := req.WithContext(tracedCtx)
+	if httpReq.Body != nil || httpReq.ContentLength != 0 {
+		// Belt and braces: with GetBody unset net/http refuses to replay a body on
+		// 307/308 and hands the 3xx back instead of resending the payload.
+		httpReq.GetBody = nil
+	}
+
+	if errPrepare := m.PrepareHttpRequest(tracedCtx, auth, httpReq); errPrepare != nil {
+		return nil, facts, errPrepare
+	}
+
+	client := &http.Client{
+		Transport:     m.transportForOnce(tracedCtx, auth, recorder, ""),
+		CheckRedirect: redirectGuard(normalized, newRedirectOrigin(httpReq)),
+	}
+
+	recorder.markDispatched()
+	resp, errDo := client.Do(httpReq)
+	facts = recorder.facts()
+	if resp != nil {
+		facts.StatusCode = resp.StatusCode
+		facts.ResponseStarted = true
+		facts.RequestWritten = true
+	} else if facts.StatusCode == 0 {
+		facts.StatusCode = statusCodeFromError(errDo)
+	}
+
+	if errCancel := claudeOAuthRequestCancellation(tracedCtx, auth, errDo); errCancel != nil {
+		return resp, facts, errCancel
+	}
+
+	marker := &onceResultMarker{}
+	result := Result{AuthID: auth.ID, Provider: executorKeyFromAuth(auth), Model: model}
+	switch {
+	case resp == nil:
+		result.Success = false
+		result.Error = resultErrorFromError(errDo)
+		if retryAfter := retryAfterFromError(errDo); retryAfter != nil {
+			result.RetryAfter = retryAfter
+		}
+	case resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices:
+		result.Success = true
+	default:
+		result.Success = false
+		result.Error = resultErrorFromError(httpStatusError(resp.StatusCode))
+		if retryAfter := retryAfterFromResponse(resp); retryAfter != nil {
+			result.RetryAfter = retryAfter
+		}
+	}
+	marker.mark(tracedCtx, m, result)
+	return resp, facts, errDo
+}
+
+// httpStatusError converts an upstream HTTP status into the package error type
+// so MarkResult keeps its status-driven cooldown classification.
+func httpStatusError(status int) error {
+	return &Error{Code: "upstream_http_status", Message: "upstream returned status " + strconv.Itoa(status), HTTPStatus: status}
+}
+
+// retryAfterFromResponse extracts a Retry-After hint from an upstream response.
+func retryAfterFromResponse(resp *http.Response) *time.Duration {
+	if resp == nil {
+		return nil
+	}
+	raw := strings.TrimSpace(resp.Header.Get("Retry-After"))
+	if raw == "" {
+		return nil
+	}
+	if seconds, errParse := strconv.Atoi(raw); errParse == nil {
+		if seconds < 0 {
+			return nil
+		}
+		value := time.Duration(seconds) * time.Second
+		return &value
+	}
+	deadline, errParse := http.ParseTime(raw)
+	if errParse != nil {
+		return nil
+	}
+	value := time.Until(deadline)
+	if value <= 0 {
+		return nil
+	}
+	return &value
+}
+
+// resolveDurableAuthForOnce returns a durable credential and its registered
+// executor without running selection. Home runtime/session auths and Home mode
+// itself are rejected because their credentials are not manager persisted.
+func (m *Manager) resolveDurableAuthForOnce(authID, providerOverride string) (*Auth, ProviderExecutor, string, error) {
+	id := strings.TrimSpace(authID)
+	if id == "" {
+		return nil, nil, "", &Error{Code: "auth_not_found", Message: "auth id is empty"}
+	}
+	if !m.localExecutionAllowed() {
+		return nil, nil, "", &Error{Code: "auth_not_durable", Message: "pinned execution requires a locally persisted auth", HTTPStatus: http.StatusServiceUnavailable}
+	}
+
+	m.mu.RLock()
+	// Clone under the read lock: MarkResult mutates the stored auth in place
+	// while holding the write lock.
+	cloned := m.auths[id].Clone()
+	sessionScoped := false
+	for _, sessionAuths := range m.homeRuntimeAuths {
+		if _, ok := sessionAuths[id]; ok {
+			sessionScoped = true
+			break
+		}
+	}
+	m.mu.RUnlock()
+
+	if sessionScoped {
+		return nil, nil, "", &Error{Code: "auth_not_durable", Message: "auth is session scoped", HTTPStatus: http.StatusServiceUnavailable}
+	}
+	if cloned == nil {
+		return nil, nil, "", &Error{Code: "auth_not_found", Message: "auth not found: " + id}
+	}
+
+	providerKey := strings.TrimSpace(providerOverride)
+	if providerKey == "" {
+		providerKey = executorKeyFromAuth(cloned)
+	}
+	if providerKey == "" {
+		return nil, nil, "", &Error{Code: "provider_not_found", Message: "auth provider is empty"}
+	}
+	executor := m.executorFor(providerKey)
+	if executor == nil {
+		return nil, nil, "", &Error{Code: "executor_not_found", Message: "executor not registered for provider: " + providerKey}
+	}
+	return cloned, executor, providerKey, nil
+}
+
+// refreshAuthForOnce runs the manager's existing proactive refresh before a
+// one-shot dispatch. It claims the refresh with markRefreshPending and performs
+// it with refreshAuthForRequest, so it shares the per-auth refresh lock and the
+// backoff bookkeeping with the auto-refresh loop instead of duplicating them.
+//
+// The refresh is skipped, without error, when the credential does not need one
+// or when another goroutine already owns it. It is also skipped when no executor
+// is registered under the raw provider string, because that is the only key the
+// manager refresh path resolves; failing there would reject openai-compatibility
+// credentials that never had a refreshable executor to begin with.
+func (m *Manager) refreshAuthForOnce(ctx context.Context, auth *Auth) (*Auth, error) {
+	if m == nil || auth == nil {
+		return auth, nil
+	}
+	id := strings.TrimSpace(auth.ID)
+	if id == "" {
+		return auth, nil
+	}
+	now := time.Now()
+	m.mu.RLock()
+	current := m.auths[id]
+	needsRefresh := current != nil && m.shouldRefresh(current, now)
+	provider := ""
+	if current != nil {
+		provider = strings.TrimSpace(current.Provider)
+	}
+	m.mu.RUnlock()
+	if !needsRefresh {
+		return auth, nil
+	}
+	if m.executorFor(provider) == nil {
+		return auth, nil
+	}
+	if !m.markRefreshPending(id, now) {
+		return auth, nil
+	}
+	refreshed, errRefresh := m.refreshAuthForRequest(ctx, id, "")
+	if errRefresh != nil {
+		return nil, errRefresh
+	}
+	if refreshed == nil {
+		return auth, nil
+	}
+	return refreshed, nil
+}
+
+// onceResultMarker guarantees at most one MarkResult call per one-shot request.
+type onceResultMarker struct {
+	once sync.Once
+}
+
+// mark records the execution result the first time it is called and never again.
+func (r *onceResultMarker) mark(ctx context.Context, m *Manager, result Result) {
+	if r == nil || m == nil {
+		return
+	}
+	r.once.Do(func() {
+		m.MarkResult(ctx, result)
+	})
+}
+
+// onceExecutionContext builds the executor context for a one-shot execution. It
+// mirrors the retrying path (per-auth transport under both round tripper keys,
+// requested-model alias attribution) and adds the httptrace hooks the attempt
+// facts are derived from.
+func (m *Manager) onceExecutionContext(ctx context.Context, auth *Auth, opts cliproxyexecutor.Options, routeModel string, policy HTTPRedirectPolicy, recorder *onceAttemptRecorder) context.Context {
+	execCtx := contextWithRequestedModelAlias(ctx, opts, routeModel)
+	transport := m.transportForOnce(ctx, auth, recorder, policy)
+	execCtx = context.WithValue(execCtx, roundTripperContextKey{}, transport)
+	execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", transport)
+	return httptrace.WithClientTrace(execCtx, recorder.clientTrace())
+}
+
+// transportForOnce resolves the transport for a one-shot attempt using the same
+// priority the shared executor helper applies - auth proxy, runtime config
+// proxy, context or per-auth RoundTripper, default transport - and wraps it so
+// the manager can count requests, observe statuses and, when a policy is set,
+// keep a shared http.Client from following a redirect.
+func (m *Manager) transportForOnce(ctx context.Context, auth *Auth, recorder *onceAttemptRecorder, policy HTTPRedirectPolicy) http.RoundTripper {
+	var base http.RoundTripper
+
+	proxyURL := ""
+	if auth != nil {
+		proxyURL = strings.TrimSpace(auth.ProxyURL)
+	}
+	if proxyURL == "" {
+		if cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config); cfg != nil {
+			proxyURL = strings.TrimSpace(cfg.ProxyURL)
+		}
+	}
+	if proxyURL != "" {
+		transport, _, errBuild := proxyutil.BuildHTTPTransport(proxyURL)
+		if errBuild != nil || transport == nil {
+			log.Debugf("one-shot request: proxy transport unavailable for %s: %v", proxyutil.Redact(proxyURL), errBuild)
+		} else {
+			base = transport
+		}
+	}
+	if base == nil && ctx != nil {
+		if rt, ok := ctx.Value(roundTripperContextKey{}).(http.RoundTripper); ok && rt != nil {
+			base = rt
+		} else if rt, ok := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); ok && rt != nil {
+			base = rt
+		}
+	}
+	if base == nil {
+		if rt := m.roundTripperFor(auth); rt != nil {
+			base = rt
+		}
+	}
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &onceRoundTripper{base: base, recorder: recorder, policy: normalizedRedirectPolicy(policy)}
+}
+
+// onceRoundTripper records attempt facts and, for executor-owned clients, keeps
+// a redirect from being followed.
+//
+// A provider executor builds its own http.Client, so the manager cannot install
+// a CheckRedirect on it. What it can do is remove the Location header from a
+// disallowed 3xx: net/http returns a 3xx without Location to its caller instead
+// of following it, so the paid request is never replayed. The policy is only
+// enforced while this transport is in effect; an executor that resolves a proxy
+// from the auth or the runtime config builds its own transport and governs its
+// own redirects, which is why the reliable guarantee lives in DoHTTPOnce.
+type onceRoundTripper struct {
+	base     http.RoundTripper
+	recorder *onceAttemptRecorder
+	policy   HTTPRedirectPolicy
+	mu       sync.Mutex
+	origin   *redirectOrigin
+}
+
+// RoundTrip implements http.RoundTripper.
+func (rt *onceRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	hop := rt.recorder.observeRequest()
+	origin := rt.rememberOrigin(req)
+
+	if rt.policy != "" && origin != nil && req.URL != nil && req.URL.String() != origin.target() {
+		// A followed redirect reached the transport; strip credentials so they
+		// never travel to a target the caller did not address.
+		stripSensitiveRedirectHeaders(req.Header)
+	}
+
+	resp, err := rt.base.RoundTrip(req)
+	if resp != nil {
+		rt.recorder.observeResponse(resp.StatusCode)
+		if rt.policy != "" && isRedirectStatus(resp.StatusCode) && !sameOriginSafeRedirectAllowed(rt.policy, origin, resp.Header.Get("Location"), int(hop)) {
+			resp.Header.Del("Location")
+		}
+	}
+	return resp, err
+}
+
+// rememberOrigin records the first request the transport observed.
+func (rt *onceRoundTripper) rememberOrigin(req *http.Request) *redirectOrigin {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if rt.origin == nil {
+		rt.origin = newRedirectOrigin(req)
+	}
+	return rt.origin
+}
+
+// redirectOrigin snapshots the properties of the original request that decide
+// whether a redirect may be followed. It is captured before dispatch because the
+// request body is consumed by then and cannot be inspected afterwards.
+type redirectOrigin struct {
+	method  string
+	url     *url.URL
+	hasBody bool
+}
+
+// newRedirectOrigin snapshots a request for redirect decisions.
+func newRedirectOrigin(req *http.Request) *redirectOrigin {
+	if req == nil {
+		return nil
+	}
+	return &redirectOrigin{
+		method:  strings.ToUpper(strings.TrimSpace(req.Method)),
+		url:     req.URL,
+		hasBody: req.Body != nil || req.ContentLength > 0,
+	}
+}
+
+// target returns the original absolute URL as a string.
+func (o *redirectOrigin) target() string {
+	if o == nil || o.url == nil {
+		return ""
+	}
+	return o.url.String()
+}
+
+// redirectGuard builds the CheckRedirect implementation for a policy. Denied
+// redirects surface the 3xx response to the caller rather than raising an error.
+func redirectGuard(policy HTTPRedirectPolicy, origin *redirectOrigin) func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		target := ""
+		if req != nil && req.URL != nil {
+			target = req.URL.String()
+		}
+		if !sameOriginSafeRedirectAllowed(policy, origin, target, len(via)) {
+			return http.ErrUseLastResponse
+		}
+		if req != nil {
+			stripSensitiveRedirectHeaders(req.Header)
+		}
+		return nil
+	}
+}
+
+// sameOriginSafeRedirectAllowed reports whether a redirect may be followed.
+//
+// HTTPRedirectDeny never allows one. HTTPRedirectSameOriginSafe allows at most
+// maxSameOriginSafeRedirectHops hops, and only when the original request is a
+// bodyless GET or HEAD over HTTPS and the target keeps the same normalized
+// origin. hop is the number of requests already made, so the first redirect
+// decision sees hop == 1.
+func sameOriginSafeRedirectAllowed(policy HTTPRedirectPolicy, origin *redirectOrigin, target string, hop int) bool {
+	if normalizedRedirectPolicy(policy) != HTTPRedirectSameOriginSafe {
+		return false
+	}
+	if origin == nil || origin.url == nil {
+		return false
+	}
+	if hop < 1 || hop > maxSameOriginSafeRedirectHops {
+		return false
+	}
+	switch origin.method {
+	case http.MethodGet, http.MethodHead:
+	default:
+		return false
+	}
+	if origin.hasBody {
+		return false
+	}
+	if !strings.EqualFold(origin.url.Scheme, "https") {
+		return false
+	}
+	if strings.TrimSpace(target) == "" {
+		return false
+	}
+	parsed, errParse := url.Parse(target)
+	if errParse != nil {
+		return false
+	}
+	if parsed.Host == "" {
+		// A relative Location stays on the current origin.
+		return true
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		return false
+	}
+	return strings.EqualFold(normalizedOriginHost(parsed), normalizedOriginHost(origin.url))
+}
+
+// normalizedOriginHost returns the comparable host[:port] of a URL.
+func normalizedOriginHost(target *url.URL) string {
+	if target == nil {
+		return ""
+	}
+	host := strings.ToLower(strings.TrimSpace(target.Host))
+	return strings.TrimSuffix(host, ":443")
+}
+
+// isRedirectStatus reports whether a status triggers redirect handling.
+func isRedirectStatus(status int) bool {
+	switch status {
+	case http.StatusMovedPermanently, http.StatusFound, http.StatusSeeOther, http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
+		return true
+	default:
+		return false
+	}
+}
+
+// redirectSensitiveHeaders lists credential-bearing headers that must never
+// travel to a redirect target. net/http only strips the first three of these on
+// its own, and only cross-host, which leaves executor-injected api-key style
+// headers in place.
+var redirectSensitiveHeaders = []string{
+	"Authorization",
+	"Cookie",
+	"Cookie2",
+	"Proxy-Authorization",
+	"Www-Authenticate",
+}
+
+// stripSensitiveRedirectHeaders removes credential-bearing headers in place. It
+// reuses the manager's own sensitivity vocabulary so provider-specific key
+// headers (x-api-key, api-key, x-goog-api-key, ...) are covered too.
+func stripSensitiveRedirectHeaders(header http.Header) {
+	if len(header) == 0 {
+		return
+	}
+	for _, name := range redirectSensitiveHeaders {
+		header.Del(name)
+	}
+	for name := range header {
+		if schedulerAttributeSensitive(name) {
+			header.Del(name)
+		}
+	}
+}
+
+// onceAttemptRecorder collects attempt facts from the manager transport and from
+// net/http/httptrace. Both sources are optional: a host supplied RoundTripper may
+// bypass the manager transport, and a non stdlib transport may ignore httptrace.
+type onceAttemptRecorder struct {
+	mu                sync.Mutex
+	dispatched        bool
+	transportObserved bool
+	traceObserved     bool
+	transportRequests uint32
+	traceRequests     uint32
+	wroteHeaders      bool
+	wroteRequest      bool
+	responseStarted   bool
+	statusCode        int
+}
+
+// newOnceAttemptRecorder returns a recorder ready for a single attempt.
+func newOnceAttemptRecorder() *onceAttemptRecorder {
+	return &onceAttemptRecorder{}
+}
+
+// markDispatched records that the attempt was handed to the executor or client.
+func (r *onceAttemptRecorder) markDispatched() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.dispatched = true
+	r.mu.Unlock()
+}
+
+// observeRequest records one request reaching the manager transport and returns
+// the number of requests observed so far.
+func (r *onceAttemptRecorder) observeRequest() uint32 {
+	if r == nil {
+		return 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.transportObserved = true
+	r.transportRequests++
+	return r.transportRequests
+}
+
+// observeResponse records the most recent status seen by the manager transport.
+func (r *onceAttemptRecorder) observeResponse(status int) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.responseStarted = true
+	r.statusCode = status
+	r.mu.Unlock()
+}
+
+// clientTrace returns the httptrace hooks used to derive attempt facts.
+func (r *onceAttemptRecorder) clientTrace() *httptrace.ClientTrace {
+	if r == nil {
+		return nil
+	}
+	return &httptrace.ClientTrace{
+		GetConn: func(string) {
+			r.mu.Lock()
+			r.traceObserved = true
+			r.mu.Unlock()
+		},
+		ConnectStart: func(string, string) {
+			r.mu.Lock()
+			r.traceObserved = true
+			r.mu.Unlock()
+		},
+		WroteHeaders: func() {
+			r.mu.Lock()
+			r.traceObserved = true
+			r.wroteHeaders = true
+			r.traceRequests++
+			r.mu.Unlock()
+		},
+		WroteRequest: func(httptrace.WroteRequestInfo) {
+			r.mu.Lock()
+			r.traceObserved = true
+			r.wroteRequest = true
+			r.mu.Unlock()
+		},
+		GotFirstResponseByte: func() {
+			r.mu.Lock()
+			r.traceObserved = true
+			r.responseStarted = true
+			r.mu.Unlock()
+		},
+	}
+}
+
+// facts collapses the observations into the caller-visible attempt facts.
+//
+// RequestWritten is deliberately biased: an attempt that dispatched but produced
+// no observation at all is reported as written, because a false "not sent" would
+// invite a duplicate paid create while a false "sent" only invites a reconcile.
+func (r *onceAttemptRecorder) facts() HTTPAttemptFacts {
+	if r == nil {
+		return HTTPAttemptFacts{}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	facts := HTTPAttemptFacts{
+		RequestCount:    r.transportRequests,
+		ResponseStarted: r.responseStarted,
+		StatusCode:      r.statusCode,
+	}
+	if !r.transportObserved {
+		facts.RequestCount = r.traceRequests
+	}
+	switch {
+	case r.wroteHeaders || r.wroteRequest || r.responseStarted:
+		facts.RequestWritten = true
+	case r.traceObserved:
+		// httptrace was honored and never reported request bytes on the wire.
+		facts.RequestWritten = false
+	default:
+		facts.RequestWritten = r.dispatched
+	}
+	return facts
+}

--- a/sdk/cliproxy/auth/conductor_execution_once.go
+++ b/sdk/cliproxy/auth/conductor_execution_once.go
@@ -625,6 +625,7 @@ func (m *Manager) refreshAuthForOnce(ctx context.Context, auth *Auth) (*Auth, er
 	now := time.Now()
 	m.mu.RLock()
 	current := m.auths[id]
+	currentSnapshot := current.Clone()
 	needsRefresh := current != nil && m.shouldRefresh(current, now)
 	if !needsRefresh && current != nil && !current.NextRefreshAfter.IsZero() && now.Before(current.NextRefreshAfter) {
 		// NextRefreshAfter also represents an in-flight refresh claim. Ignore it
@@ -642,12 +643,15 @@ func (m *Manager) refreshAuthForOnce(ctx context.Context, auth *Auth) (*Auth, er
 	}
 	m.mu.RUnlock()
 	if !needsRefresh {
+		if currentSnapshot != nil {
+			return currentSnapshot, nil
+		}
 		return auth, nil
 	}
 	if m.executorFor(providerKey) == nil {
 		return auth, nil
 	}
-	observedAccessToken := authAccessToken(current)
+	observedAccessToken := authAccessToken(currentSnapshot)
 	// markRefreshPending coordinates scheduling/backoff, but losing that claim
 	// does not mean the refresh is complete. Enter the per-auth refresh lock in
 	// either case and identify the credential version we observed so a waiter can

--- a/sdk/cliproxy/auth/conductor_execution_once.go
+++ b/sdk/cliproxy/auth/conductor_execution_once.go
@@ -30,13 +30,26 @@ import (
 //     preparation, no result marking and reports no attempt facts.
 //
 // ExecuteWithAuthOnce and DoHTTPOnce keep the lifecycle and drop every replay
-// vector, and they report typed attempt facts so a caller can tell "definitely
-// not sent" from "may have been sent".
+// vector the manager owns, and they report typed attempt facts so a caller can
+// tell "definitely not sent" from "may have been sent".
+//
+// The two differ in how far the guarantee reaches, and the difference is a
+// boundary rather than a gap in effort. DoHTTPOnce performs the request itself,
+// so it can police redirects and cap the attempt outright. ExecuteWithAuthOnce
+// hands the request to a provider executor that constructs and owns its own
+// http.Client, which the manager cannot reach: the shared executor helper
+// consults the auth proxy and the runtime config proxy before it looks at the
+// manager transport, and no executor sets a CheckRedirect. So there the manager
+// guarantees one executor invocation and reports what it observed, and
+// HTTPAttemptFacts.RequestCount - not the absence of an error - is what a caller
+// of a non-idempotent create reconciles against.
 
 // maxSameOriginSafeRedirectHops bounds HTTPRedirectSameOriginSafe redirect following.
 const maxSameOriginSafeRedirectHops = 3
 
 // HTTPRedirectPolicy names the redirect contract applied to a one-shot request.
+// It is only offered by DoHTTPOnce, the path where the manager owns the client
+// and can therefore enforce it; see the file comment for why.
 type HTTPRedirectPolicy string
 
 const (
@@ -55,7 +68,8 @@ func normalizedRedirectPolicy(policy HTTPRedirectPolicy) HTTPRedirectPolicy {
 }
 
 // validateRedirectPolicy reports whether the supplied policy is understood.
-// An empty policy is accepted; each caller documents what it means for that path.
+// An empty policy is accepted and means HTTPRedirectDeny: redirect policy is only
+// offered where the manager owns the http.Client, which is DoHTTPOnce alone.
 func validateRedirectPolicy(policy HTTPRedirectPolicy) error {
 	switch normalizedRedirectPolicy(policy) {
 	case "", HTTPRedirectDeny, HTTPRedirectSameOriginSafe:
@@ -70,16 +84,23 @@ func validateRedirectPolicy(policy HTTPRedirectPolicy) error {
 // not sent" from "may have been sent" without parsing an error string.
 //
 // The facts are derived from the transport the manager installed and from
-// net/http/httptrace. When neither source reports anything - which happens when
-// a host supplied RoundTripper ignores httptrace - RequestWritten is reported as
-// true for any attempt that reached the executor, because an ambiguous "may have
-// been sent" is safe while a false "not sent" causes a double charge.
+// net/http/httptrace, and both sources are optional. RequestWritten is therefore
+// the pessimistic claim - it is true whenever bytes may have reached the wire -
+// while RequestWrittenObserved is the positive one, true only when a write was
+// actually observed. A false RequestWritten is the only statement of "definitely
+// not sent", and it is never made on a path where a provider executor owned the
+// http.Client, because an executor can issue requests the manager cannot see.
 type HTTPAttemptFacts struct {
-	// RequestCount counts upstream requests observed by the manager transport,
-	// including redirect hops. It stays 0 when the attempt never dispatched.
+	// RequestCount counts upstream requests observed on this attempt, including
+	// redirect hops and transport-internal resends, taking the larger of what the
+	// manager transport and httptrace saw. A 0 means "nothing observed", which is
+	// "unknown" rather than "not sent" whenever the client was not manager owned.
 	RequestCount uint32
 	// RequestWritten reports whether any request byte may have reached the wire.
 	RequestWritten bool
+	// RequestWrittenObserved reports that a write was positively observed. It is
+	// the proof-carrying counterpart of RequestWritten.
+	RequestWrittenObserved bool
 	// ResponseStarted reports whether upstream response headers were received.
 	ResponseStarted bool
 	// StatusCode is the observed upstream status, or the status carried by the
@@ -102,20 +123,16 @@ type ExecuteWithAuthOnceRequest struct {
 	Request cliproxyexecutor.Request
 	// Options are the canonical executor options.
 	Options cliproxyexecutor.Options
-	// RedirectPolicy optionally constrains redirects for the executor's HTTP
-	// client. Empty keeps the executor's own behavior, which is what every
-	// existing caller gets today. Enforcement is best effort here because the
-	// executor owns its http.Client; it holds only while the manager-installed
-	// transport is in effect (see onceRoundTripper). DoHTTPOnce owns the client
-	// itself and is therefore the path with the unconditional guarantee.
-	RedirectPolicy HTTPRedirectPolicy
 }
 
 // HTTPOnceRequest describes a single pinned, non-replayed raw HTTP call.
 type HTTPOnceRequest struct {
 	// AuthID identifies a manager-persisted credential.
 	AuthID string
-	// Model is recorded with the execution result. It may be empty.
+	// Model names the model this call is attributed to. Credential availability
+	// in this manager is model scoped, so a call that names no model is recorded
+	// for observability only and never rewrites credential health - a raw poll
+	// must not resurrect a rate-limited credential nor suspend a working one.
 	Model string
 	// Method is the HTTP method. Empty defaults to GET.
 	Method string
@@ -139,6 +156,21 @@ type HTTPOnceRequest struct {
 // credential hop, no post-401 re-execute, and a model pool collapsed to its
 // first entry exactly as the Home execution path does.
 //
+// SCOPE OF THE ONCE GUARANTEE. Once-ness here is per executor invocation, not per
+// upstream HTTP request. A provider executor constructs and owns its own
+// http.Client, so the manager cannot install a CheckRedirect on it and cannot cap
+// the requests it makes: an executor may follow redirects (net/http replays the
+// body on 307 and 308 whenever GetBody is set, which it always is for a bytes
+// body), may fall back across base URLs, and may run its own attempt loop. The
+// manager does not offer a redirect policy on this path, because any policy it
+// could advertise would be silently unenforced whenever a proxy is configured -
+// the shared executor helper consults the auth proxy and the runtime config proxy
+// before it ever looks at the manager transport. HTTPAttemptFacts.RequestCount is
+// therefore the only authority on how many upstream requests were made, and a
+// caller performing a non-idempotent create must treat RequestCount > 1 as a
+// possible double spend and RequestCount == 0 as unknown rather than "not sent".
+// DoHTTPOnce owns its client and is the path with an enforceable guarantee.
+//
 // MarkResult is called at most once. It is not called at all when the failure
 // happened before the credential was exercised: unknown or non-durable auth,
 // unregistered executor, refresh failure, or an interceptor termination.
@@ -151,9 +183,6 @@ func (m *Manager) ExecuteWithAuthOnce(ctx context.Context, in ExecuteWithAuthOnc
 	}
 	if ctx == nil {
 		ctx = context.Background()
-	}
-	if errPolicy := validateRedirectPolicy(in.RedirectPolicy); errPolicy != nil {
-		return cliproxyexecutor.Response{}, facts, errPolicy
 	}
 
 	auth, executor, providerKey, errResolve := m.resolveDurableAuthForOnce(in.AuthID, in.Provider)
@@ -178,8 +207,10 @@ func (m *Manager) ExecuteWithAuthOnce(ctx context.Context, in ExecuteWithAuthOnc
 	opts := ensureRequestedModelMetadata(in.Options, routeModel)
 	publishSelectedAuthMetadata(opts.Metadata, auth)
 
-	recorder := newOnceAttemptRecorder()
-	execCtx := m.onceExecutionContext(ctx, auth, opts, routeModel, in.RedirectPolicy, recorder)
+	// The executor owns its http.Client, so the recorder must never claim that a
+	// request was definitely not written on this path.
+	recorder := newOnceAttemptRecorder(false)
+	execCtx := m.onceExecutionContext(ctx, auth, opts, routeModel, recorder)
 
 	models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel)
 	if len(models) == 0 {
@@ -271,9 +302,19 @@ func (m *Manager) ExecuteWithAuthOnce(ctx context.Context, in ExecuteWithAuthOnc
 // style headers cross-host - net/http only strips Authorization, Cookie and
 // WWW-Authenticate. Both of those are disqualifying for a paid create.
 //
-// The response body is not read or closed; the caller owns it. Exactly one
-// execution result is marked: success is HTTP 2xx alone, so a 3xx is never
-// marked as success. An empty RedirectPolicy means HTTPRedirectDeny.
+// The response body is not read or closed; the caller owns it. A redirect the
+// policy refuses is returned as the unfollowed 3xx response together with a
+// redirect_denied error, so a caller that branches on the error alone cannot read
+// a refused attempt as a success. An empty RedirectPolicy means HTTPRedirectDeny.
+//
+// Exactly one execution result is recorded, and the recording is classified
+// because a raw HTTP call addresses arbitrary endpoints rather than a model
+// serving route. Only statuses that describe the credential - 401, 402, 403, 408,
+// 429, 5xx - and transport failures reach MarkResult and may cool the credential;
+// success is HTTP 2xx alone; every other outcome, including a 3xx and a
+// request-shaped 4xx such as 404, is recorded through the availability-neutral
+// path the count_tokens 404 case already uses, so polling a job URL cannot
+// suspend a healthy credential. A call that names no Model is always neutral.
 //
 // It never returns an *Auth, request headers or any other credential material.
 func (m *Manager) DoHTTPOnce(ctx context.Context, in HTTPOnceRequest) (*http.Response, HTTPAttemptFacts, error) {
@@ -349,7 +390,9 @@ func (m *Manager) httpOnce(ctx context.Context, auth *Auth, req *http.Request, m
 		normalized = HTTPRedirectDeny
 	}
 
-	recorder := newOnceAttemptRecorder()
+	// The manager owns this client end to end, so the recorder may report a
+	// negative: an attempt that never wrote is provably not sent.
+	recorder := newOnceAttemptRecorder(true)
 	tracedCtx := httptrace.WithClientTrace(ctx, recorder.clientTrace())
 	httpReq := req.WithContext(tracedCtx)
 	if httpReq.Body != nil || httpReq.ContentLength != 0 {
@@ -362,9 +405,10 @@ func (m *Manager) httpOnce(ctx context.Context, auth *Auth, req *http.Request, m
 		return nil, facts, errPrepare
 	}
 
+	guard := &onceRedirectGuard{policy: normalized, origin: newRedirectOrigin(httpReq)}
 	client := &http.Client{
-		Transport:     m.transportForOnce(tracedCtx, auth, recorder, ""),
-		CheckRedirect: redirectGuard(normalized, newRedirectOrigin(httpReq)),
+		Transport:     m.clientTransportForOnce(tracedCtx, auth, recorder),
+		CheckRedirect: guard.checkRedirect,
 	}
 
 	recorder.markDispatched()
@@ -374,6 +418,7 @@ func (m *Manager) httpOnce(ctx context.Context, auth *Auth, req *http.Request, m
 		facts.StatusCode = resp.StatusCode
 		facts.ResponseStarted = true
 		facts.RequestWritten = true
+		facts.RequestWrittenObserved = true
 	} else if facts.StatusCode == 0 {
 		facts.StatusCode = statusCodeFromError(errDo)
 	}
@@ -384,6 +429,7 @@ func (m *Manager) httpOnce(ctx context.Context, auth *Auth, req *http.Request, m
 
 	marker := &onceResultMarker{}
 	result := Result{AuthID: auth.ID, Provider: executorKeyFromAuth(auth), Model: model}
+	availabilityRelevant := false
 	switch {
 	case resp == nil:
 		result.Success = false
@@ -391,23 +437,83 @@ func (m *Manager) httpOnce(ctx context.Context, auth *Auth, req *http.Request, m
 		if retryAfter := retryAfterFromError(errDo); retryAfter != nil {
 			result.RetryAfter = retryAfter
 		}
+		availabilityRelevant = true
 	case resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices:
 		result.Success = true
+		availabilityRelevant = true
 	default:
 		result.Success = false
 		result.Error = resultErrorFromError(httpStatusError(resp.StatusCode))
 		if retryAfter := retryAfterFromResponse(resp); retryAfter != nil {
 			result.RetryAfter = retryAfter
 		}
+		availabilityRelevant = httpStatusCoolsCredential(resp.StatusCode)
 	}
-	marker.mark(tracedCtx, m, result)
+	if strings.TrimSpace(model) == "" {
+		// Credential health is model scoped here. With no model, a success would
+		// clear the whole credential's quota state and a failure would suspend the
+		// credential outright, so an unattributed call is only ever observed.
+		availabilityRelevant = false
+	}
+	marker.record(tracedCtx, m, result, availabilityRelevant)
+
+	if errDo == nil && resp != nil {
+		denied, target := guard.denied()
+		if !denied && unfollowedRedirect(resp) {
+			// net/http can refuse a redirect before CheckRedirect runs: with
+			// GetBody cleared it hands a 307 or 308 straight back rather than
+			// replaying the body. Either way a redirect was offered, not followed,
+			// and the caller must not read the 3xx as a completed request.
+			denied = true
+			target = resp.Header.Get("Location")
+		}
+		if denied {
+			return resp, facts, &Error{
+				Code:       "redirect_denied",
+				Message:    "redirect to " + target + " was not followed",
+				HTTPStatus: resp.StatusCode,
+			}
+		}
+	}
 	return resp, facts, errDo
+}
+
+// unfollowedRedirect reports whether a response is a redirect the client handed
+// back instead of following.
+func unfollowedRedirect(resp *http.Response) bool {
+	if resp == nil || strings.TrimSpace(resp.Header.Get("Location")) == "" {
+		return false
+	}
+	switch resp.StatusCode {
+	case http.StatusMovedPermanently, http.StatusFound, http.StatusSeeOther,
+		http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
+		return true
+	default:
+		return false
+	}
 }
 
 // httpStatusError converts an upstream HTTP status into the package error type
 // so MarkResult keeps its status-driven cooldown classification.
 func httpStatusError(status int) error {
 	return &Error{Code: "upstream_http_status", Message: "upstream returned status " + strconv.Itoa(status), HTTPStatus: status}
+}
+
+// httpStatusCoolsCredential reports whether an upstream status says something
+// about the credential rather than about the request that was addressed.
+//
+// A raw one-shot HTTP call targets arbitrary endpoints - a job status URL, an
+// asset URL - so its statuses cannot be read the way a serving response is. Only
+// credential-shaped statuses may change availability; everything else, including
+// a policy-refused 3xx and request-shaped 4xx such as 404, stays neutral. This is
+// the same distinction the count_tokens 404 case draws in conductor_execution.go.
+func httpStatusCoolsCredential(status int) bool {
+	switch status {
+	case http.StatusUnauthorized, http.StatusPaymentRequired, http.StatusForbidden,
+		http.StatusRequestTimeout, http.StatusTooManyRequests:
+		return true
+	}
+	return status >= http.StatusInternalServerError
 }
 
 // retryAfterFromResponse extracts a Retry-After hint from an upstream response.
@@ -529,18 +635,30 @@ func (m *Manager) refreshAuthForOnce(ctx context.Context, auth *Auth) (*Auth, er
 	return refreshed, nil
 }
 
-// onceResultMarker guarantees at most one MarkResult call per one-shot request.
+// onceResultMarker guarantees at most one result recording per one-shot request.
 type onceResultMarker struct {
 	once sync.Once
 }
 
-// mark records the execution result the first time it is called and never again.
+// mark records an availability-relevant execution result exactly once.
 func (r *onceResultMarker) mark(ctx context.Context, m *Manager, result Result) {
+	r.record(ctx, m, result, true)
+}
+
+// record records the execution result the first time it is called and never
+// again. An availability-irrelevant result is reported through the neutral path
+// so hooks, counters and error events still see it while credential cooldown,
+// quota and suspension state stay untouched.
+func (r *onceResultMarker) record(ctx context.Context, m *Manager, result Result, availabilityRelevant bool) {
 	if r == nil || m == nil {
 		return
 	}
 	r.once.Do(func() {
-		m.MarkResult(ctx, result)
+		if availabilityRelevant {
+			m.MarkResult(ctx, result)
+			return
+		}
+		m.recordAvailabilityNeutralResult(ctx, result)
 	})
 }
 
@@ -548,22 +666,41 @@ func (r *onceResultMarker) mark(ctx context.Context, m *Manager, result Result) 
 // mirrors the retrying path (per-auth transport under both round tripper keys,
 // requested-model alias attribution) and adds the httptrace hooks the attempt
 // facts are derived from.
-func (m *Manager) onceExecutionContext(ctx context.Context, auth *Auth, opts cliproxyexecutor.Options, routeModel string, policy HTTPRedirectPolicy, recorder *onceAttemptRecorder) context.Context {
+func (m *Manager) onceExecutionContext(ctx context.Context, auth *Auth, opts cliproxyexecutor.Options, routeModel string, recorder *onceAttemptRecorder) context.Context {
 	execCtx := contextWithRequestedModelAlias(ctx, opts, routeModel)
-	transport := m.transportForOnce(ctx, auth, recorder, policy)
+	transport := m.executorTransportForOnce(ctx, auth, recorder)
 	execCtx = context.WithValue(execCtx, roundTripperContextKey{}, transport)
 	execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", transport)
 	return httptrace.WithClientTrace(execCtx, recorder.clientTrace())
 }
 
-// transportForOnce resolves the transport for a one-shot attempt using the same
-// priority the shared executor helper applies - auth proxy, runtime config
-// proxy, context or per-auth RoundTripper, default transport - and wraps it so
-// the manager can count requests, observe statuses and, when a policy is set,
-// keep a shared http.Client from following a redirect.
-func (m *Manager) transportForOnce(ctx context.Context, auth *Auth, recorder *onceAttemptRecorder, policy HTTPRedirectPolicy) http.RoundTripper {
-	var base http.RoundTripper
+// executorTransportForOnce wraps the transport the retrying execution path would
+// hand to the executor - the context RoundTripper, then the per-auth one, then
+// the default transport - so the manager can count requests and observe statuses.
+//
+// It deliberately does not resolve a proxy URL: the shared executor helper
+// consults the auth and runtime config proxies before the context RoundTripper,
+// so a proxy transport built here would never be used, and building one would
+// also diverge from what the retrying path installs.
+func (m *Manager) executorTransportForOnce(ctx context.Context, auth *Auth, recorder *onceAttemptRecorder) http.RoundTripper {
+	return &onceRoundTripper{base: m.baseTransportForOnce(ctx, auth), recorder: recorder}
+}
 
+// clientTransportForOnce wraps the transport the manager-owned one-shot HTTP
+// client rides. It applies the same priority the shared executor helper does -
+// auth proxy, runtime config proxy, context or per-auth RoundTripper, default
+// transport - because here the manager, not the executor, performs the request.
+func (m *Manager) clientTransportForOnce(ctx context.Context, auth *Auth, recorder *onceAttemptRecorder) http.RoundTripper {
+	base := m.proxyTransportForOnce(auth)
+	if base == nil {
+		base = m.baseTransportForOnce(ctx, auth)
+	}
+	return &onceRoundTripper{base: base, recorder: recorder}
+}
+
+// proxyTransportForOnce returns the transport implied by the auth proxy or the
+// runtime config proxy, or nil when neither is configured or usable.
+func (m *Manager) proxyTransportForOnce(auth *Auth) http.RoundTripper {
 	proxyURL := ""
 	if auth != nil {
 		proxyURL = strings.TrimSpace(auth.ProxyURL)
@@ -573,79 +710,55 @@ func (m *Manager) transportForOnce(ctx context.Context, auth *Auth, recorder *on
 			proxyURL = strings.TrimSpace(cfg.ProxyURL)
 		}
 	}
-	if proxyURL != "" {
-		transport, _, errBuild := proxyutil.BuildHTTPTransport(proxyURL)
-		if errBuild != nil || transport == nil {
-			log.Debugf("one-shot request: proxy transport unavailable for %s: %v", proxyutil.Redact(proxyURL), errBuild)
-		} else {
-			base = transport
-		}
+	if proxyURL == "" {
+		return nil
 	}
-	if base == nil && ctx != nil {
-		if rt, ok := ctx.Value(roundTripperContextKey{}).(http.RoundTripper); ok && rt != nil {
-			base = rt
-		} else if rt, ok := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); ok && rt != nil {
-			base = rt
-		}
+	transport, _, errBuild := proxyutil.BuildHTTPTransport(proxyURL)
+	if errBuild != nil || transport == nil {
+		log.Debugf("one-shot request: proxy transport unavailable for %s: %v", proxyutil.Redact(proxyURL), errBuild)
+		return nil
 	}
-	if base == nil {
-		if rt := m.roundTripperFor(auth); rt != nil {
-			base = rt
-		}
-	}
-	if base == nil {
-		base = http.DefaultTransport
-	}
-	return &onceRoundTripper{base: base, recorder: recorder, policy: normalizedRedirectPolicy(policy)}
+	return transport
 }
 
-// onceRoundTripper records attempt facts and, for executor-owned clients, keeps
-// a redirect from being followed.
+// baseTransportForOnce resolves the non-proxy transport for a one-shot attempt.
+func (m *Manager) baseTransportForOnce(ctx context.Context, auth *Auth) http.RoundTripper {
+	if ctx != nil {
+		if rt, ok := ctx.Value(roundTripperContextKey{}).(http.RoundTripper); ok && rt != nil {
+			return rt
+		}
+		if rt, ok := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); ok && rt != nil {
+			return rt
+		}
+	}
+	if rt := m.roundTripperFor(auth); rt != nil {
+		return rt
+	}
+	return http.DefaultTransport
+}
+
+// onceRoundTripper observes a one-shot attempt and never alters it.
 //
-// A provider executor builds its own http.Client, so the manager cannot install
-// a CheckRedirect on it. What it can do is remove the Location header from a
-// disallowed 3xx: net/http returns a 3xx without Location to its caller instead
-// of following it, so the paid request is never replayed. The policy is only
-// enforced while this transport is in effect; an executor that resolves a proxy
-// from the auth or the runtime config builds its own transport and governs its
-// own redirects, which is why the reliable guarantee lives in DoHTTPOnce.
+// It counts requests and records statuses so HTTPAttemptFacts can be derived even
+// when httptrace is ignored. It deliberately performs no redirect enforcement: a
+// transport sits below http.Client's redirect handling and cannot tell a followed
+// redirect from an executor's own second request, so any enforcement attempted
+// here would either corrupt an upstream response or strip credentials from a
+// legitimate request. Redirect policy lives where the manager owns the client,
+// which is DoHTTPOnce.
 type onceRoundTripper struct {
 	base     http.RoundTripper
 	recorder *onceAttemptRecorder
-	policy   HTTPRedirectPolicy
-	mu       sync.Mutex
-	origin   *redirectOrigin
 }
 
 // RoundTrip implements http.RoundTripper.
 func (rt *onceRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	hop := rt.recorder.observeRequest()
-	origin := rt.rememberOrigin(req)
-
-	if rt.policy != "" && origin != nil && req.URL != nil && req.URL.String() != origin.target() {
-		// A followed redirect reached the transport; strip credentials so they
-		// never travel to a target the caller did not address.
-		stripSensitiveRedirectHeaders(req.Header)
-	}
-
+	rt.recorder.observeRequest()
 	resp, err := rt.base.RoundTrip(req)
 	if resp != nil {
 		rt.recorder.observeResponse(resp.StatusCode)
-		if rt.policy != "" && isRedirectStatus(resp.StatusCode) && !sameOriginSafeRedirectAllowed(rt.policy, origin, resp.Header.Get("Location"), int(hop)) {
-			resp.Header.Del("Location")
-		}
 	}
 	return resp, err
-}
-
-// rememberOrigin records the first request the transport observed.
-func (rt *onceRoundTripper) rememberOrigin(req *http.Request) *redirectOrigin {
-	rt.mu.Lock()
-	defer rt.mu.Unlock()
-	if rt.origin == nil {
-		rt.origin = newRedirectOrigin(req)
-	}
-	return rt.origin
 }
 
 // redirectOrigin snapshots the properties of the original request that decide
@@ -669,30 +782,44 @@ func newRedirectOrigin(req *http.Request) *redirectOrigin {
 	}
 }
 
-// target returns the original absolute URL as a string.
-func (o *redirectOrigin) target() string {
-	if o == nil || o.url == nil {
-		return ""
-	}
-	return o.url.String()
+// onceRedirectGuard is the CheckRedirect implementation for a one-shot HTTP
+// attempt. It records the refusal so the caller receives an explicit error
+// alongside the unfollowed 3xx response instead of a silent success.
+type onceRedirectGuard struct {
+	policy HTTPRedirectPolicy
+	origin *redirectOrigin
+
+	mu           sync.Mutex
+	refused      bool
+	refusedAfter string
 }
 
-// redirectGuard builds the CheckRedirect implementation for a policy. Denied
-// redirects surface the 3xx response to the caller rather than raising an error.
-func redirectGuard(policy HTTPRedirectPolicy, origin *redirectOrigin) func(*http.Request, []*http.Request) error {
-	return func(req *http.Request, via []*http.Request) error {
-		target := ""
-		if req != nil && req.URL != nil {
-			target = req.URL.String()
-		}
-		if !sameOriginSafeRedirectAllowed(policy, origin, target, len(via)) {
-			return http.ErrUseLastResponse
-		}
-		if req != nil {
-			stripSensitiveRedirectHeaders(req.Header)
-		}
-		return nil
+// checkRedirect implements http.Client.CheckRedirect.
+func (g *onceRedirectGuard) checkRedirect(req *http.Request, via []*http.Request) error {
+	target := ""
+	if req != nil && req.URL != nil {
+		target = req.URL.String()
 	}
+	if !sameOriginSafeRedirectAllowed(g.policy, g.origin, target, len(via)) {
+		g.mu.Lock()
+		if !g.refused {
+			g.refused = true
+			g.refusedAfter = target
+		}
+		g.mu.Unlock()
+		return http.ErrUseLastResponse
+	}
+	if req != nil {
+		stripSensitiveRedirectHeaders(req.Header)
+	}
+	return nil
+}
+
+// denied reports whether a redirect was refused and where it pointed.
+func (g *onceRedirectGuard) denied() (bool, string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.refused, g.refusedAfter
 }
 
 // sameOriginSafeRedirectAllowed reports whether a redirect may be followed.
@@ -749,16 +876,6 @@ func normalizedOriginHost(target *url.URL) string {
 	return strings.TrimSuffix(host, ":443")
 }
 
-// isRedirectStatus reports whether a status triggers redirect handling.
-func isRedirectStatus(status int) bool {
-	switch status {
-	case http.StatusMovedPermanently, http.StatusFound, http.StatusSeeOther, http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
-		return true
-	default:
-		return false
-	}
-}
-
 // redirectSensitiveHeaders lists credential-bearing headers that must never
 // travel to a redirect target. net/http only strips the first three of these on
 // its own, and only cross-host, which leaves executor-injected api-key style
@@ -791,10 +908,15 @@ func stripSensitiveRedirectHeaders(header http.Header) {
 // onceAttemptRecorder collects attempt facts from the manager transport and from
 // net/http/httptrace. Both sources are optional: a host supplied RoundTripper may
 // bypass the manager transport, and a non stdlib transport may ignore httptrace.
+//
+// clientOwned records whether the manager owned the http.Client for the whole
+// attempt. Only then may the recorder state that a request was not written: when
+// a provider executor owns the client it can issue requests on a detached context
+// and an unwrapped transport, so silence proves nothing.
 type onceAttemptRecorder struct {
 	mu                sync.Mutex
+	clientOwned       bool
 	dispatched        bool
-	transportObserved bool
 	traceObserved     bool
 	transportRequests uint32
 	traceRequests     uint32
@@ -805,8 +927,8 @@ type onceAttemptRecorder struct {
 }
 
 // newOnceAttemptRecorder returns a recorder ready for a single attempt.
-func newOnceAttemptRecorder() *onceAttemptRecorder {
-	return &onceAttemptRecorder{}
+func newOnceAttemptRecorder(clientOwned bool) *onceAttemptRecorder {
+	return &onceAttemptRecorder{clientOwned: clientOwned}
 }
 
 // markDispatched records that the attempt was handed to the executor or client.
@@ -827,7 +949,6 @@ func (r *onceAttemptRecorder) observeRequest() uint32 {
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.transportObserved = true
 	r.transportRequests++
 	return r.transportRequests
 }
@@ -883,9 +1004,17 @@ func (r *onceAttemptRecorder) clientTrace() *httptrace.ClientTrace {
 
 // facts collapses the observations into the caller-visible attempt facts.
 //
+// RequestCount takes the larger of the two counts rather than preferring one:
+// http.Transport and the bundled HTTP/2 transport resend a request internally,
+// below any wrapping RoundTripper, and httptrace's WroteHeaders fires once per
+// wire attempt inside them. Under-reporting the number of upstream sends is the
+// dangerous direction for a caller reconciling a non-idempotent create.
+//
 // RequestWritten is deliberately biased: an attempt that dispatched but produced
-// no observation at all is reported as written, because a false "not sent" would
-// invite a duplicate paid create while a false "sent" only invites a reconcile.
+// no conclusive observation is reported as written, because a false "not sent"
+// would invite a duplicate paid create while a false "sent" only invites a
+// reconcile. The negative is stated only when the manager owned the client and
+// httptrace reported connection progress without a write.
 func (r *onceAttemptRecorder) facts() HTTPAttemptFacts {
 	if r == nil {
 		return HTTPAttemptFacts{}
@@ -898,14 +1027,16 @@ func (r *onceAttemptRecorder) facts() HTTPAttemptFacts {
 		ResponseStarted: r.responseStarted,
 		StatusCode:      r.statusCode,
 	}
-	if !r.transportObserved {
+	if r.traceRequests > facts.RequestCount {
 		facts.RequestCount = r.traceRequests
 	}
+	facts.RequestWrittenObserved = r.wroteHeaders || r.wroteRequest || r.responseStarted
 	switch {
-	case r.wroteHeaders || r.wroteRequest || r.responseStarted:
+	case facts.RequestWrittenObserved:
 		facts.RequestWritten = true
-	case r.traceObserved:
-		// httptrace was honored and never reported request bytes on the wire.
+	case r.clientOwned && r.traceObserved:
+		// The manager owned the whole attempt and httptrace, which it honored,
+		// never reported request bytes on the wire.
 		facts.RequestWritten = false
 	default:
 		facts.RequestWritten = r.dispatched

--- a/sdk/cliproxy/auth/conductor_execution_once.go
+++ b/sdk/cliproxy/auth/conductor_execution_once.go
@@ -606,11 +606,15 @@ func (m *Manager) resolveDurableAuthForOnce(authID, providerOverride string) (*A
 // it with refreshAuthForRequest, so it shares the per-auth refresh lock and the
 // backoff bookkeeping with the auto-refresh loop instead of duplicating them.
 //
-// The refresh is skipped, without error, when the credential does not need one
-// or when another goroutine already owns it. It is also skipped when no executor
-// is registered under the raw provider string, because that is the only key the
-// manager refresh path resolves; failing there would reject openai-compatibility
-// credentials that never had a refreshable executor to begin with.
+// The refresh is skipped, without error, when the credential does not need one.
+// Concurrent callers all enter refreshAuthForRequest with the access token they
+// observed before claiming the refresh. Its per-auth lock makes the first caller
+// the refresh owner; waiters then reload and reuse the replacement credential
+// instead of dispatching with the stale clone. It is also skipped when no
+// executor is registered under the raw provider string, because that is the only
+// key the manager refresh path resolves; failing there would reject
+// openai-compatibility credentials that never had a refreshable executor to begin
+// with.
 func (m *Manager) refreshAuthForOnce(ctx context.Context, auth *Auth) (*Auth, error) {
 	if m == nil || auth == nil {
 		return auth, nil
@@ -623,6 +627,16 @@ func (m *Manager) refreshAuthForOnce(ctx context.Context, auth *Auth) (*Auth, er
 	m.mu.RLock()
 	current := m.auths[id]
 	needsRefresh := current != nil && m.shouldRefresh(current, now)
+	if !needsRefresh && current != nil && !current.NextRefreshAfter.IsZero() && now.Before(current.NextRefreshAfter) {
+		// NextRefreshAfter also represents an in-flight refresh claim. Ignore it
+		// for this due check so a concurrent paid call joins the per-auth refresh
+		// lock instead of treating the stale credential as fresh. This also makes
+		// a paid one-shot fail closed during refresh backoff rather than spending a
+		// credential the evaluator still considers due.
+		withoutBackoff := current.Clone()
+		withoutBackoff.NextRefreshAfter = time.Time{}
+		needsRefresh = m.shouldRefresh(withoutBackoff, now)
+	}
 	provider := ""
 	if current != nil {
 		provider = strings.TrimSpace(current.Provider)
@@ -634,10 +648,13 @@ func (m *Manager) refreshAuthForOnce(ctx context.Context, auth *Auth) (*Auth, er
 	if m.executorFor(provider) == nil {
 		return auth, nil
 	}
-	if !m.markRefreshPending(id, now) {
-		return auth, nil
-	}
-	refreshed, errRefresh := m.refreshAuthForRequest(ctx, id, "")
+	observedAccessToken := authAccessToken(current)
+	// markRefreshPending coordinates scheduling/backoff, but losing that claim
+	// does not mean the refresh is complete. Enter the per-auth refresh lock in
+	// either case and identify the credential version we observed so a waiter can
+	// reuse the owner's replacement without refreshing twice.
+	_ = m.markRefreshPending(id, now)
+	refreshed, errRefresh := m.refreshAuthForRequest(ctx, id, observedAccessToken)
 	if errRefresh != nil {
 		return nil, errRefresh
 	}
@@ -790,7 +807,7 @@ func newRedirectOrigin(req *http.Request) *redirectOrigin {
 	return &redirectOrigin{
 		method:  strings.ToUpper(strings.TrimSpace(req.Method)),
 		url:     req.URL,
-		hasBody: req.Body != nil || req.ContentLength > 0,
+		hasBody: (req.Body != nil && req.Body != http.NoBody) || req.ContentLength > 0,
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_execution_once.go
+++ b/sdk/cliproxy/auth/conductor_execution_once.go
@@ -611,10 +611,9 @@ func (m *Manager) resolveDurableAuthForOnce(authID, providerOverride string) (*A
 // observed before claiming the refresh. Its per-auth lock makes the first caller
 // the refresh owner; waiters then reload and reuse the replacement credential
 // instead of dispatching with the stale clone. It is also skipped when no
-// executor is registered under the raw provider string, because that is the only
-// key the manager refresh path resolves; failing there would reject
-// openai-compatibility credentials that never had a refreshable executor to begin
-// with.
+// executor is registered under the auth's effective executor key. This matches
+// refreshAuthForRequest, including OpenAI-compatible credentials whose raw
+// Provider differs from compat_name/provider_key.
 func (m *Manager) refreshAuthForOnce(ctx context.Context, auth *Auth) (*Auth, error) {
 	if m == nil || auth == nil {
 		return auth, nil
@@ -637,15 +636,15 @@ func (m *Manager) refreshAuthForOnce(ctx context.Context, auth *Auth) (*Auth, er
 		withoutBackoff.NextRefreshAfter = time.Time{}
 		needsRefresh = m.shouldRefresh(withoutBackoff, now)
 	}
-	provider := ""
+	providerKey := ""
 	if current != nil {
-		provider = strings.TrimSpace(current.Provider)
+		providerKey = executorKeyFromAuth(current)
 	}
 	m.mu.RUnlock()
 	if !needsRefresh {
 		return auth, nil
 	}
-	if m.executorFor(provider) == nil {
+	if m.executorFor(providerKey) == nil {
 		return auth, nil
 	}
 	observedAccessToken := authAccessToken(current)

--- a/sdk/cliproxy/auth/conductor_execution_once.go
+++ b/sdk/cliproxy/auth/conductor_execution_once.go
@@ -344,7 +344,7 @@ func (m *Manager) DoHTTPOnce(ctx context.Context, in HTTPOnceRequest) (*http.Res
 		return nil, facts, &Error{Code: "invalid_request", Message: "http request url is empty", HTTPStatus: http.StatusBadRequest}
 	}
 
-	auth, executor, _, errResolve := m.resolveDurableAuthForOnce(in.AuthID, "")
+	auth, executor, providerKey, errResolve := m.resolveDurableAuthForOnce(in.AuthID, "")
 	if errResolve != nil {
 		return nil, facts, errResolve
 	}
@@ -357,6 +357,17 @@ func (m *Manager) DoHTTPOnce(ctx context.Context, in HTTPOnceRequest) (*http.Res
 
 	prepared, errPrepare := m.prepareRequestAuth(ctx, executor, auth)
 	if errPrepare != nil {
+		if errCancel := claudeOAuthRequestCancellation(ctx, auth, errPrepare); errCancel != nil {
+			return nil, facts, errCancel
+		}
+		marker := &onceResultMarker{}
+		marker.record(ctx, m, Result{
+			AuthID:   auth.ID,
+			Provider: providerKey,
+			Model:    strings.TrimSpace(in.Model),
+			Success:  false,
+			Error:    resultErrorFromError(errPrepare),
+		}, strings.TrimSpace(in.Model) != "")
 		return nil, facts, errPrepare
 	}
 	auth = prepared
@@ -442,6 +453,7 @@ func (m *Manager) httpOnce(ctx context.Context, auth *Auth, req *http.Request, m
 	marker := &onceResultMarker{}
 	result := Result{AuthID: auth.ID, Provider: executorKeyFromAuth(auth), Model: model}
 	availabilityRelevant := false
+	redirectFollowed := guard.followedRedirect()
 	switch {
 	case resp == nil:
 		result.Success = false
@@ -465,6 +477,14 @@ func (m *Manager) httpOnce(ctx context.Context, auth *Auth, req *http.Request, m
 		// Credential health is model scoped here. With no model, a success would
 		// clear the whole credential's quota state and a failure would suspend the
 		// credential outright, so an unattributed call is only ever observed.
+		availabilityRelevant = false
+	}
+	if redirectFollowed {
+		// Every allowed redirect hop has its credential headers stripped. The
+		// terminal response therefore says nothing reliable about the selected
+		// credential: a 401/403 can be caused solely by the stripped hop, while a
+		// success can come from a signed or otherwise public target. Keep all such
+		// results observable but availability-neutral.
 		availabilityRelevant = false
 	}
 	marker.record(tracedCtx, m, result, availabilityRelevant)
@@ -824,6 +844,7 @@ type onceRedirectGuard struct {
 	mu           sync.Mutex
 	refused      bool
 	refusedAfter string
+	followed     bool
 }
 
 // checkRedirect implements http.Client.CheckRedirect.
@@ -841,10 +862,21 @@ func (g *onceRedirectGuard) checkRedirect(req *http.Request, via []*http.Request
 		g.mu.Unlock()
 		return http.ErrUseLastResponse
 	}
+	g.mu.Lock()
+	g.followed = true
+	g.mu.Unlock()
 	if req != nil {
 		stripSensitiveRedirectHeaders(req.Header)
 	}
 	return nil
+}
+
+// followed reports whether at least one redirect was allowed after stripping
+// credential headers from the next hop.
+func (g *onceRedirectGuard) followedRedirect() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.followed
 }
 
 // denied reports whether a redirect was refused and where it pointed.

--- a/sdk/cliproxy/auth/conductor_execution_once_hazard_test.go
+++ b/sdk/cliproxy/auth/conductor_execution_once_hazard_test.go
@@ -1,0 +1,427 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// This file pins the hazards found while auditing the single-attempt guarantee of
+// ExecuteWithAuthOnce and DoHTTPOnce. Each test states the contract that closed
+// one of them, so a later change that re-opens the hazard fails here.
+//
+// The through line is a boundary: a provider executor constructs and owns its own
+// http.Client, so the manager can observe that path but cannot police it. Every
+// guarantee that needs control of the client - redirect policy, credential
+// stripping, a hard cap on upstream sends - therefore lives in DoHTTPOnce, and on
+// the executor path the manager reports facts instead of pretending to enforce.
+
+// hazardExecutorClient mirrors helps.NewProxyAwareHTTPClient: a plain http.Client
+// whose Transport is the context RoundTripper and which sets no CheckRedirect.
+// internal/runtime/executor/helps/proxy_helpers.go:28-62 builds exactly this.
+func hazardExecutorClient(ctx context.Context) *http.Client {
+	rt, _ := ctx.Value("cliproxy.roundtripper").(http.RoundTripper)
+	return &http.Client{Transport: rt}
+}
+
+// An executor-owned client follows redirects and net/http replays the body on a
+// 307, so one ExecuteWithAuthOnce can produce two upstream creates. The manager
+// cannot prevent that - it does not own the client - so it must not hide it:
+// RequestCount reports every send, which is the fact a caller of a paid create
+// reconciles against.
+func TestExecuteWithAuthOnce_ExecutorRedirectReplayIsCounted(t *testing.T) {
+	var upstreamCreates atomic.Int32
+	var redirects atomic.Int32
+	mux := http.NewServeMux()
+	var server *httptest.Server
+	mux.HandleFunc("/create", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if len(body) > 0 {
+			upstreamCreates.Add(1)
+		}
+		if redirects.Add(1) == 1 {
+			http.Redirect(w, r, server.URL+"/create", http.StatusTemporaryRedirect)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	server = httptest.NewServer(mux)
+	defer server.Close()
+
+	executor := &onceTestExecutor{provider: "codex"}
+	executor.executeFunc = func(ctx context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+		httpReq, _ := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/create", bytes.NewReader([]byte(`{"paid":true}`)))
+		resp, errDo := hazardExecutorClient(ctx).Do(httpReq)
+		if errDo != nil {
+			return cliproxyexecutor.Response{}, errDo
+		}
+		defer func() { _ = resp.Body.Close() }()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+	}
+	manager, _ := newOnceTestManager(t, executor, newOnceTestAuth("replay-auth"))
+
+	_, facts, err := manager.ExecuteWithAuthOnce(context.Background(), onceRequest("replay-auth"))
+	if err != nil {
+		t.Fatalf("ExecuteWithAuthOnce() error = %v", err)
+	}
+	if got := upstreamCreates.Load(); got != 2 {
+		t.Fatalf("upstream paid creates = %d, want 2 for an executor that follows a 307", got)
+	}
+	if int(facts.RequestCount) != int(upstreamCreates.Load()) {
+		t.Fatalf("facts.RequestCount = %d, want %d: attempt facts must not under-report upstream sends", facts.RequestCount, upstreamCreates.Load())
+	}
+	if got := executor.executeCalls.Load(); got != 1 {
+		t.Fatalf("executor invocations = %d, want 1", got)
+	}
+}
+
+// The manager transport observes; it never mutates. An earlier design deleted the
+// Location header off a 3xx to keep a shared client from following it, which
+// corrupted an upstream response the caller may legitimately need to read.
+func TestExecuteWithAuthOnce_ObservingTransportPreservesUpstreamResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "https://elsewhere.example.com/next")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer server.Close()
+
+	var seenLocation atomic.Value
+	seenLocation.Store("")
+	executor := &onceTestExecutor{provider: "codex"}
+	executor.executeFunc = func(ctx context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+		httpReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+		client := hazardExecutorClient(ctx)
+		client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+		resp, errDo := client.Do(httpReq)
+		if errDo != nil {
+			return cliproxyexecutor.Response{}, errDo
+		}
+		defer func() { _ = resp.Body.Close() }()
+		seenLocation.Store(resp.Header.Get("Location"))
+		return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+	}
+	manager, _ := newOnceTestManager(t, executor, newOnceTestAuth("location-auth"))
+
+	if _, _, err := manager.ExecuteWithAuthOnce(context.Background(), onceRequest("location-auth")); err != nil {
+		t.Fatalf("ExecuteWithAuthOnce() error = %v", err)
+	}
+	if got, _ := seenLocation.Load().(string); got != "https://elsewhere.example.com/next" {
+		t.Fatalf("Location header seen by the executor = %q, want it untouched", got)
+	}
+}
+
+// A transport cannot tell a followed redirect from an executor's own second
+// request - antigravity's base-URL fallback, a pre-flight, a multipart upload -
+// so it must never strip credentials. An earlier design inferred "redirect" from
+// a URL differing from the first one observed and sent real requests unauthorized.
+func TestExecuteWithAuthOnce_ObservingTransportKeepsCredentialsOnEveryRequest(t *testing.T) {
+	var authorized [2]atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/first":
+			authorized[0].Store(r.Header.Get("Authorization") != "")
+		case "/second":
+			authorized[1].Store(r.Header.Get("Authorization") != "")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	executor := &onceTestExecutor{provider: "codex"}
+	executor.executeFunc = func(ctx context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+		client := hazardExecutorClient(ctx)
+		for _, path := range []string{"/first", "/second"} {
+			httpReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+path, nil)
+			httpReq.Header.Set("Authorization", "Bearer secret-token")
+			resp, errDo := client.Do(httpReq)
+			if errDo != nil {
+				return cliproxyexecutor.Response{}, errDo
+			}
+			_ = resp.Body.Close()
+		}
+		return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+	}
+	manager, _ := newOnceTestManager(t, executor, newOnceTestAuth("strip-auth"))
+
+	if _, _, err := manager.ExecuteWithAuthOnce(context.Background(), onceRequest("strip-auth")); err != nil {
+		t.Fatalf("ExecuteWithAuthOnce() error = %v", err)
+	}
+	if !authorized[0].Load() || !authorized[1].Load() {
+		t.Fatalf("authorized requests = %v/%v, want both; the observing transport must not strip credentials", authorized[0].Load(), authorized[1].Load())
+	}
+}
+
+// A negative claim needs positive proof. httptrace firing at all is not proof
+// that the recorder saw the whole attempt: GetConn and ConnectStart fire for any
+// traced request, including a pre-flight that never wrote a byte, while the paid
+// request may have gone out on a client the manager cannot observe.
+func TestOnceAttemptRecorder_ExecutorPathNeverClaimsNotWritten(t *testing.T) {
+	recorder := newOnceAttemptRecorder(false)
+	trace := recorder.clientTrace()
+
+	// A pre-flight or token call that never got past connection setup.
+	trace.GetConn("api.example.com:443")
+	trace.ConnectStart("tcp", "203.0.113.10:443")
+
+	// The paid request then went out on a client the manager cannot observe.
+	recorder.markDispatched()
+
+	facts := recorder.facts()
+	if !facts.RequestWritten {
+		t.Fatalf("facts.RequestWritten = false, want true: an executor-owned attempt must fail safe toward \"may have been sent\"")
+	}
+	if facts.RequestWrittenObserved {
+		t.Fatalf("facts.RequestWrittenObserved = true, want false: nothing was actually observed")
+	}
+}
+
+// A manager-owned attempt may state the negative, because the manager saw the
+// whole attempt through a transport and a trace it installed itself.
+func TestOnceAttemptRecorder_OwnedClientReportsNotWritten(t *testing.T) {
+	recorder := newOnceAttemptRecorder(true)
+	trace := recorder.clientTrace()
+	recorder.markDispatched()
+	trace.GetConn("api.example.com:443")
+	trace.ConnectStart("tcp", "203.0.113.10:443")
+
+	if facts := recorder.facts(); facts.RequestWritten {
+		t.Fatalf("facts.RequestWritten = true, want false for a manager-owned attempt that never wrote")
+	}
+}
+
+// hazardRetryingTransport models what http.Transport and the bundled http2
+// Transport do below any wrapping RoundTripper: they resend a request
+// internally. See net/http/transport.go shouldRetryRequest and
+// h2_bundle.go http2shouldRetryRequest / http2canRetryError (a peer PROTOCOL_ERROR
+// is retried whenever GetBody is set, which http.NewRequest always sets for a
+// bytes body).
+type hazardRetryingTransport struct {
+	base http.RoundTripper
+}
+
+func (t *hazardRetryingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// First send is written and lost; the transport silently replays it.
+	if req.GetBody != nil {
+		body, _ := req.GetBody()
+		retry := req.Clone(req.Context())
+		retry.Body = body
+		if resp, err := t.base.RoundTrip(retry); err == nil {
+			_ = resp.Body.Close()
+		}
+	}
+	return t.base.RoundTrip(req)
+}
+
+// A retry performed inside the base transport is invisible to the wrapping
+// RoundTripper, so RequestCount must also read httptrace, which fires per wire
+// attempt from inside the transport. DoHTTPOnce clears GetBody to stop the replay
+// outright; ExecuteWithAuthOnce cannot, because the executor builds the request.
+func TestExecuteWithAuthOnce_TransportInternalRetryIsCounted(t *testing.T) {
+	var sends atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		sends.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	executor := &onceTestExecutor{provider: "codex"}
+	executor.executeFunc = func(ctx context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+		// A provider executor builds its own request; GetBody is set for it.
+		httpReq, _ := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/create", bytes.NewReader([]byte(`{"paid":true}`)))
+		resp, errDo := hazardExecutorClient(ctx).Do(httpReq)
+		if errDo != nil {
+			return cliproxyexecutor.Response{}, errDo
+		}
+		defer func() { _ = resp.Body.Close() }()
+		return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+	}
+	manager, _ := newOnceTestManager(t, executor, newOnceTestAuth("count-auth"))
+
+	base := &hazardRetryingTransport{base: http.DefaultTransport}
+	ctx := context.WithValue(context.Background(), roundTripperContextKey{}, http.RoundTripper(base))
+	ctx = context.WithValue(ctx, "cliproxy.roundtripper", http.RoundTripper(base))
+
+	_, facts, err := manager.ExecuteWithAuthOnce(ctx, onceRequest("count-auth"))
+	if err != nil {
+		t.Fatalf("ExecuteWithAuthOnce() error = %v", err)
+	}
+	if int(facts.RequestCount) != int(sends.Load()) {
+		t.Fatalf("facts.RequestCount = %d but upstream saw %d requests; attempt facts must not under-report", facts.RequestCount, sends.Load())
+	}
+}
+
+// A denied redirect must not read as a success to a caller that branches on the
+// error alone: it is returned as the unfollowed 3xx plus an explicit error.
+func TestHTTPOnce_DeniedRedirectIsAnError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://elsewhere.example.com/create", http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+
+	executor := &onceTestExecutor{provider: "codex"}
+	manager, _ := newOnceTestManager(t, executor, newOnceTestAuth("deny-auth"))
+	auth := onceAuthByID(t, manager, "deny-auth")
+
+	ctx := context.Background()
+	req := onceHTTPRequest(t, ctx, http.MethodPost, server.URL+"/create", bytes.NewReader([]byte(`{"paid":true}`)))
+	resp, _, err := httpOnceWithAuth(manager, ctx, auth, req, HTTPRedirectDeny)
+	if resp != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+	if err == nil {
+		t.Fatalf("httpOnce() error = nil for a policy-denied redirect; a refused attempt must not look like a success")
+	}
+	var authErr *Error
+	if !errors.As(err, &authErr) || authErr.Code != "redirect_denied" {
+		t.Fatalf("httpOnce() error = %v, want *Error{Code: \"redirect_denied\"}", err)
+	}
+	if resp == nil || resp.StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("httpOnce() response = %v, want the unfollowed 3xx", resp)
+	}
+}
+
+// "The executor is invoked exactly once" is not "one upstream request": registered
+// executors run their own attempt loops (antigravity loops attempts x base URLs
+// around httpClient.Do). The manager cannot cap that, so RequestCount must expose
+// it and the doc comment must scope the guarantee to the executor invocation.
+func TestExecuteWithAuthOnce_ExecutorInternalRetryIsCounted(t *testing.T) {
+	var upstreamCreates atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		upstreamCreates.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	executor := &onceTestExecutor{provider: "codex"}
+	executor.executeFunc = func(ctx context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+		client := hazardExecutorClient(ctx)
+		// The antigravity executor's own attempt loop, reproduced faithfully.
+		for attempt := 0; attempt < 3; attempt++ {
+			httpReq, _ := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/create", bytes.NewReader([]byte(`{"paid":true}`)))
+			resp, errDo := client.Do(httpReq)
+			if errDo != nil {
+				return cliproxyexecutor.Response{}, errDo
+			}
+			_ = resp.Body.Close()
+		}
+		return cliproxyexecutor.Response{}, &onceStatusError{status: http.StatusTooManyRequests, message: "rate limited"}
+	}
+	manager, _ := newOnceTestManager(t, executor, newOnceTestAuth("inner-retry-auth"))
+
+	_, facts, _ := manager.ExecuteWithAuthOnce(context.Background(), onceRequest("inner-retry-auth"))
+	if got := upstreamCreates.Load(); got != 3 {
+		t.Fatalf("upstream paid creates = %d, want the executor's own 3", got)
+	}
+	if int(facts.RequestCount) != int(upstreamCreates.Load()) {
+		t.Fatalf("facts.RequestCount = %d, want %d; a caller of a paid create must be able to see the extra sends", facts.RequestCount, upstreamCreates.Load())
+	}
+	if got := executor.executeCalls.Load(); got != 1 {
+		t.Fatalf("executor invocations = %d, want 1", got)
+	}
+}
+
+// A raw one-shot HTTP call addresses arbitrary endpoints, so a request-shaped
+// status says nothing about the credential. A polled job URL that 404s must not
+// suspend the model for twelve hours.
+func TestDoHTTPOnce_RequestShapedStatusDoesNotCoolCredential(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		wantCool bool
+	}{
+		{name: "not found", status: http.StatusNotFound},
+		{name: "bad request", status: http.StatusBadRequest},
+		{name: "conflict", status: http.StatusConflict},
+		{name: "unprocessable", status: http.StatusUnprocessableEntity},
+		{name: "unauthorized", status: http.StatusUnauthorized, wantCool: true},
+		{name: "forbidden", status: http.StatusForbidden, wantCool: true},
+		{name: "rate limited", status: http.StatusTooManyRequests, wantCool: true},
+		{name: "server error", status: http.StatusInternalServerError, wantCool: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+			}))
+			defer server.Close()
+
+			manager, hook := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, newOnceTestAuth("cool-auth"))
+			resp, _, err := manager.DoHTTPOnce(context.Background(), HTTPOnceRequest{
+				AuthID: "cool-auth",
+				Model:  "test-model",
+				Method: http.MethodGet,
+				URL:    server.URL,
+			})
+			if err != nil {
+				t.Fatalf("DoHTTPOnce() error = %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if got := len(hook.snapshot()); got != 1 {
+				t.Fatalf("recorded results = %d, want 1", got)
+			}
+			stored := onceAuthByID(t, manager, "cool-auth")
+			state := stored.ModelStates["test-model"]
+			cooled := state != nil && state.Unavailable
+			if cooled != tt.wantCool {
+				t.Fatalf("model cooled = %v, want %v for status %d", cooled, tt.wantCool, tt.status)
+			}
+		})
+	}
+}
+
+// Credential health is model scoped. A raw call that names no model must not
+// rewrite it: a successful status poll once cleared the whole credential's quota
+// state and resurrected a rate-limited credential into the serving pool.
+func TestDoHTTPOnce_UnmodeledCallNeverRewritesCredentialHealth(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{name: "success", status: http.StatusOK},
+		{name: "unauthorized", status: http.StatusUnauthorized},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+			}))
+			defer server.Close()
+
+			auth := newOnceTestAuth("unmodeled-auth")
+			auth.Unavailable = true
+			auth.Quota = QuotaState{Exceeded: true, Reason: "quota"}
+			manager, hook := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, auth)
+
+			resp, _, err := manager.DoHTTPOnce(context.Background(), HTTPOnceRequest{
+				AuthID: "unmodeled-auth",
+				Method: http.MethodGet,
+				URL:    server.URL,
+			})
+			if err != nil {
+				t.Fatalf("DoHTTPOnce() error = %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if got := len(hook.snapshot()); got != 1 {
+				t.Fatalf("recorded results = %d, want 1: the call must stay observable", got)
+			}
+			stored := onceAuthByID(t, manager, "unmodeled-auth")
+			if !stored.Quota.Exceeded || !stored.Unavailable {
+				t.Fatalf("credential health = {unavailable:%v quota:%+v}, want it untouched", stored.Unavailable, stored.Quota)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/auth/conductor_execution_once_test.go
+++ b/sdk/cliproxy/auth/conductor_execution_once_test.go
@@ -1392,3 +1392,90 @@ func TestOnceAttemptRecorderFacts(t *testing.T) {
 		})
 	}
 }
+
+// oncePrepareAuthExecutor fails the request-scoped credential preparation seam
+// before any HTTP request can be constructed or dispatched.
+type oncePrepareAuthExecutor struct {
+	*onceTestExecutor
+	prepareAuthErr error
+}
+
+func (e *oncePrepareAuthExecutor) ShouldPrepareRequestAuth(*Auth) bool { return true }
+
+func (e *oncePrepareAuthExecutor) PrepareRequestAuth(context.Context, *Auth) (*Auth, error) {
+	return nil, e.prepareAuthErr
+}
+
+func TestManagerDoHTTPOnce_RequestAuthPreparationFailureIsRecordedWithoutDispatch(t *testing.T) {
+	executor := &oncePrepareAuthExecutor{
+		onceTestExecutor: &onceTestExecutor{provider: "codex"},
+		prepareAuthErr:   &onceStatusError{status: http.StatusUnauthorized, message: "credential acquisition failed"},
+	}
+	hook := &onceResultHook{}
+	manager := NewManager(nil, &RoundRobinSelector{}, hook)
+	manager.RegisterExecutor(executor)
+	if _, err := manager.Register(context.Background(), newOnceTestAuth("prepare-auth-failure")); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	resp, facts, errDo := manager.DoHTTPOnce(context.Background(), HTTPOnceRequest{
+		AuthID: "prepare-auth-failure",
+		Model:  "test-model",
+		URL:    "https://example.invalid/never-dispatched",
+	})
+	if resp != nil {
+		t.Fatalf("response = %#v, want nil", resp)
+	}
+	if code := onceErrorCode(errDo); code != "credential acquisition failed" {
+		t.Fatalf("DoHTTPOnce() error = %v, want preparation failure", errDo)
+	}
+	if facts.RequestCount != 0 || facts.RequestWritten || facts.RequestWrittenObserved || facts.ResponseStarted {
+		t.Fatalf("facts = %+v, want undispatched attempt", facts)
+	}
+	if got := executor.prepareCalls.Load(); got != 0 {
+		t.Fatalf("HTTP credential injections = %d, want 0", got)
+	}
+	results := hook.snapshot()
+	if len(results) != 1 {
+		t.Fatalf("recorded results = %d, want 1", len(results))
+	}
+	if results[0].Success || results[0].AuthID != "prepare-auth-failure" || results[0].Provider != "codex" || results[0].Model != "test-model" {
+		t.Fatalf("recorded result = %+v, want the pinned credential preparation failure", results[0])
+	}
+}
+
+func TestManagerHTTPOnceCore_FollowedUnauthenticatedRedirectIsAvailabilityNeutral(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/start", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "/protected")
+		w.WriteHeader(http.StatusFound)
+	})
+	mux.HandleFunc("/protected", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization") + "|" + r.Header.Get("X-Api-Key"); got != "|" {
+			t.Errorf("credential headers on followed hop = %q, want stripped", got)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	manager, hook := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, newOnceTestAuth("redirect-neutral"))
+	auth := onceAuthByID(t, manager, "redirect-neutral")
+	ctx := newOnceTLSContext(server)
+	resp, facts, errDo := httpOnceWithAuth(manager, ctx, auth, onceHTTPRequest(t, ctx, http.MethodGet, server.URL+"/start", nil), HTTPRedirectSameOriginSafe)
+	if errDo != nil {
+		t.Fatalf("httpOnceWithAuth() error = %v", errDo)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized || facts.RequestCount != 2 {
+		t.Fatalf("response status/facts = %d/%+v, want 401 after two requests", resp.StatusCode, facts)
+	}
+	results := hook.snapshot()
+	if len(results) != 1 || results[0].Success {
+		t.Fatalf("recorded results = %+v, want one observable failure", results)
+	}
+	stored := onceAuthByID(t, manager, "redirect-neutral")
+	if state := stored.ModelStates["test-model"]; state != nil && state.Unavailable {
+		t.Fatalf("model state = %+v, want stripped redirect-hop failure to remain availability-neutral", state)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_execution_once_test.go
+++ b/sdk/cliproxy/auth/conductor_execution_once_test.go
@@ -394,6 +394,32 @@ func TestManagerExecuteWithAuthOnce_RefreshFailureFailsClosed(t *testing.T) {
 	}
 }
 
+func TestManagerRefreshAuthForOnce_ReloadsCurrentAuthWhenNoLongerDue(t *testing.T) {
+	executor := &onceTestExecutor{provider: "codex"}
+	auth := newOnceTestAuth("refresh-reload")
+	auth.Metadata = map[string]any{"access_token": "stale-token"}
+	manager, _ := newOnceTestManager(t, executor, auth)
+
+	stale := onceAuthByID(t, manager, auth.ID)
+	manager.mu.Lock()
+	current := manager.auths[auth.ID].Clone()
+	current.Metadata["access_token"] = "fresh-token"
+	current.LastRefreshedAt = time.Now()
+	manager.auths[auth.ID] = current
+	manager.mu.Unlock()
+
+	reloaded, errRefresh := manager.refreshAuthForOnce(context.Background(), stale)
+	if errRefresh != nil {
+		t.Fatalf("refreshAuthForOnce() error = %v", errRefresh)
+	}
+	if got := authAccessToken(reloaded); got != "fresh-token" {
+		t.Fatalf("reloaded access token = %q, want fresh-token", got)
+	}
+	if got := executor.refreshCalls.Load(); got != 0 {
+		t.Fatalf("refresh calls = %d, want 0", got)
+	}
+}
+
 func TestManagerExecuteWithAuthOnce_ConcurrentRefreshWaitsForOwner(t *testing.T) {
 	refreshStarted := make(chan struct{})
 	releaseRefresh := make(chan struct{})

--- a/sdk/cliproxy/auth/conductor_execution_once_test.go
+++ b/sdk/cliproxy/auth/conductor_execution_once_test.go
@@ -103,7 +103,7 @@ func (e *onceTestExecutor) models() []string {
 // it, and then funnels into exactly this core, so the redirect, marking and
 // attempt-fact contracts are pinned here once instead of at every entry point.
 func httpOnceWithAuth(m *Manager, ctx context.Context, auth *Auth, req *http.Request, policy HTTPRedirectPolicy) (*http.Response, HTTPAttemptFacts, error) {
-	return m.httpOnce(ctx, auth, req, "", policy)
+	return m.httpOnce(ctx, auth, req, "test-model", policy)
 }
 
 // onceAuthByID reads a registered auth snapshot directly from the manager, which
@@ -564,6 +564,18 @@ type onceRoundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f onceRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
 
+// onceErrorCode returns the *Error code carried by err, or "" when err is nil.
+func onceErrorCode(err error) string {
+	if err == nil {
+		return ""
+	}
+	var authErr *Error
+	if errors.As(err, &authErr) && authErr != nil {
+		return authErr.Code
+	}
+	return err.Error()
+}
+
 func onceHTTPRequest(t *testing.T, ctx context.Context, method, target string, body io.Reader) *http.Request {
 	t.Helper()
 	req, err := http.NewRequestWithContext(ctx, method, target, body)
@@ -580,10 +592,12 @@ func TestManagerHTTPOnceCore_MarksOnceAndOnlySucceedsOn2xx(t *testing.T) {
 		retryAfter  string
 		wantSuccess bool
 		wantRetry   bool
+		wantErrCode string
 	}{
 		{name: "ok", status: http.StatusOK, wantSuccess: true},
 		{name: "created", status: http.StatusCreated, wantSuccess: true},
-		{name: "found", status: http.StatusFound},
+		{name: "found", status: http.StatusFound, wantErrCode: "redirect_denied"},
+		{name: "not found", status: http.StatusNotFound},
 		{name: "unauthorized", status: http.StatusUnauthorized},
 		{name: "request timeout", status: http.StatusRequestTimeout},
 		{name: "rate limited", status: http.StatusTooManyRequests, retryAfter: "30", wantRetry: true},
@@ -608,8 +622,8 @@ func TestManagerHTTPOnceCore_MarksOnceAndOnlySucceedsOn2xx(t *testing.T) {
 			auth := onceAuthByID(t, manager, "http-once")
 
 			resp, facts, errDo := httpOnceWithAuth(manager, context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodPost, server.URL, strings.NewReader(`{}`)), HTTPRedirectDeny)
-			if errDo != nil {
-				t.Fatalf("httpOnceWithAuth() error = %v", errDo)
+			if code := onceErrorCode(errDo); code != tt.wantErrCode {
+				t.Fatalf("httpOnceWithAuth() error = %v, want code %q", errDo, tt.wantErrCode)
 			}
 			defer func() { _ = resp.Body.Close() }()
 
@@ -679,8 +693,8 @@ func TestManagerHTTPOnceCore_DenyNeverFollowsRedirect(t *testing.T) {
 				body = strings.NewReader(`{"paid":true}`)
 			}
 			resp, facts, errDo := httpOnceWithAuth(manager, context.Background(), auth, onceHTTPRequest(t, context.Background(), tt.method, server.URL+"/start", body), HTTPRedirectDeny)
-			if errDo != nil {
-				t.Fatalf("httpOnceWithAuth() error = %v", errDo)
+			if code := onceErrorCode(errDo); code != "redirect_denied" {
+				t.Fatalf("httpOnceWithAuth() error = %v, want redirect_denied", errDo)
 			}
 			defer func() { _ = resp.Body.Close() }()
 
@@ -696,6 +710,12 @@ func TestManagerHTTPOnceCore_DenyNeverFollowsRedirect(t *testing.T) {
 			results := hook.snapshot()
 			if len(results) != 1 || results[0].Success {
 				t.Fatalf("results = %+v, want exactly one unsuccessful result", results)
+			}
+			// Refusing a redirect is the policy working, not the credential
+			// failing, so it must never cool the credential.
+			stored := onceAuthByID(t, manager, "redirect-deny")
+			if state := stored.ModelStates["test-model"]; state != nil && state.Unavailable {
+				t.Fatalf("model state = %+v, want a policy refusal to leave the credential untouched", state)
 			}
 		})
 	}
@@ -719,8 +739,8 @@ func TestManagerHTTPOnceCore_EmptyPolicyDefaultsToDeny(t *testing.T) {
 	auth := onceAuthByID(t, manager, "redirect-default")
 
 	resp, facts, errDo := httpOnceWithAuth(manager, context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodGet, server.URL+"/start", nil), "")
-	if errDo != nil {
-		t.Fatalf("httpOnceWithAuth() error = %v", errDo)
+	if code := onceErrorCode(errDo); code != "redirect_denied" {
+		t.Fatalf("httpOnceWithAuth() error = %v, want redirect_denied", errDo)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusFound {
@@ -768,6 +788,7 @@ func TestManagerHTTPOnceCore_SameOriginSafeFollowsOnlySafeRedirects(t *testing.T
 		wantFollowed  int32
 		wantRequests  uint32
 		wantSucceeded bool
+		wantErrCode   string
 	}{
 		{
 			name:          "same origin get is followed",
@@ -785,6 +806,7 @@ func TestManagerHTTPOnceCore_SameOriginSafeFollowsOnlySafeRedirects(t *testing.T
 			wantStatus:   http.StatusFound,
 			wantFollowed: 0,
 			wantRequests: 1,
+			wantErrCode:  "redirect_denied",
 		},
 		{
 			name:         "post is refused",
@@ -794,6 +816,7 @@ func TestManagerHTTPOnceCore_SameOriginSafeFollowsOnlySafeRedirects(t *testing.T
 			wantStatus:   http.StatusTemporaryRedirect,
 			wantFollowed: 0,
 			wantRequests: 1,
+			wantErrCode:  "redirect_denied",
 		},
 	}
 
@@ -829,8 +852,8 @@ func TestManagerHTTPOnceCore_SameOriginSafeFollowsOnlySafeRedirects(t *testing.T
 				body = strings.NewReader(`{"paid":true}`)
 			}
 			resp, facts, errDo := httpOnceWithAuth(manager, ctx, auth, onceHTTPRequest(t, ctx, tt.method, server.URL+"/start", body), HTTPRedirectSameOriginSafe)
-			if errDo != nil {
-				t.Fatalf("httpOnceWithAuth() error = %v", errDo)
+			if code := onceErrorCode(errDo); code != tt.wantErrCode {
+				t.Fatalf("httpOnceWithAuth() error = %v, want code %q", errDo, tt.wantErrCode)
 			}
 			defer func() { _ = resp.Body.Close() }()
 
@@ -886,8 +909,8 @@ func TestManagerHTTPOnceCore_SameOriginSafeStopsAtThreeHops(t *testing.T) {
 
 	ctx := newOnceTLSContext(server)
 	resp, facts, errDo := httpOnceWithAuth(manager, ctx, auth, onceHTTPRequest(t, ctx, http.MethodGet, server.URL+"/hop1", nil), HTTPRedirectSameOriginSafe)
-	if errDo != nil {
-		t.Fatalf("httpOnceWithAuth() error = %v", errDo)
+	if code := onceErrorCode(errDo); code != "redirect_denied" {
+		t.Fatalf("httpOnceWithAuth() error = %v, want redirect_denied", errDo)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -1166,24 +1189,28 @@ func TestSameOriginSafeRedirectAllowed(t *testing.T) {
 
 func TestOnceAttemptRecorderFacts(t *testing.T) {
 	tests := []struct {
-		name    string
-		prepare func(recorder *onceAttemptRecorder)
-		want    HTTPAttemptFacts
+		name        string
+		clientOwned bool
+		prepare     func(recorder *onceAttemptRecorder)
+		want        HTTPAttemptFacts
 	}{
 		{
-			name:    "never dispatched",
-			prepare: func(*onceAttemptRecorder) {},
-			want:    HTTPAttemptFacts{},
+			name:        "never dispatched",
+			clientOwned: true,
+			prepare:     func(*onceAttemptRecorder) {},
+			want:        HTTPAttemptFacts{},
 		},
 		{
-			name: "dispatched without observation is ambiguous",
+			name:        "dispatched without observation is ambiguous",
+			clientOwned: true,
 			prepare: func(recorder *onceAttemptRecorder) {
 				recorder.markDispatched()
 			},
 			want: HTTPAttemptFacts{RequestWritten: true},
 		},
 		{
-			name: "trace observed without write",
+			name:        "owned client trace observed without write",
+			clientOwned: true,
 			prepare: func(recorder *onceAttemptRecorder) {
 				recorder.markDispatched()
 				recorder.clientTrace().ConnectStart("tcp", "host:443")
@@ -1191,29 +1218,52 @@ func TestOnceAttemptRecorderFacts(t *testing.T) {
 			want: HTTPAttemptFacts{},
 		},
 		{
-			name: "trace observed with write",
+			name: "executor owned client never claims not written",
+			prepare: func(recorder *onceAttemptRecorder) {
+				recorder.markDispatched()
+				recorder.clientTrace().ConnectStart("tcp", "host:443")
+			},
+			want: HTTPAttemptFacts{RequestWritten: true},
+		},
+		{
+			name:        "trace observed with write",
+			clientOwned: true,
 			prepare: func(recorder *onceAttemptRecorder) {
 				recorder.markDispatched()
 				trace := recorder.clientTrace()
 				trace.WroteHeaders()
 				trace.GotFirstResponseByte()
 			},
-			want: HTTPAttemptFacts{RequestCount: 1, RequestWritten: true, ResponseStarted: true},
+			want: HTTPAttemptFacts{RequestCount: 1, RequestWritten: true, RequestWrittenObserved: true, ResponseStarted: true},
 		},
 		{
-			name: "transport observed",
+			name:        "transport observed",
+			clientOwned: true,
 			prepare: func(recorder *onceAttemptRecorder) {
 				recorder.markDispatched()
 				recorder.observeRequest()
 				recorder.observeResponse(http.StatusTooManyRequests)
 			},
-			want: HTTPAttemptFacts{RequestCount: 1, RequestWritten: true, ResponseStarted: true, StatusCode: http.StatusTooManyRequests},
+			want: HTTPAttemptFacts{RequestCount: 1, RequestWritten: true, RequestWrittenObserved: true, ResponseStarted: true, StatusCode: http.StatusTooManyRequests},
+		},
+		{
+			name:        "transport resend below the wrapper is counted from the trace",
+			clientOwned: true,
+			prepare: func(recorder *onceAttemptRecorder) {
+				recorder.markDispatched()
+				recorder.observeRequest()
+				trace := recorder.clientTrace()
+				trace.WroteHeaders()
+				trace.WroteHeaders()
+				recorder.observeResponse(http.StatusOK)
+			},
+			want: HTTPAttemptFacts{RequestCount: 2, RequestWritten: true, RequestWrittenObserved: true, ResponseStarted: true, StatusCode: http.StatusOK},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			recorder := newOnceAttemptRecorder()
+			recorder := newOnceAttemptRecorder(tt.clientOwned)
 			tt.prepare(recorder)
 			if got := recorder.facts(); got != tt.want {
 				t.Fatalf("facts() = %+v, want %+v", got, tt.want)

--- a/sdk/cliproxy/auth/conductor_execution_once_test.go
+++ b/sdk/cliproxy/auth/conductor_execution_once_test.go
@@ -37,6 +37,7 @@ type onceTestExecutor struct {
 	countCalls    atomic.Int32
 	executeErr    error
 	refreshErr    error
+	refreshFunc   func(ctx context.Context, auth *Auth) (*Auth, error)
 	executeFunc   func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error)
 	mu            sync.Mutex
 	executedModel []string
@@ -62,8 +63,11 @@ func (e *onceTestExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecuto
 	return nil, errors.New("stream not implemented")
 }
 
-func (e *onceTestExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+func (e *onceTestExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
 	e.refreshCalls.Add(1)
+	if e.refreshFunc != nil {
+		return e.refreshFunc(ctx, auth)
+	}
 	if e.refreshErr != nil {
 		return nil, e.refreshErr
 	}
@@ -361,6 +365,57 @@ func TestManagerExecuteWithAuthOnce_RefreshFailureFailsClosed(t *testing.T) {
 	}
 	if got := len(hook.snapshot()); got != 0 {
 		t.Fatalf("MarkResult calls = %d, want 0", got)
+	}
+}
+
+func TestManagerExecuteWithAuthOnce_ConcurrentRefreshWaitsForOwner(t *testing.T) {
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	executor := &onceTestExecutor{provider: "codex"}
+	executor.refreshFunc = func(ctx context.Context, auth *Auth) (*Auth, error) {
+		close(refreshStarted)
+		select {
+		case <-releaseRefresh:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		updated := auth.Clone()
+		if updated.Metadata == nil {
+			updated.Metadata = map[string]any{}
+		}
+		updated.Metadata["access_token"] = "fresh-token"
+		return updated, nil
+	}
+	auth := newOnceTestAuth("refresh-concurrent")
+	auth.Attributes["refresh_interval_seconds"] = "1"
+	auth.Metadata = map[string]any{"access_token": "stale-token"}
+	manager, _ := newOnceTestManager(t, executor, auth)
+
+	const callers = 2
+	errs := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			_, _, err := manager.ExecuteWithAuthOnce(context.Background(), onceRequest("refresh-concurrent"))
+			errs <- err
+		}()
+	}
+
+	<-refreshStarted
+	time.Sleep(20 * time.Millisecond)
+	if got := executor.executeCalls.Load(); got != 0 {
+		t.Fatalf("executor invocations before refresh owner completed = %d, want 0", got)
+	}
+	close(releaseRefresh)
+	for i := 0; i < callers; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("ExecuteWithAuthOnce() error = %v", err)
+		}
+	}
+	if got := executor.refreshCalls.Load(); got != 1 {
+		t.Fatalf("refresh calls = %d, want exactly one", got)
+	}
+	if got := executor.executeCalls.Load(); got != callers {
+		t.Fatalf("executor invocations = %d, want %d", got, callers)
 	}
 }
 
@@ -800,6 +855,16 @@ func TestManagerHTTPOnceCore_SameOriginSafeFollowsOnlySafeRedirects(t *testing.T
 			wantSucceeded: true,
 		},
 		{
+			name:          "same origin get with explicit zero-length body is followed",
+			method:        http.MethodGet,
+			withBody:      true,
+			location:      func(*httptest.Server) string { return "/followed" },
+			wantStatus:    http.StatusOK,
+			wantFollowed:  1,
+			wantRequests:  2,
+			wantSucceeded: true,
+		},
+		{
 			name:         "cross origin is refused",
 			method:       http.MethodGet,
 			location:     func(*httptest.Server) string { return "https://redirect-target.invalid/followed" },
@@ -849,7 +914,11 @@ func TestManagerHTTPOnceCore_SameOriginSafeFollowsOnlySafeRedirects(t *testing.T
 			ctx := newOnceTLSContext(server)
 			var body io.Reader
 			if tt.withBody {
-				body = strings.NewReader(`{"paid":true}`)
+				if strings.Contains(tt.name, "zero-length") {
+					body = strings.NewReader("")
+				} else {
+					body = strings.NewReader(`{"paid":true}`)
+				}
 			}
 			resp, facts, errDo := httpOnceWithAuth(manager, ctx, auth, onceHTTPRequest(t, ctx, tt.method, server.URL+"/start", body), HTTPRedirectSameOriginSafe)
 			if code := onceErrorCode(errDo); code != tt.wantErrCode {

--- a/sdk/cliproxy/auth/conductor_execution_once_test.go
+++ b/sdk/cliproxy/auth/conductor_execution_once_test.go
@@ -98,8 +98,16 @@ func (e *onceTestExecutor) models() []string {
 	return append([]string(nil), e.executedModel...)
 }
 
+// httpOnceWithAuth exercises the shared one-shot HTTP core against a caller
+// resolved auth. DoHTTPOnce resolves the credential by ID, refreshes and prepares
+// it, and then funnels into exactly this core, so the redirect, marking and
+// attempt-fact contracts are pinned here once instead of at every entry point.
+func httpOnceWithAuth(m *Manager, ctx context.Context, auth *Auth, req *http.Request, policy HTTPRedirectPolicy) (*http.Response, HTTPAttemptFacts, error) {
+	return m.httpOnce(ctx, auth, req, "", policy)
+}
+
 // onceAuthByID reads a registered auth snapshot directly from the manager, which
-// is what a host holds when it calls DoHTTPOnce with an auth it already resolved.
+// is what the one-shot HTTP core receives after DoHTTPOnce resolves an auth ID.
 func onceAuthByID(t *testing.T, manager *Manager, id string) *Auth {
 	t.Helper()
 	manager.mu.RLock()
@@ -565,7 +573,7 @@ func onceHTTPRequest(t *testing.T, ctx context.Context, method, target string, b
 	return req
 }
 
-func TestManagerDoHTTPOnce_MarksOnceAndOnlySucceedsOn2xx(t *testing.T) {
+func TestManagerHTTPOnceCore_MarksOnceAndOnlySucceedsOn2xx(t *testing.T) {
 	tests := []struct {
 		name        string
 		status      int
@@ -599,9 +607,9 @@ func TestManagerDoHTTPOnce_MarksOnceAndOnlySucceedsOn2xx(t *testing.T) {
 			manager, hook := newOnceTestManager(t, executor, newOnceTestAuth("http-once"))
 			auth := onceAuthByID(t, manager, "http-once")
 
-			resp, facts, errDo := manager.DoHTTPOnce(context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodPost, server.URL, strings.NewReader(`{}`)), HTTPRedirectDeny)
+			resp, facts, errDo := httpOnceWithAuth(manager, context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodPost, server.URL, strings.NewReader(`{}`)), HTTPRedirectDeny)
 			if errDo != nil {
-				t.Fatalf("DoHTTPOnce() error = %v", errDo)
+				t.Fatalf("httpOnceWithAuth() error = %v", errDo)
 			}
 			defer func() { _ = resp.Body.Close() }()
 
@@ -634,7 +642,7 @@ func TestManagerDoHTTPOnce_MarksOnceAndOnlySucceedsOn2xx(t *testing.T) {
 	}
 }
 
-func TestManagerDoHTTPOnce_DenyNeverFollowsRedirect(t *testing.T) {
+func TestManagerHTTPOnceCore_DenyNeverFollowsRedirect(t *testing.T) {
 	tests := []struct {
 		name   string
 		status int
@@ -670,9 +678,9 @@ func TestManagerDoHTTPOnce_DenyNeverFollowsRedirect(t *testing.T) {
 			if tt.method != http.MethodGet {
 				body = strings.NewReader(`{"paid":true}`)
 			}
-			resp, facts, errDo := manager.DoHTTPOnce(context.Background(), auth, onceHTTPRequest(t, context.Background(), tt.method, server.URL+"/start", body), HTTPRedirectDeny)
+			resp, facts, errDo := httpOnceWithAuth(manager, context.Background(), auth, onceHTTPRequest(t, context.Background(), tt.method, server.URL+"/start", body), HTTPRedirectDeny)
 			if errDo != nil {
-				t.Fatalf("DoHTTPOnce() error = %v", errDo)
+				t.Fatalf("httpOnceWithAuth() error = %v", errDo)
 			}
 			defer func() { _ = resp.Body.Close() }()
 
@@ -693,7 +701,7 @@ func TestManagerDoHTTPOnce_DenyNeverFollowsRedirect(t *testing.T) {
 	}
 }
 
-func TestManagerDoHTTPOnce_EmptyPolicyDefaultsToDeny(t *testing.T) {
+func TestManagerHTTPOnceCore_EmptyPolicyDefaultsToDeny(t *testing.T) {
 	var followed atomic.Int32
 	mux := http.NewServeMux()
 	mux.HandleFunc("/start", func(w http.ResponseWriter, _ *http.Request) {
@@ -710,9 +718,9 @@ func TestManagerDoHTTPOnce_EmptyPolicyDefaultsToDeny(t *testing.T) {
 	manager, _ := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, newOnceTestAuth("redirect-default"))
 	auth := onceAuthByID(t, manager, "redirect-default")
 
-	resp, facts, errDo := manager.DoHTTPOnce(context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodGet, server.URL+"/start", nil), "")
+	resp, facts, errDo := httpOnceWithAuth(manager, context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodGet, server.URL+"/start", nil), "")
 	if errDo != nil {
-		t.Fatalf("DoHTTPOnce() error = %v", errDo)
+		t.Fatalf("httpOnceWithAuth() error = %v", errDo)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusFound {
@@ -726,14 +734,14 @@ func TestManagerDoHTTPOnce_EmptyPolicyDefaultsToDeny(t *testing.T) {
 	}
 }
 
-func TestManagerDoHTTPOnce_InvalidRedirectPolicyIsRejected(t *testing.T) {
+func TestManagerHTTPOnceCore_InvalidRedirectPolicyIsRejected(t *testing.T) {
 	manager, hook := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, newOnceTestAuth("bad-policy"))
 	auth := onceAuthByID(t, manager, "bad-policy")
 
-	_, facts, errDo := manager.DoHTTPOnce(context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodGet, "https://example.invalid/", nil), HTTPRedirectPolicy("follow-everything"))
+	_, facts, errDo := httpOnceWithAuth(manager, context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodGet, "https://example.invalid/", nil), HTTPRedirectPolicy("follow-everything"))
 	var authErr *Error
 	if !errors.As(errDo, &authErr) || authErr == nil || authErr.Code != "invalid_redirect_policy" {
-		t.Fatalf("DoHTTPOnce() error = %v, want invalid_redirect_policy", errDo)
+		t.Fatalf("httpOnceWithAuth() error = %v, want invalid_redirect_policy", errDo)
 	}
 	if facts.RequestWritten || facts.RequestCount != 0 {
 		t.Fatalf("facts = %+v, want an undispatched attempt", facts)
@@ -750,7 +758,7 @@ func newOnceTLSContext(server *httptest.Server) context.Context {
 	return context.WithValue(context.Background(), "cliproxy.roundtripper", server.Client().Transport)
 }
 
-func TestManagerDoHTTPOnce_SameOriginSafeFollowsOnlySafeRedirects(t *testing.T) {
+func TestManagerHTTPOnceCore_SameOriginSafeFollowsOnlySafeRedirects(t *testing.T) {
 	tests := []struct {
 		name          string
 		method        string
@@ -820,9 +828,9 @@ func TestManagerDoHTTPOnce_SameOriginSafeFollowsOnlySafeRedirects(t *testing.T) 
 			if tt.withBody {
 				body = strings.NewReader(`{"paid":true}`)
 			}
-			resp, facts, errDo := manager.DoHTTPOnce(ctx, auth, onceHTTPRequest(t, ctx, tt.method, server.URL+"/start", body), HTTPRedirectSameOriginSafe)
+			resp, facts, errDo := httpOnceWithAuth(manager, ctx, auth, onceHTTPRequest(t, ctx, tt.method, server.URL+"/start", body), HTTPRedirectSameOriginSafe)
 			if errDo != nil {
-				t.Fatalf("DoHTTPOnce() error = %v", errDo)
+				t.Fatalf("httpOnceWithAuth() error = %v", errDo)
 			}
 			defer func() { _ = resp.Body.Close() }()
 
@@ -851,7 +859,7 @@ func TestManagerDoHTTPOnce_SameOriginSafeFollowsOnlySafeRedirects(t *testing.T) 
 	}
 }
 
-func TestManagerDoHTTPOnce_SameOriginSafeStopsAtThreeHops(t *testing.T) {
+func TestManagerHTTPOnceCore_SameOriginSafeStopsAtThreeHops(t *testing.T) {
 	var final atomic.Int32
 	mux := http.NewServeMux()
 	for _, hop := range []struct{ from, to string }{
@@ -877,9 +885,9 @@ func TestManagerDoHTTPOnce_SameOriginSafeStopsAtThreeHops(t *testing.T) {
 	auth := onceAuthByID(t, manager, "hops")
 
 	ctx := newOnceTLSContext(server)
-	resp, facts, errDo := manager.DoHTTPOnce(ctx, auth, onceHTTPRequest(t, ctx, http.MethodGet, server.URL+"/hop1", nil), HTTPRedirectSameOriginSafe)
+	resp, facts, errDo := httpOnceWithAuth(manager, ctx, auth, onceHTTPRequest(t, ctx, http.MethodGet, server.URL+"/hop1", nil), HTTPRedirectSameOriginSafe)
 	if errDo != nil {
-		t.Fatalf("DoHTTPOnce() error = %v", errDo)
+		t.Fatalf("httpOnceWithAuth() error = %v", errDo)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -894,7 +902,7 @@ func TestManagerDoHTTPOnce_SameOriginSafeStopsAtThreeHops(t *testing.T) {
 	}
 }
 
-func TestManagerDoHTTPOnce_AttemptFacts(t *testing.T) {
+func TestManagerHTTPOnceCore_AttemptFacts(t *testing.T) {
 	t.Run("clean response", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte("done"))
@@ -904,9 +912,9 @@ func TestManagerDoHTTPOnce_AttemptFacts(t *testing.T) {
 		manager, _ := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, newOnceTestAuth("facts-clean"))
 		auth := onceAuthByID(t, manager, "facts-clean")
 
-		resp, facts, err := manager.DoHTTPOnce(context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodGet, server.URL, nil), HTTPRedirectDeny)
+		resp, facts, err := httpOnceWithAuth(manager, context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodGet, server.URL, nil), HTTPRedirectDeny)
 		if err != nil {
-			t.Fatalf("DoHTTPOnce() error = %v", err)
+			t.Fatalf("httpOnceWithAuth() error = %v", err)
 		}
 		defer func() { _ = resp.Body.Close() }()
 		if !facts.RequestWritten || !facts.ResponseStarted || facts.StatusCode != http.StatusOK || facts.RequestCount != 1 {
@@ -922,12 +930,12 @@ func TestManagerDoHTTPOnce_AttemptFacts(t *testing.T) {
 		manager, hook := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, newOnceTestAuth("facts-refused"))
 		auth := onceAuthByID(t, manager, "facts-refused")
 
-		resp, facts, err := manager.DoHTTPOnce(context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodPost, target, strings.NewReader(`{}`)), HTTPRedirectDeny)
+		resp, facts, err := httpOnceWithAuth(manager, context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodPost, target, strings.NewReader(`{}`)), HTTPRedirectDeny)
 		if err == nil {
 			if resp != nil {
 				_ = resp.Body.Close()
 			}
-			t.Fatal("DoHTTPOnce() error = nil, want a transport failure")
+			t.Fatal("httpOnceWithAuth() error = nil, want a transport failure")
 		}
 		if facts.RequestWritten {
 			t.Fatalf("facts.RequestWritten = true, want false when the connection was refused")
@@ -962,9 +970,9 @@ func TestManagerDoHTTPOnce_AttemptFacts(t *testing.T) {
 		manager, _ := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, newOnceTestAuth("facts-truncated"))
 		auth := onceAuthByID(t, manager, "facts-truncated")
 
-		resp, facts, err := manager.DoHTTPOnce(context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodGet, server.URL, nil), HTTPRedirectDeny)
+		resp, facts, err := httpOnceWithAuth(manager, context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodGet, server.URL, nil), HTTPRedirectDeny)
 		if err != nil {
-			t.Fatalf("DoHTTPOnce() error = %v", err)
+			t.Fatalf("httpOnceWithAuth() error = %v", err)
 		}
 		defer func() { _ = resp.Body.Close() }()
 		if _, errRead := io.ReadAll(resp.Body); errRead == nil {
@@ -986,9 +994,9 @@ func TestManagerDoHTTPOnce_AttemptFacts(t *testing.T) {
 		manager, _ := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, newOnceTestAuth("facts-opaque"))
 		auth := onceAuthByID(t, manager, "facts-opaque")
 
-		_, facts, err := manager.DoHTTPOnce(ctx, auth, onceHTTPRequest(t, ctx, http.MethodPost, "https://example.invalid/create", strings.NewReader(`{}`)), HTTPRedirectDeny)
+		_, facts, err := httpOnceWithAuth(manager, ctx, auth, onceHTTPRequest(t, ctx, http.MethodPost, "https://example.invalid/create", strings.NewReader(`{}`)), HTTPRedirectDeny)
 		if err == nil {
-			t.Fatal("DoHTTPOnce() error = nil, want the transport failure")
+			t.Fatal("httpOnceWithAuth() error = nil, want the transport failure")
 		}
 		if !facts.RequestWritten {
 			t.Fatal("facts.RequestWritten = false, want true when the transport reports nothing")
@@ -999,7 +1007,7 @@ func TestManagerDoHTTPOnce_AttemptFacts(t *testing.T) {
 	})
 }
 
-func TestManagerHTTPOnce_ResolvesDurableAuthAndPreparesBeforeDispatch(t *testing.T) {
+func TestManagerDoHTTPOnce_ResolvesDurableAuthAndPreparesBeforeDispatch(t *testing.T) {
 	var seenKey atomic.Value
 	seenKey.Store("")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1011,7 +1019,7 @@ func TestManagerHTTPOnce_ResolvesDurableAuthAndPreparesBeforeDispatch(t *testing
 	executor := &onceTestExecutor{provider: "codex"}
 	manager, hook := newOnceTestManager(t, executor, newOnceTestAuth("http-once-id"))
 
-	resp, facts, err := manager.HTTPOnce(context.Background(), HTTPOnceRequest{
+	resp, facts, err := manager.DoHTTPOnce(context.Background(), HTTPOnceRequest{
 		AuthID:         "http-once-id",
 		Model:          "test-model",
 		Method:         http.MethodPost,
@@ -1021,7 +1029,7 @@ func TestManagerHTTPOnce_ResolvesDurableAuthAndPreparesBeforeDispatch(t *testing
 		RedirectPolicy: HTTPRedirectDeny,
 	})
 	if err != nil {
-		t.Fatalf("HTTPOnce() error = %v", err)
+		t.Fatalf("DoHTTPOnce() error = %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -1037,7 +1045,7 @@ func TestManagerHTTPOnce_ResolvesDurableAuthAndPreparesBeforeDispatch(t *testing
 	}
 }
 
-func TestManagerHTTPOnce_PreflightFailuresNeverDispatch(t *testing.T) {
+func TestManagerDoHTTPOnce_PreflightFailuresNeverDispatch(t *testing.T) {
 	tests := []struct {
 		name     string
 		request  HTTPOnceRequest
@@ -1065,10 +1073,10 @@ func TestManagerHTTPOnce_PreflightFailuresNeverDispatch(t *testing.T) {
 				tt.setup(manager)
 			}
 
-			_, facts, err := manager.HTTPOnce(context.Background(), tt.request)
+			_, facts, err := manager.DoHTTPOnce(context.Background(), tt.request)
 			var authErr *Error
 			if !errors.As(err, &authErr) || authErr == nil {
-				t.Fatalf("HTTPOnce() error = %v, want *Error", err)
+				t.Fatalf("DoHTTPOnce() error = %v, want *Error", err)
 			}
 			if authErr.Code != tt.wantCode {
 				t.Fatalf("error code = %q, want %q", authErr.Code, tt.wantCode)

--- a/sdk/cliproxy/auth/conductor_execution_once_test.go
+++ b/sdk/cliproxy/auth/conductor_execution_once_test.go
@@ -344,6 +344,32 @@ func TestManagerExecuteWithAuthOnce_PreflightFailuresNeverDispatch(t *testing.T)
 	}
 }
 
+func TestManagerExecuteWithAuthOnce_RefreshUsesEffectiveExecutorKey(t *testing.T) {
+	executor := &onceTestExecutor{provider: "openai-compatible-custom"}
+	auth := newOnceTestAuth("refresh-compatible")
+	auth.Provider = "plugin-provider"
+	auth.Attributes["compat_name"] = "custom"
+	auth.Attributes["provider_key"] = "custom"
+	auth.Attributes["refresh_interval_seconds"] = "1"
+	auth.Metadata = map[string]any{
+		"access_token":  "stale-token",
+		"refresh_token": "refresh-token",
+	}
+	manager, _ := newOnceTestManager(t, executor, auth)
+
+	request := onceRequest(auth.ID)
+	request.Provider = "openai-compatible-custom"
+	if _, _, err := manager.ExecuteWithAuthOnce(context.Background(), request); err != nil {
+		t.Fatalf("ExecuteWithAuthOnce() error = %v", err)
+	}
+	if got := executor.refreshCalls.Load(); got != 1 {
+		t.Fatalf("refresh calls = %d, want 1 through effective executor key", got)
+	}
+	if got := executor.executeCalls.Load(); got != 1 {
+		t.Fatalf("executor calls = %d, want 1", got)
+	}
+}
+
 func TestManagerExecuteWithAuthOnce_RefreshFailureFailsClosed(t *testing.T) {
 	executor := &onceTestExecutor{provider: "codex", refreshErr: errors.New("refresh rejected")}
 	auth := newOnceTestAuth("refresh-fail")

--- a/sdk/cliproxy/auth/conductor_execution_once_test.go
+++ b/sdk/cliproxy/auth/conductor_execution_once_test.go
@@ -1,0 +1,1215 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// onceStatusError carries an HTTP status the way provider executors do.
+type onceStatusError struct {
+	status  int
+	message string
+}
+
+func (e *onceStatusError) Error() string { return e.message }
+
+func (e *onceStatusError) StatusCode() int { return e.status }
+
+// onceTestExecutor counts every executor entry point the one-shot path may touch.
+type onceTestExecutor struct {
+	provider string
+
+	executeCalls  atomic.Int32
+	refreshCalls  atomic.Int32
+	prepareCalls  atomic.Int32
+	httpCalls     atomic.Int32
+	countCalls    atomic.Int32
+	executeErr    error
+	refreshErr    error
+	executeFunc   func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error)
+	mu            sync.Mutex
+	executedModel []string
+}
+
+func (e *onceTestExecutor) Identifier() string { return e.provider }
+
+func (e *onceTestExecutor) Execute(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.executeCalls.Add(1)
+	e.mu.Lock()
+	e.executedModel = append(e.executedModel, req.Model)
+	e.mu.Unlock()
+	if e.executeFunc != nil {
+		return e.executeFunc(ctx, auth, req, opts)
+	}
+	if e.executeErr != nil {
+		return cliproxyexecutor.Response{}, e.executeErr
+	}
+	return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+}
+
+func (e *onceTestExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, errors.New("stream not implemented")
+}
+
+func (e *onceTestExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	e.refreshCalls.Add(1)
+	if e.refreshErr != nil {
+		return nil, e.refreshErr
+	}
+	return auth, nil
+}
+
+func (e *onceTestExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.countCalls.Add(1)
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *onceTestExecutor) HttpRequest(_ context.Context, _ *Auth, _ *http.Request) (*http.Response, error) {
+	e.httpCalls.Add(1)
+	return nil, errors.New("http request not implemented")
+}
+
+// PrepareRequest implements RequestPreparer so the one-shot HTTP path can inject
+// credentials through the executor exactly as PrepareHttpRequest requires.
+func (e *onceTestExecutor) PrepareRequest(req *http.Request, auth *Auth) error {
+	e.prepareCalls.Add(1)
+	if req == nil {
+		return errors.New("nil request")
+	}
+	req.Header.Set("X-Api-Key", "secret-key")
+	req.Header.Set("Authorization", "Bearer secret-token")
+	return nil
+}
+
+func (e *onceTestExecutor) models() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.executedModel...)
+}
+
+// onceAuthByID reads a registered auth snapshot directly from the manager, which
+// is what a host holds when it calls DoHTTPOnce with an auth it already resolved.
+func onceAuthByID(t *testing.T, manager *Manager, id string) *Auth {
+	t.Helper()
+	manager.mu.RLock()
+	auth := manager.auths[id]
+	manager.mu.RUnlock()
+	if auth == nil {
+		t.Fatalf("auth %q is not registered", id)
+	}
+	return auth.Clone()
+}
+
+// onceResultHook records every MarkResult the manager emits.
+type onceResultHook struct {
+	mu      sync.Mutex
+	results []Result
+}
+
+func (h *onceResultHook) OnAuthRegistered(context.Context, *Auth) {}
+
+func (h *onceResultHook) OnAuthUpdated(context.Context, *Auth) {}
+
+func (h *onceResultHook) OnResult(_ context.Context, result Result) {
+	h.mu.Lock()
+	h.results = append(h.results, result)
+	h.mu.Unlock()
+}
+
+func (h *onceResultHook) snapshot() []Result {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]Result(nil), h.results...)
+}
+
+func newOnceTestManager(t *testing.T, executor *onceTestExecutor, auth *Auth) (*Manager, *onceResultHook) {
+	t.Helper()
+	hook := &onceResultHook{}
+	manager := NewManager(nil, &RoundRobinSelector{}, hook)
+	// A generous retry budget proves the one-shot path never consults it.
+	manager.SetRetryConfig(5, time.Second, 5)
+	manager.RegisterExecutor(executor)
+	if auth != nil {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register auth: %v", err)
+		}
+	}
+	return manager, hook
+}
+
+func newOnceTestAuth(id string) *Auth {
+	return &Auth{
+		ID:       id,
+		Provider: "codex",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"api_key": "test-key",
+		},
+	}
+}
+
+func onceRequest(authID string) ExecuteWithAuthOnceRequest {
+	return ExecuteWithAuthOnceRequest{
+		AuthID:  authID,
+		Model:   "test-model",
+		Request: cliproxyexecutor.Request{Model: "test-model", Payload: []byte(`{}`)},
+		Options: cliproxyexecutor.Options{Metadata: map[string]any{}},
+	}
+}
+
+func TestManagerExecuteWithAuthOnce_InvokesExecutorAndMarksExactlyOnce(t *testing.T) {
+	tests := []struct {
+		name        string
+		executeErr  error
+		wantSuccess bool
+		wantStatus  int
+	}{
+		{name: "success", wantSuccess: true},
+		{name: "unauthorized", executeErr: &onceStatusError{status: http.StatusUnauthorized, message: "unauthorized"}, wantStatus: http.StatusUnauthorized},
+		{name: "request timeout", executeErr: &onceStatusError{status: http.StatusRequestTimeout, message: "timeout"}, wantStatus: http.StatusRequestTimeout},
+		{name: "rate limited", executeErr: &onceStatusError{status: http.StatusTooManyRequests, message: "slow down"}, wantStatus: http.StatusTooManyRequests},
+		{name: "server error", executeErr: &onceStatusError{status: http.StatusInternalServerError, message: "boom"}, wantStatus: http.StatusInternalServerError},
+		{name: "transport error", executeErr: errors.New("connection reset by peer")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &onceTestExecutor{provider: "codex", executeErr: tt.executeErr}
+			manager, hook := newOnceTestManager(t, executor, newOnceTestAuth("once-auth"))
+
+			_, facts, err := manager.ExecuteWithAuthOnce(context.Background(), onceRequest("once-auth"))
+			if tt.wantSuccess && err != nil {
+				t.Fatalf("ExecuteWithAuthOnce() error = %v, want nil", err)
+			}
+			if !tt.wantSuccess && err == nil {
+				t.Fatalf("ExecuteWithAuthOnce() error = nil, want %v", tt.executeErr)
+			}
+			if got := executor.executeCalls.Load(); got != 1 {
+				t.Fatalf("executor invocations = %d, want 1", got)
+			}
+			results := hook.snapshot()
+			if len(results) != 1 {
+				t.Fatalf("MarkResult calls = %d, want 1", len(results))
+			}
+			if results[0].Success != tt.wantSuccess {
+				t.Fatalf("Result.Success = %v, want %v", results[0].Success, tt.wantSuccess)
+			}
+			if results[0].AuthID != "once-auth" {
+				t.Fatalf("Result.AuthID = %q, want %q", results[0].AuthID, "once-auth")
+			}
+			if tt.wantStatus != 0 && facts.StatusCode != tt.wantStatus {
+				t.Fatalf("facts.StatusCode = %d, want %d", facts.StatusCode, tt.wantStatus)
+			}
+			if got := executor.countCalls.Load(); got != 0 {
+				t.Fatalf("CountTokens calls = %d, want 0", got)
+			}
+			if got := executor.models(); len(got) != 1 || got[0] != "test-model" {
+				t.Fatalf("executed models = %v, want [test-model]", got)
+			}
+		})
+	}
+}
+
+func TestManagerExecuteWithAuthOnce_UnauthorizedDoesNotReplay(t *testing.T) {
+	executor := &onceTestExecutor{
+		provider:   "codex",
+		executeErr: &onceStatusError{status: http.StatusUnauthorized, message: "unauthorized"},
+	}
+	manager, hook := newOnceTestManager(t, executor, newOnceTestAuth("no-replay"))
+
+	_, _, err := manager.ExecuteWithAuthOnce(context.Background(), onceRequest("no-replay"))
+	if err == nil {
+		t.Fatal("ExecuteWithAuthOnce() error = nil, want unauthorized")
+	}
+	if got := executor.executeCalls.Load(); got != 1 {
+		t.Fatalf("executor invocations after 401 = %d, want 1", got)
+	}
+	if got := executor.refreshCalls.Load(); got != 0 {
+		t.Fatalf("post-401 refresh calls = %d, want 0", got)
+	}
+	if got := len(hook.snapshot()); got != 1 {
+		t.Fatalf("MarkResult calls = %d, want 1", got)
+	}
+}
+
+func TestManagerExecuteWithAuthOnce_NeverHopsToAnotherCredential(t *testing.T) {
+	executor := &onceTestExecutor{
+		provider:   "codex",
+		executeErr: &onceStatusError{status: http.StatusInternalServerError, message: "boom"},
+	}
+	manager, hook := newOnceTestManager(t, executor, newOnceTestAuth("pinned-auth"))
+	if _, err := manager.Register(context.Background(), newOnceTestAuth("sibling-auth")); err != nil {
+		t.Fatalf("register sibling auth: %v", err)
+	}
+
+	if _, _, err := manager.ExecuteWithAuthOnce(context.Background(), onceRequest("pinned-auth")); err == nil {
+		t.Fatal("ExecuteWithAuthOnce() error = nil, want failure")
+	}
+	if got := executor.executeCalls.Load(); got != 1 {
+		t.Fatalf("executor invocations = %d, want 1", got)
+	}
+	for _, result := range hook.snapshot() {
+		if result.AuthID != "pinned-auth" {
+			t.Fatalf("Result.AuthID = %q, want only the pinned auth", result.AuthID)
+		}
+	}
+}
+
+func TestManagerExecuteWithAuthOnce_PreflightFailuresNeverDispatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		authID   string
+		provider string
+		setup    func(t *testing.T, manager *Manager)
+		wantCode string
+	}{
+		{name: "empty auth id", authID: "", wantCode: "auth_not_found"},
+		{name: "unknown auth id", authID: "missing", wantCode: "auth_not_found"},
+		{name: "unregistered executor", authID: "preflight", provider: "not-registered", wantCode: "executor_not_found"},
+		{
+			name:   "home mode",
+			authID: "preflight",
+			setup: func(_ *testing.T, manager *Manager) {
+				manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			},
+			wantCode: "auth_not_durable",
+		},
+		{
+			name:   "session scoped auth",
+			authID: "preflight",
+			setup: func(_ *testing.T, manager *Manager) {
+				manager.mu.Lock()
+				manager.homeRuntimeAuths["session-1"] = map[string]*Auth{"preflight": newOnceTestAuth("preflight")}
+				manager.mu.Unlock()
+			},
+			wantCode: "auth_not_durable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &onceTestExecutor{provider: "codex"}
+			manager, hook := newOnceTestManager(t, executor, newOnceTestAuth("preflight"))
+			if tt.setup != nil {
+				tt.setup(t, manager)
+			}
+
+			in := onceRequest(tt.authID)
+			in.Provider = tt.provider
+			_, facts, err := manager.ExecuteWithAuthOnce(context.Background(), in)
+
+			var authErr *Error
+			if !errors.As(err, &authErr) || authErr == nil {
+				t.Fatalf("ExecuteWithAuthOnce() error = %v, want *Error", err)
+			}
+			if authErr.Code != tt.wantCode {
+				t.Fatalf("error code = %q, want %q", authErr.Code, tt.wantCode)
+			}
+			if facts.RequestWritten {
+				t.Fatalf("facts.RequestWritten = true, want false for a pre-flight failure")
+			}
+			if facts.RequestCount != 0 {
+				t.Fatalf("facts.RequestCount = %d, want 0", facts.RequestCount)
+			}
+			if got := executor.executeCalls.Load(); got != 0 {
+				t.Fatalf("executor invocations = %d, want 0", got)
+			}
+			if got := len(hook.snapshot()); got != 0 {
+				t.Fatalf("MarkResult calls = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestManagerExecuteWithAuthOnce_RefreshFailureFailsClosed(t *testing.T) {
+	executor := &onceTestExecutor{provider: "codex", refreshErr: errors.New("refresh rejected")}
+	auth := newOnceTestAuth("refresh-fail")
+	auth.Attributes["refresh_interval_seconds"] = "1"
+	manager, hook := newOnceTestManager(t, executor, auth)
+
+	_, facts, err := manager.ExecuteWithAuthOnce(context.Background(), onceRequest("refresh-fail"))
+	if err == nil {
+		t.Fatal("ExecuteWithAuthOnce() error = nil, want refresh failure")
+	}
+	if got := executor.refreshCalls.Load(); got != 1 {
+		t.Fatalf("refresh calls = %d, want 1", got)
+	}
+	if got := executor.executeCalls.Load(); got != 0 {
+		t.Fatalf("executor invocations = %d, want 0", got)
+	}
+	if facts.RequestWritten {
+		t.Fatal("facts.RequestWritten = true, want false when refresh failed before dispatch")
+	}
+	if got := len(hook.snapshot()); got != 0 {
+		t.Fatalf("MarkResult calls = %d, want 0", got)
+	}
+}
+
+func TestManagerExecuteWithAuthOnce_RefreshRunsBeforeDispatch(t *testing.T) {
+	var order []string
+	var mu sync.Mutex
+	executor := &onceTestExecutor{provider: "codex"}
+	executor.executeFunc = func(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+		mu.Lock()
+		order = append(order, "execute")
+		mu.Unlock()
+		return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+	}
+	auth := newOnceTestAuth("refresh-order")
+	auth.Attributes["refresh_interval_seconds"] = "1"
+	manager, _ := newOnceTestManager(t, executor, auth)
+
+	if _, _, err := manager.ExecuteWithAuthOnce(context.Background(), onceRequest("refresh-order")); err != nil {
+		t.Fatalf("ExecuteWithAuthOnce() error = %v", err)
+	}
+	if got := executor.refreshCalls.Load(); got != 1 {
+		t.Fatalf("refresh calls = %d, want 1", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) != 1 || order[0] != "execute" {
+		t.Fatalf("execute order = %v, want a single execute after refresh", order)
+	}
+}
+
+type oncePrepareFailExecutor struct {
+	onceTestExecutor
+	prepareAuthCalls atomic.Int32
+}
+
+func (e *oncePrepareFailExecutor) ShouldPrepareRequestAuth(*Auth) bool { return true }
+
+func (e *oncePrepareFailExecutor) PrepareRequestAuth(context.Context, *Auth) (*Auth, error) {
+	e.prepareAuthCalls.Add(1)
+	return nil, errors.New("prepare failed")
+}
+
+func TestManagerExecuteWithAuthOnce_PrepareFailureMarksOnceWithoutDispatch(t *testing.T) {
+	executor := &oncePrepareFailExecutor{onceTestExecutor: onceTestExecutor{provider: "codex"}}
+	hook := &onceResultHook{}
+	manager := NewManager(nil, &RoundRobinSelector{}, hook)
+	manager.RegisterExecutor(executor)
+	if _, err := manager.Register(context.Background(), newOnceTestAuth("prepare-fail")); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	_, facts, err := manager.ExecuteWithAuthOnce(context.Background(), onceRequest("prepare-fail"))
+	if err == nil {
+		t.Fatal("ExecuteWithAuthOnce() error = nil, want prepare failure")
+	}
+	if got := executor.prepareAuthCalls.Load(); got != 1 {
+		t.Fatalf("PrepareRequestAuth calls = %d, want 1", got)
+	}
+	if got := executor.executeCalls.Load(); got != 0 {
+		t.Fatalf("executor invocations = %d, want 0", got)
+	}
+	if facts.RequestWritten {
+		t.Fatal("facts.RequestWritten = true, want false when preparation failed")
+	}
+	results := hook.snapshot()
+	if len(results) != 1 {
+		t.Fatalf("MarkResult calls = %d, want 1", len(results))
+	}
+	if results[0].Success {
+		t.Fatal("Result.Success = true, want false for a preparation failure")
+	}
+}
+
+func TestManagerExecuteWithAuthOnce_InterceptorTerminationSkipsExecutorAndMarking(t *testing.T) {
+	executor := &onceTestExecutor{provider: "codex"}
+	manager, hook := newOnceTestManager(t, executor, newOnceTestAuth("terminated"))
+
+	in := onceRequest("terminated")
+	in.Options.RequestAfterAuthInterceptor = func(context.Context, cliproxyexecutor.RequestAfterAuthInterceptRequest) cliproxyexecutor.RequestAfterAuthInterceptResponse {
+		return cliproxyexecutor.RequestAfterAuthInterceptResponse{Terminate: true, StatusCode: http.StatusTeapot}
+	}
+
+	_, facts, err := manager.ExecuteWithAuthOnce(context.Background(), in)
+	var terminated *cliproxyexecutor.RequestTerminatedError
+	if !errors.As(err, &terminated) || terminated == nil {
+		t.Fatalf("ExecuteWithAuthOnce() error = %v, want *RequestTerminatedError", err)
+	}
+	if terminated.HTTPStatus != http.StatusTeapot {
+		t.Fatalf("terminated status = %d, want %d", terminated.HTTPStatus, http.StatusTeapot)
+	}
+	if got := executor.executeCalls.Load(); got != 0 {
+		t.Fatalf("executor invocations = %d, want 0", got)
+	}
+	if facts.RequestWritten {
+		t.Fatal("facts.RequestWritten = true, want false for an interceptor termination")
+	}
+	if got := len(hook.snapshot()); got != 0 {
+		t.Fatalf("MarkResult calls = %d, want 0", got)
+	}
+}
+
+func TestManagerExecuteWithAuthOnce_ModelPoolCollapsesToOneInvocation(t *testing.T) {
+	alias := "pooled-alias"
+	executor := &openAICompatPoolExecutor{
+		id:            openAICompatPoolProviderKey,
+		executeErrors: map[string]error{"pool-model-a": &onceStatusError{status: http.StatusInternalServerError, message: "boom"}},
+	}
+	manager := newOpenAICompatPoolTestManager(t, alias, []internalconfig.OpenAICompatibilityModel{
+		{Name: "pool-model-a", Alias: alias},
+		{Name: "pool-model-b", Alias: alias},
+	}, executor)
+
+	authID := "pool-auth-" + t.Name()
+	_, _, err := manager.ExecuteWithAuthOnce(context.Background(), ExecuteWithAuthOnceRequest{
+		AuthID:  authID,
+		Model:   alias,
+		Request: cliproxyexecutor.Request{Model: alias},
+		Options: cliproxyexecutor.Options{Metadata: map[string]any{}},
+	})
+	if err == nil {
+		t.Fatal("ExecuteWithAuthOnce() error = nil, want the first pooled model failure")
+	}
+	if got := executor.ExecuteModels(); len(got) != 1 {
+		t.Fatalf("pooled executor invocations = %v, want exactly one", got)
+	}
+}
+
+func TestManagerExecuteWithAuthOnce_ReportsAttemptFactsFromTransport(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("upstream"))
+	}))
+	defer server.Close()
+
+	executor := &onceTestExecutor{provider: "codex"}
+	executor.executeFunc = func(ctx context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+		transport, _ := ctx.Value("cliproxy.roundtripper").(http.RoundTripper)
+		if transport == nil {
+			return cliproxyexecutor.Response{}, errors.New("missing manager transport")
+		}
+		req, errNew := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+		if errNew != nil {
+			return cliproxyexecutor.Response{}, errNew
+		}
+		resp, errDo := (&http.Client{Transport: transport}).Do(req)
+		if errDo != nil {
+			return cliproxyexecutor.Response{}, errDo
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, _ := io.ReadAll(resp.Body)
+		return cliproxyexecutor.Response{Payload: body}, nil
+	}
+	manager, _ := newOnceTestManager(t, executor, newOnceTestAuth("facts-auth"))
+
+	resp, facts, err := manager.ExecuteWithAuthOnce(context.Background(), onceRequest("facts-auth"))
+	if err != nil {
+		t.Fatalf("ExecuteWithAuthOnce() error = %v", err)
+	}
+	if string(resp.Payload) != "upstream" {
+		t.Fatalf("response payload = %q, want %q", resp.Payload, "upstream")
+	}
+	if facts.RequestCount != 1 {
+		t.Fatalf("facts.RequestCount = %d, want 1", facts.RequestCount)
+	}
+	if !facts.RequestWritten || !facts.ResponseStarted {
+		t.Fatalf("facts = %+v, want request written and response started", facts)
+	}
+	if facts.StatusCode != http.StatusOK {
+		t.Fatalf("facts.StatusCode = %d, want %d", facts.StatusCode, http.StatusOK)
+	}
+}
+
+func TestManagerExecuteWithAuthOnce_ConcurrentCallsMarkOncePerCall(t *testing.T) {
+	executor := &onceTestExecutor{provider: "codex"}
+	manager, hook := newOnceTestManager(t, executor, newOnceTestAuth("concurrent-auth"))
+
+	const callers = 8
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			if _, _, err := manager.ExecuteWithAuthOnce(context.Background(), onceRequest("concurrent-auth")); err != nil {
+				t.Errorf("ExecuteWithAuthOnce() error = %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := executor.executeCalls.Load(); got != callers {
+		t.Fatalf("executor invocations = %d, want %d", got, callers)
+	}
+	if got := len(hook.snapshot()); got != callers {
+		t.Fatalf("MarkResult calls = %d, want %d", got, callers)
+	}
+}
+
+// onceRoundTripperFunc is a transport that ignores httptrace, standing in for a
+// host supplied RoundTripper.
+type onceRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f onceRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func onceHTTPRequest(t *testing.T, ctx context.Context, method, target string, body io.Reader) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, method, target, body)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	return req
+}
+
+func TestManagerDoHTTPOnce_MarksOnceAndOnlySucceedsOn2xx(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int
+		retryAfter  string
+		wantSuccess bool
+		wantRetry   bool
+	}{
+		{name: "ok", status: http.StatusOK, wantSuccess: true},
+		{name: "created", status: http.StatusCreated, wantSuccess: true},
+		{name: "found", status: http.StatusFound},
+		{name: "unauthorized", status: http.StatusUnauthorized},
+		{name: "request timeout", status: http.StatusRequestTimeout},
+		{name: "rate limited", status: http.StatusTooManyRequests, retryAfter: "30", wantRetry: true},
+		{name: "server error", status: http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tt.retryAfter != "" {
+					w.Header().Set("Retry-After", tt.retryAfter)
+				}
+				if tt.status == http.StatusFound {
+					w.Header().Set("Location", "/elsewhere")
+				}
+				w.WriteHeader(tt.status)
+			}))
+			defer server.Close()
+
+			executor := &onceTestExecutor{provider: "codex"}
+			manager, hook := newOnceTestManager(t, executor, newOnceTestAuth("http-once"))
+			auth := onceAuthByID(t, manager, "http-once")
+
+			resp, facts, errDo := manager.DoHTTPOnce(context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodPost, server.URL, strings.NewReader(`{}`)), HTTPRedirectDeny)
+			if errDo != nil {
+				t.Fatalf("DoHTTPOnce() error = %v", errDo)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != tt.status {
+				t.Fatalf("response status = %d, want %d", resp.StatusCode, tt.status)
+			}
+			if facts.StatusCode != tt.status {
+				t.Fatalf("facts.StatusCode = %d, want %d", facts.StatusCode, tt.status)
+			}
+			if facts.RequestCount != 1 {
+				t.Fatalf("facts.RequestCount = %d, want 1", facts.RequestCount)
+			}
+			if got := executor.prepareCalls.Load(); got != 1 {
+				t.Fatalf("credential injections = %d, want 1", got)
+			}
+			if got := executor.httpCalls.Load(); got != 0 {
+				t.Fatalf("executor HttpRequest calls = %d, want 0", got)
+			}
+			results := hook.snapshot()
+			if len(results) != 1 {
+				t.Fatalf("MarkResult calls = %d, want 1", len(results))
+			}
+			if results[0].Success != tt.wantSuccess {
+				t.Fatalf("Result.Success = %v, want %v", results[0].Success, tt.wantSuccess)
+			}
+			if tt.wantRetry && results[0].RetryAfter == nil {
+				t.Fatal("Result.RetryAfter = nil, want a parsed Retry-After hint")
+			}
+		})
+	}
+}
+
+func TestManagerDoHTTPOnce_DenyNeverFollowsRedirect(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		method string
+	}{
+		{name: "moved permanently", status: http.StatusMovedPermanently, method: http.MethodGet},
+		{name: "found", status: http.StatusFound, method: http.MethodGet},
+		{name: "see other", status: http.StatusSeeOther, method: http.MethodPost},
+		{name: "temporary redirect", status: http.StatusTemporaryRedirect, method: http.MethodPost},
+		{name: "permanent redirect", status: http.StatusPermanentRedirect, method: http.MethodPost},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var followed atomic.Int32
+			mux := http.NewServeMux()
+			mux.HandleFunc("/start", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Location", "/followed")
+				w.WriteHeader(tt.status)
+			})
+			mux.HandleFunc("/followed", func(w http.ResponseWriter, _ *http.Request) {
+				followed.Add(1)
+				w.WriteHeader(http.StatusOK)
+			})
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			executor := &onceTestExecutor{provider: "codex"}
+			manager, hook := newOnceTestManager(t, executor, newOnceTestAuth("redirect-deny"))
+			auth := onceAuthByID(t, manager, "redirect-deny")
+
+			var body io.Reader
+			if tt.method != http.MethodGet {
+				body = strings.NewReader(`{"paid":true}`)
+			}
+			resp, facts, errDo := manager.DoHTTPOnce(context.Background(), auth, onceHTTPRequest(t, context.Background(), tt.method, server.URL+"/start", body), HTTPRedirectDeny)
+			if errDo != nil {
+				t.Fatalf("DoHTTPOnce() error = %v", errDo)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != tt.status {
+				t.Fatalf("response status = %d, want the unfollowed %d", resp.StatusCode, tt.status)
+			}
+			if got := followed.Load(); got != 0 {
+				t.Fatalf("redirect target hits = %d, want 0", got)
+			}
+			if facts.RequestCount != 1 {
+				t.Fatalf("facts.RequestCount = %d, want 1 for a paid request", facts.RequestCount)
+			}
+			results := hook.snapshot()
+			if len(results) != 1 || results[0].Success {
+				t.Fatalf("results = %+v, want exactly one unsuccessful result", results)
+			}
+		})
+	}
+}
+
+func TestManagerDoHTTPOnce_EmptyPolicyDefaultsToDeny(t *testing.T) {
+	var followed atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/start", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "/followed")
+		w.WriteHeader(http.StatusFound)
+	})
+	mux.HandleFunc("/followed", func(w http.ResponseWriter, _ *http.Request) {
+		followed.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	manager, _ := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, newOnceTestAuth("redirect-default"))
+	auth := onceAuthByID(t, manager, "redirect-default")
+
+	resp, facts, errDo := manager.DoHTTPOnce(context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodGet, server.URL+"/start", nil), "")
+	if errDo != nil {
+		t.Fatalf("DoHTTPOnce() error = %v", errDo)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("response status = %d, want %d", resp.StatusCode, http.StatusFound)
+	}
+	if got := followed.Load(); got != 0 {
+		t.Fatalf("redirect target hits = %d, want 0", got)
+	}
+	if facts.RequestCount != 1 {
+		t.Fatalf("facts.RequestCount = %d, want 1", facts.RequestCount)
+	}
+}
+
+func TestManagerDoHTTPOnce_InvalidRedirectPolicyIsRejected(t *testing.T) {
+	manager, hook := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, newOnceTestAuth("bad-policy"))
+	auth := onceAuthByID(t, manager, "bad-policy")
+
+	_, facts, errDo := manager.DoHTTPOnce(context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodGet, "https://example.invalid/", nil), HTTPRedirectPolicy("follow-everything"))
+	var authErr *Error
+	if !errors.As(errDo, &authErr) || authErr == nil || authErr.Code != "invalid_redirect_policy" {
+		t.Fatalf("DoHTTPOnce() error = %v, want invalid_redirect_policy", errDo)
+	}
+	if facts.RequestWritten || facts.RequestCount != 0 {
+		t.Fatalf("facts = %+v, want an undispatched attempt", facts)
+	}
+	if got := len(hook.snapshot()); got != 0 {
+		t.Fatalf("MarkResult calls = %d, want 0", got)
+	}
+}
+
+// newOnceTLSContext returns a context carrying the transport that trusts the
+// supplied TLS test server, which is how the manager reaches an https origin in
+// tests without weakening certificate verification.
+func newOnceTLSContext(server *httptest.Server) context.Context {
+	return context.WithValue(context.Background(), "cliproxy.roundtripper", server.Client().Transport)
+}
+
+func TestManagerDoHTTPOnce_SameOriginSafeFollowsOnlySafeRedirects(t *testing.T) {
+	tests := []struct {
+		name          string
+		method        string
+		withBody      bool
+		location      func(server *httptest.Server) string
+		wantStatus    int
+		wantFollowed  int32
+		wantRequests  uint32
+		wantSucceeded bool
+	}{
+		{
+			name:          "same origin get is followed",
+			method:        http.MethodGet,
+			location:      func(*httptest.Server) string { return "/followed" },
+			wantStatus:    http.StatusOK,
+			wantFollowed:  1,
+			wantRequests:  2,
+			wantSucceeded: true,
+		},
+		{
+			name:         "cross origin is refused",
+			method:       http.MethodGet,
+			location:     func(*httptest.Server) string { return "https://redirect-target.invalid/followed" },
+			wantStatus:   http.StatusFound,
+			wantFollowed: 0,
+			wantRequests: 1,
+		},
+		{
+			name:         "post is refused",
+			method:       http.MethodPost,
+			withBody:     true,
+			location:     func(*httptest.Server) string { return "/followed" },
+			wantStatus:   http.StatusTemporaryRedirect,
+			wantFollowed: 0,
+			wantRequests: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var followed atomic.Int32
+			var followedAuth atomic.Value
+			followedAuth.Store("")
+			mux := http.NewServeMux()
+			var server *httptest.Server
+			mux.HandleFunc("/start", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Location", tt.location(server))
+				if r.Method == http.MethodGet {
+					w.WriteHeader(http.StatusFound)
+					return
+				}
+				w.WriteHeader(http.StatusTemporaryRedirect)
+			})
+			mux.HandleFunc("/followed", func(w http.ResponseWriter, r *http.Request) {
+				followed.Add(1)
+				followedAuth.Store(r.Header.Get("Authorization") + "|" + r.Header.Get("X-Api-Key"))
+				w.WriteHeader(http.StatusOK)
+			})
+			server = httptest.NewTLSServer(mux)
+			defer server.Close()
+
+			manager, hook := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, newOnceTestAuth("same-origin"))
+			auth := onceAuthByID(t, manager, "same-origin")
+
+			ctx := newOnceTLSContext(server)
+			var body io.Reader
+			if tt.withBody {
+				body = strings.NewReader(`{"paid":true}`)
+			}
+			resp, facts, errDo := manager.DoHTTPOnce(ctx, auth, onceHTTPRequest(t, ctx, tt.method, server.URL+"/start", body), HTTPRedirectSameOriginSafe)
+			if errDo != nil {
+				t.Fatalf("DoHTTPOnce() error = %v", errDo)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != tt.wantStatus {
+				t.Fatalf("response status = %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+			if got := followed.Load(); got != tt.wantFollowed {
+				t.Fatalf("redirect target hits = %d, want %d", got, tt.wantFollowed)
+			}
+			if facts.RequestCount != tt.wantRequests {
+				t.Fatalf("facts.RequestCount = %d, want %d", facts.RequestCount, tt.wantRequests)
+			}
+			if tt.wantFollowed > 0 {
+				if got, _ := followedAuth.Load().(string); got != "|" {
+					t.Fatalf("credential headers on the followed hop = %q, want them stripped", got)
+				}
+			}
+			results := hook.snapshot()
+			if len(results) != 1 {
+				t.Fatalf("MarkResult calls = %d, want 1", len(results))
+			}
+			if results[0].Success != tt.wantSucceeded {
+				t.Fatalf("Result.Success = %v, want %v", results[0].Success, tt.wantSucceeded)
+			}
+		})
+	}
+}
+
+func TestManagerDoHTTPOnce_SameOriginSafeStopsAtThreeHops(t *testing.T) {
+	var final atomic.Int32
+	mux := http.NewServeMux()
+	for _, hop := range []struct{ from, to string }{
+		{"/hop1", "/hop2"},
+		{"/hop2", "/hop3"},
+		{"/hop3", "/hop4"},
+		{"/hop4", "/final"},
+	} {
+		target := hop.to
+		mux.HandleFunc(hop.from, func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Location", target)
+			w.WriteHeader(http.StatusFound)
+		})
+	}
+	mux.HandleFunc("/final", func(w http.ResponseWriter, _ *http.Request) {
+		final.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	manager, _ := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, newOnceTestAuth("hops"))
+	auth := onceAuthByID(t, manager, "hops")
+
+	ctx := newOnceTLSContext(server)
+	resp, facts, errDo := manager.DoHTTPOnce(ctx, auth, onceHTTPRequest(t, ctx, http.MethodGet, server.URL+"/hop1", nil), HTTPRedirectSameOriginSafe)
+	if errDo != nil {
+		t.Fatalf("DoHTTPOnce() error = %v", errDo)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("response status = %d, want the unfollowed %d", resp.StatusCode, http.StatusFound)
+	}
+	if got := final.Load(); got != 0 {
+		t.Fatalf("final target hits = %d, want 0", got)
+	}
+	if facts.RequestCount != uint32(maxSameOriginSafeRedirectHops+1) {
+		t.Fatalf("facts.RequestCount = %d, want %d", facts.RequestCount, maxSameOriginSafeRedirectHops+1)
+	}
+}
+
+func TestManagerDoHTTPOnce_AttemptFacts(t *testing.T) {
+	t.Run("clean response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("done"))
+		}))
+		defer server.Close()
+
+		manager, _ := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, newOnceTestAuth("facts-clean"))
+		auth := onceAuthByID(t, manager, "facts-clean")
+
+		resp, facts, err := manager.DoHTTPOnce(context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodGet, server.URL, nil), HTTPRedirectDeny)
+		if err != nil {
+			t.Fatalf("DoHTTPOnce() error = %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if !facts.RequestWritten || !facts.ResponseStarted || facts.StatusCode != http.StatusOK || facts.RequestCount != 1 {
+			t.Fatalf("facts = %+v, want a written request with a started 200 response", facts)
+		}
+	})
+
+	t.Run("connection refused", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		target := server.URL
+		server.Close()
+
+		manager, hook := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, newOnceTestAuth("facts-refused"))
+		auth := onceAuthByID(t, manager, "facts-refused")
+
+		resp, facts, err := manager.DoHTTPOnce(context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodPost, target, strings.NewReader(`{}`)), HTTPRedirectDeny)
+		if err == nil {
+			if resp != nil {
+				_ = resp.Body.Close()
+			}
+			t.Fatal("DoHTTPOnce() error = nil, want a transport failure")
+		}
+		if facts.RequestWritten {
+			t.Fatalf("facts.RequestWritten = true, want false when the connection was refused")
+		}
+		if facts.ResponseStarted {
+			t.Fatalf("facts.ResponseStarted = true, want false when the connection was refused")
+		}
+		results := hook.snapshot()
+		if len(results) != 1 || results[0].Success {
+			t.Fatalf("results = %+v, want exactly one unsuccessful result", results)
+		}
+	})
+
+	t.Run("truncated body", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				t.Errorf("response writer is not a hijacker")
+				return
+			}
+			conn, buf, errHijack := hijacker.Hijack()
+			if errHijack != nil {
+				t.Errorf("hijack: %v", errHijack)
+				return
+			}
+			_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 128\r\n\r\npartial")
+			_ = buf.Flush()
+			_ = conn.Close()
+		}))
+		defer server.Close()
+
+		manager, _ := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, newOnceTestAuth("facts-truncated"))
+		auth := onceAuthByID(t, manager, "facts-truncated")
+
+		resp, facts, err := manager.DoHTTPOnce(context.Background(), auth, onceHTTPRequest(t, context.Background(), http.MethodGet, server.URL, nil), HTTPRedirectDeny)
+		if err != nil {
+			t.Fatalf("DoHTTPOnce() error = %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if _, errRead := io.ReadAll(resp.Body); errRead == nil {
+			t.Fatal("body read error = nil, want a truncated body failure")
+		}
+		if !facts.RequestWritten || !facts.ResponseStarted {
+			t.Fatalf("facts = %+v, want a written request with a started response", facts)
+		}
+		if facts.StatusCode != http.StatusOK {
+			t.Fatalf("facts.StatusCode = %d, want %d", facts.StatusCode, http.StatusOK)
+		}
+	})
+
+	t.Run("opaque transport reports ambiguity as written", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", onceRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("opaque transport failure")
+		}))
+
+		manager, _ := newOnceTestManager(t, &onceTestExecutor{provider: "codex"}, newOnceTestAuth("facts-opaque"))
+		auth := onceAuthByID(t, manager, "facts-opaque")
+
+		_, facts, err := manager.DoHTTPOnce(ctx, auth, onceHTTPRequest(t, ctx, http.MethodPost, "https://example.invalid/create", strings.NewReader(`{}`)), HTTPRedirectDeny)
+		if err == nil {
+			t.Fatal("DoHTTPOnce() error = nil, want the transport failure")
+		}
+		if !facts.RequestWritten {
+			t.Fatal("facts.RequestWritten = false, want true when the transport reports nothing")
+		}
+		if facts.ResponseStarted {
+			t.Fatal("facts.ResponseStarted = true, want false")
+		}
+	})
+}
+
+func TestManagerHTTPOnce_ResolvesDurableAuthAndPreparesBeforeDispatch(t *testing.T) {
+	var seenKey atomic.Value
+	seenKey.Store("")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenKey.Store(r.Header.Get("X-Api-Key"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	executor := &onceTestExecutor{provider: "codex"}
+	manager, hook := newOnceTestManager(t, executor, newOnceTestAuth("http-once-id"))
+
+	resp, facts, err := manager.HTTPOnce(context.Background(), HTTPOnceRequest{
+		AuthID:         "http-once-id",
+		Model:          "test-model",
+		Method:         http.MethodPost,
+		URL:            server.URL,
+		Header:         http.Header{"Content-Type": {"application/json"}},
+		Body:           []byte(`{"paid":true}`),
+		RedirectPolicy: HTTPRedirectDeny,
+	})
+	if err != nil {
+		t.Fatalf("HTTPOnce() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if got, _ := seenKey.Load().(string); got != "secret-key" {
+		t.Fatalf("injected api key = %q, want %q", got, "secret-key")
+	}
+	if facts.RequestCount != 1 {
+		t.Fatalf("facts.RequestCount = %d, want 1", facts.RequestCount)
+	}
+	results := hook.snapshot()
+	if len(results) != 1 || !results[0].Success || results[0].Model != "test-model" {
+		t.Fatalf("results = %+v, want one successful result for test-model", results)
+	}
+}
+
+func TestManagerHTTPOnce_PreflightFailuresNeverDispatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		request  HTTPOnceRequest
+		setup    func(manager *Manager)
+		wantCode string
+	}{
+		{name: "unknown auth", request: HTTPOnceRequest{AuthID: "missing", URL: "https://example.invalid/"}, wantCode: "auth_not_found"},
+		{name: "empty url", request: HTTPOnceRequest{AuthID: "http-once-preflight"}, wantCode: "invalid_request"},
+		{name: "invalid policy", request: HTTPOnceRequest{AuthID: "http-once-preflight", URL: "https://example.invalid/", RedirectPolicy: "always"}, wantCode: "invalid_redirect_policy"},
+		{
+			name:    "home mode",
+			request: HTTPOnceRequest{AuthID: "http-once-preflight", URL: "https://example.invalid/"},
+			setup: func(manager *Manager) {
+				manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			},
+			wantCode: "auth_not_durable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &onceTestExecutor{provider: "codex"}
+			manager, hook := newOnceTestManager(t, executor, newOnceTestAuth("http-once-preflight"))
+			if tt.setup != nil {
+				tt.setup(manager)
+			}
+
+			_, facts, err := manager.HTTPOnce(context.Background(), tt.request)
+			var authErr *Error
+			if !errors.As(err, &authErr) || authErr == nil {
+				t.Fatalf("HTTPOnce() error = %v, want *Error", err)
+			}
+			if authErr.Code != tt.wantCode {
+				t.Fatalf("error code = %q, want %q", authErr.Code, tt.wantCode)
+			}
+			if facts.RequestWritten || facts.RequestCount != 0 {
+				t.Fatalf("facts = %+v, want an undispatched attempt", facts)
+			}
+			if got := executor.prepareCalls.Load(); got != 0 {
+				t.Fatalf("credential injections = %d, want 0", got)
+			}
+			if got := len(hook.snapshot()); got != 0 {
+				t.Fatalf("MarkResult calls = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestStripSensitiveRedirectHeaders(t *testing.T) {
+	tests := []struct {
+		name   string
+		header http.Header
+		want   []string
+	}{
+		{
+			name:   "standard credential headers",
+			header: http.Header{"Authorization": {"Bearer x"}, "Cookie": {"a=b"}, "Proxy-Authorization": {"Basic x"}, "Accept": {"application/json"}},
+			want:   []string{"Accept"},
+		},
+		{
+			name:   "provider key headers",
+			header: http.Header{"X-Api-Key": {"k"}, "Api-Key": {"k"}, "X-Goog-Api-Key": {"k"}, "Content-Type": {"application/json"}},
+			want:   []string{"Content-Type"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stripSensitiveRedirectHeaders(tt.header)
+			if len(tt.header) != len(tt.want) {
+				t.Fatalf("remaining headers = %v, want %v", tt.header, tt.want)
+			}
+			for _, name := range tt.want {
+				if tt.header.Get(name) == "" {
+					t.Fatalf("header %q was stripped, want it kept", name)
+				}
+			}
+		})
+	}
+}
+
+func TestSameOriginSafeRedirectAllowed(t *testing.T) {
+	origin := func(method, raw string, hasBody bool) *redirectOrigin {
+		req := onceHTTPRequest(t, context.Background(), method, raw, nil)
+		snapshot := newRedirectOrigin(req)
+		snapshot.hasBody = hasBody
+		return snapshot
+	}
+
+	tests := []struct {
+		name   string
+		policy HTTPRedirectPolicy
+		origin *redirectOrigin
+		target string
+		hop    int
+		want   bool
+	}{
+		{name: "deny never follows", policy: HTTPRedirectDeny, origin: origin(http.MethodGet, "https://api.example.com/a", false), target: "https://api.example.com/b", hop: 1},
+		{name: "same origin get", policy: HTTPRedirectSameOriginSafe, origin: origin(http.MethodGet, "https://api.example.com/a", false), target: "https://api.example.com/b", hop: 1, want: true},
+		{name: "relative location", policy: HTTPRedirectSameOriginSafe, origin: origin(http.MethodHead, "https://api.example.com/a", false), target: "/b", hop: 1, want: true},
+		{name: "cross host", policy: HTTPRedirectSameOriginSafe, origin: origin(http.MethodGet, "https://api.example.com/a", false), target: "https://cdn.example.com/b", hop: 1},
+		{name: "downgrade to http", policy: HTTPRedirectSameOriginSafe, origin: origin(http.MethodGet, "https://api.example.com/a", false), target: "http://api.example.com/b", hop: 1},
+		{name: "insecure origin", policy: HTTPRedirectSameOriginSafe, origin: origin(http.MethodGet, "http://api.example.com/a", false), target: "http://api.example.com/b", hop: 1},
+		{name: "post", policy: HTTPRedirectSameOriginSafe, origin: origin(http.MethodPost, "https://api.example.com/a", false), target: "https://api.example.com/b", hop: 1},
+		{name: "body bearing get", policy: HTTPRedirectSameOriginSafe, origin: origin(http.MethodGet, "https://api.example.com/a", true), target: "https://api.example.com/b", hop: 1},
+		{name: "hop limit", policy: HTTPRedirectSameOriginSafe, origin: origin(http.MethodGet, "https://api.example.com/a", false), target: "https://api.example.com/b", hop: maxSameOriginSafeRedirectHops + 1},
+		{name: "unknown policy", policy: HTTPRedirectPolicy("loose"), origin: origin(http.MethodGet, "https://api.example.com/a", false), target: "https://api.example.com/b", hop: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sameOriginSafeRedirectAllowed(tt.policy, tt.origin, tt.target, tt.hop); got != tt.want {
+				t.Fatalf("sameOriginSafeRedirectAllowed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOnceAttemptRecorderFacts(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(recorder *onceAttemptRecorder)
+		want    HTTPAttemptFacts
+	}{
+		{
+			name:    "never dispatched",
+			prepare: func(*onceAttemptRecorder) {},
+			want:    HTTPAttemptFacts{},
+		},
+		{
+			name: "dispatched without observation is ambiguous",
+			prepare: func(recorder *onceAttemptRecorder) {
+				recorder.markDispatched()
+			},
+			want: HTTPAttemptFacts{RequestWritten: true},
+		},
+		{
+			name: "trace observed without write",
+			prepare: func(recorder *onceAttemptRecorder) {
+				recorder.markDispatched()
+				recorder.clientTrace().ConnectStart("tcp", "host:443")
+			},
+			want: HTTPAttemptFacts{},
+		},
+		{
+			name: "trace observed with write",
+			prepare: func(recorder *onceAttemptRecorder) {
+				recorder.markDispatched()
+				trace := recorder.clientTrace()
+				trace.WroteHeaders()
+				trace.GotFirstResponseByte()
+			},
+			want: HTTPAttemptFacts{RequestCount: 1, RequestWritten: true, ResponseStarted: true},
+		},
+		{
+			name: "transport observed",
+			prepare: func(recorder *onceAttemptRecorder) {
+				recorder.markDispatched()
+				recorder.observeRequest()
+				recorder.observeResponse(http.StatusTooManyRequests)
+			},
+			want: HTTPAttemptFacts{RequestCount: 1, RequestWritten: true, ResponseStarted: true, StatusCode: http.StatusTooManyRequests},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := newOnceAttemptRecorder()
+			tt.prepare(recorder)
+			if got := recorder.facts(); got != tt.want {
+				t.Fatalf("facts() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1021,10 +1021,11 @@ func (m *Manager) findAllAntigravityCreditsCandidateAuths(ctx context.Context, r
 	}
 	m.mu.RUnlock()
 
-	candidates = narrowCreditsCandidatesToLowestRank(candidateSet, candidates)
-
-	var known []creditsCandidateEntry
-	var unknown []creditsCandidateEntry
+	// Credit availability is part of eligibility. Filter known-unavailable
+	// credentials before choosing the lowest surviving request-scoped rank, so
+	// an exhausted lower rank cannot hide an eligible higher-ranked fallback.
+	knownAvailable := make(map[string]bool, len(candidates))
+	eligible := make([]creditsCandidateEntry, 0, len(candidates))
 	for _, candidate := range candidates {
 		hint, okHint, errHint := GetAntigravityCreditsHintRequired(ctx, candidate.auth.ID)
 		if errHint != nil {
@@ -1034,6 +1035,16 @@ func (m *Manager) findAllAntigravityCreditsCandidateAuths(ctx context.Context, r
 			if !hint.Available {
 				continue
 			}
+			knownAvailable[candidate.auth.ID] = true
+		}
+		eligible = append(eligible, candidate)
+	}
+	eligible = narrowCreditsCandidatesToLowestRank(candidateSet, eligible)
+
+	var known []creditsCandidateEntry
+	var unknown []creditsCandidateEntry
+	for _, candidate := range eligible {
+		if knownAvailable[candidate.auth.ID] {
 			known = append(known, candidate)
 			continue
 		}

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -708,6 +708,11 @@ func (m *Manager) pickNextViaHome(ctx context.Context, model string, opts clipro
 	if m == nil {
 		return nil, nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
+	// Defensive: Home dispatch cannot honour a ranked candidate list, so fail closed here as
+	// well as in pickHomeDispatchSelection to keep the intent local to every selection funnel.
+	if errCandidates := homeRankedCandidateGuard(opts); errCandidates != nil {
+		return nil, nil, "", errCandidates
+	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -730,6 +735,11 @@ func (m *Manager) pickNextViaHome(ctx context.Context, model string, opts clipro
 func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, opts cliproxyexecutor.Options) (*HomeDispatchSelection, error) {
 	if m == nil {
 		return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
+	}
+	// Home selects remotely and exposes no local candidate filter, so a ranked request fails
+	// closed before session retention, before BeginDispatch, and before any remote dispatch.
+	if errCandidates := homeRankedCandidateGuard(opts); errCandidates != nil {
+		return nil, errCandidates
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -974,6 +984,10 @@ func (m *Manager) findAllAntigravityCreditsCandidateAuths(ctx context.Context, r
 		return nil, nil
 	}
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
+	candidateSet, errCandidates := authSelectionCandidatesFromMetadata(opts.Metadata)
+	if errCandidates != nil {
+		return nil, errCandidates
+	}
 	var candidates []creditsCandidateEntry
 	m.mu.RLock()
 	for _, auth := range m.auths {
@@ -981,6 +995,11 @@ func (m *Manager) findAllAntigravityCreditsCandidateAuths(ctx context.Context, r
 			continue
 		}
 		if pinnedAuthID != "" && auth.ID != pinnedAuthID {
+			continue
+		}
+		// This fallback path has no eligibility filter of its own; the request-scoped candidate
+		// list must still hold so a ranked request never executes on an unlisted credential.
+		if !candidateSet.allows(auth.ID) {
 			continue
 		}
 		if !strings.EqualFold(strings.TrimSpace(auth.Provider), "antigravity") {
@@ -1001,6 +1020,8 @@ func (m *Manager) findAllAntigravityCreditsCandidateAuths(ctx context.Context, r
 		})
 	}
 	m.mu.RUnlock()
+
+	candidates = narrowCreditsCandidatesToLowestRank(candidateSet, candidates)
 
 	var known []creditsCandidateEntry
 	var unknown []creditsCandidateEntry

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1039,24 +1039,27 @@ func (m *Manager) findAllAntigravityCreditsCandidateAuths(ctx context.Context, r
 		}
 		eligible = append(eligible, candidate)
 	}
-	eligible = narrowCreditsCandidatesToLowestRank(candidateSet, eligible)
-
-	var known []creditsCandidateEntry
-	var unknown []creditsCandidateEntry
-	for _, candidate := range eligible {
-		if knownAvailable[candidate.auth.ID] {
-			known = append(known, candidate)
-			continue
+	// Preserve the full eligible rank ladder. The caller attempts candidates in
+	// this order, so retaining higher ranks lets it advance after every candidate
+	// in a lower rank has failed. Within one rank, a known-available credit hint
+	// precedes an unknown hint; auth ID is only a deterministic tie-breaker.
+	sort.Slice(eligible, func(i, j int) bool {
+		leftRank, rightRank := uint32(0), uint32(0)
+		if candidateSet != nil {
+			leftRank, _ = candidateSet.rankFor(eligible[i].auth.ID)
+			rightRank, _ = candidateSet.rankFor(eligible[j].auth.ID)
 		}
-		unknown = append(unknown, candidate)
-	}
-	sort.Slice(known, func(i, j int) bool {
-		return known[i].auth.ID < known[j].auth.ID
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		leftKnown := knownAvailable[eligible[i].auth.ID]
+		rightKnown := knownAvailable[eligible[j].auth.ID]
+		if leftKnown != rightKnown {
+			return leftKnown
+		}
+		return eligible[i].auth.ID < eligible[j].auth.ID
 	})
-	sort.Slice(unknown, func(i, j int) bool {
-		return unknown[i].auth.ID < unknown[j].auth.ID
-	})
-	return append(known, unknown...), nil
+	return eligible, nil
 }
 
 type creditsCandidateEntry struct {

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -10,6 +10,10 @@ import (
 )
 
 func (m *Manager) executeHome(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, countTokens bool) (cliproxyexecutor.Response, error) {
+	// Fail closed before the dispatch loop starts: Home cannot honour ranked auth candidates.
+	if errCandidates := homeRankedCandidateGuard(opts); errCandidates != nil {
+		return cliproxyexecutor.Response{}, errCandidates
+	}
 	if unlockSession := m.lockHomeWebsocketSession(ctx, opts); unlockSession != nil {
 		defer unlockSession()
 	}

--- a/sdk/cliproxy/auth/conductor_ranked_once_test.go
+++ b/sdk/cliproxy/auth/conductor_ranked_once_test.go
@@ -1,0 +1,212 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// rankedOnceSelectionModel is the route model used while selecting. It is empty on
+// purpose: per-model routing is driven by the global model registry, which is
+// orthogonal to this composition, so an empty route model keeps every registered
+// credential eligible and leaves the ranked candidate list as the only filter.
+const rankedOnceSelectionModel = ""
+
+// newRankedOnceTestManager registers one counting executor and a set of auths so a
+// ranked selection and a pinned one-shot execution can be observed on one manager.
+func newRankedOnceTestManager(t *testing.T, executor *onceTestExecutor, auths ...*Auth) (*Manager, *onceResultHook) {
+	t.Helper()
+	hook := &onceResultHook{}
+	manager := NewManager(nil, &RoundRobinSelector{}, hook)
+	// A generous retry budget proves the one-shot path never consults it.
+	manager.SetRetryConfig(5, time.Second, 5)
+	manager.RegisterExecutor(executor)
+	for _, auth := range auths {
+		if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+			t.Fatalf("Register(%s) error = %v", auth.ID, errRegister)
+		}
+	}
+	return manager, hook
+}
+
+// TestRankedSelectionComposesWithExecuteWithAuthOnce walks the whole contribution end
+// to end: a request-scoped ranked candidate list picks the credential, that exact
+// credential is then executed by the pinned one-shot path, the provider executor is
+// entered exactly once, and exactly one execution result is marked against it.
+func TestRankedSelectionComposesWithExecuteWithAuthOnce(t *testing.T) {
+	tests := []struct {
+		name           string
+		disableLowRank bool
+		wantAuthID     string
+	}{
+		{
+			name:       "lowest eligible rank wins and is the credential executed once",
+			wantAuthID: "once-rank-low",
+		},
+		{
+			name:           "next rank is executed once only when the lowest rank is ineligible",
+			disableLowRank: true,
+			wantAuthID:     "once-rank-high",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &onceTestExecutor{provider: "codex"}
+			manager, hook := newRankedOnceTestManager(t, executor,
+				&Auth{ID: "once-rank-low", Provider: "codex", Status: StatusActive, Disabled: tt.disableLowRank},
+				&Auth{ID: "once-rank-high", Provider: "codex", Status: StatusActive},
+				&Auth{ID: "once-unlisted", Provider: "codex", Status: StatusActive},
+			)
+			opts := rankedCandidateOptions(
+				cliproxyexecutor.AuthSelectionCandidate{AuthID: "once-rank-low", PriorityRank: 0, StableOrder: 0},
+				cliproxyexecutor.AuthSelectionCandidate{AuthID: "once-rank-high", PriorityRank: 1, StableOrder: 0},
+			)
+
+			selected, errSelect := manager.SelectAuth(context.Background(), "codex", rankedOnceSelectionModel, opts)
+			if errSelect != nil {
+				t.Fatalf("SelectAuth() error = %v", errSelect)
+			}
+			if selected.ID != tt.wantAuthID {
+				t.Fatalf("SelectAuth() auth id = %q, want %q", selected.ID, tt.wantAuthID)
+			}
+
+			// The caller hands the ranked winner straight to the pinned one-shot path.
+			// The candidate metadata rides along untouched to prove it is inert there:
+			// ExecuteWithAuthOnce never selects, so it neither re-ranks nor re-picks.
+			in := onceRequest(selected.ID)
+			in.Options = opts
+			resp, facts, errExec := manager.ExecuteWithAuthOnce(context.Background(), in)
+			if errExec != nil {
+				t.Fatalf("ExecuteWithAuthOnce() error = %v", errExec)
+			}
+			if got := string(resp.Payload); got != "ok" {
+				t.Fatalf("ExecuteWithAuthOnce() payload = %q, want %q", got, "ok")
+			}
+			if !facts.RequestWritten {
+				t.Fatalf("HTTPAttemptFacts.RequestWritten = false, want true")
+			}
+
+			if got := executor.executeCalls.Load(); got != 1 {
+				t.Fatalf("executor invocations = %d, want 1", got)
+			}
+			if got := executor.models(); len(got) != 1 || got[0] != "test-model" {
+				t.Fatalf("executed models = %#v, want [test-model]", got)
+			}
+
+			results := hook.snapshot()
+			if len(results) != 1 {
+				t.Fatalf("MarkResult calls = %d, want 1; results=%#v", len(results), results)
+			}
+			if results[0].AuthID != tt.wantAuthID {
+				t.Fatalf("marked auth id = %q, want %q", results[0].AuthID, tt.wantAuthID)
+			}
+			if results[0].Provider != "codex" {
+				t.Fatalf("marked provider = %q, want %q", results[0].Provider, "codex")
+			}
+			if results[0].Model != "test-model" {
+				t.Fatalf("marked model = %q, want %q", results[0].Model, "test-model")
+			}
+			if !results[0].Success {
+				t.Fatalf("marked success = false, want true")
+			}
+		})
+	}
+}
+
+// TestRankedSelectionNeverFeedsAnUnlistedCredentialToExecuteOnce pins the negative
+// half of the composition: a credential outside the candidate list is never the
+// ranked winner, so the paid one-shot execution can never land on it.
+func TestRankedSelectionNeverFeedsAnUnlistedCredentialToExecuteOnce(t *testing.T) {
+	executor := &onceTestExecutor{provider: "codex"}
+	manager, hook := newRankedOnceTestManager(t, executor,
+		&Auth{ID: "once-listed", Provider: "codex", Status: StatusActive},
+		&Auth{ID: "once-unlisted", Provider: "codex", Status: StatusActive},
+	)
+	opts := rankedCandidateOptions(
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "once-listed", PriorityRank: 0, StableOrder: 0},
+	)
+
+	for index := 0; index < 8; index++ {
+		selected, errSelect := manager.SelectAuth(context.Background(), "codex", rankedOnceSelectionModel, opts)
+		if errSelect != nil {
+			t.Fatalf("SelectAuth() #%d error = %v", index, errSelect)
+		}
+		if selected.ID != "once-listed" {
+			t.Fatalf("SelectAuth() #%d auth id = %q, want %q", index, selected.ID, "once-listed")
+		}
+		in := onceRequest(selected.ID)
+		in.Options = opts
+		if _, _, errExec := manager.ExecuteWithAuthOnce(context.Background(), in); errExec != nil {
+			t.Fatalf("ExecuteWithAuthOnce() #%d error = %v", index, errExec)
+		}
+	}
+
+	if got := executor.executeCalls.Load(); got != 8 {
+		t.Fatalf("executor invocations = %d, want 8 (one per call)", got)
+	}
+	results := hook.snapshot()
+	if len(results) != 8 {
+		t.Fatalf("MarkResult calls = %d, want 8 (one per call)", len(results))
+	}
+	for index, result := range results {
+		if result.AuthID != "once-listed" {
+			t.Fatalf("marked auth id #%d = %q, want %q", index, result.AuthID, "once-listed")
+		}
+	}
+}
+
+// TestRankedSelectionAndExecuteOnceShareTheHomeFailClosedContract keeps the two
+// primitives consistent under Home: ranked selection refuses before any remote
+// dispatch, and the pinned one-shot path refuses because Home credentials are not
+// manager persisted. Neither reaches an executor.
+func TestRankedSelectionAndExecuteOnceShareTheHomeFailClosedContract(t *testing.T) {
+	executor := &onceTestExecutor{provider: "codex"}
+	manager, hook := newRankedOnceTestManager(t, executor,
+		&Auth{ID: "once-home", Provider: "codex", Status: StatusActive},
+	)
+	dispatcher := &rankedHomeTestDispatcher{}
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+
+	opts := rankedCandidateOptions(
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "once-home", PriorityRank: 0, StableOrder: 0},
+	)
+	_, _, _, errPick := manager.pickNextMixed(context.Background(), []string{"codex"}, rankedOnceSelectionModel, opts, nil)
+	assertOnceErrorCode(t, errPick, "ranked_candidates_unsupported_in_home")
+
+	in := onceRequest("once-home")
+	in.Options = opts
+	_, facts, errExec := manager.ExecuteWithAuthOnce(context.Background(), in)
+	assertOnceErrorCode(t, errExec, "auth_not_durable")
+	if facts.RequestCount != 0 || facts.RequestWritten {
+		t.Fatalf("HTTPAttemptFacts = %#v, want a dispatch-free zero value", facts)
+	}
+
+	if got := executor.executeCalls.Load(); got != 0 {
+		t.Fatalf("executor invocations = %d, want 0", got)
+	}
+	if results := hook.snapshot(); len(results) != 0 {
+		t.Fatalf("MarkResult calls = %d, want 0; results=%#v", len(results), results)
+	}
+	if calls := dispatcher.dispatchCalls(); calls != 0 {
+		t.Fatalf("home dispatch calls = %d, want 0", calls)
+	}
+}
+
+// assertOnceErrorCode fails unless err is the package error type with the wanted code.
+func assertOnceErrorCode(t *testing.T, err error, want string) {
+	t.Helper()
+	var authErr *Error
+	if !errors.As(err, &authErr) {
+		t.Fatalf("error = %v (%T), want *Error with code %q", err, err, want)
+	}
+	if authErr.Code != want {
+		t.Fatalf("error code = %q, want %q", authErr.Code, want)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -509,12 +509,17 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 	defer lock.mu.Unlock()
 
 	m.mu.RLock()
-	auth := m.auths[id]
+	storedAuth := m.auths[id]
+	var auth *Auth
 	var exec ProviderExecutor
-	if auth != nil {
+	if storedAuth != nil {
+		// Clone while the manager lock protects the mutable stored auth. MarkResult
+		// updates that object in place, so cloning after unlock would race with
+		// concurrent request accounting.
+		auth = storedAuth.Clone()
 		// Use the same effective provider key as request execution so OpenAI-compat
 		// auths registered under namespaced keys still resolve for refresh.
-		exec = m.executors[executorKeyFromAuth(auth)]
+		exec = m.executors[executorKeyFromAuth(storedAuth)]
 	}
 	m.mu.RUnlock()
 	if auth == nil || exec == nil {

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -1083,7 +1083,6 @@ func (m *Manager) pickNextLegacyWithinRank(ctx context.Context, provider, model 
 		m.mu.RUnlock()
 		return nil, nil, &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
-	eligibility.candidates.sortCandidates(candidates)
 	available, selectorAuths, errAvailable := m.availableAuthsForSelector(selector, candidates, provider, model, time.Now())
 	if errAvailable != nil {
 		m.mu.RUnlock()
@@ -1422,7 +1421,6 @@ func (m *Manager) pickNextMixedLegacyWithinRank(ctx context.Context, providers [
 		m.mu.RUnlock()
 		return nil, nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
-	eligibility.candidates.sortCandidates(candidates)
 	available, selectorAuths, errAvailable := m.availableAuthsForSelector(selector, candidates, "mixed", model, time.Now())
 	if errAvailable != nil {
 		m.mu.RUnlock()

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -1135,6 +1135,35 @@ func (m *Manager) SelectAuth(ctx context.Context, provider, model string, opts c
 	return selected, nil
 }
 
+// SelectAuthMixed selects one credential through the configured scheduling
+// strategy across an explicit set of provider executor keys. The provider list
+// and any ranked-candidate metadata are request scoped; neither mutates global
+// auth priority or replaces the configured scheduler.
+//
+// This is the public mixed-provider counterpart of SelectAuth. It exists for
+// callers whose one semantic operation has compatible routes on more than one
+// provider and therefore cannot safely probe providers with multiple selection
+// calls. Exactly one mixed selection funnel is entered.
+func (m *Manager) SelectAuthMixed(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options) (*Auth, error) {
+	if m != nil && m.HomeEnabled() {
+		if errCandidates := homeRankedCandidateGuard(opts); errCandidates != nil {
+			return nil, errCandidates
+		}
+		return nil, &Error{Code: "home_unavailable", Message: "legacy auth selection is unavailable while Home is enabled", HTTPStatus: http.StatusServiceUnavailable}
+	}
+	selected, _, _, errPick := m.pickNextMixed(ctx, providers, model, opts, nil)
+	if errPick != nil {
+		return nil, errPick
+	}
+	if selected == nil {
+		return nil, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
+	}
+	if m.HomeEnabled() {
+		return nil, &Error{Code: "home_unavailable", Message: "legacy auth selection is unavailable while Home is enabled", HTTPStatus: http.StatusServiceUnavailable}
+	}
+	return selected, nil
+}
+
 // SelectAuthByKind selects one credential of the required kind through the
 // configured scheduling strategy. Credentials of other kinds are skipped.
 func (m *Manager) SelectAuthByKind(ctx context.Context, provider, model, requiredKind string, opts cliproxyexecutor.Options) (*Auth, error) {

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -56,6 +56,14 @@ type authSelectionEligibility struct {
 	requiredKind     string
 	credentialPolicy string
 	disallowFreeAuth bool
+	// candidates restricts selection to a request-scoped ranked candidate allow list.
+	candidates *rankedCandidateSet
+	// activeRank is the candidate rank the current selection attempt is restricted to.
+	activeRank uint32
+	// activeRankSet reports whether activeRank narrows the candidate list.
+	activeRankSet bool
+	// candidatesInvalid fails selection closed when candidate metadata is malformed.
+	candidatesInvalid bool
 }
 
 func withRequiredAuthKind(ctx context.Context, requiredKind string) context.Context {
@@ -80,11 +88,38 @@ func authSelectionEligibilityForRequest(ctx context.Context, opts cliproxyexecut
 		eligibility.requiredKind, _ = ctx.Value(requiredAuthKindContextKey{}).(string)
 		eligibility.credentialPolicy, _ = ctx.Value(credentialPolicyContextKey{}).(string)
 	}
+	eligibility.applyRankedCandidates(ctx, opts)
 	return eligibility
+}
+
+// applyRankedCandidates narrows the eligibility to the request-scoped ranked candidate list.
+// The active rank is read from the context first because the built-in scheduler and the
+// plugin delegation path re-derive eligibility from context and options rather than receiving it.
+func (e *authSelectionEligibility) applyRankedCandidates(ctx context.Context, opts cliproxyexecutor.Options) {
+	if active, ok := activeSelectionRankFromContext(ctx); ok {
+		e.candidates = active.candidates
+		e.activeRank = active.rank
+		e.activeRankSet = active.candidates != nil
+		return
+	}
+	set, errCandidates := authSelectionCandidatesFromMetadata(opts.Metadata)
+	if errCandidates != nil {
+		// The selection funnel reports the typed error; eligibility only fails closed so no
+		// path that skipped the funnel can widen selection past a malformed candidate list.
+		e.candidatesInvalid = true
+		return
+	}
+	e.candidates = set
 }
 
 func (e authSelectionEligibility) allows(auth *Auth) bool {
 	if auth == nil {
+		return false
+	}
+	if e.candidatesInvalid {
+		return false
+	}
+	if e.candidates != nil && !e.candidates.allowsAtRank(auth.ID, e.activeRank, e.activeRankSet) {
 		return false
 	}
 	if e.requiredKind != "" && auth.AuthKind() != e.requiredKind {
@@ -994,6 +1029,12 @@ func (m *Manager) routeAwareSelectionRequired(auth *Auth, routeModel string) boo
 }
 
 func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, error) {
+	return runRankedSingleSelection(ctx, opts, func(rankCtx context.Context) (*Auth, ProviderExecutor, error) {
+		return m.pickNextLegacyWithinRank(rankCtx, provider, model, opts, tried)
+	})
+}
+
+func (m *Manager) pickNextLegacyWithinRank(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, error) {
 	if m.HomeEnabled() {
 		auth, exec, _, err := m.pickNextViaHome(ctx, model, opts, tried)
 		return auth, exec, err
@@ -1042,6 +1083,7 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		m.mu.RUnlock()
 		return nil, nil, &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
+	eligibility.candidates.sortCandidates(candidates)
 	available, selectorAuths, errAvailable := m.availableAuthsForSelector(selector, candidates, provider, model, time.Now())
 	if errAvailable != nil {
 		m.mu.RUnlock()
@@ -1154,6 +1196,9 @@ func (m *Manager) SelectHomeAuthWithCredentialPolicy(ctx context.Context, provid
 	if m == nil || !m.HomeEnabled() {
 		return nil, &Error{Code: "home_unavailable", Message: "home control center unavailable", HTTPStatus: http.StatusServiceUnavailable}
 	}
+	if errCandidates := homeRankedCandidateGuard(opts); errCandidates != nil {
+		return nil, errCandidates
+	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -1203,6 +1248,9 @@ func (m *Manager) SelectHomeAuthByKind(ctx context.Context, provider string, mod
 	if m == nil || !m.HomeEnabled() {
 		return nil, &Error{Code: "home_unavailable", Message: "home control center unavailable", HTTPStatus: http.StatusServiceUnavailable}
 	}
+	if errCandidates := homeRankedCandidateGuard(opts); errCandidates != nil {
+		return nil, errCandidates
+	}
 
 	homeAuthCount := homeAuthCountFromMetadata(opts.Metadata)
 	tried := make(map[string]struct{})
@@ -1242,6 +1290,12 @@ func (m *Manager) SelectHomeAuthByKind(ctx context.Context, provider string, mod
 }
 
 func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, error) {
+	return runRankedSingleSelection(ctx, opts, func(rankCtx context.Context) (*Auth, ProviderExecutor, error) {
+		return m.pickNextWithinRank(rankCtx, provider, model, opts, tried)
+	})
+}
+
+func (m *Manager) pickNextWithinRank(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, error) {
 	if m.HomeEnabled() {
 		auth, exec, _, err := m.pickNextViaHome(ctx, model, opts, tried)
 		return auth, exec, err
@@ -1298,6 +1352,12 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 }
 
 func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, string, error) {
+	return runRankedMixedSelection(ctx, opts, func(rankCtx context.Context) (*Auth, ProviderExecutor, string, error) {
+		return m.pickNextMixedLegacyWithinRank(rankCtx, providers, model, opts, tried)
+	})
+}
+
+func (m *Manager) pickNextMixedLegacyWithinRank(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, string, error) {
 	if m.HomeEnabled() {
 		return m.pickNextViaHome(ctx, model, opts, tried)
 	}
@@ -1362,6 +1422,7 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		m.mu.RUnlock()
 		return nil, nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
+	eligibility.candidates.sortCandidates(candidates)
 	available, selectorAuths, errAvailable := m.availableAuthsForSelector(selector, candidates, "mixed", model, time.Now())
 	if errAvailable != nil {
 		m.mu.RUnlock()
@@ -1404,6 +1465,12 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 }
 
 func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, string, error) {
+	return runRankedMixedSelection(ctx, opts, func(rankCtx context.Context) (*Auth, ProviderExecutor, string, error) {
+		return m.pickNextMixedWithinRank(rankCtx, providers, model, opts, tried)
+	})
+}
+
+func (m *Manager) pickNextMixedWithinRank(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, string, error) {
 	if m.HomeEnabled() {
 		return m.pickNextViaHome(ctx, model, opts, tried)
 	}

--- a/sdk/cliproxy/auth/conductor_selection_candidates.go
+++ b/sdk/cliproxy/auth/conductor_selection_candidates.go
@@ -165,37 +165,6 @@ func rankedSelectionPlan(ctx context.Context, opts cliproxyexecutor.Options) ([]
 	return set.ranks, set, nil
 }
 
-// narrowCreditsCandidatesToLowestRank keeps only the lowest request-scoped rank that still holds a
-// candidate, mirroring the ladder the selection funnels walk. The credits fallback collection has
-// no eligibility filter of its own, so the ladder is applied here rather than inherited; its
-// caller orders the survivors.
-func narrowCreditsCandidatesToLowestRank(set *rankedCandidateSet, entries []creditsCandidateEntry) []creditsCandidateEntry {
-	if set == nil || len(entries) == 0 {
-		return entries
-	}
-	authIDs := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		if entry.auth != nil {
-			authIDs = append(authIDs, entry.auth.ID)
-		}
-	}
-	lowest, found := set.lowestRankPresent(authIDs)
-	if !found {
-		return nil
-	}
-	out := make([]creditsCandidateEntry, 0, len(entries))
-	for _, entry := range entries {
-		if entry.auth == nil {
-			continue
-		}
-		if rank, listed := set.rankFor(entry.auth.ID); !listed || rank != lowest {
-			continue
-		}
-		out = append(out, entry)
-	}
-	return out
-}
-
 // errRankedCandidatesUnsupportedInHome reports that Home dispatch cannot honour ranked candidates.
 // Home selection happens remotely and exposes no local candidate filter, so a ranked request
 // fails closed before any remote dispatch instead of silently selecting outside the list.

--- a/sdk/cliproxy/auth/conductor_selection_candidates.go
+++ b/sdk/cliproxy/auth/conductor_selection_candidates.go
@@ -1,0 +1,292 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strings"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// activeSelectionRankContextKey carries the ranked candidate list and the rank currently attempted.
+type activeSelectionRankContextKey struct{}
+
+// activeSelectionRank is the request-scoped rank a selection attempt is restricted to.
+type activeSelectionRank struct {
+	candidates *rankedCandidateSet
+	rank       uint32
+}
+
+// rankedCandidateSet is the normalized, request-scoped auth candidate allow list.
+// It is derived from Options.Metadata for one selection call and is never persisted.
+type rankedCandidateSet struct {
+	ranksByAuthID map[string]uint32
+	orderByAuthID map[string]uint32
+	ranks         []uint32
+}
+
+// allows reports whether an auth ID is part of the request-scoped candidate list.
+func (s *rankedCandidateSet) allows(authID string) bool {
+	if s == nil {
+		return true
+	}
+	_, listed := s.rankFor(authID)
+	return listed
+}
+
+// allowsAtRank reports whether an auth ID is listed and, when a rank is active, belongs to it.
+func (s *rankedCandidateSet) allowsAtRank(authID string, rank uint32, rankActive bool) bool {
+	if s == nil {
+		return true
+	}
+	candidateRank, listed := s.rankFor(authID)
+	if !listed {
+		return false
+	}
+	return !rankActive || candidateRank == rank
+}
+
+// rankFor returns the request-scoped rank of an auth ID.
+func (s *rankedCandidateSet) rankFor(authID string) (uint32, bool) {
+	if s == nil {
+		return 0, false
+	}
+	rank, listed := s.ranksByAuthID[strings.TrimSpace(authID)]
+	return rank, listed
+}
+
+// lowestRankPresent returns the lowest listed rank across the supplied auth IDs.
+func (s *rankedCandidateSet) lowestRankPresent(authIDs []string) (uint32, bool) {
+	if s == nil {
+		return 0, false
+	}
+	lowest := uint32(0)
+	found := false
+	for _, authID := range authIDs {
+		rank, listed := s.rankFor(authID)
+		if !listed {
+			continue
+		}
+		if !found || rank < lowest {
+			lowest = rank
+			found = true
+		}
+	}
+	return lowest, found
+}
+
+// sortCandidates orders candidates by rank then stable order so ranked requests present a
+// deterministic candidate list to the configured selector and to plugin schedulers.
+// Stable order is presentation only: it never replaces the configured scheduling strategy.
+func (s *rankedCandidateSet) sortCandidates(auths []*Auth) {
+	if s == nil || len(auths) < 2 {
+		return
+	}
+	sort.SliceStable(auths, func(i, j int) bool {
+		left, right := auths[i], auths[j]
+		if left == nil || right == nil {
+			return right == nil && left != nil
+		}
+		leftRank, leftListed := s.rankFor(left.ID)
+		rightRank, rightListed := s.rankFor(right.ID)
+		if leftListed != rightListed {
+			return leftListed
+		}
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		leftOrder := s.orderByAuthID[strings.TrimSpace(left.ID)]
+		rightOrder := s.orderByAuthID[strings.TrimSpace(right.ID)]
+		if leftOrder != rightOrder {
+			return leftOrder < rightOrder
+		}
+		return left.ID < right.ID
+	})
+}
+
+// authSelectionCandidatesPresent reports whether a request carries ranked candidate metadata.
+func authSelectionCandidatesPresent(meta map[string]any) bool {
+	if len(meta) == 0 {
+		return false
+	}
+	_, present := meta[cliproxyexecutor.AuthSelectionCandidatesMetadataKey]
+	return present
+}
+
+// authSelectionCandidatesFromMetadata parses the request-scoped ranked candidate list.
+// It returns a nil set when the metadata key is absent and rejects every malformed shape,
+// so a caller can never silently widen selection past the credentials it listed.
+func authSelectionCandidatesFromMetadata(meta map[string]any) (*rankedCandidateSet, error) {
+	if !authSelectionCandidatesPresent(meta) {
+		return nil, nil
+	}
+	raw := meta[cliproxyexecutor.AuthSelectionCandidatesMetadataKey]
+	candidates, okType := raw.([]cliproxyexecutor.AuthSelectionCandidate)
+	if !okType {
+		return nil, &Error{Code: "invalid_auth_selection_candidates", Message: "auth selection candidates must be []executor.AuthSelectionCandidate", HTTPStatus: http.StatusBadRequest}
+	}
+	if len(candidates) == 0 {
+		return nil, &Error{Code: "invalid_auth_selection_candidates", Message: "auth selection candidates must not be empty", HTTPStatus: http.StatusBadRequest}
+	}
+	set := &rankedCandidateSet{
+		ranksByAuthID: make(map[string]uint32, len(candidates)),
+		orderByAuthID: make(map[string]uint32, len(candidates)),
+	}
+	ordersByRank := make(map[uint32]map[uint32]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		authID := strings.TrimSpace(candidate.AuthID)
+		if authID == "" {
+			return nil, &Error{Code: "invalid_auth_selection_candidates", Message: "auth selection candidate id must not be empty", HTTPStatus: http.StatusBadRequest}
+		}
+		if _, duplicate := set.ranksByAuthID[authID]; duplicate {
+			return nil, &Error{Code: "invalid_auth_selection_candidates", Message: "duplicate auth selection candidate id: " + authID, HTTPStatus: http.StatusBadRequest}
+		}
+		orders := ordersByRank[candidate.PriorityRank]
+		if orders == nil {
+			orders = make(map[uint32]struct{}, len(candidates))
+			ordersByRank[candidate.PriorityRank] = orders
+			set.ranks = append(set.ranks, candidate.PriorityRank)
+		}
+		if _, duplicate := orders[candidate.StableOrder]; duplicate {
+			return nil, &Error{Code: "invalid_auth_selection_candidates", Message: "duplicate auth selection candidate stable order in one rank: " + authID, HTTPStatus: http.StatusBadRequest}
+		}
+		orders[candidate.StableOrder] = struct{}{}
+		set.ranksByAuthID[authID] = candidate.PriorityRank
+		set.orderByAuthID[authID] = candidate.StableOrder
+	}
+	sort.Slice(set.ranks, func(i, j int) bool { return set.ranks[i] < set.ranks[j] })
+	return set, nil
+}
+
+// withActiveSelectionRank restricts a selection attempt to one request-scoped candidate rank.
+// The rank travels on the context because scheduler and plugin paths re-derive eligibility
+// from the context and the request options rather than from a caller supplied argument.
+func withActiveSelectionRank(ctx context.Context, candidates *rankedCandidateSet, rank uint32) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, activeSelectionRankContextKey{}, activeSelectionRank{candidates: candidates, rank: rank})
+}
+
+// activeSelectionRankFromContext reports the candidate rank a selection attempt is restricted to.
+func activeSelectionRankFromContext(ctx context.Context) (activeSelectionRank, bool) {
+	if ctx == nil {
+		return activeSelectionRank{}, false
+	}
+	active, ok := ctx.Value(activeSelectionRankContextKey{}).(activeSelectionRank)
+	return active, ok
+}
+
+// rankedSelectionPlan reports the rank ladder a selection funnel must walk, lowest rank first.
+// It returns an empty ladder when the request carries no candidate metadata and when the
+// context already drives a ladder, so a funnel delegating to another funnel never loops twice.
+func rankedSelectionPlan(ctx context.Context, opts cliproxyexecutor.Options) ([]uint32, *rankedCandidateSet, error) {
+	if _, active := activeSelectionRankFromContext(ctx); active {
+		return nil, nil, nil
+	}
+	set, errCandidates := authSelectionCandidatesFromMetadata(opts.Metadata)
+	if errCandidates != nil {
+		return nil, nil, errCandidates
+	}
+	if set == nil {
+		return nil, nil, nil
+	}
+	return set.ranks, set, nil
+}
+
+// narrowCreditsCandidatesToLowestRank keeps only the lowest request-scoped rank that still holds a
+// candidate, mirroring the ladder the selection funnels walk. The credits fallback collection has
+// no eligibility filter of its own, so the ladder is applied here rather than inherited; its
+// caller orders the survivors.
+func narrowCreditsCandidatesToLowestRank(set *rankedCandidateSet, entries []creditsCandidateEntry) []creditsCandidateEntry {
+	if set == nil || len(entries) == 0 {
+		return entries
+	}
+	authIDs := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.auth != nil {
+			authIDs = append(authIDs, entry.auth.ID)
+		}
+	}
+	lowest, found := set.lowestRankPresent(authIDs)
+	if !found {
+		return nil
+	}
+	out := make([]creditsCandidateEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.auth == nil {
+			continue
+		}
+		if rank, listed := set.rankFor(entry.auth.ID); !listed || rank != lowest {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// errRankedCandidatesUnsupportedInHome reports that Home dispatch cannot honour ranked candidates.
+// Home selection happens remotely and exposes no local candidate filter, so a ranked request
+// fails closed before any remote dispatch instead of silently selecting outside the list.
+func errRankedCandidatesUnsupportedInHome() *Error {
+	return &Error{Code: "ranked_candidates_unsupported_in_home", Message: "ranked auth selection candidates are unsupported while Home is enabled", HTTPStatus: http.StatusServiceUnavailable}
+}
+
+// homeRankedCandidateGuard fails closed when a Home dispatch carries ranked candidate metadata.
+func homeRankedCandidateGuard(opts cliproxyexecutor.Options) error {
+	if authSelectionCandidatesPresent(opts.Metadata) {
+		return errRankedCandidatesUnsupportedInHome()
+	}
+	return nil
+}
+
+// runRankedSingleSelection runs a single-provider selection once per candidate rank, lowest first.
+// Only the lowest rank that still yields an eligible auth is used; a rank is abandoned only when
+// the configured scheduler reports that nothing in it is selectable.
+func runRankedSingleSelection(ctx context.Context, opts cliproxyexecutor.Options, pick func(context.Context) (*Auth, ProviderExecutor, error)) (*Auth, ProviderExecutor, error) {
+	ranks, set, errPlan := rankedSelectionPlan(ctx, opts)
+	if errPlan != nil {
+		return nil, nil, errPlan
+	}
+	if len(ranks) == 0 {
+		return pick(ctx)
+	}
+	var errLast error
+	for _, rank := range ranks {
+		auth, executor, errPick := pick(withActiveSelectionRank(ctx, set, rank))
+		if errPick == nil {
+			return auth, executor, nil
+		}
+		errLast = errPick
+		if shouldRetrySchedulerPick(errPick) {
+			continue
+		}
+		return nil, nil, errPick
+	}
+	return nil, nil, errLast
+}
+
+// runRankedMixedSelection runs a mixed-provider selection once per candidate rank, lowest first.
+func runRankedMixedSelection(ctx context.Context, opts cliproxyexecutor.Options, pick func(context.Context) (*Auth, ProviderExecutor, string, error)) (*Auth, ProviderExecutor, string, error) {
+	ranks, set, errPlan := rankedSelectionPlan(ctx, opts)
+	if errPlan != nil {
+		return nil, nil, "", errPlan
+	}
+	if len(ranks) == 0 {
+		return pick(ctx)
+	}
+	var errLast error
+	for _, rank := range ranks {
+		auth, executor, provider, errPick := pick(withActiveSelectionRank(ctx, set, rank))
+		if errPick == nil {
+			return auth, executor, provider, nil
+		}
+		errLast = errPick
+		if shouldRetrySchedulerPick(errPick) {
+			continue
+		}
+		return nil, nil, "", errPick
+	}
+	return nil, nil, "", errLast
+}

--- a/sdk/cliproxy/auth/conductor_selection_candidates.go
+++ b/sdk/cliproxy/auth/conductor_selection_candidates.go
@@ -22,7 +22,6 @@ type activeSelectionRank struct {
 // It is derived from Options.Metadata for one selection call and is never persisted.
 type rankedCandidateSet struct {
 	ranksByAuthID map[string]uint32
-	orderByAuthID map[string]uint32
 	ranks         []uint32
 }
 
@@ -76,35 +75,6 @@ func (s *rankedCandidateSet) lowestRankPresent(authIDs []string) (uint32, bool) 
 	return lowest, found
 }
 
-// sortCandidates orders candidates by rank then stable order so ranked requests present a
-// deterministic candidate list to the configured selector and to plugin schedulers.
-// Stable order is presentation only: it never replaces the configured scheduling strategy.
-func (s *rankedCandidateSet) sortCandidates(auths []*Auth) {
-	if s == nil || len(auths) < 2 {
-		return
-	}
-	sort.SliceStable(auths, func(i, j int) bool {
-		left, right := auths[i], auths[j]
-		if left == nil || right == nil {
-			return right == nil && left != nil
-		}
-		leftRank, leftListed := s.rankFor(left.ID)
-		rightRank, rightListed := s.rankFor(right.ID)
-		if leftListed != rightListed {
-			return leftListed
-		}
-		if leftRank != rightRank {
-			return leftRank < rightRank
-		}
-		leftOrder := s.orderByAuthID[strings.TrimSpace(left.ID)]
-		rightOrder := s.orderByAuthID[strings.TrimSpace(right.ID)]
-		if leftOrder != rightOrder {
-			return leftOrder < rightOrder
-		}
-		return left.ID < right.ID
-	})
-}
-
 // authSelectionCandidatesPresent reports whether a request carries ranked candidate metadata.
 func authSelectionCandidatesPresent(meta map[string]any) bool {
 	if len(meta) == 0 {
@@ -131,7 +101,6 @@ func authSelectionCandidatesFromMetadata(meta map[string]any) (*rankedCandidateS
 	}
 	set := &rankedCandidateSet{
 		ranksByAuthID: make(map[string]uint32, len(candidates)),
-		orderByAuthID: make(map[string]uint32, len(candidates)),
 	}
 	ordersByRank := make(map[uint32]map[uint32]struct{}, len(candidates))
 	for _, candidate := range candidates {
@@ -148,12 +117,13 @@ func authSelectionCandidatesFromMetadata(meta map[string]any) (*rankedCandidateS
 			ordersByRank[candidate.PriorityRank] = orders
 			set.ranks = append(set.ranks, candidate.PriorityRank)
 		}
+		// StableOrder never influences which credential is selected; it is validated
+		// only so a caller can record an unambiguous, replayable candidate list.
 		if _, duplicate := orders[candidate.StableOrder]; duplicate {
 			return nil, &Error{Code: "invalid_auth_selection_candidates", Message: "duplicate auth selection candidate stable order in one rank: " + authID, HTTPStatus: http.StatusBadRequest}
 		}
 		orders[candidate.StableOrder] = struct{}{}
 		set.ranksByAuthID[authID] = candidate.PriorityRank
-		set.orderByAuthID[authID] = candidate.StableOrder
 	}
 	sort.Slice(set.ranks, func(i, j int) bool { return set.ranks[i] < set.ranks[j] })
 	return set, nil

--- a/sdk/cliproxy/auth/conductor_selection_candidates_test.go
+++ b/sdk/cliproxy/auth/conductor_selection_candidates_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sync"
 	"testing"
+	"time"
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
@@ -758,6 +759,32 @@ func TestFindAllAntigravityCreditsCandidateAuthsHonoursRankedCandidates(t *testi
 	}}
 	if _, errInvalid := manager.findAllAntigravityCreditsCandidateAuths(context.Background(), "claude-sonnet-4-6", invalidOpts); errInvalid == nil {
 		t.Fatal("findAllAntigravityCreditsCandidateAuths(invalid) error = nil, want invalid_auth_selection_candidates")
+	}
+}
+
+func TestFindAllAntigravityCreditsCandidateAuths_WalksPastExhaustedLowerRank(t *testing.T) {
+	manager := &Manager{
+		auths: map[string]*Auth{
+			"ranked-credits-exhausted": {ID: "ranked-credits-exhausted", Provider: "antigravity"},
+			"ranked-credits-available": {ID: "ranked-credits-available", Provider: "antigravity"},
+		},
+		executors: map[string]ProviderExecutor{
+			"antigravity": schedulerTestExecutor{},
+		},
+	}
+	SetAntigravityCreditsHint("ranked-credits-exhausted", AntigravityCreditsHint{Known: true, Available: false, UpdatedAt: time.Now()})
+	SetAntigravityCreditsHint("ranked-credits-available", AntigravityCreditsHint{Known: true, Available: true, UpdatedAt: time.Now()})
+
+	opts := rankedCandidateOptions(
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "ranked-credits-exhausted", PriorityRank: 0, StableOrder: 0},
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "ranked-credits-available", PriorityRank: 1, StableOrder: 0},
+	)
+	candidates, errCandidates := manager.findAllAntigravityCreditsCandidateAuths(context.Background(), "claude-sonnet-4-6", opts)
+	if errCandidates != nil {
+		t.Fatalf("findAllAntigravityCreditsCandidateAuths() error = %v", errCandidates)
+	}
+	if len(candidates) != 1 || candidates[0].auth.ID != "ranked-credits-available" {
+		t.Fatalf("candidates = %#v, want available candidate from next rank", candidates)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_selection_candidates_test.go
+++ b/sdk/cliproxy/auth/conductor_selection_candidates_test.go
@@ -893,3 +893,41 @@ func TestManagerRankedCandidatesAreIsolatedBetweenConcurrentRequests(t *testing.
 		t.Fatalf("concurrent selection error = %v", errWorker)
 	}
 }
+
+func TestManagerSelectAuthMixedAppliesRankedCandidatesAcrossProviders(t *testing.T) {
+	manager := newRankedCandidateTestManager(t, &RoundRobinSelector{},
+		&Auth{ID: "gemini-low", Provider: "gemini"},
+		&Auth{ID: "codex-high", Provider: "codex"},
+	)
+	opts := rankedCandidateOptions(
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "gemini-low", PriorityRank: 5, StableOrder: 0},
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "codex-high", PriorityRank: 0, StableOrder: 0},
+	)
+
+	selected, errSelect := manager.SelectAuthMixed(context.Background(), []string{"gemini", "codex"}, "", opts)
+	if errSelect != nil {
+		t.Fatalf("SelectAuthMixed() error = %v", errSelect)
+	}
+	if selected == nil || selected.ID != "codex-high" {
+		t.Fatalf("SelectAuthMixed() auth = %#v, want codex-high", selected)
+	}
+}
+
+func TestManagerSelectAuthMixedRejectsRankedCandidatesInHomeBeforeDispatch(t *testing.T) {
+	dispatcher := &rankedHomeTestDispatcher{}
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.executors["gemini"] = schedulerTestExecutor{provider: "gemini"}
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+
+	_, errSelect := manager.SelectAuthMixed(context.Background(), []string{"gemini"}, "", rankedCandidateOptions(
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-a"},
+	))
+	var authErr *Error
+	if !errors.As(errSelect, &authErr) || authErr.Code != "ranked_candidates_unsupported_in_home" {
+		t.Fatalf("SelectAuthMixed() error = %#v, want ranked_candidates_unsupported_in_home", errSelect)
+	}
+	if calls := dispatcher.dispatchCalls(); calls != 0 {
+		t.Fatalf("home dispatch calls = %d, want 0", calls)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_selection_candidates_test.go
+++ b/sdk/cliproxy/auth/conductor_selection_candidates_test.go
@@ -1,0 +1,764 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+func rankedCandidateOptions(candidates ...cliproxyexecutor.AuthSelectionCandidate) cliproxyexecutor.Options {
+	return cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.AuthSelectionCandidatesMetadataKey: candidates,
+	}}
+}
+
+func newRankedCandidateTestManager(t *testing.T, selector Selector, auths ...*Auth) *Manager {
+	t.Helper()
+	manager := NewManager(nil, selector, nil)
+	providers := make(map[string]struct{}, len(auths))
+	for _, auth := range auths {
+		if _, seen := providers[auth.Provider]; !seen {
+			providers[auth.Provider] = struct{}{}
+			manager.executors[auth.Provider] = schedulerTestExecutor{provider: auth.Provider}
+		}
+		if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+			t.Fatalf("Register(%s) error = %v", auth.ID, errRegister)
+		}
+	}
+	return manager
+}
+
+type rankedHomeTestDispatcher struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (d *rankedHomeTestDispatcher) HeartbeatOK() bool { return true }
+
+func (d *rankedHomeTestDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+	d.mu.Lock()
+	d.calls++
+	d.mu.Unlock()
+	return nil, errors.New("ranked home dispatch must never happen")
+}
+
+func (d *rankedHomeTestDispatcher) RPopAuthWithPolicy(ctx context.Context, model string, sessionID string, headers http.Header, count int, policy string) ([]byte, error) {
+	return d.RPopAuth(ctx, model, sessionID, headers, count)
+}
+
+func (*rankedHomeTestDispatcher) AbortAmbiguousDispatch() {}
+
+func (d *rankedHomeTestDispatcher) dispatchCalls() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.calls
+}
+
+func TestAuthSelectionCandidatesFromMetadata(t *testing.T) {
+	tests := []struct {
+		name      string
+		meta      map[string]any
+		wantSet   bool
+		wantRanks []uint32
+		wantErr   bool
+	}{
+		{
+			name: "absent key keeps current behavior",
+			meta: map[string]any{cliproxyexecutor.PinnedAuthMetadataKey: "auth-a"},
+		},
+		{
+			name:    "untyped nil value is rejected",
+			meta:    map[string]any{cliproxyexecutor.AuthSelectionCandidatesMetadataKey: nil},
+			wantErr: true,
+		},
+		{
+			name:    "foreign type is rejected",
+			meta:    map[string]any{cliproxyexecutor.AuthSelectionCandidatesMetadataKey: []string{"auth-a"}},
+			wantErr: true,
+		},
+		{
+			name:    "empty list is rejected",
+			meta:    map[string]any{cliproxyexecutor.AuthSelectionCandidatesMetadataKey: []cliproxyexecutor.AuthSelectionCandidate{}},
+			wantErr: true,
+		},
+		{
+			name: "blank auth id is rejected",
+			meta: map[string]any{cliproxyexecutor.AuthSelectionCandidatesMetadataKey: []cliproxyexecutor.AuthSelectionCandidate{
+				{AuthID: "  "},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "duplicate auth id is rejected",
+			meta: map[string]any{cliproxyexecutor.AuthSelectionCandidatesMetadataKey: []cliproxyexecutor.AuthSelectionCandidate{
+				{AuthID: "auth-a", StableOrder: 0},
+				{AuthID: " auth-a ", StableOrder: 1},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "duplicate stable order inside one rank is rejected",
+			meta: map[string]any{cliproxyexecutor.AuthSelectionCandidatesMetadataKey: []cliproxyexecutor.AuthSelectionCandidate{
+				{AuthID: "auth-a", PriorityRank: 1, StableOrder: 7},
+				{AuthID: "auth-b", PriorityRank: 1, StableOrder: 7},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "repeated stable order across ranks is accepted",
+			meta: map[string]any{cliproxyexecutor.AuthSelectionCandidatesMetadataKey: []cliproxyexecutor.AuthSelectionCandidate{
+				{AuthID: "auth-a", PriorityRank: 0, StableOrder: 7},
+				{AuthID: "auth-b", PriorityRank: 1, StableOrder: 7},
+			}},
+			wantSet:   true,
+			wantRanks: []uint32{0, 1},
+		},
+		{
+			name: "ranks are normalized ascending",
+			meta: map[string]any{cliproxyexecutor.AuthSelectionCandidatesMetadataKey: []cliproxyexecutor.AuthSelectionCandidate{
+				{AuthID: "auth-c", PriorityRank: 5, StableOrder: 0},
+				{AuthID: "auth-a", PriorityRank: 1, StableOrder: 0},
+				{AuthID: "auth-b", PriorityRank: 1, StableOrder: 1},
+			}},
+			wantSet:   true,
+			wantRanks: []uint32{1, 5},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			set, errCandidates := authSelectionCandidatesFromMetadata(tt.meta)
+			if tt.wantErr {
+				var authErr *Error
+				if !errors.As(errCandidates, &authErr) || authErr.Code != "invalid_auth_selection_candidates" {
+					t.Fatalf("authSelectionCandidatesFromMetadata() error = %#v, want invalid_auth_selection_candidates", errCandidates)
+				}
+				if authErr.HTTPStatus != http.StatusBadRequest {
+					t.Fatalf("authSelectionCandidatesFromMetadata() status = %d, want %d", authErr.HTTPStatus, http.StatusBadRequest)
+				}
+				if set != nil {
+					t.Fatalf("authSelectionCandidatesFromMetadata() set = %#v, want nil", set)
+				}
+				return
+			}
+			if errCandidates != nil {
+				t.Fatalf("authSelectionCandidatesFromMetadata() error = %v", errCandidates)
+			}
+			if !tt.wantSet {
+				if set != nil {
+					t.Fatalf("authSelectionCandidatesFromMetadata() set = %#v, want nil", set)
+				}
+				return
+			}
+			if set == nil {
+				t.Fatal("authSelectionCandidatesFromMetadata() set = nil, want candidates")
+			}
+			if len(set.ranks) != len(tt.wantRanks) {
+				t.Fatalf("ranks = %v, want %v", set.ranks, tt.wantRanks)
+			}
+			for index := range tt.wantRanks {
+				if set.ranks[index] != tt.wantRanks[index] {
+					t.Fatalf("ranks = %v, want %v", set.ranks, tt.wantRanks)
+				}
+			}
+		})
+	}
+}
+
+func TestRankedCandidateSetAllowsAtRank(t *testing.T) {
+	set, errCandidates := authSelectionCandidatesFromMetadata(map[string]any{
+		cliproxyexecutor.AuthSelectionCandidatesMetadataKey: []cliproxyexecutor.AuthSelectionCandidate{
+			{AuthID: "auth-a", PriorityRank: 0, StableOrder: 0},
+			{AuthID: "auth-b", PriorityRank: 1, StableOrder: 0},
+		},
+	})
+	if errCandidates != nil {
+		t.Fatalf("authSelectionCandidatesFromMetadata() error = %v", errCandidates)
+	}
+
+	tests := []struct {
+		name       string
+		authID     string
+		rank       uint32
+		rankActive bool
+		want       bool
+	}{
+		{name: "listed auth without active rank", authID: "auth-b", want: true},
+		{name: "unlisted auth without active rank", authID: "auth-z", want: false},
+		{name: "listed auth inside active rank", authID: "auth-a", rank: 0, rankActive: true, want: true},
+		{name: "listed auth outside active rank", authID: "auth-b", rank: 0, rankActive: true, want: false},
+		{name: "unlisted auth inside active rank", authID: "auth-z", rank: 0, rankActive: true, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := set.allowsAtRank(tt.authID, tt.rank, tt.rankActive); got != tt.want {
+				t.Fatalf("allowsAtRank(%q) = %v, want %v", tt.authID, got, tt.want)
+			}
+		})
+	}
+
+	var absent *rankedCandidateSet
+	if !absent.allowsAtRank("anything", 0, true) {
+		t.Fatal("nil candidate set must not restrict selection")
+	}
+}
+
+func TestManagerPickNextRestrictsSelectionToRankedCandidates(t *testing.T) {
+	manager := newRankedCandidateTestManager(t, &RoundRobinSelector{},
+		&Auth{ID: "auth-a", Provider: "gemini"},
+		&Auth{ID: "auth-b", Provider: "gemini"},
+		&Auth{ID: "auth-c", Provider: "gemini"},
+	)
+	opts := rankedCandidateOptions(
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-a", PriorityRank: 0, StableOrder: 0},
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-c", PriorityRank: 0, StableOrder: 1},
+	)
+
+	counts := make(map[string]int)
+	for index := 0; index < 30; index++ {
+		selected, _, errPick := manager.pickNext(context.Background(), "gemini", "", opts, nil)
+		if errPick != nil {
+			t.Fatalf("pickNext() #%d error = %v", index, errPick)
+		}
+		counts[selected.ID]++
+	}
+	if counts["auth-b"] != 0 {
+		t.Fatalf("unlisted auth selected %d times, want 0; all=%#v", counts["auth-b"], counts)
+	}
+	// Round-robin still runs unchanged inside the winning rank.
+	if counts["auth-a"] != 15 || counts["auth-c"] != 15 {
+		t.Fatalf("ranked picks = %#v, want auth-a:auth-c=15:15", counts)
+	}
+
+	// The filtered auth never consumed scheduler state, so unrestricted rotation stays even.
+	unrestricted := make(map[string]int)
+	for index := 0; index < 30; index++ {
+		selected, _, errPick := manager.pickNext(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil)
+		if errPick != nil {
+			t.Fatalf("unrestricted pickNext() #%d error = %v", index, errPick)
+		}
+		unrestricted[selected.ID]++
+	}
+	for _, authID := range []string{"auth-a", "auth-b", "auth-c"} {
+		if unrestricted[authID] != 10 {
+			t.Fatalf("unrestricted picks = %#v, want 10 each", unrestricted)
+		}
+	}
+}
+
+func TestManagerPickNextUsesLowestEligibleCandidateRank(t *testing.T) {
+	tests := []struct {
+		name             string
+		lowestRankAuth   *Auth
+		wantSelectedAuth string
+	}{
+		{
+			name:             "lowest rank wins while it is eligible",
+			lowestRankAuth:   &Auth{ID: "auth-low-rank", Provider: "gemini", Attributes: map[string]string{"priority": "0"}},
+			wantSelectedAuth: "auth-low-rank",
+		},
+		{
+			name:             "higher rank is used only once the lowest rank has nothing eligible",
+			lowestRankAuth:   &Auth{ID: "auth-low-rank", Provider: "gemini", Attributes: map[string]string{"priority": "0"}, Disabled: true},
+			wantSelectedAuth: "auth-high-rank",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The higher rank also carries the higher persistent priority, so a rank ladder that
+			// leaked into persistent priority tiering would pick the wrong credential.
+			manager := newRankedCandidateTestManager(t, &RoundRobinSelector{},
+				&Auth{ID: "auth-high-rank", Provider: "gemini", Attributes: map[string]string{"priority": "10"}},
+				tt.lowestRankAuth,
+			)
+			opts := rankedCandidateOptions(
+				cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-high-rank", PriorityRank: 7, StableOrder: 0},
+				cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-low-rank", PriorityRank: 1, StableOrder: 0},
+			)
+
+			selected, _, errPick := manager.pickNext(context.Background(), "gemini", "", opts, nil)
+			if errPick != nil {
+				t.Fatalf("pickNext() error = %v", errPick)
+			}
+			if selected == nil || selected.ID != tt.wantSelectedAuth {
+				t.Fatalf("pickNext() auth = %#v, want %q", selected, tt.wantSelectedAuth)
+			}
+
+			manager.mu.RLock()
+			defer manager.mu.RUnlock()
+			for _, authID := range []string{"auth-high-rank", "auth-low-rank"} {
+				want := "10"
+				if authID == "auth-low-rank" {
+					want = "0"
+				}
+				if got := manager.auths[authID].Attributes["priority"]; got != want {
+					t.Fatalf("auth %q priority attribute = %q, want %q", authID, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestManagerRankedCandidatesFailClosedWhenNothingIsEligible(t *testing.T) {
+	manager := newRankedCandidateTestManager(t, &RoundRobinSelector{},
+		&Auth{ID: "auth-a", Provider: "gemini"},
+		&Auth{ID: "auth-b", Provider: "gemini"},
+	)
+	opts := rankedCandidateOptions(cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-unknown"})
+
+	selected, _, errPick := manager.pickNext(context.Background(), "gemini", "", opts, nil)
+	if selected != nil {
+		t.Fatalf("pickNext() auth = %#v, want nil", selected)
+	}
+	var authErr *Error
+	if !errors.As(errPick, &authErr) || authErr.Code != "auth_not_found" {
+		t.Fatalf("pickNext() error = %#v, want auth_not_found", errPick)
+	}
+}
+
+func TestManagerPinnedAuthOutsideRankedCandidatesFailsClosed(t *testing.T) {
+	manager := newRankedCandidateTestManager(t, &RoundRobinSelector{},
+		&Auth{ID: "auth-a", Provider: "gemini"},
+		&Auth{ID: "auth-b", Provider: "gemini"},
+	)
+	opts := rankedCandidateOptions(cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-a"})
+	opts.Metadata[cliproxyexecutor.PinnedAuthMetadataKey] = "auth-b"
+
+	selected, _, errPick := manager.pickNext(context.Background(), "gemini", "", opts, nil)
+	if selected != nil {
+		t.Fatalf("pickNext() auth = %#v, want nil", selected)
+	}
+	var authErr *Error
+	if !errors.As(errPick, &authErr) || authErr.Code != "auth_not_found" {
+		t.Fatalf("pickNext() error = %#v, want auth_not_found", errPick)
+	}
+}
+
+func TestManagerPinnedAuthInsideRankedCandidatesIsSelected(t *testing.T) {
+	manager := newRankedCandidateTestManager(t, &RoundRobinSelector{},
+		&Auth{ID: "auth-a", Provider: "gemini"},
+		&Auth{ID: "auth-b", Provider: "gemini"},
+	)
+	opts := rankedCandidateOptions(
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-a", PriorityRank: 0},
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-b", PriorityRank: 1},
+	)
+	opts.Metadata[cliproxyexecutor.PinnedAuthMetadataKey] = "auth-b"
+
+	selected, _, errPick := manager.pickNext(context.Background(), "gemini", "", opts, nil)
+	if errPick != nil {
+		t.Fatalf("pickNext() error = %v", errPick)
+	}
+	if selected == nil || selected.ID != "auth-b" {
+		t.Fatalf("pickNext() auth = %#v, want auth-b", selected)
+	}
+}
+
+func TestManagerRankedCandidatesRejectInvalidMetadata(t *testing.T) {
+	manager := newRankedCandidateTestManager(t, &RoundRobinSelector{},
+		&Auth{ID: "auth-a", Provider: "gemini"},
+	)
+	opts := cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.AuthSelectionCandidatesMetadataKey: []cliproxyexecutor.AuthSelectionCandidate{},
+	}}
+
+	tests := []struct {
+		name string
+		pick func() error
+	}{
+		{
+			name: "single provider",
+			pick: func() error {
+				_, _, errPick := manager.pickNext(context.Background(), "gemini", "", opts, nil)
+				return errPick
+			},
+		},
+		{
+			name: "mixed provider",
+			pick: func() error {
+				_, _, _, errPick := manager.pickNextMixed(context.Background(), []string{"gemini"}, "", opts, nil)
+				return errPick
+			},
+		},
+		{
+			name: "public selection entry point",
+			pick: func() error {
+				_, errSelect := manager.SelectAuth(context.Background(), "gemini", "", opts)
+				return errSelect
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var authErr *Error
+			errPick := tt.pick()
+			if !errors.As(errPick, &authErr) || authErr.Code != "invalid_auth_selection_candidates" {
+				t.Fatalf("pick error = %#v, want invalid_auth_selection_candidates", errPick)
+			}
+			if authErr.HTTPStatus != http.StatusBadRequest {
+				t.Fatalf("pick error status = %d, want %d", authErr.HTTPStatus, http.StatusBadRequest)
+			}
+		})
+	}
+}
+
+func TestManagerLegacySelectionPresentsOnlyRankedCandidates(t *testing.T) {
+	selector := &trackingSelector{}
+	manager := newRankedCandidateTestManager(t, selector,
+		&Auth{ID: "auth-a", Provider: "gemini"},
+		&Auth{ID: "auth-b", Provider: "gemini"},
+		&Auth{ID: "auth-c", Provider: "gemini"},
+	)
+	opts := rankedCandidateOptions(
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-c", PriorityRank: 0, StableOrder: 1},
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-a", PriorityRank: 0, StableOrder: 0},
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-b", PriorityRank: 3, StableOrder: 0},
+	)
+
+	selected, _, errPick := manager.pickNextLegacy(context.Background(), "gemini", "", opts, nil)
+	if errPick != nil {
+		t.Fatalf("pickNextLegacy() error = %v", errPick)
+	}
+	if selector.calls != 1 {
+		t.Fatalf("selector.calls = %d, want 1", selector.calls)
+	}
+	if len(selector.lastAuthID) != 2 || selector.lastAuthID[0] != "auth-a" || selector.lastAuthID[1] != "auth-c" {
+		t.Fatalf("selector candidates = %v, want [auth-a auth-c] in stable order", selector.lastAuthID)
+	}
+	if selected == nil || selected.ID != "auth-c" {
+		t.Fatalf("pickNextLegacy() auth = %#v, want auth-c", selected)
+	}
+}
+
+func TestManagerMixedSelectionRestrictsToRankedCandidates(t *testing.T) {
+	manager := newRankedCandidateTestManager(t, &RoundRobinSelector{},
+		&Auth{ID: "gemini-a", Provider: "gemini"},
+		&Auth{ID: "codex-a", Provider: "codex"},
+		&Auth{ID: "codex-b", Provider: "codex"},
+	)
+	opts := rankedCandidateOptions(
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "codex-b", PriorityRank: 0, StableOrder: 0},
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "gemini-a", PriorityRank: 4, StableOrder: 0},
+	)
+
+	for index := 0; index < 10; index++ {
+		selected, _, provider, errPick := manager.pickNextMixed(context.Background(), []string{"gemini", "codex"}, "", opts, nil)
+		if errPick != nil {
+			t.Fatalf("pickNextMixed() #%d error = %v", index, errPick)
+		}
+		if selected == nil || selected.ID != "codex-b" || provider != "codex" {
+			t.Fatalf("pickNextMixed() = %#v provider %q, want codex-b on codex", selected, provider)
+		}
+	}
+}
+
+func TestManagerMixedLegacySelectionRestrictsToRankedCandidates(t *testing.T) {
+	selector := &trackingSelector{}
+	manager := newRankedCandidateTestManager(t, selector,
+		&Auth{ID: "gemini-a", Provider: "gemini"},
+		&Auth{ID: "codex-a", Provider: "codex"},
+		&Auth{ID: "codex-b", Provider: "codex"},
+	)
+	opts := rankedCandidateOptions(
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "codex-a", PriorityRank: 2, StableOrder: 0},
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "gemini-a", PriorityRank: 2, StableOrder: 1},
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "codex-b", PriorityRank: 9, StableOrder: 0},
+	)
+
+	selected, _, provider, errPick := manager.pickNextMixedLegacy(context.Background(), []string{"gemini", "codex"}, "", opts, nil)
+	if errPick != nil {
+		t.Fatalf("pickNextMixedLegacy() error = %v", errPick)
+	}
+	if len(selector.lastAuthID) != 2 || selector.lastAuthID[0] != "codex-a" || selector.lastAuthID[1] != "gemini-a" {
+		t.Fatalf("selector candidates = %v, want [codex-a gemini-a] in stable order", selector.lastAuthID)
+	}
+	if selected == nil || selected.ID != "gemini-a" || provider != "gemini" {
+		t.Fatalf("pickNextMixedLegacy() = %#v provider %q, want gemini-a on gemini", selected, provider)
+	}
+}
+
+func TestManagerPluginSchedulerReceivesOnlyRankedCandidates(t *testing.T) {
+	tests := []struct {
+		name string
+		resp pluginapi.SchedulerPickResponse
+		want string
+	}{
+		{
+			name: "plugin picks inside the winning rank",
+			resp: pluginapi.SchedulerPickResponse{Handled: true, AuthID: "auth-a"},
+			want: "auth-a",
+		},
+		{
+			name: "plugin delegates back to the built-in scheduler",
+			resp: pluginapi.SchedulerPickResponse{Handled: true, DelegateBuiltin: pluginapi.SchedulerBuiltinRoundRobin},
+			want: "auth-a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := newRankedCandidateTestManager(t, &RoundRobinSelector{},
+				&Auth{ID: "auth-a", Provider: "gemini"},
+				&Auth{ID: "auth-b", Provider: "gemini"},
+				&Auth{ID: "auth-c", Provider: "gemini"},
+			)
+			scheduler := &fakePluginScheduler{resp: tt.resp, handled: true}
+			manager.SetPluginScheduler(scheduler)
+			opts := rankedCandidateOptions(
+				cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-a", PriorityRank: 0, StableOrder: 0},
+				cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-c", PriorityRank: 6, StableOrder: 0},
+			)
+
+			selected, _, errPick := manager.pickNext(context.Background(), "gemini", "", opts, nil)
+			if errPick != nil {
+				t.Fatalf("pickNext() error = %v", errPick)
+			}
+			if selected == nil || selected.ID != tt.want {
+				t.Fatalf("pickNext() auth = %#v, want %q", selected, tt.want)
+			}
+			if len(scheduler.requests) != 1 {
+				t.Fatalf("len(scheduler.requests) = %d, want 1", len(scheduler.requests))
+			}
+			if len(scheduler.requests[0].Candidates) != 1 || scheduler.requests[0].Candidates[0].ID != "auth-a" {
+				t.Fatalf("plugin candidates = %#v, want only auth-a", scheduler.requests[0].Candidates)
+			}
+		})
+	}
+}
+
+func TestManagerRankedCandidatesComposeWithAuthKindAndPolicy(t *testing.T) {
+	newManager := func(t *testing.T) *Manager {
+		t.Helper()
+		return newRankedCandidateTestManager(t, &RoundRobinSelector{},
+			&Auth{ID: "codex-api-key", Provider: "codex", Attributes: map[string]string{AttributeAPIKey: "test-key"}},
+			&Auth{ID: "codex-oauth", Provider: "codex", Metadata: map[string]any{"access_token": "test-token"}},
+		)
+	}
+
+	t.Run("candidate list narrows the required kind", func(t *testing.T) {
+		manager := newManager(t)
+		opts := rankedCandidateOptions(
+			cliproxyexecutor.AuthSelectionCandidate{AuthID: "codex-api-key", PriorityRank: 0, StableOrder: 0},
+			cliproxyexecutor.AuthSelectionCandidate{AuthID: "codex-oauth", PriorityRank: 0, StableOrder: 1},
+		)
+		selected, errSelect := manager.SelectAuthByKind(context.Background(), "codex", "", AuthKindOAuth, opts)
+		if errSelect != nil {
+			t.Fatalf("SelectAuthByKind() error = %v", errSelect)
+		}
+		if selected == nil || selected.ID != "codex-oauth" {
+			t.Fatalf("SelectAuthByKind() auth = %#v, want codex-oauth", selected)
+		}
+	})
+
+	t.Run("required kind cannot escape the candidate list", func(t *testing.T) {
+		manager := newManager(t)
+		opts := rankedCandidateOptions(cliproxyexecutor.AuthSelectionCandidate{AuthID: "codex-api-key"})
+		selected, errSelect := manager.SelectAuthByKind(context.Background(), "codex", "", AuthKindOAuth, opts)
+		if selected != nil {
+			t.Fatalf("SelectAuthByKind() auth = %#v, want nil", selected)
+		}
+		var authErr *Error
+		if !errors.As(errSelect, &authErr) || authErr.Code != "auth_not_found" {
+			t.Fatalf("SelectAuthByKind() error = %#v, want auth_not_found", errSelect)
+		}
+	})
+
+	t.Run("credential policy cannot escape the candidate list", func(t *testing.T) {
+		manager := newManager(t)
+		opts := rankedCandidateOptions(cliproxyexecutor.AuthSelectionCandidate{AuthID: "codex-api-key"})
+		selected, errSelect := manager.SelectAuthWithCredentialPolicy(context.Background(), "codex", "", CredentialPolicyCodexAlphaSearchV1, opts)
+		if selected != nil {
+			t.Fatalf("SelectAuthWithCredentialPolicy() auth = %#v, want nil", selected)
+		}
+		var authErr *Error
+		if !errors.As(errSelect, &authErr) || authErr.Code != "auth_not_found" {
+			t.Fatalf("SelectAuthWithCredentialPolicy() error = %#v, want auth_not_found", errSelect)
+		}
+	})
+}
+
+func TestManagerSelectionWithoutCandidateMetadataIsUnchanged(t *testing.T) {
+	t.Run("built-in scheduler rotation", func(t *testing.T) {
+		manager := newRankedCandidateTestManager(t, &RoundRobinSelector{},
+			&Auth{ID: "auth-a", Provider: "gemini"},
+			&Auth{ID: "auth-b", Provider: "gemini"},
+			&Auth{ID: "auth-c", Provider: "gemini"},
+		)
+		counts := make(map[string]int)
+		for index := 0; index < 30; index++ {
+			selected, _, errPick := manager.pickNext(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil)
+			if errPick != nil {
+				t.Fatalf("pickNext() #%d error = %v", index, errPick)
+			}
+			counts[selected.ID]++
+		}
+		for _, authID := range []string{"auth-a", "auth-b", "auth-c"} {
+			if counts[authID] != 10 {
+				t.Fatalf("picks = %#v, want 10 each", counts)
+			}
+		}
+	})
+
+	t.Run("legacy selector still sees every candidate", func(t *testing.T) {
+		selector := &trackingSelector{}
+		manager := newRankedCandidateTestManager(t, selector,
+			&Auth{ID: "auth-a", Provider: "gemini"},
+			&Auth{ID: "auth-b", Provider: "gemini"},
+			&Auth{ID: "auth-c", Provider: "gemini"},
+		)
+		if _, _, errPick := manager.pickNextLegacy(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil); errPick != nil {
+			t.Fatalf("pickNextLegacy() error = %v", errPick)
+		}
+		if len(selector.lastAuthID) != 3 {
+			t.Fatalf("selector candidates = %v, want all three auths", selector.lastAuthID)
+		}
+	})
+}
+
+func TestFindAllAntigravityCreditsCandidateAuthsHonoursRankedCandidates(t *testing.T) {
+	manager := &Manager{
+		auths: map[string]*Auth{
+			"ranked-credits-a": {ID: "ranked-credits-a", Provider: "antigravity"},
+			"ranked-credits-b": {ID: "ranked-credits-b", Provider: "antigravity"},
+			"ranked-credits-c": {ID: "ranked-credits-c", Provider: "antigravity"},
+		},
+		executors: map[string]ProviderExecutor{
+			"antigravity": schedulerTestExecutor{},
+		},
+	}
+
+	opts := rankedCandidateOptions(
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "ranked-credits-b", PriorityRank: 0, StableOrder: 0},
+		cliproxyexecutor.AuthSelectionCandidate{AuthID: "ranked-credits-c", PriorityRank: 2, StableOrder: 0},
+	)
+	candidates, errCandidates := manager.findAllAntigravityCreditsCandidateAuths(context.Background(), "claude-sonnet-4-6", opts)
+	if errCandidates != nil {
+		t.Fatalf("findAllAntigravityCreditsCandidateAuths() error = %v", errCandidates)
+	}
+	if len(candidates) != 1 || candidates[0].auth.ID != "ranked-credits-b" {
+		t.Fatalf("candidates = %#v, want only ranked-credits-b", candidates)
+	}
+
+	invalidOpts := cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.AuthSelectionCandidatesMetadataKey: "ranked-credits-b",
+	}}
+	if _, errInvalid := manager.findAllAntigravityCreditsCandidateAuths(context.Background(), "claude-sonnet-4-6", invalidOpts); errInvalid == nil {
+		t.Fatal("findAllAntigravityCreditsCandidateAuths(invalid) error = nil, want invalid_auth_selection_candidates")
+	}
+}
+
+func TestManagerHomeRejectsRankedCandidatesBeforeDispatch(t *testing.T) {
+	dispatcher := &rankedHomeTestDispatcher{}
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.executors["gemini"] = schedulerTestExecutor{provider: "gemini"}
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+
+	opts := rankedCandidateOptions(cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-a"})
+
+	tests := []struct {
+		name   string
+		invoke func() error
+	}{
+		{
+			name: "home selection funnel",
+			invoke: func() error {
+				_, _, _, errPick := manager.pickNextViaHome(context.Background(), "", opts, nil)
+				return errPick
+			},
+		},
+		{
+			name: "home dispatch selection",
+			invoke: func() error {
+				_, errSelection := manager.pickHomeDispatchSelection(context.Background(), "", opts)
+				return errSelection
+			},
+		},
+		{
+			name: "select home auth by kind",
+			invoke: func() error {
+				_, errSelect := manager.SelectHomeAuthByKind(context.Background(), "gemini", "", AuthKindOAuth, opts)
+				return errSelect
+			},
+		},
+		{
+			name: "select home auth with credential policy",
+			invoke: func() error {
+				_, errSelect := manager.SelectHomeAuthWithCredentialPolicy(context.Background(), "gemini", "", CredentialPolicyCodexAlphaSearchV1, opts)
+				return errSelect
+			},
+		},
+		{
+			name: "home execution",
+			invoke: func() error {
+				_, errExecute := manager.Execute(context.Background(), []string{"gemini"}, cliproxyexecutor.Request{Model: "test"}, opts)
+				return errExecute
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var authErr *Error
+			errInvoke := tt.invoke()
+			if !errors.As(errInvoke, &authErr) || authErr.Code != "ranked_candidates_unsupported_in_home" {
+				t.Fatalf("error = %#v, want ranked_candidates_unsupported_in_home", errInvoke)
+			}
+			if authErr.HTTPStatus != http.StatusServiceUnavailable {
+				t.Fatalf("error status = %d, want %d", authErr.HTTPStatus, http.StatusServiceUnavailable)
+			}
+		})
+	}
+
+	if calls := dispatcher.dispatchCalls(); calls != 0 {
+		t.Fatalf("home dispatch calls = %d, want 0", calls)
+	}
+}
+
+func TestManagerRankedCandidatesAreIsolatedBetweenConcurrentRequests(t *testing.T) {
+	manager := newRankedCandidateTestManager(t, &RoundRobinSelector{},
+		&Auth{ID: "auth-a", Provider: "gemini"},
+		&Auth{ID: "auth-b", Provider: "gemini"},
+		&Auth{ID: "auth-c", Provider: "gemini"},
+	)
+
+	var waitGroup sync.WaitGroup
+	errCh := make(chan error, 64)
+	for worker := 0; worker < 8; worker++ {
+		waitGroup.Add(1)
+		ranked := worker%2 == 0
+		go func() {
+			defer waitGroup.Done()
+			opts := cliproxyexecutor.Options{}
+			if ranked {
+				opts = rankedCandidateOptions(cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-a", PriorityRank: 0, StableOrder: 0})
+			}
+			for index := 0; index < 50; index++ {
+				selected, _, errPick := manager.pickNext(context.Background(), "gemini", "", opts, nil)
+				if errPick != nil {
+					errCh <- errPick
+					return
+				}
+				if ranked && selected.ID != "auth-a" {
+					errCh <- errors.New("ranked request selected " + selected.ID)
+					return
+				}
+			}
+		}()
+	}
+	waitGroup.Wait()
+	close(errCh)
+	for errWorker := range errCh {
+		t.Fatalf("concurrent selection error = %v", errWorker)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_selection_candidates_test.go
+++ b/sdk/cliproxy/auth/conductor_selection_candidates_test.go
@@ -418,6 +418,7 @@ func TestManagerLegacySelectionPresentsOnlyRankedCandidates(t *testing.T) {
 		&Auth{ID: "auth-a", Provider: "gemini"},
 		&Auth{ID: "auth-b", Provider: "gemini"},
 		&Auth{ID: "auth-c", Provider: "gemini"},
+		&Auth{ID: "auth-unlisted", Provider: "gemini"},
 	)
 	opts := rankedCandidateOptions(
 		cliproxyexecutor.AuthSelectionCandidate{AuthID: "auth-c", PriorityRank: 0, StableOrder: 1},
@@ -432,12 +433,115 @@ func TestManagerLegacySelectionPresentsOnlyRankedCandidates(t *testing.T) {
 	if selector.calls != 1 {
 		t.Fatalf("selector.calls = %d, want 1", selector.calls)
 	}
-	if len(selector.lastAuthID) != 2 || selector.lastAuthID[0] != "auth-a" || selector.lastAuthID[1] != "auth-c" {
-		t.Fatalf("selector candidates = %v, want [auth-a auth-c] in stable order", selector.lastAuthID)
+	// The guarantee is set membership, not order: exactly the lowest-rank listed
+	// credentials are presented. auth-b is listed but ranks higher, so its rank is
+	// never reached; nothing unlisted may appear at all.
+	if len(selector.lastAuthID) != 2 {
+		t.Fatalf("selector candidates = %v, want exactly 2 candidates", selector.lastAuthID)
 	}
-	if selected == nil || selected.ID != "auth-c" {
-		t.Fatalf("pickNextLegacy() auth = %#v, want auth-c", selected)
+	if got, want := authIDSet(selector.lastAuthID), map[string]struct{}{"auth-a": {}, "auth-c": {}}; !sameAuthIDSet(got, want) {
+		t.Fatalf("selector candidates = %v, want exactly [auth-a auth-c] in any order", selector.lastAuthID)
 	}
+	for _, authID := range []string{"auth-b", "auth-unlisted"} {
+		if _, presented := authIDSet(selector.lastAuthID)[authID]; presented {
+			t.Fatalf("selector candidates = %v, want %q withheld", selector.lastAuthID, authID)
+		}
+	}
+	if selected == nil {
+		t.Fatal("pickNextLegacy() auth = nil, want a lowest-rank candidate")
+	}
+	if selected.ID != "auth-a" && selected.ID != "auth-c" {
+		t.Fatalf("pickNextLegacy() auth = %q, want one of [auth-a auth-c]", selected.ID)
+	}
+}
+
+// TestManagerRankedCandidatesStableOrderDoesNotAffectPresentedOrder pins the documented
+// contract of AuthSelectionCandidate.StableOrder: it is an audit key, not a preference.
+// Selection order inside a rank belongs to the configured scheduler, which observes its
+// own ordering, so inverting StableOrder against auth ID order changes nothing. This is
+// current, intended behavior - a future reader must not read it as a bug.
+func TestManagerRankedCandidatesStableOrderDoesNotAffectPresentedOrder(t *testing.T) {
+	tests := []struct {
+		name       string
+		candidates []cliproxyexecutor.AuthSelectionCandidate
+	}{
+		{
+			name: "stable order agrees with auth id order",
+			candidates: []cliproxyexecutor.AuthSelectionCandidate{
+				{AuthID: "auth-a", PriorityRank: 0, StableOrder: 0},
+				{AuthID: "auth-c", PriorityRank: 0, StableOrder: 1},
+			},
+		},
+		{
+			name: "stable order is inverted against auth id order",
+			candidates: []cliproxyexecutor.AuthSelectionCandidate{
+				{AuthID: "auth-c", PriorityRank: 0, StableOrder: 0},
+				{AuthID: "auth-a", PriorityRank: 0, StableOrder: 1},
+			},
+		},
+	}
+
+	var presented [][]string
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selector := &trackingSelector{}
+			manager := newRankedCandidateTestManager(t, selector,
+				&Auth{ID: "auth-a", Provider: "gemini"},
+				&Auth{ID: "auth-c", Provider: "gemini"},
+			)
+
+			if _, _, errPick := manager.pickNextLegacy(context.Background(), "gemini", "", rankedCandidateOptions(tt.candidates...), nil); errPick != nil {
+				t.Fatalf("pickNextLegacy() error = %v", errPick)
+			}
+			got := append([]string(nil), selector.lastAuthID...)
+			presented = append(presented, got)
+			if len(got) != 2 {
+				t.Fatalf("selector candidates = %v, want 2 candidates", got)
+			}
+		})
+	}
+
+	if len(presented) != 2 {
+		t.Fatalf("presented candidate lists = %d, want 2", len(presented))
+	}
+	if !equalAuthIDs(presented[0], presented[1]) {
+		t.Fatalf("presented order with inverted stable order = %v, want %v (StableOrder must not affect order)", presented[1], presented[0])
+	}
+}
+
+// authIDSet collects auth IDs into a set for order-independent assertions.
+func authIDSet(authIDs []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(authIDs))
+	for _, authID := range authIDs {
+		set[authID] = struct{}{}
+	}
+	return set
+}
+
+// sameAuthIDSet reports whether two auth ID sets hold exactly the same members.
+func sameAuthIDSet(got, want map[string]struct{}) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for authID := range want {
+		if _, present := got[authID]; !present {
+			return false
+		}
+	}
+	return true
+}
+
+// equalAuthIDs reports whether two auth ID slices match element for element.
+func equalAuthIDs(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for index := range got {
+		if got[index] != want[index] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestManagerMixedSelectionRestrictsToRankedCandidates(t *testing.T) {

--- a/sdk/cliproxy/auth/conductor_selection_candidates_test.go
+++ b/sdk/cliproxy/auth/conductor_selection_candidates_test.go
@@ -750,8 +750,8 @@ func TestFindAllAntigravityCreditsCandidateAuthsHonoursRankedCandidates(t *testi
 	if errCandidates != nil {
 		t.Fatalf("findAllAntigravityCreditsCandidateAuths() error = %v", errCandidates)
 	}
-	if len(candidates) != 1 || candidates[0].auth.ID != "ranked-credits-b" {
-		t.Fatalf("candidates = %#v, want only ranked-credits-b", candidates)
+	if len(candidates) != 2 || candidates[0].auth.ID != "ranked-credits-b" || candidates[1].auth.ID != "ranked-credits-c" {
+		t.Fatalf("candidates = %#v, want ranked ladder [ranked-credits-b ranked-credits-c]", candidates)
 	}
 
 	invalidOpts := cliproxyexecutor.Options{Metadata: map[string]any{

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -34,6 +34,9 @@ const GenerateMetadataKey = "generate"
 const (
 	// PinnedAuthMetadataKey locks execution to a specific auth ID.
 	PinnedAuthMetadataKey = "pinned_auth_id"
+	// AuthSelectionCandidatesMetadataKey restricts auth selection to an explicit ranked
+	// candidate list. Its value must be a []AuthSelectionCandidate.
+	AuthSelectionCandidatesMetadataKey = "auth_selection_candidates"
 	// SelectedAuthMetadataKey stores the auth ID selected by the scheduler.
 	SelectedAuthMetadataKey = "selected_auth_id"
 	// SelectedAuthCallbackMetadataKey carries an optional callback invoked with the selected auth ID.
@@ -49,6 +52,20 @@ const (
 	// CallerScopeMetadataKey isolates inferred session identities between downstream callers.
 	CallerScopeMetadataKey = "caller_scope"
 )
+
+// AuthSelectionCandidate describes one credential a caller allows for a single request.
+// The candidate list is request scoped: it never mutates persistent auth priority or any
+// scheduler state, and it restricts selection to exactly the listed credentials.
+type AuthSelectionCandidate struct {
+	// AuthID is the manager registered credential identifier.
+	AuthID string
+	// PriorityRank groups candidates into request-scoped ranks; the lowest rank that still
+	// contains an eligible credential is the only rank the configured scheduler runs within.
+	PriorityRank uint32
+	// StableOrder deterministically orders candidates inside one rank. It is presentation
+	// only and never replaces the configured scheduling strategy.
+	StableOrder uint32
+}
 
 // Request encapsulates the translated payload that will be sent to a provider executor.
 type Request struct {

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -67,8 +67,15 @@ type AuthSelectionCandidate struct {
 	// PriorityRank groups candidates into request-scoped ranks; the lowest rank that still
 	// contains an eligible credential is the only rank the configured scheduler runs within.
 	PriorityRank uint32
-	// StableOrder deterministically orders candidates inside one rank. It is presentation
-	// only and never replaces the configured scheduling strategy.
+	// StableOrder does not influence selection order within a rank. Once a rank is
+	// chosen, the configured scheduler alone decides which of that rank's credentials
+	// runs, and it observes its own ordering; nothing in this package reorders the
+	// candidates by this value.
+	//
+	// The field exists so a caller can record a deterministic, reproducible candidate
+	// list alongside the request: it is validated to be unique within a rank, so a
+	// stored plan identifies each candidate unambiguously and a routing decision can
+	// be replayed and explained after the fact. It is an audit key, not a preference.
 	StableOrder uint32
 }
 

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -54,8 +54,13 @@ const (
 )
 
 // AuthSelectionCandidate describes one credential a caller allows for a single request.
-// The candidate list is request scoped: it never mutates persistent auth priority or any
-// scheduler state, and it restricts selection to exactly the listed credentials.
+// The candidate list is request scoped: it never mutates persistent auth priority, and it
+// restricts selection to exactly the listed credentials.
+//
+// Like PinnedAuthMetadataKey and DisallowFreeAuthMetadataKey, narrowing the candidate list
+// for one request can perturb smooth weighted round-robin bookkeeping observed by concurrent
+// requests, because that strategy derives its running state from the eligible weight vector.
+// Round-robin and fill-first only advance on a match and are unaffected.
 type AuthSelectionCandidate struct {
 	// AuthID is the manager registered credential identifier.
 	AuthID string


### PR DESCRIPTION
## Withdrawn

This PR is withdrawn. The downstream integration had incorrectly elevated a local aspirational design into a required upstream dependency. CLIProxyAPI's existing public SDK surfaces already cover the immediate integration needs, and the downstream project will consume the latest official release rather than ask upstream to carry speculative APIs.

No downstream release will pin this fork branch, pseudo-version, or replacement.