### PR TITLE
perf(openai): detach websocket tool cache from transcripts

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -246,7 +247,7 @@ func (t *responsesWebsocketToolCacheTurn) recordRequest(payload []byte) {
 	if t == nil || len(payload) == 0 {
 		return
 	}
-	input := gjson.GetBytes(payload, "input")
+	input := util.GetGJSONBytesNoCopy(payload, "input")
 	if !input.Exists() || !input.IsArray() {
 		return
 	}
@@ -259,9 +260,9 @@ func (t *responsesWebsocketToolCacheTurn) recordResponse(payload []byte) {
 	if t == nil || len(payload) == 0 {
 		return
 	}
-	switch strings.TrimSpace(gjson.GetBytes(payload, "type").String()) {
+	switch strings.TrimSpace(util.GetGJSONBytesNoCopy(payload, "type").String()) {
 	case "response.completed":
-		output := gjson.GetBytes(payload, "response.output")
+		output := util.GetGJSONBytesNoCopy(payload, "response.output")
 		if !output.Exists() || !output.IsArray() {
 			return
 		}
@@ -271,7 +272,7 @@ func (t *responsesWebsocketToolCacheTurn) recordResponse(payload []byte) {
 			}
 		}
 	case "response.output_item.added", "response.output_item.done":
-		item := gjson.GetBytes(payload, "item")
+		item := util.GetGJSONBytesNoCopy(payload, "item")
 		if isCompleteResponsesWebsocketToolCall(item) {
 			t.recordItem(item)
 		}
@@ -286,6 +287,7 @@ func (t *responsesWebsocketToolCacheTurn) recordItem(item gjson.Result) {
 	if callID == "" || strings.TrimSpace(item.Raw) == "" {
 		return
 	}
+	callID = strings.Clone(callID)
 	raw := append(json.RawMessage(nil), item.Raw...)
 	switch {
 	case isResponsesToolCallOutputType(item.Get("type").String()):

--- a/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair_memory_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair_memory_test.go
@@ -1,0 +1,94 @@
+package openai
+
+import (
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/tidwall/gjson"
+)
+
+const responsesWebsocketLargeTranscriptSize = 8 << 20
+
+var responsesWebsocketToolCacheBenchmarkSink *responsesWebsocketToolCacheTurn
+
+func TestResponsesWebsocketToolCacheTurnDetachesCallIDFromInput(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		item      string
+		storedIDs func(*responsesWebsocketToolCacheTurn) []string
+	}{
+		{
+			name: "function call",
+			item: `{"type":"function_call","call_id":"call-large-transcript","name":"lookup","arguments":"{}"}`,
+			storedIDs: func(turn *responsesWebsocketToolCacheTurn) []string {
+				return turn.callOrder
+			},
+		},
+		{
+			name: "function call output",
+			item: `{"type":"function_call_output","call_id":"call-large-transcript","output":"done"}`,
+			storedIDs: func(turn *responsesWebsocketToolCacheTurn) []string {
+				return turn.outputOrder
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := []byte(`{"input":[{"type":"message","role":"user","content":"` + strings.Repeat("x", responsesWebsocketLargeTranscriptSize) + `"},` + tt.item + `]}`)
+			input := gjson.GetBytes(payload, "input")
+			items := input.Array()
+			if len(items) != 2 {
+				t.Fatalf("input item count = %d, want 2", len(items))
+			}
+
+			turn := newResponsesWebsocketToolCacheTurn("large-transcript-session")
+			turn.recordItem(items[1])
+			storedIDs := tt.storedIDs(turn)
+			if len(storedIDs) != 1 {
+				t.Fatalf("stored call IDs = %d, want 1", len(storedIDs))
+			}
+			if stringAliases(storedIDs[0], input.Raw) {
+				t.Fatal("stored call_id retains the complete parsed input allocation")
+			}
+		})
+	}
+}
+
+func TestResponsesWebsocketToolCacheTurnOwnsRecordedDataAfterRequestReturns(t *testing.T) {
+	payload := []byte(`{"input":[{"type":"message","role":"user","content":"context"},{"type":"function_call_output","call_id":"call-owned","output":"done"}]}`)
+	turn := newResponsesWebsocketToolCacheTurn("owned-data-session")
+	turn.recordRequest(payload)
+
+	for index := range payload {
+		payload[index] = 'x'
+	}
+
+	if len(turn.outputOrder) != 1 || turn.outputOrder[0] != "call-owned" {
+		t.Fatalf("stored call IDs = %v, want [call-owned]", turn.outputOrder)
+	}
+	stored := turn.outputs["call-owned"]
+	if got := gjson.GetBytes(stored, "output").String(); got != "done" {
+		t.Fatalf("stored output = %q, want done; item = %s", got, stored)
+	}
+}
+
+func BenchmarkResponsesWebsocketToolCacheTurnRecordLargeRequest(b *testing.B) {
+	payload := []byte(`{"input":[{"type":"message","role":"user","content":"` + strings.Repeat("x", responsesWebsocketLargeTranscriptSize) + `"},{"type":"function_call_output","call_id":"call-large-transcript","output":"done"}]}`)
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		turn := newResponsesWebsocketToolCacheTurn("large-transcript-session")
+		turn.recordRequest(payload)
+		responsesWebsocketToolCacheBenchmarkSink = turn
+	}
+}
+
+func stringAliases(value string, backing string) bool {
+	if value == "" || backing == "" {
+		return false
+	}
+	valueStart := uintptr(unsafe.Pointer(unsafe.StringData(value)))
+	backingStart := uintptr(unsafe.Pointer(unsafe.StringData(backing)))
+	return valueStart >= backingStart && valueStart < backingStart+uintptr(len(backing))
+}


### PR DESCRIPTION
## Summary

- detach cached Responses WebSocket `call_id` values from the parsed transcript backing allocation;
- scan request and response payloads through the repository's no-copy GJSON helper;
- keep independent copies of every value that survives the recording call;
- add a deterministic backing-storage regression test, a caller-buffer ownership test, and an 8 MiB allocation benchmark.

This addresses the live-heap retention mechanism reported in #4913. The separate full-transcript reconstruction churn from that issue is intentionally out of scope.

## Root cause

`gjson.GetBytes(payload, "input")` allocates a string copy of the complete input array. Each item's `call_id` can be a substring of that allocation. `recordItem` copied `item.Raw`, but stored the short `call_id` directly as a map key and in an ordering slice, keeping the full parsed input allocation reachable for the turn lifetime.

The recorder now reads from the immutable caller buffer without copying the full JSON subtree, then explicitly clones the short identifier and the raw tool item before either can escape the call.

## TDD regression

The regression creates an 8 MiB Responses input containing a large message and a small tool item. It records both `function_call` and `function_call_output` cases and inspects backing-storage ownership directly. On current `dev`, both cases fail because the stored ID points inside the complete parsed `input` allocation.

A second test calls `recordRequest`, overwrites the caller's payload after the function returns, and verifies that both the stored ID and raw tool item remain intact. This guards the lifetime contract introduced by the no-copy scan.

## Allocation result

`BenchmarkResponsesWebsocketToolCacheTurnRecordLargeRequest`, Apple M5 Pro, 8 MiB payload, `-benchtime=5x`:

| | Before | After |
| --- | ---: | ---: |
| bytes/op | 8,397,702 | 904 |
| allocs/op | 9 | 9 |

The payload-size allocation is removed; the remaining allocations are the turn maps/slices, detached identifier, and copied small tool item.

## Compatibility

Cache keys, eviction, TTL, commit behavior, and stored JSON bytes are unchanged. The no-copy results do not escape the recording methods, and the tests prove that retained data does not alias the caller buffer. This is inside the OpenAI Responses WebSocket handler and does not alter provider translation or request/response wire formats for Codex, Claude, Kimi, or Antigravity.

## Verification

- focused regression suite, `-count=20`
- focused regression suite under `-race`, `-count=3`
- 8 MiB benchmark with `-benchmem`
- `go vet ./sdk/api/handlers/openai`
- `go test ./...`
- `go build -o test-output ./cmd/server`
- `git diff --check`
