### PR TITLE
feat(openai): expose model metadata in /v1/models

### DIFF
--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -726,7 +726,14 @@ func (s *Server) handleHomeModels(c *gin.Context) {
 		return
 	}
 
-	filtered := make([]map[string]any, 0, len(entries))
+	c.JSON(http.StatusOK, gin.H{
+		"object": "list",
+		"data":   formatHomeOpenAIModels(entries),
+	})
+}
+
+func formatHomeOpenAIModels(entries []homeModelEntry) []map[string]any {
+	models := make([]map[string]any, 0, len(entries))
 	for _, entry := range entries {
 		model := map[string]any{
 			"id":     entry.id,
@@ -738,12 +745,18 @@ func (s *Server) handleHomeModels(c *gin.Context) {
 		if entry.ownedBy != "" {
 			model["owned_by"] = entry.ownedBy
 		}
-		filtered = append(filtered, model)
+		if entry.displayName != "" {
+			model["display_name"] = entry.displayName
+		}
+		if entry.contextLength > 0 {
+			model["context_length"] = entry.contextLength
+		}
+		if entry.maxCompletionTokens > 0 {
+			model["max_completion_tokens"] = entry.maxCompletionTokens
+		}
+		models = append(models, model)
 	}
-	c.JSON(http.StatusOK, gin.H{
-		"object": "list",
-		"data":   filtered,
-	})
+	return models
 }
 
 func formatHomeClaudeModels(entries []homeModelEntry) []map[string]any {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2124,6 +2124,30 @@ func TestDefaultRequestLoggerFactory_UsesResolvedLogDirectory(t *testing.T) {
 	}
 }
 
+func TestFormatHomeOpenAIModelsIncludesRegistryMetadata(t *testing.T) {
+	models := formatHomeOpenAIModels([]homeModelEntry{{
+		id:                  "gpt-5.6-sol",
+		created:             1776902400,
+		ownedBy:             "openai",
+		displayName:         "GPT-5.6 Sol",
+		contextLength:       372000,
+		maxCompletionTokens: 128000,
+	}})
+	if len(models) != 1 {
+		t.Fatalf("models = %d, want 1", len(models))
+	}
+	model := models[0]
+	if got := model["display_name"]; got != "GPT-5.6 Sol" {
+		t.Fatalf("display_name = %v, want GPT-5.6 Sol", got)
+	}
+	if got := model["context_length"]; got != 372000 {
+		t.Fatalf("context_length = %v, want 372000", got)
+	}
+	if got := model["max_completion_tokens"]; got != 128000 {
+		t.Fatalf("max_completion_tokens = %v, want 128000", got)
+	}
+}
+
 func TestFormatHomeClaudeModelIncludesAnthropicSchemaFields(t *testing.T) {
 	withMetadata := formatHomeClaudeModel(homeModelEntry{
 		id:                  "claude-sonnet-4-6",

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -66,6 +66,13 @@ func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 
 	// Get all available models
 	allModels := h.Models()
+	if c.Query("full") == "1" {
+		c.JSON(http.StatusOK, gin.H{
+			"object": "list",
+			"data":   allModels,
+		})
+		return
+	}
 
 	// Filter to only include the 4 required fields: id, object, created, owned_by
 	filteredModels := make([]map[string]any, len(allModels))

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -66,38 +66,10 @@ func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 
 	// Get all available models
 	allModels := h.Models()
-	if c.Query("full") == "1" {
-		c.JSON(http.StatusOK, gin.H{
-			"object": "list",
-			"data":   allModels,
-		})
-		return
-	}
-
-	// Filter to only include the 4 required fields: id, object, created, owned_by
-	filteredModels := make([]map[string]any, len(allModels))
-	for i, model := range allModels {
-		filteredModel := map[string]any{
-			"id":     model["id"],
-			"object": model["object"],
-		}
-
-		// Add created field if it exists
-		if created, exists := model["created"]; exists {
-			filteredModel["created"] = created
-		}
-
-		// Add owned_by field if it exists
-		if ownedBy, exists := model["owned_by"]; exists {
-			filteredModel["owned_by"] = ownedBy
-		}
-
-		filteredModels[i] = filteredModel
-	}
 
 	c.JSON(http.StatusOK, gin.H{
 		"object": "list",
-		"data":   filteredModels,
+		"data":   allModels,
 	})
 }
 

--- a/sdk/api/handlers/openai/openai_models_test.go
+++ b/sdk/api/handlers/openai/openai_models_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
 
-func TestOpenAIModelsFullMetadataIsOptIn(t *testing.T) {
+func TestOpenAIModelsIncludesRegistryMetadata(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	suffix := time.Now().UnixNano()
@@ -30,14 +30,9 @@ func TestOpenAIModelsFullMetadataIsOptIn(t *testing.T) {
 	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
 
 	handler := &OpenAIAPIHandler{}
-	defaultModel := requestListedModel(t, handler, "/v1/models", modelID)
-	if _, ok := defaultModel["context_length"]; ok {
-		t.Fatalf("default response unexpectedly included context_length: %#v", defaultModel)
-	}
-
-	fullModel := requestListedModel(t, handler, "/v1/models?full=1", modelID)
-	assertJSONNumber(t, fullModel, "context_length", 372000)
-	assertJSONNumber(t, fullModel, "max_completion_tokens", 128000)
+	model := requestListedModel(t, handler, "/v1/models", modelID)
+	assertJSONNumber(t, model, "context_length", 372000)
+	assertJSONNumber(t, model, "max_completion_tokens", 128000)
 }
 
 func requestListedModel(t *testing.T, handler *OpenAIAPIHandler, target, modelID string) map[string]any {

--- a/sdk/api/handlers/openai/openai_models_test.go
+++ b/sdk/api/handlers/openai/openai_models_test.go
@@ -1,0 +1,74 @@
+package openai
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestOpenAIModelsFullMetadataIsOptIn(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	suffix := time.Now().UnixNano()
+	clientID := fmt.Sprintf("openai-models-full-test-client-%d", suffix)
+	modelID := fmt.Sprintf("openai-models-full-test-model-%d", suffix)
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(clientID, "openai", []*registry.ModelInfo{{
+		ID:                  modelID,
+		Object:              "model",
+		Created:             1776902400,
+		OwnedBy:             "openai",
+		ContextLength:       372000,
+		MaxCompletionTokens: 128000,
+	}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+	handler := &OpenAIAPIHandler{}
+	defaultModel := requestListedModel(t, handler, "/v1/models", modelID)
+	if _, ok := defaultModel["context_length"]; ok {
+		t.Fatalf("default response unexpectedly included context_length: %#v", defaultModel)
+	}
+
+	fullModel := requestListedModel(t, handler, "/v1/models?full=1", modelID)
+	assertJSONNumber(t, fullModel, "context_length", 372000)
+	assertJSONNumber(t, fullModel, "max_completion_tokens", 128000)
+}
+
+func requestListedModel(t *testing.T, handler *OpenAIAPIHandler, target, modelID string) map[string]any {
+	t.Helper()
+
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	context.Request = httptest.NewRequest(http.MethodGet, target, nil)
+	handler.OpenAIModels(context)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET %s status = %d, want %d: %s", target, recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var response struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode GET %s response: %v", target, err)
+	}
+	for _, model := range response.Data {
+		if model["id"] == modelID {
+			return model
+		}
+	}
+	t.Fatalf("GET %s response did not include model %q", target, modelID)
+	return nil
+}
+
+func assertJSONNumber(t *testing.T, model map[string]any, key string, want float64) {
+	t.Helper()
+	if got, ok := model[key].(float64); !ok || got != want {
+		t.Fatalf("%s = %#v, want %v", key, model[key], want)
+	}
+}


### PR DESCRIPTION
## What and why

Return the model registry's available metadata from the standard OpenAI-compatible endpoint:

```text
GET /v1/models
```

The response retains the standard `id`, `object`, `created`, and `owned_by` fields and now also preserves optional registry fields such as:

- `context_length`
- `max_context_length`
- `max_completion_tokens`
- `display_name`
- `supported_parameters`

Clients that do not understand these optional JSON fields continue to ignore them. Clients that do can size context management, output budgets, and capability negotiation from server-advertised values instead of maintaining route-specific lookup tables.

We observed a concrete failure mode downstream: the registry held the route's measured `372000`-token limit, but `/v1/models` stripped it. The client consequently inferred a `1050000`-token context window and delayed compaction beyond the provider's real limit.

## Scope

- Standard non-Home `/v1/models` now returns the registry maps directly.
- Home mode now includes `display_name`, `context_length`, and `max_completion_tokens` when available.
- Anthropic-formatted model-list requests remain unchanged.
- The existing `client_version` catalog path remains unchanged.

This deliberately supersedes the initial opt-in `full=1` design after integration testing showed that existing discovery clients call the standard endpoint and therefore could not consume the authoritative metadata.

## Relationship to existing work

- Refreshes the direction of stale/conflicting PR #3337 on current `dev` with regression coverage.
- Issue #4543 documented the compatibility concern. This PR keeps the standard fields intact and only adds optional JSON members, which is backward-compatible for normal OpenAI model-list clients.

## How to test

```bash
go test ./sdk/api/handlers/openai -count=1
go test ./internal/api -count=1
go test ./internal/registry -run 'TestGetAvailableModelsIncludesMaxContextLengthOverride|TestGetAvailableModelsReturnsClonedSnapshots' -count=1
go vet ./sdk/api/handlers/openai ./internal/api
```

Locally verified with Go 1.26.0 on Linux arm64:

- `sdk/api/handlers/openai` + `internal/api`: **418 tests passed**.
- Focused registry tests: **2 tests passed**.
- `go vet ./sdk/api/handlers/openai ./internal/api`: passed.

## Platforms tested

- Linux arm64, Go 1.26.0.
- macOS and Windows not manually tested; the change is limited to model response serialization.
