### PR TITLE
test(openai): set Gin mode once per package

### DIFF
--- a/sdk/api/handlers/openai/gin_testmode_test.go
+++ b/sdk/api/handlers/openai/gin_testmode_test.go
@@ -1,0 +1,18 @@
+package openai
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestMain sets gin.TestMode once before any test runs. The per-test
+// gin.SetMode(gin.TestMode) calls were removed because they race: parallel
+// tests write the package-global gin mode while other parallel tests read it
+// through gin.New/CreateTestContext. Setting it once up front removes the
+// concurrent write.
+func TestMain(m *testing.M) {
+	gin.SetMode(gin.TestMode)
+	os.Exit(m.Run())
+}

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -25,7 +25,6 @@ import (
 func performImagesEndpointRequest(t *testing.T, endpointPath string, contentType string, body io.Reader, handler gin.HandlerFunc) *httptest.ResponseRecorder {
 	t.Helper()
 
-	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	router.POST(endpointPath, handler)
 
@@ -370,7 +369,6 @@ func TestSSEFrameAccumulatorFlushesDataOnlyFrame(t *testing.T) {
 }
 
 func TestWriteImagesStreamErrorEventSanitizesPayload(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
 	raw := `{"error":{"code":"upstream_failed","message":"token=image-secret"},"debug":"` + strings.Repeat("x", 8192) + `"}`
@@ -400,7 +398,6 @@ func TestCollectImagesRejectsPayloadErrorBeforeCompleted(t *testing.T) {
 }
 
 func TestForwardImagesStreamCancelsWithPayloadError(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	h := NewOpenAIAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil))
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
@@ -426,7 +423,6 @@ func TestForwardImagesStreamCancelsWithPayloadError(t *testing.T) {
 }
 
 func TestForwardRawImageStreamPrefersPendingErrorOnClose(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	h := NewOpenAIAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil))
 	for i := 0; i < 100; i++ {
 		recorder := httptest.NewRecorder()

--- a/sdk/api/handlers/openai/openai_responses_compact_test.go
+++ b/sdk/api/handlers/openai/openai_responses_compact_test.go
@@ -50,7 +50,6 @@ func (e *compactCaptureExecutor) HttpRequest(context.Context, *coreauth.Auth, *h
 }
 
 func TestOpenAIResponsesCompactRejectsStream(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	executor := &compactCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
@@ -83,7 +82,6 @@ func TestOpenAIResponsesCompactRejectsStream(t *testing.T) {
 }
 
 func TestOpenAIResponsesCompactExecute(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	executor := &compactCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
@@ -122,7 +120,6 @@ func TestOpenAIResponsesCompactExecute(t *testing.T) {
 }
 
 func TestOpenAIResponsesCompactDecodesZstdRequestBody(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	executor := &compactCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_error_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_error_test.go
@@ -107,7 +107,6 @@ func (*prematureResponsesStreamExecutor) HttpRequest(context.Context, *coreauth.
 }
 
 func TestResponsesHandlerEmitsFailureWhenExecutorStopsAfterPartialOutput(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &prematureResponsesStreamExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -152,7 +151,6 @@ func TestSanitizeResponsesStreamErrorMessageNormalizesSuccessStatus(t *testing.T
 }
 
 func TestResponsesHandlerCommitsValidFrameBeforeMalformedFrameInSameChunk(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &prematureResponsesStreamExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -182,7 +180,6 @@ func TestResponsesHandlerCommitsValidFrameBeforeMalformedFrameInSameChunk(t *tes
 }
 
 func TestResponsesHandlerAcceptsMultilineDataAcrossExecutorChunks(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &prematureResponsesStreamExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -211,7 +208,6 @@ func TestResponsesHandlerAcceptsMultilineDataAcrossExecutorChunks(t *testing.T) 
 }
 
 func TestResponsesHandlerPreservesDirectResponseBeforeFirstFrame(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &prematureResponsesStreamExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -243,7 +239,6 @@ func TestResponsesHandlerPreservesDirectResponseBeforeFirstFrame(t *testing.T) {
 }
 
 func TestResponsesHandlerSanitizesErrorBeforeFirstFrame(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &prematureResponsesStreamExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -282,7 +277,6 @@ func TestResponsesHandlerSanitizesErrorBeforeFirstFrame(t *testing.T) {
 }
 
 func TestResponsesHandlerFlushesDataOnlyFrameBeforeStreamingError(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &prematureResponsesStreamExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -317,7 +311,6 @@ func TestResponsesHandlerFlushesDataOnlyFrameBeforeStreamingError(t *testing.T) 
 }
 
 func TestResponsesHandlerEmitsFailureWhenDataOnlyStreamClosesCleanly(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &prematureResponsesStreamExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -355,7 +348,6 @@ func TestResponsesHandlerEmitsFailureWhenDataOnlyStreamClosesCleanly(t *testing.
 }
 
 func TestResponsesHandlerDoesNotCommitHeadersForIncompleteFirstFrame(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &prematureResponsesStreamExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -388,7 +380,6 @@ func TestResponsesHandlerDoesNotCommitHeadersForIncompleteFirstFrame(t *testing.
 }
 
 func TestResponsesHandlerRejectsStreamClosedBeforeFirstPayload(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &prematureResponsesStreamExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -421,7 +412,6 @@ func TestResponsesHandlerRejectsStreamClosedBeforeFirstPayload(t *testing.T) {
 }
 
 func TestResponsesHandlerDoesNotLoseErrorBeforeFirstPayload(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	for i := 0; i < 100; i++ {
 		executor := &prematureResponsesStreamExecutor{}
@@ -456,7 +446,6 @@ func TestResponsesHandlerDoesNotLoseErrorBeforeFirstPayload(t *testing.T) {
 // TestForwardResponsesStreamExposesTerminalErrors pins the SSE side: once a
 // Responses stream has started, every terminal upstream error reaches the client.
 func TestForwardResponsesStreamExposesTerminalErrors(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
 		name        string
@@ -529,7 +518,6 @@ func TestForwardResponsesStreamExposesTerminalErrors(t *testing.T) {
 }
 
 func TestForwardResponsesStreamUsesResponseFailedForCodex(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
 	h := NewOpenAIResponsesAPIHandler(base)
@@ -566,7 +554,6 @@ func TestForwardResponsesStreamUsesResponseFailedForCodex(t *testing.T) {
 }
 
 func TestForwardResponsesStreamExposesTransportErrorAfterOutputForCodex(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, nil)
 	h := NewOpenAIResponsesAPIHandler(base)
@@ -612,7 +599,6 @@ func TestForwardResponsesStreamExposesTransportErrorAfterOutputForCodex(t *testi
 }
 
 func TestForwardResponsesStreamSanitizesDiagnosticErrorDetails(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, nil)
 	h := NewOpenAIResponsesAPIHandler(base)
@@ -663,7 +649,6 @@ func TestForwardResponsesStreamSanitizesDiagnosticErrorDetails(t *testing.T) {
 }
 
 func TestForwardResponsesStreamPreservesNestedResponseError(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, nil)
 	h := NewOpenAIResponsesAPIHandler(base)
@@ -694,7 +679,6 @@ func TestForwardResponsesStreamPreservesNestedResponseError(t *testing.T) {
 }
 
 func TestForwardResponsesStreamSanitizesLastEventDiagnostic(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, nil)
 	h := NewOpenAIResponsesAPIHandler(base)
@@ -751,7 +735,6 @@ func TestForwardResponsesStreamSanitizesPayloadErrorsAndStopsAtFailure(t *testin
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			gin.SetMode(gin.TestMode)
 			base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, nil)
 			h := NewOpenAIResponsesAPIHandler(base)
 			recorder := httptest.NewRecorder()
@@ -786,7 +769,6 @@ func TestForwardResponsesStreamSanitizesPayloadErrorsAndStopsAtFailure(t *testin
 }
 
 func TestForwardResponsesStreamReportsDataOnlyErrorFlushedAtEOF(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, nil)
 	h := NewOpenAIResponsesAPIHandler(base)
 	recorder := httptest.NewRecorder()
@@ -818,7 +800,6 @@ func TestForwardResponsesStreamReportsDataOnlyErrorFlushedAtEOF(t *testing.T) {
 }
 
 func TestForwardResponsesStreamDoesNotAppendFailureAfterTerminalEvent(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, nil)
 	h := NewOpenAIResponsesAPIHandler(base)
@@ -861,7 +842,6 @@ func TestForwardResponsesStreamDoesNotAppendFailureAfterTerminalEvent(t *testing
 }
 
 func TestForwardResponsesStreamFailsWhenUpstreamClosesWithoutTerminalEvent(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
 	h := NewOpenAIResponsesAPIHandler(base)

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -17,7 +17,6 @@ import (
 func newResponsesStreamTestHandler(t *testing.T) (*OpenAIResponsesAPIHandler, *httptest.ResponseRecorder, *gin.Context, http.Flusher) {
 	t.Helper()
 
-	gin.SetMode(gin.TestMode)
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
 	h := NewOpenAIResponsesAPIHandler(base)
 

--- a/sdk/api/handlers/openai/openai_responses_multi_agent_test.go
+++ b/sdk/api/handlers/openai/openai_responses_multi_agent_test.go
@@ -23,7 +23,6 @@ import (
 func TestPrepareCodexMultiAgentV2ToolsAtResponsesBoundary(t *testing.T) {
 	t.Parallel()
 
-	gin.SetMode(gin.TestMode)
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{CodexOptimizeMultiAgentV2: true}, nil)
 	handler := NewOpenAIResponsesAPIHandler(base)
 	request := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
@@ -129,7 +128,6 @@ func newResponsesMultiAgentTestHandler(t *testing.T, executor *responsesMultiAge
 }
 
 func TestResponsesWebsocketPreparesCodexMultiAgentV2Tools(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	executor := &websocketDirectCaptureExecutor{provider: "codex"}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
@@ -181,7 +179,6 @@ func TestResponsesWebsocketPreparesCodexMultiAgentV2Tools(t *testing.T) {
 func TestPrepareCodexMultiAgentV2ToolsAtResponsesBoundarySkipsOtherClients(t *testing.T) {
 	t.Parallel()
 
-	gin.SetMode(gin.TestMode)
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{CodexOptimizeMultiAgentV2: true}, nil)
 	handler := NewOpenAIResponsesAPIHandler(base)
 	request := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)

--- a/sdk/api/handlers/openai/openai_responses_signature_test.go
+++ b/sdk/api/handlers/openai/openai_responses_signature_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestOpenAIResponsesForwardsInvalidReasoningEncryptedContentToExecutor(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	executor := &compactCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
@@ -49,7 +48,6 @@ func TestOpenAIResponsesForwardsInvalidReasoningEncryptedContentToExecutor(t *te
 }
 
 func TestOpenAIResponsesCompactForwardsInvalidReasoningEncryptedContentToExecutor(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	executor := &compactCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -92,7 +92,6 @@ func (*homeResponsesWebsocketExecutor) HttpRequest(context.Context, *coreauth.Au
 }
 
 func TestResponsesWebsocketHomeSelectedAuthCallbackPinsAndReusesFirstSelection(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	dispatcher := &homeResponsesWebsocketDispatcher{}
 	executor := &homeResponsesWebsocketExecutor{}
@@ -457,7 +456,6 @@ func TestTruncateWebsocketCloseReason(t *testing.T) {
 }
 
 func TestForwardResponsesWebsocketMirrorsMappedMessageTooBig(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	serverErrCh := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -526,7 +524,6 @@ func TestForwardResponsesWebsocketMirrorsMappedMessageTooBig(t *testing.T) {
 }
 
 func TestForwardResponsesWebsocketMirrorsPayloadMessageTooBig(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	serverErrCh := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1979,7 +1976,6 @@ func TestAppendWebsocketTimelineEvent(t *testing.T) {
 }
 
 func TestSetWebsocketTimelineBody(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
 
@@ -2003,7 +1999,6 @@ func TestSetWebsocketTimelineBody(t *testing.T) {
 }
 
 func TestWebsocketTimelineLogFallsBackToMemoryWithoutSource(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
 	ts := time.Date(2026, time.April, 1, 12, 34, 56, 789000000, time.UTC)
@@ -2431,7 +2426,6 @@ func TestRecordResponsesWebsocketCustomToolCallsFromOutputItemDoneWithCache(t *t
 }
 
 func TestForwardResponsesWebsocketRestoresAndForwardsCompletedOutput(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	serverErrCh := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2535,7 +2529,6 @@ func TestForwardResponsesWebsocketRestoresAndForwardsCompletedOutput(t *testing.
 }
 
 func TestForwardResponsesWebsocketTreatsResponseDoneAsTerminalWithoutRewriting(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	serverErrCh := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2705,7 +2698,6 @@ func TestResponsesUpstreamErrorBodyDrivesExposure(t *testing.T) {
 }
 
 func TestForwardResponsesWebsocketTreatsErrorPayloadAsTerminal(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	serverErrCh := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2791,7 +2783,6 @@ func TestRecordPendingToolCallIDsFromPayloadDropsSatisfiedCalls(t *testing.T) {
 }
 
 func TestForwardResponsesWebsocketLogsAttemptedResponseOnWriteFailure(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	serverErrCh := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2856,7 +2847,6 @@ func TestForwardResponsesWebsocketLogsAttemptedResponseOnWriteFailure(t *testing
 }
 
 func TestResponsesWebsocketTimelineRecordsDisconnectEvent(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	manager := coreauth.NewManager(nil, nil, nil)
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, manager)
@@ -2919,7 +2909,6 @@ func TestResponsesWebsocketTimelineRecordsDisconnectEvent(t *testing.T) {
 }
 
 func TestResponsesWebsocketMirrorsUpstreamMessageTooBigDisconnect(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	for _, provider := range []string{"codex", "xai"} {
 		t.Run(provider, func(t *testing.T) {
@@ -2970,7 +2959,6 @@ func TestResponsesWebsocketMirrorsUpstreamMessageTooBigDisconnect(t *testing.T) 
 }
 
 func TestResponsesWebsocketSendsJSONErrorOnUpstreamCyberPolicyDisconnect(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &websocketUpstreamDisconnectExecutor{provider: "codex", subscribed: make(chan string, 1)}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -3030,7 +3018,6 @@ func TestResponsesWebsocketSendsJSONErrorOnUpstreamCyberPolicyDisconnect(t *test
 }
 
 func TestResponsesWebsocketHidesNonClientUpstreamDisconnectErrors(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
 		name string
@@ -3113,7 +3100,6 @@ func TestResponsesWebsocketHidesNonClientUpstreamDisconnectErrors(t *testing.T) 
 // with status 400 on the stream path and 502 through the disconnect channel. Both
 // must reach the client, because no credential rotation can satisfy the request.
 func TestResponsesWebsocketExposesCyberPolicyRegardlessOfStatus(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	const cyberPolicyBody = `{"error":{"type":"invalid_request","code":"cyber_policy","message":"This content was flagged for possible cybersecurity risk.","param":null}}`
 
@@ -3239,7 +3225,6 @@ func TestResponsesWebsocketTerminalErrorWrittenOnceAcrossForwardAndDisconnect(t 
 }
 
 func TestResponsesWebsocketCodexWebsocketPassthroughPassesCompactedRequestWithoutTranscriptMerge(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &websocketDirectCaptureExecutor{done: make(chan struct{})}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -3318,7 +3303,6 @@ func TestResponsesWebsocketCodexWebsocketPassthroughPassesCompactedRequestWithou
 }
 
 func TestResponsesWebsocketXAIWebsocketPassthroughKeepsNativeIncrementalRequest(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	modelName := "xai-websocket-passthrough-model"
 	executor := &websocketDirectCaptureExecutor{provider: "xai", done: make(chan struct{})}
@@ -3403,7 +3387,6 @@ func TestResponsesWebsocketXAIWebsocketPassthroughKeepsNativeIncrementalRequest(
 }
 
 func TestResponsesWebsocketFullRequestCanRouteFromNativeWebsocketToBuiltInProvider(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	const sourceModel = "codex-provider-route-source"
 	const targetModel = "claude-provider-route-target"
@@ -3482,7 +3465,6 @@ func TestResponsesWebsocketFullRequestCanRouteFromNativeWebsocketToBuiltInProvid
 }
 
 func TestResponsesWebsocketHidesProviderRouteAuthFailure(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	const sourceModel = "codex-provider-route-failure-source"
 	const targetModel = "claude-provider-route-target"
@@ -3549,7 +3531,6 @@ func TestResponsesWebsocketHidesProviderRouteAuthFailure(t *testing.T) {
 }
 
 func TestResponsesWebsocketDeltaRouteToBuiltInProviderRequiresFullReplay(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	const sourceModel = "codex-provider-route-delta-source"
 	const targetModel = "claude-provider-route-target"
@@ -3616,7 +3597,6 @@ func TestResponsesWebsocketDeltaRouteToBuiltInProviderRequiresFullReplay(t *test
 }
 
 func TestResponsesWebsocketClosesForHTTPReplayWhenWebsocketEligibilityChanges(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	modelName := "xai-websocket-mode-change-model"
 	executor := &websocketDirectCaptureExecutor{provider: "xai", done: make(chan struct{})}
@@ -3742,7 +3722,6 @@ func TestResponsesWebsocketClosesForHTTPReplayWhenWebsocketEligibilityChanges(t 
 }
 
 func TestResponsesWebsocketRejectsUnknownPreviousResponseOnNewSocket(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	modelName := "xai-websocket-reconnect-model"
 	executor := &websocketDirectCaptureExecutor{provider: "xai"}
@@ -3819,7 +3798,6 @@ func TestResponsesWebsocketRejectsUnknownPreviousResponseOnNewSocket(t *testing.
 }
 
 func TestResponsesWebsocketClosesAfterNonRetryableClientError(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	modelName := "xai-websocket-rollback-model"
 	executor := &websocketCanonicalRollbackExecutor{}
@@ -3896,7 +3874,6 @@ const itemNotPersistedUpstreamMessage = "Item with id 'rs_0b5f3eb6f51f175c0169ca
 // conversation must survive: after reconnecting with the full input the turn
 // succeeds, and no stale per-socket transcript leaks into the new connection.
 func TestResponsesWebsocketExposesItemNotPersistedAndRecoversOnReconnect(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	modelName := "xai-item-miss-model"
 	executor := &websocketCanonicalRollbackExecutor{
@@ -4009,7 +3986,6 @@ func TestResponsesWebsocketSwitchesPinnedAuthAcrossProviders(t *testing.T) {
 		{name: "xai websocket different model", xaiWebsockets: true, returnToDifferentXAIModel: true},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			gin.SetMode(gin.TestMode)
 
 			xaiModel := "xai-provider-switch-" + strings.ReplaceAll(testCase.name, " ", "-")
 			returnXAIModel := xaiModel
@@ -4291,7 +4267,6 @@ func TestWebsocketUpstreamSupportsCompactionReplayForModelFalseWhenMixedBackends
 }
 
 func TestResponsesWebsocketPrewarmHandledLocallyForSSEUpstream(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &websocketCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -4398,7 +4373,6 @@ func TestResponsesWebsocketPrewarmHandledLocallyForSSEUpstream(t *testing.T) {
 }
 
 func TestResponsesWebsocketMergesTranscriptForNonPassthroughUpstream(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &websocketCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -4470,7 +4444,6 @@ func TestResponsesWebsocketMergesTranscriptForNonPassthroughUpstream(t *testing.
 }
 
 func TestResponsesWebsocketDoesNotInjectPreviousResponseIDWhenPendingToolOutputMissing(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &websocketCompactionCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -4546,7 +4519,6 @@ func TestResponsesWebsocketDoesNotInjectPreviousResponseIDWhenPendingToolOutputM
 }
 
 func TestResponsesWebsocketStripsGenerateWhenWebsocketAttemptFallsBackToHTTP(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	selector := &orderedWebsocketSelector{order: []string{"auth-ws", "auth-http", "auth-http"}}
 	executor := &websocketBootstrapFallbackExecutor{}
@@ -4642,7 +4614,6 @@ func TestResponsesWebsocketStripsGenerateWhenWebsocketAttemptFallsBackToHTTP(t *
 }
 
 func TestWebsocketClientAddressUsesGinClientIP(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	recorder := httptest.NewRecorder()
 	c, engine := gin.CreateTestContext(recorder)
@@ -4667,7 +4638,6 @@ func TestWebsocketClientAddressReturnsEmptyForNilContext(t *testing.T) {
 }
 
 func TestResponsesWebsocketPinsOnlyWebsocketCapableAuth(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	selector := &orderedWebsocketSelector{order: []string{"auth-sse", "auth-ws"}}
 	executor := &websocketAuthCaptureExecutor{}
@@ -4737,7 +4707,6 @@ func TestResponsesWebsocketPinsOnlyWebsocketCapableAuth(t *testing.T) {
 }
 
 func TestResponsesWebsocketUsesNativeIncrementalAfterPinningWebsocketAuthFromMixedPool(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	modelName := "xai-mixed-pool-model"
 	selector := &orderedWebsocketSelector{order: []string{"auth-http", "auth-ws"}}
@@ -4812,7 +4781,6 @@ func TestResponsesWebsocketUsesNativeIncrementalAfterPinningWebsocketAuthFromMix
 }
 
 func TestResponsesWebsocketReplaysImmediatelyAfterPinnedAuthFailure(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
 		name            string
@@ -5039,7 +5007,6 @@ func (e *websocketPinnedPrematureCloseExecutor) Payloads(authID string) [][]byte
 }
 
 func TestResponsesWebsocketReleasesPinnedAuthAfterStreamClosed408(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	selector := &orderedWebsocketSelector{order: []string{"auth-a", "auth-b"}}
 	executor := &websocketPinnedPrematureCloseExecutor{}
@@ -5330,7 +5297,6 @@ func TestDedupeResponsesWebsocketInputItemsByIDKeepsReferencedToolCall(t *testin
 }
 
 func TestResponsesWebsocketCompactionResetsTurnStateOnCustomToolTranscriptReplacement(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &websocketCompactionCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -5434,7 +5400,6 @@ func TestResponsesWebsocketCompactionResetsTurnStateOnCustomToolTranscriptReplac
 }
 
 func TestResponsesWebsocketCompactionResetsTurnStateOnTranscriptReplacement(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &websocketCompactionCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)

--- a/sdk/api/handlers/openai/openai_videos_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_videos_handlers_test.go
@@ -23,7 +23,6 @@ import (
 func performVideosEndpointRequest(t *testing.T, method string, endpointPath string, contentType string, body io.Reader, handler gin.HandlerFunc) *httptest.ResponseRecorder {
 	t.Helper()
 
-	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	switch method {
 	case http.MethodGet:
@@ -44,7 +43,6 @@ func performVideosEndpointRequest(t *testing.T, method string, endpointPath stri
 func performVideosRouteRequest(t *testing.T, method string, routePath string, requestPath string, contentType string, body io.Reader, handler gin.HandlerFunc) *httptest.ResponseRecorder {
 	t.Helper()
 
-	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	switch method {
 	case http.MethodGet:
@@ -445,7 +443,6 @@ func TestWriteVideoContentFromURL(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	gin.SetMode(gin.TestMode)
 	resp := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(resp)
 	ctx.Request = httptest.NewRequest(http.MethodGet, "/openai/v1/videos/video_123/content", nil)
@@ -495,7 +492,6 @@ func TestWriteVideoContentFromURLUsesPinnedAuthProxy(t *testing.T) {
 	handler := NewOpenAIAPIHandler(base)
 	videoAuthBindings.set("video_123", authID, time.Hour)
 
-	gin.SetMode(gin.TestMode)
 	resp := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(resp)
 	ctx.Params = gin.Params{{Key: "video_id", Value: "video_123"}}
@@ -524,7 +520,6 @@ func TestWriteVideoContentFromURLFallsBackToGlobalProxy(t *testing.T) {
 	base := apihandlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{ProxyURL: "http://global-proxy.example.com:8080"}, nil)
 	handler := NewOpenAIAPIHandler(base)
 
-	gin.SetMode(gin.TestMode)
 	resp := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(resp)
 	ctx.Params = gin.Params{{Key: "video_id", Value: "video_456"}}
@@ -1005,7 +1000,6 @@ func TestVideosCreateFormRequest(t *testing.T) {
 }
 
 func videosCreateRequestFromFormContext(body string) ([]byte, error) {
-	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	var rawJSON []byte
 	var err error


### PR DESCRIPTION
## Summary

Eliminate data race in `sdk/api/handlers/openai` tests under `-race` by setting `gin.TestMode` once in `TestMain` instead of mutating package-global state inside individual parallel test cases.

## Problem

1. **Concurrent write and read of global Gin mode under `-race`**:
   Individual unit tests in `sdk/api/handlers/openai` repeatedly called `gin.SetMode(gin.TestMode)`. In parallel test executions (`t.Parallel()`), concurrent writes to Gin's package-global mode variable raced with reads inside `gin.New()` and `gin.CreateTestContext()`, triggering `-race` detector failures.

## Fix

1. **Package-level TestMain initialization (`sdk/api/handlers/openai/gin_testmode_test.go:1-18`)**:
   - Added `TestMain(m *testing.M)` to initialize `gin.SetMode(gin.TestMode)` exactly once at package startup.
2. **Removed per-test mutations across 8 test files**:
   - Removed 74 per-test `gin.SetMode(gin.TestMode)` invocations across:
     - `openai_images_handlers_test.go`
     - `openai_responses_compact_test.go`
     - `openai_responses_handlers_stream_error_test.go`
     - `openai_responses_handlers_stream_test.go`
     - `openai_responses_multi_agent_test.go`
     - `openai_responses_signature_test.go`
     - `openai_responses_websocket_test.go`
     - `openai_videos_handlers_test.go`
3. **Preserved invariants**:
   - All `t.Parallel()` markers remain intact across parallel test suites.
   - Zero runtime code touched; test harness files only.

## Testing

- `go test -count=1 ./sdk/api/handlers/openai/` — exit code 0
- `go test -race -count=1 ./sdk/api/handlers/openai/` — exit code 0
- `go vet ./sdk/api/handlers/openai/...` — exit code 0
- `gofmt -l sdk/api/handlers/openai/*_test.go` — clean

## Mirror

- CPAPlus companion: [kaitranntt/CLIProxyAPIPlus#179](https://github.com/kaitranntt/CLIProxyAPIPlus/pull/179)
