### PR TITLE
fix(openrouter): forward prompt cache affinity header

### DIFF
--- a/internal/runtime/executor/helps/openrouter_session_affinity.go
+++ b/internal/runtime/executor/helps/openrouter_session_affinity.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	cliproxysession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
 	"github.com/tidwall/gjson"
 )
 
@@ -12,7 +13,7 @@ func ApplyOpenRouterSessionAffinity(req *http.Request, payload []byte) {
 	if req == nil || req.URL == nil || !isOpenRouterHost(req.URL.Hostname()) || req.Header.Get("X-Session-ID") != "" {
 		return
 	}
-	if promptCacheKey := strings.TrimSpace(gjson.GetBytes(payload, "prompt_cache_key").String()); promptCacheKey != "" {
+	if promptCacheKey := cliproxysession.NormalizeExplicitID(gjson.GetBytes(payload, "prompt_cache_key").String()); promptCacheKey != "" {
 		req.Header.Set("X-Session-ID", promptCacheKey)
 	}
 }

--- a/internal/runtime/executor/helps/openrouter_session_affinity.go
+++ b/internal/runtime/executor/helps/openrouter_session_affinity.go
@@ -1,0 +1,23 @@
+package helps
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// ApplyOpenRouterSessionAffinity gives OpenRouter an explicit sticky-routing key.
+func ApplyOpenRouterSessionAffinity(req *http.Request, payload []byte) {
+	if req == nil || req.URL == nil || !isOpenRouterHost(req.URL.Hostname()) || req.Header.Get("X-Session-ID") != "" {
+		return
+	}
+	if promptCacheKey := strings.TrimSpace(gjson.GetBytes(payload, "prompt_cache_key").String()); promptCacheKey != "" {
+		req.Header.Set("X-Session-ID", promptCacheKey)
+	}
+}
+
+func isOpenRouterHost(host string) bool {
+	host = strings.TrimSpace(strings.ToLower(host))
+	return host == "openrouter.ai" || strings.HasSuffix(host, ".openrouter.ai")
+}

--- a/internal/runtime/executor/helps/openrouter_session_affinity_test.go
+++ b/internal/runtime/executor/helps/openrouter_session_affinity_test.go
@@ -1,0 +1,39 @@
+package helps
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestApplyOpenRouterSessionAffinity(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		header     string
+		payload    string
+		wantHeader string
+	}{
+		{name: "OpenRouter uses prompt cache key", url: "https://openrouter.ai/api/v1/chat/completions", payload: `{"prompt_cache_key":"cache-123"}`, wantHeader: "cache-123"},
+		{name: "OpenRouter subdomain uses prompt cache key", url: "https://eu.openrouter.ai/api/v1/chat/completions", payload: `{"prompt_cache_key":"cache-123"}`, wantHeader: "cache-123"},
+		{name: "other compatibility endpoint is unchanged", url: "https://api.example.com/v1/chat/completions", payload: `{"prompt_cache_key":"cache-123"}`},
+		{name: "lookalike endpoint is unchanged", url: "https://openrouter.ai.example.com/v1/chat/completions", payload: `{"prompt_cache_key":"cache-123"}`},
+		{name: "explicit header wins", url: "https://openrouter.ai/api/v1/chat/completions", header: "caller-session", payload: `{"prompt_cache_key":"cache-123"}`, wantHeader: "caller-session"},
+		{name: "blank key is ignored", url: "https://openrouter.ai/api/v1/chat/completions", payload: `{"prompt_cache_key":"  "}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, test.url, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("X-Session-ID", test.header)
+
+			ApplyOpenRouterSessionAffinity(req, []byte(test.payload))
+
+			if got := req.Header.Get("X-Session-ID"); got != test.wantHeader {
+				t.Fatalf("X-Session-ID = %q, want %q", got, test.wantHeader)
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/helps/openrouter_session_affinity_test.go
+++ b/internal/runtime/executor/helps/openrouter_session_affinity_test.go
@@ -2,6 +2,7 @@ package helps
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -19,6 +20,8 @@ func TestApplyOpenRouterSessionAffinity(t *testing.T) {
 		{name: "lookalike endpoint is unchanged", url: "https://openrouter.ai.example.com/v1/chat/completions", payload: `{"prompt_cache_key":"cache-123"}`},
 		{name: "explicit header wins", url: "https://openrouter.ai/api/v1/chat/completions", header: "caller-session", payload: `{"prompt_cache_key":"cache-123"}`, wantHeader: "caller-session"},
 		{name: "blank key is ignored", url: "https://openrouter.ai/api/v1/chat/completions", payload: `{"prompt_cache_key":"  "}`},
+		{name: "control-bearing key is ignored", url: "https://openrouter.ai/api/v1/chat/completions", payload: `{"prompt_cache_key":"cache\nkey"}`},
+		{name: "oversized key is ignored", url: "https://openrouter.ai/api/v1/chat/completions", payload: `{"prompt_cache_key":"` + strings.Repeat("a", 257) + `"}`},
 	}
 
 	for _, test := range tests {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -158,6 +158,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		attrs = auth.Attributes
 	}
 	util.ApplyCustomHeadersFromAttrs(httpReq, attrs)
+	helps.ApplyOpenRouterSessionAffinity(httpReq, translated)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -367,6 +368,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		attrs = auth.Attributes
 	}
 	util.ApplyCustomHeadersFromAttrs(httpReq, attrs)
+	helps.ApplyOpenRouterSessionAffinity(httpReq, translated)
 	httpReq.Header.Set("Accept", "text/event-stream")
 	httpReq.Header.Set("Cache-Control", "no-cache")
 	var authID, authLabel, authType, authValue string


### PR DESCRIPTION
## Summary

- detect OpenRouter at the resolved upstream URL boundary
- forward a validated stable X-Session-ID when the translated request has prompt_cache_key
- preserve an explicitly configured X-Session-ID header
- keep generic OpenAI-compatibility prompt-cache behavior and tests unchanged
- cover OpenRouter, subdomain, non-OpenRouter, lookalike-host, explicit-header, blank-key, control-character, and oversized-key cases in the executor helper package

## Why

OpenRouter uses X-Session-ID for immediate provider stickiness. OpenRouter is configured through the generic OpenAI-compatible executor, so the resolved endpoint host - not the executor label - is the reliable discriminator. Session identifiers are normalized before crossing the HTTP header boundary.

## Validation

- go test ./internal/runtime/executor/helps -run TestApplyOpenRouterSessionAffinity -count=1
- go test ./internal/runtime/executor -run TestOpenAICompatExecutorPromptCacheKey -count=1
- go build -o /tmp/cliproxy-cache-affinity-build ./cmd/server
- git diff --check
- built and exercised on Kyber from exact head 6749a4ce