### PR TITLE
fix(codex): strip top-level metadata before upstream dispatch

### DIFF
--- a/internal/runtime/executor/codex_executor_instructions_test.go
+++ b/internal/runtime/executor/codex_executor_instructions_test.go
@@ -94,6 +94,38 @@ func TestCodexExecutorExecuteStreamNormalizesNullInstructions(t *testing.T) {
 	}
 }
 
+func TestCodexExecutorExecuteStripsTopLevelMetadataPreservesClientMetadata(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":0,\"status\":\"completed\",\"background\":false,\"error\":null}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":"hello","metadata":{"user_id":"remove-me"},"client_metadata":{"sentinel":"must-remain"}}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gjson.GetBytes(gotBody, "metadata").Exists() {
+		t.Fatalf("top-level metadata was forwarded: %s", gotBody)
+	}
+	if got := gjson.GetBytes(gotBody, "client_metadata.sentinel").String(); got != "must-remain" {
+		t.Fatalf("client_metadata.sentinel = %q, want %q; body=%s", got, "must-remain", gotBody)
+	}
+}
+
 func TestCodexExecutorCountTokensTreatsNullInstructionsAsEmpty(t *testing.T) {
 	executor := NewCodexExecutor(&config.Config{})
 

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -139,6 +139,7 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 		rawJSON = helps.SetStringIfDifferent(rawJSON, "prompt_cache_key", cache.ID)
 	}
 	rawJSON = helps.SanitizeCodexInputItemIDs(rawJSON)
+	rawJSON = sanitizeCodexUpstreamBody(rawJSON)
 	var identityState codexIdentityConfuseState
 	rawJSON, identityState = applyCodexIdentityConfuseBody(e.cfg, auth, userPayload, rawJSON)
 	if identityState.promptCacheKey != "" {
@@ -152,6 +153,17 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 		httpReq.Header.Set("Session_id", cache.ID)
 	}
 	return httpReq, rawJSON, identityState, nil
+}
+
+func sanitizeCodexUpstreamBody(body []byte) []byte {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return body
+	}
+	updated, errDelete := sjson.DeleteBytes(body, "metadata")
+	if errDelete != nil || len(updated) == 0 {
+		return body
+	}
+	return updated
 }
 
 func applyCodexIdentityConfuseBody(cfg *config.Config, auth *cliproxyauth.Auth, userPayload []byte, rawJSON []byte) ([]byte, codexIdentityConfuseState) {

--- a/internal/runtime/executor/codex_websockets_connection.go
+++ b/internal/runtime/executor/codex_websockets_connection.go
@@ -113,6 +113,7 @@ func buildCodexWebsocketRequestBody(body []byte) []byte {
 	// Incremental follow-up turns continue on the same websocket using
 	// `previous_response_id` + incremental `input`, not `response.append`.
 	body = helps.SanitizeCodexInputItemIDs(body)
+	body = sanitizeCodexUpstreamBody(body)
 	wsReqBody, errSet := sjson.SetBytes(body, "type", "response.create")
 	if errSet == nil && len(wsReqBody) > 0 {
 		return wsReqBody

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -45,6 +45,21 @@ func TestBuildCodexWebsocketRequestBodyPreservesPreviousResponseID(t *testing.T)
 	}
 }
 
+func TestBuildCodexWebsocketRequestBodyStripsTopLevelMetadataPreservesClientMetadata(t *testing.T) {
+	body := []byte(`{"model":"gpt-5-codex","metadata":{"user_id":"remove-me"},"client_metadata":{"sentinel":"must-remain"}}`)
+
+	got := buildCodexWebsocketRequestBody(body)
+	if gjson.GetBytes(got, "metadata").Exists() {
+		t.Fatalf("top-level metadata was forwarded: %s", got)
+	}
+	if value := gjson.GetBytes(got, "client_metadata.sentinel").String(); value != "must-remain" {
+		t.Fatalf("client_metadata.sentinel = %q, want %q; body=%s", value, "must-remain", got)
+	}
+	if value := gjson.GetBytes(got, "type").String(); value != "response.create" {
+		t.Fatalf("type = %q, want response.create", value)
+	}
+}
+
 func BenchmarkBuildCodexWebsocketRequestBodyLargePayload(b *testing.B) {
 	body := []byte(`{"model":"gpt-5.6","input":[{"type":"message","id":"msg_1","role":"user","content":"` + strings.Repeat("x", 8<<20) + `"}]}`)
 	b.ReportAllocs()


### PR DESCRIPTION
@
## Summary

Codex Responses upstream rejects the standard top-level `metadata` request field with `400 Unsupported parameter: metadata`. This change removes only that exact top-level field at the shared HTTP and WebSocket upstream-body boundaries.

The existing nested `client_metadata` used by Codex prompt-cache and WebSocket handling is preserved.

## Changes

- Sanitize the shared HTTP Codex upstream request body.
- Sanitize the shared WebSocket `response.create` request body.
- Add HTTP and WebSocket regression coverage for top-level removal and nested `client_metadata` preservation.
- No changes under `internal/translator/`.

## Verification

- Focused metadata regression tests passed.
- `go test ./internal/runtime/executor -count=1` was run; three pre-existing Claude header fingerprint tests fail because the environment reports `MacOS` while they expect `Windows`.
- `go test ./...` was run; it has the same three pre-existing Claude header fingerprint failures.
- `go build -o test-output ./cmd/server` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@