### PR TITLE
fix(codex): avoid input ID normalization collisions

### DIFF
--- a/internal/runtime/executor/helps/codex_input_ids.go
+++ b/internal/runtime/executor/helps/codex_input_ids.go
@@ -31,6 +31,7 @@ func SanitizeCodexInputItemIDs(body []byte) []byte {
 
 	items := input.Array()
 	occupied := make(map[string]struct{}, len(items))
+	preserved := make(map[string]struct{}, len(items))
 	for _, item := range items {
 		if shouldDropCodexEncryptedReasoningItem(item) {
 			continue
@@ -39,13 +40,20 @@ func SanitizeCodexInputItemIDs(body []byte) []byte {
 		if itemID.Type != gjson.String {
 			continue
 		}
-		id := normalizeCodexInputItemID(item, itemID.String())
+		originalID := itemID.String()
+		id := normalizeCodexInputItemID(item, originalID)
+		if id == originalID {
+			// Record preserved identities before length handling so a rewrite cannot
+			// merge with an overlong ID that will be shortened later.
+			preserved[id] = struct{}{}
+		}
 		if len([]rune(id)) <= codexInputItemIDLimit {
 			occupied[id] = struct{}{}
 		}
 	}
 
 	mapped := make(map[string]string, len(items))
+	collisionMapped := make(map[string]string, len(items))
 	rebuilt := make([]string, 0, len(items))
 	changed := false
 	for _, item := range items {
@@ -59,6 +67,22 @@ func SanitizeCodexInputItemIDs(body []byte) []byte {
 		if itemID.Type == gjson.String {
 			originalID := itemID.String()
 			id := normalizeCodexInputItemID(item, originalID)
+			if id != originalID {
+				if collisionID, ok := collisionMapped[id]; ok {
+					id = collisionID
+				} else if _, exists := preserved[id]; exists {
+					for attempt := 0; ; attempt++ {
+						collisionID := codexInputItemIDWithHashSuffix(id, attempt)
+						if _, occupiedID := occupied[collisionID]; occupiedID {
+							continue
+						}
+						collisionMapped[id] = collisionID
+						occupied[collisionID] = struct{}{}
+						id = collisionID
+						break
+					}
+				}
+			}
 			if len([]rune(id)) > codexInputItemIDLimit {
 				shortened, ok := mapped[id]
 				if !ok {
@@ -139,7 +163,11 @@ func shortenCodexInputItemIDWithAttempt(id string, attempt int) string {
 	if len(runes) <= codexInputItemIDLimit {
 		return id
 	}
+	return codexInputItemIDWithHashSuffix(id, attempt)
+}
 
+func codexInputItemIDWithHashSuffix(id string, attempt int) string {
+	runes := []rune(id)
 	hashInput := id
 	if attempt > 0 {
 		hashInput += "\x00" + strconv.Itoa(attempt)
@@ -147,5 +175,8 @@ func shortenCodexInputItemIDWithAttempt(id string, attempt int) string {
 	sum := sha256.Sum256([]byte(hashInput))
 	suffix := "_" + hex.EncodeToString(sum[:8])
 	prefixLength := codexInputItemIDLimit - len(suffix)
+	if len(runes) < prefixLength {
+		prefixLength = len(runes)
+	}
 	return string(runes[:prefixLength]) + suffix
 }

--- a/internal/runtime/executor/helps/codex_input_ids_test.go
+++ b/internal/runtime/executor/helps/codex_input_ids_test.go
@@ -94,6 +94,71 @@ func TestSanitizeCodexInputItemIDsNormalizesResponseItemIDs(t *testing.T) {
 	}
 }
 
+func TestSanitizeCodexInputItemIDsAvoidsNormalizationCollisions(t *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		typeID string
+		prefix string
+	}{
+		{name: "message", typeID: "message", prefix: "msg_"},
+		{name: "reasoning", typeID: "reasoning", prefix: "rs_"},
+		{name: "function call", typeID: "function_call", prefix: "fc_"},
+		{name: "custom tool call", typeID: "custom_tool_call", prefix: "ctc_"},
+		{name: "custom tool call output", typeID: "custom_tool_call_output", prefix: "ctco_"},
+	} {
+		for _, idCase := range []struct {
+			name      string
+			invalidID string
+		}{
+			{name: "short", invalidID: "item_collision"},
+			{name: "overlong", invalidID: strings.Repeat("x", codexInputItemIDLimit-len([]rune(testCase.prefix))+1)},
+		} {
+			prefixedID := testCase.prefix + idCase.invalidID
+			for _, order := range []struct {
+				name          string
+				ids           [2]string
+				prefixedIndex int
+			}{
+				{name: "local first", ids: [2]string{idCase.invalidID, prefixedID}, prefixedIndex: 1},
+				{name: "prefixed first", ids: [2]string{prefixedID, idCase.invalidID}, prefixedIndex: 0},
+			} {
+				t.Run(testCase.name+"/"+idCase.name+"/"+order.name, func(t *testing.T) {
+					body := []byte(fmt.Sprintf(`{"input":[{"type":%q,"id":%q},{"type":%q,"id":%q}]}`, testCase.typeID, order.ids[0], testCase.typeID, order.ids[1]))
+
+					first := SanitizeCodexInputItemIDs(body)
+					second := SanitizeCodexInputItemIDs(body)
+					normalizedAgain := SanitizeCodexInputItemIDs(first)
+					ids := [2]string{
+						gjson.GetBytes(first, "input.0.id").String(),
+						gjson.GetBytes(first, "input.1.id").String(),
+					}
+
+					if ids[0] == ids[1] {
+						t.Fatalf("distinct IDs collided after normalization: %q; payload=%s", ids[0], first)
+					}
+					for index, id := range ids {
+						if !strings.HasPrefix(id, testCase.prefix) {
+							t.Fatalf("input.%d.id = %q, want prefix %q", index, id, testCase.prefix)
+						}
+						if len([]rune(id)) > codexInputItemIDLimit {
+							t.Fatalf("input.%d.id length = %d, want at most %d: %q", index, len([]rune(id)), codexInputItemIDLimit, id)
+						}
+					}
+					if len([]rune(prefixedID)) <= codexInputItemIDLimit && ids[order.prefixedIndex] != prefixedID {
+						t.Fatalf("existing valid ID changed: got %q want %q", ids[order.prefixedIndex], prefixedID)
+					}
+					if string(first) != string(second) {
+						t.Fatalf("collision resolution is not deterministic: first=%s second=%s", first, second)
+					}
+					if string(first) != string(normalizedAgain) {
+						t.Fatalf("collision resolution is not idempotent: first=%s normalized_again=%s", first, normalizedAgain)
+					}
+				})
+			}
+		}
+	}
+}
+
 func TestSanitizeCodexInputItemIDsNormalizesCustomToolCallIDs(t *testing.T) {
 	const invalidID = "item_44e13caebc1ddf25f1337cbe"
 	body := []byte(`{"input":[{"type":"custom_tool_call","id":"` + invalidID + `","call_id":"call-1","name":"lookup","input":"{}"}]}`)


### PR DESCRIPTION
## Summary

Fixes #4891.

A Responses conversation/history can mix items produced through two GPT access paths: OpenAI's native GPT/Codex service and GPT accessed through a relay or intermediary proxy. Those paths can emit or preserve different item-ID shapes. When the mixed history is replayed through CLIProxyAPI, normalization can collapse two originally distinct IDs into the same upstream identity.

This patch keeps the fix in the shared Codex executor sanitizer:

- reserve identities that the sanitizer would otherwise preserve;
- when a prefix rewrite would land on a reserved identity, assign the rewritten item a deterministic hash-suffixed ID;
- keep the existing valid identity unchanged;
- preserve the 64-rune limit, determinism, idempotence, and the single final `input` array replacement;
- cover all five normalized Responses item types, short and overlong IDs, and both item orders.

The scope is intentionally small: no handler, translator, protocol, configuration, or documentation changes.

## User-visible reproduction

The issue appears when native and relay GPT histories are combined. For a message pair such as:

| History item | Original ID | Current `dev` after normalization |
| --- | --- | --- |
| Unprefixed/local item from one access path | `item_collision` | `msg_item_collision` |
| Already-valid item from the other access path | `msg_item_collision` | `msg_item_collision` |

Both distinct items reach the upstream API with the same identity. That can cause upstream rejection or ambiguous association between Responses items and their outputs.

The equivalent collision exists for `reasoning`, `function_call`, `custom_tool_call`, and `custom_tool_call_output`.

## Root cause

`SanitizeCodexInputItemIDs` builds an occupied-ID set and then normalizes the input items. Existing collision handling protects deterministic shortening of overlong IDs, but a short prefix rewrite such as `item_collision` → `msg_item_collision` did not check whether that target belonged to an already-valid item.

As a result, the compatibility sanitizer itself could introduce a duplicate into an originally distinct mixed history.

## Relationship to #4889

This is a narrow follow-up to the automated review on #4889, not a revival of that handler-level patch.

The review identified two concerns:

1. prefix normalization could collide with an already-valid item ID;
2. repeatedly rewriting the full request body could create quadratic work for large histories.

Current `dev` already performs normalization in the shared Codex executor path and rebuilds the `input` array once, so the second concern is already resolved architecturally. This PR addresses only the remaining collision gap in that shared helper.

## Implementation

The sanitizer now records preserved original identities before length handling. If a normalized target is reserved, it uses the existing SHA-256-based shortening strategy to derive a deterministic collision-safe ID, retrying only if that derived identity is also occupied.

Recording overlong preserved identities before shortening is intentional: it prevents an overlong existing ID and a rewritten ID from choosing the same shortened output, regardless of their order in the array.

Both Codex HTTP and WebSocket execution paths already call this helper, so no endpoint-specific wiring is needed.

## Validation

Using Go 1.26.5 in Docker. The required build and focused tests were rerun on the PR merge result against `dev` at `177c7619b681b0ab97bccbac0931493f0419bbe5`. The subsequent identity-only amend preserved the exact source tree SHA `030820e1c9370f52167ab7981b10c35a5e574f79`:

- required server compile: `go build -o test-output ./cmd/server` passed;
- complete Codex input-ID helper tests passed;
- Codex HTTP and WebSocket sanitizer-path tests passed;
- collision regression coverage passed for all five supported item types, short/overlong targets, both orders, determinism, and idempotence;
- `git diff --check upstream/dev...HEAD` passed;
- independent review of the final commit reported no findings.

`go test ./... -count=1` reproduced only the same three Docker OS-fingerprint baseline failures present before this patch:

- `TestApplyClaudeHeaders_DisableDeviceProfileStabilization`
- `TestApplyClaudeHeaders_LegacyModePreservesConfiguredUserAgentOverrideForClaudeClients`
- `TestClaudeExecutor_NonClaudeRequestUsesClaudeCode220CLIFingerprint`

All other packages passed.