### PR TITLE
test(codex): cover websocket continuation contracts

### DIFF
--- a/internal/runtime/executor/codex_websockets_contract_test.go
+++ b/internal/runtime/executor/codex_websockets_contract_test.go
@@ -17,6 +17,23 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func codexWebsocketContractResponseID(payloads [][]byte) string {
+	for _, payload := range payloads {
+		payload = bytes.TrimSpace(payload)
+		payload = bytes.TrimSpace(bytes.TrimPrefix(payload, []byte("data:")))
+		if responseID := gjson.GetBytes(payload, "id").String(); responseID != "" {
+			return responseID
+		}
+		if eventType := gjson.GetBytes(payload, "type").String(); eventType != "response.completed" && eventType != "response.done" {
+			continue
+		}
+		if responseID := gjson.GetBytes(payload, "response.id").String(); responseID != "" {
+			return responseID
+		}
+	}
+	return ""
+}
+
 func TestCodexWebsocketsExecutorPrewarmChainsOnSameConnection(t *testing.T) {
 	for _, testCase := range []struct {
 		name   string
@@ -83,30 +100,45 @@ func TestCodexWebsocketsExecutorPrewarmChainsOnSameConnection(t *testing.T) {
 					cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
 				},
 			}
-			execute := func(payload string) error {
+			execute := func(payload string) ([][]byte, error) {
 				t.Helper()
 				req := cliproxyexecutor.Request{Model: "gpt-5.6-luna", Payload: []byte(payload)}
 				if !testCase.stream {
-					_, errExecute := exec.Execute(context.Background(), auth, req, opts)
-					return errExecute
+					response, errExecute := exec.Execute(context.Background(), auth, req, opts)
+					if errExecute != nil {
+						return nil, errExecute
+					}
+					return [][]byte{bytes.Clone(response.Payload)}, nil
 				}
 				result, errExecute := exec.ExecuteStream(context.Background(), auth, req, opts)
 				if errExecute != nil {
-					return errExecute
+					return nil, errExecute
 				}
+				var payloads [][]byte
 				for chunk := range result.Chunks {
 					if chunk.Err != nil {
-						return chunk.Err
+						return nil, chunk.Err
 					}
+					payloads = append(payloads, bytes.Clone(chunk.Payload))
 				}
-				return nil
+				return payloads, nil
 			}
 
-			if errExecute := execute(`{"model":"gpt-5.6-luna","store":false,"generate":false,"input":[]}`); errExecute != nil {
+			prewarmPayloads, errExecute := execute(`{"model":"gpt-5.6-luna","store":false,"generate":false,"input":[]}`)
+			if errExecute != nil {
 				t.Fatalf("prewarm request failed: %v", errExecute)
 			}
-			if errExecute := execute(`{"model":"gpt-5.6-luna","store":false,"previous_response_id":"resp-warm","input":[]}`); errExecute != nil {
+			prewarmResponseID := codexWebsocketContractResponseID(prewarmPayloads)
+			if prewarmResponseID != "resp-warm" {
+				t.Fatalf("caller-visible prewarm response ID = %q, want resp-warm; payloads=%q", prewarmResponseID, prewarmPayloads)
+			}
+
+			generatedPayloads, errExecute := execute(fmt.Sprintf(`{"model":"gpt-5.6-luna","store":false,"previous_response_id":%q,"input":[]}`, prewarmResponseID))
+			if errExecute != nil {
 				t.Fatalf("generated request failed: %v", errExecute)
+			}
+			if generatedResponseID := codexWebsocketContractResponseID(generatedPayloads); generatedResponseID != "resp-generated" {
+				t.Fatalf("caller-visible generated response ID = %q, want resp-generated; payloads=%q", generatedResponseID, generatedPayloads)
 			}
 
 			first := <-captured

--- a/internal/runtime/executor/codex_websockets_contract_test.go
+++ b/internal/runtime/executor/codex_websockets_contract_test.go
@@ -1,0 +1,240 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestCodexWebsocketsExecutorPrewarmChainsOnSameConnection(t *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		stream bool
+	}{
+		{name: "execute"},
+		{name: "stream", stream: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+			captured := make(chan []byte, 2)
+			var connections atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				connections.Add(1)
+				conn, errUpgrade := upgrader.Upgrade(w, request, nil)
+				if errUpgrade != nil {
+					t.Errorf("upgrade websocket: %v", errUpgrade)
+					return
+				}
+				defer func() { _ = conn.Close() }()
+
+				for turn := 1; turn <= 2; turn++ {
+					_, payload, errRead := conn.ReadMessage()
+					if errRead != nil {
+						t.Errorf("read websocket request %d: %v", turn, errRead)
+						return
+					}
+					captured <- bytes.Clone(payload)
+
+					responseID := "resp-warm"
+					if turn == 2 {
+						responseID = "resp-generated"
+						itemDone := []byte(`{"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg-generated","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"ok"}]}}`)
+						if errWrite := conn.WriteMessage(websocket.TextMessage, itemDone); errWrite != nil {
+							t.Errorf("write output item: %v", errWrite)
+							return
+						}
+					}
+					completed := []byte(fmt.Sprintf(`{"type":"response.completed","response":{"id":%q,"status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":0,"total_tokens":1}}}`, responseID))
+					if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
+						t.Errorf("write completed response %d: %v", turn, errWrite)
+						return
+					}
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+			sessionID := "codex-prewarm-contract-" + testCase.name
+			t.Cleanup(func() { exec.CloseExecutionSession(sessionID) })
+			auth := &cliproxyauth.Auth{
+				ID:       "codex-prewarm-auth",
+				Provider: "codex",
+				Attributes: map[string]string{
+					"api_key":  "test",
+					"base_url": server.URL,
+				},
+			}
+			opts := cliproxyexecutor.Options{
+				SourceFormat:   sdktranslator.FromString("openai-response"),
+				ResponseFormat: sdktranslator.FromString("openai-response"),
+				Headers:        http.Header{"User-Agent": []string{"codex-contract-test/1.0"}},
+				Metadata: map[string]any{
+					cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+				},
+			}
+			execute := func(payload string) error {
+				t.Helper()
+				req := cliproxyexecutor.Request{Model: "gpt-5.6-luna", Payload: []byte(payload)}
+				if !testCase.stream {
+					_, errExecute := exec.Execute(context.Background(), auth, req, opts)
+					return errExecute
+				}
+				result, errExecute := exec.ExecuteStream(context.Background(), auth, req, opts)
+				if errExecute != nil {
+					return errExecute
+				}
+				for chunk := range result.Chunks {
+					if chunk.Err != nil {
+						return chunk.Err
+					}
+				}
+				return nil
+			}
+
+			if errExecute := execute(`{"model":"gpt-5.6-luna","store":false,"generate":false,"input":[]}`); errExecute != nil {
+				t.Fatalf("prewarm request failed: %v", errExecute)
+			}
+			if errExecute := execute(`{"model":"gpt-5.6-luna","store":false,"previous_response_id":"resp-warm","input":[]}`); errExecute != nil {
+				t.Fatalf("generated request failed: %v", errExecute)
+			}
+
+			first := <-captured
+			second := <-captured
+			if got := gjson.GetBytes(first, "type").String(); got != "response.create" {
+				t.Fatalf("prewarm type = %q, want response.create: %s", got, first)
+			}
+			if !gjson.GetBytes(first, "generate").Exists() || gjson.GetBytes(first, "generate").Bool() {
+				t.Fatalf("prewarm generate was not false: %s", first)
+			}
+			if got := gjson.GetBytes(second, "previous_response_id").String(); got != "resp-warm" {
+				t.Fatalf("follow-up previous_response_id = %q, want resp-warm: %s", got, second)
+			}
+			if input := gjson.GetBytes(second, "input"); !input.IsArray() || len(input.Array()) != 0 {
+				t.Fatalf("follow-up input is not the empty incremental input: %s", second)
+			}
+			if got := connections.Load(); got != 1 {
+				t.Fatalf("upstream websocket connections = %d, want 1", got)
+			}
+		})
+	}
+}
+
+func TestCodexWebsocketsExecutorReconnectsAfterOfficialConnectionLimitError(t *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		stream bool
+	}{
+		{name: "execute"},
+		{name: "stream", stream: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+			captured := make(chan []byte, 2)
+			var connections atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				connection := connections.Add(1)
+				conn, errUpgrade := upgrader.Upgrade(w, request, nil)
+				if errUpgrade != nil {
+					t.Errorf("upgrade websocket: %v", errUpgrade)
+					return
+				}
+				defer func() { _ = conn.Close() }()
+
+				_, payload, errRead := conn.ReadMessage()
+				if errRead != nil {
+					t.Errorf("read websocket request: %v", errRead)
+					return
+				}
+				captured <- bytes.Clone(payload)
+				if connection == 1 {
+					errorPayload := []byte(`{"type":"error","status":400,"error":{"type":"invalid_request_error","code":"websocket_connection_limit_reached","message":"Responses websocket connection limit reached (60 minutes). Create a new websocket connection to continue."}}`)
+					if errWrite := conn.WriteMessage(websocket.TextMessage, errorPayload); errWrite != nil {
+						t.Errorf("write connection-limit error: %v", errWrite)
+					}
+					return
+				}
+				completed := []byte(`{"type":"response.completed","response":{"id":"resp-recovered","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":0,"total_tokens":1}}}`)
+				if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
+					t.Errorf("write recovered response: %v", errWrite)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+			sessionID := "codex-connection-limit-contract-" + testCase.name
+			t.Cleanup(func() { exec.CloseExecutionSession(sessionID) })
+			auth := &cliproxyauth.Auth{
+				ID:       "codex-connection-limit-auth",
+				Provider: "codex",
+				Attributes: map[string]string{
+					"api_key":  "test",
+					"base_url": server.URL,
+				},
+			}
+			opts := cliproxyexecutor.Options{
+				SourceFormat:   sdktranslator.FromString("openai-response"),
+				ResponseFormat: sdktranslator.FromString("openai-response"),
+				Headers:        http.Header{"User-Agent": []string{"codex-contract-test/1.0"}},
+				Metadata: map[string]any{
+					cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+				},
+			}
+			execute := func(payload string) error {
+				t.Helper()
+				req := cliproxyexecutor.Request{Model: "gpt-5.6-luna", Payload: []byte(payload)}
+				if !testCase.stream {
+					_, errExecute := exec.Execute(context.Background(), auth, req, opts)
+					return errExecute
+				}
+				result, errExecute := exec.ExecuteStream(context.Background(), auth, req, opts)
+				if errExecute != nil {
+					return errExecute
+				}
+				for chunk := range result.Chunks {
+					if chunk.Err != nil {
+						return chunk.Err
+					}
+				}
+				return nil
+			}
+
+			firstErr := execute(`{"model":"gpt-5.6-luna","store":false,"previous_response_id":"resp-stale","input":[{"type":"message","id":"msg-incremental","role":"user","content":"continue"}]}`)
+			if firstErr == nil {
+				t.Fatal("connection-limit request error = nil")
+			}
+			withStatus, okStatus := firstErr.(interface{ StatusCode() int })
+			if !okStatus || withStatus.StatusCode() != http.StatusBadRequest {
+				t.Fatalf("connection-limit error = %T %v, want status 400", firstErr, firstErr)
+			}
+			if errExecute := execute(`{"model":"gpt-5.6-luna","store":false,"input":[{"type":"message","id":"msg-full","role":"user","content":"full replay"}]}`); errExecute != nil {
+				t.Fatalf("full replay after reconnect failed: %v", errExecute)
+			}
+
+			first := <-captured
+			second := <-captured
+			if got := gjson.GetBytes(first, "previous_response_id").String(); got != "resp-stale" {
+				t.Fatalf("first previous_response_id = %q, want resp-stale: %s", got, first)
+			}
+			if gjson.GetBytes(second, "previous_response_id").Exists() {
+				t.Fatalf("recovered full request retained previous_response_id: %s", second)
+			}
+			if got := gjson.GetBytes(second, "input.0.id").String(); got != "msg-full" {
+				t.Fatalf("recovered full request input = %q, want msg-full: %s", got, second)
+			}
+			if got := connections.Load(); got != 2 {
+				t.Fatalf("upstream websocket connections = %d, want 2", got)
+			}
+		})
+	}
+}

