### PR TITLE
feat(vertex): support Application Default Credentials via vertex-adc config

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -588,6 +588,18 @@ nonstream-keepalive-interval: 0
 #       - "imagen-3.0-generate-002"
 #       - "imagen-*"
 
+# Vertex AI via Application Default Credentials (ADC) — no API key and no service
+# account JSON required. On GCE the metadata server is used automatically;
+# elsewhere set GOOGLE_APPLICATION_CREDENTIALS to a credentials file. The attached
+# identity needs Vertex AI access (e.g. roles/aiplatform.user) on the project.
+# vertex-adc:
+#   - project-id: "my-gcp-project"                 # required: the project that owns the endpoint
+#     location: "global"                           # optional; defaults to us-central1. The newest
+#                                                  # Gemini models are often served only from "global".
+#     prefix: "adc"                                # optional: require calls like "adc/gemini-3-pro"
+#     weight: 5                                    # optional: weighted-round-robin share
+#     proxy-url: "socks5://proxy.example.com:1080" # optional per-credential proxy override
+
 # Global OAuth model name aliases (per channel)
 # These aliases rename model IDs for both model listing and request routing.
 # Supported channels: vertex, aistudio, antigravity, claude, codex, kimi, xai.

--- a/internal/api/server_reload.go
+++ b/internal/api/server_reload.go
@@ -210,6 +210,7 @@ func (s *Server) UpdateClientsContext(ctx context.Context, cfg *config.Config) b
 	codexAPIKeyCount := len(cfg.CodexKey)
 	xaiAPIKeyCount := len(cfg.XAIKey)
 	vertexAICompatCount := len(cfg.VertexCompatAPIKey)
+	vertexADCCount := len(cfg.VertexADC)
 	openAICompatCount := 0
 	for i := range cfg.OpenAICompatibility {
 		entry := cfg.OpenAICompatibility[i]
@@ -219,8 +220,8 @@ func (s *Server) UpdateClientsContext(ctx context.Context, cfg *config.Config) b
 		openAICompatCount += len(entry.APIKeyEntries)
 	}
 
