### PR TITLE
fix(claude): keep tool_result blocks first when injecting currentDate

### DIFF
--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -820,9 +820,16 @@ func injectClaudeCodeCurrentDate(payload []byte, now time.Time) []byte {
 		rawBlocks = append(rawBlocks, block.Raw)
 	}
 
+	// Anthropic requires the user message following an assistant tool_use turn
+	// to lead with its tool_result blocks, so the reminder goes after them.
+	// Every other content shape keeps the native first-block placement.
+	insertAt := 0
+	for insertAt < len(rawBlocks) && gjson.Parse(rawBlocks[insertAt]).Get("type").String() == "tool_result" {
+		insertAt++
+	}
 	rawBlocks = append(rawBlocks, "")
-	copy(rawBlocks[1:], rawBlocks)
-	rawBlocks[0] = dateBlock
+	copy(rawBlocks[insertAt+1:], rawBlocks[insertAt:])
+	rawBlocks[insertAt] = dateBlock
 	payload, _ = sjson.SetRawBytes(payload, contentPath, []byte("["+strings.Join(rawBlocks, ",")+"]"))
 	return payload
 }

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -3875,6 +3875,60 @@ func TestInjectClaudeCodeCurrentDatePrecedesExistingReminder(t *testing.T) {
 	assertEphemeralUserTextBlock(t, content[2], "continue", "")
 }
 
