### PR TITLE
honor negotiated protocol for ChatGPT requests

### DIFF
--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -1,6 +1,7 @@
 package helps
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -23,8 +24,8 @@ import (
 )
 
 // utlsRoundTripper implements http.RoundTripper using a Chrome fingerprint for
-// providers that require a browser-like TLS and HTTP/2 transport. Each request
-// gets a dedicated connection that is closed with the response body.
+// providers that require a browser-like TLS transport. Each request gets a
+// dedicated connection that is closed with the response body.
 type utlsRoundTripper struct {
 	dialer proxy.Dialer
 }
@@ -67,7 +68,7 @@ func newUtlsRoundTripper(proxyURL string) *utlsRoundTripper {
 	return &utlsRoundTripper{dialer: dialer}
 }
 
-func (t *utlsRoundTripper) createConnection(ctx context.Context, host, addr string) (*http2.ClientConn, error) {
+func (t *utlsRoundTripper) createConnection(ctx context.Context, host, addr string) (*tls.UConn, error) {
 	contextDialer, ok := t.dialer.(proxy.ContextDialer)
 	if !ok {
 		return nil, fmt.Errorf("utls: dialer does not support context cancellation")
@@ -90,16 +91,7 @@ func (t *utlsRoundTripper) createConnection(ctx context.Context, host, addr stri
 		return nil, fmt.Errorf("utls: TLS handshake: %w", errHandshake)
 	}
 
-	tr := &http2.Transport{}
-	h2Conn, errClientConn := tr.NewClientConn(tlsConn)
-	if errClientConn != nil {
-		if errClose := tlsConn.Close(); errClose != nil {
-			return nil, fmt.Errorf("utls: initialize HTTP/2 connection: %w; close TLS connection: %v", errClientConn, errClose)
-		}
-		return nil, fmt.Errorf("utls: initialize HTTP/2 connection: %w", errClientConn)
-	}
-
-	return h2Conn, nil
+	return tlsConn, nil
 }
 
 func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -110,20 +102,51 @@ func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 	addr := net.JoinHostPort(hostname, port)
 
-	h2Conn, err := t.createConnection(req.Context(), hostname, addr)
+	tlsConn, err := t.createConnection(req.Context(), hostname, addr)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := h2Conn.RoundTrip(req)
+	var (
+		resp            *http.Response
+		closeConnection func() error
+	)
+	negotiatedProtocol := tlsConn.ConnectionState().NegotiatedProtocol
+	switch negotiatedProtocol {
+	case "h2":
+		tr := &http2.Transport{}
+		h2Conn, errClientConn := tr.NewClientConn(tlsConn)
+		if errClientConn != nil {
+			if errClose := tlsConn.Close(); errClose != nil {
+				return nil, fmt.Errorf("utls: initialize HTTP/2 connection: %w; close TLS connection: %v", errClientConn, errClose)
+			}
+			return nil, fmt.Errorf("utls: initialize HTTP/2 connection: %w", errClientConn)
+		}
+		resp, err = h2Conn.RoundTrip(req)
+		closeConnection = h2Conn.Close
+	case "", "http/1.1":
+		if errWrite := req.Write(tlsConn); errWrite != nil {
+			if errClose := tlsConn.Close(); errClose != nil {
+				return nil, fmt.Errorf("utls: write HTTP/1.1 request: %w; close connection: %v", errWrite, errClose)
+			}
+			return nil, fmt.Errorf("utls: write HTTP/1.1 request: %w", errWrite)
+		}
+		resp, err = http.ReadResponse(bufio.NewReader(tlsConn), req)
+		closeConnection = tlsConn.Close
+	default:
+		if errClose := tlsConn.Close(); errClose != nil {
+			return nil, fmt.Errorf("utls: unsupported negotiated protocol %q; close connection: %v", negotiatedProtocol, errClose)
+		}
+		return nil, fmt.Errorf("utls: unsupported negotiated protocol %q", negotiatedProtocol)
+	}
 	if err != nil {
-		if errClose := h2Conn.Close(); errClose != nil {
+		if errClose := closeConnection(); errClose != nil {
 			log.Debugf("utls: close connection after round trip failure: %v", errClose)
 		}
 		return nil, err
 	}
 	if resp == nil {
-		if errClose := h2Conn.Close(); errClose != nil {
+		if errClose := closeConnection(); errClose != nil {
 			log.Debugf("utls: close connection after empty response: %v", errClose)
 		}
 		return nil, fmt.Errorf("utls: upstream returned an empty response")
@@ -133,7 +156,7 @@ func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 	resp.Body = &closeConnectionBody{
 		ReadCloser:      resp.Body,
-		closeConnection: h2Conn.Close,
+		closeConnection: closeConnection,
 	}
 	return resp, nil
 }


### PR DESCRIPTION
The ChatGPT/Codex upstream client establishes connections with a Chrome-style uTLS fingerprint. Previously, it always created an http2.ClientConn after the TLS handshake, regardless of the protocol actually negotiated through TLS ALPN.

In some enterprise networks, TLS inspection gateways, or proxy environments, the upstream may negotiate or return HTTP/1.1. If the client still parses the response as HTTP/2, it fails with:

```txt
http2: frame too large, note that the frame header looked like an HTTP/1.1 header
```

This patch reads the negotiated ALPN protocol after the TLS handshake:
 - When h2 is negotiated, it keeps the existing HTTP/2 request path.
 - When http/1.1 is negotiated, or ALPN is omitted, it sends and receives HTTP/1.1 over the same TLS connection.
 - For unsupported protocols, it closes the connection and returns a clear error.

The patch does not change the TLS fingerprint or force a specific HTTP version. It makes the client honor the protocol actually negotiated with the upstream, preventing HTTP/1.1 responses from being parsed as HTTP/2 frames.

fix(codex): honor negotiated protocol for ChatGPT requests

- Keep the Chrome TLS fingerprint and select the request protocol after the TLS handshake.
- Use the existing HTTP/2 path when ALPN negotiates `h2`.
- Use HTTP/1.1 on the negotiated connection when the peer selects `http/1.1` or omits ALPN.