### PR TITLE
fix(codex): track multi-agent namespace state by response lineage

### DIFF
--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -183,7 +183,8 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			sess.clearActive(conn, readCh)
 		}()
 	}
-	restoreMultiAgentV2 := !multiAgentV2Conflict && (optimizeMultiAgentV2 || sess.isMultiAgentV2Optimized(conn))
+	previousResponseID := strings.TrimSpace(gjson.GetBytes(wsReqBody, "previous_response_id").String())
+	restoreMultiAgentV2 := sess.multiAgentV2OptimizedForRequest(conn, previousResponseID, optimizeMultiAgentV2, multiAgentV2Conflict)
 
 	if errSend := writeCodexWebsocketMessage(sess, conn, wsReqBody); errSend != nil {
 		errSend = mapCodexWebsocketWriteError(sess, conn, errSend)
@@ -217,7 +218,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 					return resp, errBind
 				}
 				readCh = sess.activate(conn)
-				restoreMultiAgentV2 = !multiAgentV2Conflict && (optimizeMultiAgentV2 || sess.isMultiAgentV2Optimized(conn))
+				restoreMultiAgentV2 = sess.multiAgentV2OptimizedForRequest(conn, previousResponseID, optimizeMultiAgentV2, multiAgentV2Conflict)
 				wsReqBodyRetry := buildCodexWebsocketRequestBody(upstreamBody)
 				helps.RecordAPIWebsocketRequest(ctx, e.cfg, helps.UpstreamRequestLog{
 					URL:       wsURL,
@@ -249,10 +250,6 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			helps.RecordAPIWebsocketError(ctx, e.cfg, "send", errSend)
 			return resp, errSend
 		}
-	}
-
-	if optimizeMultiAgentV2 || multiAgentV2Conflict {
-		sess.setMultiAgentV2Optimized(conn, optimizeMultiAgentV2 && !multiAgentV2Conflict)
 	}
 
 	outputItemsByIndex := make(map[int64][]byte)
@@ -316,6 +313,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			collectCodexOutputItemDone(payload, outputItemsByIndex, &outputItemsFallback)
 		case "response.completed":
 			payload = patchCodexCompletedOutput(payload, outputItemsByIndex, outputItemsFallback)
