### PR TITLE
fix(claude): align cloaked cache placement and native Haiku helper passthrough

### DIFF
--- a/internal/runtime/executor/caching_verify_test.go
+++ b/internal/runtime/executor/caching_verify_test.go
@@ -1,9 +1,12 @@
 package executor
 
 import (
+	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/tidwall/gjson"
 )
 
@@ -36,8 +39,8 @@ func TestEnsureCacheControl(t *testing.T) {
 		}
 	})
 
-	// Test case 3: Tools are cached
-	t.Run("Tools Caching", func(t *testing.T) {
+	// Test case 3: Native Claude Code does not auto-stamp tools; system still caches.
+	t.Run("Tools Not Auto Cached", func(t *testing.T) {
 		input := []byte(`{
 			"model": "claude-3-5-sonnet",
 			"tools": [
@@ -49,21 +52,19 @@ func TestEnsureCacheControl(t *testing.T) {
 		}`)
 		output := ensureCacheControl(input)
 
-		// cache_control should only be on the LAST tool
-		tool0Cache := gjson.GetBytes(output, "tools.0.cache_control")
-		tool1Cache := gjson.GetBytes(output, "tools.1.cache_control.type")
-
-		if tool0Cache.Exists() {
-			t.Errorf("cache_control should NOT be on the first tool")
-		}
-		if tool1Cache.String() != "ephemeral" {
-			t.Errorf("cache_control not found on last tool. Output: %s", string(output))
+		if gjson.GetBytes(output, "tools.0.cache_control").Exists() || gjson.GetBytes(output, "tools.1.cache_control").Exists() {
+			t.Errorf("default ensureCacheControl must not stamp tools[*].cache_control: %s", string(output))
 		}
 
-		// System should also have cache_control
-		systemCache := gjson.GetBytes(output, "system.0.cache_control.type")
-		if systemCache.String() != "ephemeral" {
+		systemCache := gjson.GetBytes(output, "system.0.cache_control")
+		if systemCache.Get("type").String() != "ephemeral" {
 			t.Errorf("cache_control not found in system. Output: %s", string(output))
+		}
+		// The native constructor spreads ttl in only when a ttl is selected, so the
+		// default breakpoint carries none. upgradeClaudeCacheControlTTL adds it later
+		// for the credentials native uses the 1h pool on.
+		if systemCache.Get("ttl").Exists() {
+			t.Errorf("default system cache_control must not carry ttl. Output: %s", string(output))
 		}
 	})
 
@@ -94,24 +95,70 @@ func TestEnsureCacheControl(t *testing.T) {
 		}
 	})
 
-	// Test case 5: Only tools, no system
-	t.Run("Only Tools No System", func(t *testing.T) {
+	// Test case 5: tools without any system prompt. Native always sends a system
+	// prompt, so this shape only reaches CPA from OpenAI/Gemini translation where the
+	// caller supplied no system message. Without a tools breakpoint the sole marker
+	// would sit on the volatile final message and a stateless caller would rewrite
+	// the whole tools prefix on every request.
+	t.Run("Only Tools No System Falls Back To Tools Breakpoint", func(t *testing.T) {
 		input := []byte(`{
 			"model": "claude-3-5-sonnet",
 			"tools": [
-				{"name": "tool1", "description": "Tool", "input_schema": {"type": "object"}}
+				{"name": "tool1", "description": "Tool", "input_schema": {"type": "object"}},
+				{"name": "tool2", "description": "Tool", "input_schema": {"type": "object"}}
 			],
 			"messages": [{"role": "user", "content": "Hi"}]
 		}`)
 		output := ensureCacheControl(input)
 
-		toolCache := gjson.GetBytes(output, "tools.0.cache_control.type")
-		if toolCache.String() != "ephemeral" {
-			t.Errorf("cache_control not found on tool. Output: %s", string(output))
+		if gjson.GetBytes(output, "tools.0.cache_control").Exists() {
+			t.Errorf("only the last tool may host the fallback breakpoint: %s", string(output))
+		}
+		if got := gjson.GetBytes(output, "tools.1.cache_control.type").String(); got != "ephemeral" {
+			t.Errorf("missing tools fallback breakpoint when system is absent: %s", string(output))
+		}
+		if gjson.GetBytes(output, "tools.1.cache_control.ttl").Exists() {
+			t.Errorf("tools fallback breakpoint must not carry a default ttl: %s", string(output))
+		}
+		if got := gjson.GetBytes(output, "messages.0.content.0.cache_control.type").String(); got != "ephemeral" {
+			t.Errorf("rolling message breakpoint should still be present: %s", string(output))
 		}
 	})
 
-	// Test case 6: Many tools (Claude Code scenario)
+	t.Run("Empty System Still Falls Back To Tools", func(t *testing.T) {
+		for name, system := range map[string]string{
+			"empty array":  `"system": [],`,
+			"empty string": `"system": "",`,
+			"blank string": `"system": "   ",`,
+		} {
+			t.Run(name, func(t *testing.T) {
+				input := []byte(`{
+					"model": "claude-3-5-sonnet",
+					` + system + `
+					"tools": [{"name": "tool1", "description": "Tool", "input_schema": {"type": "object"}}],
+					"messages": [{"role": "user", "content": "Hi"}]
+				}`)
+				output := ensureCacheControl(input)
+
+				if got := gjson.GetBytes(output, "tools.0.cache_control.type").String(); got != "ephemeral" {
+					t.Errorf("an unusable system prompt must still yield a tools breakpoint: %s", string(output))
+				}
+				// Empty/blank string system must not be rewritten into a marked text
+				// block; that would double-stamp tools + a whitespace system host.
+				if bytes.Contains(output, []byte(`"text":""`)) || bytes.Contains(output, []byte(`"text":"   "`)) {
+					t.Errorf("unusable string system must stay unconverted: %s", string(output))
+				}
+				if gjson.GetBytes(output, "system.0.cache_control").Exists() {
+					t.Errorf("unusable system must not receive its own breakpoint: %s", string(output))
+				}
+				if countCacheControls(output) != 2 {
+					t.Errorf("want tools+message breakpoints only, got %d in %s", countCacheControls(output), string(output))
+				}
+			})
+		}
+	})
+
+	// Test case 6: Many tools (Claude Code scenario) — default skips tools.
 	t.Run("Many Tools (Claude Code Scenario)", func(t *testing.T) {
 		// Simulate Claude Code with many tools
 		toolsJSON := `[`
@@ -132,26 +179,24 @@ func TestEnsureCacheControl(t *testing.T) {
 
 		output := ensureCacheControl(input)
 
-		// Only the last tool (index 49) should have cache_control
-		for i := 0; i < 49; i++ {
+		for i := 0; i < 50; i++ {
 			path := fmt.Sprintf("tools.%d.cache_control", i)
 			if gjson.GetBytes(output, path).Exists() {
-				t.Errorf("tool %d should NOT have cache_control", i)
+				t.Errorf("tool %d should NOT have cache_control under default ensure", i)
 			}
 		}
 
-		lastToolCache := gjson.GetBytes(output, "tools.49.cache_control.type")
-		if lastToolCache.String() != "ephemeral" {
-			t.Errorf("last tool (49) should have cache_control")
+		helperOut := injectToolsCacheControl(input)
+		if got := gjson.GetBytes(helperOut, "tools.49.cache_control.type").String(); got != "ephemeral" {
+			t.Errorf("injectToolsCacheControl should still mark last tool")
 		}
 
-		// System should also have cache_control
-		systemCache := gjson.GetBytes(output, "system.0.cache_control.type")
-		if systemCache.String() != "ephemeral" {
-			t.Errorf("system should have cache_control")
+		if got := gjson.GetBytes(output, "system.0.cache_control.type").String(); got != "ephemeral" {
+			t.Errorf("system should have cache_control, got %q", got)
 		}
-
-		t.Log("test passed: 50 tools - cache_control only on last tool")
+		if got := gjson.GetBytes(output, "messages.0.content.0.cache_control.type").String(); got != "ephemeral" {
+			t.Errorf("latest user should have cache_control, got %q", got)
+		}
 	})
 
 	// Test case 7: Empty tools array
@@ -166,8 +211,8 @@ func TestEnsureCacheControl(t *testing.T) {
 		}
 	})
 
-	// Test case 8: Messages caching for multi-turn (second-to-last user)
-	t.Run("Messages Caching Second-To-Last User", func(t *testing.T) {
+	// Test case 8: Messages caching follows native Claude Code (latest user turn).
+	t.Run("Messages Caching Latest User", func(t *testing.T) {
 		input := []byte(`{
 			"model": "claude-3-5-sonnet",
 			"messages": [
@@ -180,39 +225,231 @@ func TestEnsureCacheControl(t *testing.T) {
 		}`)
 		output := ensureCacheControl(input)
 
-		cacheType := gjson.GetBytes(output, "messages.2.content.0.cache_control.type")
-		if cacheType.String() != "ephemeral" {
-			t.Errorf("cache_control not found on second-to-last user turn. Output: %s", string(output))
+		if got := gjson.GetBytes(output, "messages.4.content.0.cache_control.type").String(); got != "ephemeral" {
+			t.Errorf("cache_control.type on latest user = %q, want ephemeral. Output: %s", got, string(output))
 		}
-
-		lastUserCache := gjson.GetBytes(output, "messages.4.content.0.cache_control")
-		if lastUserCache.Exists() {
-			t.Errorf("last user turn should NOT have cache_control")
+		if gjson.GetBytes(output, "messages.4.content.0.cache_control.ttl").Exists() {
+			t.Errorf("default rolling marker must not carry ttl. Output: %s", string(output))
+		}
+		if gjson.GetBytes(output, "messages.2.content.0.cache_control").Exists() {
+			t.Errorf("second-to-last user turn should NOT have cache_control; native Claude Code rolls onto the latest user")
 		}
 	})
 
-	// Test case 9: Existing message cache_control should skip injection
-	t.Run("Messages Skip When Cache Control Exists", func(t *testing.T) {
+	// The native final-system special case is narrow: it requires non-empty STRING
+	// content and replaces it with a single freshly marked text block.
+	t.Run("Messages Caching Trailing System String", func(t *testing.T) {
 		input := []byte(`{
 			"model": "claude-3-5-sonnet",
 			"messages": [
-				{"role": "user", "content": [{"type": "text", "text": "First user"}]},
-				{"role": "assistant", "content": [{"type": "text", "text": "Assistant reply", "cache_control": {"type": "ephemeral"}}]},
-				{"role": "user", "content": [{"type": "text", "text": "Second user"}]}
+				{"role": "user", "content": "User"},
+				{"role": "assistant", "content": "Assistant"},
+				{"role": "system", "content": "Internal system"}
 			]
 		}`)
 		output := ensureCacheControl(input)
 
-		userCache := gjson.GetBytes(output, "messages.0.content.0.cache_control")
-		if userCache.Exists() {
-			t.Errorf("cache_control should NOT be injected when a message already has cache_control")
+		systemContent := gjson.GetBytes(output, "messages.2.content")
+		if !systemContent.IsArray() || len(systemContent.Array()) != 1 {
+			t.Fatalf("trailing string system was not replaced by a single text block: %s", output)
 		}
-
-		existingCache := gjson.GetBytes(output, "messages.1.content.0.cache_control.type")
-		if existingCache.String() != "ephemeral" {
-			t.Errorf("existing cache_control should be preserved. Output: %s", string(output))
+		if got := systemContent.Get("0.text").String(); got != "Internal system" {
+			t.Fatalf("trailing system text = %q, want the original string: %s", got, output)
+		}
+		if got := systemContent.Get("0.cache_control.type").String(); got != "ephemeral" {
+			t.Fatalf("trailing string system did not take the native special case: %s", output)
+		}
+		if gjson.GetBytes(output, "messages.1.content.0.cache_control").Exists() {
+			t.Fatalf("preceding assistant must not also receive the rolling marker: %s", output)
 		}
 	})
+
+	// An array-content trailing system turn is NOT the native special case: native
+	// requires string content there, so the marker falls back to the last eligible
+	// user/assistant turn instead.
+	t.Run("Messages Caching Trailing System Array Falls Back", func(t *testing.T) {
+		input := []byte(`{
+			"model": "claude-3-5-sonnet",
+			"messages": [
+				{"role": "user", "content": "User"},
+				{"role": "assistant", "content": "Assistant"},
+				{"role": "system", "content": [{"type": "text", "text": "Internal 1"}, {"type": "text", "text": "Internal 2"}]}
+			]
+		}`)
+		output := ensureCacheControl(input)
+
+		if gjson.GetBytes(output, "messages.2.content.1.cache_control").Exists() {
+			t.Fatalf("array-content trailing system must not be marked; native requires string content: %s", output)
+		}
+		if got := gjson.GetBytes(output, "messages.1.content.0.cache_control.type").String(); got != "ephemeral" {
+			t.Fatalf("marker should fall back to the last eligible assistant turn: %s", output)
+		}
+	})
+
+	t.Run("Messages Caching Trailing Assistant Text", func(t *testing.T) {
+		input := []byte(`{
+			"messages": [
+				{"role": "user", "content": "User"},
+				{"role": "assistant", "content": "Assistant prefill"}
+			]
+		}`)
+		output := ensureCacheControl(input)
+
+		if got := gjson.GetBytes(output, "messages.1.content.0.cache_control.type").String(); got != "ephemeral" {
+			t.Fatalf("trailing assistant cache_control.type = %q, want ephemeral. Output: %s", got, output)
+		}
+		wantAssistant := []byte(`[{"type":"text","text":"Assistant prefill","cache_control":{"type":"ephemeral"}}]`)
+		if !bytes.Contains(output, wantAssistant) {
+			t.Fatalf("assistant string promotion does not match native order: %s", output)
+		}
+		if gjson.GetBytes(output, "messages.0.content.0.cache_control").Exists() {
+			t.Fatalf("preceding user must not receive an assistant rolling marker: %s", output)
+		}
+	})
+
+	t.Run("Messages Skip Trailing Assistant Thinking", func(t *testing.T) {
+		input := []byte(`{
+			"messages": [
+				{"role": "user", "content": "User"},
+				{"role": "system", "content": "Internal system"},
+				{"role": "assistant", "content": [
+					{"type": "text", "text": "Assistant"},
+					{"type": "thinking", "thinking": "Internal"}
+				]}
+			]
+		}`)
+		output := ensureCacheControl(input)
+
+		if got := gjson.GetBytes(output, "messages.0.content.0.cache_control.type").String(); got != "ephemeral" {
+			t.Fatalf("preceding user cache_control.type = %q, want fallback ephemeral. Output: %s", got, output)
+		}
+		if got := gjson.GetBytes(output, "messages.1.content"); got.Type != gjson.String {
+			t.Fatalf("internal system message was rewritten instead of skipped: %s", output)
+		}
+		if gjson.GetBytes(output, "messages.2.content.1.cache_control").Exists() {
+			t.Fatalf("assistant thinking block must not receive cache_control: %s", output)
+		}
+	})
+
+	// Test case 9: Cloaking first-user marker must not suppress latest-user rolling write.
+	t.Run("Messages Inject Despite Cloaking First User Marker", func(t *testing.T) {
+		input := []byte(`{
+			"model": "claude-3-5-sonnet",
+			"tools": [{"name": "Read", "description": "read", "input_schema": {"type": "object"}}],
+			"system": "You are helpful.",
+			"messages": [
+				{"role": "user", "content": [{"type": "text", "text": "currentDate"}, {"type": "text", "text": "First user", "cache_control": {"type": "ephemeral"}}]},
+				{"role": "assistant", "content": [{"type": "text", "text": "Assistant reply"}]},
+				{"role": "user", "content": [{"type": "text", "text": "Second user"}]},
+				{"role": "assistant", "content": [{"type": "text", "text": "Assistant reply 2"}]},
+				{"role": "user", "content": [{"type": "text", "text": "Third user"}]}
+			]
+		}`)
+		output := ensureCacheControl(input)
+
+		if got := gjson.GetBytes(output, "messages.0.content.1.cache_control.type").String(); got != "ephemeral" {
+			t.Errorf("cloaking first-user marker lost: %s", string(output))
+		}
+		if got := gjson.GetBytes(output, "messages.4.content.0.cache_control.type").String(); got != "ephemeral" {
+			t.Errorf("latest user missing rolling cache_control after cloaking marker. Output: %s", string(output))
+		}
+		if gjson.GetBytes(output, "tools.0.cache_control").Exists() {
+			t.Errorf("a payload with a system prompt must not stamp tools[*].cache_control: %s", string(output))
+		}
+		if got := gjson.GetBytes(output, "system.0.cache_control.type").String(); got != "ephemeral" {
+			t.Errorf("system should still receive independent cache_control. Output: %s", string(output))
+		}
+	})
+
+	// Test case 10: Existing marker on the latest user turn is preserved / not duplicated.
+	t.Run("Messages Skip When Latest User Already Has Cache Control", func(t *testing.T) {
+		input := []byte(`{
+			"model": "claude-3-5-sonnet",
+			"messages": [
+				{"role": "user", "content": [{"type": "text", "text": "First user"}]},
+				{"role": "assistant", "content": [{"type": "text", "text": "Assistant reply"}]},
+				{"role": "user", "content": [{"type": "text", "text": "Second user", "cache_control": {"type": "ephemeral", "ttl": "1h"}}]}
+			]
+		}`)
+		output := ensureCacheControl(input)
+
+		if got := gjson.GetBytes(output, "messages.2.content.0.cache_control.ttl").String(); got != "1h" {
+			t.Errorf("existing latest-user cache_control.ttl = %q, want 1h. Output: %s", got, string(output))
+		}
+		if gjson.GetBytes(output, "messages.0.content.0.cache_control").Exists() {
+			t.Errorf("should not invent an extra message breakpoint on the first user when latest already has one")
+		}
+	})
+
+	// Test case 11: Generated cache controls preserve native JSON property order.
+	t.Run("Native Cache Control Wire Order", func(t *testing.T) {
+		input := []byte(`{
+			"system": [{"type": "text", "text": "System"}],
+			"messages": [{"role": "user", "content": [{"type": "text", "text": "User"}]}]
+		}`)
+		output := ensureCacheControl(input)
+		want := []byte(`"cache_control":{"type":"ephemeral"}`)
+		if got := bytes.Count(output, want); got != 2 {
+			t.Fatalf("native cache_control wire shape count = %d, want 2. Output: %s", got, output)
+		}
+
+		upgraded := upgradeClaudeCacheControlTTL(output, claudeCacheControlTTL1h)
+		wantUpgraded := []byte(`"cache_control":{"type":"ephemeral","ttl":"1h"}`)
+		if got := bytes.Count(upgraded, wantUpgraded); got != 2 {
+			t.Fatalf("upgraded cache_control wire shape count = %d, want 2. Output: %s", got, upgraded)
+		}
+		if bytes.Contains(upgraded, []byte(`"cache_control":{"ttl":"1h","type":"ephemeral"}`)) {
+			t.Fatalf("cache_control keys emitted in non-native order: %s", upgraded)
+		}
+	})
+
+	t.Run("String Promotion Native Parent Order", func(t *testing.T) {
+		input := []byte(`{"system":"System <tag> &","messages":[{"role":"user","content":"User <tag> &"}]}`)
+		output := ensureCacheControl(input)
+		wantSystem := []byte(`"system":[{"type":"text","text":"System <tag> &","cache_control":{"type":"ephemeral"}}]`)
+		wantMessage := []byte(`"content":[{"type":"text","text":"User <tag> &","cache_control":{"type":"ephemeral"}}]`)
+		if !bytes.Contains(output, wantSystem) || !bytes.Contains(output, wantMessage) {
+			t.Fatalf("string promotion does not match native parent/key escaping order: %s", output)
+		}
+		if bytes.Contains(output, []byte(`\u003c`)) || bytes.Contains(output, []byte(`\u003e`)) || bytes.Contains(output, []byte(`\u0026`)) {
+			t.Fatalf("string promotion introduced HTML escaping: %s", output)
+		}
+	})
+
+	t.Run("Existing Global Scope Preserved", func(t *testing.T) {
+		input := []byte(`{"system":[{"type":"text","text":"Global","cache_control":{"type":"ephemeral","ttl":"1h","scope":"global"}}],"messages":[{"role":"user","content":"User"}]}`)
+		output := ensureCacheControl(input)
+		want := []byte(`"cache_control":{"type":"ephemeral","ttl":"1h","scope":"global"}`)
+		if !bytes.Contains(output, want) {
+			t.Fatalf("existing native global scope marker changed: %s", output)
+		}
+	})
+}
+
+func TestShouldEnsureCacheControl(t *testing.T) {
+	markerless := []byte(`{"messages":[{"role":"user","content":"x"}]}`)
+	withMarker := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"x","cache_control":{"type":"ephemeral"}}]}]}`)
+	tests := []struct {
+		name                string
+		payload             []byte
+		cloaked             bool
+		confirmedClaudeCode bool
+		want                bool
+	}{
+		{name: "confirmed native markerless", payload: markerless, confirmedClaudeCode: true, want: false},
+		{name: "confirmed native with marker", payload: withMarker, confirmedClaudeCode: true, want: false},
+		{name: "cloaked with marker", payload: withMarker, cloaked: true, want: true},
+		{name: "unconfirmed markerless", payload: markerless, want: true},
+		{name: "unconfirmed with marker", payload: withMarker, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldEnsureCacheControl(tt.payload, tt.cloaked, tt.confirmedClaudeCode); got != tt.want {
+				t.Fatalf("shouldEnsureCacheControl() = %t, want %t", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestInjectToolsCacheControlSkipsDeferredTools(t *testing.T) {
@@ -321,25 +558,143 @@ func TestCacheControlOrder(t *testing.T) {
 
 	output := ensureCacheControl(input)
 
-	// 1. Last tool has cache_control
-	if gjson.GetBytes(output, "tools.1.cache_control.type").String() != "ephemeral" {
-		t.Error("last tool should have cache_control")
+	// Native default path does not stamp tools.
+	if gjson.GetBytes(output, "tools.0.cache_control").Exists() || gjson.GetBytes(output, "tools.1.cache_control").Exists() {
+		t.Error("default ensureCacheControl must not stamp tools[*].cache_control")
 	}
 
-	// 2. First tool has NO cache_control
-	if gjson.GetBytes(output, "tools.0.cache_control").Exists() {
-		t.Error("first tool should NOT have cache_control")
-	}
-
-	// 3. Last system element has cache_control
+	// Last system element has the default cache_control, which carries no ttl.
 	if gjson.GetBytes(output, "system.1.cache_control.type").String() != "ephemeral" {
 		t.Error("last system element should have cache_control")
 	}
+	if gjson.GetBytes(output, "system.1.cache_control.ttl").Exists() {
+		t.Error("default last system element must not carry a ttl")
+	}
+	if got := gjson.GetBytes(upgradeClaudeCacheControlTTL(output, claudeCacheControlTTL1h), "system.1.cache_control.ttl").String(); got != "1h" {
+		t.Errorf("upgraded last system element ttl = %q, want 1h", got)
+	}
 
-	// 4. First system element has NO cache_control
+	// First system element has NO cache_control
 	if gjson.GetBytes(output, "system.0.cache_control").Exists() {
 		t.Error("first system element should NOT have cache_control")
 	}
+}
 
-	t.Log("cache order correct: tools -> system")
+// The native ttl helper only touches blocks that already carry a cache_control and
+// have no ttl yet. It must never create a breakpoint, because placement is decided
+// by ensureCacheControl before this step runs.
+func TestUpgradeClaudeCacheControlTTL(t *testing.T) {
+	t.Run("Upgrades Only Existing Markers", func(t *testing.T) {
+		input := []byte(`{` +
+			`"tools":[{"name":"t","cache_control":{"type":"ephemeral"}},{"name":"u"}],` +
+			`"system":[{"type":"text","text":"s0"},{"type":"text","text":"s1","cache_control":{"type":"ephemeral"}}],` +
+			`"messages":[{"role":"user","content":[{"type":"text","text":"a"},{"type":"text","text":"b","cache_control":{"type":"ephemeral"}}]}]}`)
+		output := upgradeClaudeCacheControlTTL(input, claudeCacheControlTTL1h)
+
+		for _, path := range []string{"tools.0", "system.1", "messages.0.content.1"} {
+			if got := gjson.GetBytes(output, path+".cache_control.ttl").String(); got != "1h" {
+				t.Errorf("%s.cache_control.ttl = %q, want 1h. Output: %s", path, got, output)
+			}
+		}
+		for _, path := range []string{"tools.1", "system.0", "messages.0.content.0"} {
+			if gjson.GetBytes(output, path+".cache_control").Exists() {
+				t.Errorf("%s must not gain a cache_control: %s", path, output)
+			}
+		}
+		if got := countCacheControls(output); got != 3 {
+			t.Errorf("breakpoint count = %d, want the original 3", got)
+		}
+	})
+
+	t.Run("Preserves Caller TTL And Is Idempotent", func(t *testing.T) {
+		input := []byte(`{"system":[{"type":"text","text":"s","cache_control":{"type":"ephemeral","ttl":"5m"}}]}`)
+		output := upgradeClaudeCacheControlTTL(input, claudeCacheControlTTL1h)
+		if got := gjson.GetBytes(output, "system.0.cache_control.ttl").String(); got != "5m" {
+			t.Errorf("existing ttl = %q, want the caller's 5m to survive", got)
+		}
+
+		once := upgradeClaudeCacheControlTTL([]byte(`{"system":[{"type":"text","text":"s","cache_control":{"type":"ephemeral"}}]}`), claudeCacheControlTTL1h)
+		twice := upgradeClaudeCacheControlTTL(once, claudeCacheControlTTL1h)
+		if !bytes.Equal(once, twice) {
+			t.Errorf("upgrade is not idempotent: %s vs %s", once, twice)
+		}
+	})
+
+	t.Run("Keeps Native Key Order With Scope", func(t *testing.T) {
+		input := []byte(`{"system":[{"type":"text","text":"s","cache_control":{"type":"ephemeral","scope":"global"}}]}`)
+		output := upgradeClaudeCacheControlTTL(input, claudeCacheControlTTL1h)
+		want := []byte(`"cache_control":{"type":"ephemeral","ttl":"1h","scope":"global"}`)
+		if !bytes.Contains(output, want) {
+			t.Errorf("scope-bearing marker lost native {type, ttl, scope} order: %s", output)
+		}
+	})
+
+	t.Run("No TTL Is A No-op", func(t *testing.T) {
+		input := []byte(`{"system":[{"type":"text","text":"s","cache_control":{"type":"ephemeral"}}]}`)
+		if output := upgradeClaudeCacheControlTTL(input, ""); !bytes.Equal(output, input) {
+			t.Errorf("empty ttl must be a no-op: %s", output)
+		}
+		if output := upgradeClaudeCacheControlTTL([]byte(`not json`), claudeCacheControlTTL1h); string(output) != "not json" {
+			t.Errorf("invalid payload must be returned untouched: %s", output)
+		}
+	})
+}
+
+// End-to-end guard for #4855. Cloaking stamps the first real user block, and the
+// old global `countCacheControls(body) == 0` gate then skipped every remaining
+// section, freezing the rolling breakpoint on messages[0] for the whole
+// conversation. Section-independent ensure has to keep that breakpoint advancing
+// as the history grows, so a reintroduced global short-circuit fails here.
+func TestClaudeExecutorCloakedRollingCacheBreakpointAdvances(t *testing.T) {
+	buildConversation := func(exchanges int) []byte {
+		messages := make([]string, 0, exchanges*2)
+		for i := 0; i < exchanges; i++ {
+			messages = append(messages,
+				fmt.Sprintf(`{"role":"user","content":"question number %d"}`, i),
+				fmt.Sprintf(`{"role":"assistant","content":"answer number %d"}`, i),
+			)
+		}
+		return []byte(`{"model":"claude-opus-5","max_tokens":100,` +
+			`"system":"You are a helpful assistant.",` +
+			`"messages":[` + strings.Join(messages, ",") + `]}`)
+	}
+
+	// lastMarkedMessage reports the highest message index carrying a breakpoint.
+	lastMarkedMessage := func(body []byte) int {
+		last := -1
+		gjson.GetBytes(body, "messages").ForEach(func(msgIdx, message gjson.Result) bool {
+			message.Get("content").ForEach(func(_, block gjson.Result) bool {
+				if block.Get("cache_control").Exists() {
+					last = int(msgIdx.Int())
+				}
+				return true
+			})
+			return true
+		})
+		return last
+	}
+
+	cfg := &config.Config{}
+	shortBody := executeClaudeContextManagementRequest(t, cfg, buildConversation(2), false)
+	longBody := executeClaudeContextManagementRequest(t, cfg, buildConversation(6), false)
+
+	shortMarked := lastMarkedMessage(shortBody)
+	longMarked := lastMarkedMessage(longBody)
+	if shortMarked <= 0 {
+		t.Fatalf("short conversation kept its only breakpoint at index %d: %s", shortMarked, shortBody)
+	}
+	if longMarked <= shortMarked {
+		t.Fatalf("rolling breakpoint did not advance with history: short=%d long=%d\n%s", shortMarked, longMarked, longBody)
+	}
+	// The rolling marker must land on the final turn, not an early frozen prefix.
+	if want := int(gjson.GetBytes(longBody, "messages.#").Int()) - 1; longMarked != want {
+		t.Fatalf("rolling breakpoint at message %d, want final message %d: %s", longMarked, want, longBody)
+	}
+	// Cloaking's own first-user marker must still be present alongside it.
+	if !gjson.GetBytes(longBody, "messages.0.content.1.cache_control").Exists() {
+		t.Fatalf("cloak first-user breakpoint lost: %s", longBody)
+	}
+	if total := countCacheControls(longBody); total > 4 {
+		t.Fatalf("cache_control count = %d, want at most 4: %s", total, longBody)
+	}
 }

--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -672,6 +672,24 @@ func injectClaudeCodeCurrentDate(payload []byte, now time.Time) []byte {
 // real client does not already get.
 const claudeCodeContextManagement = `{"edits":[{"type":"clear_thinking_20251015","keep":"all"}]}`
 
+// claudeThinkingAcceptsClearThinking reports whether the payload's thinking
+// value allows the clear_thinking_20251015 strategy. Anthropic rejects the
+// request outright otherwise:
+//
+//	`clear_thinking_20251015` strategy requires `thinking` to be enabled or adaptive
+//
+// An absent thinking field is therefore just as ineligible as an explicit
+// {"type":"disabled"}, which is why this checks for the accepted values rather
+// than excluding the disabled one.
+func claudeThinkingAcceptsClearThinking(payload []byte) bool {
+	switch gjson.GetBytes(payload, "thinking.type").String() {
+	case "enabled", "adaptive":
+		return true
+	default:
+		return false
+	}
+}
+
 // injectClaudeCodeContextManagement supplies context_management when the caller
 // omitted it. CPA already claims context-management-2025-06-27 in Anthropic-Beta,
 // so a missing body field is an observable inconsistency with the real client. A
@@ -680,7 +698,7 @@ func injectClaudeCodeContextManagement(payload []byte) ([]byte, bool) {
 	if gjson.GetBytes(payload, "context_management").Exists() {
 		return payload, false
 	}
-	if gjson.GetBytes(payload, "thinking.type").String() == "disabled" {
+	if !claudeThinkingAcceptsClearThinking(payload) {
 		return payload, false
 	}
 	updated, err := sjson.SetRawBytes(payload, "context_management", []byte(claudeCodeContextManagement))
@@ -700,10 +718,13 @@ type claudeCodeContextManagementState struct {
 // reconcileClaudeCodeContextManagement resolves automatic ownership after all
 // payload rules and forced tool-choice processing have completed.
 func reconcileClaudeCodeContextManagement(payload []byte, state claudeCodeContextManagementState) []byte {
-	thinkingType := gjson.GetBytes(payload, "thinking.type").String()
 	contextManagement := gjson.GetBytes(payload, "context_management")
 
-	if thinkingType == "disabled" {
+	// Any thinking value the strategy does not accept must drop an object CPA
+	// injected itself. disableThinkingIfToolChoiceForced deletes the whole
+	// thinking field after injection, so this also covers a request that was
+	// still eligible when injectClaudeCodeContextManagement ran.
+	if !claudeThinkingAcceptsClearThinking(payload) {
 		if state.callerOwned || !state.automaticallyInjected || state.payloadRuleTouched {
 			return payload
 		}
@@ -717,9 +738,6 @@ func reconcileClaudeCodeContextManagement(payload []byte, state claudeCodeContex
 		return updated
 	}
 
-	if thinkingType != "enabled" && thinkingType != "adaptive" {
-		return payload
-	}
 	if !state.eligible || state.callerOwned || state.payloadRuleTouched || contextManagement.Exists() {
 		return payload
 	}

--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -221,7 +221,7 @@ func checkSystemInstructionsWithSigningModeAt(payload []byte, strictMode bool, c
 
 	billingText := generateBillingHeader(cchSigning, version, messageText, entrypoint, workload)
 	billingBlock := buildTextBlock(billingText, nil)
-	agentBlock := buildTextBlock(claudeCodeCLIIdentity, map[string]string{"type": "ephemeral"})
+	agentBlock := buildTextBlock(claudeCodeCLIIdentity, &claudeCodeCacheControl)
 	payload, _ = sjson.SetRawBytes(payload, "system", []byte("["+billingBlock+","+agentBlock+"]"))
 	if strictMode {
 		return injectClaudeCodeCurrentDate(payload, now)
@@ -383,12 +383,12 @@ func collectForwardedClaudeSystemPromptBlocks(system gjson.Result) []string {
 // buildTextBlock constructs a JSON text block with JSON.stringify-compatible
 // HTML characters. encoding/json's default \u003c escaping would change the
 // exact currentDate bytes and therefore the final CCH.
-func buildTextBlock(text string, cacheControl map[string]string) string {
+func buildTextBlock(text string, cacheControl *claudeCacheControl) string {
 	block := `{"type":"text","text":` + marshalJSONStringWithoutHTMLEscape(text)
-	if cacheControl != nil && len(cacheControl) > 0 {
-		block += `,"cache_control":{"type":"ephemeral"`
-		if ttl, ok := cacheControl["ttl"]; ok {
-			block += `,"ttl":` + marshalJSONStringWithoutHTMLEscape(ttl)
+	if cacheControl != nil && cacheControl.Type != "" {
+		block += `,"cache_control":{"type":` + marshalJSONStringWithoutHTMLEscape(cacheControl.Type)
+		if cacheControl.TTL != "" {
+			block += `,"ttl":` + marshalJSONStringWithoutHTMLEscape(cacheControl.TTL)
 		}
 		block += "}"
 	}
@@ -505,7 +505,7 @@ func insertClaudeMidConversationSystemMessages(payload []byte, texts []string) [
 
 	systemMessages := make([]string, 0, len(texts))
 	for _, text := range texts {
-		content := "[" + buildTextBlock(text, map[string]string{"type": "ephemeral"}) + "]"
+		content := "[" + buildTextBlock(text, &claudeCodeCacheControl) + "]"
 		systemMessages = append(systemMessages, `{"role":"system","content":`+content+"}")
 	}
 	rawMessages := make([]string, 0, len(messageBlocks)+len(systemMessages))
@@ -631,7 +631,7 @@ func injectClaudeCodeCurrentDate(payload []byte, now time.Time) []byte {
 	dateBlock := buildTextBlock(dateText, nil)
 
 	if content.Type == gjson.String {
-		userBlock := buildTextBlock(content.String(), map[string]string{"type": "ephemeral"})
+		userBlock := buildTextBlock(content.String(), &claudeCodeCacheControl)
 		newArray := "[" + dateBlock + "," + userBlock + "]"
 		payload, _ = sjson.SetRawBytes(payload, contentPath, []byte(newArray))
 		return payload
@@ -730,6 +730,10 @@ func reconcileClaudeCodeContextManagement(payload []byte, state claudeCodeContex
 	return updated
 }
 
+// withEphemeralCacheControl stamps the native Claude Code default cache marker
+// {"type":"ephemeral"} onto a content block. A 1h ttl is not part of the default
+// shape; upgradeClaudeCacheControlTTL adds it for the credentials native uses it
+// on, after all placement decisions are final.
 func withEphemeralCacheControl(rawBlock string) string {
 	updated, err := sjson.SetRawBytes([]byte(rawBlock), "cache_control", []byte(`{"type":"ephemeral"}`))
 	if err != nil {
@@ -848,30 +852,156 @@ func applyCloaking(
 	return payload, true, nil
 }
 
-// ensureCacheControl injects cache_control breakpoints into the payload for optimal prompt caching.
-// According to Anthropic's documentation, cache prefixes are created in order: tools -> system -> messages.
-// This function adds cache_control to:
-// 1. The LAST non-deferred tool in the tools array (caches all preceding tool definitions)
-// 2. The LAST system prompt element
-// 3. The SECOND-TO-LAST user turn (caches conversation history for multi-turn)
+type claudeCacheControl struct {
+	Type string `json:"type"`
+	TTL  string `json:"ttl,omitempty"`
+}
+
+// claudeCodeCacheControl is the default Claude Code breakpoint shape.
 //
-// Up to 4 cache breakpoints are allowed per request. Tools, System, and Messages are INDEPENDENT breakpoints.
-// This enables up to 90% cost reduction on cached tokens (cache read = 0.1x base price).
+// Recovered from the cache-control constructor in the installed 2.1.220,
+// 2.1.221 and 2.1.227 binaries, which is byte-identical in all three:
+//
+//	function ctor({scope, ttl} = {}) {
+//	  return {type: "ephemeral", ...ttl && {ttl}, ...scope === "global" && {scope}}
+//	}
+//
+// ttl is spread in only when the caller passes one, so the default native wire
+// shape carries no ttl at all. upgradeClaudeCacheControlTTL applies the 1h pool
+// separately, for the credentials native selects it on. The struct field order
+// preserves the native {type, ttl} key order when sjson marshals a value.
+var claudeCodeCacheControl = claudeCacheControl{
+	Type: "ephemeral",
+}
+
+// claudeCacheControlTTL1h is the only non-default ttl native ever selects.
+const claudeCacheControlTTL1h = "1h"
+
+// ensureCacheControl injects default cache_control breakpoints for translated
+// entrypoints (Responses/Chat/Gemini) after cloaking. Placement follows the
+// native request builder recovered from the installed binaries:
+//  1. LAST system block when no system marker exists
+//  2. LAST cacheable message when that message has no marker
+//
+// Tools are normally not stamped: the native Messages builder never passes a
+// cacheControl to its tool-schema converter, and a system breakpoint already
+// covers the tools prefix. The one exception is a payload with tools but no
+// system at all, which native never produces (it always sends a system prompt).
+// Without the fallback such a request has its only breakpoint on the volatile
+// final message, so a stateless caller with large tool definitions rewrites the
+// whole prefix on every request and never reads it back.
+//
+// Each section injects independently so cloaking's first-user marker cannot
+// suppress system/latest-user breakpoints. Callers still run enforceCacheControlLimit.
 // See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
 func ensureCacheControl(payload []byte) []byte {
-	// 1. Inject cache_control into the LAST non-deferred tool
-	// Tools are cached first in the hierarchy, so this is the most important breakpoint.
-	payload = injectToolsCacheControl(payload)
-
-	// 2. Inject cache_control into the LAST system prompt element
-	// System is the second level in the cache hierarchy.
+	if !claudePayloadHasCacheableSystem(payload) {
+		payload = injectToolsCacheControl(payload)
+	}
 	payload = injectSystemCacheControl(payload)
-
-	// 3. Inject cache_control into messages for multi-turn conversation caching
-	// This caches the conversation history up to the second-to-last user turn.
 	payload = injectMessagesCacheControl(payload)
-
 	return payload
+}
+
+// claudePayloadHasCacheableSystem reports whether the payload has a system prompt
+// that injectSystemCacheControl can actually host a breakpoint on. An absent key, an
+// empty array and an empty string all leave the tools prefix uncovered.
+func claudePayloadHasCacheableSystem(payload []byte) bool {
+	system := gjson.GetBytes(payload, "system")
+	switch {
+	case !system.Exists():
+		return false
+	case system.IsArray():
+		return system.Get("#").Int() > 0
+	case system.Type == gjson.String:
+		return strings.TrimSpace(system.String()) != ""
+	default:
+		return false
+	}
+}
+
+// upgradeClaudeCacheControlTTL mirrors the native ttl upgrade helper, which only
+// touches blocks that already carry a cache_control without a ttl:
+//
+//	function upgrade(block, ttl) {
+//	  if (!("cache_control" in block) || !block.cache_control || block.cache_control.ttl) return block
+//	  return {...block, cache_control: {...block.cache_control, ttl}}
+//	}
+//
+// It never creates a breakpoint, so placement stays owned by ensureCacheControl.
+// Native gates the 1h selection on OAuth scopes, a non-overage account and an
+// allowlisted internal query source, and pushes extended-cache-ttl-2025-04-11
+// only when that selection produced a 1h body ttl. CPA has no query-source
+// equivalent, so the credential check is the reproducible half: OAuth is exactly
+// when claudeCodeCLIBetas emits extended-cache-ttl, which keeps body ttl and the
+// beta strictly paired the way native does. API-key credentials keep the plain
+// {"type":"ephemeral"} native default, which also avoids sending ttl to
+// Anthropic-compatible gateways that never advertised support for it.
+func upgradeClaudeCacheControlTTL(payload []byte, ttl string) []byte {
+	if ttl == "" || len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return payload
+	}
+
+	upgrade := func(path string, block gjson.Result) {
+		cacheControl := block.Get("cache_control")
+		if !cacheControl.IsObject() || cacheControl.Get("ttl").Exists() {
+			return
+		}
+		blockType := cacheControl.Get("type")
+		if blockType.Type != gjson.String {
+			return
+		}
+		// Rebuild the object so the native {type, ttl, scope} key order survives
+		// instead of appending ttl after a caller-supplied scope.
+		upgraded := `{"type":` + marshalJSONStringWithoutHTMLEscape(blockType.String()) +
+			`,"ttl":` + marshalJSONStringWithoutHTMLEscape(ttl)
+		if scope := cacheControl.Get("scope"); scope.Exists() {
+			upgraded += `,"scope":` + scope.Raw
+		}
+		upgraded += "}"
+		updated, errSet := sjson.SetRawBytes(payload, path+".cache_control", []byte(upgraded))
+		if errSet != nil {
+			return
+		}
+		payload = updated
+	}
+
+	forEachClaudeCacheControlBlock(payload, upgrade)
+	return payload
+}
+
+// forEachClaudeCacheControlBlock walks every block that can carry cache_control
+// in Anthropic's evaluation order: tools, then system, then messages.
+func forEachClaudeCacheControlBlock(payload []byte, visit func(path string, block gjson.Result)) {
+	if tools := gjson.GetBytes(payload, "tools"); tools.IsArray() {
+		tools.ForEach(func(idx, item gjson.Result) bool {
+			visit(fmt.Sprintf("tools.%d", int(idx.Int())), item)
+			return true
+		})
+	}
+	if system := gjson.GetBytes(payload, "system"); system.IsArray() {
+		system.ForEach(func(idx, item gjson.Result) bool {
+			visit(fmt.Sprintf("system.%d", int(idx.Int())), item)
+			return true
+		})
+	}
+	if messages := gjson.GetBytes(payload, "messages"); messages.IsArray() {
+		messages.ForEach(func(msgIdx, message gjson.Result) bool {
+			content := message.Get("content")
+			if !content.IsArray() {
+				return true
+			}
+			content.ForEach(func(itemIdx, item gjson.Result) bool {
+				visit(fmt.Sprintf("messages.%d.content.%d", int(msgIdx.Int()), int(itemIdx.Int())), item)
+				return true
+			})
+			return true
+		})
+	}
+}
+
+func shouldEnsureCacheControl(payload []byte, cloaked, confirmedClaudeCode bool) bool {
+	return !confirmedClaudeCode && (cloaked || countCacheControls(payload) == 0)
 }
 
 func countCacheControls(payload []byte) int {
@@ -1181,64 +1311,64 @@ func enforceCacheControlLimit(payload []byte, maxBlocks int) []byte {
 	return payload
 }
 
-// injectMessagesCacheControl adds cache_control to the second-to-last user turn for multi-turn caching.
-// Per Anthropic docs: "Place cache_control on the second-to-last User message to let the model reuse the earlier cache."
-// This enables caching of conversation history, which is especially beneficial for long multi-turn conversations.
-// Only adds cache_control if:
-// - There are at least 2 user turns in the conversation
-// - No message content already has cache_control
+// injectMessagesCacheControl adds cache_control to the message the native rolling
+// breakpoint selector would pick. Recovered from the marker selector in the
+// installed 2.1.220/2.1.221/2.1.227 binaries:
+//
+//	eligible(msg): a non-assistant turn is always eligible; an assistant turn with
+//	               string content is eligible; an assistant turn with array content
+//	               is eligible only when its last block is not thinking-like.
+//	last        := walk back from the end, skipping internal system turns and
+//	               ineligible turns.
+//	target      := (final turn is a system turn with non-empty STRING content and
+//	               last >= 0) ? final turn : last
+//
+// The final-system special case is deliberately narrow: native requires string
+// content there and writes a brand new single text block for it rather than
+// stamping the last element of an existing array. Markers on other messages must
+// not suppress this rolling write.
 func injectMessagesCacheControl(payload []byte) []byte {
 	messages := gjson.GetBytes(payload, "messages")
 	if !messages.Exists() || !messages.IsArray() {
 		return payload
 	}
 
-	// Check if ANY message content already has cache_control
-	hasCacheControlInMessages := false
-	messages.ForEach(func(_, msg gjson.Result) bool {
-		content := msg.Get("content")
-		if content.IsArray() {
-			content.ForEach(func(_, item gjson.Result) bool {
-				if item.Get("cache_control").Exists() {
-					hasCacheControlInMessages = true
-					return false
-				}
-				return true
-			})
+	lastMessageIndex := int(messages.Get("#").Int()) - 1
+	lastEligibleIndex := -1
+	messages.ForEach(func(index gjson.Result, message gjson.Result) bool {
+		if role := message.Get("role").String(); role != "user" && role != "assistant" {
+			return true
 		}
-		return !hasCacheControlInMessages
-	})
-	if hasCacheControlInMessages {
-		return payload
-	}
-
-	// Find all user message indices
-	var userMsgIndices []int
-	messages.ForEach(func(index gjson.Result, msg gjson.Result) bool {
-		if msg.Get("role").String() == "user" {
-			userMsgIndices = append(userMsgIndices, int(index.Int()))
+		if claudeMessageEligibleForRollingCache(message) {
+			lastEligibleIndex = int(index.Int())
 		}
 		return true
 	})
 
-	// Need at least 2 user turns to cache the second-to-last
-	if len(userMsgIndices) < 2 {
+	if lastEligibleIndex >= 0 {
+		finalMessage := messages.Get(fmt.Sprintf("%d", lastMessageIndex))
+		finalContent := finalMessage.Get("content")
+		if finalMessage.Get("role").String() == "system" &&
+			finalContent.Type == gjson.String &&
+			strings.TrimSpace(finalContent.String()) != "" {
+			return injectClaudeFinalSystemCacheControl(payload, lastMessageIndex, finalContent.String())
+		}
+	}
+	if lastEligibleIndex < 0 {
 		return payload
 	}
 
-	// Get the second-to-last user message index
-	secondToLastUserIdx := userMsgIndices[len(userMsgIndices)-2]
-
-	// Get the content of this message
-	contentPath := fmt.Sprintf("messages.%d.content", secondToLastUserIdx)
+	contentPath := fmt.Sprintf("messages.%d.content", lastEligibleIndex)
 	content := gjson.GetBytes(payload, contentPath)
+	if messageContentHasCacheControl(content) {
+		return payload
+	}
 
 	if content.IsArray() {
-		// Add cache_control to the last content block of this message
 		contentCount := int(content.Get("#").Int())
 		if contentCount > 0 {
-			cacheControlPath := fmt.Sprintf("messages.%d.content.%d.cache_control", secondToLastUserIdx, contentCount-1)
-			result, err := sjson.SetBytes(payload, cacheControlPath, map[string]string{"type": "ephemeral"})
+			cacheControlPath := fmt.Sprintf("messages.%d.content.%d.cache_control", lastEligibleIndex, contentCount-1)
+			result, err := sjson.SetBytes(payload, cacheControlPath, claudeCodeCacheControl)
 			if err != nil {
 				log.Warnf("failed to inject cache_control into messages: %v", err)
 				return payload
@@ -1246,18 +1376,8 @@ func injectMessagesCacheControl(payload []byte) []byte {
 			payload = result
 		}
 	} else if content.Type == gjson.String {
-		// Convert string content to array with cache_control
-		text := content.String()
-		newContent := []map[string]interface{}{
-			{
-				"type": "text",
-				"text": text,
-				"cache_control": map[string]string{
-					"type": "ephemeral",
-				},
-			},
-		}
-		result, err := sjson.SetBytes(payload, contentPath, newContent)
+		newContent := "[" + buildTextBlock(content.String(), &claudeCodeCacheControl) + "]"
+		result, err := sjson.SetRawBytes(payload, contentPath, []byte(newContent))
 		if err != nil {
 			log.Warnf("failed to inject cache_control into message string content: %v", err)
 			return payload
@@ -1266,6 +1386,58 @@ func injectMessagesCacheControl(payload []byte) []byte {
 	}
 
 	return payload
+}
+
+// claudeMessageEligibleForRollingCache reports whether the native selector would
+// consider this user/assistant turn as a rolling breakpoint host. Native rejects
+// an assistant turn whose last content block is thinking-like, because a thinking
+// block cannot host the marker.
+func claudeMessageEligibleForRollingCache(message gjson.Result) bool {
+	content := message.Get("content")
+	if content.Type == gjson.String {
+		return true
+	}
+	if !content.IsArray() || content.Get("#").Int() == 0 {
+		return false
+	}
+	if message.Get("role").String() != "assistant" {
+		return true
+	}
+	lastBlock := content.Get(fmt.Sprintf("%d", content.Get("#").Int()-1))
+	switch lastBlock.Get("type").String() {
+	case "thinking", "redacted_thinking":
+		return false
+	default:
+		return true
+	}
+}
+
+// injectClaudeFinalSystemCacheControl reproduces the native final-system special
+// case, which replaces the string content with a single marked text block.
+func injectClaudeFinalSystemCacheControl(payload []byte, messageIndex int, text string) []byte {
+	contentPath := fmt.Sprintf("messages.%d.content", messageIndex)
+	newContent := "[" + buildTextBlock(text, &claudeCodeCacheControl) + "]"
+	result, err := sjson.SetRawBytes(payload, contentPath, []byte(newContent))
+	if err != nil {
+		log.Warnf("failed to inject cache_control into trailing system message: %v", err)
+		return payload
+	}
+	return result
+}
+
+func messageContentHasCacheControl(content gjson.Result) bool {
+	if content.IsArray() {
+		found := false
+		content.ForEach(func(_, item gjson.Result) bool {
+			if item.Get("cache_control").Exists() {
+				found = true
+				return false
+			}
+			return true
+		})
+		return found
+	}
+	return false
 }
 
 // injectToolsCacheControl adds cache_control to the last non-deferred tool in the tools array.
@@ -1295,7 +1467,7 @@ func injectToolsCacheControl(payload []byte) []byte {
 	}
 
 	lastToolPath := fmt.Sprintf("tools.%d.cache_control", lastEligibleToolIndex)
-	result, err := sjson.SetBytes(payload, lastToolPath, map[string]string{"type": "ephemeral"})
+	result, err := sjson.SetBytes(payload, lastToolPath, claudeCodeCacheControl)
 	if err != nil {
 		log.Warnf("failed to inject cache_control into tools array: %v", err)
 		return payload
@@ -1334,26 +1506,22 @@ func injectSystemCacheControl(payload []byte) []byte {
 
 		// Add cache_control to the last system element
 		lastSystemPath := fmt.Sprintf("system.%d.cache_control", count-1)
-		result, err := sjson.SetBytes(payload, lastSystemPath, map[string]string{"type": "ephemeral"})
+		result, err := sjson.SetBytes(payload, lastSystemPath, claudeCodeCacheControl)
 		if err != nil {
 			log.Warnf("failed to inject cache_control into system array: %v", err)
 			return payload
 		}
 		payload = result
 	} else if system.Type == gjson.String {
-		// Convert string system prompt to array with cache_control
-		// "system": "text" -> "system": [{"type": "text", "text": "text", "cache_control": {"type": "ephemeral"}}]
-		text := system.String()
-		newSystem := []map[string]interface{}{
-			{
-				"type": "text",
-				"text": text,
-				"cache_control": map[string]string{
-					"type": "ephemeral",
-				},
-			},
+		// Empty/blank strings are not cacheable hosts. claudePayloadHasCacheableSystem
+		// already treats them as missing so tools can cover the prefix; converting them
+		// here would create a second, useless breakpoint on whitespace.
+		if strings.TrimSpace(system.String()) == "" {
+			return payload
 		}
-		result, err := sjson.SetBytes(payload, "system", newSystem)
+		// Convert string system prompt to an ordered native text block.
+		newSystem := "[" + buildTextBlock(system.String(), &claudeCodeCacheControl) + "]"
+		result, err := sjson.SetRawBytes(payload, "system", []byte(newSystem))
 		if err != nil {
 			log.Warnf("failed to inject cache_control into system string: %v", err)
 			return payload

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -108,7 +108,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
 	body = disableThinkingIfToolChoiceForced(body)
 	body = reconcileClaudeCodeContextManagement(body, contextManagementState)
-	body = normalizeClaudeSamplingForUpstream(body)
+	body = normalizeClaudeSamplingForUpstream(body, confirmedClaudeCode)
 
 	// Default cache_control for translated entrypoints (Responses/Chat/Gemini) and other
 	// non-native callers. Confirmed native Claude Code owns its marker placement and must
@@ -145,7 +145,12 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body = normalizeCacheControlTTL(body)
 	// Payload rules and other request processing may rewrite stream. Keep the
 	// upstream body, transport headers, and response parser on one authority.
-	body = helps.SetBoolIfDifferent(body, "stream", upstreamStream)
+	// Native non-stream Haiku helper requests omit stream rather than sending
+	// false, so preserve that measured wire shape when the transport agrees.
+	streamField := gjson.GetBytes(body, "stream")
+	if !claudeCodeDetection.HelperProfile || streamField.Exists() || upstreamStream {
+		body = helps.SetBoolIfDifferent(body, "stream", upstreamStream)
+	}
 
 	// Extract betas from body and convert to header
 	var extraBetas []string
@@ -166,7 +171,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	}
 	cchBilling := ""
 	if cchSigning {
-		cchBilling = claudeCCHFallbackBillingHeader(ctx, e.cfg, bodyForUpstream, claudeCodeDetection.Entrypoint)
+		if !claudeCodeDetection.HelperProfile || claudeBodyNeedsBillingFallback(bodyForUpstream) {
+			cchBilling = claudeCCHFallbackBillingHeader(ctx, e.cfg, bodyForUpstream, claudeCodeDetection.Entrypoint)
+		}
 		bodyForUpstream, err = finalizeAnthropicMessagesBodyCCH(bodyForUpstream, cchBilling)
 		if err != nil {
 			return resp, fmt.Errorf("finalize Claude CCH: %w", err)
@@ -177,7 +184,19 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if err != nil {
 		return resp, err
 	}
-	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, upstreamStream, extraBetas, bodyForUpstream, e.cfg, incomingHeaders, confirmedClaudeCode && !cloaked, claudeSessionID); errHeaders != nil {
+	if errHeaders := applyClaudeHeadersWithNativeProfile(
+		httpReq,
+		auth,
+		apiKey,
+		upstreamStream,
+		extraBetas,
+		bodyForUpstream,
+		e.cfg,
+		incomingHeaders,
+		confirmedClaudeCode && !cloaked,
+		claudeCodeDetection.HelperProfile,
+		claudeSessionID,
+	); errHeaders != nil {
 		return resp, errHeaders
 	}
 	fastRequest := isAnthropicUpstreamBase(baseURL) && claudeRequestIsFast(httpReq, bodyForUpstream)

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -110,8 +110,14 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body = reconcileClaudeCodeContextManagement(body, contextManagementState)
 	body = normalizeClaudeSamplingForUpstream(body)
 
-	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
-	if countCacheControls(body) == 0 {
+	// Default cache_control for translated entrypoints (Responses/Chat/Gemini) and other
+	// non-native callers. Confirmed native Claude Code owns its marker placement and must
+	// not be rewritten. Cloaked requests always run section-independent ensure so cloaking's
+	// first-user marker cannot suppress system/latest-user breakpoints.
+	// cloaked and confirmedClaudeCode are mutually exclusive: resolveClaudeWirePolicy
+	// forces Cloak off for a confirmed native client.
+	cpaOwnsCacheControl := shouldEnsureCacheControl(body, cloaked, confirmedClaudeCode)
+	if cpaOwnsCacheControl {
 		body = ensureCacheControl(body)
 	}
 
@@ -119,6 +125,20 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	// Cloaking and ensureCacheControl may push the total over 4 when the client
 	// already sends multiple cache_control blocks.
 	body = enforceCacheControlLimit(body, 4)
+
+	// Native selects the 1h cache pool only for OAuth credentials and pairs it with
+	// extended-cache-ttl-2025-04-11, which claudeCodeCLIBetas emits on exactly the
+	// same credential condition. Upgrading after placement is settled mirrors the
+	// native ttl helper.
+	//
+	// This runs only while CPA owns placement, and it then owns the ttl of every
+	// breakpoint it can reach: a marker carrying no ttl is the wire default, not an
+	// opt-in to 5m, so a cloaked caller's bare {"type":"ephemeral"} is upgraded too.
+	// Only a ttl the caller wrote out explicitly survives, because
+	// upgradeClaudeCacheControlTTL skips any block that already has one.
+	if cpaOwnsCacheControl && claudeCredentialUsesOAuth(auth, apiKey) {
+		body = upgradeClaudeCacheControlTTL(body, claudeCacheControlTTL1h)
+	}
 
 	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
 	// A 1h-TTL block must not appear after a 5m-TTL block in evaluation order (tools→system→messages).

--- a/internal/runtime/executor/claude_executor_native_helper_test.go
+++ b/internal/runtime/executor/claude_executor_native_helper_test.go
@@ -1,0 +1,288 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	claudeNativeHelperSessionID = "11111111-2222-4333-8444-555555555555"
+	claudeNativeHelperUserID    = `{"device_id":"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","account_uuid":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","session_id":"11111111-2222-4333-8444-555555555555"}`
+	claudeNativeHelperCoreBetas = "oauth-2025-04-20,interleaved-thinking-2025-05-14,redact-thinking-2026-02-12,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05"
+)
+
+func claudeNativeHelperHeaders(betas, compression string, structured bool) http.Header {
+	headers := http.Header{
+		"Accept":            {"application/json"},
+		"Accept-Encoding":   {compression},
+		"Content-Type":      {"application/json"},
+		"User-Agent":        {"claude-cli/2.1.220 (external, cli)"},
+		"X-App":             {"cli"},
+		"Anthropic-Beta":    {betas},
+		"Anthropic-Version": {"2023-06-01"},
+		"Anthropic-Dangerous-Direct-Browser-Access": {"true"},
+		"X-Claude-Code-Session-Id":                  {claudeNativeHelperSessionID},
+		"X-Client-Request-Id":                       {"66666666-7777-4888-8999-aaaaaaaaaaaa"},
+		"X-Stainless-Lang":                          {"js"},
+		"X-Stainless-Runtime":                       {"node"},
+		"X-Stainless-Package-Version":               {"0.94.0"},
+		"X-Stainless-Runtime-Version":               {"v26.3.0"},
+		"X-Stainless-OS":                            {"MacOS"},
+		"X-Stainless-Arch":                          {"arm64"},
+		"X-Stainless-Retry-Count":                   {"0"},
+		"X-Stainless-Timeout":                       {"600"},
+	}
+	if structured {
+		headers.Set("X-Stainless-Async", "async")
+	}
+	canonical := make(http.Header, len(headers))
+	for name, values := range headers {
+		for _, value := range values {
+			canonical.Add(name, value)
+		}
+	}
+	return canonical
+}
+
+func claudeNativeHelperOAuthAuth(baseURL string) *cliproxyauth.Auth {
+	return &cliproxyauth.Auth{
+		ID: "native-helper-oauth",
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-native-helper",
+			"base_url": baseURL,
+		},
+		Metadata: claudeOAuthTestMetadata(),
+	}
+}
+
+func TestApplyClaudeHeadersPreservesAsyncOnlyForConfirmedNative(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		confirmed bool
+		wantAsync string
+	}{
+		{name: "confirmed native", confirmed: true, wantAsync: "async"},
+		{name: "unconfirmed caller", confirmed: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request, errRequest := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages?beta=true", nil)
+			if errRequest != nil {
+				t.Fatal(errRequest)
+			}
+			incoming := http.Header{"X-Stainless-Async": {"async"}}
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-api-key"}}
+			if errHeaders := applyClaudeHeaders(
+				request,
+				auth,
+				"test-api-key",
+				true,
+				nil,
+				[]byte(`{"model":"claude-haiku-4-5-20251001"}`),
+				&config.Config{},
+				incoming,
+				test.confirmed,
+				claudeNativeHelperSessionID,
+			); errHeaders != nil {
+				t.Fatalf("applyClaudeHeaders() error = %v", errHeaders)
+			}
+			if got := request.Header.Get("X-Stainless-Async"); got != test.wantAsync {
+				t.Fatalf("X-Stainless-Async = %q, want %q", got, test.wantAsync)
+			}
+		})
+	}
+}
+
+func TestClaudeExecutorMinimalNativeHelperPreservesMarkerlessWire(t *testing.T) {
+	var upstreamBody []byte
+	var upstreamHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamBody, _ = io.ReadAll(r.Body)
+		upstreamHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude-haiku-4-5-20251001","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	payload := []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"helper probe"}],"metadata":{"user_id":"` + strings.ReplaceAll(claudeNativeHelperUserID, `"`, `\"`) + `"}}`)
+	headers := claudeNativeHelperHeaders(claudeNativeHelperCoreBetas, "gzip", false)
+	executor := NewClaudeExecutor(&config.Config{})
+	_, errExecute := executor.Execute(context.Background(), claudeNativeHelperOAuthAuth(server.URL), cliproxyexecutor.Request{
+		Model:   "claude-haiku-4-5-20251001",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FormatClaude,
+		OriginalRequest: payload,
+		Headers:         headers,
+	})
+	if errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+
+	for _, path := range []string{"system", "stream", "context_management", "output_config"} {
+		if got := gjson.GetBytes(upstreamBody, path); got.Exists() {
+			t.Fatalf("helper body unexpectedly contains %s=%s: %s", path, got.Raw, upstreamBody)
+		}
+	}
+	if bytes.Contains(upstreamBody, []byte(`"cache_control"`)) {
+		t.Fatalf("helper body unexpectedly contains cache_control: %s", upstreamBody)
+	}
+	if got := gjson.GetBytes(upstreamBody, "messages.0.content").String(); got != "helper probe" {
+		t.Fatalf("messages.0.content = %q, want preserved string", got)
+	}
+	if !bytes.HasPrefix(upstreamBody, []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":`)) {
+		t.Fatalf("helper top-level order changed: %s", upstreamBody)
+	}
+	assertClaudeNativeHelperHeaders(t, upstreamHeaders, headers)
+}
+
+func TestClaudeExecutorStructuredNativeHelperPreservesStreamProfile(t *testing.T) {
+	var upstreamBody []byte
+	var upstreamHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamBody, _ = io.ReadAll(r.Body)
+		upstreamHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-haiku-4-5-20251001\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":1,\"output_tokens\":0}}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+	}))
+	defer server.Close()
+
+	betas := claudeNativeHelperCoreBetas + ",structured-outputs-2025-12-15"
+	payload := []byte(`{"model":"claude-haiku-4-5-20251001","messages":[{"role":"user","content":[{"type":"text","text":"helper probe"}]}],"system":[{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.220; cc_entrypoint=cli; cch=00000;"},{"type":"text","text":"You are Claude Code, Anthropic's official CLI for Claude."},{"type":"text","text":"Return a short title."}],"tools":[],"metadata":{"user_id":"` + strings.ReplaceAll(claudeNativeHelperUserID, `"`, `\"`) + `"},"max_tokens":32000,"thinking":{"type":"disabled"},"temperature":1,"output_config":{"format":{"type":"json_schema","schema":{"type":"object","properties":{"title":{"type":"string"}},"required":["title"],"additionalProperties":false}}},"stream":true}`)
+	headers := claudeNativeHelperHeaders(betas, "gzip, deflate, br, zstd", true)
+	executor := NewClaudeExecutor(&config.Config{})
+	result, errStream := executor.ExecuteStream(context.Background(), claudeNativeHelperOAuthAuth(server.URL), cliproxyexecutor.Request{
+		Model:   "claude-haiku-4-5-20251001",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FormatClaude,
+		OriginalRequest: payload,
+		Headers:         headers,
+	})
+	if errStream != nil {
+		t.Fatalf("ExecuteStream() error = %v", errStream)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+	}
+
+	if got := gjson.GetBytes(upstreamBody, "system.#").Int(); got != 3 {
+		t.Fatalf("system block count = %d, want native 3: %s", got, upstreamBody)
+	}
+	if !bytes.HasPrefix(upstreamBody, []byte(`{"model":"claude-haiku-4-5-20251001","messages":`)) {
+		t.Fatalf("structured helper top-level order changed: %s", upstreamBody)
+	}
+	for _, path := range []string{"context_management", "output_config.effort"} {
+		if got := gjson.GetBytes(upstreamBody, path); got.Exists() {
+			t.Fatalf("structured helper unexpectedly contains %s=%s: %s", path, got.Raw, upstreamBody)
+		}
+	}
+	if bytes.Contains(upstreamBody, []byte(`"cache_control"`)) {
+		t.Fatalf("structured helper unexpectedly contains cache_control: %s", upstreamBody)
+	}
+	if got := gjson.GetBytes(upstreamBody, "stream").Bool(); !got {
+		t.Fatalf("structured helper stream = false, want true: %s", upstreamBody)
+	}
+	if got := gjson.GetBytes(upstreamBody, "system.0.text").String(); strings.Contains(got, "cch=00000") || !strings.Contains(got, " cch=") {
+		t.Fatalf("structured helper billing CCH was not re-signed: %q", got)
+	}
+	assertClaudeNativeHelperHeaders(t, upstreamHeaders, headers)
+}
+
+func assertClaudeNativeHelperHeaders(t *testing.T, got, incoming http.Header) {
+	t.Helper()
+	if got.Get("Anthropic-Beta") != incoming.Get("Anthropic-Beta") {
+		t.Fatalf("Anthropic-Beta = %q, want exact native helper profile %q", got.Get("Anthropic-Beta"), incoming.Get("Anthropic-Beta"))
+	}
+	if strings.Contains(got.Get("Anthropic-Beta"), claudeExtendedCacheTTLBeta) || strings.Contains(got.Get("Anthropic-Beta"), claudeCodeBeta) {
+		t.Fatalf("Anthropic-Beta gained standard Claude Code cache betas: %q", got.Get("Anthropic-Beta"))
+	}
+	for _, name := range []string{
+		"Accept",
+		"Accept-Encoding",
+		"Content-Type",
+		"User-Agent",
+		"X-App",
+		"Anthropic-Version",
+		"Anthropic-Dangerous-Direct-Browser-Access",
+		"X-Claude-Code-Session-Id",
+		"X-Client-Request-Id",
+		"X-Stainless-Async",
+		"X-Stainless-Lang",
+		"X-Stainless-Runtime",
+		"X-Stainless-Package-Version",
+		"X-Stainless-Runtime-Version",
+		"X-Stainless-OS",
+		"X-Stainless-Arch",
+		"X-Stainless-Retry-Count",
+		"X-Stainless-Timeout",
+	} {
+		gotValue := claudeNativeHelperHeaderValue(got, name)
+		wantValue := claudeNativeHelperHeaderValue(incoming, name)
+		if gotValue != wantValue {
+			t.Fatalf("%s = %q, want preserved %q", name, gotValue, wantValue)
+		}
+	}
+}
+
+func claudeNativeHelperHeaderValue(headers http.Header, name string) string {
+	for key, values := range headers {
+		if strings.EqualFold(key, name) {
+			return strings.Join(values, ",")
+		}
+	}
+	return ""
+}
+
+// The measured minimal helper has no system field at all, so injecting a billing
+// header would itself be the deviation. Keying the fallback on system presence means
+// that if a payload rule later attaches a system prompt, the billing header and its
+// CCH come back instead of shipping a system block native would never send unsigned.
+func TestClaudeBodyNeedsBillingFallbackTracksSystemPresence(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "measured minimal helper has no system",
+			body: `{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"probe"}]}`,
+			want: false,
+		},
+		{
+			name: "structured helper carries its own billing header",
+			body: `{"system":[{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.220; cc_entrypoint=cli; cch=00000;"}]}`,
+			want: true,
+		},
+		{
+			name: "pipeline attached a system prompt without a billing header",
+			body: `{"system":[{"type":"text","text":"injected by a payload rule"}]}`,
+			want: true,
+		},
+		{
+			name: "string system prompt also needs the fallback",
+			body: `{"system":"injected by a payload rule"}`,
+			want: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := claudeBodyNeedsBillingFallback([]byte(test.body)); got != test.want {
+				t.Fatalf("claudeBodyNeedsBillingFallback() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -369,15 +369,49 @@ func disableThinkingIfToolChoiceForced(body []byte) []byte {
 }
 
 // normalizeClaudeSamplingForUpstream keeps Anthropic message requests valid.
-func normalizeClaudeSamplingForUpstream(body []byte) []byte {
-	body, _ = sjson.DeleteBytes(body, "temperature")
-	body, _ = sjson.DeleteBytes(body, "top_p")
-
-	thinkingType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "thinking.type").String()))
-	switch thinkingType {
+//
+// Translated and cloaked callers keep the conservative normalization: their
+// sampling knobs come from a protocol that was not written for Anthropic, and
+// Anthropic rejects several combinations outright, so neither temperature nor
+// top_p is worth forwarding.
+//
+// A confirmed native Claude Code client owns its own wire, exactly like
+// cache_control placement. The measured structured Haiku helper sends
+// "temperature":1 and claudeCodeHelperShapeStructured keys on it, so stripping
+// it would emit a shape no native client ever produces. Keep what the caller
+// sent and drop only what Anthropic actually rejects (verified live):
+//   - thinking active: temperature must be 1, top_p must be >= 0.95, top_k unset
+//   - otherwise: temperature and top_p cannot both be specified
+func normalizeClaudeSamplingForUpstream(body []byte, nativeOwned bool) []byte {
+	thinkingActive := false
+	switch strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "thinking.type").String())) {
 	case "enabled", "adaptive", "auto":
+		thinkingActive = true
+	}
+
+	if !nativeOwned {
+		body, _ = sjson.DeleteBytes(body, "temperature")
 		body, _ = sjson.DeleteBytes(body, "top_p")
+		if thinkingActive {
+			body, _ = sjson.DeleteBytes(body, "top_k")
+		}
+		return body
+	}
+
+	if thinkingActive {
+		if temperature := gjson.GetBytes(body, "temperature"); temperature.Exists() && temperature.Num != 1 {
+			body, _ = sjson.DeleteBytes(body, "temperature")
+		}
+		if topP := gjson.GetBytes(body, "top_p"); topP.Exists() && topP.Num < 0.95 {
+			body, _ = sjson.DeleteBytes(body, "top_p")
+		}
 		body, _ = sjson.DeleteBytes(body, "top_k")
+		return body
+	}
+	// Anthropic accepts either one but not both; temperature is the knob native
+	// Claude Code actually sends, so top_p is the one that gives way.
+	if gjson.GetBytes(body, "temperature").Exists() && gjson.GetBytes(body, "top_p").Exists() {
+		body, _ = sjson.DeleteBytes(body, "top_p")
 	}
 	return body
 }
@@ -549,6 +583,34 @@ func claudeCredentialUsesOAuth(auth *cliproxyauth.Auth, apiKey string) bool {
 }
 
 func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string, stream bool, extraBetas []string, body []byte, cfg *config.Config, incomingHeaders http.Header, confirmedClaudeCode bool, sessionIDs ...string) error {
+	return applyClaudeHeadersWithNativeProfile(
+		r,
+		auth,
+		apiKey,
+		stream,
+		extraBetas,
+		body,
+		cfg,
+		incomingHeaders,
+		confirmedClaudeCode,
+		false,
+		sessionIDs...,
+	)
+}
+
+func applyClaudeHeadersWithNativeProfile(
+	r *http.Request,
+	auth *cliproxyauth.Auth,
+	apiKey string,
+	stream bool,
+	extraBetas []string,
+	body []byte,
+	cfg *config.Config,
+	incomingHeaders http.Header,
+	confirmedClaudeCode bool,
+	helperProfile bool,
+	sessionIDs ...string,
+) error {
 	if r == nil {
 		return nil
 	}
@@ -598,7 +660,9 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 	}
 	if confirmedClaudeCode && incomingBetas != "" {
 		baseBetas = incomingBetas
-		if oauthToken {
+		// Measured Haiku helper requests already carry the exact credential
+		// beta profile and intentionally omit extended-cache-ttl.
+		if oauthToken && !helperProfile {
 			if countTokens {
 				baseBetas = withClaudeCountTokensOAuthBeta(baseBetas)
 			} else {
@@ -657,6 +721,11 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 	identityHeader("X-Stainless-Retry-Count", "0")
 	identityHeader("X-Stainless-Runtime", "node")
 	identityHeader("X-Stainless-Lang", "js")
+	// Native async SDK helpers add this header independently of body.stream.
+	// Preserve it only after the complete native-client detector succeeds.
+	if confirmedClaudeCode && incomingHeaders.Get("X-Stainless-Async") == "async" {
+		r.Header.Set("X-Stainless-Async", "async")
+	}
 	// Claude Code omits X-Stainless-Timeout on count_tokens; only a confirmed
 	// native client that sent one of its own keeps it there.
 	if !countTokens {
@@ -687,18 +756,24 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 		identityHeader("X-Claude-Code-Session-Id", sessionID)
 	}
 	// Per-request UUID, matches Claude Code's x-client-request-id for first-party API.
-	if isAnthropicBase {
+	// identityHeader prefers the incoming value for a confirmed client, so a confirmed
+	// helper keeps its own native request ID and this fresh UUID only covers a caller
+	// that sent none. Helpers opt in on custom gateways too.
+	if isAnthropicBase || helperProfile {
 		identityHeader("x-client-request-id", uuid.New().String())
 	}
 	r.Header.Set("Connection", "keep-alive")
-	// Claude Code negotiates transport identically for streaming and non-streaming
-	// requests: Accept stays application/json and full compression is offered even
-	// when the body sets stream:true, because Anthropic selects SSE from the body
-	// rather than from Accept. Verified across every captured 2.1.220 stream.
-	// Forcing text/event-stream plus identity here would otherwise mark every
-	// streaming request, which is nearly all traffic. decodeResponseBody already
-	// wraps the success path, so a compressed SSE body is decoded transparently.
+	// Regular Claude Code requests negotiate transport identically for streaming
+	// and non-streaming requests. Measured Haiku helpers are the exception: their
+	// minimal non-stream request offers gzip only, while the structured streaming
+	// helper offers the full compression set. Confirmed helpers preserve the
+	// incoming native values.
 	applyTransportNegotiation := func() {
+		if helperProfile {
+			identityHeader("Accept", "application/json")
+			identityHeader("Accept-Encoding", "gzip")
+			return
+		}
 		if stream && !isAnthropicBase {
 			// Other Anthropic-compatible upstreams (Kimi, custom gateways) may select
 			// SSE from Accept and need not compress predictably, so they keep the

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -540,6 +540,14 @@ func isZlibHeader(header []byte) bool {
 	return cmf&0x0f == 8 && cmf>>4 <= 7 && (uint16(cmf)<<8|uint16(flg))%31 == 0
 }
 
+// claudeCredentialUsesOAuth classifies the selected upstream credential. It is the
+// single authority for every decision that has to agree with the OAuth beta
+// profile, including the extended-cache-ttl beta and the matching body cache ttl.
+func claudeCredentialUsesOAuth(auth *cliproxyauth.Auth, apiKey string) bool {
+	hasAPIKeyAttr := auth != nil && auth.Attributes != nil && strings.TrimSpace(auth.Attributes["api_key"]) != ""
+	return isClaudeOAuthToken(apiKey) || !hasAPIKeyAttr
+}
+
 func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string, stream bool, extraBetas []string, body []byte, cfg *config.Config, incomingHeaders http.Header, confirmedClaudeCode bool, sessionIDs ...string) error {
 	if r == nil {
 		return nil
@@ -556,8 +564,7 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 		hd = cfg.ClaudeHeaderDefaults
 	}
 
-	hasAPIKeyAttr := auth != nil && auth.Attributes != nil && strings.TrimSpace(auth.Attributes["api_key"]) != ""
-	oauthToken := isClaudeOAuthToken(apiKey) || !hasAPIKeyAttr
+	oauthToken := claudeCredentialUsesOAuth(auth, apiKey)
 	useAPIKey := !oauthToken
 	isAnthropicBase := isAnthropicUpstreamURL(r.URL)
 	if isAnthropicBase && useAPIKey {

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -114,13 +114,33 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body = reconcileClaudeCodeContextManagement(body, contextManagementState)
 	body = normalizeClaudeSamplingForUpstream(body)
 
-	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
-	if countCacheControls(body) == 0 {
+	// Default cache_control for translated entrypoints (Responses/Chat/Gemini) and other
+	// non-native callers. Confirmed native Claude Code owns its marker placement and must
+	// not be rewritten. Cloaked requests always run section-independent ensure so cloaking's
+	// first-user marker cannot suppress system/latest-user breakpoints.
+	// cloaked and confirmedClaudeCode are mutually exclusive: resolveClaudeWirePolicy
+	// forces Cloak off for a confirmed native client.
+	cpaOwnsCacheControl := shouldEnsureCacheControl(body, cloaked, confirmedClaudeCode)
+	if cpaOwnsCacheControl {
 		body = ensureCacheControl(body)
 	}
 
 	// Enforce Anthropic's cache_control block limit (max 4 breakpoints per request).
 	body = enforceCacheControlLimit(body, 4)
+
+	// Native selects the 1h cache pool only for OAuth credentials and pairs it with
+	// extended-cache-ttl-2025-04-11, which claudeCodeCLIBetas emits on exactly the
+	// same credential condition. Upgrading after placement is settled mirrors the
+	// native ttl helper.
+	//
+	// This runs only while CPA owns placement, and it then owns the ttl of every
+	// breakpoint it can reach: a marker carrying no ttl is the wire default, not an
+	// opt-in to 5m, so a cloaked caller's bare {"type":"ephemeral"} is upgraded too.
+	// Only a ttl the caller wrote out explicitly survives, because
+	// upgradeClaudeCacheControlTTL skips any block that already has one.
+	if cpaOwnsCacheControl && claudeCredentialUsesOAuth(auth, apiKey) {
+		body = upgradeClaudeCacheControlTTL(body, claudeCacheControlTTL1h)
+	}
 
 	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
 	body = normalizeCacheControlTTL(body)

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -112,7 +112,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
 	body = disableThinkingIfToolChoiceForced(body)
 	body = reconcileClaudeCodeContextManagement(body, contextManagementState)
-	body = normalizeClaudeSamplingForUpstream(body)
+	body = normalizeClaudeSamplingForUpstream(body, confirmedClaudeCode)
 
 	// Default cache_control for translated entrypoints (Responses/Chat/Gemini) and other
 	// non-native callers. Confirmed native Claude Code owns its marker placement and must
@@ -164,7 +164,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	}
 	cchBilling := ""
 	if cchSigning {
-		cchBilling = claudeCCHFallbackBillingHeader(ctx, e.cfg, bodyForUpstream, claudeCodeDetection.Entrypoint)
+		if !claudeCodeDetection.HelperProfile || claudeBodyNeedsBillingFallback(bodyForUpstream) {
+			cchBilling = claudeCCHFallbackBillingHeader(ctx, e.cfg, bodyForUpstream, claudeCodeDetection.Entrypoint)
+		}
 		bodyForUpstream, err = finalizeAnthropicMessagesBodyCCH(bodyForUpstream, cchBilling)
 		if err != nil {
 			return nil, fmt.Errorf("finalize Claude CCH: %w", err)
@@ -175,7 +177,19 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	if err != nil {
 		return nil, err
 	}
-	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, true, extraBetas, bodyForUpstream, e.cfg, incomingHeaders, confirmedClaudeCode && !cloaked, claudeSessionID); errHeaders != nil {
+	if errHeaders := applyClaudeHeadersWithNativeProfile(
+		httpReq,
+		auth,
+		apiKey,
+		true,
+		extraBetas,
+		bodyForUpstream,
+		e.cfg,
+		incomingHeaders,
+		confirmedClaudeCode && !cloaked,
+		claudeCodeDetection.HelperProfile,
+		claudeSessionID,
+	); errHeaders != nil {
 		return nil, errHeaders
 	}
 	fastRequest := isAnthropicUpstreamBase(baseURL) && claudeRequestIsFast(httpReq, bodyForUpstream)

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -4489,7 +4489,7 @@ func TestApplyCloaking_PreservesConfiguredStrictModeAndSensitiveWordsWhenModeOmi
 
 func TestNormalizeClaudeSamplingForUpstream_RemovesTemperature(t *testing.T) {
 	payload := []byte(`{"temperature":0,"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}}`)
-	out := normalizeClaudeSamplingForUpstream(payload)
+	out := normalizeClaudeSamplingForUpstream(payload, false)
 
 	if gjson.GetBytes(out, "temperature").Exists() {
 		t.Fatalf("temperature should be removed")
@@ -4498,7 +4498,7 @@ func TestNormalizeClaudeSamplingForUpstream_RemovesTemperature(t *testing.T) {
 
 func TestNormalizeClaudeSamplingForUpstream_RemovesTemperatureWithThinkingEnabled(t *testing.T) {
 	payload := []byte(`{"temperature":0.2,"thinking":{"type":"enabled","budget_tokens":2048}}`)
-	out := normalizeClaudeSamplingForUpstream(payload)
+	out := normalizeClaudeSamplingForUpstream(payload, false)
 
 	if gjson.GetBytes(out, "temperature").Exists() {
 		t.Fatalf("temperature should be removed")
@@ -4507,7 +4507,7 @@ func TestNormalizeClaudeSamplingForUpstream_RemovesTemperatureWithThinkingEnable
 
 func TestNormalizeClaudeSamplingForUpstream_RemovesTopPAndTopKForThinking(t *testing.T) {
 	payload := []byte(`{"temperature":0.2,"top_p":0.9,"top_k":40,"thinking":{"type":"adaptive"}}`)
-	out := normalizeClaudeSamplingForUpstream(payload)
+	out := normalizeClaudeSamplingForUpstream(payload, false)
 
 	if gjson.GetBytes(out, "temperature").Exists() {
 		t.Fatalf("temperature should be removed")
@@ -4522,7 +4522,7 @@ func TestNormalizeClaudeSamplingForUpstream_RemovesTopPAndTopKForThinking(t *tes
 
 func TestNormalizeClaudeSamplingForUpstream_NoThinkingRemovesTemperatureAndTopP(t *testing.T) {
 	payload := []byte(`{"temperature":0,"top_p":0.9,"top_k":40,"messages":[{"role":"user","content":"hi"}]}`)
-	out := normalizeClaudeSamplingForUpstream(payload)
+	out := normalizeClaudeSamplingForUpstream(payload, false)
 
 	if gjson.GetBytes(out, "temperature").Exists() {
 		t.Fatalf("temperature should be removed")
@@ -4538,13 +4538,109 @@ func TestNormalizeClaudeSamplingForUpstream_NoThinkingRemovesTemperatureAndTopP(
 func TestNormalizeClaudeSamplingForUpstream_AfterForcedToolChoiceRemovesTemperature(t *testing.T) {
 	payload := []byte(`{"temperature":0,"thinking":{"type":"adaptive"},"output_config":{"effort":"max"},"tool_choice":{"type":"any"}}`)
 	out := disableThinkingIfToolChoiceForced(payload)
-	out = normalizeClaudeSamplingForUpstream(out)
+	out = normalizeClaudeSamplingForUpstream(out, false)
 
 	if gjson.GetBytes(out, "thinking").Exists() {
 		t.Fatalf("thinking should be removed when tool_choice forces tool use")
 	}
 	if gjson.GetBytes(out, "temperature").Exists() {
 		t.Fatalf("temperature should be removed")
+	}
+}
+
+// The measured structured Haiku helper sends "temperature":1, and
+// claudeCodeHelperShapeStructured keys on exactly that value. Stripping it would
+// make CPA emit a shape no native client produces, so a confirmed native caller
+// must keep it.
+func TestNormalizeClaudeSamplingForUpstreamNativeKeepsMeasuredHelperTemperature(t *testing.T) {
+	// Top-level key order and values mirror the measured structured helper.
+	payload := []byte(`{"model":"claude-haiku-4-5-20251001","messages":[{"role":"user","content":[{"type":"text","text":"helper probe"}]}],"system":[{"type":"text","text":"Return a short title."}],"tools":[],"metadata":{"user_id":"u"},"max_tokens":32000,"thinking":{"type":"disabled"},"temperature":1,"output_config":{"format":{"type":"json_schema"}},"stream":true}`)
+	if got := gjson.GetBytes(payload, "temperature"); !got.Exists() || got.Num != 1 {
+		t.Fatalf("measured helper fixture should carry temperature=1, got %q", got.Raw)
+	}
+
+	out := normalizeClaudeSamplingForUpstream(payload, true)
+
+	if got := gjson.GetBytes(out, "temperature"); !got.Exists() || got.Num != 1 {
+		t.Fatalf("confirmed native must preserve the measured temperature, got %q", got.Raw)
+	}
+}
+
+// Anthropic's real constraints, verified against the live API: with thinking
+// active temperature must be 1, top_p must be >= 0.95 and top_k must be unset;
+// otherwise temperature and top_p cannot both be specified. Preserving the
+// native wire must never forward a combination that would 400.
+func TestNormalizeClaudeSamplingForUpstreamNativeDropsOnlyRejectedCombinations(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		keep    map[string]float64
+		dropped []string
+	}{
+		{
+			name:    "thinking off keeps every accepted knob",
+			payload: `{"temperature":0.5,"top_k":40}`,
+			keep:    map[string]float64{"temperature": 0.5, "top_k": 40},
+		},
+		{
+			name:    "thinking off drops top_p when temperature is also set",
+			payload: `{"temperature":0.5,"top_p":0.9}`,
+			keep:    map[string]float64{"temperature": 0.5},
+			dropped: []string{"top_p"},
+		},
+		{
+			name:    "thinking off keeps a lone top_p",
+			payload: `{"top_p":0.9}`,
+			keep:    map[string]float64{"top_p": 0.9},
+		},
+		{
+			name:    "thinking disabled is not thinking",
+			payload: `{"temperature":1,"thinking":{"type":"disabled"}}`,
+			keep:    map[string]float64{"temperature": 1},
+		},
+		{
+			name:    "thinking enabled keeps temperature 1",
+			payload: `{"temperature":1,"thinking":{"type":"enabled","budget_tokens":1024}}`,
+			keep:    map[string]float64{"temperature": 1},
+		},
+		{
+			name:    "thinking enabled drops temperature that is not 1",
+			payload: `{"temperature":0.5,"thinking":{"type":"enabled","budget_tokens":1024}}`,
+			dropped: []string{"temperature"},
+		},
+		{
+			name:    "thinking enabled keeps top_p at or above 0.95",
+			payload: `{"top_p":0.99,"thinking":{"type":"enabled","budget_tokens":1024}}`,
+			keep:    map[string]float64{"top_p": 0.99},
+		},
+		{
+			name:    "thinking enabled drops top_p below 0.95",
+			payload: `{"top_p":0.9,"thinking":{"type":"enabled","budget_tokens":1024}}`,
+			dropped: []string{"top_p"},
+		},
+		{
+			name:    "thinking enabled always drops top_k",
+			payload: `{"top_k":40,"thinking":{"type":"enabled","budget_tokens":1024}}`,
+			dropped: []string{"top_k"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := normalizeClaudeSamplingForUpstream([]byte(tc.payload), true)
+
+			for field, want := range tc.keep {
+				got := gjson.GetBytes(out, field)
+				if !got.Exists() || got.Num != want {
+					t.Fatalf("%s = %q, want %v preserved", field, got.Raw, want)
+				}
+			}
+			for _, field := range tc.dropped {
+				if got := gjson.GetBytes(out, field); got.Exists() {
+					t.Fatalf("%s = %q, want dropped because Anthropic rejects it", field, got.Raw)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -779,15 +779,21 @@ func TestClaudeExecutor_NonClaudeRequestUsesClaudeCode220CLIFingerprint(t *testi
 	if got := system[1].Get("cache_control.type").String(); got != "ephemeral" {
 		t.Fatalf("system[1].cache_control.type = %q, want ephemeral", got)
 	}
+	// This credential is an API key, and native only selects the 1h cache pool for
+	// OAuth. The body ttl therefore has to stay absent, matching the fact that
+	// claudeCodeCLIBetas does not emit extended-cache-ttl-2025-04-11 here either.
 	if system[1].Get("cache_control.ttl").Exists() {
-		t.Fatalf("system[1] unexpectedly has cache_control.ttl: %s", system[1].Raw)
+		t.Fatalf("API-key request must not carry a 1h body ttl: %s", system[1].Raw)
+	}
+	if betas := seenHeaders.Get("Anthropic-Beta"); strings.Contains(betas, claudeExtendedCacheTTLBeta) {
+		t.Fatalf("API-key request must not declare extended-cache-ttl: %s", betas)
 	}
 	content := gjson.GetBytes(seenBody, "messages.0.content").Array()
 	if len(content) != 2 {
 		t.Fatalf("messages[0].content has %d blocks, want currentDate and user text", len(content))
 	}
 	assertClaudeCodeCurrentDateBlock(t, content[0])
-	assertEphemeralUserTextBlock(t, content[1], "x")
+	assertEphemeralUserTextBlock(t, content[1], "x", "")
 
 	userID := gjson.GetBytes(seenBody, "metadata.user_id").String()
 	if !helps.IsValidUserID(userID) {
@@ -852,6 +858,77 @@ func TestClaudeExecutor_ConfirmedClaudeCodeRequestPreservesInteractiveIdentity(t
 	}
 	if got := seenHeaders.Get("Anthropic-Beta"); got != incoming.Get("Anthropic-Beta") {
 		t.Fatalf("Anthropic-Beta = %q, want preserved %q", got, incoming.Get("Anthropic-Beta"))
+	}
+}
+
+func TestClaudeExecutor_ConfirmedClaudeCodeWithoutCacheControlPreservesContent(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream bool
+	}{
+		{name: "non-stream"},
+		{name: "stream", stream: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var seenBody []byte
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				seenBody, _ = io.ReadAll(r.Body)
+				if tt.stream {
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = w.Write([]byte("event: message_stop\n" + `data: {"type":"message_stop"}` + "\n\n"))
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-opus-4-6","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+			}))
+			defer server.Close()
+
+			const sessionID = "11111111-2222-4333-8444-555555555555"
+			const userID = `{"device_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","account_uuid":"","session_id":"11111111-2222-4333-8444-555555555555"}`
+			payload := []byte(`{"model":"claude-opus-4-6","messages":[{"role":"user","content":"x"}],"metadata":{"user_id":` + fmt.Sprintf("%q", userID) + `}}`)
+			incoming := http.Header{
+				"User-Agent":               {"claude-cli/2.1.220 (external, cli)"},
+				"X-App":                    {"cli"},
+				"Anthropic-Beta":           {"claude-code-20250219"},
+				"X-Claude-Code-Session-Id": {sessionID},
+			}
+			executor := NewClaudeExecutor(&config.Config{})
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{
+				"api_key":  "key-confirmed-markerless",
+				"base_url": server.URL,
+			}}
+			req := cliproxyexecutor.Request{Model: "claude-opus-4-6", Payload: payload}
+			opts := cliproxyexecutor.Options{
+				Stream:          tt.stream,
+				SourceFormat:    sdktranslator.FormatClaude,
+				OriginalRequest: payload,
+				Headers:         incoming,
+			}
+
+			if tt.stream {
+				result, errStream := executor.ExecuteStream(context.Background(), auth, req, opts)
+				if errStream != nil {
+					t.Fatalf("ExecuteStream() error = %v", errStream)
+				}
+				for chunk := range result.Chunks {
+					if chunk.Err != nil {
+						t.Fatalf("stream chunk error = %v", chunk.Err)
+					}
+				}
+			} else if _, errExecute := executor.Execute(context.Background(), auth, req, opts); errExecute != nil {
+				t.Fatalf("Execute() error = %v", errExecute)
+			}
+
+			content := gjson.GetBytes(seenBody, "messages.0.content")
+			if content.Type != gjson.String || content.String() != "x" {
+				t.Fatalf("messages.0.content = %s, want native string content preserved; body=%s", content.Raw, seenBody)
+			}
+			if gjson.GetBytes(seenBody, "messages.0.content.0.cache_control").Exists() {
+				t.Fatalf("confirmed markerless native request received synthetic cache_control: %s", seenBody)
+			}
+		})
 	}
 }
 
@@ -973,8 +1050,8 @@ func TestClaudeExecutor_CopiedVSCodeAgentSDKHeadersWithoutMetadataAreCloaked(t *
 		t.Fatalf("messages[0].content has %d blocks, want currentDate and user text", len(content))
 	}
 	assertClaudeCodeCurrentDateBlock(t, content[0])
-	assertEphemeralUserTextBlock(t, content[1], "x")
-	assertClaudeMidConversationSystemMessage(t, seenBody, 1, "spoofed-system")
+	assertEphemeralUserTextBlock(t, content[1], "x", "")
+	assertClaudeMidConversationSystemMessage(t, seenBody, 1, "spoofed-system", "")
 }
 
 func TestClaudeExecutor_AgentSDKEntrypointWithStrongSignalsUsesCLICloak(t *testing.T) {
@@ -2116,7 +2193,7 @@ func TestClaudeExecutor_LegacySystemReminderAcrossMessagesAndStream(t *testing.T
 		if len(body) == 0 {
 			t.Fatalf("missing %s upstream capture", kind)
 		}
-		assertClaudeLegacySystemReminderLayout(t, body, "legacy-system-prompt", wantUser)
+		assertClaudeLegacySystemReminderLayout(t, body, "legacy-system-prompt", wantUser, "1h")
 		if _, ok := claudeBillingCCHDigitsOffset(body); !ok {
 			t.Fatalf("%s body is missing final CCH", kind)
 		}
@@ -3608,7 +3685,10 @@ func TestClaudeExecutor_ExecuteStream_AcceptEncodingOverrideCannotBypassIdentity
 	}
 }
 
-func assertClaudeMidConversationSystemMessage(t *testing.T, body []byte, messageIndex int, wantText string) {
+// assertClaudeMidConversationSystemMessage checks a forwarded caller system prompt.
+// wantTTL is "" for the native default marker and "1h" once
+// upgradeClaudeCacheControlTTL has run, which only happens for OAuth credentials.
+func assertClaudeMidConversationSystemMessage(t *testing.T, body []byte, messageIndex int, wantText, wantTTL string) {
 	t.Helper()
 	messagePath := fmt.Sprintf("messages.%d", messageIndex)
 	if got := gjson.GetBytes(body, messagePath+".role").String(); got != "system" {
@@ -3624,12 +3704,12 @@ func assertClaudeMidConversationSystemMessage(t *testing.T, body []byte, message
 	if got := content[0].Get("cache_control.type").String(); got != "ephemeral" {
 		t.Fatalf("%s.content.0.cache_control.type = %q, want ephemeral", messagePath, got)
 	}
-	if content[0].Get("cache_control.ttl").Exists() {
-		t.Fatalf("%s.content.0 unexpectedly has cache_control.ttl", messagePath)
+	if got := content[0].Get("cache_control.ttl").String(); got != wantTTL {
+		t.Fatalf("%s.content.0.cache_control.ttl = %q, want %q: %s", messagePath, got, wantTTL, content[0].Raw)
 	}
 }
 
-func assertClaudeLegacySystemReminderLayout(t *testing.T, body []byte, wantSystem, wantUser string) {
+func assertClaudeLegacySystemReminderLayout(t *testing.T, body []byte, wantSystem, wantUser, wantTTL string) {
 	t.Helper()
 	if got := gjson.GetBytes(body, "system.#").Int(); got != 2 {
 		t.Fatalf("top-level system block count = %d, want billing and identity only", got)
@@ -3648,7 +3728,7 @@ func assertClaudeLegacySystemReminderLayout(t *testing.T, body []byte, wantSyste
 	if content[1].Get("cache_control").Exists() {
 		t.Fatalf("caller reminder unexpectedly has cache_control: %s", content[1].Raw)
 	}
-	assertEphemeralUserTextBlock(t, content[2], wantUser)
+	assertEphemeralUserTextBlock(t, content[2], wantUser, wantTTL)
 }
 
 func assertClaudeCodeCurrentDateBlock(t *testing.T, block gjson.Result) {
@@ -3669,7 +3749,10 @@ func assertClaudeCodeCurrentDateBlockAt(t *testing.T, block gjson.Result, now ti
 	}
 }
 
-func assertEphemeralUserTextBlock(t *testing.T, block gjson.Result, wantText string) {
+// assertEphemeralUserTextBlock checks the cloaked first-user block. wantTTL is ""
+// for the native default marker and "1h" once upgradeClaudeCacheControlTTL has run,
+// which only happens for OAuth credentials.
+func assertEphemeralUserTextBlock(t *testing.T, block gjson.Result, wantText, wantTTL string) {
 	t.Helper()
 	if got := block.Get("type").String(); got != "text" {
 		t.Fatalf("user block type = %q, want text", got)
@@ -3680,8 +3763,8 @@ func assertEphemeralUserTextBlock(t *testing.T, block gjson.Result, wantText str
 	if got := block.Get("cache_control.type").String(); got != "ephemeral" {
 		t.Fatalf("user block cache_control.type = %q, want ephemeral", got)
 	}
-	if block.Get("cache_control.ttl").Exists() {
-		t.Fatalf("user block must not contain cache_control.ttl: %s", block.Raw)
+	if got := block.Get("cache_control.ttl").String(); got != wantTTL {
+		t.Fatalf("user block cache_control.ttl = %q, want %q: %s", got, wantTTL, block.Raw)
 	}
 }
 
@@ -3755,7 +3838,7 @@ func TestInjectClaudeCodeCurrentDateIsIdempotentAndAlignsFirstUserCache(t *testi
 	if content[0].Get("cache_control").Exists() {
 		t.Fatalf("currentDate block must not contain cache_control: %s", content[0].Raw)
 	}
-	assertEphemeralUserTextBlock(t, content[1], "hello")
+	assertEphemeralUserTextBlock(t, content[1], "hello", "")
 }
 
 func TestInjectClaudeCodeCurrentDateMovesExistingCopyToFirstBlock(t *testing.T) {
@@ -3770,7 +3853,7 @@ func TestInjectClaudeCodeCurrentDateMovesExistingCopyToFirstBlock(t *testing.T) 
 		t.Fatalf("content has %d blocks, want one currentDate and user text: %s", len(content), out)
 	}
 	assertClaudeCodeCurrentDateBlockAt(t, content[0], fixed)
-	assertEphemeralUserTextBlock(t, content[1], "hello")
+	assertEphemeralUserTextBlock(t, content[1], "hello", "")
 }
 
 func TestInjectClaudeCodeCurrentDatePrecedesExistingReminder(t *testing.T) {
@@ -3789,7 +3872,7 @@ func TestInjectClaudeCodeCurrentDatePrecedesExistingReminder(t *testing.T) {
 	if got := content[1].Get("text").String(); got != reminder {
 		t.Fatalf("content[1].text = %q, want standalone reminder", got)
 	}
-	assertEphemeralUserTextBlock(t, content[2], "continue")
+	assertEphemeralUserTextBlock(t, content[2], "continue", "")
 }
 
 // Test case 1: String system prompt becomes an authoritative mid-conversation
@@ -3817,15 +3900,15 @@ func TestCheckSystemInstructionsWithMode_StringSystemPreserved(t *testing.T) {
 		t.Fatalf("blocks[1] cache_control.type = %q, want ephemeral", got)
 	}
 	if blocks[1].Get("cache_control.ttl").Exists() {
-		t.Fatalf("blocks[1] should not set cache_control.ttl: %s", blocks[1].Raw)
+		t.Fatalf("blocks[1] cache_control must not carry a default ttl: %s", blocks[1].Raw)
 	}
 	content := gjson.GetBytes(out, "messages.0.content").Array()
 	if len(content) != 2 {
 		t.Fatalf("messages[0].content has %d blocks, want currentDate and user text: %s", len(content), out)
 	}
 	assertClaudeCodeCurrentDateBlock(t, content[0])
-	assertEphemeralUserTextBlock(t, content[1], "hi")
-	assertClaudeMidConversationSystemMessage(t, out, 1, "You are a helpful assistant.")
+	assertEphemeralUserTextBlock(t, content[1], "hi", "")
+	assertClaudeMidConversationSystemMessage(t, out, 1, "You are a helpful assistant.", "")
 }
 
 func TestClaudeUsesLegacySystemReminder(t *testing.T) {
@@ -3863,8 +3946,8 @@ func TestCheckSystemInstructionsWithMode_FutureModelDefaultsToMidSystem(t *testi
 		t.Fatalf("user content has %d blocks, want currentDate and user text", len(content))
 	}
 	assertClaudeCodeCurrentDateBlock(t, content[0])
-	assertEphemeralUserTextBlock(t, content[1], "hi")
-	assertClaudeMidConversationSystemMessage(t, out, 1, "future instructions")
+	assertEphemeralUserTextBlock(t, content[1], "hi", "")
+	assertClaudeMidConversationSystemMessage(t, out, 1, "future instructions", "")
 }
 
 func TestCheckSystemInstructionsWithMode_LegacyModelUsesSystemReminder(t *testing.T) {
@@ -3888,7 +3971,7 @@ func TestCheckSystemInstructionsWithMode_LegacyModelUsesSystemReminder(t *testin
 	if content[1].Get("cache_control").Exists() {
 		t.Fatalf("caller system reminder unexpectedly has cache_control: %s", content[1].Raw)
 	}
-	assertEphemeralUserTextBlock(t, content[2], "hi")
+	assertEphemeralUserTextBlock(t, content[2], "hi", "")
 }
 
 func TestCheckSystemInstructionsWithMode_LegacyModelKeepsSystemBlocksSeparate(t *testing.T) {
@@ -3912,7 +3995,7 @@ func TestCheckSystemInstructionsWithMode_LegacyModelKeepsSystemBlocksSeparate(t 
 			t.Fatalf("content[%d] caller reminder unexpectedly has cache_control: %s", idx+1, block.Raw)
 		}
 	}
-	assertEphemeralUserTextBlock(t, content[3], "hi")
+	assertEphemeralUserTextBlock(t, content[3], "hi", "")
 }
 
 // Test case 2: Strict mode keeps only the injected Claude Code system blocks.
@@ -3930,7 +4013,7 @@ func TestCheckSystemInstructionsWithMode_StringSystemStrict(t *testing.T) {
 		t.Fatalf("strict mode content has %d blocks, want currentDate and user text", len(content))
 	}
 	assertClaudeCodeCurrentDateBlock(t, content[0])
-	assertEphemeralUserTextBlock(t, content[1], "hi")
+	assertEphemeralUserTextBlock(t, content[1], "hi", "")
 }
 
 // Test case 3: Empty string system prompt adds only currentDate before user text.
@@ -3948,7 +4031,7 @@ func TestCheckSystemInstructionsWithMode_EmptyStringSystemIgnored(t *testing.T) 
 		t.Fatalf("empty system content has %d blocks, want 2", len(content))
 	}
 	assertClaudeCodeCurrentDateBlock(t, content[0])
-	assertEphemeralUserTextBlock(t, content[1], "hi")
+	assertEphemeralUserTextBlock(t, content[1], "hi", "")
 }
 
 // Test case 4: Array system prompt becomes one mid-conversation system message.
@@ -3966,8 +4049,8 @@ func TestCheckSystemInstructionsWithMode_ArraySystemStillWorks(t *testing.T) {
 		t.Fatalf("messages[0].content has %d blocks, want currentDate and user text", len(content))
 	}
 	assertClaudeCodeCurrentDateBlock(t, content[0])
-	assertEphemeralUserTextBlock(t, content[1], "hi")
-	assertClaudeMidConversationSystemMessage(t, out, 1, "Be concise.")
+	assertEphemeralUserTextBlock(t, content[1], "hi", "")
+	assertClaudeMidConversationSystemMessage(t, out, 1, "Be concise.", "")
 }
 
 func TestCheckSystemInstructionsWithMode_ArraySystemKeepsBlocksAsSeparateMessages(t *testing.T) {
@@ -3985,9 +4068,9 @@ func TestCheckSystemInstructionsWithMode_ArraySystemKeepsBlocksAsSeparateMessage
 		t.Fatalf("user content has %d blocks, want currentDate and user text: %s", len(content), out)
 	}
 	assertClaudeCodeCurrentDateBlock(t, content[0])
-	assertEphemeralUserTextBlock(t, content[1], "hi")
-	assertClaudeMidConversationSystemMessage(t, out, 1, "first guidance")
-	assertClaudeMidConversationSystemMessage(t, out, 2, "second guidance")
+	assertEphemeralUserTextBlock(t, content[1], "hi", "")
+	assertClaudeMidConversationSystemMessage(t, out, 1, "first guidance", "")
+	assertClaudeMidConversationSystemMessage(t, out, 2, "second guidance", "")
 }
 
 func TestRelocateClaudeSystemPromptForCountTokensKeepsBlocksSeparate(t *testing.T) {
@@ -4030,8 +4113,8 @@ func TestRelocateClaudeSystemPromptForCountTokensKeepsBlocksSeparate(t *testing.
 			if got := gjson.GetBytes(out, "messages.#").Int(); got != 3 {
 				t.Fatalf("message count = %d, want user and two system messages: %s", got, out)
 			}
-			assertClaudeMidConversationSystemMessage(t, out, 1, "first guidance")
-			assertClaudeMidConversationSystemMessage(t, out, 2, "second guidance")
+			assertClaudeMidConversationSystemMessage(t, out, 1, "first guidance", "")
+			assertClaudeMidConversationSystemMessage(t, out, 2, "second guidance", "")
 		})
 	}
 }
@@ -4051,8 +4134,8 @@ func TestCheckSystemInstructionsWithMode_StringWithSpecialChars(t *testing.T) {
 		t.Fatalf("messages[0].content has %d blocks, want 2", len(content))
 	}
 	assertClaudeCodeCurrentDateBlock(t, content[0])
-	assertEphemeralUserTextBlock(t, content[1], "hi")
-	assertClaudeMidConversationSystemMessage(t, out, 1, wantSystem)
+	assertEphemeralUserTextBlock(t, content[1], "hi", "")
+	assertClaudeMidConversationSystemMessage(t, out, 1, wantSystem, "")
 }
 
 func TestCheckSystemInstructionsWithSigningMode_LongPromptIsExactAndIdempotent(t *testing.T) {
@@ -4086,8 +4169,8 @@ func TestCheckSystemInstructionsWithSigningMode_LongPromptIsExactAndIdempotent(t
 		t.Fatalf("user content has %d blocks, want currentDate and user text", len(content))
 	}
 	assertClaudeCodeCurrentDateBlock(t, content[0])
-	assertEphemeralUserTextBlock(t, content[1], "hello")
-	assertClaudeMidConversationSystemMessage(t, first, 1, wantSystem)
+	assertEphemeralUserTextBlock(t, content[1], "hello", "")
+	assertClaudeMidConversationSystemMessage(t, first, 1, wantSystem, "")
 	if strings.Contains(content[0].Get("text").String(), "PI_SYSTEM_BEGIN") || strings.Contains(content[1].Get("text").String(), "PI_SYSTEM_BEGIN") {
 		t.Fatal("caller system prompt leaked into the user content blocks")
 	}
@@ -4959,8 +5042,8 @@ func TestClaudeExecutor_ExecuteOAuthCustomToolMCPAliasRoundTrip(t *testing.T) {
 		t.Fatalf("Messages first user content has %d blocks, want currentDate and user text", len(content))
 	}
 	assertClaudeCodeCurrentDateBlock(t, content[0])
-	assertEphemeralUserTextBlock(t, content[1], "search")
-	assertClaudeMidConversationSystemMessage(t, upstreamBody, 1, "messages-system-prompt")
+	assertEphemeralUserTextBlock(t, content[1], "search", "1h")
+	assertClaudeMidConversationSystemMessage(t, upstreamBody, 1, "messages-system-prompt", "1h")
 }
 
 func TestClaudeExecutor_ExecuteStreamOAuthCustomToolMCPAliasRoundTrip(t *testing.T) {
@@ -5036,8 +5119,8 @@ func TestClaudeExecutor_ExecuteStreamOAuthCustomToolMCPAliasRoundTrip(t *testing
 		t.Fatalf("streaming first user content has %d blocks, want currentDate and user text", len(content))
 	}
 	assertClaudeCodeCurrentDateBlock(t, content[0])
-	assertEphemeralUserTextBlock(t, content[1], "fetch")
-	assertClaudeMidConversationSystemMessage(t, upstreamBody, 1, "stream-system-prompt")
+	assertEphemeralUserTextBlock(t, content[1], "fetch", "1h")
+	assertClaudeMidConversationSystemMessage(t, upstreamBody, 1, "stream-system-prompt", "1h")
 	assertClaudeCredentialIdentity(t, upstreamBody, upstreamHeaders, deviceIDs, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
 	if !strings.Contains(downstream.String(), `"name":"fetch_url"`) {
 		t.Fatalf("downstream stream did not restore fetch_url: %s", downstream.String())
@@ -5093,7 +5176,7 @@ func TestInsertClaudeMidConversationSystemMessages_FollowsToolResultUserTurn(t *
 	if got := blocks.Get("0.tool_use_id").String(); got != "toolu_1" {
 		t.Fatalf("tool_use_id = %q, want toolu_1: %s", got, out)
 	}
-	assertClaudeMidConversationSystemMessage(t, out, 2, "guidance")
+	assertClaudeMidConversationSystemMessage(t, out, 2, "guidance", "")
 }
 
 func TestInsertClaudeMidConversationSystemMessages_PrecedesExistingAssistantTurn(t *testing.T) {
@@ -5114,7 +5197,7 @@ func TestInsertClaudeMidConversationSystemMessages_PrecedesExistingAssistantTurn
 			t.Fatalf("messages[%d].role = %q, want %q", idx, got, wantRole)
 		}
 	}
-	assertClaudeMidConversationSystemMessage(t, out, 1, "guidance")
+	assertClaudeMidConversationSystemMessage(t, out, 1, "guidance", "")
 }
 
 func TestInsertClaudeMidConversationSystemMessages_FollowsConsecutiveUserRun(t *testing.T) {
@@ -5135,7 +5218,7 @@ func TestInsertClaudeMidConversationSystemMessages_FollowsConsecutiveUserRun(t *
 			t.Fatalf("messages[%d].role = %q, want %q", idx, got, wantRole)
 		}
 	}
-	assertClaudeMidConversationSystemMessage(t, out, 2, "guidance")
+	assertClaudeMidConversationSystemMessage(t, out, 2, "guidance", "")
 }
 
 func TestInsertClaudeMidConversationSystemMessages_IsIdempotent(t *testing.T) {
@@ -5149,8 +5232,8 @@ func TestInsertClaudeMidConversationSystemMessages_IsIdempotent(t *testing.T) {
 	if got := gjson.GetBytes(first, "messages.#").Int(); got != 3 {
 		t.Fatalf("message count = %d, want user and two system messages: %s", got, first)
 	}
-	assertClaudeMidConversationSystemMessage(t, first, 1, texts[0])
-	assertClaudeMidConversationSystemMessage(t, first, 2, texts[1])
+	assertClaudeMidConversationSystemMessage(t, first, 1, texts[0], "")
+	assertClaudeMidConversationSystemMessage(t, first, 2, texts[1], "")
 }
 
 // TestClaudeCodeCLIBetas_MatchesObservedClientMatrix pins the Anthropic-Beta
@@ -5941,5 +6024,77 @@ func TestClaudeExecutor_CountTokensRejectsNonTextCallerSystemBlock(t *testing.T)
 	}
 	if upstreamCalled {
 		t.Fatal("countTokensUpstream() called upstream, want local rejection")
+	}
+}
+
+// The native gate selects the 1h cache pool only for OAuth credentials and pushes
+// extended-cache-ttl-2025-04-11 exactly when that selection produced a 1h body ttl.
+// Body ttl and the beta must therefore always travel together.
+func TestClaudeExecutor_CacheTTLIsPairedWithExtendedCacheTTLBeta(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiKey   string
+		wantTTL  string
+		wantBeta bool
+	}{
+		{
+			name:     "oauth credential selects the 1h pool",
+			apiKey:   "sk-ant-oat-cache-ttl-pairing",
+			wantTTL:  "1h",
+			wantBeta: true,
+		},
+		{
+			name:     "api key credential keeps the default pool",
+			apiKey:   "key-cache-ttl-pairing",
+			wantTTL:  "",
+			wantBeta: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var seenBody []byte
+			var seenHeaders http.Header
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				seenBody, _ = io.ReadAll(r.Body)
+				seenHeaders = r.Header.Clone()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-opus-4-6","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+			}))
+			defer server.Close()
+
+			executor := NewClaudeExecutor(&config.Config{})
+			auth := &cliproxyauth.Auth{
+				ID: "cache-ttl-pairing",
+				Attributes: map[string]string{
+					"api_key":  test.apiKey,
+					"base_url": server.URL,
+				},
+				Metadata: claudeOAuthTestMetadata(),
+			}
+			_, errExecute := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+				Model:   "claude-opus-4-6",
+				Payload: []byte(`{"model":"claude-opus-4-6","messages":[{"role":"user","content":[{"type":"text","text":"x"}]}]}`),
+			}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+			if errExecute != nil {
+				t.Fatalf("Execute() error = %v", errExecute)
+			}
+
+			gotTTL := gjson.GetBytes(seenBody, "system.1.cache_control.ttl").String()
+			if gotTTL != test.wantTTL {
+				t.Fatalf("system[1].cache_control.ttl = %q, want %q: %s", gotTTL, test.wantTTL, seenBody)
+			}
+			if got := gjson.GetBytes(seenBody, "system.1.cache_control.type").String(); got != "ephemeral" {
+				t.Fatalf("system[1].cache_control.type = %q, want ephemeral: %s", got, seenBody)
+			}
+			gotBeta := strings.Contains(seenHeaders.Get("Anthropic-Beta"), claudeExtendedCacheTTLBeta)
+			if gotBeta != test.wantBeta {
+				t.Fatalf("extended-cache-ttl declared = %v, want %v: %s", gotBeta, test.wantBeta, seenHeaders.Get("Anthropic-Beta"))
+			}
+			// The pairing invariant itself: a 1h body ttl without the beta, or the beta
+			// without a 1h body ttl, is a combination native never produces.
+			if (gotTTL == "1h") != gotBeta {
+				t.Fatalf("body ttl %q and extended-cache-ttl beta %v disagree", gotTTL, gotBeta)
+			}
+		})
 	}
 }

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -5574,7 +5574,6 @@ func TestInjectClaudeCodeContextManagement(t *testing.T) {
 		name    string
 		payload string
 	}{
-		{name: "omitted thinking", payload: `{"model":"claude-opus-4-6"}`},
 		{name: "enabled thinking", payload: `{"model":"claude-opus-5","thinking":{"type":"enabled"}}`},
 		{name: "adaptive thinking", payload: `{"model":"claude-opus-5","thinking":{"type":"adaptive"}}`},
 	} {
@@ -5598,16 +5597,76 @@ func TestInjectClaudeCodeContextManagement(t *testing.T) {
 		t.Fatalf("caller context_management was modified: %s", callerOwnedGot)
 	}
 
-	disabledThinking := []byte(`{"model":"claude-opus-5","thinking":{"type":"disabled"}}`)
-	disabledThinkingGot, automaticallyInjected := injectClaudeCodeContextManagement(disabledThinking)
-	if automaticallyInjected {
-		t.Error("disabled thinking context_management was reported as automatically injected")
+	// Anthropic rejects clear_thinking_20251015 unless thinking is enabled or
+	// adaptive, so an omitted thinking field is as ineligible as an explicit
+	// disabled one.
+	for _, test := range []struct {
+		name    string
+		payload string
+	}{
+		{name: "disabled thinking", payload: `{"model":"claude-opus-5","thinking":{"type":"disabled"}}`},
+		{name: "omitted thinking", payload: `{"model":"claude-opus-4-6"}`},
+		{name: "unknown thinking", payload: `{"model":"claude-opus-5","thinking":{"type":"unexpected"}}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ineligible := []byte(test.payload)
+			got, automaticallyInjected := injectClaudeCodeContextManagement(ineligible)
+			if automaticallyInjected {
+				t.Error("ineligible thinking context_management was reported as automatically injected")
+			}
+			if !bytes.Equal(got, ineligible) {
+				t.Errorf("ineligible payload was modified: %s", got)
+			}
+			if cm := gjson.GetBytes(got, "context_management"); cm.Exists() {
+				t.Errorf("context_management = %s, want absent", cm.Raw)
+			}
+		})
 	}
-	if !bytes.Equal(disabledThinkingGot, disabledThinking) {
-		t.Errorf("disabled thinking payload was modified: %s", disabledThinkingGot)
-	}
-	if got := gjson.GetBytes(disabledThinkingGot, "context_management"); got.Exists() {
-		t.Errorf("disabled thinking payload has context_management = %s, want absent", got.Raw)
+}
+
+// Anthropic rejects a request carrying the clear_thinking_20251015 strategy
+// without enabled/adaptive thinking:
+//
+//	`clear_thinking_20251015` strategy requires `thinking` to be enabled or adaptive
+//
+// This walks the real execute.go ordering, where disableThinkingIfToolChoiceForced
+// deletes the thinking field between injection and reconciliation.
+func TestClaudeCodeContextManagementNeverOutlivesEligibleThinking(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		payload string
+		wantCM  bool
+	}{
+		{
+			name:    "thinking omitted from the start",
+			payload: `{"model":"claude-opus-5","messages":[]}`,
+		},
+		{
+			name:    "forced tool_choice strips thinking after injection",
+			payload: `{"model":"claude-opus-5","thinking":{"type":"enabled","budget_tokens":1024},"tool_choice":{"type":"any"},"messages":[]}`,
+		},
+		{
+			name:    "thinking survives without forced tool_choice",
+			payload: `{"model":"claude-opus-5","thinking":{"type":"enabled","budget_tokens":1024},"messages":[]}`,
+			wantCM:  true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			body, injected := injectClaudeCodeContextManagement([]byte(test.payload))
+			state := claudeCodeContextManagementState{eligible: true, automaticallyInjected: injected}
+			body = disableThinkingIfToolChoiceForced(body)
+			body = reconcileClaudeCodeContextManagement(body, state)
+
+			thinkingEligible := gjson.GetBytes(body, "thinking.type").String() == "enabled" ||
+				gjson.GetBytes(body, "thinking.type").String() == "adaptive"
+			cm := gjson.GetBytes(body, "context_management")
+			if cm.Exists() && !thinkingEligible {
+				t.Fatalf("context_management = %s survived ineligible thinking; Anthropic would reject this: %s", cm.Raw, body)
+			}
+			if cm.Exists() != test.wantCM {
+				t.Fatalf("context_management present = %v, want %v; body=%s", cm.Exists(), test.wantCM, body)
+			}
+		})
 	}
 }
 
@@ -5669,6 +5728,17 @@ func TestReconcileClaudeCodeContextManagement(t *testing.T) {
 			name:    "omitted thinking prevents addition",
 			payload: `{}`,
 			state:   claudeCodeContextManagementState{eligible: true},
+		},
+		{
+			name:    "removes automatic object when thinking was stripped entirely",
+			payload: `{"context_management":` + claudeCodeContextManagement + `}`,
+			state:   claudeCodeContextManagementState{eligible: true, automaticallyInjected: true},
+		},
+		{
+			name:    "keeps caller object when thinking was stripped entirely",
+			payload: `{"context_management":` + claudeCodeContextManagement + `}`,
+			state:   claudeCodeContextManagementState{eligible: true, callerOwned: true},
+			wantRaw: claudeCodeContextManagement,
 		},
 		{
 			name:    "unknown thinking prevents addition",
@@ -5829,7 +5899,11 @@ func TestClaudeExecutorPayloadOverrideDisabledThinking(t *testing.T) {
 	})
 
 	for _, stream := range []bool{false, true} {
-		name := "forced tool choice retains automatic context management execute"
+		// Anthropic rejects the automatic strategy once forced tool choice has
+		// stripped thinking:
+		//
+		//	`clear_thinking_20251015` strategy requires `thinking` to be enabled or adaptive
+		name := "forced tool choice drops automatic context management execute"
 		if stream {
 			name += " stream"
 		}
@@ -5839,8 +5913,8 @@ func TestClaudeExecutorPayloadOverrideDisabledThinking(t *testing.T) {
 			if got := gjson.GetBytes(upstreamBody, "thinking"); got.Exists() {
 				t.Fatalf("forced tool choice thinking = %s, want absent", got.Raw)
 			}
-			if got := gjson.GetBytes(upstreamBody, "context_management").Raw; got != claudeCodeContextManagement {
-				t.Fatalf("forced tool choice context_management = %s, want %s", got, claudeCodeContextManagement)
+			if got := gjson.GetBytes(upstreamBody, "context_management"); got.Exists() {
+				t.Fatalf("forced tool choice context_management = %s, want absent because Anthropic rejects it without thinking", got.Raw)
 			}
 			if got := gjson.GetBytes(upstreamBody, "tool_choice.type").String(); got != "any" {
 				t.Fatalf("forced tool_choice.type = %q, want any", got)

--- a/internal/runtime/executor/claude_signing.go
+++ b/internal/runtime/executor/claude_signing.go
@@ -56,6 +56,19 @@ func finalizeAnthropicMessagesBodyCCH(body []byte, fallbackBilling string) ([]by
 	return signAnthropicMessagesBody(bodyWithPlaceholder)
 }
 
+// claudeBodyNeedsBillingFallback reports whether a confirmed native helper request
+// still needs CPA's billing-header fallback.
+//
+// The measured minimal helper carries no system field at all, which is exactly the
+// native wire shape, so injecting a billing header there would be the deviation.
+// Keying on "system is absent" rather than "no billing header present" means that
+// if anything later in the pipeline (a payload rule, for instance) does attach a
+// system prompt, the fallback comes back and the request cannot go upstream with a
+// system block that native would never send unsigned.
+func claudeBodyNeedsBillingFallback(body []byte) bool {
+	return gjson.GetBytes(body, "system").Exists()
+}
+
 func ensureClaudeBillingHeaderCCHPlaceholder(body []byte, fallbackBilling string) ([]byte, error) {
 	billing := gjson.GetBytes(body, "system.0.text")
 	if billing.Type != gjson.String || !strings.HasPrefix(billing.String(), "x-anthropic-billing-header:") {

--- a/internal/runtime/executor/helps/claude_client_detection.go
+++ b/internal/runtime/executor/helps/claude_client_detection.go
@@ -1,12 +1,29 @@
 package helps
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"regexp"
+	"sort"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/tidwall/gjson"
+)
+
+const (
+	// claudeAnthropicVersion is the only Anthropic-Version Claude Code sends.
+	claudeAnthropicVersion = "2023-06-01"
+	// claudeDefaultStainlessTimeout is the X-Stainless-Timeout every measured
+	// native helper sends. It is deliberately NOT read from
+	// claude-header-defaults.timeout: applyClaudeHeaders routes a confirmed client
+	// through misc.EnsureHeader, which prefers the incoming header and only falls
+	// back to the configured value when the caller sent none. A confirmed helper
+	// therefore always forwards its own 600, so comparing against the operator
+	// value would make any non-600 configuration reject every genuine helper.
+	claudeDefaultStainlessTimeout = "600"
 )
 
 var (
@@ -52,6 +69,39 @@ var nativeClaudeEntrypoints = map[string]bool{
 	"claude-vscode": true,
 }
 
+type claudeCodeHelperShape uint8
+
+const (
+	claudeCodeHelperShapeNone claudeCodeHelperShape = iota
+	claudeCodeHelperShapeMinimal
+	claudeCodeHelperShapeStructured
+
+	claudeCodeHelperModel = "claude-haiku-4-5-20251001"
+)
+
+// These are the six exact beta sequences observed across 14 markerless native
+// Claude Code 2.1.220 Haiku helper requests. Keeping the allowlist exact avoids
+// turning the helper exception into a generic no-claude-code-beta bypass.
+var measuredClaudeCodeHelperBetaProfiles = map[string]claudeCodeHelperShape{
+	claudeCodeHelperBetaProfile(true):  claudeCodeHelperShapeMinimal,
+	claudeCodeHelperBetaProfile(false): claudeCodeHelperShapeMinimal,
+	claudeCodeHelperBetaProfile(true,
+		"advisor-tool-2026-03-01",
+		"structured-outputs-2025-12-15",
+		"cache-diagnosis-2026-04-07",
+	): claudeCodeHelperShapeStructured,
+	claudeCodeHelperBetaProfile(true,
+		"structured-outputs-2025-12-15",
+		"fallback-credit-2026-06-01",
+	): claudeCodeHelperShapeStructured,
+	claudeCodeHelperBetaProfile(true,
+		"structured-outputs-2025-12-15",
+	): claudeCodeHelperShapeStructured,
+	claudeCodeHelperBetaProfile(false,
+		"structured-outputs-2025-12-15",
+	): claudeCodeHelperShapeStructured,
+}
+
 // ClaudeCodeRequestDetection records the strong signals and first-party
 // subclient identity used to distinguish an official Claude Code request from
 // a client that only copied its User-Agent.
@@ -63,17 +113,18 @@ type ClaudeCodeRequestDetection struct {
 	UserAgent       bool
 	BetasPresent    bool
 	MetadataUserID  bool
+	HelperProfile   bool
 	Entrypoint      string
 	Subclient       string
 	AgentSDKVersion string
 }
 
 // DetectClaudeCodeRequest first mirrors CCH's strong-signal contract, then
-// applies CPA's native-client policy. Messages requests require all four strong
-// signals; count_tokens omits metadata.user_id and uses the three header signals.
-// Only Anthropic first-party product entrypoints are confirmed for pass-through.
-// Generic sdk-ts/sdk-py Agent SDK entrypoints remain unconfirmed and receive
-// CLI cloaking; native Claude Code print mode keeps its original sdk-cli identity.
+// applies CPA's native-client policy. Standard Messages requests require all
+// four strong signals; count_tokens omits metadata.user_id. A separate narrow
+// profile recognizes measured native Haiku helper requests that intentionally
+// omit claude-code-20250219. Generic sdk-ts/sdk-py Agent SDK entrypoints remain
+// unconfirmed and receive CLI cloaking.
 func DetectClaudeCodeRequest(headers http.Header, payload []byte, countTokens bool, configs ...*config.Config) ClaudeCodeRequestDetection {
 	var cfg *config.Config
 	if len(configs) > 0 {
@@ -92,10 +143,320 @@ func DetectClaudeCodeRequest(headers http.Header, payload []byte, countTokens bo
 
 	metadataUserID := gjson.GetBytes(payload, "metadata.user_id")
 	detection.MetadataUserID = metadataUserID.Exists() && metadataUserID.Type == gjson.String && isValidUserID(metadataUserID.String())
-	detection.StrongSignals = detection.XAppCLI && detection.UserAgent && detection.BetasPresent && (countTokens || detection.MetadataUserID)
 	detection.NativeClient = nativeClaudeEntrypoints[entrypoint]
+	standardSignals := detection.XAppCLI && detection.UserAgent && detection.BetasPresent && (countTokens || detection.MetadataUserID)
+	detection.HelperProfile = detection.NativeClient && matchesMeasuredClaudeCodeHelperProfile(headers, payload, countTokens, detection, cfg)
+	detection.StrongSignals = standardSignals || detection.HelperProfile
 	detection.Confirmed = detection.StrongSignals && detection.NativeClient
 	return detection
+}
+
+func claudeCodeHelperBetaProfile(redactThinking bool, trailing ...string) string {
+	betas := []string{"oauth-2025-04-20", "interleaved-thinking-2025-05-14"}
+	if redactThinking {
+		betas = append(betas, "redact-thinking-2026-02-12")
+	}
+	betas = append(betas,
+		"thinking-token-count-2026-05-13",
+		"context-management-2025-06-27",
+		"prompt-caching-scope-2026-01-05",
+	)
+	betas = append(betas, trailing...)
+	return strings.Join(betas, ",")
+}
+
+func matchesMeasuredClaudeCodeHelperProfile(
+	headers http.Header,
+	payload []byte,
+	countTokens bool,
+	detection ClaudeCodeRequestDetection,
+	cfg *config.Config,
+) bool {
+	if countTokens ||
+		detection.Entrypoint != "cli" ||
+		detection.BetasPresent ||
+		!detection.XAppCLI ||
+		!detection.UserAgent ||
+		!detection.MetadataUserID {
+		return false
+	}
+
+	shape := measuredClaudeCodeHelperBetaProfiles[normalizedClaudeBetaHeader(headers)]
+	if shape == claudeCodeHelperShapeNone || measuredClaudeCodeHelperBodyShape(payload) != shape {
+		return false
+	}
+	if !measuredClaudeCodeHelperHeadersMatch(headers, cfg, shape) {
+		return false
+	}
+	return measuredClaudeCodeHelperSessionMatches(headers, payload)
+}
+
+// normalizedClaudeBetaHeader joins every Anthropic-Beta value in wire order.
+// Values() is tried first so canonical headers keep a deterministic order; the
+// case-insensitive fallback only exists for hand-built header maps that store a
+// non-canonical key, where ranging the map alone would be order-dependent.
+func normalizedClaudeBetaHeader(headers http.Header) string {
+	if headers == nil {
+		return ""
+	}
+	values := headers.Values("Anthropic-Beta")
+	if len(values) == 0 {
+		keys := make([]string, 0, 2)
+		for key := range headers {
+			if strings.EqualFold(key, "Anthropic-Beta") {
+				keys = append(keys, key)
+			}
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			values = append(values, headers[key]...)
+		}
+	}
+	betas := make([]string, 0, 12)
+	for _, value := range values {
+		for _, beta := range strings.Split(value, ",") {
+			if beta = strings.TrimSpace(beta); beta != "" {
+				betas = append(betas, beta)
+			}
+		}
+	}
+	return strings.Join(betas, ",")
+}
+
+// measuredClaudeCodeHelperHeadersMatch validates the helper transport envelope.
+//
+// Platform and software-version headers are deliberately NOT compared for
+// equality. The device-profile pipeline this detector feeds already pins OS/Arch
+// to the configured baseline and replaces a non-baseline software tuple instead
+// of rejecting it, so demanding equality here would classify a genuine Claude
+// Code helper from Windows/Linux, or from a different Node or SDK build, as a
+// foreign client and cloak it. Values that carry real discriminating power - the
+// exact beta allowlist, the body shape, the billing CCH and the session binding -
+// stay strict.
+func measuredClaudeCodeHelperHeadersMatch(headers http.Header, cfg *config.Config, shape claudeCodeHelperShape) bool {
+	profile := defaultClaudeDeviceProfile(cfg)
+	expected := map[string]string{
+		"Accept":                  "application/json",
+		"Content-Type":            "application/json",
+		"X-Stainless-Lang":        "js",
+		"X-Stainless-Runtime":     "node",
+		"X-Stainless-Retry-Count": "0",
+		"X-Stainless-Timeout":     claudeDefaultStainlessTimeout,
+		"Anthropic-Version":       claudeAnthropicVersion,
+		"Anthropic-Dangerous-Direct-Browser-Access": "true",
+	}
+	for name, want := range expected {
+		if headerValue(headers, name) != want {
+			return false
+		}
+	}
+	// Presence is still required: the native SDK always sends these.
+	for _, name := range []string{
+		"X-Stainless-Package-Version",
+		"X-Stainless-Runtime-Version",
+		"X-Stainless-OS",
+		"X-Stainless-Arch",
+	} {
+		if headerValue(headers, name) == "" {
+			return false
+		}
+	}
+	candidate := ClaudeDeviceProfile{
+		UserAgent:      headerValue(headers, "User-Agent"),
+		PackageVersion: headerValue(headers, "X-Stainless-Package-Version"),
+		RuntimeVersion: headerValue(headers, "X-Stainless-Runtime-Version"),
+	}
+	if version, ok := parseClaudeCLIVersion(candidate.UserAgent); ok {
+		candidate.version = version
+		candidate.hasVersion = true
+	}
+	if !meetsClaudeDeviceProfileBaseline(candidate, profile) {
+		return false
+	}
+	if async := headerValue(headers, "X-Stainless-Async"); (shape == claudeCodeHelperShapeStructured && async != "async") ||
+		(shape == claudeCodeHelperShapeMinimal && async != "") {
+		return false
+	}
+	compression := headerValue(headers, "Accept-Encoding")
+	if (shape == claudeCodeHelperShapeStructured && compression != "gzip, deflate, br, zstd") ||
+		(shape == claudeCodeHelperShapeMinimal && compression != "gzip") {
+		return false
+	}
+	requestID := headerValue(headers, "X-Client-Request-Id")
+	_, errRequestID := uuid.Parse(requestID)
+	return errRequestID == nil
+}
+
+func measuredClaudeCodeHelperSessionMatches(headers http.Header, payload []byte) bool {
+	metadata := gjson.GetBytes(payload, "metadata")
+	if !metadata.IsObject() || !claudeJSONObjectHasKeys([]byte(metadata.Raw), []string{"user_id"}) {
+		return false
+	}
+	userID := metadata.Get("user_id")
+	if userID.Type != gjson.String || !isValidUserID(userID.String()) {
+		return false
+	}
+	// The native metadata builder is
+	//	{...extraMetadata, device_id, account_uuid, session_id, ...parentSessionId && {parent_session_id}}
+	// in 2.1.220, 2.1.221 and 2.1.227 alike, so parent_session_id is a legitimate
+	// optional trailing key for sub-agent and forked sessions. Rejecting it would
+	// cloak the helper requests those sessions issue.
+	identityRaw := []byte(userID.String())
+	if !claudeJSONObjectHasKeys(identityRaw, []string{"device_id", "account_uuid", "session_id"}) &&
+		!claudeJSONObjectHasKeys(identityRaw, []string{"device_id", "account_uuid", "session_id", "parent_session_id"}) {
+		return false
+	}
+	return headerValue(headers, ClaudeCodeSessionHeader) == gjson.GetBytes(identityRaw, "session_id").String()
+}
+
+func measuredClaudeCodeHelperBodyShape(payload []byte) claudeCodeHelperShape {
+	minimalKeys := []string{"model", "max_tokens", "messages", "metadata"}
+	structuredKeys := []string{"model", "messages", "system", "tools", "metadata", "max_tokens", "thinking", "temperature", "output_config", "stream"}
+	shape := claudeCodeHelperShapeNone
+	switch {
+	case claudeJSONObjectHasKeys(payload, minimalKeys):
+		shape = claudeCodeHelperShapeMinimal
+	case claudeJSONObjectHasKeys(payload, structuredKeys):
+		shape = claudeCodeHelperShapeStructured
+	default:
+		return claudeCodeHelperShapeNone
+	}
+
+	maxTokens := gjson.GetBytes(payload, "max_tokens")
+	if gjson.GetBytes(payload, "model").String() != claudeCodeHelperModel ||
+		maxTokens.Type != gjson.Number {
+		return claudeCodeHelperShapeNone
+	}
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.IsArray() || len(messages.Array()) != 1 {
+		return claudeCodeHelperShapeNone
+	}
+	message := messages.Get("0")
+	if !claudeJSONObjectHasKeys([]byte(message.Raw), []string{"role", "content"}) ||
+		message.Get("role").String() != "user" {
+		return claudeCodeHelperShapeNone
+	}
+
+	if shape == claudeCodeHelperShapeMinimal {
+		if maxTokens.Raw != "1" || message.Get("content").Type != gjson.String {
+			return claudeCodeHelperShapeNone
+		}
+		return shape
+	}
+
+	content := message.Get("content")
+	if !content.IsArray() || len(content.Array()) != 1 {
+		return claudeCodeHelperShapeNone
+	}
+	contentBlock := content.Get("0")
+	if !claudeJSONObjectHasKeys([]byte(contentBlock.Raw), []string{"type", "text"}) ||
+		contentBlock.Get("type").String() != "text" {
+		return claudeCodeHelperShapeNone
+	}
+	if !measuredClaudeCodeHelperSystemMatches(gjson.GetBytes(payload, "system")) {
+		return claudeCodeHelperShapeNone
+	}
+	if tools := gjson.GetBytes(payload, "tools"); !tools.IsArray() || len(tools.Array()) != 0 {
+		return claudeCodeHelperShapeNone
+	}
+	thinking := gjson.GetBytes(payload, "thinking")
+	outputConfig := gjson.GetBytes(payload, "output_config")
+	if !claudeJSONObjectHasKeys([]byte(thinking.Raw), []string{"type"}) ||
+		thinking.Get("type").String() != "disabled" {
+		return claudeCodeHelperShapeNone
+	}
+	format := outputConfig.Get("format")
+	schema := format.Get("schema")
+	properties := schema.Get("properties")
+	titleProperty := properties.Get("title")
+	required := schema.Get("required")
+	additionalProperties := schema.Get("additionalProperties")
+	if !claudeJSONObjectHasKeys([]byte(outputConfig.Raw), []string{"format"}) ||
+		!claudeJSONObjectHasKeys([]byte(format.Raw), []string{"type", "schema"}) ||
+		format.Get("type").String() != "json_schema" ||
+		!claudeJSONObjectHasKeys([]byte(schema.Raw), []string{"type", "properties", "required", "additionalProperties"}) ||
+		schema.Get("type").String() != "object" ||
+		!claudeJSONObjectHasKeys([]byte(properties.Raw), []string{"title"}) ||
+		!claudeJSONObjectHasKeys([]byte(titleProperty.Raw), []string{"type"}) ||
+		titleProperty.Get("type").String() != "string" ||
+		!required.IsArray() || len(required.Array()) != 1 || required.Get("0").String() != "title" ||
+		additionalProperties.Type != gjson.False {
+		return claudeCodeHelperShapeNone
+	}
+	temperature := gjson.GetBytes(payload, "temperature")
+	if maxTokens.Raw != "32000" ||
+		temperature.Raw != "1" ||
+		gjson.GetBytes(payload, "stream").Type != gjson.True {
+		return claudeCodeHelperShapeNone
+	}
+	return shape
+}
+
+func measuredClaudeCodeHelperSystemMatches(system gjson.Result) bool {
+	if !system.IsArray() || len(system.Array()) != 3 {
+		return false
+	}
+	for _, block := range system.Array() {
+		if !claudeJSONObjectHasKeys([]byte(block.Raw), []string{"type", "text"}) || block.Get("type").String() != "text" {
+			return false
+		}
+	}
+	billing := system.Get("0.text").String()
+	identity := system.Get("1.text").String()
+	return strings.HasPrefix(billing, "x-anthropic-billing-header:") && measuredClaudeBillingCCH(billing) && strings.HasPrefix(identity, "You are Claude Code")
+}
+
+// measuredClaudeBillingCCH validates the five lowercase hexadecimal characters the
+// native billing header carries. It duplicates isLowerHex in
+// internal/runtime/executor/claude_signing.go because the signing side lives in the
+// package that imports this one; keep the two definitions in step.
+func measuredClaudeBillingCCH(billing string) bool {
+	marker := strings.Index(billing, " cch=")
+	if marker < 0 {
+		return false
+	}
+	valueStart := marker + len(" cch=")
+	valueEnd := valueStart + 5
+	if valueEnd >= len(billing) || billing[valueEnd] != ';' {
+		return false
+	}
+	for _, character := range billing[valueStart:valueEnd] {
+		decimal := character >= '0' && character <= '9'
+		lowerHex := character >= 'a' && character <= 'f'
+		if !decimal && !lowerHex {
+			return false
+		}
+	}
+	return true
+}
+
+func claudeJSONObjectHasKeys(raw []byte, want []string) bool {
+	if !json.Valid(raw) {
+		return false
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	opening, errOpening := decoder.Token()
+	if errOpening != nil || opening != json.Delim('{') {
+		return false
+	}
+	keyIndex := 0
+	for decoder.More() {
+		token, errToken := decoder.Token()
+		if errToken != nil {
+			return false
+		}
+		key, okKey := token.(string)
+		if !okKey || keyIndex >= len(want) || key != want[keyIndex] {
+			return false
+		}
+		keyIndex++
+		var value json.RawMessage
+		if errValue := decoder.Decode(&value); errValue != nil {
+			return false
+		}
+	}
+	closing, errClosing := decoder.Token()
+	return errClosing == nil && closing == json.Delim('}') && keyIndex == len(want)
 }
 
 func plausibleClaudeCodeUserAgent(userAgent string, cfg *config.Config) bool {

--- a/internal/runtime/executor/helps/claude_client_detection_test.go
+++ b/internal/runtime/executor/helps/claude_client_detection_test.go
@@ -3,6 +3,7 @@ package helps
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -21,6 +22,51 @@ func confirmedClaudeCodeHeaders() http.Header {
 		"X-App":          {"cli"},
 		"Anthropic-Beta": {"claude-code-20250219,interleaved-thinking-2025-05-14"},
 	}
+}
+
+func measuredClaudeCodeHelperHeaders(betaProfile string, structured bool) http.Header {
+	profile := defaultClaudeDeviceProfile(&config.Config{})
+	headers := http.Header{
+		"Accept":            {"application/json"},
+		"Accept-Encoding":   {"gzip"},
+		"Content-Type":      {"application/json"},
+		"User-Agent":        {profile.UserAgent},
+		"X-App":             {"cli"},
+		"Anthropic-Beta":    {betaProfile},
+		"Anthropic-Version": {"2023-06-01"},
+		"Anthropic-Dangerous-Direct-Browser-Access": {"true"},
+		"X-Claude-Code-Session-Id":                  {"11111111-2222-4333-8444-555555555555"},
+		"X-Client-Request-Id":                       {"66666666-7777-4888-8999-aaaaaaaaaaaa"},
+		"X-Stainless-Lang":                          {"js"},
+		"X-Stainless-Runtime":                       {"node"},
+		"X-Stainless-Package-Version":               {profile.PackageVersion},
+		"X-Stainless-Runtime-Version":               {profile.RuntimeVersion},
+		"X-Stainless-OS":                            {profile.OS},
+		"X-Stainless-Arch":                          {profile.Arch},
+		"X-Stainless-Retry-Count":                   {"0"},
+		"X-Stainless-Timeout":                       {"600"},
+	}
+	if structured {
+		headers.Set("Accept-Encoding", "gzip, deflate, br, zstd")
+		headers.Set("X-Stainless-Async", "async")
+	}
+	canonical := make(http.Header, len(headers))
+	for name, values := range headers {
+		for _, value := range values {
+			canonical.Add(name, value)
+		}
+	}
+	return canonical
+}
+
+func measuredClaudeCodeMinimalHelperPayload() []byte {
+	encodedUserID, _ := json.Marshal(validClaudeCodeMetadataUserID)
+	return []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"helper probe"}],"metadata":{"user_id":` + string(encodedUserID) + `}}`)
+}
+
+func measuredClaudeCodeStructuredHelperPayload() []byte {
+	encodedUserID, _ := json.Marshal(validClaudeCodeMetadataUserID)
+	return []byte(`{"model":"claude-haiku-4-5-20251001","messages":[{"role":"user","content":[{"type":"text","text":"helper probe"}]}],"system":[{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.220; cc_entrypoint=cli; cch=00000;"},{"type":"text","text":"You are Claude Code, Anthropic's official CLI for Claude."},{"type":"text","text":"Return a short title."}],"tools":[],"metadata":{"user_id":` + string(encodedUserID) + `},"max_tokens":32000,"thinking":{"type":"disabled"},"temperature":1,"output_config":{"format":{"type":"json_schema","schema":{"type":"object","properties":{"title":{"type":"string"}},"required":["title"],"additionalProperties":false}}},"stream":true}`)
 }
 
 func TestDetectClaudeCodeRequestRequiresAllFourMessageSignals(t *testing.T) {
@@ -126,6 +172,172 @@ func TestDetectClaudeCodeCountTokensAllowsMissingMetadata(t *testing.T) {
 	}
 }
 
+func TestDetectClaudeCodeRequestRecognizesMeasuredHaikuHelpers(t *testing.T) {
+	tests := []struct {
+		name       string
+		beta       string
+		structured bool
+		payload    []byte
+	}{
+		{
+			name:    "minimal with redact thinking",
+			beta:    claudeCodeHelperBetaProfile(true),
+			payload: measuredClaudeCodeMinimalHelperPayload(),
+		},
+		{
+			name:    "minimal without redact thinking",
+			beta:    claudeCodeHelperBetaProfile(false),
+			payload: measuredClaudeCodeMinimalHelperPayload(),
+		},
+		{
+			name:       "structured title helper with advisor",
+			beta:       claudeCodeHelperBetaProfile(true, "advisor-tool-2026-03-01", "structured-outputs-2025-12-15", "cache-diagnosis-2026-04-07"),
+			structured: true,
+			payload:    measuredClaudeCodeStructuredHelperPayload(),
+		},
+		{
+			name:       "structured title helper with fallback credit",
+			beta:       claudeCodeHelperBetaProfile(true, "structured-outputs-2025-12-15", "fallback-credit-2026-06-01"),
+			structured: true,
+			payload:    measuredClaudeCodeStructuredHelperPayload(),
+		},
+		{
+			name:       "structured title helper with lowercase hex CCH",
+			beta:       claudeCodeHelperBetaProfile(true, "structured-outputs-2025-12-15"),
+			structured: true,
+			payload:    []byte(strings.Replace(string(measuredClaudeCodeStructuredHelperPayload()), "cch=00000", "cch=7ee87", 1)),
+		},
+		{
+			name:       "structured title helper without redact thinking",
+			beta:       claudeCodeHelperBetaProfile(false, "structured-outputs-2025-12-15"),
+			structured: true,
+			payload:    measuredClaudeCodeStructuredHelperPayload(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			detection := DetectClaudeCodeRequest(
+				measuredClaudeCodeHelperHeaders(test.beta, test.structured),
+				test.payload,
+				false,
+			)
+			if !detection.Confirmed || !detection.StrongSignals || !detection.NativeClient || !detection.HelperProfile {
+				t.Fatalf("detection = %#v, want confirmed measured helper", detection)
+			}
+			if detection.BetasPresent {
+				t.Fatalf("claude-code beta signal = true, want helper profile to remain separate: %#v", detection)
+			}
+		})
+	}
+}
+
+func TestDetectClaudeCodeRequestRejectsMalformedStructuredHaikuHelpers(t *testing.T) {
+	basePayload := string(measuredClaudeCodeStructuredHelperPayload())
+	beta := claudeCodeHelperBetaProfile(true, "structured-outputs-2025-12-15")
+	for _, test := range []struct {
+		name    string
+		payload string
+	}{
+		{name: "non-hex CCH", payload: strings.Replace(basePayload, "cch=00000", "cch=ghijk", 1)},
+		{name: "uppercase CCH", payload: strings.Replace(basePayload, "cch=00000", "cch=7EE87", 1)},
+		{name: "wrong token cap", payload: strings.Replace(basePayload, `"max_tokens":32000`, `"max_tokens":32001`, 1)},
+		{name: "open schema", payload: strings.Replace(basePayload, `"additionalProperties":false`, `"additionalProperties":true`, 1)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			detection := DetectClaudeCodeRequest(measuredClaudeCodeHelperHeaders(beta, true), []byte(test.payload), false)
+			if detection.Confirmed || detection.HelperProfile {
+				t.Fatalf("detection = %#v, want malformed structured helper rejected", detection)
+			}
+		})
+	}
+}
+
+func TestDetectClaudeCodeRequestRejectsNearMissHaikuHelpers(t *testing.T) {
+	minimalPayload := string(measuredClaudeCodeMinimalHelperPayload())
+	tests := []struct {
+		name        string
+		mutate      func(http.Header)
+		payload     string
+		countTokens bool
+	}{
+		{
+			name: "unexpected beta profile",
+			mutate: func(headers http.Header) {
+				headers.Set("Anthropic-Beta", headers.Get("Anthropic-Beta")+",unknown-beta")
+			},
+			payload: minimalPayload,
+		},
+		{
+			name: "missing stainless package",
+			mutate: func(headers http.Header) {
+				headers.Del("X-Stainless-Package-Version")
+			},
+			payload: minimalPayload,
+		},
+		{
+			name: "wrong compression profile",
+			mutate: func(headers http.Header) {
+				headers.Set("Accept-Encoding", "gzip, deflate, br, zstd")
+			},
+			payload: minimalPayload,
+		},
+		{
+			name: "mismatched session header",
+			mutate: func(headers http.Header) {
+				headers.Set("X-Claude-Code-Session-Id", "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
+			},
+			payload: minimalPayload,
+		},
+		{
+			name: "invalid request id",
+			mutate: func(headers http.Header) {
+				headers.Set("X-Client-Request-Id", "not-a-uuid")
+			},
+			payload: minimalPayload,
+		},
+		{
+			name: "unexpected async mode",
+			mutate: func(headers http.Header) {
+				headers.Set("X-Stainless-Async", "async")
+			},
+			payload: minimalPayload,
+		},
+		{
+			name:    "wrong helper model",
+			payload: strings.Replace(minimalPayload, claudeCodeHelperModel, "claude-sonnet-4-6", 1),
+		},
+		{
+			name:    "wrong helper token cap",
+			payload: strings.Replace(minimalPayload, `"max_tokens":1`, `"max_tokens":2`, 1),
+		},
+		{
+			name:    "extra root key",
+			payload: strings.TrimSuffix(minimalPayload, "}") + `,"tools":[]}`,
+		},
+		{
+			name:    "cache marker content shape",
+			payload: strings.Replace(minimalPayload, `"content":"helper probe"`, `"content":[{"type":"text","text":"helper probe","cache_control":{"type":"ephemeral","ttl":"1h"}}]`, 1),
+		},
+		{
+			name:        "count tokens endpoint",
+			payload:     minimalPayload,
+			countTokens: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+			if test.mutate != nil {
+				test.mutate(headers)
+			}
+			detection := DetectClaudeCodeRequest(headers, []byte(test.payload), test.countTokens)
+			if detection.Confirmed || detection.HelperProfile {
+				t.Fatalf("detection = %#v, want helper near miss rejected", detection)
+			}
+		})
+	}
+}
+
 func TestDetectClaudeCodeRequestRejectsMalformedNativeSignals(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -148,4 +360,171 @@ func TestDetectClaudeCodeRequestRejectsMalformedNativeSignals(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Recovered from the native metadata builder in 2.1.220, 2.1.221 and 2.1.227:
+//
+//	{...extraMetadata, device_id, account_uuid, session_id, ...parentSessionId && {parent_session_id}}
+//
+// parent_session_id is therefore a legitimate optional trailing key that sub-agent
+// and forked sessions attach, and it must not disqualify a helper request.
+func TestDetectClaudeCodeRequestAcceptsHelperSubagentParentSessionID(t *testing.T) {
+	identity := `{"device_id":"0000000000000000000000000000000000000000000000000000000000000000","account_uuid":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","session_id":"11111111-2222-4333-8444-555555555555","parent_session_id":"99999999-8888-4777-8666-555555555555"}`
+	encoded, _ := json.Marshal(identity)
+	payload := []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"helper probe"}],"metadata":{"user_id":` + string(encoded) + `}}`)
+
+	detection := DetectClaudeCodeRequest(
+		measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false),
+		payload,
+		false,
+	)
+	if !detection.Confirmed || !detection.HelperProfile {
+		t.Fatalf("detection = %#v, want a confirmed sub-agent helper", detection)
+	}
+}
+
+func TestDetectClaudeCodeRequestRejectsHelperIdentityWithUnknownKeys(t *testing.T) {
+	identity := `{"device_id":"0000000000000000000000000000000000000000000000000000000000000000","account_uuid":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","session_id":"11111111-2222-4333-8444-555555555555","spoofed":"x"}`
+	encoded, _ := json.Marshal(identity)
+	payload := []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"helper probe"}],"metadata":{"user_id":` + string(encoded) + `}}`)
+
+	detection := DetectClaudeCodeRequest(
+		measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false),
+		payload,
+		false,
+	)
+	if detection.HelperProfile {
+		t.Fatalf("detection = %#v, want an unknown identity key to disqualify the helper profile", detection)
+	}
+}
+
+// The surrounding device-profile pipeline pins OS/Arch to the configured baseline
+// rather than rejecting a foreign platform, so a genuine Windows or Linux helper
+// must still be recognized instead of being cloaked.
+func TestDetectClaudeCodeRequestAcceptsHelperFromNonBaselinePlatform(t *testing.T) {
+	for _, platform := range []struct{ os, arch string }{
+		{"Windows", "x64"},
+		{"Linux", "x64"},
+		{"MacOS", "x64"},
+	} {
+		t.Run(platform.os+"/"+platform.arch, func(t *testing.T) {
+			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+			headers.Set("X-Stainless-OS", platform.os)
+			headers.Set("X-Stainless-Arch", platform.arch)
+
+			detection := DetectClaudeCodeRequest(headers, measuredClaudeCodeMinimalHelperPayload(), false)
+			if !detection.Confirmed || !detection.HelperProfile {
+				t.Fatalf("detection = %#v, want a confirmed helper on a non-baseline platform", detection)
+			}
+		})
+	}
+}
+
+func TestDetectClaudeCodeRequestRejectsHelperWithoutPlatformHeaders(t *testing.T) {
+	for _, name := range []string{
+		"X-Stainless-OS",
+		"X-Stainless-Arch",
+		"X-Stainless-Package-Version",
+		"X-Stainless-Runtime-Version",
+	} {
+		t.Run("missing "+name, func(t *testing.T) {
+			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+			headers.Del(name)
+
+			detection := DetectClaudeCodeRequest(headers, measuredClaudeCodeMinimalHelperPayload(), false)
+			if detection.HelperProfile {
+				t.Fatalf("detection = %#v, want a missing %s to disqualify the helper profile", detection, name)
+			}
+		})
+	}
+}
+
+func TestDetectClaudeCodeRequestRejectsHelperWithForeignSoftwareTuple(t *testing.T) {
+	for name, value := range map[string]string{
+		"X-Stainless-Package-Version": "0.0.1",
+		"X-Stainless-Runtime-Version": "v0.0.1",
+	} {
+		t.Run(name, func(t *testing.T) {
+			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+			headers.Set(name, value)
+
+			detection := DetectClaudeCodeRequest(headers, measuredClaudeCodeMinimalHelperPayload(), false)
+			if detection.HelperProfile {
+				t.Fatalf("detection = %#v, want a foreign %s to disqualify the helper profile", detection, name)
+			}
+		})
+	}
+}
+
+func TestNormalizedClaudeBetaHeaderIsDeterministic(t *testing.T) {
+	canonical := http.Header{}
+	canonical.Add("Anthropic-Beta", "oauth-2025-04-20")
+	canonical.Add("Anthropic-Beta", "interleaved-thinking-2025-05-14")
+	if got, want := normalizedClaudeBetaHeader(canonical), "oauth-2025-04-20,interleaved-thinking-2025-05-14"; got != want {
+		t.Fatalf("canonical join = %q, want %q", got, want)
+	}
+
+	// Two non-canonical spellings in one map used to be joined in Go map order.
+	nonCanonical := http.Header{
+		"anthropic-beta": {"oauth-2025-04-20"},
+		"ANTHROPIC-BETA": {"interleaved-thinking-2025-05-14"},
+	}
+	first := normalizedClaudeBetaHeader(nonCanonical)
+	for i := 0; i < 50; i++ {
+		if got := normalizedClaudeBetaHeader(nonCanonical); got != first {
+			t.Fatalf("non-canonical join is order-dependent: %q then %q", first, got)
+		}
+	}
+	if !strings.Contains(first, "oauth-2025-04-20") || !strings.Contains(first, "interleaved-thinking-2025-05-14") {
+		t.Fatalf("non-canonical join lost values: %q", first)
+	}
+
+	if got := normalizedClaudeBetaHeader(nil); got != "" {
+		t.Fatalf("nil header join = %q, want empty", got)
+	}
+}
+
+// A confirmed helper is routed through misc.EnsureHeader, so CPA forwards the
+// helper's own X-Stainless-Timeout and never the operator default. Keying the
+// detector on claude-header-defaults.timeout instead of the measured constant
+// therefore rejected every genuine helper whenever that value was customized.
+func TestMeasuredHelperProfileIgnoresConfiguredStainlessTimeout(t *testing.T) {
+	headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+	payload := measuredClaudeCodeMinimalHelperPayload()
+	if got := headers.Get("X-Stainless-Timeout"); got != claudeDefaultStainlessTimeout {
+		t.Fatalf("measured helper timeout = %q, want %q", got, claudeDefaultStainlessTimeout)
+	}
+
+	withTimeout := func(timeout string) *config.Config {
+		cfg := &config.Config{}
+		cfg.ClaudeHeaderDefaults.Timeout = timeout
+		return cfg
+	}
+	for _, test := range []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{name: "nil config"},
+		{name: "unset", cfg: &config.Config{}},
+		{name: "measured default", cfg: withTimeout(claudeDefaultStainlessTimeout)},
+		{name: "shorter operator default", cfg: withTimeout("300")},
+		{name: "longer operator default", cfg: withTimeout("900")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			detection := DetectClaudeCodeRequest(headers, payload, false, test.cfg)
+			if !detection.HelperProfile || !detection.Confirmed {
+				t.Fatalf("detection = %#v, want confirmed helper regardless of configured timeout", detection)
+			}
+		})
+	}
+
+	// The measured constant stays the only accepted value, so a caller that does not
+	// send it is still disqualified even when the operator default happens to match.
+	t.Run("foreign timeout stays rejected", func(t *testing.T) {
+		foreign := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+		foreign.Set("X-Stainless-Timeout", "900")
+		if detection := DetectClaudeCodeRequest(foreign, payload, false, withTimeout("900")); detection.HelperProfile {
+			t.Fatalf("detection = %#v, want a non-measured timeout to disqualify the helper profile", detection)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Three focused Claude executor fixes aligned with Claude Code 2.1.220 / 2.1.221 / 2.1.227 request-builder behavior. The third was found while live-testing the second and is an outright upstream rejection, so it is fixed here rather than left in place.

### 1. Cloaked prompt-cache ownership and native shape
- Cloaked Responses/Chat/Gemini→Claude traffic was skipping `ensureCacheControl` once the first-user cloak marker existed, freezing multi-turn cache hits.
- Always ensure section-independent system + rolling-message breakpoints for non-native callers; leave confirmed Claude Code placement intact.
- Default breakpoint is `{"type":"ephemeral"}` (no `ttl`). A `1h` body ttl is upgraded only after placement, only for OAuth credentials, and only onto blocks that already carry `cache_control`, so it stays paired with `extended-cache-ttl-2025-04-11`.
- Rolling selector matches native: last eligible turn, skip thinking-like assistant tails, final non-empty string system special case.
- Tools stay unstamped when a usable system prompt covers the prefix; fall back to a tools breakpoint when system is absent/empty/blank.
- Empty/whitespace string systems are not rewritten into a marked text block (avoids tools + whitespace double-stamp).

### 2. Native Haiku helper recognition and passthrough
- Measured Claude Code Haiku helpers intentionally omit the `claude-code` beta (and the minimal shape omits `system`). Recognize those profiles as confirmed native instead of cloaking them.
- Accept optional `parent_session_id`, require platform headers for presence + software baseline (not OS/Arch equality), derive timeout/version from the measured native constant.
- Keep discriminating signals strict: exact beta allowlist, body shape, lowercase hex CCH, session binding.
- Preserve helper transport headers; omit synthetic `stream:false` on markerless helpers; gate billing/CCH fallback on system presence so a pipeline-attached system cannot go upstream unsigned.

### 3. Automatic `context_management` without eligible thinking
- Anthropic rejects the injected `clear_thinking_20251015` strategy unless `thinking` is enabled or adaptive; both the injection and the reconciliation only excluded the literal `{"type":"disabled"}`, so an **absent** `thinking` field slipped through and the request 400'd.
- Reachable both when the caller never sent `thinking` and when `disableThinkingIfToolChoiceForced` deletes it between injection and reconciliation.
- Both sides now test for the accepted values via a shared `claudeThinkingAcceptsClearThinking`; caller-owned and payload-rule-owned objects keep their existing precedence.

## Related issues

Fixes #4855

## Commits
1. `fix(claude): restore cloaked prompt-cache ownership and native shape`
2. `fix(claude): recognize and pass through native Haiku helpers`
3. `fix(claude): drop auto context_management without eligible thinking`

## Review follow-ups (applied)

- **Helper detection no longer keys on `claude-header-defaults.timeout`.** `applyClaudeHeaders` routes a confirmed client through `misc.EnsureHeader`, which prefers the *incoming* header and only falls back to the configured value when the caller sent none — so a confirmed helper always forwards its own `600`. Comparing against the operator value meant any non-`600` `claude-header-defaults.timeout` rejected **every** genuine helper and cloaked it, defeating commit 2. The matcher now compares the measured constant `600` only. Guarded by `TestMeasuredHelperProfileIgnoresConfiguredStainlessTimeout` (verified to fail when the config-derived value is reintroduced). The test that pinned the old inverted contract was removed.
- **Corrected two comments that described the opposite of the code.** The ttl-upgrade comment claimed it "leaves an explicit caller-owned 5m choice untouched", but a caller's bare `{"type":"ephemeral"}` (which *is* 5m) is upgraded to `1h`; only an explicitly written `ttl` survives. The `x-client-request-id` comment implied the fresh `uuid.New()` is what preserves a helper's native ID, when `identityHeader`/`EnsureHeader` does.
- **Added the missing end-to-end regression guard for #4855**: `TestClaudeExecutorCloakedRollingCacheBreakpointAdvances` drives two different-length cloaked conversations through `Execute` and asserts the rolling breakpoint advances to the final turn while cloaking's first-user marker survives and the total stays within 4. Restoring the old global `countCacheControls(body) == 0` short-circuit makes it fail with `short=1 long=1`, i.e. the exact frozen-breakpoint symptom from the issue.

- **Confirmed native now keeps its own sampling parameters.** `normalizeClaudeSamplingForUpstream` deleted `temperature`/`top_p` from *every* Claude request. The measured structured Haiku helper sends `"temperature":1`, and `claudeCodeHelperShapeStructured` keys on exactly that value — so CPA required the field to classify the request and then stripped it before sending, emitting a shape no native client produces. Confirmed native now owns its sampling exactly as it already owns `cache_control` placement, and only combinations Anthropic actually rejects are dropped. Translated and cloaked callers keep the previous conservative normalization unchanged. Guarded by `TestNormalizeClaudeSamplingForUpstreamNativeKeepsMeasuredHelperTemperature` and `TestNormalizeClaudeSamplingForUpstreamNativeDropsOnlyRejectedCombinations` (both verified to fail against the old unconditional strip, and the latter also against a naive preserve-everything implementation).

  Anthropic's real constraints, probed live against `api.anthropic.com`:

  | thinking | accepted |
  | --- | --- |
  | off / absent | `temperature` any, `top_p` any, `top_k` any — but `temperature` + `top_p` together → 400 |
  | enabled | `temperature` only `1`; `top_p` only `>= 0.95`; `top_k` must be unset |

## Test plan
- [x] `go test ./internal/runtime/executor/ ./internal/runtime/executor/helps/`
- [x] `go test ./... -count=1`, `-race` on Claude/cache/helper/diagnostics, `go vet`, `gofmt -l`, `go build ./cmd/server`, `git diff --check`
- [x] Per-commit worktree build/test for all three commits
- [x] Reviewer: confirm cloaked multi-turn cache ownership change is intended — settled by the live measurement below
- [x] Reviewer: confirm API-key traffic no longer carries unpaired `ttl:1h` — verified by unit test + code path (`claudeCredentialUsesOAuth` gate, `TestClaudeExecutor_CacheTTLIsPairedWithExtendedCacheTTLBeta`), not live
- [x] Live: native Haiku helper through a real CPA keeps the measured wire — see "Live verification of the native helper wire" below

### Live verification of the cloaked cache-ownership question

The one substantive risk in commit 1 was dropping the `tools` breakpoint whenever a system exists: under cloak, `system[0]` is the `x-anthropic-billing-header:` block, and its bytes change on **every** request (the `cch` digits are an xxHash over the whole final body, and cloak's `cc_version` buildHash is `computeFingerprint` over the last user message). If that block were part of the prompt-cache key, every breakpoint after it would be poisoned and removing the tools breakpoint would take cloaked cache hits to zero.

Measured directly against `api.anthropic.com` with a Claude OAuth credential on `claude-haiku-4-5`, as a **read-only** probe against a pre-existing 4098-token cache entry (so cache-write throttling cannot confound it), with a no-change control before and after in the same run — reproduced across two independent runs:

| request | `cache_read_input_tokens` |
| --- | --- |
| baseline, no `system` field | 4098 |
| `+ system:[{billing block}]` | **4098** (same entry) |
| `+ system:[{"You are helpful."}]` (4 tokens) | 0 → creates/reads a separate 4102 entry |
| control, no `system` again | 4098 |

`system=[billing block]` is therefore **equivalent to sending no system at all**: Anthropic strips that block, and it contributes zero tokens to the prompt and to the cache key, while ordinary system content of only 4 tokens does change the key. The per-request `cch`/buildHash cannot poison any cache prefix, so leaving `tools` unstamped when a system exists is safe and matches the native builder.

Not established: per-section breakpoint efficacy (a `system` marker vs a message marker). Cache **creation** on this subscription credential is intermittently throttled — distinct large prefixes silently return `cache_creation_input_tokens=0` with no error — so that comparison was not measurable and is deliberately not claimed either way.

### Live verification of the native helper wire

Ran a debug CPA built from this branch (isolated state dir, its own port, OAuth credential with the refresh token stripped) and replayed both measured Haiku helper shapes through it, then read the upstream request log.

**Minimal helper** — upstream body is exactly `{model, max_tokens, messages, metadata}`: no `system`, so no billing block and no CCH; no `stream` key (the measured non-stream helper omits it rather than sending `false`); no `cache_control`, `context_management` or `diagnostics`; `Anthropic-Beta` forwarded verbatim with no `claude-code-20250219` and no `extended-cache-ttl-2025-04-11`; `Accept-Encoding: gzip` and no `X-Stainless-Async`, matching the minimal transport profile. HTTP 200.

**Structured helper** — upstream top-level keys are exactly the captured native order:

```
model, messages, system, tools, metadata, max_tokens, thinking, temperature, output_config, stream
```

with `temperature: 1` preserved, the caller's three `system` blocks untouched, no `cache_control`/`context_management`/`diagnostics` injected, `stream: true` and `X-Stainless-Async: async` preserved, and `Anthropic-Beta` forwarded verbatim. The billing block's `cch` is re-signed (`00000` → real digest) and `metadata.user_id` identity is remapped to the selected credential while `session_id` is preserved, both of which are the intended `ApplyClaudeCredentialMetadata` behaviour. HTTP 200 with a normal SSE stream.

Control in the same run: a plain non-native caller sending `temperature`/`top_p`/`top_k` still reaches upstream with `temperature` and `top_p` stripped and `top_k` kept — identical to the previous behaviour.

The measured shapes themselves were re-confirmed against real captured native traffic (316 `POST api.anthropic.com/v1/messages` flows from Claude Code `2.1.220`/`2.1.221` on OAuth). Across a spread of 24, only the structured helper carries `temperature`; main conversation turns, the minimal helper and model probes all omit it — which is exactly what the detector encodes.

### Live verification of the `context_management` rejection

Found while live-testing the helper wire, and fixed here rather than left in place because it is a hard upstream rejection.

Anthropic refuses the strategy CPA injects unless thinking is enabled or adaptive:

```
400 invalid_request_error:
`clear_thinking_20251015` strategy requires `thinking` to be enabled or adaptive
```

`injectClaudeCodeContextManagement` and `reconcileClaudeCodeContextManagement` both special-cased only the literal `{"type":"disabled"}`, so an **absent** `thinking` field read back as gjson's empty string and slipped through both. Two reachable paths produced the rejected body:

1. a cloaked caller that never sent `thinking` at all;
2. a caller whose `thinking` was enabled at injection time and then deleted by `disableThinkingIfToolChoiceForced`, which runs between injection and reconciliation.

Both now test for the accepted values through a shared `claudeThinkingAcceptsClearThinking` helper, so reconciliation also withdraws an object CPA injected itself once thinking disappears. Caller-owned and payload-rule-owned objects keep their existing precedence and are never withdrawn.

Probed directly against `api.anthropic.com` with `context_management` fixed and only `thinking` varying:

| `thinking` | result |
| --- | --- |
| absent | **400** `requires thinking to be enabled or adaptive` |
| `disabled` | **400** same |
| `enabled` | 200 |
| `adaptive` | reaches the model check (`adaptive thinking is not supported on this model`), i.e. accepted by the strategy |

Live through a real CPA on this branch: a cloaked no-thinking request now sends no `context_management` and returns 200 (previously 400), while a thinking-enabled request still carries it and returns 200.

The existing expectation that forced tool choice *retains* the automatic object pinned exactly the rejected shape, so it is inverted. Both halves of the fix were negative-control verified independently.

## Notes
- Related but distinct from #4731 (configurable default TTL): this PR aligns with native pairing (default no `1h`; OAuth-only upgrade + beta), not a free-form default TTL config.
- Scope is Claude executor / client detection only; no translator changes.

## Open reviewer question

Codex flagged (P2) that a markerless helper backed by an **API-key** credential now forwards the helper's OAuth-only beta profile (every allowed profile starts with `oauth-2025-04-20`) together with `x-api-key`, instead of being cloaked.

Verified: the mechanism is real, but it is **pre-existing** for confirmed native callers rather than introduced here. `baseBetas = incomingBetas` has always applied to any `confirmedClaudeCode` request regardless of credential kind — a standard (non-helper) native request on an API-key credential already emits `claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14` with `x-api-key` today. What commit 2 changes is only *which callers count as confirmed native*. The `!helperProfile` gate itself behaves correctly: `extended-cache-ttl-2025-04-11` is appended for OAuth std-native and for neither helper case.

So gating **only** the helper profile on OAuth would make helper and standard native traffic inconsistent on the same credential. The consistent alternatives are to leave this as-is, or to OAuth-gate confirmed-native beta passthrough as a whole — which is a broader behavior change than this PR's scope and touches the "confirmed native preserves its measured wire shape" invariant. Flagging for a maintainer decision rather than silently picking one.




