### PR TITLE
fix(responses): backfill usage.output_tokens_details for Grok Build

### DIFF
--- a/internal/runtime/executor/helps/responses_usage_helpers.go
+++ b/internal/runtime/executor/helps/responses_usage_helpers.go
@@ -2,6 +2,8 @@ package helps
 
 import (
 	"bytes"
+	"strconv"
+	"strings"
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -80,29 +82,52 @@ func ensureUsageDetailsAt(jsonBody []byte, path string) []byte {
 		return jsonBody
 	}
 
-	outputDetails := usageNode.Get("output_tokens_details")
-	if !outputDetails.Exists() {
-		jsonBody, _ = sjson.SetBytes(jsonBody, path+".output_tokens_details.reasoning_tokens", 0)
-	} else if outputDetails.Type == gjson.Null || !outputDetails.IsObject() {
-		jsonBody, _ = sjson.SetRawBytes(jsonBody, path+".output_tokens_details", []byte(`{"reasoning_tokens":0}`))
-	} else {
-		reasoning := outputDetails.Get("reasoning_tokens")
-		if !reasoning.Exists() || reasoning.Type == gjson.Null {
-			jsonBody, _ = sjson.SetBytes(jsonBody, path+".output_tokens_details.reasoning_tokens", 0)
-		}
-	}
-
-	inputDetails := usageNode.Get("input_tokens_details")
-	if !inputDetails.Exists() {
-		jsonBody, _ = sjson.SetBytes(jsonBody, path+".input_tokens_details.cached_tokens", 0)
-	} else if inputDetails.Type == gjson.Null || !inputDetails.IsObject() {
-		jsonBody, _ = sjson.SetRawBytes(jsonBody, path+".input_tokens_details", []byte(`{"cached_tokens":0}`))
-	} else {
-		cached := inputDetails.Get("cached_tokens")
-		if !cached.Exists() || cached.Type == gjson.Null {
-			jsonBody, _ = sjson.SetBytes(jsonBody, path+".input_tokens_details.cached_tokens", 0)
-		}
-	}
-
+	jsonBody = ensureUsageCounter(jsonBody, usageNode, path, "output_tokens_details", "reasoning_tokens", "completion_tokens_details.reasoning_tokens")
+	jsonBody = ensureUsageCounter(jsonBody, usageNode, path, "input_tokens_details", "cached_tokens", "prompt_tokens_details.cached_tokens")
 	return jsonBody
+}
+
+func ensureUsageCounter(jsonBody []byte, usageNode gjson.Result, usagePath, detailsField, counterField, fallbackPath string) []byte {
+	details := usageNode.Get(detailsField)
+	if !details.Exists() || details.Type == gjson.Null || !details.IsObject() {
+		jsonBody, _ = sjson.SetBytes(jsonBody, usagePath+"."+detailsField+"."+counterField, usageCounterValue(gjson.Result{}, usageNode.Get(fallbackPath)))
+		return jsonBody
+	}
+	counter := details.Get(counterField)
+	if counter.Type == gjson.Number {
+		return jsonBody
+	}
+	jsonBody, _ = sjson.SetBytes(jsonBody, usagePath+"."+detailsField+"."+counterField, usageCounterValue(counter, usageNode.Get(fallbackPath)))
+	return jsonBody
+}
+
+func usageCounterValue(primary, fallback gjson.Result) int64 {
+	if n, ok := parseUsageCounter(primary); ok {
+		return n
+	}
+	if n, ok := parseUsageCounter(fallback); ok {
+		return n
+	}
+	return 0
+}
+
+func parseUsageCounter(node gjson.Result) (int64, bool) {
+	switch node.Type {
+	case gjson.Number:
+		return node.Int(), true
+	case gjson.String:
+		s := strings.TrimSpace(node.String())
+		if s == "" {
+			return 0, false
+		}
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return n, true
+		}
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			return int64(f), true
+		}
+		return 0, false
+	default:
+		return 0, false
+	}
 }

--- a/internal/runtime/executor/helps/responses_usage_helpers_test.go
+++ b/internal/runtime/executor/helps/responses_usage_helpers_test.go
@@ -120,6 +120,26 @@ func TestEnsureResponsesUsageDetails_HandlesNullOrEmptyDetails(t *testing.T) {
 	}
 }
 
+func TestEnsureResponsesUsageDetails_CoercesNonNumericCounters(t *testing.T) {
+	raw := []byte(`{"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":"3"},"output_tokens":4,"output_tokens_details":{"reasoning_tokens":"5"},"total_tokens":14}}`)
+	got := EnsureResponsesUsageDetails(raw)
+	if node := gjson.GetBytes(got, "usage.output_tokens_details.reasoning_tokens"); node.Type != gjson.Number || node.Int() != 5 {
+		t.Fatalf("reasoning_tokens = %s, want number 5", got)
+	}
+	if node := gjson.GetBytes(got, "usage.input_tokens_details.cached_tokens"); node.Type != gjson.Number || node.Int() != 3 {
+		t.Fatalf("cached_tokens = %s, want number 3", got)
+	}
+
+	invalid := []byte(`{"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":false},"output_tokens":4,"output_tokens_details":{"reasoning_tokens":null},"completion_tokens_details":{"reasoning_tokens":7},"total_tokens":14}}`)
+	got = EnsureResponsesUsageDetails(invalid)
+	if node := gjson.GetBytes(got, "usage.output_tokens_details.reasoning_tokens"); node.Type != gjson.Number || node.Int() != 7 {
+		t.Fatalf("null reasoning_tokens should fall back to 7, got %s", got)
+	}
+	if node := gjson.GetBytes(got, "usage.input_tokens_details.cached_tokens"); node.Type != gjson.Number || node.Int() != 0 {
+		t.Fatalf("false cached_tokens should become 0, got %s", got)
+	}
+}
+
 func TestEnsureResponsesUsageDetails_NonJSONAndDone(t *testing.T) {
 	cases := [][]byte{
 		[]byte("data: [DONE]"),


### PR DESCRIPTION
## Summary
Follow-up on `e0b49562` (`fix(openai): ensure Responses usage includes token detail fields`), which already landed the shared helper and executor hooks for #4985.

This PR rebases onto current `dev` and keeps only the remaining gap: strict Responses clients still reject usage when `reasoning_tokens` / `cached_tokens` is a non-number (`"5"`, `false`, leftover `null`).

## Change
In `helps.EnsureResponsesUsageDetails`:

- Leave numeric counters unchanged
- Coerce parseable strings to numbers
- Otherwise fill from the legacy `completion_tokens_details` / `prompt_tokens_details` field, or `0`

## Test plan
- [x] `go test ./internal/runtime/executor/helps/`
- [x] `go test ./internal/runtime/executor/helps/ -run TestEnsureResponsesUsageDetails`

Fixes #4985

Related: #4218 #4479 #4498 #4783
