### PR TITLE
fix(auth): do not cooldown credentials on transport-level failures

### DIFF
--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1369,15 +1369,20 @@ func vertexSALocation(auth *Auth) string {
 // (auth.Disabled or Status StatusDisabled) and peers currently blocked for
 // the model (quota cooldown, retry-after, or auth-level unavailability, as
 // judged by isAuthBlockedForModel) cannot serve requests, so they are ignored
-// when judging whether an alternative endpoint exists. When pollable peers
-// exist, a transport failure is specific to this auth's endpoint and rotation
-// can only reach a healthy credential if this auth cools down. Caller must
-// hold m.mu.
+// when judging whether an alternative endpoint exists. Peers that do not
+// support the route model (per authSupportsRouteModel, the same judgment
+// request selection applies) can never be picked for this model and are
+// ignored too, otherwise a healthy but model-ineligible peer would hide the
+// endpoint uniqueness and leave polling stuck on the failing auth. When
+// pollable peers exist, a transport failure is specific to this auth's
+// endpoint and rotation can only reach a healthy credential if this auth
+// cools down. Caller must hold m.mu.
 func (m *Manager) vertexTransportFailureIsAuthSpecificLocked(auth *Auth, modelKey string, now time.Time) bool {
 	loc := vertexSALocation(auth)
 	if loc == "" {
 		return false
 	}
+	registryRef := registry.GetGlobalRegistry()
 	hasPeer := false
 	for _, peer := range m.auths {
 		if peer == nil || peer.ID == auth.ID {
@@ -1391,6 +1396,9 @@ func (m *Manager) vertexTransportFailureIsAuthSpecificLocked(auth *Auth, modelKe
 		}
 		peerLoc := vertexSALocation(peer)
 		if peerLoc == "" {
+			continue
+		}
+		if !m.authSupportsRouteModel(registryRef, peer, modelKey) {
 			continue
 		}
 		hasPeer = true

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -743,7 +743,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			}
 		} else {
 			if modelKey != "" {
-				if !shouldSkipCredentialCooldown(result.Error) {
+				if !shouldSkipCredentialCooldownForAuth(result.Error, auth) {
 					disableCooling := m.cooldownDisabledForAuth(auth)
 					state := ensureModelState(auth, modelKey)
 					state.Unavailable = true
@@ -1309,6 +1309,38 @@ func shouldSkipCredentialCooldown(err *Error) bool {
 	return isRequestScopedResultError(err) || isConnectionLifecycleResultError(err)
 }
 
+// shouldSkipCredentialCooldownForAuth reports failures that must not mark auth/model cooling.
+// Transport-level failures still cool down credentials that carry their own proxy
+// override, because those failures indicate auth-specific routing problems.
+func shouldSkipCredentialCooldownForAuth(err *Error, auth *Auth) bool {
+	if !shouldSkipCredentialCooldown(err) {
+		return false
+	}
+	if isTransportFailureResultError(err) && authHasProxyOverride(auth) {
+		return false
+	}
+	return true
+}
+
+// authHasProxyOverride reports whether the auth carries its own proxy configuration.
+// Transport failures through a per-auth proxy are auth-specific routing faults,
+// not shared network outages, so they should keep credential cooldown.
+func authHasProxyOverride(auth *Auth) bool {
+	return auth != nil && strings.TrimSpace(auth.ProxyURL) != ""
+}
+
+// isTransportFailureResultError reports whether the result error is classified as a
+// transport-level failure (as opposed to client cancellation or stream EOF), so
+// callers can restore cooldown when the failure is auth-specific. Only errors that
+// were classified connection-lifecycle, carry no HTTP status, and whose message
+// matches a transport pattern qualify.
+func isTransportFailureResultError(err *Error) bool {
+	if err == nil || statusCodeFromResult(err) != 0 {
+		return false
+	}
+	return hasTransportFailureMessage(err.Message)
+}
+
 // isConnectionLifecycleError reports transport/session lifecycle failures that must
 // not cool credentials: client cancellation, WebSocket close/EOF disconnects, and
 // transport-level dial/TLS/write failures that carry no credential signal.
@@ -1371,6 +1403,16 @@ func isConnectionLifecycleMessage(message string) bool {
 	}
 	// Transport-level failures (dial, DNS, TLS handshake, write) never indicate
 	// credential health, so they must not cool credentials either.
+	return hasTransportFailureMessage(lower)
+}
+
+// hasTransportFailureMessage reports whether a message matches a known transport-level
+// failure pattern (dial, DNS, TLS handshake, proxy connect, read/write timeouts).
+func hasTransportFailureMessage(message string) bool {
+	lower := strings.ToLower(strings.TrimSpace(message))
+	if lower == "" {
+		return false
+	}
 	for _, pattern := range transportFailureMessagePatterns {
 		if strings.Contains(lower, pattern) {
 			return true
@@ -1824,7 +1866,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	if auth == nil {
 		return
 	}
-	if shouldSkipCredentialCooldown(resultErr) {
+	if shouldSkipCredentialCooldownForAuth(resultErr, auth) {
 		return
 	}
 	defer func() {

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1327,13 +1327,16 @@ func shouldSkipCredentialCooldownForAuth(err *Error, auth *Auth) bool {
 // pool-aware Vertex regional-endpoint disambiguation. A transport failure on
 // a Vertex service-account auth whose regional endpoint is unique in the pool
 // (other Vertex service-account auths exist, none sharing its location) is an
-// auth-specific routing fault and must keep credential cooldown. Caller must
-// hold m.mu.
+// auth-specific routing fault and must keep credential cooldown. Failures in
+// the shared proxy dial layer never reach a regional endpoint, so they are
+// never attributed to one. Caller must hold m.mu.
 func (m *Manager) shouldSkipCredentialCooldownPoolAware(err *Error, auth *Auth) bool {
 	if !shouldSkipCredentialCooldownForAuth(err, auth) {
 		return false
 	}
-	if isTransportFailureResultError(err) && m.vertexTransportFailureIsAuthSpecificLocked(auth) {
+	if isTransportFailureResultError(err) &&
+		!isProxyConnectFailureMessage(err.Message) &&
+		m.vertexTransportFailureIsAuthSpecificLocked(auth) {
 		return false
 	}
 	return true
@@ -1484,6 +1487,16 @@ func hasTransportFailureMessage(message string) bool {
 	return false
 }
 
+// isProxyConnectFailureMessage reports whether a message indicates a failure
+// establishing the proxy connection itself (e.g. "proxyconnect tcp: dial tcp
+// 127.0.0.1:7890: connect: connection refused"). Such failures occur in the
+// shared proxy dial layer before any provider regional endpoint is reached, so
+// they must not be attributed to a Vertex location endpoint.
+func isProxyConnectFailureMessage(message string) bool {
+	lower := strings.ToLower(strings.TrimSpace(message))
+	return lower != "" && strings.Contains(lower, "proxyconnect tcp")
+}
+
 // transportFailureMessagePatterns are lowercase substrings identifying
 // transport-level failures such as "net/http: TLS handshake timeout",
 // "dial tcp ...: connect: connection refused" or "read tcp ...: i/o timeout".
@@ -1498,6 +1511,9 @@ var transportFailureMessagePatterns = []string{
 	"proxyconnect tcp",
 	"i/o timeout",
 	"tls handshake timeout",
+	"connection timed out",
+	"operation timed out",
+	"server misbehaving",
 }
 
 func isUnauthorizedError(err error) bool {

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1311,37 +1311,35 @@ func shouldSkipCredentialCooldown(err *Error) bool {
 	return isRequestScopedResultError(err) || isConnectionLifecycleResultError(err)
 }
 
-// shouldSkipCredentialCooldownForAuth reports failures that must not mark auth/model cooling.
-// Transport-level failures still cool down credentials that carry their own proxy
-// override, because those failures indicate auth-specific routing problems.
-func shouldSkipCredentialCooldownForAuth(err *Error, auth *Auth) bool {
+// shouldSkipCredentialCooldownPoolAware extends the per-auth check with
+// pool-aware judgments. A transport failure through a per-auth proxy that is
+// shared with another pollable credential (same ProxyURL) is a shared
+// infrastructure fault and must not cool the failing credential down; a proxy
+// used by a single credential remains an auth-specific routing fault and
+// keeps cooldown. A transport failure on a Vertex service-account auth whose
+// regional endpoint is unique among the selectable Vertex service-account
+// auths (other auths exist, none sharing its location and currently pickable
+// for the model) is likewise an auth-specific routing fault and must keep
+// credential cooldown. Only failure messages that can point to the failing
+// endpoint are attributed; shared-host faults (network unreachable, DNS
+// server misbehaving, operation timed out) and proxy dial failures never
+// reach a regional endpoint and are never attributed to one. Caller must hold
+// m.mu.
+func (m *Manager) shouldSkipCredentialCooldownPoolAware(err *Error, auth *Auth, modelKey string, now time.Time) bool {
 	if !shouldSkipCredentialCooldown(err) {
 		return false
 	}
-	if isTransportFailureResultError(err) && authHasProxyOverride(auth) {
-		return false
-	}
-	return true
-}
-
-// shouldSkipCredentialCooldownPoolAware extends the per-auth check with
-// pool-aware Vertex regional-endpoint disambiguation. A transport failure on
-// a Vertex service-account auth whose regional endpoint is unique among the
-// pollable Vertex service-account auths (other auths exist, none sharing its
-// location and currently available for the model) is an auth-specific routing
-// fault and must keep credential cooldown. Only failure messages that can
-// point to the failing endpoint are attributed; shared-host faults (network
-// unreachable, DNS server misbehaving, operation timed out) and proxy dial
-// failures never reach a regional endpoint and are never attributed to one.
-// Caller must hold m.mu.
-func (m *Manager) shouldSkipCredentialCooldownPoolAware(err *Error, auth *Auth, modelKey string, now time.Time) bool {
-	if !shouldSkipCredentialCooldownForAuth(err, auth) {
-		return false
-	}
-	if isTransportFailureResultError(err) &&
-		isVertexEndpointFailureMessage(err.Message) &&
-		m.vertexTransportFailureIsAuthSpecificLocked(auth, modelKey, now) {
-		return false
+	if isTransportFailureResultError(err) {
+		if authHasProxyOverride(auth) {
+			// A per-auth proxy makes the transport failure auth-specific
+			// unless another pollable credential shares the same proxy
+			// endpoint, in which case the fault is a shared proxy outage.
+			return m.authHasSharedProxyPeerLocked(auth, modelKey, now)
+		}
+		if isVertexEndpointFailureMessage(err.Message) &&
+			m.vertexTransportFailureIsAuthSpecificLocked(auth, modelKey, now) {
+			return false
+		}
 	}
 	return true
 }
@@ -1369,43 +1367,57 @@ func vertexSALocation(auth *Auth) string {
 
 // vertexTransportFailureIsAuthSpecificLocked reports whether the given Vertex
 // service-account auth routes through a regional endpoint that no other
-// pollable Vertex service-account auth in the pool shares. Peers currently
-// blocked for the model (disabled, quota cooldown, retry-after, or auth-level
-// unavailability, as judged by isAuthBlockedForModel) cannot serve requests,
-// so they are ignored when judging whether an alternative endpoint exists.
-// Peers that do not support the route model (per authSupportsRouteModel, the
-// same judgment request selection applies) can never be picked for this model
-// and are ignored too, otherwise a healthy but model-ineligible peer would
-// hide the endpoint uniqueness and leave polling stuck on the failing auth.
-// On the auth-level path (empty model key) authSupportsRouteModel is always
-// true, so peers are not filtered by model; this limitation only affects SDK
-// users who call Manager.MarkResult directly with an empty Model, since the
-// production path always sets result.Model. When pollable peers exist, a
-// transport failure is specific to this auth's endpoint and rotation can only
-// reach a healthy credential if this auth cools down. Caller must hold m.mu.
+// selectable Vertex service-account auth in the pool shares. Peers are judged
+// exactly like the request-selection candidate set: pollable (disabled, quota
+// cooldown, retry-after, or auth-level unavailability, as judged by
+// isAuthBlockedForModel, cannot serve requests), route-model eligible (per
+// authSupportsRouteModel, the same judgment request selection applies),
+// restricted to the current highest available priority tier (matching
+// availableAuthsForRouteModel's allPriorities=false semantics so lower
+// priority peers cannot hide endpoint uniqueness), and to positive weights
+// when the strategy is weighted (see isWeightedSelector). Peers outside this
+// set can never be picked for this model, so they must not hide the endpoint
+// uniqueness, otherwise a healthy but unreachable peer would leave polling
+// stuck on the failing auth. On the auth-level path (empty model key)
+// authSupportsRouteModel is always true, so peers are not filtered by model;
+// this limitation only affects SDK users who call Manager.MarkResult directly
+// with an empty Model, since the production path always sets result.Model.
+// When selectable peers exist, a transport failure is specific to this auth's
+// endpoint and rotation can only reach a healthy credential if this auth
+// cools down. Caller must hold m.mu.
 func (m *Manager) vertexTransportFailureIsAuthSpecificLocked(auth *Auth, modelKey string, now time.Time) bool {
 	loc := vertexSALocation(auth)
 	if loc == "" {
 		return false
 	}
+	peers := m.vertexPeerCandidatesLocked(auth, modelKey, now)
+	if len(peers) == 0 {
+		return false
+	}
+	for _, peer := range peers {
+		if vertexSALocation(peer) == loc {
+			return false
+		}
+	}
+	return true
+}
+
+// vertexPeerCandidatesLocked returns the Vertex service-account peers that
+// request selection could actually pick for the same model, mirroring the
+// selector's candidate set: pollable, route-model eligible, restricted to the
+// current highest available priority tier, and to positive weights when the
+// selector is weighted. It reuses availableAuthsForSelector, which never
+// takes m.mu, so it is safe under the caller-held lock. Caller must hold m.mu.
+func (m *Manager) vertexPeerCandidatesLocked(auth *Auth, modelKey string, now time.Time) []*Auth {
+	candidates := make([]*Auth, 0, len(m.auths))
 	registryRef := registry.GetGlobalRegistry()
-	hasPeer := false
 	for _, peer := range m.auths {
 		if peer == nil || peer.ID == auth.ID {
 			continue
 		}
 		// Skip non-service-account peers first: they have no regional
 		// endpoint to compare, so avoid the blocked/model checks on them.
-		peerLoc := vertexSALocation(peer)
-		if peerLoc == "" {
-			continue
-		}
-		// Under a weighted selection strategy peers with a non-positive weight
-		// are never picked for this model (see positiveWeightAuths), so they
-		// cannot serve requests and must not hide endpoint uniqueness. The
-		// default round-robin strategy ignores weights entirely and keeps the
-		// legacy peer set. Caller holds m.mu, so reading m.selector is safe.
-		if _, weighted := m.selector.(*WeightedRoundRobinSelector); weighted && authWeight(peer) <= 0 {
+		if vertexSALocation(peer) == "" {
 			continue
 		}
 		if blocked, _, _ := isAuthBlockedForModel(peer, modelKey, now); blocked {
@@ -1414,22 +1426,96 @@ func (m *Manager) vertexTransportFailureIsAuthSpecificLocked(auth *Auth, modelKe
 		if !m.authSupportsRouteModel(registryRef, peer, modelKey) {
 			continue
 		}
-		hasPeer = true
-		if peerLoc == loc {
+		candidates = append(candidates, peer)
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	priorityTier, _, errAvailable := m.availableAuthsForSelector(m.selector, candidates, provider, modelKey, now)
+	if errAvailable != nil {
+		return nil
+	}
+	// Under a weighted selection strategy peers with a non-positive weight are
+	// never picked for this model (see positiveWeightAuths), so they cannot
+	// serve requests and must not hide endpoint uniqueness. The default
+	// round-robin strategy ignores weights entirely and keeps the legacy peer
+	// set. Caller holds m.mu, so reading m.selector is safe.
+	if isWeightedSelector(m.selector) {
+		priorityTier = positiveWeightAuths(priorityTier)
+	}
+	return priorityTier
+}
+
+// isWeightedSelector reports whether the selector routes through a
+// WeightedRoundRobinSelector, either directly or as the fallback of a
+// SessionAffinitySelector. Both configurations exclude non-positive-weight
+// auths before picking (positiveWeightAuths), so peer-eligibility judgments
+// that mirror selection must apply the same exclusion.
+func isWeightedSelector(selector Selector) bool {
+	switch sel := selector.(type) {
+	case *WeightedRoundRobinSelector:
+		return true
+	case *SessionAffinitySelector:
+		if sel == nil {
 			return false
 		}
+		_, weighted := sel.fallback.(*WeightedRoundRobinSelector)
+		return weighted
+	default:
+		return false
 	}
-	return hasPeer
+}
+
+// authHasSharedProxyPeerLocked reports whether another pollable credential
+// routes through the same per-auth proxy endpoint as auth (ProxyURL compared
+// after TrimSpace). When the proxy is shared, a transport failure against it
+// is a shared infrastructure fault: cooling the failing credential would only
+// drain the pool, since its peers hit the same dead endpoint. Peers currently
+// blocked for the model (isAuthBlockedForModel) or ineligible for the route
+// model (authSupportsRouteModel, model-level path only) cannot serve requests
+// and are ignored, so a single-credential dedicated proxy keeps restoring
+// cooldown. On the auth-level path (empty model key) model support is always
+// true, so peers are not filtered by model; this limitation only affects SDK
+// users who call Manager.MarkResult directly with an empty Model, since the
+// production path always sets result.Model. Caller must hold m.mu.
+func (m *Manager) authHasSharedProxyPeerLocked(auth *Auth, modelKey string, now time.Time) bool {
+	if auth == nil {
+		return false
+	}
+	proxyURL := strings.TrimSpace(auth.ProxyURL)
+	if proxyURL == "" {
+		return false
+	}
+	registryRef := registry.GetGlobalRegistry()
+	for _, peer := range m.auths {
+		if peer == nil || peer.ID == auth.ID {
+			continue
+		}
+		if strings.TrimSpace(peer.ProxyURL) != proxyURL {
+			continue
+		}
+		if blocked, _, _ := isAuthBlockedForModel(peer, modelKey, now); blocked {
+			continue
+		}
+		if modelKey != "" && !m.authSupportsRouteModel(registryRef, peer, modelKey) {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // authHasProxyOverride reports whether the auth carries its own proxy
 // configuration. Transport failures through a per-auth proxy are auth-specific
 // routing faults, not shared network outages, so they should keep credential
-// cooldown. The judgment mirrors proxyutil.Parse: only a real proxy mode
-// (ModeProxy) counts as an override; the explicit direct modes "direct"/"none"
-// (ModeDirect) and empty values (ModeInherit) route through no proxy endpoint;
-// malformed or unsupported values (ModeInvalid) are the credential's own
-// configuration problem, so cooldown is restored like a real override.
+// cooldown unless another credential shares the proxy endpoint (see
+// authHasSharedProxyPeerLocked). The judgment mirrors proxyutil.Parse: only a
+// real proxy mode (ModeProxy) counts as an override; the explicit direct
+// modes "direct"/"none" (ModeDirect) and empty values (ModeInherit) route
+// through no proxy endpoint; malformed or unsupported values (ModeInvalid)
+// are the credential's own configuration problem, so cooldown is restored
+// like a real override.
 func authHasProxyOverride(auth *Auth) bool {
 	if auth == nil {
 		return false

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1332,10 +1332,11 @@ func authHasProxyOverride(auth *Auth) bool {
 // isTransportFailureResultError reports whether the result error is classified as a
 // transport-level failure (as opposed to client cancellation or stream EOF), so
 // callers can restore cooldown when the failure is auth-specific. Only errors that
-// were classified connection-lifecycle, carry no HTTP status, and whose message
-// matches a transport pattern qualify.
+// were classified connection-lifecycle (request-scoped errors, Code "request_scoped",
+// are explicitly excluded), carry no HTTP status, and whose message matches a
+// transport pattern qualify.
 func isTransportFailureResultError(err *Error) bool {
-	if err == nil || statusCodeFromResult(err) != 0 {
+	if err == nil || err.Code != connectionLifecycleErrorCode || statusCodeFromResult(err) != 0 {
 		return false
 	}
 	return hasTransportFailureMessage(err.Message)

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1365,18 +1365,20 @@ func vertexSALocation(auth *Auth) string {
 
 // vertexTransportFailureIsAuthSpecificLocked reports whether the given Vertex
 // service-account auth routes through a regional endpoint that no other
-// pollable Vertex service-account auth in the pool shares. Disabled peers
-// (auth.Disabled or Status StatusDisabled) and peers currently blocked for
-// the model (quota cooldown, retry-after, or auth-level unavailability, as
-// judged by isAuthBlockedForModel) cannot serve requests, so they are ignored
-// when judging whether an alternative endpoint exists. Peers that do not
-// support the route model (per authSupportsRouteModel, the same judgment
-// request selection applies) can never be picked for this model and are
-// ignored too, otherwise a healthy but model-ineligible peer would hide the
-// endpoint uniqueness and leave polling stuck on the failing auth. When
-// pollable peers exist, a transport failure is specific to this auth's
-// endpoint and rotation can only reach a healthy credential if this auth
-// cools down. Caller must hold m.mu.
+// pollable Vertex service-account auth in the pool shares. Peers currently
+// blocked for the model (disabled, quota cooldown, retry-after, or auth-level
+// unavailability, as judged by isAuthBlockedForModel) cannot serve requests,
+// so they are ignored when judging whether an alternative endpoint exists.
+// Peers that do not support the route model (per authSupportsRouteModel, the
+// same judgment request selection applies) can never be picked for this model
+// and are ignored too, otherwise a healthy but model-ineligible peer would
+// hide the endpoint uniqueness and leave polling stuck on the failing auth.
+// On the auth-level path (empty model key) authSupportsRouteModel is always
+// true, so peers are not filtered by model; this limitation only affects SDK
+// users who call Manager.MarkResult directly with an empty Model, since the
+// production path always sets result.Model. When pollable peers exist, a
+// transport failure is specific to this auth's endpoint and rotation can only
+// reach a healthy credential if this auth cools down. Caller must hold m.mu.
 func (m *Manager) vertexTransportFailureIsAuthSpecificLocked(auth *Auth, modelKey string, now time.Time) bool {
 	loc := vertexSALocation(auth)
 	if loc == "" {
@@ -1388,14 +1390,13 @@ func (m *Manager) vertexTransportFailureIsAuthSpecificLocked(auth *Auth, modelKe
 		if peer == nil || peer.ID == auth.ID {
 			continue
 		}
-		if peer.Disabled || peer.Status == StatusDisabled {
+		// Skip non-service-account peers first: they have no regional
+		// endpoint to compare, so avoid the blocked/model checks on them.
+		peerLoc := vertexSALocation(peer)
+		if peerLoc == "" {
 			continue
 		}
 		if blocked, _, _ := isAuthBlockedForModel(peer, modelKey, now); blocked {
-			continue
-		}
-		peerLoc := vertexSALocation(peer)
-		if peerLoc == "" {
 			continue
 		}
 		if !m.authSupportsRouteModel(registryRef, peer, modelKey) {
@@ -1515,11 +1516,12 @@ func hasTransportFailureMessage(message string) bool {
 // endpoint itself qualify: NXDOMAIN ("no such host"), refused/reset
 // connections, broken pipes, dial/read timeouts and TLS handshake timeouts.
 // Shared-host or shared-layer faults ("network is unreachable", DNS "server
-// misbehaving", "operation timed out") and "proxyconnect tcp" proxy dial
-// failures do not prove the endpoint failed and are never attributed.
+// misbehaving", "operation timed out") and proxy dial failures
+// ("proxyconnect tcp" for HTTP proxies, "socks connect" for SOCKS5) do not
+// prove the endpoint failed and are never attributed.
 func isVertexEndpointFailureMessage(message string) bool {
 	lower := strings.ToLower(strings.TrimSpace(message))
-	if lower == "" || strings.Contains(lower, "proxyconnect tcp") {
+	if lower == "" || strings.Contains(lower, "proxyconnect tcp") || strings.Contains(lower, "socks connect") {
 		return false
 	}
 	for _, pattern := range vertexEndpointFailureMessagePatterns {

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -743,7 +743,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			}
 		} else {
 			if modelKey != "" {
-				if !shouldSkipCredentialCooldownForAuth(result.Error, auth) {
+				if !m.shouldSkipCredentialCooldownPoolAware(result.Error, auth) {
 					disableCooling := m.cooldownDisabledForAuth(auth)
 					state := ensureModelState(auth, modelKey)
 					state.Unavailable = true
@@ -884,7 +884,8 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				}
 			} else {
 				disableCooling := m.cooldownDisabledForAuth(auth)
-				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling)
+				skipCooldown := m.shouldSkipCredentialCooldownPoolAware(result.Error, auth)
+				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling, skipCooldown)
 			}
 		}
 
@@ -1320,6 +1321,67 @@ func shouldSkipCredentialCooldownForAuth(err *Error, auth *Auth) bool {
 		return false
 	}
 	return true
+}
+
+// shouldSkipCredentialCooldownPoolAware extends the per-auth check with
+// pool-aware Vertex regional-endpoint disambiguation. A transport failure on
+// a Vertex service-account auth whose regional endpoint is unique in the pool
+// (other Vertex service-account auths exist, none sharing its location) is an
+// auth-specific routing fault and must keep credential cooldown. Caller must
+// hold m.mu.
+func (m *Manager) shouldSkipCredentialCooldownPoolAware(err *Error, auth *Auth) bool {
+	if !shouldSkipCredentialCooldownForAuth(err, auth) {
+		return false
+	}
+	if isTransportFailureResultError(err) && m.vertexTransportFailureIsAuthSpecificLocked(auth) {
+		return false
+	}
+	return true
+}
+
+// vertexSALocation returns the effective regional location of a Vertex
+// service-account auth, mirroring the executor-side default of us-central1.
+// Non-service-account auths (e.g. vertex apikey compat entries) return "".
+func vertexSALocation(auth *Auth) string {
+	if auth == nil || auth.Provider != "vertex" || auth.Metadata == nil {
+		return ""
+	}
+	if _, ok := auth.Metadata["service_account"]; !ok {
+		return ""
+	}
+	loc, _ := auth.Metadata["location"].(string)
+	loc = strings.TrimSpace(loc)
+	if loc == "" {
+		return "us-central1"
+	}
+	return loc
+}
+
+// vertexTransportFailureIsAuthSpecificLocked reports whether the given Vertex
+// service-account auth routes through a regional endpoint that no other Vertex
+// service-account auth in the pool shares. When such peers exist, a transport
+// failure is specific to this auth's endpoint and rotation can only reach a
+// healthy credential if this auth cools down. Caller must hold m.mu.
+func (m *Manager) vertexTransportFailureIsAuthSpecificLocked(auth *Auth) bool {
+	loc := vertexSALocation(auth)
+	if loc == "" {
+		return false
+	}
+	hasPeer := false
+	for _, peer := range m.auths {
+		if peer == nil || peer.ID == auth.ID {
+			continue
+		}
+		peerLoc := vertexSALocation(peer)
+		if peerLoc == "" {
+			continue
+		}
+		hasPeer = true
+		if peerLoc == loc {
+			return false
+		}
+	}
+	return hasPeer
 }
 
 // authHasProxyOverride reports whether the auth carries its own proxy configuration.
@@ -1863,11 +1925,11 @@ func isRequestInvalidError(err error) bool {
 	return false
 }
 
-func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time, disableCooling bool) {
+func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time, disableCooling bool, skipCooldown bool) {
 	if auth == nil {
 		return
 	}
-	if shouldSkipCredentialCooldownForAuth(resultErr, auth) {
+	if skipCooldown {
 		return
 	}
 	defer func() {

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1310,7 +1310,8 @@ func shouldSkipCredentialCooldown(err *Error) bool {
 }
 
 // isConnectionLifecycleError reports transport/session lifecycle failures that must
-// not cool credentials: client cancellation and WebSocket close/EOF disconnects.
+// not cool credentials: client cancellation, WebSocket close/EOF disconnects, and
+// transport-level dial/TLS/write failures that carry no credential signal.
 func isConnectionLifecycleError(err error) bool {
 	if err == nil {
 		return false
@@ -1368,7 +1369,30 @@ func isConnectionLifecycleMessage(message string) bool {
 	if strings.Contains(lower, "unexpected eof") {
 		return true
 	}
+	// Transport-level failures (dial, DNS, TLS handshake, write) never indicate
+	// credential health, so they must not cool credentials either.
+	for _, pattern := range transportFailureMessagePatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
 	return false
+}
+
+// transportFailureMessagePatterns are lowercase substrings identifying
+// transport-level failures such as "net/http: TLS handshake timeout",
+// "dial tcp ...: connect: connection refused" or "read tcp ...: i/o timeout".
+// They only apply to errors without an HTTP status, so upstream response bodies
+// cannot suppress credential cooldown.
+var transportFailureMessagePatterns = []string{
+	"connection refused",
+	"connection reset",
+	"broken pipe",
+	"no such host",
+	"network is unreachable",
+	"proxyconnect tcp",
+	"i/o timeout",
+	"tls handshake timeout",
 }
 
 func isUnauthorizedError(err error) bool {

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1327,15 +1327,17 @@ func shouldSkipCredentialCooldownForAuth(err *Error, auth *Auth) bool {
 // pool-aware Vertex regional-endpoint disambiguation. A transport failure on
 // a Vertex service-account auth whose regional endpoint is unique in the pool
 // (other Vertex service-account auths exist, none sharing its location) is an
-// auth-specific routing fault and must keep credential cooldown. Failures in
-// the shared proxy dial layer never reach a regional endpoint, so they are
-// never attributed to one. Caller must hold m.mu.
+// auth-specific routing fault and must keep credential cooldown. Only failure
+// messages that can point to the failing endpoint are attributed; shared-host
+// faults (network unreachable, DNS server misbehaving, operation timed out)
+// and proxy dial failures never reach a regional endpoint and are never
+// attributed to one. Caller must hold m.mu.
 func (m *Manager) shouldSkipCredentialCooldownPoolAware(err *Error, auth *Auth) bool {
 	if !shouldSkipCredentialCooldownForAuth(err, auth) {
 		return false
 	}
 	if isTransportFailureResultError(err) &&
-		!isProxyConnectFailureMessage(err.Message) &&
+		isVertexEndpointFailureMessage(err.Message) &&
 		m.vertexTransportFailureIsAuthSpecificLocked(auth) {
 		return false
 	}
@@ -1361,10 +1363,13 @@ func vertexSALocation(auth *Auth) string {
 }
 
 // vertexTransportFailureIsAuthSpecificLocked reports whether the given Vertex
-// service-account auth routes through a regional endpoint that no other Vertex
-// service-account auth in the pool shares. When such peers exist, a transport
-// failure is specific to this auth's endpoint and rotation can only reach a
-// healthy credential if this auth cools down. Caller must hold m.mu.
+// service-account auth routes through a regional endpoint that no other
+// pollable Vertex service-account auth in the pool shares. Disabled peers
+// (auth.Disabled or Status StatusDisabled) cannot serve requests, so they are
+// ignored when judging whether an alternative endpoint exists. When such peers
+// exist, a transport failure is specific to this auth's endpoint and rotation
+// can only reach a healthy credential if this auth cools down. Caller must
+// hold m.mu.
 func (m *Manager) vertexTransportFailureIsAuthSpecificLocked(auth *Auth) bool {
 	loc := vertexSALocation(auth)
 	if loc == "" {
@@ -1373,6 +1378,9 @@ func (m *Manager) vertexTransportFailureIsAuthSpecificLocked(auth *Auth) bool {
 	hasPeer := false
 	for _, peer := range m.auths {
 		if peer == nil || peer.ID == auth.ID {
+			continue
+		}
+		if peer.Disabled || peer.Status == StatusDisabled {
 			continue
 		}
 		peerLoc := vertexSALocation(peer)
@@ -1487,14 +1495,39 @@ func hasTransportFailureMessage(message string) bool {
 	return false
 }
 
-// isProxyConnectFailureMessage reports whether a message indicates a failure
-// establishing the proxy connection itself (e.g. "proxyconnect tcp: dial tcp
-// 127.0.0.1:7890: connect: connection refused"). Such failures occur in the
-// shared proxy dial layer before any provider regional endpoint is reached, so
-// they must not be attributed to a Vertex location endpoint.
-func isProxyConnectFailureMessage(message string) bool {
+// isVertexEndpointFailureMessage reports whether a message can be attributed
+// to a specific provider regional endpoint, so it may restore credential
+// cooldown for a unique-location Vertex auth. Only failures targeting the
+// endpoint itself qualify: NXDOMAIN ("no such host"), refused/reset
+// connections, broken pipes, dial/read timeouts and TLS handshake timeouts.
+// Shared-host or shared-layer faults ("network is unreachable", DNS "server
+// misbehaving", "operation timed out") and "proxyconnect tcp" proxy dial
+// failures do not prove the endpoint failed and are never attributed.
+func isVertexEndpointFailureMessage(message string) bool {
 	lower := strings.ToLower(strings.TrimSpace(message))
-	return lower != "" && strings.Contains(lower, "proxyconnect tcp")
+	if lower == "" || strings.Contains(lower, "proxyconnect tcp") {
+		return false
+	}
+	for _, pattern := range vertexEndpointFailureMessagePatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// vertexEndpointFailureMessagePatterns are lowercase substrings identifying
+// transport failures that point at a specific regional endpoint. Messages not
+// matching any pattern are treated as shared-host or shared-layer faults and
+// never attributed to a Vertex location endpoint.
+var vertexEndpointFailureMessagePatterns = []string{
+	"no such host",
+	"connection refused",
+	"connection reset",
+	"broken pipe",
+	"i/o timeout",
+	"connection timed out",
+	"tls handshake timeout",
 }
 
 // transportFailureMessagePatterns are lowercase substrings identifying

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -743,7 +743,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			}
 		} else {
 			if modelKey != "" {
-				if !m.shouldSkipCredentialCooldownPoolAware(result.Error, auth) {
+				if !m.shouldSkipCredentialCooldownPoolAware(result.Error, auth, modelKey, now) {
 					disableCooling := m.cooldownDisabledForAuth(auth)
 					state := ensureModelState(auth, modelKey)
 					state.Unavailable = true
@@ -884,7 +884,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				}
 			} else {
 				disableCooling := m.cooldownDisabledForAuth(auth)
-				skipCooldown := m.shouldSkipCredentialCooldownPoolAware(result.Error, auth)
+				skipCooldown := m.shouldSkipCredentialCooldownPoolAware(result.Error, auth, modelKey, now)
 				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling, skipCooldown)
 			}
 		}
@@ -1325,20 +1325,21 @@ func shouldSkipCredentialCooldownForAuth(err *Error, auth *Auth) bool {
 
 // shouldSkipCredentialCooldownPoolAware extends the per-auth check with
 // pool-aware Vertex regional-endpoint disambiguation. A transport failure on
-// a Vertex service-account auth whose regional endpoint is unique in the pool
-// (other Vertex service-account auths exist, none sharing its location) is an
-// auth-specific routing fault and must keep credential cooldown. Only failure
-// messages that can point to the failing endpoint are attributed; shared-host
-// faults (network unreachable, DNS server misbehaving, operation timed out)
-// and proxy dial failures never reach a regional endpoint and are never
-// attributed to one. Caller must hold m.mu.
-func (m *Manager) shouldSkipCredentialCooldownPoolAware(err *Error, auth *Auth) bool {
+// a Vertex service-account auth whose regional endpoint is unique among the
+// pollable Vertex service-account auths (other auths exist, none sharing its
+// location and currently available for the model) is an auth-specific routing
+// fault and must keep credential cooldown. Only failure messages that can
+// point to the failing endpoint are attributed; shared-host faults (network
+// unreachable, DNS server misbehaving, operation timed out) and proxy dial
+// failures never reach a regional endpoint and are never attributed to one.
+// Caller must hold m.mu.
+func (m *Manager) shouldSkipCredentialCooldownPoolAware(err *Error, auth *Auth, modelKey string, now time.Time) bool {
 	if !shouldSkipCredentialCooldownForAuth(err, auth) {
 		return false
 	}
 	if isTransportFailureResultError(err) &&
 		isVertexEndpointFailureMessage(err.Message) &&
-		m.vertexTransportFailureIsAuthSpecificLocked(auth) {
+		m.vertexTransportFailureIsAuthSpecificLocked(auth, modelKey, now) {
 		return false
 	}
 	return true
@@ -1365,12 +1366,14 @@ func vertexSALocation(auth *Auth) string {
 // vertexTransportFailureIsAuthSpecificLocked reports whether the given Vertex
 // service-account auth routes through a regional endpoint that no other
 // pollable Vertex service-account auth in the pool shares. Disabled peers
-// (auth.Disabled or Status StatusDisabled) cannot serve requests, so they are
-// ignored when judging whether an alternative endpoint exists. When such peers
+// (auth.Disabled or Status StatusDisabled) and peers currently blocked for
+// the model (quota cooldown, retry-after, or auth-level unavailability, as
+// judged by isAuthBlockedForModel) cannot serve requests, so they are ignored
+// when judging whether an alternative endpoint exists. When pollable peers
 // exist, a transport failure is specific to this auth's endpoint and rotation
 // can only reach a healthy credential if this auth cools down. Caller must
 // hold m.mu.
-func (m *Manager) vertexTransportFailureIsAuthSpecificLocked(auth *Auth) bool {
+func (m *Manager) vertexTransportFailureIsAuthSpecificLocked(auth *Auth, modelKey string, now time.Time) bool {
 	loc := vertexSALocation(auth)
 	if loc == "" {
 		return false
@@ -1381,6 +1384,9 @@ func (m *Manager) vertexTransportFailureIsAuthSpecificLocked(auth *Auth) bool {
 			continue
 		}
 		if peer.Disabled || peer.Status == StatusDisabled {
+			continue
+		}
+		if blocked, _, _ := isAuthBlockedForModel(peer, modelKey, now); blocked {
 			continue
 		}
 		peerLoc := vertexSALocation(peer)

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1471,14 +1471,25 @@ func isWeightedSelector(selector Selector) bool {
 // routes through the same per-auth proxy endpoint as auth (ProxyURL compared
 // after TrimSpace). When the proxy is shared, a transport failure against it
 // is a shared infrastructure fault: cooling the failing credential would only
-// drain the pool, since its peers hit the same dead endpoint. Peers currently
-// blocked for the model (isAuthBlockedForModel) or ineligible for the route
-// model (authSupportsRouteModel, model-level path only) cannot serve requests
-// and are ignored, so a single-credential dedicated proxy keeps restoring
-// cooldown. On the auth-level path (empty model key) model support is always
-// true, so peers are not filtered by model; this limitation only affects SDK
-// users who call Manager.MarkResult directly with an empty Model, since the
-// production path always sets result.Model. Caller must hold m.mu.
+// drain the pool, since its peers hit the same dead endpoint. Peers are judged
+// exactly like the request-selection candidate set (mirroring
+// vertexPeerCandidatesLocked): same provider as the failing auth (selection
+// only ever considers candidates of one provider, so a cross-provider peer
+// sharing the proxy can never serve the failing auth's requests and must not
+// hide proxy uniqueness), pollable (disabled, quota cooldown, retry-after, or
+// auth-level unavailability, as judged by isAuthBlockedForModel, cannot serve
+// requests), route-model eligible (per authSupportsRouteModel, the same
+// judgment request selection applies), restricted to the current highest
+// available priority tier (matching availableAuthsForSelector's
+// allPriorities=false semantics so lower priority peers cannot hide proxy
+// uniqueness), and to positive weights when the strategy is weighted (see
+// isWeightedSelector). Peers outside this set can never be picked for this
+// model, so they must not hide the proxy uniqueness, otherwise a healthy but
+// unreachable peer would leave polling stuck on the failing auth. On the
+// auth-level path (empty model key) authSupportsRouteModel is always true, so
+// peers are not filtered by model; this limitation only affects SDK users who
+// call Manager.MarkResult directly with an empty Model, since the production
+// path always sets result.Model. Caller must hold m.mu.
 func (m *Manager) authHasSharedProxyPeerLocked(auth *Auth, modelKey string, now time.Time) bool {
 	if auth == nil {
 		return false
@@ -1487,21 +1498,43 @@ func (m *Manager) authHasSharedProxyPeerLocked(auth *Auth, modelKey string, now 
 	if proxyURL == "" {
 		return false
 	}
+	provider := executorKeyFromAuth(auth)
+	candidates := make([]*Auth, 0, len(m.auths))
 	registryRef := registry.GetGlobalRegistry()
 	for _, peer := range m.auths {
 		if peer == nil || peer.ID == auth.ID {
 			continue
 		}
-		if strings.TrimSpace(peer.ProxyURL) != proxyURL {
+		if executorKeyFromAuth(peer) != provider {
 			continue
 		}
 		if blocked, _, _ := isAuthBlockedForModel(peer, modelKey, now); blocked {
 			continue
 		}
-		if modelKey != "" && !m.authSupportsRouteModel(registryRef, peer, modelKey) {
+		if !m.authSupportsRouteModel(registryRef, peer, modelKey) {
 			continue
 		}
-		return true
+		candidates = append(candidates, peer)
+	}
+	if len(candidates) == 0 {
+		return false
+	}
+	priorityTier, _, errAvailable := m.availableAuthsForSelector(m.selector, candidates, provider, modelKey, now)
+	if errAvailable != nil {
+		return false
+	}
+	// Under a weighted selection strategy peers with a non-positive weight are
+	// never picked for this model (see positiveWeightAuths), so they cannot
+	// serve requests and must not hide the proxy uniqueness. The default
+	// round-robin strategy ignores weights entirely and keeps the legacy peer
+	// set. Caller holds m.mu, so reading m.selector is safe.
+	if isWeightedSelector(m.selector) {
+		priorityTier = positiveWeightAuths(priorityTier)
+	}
+	for _, peer := range priorityTier {
+		if strings.TrimSpace(peer.ProxyURL) == proxyURL {
+			return true
+		}
 	}
 	return false
 }

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -18,6 +18,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
 )
 
 var quotaCooldownDisabled atomic.Bool
@@ -1348,8 +1349,11 @@ func (m *Manager) shouldSkipCredentialCooldownPoolAware(err *Error, auth *Auth, 
 // vertexSALocation returns the effective regional location of a Vertex
 // service-account auth, mirroring the executor-side default of us-central1.
 // Non-service-account auths (e.g. vertex apikey compat entries) return "".
+// The provider comparison is normalized exactly like the selection path does
+// (executorKeyFromAuth trims and lowercases the provider), so "Vertex" and
+// "vertex" select the same executor and must be judged the same here.
 func vertexSALocation(auth *Auth) string {
-	if auth == nil || auth.Provider != "vertex" || auth.Metadata == nil {
+	if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "vertex") || auth.Metadata == nil {
 		return ""
 	}
 	if _, ok := auth.Metadata["service_account"]; !ok {
@@ -1396,6 +1400,14 @@ func (m *Manager) vertexTransportFailureIsAuthSpecificLocked(auth *Auth, modelKe
 		if peerLoc == "" {
 			continue
 		}
+		// Under a weighted selection strategy peers with a non-positive weight
+		// are never picked for this model (see positiveWeightAuths), so they
+		// cannot serve requests and must not hide endpoint uniqueness. The
+		// default round-robin strategy ignores weights entirely and keeps the
+		// legacy peer set. Caller holds m.mu, so reading m.selector is safe.
+		if _, weighted := m.selector.(*WeightedRoundRobinSelector); weighted && authWeight(peer) <= 0 {
+			continue
+		}
 		if blocked, _, _ := isAuthBlockedForModel(peer, modelKey, now); blocked {
 			continue
 		}
@@ -1410,11 +1422,23 @@ func (m *Manager) vertexTransportFailureIsAuthSpecificLocked(auth *Auth, modelKe
 	return hasPeer
 }
 
-// authHasProxyOverride reports whether the auth carries its own proxy configuration.
-// Transport failures through a per-auth proxy are auth-specific routing faults,
-// not shared network outages, so they should keep credential cooldown.
+// authHasProxyOverride reports whether the auth carries its own proxy
+// configuration. Transport failures through a per-auth proxy are auth-specific
+// routing faults, not shared network outages, so they should keep credential
+// cooldown. The judgment mirrors proxyutil.Parse: only a real proxy mode
+// (ModeProxy) counts as an override; the explicit direct modes "direct"/"none"
+// (ModeDirect) and empty values (ModeInherit) route through no proxy endpoint;
+// malformed or unsupported values (ModeInvalid) are the credential's own
+// configuration problem, so cooldown is restored like a real override.
 func authHasProxyOverride(auth *Auth) bool {
-	return auth != nil && strings.TrimSpace(auth.ProxyURL) != ""
+	if auth == nil {
+		return false
+	}
+	setting, errParse := proxyutil.Parse(auth.ProxyURL)
+	if errParse != nil {
+		return setting.Mode == proxyutil.ModeInvalid
+	}
+	return setting.Mode == proxyutil.ModeProxy
 }
 
 // isTransportFailureResultError reports whether the result error is classified as a

--- a/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
+++ b/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
@@ -513,9 +513,11 @@ func newVertexSATestAuth(id, location string) *Auth {
 // registerClientModelForTest registers a route model for an auth in the global
 // registry, mirroring production where client models are registered at the
 // service layer. Only auths that register the model count as pollable peers
-// for request selection (see Manager.authSupportsRouteModel).
-func registerClientModelForTest(authID, model string) {
+// for request selection (see Manager.authSupportsRouteModel). The registration
+// is removed on test cleanup so the global registry is not polluted.
+func registerClientModelForTest(t *testing.T, authID, model string) {
 	registry.GetGlobalRegistry().RegisterClient(authID, "vertex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(authID) })
 }
 
 func TestManager_MarkResult_TransportFailureWithUniqueVertexLocationStillCooldowns(t *testing.T) {
@@ -540,8 +542,8 @@ func TestManager_MarkResult_TransportFailureWithUniqueVertexLocationStillCooldow
 	transportErr := resultErrorFromError(fmt.Errorf("dial tcp: lookup europe-west4-aiplatform.googleapis.com: no such host"))
 
 	model := "gemini-2.5-pro"
-	registerClientModelForTest(authA.ID, model)
-	registerClientModelForTest(authB.ID, model)
+	registerClientModelForTest(t, authA.ID, model)
+	registerClientModelForTest(t, authB.ID, model)
 	m.MarkResult(context.Background(), Result{
 		AuthID:   authB.ID,
 		Provider: authB.Provider,
@@ -764,8 +766,8 @@ func TestManager_MarkResult_TransportFailureWithSharedVertexLocationSkipsCooldow
 	}
 	// Both auths register the route model, so the shared-location peer is a
 	// pollable alternative and the endpoint is not unique.
-	registerClientModelForTest(sharedA.ID, model)
-	registerClientModelForTest(sharedB.ID, model)
+	registerClientModelForTest(t, sharedA.ID, model)
+	registerClientModelForTest(t, sharedB.ID, model)
 	mShared.MarkResult(context.Background(), Result{
 		AuthID:   sharedA.ID,
 		Provider: sharedA.Provider,
@@ -880,8 +882,8 @@ func TestManager_MarkResult_VertexEndpointConnectionRefusedStillCooldowns(t *tes
 	model := "gemini-2.5-pro"
 	// The US peer must register the route model to count as a pollable
 	// alternative endpoint for the model-level attribution below.
-	registerClientModelForTest(authUS.ID, model)
-	registerClientModelForTest(authEU.ID, model)
+	registerClientModelForTest(t, authUS.ID, model)
+	registerClientModelForTest(t, authEU.ID, model)
 	m.MarkResult(context.Background(), Result{
 		AuthID:   authEU.ID,
 		Provider: authEU.Provider,
@@ -1006,9 +1008,9 @@ func TestManager_MarkResult_VertexCoolingPeerStillCooldowns(t *testing.T) {
 	}
 	// The US auth must register the route model to count as the only reachable
 	// alternative endpoint for the model-level attribution below.
-	registerClientModelForTest(authUS.ID, model)
-	registerClientModelForTest(authEU.ID, model)
-	registerClientModelForTest(authEUPeer.ID, model)
+	registerClientModelForTest(t, authUS.ID, model)
+	registerClientModelForTest(t, authEU.ID, model)
+	registerClientModelForTest(t, authEUPeer.ID, model)
 	if blocked, _, _ := isAuthBlockedForModel(authEUPeer, model, now); !blocked {
 		t.Fatalf("expected cooling peer to be blocked for model")
 	}
@@ -1095,8 +1097,8 @@ func TestManager_MarkResult_VertexExpiredCooldownPeerSkipsCooldown(t *testing.T)
 	}
 	// The same-location peer must also register the route model: its cooldown
 	// expired and it can serve the model, so the endpoint stays shared.
-	registerClientModelForTest(authEU.ID, model)
-	registerClientModelForTest(authPeer.ID, model)
+	registerClientModelForTest(t, authEU.ID, model)
+	registerClientModelForTest(t, authPeer.ID, model)
 	if blocked, _, _ := isAuthBlockedForModel(authPeer, model, now); blocked {
 		t.Fatalf("expected expired-cooldown peer to be pollable")
 	}
@@ -1138,7 +1140,7 @@ func TestManager_MarkResult_VertexModelIneligiblePeerStillCooldowns(t *testing.T
 	}
 	// Only the US credential registers the route model, so it is the only
 	// pollable alternative endpoint for this model.
-	registerClientModelForTest(authUS.ID, model)
+	registerClientModelForTest(t, authUS.ID, model)
 
 	now := time.Now()
 	if blocked, _, _ := isAuthBlockedForModel(authEUPeer, model, now); blocked {
@@ -1166,5 +1168,118 @@ func TestManager_MarkResult_VertexModelIneligiblePeerStillCooldowns(t *testing.T
 	state := updated.ModelStates[model]
 	if state == nil || state.NextRetryAfter.IsZero() {
 		t.Fatalf("expected model-ineligible same-location peer to keep model cooldown")
+	}
+}
+
+func TestManager_MarkResult_TransportFailureWithSocksProxyDialSkipsVertexAttribution(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	m := NewManager(nil, nil, nil)
+	authUS := newVertexSATestAuth("auth-vertex-socks-us", "us-central1")
+	authEU := newVertexSATestAuth("auth-vertex-socks-eu", "europe-west4")
+	for _, a := range []*Auth{authUS, authEU} {
+		if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	model := "gemini-2.5-pro"
+
+	// x/net/proxy SOCKS5 dialer failures surface as
+	// "socks connect tcp <proxy>-><target>: <err>" (net.OpError with
+	// Op "socks connect", see golang.org/x/net/internal/socks). The message
+	// carries no "proxyconnect tcp", so it previously matched both the
+	// transport and vertex endpoint pattern tables and drained the pool by
+	// attributing a shared socks5 proxy outage to each unique-location
+	// Vertex credential (cfg-level proxy, no per-auth ProxyURL override).
+	socksErr := resultErrorFromError(fmt.Errorf("socks connect tcp 127.0.0.1:1080->europe-west4-aiplatform.googleapis.com:443: connection refused"))
+	if !isTransportFailureResultError(socksErr) {
+		t.Fatalf("isTransportFailureResultError(%#v) = false, want true", socksErr)
+	}
+	if isVertexEndpointFailureMessage(socksErr.Message) {
+		t.Fatalf("isVertexEndpointFailureMessage(%q) = true, want false", socksErr.Message)
+	}
+
+	// Model-level path: the socks dial failure must skip cooldown even though
+	// the failing auth's location is unique in the pool.
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authEU.ID,
+		Provider: authEU.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    socksErr,
+	})
+	assertNoCooldown(t, m, authEU.ID, model)
+
+	// Auth-level path (empty model) must behave identically.
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authUS.ID,
+		Provider: authUS.Provider,
+		Success:  false,
+		Error:    socksErr,
+	})
+	updatedUS, okUS := m.GetByID(authUS.ID)
+	if !okUS || updatedUS == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	if updatedUS.Unavailable || !updatedUS.NextRetryAfter.IsZero() {
+		t.Fatalf("expected socks dial failure to skip auth-level cooldown, got unavailable=%v next=%v", updatedUS.Unavailable, updatedUS.NextRetryAfter)
+	}
+}
+
+func TestManager_MarkResult_VertexEndpointConnectionTimedOutStillCooldowns(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	m := NewManager(nil, nil, nil)
+	authUS := newVertexSATestAuth("auth-vertex-timedout-us", "us-central1")
+	authEU := newVertexSATestAuth("auth-vertex-timedout-eu", "europe-west4")
+	for _, a := range []*Auth{authUS, authEU} {
+		if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	// A direct dial timeout against the regional endpoint is a per-endpoint
+	// fault (unlike "operation timed out", which is shared-host) and must
+	// keep cooldown when the location is unique in the pool. This guards the
+	// "connection timed out" pattern in vertexEndpointFailureMessagePatterns
+	// from being dropped as shared-host.
+	endpointErr := resultErrorFromError(fmt.Errorf("dial tcp 142.250.4.1:443: connect: connection timed out"))
+	if !isTransportFailureResultError(endpointErr) {
+		t.Fatalf("isTransportFailureResultError(%#v) = false, want true", endpointErr)
+	}
+	if !isVertexEndpointFailureMessage(endpointErr.Message) {
+		t.Fatalf("isVertexEndpointFailureMessage(%q) = false, want true", endpointErr.Message)
+	}
+
+	model := "gemini-2.5-pro"
+	// The US peer must register the route model to count as a pollable
+	// alternative endpoint for the model-level attribution below.
+	registerClientModelForTest(t, authUS.ID, model)
+	registerClientModelForTest(t, authEU.ID, model)
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authEU.ID,
+		Provider: authEU.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    endpointErr,
+	})
+	updated, ok := m.GetByID(authEU.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected unique-location vertex connection timed out to keep cooldown")
 	}
 }

--- a/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
+++ b/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
 
 func TestManager_MarkResult_ConnectionLifecycleDoesNotCooldown(t *testing.T) {
@@ -509,6 +510,14 @@ func newVertexSATestAuth(id, location string) *Auth {
 	return &Auth{ID: id, Provider: "vertex", Metadata: metadata}
 }
 
+// registerClientModelForTest registers a route model for an auth in the global
+// registry, mirroring production where client models are registered at the
+// service layer. Only auths that register the model count as pollable peers
+// for request selection (see Manager.authSupportsRouteModel).
+func registerClientModelForTest(authID, model string) {
+	registry.GetGlobalRegistry().RegisterClient(authID, "vertex", []*registry.ModelInfo{{ID: model}})
+}
+
 func TestManager_MarkResult_TransportFailureWithUniqueVertexLocationStillCooldowns(t *testing.T) {
 	previous := quotaCooldownDisabled.Load()
 	quotaCooldownDisabled.Store(false)
@@ -526,9 +535,13 @@ func TestManager_MarkResult_TransportFailureWithUniqueVertexLocationStillCooldow
 			t.Fatalf("register auth: %v", errRegister)
 		}
 	}
+	// The US peer must register the route model to count as a pollable
+	// alternative endpoint for the model-level attribution below.
 	transportErr := resultErrorFromError(fmt.Errorf("dial tcp: lookup europe-west4-aiplatform.googleapis.com: no such host"))
 
 	model := "gemini-2.5-pro"
+	registerClientModelForTest(authA.ID, model)
+	registerClientModelForTest(authB.ID, model)
 	m.MarkResult(context.Background(), Result{
 		AuthID:   authB.ID,
 		Provider: authB.Provider,
@@ -749,6 +762,10 @@ func TestManager_MarkResult_TransportFailureWithSharedVertexLocationSkipsCooldow
 			t.Fatalf("register auth: %v", errRegister)
 		}
 	}
+	// Both auths register the route model, so the shared-location peer is a
+	// pollable alternative and the endpoint is not unique.
+	registerClientModelForTest(sharedA.ID, model)
+	registerClientModelForTest(sharedB.ID, model)
 	mShared.MarkResult(context.Background(), Result{
 		AuthID:   sharedA.ID,
 		Provider: sharedA.Provider,
@@ -861,6 +878,10 @@ func TestManager_MarkResult_VertexEndpointConnectionRefusedStillCooldowns(t *tes
 	// A direct endpoint failure (connection refused) must keep cooldown when
 	// the location is unique in the pool.
 	model := "gemini-2.5-pro"
+	// The US peer must register the route model to count as a pollable
+	// alternative endpoint for the model-level attribution below.
+	registerClientModelForTest(authUS.ID, model)
+	registerClientModelForTest(authEU.ID, model)
 	m.MarkResult(context.Background(), Result{
 		AuthID:   authEU.ID,
 		Provider: authEU.Provider,
@@ -983,6 +1004,11 @@ func TestManager_MarkResult_VertexCoolingPeerStillCooldowns(t *testing.T) {
 			t.Fatalf("register auth: %v", errRegister)
 		}
 	}
+	// The US auth must register the route model to count as the only reachable
+	// alternative endpoint for the model-level attribution below.
+	registerClientModelForTest(authUS.ID, model)
+	registerClientModelForTest(authEU.ID, model)
+	registerClientModelForTest(authEUPeer.ID, model)
 	if blocked, _, _ := isAuthBlockedForModel(authEUPeer, model, now); !blocked {
 		t.Fatalf("expected cooling peer to be blocked for model")
 	}
@@ -1067,6 +1093,10 @@ func TestManager_MarkResult_VertexExpiredCooldownPeerSkipsCooldown(t *testing.T)
 			t.Fatalf("register auth: %v", errRegister)
 		}
 	}
+	// The same-location peer must also register the route model: its cooldown
+	// expired and it can serve the model, so the endpoint stays shared.
+	registerClientModelForTest(authEU.ID, model)
+	registerClientModelForTest(authPeer.ID, model)
 	if blocked, _, _ := isAuthBlockedForModel(authPeer, model, now); blocked {
 		t.Fatalf("expected expired-cooldown peer to be pollable")
 	}
@@ -1080,4 +1110,61 @@ func TestManager_MarkResult_VertexExpiredCooldownPeerSkipsCooldown(t *testing.T)
 	// The same-location peer's cooldown has expired, so it is pollable again
 	// and the endpoint is shared: cooldown must stay skipped.
 	assertNoCooldown(t, m, authEU.ID, model)
+}
+
+func TestManager_MarkResult_VertexModelIneligiblePeerStillCooldowns(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	model := "gemini-2.5-pro"
+	endpointErr := resultErrorFromError(fmt.Errorf("dial tcp 142.250.4.1:443: connect: connection refused"))
+
+	m := NewManager(nil, nil, nil)
+	authEU := newVertexSATestAuth("auth-vertex-model-ineligible-eu", "europe-west4")
+	// Same-location peer that is ready but does not register the route model.
+	// Request selection would never pick it for this model, so it must not
+	// hide endpoint uniqueness either.
+	authEUPeer := newVertexSATestAuth("auth-vertex-model-ineligible-eu-peer", "europe-west4")
+	authUS := newVertexSATestAuth("auth-vertex-model-ineligible-us", "us-central1")
+	for _, a := range []*Auth{authEU, authEUPeer, authUS} {
+		if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	// Only the US credential registers the route model, so it is the only
+	// pollable alternative endpoint for this model.
+	registerClientModelForTest(authUS.ID, model)
+
+	now := time.Now()
+	if blocked, _, _ := isAuthBlockedForModel(authEUPeer, model, now); blocked {
+		t.Fatalf("expected same-location peer to be ready")
+	}
+	registryRef := registry.GetGlobalRegistry()
+	if m.authSupportsRouteModel(registryRef, authEUPeer, model) {
+		t.Fatalf("expected model-ineligible peer to be excluded from selection")
+	}
+	if !m.authSupportsRouteModel(registryRef, authUS, model) {
+		t.Fatalf("expected US auth to support the route model")
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authEU.ID,
+		Provider: authEU.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    endpointErr,
+	})
+	updated, ok := m.GetByID(authEU.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected model-ineligible same-location peer to keep model cooldown")
+	}
 }

--- a/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
+++ b/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
@@ -1692,3 +1692,118 @@ func TestManager_MarkResult_VertexLowPrioritySameLocationPeerStillCooldowns(t *t
 		t.Fatalf("expected low-priority same-location peer to keep cooldown")
 	}
 }
+
+func TestManager_MarkResult_TransportFailureWithSharedProxyWeightedZeroWeightPeerStillCooldowns(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	// Review bot #17: under a WeightedRoundRobinSelector the failing credential
+	// and a zero-weight peer share the same real ProxyURL, while a healthy
+	// positive-weight credential routes through a different proxy. Weighted
+	// selection removes the zero-weight peer before picking
+	// (positiveWeightAuths), so the failing credential's proxy is effectively
+	// dedicated: only cooling the failing credential down lets the weighted
+	// route switch to the healthy credential. The zero-weight peer must not
+	// count as a shared-proxy peer.
+	transportErr := resultErrorFromError(fmt.Errorf("proxyconnect tcp: dial tcp 127.0.0.1:7890: connect: connection refused"))
+	if !isTransportFailureResultError(transportErr) {
+		t.Fatalf("isTransportFailureResultError(%#v) = false, want true", transportErr)
+	}
+
+	model := "gpt-5.6-sol"
+	m := NewManager(nil, &WeightedRoundRobinSelector{}, nil)
+	authFail := &Auth{ID: "auth-weighted-shared-proxy-fail", Provider: "codex", ProxyURL: "http://127.0.0.1:7890"}
+	authZero := &Auth{ID: "auth-weighted-shared-proxy-zero", Provider: "codex", ProxyURL: "http://127.0.0.1:7890", Attributes: map[string]string{AttributeWeight: "0"}}
+	authHealthy := &Auth{ID: "auth-weighted-shared-proxy-healthy", Provider: "codex", ProxyURL: "http://127.0.0.1:7891", Attributes: map[string]string{AttributeWeight: "1"}}
+	for _, a := range []*Auth{authFail, authZero, authHealthy} {
+		if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	for _, a := range []*Auth{authFail, authZero, authHealthy} {
+		registerClientModelForTest(t, a.ID, model)
+	}
+
+	// Model-level path: the zero-weight same-proxy peer is never picked by the
+	// weighted selector, so it must not hide proxy uniqueness and cooldown is
+	// restored.
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authFail.ID,
+		Provider: authFail.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    transportErr,
+	})
+	updated, ok := m.GetByID(authFail.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected weighted zero-weight shared-proxy peer to keep cooldown")
+	}
+
+	// Auth-level path behaves identically: model eligibility is always true on
+	// this path, but the weighted positive-weight filter still excludes the
+	// zero-weight peer, so cooldown is restored.
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authFail.ID,
+		Provider: authFail.Provider,
+		Success:  false,
+		Error:    transportErr,
+	})
+	updated, ok = m.GetByID(authFail.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	if !updated.Unavailable || updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected weighted zero-weight shared-proxy peer to keep auth-level cooldown, got unavailable=%v next=%v", updated.Unavailable, updated.NextRetryAfter)
+	}
+}
+
+func TestManager_MarkResult_TransportFailureWithSharedProxyRoundRobinIgnoresWeightSkipsCooldown(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	// Default round-robin selector ignores weights entirely, so the zero-weight
+	// same-proxy peer is still a pollable alternative and the proxy fault is a
+	// shared infrastructure fault: cooldown is skipped. Guards against the
+	// weighted positive-weight filter leaking into the legacy selector.
+	transportErr := resultErrorFromError(fmt.Errorf("proxyconnect tcp: dial tcp 127.0.0.1:7890: connect: connection refused"))
+	if !isTransportFailureResultError(transportErr) {
+		t.Fatalf("isTransportFailureResultError(%#v) = false, want true", transportErr)
+	}
+
+	model := "gpt-5.6-sol"
+	m := NewManager(nil, nil, nil)
+	authFail := &Auth{ID: "auth-rr-shared-proxy-fail", Provider: "codex", ProxyURL: "http://127.0.0.1:7890"}
+	authZero := &Auth{ID: "auth-rr-shared-proxy-zero", Provider: "codex", ProxyURL: "http://127.0.0.1:7890", Attributes: map[string]string{AttributeWeight: "0"}}
+	authHealthy := &Auth{ID: "auth-rr-shared-proxy-healthy", Provider: "codex", ProxyURL: "http://127.0.0.1:7891", Attributes: map[string]string{AttributeWeight: "1"}}
+	for _, a := range []*Auth{authFail, authZero, authHealthy} {
+		if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	for _, a := range []*Auth{authFail, authZero, authHealthy} {
+		registerClientModelForTest(t, a.ID, model)
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authFail.ID,
+		Provider: authFail.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    transportErr,
+	})
+	assertNoCooldown(t, m, authFail.ID, model)
+}

--- a/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
+++ b/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
@@ -337,3 +337,63 @@ func assertNoCooldown(t *testing.T, m *Manager, authID, model string) {
 		}
 	}
 }
+
+func TestManager_MarkResult_TransportFailureDoesNotCooldown(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{name: "tls handshake timeout", err: fmt.Errorf(`Post "https://example.com/v1/chat/completions": net/http: TLS handshake timeout`)},
+		{name: "connection refused", err: fmt.Errorf("dial tcp 1.2.3.4:443: connect: connection refused")},
+		{name: "connection reset", err: fmt.Errorf("read tcp 127.0.0.1:1->127.0.0.1:2: read: connection reset by peer")},
+		{name: "dns failure", err: fmt.Errorf(`dial tcp: lookup example.com: no such host`)},
+		{name: "io timeout", err: fmt.Errorf("dial tcp 1.2.3.4:443: i/o timeout")},
+		{name: "proxyconnect", err: fmt.Errorf("proxyconnect tcp: dial tcp 127.0.0.1:7890: connect: connection refused")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !isConnectionLifecycleError(tc.err) {
+				t.Fatalf("isConnectionLifecycleError(%v) = false, want true", tc.err)
+			}
+			got := resultErrorFromError(tc.err)
+			if !shouldSkipCredentialCooldown(got) {
+				t.Fatalf("shouldSkipCredentialCooldown(%#v) = false, want true", got)
+			}
+
+			m := NewManager(nil, nil, nil)
+			auth := &Auth{ID: "auth-transport-" + tc.name, Provider: "codex"}
+			if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+				t.Fatalf("register auth: %v", errRegister)
+			}
+			model := "gpt-5.6-sol"
+			m.MarkResult(context.Background(), Result{
+				AuthID:   auth.ID,
+				Provider: auth.Provider,
+				Model:    model,
+				Success:  false,
+				Error:    got,
+			})
+			assertNoCooldown(t, m, auth.ID, model)
+		})
+	}
+}
+
+func TestIsConnectionLifecycleError_TransportTextWithStatusStillCooldowns(t *testing.T) {
+	// An upstream HTTP error body mentioning transport text must stay coolable.
+	err := &statusBearingError{status: http.StatusBadGateway, msg: "upstream reported: connection refused"}
+	if isConnectionLifecycleError(err) {
+		t.Fatalf("status-bearing transport text must not be classified as lifecycle")
+	}
+	if shouldSkipCredentialCooldown(resultErrorFromError(err)) {
+		t.Fatalf("shouldSkipCredentialCooldown = true, want false")
+	}
+}

--- a/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
+++ b/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
@@ -448,8 +448,12 @@ func TestManager_MarkResult_TransportFailureWithAuthProxyStillCooldowns(t *testi
 	assertNoCooldown(t, m, authCancel.ID, model)
 
 	// Auth-level path (empty model) must also keep cooldown for transport
-	// failures through a per-auth proxy.
-	authLevel := &Auth{ID: "auth-transport-proxy-auth-level", Provider: "codex", ProxyURL: "http://127.0.0.1:7890"}
+	// failures through a per-auth proxy. The dedicated proxy must differ from
+	// the one used by the credentials above: a proxy shared by several
+	// pollable credentials is now treated as shared infrastructure and skips
+	// cooldown (see
+	// TestManager_MarkResult_TransportFailureWithSharedProxySkipsCooldown).
+	authLevel := &Auth{ID: "auth-transport-proxy-auth-level", Provider: "codex", ProxyURL: "http://127.0.0.1:7892"}
 	if _, errRegister := m.Register(context.Background(), authLevel); errRegister != nil {
 		t.Fatalf("register auth: %v", errRegister)
 	}
@@ -1469,4 +1473,222 @@ func TestManager_MarkResult_VertexRoundRobinIgnoresWeightSkipsCooldown(t *testin
 		Error:    endpointErr,
 	})
 	assertNoCooldown(t, m, authEU.ID, model)
+}
+
+func TestManager_MarkResult_TransportFailureWithSharedProxySkipsCooldown(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	// Multiple credentials can share one real ProxyURL (the synthesizer passes
+	// the proxy through verbatim), so they route through the same proxy layer.
+	// A proxy dial failure is then a shared infrastructure fault, not an
+	// auth-specific routing problem: cooling every credential behind the dead
+	// proxy would drain the pool.
+	transportErr := resultErrorFromError(fmt.Errorf("proxyconnect tcp: dial tcp 127.0.0.1:7890: connect: connection refused"))
+	if !isTransportFailureResultError(transportErr) {
+		t.Fatalf("isTransportFailureResultError(%#v) = false, want true", transportErr)
+	}
+
+	model := "gpt-5.6-sol"
+	m := NewManager(nil, nil, nil)
+	authA := &Auth{ID: "auth-shared-proxy-a", Provider: "codex", ProxyURL: "http://127.0.0.1:7890"}
+	authB := &Auth{ID: "auth-shared-proxy-b", Provider: "codex", ProxyURL: "http://127.0.0.1:7890"}
+	for _, a := range []*Auth{authA, authB} {
+		if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	// The shared-proxy peer must support the route model to count as pollable
+	// for the model-level path.
+	registerClientModelForTest(t, authA.ID, model)
+	registerClientModelForTest(t, authB.ID, model)
+
+	// Model-level path: the shared proxy peer keeps the failure non-specific.
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authA.ID,
+		Provider: authA.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    transportErr,
+	})
+	assertNoCooldown(t, m, authA.ID, model)
+
+	// Auth-level path (empty model) must behave identically.
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authB.ID,
+		Provider: authB.Provider,
+		Success:  false,
+		Error:    transportErr,
+	})
+	updated, ok := m.GetByID(authB.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	if updated.Unavailable || !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected shared-proxy failure to skip auth-level cooldown, got unavailable=%v next=%v", updated.Unavailable, updated.NextRetryAfter)
+	}
+}
+
+func TestManager_MarkResult_TransportFailureWithDedicatedProxyStillCooldowns(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	// Distinct per-auth proxies: each credential owns its proxy endpoint, so a
+	// proxy dial failure on one credential is auth-specific routing and must
+	// keep cooldown. The single-credential dedicated-proxy case is covered by
+	// TestManager_MarkResult_TransportFailureWithAuthProxyStillCooldowns.
+	transportErr := resultErrorFromError(fmt.Errorf("proxyconnect tcp: dial tcp 127.0.0.1:7890: connect: connection refused"))
+	model := "gpt-5.6-sol"
+
+	m := NewManager(nil, nil, nil)
+	authA := &Auth{ID: "auth-dedicated-proxy-a", Provider: "codex", ProxyURL: "http://127.0.0.1:7890"}
+	authB := &Auth{ID: "auth-dedicated-proxy-b", Provider: "codex", ProxyURL: "http://127.0.0.1:7891"}
+	for _, a := range []*Auth{authA, authB} {
+		if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	registerClientModelForTest(t, authA.ID, model)
+	registerClientModelForTest(t, authB.ID, model)
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authA.ID,
+		Provider: authA.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    transportErr,
+	})
+	updated, ok := m.GetByID(authA.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected dedicated-proxy transport failure to keep cooldown")
+	}
+}
+
+func TestManager_MarkResult_VertexSessionAffinityWeightedZeroWeightStillCooldowns(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	// Session affinity can wrap a WeightedRoundRobinSelector as its fallback
+	// (see newRoutingSelector in sdk/cliproxy/service_config.go). Selection
+	// still routes through positiveWeightAuths in that configuration, so the
+	// zero-weight same-location peer must not hide endpoint uniqueness.
+	endpointErr := resultErrorFromError(fmt.Errorf("dial tcp 142.250.4.1:443: connect: connection refused"))
+	model := "gemini-2.5-pro"
+
+	cases := []struct {
+		name     string
+		selector Selector
+	}{
+		{name: "NewSessionAffinitySelector", selector: NewSessionAffinitySelector(&WeightedRoundRobinSelector{})},
+		{name: "NewSessionAffinitySelectorWithConfig", selector: NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+			Fallback: &WeightedRoundRobinSelector{},
+			TTL:      time.Hour,
+		})},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewManager(nil, tc.selector, nil)
+			authEU := newVertexSATestAuth("auth-vertex-affinity-weight-eu", "europe-west4")
+			authEU2 := newVertexSATestAuth("auth-vertex-affinity-weight-eu2", "europe-west4")
+			authUS := newVertexSATestAuth("auth-vertex-affinity-weight-us", "us-central1")
+			authEU2.Attributes = map[string]string{AttributeWeight: "0"}
+			authUS.Attributes = map[string]string{AttributeWeight: "1"}
+			for _, a := range []*Auth{authEU, authEU2, authUS} {
+				if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+					t.Fatalf("register auth: %v", errRegister)
+				}
+			}
+			for _, a := range []*Auth{authEU, authEU2, authUS} {
+				registerClientModelForTest(t, a.ID, model)
+			}
+			m.MarkResult(context.Background(), Result{
+				AuthID:   authEU.ID,
+				Provider: authEU.Provider,
+				Model:    model,
+				Success:  false,
+				Error:    endpointErr,
+			})
+			updated, ok := m.GetByID(authEU.ID)
+			if !ok || updated == nil {
+				t.Fatalf("expected auth to be present")
+			}
+			state := updated.ModelStates[model]
+			if state == nil || state.NextRetryAfter.IsZero() {
+				t.Fatalf("expected session-affinity weighted zero-weight same-location peer to keep cooldown")
+			}
+		})
+	}
+}
+
+func TestManager_MarkResult_VertexLowPrioritySameLocationPeerStillCooldowns(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	// The same-location EU peer runs at a lower priority than the failing EU
+	// auth, so request selection (availableAuthsForRouteModel,
+	// allPriorities=false) never hands it to the round-robin selector; only
+	// the healthy US peer at the same high priority is a real alternative
+	// endpoint. The low-priority peer must not hide endpoint uniqueness. The
+	// equal-priority control (two same-location peers sharing the top tier)
+	// still skips cooldown and is covered by
+	// TestManager_MarkResult_TransportFailureWithSharedVertexLocationSkipsCooldown.
+	endpointErr := resultErrorFromError(fmt.Errorf("dial tcp 142.250.4.1:443: connect: connection refused"))
+	model := "gemini-2.5-pro"
+
+	m := NewManager(nil, nil, nil)
+	authEU := newVertexSATestAuth("auth-vertex-priority-eu", "europe-west4")
+	authEU2 := newVertexSATestAuth("auth-vertex-priority-eu2", "europe-west4")
+	authUS := newVertexSATestAuth("auth-vertex-priority-us", "us-central1")
+	authEU.Attributes = map[string]string{"priority": "10"}
+	authEU2.Attributes = map[string]string{"priority": "0"}
+	authUS.Attributes = map[string]string{"priority": "10"}
+	for _, a := range []*Auth{authEU, authEU2, authUS} {
+		if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	for _, a := range []*Auth{authEU, authEU2, authUS} {
+		registerClientModelForTest(t, a.ID, model)
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authEU.ID,
+		Provider: authEU.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    endpointErr,
+	})
+	updated, ok := m.GetByID(authEU.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected low-priority same-location peer to keep cooldown")
+	}
 }

--- a/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
+++ b/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
@@ -466,3 +466,31 @@ func TestManager_MarkResult_TransportFailureWithAuthProxyStillCooldowns(t *testi
 		t.Fatalf("expected auth-level transport failure via per-auth proxy to keep cooldown")
 	}
 }
+
+func TestManager_MarkResult_RequestScopedTransportTextWithAuthProxySkipsCooldown(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-request-scoped-proxy", Provider: "claude", ProxyURL: "http://127.0.0.1:7890"}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	model := "claude-sonnet-4-5"
+
+	// request_scoped code must win over the per-auth proxy transport override.
+	scopedErr := &Error{Code: "request_scoped", Message: "Post \"https://example.com/v1/messages\": net/http: TLS handshake timeout"}
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    scopedErr,
+	})
+	assertNoCooldown(t, m, auth.ID, model)
+}

--- a/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
+++ b/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
@@ -582,6 +582,151 @@ func TestManager_MarkResult_TransportFailureWithUniqueVertexLocationStillCooldow
 	assertNoCooldown(t, m, authCancel.ID, model)
 }
 
+func TestManager_MarkResult_TransportFailureWithProxyDialSkipsVertexAttribution(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	m := NewManager(nil, nil, nil)
+	authUS := newVertexSATestAuth("auth-vertex-proxy-us", "us-central1")
+	authEU := newVertexSATestAuth("auth-vertex-proxy-eu", "europe-west4")
+	for _, a := range []*Auth{authUS, authEU} {
+		if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	model := "gemini-2.5-pro"
+
+	// A proxy dial failure (shared proxy layer, before any regional endpoint is
+	// reached) must not be attributed to a Vertex location, even though the
+	// failing auth's location is unique in the pool.
+	proxyErr := resultErrorFromError(fmt.Errorf("proxyconnect tcp: dial tcp 127.0.0.1:7890: connect: connection refused"))
+	if !isTransportFailureResultError(proxyErr) {
+		t.Fatalf("isTransportFailureResultError(%#v) = false, want true", proxyErr)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authEU.ID,
+		Provider: authEU.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    proxyErr,
+	})
+	assertNoCooldown(t, m, authEU.ID, model)
+
+	// Auth-level path (empty model) must behave identically.
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authUS.ID,
+		Provider: authUS.Provider,
+		Success:  false,
+		Error:    proxyErr,
+	})
+	updatedUS, okUS := m.GetByID(authUS.ID)
+	if !okUS || updatedUS == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	if updatedUS.Unavailable || !updatedUS.NextRetryAfter.IsZero() {
+		t.Fatalf("expected proxy dial failure to skip auth-level cooldown, got unavailable=%v next=%v", updatedUS.Unavailable, updatedUS.NextRetryAfter)
+	}
+
+	// Regression guard: a direct regional-endpoint failure (no proxy involved)
+	// must still keep cooldown when the location is unique in the pool.
+	endpointErr := resultErrorFromError(fmt.Errorf("dial tcp: lookup asia-south1-aiplatform.googleapis.com: no such host"))
+	authLevel := newVertexSATestAuth("auth-vertex-proxy-level", "asia-south1")
+	if _, errRegister := m.Register(context.Background(), authLevel); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authLevel.ID,
+		Provider: authLevel.Provider,
+		Success:  false,
+		Error:    endpointErr,
+	})
+	updatedLevel, okLevel := m.GetByID(authLevel.ID)
+	if !okLevel || updatedLevel == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	if updatedLevel.NextRetryAfter.IsZero() {
+		t.Fatalf("expected unique-location vertex endpoint failure to keep cooldown")
+	}
+}
+
+func TestManager_MarkResult_TransportFailureNewPatternsSkipCooldown(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	model := "gpt-5.6-sol"
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{name: "server misbehaving", err: fmt.Errorf(`dial tcp: lookup example.com on 8.8.8.8:53: server misbehaving`)},
+		{name: "connection timed out", err: fmt.Errorf(`dial tcp 1.2.3.4:443: connect: connection timed out`)},
+		{name: "operation timed out", err: fmt.Errorf(`Post "https://example.com/v1/chat/completions": dial tcp 1.2.3.4:443: connect: operation timed out`)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !isConnectionLifecycleError(tc.err) {
+				t.Fatalf("isConnectionLifecycleError(%v) = false, want true", tc.err)
+			}
+			got := resultErrorFromError(tc.err)
+			if !isTransportFailureResultError(got) {
+				t.Fatalf("isTransportFailureResultError(%#v) = false, want true", got)
+			}
+			if !shouldSkipCredentialCooldown(got) {
+				t.Fatalf("shouldSkipCredentialCooldown(%#v) = false, want true", got)
+			}
+
+			// Plain auth: the new transport texts must skip cooldown.
+			m := NewManager(nil, nil, nil)
+			auth := &Auth{ID: "auth-transport-new-" + tc.name, Provider: "codex"}
+			if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+				t.Fatalf("register auth: %v", errRegister)
+			}
+			m.MarkResult(context.Background(), Result{
+				AuthID:   auth.ID,
+				Provider: auth.Provider,
+				Model:    model,
+				Success:  false,
+				Error:    got,
+			})
+			assertNoCooldown(t, m, auth.ID, model)
+
+			// Per-auth proxy: the same texts must flow through the
+			// isTransportFailureResultError override and keep cooldown.
+			mProxy := NewManager(nil, nil, nil)
+			authProxy := &Auth{ID: "auth-transport-new-proxy-" + tc.name, Provider: "codex", ProxyURL: "http://127.0.0.1:7890"}
+			if _, errRegister := mProxy.Register(context.Background(), authProxy); errRegister != nil {
+				t.Fatalf("register auth: %v", errRegister)
+			}
+			mProxy.MarkResult(context.Background(), Result{
+				AuthID:   authProxy.ID,
+				Provider: authProxy.Provider,
+				Model:    model,
+				Success:  false,
+				Error:    got,
+			})
+			updated, ok := mProxy.GetByID(authProxy.ID)
+			if !ok || updated == nil {
+				t.Fatalf("expected auth to be present")
+			}
+			state := updated.ModelStates[model]
+			if state == nil || state.NextRetryAfter.IsZero() {
+				t.Fatalf("expected per-auth proxy transport failure to keep cooldown")
+			}
+		})
+	}
+}
+
 func TestManager_MarkResult_TransportFailureWithSharedVertexLocationSkipsCooldown(t *testing.T) {
 	previous := quotaCooldownDisabled.Load()
 	quotaCooldownDisabled.Store(false)

--- a/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
+++ b/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
@@ -774,3 +774,169 @@ func TestManager_MarkResult_TransportFailureWithSharedVertexLocationSkipsCooldow
 	})
 	assertNoCooldown(t, mSingle, single.ID, model)
 }
+
+func TestManager_MarkResult_VertexSharedHostNetworkFailureSkipsCooldown(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	model := "gemini-2.5-pro"
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{name: "network unreachable", err: fmt.Errorf("dial tcp 142.250.4.1:443: connect: network is unreachable")},
+		{name: "dns server misbehaving", err: fmt.Errorf("dial tcp: lookup europe-west4-aiplatform.googleapis.com: server misbehaving")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !isTransportFailureResultError(resultErrorFromError(tc.err)) {
+				t.Fatalf("isTransportFailureResultError(%v) = false, want true", tc.err)
+			}
+
+			// Unique-location vertex auths: shared-host faults cannot prove the
+			// regional endpoint failed, so cooldown must stay skipped.
+			m := NewManager(nil, nil, nil)
+			authUS := newVertexSATestAuth("auth-vertex-shared-fault-us", "us-central1")
+			authEU := newVertexSATestAuth("auth-vertex-shared-fault-eu", "europe-west4")
+			for _, a := range []*Auth{authUS, authEU} {
+				if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+					t.Fatalf("register auth: %v", errRegister)
+				}
+			}
+			m.MarkResult(context.Background(), Result{
+				AuthID:   authEU.ID,
+				Provider: authEU.Provider,
+				Model:    model,
+				Success:  false,
+				Error:    resultErrorFromError(tc.err),
+			})
+			assertNoCooldown(t, m, authEU.ID, model)
+
+			// Auth-level path (empty model) must behave identically.
+			m.MarkResult(context.Background(), Result{
+				AuthID:   authUS.ID,
+				Provider: authUS.Provider,
+				Success:  false,
+				Error:    resultErrorFromError(tc.err),
+			})
+			updatedUS, okUS := m.GetByID(authUS.ID)
+			if !okUS || updatedUS == nil {
+				t.Fatalf("expected auth to be present")
+			}
+			if updatedUS.Unavailable || !updatedUS.NextRetryAfter.IsZero() {
+				t.Fatalf("expected shared-host fault to skip auth-level cooldown, got unavailable=%v next=%v", updatedUS.Unavailable, updatedUS.NextRetryAfter)
+			}
+		})
+	}
+}
+
+func TestManager_MarkResult_VertexEndpointConnectionRefusedStillCooldowns(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	m := NewManager(nil, nil, nil)
+	authUS := newVertexSATestAuth("auth-vertex-refused-us", "us-central1")
+	authEU := newVertexSATestAuth("auth-vertex-refused-eu", "europe-west4")
+	for _, a := range []*Auth{authUS, authEU} {
+		if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	endpointErr := resultErrorFromError(fmt.Errorf("dial tcp 142.250.4.1:443: connect: connection refused"))
+	if !isTransportFailureResultError(endpointErr) {
+		t.Fatalf("isTransportFailureResultError(%#v) = false, want true", endpointErr)
+	}
+
+	// A direct endpoint failure (connection refused) must keep cooldown when
+	// the location is unique in the pool.
+	model := "gemini-2.5-pro"
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authEU.ID,
+		Provider: authEU.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    endpointErr,
+	})
+	updated, ok := m.GetByID(authEU.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected unique-location vertex endpoint failure (connection refused) to keep cooldown")
+	}
+
+	// Auth-level path (empty model) must also keep cooldown.
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authUS.ID,
+		Provider: authUS.Provider,
+		Success:  false,
+		Error:    endpointErr,
+	})
+	updatedUS, okUS := m.GetByID(authUS.ID)
+	if !okUS || updatedUS == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	if updatedUS.NextRetryAfter.IsZero() {
+		t.Fatalf("expected auth-level unique-location vertex endpoint failure to keep cooldown")
+	}
+}
+
+func TestManager_MarkResult_VertexDisabledPeerSkipsCooldown(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	m := NewManager(nil, nil, nil)
+	authUS := newVertexSATestAuth("auth-vertex-disabled-peer-us", "us-central1")
+	authUS.Disabled = true
+	authEU := newVertexSATestAuth("auth-vertex-disabled-peer-eu", "europe-west4")
+	for _, a := range []*Auth{authUS, authEU} {
+		if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	endpointErr := resultErrorFromError(fmt.Errorf("dial tcp 142.250.4.1:443: connect: connection refused"))
+
+	model := "gemini-2.5-pro"
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authEU.ID,
+		Provider: authEU.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    endpointErr,
+	})
+	// The only other vertex SA auth is disabled, so the failing auth is the
+	// only pollable credential and must not be cooled down.
+	assertNoCooldown(t, m, authEU.ID, model)
+
+	// Auth-level path (empty model) must behave identically.
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authEU.ID,
+		Provider: authEU.Provider,
+		Success:  false,
+		Error:    endpointErr,
+	})
+	updated, ok := m.GetByID(authEU.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	if updated.Unavailable || !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected disabled-peer failure to skip auth-level cooldown, got unavailable=%v next=%v", updated.Unavailable, updated.NextRetryAfter)
+	}
+}

--- a/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
+++ b/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
@@ -1283,3 +1283,190 @@ func TestManager_MarkResult_VertexEndpointConnectionTimedOutStillCooldowns(t *te
 		t.Fatalf("expected unique-location vertex connection timed out to keep cooldown")
 	}
 }
+
+func TestManager_MarkResult_TransportFailureWithDirectOrNoneProxySkipsCooldown(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	transportErr := resultErrorFromError(fmt.Errorf(`Post "https://example.com/v1/chat/completions": net/http: TLS handshake timeout`))
+	if !isTransportFailureResultError(transportErr) {
+		t.Fatalf("isTransportFailureResultError(%#v) = false, want true", transportErr)
+	}
+
+	// proxyutil.Parse resolves "direct" and "none" to ModeDirect (explicit
+	// bypass, no proxy endpoint), so neither is a per-auth proxy override.
+	// The real-proxy counterpart (http://127.0.0.1:7890 keeping cooldown) is
+	// covered by TestManager_MarkResult_TransportFailureWithAuthProxyStillCooldowns.
+	for _, proxyValue := range []string{"direct", "none"} {
+		t.Run("proxy="+proxyValue, func(t *testing.T) {
+			m := NewManager(nil, nil, nil)
+			auth := &Auth{ID: "auth-proxy-" + proxyValue, Provider: "codex", ProxyURL: proxyValue}
+			if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+				t.Fatalf("register auth: %v", errRegister)
+			}
+			model := "gpt-5.6-sol"
+
+			// Model-level path must skip cooldown.
+			m.MarkResult(context.Background(), Result{
+				AuthID:   auth.ID,
+				Provider: auth.Provider,
+				Model:    model,
+				Success:  false,
+				Error:    transportErr,
+			})
+			assertNoCooldown(t, m, auth.ID, model)
+
+			// Auth-level path must skip cooldown as well.
+			m.MarkResult(context.Background(), Result{
+				AuthID:   auth.ID,
+				Provider: auth.Provider,
+				Success:  false,
+				Error:    transportErr,
+			})
+			updated, ok := m.GetByID(auth.ID)
+			if !ok || updated == nil {
+				t.Fatalf("expected auth to be present")
+			}
+			if updated.Unavailable || !updated.NextRetryAfter.IsZero() {
+				t.Fatalf("expected direct/none proxy transport failure to skip auth-level cooldown, got unavailable=%v next=%v", updated.Unavailable, updated.NextRetryAfter)
+			}
+		})
+	}
+}
+
+func TestManager_MarkResult_VertexProviderCaseNormalizedStillCooldowns(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	m := NewManager(nil, nil, nil)
+	authUS := newVertexSATestAuth("auth-vertex-case-us", "us-central1")
+	authEU := newVertexSATestAuth("auth-vertex-case-eu", "europe-west4")
+	// Provider "Vertex" with a capital first letter must still be recognized
+	// as a Vertex service account, mirroring how executorKeyFromAuth trims and
+	// lowercases the provider for selection.
+	authUS.Provider = "Vertex"
+	authEU.Provider = "Vertex"
+	for _, a := range []*Auth{authUS, authEU} {
+		if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	endpointErr := resultErrorFromError(fmt.Errorf("dial tcp 142.250.4.1:443: connect: connection refused"))
+	if !isVertexEndpointFailureMessage(endpointErr.Message) {
+		t.Fatalf("isVertexEndpointFailureMessage(%q) = false, want true", endpointErr.Message)
+	}
+
+	model := "gemini-2.5-pro"
+	registerClientModelForTest(t, authUS.ID, model)
+	registerClientModelForTest(t, authEU.ID, model)
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authEU.ID,
+		Provider: authEU.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    endpointErr,
+	})
+	updated, ok := m.GetByID(authEU.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected normalized Vertex provider to keep cooldown for unique location")
+	}
+}
+
+func TestManager_MarkResult_VertexWeightedPeerZeroWeightStillCooldowns(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	// Weighted selector: the same-location EU peer carries weight 0 and is
+	// never picked for this model, while the healthy US peer (weight 1) is the
+	// only pollable alternative endpoint, so the EU failure is auth-specific.
+	m := NewManager(nil, &WeightedRoundRobinSelector{}, nil)
+	authEU := newVertexSATestAuth("auth-vertex-weight-eu", "europe-west4")
+	authEU2 := newVertexSATestAuth("auth-vertex-weight-eu2", "europe-west4")
+	authUS := newVertexSATestAuth("auth-vertex-weight-us", "us-central1")
+	authEU2.Attributes = map[string]string{AttributeWeight: "0"}
+	authUS.Attributes = map[string]string{AttributeWeight: "1"}
+	for _, a := range []*Auth{authEU, authEU2, authUS} {
+		if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	endpointErr := resultErrorFromError(fmt.Errorf("dial tcp 142.250.4.1:443: connect: connection refused"))
+
+	model := "gemini-2.5-pro"
+	for _, a := range []*Auth{authEU, authEU2, authUS} {
+		registerClientModelForTest(t, a.ID, model)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authEU.ID,
+		Provider: authEU.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    endpointErr,
+	})
+	updated, ok := m.GetByID(authEU.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected weighted zero-weight same-location peer to keep cooldown")
+	}
+}
+
+func TestManager_MarkResult_VertexRoundRobinIgnoresWeightSkipsCooldown(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	// Default round-robin selector ignores weights entirely, so the
+	// same-location EU peer (weight 0) still counts as a pollable alternative
+	// endpoint and the failure is not auth-specific: cooldown is skipped.
+	m := NewManager(nil, nil, nil)
+	authEU := newVertexSATestAuth("auth-vertex-rr-eu", "europe-west4")
+	authEU2 := newVertexSATestAuth("auth-vertex-rr-eu2", "europe-west4")
+	authUS := newVertexSATestAuth("auth-vertex-rr-us", "us-central1")
+	authEU2.Attributes = map[string]string{AttributeWeight: "0"}
+	authUS.Attributes = map[string]string{AttributeWeight: "1"}
+	for _, a := range []*Auth{authEU, authEU2, authUS} {
+		if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	endpointErr := resultErrorFromError(fmt.Errorf("dial tcp 142.250.4.1:443: connect: connection refused"))
+
+	model := "gemini-2.5-pro"
+	for _, a := range []*Auth{authEU, authEU2, authUS} {
+		registerClientModelForTest(t, a.ID, model)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authEU.ID,
+		Provider: authEU.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    endpointErr,
+	})
+	assertNoCooldown(t, m, authEU.ID, model)
+}

--- a/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
+++ b/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
@@ -877,7 +877,10 @@ func TestManager_MarkResult_VertexEndpointConnectionRefusedStillCooldowns(t *tes
 		t.Fatalf("expected unique-location vertex endpoint failure (connection refused) to keep cooldown")
 	}
 
-	// Auth-level path (empty model) must also keep cooldown.
+	// Auth-level path (empty model): the only other vertex SA peer (authEU)
+	// is already cooling from the model-level step above, so it cannot serve
+	// requests and the failing auth is the only pollable credential. It must
+	// not cool down (same principle as the disabled-peer case).
 	m.MarkResult(context.Background(), Result{
 		AuthID:   authUS.ID,
 		Provider: authUS.Provider,
@@ -888,8 +891,8 @@ func TestManager_MarkResult_VertexEndpointConnectionRefusedStillCooldowns(t *tes
 	if !okUS || updatedUS == nil {
 		t.Fatalf("expected auth to be present")
 	}
-	if updatedUS.NextRetryAfter.IsZero() {
-		t.Fatalf("expected auth-level unique-location vertex endpoint failure to keep cooldown")
+	if updatedUS.Unavailable || !updatedUS.NextRetryAfter.IsZero() {
+		t.Fatalf("expected cooling-peer failure to skip auth-level cooldown, got unavailable=%v next=%v", updatedUS.Unavailable, updatedUS.NextRetryAfter)
 	}
 }
 
@@ -939,4 +942,142 @@ func TestManager_MarkResult_VertexDisabledPeerSkipsCooldown(t *testing.T) {
 	if updated.Unavailable || !updated.NextRetryAfter.IsZero() {
 		t.Fatalf("expected disabled-peer failure to skip auth-level cooldown, got unavailable=%v next=%v", updated.Unavailable, updated.NextRetryAfter)
 	}
+}
+
+func TestManager_MarkResult_VertexCoolingPeerStillCooldowns(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	now := time.Now()
+	model := "gemini-2.5-pro"
+	endpointErr := resultErrorFromError(fmt.Errorf("dial tcp 142.250.4.1:443: connect: connection refused"))
+
+	// Model-level path: the failing EU auth shares its location only with a
+	// peer that is itself cooling down (quota cooldown for the same model),
+	// so the scheduler would never rotate to that peer. The healthy US auth
+	// offers the only reachable endpoint, so the failing auth must cool down
+	// to let rotation switch locations.
+	mModel := NewManager(nil, nil, nil)
+	authEU := newVertexSATestAuth("auth-vertex-cool-peer-eu", "europe-west4")
+	authEUPeer := newVertexSATestAuth("auth-vertex-cool-peer-eu-peer", "europe-west4")
+	authEUPeer.ModelStates = map[string]*ModelState{
+		model: {
+			Status:         StatusError,
+			Unavailable:    true,
+			NextRetryAfter: now.Add(10 * time.Minute),
+			Quota: QuotaState{
+				Exceeded:      true,
+				Reason:        "quota",
+				NextRecoverAt: now.Add(10 * time.Minute),
+			},
+		},
+	}
+	authUS := newVertexSATestAuth("auth-vertex-cool-peer-us", "us-central1")
+	for _, a := range []*Auth{authEU, authEUPeer, authUS} {
+		if _, errRegister := mModel.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	if blocked, _, _ := isAuthBlockedForModel(authEUPeer, model, now); !blocked {
+		t.Fatalf("expected cooling peer to be blocked for model")
+	}
+	mModel.MarkResult(context.Background(), Result{
+		AuthID:   authEU.ID,
+		Provider: authEU.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    endpointErr,
+	})
+	updated, ok := mModel.GetByID(authEU.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected cooling same-location peer to keep model cooldown")
+	}
+
+	// Auth-level path (empty model): same scenario with an auth-level cooling
+	// peer.
+	mAuth := NewManager(nil, nil, nil)
+	authEULevel := newVertexSATestAuth("auth-vertex-cool-peer-level-eu", "europe-west4")
+	authPeerLevel := newVertexSATestAuth("auth-vertex-cool-peer-level-eu-peer", "europe-west4")
+	authPeerLevel.Unavailable = true
+	authPeerLevel.NextRetryAfter = now.Add(10 * time.Minute)
+	authPeerLevel.Quota = QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: now.Add(10 * time.Minute)}
+	authUSLevel := newVertexSATestAuth("auth-vertex-cool-peer-level-us", "us-central1")
+	for _, a := range []*Auth{authEULevel, authPeerLevel, authUSLevel} {
+		if _, errRegister := mAuth.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	if blocked, _, _ := isAuthBlockedForModel(authPeerLevel, "", now); !blocked {
+		t.Fatalf("expected auth-level cooling peer to be blocked")
+	}
+	mAuth.MarkResult(context.Background(), Result{
+		AuthID:   authEULevel.ID,
+		Provider: authEULevel.Provider,
+		Success:  false,
+		Error:    endpointErr,
+	})
+	updatedLevel, okLevel := mAuth.GetByID(authEULevel.ID)
+	if !okLevel || updatedLevel == nil {
+		t.Fatalf("expected auth-level auth to be present")
+	}
+	if updatedLevel.NextRetryAfter.IsZero() {
+		t.Fatalf("expected cooling same-location peer to keep auth-level cooldown")
+	}
+}
+
+func TestManager_MarkResult_VertexExpiredCooldownPeerSkipsCooldown(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	now := time.Now()
+	model := "gemini-2.5-pro"
+	endpointErr := resultErrorFromError(fmt.Errorf("dial tcp 142.250.4.1:443: connect: connection refused"))
+
+	m := NewManager(nil, nil, nil)
+	authEU := newVertexSATestAuth("auth-vertex-expired-peer-eu", "europe-west4")
+	authPeer := newVertexSATestAuth("auth-vertex-expired-peer-eu-peer", "europe-west4")
+	authPeer.ModelStates = map[string]*ModelState{
+		model: {
+			Status:         StatusError,
+			Unavailable:    true,
+			NextRetryAfter: now.Add(-time.Minute),
+			Quota: QuotaState{
+				Exceeded:      true,
+				Reason:        "quota",
+				NextRecoverAt: now.Add(-time.Minute),
+			},
+		},
+	}
+	for _, a := range []*Auth{authEU, authPeer} {
+		if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	if blocked, _, _ := isAuthBlockedForModel(authPeer, model, now); blocked {
+		t.Fatalf("expected expired-cooldown peer to be pollable")
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authEU.ID,
+		Provider: authEU.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    endpointErr,
+	})
+	// The same-location peer's cooldown has expired, so it is pollable again
+	// and the endpoint is shared: cooldown must stay skipped.
+	assertNoCooldown(t, m, authEU.ID, model)
 }

--- a/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
+++ b/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
@@ -397,3 +397,72 @@ func TestIsConnectionLifecycleError_TransportTextWithStatusStillCooldowns(t *tes
 		t.Fatalf("shouldSkipCredentialCooldown = true, want false")
 	}
 }
+
+func TestManager_MarkResult_TransportFailureWithAuthProxyStillCooldowns(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-transport-proxy", Provider: "codex", ProxyURL: "http://127.0.0.1:7890"}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	transportErr := resultErrorFromError(fmt.Errorf("proxyconnect tcp: dial tcp 127.0.0.1:7890: connect: connection refused"))
+
+	model := "gpt-5.6-sol"
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    transportErr,
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected per-auth proxy transport failure to keep cooldown")
+	}
+
+	// Client cancellation must still skip cooldown even with a per-auth proxy.
+	authCancel := &Auth{ID: "auth-transport-proxy-cancel", Provider: "codex", ProxyURL: "http://127.0.0.1:7890"}
+	if _, errRegister := m.Register(context.Background(), authCancel); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authCancel.ID,
+		Provider: authCancel.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    resultErrorFromError(context.Canceled),
+	})
+	assertNoCooldown(t, m, authCancel.ID, model)
+
+	// Auth-level path (empty model) must also keep cooldown for transport
+	// failures through a per-auth proxy.
+	authLevel := &Auth{ID: "auth-transport-proxy-auth-level", Provider: "codex", ProxyURL: "http://127.0.0.1:7890"}
+	if _, errRegister := m.Register(context.Background(), authLevel); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authLevel.ID,
+		Provider: authLevel.Provider,
+		Success:  false,
+		Error:    transportErr,
+	})
+	updatedAuthLevel, okAuthLevel := m.GetByID(authLevel.ID)
+	if !okAuthLevel || updatedAuthLevel == nil {
+		t.Fatalf("expected auth-level auth to be present")
+	}
+	if updatedAuthLevel.NextRetryAfter.IsZero() {
+		t.Fatalf("expected auth-level transport failure via per-auth proxy to keep cooldown")
+	}
+}

--- a/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
+++ b/sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
@@ -494,3 +494,138 @@ func TestManager_MarkResult_RequestScopedTransportTextWithAuthProxySkipsCooldown
 	})
 	assertNoCooldown(t, m, auth.ID, model)
 }
+
+func newVertexSATestAuth(id, location string) *Auth {
+	metadata := map[string]any{
+		"service_account": map[string]any{
+			"project_id":   "test-project",
+			"client_email": "sa@test-project.iam.gserviceaccount.com",
+		},
+		"project_id": "test-project",
+	}
+	if location != "" {
+		metadata["location"] = location
+	}
+	return &Auth{ID: id, Provider: "vertex", Metadata: metadata}
+}
+
+func TestManager_MarkResult_TransportFailureWithUniqueVertexLocationStillCooldowns(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	m := NewManager(nil, nil, nil)
+	authA := newVertexSATestAuth("auth-vertex-us", "us-central1")
+	authB := newVertexSATestAuth("auth-vertex-eu", "europe-west4")
+	for _, a := range []*Auth{authA, authB} {
+		if _, errRegister := m.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	transportErr := resultErrorFromError(fmt.Errorf("dial tcp: lookup europe-west4-aiplatform.googleapis.com: no such host"))
+
+	model := "gemini-2.5-pro"
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authB.ID,
+		Provider: authB.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    transportErr,
+	})
+
+	updated, ok := m.GetByID(authB.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected unique-location vertex transport failure to keep cooldown")
+	}
+
+	// Auth-level path (empty model) must also keep cooldown. It needs a
+	// location not used by other pool members to count as auth-specific.
+	authLevel := newVertexSATestAuth("auth-vertex-eu-level", "asia-south1")
+	if _, errRegister := m.Register(context.Background(), authLevel); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authLevel.ID,
+		Provider: authLevel.Provider,
+		Success:  false,
+		Error:    transportErr,
+	})
+	updatedAuthLevel, okAuthLevel := m.GetByID(authLevel.ID)
+	if !okAuthLevel || updatedAuthLevel == nil {
+		t.Fatalf("expected auth-level auth to be present")
+	}
+	if updatedAuthLevel.NextRetryAfter.IsZero() {
+		t.Fatalf("expected auth-level unique-location vertex transport failure to keep cooldown")
+	}
+
+	// Non-transport lifecycle failures (client cancellation) still skip cooldown
+	// even with a unique vertex location.
+	authCancel := newVertexSATestAuth("auth-vertex-ap-cancel", "asia-east1")
+	if _, errRegister := m.Register(context.Background(), authCancel); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authCancel.ID,
+		Provider: authCancel.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    resultErrorFromError(context.Canceled),
+	})
+	assertNoCooldown(t, m, authCancel.ID, model)
+}
+
+func TestManager_MarkResult_TransportFailureWithSharedVertexLocationSkipsCooldown(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	transportErr := resultErrorFromError(fmt.Errorf("dial tcp: lookup us-central1-aiplatform.googleapis.com: no such host"))
+	model := "gemini-2.5-pro"
+
+	// Shared location: the fault may be regional and affect both auths, so
+	// cooldown must stay skipped.
+	mShared := NewManager(nil, nil, nil)
+	sharedA := newVertexSATestAuth("auth-vertex-shared-a", "us-central1")
+	sharedB := newVertexSATestAuth("auth-vertex-shared-b", "us-central1")
+	for _, a := range []*Auth{sharedA, sharedB} {
+		if _, errRegister := mShared.Register(context.Background(), a); errRegister != nil {
+			t.Fatalf("register auth: %v", errRegister)
+		}
+	}
+	mShared.MarkResult(context.Background(), Result{
+		AuthID:   sharedA.ID,
+		Provider: sharedA.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    transportErr,
+	})
+	assertNoCooldown(t, mShared, sharedA.ID, model)
+
+	// Single vertex auth: no peer offers an alternative endpoint, so skipping
+	// cooldown must stay in effect (original transport-failure fix).
+	mSingle := NewManager(nil, nil, nil)
+	single := newVertexSATestAuth("auth-vertex-single", "us-central1")
+	if _, errRegister := mSingle.Register(context.Background(), single); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	mSingle.MarkResult(context.Background(), Result{
+		AuthID:   single.ID,
+		Provider: single.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    transportErr,
+	})
+	assertNoCooldown(t, mSingle, single.ID, model)
+}

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -167,7 +167,7 @@ func TestRecoverableUnknownFailuresHaveFiniteCooldown(t *testing.T) {
 		resultErr *Error
 	}{
 		{name: "model failure without error details", model: "gpt-5"},
-		{name: "auth transport failure without status", resultErr: &Error{Message: "connection reset"}},
+		{name: "auth unknown failure without status", resultErr: &Error{Message: "upstream failed without status"}},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -117,7 +117,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	quotaErr := &Error{Code: "rate_limit", Message: "quota", HTTPStatus: http.StatusTooManyRequests}
 	auth := &Auth{ID: "auth-level-quota"}
 
-	applyAuthFailureState(auth, quotaErr, nil, now, false)
+	applyAuthFailureState(auth, quotaErr, nil, now, false, false)
 	if auth.Quota.BackoffLevel != 1 {
 		t.Fatalf("expected BackoffLevel 1 after first failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -127,7 +127,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	}
 
 	// In-window failure keeps the current window and level.
-	applyAuthFailureState(auth, quotaErr, nil, now.Add(100*time.Millisecond), false)
+	applyAuthFailureState(auth, quotaErr, nil, now.Add(100*time.Millisecond), false, false)
 	if auth.Quota.BackoffLevel != 1 {
 		t.Fatalf("expected BackoffLevel to stay 1 for in-window failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -136,7 +136,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	}
 
 	// A failure after the window expired escalates to the next level.
-	applyAuthFailureState(auth, quotaErr, nil, now.Add(2*time.Second), false)
+	applyAuthFailureState(auth, quotaErr, nil, now.Add(2*time.Second), false, false)
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel 2 after post-window failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -146,7 +146,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 
 	// A provider supplied retry hint always takes effect, even in-window.
 	retryAfter := 10 * time.Second
-	applyAuthFailureState(auth, quotaErr, &retryAfter, now.Add(3*time.Second), false)
+	applyAuthFailureState(auth, quotaErr, &retryAfter, now.Add(3*time.Second), false, false)
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel to stay 2 with retry hint, got %d", auth.Quota.BackoffLevel)
 	}


### PR DESCRIPTION
## Problem

A transport-level failure on a provider (for example open.bigmodel.cn via the openai-compatible provider returning "net/http: TLS handshake timeout") put the only credential into a 60s transient cooldown. Subsequent requests then failed first with a 500 "TLS handshake timeout" and afterwards with 503 "auth_unavailable: no auth available" until the cooldown expired, because non-quota cooldowns surface as blockReasonOther and produce a misleading auth_unavailable error.

## Fix

Classify transport-level failures as connection_lifecycle so they skip credential cooldown:

- net/http: TLS handshake timeout
- dial tcp: connection refused / connection reset
- broken pipe
- DNS no such host
- network is unreachable
- proxyconnect error
- i/o timeout

This is consistent with the existing design for client cancellation and WebSocket EOF disconnects, which already skip cooldown since they say nothing about credential health.

## Safety

The classification only applies to errors without an HTTP status. Status-bearing upstream errors (401/429/5xx response bodies) still cool down credentials exactly as before. A test covers this case.

## Tests

- Added TestManager_MarkResult_TransportFailureDoesNotCooldown in sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
- Added TestIsConnectionLifecycleError_TransportTextWithStatusStillCooldowns in sdk/cliproxy/auth/connection_lifecycle_cooldown_test.go
- Adjusted one pre-existing table case in sdk/cliproxy/auth/cooldown_backoff_test.go to use a non-transport message

`go test ./sdk/cliproxy/auth/ -count=1` passes.

## Note

This change does not add in-request retries for these errors; it prevents credential penalization so the next request retries naturally.