+			sess.recordMultiAgentV2Lineage(conn, gjson.GetBytes(payload, "response.id").String(), restoreMultiAgentV2)
 			cacheCodexReasoningReplayFromCompleted(replayScope, payload)
 			if detail, ok := helps.ParseCodexUsage(payload); ok {
 				reporter.Publish(ctx, detail)

--- a/internal/runtime/executor/codex_websockets_session.go
+++ b/internal/runtime/executor/codex_websockets_session.go
@@ -19,6 +19,8 @@ type codexWebsocketSessionStore struct {
 	sessions map[string]*codexWebsocketSession
 }
 
+const codexMultiAgentV2LineageMaxEntries = 256
+
 var globalCodexWebsocketSessionStore = &codexWebsocketSessionStore{
 	sessions: make(map[string]*codexWebsocketSession),
 }
@@ -51,15 +53,16 @@ type codexWebsocketSession struct {
 
 	reqMu sync.Mutex
 
-	connMu                    sync.Mutex
-	conn                      *websocket.Conn
-	connCloser                *websocketConnectionCloser
-	wsURL                     string
-	authID                    string
-	multiAgentV2OptimizedConn *websocket.Conn
-	lifecycleBindMu           sync.Mutex
-	lifecycle                 cliproxyexecutor.ExecutionLifecycle
-	lifecycleModel            string
+	connMu                   sync.Mutex
+	conn                     *websocket.Conn
+	connCloser               *websocketConnectionCloser
+	wsURL                    string
+	authID                   string
+	multiAgentV2Lineages     map[string]bool
+	multiAgentV2LineageOrder []string
+	lifecycleBindMu          sync.Mutex
+	lifecycle                cliproxyexecutor.ExecutionLifecycle
+	lifecycleModel           string
 
 	writeMu sync.Mutex
 
@@ -164,28 +167,53 @@ func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, 
 	return conn.WriteMessage(msgType, payload)
 }
 
-func (s *codexWebsocketSession) setMultiAgentV2Optimized(conn *websocket.Conn, optimized bool) {
-	if s == nil || conn == nil {
-		return
+func (s *codexWebsocketSession) multiAgentV2OptimizedForRequest(conn *websocket.Conn, previousResponseID string, optimized bool, conflict bool) bool {
+	if conflict {
+		return false
 	}
-	s.connMu.Lock()
-	if s.conn == conn {
-		if optimized {
-			s.multiAgentV2OptimizedConn = conn
-		} else {
-			s.multiAgentV2OptimizedConn = nil
-		}
+	if optimized {
+		return true
 	}
-	s.connMu.Unlock()
-}
-
-func (s *codexWebsocketSession) isMultiAgentV2Optimized(conn *websocket.Conn) bool {
-	if s == nil || conn == nil {
+	previousResponseID = strings.TrimSpace(previousResponseID)
+	if s == nil || conn == nil || previousResponseID == "" {
 		return false
 	}
 	s.connMu.Lock()
 	defer s.connMu.Unlock()
-	return s.conn == conn && s.multiAgentV2OptimizedConn == conn
+	if s.conn != conn {
+		return false
+	}
+	return s.multiAgentV2Lineages[previousResponseID]
+}
+
+func (s *codexWebsocketSession) recordMultiAgentV2Lineage(conn *websocket.Conn, responseID string, optimized bool) {
+	responseID = strings.Clone(strings.TrimSpace(responseID))
+	if s == nil || conn == nil || responseID == "" {
+		return
+	}
+	s.connMu.Lock()
+	defer s.connMu.Unlock()
+	if s.conn != conn {
+		return
+	}
+	if s.multiAgentV2Lineages == nil {
+		s.multiAgentV2Lineages = make(map[string]bool)
+	}
+	if _, exists := s.multiAgentV2Lineages[responseID]; !exists {
+		s.multiAgentV2LineageOrder = append(s.multiAgentV2LineageOrder, responseID)
+	}
+	s.multiAgentV2Lineages[responseID] = optimized
+	for len(s.multiAgentV2LineageOrder) > codexMultiAgentV2LineageMaxEntries {
+		evict := s.multiAgentV2LineageOrder[0]
+		s.multiAgentV2LineageOrder[0] = ""
+		s.multiAgentV2LineageOrder = s.multiAgentV2LineageOrder[1:]
+		delete(s.multiAgentV2Lineages, evict)
+	}
+}
+
+func (s *codexWebsocketSession) resetMultiAgentV2LineagesLocked() {
+	s.multiAgentV2Lineages = nil
+	s.multiAgentV2LineageOrder = nil
 }
 
 // sendTerminalWebsocketRead reports whether it invalidated a full channel's connection before waiting.
@@ -297,7 +325,7 @@ func (s *codexWebsocketSession) detachConnection(conn *websocket.Conn, lifecycle
 		closer = s.connCloser
 		s.conn = nil
 		s.connCloser = nil
-		s.multiAgentV2OptimizedConn = nil
+		s.resetMultiAgentV2LineagesLocked()
 		if s.readerConn == conn {
 			s.readerConn = nil
 		}
@@ -372,7 +400,7 @@ func detachMismatchedWebsocketSessionConn(sess *codexWebsocketSession, authID st
 	sess.lifecycleModel = ""
 	sess.conn = nil
 	sess.connCloser = nil
-	sess.multiAgentV2OptimizedConn = nil
+	sess.resetMultiAgentV2LineagesLocked()
 	if sess.readerConn == conn {
 		sess.readerConn = nil
 	}
@@ -532,7 +560,7 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 	}
 	sess.conn = conn
 	sess.connCloser = closer
-	sess.multiAgentV2OptimizedConn = nil
+	sess.resetMultiAgentV2LineagesLocked()
 	sess.wsURL = wsURL
 	sess.authID = authID
 	sess.readerConn = conn
@@ -630,7 +658,7 @@ func (e *CodexWebsocketsExecutor) invalidateUpstreamConnWithNotify(sess *codexWe
 	sess.lifecycleModel = ""
 	sess.conn = nil
 	sess.connCloser = nil
-	sess.multiAgentV2OptimizedConn = nil
+	sess.resetMultiAgentV2LineagesLocked()
 	if sess.readerConn == conn {
 		sess.readerConn = nil
 	}
@@ -722,7 +750,7 @@ func closeCodexWebsocketSession(sess *codexWebsocketSession, reason string) {
 	sess.lifecycleModel = ""
 	sess.conn = nil
 	sess.connCloser = nil
-	sess.multiAgentV2OptimizedConn = nil
+	sess.resetMultiAgentV2LineagesLocked()
 	if sess.readerConn == conn {
 		sess.readerConn = nil
 	}

--- a/internal/runtime/executor/codex_websockets_session.go
+++ b/internal/runtime/executor/codex_websockets_session.go
@@ -19,8 +19,6 @@ type codexWebsocketSessionStore struct {
 	sessions map[string]*codexWebsocketSession
 }
 
-const codexMultiAgentV2LineageMaxEntries = 256
-
 var globalCodexWebsocketSessionStore = &codexWebsocketSessionStore{
 	sessions: make(map[string]*codexWebsocketSession),
 }
@@ -53,16 +51,15 @@ type codexWebsocketSession struct {
 
 	reqMu sync.Mutex
 
-	connMu                   sync.Mutex
-	conn                     *websocket.Conn
-	connCloser               *websocketConnectionCloser
-	wsURL                    string
-	authID                   string
-	multiAgentV2Lineages     map[string]bool
-	multiAgentV2LineageOrder []string
-	lifecycleBindMu          sync.Mutex
-	lifecycle                cliproxyexecutor.ExecutionLifecycle
-	lifecycleModel           string
+	connMu               sync.Mutex
+	conn                 *websocket.Conn
+	connCloser           *websocketConnectionCloser
+	wsURL                string
+	authID               string
+	multiAgentV2Lineages map[string]struct{}
+	lifecycleBindMu      sync.Mutex
+	lifecycle            cliproxyexecutor.ExecutionLifecycle
+	lifecycleModel       string
 
 	writeMu sync.Mutex
 
@@ -183,12 +180,13 @@ func (s *codexWebsocketSession) multiAgentV2OptimizedForRequest(conn *websocket.
 	if s.conn != conn {
 		return false
 	}
-	return s.multiAgentV2Lineages[previousResponseID]
+	_, optimized = s.multiAgentV2Lineages[previousResponseID]
+	return optimized
 }
 
 func (s *codexWebsocketSession) recordMultiAgentV2Lineage(conn *websocket.Conn, responseID string, optimized bool) {
 	responseID = strings.Clone(strings.TrimSpace(responseID))
-	if s == nil || conn == nil || responseID == "" {
+	if s == nil || conn == nil || responseID == "" || !optimized {
 		return
 	}
 	s.connMu.Lock()
@@ -197,23 +195,13 @@ func (s *codexWebsocketSession) recordMultiAgentV2Lineage(conn *websocket.Conn, 
 		return
 	}
 	if s.multiAgentV2Lineages == nil {
-		s.multiAgentV2Lineages = make(map[string]bool)
+		s.multiAgentV2Lineages = make(map[string]struct{})
 	}
-	if _, exists := s.multiAgentV2Lineages[responseID]; !exists {
-		s.multiAgentV2LineageOrder = append(s.multiAgentV2LineageOrder, responseID)
-	}
-	s.multiAgentV2Lineages[responseID] = optimized
-	for len(s.multiAgentV2LineageOrder) > codexMultiAgentV2LineageMaxEntries {
-		evict := s.multiAgentV2LineageOrder[0]
-		s.multiAgentV2LineageOrder[0] = ""
-		s.multiAgentV2LineageOrder = s.multiAgentV2LineageOrder[1:]
-		delete(s.multiAgentV2Lineages, evict)
-	}
+	s.multiAgentV2Lineages[responseID] = struct{}{}
 }
 
 func (s *codexWebsocketSession) resetMultiAgentV2LineagesLocked() {
 	s.multiAgentV2Lineages = nil
-	s.multiAgentV2LineageOrder = nil
 }
 
 // sendTerminalWebsocketRead reports whether it invalidated a full channel's connection before waiting.

--- a/internal/runtime/executor/codex_websockets_spawn_agent_test.go
+++ b/internal/runtime/executor/codex_websockets_spawn_agent_test.go
@@ -27,7 +27,7 @@ func TestCodexWebsocketsExecutorRestoresMultiAgentV2NamespaceAcrossIncrementalTu
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
-			capturedPayload := make(chan []byte, 6)
+			capturedPayload := make(chan []byte, 8)
 			var connectionCount atomic.Int32
 			var requestCount atomic.Int32
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
@@ -51,7 +51,7 @@ func TestCodexWebsocketsExecutorRestoresMultiAgentV2NamespaceAcrossIncrementalTu
 						t.Errorf("write websocket response: %v", errWrite)
 						return
 					}
-					if turn == 6 {
+					if turn == 8 {
 						return
 					}
 				}
@@ -136,25 +136,78 @@ func TestCodexWebsocketsExecutorRestoresMultiAgentV2NamespaceAcrossIncrementalTu
 				t.Fatalf("user-defined namespace was rewritten on the post-conflict incremental turn: %s", fourthClientPayload)
 			}
 
-			fifthClientPayload := execute(codexSpawnAgentTestPayload())
-			fifthUpstreamPayload := <-capturedPayload
-			if namespace := gjson.GetBytes(fifthUpstreamPayload, "input.0.tools.0.name").String(); namespace != "collaboration-optimize" {
+			optimizedBranchRequest := []byte(`{"model":"gpt-5.4","previous_response_id":"resp_2","input":[{"type":"function_call_output","call_id":"call_2","output":"branch-a"}]}`)
+			optimizedBranchClientPayload := execute(optimizedBranchRequest)
+			optimizedBranchUpstreamPayload := <-capturedPayload
+			if strings.Contains(string(optimizedBranchUpstreamPayload), "collaboration") || strings.Contains(string(optimizedBranchUpstreamPayload), "spawn_agent") {
+				t.Fatalf("optimized branch request unexpectedly contains collaboration tools: %s", optimizedBranchUpstreamPayload)
+			}
+			assertCodexSpawnAgentClientNamespace(t, optimizedBranchClientPayload)
+
+			conflictBranchRequest := []byte(`{"model":"gpt-5.4","previous_response_id":"resp_4","input":[{"type":"function_call_output","call_id":"call_4","output":"branch-b"}]}`)
+			conflictBranchClientPayload := execute(conflictBranchRequest)
+			conflictBranchUpstreamPayload := <-capturedPayload
+			if strings.Contains(string(conflictBranchUpstreamPayload), "collaboration") || strings.Contains(string(conflictBranchUpstreamPayload), "spawn_agent") {
+				t.Fatalf("conflict branch request unexpectedly contains collaboration tools: %s", conflictBranchUpstreamPayload)
+			}
+			if !strings.Contains(string(conflictBranchClientPayload), `"namespace":"collaboration-optimize"`) {
+				t.Fatalf("conflict branch user-defined namespace was rewritten: %s", conflictBranchClientPayload)
+			}
+
+			reenabledClientPayload := execute(codexSpawnAgentTestPayload())
+			reenabledUpstreamPayload := <-capturedPayload
+			if namespace := gjson.GetBytes(reenabledUpstreamPayload, "input.0.tools.0.name").String(); namespace != "collaboration-optimize" {
 				t.Fatalf("re-enabled upstream namespace = %q, want collaboration-optimize", namespace)
 			}
-			assertCodexSpawnAgentClientNamespace(t, fifthClientPayload)
+			assertCodexSpawnAgentClientNamespace(t, reenabledClientPayload)
 
-			sixthRequest := []byte(`{"model":"gpt-5.4","previous_response_id":"resp_5","input":[{"type":"function_call_output","call_id":"call_5","output":"done"}]}`)
-			sixthClientPayload := execute(sixthRequest)
-			sixthUpstreamPayload := <-capturedPayload
-			if strings.Contains(string(sixthUpstreamPayload), "collaboration") || strings.Contains(string(sixthUpstreamPayload), "spawn_agent") {
-				t.Fatalf("re-enabled incremental upstream request unexpectedly contains collaboration tools: %s", sixthUpstreamPayload)
+			finalRequest := []byte(`{"model":"gpt-5.4","previous_response_id":"resp_7","input":[{"type":"function_call_output","call_id":"call_7","output":"done"}]}`)
+			finalClientPayload := execute(finalRequest)
+			finalUpstreamPayload := <-capturedPayload
+			if strings.Contains(string(finalUpstreamPayload), "collaboration") || strings.Contains(string(finalUpstreamPayload), "spawn_agent") {
+				t.Fatalf("final incremental upstream request unexpectedly contains collaboration tools: %s", finalUpstreamPayload)
 			}
-			assertCodexSpawnAgentClientNamespace(t, sixthClientPayload)
+			assertCodexSpawnAgentClientNamespace(t, finalClientPayload)
 
 			if got := connectionCount.Load(); got != 1 {
 				t.Fatalf("upstream websocket connections = %d, want 1", got)
 			}
 		})
+	}
+}
+
+func TestCodexWebsocketSessionBoundsMultiAgentV2LineageState(t *testing.T) {
+	conn := &websocket.Conn{}
+	sess := &codexWebsocketSession{conn: conn}
+
+	for index := 0; index < codexMultiAgentV2LineageMaxEntries+2; index++ {
+		sess.recordMultiAgentV2Lineage(conn, fmt.Sprintf("resp_%d", index), index%2 == 0)
+	}
+
+	sess.connMu.Lock()
+	lineageCount := len(sess.multiAgentV2Lineages)
+	orderCount := len(sess.multiAgentV2LineageOrder)
+	_, retainedOldest := sess.multiAgentV2Lineages["resp_0"]
+	_, retainedNewest := sess.multiAgentV2Lineages[fmt.Sprintf("resp_%d", codexMultiAgentV2LineageMaxEntries+1)]
+	sess.connMu.Unlock()
+	if lineageCount != codexMultiAgentV2LineageMaxEntries || orderCount != codexMultiAgentV2LineageMaxEntries {
+		t.Fatalf("lineage state sizes = map:%d order:%d, want %d", lineageCount, orderCount, codexMultiAgentV2LineageMaxEntries)
+	}
+	if retainedOldest {
+		t.Fatal("oldest lineage was not evicted")
+	}
+	if !retainedNewest {
+		t.Fatal("newest lineage was evicted")
+	}
+	if sess.multiAgentV2OptimizedForRequest(&websocket.Conn{}, fmt.Sprintf("resp_%d", codexMultiAgentV2LineageMaxEntries), false, false) {
+		t.Fatal("lineage state leaked to a different connection")
+	}
+
+	sess.detachConnection(conn, nil)
+	sess.connMu.Lock()
+	defer sess.connMu.Unlock()
+	if len(sess.multiAgentV2Lineages) != 0 || len(sess.multiAgentV2LineageOrder) != 0 {
+		t.Fatalf("lineage state survived connection detach: map=%d order=%d", len(sess.multiAgentV2Lineages), len(sess.multiAgentV2LineageOrder))
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_spawn_agent_test.go
+++ b/internal/runtime/executor/codex_websockets_spawn_agent_test.go
@@ -176,38 +176,40 @@ func TestCodexWebsocketsExecutorRestoresMultiAgentV2NamespaceAcrossIncrementalTu
 	}
 }
 
-func TestCodexWebsocketSessionBoundsMultiAgentV2LineageState(t *testing.T) {
+func TestCodexWebsocketSessionPreservesOptimizedMultiAgentV2Lineages(t *testing.T) {
 	conn := &websocket.Conn{}
 	sess := &codexWebsocketSession{conn: conn}
 
-	for index := 0; index < codexMultiAgentV2LineageMaxEntries+2; index++ {
-		sess.recordMultiAgentV2Lineage(conn, fmt.Sprintf("resp_%d", index), index%2 == 0)
+	sess.recordMultiAgentV2Lineage(conn, "resp_optimized_old", true)
+	for index := 0; index < 512; index++ {
+		sess.recordMultiAgentV2Lineage(conn, fmt.Sprintf("resp_unoptimized_%d", index), false)
 	}
+	sess.recordMultiAgentV2Lineage(conn, "resp_optimized_new", true)
 
 	sess.connMu.Lock()
 	lineageCount := len(sess.multiAgentV2Lineages)
-	orderCount := len(sess.multiAgentV2LineageOrder)
-	_, retainedOldest := sess.multiAgentV2Lineages["resp_0"]
-	_, retainedNewest := sess.multiAgentV2Lineages[fmt.Sprintf("resp_%d", codexMultiAgentV2LineageMaxEntries+1)]
 	sess.connMu.Unlock()
-	if lineageCount != codexMultiAgentV2LineageMaxEntries || orderCount != codexMultiAgentV2LineageMaxEntries {
-		t.Fatalf("lineage state sizes = map:%d order:%d, want %d", lineageCount, orderCount, codexMultiAgentV2LineageMaxEntries)
+	if lineageCount != 2 {
+		t.Fatalf("stored optimized lineage count = %d, want 2", lineageCount)
 	}
-	if retainedOldest {
-		t.Fatal("oldest lineage was not evicted")
+	if !sess.multiAgentV2OptimizedForRequest(conn, "resp_optimized_old", false, false) {
+		t.Fatal("old optimized lineage was not retained")
 	}
-	if !retainedNewest {
-		t.Fatal("newest lineage was evicted")
+	if !sess.multiAgentV2OptimizedForRequest(conn, "resp_optimized_new", false, false) {
+		t.Fatal("new optimized lineage was not retained")
 	}
-	if sess.multiAgentV2OptimizedForRequest(&websocket.Conn{}, fmt.Sprintf("resp_%d", codexMultiAgentV2LineageMaxEntries), false, false) {
+	if sess.multiAgentV2OptimizedForRequest(conn, "resp_unoptimized_511", false, false) {
+		t.Fatal("unoptimized lineage was recorded as optimized")
+	}
+	if sess.multiAgentV2OptimizedForRequest(&websocket.Conn{}, "resp_optimized_old", false, false) {
 		t.Fatal("lineage state leaked to a different connection")
 	}
 
 	sess.detachConnection(conn, nil)
 	sess.connMu.Lock()
 	defer sess.connMu.Unlock()
-	if len(sess.multiAgentV2Lineages) != 0 || len(sess.multiAgentV2LineageOrder) != 0 {
-		t.Fatalf("lineage state survived connection detach: map=%d order=%d", len(sess.multiAgentV2Lineages), len(sess.multiAgentV2LineageOrder))
+	if len(sess.multiAgentV2Lineages) != 0 {
+		t.Fatalf("lineage state survived connection detach: map=%d", len(sess.multiAgentV2Lineages))
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -184,7 +184,8 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	if sess != nil {
 		readCh = sess.activate(conn)
 	}
-	restoreMultiAgentV2 := !multiAgentV2Conflict && (optimizeMultiAgentV2 || sess.isMultiAgentV2Optimized(conn))
+	previousResponseID := strings.TrimSpace(gjson.GetBytes(wsReqBody, "previous_response_id").String())
+	restoreMultiAgentV2 := sess.multiAgentV2OptimizedForRequest(conn, previousResponseID, optimizeMultiAgentV2, multiAgentV2Conflict)
 
 	if errSend := writeCodexWebsocketMessage(sess, conn, wsReqBody); errSend != nil {
 		errSend = mapCodexWebsocketWriteError(sess, conn, errSend)
@@ -225,7 +226,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				return nil, errBind
 			}
 			readCh = sess.activate(conn)
-			restoreMultiAgentV2 = !multiAgentV2Conflict && (optimizeMultiAgentV2 || sess.isMultiAgentV2Optimized(conn))
+			restoreMultiAgentV2 = sess.multiAgentV2OptimizedForRequest(conn, previousResponseID, optimizeMultiAgentV2, multiAgentV2Conflict)
 			wsReqBodyRetry := buildCodexWebsocketRequestBody(upstreamBody)
 			helps.RecordAPIWebsocketRequest(ctx, e.cfg, helps.UpstreamRequestLog{
 				URL:       wsURL,
@@ -256,10 +257,6 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			}
 			return nil, errSend
 		}
-	}
-
-	if optimizeMultiAgentV2 || multiAgentV2Conflict {
-		sess.setMultiAgentV2Optimized(conn, optimizeMultiAgentV2 && !multiAgentV2Conflict)
 	}
 
 	out := make(chan cliproxyexecutor.StreamChunk)
@@ -392,6 +389,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			if eventType == "response.completed" || eventType == "response.done" {
 				completedPayload = normalizeCodexWebsocketCompletion(completedPayload)
 				completedPayload = patchCodexCompletedOutput(completedPayload, outputItemsByIndex, outputItemsFallback)
+				sess.recordMultiAgentV2Lineage(conn, gjson.GetBytes(completedPayload, "response.id").String(), restoreMultiAgentV2)
 				cacheCodexReasoningReplayFromCompleted(replayScope, completedPayload)
 				if detail, ok := helps.ParseCodexUsage(completedPayload); ok {
 					reporter.Publish(ctx, detail)


### PR DESCRIPTION
## Summary

- track Codex Multi-Agent v2 namespace restoration by `previous_response_id` lineage instead of one connection-wide flag;
- preserve independent proxy-owned and user-owned branches on the same upstream WebSocket;
- store only optimized response IDs and clear the set whenever the physical connection is detached, replaced, invalidated, or closed.

This is a follow-up to #4919 and the partial fix already merged in `133047de`.

## Why the current `dev` fix is incomplete

`133047de` correctly clears the connection-wide optimization marker when a request explicitly owns the `collaboration-optimize` namespace. However, clearing that single marker loses the state of every earlier optimized branch on the same connection.

If the client later continues an earlier optimized `previous_response_id`, the upstream response namespace is no longer restored and `collaboration-optimize` leaks to Codex.

The finalized branch-back test is RED on current `dev` at `f43aad76` for both `Execute` and `ExecuteStream`, and GREEN with this PR.

## State model

Each completed optimized response records its response ID. A definition-free continuation resolves its namespace mode from its own `previous_response_id`; explicit optimization returns proxy-owned mode, while an explicit namespace conflict remains user-owned.

Only optimized IDs are stored. Unoptimized responses require no entry, so 512 intervening unoptimized responses leave only the two optimized IDs used by the regression test.

State remains scoped to one physical upstream connection and is cleared on connection teardown/replacement/invalidation and target/account changes. This matches the current Codex executor path, which normalizes upstream requests to `store:false`; OpenAI documents that uncached `store:false` response IDs have no persisted fallback after reconnect: https://developers.openai.com/api/docs/guides/websocket-mode#reconnect-and-recover

## TDD regression coverage

The integration test runs eight turns over one physical upstream WebSocket for both execution paths:

1. proxy-owned tools enable optimization;
2. an incremental continuation restores `collaboration`;
3. a user-owned namespace conflict remains untouched;
4. its continuation remains user-owned;
5. a branch back to the earlier optimized response restores `collaboration`;
6. a branch back to the conflict response remains `collaboration-optimize`;
7. proxy-owned tools enable optimization again;
8. the final continuation restores `collaboration`.

The branch-back assertion fails on current `dev` before these changes. A separate unit test verifies old/new optimized lineage retention, omission of 512 unoptimized responses, physical-connection isolation, and detach cleanup.

## Compatibility

Request and response wire formats are unchanged. The change is limited to Codex Multi-Agent v2 response restoration. Connections without this optimization, other providers, explicit user-owned `collaboration-optimize` namespaces, reconnects, and account failover retain their existing behavior.

## Verification

- focused regression suite, `-count=20`;
- focused suite under `-race`, `-count=3`;
- `go vet ./internal/runtime/executor`;
- `go test ./...`;
- `go test -race ./...`;
- `go build -o <temporary-output> ./cmd/server`;
- `git diff --check`.
