### PR TITLE
perf(openai): reduce websocket transcript merge allocations

### DIFF
--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1515,11 +1515,13 @@ func TestNormalizeAuthNil(t *testing.T) {
 
 // stubStore implements coreauth.Store plus watcher-specific persistence helpers.
 type stubStore struct {
+	mu              sync.Mutex
 	authDir         string
-	cfgPersisted    int32
-	authPersisted   int32
+	cfgPersisted    int
+	authPersisted   int
 	lastAuthMessage string
 	lastAuthPaths   []string
+	persisted       chan struct{}
 }
 
 func (s *stubStore) List(context.Context) ([]*coreauth.Auth, error) { return nil, nil }
@@ -1528,16 +1530,38 @@ func (s *stubStore) Save(context.Context, *coreauth.Auth) (string, error) {
 }
 func (s *stubStore) Delete(context.Context, string) error { return nil }
 func (s *stubStore) PersistConfig(context.Context) error {
-	atomic.AddInt32(&s.cfgPersisted, 1)
+	s.mu.Lock()
+	s.cfgPersisted++
+	s.mu.Unlock()
+	s.signalPersisted()
 	return nil
 }
 func (s *stubStore) PersistAuthFiles(_ context.Context, message string, paths ...string) error {
-	atomic.AddInt32(&s.authPersisted, 1)
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.lastAuthMessage = message
-	s.lastAuthPaths = paths
+	s.lastAuthPaths = append([]string(nil), paths...)
+	s.authPersisted++
+	s.signalPersisted()
 	return nil
 }
 func (s *stubStore) AuthDir() string { return s.authDir }
+
+func (s *stubStore) signalPersisted() {
+	if s.persisted == nil {
+		return
+	}
+	select {
+	case s.persisted <- struct{}{}:
+	default:
+	}
+}
+
+func (s *stubStore) persistenceSnapshot() (cfgPersisted, authPersisted int, message string, paths []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cfgPersisted, s.authPersisted, s.lastAuthMessage, append([]string(nil), s.lastAuthPaths...)
+}
 
 func TestNewWatcherDetectsPersisterAndAuthDir(t *testing.T) {
 	tmp := t.TempDir()
@@ -1559,26 +1583,33 @@ func TestNewWatcherDetectsPersisterAndAuthDir(t *testing.T) {
 }
 
 func TestPersistConfigAndAuthAsyncInvokePersister(t *testing.T) {
+	store := &stubStore{persisted: make(chan struct{}, 2)}
 	w := &Watcher{
-		storePersister: &stubStore{},
+		storePersister: store,
 	}
 
 	w.persistConfigAsync()
 	w.persistAuthAsync("msg", " a ", "", "b ")
 
-	time.Sleep(30 * time.Millisecond)
-	store := w.storePersister.(*stubStore)
-	if atomic.LoadInt32(&store.cfgPersisted) != 1 {
-		t.Fatalf("expected PersistConfig to be called once, got %d", store.cfgPersisted)
+	for range 2 {
+		select {
+		case <-store.persisted:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for asynchronous persistence")
+		}
 	}
-	if atomic.LoadInt32(&store.authPersisted) != 1 {
-		t.Fatalf("expected PersistAuthFiles to be called once, got %d", store.authPersisted)
+	cfgPersisted, authPersisted, message, paths := store.persistenceSnapshot()
+	if cfgPersisted != 1 {
+		t.Fatalf("expected PersistConfig to be called once, got %d", cfgPersisted)
 	}
-	if store.lastAuthMessage != "msg" {
-		t.Fatalf("unexpected auth message: %s", store.lastAuthMessage)
+	if authPersisted != 1 {
+		t.Fatalf("expected PersistAuthFiles to be called once, got %d", authPersisted)
 	}
-	if len(store.lastAuthPaths) != 2 || store.lastAuthPaths[0] != "a" || store.lastAuthPaths[1] != "b" {
-		t.Fatalf("unexpected filtered paths: %#v", store.lastAuthPaths)
+	if message != "msg" {
+		t.Fatalf("unexpected auth message: %s", message)
+	}
+	if len(paths) != 2 || paths[0] != "a" || paths[1] != "b" {
+		t.Fatalf("unexpected filtered paths: %#v", paths)
 	}
 }
 
@@ -1601,13 +1632,21 @@ func TestScheduleConfigReloadDebounces(t *testing.T) {
 	w.scheduleConfigReload()
 	w.scheduleConfigReload()
 
-	time.Sleep(400 * time.Millisecond)
-
-	if atomic.LoadInt32(&reloads) != 1 {
-		t.Fatalf("expected single debounced reload, got %d", reloads)
+	deadline := time.Now().Add(time.Second)
+	for {
+		w.clientsMutex.RLock()
+		hashSet := w.lastConfigHash != ""
+		w.clientsMutex.RUnlock()
+		if hashSet {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for debounced config reload")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
-	if w.lastConfigHash == "" {
-		t.Fatal("expected lastConfigHash to be set after reload")
+	if got := atomic.LoadInt32(&reloads); got != 1 {
+		t.Fatalf("expected single debounced reload, got %d", got)
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_responses_multi_agent_test.go
+++ b/sdk/api/handlers/openai/openai_responses_multi_agent_test.go
@@ -23,7 +23,6 @@ import (
 func TestPrepareCodexMultiAgentV2ToolsAtResponsesBoundary(t *testing.T) {
 	t.Parallel()
 
-	gin.SetMode(gin.TestMode)
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{CodexOptimizeMultiAgentV2: true}, nil)
 	handler := NewOpenAIResponsesAPIHandler(base)
 	request := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
@@ -181,7 +180,6 @@ func TestResponsesWebsocketPreparesCodexMultiAgentV2Tools(t *testing.T) {
 func TestPrepareCodexMultiAgentV2ToolsAtResponsesBoundarySkipsOtherClients(t *testing.T) {
 	t.Parallel()
 
-	gin.SetMode(gin.TestMode)
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{CodexOptimizeMultiAgentV2: true}, nil)
 	handler := NewOpenAIResponsesAPIHandler(base)
 	request := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)

--- a/sdk/api/handlers/openai/openai_responses_websocket_requests.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_requests.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -129,10 +131,10 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 	// skip merging with stale lastRequest/lastResponseOutput to avoid breaking
 	// function_call / function_call_output pairings.
 	// See: https://github.com/router-for-me/CLIProxyAPI/issues/2207
-	var mergedInput string
+	var mergedInput []byte
 	if allowCompactionReplayBypass && inputContainsFullTranscript(nextInput) {
 		log.Infof("responses websocket: full transcript detected, skipping stale merge (input items=%d)", len(nextInput.Array()))
-		mergedInput = nextInput.Raw
+		mergedInput = []byte(nextInput.Raw)
 	} else {
 		appendInputRaw := nextInput.Raw
 		if inputContainsFullTranscript(nextInput) {
@@ -168,7 +170,7 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 	}
 	normalized, _ = sjson.SetBytes(normalized, "stream", true)
 	var errSet error
-	normalized, errSet = sjson.SetRawBytes(normalized, "input", []byte(mergedInput))
+	normalized, errSet = sjson.SetRawBytes(normalized, "input", mergedInput)
 	if errSet != nil {
 		return nil, lastRequest, &interfaces.ErrorMessage{
 			StatusCode: http.StatusBadRequest,
@@ -319,38 +321,202 @@ type responsesWebsocketInputItem struct {
 	callID   string
 }
 
-func mergeResponsesWebsocketInput(lastRequest []byte, lastResponseOutput []byte, appendRaw string) (string, error) {
+type responsesWebsocketMergeInputItem struct {
+	// raw may reference a caller-owned request buffer. Merge items must remain
+	// local to mergeResponsesWebsocketInput, which copies every item into the
+	// owned output buffer before returning.
+	raw      string
+	itemType string
+	id       string
+	callID   string
+}
+
+func mergeResponsesWebsocketInput(lastRequest []byte, lastResponseOutput []byte, appendRaw string) ([]byte, error) {
+	previousInput, errPrevious := responsesWebsocketPreviousInputNoCopy(lastRequest)
+	if errPrevious != nil {
+		return nil, fmt.Errorf("invalid previous request input: %w", errPrevious)
+	}
+	items, errExisting := appendResponsesWebsocketMergeInputResult(nil, previousInput)
+	if errExisting != nil {
+		return nil, fmt.Errorf("invalid previous request input: %w", errExisting)
+	}
+
+	trimmedResponse := bytes.TrimSpace(lastResponseOutput)
+	if len(trimmedResponse) > 0 && trimmedResponse[0] == '[' && json.Valid(trimmedResponse) {
+		responseInput := util.ParseGJSONBytesNoCopy(trimmedResponse)
+		var errResponse error
+		items, errResponse = appendResponsesWebsocketMergeInputResult(items, responseInput)
+		if errResponse != nil {
+			return nil, fmt.Errorf("invalid previous response output: %w", errResponse)
+		}
+	}
+
+	items, errAppend := appendResponsesWebsocketMergeInputItems(items, appendRaw)
+	if errAppend != nil {
+		return nil, fmt.Errorf("invalid request input: %w", errAppend)
+	}
+
+	items = dedupeResponsesWebsocketMergeFunctionCalls(items)
+	items = dedupeResponsesWebsocketMergeInputItems(items)
+	return marshalResponsesWebsocketMergeInputItems(items), nil
+}
+
+func responsesWebsocketPreviousInputNoCopy(lastRequest []byte) (gjson.Result, error) {
+	if !json.Valid(lastRequest) {
+		return gjson.Result{}, responsesWebsocketPreviousInputDecodeError(lastRequest)
+	}
+
+	root := util.ParseGJSONBytesNoCopy(lastRequest)
+	if root.Type == gjson.Null {
+		return gjson.Parse("[]"), nil
+	}
+	if !root.IsObject() {
+		return gjson.Result{}, responsesWebsocketPreviousInputDecodeError(lastRequest)
+	}
+
+	input := root.Get("input")
+	if !input.Exists() || input.Type == gjson.Null {
+		return gjson.Parse("[]"), nil
+	}
+	if !input.IsArray() {
+		return gjson.Result{}, responsesWebsocketPreviousInputDecodeError(lastRequest)
+	}
+	return input, nil
+}
+
+func responsesWebsocketPreviousInputDecodeError(lastRequest []byte) error {
 	var previousRequest struct {
 		Input []json.RawMessage `json:"input"`
 	}
-	if errUnmarshal := json.Unmarshal(lastRequest, &previousRequest); errUnmarshal != nil {
-		return "", fmt.Errorf("invalid previous request input: %w", errUnmarshal)
+	return json.Unmarshal(lastRequest, &previousRequest)
+}
+
+func appendResponsesWebsocketMergeInputItems(items []responsesWebsocketMergeInputItem, rawArray string) ([]responsesWebsocketMergeInputItem, error) {
+	rawArray = strings.TrimSpace(rawArray)
+	if rawArray == "" {
+		rawArray = "[]"
 	}
-	items, errExisting := appendResponsesWebsocketRawInputItems(nil, previousRequest.Input)
-	if errExisting != nil {
-		return "", fmt.Errorf("invalid previous request input: %w", errExisting)
+	parsed := gjson.Parse(rawArray)
+	if gjson.Valid(rawArray) {
+		return appendResponsesWebsocketMergeInputResult(items, parsed)
 	}
 
-	var responseItems []json.RawMessage
-	trimmedResponse := bytes.TrimSpace(lastResponseOutput)
-	if len(trimmedResponse) > 0 && trimmedResponse[0] == '[' && json.Valid(trimmedResponse) {
-		if errUnmarshal := json.Unmarshal(trimmedResponse, &responseItems); errUnmarshal != nil {
-			return "", fmt.Errorf("invalid previous response output: %w", errUnmarshal)
+	var rawItems []json.RawMessage
+	if errUnmarshal := json.Unmarshal([]byte(rawArray), &rawItems); errUnmarshal != nil {
+		return nil, errUnmarshal
+	}
+	return items, nil
+}
+
+func appendResponsesWebsocketMergeInputResult(items []responsesWebsocketMergeInputItem, input gjson.Result) ([]responsesWebsocketMergeInputItem, error) {
+	if input.Type == gjson.Null {
+		return items, nil
+	}
+	if !input.IsArray() {
+		var rawItems []json.RawMessage
+		if errUnmarshal := json.Unmarshal([]byte(input.Raw), &rawItems); errUnmarshal != nil {
+			return nil, errUnmarshal
+		}
+		return items, nil
+	}
+
+	rawItems := input.Array()
+	items = slices.Grow(items, len(rawItems))
+	for _, rawItem := range rawItems {
+		item := responsesWebsocketMergeInputItem{raw: rawItem.Raw}
+		if rawItem.IsObject() {
+			rawItem.ForEach(func(key, value gjson.Result) bool {
+				switch key.String() {
+				case "type":
+					item.itemType = strings.TrimSpace(value.String())
+				case "id":
+					item.id = strings.TrimSpace(value.String())
+				case "call_id":
+					item.callID = strings.TrimSpace(value.String())
+				}
+				return true
+			})
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}
+
+func dedupeResponsesWebsocketMergeFunctionCalls(items []responsesWebsocketMergeInputItem) []responsesWebsocketMergeInputItem {
+	seenCallIDs := make(map[string]struct{}, len(items))
+	filtered := items[:0]
+	for _, item := range items {
+		if isResponsesToolCallType(item.itemType) && item.callID != "" {
+			if _, ok := seenCallIDs[item.callID]; ok {
+				continue
+			}
+			seenCallIDs[item.callID] = struct{}{}
+		}
+		filtered = append(filtered, item)
+	}
+	clear(items[len(filtered):])
+	return filtered
+}
+
+func dedupeResponsesWebsocketMergeInputItems(items []responsesWebsocketMergeInputItem) []responsesWebsocketMergeInputItem {
+	referencedCallIDs := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		if isResponsesToolCallOutputType(item.itemType) && item.callID != "" {
+			referencedCallIDs[item.callID] = struct{}{}
 		}
 	}
-	items, errResponse := appendResponsesWebsocketRawInputItems(items, responseItems)
-	if errResponse != nil {
-		return "", fmt.Errorf("invalid previous response output: %w", errResponse)
+
+	keepIndexByID := make(map[string]int, len(items))
+	keepReferencedByID := make(map[string]bool, len(items))
+	for index, item := range items {
+		if item.id == "" {
+			continue
+		}
+		_, referenced := referencedCallIDs[item.callID]
+		referenced = referenced && item.callID != ""
+		if _, seen := keepIndexByID[item.id]; !seen {
+			keepIndexByID[item.id] = index
+			keepReferencedByID[item.id] = referenced
+			continue
+		}
+		if referenced || !keepReferencedByID[item.id] {
+			keepIndexByID[item.id] = index
+			keepReferencedByID[item.id] = referenced
+		}
 	}
 
-	items, errAppend := appendResponsesWebsocketInputItems(items, appendRaw)
-	if errAppend != nil {
-		return "", fmt.Errorf("invalid request input: %w", errAppend)
+	filtered := items[:0]
+	for index, item := range items {
+		if item.id != "" && keepIndexByID[item.id] != index {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	clear(items[len(filtered):])
+	return filtered
+}
+
+func marshalResponsesWebsocketMergeInputItems(items []responsesWebsocketMergeInputItem) []byte {
+	outputLength := 2
+	if len(items) > 1 {
+		outputLength += len(items) - 1
+	}
+	for _, item := range items {
+		outputLength += len(item.raw)
 	}
 
-	items = dedupeResponsesWebsocketFunctionCalls(items)
-	items = dedupeResponsesWebsocketInputItems(items)
-	return marshalResponsesWebsocketInputItems(items)
+	// This allocation establishes ownership of the merged transcript and is the
+	// only large allocation the merge path retains after it returns.
+	out := make([]byte, 0, outputLength)
+	out = append(out, '[')
+	for index, item := range items {
+		if index > 0 {
+			out = append(out, ',')
+		}
+		out = append(out, item.raw...)
+	}
+	out = append(out, ']')
+	return out
 }
 
 func parseResponsesWebsocketInputItems(rawArray string) ([]responsesWebsocketInputItem, error) {

--- a/sdk/api/handlers/openai/openai_responses_websocket_requests.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_requests.go
@@ -374,12 +374,29 @@ func responsesWebsocketPreviousInputNoCopy(lastRequest []byte) (gjson.Result, er
 		return gjson.Result{}, responsesWebsocketPreviousInputDecodeError(lastRequest)
 	}
 
-	input := root.Get("input")
-	if !input.Exists() || input.Type == gjson.Null {
-		return gjson.Parse("[]"), nil
-	}
-	if !input.IsArray() {
+	var input gjson.Result
+	inputFound := false
+	invalidInput := false
+	root.ForEach(func(key, value gjson.Result) bool {
+		if !strings.EqualFold(key.String(), "input") {
+			return true
+		}
+		// encoding/json processes matching duplicate fields in source order,
+		// retains the last value, and still reports a type error from any
+		// incompatible duplicate. Preserve those semantics without copying the
+		// selected array out of the caller-owned request buffer.
+		inputFound = true
+		input = value
+		if value.Type != gjson.Null && !value.IsArray() {
+			invalidInput = true
+		}
+		return true
+	})
+	if invalidInput {
 		return gjson.Result{}, responsesWebsocketPreviousInputDecodeError(lastRequest)
+	}
+	if !inputFound || input.Type == gjson.Null {
+		return gjson.Parse("[]"), nil
 	}
 	return input, nil
 }

--- a/sdk/api/handlers/openai/openai_responses_websocket_requests.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_requests.go
@@ -443,12 +443,13 @@ func appendResponsesWebsocketMergeInputResult(items []responsesWebsocketMergeInp
 		item := responsesWebsocketMergeInputItem{raw: rawItem.Raw}
 		if rawItem.IsObject() {
 			rawItem.ForEach(func(key, value gjson.Result) bool {
-				switch key.String() {
-				case "type":
+				metadataKey := key.String()
+				switch {
+				case strings.EqualFold(metadataKey, "type"):
 					item.itemType = strings.TrimSpace(value.String())
-				case "id":
+				case strings.EqualFold(metadataKey, "id"):
 					item.id = strings.TrimSpace(value.String())
-				case "call_id":
+				case strings.EqualFold(metadataKey, "call_id"):
 					item.callID = strings.TrimSpace(value.String())
 				}
 				return true

--- a/sdk/api/handlers/openai/openai_responses_websocket_requests_memory_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_requests_memory_test.go
@@ -1,0 +1,407 @@
+package openai
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const (
+	responsesWebsocketLargeTranscriptSize     = 1 << 20
+	responsesWebsocketBenchmarkTranscriptSize = 8 << 20
+)
+
+var (
+	responsesWebsocketMergedInputSink       []byte
+	responsesWebsocketNormalizedRequestSink []byte
+)
+
+func TestMergeResponsesWebsocketInputMatchesReferenceSemantics(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		lastRequest        string
+		lastResponseOutput string
+		appendInput        string
+	}{
+		{
+			name:               "messages and paired tool call",
+			lastRequest:        `{"model":"gpt-5.4","input":[{"type":"message","id":"msg-1","role":"user","content":"hello"}]}`,
+			lastResponseOutput: `[{"type":"function_call","id":"fc-1","call_id":"call-1","name":"lookup","arguments":"{}"}]`,
+			appendInput:        `[{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"done"}]`,
+		},
+		{
+			name:               "duplicate function call keeps first",
+			lastRequest:        `{"input":[{"type":"function_call","id":"fc-first","call_id":"call-1","name":"first","arguments":"{}"}]}`,
+			lastResponseOutput: `[{"type":"function_call","id":"fc-second","call_id":"call-1","name":"second","arguments":"{}"}]`,
+			appendInput:        `[{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"done"}]`,
+		},
+		{
+			name:               "duplicate id keeps item referenced by output",
+			lastRequest:        `{"input":[{"type":"function_call","id":"fc-1","call_id":"call-kept","name":"first","arguments":"{}"}]}`,
+			lastResponseOutput: `[{"type":"function_call","id":"fc-1","call_id":"call-other","name":"second","arguments":"{}"}]`,
+			appendInput:        `[{"type":"function_call_output","id":"fco-1","call_id":"call-kept","output":"done"}]`,
+		},
+		{
+			name:               "raw JSON values and escaping",
+			lastRequest:        `{"input":[ {"type":"message","id":"msg-1","content":"<tag> & \\u263a"}, true ]}`,
+			lastResponseOutput: `[null, 42, "line\\nvalue"]`,
+			appendInput:        `[{"id":"last","nested":{"value":[1,2,3]}}]`,
+		},
+		{
+			name:               "invalid response output remains ignored",
+			lastRequest:        `{"input":[{"id":"first"}]}`,
+			lastResponseOutput: `[{"id":`,
+			appendInput:        `[{"id":"last"}]`,
+		},
+		{
+			name:               "missing previous input and null append",
+			lastRequest:        `{"model":"gpt-5.4"}`,
+			lastResponseOutput: `[{"id":"response"}]`,
+			appendInput:        `null`,
+		},
+		{
+			name:               "null previous request",
+			lastRequest:        `null`,
+			lastResponseOutput: `[]`,
+			appendInput:        `[{"id":"last"}]`,
+		},
+		{
+			name:               "duplicate metadata keys follow encoding json",
+			lastRequest:        `{"input":[{"type":"message","type":"function_call","id":"first","id":"fc-1","call_id":"call-other","call_id":"call-kept"}]}`,
+			lastResponseOutput: `[{"type":"function_call","id":"fc-2","call_id":"call-kept"}]`,
+			appendInput:        `[{"type":"function_call_output","id":"fco-1","call_id":"call-kept","output":"done"}]`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			want, errWant := mergeResponsesWebsocketInputReference([]byte(test.lastRequest), []byte(test.lastResponseOutput), test.appendInput)
+			if errWant != nil {
+				t.Fatalf("reference merge failed: %v", errWant)
+			}
+			got, errGot := mergeResponsesWebsocketInput([]byte(test.lastRequest), []byte(test.lastResponseOutput), test.appendInput)
+			if errGot != nil {
+				t.Fatalf("mergeResponsesWebsocketInput() error = %v", errGot)
+			}
+			assertJSONSemanticallyEqual(t, got, want)
+		})
+	}
+}
+
+func TestMergeResponsesWebsocketInputMatchesReferenceErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		lastRequest        string
+		lastResponseOutput string
+		appendInput        string
+	}{
+		{name: "invalid previous request", lastRequest: `{"input":`, appendInput: `[]`},
+		{name: "non-array previous input", lastRequest: `{"input":{"id":"item"}}`, appendInput: `[]`},
+		{name: "invalid appended input", lastRequest: `{"input":[]}`, appendInput: `[{"id":`},
+		{name: "non-array appended input", lastRequest: `{"input":[]}`, appendInput: `{"id":"item"}`},
+		{name: "array previous request", lastRequest: `[]`, appendInput: `[]`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, errWant := mergeResponsesWebsocketInputReference([]byte(test.lastRequest), []byte(test.lastResponseOutput), test.appendInput)
+			_, errGot := mergeResponsesWebsocketInput([]byte(test.lastRequest), []byte(test.lastResponseOutput), test.appendInput)
+			if (errGot == nil) != (errWant == nil) {
+				t.Fatalf("error presence differs: got %v, reference %v", errGot, errWant)
+			}
+			if errGot == nil {
+				t.Fatal("expected merge error")
+			}
+			if errGot.Error() != errWant.Error() {
+				t.Fatalf("error differs:\n got: %v\nwant: %v", errGot, errWant)
+			}
+		})
+	}
+}
+
+func TestMergeResponsesWebsocketInputMatchesReferenceAcrossGeneratedTranscripts(t *testing.T) {
+	t.Parallel()
+
+	random := rand.New(rand.NewSource(0xC0DE))
+	for iteration := 0; iteration < 250; iteration++ {
+		previous := generatedResponsesWebsocketInput(t, random, random.Intn(12))
+		response := generatedResponsesWebsocketInput(t, random, random.Intn(12))
+		appendInput := generatedResponsesWebsocketInput(t, random, random.Intn(12))
+		lastRequest := append(append([]byte(`{"model":"gpt-5.4","input":`), previous...), '}')
+
+		want, errWant := mergeResponsesWebsocketInputReference(lastRequest, response, string(appendInput))
+		if errWant != nil {
+			t.Fatalf("iteration %d reference merge failed: %v", iteration, errWant)
+		}
+		got, errGot := mergeResponsesWebsocketInput(lastRequest, response, string(appendInput))
+		if errGot != nil {
+			t.Fatalf("iteration %d merge failed: %v", iteration, errGot)
+		}
+		assertJSONSemanticallyEqual(t, got, want)
+	}
+}
+
+func generatedResponsesWebsocketInput(t *testing.T, random *rand.Rand, count int) []byte {
+	t.Helper()
+
+	items := make([]any, 0, count)
+	itemTypes := []string{"message", "function_call", "function_call_output", "custom_tool_call", "custom_tool_call_output", "reasoning"}
+	for index := 0; index < count; index++ {
+		if random.Intn(10) == 0 {
+			items = append(items, []any{true, float64(index), nil}[random.Intn(3)])
+			continue
+		}
+		item := map[string]any{
+			"type":    itemTypes[random.Intn(len(itemTypes))],
+			"id":      fmt.Sprintf("item-%d", random.Intn(8)),
+			"call_id": fmt.Sprintf("call-%d", random.Intn(6)),
+			"content": fmt.Sprintf("iteration-%d <tag> & \\u263a", index),
+		}
+		items = append(items, item)
+	}
+	out, errMarshal := json.Marshal(items)
+	if errMarshal != nil {
+		t.Fatalf("marshal generated input: %v", errMarshal)
+	}
+	return out
+}
+
+func TestNormalizeResponseSubsequentRequestDetachesSourceBuffers(t *testing.T) {
+	t.Parallel()
+
+	lastRequest := []byte(`{"model":"gpt-5.4","instructions":"keep me","input":[{"type":"message","id":"msg-1","role":"user","content":"history sentinel"}]}`)
+	lastResponseOutput := []byte(`[{"type":"message","id":"msg-2","role":"assistant","content":[{"type":"output_text","text":"response sentinel"}]}]`)
+	raw := []byte(`{"type":"response.create","input":[{"type":"message","id":"msg-3","role":"user","content":"append sentinel"}]}`)
+
+	normalized, next, errMessage := normalizeResponseSubsequentRequest(raw, lastRequest, lastResponseOutput, "", nil, false, false)
+	if errMessage != nil {
+		t.Fatalf("normalizeResponseSubsequentRequest() error = %v", errMessage.Error)
+	}
+	wantNormalized := bytes.Clone(normalized)
+	wantNext := bytes.Clone(next)
+
+	for _, source := range [][]byte{lastRequest, lastResponseOutput, raw} {
+		for index := range source {
+			source[index] = 'x'
+		}
+	}
+	runtime.KeepAlive(lastRequest)
+	runtime.KeepAlive(lastResponseOutput)
+	runtime.KeepAlive(raw)
+
+	if !bytes.Equal(normalized, wantNormalized) {
+		t.Fatal("normalized request aliases a source buffer")
+	}
+	if !bytes.Equal(next, wantNext) {
+		t.Fatal("stored next request aliases a source buffer")
+	}
+}
+
+func TestMergeResponsesWebsocketInputBoundsLargeTranscriptAllocations(t *testing.T) {
+	lastRequest, lastResponseOutput, appendInput := responsesWebsocketLargeTranscriptFixture()
+	inputBytes := len(lastRequest) + len(lastResponseOutput) + len(appendInput)
+
+	result := testing.Benchmark(func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			merged, errMerge := mergeResponsesWebsocketInput(lastRequest, lastResponseOutput, appendInput)
+			if errMerge != nil {
+				b.Fatalf("mergeResponsesWebsocketInput() error = %v", errMerge)
+			}
+			responsesWebsocketMergedInputSink = merged
+		}
+	})
+
+	const maxAllocationMultiple = 2
+	maxAllocatedBytes := int64(inputBytes * maxAllocationMultiple)
+	t.Logf("merge allocated %d bytes per operation for %d input bytes", result.AllocedBytesPerOp(), inputBytes)
+	if allocatedBytes := result.AllocedBytesPerOp(); allocatedBytes > maxAllocatedBytes {
+		t.Fatalf("merging %d input bytes allocated %d bytes per operation, want at most %d", inputBytes, allocatedBytes, maxAllocatedBytes)
+	}
+}
+
+func BenchmarkNormalizeResponseSubsequentRequestLargeTranscript(b *testing.B) {
+	lastRequest, lastResponseOutput, appendInput := responsesWebsocketTranscriptFixture(responsesWebsocketBenchmarkTranscriptSize)
+	raw := []byte(`{"type":"response.create","input":` + appendInput + `}`)
+
+	b.SetBytes(int64(len(lastRequest) + len(lastResponseOutput) + len(raw)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		normalized, _, errMessage := normalizeResponseSubsequentRequest(raw, lastRequest, lastResponseOutput, "", nil, false, false)
+		if errMessage != nil {
+			b.Fatalf("normalizeResponseSubsequentRequest() error = %v", errMessage.Error)
+		}
+		responsesWebsocketNormalizedRequestSink = normalized
+	}
+}
+
+func responsesWebsocketLargeTranscriptFixture() ([]byte, []byte, string) {
+	return responsesWebsocketTranscriptFixture(responsesWebsocketLargeTranscriptSize)
+}
+
+func responsesWebsocketTranscriptFixture(transcriptSize int) ([]byte, []byte, string) {
+	lastRequest := []byte(`{"model":"gpt-5.4","instructions":"coding","stream":true,"input":[{"type":"message","id":"msg-large","role":"user","content":"` + strings.Repeat("x", transcriptSize) + `"}]}`)
+	lastResponseOutput := []byte(`[{"type":"function_call","id":"fc-1","call_id":"call-1","name":"lookup","arguments":"{}"}]`)
+	appendInput := `[{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"done"}]`
+	return lastRequest, lastResponseOutput, appendInput
+}
+
+type referenceResponsesWebsocketInputItem struct {
+	raw      json.RawMessage
+	itemType string
+	id       string
+	callID   string
+}
+
+func mergeResponsesWebsocketInputReference(lastRequest []byte, lastResponseOutput []byte, appendRaw string) (string, error) {
+	var previousRequest struct {
+		Input []json.RawMessage `json:"input"`
+	}
+	if errUnmarshal := json.Unmarshal(lastRequest, &previousRequest); errUnmarshal != nil {
+		return "", fmt.Errorf("invalid previous request input: %w", errUnmarshal)
+	}
+	items, errExisting := appendReferenceResponsesWebsocketRawInputItems(nil, previousRequest.Input)
+	if errExisting != nil {
+		return "", fmt.Errorf("invalid previous request input: %w", errExisting)
+	}
+
+	var responseItems []json.RawMessage
+	trimmedResponse := bytes.TrimSpace(lastResponseOutput)
+	if len(trimmedResponse) > 0 && trimmedResponse[0] == '[' && json.Valid(trimmedResponse) {
+		if errUnmarshal := json.Unmarshal(trimmedResponse, &responseItems); errUnmarshal != nil {
+			return "", fmt.Errorf("invalid previous response output: %w", errUnmarshal)
+		}
+	}
+	items, errResponse := appendReferenceResponsesWebsocketRawInputItems(items, responseItems)
+	if errResponse != nil {
+		return "", fmt.Errorf("invalid previous response output: %w", errResponse)
+	}
+
+	appendRaw = strings.TrimSpace(appendRaw)
+	if appendRaw == "" {
+		appendRaw = "[]"
+	}
+	var appendItems []json.RawMessage
+	if errUnmarshal := json.Unmarshal([]byte(appendRaw), &appendItems); errUnmarshal != nil {
+		return "", fmt.Errorf("invalid request input: %w", errUnmarshal)
+	}
+	items, errAppend := appendReferenceResponsesWebsocketRawInputItems(items, appendItems)
+	if errAppend != nil {
+		return "", fmt.Errorf("invalid request input: %w", errAppend)
+	}
+
+	items = dedupeReferenceResponsesWebsocketFunctionCalls(items)
+	items = dedupeReferenceResponsesWebsocketInputItems(items)
+	rawItems := make([]json.RawMessage, len(items))
+	for index := range items {
+		rawItems[index] = items[index].raw
+	}
+	out, errMarshal := json.Marshal(rawItems)
+	if errMarshal != nil {
+		return "", errMarshal
+	}
+	return string(out), nil
+}
+
+func appendReferenceResponsesWebsocketRawInputItems(items []referenceResponsesWebsocketInputItem, rawItems []json.RawMessage) ([]referenceResponsesWebsocketInputItem, error) {
+	for _, rawItem := range rawItems {
+		item := referenceResponsesWebsocketInputItem{raw: rawItem}
+		trimmed := bytes.TrimSpace(rawItem)
+		if len(trimmed) > 0 && trimmed[0] == '{' {
+			var metadata struct {
+				Type   json.RawMessage `json:"type"`
+				ID     json.RawMessage `json:"id"`
+				CallID json.RawMessage `json:"call_id"`
+			}
+			if errUnmarshal := json.Unmarshal(trimmed, &metadata); errUnmarshal != nil {
+				return nil, errUnmarshal
+			}
+			item.itemType = responsesWebsocketMetadataString(metadata.Type)
+			item.id = responsesWebsocketMetadataString(metadata.ID)
+			item.callID = responsesWebsocketMetadataString(metadata.CallID)
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}
+
+func dedupeReferenceResponsesWebsocketFunctionCalls(items []referenceResponsesWebsocketInputItem) []referenceResponsesWebsocketInputItem {
+	seenCallIDs := make(map[string]struct{}, len(items))
+	filtered := items[:0]
+	for _, item := range items {
+		if isResponsesToolCallType(item.itemType) && item.callID != "" {
+			if _, ok := seenCallIDs[item.callID]; ok {
+				continue
+			}
+			seenCallIDs[item.callID] = struct{}{}
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}
+
+func dedupeReferenceResponsesWebsocketInputItems(items []referenceResponsesWebsocketInputItem) []referenceResponsesWebsocketInputItem {
+	referencedCallIDs := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		if isResponsesToolCallOutputType(item.itemType) && item.callID != "" {
+			referencedCallIDs[item.callID] = struct{}{}
+		}
+	}
+
+	keepIndexByID := make(map[string]int, len(items))
+	keepReferencedByID := make(map[string]bool, len(items))
+	for index, item := range items {
+		if item.id == "" {
+			continue
+		}
+		_, referenced := referencedCallIDs[item.callID]
+		referenced = referenced && item.callID != ""
+		if _, seen := keepIndexByID[item.id]; !seen {
+			keepIndexByID[item.id] = index
+			keepReferencedByID[item.id] = referenced
+			continue
+		}
+		if referenced || !keepReferencedByID[item.id] {
+			keepIndexByID[item.id] = index
+			keepReferencedByID[item.id] = referenced
+		}
+	}
+
+	filtered := items[:0]
+	for index, item := range items {
+		if item.id != "" && keepIndexByID[item.id] != index {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}
+
+func assertJSONSemanticallyEqual(t *testing.T, got []byte, want string) {
+	t.Helper()
+	var gotValue any
+	if errUnmarshal := json.Unmarshal(got, &gotValue); errUnmarshal != nil {
+		t.Fatalf("invalid actual JSON: %v\n%s", errUnmarshal, got)
+	}
+	var wantValue any
+	if errUnmarshal := json.Unmarshal([]byte(want), &wantValue); errUnmarshal != nil {
+		t.Fatalf("invalid reference JSON: %v\n%s", errUnmarshal, want)
+	}
+	if !reflect.DeepEqual(gotValue, wantValue) {
+		t.Fatalf("JSON values differ:\n got: %s\nwant: %s", got, want)
+	}
+}

--- a/sdk/api/handlers/openai/openai_responses_websocket_requests_memory_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_requests_memory_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -17,11 +18,11 @@ const (
 )
 
 var (
-	responsesWebsocketMergedInputSink       []byte
+	responsesWebsocketMergedInputSink       any
 	responsesWebsocketNormalizedRequestSink []byte
 )
 
-func TestMergeResponsesWebsocketInputMatchesReferenceSemantics(t *testing.T) {
+func TestMergeResponsesWebsocketInputMatchesCompatibilityScenarios(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -29,54 +30,70 @@ func TestMergeResponsesWebsocketInputMatchesReferenceSemantics(t *testing.T) {
 		lastRequest        string
 		lastResponseOutput string
 		appendInput        string
+		want               string
 	}{
 		{
 			name:               "messages and paired tool call",
 			lastRequest:        `{"model":"gpt-5.4","input":[{"type":"message","id":"msg-1","role":"user","content":"hello"}]}`,
 			lastResponseOutput: `[{"type":"function_call","id":"fc-1","call_id":"call-1","name":"lookup","arguments":"{}"}]`,
 			appendInput:        `[{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"done"}]`,
+			want:               `[{"type":"message","id":"msg-1","role":"user","content":"hello"},{"type":"function_call","id":"fc-1","call_id":"call-1","name":"lookup","arguments":"{}"},{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"done"}]`,
 		},
 		{
 			name:               "duplicate function call keeps first",
 			lastRequest:        `{"input":[{"type":"function_call","id":"fc-first","call_id":"call-1","name":"first","arguments":"{}"}]}`,
 			lastResponseOutput: `[{"type":"function_call","id":"fc-second","call_id":"call-1","name":"second","arguments":"{}"}]`,
 			appendInput:        `[{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"done"}]`,
+			want:               `[{"type":"function_call","id":"fc-first","call_id":"call-1","name":"first","arguments":"{}"},{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"done"}]`,
 		},
 		{
 			name:               "duplicate id keeps item referenced by output",
 			lastRequest:        `{"input":[{"type":"function_call","id":"fc-1","call_id":"call-kept","name":"first","arguments":"{}"}]}`,
 			lastResponseOutput: `[{"type":"function_call","id":"fc-1","call_id":"call-other","name":"second","arguments":"{}"}]`,
 			appendInput:        `[{"type":"function_call_output","id":"fco-1","call_id":"call-kept","output":"done"}]`,
+			want:               `[{"type":"function_call","id":"fc-1","call_id":"call-kept","name":"first","arguments":"{}"},{"type":"function_call_output","id":"fco-1","call_id":"call-kept","output":"done"}]`,
 		},
 		{
 			name:               "raw JSON values and escaping",
 			lastRequest:        `{"input":[ {"type":"message","id":"msg-1","content":"<tag> & \\u263a"}, true ]}`,
 			lastResponseOutput: `[null, 42, "line\\nvalue"]`,
 			appendInput:        `[{"id":"last","nested":{"value":[1,2,3]}}]`,
+			want:               `[{"type":"message","id":"msg-1","content":"<tag> & \\u263a"},true,null,42,"line\\nvalue",{"id":"last","nested":{"value":[1,2,3]}}]`,
+		},
+		{
+			name:               "large numbers retain exact JSON values",
+			lastRequest:        `{"input":[9007199254740993,{"id":"n","value":9223372036854775807}]}`,
+			lastResponseOutput: `[18446744073709551615]`,
+			appendInput:        `[{"id":"decimal","value":1.0000000000000000001}]`,
+			want:               `[9007199254740993,{"id":"n","value":9223372036854775807},18446744073709551615,{"id":"decimal","value":1.0000000000000000001}]`,
 		},
 		{
 			name:               "invalid response output remains ignored",
 			lastRequest:        `{"input":[{"id":"first"}]}`,
 			lastResponseOutput: `[{"id":`,
 			appendInput:        `[{"id":"last"}]`,
+			want:               `[{"id":"first"},{"id":"last"}]`,
 		},
 		{
 			name:               "missing previous input and null append",
 			lastRequest:        `{"model":"gpt-5.4"}`,
 			lastResponseOutput: `[{"id":"response"}]`,
 			appendInput:        `null`,
+			want:               `[{"id":"response"}]`,
 		},
 		{
 			name:               "null previous request",
 			lastRequest:        `null`,
 			lastResponseOutput: `[]`,
 			appendInput:        `[{"id":"last"}]`,
+			want:               `[{"id":"last"}]`,
 		},
 		{
 			name:               "duplicate metadata keys follow encoding json",
 			lastRequest:        `{"input":[{"type":"message","type":"function_call","id":"first","id":"fc-1","call_id":"call-other","call_id":"call-kept"}]}`,
 			lastResponseOutput: `[{"type":"function_call","id":"fc-2","call_id":"call-kept"}]`,
 			appendInput:        `[{"type":"function_call_output","id":"fco-1","call_id":"call-kept","output":"done"}]`,
+			want:               `[{"type":"function_call","id":"fc-1","call_id":"call-kept"},{"type":"function_call_output","id":"fco-1","call_id":"call-kept","output":"done"}]`,
 		},
 	}
 
@@ -84,20 +101,22 @@ func TestMergeResponsesWebsocketInputMatchesReferenceSemantics(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			want, errWant := mergeResponsesWebsocketInputReference([]byte(test.lastRequest), []byte(test.lastResponseOutput), test.appendInput)
-			if errWant != nil {
-				t.Fatalf("reference merge failed: %v", errWant)
+			legacy, errLegacy := mergeResponsesWebsocketInputReference([]byte(test.lastRequest), []byte(test.lastResponseOutput), test.appendInput)
+			if errLegacy != nil {
+				t.Fatalf("legacy merge failed: %v", errLegacy)
 			}
+			assertJSONSemanticallyEqual(t, []byte(legacy), test.want)
+
 			got, errGot := mergeResponsesWebsocketInput([]byte(test.lastRequest), []byte(test.lastResponseOutput), test.appendInput)
 			if errGot != nil {
 				t.Fatalf("mergeResponsesWebsocketInput() error = %v", errGot)
 			}
-			assertJSONSemanticallyEqual(t, got, want)
+			assertJSONSemanticallyEqual(t, []byte(got), test.want)
 		})
 	}
 }
 
-func TestMergeResponsesWebsocketInputMatchesReferenceErrors(t *testing.T) {
+func TestMergeResponsesWebsocketInputReturnsCompatibleErrors(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -105,28 +124,37 @@ func TestMergeResponsesWebsocketInputMatchesReferenceErrors(t *testing.T) {
 		lastRequest        string
 		lastResponseOutput string
 		appendInput        string
+		wantPrefix         string
+		wantSyntaxError    bool
 	}{
-		{name: "invalid previous request", lastRequest: `{"input":`, appendInput: `[]`},
-		{name: "non-array previous input", lastRequest: `{"input":{"id":"item"}}`, appendInput: `[]`},
-		{name: "invalid appended input", lastRequest: `{"input":[]}`, appendInput: `[{"id":`},
-		{name: "non-array appended input", lastRequest: `{"input":[]}`, appendInput: `{"id":"item"}`},
-		{name: "array previous request", lastRequest: `[]`, appendInput: `[]`},
+		{name: "invalid previous request", lastRequest: `{"input":`, appendInput: `[]`, wantPrefix: "invalid previous request input", wantSyntaxError: true},
+		{name: "non-array previous input", lastRequest: `{"input":{"id":"item"}}`, appendInput: `[]`, wantPrefix: "invalid previous request input"},
+		{name: "invalid appended input", lastRequest: `{"input":[]}`, appendInput: `[{"id":`, wantPrefix: "invalid request input", wantSyntaxError: true},
+		{name: "non-array appended input", lastRequest: `{"input":[]}`, appendInput: `{"id":"item"}`, wantPrefix: "invalid request input"},
+		{name: "array previous request", lastRequest: `[]`, appendInput: `[]`, wantPrefix: "invalid previous request input"},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, errWant := mergeResponsesWebsocketInputReference([]byte(test.lastRequest), []byte(test.lastResponseOutput), test.appendInput)
 			_, errGot := mergeResponsesWebsocketInput([]byte(test.lastRequest), []byte(test.lastResponseOutput), test.appendInput)
-			if (errGot == nil) != (errWant == nil) {
-				t.Fatalf("error presence differs: got %v, reference %v", errGot, errWant)
-			}
 			if errGot == nil {
 				t.Fatal("expected merge error")
 			}
-			if errGot.Error() != errWant.Error() {
-				t.Fatalf("error differs:\n got: %v\nwant: %v", errGot, errWant)
+			if !strings.HasPrefix(errGot.Error(), test.wantPrefix+": ") {
+				t.Fatalf("error = %q, want prefix %q", errGot, test.wantPrefix+": ")
+			}
+			if test.wantSyntaxError {
+				var syntaxError *json.SyntaxError
+				if !errors.As(errGot, &syntaxError) {
+					t.Fatalf("error cause = %T, want *json.SyntaxError", errGot)
+				}
+				return
+			}
+			var typeError *json.UnmarshalTypeError
+			if !errors.As(errGot, &typeError) {
+				t.Fatalf("error cause = %T, want *json.UnmarshalTypeError", errGot)
 			}
 		})
 	}
@@ -150,7 +178,7 @@ func TestMergeResponsesWebsocketInputMatchesReferenceAcrossGeneratedTranscripts(
 		if errGot != nil {
 			t.Fatalf("iteration %d merge failed: %v", iteration, errGot)
 		}
-		assertJSONSemanticallyEqual(t, got, want)
+		assertJSONSemanticallyEqual(t, []byte(got), want)
 	}
 }
 
@@ -211,41 +239,80 @@ func TestNormalizeResponseSubsequentRequestDetachesSourceBuffers(t *testing.T) {
 }
 
 func TestMergeResponsesWebsocketInputBoundsLargeTranscriptAllocations(t *testing.T) {
-	lastRequest, lastResponseOutput, appendInput := responsesWebsocketLargeTranscriptFixture()
-	inputBytes := len(lastRequest) + len(lastResponseOutput) + len(appendInput)
+	if raceDetectorEnabled {
+		t.Skip("allocation budgets are not meaningful with race detector instrumentation")
+	}
 
-	result := testing.Benchmark(func(b *testing.B) {
-		b.ReportAllocs()
-		for range b.N {
-			merged, errMerge := mergeResponsesWebsocketInput(lastRequest, lastResponseOutput, appendInput)
-			if errMerge != nil {
-				b.Fatalf("mergeResponsesWebsocketInput() error = %v", errMerge)
+	tests := []struct {
+		name        string
+		makeFixture func() ([]byte, []byte, string)
+	}{
+		{name: "single_large_item", makeFixture: responsesWebsocketLargeTranscriptFixture},
+		{name: "many_messages_and_tool_pairs", makeFixture: func() ([]byte, []byte, string) {
+			return responsesWebsocketManyItemsTranscriptFixture(responsesWebsocketLargeTranscriptSize)
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lastRequest, lastResponseOutput, appendInput := test.makeFixture()
+			inputBytes := len(lastRequest) + len(lastResponseOutput) + len(appendInput)
+
+			result := testing.Benchmark(func(b *testing.B) {
+				b.SetBytes(int64(inputBytes))
+				b.ReportAllocs()
+				for b.Loop() {
+					merged, errMerge := mergeResponsesWebsocketInput(lastRequest, lastResponseOutput, appendInput)
+					if errMerge != nil {
+						b.Fatalf("mergeResponsesWebsocketInput() error = %v", errMerge)
+					}
+					responsesWebsocketMergedInputSink = merged
+				}
+				responsesWebsocketMergedInputSink = nil
+			})
+
+			const (
+				maxAllocationNumerator   = 3
+				maxAllocationDenominator = 2
+			)
+			maxAllocatedBytes := int64(inputBytes) * maxAllocationNumerator / maxAllocationDenominator
+			t.Logf("merge allocated %d bytes per operation for %d input bytes", result.AllocedBytesPerOp(), inputBytes)
+			if allocatedBytes := result.AllocedBytesPerOp(); allocatedBytes > maxAllocatedBytes {
+				t.Fatalf("merging %d input bytes allocated %d bytes per operation, want at most %d", inputBytes, allocatedBytes, maxAllocatedBytes)
 			}
-			responsesWebsocketMergedInputSink = merged
-		}
-	})
-
-	const maxAllocationMultiple = 2
-	maxAllocatedBytes := int64(inputBytes * maxAllocationMultiple)
-	t.Logf("merge allocated %d bytes per operation for %d input bytes", result.AllocedBytesPerOp(), inputBytes)
-	if allocatedBytes := result.AllocedBytesPerOp(); allocatedBytes > maxAllocatedBytes {
-		t.Fatalf("merging %d input bytes allocated %d bytes per operation, want at most %d", inputBytes, allocatedBytes, maxAllocatedBytes)
+		})
 	}
 }
 
-func BenchmarkNormalizeResponseSubsequentRequestLargeTranscript(b *testing.B) {
-	lastRequest, lastResponseOutput, appendInput := responsesWebsocketTranscriptFixture(responsesWebsocketBenchmarkTranscriptSize)
-	raw := []byte(`{"type":"response.create","input":` + appendInput + `}`)
+func BenchmarkNormalizeResponseSubsequentRequestTranscripts(b *testing.B) {
+	tests := []struct {
+		name        string
+		makeFixture func() ([]byte, []byte, string)
+	}{
+		{name: "single_large_item", makeFixture: func() ([]byte, []byte, string) {
+			return responsesWebsocketTranscriptFixture(responsesWebsocketBenchmarkTranscriptSize)
+		}},
+		{name: "many_messages_and_tool_pairs", makeFixture: func() ([]byte, []byte, string) {
+			return responsesWebsocketManyItemsTranscriptFixture(responsesWebsocketBenchmarkTranscriptSize)
+		}},
+	}
 
-	b.SetBytes(int64(len(lastRequest) + len(lastResponseOutput) + len(raw)))
-	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
-		normalized, _, errMessage := normalizeResponseSubsequentRequest(raw, lastRequest, lastResponseOutput, "", nil, false, false)
-		if errMessage != nil {
-			b.Fatalf("normalizeResponseSubsequentRequest() error = %v", errMessage.Error)
-		}
-		responsesWebsocketNormalizedRequestSink = normalized
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			lastRequest, lastResponseOutput, appendInput := test.makeFixture()
+			raw := []byte(`{"type":"response.create","input":` + appendInput + `}`)
+
+			b.SetBytes(int64(len(lastRequest) + len(lastResponseOutput) + len(raw)))
+			b.ReportAllocs()
+			for b.Loop() {
+				normalized, _, errMessage := normalizeResponseSubsequentRequest(raw, lastRequest, lastResponseOutput, "", nil, false, false)
+				if errMessage != nil {
+					b.Fatalf("normalizeResponseSubsequentRequest() error = %v", errMessage.Error)
+				}
+				responsesWebsocketNormalizedRequestSink = normalized
+			}
+			responsesWebsocketNormalizedRequestSink = nil
+		})
 	}
 }
 
@@ -260,6 +327,53 @@ func responsesWebsocketTranscriptFixture(transcriptSize int) ([]byte, []byte, st
 	return lastRequest, lastResponseOutput, appendInput
 }
 
+func responsesWebsocketManyItemsTranscriptFixture(transcriptSize int) ([]byte, []byte, string) {
+	const (
+		messageCount  = 512
+		toolPairCount = 128
+	)
+	contentSize := max(transcriptSize/messageCount, 1)
+	content := strings.Repeat("x", contentSize)
+
+	var lastRequest strings.Builder
+	lastRequest.Grow(transcriptSize + messageCount*96)
+	lastRequest.WriteString(`{"model":"gpt-5.4","instructions":"coding","stream":true,"input":[`)
+	for index := range messageCount {
+		if index > 0 {
+			lastRequest.WriteByte(',')
+		}
+		fmt.Fprintf(&lastRequest, `{"type":"message","id":"msg-%d","role":"user","content":"%s"}`, index, content)
+	}
+	lastRequest.WriteString(`]}`)
+
+	var lastResponseOutput strings.Builder
+	lastResponseOutput.Grow(toolPairCount * 112)
+	lastResponseOutput.WriteByte('[')
+	for index := range toolPairCount {
+		if index > 0 {
+			lastResponseOutput.WriteByte(',')
+		}
+		fmt.Fprintf(&lastResponseOutput, `{"type":"function_call","id":"fc-%d","call_id":"call-%d","name":"lookup","arguments":"{}"}`, index, index)
+	}
+	lastResponseOutput.WriteByte(']')
+
+	var appendInput strings.Builder
+	appendInput.Grow(toolPairCount * 104)
+	appendInput.WriteByte('[')
+	for index := range toolPairCount {
+		if index > 0 {
+			appendInput.WriteByte(',')
+		}
+		fmt.Fprintf(&appendInput, `{"type":"function_call_output","id":"fco-%d","call_id":"call-%d","output":"done"}`, index, index)
+	}
+	appendInput.WriteByte(']')
+
+	return []byte(lastRequest.String()), []byte(lastResponseOutput.String()), appendInput.String()
+}
+
+// The legacy oracle detects broad behavior drift from the implementation that
+// preceded the allocation optimization. Explicit compatibility scenarios above
+// remain the independent specification for important merge behavior.
 type referenceResponsesWebsocketInputItem struct {
 	raw      json.RawMessage
 	itemType string
@@ -393,12 +507,22 @@ func dedupeReferenceResponsesWebsocketInputItems(items []referenceResponsesWebso
 
 func assertJSONSemanticallyEqual(t *testing.T, got []byte, want string) {
 	t.Helper()
+	if !json.Valid(got) {
+		t.Fatalf("invalid actual JSON:\n%s", got)
+	}
 	var gotValue any
-	if errUnmarshal := json.Unmarshal(got, &gotValue); errUnmarshal != nil {
+	gotDecoder := json.NewDecoder(bytes.NewReader(got))
+	gotDecoder.UseNumber()
+	if errUnmarshal := gotDecoder.Decode(&gotValue); errUnmarshal != nil {
 		t.Fatalf("invalid actual JSON: %v\n%s", errUnmarshal, got)
 	}
+	if !json.Valid([]byte(want)) {
+		t.Fatalf("invalid expected JSON:\n%s", want)
+	}
 	var wantValue any
-	if errUnmarshal := json.Unmarshal([]byte(want), &wantValue); errUnmarshal != nil {
+	wantDecoder := json.NewDecoder(strings.NewReader(want))
+	wantDecoder.UseNumber()
+	if errUnmarshal := wantDecoder.Decode(&wantValue); errUnmarshal != nil {
 		t.Fatalf("invalid reference JSON: %v\n%s", errUnmarshal, want)
 	}
 	if !reflect.DeepEqual(gotValue, wantValue) {

--- a/sdk/api/handlers/openai/openai_responses_websocket_requests_memory_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_requests_memory_test.go
@@ -95,6 +95,27 @@ func TestMergeResponsesWebsocketInputMatchesCompatibilityScenarios(t *testing.T)
 			appendInput:        `[{"type":"function_call_output","id":"fco-1","call_id":"call-kept","output":"done"}]`,
 			want:               `[{"type":"function_call","id":"fc-1","call_id":"call-kept"},{"type":"function_call_output","id":"fco-1","call_id":"call-kept","output":"done"}]`,
 		},
+		{
+			name:               "duplicate previous input keeps last array",
+			lastRequest:        `{"input":[{"id":"old"}],"input":[{"id":"new"}]}`,
+			lastResponseOutput: `[]`,
+			appendInput:        `[]`,
+			want:               `[{"id":"new"}]`,
+		},
+		{
+			name:               "previous input field matching is case insensitive",
+			lastRequest:        `{"Input":[{"id":"old"}],"INPUT":[{"id":"new"}]}`,
+			lastResponseOutput: `[]`,
+			appendInput:        `[]`,
+			want:               `[{"id":"new"}]`,
+		},
+		{
+			name:               "last duplicate null clears previous input",
+			lastRequest:        `{"input":[{"id":"old"}],"input":null}`,
+			lastResponseOutput: `[{"id":"response"}]`,
+			appendInput:        `[]`,
+			want:               `[{"id":"response"}]`,
+		},
 	}
 
 	for _, test := range tests {
@@ -132,6 +153,8 @@ func TestMergeResponsesWebsocketInputReturnsCompatibleErrors(t *testing.T) {
 		{name: "invalid appended input", lastRequest: `{"input":[]}`, appendInput: `[{"id":`, wantPrefix: "invalid request input", wantSyntaxError: true},
 		{name: "non-array appended input", lastRequest: `{"input":[]}`, appendInput: `{"id":"item"}`, wantPrefix: "invalid request input"},
 		{name: "array previous request", lastRequest: `[]`, appendInput: `[]`, wantPrefix: "invalid previous request input"},
+		{name: "last duplicate previous input is non-array", lastRequest: `{"input":[],"input":{"id":"item"}}`, appendInput: `[]`, wantPrefix: "invalid previous request input"},
+		{name: "earlier non-array previous input remains invalid", lastRequest: `{"input":{"id":"item"},"input":[]}`, appendInput: `[]`, wantPrefix: "invalid previous request input"},
 	}
 
 	for _, test := range tests {

--- a/sdk/api/handlers/openai/openai_responses_websocket_requests_memory_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_requests_memory_test.go
@@ -96,6 +96,27 @@ func TestMergeResponsesWebsocketInputMatchesCompatibilityScenarios(t *testing.T)
 			want:               `[{"type":"function_call","id":"fc-1","call_id":"call-kept"},{"type":"function_call_output","id":"fco-1","call_id":"call-kept","output":"done"}]`,
 		},
 		{
+			name:               "case insensitive metadata dedupes function calls",
+			lastRequest:        `{"input":[{"Type":"function_call","ID":"fc-old","CALL_ID":"call-1","name":"first"}]}`,
+			lastResponseOutput: `[{"type":"function_call","id":"fc-new","call_id":"call-1","name":"second"}]`,
+			appendInput:        `[{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"done"}]`,
+			want:               `[{"Type":"function_call","ID":"fc-old","CALL_ID":"call-1","name":"first"},{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"done"}]`,
+		},
+		{
+			name:               "case insensitive metadata keeps referenced duplicate id",
+			lastRequest:        `{"input":[{"Type":"function_call","Id":"fc-1","Call_Id":"call-kept","name":"first"}]}`,
+			lastResponseOutput: `[{"type":"function_call","id":"fc-1","call_id":"call-other","name":"second"}]`,
+			appendInput:        `[{"type":"function_call_output","id":"fco-1","call_id":"call-kept","output":"done"}]`,
+			want:               `[{"Type":"function_call","Id":"fc-1","Call_Id":"call-kept","name":"first"},{"type":"function_call_output","id":"fco-1","call_id":"call-kept","output":"done"}]`,
+		},
+		{
+			name:               "mixed case duplicate metadata keeps last values",
+			lastRequest:        `{"input":[{"type":"message","TYPE":"function_call","id":"first","ID":"fc-1","call_id":"call-other","CALL_ID":"call-kept"}]}`,
+			lastResponseOutput: `[{"type":"function_call","id":"fc-2","call_id":"call-kept"}]`,
+			appendInput:        `[{"type":"function_call_output","id":"fco-1","call_id":"call-kept","output":"done"}]`,
+			want:               `[{"type":"message","TYPE":"function_call","id":"first","ID":"fc-1","call_id":"call-other","CALL_ID":"call-kept"},{"type":"function_call_output","id":"fco-1","call_id":"call-kept","output":"done"}]`,
+		},
+		{
 			name:               "duplicate previous input keeps last array",
 			lastRequest:        `{"input":[{"id":"old"}],"input":[{"id":"new"}]}`,
 			lastResponseOutput: `[]`,

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -1190,6 +1190,10 @@ func TestNormalizeResponsesWebsocketRequestCreate(t *testing.T) {
 }
 
 func TestNormalizeResponseSubsequentRequestBoundsTranscriptAllocations(t *testing.T) {
+	if raceDetectorEnabled {
+		t.Skip("allocation budgets are not meaningful with race detector instrumentation")
+	}
+
 	makeInput := func(count int, role string) string {
 		var input strings.Builder
 		input.WriteByte('[')
@@ -1230,6 +1234,10 @@ func TestNormalizeResponseSubsequentRequestBoundsTranscriptAllocations(t *testin
 }
 
 func TestResponsesWebsocketFallbackTurnBoundsTranscriptAllocations(t *testing.T) {
+	if raceDetectorEnabled {
+		t.Skip("allocation budgets are not meaningful with race detector instrumentation")
+	}
+
 	makeInput := func(count int, role string) string {
 		var input strings.Builder
 		input.WriteByte('[')

--- a/sdk/api/handlers/openai/race_disabled_test.go
+++ b/sdk/api/handlers/openai/race_disabled_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package openai
+
+const raceDetectorEnabled = false

--- a/sdk/api/handlers/openai/race_enabled_test.go
+++ b/sdk/api/handlers/openai/race_enabled_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package openai
+
+const raceDetectorEnabled = true


### PR DESCRIPTION
## Summary

- parse previous request, response output, and appended input without copying every JSON item into `json.RawMessage`;
- deduplicate temporary metadata while raw items only borrow caller buffers inside the merge call;
- serialize retained items once into a capacity-sized owned output buffer;
- preserve existing tool-pair, duplicate-ID, duplicate-key, invalid-response, error, compaction, and ownership behavior.

This is a focused follow-up to the transcript allocation-churn portion of #4913. It does not claim to address the separate WebSocket tool-cache retention path.

## Dependency

**Blocked by #4926.**

This PR is intentionally stacked and currently includes the test-only commit from #4926. The allocation gates use its race-build marker so allocation budgets are skipped under race instrumentation. After #4926 merges into `dev`, that overlapping test diff should disappear from this PR.

## Red / green evidence

The finalized allocation test was run unchanged against `dev` at `f43aad76` and against this branch:

| Transcript fixture | `dev` B/op | This PR B/op | Gate |
| --- | ---: | ---: | ---: |
| one approximately 1 MiB content item | 3,538,026 | 1,058,046-1,058,061 | 1.5x input |
| 512 messages plus 128 tool call/output pairs | 6,572,842 | 1,452,234-1,452,263 | 1.5x input |

Both fixtures fail on `dev` and pass repeatedly on this branch. The 8 MiB end-to-end normalization benchmark also drops from the previously measured approximately 47-50 MiB/op and 131-134 allocs/op to approximately 16.8 MiB/op and 39-46 allocs/op for the large-item fixture.

The benchmark uses `testing.B.Loop`; timing is diagnostic only and is not used as a CI assertion.

## Correctness coverage

- independent expected-output cases for message/tool pairing, duplicate calls and IDs, primitives, escaping, null/missing inputs, invalid response output, and duplicate metadata keys;
- exact large-number comparisons via `json.Decoder.UseNumber`;
- stable wrapper-prefix and wrapped JSON error-type assertions instead of standard-library error text;
- deterministic 250-case compatibility comparison with the pre-optimization implementation;
- source-buffer mutation test proving returned request state owns its bytes;
- allocation gates for both a single large value and a many-item/tool-heavy transcript;
- allocation gates skipped under `-race` through #4926.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./sdk/api/handlers/openai`
- `go build -o <temporary-output> ./cmd/server`
- semantic and ownership tests repeated 20 times under `-race`
- allocation gates repeated three times
- isolated OAuth smoke: 8/8 downstream WebSocket requests completed through the HTTP upstream fallback path
