### PR TITLE
feat(openai): expose model metadata in /v1/models

### DIFF
--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -726,7 +726,14 @@ func (s *Server) handleHomeModels(c *gin.Context) {
 		return
 	}
 
-	filtered := make([]map[string]any, 0, len(entries))
+	c.JSON(http.StatusOK, gin.H{
+		"object": "list",
+		"data":   formatHomeOpenAIModels(entries),
+	})
+}
+
+func formatHomeOpenAIModels(entries []homeModelEntry) []map[string]any {
+	models := make([]map[string]any, 0, len(entries))
 	for _, entry := range entries {
 		model := map[string]any{
 			"id":     entry.id,
@@ -738,12 +745,18 @@ func (s *Server) handleHomeModels(c *gin.Context) {
 		if entry.ownedBy != "" {
 			model["owned_by"] = entry.ownedBy
 		}
-		filtered = append(filtered, model)
+		if entry.displayName != "" {
+			model["display_name"] = entry.displayName
+		}
+		if entry.contextLength > 0 {
+			model["context_length"] = entry.contextLength
+		}
+		if entry.maxCompletionTokens > 0 {
+			model["max_completion_tokens"] = entry.maxCompletionTokens
+		}
+		models = append(models, model)
 	}
-	c.JSON(http.StatusOK, gin.H{
-		"object": "list",
-		"data":   filtered,
-	})
+	return models
 }
 
 func formatHomeClaudeModels(entries []homeModelEntry) []map[string]any {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2124,6 +2124,30 @@ func TestDefaultRequestLoggerFactory_UsesResolvedLogDirectory(t *testing.T) {
 	}
 }
 
+func TestFormatHomeOpenAIModelsIncludesRegistryMetadata(t *testing.T) {
+	models := formatHomeOpenAIModels([]homeModelEntry{{
+		id:                  "gpt-5.6-sol",
+		created:             1776902400,
+		ownedBy:             "openai",
+		displayName:         "GPT-5.6 Sol",
+		contextLength:       372000,
+		maxCompletionTokens: 128000,
+	}})
+	if len(models) != 1 {
+		t.Fatalf("models = %d, want 1", len(models))
+	}
+	model := models[0]
+	if got := model["display_name"]; got != "GPT-5.6 Sol" {
+		t.Fatalf("display_name = %v, want GPT-5.6 Sol", got)
+	}
+	if got := model["context_length"]; got != 372000 {
+		t.Fatalf("context_length = %v, want 372000", got)
+	}
+	if got := model["max_completion_tokens"]; got != 128000 {
+		t.Fatalf("max_completion_tokens = %v, want 128000", got)
+	}
+}
+
 func TestFormatHomeClaudeModelIncludesAnthropicSchemaFields(t *testing.T) {
 	withMetadata := formatHomeClaudeModel(homeModelEntry{
 		id:                  "claude-sonnet-4-6",

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -67,30 +67,9 @@ func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 	// Get all available models
 	allModels := h.Models()
 
-	// Filter to only include the 4 required fields: id, object, created, owned_by
-	filteredModels := make([]map[string]any, len(allModels))
-	for i, model := range allModels {
-		filteredModel := map[string]any{
-			"id":     model["id"],
-			"object": model["object"],
-		}
-
-		// Add created field if it exists
-		if created, exists := model["created"]; exists {
-			filteredModel["created"] = created
-		}
-
-		// Add owned_by field if it exists
-		if ownedBy, exists := model["owned_by"]; exists {
-			filteredModel["owned_by"] = ownedBy
-		}
-
-		filteredModels[i] = filteredModel
-	}
-
 	c.JSON(http.StatusOK, gin.H{
 		"object": "list",
-		"data":   filteredModels,
+		"data":   allModels,
 	})
 }
 

--- a/sdk/api/handlers/openai/openai_models_test.go
+++ b/sdk/api/handlers/openai/openai_models_test.go
@@ -1,0 +1,69 @@
+package openai
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestOpenAIModelsIncludesRegistryMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	suffix := time.Now().UnixNano()
+	clientID := fmt.Sprintf("openai-models-full-test-client-%d", suffix)
+	modelID := fmt.Sprintf("openai-models-full-test-model-%d", suffix)
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(clientID, "openai", []*registry.ModelInfo{{
+		ID:                  modelID,
+		Object:              "model",
+		Created:             1776902400,
+		OwnedBy:             "openai",
+		ContextLength:       372000,
+		MaxCompletionTokens: 128000,
+	}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+	handler := &OpenAIAPIHandler{}
+	model := requestListedModel(t, handler, "/v1/models", modelID)
+	assertJSONNumber(t, model, "context_length", 372000)
+	assertJSONNumber(t, model, "max_completion_tokens", 128000)
+}
+
+func requestListedModel(t *testing.T, handler *OpenAIAPIHandler, target, modelID string) map[string]any {
+	t.Helper()
+
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	context.Request = httptest.NewRequest(http.MethodGet, target, nil)
+	handler.OpenAIModels(context)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET %s status = %d, want %d: %s", target, recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var response struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode GET %s response: %v", target, err)
+	}
+	for _, model := range response.Data {
+		if model["id"] == modelID {
+			return model
+		}
+	}
+	t.Fatalf("GET %s response did not include model %q", target, modelID)
+	return nil
+}
+
+func assertJSONNumber(t *testing.T, model map[string]any, key string, want float64) {
+	t.Helper()
+	if got, ok := model[key].(float64); !ok || got != want {
+		t.Fatalf("%s = %#v, want %v", key, model[key], want)
+	}
+}


### PR DESCRIPTION
## What and why

Return the model registry's available metadata from standard `GET /v1/models` responses.

The response retains the standard `id`, `object`, `created`, and `owned_by` members and also preserves optional registry members such as:

- `context_length`
- `max_context_length`
- `max_completion_tokens`
- `display_name`
- `supported_parameters`

Additional JSON object members are backward-compatible for clients that only consume the standard fields, while metadata-aware clients can size context management and output budgets from the serving route's advertised capabilities.

A concrete downstream failure motivated this change: the registry contained the route's measured `372000`-token context limit, but `/v1/models` stripped it. The client therefore inferred `1050000` tokens and delayed compaction beyond the provider's actual limit.

## Scope

- Standard non-Home `/v1/models` returns the OpenAI registry maps directly.
- Home mode includes `display_name`, `context_length`, and `max_completion_tokens` when available.
- Anthropic-formatted model-list requests remain unchanged.
- The existing `client_version` catalog path remains unchanged.

This intentionally changes the default OpenAI model-list response rather than requiring a query flag: existing model-discovery clients call the standard endpoint and cannot benefit from metadata hidden behind a separate request shape.

This is a fresh, single-commit replacement for closed PR #4934.

## Verification

```bash
go test ./sdk/api/handlers/openai ./internal/api -count=1
go test ./internal/registry -run 'TestGetAvailableModelsIncludesMaxContextLengthOverride|TestGetAvailableModelsReturnsClonedSnapshots' -count=1
go vet ./sdk/api/handlers/openai ./internal/api
```

Verified with Go 1.26.0 on Linux arm64:

- Handler and internal API suites: **418 passed**.
- Focused registry tests: **2 passed**.
- Go vet: passed.
