### PR TITLE
fix(auth): refresh provider-owned credentials after 401

### DIFF
--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -353,7 +353,10 @@ func authHasRefreshCredential(auth *Auth) bool {
 	if authMetadataString(auth, "refresh_token") != "" {
 		return true
 	}
-	return authMetadataString(auth, "refreshToken") != ""
+	if authMetadataString(auth, "refreshToken") != "" {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(auth.Attributes[AttributeRefreshCapable]), "true")
 }
 
 func clearUnauthorizedModelStates(auth *Auth, now time.Time) []string {

--- a/sdk/cliproxy/auth/conductor_unauthorized_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_unauthorized_refresh_test.go
@@ -312,6 +312,55 @@ func TestManager_Execute_UnauthorizedWithoutRefreshTokenDoesNotCallRefresh(t *te
 	}
 }
 
+func TestAuthHasRefreshCredentialAllowsProviderOwnedRefresh(t *testing.T) {
+	auth := &Auth{Attributes: map[string]string{AttributeRefreshCapable: "true"}}
+	if !authHasRefreshCredential(auth) {
+		t.Fatal("plugin-owned refresh capability should permit one-time unauthorized refresh")
+	}
+	if authHasRefreshCredential(&Auth{Attributes: map[string]string{AttributeRefreshCapable: "false"}}) {
+		t.Fatal("disabled plugin-owned refresh capability should not permit unauthorized refresh")
+	}
+}
+
+func TestManager_ExecuteStream_UnauthorizedRefreshesProviderOwnedCredential(t *testing.T) {
+	m, executor, primary, backup, model := newUnauthorizedRefreshFixture(t, false)
+	registered, ok := m.GetByID(primary.ID)
+	if !ok || registered == nil {
+		t.Fatal("primary auth is not registered")
+	}
+	delete(registered.Metadata, "refresh_token")
+	registered.Attributes = map[string]string{AttributeRefreshCapable: "true"}
+	if _, errUpdate := m.Update(context.Background(), registered); errUpdate != nil {
+		t.Fatalf("update primary auth: %v", errUpdate)
+	}
+
+	stream, errStream := m.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if errStream != nil {
+		t.Fatalf("ExecuteStream error = %v, want refreshed primary success", errStream)
+	}
+	if stream == nil || stream.Chunks == nil {
+		t.Fatal("expected stream result")
+	}
+	chunk, ok := <-stream.Chunks
+	if !ok || chunk.Err != nil {
+		t.Fatalf("stream chunk = %#v, want successful payload", chunk)
+	}
+	if got := string(chunk.Payload); got != primary.ID+":fresh-access-token" {
+		t.Fatalf("stream payload = %q, want refreshed primary response", got)
+	}
+	if got := executor.RefreshCalls(); got != 1 {
+		t.Fatalf("Refresh calls = %d, want 1", got)
+	}
+	if got := executor.StreamCalls(); len(got) != 2 || got[0] != primary.ID || got[1] != primary.ID {
+		t.Fatalf("Stream calls = %v, want [primary, primary]", got)
+	}
+	for _, id := range executor.StreamCalls() {
+		if id == backup.ID {
+			t.Fatal("backup auth should not be used when provider-owned refresh recovers primary")
+		}
+	}
+}
+
 func TestManager_Execute_UnauthorizedRefreshThenRetryStillFailsFallsBackOnce(t *testing.T) {
 	m, executor, primary, backup, model := newUnauthorizedRefreshFixture(t, false)
 	// Refresh "succeeds" but hands back another invalidated token.

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -101,9 +101,12 @@ type Auth struct {
 }
 
 const (
-	AttributeAuthIndexSeed   = "auth_index_seed"
-	AttributePluginVirtual   = "plugin_virtual"
-	AttributeVirtualSource   = "virtual_source"
+	AttributeAuthIndexSeed = "auth_index_seed"
+	AttributePluginVirtual = "plugin_virtual"
+	AttributeVirtualSource = "virtual_source"
+	// AttributeRefreshCapable permits a credential whose refresh material is
+	// held by its provider to refresh after an unauthorized response.
+	AttributeRefreshCapable  = "refresh_capable"
 	pluginVirtualAttrEnabled = "true"
 )
 


### PR DESCRIPTION
## Summary
- allow plugin-owned credentials to declare refresh capability without storing refresh material in shared auth metadata
- retry a stream once after a 401 by refreshing the same credential
- cover provider-owned refresh capability and stream recovery with regression tests

## Security
No credential material is added to CPA metadata. The provider retains refresh material in its own storage.

## Validation
- go test -race ./sdk/cliproxy/auth