+func TestInjectClaudeCodeCurrentDateFollowsLeadingToolResults(t *testing.T) {
+	fixed := time.Date(2026, time.August, 1, 9, 0, 0, 0, time.FixedZone("UTC+8", 8*60*60))
+	payload := []byte(`{"messages":[` +
+		`{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{}}]},` +
+		`{"role":"user","content":[` +
+		`{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"},` +
+		`{"type":"text","text":"continue"}]}]}`)
+
+	first := injectClaudeCodeCurrentDate(payload, fixed)
+	second := injectClaudeCodeCurrentDate(first, fixed)
+	if !bytes.Equal(first, second) {
+		t.Fatalf("currentDate injection is not idempotent:\nfirst:  %s\nsecond: %s", first, second)
+	}
+
+	content := gjson.GetBytes(first, "messages.1.content").Array()
+	if len(content) != 3 {
+		t.Fatalf("content has %d blocks, want tool_result, currentDate, and user text: %s", len(content), first)
+	}
+	if got := content[0].Get("type").String(); got != "tool_result" {
+		t.Fatalf("content[0].type = %q, want tool_result to stay first: %s", got, first)
+	}
+	if got := content[0].Get("tool_use_id").String(); got != "toolu_1" {
+		t.Fatalf("content[0].tool_use_id = %q, want toolu_1", got)
+	}
+	assertClaudeCodeCurrentDateBlockAt(t, content[1], fixed)
+	assertEphemeralUserTextBlock(t, content[2], "continue", "")
+}
+
+func TestInjectClaudeCodeCurrentDateFollowsAllLeadingToolResults(t *testing.T) {
+	fixed := time.Date(2026, time.August, 1, 9, 0, 0, 0, time.FixedZone("UTC+8", 8*60*60))
+	payload := []byte(`{"messages":[` +
+		`{"role":"assistant","content":[` +
+		`{"type":"tool_use","id":"toolu_1","name":"Read","input":{}},` +
+		`{"type":"tool_use","id":"toolu_2","name":"Read","input":{}}]},` +
+		`{"role":"user","content":[` +
+		`{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"},` +
+		`{"type":"tool_result","tool_use_id":"toolu_2","content":"ok"}]}]}`)
+
+	out := injectClaudeCodeCurrentDate(payload, fixed)
+	content := gjson.GetBytes(out, "messages.1.content").Array()
+	if len(content) != 3 {
+		t.Fatalf("content has %d blocks, want two tool_results and currentDate: %s", len(content), out)
+	}
+	for idx, wantID := range []string{"toolu_1", "toolu_2"} {
+		if got := content[idx].Get("type").String(); got != "tool_result" {
+			t.Fatalf("content[%d].type = %q, want tool_result: %s", idx, got, out)
+		}
+		if got := content[idx].Get("tool_use_id").String(); got != wantID {
+			t.Fatalf("content[%d].tool_use_id = %q, want %q", idx, got, wantID)
+		}
+	}
+	assertClaudeCodeCurrentDateBlockAt(t, content[2], fixed)
+}
+
 // Test case 1: String system prompt becomes an authoritative mid-conversation
 // system message after the first user turn.
 func TestCheckSystemInstructionsWithMode_StringSystemPreserved(t *testing.T) {


### PR DESCRIPTION
Fixes #4970.

## Problem

`injectClaudeCodeCurrentDate` inserts the currentDate `<system-reminder>` at index 0 of the first user message, without checking what already leads that message.

When a client replays a history that starts mid tool-exchange, the first user message is the `tool_result` carrier. Anthropic requires that message to lead with its `tool_result` blocks, so the request is rejected:

```
messages.2: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_1
```

The sibling injector `prependClaudeSystemRemindersToFirstUserMessage` already guards this. `injectClaudeCodeCurrentDate` had the same guard until `3fac4a09`, which replaced the insert-index loop with an unconditional index-0 insertion and removed the `tool_result` case from its regression test in the same commit.

## Change

Advance the insert index past leading `tool_result` blocks before inserting the date block, matching the sibling injector:

```go
insertAt := 0
for insertAt < len(rawBlocks) && gjson.Parse(rawBlocks[insertAt]).Get("type").String() == "tool_result" {
    insertAt++
}
rawBlocks = append(rawBlocks, "")
copy(rawBlocks[insertAt+1:], rawBlocks[insertAt:])
rawBlocks[insertAt] = dateBlock
```

Only the `tool_result` skip is restored. The pre-`3fac4a09` loop also skipped leading `<system-reminder>` blocks. That part stays out, so `TestInjectClaudeCodeCurrentDatePrecedesExistingReminder` keeps its current expectation. Every content shape that does not lead with `tool_result` keeps index-0 placement.

## Tests

Two regression tests added, covering one leading `tool_result` and a run of several, including idempotence and unchanged `tool_use_id` values.

Both fail on unpatched `dev` and pass with the change:

```
before
--- FAIL: TestInjectClaudeCodeCurrentDateFollowsLeadingToolResults
--- FAIL: TestInjectClaudeCodeCurrentDateFollowsAllLeadingToolResults

after
--- PASS: TestInjectClaudeCodeCurrentDateIsIdempotentAndAlignsFirstUserCache
--- PASS: TestInjectClaudeCodeCurrentDateMovesExistingCopyToFirstBlock
--- PASS: TestInjectClaudeCodeCurrentDatePrecedesExistingReminder
--- PASS: TestInjectClaudeCodeCurrentDateFollowsLeadingToolResults
--- PASS: TestInjectClaudeCodeCurrentDateFollowsAllLeadingToolResults
--- PASS: TestPrependClaudeSystemReminders_FollowsToolResultsAndIsIdempotent
--- PASS: TestInsertClaudeMidConversationSystemMessages_* (4 tests)
```

Commands run against `dev` at `fab077a0`:

```
gofmt -l <changed files>              # clean
go vet ./internal/runtime/executor/   # exit 0
go test ./internal/runtime/executor/ -count=1
go build -o test-output ./cmd/server  # exit 0
```

One disclosure on the full package run. Three tests fail in my environment:

```
TestApplyClaudeHeaders_DisableDeviceProfileStabilization
TestApplyClaudeHeaders_LegacyModePreservesConfiguredUserAgentOverrideForClaudeClients
TestClaudeExecutor_NonClaudeRequestUsesClaudeCode220CLIFingerprint
```

all with `X-Stainless-Os = "MacOS", want "Windows"`. They fail identically on a clean `dev` checkout with this change stashed, so they are pre-existing and unrelated.

No `internal/translator/**` and no `AGENTS.md` paths are touched.
