### PR TITLE
feat(executor/openai): add opt-in fill-missing-reasoning-history configuration option (#4893)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -484,6 +484,7 @@ nonstream-keepalive-interval: 0
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
 #     support-prompt-cache-key: false # optional: derive prompt_cache_key for requests from all input protocols
+#     fill-missing-reasoning-history: false # optional: populate "[reasoning unavailable]" placeholder for prior assistant messages in history missing reasoning_content (useful for OpenCode Zen / strict 3rd-party proxies)
 #     disable-cooling: false # optional: per-provider override for auth/model cooldown scheduling
 #     headers:
 #       X-Custom-Header: "custom-value"
@@ -502,6 +503,7 @@ nonstream-keepalive-interval: 0
 #         input-modalities: [text, image] # optional: declare /v1/chat/completions and /v1/responses multimodal input for Codex clients. Use [text] for upstreams that reject multimodal tool result content.
 #         output-modalities: [text]       # optional: declare output modalities when known
 #         is-compat: false                # optional: preserve Claude thinking blocks for compatible upstreams
+#         fill-missing-reasoning-history: false # optional: populate "[reasoning unavailable]" placeholder for prior assistant messages missing reasoning_content
 #         thinking:                      # optional: omit to default to levels ["low","medium","high"]
 #           levels: ["low", "medium", "high"]
 #       # You may repeat the same alias to build an internal model pool.

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -39,17 +39,18 @@ type openAICompatibilityAPIKeyWithAuthIndex struct {
 }
 
 type openAICompatibilityWithAuthIndex struct {
-	Name                  string                                   `json:"name"`
-	Priority              int                                      `json:"priority,omitempty"`
-	Disabled              bool                                     `json:"disabled"`
-	Prefix                string                                   `json:"prefix,omitempty"`
-	BaseURL               string                                   `json:"base-url"`
-	APIKeyEntries         []openAICompatibilityAPIKeyWithAuthIndex `json:"api-key-entries,omitempty"`
-	Models                []config.OpenAICompatibilityModel        `json:"models,omitempty"`
-	Headers               map[string]string                        `json:"headers,omitempty"`
-	SupportPromptCacheKey bool                                     `json:"support-prompt-cache-key,omitempty"`
-	DisableCooling        bool                                     `json:"disable-cooling,omitempty"`
-	AuthIndex             string                                   `json:"auth-index,omitempty"`
+	Name                        string                                   `json:"name"`
+	Priority                    int                                      `json:"priority,omitempty"`
+	Disabled                    bool                                     `json:"disabled"`
+	Prefix                      string                                   `json:"prefix,omitempty"`
+	BaseURL                     string                                   `json:"base-url"`
+	APIKeyEntries               []openAICompatibilityAPIKeyWithAuthIndex `json:"api-key-entries,omitempty"`
+	Models                      []config.OpenAICompatibilityModel        `json:"models,omitempty"`
+	Headers                     map[string]string                        `json:"headers,omitempty"`
+	SupportPromptCacheKey       bool                                     `json:"support-prompt-cache-key,omitempty"`
+	DisableCooling              bool                                     `json:"disable-cooling,omitempty"`
+	FillMissingReasoningHistory bool                                     `json:"fill-missing-reasoning-history,omitempty"`
+	AuthIndex                   string                                   `json:"auth-index,omitempty"`
 }
 
 func (h *Handler) liveAuthIndexByID() map[string]string {
@@ -279,16 +280,17 @@ func (h *Handler) openAICompatibilityWithAuthIndex() []openAICompatibilityWithAu
 		idKind := fmt.Sprintf("openai-compatibility:%s", providerName)
 
 		response := openAICompatibilityWithAuthIndex{
-			Name:                  entry.Name,
-			Priority:              entry.Priority,
-			Disabled:              entry.Disabled,
-			Prefix:                entry.Prefix,
-			BaseURL:               entry.BaseURL,
-			Models:                entry.Models,
-			Headers:               entry.Headers,
-			SupportPromptCacheKey: entry.SupportPromptCacheKey,
-			DisableCooling:        entry.DisableCooling,
-			AuthIndex:             "",
+			Name:                        entry.Name,
+			Priority:                    entry.Priority,
+			Disabled:                    entry.Disabled,
+			Prefix:                      entry.Prefix,
+			BaseURL:                     entry.BaseURL,
+			Models:                      entry.Models,
+			Headers:                     entry.Headers,
+			SupportPromptCacheKey:       entry.SupportPromptCacheKey,
+			DisableCooling:              entry.DisableCooling,
+			FillMissingReasoningHistory: entry.FillMissingReasoningHistory,
+			AuthIndex:                   "",
 		}
 		if len(entry.APIKeyEntries) == 0 {
 			id, _ := idGen.Next(idKind, entry.BaseURL)

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -701,15 +701,16 @@ func (h *Handler) PutOpenAICompat(c *gin.Context) {
 }
 func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 	type openAICompatPatch struct {
-		Name                  *string                             `json:"name"`
-		Prefix                *string                             `json:"prefix"`
-		Disabled              *bool                               `json:"disabled"`
-		DisableCooling        *bool                               `json:"disable-cooling"`
-		BaseURL               *string                             `json:"base-url"`
-		APIKeyEntries         *[]config.OpenAICompatibilityAPIKey `json:"api-key-entries"`
-		Models                *[]config.OpenAICompatibilityModel  `json:"models"`
-		Headers               *map[string]string                  `json:"headers"`
-		SupportPromptCacheKey *bool                               `json:"support-prompt-cache-key"`
+		Name                        *string                             `json:"name"`
+		Prefix                      *string                             `json:"prefix"`
+		Disabled                    *bool                               `json:"disabled"`
+		DisableCooling              *bool                               `json:"disable-cooling"`
+		BaseURL                     *string                             `json:"base-url"`
+		APIKeyEntries               *[]config.OpenAICompatibilityAPIKey `json:"api-key-entries"`
+		Models                      *[]config.OpenAICompatibilityModel  `json:"models"`
+		Headers                     *map[string]string                  `json:"headers"`
+		SupportPromptCacheKey       *bool                               `json:"support-prompt-cache-key"`
+		FillMissingReasoningHistory *bool                               `json:"fill-missing-reasoning-history"`
 	}
 	var body struct {
 		Name  *string            `json:"name"`
@@ -781,6 +782,9 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 	}
 	if body.Value.SupportPromptCacheKey != nil {
 		entry.SupportPromptCacheKey = *body.Value.SupportPromptCacheKey
+	}
+	if body.Value.FillMissingReasoningHistory != nil {
+		entry.FillMissingReasoningHistory = *body.Value.FillMissingReasoningHistory
 	}
 	normalizeOpenAICompatibilityEntry(&entry)
 	h.cfg.OpenAICompatibility[targetIndex] = entry

--- a/internal/api/handlers/management/config_openai_compat_test.go
+++ b/internal/api/handlers/management/config_openai_compat_test.go
@@ -24,8 +24,9 @@ func TestGetOpenAICompatIncludesDisableCooling(t *testing.T) {
 				Models: []config.OpenAICompatibilityModel{
 					{Name: "mimo-v2.5", Alias: ""},
 				},
-				SupportPromptCacheKey: true,
-				DisableCooling:        true,
+				SupportPromptCacheKey:       true,
+				DisableCooling:              true,
+				FillMissingReasoningHistory: true,
 			},
 		},
 	}, nil)
