### PR TITLE
fix(handlers): skip inactive before-auth interceptors

### DIFF
--- a/sdk/api/handlers/handlers_interceptors.go
+++ b/sdk/api/handlers/handlers_interceptors.go
@@ -425,7 +425,7 @@ func interceptStreamChunk(ctx context.Context, host PluginInterceptorHost, req p
 
 func (h *BaseAPIHandler) applyRequestInterceptorsBeforeAuth(ctx context.Context, handlerType, requestedModel, requestID string, req coreexecutor.Request, opts coreexecutor.Options, skipPluginID string) (coreexecutor.Request, coreexecutor.Options, *interfaces.ErrorMessage) {
 	host := h.interceptorHost()
-	if host == nil {
+	if !requestInterceptorsEnabled(host) {
 		return req, opts, nil
 	}
 	resp := interceptRequestBeforeAuth(ctx, host, pluginapi.RequestInterceptRequest{

--- a/sdk/api/handlers/handlers_interceptors_test.go
+++ b/sdk/api/handlers/handlers_interceptors_test.go
@@ -34,6 +34,15 @@ type handlerInterceptorNoStreamTestHost struct {
 	*handlerInterceptorTestHost
 }
 
+type handlerInterceptorDetectorTestHost struct {
+	*handlerInterceptorTestHost
+	hasRequestInterceptors bool
+}
+
+func (h *handlerInterceptorDetectorTestHost) HasRequestInterceptors() bool {
+	return h != nil && h.hasRequestInterceptors
+}
+
 func (h *handlerInterceptorNoStreamTestHost) HasStreamInterceptors() bool {
 	return false
 }
@@ -229,6 +238,38 @@ func TestRequestLifecycleTrackerUsesUniqueExecutionIDs(t *testing.T) {
 	}
 	if first.completion.TraceID != "trace-1" || second.completion.TraceID != "trace-1" {
 		t.Fatalf("trace IDs = %q and %q", first.completion.TraceID, second.completion.TraceID)
+	}
+}
+
+func TestHandlerSkipsBeforeAuthWithoutRequestInterceptors(t *testing.T) {
+	handler := NewBaseAPIHandlers(nil, nil)
+	calls := 0
+	handler.SetPluginHost(&handlerInterceptorDetectorTestHost{
+		handlerInterceptorTestHost: &handlerInterceptorTestHost{
+			interceptRequestBeforeAuth: func(_ context.Context, req pluginapi.RequestInterceptRequest) pluginapi.RequestInterceptResponse {
+				calls++
+				return pluginapi.RequestInterceptResponse{Headers: req.Headers, Body: req.Body}
+			},
+		},
+	})
+	payload := []byte(`{"model":"test"}`)
+	originalRequest := []byte(`{"model":"original"}`)
+	req := coreexecutor.Request{Model: "test", Payload: payload}
+	opts := coreexecutor.Options{OriginalRequest: originalRequest}
+
+	gotReq, gotOpts, errMsg := handler.applyRequestInterceptorsBeforeAuth(context.Background(), "openai", "test", "request-id", req, opts, "")
+
+	if errMsg != nil {
+		t.Fatalf("applyRequestInterceptorsBeforeAuth() error = %#v", errMsg)
+	}
+	if calls != 0 {
+		t.Fatalf("before-auth interceptor calls = %d, want 0", calls)
+	}
+	if &gotReq.Payload[0] != &payload[0] {
+		t.Fatal("request payload was copied without active request interceptors")
+	}
+	if &gotOpts.OriginalRequest[0] != &originalRequest[0] {
+		t.Fatal("original request was copied without active request interceptors")
 	}
 }
 


### PR DESCRIPTION
## What

Skip the before-auth request interceptor path when the plugin host reports that no request interceptors are active.

## Why

The server installs a non-nil plugin host even when no plugins are enabled. The after-auth path already uses `requestInterceptorsEnabled`, but the before-auth path only checked whether the host was nil.

As a result, a request with no active interceptors still passed through the empty plugin host. That path cloned the request body in the handler, cloned it again in the host, and then retained two handler-side copies returned from the no-op interception.

This was observed on a small-memory host handling a large Responses request. A forced-GC pprof `inuse_space` profile attributed about 110 MiB to `applyRequestInterceptorsBeforeAuth -> cloneBytes` for an approximately 55 MiB request body, despite no active plugins. 

## Behavior and compatibility

- Hosts reporting active request interceptors keep the existing before-auth behavior.
- Hosts that do not implement the detector keep the conservative existing behavior because `requestInterceptorsEnabled` defaults to true for unknown hosts.
- Only hosts explicitly reporting no active request interceptors take the zero-copy fast path.
- The change makes before-auth consistent with the existing after-auth guard.

## Checks

- `go test ./sdk/api/handlers -count=1`
- `go build -o /tmp/cpa-pr1-server-build ./cmd/server`

The regression test also checks that the interceptor is not called and the request body slices retain their original backing storage when request interceptors are inactive.
