### PR TITLE
perf(antigravity): batch pre-upstream JSON rewrites

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -4,6 +4,7 @@
 package executor
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -132,6 +133,17 @@ func sanitizeAntigravityGeminiRequestSignatures(modelName string, rawJSON []byte
 	return normalizeAntigravityGeminiFunctionResponseRoles(rawJSON)
 }
 
+type antigravityContentEdit struct {
+	index       int64
+	start       int
+	end         int
+	replacement []byte
+}
+
+// normalizeAntigravityGeminiFunctionResponseRoles edits each response turn in
+// isolation, then splices all changed turns into the request with one body copy.
+// Applying SJSON once per field made large histories scale with history size
+// multiplied by the number of tool turns.
 func normalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byte {
 	rawJSON = repairAntigravityGeminiFunctionResponseNames(rawJSON)
 	contents := util.GetGJSONBytesNoCopy(rawJSON, "request.contents")
@@ -142,18 +154,23 @@ func normalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byte {
 		id   string
 		name string
 	}
-	out := rawJSON
+
+	edits := make([]antigravityContentEdit, 0)
 	var pending []functionRef
-	for contentIndex, content := range contents.Array() {
+	validOffsets := true
+	contents.ForEach(func(contentIndex, content gjson.Result) bool {
 		parts := content.Get("parts")
-		if !parts.IsArray() || len(parts.Array()) == 0 {
+		if !parts.IsArray() {
 			pending = nil
-			continue
+			return true
 		}
+
 		var calls, responses []functionRef
 		var responseParts []json.RawMessage
+		partCount := 0
 		hasOtherPart := false
 		parts.ForEach(func(_, part gjson.Result) bool {
+			partCount++
 			switch {
 			case part.Get("functionCall").Exists():
 				calls = append(calls, functionRef{id: part.Get("functionCall.id").String(), name: part.Get("functionCall.name").String()})
@@ -165,21 +182,27 @@ func normalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byte {
 			}
 			return true
 		})
+		if partCount == 0 {
+			pending = nil
+			return true
+		}
 		if len(calls) > 0 && len(responses) == 0 {
 			pending = calls
-			continue
+			return true
 		}
 		if len(responses) == 0 {
 			if hasOtherPart {
 				pending = nil
 			}
-			continue
+			return true
 		}
 		if hasOtherPart || len(calls) > 0 {
 			pending = nil
-			continue
+			return true
 		}
 
+		var contentJSON []byte
+		contentChanged := false
 		if len(pending) == len(responses) {
 			ordered := make([]json.RawMessage, 0, len(responseParts))
 			used := make([]bool, len(responses))
@@ -202,18 +225,80 @@ func normalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byte {
 				ordered = append(ordered, responseParts[matched])
 			}
 			if len(ordered) == len(responseParts) {
-				if encoded, errMarshal := json.Marshal(ordered); errMarshal == nil {
-					if updated, errSet := sjson.SetRawBytes(out, fmt.Sprintf("request.contents.%d.parts", contentIndex), encoded); errSet == nil {
-						out = updated
+				encoded, errMarshal := json.Marshal(ordered)
+				if errMarshal == nil && !bytes.Equal(encoded, []byte(parts.Raw)) {
+					contentJSON = []byte(content.Raw)
+					if updated, errSet := sjson.SetRawBytes(contentJSON, "parts", encoded); errSet == nil {
+						contentJSON = updated
+						contentChanged = true
 					}
 				}
 			}
 		}
 		pending = nil
 		if content.Get("role").String() != "model" {
-			if updated, errSet := sjson.SetBytes(out, fmt.Sprintf("request.contents.%d.role", contentIndex), "model"); errSet == nil {
-				out = updated
+			if contentJSON == nil {
+				contentJSON = []byte(content.Raw)
 			}
+			if updated, errSet := sjson.SetBytes(contentJSON, "role", "model"); errSet == nil {
+				contentJSON = updated
+				contentChanged = true
+			}
+		}
+		if !contentChanged {
+			return true
+		}
+
+		start := content.Index
+		end := start + len(content.Raw)
+		if start < 0 || end < start || end > len(rawJSON) || !bytes.Equal(rawJSON[start:end], []byte(content.Raw)) {
+			validOffsets = false
+		}
+		edits = append(edits, antigravityContentEdit{
+			index:       contentIndex.Int(),
+			start:       start,
+			end:         end,
+			replacement: contentJSON,
+		})
+		return true
+	})
+	if len(edits) == 0 {
+		return rawJSON
+	}
+	if !validOffsets {
+		return applyAntigravityContentEditsWithSJSON(rawJSON, edits)
+	}
+
+	finalSize := len(rawJSON)
+	cursor := 0
+	for _, edit := range edits {
+		if edit.start < cursor {
+			return applyAntigravityContentEditsWithSJSON(rawJSON, edits)
+		}
+		finalSize += len(edit.replacement) - (edit.end - edit.start)
+		if finalSize < 0 {
+			return applyAntigravityContentEditsWithSJSON(rawJSON, edits)
+		}
+		cursor = edit.end
+	}
+	out := make([]byte, 0, finalSize)
+	cursor = 0
+	for _, edit := range edits {
+		out = append(out, rawJSON[cursor:edit.start]...)
+		out = append(out, edit.replacement...)
+		cursor = edit.end
+	}
+	return append(out, rawJSON[cursor:]...)
+}
+
+// applyAntigravityContentEditsWithSJSON preserves the legacy path semantics if
+// a GJSON result cannot be proven to point into the original request bytes.
+func applyAntigravityContentEditsWithSJSON(rawJSON []byte, edits []antigravityContentEdit) []byte {
+	out := rawJSON
+	for _, edit := range edits {
+		path := fmt.Sprintf("request.contents.%d", edit.index)
+		if updated, errSet := sjson.SetRawBytes(out, path, edit.replacement); errSet == nil {
+			out = updated
 		}
 	}
 	return out

--- a/internal/runtime/executor/antigravity_executor_execute.go
+++ b/internal/runtime/executor/antigravity_executor_execute.go
@@ -66,8 +66,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 		auth = updatedAuth
 		reporter.UpdateAccessTokenFingerprint(auth)
 	}
-	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, false)
-	translated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false)
+	originalTranslated, translated := helps.TranslateRequestPairWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, req.Payload, false)
 
 	translated, err = helps.ApplyThinkingWithSourcePayload(translated, req.Payload, originalPayloadSource, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {
@@ -290,8 +289,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 		auth = updatedAuth
 		reporter.UpdateAccessTokenFingerprint(auth)
 	}
-	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, true)
-	translated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, true)
+	originalTranslated, translated := helps.TranslateRequestPairWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, req.Payload, true)
 
 	translated, err = helps.ApplyThinkingWithSourcePayload(translated, req.Payload, originalPayloadSource, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {

--- a/internal/runtime/executor/antigravity_executor_request.go
+++ b/internal/runtime/executor/antigravity_executor_request.go
@@ -160,6 +160,35 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 // whole document silently mutated that history, so tools lost required argument fields and the
 // model imitated the corrupted examples on later turns.
 func sanitizeAntigravityRequestSchemas(payloadStr string, useAntigravitySchema bool) string {
+	payloadStr = sanitizeAntigravityToolSchemas(payloadStr, useAntigravitySchema)
+	return sanitizeAntigravityGenerationSchemas(payloadStr)
+}
+
+// sanitizeAntigravityToolSchemas applies the existing declaration rewrites to
+// a small document containing only request.tools, then replaces that subtree
+// once. This preserves rewrite order and bytes without copying the full request
+// for every declaration schema.
+func sanitizeAntigravityToolSchemas(payloadStr string, useAntigravitySchema bool) string {
+	tools := gjson.Get(payloadStr, "request.tools")
+	if !tools.IsArray() {
+		return payloadStr
+	}
+
+	toolDocument := `{"request":{"tools":` + tools.Raw + `}}`
+	toolDocument = sanitizeAntigravityToolSchemaDocument(toolDocument, useAntigravitySchema)
+	cleanedTools := gjson.Get(toolDocument, "request.tools")
+	if !cleanedTools.IsArray() || cleanedTools.Raw == tools.Raw {
+		return payloadStr
+	}
+	updated, errSet := sjson.SetRawBytes([]byte(payloadStr), "request.tools", []byte(cleanedTools.Raw))
+	if errSet != nil {
+		log.Debugf("antigravity: failed to write cleaned request.tools: %v", errSet)
+		return payloadStr
+	}
+	return string(updated)
+}
+
+func sanitizeAntigravityToolSchemaDocument(payloadStr string, useAntigravitySchema bool) string {
 	for _, base := range antigravityFunctionDeclarationPaths(payloadStr) {
 		oldPath := base + ".parametersJsonSchema"
 		if !gjson.Get(payloadStr, oldPath).Exists() {
@@ -177,13 +206,51 @@ func sanitizeAntigravityRequestSchemas(payloadStr string, useAntigravitySchema b
 	if useAntigravitySchema {
 		toolSchemaCleaner = util.CleanJSONSchemaForAntigravity
 	}
-	responseSchemaCleaner := util.CleanJSONSchemaForAntigravityResponse
-
 	cleanNestedToolSchema := func(schemaRaw string) string {
 		return cleanNestedSchema(toolSchemaCleaner, schemaRaw)
 	}
-	payloadStr = cleanAntigravitySchemasAtPaths(payloadStr, antigravityDeclarationSchemaPaths(payloadStr), cleanNestedToolSchema)
-	payloadStr = cleanAntigravitySchemasAtPaths(payloadStr, antigravityGenerationSchemaPaths(payloadStr), responseSchemaCleaner)
+	return cleanAntigravitySchemasAtPaths(
+		payloadStr,
+		antigravityDeclarationSchemaPaths(payloadStr),
+		cleanNestedToolSchema,
+	)
+}
+
+// sanitizeAntigravityGenerationSchemas batches every schema edit within one
+// generation config before replacing that config in the full request.
+func sanitizeAntigravityGenerationSchemas(payloadStr string) string {
+	for _, container := range antigravityGenerationConfigContainers {
+		generationConfig := gjson.Get(payloadStr, container)
+		if !generationConfig.IsObject() {
+			continue
+		}
+		cleanedConfig := generationConfig.Raw
+		for _, key := range antigravityGenerationSchemaKeys {
+			schema := gjson.Get(cleanedConfig, key)
+			if !schema.IsObject() {
+				continue
+			}
+			cleanedSchema := util.CleanJSONSchemaForAntigravityResponse(schema.Raw)
+			if cleanedSchema == schema.Raw {
+				continue
+			}
+			updated, errSet := sjson.SetRawBytes([]byte(cleanedConfig), key, []byte(cleanedSchema))
+			if errSet != nil {
+				log.Debugf("antigravity: failed to write cleaned schema at %s.%s: %v", container, key, errSet)
+				continue
+			}
+			cleanedConfig = string(updated)
+		}
+		if cleanedConfig == generationConfig.Raw {
+			continue
+		}
+		updated, errSet := sjson.SetRawBytes([]byte(payloadStr), container, []byte(cleanedConfig))
+		if errSet != nil {
+			log.Debugf("antigravity: failed to write cleaned %s: %v", container, errSet)
+			continue
+		}
+		payloadStr = string(updated)
+	}
 	return payloadStr
 }
 
@@ -193,7 +260,11 @@ func cleanAntigravitySchemasAtPaths(payloadStr string, schemaPaths []string, cle
 		if !schema.Exists() {
 			continue
 		}
-		updated, errSet := sjson.SetRawBytes([]byte(payloadStr), schemaPath, []byte(clean(schema.Raw)))
+		cleanedSchema := clean(schema.Raw)
+		if cleanedSchema == schema.Raw {
+			continue
+		}
+		updated, errSet := sjson.SetRawBytes([]byte(payloadStr), schemaPath, []byte(cleanedSchema))
 		if errSet != nil {
 			log.Debugf("antigravity: failed to write cleaned schema at %s: %v", schemaPath, errSet)
 			continue
@@ -451,18 +522,27 @@ func generateSessionID() string {
 }
 
 func generateStableSessionID(payload []byte) string {
-	contents := gjson.GetBytes(payload, "request.contents")
-	if contents.IsArray() {
-		for _, content := range contents.Array() {
-			if content.Get("role").String() == "user" {
-				text := content.Get("parts.0.text").String()
-				if text != "" {
-					h := sha256.Sum256([]byte(text))
-					n := int64(binary.BigEndian.Uint64(h[:8])) & 0x7FFFFFFFFFFFFFFF
-					return "-" + strconv.FormatInt(n, 10)
-				}
-			}
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
+	if !contents.IsArray() {
+		return generateSessionID()
+	}
+
+	stableID := ""
+	contents.ForEach(func(_, content gjson.Result) bool {
+		if content.Get("role").String() != "user" {
+			return true
 		}
+		text := content.Get("parts.0.text").String()
+		if text == "" {
+			return true
+		}
+		hash := sha256.Sum256([]byte(text))
+		value := int64(binary.BigEndian.Uint64(hash[:8])) & 0x7FFFFFFFFFFFFFFF
+		stableID = "-" + strconv.FormatInt(value, 10)
+		return false
+	})
+	if stableID != "" {
+		return stableID
 	}
 	return generateSessionID()
 }

--- a/internal/runtime/executor/antigravity_executor_stream.go
+++ b/internal/runtime/executor/antigravity_executor_stream.go
@@ -61,8 +61,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 		reporter.UpdateAccessTokenFingerprint(auth)
 	}
 
-	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, true)
-	translated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, true)
+	originalTranslated, translated := helps.TranslateRequestPairWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, req.Payload, true)
 
 	translated, err = helps.ApplyThinkingWithSourcePayload(translated, req.Payload, originalPayloadSource, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {

--- a/internal/runtime/executor/antigravity_preupstream_rewrite_differential_test.go
+++ b/internal/runtime/executor/antigravity_preupstream_rewrite_differential_test.go
@@ -1,0 +1,246 @@
+package executor
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	"github.com/tidwall/sjson"
+)
+
+func TestNormalizeAntigravityGeminiFunctionResponseRolesMatchesLegacy(t *testing.T) {
+	fixtures := [][]byte{
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"read","args":{}}},{"functionCall":{"id":"call-2","name":"write","args":{}}}]},{"role":"user","parts":[{"functionResponse":{"id":"call-2","name":"write","response":{"ok":2}}},{"functionResponse":{"id":"call-1","name":"read","response":{"ok":1}}}]}]}}`),
+		[]byte("{\r\n  \"request\" : {\r\n    \"contents\" : [\r\n      {\"role\":\"model\",\"parts\":[{\"functionCall\":{\"id\":\"a\",\"name\":\"one\"}},{\"functionCall\":{\"id\":\"b\",\"name\":\"two\"}}]},\r\n      {\"role\" : \"user\", \"parts\" : [ { \"functionResponse\" : {\"id\":\"a\",\"name\":\"one\"} }, { \"functionResponse\" : {\"id\":\"b\",\"name\":\"two\"} } ]}\r\n    ]\r\n  }\r\n}"),
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"a","name":"actual"}}]},{"parts":[{"functionResponse":{"id":"a","name":"unknown"}}]}]}}`),
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"a","name":"one"}}]},{"role":"user","role":"model","parts":[{"functionResponse":{"id":"a","name":"one"}}]}]}}`),
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"a","name":"one"}}]},{"role":"user","parts":[{"functionResponse":{"id":"a","name":"one"}}],"parts":[{"text":"duplicate"}]}]}}`),
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"a","name":"one"}}]},{"role":"user","parts":[{"functionResponse":{"id":"a","name":"one"}}]}],"contents":[{"role":"user","parts":[]}]}}`),
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"name":"one"}},{"functionCall":{"name":"one"}}]},{"role":" Model ","parts":[{"functionResponse":{"name":"one"}},{"functionResponse":{"name":"one"}}]}]}}`),
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"a","name":"one"}}]},{"role":"user","parts":[]},{"role":"user","parts":[{"functionResponse":{"id":"a","name":"one"}}]}]}}`),
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"a","name":"one"}}]},{"role":"user","parts":[{"functionResponse":{"id":"a","name":"one"}}]}]`),
+		[]byte(`{"prefix":broken,"request":{"contents":[{"role":"user","parts":[{"functionResponse":{"id":"a","name":"one"}}]}]}}`),
+	}
+
+	randomSource := rand.New(rand.NewSource(0xA617A5))
+	for range 1_000 {
+		fixtures = append(fixtures, randomAntigravityFunctionHistory(randomSource))
+	}
+
+	changed := 0
+	unchanged := 0
+	for index, fixture := range fixtures {
+		want := legacyNormalizeAntigravityGeminiFunctionResponseRoles(fixture)
+		got := normalizeAntigravityGeminiFunctionResponseRoles(fixture)
+		if !bytes.Equal(got, want) {
+			t.Fatalf("case %d differs: input_bytes=%d got_bytes=%d want_bytes=%d", index, len(fixture), len(got), len(want))
+		}
+		if bytes.Equal(fixture, want) {
+			unchanged++
+		} else {
+			changed++
+		}
+		if again := normalizeAntigravityGeminiFunctionResponseRoles(got); !bytes.Equal(again, got) {
+			t.Fatalf("case %d is not idempotent", index)
+		}
+	}
+	if changed == 0 || unchanged == 0 {
+		t.Fatalf("degenerate fixtures: changed=%d unchanged=%d", changed, unchanged)
+	}
+}
+
+func randomAntigravityFunctionHistory(randomSource *rand.Rand) []byte {
+	contents := make([]any, 0)
+	groupCount := 1 + randomSource.Intn(6)
+	for groupIndex := range groupCount {
+		partCount := 1 + randomSource.Intn(4)
+		calls := make([]any, 0, partCount)
+		responses := make([]any, 0, partCount)
+		for partIndex := range partCount {
+			id := fmt.Sprintf("call-%d-%d", groupIndex, partIndex)
+			if randomSource.Intn(5) == 0 {
+				id = ""
+			}
+			name := fmt.Sprintf("tool-%d", partIndex)
+			call := map[string]any{"name": name, "args": map[string]any{"value": partIndex}}
+			response := map[string]any{"name": name, "response": map[string]any{"value": partIndex}}
+			if id != "" {
+				call["id"] = id
+				response["id"] = id
+			}
+			if id != "" && randomSource.Intn(8) == 0 {
+				response["name"] = "unknown"
+			}
+			calls = append(calls, map[string]any{"functionCall": call})
+			responses = append(responses, map[string]any{"functionResponse": response})
+		}
+		contents = append(contents, map[string]any{"role": "model", "parts": calls})
+		if randomSource.Intn(10) == 0 {
+			contents = append(contents, map[string]any{"role": "user", "parts": []any{}})
+		}
+		permutation := randomSource.Perm(len(responses))
+		orderedResponses := make([]any, 0, len(responses))
+		for _, responseIndex := range permutation {
+			orderedResponses = append(orderedResponses, responses[responseIndex])
+		}
+		responseContent := map[string]any{"parts": orderedResponses}
+		switch randomSource.Intn(4) {
+		case 0:
+			responseContent["role"] = "model"
+		case 1:
+			responseContent["role"] = "user"
+		case 2:
+			responseContent["role"] = " Model "
+		}
+		if randomSource.Intn(12) == 0 {
+			orderedResponses = append(orderedResponses, map[string]any{"text": "mixed"})
+			responseContent["parts"] = orderedResponses
+		}
+		contents = append(contents, responseContent)
+	}
+	payload, errMarshal := json.Marshal(map[string]any{"request": map[string]any{"contents": contents}})
+	if errMarshal != nil {
+		panic(errMarshal)
+	}
+	return payload
+}
+
+func TestApplyAntigravityContentEditsWithSJSONFallback(t *testing.T) {
+	payload := []byte(`{"request":{"contents":[{"role":"user","parts":[{"functionResponse":{"id":"call-1","name":"read"}}]}]}}`)
+	replacement := []byte(`{"role":"model","parts":[{"functionResponse":{"id":"call-1","name":"read"}}]}`)
+	edits := []antigravityContentEdit{{
+		index:       0,
+		start:       -1,
+		end:         -1,
+		replacement: replacement,
+	}}
+	want, errSet := sjson.SetRawBytes(payload, "request.contents.0", replacement)
+	if errSet != nil {
+		t.Fatal(errSet)
+	}
+	got := applyAntigravityContentEditsWithSJSON(payload, edits)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("fallback differs: got=%s want=%s", got, want)
+	}
+}
+
+func TestAntigravityProvenanceScansMatchLegacyArraySemantics(t *testing.T) {
+	reservedID := util.GeminiClaudeToolUseID("native-call", "read", `{}`)
+	if reservedID == "" {
+		t.Fatal("failed to build reserved provenance ID")
+	}
+
+	fixtures := [][]byte{
+		[]byte(`{"request":{"contents":[{"parts":{"functionCall":{"id":"` + reservedID + `"}}}]}}`),
+		[]byte(`{"request":{"contents":[{"parts":[{"functionCall":{"id":"` + reservedID + `"}}]}]}}`),
+		[]byte(`{"request":{"contents":[{"parts":null}]}}`),
+		[]byte(`{"request":{"contents":[{}]}}`),
+		[]byte(`{"request":{"contents":[{"parts":"scalar"}]}}`),
+	}
+	for fixtureIndex, fixture := range fixtures {
+		wantCount := legacyAntigravityCountClaudeToolProvenanceIDs(fixture)
+		if gotCount := antigravityCountClaudeToolProvenanceIDs(fixture); gotCount != wantCount {
+			t.Errorf("case %d count = %d, want legacy %d", fixtureIndex, gotCount, wantCount)
+		}
+		wantFound := legacyAntigravityPayloadHasClaudeToolProvenanceID(fixture)
+		if gotFound := antigravityPayloadHasClaudeToolProvenanceID(fixture); gotFound != wantFound {
+			t.Errorf("case %d found = %t, want legacy %t", fixtureIndex, gotFound, wantFound)
+		}
+	}
+}
+
+func TestSanitizeAntigravityRequestSchemasMatchesLegacy(t *testing.T) {
+	fixtures := []string{
+		sanitizeTestPayload,
+		"{\r\n  \"request\" : {\r\n    \"contents\" : [{\"role\":\"user\",\"parts\":[{\"text\":\"keep formatting\"}]}],\r\n    \"tools\" : [{\"functionDeclarations\":[{\"name\":\"t\",\"parametersJsonSchema\":{\"type\":\"object\",\"title\":\"drop\",\"properties\":{\"x\":{\"type\":\"string\",\"minLength\":1}}}}]}]\r\n  }\r\n}",
+		`{"request":{"tools":[{"functionDeclarations":[{"name":"t","parameters":{"type":"object","$id":"drop"},"parametersJsonSchema":{"type":"object","properties":{"x":{"type":"string"}}}}]}]}}`,
+		`{"request":{"tools":[{"function_declarations":[{"name":"t","parameters_json_schema":{"type":"object","title":"drop","properties":{"x":{"type":"string"}}},"responseJsonSchema":{"type":"object","$comment":"drop"}}]}]}}`,
+		`{"request":{"generationConfig":{"responseSchema":{"type":"object","$id":"drop-a"},"response_schema":{"type":"object","$id":"drop-b"}},"generation_config":{"responseJsonSchema":{"type":"object","$comment":"drop-c"}}}}`,
+		`{"request":{"tools":[{"functionDeclarations":[{"name":"t","parameters":{"type":"object","title":"drop"}}]}],"tools":[{"functionDeclarations":[{"name":"duplicate","parameters":{"type":"object","title":"drop-too"}}]}]}}`,
+		`{"request":{"generationConfig":{"responseSchema":{"type":"object","$id":"first"},"responseSchema":{"type":"object","$id":"second"}}}}`,
+		`{"request":{"tools":[{"functionDeclarations":[{"name":"t","parameters":{"type":"object","title":"drop"}}]}]`,
+		`{"prefix":broken,"request":{"tools":[{"functionDeclarations":[{"name":"t","parameters":{"type":"object","title":"drop"}}]}]}}`,
+	}
+
+	randomSource := rand.New(rand.NewSource(0x5C4E6A))
+	for range 600 {
+		fixtures = append(fixtures, randomAntigravitySchemaRequest(randomSource))
+	}
+
+	changed := 0
+	for fixtureIndex, fixture := range fixtures {
+		for _, useAntigravitySchema := range []bool{false, true} {
+			want := legacySanitizeAntigravityRequestSchemas(fixture, useAntigravitySchema)
+			got := sanitizeAntigravityRequestSchemas(fixture, useAntigravitySchema)
+			if got != want {
+				t.Fatalf("case %d antigravity=%t differs: input_bytes=%d got_bytes=%d want_bytes=%d", fixtureIndex, useAntigravitySchema, len(fixture), len(got), len(want))
+			}
+			if got != fixture {
+				changed++
+			}
+		}
+	}
+	if changed == 0 {
+		t.Fatal("degenerate schema fixtures: no rewrite occurred")
+	}
+}
+
+func randomAntigravitySchemaRequest(randomSource *rand.Rand) string {
+	declarationContainer := "functionDeclarations"
+	if randomSource.Intn(2) == 0 {
+		declarationContainer = "function_declarations"
+	}
+	declarationCount := 1 + randomSource.Intn(4)
+	declarations := make([]any, 0, declarationCount)
+	for declarationIndex := range declarationCount {
+		schema := map[string]any{
+			"type":  "object",
+			"title": fmt.Sprintf("drop-%d", declarationIndex),
+			"properties": map[string]any{
+				"value": map[string]any{"type": "string", "minLength": 1 + randomSource.Intn(4)},
+			},
+		}
+		if randomSource.Intn(3) == 0 {
+			schema["required"] = []string{"value"}
+		}
+		key := antigravityDeclarationSchemaKeys[randomSource.Intn(len(antigravityDeclarationSchemaKeys))]
+		declarations = append(declarations, map[string]any{
+			"name": fmt.Sprintf("tool-%d", declarationIndex),
+			key:    schema,
+		})
+	}
+	request := map[string]any{
+		"contents": []any{map[string]any{
+			"role": "model",
+			"parts": []any{map[string]any{"functionCall": map[string]any{
+				"name": "history",
+				"args": map[string]any{"title": "keep", "format": "keep"},
+			}}},
+		}},
+		"tools": []any{map[string]any{declarationContainer: declarations}},
+	}
+	if randomSource.Intn(2) == 0 {
+		generationContainer := "generationConfig"
+		if randomSource.Intn(2) == 0 {
+			generationContainer = "generation_config"
+		}
+		generationKey := antigravityGenerationSchemaKeys[randomSource.Intn(len(antigravityGenerationSchemaKeys))]
+		request[generationContainer] = map[string]any{
+			generationKey: map[string]any{
+				"type": "object",
+				"$id":  "drop",
+				"properties": map[string]any{
+					"result": map[string]any{"type": "string"},
+				},
+			},
+		}
+	}
+	payload, errMarshal := json.Marshal(map[string]any{"request": request})
+	if errMarshal != nil {
+		panic(errMarshal)
+	}
+	return string(payload)
+}

