### PR TITLE
fix(thinking): default OpenAI-compatible models to xhigh/max level support

### DIFF
--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -665,7 +665,8 @@ type OpenAICompatibilityModel struct {
 	IsCompat bool `yaml:"is-compat,omitempty" json:"is-compat,omitempty"`
 
 	// Thinking configures the thinking/reasoning capability for this model.
-	// If nil, the model defaults to level-based reasoning with levels ["low", "medium", "high"].
+	// If nil, the model defaults to level-based reasoning with levels
+	// ["low", "medium", "high", "xhigh", "max"].
 	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 

--- a/sdk/cliproxy/auth/api_key_model_capabilities.go
+++ b/sdk/cliproxy/auth/api_key_model_capabilities.go
@@ -214,7 +214,11 @@ func compileOpenAICompatibleModelCapabilities(out map[string][]apiKeyModelCapabi
 	for i := range models {
 		support := models[i].Thinking
 		if support == nil && !models[i].Image {
-			support = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+			// Default discrete levels for OpenAI-compatible models. xhigh/max are
+			// included so upstreams that support them (e.g. DeepSeek flash with
+			// reasoning_effort=max, OpenAI xhigh) receive the user's requested level
+			// instead of being silently downgraded to high.
+			support = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high", "xhigh", "max"}}
 		}
 		addConfiguredModelCapability(out, models[i].Name, models[i].Alias, "openai-compatibility", support, models[i].IsCompat)
 	}

--- a/sdk/cliproxy/auth/api_key_model_capabilities_test.go
+++ b/sdk/cliproxy/auth/api_key_model_capabilities_test.go
@@ -256,6 +256,66 @@ func assertResolvedThinkingLevels(t *testing.T, req cliproxyexecutor.Request, wa
 	}
 }
 
+func TestAttachResolvedAPIKeyModelInfoDefaultsToExtendedLevels(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{OpenAICompatibility: []internalconfig.OpenAICompatibility{{
+		Name:    "keyless",
+		Prefix:  "tenant",
+		BaseURL: "https://example.com/v1",
+		Models: []internalconfig.OpenAICompatibilityModel{
+			{Name: "shared-upstream", Alias: "public-model", ForceMapping: true, IsCompat: true},
+		},
+	}}})
+	auth := &Auth{
+		ID:       "auth-keyless-default-levels",
+		Provider: "openai-compatibility:keyless",
+		Prefix:   "tenant",
+		Attributes: map[string]string{
+			AttributeSource: "config:keyless[0]",
+			"compat_name":   "keyless",
+			"provider_key":  "openai-compatibility:keyless",
+		},
+	}
+	registerCapabilityTestAuth(t, manager, auth)
+	models, _, _, routing := manager.executionModelCandidatesWithAlias(auth, "tenant/public-model")
+	if len(models) != 1 || models[0] != "shared-upstream" {
+		t.Fatalf("execution models = %v, want [shared-upstream]", models)
+	}
+	req := attachResolvedAPIKeyModelInfo(routing, cliproxyexecutor.Request{}, auth, "tenant/public-model", models[0])
+	// Models without an explicit thinking block must default to a level set that
+	// includes xhigh/max so high-intent requests pass through to upstreams that
+	// support them (e.g. DeepSeek reasoning_effort=max) instead of being
+	// silently downgraded to high.
+	assertResolvedThinkingLevels(t, req, "low", "medium", "high", "xhigh", "max")
+}
+
+func TestAttachResolvedAPIKeyModelInfoKeepsExplicitConfiguredLevels(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{OpenAICompatibility: []internalconfig.OpenAICompatibility{{
+		Name:    "keyless",
+		Prefix:  "tenant",
+		BaseURL: "https://example.com/v1",
+		Models: []internalconfig.OpenAICompatibilityModel{
+			{Name: "shared-upstream", Alias: "public-model",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"low", "high"}}},
+		},
+	}}})
+	auth := &Auth{
+		ID:       "auth-keyless-explicit-levels",
+		Provider: "openai-compatibility:keyless",
+		Prefix:   "tenant",
+		Attributes: map[string]string{
+			AttributeSource: "config:keyless[0]",
+			"compat_name":   "keyless",
+			"provider_key":  "openai-compatibility:keyless",
+		},
+	}
+	registerCapabilityTestAuth(t, manager, auth)
+	models, _, _, routing := manager.executionModelCandidatesWithAlias(auth, "tenant/public-model")
+	req := attachResolvedAPIKeyModelInfo(routing, cliproxyexecutor.Request{}, auth, "tenant/public-model", models[0])
+	assertResolvedThinkingLevels(t, req, "low", "high")
+}
+
 func TestCodexAPIKeyModelIsCompat(t *testing.T) {
 	cfg := &internalconfig.Config{CodexKey: []internalconfig.CodexKey{{
 		APIKey:  "codex-key",

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -729,7 +729,10 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		}
 		thinkingSupport := model.Thinking
 		if thinkingSupport == nil && !model.Image {
-			thinkingSupport = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+			// Keep in sync with compileOpenAICompatibleModelCapabilities: xhigh/max
+			// are part of the default level set so high-intent requests are not
+			// silently downgraded for OpenAI-compatible upstreams that support them.
+			thinkingSupport = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high", "xhigh", "max"}}
 		}
 		info.Thinking = modelconfig.NormalizeThinkingSupport(thinkingSupport)
 		info.SupportedInputModalities = normalizeCompatConfigModalities(model.InputModalities)

--- a/test/thinking_conversion_test.go
+++ b/test/thinking_conversion_test.go
@@ -1131,6 +1131,39 @@ func TestThinkingE2EMatrix_Body(t *testing.T) {
 			expectField: "",
 			expectErr:   true,
 		},
+		// Case 3a: default-level-model (no explicit thinking block, defaults to
+		// [low, medium, high, xhigh, max]) reasoning_effort=xhigh → passthrough
+		{
+			name:        "3a",
+			from:        "openai",
+			to:          "openai",
+			model:       "default-level-model",
+			inputJSON:   `{"model":"default-level-model","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"xhigh"}`,
+			expectField: "reasoning_effort",
+			expectValue: "xhigh",
+			expectErr:   false,
+		},
+		// Case 3b: default-level-model reasoning_effort=max → passthrough
+		{
+			name:        "3b",
+			from:        "openai",
+			to:          "openai",
+			model:       "default-level-model",
+			inputJSON:   `{"model":"default-level-model","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"max"}`,
+			expectField: "reasoning_effort",
+			expectValue: "max",
+			expectErr:   false,
+		},
+		// Case 3c: default-level-model reasoning_effort=ultra → invalid level error
+		{
+			name:        "3c",
+			from:        "openai",
+			to:          "openai",
+			model:       "default-level-model",
+			inputJSON:   `{"model":"default-level-model","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"ultra"}`,
+			expectField: "",
+			expectErr:   true,
+		},
 		// Case 4: reasoning_effort=none → clamped to minimal
 		{
 			name:        "4",
@@ -3273,6 +3306,18 @@ func TestThinkingE2EClaudeAdaptive_Body(t *testing.T) {
 // getTestModels returns the shared model definitions for E2E tests.
 func getTestModels() []*registry.ModelInfo {
 	return []*registry.ModelInfo{
+		{
+			ID:          "default-level-model",
+			Object:      "model",
+			Created:     1700000000,
+			OwnedBy:     "test",
+			Type:        "openai-compatibility",
+			DisplayName: "Default Level Model",
+			// Mirrors an OpenAI-compatible config entry without an explicit
+			// `thinking` block: the routing layer fills in the default level set
+			// [low, medium, high, xhigh, max] before execution.
+			Thinking: &registry.ThinkingSupport{Levels: []string{"low", "medium", "high", "xhigh", "max"}},
+		},
 		{
 			ID:          "level-model",
 			Object:      "model",


### PR DESCRIPTION
## Problem

OpenAI-compatible models configured **without** an explicit `thinking` block fall back to a hardcoded level set of `["low", "medium", "high"]` in two places:

- `sdk/cliproxy/auth/api_key_model_capabilities.go` (`compileOpenAICompatibleModelCapabilities`)
- `sdk/cliproxy/service_models.go` (`buildOpenAICompatibilityConfigModels`)

Because `mapConfiguredHighIntent` downgrades `reasoning_effort=xhigh`/`max` to the highest supported level, these requests were **silently rewritten to `high`** before reaching the upstream. Upstreams that natively support higher levels — e.g. DeepSeek official API (`reasoning_effort=max → flash=max`) and OpenAI-compatible gateways with `xhigh` — could never receive the user's requested level. Usage logs showed `high` even though the client asked for `max`.

## Fix

Extend the default level set to `["low", "medium", "high", "xhigh", "max"]`, matching the static registry entries (e.g. Claude Sonnet 5 already uses this set). The behavior change is narrow:

- `xhigh`/`max` now pass through unchanged for models without an explicit `thinking` config (previously downgraded to `high`).
- Models with an explicit `thinking.levels` keep their configured set (already supported).
- Invalid levels such as `ultra` still fail validation with `level %q not supported`.
- `none`/`minimal` behavior unchanged (`Levels[0]` is still `low`).

## Verification

- New unit tests in `sdk/cliproxy/auth`: default level set includes `xhigh`/`max`; explicit `thinking.levels` is preserved.
- New E2E cases in `test/thinking_conversion_test.go`: `reasoning_effort=xhigh` and `max` pass through on a default-level model; `ultra` is rejected.
- `go test ./internal/thinking/ ./internal/registry/ ./internal/modelconfig/ ./sdk/cliproxy/... ./test/...` all pass.