### PR TITLE
fix(pluginhost): avoid empty request normalizer clone

### DIFF
--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -950,6 +950,19 @@ func TestRegisterExecutorsDoesNotUnregisterStaleProviderOwnedExternally(t *testi
 	}
 }
 
+func TestNormalizeRequestWithoutPluginsReturnsOriginalBody(t *testing.T) {
+	host := New()
+	body := []byte("original")
+
+	got := host.NormalizeRequest(context.Background(), sdktranslator.FormatOpenAI, sdktranslator.FormatClaude, "model", body, false)
+	if string(got) != string(body) {
+		t.Fatalf("NormalizeRequest() = %q, want %q", got, body)
+	}
+	if &got[0] != &body[0] {
+		t.Fatal("NormalizeRequest() copied body without active request normalizers")
+	}
+}
+
 func TestNormalizeRequestChainsByPriority(t *testing.T) {
 	host := newHostWithRecords(
 		capabilityRecord{

--- a/internal/pluginhost/adapters_usage_translation.go
+++ b/internal/pluginhost/adapters_usage_translation.go
@@ -203,10 +203,15 @@ func (a *thinkingAdapter) Apply(body []byte, config thinking.ThinkingConfig, mod
 }
 
 func (h *Host) NormalizeRequest(ctx context.Context, from, to sdktranslator.Format, model string, body []byte, stream bool) []byte {
-	current := bytes.Clone(body)
+	current := body
+	cloned := false
 	for _, record := range h.activeRecords() {
 		if h.isPluginFused(record.id) || record.plugin.Capabilities.RequestNormalizer == nil {
 			continue
+		}
+		if !cloned {
+			current = bytes.Clone(body)
+			cloned = true
 		}
 		if normalized, ok := h.callRequestNormalizer(ctx, record, from, to, model, current, stream); ok {
 			current = normalized


### PR DESCRIPTION
## What

Delay the initial request-body clone in `Host.NormalizeRequest` until an active request normalizer is actually found.

## Why

The service installs a non-nil plugin host as translator hooks even when no plugins are active. `NormalizeRequest` cloned the full request body before scanning plugin capabilities, so an empty host allocated and copied the complete payload on every call. This increases transient memory usage, can raise peak memory consumption, and is especially unfriendly to memory-constrained systems.

## Behavior and compatibility

- With no active request normalizers, the original body is returned without copying, matching the translator's no-hook path.
- When a request normalizer is present, the body is still cloned before the first plugin call, preserving the existing plugin isolation and chaining behavior.
- Request translators and response normalization paths are unchanged.

## Checks

- `go test ./internal/pluginhost -count=1`
- `go test ./...`
- `go build -o /tmp/cpa-pr2-server-build ./cmd/server`
- Before/after 64 MiB benchmark, three runs each

The regression test verifies both content and backing-storage identity for the empty-host path; the existing priority-chain test continues to cover the active-normalizer path.
