### PR TITLE
fix(codex): honor negotiated protocol for ChatGPT requests

### DIFF
--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -37,6 +37,37 @@ type closeConnectionBody struct {
 	err             error
 }
 
+const (
+	maxHTTP1ResponseHeaderBytes = 10 << 20
+	maxInterimHTTP1Responses    = 10
+)
+
+var errHTTP1ResponseHeadersTooLarge = errors.New("utls: HTTP/1.1 response headers too large")
+
+type responseHeaderLimitReader struct {
+	reader    io.Reader
+	remaining int64
+}
+
+func (r *responseHeaderLimitReader) Read(p []byte) (int, error) {
+	if r.remaining < 0 {
+		return r.reader.Read(p)
+	}
+	if r.remaining == 0 {
+		return 0, errHTTP1ResponseHeadersTooLarge
+	}
+	if int64(len(p)) > r.remaining {
+		p = p[:r.remaining]
+	}
+	n, errRead := r.reader.Read(p)
+	r.remaining -= int64(n)
+	return n, errRead
+}
+
+func (r *responseHeaderLimitReader) disableLimit() {
+	r.remaining = -1
+}
+
 func (b *closeConnectionBody) Close() error {
 	if b == nil {
 		return nil
@@ -72,6 +103,24 @@ func closeConnectionOnContextCancel(ctx context.Context, conn net.Conn) func() e
 	return func() error {
 		stop()
 		return closeConnection()
+	}
+}
+
+func readFinalHTTP1Response(reader io.Reader, req *http.Request) (*http.Response, error) {
+	limitedReader := &responseHeaderLimitReader{reader: reader, remaining: maxHTTP1ResponseHeaderBytes}
+	responseReader := bufio.NewReader(limitedReader)
+	for interimResponses := 0; ; interimResponses++ {
+		resp, errRead := http.ReadResponse(responseReader, req)
+		if errRead != nil {
+			return nil, errRead
+		}
+		if resp.StatusCode < http.StatusContinue || resp.StatusCode >= http.StatusOK || resp.StatusCode == http.StatusSwitchingProtocols {
+			limitedReader.disableLimit()
+			return resp, nil
+		}
+		if interimResponses == maxInterimHTTP1Responses {
+			return nil, fmt.Errorf("utls: too many interim HTTP/1.1 responses")
+		}
 	}
 }
 
@@ -150,10 +199,12 @@ func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 			if errClose := closeConnection(); errClose != nil {
 				return nil, fmt.Errorf("utls: write HTTP/1.1 request: %w; close connection: %v", errWrite, errClose)
 			}
+			if errContext := req.Context().Err(); errContext != nil {
+				return nil, errContext
+			}
 			return nil, fmt.Errorf("utls: write HTTP/1.1 request: %w", errWrite)
 		}
