### PR TITLE
fix(responses): surface incomplete upstream streams instead of silent success

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -52,6 +53,7 @@ type responsesSSEFramer struct {
 	outputItems          map[int][]byte
 	outputOrder          []int
 	unindexedOutputItems [][]byte
+	sawTerminalEvent     bool
 }
 
 func (f *responsesSSEFramer) WriteChunk(w io.Writer, chunk []byte) {
@@ -98,6 +100,10 @@ func (f *responsesSSEFramer) Flush(w io.Writer) {
 	f.pending = f.pending[:0]
 }
 
+func (f *responsesSSEFramer) sawResponsesTerminalEvent() bool {
+	return f != nil && f.sawTerminalEvent
+}
+
 func (f *responsesSSEFramer) writeFrame(w io.Writer, frame []byte) {
 	writeResponsesSSEChunk(w, f.repairFrame(frame))
 }
@@ -108,14 +114,18 @@ func (f *responsesSSEFramer) repairFrame(frame []byte) []byte {
 		return frame
 	}
 
-	switch gjson.GetBytes(payload, "type").String() {
-	case "response.output_item.done":
-		f.recordOutputItem(payload)
-	case "response.completed":
+	switch event := gjson.GetBytes(payload, "type").String(); event {
+	case "response.completed", "response.incomplete", "response.failed", "error":
+		f.sawTerminalEvent = true
+		if event != "response.completed" {
+			return frame
+		}
 		repaired := f.repairCompletedPayload(payload)
 		if !bytes.Equal(repaired, payload) {
 			return responsesSSEFrameWithData(frame, repaired)
 		}
+	case "response.output_item.done":
+		f.recordOutputItem(payload)
 	}
 	return frame
 }
@@ -553,7 +563,7 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 				// Stream closed without data? Send headers and done.
 				setSSEHeaders()
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-				_, _ = c.Writer.Write([]byte("\n"))
+				writeResponsesStreamGenericFailure(c, framer, responsesStreamPrematureCloseMessage)
 				flusher.Flush()
 				cliCancel(nil)
 				return
@@ -591,6 +601,22 @@ func isCodexResponsesClientRequest(c *gin.Context) bool {
 	}
 }
 
+const responsesStreamPrematureCloseMessage = "upstream stream ended before a terminal response event"
+
+// writeResponsesStreamGenericFailure signals a terminal failure without leaking upstream error details.
+func writeResponsesStreamGenericFailure(c *gin.Context, framer *responsesSSEFramer, message string) {
+	if framer != nil {
+		framer.Flush(c.Writer)
+	}
+	if isCodexResponsesClientRequest(c) {
+		chunk := handlers.BuildOpenAIResponsesStreamFailedChunk(http.StatusInternalServerError, message, 0)
+		_, _ = fmt.Fprintf(c.Writer, "\nevent: response.failed\ndata: %s\n\n", string(chunk))
+		return
+	}
+	chunk := handlers.BuildOpenAIResponsesStreamErrorChunk(http.StatusInternalServerError, message, 0)
+	_, _ = fmt.Fprintf(c.Writer, "\nevent: error\ndata: %s\n\n", string(chunk))
+}
+
 func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage, framer *responsesSSEFramer) {
 	if framer == nil {
 		framer = &responsesSSEFramer{}
@@ -602,6 +628,10 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flush
 		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) {
 			framer.Flush(c.Writer)
 			if !shouldExposeResponsesUpstreamError(errMsg) {
+				if errMsg != nil && errMsg.Error != nil {
+					log.Warnf("responses http stream: hiding upstream terminal error from client: %v", errMsg.Error)
+				}
+				writeResponsesStreamGenericFailure(c, framer, responsesStreamPrematureCloseMessage)
 				return
 			}
 			status := http.StatusInternalServerError
@@ -622,6 +652,11 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flush
 		},
 		WriteDone: func() {
 			framer.Flush(c.Writer)
+			if !framer.sawResponsesTerminalEvent() {
+				log.Warnf("responses http stream: upstream ended without a terminal response event")
+				writeResponsesStreamGenericFailure(c, framer, responsesStreamPrematureCloseMessage)
+				return
+			}
 			_, _ = c.Writer.Write([]byte("\n"))
 		},
 	})

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_error_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_error_test.go
@@ -14,8 +14,9 @@ import (
 )
 
 // TestForwardResponsesStreamExposesOnlyClientErrors pins the SSE side: only
