### PR TITLE
fix(xai): preserve Claude tool results and block repeated calls

### DIFF
--- a/internal/runtime/executor/helps/xai_claude_tool_result.go
+++ b/internal/runtime/executor/helps/xai_claude_tool_result.go
@@ -1,0 +1,317 @@
+package helps
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const XAIClaudeRepeatedToolMessage = "The upstream model repeated the immediately completed tool call with unchanged arguments. The gateway blocked the duplicate execution."
+
+type XAIClaudeToolRepeatGuard struct {
+	fingerprints map[string]struct{}
+	blockedIDs   map[string]struct{}
+}
+
+const (
+	XAIClaudeToolResultSuccessPrefix = "[tool_result status=success] The tool call completed successfully. Treat this result as consumed. Do not repeat the same tool call with unchanged arguments unless the result explicitly asks for a retry.\n"
+	XAIClaudeToolResultErrorPrefix   = "[tool_result status=error] The tool call failed. Use the error details below to change the approach or arguments. Do not repeat the same tool call unchanged.\n"
+)
+
+// annotateXAIClaudeToolResults preserves Anthropic tool_result status on the
+// Responses wire format, which has no is_error field. This is deliberately an
+// xAI-only compatibility shim and can be removed when the upstream accepts an
+// explicit tool output status.
+func AnnotateXAIClaudeToolResults(body, source []byte, from sdktranslator.Format) []byte {
+	if !strings.EqualFold(strings.TrimSpace(from.String()), sdktranslator.FormatClaude.String()) {
+		return body
+	}
+
+	statuses := xaiClaudeToolResultStatuses(source)
+	if len(statuses) == 0 {
+		return body
+	}
+
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return body
+	}
+	for index, item := range input.Array() {
+		if item.Get("type").String() != "function_call_output" {
+			continue
+		}
+		isError, ok := statuses[strings.TrimSpace(item.Get("call_id").String())]
+		if !ok {
+			continue
+		}
+		body = annotateXAIClaudeToolOutputAt(body, index, item.Get("output"), isError)
+	}
+	return body
+}
+
+func xaiClaudeToolResultStatuses(source []byte) map[string]bool {
+	statuses := make(map[string]bool)
+	gjson.GetBytes(source, "messages").ForEach(func(_, message gjson.Result) bool {
+		content := message.Get("content")
+		if !content.IsArray() {
+			return true
+		}
+		content.ForEach(func(_, part gjson.Result) bool {
+			if part.Get("type").String() != "tool_result" {
+				return true
+			}
+			callID := strings.TrimSpace(part.Get("tool_use_id").String())
+			if callID != "" {
+				statuses[callID] = part.Get("is_error").Bool()
+			}
+			return true
+		})
+		return true
+	})
+	return statuses
+}
+
+func annotateXAIClaudeToolOutputAt(body []byte, index int, output gjson.Result, isError bool) []byte {
+	prefix := XAIClaudeToolResultSuccessPrefix
+	if isError {
+		prefix = XAIClaudeToolResultErrorPrefix
+	}
+	path := fmt.Sprintf("input.%d.output", index)
+
+	if output.IsArray() {
+		items := output.Array()
+		if len(items) > 0 && xaiClaudeToolResultAlreadyAnnotated(items[0].Get("text").String()) {
+			return body
+		}
+		marker := []byte(`{"type":"input_text","text":""}`)
+		marker, _ = sjson.SetBytes(marker, "text", strings.TrimSuffix(prefix, "\n"))
+		rawItems := make([]string, 0, len(items)+1)
+		rawItems = append(rawItems, string(marker))
+		for _, item := range items {
+			rawItems = append(rawItems, item.Raw)
+		}
+		updated, err := sjson.SetRawBytes(body, path, []byte("["+strings.Join(rawItems, ",")+"]"))
+		if err == nil {
+			return updated
+		}
+		return body
+	}
+
+	text := output.String()
+	if xaiClaudeToolResultAlreadyAnnotated(text) {
+		return body
+	}
+	updated, err := sjson.SetBytes(body, path, prefix+text)
+	if err != nil {
+		return body
+	}
+	return updated
+}
+
+func xaiClaudeToolResultAlreadyAnnotated(text string) bool {
+	return strings.HasPrefix(text, XAIClaudeToolResultSuccessPrefix) ||
+		strings.HasPrefix(text, XAIClaudeToolResultErrorPrefix) ||
+		strings.HasPrefix(text, strings.TrimSuffix(XAIClaudeToolResultSuccessPrefix, "\n")) ||
+		strings.HasPrefix(text, strings.TrimSuffix(XAIClaudeToolResultErrorPrefix, "\n"))
+}
+
+func NewXAIClaudeToolRepeatGuard(source, body []byte, from sdktranslator.Format) *XAIClaudeToolRepeatGuard {
+	if !strings.EqualFold(strings.TrimSpace(from.String()), sdktranslator.FormatClaude.String()) {
+		return nil
+	}
+	fingerprints := xaiClaudeCompletedToolFingerprints(source)
+	if len(fingerprints) == 0 {
+		fingerprints = xaiResponsesCompletedToolFingerprints(body)
+	}
+	if len(fingerprints) == 0 {
+		return nil
+	}
+	return &XAIClaudeToolRepeatGuard{
+		fingerprints: fingerprints,
+		blockedIDs:   make(map[string]struct{}),
+	}
+}
+
+// xaiClaudeCompletedToolFingerprints derives the guard from the unmodified
+// downstream request. The translated xAI body is not authoritative here: the
+// reasoning replay and namespace normalization stages may reorder or omit the
+// matching function_call while retaining its output.
+func xaiClaudeCompletedToolFingerprints(source []byte) map[string]struct{} {
+	messages := gjson.GetBytes(source, "messages")
+	if !messages.IsArray() {
+		return nil
+	}
+	items := messages.Array()
+	if len(items) == 0 {
+		return nil
+	}
+	last := items[len(items)-1]
+	if last.Get("role").String() != "user" || !last.Get("content").IsArray() {
+		return nil
+	}
+	completedIDs := make(map[string]struct{})
+	last.Get("content").ForEach(func(_, part gjson.Result) bool {
+		if part.Get("type").String() == "tool_result" {
+			if callID := strings.TrimSpace(part.Get("tool_use_id").String()); callID != "" {
+				completedIDs[callID] = struct{}{}
+			}
+		}
+		return true
+	})
+	if len(completedIDs) == 0 {
+		return nil
+	}
+
+	fingerprints := make(map[string]struct{})
+	for index := len(items) - 2; index >= 0 && len(completedIDs) > 0; index-- {
+		message := items[index]
+		if message.Get("role").String() != "assistant" || !message.Get("content").IsArray() {
+			continue
+		}
+		message.Get("content").ForEach(func(_, part gjson.Result) bool {
+			if part.Get("type").String() != "tool_use" {
+				return true
+			}
+			callID := strings.TrimSpace(part.Get("id").String())
+			if _, completed := completedIDs[callID]; !completed {
+				return true
+			}
+			fingerprint := xaiToolCallFingerprint(part.Get("name").String(), part.Get("input").Raw)
+			if fingerprint != "" {
+				fingerprints[fingerprint] = struct{}{}
+			}
+			delete(completedIDs, callID)
+			return true
+		})
+	}
+	return fingerprints
+}
+
+func xaiResponsesCompletedToolFingerprints(body []byte) map[string]struct{} {
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return nil
+	}
+	items := input.Array()
+	lastOutput := -1
+	for index := len(items) - 1; index >= 0; index-- {
+		if items[index].Get("type").String() == "function_call_output" {
+			lastOutput = index
+			break
+		}
+	}
+	if lastOutput < 0 {
+		return nil
+	}
+
+	calls := make(map[string]gjson.Result)
+	for index := 0; index < lastOutput; index++ {
+		if items[index].Get("type").String() == "function_call" {
+			calls[strings.TrimSpace(items[index].Get("call_id").String())] = items[index]
+		}
+	}
+	callID := strings.TrimSpace(items[lastOutput].Get("call_id").String())
+	call, ok := calls[callID]
+	if !ok {
+		return nil
+	}
+	fingerprint := xaiToolCallFingerprint(call.Get("name").String(), call.Get("arguments").String())
+	if fingerprint == "" {
+		return nil
+	}
+	return map[string]struct{}{fingerprint: {}}
+}
+
+func (g *XAIClaudeToolRepeatGuard) PatchCompleted(data []byte) ([]byte, bool) {
+	if g == nil || len(g.fingerprints) == 0 || gjson.GetBytes(data, "type").String() != "response.completed" {
+		return data, false
+	}
+	output := gjson.GetBytes(data, "response.output")
+	if !output.IsArray() {
+		return data, false
+	}
+
+	kept := make([]string, 0, len(output.Array())+1)
+	blocked := false
+	for _, item := range output.Array() {
+		if item.Get("type").String() == "function_call" {
+			fingerprint := xaiToolCallFingerprint(item.Get("name").String(), item.Get("arguments").String())
+			if _, duplicate := g.fingerprints[fingerprint]; duplicate {
+				blocked = true
+				if callID := strings.TrimSpace(item.Get("call_id").String()); callID != "" {
+					g.blockedIDs[callID] = struct{}{}
+				}
+				if itemID := strings.TrimSpace(item.Get("id").String()); itemID != "" {
+					g.blockedIDs[itemID] = struct{}{}
+				}
+				continue
+			}
+		}
+		kept = append(kept, item.Raw)
+	}
+	if !blocked {
+		return data, false
+	}
+	message := xaiClaudeRepeatedToolOutputItem()
+	kept = append(kept, string(message))
+	updated, err := sjson.SetRawBytes(data, "response.output", []byte("["+strings.Join(kept, ",")+"]"))
+	if err != nil {
+		return data, false
+	}
+	return updated, true
+}
+
+func (g *XAIClaudeToolRepeatGuard) IsBlockedCallEvent(event gjson.Result) bool {
+	if g == nil {
+		return false
+	}
+	callID := strings.TrimSpace(event.Get("call_id").String())
+	if callID == "" {
+		callID = strings.TrimSpace(event.Get("item_id").String())
+	}
+	_, blocked := g.blockedIDs[callID]
+	return blocked
+}
+
+func (g *XAIClaudeToolRepeatGuard) IsDuplicateItem(item gjson.Result) bool {
+	if g == nil || item.Get("type").String() != "function_call" {
+		return false
+	}
+	fingerprint := xaiToolCallFingerprint(item.Get("name").String(), item.Get("arguments").String())
+	_, duplicate := g.fingerprints[fingerprint]
+	return duplicate
+}
+
+func xaiToolCallFingerprint(name, arguments string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	canonical := arguments
+	var value any
+	if json.Unmarshal([]byte(arguments), &value) == nil {
+		if encoded, err := json.Marshal(value); err == nil {
+			canonical = string(encoded)
+		}
+	}
+	sum := sha256.Sum256([]byte(name + "\x00" + canonical))
+	return hex.EncodeToString(sum[:])
+}
+
+func xaiClaudeRepeatedToolOutputItem() []byte {
+	item := []byte(`{"type":"message","role":"assistant","content":[{"type":"output_text","text":""}]}`)
+	item, _ = sjson.SetBytes(item, "content.0.text", XAIClaudeRepeatedToolMessage)
+	return item
+}
+
+func XAIClaudeRepeatedToolOutputEvent() []byte {
+	event := []byte(`{"type":"response.output_item.done","output_index":0,"item":{}}`)
+	event, _ = sjson.SetRawBytes(event, "item", xaiClaudeRepeatedToolOutputItem())
+	return event
+}

