### PR TITLE
fix(claude): advance prompt cache breakpoints after cloaking

### DIFF
--- a/internal/runtime/executor/caching_verify_test.go
+++ b/internal/runtime/executor/caching_verify_test.go
@@ -331,7 +331,7 @@ func TestEnsureCacheControlPreservesLaterMessageTTL(t *testing.T) {
 	}
 }
 
-func TestEnsureCacheControlCappedAfterIndependentInjection(t *testing.T) {
+func TestEnsureCacheControlStopsIndependentInjectionAtLimit(t *testing.T) {
 	input := []byte(`{
 		"tools":[{"name":"tool"}],
 		"system":[{"type":"text","text":"system"}],
@@ -345,12 +345,8 @@ func TestEnsureCacheControlCappedAfterIndependentInjection(t *testing.T) {
 	}`)
 
 	output := ensureCacheControl(input)
-	if got := countCacheControls(output); got != 5 {
-		t.Fatalf("cache_control count before cap = %d, want 5: %s", got, output)
-	}
-	output = enforceCacheControlLimit(output, 4)
 	if got := countCacheControls(output); got != 4 {
-		t.Fatalf("cache_control count after cap = %d, want 4: %s", got, output)
+		t.Fatalf("cache_control count = %d, want 4: %s", got, output)
 	}
 	if got := gjson.GetBytes(output, "tools.0.cache_control.type").String(); got != "ephemeral" {
 		t.Fatalf("tools breakpoint type = %q, want ephemeral: %s", got, output)
@@ -358,8 +354,50 @@ func TestEnsureCacheControlCappedAfterIndependentInjection(t *testing.T) {
 	if got := gjson.GetBytes(output, "system.0.cache_control.type").String(); got != "ephemeral" {
 		t.Fatalf("system breakpoint type = %q, want ephemeral: %s", got, output)
 	}
-	if got := gjson.GetBytes(output, "messages.2.content.0.cache_control.type").String(); got != "ephemeral" {
-		t.Fatalf("rolling breakpoint type = %q, want ephemeral: %s", got, output)
+	for _, path := range []string{
+		"messages.0.content.0.cache_control.type",
+		"messages.1.content.0.cache_control.type",
+	} {
+		if got := gjson.GetBytes(output, path).String(); got != "ephemeral" {
+			t.Fatalf("caller breakpoint %s = %q, want preserved ephemeral: %s", path, got, output)
+		}
+	}
+	if got := gjson.GetBytes(output, "messages.2.content.0.cache_control"); got.Exists() {
+		t.Fatalf("rolling breakpoint unexpectedly replaced a caller breakpoint: %s", output)
+	}
+}
+
+func TestEnsureCacheControlPreservesFullCallerLayout(t *testing.T) {
+	input := []byte(`{
+		"tools":[{"name":"tool"}],
+		"system":[{"type":"text","text":"system"}],
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"first","cache_control":{"type":"ephemeral"}}]},
+			{"role":"assistant","content":[{"type":"text","text":"reply one","cache_control":{"type":"ephemeral"}}]},
+			{"role":"user","content":[{"type":"text","text":"second","cache_control":{"type":"ephemeral"}}]},
+			{"role":"assistant","content":[{"type":"text","text":"reply two","cache_control":{"type":"ephemeral"}}]},
+			{"role":"user","content":"third"}
+		]
+	}`)
+
+	output := ensureCacheControl(input)
+	if got := countCacheControls(output); got != 4 {
+		t.Fatalf("cache_control count = %d, want 4: %s", got, output)
+	}
+	for _, path := range []string{
+		"messages.0.content.0.cache_control.type",
+		"messages.1.content.0.cache_control.type",
+		"messages.2.content.0.cache_control.type",
+		"messages.3.content.0.cache_control.type",
+	} {
+		if got := gjson.GetBytes(output, path).String(); got != "ephemeral" {
+			t.Fatalf("caller breakpoint %s = %q, want preserved ephemeral: %s", path, got, output)
+		}
+	}
+	for _, path := range []string{"tools.0.cache_control", "system.0.cache_control"} {
+		if got := gjson.GetBytes(output, path); got.Exists() {
+			t.Fatalf("automatic breakpoint %s was added to a full caller layout: %s", path, output)
+		}
 	}
 }
 

--- a/internal/runtime/executor/caching_verify_test.go
+++ b/internal/runtime/executor/caching_verify_test.go
@@ -287,9 +287,12 @@ func TestEnsureCacheControlNonCloakedMultiTurn(t *testing.T) {
 		]
 	}`)
 
-	output := ensureCacheControl(input)
+	output := normalizeCacheControlTTL(ensureCacheControl(input))
 	if got := gjson.GetBytes(output, "tools.0.cache_control.type").String(); got != "ephemeral" {
 		t.Fatalf("tools breakpoint type = %q, want ephemeral: %s", got, output)
+	}
+	if got := gjson.GetBytes(output, "tools.0.cache_control.ttl").String(); got != "1h" {
+		t.Fatalf("tools breakpoint ttl = %q, want inherited 1h: %s", got, output)
 	}
 	if got := gjson.GetBytes(output, "system.0.cache_control.ttl").String(); got != "1h" {
 		t.Fatalf("caller system breakpoint ttl = %q, want preserved 1h: %s", got, output)
@@ -299,6 +302,32 @@ func TestEnsureCacheControlNonCloakedMultiTurn(t *testing.T) {
 	}
 	if gjson.GetBytes(output, "messages.0.content.0.cache_control").Exists() {
 		t.Fatalf("first user turn unexpectedly received cache_control: %s", output)
+	}
+}
+
+func TestEnsureCacheControlPreservesLaterMessageTTL(t *testing.T) {
+	input := []byte(`{
+		"tools":[{"name":"tool"}],
+		"system":"system",
+		"messages":[
+			{"role":"user","content":"first"},
+			{"role":"assistant","content":"reply one"},
+			{"role":"user","content":"second"},
+			{"role":"assistant","content":"reply two"},
+			{"role":"user","content":[{"type":"text","text":"third","cache_control":{"type":"ephemeral","ttl":"1h"}}]}
+		]
+	}`)
+
+	output := normalizeCacheControlTTL(ensureCacheControl(input))
+	for _, path := range []string{
+		"tools.0.cache_control.ttl",
+		"system.0.cache_control.ttl",
+		"messages.2.content.0.cache_control.ttl",
+		"messages.4.content.0.cache_control.ttl",
+	} {
+		if got := gjson.GetBytes(output, path).String(); got != "1h" {
+			t.Fatalf("%s = %q, want preserved 1h: %s", path, got, output)
+		}
 	}
 }
 

--- a/internal/runtime/executor/caching_verify_test.go
+++ b/internal/runtime/executor/caching_verify_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/tidwall/gjson"
 )
@@ -191,28 +192,146 @@ func TestEnsureCacheControl(t *testing.T) {
 		}
 	})
 
-	// Test case 9: Existing message cache_control should skip injection
-	t.Run("Messages Skip When Cache Control Exists", func(t *testing.T) {
+	// Test case 9: An existing message cache_control does not block the rolling breakpoint
+	t.Run("Messages Preserve Existing And Add Rolling Breakpoint", func(t *testing.T) {
 		input := []byte(`{
 			"model": "claude-3-5-sonnet",
 			"messages": [
-				{"role": "user", "content": [{"type": "text", "text": "First user"}]},
+				{"role": "user", "content": [{"type": "text", "text": "First user", "cache_control": {"type": "ephemeral", "ttl": "1h"}}]},
 				{"role": "assistant", "content": [{"type": "text", "text": "Assistant reply", "cache_control": {"type": "ephemeral"}}]},
-				{"role": "user", "content": [{"type": "text", "text": "Second user"}]}
+				{"role": "user", "content": [{"type": "text", "text": "Second user"}]},
+				{"role": "assistant", "content": "Assistant reply 2"},
+				{"role": "user", "content": "Third user"}
 			]
 		}`)
 		output := ensureCacheControl(input)
 
-		userCache := gjson.GetBytes(output, "messages.0.content.0.cache_control")
-		if userCache.Exists() {
-			t.Errorf("cache_control should NOT be injected when a message already has cache_control")
+		if got := gjson.GetBytes(output, "messages.2.content.0.cache_control.type").String(); got != "ephemeral" {
+			t.Errorf("rolling cache_control type = %q, want ephemeral: %s", got, output)
 		}
-
-		existingCache := gjson.GetBytes(output, "messages.1.content.0.cache_control.type")
-		if existingCache.String() != "ephemeral" {
-			t.Errorf("existing cache_control should be preserved. Output: %s", string(output))
+		if got := gjson.GetBytes(output, "messages.0.content.0.cache_control.ttl").String(); got != "1h" {
+			t.Errorf("caller cache_control ttl = %q, want preserved 1h: %s", got, output)
+		}
+		if got := gjson.GetBytes(output, "messages.1.content.0.cache_control.type").String(); got != "ephemeral" {
+			t.Errorf("existing assistant cache_control type = %q, want preserved ephemeral: %s", got, output)
 		}
 	})
+}
+
+func TestEnsureCacheControlCloakedMultiTurnRolling(t *testing.T) {
+	fixed := time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		payload    string
+		wantTarget string
+	}{
+		{
+			name: "two user turns keeps first-user cloak marker as target",
+			payload: `{"messages":[
+				{"role":"user","content":"first"},
+				{"role":"assistant","content":"reply one"},
+				{"role":"user","content":"second"}
+			]}`,
+			wantTarget: "messages.0.content.1.cache_control.type",
+		},
+		{
+			name: "third user turn advances past first-user cloak marker",
+			payload: `{"messages":[
+				{"role":"user","content":"first"},
+				{"role":"assistant","content":"reply one"},
+				{"role":"user","content":"second"},
+				{"role":"assistant","content":"reply two"},
+				{"role":"user","content":"third"}
+			]}`,
+			wantTarget: "messages.2.content.0.cache_control.type",
+		},
+		{
+			name: "fourth user turn advances again",
+			payload: `{"messages":[
+				{"role":"user","content":"first"},
+				{"role":"assistant","content":"reply one"},
+				{"role":"user","content":"second"},
+				{"role":"assistant","content":"reply two"},
+				{"role":"user","content":"third"},
+				{"role":"assistant","content":"reply three"},
+				{"role":"user","content":"fourth"}
+			]}`,
+			wantTarget: "messages.4.content.0.cache_control.type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cloaked := injectClaudeCodeCurrentDate([]byte(tt.payload), fixed)
+			output := ensureCacheControl(cloaked)
+			if got := gjson.GetBytes(output, tt.wantTarget).String(); got != "ephemeral" {
+				t.Fatalf("rolling cache_control type = %q, want ephemeral at %s: %s", got, tt.wantTarget, output)
+			}
+			if got := gjson.GetBytes(output, "messages.0.content.1.cache_control.type").String(); got != "ephemeral" {
+				t.Fatalf("first-user cloak marker type = %q, want preserved ephemeral: %s", got, output)
+			}
+		})
+	}
+}
+
+func TestEnsureCacheControlNonCloakedMultiTurn(t *testing.T) {
+	input := []byte(`{
+		"tools":[{"name":"tool"}],
+		"system":[{"type":"text","text":"system","cache_control":{"type":"ephemeral","ttl":"1h"}}],
+		"messages":[
+			{"role":"user","content":"first"},
+			{"role":"assistant","content":"reply one"},
+			{"role":"user","content":"second"},
+			{"role":"assistant","content":"reply two"},
+			{"role":"user","content":"third"}
+		]
+	}`)
+
+	output := ensureCacheControl(input)
+	if got := gjson.GetBytes(output, "tools.0.cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("tools breakpoint type = %q, want ephemeral: %s", got, output)
+	}
+	if got := gjson.GetBytes(output, "system.0.cache_control.ttl").String(); got != "1h" {
+		t.Fatalf("caller system breakpoint ttl = %q, want preserved 1h: %s", got, output)
+	}
+	if got := gjson.GetBytes(output, "messages.2.content.0.cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("rolling breakpoint type = %q, want ephemeral: %s", got, output)
+	}
+	if gjson.GetBytes(output, "messages.0.content.0.cache_control").Exists() {
+		t.Fatalf("first user turn unexpectedly received cache_control: %s", output)
+	}
+}
+
+func TestEnsureCacheControlCappedAfterIndependentInjection(t *testing.T) {
+	input := []byte(`{
+		"tools":[{"name":"tool"}],
+		"system":[{"type":"text","text":"system"}],
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"first","cache_control":{"type":"ephemeral"}}]},
+			{"role":"assistant","content":[{"type":"text","text":"reply","cache_control":{"type":"ephemeral"}}]},
+			{"role":"user","content":"second"},
+			{"role":"assistant","content":"reply two"},
+			{"role":"user","content":"third"}
+		]
+	}`)
+
+	output := ensureCacheControl(input)
+	if got := countCacheControls(output); got != 5 {
+		t.Fatalf("cache_control count before cap = %d, want 5: %s", got, output)
+	}
+	output = enforceCacheControlLimit(output, 4)
+	if got := countCacheControls(output); got != 4 {
+		t.Fatalf("cache_control count after cap = %d, want 4: %s", got, output)
+	}
+	if got := gjson.GetBytes(output, "tools.0.cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("tools breakpoint type = %q, want ephemeral: %s", got, output)
+	}
+	if got := gjson.GetBytes(output, "system.0.cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("system breakpoint type = %q, want ephemeral: %s", got, output)
+	}
+	if got := gjson.GetBytes(output, "messages.2.content.0.cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("rolling breakpoint type = %q, want ephemeral: %s", got, output)
+	}
 }
 
 func TestInjectToolsCacheControlSkipsDeferredTools(t *testing.T) {

--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -919,6 +919,56 @@ func countCacheControls(payload []byte) int {
 	return count
 }
 
+func newCacheControl(oneHour bool) map[string]string {
+	cacheControl := map[string]string{"type": "ephemeral"}
+	if oneHour {
+		cacheControl["ttl"] = "1h"
+	}
+	return cacheControl
+}
+
+func systemHasOneHourCacheControl(payload []byte) bool {
+	system := gjson.GetBytes(payload, "system")
+	if !system.IsArray() {
+		return false
+	}
+
+	found := false
+	system.ForEach(func(_, item gjson.Result) bool {
+		found = item.Get("cache_control.ttl").String() == "1h"
+		return !found
+	})
+	return found
+}
+
+func messagesHaveOneHourCacheControlAfter(payload []byte, messageIndex, contentIndex int) bool {
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.IsArray() {
+		return false
+	}
+
+	found := false
+	messages.ForEach(func(msgIdx, msg gjson.Result) bool {
+		currentMessageIndex := int(msgIdx.Int())
+		if currentMessageIndex < messageIndex {
+			return true
+		}
+		content := msg.Get("content")
+		if !content.IsArray() {
+			return true
+		}
+		content.ForEach(func(itemIdx, item gjson.Result) bool {
+			if currentMessageIndex == messageIndex && int(itemIdx.Int()) <= contentIndex {
+				return true
+			}
+			found = item.Get("cache_control.ttl").String() == "1h"
+			return !found
+		})
+		return !found
+	})
+	return found
+}
+
 // normalizeCacheControlTTL ensures cache_control TTL values don't violate the
 // prompt-caching-scope-2026-01-05 ordering constraint: a 1h-TTL block must not
 // appear after a 5m-TTL block anywhere in the evaluation order.
@@ -1221,7 +1271,8 @@ func injectMessagesCacheControl(payload []byte) []byte {
 				return payload
 			}
 			cacheControlPath := fmt.Sprintf("messages.%d.content.%d.cache_control", secondToLastUserIdx, contentCount-1)
-			result, err := sjson.SetBytes(payload, cacheControlPath, map[string]string{"type": "ephemeral"})
+			cacheControl := newCacheControl(messagesHaveOneHourCacheControlAfter(payload, secondToLastUserIdx, contentCount-1))
+			result, err := sjson.SetBytes(payload, cacheControlPath, cacheControl)
 			if err != nil {
 				log.Warnf("failed to inject cache_control into messages: %v", err)
 				return payload
@@ -1233,11 +1284,9 @@ func injectMessagesCacheControl(payload []byte) []byte {
 		text := content.String()
 		newContent := []map[string]interface{}{
 			{
-				"type": "text",
-				"text": text,
-				"cache_control": map[string]string{
-					"type": "ephemeral",
-				},
+				"type":          "text",
+				"text":          text,
+				"cache_control": newCacheControl(messagesHaveOneHourCacheControlAfter(payload, secondToLastUserIdx, -1)),
 			},
 		}
 		result, err := sjson.SetBytes(payload, contentPath, newContent)
@@ -1278,7 +1327,8 @@ func injectToolsCacheControl(payload []byte) []byte {
 	}
 
 	lastToolPath := fmt.Sprintf("tools.%d.cache_control", lastEligibleToolIndex)
-	result, err := sjson.SetBytes(payload, lastToolPath, map[string]string{"type": "ephemeral"})
+	cacheControl := newCacheControl(systemHasOneHourCacheControl(payload) || messagesHaveOneHourCacheControlAfter(payload, -1, -1))
+	result, err := sjson.SetBytes(payload, lastToolPath, cacheControl)
 	if err != nil {
 		log.Warnf("failed to inject cache_control into tools array: %v", err)
 		return payload
@@ -1317,7 +1367,8 @@ func injectSystemCacheControl(payload []byte) []byte {
 
 		// Add cache_control to the last system element
 		lastSystemPath := fmt.Sprintf("system.%d.cache_control", count-1)
-		result, err := sjson.SetBytes(payload, lastSystemPath, map[string]string{"type": "ephemeral"})
+		cacheControl := newCacheControl(messagesHaveOneHourCacheControlAfter(payload, -1, -1))
+		result, err := sjson.SetBytes(payload, lastSystemPath, cacheControl)
 		if err != nil {
 			log.Warnf("failed to inject cache_control into system array: %v", err)
 			return payload
@@ -1329,11 +1380,9 @@ func injectSystemCacheControl(payload []byte) []byte {
 		text := system.String()
 		newSystem := []map[string]interface{}{
 			{
-				"type": "text",
-				"text": text,
-				"cache_control": map[string]string{
-					"type": "ephemeral",
-				},
+				"type":          "text",
+				"text":          text,
+				"cache_control": newCacheControl(messagesHaveOneHourCacheControlAfter(payload, -1, -1)),
 			},
 		}
 		result, err := sjson.SetBytes(payload, "system", newSystem)

--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -859,13 +859,25 @@ func applyCloaking(
 // This enables up to 90% cost reduction on cached tokens (cache read = 0.1x base price).
 // See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
 func ensureCacheControl(payload []byte) []byte {
+	const maxCacheControls = 4
+
+	if countCacheControls(payload) >= maxCacheControls {
+		return payload
+	}
+
 	// 1. Inject cache_control into the LAST non-deferred tool
 	// Tools are cached first in the hierarchy, so this is the most important breakpoint.
 	payload = injectToolsCacheControl(payload)
+	if countCacheControls(payload) >= maxCacheControls {
+		return payload
+	}
 
 	// 2. Inject cache_control into the LAST system prompt element
 	// System is the second level in the cache hierarchy.
 	payload = injectSystemCacheControl(payload)
+	if countCacheControls(payload) >= maxCacheControls {
+		return payload
+	}
 
 	// 3. Inject cache_control into messages for multi-turn conversation caching
 	// This caches the conversation history up to the second-to-last user turn.

--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -1184,31 +1184,11 @@ func enforceCacheControlLimit(payload []byte, maxBlocks int) []byte {
 // injectMessagesCacheControl adds cache_control to the second-to-last user turn for multi-turn caching.
 // Per Anthropic docs: "Place cache_control on the second-to-last User message to let the model reuse the earlier cache."
 // This enables caching of conversation history, which is especially beneficial for long multi-turn conversations.
-// Only adds cache_control if:
-// - There are at least 2 user turns in the conversation
-// - No message content already has cache_control
+// Only adds cache_control if there are at least 2 user turns and the target
+// content block does not already have one. Other message breakpoints are kept.
 func injectMessagesCacheControl(payload []byte) []byte {
 	messages := gjson.GetBytes(payload, "messages")
 	if !messages.Exists() || !messages.IsArray() {
-		return payload
-	}
-
-	// Check if ANY message content already has cache_control
-	hasCacheControlInMessages := false
-	messages.ForEach(func(_, msg gjson.Result) bool {
-		content := msg.Get("content")
-		if content.IsArray() {
-			content.ForEach(func(_, item gjson.Result) bool {
-				if item.Get("cache_control").Exists() {
-					hasCacheControlInMessages = true
-					return false
-				}
-				return true
-			})
-		}
-		return !hasCacheControlInMessages
-	})
-	if hasCacheControlInMessages {
 		return payload
 	}
 
@@ -1237,6 +1217,9 @@ func injectMessagesCacheControl(payload []byte) []byte {
 		// Add cache_control to the last content block of this message
 		contentCount := int(content.Get("#").Int())
 		if contentCount > 0 {
+			if content.Get(fmt.Sprintf("%d.cache_control", contentCount-1)).Exists() {
+				return payload
+			}
 			cacheControlPath := fmt.Sprintf("messages.%d.content.%d.cache_control", secondToLastUserIdx, contentCount-1)
 			result, err := sjson.SetBytes(payload, cacheControlPath, map[string]string{"type": "ephemeral"})
 			if err != nil {

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -110,10 +110,8 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body = reconcileClaudeCodeContextManagement(body, contextManagementState)
 	body = normalizeClaudeSamplingForUpstream(body)
 
-	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
-	if countCacheControls(body) == 0 {
-		body = ensureCacheControl(body)
-	}
+	// Ensure independent cache breakpoints without replacing caller-provided ones.
+	body = ensureCacheControl(body)
 
 	// Enforce Anthropic's cache_control block limit (max 4 breakpoints per request).
 	// Cloaking and ensureCacheControl may push the total over 4 when the client

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -114,10 +114,8 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body = reconcileClaudeCodeContextManagement(body, contextManagementState)
 	body = normalizeClaudeSamplingForUpstream(body)
 
-	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
-	if countCacheControls(body) == 0 {
-		body = ensureCacheControl(body)
-	}
+	// Ensure independent cache breakpoints without replacing caller-provided ones.
+	body = ensureCacheControl(body)
 
 	// Enforce Anthropic's cache_control block limit (max 4 breakpoints per request).
 	body = enforceCacheControlLimit(body, 4)

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -5827,6 +5827,34 @@ func TestClaudeExecutor_CloakedCacheBreakpointAdvancesAcrossExecutePaths(t *test
 	}
 }
 
+func TestClaudeExecutor_PreservesCallerOneHourCacheTTLAcrossExecutePaths(t *testing.T) {
+	payload := []byte(`{"model":"claude-opus-5",
+		"tools":[{"name":"tool","input_schema":{"type":"object"}}],
+		"system":[{"type":"text","text":"system","cache_control":{"type":"ephemeral","ttl":"1h"}}],
+		"messages":[
+			{"role":"user","content":"first"},
+			{"role":"assistant","content":"reply one"},
+			{"role":"user","content":"second"}
+		]}`)
+
+	for _, stream := range []bool{false, true} {
+		name := "execute"
+		if stream {
+			name = "execute stream"
+		}
+		t.Run(name, func(t *testing.T) {
+			cfg := &config.Config{DisableClaudeCloakMode: true}
+			upstreamBody := executeClaudeContextManagementRequest(t, cfg, payload, stream)
+			if got := gjson.GetBytes(upstreamBody, "tools.0.cache_control.ttl").String(); got != "1h" {
+				t.Fatalf("injected tool cache_control ttl = %q, want 1h: %s", got, upstreamBody)
+			}
+			if got := gjson.GetBytes(upstreamBody, `system.#(text=="system").cache_control.ttl`).String(); got != "1h" {
+				t.Fatalf("caller system cache_control ttl = %q, want preserved 1h: %s", got, upstreamBody)
+			}
+		})
+	}
+}
+
 func TestValidateClaudeCallerSystemBlocksAcceptsTextOnly(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -5855,6 +5855,48 @@ func TestClaudeExecutor_PreservesCallerOneHourCacheTTLAcrossExecutePaths(t *test
 	}
 }
 
