### PR TITLE
fix(models): embed Grok 4.6 catalog entry

### DIFF
--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -60,6 +60,26 @@ func TestWithXAIBuiltinsIncludesVideo15GAAndPreviewAlias(t *testing.T) {
 	}
 }
 
+func TestGetXAIModelsIncludesGrok46(t *testing.T) {
+	for _, model := range GetXAIModels() {
+		if model == nil || model.ID != "grok-4.6" {
+			continue
+		}
+		if model.ContextLength != 500000 || model.MaxCompletionTokens != 65536 {
+			t.Fatalf("grok-4.6 limits = context %d, completion %d", model.ContextLength, model.MaxCompletionTokens)
+		}
+		if model.Thinking == nil || model.Thinking.ZeroAllowed || len(model.Thinking.Levels) != 3 {
+			t.Fatalf("grok-4.6 thinking = %#v", model.Thinking)
+		}
+		if len(model.SupportedInputModalities) != 2 || len(model.SupportedOutputModalities) != 1 {
+			t.Fatalf("grok-4.6 modalities = input %#v, output %#v", model.SupportedInputModalities, model.SupportedOutputModalities)
+		}
+		return
+	}
+
+	t.Fatal("xAI models do not contain grok-4.6")
+}
+
 func TestAntigravityWebSearchModelForRequiresRequestedModelCapability(t *testing.T) {
 	registryRef := GetGlobalRegistry()
 	registryRef.RegisterClient("test-antigravity-websearch-route", "antigravity", []*ModelInfo{

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2693,6 +2693,33 @@
       "max_completion_tokens": 256000
     },
     {
+      "id": "grok-4.6",
+      "object": "model",
+      "created": 1785974400,
+      "owned_by": "xai",
+      "type": "xai",
+      "display_name": "Grok 4.6",
+      "name": "grok-4.6",
+      "description": "SpaceXAI's smartest model built for long-running agents, interactive and visual work.",
+      "context_length": 500000,
+      "max_completion_tokens": 65536,
+      "thinking": {
+        "zero_allowed": false,
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
+    },
+    {
       "id": "grok-4.5",
       "object": "model",
       "created": 1783526400,


### PR DESCRIPTION
## Summary

Add `grok-4.6` to the embedded xAI model catalog so a fresh or offline CLIProxyAPI instance can resolve it before remote catalog refresh succeeds.

The remote `router-for-me/models` catalog already contains this entry, but the embedded fallback did not. That left xAI OAuth requests failing locally with `unknown provider for model grok-4.6`.

## Changes

- Add Grok 4.6 metadata, reasoning support, and text/image modalities to `internal/registry/models/models.json`.
- Add a regression test covering the embedded xAI model definition.

## Testing

- `go test ./internal/registry -count=1`
- `go build -o /var/folders/y8/vnh__wy973g2l_ckn6cfx2bns3fp19/T/opencode/cli-proxy-api-pr-final ./cmd/server`
- Validated the catalog JSON with `jq`.

Refs router-for-me/models#39.