--- a/sdk/api/handlers/openai/openai_responses_websocket_contract_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_contract_test.go
@@ -1,0 +1,278 @@
+package openai
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	"github.com/tidwall/gjson"
+)
+
+func TestResponsesWebsocketReasoningReplayPreservesCompleteOutputItems(t *testing.T) {
+	const encryptedContent = "gAAAAA-test-encrypted-reasoning-content"
+
+	outputItemsByIndex := make(map[int64][]byte)
+	var outputItemsFallback [][]byte
+	for _, payload := range [][]byte{
+		[]byte(`{"type":"response.output_item.done","output_index":2,"item":{"type":"function_call","id":"fc-1","call_id":"call-1","name":"lookup","arguments":"{\"query\":\"status\"}","caller":"program-1","future_call":{"version":2}}}`),
+		[]byte(`{"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"rs-1","encrypted_content":"` + encryptedContent + `","summary":[{"type":"summary_text","text":"checked the repository"}],"future_reasoning":{"version":2,"flags":["keep","opaque"]}}}`),
+		[]byte(`{"type":"response.output_item.done","output_index":1,"item":{"type":"message","id":"msg-assistant","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"ready","annotations":[]}],"future_message":{"preserve":true}}}`),
+	} {
+		collectResponsesWebsocketOutputItem(payload, outputItemsByIndex, &outputItemsFallback)
+	}
+
+	completedOutput := responseCompletedOutputFromPayload(
+		[]byte(`{"type":"response.completed","response":{"id":"resp-a","output":[]}}`),
+		outputItemsByIndex,
+		outputItemsFallback,
+	)
+	collected := gjson.ParseBytes(completedOutput).Array()
+	if len(collected) != 3 {
+		t.Fatalf("collected output len = %d, want 3: %s", len(collected), completedOutput)
+	}
+	if got := collected[0].Get("encrypted_content").String(); got != encryptedContent {
+		t.Fatalf("collected encrypted_content = %q, want exact ciphertext", got)
+	}
+	if got := collected[0].Get("future_reasoning").Raw; got != `{"version":2,"flags":["keep","opaque"]}` {
+		t.Fatalf("collected future reasoning fields changed: %s", got)
+	}
+	if got := collected[1].Get("phase").String(); got != "final_answer" {
+		t.Fatalf("collected assistant phase = %q, want final_answer", got)
+	}
+	if !collected[1].Get("future_message.preserve").Bool() {
+		t.Fatalf("collected future assistant fields changed: %s", collected[1].Raw)
+	}
+
+	lastRequest := []byte(`{
+		"model":"gpt-5.6-terra",
+		"store":false,
+		"stream":true,
+		"instructions":"Preserve the complete response history.",
+		"input":[{"type":"message","id":"msg-user-1","role":"user","content":[{"type":"input_text","text":"inspect"}]}]
+	}`)
+	raw := []byte(`{
+		"type":"response.create",
+		"previous_response_id":"resp-a",
+		"reasoning":{"effort":"medium","context":"all_turns"},
+		"include":["reasoning.encrypted_content"],
+		"client_metadata":{"contract_test":"reasoning-replay"},
+		"input":[
+			{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"done","future_output":{"preserve":true}},
+			{"type":"message","id":"msg-user-2","role":"user","content":[{"type":"input_text","text":"continue"}]}
+		]
+	}`)
+
+	normalized, _, errMsg := normalizeResponseSubsequentRequest(
+		raw,
+		lastRequest,
+		completedOutput,
+		"resp-a",
+		nil,
+		false,
+		false,
+	)
+	if errMsg != nil {
+		t.Fatalf("normalizeResponseSubsequentRequest() error = %v", errMsg.Error)
+	}
+	if gjson.GetBytes(normalized, "previous_response_id").Exists() {
+		t.Fatalf("full replay retained previous_response_id: %s", normalized)
+	}
+	if got := gjson.GetBytes(normalized, "reasoning.context").String(); got != "all_turns" {
+		t.Fatalf("reasoning.context = %q, want all_turns: %s", got, normalized)
+	}
+	if got := gjson.GetBytes(normalized, "client_metadata.contract_test").String(); got != "reasoning-replay" {
+		t.Fatalf("client_metadata was not preserved: %s", normalized)
+	}
+
+	input := gjson.GetBytes(normalized, "input").Array()
+	wantIDs := []string{"msg-user-1", "rs-1", "msg-assistant", "fc-1", "fco-1", "msg-user-2"}
+	if len(input) != len(wantIDs) {
+		t.Fatalf("replay input len = %d, want %d: %s", len(input), len(wantIDs), normalized)
+	}
+	for index, wantID := range wantIDs {
+		if got := input[index].Get("id").String(); got != wantID {
+			t.Fatalf("replay input[%d].id = %q, want %q: %s", index, got, wantID, normalized)
+		}
+	}
+	if got := input[1].Get("encrypted_content").String(); got != encryptedContent {
+		t.Fatalf("replayed encrypted_content = %q, want exact ciphertext", got)
+	}
+	if got := input[1].Get("future_reasoning").Raw; got != `{"version":2,"flags":["keep","opaque"]}` {
+		t.Fatalf("replayed future reasoning fields changed: %s", got)
+	}
+	if got := input[2].Get("phase").String(); got != "final_answer" {
+		t.Fatalf("replayed assistant phase = %q, want final_answer", got)
+	}
+	if got := input[3].Get("caller").String(); got != "program-1" {
+		t.Fatalf("replayed function caller = %q, want program-1", got)
+	}
+	if !input[4].Get("future_output.preserve").Bool() {
+		t.Fatalf("replayed future tool-output fields changed: %s", input[4].Raw)
+	}
+
+	var decoded map[string]json.RawMessage
+	if errUnmarshal := json.Unmarshal(normalized, &decoded); errUnmarshal != nil {
+		t.Fatalf("normalized replay is invalid JSON: %v", errUnmarshal)
+	}
+}
+
+func TestResponsesWebsocketAuthFailoverPreservesCompleteReasoningReplay(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const (
+		modelName        = "reasoning-auth-failover-model"
+		encryptedContent = "gAAAAA-cross-account-encrypted-reasoning"
+	)
+
+	executor := &websocketPinnedFailoverExecutor{
+		failStatus: http.StatusTooManyRequests,
+		initialResponseChunks: [][]byte{
+			[]byte(`{"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"rs-a","encrypted_content":"` + encryptedContent + `","summary":[{"type":"summary_text","text":"kept"}],"future_reasoning":{"preserve":true}}}`),
+			[]byte(`{"type":"response.output_item.done","output_index":1,"item":{"type":"message","id":"msg-a","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"ready"}],"future_message":{"preserve":true}}}`),
+			[]byte(`{"type":"response.output_item.done","output_index":2,"item":{"type":"function_call","id":"fc-a","call_id":"call-a","name":"lookup","arguments":"{}","caller":"program-a"}}`),
+			[]byte(`{"type":"response.completed","response":{"id":"resp-auth-a-1","status":"completed","output":[]}}`),
+		},
+	}
+	selector := &orderedWebsocketSelector{order: []string{"auth-a", "auth-b"}}
+	manager := coreauth.NewManager(nil, selector, nil)
+	manager.RegisterExecutor(executor)
+	for _, authID := range []string{"auth-a", "auth-b"} {
+		auth := &coreauth.Auth{
+			ID:         authID,
+			Provider:   executor.Identifier(),
+			Status:     coreauth.StatusActive,
+			Attributes: map[string]string{"websockets": "true"},
+		}
+		if _, errRegister := manager.Register(t.Context(), auth); errRegister != nil {
+			t.Fatalf("register %s: %v", authID, errRegister)
+		}
+		registry.GetGlobalRegistry().RegisterClient(authID, auth.Provider, []*registry.ModelInfo{{ID: modelName}})
+		t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(authID) })
+	}
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	handler := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", handler.ResponsesWebsocket)
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+
+	dial := func() *websocket.Conn {
+		t.Helper()
+		conn, _, errDial := websocket.DefaultDialer.Dial(wsURL, nil)
+		if errDial != nil {
+			t.Fatalf("dial responses websocket: %v", errDial)
+		}
+		t.Cleanup(func() { _ = conn.Close() })
+		return conn
+	}
+	readCompleted := func(conn *websocket.Conn) []byte {
+		t.Helper()
+		for {
+			_, payload, errRead := conn.ReadMessage()
+			if errRead != nil {
+				t.Fatalf("read websocket response: %v", errRead)
+			}
+			if gjson.GetBytes(payload, "type").String() == wsEventTypeCompleted {
+				return payload
+			}
+		}
+	}
+
+	conn := dial()
+	firstRequest := fmt.Sprintf(`{"type":"response.create","model":%q,"store":false,"reasoning":{"context":"all_turns"},"include":["reasoning.encrypted_content"],"input":[{"type":"message","id":"msg-user-a","role":"user","content":"inspect"}]}`, modelName)
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(firstRequest)); errWrite != nil {
+		t.Fatalf("write first request: %v", errWrite)
+	}
+	firstCompleted := readCompleted(conn)
+	firstOutput := gjson.GetBytes(firstCompleted, "response.output")
+	if !firstOutput.IsArray() || len(firstOutput.Array()) != 3 {
+		t.Fatalf("reconstructed first output = %s, want three collected items: %s", firstOutput.Raw, firstCompleted)
+	}
+	if got := firstOutput.Get("0.encrypted_content").String(); got != encryptedContent {
+		t.Fatalf("reconstructed encrypted_content = %q, want exact ciphertext", got)
+	}
+	if got := firstOutput.Get("1.phase").String(); got != "final_answer" {
+		t.Fatalf("reconstructed assistant phase = %q, want final_answer", got)
+	}
+
+	incremental := []byte(`{"type":"response.create","previous_response_id":"resp-auth-a-1","input":[{"type":"function_call_output","id":"fco-a","call_id":"call-a","output":"done","future_output":{"preserve":true}},{"type":"message","id":"msg-user-b","role":"user","content":"continue"}]}`)
+	if errWrite := conn.WriteMessage(websocket.TextMessage, incremental); errWrite != nil {
+		t.Fatalf("write failing incremental request: %v", errWrite)
+	}
+	_, _, errReadClose := conn.ReadMessage()
+	var replayClose *websocket.CloseError
+	if !errors.As(errReadClose, &replayClose) || replayClose.Code != websocket.CloseServiceRestart || replayClose.Text != wsHTTPReplayRequiredCloseReason {
+		t.Fatalf("credential failure response = %v, want replay close %d %q", errReadClose, websocket.CloseServiceRestart, wsHTTPReplayRequiredCloseReason)
+	}
+
+	replayConn := dial()
+	fullReplay := fmt.Sprintf(`{
+		"type":"response.create",
+		"model":%q,
+		"store":false,
+		"reasoning":{"effort":"medium","context":"all_turns"},
+		"include":["reasoning.encrypted_content"],
+		"client_metadata":{"contract_test":"auth-failover"},
+		"input":[
+			{"type":"message","id":"msg-user-a","role":"user","content":"inspect"},
+			%s,
+			{"type":"function_call_output","id":"fco-a","call_id":"call-a","output":"done","future_output":{"preserve":true}},
+			{"type":"message","id":"msg-user-b","role":"user","content":"continue"}
+		]
+	}`, modelName, strings.TrimSuffix(strings.TrimPrefix(firstOutput.Raw, "["), "]"))
+	if errWrite := replayConn.WriteMessage(websocket.TextMessage, []byte(fullReplay)); errWrite != nil {
+		t.Fatalf("write full replay: %v", errWrite)
+	}
+	_ = readCompleted(replayConn)
+
+	authBPayloads := executor.Payloads("auth-b")
+	if len(authBPayloads) != 1 {
+		t.Fatalf("auth-b payloads = %d, want 1", len(authBPayloads))
+	}
+	authBPayload := authBPayloads[0]
+	if gjson.GetBytes(authBPayload, "previous_response_id").Exists() {
+		t.Fatalf("auth-b full replay retained previous_response_id: %s", authBPayload)
+	}
+	if got := gjson.GetBytes(authBPayload, "reasoning.context").String(); got != "all_turns" {
+		t.Fatalf("auth-b reasoning.context = %q, want all_turns: %s", got, authBPayload)
+	}
+	if got := gjson.GetBytes(authBPayload, "client_metadata.contract_test").String(); got != "auth-failover" {
+		t.Fatalf("auth-b client_metadata was not preserved: %s", authBPayload)
+	}
+	input := gjson.GetBytes(authBPayload, "input").Array()
+	wantIDs := []string{"msg-user-a", "rs-a", "msg-a", "fc-a", "fco-a", "msg-user-b"}
+	if len(input) != len(wantIDs) {
+		t.Fatalf("auth-b replay input len = %d, want %d: %s", len(input), len(wantIDs), authBPayload)
+	}
+	for index, wantID := range wantIDs {
+		if got := input[index].Get("id").String(); got != wantID {
+			t.Fatalf("auth-b input[%d].id = %q, want %q: %s", index, got, wantID, authBPayload)
+		}
+	}
+	if got := input[1].Get("encrypted_content").String(); got != encryptedContent {
+		t.Fatalf("auth-b encrypted_content = %q, want exact ciphertext", got)
+	}
+	if !input[1].Get("future_reasoning.preserve").Bool() || !input[2].Get("future_message.preserve").Bool() {
+		t.Fatalf("auth-b replay lost future output fields: %s", authBPayload)
+	}
+	if got := input[2].Get("phase").String(); got != "final_answer" {
+		t.Fatalf("auth-b assistant phase = %q, want final_answer", got)
+	}
+	if got := input[3].Get("caller").String(); got != "program-a" {
+		t.Fatalf("auth-b function caller = %q, want program-a", got)
+	}
+	if !input[4].Get("future_output.preserve").Bool() {
+		t.Fatalf("auth-b tool output lost future fields: %s", input[4].Raw)
+	}
+}

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -658,11 +658,12 @@ type websocketAuthCaptureExecutor struct {
 }
 
 type websocketPinnedFailoverExecutor struct {
-	mu         sync.Mutex
-	failStatus int
-	authIDs    []string
-	calls      map[string]int
-	payloads   map[string][][]byte
+	mu                    sync.Mutex
+	failStatus            int
+	authIDs               []string
+	calls                 map[string]int
+	payloads              map[string][][]byte
+	initialResponseChunks [][]byte
 }
 
 type websocketBootstrapFallbackExecutor struct {
@@ -1049,6 +1050,15 @@ func (e *websocketPinnedFailoverExecutor) ExecuteStream(_ context.Context, auth 
 			status: e.failStatus,
 			msg:    fmt.Sprintf(`{"error":{"message":"credential failed","status":%d}}`, e.failStatus),
 		}}
