### PR TITLE
fix(responses): shorten overlong call IDs

### DIFF
--- a/internal/runtime/executor/helps/codex_input_ids.go
+++ b/internal/runtime/executor/helps/codex_input_ids.go
@@ -23,6 +23,11 @@ const (
 
 	codexInputItemIDOccupied  uint8 = 1 << 0
 	codexInputItemIDPreserved uint8 = 1 << 1
+
+	codexCallIDFunctionCall     uint8 = 1 << 1
+	codexCallIDFunctionOutput   uint8 = 1 << 2
+	codexCallIDCustomToolCall   uint8 = 1 << 3
+	codexCallIDCustomToolOutput uint8 = 1 << 4
 )
 
 // SanitizeCodexInputItemIDs normalizes supported input item IDs for Codex, removes encrypted
@@ -37,6 +42,7 @@ func SanitizeCodexInputItemIDs(body []byte) []byte {
 	items := input.Array()
 	idStates := make(map[string]uint8, len(items))
 	var callIDStates map[string]uint8
+	var overlongCallIDRoles map[string]uint8
 	for _, item := range items {
 		if shouldDropCodexEncryptedReasoningItem(item) {
 			continue
@@ -48,7 +54,12 @@ func SanitizeCodexInputItemIDs(body []byte) []byte {
 				if callIDStates == nil {
 					callIDStates = make(map[string]uint8)
 				}
-				callIDStates[value] |= codexInputItemIDOccupied
+				callIDStates[value] |= codexInputItemIDOccupied | codexCallIDRole(item)
+			} else {
+				if overlongCallIDRoles == nil {
+					overlongCallIDRoles = make(map[string]uint8)
+				}
+				overlongCallIDRoles[value] |= codexCallIDRole(item)
 			}
 		}
 
@@ -139,7 +150,9 @@ func SanitizeCodexInputItemIDs(body []byte) []byte {
 			if !ok {
 				for attempt := 0; ; attempt++ {
 					shortened = shortenCodexCallIDWithAttempt(originalCallID, attempt)
-					if callIDStates[shortened]&codexInputItemIDOccupied == 0 {
+					shortenedState := callIDStates[shortened]
+					if shortenedState&codexInputItemIDOccupied == 0 ||
+						(attempt == 0 && codexCallIDRolesArePair(overlongCallIDRoles[originalCallID], shortenedState)) {
 						break
 					}
 				}
@@ -170,6 +183,29 @@ func SanitizeCodexInputItemIDs(body []byte) []byte {
 		return body
 	}
 	return updated
+}
+
+func codexCallIDRole(item gjson.Result) uint8 {
+	switch item.Get("type").String() {
+	case "function_call":
+		return codexCallIDFunctionCall
+	case "function_call_output":
+		return codexCallIDFunctionOutput
+	case "custom_tool_call":
+		return codexCallIDCustomToolCall
+	case "custom_tool_call_output":
+		return codexCallIDCustomToolOutput
+	default:
+		return 0
+	}
+}
+
+func codexCallIDRolesArePair(overlongRole, shortenedState uint8) bool {
+	shortenedRole := shortenedState &^ codexInputItemIDOccupied
+	return (overlongRole == codexCallIDFunctionCall && shortenedRole == codexCallIDFunctionOutput) ||
+		(overlongRole == codexCallIDFunctionOutput && shortenedRole == codexCallIDFunctionCall) ||
+		(overlongRole == codexCallIDCustomToolCall && shortenedRole == codexCallIDCustomToolOutput) ||
+		(overlongRole == codexCallIDCustomToolOutput && shortenedRole == codexCallIDCustomToolCall)
 }
 
 func normalizeCodexInputItemID(item gjson.Result, id string) string {

--- a/internal/runtime/executor/helps/codex_input_ids.go
+++ b/internal/runtime/executor/helps/codex_input_ids.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
@@ -13,6 +14,7 @@ import (
 
 const (
 	codexInputItemIDLimit                 = 64
+	codexCallIDLimit                      = 64
 	codexMessageItemIDPrefix              = "msg"
 	codexReasoningItemIDPrefix            = "rs"
 	codexFunctionCallItemIDPrefix         = "fc"
@@ -25,7 +27,7 @@ const (
 
 // SanitizeCodexInputItemIDs normalizes supported input item IDs for Codex, removes encrypted
 // reasoning items whose IDs exceed the Codex limit, and deterministically shortens
-// other overlong input item IDs.
+// other overlong input item IDs and call IDs.
 func SanitizeCodexInputItemIDs(body []byte) []byte {
 	input := util.GetGJSONBytesNoCopy(body, "input")
 	if !input.IsArray() {
@@ -34,10 +36,22 @@ func SanitizeCodexInputItemIDs(body []byte) []byte {
 
 	items := input.Array()
 	idStates := make(map[string]uint8, len(items))
+	var callIDStates map[string]uint8
 	for _, item := range items {
 		if shouldDropCodexEncryptedReasoningItem(item) {
 			continue
 		}
+		callID := item.Get("call_id")
+		if callID.Type == gjson.String {
+			value := callID.String()
+			if utf8.RuneCountInString(value) <= codexCallIDLimit {
+				if callIDStates == nil {
+					callIDStates = make(map[string]uint8)
+				}
+				callIDStates[value] |= codexInputItemIDOccupied
+			}
+		}
+
 		itemID := item.Get("id")
 		if itemID.Type != gjson.String {
 			continue
@@ -58,6 +72,7 @@ func SanitizeCodexInputItemIDs(body []byte) []byte {
 
 	var mapped map[string]string
 	var collisionMapped map[string]string
+	var callIDMapped map[string]string
 	rebuilt := make([]string, 0, len(items))
 	changed := false
 	for _, item := range items {
@@ -114,6 +129,34 @@ func SanitizeCodexInputItemIDs(body []byte) []byte {
 					raw = string(next)
 					changed = true
 				}
+			}
+		}
+
+		callID := item.Get("call_id")
+		if callID.Type == gjson.String && utf8.RuneCountInString(callID.String()) > codexCallIDLimit {
+			originalCallID := callID.String()
+			shortened, ok := callIDMapped[originalCallID]
+			if !ok {
+				for attempt := 0; ; attempt++ {
+					shortened = shortenCodexCallIDWithAttempt(originalCallID, attempt)
+					if callIDStates[shortened]&codexInputItemIDOccupied == 0 {
+						break
+					}
+				}
+				if callIDMapped == nil {
+					callIDMapped = make(map[string]string)
+				}
+				if callIDStates == nil {
+					callIDStates = make(map[string]uint8)
+				}
+				callIDMapped[originalCallID] = shortened
+				callIDStates[shortened] |= codexInputItemIDOccupied
+			}
+
+			next, errSet := sjson.SetBytes([]byte(raw), "call_id", shortened)
+			if errSet == nil {
+				raw = string(next)
+				changed = true
 			}
 		}
 		rebuilt = append(rebuilt, raw)
@@ -173,6 +216,14 @@ func shortenCodexInputItemIDWithAttempt(id string, attempt int) string {
 		return id
 	}
 	return codexInputItemIDWithHashSuffixRunes(id, runes, attempt)
+}
+
+func shortenCodexCallIDWithAttempt(callID string, attempt int) string {
+	runes := []rune(callID)
+	if len(runes) <= codexCallIDLimit {
+		return callID
+	}
+	return codexInputItemIDWithHashSuffixRunes(callID, runes, attempt)
 }
 
 func codexInputItemIDWithHashSuffix(id string, attempt int) string {

--- a/internal/runtime/executor/helps/codex_input_ids.go
+++ b/internal/runtime/executor/helps/codex_input_ids.go
@@ -34,6 +34,15 @@ const (
 // reasoning items whose IDs exceed the Codex limit, and deterministically shortens
 // other overlong input item IDs and call IDs.
 func SanitizeCodexInputItemIDs(body []byte) []byte {
+	return sanitizeResponsesInputIDs(body, true)
+}
+
+// SanitizeResponsesCallIDs deterministically shortens only overlong Responses call IDs.
+func SanitizeResponsesCallIDs(body []byte) []byte {
+	return sanitizeResponsesInputIDs(body, false)
+}
+
+func sanitizeResponsesInputIDs(body []byte, sanitizeItemIDs bool) []byte {
 	input := util.GetGJSONBytesNoCopy(body, "input")
 	if !input.IsArray() {
 		return body
@@ -44,7 +53,7 @@ func SanitizeCodexInputItemIDs(body []byte) []byte {
 	var callIDStates map[string]uint8
 	var overlongCallIDRoles map[string]uint8
 	for _, item := range items {
-		if shouldDropCodexEncryptedReasoningItem(item) {
+		if sanitizeItemIDs && shouldDropCodexEncryptedReasoningItem(item) {
 			continue
 		}
 		callID := item.Get("call_id")
@@ -61,6 +70,9 @@ func SanitizeCodexInputItemIDs(body []byte) []byte {
 				}
 				overlongCallIDRoles[value] |= codexCallIDRole(item)
 			}
+		}
+		if !sanitizeItemIDs {
+			continue
 		}
 
 		itemID := item.Get("id")
@@ -87,14 +99,14 @@ func SanitizeCodexInputItemIDs(body []byte) []byte {
 	rebuilt := make([]string, 0, len(items))
 	changed := false
 	for _, item := range items {
-		if shouldDropCodexEncryptedReasoningItem(item) {
+		if sanitizeItemIDs && shouldDropCodexEncryptedReasoningItem(item) {
 			changed = true
 			continue
 		}
 
 		raw := item.Raw
 		itemID := item.Get("id")
-		if itemID.Type == gjson.String {
+		if sanitizeItemIDs && itemID.Type == gjson.String {
 			originalID := itemID.String()
 			id := normalizeCodexInputItemID(item, originalID)
 			if id != originalID && idStates[id]&codexInputItemIDPreserved != 0 {

--- a/internal/runtime/executor/helps/codex_input_ids.go
+++ b/internal/runtime/executor/helps/codex_input_ids.go
@@ -160,11 +160,21 @@ func sanitizeResponsesInputIDs(body []byte, sanitizeItemIDs bool) []byte {
 			originalCallID := callID.String()
 			shortened, ok := callIDMapped[originalCallID]
 			if !ok {
+				claudeCallID := util.SanitizeClaudeToolID(originalCallID)
 				for attempt := 0; ; attempt++ {
 					shortened = shortenCodexCallIDWithAttempt(originalCallID, attempt)
 					shortenedState := callIDStates[shortened]
-					if shortenedState&codexInputItemIDOccupied == 0 ||
-						(attempt == 0 && codexCallIDRolesArePair(overlongCallIDRoles[originalCallID], shortenedState)) {
+					if codexCallIDRolesArePair(overlongCallIDRoles[originalCallID], shortenedState) {
+						break
+					}
+					if claudeCallID != originalCallID {
+						claudeShortened := shortenCodexCallIDWithAttempt(claudeCallID, attempt)
+						if codexCallIDRolesArePair(overlongCallIDRoles[originalCallID], callIDStates[claudeShortened]) {
+							shortened = claudeShortened
+							break
+						}
+					}
+					if shortenedState&codexInputItemIDOccupied == 0 {
 						break
 					}
 				}

--- a/internal/runtime/executor/helps/codex_input_ids_test.go
+++ b/internal/runtime/executor/helps/codex_input_ids_test.go
@@ -92,6 +92,65 @@ func TestSanitizeCodexInputItemIDsAvoidsExistingCallIDCollision(t *testing.T) {
 	}
 }
 
+func TestSanitizeCodexInputItemIDsReusesMatchingPreShortenedCallID(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		callType   string
+		outputType string
+	}{
+		{name: "function tool", callType: "function_call", outputType: "function_call_output"},
+		{name: "custom tool", callType: "custom_tool_call", outputType: "custom_tool_call_output"},
+	} {
+		for _, order := range []struct {
+			name       string
+			firstType  string
+			secondType string
+			firstLong  bool
+		}{
+			{name: "long call first", firstType: testCase.callType, secondType: testCase.outputType, firstLong: true},
+			{name: "short output first", firstType: testCase.outputType, secondType: testCase.callType, firstLong: false},
+		} {
+			t.Run(testCase.name+"/"+order.name, func(t *testing.T) {
+				longCallID := strings.Repeat("cursor-call-", 8)
+				shortCallID := shortenCodexCallIDWithAttempt(longCallID, 0)
+				firstCallID, secondCallID := shortCallID, longCallID
+				if order.firstLong {
+					firstCallID, secondCallID = longCallID, shortCallID
+				}
+				body := []byte(fmt.Sprintf(`{"input":[{"type":%q,"call_id":%q},{"type":%q,"call_id":%q}]}`, order.firstType, firstCallID, order.secondType, secondCallID))
+
+				first := SanitizeCodexInputItemIDs(body)
+				normalizedAgain := SanitizeCodexInputItemIDs(first)
+				for index := range 2 {
+					if actual := gjson.GetBytes(first, fmt.Sprintf("input.%d.call_id", index)).String(); actual != shortCallID {
+						t.Fatalf("input.%d.call_id = %q, want matching pre-shortened ID %q; payload=%s", index, actual, shortCallID, first)
+					}
+				}
+				if string(first) != string(normalizedAgain) {
+					t.Fatalf("pre-shortened pair normalization is not idempotent: first=%s normalized_again=%s", first, normalizedAgain)
+				}
+			})
+		}
+	}
+}
+
+func TestSanitizeCodexInputItemIDsDoesNotReusePreShortenedIDAcrossToolKinds(t *testing.T) {
+	longCallID := strings.Repeat("cursor-call-", 8)
+	shortCallID := shortenCodexCallIDWithAttempt(longCallID, 0)
+	body := []byte(`{"input":[` +
+		`{"type":"function_call","call_id":"` + longCallID + `"},` +
+		`{"type":"custom_tool_call_output","call_id":"` + shortCallID + `"}` +
+		`]}`)
+
+	got := SanitizeCodexInputItemIDs(body)
+	if actual := gjson.GetBytes(got, "input.0.call_id").String(); actual == shortCallID {
+		t.Fatalf("function call reused unrelated custom-tool output ID: %q", actual)
+	}
+	if actual := gjson.GetBytes(got, "input.1.call_id").String(); actual != shortCallID {
+		t.Fatalf("existing custom-tool output ID changed: %q", actual)
+	}
+}
+
 func TestSanitizeCodexInputItemIDsShortensOnlyOverlongCallID(t *testing.T) {
 	longCallID := strings.Repeat("call-", 20)
 	body := []byte(`{"input":[{"type":"function_call","call_id":"` + longCallID + `","name":"read","arguments":"{}"}]}`)

--- a/internal/runtime/executor/helps/codex_input_ids_test.go
+++ b/internal/runtime/executor/helps/codex_input_ids_test.go
@@ -151,6 +151,38 @@ func TestSanitizeCodexInputItemIDsDoesNotReusePreShortenedIDAcrossToolKinds(t *t
 	}
 }
 
+func TestSanitizeResponsesCallIDsChangesOnlyCallIDs(t *testing.T) {
+	longCallID := strings.Repeat("cursor-call-", 8)
+	longReasoningID := "reasoning_" + strings.Repeat("a", 64)
+	body := []byte(`{"input":[` +
+		`{"type":"message","id":"item_message","role":"user","content":"before"},` +
+		`{"type":"reasoning","id":"` + longReasoningID + `","encrypted_content":"encrypted","summary":[]},` +
+		`{"type":"function_call","id":"item_call","call_id":"` + longCallID + `","name":"lookup","arguments":"{}"},` +
+		`{"type":"function_call_output","call_id":"` + longCallID + `","output":"done"}` +
+		`]}`)
+
+	got := SanitizeResponsesCallIDs(body)
+	if actual := gjson.GetBytes(got, "input.0.id").String(); actual != "item_message" {
+		t.Fatalf("message ID changed: %q", actual)
+	}
+	if actual := gjson.GetBytes(got, "input.1.id").String(); actual != longReasoningID {
+		t.Fatalf("reasoning ID changed: %q", actual)
+	}
+	if actual := gjson.GetBytes(got, "input.1.encrypted_content").String(); actual != "encrypted" {
+		t.Fatalf("reasoning item changed or was dropped: %q; payload=%s", actual, got)
+	}
+	if actual := gjson.GetBytes(got, "input.2.id").String(); actual != "item_call" {
+		t.Fatalf("function-call item ID changed: %q", actual)
+	}
+	callID := gjson.GetBytes(got, "input.2.call_id").String()
+	if callID == longCallID || len([]rune(callID)) != codexCallIDLimit {
+		t.Fatalf("overlong call ID was not shortened: %q", callID)
+	}
+	if outputCallID := gjson.GetBytes(got, "input.3.call_id").String(); outputCallID != callID {
+		t.Fatalf("paired call IDs differ: %q != %q", callID, outputCallID)
+	}
+}
+
 func TestSanitizeCodexInputItemIDsShortensOnlyOverlongCallID(t *testing.T) {
 	longCallID := strings.Repeat("call-", 20)
 	body := []byte(`{"input":[{"type":"function_call","call_id":"` + longCallID + `","name":"read","arguments":"{}"}]}`)

--- a/internal/runtime/executor/helps/codex_input_ids_test.go
+++ b/internal/runtime/executor/helps/codex_input_ids_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
 )
 
@@ -130,6 +131,47 @@ func TestSanitizeCodexInputItemIDsReusesMatchingPreShortenedCallID(t *testing.T)
 					t.Fatalf("pre-shortened pair normalization is not idempotent: first=%s normalized_again=%s", first, normalizedAgain)
 				}
 			})
+		}
+	}
+}
+
+func TestSanitizeCodexInputItemIDsReusesMatchingLaterAttemptCallID(t *testing.T) {
+	longCallID := strings.Repeat("cursor-call-", 8)
+	firstAttempt := shortenCodexCallIDWithAttempt(longCallID, 0)
+	matchingLaterAttempt := shortenCodexCallIDWithAttempt(longCallID, 1)
+	body := []byte(`{"input":[` +
+		`{"type":"function_call","call_id":"` + firstAttempt + `","name":"other","arguments":"{}"},` +
+		`{"type":"function_call","call_id":"` + longCallID + `","name":"lookup","arguments":"{}"},` +
+		`{"type":"function_call_output","call_id":"` + matchingLaterAttempt + `","output":"done"}` +
+		`]}`)
+
+	got := SanitizeCodexInputItemIDs(body)
+	if actual := gjson.GetBytes(got, "input.0.call_id").String(); actual != firstAttempt {
+		t.Fatalf("existing colliding call ID changed: %q", actual)
+	}
+	for _, path := range []string{"input.1.call_id", "input.2.call_id"} {
+		if actual := gjson.GetBytes(got, path).String(); actual != matchingLaterAttempt {
+			t.Fatalf("%s = %q, want matching later-attempt ID %q; payload=%s", path, actual, matchingLaterAttempt, got)
+		}
+	}
+}
+
+func TestSanitizeCodexInputItemIDsReusesClaudeSanitizedPreShortenedCallID(t *testing.T) {
+	longCallID := "call.with/slashes/" + strings.Repeat("cursor-call-", 6)
+	claudeCallID := util.SanitizeClaudeToolID(longCallID)
+	claudeShortened := shortenCodexCallIDWithAttempt(claudeCallID, 0)
+	if claudeCallID == longCallID || claudeShortened == shortenCodexCallIDWithAttempt(longCallID, 0) {
+		t.Fatalf("invalid test setup: original=%q claude=%q shortened=%q", longCallID, claudeCallID, claudeShortened)
+	}
+	body := []byte(`{"input":[` +
+		`{"type":"function_call","call_id":"` + longCallID + `","name":"lookup","arguments":"{}"},` +
+		`{"type":"function_call_output","call_id":"` + claudeShortened + `","output":"done"}` +
+		`]}`)
+
+	got := SanitizeCodexInputItemIDs(body)
+	for _, path := range []string{"input.0.call_id", "input.1.call_id"} {
+		if actual := gjson.GetBytes(got, path).String(); actual != claudeShortened {
+			t.Fatalf("%s = %q, want Claude-visible ID %q; payload=%s", path, actual, claudeShortened, got)
 		}
 	}
 }

--- a/internal/runtime/executor/helps/codex_input_ids_test.go
+++ b/internal/runtime/executor/helps/codex_input_ids_test.go
@@ -29,6 +29,88 @@ func TestSanitizeCodexInputItemIDsBoundaries(t *testing.T) {
 	}
 }
 
+func TestSanitizeCodexInputItemIDsShortensPairedCallIDs(t *testing.T) {
+	callID64 := strings.Repeat("a", 64)
+	callID65 := strings.Repeat("b", 65)
+	callID86 := strings.Repeat("c", 86)
+	callID87 := strings.Repeat("界", 87)
+	body := []byte(`{"input":[` +
+		`{"type":"function_call","call_id":"` + callID64 + `","name":"read","arguments":"{}"},` +
+		`{"type":"function_call_output","call_id":"` + callID64 + `","output":"done"},` +
+		`{"type":"function_call","call_id":"` + callID65 + `","name":"read","arguments":"{}"},` +
+		`{"type":"function_call_output","call_id":"` + callID65 + `","output":"done"},` +
+		`{"type":"custom_tool_call","call_id":"` + callID86 + `","name":"lookup","input":"{}"},` +
+		`{"type":"custom_tool_call_output","call_id":"` + callID86 + `","output":"done"},` +
+		`{"type":"function_call","call_id":"` + callID87 + `","name":"read","arguments":"{}"},` +
+		`{"type":"function_call_output","call_id":"` + callID87 + `","output":"done"}` +
+		`]}`)
+
+	first := SanitizeCodexInputItemIDs(body)
+	second := SanitizeCodexInputItemIDs(body)
+	normalizedAgain := SanitizeCodexInputItemIDs(first)
+
+	if actual := gjson.GetBytes(first, "input.0.call_id").String(); actual != callID64 {
+		t.Fatalf("64-character call_id changed: %q", actual)
+	}
+	for _, pair := range [][2]int{{2, 3}, {4, 5}, {6, 7}} {
+		callID := gjson.GetBytes(first, fmt.Sprintf("input.%d.call_id", pair[0])).String()
+		outputCallID := gjson.GetBytes(first, fmt.Sprintf("input.%d.call_id", pair[1])).String()
+		if callID != outputCallID {
+			t.Fatalf("paired call IDs differ at input.%d and input.%d: %q != %q", pair[0], pair[1], callID, outputCallID)
+		}
+		if len([]rune(callID)) != codexCallIDLimit {
+			t.Fatalf("input.%d.call_id length = %d, want %d: %q", pair[0], len([]rune(callID)), codexCallIDLimit, callID)
+		}
+	}
+	if string(first) != string(second) {
+		t.Fatalf("call_id shortening is not deterministic: first=%s second=%s", first, second)
+	}
+	if string(first) != string(normalizedAgain) {
+		t.Fatalf("call_id shortening is not idempotent: first=%s normalized_again=%s", first, normalizedAgain)
+	}
+}
+
+func TestSanitizeCodexInputItemIDsAvoidsExistingCallIDCollision(t *testing.T) {
+	longCallID := strings.Repeat("cursor-call-", 8)
+	collidingValidCallID := shortenCodexCallIDWithAttempt(longCallID, 0)
+	body := []byte(`{"input":[` +
+		`{"type":"function_call","call_id":"` + longCallID + `","name":"read","arguments":"{}"},` +
+		`{"type":"function_call_output","call_id":"` + longCallID + `","output":"done"},` +
+		`{"type":"function_call","call_id":"` + collidingValidCallID + `","name":"other","arguments":"{}"}` +
+		`]}`)
+
+	got := SanitizeCodexInputItemIDs(body)
+	shortened := gjson.GetBytes(got, "input.0.call_id").String()
+	if shortened == collidingValidCallID {
+		t.Fatalf("shortened call_id collided with existing valid call_id: %q", shortened)
+	}
+	if paired := gjson.GetBytes(got, "input.1.call_id").String(); paired != shortened {
+		t.Fatalf("paired call_id = %q, want %q", paired, shortened)
+	}
+	if actual := gjson.GetBytes(got, "input.2.call_id").String(); actual != collidingValidCallID {
+		t.Fatalf("existing valid call_id changed: %q", actual)
+	}
+}
+
+func TestSanitizeCodexInputItemIDsShortensOnlyOverlongCallID(t *testing.T) {
+	longCallID := strings.Repeat("call-", 20)
+	body := []byte(`{"input":[{"type":"function_call","call_id":"` + longCallID + `","name":"read","arguments":"{}"}]}`)
+
+	got := SanitizeCodexInputItemIDs(body)
+	if actual := gjson.GetBytes(got, "input.0.call_id").String(); actual == longCallID || len([]rune(actual)) != codexCallIDLimit {
+		t.Fatalf("overlong call_id was not shortened: %q", actual)
+	}
+}
+
+func TestSanitizeCodexInputItemIDsLeavesValidCallIDsByteForByteUnchanged(t *testing.T) {
+	body := []byte(`{ "model": "gpt-5", "input": [ { "type": "function_call", "call_id": "call_123", "name": "read", "arguments": "{}" } ] }`)
+
+	got := SanitizeCodexInputItemIDs(body)
+	if string(got) != string(body) {
+		t.Fatalf("valid payload changed byte-for-byte: got=%q want=%q", got, body)
+	}
+}
+
 func TestSanitizeCodexInputItemIDsNormalizesMessageIDs(t *testing.T) {
 	const invalidID = "item_74ec40c883248ebb4885ec84"
 	body := []byte(`{"input":[` +
@@ -305,6 +387,28 @@ func BenchmarkSanitizeCodexInputItemIDsLargeHistory(b *testing.B) {
 			payload.WriteByte(',')
 		}
 		fmt.Fprintf(&payload, `{"type":"message","id":"msg_%d","role":"user","content":"x"}`, index)
+	}
+	payload.WriteString(`]}`)
+	body := []byte(payload.String())
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(body)))
+	b.ResetTimer()
+	for b.Loop() {
+		benchmarkSanitizeCodexInputItemIDsOutput = SanitizeCodexInputItemIDs(body)
+	}
+}
+
+func BenchmarkSanitizeCodexInputItemIDsLargeToolHistory(b *testing.B) {
+	var payload strings.Builder
+	payload.Grow(128 << 10)
+	payload.WriteString(`{"input":[`)
+	for index := range 500 {
+		if index > 0 {
+			payload.WriteByte(',')
+		}
+		fmt.Fprintf(&payload, `{"type":"function_call","call_id":"call_%d","name":"read","arguments":"{}"},`, index)
+		fmt.Fprintf(&payload, `{"type":"function_call_output","call_id":"call_%d","output":"done"}`, index)
 	}
 	payload.WriteString(`]}`)
 	body := []byte(payload.String())

--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -115,6 +115,7 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	body = normalizeCodexInstructions(body)
 	body = sanitizeXAIResponsesBody(body, baseModel)
 	body = normalizeXAIImageRefs(body)
+	body = helps.SanitizeResponsesCallIDs(body)
 
 	sessionID, errSession := xaiResolveComposerSessionID(ctx, req, opts, baseModel)
 	if errSession != nil {

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -329,6 +329,30 @@ func TestXAIExecutorExecuteShapesResponsesRequest(t *testing.T) {
 	}
 }
 
+func TestXAIExecutorPrepareResponsesRequestShortensPairedCallIDs(t *testing.T) {
+	longCallID := strings.Repeat("cursor-call-", 8)
+	exec := NewXAIExecutor(&config.Config{})
+
+	prepared, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+		Model: "grok-4.3",
+		Payload: []byte(`{"model":"grok-4.3","input":[` +
+			`{"type":"function_call","call_id":"` + longCallID + `","name":"lookup","arguments":"{}"},` +
+			`{"type":"function_call_output","call_id":"` + longCallID + `","output":"done"}` +
+			`]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse}, true)
+	if err != nil {
+		t.Fatalf("prepareResponsesRequest() error = %v", err)
+	}
+
+	callID := gjson.GetBytes(prepared.body, "input.0.call_id").String()
+	if callID == longCallID || len([]rune(callID)) != 64 {
+		t.Fatalf("overlong function call ID was not shortened: %q; body=%s", callID, prepared.body)
+	}
+	if outputCallID := gjson.GetBytes(prepared.body, "input.1.call_id").String(); outputCallID != callID {
+		t.Fatalf("paired call IDs differ: %q != %q; body=%s", callID, outputCallID, prepared.body)
+	}
+}
+
 func TestXAIExecutorPrepareResponsesRequestRewritesCodexAgentMessage(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- deterministically shorten Responses `call_id` values longer than 64 characters
- reuse one mapping for matching call/output items so tool-result correlation is preserved
- recognize already-shortened replay pairs without weakening genuine collision handling
- apply the full existing input-item compatibility pass to Codex and a call-ID-only pass to xAI, leaving unrelated xAI item/reasoning fields untouched

This fixes Responses API rejections such as `input[4].call_id: length must be <= 64` from clients that generate longer tool-call identifiers. The change is isolated to the final upstream request-compatibility boundaries for Codex and xAI. Existing valid call IDs remain byte-for-byte unchanged.

## Verification

- `go test ./...`
- `go build -o /tmp/cli-proxy-api-call-id-test ./cmd/server`
- boundaries at 64/65/86/87 characters
- paired function and custom-tool call/output coverage
- pre-shortened replay-pair and genuine-collision coverage
- direct xAI executor boundary coverage
- byte-for-byte no-op coverage for valid payloads
- call-ID-only xAI coverage proving item/reasoning IDs and encrypted reasoning are unchanged

A 1,000-item no-tool Codex history benchmark changed from about 332.5 microseconds to 334.2 microseconds on Apple M5 Pro (~1.7 microseconds, ~0.5%).