### PR TITLE
test(util): skip build caches in source walker

### DIFF
--- a/internal/util/nocopy_invariant_test.go
+++ b/internal/util/nocopy_invariant_test.go
@@ -18,6 +18,15 @@ var inPlaceSJSONTokens = []string{"ReplaceInPlace", "Optimistic"}
 // from the same buffer can still be alive at that point.
 var inPlaceSJSONAllowlist = map[string]struct{}{}
 
+// skippedWalkDirs are directories the source walker never descends into. The
+// build and tool dirs are excluded because they hold cloned third-party or
+// generated Go sources (build output, caches, temporary GOPATH/module trees)
+// that must not be treated as product code governed by these invariants.
+var skippedWalkDirs = map[string]struct{}{
+	".git": {}, "vendor": {}, "node_modules": {}, "testdata": {},
+	".tmp_build": {}, ".go-cache": {}, ".go-tmp": {}, ".gocache": {},
+}
+
 // forEachSourceFile visits every non-test Go file in the repository.
 func forEachSourceFile(t *testing.T, root string, visit func(rel string, data []byte)) {
 	t.Helper()
@@ -26,8 +35,7 @@ func forEachSourceFile(t *testing.T, root string, visit func(rel string, data []
 			return err
 		}
 		if d.IsDir() {
-			switch d.Name() {
-			case ".git", "vendor", "node_modules", "testdata":
+			if _, skip := skippedWalkDirs[d.Name()]; skip {
 				return filepath.SkipDir
 			}
 			return nil
@@ -49,6 +57,63 @@ func forEachSourceFile(t *testing.T, root string, visit func(rel string, data []
 	if err != nil {
 		t.Fatalf("walk repository: %v", err)
 	}
+}
+
+// TestForEachSourceFileSkipsKnownDirs is the regression for the walker's skip
+// list: it must skip exactly the build/cache/dependency basenames and still
+// descend into an unrelated dot-directory such as .hidden-source.
+func TestForEachSourceFileSkipsKnownDirs(t *testing.T) {
+	root := t.TempDir()
+	kept := "prod.go"
+	skipped := []string{
+		".git", "vendor", "node_modules", "testdata",
+		".tmp_build", ".go-cache", ".go-tmp", ".gocache",
+	}
+	for _, name := range skipped {
+		dir := filepath.Join(root, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte("package x\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	hiddenDir := filepath.Join(root, ".hidden-source")
+	if err := os.MkdirAll(hiddenDir, 0o755); err != nil {
+		t.Fatalf("mkdir .hidden-source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hiddenDir, kept), []byte("package x\n"), 0o644); err != nil {
+		t.Fatalf("write .hidden-source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "top.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatalf("write top.go: %v", err)
+	}
+
+	var visited []string
+	forEachSourceFile(t, root, func(rel string, _ []byte) {
+		visited = append(visited, rel)
+	})
+
+	for _, name := range skipped {
+		if containsString(visited, name+"/a.go") {
+			t.Errorf("walker descended into skipped dir %q", name)
+		}
+	}
+	if !containsString(visited, ".hidden-source/"+kept) {
+		t.Errorf("walker did not scan dot-dir .hidden-source (visited %v)", visited)
+	}
+	if !containsString(visited, "top.go") {
+		t.Errorf("walker did not scan top-level file top.go (visited %v)", visited)
+	}
+}
+
+func containsString(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
 }
 
 // TestNoInPlaceSJSONWrites protects the invariant that request payload buffers


### PR DESCRIPTION
## Summary

Update `forEachSourceFile` directory skipper to exclude build output and temporary cache directories while continuing to scan legitimate source dot-directories, keeping no-copy invariant checks isolated to product code.

## Problem

1. **Source walker descending into build and tool caches**:
   `forEachSourceFile` previously skipped only `.git`, `vendor`, `node_modules`, and `testdata`. When local worktrees or CI runs created temporary build directories or Go module caches (`.tmp_build`, `.go-cache`, `.go-tmp`, `.gocache`), the walker traversed cloned third-party or generated Go code and evaluated no-copy invariant rules against non-product files.

## Fix

1. **Directory skip map (`internal/util/nocopy_invariant_test.go:24-39`)**:
   - Replaced switch statement with `skippedWalkDirs` map.
   - Added `.tmp_build`, `.go-cache`, `.go-tmp`, and `.gocache` to skipped directory set alongside `.git`, `vendor`, `node_modules`, and `testdata`.
2. **Preserved invariants**:
   - Unrelated dot-directories containing product sources (e.g. `.hidden-source`) and top-level files continue to be scanned.
3. **Unit tests (`internal/util/nocopy_invariant_test.go:62-114`)**:
   - `TestForEachSourceFileSkipsKnownDirs`: creates temporary directories for each of the 8 skipped directory names plus `.hidden-source` and top-level files, verifying that the walker skips all 8 build/cache/dependency directories while scanning `.hidden-source` and top-level sources.

## Testing

- `go test -count=1 ./internal/util` — exit code 0
- `go test -race -count=1 ./internal/util` — exit code 0
- `go vet ./internal/util/...` — exit code 0
- `go build ./...` — exit code 0
- `gofmt -l internal/util/nocopy_invariant_test.go` — clean

## Mirror

- CPAPlus companion: [kaitranntt/CLIProxyAPIPlus#178](https://github.com/kaitranntt/CLIProxyAPIPlus/pull/178)