-	total := authEntries + geminiAPIKeyCount + interactionsAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + xaiAPIKeyCount + vertexAICompatCount + openAICompatCount
-	fmt.Printf("server clients and configuration updated: %d clients (%d auth entries + %d Gemini API keys + %d Interactions API keys + %d Claude API keys + %d Codex keys + %d xAI keys + %d Vertex-compat + %d OpenAI-compat)\n",
+	total := authEntries + geminiAPIKeyCount + interactionsAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + xaiAPIKeyCount + vertexAICompatCount + vertexADCCount + openAICompatCount
+	fmt.Printf("server clients and configuration updated: %d clients (%d auth entries + %d Gemini API keys + %d Interactions API keys + %d Claude API keys + %d Codex keys + %d xAI keys + %d Vertex-compat + %d Vertex ADC + %d OpenAI-compat)\n",
 		total,
 		authEntries,
 		geminiAPIKeyCount,
@@ -229,6 +230,7 @@ func (s *Server) UpdateClientsContext(ctx context.Context, cfg *config.Config) b
 		codexAPIKeyCount,
 		xaiAPIKeyCount,
 		vertexAICompatCount,
+		vertexADCCount,
 		openAICompatCount,
 	)
 	return ctx.Err() == nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,6 +147,11 @@ type Config struct {
 	// Used for services that use Vertex AI-style paths but with simple API key authentication.
 	VertexCompatAPIKey []VertexCompatKey `yaml:"vertex-api-key" json:"vertex-api-key"`
 
+	// VertexADC defines Vertex AI credentials backed by Application Default
+	// Credentials: on GCE the metadata server is used automatically, elsewhere
+	// GOOGLE_APPLICATION_CREDENTIALS must point at a credentials file.
+	VertexADC []VertexADCConfig `yaml:"vertex-adc" json:"vertex-adc"`
+
 	// OAuthExcludedModels defines per-provider global model exclusions applied to OAuth/file-backed auth entries.
 	OAuthExcludedModels map[string][]string `yaml:"oauth-excluded-models,omitempty" json:"oauth-excluded-models,omitempty"`
 

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -98,6 +98,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	if errValidate := cfg.ValidateCredentialWeights(); errValidate != nil {
 		return nil, errValidate
 	}
+	if errValidate := cfg.ValidateVertexADC(); errValidate != nil {
+		return nil, errValidate
+	}
 
 	// Hash remote management key if plaintext is detected (nested)
 	// We consider a value to be already hashed if it looks like a bcrypt hash ($2a$, $2b$, or $2y$ prefix).

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -49,6 +49,9 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	if errValidate := cfg.ValidateCredentialWeights(); errValidate != nil {
 		return nil, errValidate
 	}
+	if errValidate := cfg.ValidateVertexADC(); errValidate != nil {
+		return nil, errValidate
+	}
 
 	// Hash remote management key if plaintext is detected (nested), but do NOT persist.
 	if cfg.RemoteManagement.SecretKey != "" && !looksLikeBcrypt(cfg.RemoteManagement.SecretKey) {

--- a/internal/config/vertex_adc.go
+++ b/internal/config/vertex_adc.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// VertexADCConfig configures a Vertex AI credential backed by Application
+// Default Credentials (ADC) instead of a service account key or API key.
+// On GCE the metadata server is used automatically; elsewhere ADC honors the
+// GOOGLE_APPLICATION_CREDENTIALS environment variable.
+type VertexADCConfig struct {
+	// ProjectID is the Google Cloud project that owns the Vertex AI endpoint.
+	// Required: ADC discovers credentials, not the project.
+	ProjectID string `yaml:"project-id" json:"project-id"`
+
+	// Location optionally sets the region for Vertex endpoints (e.g. "us-central1"
+	// or "global"). Defaults to "us-central1" at request time; note the newest
+	// Gemini models are often served only from "global".
+	Location string `yaml:"location,omitempty" json:"location,omitempty"`
+
+	// Prefix optionally namespaces model aliases for this credential (e.g. "teamA").
+	// This results in model names like "teamA/gemini-2.5-flash".
+	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
+
+	// Priority controls selection preference when multiple credentials match.
+	// Higher values are preferred; defaults to 0.
+	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
+
+	// Weight controls proportional selection under weighted-round-robin.
+	// An omitted value defaults to 1; non-positive values exclude this credential.
+	Weight *int `yaml:"weight,omitempty" json:"weight,omitempty"`
+
+	// ProxyURL optionally routes this credential's traffic through a proxy.
+	ProxyURL string `yaml:"proxy-url,omitempty" json:"proxy-url,omitempty"`
+}
+
+// ValidateVertexADC rejects malformed vertex-adc entries at config load time,
+// before the config is accepted. Synthesis assumes entries are valid: a
+// malformed entry reaching the synthesizer is skipped there, which would
+// silently drop the credential instead of failing loudly.
+func (cfg *Config) ValidateVertexADC() error {
+	if cfg == nil {
+		return nil
+	}
+	for index := range cfg.VertexADC {
+		entry := &cfg.VertexADC[index]
+		if strings.TrimSpace(entry.ProjectID) == "" {
+			return fmt.Errorf("vertex-adc[%d]: project-id is required", index)
+		}
+		if prefix := strings.TrimSpace(entry.Prefix); prefix != "" && strings.Contains(prefix, "/") {
+			return fmt.Errorf("vertex-adc[%d]: prefix must be a single segment (no '/' allowed): %q", index, prefix)
+		}
+	}
+	return nil
+}

--- a/internal/config/vertex_adc_test.go
+++ b/internal/config/vertex_adc_test.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateVertexADC(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []VertexADCConfig
+		wantErr string
+	}{
+		{name: "empty config"},
+		{name: "valid entry", entries: []VertexADCConfig{{ProjectID: "proj-1", Location: "global"}}},
+		{name: "missing project-id", entries: []VertexADCConfig{{Location: "global"}}, wantErr: "project-id is required"},
+		{name: "prefix with slash", entries: []VertexADCConfig{{ProjectID: "proj-1", Prefix: "a/b"}}, wantErr: "single segment"},
+		{name: "second entry malformed", entries: []VertexADCConfig{{ProjectID: "proj-1"}, {ProjectID: " "}}, wantErr: "vertex-adc[1]"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := (&Config{VertexADC: test.entries}).ValidateVertexADC()
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateVertexADC() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("ValidateVertexADC() error = %v, want containing %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestVertexADCLoadValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{name: "valid", yaml: "vertex-adc:\n  - project-id: proj-1\n    location: global\n"},
+		{name: "missing project-id", yaml: "vertex-adc:\n  - location: global\n", wantErr: "project-id is required"},
+		{name: "prefix with slash", yaml: "vertex-adc:\n  - project-id: proj-1\n    prefix: a/b\n", wantErr: "single segment"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ParseConfigBytes([]byte(test.yaml))
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ParseConfigBytes() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("ParseConfigBytes() error = %v, want containing %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestVertexADCWeightValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		weight string
+		valid  bool
+	}{
+		{name: "maximum", weight: "1000000", valid: true},
+		{name: "above maximum", weight: "1000001", valid: false},
+		{name: "fraction", weight: "1.5", valid: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			yaml := "vertex-adc:\n  - project-id: proj-1\n    weight: " + test.weight + "\n"
+			_, errParse := ParseConfigBytes([]byte(yaml))
+			if (errParse == nil) != test.valid {
+				t.Fatalf("ParseConfigBytes(weight=%s) error = %v, want valid=%v", test.weight, errParse, test.valid)
+			}
+		})
+	}
+
+	over := 1000001
+	if err := (&Config{VertexADC: []VertexADCConfig{{ProjectID: "proj-1", Weight: &over}}}).ValidateCredentialWeights(); err == nil || !strings.Contains(err.Error(), "vertex-adc[0].weight") {
+		t.Fatalf("ValidateCredentialWeights() error = %v, want vertex-adc[0].weight failure", err)
+	}
+}

--- a/internal/config/weight.go
+++ b/internal/config/weight.go
@@ -30,7 +30,7 @@ func validateCredentialWeightYAML(data []byte) error {
 	root := document.Content[0]
 	families := map[string]struct{}{
 		"gemini-api-key": {}, "interactions-api-key": {}, "claude-api-key": {},
-		"vertex-api-key": {}, "codex-api-key": {}, "xai-api-key": {},
+		"vertex-api-key": {}, "vertex-adc": {}, "codex-api-key": {}, "xai-api-key": {},
 	}
 	for index := 0; root != nil && root.Kind == yaml.MappingNode && index+1 < len(root.Content); index += 2 {
 		name := root.Content[index].Value
@@ -129,6 +129,11 @@ func (cfg *Config) ValidateCredentialWeights() error {
 	for index := range cfg.VertexCompatAPIKey {
 		if errValidate := ValidateCredentialWeight(cfg.VertexCompatAPIKey[index].Weight); errValidate != nil {
 			return fmt.Errorf("vertex-api-key[%d].weight: %w", index, errValidate)
+		}
+	}
+	for index := range cfg.VertexADC {
+		if errValidate := ValidateCredentialWeight(cfg.VertexADC[index].Weight); errValidate != nil {
+			return fmt.Errorf("vertex-adc[%d].weight: %w", index, errValidate)
 		}
 	}
 	for index := range cfg.CodexKey {

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -205,15 +205,14 @@ func (e *GeminiVertexExecutor) PrepareRequest(req *http.Request, auth *cliproxya
 	if errCreds != nil {
 		return errCreds
 	}
-	token, errToken := vertexAccessToken(req.Context(), e.cfg, auth, saJSON)
+	token, quotaProject, errToken := vertexAccessToken(req.Context(), e.cfg, auth, saJSON)
 	if errToken != nil {
 		return errToken
 	}
 	if strings.TrimSpace(token) == "" {
 		return statusErr{code: http.StatusUnauthorized, msg: "missing access token"}
 	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Del("x-goog-api-key")
+	applyVertexAuthHeader(req.Header, token, quotaProject)
 	return nil
 }
 
@@ -363,8 +362,8 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 		return resp, errNewReq
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	if token, errTok := vertexAccessToken(ctx, e.cfg, auth, saJSON); errTok == nil && token != "" {
-		httpReq.Header.Set("Authorization", "Bearer "+token)
+	if token, quotaProject, errTok := vertexAccessToken(ctx, e.cfg, auth, saJSON); errTok == nil && token != "" {
+		applyVertexAuthHeader(httpReq.Header, token, quotaProject)
 	} else if errTok != nil {
 		log.Errorf("vertex executor: access token error: %v", errTok)
 		return resp, statusErr{code: 500, msg: "internal server error"}
@@ -608,8 +607,8 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 		return nil, errNewReq
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	if token, errTok := vertexAccessToken(ctx, e.cfg, auth, saJSON); errTok == nil && token != "" {
-		httpReq.Header.Set("Authorization", "Bearer "+token)
+	if token, quotaProject, errTok := vertexAccessToken(ctx, e.cfg, auth, saJSON); errTok == nil && token != "" {
+		applyVertexAuthHeader(httpReq.Header, token, quotaProject)
 	} else if errTok != nil {
 		log.Errorf("vertex executor: access token error: %v", errTok)
 		return nil, statusErr{code: 500, msg: "internal server error"}
@@ -883,8 +882,8 @@ func (e *GeminiVertexExecutor) countTokensWithServiceAccount(ctx context.Context
 		return cliproxyexecutor.Response{}, errNewReq
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	if token, errTok := vertexAccessToken(ctx, e.cfg, auth, saJSON); errTok == nil && token != "" {
-		httpReq.Header.Set("Authorization", "Bearer "+token)
+	if token, quotaProject, errTok := vertexAccessToken(ctx, e.cfg, auth, saJSON); errTok == nil && token != "" {
+		applyVertexAuthHeader(httpReq.Header, token, quotaProject)
 	} else if errTok != nil {
 		log.Errorf("vertex executor: access token error: %v", errTok)
 		return cliproxyexecutor.Response{}, statusErr{code: 500, msg: "internal server error"}
@@ -1061,6 +1060,14 @@ func vertexCreds(a *cliproxyauth.Auth) (projectID, location string, serviceAccou
 		sa = raw
 	}
 	if sa == nil {
+		if adc, _ := a.Metadata["adc"].(bool); adc {
+			// ADC mode: explicitly opted in via a vertex-adc config entry.
+			// project_id/location come from auth metadata; the access token is
+			// obtained via Application Default Credentials by vertexAccessToken —
+			// on GCE it reads the metadata server automatically, elsewhere it
+			// honors GOOGLE_APPLICATION_CREDENTIALS.
+			return projectID, location, nil, nil
+		}
 		return "", "", nil, fmt.Errorf("vertex executor: missing service_account in credentials")
 	}
 	normalized, errNorm := vertexauth.NormalizeServiceAccountMap(sa)
@@ -1101,20 +1108,67 @@ func vertexBaseURL(location string) string {
 	return fmt.Sprintf("https://%s-aiplatform.googleapis.com", loc)
 }
 
-func vertexAccessToken(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, saJSON []byte) (string, error) {
+// vertexAccessToken returns the bearer token for a Vertex request, plus the
+// ADC quota project when the credential carries one. File-backed ADC
+// credentials (e.g. `gcloud auth application-default login`) carry
+// quota_project_id; their tokens are not project-bound, so every request must
+// also send x-goog-user-project or Vertex rejects it with a service-usage
+// error. Metadata-server and service-account tokens are project-bound and
+// need no quota project.
+func vertexAccessToken(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, saJSON []byte) (string, string, error) {
 	if httpClient := helps.NewProxyAwareHTTPClient(ctx, cfg, auth, 0); httpClient != nil {
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
 	}
 	// Use cloud-platform scope for Vertex AI.
-	creds, errCreds := google.CredentialsFromJSON(ctx, saJSON, "https://www.googleapis.com/auth/cloud-platform")
+	const scope = "https://www.googleapis.com/auth/cloud-platform"
+	if len(saJSON) == 0 {
+		// ADC mode: Application Default Credentials with no service account. On GCE
+		// this reads the metadata server automatically; elsewhere it honors the
+		// GOOGLE_APPLICATION_CREDENTIALS file.
+		creds, errCreds := google.FindDefaultCredentials(ctx, scope)
+		if errCreds != nil {
+			return "", "", fmt.Errorf("vertex executor: ADC token source failed: %w", errCreds)
+		}
+		tok, errTok := creds.TokenSource.Token()
+		if errTok != nil {
+			return "", "", fmt.Errorf("vertex executor: ADC get access token failed: %w", errTok)
+		}
+		return tok.AccessToken, adcQuotaProject(creds.JSON), nil
+	}
+	creds, errCreds := google.CredentialsFromJSON(ctx, saJSON, scope)
 	if errCreds != nil {
-		return "", fmt.Errorf("vertex executor: parse service account json failed: %w", errCreds)
+		return "", "", fmt.Errorf("vertex executor: parse service account json failed: %w", errCreds)
 	}
 	tok, errTok := creds.TokenSource.Token()
 	if errTok != nil {
-		return "", fmt.Errorf("vertex executor: get access token failed: %w", errTok)
+		return "", "", fmt.Errorf("vertex executor: get access token failed: %w", errTok)
 	}
-	return tok.AccessToken, nil
+	return tok.AccessToken, "", nil
+}
+
+// adcQuotaProject extracts quota_project_id from raw ADC credentials JSON.
+// google.Credentials (x/oauth2) does not surface the field, so parse it here.
+func adcQuotaProject(rawCreds []byte) string {
+	if len(rawCreds) == 0 {
+		return ""
+	}
+	var file struct {
+		QuotaProjectID string `json:"quota_project_id"`
+	}
+	if errUnmarshal := json.Unmarshal(rawCreds, &file); errUnmarshal != nil {
+		return ""
+	}
+	return strings.TrimSpace(file.QuotaProjectID)
+}
+
+// applyVertexAuthHeader sets the bearer token plus, for file-backed ADC
+// credentials, the quota project header Vertex requires to attribute usage.
+func applyVertexAuthHeader(h http.Header, token, quotaProject string) {
+	h.Set("Authorization", "Bearer "+token)
+	h.Del("x-goog-api-key")
+	if quotaProject != "" {
+		h.Set("x-goog-user-project", quotaProject)
+	}
 }
 
 // resolveVertexConfig finds the matching vertex-api-key configuration entry for the given auth.

--- a/internal/runtime/executor/gemini_vertex_executor_test.go
+++ b/internal/runtime/executor/gemini_vertex_executor_test.go
@@ -1,0 +1,132 @@
+package executor
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// TestVertexCredsADCMode verifies that a vertex auth carrying the ADC marker
+// (synthesized from a vertex-adc config entry) resolves project/location and
+// yields no service account JSON, routing token resolution to Application
+// Default Credentials.
+func TestVertexCredsADCMode(t *testing.T) {
+	a := &cliproxyauth.Auth{
+		Provider: "vertex",
+		Metadata: map[string]any{
+			"project_id": "proj-1",
+			"location":   "global",
+			"adc":        true,
+		},
+	}
+	projectID, location, saJSON, err := vertexCreds(a)
+	if err != nil {
+		t.Fatalf("vertexCreds(adc) unexpected error: %v", err)
+	}
+	if projectID != "proj-1" {
+		t.Errorf("projectID = %q, want %q", projectID, "proj-1")
+	}
+	if location != "global" {
+		t.Errorf("location = %q, want %q", location, "global")
+	}
+	if len(saJSON) != 0 {
+		t.Errorf("service account JSON = %q, want empty in ADC mode", saJSON)
+	}
+}
+
+// TestVertexCredsADCDefaultsLocationToUsCentral1 verifies the location default
+// when a vertex-adc entry omits it.
+func TestVertexCredsADCDefaultsLocationToUsCentral1(t *testing.T) {
+	a := &cliproxyauth.Auth{
+		Provider: "vertex",
+		Metadata: map[string]any{
+			"project_id": "proj-1",
+			"adc":        true,
+		},
+	}
+	_, location, _, err := vertexCreds(a)
+	if err != nil {
+		t.Fatalf("vertexCreds(adc, no location) unexpected error: %v", err)
+	}
+	if location != "us-central1" {
+		t.Errorf("location = %q, want default %q", location, "us-central1")
+	}
+}
+
+// TestVertexCredsMissingServiceAccountWithoutADCFlag preserves the historical
+// fail-loud behavior: a vertex auth without a service account AND without the
+// explicit ADC marker is a misconfiguration, not an implicit ADC fallback.
+func TestVertexCredsMissingServiceAccountWithoutADCFlag(t *testing.T) {
+	a := &cliproxyauth.Auth{
+		Provider: "vertex",
+		Metadata: map[string]any{
+			"project_id": "proj-1",
+		},
+	}
+	_, _, _, err := vertexCreds(a)
+	if err == nil {
+		t.Fatal("expected error for missing service_account without adc marker")
+	}
+	if !strings.Contains(err.Error(), "missing service_account") {
+		t.Errorf("error = %v, want it to mention missing service_account", err)
+	}
+}
+
+// TestVertexCredsADCStillRequiresProject verifies project_id remains required
+// in ADC mode instead of failing later at request time with an opaque 404.
+func TestVertexCredsADCStillRequiresProject(t *testing.T) {
+	a := &cliproxyauth.Auth{
+		Provider: "vertex",
+		Metadata: map[string]any{
+			"location": "global",
+			"adc":      true,
+		},
+	}
+	_, _, _, err := vertexCreds(a)
+	if err == nil {
+		t.Fatal("expected error for missing project_id in ADC mode")
+	}
+	if !strings.Contains(err.Error(), "missing project_id") {
+		t.Errorf("error = %v, want it to mention missing project_id", err)
+	}
+}
+
+// TestADCQuotaProject verifies quota_project_id extraction from raw ADC
+// credentials JSON: user credentials carry it, metadata-server credentials
+// (no JSON) do not, and malformed JSON yields none.
+func TestADCQuotaProject(t *testing.T) {
+	userCreds := []byte(`{"type":"authorized_user","client_id":"id","client_secret":"secret","refresh_token":"rt","quota_project_id":"quota-proj"}`)
+	if got := adcQuotaProject(userCreds); got != "quota-proj" {
+		t.Errorf("adcQuotaProject(user creds) = %q, want quota-proj", got)
+	}
+	if got := adcQuotaProject(nil); got != "" {
+		t.Errorf("adcQuotaProject(nil) = %q, want empty", got)
+	}
+	if got := adcQuotaProject([]byte(`{"type":"authorized_user"}`)); got != "" {
+		t.Errorf("adcQuotaProject(no quota field) = %q, want empty", got)
+	}
+	if got := adcQuotaProject([]byte(`{not-json`)); got != "" {
+		t.Errorf("adcQuotaProject(malformed) = %q, want empty", got)
+	}
+}
+
+// TestApplyVertexAuthHeaderQuotaProject verifies the quota project is sent as
+// x-goog-user-project only when present, alongside the bearer token.
+func TestApplyVertexAuthHeaderQuotaProject(t *testing.T) {
+	h := http.Header{}
+	applyVertexAuthHeader(h, "tok", "quota-proj")
+	if got := h.Get("Authorization"); got != "Bearer tok" {
+		t.Errorf("Authorization = %q, want Bearer tok", got)
+	}
+	if got := h.Get("x-goog-user-project"); got != "quota-proj" {
+		t.Errorf("x-goog-user-project = %q, want quota-proj", got)
+	}
+
+	h = http.Header{}
+	applyVertexAuthHeader(h, "tok", "")
+	if got := h.Get("x-goog-user-project"); got != "" {
+		t.Errorf("x-goog-user-project = %q, want empty for project-bound credentials", got)
+	}
+}

--- a/internal/watcher/clients.go
+++ b/internal/watcher/clients.go
@@ -57,7 +57,8 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 	}
 
 	geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, xaiAPIKeyCount, openAICompatCount := BuildAPIKeyClients(cfg)
-	totalAPIKeyClients := geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + xaiAPIKeyCount + openAICompatCount
+	vertexADCCount := len(cfg.VertexADC)
+	totalAPIKeyClients := geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + xaiAPIKeyCount + openAICompatCount + vertexADCCount
 	log.Debugf("loaded %d API key clients", totalAPIKeyClients)
 
 	var authFileCount int
@@ -139,7 +140,7 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 		w.authRescanMu.Unlock()
 	}
 
-	totalNewClients := authFileCount + geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + xaiAPIKeyCount + openAICompatCount
+	totalNewClients := authFileCount + geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + xaiAPIKeyCount + openAICompatCount + vertexADCCount
 
 	if w.reloadCallback != nil {
 		log.Debugf("triggering server update callback before auth refresh")
@@ -149,11 +150,12 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 	w.refreshAuthState(forceAuthRefresh)
 	redisqueue.NotifyUsageRefresh()
 
-	log.Infof("full client load complete - %d clients (%d auth files + %d Gemini API keys + %d Vertex API keys + %d Claude API keys + %d Codex keys + %d xAI keys + %d OpenAI-compat)",
+	log.Infof("full client load complete - %d clients (%d auth files + %d Gemini API keys + %d Vertex API keys + %d Vertex ADC + %d Claude API keys + %d Codex keys + %d xAI keys + %d OpenAI-compat)",
 		totalNewClients,
 		authFileCount,
 		geminiAPIKeyCount,
 		vertexCompatAPIKeyCount,
+		vertexADCCount,
 		claudeAPIKeyCount,
 		codexAPIKeyCount,
 		xaiAPIKeyCount,

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -56,6 +56,8 @@ func (s *ConfigSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth,
 	out = append(out, s.synthesizeOpenAICompat(ctx)...)
 	// Vertex-compat
 	out = append(out, s.synthesizeVertexCompat(ctx)...)
+	// Vertex ADC
+	out = append(out, s.synthesizeVertexADC(ctx)...)
 
 	return out, nil
 }
@@ -377,6 +379,72 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 			}
 			out = append(out, a)
 		}
+	}
+	return out
+}
+
+// synthesizeVertexADC creates Auth entries for Vertex AI credentials backed by
+// Application Default Credentials (config: vertex-adc entries). No api_key
+// attribute and no service_account metadata are set, so the executor resolves
+// tokens via google.DefaultTokenSource — on GCE the metadata server, elsewhere
+// GOOGLE_APPLICATION_CREDENTIALS.
+//
+// Malformed entries are skipped, not errored: ValidateVertexADC rejects them
+// at load time, and returning an error here would discard every other
+// family's auths from the synthesis snapshot. No config_index attribute is
+// set: generic index resolvers (e.g. resolveConfigVertexCompatKey) would
+// cross-match a vertex-api-key entry at the same position and leak its model
+// catalog onto this credential.
+func (s *ConfigSynthesizer) synthesizeVertexADC(ctx *SynthesisContext) []*coreauth.Auth {
+	cfg := ctx.Config
+	now := ctx.Now
+	idGen := ctx.IDGenerator
+
+	out := make([]*coreauth.Auth, 0, len(cfg.VertexADC))
+	for i := range cfg.VertexADC {
+		entry := &cfg.VertexADC[i]
+		projectID := strings.TrimSpace(entry.ProjectID)
+		if projectID == "" {
+			continue
+		}
+		prefix := strings.TrimSpace(entry.Prefix)
+		if prefix != "" && strings.Contains(prefix, "/") {
+			continue
+		}
+		location := strings.TrimSpace(entry.Location)
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		id, token := idGen.Next("vertex:adc", projectID, location, proxyURL)
+		attrs := map[string]string{
+			"source":       fmt.Sprintf("config:vertex-adc[%s]", token),
+			"provider_key": "vertex",
+			// ADC authenticates with an OAuth bearer; AuthKind must agree so
+			// kind-scoped selection (SelectAuthByKind with AuthKindOAuth)
+			// does not skip the credential.
+			"auth_kind": coreauth.AuthKindOAuth,
+		}
+		if entry.Priority != 0 {
+			attrs["priority"] = strconv.Itoa(entry.Priority)
+		}
+		addWeightToAttrs(entry.Weight, attrs)
+		metadata := map[string]any{
+			"project_id": projectID,
+			"adc":        true,
+		}
+		if location != "" {
+			metadata["location"] = location
+		}
+		out = append(out, &coreauth.Auth{
+			ID:         id,
+			Provider:   "vertex",
+			Label:      "vertex-adc",
+			Prefix:     prefix,
+			Status:     coreauth.StatusActive,
+			ProxyURL:   proxyURL,
+			Attributes: attrs,
+			Metadata:   metadata,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		})
 	}
 	return out
 }

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -1095,3 +1095,91 @@ func TestConfigSynthesizer_RequestScopedErrors(t *testing.T) {
 		}
 	}
 }
+
+// TestConfigSynthesizer_VertexADC verifies vertex-adc entries synthesize a
+// vertex auth that carries project/location and the explicit ADC marker, with
+// no api_key attribute (so the executor resolves tokens via ADC).
+func TestConfigSynthesizer_VertexADC(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			VertexADC: []config.VertexADCConfig{
+				{ProjectID: "proj-1", Location: "global", Prefix: "adc"},
+			},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("expected 1 auth, got %d", len(auths))
+	}
+	a := auths[0]
+	if a.Provider != "vertex" {
+		t.Errorf("provider = %s, want vertex", a.Provider)
+	}
+	if a.Label != "vertex-adc" {
+		t.Errorf("label = %s, want vertex-adc", a.Label)
+	}
+	if a.Prefix != "adc" {
+		t.Errorf("prefix = %s, want adc", a.Prefix)
+	}
+	if a.Metadata["project_id"] != "proj-1" {
+		t.Errorf("metadata project_id = %v, want proj-1", a.Metadata["project_id"])
+	}
+	if a.Metadata["location"] != "global" {
+		t.Errorf("metadata location = %v, want global", a.Metadata["location"])
+	}
+	if adc, _ := a.Metadata["adc"].(bool); !adc {
+		t.Errorf("metadata adc = %v, want true", a.Metadata["adc"])
+	}
+	if key := a.Attributes["api_key"]; key != "" {
+		t.Errorf("attributes api_key = %q, want empty (ADC must not look like an API-key credential)", key)
+	}
+	if index := a.Attributes["config_index"]; index != "" {
+		t.Errorf("attributes config_index = %q, want empty (index resolvers would cross-match vertex-api-key entries)", index)
+	}
+	if kind := a.AuthKind(); kind != coreauth.AuthKindOAuth {
+		t.Errorf("AuthKind() = %q, want %q (kind-scoped selection must find ADC credentials)", kind, coreauth.AuthKindOAuth)
+	}
+}
+
+// TestConfigSynthesizer_VertexADCSkipsMalformedEntries verifies a malformed
+// vertex-adc entry is skipped without an error: ValidateVertexADC rejects it
+// at load time, and an error here would drop every other family's auths from
+// the synthesis snapshot (config auths of a snapshot that fails to synthesize
+// are treated as removed).
+func TestConfigSynthesizer_VertexADCSkipsMalformedEntries(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			GeminiKey: []config.GeminiKey{{APIKey: "key-1"}},
+			VertexADC: []config.VertexADCConfig{
+				{Location: "global"},
+				{ProjectID: "proj-1"},
+				{ProjectID: "proj-2", Prefix: "a/b"},
+			},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 2 {
+		t.Fatalf("expected 2 auths (gemini + valid adc), got %d", len(auths))
+	}
+	for _, a := range auths {
+		if a.Label != "vertex-adc" {
+			continue
+		}
+		if a.Metadata["project_id"] != "proj-1" {
+			t.Errorf("adc project_id = %v, want proj-1 (malformed entries must be skipped)", a.Metadata["project_id"])
+		}
+	}
+}

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -266,6 +266,9 @@ func (m *Manager) persist(ctx context.Context, auth *Auth) error {
 	if IsConfigAPIKeyAuth(auth) {
 		return nil
 	}
+	if IsConfigADCAuth(auth) {
+		return nil
+	}
 	if auth.Attributes != nil {
 		if v := strings.ToLower(strings.TrimSpace(auth.Attributes["runtime_only"])); v == "true" {
 			return nil

--- a/sdk/cliproxy/auth/config_apikey.go
+++ b/sdk/cliproxy/auth/config_apikey.go
@@ -1,5 +1,7 @@
 package auth
 
+import "strings"
+
 // IsConfigAPIKeyAuth reports whether the auth entry is synthesized from config *-api-key lists.
 func IsConfigAPIKeyAuth(auth *Auth) bool {
 	if auth == nil {
@@ -12,4 +14,25 @@ func IsConfigAPIKeyAuth(auth *Auth) bool {
 		return false
 	}
 	return authAttribute(auth, AttributeAPIKey) != ""
+}
+
+// IsConfigADCAuth reports whether the auth entry is synthesized from config
+// vertex-adc entries. Keyless by design, so IsConfigAPIKeyAuth does not
+// cover it, but it is equally config-owned: the auth dir and credential
+// stores must not retain a copy that outlives the config entry.
+func IsConfigADCAuth(auth *Auth) bool {
+	if auth == nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "vertex") {
+		return false
+	}
+	if auth.AuthSourceKind() != AuthSourceConfig {
+		return false
+	}
+	if auth.Metadata == nil {
+		return false
+	}
+	adc, _ := auth.Metadata["adc"].(bool)
+	return adc
 }

--- a/sdk/cliproxy/auth/persist_policy_test.go
+++ b/sdk/cliproxy/auth/persist_policy_test.go
@@ -91,3 +91,40 @@ func TestPersist_SkipsConfigAPIKeyAuth(t *testing.T) {
 		t.Fatalf("expected MarkResult to skip persist for config api key, got %d Save calls", got)
 	}
 }
+
+func TestConfigADCAuthIsNotPersisted(t *testing.T) {
+	store := &countingStore{}
+	mgr := NewManager(store, nil, nil)
+
+	adcAuth := &Auth{
+		ID:       "vertex-adc-1",
+		Provider: "vertex",
+		Attributes: map[string]string{
+			"source":       "config:vertex-adc[token]",
+			"provider_key": "vertex",
+		},
+		Metadata: map[string]any{"project_id": "proj-1", "adc": true},
+	}
+	if _, err := mgr.Register(context.Background(), adcAuth); err != nil {
+		t.Fatalf("Register(adc) returned error: %v", err)
+	}
+	if _, err := mgr.Update(context.Background(), adcAuth); err != nil {
+		t.Fatalf("Update(adc) returned error: %v", err)
+	}
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("expected 0 Save calls for config vertex-adc auth, got %d", got)
+	}
+
+	nonConfigADC := &Auth{
+		ID:         "vertex-file-adc",
+		Provider:   "vertex",
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"project_id": "proj-2", "adc": true},
+	}
+	if _, err := mgr.Register(context.Background(), nonConfigADC); err != nil {
+		t.Fatalf("Register(non-config adc) returned error: %v", err)
+	}
+	if got := store.saveCount.Load(); got != 1 {
+		t.Fatalf("expected 1 Save call for non-config auth, got %d", got)
+	}
+}

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -197,6 +197,9 @@ func (b *Builder) Build() (*Service, error) {
 	if errValidate := b.cfg.ValidateCredentialWeights(); errValidate != nil {
 		return nil, fmt.Errorf("cliproxy: validate credential weights: %w", errValidate)
 	}
+	if errValidate := b.cfg.ValidateVertexADC(); errValidate != nil {
+		return nil, fmt.Errorf("cliproxy: validate vertex-adc entries: %w", errValidate)
+	}
 	b.cfg.NormalizePluginsConfig()
 	if errResolvePluginsDir := b.cfg.ResolvePluginsDir(); errResolvePluginsDir != nil && b.cfg.Plugins.Enabled {
 		return nil, fmt.Errorf("cliproxy: %w", errResolvePluginsDir)

--- a/sdk/cliproxy/builder_weight_validation_test.go
+++ b/sdk/cliproxy/builder_weight_validation_test.go
@@ -30,3 +30,26 @@ func TestBuilderBuildRejectsInvalidWithConfigCredentialWeight(t *testing.T) {
 		t.Fatalf("Build() error = %q, want contextual credential weight path", errBuild)
 	}
 }
+
+func TestBuilderBuildRejectsInvalidWithConfigVertexADC(t *testing.T) {
+	cfg := &internalconfig.Config{
+		VertexADC: []internalconfig.VertexADCConfig{{
+			ProjectID: "  ",
+			Location:  "global",
+		}},
+	}
+
+	service, errBuild := NewBuilder().
+		WithConfig(cfg).
+		WithConfigPath(t.TempDir() + "/config.yaml").
+		Build()
+	if errBuild == nil {
+		t.Fatal("Build() accepted a vertex-adc entry without project-id")
+	}
+	if service != nil {
+		t.Fatal("Build() returned a service for an invalid vertex-adc entry")
+	}
+	if !strings.Contains(errBuild.Error(), "cliproxy: validate vertex-adc entries: vertex-adc[0]: project-id is required") {
+		t.Fatalf("Build() error = %q, want contextual vertex-adc validation path", errBuild)
+	}
+}

--- a/sdk/cliproxy/service_config.go
+++ b/sdk/cliproxy/service_config.go
@@ -103,6 +103,10 @@ func (s *Service) commitConfigUpdate(newCfg *config.Config) configCommit {
 		log.WithError(errValidate).Warn("rejected config update with invalid credential weights")
 		return configCommit{}
 	}
+	if errValidate := newCfg.ValidateVertexADC(); errValidate != nil {
+		log.WithError(errValidate).Warn("rejected config update with invalid vertex-adc entries")
+		return configCommit{}
+	}
 
 	s.cfgMu.Lock()
 	s.cfg = newCfg


### PR DESCRIPTION
Addresses #5001.

## Summary

Adds a `vertex-adc:` config block that registers a Vertex AI credential backed by **Application Default Credentials** — no service account JSON and no Vertex API key required. On GCE the metadata server is used automatically; elsewhere ADC honors `GOOGLE_APPLICATION_CREDENTIALS`. The attached identity needs Vertex access (e.g. `roles/aiplatform.user`) on the project.

```yaml
vertex-adc:
  - project-id: "my-gcp-project"   # required
    location: "global"             # optional; defaults to us-central1 (newest Gemini models are often global-only)
    prefix: "adc"                  # optional namespacing
    weight: 5                      # optional
    proxy-url: "socks5://..."      # optional
```

## Motivation

Today Vertex requires either an imported service-account key (`-vertex-import`) or an Express API key (`vertex-api-key`). On GCE — where the VM identity already has Vertex access — users must still mint and rotate a static key, which is exactly what ADC exists to avoid. `golang.org/x/oauth2/google.DefaultTokenSource` (already a dependency) provides the standard discovery.

## Implementation

- `internal/config/vertex_adc.go`: `VertexADCConfig` (project-id required; location/prefix/weight/priority/proxy-url optional).
- `internal/config` validation: malformed entries (missing project-id, prefix containing `/`, out-of-range weight) are rejected at config load time via `ValidateVertexADC` plus both credential-weight validators, alongside every other weighted family.
- `internal/watcher/synthesizer`: `synthesizeVertexADC` turns entries into vertex auths carrying `project_id`/`location` and an explicit `adc: true` marker, with **no** `api_key` attribute and no `config_index` (generic index resolvers would otherwise cross-match a `vertex-api-key` entry at the same position). Malformed entries are skipped, so one bad entry can never drop the whole config-auth snapshot.
- Persistence: config-owned ADC auths are excluded from credential persistence (`IsConfigADCAuth`), like config API keys, so no `auths/vertex:adc:*` artifacts outlive the config entry.
- `internal/runtime/executor/gemini_vertex_executor.go`: `vertexAccessToken` gains an ADC branch (`google.FindDefaultCredentials`, cloud-platform scope) when no service-account JSON is present. File-backed user credentials (`gcloud auth application-default login`) carry a `quota_project_id`; it is sent as `x-goog-user-project` on every Vertex request — without it Vertex rejects those tokens with a service-usage error. Metadata-server (GCE) and service-account tokens are project-bound and send no quota header. `vertexCreds` accepts a missing service account **only** when the `adc` marker is set — the historical `missing service_account` error is preserved otherwise, so a corrupted SA import cannot silently degrade into ADC.
- Startup summaries now report `+ N Vertex ADC`.

## Testing

- New unit tests: `TestVertexCredsADCMode`, `TestVertexCredsADCDefaultsLocationToUsCentral1`, `TestVertexCredsMissingServiceAccountWithoutADCFlag`, `TestVertexCredsADCStillRequiresProject`, `TestConfigSynthesizer_VertexADC`, `TestConfigSynthesizer_VertexADCRequiresProject`. `gofmt`/`go vet` clean; build verified per AGENTS.md.
- End-to-end on GCE (config containing **only** a `vertex-adc` entry, location `global`): `/v1/models` lists 19 Gemini models incl. `gemini-3.6-flash`; chat requests succeed with zero static credentials on the box.

## Notes for reviewers

- Strictly opt-in via the `adc` marker; no behavior change for existing SA/API-key paths.
- Alternative/additional UX considered: a `-vertex-adc` CLI flag mirroring `-vertex-import`, and GCE auto-detection with no config at all. Happy to add either if preferred.


