### PR TITLE
fix(thinking): keep client thinking config for uncatalogued models

### DIFF
--- a/internal/modelconfig/model_info.go
+++ b/internal/modelconfig/model_info.go
@@ -10,10 +10,21 @@ import (
 // ResolveModelInfo returns a private capability snapshot for a configured model.
 // Static capabilities come from the suffix-free upstream name, while explicit
 // configuration takes precedence.
+//
+// Capability absence is only authoritative when it is actually known. A model the
+// bundled catalog does not carry, configured without an explicit thinking block,
+// has *unknown* reasoning capability — not a proven absent one. Such a snapshot is
+// marked user-defined so downstream thinking application forwards the caller's
+// configuration and lets the upstream service validate it, instead of stripping
+// generationConfig.thinkingConfig as it would for a catalog model documented to
+// have no reasoning support. Without this distinction every model newer than the
+// embedded catalog silently loses reasoning: the upstream still bills thinking
+// tokens while returning no thought parts, because includeThoughts never arrives.
 func ResolveModelInfo(name, modelType string, support *registry.ThinkingSupport) *registry.ModelInfo {
 	trimmedName := strings.TrimSpace(name)
 	baseName := strings.TrimSpace(thinking.ParseSuffix(trimmedName).ModelName)
 	info := registry.LookupStaticModelInfo(baseName)
+	catalogKnown := info != nil
 	if info == nil {
 		info = &registry.ModelInfo{}
 	}
@@ -22,7 +33,7 @@ func ResolveModelInfo(name, modelType string, support *registry.ThinkingSupport)
 	if support != nil {
 		info.Thinking = NormalizeThinkingSupport(support)
 	}
-	info.UserDefined = false
+	info.UserDefined = !catalogKnown && support == nil
 	return info
 }
 

--- a/internal/modelconfig/model_info_test.go
+++ b/internal/modelconfig/model_info_test.go
@@ -55,7 +55,11 @@ func TestResolveModelInfoUnknownModelKeepsMissingCapability(t *testing.T) {
 	if info.Thinking != nil {
 		t.Fatalf("unknown model thinking = %+v, want nil", info.Thinking)
 	}
-	if info.UserDefined {
-		t.Fatal("unknown configured model must use its exact bound capability")
+	// A model the bundled catalog does not carry has unknown — not proven absent —
+	// reasoning capability, so the snapshot stays user-defined and the caller's
+	// thinking configuration reaches the upstream for validation. See
+	// model_info_unknown_thinking_test.go for the end-to-end guarantee.
+	if !info.UserDefined {
+		t.Fatal("unknown configured model must keep unknown capability semantics")
 	}
 }

--- a/internal/modelconfig/model_info_unknown_thinking_test.go
+++ b/internal/modelconfig/model_info_unknown_thinking_test.go
@@ -1,0 +1,75 @@
+package modelconfig
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	"github.com/tidwall/gjson"
+)
+
+// TestResolveModelInfoUnknownModelKeepsClientThinkingConfig pins the behaviour
+// that a configured model missing from the bundled catalog must not silently
+// lose the caller's thinking configuration.
+//
+// Regression: a Gemini API key configured with a model newer than the embedded
+// models.json (e.g. gemini-3.7-flash) resolved to an empty capability snapshot
+// with Thinking == nil and UserDefined == false. applyThinking read that as
+// "this model provably cannot think" and stripped generationConfig.thinkingConfig
+// before dispatch, so the upstream received no includeThoughts and returned no
+// thought parts while still billing thinking tokens.
+func TestResolveModelInfoUnknownModelKeepsClientThinkingConfig(t *testing.T) {
+	const unknownModel = "gemini-3.7-flash-not-in-catalog"
+
+	info := ResolveModelInfo(unknownModel, "gemini", nil)
+	if info == nil {
+		t.Fatal("ResolveModelInfo() = nil")
+	}
+	if info.Thinking != nil {
+		t.Fatalf("unknown model thinking = %+v, want nil (no capability was resolved)", info.Thinking)
+	}
+	if !info.UserDefined {
+		t.Fatal("unknown configured model must be treated as unknown capability, not proven-absent")
+	}
+
+	body := []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}],` +
+		`"generationConfig":{"thinkingConfig":{"includeThoughts":true,"thinkingBudget":2048}}}`)
+	out, err := thinking.ApplyThinkingWithModelInfoAndSummary(
+		body, body, unknownModel, "gemini", "gemini", "gemini", info,
+		thinking.SummaryConfig{Mode: thinking.SummaryEnabled, Detail: "auto"},
+	)
+	if err != nil {
+		t.Fatalf("ApplyThinkingWithModelInfoAndSummary() error = %v", err)
+	}
+	if include := gjson.GetBytes(out, "generationConfig.thinkingConfig.includeThoughts"); !include.Exists() || !include.Bool() {
+		t.Fatalf("includeThoughts = %v (exists=%v), want true; body=%s", include.Bool(), include.Exists(), out)
+	}
+	if budget := gjson.GetBytes(out, "generationConfig.thinkingConfig.thinkingBudget"); !budget.Exists() || budget.Int() != 2048 {
+		t.Fatalf("thinkingBudget = %d (exists=%v), want 2048; body=%s", budget.Int(), budget.Exists(), out)
+	}
+}
+
+// TestResolveModelInfoCatalogKnownWithoutThinkingStaysAuthoritative keeps the
+// opposite guarantee: when the bundled catalog knows the model and records no
+// thinking support, that absence is authoritative and the config must still be
+// stripped rather than forwarded.
+func TestResolveModelInfoCatalogKnownWithoutThinkingStaysAuthoritative(t *testing.T) {
+	var known string
+	for _, candidate := range []string{"claude-3-5-haiku-20241022", "imagen-4.0-generate-001", "kimi-k2"} {
+		if static := registry.LookupStaticModelInfo(candidate); static != nil && static.Thinking == nil {
+			known = candidate
+			break
+		}
+	}
+	if known == "" {
+		t.Skip("no catalog model without thinking support available in this build")
+	}
+
+	info := ResolveModelInfo(known, "gemini", nil)
+	if info == nil {
+		t.Fatal("ResolveModelInfo() = nil")
+	}
+	if info.UserDefined {
+		t.Fatalf("catalog-known model %q must keep its authoritative capability", known)
+	}
+}

--- a/sdk/cliproxy/auth/api_key_model_capabilities_test.go
+++ b/sdk/cliproxy/auth/api_key_model_capabilities_test.go
@@ -207,8 +207,13 @@ func TestAttachResolvedAPIKeyModelInfoBindsUnknownConfiguredCapability(t *testin
 
 	req := manager.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, auth, "tenant/unknown-public", "unknown-upstream")
 	info, ok := ResolvedAPIKeyModelInfo(req)
-	if !ok || info == nil || info.UserDefined || info.Thinking != nil {
-		t.Fatalf("ResolvedAPIKeyModelInfo() = (%+v, %t), want authoritative empty capability", info, ok)
+	// The capability snapshot is still bound (the model is configured), but a model
+	// absent from the bundled catalog and configured without an explicit thinking
+	// block carries unknown reasoning capability: Thinking stays nil while
+	// UserDefined marks the absence as unproven, so thinking application forwards
+	// the caller's configuration instead of stripping it.
+	if !ok || info == nil || !info.UserDefined || info.Thinking != nil {
+		t.Fatalf("ResolvedAPIKeyModelInfo() = (%+v, %t), want unknown-capability snapshot", info, ok)
 	}
 	fallbackReq := manager.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, auth, "tenant/not-configured", "not-configured")
 	if fallbackInfo, fallbackOK := ResolvedAPIKeyModelInfo(fallbackReq); fallbackOK || fallbackInfo != nil {


### PR DESCRIPTION
## Problem

When a model was configured via API key (`*-api-key.models[]`) but was not present in the embedded `internal/registry/models/models.json` catalog (e.g. newly released models like `gemini-2.5-flash` or custom provider endpoints), `ResolveModelInfo` set `info.UserDefined = false` with `info.Thinking = nil`.

Downstream, `ApplyThinkingWithModelInfoAndSummary` interpreted `Thinking == nil && !UserDefined` as authoritative proof that the model lacks reasoning capabilities, stripping `generationConfig.thinkingConfig` (`includeThoughts`). Upstream providers executed and billed the thinking pass while returning no thought parts because `includeThoughts` was stripped.

## Fix

- In `internal/modelconfig/model_info.go:25`, track `catalogKnown := info != nil`.
- In `internal/modelconfig/model_info.go:34`, set `info.UserDefined = !catalogKnown && support == nil` instead of unconditionally defaulting to `false`.
- Uncatalogued models without explicit thinking blocks retain `UserDefined = true` with `Thinking == nil`, allowing client thinking configurations to pass through to upstream for validation rather than being prematurely stripped.
- Catalog-known models documented without reasoning keep authoritative absence (`UserDefined = false`), preserving intentional stripping.

## Tests

- `TestResolveModelInfoUnknownModelKeepsClientThinkingConfig`: verifies uncatalogued models preserve client `includeThoughts` and `thinkingBudget` through thinking application.
- `TestResolveModelInfoCatalogKnownWithoutThinkingStaysAuthoritative`: verifies catalog-known models without reasoning support maintain authoritative stripping.
- `TestResolveModelInfoUnknownModelKeepsMissingCapability`: validates that uncatalogued configured models retain `UserDefined = true`.
- `TestAttachResolvedAPIKeyModelInfoBindsUnknownConfiguredCapability`: validates that bound capability snapshots for uncatalogued API key models preserve unknown reasoning semantics.

## Reverse Bite-Check

Verbatim test failure output when `internal/modelconfig/model_info.go` is reverted to `origin/dev`:

```text
=== RUN   TestResolveModelInfoUnknownModelKeepsMissingCapability
    model_info_test.go:63: unknown configured model must keep unknown capability semantics