+func TestClaudeExecutor_PreservesFullCallerCacheLayoutAcrossExecutePaths(t *testing.T) {
+	payload := []byte(`{"model":"claude-opus-5",
+		"tools":[{"name":"tool","input_schema":{"type":"object"}}],
+		"system":[{"type":"text","text":"system"}],
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"first","cache_control":{"type":"ephemeral"}}]},
+			{"role":"assistant","content":[{"type":"text","text":"reply one","cache_control":{"type":"ephemeral"}}]},
+			{"role":"user","content":[{"type":"text","text":"second","cache_control":{"type":"ephemeral"}}]},
+			{"role":"assistant","content":[{"type":"text","text":"reply two","cache_control":{"type":"ephemeral"}}]},
+			{"role":"user","content":"third"}
+		]}`)
+
+	for _, stream := range []bool{false, true} {
+		name := "execute"
+		if stream {
+			name = "execute stream"
+		}
+		t.Run(name, func(t *testing.T) {
+			cfg := &config.Config{DisableClaudeCloakMode: true}
+			upstreamBody := executeClaudeContextManagementRequest(t, cfg, payload, stream)
+			if got := countCacheControls(upstreamBody); got != 4 {
+				t.Fatalf("cache_control count = %d, want 4: %s", got, upstreamBody)
+			}
+			for _, path := range []string{
+				"messages.0.content.0.cache_control.type",
+				"messages.1.content.0.cache_control.type",
+				"messages.2.content.0.cache_control.type",
+				"messages.3.content.0.cache_control.type",
+			} {
+				if got := gjson.GetBytes(upstreamBody, path).String(); got != "ephemeral" {
+					t.Fatalf("caller breakpoint %s = %q, want preserved ephemeral: %s", path, got, upstreamBody)
+				}
+			}
+			for _, path := range []string{"tools.0.cache_control", "system.0.cache_control"} {
+				if got := gjson.GetBytes(upstreamBody, path); got.Exists() {
+					t.Fatalf("automatic breakpoint %s was added to a full caller layout: %s", path, upstreamBody)
+				}
+			}
+		})
+	}
+}
+
 func TestValidateClaudeCallerSystemBlocksAcceptsTextOnly(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -5801,6 +5801,32 @@ func executeClaudeContextManagementRequest(t *testing.T, cfg *config.Config, pay
 	return upstreamBody
 }
 
+func TestClaudeExecutor_CloakedCacheBreakpointAdvancesAcrossExecutePaths(t *testing.T) {
+	payload := []byte(`{"model":"claude-opus-5","messages":[
+		{"role":"user","content":"first"},
+		{"role":"assistant","content":"reply one"},
+		{"role":"user","content":"second"},
+		{"role":"assistant","content":"reply two"},
+		{"role":"user","content":"third"}
+	]}`)
+
+	for _, stream := range []bool{false, true} {
+		name := "execute"
+		if stream {
+			name = "execute stream"
+		}
+		t.Run(name, func(t *testing.T) {
+			upstreamBody := executeClaudeContextManagementRequest(t, &config.Config{}, payload, stream)
+			if got := gjson.GetBytes(upstreamBody, "messages.2.content.0.cache_control.type").String(); got != "ephemeral" {
+				t.Fatalf("rolling breakpoint type = %q, want ephemeral: %s", got, upstreamBody)
+			}
+			if got := gjson.GetBytes(upstreamBody, "messages.0.content.1.cache_control.type").String(); got != "ephemeral" {
+				t.Fatalf("first-user cloak marker type = %q, want preserved ephemeral: %s", got, upstreamBody)
+			}
+		})
+	}
+}
+
 func TestValidateClaudeCallerSystemBlocksAcceptsTextOnly(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Summary

- ensure tool, system, and rolling message cache breakpoints independently when existing markers are present
- advance the rolling breakpoint to the second-to-last user turn while preserving caller-provided markers and TTLs
- retain the four-breakpoint limit and TTL ordering

## Testing

- regression coverage for cloaked and non-cloaked multi-turn requests, caller-provided markers, `1h` TTL preservation, and both executor paths
- `go test ./...`
- `go build -o test-output ./cmd/server && rm test-output`
- live Responses validation confirmed that cache reads advance across turns and a rebuilt 85,987-token cache is fully reused by the next turn

Fixes #4855