+		close(chunks)
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}
+
+	if authID == "auth-a" && call == 1 && len(e.initialResponseChunks) > 0 {
+		chunks := make(chan coreexecutor.StreamChunk, len(e.initialResponseChunks))
+		for _, payload := range e.initialResponseChunks {
+			chunks <- coreexecutor.StreamChunk{Payload: bytes.Clone(payload)}
+		}
 		close(chunks)
 		return &coreexecutor.StreamResult{Chunks: chunks}, nil
 	}

--- a/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair_memory_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair_memory_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 
@@ -61,6 +62,66 @@ func TestResponsesWebsocketToolCacheTurnOwnsRecordedResponseData(t *testing.T) {
 			}
 			if output := gjson.GetBytes(stored, "output"); output.Exists() && output.String() != "done" {
 				t.Fatalf("stored output = %q, want done; item=%s", output.String(), stored)
+			}
+		})
+	}
+}
+
+func TestResponsesWebsocketToolCacheTurnDoesNotRetainResponseBackingStorage(t *testing.T) {
+	const (
+		paddingSize     = 32 << 20
+		maxRetainedHeap = 8 << 20
+	)
+
+	for _, testCase := range []struct {
+		name   string
+		prefix string
+		suffix string
+	}{
+		{
+			name:   "response completed",
+			prefix: `{"type":"response.completed","response":{"output":[{"type":"message","role":"assistant","content":"`,
+			suffix: `"},{"type":"function_call","call_id":"call-retained","name":"lookup","arguments":"{}"}]}}`,
+		},
+		{
+			name:   "output item added",
+			prefix: `{"type":"response.output_item.added","padding":"`,
+			suffix: `","item":{"type":"function_call","call_id":"call-retained","name":"lookup","arguments":"{}"}}`,
+		},
+		{
+			name:   "output item done",
+			prefix: `{"type":"response.output_item.done","padding":"`,
+			suffix: `","item":{"type":"function_call","call_id":"call-retained","name":"lookup","arguments":"{}"}}`,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			runtime.GC()
+			var before runtime.MemStats
+			runtime.ReadMemStats(&before)
+
+			payload := make([]byte, len(testCase.prefix)+paddingSize+len(testCase.suffix))
+			copy(payload, testCase.prefix)
+			for index := len(testCase.prefix); index < len(testCase.prefix)+paddingSize; index++ {
+				payload[index] = 'x'
+			}
+			copy(payload[len(testCase.prefix)+paddingSize:], testCase.suffix)
+
+			turn := newResponsesWebsocketToolCacheTurn("response-backing-storage-session")
+			turn.recordResponse(payload)
+			payload = nil
+			runtime.GC()
+
+			var after runtime.MemStats
+			runtime.ReadMemStats(&after)
+			stored := turn.calls["call-retained"]
+			if got := gjson.GetBytes(stored, "call_id").String(); got != "call-retained" {
+				t.Fatalf("stored call_id = %q, want call-retained; item=%s", got, stored)
+			}
+			runtime.KeepAlive(turn)
+
+			retainedHeap := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+			if retainedHeap > maxRetainedHeap {
+				t.Fatalf("tool cache turn retained %d bytes after response release, want at most %d", retainedHeap, maxRetainedHeap)
 			}
 		})
 	}