-		resp, err = http.ReadResponse(bufio.NewReader(tlsConn), req)
-		closeConnection = tlsConn.Close
+		resp, err = readFinalHTTP1Response(tlsConn, req)
 	default:
 		if errClose := tlsConn.Close(); errClose != nil {
 			return nil, fmt.Errorf("utls: unsupported negotiated protocol %q; close connection: %v", negotiatedProtocol, errClose)
@@ -163,6 +214,9 @@ func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	if err != nil {
 		if errClose := closeConnection(); errClose != nil {
 			log.Debugf("utls: close connection after round trip failure: %v", errClose)
+		}
+		if errContext := req.Context().Err(); errContext != nil {
+			return nil, errContext
 		}
 		return nil, err
 	}

--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -1,6 +1,7 @@
 package helps
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -23,8 +24,8 @@ import (
 )
 
 // utlsRoundTripper implements http.RoundTripper using a Chrome fingerprint for
-// providers that require a browser-like TLS and HTTP/2 transport. Each request
-// gets a dedicated connection that is closed with the response body.
+// providers that require a browser-like TLS transport. Each request gets a
+// dedicated connection that is closed with the response body.
 type utlsRoundTripper struct {
 	dialer proxy.Dialer
 }
@@ -54,6 +55,26 @@ func (b *closeConnectionBody) Close() error {
 	return b.err
 }
 
+func closeConnectionOnContextCancel(ctx context.Context, conn net.Conn) func() error {
+	var (
+		once     sync.Once
+		errClose error
+	)
+	closeConnection := func() error {
+		once.Do(func() {
+			errClose = conn.Close()
+		})
+		return errClose
+	}
+	stop := context.AfterFunc(ctx, func() {
+		_ = closeConnection()
+	})
+	return func() error {
+		stop()
+		return closeConnection()
+	}
+}
+
 func newUtlsRoundTripper(proxyURL string) *utlsRoundTripper {
 	var dialer proxy.Dialer = proxy.Direct
 	if proxyURL != "" {
@@ -67,7 +88,7 @@ func newUtlsRoundTripper(proxyURL string) *utlsRoundTripper {
 	return &utlsRoundTripper{dialer: dialer}
 }
 
-func (t *utlsRoundTripper) createConnection(ctx context.Context, host, addr string) (*http2.ClientConn, error) {
+func (t *utlsRoundTripper) createConnection(ctx context.Context, host, addr string) (*tls.UConn, error) {
 	contextDialer, ok := t.dialer.(proxy.ContextDialer)
 	if !ok {
 		return nil, fmt.Errorf("utls: dialer does not support context cancellation")
@@ -90,16 +111,7 @@ func (t *utlsRoundTripper) createConnection(ctx context.Context, host, addr stri
 		return nil, fmt.Errorf("utls: TLS handshake: %w", errHandshake)
 	}
 
-	tr := &http2.Transport{}
-	h2Conn, errClientConn := tr.NewClientConn(tlsConn)
-	if errClientConn != nil {
-		if errClose := tlsConn.Close(); errClose != nil {
-			return nil, fmt.Errorf("utls: initialize HTTP/2 connection: %w; close TLS connection: %v", errClientConn, errClose)
-		}
-		return nil, fmt.Errorf("utls: initialize HTTP/2 connection: %w", errClientConn)
-	}
-
-	return h2Conn, nil
+	return tlsConn, nil
 }
 
 func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -110,20 +122,52 @@ func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 	addr := net.JoinHostPort(hostname, port)
 
-	h2Conn, err := t.createConnection(req.Context(), hostname, addr)
+	tlsConn, err := t.createConnection(req.Context(), hostname, addr)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := h2Conn.RoundTrip(req)
+	var (
+		resp            *http.Response
+		closeConnection func() error
+	)
+	negotiatedProtocol := tlsConn.ConnectionState().NegotiatedProtocol
+	switch negotiatedProtocol {
+	case "h2":
+		tr := &http2.Transport{}
+		h2Conn, errClientConn := tr.NewClientConn(tlsConn)
+		if errClientConn != nil {
+			if errClose := tlsConn.Close(); errClose != nil {
+				return nil, fmt.Errorf("utls: initialize HTTP/2 connection: %w; close TLS connection: %v", errClientConn, errClose)
+			}
+			return nil, fmt.Errorf("utls: initialize HTTP/2 connection: %w", errClientConn)
+		}
+		resp, err = h2Conn.RoundTrip(req)
+		closeConnection = h2Conn.Close
+	case "", "http/1.1":
+		closeConnection = closeConnectionOnContextCancel(req.Context(), tlsConn)
+		if errWrite := req.Write(tlsConn); errWrite != nil {
+			if errClose := closeConnection(); errClose != nil {
+				return nil, fmt.Errorf("utls: write HTTP/1.1 request: %w; close connection: %v", errWrite, errClose)
+			}
+			return nil, fmt.Errorf("utls: write HTTP/1.1 request: %w", errWrite)
+		}
+		resp, err = http.ReadResponse(bufio.NewReader(tlsConn), req)
+		closeConnection = tlsConn.Close
+	default:
+		if errClose := tlsConn.Close(); errClose != nil {
+			return nil, fmt.Errorf("utls: unsupported negotiated protocol %q; close connection: %v", negotiatedProtocol, errClose)
+		}
+		return nil, fmt.Errorf("utls: unsupported negotiated protocol %q", negotiatedProtocol)
+	}
 	if err != nil {
-		if errClose := h2Conn.Close(); errClose != nil {
+		if errClose := closeConnection(); errClose != nil {
 			log.Debugf("utls: close connection after round trip failure: %v", errClose)
 		}
 		return nil, err
 	}
 	if resp == nil {
-		if errClose := h2Conn.Close(); errClose != nil {
+		if errClose := closeConnection(); errClose != nil {
 			log.Debugf("utls: close connection after empty response: %v", errClose)
 		}
 		return nil, fmt.Errorf("utls: upstream returned an empty response")
@@ -133,7 +177,7 @@ func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 	resp.Body = &closeConnectionBody{
 		ReadCloser:      resp.Body,
-		closeConnection: h2Conn.Close,
+		closeConnection: closeConnection,
 	}
 	return resp, nil
 }


### PR DESCRIPTION
I'm in a enterprise networks, TLS inspection gateways, the upstream may negotiate or return HTTP/1.1, CLIProxyAPI still parses the response as HTTP/2, it fails with:

```txt
http2: frame too large, note that the frame header looked like an HTTP/1.1 header
```

The ChatGPT/Codex upstream client establishes connections with a Chrome-style uTLS fingerprint. Previously, it always created an http2.ClientConn after the TLS handshake, regardless of the protocol actually negotiated through TLS ALPN.

This patch reads the negotiated ALPN protocol after the TLS handshake:
 - When h2 is negotiated, it keeps the existing HTTP/2 request path.
 - When http/1.1 is negotiated, or ALPN is omitted, it sends and receives HTTP/1.1 over the same TLS connection.
 - For unsupported protocols, it closes the connection and returns a clear error.

The patch does not change the TLS fingerprint or force a specific HTTP version. It makes the client honor the protocol actually negotiated with the upstream, preventing HTTP/1.1 responses from being parsed as HTTP/2 frames.