### PR TITLE
docs(config): add OrcaRouter as a named OpenAI-compatible upstream example

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ PackyCode provides special discounts for our software users: register using <a h
 - Claude Code multi-account load balancing
 - OpenAI Codex multi-account load balancing
 - Grok Build multi-account load balancing
-- OpenAI-compatible upstream providers via config (e.g., OpenRouter)
+- OpenAI-compatible upstream providers via config (e.g., OpenRouter, OrcaRouter)
 - Reusable Go SDK for embedding the proxy (see `docs/sdk-usage.md`)
 
 ## Getting Started

--- a/README_CN.md
+++ b/README_CN.md
@@ -127,7 +127,7 @@ PackyCode 为本软件用户提供了特别优惠：使用<a href="https://www.p
 - 支持 Claude Code 多账户轮询
 - 支持 OpenAI Codex 多账户轮询
 - 支持 Grok Build 多账户轮询
-- 通过配置接入上游 OpenAI 兼容提供商（例如 OpenRouter）
+- 通过配置接入上游 OpenAI 兼容提供商（例如 OpenRouter、OrcaRouter）
 - 可复用的 Go SDK（见 `docs/sdk-usage_CN.md`）
 
 ## 新手入门

--- a/README_JA.md
+++ b/README_JA.md
@@ -126,7 +126,7 @@ PackyCodeは当ソフトウェアのユーザーに特別割引を提供して�
 - Claude Codeのマルチアカウント負荷分散
 - OpenAI Codexのマルチアカウント負荷分散
 - Grok Buildのマルチアカウント負荷分散
-- 設定によるOpenAI互換アップストリームプロバイダー（例：OpenRouter）
+- 設定によるOpenAI互換アップストリームプロバイダー（例：OpenRouter、OrcaRouter）
 - プロキシ埋め込み用の再利用可能なGo SDK（`docs/sdk-usage.md`を参照）
 
 ## はじめに

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -523,6 +523,16 @@ nonstream-keepalive-interval: 0
 #         alias: "claude-opus-4.66"
 #       - name: "kimi-k2.5"
 #         alias: "claude-opus-4.66"
+#   - name: "orcarouter" # OpenAI-compatible gateway; see https://www.orcarouter.ai
+#     disabled: false # optional: set to true to disable this provider without removing it
+#     prefix: "orca" # optional: require calls like "orca/orcarouter-auto" to target this provider's credentials
+#     base-url: "https://api.orcarouter.ai/v1" # The base URL of the provider.
+#     api-key-entries:
+#       - api-key: "sk-orca-..." # get a key at https://api.orcarouter.ai
+#     models: # The models supported by the provider.
+#       - name: "orcarouter/auto" # per-request virtual router: routes each call to the best model for the task
+#         alias: "orcarouter-auto"
+#         display-name: "OrcaRouter Auto"
 
 # Vertex API keys (Vertex-compatible endpoints, base-url is optional)
 # vertex-api-key:


### PR DESCRIPTION
## Add [OrcaRouter](https://www.orcarouter.ai) as a named OpenAI-compatible upstream example

This PR adds [OrcaRouter](https://www.orcarouter.ai) as a named, copy-paste-ready example in the `openai-compatibility` section of `config.example.yaml`, mirroring the existing OpenRouter block, and names OrcaRouter alongside OpenRouter in the feature list across `README.md`, `README_CN.md`, and `README_JA.md`.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### What changes

- **`config.example.yaml`**: a fully commented `orcarouter` provider example under `openai-compatibility` — `base-url: https://api.orcarouter.ai/v1`, an `sk-orca-...` API key entry, and a single `orcarouter/auto` model (OrcaRouter's per-request virtual router) aliased as `orcarouter-auto`. Users can uncomment and reuse the block exactly like the OpenRouter one.
- **`README.md` / `README_CN.md` / `README_JA.md`**: the "OpenAI-compatible upstream providers via config" feature bullet now lists OrcaRouter alongside OpenRouter.

### Why this form

CLIProxyAPI already routes any OpenAI-compatible gateway through the generic `openai-compatibility` config, so no executor or translator changes are needed (and `internal/translator/` is explicitly off-limits for PRs). Mirroring the OpenRouter example gives OrcaRouter a named, first-class config block with correct defaults — the same way OpenRouter is showcased today.

### Verification

- `go build -o test-output ./cmd/server` passes on this branch (repo's required PR build gate).
- `config.example.yaml` parses cleanly as YAML.
- Live check of the documented values: `POST https://api.orcarouter.ai/v1/chat/completions` with model `orcarouter/auto` returns a normal response (routed to `deepseek-v4-pro`, reply `ORCA-OK`), confirming the example's base URL + model are correct.

I'm an engineer on the OrcaRouter team.
