### PR TITLE
fix(claude): dedupe replayed tool results

### DIFF
--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -175,6 +175,19 @@ func convertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream,
 	if messages := root.Get("messages"); messages.Exists() && messages.IsArray() {
 		systemBlocks := make([][]byte, 0)
 		messageAccumulator := common.NewClaudeMessageAccumulator(int(root.Get("messages.#").Int()))
+		finalToolResultByID := make(map[string]gjson.Result)
+		messages.ForEach(func(_, message gjson.Result) bool {
+			if message.Get("role").String() == "tool" {
+				rawToolCallID := message.Get("tool_call_id").String()
+				if rawToolCallID != "" {
+					toolCallID := util.SanitizeClaudeToolID(rawToolCallID)
+					finalToolResultByID[toolCallID] = message
+				}
+			}
+			return true
+		})
+		emittedToolResultIDs := make(map[string]struct{}, len(finalToolResultByID))
+
 		messages.ForEach(func(_, message gjson.Result) bool {
 			role := message.Get("role").String()
 			contentResult := message.Get("content")
@@ -282,9 +295,17 @@ func convertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream,
 
 			case "tool":
 				// Handle tool result messages conversion
-				toolCallID := message.Get("tool_call_id").String()
-				toolCallID = util.SanitizeClaudeToolID(toolCallID)
-				toolContentResult := message.Get("content")
+				rawToolCallID := message.Get("tool_call_id").String()
+				toolCallID := util.SanitizeClaudeToolID(rawToolCallID)
+				toolResultMessage := message
+				if rawToolCallID != "" {
+					if _, exists := emittedToolResultIDs[toolCallID]; exists {
+						return true
+					}
+					emittedToolResultIDs[toolCallID] = struct{}{}
+					toolResultMessage = finalToolResultByID[toolCallID]
+				}
+				toolContentResult := toolResultMessage.Get("content")
 
 				msg := []byte(`{"role":"user","content":[{"type":"tool_result","tool_use_id":"","content":""}]}`)
 				msg, _ = sjson.SetBytes(msg, "content.0.tool_use_id", toolCallID)
@@ -294,7 +315,7 @@ func convertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream,
 				} else {
 					msg, _ = sjson.SetBytes(msg, "content.0.content", toolResultContent)
 				}
-				msg = common.AttachMessageCacheControl(msg, message)
+				msg = common.AttachMessageCacheControl(msg, toolResultMessage)
 				messageAccumulator.Append(msg)
 			}
 			return true

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request_test.go
@@ -131,6 +131,44 @@ func TestConvertOpenAIRequestToClaude_SanitizesToolCallIDsForClaude(t *testing.T
 	}
 }
 
