### PR TITLE
perf(antigravity): avoid copying large requests in the Antigravity path

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	internalsignature "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	antigravityclaude "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/antigravity/claude"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	log "github.com/sirupsen/logrus"
@@ -133,7 +134,7 @@ func sanitizeAntigravityGeminiRequestSignatures(modelName string, rawJSON []byte
 
 func normalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byte {
 	rawJSON = repairAntigravityGeminiFunctionResponseNames(rawJSON)
-	contents := gjson.GetBytes(rawJSON, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(rawJSON, "request.contents")
 	if !contents.IsArray() {
 		return rawJSON
 	}
@@ -219,7 +220,7 @@ func normalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byte {
 }
 
 func repairAntigravityGeminiFunctionResponseNames(rawJSON []byte) []byte {
-	contents := gjson.GetBytes(rawJSON, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(rawJSON, "request.contents")
 	if !contents.IsArray() {
 		return rawJSON
 	}
@@ -301,7 +302,7 @@ func validateAntigravityRequestSignatures(ctx context.Context, modelName string,
 }
 
 func hasAntigravityClaudeTypedWebSearchTool(payload []byte) bool {
-	tools := gjson.GetBytes(payload, "tools")
+	tools := util.GetGJSONBytesNoCopy(payload, "tools")
 	if !tools.IsArray() {
 		return false
 	}
@@ -315,7 +316,7 @@ func hasAntigravityClaudeTypedWebSearchTool(payload []byte) bool {
 }
 
 func hasAntigravityGoogleSearchTool(payload []byte) bool {
-	tools := gjson.GetBytes(payload, "request.tools")
+	tools := util.GetGJSONBytesNoCopy(payload, "request.tools")
 	if !tools.IsArray() {
 		return false
 	}
@@ -341,7 +342,7 @@ func (e *AntigravityExecutor) resolveWebSearchGroundingURLs(ctx context.Context,
 }
 
 func countClaudeThinkingBlocks(rawJSON []byte) int {
-	messages := gjson.GetBytes(rawJSON, "messages")
+	messages := util.GetGJSONBytesNoCopy(rawJSON, "messages")
 	if !messages.IsArray() {
 		return 0
 	}

--- a/internal/runtime/executor/antigravity_reasoning_replay.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay.go
@@ -37,7 +37,7 @@ func antigravityReplayLogKey(value string) string {
 // Claude-facing provenance IDs are still present in a Gemini-shaped payload.
 func antigravityCountClaudeToolProvenanceIDs(payload []byte) int {
 	count := 0
-	contents := gjson.GetBytes(payload, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
 	if !contents.IsArray() {
 		return 0
 	}
@@ -139,7 +139,7 @@ func antigravityReasoningReplayClientSessionKey(ctx context.Context, req cliprox
 }
 
 func antigravityClaudeReplaySystemLane(payload []byte) string {
-	system := gjson.GetBytes(payload, "system")
+	system := util.GetGJSONBytesNoCopy(payload, "system")
 	if !system.Exists() {
 		return ""
 	}
@@ -191,7 +191,7 @@ func antigravityReplaySessionIDFromPayload(payload []byte) string {
 }
 
 func antigravityReasoningReplayPendingModelContentIndex(payload []byte) (contentIndex int, basePartIndex int) {
-	contents := gjson.GetBytes(payload, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
 	if !contents.IsArray() {
 		return 0, 0
 	}
@@ -221,7 +221,7 @@ func antigravityReasoningReplayPendingModelContentIndex(payload []byte) (content
 }
 
 func antigravityReasoningReplayResolveContentIndex(payload []byte, cached int) int {
-	contents := gjson.GetBytes(payload, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
 	if !contents.IsArray() {
 		return cached
 	}
@@ -408,7 +408,7 @@ func filterAntigravityReasoningReplayItemsForRequestWithSchemas(payload []byte, 
 
 func antigravityExistingToolCallKeys(payload []byte) map[string]bool {
 	existing := make(map[string]bool)
-	contents := gjson.GetBytes(payload, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
 	if !contents.IsArray() {
 		return existing
 	}
@@ -512,7 +512,7 @@ func antigravityFunctionResponseContentIndex(payload []byte, callID string) (int
 	if callID == "" {
 		return -1, false
 	}
-	contents := gjson.GetBytes(payload, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
 	if !contents.IsArray() {
 		return -1, false
 	}
@@ -539,7 +539,7 @@ func restoreAntigravityFunctionResponseReplayIdentity(payload []byte, currentID,
 		return payload
 	}
 	out := payload
-	contents := gjson.GetBytes(out, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(out, "request.contents")
 	contents.ForEach(func(contentKey, content gjson.Result) bool {
 		content.Get("parts").ForEach(func(partKey, part gjson.Result) bool {
 			response := part.Get("functionResponse")
@@ -566,7 +566,7 @@ func antigravityFunctionCallPartLocation(payload []byte, callID string) (content
 	if callID == "" {
 		return -1, -1, false
 	}
-	contents := gjson.GetBytes(payload, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
 	if !contents.IsArray() {
 		return -1, -1, false
 	}
@@ -627,7 +627,7 @@ func antigravityFunctionCallPartLocationForReplayWithSchemas(payload []byte, ite
 			name, ci, pi, util.IsGeminiClaudeToolUseID(candidateID))
 		return -1, -1, false
 	}
-	contents := gjson.GetBytes(payload, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
 	if !contents.IsArray() {
 		return -1, -1, false
 	}
@@ -705,7 +705,7 @@ func antigravityFunctionCallProvenanceLocation(payload []byte, itemResult gjson.
 }
 
 func insertAntigravityModelFunctionCallBeforeContent(payload []byte, beforeIndex int, name, callID, thoughtSig string, args gjson.Result) ([]byte, bool) {
-	contents := gjson.GetBytes(payload, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
 	if !contents.IsArray() {
 		return payload, false
 	}
@@ -838,7 +838,7 @@ func antigravityReplayPartOccurrence(parts []gjson.Result, targetPartIndex int, 
 }
 
 func antigravityReplayContextFingerprint(payload []byte, beforeContentIndex int) string {
-	contents := gjson.GetBytes(payload, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
 	if !contents.IsArray() || beforeContentIndex < 0 {
 		return ""
 	}
@@ -887,7 +887,7 @@ func antigravityReplayToolSchemasFromRequests(rawRequests ...[]byte) map[string]
 			continue
 		}
 		nameMap := util.SanitizedFunctionNameMap(raw)
-		tools := gjson.GetBytes(raw, "tools")
+		tools := util.GetGJSONBytesNoCopy(raw, "tools")
 		if !tools.IsArray() {
 			continue
 		}
@@ -996,7 +996,7 @@ func antigravityFunctionCallMatchesReplayItem(functionCall, itemResult gjson.Res
 }
 
 func antigravityPayloadHasClaudeToolProvenanceID(payload []byte) bool {
-	contents := gjson.GetBytes(payload, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
 	if !contents.IsArray() {
 		return false
 	}
@@ -1034,7 +1034,7 @@ func antigravitySyntheticToolCallID(reservedID string) string {
 // antigravityRepairUnsignedFirstFunctionCalls. Every other part is left alone,
 // preserving the native "1 signed + N unsigned" parallel-call shape.
 func degradeAntigravityClaudeToolProvenanceIDs(payload []byte) ([]byte, int) {
-	contents := gjson.GetBytes(payload, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
 	if !contents.IsArray() {
 		return payload, 0
 	}
@@ -1079,7 +1079,7 @@ func degradeAntigravityClaudeToolProvenanceIDs(payload []byte) ([]byte, int) {
 // context deliberately declines to replay one. Only a missing signature is filled
 // in here, so native signatures are never touched.
 func antigravityRepairUnsignedFirstFunctionCalls(payload []byte) []byte {
-	contents := gjson.GetBytes(payload, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
 	if !contents.IsArray() {
 		return payload
 	}
@@ -1134,7 +1134,7 @@ func antigravitySetReplayItemContextHash(item []byte, payload []byte, contentInd
 
 func antigravityThoughtSignatureReplayPartPath(payload []byte, itemResult gjson.Result) (string, bool) {
 	ci := int(itemResult.Get("contentIndex").Int())
-	contents := gjson.GetBytes(payload, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
 	if !contents.IsArray() {
 		return "", false
 	}
@@ -1309,7 +1309,7 @@ func antigravityFunctionResponsesCanRestoreID(payload []byte, currentID, nativeN
 	if currentID == "" {
 		return true
 	}
-	contents := gjson.GetBytes(payload, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
 	if !contents.IsArray() {
 		return false
 	}
@@ -1372,7 +1372,7 @@ func restoreAntigravityNativeFunctionCallReplay(payload []byte, contentIndex, pa
 		out, _ = sjson.SetBytes(out, partPath+".thoughtSignature", signature)
 	}
 	if currentID != "" && nativeID != "" && currentID != nativeID {
-		contents := gjson.GetBytes(out, "request.contents")
+		contents := util.GetGJSONBytesNoCopy(out, "request.contents")
 		contents.ForEach(func(contentKey, content gjson.Result) bool {
 			content.Get("parts").ForEach(func(partKey, part gjson.Result) bool {
 				response := part.Get("functionResponse")
@@ -1581,7 +1581,7 @@ func newAntigravityReasoningReplayAccumulator(scope antigravityReasoningReplaySc
 }
 
 func antigravityReasoningReplayItemsFromRequest(payload []byte) [][]byte {
-	contents := gjson.GetBytes(payload, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
 	if !contents.IsArray() {
 		return nil
 	}

--- a/internal/signature/gemini_validation.go
+++ b/internal/signature/gemini_validation.go
@@ -72,6 +72,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
 	"google.golang.org/protobuf/encoding/protowire"
 )
@@ -502,8 +503,8 @@ func isASCIIUUIDBytes(decoded []byte) bool {
 }
 
 func geminiContents(inputRawJSON []byte) (gjson.Result, string) {
-	if contents := gjson.GetBytes(inputRawJSON, "contents"); contents.Exists() {
+	if contents := util.GetGJSONBytesNoCopy(inputRawJSON, "contents"); contents.Exists() {
 		return contents, "contents"
 	}
-	return gjson.GetBytes(inputRawJSON, "request.contents"), "request.contents"
+	return util.GetGJSONBytesNoCopy(inputRawJSON, "request.contents"), "request.contents"
 }

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request.go
@@ -39,32 +39,32 @@ import (
 func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ bool) []byte {
 	rawJSON := inputRawJSON
 	functionNameMap := util.SanitizedFunctionNameMap(inputRawJSON)
-	template := `{"project":"","request":{},"model":""}`
-	templateBytes, _ := sjson.SetRawBytes([]byte(template), "request", rawJSON)
-	templateBytes, _ = sjson.SetBytes(templateBytes, "model", modelName)
-	template = string(templateBytes)
-	if gjson.Get(template, "request.model").Exists() {
-		template, _ = sjson.Delete(template, "request.model")
+	// Keep the envelope in []byte form. Round-tripping through string copies the
+	// entire request, which dominates allocations for large inline data. Fill the
+	// small envelope fields first so the payload is only spliced in once.
+	envelope, _ := sjson.SetBytes([]byte(`{"project":"","request":{},"model":""}`), "model", modelName)
+	rawJSON, _ = sjson.SetRawBytes(envelope, "request", rawJSON)
+	if util.GetGJSONBytesNoCopy(rawJSON, "request.model").Exists() {
+		rawJSON, _ = sjson.DeleteBytes(rawJSON, "request.model")
 	}
 
-	template, errFixCLIToolResponse := fixCLIToolResponse(template)
+	fixedJSON, errFixCLIToolResponse := fixCLIToolResponse(rawJSON)
 	if errFixCLIToolResponse != nil {
 		return []byte{}
 	}
+	rawJSON = fixedJSON
 
-	systemInstructionResult := gjson.Get(template, "request.system_instruction")
-	if systemInstructionResult.Exists() {
-		templateBytes, _ = sjson.SetRawBytes([]byte(template), "request.systemInstruction", []byte(systemInstructionResult.Raw))
-		template = string(templateBytes)
-		template, _ = sjson.Delete(template, "request.system_instruction")
+	if systemInstructionResult := util.GetGJSONBytesNoCopy(rawJSON, "request.system_instruction"); systemInstructionResult.Exists() {
+		rawJSON, _ = sjson.SetRawBytes(rawJSON, "request.systemInstruction", []byte(systemInstructionResult.Raw))
+		rawJSON, _ = sjson.DeleteBytes(rawJSON, "request.system_instruction")
 	}
-	rawJSON = []byte(template)
 
-	// Normalize roles in request.contents: default to valid values if missing/invalid
-	contents := gjson.GetBytes(rawJSON, "request.contents")
-	if contents.IsArray() {
+	// Normalize roles in request.contents: default to valid values if missing/invalid.
+	// The contents array is only materialized when a role actually changes; copying
+	// every content up front duplicates the whole payload for large inline data.
+	contents := util.GetGJSONBytesNoCopy(rawJSON, "request.contents")
+	if contents.IsArray() && geminiContentRolesNeedNormalization(contents) {
 		contentItems := translatorcommon.NewRawArrayItems(contents.Get("#").Int())
-		rolesChanged := false
 		previousRole := ""
 		contents.ForEach(func(_, value gjson.Result) bool {
 			role := value.Get("role").String()
@@ -76,18 +76,15 @@ func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 					role = "model"
 				}
 				content, _ = sjson.SetBytes(content, "role", role)
-				rolesChanged = true
 			}
 			previousRole = role
 			contentItems = append(contentItems, content)
 			return true
 		})
-		if rolesChanged {
-			rawJSON, _ = sjson.SetRawBytes(rawJSON, "request.contents", translatorcommon.JoinRawArray(contentItems))
-		}
+		rawJSON, _ = sjson.SetRawBytes(rawJSON, "request.contents", translatorcommon.JoinRawArray(contentItems))
 	}
 
-	toolsResult := gjson.GetBytes(rawJSON, "request.tools")
+	toolsResult := util.GetGJSONBytesNoCopy(rawJSON, "request.tools")
 	if toolsResult.IsArray() {
 		seenFunctionNames := make(map[string]struct{})
 		toolsChanged := false
@@ -158,8 +155,23 @@ func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 	return common.AttachDefaultSafetySettings(rawJSON, "request.safetySettings")
 }
 
+// geminiContentRolesNeedNormalization reports whether any content role is missing
+// or invalid and therefore requires rebuilding the contents array.
+func geminiContentRolesNeedNormalization(contents gjson.Result) bool {
+	needsNormalization := false
+	contents.ForEach(func(_, value gjson.Result) bool {
+		role := value.Get("role").String()
+		if role != "user" && role != "model" {
+			needsNormalization = true
+			return false
+		}
+		return true
+	})
+	return needsNormalization
+}
+
 func removeEmptyGeminiFunctionTools(rawJSON []byte) []byte {
-	tools := gjson.GetBytes(rawJSON, "request.tools")
+	tools := util.GetGJSONBytesNoCopy(rawJSON, "request.tools")
 	if tools.IsArray() && len(tools.Array()) == 0 {
 		rawJSON, _ = sjson.DeleteBytes(rawJSON, "request.tools")
 		return rawJSON
@@ -175,7 +187,7 @@ func removeEmptyGeminiFunctionTools(rawJSON []byte) []byte {
 					changed = true
 				}
 			}
-			if len(gjson.ParseBytes(toolJSON).Map()) == 0 {
+			if len(util.ParseGJSONBytesNoCopy(toolJSON).Map()) == 0 {
 				changed = true
 				continue
 			}
@@ -193,8 +205,36 @@ func removeEmptyGeminiFunctionTools(rawJSON []byte) []byte {
 	return rawJSON
 }
 
+// geminiFunctionNameFields lists the part fields that can carry a function name.
+var geminiFunctionNameFields = []string{"functionCall", "functionResponse", "function_call", "function_response"}
+
+// geminiFunctionNamesNeedRewrite reports whether any part carries a function name
+// that must be remapped or coerced to a string.
+func geminiFunctionNamesNeedRewrite(contents gjson.Result, functionNameMap map[string]string) bool {
+	needsRewrite := false
+	contents.ForEach(func(_, content gjson.Result) bool {
+		content.Get("parts").ForEach(func(_, part gjson.Result) bool {
+			for _, field := range geminiFunctionNameFields {
+				nameResult := part.Get(field + ".name")
+				name := nameResult.String()
+				if name == "" {
+					continue
+				}
+				if nameResult.Type == gjson.String && util.MapSanitizedFunctionName(functionNameMap, name) == name {
+					continue
+				}
+				needsRewrite = true
+				return false
+			}
+			return true
+		})
+		return !needsRewrite
+	})
+	return needsRewrite
+}
+
 func rewriteGeminiFunctionNames(rawJSON []byte, functionNameMap map[string]string) []byte {
-	contents := gjson.GetBytes(rawJSON, "request.contents")
+	contents := util.GetGJSONBytesNoCopy(rawJSON, "request.contents")
 	canBatchContents := contents.IsArray()
 	if canBatchContents {
 		contents.ForEach(func(_, content gjson.Result) bool {
@@ -206,8 +246,9 @@ func rewriteGeminiFunctionNames(rawJSON []byte, functionNameMap map[string]strin
 			return true
 		})
 	}
-	if canBatchContents {
-		contentsChanged := false
+	// Rebuilding the contents array copies every content and part, so only pay for
+	// it once a name actually needs rewriting.
+	if canBatchContents && geminiFunctionNamesNeedRewrite(contents, functionNameMap) {
 		contentItems := translatorcommon.NewRawArrayItems(contents.Get("#").Int())
 		contents.ForEach(func(_, content gjson.Result) bool {
 			contentJSON := []byte(content.Raw)
@@ -215,7 +256,7 @@ func rewriteGeminiFunctionNames(rawJSON []byte, functionNameMap map[string]strin
 			partItems := make([][]byte, 0, 4)
 			content.Get("parts").ForEach(func(_, part gjson.Result) bool {
 				partJSON := []byte(part.Raw)
-				for _, field := range []string{"functionCall", "functionResponse", "function_call", "function_response"} {
+				for _, field := range geminiFunctionNameFields {
 					nameResult := part.Get(field + ".name")
 					name := nameResult.String()
 					if name == "" {
@@ -233,18 +274,15 @@ func rewriteGeminiFunctionNames(rawJSON []byte, functionNameMap map[string]strin
 			})
 			if partsChanged {
 				contentJSON, _ = sjson.SetRawBytes(contentJSON, "parts", translatorcommon.JoinRawArray(partItems))
-				contentsChanged = true
 			}
 			contentItems = append(contentItems, contentJSON)
 			return true
 		})
-		if contentsChanged {
-			rawJSON, _ = sjson.SetRawBytes(rawJSON, "request.contents", translatorcommon.JoinRawArray(contentItems))
-		}
-	} else {
+		rawJSON, _ = sjson.SetRawBytes(rawJSON, "request.contents", translatorcommon.JoinRawArray(contentItems))
+	} else if !canBatchContents {
 		for contentIndex, content := range contents.Array() {
 			for partIndex, part := range content.Get("parts").Array() {
-				for _, field := range []string{"functionCall", "functionResponse", "function_call", "function_response"} {
+				for _, field := range geminiFunctionNameFields {
 					nameResult := part.Get(field + ".name")
 					name := nameResult.String()
 					if name == "" {
@@ -265,7 +303,7 @@ func rewriteGeminiFunctionNames(rawJSON []byte, functionNameMap map[string]strin
 		"request.toolConfig.functionCallingConfig.allowedFunctionNames",
 		"request.tool_config.function_calling_config.allowed_function_names",
 	} {
-		allowedNames := gjson.GetBytes(rawJSON, allowedPath)
+		allowedNames := util.GetGJSONBytesNoCopy(rawJSON, allowedPath)
 		if allowedNames.IsArray() {
 			namesChanged := false
 			nameItems := make([][]byte, 0, 4)
@@ -551,9 +589,11 @@ func parseFunctionResponseRaw(response gjson.Result, fallbackName string) string
 // Returns:
 //   - string: The processed JSON string with grouped function calls and responses
 //   - error: An error if the processing fails
-func fixCLIToolResponse(input string) (string, error) {
-	// Parse the input JSON to extract the conversation structure
-	parsed := gjson.Parse(input)
+func fixCLIToolResponse(input []byte) ([]byte, error) {
+	// Parse the input JSON to extract the conversation structure.
+	// The parsed result references input directly; input must not be mutated
+	// while the result and its raw slices are still in use.
+	parsed := util.ParseGJSONBytesNoCopy(input)
 
 	// Extract the contents array which contains the conversation messages
 	contents := parsed.Get("request.contents")
@@ -690,7 +730,7 @@ func fixCLIToolResponse(input string) (string, error) {
 	}
 
 	// Update the original JSON with the new contents
-	result, _ := sjson.SetRawBytes([]byte(input), "request.contents", translatorcommon.JoinRawArray(contentItems))
+	result, _ := sjson.SetRawBytes(input, "request.contents", translatorcommon.JoinRawArray(contentItems))
 
-	return string(result), nil
+	return result, nil
 }

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
@@ -332,13 +332,13 @@ func TestFixCLIToolResponse_PreservesFunctionResponseParts(t *testing.T) {
 		}
 	}`
 
-	result, err := fixCLIToolResponse(input)
+	result, err := fixCLIToolResponse([]byte(input))
 	if err != nil {
 		t.Fatalf("fixCLIToolResponse failed: %v", err)
 	}
 
 	// Find the function response content (role=function)
-	contents := gjson.Get(result, "request.contents").Array()
+	contents := gjson.GetBytes(result, "request.contents").Array()
 	var funcContent gjson.Result
 	for _, c := range contents {
 		if c.Get("role").String() == "function" {
@@ -396,12 +396,12 @@ func TestFixCLIToolResponse_BackfillsEmptyFunctionResponseName(t *testing.T) {
 		}
 	}`
 
-	result, err := fixCLIToolResponse(input)
+	result, err := fixCLIToolResponse([]byte(input))
 	if err != nil {
 		t.Fatalf("fixCLIToolResponse failed: %v", err)
 	}
 
-	contents := gjson.Get(result, "request.contents").Array()
+	contents := gjson.GetBytes(result, "request.contents").Array()
 	var funcContent gjson.Result
 	for _, c := range contents {
 		if c.Get("role").String() == "function" {
@@ -443,12 +443,12 @@ func TestFixCLIToolResponse_BackfillsMultipleEmptyNames(t *testing.T) {
 		}
 	}`
 
-	result, err := fixCLIToolResponse(input)
+	result, err := fixCLIToolResponse([]byte(input))
 	if err != nil {
 		t.Fatalf("fixCLIToolResponse failed: %v", err)
 	}
 
-	contents := gjson.Get(result, "request.contents").Array()
+	contents := gjson.GetBytes(result, "request.contents").Array()
 	var funcContent gjson.Result
 	for _, c := range contents {
 		if c.Get("role").String() == "function" {
@@ -497,12 +497,12 @@ func TestFixCLIToolResponse_PreservesExistingName(t *testing.T) {
 		}
 	}`
 
-	result, err := fixCLIToolResponse(input)
+	result, err := fixCLIToolResponse([]byte(input))
 	if err != nil {
 		t.Fatalf("fixCLIToolResponse failed: %v", err)
 	}
 
-	contents := gjson.Get(result, "request.contents").Array()
+	contents := gjson.GetBytes(result, "request.contents").Array()
 	var funcContent gjson.Result
 	for _, c := range contents {
 		if c.Get("role").String() == "function" {
@@ -543,12 +543,12 @@ func TestFixCLIToolResponse_MoreResponsesThanCalls(t *testing.T) {
 		}
 	}`
 
-	result, err := fixCLIToolResponse(input)
+	result, err := fixCLIToolResponse([]byte(input))
 	if err != nil {
 		t.Fatalf("fixCLIToolResponse failed: %v", err)
 	}
 
-	contents := gjson.Get(result, "request.contents").Array()
+	contents := gjson.GetBytes(result, "request.contents").Array()
 	var funcContent gjson.Result
 	for _, c := range contents {
 		if c.Get("role").String() == "function" {
@@ -601,12 +601,12 @@ func TestFixCLIToolResponse_MultipleGroupsFIFO(t *testing.T) {
 		}
 	}`
 
-	result, err := fixCLIToolResponse(input)
+	result, err := fixCLIToolResponse([]byte(input))
 	if err != nil {
 		t.Fatalf("fixCLIToolResponse failed: %v", err)
 	}
 
-	contents := gjson.Get(result, "request.contents").Array()
+	contents := gjson.GetBytes(result, "request.contents").Array()
 	var funcContents []gjson.Result
 	for _, c := range contents {
 		if c.Get("role").String() == "function" {

--- a/internal/translator/antigravity/gemini/noop_optimization_test.go
+++ b/internal/translator/antigravity/gemini/noop_optimization_test.go
@@ -1,6 +1,8 @@
 package gemini
 
 import (
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -50,25 +52,62 @@ func TestRewriteGeminiFunctionNamesNormalizesNonStringNames(t *testing.T) {
 }
 
 func TestFixCLIToolResponseReusesHistoryWithoutFunctionResponses(t *testing.T) {
-	input := `{"request":{"contents":[{"role":"user","parts":[{"text":"hello"}]},{"role":"model","parts":[{"text":"world"}]}]}}`
+	input := []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"hello"}]},{"role":"model","parts":[{"text":"world"}]}]}}`)
 
 	output, errFix := fixCLIToolResponse(input)
 	if errFix != nil {
 		t.Fatalf("fixCLIToolResponse returned an error: %v", errFix)
 	}
-	if output != input {
+	if string(output) != string(input) {
 		t.Fatalf("history changed:\n got: %s\nwant: %s", output, input)
+	}
+	if &output[0] != &input[0] {
+		t.Fatal("history without function responses caused a payload copy")
 	}
 }
 
 func TestFixCLIToolResponsePreservesObjectNormalization(t *testing.T) {
-	input := `{"request":{"contents":{"first":{"role":"user","parts":[{"text":"hello"}]}}}}`
+	input := []byte(`{"request":{"contents":{"first":{"role":"user","parts":[{"text":"hello"}]}}}}`)
 
 	output, errFix := fixCLIToolResponse(input)
 	if errFix != nil {
 		t.Fatalf("fixCLIToolResponse returned an error: %v", errFix)
 	}
-	if !gjson.Get(output, "request.contents").IsArray() {
+	if !gjson.GetBytes(output, "request.contents").IsArray() {
 		t.Fatalf("contents should be normalized to an array: %s", output)
+	}
+}
+
+// TestConvertGeminiRequestToAntigravityBoundsLargePayloadCopies keeps the number of
+// full-payload copies bounded for large inline data. The assertions run directly in
+// the test (not inside testing.Benchmark) so a regression fails loudly instead of
+// being swallowed by a discarded benchmark result.
+func TestConvertGeminiRequestToAntigravityBoundsLargePayloadCopies(t *testing.T) {
+	const inlineDataSize = 4 << 20
+	input := []byte(`{"contents":[{"role":"user","parts":[{"inlineData":{"mimeType":"image/png","data":"` +
+		strings.Repeat("A", inlineDataSize) + `"}},{"text":"describe"}]}]}`)
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	output := ConvertGeminiRequestToAntigravity("gemini-3-flash", input, false)
+	runtime.ReadMemStats(&after)
+
+	if got := gjson.GetBytes(output, "request.contents.0.parts.0.inlineData.data").String(); len(got) != inlineDataSize {
+		t.Fatalf("inline data length = %d, want %d", len(got), inlineDataSize)
+	}
+	if got := gjson.GetBytes(output, "model").String(); got != "gemini-3-flash" {
+		t.Fatalf("model = %q, want gemini-3-flash", got)
+	}
+	if got := gjson.GetBytes(output, "request.safetySettings"); !got.IsArray() {
+		t.Fatalf("request.safetySettings = %s, want array", got.Raw)
+	}
+
+	// Wrapping the request in the Antigravity envelope and setting the model each
+	// allocate one payload-sized buffer; everything beyond that is a regression.
+	const allowedCopies = 3
+	if allocated := after.TotalAlloc - before.TotalAlloc; allocated > allowedCopies*inlineDataSize {
+		t.Fatalf("conversion allocated %d bytes for a %d byte payload, want at most %d",
+			allocated, inlineDataSize, allowedCopies*inlineDataSize)
 	}
 }

--- a/internal/translator/gemini/gemini/gemini_gemini_request_test.go
+++ b/internal/translator/gemini/gemini/gemini_gemini_request_test.go
@@ -14,17 +14,26 @@ var largeInlineDataBenchmarkOutput []byte
 func TestConvertGeminiRequestToGeminiReusesLargeNormalizedPayload(t *testing.T) {
 	input := largeInlineDataGeminiRequest(true)
 
+	// Assert the reuse invariant with t.Fatal rather than inside testing.Benchmark:
+	// a failing benchmark aborts before any iteration completes and yields a zero
+	// BenchmarkResult, so AllocedBytesPerOp would report 0 and silently satisfy the
+	// allocation check below exactly when the payload is being copied.
+	output := ConvertGeminiRequestToGemini("gemini-test", input, false)
+	if &output[0] != &input[0] {
+		t.Fatal("normalized request should reuse the input payload")
+	}
+	largeInlineDataBenchmarkOutput = output
+
 	result := testing.Benchmark(func(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
-			output := ConvertGeminiRequestToGemini("gemini-test", input, false)
-			if &output[0] != &input[0] {
-				b.Fatal("normalized request should reuse the input payload")
-			}
-			largeInlineDataBenchmarkOutput = output
+			largeInlineDataBenchmarkOutput = ConvertGeminiRequestToGemini("gemini-test", input, false)
 		}
 	})
 
+	if result.N == 0 {
+		t.Fatal("allocation benchmark did not complete an iteration")
+	}
 	if allocated := result.AllocedBytesPerOp(); allocated >= 1<<20 {
 		t.Fatalf("normalized 20 MiB inlineData request allocated %d bytes/op, want less than 1 MiB", allocated)
 	}

--- a/internal/util/gjson.go
+++ b/internal/util/gjson.go
@@ -14,3 +14,14 @@ func GetGJSONBytesNoCopy(data []byte, path string) gjson.Result {
 	}
 	return gjson.Get(unsafe.String(unsafe.SliceData(data), len(data)), path)
 }
+
+// ParseGJSONBytesNoCopy parses data into a GJSON result that references data
+// directly. gjson.ParseBytes copies the whole document, which is prohibitive
+// for multi-megabyte payloads. Callers must not retain the result or mutate
+// data while using it.
+func ParseGJSONBytesNoCopy(data []byte) gjson.Result {
+	if len(data) == 0 {
+		return gjson.Result{}
+	}
+	return gjson.Parse(unsafe.String(unsafe.SliceData(data), len(data)))
+}

--- a/internal/util/gjson_test.go
+++ b/internal/util/gjson_test.go
@@ -1,6 +1,9 @@
 package util
 
-import "testing"
+import (
+	"testing"
+	"unsafe"
+)
 
 func TestGetGJSONBytesNoCopy(t *testing.T) {
 	input := []byte(`{"request":{"contents":[{"role":"user"}]}}`)
@@ -12,6 +15,31 @@ func TestGetGJSONBytesNoCopy(t *testing.T) {
 
 func TestGetGJSONBytesNoCopyEmptyInput(t *testing.T) {
 	if result := GetGJSONBytesNoCopy(nil, "contents"); result.Exists() {
+		t.Fatalf("empty input result = %s, want missing", result.Raw)
+	}
+}
+
+func TestParseGJSONBytesNoCopy(t *testing.T) {
+	input := []byte(`{"request":{"contents":[{"role":"user"}]}}`)
+	root := ParseGJSONBytesNoCopy(input)
+	if !root.IsObject() || root.Get("request.contents.0.role").String() != "user" {
+		t.Fatalf("parsed root = %s, want user content array", root.Raw)
+	}
+}
+
+func TestParseGJSONBytesNoCopyReferencesInput(t *testing.T) {
+	input := []byte(`{"contents":[{"role":"user"}]}`)
+	root := ParseGJSONBytesNoCopy(input)
+	if len(root.Raw) != len(input) {
+		t.Fatalf("raw length = %d, want %d", len(root.Raw), len(input))
+	}
+	if unsafe.StringData(root.Raw) != unsafe.SliceData(input) {
+		t.Fatal("parsed result copied the input instead of referencing it")
+	}
+}
+
+func TestParseGJSONBytesNoCopyEmptyInput(t *testing.T) {
+	if result := ParseGJSONBytesNoCopy(nil); result.Exists() {
 		t.Fatalf("empty input result = %s, want missing", result.Raw)
 	}
 }

--- a/internal/util/nocopy_invariant_test.go
+++ b/internal/util/nocopy_invariant_test.go
@@ -90,42 +90,58 @@ var inPlaceByteWritePatterns = []*regexp.Regexp{
 	regexp.MustCompile(`^\s*[a-zA-Z_][A-Za-z0-9_.]*\[[a-zA-Z0-9_]+\] = 0$`),
 }
 
-// inPlaceByteWriteAllowlist enumerates the reviewed in-place byte writes. Each
-// entry states why the write cannot corrupt a no-copy GJSON result: either the
-// buffer is private to the writer, or every reader copies out before the write.
-var inPlaceByteWriteAllowlist = map[string]string{
-	"internal/runtime/executor/claude_signing.go":           "writes CCH digits into bytes.Clone(body); the caller's body is never touched",
-	"internal/runtime/executor/claude_executor_cloaking.go": "shifts []string headers to prepend a block; no byte of any payload is rewritten",
-	"internal/runtime/executor/claude_executor_request.go":  "shifts []string headers to insert a part; no byte of any payload is rewritten",
-	"internal/runtime/executor/helps/claude_mcp_alias.go":   "copies an HMAC sum into a local fixed-size digest array",
-	"internal/client/codex/live/tcp_proxy.go":               "copies header and payload into a freshly allocated frame",
-	"internal/home/client.go":                               "zeroes a secret buffer after json.Unmarshal has copied every value out",
-	"internal/pluginstore/auth.go":                          "zeroes a locally built credential buffer after base64 encoding copied it out",
-	"internal/wsrelay/manager.go":                           "rewrites a locally allocated random-id buffer",
+// reviewedInPlaceByteWrites records the reviewed in-place byte writes per file.
+// The count is part of the contract: a new write inside an already reviewed file
+// must be reviewed too, so the count must be updated deliberately. Each reason
+// states why the write cannot corrupt a no-copy GJSON result, either because the
+// buffer is private to the writer or because every reader copies out first.
+type reviewedInPlaceByteWrite struct {
+	count  int
+	reason string
+}
+
+var reviewedInPlaceByteWrites = map[string]reviewedInPlaceByteWrite{
+	"internal/runtime/executor/claude_signing.go":           {2, "writes CCH digits into bytes.Clone(body); the caller's body is never touched"},
+	"internal/runtime/executor/claude_executor_cloaking.go": {1, "shifts []string headers to prepend a block; no byte of any payload is rewritten"},
+	"internal/runtime/executor/claude_executor_request.go":  {2, "shifts []string headers to insert a part; no byte of any payload is rewritten"},
+	"internal/runtime/executor/helps/claude_mcp_alias.go":   {1, "copies an HMAC sum into a local fixed-size digest array"},
+	"internal/client/codex/live/tcp_proxy.go":               {1, "copies header and payload into a freshly allocated frame"},
+	"internal/home/client.go":                               {1, "zeroes a secret buffer after json.Unmarshal has copied every value out"},
+	"internal/pluginstore/auth.go":                          {1, "zeroes a locally built credential buffer after base64 encoding copied it out"},
 }
 
 // TestInPlaceByteWritesAreReviewed keeps the set of in-place byte writes small
-// and justified. A new hit means the author must prove that no no-copy GJSON
-// result derived from that buffer can still be alive, then document it here.
+// and justified. Any change to the set, including a new write in an already
+// reviewed file, fails until the author proves that no no-copy GJSON result
+// derived from that buffer can still be alive and records it above.
 func TestInPlaceByteWritesAreReviewed(t *testing.T) {
 	root := repoRoot(t)
-	var offenders []string
+	found := make(map[string][]string)
 	forEachSourceFile(t, root, func(rel string, data []byte) {
-		if _, allowed := inPlaceByteWriteAllowlist[rel]; allowed {
-			return
-		}
 		for _, line := range strings.Split(string(data), "\n") {
 			for _, pattern := range inPlaceByteWritePatterns {
 				if pattern.MatchString(line) {
-					offenders = append(offenders, rel+": "+strings.TrimSpace(line))
+					found[rel] = append(found[rel], strings.TrimSpace(line))
 				}
 			}
 		}
 	})
-	if len(offenders) > 0 {
-		t.Fatalf("unreviewed in-place byte write(s):\n  %s\n"+
-			"Prove that no no-copy GJSON result derived from that buffer is still alive, then add the file to inPlaceByteWriteAllowlist with the reason.",
-			strings.Join(offenders, "\n  "))
+	for rel, lines := range found {
+		reviewed, ok := reviewedInPlaceByteWrites[rel]
+		if !ok {
+			t.Errorf("unreviewed in-place byte write in %s:\n  %s\nProve that no no-copy GJSON result derived from that buffer is still alive, then record it in reviewedInPlaceByteWrites.",
+				rel, strings.Join(lines, "\n  "))
+			continue
+		}
+		if len(lines) != reviewed.count {
+			t.Errorf("%s has %d in-place byte write(s), reviewed %d (%s):\n  %s",
+				rel, len(lines), reviewed.count, reviewed.reason, strings.Join(lines, "\n  "))
+		}
+	}
+	for rel := range reviewedInPlaceByteWrites {
+		if _, ok := found[rel]; !ok {
+			t.Errorf("stale entry in reviewedInPlaceByteWrites: %s no longer contains an in-place byte write", rel)
+		}
 	}
 }
 

--- a/internal/util/nocopy_invariant_test.go
+++ b/internal/util/nocopy_invariant_test.go
@@ -1,0 +1,148 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// inPlaceSJSONTokens are the sjson knobs that let a write reuse the caller's
+// backing array instead of allocating a new one.
+var inPlaceSJSONTokens = []string{"ReplaceInPlace", "Optimistic"}
+
+// inPlaceSJSONAllowlist holds files that are allowed to opt into in-place
+// sjson writes. A file may only be added here once it is proven that no
+// no-copy GJSON result (GetGJSONBytesNoCopy / ParseGJSONBytesNoCopy) derived
+// from the same buffer can still be alive at that point.
+var inPlaceSJSONAllowlist = map[string]struct{}{}
+
+// forEachSourceFile visits every non-test Go file in the repository.
+func forEachSourceFile(t *testing.T, root string, visit func(rel string, data []byte)) {
+	t.Helper()
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "vendor", "node_modules", "testdata":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		rel, errRel := filepath.Rel(root, path)
+		if errRel != nil {
+			return errRel
+		}
+		data, errRead := os.ReadFile(path)
+		if errRead != nil {
+			return errRead
+		}
+		visit(filepath.ToSlash(rel), data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repository: %v", err)
+	}
+}
+
+// TestNoInPlaceSJSONWrites protects the invariant that request payload buffers
+// stay immutable for their whole lifetime.
+//
+// GetGJSONBytesNoCopy and ParseGJSONBytesNoCopy hand out gjson.Result values
+// whose Raw and Str alias the caller's []byte. Go strings must never change,
+// so any in-place mutation of that buffer turns already-derived results into
+// silently wrong data: re-parsing sees the new bytes, and strings that were
+// used as map keys keep a hash computed from the old ones. The race detector
+// cannot see this, and normal tests rarely trigger it, so the invariant is
+// enforced statically here instead.
+func TestNoInPlaceSJSONWrites(t *testing.T) {
+	root := repoRoot(t)
+	var offenders []string
+	forEachSourceFile(t, root, func(rel string, data []byte) {
+		if _, allowed := inPlaceSJSONAllowlist[rel]; allowed {
+			return
+		}
+		for _, token := range inPlaceSJSONTokens {
+			if strings.Contains(string(data), token) {
+				offenders = append(offenders, rel+" uses "+token)
+			}
+		}
+	})
+	if len(offenders) > 0 {
+		t.Fatalf("in-place sjson writes would corrupt no-copy GJSON results that alias the same buffer:\n  %s\n"+
+			"Either keep the default (allocating) sjson call, or prove no no-copy result derived from that buffer is still alive and add the file to inPlaceSJSONAllowlist.",
+			strings.Join(offenders, "\n  "))
+	}
+}
+
+// inPlaceByteWritePatterns match the realistic ways Go code overwrites bytes
+// of an existing buffer: copying into a slice expression, or zeroing elements
+// in a loop. They do not catch every possible form, so they are a tripwire for
+// new code rather than a proof of absence.
+var inPlaceByteWritePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\bcopy\([a-zA-Z_][A-Za-z0-9_.]*\[`),
+	regexp.MustCompile(`^\s*[a-zA-Z_][A-Za-z0-9_.]*\[[a-zA-Z0-9_]+\] = 0$`),
+}
+
+// inPlaceByteWriteAllowlist enumerates the reviewed in-place byte writes. Each
+// entry states why the write cannot corrupt a no-copy GJSON result: either the
+// buffer is private to the writer, or every reader copies out before the write.
+var inPlaceByteWriteAllowlist = map[string]string{
+	"internal/runtime/executor/claude_signing.go":           "writes CCH digits into bytes.Clone(body); the caller's body is never touched",
+	"internal/runtime/executor/claude_executor_cloaking.go": "shifts []string headers to prepend a block; no byte of any payload is rewritten",
+	"internal/runtime/executor/claude_executor_request.go":  "shifts []string headers to insert a part; no byte of any payload is rewritten",
+	"internal/runtime/executor/helps/claude_mcp_alias.go":   "copies an HMAC sum into a local fixed-size digest array",
+	"internal/client/codex/live/tcp_proxy.go":               "copies header and payload into a freshly allocated frame",
+	"internal/home/client.go":                               "zeroes a secret buffer after json.Unmarshal has copied every value out",
+	"internal/pluginstore/auth.go":                          "zeroes a locally built credential buffer after base64 encoding copied it out",
+	"internal/wsrelay/manager.go":                           "rewrites a locally allocated random-id buffer",
+}
+
+// TestInPlaceByteWritesAreReviewed keeps the set of in-place byte writes small
+// and justified. A new hit means the author must prove that no no-copy GJSON
+// result derived from that buffer can still be alive, then document it here.
+func TestInPlaceByteWritesAreReviewed(t *testing.T) {
+	root := repoRoot(t)
+	var offenders []string
+	forEachSourceFile(t, root, func(rel string, data []byte) {
+		if _, allowed := inPlaceByteWriteAllowlist[rel]; allowed {
+			return
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			for _, pattern := range inPlaceByteWritePatterns {
+				if pattern.MatchString(line) {
+					offenders = append(offenders, rel+": "+strings.TrimSpace(line))
+				}
+			}
+		}
+	})
+	if len(offenders) > 0 {
+		t.Fatalf("unreviewed in-place byte write(s):\n  %s\n"+
+			"Prove that no no-copy GJSON result derived from that buffer is still alive, then add the file to inPlaceByteWriteAllowlist with the reason.",
+			strings.Join(offenders, "\n  "))
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, errStat := os.Stat(filepath.Join(dir, "go.mod")); errStat == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found above working directory")
+		}
+		dir = parent
+	}
+}

--- a/sdk/cliproxy/session/identity.go
+++ b/sdk/cliproxy/session/identity.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
@@ -140,7 +141,9 @@ func hasExplicitSession(headers map[string][]string, payload []byte) bool {
 	if len(payload) == 0 {
 		return false
 	}
-	root := gjson.ParseBytes(payload)
+	// Parsing without copying matters here: this runs on every request and the
+	// payload can be multiple megabytes.
+	root := util.ParseGJSONBytesNoCopy(payload)
 	for _, path := range []string{"session_id", "sessionId", "conversation_id", "prompt_cache_key"} {
 		if NormalizeExplicitID(root.Get(path).String()) != "" {
 			return true


### PR DESCRIPTION
## Summary

A single 8 MiB `inlineData` Gemini request through the Antigravity path allocated about **480 MB** end to end. Most of it was copying: `gjson.GetBytes` copies the matched subtree on every read, `gjson.ParseBytes` copies the whole document, and the Gemini-to-Antigravity translator rebuilt the `contents` array and re-spliced the payload even when nothing changed.

This is the same class of problem as #4832, applied to the Antigravity request path.

Measured on the same request with `pprof allocs?gc=1`: **479.49 MB → 287.63 MB (-40%)**.

## What changes

**`internal/util`** — add `ParseGJSONBytesNoCopy`, mirroring the existing `GetGJSONBytesNoCopy` contract: the result references the caller's bytes, so callers must neither retain it nor mutate the buffer while it is in use.

**`internal/translator/antigravity/gemini`** — four separate copies removed from `ConvertGeminiRequestToAntigravity`:

- the entry point converted the payload between `string` and `[]byte`, copying the whole request before any rewrite;
- the `contents` array was rebuilt part by part even when every role was already valid and no function name needed rewriting (the write was already gated by `rolesChanged` / `contentsChanged`, so only the wasted copies are removed, not the behavior);
- the envelope was built by splicing the payload into the template and then setting `model`, which copied the payload a second time — the small envelope fields are now filled first;
- `fixCLIToolResponse` took and returned a `string`, so even its no-op path copied the request twice; it now takes and returns `[]byte` and returns the input unchanged on the fast path.

**`internal/runtime/executor`, `internal/signature`, `sdk/cliproxy/session`** — whole-array reads (`request.contents`, `messages`, `tools`) switched to the no-copy helpers, and `hasExplicitSession` no longer parses the entire body with `gjson.ParseBytes` on every request. Every one of these call sites only reads from the result and writes through `sjson`, which allocates a new buffer, so the payload stays immutable while the results are alive.

**Guards** — `TestConvertGeminiRequestToGeminiReusesLargeNormalizedPayload` asserted its reuse invariant with `b.Fatal` *inside* `testing.Benchmark`. A failing benchmark aborts before completing an iteration and returns a zero `BenchmarkResult`, so `AllocedBytesPerOp()` reported `0` and the allocation check passed exactly when the payload was being copied — injecting a full copy into the translator left the test green. It now asserts with `t.Fatal` and rejects a zero-iteration result.

Two static guards are added for the no-copy invariant, because mutating a buffer that a no-copy result aliases corrupts already-derived values in a way the race detector cannot see: one rejects in-place `sjson` options, the other keeps the set of in-place byte writes small and documented (each of the 7 reviewed sites records why it cannot corrupt a no-copy result; a new write, including one inside an already reviewed file, fails the test until it is justified).

## Benchmarks

`-benchmem -count=6`, medians, run sequentially in separate worktrees:

| case | ns/op before → after | B/op before → after |
| --- | --- | --- |
| 60 B text | 3,641 → 3,342 (-8.2%) | 5,094 → 4,477 (-12%) |
| 80 tool-call turns | 301,634 → 295,130 (-2.2%) | 359 KB → 281 KB (-22%) |
| 1 MiB inlineData | 5.88 ms → 5.01 ms (-14.8%) | 10.6 MB → 2.1 MB (-80%) |
| 8 MiB inlineData | 44.94 ms → 39.31 ms (-12.5%) | 84.0 MB → 16.8 MB (-80%) |
| 8 MiB + invalid role | 48.01 ms → 44.51 ms (-7.3%) | 109 MB → 50 MB (-54%) |
| executor: normalize roles (8 MiB) | 13.10 ms → 12.68 ms (-3.2%) | 16.8 MB → 160 B |
| executor: repair response names (8 MiB) | 4.64 ms → 4.88 ms (+5.1%, ranges overlap) | 8.4 MB → 0 B |

The wall-clock win is not the point: ~5 ms on a request whose upstream inference takes seconds is invisible. The 190 MB of avoided allocation per request is what reduces GC pressure under concurrency.

## Verification

**Byte-exact differential against `dev`.** The same throwaway harness was placed in two worktrees, one at the merge base and one at this branch, and every output was compared:

| entry point | assertions | result |
| --- | --- | --- |
| `ConvertGeminiRequestToAntigravity` | 8,244 | identical |
| 13 Antigravity executor helpers | 1,950 | identical |
| reasoning-replay helpers | 61,147 | identical |
| `ValidateGeminiThoughtSignatures` / `ValidateGeminiFunctionCallPairing` | 2,010 | identical |
| `DeriveID` / `ClaudeMetadataSessionID` | 10,899 | identical |
| `Enrich` (the only caller of `hasExplicitSession`) | 22,992 | identical |

Inputs include pretty-printed, tab/CRLF, duplicate-key and reordered-key payloads (a skip-rebuild fast path preserves formatting where an unconditional rebuild would normalize it, so that difference only shows up with whitespace-bearing inputs), invalid JSON, non-string function names, snake_case variants, 1 MiB and 8 MiB inline data, plus deterministic randomized generators. Non-degeneracy was checked: 7,678 distinct output hashes out of 8,244 translator cases, output sizes up to 8,389,348 bytes, and 1,289 of the 2,010 signature assertions are non-nil errors.

**Coverage intersection.** Running the differential under `-coverprofile` and intersecting the covered blocks with the changed line numbers from `git diff --unified=0`: **82 executable changed lines, 82 exercised, 0 uncovered**. Reaching that required fixing three cases where a changed line ran without asserting anything — the tool-schema collector reads top-level `tools` in Claude/OpenAI shape rather than `functionDeclarations`, provenance degradation only triggers on `cpa_gemini_` + 32 hex ids, and the id-rewrite branch of `restoreAntigravityNativeFunctionCallReplay` is only reachable with a synthesized replay item whose `call_id` differs from the payload.

**Guards were verified to fail.** Injecting a full payload copy makes the Gemini reuse guard fail (it previously passed); injecting an extra `gjson.GetBytes` makes the allocation check fail; injecting an in-place `sjson` option or a new in-place byte write makes the corresponding guard fail, including inside an already reviewed file.

`gofmt` clean, `go build ./...`, `go test -count=1 ./...`, and `-race` on the touched packages all pass, and each of the five commits builds and passes the touched-package tests on its own. The pre-existing `-race` failure in `TestAntigravityExecute_NoCreditsWithoutConductorFlag` reproduces on unmodified `dev` and is unrelated.

**Live.** Deployed on a local instance against the real Antigravity upstream: an 8 MiB inline-data request and a two-turn tool-call conversation (dotted MCP tool name round-tripped intact, `thoughtSignature` replay, correct tool-derived answer) both succeed.

## Note

`translator-path-guard` will fail on this PR because `internal/translator/**` is touched. The translator change is the core of the fix rather than a standalone edit, and it comes with the byte-exact differential above.