--- a/internal/runtime/executor/xai_claude_tool_result_test.go
+++ b/internal/runtime/executor/xai_claude_tool_result_test.go
@@ -1,0 +1,244 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestAnnotateXAIClaudeToolResults(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`{
+		"messages":[{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"call_ok","content":"updated"},
+			{"type":"tool_result","tool_use_id":"call_err","is_error":true,"content":"exit 1"}
+		]}]
+	}`)
+	body := []byte(`{"input":[
+		{"type":"function_call_output","call_id":"call_ok","output":"updated"},
+		{"type":"function_call_output","call_id":"call_err","output":"exit 1"},
+		{"type":"function_call_output","call_id":"unmatched","output":"unchanged"}
+	]}`)
+
+	got := helps.AnnotateXAIClaudeToolResults(body, source, sdktranslator.FormatClaude)
+	if output := gjson.GetBytes(got, "input.0.output").String(); output != helps.XAIClaudeToolResultSuccessPrefix+"updated" {
+		t.Fatalf("success output = %q", output)
+	}
+	if output := gjson.GetBytes(got, "input.1.output").String(); output != helps.XAIClaudeToolResultErrorPrefix+"exit 1" {
+		t.Fatalf("error output = %q", output)
+	}
+	if output := gjson.GetBytes(got, "input.2.output").String(); output != "unchanged" {
+		t.Fatalf("unmatched output changed: %q", output)
+	}
+	if callID := gjson.GetBytes(got, "input.1.call_id").String(); callID != "call_err" {
+		t.Fatalf("call_id changed: %q", callID)
+	}
+
+	gotAgain := helps.AnnotateXAIClaudeToolResults(got, source, sdktranslator.FormatClaude)
+	if string(gotAgain) != string(got) {
+		t.Fatalf("annotation must be idempotent:\nfirst: %s\nagain: %s", got, gotAgain)
+	}
+	if other := helps.AnnotateXAIClaudeToolResults(body, source, sdktranslator.FormatOpenAIResponse); string(other) != string(body) {
+		t.Fatalf("non-Claude source changed: %s", other)
+	}
+}
+
+func TestAnnotateXAIClaudeToolResultPreservesMultimodalOutput(t *testing.T) {
+	t.Parallel()
+	source := []byte(`{"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_image","is_error":true,"content":[]}]}]}`)
+	body := []byte(`{"input":[{"type":"function_call_output","call_id":"call_image","output":[{"type":"input_text","text":"failed"},{"type":"input_image","image_url":"data:image/png;base64,AA=="}]}]}`)
+
+	got := helps.AnnotateXAIClaudeToolResults(body, source, sdktranslator.FormatClaude)
+	output := gjson.GetBytes(got, "input.0.output")
+	if !output.IsArray() || len(output.Array()) != 3 {
+		t.Fatalf("multimodal output shape changed: %s", got)
+	}
+	if marker := output.Get("0.text").String(); marker != strings.TrimSuffix(helps.XAIClaudeToolResultErrorPrefix, "\n") {
+		t.Fatalf("error marker = %q", marker)
+	}
+	if image := output.Get("2.image_url").String(); image != "data:image/png;base64,AA==" {
+		t.Fatalf("image output changed: %q", image)
+	}
+}
+
+func TestXAIExecutorPrepareAnnotatesClaudeToolResultsForStreamModes(t *testing.T) {
+	t.Parallel()
+
+	for _, stream := range []bool{false, true} {
+		stream := stream
+		t.Run(fmt.Sprintf("stream_%t", stream), func(t *testing.T) {
+			t.Parallel()
+			exec := NewXAIExecutor(&config.Config{})
+			prepared, errPrepare := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+				Model: "grok-4.6",
+				Payload: []byte(`{
+					"model":"grok-4.6",
+					"messages":[
+						{"role":"user","content":"run once"},
+						{"role":"assistant","content":[{"type":"tool_use","id":"call_1","name":"probe","input":{"value":7}}]},
+						{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","is_error":true,"content":"failed"}]}
+					],
+					"tools":[{"name":"probe","description":"probe","input_schema":{"type":"object","properties":{"value":{"type":"integer"}}}}]
+				}`),
+			}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude, Stream: stream}, stream)
+			if errPrepare != nil {
+				t.Fatalf("prepareResponsesRequest() error = %v", errPrepare)
+			}
+			output := gjson.GetBytes(prepared.body, `input.#(type=="function_call_output").output`).String()
+			if output != helps.XAIClaudeToolResultErrorPrefix+"failed" {
+				t.Fatalf("tool output = %q; body=%s", output, prepared.body)
+			}
+			if callID := gjson.GetBytes(prepared.body, `input.#(type=="function_call_output").call_id`).String(); callID != "call_1" {
+				t.Fatalf("call_id = %q; body=%s", callID, prepared.body)
+			}
+		})
+	}
+}
+
+func TestXAIClaudeToolRepeatGuard(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"input":[
+		{"type":"function_call","call_id":"old","name":"Write","arguments":"{\"path\":\"a\",\"text\":\"x\"}"},
+		{"type":"function_call_output","call_id":"old","output":"[tool_result status=success] done"}
+	]}`)
+	guard := helps.NewXAIClaudeToolRepeatGuard(nil, body, sdktranslator.FormatClaude)
+	if guard == nil {
+		t.Fatal("repeat guard is nil")
+	}
+	completed := []byte(`{"type":"response.completed","response":{"output":[
+		{"type":"function_call","call_id":"new","name":"Write","arguments":"{\"text\":\"x\",\"path\":\"a\"}"}
+	]}}`)
+	patched, blocked := guard.PatchCompleted(completed)
+	if !blocked {
+		t.Fatalf("duplicate call was not blocked: %s", patched)
+	}
+	if gjson.GetBytes(patched, "response.output.0.type").String() != "message" {
+		t.Fatalf("duplicate was not replaced with a message: %s", patched)
+	}
+
+	changed := []byte(`{"type":"response.completed","response":{"output":[
+		{"type":"function_call","call_id":"new","name":"Write","arguments":"{\"text\":\"y\",\"path\":\"a\"}"}
+	]}}`)
+	unchanged, blocked := guard.PatchCompleted(changed)
+	if blocked || string(unchanged) != string(changed) {
+		t.Fatalf("changed arguments must be allowed: %s", unchanged)
+	}
+}
+
+func TestXAIClaudeToolRepeatGuardUsesOriginalAnthropicHistory(t *testing.T) {
+	t.Parallel()
+	source := []byte(`{"messages":[
+		{"role":"user","content":"update both"},
+		{"role":"assistant","content":[
+			{"type":"tool_use","id":"call_write","name":"Write","input":{"path":"a","text":"x"}},
+			{"type":"tool_use","id":"call_bash","name":"Bash","input":{"command":"compile"}}
+		]},
+		{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"call_write","content":"updated"},
+			{"type":"tool_result","tool_use_id":"call_bash","is_error":true,"content":"exit 1"}
+		]}
+	]}`)
+	// Replay/sanitization may leave the output without its historical call. The
+	// guard must use the original Anthropic history rather than this body.
+	body := []byte(`{"input":[
+		{"type":"reasoning","encrypted_content":"opaque"},
+		{"type":"function_call_output","call_id":"call_write","output":"updated"},
+		{"type":"function_call_output","call_id":"call_bash","output":"exit 1"}
+	]}`)
+	guard := helps.NewXAIClaudeToolRepeatGuard(source, body, sdktranslator.FormatClaude)
+	if guard == nil {
+		t.Fatal("original history did not create a repeat guard")
+	}
+
+	completed := []byte(`{"type":"response.completed","response":{"output":[
+		{"type":"function_call","id":"item_new","call_id":"new","name":"Write","arguments":"{\"text\":\"x\",\"path\":\"a\"}"},
+		{"type":"function_call","id":"item_changed","call_id":"changed","name":"Bash","arguments":"{\"command\":\"compile --verbose\"}"}
+	]}}`)
+	patched, blocked := guard.PatchCompleted(completed)
+	if !blocked {
+		t.Fatalf("duplicate from original history was not blocked: %s", patched)
+	}
+	if gjson.GetBytes(patched, `response.output.#(call_id=="new")`).Exists() {
+		t.Fatalf("duplicate call remained: %s", patched)
+	}
+	if !gjson.GetBytes(patched, `response.output.#(call_id=="changed")`).Exists() {
+		t.Fatalf("changed call was removed: %s", patched)
+	}
+	if !guard.IsBlockedCallEvent(gjson.Parse(`{"type":"response.function_call_arguments.delta","item_id":"item_new"}`)) {
+		t.Fatal("blocked output item id was not tracked for stream filtering")
+	}
+}
+
+func TestXAIExecutorBlocksRepeatedClaudeToolCall(t *testing.T) {
+	t.Parallel()
+
+	for _, stream := range []bool{false, true} {
+		stream := stream
+		t.Run(fmt.Sprintf("stream_%t", stream), func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.ReadAll(r.Body)
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = io.WriteString(w, "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"new\",\"name\":\"Write\",\"arguments\":\"{\\\"text\\\":\\\"x\\\",\\\"path\\\":\\\"a\\\"}\"}}\n")
+				_, _ = io.WriteString(w, "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"new\",\"name\":\"Write\",\"arguments\":\"{\\\"text\\\":\\\"x\\\",\\\"path\\\":\\\"a\\\"}\"}}\n")
+				_, _ = io.WriteString(w, "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"model\":\"grok-4.6\",\"output\":[{\"type\":\"function_call\",\"call_id\":\"new\",\"name\":\"Write\",\"arguments\":\"{\\\"text\\\":\\\"x\\\",\\\"path\\\":\\\"a\\\"}\"}],\"usage\":{}}}\n")
+			}))
+			defer server.Close()
+
+			executor := NewXAIExecutor(&config.Config{})
+			auth := &cliproxyauth.Auth{Provider: "xai", Attributes: map[string]string{"base_url": server.URL, "auth_kind": "oauth"}}
+			payload := []byte(`{
+				"model":"grok-4.6",
+				"messages":[
+					{"role":"assistant","content":[{"type":"tool_use","id":"old","name":"Write","input":{"path":"a","text":"x"}}]},
+					{"role":"user","content":[{"type":"tool_result","tool_use_id":"old","content":"updated","is_error":false}]}
+				],
+				"tools":[{"name":"Write","input_schema":{"type":"object","properties":{"path":{"type":"string"},"text":{"type":"string"}}}}]
+			}`)
+			opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude, Stream: stream}
+			if stream {
+				result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{Model: "grok-4.6", Payload: payload}, opts)
+				if err != nil {
+					t.Fatalf("ExecuteStream() error = %v", err)
+				}
+				var output strings.Builder
+				for chunk := range result.Chunks {
+					if chunk.Err != nil {
+						t.Fatalf("stream chunk error = %v", chunk.Err)
+					}
+					output.Write(chunk.Payload)
+				}
+				assertRepeatedToolBlocked(t, output.String())
+				return
+			}
+
+			response, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{Model: "grok-4.6", Payload: payload}, opts)
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			assertRepeatedToolBlocked(t, string(response.Payload))
+		})
+	}
+}
+
+func assertRepeatedToolBlocked(t *testing.T, output string) {
+	t.Helper()
+	if strings.Contains(output, `"type":"tool_use"`) {
+		t.Fatalf("repeated tool_use reached Claude output: %s", output)
+	}
+	if !strings.Contains(output, helps.XAIClaudeRepeatedToolMessage) {
+		t.Fatalf("blocked-repeat message missing: %s", output)
+	}
+}