--- a/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair_memory_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair_memory_test.go
@@ -1,0 +1,79 @@
+package openai
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+const responsesWebsocketLargeResponseFrameSize = 8 << 20
+
+var responsesWebsocketResponseToolCacheBenchmarkSink *responsesWebsocketToolCacheTurn
+
+func TestResponsesWebsocketToolCacheTurnOwnsRecordedResponseData(t *testing.T) {
+	for _, testCase := range []struct {
+		name    string
+		payload func(string) []byte
+	}{
+		{
+			name: "response completed",
+			payload: func(padding string) []byte {
+				return []byte(`{"type":"response.completed","response":{"output":[{"type":"message","role":"assistant","content":"` + padding + `"},{"type":"function_call","call_id":"call-owned","name":"lookup","arguments":"{}"}]}}`)
+			},
+		},
+		{
+			name: "output item added",
+			payload: func(padding string) []byte {
+				return []byte(`{"type":"response.output_item.added","padding":"` + padding + `","item":{"type":"function_call","call_id":"call-owned","name":"lookup","arguments":"{}"}}`)
+			},
+		},
+		{
+			name: "output item done",
+			payload: func(padding string) []byte {
+				return []byte(`{"type":"response.output_item.done","padding":"` + padding + `","item":{"type":"function_call","call_id":"call-owned","name":"lookup","arguments":"{}"}}`)
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			payload := testCase.payload(strings.Repeat("x", responsesWebsocketLargeResponseFrameSize))
+			turn := newResponsesWebsocketToolCacheTurn("owned-response-data-session")
+			turn.recordResponse(payload)
+
+			for index := range payload {
+				payload[index] = 'x'
+			}
+
+			var order []string
+			var stored []byte
+			if len(turn.callOrder) > 0 {
+				order = turn.callOrder
+				stored = turn.calls["call-owned"]
+			} else {
+				order = turn.outputOrder
+				stored = turn.outputs["call-owned"]
+			}
+			if len(order) != 1 || order[0] != "call-owned" {
+				t.Fatalf("stored call IDs = %v, want [call-owned]", order)
+			}
+			if got := gjson.GetBytes(stored, "call_id").String(); got != "call-owned" {
+				t.Fatalf("stored call_id = %q, want call-owned; item=%s", got, stored)
+			}
+			if output := gjson.GetBytes(stored, "output"); output.Exists() && output.String() != "done" {
+				t.Fatalf("stored output = %q, want done; item=%s", output.String(), stored)
+			}
+		})
+	}
+}
+
+func BenchmarkResponsesWebsocketToolCacheTurnRecordLargeResponse(b *testing.B) {
+	payload := []byte(`{"type":"response.output_item.done","padding":"` + strings.Repeat("x", responsesWebsocketLargeResponseFrameSize) + `","item":{"type":"function_call","call_id":"call-large-response","name":"lookup","arguments":"{}"}}`)
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		turn := newResponsesWebsocketToolCacheTurn("large-response-session")
+		turn.recordResponse(payload)
+		responsesWebsocketResponseToolCacheBenchmarkSink = turn
+	}
+}