-// request-shape failures reach the client. Credential, quota and transport
-// failures end the stream silently so the client retries on its own.
+// request-shape failures reach the client verbatim. Credential, quota and
+// transport failures are replaced with a generic terminal error that does not
+// leak upstream error details.
 func TestForwardResponsesStreamExposesOnlyClientErrors(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -24,12 +25,14 @@ func TestForwardResponsesStreamExposesOnlyClientErrors(t *testing.T) {
 		status      int
 		message     string
 		wantExposed bool
+		wantText    string
 	}{
 		{
 			name:        "bad request",
 			status:      http.StatusBadRequest,
 			message:     `{"error":{"type":"invalid_request","code":"cyber_policy","message":"blocked"}}`,
 			wantExposed: true,
+			wantText:    "blocked",
 		},
 		{
 			// Observed in production: the same cyber_policy rejection arrives with 502
@@ -38,12 +41,14 @@ func TestForwardResponsesStreamExposesOnlyClientErrors(t *testing.T) {
 			status:      http.StatusBadGateway,
 			message:     `{"error":{"type":"invalid_request","code":"cyber_policy","message":"This content was flagged for possible cybersecurity risk.","param":null}}`,
 			wantExposed: true,
+			wantText:    "This content was flagged for possible cybersecurity risk.",
 		},
 		{
 			name:        "context length exceeded behind bad gateway status",
 			status:      http.StatusBadGateway,
 			message:     `{"error":{"type":"invalid_request_error","code":"context_length_exceeded","message":"Your input exceeds the context window."}}`,
 			wantExposed: true,
+			wantText:    "Your input exceeds the context window.",
 		},
 		{name: "conflict", status: http.StatusConflict, message: "conflict", wantExposed: true},
 		{name: "message too big", status: http.StatusRequestEntityTooLarge, message: "too large", wantExposed: true},
@@ -78,11 +83,19 @@ func TestForwardResponsesStreamExposesOnlyClientErrors(t *testing.T) {
 
 			h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
 			body := recorder.Body.String()
-			exposed := strings.Contains(body, `"type":"error"`)
-			if exposed != tc.wantExposed {
-				t.Fatalf("error exposed = %t, want %t: %q", exposed, tc.wantExposed, body)
+			wantText := tc.wantText
+			if wantText == "" {
+				wantText = tc.message
 			}
-			if exposed && strings.Contains(body, `"error":{`) {
+			rawExposed := strings.Contains(body, wantText)
+			if rawExposed != tc.wantExposed {
+				t.Fatalf("upstream error exposed = %t, want %t: %q", rawExposed, tc.wantExposed, body)
+			}
+			genericExposed := strings.Contains(body, responsesStreamPrematureCloseMessage)
+			if genericExposed == tc.wantExposed {
+				t.Fatalf("generic failure presence = %t, want %t: %q", genericExposed, !tc.wantExposed, body)
+			}
+			if rawExposed && strings.Contains(body, `"error":{`) {
 				t.Fatalf("expected streaming error chunk, got HTTP error body: %q", body)
 			}
 		})

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -171,8 +171,11 @@ func TestForwardResponsesStreamReassemblesSplitSSEEventChunks(t *testing.T) {
 
 	got := strings.TrimSuffix(recorder.Body.String(), "\n")
 	want := "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n"
-	if got != want {
-		t.Fatalf("unexpected split-event framing.\nGot:  %q\nWant: %q", got, want)
+	if !strings.HasPrefix(got, want) {
+		t.Fatalf("unexpected split-event framing.\nGot:  %q\nWant prefix: %q", got, want)
+	}
+	if !strings.Contains(got, "event: error") || !strings.Contains(got, responsesStreamPrematureCloseMessage) {
+		t.Fatalf("expected terminal failure after non-terminal event: %q", got)
 	}
 }
 
@@ -189,8 +192,11 @@ func TestForwardResponsesStreamPreservesValidFullSSEEventChunks(t *testing.T) {
 	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
 
 	got := strings.TrimSuffix(recorder.Body.String(), "\n")
-	if got != string(chunk) {
-		t.Fatalf("unexpected full-event framing.\nGot:  %q\nWant: %q", got, string(chunk))
+	if !strings.HasPrefix(got, string(chunk)) {
+		t.Fatalf("unexpected full-event framing.\nGot:  %q\nWant prefix: %q", got, string(chunk))
+	}
+	if !strings.Contains(got, "event: error") || !strings.Contains(got, responsesStreamPrematureCloseMessage) {
+		t.Fatalf("expected terminal failure after non-terminal event: %q", got)
 	}
 }
 
@@ -208,8 +214,11 @@ func TestForwardResponsesStreamBuffersSplitDataPayloadChunks(t *testing.T) {
 
 	got := recorder.Body.String()
 	want := "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n\n"
-	if got != want {
-		t.Fatalf("unexpected split-data framing.\nGot:  %q\nWant: %q", got, want)
+	if !strings.HasPrefix(got, want) {
+		t.Fatalf("unexpected split-data framing.\nGot:  %q\nWant prefix: %q", got, want)
+	}
+	if !strings.Contains(got, "event: error") || !strings.Contains(got, responsesStreamPrematureCloseMessage) {
+		t.Fatalf("expected terminal failure after non-terminal event: %q", got)
 	}
 }
 
@@ -233,7 +242,56 @@ func TestForwardResponsesStreamDropsIncompleteTrailingDataChunkOnFlush(t *testin
 
 	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
 
-	if got := recorder.Body.String(); got != "\n" {
+	got := recorder.Body.String()
+	if strings.Contains(got, "response.created") {
 		t.Fatalf("expected incomplete trailing data to be dropped on flush.\nGot: %q", got)
+	}
+	if !strings.Contains(got, "event: error") || !strings.Contains(got, responsesStreamPrematureCloseMessage) {
+		t.Fatalf("expected terminal failure after dropped chunk: %q", got)
+	}
+}
+
+func TestForwardResponsesStreamSendsErrorWhenUpstreamEndsWithoutTerminalEvent(t *testing.T) {
+	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
+
+	data := make(chan []byte, 1)
+	errs := make(chan *interfaces.ErrorMessage)
+	data <- []byte(`data: {"type":"response.output_item.done","item":{"type":"reasoning","id":"rs-1","summary":[{"type":"summary_text","text":"thinking"}]}}`)
+	close(data)
+	close(errs)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+	body := recorder.Body.String()
+	if !strings.Contains(body, "event: error") {
+		t.Fatalf("missing terminal error event: %q", body)
+	}
+	if !strings.Contains(body, responsesStreamPrematureCloseMessage) {
+		t.Fatalf("missing premature-close message: %q", body)
+	}
+	if strings.Contains(body, "event: response.failed") || strings.Contains(body, `"type":"response.completed"`) {
+		t.Fatalf("unexpected completed/failed event for non-Codex client: %q", body)
+	}
+}
+
+func TestForwardResponsesStreamSendsFailureWhenUpstreamEndsWithoutTerminalEvent(t *testing.T) {
+	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
+	c.Request.Header.Set("User-Agent", "Codex Desktop/26.803.41515")
+
+	data := make(chan []byte, 1)
+	errs := make(chan *interfaces.ErrorMessage)
+	data <- []byte(`data: {"type":"response.output_item.done","item":{"type":"reasoning","id":"rs-1","summary":[{"type":"summary_text","text":"thinking"}]}}`)
+	close(data)
+	close(errs)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+	body := recorder.Body.String()
+	if !strings.Contains(body, "event: response.failed") {
+		t.Fatalf("missing response.failed event: %q", body)
+	}
+	if !strings.Contains(body, responsesStreamPrematureCloseMessage) {
+		t.Fatalf("missing premature-close message: %q", body)
+	}
+	if strings.Contains(body, "event: error") || strings.Contains(body, `"type":"response.completed"`) {
+		t.Fatalf("unexpected completed/legacy error event for Codex: %q", body)
 	}
 }


### PR DESCRIPTION
Fixes #4904

## Problem

`POST /v1/responses` can end mid-output with HTTP 200 and no terminal event (`response.completed` / `response.incomplete` / `response.failed` / `error`). Observed with `deepseek-v4-flash` + Codex Desktop through the HTTP Responses route: the stream stops while assistant text is being emitted, no failure is surfaced, and the client has to resend "continue".

This PR implements the handler-layer fix. The translator-side part of the root cause (unconditional `response.completed` on `[DONE]` even for reasoning-only/empty streams) is documented in #4904 for the maintenance team, because this repository's `pr-path-guard.yml` does not allow PRs to modify `internal/translator/**`.

## Changes

- `responsesSSEFramer` now records whether a terminal event was seen (`response.completed`, `response.incomplete`, `response.failed`, `error`).
- `WriteDone` emits a generic terminal failure when the upstream ended without a terminal event, instead of silently finalizing as success.
- `WriteTerminalError` no longer closes silently for non-exposable upstream errors: it writes a generic failure event and keeps the upstream reason in a warn log.
- The "stream closed without data" branch now writes the generic failure instead of a bare newline.
- Codex Desktop clients receive `response.failed`; other clients receive an `error` event. Upstream error details are still not leaked to clients.

## Behaviour change

Only the paths that previously ended silently or reported success for an incomplete stream are affected. A stream that genuinely completes with a terminal event is unchanged.

## Verification

- `go test ./sdk/api/handlers/...` — pass
- `go build ./...` — pass
- `gofmt` clean on changed files
- New tests: upstream close without terminal event emits terminal failure for both Codex and non-Codex clients; hidden upstream errors are replaced with the generic failure instead of a silent close.

## Related

- #4873 (incomplete Responses tool stream finalized as `response.completed`)
- #4760 (Codex stream closes before `response.completed`)
- #4711 (surface pending terminal error in streaming peek loops). This PR is complementary: #4711 fixes the buffered-error race, while this PR covers the nil-error close path without a terminal event.