--- a/internal/runtime/executor/xai_executor_execute.go
+++ b/internal/runtime/executor/xai_executor_execute.go
@@ -83,6 +83,7 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 
 	outputItemsByIndex := make(map[int64][]byte)
 	var outputItemsFallback [][]byte
+	repeatGuard := helps.NewXAIClaudeToolRepeatGuard(prepared.originalPayload, prepared.body, prepared.from)
 	responseFilter := newXAIInternalXSearchResponseFilter(prepared.filterInternalXSearch, prepared.clientDeclaredTools)
 	for _, line := range bytes.Split(data, []byte("\n")) {
 		if !bytes.HasPrefix(line, xaiDataTag) {
@@ -103,6 +104,7 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 			}
 			completedData := xaiPatchCompletedOutput(eventData, outputItemsByIndex, outputItemsFallback)
 			completedData = xaiNormalizeReasoningSummaryData(completedData)
+			completedData, _ = repeatGuard.PatchCompleted(completedData)
 			cacheXAIReasoningReplayFromCompleted(ctx, prepared.replayScope, completedData)
 			var param any
 			out := sdktranslator.TranslateNonStream(ctx, prepared.to, prepared.responseFormat, req.Model, prepared.originalPayload, prepared.body, completedData, &param)

--- a/internal/runtime/executor/xai_executor_execute.go
+++ b/internal/runtime/executor/xai_executor_execute.go
@@ -105,6 +105,9 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 			completedData := xaiPatchCompletedOutput(eventData, outputItemsByIndex, outputItemsFallback)
 			completedData = xaiNormalizeReasoningSummaryData(completedData)
 			completedData, _ = repeatGuard.PatchCompleted(completedData)
+			if xaiCompletedHasReasoningOnly(completedData) {
+				return resp, statusErr{code: http.StatusBadGateway, msg: "xai upstream completed with reasoning only and no final answer"}
+			}
 			cacheXAIReasoningReplayFromCompleted(ctx, prepared.replayScope, completedData)
 			var param any
 			out := sdktranslator.TranslateNonStream(ctx, prepared.to, prepared.responseFormat, req.Model, prepared.originalPayload, prepared.body, completedData, &param)

--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -103,6 +103,7 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	if e.cfg != nil && e.cfg.XAI.InjectXSearch {
 		body = ensureXAINativeXSearchTool(body)
 	}
+	body = helps.AnnotateXAIClaudeToolResults(body, req.Payload, from)
 	var replayScope xaiReasoningReplayScope
 	body, replayScope, err = applyXAIReasoningReplayCacheRequired(ctx, from, req, opts, body)
 	if err != nil {

--- a/internal/runtime/executor/xai_executor_response.go
+++ b/internal/runtime/executor/xai_executor_response.go
@@ -701,6 +701,25 @@ func xaiNormalizeReasoningSummaryData(eventData []byte) []byte {
 	return normalized
 }
 
+func xaiCompletedHasReasoningOnly(eventData []byte) bool {
+	if gjson.GetBytes(eventData, "type").String() != "response.completed" {
+		return false
+	}
+	output := gjson.GetBytes(eventData, "response.output")
+	if !output.IsArray() {
+		return false
+	}
+	hasReasoning := false
+	for _, item := range output.Array() {
+		if strings.TrimSpace(item.Get("type").String()) == "reasoning" {
+			hasReasoning = true
+			continue
+		}
+		return false
+	}
+	return hasReasoning
+}
+
 func xaiNormalizeReasoningSummaryDataEvents(eventData []byte) [][]byte {
 	if len(eventData) == 0 || !gjson.ValidBytes(eventData) {
 		return [][]byte{eventData}

--- a/internal/runtime/executor/xai_executor_stream.go
+++ b/internal/runtime/executor/xai_executor_stream.go
@@ -136,6 +136,15 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 						eventData = xaiPatchCompletedOutput(eventData, outputItemsByIndex, outputItemsFallback)
 						eventData = xaiNormalizeReasoningSummaryData(eventData)
 						eventData, blockedDuplicate = repeatGuard.PatchCompleted(eventData)
+						if xaiCompletedHasReasoningOnly(eventData) {
+							errReasoningOnly := statusErr{code: http.StatusBadGateway, msg: "xai upstream completed with reasoning only and no final answer"}
+							reporter.PublishFailure(ctx, errReasoningOnly)
+							select {
+							case out <- cliproxyexecutor.StreamChunk{Err: errReasoningOnly}:
+							case <-ctx.Done():
+							}
+							return
+						}
 						cacheXAIReasoningReplayFromCompleted(ctx, prepared.replayScope, eventData)
 						normalizedEventName = gjson.GetBytes(eventData, "type").String()
 					}

--- a/internal/runtime/executor/xai_executor_stream.go
+++ b/internal/runtime/executor/xai_executor_stream.go
@@ -81,6 +81,13 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 		outputItemsByIndex := make(map[int64][]byte)
 		var outputItemsFallback [][]byte
 		responseFilter := newXAIInternalXSearchResponseFilter(prepared.filterInternalXSearch, prepared.clientDeclaredTools)
+		repeatGuard := helps.NewXAIClaudeToolRepeatGuard(prepared.originalPayload, prepared.body, prepared.from)
+		type bufferedXAIEvent struct {
+			name string
+			data []byte
+		}
+		var guardedEvents []bufferedXAIEvent
+		guardActive := repeatGuard != nil
 		var pendingEventLine []byte
 		emitTranslatedLine := func(translatedLine []byte) bool {
 			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, prepared.to, prepared.responseFormat, req.Model, prepared.originalPayload, prepared.body, translatedLine, &param, claudeInputTokens)
@@ -118,6 +125,7 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 						continue
 					}
 					normalizedEventName := gjson.GetBytes(eventData, "type").String()
+					blockedDuplicate := false
 					switch normalizedEventName {
 					case "response.output_item.done":
 						xaiCollectOutputItemDone(eventData, outputItemsByIndex, &outputItemsFallback)
@@ -127,8 +135,42 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 						}
 						eventData = xaiPatchCompletedOutput(eventData, outputItemsByIndex, outputItemsFallback)
 						eventData = xaiNormalizeReasoningSummaryData(eventData)
+						eventData, blockedDuplicate = repeatGuard.PatchCompleted(eventData)
 						cacheXAIReasoningReplayFromCompleted(ctx, prepared.replayScope, eventData)
 						normalizedEventName = gjson.GetBytes(eventData, "type").String()
+					}
+
+					if guardActive {
+						guardedEvents = append(guardedEvents, bufferedXAIEvent{name: normalizedEventName, data: bytes.Clone(eventData)})
+						if normalizedEventName != "response.completed" {
+							continue
+						}
+						if blockedDuplicate {
+							filtered := guardedEvents[:0]
+							for _, buffered := range guardedEvents {
+								if buffered.name == "response.output_item.added" || buffered.name == "response.output_item.done" {
+									if repeatGuard.IsDuplicateItem(gjson.GetBytes(buffered.data, "item")) {
+										continue
+									}
+								}
+								if (buffered.name == "response.function_call_arguments.delta" || buffered.name == "response.function_call_arguments.done") && repeatGuard.IsBlockedCallEvent(gjson.ParseBytes(buffered.data)) {
+									continue
+								}
+								if buffered.name == "response.completed" {
+									filtered = append(filtered, bufferedXAIEvent{name: "response.output_item.done", data: helps.XAIClaudeRepeatedToolOutputEvent()})
+								}
+								filtered = append(filtered, buffered)
+							}
+							guardedEvents = filtered
+						}
+						for _, buffered := range guardedEvents {
+							if !emitTranslatedLine([]byte("event: "+buffered.name)) || !emitTranslatedLine(append([]byte("data: "), buffered.data...)) {
+								return
+							}
+						}
+						guardedEvents = nil
+						pendingEventLine = nil
+						continue
 					}
 
 					if hasPendingEventLine {

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -2523,8 +2523,9 @@ func TestXAIExecutorExecuteStreamNormalizesReasoningTextEvents(t *testing.T) {
 		_, _ = w.Write([]byte("data: {\"type\":\"response.reasoning_text.done\",\"sequence_number\":4,\"item_id\":\"rs_1\",\"output_index\":0,\"content_index\":0,\"text\":\"thinking\"}\n\n"))
 		_, _ = w.Write([]byte("event: response.output_item.done\n"))
 		_, _ = w.Write([]byte("data: {\"type\":\"response.output_item.done\",\"sequence_number\":5,\"output_index\":0,\"item\":{\"id\":\"rs_1\",\"type\":\"reasoning\",\"status\":\"completed\",\"summary\":[],\"content\":[{\"type\":\"reasoning_text\",\"text\":\"thinking\"}]}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_item.done\",\"sequence_number\":6,\"output_index\":1,\"item\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":\"answer\"}]}}\n\n"))
 		_, _ = w.Write([]byte("event: response.completed\n"))
-		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"sequence_number\":6,\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":0,\"status\":\"completed\",\"model\":\"grok-4.3\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"sequence_number\":7,\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":0,\"status\":\"completed\",\"model\":\"grok-4.3\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n"))
 	}))
 	defer server.Close()
 
