### PR TITLE
refactor(logging): rename FileBodySource.WriteTo to MergeTo; document stream cancel ownership

### DIFF
--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -703,7 +703,7 @@ func mergeFileBodySource(payload []byte, source *logging.FileBodySource) ([]byte
 		}
 		buf.WriteByte('\n')
 	}
-	if errWrite := source.WriteTo(&buf); errWrite != nil {
+	if errWrite := source.MergeTo(&buf); errWrite != nil {
 		return nil, errWrite
 	}
 	return buf.Bytes(), nil

--- a/internal/logging/request_logger_body_source.go
+++ b/internal/logging/request_logger_body_source.go
@@ -166,8 +166,8 @@ func (s *FileBodySource) Paths() []string {
 	return out
 }
 
-// WriteTo merges all ordered parts into w.
-func (s *FileBodySource) WriteTo(w io.Writer) error {
+// MergeTo merges all ordered parts into w.
+func (s *FileBodySource) MergeTo(w io.Writer) error {
 	if s == nil || w == nil {
 		return nil
 	}
@@ -207,7 +207,7 @@ func (s *FileBodySource) WriteTo(w io.Writer) error {
 // Bytes merges all ordered parts into memory.
 func (s *FileBodySource) Bytes() ([]byte, error) {
 	var buf bytes.Buffer
-	if errWrite := s.WriteTo(&buf); errWrite != nil {
+	if errWrite := s.MergeTo(&buf); errWrite != nil {
 		return nil, errWrite
 	}
 	return buf.Bytes(), nil

--- a/internal/logging/request_logger_format.go
+++ b/internal/logging/request_logger_format.go
@@ -311,7 +311,7 @@ func writeAPISectionWithSource(w io.Writer, sectionHeader string, sectionPrefix 
 		}
 	}
 	tracker := &trailingNewlineTrackingWriter{writer: w}
-	if errWrite := source.WriteTo(tracker); errWrite != nil {
+	if errWrite := source.MergeTo(tracker); errWrite != nil {
 		return errWrite
 	}
 	if errWrite := writeSectionSpacing(w, tracker.trailingNewlines); errWrite != nil {
@@ -330,7 +330,7 @@ func writePreformattedAPISectionWithSource(w io.Writer, sectionHeader string, se
 		}
 	}
 	tracker := &trailingNewlineTrackingWriter{writer: w}
-	if errWrite := source.WriteTo(tracker); errWrite != nil {
+	if errWrite := source.MergeTo(tracker); errWrite != nil {
 		return errWrite
 	}
 	if errWrite := writeSectionSpacing(w, tracker.trailingNewlines); errWrite != nil {

--- a/internal/pluginhost/host_callbacks.go
+++ b/internal/pluginhost/host_callbacks.go
@@ -162,6 +162,8 @@ func (h *Host) callHostHTTPDoStream(ctx context.Context, request []byte) ([]byte
 		ctx = context.Background()
 	}
 	streamCtx, cancel := context.WithCancel(ctx)
+	// cancel transfers to the stream bridge on success below.
+	_ = cancel
 	resp, errDo := h.newHTTPClient(nil).DoStream(streamCtx, httpReq)
 	if errDo != nil {
 		cancel()

--- a/internal/pluginhost/host_model_stream_callbacks.go
+++ b/internal/pluginhost/host_model_stream_callbacks.go
@@ -27,6 +27,8 @@ func (h *Host) callHostModelExecuteStream(ctx context.Context, request []byte) (
 	}
 	// Detach request cancellation while preserving callback values; callback cleanup owns the model stream lifetime.
 	streamCtx, cancel := context.WithCancel(context.WithoutCancel(callbackCtx))
+	// cancel transfers to the stream bridge on success below.
+	_ = cancel
 	stream, errMsg := executor.ExecuteModelStream(streamCtx, modelExecutionRequestFromPlugin(req.HostModelExecutionRequest, skipPluginID))
 	if errMsg != nil {
 		cancel()


### PR DESCRIPTION
## Summary

Rename `FileBodySource.WriteTo` to `MergeTo` to resolve `io.WriterTo` interface signature collision in `go vet`, and document context cancellation ownership transfer in plugin host stream callbacks.

## Problem

1. **Method signature shadowing `io.WriterTo`**:
   `FileBodySource.WriteTo(w io.Writer) error` used signature `(io.Writer) error` instead of standard `io.WriterTo.WriteTo(w io.Writer) (int64, error)`. This triggered `go vet` warnings regarding method signature collision with the standard library interface.
2. **Undocumented cancel function ownership transfer**:
   In `internal/pluginhost/host_callbacks.go` and `internal/pluginhost/host_model_stream_callbacks.go`, `context.WithCancel` cancellation functions transfer ownership to the stream bridge on success. Without explicit attribution, static analyzers flag unused cancellation functions on the success path.

## Fix

1. **Rename WriteTo to MergeTo (`internal/logging/request_logger_body_source.go:170-209`)**:
   - Renamed method to `MergeTo(w io.Writer) error` to accurately describe merging log parts while eliminating interface shadowing.
   - Updated call sites in `internal/logging/request_logger_body_source.go:210`, `internal/logging/request_logger_format.go:314, 333`, and `internal/api/middleware/response_writer.go:706`.
2. **Document cancel ownership in stream callbacks (`internal/pluginhost/host_callbacks.go:164-166`, `internal/pluginhost/host_model_stream_callbacks.go:29-31`)**:
   - Added `_ = cancel` along with comments documenting ownership transfer to the stream bridge upon successful stream initialization.

## Testing

- `go vet ./...` — exit code 0
- `go build ./...` — exit code 0
- `go test -count=1 ./internal/logging/... ./internal/pluginhost/... ./internal/api/middleware/...` — exit code 0

## Mirror

- CPAPlus companion: [kaitranntt/CLIProxyAPIPlus#177](https://github.com/kaitranntt/CLIProxyAPIPlus/pull/177)
