### PR TITLE
fix(codex): forward sequential cutoff reasoning summaries

### DIFF
--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -58,7 +58,11 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	body, _ = sjson.DeleteBytes(body, "generate")
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
+	reasoningSummaryDelivery := gjson.GetBytes(body, "stream_options.reasoning_summary_delivery")
 	body, _ = sjson.DeleteBytes(body, "stream_options")
+	if reasoningSummaryDelivery.Exists() {
+		body, _ = sjson.SetBytes(body, "stream_options.reasoning_summary_delivery", reasoningSummaryDelivery.Value())
+	}
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = normalizeCodexInstructions(body)
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {

--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -288,6 +288,56 @@ func TestCodexExecutorExecuteStreamExplicitTerminalFailureIsNotSuccessful(t *tes
 	assertNotRequestScopedTestError(t, streamErr)
 }
 
+func TestCodexAutoExecutorHTTPFallbackForwardsSequentialCutoffReasoningSummaryDelivery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		if gjson.GetBytes(body, "stream_options.include_usage").Exists() {
+			t.Errorf("unsupported stream option was forwarded: %s", body)
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		if delivery := gjson.GetBytes(body, "stream_options.reasoning_summary_delivery").String(); delivery == "sequential_cutoff" {
+			_, _ = w.Write([]byte(`data: {"type":"response.reasoning_summary_text.done","item_id":"rs_1","summary_index":0,"text":"Checking"}` + "\n\n"))
+		} else {
+			_, _ = w.Write([]byte(`data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_1","summary_index":0,"delta":"Checking"}` + "\n\n"))
+		}
+		_, _ = w.Write([]byte(`data: {"type":"response.completed","response":{"id":"resp_1","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexAutoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+	result, err := executor.ExecuteStream(cliproxyexecutor.WithDownstreamWebsocket(context.Background()), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.6-sol",
+		Payload: []byte(`{"model":"gpt-5.6-sol","input":"hello","reasoning":{"summary":"detailed"},"stream_options":{"reasoning_summary_delivery":"sequential_cutoff","include_usage":true}}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FromString("openai-response"),
+		ResponseFormat: sdktranslator.FromString("openai-response"),
+		Stream:         true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var output bytes.Buffer
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream error: %v", chunk.Err)
+		}
+		output.Write(chunk.Payload)
+	}
+	if !strings.Contains(output.String(), `"type":"response.reasoning_summary_text.done"`) {
+		t.Fatalf("missing sequential-cutoff summary event; output=%s", output.String())
+	}
+}
+
 func TestCodexExecutorTransportFailureBeforeTerminalIsRequestScoped(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Summary

- preserve `stream_options.reasoning_summary_delivery` when the Codex auto executor falls back from a downstream WebSocket request to the HTTP upstream
- continue removing unsupported stream options such as `include_usage` from the HTTP upstream request
- add a regression test covering the downstream-WebSocket to upstream-HTTP fallback path

## Root cause

The HTTP streaming executor removed the entire `stream_options` object. As a result, a client requesting `reasoning_summary_delivery: sequential_cutoff` did not send that preference to the Codex upstream. The upstream returned reasoning-summary delta events instead of the requested completed summary events, leaving clients that consume sequential-cutoff `.done` events with no displayable summary.

The native WebSocket upstream path already forwards this field unchanged. This change brings the HTTP fallback path in line with the same request contract and with the upstream Codex behavior documented in https://github.com/openai/codex/pull/31306.

## Verification

- `go test -run '^TestCodexAutoExecutorHTTPFallbackForwardsSequentialCutoffReasoningSummaryDelivery$' ./internal/runtime/executor`
- `go test -run 'Codex' ./internal/runtime/executor`
- `go build -o test-output ./cmd/server && rm test-output`
- `git diff --check`

Closes #4863