@@ -2586,7 +2587,8 @@ func TestXAIExecutorExecuteNormalizesReasoningOutputForNonStreamTranslation(t *t
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte("data: {\"type\":\"response.output_item.done\",\"sequence_number\":1,\"output_index\":0,\"item\":{\"id\":\"rs_1\",\"type\":\"reasoning\",\"status\":\"completed\",\"summary\":[],\"content\":[{\"type\":\"reasoning_text\",\"text\":\"thinking\"}]}}\n\n"))
-		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"sequence_number\":2,\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":0,\"status\":\"completed\",\"model\":\"grok-4.3\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_item.done\",\"sequence_number\":2,\"output_index\":1,\"item\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":\"answer\"}]}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"sequence_number\":3,\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":0,\"status\":\"completed\",\"model\":\"grok-4.3\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n"))
 	}))
 	defer server.Close()
 
@@ -2620,6 +2622,54 @@ func TestXAIExecutorExecuteNormalizesReasoningOutputForNonStreamTranslation(t *t
 	}
 	if gjson.GetBytes(resp.Payload, "response.output.0.content").Exists() {
 		t.Fatalf("reasoning output content exists, want summary only: %s", string(resp.Payload))
+	}
+}
+
+func TestXAIExecutorRejectsReasoningOnlyCompletion(t *testing.T) {
+	t.Parallel()
+
+	for _, stream := range []bool{false, true} {
+		stream := stream
+		t.Run(fmt.Sprintf("stream_%t", stream), func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte("data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_1\",\"type\":\"reasoning\",\"status\":\"completed\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"stuck summary\"}]}}\n\n"))
+				_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"model\":\"grok-4.5\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":2,\"total_tokens\":3}}}\n\n"))
+			}))
+			defer server.Close()
+
+			exec := NewXAIExecutor(&config.Config{})
+			auth := &cliproxyauth.Auth{
+				Provider:   "xai",
+				Attributes: map[string]string{"base_url": server.URL},
+				Metadata:   map[string]any{"access_token": "xai-token"},
+			}
+			req := cliproxyexecutor.Request{Model: "grok-4.5", Payload: []byte(`{"model":"grok-4.5","input":"hello"}`)}
+			opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, ResponseFormat: sdktranslator.FormatCodex, Stream: stream}
+
+			if !stream {
+				_, err := exec.Execute(context.Background(), auth, req, opts)
+				if err == nil || !strings.Contains(err.Error(), "reasoning only") {
+					t.Fatalf("Execute() error = %v, want reasoning-only error", err)
+				}
+				return
+			}
+
+			result, err := exec.ExecuteStream(context.Background(), auth, req, opts)
+			if err != nil {
+				t.Fatalf("ExecuteStream() setup error = %v", err)
+			}
+			var streamErr error
+			for chunk := range result.Chunks {
+				if chunk.Err != nil {
+					streamErr = chunk.Err
+				}
+			}
+			if streamErr == nil || !strings.Contains(streamErr.Error(), "reasoning only") {
+				t.Fatalf("stream error = %v, want reasoning-only error", streamErr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve Anthropic `tool_result.is_error` semantics when Claude Messages requests are translated to the xAI Responses API
- derive completed tool-call fingerprints from the original Anthropic history, retaining `tool_use_id` / `call_id` correlation even when later request normalization removes the historical function call
- prevent a new-call-ID replay of the same tool name and canonical JSON arguments after that call has already completed
- cover both non-streaming and streaming execution paths; guarded streaming responses are buffered until `response.completed` so a duplicate call is never exposed to the client before it can be rejected

## Problem

The Responses `function_call_output` item has no native equivalent of Anthropic's `tool_result.is_error`. The existing translation therefore preserved the output and call ID, but discarded success/failure semantics. Some xAI models can then emit the same function call again with a new call ID and unchanged arguments after receiving the result. Since that response is validly translated back into an Anthropic `tool_use`, Claude Code executes it again and can enter a loop.

## Implementation

- annotate xAI-only function outputs with stable success/error guidance while preserving the original output type and content
- build canonical SHA-256 fingerprints from completed `tool_use` + `tool_result` pairs
- remove only exact repeats (`same name + same canonical arguments`) from the completed xAI response
- allow calls whose arguments changed
- replace a blocked repeat with a final explanatory text output rather than returning another executable tool call
- keep the compatibility logic isolated in `internal/runtime/executor/helps/xai_claude_tool_result.go`

## Tests

Validated with Go 1.26.5:

```text
go test ./internal/runtime/executor -run 'XAI.*Claude.*Tool|XAI.*ToolResult|XAI.*Repeat|AnnotateXAI' -count=1
ok github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor

go build -o /tmp/cli-proxy-api-test ./cmd/server
passed
```

Regression coverage includes:

- successful and failed Anthropic `tool_result`
- text and multimodal tool output preservation
- `tool_use_id` / `call_id` correlation
- original Anthropic history when normalized Responses input no longer contains the prior function call
- exact repeated calls blocked
- changed arguments allowed
- streaming and non-streaming executor paths

## Scope

This is limited to Claude-format requests executed through the xAI Responses adapter. OpenAI, Codex, and non-Claude xAI request formats are unchanged.
## Reasoning-only completion guard

A production trace exposed a second xAI failure mode that affects both OpenAI Responses clients and Claude Messages clients: xAI can emit a completed response containing only a reasoning summary, with no final message or actionable tool call. Agent clients treat that as an unfinished turn and can automatically submit the growing history again, producing a tight loop.

This PR now rejects reasoning-only `response.completed` payloads before they are cached or translated:

- non-streaming requests return an explicit upstream error
- streaming requests emit a terminal error chunk
- valid responses containing text, function/tool calls, or other non-reasoning output are unchanged
- regression tests cover streaming, non-streaming, normal reasoning-plus-message responses, and the existing Claude tool-repeat guard