### PR TITLE
feat(codex): synchronize official application fingerprint

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -677,7 +677,7 @@ func main() {
 				// Standalone mode: start an embedded local server and connect TUI client to it.
 				managementasset.StartAutoUpdater(context.Background(), configFilePath)
 				misc.StartAntigravityVersionUpdater(context.Background())
-				startModelCatalogUpdaters(localModel, cfg.Home.Enabled)
+				startModelCatalogUpdaters(localModel, cfg.Home.Enabled, cfg.Codex.DisableFingerprintAutoSync)
 				hook := tui.NewLogHook(2000)
 				hook.SetFormatter(&logging.LogFormatter{})
 				log.AddHook(hook)
@@ -751,7 +751,7 @@ func main() {
 			// Start the main proxy service
 			managementasset.StartAutoUpdater(context.Background(), configFilePath)
 			misc.StartAntigravityVersionUpdater(context.Background())
-			startModelCatalogUpdaters(localModel, cfg.Home.Enabled)
+			startModelCatalogUpdaters(localModel, cfg.Home.Enabled, cfg.Codex.DisableFingerprintAutoSync)
 			cmd.StartServiceWithPluginHost(cfg, configFilePath, password, pluginHost, serverOptions...)
 		}
 	}
@@ -760,15 +760,18 @@ func main() {
 // modelCatalogUpdaterPlan decides which remote model catalogs should refresh.
 // Codex client templates still refresh under Home mode because the model list
 // comes from Home IDs while template metadata stays edge-local.
-func modelCatalogUpdaterPlan(localModel, homeEnabled bool) (startModels, startCodexClient bool) {
+func modelCatalogUpdaterPlan(localModel, homeEnabled, disableFingerprint bool) (startModels, startCodexClient, startFingerprint bool) {
 	if localModel {
-		return false, false
+		return false, false, !disableFingerprint
 	}
-	return !homeEnabled, true
+	return !homeEnabled, true, !disableFingerprint
 }
 
-func startModelCatalogUpdaters(localModel, homeEnabled bool) {
-	startModels, startCodexClient := modelCatalogUpdaterPlan(localModel, homeEnabled)
+func startModelCatalogUpdaters(localModel, homeEnabled, disableFingerprint bool) {
+	startModels, startCodexClient, startFingerprint := modelCatalogUpdaterPlan(localModel, homeEnabled, disableFingerprint)
+	if startFingerprint {
+		registry.StartCodexFingerprintUpdater(context.Background())
+	}
 	if startCodexClient {
 		registry.StartCodexClientModelsUpdater(context.Background())
 	}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -90,11 +90,13 @@ func TestShouldEnableExampleAPIKeySafeMode(t *testing.T) {
 
 func TestModelCatalogUpdaterPlan(t *testing.T) {
 	tests := []struct {
-		name            string
-		localModel      bool
-		homeEnabled     bool
-		wantModels      bool
-		wantCodexClient bool
+		name               string
+		localModel         bool
+		homeEnabled        bool
+		disableFingerprint bool
+		wantModels         bool
+		wantCodexClient    bool
+		wantFingerprint    bool
 	}{
 		{
 			name:            "normal CPA refreshes both catalogs",
@@ -102,6 +104,7 @@ func TestModelCatalogUpdaterPlan(t *testing.T) {
 			homeEnabled:     false,
 			wantModels:      true,
 			wantCodexClient: true,
+			wantFingerprint: true,
 		},
 		{
 			name:            "home mode keeps models.json local and refreshes codex templates",
@@ -109,6 +112,7 @@ func TestModelCatalogUpdaterPlan(t *testing.T) {
 			homeEnabled:     true,
 			wantModels:      false,
 			wantCodexClient: true,
+			wantFingerprint: true,
 		},
 		{
 			name:            "local-model disables both remote catalogs",
@@ -116,6 +120,7 @@ func TestModelCatalogUpdaterPlan(t *testing.T) {
 			homeEnabled:     false,
 			wantModels:      false,
 			wantCodexClient: false,
+			wantFingerprint: true,
 		},
 		{
 			name:            "local-model disables both remote catalogs even under home",
@@ -123,14 +128,24 @@ func TestModelCatalogUpdaterPlan(t *testing.T) {
 			homeEnabled:     true,
 			wantModels:      false,
 			wantCodexClient: false,
+			wantFingerprint: true,
+		},
+		{
+			name:               "fingerprint sync can be disabled independently",
+			disableFingerprint: true,
+			wantModels:         true,
+			wantCodexClient:    true,
+			wantFingerprint:    false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotModels, gotCodex := modelCatalogUpdaterPlan(tt.localModel, tt.homeEnabled)
-			if gotModels != tt.wantModels || gotCodex != tt.wantCodexClient {
-				t.Fatalf("modelCatalogUpdaterPlan(%v, %v) = (%v, %v), want (%v, %v)",
-					tt.localModel, tt.homeEnabled, gotModels, gotCodex, tt.wantModels, tt.wantCodexClient)
+			gotModels, gotCodex, gotFingerprint := modelCatalogUpdaterPlan(tt.localModel, tt.homeEnabled, tt.disableFingerprint)
+			if gotModels != tt.wantModels || gotCodex != tt.wantCodexClient || gotFingerprint != tt.wantFingerprint {
+				t.Fatalf("modelCatalogUpdaterPlan(%v, %v, %v) = (%v, %v, %v), want (%v, %v, %v)",
+					tt.localModel, tt.homeEnabled, tt.disableFingerprint,
+					gotModels, gotCodex, gotFingerprint,
+					tt.wantModels, tt.wantCodexClient, tt.wantFingerprint)
 			}
 		})
 	}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -225,6 +225,9 @@ codex:
   identity-confuse: false
   # Disable forcing the official Codex User-Agent and Originator headers on HTTP/SSE and WebSocket requests.
   disable-codex-cloaking: false
+  # Disable startup and hourly synchronization of the Codex application fingerprint
+  # from the official OpenAI Codex NPM package and source repository.
+  disable-fingerprint-auto-sync: false
   # When true, optimize Codex Desktop, codex-tui, and codex_cli_rs requests for multi-agent v2.
   # This refreshes Codex spawn_agent model details, removes message parameter encryption,
   # normalizes encrypted agent_message content for Codex, and converts agent_message input

--- a/docs/superpowers/plans/2026-07-31-codex-fingerprint-sync.md
+++ b/docs/superpowers/plans/2026-07-31-codex-fingerprint-sync.md
@@ -1,0 +1,280 @@
+# Codex Fingerprint Synchronization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give official ChatGPT OAuth Codex traffic a coherent, automatically refreshed application fingerprint and Chrome uTLS coverage for both HTTP and WebSocket transports while preserving API-key and custom-gateway behavior.
+
+**Architecture:** A registry-owned immutable profile is loaded from an embedded fallback and atomically refreshed from official OpenAI Codex sources. Executor-owned identity assembly projects one request identity into headers and `client_metadata`; the existing HTTP uTLS transport is retained and the official WebSocket path gains an HTTP/1.1 uTLS dialer.
+
+**Tech Stack:** Go 1.26, `net/http`, Gorilla WebSocket, `refraction-networking/utls`, Google UUID, `tidwall/gjson`/`sjson`, embedded JSON, existing CLIProxyAPI registry/config/executor patterns.
+
+---
+
+### Task 1: Immutable Codex Fingerprint Profile
+
+**Files:**
+- Create: `internal/registry/models/codex_fingerprint_profile.json`
+- Create: `internal/registry/codex_fingerprint_profile.go`
+- Create: `internal/registry/codex_fingerprint_profile_test.go`
+
+- [ ] **Step 1: Write failing profile tests**
+
+Cover embedded fallback loading, cloned snapshots, required header/metadata fields, User-Agent expansion, invalid header names, invalid templates, and semantic version downgrade rejection.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `go test ./internal/registry -run 'TestCodexFingerprintProfile' -count=1`
+
+Expected: build failure because the profile API does not exist.
+
+- [ ] **Step 3: Add the embedded profile and minimal validated store**
+
+Implement:
+
+```go
+type CodexFingerprintProfile struct {
+    SchemaVersion     int                          `json:"schema_version"`
+    SourceRevision   string                       `json:"source_revision"`
+    Version          string                       `json:"version"`
+    Originator       string                       `json:"originator"`
+    UserAgentTemplate string                      `json:"user_agent_template"`
+    WebsocketBeta    string                       `json:"websocket_beta"`
+    Headers          CodexFingerprintHeaders      `json:"headers"`
+    MetadataKeys     CodexFingerprintMetadataKeys `json:"metadata_keys"`
+}
+```
+
+Expose `GetCodexFingerprintProfile`, `GetCodexFingerprintProfileSnapshot`, and `UserAgent`. Clone all maps/slices returned to callers and increment the store revision only when validated content changes.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run: `go test ./internal/registry -run 'TestCodexFingerprintProfile' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the profile store**
+
+```bash
+git add internal/registry/models/codex_fingerprint_profile.json internal/registry/codex_fingerprint_profile.go internal/registry/codex_fingerprint_profile_test.go
+git commit -m "feat(codex): add validated fingerprint profile"
+```
+
+### Task 2: Official-Source Profile Updater
+
+**Files:**
+- Create: `internal/registry/codex_fingerprint_updater.go`
+- Create: `internal/registry/codex_fingerprint_updater_test.go`
+
+- [ ] **Step 1: Write failing updater fixture tests**
+
+Use `httptest.Server` fixtures for NPM dist-tags, `default_client.rs`, `client.rs`, `responses_metadata.rs`, and the GitHub commit payload. Cover a successful complete update, no downgrade, partial-source failure, malformed constants, oversized data, and unchanged revision.
+
+- [ ] **Step 2: Run the focused updater tests and verify RED**
+
+Run: `go test ./internal/registry -run 'TestCodexFingerprintUpdater' -count=1`
+
+Expected: build failure because the updater functions do not exist.
+
+- [ ] **Step 3: Implement bounded official-source parsing**
+
+Add startup plus hourly refresh, a 30-second acquisition timeout, bounded reads, exact constant extraction, semantic version comparison, full candidate validation, and atomic publication. Keep endpoint variables injectable from tests.
+
+- [ ] **Step 4: Run registry tests and verify GREEN**
+
+Run: `go test ./internal/registry -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the updater**
+
+```bash
+git add internal/registry/codex_fingerprint_updater.go internal/registry/codex_fingerprint_updater_test.go
+git commit -m "feat(codex): sync fingerprint from official sources"
+```
+
+### Task 3: Configuration and Service Lifecycle
+
+**Files:**
+- Modify: `internal/config/config_types.go`
+- Modify: `internal/config/config_normalization.go`
+- Modify: `internal/config/clone_test.go`
+- Modify: `internal/watcher/diff/config_diff.go`
+- Modify: `internal/watcher/diff/config_diff_test.go`
+- Modify: `config.example.yaml`
+- Modify: `cmd/server/main.go`
+- Test: `cmd/server/main_test.go`
+
+- [ ] **Step 1: Write failing config and lifecycle tests**
+
+Assert that `codex.disable-fingerprint-auto-sync` parses/clones/diffs correctly and that the server updater plan starts fingerprint synchronization by default but not when disabled.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run: `go test ./internal/config ./internal/watcher/diff ./cmd/server -run 'CodexFingerprint|FingerprintAutoSync' -count=1`
+
+Expected: build or assertion failure for the missing config field and updater plan.
+
+- [ ] **Step 3: Wire the config and updater lifecycle**
+
+Add `DisableFingerprintAutoSync bool` to `CodexConfig`, document it in `config.example.yaml`, include it in config diff reporting, and start `registry.StartCodexFingerprintUpdater` for the server unless disabled.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run: `go test ./internal/config ./internal/watcher/diff ./cmd/server -run 'CodexFingerprint|FingerprintAutoSync' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit lifecycle wiring**
+
+```bash
+git add internal/config internal/watcher/diff config.example.yaml cmd/server/main.go cmd/server/main_test.go
+git commit -m "feat(codex): start fingerprint auto sync"
+```
+
+### Task 4: Official OAuth Application Identity
+
+**Files:**
+- Create: `internal/runtime/executor/codex_fingerprint.go`
+- Create: `internal/runtime/executor/codex_fingerprint_test.go`
+- Modify: `internal/runtime/executor/codex_executor_request.go`
+- Modify: `internal/runtime/executor/codex_executor_cache_test.go`
+- Modify: `internal/runtime/executor/codex_websockets_execute.go`
+- Modify: `internal/runtime/executor/codex_websockets_stream.go`
+
+- [ ] **Step 1: Write failing identity assembly tests**
+
+Assert deterministic per-auth installation identity, stable per-session UUIDv7 window identity, fresh UUIDv7 turn identity, canonical turn metadata, body/header parity, preserved parent/subagent metadata, and request-kind selection for `/responses` and `/responses/compact`.
+
+- [ ] **Step 2: Write failing scope regression tests**
+
+Assert that API-key auth, OAuth with custom `base_url`, and `disable-codex-cloaking: true` bypass body and identity projection.
+
+- [ ] **Step 3: Run focused tests and verify RED**
+
+Run: `go test ./internal/runtime/executor -run 'TestCodexOfficialFingerprint|TestCodexApplicationIdentity' -count=1`
+
+Expected: build failure because the assembler does not exist.
+
+- [ ] **Step 4: Implement one canonical identity snapshot**
+
+Create a concurrency-safe one-hour session window cache. Assemble identity after the existing account-confusion projection, write Codex-owned metadata from one snapshot, and project it to compatibility headers at each HTTP and WebSocket call site.
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+Run: `go test ./internal/runtime/executor -run 'TestCodexOfficialFingerprint|TestCodexApplicationIdentity|TestCodexIdentityConfuse' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit identity assembly**
+
+```bash
+git add internal/runtime/executor/codex_fingerprint.go internal/runtime/executor/codex_fingerprint_test.go internal/runtime/executor/codex_executor_request.go internal/runtime/executor/codex_executor_cache_test.go internal/runtime/executor/codex_websockets_execute.go internal/runtime/executor/codex_websockets_stream.go
+git commit -m "feat(codex): project official request identity"
+```
+
+### Task 5: Coherent HTTP and WebSocket Headers
+
+**Files:**
+- Modify: `internal/runtime/executor/codex_executor_request.go`
+- Modify: `internal/runtime/executor/codex_websockets_request.go`
+- Modify: `internal/runtime/executor/codex_websockets_executor_test.go`
+- Modify: `internal/runtime/executor/codex_openai_images_test.go`
+
+- [ ] **Step 1: Write failing coherent-profile tests**
+
+Publish a test profile and prove that HTTP and WebSocket requests use its User-Agent, Originator, Version, and WebSocket beta as one unit. Add regressions for config/custom attributes and all bypass scopes.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run: `go test ./internal/runtime/executor -run 'TestApplyCodex.*Fingerprint|TestApplyCodexWebsocket.*Profile' -count=1`
+
+Expected: assertions show compile-time values or mismatched Version headers.
+
+- [ ] **Step 3: Replace compile-time request identity with profile snapshots**
+
+Use one profile snapshot per request, force coherent software headers only within the approved OAuth scope, and keep existing custom/manual behavior outside that scope.
+
+- [ ] **Step 4: Run executor tests and verify GREEN**
+
+Run: `go test ./internal/runtime/executor -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit header integration**
+
+```bash
+git add internal/runtime/executor
+git commit -m "feat(codex): apply coherent dynamic headers"
+```
+
+### Task 6: WebSocket Chrome uTLS With Proxy Support
+
+**Files:**
+- Modify: `internal/runtime/executor/helps/utls_client.go`
+- Modify: `internal/runtime/executor/helps/utls_client_test.go`
+- Modify: `internal/runtime/executor/codex_websockets_connection.go`
+- Modify: `internal/runtime/executor/codex_websockets_executor_test.go`
+
+- [ ] **Step 1: Write failing dial selection tests**
+
+Assert that official `wss://chatgpt.com/backend-api/codex` OAuth connections install a uTLS `NetDialTLSContext` with `http/1.1` ALPN, while API-key/custom targets retain standard TLS. Cover direct, HTTP, HTTPS, SOCKS5, and SOCKS5H dialer selection without exposing proxy credentials.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run: `go test ./internal/runtime/executor/helps ./internal/runtime/executor -run 'Test.*UTLS.*Websocket|Test.*Websocket.*UTLS' -count=1`
+
+Expected: assertion failure because the current WebSocket dialer uses standard TLS.
+
+- [ ] **Step 3: Implement the context-aware uTLS WebSocket dial path**
+
+Use `proxyutil.BuildDialer` to establish the raw target tunnel, wrap it in `tls.UClient` with `HelloChrome_Auto`, set `ServerName` and `NextProtos: []string{"http/1.1"}`, run `HandshakeContext`, and close the raw connection on error. Enable it only for approved official OAuth WSS URLs.
+
+- [ ] **Step 4: Run transport and executor tests and verify GREEN**
+
+Run: `go test ./internal/runtime/executor/helps ./internal/runtime/executor -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit WebSocket uTLS**
+
+```bash
+git add internal/runtime/executor/helps/utls_client.go internal/runtime/executor/helps/utls_client_test.go internal/runtime/executor/codex_websockets_connection.go internal/runtime/executor/codex_websockets_executor_test.go
+git commit -m "feat(codex): use uTLS for official websockets"
+```
+
+### Task 7: Full Verification and Branch Publication
+
+**Files:**
+- Modify as required by verification findings.
+
+- [ ] **Step 1: Format all Go changes**
+
+Run: `gofmt -w <all changed .go files>`
+
+- [ ] **Step 2: Run static diff checks**
+
+Run: `git diff --check`
+
+Expected: no output.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `go test ./...`
+
+Expected: PASS with zero failing packages.
+
+- [ ] **Step 4: Run the required build**
+
+Run: `go build -o test-output ./cmd/server`
+
+Expected: exit 0. Remove `test-output` after recording the result.
+
+- [ ] **Step 5: Audit every requested capability**
+
+Verify from current source and tests that official OAuth traffic has application identity, current UA/Version, full profile synchronization, HTTP uTLS, WebSocket uTLS, and unchanged API-key/custom behavior.
+
+- [ ] **Step 6: Push the completed branch**
+
+Run: `git push origin feat/codex-fingerprint-sync`
+
+Expected: the remote branch points to the verified local HEAD.

--- a/docs/superpowers/plans/2026-08-03-codex-request-compatibility.md
+++ b/docs/superpowers/plans/2026-08-03-codex-request-compatibility.md
@@ -1,0 +1,148 @@
+# Codex Request Compatibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task by task in a single primary-agent session.
+
+**Goal:** Match official Codex request behavior while preventing model-specific high reasoning levels from failing when a nearby supported level is available.
+
+**Architecture:** Keep `internal/thinking` as the canonical capability and validation pipeline. Add `ultra` to the canonical level vocabulary, clamp only high-intent OpenAI/Codex levels to the nearest lower supported level, and keep exact per-model capabilities in the registry. At the executor boundary, remove unsupported metadata fields according to the actual upstream target and cap compact requests at `xhigh`.
+
+**Tech Stack:** Go 1.26, gjson/sjson, embedded JSON model registries, Go table-driven tests.
+
+---
+
+### Task 1: Define the high-reasoning compatibility contract
+
+**Files:**
+- Modify: `internal/thinking/apply_configured_api_key_test.go`
+- Modify: `internal/thinking/types.go`
+- Modify: `internal/thinking/suffix.go`
+- Modify: `internal/thinking/convert.go`
+- Modify: `internal/thinking/validate.go`
+
+**Step 1: Write the failing tests**
+
+Add table-driven tests proving that OpenAI/Codex high-intent levels fall back downward by capability:
+
+- `ultra -> max -> xhigh -> high`
+- `max -> xhigh -> high`
+- `xhigh -> high`
+
+Also prove that unsupported low/medium requests remain validation errors and that `-ultra` suffix parsing produces canonical `LevelUltra`.
+
+**Step 2: Run the focused tests and confirm red**
+
+Run: `go test ./internal/thinking -run 'TestApplyThinking.*HighIntent|TestParse.*Ultra' -count=1`
+
+Expected: failure because `ultra` is not canonical and same-family high levels are currently rejected.
+
+**Step 3: Implement the smallest canonical change**
+
+- Add `LevelUltra`.
+- Include `ultra` in suffix parsing and standard level ordering.
+- Permit downward clamping only when the target format is OpenAI/Codex and the requested level is `xhigh`, `max`, or `ultra`.
+- Preserve existing cross-family mapping and ordinary strict validation.
+- Extend conversions so canonical `ultra` has deterministic behavior when translated to token budgets or Claude effort.
+
+**Step 4: Run the focused tests and confirm green**
+
+Run: `go test ./internal/thinking -count=1`
+
+Expected: all thinking tests pass.
+
+### Task 2: Align built-in model capabilities with the official Codex manifest
+
+**Files:**
+- Modify: `internal/registry/model_definitions_test.go`
+- Modify: `internal/registry/models/models.json`
+
+**Step 1: Write the failing registry test**
+
+Assert for every built-in Codex subscription tier:
+
+- GPT-5.6 Sol and Terra advertise `low, medium, high, xhigh, max, ultra`.
+- GPT-5.6 Luna advertises `low, medium, high, xhigh, max` and excludes `ultra`.
+
+**Step 2: Run the focused test and confirm red**
+
+Run: `go test ./internal/registry -run 'Test.*GPT56.*Thinking' -count=1`
+
+Expected: Sol/Terra assertions fail because the built-in registry currently stops at `max`.
+
+**Step 3: Update exact model definitions**
+
+Add `ultra` to every Sol/Terra definition while leaving Luna capped at `max`.
+
+**Step 4: Run registry tests and confirm green**
+
+Run: `go test ./internal/registry -count=1`
+
+Expected: all registry tests pass.
+
+### Task 3: Normalize Codex metadata and compact reasoning at the upstream boundary
+
+**Files:**
+- Modify: `internal/runtime/executor/codex_executor_cache_test.go`
+- Modify: `internal/runtime/executor/codex_executor_request.go`
+- Modify: `internal/runtime/executor/codex_fingerprint.go`
+
+**Step 1: Write the failing executor tests**
+
+Cover these target-sensitive cases:
+
+- Official ChatGPT Codex `/responses` keeps official `client_metadata` and removes top-level `metadata`.
+- `/responses/compact` removes both metadata fields and maps `max`/`ultra` effort to `xhigh`.
+- Public API and custom upstream URLs remove both metadata fields.
+- Ordinary official non-compact requests preserve a supported `ultra` effort.
+
+**Step 2: Run the focused tests and confirm red**
+
+Run: `go test ./internal/runtime/executor -run 'TestCodex.*(Metadata|Compact|Reasoning)' -count=1`
+
+Expected: custom-target `client_metadata` and compact high-effort assertions fail.
+
+**Step 3: Implement endpoint-aware normalization**
+
+- Factor official ChatGPT Codex URL recognition into a shared executor helper.
+- Always remove unsupported top-level `metadata`.
+- Keep `client_metadata` only for ordinary official ChatGPT Codex responses requests.
+- Remove it for compact, public API, and custom targets.
+- Cap compact `reasoning.effort` values `max` and `ultra` to `xhigh` immediately before sending upstream.
+
+**Step 4: Run focused executor tests and confirm green**
+
+Run: `go test ./internal/runtime/executor -run 'TestCodex.*(Metadata|Compact|Reasoning)' -count=1`
+
+Expected: all selected executor tests pass.
+
+### Task 4: Verify integration and deliver to main
+
+**Files:**
+- Verify all modified Go and JSON files.
+
+**Step 1: Format code**
+
+Run: `gofmt -w .`
+
+**Step 2: Run affected package tests**
+
+Run: `go test ./internal/thinking ./internal/registry ./internal/runtime/executor -count=1`
+
+**Step 3: Run the full suite**
+
+Run: `go test ./...`
+
+**Step 4: Run the required compile check**
+
+Run: `go build -o test-output ./cmd/server && rm test-output`
+
+**Step 5: Review the final diff**
+
+Run: `git diff --check && git status --short && git diff --stat && git diff`
+
+Confirm that the change is limited to the canonical thinking pipeline, exact model capabilities, executor boundary normalization, tests, and design/plan documents.
+
+**Step 6: Commit and push**
+
+Create a focused commit, then push the current verified `HEAD` explicitly to `origin/main` because `main` is checked out in another local worktree.
+
+Run: `git push origin HEAD:main`

--- a/docs/superpowers/specs/2026-07-31-codex-fingerprint-sync-design.md
+++ b/docs/superpowers/specs/2026-07-31-codex-fingerprint-sync-design.md
@@ -1,0 +1,110 @@
+# Codex Fingerprint Synchronization Design
+
+## Goal
+
+Bring CLIProxyAPI's ChatGPT-backed Codex requests into application-layer parity with the current official Codex client while preserving the existing behavior of Codex API-key entries and custom gateways. Keep the software fingerprint current without changing the stable per-account device identity when a new Codex release is published.
+
+## Scope
+
+The feature applies by default only when all of the following are true:
+
+- The selected auth is OAuth/file-backed rather than an API-key entry.
+- The auth does not configure a custom `base_url`.
+- The upstream target is the official `chatgpt.com/backend-api/codex` service.
+- `codex.disable-codex-cloaking` is false.
+
+API-key entries, custom gateways, and requests with cloaking disabled keep their current header, body, and transport behavior.
+
+## Considered Approaches
+
+### 1. Parse the official release and source contract at runtime
+
+Fetch the stable version from the official `@openai/codex` NPM dist-tags and extract public constants from the official `openai/codex` source files. Validate the complete candidate before atomically publishing it. This is the selected approach because it follows the primary source and does not depend on a separately maintained fingerprint service.
+
+### 2. Fetch a project-maintained JSON manifest
+
+Publish a complete profile in a CLIProxyAPI-owned repository and make the runtime consume it. This is easier to parse, but creates an additional trust and maintenance layer and can drift from the official client.
+
+### 3. Keep a compile-time profile and update only the version
+
+Use NPM dist-tags to replace the version inside a fixed User-Agent template. This is the smallest change but does not satisfy contract synchronization when header names, metadata fields, or WebSocket beta values change.
+
+## Architecture
+
+### Versioned fingerprint profile
+
+Add an immutable `CodexFingerprintProfile` in `internal/registry`. It contains:
+
+- Schema version and official source revision.
+- Stable Codex release version.
+- Originator and official User-Agent template.
+- WebSocket beta value.
+- Header names used by the current Responses HTTP/WebSocket contract.
+- Reserved `client_metadata` and turn-metadata keys.
+
+An embedded JSON profile provides the startup and offline fallback. Readers receive cloned snapshots so request execution never observes a partially updated profile.
+
+### Official-source updater
+
+Add a background updater that runs at startup and every hour. It retrieves bounded responses from official sources, parses only explicitly named constants, rejects downgrades, validates every required field, and publishes the profile under a lock only after the full candidate passes validation. A failed refresh preserves the previous snapshot.
+
+The updater reads:
+
+- `@openai/codex` NPM dist-tags for the stable release version.
+- `openai/codex` `default_client.rs` for the default originator and User-Agent contract marker.
+- `openai/codex` `client.rs` for Codex headers and the Responses WebSocket beta value.
+- `openai/codex` `responses_metadata.rs` for metadata key names.
+- The official repository commit endpoint for source provenance.
+
+`codex.disable-fingerprint-auto-sync` disables network refresh while retaining the embedded profile. It defaults to false.
+
+### Stable application identity
+
+Add a request identity assembler for official OAuth traffic. It runs after existing identity-confusion projection so all outbound representations use the final account-scoped values.
+
+- Installation identity is deterministic per selected auth and remains stable across releases.
+- Session and thread identity reuse the final prompt-cache/session identity when available.
+- A UUIDv7 window identity is cached per session for one hour.
+- A fresh UUIDv7 turn identity is created for a new request when the client did not supply one.
+- HTTP headers, WebSocket handshake headers, `client_metadata`, and `x-codex-turn-metadata` are generated from one identity snapshot.
+- Existing parent-thread, subagent, and client metadata values are preserved unless they conflict with Codex-owned identity fields.
+
+The canonical turn metadata includes installation, session, thread, turn, window, request kind, and turn start time. Compatibility headers are projections of the same object.
+
+### Header consistency
+
+For scoped official OAuth traffic, the active profile supplies `User-Agent`, `Originator`, and `Version` as one atomic unit. Manual/custom behavior remains available through the existing cloaking switch. WebSocket `OpenAI-Beta` uses the active profile rather than a compile-time constant.
+
+### TLS parity
+
+Keep the existing Chrome uTLS HTTP/2 path for `chatgpt.com`. Extend the official `wss://chatgpt.com` path to perform a Chrome uTLS handshake with HTTP/1.1 ALPN before the Gorilla WebSocket upgrade. The dial path uses the existing proxy abstraction so direct, HTTP, HTTPS, SOCKS5, and SOCKS5H egress continue to work. Custom WebSocket gateways retain the standard TLS path.
+
+## Data Flow
+
+1. The service loads the embedded profile.
+2. The updater builds and validates a candidate from official sources, then atomically swaps it in.
+3. A Codex executor selects an auth and resolves the upstream target.
+4. Official OAuth requests assemble one stable application identity.
+5. The active profile and identity snapshot populate the body and all transport headers.
+6. HTTP uses the existing ChatGPT uTLS transport; WebSocket uses the new uTLS dial path.
+7. API-key or custom-gateway requests bypass the new profile and identity assembler.
+
+## Error Handling
+
+- Remote timeouts, non-200 responses, oversized responses, parse failures, invalid profiles, and release downgrades are logged without replacing the active profile.
+- Identity generation falls back to deterministic UUIDs where a client session value is absent or malformed.
+- A uTLS connection error closes the underlying connection and is returned with transport context.
+- Proxy credentials remain redacted in logs.
+
+## Testing
+
+- Profile validation, cloning, no-downgrade behavior, and atomic revision tests.
+- Updater tests with local HTTP fixtures for official-source parsing, fallback, oversized responses, and partial-source failure.
+- HTTP tests proving coherent UA/Originator/Version plus complete identity projections.
+- WebSocket tests proving dynamic beta/profile use, body metadata parity, and uTLS selection only for the official OAuth target.
+- Regression tests proving API-key, custom base URL, and disabled-cloaking behavior remain unchanged.
+- Existing executor, registry, config, and proxy tests, followed by `go test ./...` and the required server build.
+
+## Boundaries
+
+This feature synchronizes the public application request contract. It preserves a real inbound attestation header but does not synthesize an OpenAI attestation token. TLS uses the project's established Chrome uTLS profile; reproducing a specific Rustls binary build byte-for-byte is outside this profile contract.

--- a/docs/superpowers/specs/2026-08-03-codex-request-compatibility-design.md
+++ b/docs/superpowers/specs/2026-08-03-codex-request-compatibility-design.md
@@ -1,0 +1,106 @@
+# Codex Request Compatibility Design
+
+## Goal
+
+Prevent local reasoning-level rejection and upstream parameter errors while preserving the capability differences advertised by the current Codex model catalog.
+
+## Scope
+
+The change covers requests routed through the Codex executor over HTTP or WebSocket:
+
+- Remove top-level `metadata` before a Codex upstream request is sent.
+- Preserve `client_metadata` only for ordinary requests to the official ChatGPT Codex backend.
+- Remove `client_metadata` for compact requests and for API-key or custom upstream targets.
+- Preserve a requested high reasoning effort when the final selected model supports it.
+- Downgrade unsupported high reasoning effort to the closest lower supported level instead of rejecting the request locally.
+- Cap `max` and `ultra` at `xhigh` for `/responses/compact` compatibility.
+- Align built-in GPT-5.6 capabilities with the embedded Codex client catalog: Sol and Terra include `ultra`; Luna stops at `max`.
+
+Ordinary unsupported low or medium values remain validation errors. Non-Codex providers retain their existing validation and conversion behavior.
+
+## Considered Approaches
+
+### 1. Capability-aware high-effort compatibility
+
+Add `ultra` to the canonical thinking representation, align the built-in GPT-5.6 model definitions, and downgrade only the ordered high-effort family according to the final selected `ModelInfo`. Add a compact endpoint cap and target-aware metadata filtering at the Codex executor boundary.
+
+This is the selected approach because it preserves exact model and credential capabilities while covering older or narrower upstreams without weakening unrelated validation.
+
+### 2. Expand every Codex model to `max` and `ultra`
+
+This removes the local error for known models but misrepresents Luna and custom API-key upstreams. Unsupported values would reach the provider and fail later.
+
+### 3. Clamp every unsupported same-family level
+
+This maximizes permissiveness but hides configuration mistakes such as unsupported low or medium values and changes validation semantics for unrelated models.
+
+## Architecture
+
+### Canonical thinking levels
+
+Add `LevelUltra` above `LevelMax` in the canonical level order. Suffix parsing, request-body extraction, and OpenAI/Codex appliers continue to transport level strings through the existing canonical pipeline.
+
+The final selected `ModelInfo` remains the source of truth. For OpenAI/Codex same-family requests, only these high-effort values use compatibility fallback:
+
+- `ultra`: `ultra`, then `max`, then `xhigh`, then `high`.
+- `max`: `max`, then `xhigh`, then `high`.
+- `xhigh`: `xhigh`, then `high`.
+
+If no candidate is supported, existing validation reports the mismatch. Cross-family conversion keeps its current mapping behavior.
+
+### Compact request compatibility
+
+After the normal thinking pipeline has produced the final Codex payload, the executor request normalizer checks the target path. `/responses/compact` rewrites `reasoning.effort=max` and `reasoning.effort=ultra` to `xhigh`. Ordinary Responses and WebSocket turns retain the model-supported level.
+
+Keeping this rule at the endpoint boundary avoids teaching the provider-neutral thinking package about HTTP paths.
+
+### Metadata compatibility
+
+The existing Codex request metadata normalizer remains the single outbound boundary:
+
+- `metadata` is removed from every Codex executor payload.
+- `client_metadata` is retained only when the target is the official `chatgpt.com/backend-api/codex/responses` endpoint.
+- `client_metadata` is removed for `/responses/compact`, official public API-key endpoints, and custom base URLs.
+
+Official application identity assembly runs before normalization. This permits ordinary ChatGPT requests to receive the generated identity while guaranteeing that unsupported targets do not receive it.
+
+### Model catalog alignment
+
+Update every embedded GPT-5.6 definition consistently across Codex subscription tiers:
+
+- GPT-5.6 Sol: `low`, `medium`, `high`, `xhigh`, `max`, `ultra`.
+- GPT-5.6 Terra: `low`, `medium`, `high`, `xhigh`, `max`, `ultra`.
+- GPT-5.6 Luna: `low`, `medium`, `high`, `xhigh`, `max`.
+
+The embedded Codex client manifest already advertises this split and remains unchanged.
+
+## Data Flow
+
+1. Routing selects the credential and final upstream model.
+2. The manager attaches the exact configured `ModelInfo` for API-key attempts when available.
+3. The thinking pipeline extracts the requested effort from the suffix or original request.
+4. High-effort compatibility selects the strongest supported value at or below the requested intent.
+5. The Codex applier writes `reasoning.effort`.
+6. Official identity assembly adds ordinary ChatGPT `client_metadata` when in scope.
+7. The outbound normalizer removes unsupported metadata and applies the compact effort cap.
+8. HTTP or WebSocket transport sends the normalized payload.
+
+## Error Handling
+
+- Malformed JSON retains existing behavior; normalizers return the original body when a JSON mutation fails.
+- Unsupported ordinary levels continue through the existing typed thinking error.
+- A high-effort value with no supported fallback also retains the typed validation error.
+- Metadata filtering does not log payload contents or credentials.
+
+## Testing
+
+- Red/green tests for same-family `ultra`, `max`, and `xhigh` fallback using exact configured model capabilities.
+- Registry tests asserting the Sol/Terra/Luna capability split in every embedded Codex tier.
+- Executor tests proving ordinary official requests preserve `client_metadata`, while compact, API-key, and custom targets remove it.
+- Executor tests proving ordinary model-supported `max`/`ultra` survive and compact requests emit `xhigh`.
+- Existing thinking, registry, executor, and integration tests.
+- Required `gofmt`, full `go test ./...`, and server compile verification.
+
+## Delivery
+
+Implementation is performed in the current workspace because `main` is checked out by another worktree. After verification, the completed commit is pushed explicitly as `HEAD:main`.

--- a/internal/config/clone_test.go
+++ b/internal/config/clone_test.go
@@ -61,6 +61,9 @@ func TestCloneForRuntimeDeepCopiesConfig(t *testing.T) {
 	if clone.OpenAICompatibility[0].Models[0].Thinking.Levels[0] != "low" {
 		t.Fatalf("clone thinking level = %q, want low", clone.OpenAICompatibility[0].Models[0].Thinking.Levels[0])
 	}
+	if !clone.Codex.DisableFingerprintAutoSync {
+		t.Fatal("clone.Codex.DisableFingerprintAutoSync = false, want true")
+	}
 	if got := clone.Payload.Default[0].Params["object"].(map[string]any)["key"]; got != "value" {
 		t.Fatalf("clone payload object key = %#v, want value", got)
 	}
@@ -142,6 +145,9 @@ func sampleCloneRuntimeConfig() *Config {
 		},
 		AntigravitySignatureCacheEnabled: &cacheStrict,
 		AntigravitySignatureBypassStrict: &bypassStrict,
+		Codex: CodexConfig{
+			DisableFingerprintAutoSync: true,
+		},
 		GeminiKey: []GeminiKey{{
 			APIKey:         "gemini-key",
 			Models:         []GeminiModel{{Name: "gemini-upstream", Alias: "gemini-upstream-alias"}},

--- a/internal/config/codex_websocket_header_defaults_test.go
+++ b/internal/config/codex_websocket_header_defaults_test.go
@@ -41,6 +41,7 @@ func TestLoadConfigOptional_CodexIdentityConfuse(t *testing.T) {
 codex:
   identity-confuse: true
   disable-codex-cloaking: true
+  disable-fingerprint-auto-sync: true
   optimize-multi-agent-v2: true
 `)
 	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
@@ -57,6 +58,9 @@ codex:
 	}
 	if !cfg.Codex.DisableCodexCloaking {
 		t.Fatal("DisableCodexCloaking = false, want true")
+	}
+	if !cfg.Codex.DisableFingerprintAutoSync {
+		t.Fatal("DisableFingerprintAutoSync = false, want true")
 	}
 	if !cfg.Codex.OptimizeMultiAgentV2 {
 		t.Fatalf("OptimizeMultiAgentV2 = false, want true")

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -136,6 +136,8 @@ type CodexConfig struct {
 	IdentityConfuse bool `yaml:"identity-confuse" json:"identity-confuse"`
 	// DisableCodexCloaking disables forcing the official Codex identity headers on HTTP/SSE and WebSocket requests.
 	DisableCodexCloaking bool `yaml:"disable-codex-cloaking" json:"disable-codex-cloaking"`
+	// DisableFingerprintAutoSync disables refreshing the Codex application profile from official sources.
+	DisableFingerprintAutoSync bool `yaml:"disable-fingerprint-auto-sync" json:"disable-fingerprint-auto-sync"`
 	// OptimizeMultiAgentV2 optimizes official Codex multi-agent requests.
 	OptimizeMultiAgentV2 bool `yaml:"optimize-multi-agent-v2" json:"optimize-multi-agent-v2"`
 	// LiveMediaRelay terminates and relays Codex Live WebRTC media in this process.

--- a/internal/registry/codex_fingerprint_profile.go
+++ b/internal/registry/codex_fingerprint_profile.go
@@ -1,0 +1,257 @@
+package registry
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/http/httpguts"
+)
+
+//go:embed models/codex_fingerprint_profile.json
+var embeddedCodexFingerprintProfileJSON []byte
+
+// CodexFingerprintHeaders names the application identity headers used by the
+// official Codex Responses HTTP and websocket transports.
+type CodexFingerprintHeaders struct {
+	InstallationID  string `json:"installation_id"`
+	TurnState       string `json:"turn_state"`
+	TurnMetadata    string `json:"turn_metadata"`
+	ParentThreadID  string `json:"parent_thread_id"`
+	WindowID        string `json:"window_id"`
+	Subagent        string `json:"subagent"`
+	TimingMetrics   string `json:"timing_metrics"`
+	ClientRequestID string `json:"client_request_id"`
+	SessionID       string `json:"session_id"`
+	ThreadID        string `json:"thread_id"`
+}
+
+// CodexFingerprintMetadataKeys names the Codex-owned fields inside canonical
+// turn metadata.
+type CodexFingerprintMetadataKeys struct {
+	InstallationID      string `json:"installation_id"`
+	SessionID           string `json:"session_id"`
+	ThreadID            string `json:"thread_id"`
+	TurnID              string `json:"turn_id"`
+	WindowID            string `json:"window_id"`
+	RequestKind         string `json:"request_kind"`
+	TurnStartedAtUnixMS string `json:"turn_started_at_unix_ms"`
+	ParentThreadID      string `json:"parent_thread_id"`
+	ParentTurnID        string `json:"parent_turn_id"`
+	SubagentKind        string `json:"subagent_kind"`
+}
+
+// CodexFingerprintProfile is a validated snapshot of the official Codex
+// application request contract.
+type CodexFingerprintProfile struct {
+	SchemaVersion     int                          `json:"schema_version"`
+	SourceRevision    string                       `json:"source_revision"`
+	Version           string                       `json:"version"`
+	Originator        string                       `json:"originator"`
+	UserAgentTemplate string                       `json:"user_agent_template"`
+	WebsocketBeta     string                       `json:"websocket_beta"`
+	Headers           CodexFingerprintHeaders      `json:"headers"`
+	MetadataKeys      CodexFingerprintMetadataKeys `json:"metadata_keys"`
+}
+
+// UserAgent expands the profile's coherent originator and release version.
+func (profile CodexFingerprintProfile) UserAgent() string {
+	value := strings.ReplaceAll(profile.UserAgentTemplate, "{originator}", profile.Originator)
+	return strings.ReplaceAll(value, "{version}", profile.Version)
+}
+
+type codexFingerprintProfileStore struct {
+	mu       sync.RWMutex
+	profile  CodexFingerprintProfile
+	revision uint64
+}
+
+var codexFingerprintCatalogStore = &codexFingerprintProfileStore{}
+
+func init() {
+	var profile CodexFingerprintProfile
+	if err := json.Unmarshal(embeddedCodexFingerprintProfileJSON, &profile); err != nil {
+		log.Warnf("registry: failed to decode embedded Codex fingerprint profile: %v", err)
+		return
+	}
+	if err := validateCodexFingerprintProfile(profile); err != nil {
+		log.Warnf("registry: embedded Codex fingerprint profile is invalid: %v", err)
+		return
+	}
+	codexFingerprintCatalogStore = newCodexFingerprintProfileStore(profile)
+}
+
+func newCodexFingerprintProfileStore(profile CodexFingerprintProfile) *codexFingerprintProfileStore {
+	return &codexFingerprintProfileStore{profile: profile, revision: 1}
+}
+
+// GetCodexFingerprintProfile returns the current immutable profile snapshot.
+func GetCodexFingerprintProfile() CodexFingerprintProfile {
+	profile, _ := GetCodexFingerprintProfileSnapshot()
+	return profile
+}
+
+// GetCodexFingerprintProfileSnapshot returns the current profile and revision.
+func GetCodexFingerprintProfileSnapshot() (CodexFingerprintProfile, uint64) {
+	codexFingerprintCatalogStore.mu.RLock()
+	defer codexFingerprintCatalogStore.mu.RUnlock()
+	return codexFingerprintCatalogStore.profile, codexFingerprintCatalogStore.revision
+}
+
+func loadCodexFingerprintProfileFromBytes(data []byte, source string) (bool, error) {
+	var profile CodexFingerprintProfile
+	if err := json.Unmarshal(data, &profile); err != nil {
+		return false, fmt.Errorf("decode Codex fingerprint profile from %s: %w", source, err)
+	}
+	return codexFingerprintCatalogStore.update(profile)
+}
+
+func (store *codexFingerprintProfileStore) update(candidate CodexFingerprintProfile) (bool, error) {
+	if err := validateCodexFingerprintProfile(candidate); err != nil {
+		return false, err
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.revision > 0 {
+		comparison, errCompare := compareCodexReleaseVersions(candidate.Version, store.profile.Version)
+		if errCompare != nil {
+			return false, errCompare
+		}
+		if comparison < 0 {
+			return false, fmt.Errorf("Codex fingerprint version downgrade %s -> %s rejected", store.profile.Version, candidate.Version)
+		}
+	}
+
+	currentJSON, _ := json.Marshal(store.profile)
+	candidateJSON, _ := json.Marshal(candidate)
+	if bytes.Equal(currentJSON, candidateJSON) {
+		return false, nil
+	}
+	store.profile = candidate
+	store.revision++
+	return true, nil
+}
+
+func validateCodexFingerprintProfile(profile CodexFingerprintProfile) error {
+	if profile.SchemaVersion != 1 {
+		return fmt.Errorf("Codex fingerprint schema version %d is unsupported", profile.SchemaVersion)
+	}
+	if strings.TrimSpace(profile.SourceRevision) == "" {
+		return fmt.Errorf("Codex fingerprint source revision is empty")
+	}
+	if _, err := parseCodexReleaseVersion(profile.Version); err != nil {
+		return err
+	}
+	if strings.TrimSpace(profile.Originator) == "" || !httpguts.ValidHeaderFieldValue(profile.Originator) {
+		return fmt.Errorf("Codex fingerprint originator is invalid")
+	}
+	if !strings.Contains(profile.UserAgentTemplate, "{originator}") || !strings.Contains(profile.UserAgentTemplate, "{version}") {
+		return fmt.Errorf("Codex fingerprint User-Agent template must contain {originator} and {version}")
+	}
+	if userAgent := profile.UserAgent(); strings.TrimSpace(userAgent) == "" || !httpguts.ValidHeaderFieldValue(userAgent) {
+		return fmt.Errorf("Codex fingerprint User-Agent is invalid")
+	}
+	if !strings.HasPrefix(strings.TrimSpace(profile.WebsocketBeta), "responses_websockets=") {
+		return fmt.Errorf("Codex fingerprint websocket beta is invalid")
+	}
+
+	headers := []string{
+		profile.Headers.InstallationID,
+		profile.Headers.TurnState,
+		profile.Headers.TurnMetadata,
+		profile.Headers.ParentThreadID,
+		profile.Headers.WindowID,
+		profile.Headers.Subagent,
+		profile.Headers.TimingMetrics,
+		profile.Headers.ClientRequestID,
+		profile.Headers.SessionID,
+		profile.Headers.ThreadID,
+	}
+	seenHeaders := make(map[string]struct{}, len(headers))
+	for _, header := range headers {
+		header = strings.TrimSpace(header)
+		if !httpguts.ValidHeaderFieldName(header) {
+			return fmt.Errorf("Codex fingerprint header name %q is invalid", header)
+		}
+		normalized := strings.ToLower(header)
+		if _, exists := seenHeaders[normalized]; exists {
+			return fmt.Errorf("Codex fingerprint header name %q is duplicated", header)
+		}
+		seenHeaders[normalized] = struct{}{}
+	}
+
+	metadataKeys := []string{
+		profile.MetadataKeys.InstallationID,
+		profile.MetadataKeys.SessionID,
+		profile.MetadataKeys.ThreadID,
+		profile.MetadataKeys.TurnID,
+		profile.MetadataKeys.WindowID,
+		profile.MetadataKeys.RequestKind,
+		profile.MetadataKeys.TurnStartedAtUnixMS,
+		profile.MetadataKeys.ParentThreadID,
+		profile.MetadataKeys.ParentTurnID,
+		profile.MetadataKeys.SubagentKind,
+	}
+	seenMetadata := make(map[string]struct{}, len(metadataKeys))
+	for _, key := range metadataKeys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return fmt.Errorf("Codex fingerprint metadata key is empty")
+		}
+		if _, exists := seenMetadata[key]; exists {
+			return fmt.Errorf("Codex fingerprint metadata key %q is duplicated", key)
+		}
+		seenMetadata[key] = struct{}{}
+	}
+	return nil
+}
+
+func compareCodexReleaseVersions(left, right string) (int, error) {
+	leftParts, errLeft := parseCodexReleaseVersion(left)
+	if errLeft != nil {
+		return 0, errLeft
+	}
+	rightParts, errRight := parseCodexReleaseVersion(right)
+	if errRight != nil {
+		return 0, errRight
+	}
+	for i := range leftParts {
+		switch {
+		case leftParts[i] < rightParts[i]:
+			return -1, nil
+		case leftParts[i] > rightParts[i]:
+			return 1, nil
+		}
+	}
+	return 0, nil
+}
+
+func parseCodexReleaseVersion(version string) ([3]int64, error) {
+	var parsed [3]int64
+	original := strings.TrimSpace(version)
+	version = strings.TrimPrefix(original, "v")
+	if separator := strings.IndexAny(version, "-+"); separator >= 0 {
+		version = version[:separator]
+	}
+	parts := strings.Split(version, ".")
+	if len(parts) != len(parsed) {
+		return parsed, fmt.Errorf("Codex fingerprint version %q is invalid", original)
+	}
+	for i, part := range parts {
+		if part == "" {
+			return parsed, fmt.Errorf("Codex fingerprint version %q is invalid", original)
+		}
+		value, errParse := strconv.ParseInt(part, 10, 64)
+		if errParse != nil || value < 0 {
+			return parsed, fmt.Errorf("Codex fingerprint version %q is invalid", original)
+		}
+		parsed[i] = value
+	}
+	return parsed, nil
+}

--- a/internal/registry/codex_fingerprint_profile.go
+++ b/internal/registry/codex_fingerprint_profile.go
@@ -98,9 +98,13 @@ func GetCodexFingerprintProfile() CodexFingerprintProfile {
 
 // GetCodexFingerprintProfileSnapshot returns the current profile and revision.
 func GetCodexFingerprintProfileSnapshot() (CodexFingerprintProfile, uint64) {
-	codexFingerprintCatalogStore.mu.RLock()
-	defer codexFingerprintCatalogStore.mu.RUnlock()
-	return codexFingerprintCatalogStore.profile, codexFingerprintCatalogStore.revision
+	return codexFingerprintCatalogStore.snapshot()
+}
+
+func (store *codexFingerprintProfileStore) snapshot() (CodexFingerprintProfile, uint64) {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	return store.profile, store.revision
 }
 
 func loadCodexFingerprintProfileFromBytes(data []byte, source string) (bool, error) {

--- a/internal/registry/codex_fingerprint_profile_test.go
+++ b/internal/registry/codex_fingerprint_profile_test.go
@@ -19,6 +19,9 @@ func TestCodexFingerprintProfileEmbeddedFallback(t *testing.T) {
 	if profile.Headers.InstallationID != "x-codex-installation-id" {
 		t.Fatalf("installation header = %q", profile.Headers.InstallationID)
 	}
+	if profile.Headers.SessionID != "session-id" || profile.Headers.ThreadID != "thread-id" {
+		t.Fatalf("session/thread headers = %q/%q", profile.Headers.SessionID, profile.Headers.ThreadID)
+	}
 	if profile.MetadataKeys.RequestKind != "request_kind" {
 		t.Fatalf("request kind metadata key = %q", profile.MetadataKeys.RequestKind)
 	}
@@ -94,8 +97,8 @@ func validTestCodexFingerprintProfile() CodexFingerprintProfile {
 			Subagent:        "x-openai-subagent",
 			TimingMetrics:   "x-responsesapi-include-timing-metrics",
 			ClientRequestID: "x-client-request-id",
-			SessionID:       "session_id",
-			ThreadID:        "thread_id",
+			SessionID:       "session-id",
+			ThreadID:        "thread-id",
 		},
 		MetadataKeys: CodexFingerprintMetadataKeys{
 			InstallationID:      "installation_id",

--- a/internal/registry/codex_fingerprint_profile_test.go
+++ b/internal/registry/codex_fingerprint_profile_test.go
@@ -1,0 +1,113 @@
+package registry
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCodexFingerprintProfileEmbeddedFallback(t *testing.T) {
+	profile, revision := GetCodexFingerprintProfileSnapshot()
+	if revision == 0 {
+		t.Fatal("embedded profile revision = 0, want initialized store")
+	}
+	if profile.SchemaVersion != 1 {
+		t.Fatalf("schema version = %d, want 1", profile.SchemaVersion)
+	}
+	if profile.Version == "" || profile.Originator == "" || profile.WebsocketBeta == "" {
+		t.Fatalf("embedded profile is incomplete: %+v", profile)
+	}
+	if profile.Headers.InstallationID != "x-codex-installation-id" {
+		t.Fatalf("installation header = %q", profile.Headers.InstallationID)
+	}
+	if profile.MetadataKeys.RequestKind != "request_kind" {
+		t.Fatalf("request kind metadata key = %q", profile.MetadataKeys.RequestKind)
+	}
+}
+
+func TestCodexFingerprintProfileSnapshotIsCloned(t *testing.T) {
+	first, firstRevision := GetCodexFingerprintProfileSnapshot()
+	first.Version = "99.99.99"
+	first.Headers.WindowID = "x-mutated-window"
+
+	second, secondRevision := GetCodexFingerprintProfileSnapshot()
+	if secondRevision != firstRevision {
+		t.Fatalf("revision changed after caller mutation: %d -> %d", firstRevision, secondRevision)
+	}
+	if second.Version == first.Version || second.Headers.WindowID == first.Headers.WindowID {
+		t.Fatalf("caller mutation leaked into store: %+v", second)
+	}
+}
+
+func TestCodexFingerprintProfileUserAgent(t *testing.T) {
+	profile := validTestCodexFingerprintProfile()
+	profile.Version = "1.2.3"
+	profile.Originator = "codex_cli_rs"
+
+	got := profile.UserAgent()
+	if !strings.Contains(got, "codex_cli_rs/1.2.3") {
+		t.Fatalf("UserAgent() = %q, want originator/version prefix", got)
+	}
+	if strings.Contains(got, "{originator}") || strings.Contains(got, "{version}") {
+		t.Fatalf("UserAgent() left template variables unresolved: %q", got)
+	}
+}
+
+func TestCodexFingerprintProfileValidationRejectsInvalidHeader(t *testing.T) {
+	profile := validTestCodexFingerprintProfile()
+	profile.Headers.WindowID = "x-codex-window-id\ninvalid"
+	if err := validateCodexFingerprintProfile(profile); err == nil {
+		t.Fatal("validateCodexFingerprintProfile() error = nil, want invalid header error")
+	}
+}
+
+func TestCodexFingerprintProfileValidationRejectsInvalidTemplate(t *testing.T) {
+	profile := validTestCodexFingerprintProfile()
+	profile.UserAgentTemplate = "codex_cli_rs/1.2.3"
+	if err := validateCodexFingerprintProfile(profile); err == nil {
+		t.Fatal("validateCodexFingerprintProfile() error = nil, want missing placeholder error")
+	}
+}
+
+func TestCodexFingerprintProfileStoreRejectsDowngrade(t *testing.T) {
+	store := newCodexFingerprintProfileStore(validTestCodexFingerprintProfile())
+	downgrade := validTestCodexFingerprintProfile()
+	downgrade.Version = "0.145.0"
+	if changed, err := store.update(downgrade); err == nil || changed {
+		t.Fatalf("store.update(downgrade) = (%v, %v), want false and error", changed, err)
+	}
+}
+
+func validTestCodexFingerprintProfile() CodexFingerprintProfile {
+	return CodexFingerprintProfile{
+		SchemaVersion:     1,
+		SourceRevision:    "test-revision",
+		Version:           "0.146.0",
+		Originator:        "codex_cli_rs",
+		UserAgentTemplate: "{originator}/{version} (Mac OS 26.5.2; arm64) Apple_Terminal/470 (codex-tui; {version})",
+		WebsocketBeta:     "responses_websockets=2026-02-06",
+		Headers: CodexFingerprintHeaders{
+			InstallationID:  "x-codex-installation-id",
+			TurnState:       "x-codex-turn-state",
+			TurnMetadata:    "x-codex-turn-metadata",
+			ParentThreadID:  "x-codex-parent-thread-id",
+			WindowID:        "x-codex-window-id",
+			Subagent:        "x-openai-subagent",
+			TimingMetrics:   "x-responsesapi-include-timing-metrics",
+			ClientRequestID: "x-client-request-id",
+			SessionID:       "session_id",
+			ThreadID:        "thread_id",
+		},
+		MetadataKeys: CodexFingerprintMetadataKeys{
+			InstallationID:      "installation_id",
+			SessionID:           "session_id",
+			ThreadID:            "thread_id",
+			TurnID:              "turn_id",
+			WindowID:            "window_id",
+			RequestKind:         "request_kind",
+			TurnStartedAtUnixMS: "turn_started_at_unix_ms",
+			ParentThreadID:      "parent_thread_id",
+			ParentTurnID:        "parent_turn_id",
+			SubagentKind:        "subagent_kind",
+		},
+	}
+}

--- a/internal/registry/codex_fingerprint_updater.go
+++ b/internal/registry/codex_fingerprint_updater.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"sync"
@@ -25,6 +26,7 @@ type codexFingerprintSourceSet struct {
 	DefaultClientURL     string
 	ClientURL            string
 	ResponsesMetadataURL string
+	RequestHeadersURL    string
 	CommitURL            string
 }
 
@@ -33,6 +35,7 @@ var codexFingerprintSources = codexFingerprintSourceSet{
 	DefaultClientURL:     "https://raw.githubusercontent.com/openai/codex/main/codex-rs/login/src/auth/default_client.rs",
 	ClientURL:            "https://raw.githubusercontent.com/openai/codex/main/codex-rs/core/src/client.rs",
 	ResponsesMetadataURL: "https://raw.githubusercontent.com/openai/codex/main/codex-rs/core/src/responses_metadata.rs",
+	RequestHeadersURL:    "https://raw.githubusercontent.com/openai/codex/main/codex-rs/codex-api/src/requests/headers.rs",
 	CommitURL:            "https://api.github.com/repos/openai/codex/commits/main",
 }
 
@@ -90,6 +93,21 @@ func fetchCodexFingerprintProfile(
 	if client == nil {
 		client = &http.Client{Timeout: codexFingerprintFetchTimeout}
 	}
+
+	commitPayload, errFetch := fetchCodexFingerprintSource(ctx, client, sources.CommitURL, "commit source")
+	if errFetch != nil {
+		return CodexFingerprintProfile{}, errFetch
+	}
+	var commit map[string]any
+	if errJSON := json.Unmarshal(commitPayload, &commit); errJSON != nil {
+		return CodexFingerprintProfile{}, fmt.Errorf("decode Codex commit source: %w", errJSON)
+	}
+	sourceRevision, _ := commit["sha"].(string)
+	sourceRevision = strings.TrimSpace(sourceRevision)
+	if sourceRevision == "" {
+		return CodexFingerprintProfile{}, fmt.Errorf("Codex commit source is missing sha")
+	}
+	sources = pinCodexFingerprintSourcesToRevision(sources, sourceRevision)
 
 	distTags, errFetch := fetchCodexFingerprintSource(ctx, client, sources.DistTagsURL, "NPM dist-tags")
 	if errFetch != nil {
@@ -187,18 +205,17 @@ func fetchCodexFingerprintProfile(
 		metadataValues[name] = value
 	}
 
-	commitPayload, errFetch := fetchCodexFingerprintSource(ctx, client, sources.CommitURL, "commit source")
+	requestHeadersSource, errFetch := fetchCodexFingerprintSource(ctx, client, sources.RequestHeadersURL, "request headers source")
 	if errFetch != nil {
 		return CodexFingerprintProfile{}, errFetch
 	}
-	var commit map[string]any
-	if errJSON := json.Unmarshal(commitPayload, &commit); errJSON != nil {
-		return CodexFingerprintProfile{}, fmt.Errorf("decode Codex commit source: %w", errJSON)
+	sessionHeader, errHeader := extractRustSessionHeader(requestHeadersSource, "session_id")
+	if errHeader != nil {
+		return CodexFingerprintProfile{}, errHeader
 	}
-	sourceRevision, _ := commit["sha"].(string)
-	sourceRevision = strings.TrimSpace(sourceRevision)
-	if sourceRevision == "" {
-		return CodexFingerprintProfile{}, fmt.Errorf("Codex commit source is missing sha")
+	threadHeader, errHeader := extractRustSessionHeader(requestHeadersSource, "thread_id")
+	if errHeader != nil {
+		return CodexFingerprintProfile{}, errHeader
 	}
 
 	candidate := base
@@ -215,8 +232,8 @@ func fetchCodexFingerprintProfile(
 		Subagent:        subagentHeader,
 		TimingMetrics:   timingHeader,
 		ClientRequestID: "x-client-request-id",
-		SessionID:       metadataValues["SESSION_ID_KEY"],
-		ThreadID:        metadataValues["THREAD_ID_KEY"],
+		SessionID:       sessionHeader,
+		ThreadID:        threadHeader,
 	}
 	candidate.MetadataKeys = CodexFingerprintMetadataKeys{
 		InstallationID:      metadataValues["INSTALLATION_ID_KEY"],
@@ -276,4 +293,40 @@ func extractRustStringConstant(source []byte, name string) (string, error) {
 		return "", fmt.Errorf("official Codex source constant %s is empty", name)
 	}
 	return value, nil
+}
+
+func extractRustSessionHeader(source []byte, variable string) (string, error) {
+	pattern := "(?s)if\\s+let\\s+Some\\(id\\)\\s*=\\s*" + regexp.QuoteMeta(variable) +
+		"\\s*\\{.*?insert_header\\(\\s*&mut\\s+headers\\s*,\\s*\"([^\"]+)\"\\s*,\\s*&id\\s*\\)"
+	matches := regexp.MustCompile(pattern).FindSubmatch(source)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("official Codex request headers source is missing %s", variable)
+	}
+	value := strings.TrimSpace(string(matches[1]))
+	if value == "" {
+		return "", fmt.Errorf("official Codex request header for %s is empty", variable)
+	}
+	return value, nil
+}
+
+func pinCodexFingerprintSourcesToRevision(sources codexFingerprintSourceSet, revision string) codexFingerprintSourceSet {
+	sources.DefaultClientURL = pinCodexFingerprintSourceURL(sources.DefaultClientURL, revision)
+	sources.ClientURL = pinCodexFingerprintSourceURL(sources.ClientURL, revision)
+	sources.ResponsesMetadataURL = pinCodexFingerprintSourceURL(sources.ResponsesMetadataURL, revision)
+	sources.RequestHeadersURL = pinCodexFingerprintSourceURL(sources.RequestHeadersURL, revision)
+	return sources
+}
+
+func pinCodexFingerprintSourceURL(sourceURL, revision string) string {
+	parsed, errParse := url.Parse(strings.TrimSpace(sourceURL))
+	if errParse != nil || !strings.EqualFold(parsed.Hostname(), "raw.githubusercontent.com") {
+		return sourceURL
+	}
+	parts := strings.Split(strings.TrimPrefix(parsed.Path, "/"), "/")
+	if len(parts) < 4 || parts[0] != "openai" || parts[1] != "codex" || parts[2] != "main" {
+		return sourceURL
+	}
+	parts[2] = strings.TrimSpace(revision)
+	parsed.Path = "/" + strings.Join(parts, "/")
+	return parsed.String()
 }

--- a/internal/registry/codex_fingerprint_updater.go
+++ b/internal/registry/codex_fingerprint_updater.go
@@ -1,0 +1,279 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	codexFingerprintFetchTimeout    = 30 * time.Second
+	codexFingerprintRefreshInterval = time.Hour
+	maxCodexFingerprintSourceSize   = 1 << 20
+)
+
+type codexFingerprintSourceSet struct {
+	DistTagsURL          string
+	DefaultClientURL     string
+	ClientURL            string
+	ResponsesMetadataURL string
+	CommitURL            string
+}
+
+var codexFingerprintSources = codexFingerprintSourceSet{
+	DistTagsURL:          "https://registry.npmjs.org/-/package/@openai%2Fcodex/dist-tags",
+	DefaultClientURL:     "https://raw.githubusercontent.com/openai/codex/main/codex-rs/login/src/auth/default_client.rs",
+	ClientURL:            "https://raw.githubusercontent.com/openai/codex/main/codex-rs/core/src/client.rs",
+	ResponsesMetadataURL: "https://raw.githubusercontent.com/openai/codex/main/codex-rs/core/src/responses_metadata.rs",
+	CommitURL:            "https://api.github.com/repos/openai/codex/commits/main",
+}
+
+var codexFingerprintUpdaterOnce sync.Once
+
+// StartCodexFingerprintUpdater starts the official Codex application profile
+// refresh loop. It is safe to call multiple times.
+func StartCodexFingerprintUpdater(ctx context.Context) {
+	codexFingerprintUpdaterOnce.Do(func() {
+		go runCodexFingerprintUpdater(ctx)
+	})
+}
+
+func runCodexFingerprintUpdater(ctx context.Context) {
+	tryRefreshCodexFingerprint(ctx, "startup Codex fingerprint refresh")
+	ticker := time.NewTicker(codexFingerprintRefreshInterval)
+	defer ticker.Stop()
+	log.Infof("periodic Codex fingerprint refresh started (interval=%s)", codexFingerprintRefreshInterval)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tryRefreshCodexFingerprint(ctx, "periodic Codex fingerprint refresh")
+		}
+	}
+}
+
+func tryRefreshCodexFingerprint(ctx context.Context, label string) {
+	current := GetCodexFingerprintProfile()
+	client := &http.Client{Timeout: codexFingerprintFetchTimeout}
+	candidate, errFetch := fetchCodexFingerprintProfile(ctx, client, codexFingerprintSources, current)
+	if errFetch != nil {
+		log.Warnf("%s failed, keeping current profile: %v", label, errFetch)
+		return
+	}
+	changed, errUpdate := codexFingerprintCatalogStore.update(candidate)
+	if errUpdate != nil {
+		log.Warnf("%s rejected, keeping current profile: %v", label, errUpdate)
+		return
+	}
+	if !changed {
+		log.Infof("%s completed, no changes detected", label)
+		return
+	}
+	log.Infof("%s completed (version=%s source=%s)", label, candidate.Version, candidate.SourceRevision)
+}
+
+func fetchCodexFingerprintProfile(
+	ctx context.Context,
+	client *http.Client,
+	sources codexFingerprintSourceSet,
+	base CodexFingerprintProfile,
+) (CodexFingerprintProfile, error) {
+	if client == nil {
+		client = &http.Client{Timeout: codexFingerprintFetchTimeout}
+	}
+
+	distTags, errFetch := fetchCodexFingerprintSource(ctx, client, sources.DistTagsURL, "NPM dist-tags")
+	if errFetch != nil {
+		return CodexFingerprintProfile{}, errFetch
+	}
+	var tags map[string]string
+	if errJSON := json.Unmarshal(distTags, &tags); errJSON != nil {
+		return CodexFingerprintProfile{}, fmt.Errorf("decode Codex NPM dist-tags: %w", errJSON)
+	}
+	version := strings.TrimSpace(tags["latest"])
+	if _, errVersion := parseCodexReleaseVersion(version); errVersion != nil {
+		return CodexFingerprintProfile{}, errVersion
+	}
+	if comparison, errCompare := compareCodexReleaseVersions(version, base.Version); errCompare != nil {
+		return CodexFingerprintProfile{}, errCompare
+	} else if comparison < 0 {
+		return CodexFingerprintProfile{}, fmt.Errorf("Codex fingerprint version downgrade %s -> %s rejected", base.Version, version)
+	}
+
+	defaultClient, errFetch := fetchCodexFingerprintSource(ctx, client, sources.DefaultClientURL, "default client source")
+	if errFetch != nil {
+		return CodexFingerprintProfile{}, errFetch
+	}
+	originator, errConstant := extractRustStringConstant(defaultClient, "DEFAULT_ORIGINATOR")
+	if errConstant != nil {
+		return CodexFingerprintProfile{}, errConstant
+	}
+	if !strings.Contains(string(defaultClient), "get_codex_user_agent") ||
+		!strings.Contains(string(defaultClient), "CARGO_PKG_VERSION") {
+		return CodexFingerprintProfile{}, fmt.Errorf("default client source is missing the official User-Agent contract")
+	}
+
+	clientSource, errFetch := fetchCodexFingerprintSource(ctx, client, sources.ClientURL, "client source")
+	if errFetch != nil {
+		return CodexFingerprintProfile{}, errFetch
+	}
+	installationHeader, errConstant := extractRustStringConstant(clientSource, "X_CODEX_INSTALLATION_ID_HEADER")
+	if errConstant != nil {
+		return CodexFingerprintProfile{}, errConstant
+	}
+	turnStateHeader, errConstant := extractRustStringConstant(clientSource, "X_CODEX_TURN_STATE_HEADER")
+	if errConstant != nil {
+		return CodexFingerprintProfile{}, errConstant
+	}
+	turnMetadataHeader, errConstant := extractRustStringConstant(clientSource, "X_CODEX_TURN_METADATA_HEADER")
+	if errConstant != nil {
+		return CodexFingerprintProfile{}, errConstant
+	}
+	parentThreadHeader, errConstant := extractRustStringConstant(clientSource, "X_CODEX_PARENT_THREAD_ID_HEADER")
+	if errConstant != nil {
+		return CodexFingerprintProfile{}, errConstant
+	}
+	windowHeader, errConstant := extractRustStringConstant(clientSource, "X_CODEX_WINDOW_ID_HEADER")
+	if errConstant != nil {
+		return CodexFingerprintProfile{}, errConstant
+	}
+	subagentHeader, errConstant := extractRustStringConstant(clientSource, "X_OPENAI_SUBAGENT_HEADER")
+	if errConstant != nil {
+		return CodexFingerprintProfile{}, errConstant
+	}
+	timingHeader, errConstant := extractRustStringConstant(clientSource, "X_RESPONSESAPI_INCLUDE_TIMING_METRICS_HEADER")
+	if errConstant != nil {
+		return CodexFingerprintProfile{}, errConstant
+	}
+	websocketBeta, errConstant := extractRustStringConstant(clientSource, "RESPONSES_WEBSOCKETS_V2_BETA_HEADER_VALUE")
+	if errConstant != nil {
+		return CodexFingerprintProfile{}, errConstant
+	}
+	if !strings.Contains(string(clientSource), "\"x-client-request-id\"") {
+		return CodexFingerprintProfile{}, fmt.Errorf("client source is missing x-client-request-id")
+	}
+
+	metadataSource, errFetch := fetchCodexFingerprintSource(ctx, client, sources.ResponsesMetadataURL, "responses metadata source")
+	if errFetch != nil {
+		return CodexFingerprintProfile{}, errFetch
+	}
+	metadataNames := []string{
+		"INSTALLATION_ID_KEY",
+		"SESSION_ID_KEY",
+		"THREAD_ID_KEY",
+		"TURN_ID_KEY",
+		"WINDOW_ID_KEY",
+		"REQUEST_KIND_KEY",
+		"TURN_STARTED_AT_UNIX_MS_KEY",
+		"PARENT_THREAD_ID_KEY",
+		"PARENT_TURN_ID_KEY",
+		"SUBAGENT_KIND_KEY",
+	}
+	metadataValues := make(map[string]string, len(metadataNames))
+	for _, name := range metadataNames {
+		value, errMetadata := extractRustStringConstant(metadataSource, name)
+		if errMetadata != nil {
+			return CodexFingerprintProfile{}, errMetadata
+		}
+		metadataValues[name] = value
+	}
+
+	commitPayload, errFetch := fetchCodexFingerprintSource(ctx, client, sources.CommitURL, "commit source")
+	if errFetch != nil {
+		return CodexFingerprintProfile{}, errFetch
+	}
+	var commit map[string]any
+	if errJSON := json.Unmarshal(commitPayload, &commit); errJSON != nil {
+		return CodexFingerprintProfile{}, fmt.Errorf("decode Codex commit source: %w", errJSON)
+	}
+	sourceRevision, _ := commit["sha"].(string)
+	sourceRevision = strings.TrimSpace(sourceRevision)
+	if sourceRevision == "" {
+		return CodexFingerprintProfile{}, fmt.Errorf("Codex commit source is missing sha")
+	}
+
+	candidate := base
+	candidate.SourceRevision = sourceRevision
+	candidate.Version = version
+	candidate.Originator = originator
+	candidate.WebsocketBeta = websocketBeta
+	candidate.Headers = CodexFingerprintHeaders{
+		InstallationID:  installationHeader,
+		TurnState:       turnStateHeader,
+		TurnMetadata:    turnMetadataHeader,
+		ParentThreadID:  parentThreadHeader,
+		WindowID:        windowHeader,
+		Subagent:        subagentHeader,
+		TimingMetrics:   timingHeader,
+		ClientRequestID: "x-client-request-id",
+		SessionID:       metadataValues["SESSION_ID_KEY"],
+		ThreadID:        metadataValues["THREAD_ID_KEY"],
+	}
+	candidate.MetadataKeys = CodexFingerprintMetadataKeys{
+		InstallationID:      metadataValues["INSTALLATION_ID_KEY"],
+		SessionID:           metadataValues["SESSION_ID_KEY"],
+		ThreadID:            metadataValues["THREAD_ID_KEY"],
+		TurnID:              metadataValues["TURN_ID_KEY"],
+		WindowID:            metadataValues["WINDOW_ID_KEY"],
+		RequestKind:         metadataValues["REQUEST_KIND_KEY"],
+		TurnStartedAtUnixMS: metadataValues["TURN_STARTED_AT_UNIX_MS_KEY"],
+		ParentThreadID:      metadataValues["PARENT_THREAD_ID_KEY"],
+		ParentTurnID:        metadataValues["PARENT_TURN_ID_KEY"],
+		SubagentKind:        metadataValues["SUBAGENT_KIND_KEY"],
+	}
+	if errValidate := validateCodexFingerprintProfile(candidate); errValidate != nil {
+		return CodexFingerprintProfile{}, errValidate
+	}
+	return candidate, nil
+}
+
+func fetchCodexFingerprintSource(ctx context.Context, client *http.Client, sourceURL, label string) ([]byte, error) {
+	req, errRequest := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimSpace(sourceURL), nil)
+	if errRequest != nil {
+		return nil, fmt.Errorf("create %s request: %w", label, errRequest)
+	}
+	req.Header.Set("Accept", "application/json,text/plain")
+	req.Header.Set("User-Agent", "CLIProxyAPI-Codex-Fingerprint")
+	resp, errDo := client.Do(req)
+	if errDo != nil {
+		return nil, fmt.Errorf("fetch %s: %w", label, errDo)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Debugf("close %s response failed: %v", label, errClose)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch %s returned %s", label, resp.Status)
+	}
+	data, errRead := io.ReadAll(io.LimitReader(resp.Body, maxCodexFingerprintSourceSize+1))
+	if errRead != nil {
+		return nil, fmt.Errorf("read %s: %w", label, errRead)
+	}
+	if len(data) > maxCodexFingerprintSourceSize {
+		return nil, fmt.Errorf("%s exceeded %d bytes", label, maxCodexFingerprintSourceSize)
+	}
+	return data, nil
+}
+
+func extractRustStringConstant(source []byte, name string) (string, error) {
+	pattern := "(?m)(?:pub(?:\\(crate\\))?\\s+)?const\\s+" + regexp.QuoteMeta(name) + "\\s*:\\s*&str\\s*=\\s*\"([^\"]+)\"\\s*;"
+	matches := regexp.MustCompile(pattern).FindSubmatch(source)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("official Codex source is missing %s", name)
+	}
+	value := strings.TrimSpace(string(matches[1]))
+	if value == "" {
+		return "", fmt.Errorf("official Codex source constant %s is empty", name)
+	}
+	return value, nil
+}

--- a/internal/registry/codex_fingerprint_updater_test.go
+++ b/internal/registry/codex_fingerprint_updater_test.go
@@ -37,6 +37,9 @@ func TestCodexFingerprintUpdaterBuildsCompleteProfile(t *testing.T) {
 	if profile.Headers.ParentThreadID != "x-codex-parent-thread-id" {
 		t.Fatalf("parent thread header = %q", profile.Headers.ParentThreadID)
 	}
+	if profile.Headers.SessionID != "session-id" || profile.Headers.ThreadID != "thread-id" {
+		t.Fatalf("session/thread headers = %q/%q", profile.Headers.SessionID, profile.Headers.ThreadID)
+	}
 	if profile.MetadataKeys.TurnStartedAtUnixMS != "turn_started_at_unix_ms" {
 		t.Fatalf("turn start metadata key = %q", profile.MetadataKeys.TurnStartedAtUnixMS)
 	}
@@ -109,12 +112,40 @@ func TestCodexFingerprintUpdaterUnchangedProfileKeepsRevision(t *testing.T) {
 	}
 }
 
+func TestPinCodexFingerprintSourcesToRevision(t *testing.T) {
+	t.Parallel()
+
+	sources := codexFingerprintSourceSet{
+		DefaultClientURL:     "https://raw.githubusercontent.com/openai/codex/main/codex-rs/login/src/auth/default_client.rs",
+		ClientURL:            "https://raw.githubusercontent.com/openai/codex/main/codex-rs/core/src/client.rs",
+		ResponsesMetadataURL: "https://raw.githubusercontent.com/openai/codex/main/codex-rs/core/src/responses_metadata.rs",
+		RequestHeadersURL:    "https://raw.githubusercontent.com/openai/codex/main/codex-rs/codex-api/src/requests/headers.rs",
+		DistTagsURL:          "https://registry.npmjs.org/-/package/@openai%2Fcodex/dist-tags",
+	}
+
+	pinned := pinCodexFingerprintSourcesToRevision(sources, "0123456789abcdef")
+	for name, sourceURL := range map[string]string{
+		"default client":     pinned.DefaultClientURL,
+		"client":             pinned.ClientURL,
+		"responses metadata": pinned.ResponsesMetadataURL,
+		"request headers":    pinned.RequestHeadersURL,
+	} {
+		if !strings.Contains(sourceURL, "/openai/codex/0123456789abcdef/") {
+			t.Fatalf("%s URL was not pinned: %s", name, sourceURL)
+		}
+	}
+	if pinned.DistTagsURL != sources.DistTagsURL {
+		t.Fatalf("NPM URL changed: %s", pinned.DistTagsURL)
+	}
+}
+
 func codexFingerprintFixtureSources(baseURL string) codexFingerprintSourceSet {
 	return codexFingerprintSourceSet{
 		DistTagsURL:          baseURL + "/npm",
 		DefaultClientURL:     baseURL + "/default-client",
 		ClientURL:            baseURL + "/client",
 		ResponsesMetadataURL: baseURL + "/responses-metadata",
+		RequestHeadersURL:    baseURL + "/request-headers",
 		CommitURL:            baseURL + "/commit",
 	}
 }
@@ -159,6 +190,18 @@ pub(crate) const TURN_STARTED_AT_UNIX_MS_KEY: &str = "turn_started_at_unix_ms";
 pub(crate) const PARENT_THREAD_ID_KEY: &str = "parent_thread_id";
 pub(crate) const PARENT_TURN_ID_KEY: &str = "parent_turn_id";
 pub(crate) const SUBAGENT_KIND_KEY: &str = "subagent_kind";`)
+		case "/request-headers":
+			fmt.Fprint(w, `
+pub fn build_session_headers(session_id: Option<String>, thread_id: Option<String>) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    if let Some(id) = session_id {
+        insert_header(&mut headers, "session-id", &id);
+    }
+    if let Some(id) = thread_id {
+        insert_header(&mut headers, "thread-id", &id);
+    }
+    headers
+}`)
 		case "/commit":
 			fmt.Fprint(w, `{"sha":"0123456789abcdef0123456789abcdef01234567"}`)
 		case "/missing-originator":

--- a/internal/registry/codex_fingerprint_updater_test.go
+++ b/internal/registry/codex_fingerprint_updater_test.go
@@ -1,0 +1,172 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCodexFingerprintUpdaterBuildsCompleteProfile(t *testing.T) {
+	server := newCodexFingerprintFixtureServer(t, nil)
+	defer server.Close()
+
+	profile, err := fetchCodexFingerprintProfile(
+		context.Background(),
+		server.Client(),
+		codexFingerprintFixtureSources(server.URL),
+		validTestCodexFingerprintProfile(),
+	)
+	if err != nil {
+		t.Fatalf("fetchCodexFingerprintProfile() error = %v", err)
+	}
+	if profile.Version != "0.147.0" {
+		t.Fatalf("version = %q, want 0.147.0", profile.Version)
+	}
+	if profile.SourceRevision != "0123456789abcdef0123456789abcdef01234567" {
+		t.Fatalf("source revision = %q", profile.SourceRevision)
+	}
+	if profile.Originator != "codex_cli_rs" {
+		t.Fatalf("originator = %q", profile.Originator)
+	}
+	if profile.WebsocketBeta != "responses_websockets=2026-03-01" {
+		t.Fatalf("websocket beta = %q", profile.WebsocketBeta)
+	}
+	if profile.Headers.ParentThreadID != "x-codex-parent-thread-id" {
+		t.Fatalf("parent thread header = %q", profile.Headers.ParentThreadID)
+	}
+	if profile.MetadataKeys.TurnStartedAtUnixMS != "turn_started_at_unix_ms" {
+		t.Fatalf("turn start metadata key = %q", profile.MetadataKeys.TurnStartedAtUnixMS)
+	}
+	if err = validateCodexFingerprintProfile(profile); err != nil {
+		t.Fatalf("updated profile validation error = %v", err)
+	}
+}
+
+func TestCodexFingerprintUpdaterRejectsPartialSourceFailure(t *testing.T) {
+	server := newCodexFingerprintFixtureServer(t, map[string]int{"/client": http.StatusBadGateway})
+	defer server.Close()
+
+	_, err := fetchCodexFingerprintProfile(
+		context.Background(),
+		server.Client(),
+		codexFingerprintFixtureSources(server.URL),
+		validTestCodexFingerprintProfile(),
+	)
+	if err == nil || !strings.Contains(err.Error(), "client source") {
+		t.Fatalf("fetch error = %v, want client source failure", err)
+	}
+}
+
+func TestCodexFingerprintUpdaterRejectsMalformedOfficialContract(t *testing.T) {
+	server := newCodexFingerprintFixtureServer(t, nil)
+	defer server.Close()
+	sources := codexFingerprintFixtureSources(server.URL)
+	sources.DefaultClientURL = server.URL + "/missing-originator"
+
+	_, err := fetchCodexFingerprintProfile(
+		context.Background(),
+		server.Client(),
+		sources,
+		validTestCodexFingerprintProfile(),
+	)
+	if err == nil || !strings.Contains(err.Error(), "DEFAULT_ORIGINATOR") {
+		t.Fatalf("fetch error = %v, want missing DEFAULT_ORIGINATOR", err)
+	}
+}
+
+func TestCodexFingerprintUpdaterRejectsOversizedSource(t *testing.T) {
+	server := newCodexFingerprintFixtureServer(t, nil)
+	defer server.Close()
+	sources := codexFingerprintFixtureSources(server.URL)
+	sources.ClientURL = server.URL + "/oversized"
+
+	_, err := fetchCodexFingerprintProfile(
+		context.Background(),
+		server.Client(),
+		sources,
+		validTestCodexFingerprintProfile(),
+	)
+	if err == nil || !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("fetch error = %v, want source size error", err)
+	}
+}
+
+func TestCodexFingerprintUpdaterUnchangedProfileKeepsRevision(t *testing.T) {
+	profile := validTestCodexFingerprintProfile()
+	store := newCodexFingerprintProfileStore(profile)
+	changed, err := store.update(profile)
+	if err != nil {
+		t.Fatalf("store.update() error = %v", err)
+	}
+	if changed {
+		t.Fatal("store.update() changed = true, want false")
+	}
+	if _, revision := store.snapshot(); revision != 1 {
+		t.Fatalf("revision = %d, want 1", revision)
+	}
+}
+
+func codexFingerprintFixtureSources(baseURL string) codexFingerprintSourceSet {
+	return codexFingerprintSourceSet{
+		DistTagsURL:          baseURL + "/npm",
+		DefaultClientURL:     baseURL + "/default-client",
+		ClientURL:            baseURL + "/client",
+		ResponsesMetadataURL: baseURL + "/responses-metadata",
+		CommitURL:            baseURL + "/commit",
+	}
+}
+
+func newCodexFingerprintFixtureServer(t *testing.T, statuses map[string]int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if status := statuses[r.URL.Path]; status != 0 {
+			http.Error(w, http.StatusText(status), status)
+			return
+		}
+		switch r.URL.Path {
+		case "/npm":
+			fmt.Fprint(w, `{"latest":"0.147.0"}`)
+		case "/default-client":
+			fmt.Fprint(w, `
+pub const DEFAULT_ORIGINATOR: &str = "codex_cli_rs";
+pub fn get_codex_user_agent() -> String {
+    let build_version = env!("CARGO_PKG_VERSION");
+    format!("{}/{build_version}", DEFAULT_ORIGINATOR)
+}`)
+		case "/client":
+			fmt.Fprint(w, `
+pub const X_CODEX_INSTALLATION_ID_HEADER: &str = "x-codex-installation-id";
+pub const X_CODEX_TURN_STATE_HEADER: &str = "x-codex-turn-state";
+pub const X_CODEX_TURN_METADATA_HEADER: &str = "x-codex-turn-metadata";
+pub const X_CODEX_PARENT_THREAD_ID_HEADER: &str = "x-codex-parent-thread-id";
+pub const X_CODEX_WINDOW_ID_HEADER: &str = "x-codex-window-id";
+pub const X_OPENAI_SUBAGENT_HEADER: &str = "x-openai-subagent";
+pub const X_RESPONSESAPI_INCLUDE_TIMING_METRICS_HEADER: &str = "x-responsesapi-include-timing-metrics";
+const RESPONSES_WEBSOCKETS_V2_BETA_HEADER_VALUE: &str = "responses_websockets=2026-03-01";
+headers.insert("x-client-request-id", header_value);`)
+		case "/responses-metadata":
+			fmt.Fprint(w, `
+pub(crate) const INSTALLATION_ID_KEY: &str = "installation_id";
+pub(crate) const SESSION_ID_KEY: &str = "session_id";
+pub(crate) const THREAD_ID_KEY: &str = "thread_id";
+pub(crate) const TURN_ID_KEY: &str = "turn_id";
+pub(crate) const WINDOW_ID_KEY: &str = "window_id";
+pub(crate) const REQUEST_KIND_KEY: &str = "request_kind";
+pub(crate) const TURN_STARTED_AT_UNIX_MS_KEY: &str = "turn_started_at_unix_ms";
+pub(crate) const PARENT_THREAD_ID_KEY: &str = "parent_thread_id";
+pub(crate) const PARENT_TURN_ID_KEY: &str = "parent_turn_id";
+pub(crate) const SUBAGENT_KIND_KEY: &str = "subagent_kind";`)
+		case "/commit":
+			fmt.Fprint(w, `{"sha":"0123456789abcdef0123456789abcdef01234567"}`)
+		case "/missing-originator":
+			fmt.Fprint(w, `pub fn get_codex_user_agent() -> String { env!("CARGO_PKG_VERSION").to_string() }`)
+		case "/oversized":
+			fmt.Fprint(w, strings.Repeat("x", maxCodexFingerprintSourceSize+1))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -1,6 +1,9 @@
 package registry
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestModelOverrideHeadersFromEmbeddedModels(t *testing.T) {
 	const wantUA = "codex-tui/0.144.0 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.144.0)"
@@ -13,6 +16,75 @@ func TestModelOverrideHeadersFromEmbeddedModels(t *testing.T) {
 	}
 	if got := ModelOverrideHeaders("gpt-5.4"); got != nil {
 		t.Fatalf("ModelOverrideHeaders(gpt-5.4) = %#v, want nil", got)
+	}
+}
+
+func TestCodexGPT56ThinkingLevelsMatchOfficialManifest(t *testing.T) {
+	withUltra := []string{"low", "medium", "high", "xhigh", "max", "ultra"}
+	withoutUltra := []string{"low", "medium", "high", "xhigh", "max"}
+	tiers := []struct {
+		name   string
+		models []*ModelInfo
+		want   map[string][]string
+	}{
+		{
+			name:   "free",
+			models: GetCodexFreeModels(),
+			want: map[string][]string{
+				"gpt-5.6-terra": withUltra,
+				"gpt-5.6-luna":  withoutUltra,
+			},
+		},
+		{
+			name:   "team",
+			models: GetCodexTeamModels(),
+			want: map[string][]string{
+				"gpt-5.6-sol":   withUltra,
+				"gpt-5.6-terra": withUltra,
+				"gpt-5.6-luna":  withoutUltra,
+			},
+		},
+		{
+			name:   "plus",
+			models: GetCodexPlusModels(),
+			want: map[string][]string{
+				"gpt-5.6-sol":   withUltra,
+				"gpt-5.6-terra": withUltra,
+				"gpt-5.6-luna":  withoutUltra,
+			},
+		},
+		{
+			name:   "pro",
+			models: GetCodexProModels(),
+			want: map[string][]string{
+				"gpt-5.6-sol":   withUltra,
+				"gpt-5.6-terra": withUltra,
+				"gpt-5.6-luna":  withoutUltra,
+			},
+		},
+	}
+
+	for _, tier := range tiers {
+		t.Run(tier.name, func(t *testing.T) {
+			byID := make(map[string]*ModelInfo, len(tier.models))
+			for _, model := range tier.models {
+				if model != nil {
+					byID[model.ID] = model
+				}
+			}
+			for modelID, wantLevels := range tier.want {
+				model := byID[modelID]
+				if model == nil {
+					t.Fatalf("model %q is missing", modelID)
+				}
+				if model.Thinking == nil {
+					t.Fatalf("model %q thinking support = nil", modelID)
+				}
+				if !slices.Equal(model.Thinking.Levels, wantLevels) {
+					t.Fatalf("model %q thinking levels = %v, want %v", modelID, model.Thinking.Levels, wantLevels)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/registry/models/codex_fingerprint_profile.json
+++ b/internal/registry/models/codex_fingerprint_profile.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_revision": "483559cc758353c83733b2b34629dbf885a99207",
+  "source_revision": "ba42e6866cef4baed7ad92c73e6be8cd42e49d8b",
   "version": "0.146.0",
   "originator": "codex_cli_rs",
   "user_agent_template": "{originator}/{version} (Mac OS 26.5.2; arm64) Apple_Terminal/470 (codex-tui; {version})",
@@ -14,8 +14,8 @@
     "subagent": "x-openai-subagent",
     "timing_metrics": "x-responsesapi-include-timing-metrics",
     "client_request_id": "x-client-request-id",
-    "session_id": "session_id",
-    "thread_id": "thread_id"
+    "session_id": "session-id",
+    "thread_id": "thread-id"
   },
   "metadata_keys": {
     "installation_id": "installation_id",

--- a/internal/registry/models/codex_fingerprint_profile.json
+++ b/internal/registry/models/codex_fingerprint_profile.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "source_revision": "483559cc758353c83733b2b34629dbf885a99207",
+  "version": "0.146.0",
+  "originator": "codex_cli_rs",
+  "user_agent_template": "{originator}/{version} (Mac OS 26.5.2; arm64) Apple_Terminal/470 (codex-tui; {version})",
+  "websocket_beta": "responses_websockets=2026-02-06",
+  "headers": {
+    "installation_id": "x-codex-installation-id",
+    "turn_state": "x-codex-turn-state",
+    "turn_metadata": "x-codex-turn-metadata",
+    "parent_thread_id": "x-codex-parent-thread-id",
+    "window_id": "x-codex-window-id",
+    "subagent": "x-openai-subagent",
+    "timing_metrics": "x-responsesapi-include-timing-metrics",
+    "client_request_id": "x-client-request-id",
+    "session_id": "session_id",
+    "thread_id": "thread_id"
+  },
+  "metadata_keys": {
+    "installation_id": "installation_id",
+    "session_id": "session_id",
+    "thread_id": "thread_id",
+    "turn_id": "turn_id",
+    "window_id": "window_id",
+    "request_kind": "request_kind",
+    "turn_started_at_unix_ms": "turn_started_at_unix_ms",
+    "parent_thread_id": "parent_thread_id",
+    "parent_turn_id": "parent_turn_id",
+    "subagent_kind": "subagent_kind"
+  }
+}

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -1680,7 +1680,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       }
     },
@@ -1828,7 +1829,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       }
     },
@@ -1852,7 +1854,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       }
     },
@@ -2023,7 +2026,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       }
     },
@@ -2047,7 +2051,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       }
     },
@@ -2218,7 +2223,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       }
     },
@@ -2242,7 +2248,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       }
     },

--- a/internal/runtime/executor/codex_executor_cache_test.go
+++ b/internal/runtime/executor/codex_executor_cache_test.go
@@ -79,7 +79,7 @@ func TestCodexOfficialFingerprintCacheHelperIntegration(t *testing.T) {
 	}
 	req := cliproxyexecutor.Request{
 		Model:   "gpt-5.6-sol",
-		Payload: []byte(`{"prompt_cache_key":"cache-integration-session"}`),
+		Payload: []byte(`{"prompt_cache_key":"cache-integration-session","metadata":{"source":"client"},"client_metadata":{"custom-key":"preserved"}}`),
 	}
 	httpReq, body, identityState, err := executor.cacheHelper(
 		context.Background(),
@@ -97,12 +97,60 @@ func TestCodexOfficialFingerprintCacheHelperIntegration(t *testing.T) {
 		t.Fatal("cacheHelper() did not assemble official application identity")
 	}
 	profile := registry.GetCodexFingerprintProfile()
+	if gjson.GetBytes(body, "metadata").Exists() {
+		t.Fatalf("cacheHelper() body retained unsupported metadata: %s", body)
+	}
+	if got := gjson.GetBytes(body, "client_metadata.custom-key").String(); got != "preserved" {
+		t.Fatalf("cacheHelper() client_metadata.custom-key = %q, want preserved", got)
+	}
 	if got := gjson.GetBytes(body, "client_metadata."+profile.Headers.InstallationID).String(); got == "" {
 		t.Fatal("cacheHelper() body is missing installation identity")
 	}
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	if got := httpReq.Header.Get(profile.Headers.WindowID); got != identityState.application.windowID {
 		t.Fatalf("window header = %q, want %q", got, identityState.application.windowID)
+	}
+}
+
+func TestCodexOfficialFingerprintCompactCacheHelperIntegration(t *testing.T) {
+	executor := &CodexExecutor{cfg: &config.Config{}}
+	auth := &cliproxyauth.Auth{
+		ID:       "oauth-compact-integration",
+		Metadata: map[string]any{"access_token": "oauth-token"},
+	}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5.6-sol",
+		Payload: []byte(`{"prompt_cache_key":"compact-integration-session","metadata":{"source":"client"},"client_metadata":{"custom-key":"drop"}}`),
+	}
+	httpReq, body, identityState, err := executor.cacheHelper(
+		context.Background(),
+		sdktranslator.FormatOpenAIResponse,
+		"https://chatgpt.com/backend-api/codex/responses/compact",
+		auth,
+		req,
+		req.Payload,
+		req.Payload,
+	)
+	if err != nil {
+		t.Fatalf("cacheHelper() error = %v", err)
+	}
+	if !identityState.application.enabled {
+		t.Fatal("cacheHelper() did not assemble official compact application identity")
+	}
+	if gjson.GetBytes(body, "metadata").Exists() {
+		t.Fatalf("compact body retained unsupported metadata: %s", body)
+	}
+	if gjson.GetBytes(body, "client_metadata").Exists() {
+		t.Fatalf("compact body retained unsupported client_metadata: %s", body)
+	}
+
+	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
+	profile := registry.GetCodexFingerprintProfile()
+	if got := httpReq.Header.Get(profile.Headers.InstallationID); got != identityState.application.installationID {
+		t.Fatalf("compact installation header = %q, want %q", got, identityState.application.installationID)
+	}
+	if got := httpReq.Header.Get(profile.Headers.TurnMetadata); got != identityState.application.turnMetadataJSON {
+		t.Fatalf("compact turn metadata header = %q, want %q", got, identityState.application.turnMetadataJSON)
 	}
 }
 

--- a/internal/runtime/executor/codex_executor_cache_test.go
+++ b/internal/runtime/executor/codex_executor_cache_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -67,6 +68,41 @@ func TestCodexExecutorCacheHelper_OpenAIChatCompletions_StablePromptCacheKeyFrom
 	gotKey2 := gjson.GetBytes(body2, "prompt_cache_key").String()
 	if gotKey2 != expectedKey {
 		t.Fatalf("prompt_cache_key (second call) = %q, want %q", gotKey2, expectedKey)
+	}
+}
+
+func TestCodexOfficialFingerprintCacheHelperIntegration(t *testing.T) {
+	executor := &CodexExecutor{cfg: &config.Config{}}
+	auth := &cliproxyauth.Auth{
+		ID:       "oauth-cache-integration",
+		Metadata: map[string]any{"access_token": "oauth-token"},
+	}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5.6-sol",
+		Payload: []byte(`{"prompt_cache_key":"cache-integration-session"}`),
+	}
+	httpReq, body, identityState, err := executor.cacheHelper(
+		context.Background(),
+		sdktranslator.FormatOpenAIResponse,
+		"https://chatgpt.com/backend-api/codex/responses",
+		auth,
+		req,
+		req.Payload,
+		req.Payload,
+	)
+	if err != nil {
+		t.Fatalf("cacheHelper() error = %v", err)
+	}
+	if !identityState.application.enabled {
+		t.Fatal("cacheHelper() did not assemble official application identity")
+	}
+	profile := registry.GetCodexFingerprintProfile()
+	if got := gjson.GetBytes(body, "client_metadata."+profile.Headers.InstallationID).String(); got == "" {
+		t.Fatal("cacheHelper() body is missing installation identity")
+	}
+	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
+	if got := httpReq.Header.Get(profile.Headers.WindowID); got != identityState.application.windowID {
+		t.Fatalf("window header = %q, want %q", got, identityState.application.windowID)
 	}
 }
 

--- a/internal/runtime/executor/codex_executor_cache_test.go
+++ b/internal/runtime/executor/codex_executor_cache_test.go
@@ -79,7 +79,7 @@ func TestCodexOfficialFingerprintCacheHelperIntegration(t *testing.T) {
 	}
 	req := cliproxyexecutor.Request{
 		Model:   "gpt-5.6-sol",
-		Payload: []byte(`{"prompt_cache_key":"cache-integration-session","metadata":{"source":"client"},"client_metadata":{"custom-key":"preserved"}}`),
+		Payload: []byte(`{"prompt_cache_key":"cache-integration-session","reasoning":{"effort":"ultra"},"metadata":{"source":"client"},"client_metadata":{"custom-key":"preserved"}}`),
 	}
 	httpReq, body, identityState, err := executor.cacheHelper(
 		context.Background(),
@@ -103,6 +103,9 @@ func TestCodexOfficialFingerprintCacheHelperIntegration(t *testing.T) {
 	if got := gjson.GetBytes(body, "client_metadata.custom-key").String(); got != "preserved" {
 		t.Fatalf("cacheHelper() client_metadata.custom-key = %q, want preserved", got)
 	}
+	if got := gjson.GetBytes(body, "reasoning.effort").String(); got != "ultra" {
+		t.Fatalf("cacheHelper() reasoning.effort = %q, want ultra", got)
+	}
 	if got := gjson.GetBytes(body, "client_metadata."+profile.Headers.InstallationID).String(); got == "" {
 		t.Fatal("cacheHelper() body is missing installation identity")
 	}
@@ -120,7 +123,7 @@ func TestCodexOfficialFingerprintCompactCacheHelperIntegration(t *testing.T) {
 	}
 	req := cliproxyexecutor.Request{
 		Model:   "gpt-5.6-sol",
-		Payload: []byte(`{"prompt_cache_key":"compact-integration-session","metadata":{"source":"client"},"client_metadata":{"custom-key":"drop"}}`),
+		Payload: []byte(`{"prompt_cache_key":"compact-integration-session","reasoning":{"effort":"ultra"},"metadata":{"source":"client"},"client_metadata":{"custom-key":"drop"}}`),
 	}
 	httpReq, body, identityState, err := executor.cacheHelper(
 		context.Background(),
@@ -143,6 +146,9 @@ func TestCodexOfficialFingerprintCompactCacheHelperIntegration(t *testing.T) {
 	if gjson.GetBytes(body, "client_metadata").Exists() {
 		t.Fatalf("compact body retained unsupported client_metadata: %s", body)
 	}
+	if got := gjson.GetBytes(body, "reasoning.effort").String(); got != "xhigh" {
+		t.Fatalf("compact reasoning.effort = %q, want xhigh; body=%s", got, body)
+	}
 
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	profile := registry.GetCodexFingerprintProfile()
@@ -151,6 +157,85 @@ func TestCodexOfficialFingerprintCompactCacheHelperIntegration(t *testing.T) {
 	}
 	if got := httpReq.Header.Get(profile.Headers.TurnMetadata); got != identityState.application.turnMetadataJSON {
 		t.Fatalf("compact turn metadata header = %q, want %q", got, identityState.application.turnMetadataJSON)
+	}
+}
+
+func TestCodexUpstreamMetadataNormalizationByTarget(t *testing.T) {
+	oauth := &cliproxyauth.Auth{
+		ID:       "oauth-normalization",
+		Metadata: map[string]any{"access_token": "oauth-token"},
+	}
+	apiKey := &cliproxyauth.Auth{
+		ID:         "api-key-normalization",
+		Attributes: map[string]string{"api_key": "test-key"},
+	}
+	tests := []struct {
+		name               string
+		auth               *cliproxyauth.Auth
+		url                string
+		effort             string
+		wantEffort         string
+		wantClientMetadata bool
+	}{
+		{
+			name:               "official OAuth turn preserves client metadata and ultra",
+			auth:               oauth,
+			url:                "https://chatgpt.com/backend-api/codex/responses",
+			effort:             "ultra",
+			wantEffort:         "ultra",
+			wantClientMetadata: true,
+		},
+		{
+			name:       "official OAuth compact caps ultra",
+			auth:       oauth,
+			url:        "https://chatgpt.com/backend-api/codex/responses/compact",
+			effort:     "ultra",
+			wantEffort: "xhigh",
+		},
+		{
+			name:       "official OAuth compact caps max",
+			auth:       oauth,
+			url:        "https://chatgpt.com/backend-api/codex/responses/compact",
+			effort:     "max",
+			wantEffort: "xhigh",
+		},
+		{
+			name:       "public API removes client metadata",
+			auth:       apiKey,
+			url:        "https://api.openai.com/v1/responses",
+			effort:     "max",
+			wantEffort: "max",
+		},
+		{
+			name:       "custom upstream removes client metadata",
+			auth:       apiKey,
+			url:        "https://example.com/responses",
+			effort:     "max",
+			wantEffort: "max",
+		},
+		{
+			name:       "API key on official URL removes client metadata",
+			auth:       apiKey,
+			url:        "https://chatgpt.com/backend-api/codex/responses",
+			effort:     "max",
+			wantEffort: "max",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := []byte(`{"metadata":{"source":"client"},"client_metadata":{"custom-key":"value"},"reasoning":{"effort":"` + tc.effort + `"}}`)
+			got := normalizeCodexUpstreamRequestMetadata(tc.auth, tc.url, body)
+			if gjson.GetBytes(got, "metadata").Exists() {
+				t.Fatalf("body retained metadata: %s", got)
+			}
+			if exists := gjson.GetBytes(got, "client_metadata").Exists(); exists != tc.wantClientMetadata {
+				t.Fatalf("client_metadata exists = %t, want %t; body=%s", exists, tc.wantClientMetadata, got)
+			}
+			if effort := gjson.GetBytes(got, "reasoning.effort").String(); effort != tc.wantEffort {
+				t.Fatalf("reasoning.effort = %q, want %q; body=%s", effort, tc.wantEffort, got)
+			}
+		})
 	}
 }
 
@@ -272,7 +357,10 @@ func TestCodexExecutorCacheHelper_IdentityConfuseRemapsBodyAndHeaders(t *testing
 	ctx := context.WithValue(context.Background(), "gin", ginCtx)
 	executor := &CodexExecutor{cfg: &config.Config{
 		Routing: config.RoutingConfig{Strategy: "fill-first"},
-		Codex:   config.CodexConfig{IdentityConfuse: true},
+		Codex: config.CodexConfig{
+			IdentityConfuse:      true,
+			DisableCodexCloaking: true,
+		},
 	}}
 	auth := &cliproxyauth.Auth{ID: "auth-1", Provider: "codex"}
 	rawJSON := []byte(`{"model":"gpt-5-codex","stream":true,"client_metadata":{"x-codex-turn-metadata":"{\"prompt_cache_key\":\"cache-1\",\"turn_id\":\"turn-1\",\"window_id\":\"cache-1:0\"}","x-codex-window-id":"cache-1:0"}}`)
@@ -280,7 +368,7 @@ func TestCodexExecutorCacheHelper_IdentityConfuseRemapsBodyAndHeaders(t *testing
 		Model:   "gpt-5-codex",
 		Payload: []byte(`{"model":"gpt-5-codex","prompt_cache_key":"cache-1","client_metadata":{"x-codex-installation-id":"install-1"}}`),
 	}
-	url := "https://example.com/responses"
+	url := "https://chatgpt.com/backend-api/codex/responses"
 
 	httpReq, body, identityState, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai-response"), url, auth, req, req.Payload, rawJSON)
 	if err != nil {

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -88,6 +88,7 @@ type codexIdentityConfuseState struct {
 	originalPromptCacheKey string
 	promptCacheKey         string
 	turnIDs                []codexIdentityReplacement
+	application            codexApplicationIdentity
 }
 
 type codexIdentityReplacement struct {
@@ -144,6 +145,7 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 	if identityState.promptCacheKey != "" {
 		cache.ID = identityState.promptCacheKey
 	}
+	rawJSON, identityState.application = applyCodexOfficialApplicationIdentity(e.cfg, auth, url, rawJSON)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(rawJSON))
 	if err != nil {
 		return nil, nil, codexIdentityConfuseState{}, err
@@ -181,27 +183,24 @@ func applyCodexIdentityConfuseBody(cfg *config.Config, auth *cliproxyauth.Auth, 
 }
 
 func applyCodexIdentityConfuseHeaders(headers http.Header, state *codexIdentityConfuseState) {
-	if headers == nil {
+	if headers == nil || state == nil {
 		return
 	}
-	if state == nil || !state.enabled {
-		return
+	if state.enabled {
+		if rawTurnMetadata := strings.TrimSpace(headers.Get("X-Codex-Turn-Metadata")); rawTurnMetadata != "" {
+			headers.Set("X-Codex-Turn-Metadata", applyCodexTurnMetadataIdentityConfuse(rawTurnMetadata, state))
+		}
+		if state.promptCacheKey != "" {
+			setCodexSessionHeaderCasePreserved(headers, "Session_id", state.promptCacheKey)
+			if headerValueCaseInsensitive(headers, "Conversation_id") != "" {
+				setHeaderCasePreserved(headers, "Conversation_id", state.promptCacheKey)
+			}
+			headers.Set("X-Client-Request-Id", state.promptCacheKey)
+			headers.Set("Thread-Id", state.promptCacheKey)
+			headers.Set("X-Codex-Window-Id", state.promptCacheKey+":0")
+		}
 	}
-
-	if rawTurnMetadata := strings.TrimSpace(headers.Get("X-Codex-Turn-Metadata")); rawTurnMetadata != "" {
-		headers.Set("X-Codex-Turn-Metadata", applyCodexTurnMetadataIdentityConfuse(rawTurnMetadata, state))
-	}
-	if state.promptCacheKey == "" {
-		return
-	}
-
-	setCodexSessionHeaderCasePreserved(headers, "Session_id", state.promptCacheKey)
-	if headerValueCaseInsensitive(headers, "Conversation_id") != "" {
-		setHeaderCasePreserved(headers, "Conversation_id", state.promptCacheKey)
-	}
-	headers.Set("X-Client-Request-Id", state.promptCacheKey)
-	headers.Set("Thread-Id", state.promptCacheKey)
-	headers.Set("X-Codex-Window-Id", state.promptCacheKey+":0")
+	applyCodexOfficialApplicationIdentityHeaders(headers, &state.application)
 }
 
 func applyCodexTurnMetadataIdentityConfuse(rawTurnMetadata string, state *codexIdentityConfuseState) string {

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -146,7 +146,7 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 		cache.ID = identityState.promptCacheKey
 	}
 	rawJSON, identityState.application = applyCodexOfficialApplicationIdentity(e.cfg, auth, url, rawJSON)
-	rawJSON = normalizeCodexUpstreamRequestMetadata(url, rawJSON)
+	rawJSON = normalizeCodexUpstreamRequestMetadata(auth, url, rawJSON)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(rawJSON))
 	if err != nil {
 		return nil, nil, codexIdentityConfuseState{}, err
@@ -158,9 +158,10 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 }
 
 // normalizeCodexUpstreamRequestMetadata matches the request shapes used by the
-// official Codex client. Responses requests carry client_metadata but not the
-// public Responses metadata field, while compact requests carry neither.
-func normalizeCodexUpstreamRequestMetadata(requestURL string, body []byte) []byte {
+// official Codex client. Official OAuth turn requests carry client_metadata but
+// not the public Responses metadata field, while other targets and compact
+// requests carry neither.
+func normalizeCodexUpstreamRequestMetadata(auth *cliproxyauth.Auth, requestURL string, body []byte) []byte {
 	if len(body) == 0 {
 		return body
 	}
@@ -168,9 +169,18 @@ func normalizeCodexUpstreamRequestMetadata(requestURL string, body []byte) []byt
 	if updated, errDelete := sjson.DeleteBytes(body, "metadata"); errDelete == nil {
 		body = updated
 	}
-	if codexApplicationRequestKind(requestURL) == "compaction" {
+	requestKind := codexApplicationRequestKind(requestURL)
+	if requestKind == "compaction" || !codexOfficialApplicationTarget(auth, requestURL) {
 		if updated, errDelete := sjson.DeleteBytes(body, "client_metadata"); errDelete == nil {
 			body = updated
+		}
+	}
+	if requestKind == "compaction" {
+		switch strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "reasoning.effort").String())) {
+		case string(thinking.LevelMax), string(thinking.LevelUltra):
+			if updated, errSet := sjson.SetBytes(body, "reasoning.effort", string(thinking.LevelXHigh)); errSet == nil {
+				body = updated
+			}
 		}
 	}
 	return body

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -146,6 +146,7 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 		cache.ID = identityState.promptCacheKey
 	}
 	rawJSON, identityState.application = applyCodexOfficialApplicationIdentity(e.cfg, auth, url, rawJSON)
+	rawJSON = normalizeCodexUpstreamRequestMetadata(url, rawJSON)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(rawJSON))
 	if err != nil {
 		return nil, nil, codexIdentityConfuseState{}, err
@@ -154,6 +155,25 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 		httpReq.Header.Set("Session_id", cache.ID)
 	}
 	return httpReq, rawJSON, identityState, nil
+}
+
+// normalizeCodexUpstreamRequestMetadata matches the request shapes used by the
+// official Codex client. Responses requests carry client_metadata but not the
+// public Responses metadata field, while compact requests carry neither.
+func normalizeCodexUpstreamRequestMetadata(requestURL string, body []byte) []byte {
+	if len(body) == 0 {
+		return body
+	}
+
+	if updated, errDelete := sjson.DeleteBytes(body, "metadata"); errDelete == nil {
+		body = updated
+	}
+	if codexApplicationRequestKind(requestURL) == "compaction" {
+		if updated, errDelete := sjson.DeleteBytes(body, "client_metadata"); errDelete == nil {
+			body = updated
+		}
+	}
+	return body
 }
 
 func applyCodexIdentityConfuseBody(cfg *config.Config, auth *cliproxyauth.Auth, userPayload []byte, rawJSON []byte) ([]byte, codexIdentityConfuseState) {

--- a/internal/runtime/executor/codex_fingerprint.go
+++ b/internal/runtime/executor/codex_fingerprint.go
@@ -163,7 +163,9 @@ func applyCodexOfficialApplicationIdentityHeaders(headers http.Header, identity 
 	}
 	setCodexSessionHeaderCasePreserved(headers, profile.Headers.SessionID, identity.sessionID)
 	setHeaderCasePreserved(headers, profile.Headers.ThreadID, identity.threadID)
-	headers.Set(profile.Headers.ClientRequestID, identity.threadID)
+	if identity.websocket {
+		headers.Set(profile.Headers.ClientRequestID, identity.threadID)
+	}
 	headers.Set(profile.Headers.WindowID, identity.windowID)
 	headers.Set(profile.Headers.TurnMetadata, identity.turnMetadataJSON)
 	if identity.requestKind == "compaction" {

--- a/internal/runtime/executor/codex_fingerprint.go
+++ b/internal/runtime/executor/codex_fingerprint.go
@@ -94,7 +94,10 @@ func applyCodexOfficialApplicationIdentity(
 	if parentThreadID == "" {
 		parentThreadID, _ = turnMetadata[profile.MetadataKeys.ParentThreadID].(string)
 	}
-	parentTurnID, _ := turnMetadata[profile.MetadataKeys.ParentTurnID].(string)
+	parentTurnID := clientMetadataString(body, profile.MetadataKeys.ParentTurnID)
+	if parentTurnID == "" {
+		parentTurnID, _ = turnMetadata[profile.MetadataKeys.ParentTurnID].(string)
+	}
 	subagentKind := clientMetadataString(body, profile.Headers.Subagent)
 	if subagentKind == "" {
 		subagentKind, _ = turnMetadata[profile.MetadataKeys.SubagentKind].(string)
@@ -131,6 +134,15 @@ func applyCodexOfficialApplicationIdentity(
 	body = setCodexClientMetadataString(body, profile.MetadataKeys.TurnID, turnID)
 	body = setCodexClientMetadataString(body, profile.Headers.WindowID, windowID)
 	body = setCodexClientMetadataString(body, profile.Headers.TurnMetadata, turnMetadataJSON)
+	if parentThreadID != "" {
+		body = setCodexClientMetadataString(body, profile.Headers.ParentThreadID, parentThreadID)
+	}
+	if parentTurnID != "" {
+		body = setCodexClientMetadataString(body, profile.MetadataKeys.ParentTurnID, parentTurnID)
+	}
+	if subagentKind != "" {
+		body = setCodexClientMetadataString(body, profile.Headers.Subagent, subagentKind)
+	}
 
 	return body, codexApplicationIdentity{
 		enabled:          true,

--- a/internal/runtime/executor/codex_fingerprint.go
+++ b/internal/runtime/executor/codex_fingerprint.go
@@ -203,6 +203,13 @@ func codexOfficialFingerprintScope(cfg *config.Config, auth *cliproxyauth.Auth, 
 	if cfg != nil && cfg.Codex.DisableCodexCloaking {
 		return false
 	}
+	return codexOfficialApplicationTarget(auth, requestURL)
+}
+
+func codexOfficialApplicationTarget(auth *cliproxyauth.Auth, requestURL string) bool {
+	if auth == nil {
+		return false
+	}
 	if auth.Attributes != nil {
 		if strings.TrimSpace(auth.Attributes["api_key"]) != "" ||
 			strings.TrimSpace(auth.Attributes["base_url"]) != "" {

--- a/internal/runtime/executor/codex_fingerprint.go
+++ b/internal/runtime/executor/codex_fingerprint.go
@@ -1,0 +1,267 @@
+package executor
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const codexApplicationWindowTTL = time.Hour
+
+type codexApplicationIdentity struct {
+	enabled          bool
+	profile          registry.CodexFingerprintProfile
+	installationID   string
+	sessionID        string
+	threadID         string
+	turnID           string
+	windowID         string
+	requestKind      string
+	turnStartedAtMS  int64
+	parentThreadID   string
+	parentTurnID     string
+	subagentKind     string
+	turnMetadataJSON string
+}
+
+type codexApplicationWindowEntry struct {
+	id        string
+	expiresAt time.Time
+}
+
+var codexApplicationWindows = struct {
+	sync.Mutex
+	entries map[string]codexApplicationWindowEntry
+}{entries: make(map[string]codexApplicationWindowEntry)}
+
+func applyCodexOfficialApplicationIdentity(
+	cfg *config.Config,
+	auth *cliproxyauth.Auth,
+	requestURL string,
+	body []byte,
+) ([]byte, codexApplicationIdentity) {
+	if !codexOfficialFingerprintScope(cfg, auth, requestURL) || len(body) == 0 {
+		return body, codexApplicationIdentity{}
+	}
+
+	profile := registry.GetCodexFingerprintProfile()
+	authIdentity := strings.TrimSpace(auth.ID)
+	turnMetadata := parseCodexTurnMetadata(body, profile)
+
+	sessionSeed := clientMetadataString(body, profile.MetadataKeys.SessionID)
+	if sessionSeed == "" {
+		sessionSeed = strings.TrimSpace(gjson.GetBytes(body, "prompt_cache_key").String())
+	}
+	sessionID := stableCodexApplicationUUID(authIdentity, "session", sessionSeed)
+
+	threadSeed := clientMetadataString(body, profile.MetadataKeys.ThreadID)
+	if threadSeed == "" {
+		threadSeed = sessionSeed
+	}
+	threadID := stableCodexApplicationUUID(authIdentity, "thread", threadSeed)
+
+	installationSeed := clientMetadataString(body, profile.Headers.InstallationID)
+	if installationSeed == "" {
+		installationSeed = authIdentity
+	}
+	installationID := stableCodexApplicationUUID(authIdentity, "installation", installationSeed)
+
+	windowID := clientMetadataString(body, profile.Headers.WindowID)
+	if parsed, errParse := uuid.Parse(windowID); errParse != nil || parsed.Version() != 7 {
+		windowID = cachedCodexApplicationWindow(authIdentity, sessionID)
+	}
+
+	turnID := clientMetadataString(body, profile.MetadataKeys.TurnID)
+	if turnID == "" {
+		turnID, _ = turnMetadata[profile.MetadataKeys.TurnID].(string)
+	}
+	if parsed, errParse := uuid.Parse(turnID); errParse != nil || parsed.Version() != 7 {
+		turnID = newCodexUUIDv7()
+	}
+
+	parentThreadID := clientMetadataString(body, profile.Headers.ParentThreadID)
+	if parentThreadID == "" {
+		parentThreadID, _ = turnMetadata[profile.MetadataKeys.ParentThreadID].(string)
+	}
+	parentTurnID, _ := turnMetadata[profile.MetadataKeys.ParentTurnID].(string)
+	subagentKind := clientMetadataString(body, profile.Headers.Subagent)
+	if subagentKind == "" {
+		subagentKind, _ = turnMetadata[profile.MetadataKeys.SubagentKind].(string)
+	}
+
+	requestKind := codexApplicationRequestKind(requestURL)
+	turnStartedAtMS := time.Now().UnixMilli()
+	if existing, ok := turnMetadata[profile.MetadataKeys.TurnStartedAtUnixMS].(float64); ok && existing > 0 {
+		turnStartedAtMS = int64(existing)
+	}
+
+	turnMetadata[profile.MetadataKeys.InstallationID] = installationID
+	turnMetadata[profile.MetadataKeys.SessionID] = sessionID
+	turnMetadata[profile.MetadataKeys.ThreadID] = threadID
+	turnMetadata[profile.MetadataKeys.TurnID] = turnID
+	turnMetadata[profile.MetadataKeys.WindowID] = windowID
+	turnMetadata[profile.MetadataKeys.RequestKind] = requestKind
+	turnMetadata[profile.MetadataKeys.TurnStartedAtUnixMS] = turnStartedAtMS
+	if parentThreadID != "" {
+		turnMetadata[profile.MetadataKeys.ParentThreadID] = parentThreadID
+	}
+	if parentTurnID != "" {
+		turnMetadata[profile.MetadataKeys.ParentTurnID] = parentTurnID
+	}
+	if subagentKind != "" {
+		turnMetadata[profile.MetadataKeys.SubagentKind] = subagentKind
+	}
+	turnMetadataJSONBytes, _ := json.Marshal(turnMetadata)
+	turnMetadataJSON := string(turnMetadataJSONBytes)
+
+	body = setCodexClientMetadataString(body, profile.Headers.InstallationID, installationID)
+	body = setCodexClientMetadataString(body, profile.MetadataKeys.SessionID, sessionID)
+	body = setCodexClientMetadataString(body, profile.MetadataKeys.ThreadID, threadID)
+	body = setCodexClientMetadataString(body, profile.MetadataKeys.TurnID, turnID)
+	body = setCodexClientMetadataString(body, profile.Headers.WindowID, windowID)
+	body = setCodexClientMetadataString(body, profile.Headers.TurnMetadata, turnMetadataJSON)
+
+	return body, codexApplicationIdentity{
+		enabled:          true,
+		profile:          profile,
+		installationID:   installationID,
+		sessionID:        sessionID,
+		threadID:         threadID,
+		turnID:           turnID,
+		windowID:         windowID,
+		requestKind:      requestKind,
+		turnStartedAtMS:  turnStartedAtMS,
+		parentThreadID:   parentThreadID,
+		parentTurnID:     parentTurnID,
+		subagentKind:     subagentKind,
+		turnMetadataJSON: turnMetadataJSON,
+	}
+}
+
+func applyCodexOfficialApplicationIdentityHeaders(headers http.Header, identity *codexApplicationIdentity) {
+	if headers == nil || identity == nil || !identity.enabled {
+		return
+	}
+	profile := identity.profile
+	setCodexSessionHeaderCasePreserved(headers, profile.Headers.SessionID, identity.sessionID)
+	setHeaderCasePreserved(headers, profile.Headers.ThreadID, identity.threadID)
+	headers.Set(profile.Headers.ClientRequestID, identity.threadID)
+	headers.Set(profile.Headers.WindowID, identity.windowID)
+	headers.Set(profile.Headers.TurnMetadata, identity.turnMetadataJSON)
+	if identity.requestKind == "compaction" {
+		headers.Set(profile.Headers.InstallationID, identity.installationID)
+	}
+	if identity.parentThreadID != "" {
+		headers.Set(profile.Headers.ParentThreadID, identity.parentThreadID)
+	}
+	if identity.subagentKind != "" {
+		headers.Set(profile.Headers.Subagent, identity.subagentKind)
+	}
+}
+
+func codexOfficialFingerprintScope(cfg *config.Config, auth *cliproxyauth.Auth, requestURL string) bool {
+	if auth == nil || strings.TrimSpace(auth.ID) == "" {
+		return false
+	}
+	if cfg != nil && cfg.Codex.DisableCodexCloaking {
+		return false
+	}
+	if auth.Attributes != nil {
+		if strings.TrimSpace(auth.Attributes["api_key"]) != "" ||
+			strings.TrimSpace(auth.Attributes["base_url"]) != "" {
+			return false
+		}
+	}
+	parsed, errParse := url.Parse(strings.TrimSpace(requestURL))
+	if errParse != nil || !strings.EqualFold(parsed.Hostname(), "chatgpt.com") {
+		return false
+	}
+	path := strings.TrimSuffix(parsed.Path, "/")
+	return path == "/backend-api/codex/responses" ||
+		path == "/backend-api/codex/responses/compact"
+}
+
+func codexApplicationRequestKind(requestURL string) string {
+	parsed, _ := url.Parse(strings.TrimSpace(requestURL))
+	if strings.HasSuffix(strings.TrimSuffix(parsed.Path, "/"), "/responses/compact") {
+		return "compaction"
+	}
+	return "turn"
+}
+
+func stableCodexApplicationUUID(authIdentity, kind, value string) string {
+	value = strings.TrimSpace(value)
+	if parsed, errParse := uuid.Parse(value); errParse == nil {
+		return parsed.String()
+	}
+	name := strings.Join([]string{"cli-proxy-api", "codex", "application-identity", kind, authIdentity, value}, "\x00")
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(name)).String()
+}
+
+func cachedCodexApplicationWindow(authIdentity, sessionID string) string {
+	key := authIdentity + "\x00" + sessionID
+	now := time.Now()
+	codexApplicationWindows.Lock()
+	defer codexApplicationWindows.Unlock()
+	for existingKey, entry := range codexApplicationWindows.entries {
+		if !entry.expiresAt.After(now) {
+			delete(codexApplicationWindows.entries, existingKey)
+		}
+	}
+	if entry, ok := codexApplicationWindows.entries[key]; ok && entry.expiresAt.After(now) {
+		entry.expiresAt = now.Add(codexApplicationWindowTTL)
+		codexApplicationWindows.entries[key] = entry
+		return entry.id
+	}
+	windowID := newCodexUUIDv7()
+	codexApplicationWindows.entries[key] = codexApplicationWindowEntry{
+		id:        windowID,
+		expiresAt: now.Add(codexApplicationWindowTTL),
+	}
+	return windowID
+}
+
+func newCodexUUIDv7() string {
+	value, errNew := uuid.NewV7()
+	if errNew != nil {
+		return uuid.NewString()
+	}
+	return value.String()
+}
+
+func parseCodexTurnMetadata(body []byte, profile registry.CodexFingerprintProfile) map[string]any {
+	metadata := make(map[string]any)
+	raw := clientMetadataString(body, profile.Headers.TurnMetadata)
+	if raw != "" {
+		_ = json.Unmarshal([]byte(raw), &metadata)
+	}
+	return metadata
+}
+
+func clientMetadataString(body []byte, key string) string {
+	return strings.TrimSpace(gjson.GetBytes(body, codexClientMetadataPath(key)).String())
+}
+
+func setCodexClientMetadataString(body []byte, key, value string) []byte {
+	updated, errSet := sjson.SetBytes(body, codexClientMetadataPath(key), value)
+	if errSet != nil {
+		return body
+	}
+	return updated
+}
+
+func codexClientMetadataPath(key string) string {
+	escaped := strings.ReplaceAll(strings.TrimSpace(key), "\\", "\\\\")
+	escaped = strings.ReplaceAll(escaped, ".", "\\.")
+	return "client_metadata." + escaped
+}

--- a/internal/runtime/executor/codex_fingerprint.go
+++ b/internal/runtime/executor/codex_fingerprint.go
@@ -32,6 +32,7 @@ type codexApplicationIdentity struct {
 	parentTurnID     string
 	subagentKind     string
 	turnMetadataJSON string
+	websocket        bool
 }
 
 type codexApplicationWindowEntry struct {
@@ -145,6 +146,7 @@ func applyCodexOfficialApplicationIdentity(
 		parentTurnID:     parentTurnID,
 		subagentKind:     subagentKind,
 		turnMetadataJSON: turnMetadataJSON,
+		websocket:        codexApplicationIsWebsocket(requestURL),
 	}
 }
 
@@ -153,6 +155,12 @@ func applyCodexOfficialApplicationIdentityHeaders(headers http.Header, identity 
 		return
 	}
 	profile := identity.profile
+	headers.Set("User-Agent", profile.UserAgent())
+	headers.Set("Originator", profile.Originator)
+	headers.Set("Version", profile.Version)
+	if identity.websocket {
+		headers.Set("OpenAI-Beta", profile.WebsocketBeta)
+	}
 	setCodexSessionHeaderCasePreserved(headers, profile.Headers.SessionID, identity.sessionID)
 	setHeaderCasePreserved(headers, profile.Headers.ThreadID, identity.threadID)
 	headers.Set(profile.Headers.ClientRequestID, identity.threadID)
@@ -167,6 +175,11 @@ func applyCodexOfficialApplicationIdentityHeaders(headers http.Header, identity 
 	if identity.subagentKind != "" {
 		headers.Set(profile.Headers.Subagent, identity.subagentKind)
 	}
+}
+
+func codexApplicationIsWebsocket(requestURL string) bool {
+	parsed, errParse := url.Parse(strings.TrimSpace(requestURL))
+	return errParse == nil && strings.EqualFold(parsed.Scheme, "wss")
 }
 
 func codexOfficialFingerprintScope(cfg *config.Config, auth *cliproxyauth.Auth, requestURL string) bool {

--- a/internal/runtime/executor/codex_fingerprint_test.go
+++ b/internal/runtime/executor/codex_fingerprint_test.go
@@ -83,8 +83,8 @@ func TestCodexApplicationIdentityProjectsCanonicalMetadata(t *testing.T) {
 	if got := headerValueCaseInsensitive(headers, profile.Headers.SessionID); got != first.sessionID {
 		t.Fatalf("session header = %q, want %q", got, first.sessionID)
 	}
-	if got := headers.Get(profile.Headers.ClientRequestID); got != first.threadID {
-		t.Fatalf("client request header = %q, want %q", got, first.threadID)
+	if got := headers.Get(profile.Headers.ClientRequestID); got != "" {
+		t.Fatalf("HTTP client request header = %q, want empty", got)
 	}
 	if got := headers.Get(profile.Headers.TurnMetadata); got != turnMetadataRaw {
 		t.Fatalf("turn metadata header differs from client_metadata: %q != %q", got, turnMetadataRaw)
@@ -178,6 +178,9 @@ func TestApplyCodexWebsocketFingerprintUsesProfile(t *testing.T) {
 	}
 	if got := headers.Get("Version"); got != profile.Version {
 		t.Fatalf("Version = %q, want %q", got, profile.Version)
+	}
+	if got := headers.Get(profile.Headers.ClientRequestID); got != identity.threadID {
+		t.Fatalf("websocket client request header = %q, want %q", got, identity.threadID)
 	}
 }
 

--- a/internal/runtime/executor/codex_fingerprint_test.go
+++ b/internal/runtime/executor/codex_fingerprint_test.go
@@ -1,0 +1,190 @@
+package executor
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/tidwall/gjson"
+)
+
+func TestCodexApplicationIdentityProjectsCanonicalMetadata(t *testing.T) {
+	cfg := &config.Config{}
+	auth := &cliproxyauth.Auth{
+		ID:       "oauth-account-a",
+		Metadata: map[string]any{"access_token": "oauth-token"},
+	}
+	body := []byte(`{
+		"prompt_cache_key":"client-session-a",
+		"client_metadata":{
+			"custom-key":"preserved",
+			"x-codex-parent-thread-id":"parent-thread-a",
+			"x-openai-subagent":"collab_spawn"
+		}
+	}`)
+	const requestURL = "https://chatgpt.com/backend-api/codex/responses"
+
+	firstBody, first := applyCodexOfficialApplicationIdentity(cfg, auth, requestURL, body)
+	if !first.enabled {
+		t.Fatal("application identity is disabled for official OAuth request")
+	}
+	assertUUIDVersion(t, first.windowID, 7)
+	assertUUIDVersion(t, first.turnID, 7)
+	if _, err := uuid.Parse(first.installationID); err != nil {
+		t.Fatalf("installation ID %q is not a UUID: %v", first.installationID, err)
+	}
+	if got := gjson.GetBytes(firstBody, "client_metadata.custom-key").String(); got != "preserved" {
+		t.Fatalf("custom client metadata = %q, want preserved", got)
+	}
+
+	profile := registry.GetCodexFingerprintProfile()
+	if got := gjson.GetBytes(firstBody, "client_metadata."+profile.Headers.InstallationID).String(); got != first.installationID {
+		t.Fatalf("body installation ID = %q, want %q", got, first.installationID)
+	}
+	if got := gjson.GetBytes(firstBody, "client_metadata."+profile.MetadataKeys.SessionID).String(); got != first.sessionID {
+		t.Fatalf("body session ID = %q, want %q", got, first.sessionID)
+	}
+	if got := gjson.GetBytes(firstBody, "client_metadata."+profile.MetadataKeys.ThreadID).String(); got != first.threadID {
+		t.Fatalf("body thread ID = %q, want %q", got, first.threadID)
+	}
+	if got := gjson.GetBytes(firstBody, "client_metadata."+profile.Headers.WindowID).String(); got != first.windowID {
+		t.Fatalf("body window ID = %q, want %q", got, first.windowID)
+	}
+
+	turnMetadataRaw := gjson.GetBytes(firstBody, "client_metadata."+profile.Headers.TurnMetadata).String()
+	var turnMetadata map[string]any
+	if err := json.Unmarshal([]byte(turnMetadataRaw), &turnMetadata); err != nil {
+		t.Fatalf("turn metadata is not JSON: %v", err)
+	}
+	for key, want := range map[string]string{
+		profile.MetadataKeys.InstallationID: first.installationID,
+		profile.MetadataKeys.SessionID:      first.sessionID,
+		profile.MetadataKeys.ThreadID:       first.threadID,
+		profile.MetadataKeys.TurnID:         first.turnID,
+		profile.MetadataKeys.WindowID:       first.windowID,
+		profile.MetadataKeys.RequestKind:    "turn",
+		profile.MetadataKeys.ParentThreadID: "parent-thread-a",
+		profile.MetadataKeys.SubagentKind:   "collab_spawn",
+	} {
+		if got, _ := turnMetadata[key].(string); got != want {
+			t.Fatalf("turn metadata %s = %q, want %q", key, got, want)
+		}
+	}
+	if _, ok := turnMetadata[profile.MetadataKeys.TurnStartedAtUnixMS].(float64); !ok {
+		t.Fatalf("turn metadata %s is missing or not numeric", profile.MetadataKeys.TurnStartedAtUnixMS)
+	}
+
+	headers := http.Header{}
+	applyCodexOfficialApplicationIdentityHeaders(headers, &first)
+	if got := headerValueCaseInsensitive(headers, profile.Headers.SessionID); got != first.sessionID {
+		t.Fatalf("session header = %q, want %q", got, first.sessionID)
+	}
+	if got := headers.Get(profile.Headers.ClientRequestID); got != first.threadID {
+		t.Fatalf("client request header = %q, want %q", got, first.threadID)
+	}
+	if got := headers.Get(profile.Headers.TurnMetadata); got != turnMetadataRaw {
+		t.Fatalf("turn metadata header differs from client_metadata: %q != %q", got, turnMetadataRaw)
+	}
+	if got := headers.Get(profile.Headers.ParentThreadID); got != "parent-thread-a" {
+		t.Fatalf("parent thread header = %q", got)
+	}
+	if got := headers.Get(profile.Headers.Subagent); got != "collab_spawn" {
+		t.Fatalf("subagent header = %q", got)
+	}
+
+	_, second := applyCodexOfficialApplicationIdentity(cfg, auth, requestURL, body)
+	if second.installationID != first.installationID ||
+		second.sessionID != first.sessionID ||
+		second.threadID != first.threadID ||
+		second.windowID != first.windowID {
+		t.Fatalf("stable identity changed: first=%+v second=%+v", first, second)
+	}
+	if second.turnID == first.turnID {
+		t.Fatalf("turn ID was reused: %q", second.turnID)
+	}
+}
+
+func TestCodexApplicationIdentityMarksCompaction(t *testing.T) {
+	cfg := &config.Config{}
+	auth := &cliproxyauth.Auth{ID: "oauth-compact", Metadata: map[string]any{"access_token": "oauth-token"}}
+	body, identity := applyCodexOfficialApplicationIdentity(
+		cfg,
+		auth,
+		"https://chatgpt.com/backend-api/codex/responses/compact",
+		[]byte(`{"prompt_cache_key":"compact-session"}`),
+	)
+	if !identity.enabled {
+		t.Fatal("compaction identity is disabled")
+	}
+	profile := registry.GetCodexFingerprintProfile()
+	raw := gjson.GetBytes(body, "client_metadata."+profile.Headers.TurnMetadata).String()
+	if got := gjson.Get(raw, profile.MetadataKeys.RequestKind).String(); got != "compaction" {
+		t.Fatalf("request kind = %q, want compaction", got)
+	}
+	headers := http.Header{}
+	applyCodexOfficialApplicationIdentityHeaders(headers, &identity)
+	if got := headers.Get(profile.Headers.InstallationID); got != identity.installationID {
+		t.Fatalf("compact installation header = %q, want %q", got, identity.installationID)
+	}
+}
+
+func TestCodexOfficialFingerprintScopeBypassesExcludedRequests(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        *config.Config
+		auth       *cliproxyauth.Auth
+		requestURL string
+	}{
+		{
+			name:       "api key",
+			cfg:        &config.Config{},
+			auth:       &cliproxyauth.Auth{ID: "api-key", Attributes: map[string]string{"api_key": "sk-test"}},
+			requestURL: "https://chatgpt.com/backend-api/codex/responses",
+		},
+		{
+			name:       "custom auth base URL",
+			cfg:        &config.Config{},
+			auth:       &cliproxyauth.Auth{ID: "custom", Attributes: map[string]string{"base_url": "https://gateway.example.com"}},
+			requestURL: "https://gateway.example.com/responses",
+		},
+		{
+			name:       "cloaking disabled",
+			cfg:        &config.Config{Codex: config.CodexConfig{DisableCodexCloaking: true}},
+			auth:       &cliproxyauth.Auth{ID: "oauth", Metadata: map[string]any{"access_token": "oauth-token"}},
+			requestURL: "https://chatgpt.com/backend-api/codex/responses",
+		},
+		{
+			name:       "custom target",
+			cfg:        &config.Config{},
+			auth:       &cliproxyauth.Auth{ID: "oauth", Metadata: map[string]any{"access_token": "oauth-token"}},
+			requestURL: "https://gateway.example.com/responses",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := []byte(`{"prompt_cache_key":"scope-session"}`)
+			got, identity := applyCodexOfficialApplicationIdentity(tt.cfg, tt.auth, tt.requestURL, input)
+			if identity.enabled {
+				t.Fatalf("identity enabled for excluded scope: %+v", identity)
+			}
+			if string(got) != string(input) {
+				t.Fatalf("excluded request body changed: %s", got)
+			}
+		})
+	}
+}
+
+func assertUUIDVersion(t *testing.T, value string, want int) {
+	t.Helper()
+	parsed, err := uuid.Parse(value)
+	if err != nil {
+		t.Fatalf("%q is not a UUID: %v", value, err)
+	}
+	if got := int(parsed.Version()); got != want {
+		t.Fatalf("UUID %q version = %d, want %d", value, got, want)
+	}
+}

--- a/internal/runtime/executor/codex_fingerprint_test.go
+++ b/internal/runtime/executor/codex_fingerprint_test.go
@@ -132,6 +132,55 @@ func TestCodexApplicationIdentityMarksCompaction(t *testing.T) {
 	}
 }
 
+func TestApplyCodexOfficialFingerprintHeadersUsesProfile(t *testing.T) {
+	cfg := &config.Config{}
+	auth := &cliproxyauth.Auth{ID: "oauth-software-profile", Metadata: map[string]any{"access_token": "oauth-token"}}
+	_, identity := applyCodexOfficialApplicationIdentity(
+		cfg,
+		auth,
+		"https://chatgpt.com/backend-api/codex/responses",
+		[]byte(`{"prompt_cache_key":"software-profile-session"}`),
+	)
+	headers := http.Header{
+		"User-Agent": {"stale-client/0.1.0"},
+		"Originator": {"stale-client"},
+		"Version":    {"0.1.0"},
+	}
+	applyCodexOfficialApplicationIdentityHeaders(headers, &identity)
+
+	profile := registry.GetCodexFingerprintProfile()
+	if got := headers.Get("User-Agent"); got != profile.UserAgent() {
+		t.Fatalf("User-Agent = %q, want %q", got, profile.UserAgent())
+	}
+	if got := headers.Get("Originator"); got != profile.Originator {
+		t.Fatalf("Originator = %q, want %q", got, profile.Originator)
+	}
+	if got := headers.Get("Version"); got != profile.Version {
+		t.Fatalf("Version = %q, want %q", got, profile.Version)
+	}
+}
+
+func TestApplyCodexWebsocketFingerprintUsesProfile(t *testing.T) {
+	cfg := &config.Config{}
+	auth := &cliproxyauth.Auth{ID: "oauth-ws-profile", Metadata: map[string]any{"access_token": "oauth-token"}}
+	_, identity := applyCodexOfficialApplicationIdentity(
+		cfg,
+		auth,
+		"wss://chatgpt.com/backend-api/codex/responses",
+		[]byte(`{"prompt_cache_key":"ws-profile-session"}`),
+	)
+	headers := http.Header{"OpenAI-Beta": {"responses_websockets=2000-01-01"}}
+	applyCodexOfficialApplicationIdentityHeaders(headers, &identity)
+
+	profile := registry.GetCodexFingerprintProfile()
+	if got := headers.Get("OpenAI-Beta"); got != profile.WebsocketBeta {
+		t.Fatalf("OpenAI-Beta = %q, want %q", got, profile.WebsocketBeta)
+	}
+	if got := headers.Get("Version"); got != profile.Version {
+		t.Fatalf("Version = %q, want %q", got, profile.Version)
+	}
+}
+
 func TestCodexOfficialFingerprintScopeBypassesExcludedRequests(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/runtime/executor/codex_fingerprint_test.go
+++ b/internal/runtime/executor/codex_fingerprint_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/google/uuid"
@@ -23,6 +24,7 @@ func TestCodexApplicationIdentityProjectsCanonicalMetadata(t *testing.T) {
 		"client_metadata":{
 			"custom-key":"preserved",
 			"x-codex-parent-thread-id":"parent-thread-a",
+			"parent_turn_id":"parent-turn-a",
 			"x-openai-subagent":"collab_spawn"
 		}
 	}`)
@@ -68,6 +70,7 @@ func TestCodexApplicationIdentityProjectsCanonicalMetadata(t *testing.T) {
 		profile.MetadataKeys.WindowID:       first.windowID,
 		profile.MetadataKeys.RequestKind:    "turn",
 		profile.MetadataKeys.ParentThreadID: "parent-thread-a",
+		profile.MetadataKeys.ParentTurnID:   "parent-turn-a",
 		profile.MetadataKeys.SubagentKind:   "collab_spawn",
 	} {
 		if got, _ := turnMetadata[key].(string); got != want {
@@ -105,6 +108,29 @@ func TestCodexApplicationIdentityProjectsCanonicalMetadata(t *testing.T) {
 	}
 	if second.turnID == first.turnID {
 		t.Fatalf("turn ID was reused: %q", second.turnID)
+	}
+}
+
+func TestCodexApplicationIdentityProjectsCanonicalParentMetadata(t *testing.T) {
+	profile := registry.GetCodexFingerprintProfile()
+	rawMetadata := `{"parent_thread_id":"parent-thread-b","parent_turn_id":"parent-turn-b","subagent_kind":"review"}`
+	body, identity := applyCodexOfficialApplicationIdentity(
+		&config.Config{},
+		&cliproxyauth.Auth{ID: "oauth-parent-projection", Metadata: map[string]any{"access_token": "oauth-token"}},
+		"https://chatgpt.com/backend-api/codex/responses",
+		[]byte(`{"prompt_cache_key":"parent-session","client_metadata":{"`+profile.Headers.TurnMetadata+`":`+strconv.Quote(rawMetadata)+`}}`),
+	)
+	if !identity.enabled {
+		t.Fatal("application identity is disabled")
+	}
+	if got := gjson.GetBytes(body, "client_metadata."+profile.Headers.ParentThreadID).String(); got != "parent-thread-b" {
+		t.Fatalf("parent thread projection = %q", got)
+	}
+	if got := gjson.GetBytes(body, "client_metadata."+profile.MetadataKeys.ParentTurnID).String(); got != "parent-turn-b" {
+		t.Fatalf("parent turn projection = %q", got)
+	}
+	if got := gjson.GetBytes(body, "client_metadata."+profile.Headers.Subagent).String(); got != "review" {
+		t.Fatalf("subagent projection = %q", got)
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_connection.go
+++ b/internal/runtime/executor/codex_websockets_connection.go
@@ -28,7 +28,7 @@ const (
 )
 
 func (e *CodexWebsocketsExecutor) dialCodexWebsocket(ctx context.Context, auth *cliproxyauth.Auth, wsURL string, headers http.Header) (*websocket.Conn, *websocketConnectionCloser, *http.Response, error) {
-	dialer := newProxyAwareWebsocketDialer(e.cfg, auth)
+	dialer := newCodexWebsocketDialer(e.cfg, auth, wsURL)
 	dialer.HandshakeTimeout = codexResponsesWebsocketHandshakeTO
 	dialer.EnableCompression = true
 	if ctx == nil {
@@ -42,6 +42,63 @@ func (e *CodexWebsocketsExecutor) dialCodexWebsocket(ctx context.Context, auth *
 		conn.EnableWriteCompression(false)
 	}
 	return conn, closer, resp, err
+}
+
+func newCodexWebsocketDialer(cfg *config.Config, auth *cliproxyauth.Auth, wsURL string) *websocket.Dialer {
+	dialer := newProxyAwareWebsocketDialer(cfg, auth)
+	if !codexOfficialFingerprintScope(cfg, auth, wsURL) {
+		return dialer
+	}
+
+	proxyURL, errProxy := codexWebsocketProxySetting(cfg, auth, wsURL)
+	if errProxy != nil {
+		log.Errorf("codex websockets executor: resolve fingerprint proxy failed: %v", errProxy)
+		return dialer
+	}
+	dialTLSContext, errDialer := helps.NewUTLSWebsocketDialContext(proxyURL)
+	if errDialer != nil {
+		log.Errorf("codex websockets executor: create fingerprint TLS dialer failed: %v", errDialer)
+		return dialer
+	}
+
+	// The TLS dialer owns direct/proxy tunnel creation so the Chrome ClientHello
+	// is sent only after the tunnel reaches the Codex endpoint.
+	dialer.Proxy = nil
+	dialer.NetDialTLSContext = dialTLSContext
+	return dialer
+}
+
+func codexWebsocketProxySetting(cfg *config.Config, auth *cliproxyauth.Auth, wsURL string) (string, error) {
+	proxyURL := ""
+	if auth != nil {
+		proxyURL = strings.TrimSpace(auth.ProxyURL)
+	}
+	if proxyURL == "" && cfg != nil {
+		proxyURL = strings.TrimSpace(cfg.ProxyURL)
+	}
+	if proxyURL != "" {
+		return proxyURL, nil
+	}
+
+	target, errParse := url.Parse(strings.TrimSpace(wsURL))
+	if errParse != nil {
+		return "", errParse
+	}
+	switch strings.ToLower(target.Scheme) {
+	case "wss":
+		target.Scheme = "https"
+	case "ws":
+		target.Scheme = "http"
+	}
+	req := &http.Request{URL: target}
+	environmentProxy, errEnvironment := http.ProxyFromEnvironment(req)
+	if errEnvironment != nil {
+		return "", errEnvironment
+	}
+	if environmentProxy == nil {
+		return "direct", nil
+	}
+	return environmentProxy.String(), nil
 }
 
 func writeCodexWebsocketMessage(sess *codexWebsocketSession, conn *websocket.Conn, payload []byte) error {

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -84,7 +84,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	var identityState codexIdentityConfuseState
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
 	upstreamBody, identityState.application = applyCodexOfficialApplicationIdentity(e.cfg, auth, wsURL, upstreamBody)
-	upstreamBody = normalizeCodexUpstreamRequestMetadata(wsURL, upstreamBody)
+	upstreamBody = normalizeCodexUpstreamRequestMetadata(auth, wsURL, upstreamBody)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 	applyModelHeaderOverrides(wsHeaders, baseModel)

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -83,6 +83,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	clientBody := body
 	var identityState codexIdentityConfuseState
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
+	upstreamBody, identityState.application = applyCodexOfficialApplicationIdentity(e.cfg, auth, httpURL, upstreamBody)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 	applyModelHeaderOverrides(wsHeaders, baseModel)

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -84,6 +84,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	var identityState codexIdentityConfuseState
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
 	upstreamBody, identityState.application = applyCodexOfficialApplicationIdentity(e.cfg, auth, wsURL, upstreamBody)
+	upstreamBody = normalizeCodexUpstreamRequestMetadata(wsURL, upstreamBody)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 	applyModelHeaderOverrides(wsHeaders, baseModel)

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -83,7 +83,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	clientBody := body
 	var identityState codexIdentityConfuseState
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
-	upstreamBody, identityState.application = applyCodexOfficialApplicationIdentity(e.cfg, auth, httpURL, upstreamBody)
+	upstreamBody, identityState.application = applyCodexOfficialApplicationIdentity(e.cfg, auth, wsURL, upstreamBody)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 	applyModelHeaderOverrides(wsHeaders, baseModel)

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -237,8 +237,8 @@ func TestCodexWebsocketsExecuteResponsesLiteDoesNotInjectImageGenerationTool(t *
 		if got := gjson.GetBytes(payload, "input.0.type").String(); got != "additional_tools" {
 			t.Fatalf("input.0.type = %q, want additional_tools; payload=%s", got, payload)
 		}
-		if got := gjson.GetBytes(payload, "client_metadata.ws_request_header_x_openai_internal_codex_responses_lite").String(); got != "true" {
-			t.Fatalf("responses-lite metadata = %q, want true; payload=%s", got, payload)
+		if gjson.GetBytes(payload, "client_metadata").Exists() {
+			t.Fatalf("custom websocket payload retained unsupported client_metadata: %s", payload)
 		}
 		if gjson.GetBytes(payload, "metadata").Exists() {
 			t.Fatalf("websocket payload retained unsupported metadata: %s", payload)

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -1783,6 +1783,74 @@ func TestNewProxyAwareWebsocketDialerDirectDisablesProxy(t *testing.T) {
 	}
 }
 
+func TestNewCodexWebsocketDialerUsesUTLSOnlyForOfficialOAuth(t *testing.T) {
+	t.Parallel()
+
+	official := newCodexWebsocketDialer(
+		&config.Config{},
+		&cliproxyauth.Auth{ID: "oauth-account", Provider: "codex"},
+		"wss://chatgpt.com/backend-api/codex/responses",
+	)
+	if official.NetDialTLSContext == nil {
+		t.Fatal("official OAuth websocket dialer did not install uTLS")
+	}
+	if official.Proxy != nil {
+		t.Fatal("official OAuth websocket proxy must be handled before the uTLS handshake")
+	}
+
+	for _, tc := range []struct {
+		name string
+		auth *cliproxyauth.Auth
+		url  string
+	}{
+		{
+			name: "api key",
+			auth: &cliproxyauth.Auth{ID: "key-account", Provider: "codex", Attributes: map[string]string{"api_key": "sk-test"}},
+			url:  "wss://chatgpt.com/backend-api/codex/responses",
+		},
+		{
+			name: "custom gateway",
+			auth: &cliproxyauth.Auth{ID: "custom-account", Provider: "codex", Attributes: map[string]string{"base_url": "https://gateway.example.com"}},
+			url:  "wss://gateway.example.com/responses",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dialer := newCodexWebsocketDialer(&config.Config{}, tc.auth, tc.url)
+			if dialer.NetDialTLSContext != nil {
+				t.Fatal("non-official websocket dialer unexpectedly installed uTLS")
+			}
+		})
+	}
+}
+
+func TestCodexWebsocketProxySettingUsesAccountThenGlobalProxy(t *testing.T) {
+	t.Parallel()
+
+	got, err := codexWebsocketProxySetting(
+		&config.Config{SDKConfig: sdkconfig.SDKConfig{ProxyURL: "http://global.example.com:8080"}},
+		&cliproxyauth.Auth{ProxyURL: "socks5://account.example.com:1080"},
+		"wss://chatgpt.com/backend-api/codex/responses",
+	)
+	if err != nil {
+		t.Fatalf("codexWebsocketProxySetting returned error: %v", err)
+	}
+	if want := "socks5://account.example.com:1080"; got != want {
+		t.Fatalf("proxy = %q, want account proxy %q", got, want)
+	}
+
+	got, err = codexWebsocketProxySetting(
+		&config.Config{SDKConfig: sdkconfig.SDKConfig{ProxyURL: "http://global.example.com:8080"}},
+		&cliproxyauth.Auth{},
+		"wss://chatgpt.com/backend-api/codex/responses",
+	)
+	if err != nil {
+		t.Fatalf("codexWebsocketProxySetting returned error: %v", err)
+	}
+	if want := "http://global.example.com:8080"; got != want {
+		t.Fatalf("proxy = %q, want global proxy %q", got, want)
+	}
+}
+
 func TestCodexWebsocketUpgradeRequiredDoesNotFallbackToHTTPWithLifecycle(t *testing.T) {
 	var httpFallbackCalls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -221,7 +221,7 @@ func TestCodexWebsocketsExecuteResponsesLiteDoesNotInjectImageGenerationTool(t *
 	}
 	req := cliproxyexecutor.Request{
 		Model:   "gpt-5.6-sol",
-		Payload: []byte(`{"model":"gpt-5.6-sol","input":[{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"exec"}]},{"role":"user","content":"hello"}],"parallel_tool_calls":true,"client_metadata":{"ws_request_header_x_openai_internal_codex_responses_lite":"true"}}`),
+		Payload: []byte(`{"model":"gpt-5.6-sol","input":[{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"exec"}]},{"role":"user","content":"hello"}],"parallel_tool_calls":true,"metadata":{"source":"client"},"client_metadata":{"ws_request_header_x_openai_internal_codex_responses_lite":"true"}}`),
 	}
 	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("codex")}
 
@@ -239,6 +239,9 @@ func TestCodexWebsocketsExecuteResponsesLiteDoesNotInjectImageGenerationTool(t *
 		}
 		if got := gjson.GetBytes(payload, "client_metadata.ws_request_header_x_openai_internal_codex_responses_lite").String(); got != "true" {
 			t.Fatalf("responses-lite metadata = %q, want true; payload=%s", got, payload)
+		}
+		if gjson.GetBytes(payload, "metadata").Exists() {
+			t.Fatalf("websocket payload retained unsupported metadata: %s", payload)
 		}
 		parallelToolCalls := gjson.GetBytes(payload, "parallel_tool_calls")
 		if !parallelToolCalls.Exists() || parallelToolCalls.Bool() {
@@ -285,7 +288,7 @@ func TestCodexWebsocketsExecuteStreamResponsesLiteForcesParallelToolCallsFalse(t
 	}
 	req := cliproxyexecutor.Request{
 		Model:   "gpt-5.6-luna",
-		Payload: []byte(`{"model":"gpt-5.6-luna","input":[{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"exec"}]},{"role":"user","content":"hello"}],"parallel_tool_calls":true,"client_metadata":{"ws_request_header_x_openai_internal_codex_responses_lite":"true"}}`),
+		Payload: []byte(`{"model":"gpt-5.6-luna","input":[{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"exec"}]},{"role":"user","content":"hello"}],"parallel_tool_calls":true,"metadata":{"source":"client"},"client_metadata":{"ws_request_header_x_openai_internal_codex_responses_lite":"true"}}`),
 	}
 	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("codex")}
 
@@ -314,6 +317,9 @@ func TestCodexWebsocketsExecuteStreamResponsesLiteForcesParallelToolCallsFalse(t
 		parallelToolCalls := gjson.GetBytes(payload, "parallel_tool_calls")
 		if !parallelToolCalls.Exists() || parallelToolCalls.Bool() {
 			t.Fatalf("responses-lite parallel_tool_calls should be false: %s", payload)
+		}
+		if gjson.GetBytes(payload, "metadata").Exists() {
+			t.Fatalf("websocket stream payload retained unsupported metadata: %s", payload)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for upstream websocket payload")

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -80,7 +80,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	clientBody := body
 	var identityState codexIdentityConfuseState
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
-	upstreamBody, identityState.application = applyCodexOfficialApplicationIdentity(e.cfg, auth, httpURL, upstreamBody)
+	upstreamBody, identityState.application = applyCodexOfficialApplicationIdentity(e.cfg, auth, wsURL, upstreamBody)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 	applyModelHeaderOverrides(wsHeaders, baseModel)

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -80,6 +80,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	clientBody := body
 	var identityState codexIdentityConfuseState
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
+	upstreamBody, identityState.application = applyCodexOfficialApplicationIdentity(e.cfg, auth, httpURL, upstreamBody)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 	applyModelHeaderOverrides(wsHeaders, baseModel)

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -81,6 +81,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	var identityState codexIdentityConfuseState
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
 	upstreamBody, identityState.application = applyCodexOfficialApplicationIdentity(e.cfg, auth, wsURL, upstreamBody)
+	upstreamBody = normalizeCodexUpstreamRequestMetadata(wsURL, upstreamBody)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 	applyModelHeaderOverrides(wsHeaders, baseModel)

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -81,7 +81,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	var identityState codexIdentityConfuseState
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
 	upstreamBody, identityState.application = applyCodexOfficialApplicationIdentity(e.cfg, auth, wsURL, upstreamBody)
-	upstreamBody = normalizeCodexUpstreamRequestMetadata(wsURL, upstreamBody)
+	upstreamBody = normalizeCodexUpstreamRequestMetadata(auth, wsURL, upstreamBody)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 	applyModelHeaderOverrides(wsHeaders, baseModel)

--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -405,3 +405,82 @@ func NewUtlsHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyau
 	}
 	return client
 }
+
+// NewUTLSWebsocketDialContext creates a TLS dial function that uses a Chrome
+// ClientHello while keeping WebSocket traffic on HTTP/1.1.
+func NewUTLSWebsocketDialContext(proxyURL string) (func(context.Context, string, string) (net.Conn, error), error) {
+	return newUTLSWebsocketDialContext(proxyURL, nil)
+}
+
+func newUTLSWebsocketDialContext(proxyURL string, tlsConfig *tls.Config) (func(context.Context, string, string) (net.Conn, error), error) {
+	baseDialer, mode, errBuild := proxyutil.BuildDialer(proxyURL)
+	if errBuild != nil {
+		return nil, fmt.Errorf("build websocket proxy dialer: %w", errBuild)
+	}
+	if mode == proxyutil.ModeInherit || baseDialer == nil {
+		baseDialer = proxy.Direct
+	}
+	contextDialer, ok := baseDialer.(proxy.ContextDialer)
+	if !ok {
+		return nil, fmt.Errorf("websocket proxy dialer does not support context cancellation")
+	}
+
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		rawConn, errDial := contextDialer.DialContext(ctx, network, addr)
+		if errDial != nil {
+			return nil, errDial
+		}
+
+		configForConn := &tls.Config{}
+		if tlsConfig != nil {
+			configForConn = tlsConfig.Clone()
+		}
+		host, _, errSplit := net.SplitHostPort(addr)
+		if errSplit != nil {
+			host = addr
+		}
+		configForConn.ServerName = host
+
+		spec, errSpec := codexChromeWebsocketClientHelloSpec()
+		if errSpec != nil {
+			_ = rawConn.Close()
+			return nil, fmt.Errorf("build Chrome websocket ClientHello: %w", errSpec)
+		}
+		tlsConn := tls.UClient(rawConn, configForConn, tls.HelloCustom)
+		if errPreset := tlsConn.ApplyPreset(&spec); errPreset != nil {
+			_ = rawConn.Close()
+			return nil, fmt.Errorf("apply Chrome websocket ClientHello: %w", errPreset)
+		}
+		if errHandshake := tlsConn.HandshakeContext(ctx); errHandshake != nil {
+			_ = rawConn.Close()
+			return nil, fmt.Errorf("Chrome websocket TLS handshake: %w", errHandshake)
+		}
+		return tlsConn, nil
+	}, nil
+}
+
+func codexChromeWebsocketClientHelloSpec() (tls.ClientHelloSpec, error) {
+	spec, errSpec := tls.UTLSIdToSpec(tls.HelloChrome_Auto)
+	if errSpec != nil {
+		return tls.ClientHelloSpec{}, errSpec
+	}
+
+	extensions := make([]tls.TLSExtension, 0, len(spec.Extensions))
+	for _, extension := range spec.Extensions {
+		switch typed := extension.(type) {
+		case *tls.ALPNExtension:
+			typed.AlpnProtocols = []string{"http/1.1"}
+			extensions = append(extensions, typed)
+		case *tls.ApplicationSettingsExtension, *tls.ApplicationSettingsExtensionNew:
+			// ALPS is specific to HTTP/2 or HTTP/3 and conflicts with an HTTP/1.1 upgrade.
+			continue
+		default:
+			extensions = append(extensions, extension)
+		}
+	}
+	spec.Extensions = extensions
+	return spec, nil
+}

--- a/internal/runtime/executor/helps/utls_client_test.go
+++ b/internal/runtime/executor/helps/utls_client_test.go
@@ -1,16 +1,20 @@
 package helps
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/md5"
+	stdtls "crypto/tls"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
 	"strconv"
@@ -638,4 +642,142 @@ func summarizeClaudeCodeClientHelloSpec(t *testing.T, spec *tls.ClientHelloSpec)
 	digest := md5.Sum([]byte(summary.JA3)) // #nosec G401 -- JA3 requires MD5.
 	summary.JA3MD5 = hex.EncodeToString(digest[:])
 	return summary
+}
+
+func TestCodexChromeWebsocketSpecUsesHTTP11(t *testing.T) {
+	t.Parallel()
+
+	spec, err := codexChromeWebsocketClientHelloSpec()
+	if err != nil {
+		t.Fatalf("codexChromeWebsocketClientHelloSpec returned error: %v", err)
+	}
+
+	var alpn []string
+	for _, extension := range spec.Extensions {
+		switch typed := extension.(type) {
+		case *tls.ALPNExtension:
+			alpn = typed.AlpnProtocols
+		case *tls.ApplicationSettingsExtension, *tls.ApplicationSettingsExtensionNew:
+			t.Fatalf("websocket ClientHello retained HTTP/2 application settings: %T", typed)
+		}
+	}
+	if got, want := strings.Join(alpn, ","), "http/1.1"; got != want {
+		t.Fatalf("ALPN = %q, want %q", got, want)
+	}
+}
+
+func TestUTLSWebsocketDialContextNegotiatesHTTP11(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	server.EnableHTTP2 = true
+	server.TLS = &stdtls.Config{NextProtos: []string{"h2", "http/1.1"}}
+	server.Config.ErrorLog = log.New(io.Discard, "", 0)
+	server.StartTLS()
+	defer server.Close()
+
+	dialTLSContext, err := newUTLSWebsocketDialContext("direct", &tls.Config{InsecureSkipVerify: true}) //nolint:gosec -- local test server
+	if err != nil {
+		t.Fatalf("newUTLSWebsocketDialContext returned error: %v", err)
+	}
+	conn, err := dialTLSContext(context.Background(), "tcp", server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dialTLSContext returned error: %v", err)
+	}
+	defer conn.Close()
+
+	utlsConn, ok := conn.(*tls.UConn)
+	if !ok {
+		t.Fatalf("connection type = %T, want *tls.UConn", conn)
+	}
+	if got, want := utlsConn.ConnectionState().NegotiatedProtocol, "http/1.1"; got != want {
+		t.Fatalf("negotiated protocol = %q, want %q", got, want)
+	}
+}
+
+func TestUTLSWebsocketDialContextTunnelsThroughHTTPProxy(t *testing.T) {
+	t.Parallel()
+
+	target := httptest.NewUnstartedServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	target.TLS = &stdtls.Config{NextProtos: []string{"http/1.1"}}
+	target.Config.ErrorLog = log.New(io.Discard, "", 0)
+	target.StartTLS()
+	defer target.Close()
+
+	proxyListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen returned error: %v", err)
+	}
+	defer proxyListener.Close()
+
+	proxyDone := make(chan error, 1)
+	go func() {
+		clientConn, errAccept := proxyListener.Accept()
+		if errAccept != nil {
+			proxyDone <- errAccept
+			return
+		}
+		defer clientConn.Close()
+
+		clientReader := bufio.NewReader(clientConn)
+		req, errRead := http.ReadRequest(clientReader)
+		if errRead != nil {
+			proxyDone <- fmt.Errorf("read CONNECT request: %w", errRead)
+			return
+		}
+		if req.Method != http.MethodConnect || req.Host != target.Listener.Addr().String() {
+			proxyDone <- fmt.Errorf("CONNECT target = %s %s", req.Method, req.Host)
+			return
+		}
+
+		upstreamConn, errDial := net.Dial("tcp", target.Listener.Addr().String())
+		if errDial != nil {
+			proxyDone <- errDial
+			return
+		}
+		defer upstreamConn.Close()
+		if _, errWrite := io.WriteString(clientConn, "HTTP/1.1 200 Connection Established\r\n\r\n"); errWrite != nil {
+			proxyDone <- errWrite
+			return
+		}
+
+		copyDone := make(chan struct{}, 2)
+		go func() {
+			_, _ = io.Copy(upstreamConn, clientReader)
+			copyDone <- struct{}{}
+		}()
+		go func() {
+			_, _ = io.Copy(clientConn, upstreamConn)
+			copyDone <- struct{}{}
+		}()
+		<-copyDone
+		proxyDone <- nil
+	}()
+
+	dialTLSContext, err := newUTLSWebsocketDialContext(
+		"http://"+proxyListener.Addr().String(),
+		&tls.Config{InsecureSkipVerify: true}, //nolint:gosec -- local test server
+	)
+	if err != nil {
+		t.Fatalf("newUTLSWebsocketDialContext returned error: %v", err)
+	}
+	conn, err := dialTLSContext(context.Background(), "tcp", target.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dialTLSContext returned error: %v", err)
+	}
+	if _, ok := conn.(*tls.UConn); !ok {
+		t.Fatalf("connection type = %T, want *tls.UConn", conn)
+	}
+	if errClose := conn.Close(); errClose != nil {
+		t.Fatalf("conn.Close returned error: %v", errClose)
+	}
+
+	select {
+	case errProxy := <-proxyDone:
+		if errProxy != nil {
+			t.Fatalf("proxy returned error: %v", errProxy)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("proxy did not finish after tunneled TLS connection closed")
+	}
 }

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -375,6 +375,8 @@ func mapConfiguredHighIntent(level ThinkingLevel, modelInfo *registry.ModelInfo)
 		candidates = []ThinkingLevel{LevelXHigh, LevelMax, LevelHigh}
 	case LevelMax:
 		candidates = []ThinkingLevel{LevelMax, LevelXHigh, LevelHigh}
+	case LevelUltra:
+		candidates = []ThinkingLevel{LevelUltra, LevelMax, LevelXHigh, LevelHigh}
 	default:
 		return level
 	}
@@ -398,7 +400,7 @@ func extractSourceThinkingConfig(body []byte, provider string) ThinkingConfig {
 //
 // Parsing priority:
 //  1. Special values: "none" → ModeNone, "auto"/"-1" → ModeAuto
-//  2. Level names: "minimal", "low", "medium", "high", "xhigh" → ModeLevel
+//  2. Level names: "minimal", "low", "medium", "high", "xhigh", "max", "ultra" → ModeLevel
 //  3. Numeric values: positive integers → ModeBudget, 0 → ModeNone
 //
 // If none of the above match, returns empty ThinkingConfig (treated as no config).

--- a/internal/thinking/apply_configured_api_key_test.go
+++ b/internal/thinking/apply_configured_api_key_test.go
@@ -79,16 +79,73 @@ func TestApplyThinkingWithModelInfoMapsResponsesToCodexHighIntent(t *testing.T) 
 	}
 }
 
-func TestApplyThinkingWithModelInfoKeepsSameFamilyValidationStrict(t *testing.T) {
+func TestApplyThinkingWithModelInfoClampsSameFamilyHighIntentDown(t *testing.T) {
+	tests := []struct {
+		name      string
+		source    string
+		supported []string
+		want      string
+	}{
+		{name: "ultra stays ultra", source: "ultra", supported: []string{"high", "xhigh", "max", "ultra"}, want: "ultra"},
+		{name: "ultra falls back to max", source: "ultra", supported: []string{"high", "xhigh", "max"}, want: "max"},
+		{name: "ultra falls back to xhigh", source: "ultra", supported: []string{"high", "xhigh"}, want: "xhigh"},
+		{name: "ultra falls back to high", source: "ultra", supported: []string{"high"}, want: "high"},
+		{name: "max falls back to xhigh", source: "max", supported: []string{"high", "xhigh"}, want: "xhigh"},
+		{name: "max falls back to high", source: "max", supported: []string{"high"}, want: "high"},
+		{name: "xhigh falls back to high", source: "xhigh", supported: []string{"high", "max"}, want: "high"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			modelInfo := &registry.ModelInfo{
+				ID:       "openai-upstream",
+				Type:     "openai",
+				Thinking: &registry.ThinkingSupport{Levels: tc.supported},
+			}
+			body := []byte(`{"reasoning_effort":"` + tc.source + `"}`)
+			out, err := thinking.ApplyThinkingWithModelInfo(body, body, "openai-upstream", "openai", "openai", "openai", modelInfo)
+			if err != nil {
+				t.Fatalf("ApplyThinkingWithModelInfo() error = %v", err)
+			}
+			if got := gjson.GetBytes(out, "reasoning_effort").String(); got != tc.want {
+				t.Fatalf("reasoning_effort = %q, want %q; body=%s", got, tc.want, out)
+			}
+		})
+	}
+}
+
+func TestApplyThinkingWithModelInfoKeepsSameFamilyOrdinaryLevelsStrict(t *testing.T) {
 	modelInfo := &registry.ModelInfo{
 		ID:       "openai-upstream",
 		Type:     "openai",
-		Thinking: &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}},
+		Thinking: &registry.ThinkingSupport{Levels: []string{"low", "high"}},
 	}
-	body := []byte(`{"reasoning_effort":"xhigh"}`)
+	body := []byte(`{"reasoning_effort":"medium"}`)
 	out, err := thinking.ApplyThinkingWithModelInfo(body, body, "openai-upstream", "openai", "openai", "openai", modelInfo)
 	if err == nil {
-		t.Fatalf("ApplyThinkingWithModelInfo() error = nil, want unsupported xhigh error; body=%s", out)
+		t.Fatalf("ApplyThinkingWithModelInfo() error = nil, want unsupported medium error; body=%s", out)
+	}
+}
+
+func TestApplyThinkingWithModelInfoDoesNotDowngradeHighIntentBelowHigh(t *testing.T) {
+	modelInfo := &registry.ModelInfo{
+		ID:       "openai-upstream",
+		Type:     "openai",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"low", "medium"}},
+	}
+	body := []byte(`{"reasoning_effort":"max"}`)
+	out, err := thinking.ApplyThinkingWithModelInfo(body, body, "openai-upstream", "openai", "openai", "openai", modelInfo)
+	if err == nil {
+		t.Fatalf("ApplyThinkingWithModelInfo() error = nil, want unsupported max error; body=%s", out)
+	}
+}
+
+func TestParseLevelSuffixAcceptsUltra(t *testing.T) {
+	level, ok := thinking.ParseLevelSuffix("ULTRA")
+	if !ok {
+		t.Fatal("ParseLevelSuffix(ULTRA) ok = false, want true")
+	}
+	if level != thinking.LevelUltra {
+		t.Fatalf("ParseLevelSuffix(ULTRA) level = %q, want %q", level, thinking.LevelUltra)
 	}
 }
 

--- a/internal/thinking/convert.go
+++ b/internal/thinking/convert.go
@@ -18,7 +18,8 @@ var levelToBudgetMap = map[string]int{
 	"xhigh":   32768,
 	// "max" is used by Claude adaptive thinking effort. We map it to a large budget
 	// and rely on per-model clamping when converting to budget-only providers.
-	"max": 128000,
+	"max":   128000,
+	"ultra": 256000,
 }
 
 // ConvertLevelToBudget converts a thinking level to a budget value.
@@ -35,6 +36,7 @@ var levelToBudgetMap = map[string]int{
 //   - high    → 24576
 //   - xhigh   → 32768
 //   - max     → 128000
+//   - ultra   → 256000
 //
 // Returns:
 //   - budget: The converted budget value
@@ -121,7 +123,7 @@ func MapToClaudeEffort(level string, supportsMax bool) (string, bool) {
 		return "low", true
 	case "low", "medium", "high":
 		return level, true
-	case "xhigh", "max":
+	case "xhigh", "max", "ultra":
 		if supportsMax {
 			return "max", true
 		}

--- a/internal/thinking/provider/interactions/apply.go
+++ b/internal/thinking/provider/interactions/apply.go
@@ -170,7 +170,7 @@ func normalizeInteractionsLevel(level string, modelInfo *registry.ModelInfo) str
 		return strings.ToLower(modelInfo.Thinking.Levels[len(modelInfo.Thinking.Levels)-1])
 	}
 	switch level {
-	case string(thinking.LevelMax), string(thinking.LevelXHigh):
+	case string(thinking.LevelUltra), string(thinking.LevelMax), string(thinking.LevelXHigh):
 		return string(thinking.LevelHigh)
 	default:
 		return level

--- a/internal/thinking/suffix.go
+++ b/internal/thinking/suffix.go
@@ -109,7 +109,7 @@ func ParseSpecialSuffix(rawSuffix string) (mode ThinkingMode, ok bool) {
 // ParseLevelSuffix attempts to parse a raw suffix as a discrete thinking level.
 //
 // This function parses the raw suffix content (from ParseSuffix.RawSuffix) as a level.
-// Only discrete effort levels are valid: minimal, low, medium, high, xhigh, max.
+// Only discrete effort levels are valid: minimal, low, medium, high, xhigh, max, ultra.
 // Level matching is case-insensitive.
 //
 // Special values (none, auto) are NOT handled by this function; use ParseSpecialSuffix
@@ -122,7 +122,7 @@ func ParseSpecialSuffix(rawSuffix string) (mode ThinkingMode, ok bool) {
 //   - "none" -> level="", ok=false (special value, use ParseSpecialSuffix)
 //   - "auto" -> level="", ok=false (special value, use ParseSpecialSuffix)
 //   - "8192" -> level="", ok=false (numeric, use ParseNumericSuffix)
-//   - "ultra" -> level="", ok=false (unknown level)
+//   - "ultra" -> level=LevelUltra, ok=true
 func ParseLevelSuffix(rawSuffix string) (level ThinkingLevel, ok bool) {
 	if rawSuffix == "" {
 		return "", false
@@ -142,6 +142,8 @@ func ParseLevelSuffix(rawSuffix string) (level ThinkingLevel, ok bool) {
 		return LevelXHigh, true
 	case "max":
 		return LevelMax, true
+	case "ultra":
+		return LevelUltra, true
 	default:
 		return "", false
 	}

--- a/internal/thinking/types.go
+++ b/internal/thinking/types.go
@@ -57,6 +57,8 @@ const (
 	// LevelMax sets maximum thinking effort.
 	// This is currently used by Claude 4.6 adaptive thinking (opus supports "max").
 	LevelMax ThinkingLevel = "max"
+	// LevelUltra sets ultra-high thinking effort for models that advertise it.
+	LevelUltra ThinkingLevel = "ultra"
 )
 
 // ThinkingConfig represents a unified thinking configuration.

--- a/internal/thinking/validate.go
+++ b/internal/thinking/validate.go
@@ -75,6 +75,7 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 		}
 	}
 	allowClampUnsupported := toHasLevelSupport && (!isSameProviderFamily(fromFormat, toFormat) || modelFamilyMismatch)
+	allowHighIntentDowngrade := toHasLevelSupport && isOpenAIFamily(toFormat) && config.Mode == ModeLevel && isHighIntentLevel(config.Level)
 
 	// strictBudget determines whether to enforce strict budget range validation.
 	// This applies when: (1) config comes from request body (not suffix), (2) source format is known,
@@ -131,7 +132,9 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 
 	if len(support.Levels) > 0 && config.Mode == ModeLevel {
 		if !isLevelSupported(string(config.Level), support.Levels) {
-			if allowClampUnsupported {
+			if allowHighIntentDowngrade {
+				config.Level = clampHighIntentLevelDown(config.Level, modelInfo, toFormat)
+			} else if allowClampUnsupported {
 				config.Level = clampLevel(config.Level, modelInfo, toFormat)
 			}
 			if !isLevelSupported(string(config.Level), support.Levels) {
@@ -237,7 +240,44 @@ func convertAutoToMidRange(config ThinkingConfig, support *registry.ThinkingSupp
 }
 
 // standardLevelOrder defines the canonical ordering of thinking levels from lowest to highest.
-var standardLevelOrder = []ThinkingLevel{LevelMinimal, LevelLow, LevelMedium, LevelHigh, LevelXHigh, LevelMax}
+var standardLevelOrder = []ThinkingLevel{LevelMinimal, LevelLow, LevelMedium, LevelHigh, LevelXHigh, LevelMax, LevelUltra}
+
+func isHighIntentLevel(level ThinkingLevel) bool {
+	switch level {
+	case LevelXHigh, LevelMax, LevelUltra:
+		return true
+	default:
+		return false
+	}
+}
+
+// clampHighIntentLevelDown selects the highest supported level at or below the
+// requested high-intent level. It never upgrades the request.
+func clampHighIntentLevelDown(level ThinkingLevel, modelInfo *registry.ModelInfo, provider string) ThinkingLevel {
+	if modelInfo == nil || modelInfo.Thinking == nil || len(modelInfo.Thinking.Levels) == 0 {
+		return level
+	}
+	requestedIndex := levelIndex(string(level))
+	if requestedIndex == -1 {
+		return level
+	}
+	highIndex := levelIndex(string(LevelHigh))
+	for index := requestedIndex; index >= highIndex; index-- {
+		candidate := standardLevelOrder[index]
+		if isLevelSupported(string(candidate), modelInfo.Thinking.Levels) {
+			if candidate != level {
+				log.WithFields(log.Fields{
+					"provider":       provider,
+					"model":          modelInfo.ID,
+					"original_value": string(level),
+					"clamped_to":     string(candidate),
+				}).Debug("thinking: high-intent level downgraded |")
+			}
+			return candidate
+		}
+	}
+	return level
+}
 
 // clampLevel clamps the given level to the nearest supported level.
 // On tie, prefers the lower level.

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -114,6 +114,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.Codex.DisableCodexCloaking != newCfg.Codex.DisableCodexCloaking {
 		changes = append(changes, fmt.Sprintf("codex.disable-codex-cloaking: %t -> %t", oldCfg.Codex.DisableCodexCloaking, newCfg.Codex.DisableCodexCloaking))
 	}
+	if oldCfg.Codex.DisableFingerprintAutoSync != newCfg.Codex.DisableFingerprintAutoSync {
+		changes = append(changes, fmt.Sprintf("codex.disable-fingerprint-auto-sync: %t -> %t", oldCfg.Codex.DisableFingerprintAutoSync, newCfg.Codex.DisableFingerprintAutoSync))
+	}
 	if oldCfg.Codex.OptimizeMultiAgentV2 != newCfg.Codex.OptimizeMultiAgentV2 {
 		changes = append(changes, fmt.Sprintf("codex.optimize-multi-agent-v2: %t -> %t", oldCfg.Codex.OptimizeMultiAgentV2, newCfg.Codex.OptimizeMultiAgentV2))
 	}

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -39,7 +39,10 @@ func TestBuildConfigChangeDetails(t *testing.T) {
 	newCfg := &config.Config{
 		Port:    9090,
 		AuthDir: "/tmp/auth-new",
-		Codex:   config.CodexConfig{DisableCodexCloaking: true},
+		Codex: config.CodexConfig{
+			DisableCodexCloaking:       true,
+			DisableFingerprintAutoSync: true,
+		},
 		GeminiKey: []config.GeminiKey{
 			{APIKey: "old", BaseURL: "http://old", ExcludedModels: []string{"old-model", "extra"}},
 		},
@@ -80,6 +83,7 @@ func TestBuildConfigChangeDetails(t *testing.T) {
 	expectContains(t, details, "remote-management.disable-auto-update-panel: false -> true")
 	expectContains(t, details, "remote-management.secret-key: updated")
 	expectContains(t, details, "codex.disable-codex-cloaking: false -> true")
+	expectContains(t, details, "codex.disable-fingerprint-auto-sync: false -> true")
 	expectContains(t, details, "oauth-excluded-models[providera]: updated (1 -> 2 entries)")
 	expectContains(t, details, "oauth-excluded-models[providerb]: added (1 entries)")
 	expectContains(t, details, "openai-compatibility:")

--- a/test/thinking_conversion_test.go
+++ b/test/thinking_conversion_test.go
@@ -77,15 +77,16 @@ func TestThinkingE2EMatrix_Suffix(t *testing.T) {
 			expectValue: "medium",
 			expectErr:   false,
 		},
-		// Case 3: Specified xhigh → out of range error
+		// Case 3: Specified xhigh → compatible downgrade to high
 		{
 			name:        "3",
 			from:        "openai",
 			to:          "codex",
 			model:       "level-model(xhigh)",
 			inputJSON:   `{"model":"level-model(xhigh)","messages":[{"role":"user","content":"hi"}]}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning.effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 4: Level none → clamped to minimal (ZeroAllowed=false)
 		{
@@ -978,15 +979,16 @@ func TestThinkingE2EMatrix_Suffix(t *testing.T) {
 			expectValue: "high",
 			expectErr:   false,
 		},
-		// Case 81: OpenAI to OpenAI, level xhigh → out of range error
+		// Case 81: OpenAI to OpenAI, level xhigh → compatible downgrade to high
 		{
 			name:        "81",
 			from:        "openai",
 			to:          "openai",
 			model:       "level-model(xhigh)",
 			inputJSON:   `{"model":"level-model(xhigh)","messages":[{"role":"user","content":"hi"}]}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning_effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 82: OpenAI-Response to Codex, level high → passthrough reasoning.effort
 		{
@@ -999,15 +1001,16 @@ func TestThinkingE2EMatrix_Suffix(t *testing.T) {
 			expectValue: "high",
 			expectErr:   false,
 		},
-		// Case 83: OpenAI-Response to Codex, level xhigh → out of range error
+		// Case 83: OpenAI-Response to Codex, level xhigh → compatible downgrade to high
 		{
 			name:        "83",
 			from:        "openai-response",
 			to:          "codex",
 			model:       "level-model(xhigh)",
 			inputJSON:   `{"model":"level-model(xhigh)","input":[{"role":"user","content":"hi"}]}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning.effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 84: Gemini to Gemini, budget 8192 → passthrough thinkingBudget
 		{
@@ -1121,15 +1124,16 @@ func TestThinkingE2EMatrix_Body(t *testing.T) {
 			expectValue: "medium",
 			expectErr:   false,
 		},
-		// Case 3: reasoning_effort=xhigh → out of range error
+		// Case 3: reasoning_effort=xhigh → compatible downgrade to high
 		{
 			name:        "3",
 			from:        "openai",
 			to:          "codex",
 			model:       "level-model",
 			inputJSON:   `{"model":"level-model","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"xhigh"}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning.effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 4: reasoning_effort=none → clamped to minimal
 		{
@@ -2052,15 +2056,16 @@ func TestThinkingE2EMatrix_Body(t *testing.T) {
 			expectValue: "high",
 			expectErr:   false,
 		},
-		// Case 81: OpenAI to OpenAI, reasoning_effort=xhigh → out of range error
+		// Case 81: OpenAI to OpenAI, reasoning_effort=xhigh → compatible downgrade to high
 		{
 			name:        "81",
 			from:        "openai",
 			to:          "openai",
 			model:       "level-model",
 			inputJSON:   `{"model":"level-model","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"xhigh"}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning_effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 82: OpenAI-Response to Codex, reasoning.effort=high → passthrough
 		{
@@ -2073,15 +2078,16 @@ func TestThinkingE2EMatrix_Body(t *testing.T) {
 			expectValue: "high",
 			expectErr:   false,
 		},
-		// Case 83: OpenAI-Response to Codex, reasoning.effort=xhigh → out of range error
+		// Case 83: OpenAI-Response to Codex, reasoning.effort=xhigh → compatible downgrade to high
 		{
 			name:        "83",
 			from:        "openai-response",
 			to:          "codex",
 			model:       "level-model",
 			inputJSON:   `{"model":"level-model","input":[{"role":"user","content":"hi"}],"reasoning":{"effort":"xhigh"}}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning.effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 84: Gemini to Gemini, thinkingBudget=8192 → passthrough
 		{


### PR DESCRIPTION
## Summary

- synchronize a validated Codex application fingerprint from official OpenAI NPM and source metadata, with an embedded offline profile and an opt-out configuration switch
- project one coherent account-scoped identity across OAuth HTTP, compact, and WebSocket requests, including client metadata, turn metadata, session/thread/window identifiers, version, originator, and user agent
- use a Chrome uTLS HTTP/1.1 handshake for official Codex WebSockets while retaining existing proxy behavior, and align current Codex model/reasoning compatibility metadata

## Compatibility

- applies only to file/OAuth credentials targeting `chatgpt.com/backend-api/codex`
- leaves API-key entries and custom gateways unchanged
- `codex.disable-codex-cloaking` retains the existing bypass behavior
- `codex.disable-fingerprint-auto-sync` disables network refresh while keeping the embedded profile

## Test Plan

- [x] `gofmt -w .`
- [x] `go test ./...`
- [x] `go build -o test-output ./cmd/server && rm test-output`
