### PR TITLE
perf(openai): bound websocket transcript reconstruction

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_websocket_prewarm.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_prewarm.go
@@ -1,7 +1,6 @@
 package openai
 
 import (
-	"encoding/json"
 	"strings"
 	"time"
 
@@ -98,31 +97,46 @@ func syntheticResponsesWebsocketPrewarmPayloads(requestJSON []byte) ([][]byte, e
 	return [][]byte{createdPayload, completedPayload}, nil
 }
 
-func mergeJSONArrayRaw(existingRaw, appendRaw string) (string, error) {
-	existingRaw = strings.TrimSpace(existingRaw)
-	appendRaw = strings.TrimSpace(appendRaw)
-	if existingRaw == "" {
-		existingRaw = "[]"
+// mergeJSONArraysRaw validates all inputs and writes their items into one
+// result allocation. The returned index identifies the invalid input, if any.
+func mergeJSONArraysRaw(rawArrays ...string) (string, int, error) {
+	arrays := make([][]gjson.Result, 0, len(rawArrays))
+	mergedLen := 2
+	itemCount := 0
+	for _, rawArray := range rawArrays {
+		rawArray = strings.TrimSpace(rawArray)
+		if rawArray == "" {
+			rawArray = "[]"
+		}
+		items, errItems := parseJSONArrayResultsNoCopy(rawArray)
+		if errItems != nil {
+			return "", len(arrays), errItems
+		}
+		arrays = append(arrays, items)
+		for _, item := range items {
+			mergedLen += len(item.Raw)
+			itemCount++
+		}
 	}
-	if appendRaw == "" {
-		appendRaw = "[]"
+	if itemCount > 1 {
+		mergedLen += itemCount - 1
 	}
 
-	var existing []json.RawMessage
-	if err := json.Unmarshal([]byte(existingRaw), &existing); err != nil {
-		return "", err
+	var merged strings.Builder
+	merged.Grow(mergedLen)
+	merged.WriteByte('[')
+	wroteItem := false
+	for _, items := range arrays {
+		for _, item := range items {
+			if wroteItem {
+				merged.WriteByte(',')
+			}
+			merged.WriteString(item.Raw)
+			wroteItem = true
+		}
 	}
-	var appendItems []json.RawMessage
-	if err := json.Unmarshal([]byte(appendRaw), &appendItems); err != nil {
-		return "", err
-	}
-
-	merged := append(existing, appendItems...)
-	out, err := json.Marshal(merged)
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
+	merged.WriteByte(']')
+	return merged.String(), -1, nil
 }
 
 // inputContainsFullTranscript returns true when the input array carries compact

--- a/sdk/api/handlers/openai/openai_responses_websocket_requests.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_requests.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -139,21 +140,18 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 			appendInputRaw = inputWithoutCompactionItems(nextInput)
 		}
 
-		existingInput := gjson.GetBytes(lastRequest, "input")
+		existingInput := util.GetGJSONBytesNoCopy(lastRequest, "input")
 		var errMerge error
-		mergedInput, errMerge = mergeJSONArrayRaw(existingInput.Raw, normalizeJSONArrayRaw(lastResponseOutput))
+		var invalidPart int
+		mergedInput, invalidPart, errMerge = mergeJSONArraysRaw(existingInput.Raw, normalizeJSONArrayRaw(lastResponseOutput), appendInputRaw)
 		if errMerge != nil {
-			return nil, lastRequest, &interfaces.ErrorMessage{
-				StatusCode: http.StatusBadRequest,
-				Error:      fmt.Errorf("invalid previous response output: %w", errMerge),
+			message := "invalid previous response output"
+			if invalidPart == 2 {
+				message = "invalid request input"
 			}
-		}
-
-		mergedInput, errMerge = mergeJSONArrayRaw(mergedInput, appendInputRaw)
-		if errMerge != nil {
 			return nil, lastRequest, &interfaces.ErrorMessage{
 				StatusCode: http.StatusBadRequest,
-				Error:      fmt.Errorf("invalid request input: %w", errMerge),
+				Error:      fmt.Errorf("%s: %w", message, errMerge),
 			}
 		}
 	}
@@ -171,14 +169,6 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 		normalized = bytes.Clone(rawJSON)
 	}
 	normalized, _ = sjson.DeleteBytes(normalized, "previous_response_id")
-	var errSet error
-	normalized, errSet = sjson.SetRawBytes(normalized, "input", []byte(mergedInput))
-	if errSet != nil {
-		return nil, lastRequest, &interfaces.ErrorMessage{
-			StatusCode: http.StatusBadRequest,
-			Error:      fmt.Errorf("failed to merge websocket input: %w", errSet),
-		}
-	}
 	if !gjson.GetBytes(normalized, "model").Exists() {
 		modelName := strings.TrimSpace(gjson.GetBytes(lastRequest, "model").String())
 		if modelName != "" {
@@ -192,6 +182,16 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 		}
 	}
 	normalized, _ = sjson.SetBytes(normalized, "stream", true)
+	// Install the merged transcript last. Every later sjson mutation would copy
+	// the complete conversation again as it grows across websocket turns.
+	var errSet error
+	normalized, errSet = sjson.SetRawBytes(normalized, "input", []byte(mergedInput))
+	if errSet != nil {
+		return nil, lastRequest, &interfaces.ErrorMessage{
+			StatusCode: http.StatusBadRequest,
+			Error:      fmt.Errorf("failed to merge websocket input: %w", errSet),
+		}
+	}
 	return normalized, bytes.Clone(normalized), nil
 }
 
@@ -334,6 +334,31 @@ func dedupeFunctionCallsByCallID(rawArray string) (string, error) {
 	if rawArray == "" {
 		return "[]", nil
 	}
+	itemsNoCopy, errItems := parseJSONArrayResultsNoCopy(rawArray)
+	if errItems != nil {
+		return "", errItems
+	}
+	seenCallIDsNoCopy := make(map[string]struct{}, len(itemsNoCopy))
+	for _, item := range itemsNoCopy {
+		itemType := strings.TrimSpace(item.Get("type").String())
+		if !isResponsesToolCallType(itemType) {
+			continue
+		}
+		callID := strings.TrimSpace(item.Get("call_id").String())
+		if callID == "" {
+			continue
+		}
+		if _, ok := seenCallIDsNoCopy[callID]; ok {
+			// Preserve the established encoding/json output for the uncommon
+			// duplicate path. The normal no-duplicate path returns without a copy.
+			return dedupeFunctionCallsByCallIDCopying(rawArray)
+		}
+		seenCallIDsNoCopy[callID] = struct{}{}
+	}
+	return rawArray, nil
+}
+
+func dedupeFunctionCallsByCallIDCopying(rawArray string) (string, error) {
 	var items []json.RawMessage
 	if errUnmarshal := json.Unmarshal([]byte(rawArray), &items); errUnmarshal != nil {
 		return "", errUnmarshal
@@ -365,6 +390,26 @@ func dedupeFunctionCallsByCallID(rawArray string) (string, error) {
 	return string(out), nil
 }
 
+func parseJSONArrayResultsNoCopy(rawArray string) ([]gjson.Result, error) {
+	parsed := gjson.Parse(rawArray)
+	if gjson.Valid(rawArray) {
+		if parsed.IsArray() {
+			return parsed.Array(), nil
+		}
+		if parsed.Type == gjson.Null {
+			return nil, nil
+		}
+	}
+
+	// Preserve encoding/json's validation and type errors for malformed or
+	// non-array payloads. Valid arrays take the allocation-free path above.
+	var items []json.RawMessage
+	if errUnmarshal := json.Unmarshal([]byte(rawArray), &items); errUnmarshal != nil {
+		return nil, errUnmarshal
+	}
+	return nil, nil
+}
+
 func dedupeResponsesWebsocketInputItemsByID(payload []byte) []byte {
 	input := gjson.GetBytes(payload, "input")
 	if !input.Exists() || !input.IsArray() {
@@ -386,6 +431,27 @@ func dedupeInputItemsByID(rawArray string) (string, error) {
 	if rawArray == "" {
 		return "[]", nil
 	}
+	itemsNoCopy, errItems := parseJSONArrayResultsNoCopy(rawArray)
+	if errItems != nil {
+		return "", errItems
+	}
+	seenItemIDs := make(map[string]struct{}, len(itemsNoCopy))
+	hasDuplicateItemID := false
+	for _, item := range itemsNoCopy {
+		itemID := strings.TrimSpace(item.Get("id").String())
+		if itemID == "" {
+			continue
+		}
+		if _, ok := seenItemIDs[itemID]; ok {
+			hasDuplicateItemID = true
+			break
+		}
+		seenItemIDs[itemID] = struct{}{}
+	}
+	if !hasDuplicateItemID {
+		return rawArray, nil
+	}
+
 	var items []json.RawMessage
 	if errUnmarshal := json.Unmarshal([]byte(rawArray), &items); errUnmarshal != nil {
 		return "", errUnmarshal

--- a/sdk/api/handlers/openai/openai_responses_websocket_requests_memory_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_requests_memory_test.go
@@ -1,0 +1,136 @@
+package openai
+
+import (
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/tidwall/gjson"
+)
+
+const responsesWebsocketLargeRequestTranscriptSize = 8 << 20
+
+var responsesWebsocketNormalizedRequestBenchmarkSink []byte
+
+func TestDedupeFunctionCallsByCallIDReusesInputWithoutDuplicates(t *testing.T) {
+	raw := `[{"type":"message","id":"msg-1","role":"user","content":"hello"},{"type":"function_call","id":"fc-1","call_id":"call-1","name":"lookup","arguments":"{}"}]`
+	deduped, errDedupe := dedupeFunctionCallsByCallID(raw)
+	if errDedupe != nil {
+		t.Fatalf("dedupeFunctionCallsByCallID() error = %v", errDedupe)
+	}
+	if deduped != raw {
+		t.Fatalf("deduped input changed without duplicates:\n got: %s\nwant: %s", deduped, raw)
+	}
+	if unsafe.StringData(deduped) != unsafe.StringData(raw) {
+		t.Fatal("dedupeFunctionCallsByCallID copied an unchanged transcript")
+	}
+}
+
+func TestDedupeInputItemsByIDReusesInputWithoutDuplicates(t *testing.T) {
+	raw := `[{"type":"message","id":"msg-1","role":"user","content":"hello"},{"type":"function_call","id":"fc-1","call_id":"call-1","name":"lookup","arguments":"{}"},{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"done"}]`
+	deduped, errDedupe := dedupeInputItemsByID(raw)
+	if errDedupe != nil {
+		t.Fatalf("dedupeInputItemsByID() error = %v", errDedupe)
+	}
+	if deduped != raw {
+		t.Fatalf("deduped input changed without duplicates:\n got: %s\nwant: %s", deduped, raw)
+	}
+	if unsafe.StringData(deduped) != unsafe.StringData(raw) {
+		t.Fatal("dedupeInputItemsByID copied an unchanged transcript")
+	}
+}
+
+func TestDedupeFunctionCallsByCallIDKeepsFirstDuplicate(t *testing.T) {
+	raw := `[{"type":"function_call","id":"fc-first","call_id":"call-1","name":"first","arguments":"{}"},{"type":"message","id":"msg-1","role":"assistant","content":"working"},{"type":"function_call","id":"fc-second","call_id":"call-1","name":"second","arguments":"{}"},{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"done"}]`
+	deduped, errDedupe := dedupeFunctionCallsByCallID(raw)
+	if errDedupe != nil {
+		t.Fatalf("dedupeFunctionCallsByCallID() error = %v", errDedupe)
+	}
+	items := gjson.Parse(deduped).Array()
+	if len(items) != 3 {
+		t.Fatalf("deduped item count = %d, want 3: %s", len(items), deduped)
+	}
+	if got := items[0].Get("id").String(); got != "fc-first" {
+		t.Fatalf("retained function call = %q, want fc-first", got)
+	}
+	if got := items[1].Get("id").String(); got != "msg-1" {
+		t.Fatalf("middle item = %q, want msg-1", got)
+	}
+	if got := items[2].Get("id").String(); got != "fco-1" {
+		t.Fatalf("output item = %q, want fco-1", got)
+	}
+}
+
+func TestMergeJSONArraysRawPreservesOrderAndValues(t *testing.T) {
+	merged, invalidPart, errMerge := mergeJSONArraysRaw(
+		` [ {"type":"message", "content":"<tag>", "nested":[1,2]} ] `,
+		`null`,
+		`[true,"escaped\nvalue",null,{"id":"last"}]`,
+		"",
+	)
+	if errMerge != nil {
+		t.Fatalf("mergeJSONArraysRaw() error = %v", errMerge)
+	}
+	if invalidPart != -1 {
+		t.Fatalf("invalid part = %d, want -1", invalidPart)
+	}
+	items := gjson.Parse(merged).Array()
+	if len(items) != 5 {
+		t.Fatalf("merged item count = %d, want 5: %s", len(items), merged)
+	}
+	if got := items[0].Get("content").String(); got != "<tag>" {
+		t.Fatalf("first content = %q, want <tag>", got)
+	}
+	if got := items[0].Get("nested.1").Int(); got != 2 {
+		t.Fatalf("nested value = %d, want 2", got)
+	}
+	if !items[1].Bool() || items[2].String() != "escaped\nvalue" || items[3].Type != gjson.Null || items[4].Get("id").String() != "last" {
+		t.Fatalf("merged order or values changed: %s", merged)
+	}
+}
+
+func TestMergeJSONArraysRawReportsInvalidPart(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		parts       []string
+		invalidPart int
+	}{
+		{name: "first part is object", parts: []string{`{"id":"not-array"}`, `[]`, `[]`}, invalidPart: 0},
+		{name: "last part malformed", parts: []string{`[]`, `[]`, `[{"id":`}, invalidPart: 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, invalidPart, errMerge := mergeJSONArraysRaw(tt.parts...)
+			if errMerge == nil {
+				t.Fatal("mergeJSONArraysRaw() error = nil, want validation error")
+			}
+			if invalidPart != tt.invalidPart {
+				t.Fatalf("invalid part = %d, want %d", invalidPart, tt.invalidPart)
+			}
+		})
+	}
+}
+
+func BenchmarkNormalizeResponseSubsequentRequestLargeTranscript(b *testing.B) {
+	lastRequest := []byte(`{"model":"gpt-5.4","instructions":"You are a coding agent.","stream":true,"input":[{"type":"message","id":"msg-large","role":"user","content":"` + strings.Repeat("x", responsesWebsocketLargeRequestTranscriptSize) + `"}]}`)
+	lastResponseOutput := []byte(`[{"type":"message","id":"msg-assistant","role":"assistant","content":[{"type":"output_text","text":"ready"}]},{"type":"function_call","id":"fc-1","call_id":"call-1","name":"lookup","arguments":"{}"}]`)
+	raw := []byte(`{"type":"response.create","input":[{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"done"}]}`)
+
+	normalized, _, errMessage := normalizeResponseSubsequentRequest(raw, lastRequest, lastResponseOutput, "", nil, false, false)
+	if errMessage != nil {
+		b.Fatalf("normalizeResponseSubsequentRequest() error = %v", errMessage.Error)
+	}
+	if !strings.Contains(string(normalized), `"id":"msg-large"`) || !strings.Contains(string(normalized), `"id":"fco-1"`) {
+		b.Fatalf("normalized request lost transcript items")
+	}
+
+	b.SetBytes(int64(len(lastRequest) + len(lastResponseOutput) + len(raw)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		normalized, _, errMessage = normalizeResponseSubsequentRequest(raw, lastRequest, lastResponseOutput, "", nil, false, false)
+		if errMessage != nil {
+			b.Fatalf("normalizeResponseSubsequentRequest() error = %v", errMessage.Error)
+		}
+		responsesWebsocketNormalizedRequestBenchmarkSink = normalized
+	}
+}


### PR DESCRIPTION
## Summary

- merge the previous input, previous response output, and new input into one validated JSON-array allocation instead of two decode/append/encode cycles;
- return unchanged transcripts directly from both dedupe passes when no duplicate exists;
- retain the established encoding/json path for the uncommon duplicate cases;
- apply small root-field mutations before installing the merged `input`, so `sjson` does not copy the complete transcript for `model`, `instructions`, and `stream`;
- use a no-copy view of the retained previous input while building the new owned result.

This addresses the cumulative transcript-reconstruction allocation churn in #4913. The independent live-heap tool-cache retention is handled separately by #4921.

## Allocation result

`BenchmarkNormalizeResponseSubsequentRequestLargeTranscript`, Apple M5 Pro, 8 MiB retained history plus assistant/tool output and a new tool result:

| | `dev` | This PR | Reduction |
| --- | ---: | ---: | ---: |
| time/op | 170.9 ms | 23.1–24.5 ms | 85.7–86.5% |
| bytes/op | 207,145,149 | 33,591,176–33,591,275 | 83.8% |
| allocs/op | 154 | 41–42 | 72.7–73.4% |

The remaining large allocations are intentional ownership boundaries: the merged array, the final request containing it, and the independent `lastRequest` state copy.

## TDD and compatibility coverage

The initial RED tests prove that both no-op dedupe passes allocate a new transcript on current `dev`. They now require the exact input string and backing storage to be reused when no duplicate exists.

Additional tests cover:

- first-occurrence behavior for duplicate tool `call_id` values;
- referenced tool-call selection for duplicate item IDs through the existing regression suite;
- ordered merging across arrays, empty parts, `null`, nested objects, escaped strings, primitives, and raw `<tag>` content;
- malformed/non-array input attribution, preserving whether the old caller reports `invalid previous response output` or `invalid request input`;
- complete non-passthrough WebSocket transcript merging.

The compaction, transcript-replacement, `previous_response_id`, pending tool-call, reasoning-item, and incremental-passthrough branches are unchanged. Duplicate cases still use the previous encoding/json implementation. The final normalized JSON values and item ordering remain the same; only redundant intermediate representations are removed.

This also follows the current [OpenAI GPT-5.6 persisted-reasoning guidance](https://developers.openai.com/api/docs/guides/latest-model): manual history must preserve every response output item, and `store: false`/ZDR callers must replay encrypted reasoning items. The optimized merge treats every array item as opaque validated JSON and writes its raw bytes in order; it does not decode, drop, or rewrite reasoning content.

This code is in the generic Responses WebSocket normalization path, so the full repository suite was used to cover Codex, Claude, Kimi, Antigravity, and all translator packages. No network credentials or live upstream calls are required.

## Verification

- focused semantic and integration tests, `-count=20`
- focused suite under `-race`, `-count=3`
- full `sdk/api/handlers/openai` package
- benchmark with `-benchmem`, `-benchtime=5x`, `-count=3`
- `go vet ./sdk/api/handlers/openai`
- `go test ./...`
- `go build -o test-output ./cmd/server`
- `git diff --check`
