### PR TITLE
fix(claude): preserve Advisor server tool requests

### DIFF
--- a/internal/runtime/executor/claude_executor_beta_policy_test.go
+++ b/internal/runtime/executor/claude_executor_beta_policy_test.go
@@ -48,7 +48,7 @@ func TestApplyClaudeHeaders_ConfirmedClientKeepsOAuthCredentialBetas(t *testing.
 	if parts[len(parts)-1] != claudeExtendedCacheTTLBeta {
 		t.Fatalf("Anthropic-Beta = %q, want OAuth cache trailer %s", got, claudeExtendedCacheTTLBeta)
 	}
-	if strings.Contains(got, "advisor-tool-2026-03-01") {
+	if strings.Contains(got, claudeAdvisorToolBeta) {
 		t.Fatalf("Anthropic-Beta = %q, contains stale OAuth tool beta", got)
 	}
 	if strings.Contains(got, claudeCacheDiagnosisBeta) {
@@ -103,6 +103,46 @@ func TestApplyClaudeHeaders_KnownBodyBetaStillPlacedOnAnthropic(t *testing.T) {
 	parts := strings.Split(got, ",")
 	if len(parts) < 2 || parts[1] != claudeContext1MBeta {
 		t.Fatalf("Anthropic-Beta = %q, want %s honored at its captured position", got, claudeContext1MBeta)
+	}
+}
+
+func TestApplyClaudeHeaders_AdvisorBetaFollowsCallerRequest(t *testing.T) {
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-advisor-beta"}}
+	body := []byte(`{"model":"claude-opus-5","tools":[{"type":"advisor_20260301","name":"advisor"}]}`)
+
+	for _, tc := range []struct {
+		name     string
+		incoming http.Header
+		want     bool
+	}{
+		{
+			name: "requested",
+			incoming: http.Header{
+				"Anthropic-Beta": []string{claudeCodeBeta + "," + claudeAdvisorToolBeta + "," + claudeEffortBeta},
+			},
+			want: true,
+		},
+		{name: "not requested", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := newClaudeHeaderTestRequest(t, nil)
+			if err := applyClaudeHeaders(req, auth, "key-advisor-beta", false, nil,
+				body, nil, tc.incoming, false); err != nil {
+				t.Fatalf("applyClaudeHeaders() error = %v", err)
+			}
+
+			got := req.Header.Get("Anthropic-Beta")
+			advisorIndex := strings.Index(got, claudeAdvisorToolBeta)
+			if (advisorIndex >= 0) != tc.want {
+				t.Fatalf("Anthropic-Beta = %q, advisor beta present = %v, want %v", got, advisorIndex >= 0, tc.want)
+			}
+			if tc.want {
+				effortIndex := strings.Index(got, claudeEffortBeta)
+				if effortIndex < 0 || advisorIndex > effortIndex {
+					t.Fatalf("Anthropic-Beta = %q, want advisor beta before effort beta", got)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -37,6 +37,7 @@ const (
 	claudeContext1MBeta          = "context-1m-2025-08-07"
 	claudeMidConvSystemBeta      = "mid-conversation-system-2026-04-07"
 	claudeAdvancedToolUseBeta    = "advanced-tool-use-2025-11-20"
+	claudeAdvisorToolBeta        = "advisor-tool-2026-03-01"
 	claudeEffortBeta             = "effort-2025-11-24"
 	claudeServerSideFallbackBeta = "server-side-fallback-2026-06-01"
 	claudeFallbackCreditBeta     = "fallback-credit-2026-06-01"
@@ -71,12 +72,14 @@ var claudeCodeTrailingBetas = []string{
 }
 
 // claudeCodeCLIBetas assembles the Anthropic-Beta baseline the way Claude Code
-// 2.1.220 does: the list is per-request, not a fixed string. requested holds the
+// does: the list is per-request, not a fixed string. requested holds the
 // betas the caller asked for, which decide the capability flags below.
 //
 // Verified against api.anthropic.com with isolated 2.1.220 profiles on both
 // API-key and OAuth paths. A 2026-08-03 A/B capture with two distinct OAuth
 // accounts confirmed the current tool beta and OAuth trailer below.
+// The Advisor position was captured from Claude Code 2.1.226 against a local
+// loopback endpoint; it was not probed against the Anthropic API.
 // The full observed order is:
 //
 //	 1 claude-code-20250219
@@ -89,12 +92,13 @@ var claudeCodeTrailingBetas = []string{
 //	 8 prompt-caching-scope-2026-01-05
 //	 9 mid-conversation-system-2026-04-07  models accepting a role=system turn
 //	10 advanced-tool-use-2025-11-20       requests with tools
-//	11 effort-2025-11-24
-//	12 server-side-fallback-2026-06-01
-//	13 fallback-credit-2026-06-01
-//	14 fast-mode-2026-02-01               speed:fast requests only
-//	15 extended-cache-ttl-2025-04-11      OAuth credentials only
-//	16 cache-diagnosis-2026-04-07         requests with diagnostics only
+//	11 advisor-tool-2026-03-01            requests with the Advisor server tool
+//	12 effort-2025-11-24
+//	13 server-side-fallback-2026-06-01
+//	14 fallback-credit-2026-06-01
+//	15 fast-mode-2026-02-01               speed:fast requests only
+//	16 extended-cache-ttl-2025-04-11      OAuth credentials only
+//	17 cache-diagnosis-2026-04-07         requests with diagnostics only
 //
 // An empty body keeps the optimistic role=system default, matching the cloaking
 // policy for unknown and future model IDs.
@@ -119,6 +123,9 @@ func claudeCodeCLIBetas(body []byte, requested map[string]bool, oauthToken bool)
 	}
 	if tools := gjson.GetBytes(body, "tools"); tools.IsArray() && len(tools.Array()) > 0 {
 		betas = append(betas, claudeAdvancedToolUseBeta)
+	}
+	if requested[claudeAdvisorToolBeta] {
+		betas = append(betas, claudeAdvisorToolBeta)
 	}
 	betas = append(betas, claudeEffortBeta)
 	if oauthToken && !requested[claudeFallbackCreditBeta] {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -4635,6 +4635,18 @@ func TestRemapOAuthToolNames_TypedCustomUsesMCPAlias(t *testing.T) {
 	}
 }
 
+func TestRemapOAuthToolNames_AdvisorServerToolRemainsNative(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"advisor_20260301","name":"advisor","model":"claude-opus-5"}]}`)
+	out, reverseMap := remapOAuthToolNamesWithOptions(body, claudeMCPAliasOptions{secret: "caller-secret"})
+
+	if !bytes.Equal(out, body) {
+		t.Fatalf("advisor server tool was rewritten:\n got: %s\nwant: %s", out, body)
+	}
+	if len(reverseMap) != 0 {
+		t.Fatalf("reverseMap = %v, want empty", reverseMap)
+	}
+}
+
 func TestRemapOAuthToolNames_MCPAliasAvoidsClientCollision(t *testing.T) {
 	const secret = "credential-secret"
 	initialCandidate := helps.ClaudeMCPToolAlias(secret, "fetch_url", 0)

--- a/internal/runtime/executor/helps/claude_builtin_tools.go
+++ b/internal/runtime/executor/helps/claude_builtin_tools.go
@@ -27,6 +27,7 @@ func newClaudeBuiltinToolRegistry() map[string]bool {
 func IsClaudeServerToolType(toolType string) bool {
 	toolType = strings.ToLower(strings.TrimSpace(toolType))
 	for _, prefix := range []string{
+		"advisor_",
 		"bash_",
 		"code_execution_",
 		"computer_",

--- a/internal/runtime/executor/helps/claude_builtin_tools_test.go
+++ b/internal/runtime/executor/helps/claude_builtin_tools_test.go
@@ -32,7 +32,7 @@ func TestClaudeBuiltinToolRegistry_AugmentsKnownTypedBuiltinsFromBody(t *testing
 }
 
 func TestIsClaudeServerToolType(t *testing.T) {
-	for _, toolType := range []string{"web_search_20250305", "code_execution_20250522", "tool_search_tool_regex_20251119"} {
+	for _, toolType := range []string{"advisor_20260301", "web_search_20250305", "code_execution_20250522", "tool_search_tool_regex_20251119"} {
 		if !IsClaudeServerToolType(toolType) {
 			t.Fatalf("IsClaudeServerToolType(%q) = false, want true", toolType)
 		}


### PR DESCRIPTION
## Summary

- Preserve `advisor_` server tools during Claude OAuth request preprocessing.
- Forward `advisor-tool-2026-03-01` only when Claude Code requests it.
- Keep the beta in Claude Code 2.1.226 wire order, before `effort-2025-11-24`.
- Add regression tests for the server tool shape and beta-header presence, absence, and order.

## Root cause

The proxy preserved standard built-in server tools but converted the new Advisor tool into a custom tool. After that shape was fixed, the Claude header policy still rebuilt unconfirmed client beta headers without allowing the Advisor beta. Anthropic then rejected the preserved `advisor_20260301` tool because its required beta was absent.

## Impact

Claude Code Advisor requests keep both the typed server tool and its required beta. Requests that do not ask for Advisor do not receive the beta.

## Validation

- `go test ./internal/runtime/executor/...`
- `go test ./...`
- `go build -o test-output ./cmd/server`
- `git diff --check`
- Captured the Claude Code 2.1.226 header order against a local loopback endpoint only. No manual Anthropic API request was used for this fix.