--- FAIL: TestResolveModelInfoUnknownModelKeepsMissingCapability (0.00s)
=== RUN   TestResolveModelInfoUnknownModelKeepsClientThinkingConfig
    model_info_unknown_thinking_test.go:32: unknown configured model must be treated as unknown capability, not proven-absent
--- FAIL: TestResolveModelInfoUnknownModelKeepsClientThinkingConfig (0.00s)
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/internal/modelconfig	0.625s
=== RUN   TestAttachResolvedAPIKeyModelInfoBindsUnknownConfiguredCapability
    api_key_model_capabilities_test.go:216: ResolvedAPIKeyModelInfo() = (&{ID:unknown-upstream Object: Created:0 OwnedBy: Type:claude DisplayName: Name: Version: Description: InputTokenLimit:0 OutputTokenLimit:0 SupportedGenerationMethods:[] ContextLength:0 MaxContextLength:0 MaxCompletionTokens:0 SupportedParameters:[] SupportedInputModalities:[] SupportedOutputModalities:[] SupportsWebSearch:false Thinking:<nil> Config:<nil> UserDefined:false IsCompat:false}, true), want unknown-capability snapshot
--- FAIL: TestAttachResolvedAPIKeyModelInfoBindsUnknownConfiguredCapability (0.00s)
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth	0.503s
FAIL
```

## Verification

```bash
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go build ./...
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go vet ./internal/modelconfig/... ./sdk/cliproxy/auth/...
gofmt -l internal/modelconfig/model_info.go internal/modelconfig/model_info_test.go internal/modelconfig/model_info_unknown_thinking_test.go sdk/cliproxy/auth/api_key_model_capabilities_test.go
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go test -count=1 ./internal/modelconfig/... ./sdk/cliproxy/auth/...
```

All commands executed successfully (exit code 0).

### Tooling note

The `jbcontext` semantic-search CLI is installed but non-functional in this environment
(`jbcontext search` fails with `the OS keychain is not accessible`). The equivalent
review passes were performed with the repository's own tooling and manual inspection
instead; this is disclosed for transparency about how the change was reviewed.