### PR DESCRIPTION
## Summary

- add offline Codex Responses WebSocket contract coverage for successful `generate:false` prewarm and incremental continuation on one physical connection;
- reproduce the documented `websocket_connection_limit_reached` status-400 event and verify recovery on a fresh upstream connection with a full request;
- verify handler-level auth failover preserves complete stateless reasoning history, including `encrypted_content`, assistant `phase`, tool linkage, ordering, and unknown future fields;
- verify response-side tool-cache recording owns the small retained item without retaining or aliasing an 8 MiB response frame.

## Why

The existing suite covers the individual WebSocket, auth-selection, output-collector, and reasoning paths, but did not combine them around the continuation contracts used by current Codex clients. In particular, the ChatGPT Codex event stream can deliver final output through `response.output_item.done` while `response.completed.response.output` is empty. A failover regression must prove that reconstructed output survives a full `store:false` replay without relying on a subscription or live upstream.

The fixtures follow the current OpenAI guidance:

- [Responses WebSocket mode](https://developers.openai.com/api/docs/guides/websocket-mode)
- [GPT-5.6 persisted reasoning and stateless replay](https://developers.openai.com/api/docs/guides/latest-model)

## Coverage

### Prewarm and connection recovery

Both `Execute` and `ExecuteStream` now verify:

- `response.create` with `generate:false` returns a chainable response ID;
- the follow-up carries `previous_response_id` plus empty incremental input on the same connection;
- the official 60-minute connection-limit error shape is classified with status 400;
- a subsequent full request omits the stale response ID and opens a new upstream WebSocket.

### Reasoning-preserving auth failover

The handler integration test uses two fake auth records and a realistic fragmented upstream response. It asserts that the second auth receives the complete ordered replay with exact:

- encrypted reasoning content and summary;
- assistant `phase`;
- function `call_id` and `caller` linkage;
- function output;
- caller-owned `reasoning.context`, `include`, and `client_metadata`;
- unknown nested fields representing forward-compatible response items.

### Response buffer ownership

`response.completed`, `response.output_item.added`, and `response.output_item.done` are exercised with an 8 MiB frame. The caller buffer is overwritten after recording and the retained call ID/item must remain intact. The companion benchmark reports about 792 B/op and 9 allocs/op on Apple M5 Pro; the frame-size allocation is not retained.

## Test environment

All tests use local `httptest` and Gorilla WebSocket servers. They do not read environment credentials, make external requests, or require an OpenAI API key or ChatGPT subscription.

## Verification

- focused suites, `-count=20`
- focused suites under `-race`, `-count=3`
- `go vet ./internal/runtime/executor ./sdk/api/handlers/openai`
- `go test ./...`
- `go build -o test-output ./cmd/server`
- `git diff --check`
