### PR TITLE
fix(management): throttle reset credit calls

### DIFF
--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -20,9 +20,10 @@ import (
 
 const (
 	defaultAPICallTimeout          = 60 * time.Second
+	defaultCodexResetCreditTimeout = 10 * time.Second
 	defaultCodexResetCreditSpacing = 5 * time.Second
 	defaultCodexResetCreditBackoff = 10 * time.Second
-	maxCodexResetCreditRetries     = 3
+	maxCodexResetCreditRetries     = 2
 	codexResetCreditCacheTTL       = 30 * time.Minute
 	codexResetCreditHost           = "chatgpt.com"
 	codexResetCreditPath           = "/backend-api/wham/rate-limit-reset-credits"
@@ -196,9 +197,12 @@ func (h *Handler) APICall(c *gin.Context) {
 		req.Host = hostOverride
 	}
 
-	httpClient := &http.Client{
-		Timeout: defaultAPICallTimeout,
+	resetCreditRequest := method == http.MethodGet && isCodexResetCreditURL(parsedURL)
+	timeout := defaultAPICallTimeout
+	if resetCreditRequest {
+		timeout = defaultCodexResetCreditTimeout
 	}
+	httpClient := &http.Client{Timeout: timeout}
 	httpClient.Transport = h.apiCallTransport(auth)
 
 	release, errGate := h.acquireCodexResetCreditGate(c.Request.Context(), parsedURL)
@@ -207,7 +211,6 @@ func (h *Handler) APICall(c *gin.Context) {
 		return
 	}
 	defer release()
-	resetCreditRequest := method == http.MethodGet && isCodexResetCreditURL(parsedURL)
 	if resetCreditRequest {
 		if cached, ok := loadCodexResetCreditCache(authIndex, false); ok {
 			c.JSON(http.StatusOK, cached)

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -19,7 +19,9 @@ import (
 
 const (
 	defaultAPICallTimeout          = 60 * time.Second
-	defaultCodexResetCreditSpacing = time.Second
+	defaultCodexResetCreditSpacing = 5 * time.Second
+	defaultCodexResetCreditBackoff = 10 * time.Second
+	maxCodexResetCreditRetries     = 3
 	codexResetCreditHost           = "chatgpt.com"
 	codexResetCreditPath           = "/backend-api/wham/rate-limit-reset-credits"
 )
@@ -194,11 +196,29 @@ func (h *Handler) APICall(c *gin.Context) {
 	}
 	defer release()
 
-	resp, errDo := httpClient.Do(req)
-	if errDo != nil {
-		log.WithError(errDo).Debug("management APICall request failed")
-		c.JSON(http.StatusBadGateway, gin.H{"error": "request failed"})
-		return
+	var resp *http.Response
+	for attempt := 0; ; attempt++ {
+		var errDo error
+		resp, errDo = httpClient.Do(req)
+		if errDo != nil {
+			log.WithError(errDo).Debug("management APICall request failed")
+			c.JSON(http.StatusBadGateway, gin.H{"error": "request failed"})
+			return
+		}
+		if resp.StatusCode != http.StatusTooManyRequests || method != http.MethodGet || !isCodexResetCreditURL(parsedURL) || attempt >= maxCodexResetCreditRetries {
+			break
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		timer := time.NewTimer(codexResetCreditRetryDelay(attempt))
+		select {
+		case <-c.Request.Context().Done():
+			timer.Stop()
+			c.JSON(http.StatusRequestTimeout, gin.H{"error": "request canceled"})
+			return
+		case <-timer.C:
+		}
 	}
 	defer func() {
 		if errClose := resp.Body.Close(); errClose != nil {
@@ -220,7 +240,7 @@ func (h *Handler) APICall(c *gin.Context) {
 }
 
 func (h *Handler) acquireCodexResetCreditGate(ctx context.Context, parsedURL *url.URL) (func(), error) {
-	if parsedURL == nil || !strings.EqualFold(parsedURL.Scheme, "https") || !strings.EqualFold(parsedURL.Host, codexResetCreditHost) || parsedURL.Path != codexResetCreditPath {
+	if !isCodexResetCreditURL(parsedURL) {
 		return func() {}, nil
 	}
 	if err := ctx.Err(); err != nil {
@@ -252,6 +272,14 @@ func (h *Handler) acquireCodexResetCreditGate(ctx context.Context, parsedURL *ur
 		codexResetCreditLast = time.Now()
 		<-codexResetCreditGate
 	}, nil
+}
+
+func isCodexResetCreditURL(parsedURL *url.URL) bool {
+	return parsedURL != nil && strings.EqualFold(parsedURL.Scheme, "https") && strings.EqualFold(parsedURL.Host, codexResetCreditHost) && parsedURL.Path == codexResetCreditPath
+}
+
+func codexResetCreditRetryDelay(attempt int) time.Duration {
+	return defaultCodexResetCreditBackoff << attempt
 }
 
 func firstNonEmptyString(values ...*string) string {

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -22,8 +23,10 @@ const (
 	defaultCodexResetCreditSpacing = 5 * time.Second
 	defaultCodexResetCreditBackoff = 10 * time.Second
 	maxCodexResetCreditRetries     = 3
+	codexResetCreditCacheTTL       = 5 * time.Minute
 	codexResetCreditHost           = "chatgpt.com"
 	codexResetCreditPath           = "/backend-api/wham/rate-limit-reset-credits"
+	codexResetCreditConsumePath    = codexResetCreditPath + "/consume"
 )
 
 const (
@@ -34,9 +37,18 @@ const (
 var antigravityOAuthTokenURL = "https://oauth2.googleapis.com/token"
 
 var (
-	codexResetCreditGate = make(chan struct{}, 1)
-	codexResetCreditLast time.Time
+	codexResetCreditGate  = make(chan struct{}, 1)
+	codexResetCreditLast  time.Time
+	codexResetCreditCache = struct {
+		sync.Mutex
+		entries map[string]codexResetCreditCacheEntry
+	}{entries: make(map[string]codexResetCreditCacheEntry)}
 )
+
+type codexResetCreditCacheEntry struct {
+	response apiCallResponse
+	storedAt time.Time
+}
 
 type apiCallRequest struct {
 	AuthIndexSnake  *string           `json:"auth_index"`
@@ -195,6 +207,15 @@ func (h *Handler) APICall(c *gin.Context) {
 		return
 	}
 	defer release()
+	resetCreditRequest := method == http.MethodGet && isCodexResetCreditURL(parsedURL)
+	if resetCreditRequest {
+		if cached, ok := loadCodexResetCreditCache(authIndex, false); ok {
+			c.JSON(http.StatusOK, cached)
+			return
+		}
+	} else if method == http.MethodPost && isCodexResetCreditConsumeURL(parsedURL) {
+		deleteCodexResetCreditCache(authIndex)
+	}
 
 	var resp *http.Response
 	for attempt := 0; ; attempt++ {
@@ -205,7 +226,7 @@ func (h *Handler) APICall(c *gin.Context) {
 			c.JSON(http.StatusBadGateway, gin.H{"error": "request failed"})
 			return
 		}
-		if resp.StatusCode != http.StatusTooManyRequests || method != http.MethodGet || !isCodexResetCreditURL(parsedURL) || attempt >= maxCodexResetCreditRetries {
+		if resp.StatusCode != http.StatusTooManyRequests || !resetCreditRequest || attempt >= maxCodexResetCreditRetries {
 			break
 		}
 		_, _ = io.Copy(io.Discard, resp.Body)
@@ -232,11 +253,19 @@ func (h *Handler) APICall(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, apiCallResponse{
+	response := apiCallResponse{
 		StatusCode: resp.StatusCode,
 		Header:     resp.Header,
 		Body:       string(respBody),
-	})
+	}
+	if resetCreditRequest && resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		storeCodexResetCreditCache(authIndex, response)
+	} else if resetCreditRequest && resp.StatusCode == http.StatusTooManyRequests {
+		if cached, ok := loadCodexResetCreditCache(authIndex, true); ok {
+			response = cached
+		}
+	}
+	c.JSON(http.StatusOK, response)
 }
 
 func (h *Handler) acquireCodexResetCreditGate(ctx context.Context, parsedURL *url.URL) (func(), error) {
@@ -278,8 +307,40 @@ func isCodexResetCreditURL(parsedURL *url.URL) bool {
 	return parsedURL != nil && strings.EqualFold(parsedURL.Scheme, "https") && strings.EqualFold(parsedURL.Host, codexResetCreditHost) && parsedURL.Path == codexResetCreditPath
 }
 
+func isCodexResetCreditConsumeURL(parsedURL *url.URL) bool {
+	return parsedURL != nil && strings.EqualFold(parsedURL.Scheme, "https") && strings.EqualFold(parsedURL.Host, codexResetCreditHost) && parsedURL.Path == codexResetCreditConsumePath
+}
+
 func codexResetCreditRetryDelay(attempt int) time.Duration {
 	return defaultCodexResetCreditBackoff << attempt
+}
+
+func loadCodexResetCreditCache(authIndex string, allowExpired bool) (apiCallResponse, bool) {
+	if authIndex == "" {
+		return apiCallResponse{}, false
+	}
+	codexResetCreditCache.Lock()
+	defer codexResetCreditCache.Unlock()
+	entry, ok := codexResetCreditCache.entries[authIndex]
+	if !ok || (!allowExpired && time.Since(entry.storedAt) >= codexResetCreditCacheTTL) {
+		return apiCallResponse{}, false
+	}
+	return entry.response, true
+}
+
+func storeCodexResetCreditCache(authIndex string, response apiCallResponse) {
+	if authIndex == "" {
+		return
+	}
+	codexResetCreditCache.Lock()
+	codexResetCreditCache.entries[authIndex] = codexResetCreditCacheEntry{response: response, storedAt: time.Now()}
+	codexResetCreditCache.Unlock()
+}
+
+func deleteCodexResetCreditCache(authIndex string) {
+	codexResetCreditCache.Lock()
+	delete(codexResetCreditCache.entries, authIndex)
+	codexResetCreditCache.Unlock()
 }
 
 func firstNonEmptyString(values ...*string) string {

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -17,7 +17,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const defaultAPICallTimeout = 60 * time.Second
+const (
+	defaultAPICallTimeout          = 60 * time.Second
+	defaultCodexResetCreditSpacing = time.Second
+	codexResetCreditHost           = "chatgpt.com"
+	codexResetCreditPath           = "/backend-api/wham/rate-limit-reset-credits"
+)
 
 const (
 	antigravityOAuthClientID     = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
@@ -25,6 +30,11 @@ const (
 )
 
 var antigravityOAuthTokenURL = "https://oauth2.googleapis.com/token"
+
+var (
+	codexResetCreditGate = make(chan struct{}, 1)
+	codexResetCreditLast time.Time
+)
 
 type apiCallRequest struct {
 	AuthIndexSnake  *string           `json:"auth_index"`
@@ -177,6 +187,13 @@ func (h *Handler) APICall(c *gin.Context) {
 	}
 	httpClient.Transport = h.apiCallTransport(auth)
 
+	release, errGate := h.acquireCodexResetCreditGate(c.Request.Context(), parsedURL)
+	if errGate != nil {
+		c.JSON(http.StatusRequestTimeout, gin.H{"error": "request canceled"})
+		return
+	}
+	defer release()
+
 	resp, errDo := httpClient.Do(req)
 	if errDo != nil {
 		log.WithError(errDo).Debug("management APICall request failed")
@@ -200,6 +217,41 @@ func (h *Handler) APICall(c *gin.Context) {
 		Header:     resp.Header,
 		Body:       string(respBody),
 	})
+}
+
+func (h *Handler) acquireCodexResetCreditGate(ctx context.Context, parsedURL *url.URL) (func(), error) {
+	if parsedURL == nil || !strings.EqualFold(parsedURL.Scheme, "https") || !strings.EqualFold(parsedURL.Host, codexResetCreditHost) || parsedURL.Path != codexResetCreditPath {
+		return func() {}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	select {
+	case codexResetCreditGate <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	spacing := h.codexResetCreditSpacing
+	if spacing <= 0 {
+		spacing = defaultCodexResetCreditSpacing
+	}
+	if wait := spacing - time.Since(codexResetCreditLast); wait > 0 {
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			<-codexResetCreditGate
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	return func() {
+		codexResetCreditLast = time.Now()
+		<-codexResetCreditGate
+	}, nil
 }
 
 func firstNonEmptyString(values ...*string) string {

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -23,7 +23,7 @@ const (
 	defaultCodexResetCreditSpacing = 5 * time.Second
 	defaultCodexResetCreditBackoff = 10 * time.Second
 	maxCodexResetCreditRetries     = 3
-	codexResetCreditCacheTTL       = 5 * time.Minute
+	codexResetCreditCacheTTL       = 30 * time.Minute
 	codexResetCreditHost           = "chatgpt.com"
 	codexResetCreditPath           = "/backend-api/wham/rate-limit-reset-credits"
 	codexResetCreditConsumePath    = codexResetCreditPath + "/consume"

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -3,12 +3,64 @@ package management
 import (
 	"context"
 	"net/http"
+	"net/url"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
+
+func TestCodexResetCreditGateSerializesCalls(t *testing.T) {
+	handlers := []*Handler{
+		{codexResetCreditSpacing: time.Millisecond},
+		{codexResetCreditSpacing: time.Millisecond},
+	}
+	target, errParse := url.Parse("https://chatgpt.com/backend-api/wham/rate-limit-reset-credits")
+	if errParse != nil {
+		t.Fatal(errParse)
+	}
+	release, errAcquire := handlers[0].acquireCodexResetCreditGate(context.Background(), target)
+	if errAcquire != nil {
+		t.Fatal(errAcquire)
+	}
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, errAcquire = handlers[1].acquireCodexResetCreditGate(canceled, target); errAcquire != context.Canceled {
+		t.Fatalf("canceled acquire error = %v, want context.Canceled", errAcquire)
+	}
+	release()
+
+	var active atomic.Int32
+	var maxActive atomic.Int32
+	var wg sync.WaitGroup
+	for i := range 3 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			release, errAcquire := handlers[i%len(handlers)].acquireCodexResetCreditGate(context.Background(), target)
+			if errAcquire != nil {
+				t.Errorf("acquire gate: %v", errAcquire)
+				return
+			}
+			current := active.Add(1)
+			if current > maxActive.Load() {
+				maxActive.Store(current)
+			}
+			time.Sleep(2 * time.Millisecond)
+			active.Add(-1)
+			release()
+		}()
+	}
+	wg.Wait()
+
+	if got := maxActive.Load(); got != 1 {
+		t.Fatalf("maximum concurrent calls = %d, want 1", got)
+	}
+}
 
 func TestAPICallTransportDirectBypassesGlobalProxy(t *testing.T) {
 	t.Parallel()

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -62,6 +62,15 @@ func TestCodexResetCreditGateSerializesCalls(t *testing.T) {
 	}
 }
 
+func TestCodexResetCreditRetryDelay(t *testing.T) {
+	want := []time.Duration{10 * time.Second, 20 * time.Second, 40 * time.Second}
+	for attempt, wantDelay := range want {
+		if got := codexResetCreditRetryDelay(attempt); got != wantDelay {
+			t.Fatalf("attempt %d delay = %s, want %s", attempt, got, wantDelay)
+		}
+	}
+}
+
 func TestAPICallTransportDirectBypassesGlobalProxy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -71,6 +71,35 @@ func TestCodexResetCreditRetryDelay(t *testing.T) {
 	}
 }
 
+func TestCodexResetCreditCacheExpiresAndDeletes(t *testing.T) {
+	const authIndex = "codex:test"
+	deleteCodexResetCreditCache(authIndex)
+	t.Cleanup(func() { deleteCodexResetCreditCache(authIndex) })
+
+	want := apiCallResponse{StatusCode: http.StatusOK, Body: `{"credits":[]}`}
+	storeCodexResetCreditCache(authIndex, want)
+	if got, ok := loadCodexResetCreditCache(authIndex, false); !ok || got.Body != want.Body {
+		t.Fatalf("fresh cache = (%+v, %v), want body %q", got, ok, want.Body)
+	}
+
+	codexResetCreditCache.Lock()
+	entry := codexResetCreditCache.entries[authIndex]
+	entry.storedAt = time.Now().Add(-codexResetCreditCacheTTL)
+	codexResetCreditCache.entries[authIndex] = entry
+	codexResetCreditCache.Unlock()
+	if _, ok := loadCodexResetCreditCache(authIndex, false); ok {
+		t.Fatal("expired cache unexpectedly returned as fresh")
+	}
+	if _, ok := loadCodexResetCreditCache(authIndex, true); !ok {
+		t.Fatal("expired cache unavailable for rate-limit fallback")
+	}
+
+	deleteCodexResetCreditCache(authIndex)
+	if _, ok := loadCodexResetCreditCache(authIndex, true); ok {
+		t.Fatal("deleted cache still available")
+	}
+}
+
 func TestAPICallTransportDirectBypassesGlobalProxy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -63,7 +63,7 @@ func TestCodexResetCreditGateSerializesCalls(t *testing.T) {
 }
 
 func TestCodexResetCreditRetryDelay(t *testing.T) {
-	want := []time.Duration{10 * time.Second, 20 * time.Second, 40 * time.Second}
+	want := []time.Duration{10 * time.Second, 20 * time.Second}
 	for attempt, wantDelay := range want {
 		if got := codexResetCreditRetryDelay(attempt); got != wantDelay {
 			t.Fatalf("attempt %d delay = %s, want %s", attempt, got, wantDelay)

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -60,6 +60,7 @@ type Handler struct {
 	pluginStoreHTTPClient   pluginstore.HTTPDoer
 	pluginReleaseCacheMu    sync.Mutex
 	pluginReleaseCache      map[string]pluginReleaseCacheEntry
+	codexResetCreditSpacing time.Duration
 }
 
 type configReloadSnapshot struct {


### PR DESCRIPTION
## Description
Prevents Management API calls to the Codex reset-credit endpoint from repeatedly triggering upstream connector limits. The exact endpoint now uses a process-wide gate, bounded waits and retries, plus a short-lived success cache that is invalidated when a credit is consumed. The branch is rebased onto the official v7.2.128 release.

### Key Changes
- Serialize only the exact ChatGPT reset-credit endpoint
- Space calls by five seconds and bound each attempt to ten seconds
- Retry 429 responses twice with 10/20 second backoff
- Cache successful responses for 30 minutes and invalidate on consume
- Preserve cancellation and leave unrelated API calls unchanged

### Verification & Testing
- go test ./...
- Custom v7.2.128 build and local service startup
- Authenticated /v1/models: HTTP 200
- Management Center: HTTP 200 with the existing serial queue preserved
- Local account files: 10/10 with identical aggregate digest after upgrade

### Impact & Risk
Reset-credit data may be served from the in-memory cache for up to 30 minutes. Consuming a credit invalidates that account immediately.