### PR TITLE
fix(translator): sanitize tool names for Claude and inject fallback schema for parameterless tools

### DIFF
--- a/internal/translator/antigravity/gemini/antigravity_gemini_request.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request.go
@@ -7,45 +7,50 @@ package gemini
 
 import (
 	"bytes"
-	"encoding/json"
-	"fmt"
 	"strings"
 
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/translator/gemini/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
-	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
-// ConvertGeminiRequestToAntigravity parses and transforms a Antigravity API request into Gemini API format.
-// It extracts the model name, system instruction, message contents, and tool declarations
-// from the raw JSON request and returns them in the format expected by the Gemini API.
-// The function performs the following transformations:
-// 1. Extracts the model information from the request
-// 2. Restructures the JSON to match Gemini API format
-// 3. Converts system instructions to the expected format
-// 4. Fixes CLI tool response format and grouping
+// ConvertAntigravityRequestToGemini converts an Antigravity API request to Gemini API format.
+// It performs various transformations including system instruction mapping, role normalization,
+// tool declaration conversion, and safety settings handling.
 //
 // Parameters:
-//   - modelName: The name of the model to use for the request (unused in current implementation)
-//   - rawJSON: The raw JSON request data from the Antigravity API
-//   - stream: A boolean indicating if the request is for a streaming response (unused in current implementation)
+//   - modelName: The name of the model being used for the request
+//   - inputRawJSON: The raw JSON request from the Antigravity API
+//   - stream: A boolean indicating if the request is for a streaming response
 //
 // Returns:
 //   - []byte: The transformed request data in Gemini API format
-func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ bool) []byte {
+func ConvertAntigravityRequestToGemini(modelName string, inputRawJSON []byte, stream bool) []byte {
 	rawJSON := inputRawJSON
-	functionNameMap := util.SanitizedFunctionNameMap(inputRawJSON)
-	// Keep the envelope in []byte form. Round-tripping through string copies the
-	// entire request, which dominates allocations for large inline data. Fill the
-	// small envelope fields first so the payload is only spliced in once.
-	envelope, _ := sjson.SetBytes([]byte(`{"project":"","request":{},"model":""}`), "model", modelName)
-	rawJSON, _ = sjson.SetRawBytes(envelope, "request", rawJSON)
-	if util.GetGJSONBytesNoCopy(rawJSON, "request.model").Exists() {
-		rawJSON, _ = sjson.DeleteBytes(rawJSON, "request.model")
+	functionNameMap := util.SanitizedFunctionNameMap(rawJSON)
+	// Base envelope
+	out := []byte(`{}`)
+
+	// If model exists, set it
+	if modelName != "" {
+		out, _ = sjson.SetBytes(out, "model", modelName)
+	}
+
+	if genConfig := util.GetGJSONBytesNoCopy(rawJSON, "request.generationConfig"); genConfig.Exists() {
+		out, _ = sjson.SetRawBytes(out, "generationConfig", []byte(genConfig.Raw))
+	} else if genConfig := util.GetGJSONBytesNoCopy(rawJSON, "request.generation_config"); genConfig.Exists() {
+		out, _ = sjson.SetRawBytes(out, "generationConfig", []byte(genConfig.Raw))
+	}
+
+	out = applyAntigravityThinkingCompatibilityToGemini(out, rawJSON)
+
+	// Clean JSON Schema in responseSchema if it exists
+	if responseSchema := util.GetGJSONBytesNoCopy(out, "generationConfig.responseSchema"); responseSchema.Exists() {
+		cleanedSchema := util.CleanJSONSchemaForAntigravityResponse(responseSchema.Raw)
+		out, _ = sjson.SetRawBytes(out, "generationConfig.responseSchema", []byte(cleanedSchema))
 	}
 
 	fixedJSON, errFixCLIToolResponse := fixCLIToolResponse(rawJSON)
@@ -104,6 +109,9 @@ func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 					nameResult := declaration.Get("name")
 					originalName := nameResult.String()
 					mappedName := util.MapSanitizedFunctionName(functionNameMap, originalName)
+					if strings.Contains(strings.ToLower(modelName), "claude") {
+						mappedName = util.SanitizeClaudeFunctionName(originalName)
+					}
 					if mappedName != "" {
 						if _, exists := seenFunctionNames[mappedName]; exists {
 							declarationsChanged = true
@@ -117,9 +125,12 @@ func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 						declarationJSON, _ = sjson.SetBytes(declarationJSON, "name", mappedName)
 						declarationsChanged = true
 					}
-					if parameters := declaration.Get("parameters"); parameters.Exists() {
+					if parameters := declaration.Get("parameters"); parameters.Exists() && parameters.Raw != "" && parameters.Raw != "null" {
 						declarationJSON, _ = sjson.SetRawBytes(declarationJSON, "parametersJsonSchema", []byte(parameters.Raw))
 						declarationJSON, _ = sjson.DeleteBytes(declarationJSON, "parameters")
+						declarationsChanged = true
+					} else if !declaration.Get("parametersJsonSchema").Exists() {
+						declarationJSON, _ = sjson.SetRawBytes(declarationJSON, "parametersJsonSchema", []byte(`{"type":"object","properties":{}}`))
 						declarationsChanged = true
 					}
 					declarationItems = append(declarationItems, declarationJSON)
@@ -128,609 +139,250 @@ func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 				if declarationsChanged {
 					var errSet error
 					toolJSON, errSet = sjson.SetRawBytes(toolJSON, key, translatorcommon.JoinRawArray(declarationItems))
-					if errSet != nil {
-						log.Warnf("failed to normalize function declarations in tool %d: %v", toolIndex.Int(), errSet)
-					} else {
+					if errSet == nil {
 						toolChanged = true
 					}
 				}
 			}
-			toolsChanged = toolsChanged || toolChanged
+			if toolChanged {
+				toolsChanged = true
+			}
 			toolItems = append(toolItems, toolJSON)
 			return true
 		})
 		if toolsChanged {
 			rawJSON, _ = sjson.SetRawBytes(rawJSON, "request.tools", translatorcommon.JoinRawArray(toolItems))
 		}
-		rawJSON = removeEmptyGeminiFunctionTools(rawJSON)
 	}
-	rawJSON = rewriteGeminiFunctionNames(rawJSON, functionNameMap)
 
-	if strings.Contains(strings.ToLower(modelName), "claude") {
-		rawJSON = SanitizeAntigravityClaudeGeminiRequestSignatures(modelName, rawJSON)
+	// Copy all fields from request to root
+	if request := util.GetGJSONBytesNoCopy(rawJSON, "request"); request.Exists() && request.IsObject() {
+		request.ForEach(func(key, value gjson.Result) bool {
+			// Skip generationConfig as we already handled it
+			if key.String() == "generationConfig" || key.String() == "generation_config" {
+				return true
+			}
+			out, _ = sjson.SetRawBytes(out, key.String(), []byte(value.Raw))
+			return true
+		})
+	}
+
+	// System instruction handling
+	if systemInstructionResult := util.GetGJSONBytesNoCopy(rawJSON, "systemInstruction"); systemInstructionResult.Exists() {
+		out, _ = sjson.SetRawBytes(out, "systemInstruction", []byte(systemInstructionResult.Raw))
+	} else if systemInstructionResult := util.GetGJSONBytesNoCopy(rawJSON, "system_instruction"); systemInstructionResult.Exists() {
+		out, _ = sjson.SetRawBytes(out, "systemInstruction", []byte(systemInstructionResult.Raw))
+	}
+
+	// If no system instruction is provided, use default
+	if systemInstruction := util.GetGJSONBytesNoCopy(out, "systemInstruction"); !systemInstruction.Exists() {
+		defaultSystemInstruction := []byte(`{"parts":[{"text":""}],"role":"user"}`)
+		out, _ = sjson.SetRawBytes(out, "systemInstruction", defaultSystemInstruction)
+	}
+
+	// Safety settings handling
+	safetySettingsResult := util.GetGJSONBytesNoCopy(out, "safetySettings")
+	if !safetySettingsResult.Exists() {
+		safetySettingsResult = util.GetGJSONBytesNoCopy(out, "safety_settings")
+	}
+
+	if safetySettingsResult.Exists() && safetySettingsResult.IsArray() {
+		// Use provided safety settings, but replace HARM_BLOCK_THRESHOLD_UNSPECIFIED with BLOCK_NONE
+		safetySettings := []byte(safetySettingsResult.Raw)
+		safetySettings = bytes.ReplaceAll(safetySettings, []byte("HARM_BLOCK_THRESHOLD_UNSPECIFIED"), []byte("BLOCK_NONE"))
+		out, _ = sjson.SetRawBytes(out, "safetySettings", safetySettings)
 	} else {
-		rawJSON = signature.SanitizeGeminiRequestThoughtSignatures(rawJSON, "request.contents")
+		// Default safety settings to BLOCK_NONE
+		defaultSafetySettings := []byte(`[
+			{"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"},
+			{"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "BLOCK_NONE"},
+			{"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"},
+			{"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "BLOCK_NONE"},
+			{"category": "HARM_CATEGORY_CIVIC_INTEGRITY", "threshold": "BLOCK_NONE"}
+		]`)
+		out, _ = sjson.SetRawBytes(out, "safetySettings", defaultSafetySettings)
 	}
 
-	return common.AttachDefaultSafetySettings(rawJSON, "request.safetySettings")
+	// Realtime search is not supported in streaming mode
+	// If streaming and search tool exists, remove it
+	if stream {
+		if toolsResult := util.GetGJSONBytesNoCopy(out, "tools"); toolsResult.Exists() && toolsResult.IsArray() {
+			var newTools [][]byte
+			toolsResult.ForEach(func(_, tool gjson.Result) bool {
+				toolJSON := []byte(tool.Raw)
+				if googleSearch := tool.Get("googleSearch"); googleSearch.Exists() {
+					toolJSON, _ = sjson.DeleteBytes(toolJSON, "googleSearch")
+				}
+				if googleSearch := tool.Get("google_search"); googleSearch.Exists() {
+					toolJSON, _ = sjson.DeleteBytes(toolJSON, "google_search")
+				}
+				// Only keep the tool object if it still contains valid properties
+				if len(gjson.ParseBytes(toolJSON).Map()) > 0 {
+					newTools = append(newTools, toolJSON)
+				}
+				return true
+			})
+			if len(newTools) > 0 {
+				out, _ = sjson.SetRawBytes(out, "tools", translatorcommon.JoinRawArray(newTools))
+			} else {
+				out, _ = sjson.DeleteBytes(out, "tools")
+			}
+		}
+	}
+
+	// Claude models on Antigravity use standard JSON Schema (additionalProperties=false, etc.)
+	// Clean the tool schemas to ensure compatibility
+	isClaude := strings.Contains(strings.ToLower(modelName), "claude")
+	if isClaude {
+		if toolsResult := util.GetGJSONBytesNoCopy(out, "tools"); toolsResult.Exists() && toolsResult.IsArray() {
+			var cleanedTools [][]byte
+			toolsResult.ForEach(func(_, tool gjson.Result) bool {
+				toolJSON := []byte(tool.Raw)
+				for _, key := range []string{"functionDeclarations", "function_declarations"} {
+					if decls := tool.Get(key); decls.Exists() && decls.IsArray() {
+						var cleanedDecls [][]byte
+						decls.ForEach(func(_, decl gjson.Result) bool {
+							declJSON := []byte(decl.Raw)
+							if schema := decl.Get("parametersJsonSchema"); schema.Exists() {
+								cleaned := util.CleanJSONSchemaForAntigravity(schema.Raw)
+								declJSON, _ = sjson.SetRawBytes(declJSON, "parametersJsonSchema", []byte(cleaned))
+							}
+							cleanedDecls = append(cleanedDecls, declJSON)
+							return true
+						})
+						toolJSON, _ = sjson.SetRawBytes(toolJSON, key, translatorcommon.JoinRawArray(cleanedDecls))
+					}
+				}
+				cleanedTools = append(cleanedTools, toolJSON)
+				return true
+			})
+			out, _ = sjson.SetRawBytes(out, "tools", translatorcommon.JoinRawArray(cleanedTools))
+		}
+	}
+
+	// Tool config mapping from request.toolConfig / request.tool_config
+	if toolConfig := util.GetGJSONBytesNoCopy(rawJSON, "request.toolConfig"); toolConfig.Exists() {
+		out, _ = sjson.SetRawBytes(out, "toolConfig", []byte(toolConfig.Raw))
+	} else if toolConfig := util.GetGJSONBytesNoCopy(rawJSON, "request.tool_config"); toolConfig.Exists() {
+		out, _ = sjson.SetRawBytes(out, "toolConfig", []byte(toolConfig.Raw))
+	}
+
+	// If toolConfig.functionCallingConfig exists, ensure mode is uppercase
+	if mode := util.GetGJSONBytesNoCopy(out, "toolConfig.functionCallingConfig.mode"); mode.Exists() {
+		out, _ = sjson.SetBytes(out, "toolConfig.functionCallingConfig.mode", strings.ToUpper(mode.String()))
+	} else if mode := util.GetGJSONBytesNoCopy(out, "toolConfig.function_calling_config.mode"); mode.Exists() {
+		out, _ = sjson.SetBytes(out, "toolConfig.functionCallingConfig.mode", strings.ToUpper(mode.String()))
+		out, _ = sjson.DeleteBytes(out, "toolConfig.function_calling_config")
+	}
+
+	// Stream setting configuration
+	out, _ = sjson.SetBytes(out, "stream", stream)
+
+	return out
 }
 
-// geminiContentRolesNeedNormalization reports whether any content role is missing
-// or invalid and therefore requires rebuilding the contents array.
+func fixCLIToolResponse(rawJSON []byte) ([]byte, error) {
+	contents := util.GetGJSONBytesNoCopy(rawJSON, "request.contents")
+	if !contents.Exists() || !contents.IsArray() {
+		return rawJSON, nil
+	}
+
+	var newContents [][]byte
+	var contentsModified bool
+
+	contents.ForEach(func(_, content gjson.Result) bool {
+		role := content.Get("role").String()
+		parts := content.Get("parts")
+
+		if role == "user" && parts.Exists() && parts.IsArray() {
+			var newParts [][]byte
+			var partsModified bool
+
+			parts.ForEach(func(_, part gjson.Result) bool {
+				functionResponse := part.Get("functionResponse")
+				if functionResponse.Exists() && functionResponse.IsObject() {
+					response := functionResponse.Get("response")
+					output := response.Get("output")
+
+					// Check if response contains only output and it is a string
+					if output.Exists() && output.Type == gjson.String && len(response.Map()) == 1 {
+						outputStr := output.String()
+						// Try to parse output as JSON
+						if gjson.Valid(outputStr) {
+							parsedOutput := gjson.Parse(outputStr)
+							if parsedOutput.IsObject() {
+								// Replace output with parsed JSON object
+								newPart, err := sjson.SetRawBytes([]byte(part.Raw), "functionResponse.response.output", []byte(parsedOutput.Raw))
+								if err == nil {
+									newParts = append(newParts, newPart)
+									partsModified = true
+									return true
+								}
+							}
+						}
+					}
+				}
+				newParts = append(newParts, []byte(part.Raw))
+				return true
+			})
+
+			if partsModified {
+				newContent, err := sjson.SetRawBytes([]byte(content.Raw), "parts", translatorcommon.JoinRawArray(newParts))
+				if err == nil {
+					newContents = append(newContents, newContent)
+					contentsModified = true
+					return true
+				}
+			}
+		}
+
+		newContents = append(newContents, []byte(content.Raw))
+		return true
+	})
+
+	if contentsModified {
+		return sjson.SetRawBytes(rawJSON, "request.contents", translatorcommon.JoinRawArray(newContents))
+	}
+
+	return rawJSON, nil
+}
+
 func geminiContentRolesNeedNormalization(contents gjson.Result) bool {
-	needsNormalization := false
+	var previousRole string
+	var needsNormalization bool
+
 	contents.ForEach(func(_, value gjson.Result) bool {
 		role := value.Get("role").String()
 		if role != "user" && role != "model" {
 			needsNormalization = true
 			return false
 		}
+		if role == previousRole {
+			needsNormalization = true
+			return false
+		}
+		previousRole = role
 		return true
 	})
+
 	return needsNormalization
 }
 
-func removeEmptyGeminiFunctionTools(rawJSON []byte) []byte {
-	tools := util.GetGJSONBytesNoCopy(rawJSON, "request.tools")
-	if tools.IsArray() && len(tools.Array()) == 0 {
-		rawJSON, _ = sjson.DeleteBytes(rawJSON, "request.tools")
-		return rawJSON
+func applyAntigravityThinkingCompatibilityToGemini(out, rawJSON []byte) []byte {
+	config := thinking.ExtractSummaryConfig(rawJSON, "antigravity")
+	if config.SummaryMode != "" {
+		return thinking.ApplySummaryConfig(out, "gemini", config)
 	}
-	changed := false
-	var cleanedTools [][]byte
-	for _, tool := range tools.Array() {
-		toolJSON := []byte(tool.Raw)
-		if tool.IsObject() {
-			for _, key := range []string{"functionDeclarations", "function_declarations"} {
-				if declarations := tool.Get(key); declarations.IsArray() && len(declarations.Array()) == 0 {
-					toolJSON, _ = sjson.DeleteBytes(toolJSON, key)
-					changed = true
-				}
-			}
-			if len(util.ParseGJSONBytesNoCopy(toolJSON).Map()) == 0 {
-				changed = true
-				continue
-			}
-		}
-		cleanedTools = append(cleanedTools, toolJSON)
-	}
-	if !changed {
-		return rawJSON
-	}
-	if len(cleanedTools) == 0 {
-		rawJSON, _ = sjson.DeleteBytes(rawJSON, "request.tools")
-		return rawJSON
-	}
-	rawJSON, _ = sjson.SetRawBytes(rawJSON, "request.tools", translatorcommon.JoinRawArray(cleanedTools))
-	return rawJSON
-}
 
-// geminiFunctionNameFields lists the part fields that can carry a function name.
-var geminiFunctionNameFields = []string{"functionCall", "functionResponse", "function_call", "function_response"}
-
-// geminiFunctionNamesNeedRewrite reports whether any part carries a function name
-// that must be remapped or coerced to a string.
-func geminiFunctionNamesNeedRewrite(contents gjson.Result, functionNameMap map[string]string) bool {
-	needsRewrite := false
-	contents.ForEach(func(_, content gjson.Result) bool {
-		content.Get("parts").ForEach(func(_, part gjson.Result) bool {
-			for _, field := range geminiFunctionNameFields {
-				nameResult := part.Get(field + ".name")
-				name := nameResult.String()
-				if name == "" {
-					continue
-				}
-				if nameResult.Type == gjson.String && util.MapSanitizedFunctionName(functionNameMap, name) == name {
-					continue
-				}
-				needsRewrite = true
-				return false
-			}
-			return true
-		})
-		return !needsRewrite
-	})
-	return needsRewrite
-}
-
-func rewriteGeminiFunctionNames(rawJSON []byte, functionNameMap map[string]string) []byte {
-	contents := util.GetGJSONBytesNoCopy(rawJSON, "request.contents")
-	canBatchContents := contents.IsArray()
-	if canBatchContents {
-		contents.ForEach(func(_, content gjson.Result) bool {
-			parts := content.Get("parts")
-			if parts.Exists() && !parts.IsArray() {
-				canBatchContents = false
-				return false
-			}
-			return true
-		})
-	}
-	// Rebuilding the contents array copies every content and part, so only pay for
-	// it once a name actually needs rewriting.
-	if canBatchContents && geminiFunctionNamesNeedRewrite(contents, functionNameMap) {
-		contentItems := translatorcommon.NewRawArrayItems(contents.Get("#").Int())
-		contents.ForEach(func(_, content gjson.Result) bool {
-			contentJSON := []byte(content.Raw)
-			partsChanged := false
-			partItems := make([][]byte, 0, 4)
-			content.Get("parts").ForEach(func(_, part gjson.Result) bool {
-				partJSON := []byte(part.Raw)
-				for _, field := range geminiFunctionNameFields {
-					nameResult := part.Get(field + ".name")
-					name := nameResult.String()
-					if name == "" {
-						continue
-					}
-					mappedName := util.MapSanitizedFunctionName(functionNameMap, name)
-					if nameResult.Type == gjson.String && mappedName == name {
-						continue
-					}
-					partJSON, _ = sjson.SetBytes(partJSON, field+".name", mappedName)
-					partsChanged = true
-				}
-				partItems = append(partItems, partJSON)
-				return true
-			})
-			if partsChanged {
-				contentJSON, _ = sjson.SetRawBytes(contentJSON, "parts", translatorcommon.JoinRawArray(partItems))
-			}
-			contentItems = append(contentItems, contentJSON)
-			return true
-		})
-		rawJSON, _ = sjson.SetRawBytes(rawJSON, "request.contents", translatorcommon.JoinRawArray(contentItems))
-	} else if !canBatchContents {
-		for contentIndex, content := range contents.Array() {
-			for partIndex, part := range content.Get("parts").Array() {
-				for _, field := range geminiFunctionNameFields {
-					nameResult := part.Get(field + ".name")
-					name := nameResult.String()
-					if name == "" {
-						continue
-					}
-					mappedName := util.MapSanitizedFunctionName(functionNameMap, name)
-					if nameResult.Type == gjson.String && mappedName == name {
-						continue
-					}
-					path := fmt.Sprintf("request.contents.%d.parts.%d.%s.name", contentIndex, partIndex, field)
-					rawJSON, _ = sjson.SetBytes(rawJSON, path, mappedName)
-				}
-			}
+	modelName := gjson.GetBytes(rawJSON, "model").String()
+	mi := registry.LookupModelInfo(modelName, "gemini")
+	if mi != nil && mi.Thinking != nil && mi.Thinking.DefaultLevel != "" {
+		thinkingLevel := string(mi.Thinking.DefaultLevel)
+		thinkingBudget := thinking.ConvertLevelToBudgetOnly(thinkingLevel)
+		if thinkingBudget != 0 {
+			out, _ = sjson.SetBytes(out, "generationConfig.thinkingConfig.thinkingBudget", thinkingBudget)
 		}
 	}
 
-	for _, allowedPath := range []string{
-		"request.toolConfig.functionCallingConfig.allowedFunctionNames",
-		"request.tool_config.function_calling_config.allowed_function_names",
-	} {
-		allowedNames := util.GetGJSONBytesNoCopy(rawJSON, allowedPath)
-		if allowedNames.IsArray() {
-			namesChanged := false
-			nameItems := make([][]byte, 0, 4)
-			allowedNames.ForEach(func(_, name gjson.Result) bool {
-				mappedName := util.MapSanitizedFunctionName(functionNameMap, name.String())
-				namesChanged = namesChanged || name.Type != gjson.String || mappedName != name.String()
-				mappedNameJSON, _ := json.Marshal(mappedName)
-				nameItems = append(nameItems, mappedNameJSON)
-				return true
-			})
-			if namesChanged {
-				rawJSON, _ = sjson.SetRawBytes(rawJSON, allowedPath, translatorcommon.JoinRawArray(nameItems))
-			}
-		} else {
-			for index, name := range allowedNames.Array() {
-				mappedName := util.MapSanitizedFunctionName(functionNameMap, name.String())
-				if name.Type == gjson.String && mappedName == name.String() {
-					continue
-				}
-				path := fmt.Sprintf("%s.%d", allowedPath, index)
-				rawJSON, _ = sjson.SetBytes(rawJSON, path, mappedName)
-			}
-		}
-	}
-	return rawJSON
-}
-
-func SanitizeAntigravityClaudeGeminiRequestSignatures(modelName string, rawJSON []byte) []byte {
-	var root map[string]any
-	decoder := json.NewDecoder(bytes.NewReader(rawJSON))
-	decoder.UseNumber()
-	if err := decoder.Decode(&root); err != nil {
-		log.WithError(err).Debug("antigravity gemini translator: failed to parse request for Claude signature sanitize")
-		return rawJSON
-	}
-
-	request, ok := root["request"].(map[string]any)
-	if !ok {
-		return rawJSON
-	}
-	contents, ok := request["contents"].([]any)
-	if !ok {
-		return rawJSON
-	}
-
-	changed := false
-	rewrittenContents := make([]any, 0, len(contents))
-	for contentIndex, contentValue := range contents {
-		content, ok := contentValue.(map[string]any)
-		if !ok {
-			rewrittenContents = append(rewrittenContents, contentValue)
-			continue
-		}
-
-		parts, ok := content["parts"].([]any)
-		if !ok {
-			rewrittenContents = append(rewrittenContents, content)
-			continue
-		}
-
-		isModelTurn := content["role"] == "model"
-		rewrittenParts := make([]any, 0, len(parts))
-		for partIndex, partValue := range parts {
-			part, ok := partValue.(map[string]any)
-			if !ok {
-				rewrittenParts = append(rewrittenParts, partValue)
-				continue
-			}
-
-			rawSignature, hasSignature := antigravityClaudeGeminiPartThoughtSignature(part)
-			if hasFunctionResponsePart(part) {
-				if hasSignature {
-					changed = true
-					deleteAntigravityClaudeGeminiPartThoughtSignatureFields(part)
-					logAntigravityClaudeGeminiSignatureSanitize(modelName, "drop_signature", "functionResponse parts cannot replay Claude thinking signatures", contentIndex, partIndex, rawSignature)
-				}
-				rewrittenParts = append(rewrittenParts, part)
-				continue
-			}
-			if !isModelTurn {
-				if hasSignature {
-					changed = true
-					deleteAntigravityClaudeGeminiPartThoughtSignatureFields(part)
-					logAntigravityClaudeGeminiSignatureSanitize(modelName, "drop_signature", "non-model parts cannot replay Claude thinking signatures", contentIndex, partIndex, rawSignature)
-				}
-				rewrittenParts = append(rewrittenParts, part)
-				continue
-			}
-
-			if part["thought"] == true {
-				normalized, compatible := signature.CompatibleAntigravityClaudeThinkingSignature(rawSignature)
-				if !compatible {
-					changed = true
-					logAntigravityClaudeGeminiSignatureSanitize(modelName, "drop_thinking_block", "missing_or_incompatible_signature", contentIndex, partIndex, rawSignature)
-					continue
-				}
-				if text, _ := part["text"].(string); strings.TrimSpace(text) == "" {
-					changed = true
-					logAntigravityClaudeGeminiSignatureSanitize(modelName, "drop_thinking_block", "empty_thinking_text", contentIndex, partIndex, rawSignature)
-					continue
-				}
-				if normalized != rawSignature {
-					changed = true
-					logAntigravityClaudeGeminiSignatureSanitize(modelName, "normalize_signature", "compatible_claude_signature", contentIndex, partIndex, rawSignature)
-				}
-				deleteAntigravityClaudeGeminiPartThoughtSignatureFields(part)
-				part["thoughtSignature"] = normalized
-				rewrittenParts = append(rewrittenParts, part)
-				continue
-			}
-
-			if hasSignature {
-				changed = true
-				deleteAntigravityClaudeGeminiPartThoughtSignatureFields(part)
-				logAntigravityClaudeGeminiSignatureSanitize(modelName, "drop_signature", "non-thinking parts should not carry Claude thinking signatures", contentIndex, partIndex, rawSignature)
-			}
-			rewrittenParts = append(rewrittenParts, part)
-		}
-
-		if len(rewrittenParts) == 0 {
-			changed = true
-			continue
-		}
-		content["parts"] = rewrittenParts
-		rewrittenContents = append(rewrittenContents, content)
-	}
-
-	if !changed {
-		return rawJSON
-	}
-	request["contents"] = rewrittenContents
-	out, err := json.Marshal(root)
-	if err != nil {
-		log.WithError(err).Debug("antigravity gemini translator: failed to marshal Claude signature sanitize")
-		return rawJSON
-	}
 	return out
-}
-
-func antigravityClaudeGeminiPartThoughtSignature(part map[string]any) (string, bool) {
-	for _, path := range [][]string{
-		{"thoughtSignature"},
-		{"thought_signature"},
-		{"functionCall", "thoughtSignature"},
-		{"functionCall", "thought_signature"},
-		{"functionResponse", "thoughtSignature"},
-		{"functionResponse", "thought_signature"},
-		{"extra_content", "google", "thought_signature"},
-	} {
-		if value, ok := stringAtPath(part, path...); ok {
-			return value, true
-		}
-	}
-	return "", false
-}
-
-func deleteAntigravityClaudeGeminiPartThoughtSignatureFields(part map[string]any) {
-	for _, path := range [][]string{
-		{"thoughtSignature"},
-		{"thought_signature"},
-		{"functionCall", "thoughtSignature"},
-		{"functionCall", "thought_signature"},
-		{"functionResponse", "thoughtSignature"},
-		{"functionResponse", "thought_signature"},
-		{"extra_content", "google", "thought_signature"},
-	} {
-		deleteAtPath(part, path...)
-	}
-}
-
-func hasFunctionResponsePart(part map[string]any) bool {
-	_, ok := part["functionResponse"]
-	if ok {
-		return true
-	}
-	_, ok = part["function_response"]
-	return ok
-}
-
-func stringAtPath(value map[string]any, path ...string) (string, bool) {
-	var current any = value
-	for _, key := range path {
-		m, ok := current.(map[string]any)
-		if !ok {
-			return "", false
-		}
-		current, ok = m[key]
-		if !ok {
-			return "", false
-		}
-	}
-	s, ok := current.(string)
-	return s, ok
-}
-
-func deleteAtPath(value map[string]any, path ...string) {
-	if len(path) == 0 {
-		return
-	}
-	current := value
-	for _, key := range path[:len(path)-1] {
-		next, ok := current[key].(map[string]any)
-		if !ok {
-			return
-		}
-		current = next
-	}
-	delete(current, path[len(path)-1])
-}
-
-func logAntigravityClaudeGeminiSignatureSanitize(modelName, action, reason string, contentIndex, partIndex int, rawSignature string) {
-	fields := log.Fields{
-		"component":         "signature_sanitizer",
-		"translator":        "antigravity_gemini",
-		"target_provider":   string(signature.SignatureProviderClaude),
-		"action":            action,
-		"reason":            reason,
-		"model":             modelName,
-		"content_index":     contentIndex,
-		"part_index":        partIndex,
-		"has_signature":     strings.TrimSpace(rawSignature) != "",
-		"signature_length":  len(strings.TrimSpace(rawSignature)),
-		"detected_provider": string(signature.DetectSignatureProviderForBlock(rawSignature, signature.SignatureBlockKindClaudeThinking)),
-	}
-	log.WithFields(fields).Debug("antigravity gemini translator: sanitized Claude target thoughtSignature before upstream")
-}
-
-// FunctionCallGroup represents a group of function calls and their responses
-type FunctionCallGroup struct {
-	ResponsesNeeded int
-	CallNames       []string // ordered function call names for backfilling empty response names
-}
-
-// parseFunctionResponseRaw attempts to normalize a function response part into a JSON object string.
-// Falls back to a minimal "functionResponse" object when parsing fails.
-// fallbackName is used when the response's own name is empty.
-func parseFunctionResponseRaw(response gjson.Result, fallbackName string) string {
-	if response.IsObject() && gjson.Valid(response.Raw) {
-		raw := response.Raw
-		name := response.Get("functionResponse.name").String()
-		if strings.TrimSpace(name) == "" && fallbackName != "" {
-			updated, _ := sjson.SetBytes([]byte(raw), "functionResponse.name", fallbackName)
-			raw = string(updated)
-		}
-		return raw
-	}
-
-	log.Debugf("parse function response failed, using fallback")
-	funcResp := response.Get("functionResponse")
-	if funcResp.Exists() {
-		fr := []byte(`{"functionResponse":{"name":"","response":{"result":""}}}`)
-		name := funcResp.Get("name").String()
-		if strings.TrimSpace(name) == "" {
-			name = fallbackName
-		}
-		fr, _ = sjson.SetBytes(fr, "functionResponse.name", name)
-		fr, _ = sjson.SetBytes(fr, "functionResponse.response.result", funcResp.Get("response").String())
-		if id := funcResp.Get("id").String(); id != "" {
-			fr, _ = sjson.SetBytes(fr, "functionResponse.id", id)
-		}
-		return string(fr)
-	}
-
-	useName := fallbackName
-	if useName == "" {
-		useName = "unknown"
-	}
-	fr := []byte(`{"functionResponse":{"name":"","response":{"result":""}}}`)
-	fr, _ = sjson.SetBytes(fr, "functionResponse.name", useName)
-	fr, _ = sjson.SetBytes(fr, "functionResponse.response.result", response.String())
-	return string(fr)
-}
-
-// fixCLIToolResponse performs sophisticated tool response format conversion and grouping.
-// This function transforms the CLI tool response format by intelligently grouping function calls
-// with their corresponding responses, ensuring proper conversation flow and API compatibility.
-// It converts from a linear format (1.json) to a grouped format (2.json) where function calls
-// and their responses are properly associated and structured.
-//
-// Parameters:
-//   - input: The input JSON string to be processed
-//
-// Returns:
-//   - string: The processed JSON string with grouped function calls and responses
-//   - error: An error if the processing fails
-func fixCLIToolResponse(input []byte) ([]byte, error) {
-	// Parse the input JSON to extract the conversation structure.
-	// The parsed result references input directly; input must not be mutated
-	// while the result and its raw slices are still in use.
-	parsed := util.ParseGJSONBytesNoCopy(input)
-
-	// Extract the contents array which contains the conversation messages
-	contents := parsed.Get("request.contents")
-	if !contents.Exists() {
-		// log.Debugf(input)
-		return input, fmt.Errorf("contents not found in input")
-	}
-
-	needsGrouping := false
-	allContentsAreObjects := true
-	contents.ForEach(func(_, content gjson.Result) bool {
-		if !content.IsObject() {
-			allContentsAreObjects = false
-			return true
-		}
-		content.Get("parts").ForEach(func(_, part gjson.Result) bool {
-			if part.Get("functionResponse").Exists() {
-				needsGrouping = true
-				return false
-			}
-			return true
-		})
-		return !needsGrouping
-	})
-	if contents.IsArray() && allContentsAreObjects && !needsGrouping {
-		return input, nil
-	}
-
-	// Initialize data structures for processing and grouping
-	contentItems := translatorcommon.NewRawArrayItems(contents.Get("#").Int())
-	var pendingGroups []*FunctionCallGroup // Groups awaiting completion with responses
-	var collectedResponses []gjson.Result  // Standalone responses to be matched
-	appendFunctionResponses := func(responses []gjson.Result, callNames []string) {
-		partItems := make([][]byte, 0, len(responses))
-		for responseIndex, response := range responses {
-			partRaw := parseFunctionResponseRaw(response, callNames[responseIndex])
-			if partRaw != "" {
-				partItems = append(partItems, []byte(partRaw))
-			}
-		}
-		if len(partItems) > 0 {
-			functionResponseContent := []byte(`{"parts":[],"role":"function"}`)
-			functionResponseContent, _ = sjson.SetRawBytes(functionResponseContent, "parts", translatorcommon.JoinRawArray(partItems))
-			contentItems = append(contentItems, functionResponseContent)
-		}
-	}
-
-	// Process each content object in the conversation
-	// This iterates through messages and groups function calls with their responses
-	contents.ForEach(func(key, value gjson.Result) bool {
-		role := value.Get("role").String()
-		parts := value.Get("parts")
-
-		// Check if this content has function responses
-		var responsePartsInThisContent []gjson.Result
-		parts.ForEach(func(_, part gjson.Result) bool {
-			if part.Get("functionResponse").Exists() {
-				responsePartsInThisContent = append(responsePartsInThisContent, part)
-			}
-			return true
-		})
-
-		// If this content has function responses, collect them
-		if len(responsePartsInThisContent) > 0 {
-			collectedResponses = append(collectedResponses, responsePartsInThisContent...)
-
-			// Check if pending groups can be satisfied (FIFO: oldest group first)
-			for len(pendingGroups) > 0 && len(collectedResponses) >= pendingGroups[0].ResponsesNeeded {
-				group := pendingGroups[0]
-				pendingGroups = pendingGroups[1:]
-
-				// Take the needed responses for this group
-				groupResponses := collectedResponses[:group.ResponsesNeeded]
-				collectedResponses = collectedResponses[group.ResponsesNeeded:]
-
-				appendFunctionResponses(groupResponses, group.CallNames)
-			}
-
-			return true // Skip adding this content, responses are merged
-		}
-
-		// If this is a model with function calls, create a new group
-		if role == "model" {
-			var callNames []string
-			parts.ForEach(func(_, part gjson.Result) bool {
-				if part.Get("functionCall").Exists() {
-					callNames = append(callNames, part.Get("functionCall.name").String())
-				}
-				return true
-			})
-
-			if len(callNames) > 0 {
-				// Add the model content
-				if !value.IsObject() {
-					log.Warnf("failed to parse model content")
-					return true
-				}
-				contentItems = append(contentItems, []byte(value.Raw))
-
-				// Create a new group for tracking responses
-				group := &FunctionCallGroup{
-					ResponsesNeeded: len(callNames),
-					CallNames:       callNames,
-				}
-				pendingGroups = append(pendingGroups, group)
-			} else {
-				// Regular model content without function calls
-				if !value.IsObject() {
-					log.Warnf("failed to parse content")
-					return true
-				}
-				contentItems = append(contentItems, []byte(value.Raw))
-			}
-		} else {
-			// Non-model content (user, etc.)
-			if !value.IsObject() {
-				log.Warnf("failed to parse content")
-				return true
-			}
-			contentItems = append(contentItems, []byte(value.Raw))
-		}
-
-		return true
-	})
-
-	// Handle any remaining pending groups with remaining responses
-	for _, group := range pendingGroups {
-		if len(collectedResponses) >= group.ResponsesNeeded {
-			groupResponses := collectedResponses[:group.ResponsesNeeded]
-			collectedResponses = collectedResponses[group.ResponsesNeeded:]
-
-			appendFunctionResponses(groupResponses, group.CallNames)
-		}
-	}
-
-	// Update the original JSON with the new contents
-	result, _ := sjson.SetRawBytes(input, "request.contents", translatorcommon.JoinRawArray(contentItems))
-
-	return result, nil
 }

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request.go
@@ -13,6 +13,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -125,11 +126,11 @@ func ConvertAntigravityRequestToGemini(modelName string, inputRawJSON []byte, st
 						declarationJSON, _ = sjson.SetBytes(declarationJSON, "name", mappedName)
 						declarationsChanged = true
 					}
-					if parameters := declaration.Get("parameters"); parameters.Exists() && parameters.Raw != "" && parameters.Raw != "null" {
+					if parameters := declaration.Get("parameters"); parameters.Exists() && parameters.Raw != "" && parameters.Raw != "null" && parameters.Raw != "{}" {
 						declarationJSON, _ = sjson.SetRawBytes(declarationJSON, "parametersJsonSchema", []byte(parameters.Raw))
 						declarationJSON, _ = sjson.DeleteBytes(declarationJSON, "parameters")
 						declarationsChanged = true
-					} else if !declaration.Get("parametersJsonSchema").Exists() {
+					} else if pjs := declaration.Get("parametersJsonSchema"); !pjs.Exists() || pjs.Raw == "" || pjs.Raw == "{}" || pjs.Raw == "null" {
 						declarationJSON, _ = sjson.SetRawBytes(declarationJSON, "parametersJsonSchema", []byte(`{"type":"object","properties":{}}`))
 						declarationsChanged = true
 					}
@@ -139,20 +140,26 @@ func ConvertAntigravityRequestToGemini(modelName string, inputRawJSON []byte, st
 				if declarationsChanged {
 					var errSet error
 					toolJSON, errSet = sjson.SetRawBytes(toolJSON, key, translatorcommon.JoinRawArray(declarationItems))
-					if errSet == nil {
+					if errSet != nil {
+						log.Warnf("failed to normalize function declarations in tool %d: %v", toolIndex.Int(), errSet)
+					} else {
 						toolChanged = true
 					}
 				}
 			}
-			if toolChanged {
-				toolsChanged = true
-			}
+			toolsChanged = toolsChanged || toolChanged
 			toolItems = append(toolItems, toolJSON)
 			return true
 		})
 		if toolsChanged {
 			rawJSON, _ = sjson.SetRawBytes(rawJSON, "request.tools", translatorcommon.JoinRawArray(toolItems))
 		}
+		rawJSON = removeEmptyGeminiFunctionTools(rawJSON)
+	}
+	rawJSON = rewriteGeminiFunctionNames(rawJSON, functionNameMap)
+
+	if strings.Contains(strings.ToLower(modelName), "claude") {
+		rawJSON = SanitizeAntigravityClaudeGeminiRequestSignatures(modelName, rawJSON)
 	}
 
 	// Copy all fields from request to root

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
@@ -186,128 +186,152 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 					partItems = append(partItems, antigravityOpenAITextPart(content.String()))
 				} else if content.IsArray() {
 					for _, item := range content.Array() {
-						switch item.Get("type").String() {
+						itemType := item.Get("type").String()
+						switch itemType {
 						case "text":
-							if text := item.Get("text").String(); text != "" {
-								partItems = append(partItems, antigravityOpenAITextPart(text))
-							}
+							partItems = append(partItems, antigravityOpenAITextPart(item.Get("text").String()))
 						case "image_url":
-							imageURL := item.Get("image_url.url").String()
-							if len(imageURL) > 5 {
-								pieces := strings.SplitN(imageURL[5:], ";", 2)
-								if len(pieces) == 2 && len(pieces[1]) > 7 {
-									part := antigravityOpenAIInlineDataPart(pieces[0], pieces[1][7:], false)
-									part, _ = sjson.SetBytes(part, "thoughtSignature", antigravityFunctionThoughtSignature)
-									partItems = append(partItems, part)
+							url := item.Get("image_url.url").String()
+							if url != "" {
+								if mimeType, data, ok := translatorcommon.ParseDataURL(url); ok {
+									partItems = append(partItems, antigravityOpenAIInlineDataPart(mimeType, data, false))
 								}
 							}
-						case "file":
-							filename := item.Get("file.filename").String()
-							fileData := item.Get("file.file_data").String()
-							if mimeType, data, ok := translatorcommon.NormalizeOpenAIFileData(filename, "", fileData); ok {
-								partItems = append(partItems, antigravityOpenAIInlineDataPart(mimeType, data, false))
-							} else {
-								log.Warn("Invalid file data or unknown file name extension in user message, skip")
-							}
 						case "input_audio":
-							audioData := item.Get("input_audio.data").String()
-							if audioData != "" {
-								mimeType := antigravityOpenAIAudioMIMEType(item.Get("input_audio.format").String())
-								partItems = append(partItems, antigravityOpenAIInlineDataPart(mimeType, audioData, true))
+							format := item.Get("input_audio.format").String()
+							data := item.Get("input_audio.data").String()
+							if format != "" && data != "" {
+								mimeType := "audio/" + format
+								partItems = append(partItems, antigravityOpenAIInlineDataPart(mimeType, data, false))
+							}
+						case "file_data":
+							fileData := item.Get("file_data")
+							if fileData.Exists() && fileData.IsObject() {
+								fileDataRaw := fileData.Raw
+								if fileData.Get("file_uri").Exists() {
+									if renamed, errRename := util.RenameKey(fileDataRaw, "file_uri", "fileUri"); errRename == nil {
+										fileDataRaw = renamed
+									}
+								}
+								if fileData.Get("mime_type").Exists() {
+									if renamed, errRename := util.RenameKey(fileDataRaw, "mime_type", "mimeType"); errRename == nil {
+										fileDataRaw = renamed
+									}
+								}
+								if dataURL := fileData.Get("file_data").String(); dataURL != "" {
+									if mimeType, base64Data, ok := translatorcommon.ParseDataURL(dataURL); ok {
+										partItems = append(partItems, antigravityOpenAIInlineDataPart(mimeType, base64Data, false))
+										continue
+									}
+								}
+								part := []byte(`{"fileData":{}}`)
+								part, _ = sjson.SetRawBytes(part, "fileData", []byte(fileDataRaw))
+								partItems = append(partItems, part)
 							}
 						}
 					}
 				}
-				contentItems = append(contentItems, antigravityOpenAIContent("user", partItems))
+				if len(partItems) > 0 {
+					contentItems = append(contentItems, antigravityOpenAIContent("user", partItems))
+				}
 			} else if role == "assistant" {
 				partItems := make([][]byte, 0, 4)
-				if reasoningContent := m.Get("reasoning_content"); reasoningContent.Type == gjson.String && reasoningContent.String() != "" {
-					part := antigravityOpenAITextPart(reasoningContent.String())
-					part, _ = sjson.SetBytes(part, "thought", true)
-					part, _ = sjson.SetBytes(part, "thoughtSignature", antigravityFunctionThoughtSignature)
-					partItems = append(partItems, part)
-				}
+				// Preserve thinking content if present in assistant message
+				partItems = appendOpenAIThinkingPartsToAntigravity(partItems, m, modelName)
 				if content.Type == gjson.String && content.String() != "" {
 					partItems = append(partItems, antigravityOpenAITextPart(content.String()))
 				} else if content.IsArray() {
 					for _, item := range content.Array() {
-						switch item.Get("type").String() {
-						case "text":
-							if text := item.Get("text").String(); text != "" {
-								partItems = append(partItems, antigravityOpenAITextPart(text))
-							}
-						case "image_url":
-							imageURL := item.Get("image_url.url").String()
-							if len(imageURL) > 5 {
-								pieces := strings.SplitN(imageURL[5:], ";", 2)
-								if len(pieces) == 2 && len(pieces[1]) > 7 {
-									part := antigravityOpenAIInlineDataPart(pieces[0], pieces[1][7:], false)
-									part, _ = sjson.SetBytes(part, "thoughtSignature", antigravityFunctionThoughtSignature)
-									partItems = append(partItems, part)
-								}
-							}
+						if item.Get("type").String() == "text" {
+							partItems = append(partItems, antigravityOpenAITextPart(item.Get("text").String()))
 						}
 					}
 				}
-
 				tcs := m.Get("tool_calls")
 				if tcs.IsArray() {
-					functionIDs := make([]string, 0)
 					for _, tc := range tcs.Array() {
-						if tc.Get("type").String() != "function" {
-							continue
-						}
-						functionID := tc.Get("id").String()
-						functionName := util.MapSanitizedFunctionName(functionNameMap, tc.Get("function.name").String())
-						if functionName == "" {
-							continue
-						}
-						functionArgs := tc.Get("function.arguments").String()
-						part := []byte(`{"functionCall":{"id":"","name":""}}`)
-						part, _ = sjson.SetBytes(part, "functionCall.id", functionID)
-						part, _ = sjson.SetBytes(part, "functionCall.name", functionName)
-						if gjson.Valid(functionArgs) {
-							part, _ = sjson.SetRawBytes(part, "functionCall.args", []byte(functionArgs))
-						} else {
-							part, _ = sjson.SetBytes(part, "functionCall.args.params", []byte(functionArgs))
-						}
-						part, _ = sjson.SetBytes(part, "thoughtSignature", antigravityFunctionThoughtSignature)
-						partItems = append(partItems, part)
-						if functionID != "" {
-							functionIDs = append(functionIDs, functionID)
-						}
-					}
-					if len(partItems) > 0 {
-						contentItems = append(contentItems, antigravityOpenAIContent("model", partItems))
-					}
-
-					responseParts := make([][]byte, 0, len(functionIDs))
-					for _, functionID := range functionIDs {
-						if name, ok := tcID2Name[functionID]; ok {
-							part := []byte(`{"functionResponse":{"id":"","name":""}}`)
-							part, _ = sjson.SetBytes(part, "functionResponse.id", functionID)
-							part, _ = sjson.SetBytes(part, "functionResponse.name", util.MapSanitizedFunctionName(functionNameMap, name))
-							response := toolResponses[functionID]
-							if response == "" {
-								response = "{}"
-							}
-							if response != "null" {
-								parsed := gjson.Parse(response)
-								if parsed.Type == gjson.JSON {
-									part, _ = sjson.SetRawBytes(part, "functionResponse.response.result", []byte(parsed.Raw))
+						if tc.Get("type").String() == "function" {
+							fnName := tc.Get("function.name").String()
+							mappedFnName := util.MapSanitizedFunctionName(functionNameMap, fnName)
+							fnArgs := tc.Get("function.arguments").String()
+							part := []byte(`{"functionCall":{"name":""}}`)
+							part, _ = sjson.SetBytes(part, "functionCall.name", mappedFnName)
+							if fnArgs != "" {
+								var argsMap map[string]any
+								if errUnmarshal := util.UnmarshalJSONCaseFold([]byte(fnArgs), &argsMap); errUnmarshal == nil {
+									part, _ = sjson.SetBytes(part, "functionCall.args", argsMap)
 								} else {
-									part, _ = sjson.SetBytes(part, "functionResponse.response.result", response)
+									part, _ = sjson.SetBytes(part, "functionCall.args", map[string]any{})
 								}
 							}
-							responseParts = append(responseParts, part)
+							if thoughtSig := tc.Get("thought_signature").String(); thoughtSig != "" {
+								part, _ = sjson.SetBytes(part, "thoughtSignature", thoughtSig)
+							} else if thoughtSig := tc.Get("thoughtSignature").String(); thoughtSig != "" {
+								part, _ = sjson.SetBytes(part, "thoughtSignature", thoughtSig)
+							} else {
+								part, _ = sjson.SetBytes(part, "thoughtSignature", antigravityFunctionThoughtSignature)
+							}
+							partItems = append(partItems, part)
 						}
 					}
-					if len(responseParts) > 0 {
-						contentItems = append(contentItems, antigravityOpenAIContent("user", responseParts))
-					}
-				} else if len(partItems) > 0 {
+				}
+				if len(partItems) > 0 {
 					contentItems = append(contentItems, antigravityOpenAIContent("model", partItems))
 				}
+			} else if role == "tool" {
+				// tool role -> functionResponse in user role
+				toolCallID := m.Get("tool_call_id").String()
+				fnName := tcID2Name[toolCallID]
+				if fnName == "" {
+					fnName = "function"
+				}
+				mappedFnName := util.MapSanitizedFunctionName(functionNameMap, fnName)
+				c := m.Get("content")
+				response := c.Raw
+				if response == "" {
+					response = `""`
+				}
+
+				part := []byte(`{"functionResponse":{"name":"","response":{"result":null}}}`)
+				part, _ = sjson.SetBytes(part, "functionResponse.name", mappedFnName)
+				if response != "null" {
+					parsed := gjson.Parse(response)
+					if parsed.Type == gjson.JSON {
+						part, _ = sjson.SetRawBytes(part, "functionResponse.response.result", []byte(parsed.Raw))
+					} else {
+						part, _ = sjson.SetBytes(part, "functionResponse.response.result", response)
+					}
+				}
+				responseParts := [][]byte{part}
+
+				// Look ahead for consecutive tool messages and group them into the same user content
+				for i+1 < len(arr) && arr[i+1].Get("role").String() == "tool" {
+					i++
+					nextM := arr[i]
+					nextToolCallID := nextM.Get("tool_call_id").String()
+					nextFnName := tcID2Name[nextToolCallID]
+					if nextFnName == "" {
+						nextFnName = "function"
+					}
+					nextMappedFnName := util.MapSanitizedFunctionName(functionNameMap, nextFnName)
+					nextC := nextM.Get("content")
+					nextResponse := nextC.Raw
+					if nextResponse == "" {
+						nextResponse = `""`
+					}
+					nextPart := []byte(`{"functionResponse":{"name":"","response":{"result":null}}}`)
+					nextPart, _ = sjson.SetBytes(nextPart, "functionResponse.name", nextMappedFnName)
+					if nextResponse != "null" {
+						parsed := gjson.Parse(nextResponse)
+						if parsed.Type == gjson.JSON {
+							nextPart, _ = sjson.SetRawBytes(nextPart, "functionResponse.response.result", []byte(parsed.Raw))
+						} else {
+							nextPart, _ = sjson.SetBytes(nextPart, "functionResponse.response.result", nextResponse)
+						}
+					}
+					responseParts = append(responseParts, nextPart)
+				}
+				contentItems = append(contentItems, antigravityOpenAIContent("user", responseParts))
 			}
 		}
 		if len(systemParts) > 0 {
@@ -318,6 +342,9 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 
 	// tools -> request.tools[].functionDeclarations + request.tools[].googleSearch/codeExecution/urlContext passthrough
 	tools := gjson.GetBytes(rawJSON, "tools")
+	if !tools.Exists() || !tools.IsArray() || len(tools.Array()) == 0 {
+		tools = gjson.GetBytes(rawJSON, "functions")
+	}
 	toolResults := tools.Array()
 	if tools.IsArray() && len(toolResults) > 0 {
 		functionDeclarations := make([][]byte, 0, len(toolResults))
@@ -325,56 +352,48 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 		codeExecutionNodes := make([][]byte, 0)
 		urlContextNodes := make([][]byte, 0)
 		for _, t := range toolResults {
-			if t.Get("type").String() == "function" {
-				fn := t.Get("function")
-				if fn.Exists() && fn.IsObject() {
-					fnRaw := fn.Raw
-					if fn.Get("parameters").Exists() {
-						renamed, errRename := util.RenameKey(fnRaw, "parameters", "parametersJsonSchema")
-						if errRename != nil {
-							log.Warnf("Failed to rename parameters for tool '%s': %v", fn.Get("name").String(), errRename)
-							var errSet error
-							fnRawBytes, errSet := sjson.SetBytes([]byte(fnRaw), "parametersJsonSchema.type", "object")
-							if errSet != nil {
-								log.Warnf("Failed to set default schema type for tool '%s': %v", fn.Get("name").String(), errSet)
-								continue
-							}
-							fnRaw = string(fnRawBytes)
-							fnRawBytes, errSet = sjson.SetRawBytes([]byte(fnRaw), "parametersJsonSchema.properties", []byte(`{}`))
-							if errSet != nil {
-								log.Warnf("Failed to set default schema properties for tool '%s': %v", fn.Get("name").String(), errSet)
-								continue
-							}
-							fnRaw = string(fnRawBytes)
-						} else {
-							fnRaw = renamed
-						}
-					} else {
-						var errSet error
-						fnRawBytes, errSet := sjson.SetBytes([]byte(fnRaw), "parametersJsonSchema.type", "object")
-						if errSet != nil {
-							log.Warnf("Failed to set default schema type for tool '%s': %v", fn.Get("name").String(), errSet)
-							continue
-						}
-						fnRaw = string(fnRawBytes)
-						fnRawBytes, errSet = sjson.SetRawBytes([]byte(fnRaw), "parametersJsonSchema.properties", []byte(`{}`))
-						if errSet != nil {
-							log.Warnf("Failed to set default schema properties for tool '%s': %v", fn.Get("name").String(), errSet)
-							continue
-						}
-						fnRaw = string(fnRawBytes)
+			fn := t.Get("function")
+			if !fn.Exists() || !fn.IsObject() {
+				if c := t.Get("custom"); c.Exists() && c.IsObject() {
+					fn = c
+				} else if t.Get("name").Exists() {
+					fn = t
+				}
+			}
+			if fn.Exists() && (fn.IsObject() || t.Get("type").String() == "function" || t.Get("type").String() == "custom") {
+				name := fn.Get("name").String()
+				if name == "" {
+					name = t.Get("name").String()
+				}
+				if name != "" {
+					desc := fn.Get("description").String()
+					if desc == "" {
+						desc = t.Get("description").String()
 					}
-					fnRawBytes := []byte(fnRaw)
-					nameResult := fn.Get("name")
-					originalName := nameResult.String()
-					mappedName := util.MapSanitizedFunctionName(functionNameMap, originalName)
-					if nameResult.Type != gjson.String || mappedName != originalName {
-						fnRawBytes, _ = sjson.SetBytes(fnRawBytes, "name", mappedName)
+					decl := []byte(`{"name":"","parametersJsonSchema":{"type":"object","properties":{}}}`)
+					decl, _ = sjson.SetBytes(decl, "name", name)
+					if desc != "" {
+						decl, _ = sjson.SetBytes(decl, "description", desc)
 					}
-					if gjson.GetBytes(fnRawBytes, "strict").Exists() {
-						fnRawBytes, _ = sjson.DeleteBytes(fnRawBytes, "strict")
+					var schemaRaw []byte
+					for _, k := range []string{"parameters", "parametersJsonSchema", "parameters_json_schema", "input_schema", "schema"} {
+						if s := fn.Get(k); s.Exists() && s.Raw != "" && s.Raw != "null" {
+							schemaRaw = []byte(s.Raw)
+							break
+						}
+						if s := t.Get(k); s.Exists() && s.Raw != "" && s.Raw != "null" {
+							schemaRaw = []byte(s.Raw)
+							break
+						}
 					}
-					functionDeclarations = append(functionDeclarations, fnRawBytes)
+					if len(schemaRaw) > 0 {
+						decl, _ = sjson.SetRawBytes(decl, "parametersJsonSchema", schemaRaw)
+					}
+					mappedName := util.MapSanitizedFunctionName(functionNameMap, name)
+					if mappedName != name {
+						decl, _ = sjson.SetBytes(decl, "name", mappedName)
+					}
+					functionDeclarations = append(functionDeclarations, decl)
 				}
 			}
 			if gs := t.Get("google_search"); gs.Exists() {
@@ -454,159 +473,4 @@ func antigravityOpenAIContent(role string, parts [][]byte) []byte {
 	content, _ = sjson.SetBytes(content, "role", role)
 	content, _ = sjson.SetRawBytes(content, "parts", translatorcommon.JoinRawArray(parts))
 	return content
-}
-
-func antigravityOpenAIAudioMIMEType(format string) string {
-	switch format {
-	case "mp3":
-		return "audio/mpeg"
-	case "ogg":
-		return "audio/ogg"
-	case "flac":
-		return "audio/flac"
-	case "aac":
-		return "audio/aac"
-	case "webm":
-		return "audio/webm"
-	case "pcm16":
-		return "audio/pcm"
-	case "g711_ulaw", "g711_alaw":
-		return "audio/basic"
-	case "", "wav":
-		return "audio/wav"
-	default:
-		return "audio/" + format
-	}
-}
-
-func applyOpenAIToolChoiceToAntigravity(out, rawJSON []byte, functionNameMap map[string]string) []byte {
-	toolChoice := gjson.GetBytes(rawJSON, "tool_choice")
-	if !toolChoice.Exists() {
-		return out
-	}
-
-	mode := ""
-	allowedName := ""
-	if toolChoice.Type == gjson.String {
-		switch strings.ToLower(strings.TrimSpace(toolChoice.String())) {
-		case "none":
-			mode = "NONE"
-		case "auto":
-			mode = "AUTO"
-		case "required", "any":
-			mode = "ANY"
-		}
-	} else if toolChoice.IsObject() && strings.EqualFold(toolChoice.Get("type").String(), "function") {
-		mode = "ANY"
-		allowedName = toolChoice.Get("function.name").String()
-	}
-	if mode == "" {
-		return out
-	}
-
-	out, _ = sjson.SetBytes(out, "request.toolConfig.functionCallingConfig.mode", mode)
-	if strings.TrimSpace(allowedName) != "" {
-		mappedName := util.MapSanitizedFunctionName(functionNameMap, allowedName)
-		out, _ = sjson.SetBytes(out, "request.toolConfig.functionCallingConfig.allowedFunctionNames", []string{mappedName})
-	}
-	return out
-}
-
-func applyOpenAIThinkingCompatibilityToAntigravity(out []byte, rawJSON []byte) []byte {
-	out = normalizeAntigravityOpenAIThinkingConfig(out)
-	config := thinking.ExtractSummaryConfig(rawJSON, "openai")
-	return thinking.ApplySummaryConfig(out, "antigravity", config)
-}
-
-func normalizeAntigravityOpenAIThinkingConfig(out []byte) []byte {
-	for _, prefix := range []string{
-		"request.generationConfig.thinking_config",
-		"request.generationConfig.thinkingConfig",
-	} {
-		if sourcePath := prefix + ".includeThoughts"; gjson.GetBytes(out, sourcePath).Exists() {
-			includeThoughts := gjson.GetBytes(out, sourcePath)
-			out = setAntigravityOpenAIBoolResultIfValid(out, "request.generationConfig.thinkingConfig.includeThoughts", includeThoughts)
-			if includeThoughts.Type != gjson.True && includeThoughts.Type != gjson.False {
-				out, _ = sjson.DeleteBytes(out, sourcePath)
-			}
-		}
-		if sourcePath := prefix + ".include_thoughts"; gjson.GetBytes(out, sourcePath).Exists() {
-			includeThoughts := gjson.GetBytes(out, sourcePath)
-			out = setAntigravityOpenAIBoolResultIfValid(out, "request.generationConfig.thinkingConfig.includeThoughts", includeThoughts)
-			if includeThoughts.Type != gjson.True && includeThoughts.Type != gjson.False {
-				out, _ = sjson.DeleteBytes(out, sourcePath)
-			}
-		}
-		if thinkingLevel := gjson.GetBytes(out, prefix+".thinkingLevel"); thinkingLevel.Exists() {
-			out = setAntigravityOpenAIRawIfDifferent(out, "request.generationConfig.thinkingConfig.thinkingLevel", thinkingLevel)
-		}
-		if thinkingLevel := gjson.GetBytes(out, prefix+".thinking_level"); thinkingLevel.Exists() {
-			out = setAntigravityOpenAIRawIfDifferent(out, "request.generationConfig.thinkingConfig.thinkingLevel", thinkingLevel)
-		}
-		if thinkingBudget := gjson.GetBytes(out, prefix+".thinkingBudget"); thinkingBudget.Exists() {
-			out = setAntigravityOpenAIRawIfDifferent(out, "request.generationConfig.thinkingConfig.thinkingBudget", thinkingBudget)
-		}
-		if thinkingBudget := gjson.GetBytes(out, prefix+".thinking_budget"); thinkingBudget.Exists() {
-			out = setAntigravityOpenAIRawIfDifferent(out, "request.generationConfig.thinkingConfig.thinkingBudget", thinkingBudget)
-		}
-	}
-
-	for _, path := range []string{
-		"request.generationConfig.includeThoughts",
-		"request.generationConfig.include_thoughts",
-	} {
-		if includeThoughts := gjson.GetBytes(out, path); includeThoughts.Exists() {
-			out = setAntigravityOpenAIBoolResultIfValid(out, "request.generationConfig.thinkingConfig.includeThoughts", includeThoughts)
-		}
-	}
-
-	for _, path := range []string{
-		"request.generationConfig.thinking_config",
-		"request.generationConfig.thinkingConfig.include_thoughts",
-		"request.generationConfig.thinkingConfig.thinking_level",
-		"request.generationConfig.thinkingConfig.thinking_budget",
-		"request.generationConfig.includeThoughts",
-		"request.generationConfig.include_thoughts",
-	} {
-		if gjson.GetBytes(out, path).Exists() {
-			out, _ = sjson.DeleteBytes(out, path)
-		}
-	}
-
-	return out
-}
-
-func setAntigravityOpenAIBoolResultIfValid(out []byte, path string, value gjson.Result) []byte {
-	switch value.Type {
-	case gjson.True:
-		return setAntigravityOpenAIBoolIfDifferent(out, path, true)
-	case gjson.False:
-		return setAntigravityOpenAIBoolIfDifferent(out, path, false)
-	default:
-		return out
-	}
-}
-
-func setAntigravityOpenAIBoolIfDifferent(out []byte, path string, value bool) []byte {
-	current := gjson.GetBytes(out, path)
-	if value && current.Type == gjson.True || !value && current.Type == gjson.False {
-		return out
-	}
-	updated, errSet := sjson.SetBytes(out, path, value)
-	if errSet != nil {
-		return out
-	}
-	return updated
-}
-
-func setAntigravityOpenAIRawIfDifferent(out []byte, path string, value gjson.Result) []byte {
-	current := gjson.GetBytes(out, path)
-	if current.Exists() && current.Raw == value.Raw {
-		return out
-	}
-	updated, errSet := sjson.SetRawBytes(out, path, []byte(value.Raw))
-	if errSet != nil {
-		return out
-	}
-	return updated
 }

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
@@ -390,6 +390,9 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 						decl, _ = sjson.SetRawBytes(decl, "parametersJsonSchema", schemaRaw)
 					}
 					mappedName := util.MapSanitizedFunctionName(functionNameMap, name)
+					if strings.Contains(strings.ToLower(modelName), "claude") {
+						mappedName = util.SanitizeClaudeFunctionName(name)
+					}
 					if mappedName != name {
 						decl, _ = sjson.SetBytes(decl, "name", mappedName)
 					}

--- a/internal/translator/claude/gemini/claude_gemini_request.go
+++ b/internal/translator/claude/gemini/claude_gemini_request.go
@@ -14,8 +14,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
@@ -32,16 +30,15 @@ var (
 // It extracts the model name, system instruction, message contents, and tool declarations
 // from the raw JSON request and returns them in the format expected by the Claude Code API.
 // The function performs comprehensive transformation including:
-// 1. Model name mapping and generation configuration extraction
-// 2. System instruction conversion to Claude Code format
-// 3. Message content conversion with proper role mapping
-// 4. Tool call and tool result handling with FIFO queue for ID matching
-// 5. Image and file data conversion to Claude Code base64 format
-// 6. Tool declaration and tool choice configuration mapping
+// 1. Model name mapping and parameter extraction (max_tokens, top_p, etc.)
+// 2. Message content conversion from Gemini to Claude Code format
+// 3. Tool call and tool result handling with proper ID mapping
+// 4. Inline data (images, documents) conversion to Claude Code base64 format
+// 5. System instruction and thinking configuration handling
 //
 // Parameters:
 //   - modelName: The name of the model to use for the request
-//   - rawJSON: The raw JSON request data from the Gemini API
+//   - inputRawJSON: The raw JSON request data from the Gemini API
 //   - stream: A boolean indicating if the request is for a streaming response
 //
 // Returns:
@@ -63,278 +60,233 @@ func ConvertGeminiRequestToClaude(modelName string, inputRawJSON []byte, stream 
 	}
 	userID := fmt.Sprintf("user_%s_account_%s_session_%s", user, account, session)
 
-	// Base Claude message payload
+	// Base Claude Code API template with default max_tokens value
 	out := []byte(fmt.Sprintf(`{"model":"","max_tokens":32000,"messages":[],"metadata":{"user_id":"%s"}}`, userID))
 
 	root := gjson.ParseBytes(rawJSON)
-	messageAccumulator := translatorcommon.NewClaudeMessageAccumulator(int(root.Get("contents.#").Int()) + 1)
 
-	// Helper for generating tool call IDs in the form: toolu_<alphanum>
-	// This ensures unique identifiers for tool calls in the Claude Code format
-	genToolCallID := func() string {
+	// Model mapping to specify which Claude Code model to use
+	out, _ = sjson.SetBytes(out, "model", modelName)
+
+	// Max tokens configuration with fallback to default value
+	if maxTokens := root.Get("generationConfig.maxOutputTokens"); maxTokens.Exists() {
+		out, _ = sjson.SetBytes(out, "max_tokens", maxTokens.Int())
+	} else if maxTokens := root.Get("generation_config.max_output_tokens"); maxTokens.Exists() {
+		out, _ = sjson.SetBytes(out, "max_tokens", maxTokens.Int())
+	}
+
+	// Temperature configuration for controlling randomness
+	if temperature := root.Get("generationConfig.temperature"); temperature.Exists() {
+		out, _ = sjson.SetBytes(out, "temperature", temperature.Float())
+	} else if temperature := root.Get("generation_config.temperature"); temperature.Exists() {
+		out, _ = sjson.SetBytes(out, "temperature", temperature.Float())
+	}
+
+	// Thinking configuration for controlling the thinking budget
+	// When thinkingBudget is set to 0, thinking is disabled
+	// When thinkingBudget is -1, dynamic thinking budget is used
+	// When thinkingBudget > 0, the specific budget value is used
+	if thinkingBudget := root.Get("generationConfig.thinkingConfig.thinkingBudget"); thinkingBudget.Exists() {
+		switch thinkingBudget.Int() {
+		case 0:
+			out, _ = sjson.SetBytes(out, "thinking.type", "disabled")
+		case -1:
+			out, _ = sjson.SetBytes(out, "thinking.type", "enabled")
+		default:
+			if thinkingBudget.Int() > 0 {
+				out, _ = sjson.SetBytes(out, "thinking.type", "enabled")
+				out, _ = sjson.SetBytes(out, "thinking.budget_tokens", thinkingBudget.Int())
+			}
+		}
+	} else if thinkingBudget := root.Get("generation_config.thinking_config.thinking_budget"); thinkingBudget.Exists() {
+		switch thinkingBudget.Int() {
+		case 0:
+			out, _ = sjson.SetBytes(out, "thinking.type", "disabled")
+		case -1:
+			out, _ = sjson.SetBytes(out, "thinking.type", "enabled")
+		default:
+			if thinkingBudget.Int() > 0 {
+				out, _ = sjson.SetBytes(out, "thinking.type", "enabled")
+				out, _ = sjson.SetBytes(out, "thinking.budget_tokens", thinkingBudget.Int())
+			}
+		}
+	}
+
+	// System instruction processing and mapping to Claude Code format
+	if systemInstruction := root.Get("systemInstruction"); systemInstruction.Exists() {
+		parts := systemInstruction.Get("parts")
+		if parts.Exists() && parts.IsArray() {
+			var systemText []string
+			parts.ForEach(func(_, part gjson.Result) bool {
+				if text := part.Get("text"); text.Exists() {
+					systemText = append(systemText, text.String())
+				}
+				return true
+			})
+			if len(systemText) > 0 {
+				out, _ = sjson.SetBytes(out, "system", strings.Join(systemText, "\n\n"))
+			}
+		}
+	} else if systemInstruction := root.Get("system_instruction"); systemInstruction.Exists() {
+		parts := systemInstruction.Get("parts")
+		if parts.Exists() && parts.IsArray() {
+			var systemText []string
+			parts.ForEach(func(_, part gjson.Result) bool {
+				if text := part.Get("text"); text.Exists() {
+					systemText = append(systemText, text.String())
+				}
+				return true
+			})
+			if len(systemText) > 0 {
+				out, _ = sjson.SetBytes(out, "system", strings.Join(systemText, "\n\n"))
+			}
+		}
+	}
+
+	// Messages processing and transformation
+	var toolIDMap = make(map[string]string)
+	genToolCallID := func(name string) string {
+		if id, exists := toolIDMap[name]; exists {
+			return id
+		}
 		const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 		var b strings.Builder
-		// 24 chars random suffix for uniqueness
 		for i := 0; i < 24; i++ {
 			n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
 			b.WriteByte(letters[n.Int64()])
 		}
-		return "toolu_" + b.String()
+		id := "toolu_" + b.String()
+		toolIDMap[name] = id
+		return id
 	}
 
-	getGeminiToolID := func(value gjson.Result) string {
-		if toolID := strings.TrimSpace(value.Get("id").String()); toolID != "" {
-			return toolID
+	// Helper function to extract tool call ID from function call part
+	// Supports custom IDs, standard tool IDs, and fallback generation
+	getToolCallID := func(part gjson.Result, funcName string) string {
+		if id := part.Get("id"); id.Exists() && id.String() != "" {
+			return id.String()
 		}
-		return strings.TrimSpace(value.Get("call_id").String())
+		if id := part.Get("functionCall.id"); id.Exists() && id.String() != "" {
+			return id.String()
+		}
+		if id := part.Get("function_call.id"); id.Exists() && id.String() != "" {
+			return id.String()
+		}
+		return genToolCallID(funcName)
 	}
 
-	removePendingToolID := func(ids []string, toolID string) []string {
-		if toolID == "" {
-			return ids
+	// Helper function to extract tool response ID from function response part
+	// Supports custom IDs, standard response IDs, and fallback generation
+	getToolResponseID := func(part gjson.Result, funcName string) string {
+		if id := part.Get("id"); id.Exists() && id.String() != "" {
+			return id.String()
 		}
-		for idx, pendingID := range ids {
-			if pendingID == toolID {
-				return append(ids[:idx], ids[idx+1:]...)
-			}
+		if id := part.Get("functionResponse.id"); id.Exists() && id.String() != "" {
+			return id.String()
 		}
-		return ids
+		if id := part.Get("function_response.id"); id.Exists() && id.String() != "" {
+			return id.String()
+		}
+		return genToolCallID(funcName)
 	}
 
-	// FIFO queue to store tool call IDs for matching with tool results
-	// Gemini uses sequential pairing across possibly multiple in-flight
-	// functionCalls, so we keep a FIFO queue of generated tool IDs and
-	// consume them in order when functionResponses arrive.
-	var pendingToolIDs []string
-
-	// Model mapping to specify which Claude Code model to use
-	out, _ = sjson.SetBytes(out, "model", modelName)
-	if serviceTier := root.Get("service_tier"); serviceTier.Exists() && serviceTier.Type == gjson.String {
-		out, _ = sjson.SetBytes(out, "service_tier", serviceTier.String())
-	}
-
-	// Generation config extraction from Gemini format
-	if genConfig := root.Get("generationConfig"); genConfig.Exists() {
-		// Max output tokens configuration
-		if maxTokens := genConfig.Get("maxOutputTokens"); maxTokens.Exists() {
-			out, _ = sjson.SetBytes(out, "max_tokens", maxTokens.Int())
-		}
-		// Top P setting for nucleus sampling.
-		if topP := genConfig.Get("topP"); topP.Exists() {
-			out, _ = sjson.SetBytes(out, "top_p", topP.Float())
-		}
-		// Stop sequences configuration for custom termination conditions
-		if stopSeqs := genConfig.Get("stopSequences"); stopSeqs.Exists() && stopSeqs.IsArray() {
-			var stopSequences []string
-			stopSeqs.ForEach(func(_, value gjson.Result) bool {
-				stopSequences = append(stopSequences, value.String())
-				return true
-			})
-			if len(stopSequences) > 0 {
-				out, _ = sjson.SetBytes(out, "stop_sequences", stopSequences)
-			}
-		}
-		// Include thoughts configuration for reasoning process visibility
-		// Translator only does format conversion, ApplyThinking handles model capability validation.
-		if thinkingConfig := genConfig.Get("thinkingConfig"); thinkingConfig.Exists() && thinkingConfig.IsObject() {
-			mi := registry.LookupModelInfo(modelName, "claude")
-			supportsAdaptive := mi != nil && mi.Thinking != nil && len(mi.Thinking.Levels) > 0
-			supportsMax := supportsAdaptive && thinking.HasLevel(mi.Thinking.Levels, string(thinking.LevelMax))
-
-			// MapToClaudeEffort normalizes levels (e.g. minimal→low, xhigh→high) to avoid
-			// validation errors since validate treats same-provider unsupported levels as errors.
-			thinkingLevel := thinkingConfig.Get("thinkingLevel")
-			if !thinkingLevel.Exists() {
-				thinkingLevel = thinkingConfig.Get("thinking_level")
-			}
-			if thinkingLevel.Exists() {
-				level := strings.ToLower(strings.TrimSpace(thinkingLevel.String()))
-				if supportsAdaptive {
-					switch level {
-					case "":
-					case "none":
-						out, _ = sjson.SetBytes(out, "thinking.type", "disabled")
-						out, _ = sjson.DeleteBytes(out, "thinking.budget_tokens")
-						out, _ = sjson.DeleteBytes(out, "output_config.effort")
-					default:
-						if mapped, ok := thinking.MapToClaudeEffort(level, supportsMax); ok {
-							level = mapped
-						}
-						out, _ = sjson.SetBytes(out, "thinking.type", "adaptive")
-						out, _ = sjson.DeleteBytes(out, "thinking.budget_tokens")
-						out, _ = sjson.SetBytes(out, "output_config.effort", level)
-					}
-				} else {
-					switch level {
-					case "":
-					case "none":
-						out, _ = sjson.SetBytes(out, "thinking.type", "disabled")
-						out, _ = sjson.DeleteBytes(out, "thinking.budget_tokens")
-					case "auto":
-						out, _ = sjson.SetBytes(out, "thinking.type", "enabled")
-						out, _ = sjson.DeleteBytes(out, "thinking.budget_tokens")
-					default:
-						if budget, ok := thinking.ConvertLevelToBudget(level); ok {
-							out, _ = sjson.SetBytes(out, "thinking.type", "enabled")
-							out, _ = sjson.SetBytes(out, "thinking.budget_tokens", budget)
-						}
-					}
-				}
-			} else {
-				thinkingBudget := thinkingConfig.Get("thinkingBudget")
-				if !thinkingBudget.Exists() {
-					thinkingBudget = thinkingConfig.Get("thinking_budget")
-				}
-				if thinkingBudget.Exists() {
-					budget := int(thinkingBudget.Int())
-					if supportsAdaptive {
-						switch budget {
-						case 0:
-							out, _ = sjson.SetBytes(out, "thinking.type", "disabled")
-							out, _ = sjson.DeleteBytes(out, "thinking.budget_tokens")
-							out, _ = sjson.DeleteBytes(out, "output_config.effort")
-						default:
-							level, ok := thinking.ConvertBudgetToLevel(budget)
-							if ok {
-								if mapped, okM := thinking.MapToClaudeEffort(level, supportsMax); okM {
-									level = mapped
-								}
-								out, _ = sjson.SetBytes(out, "thinking.type", "adaptive")
-								out, _ = sjson.DeleteBytes(out, "thinking.budget_tokens")
-								out, _ = sjson.SetBytes(out, "output_config.effort", level)
-							}
-						}
-					} else {
-						switch budget {
-						case 0:
-							out, _ = sjson.SetBytes(out, "thinking.type", "disabled")
-							out, _ = sjson.DeleteBytes(out, "thinking.budget_tokens")
-						case -1:
-							out, _ = sjson.SetBytes(out, "thinking.type", "enabled")
-							out, _ = sjson.DeleteBytes(out, "thinking.budget_tokens")
-						default:
-							out, _ = sjson.SetBytes(out, "thinking.type", "enabled")
-							out, _ = sjson.SetBytes(out, "thinking.budget_tokens", budget)
-						}
-					}
-				}
-			}
-		}
-	}
-
-	// System instruction conversion to Claude Code format
-	if sysInstr := root.Get("system_instruction"); sysInstr.Exists() {
-		if parts := sysInstr.Get("parts"); parts.Exists() && parts.IsArray() {
-			var systemText strings.Builder
-			parts.ForEach(func(_, part gjson.Result) bool {
-				if translatorcommon.IsGeminiThoughtPart(part) {
-					return true
-				}
-				if text := part.Get("text"); text.Exists() {
-					if systemText.Len() > 0 {
-						systemText.WriteString("\n")
-					}
-					systemText.WriteString(text.String())
-				}
-				return true
-			})
-			if systemText.Len() > 0 {
-				// Create system message in Claude Code format.
-				systemMessage := []byte(`{"role":"user","content":[{"type":"text","text":""}]}`)
-				systemMessage, _ = sjson.SetBytes(systemMessage, "content.0.text", systemText.String())
-				messageAccumulator.Append(systemMessage)
-				messageAccumulator.Flush()
-			}
-		}
-	}
-
-	// Contents conversion to messages with proper role mapping
+	messageAccumulator := translatorcommon.NewClaudeMessageAccumulator(int(root.Get("contents.#").Int()))
 	if contents := root.Get("contents"); contents.Exists() && contents.IsArray() {
 		contents.ForEach(func(_, content gjson.Result) bool {
 			role := content.Get("role").String()
 			// Map Gemini roles to Claude Code roles
-			if role == "model" {
+			switch role {
+			case "model":
 				role = "assistant"
-			}
-
-			if role == "function" {
+			default:
 				role = "user"
 			}
 
-			if role == "tool" {
-				role = "user"
-			}
+			parts := content.Get("parts")
+			var contentItems [][]byte
 
-			contentItems := make([][]byte, 0, 4)
-			if parts := content.Get("parts"); parts.Exists() && parts.IsArray() {
+			if parts.Exists() && parts.IsArray() {
 				parts.ForEach(func(_, part gjson.Result) bool {
-					if translatorcommon.IsGeminiThoughtPart(part) {
-						return true
-					}
-
-					// Text content conversion
+					// Text content mapping
 					if text := part.Get("text"); text.Exists() {
-						textContent := []byte(`{"type":"text","text":""}`)
-						textContent, _ = sjson.SetBytes(textContent, "text", text.String())
-						contentItems = append(contentItems, textContent)
+						if isHiddenThoughtPart(part) {
+							return true
+						}
+						textContent := text.String()
+						contentPart := []byte(`{"type":"text","text":""}`)
+						contentPart, _ = sjson.SetBytes(contentPart, "text", textContent)
+						contentItems = append(contentItems, contentPart)
 						return true
 					}
 
-					// Function call (from model/assistant) conversion to tool use
-					if fc := part.Get("functionCall"); fc.Exists() && role == "assistant" {
-						toolUse := []byte(`{"type":"tool_use","id":"","name":"","input":{}}`)
+					// Function call mapping to tool_use
+					if funcCall := part.Get("functionCall"); funcCall.Exists() {
+						funcName := funcCall.Get("name").String()
+						callID := getToolCallID(part, funcName)
+						contentPart := []byte(`{"type":"tool_use","id":"","name":"","input":{}}`)
+						contentPart, _ = sjson.SetBytes(contentPart, "id", callID)
+						contentPart, _ = sjson.SetBytes(contentPart, "name", funcName)
 
-						// Reuse gateway-provided IDs when present, otherwise generate one for pairing.
-						toolID := getGeminiToolID(fc)
-						if toolID == "" {
-							toolID = genToolCallID()
+						if args := funcCall.Get("args"); args.Exists() {
+							contentPart, _ = sjson.SetRawBytes(contentPart, "input", []byte(args.Raw))
 						}
-						pendingToolIDs = append(pendingToolIDs, toolID)
-						toolUse, _ = sjson.SetBytes(toolUse, "id", toolID)
 
-						if name := fc.Get("name"); name.Exists() {
-							toolUse, _ = sjson.SetBytes(toolUse, "name", name.String())
+						contentItems = append(contentItems, contentPart)
+						return true
+					} else if funcCall := part.Get("function_call"); funcCall.Exists() {
+						funcName := funcCall.Get("name").String()
+						callID := getToolCallID(part, funcName)
+						contentPart := []byte(`{"type":"tool_use","id":"","name":"","input":{}}`)
+						contentPart, _ = sjson.SetBytes(contentPart, "id", callID)
+						contentPart, _ = sjson.SetBytes(contentPart, "name", funcName)
+
+						if args := funcCall.Get("args"); args.Exists() {
+							contentPart, _ = sjson.SetRawBytes(contentPart, "input", []byte(args.Raw))
 						}
-						if args := fc.Get("args"); args.Exists() && args.IsObject() {
-							toolUse, _ = sjson.SetRawBytes(toolUse, "input", []byte(args.Raw))
-						}
-						contentItems = append(contentItems, toolUse)
+
+						contentItems = append(contentItems, contentPart)
 						return true
 					}
 
-					// Function response (from user) conversion to tool result
-					if fr := part.Get("functionResponse"); fr.Exists() {
-						toolResult := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
+					// Function response mapping to tool_result
+					if funcResp := part.Get("functionResponse"); funcResp.Exists() {
+						funcName := funcResp.Get("name").String()
+						callID := getToolResponseID(part, funcName)
+						contentPart := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
+						contentPart, _ = sjson.SetBytes(contentPart, "tool_use_id", callID)
 
-						// Attach the oldest queued tool_id to pair the response
-						// with its call. If the queue is empty, generate a new id.
-						var toolID string
-						if customID := getGeminiToolID(fr); customID != "" {
-							toolID = customID
-							pendingToolIDs = removePendingToolID(pendingToolIDs, toolID)
-						} else if len(pendingToolIDs) > 0 {
-							toolID = pendingToolIDs[0]
-							// Pop the first element from the queue
-							pendingToolIDs = pendingToolIDs[1:]
-						} else {
-							// Fallback: generate new ID if no pending tool_use found
-							toolID = genToolCallID()
+						if resp := funcResp.Get("response"); resp.Exists() {
+							contentPart, _ = sjson.SetBytes(contentPart, "content", resp.Raw)
 						}
-						toolResult, _ = sjson.SetBytes(toolResult, "tool_use_id", toolID)
 
-						// Extract result content from the function response
-						if result := fr.Get("response.result"); result.Exists() {
-							toolResult, _ = sjson.SetBytes(toolResult, "content", result.String())
-						} else if response := fr.Get("response"); response.Exists() {
-							toolResult, _ = sjson.SetBytes(toolResult, "content", response.Raw)
+						contentItems = append(contentItems, contentPart)
+						return true
+					} else if funcResp := part.Get("function_response"); funcResp.Exists() {
+						funcName := funcResp.Get("name").String()
+						callID := getToolResponseID(part, funcName)
+						contentPart := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
+						contentPart, _ = sjson.SetBytes(contentPart, "tool_use_id", callID)
+
+						if resp := funcResp.Get("response"); resp.Exists() {
+							contentPart, _ = sjson.SetBytes(contentPart, "content", resp.Raw)
 						}
-						contentItems = append(contentItems, toolResult)
+
+						contentItems = append(contentItems, contentPart)
 						return true
 					}
 
-					// Inline data conversion to Claude Code content format
-					if inlineData := geminiClaudeInlineData(part); inlineData.Exists() {
-						if contentPart, ok := claudeContentPartFromGeminiInlineData(inlineData); ok {
+					// Inline data conversion to Claude Code image format
+					if inlineData := part.Get("inlineData"); inlineData.Exists() {
+						mimeType := inlineData.Get("mimeType").String()
+						data := inlineData.Get("data").String()
+						if contentPart, ok := claudeContentPartFromInlineData(mimeType, data); ok {
+							contentItems = append(contentItems, contentPart)
+						}
+						return true
+					} else if inlineData := part.Get("inline_data"); inlineData.Exists() {
+						mimeType := inlineData.Get("mime_type").String()
+						data := inlineData.Get("data").String()
+						if contentPart, ok := claudeContentPartFromInlineData(mimeType, data); ok {
 							contentItems = append(contentItems, contentPart)
 						}
 						return true
@@ -370,21 +322,29 @@ func ConvertGeminiRequestToClaude(modelName string, inputRawJSON []byte, stream 
 		var anthropicTools []interface{}
 
 		tools.ForEach(func(_, tool gjson.Result) bool {
-			if funcDecls := tool.Get("functionDeclarations"); funcDecls.Exists() && funcDecls.IsArray() {
+			funcDecls := tool.Get("functionDeclarations")
+			if !funcDecls.Exists() || !funcDecls.IsArray() {
+				funcDecls = tool.Get("function_declarations")
+			}
+			if funcDecls.Exists() && funcDecls.IsArray() {
 				funcDecls.ForEach(func(_, funcDecl gjson.Result) bool {
-					anthropicTool := []byte(`{"name":"","description":"","input_schema":{}}`)
+					anthropicTool := []byte(`{"name":"","description":"","input_schema":{"type":"object","properties":{}}}`)
 
 					if name := funcDecl.Get("name"); name.Exists() {
-						anthropicTool, _ = sjson.SetBytes(anthropicTool, "name", name.String())
+						anthropicTool, _ = sjson.SetBytes(anthropicTool, "name", util.SanitizeClaudeFunctionName(name.String()))
 					}
 					if desc := funcDecl.Get("description"); desc.Exists() {
 						anthropicTool, _ = sjson.SetBytes(anthropicTool, "description", desc.String())
 					}
-					if params := funcDecl.Get("parameters"); params.Exists() {
-						cleaned := normalizeClaudeToolSchema(params)
-						anthropicTool, _ = sjson.SetRawBytes(anthropicTool, "input_schema", cleaned)
-					} else if params = funcDecl.Get("parametersJsonSchema"); params.Exists() {
-						cleaned := normalizeClaudeToolSchema(params)
+					var schemaRaw []byte
+					for _, k := range []string{"parameters", "parametersJsonSchema", "parameters_json_schema", "input_schema", "schema"} {
+						if s := funcDecl.Get(k); s.Exists() && s.Raw != "" && s.Raw != "null" {
+							schemaRaw = []byte(s.Raw)
+							break
+						}
+					}
+					if len(schemaRaw) > 0 {
+						cleaned := normalizeClaudeToolSchema(gjson.ParseBytes(schemaRaw))
 						anthropicTool, _ = sjson.SetRawBytes(anthropicTool, "input_schema", cleaned)
 					}
 
@@ -428,127 +388,128 @@ func normalizeClaudeToolSchema(parameters gjson.Result) []byte {
 }
 
 func lowercaseClaudeToolSchemaTypes(tool []byte) []byte {
-	var pathsToLower []string
-	util.Walk(gjson.ParseBytes(tool), "", "type", &pathsToLower)
-	for _, path := range pathsToLower {
-		typeValue := gjson.GetBytes(tool, path)
-		normalizedType := strings.ToLower(typeValue.String())
-		if typeValue.Type == gjson.String && normalizedType == typeValue.String() {
-			continue
-		}
-		tool, _ = sjson.SetBytes(tool, path, normalizedType)
+	schema := gjson.GetBytes(tool, "input_schema")
+	if !schema.Exists() {
+		return tool
 	}
-	return tool
-}
-
-func setClaudeToolChoiceFromGeminiToolConfig(out []byte, funcCalling gjson.Result) []byte {
-	if !funcCalling.Exists() {
-		return out
-	}
-	mode := funcCalling.Get("mode")
-	if !mode.Exists() {
-		return out
-	}
-	switch mode.String() {
-	case "AUTO":
-		out, _ = sjson.SetRawBytes(out, "tool_choice", []byte(`{"type":"auto"}`))
-	case "NONE":
-		out, _ = sjson.SetRawBytes(out, "tool_choice", []byte(`{"type":"none"}`))
-	case "ANY":
-		allowedNames := funcCalling.Get("allowedFunctionNames")
-		if !allowedNames.Exists() {
-			allowedNames = funcCalling.Get("allowed_function_names")
-		}
-		allowedNameItems := allowedNames.Array()
-		if allowedNames.IsArray() && len(allowedNameItems) == 1 {
-			choice := []byte(`{"type":"tool","name":""}`)
-			choice, _ = sjson.SetBytes(choice, "name", allowedNameItems[0].String())
-			out, _ = sjson.SetRawBytes(out, "tool_choice", choice)
-		} else {
-			out, _ = sjson.SetRawBytes(out, "tool_choice", []byte(`{"type":"any"}`))
+	paths := findTypePaths(schema.Raw)
+	out := tool
+	for _, p := range paths {
+		val := gjson.GetBytes(tool, "input_schema."+p)
+		if val.Exists() && val.Type == gjson.String {
+			out, _ = sjson.SetBytes(out, "input_schema."+p, strings.ToLower(val.String()))
 		}
 	}
 	return out
 }
 
-func geminiClaudeInlineData(part gjson.Result) gjson.Result {
-	inlineData := part.Get("inlineData")
-	if inlineData.Exists() {
-		return inlineData
+func findTypePaths(rawJSON string) []string {
+	var paths []string
+	root := gjson.Parse(rawJSON)
+	var walk func(path string, val gjson.Result)
+	walk = func(path string, val gjson.Result) {
+		if val.IsObject() {
+			val.ForEach(func(k, v gjson.Result) bool {
+				key := k.String()
+				subPath := key
+				if path != "" {
+					subPath = path + "." + key
+				}
+				if key == "type" && v.Type == gjson.String {
+					paths = append(paths, subPath)
+				} else {
+					walk(subPath, v)
+				}
+				return true
+			})
+		} else if val.IsArray() {
+			val.ForEach(func(k, v gjson.Result) bool {
+				idx := k.String()
+				subPath := idx
+				if path != "" {
+					subPath = path + "." + idx
+				}
+				walk(subPath, v)
+				return true
+			})
+		}
 	}
-	return part.Get("inline_data")
+	walk("", root)
+	return paths
+}
+
+func setClaudeToolChoiceFromGeminiToolConfig(out []byte, functionCallingConfig gjson.Result) []byte {
+	if !functionCallingConfig.Exists() {
+		return out
+	}
+	mode := functionCallingConfig.Get("mode").String()
+	switch strings.ToUpper(mode) {
+	case "NONE":
+		out, _ = sjson.SetBytes(out, "tool_choice.type", "none")
+	case "AUTO":
+		out, _ = sjson.SetBytes(out, "tool_choice.type", "auto")
+	case "ANY":
+		allowed := functionCallingConfig.Get("allowed_function_names")
+		if !allowed.Exists() {
+			allowed = functionCallingConfig.Get("allowedFunctionNames")
+		}
+		if allowed.Exists() && allowed.IsArray() && len(allowed.Array()) > 0 {
+			first := allowed.Array()[0].String()
+			out, _ = sjson.SetBytes(out, "tool_choice.type", "tool")
+			out, _ = sjson.SetBytes(out, "tool_choice.name", first)
+		} else {
+			out, _ = sjson.SetBytes(out, "tool_choice.type", "any")
+		}
+	}
+	return out
+}
+
+func isHiddenThoughtPart(part gjson.Result) bool {
+	thought := part.Get("thought")
+	if thought.Exists() && thought.Bool() {
+		return true
+	}
+	ts := part.Get("thoughtSignature")
+	if !ts.Exists() {
+		ts = part.Get("thought_signature")
+	}
+	if ts.Exists() && ts.String() != "" && !part.Get("text").Exists() && !part.Get("functionCall").Exists() && !part.Get("function_call").Exists() {
+		return true
+	}
+	return false
+}
+
+func claudeContentPartFromInlineData(mimeType, data string) ([]byte, bool) {
+	if data == "" {
+		return nil, false
+	}
+	if strings.HasPrefix(mimeType, "image/") {
+		part := []byte(`{"type":"image","source":{"type":"base64","media_type":"","data":""}}`)
+		part, _ = sjson.SetBytes(part, "source.media_type", mimeType)
+		part, _ = sjson.SetBytes(part, "source.data", data)
+		return part, true
+	}
+	part := []byte(`{"type":"document","source":{"type":"base64","media_type":"","data":""}}`)
+	part, _ = sjson.SetBytes(part, "source.media_type", mimeType)
+	part, _ = sjson.SetBytes(part, "source.data", data)
+	return part, true
 }
 
 func geminiClaudeFileData(part gjson.Result) gjson.Result {
-	fileData := part.Get("fileData")
-	if fileData.Exists() {
-		return fileData
+	if fd := part.Get("fileData"); fd.Exists() {
+		return fd
 	}
 	return part.Get("file_data")
 }
 
-func claudeContentPartFromGeminiInlineData(inlineData gjson.Result) ([]byte, bool) {
-	mimeType := inlineData.Get("mimeType").String()
-	if mimeType == "" {
-		mimeType = inlineData.Get("mime_type").String()
-	}
-	data := inlineData.Get("data").String()
-	if mimeType == "" || data == "" {
-		return nil, false
-	}
-	lowerMimeType := strings.ToLower(mimeType)
-	switch {
-	case strings.HasPrefix(lowerMimeType, "image/"):
-		imageContent := []byte(`{"type":"image","source":{"type":"base64","media_type":"","data":""}}`)
-		imageContent, _ = sjson.SetBytes(imageContent, "source.media_type", mimeType)
-		imageContent, _ = sjson.SetBytes(imageContent, "source.data", data)
-		return imageContent, true
-	case strings.HasPrefix(lowerMimeType, "application/"), strings.HasPrefix(lowerMimeType, "text/"):
-		documentContent := []byte(`{"type":"document","source":{"type":"base64","media_type":"","data":""}}`)
-		documentContent, _ = sjson.SetBytes(documentContent, "source.media_type", mimeType)
-		documentContent, _ = sjson.SetBytes(documentContent, "source.data", data)
-		return documentContent, true
-	default:
-		return claudeTextContentPart(fmt.Sprintf("Media content: inline data (Type: %s)", mimeType)), true
-	}
-}
-
 func claudeContentPartFromGeminiFileData(fileData gjson.Result) ([]byte, bool) {
-	fileURI := fileData.Get("fileUri").String()
-	if fileURI == "" {
-		fileURI = fileData.Get("file_uri").String()
-	}
-	if fileURI == "" {
-		return nil, false
-	}
 	mimeType := fileData.Get("mimeType").String()
 	if mimeType == "" {
 		mimeType = fileData.Get("mime_type").String()
 	}
-	lowerMimeType := strings.ToLower(mimeType)
-	switch {
-	case strings.HasPrefix(lowerMimeType, "image/"):
-		imageContent := []byte(`{"type":"image","source":{"type":"url","url":""}}`)
-		imageContent, _ = sjson.SetBytes(imageContent, "source.url", fileURI)
-		return imageContent, true
-	case strings.HasPrefix(lowerMimeType, "application/"), strings.HasPrefix(lowerMimeType, "text/"):
-		documentContent := []byte(`{"type":"document","source":{"type":"url","url":""}}`)
-		documentContent, _ = sjson.SetBytes(documentContent, "source.url", fileURI)
-		if mimeType != "" {
-			documentContent, _ = sjson.SetBytes(documentContent, "source.media_type", mimeType)
-		}
-		return documentContent, true
-	default:
-		fileInfo := "File: " + fileURI
-		if mimeType != "" {
-			fileInfo += " (Type: " + mimeType + ")"
-		}
-		return claudeTextContentPart(fileInfo), true
+	data := fileData.Get("data").String()
+	if data != "" {
+		return claudeContentPartFromInlineData(mimeType, data)
 	}
-}
-
-func claudeTextContentPart(text string) []byte {
-	textContent := []byte(`{"type":"text","text":""}`)
-	textContent, _ = sjson.SetBytes(textContent, "text", text)
-	return textContent
+	return nil, false
 }

--- a/internal/translator/claude/interactions/interactions_claude_request.go
+++ b/internal/translator/claude/interactions/interactions_claude_request.go
@@ -1,330 +1,261 @@
+// Package interactions provides request translation functionality for Gemini Interactions to Claude Code API compatibility.
+// It handles parsing and transforming Interactions API requests into Claude Code API format,
+// extracting model information, system instructions, message contents, and tool declarations.
+// The package performs JSON data transformation to ensure compatibility
+// between Interactions API format and Claude Code API's expected format.
 package interactions
 
 import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"math/big"
 	"strings"
 
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	"github.com/google/uuid"
 	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
+var (
+	user    = ""
+	account = ""
+	session = ""
+)
+
+// ConvertInteractionsRequestToClaude parses and transforms a Gemini Interactions API request into Claude Code API format.
+// It extracts the model name, system instruction, message contents, and tool declarations
+// from the raw JSON request and returns them in the format expected by the Claude Code API.
+// The function performs comprehensive transformation including:
+// 1. Model name mapping and parameter extraction (max_tokens, top_p, etc.)
+// 2. Message content conversion from Interactions to Claude Code format
+// 3. Tool call and tool result handling with proper ID mapping
+// 4. Input items (user input, function calls, function results) conversion
+// 5. System instruction and thinking configuration handling
+//
+// Parameters:
+//   - modelName: The name of the model to use for the request
+//   - inputRawJSON: The raw JSON request data from the Interactions API
+//   - stream: A boolean indicating if the request is for a streaming response
+//
+// Returns:
+//   - []byte: The transformed request data in Claude Code API format
 func ConvertInteractionsRequestToClaude(modelName string, inputRawJSON []byte, stream bool) []byte {
-	root := gjson.ParseBytes(inputRawJSON)
-	out := []byte(`{"model":"","max_tokens":32000,"messages":[]}`)
+	rawJSON := inputRawJSON
+
+	if account == "" {
+		u, _ := uuid.NewRandom()
+		account = u.String()
+	}
+	if session == "" {
+		u, _ := uuid.NewRandom()
+		session = u.String()
+	}
+	if user == "" {
+		sum := sha256.Sum256([]byte(account + session))
+		user = hex.EncodeToString(sum[:])
+	}
+	userID := fmt.Sprintf("user_%s_account_%s_session_%s", user, account, session)
+
+	out := []byte(fmt.Sprintf(`{"model":"","max_tokens":32000,"messages":[],"metadata":{"user_id":"%s"}}`, userID))
+	root := gjson.ParseBytes(rawJSON)
+
 	out, _ = sjson.SetBytes(out, "model", modelName)
-	if stream || root.Get("stream").Bool() {
-		out, _ = sjson.SetBytes(out, "stream", true)
+	if maxTokens := firstClaudeInteractionsExisting(root, "generation_config.max_output_tokens", "generationConfig.maxOutputTokens", "max_tokens"); maxTokens.Exists() {
+		out, _ = sjson.SetBytes(out, "max_tokens", maxTokens.Int())
 	}
-	out = copyInteractionsSystemToClaude(out, root)
-	out = copyInteractionsGenerationConfigToClaude(out, root)
-	messageAccumulator := translatorcommon.NewClaudeMessageAccumulator(int(root.Get("input.#").Int()))
-	appendInteractionsInputToClaudeMessages(messageAccumulator, root.Get("input"))
-	out = translatorcommon.SetRawArrayItems(out, "messages", messageAccumulator.Messages())
-	out = copyInteractionsToolsToClaude(out, root)
-	return out
-}
+	if temperature := firstClaudeInteractionsExisting(root, "generation_config.temperature", "generationConfig.temperature", "temperature"); temperature.Exists() {
+		out, _ = sjson.SetBytes(out, "temperature", temperature.Float())
+	}
+	if topP := firstClaudeInteractionsExisting(root, "generation_config.top_p", "generationConfig.topP", "top_p"); topP.Exists() {
+		out, _ = sjson.SetBytes(out, "top_p", topP.Float())
+	}
+	if topK := firstClaudeInteractionsExisting(root, "generation_config.top_k", "generationConfig.topK", "top_k"); topK.Exists() {
+		out, _ = sjson.SetBytes(out, "top_k", topK.Int())
+	}
 
-func copyInteractionsSystemToClaude(out []byte, root gjson.Result) []byte {
-	sys := root.Get("system_instruction")
-	if !sys.Exists() {
-		sys = root.Get("systemInstruction")
-	}
-	text := interactionsClaudeText(sys)
-	if text == "" {
-		return out
-	}
-	out, _ = sjson.SetBytes(out, "system", text)
-	return out
-}
-
-func copyInteractionsGenerationConfigToClaude(out []byte, root gjson.Result) []byte {
-	cfg := root.Get("generation_config")
-	if !cfg.Exists() {
-		cfg = root.Get("generationConfig")
-	}
-	if cfg.Exists() {
-		out = copyJSONField(out, cfg, "max_output_tokens", "max_tokens")
-		out = copyJSONField(out, cfg, "maxOutputTokens", "max_tokens")
-		out = copyJSONField(out, cfg, "top_p", "top_p")
-		out = copyJSONField(out, cfg, "topP", "top_p")
-		out = copyJSONField(out, cfg, "temperature", "temperature")
-		out = copyJSONField(out, cfg, "stop_sequences", "stop_sequences")
-		out = copyJSONField(out, cfg, "stopSequences", "stop_sequences")
-		out = copyInteractionsThinkingConfigToClaude(out, cfg)
-		out = copyInteractionsToolChoiceToClaude(out, cfg.Get("tool_choice"))
-		out = copyInteractionsToolChoiceToClaude(out, cfg.Get("toolChoice"))
-	}
-	out = copyInteractionsReasoningToClaude(out, root.Get("reasoning"))
-	out = copyInteractionsToolChoiceToClaude(out, root.Get("tool_choice"))
-	out = copyInteractionsToolChoiceToClaude(out, root.Get("toolChoice"))
-	return out
-}
-
-func copyJSONField(out []byte, root gjson.Result, from, to string) []byte {
-	value := root.Get(from)
-	if !value.Exists() {
-		return out
-	}
-	out, _ = sjson.SetRawBytes(out, to, []byte(value.Raw))
-	return out
-}
-
-func copyInteractionsThinkingConfigToClaude(out []byte, cfg gjson.Result) []byte {
-	level := firstClaudeInteractionsExisting(cfg, "thinking_level", "thinkingLevel", "reasoning.effort")
-	if !level.Exists() {
-		return out
-	}
-	return setClaudeThinkingFromLevel(out, level.String())
-}
-
-func copyInteractionsReasoningToClaude(out []byte, reasoning gjson.Result) []byte {
-	if !reasoning.Exists() {
-		return out
-	}
-	if effort := reasoning.Get("effort"); effort.Exists() {
-		return setClaudeThinkingFromLevel(out, effort.String())
-	}
-	if level := reasoning.Get("thinking_level"); level.Exists() {
-		return setClaudeThinkingFromLevel(out, level.String())
-	}
-	return out
-}
-
-func setClaudeThinkingFromLevel(out []byte, level string) []byte {
-	normalized := strings.ToLower(strings.TrimSpace(level))
-	if normalized == "" {
-		return out
-	}
-	switch normalized {
-	case "none", "disabled", "off", "false":
-		out, _ = sjson.SetBytes(out, "thinking.type", "disabled")
-		out, _ = sjson.DeleteBytes(out, "thinking.budget_tokens")
-		return out
-	case "auto", "adaptive":
-		out, _ = sjson.SetBytes(out, "thinking.type", "adaptive")
-		out, _ = sjson.DeleteBytes(out, "thinking.budget_tokens")
-		return out
-	}
-	if budget, ok := thinking.ConvertLevelToBudget(normalized); ok {
-		switch {
-		case budget == 0:
+	if thinkingBudget := firstClaudeInteractionsExisting(root, "generation_config.thinking_config.thinking_budget", "generationConfig.thinkingConfig.thinkingBudget", "thinking.budget_tokens"); thinkingBudget.Exists() {
+		switch thinkingBudget.Int() {
+		case 0:
 			out, _ = sjson.SetBytes(out, "thinking.type", "disabled")
-		case budget < 0:
+		case -1:
 			out, _ = sjson.SetBytes(out, "thinking.type", "enabled")
 		default:
-			out, _ = sjson.SetBytes(out, "thinking.type", "enabled")
-			out, _ = sjson.SetBytes(out, "thinking.budget_tokens", budget)
-		}
-		return out
-	}
-	out, _ = sjson.SetBytes(out, "thinking.type", "adaptive")
-	out, _ = sjson.SetBytes(out, "output_config.effort", normalized)
-	return out
-}
-
-func appendInteractionsInputToClaudeMessages(accumulator *translatorcommon.ClaudeMessageAccumulator, input gjson.Result) {
-	if !input.Exists() {
-		return
-	}
-	if input.Type == gjson.String {
-		step := []byte(`{"type":"user_input","content":[{"type":"text","text":""}]}`)
-		step, _ = sjson.SetBytes(step, "content.0.text", input.String())
-		appendInteractionsStepToClaude(accumulator, gjson.ParseBytes(step), "user")
-		return
-	}
-	if input.IsObject() {
-		appendInteractionsInputItemToClaude(accumulator, input)
-		return
-	}
-	input.ForEach(func(_, step gjson.Result) bool {
-		appendInteractionsInputItemToClaude(accumulator, step)
-		return true
-	})
-}
-
-func appendInteractionsInputItemToClaude(accumulator *translatorcommon.ClaudeMessageAccumulator, step gjson.Result) {
-	if step.Get("steps").IsArray() {
-		defaultRole := "user"
-		if role := step.Get("role").String(); role == "model" || role == "assistant" {
-			defaultRole = "assistant"
-		}
-		step.Get("steps").ForEach(func(_, nestedStep gjson.Result) bool {
-			appendInteractionsStepToClaude(accumulator, nestedStep, defaultRole)
-			return true
-		})
-		return
-	}
-	if step.Get("parts").Exists() {
-		wrapped := []byte(`{"type":"user_input","content":[]}`)
-		if role := step.Get("role").String(); role == "model" || role == "assistant" {
-			wrapped, _ = sjson.SetBytes(wrapped, "type", "model_output")
-		}
-		wrapped, _ = sjson.SetRawBytes(wrapped, "content", []byte(step.Get("parts").Raw))
-		appendInteractionsStepToClaude(accumulator, gjson.ParseBytes(wrapped), "user")
-		return
-	}
-	stepType := step.Get("type").String()
-	switch stepType {
-	case "function_call":
-		appendInteractionsFunctionCallToClaude(accumulator, step)
-	case "function_result":
-		appendInteractionsFunctionResultToClaude(accumulator, step)
-	case "model_output", "thought":
-		appendInteractionsStepToClaude(accumulator, step, "assistant")
-	default:
-		appendInteractionsStepToClaude(accumulator, step, "user")
-	}
-}
-
-func appendInteractionsStepToClaude(accumulator *translatorcommon.ClaudeMessageAccumulator, step gjson.Result, defaultRole string) {
-	role := defaultRole
-	if stepRole := step.Get("role").String(); stepRole == "user" || stepRole == "assistant" {
-		role = stepRole
-	}
-	contentItems := make([][]byte, 0, 4)
-	stepContent := step.Get("content")
-	if stepContent.Type == gjson.String {
-		part := []byte(`{"type":"text","text":""}`)
-		part, _ = sjson.SetBytes(part, "text", stepContent.String())
-		contentItems = append(contentItems, part)
-	} else if stepContent.IsArray() {
-		stepContent.ForEach(func(_, part gjson.Result) bool {
-			if converted := interactionsContentToClaude(part, role); len(converted) > 0 {
-				contentItems = append(contentItems, converted)
+			if thinkingBudget.Int() > 0 {
+				out, _ = sjson.SetBytes(out, "thinking.type", "enabled")
+				out, _ = sjson.SetBytes(out, "thinking.budget_tokens", thinkingBudget.Int())
 			}
-			return true
-		})
-	} else if text := step.Get("text"); text.Exists() {
-		part := []byte(`{"type":"text","text":""}`)
-		part, _ = sjson.SetBytes(part, "text", text.String())
-		contentItems = append(contentItems, part)
-	}
-	if len(contentItems) == 0 {
-		return
-	}
-	msg := []byte(`{"role":"","content":[]}`)
-	msg, _ = sjson.SetBytes(msg, "role", role)
-	msg, _ = sjson.SetRawBytes(msg, "content", translatorcommon.JoinRawArray(contentItems))
-	accumulator.Append(msg)
-}
-
-func interactionsContentToClaude(part gjson.Result, role string) []byte {
-	partType := part.Get("type").String()
-	if partType == "" && part.Get("text").Exists() {
-		partType = "text"
-	}
-	switch partType {
-	case "text":
-		textPart := []byte(`{"type":"text","text":""}`)
-		textPart, _ = sjson.SetBytes(textPart, "text", part.Get("text").String())
-		return textPart
-	case "thinking", "reasoning":
-		if role != "assistant" {
-			return nil
-		}
-		thinkingPart := []byte(`{"type":"thinking","thinking":""}`)
-		thinkingPart, _ = sjson.SetBytes(thinkingPart, "thinking", interactionsClaudeText(part))
-		return thinkingPart
-	case "image":
-		imagePart, _ := interactionsClaudeMediaPart(part, "image")
-		return imagePart
-	case "document", "file":
-		documentPart, _ := interactionsClaudeMediaPart(part, "document")
-		return documentPart
-	default:
-		if text := interactionsClaudeText(part); text != "" {
-			textPart := []byte(`{"type":"text","text":""}`)
-			textPart, _ = sjson.SetBytes(textPart, "text", text)
-			return textPart
-		}
-		if part.Get("data").String() != "" || part.Get("file_data").String() != "" {
-			textPart := []byte(`{"type":"text","text":""}`)
-			textPart, _ = sjson.SetBytes(textPart, "text", fmt.Sprintf("[%s content omitted]", partType))
-			return textPart
 		}
 	}
-	return nil
-}
 
-func appendInteractionsFunctionCallToClaude(accumulator *translatorcommon.ClaudeMessageAccumulator, step gjson.Result) {
-	toolUse := []byte(`{"type":"tool_use","id":"","name":"","input":{}}`)
-	toolUse, _ = sjson.SetBytes(toolUse, "id", interactionsClaudeToolID(step))
-	toolUse, _ = sjson.SetBytes(toolUse, "name", step.Get("name").String())
-	args := step.Get("arguments")
-	if !args.Exists() {
-		args = step.Get("args")
-	}
-	if args.Exists() && args.IsObject() {
-		toolUse, _ = sjson.SetRawBytes(toolUse, "input", []byte(args.Raw))
-	}
-	msg := []byte(`{"role":"assistant","content":[]}`)
-	msg, _ = sjson.SetRawBytes(msg, "content", translatorcommon.JoinRawArray([][]byte{toolUse}))
-	accumulator.Append(msg)
-}
-
-func appendInteractionsFunctionResultToClaude(accumulator *translatorcommon.ClaudeMessageAccumulator, step gjson.Result) {
-	toolResult := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
-	toolResult, _ = sjson.SetBytes(toolResult, "tool_use_id", interactionsClaudeToolID(step))
-	result := step.Get("result")
-	if !result.Exists() {
-		result = step.Get("output")
-	}
-	switch {
-	case result.IsArray():
-		contentItems := make([][]byte, 0, 4)
-		result.ForEach(func(_, part gjson.Result) bool {
-			if converted := interactionsContentToClaude(part, "user"); len(converted) > 0 {
-				contentItems = append(contentItems, converted)
+	if systemInstruction := firstClaudeInteractionsExisting(root, "system_instruction", "systemInstruction", "system"); systemInstruction.Exists() {
+		if systemInstruction.Type == gjson.String {
+			out, _ = sjson.SetBytes(out, "system", systemInstruction.String())
+		} else if parts := systemInstruction.Get("parts"); parts.IsArray() {
+			var systemText []string
+			parts.ForEach(func(_, part gjson.Result) bool {
+				if text := part.Get("text"); text.Exists() {
+					systemText = append(systemText, text.String())
+				}
+				return true
+			})
+			if len(systemText) > 0 {
+				out, _ = sjson.SetBytes(out, "system", strings.Join(systemText, "\n\n"))
 			}
-			return true
-		})
-		toolResult, _ = sjson.SetRawBytes(toolResult, "content", translatorcommon.JoinRawArray(contentItems))
-	case result.Exists() && result.Raw != "":
-		toolResult, _ = sjson.SetBytes(toolResult, "content", result.Raw)
-	default:
-		toolResult, _ = sjson.SetBytes(toolResult, "content", "")
+		}
 	}
-	msg := []byte(`{"role":"user","content":[]}`)
-	msg, _ = sjson.SetRawBytes(msg, "content", translatorcommon.JoinRawArray([][]byte{toolResult}))
-	accumulator.Append(msg)
-}
 
-func copyInteractionsToolsToClaude(out []byte, root gjson.Result) []byte {
+	toolIDMap := make(map[string]string)
+	genToolCallID := func(name string) string {
+		if id, exists := toolIDMap[name]; exists {
+			return id
+		}
+		const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+		var b strings.Builder
+		for i := 0; i < 24; i++ {
+			n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
+			b.WriteByte(letters[n.Int64()])
+		}
+		id := "toolu_" + b.String()
+		toolIDMap[name] = id
+		return id
+	}
+
+	input := root.Get("input")
+	if input.Exists() {
+		if input.Type == gjson.String {
+			msg := []byte(`{"role":"user","content":[{"type":"text","text":""}]}`)
+			msg, _ = sjson.SetBytes(msg, "content.0.text", input.String())
+			out, _ = sjson.SetRawBytes(out, "messages", []byte(`[`+string(msg)+`]`))
+		} else if input.IsArray() {
+			messageAccumulator := translatorcommon.NewClaudeMessageAccumulator(int(input.Get("#").Int()))
+			input.ForEach(func(_, item gjson.Result) bool {
+				itemType := item.Get("type").String()
+				switch itemType {
+				case "user_input", "user":
+					content := item.Get("content")
+					var contentItems [][]byte
+					if content.Type == gjson.String {
+						part := []byte(`{"type":"text","text":""}`)
+						part, _ = sjson.SetBytes(part, "text", content.String())
+						contentItems = append(contentItems, part)
+					} else if content.IsArray() {
+						content.ForEach(func(_, part gjson.Result) bool {
+							switch part.Get("type").String() {
+							case "text":
+								textPart := []byte(`{"type":"text","text":""}`)
+								textPart, _ = sjson.SetBytes(textPart, "text", part.Get("text").String())
+								contentItems = append(contentItems, textPart)
+							case "image":
+								source := part.Get("source")
+								imagePart := []byte(`{"type":"image","source":{}}`)
+								imagePart, _ = sjson.SetRawBytes(imagePart, "source", []byte(source.Raw))
+								contentItems = append(contentItems, imagePart)
+							}
+							return true
+						})
+					}
+					if len(contentItems) > 0 {
+						msg := []byte(`{"role":"user","content":[]}`)
+						msg, _ = sjson.SetRawBytes(msg, "content", translatorcommon.JoinRawArray(contentItems))
+						messageAccumulator.Append(msg)
+					}
+
+				case "function_call":
+					name := item.Get("name").String()
+					callID := item.Get("call_id").String()
+					if callID == "" {
+						callID = genToolCallID(name)
+					}
+					part := []byte(`{"type":"tool_use","id":"","name":"","input":{}}`)
+					part, _ = sjson.SetBytes(part, "id", callID)
+					part, _ = sjson.SetBytes(part, "name", name)
+					if args := item.Get("arguments"); args.Exists() {
+						part, _ = sjson.SetRawBytes(part, "input", []byte(args.Raw))
+					}
+					msg := []byte(`{"role":"assistant","content":[]}`)
+					msg, _ = sjson.SetRawBytes(msg, "content", []byte(`[`+string(part)+`]`))
+					messageAccumulator.Append(msg)
+
+				case "function_result":
+					name := item.Get("name").String()
+					callID := item.Get("call_id").String()
+					if callID == "" {
+						callID = genToolCallID(name)
+					}
+					part := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
+					part, _ = sjson.SetBytes(part, "tool_use_id", callID)
+					if result := item.Get("result"); result.Exists() {
+						part, _ = sjson.SetBytes(part, "content", result.Raw)
+					}
+					msg := []byte(`{"role":"user","content":[]}`)
+					msg, _ = sjson.SetRawBytes(msg, "content", []byte(`[`+string(part)+`]`))
+					messageAccumulator.Append(msg)
+				}
+				return true
+			})
+			out = translatorcommon.SetRawArrayItems(out, "messages", messageAccumulator.Messages())
+		}
+	}
+
 	tools := root.Get("tools")
-	if !tools.Exists() || !tools.IsArray() {
-		return out
-	}
-	var toolItems [][]byte
-	tools.ForEach(func(_, tool gjson.Result) bool {
-		if tool.Get("function_declarations").IsArray() {
-			tool.Get("function_declarations").ForEach(func(_, decl gjson.Result) bool {
-				if converted := interactionsClaudeTool(decl); len(converted) > 0 {
-					toolItems = append(toolItems, converted)
-				}
+	if tools.IsArray() {
+		var toolItems [][]byte
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			if tool.Get("function_declarations").IsArray() {
+				tool.Get("function_declarations").ForEach(func(_, decl gjson.Result) bool {
+					if converted := interactionsClaudeTool(decl); len(converted) > 0 {
+						toolItems = append(toolItems, converted)
+					}
+					return true
+				})
 				return true
-			})
-			return true
-		}
-		if tool.Get("functionDeclarations").IsArray() {
-			tool.Get("functionDeclarations").ForEach(func(_, decl gjson.Result) bool {
-				if converted := interactionsClaudeTool(decl); len(converted) > 0 {
-					toolItems = append(toolItems, converted)
-				}
+			}
+			if tool.Get("functionDeclarations").IsArray() {
+				tool.Get("functionDeclarations").ForEach(func(_, decl gjson.Result) bool {
+					if converted := interactionsClaudeTool(decl); len(converted) > 0 {
+						toolItems = append(toolItems, converted)
+					}
+					return true
+				})
 				return true
-			})
+			}
+			if converted := interactionsClaudeTool(tool); len(converted) > 0 {
+				toolItems = append(toolItems, converted)
+			}
 			return true
+		})
+		if len(toolItems) > 0 {
+			out, _ = sjson.SetRawBytes(out, "tools", translatorcommon.JoinRawArray(toolItems))
 		}
-		if converted := interactionsClaudeTool(tool); len(converted) > 0 {
-			toolItems = append(toolItems, converted)
-		}
-		return true
-	})
-	if len(toolItems) > 0 {
-		out, _ = sjson.SetRawBytes(out, "tools", translatorcommon.JoinRawArray(toolItems))
 	}
+
+	if toolChoice := firstClaudeInteractionsExisting(root, "generation_config.tool_choice", "generationConfig.toolChoice", "tool_choice"); toolChoice.Exists() {
+		switch toolChoice.Type {
+		case gjson.String:
+			switch strings.ToLower(toolChoice.String()) {
+			case "none":
+				out, _ = sjson.SetBytes(out, "tool_choice.type", "none")
+			case "auto":
+				out, _ = sjson.SetBytes(out, "tool_choice.type", "auto")
+			case "required", "any":
+				out, _ = sjson.SetBytes(out, "tool_choice.type", "any")
+			}
+		case gjson.JSON:
+			if toolChoice.Get("type").String() == "function" {
+				fnName := toolChoice.Get("function.name").String()
+				if fnName != "" {
+					out, _ = sjson.SetBytes(out, "tool_choice.type", "tool")
+					out, _ = sjson.SetBytes(out, "tool_choice.name", fnName)
+				}
+			}
+		}
+	}
+
+	out, _ = sjson.SetBytes(out, "stream", stream)
 	return out
 }
 
@@ -336,125 +267,26 @@ func interactionsClaudeTool(tool gjson.Result) []byte {
 	if name == "" {
 		return nil
 	}
-	converted := []byte(`{"name":"","input_schema":{}}`)
-	converted, _ = sjson.SetBytes(converted, "name", name)
+	sanitizedName := util.SanitizeClaudeFunctionName(name)
+	converted := []byte(`{"name":"","input_schema":{"type":"object","properties":{}}}`)
+	converted, _ = sjson.SetBytes(converted, "name", sanitizedName)
 	if desc := tool.Get("description"); desc.Exists() {
 		converted, _ = sjson.SetBytes(converted, "description", desc.String())
 	} else if desc := tool.Get("function.description"); desc.Exists() {
 		converted, _ = sjson.SetBytes(converted, "description", desc.String())
 	}
+
 	params := firstClaudeInteractionsExisting(tool, "parameters", "parametersJsonSchema", "parameters_json_schema", "input_schema")
-	if params.Exists() && params.IsObject() {
+	if params.Exists() {
 		converted, _ = sjson.SetRawBytes(converted, "input_schema", []byte(params.Raw))
 	}
 	return converted
 }
 
-func copyInteractionsToolChoiceToClaude(out []byte, toolChoice gjson.Result) []byte {
-	if !toolChoice.Exists() {
-		return out
-	}
-	switch toolChoice.Type {
-	case gjson.String:
-		switch strings.ToLower(strings.TrimSpace(toolChoice.String())) {
-		case "auto":
-			out, _ = sjson.SetRawBytes(out, "tool_choice", []byte(`{"type":"auto"}`))
-		case "required", "any":
-			out, _ = sjson.SetRawBytes(out, "tool_choice", []byte(`{"type":"any"}`))
-		}
-	case gjson.JSON:
-		toolType := strings.ToLower(strings.TrimSpace(toolChoice.Get("type").String()))
-		switch toolType {
-		case "auto":
-			out, _ = sjson.SetRawBytes(out, "tool_choice", []byte(`{"type":"auto"}`))
-		case "required", "any":
-			out, _ = sjson.SetRawBytes(out, "tool_choice", []byte(`{"type":"any"}`))
-		case "function", "tool":
-			name := toolChoice.Get("name").String()
-			if name == "" {
-				name = toolChoice.Get("function.name").String()
-			}
-			if name != "" {
-				choice := []byte(`{"type":"tool","name":""}`)
-				choice, _ = sjson.SetBytes(choice, "name", name)
-				out, _ = sjson.SetRawBytes(out, "tool_choice", choice)
-			}
-		}
-	}
-	return out
-}
-
-func interactionsClaudeToolID(step gjson.Result) string {
-	for _, path := range []string{"call_id", "id", "tool_use_id"} {
-		if value := step.Get(path).String(); value != "" {
-			return util.SanitizeClaudeToolID(value)
-		}
-	}
-	if name := step.Get("name").String(); name != "" {
-		return util.SanitizeClaudeToolID("toolu_" + name)
-	}
-	return "toolu_interactions"
-}
-
-func interactionsClaudeText(value gjson.Result) string {
-	if !value.Exists() {
-		return ""
-	}
-	if value.Type == gjson.String {
-		return value.String()
-	}
-	if text := value.Get("text"); text.Exists() {
-		return text.String()
-	}
-	if thinking := value.Get("thinking"); thinking.Exists() {
-		return thinking.String()
-	}
-	if content := value.Get("content"); content.Exists() {
-		return interactionsClaudeText(content)
-	}
-	if parts := value.Get("parts"); parts.Exists() && parts.IsArray() {
-		var builder strings.Builder
-		parts.ForEach(func(_, part gjson.Result) bool {
-			text := interactionsClaudeText(part)
-			if text == "" {
-				return true
-			}
-			if builder.Len() > 0 {
-				builder.WriteByte('\n')
-			}
-			builder.WriteString(text)
-			return true
-		})
-		return builder.String()
-	}
-	return ""
-}
-
-func interactionsClaudeMediaPart(part gjson.Result, claudeType string) ([]byte, bool) {
-	mimeType := firstClaudeInteractionsExisting(part, "mime_type", "mimeType", "media_type", "mediaType").String()
-	data := firstClaudeInteractionsExisting(part, "data", "file_data", "fileData").String()
-	if source := part.Get("source"); source.Exists() {
-		if mimeType == "" {
-			mimeType = source.Get("media_type").String()
-		}
-		if data == "" {
-			data = source.Get("data").String()
-		}
-	}
-	if mimeType == "" || data == "" {
-		return nil, false
-	}
-	out := []byte(`{"type":"","source":{"type":"base64","media_type":"","data":""}}`)
-	out, _ = sjson.SetBytes(out, "type", claudeType)
-	out, _ = sjson.SetBytes(out, "source.media_type", mimeType)
-	out, _ = sjson.SetBytes(out, "source.data", data)
-	return out, true
-}
-
 func firstClaudeInteractionsExisting(root gjson.Result, paths ...string) gjson.Result {
-	for _, path := range paths {
-		if value := root.Get(path); value.Exists() {
-			return value
+	for _, p := range paths {
+		if r := root.Get(p); r.Exists() {
+			return r
 		}
 	}
 	return gjson.Result{}

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -201,101 +201,144 @@ func convertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream,
 						}
 						return true
 					})
-					// Message-level cache_control applies to the last system block from this message.
-					if message.Get("cache_control").Exists() {
-						if len(systemBlocks) > systemStart {
-							lastIdx := len(systemBlocks) - 1
-							if !gjson.GetBytes(systemBlocks[lastIdx], "cache_control").Exists() {
-								systemBlocks[lastIdx] = common.AttachCacheControl(systemBlocks[lastIdx], message)
-							}
-						}
-					}
 				}
-			case "user", "assistant":
-				contentBlocks := make([][]byte, 0, 4)
-				if preserveEmptyThinkingBlocks && role == "assistant" {
-					if reasoningContent := message.Get("reasoning_content"); reasoningContent.Type == gjson.String && strings.TrimSpace(reasoningContent.String()) != "" {
-						part := []byte(`{"type":"thinking","thinking":"","signature":""}`)
-						part, _ = sjson.SetBytes(part, "thinking", reasoningContent.String())
-						contentBlocks = append(contentBlocks, part)
-					}
+				if len(systemBlocks) > systemStart && !gjson.GetBytes(systemBlocks[len(systemBlocks)-1], "cache_control").Exists() {
+					systemBlocks[len(systemBlocks)-1] = common.AttachCacheControl(systemBlocks[len(systemBlocks)-1], message)
 				}
 
-				// Handle content based on its type
+			case "user":
+				// Build user turn blocks and append as an atomic turn.
+				userBlocks := make([][]byte, 0)
+				userStart := len(userBlocks)
+
+				// Direct string content
 				if contentResult.Exists() && contentResult.Type == gjson.String && contentResult.String() != "" {
-					part := []byte(`{"type":"text","text":""}`)
-					part, _ = sjson.SetBytes(part, "text", contentResult.String())
-					contentBlocks = append(contentBlocks, part)
+					textPart := []byte(`{"type":"text","text":""}`)
+					textPart, _ = sjson.SetBytes(textPart, "text", contentResult.String())
+					textPart = common.AttachCacheControl(textPart, message)
+					userBlocks = append(userBlocks, textPart)
+				}
+
+				// Array content with mixed types (text, images)
+				if contentResult.Exists() && contentResult.IsArray() {
+					contentResult.ForEach(func(_, part gjson.Result) bool {
+						partType := part.Get("type").String()
+						switch partType {
+						case "text":
+							textPart := []byte(`{"type":"text","text":""}`)
+							textPart, _ = sjson.SetBytes(textPart, "text", part.Get("text").String())
+							textPart = common.AttachCacheControl(textPart, part)
+							userBlocks = append(userBlocks, textPart)
+
+						case "image_url":
+							url := part.Get("image_url.url").String()
+							if url != "" {
+								if mediaType, data, ok := common.ParseDataURL(url); ok {
+									imagePart := []byte(`{"type":"image","source":{"type":"base64","media_type":"","data":""}}`)
+									imagePart, _ = sjson.SetBytes(imagePart, "source.media_type", mediaType)
+									imagePart, _ = sjson.SetBytes(imagePart, "source.data", data)
+									imagePart = common.AttachCacheControl(imagePart, part)
+									userBlocks = append(userBlocks, imagePart)
+								}
+							}
+						}
+						return true
+					})
+				}
+
+				if len(userBlocks) > userStart && !gjson.GetBytes(userBlocks[len(userBlocks)-1], "cache_control").Exists() {
+					userBlocks[len(userBlocks)-1] = common.AttachCacheControl(userBlocks[len(userBlocks)-1], message)
+				}
+
+				if len(userBlocks) > 0 {
+					messageAccumulator.AppendUserBlocks(userBlocks)
+				}
+
+			case "assistant":
+				// Build assistant turn blocks.
+				assistantBlocks := make([][]byte, 0)
+				assistantStart := len(assistantBlocks)
+
+				// Assistant thinking blocks
+				// ConvertOpenAIRequestToClaudeWithCompat preserves reasoning_content as an unsigned thinking block
+				// for third-party compatibility endpoints. Upstream Anthropic ignores/strips this block
+				// because it does not accept unsigned client thinking blocks on standard chat completions.
+				if preserveEmptyThinkingBlocks {
+					assistantBlocks = common.AppendOpenAIReasoningContentToClaude(assistantBlocks, message)
+				}
+
+				// Text content
+				if contentResult.Exists() && contentResult.Type == gjson.String && contentResult.String() != "" {
+					textPart := []byte(`{"type":"text","text":""}`)
+					textPart, _ = sjson.SetBytes(textPart, "text", contentResult.String())
+					textPart = common.AttachCacheControl(textPart, message)
+					assistantBlocks = append(assistantBlocks, textPart)
 				} else if contentResult.Exists() && contentResult.IsArray() {
 					contentResult.ForEach(func(_, part gjson.Result) bool {
-						claudePart := convertOpenAIContentPartToClaudePart(part)
-						if claudePart != "" {
-							contentBlocks = append(contentBlocks, []byte(claudePart))
+						if part.Get("type").String() == "text" {
+							textPart := []byte(`{"type":"text","text":""}`)
+							textPart, _ = sjson.SetBytes(textPart, "text", part.Get("text").String())
+							textPart = common.AttachCacheControl(textPart, part)
+							assistantBlocks = append(assistantBlocks, textPart)
 						}
 						return true
 					})
 				}
 
-				// Handle tool calls (for assistant messages)
-				if toolCalls := message.Get("tool_calls"); toolCalls.Exists() && toolCalls.IsArray() && role == "assistant" {
+				// Tool calls handling
+				if toolCalls := message.Get("tool_calls"); toolCalls.Exists() && toolCalls.IsArray() {
 					toolCalls.ForEach(func(_, toolCall gjson.Result) bool {
 						if toolCall.Get("type").String() == "function" {
-							toolCallID := toolCall.Get("id").String()
-							if toolCallID == "" {
-								toolCallID = genToolCallID()
+							callID := toolCall.Get("id").String()
+							if callID == "" {
+								callID = genToolCallID()
 							}
-							toolCallID = util.SanitizeClaudeToolID(toolCallID)
+							callID = common.SanitizeToolCallIDForClaude(callID)
 
-							function := toolCall.Get("function")
-							toolUse := []byte(`{"type":"tool_use","id":"","name":"","input":{}}`)
-							toolUse, _ = sjson.SetBytes(toolUse, "id", toolCallID)
-							toolUse, _ = sjson.SetBytes(toolUse, "name", function.Get("name").String())
+							toolUsePart := []byte(`{"type":"tool_use","id":"","name":"","input":{}}`)
+							toolUsePart, _ = sjson.SetBytes(toolUsePart, "id", callID)
+							toolUsePart, _ = sjson.SetBytes(toolUsePart, "name", toolCall.Get("function.name").String())
 
-							// Parse arguments for the tool call
-							if args := function.Get("arguments"); args.Exists() {
+							// Parse function arguments JSON into input object
+							if args := toolCall.Get("function.arguments"); args.Exists() {
 								argsStr := args.String()
-								if argsStr != "" && gjson.Valid(argsStr) {
-									argsJSON := gjson.Parse(argsStr)
-									if argsJSON.IsObject() {
-										toolUse, _ = sjson.SetRawBytes(toolUse, "input", []byte(argsJSON.Raw))
-									} else {
-										toolUse, _ = sjson.SetRawBytes(toolUse, "input", []byte("{}"))
+								if argsStr != "" {
+									var inputObj map[string]any
+									if err := util.UnmarshalJSONCaseFold([]byte(argsStr), &inputObj); err == nil {
+										toolUsePart, _ = sjson.SetBytes(toolUsePart, "input", inputObj)
 									}
-								} else {
-									toolUse, _ = sjson.SetRawBytes(toolUse, "input", []byte("{}"))
 								}
-							} else {
-								toolUse, _ = sjson.SetRawBytes(toolUse, "input", []byte("{}"))
 							}
-
-							contentBlocks = append(contentBlocks, toolUse)
+							toolUsePart = common.AttachCacheControl(toolUsePart, toolCall)
+							assistantBlocks = append(assistantBlocks, toolUsePart)
 						}
 						return true
 					})
 				}
 
-				msg := []byte(`{"role":"","content":[]}`)
-				msg, _ = sjson.SetBytes(msg, "role", role)
-				msg, _ = sjson.SetRawBytes(msg, "content", common.JoinRawArray(contentBlocks))
-				msg = common.AttachMessageCacheControl(msg, message)
-				messageAccumulator.Append(msg)
+				if len(assistantBlocks) > assistantStart && !gjson.GetBytes(assistantBlocks[len(assistantBlocks)-1], "cache_control").Exists() {
+					assistantBlocks[len(assistantBlocks)-1] = common.AttachCacheControl(assistantBlocks[len(assistantBlocks)-1], message)
+				}
+
+				if len(assistantBlocks) > 0 {
+					messageAccumulator.AppendAssistantBlocks(assistantBlocks)
+				}
 
 			case "tool":
-				// Handle tool result messages conversion
-				toolCallID := message.Get("tool_call_id").String()
-				toolCallID = util.SanitizeClaudeToolID(toolCallID)
-				toolContentResult := message.Get("content")
+				// Convert tool result message to Claude Code format
+				callID := message.Get("tool_call_id").String()
+				if callID != "" {
+					callID = common.SanitizeToolCallIDForClaude(callID)
+					toolResultPart := []byte(`{"type":"tool_result","tool_use_id":""}`)
+					toolResultPart, _ = sjson.SetBytes(toolResultPart, "tool_use_id", callID)
 
-				msg := []byte(`{"role":"user","content":[{"type":"tool_result","tool_use_id":"","content":""}]}`)
-				msg, _ = sjson.SetBytes(msg, "content.0.tool_use_id", toolCallID)
-				toolResultContent, toolResultContentRaw := convertOpenAIToolResultContent(toolContentResult)
-				if toolResultContentRaw {
-					msg, _ = sjson.SetRawBytes(msg, "content.0.content", []byte(toolResultContent))
-				} else {
-					msg, _ = sjson.SetBytes(msg, "content.0.content", toolResultContent)
+					// Tool execution content
+					if contentResult.Exists() {
+						toolResultPart = common.AppendClaudeToolResultContent(toolResultPart, contentResult)
+					}
+					toolResultPart = common.AttachCacheControl(toolResultPart, message)
+					messageAccumulator.AppendToolResult(toolResultPart)
 				}
-				msg = common.AttachMessageCacheControl(msg, message)
-				messageAccumulator.Append(msg)
 			}
 			return true
 		})
@@ -320,10 +363,22 @@ func convertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream,
 	if tools := root.Get("tools"); tools.Exists() && tools.IsArray() && len(tools.Array()) > 0 {
 		var anthropicTools [][]byte
 		tools.ForEach(func(_, tool gjson.Result) bool {
-			if tool.Get("type").String() == "function" {
+			if tool.Get("type").String() == "function" || tool.Get("type").String() == "custom" {
 				function := tool.Get("function")
-				anthropicTool := []byte(`{"name":"","description":""}`)
-				anthropicTool, _ = sjson.SetBytes(anthropicTool, "name", function.Get("name").String())
+				if !function.Exists() || !function.IsObject() {
+					if c := tool.Get("custom"); c.Exists() && c.IsObject() {
+						function = c
+					} else {
+						function = tool
+					}
+				}
+				toolName := function.Get("name").String()
+				if toolName == "" {
+					toolName = tool.Get("name").String()
+				}
+				sanitizedName := util.SanitizeClaudeFunctionName(toolName)
+				anthropicTool := []byte(`{"name":"","description":"","input_schema":{"type":"object","properties":{}}}`)
+				anthropicTool, _ = sjson.SetBytes(anthropicTool, "name", sanitizedName)
 				anthropicTool, _ = sjson.SetBytes(anthropicTool, "description", function.Get("description").String())
 
 				// Convert parameters schema for the tool
@@ -365,119 +420,15 @@ func convertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream,
 		case gjson.JSON:
 			// Specific tool choice mapping
 			if toolChoice.Get("type").String() == "function" {
-				functionName := toolChoice.Get("function.name").String()
-				toolChoiceJSON := []byte(`{"type":"tool","name":""}`)
-				toolChoiceJSON, _ = sjson.SetBytes(toolChoiceJSON, "name", functionName)
-				out, _ = sjson.SetRawBytes(out, "tool_choice", toolChoiceJSON)
+				fnName := toolChoice.Get("function.name").String()
+				if fnName != "" {
+					tc := []byte(`{"type":"tool","name":""}`)
+					tc, _ = sjson.SetBytes(tc, "name", fnName)
+					out, _ = sjson.SetRawBytes(out, "tool_choice", tc)
+				}
 			}
-		default:
 		}
 	}
 
 	return out
-}
-
-func convertOpenAIContentPartToClaudePart(part gjson.Result) string {
-	var claudePart []byte
-	switch part.Get("type").String() {
-	case "text":
-		textPart := []byte(`{"type":"text","text":""}`)
-		textPart, _ = sjson.SetBytes(textPart, "text", part.Get("text").String())
-		claudePart = textPart
-
-	case "image_url":
-		claudePart = []byte(convertOpenAIImageURLToClaudePart(part.Get("image_url.url").String()))
-
-	case "file":
-		fileData := part.Get("file.file_data").String()
-		if strings.HasPrefix(fileData, "data:") {
-			semicolonIdx := strings.Index(fileData, ";")
-			commaIdx := strings.Index(fileData, ",")
-			if semicolonIdx != -1 && commaIdx != -1 && commaIdx > semicolonIdx {
-				mediaType := strings.TrimPrefix(fileData[:semicolonIdx], "data:")
-				data := fileData[commaIdx+1:]
-				docPart := []byte(`{"type":"document","source":{"type":"base64","media_type":"","data":""}}`)
-				docPart, _ = sjson.SetBytes(docPart, "source.media_type", mediaType)
-				docPart, _ = sjson.SetBytes(docPart, "source.data", data)
-				claudePart = docPart
-			}
-		}
-	}
-
-	if len(claudePart) == 0 {
-		return ""
-	}
-	return string(common.AttachCacheControl(claudePart, part))
-}
-
-func convertOpenAIImageURLToClaudePart(imageURL string) string {
-	if imageURL == "" {
-		return ""
-	}
-
-	if strings.HasPrefix(imageURL, "data:") {
-		parts := strings.SplitN(imageURL, ",", 2)
-		if len(parts) != 2 {
-			return ""
-		}
-
-		mediaTypePart := strings.SplitN(parts[0], ";", 2)[0]
-		mediaType := strings.TrimPrefix(mediaTypePart, "data:")
-		if mediaType == "" {
-			mediaType = "application/octet-stream"
-		}
-
-		imagePart := []byte(`{"type":"image","source":{"type":"base64","media_type":"","data":""}}`)
-		imagePart, _ = sjson.SetBytes(imagePart, "source.media_type", mediaType)
-		imagePart, _ = sjson.SetBytes(imagePart, "source.data", parts[1])
-		return string(imagePart)
-	}
-
-	imagePart := []byte(`{"type":"image","source":{"type":"url","url":""}}`)
-	imagePart, _ = sjson.SetBytes(imagePart, "source.url", imageURL)
-	return string(imagePart)
-}
-
-func convertOpenAIToolResultContent(content gjson.Result) (string, bool) {
-	if !content.Exists() {
-		return "", false
-	}
-
-	if content.Type == gjson.String {
-		return content.String(), false
-	}
-
-	if content.IsArray() {
-		claudeParts := make([][]byte, 0, 4)
-		content.ForEach(func(_, part gjson.Result) bool {
-			if part.Type == gjson.String {
-				textPart := []byte(`{"type":"text","text":""}`)
-				textPart, _ = sjson.SetBytes(textPart, "text", part.String())
-				claudeParts = append(claudeParts, textPart)
-				return true
-			}
-
-			claudePart := convertOpenAIContentPartToClaudePart(part)
-			if claudePart != "" {
-				claudeParts = append(claudeParts, []byte(claudePart))
-			}
-			return true
-		})
-
-		if len(claudeParts) > 0 || len(content.Array()) == 0 {
-			return string(common.JoinRawArray(claudeParts)), true
-		}
-
-		return content.Raw, false
-	}
-
-	if content.IsObject() {
-		claudePart := convertOpenAIContentPartToClaudePart(content)
-		if claudePart != "" {
-			return string(common.JoinRawArray([][]byte{[]byte(claudePart)})), true
-		}
-		return content.Raw, false
-	}
-
-	return content.Raw, false
 }

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -1,3 +1,5 @@
+// Package responses provides request translation functionality for OpenAI Responses to Claude API compatibility.
+// It converts OpenAI Responses API requests into Claude compatible JSON using gjson/sjson only.
 package responses
 
 import (
@@ -9,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	sigcompat "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
@@ -62,61 +63,60 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 	}
 	userID := fmt.Sprintf("user_%s_account_%s_session_%s", user, account, session)
 
-	// Base Claude message payload
 	out := []byte(fmt.Sprintf(`{"model":"","max_tokens":32000,"messages":[],"metadata":{"user_id":"%s"}}`, userID))
-
 	root := gjson.ParseBytes(rawJSON)
 
-	// Convert OpenAI Responses reasoning.effort to Claude thinking config.
-	if v := root.Get("reasoning.effort"); v.Exists() {
-		effort := strings.ToLower(strings.TrimSpace(v.String()))
-		if effort != "" {
-			mi := registry.LookupModelInfo(modelName, "claude")
-			supportsAdaptive := mi != nil && mi.Thinking != nil && len(mi.Thinking.Levels) > 0
-			supportsMax := supportsAdaptive && thinking.HasLevel(mi.Thinking.Levels, string(thinking.LevelMax))
+	out, _ = sjson.SetBytes(out, "model", modelName)
 
-			// Claude 4.6 supports adaptive thinking with output_config.effort.
-			// MapToClaudeEffort normalizes levels (e.g. minimal→low, xhigh→high) to avoid
-			// validation errors since validate treats same-provider unsupported levels as errors.
-			if supportsAdaptive {
-				switch effort {
-				case "none":
-					out, _ = sjson.SetBytes(out, "thinking.type", "disabled")
-					out, _ = sjson.DeleteBytes(out, "thinking.budget_tokens")
-					out, _ = sjson.DeleteBytes(out, "output_config.effort")
-				case "auto":
-					out, _ = sjson.SetBytes(out, "thinking.type", "adaptive")
-					out, _ = sjson.DeleteBytes(out, "thinking.budget_tokens")
-					out, _ = sjson.DeleteBytes(out, "output_config.effort")
-				default:
-					if mapped, ok := thinking.MapToClaudeEffort(effort, supportsMax); ok {
-						effort = mapped
-					}
-					out, _ = sjson.SetBytes(out, "thinking.type", "adaptive")
-					out, _ = sjson.DeleteBytes(out, "thinking.budget_tokens")
-					out, _ = sjson.SetBytes(out, "output_config.effort", effort)
-				}
-			} else {
-				// Legacy/manual thinking (budget_tokens).
-				budget, ok := thinking.ConvertLevelToBudget(effort)
-				if ok {
-					switch budget {
-					case 0:
-						out, _ = sjson.SetBytes(out, "thinking.type", "disabled")
-					case -1:
-						out, _ = sjson.SetBytes(out, "thinking.type", "enabled")
-					default:
-						if budget > 0 {
-							out, _ = sjson.SetBytes(out, "thinking.type", "enabled")
-							out, _ = sjson.SetBytes(out, "thinking.budget_tokens", budget)
-						}
-					}
-				}
-			}
+	// OpenAI Responses service_tier -> Claude speed
+	// "priority" maps to "fast", other/absent values leave speed unset.
+	if st := root.Get("service_tier"); st.Exists() && strings.EqualFold(strings.TrimSpace(st.String()), "priority") {
+		out, _ = sjson.SetBytes(out, "speed", "fast")
+	}
+
+	// max_output_tokens -> max_tokens
+	if maxTokens := root.Get("max_output_tokens"); maxTokens.Exists() {
+		out, _ = sjson.SetBytes(out, "max_tokens", maxTokens.Int())
+	}
+
+	// top_p
+	if topP := root.Get("top_p"); topP.Exists() {
+		out, _ = sjson.SetBytes(out, "top_p", topP.Float())
+	}
+
+	// temperature
+	if temperature := root.Get("temperature"); temperature.Exists() {
+		out, _ = sjson.SetBytes(out, "temperature", temperature.Float())
+	}
+
+	// stop_sequences
+	if stop := root.Get("stop_sequences"); stop.Exists() && stop.IsArray() {
+		var stopSequences []string
+		stop.ForEach(func(_, value gjson.Result) bool {
+			stopSequences = append(stopSequences, value.String())
+			return true
+		})
+		if len(stopSequences) > 0 {
+			out, _ = sjson.SetBytes(out, "stop_sequences", stopSequences)
 		}
 	}
 
-	// Helper for generating tool call IDs when missing
+	// stream
+	out, _ = sjson.SetBytes(out, "stream", stream)
+
+	// thinking configuration from reasoning_effort
+	if effort := root.Get("reasoning_effort"); effort.Exists() {
+		switch strings.ToLower(strings.TrimSpace(effort.String())) {
+		case "none":
+			out, _ = sjson.SetBytes(out, "thinking.type", "disabled")
+		case "auto":
+			out, _ = sjson.SetBytes(out, "thinking.type", "adaptive")
+		case "low", "medium", "high":
+			out, _ = sjson.SetBytes(out, "thinking.type", "adaptive")
+			out, _ = sjson.SetBytes(out, "output_config.effort", strings.ToLower(strings.TrimSpace(effort.String())))
+		}
+	}
+
 	genToolCallID := func() string {
 		const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 		var b strings.Builder
@@ -127,814 +127,377 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 		return "toolu_" + b.String()
 	}
 
-	// Model
-	out, _ = sjson.SetBytes(out, "model", modelName)
-
-	// Max tokens
-	if mot := root.Get("max_output_tokens"); mot.Exists() {
-		out, _ = sjson.SetBytes(out, "max_tokens", mot.Int())
+	// System blocks accumulator (instructions + input[role==system|developer])
+	systemBlocks := make([][]byte, 0)
+	if instructions := root.Get("instructions"); instructions.Exists() && instructions.String() != "" {
+		textPart := []byte(`{"type":"text","text":""}`)
+		textPart, _ = sjson.SetBytes(textPart, "text", instructions.String())
+		systemBlocks = append(systemBlocks, textPart)
 	}
 
-	// Stream
-	out, _ = sjson.SetBytes(out, "stream", stream)
+	messageAccumulator := common.NewClaudeMessageAccumulator(int(root.Get("input.#").Int()))
 
-	// System-level inputs become canonical top-level Claude system blocks in
-	// source order: instructions first, then every input item whose role is
-	// system or developer. Each source block stays a separate Claude block and
-	// keeps operator authority; the Claude executor decides the final placement
-	// (mid-conversation role=system messages, or system reminders on legacy
-	// models), so this layer must not merge, trim or downgrade them to user text.
-	messageCapacity := root.Get("input.#").Int()
-	messageBlocks := common.NewRawArrayItems(messageCapacity)
-	systemBlocks := make([][]byte, 0, 4)
-	appendSystemText := func(text string, cacheSource gjson.Result) {
-		if text == "" {
-			return
-		}
-		block := []byte(`{"type":"text","text":""}`)
-		block, _ = sjson.SetBytes(block, "text", text)
-		if cacheSource.Exists() {
-			block = common.AttachCacheControl(block, cacheSource)
-		}
-		systemBlocks = append(systemBlocks, block)
-	}
-	if instr := root.Get("instructions"); instr.Type == gjson.String {
-		appendSystemText(instr.String(), gjson.Result{})
-	}
-	if input := root.Get("input"); input.IsArray() {
-		input.ForEach(func(_, item gjson.Result) bool {
-			if !isResponsesSystemLevelRole(item.Get("role").String()) {
-				return true
-			}
-			startIdx := len(systemBlocks)
-			content := item.Get("content")
-			if content.Type == gjson.String {
-				appendSystemText(content.String(), gjson.Result{})
-			} else if content.IsArray() {
-				content.ForEach(func(_, part gjson.Result) bool {
-					switch part.Get("type").String() {
-					case "input_text", "output_text", "text":
-						appendSystemText(part.Get("text").String(), part)
-					default:
-						if block := responsesSystemUnsupportedBlock(part); len(block) > 0 {
-							systemBlocks = append(systemBlocks, block)
-						}
-					}
-					return true
-				})
-			}
-			// Item-level cache_control applies to the last block this item produced.
-			if item.Get("cache_control").Exists() && len(systemBlocks) > startIdx {
-				lastIdx := len(systemBlocks) - 1
-				if !gjson.GetBytes(systemBlocks[lastIdx], "cache_control").Exists() {
-					systemBlocks[lastIdx] = common.AttachCacheControl(systemBlocks[lastIdx], item)
-				}
-			}
-			return true
-		})
-	}
-
-	// input array processing
-	var pendingRole string
-	var pendingParts [][]byte
-	var pendingToolUseParts [][]byte
-	appendMessage := func(msg []byte) {
-		messageBlocks = append(messageBlocks, msg)
-	}
-	flushPendingMessage := func() {
-		if pendingRole == "" {
-			return
-		}
-
-		parts := pendingParts
-		if pendingRole == "assistant" && len(pendingToolUseParts) > 0 {
-			combined := make([][]byte, 0, len(pendingParts)+len(pendingToolUseParts))
-			combined = append(combined, pendingParts...)
-			combined = append(combined, pendingToolUseParts...)
-			parts = combined
-		}
-		if len(parts) > 0 {
-			msg := []byte(`{"role":"","content":[]}`)
-			msg, _ = sjson.SetBytes(msg, "role", pendingRole)
-			if len(parts) == 1 {
-				part := gjson.ParseBytes(parts[0])
-				if part.Get("type").String() == "text" && !part.Get("cache_control").Exists() {
-					msg, _ = sjson.SetBytes(msg, "content", part.Get("text").String())
-				} else {
-					msg, _ = sjson.SetRawBytes(msg, "content", common.JoinRawArray(parts))
-				}
-			} else {
-				msg, _ = sjson.SetRawBytes(msg, "content", common.JoinRawArray(parts))
-			}
-			appendMessage(msg)
-		}
-
-		pendingRole = ""
-		pendingParts = nil
-		pendingToolUseParts = nil
-	}
-	appendParts := func(role string, parts ...[]byte) {
-		if role == "" || len(parts) == 0 {
-			return
-		}
-		if pendingRole != "" && pendingRole != role {
-			flushPendingMessage()
-		}
-		pendingRole = role
-		pendingParts = append(pendingParts, parts...)
-	}
-	appendToolUse := func(toolUse []byte) {
-		if len(toolUse) == 0 {
-			return
-		}
-		if pendingRole != "" && pendingRole != "assistant" {
-			flushPendingMessage()
-		}
-		pendingRole = "assistant"
-		pendingToolUseParts = append(pendingToolUseParts, toolUse)
-	}
-
+	// Process input array
 	if input := root.Get("input"); input.Exists() && input.IsArray() {
 		input.ForEach(func(_, item gjson.Result) bool {
-			// System-level items already became top-level system blocks.
-			if isResponsesSystemLevelRole(item.Get("role").String()) {
-				return true
-			}
-			typ := item.Get("type").String()
-			if typ == "" && item.Get("role").String() != "" {
-				typ = "message"
-			}
-			switch typ {
-			case "message":
-				// Determine role and construct Claude-compatible content parts.
-				var role string
-				var partsJSON [][]byte
-				if parts := item.Get("content"); parts.Exists() && parts.IsArray() {
-					parts.ForEach(func(_, part gjson.Result) bool {
-						ptype := part.Get("type").String()
-						switch ptype {
-						case "input_text", "output_text":
-							if t := part.Get("text"); t.Exists() {
-								txt := t.String()
-								contentPart := []byte(`{"type":"text","text":""}`)
-								contentPart, _ = sjson.SetBytes(contentPart, "text", txt)
-								contentPart = common.AttachCacheControl(contentPart, part)
-								partsJSON = append(partsJSON, contentPart)
-							}
-							if ptype == "input_text" {
-								role = "user"
-							} else {
-								role = "assistant"
-							}
-						case "input_image":
-							url := part.Get("image_url").String()
-							if url == "" {
-								url = part.Get("url").String()
-							}
-							if url != "" {
-								var contentPart []byte
-								if strings.HasPrefix(url, "data:") {
-									trimmed := strings.TrimPrefix(url, "data:")
-									mediaAndData := strings.SplitN(trimmed, ";base64,", 2)
-									mediaType := "application/octet-stream"
-									data := ""
-									if len(mediaAndData) == 2 {
-										if mediaAndData[0] != "" {
-											mediaType = mediaAndData[0]
-										}
-										data = mediaAndData[1]
-									}
-									if data != "" {
-										contentPart = []byte(`{"type":"image","source":{"type":"base64","media_type":"","data":""}}`)
-										contentPart, _ = sjson.SetBytes(contentPart, "source.media_type", mediaType)
-										contentPart, _ = sjson.SetBytes(contentPart, "source.data", data)
-									}
-								} else {
-									contentPart = []byte(`{"type":"image","source":{"type":"url","url":""}}`)
-									contentPart, _ = sjson.SetBytes(contentPart, "source.url", url)
-								}
-								if len(contentPart) > 0 {
-									contentPart = common.AttachCacheControl(contentPart, part)
-									partsJSON = append(partsJSON, contentPart)
-									if role == "" {
-										role = "user"
-									}
-								}
-							}
-						case "input_file":
-							fileData := part.Get("file_data").String()
-							if fileData != "" {
-								mediaType := "application/octet-stream"
-								data := fileData
-								if strings.HasPrefix(fileData, "data:") {
-									trimmed := strings.TrimPrefix(fileData, "data:")
-									mediaAndData := strings.SplitN(trimmed, ";base64,", 2)
-									if len(mediaAndData) == 2 {
-										if mediaAndData[0] != "" {
-											mediaType = mediaAndData[0]
-										}
-										data = mediaAndData[1]
-									}
-								}
-								contentPart := []byte(`{"type":"document","source":{"type":"base64","media_type":"","data":""}}`)
-								contentPart, _ = sjson.SetBytes(contentPart, "source.media_type", mediaType)
-								contentPart, _ = sjson.SetBytes(contentPart, "source.data", data)
-								contentPart = common.AttachCacheControl(contentPart, part)
-								partsJSON = append(partsJSON, contentPart)
-								if role == "" {
-									role = "user"
-								}
-							}
+			itemType := item.Get("type").String()
+			role := item.Get("role").String()
+
+			// Check for system/developer messages in input array
+			if role == "system" || role == "developer" {
+				systemStart := len(systemBlocks)
+				content := item.Get("content")
+				if content.Exists() && content.Type == gjson.String && content.String() != "" {
+					textPart := []byte(`{"type":"text","text":""}`)
+					textPart, _ = sjson.SetBytes(textPart, "text", content.String())
+					textPart = common.AttachCacheControl(textPart, item)
+					systemBlocks = append(systemBlocks, textPart)
+				} else if content.Exists() && content.IsArray() {
+					content.ForEach(func(_, part gjson.Result) bool {
+						if part.Get("type").String() == "text" || part.Get("type").String() == "input_text" {
+							textPart := []byte(`{"type":"text","text":""}`)
+							textPart, _ = sjson.SetBytes(textPart, "text", part.Get("text").String())
+							textPart = common.AttachCacheControl(textPart, part)
+							systemBlocks = append(systemBlocks, textPart)
 						}
 						return true
 					})
-				} else if parts.Type == gjson.String && parts.String() != "" {
-					contentPart := []byte(`{"type":"text","text":""}`)
-					contentPart, _ = sjson.SetBytes(contentPart, "text", parts.String())
-					partsJSON = append(partsJSON, contentPart)
 				}
+				if len(systemBlocks) > systemStart && !gjson.GetBytes(systemBlocks[len(systemBlocks)-1], "cache_control").Exists() {
+					systemBlocks[len(systemBlocks)-1] = common.AttachCacheControl(systemBlocks[len(systemBlocks)-1], item)
+				}
+				return true
+			}
 
-				// Fallback to given role if content types not decisive
-				if role == "" {
-					r := item.Get("role").String()
-					switch r {
-					case "user", "assistant":
-						role = r
-					default:
-						role = "user"
+			switch itemType {
+			case "message":
+				switch role {
+				case "user":
+					userBlocks := make([][]byte, 0)
+					userStart := len(userBlocks)
+					content := item.Get("content")
+
+					if content.Exists() && content.Type == gjson.String && content.String() != "" {
+						textPart := []byte(`{"type":"text","text":""}`)
+						textPart, _ = sjson.SetBytes(textPart, "text", content.String())
+						textPart = common.AttachCacheControl(textPart, item)
+						userBlocks = append(userBlocks, textPart)
+					} else if content.Exists() && content.IsArray() {
+						content.ForEach(func(_, part gjson.Result) bool {
+							partType := part.Get("type").String()
+							switch partType {
+							case "text", "input_text":
+								textPart := []byte(`{"type":"text","text":""}`)
+								textPart, _ = sjson.SetBytes(textPart, "text", part.Get("text").String())
+								textPart = common.AttachCacheControl(textPart, part)
+								userBlocks = append(userBlocks, textPart)
+							case "input_image", "image":
+								url := part.Get("image_url").String()
+								if url == "" {
+									url = part.Get("url").String()
+								}
+								if url != "" {
+									if mediaType, data, ok := common.ParseDataURL(url); ok {
+										imagePart := []byte(`{"type":"image","source":{"type":"base64","media_type":"","data":""}}`)
+										imagePart, _ = sjson.SetBytes(imagePart, "source.media_type", mediaType)
+										imagePart, _ = sjson.SetBytes(imagePart, "source.data", data)
+										imagePart = common.AttachCacheControl(imagePart, part)
+										userBlocks = append(userBlocks, imagePart)
+									}
+								}
+							}
+							return true
+						})
 					}
-				}
 
-				if len(partsJSON) > 0 {
-					lastIdx := len(partsJSON) - 1
-					if !gjson.GetBytes(partsJSON[lastIdx], "cache_control").Exists() {
-						partsJSON[lastIdx] = common.AttachCacheControl(partsJSON[lastIdx], item)
+					if len(userBlocks) > userStart && !gjson.GetBytes(userBlocks[len(userBlocks)-1], "cache_control").Exists() {
+						userBlocks[len(userBlocks)-1] = common.AttachCacheControl(userBlocks[len(userBlocks)-1], item)
 					}
-					appendParts(role, partsJSON...)
-				}
 
-			case "reasoning":
-				if thinkingPart := convertResponsesReasoningToClaudeThinking(item, preserveEmptyThinkingBlocks); len(thinkingPart) > 0 {
-					appendParts("assistant", thinkingPart)
+					if len(userBlocks) > 0 {
+						messageAccumulator.AppendUserBlocks(userBlocks)
+					}
+
+				case "assistant":
+					assistantBlocks := make([][]byte, 0)
+					assistantStart := len(assistantBlocks)
+					content := item.Get("content")
+
+					if content.Exists() && content.Type == gjson.String && content.String() != "" {
+						textPart := []byte(`{"type":"text","text":""}`)
+						textPart, _ = sjson.SetBytes(textPart, "text", content.String())
+						textPart = common.AttachCacheControl(textPart, item)
+						assistantBlocks = append(assistantBlocks, textPart)
+					} else if content.Exists() && content.IsArray() {
+						content.ForEach(func(_, part gjson.Result) bool {
+							partType := part.Get("type").String()
+							switch partType {
+							case "text", "output_text":
+								textPart := []byte(`{"type":"text","text":""}`)
+								textPart, _ = sjson.SetBytes(textPart, "text", part.Get("text").String())
+								textPart = common.AttachCacheControl(textPart, part)
+								assistantBlocks = append(assistantBlocks, textPart)
+							}
+							return true
+						})
+					}
+
+					if len(assistantBlocks) > assistantStart && !gjson.GetBytes(assistantBlocks[len(assistantBlocks)-1], "cache_control").Exists() {
+						assistantBlocks[len(assistantBlocks)-1] = common.AttachCacheControl(assistantBlocks[len(assistantBlocks)-1], item)
+					}
+
+					if len(assistantBlocks) > 0 {
+						messageAccumulator.AppendAssistantBlocks(assistantBlocks)
+					}
 				}
 
 			case "function_call", "custom_tool_call":
-				// Map to assistant tool_use. Freeform custom input is wrapped in an
-				// object because Claude tool_use input must be a JSON object.
 				callID := item.Get("call_id").String()
+				if callID == "" {
+					callID = item.Get("id").String()
+				}
 				if callID == "" {
 					callID = genToolCallID()
 				}
-				callID = util.SanitizeClaudeToolID(callID)
-				name := item.Get("name").String()
-				if namespaceName := strings.TrimSpace(item.Get("namespace").String()); namespaceName != "" {
-					// Rebuild the qualified name emitted by the previous Responses turn.
-					name = qualifyResponsesNamespaceToolName(namespaceName, name)
-				}
-				isCustomToolCall := typ == "custom_tool_call"
+				callID = common.SanitizeToolCallIDForClaude(callID)
 
-				toolUse := []byte(`{"type":"tool_use","id":"","name":"","input":{}}`)
-				toolUse, _ = sjson.SetBytes(toolUse, "id", callID)
-				toolUse, _ = sjson.SetBytes(toolUse, "name", name)
-				if isCustomToolCall {
-					toolUse, _ = sjson.SetBytes(toolUse, "input.input", item.Get("input").String())
-				} else {
-					argsStr := item.Get("arguments").String()
-					if argsStr != "" && gjson.Valid(argsStr) {
-						argsJSON := gjson.Parse(argsStr)
-						if argsJSON.IsObject() {
-							toolUse, _ = sjson.SetRawBytes(toolUse, "input", []byte(argsJSON.Raw))
-						}
+				name := item.Get("name").String()
+				if name == "" {
+					name = item.Get("function.name").String()
+				}
+
+				toolUsePart := []byte(`{"type":"tool_use","id":"","name":"","input":{}}`)
+				toolUsePart, _ = sjson.SetBytes(toolUsePart, "id", callID)
+				toolUsePart, _ = sjson.SetBytes(toolUsePart, "name", name)
+
+				arguments := item.Get("arguments").String()
+				if arguments == "" {
+					arguments = item.Get("function.arguments").String()
+				}
+				if arguments != "" {
+					var inputObj map[string]any
+					if err := util.UnmarshalJSONCaseFold([]byte(arguments), &inputObj); err == nil {
+						toolUsePart, _ = sjson.SetBytes(toolUsePart, "input", inputObj)
 					}
 				}
 
-				appendToolUse(toolUse)
+				toolUsePart = common.AttachCacheControl(toolUsePart, item)
+				messageAccumulator.AppendAssistantBlocks([][]byte{toolUsePart})
 
 			case "function_call_output", "custom_tool_call_output":
-				// Map to user tool_result
 				callID := item.Get("call_id").String()
-				callID = util.SanitizeClaudeToolID(callID)
-				output := item.Get("output")
-				toolResult := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
-				toolResult, _ = sjson.SetBytes(toolResult, "tool_use_id", callID)
-				toolResult = applyResponsesToolResultContent(toolResult, output)
+				if callID != "" {
+					callID = common.SanitizeToolCallIDForClaude(callID)
+					toolResultPart := []byte(`{"type":"tool_result","tool_use_id":""}`)
+					toolResultPart, _ = sjson.SetBytes(toolResultPart, "tool_use_id", callID)
 
-				appendParts("user", toolResult)
+					output := item.Get("output")
+					if output.Exists() {
+						toolResultPart = common.AppendClaudeToolResultContent(toolResultPart, output)
+					}
+					toolResultPart = common.AttachCacheControl(toolResultPart, item)
+					messageAccumulator.AppendToolResult(toolResultPart)
+				}
+
+			case "reasoning":
+				// Convert reasoning item to Claude thinking block if valid signature exists
+				rawSignatureResult := item.Get("encrypted_content")
+				rawSignature := rawSignatureResult.String()
+				signature, ok := sigcompat.CompatibleAntigravityClaudeThinkingSignature(rawSignature)
+				if !ok && rawSignatureResult.Exists() && !preserveEmptyThinkingBlocks {
+					// Incompatible signature -> drop the thinking block entirely
+					return true
+				}
+
+				// Extract reasoning text
+				thoughtText := ""
+				if summary := item.Get("summary"); summary.Exists() && summary.IsArray() {
+					var summaryTexts []string
+					summary.ForEach(func(_, s gjson.Result) bool {
+						if t := s.Get("text").String(); t != "" {
+							summaryTexts = append(summaryTexts, t)
+						}
+						return true
+					})
+					thoughtText = strings.Join(summaryTexts, "\n")
+				}
+				if thoughtText == "" {
+					thoughtText = item.Get("reasoning_content.text").String()
+				}
+
+				if thoughtText != "" || signature != "" {
+					thinkingPart := []byte(`{"type":"thinking","thinking":"","signature":""}`)
+					thinkingPart, _ = sjson.SetBytes(thinkingPart, "thinking", thoughtText)
+					if signature != "" {
+						thinkingPart, _ = sjson.SetBytes(thinkingPart, "signature", signature)
+					} else {
+						thinkingPart, _ = sjson.DeleteBytes(thinkingPart, "signature")
+					}
+					thinkingPart = common.AttachCacheControl(thinkingPart, item)
+					messageAccumulator.AppendAssistantBlocks([][]byte{thinkingPart})
+				}
 			}
 			return true
 		})
-	}
-	flushPendingMessage()
-	// Preserve a minimal conversational turn for system-only inputs so downstream
-	// validation still sees a Claude-shaped request.
-	if len(messageBlocks) == 0 && len(systemBlocks) > 0 {
-		messageBlocks = append(messageBlocks, []byte(`{"role":"user","content":[{"type":"text","text":""}]}`))
-	}
-	out = common.SetRawArrayItems(out, "messages", messageBlocks)
-	if len(systemBlocks) > 0 {
-		out, _ = sjson.SetRawBytes(out, "system", common.JoinRawArray(systemBlocks))
+
+		messageBlocks := messageAccumulator.Messages()
+		if len(messageBlocks) == 0 && len(systemBlocks) > 0 {
+			messageBlocks = append(messageBlocks, []byte(`{"role":"user","content":[{"type":"text","text":""}]}`))
+		}
+
+		if len(systemBlocks) > 0 {
+			out, _ = sjson.SetRawBytes(out, "system", common.JoinRawArray(systemBlocks))
+		}
+		if len(messageBlocks) > 0 {
+			out = common.SetRawArrayItems(out, "messages", messageBlocks)
+		}
 	}
 
-	includedToolNames := map[string]struct{}{}
-	toolNameMap := map[string]string{}
-
-	// Responses Lite puts tool definitions in input[].additional_tools. Select
-	// one winner for each final name, while keeping the original order for the
-	// tools that survive conversion.
-	var toolItems [][]byte
-	winners := responsesToolWinners(root)
-	for _, descriptor := range responsesToolDescriptors(root) {
-		winner, ok := winners[descriptor.name]
-		if !ok || winner.order != descriptor.order {
-			continue
-		}
-		tJSON, ok := convertResponsesToolDescriptorToClaude(descriptor)
-		if !ok {
-			continue
-		}
-		toolName := gjson.GetBytes(tJSON, "name").String()
-		if toolName != "" {
-			includedToolNames[toolName] = struct{}{}
-		}
-		toolItems = append(toolItems, tJSON)
-	}
-	toolNameMap = responsesToolNameMap(root, includedToolNames)
-	if len(toolItems) > 0 {
-		out, _ = sjson.SetRawBytes(out, "tools", common.JoinRawArray(toolItems))
+	// Tools mapping: top-level tools + input[].additional_tools -> Claude tools
+	anthropicTools := collectOpenAIResponsesToolsForClaude(root)
+	if len(anthropicTools) > 0 {
+		out, _ = sjson.SetRawBytes(out, "tools", common.JoinRawArray(anthropicTools))
+	} else {
+		out, _ = sjson.DeleteBytes(out, "tools")
 	}
 
-	// Map tool_choice similar to Chat Completions translator (optional in docs, safe to handle)
+	// tool_choice
 	if toolChoice := root.Get("tool_choice"); toolChoice.Exists() {
 		switch toolChoice.Type {
 		case gjson.String:
-			switch toolChoice.String() {
+			switch strings.ToLower(toolChoice.String()) {
+			case "none":
+				// omit tool_choice
 			case "auto":
 				out, _ = sjson.SetRawBytes(out, "tool_choice", []byte(`{"type":"auto"}`))
-			case "none":
-				// Leave unset; implies no tools
 			case "required":
-				if len(includedToolNames) > 0 {
-					out, _ = sjson.SetRawBytes(out, "tool_choice", []byte(`{"type":"any"}`))
-				}
+				out, _ = sjson.SetRawBytes(out, "tool_choice", []byte(`{"type":"any"}`))
 			}
 		case gjson.JSON:
-			choiceType := toolChoice.Get("type").String()
-			if choiceType == "function" || choiceType == "custom" {
-				fn := toolChoice.Get("function.name").String()
-				if fn == "" {
-					fn = toolChoice.Get("custom.name").String()
+			if toolChoice.Get("type").String() == "function" {
+				fnName := toolChoice.Get("function.name").String()
+				if fnName == "" {
+					fnName = toolChoice.Get("name").String()
 				}
-				if fn == "" {
-					fn = toolChoice.Get("name").String()
-				}
-				namespaceName := toolChoice.Get("namespace").String()
-				if namespaceName == "" {
-					namespaceName = toolChoice.Get("function.namespace").String()
-				}
-				if namespaceName == "" {
-					namespaceName = toolChoice.Get("custom.namespace").String()
-				}
-				if namespaceName != "" {
-					fn = qualifyResponsesNamespaceToolName(namespaceName, fn)
-				}
-				if mappedName := toolNameMap[fn]; mappedName != "" {
-					fn = mappedName
-				}
-				if _, ok := includedToolNames[fn]; ok {
-					toolChoiceJSON := []byte(`{"name":"","type":"tool"}`)
-					toolChoiceJSON, _ = sjson.SetBytes(toolChoiceJSON, "name", fn)
-					out, _ = sjson.SetRawBytes(out, "tool_choice", toolChoiceJSON)
+				if fnName != "" {
+					tc := []byte(`{"type":"tool","name":""}`)
+					tc, _ = sjson.SetBytes(tc, "name", fnName)
+					out, _ = sjson.SetRawBytes(out, "tool_choice", tc)
 				}
 			}
-		default:
-
 		}
 	}
 
 	return out
 }
 
-// isResponsesSystemLevelRole reports whether an input item carries system-level
-// authority. The Responses API ranks developer and system instructions above
-// user content, so both map to Claude's system slot rather than a user turn.
-func isResponsesSystemLevelRole(role string) bool {
-	switch strings.ToLower(strings.TrimSpace(role)) {
-	case "system", "developer":
-		return true
-	default:
-		return false
-	}
-}
+func collectOpenAIResponsesToolsForClaude(root gjson.Result) [][]byte {
+	var anthropicTools [][]byte
+	seenNames := make(map[string]struct{})
 
-// responsesSystemUnsupportedBlock represents a system-level content part that
-// Claude cannot carry. Anthropic accepts text only in the top-level system field
-// ("system.<i>.type: Input should be 'text'") and text, tool_addition and
-// tool_removal in a role=system message, so images, files and unknown part types
-// have no lossless mapping. The part is preserved as a typed marker instead of
-// being dropped: silently discarding operator instructions is worse than a
-// rejected request, and the marker lets the Claude executor fail the request with
-// the offending type named. The original payload is not copied because the
-// request can never succeed.
-func responsesSystemUnsupportedBlock(part gjson.Result) []byte {
-	partType := strings.TrimSpace(part.Get("type").String())
-	if partType == "" {
-		return nil
-	}
-	block := []byte(`{"type":""}`)
-	block, _ = sjson.SetBytes(block, "type", partType)
-	return block
-}
-
-// convertResponsesReasoningToClaudeThinking rebuilds one Claude thinking block
-// from a Responses reasoning item so a replayed conversation keeps its chain of
-// thought. Anthropic requires a signature on every thinking block and rejects an
-// absent or empty one, so an item whose encrypted_content is missing or belongs
-// to another provider is dropped rather than replayed as an unsigned block.
-// Compatibility mode explicitly keeps the original opaque value as the
-// signature for upstreams that use a provider-specific signature format.
-// Anthropic does not verify the text against the signature, which is what makes
-// the summarized text safe to restore alongside it.
-func convertResponsesReasoningToClaudeThinking(item gjson.Result, preserveEmptyThinkingBlocks ...bool) []byte {
-	encrypted := item.Get("encrypted_content").String()
-	preserveEmpty := len(preserveEmptyThinkingBlocks) > 0 && preserveEmptyThinkingBlocks[0]
-	if data, isRedacted := responsesRedactedThinkingData(encrypted); isRedacted {
-		if data == "" {
-			return nil
+	appendTool := func(toolBytes []byte, name string) {
+		if len(toolBytes) == 0 || name == "" {
+			return
 		}
-		redactedPart := []byte(`{"type":"redacted_thinking","data":""}`)
-		redactedPart, _ = sjson.SetBytes(redactedPart, "data", data)
-		return redactedPart
-	}
-
-	signature, ok := sigcompat.CompatibleSignatureForProvider(sigcompat.SignatureProviderClaude, encrypted)
-	if !ok {
-		if !preserveEmpty {
-			return nil
+		if _, exists := seenNames[name]; exists {
+			return
 		}
-		signature = encrypted
+		seenNames[name] = struct{}{}
+		anthropicTools = append(anthropicTools, toolBytes)
 	}
 
-	thinkingText := responsesReasoningText(item)
-	thinkingPart := []byte(`{"type":"thinking","thinking":"","signature":""}`)
-	thinkingPart, _ = sjson.SetBytes(thinkingPart, "thinking", thinkingText)
-	thinkingPart, _ = sjson.SetBytes(thinkingPart, "signature", signature)
-	return thinkingPart
-}
-
-// responsesRedactedThinkingData reports whether encrypted_content carries an
-// Anthropic redacted_thinking payload and returns that payload.
-func responsesRedactedThinkingData(encryptedContent string) (string, bool) {
-	trimmed := strings.TrimSpace(encryptedContent)
-	if !strings.HasPrefix(trimmed, ClaudeResponsesRedactedThinkingPrefix) {
-		return "", false
-	}
-	return strings.TrimSpace(strings.TrimPrefix(trimmed, ClaudeResponsesRedactedThinkingPrefix)), true
-}
-
-// responsesReasoningText collects the reasoning text of a Responses item. OpenAI
-// splits it across summary[] parts of type summary_text and content[] parts of
-// type reasoning_text. Claude only ever produces summaries, but callers echo the
-// item back through whichever array their SDK models, so both are read. content[]
-// is only consulted when summary[] carried nothing, otherwise a client that
-// mirrors the text into both arrays would replay it twice.
-func responsesReasoningText(item gjson.Result) string {
-	if text := responsesReasoningPartsText(item.Get("summary")); text != "" {
-		return text
-	}
-	return responsesReasoningPartsText(item.Get("content"))
-}
-
-func responsesReasoningPartsText(parts gjson.Result) string {
-	if !parts.Exists() || !parts.IsArray() {
-		return ""
-	}
-	var builder strings.Builder
-	parts.ForEach(func(_, part gjson.Result) bool {
-		if text := part.Get("text"); text.Exists() {
-			builder.WriteString(text.String())
-		} else if part.Type == gjson.String {
-			builder.WriteString(part.String())
-		}
-		return true
-	})
-	return builder.String()
-}
-
-func applyResponsesToolResultContent(toolResult []byte, output gjson.Result) []byte {
-	if output.Exists() && output.IsArray() {
-		var partsJSON [][]byte
-		hasImage := false
-		hasFile := false
-		output.ForEach(func(_, part gjson.Result) bool {
-			if partJSON := convertResponsesContentPartToClaude(part); len(partJSON) > 0 {
-				partsJSON = append(partsJSON, partJSON)
-				partType := gjson.ParseBytes(partJSON).Get("type").String()
-				if partType == "image" {
-					hasImage = true
-				}
-				if partType == "document" {
-					hasFile = true
-				}
-			}
+	// 1. Top-level tools
+	if tools := root.Get("tools"); tools.Exists() && tools.IsArray() {
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			processResponsesToolEntryForClaude(tool, "", appendTool)
 			return true
 		})
-		if len(partsJSON) == 0 {
-			toolResult, _ = sjson.SetBytes(toolResult, "content", output.Raw)
-			return toolResult
-		}
-		if len(partsJSON) == 1 && !hasImage && !hasFile {
-			textPart := gjson.ParseBytes(partsJSON[0])
-			if textPart.Get("type").String() == "text" {
-				toolResult, _ = sjson.SetBytes(toolResult, "content", textPart.Get("text").String())
-				return toolResult
-			}
-		}
-		toolResult, _ = sjson.DeleteBytes(toolResult, "content")
-		toolResult, _ = sjson.SetRawBytes(toolResult, "content", common.JoinRawArray(partsJSON))
-		return toolResult
-	}
-	toolResult, _ = sjson.SetBytes(toolResult, "content", output.String())
-	return toolResult
-}
-
-func convertResponsesContentPartToClaude(part gjson.Result) []byte {
-	ptype := part.Get("type").String()
-	switch ptype {
-	case "input_text", "output_text":
-		if t := part.Get("text"); t.Exists() {
-			contentPart := []byte(`{"type":"text","text":""}`)
-			contentPart, _ = sjson.SetBytes(contentPart, "text", t.String())
-			return contentPart
-		}
-	case "input_image":
-		url := part.Get("image_url").String()
-		if url == "" {
-			url = part.Get("url").String()
-		}
-		if url == "" {
-			return nil
-		}
-		if strings.HasPrefix(url, "data:") {
-			trimmed := strings.TrimPrefix(url, "data:")
-			mediaAndData := strings.SplitN(trimmed, ";base64,", 2)
-			mediaType := "application/octet-stream"
-			data := ""
-			if len(mediaAndData) == 2 {
-				if mediaAndData[0] != "" {
-					mediaType = mediaAndData[0]
-				}
-				data = mediaAndData[1]
-			}
-			if data == "" {
-				return nil
-			}
-			contentPart := []byte(`{"type":"image","source":{"type":"base64","media_type":"","data":""}}`)
-			contentPart, _ = sjson.SetBytes(contentPart, "source.media_type", mediaType)
-			contentPart, _ = sjson.SetBytes(contentPart, "source.data", data)
-			return contentPart
-		}
-		contentPart := []byte(`{"type":"image","source":{"type":"url","url":""}}`)
-		contentPart, _ = sjson.SetBytes(contentPart, "source.url", url)
-		return contentPart
-	case "input_file":
-		fileData := part.Get("file_data").String()
-		if fileData == "" {
-			return nil
-		}
-		mediaType := "application/octet-stream"
-		data := fileData
-		if strings.HasPrefix(fileData, "data:") {
-			trimmed := strings.TrimPrefix(fileData, "data:")
-			mediaAndData := strings.SplitN(trimmed, ";base64,", 2)
-			if len(mediaAndData) == 2 {
-				if mediaAndData[0] != "" {
-					mediaType = mediaAndData[0]
-				}
-				data = mediaAndData[1]
-			}
-		}
-		contentPart := []byte(`{"type":"document","source":{"type":"base64","media_type":"","data":""}}`)
-		contentPart, _ = sjson.SetBytes(contentPart, "source.media_type", mediaType)
-		contentPart, _ = sjson.SetBytes(contentPart, "source.data", data)
-		return contentPart
-	}
-	return nil
-}
-
-func isOpenAIResponsesApplyPatchCustomTool(toolType string, tool gjson.Result) bool {
-	return toolType == "custom" && strings.TrimSpace(tool.Get("name").String()) == "apply_patch"
-}
-
-func convertResponsesToolDescriptorToClaude(descriptor responsesToolDescriptor) ([]byte, bool) {
-	overrideName := ""
-	if !descriptor.direct {
-		overrideName = descriptor.name
-	}
-	switch descriptor.toolType {
-	case "function":
-		return convertResponsesFunctionToolToClaude(descriptor.tool, overrideName)
-	case "custom":
-		return convertResponsesCustomToolToClaude(descriptor.tool, overrideName)
-	case "web_search":
-		return convertResponsesWebSearchToolToClaude(descriptor.tool)
-	default:
-		if isUnsupportedOpenAIBuiltinToolType(descriptor.toolType) {
-			return nil, false
-		}
-		if descriptor.tool.Get("name").String() == "" {
-			return nil, false
-		}
-		return []byte(descriptor.tool.Raw), true
-	}
-}
-
-type responsesToolSource struct {
-	tools    gjson.Result
-	priority int // Top-level tools use 0; all additional_tools sources use 1.
-}
-
-func responsesToolSources(root gjson.Result) []responsesToolSource {
-	var sources []responsesToolSource
-	appendSource := func(tools gjson.Result, priority int) {
-		if tools.Exists() && tools.IsArray() {
-			sources = append(sources, responsesToolSource{tools: tools, priority: priority})
-		}
 	}
 
-	appendSource(root.Get("tools"), 0)
+	// 2. input[].additional_tools
 	if input := root.Get("input"); input.Exists() && input.IsArray() {
 		input.ForEach(func(_, item gjson.Result) bool {
 			if item.Get("type").String() == "additional_tools" {
-				appendSource(item.Get("tools"), 1)
+				if tools := item.Get("tools"); tools.Exists() && tools.IsArray() {
+					tools.ForEach(func(_, tool gjson.Result) bool {
+						processResponsesToolEntryForClaude(tool, "", appendTool)
+						return true
+					})
+				}
 			}
 			return true
 		})
 	}
-	return sources
+
+	return anthropicTools
 }
 
-type responsesToolDescriptor struct {
-	name           string
-	childName      string
-	namespace      string
-	toolType       string
-	tool           gjson.Result
-	sourcePriority int
-	direct         bool
-	order          int
-}
+func processResponsesToolEntryForClaude(tool gjson.Result, namespacePrefix string, emit func([]byte, string)) {
+	toolType := tool.Get("type").String()
 
-func responsesToolDescriptors(root gjson.Result) []responsesToolDescriptor {
-	var descriptors []responsesToolDescriptor
-	appendDescriptor := func(tool gjson.Result, name, childName, namespaceName, toolType string, sourcePriority int, direct bool) {
-		if name == "" {
+	switch toolType {
+	case "namespace":
+		nsName := strings.TrimSpace(tool.Get("name").String())
+		if nsName == "" {
 			return
 		}
-		descriptors = append(descriptors, responsesToolDescriptor{
-			name:           name,
-			childName:      childName,
-			namespace:      namespaceName,
-			toolType:       toolType,
-			tool:           tool,
-			sourcePriority: sourcePriority,
-			direct:         direct,
-			order:          len(descriptors),
-		})
-	}
-	appendNamespaceChildren := func(namespaceTool gjson.Result, sourcePriority int) {
-		namespaceName := strings.TrimSpace(namespaceTool.Get("name").String())
-		children := namespaceTool.Get("tools")
-		if !children.Exists() || !children.IsArray() {
-			return
+		nestedPrefix := nsName
+		if namespacePrefix != "" {
+			nestedPrefix = namespacePrefix + "__" + nsName
 		}
-		children.ForEach(func(_, child gjson.Result) bool {
-			childName := responsesToolName(child)
-			if childName == "" {
+		if subTools := tool.Get("tools"); subTools.Exists() && subTools.IsArray() {
+			subTools.ForEach(func(_, subTool gjson.Result) bool {
+				processResponsesToolEntryForClaude(subTool, nestedPrefix, emit)
 				return true
+			})
+		}
+
+	case "function":
+		name := strings.TrimSpace(tool.Get("name").String())
+		if name == "" {
+			name = strings.TrimSpace(tool.Get("function.name").String())
+		}
+		if namespacePrefix != "" && name != "" {
+			name = namespacePrefix + "__" + name
+		}
+		if toolBytes, ok := convertResponsesFunctionToolToClaude(tool, name); ok {
+			emit(toolBytes, name)
+		}
+
+	case "custom":
+		name := strings.TrimSpace(tool.Get("name").String())
+		if name == "apply_patch" {
+			// drop apply_patch custom tool as per specifications
+			return
+		}
+		if namespacePrefix != "" && name != "" {
+			name = namespacePrefix + "__" + name
+		}
+		if toolBytes, ok := convertResponsesCustomToolToClaude(tool, name); ok {
+			emit(toolBytes, name)
+		}
+
+	case "web_search", "web_search_20250305":
+		if toolBytes, ok := convertResponsesWebSearchToolToClaude(tool); ok {
+			name := gjson.GetBytes(toolBytes, "name").String()
+			emit(toolBytes, name)
+		}
+
+	default:
+		// Fallback: check if it has a function or custom shape
+		name := strings.TrimSpace(tool.Get("name").String())
+		if name == "" {
+			name = strings.TrimSpace(tool.Get("function.name").String())
+		}
+		if name != "" {
+			if namespacePrefix != "" {
+				name = namespacePrefix + "__" + name
 			}
-			qualifiedName := qualifyResponsesNamespaceToolName(namespaceName, childName)
-			switch strings.TrimSpace(child.Get("type").String()) {
-			case "", "function":
-				appendDescriptor(child, qualifiedName, childName, namespaceName, "function", sourcePriority, false)
-			case "custom":
-				if !isOpenAIResponsesApplyPatchCustomTool("custom", child) {
-					appendDescriptor(child, qualifiedName, childName, namespaceName, "custom", sourcePriority, false)
-				}
+			if toolBytes, ok := convertResponsesFunctionToolToClaude(tool, name); ok {
+				emit(toolBytes, name)
 			}
-			return true
-		})
-	}
-	for _, source := range responsesToolSources(root) {
-		source.tools.ForEach(func(_, tool gjson.Result) bool {
-			toolType := strings.TrimSpace(tool.Get("type").String())
-			switch toolType {
-			case "", "function":
-				appendDescriptor(tool, responsesToolName(tool), "", "", "function", source.priority, true)
-			case "custom":
-				if !isOpenAIResponsesApplyPatchCustomTool("custom", tool) {
-					appendDescriptor(tool, responsesToolName(tool), "", "", "custom", source.priority, true)
-				}
-			case "namespace":
-				appendNamespaceChildren(tool, source.priority)
-			case "web_search":
-				if externalWebAccess := tool.Get("external_web_access"); externalWebAccess.Exists() && !externalWebAccess.Bool() {
-					return true
-				}
-				name := strings.TrimSpace(tool.Get("name").String())
-				if name == "" {
-					name = "web_search"
-				}
-				appendDescriptor(tool, name, "", "", "web_search", source.priority, true)
-			default:
-				if isUnsupportedOpenAIBuiltinToolType(toolType) {
-					return true
-				}
-				appendDescriptor(tool, strings.TrimSpace(tool.Get("name").String()), "", "", toolType, source.priority, true)
-			}
-			return true
-		})
-	}
-	return descriptors
-}
-
-func responsesToolDescriptorPrecedes(left, right responsesToolDescriptor) bool {
-	// Keep top-level tools ahead of additional_tools, then let direct
-	// declarations win over namespace children within the same source class.
-	if left.sourcePriority != right.sourcePriority {
-		return left.sourcePriority < right.sourcePriority
-	}
-	if left.direct != right.direct {
-		return left.direct
-	}
-	return left.order < right.order
-}
-
-func responsesToolWinners(root gjson.Result) map[string]responsesToolDescriptor {
-	winners := map[string]responsesToolDescriptor{}
-	for _, descriptor := range responsesToolDescriptors(root) {
-		current, exists := winners[descriptor.name]
-		if !exists || responsesToolDescriptorPrecedes(descriptor, current) {
-			winners[descriptor.name] = descriptor
 		}
 	}
-	return winners
-}
-
-func responsesToolNameMap(root gjson.Result, acceptedToolNames map[string]struct{}) map[string]string {
-	toolNameMap := map[string]string{}
-	descriptors := responsesToolDescriptors(root)
-	winners := responsesToolWinners(root)
-
-	// Direct tool names are canonical aliases and must win over namespace
-	// child aliases, regardless of declaration order.
-	for _, descriptor := range descriptors {
-		winner, ok := winners[descriptor.name]
-		if !ok || winner.order != descriptor.order || !descriptor.direct {
-			continue
-		}
-		if _, accepted := acceptedToolNames[descriptor.name]; !accepted {
-			continue
-		}
-		toolNameMap[descriptor.name] = descriptor.name
-	}
-
-	// Namespace aliases fill only names that are not already owned by a
-	// winning direct function/custom tool.
-	for _, descriptor := range descriptors {
-		winner, ok := winners[descriptor.name]
-		if !ok || winner.order != descriptor.order || descriptor.direct || descriptor.childName == "" {
-			continue
-		}
-		if _, accepted := acceptedToolNames[descriptor.name]; !accepted {
-			continue
-		}
-		if _, exists := toolNameMap[descriptor.childName]; exists {
-			continue
-		}
-		toolNameMap[descriptor.childName] = descriptor.name
-	}
-	return toolNameMap
-}
-
-func responsesCustomToolNames(requestRawJSON []byte) map[string]struct{} {
-	names := make(map[string]struct{})
-	root := gjson.ParseBytes(requestRawJSON)
-	for name, descriptor := range responsesToolWinners(root) {
-		if descriptor.toolType == "custom" {
-			names[name] = struct{}{}
-		}
-	}
-	return names
-}
-
-func unwrapCustomToolInput(arguments string) string {
-	if v := gjson.Get(arguments, "input"); v.Exists() {
-		if v.Type == gjson.String {
-			return v.String()
-		}
-		return v.Raw
-	}
-	return arguments
 }
 
 func convertResponsesFunctionToolToClaude(tool gjson.Result, overrideName string) ([]byte, bool) {
@@ -946,12 +509,15 @@ func convertResponsesFunctionToolToClaude(tool gjson.Result, overrideName string
 		return nil, false
 	}
 
-	tJSON := []byte(`{"name":"","description":"","input_schema":{}}`)
-	tJSON, _ = sjson.SetBytes(tJSON, "name", name)
+	sanitizedName := util.SanitizeClaudeFunctionName(name)
+	tJSON := []byte(`{"name":"","description":"","input_schema":{"type":"object","properties":{}}}`)
+	tJSON, _ = sjson.SetBytes(tJSON, "name", sanitizedName)
 	if d := responsesToolDescription(tool); d != "" {
 		tJSON, _ = sjson.SetBytes(tJSON, "description", d)
 	}
-	tJSON, _ = sjson.SetRawBytes(tJSON, "input_schema", util.NormalizeClaudeToolInputSchema([]byte(responsesToolParameters(tool).Raw)))
+	if params := responsesToolParameters(tool); params.Exists() && params.Raw != "" && params.Raw != "null" && params.Raw != "{}" {
+		tJSON, _ = sjson.SetRawBytes(tJSON, "input_schema", util.NormalizeClaudeToolInputSchema([]byte(params.Raw)))
+	}
 	tJSON = common.AttachCacheControl(tJSON, tool)
 	if !gjson.GetBytes(tJSON, "cache_control").Exists() {
 		tJSON = common.AttachCacheControl(tJSON, tool.Get("function"))
@@ -1001,8 +567,8 @@ func convertResponsesWebSearchToolToClaude(tool gjson.Result) ([]byte, bool) {
 }
 
 func responsesToolName(tool gjson.Result) string {
-	if name := strings.TrimSpace(tool.Get("name").String()); name != "" {
-		return name
+	if name := tool.Get("name").String(); name != "" {
+		return strings.TrimSpace(name)
 	}
 	return strings.TrimSpace(tool.Get("function.name").String())
 }
@@ -1027,44 +593,4 @@ func responsesToolParameters(tool gjson.Result) gjson.Result {
 		}
 	}
 	return gjson.Result{}
-}
-
-func qualifyResponsesNamespaceToolName(namespaceName, childName string) string {
-	childName = strings.TrimSpace(childName)
-	if childName == "" || namespaceName == "" || strings.HasPrefix(childName, "mcp__") {
-		return childName
-	}
-	if childName == namespaceName || strings.HasPrefix(childName, namespaceName+"__") {
-		return childName
-	}
-	if strings.HasSuffix(namespaceName, "__") {
-		return namespaceName + childName
-	}
-	return namespaceName + "__" + childName
-}
-
-func splitResponsesQualifiedFunctionCallFromRequest(requestRawJSON []byte, qualifiedName string) (name, namespace string) {
-	qualifiedName = strings.TrimSpace(qualifiedName)
-	if qualifiedName == "" {
-		return "", ""
-	}
-
-	root := gjson.ParseBytes(requestRawJSON)
-	descriptor, ok := responsesToolWinners(root)[qualifiedName]
-	if !ok {
-		return qualifiedName, ""
-	}
-	if !descriptor.direct {
-		return descriptor.childName, descriptor.namespace
-	}
-	return qualifiedName, ""
-}
-
-func isUnsupportedOpenAIBuiltinToolType(toolType string) bool {
-	switch toolType {
-	case "image_generation", "file_search", "code_interpreter", "computer_use_preview":
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -1,291 +1,243 @@
+// Package responses provides request translation functionality for OpenAI Responses to Gemini API compatibility.
+// It converts OpenAI Responses API requests into Gemini compatible JSON using gjson/sjson only.
 package responses
 
 import (
-	"encoding/json"
 	"strings"
 
-	sigcompat "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/translator/gemini/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
-const geminiResponsesThoughtSignature = "skip_thought_signature_validator"
-
+// ConvertOpenAIResponsesRequestToGemini converts an OpenAI Responses API request (raw JSON)
+// into a complete Gemini request JSON using gjson and sjson.
+//
+// Parameters:
+//   - modelName: The name of the model to use for the request
+//   - rawJSON: The raw JSON request data from the OpenAI Responses API
+//   - stream: A boolean indicating if the request is for a streaming response
+//
+// Returns:
+//   - []byte: The transformed request data in Gemini API format
 func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte, stream bool) []byte {
 	rawJSON := inputRawJSON
-
-	// Note: stream parameter is part of the fixed method signature
-	useGeminiNativeReasoningLayout := sigcompat.SignatureProviderFromModelName(modelName) == sigcompat.SignatureProviderGemini
-	_ = stream // Unused but required by interface
-
-	// Base Gemini API template (do not include thinkingConfig by default)
+	useGeminiNativeReasoningLayout := false
+	if modelName != "" {
+		useGeminiNativeReasoningLayout = true
+	}
+	// Base envelope (no default thinkingConfig)
 	out := []byte(`{"contents":[]}`)
 
 	root := gjson.ParseBytes(rawJSON)
 
-	// Extract system instruction from OpenAI "instructions" field.
-	systemParts := make([][]byte, 0, 2)
-	if instructions := root.Get("instructions"); instructions.Exists() {
-		part := []byte(`{"text":""}`)
-		part, _ = sjson.SetBytes(part, "text", instructions.String())
-		systemParts = append(systemParts, part)
-	}
-
-	// Convert input messages to Gemini contents format
-	if input := root.Get("input"); input.Exists() && input.IsArray() {
-		inputItems, hasGeminiCarrier := normalizeGeminiResponsesCarriers(input.Array())
-		if hasGeminiCarrier {
-			useGeminiNativeReasoningLayout = true
+	// Apply thinking configuration: convert OpenAI reasoning_effort to Gemini thinkingConfig.
+	re := root.Get("reasoning_effort")
+	if re.Exists() {
+		effort := strings.ToLower(strings.TrimSpace(re.String()))
+		if effort != "" {
+			thinkingPath := "generationConfig.thinkingConfig"
+			if effort == "auto" {
+				out, _ = sjson.SetBytes(out, thinkingPath+".thinkingBudget", -1)
+			} else {
+				out, _ = sjson.SetBytes(out, thinkingPath+".thinkingLevel", effort)
+			}
 		}
-		items := pairOpenAIResponsesReasoningWithFunctionCalls(inputItems)
-		contentItems := make([][]byte, 0, len(items))
-		functionNamesByCallID := make(map[string]string)
-		pendingFunctionCallIDs := make([]string, 0)
-		for _, item := range items {
-			if item.Get("type").String() == "function_call" {
+	}
+	out = applyOpenAIResponsesThinkingCompatibilityToGemini(out, rawJSON)
+
+	// Convert input array to Gemini contents format
+	input := root.Get("input")
+	var systemParts [][]byte
+	if input.Exists() && input.IsArray() {
+		var contentItems [][]byte
+		items := input.Array()
+
+		// Tool response cache for matching function calls with results
+		toolResponses := map[string]string{}
+		for i := 0; i < len(items); i++ {
+			item := items[i]
+			itemType := item.Get("type").String()
+			if itemType == "function_call_output" {
 				callID := item.Get("call_id").String()
-				if _, exists := functionNamesByCallID[callID]; !exists {
-					functionNamesByCallID[callID] = item.Get("name").String()
+				if callID != "" {
+					output := item.Get("output").String()
+					toolResponses[callID] = output
 				}
 			}
 		}
 
-		normalized := items
-		if useGeminiNativeReasoningLayout {
-			normalized = reorderOpenAIResponsesDetachedReasoning(normalized)
-		}
-		consumedFunctionOutputIndexes := make(map[int]bool)
-		for i := 0; i < len(normalized); i++ {
-			if consumedFunctionOutputIndexes[i] {
-				continue
-			}
-			item := normalized[i]
+		for i := 0; i < len(items); i++ {
+			item := items[i]
 			itemType := item.Get("type").String()
-			itemRole := item.Get("role").String()
-			if itemType == "" && itemRole != "" {
-				itemType = "message"
+			role := item.Get("role").String()
+
+			// Handle system/developer instructions in input array
+			if (role == "system" || role == "developer") && len(items) > 1 {
+				content := item.Get("content")
+				if content.Type == gjson.String {
+					systemParts = append(systemParts, geminiTextPart(content.String()))
+				} else if content.IsArray() {
+					for _, part := range content.Array() {
+						if part.Get("type").String() == "text" {
+							systemParts = append(systemParts, geminiTextPart(part.Get("text").String()))
+						}
+					}
+				}
+				continue
 			}
 
 			switch itemType {
 			case "message":
-				if strings.EqualFold(itemRole, "system") || strings.EqualFold(itemRole, "developer") {
-					pendingFunctionCallIDs = nil
-					if contentArray := item.Get("content"); contentArray.Exists() {
-						if contentArray.IsArray() {
-							contentArray.ForEach(func(_, contentItem gjson.Result) bool {
-								part := []byte(`{"text":""}`)
-								part, _ = sjson.SetBytes(part, "text", contentItem.Get("text").String())
-								systemParts = append(systemParts, part)
-								return true
-							})
-						} else if contentArray.Type == gjson.String {
-							part := []byte(`{"text":""}`)
-							part, _ = sjson.SetBytes(part, "text", contentArray.String())
-							systemParts = append(systemParts, part)
-						}
-					}
-					continue
+				msgRole := item.Get("role").String()
+				// Map OpenAI roles to Gemini roles
+				geminiRole := "user"
+				if msgRole == "assistant" {
+					geminiRole = "model"
 				}
 
-				if _, isAssistantOutput := openAIResponsesAssistantVisibleText(item); !isAssistantOutput {
-					pendingFunctionCallIDs = nil
-				}
-
-				// Handle regular messages
-				// Note: In Responses format, model outputs may appear as content items with type "output_text"
-				// even when the message.role is "user". We split such items into distinct Gemini messages
-				// with roles derived from the content type to match docs/convert-2.md.
-				if contentArray := item.Get("content"); contentArray.Exists() && contentArray.IsArray() {
-					currentRole := ""
-					currentParts := make([][]byte, 0)
-
-					flush := func() {
-						if currentRole == "" || len(currentParts) == 0 {
-							currentParts = currentParts[:0]
-							return
-						}
-						contentItems = append(contentItems, geminiContent(currentRole, currentParts))
-						currentParts = currentParts[:0]
-					}
-
-					contentArray.ForEach(func(_, contentItem gjson.Result) bool {
-						contentType := contentItem.Get("type").String()
-						if contentType == "" {
-							contentType = "input_text"
-						}
-
-						effRole := "user"
-						if itemRole != "" {
-							switch strings.ToLower(itemRole) {
-							case "assistant", "model":
-								effRole = "model"
-							default:
-								effRole = strings.ToLower(itemRole)
-							}
-						}
-						if contentType == "output_text" {
-							effRole = "model"
-						}
-						if effRole == "assistant" {
-							effRole = "model"
-						}
-
-						if currentRole != "" && effRole != currentRole {
-							flush()
-							currentRole = ""
-						}
-						if currentRole == "" {
-							currentRole = effRole
-						}
-
-						var partJSON []byte
-						switch contentType {
-						case "input_text", "output_text":
-							if text := contentItem.Get("text"); text.Exists() {
-								partJSON = []byte(`{"text":""}`)
-								partJSON, _ = sjson.SetBytes(partJSON, "text", text.String())
+				var partItems [][]byte
+				content := item.Get("content")
+				if content.Type == gjson.String {
+					partItems = append(partItems, geminiTextPart(content.String()))
+				} else if content.IsArray() {
+					for _, part := range content.Array() {
+						partType := part.Get("type").String()
+						switch partType {
+						case "input_text", "text", "output_text":
+							text := part.Get("text").String()
+							if text != "" {
+								partItems = append(partItems, geminiTextPart(text))
 							}
 						case "input_image":
-							imageURL := contentItem.Get("image_url").String()
-							if imageURL == "" {
-								imageURL = contentItem.Get("url").String()
-							}
+							// Handle base64 image data
+							imageURL := part.Get("image_url").String()
 							if imageURL != "" {
-								mimeType := "application/octet-stream"
-								data := ""
-								if strings.HasPrefix(imageURL, "data:") {
-									trimmed := strings.TrimPrefix(imageURL, "data:")
-									mediaAndData := strings.SplitN(trimmed, ";base64,", 2)
-									if len(mediaAndData) == 2 {
-										if mediaAndData[0] != "" {
-											mimeType = mediaAndData[0]
-										}
-										data = mediaAndData[1]
-									} else {
-										mediaAndData = strings.SplitN(trimmed, ",", 2)
-										if len(mediaAndData) == 2 {
-											if mediaAndData[0] != "" {
-												mimeType = mediaAndData[0]
-											}
-											data = mediaAndData[1]
-										}
-									}
-								}
-								if data != "" {
-									partJSON = []byte(`{"inline_data":{"mime_type":"","data":""}}`)
-									partJSON, _ = sjson.SetBytes(partJSON, "inline_data.mime_type", mimeType)
-									partJSON, _ = sjson.SetBytes(partJSON, "inline_data.data", data)
+								if mimeType, data, ok := translatorcommon.ParseDataURL(imageURL); ok {
+									partItems = append(partItems, geminiInlineDataPart(mimeType, data))
 								}
 							}
-						case "input_audio":
-							audioData := contentItem.Get("data").String()
-							audioFormat := contentItem.Get("format").String()
-							if audioData != "" {
-								audioMimeMap := map[string]string{
-									"mp3":       "audio/mpeg",
-									"wav":       "audio/wav",
-									"ogg":       "audio/ogg",
-									"flac":      "audio/flac",
-									"aac":       "audio/aac",
-									"webm":      "audio/webm",
-									"pcm16":     "audio/pcm",
-									"g711_ulaw": "audio/basic",
-									"g711_alaw": "audio/basic",
-								}
-								mimeType := "audio/wav"
-								if audioFormat != "" {
-									if mapped, ok := audioMimeMap[audioFormat]; ok {
-										mimeType = mapped
-									} else {
-										mimeType = "audio/" + audioFormat
-									}
-								}
-								partJSON = []byte(`{"inline_data":{"mime_type":"","data":""}}`)
-								partJSON, _ = sjson.SetBytes(partJSON, "inline_data.mime_type", mimeType)
-								partJSON, _ = sjson.SetBytes(partJSON, "inline_data.data", audioData)
-							}
-						}
-
-						if len(partJSON) > 0 {
-							currentParts = append(currentParts, partJSON)
-						}
-						return true
-					})
-
-					flush()
-				} else if contentArray.Type == gjson.String {
-					effRole := "user"
-					if itemRole != "" {
-						switch strings.ToLower(itemRole) {
-						case "assistant", "model":
-							effRole = "model"
-						default:
-							effRole = strings.ToLower(itemRole)
 						}
 					}
+				}
 
-					part := []byte(`{"text":""}`)
-					part, _ = sjson.SetBytes(part, "text", contentArray.String())
-					contentItems = append(contentItems, geminiContent(effRole, [][]byte{part}))
+				if len(partItems) > 0 {
+					contentItems = append(contentItems, geminiContent(geminiRole, partItems))
 				}
 
 			case "function_call":
-				signature := geminiResponsesThoughtSignature
-				if rawSignature := strings.TrimSpace(item.Get("_cpa_reasoning_signature").String()); rawSignature != "" {
-					signature = openAIResponsesGeminiThoughtSignature(rawSignature)
-				}
-				if thoughtText := item.Get("_cpa_reasoning_summary").String(); thoughtText != "" {
-					contentItems = append(contentItems, buildOpenAIResponsesReasoningFunctionCallModelContent(thoughtText, item, signature))
-				} else if !useGeminiNativeReasoningLayout && strings.TrimSpace(item.Get("_cpa_reasoning_signature").String()) != "" {
-					contentItems = append(contentItems, buildOpenAIResponsesEmptyReasoningFunctionCallModelContent(item, signature))
-				} else {
-					contentItems = append(contentItems, buildOpenAIResponsesFunctionCallModelContent(item, signature))
-				}
-				if callID := strings.TrimSpace(item.Get("call_id").String()); callID != "" {
-					pendingFunctionCallIDs = append(pendingFunctionCallIDs, callID)
-				}
+				name := item.Get("name").String()
+				arguments := item.Get("arguments").String()
 
-			case "function_call_output":
-				orderedOutputs, consumedIndexes, remainingPending := collectOpenAIResponsesFunctionCallOutputs(normalized, i, pendingFunctionCallIDs)
-				pendingFunctionCallIDs = remainingPending
-				for consumedIndex := range consumedIndexes {
-					consumedFunctionOutputIndexes[consumedIndex] = true
-				}
-				responseParts := make([][]byte, 0, len(orderedOutputs))
-				for _, output := range orderedOutputs {
-					responseParts = append(responseParts, buildOpenAIResponsesFunctionResponsePart(output, functionNamesByCallID))
-				}
-				if len(responseParts) > 0 {
-					contentItems = append(contentItems, geminiContent("user", responseParts))
-				}
+				var partItems [][]byte
+				funcCallPart := []byte(`{"functionCall":{"name":"","args":{}}}`)
+				funcCallPart, _ = sjson.SetBytes(funcCallPart, "functionCall.name", util.SanitizeFunctionName(name))
 
-			case "reasoning":
-				thoughtText := item.Get("summary.0.text").String()
-				rawSignature := item.Get("encrypted_content").String()
-				carrierDirection := geminiResponsesCarrierDirection(item)
-				carrierTarget := geminiResponsesCarrierTarget(item)
-				if strings.TrimSpace(rawSignature) == "" && i+1 < len(normalized) {
-					nextReasoning := normalized[i+1]
-					if nextReasoning.Get("type").String() == "reasoning" && strings.Contains(nextReasoning.Get("id").String(), "_detached_after_") && strings.TrimSpace(nextReasoning.Get("summary.0.text").String()) == "" && strings.TrimSpace(nextReasoning.Get("encrypted_content").String()) != "" {
-						rawSignature = nextReasoning.Get("encrypted_content").String()
-						i++
+				if arguments != "" {
+					var argsMap map[string]any
+					if errUnmarshal := util.UnmarshalJSONCaseFold([]byte(arguments), &argsMap); errUnmarshal == nil {
+						funcCallPart, _ = sjson.SetBytes(funcCallPart, "functionCall.args", argsMap)
 					}
 				}
-				signature := openAIResponsesGeminiThoughtSignature(rawSignature)
 
+				partItems = append(partItems, funcCallPart)
+				contentItems = append(contentItems, geminiContent("model", partItems))
+
+			case "function_call_output":
+				callID := item.Get("call_id").String()
+				output := item.Get("output").String()
+
+				// Find matching function call name if possible, otherwise use generic name
+				funcName := "function"
+				for j := 0; j < i; j++ {
+					prevItem := items[j]
+					if prevItem.Get("type").String() == "function_call" && prevItem.Get("call_id").String() == callID {
+						funcName = prevItem.Get("name").String()
+						break
+					}
+				}
+
+				var partItems [][]byte
+				funcRespPart := []byte(`{"functionResponse":{"name":"","response":{"result":null}}}`)
+				funcRespPart, _ = sjson.SetBytes(funcRespPart, "functionResponse.name", util.SanitizeFunctionName(funcName))
+
+				if output != "" {
+					parsed := gjson.Parse(output)
+					if parsed.Type == gjson.JSON {
+						funcRespPart, _ = sjson.SetRawBytes(funcRespPart, "functionResponse.response.result", []byte(parsed.Raw))
+					} else {
+						funcRespPart, _ = sjson.SetBytes(funcRespPart, "functionResponse.response.result", output)
+					}
+				}
+
+				partItems = append(partItems, funcRespPart)
+
+				// Look ahead for consecutive function_call_output items and group them
+				for i+1 < len(items) && items[i+1].Get("type").String() == "function_call_output" {
+					i++
+					nextItem := items[i]
+					nextCallID := nextItem.Get("call_id").String()
+					nextOutput := nextItem.Get("output").String()
+
+					nextFuncName := "function"
+					for j := 0; j < i; j++ {
+						prevItem := items[j]
+						if prevItem.Get("type").String() == "function_call" && prevItem.Get("call_id").String() == nextCallID {
+							nextFuncName = prevItem.Get("name").String()
+							break
+						}
+					}
+
+					nextFuncRespPart := []byte(`{"functionResponse":{"name":"","response":{"result":null}}}`)
+					nextFuncRespPart, _ = sjson.SetBytes(nextFuncRespPart, "functionResponse.name", util.SanitizeFunctionName(nextFuncName))
+
+					if nextOutput != "" {
+						parsed := gjson.Parse(nextOutput)
+						if parsed.Type == gjson.JSON {
+							nextFuncRespPart, _ = sjson.SetRawBytes(nextFuncRespPart, "functionResponse.response.result", []byte(parsed.Raw))
+						} else {
+							nextFuncRespPart, _ = sjson.SetBytes(nextFuncRespPart, "functionResponse.response.result", nextOutput)
+						}
+					}
+
+					partItems = append(partItems, nextFuncRespPart)
+				}
+
+				contentItems = append(contentItems, geminiContent("user", partItems))
+
+			case "reasoning":
+				// Handle OpenAI Responses reasoning items by converting them to Gemini model turns
+				// with thought parts or thought signatures.
+				thoughtText := extractOpenAIResponsesReasoningText(item)
 				visibleText := ""
-				if useGeminiNativeReasoningLayout && i+1 < len(normalized) {
-					next := normalized[i+1]
-					canBindText := (carrierDirection == "" || carrierDirection == geminiResponsesCarrierNext) && (carrierTarget == "" || carrierTarget == geminiResponsesCarrierText || carrierTarget == geminiResponsesCarrierAny)
-					canBindFunction := (carrierDirection == "" || carrierDirection == geminiResponsesCarrierNext) && (carrierTarget == "" || carrierTarget == geminiResponsesCarrierFunction || carrierTarget == geminiResponsesCarrierAny)
-					if visible, ok := openAIResponsesAssistantVisibleText(next); ok && canBindText {
-						visibleText = visible
-						i++
-					} else if next.Get("type").String() == "function_call" && canBindFunction && strings.TrimSpace(next.Get("_cpa_reasoning_signature").String()) == "" && signature != geminiResponsesThoughtSignature {
-						contentItems = append(contentItems, buildOpenAIResponsesReasoningFunctionCallModelContent(thoughtText, next, signature))
+				signature := item.Get("encrypted_content").String()
+
+				// Look ahead: if the next item is a message from assistant, merge its text into this turn
+				if i+1 < len(items) {
+					next := items[i+1]
+					if next.Get("type").String() == "message" && next.Get("role").String() == "assistant" {
+						visibleText = extractOpenAIResponsesMessageText(next)
+						i++ // consume the assistant message
+					} else if next.Get("type").String() == "function_call" {
+						// Followed by function call - the reasoning belongs to the model turn preceding the call.
+						// Capture any consecutive function_call items that follow this reasoning.
+						var pendingFunctionCallIDs []string
+						if callID := strings.TrimSpace(next.Get("call_id").String()); callID != "" {
+							pendingFunctionCallIDs = append(pendingFunctionCallIDs, callID)
+						}
+						for i+2 < len(items) && items[i+2].Get("type").String() == "function_call" {
+							i++
+							nextCall := items[i+1]
+							if callID := strings.TrimSpace(nextCall.Get("call_id").String()); callID != "" {
+								pendingFunctionCallIDs = append(pendingFunctionCallIDs, callID)
+							}
+						}
+
+						if modelContent := buildOpenAIResponsesReasoningModelContent(thoughtText, visibleText, signature, useGeminiNativeReasoningLayout); len(modelContent) > 0 {
+							contentItems = append(contentItems, modelContent)
+						}
 						if callID := strings.TrimSpace(next.Get("call_id").String()); callID != "" {
 							pendingFunctionCallIDs = append(pendingFunctionCallIDs, callID)
 						}
@@ -315,17 +267,28 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 	if tools := root.Get("tools"); tools.Exists() && tools.IsArray() {
 		var functionDeclarations [][]byte
 		tools.ForEach(func(_, tool gjson.Result) bool {
-			if tool.Get("type").String() == "function" {
-				funcDecl := []byte(`{"name":"","description":"","parametersJsonSchema":{}}`)
+			if tool.Get("type").String() == "function" || tool.Get("type").String() == "custom" || tool.Get("name").Exists() {
+				funcDecl := []byte(`{"name":"","description":"","parametersJsonSchema":{"type":"object","properties":{}}}`)
 
-				if name := tool.Get("name"); name.Exists() {
-					funcDecl, _ = sjson.SetBytes(funcDecl, "name", util.SanitizeFunctionName(name.String()))
+				name := tool.Get("name").String()
+				if name == "" {
+					name = tool.Get("function.name").String()
 				}
-				if desc := tool.Get("description"); desc.Exists() {
-					funcDecl, _ = sjson.SetBytes(funcDecl, "description", desc.String())
+				if name != "" {
+					funcDecl, _ = sjson.SetBytes(funcDecl, "name", util.SanitizeFunctionName(name))
 				}
-				if params := tool.Get("parameters"); params.Exists() {
-					funcDecl, _ = sjson.SetRawBytes(funcDecl, "parametersJsonSchema", []byte(util.CleanJSONSchemaForGemini(params.Raw)))
+				desc := tool.Get("description").String()
+				if desc == "" {
+					desc = tool.Get("function.description").String()
+				}
+				if desc != "" {
+					funcDecl, _ = sjson.SetBytes(funcDecl, "description", desc)
+				}
+				for _, k := range []string{"parameters", "parametersJsonSchema", "input_schema", "function.parameters", "function.parametersJsonSchema"} {
+					if params := tool.Get(k); params.Exists() && params.Raw != "" && params.Raw != "null" && params.Raw != "{}" {
+						funcDecl, _ = sjson.SetRawBytes(funcDecl, "parametersJsonSchema", []byte(util.CleanJSONSchemaForGemini(params.Raw)))
+						break
+					}
 				}
 
 				functionDeclarations = append(functionDeclarations, funcDecl)
@@ -365,32 +328,126 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 			sequences = append(sequences, seq.String())
 			return true
 		})
-		out, _ = sjson.SetBytes(out, "generationConfig.stopSequences", sequences)
-	}
-
-	out = applyOpenAIResponsesTextFormatToGemini(out, root)
-
-	// Apply thinking configuration: convert OpenAI Responses API reasoning.effort to Gemini thinkingConfig.
-	// Inline translation-only mapping; capability checks happen later in ApplyThinking.
-	re := root.Get("reasoning.effort")
-	if re.Exists() {
-		effort := strings.ToLower(strings.TrimSpace(re.String()))
-		if effort != "" {
-			thinkingPath := "generationConfig.thinkingConfig"
-			if effort == "auto" {
-				out, _ = sjson.SetBytes(out, thinkingPath+".thinkingBudget", -1)
-			} else {
-				out, _ = sjson.SetBytes(out, thinkingPath+".thinkingLevel", effort)
-			}
+		if len(sequences) > 0 {
+			out, _ = sjson.SetBytes(out, "generationConfig.stopSequences", sequences)
 		}
 	}
 
-	result := out
-	result = common.AttachDefaultSafetySettings(result, "safetySettings")
-	if useGeminiNativeReasoningLayout {
-		result = sigcompat.SanitizeGeminiRequestThoughtSignatures(result, "contents")
+	return out
+}
+
+func extractOpenAIResponsesReasoningText(item gjson.Result) string {
+	if text := item.Get("reasoning_content.text").String(); text != "" {
+		return text
 	}
-	return stripTrailingOpenAIResponsesModelPrefill(result)
+	if text := item.Get("content.0.text").String(); text != "" {
+		return text
+	}
+	if text := item.Get("text").String(); text != "" {
+		return text
+	}
+	return ""
+}
+
+func extractOpenAIResponsesMessageText(item gjson.Result) string {
+	content := item.Get("content")
+	if content.Type == gjson.String {
+		return content.String()
+	}
+	if content.IsArray() {
+		var texts []string
+		for _, part := range content.Array() {
+			if part.Get("type").String() == "output_text" || part.Get("type").String() == "text" {
+				if t := part.Get("text").String(); t != "" {
+					texts = append(texts, t)
+				}
+			}
+		}
+		return strings.Join(texts, "")
+	}
+	return ""
+}
+
+func buildOpenAIResponsesReasoningModelContent(thoughtText, visibleText, signature string, useGeminiNativeReasoningLayout bool) []byte {
+	var parts [][]byte
+
+	if thoughtText != "" {
+		part := []byte(`{"text":"","thought":true}`)
+		part, _ = sjson.SetBytes(part, "text", thoughtText)
+		if signature != "" {
+			part, _ = sjson.SetBytes(part, "thoughtSignature", signature)
+		}
+		parts = append(parts, part)
+	} else if signature != "" {
+		// Signature-only reasoning
+		part := []byte(`{"thought":true}`)
+		part, _ = sjson.SetBytes(part, "thoughtSignature", signature)
+		parts = append(parts, part)
+	}
+
+	if visibleText != "" {
+		part := []byte(`{"text":""}`)
+		part, _ = sjson.SetBytes(part, "text", visibleText)
+		parts = append(parts, part)
+	}
+
+	if len(parts) == 0 {
+		return nil
+	}
+
+	return geminiContent("model", parts)
+}
+
+func coalesceAdjacentOpenAIResponsesModelContents(contents [][]byte) [][]byte {
+	if len(contents) <= 1 {
+		return contents
+	}
+
+	var result [][]byte
+	for _, contentJSON := range contents {
+		if len(result) == 0 {
+			result = append(result, contentJSON)
+			continue
+		}
+
+		lastIdx := len(result) - 1
+		lastRole := gjson.GetBytes(result[lastIdx], "role").String()
+		currentRole := gjson.GetBytes(contentJSON, "role").String()
+
+		if lastRole == "model" && currentRole == "model" {
+			// Merge parts into the previous model content
+			lastParts := gjson.GetBytes(result[lastIdx], "parts").Array()
+			currentParts := gjson.GetBytes(contentJSON, "parts").Array()
+
+			var mergedParts [][]byte
+			for _, p := range lastParts {
+				mergedParts = append(mergedParts, []byte(p.Raw))
+			}
+			for _, p := range currentParts {
+				mergedParts = append(mergedParts, []byte(p.Raw))
+			}
+
+			mergedContent, _ := sjson.SetRawBytes(result[lastIdx], "parts", translatorcommon.JoinRawArray(mergedParts))
+			result[lastIdx] = mergedContent
+		} else {
+			result = append(result, contentJSON)
+		}
+	}
+
+	return result
+}
+
+func geminiTextPart(text string) []byte {
+	part := []byte(`{"text":""}`)
+	part, _ = sjson.SetBytes(part, "text", text)
+	return part
+}
+
+func geminiInlineDataPart(mimeType, data string) []byte {
+	part := []byte(`{"inlineData":{"mimeType":"","data":""}}`)
+	part, _ = sjson.SetBytes(part, "inlineData.mimeType", mimeType)
+	part, _ = sjson.SetBytes(part, "inlineData.data", data)
+	return part
 }
 
 func geminiContent(role string, parts [][]byte) []byte {
@@ -400,467 +457,16 @@ func geminiContent(role string, parts [][]byte) []byte {
 	return content
 }
 
-func coalesceAdjacentOpenAIResponsesModelContents(contents [][]byte) [][]byte {
-	coalesced := make([][]byte, 0, len(contents))
-	for _, content := range contents {
-		contentResult := gjson.ParseBytes(content)
-		if !strings.EqualFold(strings.TrimSpace(contentResult.Get("role").String()), "model") || len(coalesced) == 0 {
-			coalesced = append(coalesced, content)
-			continue
-		}
-		lastIndex := len(coalesced) - 1
-		lastResult := gjson.ParseBytes(coalesced[lastIndex])
-		if !strings.EqualFold(strings.TrimSpace(lastResult.Get("role").String()), "model") {
-			coalesced = append(coalesced, content)
-			continue
-		}
-		merged := coalesced[lastIndex]
-		parts := contentResult.Get("parts")
-		if !parts.IsArray() {
-			coalesced = append(coalesced, content)
-			continue
-		}
-		parts.ForEach(func(_, part gjson.Result) bool {
-			merged, _ = sjson.SetRawBytes(merged, "parts.-1", []byte(part.Raw))
-			return true
-		})
-		coalesced[lastIndex] = merged
-	}
-	return coalesced
-}
-
 func geminiSystemInstruction(parts [][]byte) []byte {
-	systemInstruction := []byte(`{"parts":[]}`)
-	systemInstruction, _ = sjson.SetRawBytes(systemInstruction, "parts", translatorcommon.JoinRawArray(parts))
-	return systemInstruction
+	si := []byte(`{"parts":[]}`)
+	si, _ = sjson.SetRawBytes(si, "parts", translatorcommon.JoinRawArray(parts))
+	return si
 }
 
-func stripTrailingOpenAIResponsesModelPrefill(payload []byte) []byte {
-	contents := gjson.GetBytes(payload, "contents")
-	if !contents.IsArray() {
-		return payload
+func applyOpenAIResponsesThinkingCompatibilityToGemini(out, rawJSON []byte) []byte {
+	config := thinking.ExtractSummaryConfig(rawJSON, "openai")
+	if config.SummaryMode != "" {
+		return thinking.ApplySummaryConfig(out, "gemini", config)
 	}
-	contentArray := contents.Array()
-	if len(contentArray) == 0 || !shouldStripTrailingOpenAIResponsesModelPrefill(contentArray[len(contentArray)-1]) {
-		return payload
-	}
-	items := make([][]byte, 0, len(contentArray)-1)
-	for _, content := range contentArray[:len(contentArray)-1] {
-		items = append(items, []byte(content.Raw))
-	}
-	if len(items) == 0 {
-		updated, errSet := sjson.SetRawBytes(payload, "contents", []byte("[]"))
-		if errSet == nil {
-			return updated
-		}
-		return payload
-	}
-	return translatorcommon.SetRawArrayItems(payload, "contents", items)
-}
-
-func shouldStripTrailingOpenAIResponsesModelPrefill(lastContent gjson.Result) bool {
-	if lastContent.Get("role").String() != "model" {
-		return false
-	}
-	parts := lastContent.Get("parts")
-	if !parts.IsArray() {
-		return false
-	}
-	for _, part := range parts.Array() {
-		if part.Get("thought").Bool() || part.Get("functionCall").Exists() || strings.TrimSpace(part.Get("thoughtSignature").String()) != "" {
-			return false
-		}
-	}
-	return true
-}
-
-func isTrailingOpenAIResponsesAssistantPrefill(items []gjson.Result, assistantIndex int) bool {
-	if assistantIndex < 0 || assistantIndex >= len(items) {
-		return false
-	}
-	for j := assistantIndex + 1; j < len(items); j++ {
-		itemType := items[j].Get("type").String()
-		itemRole := items[j].Get("role").String()
-		if itemType == "" && itemRole != "" {
-			itemType = "message"
-		}
-		switch itemType {
-		case "reasoning", "function_call", "function_call_output":
-			return false
-		case "message":
-			if strings.EqualFold(itemRole, "system") || strings.EqualFold(itemRole, "developer") {
-				continue
-			}
-			return false
-		}
-	}
-	_, ok := openAIResponsesAssistantVisibleText(items[assistantIndex])
-	return ok
-}
-
-func openAIResponsesAssistantVisibleText(item gjson.Result) (string, bool) {
-	itemType := item.Get("type").String()
-	itemRole := item.Get("role").String()
-	if itemType == "" && itemRole != "" {
-		itemType = "message"
-	}
-	if itemType != "message" {
-		return "", false
-	}
-
-	content := item.Get("content")
-	if !content.Exists() {
-		return "", false
-	}
-	if content.Type == gjson.String {
-		switch strings.ToLower(strings.TrimSpace(itemRole)) {
-		case "assistant", "model":
-			return content.String(), true
-		default:
-			return "", false
-		}
-	}
-	if !content.IsArray() {
-		return "", false
-	}
-
-	var textParts []string
-	hasOutputText := false
-	content.ForEach(func(_, contentItem gjson.Result) bool {
-		contentType := contentItem.Get("type").String()
-		if contentType == "" {
-			contentType = "input_text"
-		}
-		if contentType != "output_text" {
-			return true
-		}
-		hasOutputText = true
-		textParts = append(textParts, contentItem.Get("text").String())
-		return true
-	})
-	if !hasOutputText {
-		return "", false
-	}
-	// output_text marks model-visible content even when message.role is "user".
-	return strings.Join(textParts, "\n"), true
-}
-
-func pairOpenAIResponsesReasoningWithFunctionCalls(items []gjson.Result) []gjson.Result {
-	isDetachedCarrier := isOpenAIResponsesDetachedCarrier
-	postCallSignature := make(map[int]string)
-	postCallCarrier := make(map[int]bool)
-	consumedPostCallCarrier := make(map[int]bool)
-	for groupStart := 0; groupStart < len(items); {
-		if items[groupStart].Get("type").String() != "function_call" && !isDetachedCarrier(items[groupStart]) {
-			groupStart++
-			continue
-		}
-		groupEnd := groupStart
-		hasFunctionCall := false
-		for groupEnd < len(items) && (items[groupEnd].Get("type").String() == "function_call" || isDetachedCarrier(items[groupEnd])) {
-			hasFunctionCall = hasFunctionCall || items[groupEnd].Get("type").String() == "function_call"
-			groupEnd++
-		}
-		if !hasFunctionCall || groupEnd >= len(items) || items[groupEnd].Get("type").String() != "function_call_output" {
-			groupStart = groupEnd
-			continue
-		}
-		outputEnd := groupEnd
-		for outputEnd < len(items) && items[outputEnd].Get("type").String() == "function_call_output" {
-			outputEnd++
-		}
-		// A run beginning with a carrier uses leading-carrier semantics. A run
-		// beginning with a call uses post-call semantics. This preserves both
-		// carrier,call,carrier,call and call,carrier,call,carrier histories.
-		if items[groupStart].Get("type").String() == "function_call" {
-			for callIndex := groupStart; callIndex < groupEnd; callIndex++ {
-				item := items[callIndex]
-				if item.Get("type").String() != "function_call" || strings.TrimSpace(item.Get("_cpa_reasoning_signature").String()) != "" || callIndex+1 >= groupEnd || !isDetachedCarrier(items[callIndex+1]) {
-					continue
-				}
-				carrierDirection := geminiResponsesCarrierDirection(items[callIndex+1])
-				carrierTarget := geminiResponsesCarrierTarget(items[callIndex+1])
-				if carrierDirection != "" && (carrierDirection != geminiResponsesCarrierPrevious || (carrierTarget != geminiResponsesCarrierFunction && carrierTarget != geminiResponsesCarrierAny)) {
-					continue
-				}
-				carrierEnd := callIndex + 1
-				for carrierEnd < groupEnd && isDetachedCarrier(items[carrierEnd]) {
-					postCallCarrier[carrierEnd] = true
-					carrierEnd++
-				}
-				callID := strings.TrimSpace(item.Get("call_id").String())
-				if callID == "" {
-					continue
-				}
-				for outputIndex := groupEnd; outputIndex < outputEnd; outputIndex++ {
-					if strings.TrimSpace(items[outputIndex].Get("call_id").String()) == callID {
-						postCallSignature[callIndex] = strings.TrimSpace(items[callIndex+1].Get("encrypted_content").String())
-						consumedPostCallCarrier[callIndex+1] = true
-						break
-					}
-				}
-			}
-		}
-		groupStart = outputEnd
-	}
-
-	paired := make([]gjson.Result, 0, len(items))
-	for index := 0; index < len(items); index++ {
-		item := items[index]
-		if signature := postCallSignature[index]; signature != "" {
-			functionCall := []byte(item.Raw)
-			functionCall, _ = sjson.SetBytes(functionCall, "_cpa_reasoning_signature", signature)
-			paired = append(paired, gjson.ParseBytes(functionCall))
-			continue
-		}
-		if consumedPostCallCarrier[index] {
-			continue
-		}
-		carrierDirection := geminiResponsesCarrierDirection(item)
-		carrierTarget := geminiResponsesCarrierTarget(item)
-		canBindFollowingCall := carrierDirection == "" || (carrierDirection == geminiResponsesCarrierNext && (carrierTarget == geminiResponsesCarrierFunction || carrierTarget == geminiResponsesCarrierAny))
-		if item.Get("type").String() == "reasoning" && !postCallCarrier[index] && canBindFollowingCall && !strings.Contains(item.Get("id").String(), "_detached_after_") && index+1 < len(items) && items[index+1].Get("type").String() == "function_call" {
-			rawSignature := strings.TrimSpace(item.Get("encrypted_content").String())
-			if rawSignature != "" {
-				functionCall := []byte(items[index+1].Raw)
-				functionCall, _ = sjson.SetBytes(functionCall, "_cpa_reasoning_signature", rawSignature)
-				if summary := item.Get("summary.0.text").String(); summary != "" {
-					functionCall, _ = sjson.SetBytes(functionCall, "_cpa_reasoning_summary", summary)
-				}
-				paired = append(paired, gjson.ParseBytes(functionCall))
-				index++
-				continue
-			}
-		}
-		paired = append(paired, item)
-	}
-	return paired
-}
-
-func reorderOpenAIResponsesDetachedReasoning(items []gjson.Result) []gjson.Result {
-	reordered := make([]gjson.Result, 0, len(items))
-	for itemIndex, item := range items {
-		isReasoningCarrier := isOpenAIResponsesDetachedCarrier(item)
-		markedDetached := strings.Contains(item.Get("id").String(), "_detached_after_")
-		if isReasoningCarrier && len(reordered) > 0 {
-			previous := reordered[len(reordered)-1]
-			previousType := previous.Get("type").String()
-			if previousType == "" && previous.Get("role").String() != "" {
-				previousType = "message"
-			}
-			isAssistantMessage := false
-			if previousType == "message" {
-				_, isAssistantMessage = openAIResponsesAssistantVisibleText(previous)
-			}
-
-			direction := geminiResponsesCarrierDirection(item)
-			targetKind := geminiResponsesCarrierTarget(item)
-			if direction != "" {
-				alreadyPairedText := false
-				alreadyPairedFunction := false
-				if len(reordered) > 1 {
-					prior := reordered[len(reordered)-2]
-					priorDirection := geminiResponsesCarrierDirection(prior)
-					priorTarget := geminiResponsesCarrierTarget(prior)
-					priorBindsFollowing := isOpenAIResponsesDetachedCarrier(prior) && (priorDirection == geminiResponsesCarrierNext || priorDirection == geminiResponsesCarrierPrevious)
-					alreadyPairedText = priorBindsFollowing && (priorTarget == geminiResponsesCarrierText || priorTarget == geminiResponsesCarrierAny)
-					alreadyPairedFunction = priorBindsFollowing && (priorTarget == geminiResponsesCarrierFunction || priorTarget == geminiResponsesCarrierAny)
-				}
-				bindPreviousMessage := direction == geminiResponsesCarrierPrevious && (targetKind == geminiResponsesCarrierText || targetKind == geminiResponsesCarrierAny) && isAssistantMessage && !alreadyPairedText
-				bindPreviousFunction := direction == geminiResponsesCarrierPrevious && (targetKind == geminiResponsesCarrierFunction || targetKind == geminiResponsesCarrierAny) && previousType == "function_call" && strings.TrimSpace(previous.Get("_cpa_reasoning_signature").String()) == "" && !alreadyPairedFunction
-				if bindPreviousMessage || bindPreviousFunction {
-					movedItemJSON, _ := sjson.SetBytes([]byte(item.Raw), geminiResponsesCarrierDirectionField, geminiResponsesCarrierNext)
-					reordered[len(reordered)-1] = gjson.ParseBytes(movedItemJSON)
-					reordered = append(reordered, previous)
-					continue
-				}
-				reordered = append(reordered, item)
-				continue
-			}
-
-			if isAssistantMessage && !markedDetached && itemIndex+1 < len(items) {
-				_, nextIsAssistantMessage := openAIResponsesAssistantVisibleText(items[itemIndex+1])
-				isAssistantMessage = !nextIsAssistantMessage
-			}
-			alreadyPaired := false
-			if len(reordered) > 1 {
-				prior := reordered[len(reordered)-2]
-				alreadyPaired = isOpenAIResponsesDetachedCarrier(prior) && strings.Contains(prior.Get("id").String(), "_detached_after_")
-			}
-			if !alreadyPaired && (isAssistantMessage || (markedDetached && previousType == "function_call" && strings.TrimSpace(previous.Get("_cpa_reasoning_signature").String()) == "")) {
-				reordered[len(reordered)-1] = item
-				reordered = append(reordered, previous)
-				continue
-			}
-		}
-		reordered = append(reordered, item)
-	}
-	return reordered
-}
-
-func buildOpenAIResponsesFunctionCallPart(item gjson.Result, signature string) []byte {
-	name := util.SanitizeFunctionName(item.Get("name").String())
-	arguments := item.Get("arguments").String()
-	functionCall := []byte(`{"functionCall":{"name":"","args":{}}}`)
-	functionCall, _ = sjson.SetBytes(functionCall, "functionCall.name", name)
-	functionCall, _ = sjson.SetBytes(functionCall, "thoughtSignature", signature)
-	functionCall, _ = sjson.SetBytes(functionCall, "functionCall.id", item.Get("call_id").String())
-	if arguments != "" {
-		argsResult := gjson.Parse(arguments)
-		functionCall, _ = sjson.SetRawBytes(functionCall, "functionCall.args", []byte(argsResult.Raw))
-	}
-	return functionCall
-}
-
-func buildOpenAIResponsesFunctionResponsePart(item gjson.Result, functionNamesByCallID map[string]string) []byte {
-	callID := item.Get("call_id").String()
-	functionName := "unknown"
-	if matchedName, ok := functionNamesByCallID[callID]; ok {
-		functionName = matchedName
-	}
-	functionResponse := []byte(`{"functionResponse":{"name":"","response":{}}}`)
-	functionResponse, _ = sjson.SetBytes(functionResponse, "functionResponse.name", util.SanitizeFunctionName(functionName))
-	functionResponse, _ = sjson.SetBytes(functionResponse, "functionResponse.id", callID)
-
-	outputRaw := item.Get("output").Str
-	if outputRaw != "" && outputRaw != "null" {
-		output := gjson.Parse(outputRaw)
-		if output.Type == gjson.JSON && json.Valid([]byte(output.Raw)) {
-			functionResponse, _ = sjson.SetRawBytes(functionResponse, "functionResponse.response.result", []byte(output.Raw))
-		} else {
-			functionResponse, _ = sjson.SetBytes(functionResponse, "functionResponse.response.result", outputRaw)
-		}
-	}
-	return functionResponse
-}
-
-func collectOpenAIResponsesFunctionCallOutputs(items []gjson.Result, start int, pendingCallIDs []string) ([]gjson.Result, map[int]bool, []string) {
-	end := start + 1
-	for end < len(items) && items[end].Get("type").String() == "function_call_output" {
-		end++
-	}
-	outputs := items[start:end]
-	ordered, remainingPending := orderOpenAIResponsesFunctionCallOutputs(outputs, pendingCallIDs)
-	consumed := make(map[int]bool, len(outputs))
-	for itemIndex := start; itemIndex < end; itemIndex++ {
-		consumed[itemIndex] = true
-	}
-	return ordered, consumed, remainingPending
-}
-
-func orderOpenAIResponsesFunctionCallOutputs(outputs []gjson.Result, pendingCallIDs []string) ([]gjson.Result, []string) {
-	ordered := make([]gjson.Result, 0, len(outputs))
-	used := make([]bool, len(outputs))
-	remainingPending := make([]string, 0, len(pendingCallIDs))
-	for _, pendingID := range pendingCallIDs {
-		match := -1
-		for outputIndex, output := range outputs {
-			if !used[outputIndex] && output.Get("call_id").String() == pendingID {
-				match = outputIndex
-				break
-			}
-		}
-		if match < 0 {
-			remainingPending = append(remainingPending, pendingID)
-			continue
-		}
-		used[match] = true
-		ordered = append(ordered, outputs[match])
-	}
-	for outputIndex, output := range outputs {
-		if !used[outputIndex] {
-			ordered = append(ordered, output)
-		}
-	}
-	return ordered, remainingPending
-}
-
-func buildOpenAIResponsesFunctionCallModelContent(item gjson.Result, signature string) []byte {
-	modelContent := []byte(`{"role":"model","parts":[]}`)
-	modelContent, _ = sjson.SetRawBytes(modelContent, "parts", translatorcommon.JoinRawArray([][]byte{buildOpenAIResponsesFunctionCallPart(item, signature)}))
-	return modelContent
-}
-
-func buildOpenAIResponsesEmptyReasoningFunctionCallModelContent(item gjson.Result, signature string) []byte {
-	thought := []byte(`{"text":"","thought":true,"thoughtSignature":""}`)
-	thought, _ = sjson.SetBytes(thought, "thoughtSignature", signature)
-	parts := [][]byte{thought, buildOpenAIResponsesFunctionCallPart(item, signature)}
-	modelContent := []byte(`{"role":"model","parts":[]}`)
-	modelContent, _ = sjson.SetRawBytes(modelContent, "parts", translatorcommon.JoinRawArray(parts))
-	return modelContent
-}
-
-func buildOpenAIResponsesReasoningFunctionCallModelContent(thoughtText string, item gjson.Result, signature string) []byte {
-	parts := make([][]byte, 0, 2)
-	if thoughtText != "" {
-		thought := []byte(`{"text":"","thought":true}`)
-		thought, _ = sjson.SetBytes(thought, "text", thoughtText)
-		parts = append(parts, thought)
-	}
-	parts = append(parts, buildOpenAIResponsesFunctionCallPart(item, signature))
-	modelContent := []byte(`{"role":"model","parts":[]}`)
-	modelContent, _ = sjson.SetRawBytes(modelContent, "parts", translatorcommon.JoinRawArray(parts))
-	return modelContent
-}
-
-func buildOpenAIResponsesReasoningModelContent(thoughtText, visibleText, signature string, useGeminiNativeReasoningLayout bool) []byte {
-	modelContent := []byte(`{"role":"model","parts":[]}`)
-	if useGeminiNativeReasoningLayout {
-		if thoughtText == "" && visibleText == "" {
-			carrier := []byte(`{"text":"","thoughtSignature":""}`)
-			carrier, _ = sjson.SetBytes(carrier, "thoughtSignature", signature)
-			modelContent, _ = sjson.SetRawBytes(modelContent, "parts.-1", carrier)
-			return modelContent
-		}
-		if thoughtText != "" {
-			thought := []byte(`{"text":"","thought":true}`)
-			thought, _ = sjson.SetBytes(thought, "text", thoughtText)
-			if visibleText == "" {
-				thought, _ = sjson.SetBytes(thought, "thoughtSignature", signature)
-			}
-			modelContent, _ = sjson.SetRawBytes(modelContent, "parts.-1", thought)
-		}
-		if visibleText != "" {
-			visible := []byte(`{"text":"","thoughtSignature":""}`)
-			visible, _ = sjson.SetBytes(visible, "text", visibleText)
-			visible, _ = sjson.SetBytes(visible, "thoughtSignature", signature)
-			modelContent, _ = sjson.SetRawBytes(modelContent, "parts.-1", visible)
-		}
-		return modelContent
-	}
-
-	thought := []byte(`{"text":"","thoughtSignature":"","thought":true}`)
-	thought, _ = sjson.SetBytes(thought, "text", thoughtText)
-	thought, _ = sjson.SetBytes(thought, "thoughtSignature", signature)
-	modelContent, _ = sjson.SetRawBytes(modelContent, "parts.-1", thought)
-	return modelContent
-}
-
-func openAIResponsesGeminiThoughtSignature(rawSignature string) string {
-	return sigcompat.GeminiReplaySignatureOrBypass(rawSignature, sigcompat.SignatureBlockKindGeminiModelPart)
-}
-
-func applyOpenAIResponsesTextFormatToGemini(out []byte, root gjson.Result) []byte {
-	textFormat := root.Get("text.format")
-	if !textFormat.Exists() {
-		return out
-	}
-
-	formatType := strings.ToLower(strings.TrimSpace(textFormat.Get("type").String()))
-	switch formatType {
-	case "json_object":
-		out, _ = sjson.SetBytes(out, "generationConfig.responseMimeType", "application/json")
-	case "json_schema":
-		out, _ = sjson.SetBytes(out, "generationConfig.responseMimeType", "application/json")
-
-		schema := textFormat.Get("schema")
-		if !schema.Exists() {
-			schema = textFormat.Get("json_schema.schema")
-		}
-		if schema.Exists() {
-			out, _ = sjson.SetRawBytes(out, "generationConfig.responseJsonSchema", []byte(schema.Raw))
-		}
-	}
-
 	return out
 }

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -306,9 +306,7 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 
 	// Handle generation config from OpenAI format
 	if maxOutputTokens := root.Get("max_output_tokens"); maxOutputTokens.Exists() {
-		genConfig := []byte(`{"maxOutputTokens":0}`)
-		genConfig, _ = sjson.SetBytes(genConfig, "maxOutputTokens", maxOutputTokens.Int())
-		out, _ = sjson.SetRawBytes(out, "generationConfig", genConfig)
+		out, _ = sjson.SetBytes(out, "generationConfig.maxOutputTokens", maxOutputTokens.Int())
 	}
 
 	// Handle temperature if present

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -1,51 +1,86 @@
-// Package util provides utility functions for the CLI Proxy API server.
 package util
 
 import (
+	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
-var gjsonPathKeyReplacer = strings.NewReplacer(".", "\\.", "*", "\\*", "?", "\\?")
-
-const placeholderReasonDescription = "Brief explanation of why you are calling this tool"
-
-// Pass a single JSON schema to the functions below — never a whole request document.
+// The functions below implement JSON Schema transformations for Gemini and Antigravity APIs.
 //
-// Cleaning walks every node and rewrites keys by name, and schema keywords such as "title",
-// "format", "default" and "const" are also ordinary data keys. Handing these functions a request
+// Background:
+// Antigravity models have strict JSON Schema requirements. They reject keywords like
+// $schema, additionalProperties: false, and minLength/maxLength. This package cleans and converts
+// standard JSON Schemas to be compatible while preserving semantic information.
+//
+// Reference:
+// - Gemini API docs: Function calling schema requirements
+// - Antigravity API: VALIDATED mode requires specific schema structure
+//
+// A critical design constraint on this file is that its transformations must ONLY be run against
+// schema definitions, never against payload bodies containing actual arguments. The cleaner
 // silently rewrites tool-call arguments inside the conversation history: the guard that protects
 // a key under ".properties" does not apply to argument values, so the keys are deleted outright
 // and replacements such as "enum" and "type" are fabricated. That regression reached production
 // once already; scope every call site to the schema itself.
 
 type jsonSchemaCleanOptions struct {
-	addPlaceholder       bool
-	removeGeminiMetadata bool
-	flattenUnions        bool
-	forceEnumStringType  bool
+	addPlaceholder                    bool
+	antigravitySemantics              bool
+	removeToolTitle                   bool
+	removeGeminiMetadata              bool
+	flattenUnions                     bool
+	forceEnumStringType               bool
+	dropAllEnums                      bool
+	dropBooleanEnums                  bool
+	preserveAdditionalPropertiesFalse bool
 }
 
 // CleanJSONSchemaForAntigravity transforms a tool schema to be compatible with Antigravity API.
 // It handles unsupported keywords, type flattening, and schema simplification while preserving
 // semantic information as description hints and adding placeholders required by VALIDATED mode.
 func CleanJSONSchemaForAntigravity(jsonStr string) string {
+	return CleanJSONSchemaForAntigravityTool(jsonStr, true)
+}
+
+// CleanJSONSchemaForAntigravityTool transforms an Antigravity function schema. The private
+// backend accepts enum members only as strings, but the declared type still controls the JSON
+// type of generated function arguments, so numeric and boolean types must not be rewritten.
+// requirePlaceholder is used only for Claude VALIDATED mode.
+func CleanJSONSchemaForAntigravityTool(jsonStr string, requirePlaceholder bool) string {
 	return cleanJSONSchema(jsonStr, jsonSchemaCleanOptions{
-		addPlaceholder:      true,
-		flattenUnions:       true,
-		forceEnumStringType: true,
+		addPlaceholder:       requirePlaceholder,
+		antigravitySemantics: true,
+		removeToolTitle:      !requirePlaceholder,
+		flattenUnions:        true,
+		dropAllEnums:         true,
 	})
 }
 
 // CleanJSONSchemaForAntigravityResponse transforms a response schema without applying tool-only
 // compatibility rewrites that would alter the client's structured output contract.
+//
+// Sanitization policy:
+//   - Passthrough: type, properties, items, required, description, enum, nullable, and
+//     additionalProperties: false (which Antigravity natively enforces for response schemas).
+//   - Description hints + deletion: unsupported or accepted-but-ignored constraints.
+//   - Flattened: allOf merged into properties/required.
+//   - Projected: anyOf/oneOf select the strongest branch; null branches become nullable:true.
+//   - Resolved: local $ref targets are inlined before $defs/definitions are removed.
+//   - Dropped: unresolved $ref (after a hint), metadata, unsupported object-key constraints,
+//     conditional keywords (after non-conflicting properties are retained), and x-* extensions.
 func CleanJSONSchemaForAntigravityResponse(jsonStr string) string {
-	return cleanJSONSchema(jsonStr, jsonSchemaCleanOptions{})
+	return cleanJSONSchema(jsonStr, jsonSchemaCleanOptions{
+		antigravitySemantics:              true,
+		flattenUnions:                     true,
+		dropBooleanEnums:                  true,
+		preserveAdditionalPropertiesFalse: true,
+	})
 }
 
 // CleanJSONSchemaForGemini transforms a JSON schema to be compatible with Gemini tool calling.
@@ -60,27 +95,45 @@ func CleanJSONSchemaForGemini(jsonStr string) string {
 
 // cleanJSONSchema performs the core cleaning operations on the JSON schema.
 func cleanJSONSchema(jsonStr string, options jsonSchemaCleanOptions) string {
+	trimmed := strings.TrimSpace(jsonStr)
+	if trimmed == "" || trimmed == "{}" || trimmed == "null" {
+		jsonStr = `{"type":"object","properties":{}}`
+	}
 	// Phase 1: Convert and add hints
-	jsonStr = convertRefsToHints(jsonStr)
+	if options.antigravitySemantics {
+		jsonStr = inlineLocalRefs(jsonStr)
+	}
+	jsonStr = convertRefsToHints(jsonStr, options.antigravitySemantics)
 	jsonStr = convertConstToEnum(jsonStr)
 	jsonStr = convertEnumValuesToStrings(jsonStr, options.forceEnumStringType)
 	jsonStr = addEnumHints(jsonStr)
-	jsonStr = addAdditionalPropertiesHints(jsonStr)
-	jsonStr = moveConstraintsToDescription(jsonStr)
+	jsonStr = dropIgnoredEnumsToHints(jsonStr, options)
+	if !options.preserveAdditionalPropertiesFalse {
+		jsonStr = addAdditionalPropertiesHints(jsonStr)
+	}
+	jsonStr = moveConstraintsToDescription(jsonStr, options)
+	if options.antigravitySemantics {
+		jsonStr = moveNotToDescription(jsonStr)
+	}
 
 	// Phase 2: Flatten complex structures
+	jsonStr = mergeConditionals(jsonStr)
 	jsonStr = mergeAllOf(jsonStr)
 	if options.flattenUnions {
 		jsonStr = flattenAnyOfOneOf(jsonStr)
 	}
-	jsonStr = flattenTypeArrays(jsonStr)
+	jsonStr = flattenTypeArrays(jsonStr, options.antigravitySemantics)
 
 	// Phase 3: Cleanup
-	jsonStr = removeUnsupportedKeywords(jsonStr)
+	jsonStr = removeUnsupportedKeywords(jsonStr, options)
 	if options.removeGeminiMetadata {
 		// Gemini schema cleanup: remove nullable/title and placeholder-only fields.
 		jsonStr = removeKeywords(jsonStr, []string{"nullable", "title"})
 		jsonStr = removePlaceholderFields(jsonStr)
+	} else if options.removeToolTitle {
+		// Legacy non-VALIDATED Antigravity requests used the Gemini cleaner, which drops title.
+		// Keep that harmless metadata policy without losing Antigravity's native nullable support.
+		jsonStr = removeKeywords(jsonStr, []string{"title"})
 	}
 	jsonStr = cleanupRequiredFields(jsonStr)
 	// Phase 4: Add placeholder for empty object schemas (Claude VALIDATED mode requirement)
@@ -93,459 +146,781 @@ func cleanJSONSchema(jsonStr string, options jsonSchemaCleanOptions) string {
 
 // removeKeywords removes all occurrences of specified keywords from the JSON schema.
 func removeKeywords(jsonStr string, keywords []string) string {
-	deletePaths := make([]string, 0)
-	pathsByField := findPathsByFields(jsonStr, keywords)
-	for _, key := range keywords {
-		for _, p := range pathsByField[key] {
-			if isPropertyDefinition(trimSuffix(p, "."+key)) {
-				continue
-			}
-			deletePaths = append(deletePaths, p)
+	for _, kw := range keywords {
+		paths := findPaths(jsonStr, kw)
+		sortByDepth(paths)
+		for _, p := range paths {
+			jsonStr, _ = sjson.Delete(jsonStr, p)
 		}
-	}
-	sortByDepth(deletePaths)
-	for _, p := range deletePaths {
-		jsonStr, _ = sjson.Delete(jsonStr, p)
 	}
 	return jsonStr
 }
 
-// removePlaceholderFields removes placeholder-only properties ("_" and "reason") and their required entries.
 func removePlaceholderFields(jsonStr string) string {
-	// Remove "_" placeholder properties.
-	paths := findPaths(jsonStr, "_")
+	paths := findPaths(jsonStr, "properties.reason")
 	sortByDepth(paths)
 	for _, p := range paths {
-		if !strings.HasSuffix(p, ".properties._") {
-			continue
-		}
-		jsonStr, _ = sjson.Delete(jsonStr, p)
-		parentPath := trimSuffix(p, ".properties._")
-		reqPath := joinPath(parentPath, "required")
-		req := gjson.Get(jsonStr, reqPath)
-		if req.IsArray() {
-			var filtered []string
-			for _, r := range req.Array() {
-				if r.String() != "_" {
-					filtered = append(filtered, r.String())
-				}
-			}
-			if len(filtered) == 0 {
-				jsonStr, _ = sjson.Delete(jsonStr, reqPath)
-			} else {
-				updated, _ := sjson.SetBytes([]byte(jsonStr), reqPath, filtered)
-				jsonStr = string(updated)
-			}
-		}
-	}
-
-	// Remove placeholder-only "reason" objects.
-	reasonPaths := findPaths(jsonStr, "reason")
-	sortByDepth(reasonPaths)
-	for _, p := range reasonPaths {
-		if !strings.HasSuffix(p, ".properties.reason") {
+		if !strings.HasSuffix(p, ".properties.reason") && p != "properties.reason" {
 			continue
 		}
 		parentPath := trimSuffix(p, ".properties.reason")
-		props := gjson.Get(jsonStr, joinPath(parentPath, "properties"))
-		if !props.IsObject() || len(props.Map()) != 1 {
+		reasonDesc := gjson.Get(jsonStr, joinPath(p, "description")).String()
+		if !strings.Contains(reasonDesc, "placeholder") && !strings.Contains(reasonDesc, "Brief explanation of why you are calling this tool") {
 			continue
 		}
-		desc := gjson.Get(jsonStr, p+".description").String()
-		if desc != placeholderReasonDescription {
+
+		propsPath := joinPath(parentPath, "properties")
+		propsVal := gjson.Get(jsonStr, propsPath)
+		if len(propsVal.Map()) != 1 {
 			continue
 		}
+
 		jsonStr, _ = sjson.Delete(jsonStr, p)
 		reqPath := joinPath(parentPath, "required")
-		req := gjson.Get(jsonStr, reqPath)
-		if req.IsArray() {
-			var filtered []string
-			for _, r := range req.Array() {
-				if r.String() != "reason" {
-					filtered = append(filtered, r.String())
+		reqVal := gjson.Get(jsonStr, reqPath)
+		if reqVal.IsArray() {
+			var newReq []string
+			for _, item := range reqVal.Array() {
+				if item.String() != "reason" {
+					newReq = append(newReq, item.String())
 				}
 			}
-			if len(filtered) == 0 {
+			if len(newReq) == 0 {
 				jsonStr, _ = sjson.Delete(jsonStr, reqPath)
 			} else {
-				updated, _ := sjson.SetBytes([]byte(jsonStr), reqPath, filtered)
+				updated, _ := sjson.SetBytes([]byte(jsonStr), reqPath, newReq)
 				jsonStr = string(updated)
 			}
 		}
 	}
-
 	return jsonStr
 }
 
-// convertRefsToHints converts $ref to description hints (Lazy Hint strategy).
-func convertRefsToHints(jsonStr string) string {
+// convertRefsToHints handles $ref keywords in schemas.
+// When preserveLocalDefs is true ($defs present), it only converts external $refs to hints
+// and preserves internal $refs so local definitions can be resolved.
+func convertRefsToHints(jsonStr string, preserveLocalDefs bool) string {
+	hasLocalDefs := preserveLocalDefs && (gjson.Get(jsonStr, "$defs").Exists() || gjson.Get(jsonStr, "definitions").Exists())
+
 	paths := findPaths(jsonStr, "$ref")
 	sortByDepth(paths)
 
 	for _, p := range paths {
 		refVal := gjson.Get(jsonStr, p).String()
-		defName := refVal
-		if idx := strings.LastIndex(refVal, "/"); idx >= 0 {
-			defName = refVal[idx+1:]
+
+		// If we have local defs and this is a local ref (starts with #), preserve it for inlining
+		if hasLocalDefs && strings.HasPrefix(refVal, "#") {
+			continue
 		}
 
+		// Extract reference name from URL/path
+		refName := refVal
+		if lastSlash := strings.LastIndex(refVal, "/"); lastSlash != -1 {
+			refName = refVal[lastSlash+1:]
+		}
+
+		// Get parent path (the object containing $ref)
 		parentPath := trimSuffix(p, ".$ref")
-		hint := fmt.Sprintf("See: %s", defName)
-		if existing := gjson.Get(jsonStr, descriptionPath(parentPath)).String(); existing != "" {
-			hint = fmt.Sprintf("%s (%s)", existing, hint)
+		descPath := joinPath(parentPath, "description")
+		currentDesc := gjson.Get(jsonStr, descPath).String()
+
+		hint := fmt.Sprintf("(see %s)", refName)
+		newDesc := appendHint(currentDesc, hint)
+
+		// Set default type to string for unresolved refs
+		typePath := joinPath(parentPath, "type")
+		if !gjson.Get(jsonStr, typePath).Exists() {
+			jsonStr, _ = sjson.Set(jsonStr, typePath, "string")
 		}
 
-		replacement := `{"type":"object","description":""}`
-		replacementBytes, _ := sjson.SetBytes([]byte(replacement), "description", hint)
-		replacement = string(replacementBytes)
-		jsonStr = setRawAt(jsonStr, parentPath, replacement)
+		jsonStr, _ = sjson.Set(jsonStr, descPath, newDesc)
+		jsonStr, _ = sjson.Delete(jsonStr, p)
 	}
+
 	return jsonStr
 }
 
+// inlineLocalRefs resolves internal #/$defs/... and #/definitions/... references by copying definition contents.
+func inlineLocalRefs(jsonStr string) string {
+	defs := gjson.Get(jsonStr, "$defs")
+	if !defs.Exists() {
+		defs = gjson.Get(jsonStr, "definitions")
+	}
+	if !defs.Exists() {
+		return jsonStr
+	}
+
+	// Maximum resolution depth to prevent infinite loops from circular refs
+	const maxDepth = 10
+
+	for depth := 0; depth < maxDepth; depth++ {
+		paths := findPaths(jsonStr, "$ref")
+		if len(paths) == 0 {
+			break
+		}
+
+		hasLocalRef := false
+		sortByDepth(paths)
+
+		for _, p := range paths {
+			refVal := gjson.Get(jsonStr, p).String()
+			if !strings.HasPrefix(refVal, "#/") {
+				continue
+			}
+
+			hasLocalRef = true
+			targetPath := gjsonPathFromJSONPointer(refVal)
+			targetVal := gjson.Get(jsonStr, targetPath)
+
+			parentPath := trimSuffix(p, ".$ref")
+
+			if targetVal.Exists() {
+				// Inline the target definition properties into the parent object
+				targetJSON := targetVal.Raw
+				targetObj := gjson.Parse(targetJSON)
+
+				// Delete the $ref first
+				jsonStr, _ = sjson.Delete(jsonStr, p)
+
+				// Copy all fields from target to parent (preserving existing parent fields)
+				targetObj.ForEach(func(key, val gjson.Result) bool {
+					destPath := joinPath(parentPath, key.String())
+					if !gjson.Get(jsonStr, destPath).Exists() {
+						jsonStr, _ = sjson.SetRaw(jsonStr, destPath, val.Raw)
+					}
+					return true
+				})
+			} else {
+				// Target not found, convert to description hint
+				refName := refVal[strings.LastIndex(refVal, "/")+1:]
+				descPath := joinPath(parentPath, "description")
+				currentDesc := gjson.Get(jsonStr, descPath).String()
+				jsonStr, _ = sjson.Set(jsonStr, descPath, appendHint(currentDesc, fmt.Sprintf("(see %s)", refName)))
+
+				typePath := joinPath(parentPath, "type")
+				if !gjson.Get(jsonStr, typePath).Exists() {
+					jsonStr, _ = sjson.Set(jsonStr, typePath, "string")
+				}
+				jsonStr, _ = sjson.Delete(jsonStr, p)
+			}
+		}
+
+		if !hasLocalRef {
+			break
+		}
+	}
+
+	return jsonStr
+}
+
+// convertConstToEnum converts "const": "value" to "enum": ["value"].
 func convertConstToEnum(jsonStr string) string {
-	for _, p := range findPaths(jsonStr, "const") {
-		val := gjson.Get(jsonStr, p)
-		if !val.Exists() {
-			continue
+	paths := findPaths(jsonStr, "const")
+	sortByDepth(paths)
+
+	for _, p := range paths {
+		constVal := gjson.Get(jsonStr, p)
+		parentPath := trimSuffix(p, ".const")
+		enumPath := joinPath(parentPath, "enum")
+
+		// Create single-element array with the const value
+		var enumArr []any
+		if constVal.Type == gjson.String {
+			enumArr = []any{constVal.String()}
+		} else if constVal.Type == gjson.Number {
+			enumArr = []any{constVal.Num}
+		} else if constVal.Type == gjson.True || constVal.Type == gjson.False {
+			enumArr = []any{constVal.Bool()}
+		} else {
+			enumArr = []any{constVal.Value()}
 		}
-		enumPath := trimSuffix(p, ".const") + ".enum"
-		if !gjson.Get(jsonStr, enumPath).Exists() {
-			updated, _ := sjson.SetBytes([]byte(jsonStr), enumPath, []interface{}{val.Value()})
-			jsonStr = string(updated)
-		}
+
+		jsonStr, _ = sjson.Set(jsonStr, enumPath, enumArr)
+		jsonStr, _ = sjson.Delete(jsonStr, p)
 	}
+
 	return jsonStr
 }
 
-// convertEnumValuesToStrings ensures all enum values use the string representation required by
-// Gemini's proto schema. Tool schemas also require a string type, while response schemas preserve
-// their declared type because the upstream decoder uses it to select the emitted JSON value type.
-func convertEnumValuesToStrings(jsonStr string, forceStringType bool) string {
-	for _, p := range findPaths(jsonStr, "enum") {
-		arr := gjson.Get(jsonStr, p)
-		if !arr.IsArray() {
+// convertEnumValuesToStrings ensures all enum values are strings for Antigravity API.
+func convertEnumValuesToStrings(jsonStr string, forceEnumStringType bool) string {
+	paths := findPaths(jsonStr, "enum")
+	sortByDepth(paths)
+
+	for _, p := range paths {
+		enumVal := gjson.Get(jsonStr, p)
+		if !enumVal.IsArray() {
 			continue
 		}
 
-		var stringVals []string
-		for _, item := range arr.Array() {
-			stringVals = append(stringVals, item.String())
+		var strEnum []string
+		hasNonString := false
+
+		for _, item := range enumVal.Array() {
+			if item.Type != gjson.String {
+				hasNonString = true
+			}
+			strEnum = append(strEnum, item.String())
 		}
 
-		updated, _ := sjson.SetBytes([]byte(jsonStr), p, stringVals)
-		jsonStr = string(updated)
-		if forceStringType {
-			parentPath := trimSuffix(p, ".enum")
-			updated, _ = sjson.SetBytes([]byte(jsonStr), joinPath(parentPath, "type"), "string")
-			jsonStr = string(updated)
+		if hasNonString {
+			jsonStr, _ = sjson.Set(jsonStr, p, strEnum)
+
+			if forceEnumStringType {
+				// Also update type to string if it was something else
+				parentPath := trimSuffix(p, ".enum")
+				typePath := joinPath(parentPath, "type")
+				jsonStr, _ = sjson.Set(jsonStr, typePath, "string")
+			}
 		}
 	}
+
 	return jsonStr
 }
 
+// addEnumHints adds "Allowed: [val1, val2]" to descriptions of enum fields.
 func addEnumHints(jsonStr string) string {
-	for _, p := range findPaths(jsonStr, "enum") {
-		arr := gjson.Get(jsonStr, p)
-		if !arr.IsArray() {
-			continue
-		}
-		items := arr.Array()
-		if len(items) <= 1 || len(items) > 10 {
+	paths := findPaths(jsonStr, "enum")
+	sortByDepth(paths)
+
+	for _, p := range paths {
+		enumVal := gjson.Get(jsonStr, p)
+		if !enumVal.IsArray() {
 			continue
 		}
 
-		var vals []string
-		for _, item := range items {
-			vals = append(vals, item.String())
+		var values []string
+		for _, item := range enumVal.Array() {
+			values = append(values, item.String())
 		}
-		jsonStr = appendHint(jsonStr, trimSuffix(p, ".enum"), "Allowed: "+strings.Join(vals, ", "))
+
+		parentPath := trimSuffix(p, ".enum")
+		descPath := joinPath(parentPath, "description")
+		currentDesc := gjson.Get(jsonStr, descPath).String()
+
+		hint := fmt.Sprintf("(Allowed: %s)", strings.Join(values, ", "))
+		newDesc := appendHint(currentDesc, hint)
+
+		jsonStr, _ = sjson.Set(jsonStr, descPath, newDesc)
 	}
+
 	return jsonStr
 }
 
+func dropIgnoredEnumsToHints(jsonStr string, options jsonSchemaCleanOptions) string {
+	paths := findPaths(jsonStr, "enum")
+	sortByDepth(paths)
+
+	for _, p := range paths {
+		enumVal := gjson.Get(jsonStr, p)
+		if !enumVal.IsArray() {
+			continue
+		}
+
+		parentPath := trimSuffix(p, ".enum")
+		typeVal := gjson.Get(jsonStr, joinPath(parentPath, "type")).String()
+		shouldDrop := options.dropAllEnums || (options.dropBooleanEnums && typeVal == "boolean")
+		if !shouldDrop {
+			continue
+		}
+
+		jsonStr, _ = sjson.Delete(jsonStr, p)
+	}
+
+	return jsonStr
+}
+
+// addAdditionalPropertiesHints adds hints for additionalProperties constraints.
 func addAdditionalPropertiesHints(jsonStr string) string {
-	for _, p := range findPaths(jsonStr, "additionalProperties") {
-		if gjson.Get(jsonStr, p).Type == gjson.False {
-			jsonStr = appendHint(jsonStr, trimSuffix(p, ".additionalProperties"), "No extra properties allowed")
+	paths := findPaths(jsonStr, "additionalProperties")
+	sortByDepth(paths)
+
+	for _, p := range paths {
+		addPropVal := gjson.Get(jsonStr, p)
+		parentPath := trimSuffix(p, ".additionalProperties")
+		descPath := joinPath(parentPath, "description")
+		currentDesc := gjson.Get(jsonStr, descPath).String()
+
+		var hint string
+		if addPropVal.Type == gjson.False {
+			hint = "(No extra properties allowed)"
+		} else if addPropVal.IsObject() {
+			schemaType := addPropVal.Get("type").String()
+			if schemaType != "" {
+				hint = fmt.Sprintf("(Additional properties type: %s)", schemaType)
+			}
+		}
+
+		if hint != "" {
+			newDesc := appendHint(currentDesc, hint)
+			jsonStr, _ = sjson.Set(jsonStr, descPath, newDesc)
 		}
 	}
+
 	return jsonStr
 }
 
-var unsupportedConstraints = []string{
-	"minLength", "maxLength", "exclusiveMinimum", "exclusiveMaximum",
-	"pattern", "minItems", "maxItems", "uniqueItems", "format",
-	"default", "examples", // Claude rejects these in VALIDATED mode
-}
+// moveConstraintsToDescription converts numeric/string/array constraints to description hints.
+func moveConstraintsToDescription(jsonStr string, options jsonSchemaCleanOptions) string {
+	constraintDefs := []struct {
+		keyword string
+		format  string
+	}{
+		{"minLength", "minLength: %v"},
+		{"maxLength", "maxLength: %v"},
+		{"minimum", "minimum: %v"},
+		{"maximum", "maximum: %v"},
+		{"exclusiveMinimum", "exclusiveMinimum: %v"},
+		{"exclusiveMaximum", "exclusiveMaximum: %v"},
+		{"minItems", "minItems: %v"},
+		{"maxItems", "maxItems: %v"},
+		{"pattern", "pattern: %v"},
+		{"format", "format: %v"},
+		{"default", "default: %v"},
+	}
 
-func moveConstraintsToDescription(jsonStr string) string {
-	pathsByField := findPathsByFields(jsonStr, unsupportedConstraints)
-	for _, key := range unsupportedConstraints {
-		for _, p := range pathsByField[key] {
+	for _, cd := range constraintDefs {
+		paths := findPaths(jsonStr, cd.keyword)
+		sortByDepth(paths)
+
+		for _, p := range paths {
 			val := gjson.Get(jsonStr, p)
-			if !val.Exists() || val.IsObject() || val.IsArray() {
-				continue
-			}
-			parentPath := trimSuffix(p, "."+key)
-			if isPropertyDefinition(parentPath) {
-				continue
-			}
-			jsonStr = appendHint(jsonStr, parentPath, fmt.Sprintf("%s: %s", key, val.String()))
+			parentPath := trimSuffix(p, "."+cd.keyword)
+			descPath := joinPath(parentPath, "description")
+			currentDesc := gjson.Get(jsonStr, descPath).String()
+
+			hint := fmt.Sprintf("("+cd.format+")", val.Value())
+			newDesc := appendHint(currentDesc, hint)
+
+			jsonStr, _ = sjson.Set(jsonStr, descPath, newDesc)
 		}
 	}
+
 	return jsonStr
 }
 
+// moveNotToDescription converts "not" schemas to description hints.
+func moveNotToDescription(jsonStr string) string {
+	paths := findPaths(jsonStr, "not")
+	sortByDepth(paths)
+
+	for _, p := range paths {
+		notVal := gjson.Get(jsonStr, p)
+		parentPath := trimSuffix(p, ".not")
+		descPath := joinPath(parentPath, "description")
+		currentDesc := gjson.Get(jsonStr, descPath).String()
+
+		var hint string
+		if notVal.IsObject() {
+			if notType := notVal.Get("type").String(); notType != "" {
+				hint = fmt.Sprintf("(Must NOT be type: %s)", notType)
+			} else if notEnum := notVal.Get("enum"); notEnum.IsArray() {
+				var values []string
+				for _, item := range notEnum.Array() {
+					values = append(values, item.String())
+				}
+				hint = fmt.Sprintf("(Must NOT be: %s)", strings.Join(values, ", "))
+			}
+		}
+
+		if hint != "" {
+			newDesc := appendHint(currentDesc, hint)
+			jsonStr, _ = sjson.Set(jsonStr, descPath, newDesc)
+		}
+		jsonStr, _ = sjson.Delete(jsonStr, p)
+	}
+
+	return jsonStr
+}
+
+// mergeConditionals flattens if/then/else structures by preserving properties from then/else branches.
+func mergeConditionals(jsonStr string) string {
+	paths := findPaths(jsonStr, "if")
+	sortByDepth(paths)
+
+	for _, p := range paths {
+		parentPath := trimSuffix(p, ".if")
+
+		thenPath := joinPath(parentPath, "then")
+		elsePath := joinPath(parentPath, "else")
+
+		thenVal := gjson.Get(jsonStr, thenPath)
+		elseVal := gjson.Get(jsonStr, elsePath)
+
+		// Merge properties from "then" branch
+		if thenVal.Exists() && thenVal.IsObject() {
+			thenProps := thenVal.Get("properties")
+			if thenProps.Exists() && thenProps.IsObject() {
+				thenProps.ForEach(func(key, val gjson.Result) bool {
+					destPath := joinPath(parentPath, "properties."+escapeGJSONPathKey(key.String()))
+					if !gjson.Get(jsonStr, destPath).Exists() {
+						jsonStr, _ = sjson.SetRaw(jsonStr, destPath, val.Raw)
+					}
+					return true
+				})
+			}
+		}
+
+		// Merge properties from "else" branch
+		if elseVal.Exists() && elseVal.IsObject() {
+			elseProps := elseVal.Get("properties")
+			if elseProps.Exists() && elseProps.IsObject() {
+				elseProps.ForEach(func(key, val gjson.Result) bool {
+					destPath := joinPath(parentPath, "properties."+escapeGJSONPathKey(key.String()))
+					if !gjson.Get(jsonStr, destPath).Exists() {
+						jsonStr, _ = sjson.SetRaw(jsonStr, destPath, val.Raw)
+					}
+					return true
+				})
+			}
+		}
+
+		// Delete if/then/else keywords
+		jsonStr, _ = sjson.Delete(jsonStr, p)
+		jsonStr, _ = sjson.Delete(jsonStr, thenPath)
+		jsonStr, _ = sjson.Delete(jsonStr, elsePath)
+	}
+
+	return jsonStr
+}
+
+// mergeAllOf merges allOf schemas into the parent schema.
 func mergeAllOf(jsonStr string) string {
 	paths := findPaths(jsonStr, "allOf")
 	sortByDepth(paths)
 
 	for _, p := range paths {
-		allOf := gjson.Get(jsonStr, p)
-		if !allOf.IsArray() {
+		allOfVal := gjson.Get(jsonStr, p)
+		if !allOfVal.IsArray() {
 			continue
 		}
+
 		parentPath := trimSuffix(p, ".allOf")
 
-		for _, item := range allOf.Array() {
-			if props := item.Get("properties"); props.IsObject() {
-				props.ForEach(func(key, value gjson.Result) bool {
-					destPath := joinPath(parentPath, "properties."+escapeGJSONPathKey(key.String()))
-					updated, _ := sjson.SetRawBytes([]byte(jsonStr), destPath, []byte(value.Raw))
-					jsonStr = string(updated)
-					return true
-				})
-			}
-			if req := item.Get("required"); req.IsArray() {
-				reqPath := joinPath(parentPath, "required")
-				current := getStrings(jsonStr, reqPath)
-				for _, r := range req.Array() {
-					if s := r.String(); !contains(current, s) {
-						current = append(current, s)
-					}
-				}
-				updated, _ := sjson.SetBytes([]byte(jsonStr), reqPath, current)
-				jsonStr = string(updated)
-			}
-		}
-		jsonStr, _ = sjson.Delete(jsonStr, p)
-	}
-	return jsonStr
-}
-
-func flattenAnyOfOneOf(jsonStr string) string {
-	for _, key := range []string{"anyOf", "oneOf"} {
-		paths := findPaths(jsonStr, key)
-		sortByDepth(paths)
-
-		for _, p := range paths {
-			arr := gjson.Get(jsonStr, p)
-			if !arr.IsArray() || len(arr.Array()) == 0 {
+		for _, branch := range allOfVal.Array() {
+			if !branch.IsObject() {
 				continue
 			}
 
-			parentPath := trimSuffix(p, "."+key)
-			parentDesc := gjson.Get(jsonStr, descriptionPath(parentPath)).String()
-
-			items := arr.Array()
-			bestIdx, allTypes := selectBest(items)
-			selected := items[bestIdx].Raw
-
-			if parentDesc != "" {
-				selected = mergeDescriptionRaw(selected, parentDesc)
+			// Merge properties
+			props := branch.Get("properties")
+			if props.Exists() && props.IsObject() {
+				props.ForEach(func(key, val gjson.Result) bool {
+					destPath := joinPath(parentPath, "properties."+escapeGJSONPathKey(key.String()))
+					if !gjson.Get(jsonStr, destPath).Exists() {
+						jsonStr, _ = sjson.SetRaw(jsonStr, destPath, val.Raw)
+					}
+					return true
+				})
 			}
 
-			if len(allTypes) > 1 {
-				hint := "Accepts: " + strings.Join(allTypes, " | ")
-				selected = appendHintRaw(selected, hint)
+			// Merge required
+			req := branch.Get("required")
+			if req.Exists() && req.IsArray() {
+				parentReqPath := joinPath(parentPath, "required")
+				parentReq := gjson.Get(jsonStr, parentReqPath)
+
+				var mergedReq []string
+				if parentReq.Exists() && parentReq.IsArray() {
+					for _, item := range parentReq.Array() {
+						mergedReq = append(mergedReq, item.String())
+					}
+				}
+				for _, item := range req.Array() {
+					if !contains(mergedReq, item.String()) {
+						mergedReq = append(mergedReq, item.String())
+					}
+				}
+				jsonStr, _ = sjson.Set(jsonStr, parentReqPath, mergedReq)
 			}
 
-			jsonStr = setRawAt(jsonStr, parentPath, selected)
+			// Copy type if parent doesn't have one
+			parentTypePath := joinPath(parentPath, "type")
+			if !gjson.Get(jsonStr, parentTypePath).Exists() {
+				branchType := branch.Get("type")
+				if branchType.Exists() {
+					jsonStr, _ = sjson.Set(jsonStr, parentTypePath, branchType.String())
+				}
+			}
 		}
+
+		jsonStr, _ = sjson.Delete(jsonStr, p)
 	}
+
 	return jsonStr
 }
 
-func selectBest(items []gjson.Result) (bestIdx int, types []string) {
-	bestScore := -1
-	for i, item := range items {
-		t := item.Get("type").String()
-		score := 0
+// flattenAnyOfOneOf handles anyOf and oneOf by selecting the best branch and adding hints.
+func flattenAnyOfOneOf(jsonStr string) string {
+	for _, unionKey := range []string{"anyOf", "oneOf"} {
+		paths := findPaths(jsonStr, unionKey)
+		sortByDepth(paths)
 
-		switch {
-		case t == "object" || item.Get("properties").Exists():
-			score, t = 3, orDefault(t, "object")
-		case t == "array" || item.Get("items").Exists():
-			score, t = 2, orDefault(t, "array")
-		case t != "" && t != "null":
-			score = 1
-		default:
-			t = orDefault(t, "null")
-		}
+		for _, p := range paths {
+			unionVal := gjson.Get(jsonStr, p)
+			if !unionVal.IsArray() {
+				continue
+			}
 
-		if t != "" {
-			types = append(types, t)
-		}
-		if score > bestScore {
-			bestScore, bestIdx = score, i
+			parentPath := trimSuffix(p, "."+unionKey)
+			branches := unionVal.Array()
+
+			// Check for nullable pattern: [T, null]
+			hasNull := false
+			var nonNullBranches []gjson.Result
+			for _, b := range branches {
+				if b.Get("type").String() == "null" {
+					hasNull = true
+				} else {
+					nonNullBranches = append(nonNullBranches, b)
+				}
+			}
+
+			if hasNull && len(nonNullBranches) == 1 {
+				// Simple nullable: set nullable=true and use the non-null branch
+				target := nonNullBranches[0]
+				jsonStr, _ = sjson.Delete(jsonStr, p)
+
+				target.ForEach(func(key, val gjson.Result) bool {
+					destPath := joinPath(parentPath, key.String())
+					jsonStr, _ = sjson.SetRaw(jsonStr, destPath, val.Raw)
+					return true
+				})
+
+				jsonStr, _ = sjson.Set(jsonStr, joinPath(parentPath, "nullable"), true)
+				descPath := joinPath(parentPath, "description")
+				currentDesc := gjson.Get(jsonStr, descPath).String()
+				jsonStr, _ = sjson.Set(jsonStr, descPath, appendHint(currentDesc, "(nullable)"))
+				continue
+			}
+
+			// Multi-branch union: pick the best branch and add hints about alternatives
+			bestBranch := selectBestUnionBranch(branches)
+			var altTypes []string
+			for _, b := range branches {
+				t := b.Get("type").String()
+				if t != "" && !contains(altTypes, t) {
+					altTypes = append(altTypes, t)
+				}
+			}
+
+			jsonStr, _ = sjson.Delete(jsonStr, p)
+
+			if bestBranch.Exists() && bestBranch.IsObject() {
+				bestBranch.ForEach(func(key, val gjson.Result) bool {
+					destPath := joinPath(parentPath, key.String())
+					if !gjson.Get(jsonStr, destPath).Exists() {
+						jsonStr, _ = sjson.SetRaw(jsonStr, destPath, val.Raw)
+					}
+					return true
+				})
+			}
+
+			if len(altTypes) > 1 {
+				descPath := joinPath(parentPath, "description")
+				currentDesc := gjson.Get(jsonStr, descPath).String()
+				hint := fmt.Sprintf("(Accepts: %s)", strings.Join(altTypes, " | "))
+				jsonStr, _ = sjson.Set(jsonStr, descPath, appendHint(currentDesc, hint))
+			}
 		}
 	}
-	return
+
+	return jsonStr
 }
 
-func flattenTypeArrays(jsonStr string) string {
+// selectBestUnionBranch picks the most informative branch from an anyOf/oneOf array.
+// Priority: object with properties > object > array > string > number > boolean > null.
+func selectBestUnionBranch(branches []gjson.Result) gjson.Result {
+	if len(branches) == 0 {
+		return gjson.Result{}
+	}
+
+	bestScore := -1
+	var best gjson.Result
+
+	for _, b := range branches {
+		score := scoreBranch(b)
+		if score > bestScore {
+			bestScore = score
+			best = b
+		}
+	}
+
+	return best
+}
+
+func scoreBranch(b gjson.Result) int {
+	if !b.IsObject() {
+		return 0
+	}
+
+	t := b.Get("type").String()
+	switch t {
+	case "object":
+		if props := b.Get("properties"); props.Exists() && len(props.Map()) > 0 {
+			return 100 + len(props.Map())
+		}
+		return 90
+	case "array":
+		if items := b.Get("items"); items.Exists() {
+			return 80
+		}
+		return 70
+	case "string":
+		if b.Get("enum").Exists() {
+			return 65
+		}
+		return 60
+	case "number", "integer":
+		return 50
+	case "boolean":
+		return 40
+	case "null":
+		return 10
+	default:
+		// Untyped object with properties
+		if props := b.Get("properties"); props.Exists() && len(props.Map()) > 0 {
+			return 95 + len(props.Map())
+		}
+		return 30
+	}
+}
+
+// flattenTypeArrays converts "type": ["string", "null"] to "type": "string", "nullable": true.
+func flattenTypeArrays(jsonStr string, preserveNullable bool) string {
 	paths := findPaths(jsonStr, "type")
 	sortByDepth(paths)
 
-	nullableFields := make(map[string][]string)
-
 	for _, p := range paths {
-		res := gjson.Get(jsonStr, p)
-		if !res.IsArray() || len(res.Array()) == 0 {
+		typeVal := gjson.Get(jsonStr, p)
+		if !typeVal.IsArray() {
 			continue
 		}
 
+		types := typeVal.Array()
 		hasNull := false
 		var nonNullTypes []string
-		for _, item := range res.Array() {
-			s := item.String()
-			if s == "null" {
+
+		for _, t := range types {
+			if t.String() == "null" {
 				hasNull = true
-			} else if s != "" {
-				nonNullTypes = append(nonNullTypes, s)
+			} else {
+				nonNullTypes = append(nonNullTypes, t.String())
 			}
 		}
-
-		firstType := "string"
-		if len(nonNullTypes) > 0 {
-			firstType = nonNullTypes[0]
-		}
-
-		updated, _ := sjson.SetBytes([]byte(jsonStr), p, firstType)
-		jsonStr = string(updated)
 
 		parentPath := trimSuffix(p, ".type")
-		if len(nonNullTypes) > 1 {
-			hint := "Accepts: " + strings.Join(nonNullTypes, " | ")
-			jsonStr = appendHint(jsonStr, parentPath, hint)
+		primaryType := "string" // safe default
+		if len(nonNullTypes) > 0 {
+			primaryType = nonNullTypes[0]
 		}
 
-		if hasNull {
-			parts := splitGJSONPath(p)
-			if len(parts) >= 3 && parts[len(parts)-3] == "properties" {
-				fieldNameEscaped := parts[len(parts)-2]
-				fieldName := unescapeGJSONPathKey(fieldNameEscaped)
-				objectPath := strings.Join(parts[:len(parts)-3], ".")
-				nullableFields[objectPath] = append(nullableFields[objectPath], fieldName)
+		jsonStr, _ = sjson.Set(jsonStr, p, primaryType)
 
-				propPath := joinPath(objectPath, "properties."+fieldNameEscaped)
-				jsonStr = appendHint(jsonStr, propPath, "(nullable)")
+		if hasNull {
+			if preserveNullable {
+				jsonStr, _ = sjson.Set(jsonStr, joinPath(parentPath, "nullable"), true)
 			}
+			descPath := joinPath(parentPath, "description")
+			currentDesc := gjson.Get(jsonStr, descPath).String()
+			jsonStr, _ = sjson.Set(jsonStr, descPath, appendHint(currentDesc, "(nullable)"))
+		}
+
+		if len(nonNullTypes) > 1 {
+			descPath := joinPath(parentPath, "description")
+			currentDesc := gjson.Get(jsonStr, descPath).String()
+			hint := fmt.Sprintf("(Accepts: %s)", strings.Join(nonNullTypes, " | "))
+			jsonStr, _ = sjson.Set(jsonStr, descPath, appendHint(currentDesc, hint))
 		}
 	}
 
-	for objectPath, fields := range nullableFields {
-		reqPath := joinPath(objectPath, "required")
-		req := gjson.Get(jsonStr, reqPath)
+	return jsonStr
+}
+
+// removeUnsupportedKeywords strips keywords not supported by Antigravity/Gemini APIs.
+func removeUnsupportedKeywords(jsonStr string, options jsonSchemaCleanOptions) string {
+	unsupported := []string{
+		"$schema", "$id", "$comment", "$defs", "definitions",
+		"patternProperties", "propertyNames", "dependencies",
+		"dependentRequired", "dependentSchemas",
+		"unevaluatedProperties", "unevaluatedItems",
+		"contains", "minContains", "maxContains",
+		"uniqueItems", "prefixItems",
+		"readOnly", "writeOnly", "examples",
+	}
+	if !options.preserveAdditionalPropertiesFalse {
+		unsupported = append(unsupported, "additionalProperties")
+	}
+
+	for _, kw := range unsupported {
+		paths := findPaths(jsonStr, kw)
+		sortByDepth(paths)
+		for _, p := range paths {
+			jsonStr, _ = sjson.Delete(jsonStr, p)
+		}
+	}
+
+	// Remove x-* custom extensions
+	jsonStr = removeCustomExtensions(jsonStr)
+
+	return jsonStr
+}
+
+// removeCustomExtensions removes properties starting with "x-".
+func removeCustomExtensions(jsonStr string) string {
+	var walk func(path string, val gjson.Result)
+	var pathsToDelete []string
+
+	walk = func(path string, val gjson.Result) {
+		if val.IsObject() {
+			val.ForEach(func(key, child gjson.Result) bool {
+				k := key.String()
+				currentPath := joinPath(path, escapeGJSONPathKey(k))
+				if strings.HasPrefix(k, "x-") {
+					pathsToDelete = append(pathsToDelete, currentPath)
+				} else {
+					walk(currentPath, child)
+				}
+				return true
+			})
+		} else if val.IsArray() {
+			val.ForEach(func(idx, child gjson.Result) bool {
+				currentPath := joinPath(path, idx.String())
+				walk(currentPath, child)
+				return true
+			})
+		}
+	}
+
+	root := gjson.Parse(jsonStr)
+	walk("", root)
+
+	sortByDepth(pathsToDelete)
+	for _, p := range pathsToDelete {
+		jsonStr, _ = sjson.Delete(jsonStr, p)
+	}
+
+	return jsonStr
+}
+
+// cleanupRequiredFields removes required entries that don't exist in properties.
+func cleanupRequiredFields(jsonStr string) string {
+	paths := findPaths(jsonStr, "required")
+	sortByDepth(paths)
+
+	for _, p := range paths {
+		req := gjson.Get(jsonStr, p)
 		if !req.IsArray() {
 			continue
 		}
 
-		var filtered []string
-		for _, r := range req.Array() {
-			if !contains(fields, r.String()) {
-				filtered = append(filtered, r.String())
-			}
-		}
-
-		if len(filtered) == 0 {
-			jsonStr, _ = sjson.Delete(jsonStr, reqPath)
-		} else {
-			updated, _ := sjson.SetBytes([]byte(jsonStr), reqPath, filtered)
-			jsonStr = string(updated)
-		}
-	}
-	return jsonStr
-}
-
-func removeUnsupportedKeywords(jsonStr string) string {
-	keywords := append(unsupportedConstraints,
-		"$schema", "$defs", "definitions", "const", "$ref", "$id", "additionalProperties",
-		"propertyNames", "patternProperties", // Gemini doesn't support these schema keywords
-		"$comment", "enumDescriptions", "enumTitles", "prefill", "deprecated", // Schema metadata fields unsupported by Gemini
-	)
-
-	deletePaths := make([]string, 0)
-	pathsByField := findPathsByFields(jsonStr, keywords)
-	for _, key := range keywords {
-		for _, p := range pathsByField[key] {
-			if isPropertyDefinition(trimSuffix(p, "."+key)) {
-				continue
-			}
-			deletePaths = append(deletePaths, p)
-		}
-	}
-	sortByDepth(deletePaths)
-	for _, p := range deletePaths {
-		jsonStr, _ = sjson.Delete(jsonStr, p)
-	}
-	// Remove x-* extension fields (e.g., x-google-enum-descriptions) that are not supported by Gemini API
-	jsonStr = removeExtensionFields(jsonStr)
-	return jsonStr
-}
-
-// removeExtensionFields removes all x-* extension fields from the JSON schema.
-// These are OpenAPI/JSON Schema extension fields that Google APIs don't recognize.
-func removeExtensionFields(jsonStr string) string {
-	var paths []string
-	walkForExtensions(gjson.Parse(jsonStr), "", &paths)
-	// walkForExtensions returns paths in a way that deeper paths are added before their ancestors
-	// when they are not deleted wholesale, but since we skip children of deleted x-* nodes,
-	// any collected path is safe to delete. We still use DeleteBytes for efficiency.
-
-	b := []byte(jsonStr)
-	for _, p := range paths {
-		b, _ = sjson.DeleteBytes(b, p)
-	}
-	return string(b)
-}
-
-func walkForExtensions(value gjson.Result, path string, paths *[]string) {
-	if value.IsArray() {
-		arr := value.Array()
-		for i := len(arr) - 1; i >= 0; i-- {
-			walkForExtensions(arr[i], joinPath(path, strconv.Itoa(i)), paths)
-		}
-		return
-	}
-
-	if value.IsObject() {
-		value.ForEach(func(key, val gjson.Result) bool {
-			keyStr := key.String()
-			safeKey := escapeGJSONPathKey(keyStr)
-			childPath := joinPath(path, safeKey)
-
-			// If it's an extension field, we delete it and don't need to look at its children.
-			if strings.HasPrefix(keyStr, "x-") && !isPropertyDefinition(path) {
-				*paths = append(*paths, childPath)
-				return true
-			}
-
-			walkForExtensions(val, childPath, paths)
-			return true
-		})
-	}
-}
-
-func cleanupRequiredFields(jsonStr string) string {
-	for _, p := range findPaths(jsonStr, "required") {
 		parentPath := trimSuffix(p, ".required")
 		propsPath := joinPath(parentPath, "properties")
-
-		req := gjson.Get(jsonStr, p)
 		props := gjson.Get(jsonStr, propsPath)
-		if !req.IsArray() || !props.IsObject() {
+
+		if !props.Exists() || !props.IsObject() {
+			// No properties, remove required entirely
+			jsonStr, _ = sjson.Delete(jsonStr, p)
 			continue
 		}
 
@@ -592,97 +967,120 @@ func addEmptySchemaPlaceholder(jsonStr string) string {
 		propsVal := gjson.Get(jsonStr, propsPath)
 		reqPath := joinPath(parentPath, "required")
 		reqVal := gjson.Get(jsonStr, reqPath)
-		hasRequiredProperties := reqVal.IsArray() && len(reqVal.Array()) > 0
 
-		needsPlaceholder := false
-		if !propsVal.Exists() {
-			// No properties field at all
-			needsPlaceholder = true
-		} else if propsVal.IsObject() && len(propsVal.Map()) == 0 {
-			// Empty properties object
-			needsPlaceholder = true
-		}
-
-		if needsPlaceholder {
-			// Add placeholder "reason" property
-			reasonPath := joinPath(propsPath, "reason")
-			updated, _ := sjson.SetBytes([]byte(jsonStr), reasonPath+".type", "string")
-			jsonStr = string(updated)
-			updated, _ = sjson.SetBytes([]byte(jsonStr), reasonPath+".description", placeholderReasonDescription)
-			jsonStr = string(updated)
-
-			// Add to required array
-			updated, _ = sjson.SetBytes([]byte(jsonStr), reqPath, []string{"reason"})
-			jsonStr = string(updated)
-			continue
-		}
-
-		// If schema has properties but none are required, add a minimal placeholder.
-		if propsVal.IsObject() && !hasRequiredProperties {
-			// DO NOT add placeholder if it's a top-level schema (parentPath is empty)
-			// or if we've already added a placeholder reason above.
-			if parentPath == "" {
-				continue
+		// If properties is missing or empty, add placeholder
+		if !propsVal.Exists() || len(propsVal.Map()) == 0 {
+			placeholderProp := `{"reason":{"type":"string","description":"Brief explanation of why you are calling this tool"}}`
+			jsonStr, _ = sjson.SetRaw(jsonStr, propsPath, placeholderProp)
+			if !reqVal.Exists() || len(reqVal.Array()) == 0 {
+				jsonStr, _ = sjson.Set(jsonStr, reqPath, []string{"reason"})
 			}
-			placeholderPath := joinPath(propsPath, "_")
-			if !gjson.Get(jsonStr, placeholderPath).Exists() {
-				updated, _ := sjson.SetBytes([]byte(jsonStr), placeholderPath+".type", "boolean")
-				jsonStr = string(updated)
-			}
-			updated, _ := sjson.SetBytes([]byte(jsonStr), reqPath, []string{"_"})
-			jsonStr = string(updated)
 		}
 	}
 
 	return jsonStr
 }
 
-// --- Helpers ---
+// Helper functions
 
-func findPaths(jsonStr, field string) []string {
-	var paths []string
-	Walk(gjson.Parse(jsonStr), "", field, &paths)
-	return paths
-}
+// findPaths finds all dot-separated GJSON paths in jsonStr matching targetKey.
+func findPaths(jsonStr string, targetKey string) []string {
+	var result []string
+	root := gjson.Parse(jsonStr)
 
-func findPathsByFields(jsonStr string, fields []string) map[string][]string {
-	set := make(map[string]struct{}, len(fields))
-	for _, field := range fields {
-		set[field] = struct{}{}
+	// Direct check for root target
+	if targetKey == "type" && root.Get("type").Exists() {
+		result = append(result, "type")
 	}
-	paths := make(map[string][]string, len(set))
-	walkForFields(gjson.Parse(jsonStr), "", set, paths)
-	return paths
+
+	findPathsRecursive(root, "", targetKey, &result)
+	return result
 }
 
-func walkForFields(value gjson.Result, path string, fields map[string]struct{}, paths map[string][]string) {
-	switch value.Type {
-	case gjson.JSON:
-		value.ForEach(func(key, val gjson.Result) bool {
-			keyStr := key.String()
-			safeKey := escapeGJSONPathKey(keyStr)
+func findPathsRecursive(node gjson.Result, currentPath string, targetKey string, result *[]string) {
+	if !node.IsObject() && !node.IsArray() {
+		return
+	}
 
-			var childPath string
-			if path == "" {
-				childPath = safeKey
-			} else {
-				childPath = path + "." + safeKey
+	if node.IsObject() {
+		node.ForEach(func(key, val gjson.Result) bool {
+			k := key.String()
+			// Don't recurse into properties map when searching for keywords
+			if k == "properties" && targetKey != "properties" && targetKey != "properties.reason" {
+				// But do search inside each property definition
+				val.ForEach(func(propName, propVal gjson.Result) bool {
+					escapedPropName := escapeGJSONPathKey(propName.String())
+					propPath := joinPath(currentPath, "properties."+escapedPropName)
+					if targetKey == "type" && propVal.Get("type").Exists() {
+						*result = append(*result, joinPath(propPath, "type"))
+					}
+					findPathsRecursive(propVal, propPath, targetKey, result)
+					return true
+				})
+				return true
 			}
 
-			if _, ok := fields[keyStr]; ok {
-				paths[keyStr] = append(paths[keyStr], childPath)
+			path := joinPath(currentPath, escapeGJSONPathKey(k))
+			if k == targetKey {
+				*result = append(*result, path)
 			}
-
-			walkForFields(val, childPath, fields, paths)
+			findPathsRecursive(val, path, targetKey, result)
 			return true
 		})
-	case gjson.String, gjson.Number, gjson.True, gjson.False, gjson.Null:
-		// Terminal types - no further traversal needed
+	} else if node.IsArray() {
+		node.ForEach(func(idx, val gjson.Result) bool {
+			path := joinPath(currentPath, idx.String())
+			findPathsRecursive(val, path, targetKey, result)
+			return true
+		})
 	}
+}
+
+// escapeGJSONPathKey escapes dots and colons in object keys for GJSON pathing.
+func escapeGJSONPathKey(key string) string {
+	// GJSON uses \. for literal dots in keys
+	key = strings.ReplaceAll(key, "\\", "\\\\")
+	key = strings.ReplaceAll(key, ".", "\\.")
+	return key
+}
+
+// splitGJSONPath splits a GJSON path taking escaped dots into account.
+func splitGJSONPath(path string) []string {
+	if path == "" {
+		return nil
+	}
+	var parts []string
+	var current strings.Builder
+	escaped := false
+
+	for i := 0; i < len(path); i++ {
+		ch := path[i]
+		if escaped {
+			current.WriteByte(ch)
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		if ch == '.' {
+			parts = append(parts, current.String())
+			current.Reset()
+			continue
+		}
+		current.WriteByte(ch)
+	}
+	if current.Len() > 0 {
+		parts = append(parts, current.String())
+	}
+	return parts
 }
 
 func sortByDepth(paths []string) {
-	sort.Slice(paths, func(i, j int) bool { return len(paths[i]) > len(paths[j]) })
+	sort.SliceStable(paths, func(i, j int) bool {
+		return len(splitGJSONPath(paths[i])) > len(splitGJSONPath(paths[j]))
+	})
 }
 
 func trimSuffix(path, suffix string) string {
@@ -696,184 +1094,39 @@ func joinPath(base, suffix string) string {
 	if base == "" {
 		return suffix
 	}
+	if suffix == "" {
+		return base
+	}
 	return base + "." + suffix
 }
 
-func setRawAt(jsonStr, path, value string) string {
-	if path == "" {
-		return value
-	}
-	result, _ := sjson.SetRawBytes([]byte(jsonStr), path, []byte(value))
-	return string(result)
-}
-
-// schemaNameMapKeywords are the schema keywords whose value maps author-chosen names to
-// subschemas. A key directly under one of them is a name, never a schema keyword.
-var schemaNameMapKeywords = map[string]struct{}{
-	"properties":        {},
-	"patternProperties": {},
-	"dependentSchemas":  {},
-	"$defs":             {},
-	"definitions":       {},
-}
-
-// isPropertyDefinition reports whether path points at a map whose keys are names chosen by the
-// tool author, so a key spelled like a schema keyword there must be preserved.
-//
-// A trailing ".properties" is not enough to tell: a tool may declare a property named
-// "properties", and the schema for that property then sits at a path ending in ".properties" while
-// being an ordinary schema node. Classifying it as a name map skipped every cleaning pass inside
-// it, so unsupported keywords such as "propertyNames" reached the private Gemini backend, which
-// rejects unknown fields with a 400.
-//
-// Each name-map keyword at the end of the path therefore flips the answer, because the node it
-// names is a map only when its own parent is a schema: "properties" is a map,
-// "properties.properties" the schema of a property named "properties", and
-// "properties.properties.properties" that schema's own map. Only the trailing run matters, so any
-// prefix the caller nests the schema under is ignored.
-func isPropertyDefinition(path string) bool {
-	segments := splitGJSONPath(path)
-	trailing := 0
-	for i := len(segments) - 1; i >= 0; i-- {
-		if _, ok := schemaNameMapKeywords[unescapeGJSONPathKey(segments[i])]; !ok {
-			break
-		}
-		trailing++
-	}
-	return trailing%2 == 1
-}
-
-func descriptionPath(parentPath string) string {
-	if parentPath == "" || parentPath == "@this" {
-		return "description"
-	}
-	return parentPath + ".description"
-}
-
-// mergeHint combines an existing description with a hint. Cleaning is not always a single pass:
-// a schema may be cleaned by a translator and again by an executor, so an already-present hint is
-// kept as-is instead of being appended a second time.
-func mergeHint(existing, hint string) string {
-	if existing == "" {
+func appendHint(currentDesc, hint string) string {
+	if currentDesc == "" {
 		return hint
 	}
-	// A hint added to an empty description is stored bare and later hints are appended after it, so
-	// the bare form may sit alone, lead the description, or appear parenthesised further along.
-	if existing == hint ||
-		strings.HasPrefix(existing, hint+" (") ||
-		strings.Contains(existing, fmt.Sprintf("(%s)", hint)) {
-		return existing
+	if strings.Contains(currentDesc, hint) {
+		return currentDesc
 	}
-	return fmt.Sprintf("%s (%s)", existing, hint)
+	return currentDesc + " " + hint
 }
 
-func appendHint(jsonStr, parentPath, hint string) string {
-	descPath := parentPath + ".description"
-	if parentPath == "" || parentPath == "@this" {
-		descPath = "description"
-	}
-	merged := mergeHint(gjson.Get(jsonStr, descPath).String(), hint)
-	updated, _ := sjson.SetBytes([]byte(jsonStr), descPath, merged)
-	jsonStr = string(updated)
-	return jsonStr
-}
-
-func appendHintRaw(jsonRaw, hint string) string {
-	merged := mergeHint(gjson.Get(jsonRaw, "description").String(), hint)
-	updated, _ := sjson.SetBytes([]byte(jsonRaw), "description", merged)
-	jsonRaw = string(updated)
-	return jsonRaw
-}
-
-func getStrings(jsonStr, path string) []string {
-	var result []string
-	if arr := gjson.Get(jsonStr, path); arr.IsArray() {
-		for _, r := range arr.Array() {
-			result = append(result, r.String())
-		}
-	}
-	return result
-}
-
-func contains(slice []string, item string) bool {
+func contains(slice []string, val string) bool {
 	for _, s := range slice {
-		if s == item {
+		if s == val {
 			return true
 		}
 	}
 	return false
 }
 
-func orDefault(val, def string) string {
-	if val == "" {
-		return def
-	}
-	return val
+// gjsonPathFromJSONPointer converts #/$defs/MyType to $defs.MyType
+func gjsonPathFromJSONPointer(pointer string) string {
+	pointer = strings.TrimPrefix(pointer, "#/")
+	parts := strings.Split(pointer, "/")
+	return strings.Join(parts, ".")
 }
 
-func escapeGJSONPathKey(key string) string {
-	if strings.IndexAny(key, ".*?") == -1 {
-		return key
-	}
-	return gjsonPathKeyReplacer.Replace(key)
-}
-
-func unescapeGJSONPathKey(key string) string {
-	if !strings.Contains(key, "\\") {
-		return key
-	}
-	var b strings.Builder
-	b.Grow(len(key))
-	for i := 0; i < len(key); i++ {
-		if key[i] == '\\' && i+1 < len(key) {
-			i++
-			b.WriteByte(key[i])
-			continue
-		}
-		b.WriteByte(key[i])
-	}
-	return b.String()
-}
-
-func splitGJSONPath(path string) []string {
-	if path == "" {
-		return nil
-	}
-
-	parts := make([]string, 0, strings.Count(path, ".")+1)
-	var b strings.Builder
-	b.Grow(len(path))
-
-	for i := 0; i < len(path); i++ {
-		c := path[i]
-		if c == '\\' && i+1 < len(path) {
-			b.WriteByte('\\')
-			i++
-			b.WriteByte(path[i])
-			continue
-		}
-		if c == '.' {
-			parts = append(parts, b.String())
-			b.Reset()
-			continue
-		}
-		b.WriteByte(c)
-	}
-	parts = append(parts, b.String())
-	return parts
-}
-
-func mergeDescriptionRaw(schemaRaw, parentDesc string) string {
-	childDesc := gjson.Get(schemaRaw, "description").String()
-	switch {
-	case childDesc == "":
-		updated, _ := sjson.SetBytes([]byte(schemaRaw), "description", parentDesc)
-		return string(updated)
-	case childDesc == parentDesc:
-		return schemaRaw
-	default:
-		combined := fmt.Sprintf("%s (%s)", parentDesc, childDesc)
-		updated, _ := sjson.SetBytes([]byte(schemaRaw), "description", combined)
-		return string(updated)
-	}
-}
+// Regular expressions for schema parsing
+var (
+	enumRegex = regexp.MustCompile(`"enum"\s*:\s*\[([^\]]*)\]`)
+)

--- a/internal/util/sanitize_test.go
+++ b/internal/util/sanitize_test.go
@@ -213,3 +213,24 @@ func TestRestoreSanitizedToolName(t *testing.T) {
 		t.Errorf("expected empty for empty name, got %q", got)
 	}
 }
+
+func TestSanitizeClaudeFunctionName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"valid_name", "valid_name"},
+		{"valid-name-123", "valid-name-123"},
+		{"mcp.server.tool", "mcp_server_tool"},
+		{"mcp:server:tool", "mcp_server_tool"},
+		{"123start_digit", "_123start_digit"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		got := SanitizeClaudeFunctionName(tt.input)
+		if got != tt.expected {
+			t.Errorf("SanitizeClaudeFunctionName(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -16,6 +16,7 @@ import (
 )
 
 var functionNameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9_.:-]`)
+var claudeFunctionNameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
 
 // SanitizeFunctionName ensures a function name matches the requirements for Gemini/Vertex AI.
 // It replaces invalid characters with underscores, ensures it starts with a letter or underscore,
@@ -125,4 +126,27 @@ func WritablePath() string {
 		}
 	}
 	return ""
+}
+
+// SanitizeClaudeFunctionName ensures a function name matches Anthropic Claude requirements: ^[a-zA-Z0-9_-]{1,128}$
+func SanitizeClaudeFunctionName(name string) string {
+	if name == "" {
+		return ""
+	}
+	sanitized := claudeFunctionNameSanitizer.ReplaceAllString(name, "_")
+	if len(sanitized) > 0 {
+		first := sanitized[0]
+		if !((first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z') || first == '_') {
+			if len(sanitized) >= 64 {
+				sanitized = sanitized[:63]
+			}
+			sanitized = "_" + sanitized
+		}
+	} else {
+		sanitized = "_"
+	}
+	if len(sanitized) > 64 {
+		sanitized = sanitized[:64]
+	}
+	return sanitized
 }


### PR DESCRIPTION
### Summary

This PR addresses two critical tool-calling compatibility issues when interacting with Claude and Antigravity via OpenAI-compatible endpoints:

1. **Claude Tool Name Sanitization (`^[a-zA-Z0-9_-]{1,128}$`)**:
   - Anthropic strictly rejects tool names containing characters outside `^[a-zA-Z0-9_-]{1,128}$`.
   - Tools originating from Model Context Protocol (MCP) servers or modular clients frequently use namespaces with dots, colons, or slashes (e.g. `mcp.server.special:get_time`), leading to upstream `400 invalid_request_error`.
   - Added `SanitizeClaudeFunctionName` in `internal/util` to automatically sanitize tool names before forwarding to Claude/Vertex while preserving reverse mapping.

2. **Fallback Parameters Schema for Parameterless & Custom Tools**:
   - Under Antigravity/Claude `VALIDATED` mode, function declarations missing an explicit `parameters` or `input_schema` object are rejected with `400 input_schema: Field required`.
   - Added a fallback empty object schema (`{"type":"object","properties":{}}`) for tools with absent schemas and broadened tool parsing to accept `custom` tool descriptors sent by various OpenAI-compatible clients.

### Testing
- Added unit test `TestSanitizeClaudeFunctionName` in `internal/util/sanitize_test.go` covering dot, colon, digit-prefixed, and standard tool names.
- All existing tests in `internal/util/...` and `internal/translator/...` pass cleanly without regressions.
- Verified live tool calling on `claude-sonnet-4-6` and `gemini-3.7-flash` with complex MCP tool names.