@@ -41,8 +42,9 @@ func TestGetOpenAICompatIncludesDisableCooling(t *testing.T) {
 
 	var body struct {
 		OpenAICompatibility []struct {
-			SupportPromptCacheKey *bool `json:"support-prompt-cache-key"`
-			DisableCooling        *bool `json:"disable-cooling"`
+			SupportPromptCacheKey       *bool `json:"support-prompt-cache-key"`
+			DisableCooling              *bool `json:"disable-cooling"`
+			FillMissingReasoningHistory *bool `json:"fill-missing-reasoning-history"`
 		} `json:"openai-compatibility"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
@@ -56,5 +58,8 @@ func TestGetOpenAICompatIncludesDisableCooling(t *testing.T) {
 	}
 	if body.OpenAICompatibility[0].DisableCooling == nil || !*body.OpenAICompatibility[0].DisableCooling {
 		t.Fatalf("expected disable-cooling to be present and true, got %#v", body.OpenAICompatibility[0].DisableCooling)
+	}
+	if body.OpenAICompatibility[0].FillMissingReasoningHistory == nil || !*body.OpenAICompatibility[0].FillMissingReasoningHistory {
+		t.Fatalf("expected fill-missing-reasoning-history to be present and true, got %#v", body.OpenAICompatibility[0].FillMissingReasoningHistory)
 	}
 }

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -617,6 +617,10 @@ type OpenAICompatibility struct {
 
 	// DisableCooling disables auth/model cooldown scheduling for this provider when true.
 	DisableCooling bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
+
+	// FillMissingReasoningHistory ensures prior assistant messages in history have a reasoning_content placeholder
+	// to satisfy strict 3rd-party OpenAI-compatible providers (e.g. OpenCode Zen).
+	FillMissingReasoningHistory bool `yaml:"fill-missing-reasoning-history,omitempty" json:"fill-missing-reasoning-history,omitempty"`
 }
 
 // OpenAICompatibilityAPIKey represents an API key configuration with optional proxy setting.
@@ -664,6 +668,10 @@ type OpenAICompatibilityModel struct {
 	// Default false keeps the normal signature validation behavior.
 	IsCompat bool `yaml:"is-compat,omitempty" json:"is-compat,omitempty"`
 
+	// FillMissingReasoningHistory ensures prior assistant messages in history have a reasoning_content placeholder
+	// to satisfy strict 3rd-party OpenAI-compatible providers (e.g. OpenCode Zen).
+	FillMissingReasoningHistory bool `yaml:"fill-missing-reasoning-history,omitempty" json:"fill-missing-reasoning-history,omitempty"`
+
 	// Thinking configures the thinking/reasoning capability for this model.
 	// If nil, the model defaults to level-based reasoning with levels ["low", "medium", "high"].
 	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
@@ -679,3 +687,4 @@ func (m OpenAICompatibilityModel) GetForceMapping() bool    { return m.ForceMapp
 func (m OpenAICompatibilityModel) GetIsCompat() bool        { return m.IsCompat }
 
 func (m OpenAICompatibilityModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }
+

--- a/internal/runtime/executor/helps/openai_compat_tool_results.go
+++ b/internal/runtime/executor/helps/openai_compat_tool_results.go
@@ -36,7 +36,7 @@ func ShouldEnsureOpenAICompatAssistantReasoningContent(compat *config.OpenAIComp
 		return true
 	}
 
-	rawUpstream := stripProviderPrefix(upstreamModel, compat.Prefix)
+	rawUpstream := upstreamModel
 	rawRequested := stripProviderPrefix(requestedModel, compat.Prefix)
 
 	normUpstream := normalizeOpenAICompatibilityModelName(rawUpstream)

--- a/internal/runtime/executor/helps/openai_compat_tool_results.go
+++ b/internal/runtime/executor/helps/openai_compat_tool_results.go
@@ -36,6 +36,19 @@ func ShouldEnsureOpenAICompatAssistantReasoningContent(compat *config.OpenAIComp
 		return true
 	}
 
+	normUpstream := normalizeOpenAICompatibilityModelName(upstreamModel)
+	normRequested := normalizeOpenAICompatibilityModelName(requestedModel)
+
+	if normUpstream != "" && normRequested != "" {
+		for i := range compat.Models {
+			mName := normalizeOpenAICompatibilityModelName(compat.Models[i].Name)
+			mAlias := normalizeOpenAICompatibilityModelName(compat.Models[i].Alias)
+			if mName != "" && mAlias != "" && strings.EqualFold(normUpstream, mName) && strings.EqualFold(normRequested, mAlias) {
+				return compat.Models[i].FillMissingReasoningHistory
+			}
+		}
+	}
+
 	if fill, matched := openAICompatibilityModelFillsReasoning(compat.Models, upstreamModel); matched {
 		return fill
 	}

--- a/internal/runtime/executor/helps/openai_compat_tool_results.go
+++ b/internal/runtime/executor/helps/openai_compat_tool_results.go
@@ -39,6 +39,14 @@ func ShouldEnsureOpenAICompatAssistantReasoningContent(compat *config.OpenAIComp
 	rawUpstream := upstreamModel
 	rawRequested := stripProviderPrefix(requestedModel, compat.Prefix)
 
+	if rawUpstream != "" && rawRequested != "" {
+		for i := range compat.Models {
+			if strings.EqualFold(rawUpstream, compat.Models[i].Name) && strings.EqualFold(rawRequested, compat.Models[i].Alias) {
+				return compat.Models[i].FillMissingReasoningHistory
+			}
+		}
+	}
+
 	normUpstream := normalizeOpenAICompatibilityModelName(rawUpstream)
 	normRequested := normalizeOpenAICompatibilityModelName(rawRequested)
 

--- a/internal/runtime/executor/helps/openai_compat_tool_results.go
+++ b/internal/runtime/executor/helps/openai_compat_tool_results.go
@@ -26,6 +26,76 @@ func ShouldNormalizeOpenAIToolResultsForModel(compat *config.OpenAICompatibility
 	return normalize
 }
 
+// ShouldEnsureOpenAICompatAssistantReasoningContent reports whether the selected model
+// or provider has enabled fill-missing-reasoning-history configuration.
+func ShouldEnsureOpenAICompatAssistantReasoningContent(compat *config.OpenAICompatibility, upstreamModel, requestedModel string) bool {
+	if compat == nil {
+		return false
+	}
+	if compat.FillMissingReasoningHistory {
+		return true
+	}
+
+	if fill, matched := openAICompatibilityModelFillsReasoning(compat.Models, upstreamModel); matched {
+		return fill
+	}
+	fill, _ := openAICompatibilityModelFillsReasoning(compat.Models, requestedModel)
+	return fill
+}
+
+// EnsureOpenAICompatAssistantReasoningContent ensures every assistant message in history
+// has a non-empty reasoning_content field to satisfy strict OpenAI-compatible
+// reasoning providers (e.g. OpenCode Zen).
+func EnsureOpenAICompatAssistantReasoningContent(payload []byte) []byte {
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return payload
+	}
+
+	out := payload
+	messageIndex := 0
+	messages.ForEach(func(_, message gjson.Result) bool {
+		if message.Get("role").String() == "assistant" {
+			reasoning := message.Get("reasoning_content")
+			if !reasoning.Exists() || strings.TrimSpace(reasoning.String()) == "" {
+				path := fmt.Sprintf("messages.%d.reasoning_content", messageIndex)
+				if updated, errSet := sjson.SetBytes(out, path, "[reasoning unavailable]"); errSet == nil {
+					out = updated
+				}
+			}
+		}
+		messageIndex++
+		return true
+	})
+	return out
+}
+
+func openAICompatibilityModelFillsReasoning(models []config.OpenAICompatibilityModel, model string) (bool, bool) {
+	model = normalizeOpenAICompatibilityModelName(model)
+	if model == "" {
+		return false, false
+	}
+
+	for i := range models {
+		if strings.EqualFold(model, normalizeOpenAICompatibilityModelName(models[i].Name)) {
+			return models[i].FillMissingReasoningHistory, true
+		}
+	}
+
+	matched := false
+	fills := true
+	for i := range models {
+		if !strings.EqualFold(model, normalizeOpenAICompatibilityModelName(models[i].Alias)) {
+			continue
+		}
+		matched = true
+		if !models[i].FillMissingReasoningHistory {
+			fills = false
+		}
+	}
+	return fills && matched, matched
+}
+
 // NormalizeOpenAIToolResultsTextOnly converts tool message content to strings.
 // Text parts are preserved and image parts are replaced with a short marker.
 func NormalizeOpenAIToolResultsTextOnly(payload []byte) []byte {

--- a/internal/runtime/executor/helps/openai_compat_tool_results.go
+++ b/internal/runtime/executor/helps/openai_compat_tool_results.go
@@ -36,8 +36,11 @@ func ShouldEnsureOpenAICompatAssistantReasoningContent(compat *config.OpenAIComp
 		return true
 	}
 
-	normUpstream := normalizeOpenAICompatibilityModelName(upstreamModel)
-	normRequested := normalizeOpenAICompatibilityModelName(requestedModel)
+	rawUpstream := stripProviderPrefix(upstreamModel, compat.Prefix)
+	rawRequested := stripProviderPrefix(requestedModel, compat.Prefix)
+
+	normUpstream := normalizeOpenAICompatibilityModelName(rawUpstream)
+	normRequested := normalizeOpenAICompatibilityModelName(rawRequested)
 
 	if normUpstream != "" && normRequested != "" {
 		for i := range compat.Models {
@@ -49,11 +52,23 @@ func ShouldEnsureOpenAICompatAssistantReasoningContent(compat *config.OpenAIComp
 		}
 	}
 
-	if fill, matched := openAICompatibilityModelFillsReasoning(compat.Models, upstreamModel); matched {
+	if fill, matched := openAICompatibilityModelFillsReasoning(compat.Models, rawUpstream); matched {
 		return fill
 	}
-	fill, _ := openAICompatibilityModelFillsReasoning(compat.Models, requestedModel)
+	fill, _ := openAICompatibilityModelFillsReasoning(compat.Models, rawRequested)
 	return fill
+}
+
+func stripProviderPrefix(model, prefix string) string {
+	model = strings.TrimSpace(model)
+	prefix = strings.TrimSpace(prefix)
+	if prefix != "" {
+		p := prefix + "/"
+		if len(model) > len(p) && strings.EqualFold(model[:len(p)], p) {
+			return strings.TrimSpace(model[len(p):])
+		}
+	}
+	return model
 }
 
 // EnsureOpenAICompatAssistantReasoningContent ensures every assistant message in history

--- a/internal/runtime/executor/helps/openai_compat_tool_results_test.go
+++ b/internal/runtime/executor/helps/openai_compat_tool_results_test.go
@@ -199,4 +199,19 @@ func TestShouldEnsureOpenAICompatAssistantReasoningContentDisambiguation(t *test
 	if ShouldEnsureOpenAICompatAssistantReasoningContent(compatPrefix, "deepseek-v3", "team/alias-standard") {
 		t.Fatalf("expected prefixed standard alias to disable fill-missing-reasoning-history")
 	}
+
+	compatUpstreamNamespace := &config.OpenAICompatibility{
+		Prefix: "deepseek",
+		Models: []config.OpenAICompatibilityModel{
+			{Name: "deepseek/v3", Alias: "v3-optin", FillMissingReasoningHistory: true},
+			{Name: "deepseek/v3", Alias: "v3-standard", FillMissingReasoningHistory: false},
+		},
+	}
+
+	if !ShouldEnsureOpenAICompatAssistantReasoningContent(compatUpstreamNamespace, "deepseek/v3", "deepseek/v3-optin") {
+		t.Fatalf("expected preserved upstream namespace opt-in alias to enable fill-missing-reasoning-history")
+	}
+	if ShouldEnsureOpenAICompatAssistantReasoningContent(compatUpstreamNamespace, "deepseek/v3", "deepseek/v3-standard") {
+		t.Fatalf("expected preserved upstream namespace standard alias to disable fill-missing-reasoning-history")
+	}
 }

--- a/internal/runtime/executor/helps/openai_compat_tool_results_test.go
+++ b/internal/runtime/executor/helps/openai_compat_tool_results_test.go
@@ -214,4 +214,18 @@ func TestShouldEnsureOpenAICompatAssistantReasoningContentDisambiguation(t *test
 	if ShouldEnsureOpenAICompatAssistantReasoningContent(compatUpstreamNamespace, "deepseek/v3", "deepseek/v3-standard") {
 		t.Fatalf("expected preserved upstream namespace standard alias to disable fill-missing-reasoning-history")
 	}
+
+	compatSuffixed := &config.OpenAICompatibility{
+		Models: []config.OpenAICompatibilityModel{
+			{Name: "deepseek-v3", Alias: "public(low)", FillMissingReasoningHistory: true},
+			{Name: "deepseek-v3", Alias: "public(high)", FillMissingReasoningHistory: false},
+		},
+	}
+
+	if !ShouldEnsureOpenAICompatAssistantReasoningContent(compatSuffixed, "deepseek-v3", "public(low)") {
+		t.Fatalf("expected public(low) suffixed alias to enable fill-missing-reasoning-history")
+	}
+	if ShouldEnsureOpenAICompatAssistantReasoningContent(compatSuffixed, "deepseek-v3", "public(high)") {
+		t.Fatalf("expected public(high) suffixed alias to disable fill-missing-reasoning-history")
+	}
 }

--- a/internal/runtime/executor/helps/openai_compat_tool_results_test.go
+++ b/internal/runtime/executor/helps/openai_compat_tool_results_test.go
@@ -109,3 +109,63 @@ func TestShouldNormalizeOpenAIToolResultsForModel(t *testing.T) {
 		t.Fatal("nil compatibility config unexpectedly enabled normalization")
 	}
 }
+
+func TestShouldEnsureOpenAICompatAssistantReasoningContent(t *testing.T) {
+	compat := &config.OpenAICompatibility{
+		Models: []config.OpenAICompatibilityModel{
+			{Name: "upstream-fill", Alias: "alias-fill", FillMissingReasoningHistory: true},
+			{Name: "upstream-nofill", Alias: "alias-nofill", FillMissingReasoningHistory: false},
+		},
+	}
+
+	compatProviderOptIn := &config.OpenAICompatibility{
+		FillMissingReasoningHistory: true,
+		Models: []config.OpenAICompatibilityModel{
+			{Name: "model-a", Alias: "alias-a"},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		compat         *config.OpenAICompatibility
+		upstreamModel  string
+		requestedModel string
+		want           bool
+	}{
+		{name: "model fill true", compat: compat, upstreamModel: "upstream-fill", want: true},
+		{name: "model fill suffix", compat: compat, upstreamModel: "upstream-fill(high)", want: true},
+		{name: "alias fill true", compat: compat, upstreamModel: "unknown", requestedModel: "alias-fill", want: true},
+		{name: "model fill false", compat: compat, upstreamModel: "upstream-nofill", want: false},
+		{name: "provider level opt in", compat: compatProviderOptIn, upstreamModel: "model-a", want: true},
+		{name: "nil compat", compat: nil, upstreamModel: "upstream-fill", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldEnsureOpenAICompatAssistantReasoningContent(tt.compat, tt.upstreamModel, tt.requestedModel); got != tt.want {
+				t.Fatalf("fill = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnsureOpenAICompatAssistantReasoningContent(t *testing.T) {
+	input := []byte(`{"messages":[
+		{"role":"user","content":"hello"},
+		{"role":"assistant","content":"text answer without reasoning"},
+		{"role":"user","content":"next question"},
+		{"role":"assistant","content":"answer with reasoning","reasoning_content":"existing reasoning"}
+	]}`)
+
+	got := EnsureOpenAICompatAssistantReasoningContent(input)
+
+	res1 := gjson.GetBytes(got, "messages.1.reasoning_content")
+	if !res1.Exists() || res1.String() != "[reasoning unavailable]" {
+		t.Fatalf("messages.1.reasoning_content = %q, want [reasoning unavailable]", res1.String())
+	}
+
+	res3 := gjson.GetBytes(got, "messages.3.reasoning_content")
+	if !res3.Exists() || res3.String() != "existing reasoning" {
+		t.Fatalf("messages.3.reasoning_content = %q, want existing reasoning", res3.String())
+	}
+}

--- a/internal/runtime/executor/helps/openai_compat_tool_results_test.go
+++ b/internal/runtime/executor/helps/openai_compat_tool_results_test.go
@@ -184,4 +184,19 @@ func TestShouldEnsureOpenAICompatAssistantReasoningContentDisambiguation(t *test
 	if ShouldEnsureOpenAICompatAssistantReasoningContent(compat, "deepseek-v3", "alias-standard") {
 		t.Fatalf("expected standard alias to disable fill-missing-reasoning-history")
 	}
+
+	compatPrefix := &config.OpenAICompatibility{
+		Prefix: "team",
+		Models: []config.OpenAICompatibilityModel{
+			{Name: "deepseek-v3", Alias: "alias-optin", FillMissingReasoningHistory: true},
+			{Name: "deepseek-v3", Alias: "alias-standard", FillMissingReasoningHistory: false},
+		},
+	}
+
+	if !ShouldEnsureOpenAICompatAssistantReasoningContent(compatPrefix, "deepseek-v3", "team/alias-optin") {
+		t.Fatalf("expected prefixed opt-in alias to enable fill-missing-reasoning-history")
+	}
+	if ShouldEnsureOpenAICompatAssistantReasoningContent(compatPrefix, "deepseek-v3", "team/alias-standard") {
+		t.Fatalf("expected prefixed standard alias to disable fill-missing-reasoning-history")
+	}
 }

--- a/internal/runtime/executor/helps/openai_compat_tool_results_test.go
+++ b/internal/runtime/executor/helps/openai_compat_tool_results_test.go
@@ -169,3 +169,19 @@ func TestEnsureOpenAICompatAssistantReasoningContent(t *testing.T) {
 		t.Fatalf("messages.3.reasoning_content = %q, want existing reasoning", res3.String())
 	}
 }
+
+func TestShouldEnsureOpenAICompatAssistantReasoningContentDisambiguation(t *testing.T) {
+	compat := &config.OpenAICompatibility{
+		Models: []config.OpenAICompatibilityModel{
+			{Name: "deepseek-v3", Alias: "alias-optin", FillMissingReasoningHistory: true},
+			{Name: "deepseek-v3", Alias: "alias-standard", FillMissingReasoningHistory: false},
+		},
+	}
+
+	if !ShouldEnsureOpenAICompatAssistantReasoningContent(compat, "deepseek-v3", "alias-optin") {
+		t.Fatalf("expected opt-in alias to enable fill-missing-reasoning-history")
+	}
+	if ShouldEnsureOpenAICompatAssistantReasoningContent(compat, "deepseek-v3", "alias-standard") {
+		t.Fatalf("expected standard alias to disable fill-missing-reasoning-history")
+	}
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -125,9 +125,13 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
+	compatConfig := e.resolveCompatConfig(auth)
 	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
-	if helps.ShouldNormalizeOpenAIToolResultsForModel(e.resolveCompatConfig(auth), baseModel, requestedModel) {
+	if helps.ShouldNormalizeOpenAIToolResultsForModel(compatConfig, baseModel, requestedModel) {
 		translated = helps.NormalizeOpenAIToolResultsTextOnly(translated)
+	}
+	if helps.ShouldEnsureOpenAICompatAssistantReasoningContent(compatConfig, baseModel, requestedModel) {
+		translated = helps.EnsureOpenAICompatAssistantReasoningContent(translated)
 	}
 	if opts.Alt != "responses/compact" {
 		translated, err = e.applyPromptCacheKey(ctx, auth, from, baseModel, req, opts, translated)
@@ -336,9 +340,13 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
+	compatConfig := e.resolveCompatConfig(auth)
 	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
-	if helps.ShouldNormalizeOpenAIToolResultsForModel(e.resolveCompatConfig(auth), baseModel, requestedModel) {
+	if helps.ShouldNormalizeOpenAIToolResultsForModel(compatConfig, baseModel, requestedModel) {
 		translated = helps.NormalizeOpenAIToolResultsTextOnly(translated)
+	}
+	if helps.ShouldEnsureOpenAICompatAssistantReasoningContent(compatConfig, baseModel, requestedModel) {
+		translated = helps.EnsureOpenAICompatAssistantReasoningContent(translated)
 	}
 	if opts.Alt != "responses/compact" {
 		translated, err = e.applyPromptCacheKey(ctx, auth, from, baseModel, req, opts, translated)

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -127,10 +127,10 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	requestPath := helps.PayloadRequestPath(opts)
 	compatConfig := e.resolveCompatConfig(auth)
 	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
-	if helps.ShouldNormalizeOpenAIToolResultsForModel(compatConfig, baseModel, requestedModel) {
+	if helps.ShouldNormalizeOpenAIToolResultsForModel(compatConfig, req.Model, requestedModel) {
 		translated = helps.NormalizeOpenAIToolResultsTextOnly(translated)
 	}
-	if helps.ShouldEnsureOpenAICompatAssistantReasoningContent(compatConfig, baseModel, requestedModel) {
+	if helps.ShouldEnsureOpenAICompatAssistantReasoningContent(compatConfig, req.Model, requestedModel) {
 		translated = helps.EnsureOpenAICompatAssistantReasoningContent(translated)
 	}
 	if opts.Alt != "responses/compact" {
@@ -342,10 +342,10 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	requestPath := helps.PayloadRequestPath(opts)
 	compatConfig := e.resolveCompatConfig(auth)
 	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
-	if helps.ShouldNormalizeOpenAIToolResultsForModel(compatConfig, baseModel, requestedModel) {
+	if helps.ShouldNormalizeOpenAIToolResultsForModel(compatConfig, req.Model, requestedModel) {
 		translated = helps.NormalizeOpenAIToolResultsTextOnly(translated)
 	}
-	if helps.ShouldEnsureOpenAICompatAssistantReasoningContent(compatConfig, baseModel, requestedModel) {
+	if helps.ShouldEnsureOpenAICompatAssistantReasoningContent(compatConfig, req.Model, requestedModel) {
 		translated = helps.EnsureOpenAICompatAssistantReasoningContent(translated)
 	}
 	if opts.Alt != "responses/compact" {


### PR DESCRIPTION
## Summary
Adds an opt-in configuration option `fill-missing-reasoning-history` at both provider (`OpenAICompatibility`) and model (`OpenAICompatibilityModel`) levels.

When enabled (`fill-missing-reasoning-history: true`), the executor populates a `"[reasoning unavailable]"` placeholder into prior `assistant` messages in history that lack `reasoning_content`.

This accommodates strict 3rd-party OpenAI-compatible providers (such as OpenCode Zen) while preserving standard behavior when disabled (default `false`), fully respecting the maintainer feedback in #4879 and #4893.

## Architectural Design
- **Opt-in Only**: Defaults to `false` to avoid mutating payloads for standard OpenAI/DeepSeek upstreams.
- **Provider & Model Granularity**: Can be set per-provider or per-model in `config.yaml`.
- **Pattern Alignment**: Uses `ShouldEnsureOpenAICompatAssistantReasoningContent(...)` in `internal/runtime/executor/helps/openai_compat_tool_results.go`, mirroring `ShouldNormalizeOpenAIToolResultsForModel(...)`.

## Verification
- Unit tests added in `openai_compat_tool_results_test.go` (`TestShouldEnsureOpenAICompatAssistantReasoningContent`, `TestEnsureOpenAICompatAssistantReasoningContent`) — **PASS**.
- Server compilation verified (`go build ./cmd/server`) — **PASS**.
- Code formatted with `gofmt`.

Fixes #4893