+func TestConvertOpenAIRequestToClaude_DeduplicatesReplayedToolResults(t *testing.T) {
+	inputJSON := []byte(`{
+		"messages":[
+			{
+				"role":"assistant",
+				"tool_calls":[
+					{"id":"call_1","type":"function","function":{"name":"first","arguments":"{}"}},
+					{"id":"call_2","type":"function","function":{"name":"second","arguments":"{}"}}
+				]
+			},
+			{"role":"tool","tool_call_id":"call_1","content":"stale result"},
+			{"role":"tool","tool_call_id":"call_2","content":"parallel result"},
+			{"role":"tool","tool_call_id":"call_1","content":"final result"}
+		]
+	}`)
+
+	result := ConvertOpenAIRequestToClaude("claude-test", inputJSON, false)
+	toolResults := gjson.GetBytes(result, "messages.1.content").Array()
+	if len(toolResults) != 2 {
+		t.Fatalf("tool result count = %d, want 2. Output: %s", len(toolResults), string(result))
+	}
+	wants := []struct {
+		id      string
+		content string
+	}{
+		{id: "call_1", content: "final result"},
+		{id: "call_2", content: "parallel result"},
+	}
+	for i, want := range wants {
+		if got := toolResults[i].Get("tool_use_id").String(); got != want.id {
+			t.Fatalf("tool result %d id = %q, want %q", i, got, want.id)
+		}
+		if got := toolResults[i].Get("content").String(); got != want.content {
+			t.Fatalf("tool result %d content = %q, want %q", i, got, want.content)
+		}
+	}
+}
+
 func TestConvertOpenAIRequestToClaude_GroupsConsecutiveParallelToolResults(t *testing.T) {
 	inputJSON := `{
 		"model": "gpt-4.1",

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -255,6 +255,20 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 	}
 
 	if input := root.Get("input"); input.Exists() && input.IsArray() {
+		finalToolResultByID := make(map[string]gjson.Result)
+		input.ForEach(func(_, item gjson.Result) bool {
+			switch item.Get("type").String() {
+			case "function_call_output", "custom_tool_call_output":
+				rawCallID := item.Get("call_id").String()
+				if rawCallID != "" {
+					callID := util.SanitizeClaudeToolID(rawCallID)
+					finalToolResultByID[callID] = item
+				}
+			}
+			return true
+		})
+		emittedToolResultIDs := make(map[string]struct{}, len(finalToolResultByID))
+
 		input.ForEach(func(_, item gjson.Result) bool {
 			// System-level items already became top-level system blocks.
 			if isResponsesSystemLevelRole(item.Get("role").String()) {
@@ -412,9 +426,17 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 
 			case "function_call_output", "custom_tool_call_output":
 				// Map to user tool_result
-				callID := item.Get("call_id").String()
-				callID = util.SanitizeClaudeToolID(callID)
-				output := item.Get("output")
+				rawCallID := item.Get("call_id").String()
+				callID := util.SanitizeClaudeToolID(rawCallID)
+				toolResultItem := item
+				if rawCallID != "" {
+					if _, exists := emittedToolResultIDs[callID]; exists {
+						return true
+					}
+					emittedToolResultIDs[callID] = struct{}{}
+					toolResultItem = finalToolResultByID[callID]
+				}
+				output := toolResultItem.Get("output")
 				toolResult := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
 				toolResult, _ = sjson.SetBytes(toolResult, "tool_use_id", callID)
 				toolResult = applyResponsesToolResultContent(toolResult, output)

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
@@ -41,6 +41,41 @@ func TestConvertOpenAIResponsesRequestToClaude_SanitizesToolCallIDsForClaude(t *
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToClaude_DeduplicatesReplayedToolResults(t *testing.T) {
+	inputJSON := []byte(`{
+		"model":"claude-test",
+		"input":[
+			{"type":"function_call","call_id":"call.1","name":"lookup","arguments":"{}"},
+			{"type":"custom_tool_call","call_id":"call_2","name":"exec","input":"pwd"},
+			{"type":"function_call_output","call_id":"call.1","output":"stale function result"},
+			{"type":"custom_tool_call_output","call_id":"call_2","output":"stale custom result"},
+			{"type":"function_call_output","call_id":"call:1","output":"final function result"},
+			{"type":"custom_tool_call_output","call_id":"call_2","output":"final custom result"}
+		]
+	}`)
+
+	result := ConvertOpenAIResponsesRequestToClaude("claude-test", inputJSON, false)
+	toolResults := gjson.GetBytes(result, "messages.1.content").Array()
+	if len(toolResults) != 2 {
+		t.Fatalf("tool result count = %d, want 2. Output: %s", len(toolResults), string(result))
+	}
+	wants := []struct {
+		id      string
+		content string
+	}{
+		{id: "call_1", content: "final function result"},
+		{id: "call_2", content: "final custom result"},
+	}
+	for i, want := range wants {
+		if got := toolResults[i].Get("tool_use_id").String(); got != want.id {
+			t.Fatalf("tool result %d id = %q, want %q", i, got, want.id)
+		}
+		if got := toolResults[i].Get("content").String(); got != want.content {
+			t.Fatalf("tool result %d content = %q, want %q", i, got, want.content)
+		}
+	}
+}
+
 func TestConvertOpenAIResponsesRequestToClaude_ReasoningItemToThinkingBlock(t *testing.T) {
 	rawSignature, expectedSignature := testClaudeResponsesThinkingSignature(t)
 	raw := []byte(`{


### PR DESCRIPTION
## Summary

- deduplicate replayed Claude tool results by their sanitized call ID
- keep the final result payload at the first result's transcript position
- cover Responses function and custom tools plus Chat Completions tool messages
- preserve distinct results from normal parallel tool calls

Fixes #4997

## Root cause

A client can retry a tool submission after a network interruption and persist the same `function_call_output` more than once in its conversation history.

The OpenAI Responses-to-Claude translator converted every output item into a Claude `tool_result`. It sanitized each `call_id`, but did not check whether that Claude-facing ID had already received a result. The Chat Completions translator had the equivalent behavior for repeated `role: "tool"` messages.

Anthropic requires each `tool_use` to have exactly one result and rejected the translated request:

```text
messages.52.content.1: each tool_use must have a single result. Found multiple `tool_result` blocks with id: toolu_01EhoCqFHBzACzsL2SJFpPzS
```

Responses clients replay the full conversation history on every request. Once a duplicate output enters the stored history, every later Claude request contains the same invalid result pair, so the conversation remains unusable.

This is distinct from #4656, which addressed grouping parallel Chat Completions results with different IDs. PR #3791 addresses tool-use/result ordering and pairing, while PR #3213 preserves distinct parallel calls in another Responses translation path. Neither deduplicates repeated results with the same Claude-facing ID.

## Fix design

The translators precompute the final output item for each sanitized call ID, then emit one result when that ID first appears.

The final payload wins because it represents the client's last recorded result after a retry. Emitting it at the first result position preserves the original tool-use/result relationship and avoids moving the result past later assistant turns.

Deduplication happens in the translation layer because this is where OpenAI history becomes an Anthropic request. Executors continue receiving a valid Claude payload without depending on OpenAI history semantics.

The same rule covers:

- `function_call_output`
- `custom_tool_call_output`
- Chat Completions `role: "tool"` messages
- different raw IDs that sanitize to the same Claude-facing ID

Distinct sanitized IDs remain independent, so normal parallel tool calls still produce one result per tool use. Single tool calls and outputs without IDs retain their existing behavior.

## Verification

Before the fix, the new regression tests failed as expected:

- Responses replay fixture produced four results instead of two
- Chat Completions replay fixture produced three results instead of two

After the fix:

- duplicate function outputs retain the final payload
- duplicate custom-tool outputs retain the final payload
- duplicate Chat Completions tool messages retain the final payload
- sanitization collisions are deduplicated
- distinct parallel call IDs remain present
- existing single-call behavior remains unchanged

Commands:

```bash
go test ./internal/translator/claude/openai/responses ./internal/translator/claude/openai/chat-completions -count=1
go test ./...
go build ./cmd/server
git diff --check
```

A patched server was also run with a copied configuration on an isolated port. The same request returned:

```text
unpatched: HTTP 400, duplicate tool_result validation error
patched:   HTTP 200, completed response
```

The branch is based on the latest `upstream/dev`, and `upstream/dev` is an ancestor of the tested commit.

Minimal reproduction:

```bash
curl http://<base-url>/v1/responses \
  -H 'Authorization: Bearer <api-key>' \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "<registered-claude-model>",
    "input": [
      {
        "type": "message",
        "role": "user",
        "content": [
          {"type": "input_text", "text": "Use the lookup tool, then say done."}
        ]
      },
      {
        "type": "function_call",
        "call_id": "toolu_duplicate",
        "name": "lookup",
        "arguments": "{}"
      },
      {
        "type": "function_call_output",
        "call_id": "toolu_duplicate",
        "output": "stale result"
      },
      {
        "type": "function_call_output",
        "call_id": "toolu_duplicate",
        "output": "final result"
      }
    ],
    "tools": [
      {
        "type": "function",
        "name": "lookup",
        "description": "Return a test result",
        "parameters": {"type": "object", "properties": {}}
      }
    ],
    "max_output_tokens": 64,
    "stream": false
  }'
```
