### PR TITLE
fix(kimi): report Claude format for count tokens

### DIFF
--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -58,6 +58,12 @@ func (e *KimiExecutor) RequestToFormat(_ cliproxyexecutor.Request, opts cliproxy
 	return sdktranslator.FormatOpenAI
 }
 
+// CountTokensToFormat reports the Claude Messages format used by Kimi token counting.
+// Unlike generation, token counting always delegates to the embedded Claude executor.
+func (e *KimiExecutor) CountTokensToFormat(_ cliproxyexecutor.Request, _ cliproxyexecutor.Options) sdktranslator.Format {
+	return sdktranslator.FormatClaude
+}
+
 // PrepareRequest injects Kimi credentials into the outgoing HTTP request.
 func (e *KimiExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth) error {
 	if req == nil {

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -63,6 +63,27 @@ func TestKimiExecutorRequestToFormatMatchesWireProtocol(t *testing.T) {
 	}
 }
 
+func TestKimiExecutorCountTokensToFormatMatchesWireProtocol(t *testing.T) {
+	type countTokensToFormatReporter interface {
+		CountTokensToFormat(cliproxyexecutor.Request, cliproxyexecutor.Options) sdktranslator.Format
+	}
+
+	executor := NewKimiExecutor(&config.Config{})
+	reporter, ok := any(executor).(countTokensToFormatReporter)
+	if !ok {
+		t.Fatal("Kimi executor does not report its token-count request format")
+	}
+
+	for _, source := range []sdktranslator.Format{sdktranslator.FormatClaude, sdktranslator.FormatOpenAI} {
+		t.Run(source.String(), func(t *testing.T) {
+			got := reporter.CountTokensToFormat(cliproxyexecutor.Request{}, cliproxyexecutor.Options{SourceFormat: source})
+			if got != sdktranslator.FormatClaude {
+				t.Fatalf("CountTokensToFormat() = %q, want %q", got, sdktranslator.FormatClaude)
+			}
+		})
+	}
+}
+
 func TestKimiExecutorClaudeRequestPreservesInternalModelSemantics(t *testing.T) {
 	var upstreamBody []byte
 	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -173,6 +173,10 @@ type requestToFormatResolver interface {
 	RequestToFormat(req cliproxyexecutor.Request, opts cliproxyexecutor.Options) sdktranslator.Format
 }
 
+type countTokensToFormatResolver interface {
+	CountTokensToFormat(req cliproxyexecutor.Request, opts cliproxyexecutor.Options) sdktranslator.Format
+}
+
 func isRequestTerminatedError(err error) bool {
 	var terminated *cliproxyexecutor.RequestTerminatedError
 	return errors.As(err, &terminated) && terminated != nil
@@ -182,7 +186,17 @@ func applyRequestAfterAuthInterceptor(ctx context.Context, executor ProviderExec
 	if opts.RequestAfterAuthInterceptor == nil {
 		return req, opts, nil
 	}
-	toFormat := requestToFormat(provider, executor, req, opts)
+	return applyRequestAfterAuthInterceptorWithFormat(ctx, req, opts, requestedModel, requestToFormat(provider, executor, req, opts))
+}
+
+func applyCountTokensRequestAfterAuthInterceptor(ctx context.Context, executor ProviderExecutor, provider string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, requestedModel string) (cliproxyexecutor.Request, cliproxyexecutor.Options, error) {
+	if opts.RequestAfterAuthInterceptor == nil {
+		return req, opts, nil
+	}
+	return applyRequestAfterAuthInterceptorWithFormat(ctx, req, opts, requestedModel, countTokensToFormat(provider, executor, req, opts))
+}
+
+func applyRequestAfterAuthInterceptorWithFormat(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, requestedModel string, toFormat sdktranslator.Format) (cliproxyexecutor.Request, cliproxyexecutor.Options, error) {
 	resp := opts.RequestAfterAuthInterceptor(ctx, cliproxyexecutor.RequestAfterAuthInterceptRequest{
 		SourceFormat:   opts.SourceFormat,
 		ToFormat:       toFormat,
@@ -239,6 +253,17 @@ func requestToFormat(provider string, executor ProviderExecutor, req cliproxyexe
 	default:
 		return sdktranslator.FormatOpenAI
 	}
+}
+
+func countTokensToFormat(provider string, executor ProviderExecutor, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) sdktranslator.Format {
+	resolver, ok := executor.(countTokensToFormatResolver)
+	if ok && resolver != nil {
+		formatRequestTo := resolver.CountTokensToFormat(req, opts)
+		if formatRequestTo != "" {
+			return formatRequestTo
+		}
+	}
+	return requestToFormat(provider, executor, req, opts)
 }
 
 func cloneRequestHeaders(src http.Header) http.Header {
@@ -469,7 +494,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			}
 			execOpts := opts
 			var errIntercept error
-			execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			execReq, execOpts, errIntercept = applyCountTokensRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
 			if errIntercept != nil {
 				return cliproxyexecutor.Response{}, errIntercept
 			}

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -95,7 +95,11 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			execOpts := opts
 			execOpts.ExecutionLifecycle = selection
 			var errIntercept error
-			execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, selection.Executor, selection.Provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			if countTokens {
+				execReq, execOpts, errIntercept = applyCountTokensRequestAfterAuthInterceptor(execCtx, selection.Executor, selection.Provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			} else {
+				execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, selection.Executor, selection.Provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			}
 			if errIntercept != nil {
 				releaseAttempt()
 				selection.End("request_intercepted")

--- a/sdk/cliproxy/auth/conductor_kimi_count_tokens_test.go
+++ b/sdk/cliproxy/auth/conductor_kimi_count_tokens_test.go
@@ -1,0 +1,98 @@
+package auth_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+type kimiCountTokensRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f kimiCountTokensRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type staticRoundTripperProvider struct {
+	roundTripper http.RoundTripper
+}
+
+func (p staticRoundTripperProvider) RoundTripperFor(*cliproxyauth.Auth) http.RoundTripper {
+	return p.roundTripper
+}
+
+func TestManagerExecuteCountReportsKimiClaudeWireFormat(t *testing.T) {
+	var upstreamRequest *http.Request
+	var upstreamBody []byte
+	roundTripper := kimiCountTokensRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		upstreamRequest = req.Clone(req.Context())
+		var errRead error
+		upstreamBody, errRead = io.ReadAll(req.Body)
+		if errRead != nil {
+			return nil, errRead
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"input_tokens":42}`)),
+		}, nil
+	})
+
+	const authID = "kimi-test-auth"
+	registry.GetGlobalRegistry().RegisterClient(authID, "kimi", []*registry.ModelInfo{{ID: "kimi-k3"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(authID) })
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor.NewKimiExecutor(&config.Config{}))
+	manager.SetRoundTripperProvider(staticRoundTripperProvider{roundTripper: roundTripper})
+	if _, errRegister := manager.Register(context.Background(), &cliproxyauth.Auth{
+		ID:         authID,
+		Provider:   "kimi",
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"access_token": "test-token"},
+	}); errRegister != nil {
+		t.Fatalf("register Kimi auth: %v", errRegister)
+	}
+
+	var interceptedFormat sdktranslator.Format
+	payload := []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`)
+	_, errCount := manager.ExecuteCount(context.Background(), []string{"kimi"}, cliproxyexecutor.Request{
+		Model:   "kimi-k3",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FormatGemini,
+		OriginalRequest: payload,
+		RequestAfterAuthInterceptor: func(_ context.Context, req cliproxyexecutor.RequestAfterAuthInterceptRequest) cliproxyexecutor.RequestAfterAuthInterceptResponse {
+			interceptedFormat = req.ToFormat
+			return cliproxyexecutor.RequestAfterAuthInterceptResponse{}
+		},
+	})
+	if errCount != nil {
+		t.Fatalf("ExecuteCount() error = %v", errCount)
+	}
+	if interceptedFormat != sdktranslator.FormatClaude {
+		t.Fatalf("interceptor ToFormat = %q, want %q", interceptedFormat, sdktranslator.FormatClaude)
+	}
+	if upstreamRequest == nil {
+		t.Fatal("Kimi count-token request was not captured")
+	}
+	if got := upstreamRequest.URL.String(); got != "https://api.kimi.com/coding/v1/messages/count_tokens?beta=true" {
+		t.Fatalf("upstream URL = %q, want Kimi Claude count-token endpoint", got)
+	}
+	if got := gjson.GetBytes(upstreamBody, "model").String(); got != "k3" {
+		t.Fatalf("upstream model = %q, want k3; body=%s", got, upstreamBody)
+	}
+	if got := gjson.GetBytes(upstreamBody, "messages.0.role").String(); got != "user" {
+		t.Fatalf("upstream body is not Claude Messages format; body=%s", upstreamBody)
+	}
+}


### PR DESCRIPTION
This is a follow-up to #4910 for a remaining CountTokens-specific gap.

## Root cause

Kimi's `RequestToFormat` describes generation, but Kimi CountTokens always sends the Claude Messages count-token request. For non-Claude sources, the after-auth interceptor could therefore receive `openai` while the actual CountTokens wire format was Claude.

## Fix

Add the optional, operation-aware `CountTokensToFormat` capability. Kimi returns `claude` for CountTokens; executors that do not implement the capability continue through the existing `RequestToFormat` and provider fallback behavior.

## Generation behavior

Generation is unchanged: Kimi's existing source-aware `RequestToFormat` behavior remains intact for both streaming and non-streaming requests.

## Tests

Added unit coverage for Kimi CountTokens format reporting and a conductor-level CountTokens test that uses a Gemini source, verifies the interceptor receives `claude`, and captures the Kimi Claude Messages count-token endpoint and request shape. The focused package tests and `go build ./cmd/...` pass.
