### PR TITLE
fix(antigravity): cap soft-rate-limit retries and cool down auth on exhaustion

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -44,6 +44,14 @@ const (
 	antigravityCreditsHintRefreshTimeout   = 5 * time.Second
 	antigravityShortQuotaCooldownThreshold = 5 * time.Minute
 	antigravityInstantRetryThreshold       = 3 * time.Second
+	// antigravitySoftRateLimitMaxAttempts caps how many attempts a bare/ambiguous
+	// 429 (RESOURCE_EXHAUSTED without RetryInfo) is retried against the SAME auth
+	// before switching. One quick retry still catches genuinely transient blips.
+	antigravitySoftRateLimitMaxAttempts = 2
+	// antigravitySoftRateLimitExhaustedCooldown is the local cooldown applied to an
+	// auth once soft-rate-limit retries are exhausted, so subsequent requests skip
+	// it (draining the pool toward fallback providers) instead of re-hitting it.
+	antigravitySoftRateLimitExhaustedCooldown = 120 * time.Second
 	// systemInstruction              = "You are Antigravity, a powerful agentic AI coding assistant designed by the Google Deepmind team working on Advanced Agentic Coding.You are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.**Absolute paths only****Proactiveness**"
 )
 

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -765,3 +765,58 @@ func TestParseMetaFloat(t *testing.T) {
 		})
 	}
 }
