### PR TITLE
feat(management): support optional display names for API keys

### DIFF
--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -131,18 +131,77 @@ func (h *Handler) deleteFromStringList(c *gin.Context, target *[]string, after f
 	c.JSON(400, gin.H{"error": "missing index or value"})
 }
 
-// api-keys
-func (h *Handler) GetAPIKeys(c *gin.Context) { c.JSON(200, gin.H{"api-keys": h.cfg.APIKeys}) }
+// api-keys (with optional display names in api-key-names)
+func (h *Handler) GetAPIKeys(c *gin.Context) {
+	keys := h.cfg.APIKeys
+	if keys == nil {
+		keys = []string{}
+	}
+	names := h.cfg.APIKeyNames
+	if names == nil {
+		names = map[string]string{}
+	}
+	c.JSON(200, gin.H{"api-keys": keys, "api-key-names": names})
+}
 func (h *Handler) PutAPIKeys(c *gin.Context) {
+	type payload struct {
+		Keys  []string          `json:"api-keys"`
+		Names map[string]string `json:"api-key-names,omitempty"`
+	}
+	var p payload
+	if err := c.ShouldBindJSON(&p); err == nil && p.Keys != nil {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		h.cfg.APIKeys = append([]string(nil), p.Keys...)
+		// rebuild names: keep only entries whose key still exists
+		kept := map[string]string{}
+		for _, k := range h.cfg.APIKeys {
+			if n, ok := p.Names[k]; ok && n != "" {
+				kept[k] = n
+			}
+		}
+		h.cfg.APIKeyNames = kept
+		h.persistLocked(c)
+		return
+	}
 	h.putStringList(c, func(v []string) {
 		h.cfg.APIKeys = append([]string(nil), v...)
+		if h.cfg.APIKeyNames != nil {
+			kept := map[string]string{}
+			for _, k := range h.cfg.APIKeys {
+				if n, ok := h.cfg.APIKeyNames[k]; ok {
+					kept[k] = n
+				}
+			}
+			h.cfg.APIKeyNames = kept
+		}
 	}, nil)
 }
 func (h *Handler) PatchAPIKeys(c *gin.Context) {
-	h.patchStringList(c, &h.cfg.APIKeys, func() {})
+	h.patchStringList(c, &h.cfg.APIKeys, func() {
+		if h.cfg.APIKeyNames != nil {
+			kept := map[string]string{}
+			for _, k := range h.cfg.APIKeys {
+				if n, ok := h.cfg.APIKeyNames[k]; ok {
+					kept[k] = n
+				}
+			}
+			h.cfg.APIKeyNames = kept
+		}
+	})
 }
 func (h *Handler) DeleteAPIKeys(c *gin.Context) {
-	h.deleteFromStringList(c, &h.cfg.APIKeys, func() {})
+	h.deleteFromStringList(c, &h.cfg.APIKeys, func() {
+		if h.cfg.APIKeyNames != nil {
+			kept := map[string]string{}
+			for _, k := range h.cfg.APIKeys {
+				if n, ok := h.cfg.APIKeyNames[k]; ok {
+					kept[k] = n
+				}
+			}
+			h.cfg.APIKeyNames = kept
+		}
+	})
 }
 
 // gemini-api-key: []GeminiKey

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -51,6 +51,10 @@ type SDKConfig struct {
 	// APIKeys is a list of keys for authenticating clients to this proxy server.
 	APIKeys []string `yaml:"api-keys" json:"api-keys"`
 
+	// APIKeyNames maps an API key to a human-readable display name (e.g. the client/app it belongs to).
+	// Optional; when absent, the panel shows the raw key. Never used for authentication.
+	APIKeyNames map[string]string `yaml:"api-key-names,omitempty" json:"api-key-names,omitempty"`
+
 	// PassthroughHeaders controls whether upstream response headers are forwarded to downstream clients.
 	// Default is false (disabled).
 	PassthroughHeaders bool `yaml:"passthrough-headers" json:"passthrough-headers"`


### PR DESCRIPTION
## Summary

Adds an optional `api-key-names` mapping (`key -> display name`) alongside the existing `api-keys` list, so operators can see which client/app each API key belongs to in the management panel.

## Changes

- `internal/config/sdk_config.go`: new optional `APIKeyNames map[string]string` field (`api-key-names` in YAML)
- `internal/api/handlers/management/config_lists.go`: management API now returns `{api-keys, api-key-names}` on GET and accepts both on PUT; PATCH/DELETE keep the names map in sync when keys are removed/renamed

## Design notes

- **Purely additive & backward compatible**: configs without `api-key-names` behave exactly as before
- **Authentication is unchanged**: only the raw keys are used for client auth (`normalizeKeys` untouched)
- Config is persisted via the existing `SaveConfigPreserveComments` path, so names survive restarts

## Verification

- Built & deployed locally against v7.2.131 baseline, `GET /v0/management/api-keys` returns both fields, PUT with names persists to config.yaml, hot reload works
- Companion frontend PR in `Cli-Proxy-API-Management-Center` displays the names in the API Keys editor