--- a/internal/runtime/executor/antigravity_preupstream_rewrite_legacy_oracle_test.go
+++ b/internal/runtime/executor/antigravity_preupstream_rewrite_legacy_oracle_test.go
@@ -1,0 +1,242 @@
+package executor
+
+// This file freezes the pre-batching Antigravity function-response and schema
+// rewrites. Differential tests use it as an independent byte-for-byte oracle.
+// Do not refactor these helpers to call the production implementations.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+func legacyAntigravityCountClaudeToolProvenanceIDs(payload []byte) int {
+	count := 0
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
+	if !contents.IsArray() {
+		return 0
+	}
+	for _, content := range contents.Array() {
+		for _, part := range content.Get("parts").Array() {
+			for _, path := range []string{"functionCall.id", "functionResponse.id"} {
+				if util.IsGeminiClaudeToolUseID(part.Get(path).String()) {
+					count++
+				}
+			}
+		}
+	}
+	return count
+}
+
+func legacyAntigravityPayloadHasClaudeToolProvenanceID(payload []byte) bool {
+	contents := util.GetGJSONBytesNoCopy(payload, "request.contents")
+	if !contents.IsArray() {
+		return false
+	}
+	for _, content := range contents.Array() {
+		for _, part := range content.Get("parts").Array() {
+			for _, path := range []string{"functionCall.id", "functionResponse.id"} {
+				if util.IsGeminiClaudeToolUseID(part.Get(path).String()) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func legacyNormalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byte {
+	rawJSON = legacyRepairAntigravityGeminiFunctionResponseNames(rawJSON)
+	contents := util.GetGJSONBytesNoCopy(rawJSON, "request.contents")
+	if !contents.IsArray() {
+		return rawJSON
+	}
+	type functionRef struct {
+		id   string
+		name string
+	}
+	out := rawJSON
+	var pending []functionRef
+	for contentIndex, content := range contents.Array() {
+		parts := content.Get("parts")
+		if !parts.IsArray() || len(parts.Array()) == 0 {
+			pending = nil
+			continue
+		}
+		var calls, responses []functionRef
+		var responseParts []json.RawMessage
+		hasOtherPart := false
+		parts.ForEach(func(_, part gjson.Result) bool {
+			switch {
+			case part.Get("functionCall").Exists():
+				calls = append(calls, functionRef{id: part.Get("functionCall.id").String(), name: part.Get("functionCall.name").String()})
+			case part.Get("functionResponse").Exists():
+				responses = append(responses, functionRef{id: part.Get("functionResponse.id").String(), name: part.Get("functionResponse.name").String()})
+				responseParts = append(responseParts, json.RawMessage(part.Raw))
+			default:
+				hasOtherPart = true
+			}
+			return true
+		})
+		if len(calls) > 0 && len(responses) == 0 {
+			pending = calls
+			continue
+		}
+		if len(responses) == 0 {
+			if hasOtherPart {
+				pending = nil
+			}
+			continue
+		}
+		if hasOtherPart || len(calls) > 0 {
+			pending = nil
+			continue
+		}
+
+		if len(pending) == len(responses) {
+			ordered := make([]json.RawMessage, 0, len(responseParts))
+			used := make([]bool, len(responses))
+			for _, call := range pending {
+				matched := -1
+				for responseIndex, response := range responses {
+					if used[responseIndex] {
+						continue
+					}
+					if (call.id != "" && response.id == call.id) || (call.id == "" && call.name != "" && response.name == call.name) {
+						matched = responseIndex
+						break
+					}
+				}
+				if matched < 0 {
+					ordered = nil
+					break
+				}
+				used[matched] = true
+				ordered = append(ordered, responseParts[matched])
+			}
+			if len(ordered) == len(responseParts) {
+				if encoded, errMarshal := json.Marshal(ordered); errMarshal == nil {
+					if updated, errSet := sjson.SetRawBytes(out, fmt.Sprintf("request.contents.%d.parts", contentIndex), encoded); errSet == nil {
+						out = updated
+					}
+				}
+			}
+		}
+		pending = nil
+		if content.Get("role").String() != "model" {
+			if updated, errSet := sjson.SetBytes(out, fmt.Sprintf("request.contents.%d.role", contentIndex), "model"); errSet == nil {
+				out = updated
+			}
+		}
+	}
+	return out
+}
+
+func legacyRepairAntigravityGeminiFunctionResponseNames(rawJSON []byte) []byte {
+	contents := util.GetGJSONBytesNoCopy(rawJSON, "request.contents")
+	if !contents.IsArray() {
+		return rawJSON
+	}
+	callIDToName := make(map[string]string)
+	contents.ForEach(func(_, content gjson.Result) bool {
+		parts := content.Get("parts")
+		if !parts.IsArray() {
+			return true
+		}
+		parts.ForEach(func(_, part gjson.Result) bool {
+			fc := part.Get("functionCall")
+			if fc.Exists() {
+				id := strings.TrimSpace(fc.Get("id").String())
+				name := strings.TrimSpace(fc.Get("name").String())
+				if id != "" && name != "" && name != "unknown" {
+					callIDToName[id] = name
+				}
+			}
+			return true
+		})
+		return true
+	})
+	if len(callIDToName) == 0 {
+		return rawJSON
+	}
+
+	out := rawJSON
+	contents.ForEach(func(contentIdx, content gjson.Result) bool {
+		parts := content.Get("parts")
+		if !parts.IsArray() {
+			return true
+		}
+		parts.ForEach(func(partIdx, part gjson.Result) bool {
+			fr := part.Get("functionResponse")
+			if fr.Exists() {
+				id := strings.TrimSpace(fr.Get("id").String())
+				name := strings.TrimSpace(fr.Get("name").String())
+				if id != "" && (name == "" || name == "unknown") {
+					if realName, ok := callIDToName[id]; ok {
+						path := fmt.Sprintf("request.contents.%d.parts.%d.functionResponse.name", contentIdx.Int(), partIdx.Int())
+						if updated, errSet := sjson.SetBytes(out, path, realName); errSet == nil {
+							out = updated
+						}
+					}
+				}
+			}
+			return true
+		})
+		return true
+	})
+	return out
+}
+
+func legacySanitizeAntigravityRequestSchemas(payloadStr string, useAntigravitySchema bool) string {
+	for _, base := range antigravityFunctionDeclarationPaths(payloadStr) {
+		oldPath := base + ".parametersJsonSchema"
+		if !gjson.Get(payloadStr, oldPath).Exists() {
+			continue
+		}
+		renamed, errRename := util.RenameKey(payloadStr, oldPath, base+".parameters")
+		if errRename != nil {
+			log.Debugf("antigravity: failed to rename %s: %v", oldPath, errRename)
+			continue
+		}
+		payloadStr = renamed
+	}
+
+	toolSchemaCleaner := util.CleanJSONSchemaForGemini
+	if useAntigravitySchema {
+		toolSchemaCleaner = util.CleanJSONSchemaForAntigravity
+	}
+	responseSchemaCleaner := util.CleanJSONSchemaForAntigravityResponse
+	cleanNestedToolSchema := func(schemaRaw string) string {
+		return cleanNestedSchema(toolSchemaCleaner, schemaRaw)
+	}
+	payloadStr = legacyCleanAntigravitySchemasAtPaths(
+		payloadStr,
+		antigravityDeclarationSchemaPaths(payloadStr),
+		cleanNestedToolSchema,
+	)
+	return legacyCleanAntigravitySchemasAtPaths(
+		payloadStr,
+		antigravityGenerationSchemaPaths(payloadStr),
+		responseSchemaCleaner,
+	)
+}
+
+func legacyCleanAntigravitySchemasAtPaths(payloadStr string, schemaPaths []string, clean func(string) string) string {
+	for _, schemaPath := range schemaPaths {
+		schema := gjson.Get(payloadStr, schemaPath)
+		if !schema.Exists() {
+			continue
+		}
+		updated, errSet := sjson.SetRawBytes([]byte(payloadStr), schemaPath, []byte(clean(schema.Raw)))
+		if errSet != nil {
+			continue
+		}
+		payloadStr = string(updated)
+	}
+	return payloadStr
+}

--- a/internal/runtime/executor/antigravity_reasoning_replay.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay.go
@@ -44,15 +44,26 @@ func antigravityCountClaudeToolProvenanceIDs(payload []byte) int {
 	if !contents.IsArray() {
 		return 0
 	}
-	for _, content := range contents.Array() {
-		for _, part := range content.Get("parts").Array() {
+	contents.ForEach(func(_, content gjson.Result) bool {
+		parts := content.Get("parts")
+		countPart := func(part gjson.Result) {
 			for _, path := range []string{"functionCall.id", "functionResponse.id"} {
 				if util.IsGeminiClaudeToolUseID(part.Get(path).String()) {
 					count++
 				}
 			}
 		}
-	}
+		if parts.IsArray() {
+			parts.ForEach(func(_, part gjson.Result) bool {
+				countPart(part)
+				return true
+			})
+		} else if parts.Type != gjson.Null {
+			// Result.Array returns a non-array JSON value as one item.
+			countPart(parts)
+		}
+		return true
+	})
 	return count
 }
 
@@ -1175,16 +1186,29 @@ func antigravityPayloadHasClaudeToolProvenanceID(payload []byte) bool {
 	if !contents.IsArray() {
 		return false
 	}
-	for _, content := range contents.Array() {
-		for _, part := range content.Get("parts").Array() {
+	found := false
+	contents.ForEach(func(_, content gjson.Result) bool {
+		parts := content.Get("parts")
+		hasReservedID := func(part gjson.Result) bool {
 			for _, path := range []string{"functionCall.id", "functionResponse.id"} {
 				if util.IsGeminiClaudeToolUseID(part.Get(path).String()) {
 					return true
 				}
 			}
+			return false
 		}
-	}
-	return false
+		if parts.IsArray() {
+			parts.ForEach(func(_, part gjson.Result) bool {
+				found = hasReservedID(part)
+				return !found
+			})
+		} else if parts.Type != gjson.Null {
+			// Result.Array returns a non-array JSON value as one item.
+			found = hasReservedID(parts)
+		}
+		return !found
+	})
+	return found
 }
 
 // antigravitySyntheticToolCallID derives a deterministic neutral call ID for a
@@ -1259,27 +1283,32 @@ func antigravityRepairUnsignedFirstFunctionCalls(payload []byte) []byte {
 		return payload
 	}
 	out := payload
-	for ci, content := range contents.Array() {
+	contents.ForEach(func(contentIndex, content gjson.Result) bool {
 		if !strings.EqualFold(strings.TrimSpace(content.Get("role").String()), "model") {
-			continue
+			return true
 		}
 		parts := content.Get("parts")
 		if !parts.IsArray() {
-			continue
+			return true
 		}
-		for pi, part := range parts.Array() {
+		parts.ForEach(func(partIndex, part gjson.Result) bool {
 			if !part.Get("functionCall").Exists() {
-				continue
+				return true
 			}
 			if antigravityNativePartThoughtSignature(part) == "" {
-				out, _ = sjson.SetBytes(out, fmt.Sprintf("request.contents.%d.parts.%d.thoughtSignature", ci, pi),
-					internalsignature.GeminiSkipThoughtSignatureValidator)
+				path := fmt.Sprintf(
+					"request.contents.%d.parts.%d.thoughtSignature",
+					contentIndex.Int(),
+					partIndex.Int(),
+				)
+				out, _ = sjson.SetBytes(out, path, internalsignature.GeminiSkipThoughtSignatureValidator)
 			}
 			// Only the first function call of a turn needs a signature; siblings stay
 			// unsigned to preserve the native parallel-call shape.
-			break
-		}
-	}
+			return false
+		})
+		return true
+	})
 	return out
 }
 

--- a/internal/runtime/executor/helps/codex_multi_agent_v2.go
+++ b/internal/runtime/executor/helps/codex_multi_agent_v2.go
@@ -35,6 +35,35 @@ func TranslateRequestWithCodexMultiAgentV2(ctx context.Context, headers http.Hea
 	return multiagentv2.TranslateRequestWithCodexMultiAgentV2(ctx, headers, cfg, from, to, model, payload, stream)
 }
 
+// TranslateRequestPairWithCodexMultiAgentV2 translates the untouched baseline
+// payload and the working payload that later stages mutate in place. Executors
+// normally assign the original payload to the request before translating, so both
+// translations would rescan the same bytes and produce the same result. Request
+// translation is deterministic and never aliases its input, so that case is
+// translated once and duplicated, which removes a full extra pass over payloads
+// that can reach tens of megabytes.
+func TranslateRequestPairWithCodexMultiAgentV2(ctx context.Context, headers http.Header, cfg *config.Config, from, to sdktranslator.Format, model string, originalPayload, requestPayload []byte, stream bool) (original, working []byte) {
+	original = TranslateRequestWithCodexMultiAgentV2(ctx, headers, cfg, from, to, model, originalPayload, stream)
+	if sameByteSlice(originalPayload, requestPayload) {
+		// The caller mutates the working copy, so it must not share the baseline array.
+		return original, append([]byte(nil), original...)
+	}
+	return original, TranslateRequestWithCodexMultiAgentV2(ctx, headers, cfg, from, to, model, requestPayload, stream)
+}
+
+// sameByteSlice reports whether both slices describe the same bytes of the same
+// backing array. It compares identity rather than content so the check stays
+// constant time on large payloads.
+func sameByteSlice(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) == 0 {
+		return true
+	}
+	return &a[0] == &b[0]
+}
+
 // TranslateRequestWithAPIKeyModelCompatibility applies compatibility-aware
 // request translators when a configured API-key model enables compatibility mode.
 func TranslateRequestWithAPIKeyModelCompatibility(ctx context.Context, headers http.Header, cfg *config.Config, from, to sdktranslator.Format, model string, payload []byte, stream, isCompat bool) []byte {

--- a/internal/runtime/executor/helps/codex_multi_agent_v2.go
+++ b/internal/runtime/executor/helps/codex_multi_agent_v2.go
@@ -38,13 +38,14 @@ func TranslateRequestWithCodexMultiAgentV2(ctx context.Context, headers http.Hea
 // TranslateRequestPairWithCodexMultiAgentV2 translates the untouched baseline
 // payload and the working payload that later stages mutate in place. Executors
 // normally assign the original payload to the request before translating, so both
-// translations would rescan the same bytes and produce the same result. Request
-// translation is deterministic and never aliases its input, so that case is
-// translated once and duplicated, which removes a full extra pass over payloads
-// that can reach tens of megabytes.
+// translations would rescan the same bytes and produce the same result. Built-in
+// request translation is deterministic, so that case is translated once and
+// duplicated when no plugin hooks are installed. Hooks retain two invocations
+// because they may have request-scoped output or side effects. This removes a
+// full extra pass over payloads that can reach tens of megabytes.
 func TranslateRequestPairWithCodexMultiAgentV2(ctx context.Context, headers http.Header, cfg *config.Config, from, to sdktranslator.Format, model string, originalPayload, requestPayload []byte, stream bool) (original, working []byte) {
 	original = TranslateRequestWithCodexMultiAgentV2(ctx, headers, cfg, from, to, model, originalPayload, stream)
-	if sameByteSlice(originalPayload, requestPayload) {
+	if sameByteSlice(originalPayload, requestPayload) && !sdktranslator.HasPluginHooks() {
 		// The caller mutates the working copy, so it must not share the baseline array.
 		return original, append([]byte(nil), original...)
 	}

--- a/internal/runtime/executor/helps/codex_multi_agent_v2_test.go
+++ b/internal/runtime/executor/helps/codex_multi_agent_v2_test.go
@@ -1,0 +1,125 @@
+package helps
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func geminiToolHistoryPayload(turns int) []byte {
+	contents := []string{`{"role":"user","parts":[{"text":"start"}]}`}
+	for i := 0; i < turns; i++ {
+		contents = append(contents,
+			fmt.Sprintf(`{"role":"user","parts":[{"text":"ask %d"}]}`, i),
+			fmt.Sprintf(`{"role":"model","parts":[{"text":"think %d"},{"thoughtSignature":"sig-%d","functionCall":{"id":"c%d","name":"read_file","args":{"path":"a%d.go"}}}]}`, i, i, i, i),
+			fmt.Sprintf(`{"role":"user","parts":[{"functionResponse":{"id":"c%d","name":"read_file","response":{"content":"data %d"}}}]}`, i, i),
+			fmt.Sprintf(`{"role":"model","parts":[{"text":"answer %d"}]}`, i))
+	}
+	return []byte(fmt.Sprintf(
+		`{"contents":[%s],"tools":[{"functionDeclarations":[{"name":"read_file","description":"read a file","parameters":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}]}],"generationConfig":{"temperature":1}}`,
+		strings.Join(contents, ",")))
+}
+
+// TestTranslateRequestPairMatchesSeparateTranslations pins the reuse fast path to
+// the behavior of translating both payloads independently.
+func TestTranslateRequestPairMatchesSeparateTranslations(t *testing.T) {
+	from := sdktranslator.FormatGemini
+	to := sdktranslator.FromString("antigravity")
+	cfg := &config.Config{}
+	const model = "gemini-3.6-flash-high"
+
+	for _, turns := range []int{0, 1, 5, 20} {
+		payload := geminiToolHistoryPayload(turns)
+		// Same bytes in a different backing array forces the translate-twice branch.
+		detached := append([]byte(nil), payload...)
+
+		want := TranslateRequestWithCodexMultiAgentV2(context.Background(), http.Header{}, cfg, from, to, model, payload, true)
+
+		reuseBase, reuseWork := TranslateRequestPairWithCodexMultiAgentV2(
+			context.Background(), http.Header{}, cfg, from, to, model, payload, payload, true)
+		twiceBase, twiceWork := TranslateRequestPairWithCodexMultiAgentV2(
+			context.Background(), http.Header{}, cfg, from, to, model, payload, detached, true)
+
+		for name, got := range map[string][]byte{
+			"reuse baseline": reuseBase,
+			"reuse working":  reuseWork,
+			"twice baseline": twiceBase,
+			"twice working":  twiceWork,
+		} {
+			if !bytes.Equal(want, got) {
+				t.Fatalf("turns=%d: %s translation differs from a standalone translation", turns, name)
+			}
+		}
+
+		if len(reuseBase) > 0 && &reuseBase[0] == &reuseWork[0] {
+			t.Fatalf("turns=%d: working copy aliases the baseline; later in-place edits would corrupt it", turns)
+		}
+
+		// The caller mutates the working copy, so the baseline must stay intact.
+		baselineBefore := append([]byte(nil), reuseBase...)
+		reuseWork[0] = 'X'
+		if !bytes.Equal(baselineBefore, reuseBase) {
+			t.Fatalf("turns=%d: mutating the working copy changed the baseline", turns)
+		}
+	}
+}
+
+// TestTranslateRequestPairTranslatesDistinctPayloads guards the case where the
+// executor really does hand over two different requests.
+func TestTranslateRequestPairTranslatesDistinctPayloads(t *testing.T) {
+	from := sdktranslator.FormatGemini
+	to := sdktranslator.FromString("antigravity")
+	cfg := &config.Config{}
+	const model = "gemini-3.6-flash-high"
+
+	original := geminiToolHistoryPayload(2)
+	request := geminiToolHistoryPayload(4)
+
+	base, work := TranslateRequestPairWithCodexMultiAgentV2(
+		context.Background(), http.Header{}, cfg, from, to, model, original, request, true)
+
+	wantBase := TranslateRequestWithCodexMultiAgentV2(context.Background(), http.Header{}, cfg, from, to, model, original, true)
+	wantWork := TranslateRequestWithCodexMultiAgentV2(context.Background(), http.Header{}, cfg, from, to, model, request, true)
+
+	if !bytes.Equal(wantBase, base) {
+		t.Fatal("baseline translation differs for distinct payloads")
+	}
+	if !bytes.Equal(wantWork, work) {
+		t.Fatal("working translation differs for distinct payloads")
+	}
+	if bytes.Equal(base, work) {
+		t.Fatal("distinct payloads produced identical translations; the reuse path was taken by mistake")
+	}
+}
+
+func TestSameByteSlice(t *testing.T) {
+	buf := []byte("payload")
+	cases := []struct {
+		name string
+		a, b []byte
+		want bool
+	}{
+		{"identical slice", buf, buf, true},
+		{"same array same length", buf[:3], buf[:3], true},
+		{"equal bytes different array", buf, append([]byte(nil), buf...), false},
+		{"different length", buf, buf[:3], false},
+		{"both nil", nil, nil, true},
+		{"nil and empty", nil, []byte{}, true},
+		{"nil and non-empty", nil, buf, false},
+		{"offset alias", buf, buf[1:], false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sameByteSlice(tc.a, tc.b); got != tc.want {
+				t.Fatalf("sameByteSlice() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/helps/codex_multi_agent_v2_test.go
+++ b/internal/runtime/executor/helps/codex_multi_agent_v2_test.go
@@ -11,7 +11,35 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
+
+type pairRequestPluginHooks struct {
+	calls int64
+}
+
+func (h *pairRequestPluginHooks) NormalizeRequest(_ context.Context, _, _ sdktranslator.Format, _ string, body []byte, _ bool) []byte {
+	h.calls++
+	updated, _ := sjson.SetBytes(body, "plugin_call", h.calls)
+	return updated
+}
+
+func (*pairRequestPluginHooks) TranslateRequest(context.Context, sdktranslator.Format, sdktranslator.Format, string, []byte, bool) ([]byte, bool) {
+	return nil, false
+}
+
+func (*pairRequestPluginHooks) NormalizeResponseBefore(context.Context, sdktranslator.Format, sdktranslator.Format, string, []byte, []byte, []byte, bool) []byte {
+	return nil
+}
+
+func (*pairRequestPluginHooks) TranslateResponse(context.Context, sdktranslator.Format, sdktranslator.Format, string, []byte, []byte, []byte, bool) ([]byte, bool) {
+	return nil, false
+}
+
+func (*pairRequestPluginHooks) NormalizeResponseAfter(context.Context, sdktranslator.Format, sdktranslator.Format, string, []byte, []byte, []byte, bool) []byte {
+	return nil
+}
 
 func geminiToolHistoryPayload(turns int) []byte {
 	contents := []string{`{"role":"user","parts":[{"text":"start"}]}`}
@@ -96,6 +124,35 @@ func TestTranslateRequestPairTranslatesDistinctPayloads(t *testing.T) {
 	}
 	if bytes.Equal(base, work) {
 		t.Fatal("distinct payloads produced identical translations; the reuse path was taken by mistake")
+	}
+}
+
+func TestTranslateRequestPairPreservesPluginHookInvocations(t *testing.T) {
+	hooks := &pairRequestPluginHooks{}
+	sdktranslator.SetPluginHooks(hooks)
+	t.Cleanup(func() { sdktranslator.SetPluginHooks(nil) })
+
+	payload := geminiToolHistoryPayload(1)
+	base, work := TranslateRequestPairWithCodexMultiAgentV2(
+		context.Background(),
+		http.Header{},
+		&config.Config{},
+		sdktranslator.FormatGemini,
+		sdktranslator.FromString("antigravity"),
+		"gemini-3.6-flash-high",
+		payload,
+		payload,
+		true,
+	)
+
+	if hooks.calls != 2 {
+		t.Fatalf("plugin hook calls = %d, want 2", hooks.calls)
+	}
+	if got := gjson.GetBytes(base, "plugin_call").Int(); got != 1 {
+		t.Fatalf("baseline plugin_call = %d, want 1", got)
+	}
+	if got := gjson.GetBytes(work, "plugin_call").Int(); got != 2 {
+		t.Fatalf("working plugin_call = %d, want 2", got)
 	}
 }
 

--- a/internal/signature/gemini_validation.go
+++ b/internal/signature/gemini_validation.go
@@ -290,25 +290,31 @@ func ValidateGeminiFunctionCallPairing(inputRawJSON []byte) error {
 	}
 
 	var pending []geminiFunctionCallRef
-	contentResults := contents.Array()
-	for i := 0; i < len(contentResults); i++ {
-		parts := contentResults[i].Get("parts")
+	var validationErr error
+	contents.ForEach(func(contentIndex, content gjson.Result) bool {
+		i := int(contentIndex.Int())
+		parts := content.Get("parts")
 		if !parts.IsArray() {
 			if len(pending) > 0 {
-				return fmt.Errorf("%s[%d]: content appears before %d pending functionResponse part(s)", contentsPath, i, len(pending))
+				validationErr = fmt.Errorf(
+					"%s[%d]: content appears before %d pending functionResponse part(s)",
+					contentsPath,
+					i,
+					len(pending),
+				)
 			}
-			continue
+			return validationErr == nil
 		}
 
 		var calls []geminiFunctionCallRef
 		var responses []geminiFunctionResponseRef
-		partResults := parts.Array()
-		for j := 0; j < len(partResults); j++ {
-			part := partResults[j]
+		parts.ForEach(func(partIndex, part gjson.Result) bool {
+			j := int(partIndex.Int())
 			partPath := fmt.Sprintf("%s[%d].parts[%d]", contentsPath, i, j)
 			if call := part.Get("functionCall"); call.Exists() {
 				if call.Get("name").String() == "" {
-					return fmt.Errorf("%s: missing functionCall.name", partPath)
+					validationErr = fmt.Errorf("%s: missing functionCall.name", partPath)
+					return false
 				}
 				calls = append(calls, geminiFunctionCallRef{
 					id:   call.Get("id").String(),
@@ -322,58 +328,91 @@ func ValidateGeminiFunctionCallPairing(inputRawJSON []byte) error {
 					path: partPath,
 				})
 			}
+			return true
+		})
+		if validationErr != nil {
+			return false
 		}
 
-		if len(calls) > 0 && len(responses) > 0 {
-			return fmt.Errorf("%s[%d]: functionCall and functionResponse parts must not be interleaved in the same content", contentsPath, i)
-		}
-
-		if len(calls) > 0 {
-			if len(pending) > 0 {
-				return fmt.Errorf("%s[%d]: functionCall appears before %d pending functionResponse part(s)", contentsPath, i, len(pending))
-			}
+		switch {
+		case len(calls) > 0 && len(responses) > 0:
+			validationErr = fmt.Errorf(
+				"%s[%d]: functionCall and functionResponse parts must not be interleaved in the same content",
+				contentsPath,
+				i,
+			)
+		case len(calls) > 0 && len(pending) > 0:
+			validationErr = fmt.Errorf(
+				"%s[%d]: functionCall appears before %d pending functionResponse part(s)",
+				contentsPath,
+				i,
+				len(pending),
+			)
+		case len(calls) > 0:
 			pending = calls
-			continue
+			return true
+		case len(responses) == 0 && len(pending) > 0:
+			validationErr = fmt.Errorf(
+				"%s[%d]: content appears before %d pending functionResponse part(s)",
+				contentsPath,
+				i,
+				len(pending),
+			)
+		case len(responses) == 0:
+			return true
+		case len(pending) == 0:
+			validationErr = fmt.Errorf("%s[%d]: functionResponse without preceding functionCall", contentsPath, i)
+		case len(responses) != len(pending):
+			validationErr = fmt.Errorf(
+				"%s[%d]: functionResponse count %d does not match pending functionCall count %d",
+				contentsPath,
+				i,
+				len(responses),
+				len(pending),
+			)
+		}
+		if validationErr != nil {
+			return false
 		}
 
-		if len(responses) == 0 {
-			if len(pending) > 0 {
-				return fmt.Errorf("%s[%d]: content appears before %d pending functionResponse part(s)", contentsPath, i, len(pending))
-			}
-			continue
-		}
-		if len(pending) == 0 {
-			return fmt.Errorf("%s[%d]: functionResponse without preceding functionCall", contentsPath, i)
-		}
-		if len(responses) != len(pending) {
-			return fmt.Errorf("%s[%d]: functionResponse count %d does not match pending functionCall count %d", contentsPath, i, len(responses), len(pending))
-		}
-
-		for j := 0; j < len(responses); j++ {
-			partPath := responses[j].path
-			response := responses[j].part.Get("functionResponse")
-			call := pending[j]
+		for responseIndex, responseRef := range responses {
+			partPath := responseRef.path
+			response := responseRef.part.Get("functionResponse")
+			call := pending[responseIndex]
 			responseID := response.Get("id").String()
 			responseName := response.Get("name").String()
 
-			if call.id != "" && responseID == "" {
-				return fmt.Errorf("%s: missing functionResponse.id for %s", partPath, call.path)
+			switch {
+			case call.id != "" && responseID == "":
+				validationErr = fmt.Errorf("%s: missing functionResponse.id for %s", partPath, call.path)
+			case call.id != "" && responseID != call.id:
+				validationErr = fmt.Errorf(
+					"%s: functionResponse.id %q does not match functionCall.id %q at %s",
+					partPath,
+					responseID,
+					call.id,
+					call.path,
+				)
+			case responseName == "":
+				validationErr = fmt.Errorf("%s: missing functionResponse.name", partPath)
+			case call.name != "" && responseName != call.name:
+				validationErr = fmt.Errorf(
+					"%s: functionResponse.name %q does not match functionCall.name %q at %s",
+					partPath,
+					responseName,
+					call.name,
+					call.path,
+				)
 			}
-			if call.id != "" && responseID != call.id {
-				return fmt.Errorf("%s: functionResponse.id %q does not match functionCall.id %q at %s", partPath, responseID, call.id, call.path)
-			}
-			if responseName == "" {
-				return fmt.Errorf("%s: missing functionResponse.name", partPath)
-			}
-			if call.name != "" && responseName != call.name {
-				return fmt.Errorf("%s: functionResponse.name %q does not match functionCall.name %q at %s", partPath, responseName, call.name, call.path)
+			if validationErr != nil {
+				return false
 			}
 		}
 
 		pending = nil
-	}
-
-	return nil
+		return true
+	})
+	return validationErr
 }
 
 func decodeGeminiThoughtSignature(sig string) ([]byte, error) {

--- a/sdk/translator/registry.go
+++ b/sdk/translator/registry.go
@@ -52,6 +52,13 @@ func (r *Registry) SetPluginHooks(hooks PluginHooks) {
 	r.hooks = hooks
 }
 
+// HasPluginHooks reports whether request or response translation hooks are installed.
+func (r *Registry) HasPluginHooks() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.hooks != nil
+}
+
 // TranslateRequest converts a payload between schemas, returning the original payload
 // if no translator is registered. When falling back to the original payload, the
 // "model" field is still updated to match the resolved model name so that
@@ -245,6 +252,11 @@ func Register(from, to Format, request RequestTransform, response ResponseTransf
 // SetPluginHooks stores plugin hooks on the default registry.
 func SetPluginHooks(hooks PluginHooks) {
 	defaultRegistry.SetPluginHooks(hooks)
+}
+
+// HasPluginHooks reports whether hooks are installed on the default registry.
+func HasPluginHooks() bool {
+	return defaultRegistry.HasPluginHooks()
 }
 
 // TranslateRequest is a helper on the default registry.

--- a/sdk/translator/registry_test.go
+++ b/sdk/translator/registry_test.go
@@ -61,6 +61,21 @@ func hasCall(calls []string, want string) bool {
 	return false
 }
 
+func TestHasPluginHooks(t *testing.T) {
+	registry := NewRegistry()
+	if registry.HasPluginHooks() {
+		t.Fatal("new registry unexpectedly reports plugin hooks")
+	}
+	registry.SetPluginHooks(&fakePluginHooks{})
+	if !registry.HasPluginHooks() {
+		t.Fatal("registry did not report installed plugin hooks")
+	}
+	registry.SetPluginHooks(nil)
+	if registry.HasPluginHooks() {
+		t.Fatal("registry still reports cleared plugin hooks")
+	}
+}
+
 func TestTranslateRequest_FallbackNormalizesModel(t *testing.T) {
 	r := NewRegistry()
 


### PR DESCRIPTION
## Summary

- batch Antigravity function-response ordering and role edits inside each small `content` value, then splice all changed contents into the request with one validated body copy
- sanitize `request.tools` and generation schemas inside equivalent small subtrees, preserving the existing cleaners, paths, and edit order while replacing each subtree once
- replace hot GJSON materialization with no-copy/`ForEach` traversal while preserving `Result.Array()` singleton semantics for non-array values
- keep SJSON fallback behavior when a GJSON offset cannot be proven safe

## Behavior compatibility

The optimization changes how JSON edits are applied, not which edits are applied.

- frozen pre-optimization oracles verify byte-for-byte normalizer and schema output
- deterministic randomized differential coverage: 1,000 function histories and 600 schema requests, plus pretty JSON, CRLF, duplicate keys, malformed JSON, and no-op inputs
- provenance scans explicitly compare array/object/scalar/null/missing behavior with the frozen legacy implementation
- a 2,000-case validator differential preserved success/failure and exact error strings
- paired debug CPA replay of the same 25,582,728-byte request produced byte-identical upstream bodies after normalizing only the existing random `requestId`

## Performance

Measured on the same real 25.58 MB Gemini history:

| Measurement | Before | After | Change |
|---|---:|---:|---:|
| Main JSON stages, median | 5,143.120 ms | 776.588 ms | -84.90% |
| Allocated bytes/op, median | 19,317,138,456 | 1,234,824,088 | -93.61% |
| Debug CPA pre-upstream, median | 5,750.718 ms | 1,704.360 ms | -70.36% |

The paired debug CPA runs used freshly built baseline/optimized binaries and the same zero-inference local mock upstream.

## Verification

- `gofmt` / `git diff --check`
- `go vet ./internal/runtime/executor ./internal/signature`
- `go test -race ./internal/runtime/executor ./internal/signature -count=1`
- `go test ./...`
- `go build -o <temp> ./cmd/server`
- independent bounded review after fixing its GJSON non-array semantics finding