+
+func TestAntigravityExecute_SoftRateLimitExhaustedRecordsCooldown(t *testing.T) {
+	resetAntigravityCreditsRetryState()
+	t.Cleanup(resetAntigravityCreditsRetryState)
+
+	// Google now returns a bare RESOURCE_EXHAUSTED 429 (no RetryInfo) for an
+	// exhausted credential, indistinguishable from a transient blip. The executor
+	// should retry the same auth at most antigravitySoftRateLimitMaxAttempts times,
+	// then record a short cooldown so subsequent requests skip this auth instead of
+	// re-hitting it (which starves lower-priority fallback providers).
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`))
+	}))
+	defer server.Close()
+
+	// RequestRetry 3 => 4 total attempts if uncapped; the soft cap must limit it.
+	exec := NewAntigravityExecutor(&config.Config{RequestRetry: 3})
+	auth := &cliproxyauth.Auth{
+		ID: "auth-soft-exhausted-429",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+		},
+		Metadata: map[string]any{
+			"access_token": "token",
+			"project_id":   "project-1",
+			"expired":      time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-4-6",
+		Payload: []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatAntigravity,
+	})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want 429 error after soft rate limit exhausted")
+	}
+	if requestCount != antigravitySoftRateLimitMaxAttempts {
+		t.Fatalf("request count = %d, want %d (soft retries must be capped)", requestCount, antigravitySoftRateLimitMaxAttempts)
+	}
+	inCooldown, remaining, cdErr := antigravityIsInShortCooldownRequired(context.Background(), auth, "claude-sonnet-4-6", time.Now())
+	if cdErr != nil {
+		t.Fatalf("antigravityIsInShortCooldownRequired() error = %v", cdErr)
+	}
+	if !inCooldown {
+		t.Fatal("expected auth to be in short cooldown after soft rate limit exhausted, got none")
+	}
+	if remaining <= 0 || remaining > antigravitySoftRateLimitExhaustedCooldown {
+		t.Fatalf("cooldown remaining = %v, want in (0, %v]", remaining, antigravitySoftRateLimitExhaustedCooldown)
+	}
+}

--- a/internal/runtime/executor/antigravity_executor_execute.go
+++ b/internal/runtime/executor/antigravity_executor_execute.go
@@ -208,13 +208,18 @@ attemptLoop:
 					}
 				}
 				if antigravityShouldRetrySoftRateLimit(httpResp.StatusCode, bodyBytes) {
-					if attempt+1 < attempts {
+					if attempt+1 < attempts && attempt+1 < antigravitySoftRateLimitMaxAttempts {
 						delay := antigravitySoftRateLimitDelay(attempt)
 						log.Debugf("antigravity executor: soft rate limit for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
 						if errWait := antigravityWait(ctx, delay); errWait != nil {
 							return resp, errWait
 						}
 						continue attemptLoop
+					}
+					if errMark := markAntigravityShortCooldownRequired(ctx, auth, baseModel, time.Now(), antigravitySoftRateLimitExhaustedCooldown); errMark != nil {
+						log.Debugf("antigravity executor: failed to record soft cooldown for model %s: %v", baseModel, errMark)
+					} else {
+						log.Debugf("antigravity executor: soft rate limit exhausted for model %s, recorded %s cooldown to switch auth", baseModel, antigravitySoftRateLimitExhaustedCooldown)
 					}
 				}
 				if errClear := clearAntigravityReasoningReplayOnInvalidSignature(ctx, replayScope, httpResp.StatusCode, bodyBytes); errClear != nil {
@@ -444,13 +449,18 @@ attemptLoop:
 					}
 				}
 				if antigravityShouldRetrySoftRateLimit(httpResp.StatusCode, bodyBytes) {
-					if attempt+1 < attempts {
+					if attempt+1 < attempts && attempt+1 < antigravitySoftRateLimitMaxAttempts {
 						delay := antigravitySoftRateLimitDelay(attempt)
 						log.Debugf("antigravity executor: soft rate limit for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
 						if errWait := antigravityWait(ctx, delay); errWait != nil {
 							return resp, errWait
 						}
 						continue attemptLoop
+					}
+					if errMark := markAntigravityShortCooldownRequired(ctx, auth, baseModel, time.Now(), antigravitySoftRateLimitExhaustedCooldown); errMark != nil {
+						log.Debugf("antigravity executor: failed to record soft cooldown for model %s: %v", baseModel, errMark)
+					} else {
+						log.Debugf("antigravity executor: soft rate limit exhausted for model %s, recorded %s cooldown to switch auth", baseModel, antigravitySoftRateLimitExhaustedCooldown)
 					}
 				}
 				if errClear := clearAntigravityReasoningReplayOnInvalidSignature(ctx, replayScope, httpResp.StatusCode, bodyBytes); errClear != nil {

--- a/internal/runtime/executor/antigravity_executor_stream.go
+++ b/internal/runtime/executor/antigravity_executor_stream.go
@@ -216,13 +216,18 @@ attemptLoop:
 					}
 				}
 				if antigravityShouldRetrySoftRateLimit(httpResp.StatusCode, bodyBytes) {
-					if attempt+1 < attempts {
+					if attempt+1 < attempts && attempt+1 < antigravitySoftRateLimitMaxAttempts {
 						delay := antigravitySoftRateLimitDelay(attempt)
 						log.Debugf("antigravity executor: soft rate limit for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
 						if errWait := antigravityWait(ctx, delay); errWait != nil {
 							return nil, errWait
 						}
 						continue attemptLoop
+					}
+					if errMark := markAntigravityShortCooldownRequired(ctx, auth, baseModel, time.Now(), antigravitySoftRateLimitExhaustedCooldown); errMark != nil {
+						log.Debugf("antigravity executor: failed to record soft cooldown for model %s: %v", baseModel, errMark)
+					} else {
+						log.Debugf("antigravity executor: soft rate limit exhausted for model %s, recorded %s cooldown to switch auth", baseModel, antigravitySoftRateLimitExhaustedCooldown)
 					}
 				}
 				if errClear := clearAntigravityReasoningReplayOnInvalidSignature(ctx, replayScope, httpResp.StatusCode, bodyBytes); errClear != nil {


### PR DESCRIPTION
## Problem

An exhausted Antigravity credential now returns a **bare `429 RESOURCE_EXHAUSTED` without `RetryInfo`**:

```json
{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}
```

`decideAntigravity429` classifies this as a *soft rate limit*, so the executor retries the **same** auth `RequestRetry+1` times (default 4) with a short backoff and **no cooldown**. In production this means each request to an exhausted account wastes several seconds before moving on, and because the pool never marks the account unavailable, requests never drain toward fallback providers (e.g. a Vertex credential sorted last in the round-robin is effectively never reached).

## Why not just always switch auth

The bare body is **ambiguous** — Google also returns it for transient blips, which is exactly what `TestAntigravityExecute_RetriesTransient429ResourceExhausted` pins down. So this keeps **one quick retry** to absorb transients, but:

- caps same-auth soft-rate-limit retries at `antigravitySoftRateLimitMaxAttempts` (2), and
- when those are exhausted, records a local cooldown via the existing `markAntigravityShortCooldownRequired` (`antigravitySoftRateLimitExhaustedCooldown`, 120s) so subsequent requests skip the exhausted auth and drain toward other providers.

No change to the 429 classification itself.

## Changes

- `antigravity_executor.go`: two new constants.
- `antigravity_executor_execute.go` / `antigravity_executor_stream.go`: cap the soft-retry loop and record the cooldown on exhaustion (3 sites).
- `antigravity_executor_credits_test.go`: add `TestAntigravityExecute_SoftRateLimitExhaustedRecordsCooldown`.

## Testing

`go test ./internal/runtime/executor/` — the new test plus the existing transient/classification tests pass.
