### PR TITLE
perf(antigravity): reuse native upstream connections

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -69,13 +69,25 @@ func (e *AntigravityExecutor) obfuscateSensitiveWords(payload []byte) []byte {
 	return helps.ObfuscateSensitiveWordsInSystemInstruction(payload, matcher)
 }
 
-// antigravityTransport is a singleton HTTP/1.1 transport shared by all Antigravity requests.
-// It is initialized once via antigravityTransportOnce to avoid leaking a new connection pool
-// (and the goroutines managing it) on every request.
+// Each Antigravity credential gets its own HTTP/1.1 connection pool. Sessions routed
+// to the same auth reuse that pool, while different OAuth identities never share a
+// TCP/TLS connection, matching the native client's one-credential process model.
 var (
-	antigravityTransport     *http.Transport
-	antigravityTransportOnce sync.Once
+	antigravityBaseTransport = defaultAntigravityBaseTransport()
+	antigravityTransports    sync.Map // antigravityTransportKey -> *http.Transport
 )
+
+type antigravityTransportKey struct {
+	credential string
+	base       *http.Transport
+}
+
+func defaultAntigravityBaseTransport() *http.Transport {
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok && transport != nil {
+		return transport
+	}
+	return &http.Transport{}
+}
 
 func cloneTransportWithHTTP11(base *http.Transport) *http.Transport {
 	if base == nil {
@@ -91,38 +103,101 @@ func cloneTransportWithHTTP11(base *http.Transport) *http.Transport {
 	} else {
 		clone.TLSClientConfig = clone.TLSClientConfig.Clone()
 	}
-	// Actively advertise only HTTP/1.1 in the ALPN handshake.
-	clone.TLSClientConfig.NextProtos = []string{"http/1.1"}
+	// Native Antigravity sends no ALPN extension. With HTTP/2 disabled above,
+	// an empty NextProtos keeps the wire shape aligned while using HTTP/1.1.
+	clone.TLSClientConfig.NextProtos = nil
 	return clone
 }
 
-// initAntigravityTransport creates the shared HTTP/1.1 transport exactly once.
-func initAntigravityTransport() {
-	base, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		base = &http.Transport{}
+// antigravityHTTP11Transport returns the HTTP/1.1 pool for one credential and
+// base transport. The base is either the process default, a credential-scoped
+// proxy transport, or a context-provided transport.
+func antigravityHTTP11Transport(auth *cliproxyauth.Auth, base *http.Transport) *http.Transport {
+	if base == nil {
+		return nil
 	}
-	antigravityTransport = cloneTransportWithHTTP11(base)
+	credential, shareable := antigravityTransportScope(auth)
+	if !shareable {
+		// Without a stable credential identity there is no safe cache key: pointer
+		// identity is reused once the old auth is collected, which would silently
+		// merge two unrelated OAuth identities onto the same TCP/TLS connections.
+		// Fall back to a private pool instead of risking cross-credential sharing.
+		return cloneTransportWithHTTP11(base)
+	}
+	key := antigravityTransportKey{
+		credential: credential,
+		base:       base,
+	}
+	if cached, ok := antigravityTransports.Load(key); ok {
+		return cached.(*http.Transport)
+	}
+	clone := cloneTransportWithHTTP11(base)
+	actual, _ := antigravityTransports.LoadOrStore(key, clone)
+	stored := actual.(*http.Transport)
+	if stored != clone {
+		// Another goroutine won the race; drop the redundant pool.
+		clone.CloseIdleConnections()
+	}
+	return stored
+}
+
+// antigravityTransportScope returns the connection-pool scope for one credential
+// and reports whether that scope is stable enough to share a pool across requests.
+// Runtime auths always carry an ID; incomplete test or plugin auth objects do not
+// and must never be grouped together.
+func antigravityTransportScope(auth *cliproxyauth.Auth) (string, bool) {
+	if auth == nil {
+		return "", false
+	}
+	id := strings.TrimSpace(auth.ID)
+	if id == "" {
+		return "", false
+	}
+	return "id:" + id, true
 }
 
 // newAntigravityHTTPClient creates an HTTP client specifically for Antigravity,
-// enforcing HTTP/1.1 by disabling HTTP/2 to perfectly mimic Node.js https defaults.
-// The underlying Transport is a singleton to avoid leaking connection pools.
+// enforcing HTTP/1.1 by disabling HTTP/2 to match the native Antigravity client, which
+// negotiates TLS 1.3 without advertising an ALPN protocol and therefore never uses h2.
+// The underlying Transport is always shared so keep-alive connections survive across
+// requests instead of forcing a fresh TCP + TLS handshake every time.
 func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, timeout time.Duration) *http.Client {
-	antigravityTransportOnce.Do(initAntigravityTransport)
+	credential, _ := antigravityTransportScope(auth)
+
+	// Native Antigravity reuses one transport across requests. Opt into a
+	// credential-scoped proxy transport only here so other providers keep their
+	// existing lifecycle and different OAuth identities remain isolated.
+	if proxyURL := antigravityProxyURL(cfg, auth); proxyURL != "" {
+		if transport, _, errProxy := helps.SharedProxyTransport(credential, proxyURL); errProxy == nil && transport != nil {
+			return &http.Client{Transport: antigravityHTTP11Transport(auth, transport), Timeout: timeout}
+		}
+	}
 
 	client := helps.NewProxyAwareHTTPClient(ctx, cfg, auth, timeout)
-	// If no transport is set, use the shared HTTP/1.1 transport.
+	// Direct requests share an HTTP/1.1 pool only within the selected credential.
 	if client.Transport == nil {
-		client.Transport = antigravityTransport
+		client.Transport = antigravityHTTP11Transport(auth, antigravityBaseTransport)
 		return client
 	}
 
-	// Preserve proxy settings from proxy-aware transports while forcing HTTP/1.1.
+	// Preserve a context-provided transport while forcing HTTP/1.1. The cache key
+	// includes credential identity, so sharing the base does not share TLS pools.
 	if transport, ok := client.Transport.(*http.Transport); ok {
-		client.Transport = cloneTransportWithHTTP11(transport)
+		client.Transport = antigravityHTTP11Transport(auth, transport)
 	}
 	return client
+}
+
+func antigravityProxyURL(cfg *config.Config, auth *cliproxyauth.Auth) string {
+	if auth != nil {
+		if proxyURL := strings.TrimSpace(auth.ProxyURL); proxyURL != "" {
+			return proxyURL
+		}
+	}
+	if cfg != nil {
+		return strings.TrimSpace(cfg.ProxyURL)
+	}
+	return ""
 }
 
 func sanitizeAntigravityGeminiRequestSignatures(modelName string, rawJSON []byte) []byte {
@@ -496,6 +571,12 @@ func (e *AntigravityExecutor) HttpRequest(ctx context.Context, auth *cliproxyaut
 	}
 	httpReq := req.WithContext(ctx)
 
+	// Connection management is a Request field, not a header, so the header
+	// whitelist below cannot strip it. An inbound "Connection: close" makes Go's
+	// server set Request.Close, and WithContext copies that field verbatim, which
+	// would both leak the downstream header upstream and drain the shared pool.
+	httpReq.Close = false
+
 	// --- Whitelist: save only the headers we need from the original request ---
 	contentType := httpReq.Header.Get("Content-Type")
 
@@ -510,7 +591,6 @@ func (e *AntigravityExecutor) HttpRequest(ctx context.Context, auth *cliproxyaut
 	}
 	// Content-Length is managed automatically by Go's http.Client from the Body
 	httpReq.Header.Set("User-Agent", resolveUserAgent(auth))
-	httpReq.Close = true // sends Connection: close
 
 	// Inject Authorization: Bearer <token>
 	if err := e.PrepareRequest(httpReq, auth); err != nil {

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -6,12 +6,13 @@ package executor
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
@@ -21,6 +22,7 @@ import (
 	antigravityclaude "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/antigravity/claude"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -72,13 +74,58 @@ func (e *AntigravityExecutor) obfuscateSensitiveWords(payload []byte) []byte {
 // Each Antigravity credential gets its own HTTP/1.1 connection pool. Sessions routed
 // to the same auth reuse that pool, while different OAuth identities never share a
 // TCP/TLS connection, matching the native client's one-credential process model.
+// The cache is bounded so pools cannot accumulate when keys churn.
 var (
 	antigravityBaseTransport = defaultAntigravityBaseTransport()
-	antigravityTransports    sync.Map // antigravityTransportKey -> *http.Transport
+	antigravityTransports    = helps.NewTransportCache[antigravityTransportKey](antigravityTransportCacheCapacity)
 )
 
+const (
+	// antigravityTransportCacheCapacity caps how many Antigravity connection pools stay
+	// alive. The bound exists only to stop entries from accumulating when keys churn, for
+	// example when a credential's proxy is rotated through the management API or when an
+	// SDK embedder supplies a freshly built base transport per request.
+	//
+	// It is sized for large deployments on purpose. An unused cache entry costs under 1 KB
+	// and no goroutines, so capacity is close to free, whereas evicting a pool that is
+	// still in active use forces the next request on that credential to redo the TCP + TLS
+	// handshake and defeats the point of caching. Credential counts in the low thousands
+	// are expected once Home-managed pools are included.
+	//
+	// Capacity is therefore NOT the lever for bounding memory: an idle pooled connection
+	// costs roughly 38 KB plus three goroutines, and that total is driven by live traffic
+	// and reclaimed by IdleConnTimeout. Shrinking this number does not save that memory,
+	// it only causes pool thrashing.
+	antigravityTransportCacheCapacity = 8192
+
+	// antigravityMaxIdleConnsPerHost mirrors the value that
+	// cloud.google.com/go/auth/httptransport and google.golang.org/api/transport/http
+	// set on their base transport, which is the stack the native Antigravity client
+	// uses. Both raise Go's DefaultMaxIdleConnsPerHost of 2 to 100 because the low
+	// default forces concurrent requests to re-handshake instead of reusing pooled
+	// connections.
+	antigravityMaxIdleConnsPerHost = 100
+
+	// antigravityIdleConnTimeout keeps pooled connections usable far longer than Go's
+	// 90s default. Captured native traffic reuses a connection after idle gaps with a
+	// p90 of roughly six minutes, and a 90s timeout would discard about an eighth of
+	// the reuses the native client actually performs.
+	antigravityIdleConnTimeout = 10 * time.Minute
+
+	// antigravityAnonymousTransportScope is the pool scope for auth objects that carry
+	// no identity at all. Reaching it means the auth has no ID, no source path and no
+	// token of any kind, so there is no credential to keep isolated and a single shared
+	// pool is safe. Allocating a private pool per request instead would leak a
+	// connection pool, and the goroutines managing it, on every call.
+	antigravityAnonymousTransportScope = "anonymous"
+)
+
+// antigravityTransportKey identifies one connection pool. At most one of proxy and
+// base is set: proxy for a credential-scoped proxy pool, base for a transport handed
+// in through the request context, and neither for a direct pool.
 type antigravityTransportKey struct {
 	credential string
+	proxy      string
 	base       *http.Transport
 }
 
@@ -106,54 +153,134 @@ func cloneTransportWithHTTP11(base *http.Transport) *http.Transport {
 	// Native Antigravity sends no ALPN extension. With HTTP/2 disabled above,
 	// an empty NextProtos keeps the wire shape aligned while using HTTP/1.1.
 	clone.TLSClientConfig.NextProtos = nil
+	applyAntigravityPoolLimits(clone)
 	return clone
 }
 
-// antigravityHTTP11Transport returns the HTTP/1.1 pool for one credential and
-// base transport. The base is either the process default, a credential-scoped
-// proxy transport, or a context-provided transport.
+// applyAntigravityPoolLimits widens the connection pool so keep-alive actually
+// survives concurrency and idle periods. Limits are only ever raised, so an
+// operator-supplied base transport with a larger pool keeps its own settings.
+func applyAntigravityPoolLimits(transport *http.Transport) {
+	if transport == nil {
+		return
+	}
+	// Go treats 0 as DefaultMaxIdleConnsPerHost (2) and a negative value as "never pool
+	// an idle connection". Raise the default and smaller positive values, but leave a
+	// negative value alone so an operator can still disable pooling outright.
+	if transport.MaxIdleConnsPerHost >= 0 && transport.MaxIdleConnsPerHost < antigravityMaxIdleConnsPerHost {
+		transport.MaxIdleConnsPerHost = antigravityMaxIdleConnsPerHost
+	}
+	// MaxIdleConns caps the pool across all hosts. Leaving it below the per-host limit
+	// would silently throttle Antigravity, which talks to a single host at a time.
+	// Zero means unlimited, so it must not be lowered.
+	if transport.MaxIdleConns > 0 && transport.MaxIdleConns < transport.MaxIdleConnsPerHost {
+		transport.MaxIdleConns = transport.MaxIdleConnsPerHost
+	}
+	// Zero already means "never expire idle connections", which is strictly longer.
+	if transport.IdleConnTimeout > 0 && transport.IdleConnTimeout < antigravityIdleConnTimeout {
+		transport.IdleConnTimeout = antigravityIdleConnTimeout
+	}
+}
+
+// antigravityHTTP11Transport returns the HTTP/1.1 pool shared by every request that
+// uses the same credential and the same base transport. The base is either the
+// process default or a transport provided through the request context.
 func antigravityHTTP11Transport(auth *cliproxyauth.Auth, base *http.Transport) *http.Transport {
 	if base == nil {
 		return nil
 	}
-	credential, shareable := antigravityTransportScope(auth)
-	if !shareable {
-		// Without a stable credential identity there is no safe cache key: pointer
-		// identity is reused once the old auth is collected, which would silently
-		// merge two unrelated OAuth identities onto the same TCP/TLS connections.
-		// Fall back to a private pool instead of risking cross-credential sharing.
-		return cloneTransportWithHTTP11(base)
-	}
 	key := antigravityTransportKey{
-		credential: credential,
+		credential: antigravityTransportScope(auth),
 		base:       base,
 	}
-	if cached, ok := antigravityTransports.Load(key); ok {
-		return cached.(*http.Transport)
+	transport, errGet := antigravityTransports.Get(key, func() (*http.Transport, error) {
+		return cloneTransportWithHTTP11(base), nil
+	})
+	if errGet != nil {
+		// Defensive only: the builder above cannot fail. Never return nil here, because a
+		// nil Transport makes http.Client fall back to http.DefaultTransport, which
+		// advertises h2 over ALPN and would break the Antigravity wire fingerprint.
+		log.Debugf("antigravity executor: cache HTTP/1.1 transport failed: %v", errGet)
+		return cloneTransportWithHTTP11(base)
 	}
-	clone := cloneTransportWithHTTP11(base)
-	actual, _ := antigravityTransports.LoadOrStore(key, clone)
-	stored := actual.(*http.Transport)
-	if stored != clone {
-		// Another goroutine won the race; drop the redundant pool.
-		clone.CloseIdleConnections()
-	}
-	return stored
+	return transport
 }
 
-// antigravityTransportScope returns the connection-pool scope for one credential
-// and reports whether that scope is stable enough to share a pool across requests.
-// Runtime auths always carry an ID; incomplete test or plugin auth objects do not
-// and must never be grouped together.
-func antigravityTransportScope(auth *cliproxyauth.Auth) (string, bool) {
+// antigravityProxiedHTTP11Transport returns the credential-scoped HTTP/1.1 pool for
+// one proxy setting, or nil when the proxy setting cannot be turned into a
+// transport. Keying on the normalized proxy string rather than on a prebuilt
+// transport keeps one pool per credential and proxy instead of one per request.
+func antigravityProxiedHTTP11Transport(auth *cliproxyauth.Auth, proxyURL string) *http.Transport {
+	proxyURL = strings.TrimSpace(proxyURL)
+	if proxyURL == "" {
+		return nil
+	}
+	key := antigravityTransportKey{
+		credential: antigravityTransportScope(auth),
+		proxy:      proxyURL,
+	}
+	transport, errGet := antigravityTransports.Get(key, func() (*http.Transport, error) {
+		base, _, errBuild := proxyutil.BuildHTTPTransport(proxyURL)
+		if errBuild != nil {
+			return nil, errBuild
+		}
+		if base == nil {
+			return nil, fmt.Errorf("antigravity executor: proxy setting produced no transport")
+		}
+		return cloneTransportWithHTTP11(base), nil
+	})
+	if errGet != nil {
+		// The caller falls back to NewProxyAwareHTTPClient, which reports the failure
+		// and applies the context transport fallback.
+		return nil
+	}
+	return transport
+}
+
+// antigravityTransportScope returns the connection-pool scope for one credential.
+// Runtime auths always carry an ID. Incomplete auth objects, such as those built by
+// tests, plugins or SDK embedders, fall back to another stable credential marker so
+// they neither share a pool with an unrelated OAuth identity nor allocate a fresh
+// pool, and with it a fresh set of pool goroutines, on every single request.
+func antigravityTransportScope(auth *cliproxyauth.Auth) string {
 	if auth == nil {
-		return "", false
+		return antigravityAnonymousTransportScope
 	}
-	id := strings.TrimSpace(auth.ID)
-	if id == "" {
-		return "", false
+	if id := strings.TrimSpace(auth.ID); id != "" {
+		return "id:" + id
 	}
-	return "id:" + id, true
+	if auth.Attributes != nil {
+		if path := strings.TrimSpace(auth.Attributes[cliproxyauth.AttributePath]); path != "" {
+			return "path:" + path
+		}
+		if source := strings.TrimSpace(auth.Attributes[cliproxyauth.AttributeSource]); source != "" {
+			return "source:" + source
+		}
+	}
+	// Fall back to the credential material itself. Auth.Label is deliberately not used:
+	// it is documented as an optional human readable label for logging and carries no
+	// uniqueness guarantee, so two different OAuth identities sharing one label would
+	// wrongly share a TCP/TLS pool.
+	//
+	// The refresh token is preferred over the access token because it stays stable
+	// across token rotation. Keying on the access token would move a credential to a new
+	// pool on every refresh, and would also strand refresh requests themselves, which
+	// run before any access token exists.
+	if refresh := strings.TrimSpace(metaStringValue(auth.Metadata, "refresh_token")); refresh != "" {
+		return antigravityCredentialScope("refresh:", refresh)
+	}
+	if access := strings.TrimSpace(metaStringValue(auth.Metadata, "access_token")); access != "" {
+		return antigravityCredentialScope("token:", access)
+	}
+	return antigravityAnonymousTransportScope
+}
+
+// antigravityCredentialScope derives a pool scope from secret credential material.
+// Only a short digest is retained, and it is never logged, so a pool key cannot be
+// used to recover the credential it came from.
+func antigravityCredentialScope(prefix, secret string) string {
+	digest := sha256.Sum256([]byte(secret))
+	return prefix + hex.EncodeToString(digest[:8])
 }
 
 // newAntigravityHTTPClient creates an HTTP client specifically for Antigravity,
@@ -162,15 +289,15 @@ func antigravityTransportScope(auth *cliproxyauth.Auth) (string, bool) {
 // The underlying Transport is always shared so keep-alive connections survive across
 // requests instead of forcing a fresh TCP + TLS handshake every time.
 func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, timeout time.Duration) *http.Client {
-	credential, _ := antigravityTransportScope(auth)
-
 	// Native Antigravity reuses one transport across requests. Opt into a
 	// credential-scoped proxy transport only here so other providers keep their
 	// existing lifecycle and different OAuth identities remain isolated.
 	if proxyURL := antigravityProxyURL(cfg, auth); proxyURL != "" {
-		if transport, _, errProxy := helps.SharedProxyTransport(credential, proxyURL); errProxy == nil && transport != nil {
-			return &http.Client{Transport: antigravityHTTP11Transport(auth, transport), Timeout: timeout}
+		if transport := antigravityProxiedHTTP11Transport(auth, proxyURL); transport != nil {
+			return &http.Client{Transport: transport, Timeout: timeout}
 		}
+		// Fall through so NewProxyAwareHTTPClient reports the failure and applies the
+		// context transport fallback, preserving the previous behavior.
 	}
 
 	client := helps.NewProxyAwareHTTPClient(ctx, cfg, auth, timeout)
@@ -182,9 +309,19 @@ func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cli
 
 	// Preserve a context-provided transport while forcing HTTP/1.1. The cache key
 	// includes credential identity, so sharing the base does not share TLS pools.
-	if transport, ok := client.Transport.(*http.Transport); ok {
-		client.Transport = antigravityHTTP11Transport(auth, transport)
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		// A RoundTripper that is not an *http.Transport owns its own protocol behavior.
+		return client
 	}
+	if transport == nil {
+		// A typed-nil *http.Transport still satisfies the interface nil check in
+		// NewProxyAwareHTTPClient. Leaving it in place would make http.Client fall back
+		// to http.DefaultTransport, which advertises h2 over ALPN and breaks the
+		// Antigravity fingerprint, so substitute the process base transport.
+		transport = antigravityBaseTransport
+	}
+	client.Transport = antigravityHTTP11Transport(auth, transport)
 	return client
 }
 

--- a/internal/runtime/executor/antigravity_executor_keepalive_test.go
+++ b/internal/runtime/executor/antigravity_executor_keepalive_test.go
@@ -1,0 +1,340 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+// TestAntigravityBuildRequestKeepsConnectionAlive guards the regression where the
+// upstream request forced "Connection: close", which discarded every established
+// TCP + TLS session and made connection pooling impossible. The native Antigravity
+// client omits the Connection header entirely.
+func TestAntigravityBuildRequestKeepsConnectionAlive(t *testing.T) {
+	e := &AntigravityExecutor{}
+	auth := &cliproxyauth.Auth{Metadata: map[string]any{"project_id": "project-1"}}
+	payload := []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`)
+
+	for _, stream := range []bool{false, true} {
+		name := "unary"
+		if stream {
+			name = "stream"
+		}
+		t.Run(name, func(t *testing.T) {
+			req, err := e.buildRequest(context.Background(), auth, "token", "gemini-3.6-flash-high", payload, stream, "", antigravityBaseURLDaily)
+			if err != nil {
+				t.Fatalf("buildRequest error: %v", err)
+			}
+			if req.Close {
+				t.Fatal("Antigravity upstream request must not force Connection: close")
+			}
+			if v := req.Header.Get("Connection"); v != "" {
+				t.Fatalf("Antigravity upstream request must not send a Connection header, got %q", v)
+			}
+		})
+	}
+}
+
+// TestAntigravityExecuteStreamReusesUpstreamConnection drives the real executor
+// against a local upstream and proves that repeated streaming requests share a
+// single pooled TCP connection and never advertise Connection: close.
+func TestAntigravityExecuteStreamReusesUpstreamConnection(t *testing.T) {
+	var mu sync.Mutex
+	remotes := map[string]int{}
+	var connectionHeaders []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		remotes[r.RemoteAddr]++
+		connectionHeaders = append(connectionHeaders, r.Header.Get("Connection"))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"response\":{\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":1,\"candidatesTokenCount\":1,\"totalTokenCount\":2}}}\n\n"))
+	}))
+	defer server.Close()
+
+	exec := NewAntigravityExecutor(&config.Config{RequestRetry: 1})
+	auth := &cliproxyauth.Auth{
+		ID:         "antigravity-keepalive-auth",
+		Provider:   "antigravity",
+		Attributes: map[string]string{"base_url": server.URL},
+		Metadata: map[string]any{
+			"access_token": "token",
+			"project_id":   "project-1",
+			"expired":      time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	const requests = 6
+	payload := []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)
+	for i := 0; i < requests; i++ {
+		result, errExecute := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+			Model:   "gemini-3.6-flash-high",
+			Payload: payload,
+		}, cliproxyexecutor.Options{
+			SourceFormat:    sdktranslator.FormatGemini,
+			ResponseFormat:  sdktranslator.FormatGemini,
+			Stream:          true,
+			OriginalRequest: payload,
+		})
+		if errExecute != nil {
+			t.Fatalf("request %d: ExecuteStream() error = %v", i, errExecute)
+		}
+		for chunk := range result.Chunks {
+			if chunk.Err != nil {
+				t.Fatalf("request %d: stream chunk error: %v", i, chunk.Err)
+			}
+		}
+	}
+
+	mu.Lock()
+	distinct := len(remotes)
+	total := 0
+	for _, c := range remotes {
+		total += c
+	}
+	headers := append([]string(nil), connectionHeaders...)
+	mu.Unlock()
+
+	if total != requests {
+		t.Fatalf("expected %d upstream requests, got %d", requests, total)
+	}
+	for i, h := range headers {
+		if h != "" {
+			t.Fatalf("upstream request %d advertised Connection: %q", i, h)
+		}
+	}
+	if distinct != 1 {
+		t.Fatalf("expected %d streaming requests to reuse one upstream connection, got %d connections", requests, distinct)
+	}
+}
+
+// TestAntigravityCountTokensReusesUpstreamConnection covers the second upstream
+// request builder, which shares the same connection pool.
+func TestAntigravityCountTokensReusesUpstreamConnection(t *testing.T) {
+	var mu sync.Mutex
+	remotes := map[string]int{}
+	var connectionHeaders []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		remotes[r.RemoteAddr]++
+		connectionHeaders = append(connectionHeaders, r.Header.Get("Connection"))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"totalTokens":7}`))
+	}))
+	defer server.Close()
+
+	exec := NewAntigravityExecutor(&config.Config{RequestRetry: 1})
+	auth := &cliproxyauth.Auth{
+		ID:         "antigravity-counttokens-auth",
+		Provider:   "antigravity",
+		Attributes: map[string]string{"base_url": server.URL},
+		Metadata: map[string]any{
+			"access_token": "token",
+			"project_id":   "project-1",
+			"expired":      time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	const requests = 4
+	payload := []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)
+	for i := 0; i < requests; i++ {
+		if _, errCount := exec.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+			Model:   "gemini-3.6-flash-high",
+			Payload: payload,
+		}, cliproxyexecutor.Options{
+			SourceFormat:    sdktranslator.FormatGemini,
+			ResponseFormat:  sdktranslator.FormatGemini,
+			OriginalRequest: payload,
+		}); errCount != nil {
+			t.Fatalf("request %d: CountTokens() error = %v", i, errCount)
+		}
+	}
+
+	mu.Lock()
+	distinct := len(remotes)
+	headers := append([]string(nil), connectionHeaders...)
+	mu.Unlock()
+	for i, h := range headers {
+		if h != "" {
+			t.Fatalf("countTokens request %d advertised Connection: %q", i, h)
+		}
+	}
+	if distinct != 1 {
+		t.Fatalf("expected %d countTokens requests to reuse one upstream connection, got %d connections", requests, distinct)
+	}
+}
+
+// TestAntigravityHTTPRequestReusesUpstreamConnection covers the raw passthrough
+// path and verifies its whitelist does not reintroduce Connection: close.
+// It exercises both ways a downstream caller can request a close: the header,
+// which the whitelist strips, and Request.Close, which is a struct field that
+// req.WithContext copies verbatim and the header whitelist cannot reach.
+func TestAntigravityHTTPRequestReusesUpstreamConnection(t *testing.T) {
+	var mu sync.Mutex
+	remotes := map[string]int{}
+	var connectionHeaders []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		remotes[r.RemoteAddr]++
+		connectionHeaders = append(connectionHeaders, r.Header.Get("Connection"))
+		mu.Unlock()
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	exec := NewAntigravityExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID:       "antigravity-http-request-auth",
+		Provider: "antigravity",
+		Metadata: map[string]any{
+			"access_token": "token",
+			"project_id":   "project-1",
+			"expired":      time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	const requests = 4
+	for i := 0; i < requests; i++ {
+		req, errRequest := http.NewRequest(http.MethodPost, server.URL, nil)
+		if errRequest != nil {
+			t.Fatalf("request %d: NewRequest() error = %v", i, errRequest)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Connection", "close")
+		// Go's server sets this field for an inbound "Connection: close"; it must not
+		// reach the Antigravity upstream.
+		req.Close = true
+		resp, errDo := exec.HttpRequest(context.Background(), auth, req)
+		if errDo != nil {
+			t.Fatalf("request %d: HttpRequest() error = %v", i, errDo)
+		}
+		if _, errDrain := io.Copy(io.Discard, resp.Body); errDrain != nil {
+			t.Fatalf("request %d: drain response body: %v", i, errDrain)
+		}
+		if errClose := resp.Body.Close(); errClose != nil {
+			t.Fatalf("request %d: close response body: %v", i, errClose)
+		}
+	}
+
+	mu.Lock()
+	distinct := len(remotes)
+	headers := append([]string(nil), connectionHeaders...)
+	mu.Unlock()
+	for i, h := range headers {
+		if h != "" {
+			t.Fatalf("raw request %d advertised Connection: %q", i, h)
+		}
+	}
+	if distinct != 1 {
+		t.Fatalf("expected %d raw requests to reuse one upstream connection, got %d connections", requests, distinct)
+	}
+}
+
+// TestAntigravityHTTPRequestConcurrentSessionsStayIsolated forces concurrent
+// requests from one auth to complete in reverse order and verifies each caller
+// receives only its own response body.
+func TestAntigravityHTTPRequestConcurrentSessionsStayIsolated(t *testing.T) {
+	const sessions = 12
+	gates := make(map[string]chan struct{}, sessions)
+	markers := make([]string, sessions)
+	for i := range sessions {
+		markers[i] = fmt.Sprintf("session-%02d", i)
+		gates[markers[i]] = make(chan struct{})
+	}
+	arrived := make(chan string, sessions)
+	completed := make(chan string, sessions)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		marker, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			http.Error(w, errRead.Error(), http.StatusBadRequest)
+			return
+		}
+		gate, ok := gates[string(marker)]
+		if !ok {
+			http.Error(w, "unknown session marker", http.StatusBadRequest)
+			return
+		}
+		arrived <- string(marker)
+		<-gate
+		_, _ = w.Write(marker)
+		completed <- string(marker)
+	}))
+	defer server.Close()
+
+	exec := NewAntigravityExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID:       "antigravity-concurrent-sessions-auth",
+		Provider: "antigravity",
+		Metadata: map[string]any{
+			"access_token": "token",
+			"project_id":   "project-1",
+			"expired":      time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	errs := make(chan error, sessions)
+	var wg sync.WaitGroup
+	wg.Add(sessions)
+	for _, marker := range markers {
+		go func(marker string) {
+			defer wg.Done()
+			req, errRequest := http.NewRequest(http.MethodPost, server.URL, strings.NewReader(marker))
+			if errRequest != nil {
+				errs <- fmt.Errorf("%s: NewRequest: %w", marker, errRequest)
+				return
+			}
+			resp, errDo := exec.HttpRequest(context.Background(), auth, req)
+			if errDo != nil {
+				errs <- fmt.Errorf("%s: HttpRequest: %w", marker, errDo)
+				return
+			}
+			body, errRead := io.ReadAll(resp.Body)
+			errClose := resp.Body.Close()
+			if errRead != nil {
+				errs <- fmt.Errorf("%s: read response: %w", marker, errRead)
+				return
+			}
+			if errClose != nil {
+				errs <- fmt.Errorf("%s: close response: %w", marker, errClose)
+				return
+			}
+			if string(body) != marker {
+				errs <- fmt.Errorf("%s received response for %q", marker, body)
+			}
+		}(marker)
+	}
+
+	seen := make(map[string]struct{}, sessions)
+	for range sessions {
+		marker := <-arrived
+		seen[marker] = struct{}{}
+	}
+	if len(seen) != sessions {
+		t.Fatalf("only %d/%d session markers reached upstream", len(seen), sessions)
+	}
+	for i := sessions - 1; i >= 0; i-- {
+		close(gates[markers[i]])
+		if marker := <-completed; marker != markers[i] {
+			t.Fatalf("completion order = %q, want %q", marker, markers[i])
+		}
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/internal/runtime/executor/antigravity_executor_request.go
+++ b/internal/runtime/executor/antigravity_executor_request.go
@@ -118,7 +118,10 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 	if errReq != nil {
 		return nil, errReq
 	}
-	httpReq.Close = true
+	// Deliberately no httpReq.Close: the native Antigravity client omits the
+	// Connection header and keeps its HTTP/1.1 connections alive, so forcing
+	// "Connection: close" would both deviate from that fingerprint and defeat the
+	// shared connection pool by discarding every established TCP + TLS session.
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("User-Agent", resolveUserAgent(auth))

--- a/internal/runtime/executor/antigravity_executor_tokens.go
+++ b/internal/runtime/executor/antigravity_executor_tokens.go
@@ -99,7 +99,7 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 		if errReq != nil {
 			return cliproxyexecutor.Response{}, errReq
 		}
-		httpReq.Close = true
+		// No httpReq.Close: keep the shared Antigravity connection pool usable.
 		httpReq.Header.Set("Content-Type", "application/json")
 		httpReq.Header.Set("Authorization", "Bearer "+token)
 		httpReq.Header.Set("User-Agent", resolveUserAgent(auth))

--- a/internal/runtime/executor/antigravity_executor_transport_test.go
+++ b/internal/runtime/executor/antigravity_executor_transport_test.go
@@ -1,0 +1,256 @@
+package executor
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func antigravityAuthWithProxy(proxyURL string) *cliproxyauth.Auth {
+	return antigravityAuthWithIDAndProxy("antigravity-test", proxyURL)
+}
+
+func antigravityAuthWithIDAndProxy(id, proxyURL string) *cliproxyauth.Auth {
+	return &cliproxyauth.Auth{
+		ID:       id,
+		ProxyURL: proxyURL,
+		Metadata: map[string]any{
+			"access_token": "test-access-token",
+			"project_id":   "test-project",
+			"expired":      time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+}
+
+// TestNewAntigravityHTTPClientSharesTransport is the regression test for the bug where
+// every proxied Antigravity request created a new transport, so no keep-alive connection
+// was ever reused and every request paid a full TCP + TLS handshake.
+func TestNewAntigravityHTTPClientSharesTransport(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *config.Config
+		auth *cliproxyauth.Auth
+	}{
+		{"direct", &config.Config{}, antigravityAuthWithProxy("")},
+		{"auth http proxy", &config.Config{}, antigravityAuthWithProxy("http://127.0.0.1:18080")},
+		{"auth socks5 proxy", &config.Config{}, antigravityAuthWithProxy("socks5://127.0.0.1:18081")},
+		{
+			"config proxy",
+			&config.Config{SDKConfig: config.SDKConfig{ProxyURL: "http://127.0.0.1:18082"}},
+			antigravityAuthWithProxy(""),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			first := newAntigravityHTTPClient(context.Background(), tc.cfg, tc.auth, 0)
+			second := newAntigravityHTTPClient(context.Background(), tc.cfg, tc.auth, 0)
+			if first.Transport == nil || second.Transport == nil {
+				t.Fatal("expected a transport to be configured")
+			}
+			if first.Transport != second.Transport {
+				t.Fatalf("expected a shared transport, got %p and %p", first.Transport, second.Transport)
+			}
+			transport, ok := first.Transport.(*http.Transport)
+			if !ok {
+				t.Fatalf("expected *http.Transport, got %T", first.Transport)
+			}
+			if transport.ForceAttemptHTTP2 {
+				t.Fatal("Antigravity transport must not attempt HTTP/2")
+			}
+			if len(transport.TLSNextProto) != 0 {
+				t.Fatal("Antigravity transport must not allow an implicit HTTP/2 upgrade")
+			}
+			if transport.TLSClientConfig == nil {
+				t.Fatal("Antigravity transport must carry an explicit TLS config")
+			}
+			if len(transport.TLSClientConfig.NextProtos) != 0 {
+				t.Fatalf("Antigravity must omit ALPN like the native client, got %v", transport.TLSClientConfig.NextProtos)
+			}
+			defaultTransport := http.DefaultTransport.(*http.Transport)
+			if transport.MaxIdleConns != defaultTransport.MaxIdleConns ||
+				transport.MaxIdleConnsPerHost != defaultTransport.MaxIdleConnsPerHost ||
+				transport.IdleConnTimeout != defaultTransport.IdleConnTimeout {
+				t.Fatal("Antigravity transport must preserve the standard Go pool settings")
+			}
+		})
+	}
+}
+
+func TestNewAntigravityHTTPClientDistinctProxiesUseDistinctPools(t *testing.T) {
+	cfg := &config.Config{}
+	a := newAntigravityHTTPClient(context.Background(), cfg, antigravityAuthWithProxy("http://127.0.0.1:18090"), 0)
+	b := newAntigravityHTTPClient(context.Background(), cfg, antigravityAuthWithProxy("http://127.0.0.1:18091"), 0)
+	if a.Transport == b.Transport {
+		t.Fatal("expected distinct proxies to use distinct connection pools")
+	}
+}
+
+func TestNewAntigravityHTTPClientScopesPoolsByAuthIdentity(t *testing.T) {
+	cfg := &config.Config{}
+	const proxyURL = "http://127.0.0.1:18092"
+
+	a1 := newAntigravityHTTPClient(context.Background(), cfg, antigravityAuthWithIDAndProxy("auth-a", proxyURL), 0)
+	a2 := newAntigravityHTTPClient(context.Background(), cfg, antigravityAuthWithIDAndProxy("auth-a", proxyURL), 0)
+	b := newAntigravityHTTPClient(context.Background(), cfg, antigravityAuthWithIDAndProxy("auth-b", proxyURL), 0)
+	if a1.Transport != a2.Transport {
+		t.Fatal("the same auth identity must share its connection pool across sessions")
+	}
+	if a1.Transport == b.Transport {
+		t.Fatal("different auth identities must not share a proxied connection pool")
+	}
+
+	directA := newAntigravityHTTPClient(context.Background(), cfg, antigravityAuthWithIDAndProxy("direct-a", ""), 0)
+	directB := newAntigravityHTTPClient(context.Background(), cfg, antigravityAuthWithIDAndProxy("direct-b", ""), 0)
+	if directA.Transport == directB.Transport {
+		t.Fatal("different auth identities must not share a direct connection pool")
+	}
+}
+
+// TestAntigravityHTTP11TransportNeverSharesWithoutStableIdentity guards the pool
+// cache against auths that carry no ID. Keying such auths by pointer identity is
+// unsafe: the address is reused once the previous auth is collected, which would
+// silently place two unrelated OAuth identities on the same TCP/TLS connections.
+func TestAntigravityHTTP11TransportNeverSharesWithoutStableIdentity(t *testing.T) {
+	base := http.DefaultTransport.(*http.Transport)
+
+	anonymous := &cliproxyauth.Auth{}
+	first := antigravityHTTP11Transport(anonymous, base)
+	second := antigravityHTTP11Transport(anonymous, base)
+	if first == nil || second == nil {
+		t.Fatal("expected a transport for an auth without an ID")
+	}
+	if first == second {
+		t.Fatal("an auth without a stable ID must not be cached, otherwise a reused address grants another credential its pool")
+	}
+
+	blankID := antigravityHTTP11Transport(&cliproxyauth.Auth{ID: "   "}, base)
+	if blankID == first || blankID == second {
+		t.Fatal("a blank auth ID must not resolve to an existing pool")
+	}
+	if nilAuth := antigravityHTTP11Transport(nil, base); nilAuth == nil || nilAuth == first || nilAuth == blankID {
+		t.Fatal("a nil auth must receive its own private pool")
+	}
+
+	// Identified auths keep sharing their pool.
+	identified := &cliproxyauth.Auth{ID: "stable-identity"}
+	if antigravityHTTP11Transport(identified, base) != antigravityHTTP11Transport(identified, base) {
+		t.Fatal("an auth with a stable ID must reuse its cached pool")
+	}
+}
+
+func TestAntigravityTransportScopeRequiresStableID(t *testing.T) {
+	cases := []struct {
+		name      string
+		auth      *cliproxyauth.Auth
+		wantScope string
+		wantOK    bool
+	}{
+		{"nil auth", nil, "", false},
+		{"missing id", &cliproxyauth.Auth{}, "", false},
+		{"blank id", &cliproxyauth.Auth{ID: " \t "}, "", false},
+		{"stable id", &cliproxyauth.Auth{ID: " auth-1 "}, "id:auth-1", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scope, ok := antigravityTransportScope(tc.auth)
+			if scope != tc.wantScope || ok != tc.wantOK {
+				t.Fatalf("antigravityTransportScope() = (%q, %v), want (%q, %v)", scope, ok, tc.wantScope, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestAntigravityTransportMatchesNativeTLSProfile(t *testing.T) {
+	var clientHelloProtos []string
+	var requestProto string
+	var tlsVersion uint16
+	var negotiatedProtocol string
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestProto = r.Proto
+		if r.TLS != nil {
+			tlsVersion = r.TLS.Version
+			negotiatedProtocol = r.TLS.NegotiatedProtocol
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	server.TLS = &tls.Config{
+		MinVersion: tls.VersionTLS13,
+		MaxVersion: tls.VersionTLS13,
+		GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+			clientHelloProtos = append([]string(nil), hello.SupportedProtos...)
+			return nil, nil
+		},
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	transport := antigravityHTTP11Transport(antigravityAuthWithIDAndProxy("native-tls-profile", ""), base)
+	resp, errDo := (&http.Client{Transport: transport}).Get(server.URL)
+	if errDo != nil {
+		t.Fatalf("GET() error = %v", errDo)
+	}
+	if errClose := resp.Body.Close(); errClose != nil {
+		t.Fatalf("close response body: %v", errClose)
+	}
+
+	if len(clientHelloProtos) != 0 {
+		t.Fatalf("ClientHello ALPN = %v, want no ALPN extension", clientHelloProtos)
+	}
+	if requestProto != "HTTP/1.1" {
+		t.Fatalf("request protocol = %q, want HTTP/1.1", requestProto)
+	}
+	if tlsVersion != tls.VersionTLS13 {
+		t.Fatalf("TLS version = %#x, want TLS 1.3", tlsVersion)
+	}
+	if negotiatedProtocol != "" {
+		t.Fatalf("negotiated ALPN = %q, want empty", negotiatedProtocol)
+	}
+}
+
+// TestAntigravityProxiedRequestsReuseOneConnection proves the end-to-end effect:
+// repeated Antigravity clients built for the same auth send every request over a
+// single pooled connection.
+func TestAntigravityProxiedRequestsReuseOneConnection(t *testing.T) {
+	var mu sync.Mutex
+	remotes := map[string]int{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		remotes[r.RemoteAddr]++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{}
+	auth := antigravityAuthWithProxy(srv.URL)
+	const requests = 8
+	for i := 0; i < requests; i++ {
+		client := newAntigravityHTTPClient(context.Background(), cfg, auth, 0)
+		req, errReq := http.NewRequest(http.MethodGet, "http://antigravity.invalid/v1internal:streamGenerateContent", nil)
+		if errReq != nil {
+			t.Fatalf("NewRequest() error = %v", errReq)
+		}
+		resp, errDo := client.Do(req)
+		if errDo != nil {
+			t.Fatalf("request %d error = %v", i, errDo)
+		}
+		_ = resp.Body.Close()
+	}
+
+	mu.Lock()
+	distinct := len(remotes)
+	mu.Unlock()
+	if distinct != 1 {
+		t.Fatalf("expected %d requests to share one connection, got %d connections", requests, distinct)
+	}
+}

--- a/internal/runtime/executor/antigravity_executor_transport_test.go
+++ b/internal/runtime/executor/antigravity_executor_transport_test.go
@@ -2,14 +2,21 @@ package executor
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
@@ -73,13 +80,154 @@ func TestNewAntigravityHTTPClientSharesTransport(t *testing.T) {
 			if len(transport.TLSClientConfig.NextProtos) != 0 {
 				t.Fatalf("Antigravity must omit ALPN like the native client, got %v", transport.TLSClientConfig.NextProtos)
 			}
-			defaultTransport := http.DefaultTransport.(*http.Transport)
-			if transport.MaxIdleConns != defaultTransport.MaxIdleConns ||
-				transport.MaxIdleConnsPerHost != defaultTransport.MaxIdleConnsPerHost ||
-				transport.IdleConnTimeout != defaultTransport.IdleConnTimeout {
-				t.Fatal("Antigravity transport must preserve the standard Go pool settings")
+			// Go's DefaultMaxIdleConnsPerHost of 2 would force concurrent sessions on one
+			// credential to re-handshake. The native Antigravity stack raises it to 100.
+			if transport.MaxIdleConnsPerHost < antigravityMaxIdleConnsPerHost {
+				t.Fatalf("MaxIdleConnsPerHost = %d, want >= %d", transport.MaxIdleConnsPerHost, antigravityMaxIdleConnsPerHost)
+			}
+			if transport.MaxIdleConns > 0 && transport.MaxIdleConns < transport.MaxIdleConnsPerHost {
+				t.Fatalf("MaxIdleConns = %d must not throttle MaxIdleConnsPerHost = %d", transport.MaxIdleConns, transport.MaxIdleConnsPerHost)
+			}
+			if transport.IdleConnTimeout > 0 && transport.IdleConnTimeout < antigravityIdleConnTimeout {
+				t.Fatalf("IdleConnTimeout = %v, want >= %v", transport.IdleConnTimeout, antigravityIdleConnTimeout)
 			}
 		})
+	}
+}
+
+// TestAntigravityPoolLimitsOnlyWiden guards that an operator-supplied base transport
+// with a larger pool keeps its own settings, and that "unlimited" sentinels are not
+// narrowed into finite limits.
+func TestAntigravityPoolLimitsOnlyWiden(t *testing.T) {
+	wide := &http.Transport{
+		MaxIdleConns:        512,
+		MaxIdleConnsPerHost: 256,
+		IdleConnTimeout:     time.Hour,
+	}
+	applyAntigravityPoolLimits(wide)
+	if wide.MaxIdleConnsPerHost != 256 || wide.MaxIdleConns != 512 || wide.IdleConnTimeout != time.Hour {
+		t.Fatalf("wider pool settings must be preserved, got perHost=%d total=%d idle=%v",
+			wide.MaxIdleConnsPerHost, wide.MaxIdleConns, wide.IdleConnTimeout)
+	}
+
+	// Zero means unlimited for both MaxIdleConns and IdleConnTimeout.
+	unlimited := &http.Transport{MaxIdleConns: 0, IdleConnTimeout: 0}
+	applyAntigravityPoolLimits(unlimited)
+	if unlimited.MaxIdleConns != 0 {
+		t.Fatalf("MaxIdleConns = %d, want 0 (unlimited) to stay unlimited", unlimited.MaxIdleConns)
+	}
+	if unlimited.IdleConnTimeout != 0 {
+		t.Fatalf("IdleConnTimeout = %v, want 0 (never expire) to stay unlimited", unlimited.IdleConnTimeout)
+	}
+
+	// A negative MaxIdleConnsPerHost is how an operator disables idle pooling; Go never
+	// pools a connection in that case, so the intent must survive.
+	disabled := &http.Transport{MaxIdleConnsPerHost: -1}
+	applyAntigravityPoolLimits(disabled)
+	if disabled.MaxIdleConnsPerHost != -1 {
+		t.Fatalf("MaxIdleConnsPerHost = %d, want -1 (pooling disabled) to be preserved", disabled.MaxIdleConnsPerHost)
+	}
+
+	// Go's zero value means DefaultMaxIdleConnsPerHost (2), which must be raised.
+	defaulted := &http.Transport{}
+	applyAntigravityPoolLimits(defaulted)
+	if defaulted.MaxIdleConnsPerHost != antigravityMaxIdleConnsPerHost {
+		t.Fatalf("MaxIdleConnsPerHost = %d, want %d", defaulted.MaxIdleConnsPerHost, antigravityMaxIdleConnsPerHost)
+	}
+
+	applyAntigravityPoolLimits(nil) // must not panic
+}
+
+// TestNewAntigravityHTTPClientRejectsTypedNilContextTransport guards the fingerprint:
+// a typed-nil *http.Transport satisfies the interface nil check in
+// NewProxyAwareHTTPClient, and leaving it in place would make http.Client fall back to
+// http.DefaultTransport, which advertises h2 over ALPN.
+func TestNewAntigravityHTTPClientRejectsTypedNilContextTransport(t *testing.T) {
+	var typedNil *http.Transport
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", http.RoundTripper(typedNil))
+	client := newAntigravityHTTPClient(ctx, &config.Config{}, antigravityAuthWithIDAndProxy("typed-nil", ""), 0)
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok || transport == nil {
+		t.Fatalf("expected a usable *http.Transport, got %#v", client.Transport)
+	}
+	if transport.ForceAttemptHTTP2 {
+		t.Fatal("fallback transport must not attempt HTTP/2")
+	}
+	if len(transport.TLSClientConfig.NextProtos) != 0 {
+		t.Fatalf("fallback transport must omit ALPN, got %v", transport.TLSClientConfig.NextProtos)
+	}
+}
+
+// TestNewAntigravityHTTPClientKeepsForeignRoundTripper verifies a RoundTripper that is
+// not an *http.Transport is left untouched instead of being replaced.
+func TestNewAntigravityHTTPClientKeepsForeignRoundTripper(t *testing.T) {
+	foreign := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("unused")
+	})
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", http.RoundTripper(foreign))
+	client := newAntigravityHTTPClient(ctx, &config.Config{}, antigravityAuthWithIDAndProxy("foreign-rt", ""), 0)
+	if _, isTransport := client.Transport.(*http.Transport); isTransport {
+		t.Fatal("a non-*http.Transport RoundTripper must be preserved as-is")
+	}
+}
+
+// TestAntigravityConcurrentRequestsReusePooledConnections is the regression test for
+// the pool limit: with Go's default of 2 idle connections per host, repeated waves of
+// concurrent requests on one credential keep re-handshaking.
+func TestAntigravityConcurrentRequestsReusePooledConnections(t *testing.T) {
+	var mu sync.Mutex
+	remotes := map[string]struct{}{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		remotes[r.RemoteAddr] = struct{}{}
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	auth := antigravityAuthWithIDAndProxy("concurrent-reuse", "")
+	client := &http.Client{Transport: antigravityHTTP11Transport(auth, http.DefaultTransport.(*http.Transport))}
+
+	const (
+		waves      = 3
+		perWave    = 8
+		totalConns = waves * perWave
+	)
+	for wave := 0; wave < waves; wave++ {
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(perWave)
+		for i := 0; i < perWave; i++ {
+			go func() {
+				defer wg.Done()
+				<-start
+				resp, errDo := client.Get(srv.URL)
+				if errDo != nil {
+					t.Error(errDo)
+					return
+				}
+				if _, errDrain := io.Copy(io.Discard, resp.Body); errDrain != nil {
+					t.Error(errDrain)
+				}
+				if errClose := resp.Body.Close(); errClose != nil {
+					t.Error(errClose)
+				}
+			}()
+		}
+		close(start)
+		wg.Wait()
+	}
+
+	mu.Lock()
+	distinct := len(remotes)
+	mu.Unlock()
+	// The first wave legitimately opens perWave connections. Later waves must reuse
+	// them; with MaxIdleConnsPerHost=2 only two survive each wave and distinct grows
+	// towards totalConns instead.
+	if distinct > perWave {
+		t.Fatalf("%d waves of %d concurrent requests opened %d connections, want at most %d (unpooled worst case is %d)",
+			waves, perWave, distinct, perWave, totalConns)
 	}
 }
 
@@ -113,11 +261,11 @@ func TestNewAntigravityHTTPClientScopesPoolsByAuthIdentity(t *testing.T) {
 	}
 }
 
-// TestAntigravityHTTP11TransportNeverSharesWithoutStableIdentity guards the pool
-// cache against auths that carry no ID. Keying such auths by pointer identity is
-// unsafe: the address is reused once the previous auth is collected, which would
-// silently place two unrelated OAuth identities on the same TCP/TLS connections.
-func TestAntigravityHTTP11TransportNeverSharesWithoutStableIdentity(t *testing.T) {
+// TestAntigravityHTTP11TransportReusesPoolWithoutAuthID guards the pool cache
+// against auths that carry no ID. Allocating a private pool per call would leak a
+// connection pool, and the goroutines managing it, on every request, which is the
+// pattern the original singleton transport was introduced to remove.
+func TestAntigravityHTTP11TransportReusesPoolWithoutAuthID(t *testing.T) {
 	base := http.DefaultTransport.(*http.Transport)
 
 	anonymous := &cliproxyauth.Auth{}
@@ -126,16 +274,25 @@ func TestAntigravityHTTP11TransportNeverSharesWithoutStableIdentity(t *testing.T
 	if first == nil || second == nil {
 		t.Fatal("expected a transport for an auth without an ID")
 	}
-	if first == second {
-		t.Fatal("an auth without a stable ID must not be cached, otherwise a reused address grants another credential its pool")
+	if first != second {
+		t.Fatal("an auth without any identity must reuse one shared pool instead of leaking a new pool per request")
+	}
+	if nilAuth := antigravityHTTP11Transport(nil, base); nilAuth != first {
+		t.Fatal("a nil auth carries no credential to isolate and must share the same pool")
 	}
 
-	blankID := antigravityHTTP11Transport(&cliproxyauth.Auth{ID: "   "}, base)
-	if blankID == first || blankID == second {
-		t.Fatal("a blank auth ID must not resolve to an existing pool")
+	// An auth without an ID but with credential material stays isolated from both the
+	// anonymous pool and from a different credential.
+	tokenA := antigravityHTTP11Transport(&cliproxyauth.Auth{Metadata: map[string]any{"access_token": "token-a"}}, base)
+	tokenB := antigravityHTTP11Transport(&cliproxyauth.Auth{Metadata: map[string]any{"access_token": "token-b"}}, base)
+	if tokenA == first || tokenB == first {
+		t.Fatal("a credential with an access token must not fall back to the anonymous pool")
 	}
-	if nilAuth := antigravityHTTP11Transport(nil, base); nilAuth == nil || nilAuth == first || nilAuth == blankID {
-		t.Fatal("a nil auth must receive its own private pool")
+	if tokenA == tokenB {
+		t.Fatal("different access tokens must not share a connection pool")
+	}
+	if again := antigravityHTTP11Transport(&cliproxyauth.Auth{Metadata: map[string]any{"access_token": "token-a"}}, base); again != tokenA {
+		t.Fatal("the same access token must resolve to the same pool across requests")
 	}
 
 	// Identified auths keep sharing their pool.
@@ -145,25 +302,172 @@ func TestAntigravityHTTP11TransportNeverSharesWithoutStableIdentity(t *testing.T
 	}
 }
 
-func TestAntigravityTransportScopeRequiresStableID(t *testing.T) {
+func TestAntigravityTransportScopeFallsBackToStableMarkers(t *testing.T) {
+	digest := func(prefix, secret string) string {
+		sum := sha256.Sum256([]byte(secret))
+		return prefix + hex.EncodeToString(sum[:8])
+	}
 	cases := []struct {
-		name      string
-		auth      *cliproxyauth.Auth
-		wantScope string
-		wantOK    bool
+		name string
+		auth *cliproxyauth.Auth
+		want string
 	}{
-		{"nil auth", nil, "", false},
-		{"missing id", &cliproxyauth.Auth{}, "", false},
-		{"blank id", &cliproxyauth.Auth{ID: " \t "}, "", false},
-		{"stable id", &cliproxyauth.Auth{ID: " auth-1 "}, "id:auth-1", true},
+		{"nil auth", nil, antigravityAnonymousTransportScope},
+		{"empty auth", &cliproxyauth.Auth{}, antigravityAnonymousTransportScope},
+		{"blank id", &cliproxyauth.Auth{ID: " \t "}, antigravityAnonymousTransportScope},
+		{"stable id", &cliproxyauth.Auth{ID: " auth-1 "}, "id:auth-1"},
+		{
+			"id wins over path",
+			&cliproxyauth.Auth{ID: "auth-1", Attributes: map[string]string{cliproxyauth.AttributePath: "/a.json"}},
+			"id:auth-1",
+		},
+		{
+			"path fallback",
+			&cliproxyauth.Auth{Attributes: map[string]string{cliproxyauth.AttributePath: " /auths/a.json "}},
+			"path:/auths/a.json",
+		},
+		{
+			"source fallback",
+			&cliproxyauth.Auth{Attributes: map[string]string{cliproxyauth.AttributeSource: "/auths/b.json"}},
+			"source:/auths/b.json",
+		},
+		{
+			// Auth.Label is a logging label with no uniqueness guarantee, so it must never
+			// become a pool scope on its own.
+			"label alone is not an identity",
+			&cliproxyauth.Auth{Label: "account-c"},
+			antigravityAnonymousTransportScope,
+		},
+		{
+			"refresh token preferred over access token",
+			&cliproxyauth.Auth{Metadata: map[string]any{"refresh_token": "r-1", "access_token": "a-1"}},
+			digest("refresh:", "r-1"),
+		},
+		{
+			"access token fallback",
+			&cliproxyauth.Auth{Metadata: map[string]any{"access_token": "secret-token"}},
+			digest("token:", "secret-token"),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			scope, ok := antigravityTransportScope(tc.auth)
-			if scope != tc.wantScope || ok != tc.wantOK {
-				t.Fatalf("antigravityTransportScope() = (%q, %v), want (%q, %v)", scope, ok, tc.wantScope, tc.wantOK)
+			if got := antigravityTransportScope(tc.auth); got != tc.want {
+				t.Fatalf("antigravityTransportScope() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestAntigravityTransportScopeIgnoresNonUniqueLabel is the regression test for using
+// Auth.Label as an identity: two different credentials that happen to share a label
+// must not end up on the same TCP/TLS pool.
+func TestAntigravityTransportScopeIgnoresNonUniqueLabel(t *testing.T) {
+	first := &cliproxyauth.Auth{Label: "shared-label", Metadata: map[string]any{"refresh_token": "refresh-a"}}
+	second := &cliproxyauth.Auth{Label: "shared-label", Metadata: map[string]any{"refresh_token": "refresh-b"}}
+	if antigravityTransportScope(first) == antigravityTransportScope(second) {
+		t.Fatal("credentials sharing only a label must not share a pool scope")
+	}
+
+	base := http.DefaultTransport.(*http.Transport)
+	if antigravityHTTP11Transport(first, base) == antigravityHTTP11Transport(second, base) {
+		t.Fatal("credentials sharing only a label must not share a connection pool")
+	}
+}
+
+// TestAntigravityTransportScopeSurvivesAccessTokenRotation covers the refresh flow:
+// refreshing an access token must not move a credential onto a new pool, and a refresh
+// request that runs before any access token exists must resolve to the same scope.
+func TestAntigravityTransportScopeSurvivesAccessTokenRotation(t *testing.T) {
+	refreshOnly := &cliproxyauth.Auth{Metadata: map[string]any{"refresh_token": "stable-refresh"}}
+	beforeRotation := &cliproxyauth.Auth{Metadata: map[string]any{"refresh_token": "stable-refresh", "access_token": "access-1"}}
+	afterRotation := &cliproxyauth.Auth{Metadata: map[string]any{"refresh_token": "stable-refresh", "access_token": "access-2"}}
+
+	want := antigravityTransportScope(refreshOnly)
+	if got := antigravityTransportScope(beforeRotation); got != want {
+		t.Fatalf("scope before rotation = %q, want %q", got, want)
+	}
+	if got := antigravityTransportScope(afterRotation); got != want {
+		t.Fatalf("scope after rotation = %q, want %q (access token rotation must not churn pools)", got, want)
+	}
+}
+
+// TestAntigravityTransportScopeNeverLeaksToken ensures the credential-derived scope
+// only carries a short digest, so a pool key can never reveal the credential.
+func TestAntigravityTransportScopeNeverLeaksToken(t *testing.T) {
+	const (
+		accessToken  = "ya29.super-secret-access-token"
+		refreshToken = "1//super-secret-refresh-token"
+	)
+	for _, tc := range []struct {
+		name   string
+		auth   *cliproxyauth.Auth
+		secret string
+		prefix string
+	}{
+		{"access token", &cliproxyauth.Auth{Metadata: map[string]any{"access_token": accessToken}}, accessToken, "token:"},
+		{"refresh token", &cliproxyauth.Auth{Metadata: map[string]any{"refresh_token": refreshToken}}, refreshToken, "refresh:"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scope := antigravityTransportScope(tc.auth)
+			if strings.Contains(scope, tc.secret) {
+				t.Fatalf("scope %q must not embed the credential", scope)
+			}
+			if !strings.HasPrefix(scope, tc.prefix) || len(scope) != len(tc.prefix)+16 {
+				t.Fatalf("scope = %q, want a short %s digest", scope, tc.prefix)
+			}
+		})
+	}
+}
+
+// TestAntigravityTransportCacheEvictsStalePools covers the bounded cache: rotating a
+// credential's proxy must not accumulate pools forever.
+func TestAntigravityTransportCacheEvictsStalePools(t *testing.T) {
+	original := antigravityTransports
+	antigravityTransports = helps.NewTransportCache[antigravityTransportKey](4)
+	t.Cleanup(func() {
+		antigravityTransports.Purge()
+		antigravityTransports = original
+	})
+
+	cfg := &config.Config{}
+	for i := 0; i < 40; i++ {
+		auth := antigravityAuthWithIDAndProxy("rotating-auth", fmt.Sprintf("http://127.0.0.1:%d", 19000+i))
+		if client := newAntigravityHTTPClient(context.Background(), cfg, auth, 0); client.Transport == nil {
+			t.Fatalf("request %d: expected a transport", i)
+		}
+	}
+	if got := antigravityTransports.Len(); got > 4 {
+		t.Fatalf("cache holds %d pools, want at most the capacity of 4", got)
+	}
+
+	// A per-request base transport from the request context must not grow the cache
+	// without bound either.
+	auth := antigravityAuthWithIDAndProxy("ctx-auth", "")
+	for i := 0; i < 40; i++ {
+		fresh := http.DefaultTransport.(*http.Transport).Clone()
+		ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", http.RoundTripper(fresh))
+		if client := newAntigravityHTTPClient(ctx, cfg, auth, 0); client.Transport == nil {
+			t.Fatalf("ctx request %d: expected a transport", i)
+		}
+	}
+	if got := antigravityTransports.Len(); got > 4 {
+		t.Fatalf("cache holds %d pools after context transports, want at most 4", got)
+	}
+}
+
+// TestAntigravityProxiedHTTP11TransportRejectsInvalidProxy verifies the caller can
+// fall back instead of caching a broken pool.
+func TestAntigravityProxiedHTTP11TransportRejectsInvalidProxy(t *testing.T) {
+	auth := antigravityAuthWithIDAndProxy("invalid-proxy", "ftp://127.0.0.1:1")
+	if transport := antigravityProxiedHTTP11Transport(auth, "ftp://127.0.0.1:1"); transport != nil {
+		t.Fatal("an unsupported proxy scheme must not produce a transport")
+	}
+	if transport := antigravityProxiedHTTP11Transport(auth, "   "); transport != nil {
+		t.Fatal("a blank proxy must not produce a transport")
+	}
+	// A failed build must not occupy a cache slot, so a later valid setting still works.
+	if transport := antigravityProxiedHTTP11Transport(auth, "http://127.0.0.1:18099"); transport == nil {
+		t.Fatal("a valid proxy must produce a transport")
 	}
 }
 

--- a/internal/runtime/executor/antigravity_refresh_test.go
+++ b/internal/runtime/executor/antigravity_refresh_test.go
@@ -33,12 +33,12 @@ func useAntigravityRefreshTestTransport(t *testing.T, targetHost string) {
 		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
 		ForceAttemptHTTP2: false,
 	}
-	antigravityTransport = transport
-	antigravityTransportOnce = sync.Once{}
-	antigravityTransportOnce.Do(func() {})
+	originalBase := antigravityBaseTransport
+	antigravityBaseTransport = transport
+	antigravityTransports = sync.Map{}
 	t.Cleanup(func() {
-		antigravityTransport = nil
-		antigravityTransportOnce = sync.Once{}
+		antigravityBaseTransport = originalBase
+		antigravityTransports = sync.Map{}
 	})
 }
 

--- a/internal/runtime/executor/antigravity_refresh_test.go
+++ b/internal/runtime/executor/antigravity_refresh_test.go
@@ -35,10 +35,10 @@ func useAntigravityRefreshTestTransport(t *testing.T, targetHost string) {
 	}
 	originalBase := antigravityBaseTransport
 	antigravityBaseTransport = transport
-	antigravityTransports = sync.Map{}
+	antigravityTransports.Purge()
 	t.Cleanup(func() {
 		antigravityBaseTransport = originalBase
-		antigravityTransports = sync.Map{}
+		antigravityTransports.Purge()
 	})
 }
 

--- a/internal/runtime/executor/helps/transport_cache.go
+++ b/internal/runtime/executor/helps/transport_cache.go
@@ -1,49 +1,125 @@
 package helps
 
 import (
+	"container/list"
+	"errors"
 	"net/http"
-	"strings"
 	"sync"
-
-	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
 )
 
-// sharedProxyTransports memoizes one transport per credential scope and normalized
-// proxy setting. Antigravity uses auth.ID as the scope so different OAuth identities
-// never share a TCP/TLS pool, matching the native client's one-credential process model.
-var sharedProxyTransports sync.Map // sharedProxyTransportKey -> *sharedProxyTransportEntry
+// DefaultTransportCacheCapacity bounds how many transports a TransportCache keeps
+// alive at once. Every cached transport owns an independent connection pool, so an
+// unbounded cache would let idle sockets and the goroutines managing them grow
+// without limit whenever keys churn, for example when a credential's proxy is
+// rotated through the management API or when an SDK embedder supplies a freshly
+// built base transport per request.
+const DefaultTransportCacheCapacity = 64
 
-type sharedProxyTransportKey struct {
-	scope string
-	proxy string
+// TransportCache memoizes HTTP transports under a comparable key using a bounded
+// LRU. Evicting an entry closes its idle connections so neither the pool nor its
+// background goroutines outlive the cache entry.
+//
+// The key type is generic so callers can mix value identity (a normalized proxy
+// URL) with pointer identity (a base transport supplied by the caller) without the
+// cache retaining either beyond the LRU window.
+type TransportCache[K comparable] struct {
+	mu       sync.Mutex
+	capacity int
+	// order keeps the most recently used entry at the front.
+	order *list.List
+	items map[K]*list.Element
 }
 
-type sharedProxyTransportEntry struct {
-	once      sync.Once
+type transportCacheEntry[K comparable] struct {
+	key       K
 	transport *http.Transport
-	mode      proxyutil.Mode
-	err       error
 }
 
-// SharedProxyTransport returns a stable transport for one credential scope and proxy
-// setting. It preserves Go's standard connection-pool settings; callers must treat
-// the result as read-only and clone it before changing protocol behavior.
-func SharedProxyTransport(scope, raw string) (*http.Transport, proxyutil.Mode, error) {
-	key := sharedProxyTransportKey{
-		scope: strings.TrimSpace(scope),
-		proxy: strings.TrimSpace(raw),
+// NewTransportCache returns a cache holding at most capacity transports. A
+// non-positive capacity falls back to DefaultTransportCacheCapacity.
+func NewTransportCache[K comparable](capacity int) *TransportCache[K] {
+	if capacity <= 0 {
+		capacity = DefaultTransportCacheCapacity
 	}
-	value, _ := sharedProxyTransports.LoadOrStore(key, &sharedProxyTransportEntry{})
-	entry := value.(*sharedProxyTransportEntry)
-	entry.once.Do(func() {
-		entry.transport, entry.mode, entry.err = proxyutil.BuildHTTPTransport(key.proxy)
-	})
-	return entry.transport, entry.mode, entry.err
+	return &TransportCache[K]{
+		capacity: capacity,
+		order:    list.New(),
+		items:    make(map[K]*list.Element, capacity),
+	}
 }
 
-func resetSharedProxyTransportsForTest() {
-	sharedProxyTransports.Range(func(key, _ any) bool {
-		sharedProxyTransports.Delete(key)
-		return true
-	})
+// Get returns the transport cached under key, calling build on the first use of
+// that key. Concurrent callers observe the same instance.
+//
+// A build error is propagated without being cached, so a later call can retry and
+// a failed lookup never occupies a cache slot. build must not call back into the
+// same cache.
+func (c *TransportCache[K]) Get(key K, build func() (*http.Transport, error)) (*http.Transport, error) {
+	if c == nil {
+		return nil, errors.New("transport cache: nil cache")
+	}
+	if build == nil {
+		return nil, errors.New("transport cache: nil build function")
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if element, ok := c.items[key]; ok {
+		c.order.MoveToFront(element)
+		return element.Value.(*transportCacheEntry[K]).transport, nil
+	}
+
+	transport, errBuild := build()
+	if errBuild != nil {
+		return nil, errBuild
+	}
+	if transport == nil {
+		return nil, errors.New("transport cache: build returned no transport")
+	}
+
+	c.items[key] = c.order.PushFront(&transportCacheEntry[K]{key: key, transport: transport})
+	c.evictLocked()
+	return transport, nil
+}
+
+// evictLocked drops least recently used entries until the cache fits its capacity.
+// Closing idle connections is what actually releases the evicted pool; in-flight
+// requests still holding the transport are unaffected because CloseIdleConnections
+// only reaps connections that are currently idle.
+func (c *TransportCache[K]) evictLocked() {
+	for c.order.Len() > c.capacity {
+		oldest := c.order.Back()
+		if oldest == nil {
+			return
+		}
+		c.order.Remove(oldest)
+		entry := oldest.Value.(*transportCacheEntry[K])
+		delete(c.items, entry.key)
+		entry.transport.CloseIdleConnections()
+	}
+}
+
+// Len reports how many transports the cache currently holds.
+func (c *TransportCache[K]) Len() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.order.Len()
+}
+
+// Purge drops every entry and closes the idle connections it was holding.
+func (c *TransportCache[K]) Purge() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for element := c.order.Front(); element != nil; element = element.Next() {
+		element.Value.(*transportCacheEntry[K]).transport.CloseIdleConnections()
+	}
+	c.order.Init()
+	c.items = make(map[K]*list.Element, c.capacity)
 }

--- a/internal/runtime/executor/helps/transport_cache.go
+++ b/internal/runtime/executor/helps/transport_cache.go
@@ -1,0 +1,49 @@
+package helps
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
+)
+
+// sharedProxyTransports memoizes one transport per credential scope and normalized
+// proxy setting. Antigravity uses auth.ID as the scope so different OAuth identities
+// never share a TCP/TLS pool, matching the native client's one-credential process model.
+var sharedProxyTransports sync.Map // sharedProxyTransportKey -> *sharedProxyTransportEntry
+
+type sharedProxyTransportKey struct {
+	scope string
+	proxy string
+}
+
+type sharedProxyTransportEntry struct {
+	once      sync.Once
+	transport *http.Transport
+	mode      proxyutil.Mode
+	err       error
+}
+
+// SharedProxyTransport returns a stable transport for one credential scope and proxy
+// setting. It preserves Go's standard connection-pool settings; callers must treat
+// the result as read-only and clone it before changing protocol behavior.
+func SharedProxyTransport(scope, raw string) (*http.Transport, proxyutil.Mode, error) {
+	key := sharedProxyTransportKey{
+		scope: strings.TrimSpace(scope),
+		proxy: strings.TrimSpace(raw),
+	}
+	value, _ := sharedProxyTransports.LoadOrStore(key, &sharedProxyTransportEntry{})
+	entry := value.(*sharedProxyTransportEntry)
+	entry.once.Do(func() {
+		entry.transport, entry.mode, entry.err = proxyutil.BuildHTTPTransport(key.proxy)
+	})
+	return entry.transport, entry.mode, entry.err
+}
+
+func resetSharedProxyTransportsForTest() {
+	sharedProxyTransports.Range(func(key, _ any) bool {
+		sharedProxyTransports.Delete(key)
+		return true
+	})
+}

--- a/internal/runtime/executor/helps/transport_cache_test.go
+++ b/internal/runtime/executor/helps/transport_cache_test.go
@@ -1,0 +1,75 @@
+package helps
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
+)
+
+func TestSharedProxyTransportCachesNormalizedProxy(t *testing.T) {
+	resetSharedProxyTransportsForTest()
+	t.Cleanup(resetSharedProxyTransportsForTest)
+
+	first, mode, errFirst := SharedProxyTransport("auth-a", "  http://127.0.0.1:3128  ")
+	if errFirst != nil {
+		t.Fatalf("SharedProxyTransport() error = %v", errFirst)
+	}
+	second, _, errSecond := SharedProxyTransport("auth-a", "http://127.0.0.1:3128")
+	if errSecond != nil {
+		t.Fatalf("SharedProxyTransport() second error = %v", errSecond)
+	}
+	if mode != proxyutil.ModeProxy {
+		t.Fatalf("mode = %v, want %v", mode, proxyutil.ModeProxy)
+	}
+	if first == nil || first != second {
+		t.Fatalf("expected the same cached transport, got %p and %p", first, second)
+	}
+
+	other, _, errOther := SharedProxyTransport("auth-a", "http://127.0.0.1:3129")
+	if errOther != nil {
+		t.Fatalf("SharedProxyTransport() other proxy error = %v", errOther)
+	}
+	if other == first {
+		t.Fatal("distinct proxies must not share a transport")
+	}
+
+	otherAuth, _, errOtherAuth := SharedProxyTransport("auth-b", "http://127.0.0.1:3128")
+	if errOtherAuth != nil {
+		t.Fatalf("SharedProxyTransport() other auth error = %v", errOtherAuth)
+	}
+	if otherAuth == first {
+		t.Fatal("distinct credential scopes must not share a transport")
+	}
+
+	defaultTransport := http.DefaultTransport.(*http.Transport)
+	if first.MaxIdleConns != defaultTransport.MaxIdleConns ||
+		first.MaxIdleConnsPerHost != defaultTransport.MaxIdleConnsPerHost ||
+		first.IdleConnTimeout != defaultTransport.IdleConnTimeout {
+		t.Fatal("shared transport must preserve the standard Go connection pool settings")
+	}
+}
+
+func TestSharedProxyTransportConcurrentCallersShareOneInstance(t *testing.T) {
+	resetSharedProxyTransportsForTest()
+	t.Cleanup(resetSharedProxyTransportsForTest)
+
+	const callers = 32
+	results := make([]*http.Transport, callers)
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func(index int) {
+			defer wg.Done()
+			results[index], _, _ = SharedProxyTransport("auth-concurrent", "socks5://127.0.0.1:1080")
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 1; i < callers; i++ {
+		if results[i] != results[0] {
+			t.Fatalf("caller %d observed a different transport (%p vs %p)", i, results[i], results[0])
+		}
+	}
+}

--- a/internal/runtime/executor/helps/transport_cache_test.go
+++ b/internal/runtime/executor/helps/transport_cache_test.go
@@ -1,59 +1,116 @@
 package helps
 
 import (
+	"errors"
 	"net/http"
 	"sync"
 	"testing"
-
-	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
 )
 
-func TestSharedProxyTransportCachesNormalizedProxy(t *testing.T) {
-	resetSharedProxyTransportsForTest()
-	t.Cleanup(resetSharedProxyTransportsForTest)
+type cacheKey struct {
+	scope string
+	proxy string
+}
 
-	first, mode, errFirst := SharedProxyTransport("auth-a", "  http://127.0.0.1:3128  ")
+func TestTransportCacheReusesEntriesPerKey(t *testing.T) {
+	cache := NewTransportCache[cacheKey](8)
+
+	builds := 0
+	build := func() (*http.Transport, error) {
+		builds++
+		return &http.Transport{}, nil
+	}
+
+	first, errFirst := cache.Get(cacheKey{"auth-a", "p1"}, build)
 	if errFirst != nil {
-		t.Fatalf("SharedProxyTransport() error = %v", errFirst)
+		t.Fatalf("Get() error = %v", errFirst)
 	}
-	second, _, errSecond := SharedProxyTransport("auth-a", "http://127.0.0.1:3128")
+	second, errSecond := cache.Get(cacheKey{"auth-a", "p1"}, build)
 	if errSecond != nil {
-		t.Fatalf("SharedProxyTransport() second error = %v", errSecond)
-	}
-	if mode != proxyutil.ModeProxy {
-		t.Fatalf("mode = %v, want %v", mode, proxyutil.ModeProxy)
+		t.Fatalf("Get() second error = %v", errSecond)
 	}
 	if first == nil || first != second {
-		t.Fatalf("expected the same cached transport, got %p and %p", first, second)
+		t.Fatalf("expected one cached transport, got %p and %p", first, second)
+	}
+	if builds != 1 {
+		t.Fatalf("build called %d times, want 1", builds)
 	}
 
-	other, _, errOther := SharedProxyTransport("auth-a", "http://127.0.0.1:3129")
-	if errOther != nil {
-		t.Fatalf("SharedProxyTransport() other proxy error = %v", errOther)
-	}
-	if other == first {
+	otherProxy, _ := cache.Get(cacheKey{"auth-a", "p2"}, build)
+	if otherProxy == first {
 		t.Fatal("distinct proxies must not share a transport")
 	}
-
-	otherAuth, _, errOtherAuth := SharedProxyTransport("auth-b", "http://127.0.0.1:3128")
-	if errOtherAuth != nil {
-		t.Fatalf("SharedProxyTransport() other auth error = %v", errOtherAuth)
-	}
-	if otherAuth == first {
+	otherScope, _ := cache.Get(cacheKey{"auth-b", "p1"}, build)
+	if otherScope == first {
 		t.Fatal("distinct credential scopes must not share a transport")
 	}
-
-	defaultTransport := http.DefaultTransport.(*http.Transport)
-	if first.MaxIdleConns != defaultTransport.MaxIdleConns ||
-		first.MaxIdleConnsPerHost != defaultTransport.MaxIdleConnsPerHost ||
-		first.IdleConnTimeout != defaultTransport.IdleConnTimeout {
-		t.Fatal("shared transport must preserve the standard Go connection pool settings")
+	if got := cache.Len(); got != 3 {
+		t.Fatalf("cache Len() = %d, want 3", got)
 	}
 }
 
-func TestSharedProxyTransportConcurrentCallersShareOneInstance(t *testing.T) {
-	resetSharedProxyTransportsForTest()
-	t.Cleanup(resetSharedProxyTransportsForTest)
+// TestTransportCacheBoundsEntries is the regression test for unbounded pool growth:
+// every cached transport owns a connection pool, so churning keys must evict.
+func TestTransportCacheBoundsEntries(t *testing.T) {
+	const capacity = 4
+	cache := NewTransportCache[cacheKey](capacity)
+
+	for i := 0; i < 100; i++ {
+		key := cacheKey{"auth", string(rune('a' + i%97))}
+		if _, err := cache.Get(key, func() (*http.Transport, error) { return &http.Transport{}, nil }); err != nil {
+			t.Fatalf("Get() error = %v", err)
+		}
+		if got := cache.Len(); got > capacity {
+			t.Fatalf("cache grew to %d entries, want at most %d", got, capacity)
+		}
+	}
+}
+
+// TestTransportCacheEvictsLeastRecentlyUsed proves recency is honoured, so a hot
+// credential is not evicted by a burst of one-off keys.
+func TestTransportCacheEvictsLeastRecentlyUsed(t *testing.T) {
+	cache := NewTransportCache[cacheKey](2)
+	build := func() (*http.Transport, error) { return &http.Transport{}, nil }
+
+	hot, _ := cache.Get(cacheKey{"hot", ""}, build)
+	cache.Get(cacheKey{"cold", ""}, build)
+	// Touch hot so cold becomes the least recently used entry.
+	if again, _ := cache.Get(cacheKey{"hot", ""}, build); again != hot {
+		t.Fatal("expected the hot entry to still be cached")
+	}
+	cache.Get(cacheKey{"new", ""}, build)
+
+	if again, _ := cache.Get(cacheKey{"hot", ""}, build); again != hot {
+		t.Fatal("the most recently used entry must survive eviction")
+	}
+}
+
+// TestTransportCacheDoesNotCacheBuildFailures ensures a transient failure neither
+// occupies a cache slot nor becomes permanent.
+func TestTransportCacheDoesNotCacheBuildFailures(t *testing.T) {
+	cache := NewTransportCache[cacheKey](4)
+	key := cacheKey{"auth", "broken"}
+
+	if _, err := cache.Get(key, func() (*http.Transport, error) { return nil, errors.New("boom") }); err == nil {
+		t.Fatal("expected the build error to be propagated")
+	}
+	if got := cache.Len(); got != 0 {
+		t.Fatalf("a failed build must not occupy a cache slot, Len() = %d", got)
+	}
+	// A build returning (nil, nil) must be reported rather than cached as usable.
+	if _, err := cache.Get(key, func() (*http.Transport, error) { return nil, nil }); err == nil {
+		t.Fatal("expected an error when build returns no transport")
+	}
+
+	transport, err := cache.Get(key, func() (*http.Transport, error) { return &http.Transport{}, nil })
+	if err != nil || transport == nil {
+		t.Fatalf("retry after failure must succeed, got (%p, %v)", transport, err)
+	}
+}
+
+func TestTransportCacheConcurrentCallersShareOneInstance(t *testing.T) {
+	cache := NewTransportCache[cacheKey](8)
+	key := cacheKey{"auth-concurrent", "socks5://127.0.0.1:1080"}
 
 	const callers = 32
 	results := make([]*http.Transport, callers)
@@ -62,7 +119,7 @@ func TestSharedProxyTransportConcurrentCallersShareOneInstance(t *testing.T) {
 	for i := 0; i < callers; i++ {
 		go func(index int) {
 			defer wg.Done()
-			results[index], _, _ = SharedProxyTransport("auth-concurrent", "socks5://127.0.0.1:1080")
+			results[index], _ = cache.Get(key, func() (*http.Transport, error) { return &http.Transport{}, nil })
 		}(i)
 	}
 	wg.Wait()
@@ -70,6 +127,46 @@ func TestSharedProxyTransportConcurrentCallersShareOneInstance(t *testing.T) {
 	for i := 1; i < callers; i++ {
 		if results[i] != results[0] {
 			t.Fatalf("caller %d observed a different transport (%p vs %p)", i, results[i], results[0])
+		}
+	}
+}
+
+func TestTransportCachePurgeAndNilSafety(t *testing.T) {
+	cache := NewTransportCache[cacheKey](4)
+	build := func() (*http.Transport, error) { return &http.Transport{}, nil }
+	cache.Get(cacheKey{"a", ""}, build)
+	cache.Get(cacheKey{"b", ""}, build)
+	if got := cache.Len(); got != 2 {
+		t.Fatalf("Len() = %d, want 2", got)
+	}
+	cache.Purge()
+	if got := cache.Len(); got != 0 {
+		t.Fatalf("Len() after Purge() = %d, want 0", got)
+	}
+	// The cache stays usable after a purge.
+	if transport, err := cache.Get(cacheKey{"a", ""}, build); err != nil || transport == nil {
+		t.Fatalf("Get() after Purge() = (%p, %v)", transport, err)
+	}
+
+	var nilCache *TransportCache[cacheKey]
+	if _, err := nilCache.Get(cacheKey{}, build); err == nil {
+		t.Fatal("expected an error from a nil cache")
+	}
+	if got := nilCache.Len(); got != 0 {
+		t.Fatalf("nil cache Len() = %d, want 0", got)
+	}
+	nilCache.Purge() // must not panic
+
+	if _, err := cache.Get(cacheKey{"nil-build", ""}, nil); err == nil {
+		t.Fatal("expected an error for a nil build function")
+	}
+}
+
+func TestNewTransportCacheDefaultsCapacity(t *testing.T) {
+	for _, capacity := range []int{0, -1} {
+		cache := NewTransportCache[cacheKey](capacity)
+		if cache.capacity != DefaultTransportCacheCapacity {
+			t.Fatalf("NewTransportCache(%d).capacity = %d, want %d", capacity, cache.capacity, DefaultTransportCacheCapacity)
 		}
 	}
 }


### PR DESCRIPTION
### Summary

Native Antigravity reuses HTTP/1.1 and HTTP/2 connection pools across requests. This PR enables connection pool reuse for Antigravity upstream requests in CLIProxyAPI, eliminating redundant TCP and TLS handshakes.

### Key Changes
1. **Credential-scoped Transport Caching**: Introduced `antigravityHTTP11Transport` to cache and reuse `http.Transport` instances per stable credential identity (`auth.ID`).
2. **Anonymous Pool Isolation**: Prevented unsafe connection pool sharing for auth objects missing a stable ID by providing isolated private pools.
3. **Keep-Alive Protection**: Explicitly reset `httpReq.Close = false` on passthrough requests so downstream `Connection: close` headers cannot bleed upstream and drain shared connection pools.
4. **Test Coverage**: Added test suites in `antigravity_executor_keepalive_test.go` and `antigravity_executor_transport_test.go` to verify keep-alive reuse, multi-session isolation, and anonymous auth safety.

### Verification
- Tested with `go test -v ./internal/runtime/executor/... -run "TestAntigravity"` (all pass).
- Verified compilation via `go build -o test-output ./cmd/server`.