### PR TITLE
pluginhost: add host.auth.save_batch and host.auth.delete callbacks

### DIFF
--- a/internal/pluginhost/auth_callbacks.go
+++ b/internal/pluginhost/auth_callbacks.go
@@ -229,7 +229,7 @@ func (h *Host) resolveAuthForDelete(req pluginapi.HostAuthDeleteRequest) (*corea
 			if errGuard := guardVirtualAuthDelete(auth, name); errGuard != nil {
 				return nil, "", "", errGuard
 			}
-			return auth, path, deleteNameForAuth(auth, path), nil
+			return auth, path, deleteNameForDelete(auth, path), nil
 		}
 		for _, auth := range manager.List() {
 			if auth == nil {
@@ -243,7 +243,7 @@ func (h *Host) resolveAuthForDelete(req pluginapi.HostAuthDeleteRequest) (*corea
 				if errGuard := guardVirtualAuthDelete(auth, name); errGuard != nil {
 					return nil, "", "", errGuard
 				}
-				return auth, path, deleteNameForAuth(auth, path), nil
+				return auth, path, deleteNameForDelete(auth, path), nil
 			}
 		}
 	}
@@ -306,6 +306,16 @@ func deleteNameForAuth(auth *coreauth.Auth, path string) string {
 		}
 	}
 	return filepath.Base(path)
+}
+
+// deleteNameForDelete reports the credential identity a delete actually removed.
+// A virtual auth deleted through its physical source name removes the whole
+// expansion, so report the source file identity rather than the matched child.
+func deleteNameForDelete(auth *coreauth.Auth, path string) string {
+	if coreauth.IsPluginVirtualAuth(auth) {
+		return filepath.Base(path)
+	}
+	return deleteNameForAuth(auth, path)
 }
 
 func (h *Host) removeAuth(ctx context.Context, id string) {

--- a/internal/pluginhost/auth_callbacks.go
+++ b/internal/pluginhost/auth_callbacks.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 )
@@ -130,6 +131,219 @@ func (h *Host) callHostAuthSave(ctx context.Context, request []byte) ([]byte, er
 		Name: name,
 		Path: path,
 	})
+}
+
+func (h *Host) callHostAuthSaveBatch(ctx context.Context, request []byte) ([]byte, error) {
+	var req pluginapi.HostAuthSaveBatchRequest
+	if errUnmarshal := json.Unmarshal(request, &req); errUnmarshal != nil {
+		return nil, fmt.Errorf("decode host auth save_batch request: %w", errUnmarshal)
+	}
+	if len(req.Files) == 0 {
+		return nil, fmt.Errorf("files are required")
+	}
+	type validatedAuthFile struct {
+		name string
+		data []byte
+	}
+	validated := make([]validatedAuthFile, 0, len(req.Files))
+	seenNames := make(map[string]struct{}, len(req.Files))
+	for _, file := range req.Files {
+		name, rawJSON, errValidate := validateHostAuthSaveRequest(file)
+		if errValidate != nil {
+			return nil, errValidate
+		}
+		if _, exists := seenNames[strings.ToLower(name)]; exists {
+			return nil, fmt.Errorf("duplicate auth file name %s", name)
+		}
+		seenNames[strings.ToLower(name)] = struct{}{}
+		validated = append(validated, validatedAuthFile{name: name, data: rawJSON})
+	}
+	files := make([]pluginapi.HostAuthSaveResponse, 0, len(validated))
+	for index, file := range validated {
+		path, errSave := h.saveAuthFile(ctx, file.name, file.data)
+		if errSave != nil {
+			return nil, fmt.Errorf("save auth file %s (%d of %d already saved): %w", file.name, index, len(validated), errSave)
+		}
+		files = append(files, pluginapi.HostAuthSaveResponse{Name: file.name, Path: path})
+	}
+	return marshalRPCResult(pluginapi.HostAuthSaveBatchResponse{Files: files})
+}
+
+func (h *Host) callHostAuthDelete(ctx context.Context, request []byte) ([]byte, error) {
+	var req pluginapi.HostAuthDeleteRequest
+	if errUnmarshal := json.Unmarshal(request, &req); errUnmarshal != nil {
+		return nil, fmt.Errorf("decode host auth delete request: %w", errUnmarshal)
+	}
+	auth, path, name, errResolve := h.resolveAuthForDelete(req)
+	if errResolve != nil {
+		return nil, errResolve
+	}
+	store := sdkAuth.GetTokenStore()
+	if store == nil {
+		return nil, fmt.Errorf("token store unavailable")
+	}
+	if errDelete := store.Delete(ctx, path); errDelete != nil {
+		return nil, fmt.Errorf("delete auth file: %w", errDelete)
+	}
+	targetID := ""
+	if auth != nil {
+		targetID = strings.TrimSpace(auth.ID)
+	}
+	h.removeAuthsForPath(ctx, path, targetID)
+	if name == "" {
+		name = filepath.Base(path)
+	}
+	return marshalRPCResult(pluginapi.HostAuthDeleteResponse{
+		Name: name,
+		Path: path,
+	})
+}
+
+func (h *Host) resolveAuthForDelete(req pluginapi.HostAuthDeleteRequest) (*coreauth.Auth, string, string, error) {
+	authIndex := strings.TrimSpace(req.AuthIndex)
+	name := strings.TrimSpace(req.Name)
+	if authIndex == "" && name == "" {
+		return nil, "", "", fmt.Errorf("auth_index or name is required")
+	}
+	if authIndex != "" {
+		auth, errGet := h.authByIndex(authIndex)
+		if errGet != nil {
+			return nil, "", "", errGet
+		}
+		path := strings.TrimSpace(authAttribute(auth, "path"))
+		if path == "" {
+			return nil, "", "", fmt.Errorf("auth file path not found for auth_index %s", authIndex)
+		}
+		return auth, path, deleteNameForAuth(auth, path), nil
+	}
+	manager := h.currentAuthManager()
+	if manager != nil {
+		if auth, ok := manager.GetByID(name); ok && auth != nil {
+			path := strings.TrimSpace(authAttribute(auth, "path"))
+			if path == "" {
+				return nil, "", "", fmt.Errorf("auth file path not found for name %s", name)
+			}
+			return auth, path, deleteNameForAuth(auth, path), nil
+		}
+		for _, auth := range manager.List() {
+			if auth == nil {
+				continue
+			}
+			if strings.TrimSpace(auth.FileName) == name || filepath.Base(strings.TrimSpace(authAttribute(auth, "path"))) == name {
+				path := strings.TrimSpace(authAttribute(auth, "path"))
+				if path == "" {
+					return nil, "", "", fmt.Errorf("auth file path not found for name %s", name)
+				}
+				return auth, path, deleteNameForAuth(auth, path), nil
+			}
+		}
+	}
+	if isUnsafeAuthFileName(name) {
+		return nil, "", "", fmt.Errorf("invalid auth file name")
+	}
+	authDir := h.resolvedAuthDir()
+	if authDir == "" {
+		return nil, "", "", fmt.Errorf("auth directory is unavailable")
+	}
+	path := filepath.Join(authDir, filepath.Base(name))
+	if !filepath.IsAbs(path) {
+		if abs, errAbs := filepath.Abs(path); errAbs == nil {
+			path = abs
+		}
+	}
+	if _, errStat := os.Stat(path); errStat != nil {
+		if os.IsNotExist(errStat) {
+			return nil, "", "", fmt.Errorf("auth file not found for name %s", name)
+		}
+		return nil, "", "", fmt.Errorf("failed to stat auth file: %w", errStat)
+	}
+	return nil, path, filepath.Base(name), nil
+}
+
+func deleteNameForAuth(auth *coreauth.Auth, path string) string {
+	if auth != nil {
+		if name := strings.TrimSpace(auth.FileName); name != "" {
+			return name
+		}
+		if id := strings.TrimSpace(auth.ID); id != "" {
+			return id
+		}
+	}
+	return filepath.Base(path)
+}
+
+func (h *Host) removeAuth(ctx context.Context, id string) {
+	if h == nil {
+		return
+	}
+	manager := h.currentAuthManager()
+	if manager == nil {
+		return
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return
+	}
+	if _, ok := manager.GetByID(id); ok {
+		manager.Remove(ctx, id)
+		return
+	}
+	authID := h.authIDForPath(id)
+	if authID == "" {
+		return
+	}
+	manager.Remove(ctx, authID)
+}
+
+func (h *Host) removeAuthsForPath(ctx context.Context, path string, fallbackID string) {
+	if h == nil {
+		return
+	}
+	manager := h.currentAuthManager()
+	if manager == nil {
+		return
+	}
+	removed := false
+	for _, auth := range manager.List() {
+		if auth == nil {
+			continue
+		}
+		if sameAuthFilePath(authAttribute(auth, "path"), path) {
+			h.removeAuth(ctx, auth.ID)
+			removed = true
+		}
+	}
+	if removed {
+		return
+	}
+	if strings.TrimSpace(fallbackID) != "" {
+		h.removeAuth(ctx, fallbackID)
+		return
+	}
+	h.removeAuth(ctx, path)
+}
+
+func sameAuthFilePath(left, right string) bool {
+	left = cleanAuthFilePath(left)
+	right = cleanAuthFilePath(right)
+	if left == "" || right == "" {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(left, right)
+	}
+	return left == right
+}
+
+func cleanAuthFilePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if abs, errAbs := filepath.Abs(path); errAbs == nil && strings.TrimSpace(abs) != "" {
+		path = abs
+	}
+	return filepath.Clean(path)
 }
 
 func (h *Host) listAuthFiles() ([]pluginapi.HostAuthFileEntry, error) {

--- a/internal/pluginhost/auth_callbacks.go
+++ b/internal/pluginhost/auth_callbacks.go
@@ -285,8 +285,13 @@ func guardVirtualAuthDelete(auth *coreauth.Auth, selectedName string) error {
 	if sourcePath == "" {
 		sourcePath = strings.TrimSpace(authAttribute(auth, "path"))
 	}
+	// Only the physical source file name itself selects the whole expansion.
+	// An expanded auth ID may contain directory components (for example
+	// "nested/source.json") whose basename collides with the source name, so a
+	// selector carrying path components never matches the physical source.
 	if sourcePath != "" && selectedName != "" &&
-		strings.EqualFold(filepath.Base(selectedName), filepath.Base(sourcePath)) {
+		!strings.ContainsAny(selectedName, "/\\") &&
+		strings.EqualFold(selectedName, filepath.Base(sourcePath)) {
 		return nil
 	}
 	source := filepath.Base(sourcePath)

--- a/internal/pluginhost/auth_callbacks.go
+++ b/internal/pluginhost/auth_callbacks.go
@@ -214,6 +214,9 @@ func (h *Host) resolveAuthForDelete(req pluginapi.HostAuthDeleteRequest) (*corea
 		if path == "" {
 			return nil, "", "", fmt.Errorf("auth file path not found for auth_index %s", authIndex)
 		}
+		if errGuard := guardVirtualAuthDelete(auth, ""); errGuard != nil {
+			return nil, "", "", errGuard
+		}
 		return auth, path, deleteNameForAuth(auth, path), nil
 	}
 	manager := h.currentAuthManager()
@@ -222,6 +225,9 @@ func (h *Host) resolveAuthForDelete(req pluginapi.HostAuthDeleteRequest) (*corea
 			path := strings.TrimSpace(authAttribute(auth, "path"))
 			if path == "" {
 				return nil, "", "", fmt.Errorf("auth file path not found for name %s", name)
+			}
+			if errGuard := guardVirtualAuthDelete(auth, name); errGuard != nil {
+				return nil, "", "", errGuard
 			}
 			return auth, path, deleteNameForAuth(auth, path), nil
 		}
@@ -234,12 +240,18 @@ func (h *Host) resolveAuthForDelete(req pluginapi.HostAuthDeleteRequest) (*corea
 				if path == "" {
 					return nil, "", "", fmt.Errorf("auth file path not found for name %s", name)
 				}
+				if errGuard := guardVirtualAuthDelete(auth, name); errGuard != nil {
+					return nil, "", "", errGuard
+				}
 				return auth, path, deleteNameForAuth(auth, path), nil
 			}
 		}
 	}
 	if isUnsafeAuthFileName(name) {
 		return nil, "", "", fmt.Errorf("invalid auth file name")
+	}
+	if !strings.HasSuffix(strings.ToLower(name), ".json") {
+		return nil, "", "", fmt.Errorf("auth file name must end with .json")
 	}
 	authDir := h.resolvedAuthDir()
 	if authDir == "" {
@@ -258,6 +270,30 @@ func (h *Host) resolveAuthForDelete(req pluginapi.HostAuthDeleteRequest) (*corea
 		return nil, "", "", fmt.Errorf("failed to stat auth file: %w", errStat)
 	}
 	return nil, path, filepath.Base(name), nil
+}
+
+// guardVirtualAuthDelete rejects deleting an individual plugin-virtual auth.
+// Virtual auths expanded from one plugin-owned source file share the same backing
+// path, so deleting one child would remove the source file and every sibling.
+// Selecting the physical source file name deletes the whole expansion, matching
+// the management deletion flow.
+func guardVirtualAuthDelete(auth *coreauth.Auth, selectedName string) error {
+	if !coreauth.IsPluginVirtualAuth(auth) {
+		return nil
+	}
+	sourcePath := strings.TrimSpace(authAttribute(auth, coreauth.AttributeVirtualSource))
+	if sourcePath == "" {
+		sourcePath = strings.TrimSpace(authAttribute(auth, "path"))
+	}
+	if sourcePath != "" && selectedName != "" &&
+		strings.EqualFold(filepath.Base(selectedName), filepath.Base(sourcePath)) {
+		return nil
+	}
+	source := filepath.Base(sourcePath)
+	if source == "" || source == "." {
+		source = "its source file"
+	}
+	return fmt.Errorf("auth %s is expanded from a plugin-owned source file; delete %s instead", strings.TrimSpace(auth.ID), source)
 }
 
 func deleteNameForAuth(auth *coreauth.Auth, path string) string {

--- a/internal/pluginhost/auth_callbacks_test.go
+++ b/internal/pluginhost/auth_callbacks_test.go
@@ -484,3 +484,42 @@ func TestHostAuthDeleteCallbackRejectsNonJSONFallback(t *testing.T) {
 		t.Fatalf("stat note file after rejected delete: %v", errStat)
 	}
 }
+
+func TestHostAuthDeleteCallbackRejectsVirtualIDWithDirectoryComponents(t *testing.T) {
+	authDir := t.TempDir()
+	sourcePath := filepath.Join(authDir, "source.json")
+	if errWrite := os.WriteFile(sourcePath, []byte(`{"type":"demo","email":"src@example.com","api_key":"ks"}`), 0o600); errWrite != nil {
+		t.Fatalf("write source file: %v", errWrite)
+	}
+	host := New()
+	host.runtimeConfig = &config.Config{AuthDir: authDir}
+	manager := coreauth.NewManager(nil, nil, nil)
+	host.SetAuthManager(manager)
+	virtualAuth := &coreauth.Auth{
+		ID:       "nested/source.json",
+		Provider: "demo",
+		FileName: "nested/source.json",
+		Label:    "child@example.com",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"path":                          sourcePath,
+			coreauth.AttributePluginVirtual: "true",
+			coreauth.AttributeVirtualSource: sourcePath,
+		},
+		Metadata: map[string]any{"type": "demo", "email": "child@example.com"},
+	}
+	if _, errRegister := manager.Register(context.Background(), virtualAuth); errRegister != nil {
+		t.Fatalf("register virtual auth: %v", errRegister)
+	}
+
+	byVirtualID, errMarshal := json.Marshal(pluginapi.HostAuthDeleteRequest{Name: "nested/source.json"})
+	if errMarshal != nil {
+		t.Fatalf("marshal request: %v", errMarshal)
+	}
+	if _, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthDelete, byVirtualID); errCall == nil {
+		t.Fatal("delete by directory-carrying virtual ID error = nil, want virtual source guard")
+	}
+	if _, errStat := os.Stat(sourcePath); errStat != nil {
+		t.Fatalf("stat source file after rejected delete: %v", errStat)
+	}
+}

--- a/internal/pluginhost/auth_callbacks_test.go
+++ b/internal/pluginhost/auth_callbacks_test.go
@@ -393,3 +393,86 @@ func TestHostAuthDeleteCallbackRequiresSelector(t *testing.T) {
 		t.Fatal("callFromPlugin() error = nil, want missing selector error")
 	}
 }
+
+func TestHostAuthDeleteCallbackRejectsIndividualVirtualAuth(t *testing.T) {
+	authDir := t.TempDir()
+	sourcePath := filepath.Join(authDir, "source.json")
+	if errWrite := os.WriteFile(sourcePath, []byte(`{"type":"demo","email":"src@example.com","api_key":"ks"}`), 0o600); errWrite != nil {
+		t.Fatalf("write source file: %v", errWrite)
+	}
+	host := New()
+	host.runtimeConfig = &config.Config{AuthDir: authDir}
+	manager := coreauth.NewManager(nil, nil, nil)
+	host.SetAuthManager(manager)
+	virtualAuth := &coreauth.Auth{
+		ID:       "source.json::child",
+		Provider: "demo",
+		FileName: "source.json::child",
+		Label:    "child@example.com",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"path":                          sourcePath,
+			coreauth.AttributePluginVirtual: "true",
+			coreauth.AttributeVirtualSource: sourcePath,
+		},
+		Metadata: map[string]any{"type": "demo", "email": "child@example.com"},
+	}
+	if _, errRegister := manager.Register(context.Background(), virtualAuth); errRegister != nil {
+		t.Fatalf("register virtual auth: %v", errRegister)
+	}
+
+	byIndex, errMarshal := json.Marshal(pluginapi.HostAuthDeleteRequest{AuthIndex: virtualAuth.Index})
+	if errMarshal != nil {
+		t.Fatalf("marshal delete by index: %v", errMarshal)
+	}
+	if _, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthDelete, byIndex); errCall == nil {
+		t.Fatal("delete by virtual auth index error = nil, want virtual source guard")
+	}
+	if _, errStat := os.Stat(sourcePath); errStat != nil {
+		t.Fatalf("stat source file after rejected delete: %v", errStat)
+	}
+
+	byName, errMarshal := json.Marshal(pluginapi.HostAuthDeleteRequest{Name: "source.json::child"})
+	if errMarshal != nil {
+		t.Fatalf("marshal delete by name: %v", errMarshal)
+	}
+	if _, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthDelete, byName); errCall == nil {
+		t.Fatal("delete by virtual auth name error = nil, want virtual source guard")
+	}
+
+	bySource, errMarshal := json.Marshal(pluginapi.HostAuthDeleteRequest{Name: "source.json"})
+	if errMarshal != nil {
+		t.Fatalf("marshal delete by source: %v", errMarshal)
+	}
+	if _, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthDelete, bySource); errCall != nil {
+		t.Fatalf("delete by source file name error = %v, want success", errCall)
+	}
+	if _, errStat := os.Stat(sourcePath); !os.IsNotExist(errStat) {
+		t.Fatalf("stat source file after source delete err = %v, want not-exist", errStat)
+	}
+	if auths := manager.List(); len(auths) != 0 {
+		t.Fatalf("auths = %#v, want virtual expansion removed with source", auths)
+	}
+}
+
+func TestHostAuthDeleteCallbackRejectsNonJSONFallback(t *testing.T) {
+	authDir := t.TempDir()
+	notePath := filepath.Join(authDir, "notes.txt")
+	if errWrite := os.WriteFile(notePath, []byte("keep me"), 0o600); errWrite != nil {
+		t.Fatalf("write note file: %v", errWrite)
+	}
+	host := New()
+	host.runtimeConfig = &config.Config{AuthDir: authDir}
+	host.SetAuthManager(coreauth.NewManager(nil, nil, nil))
+
+	req, errMarshal := json.Marshal(pluginapi.HostAuthDeleteRequest{Name: "notes.txt"})
+	if errMarshal != nil {
+		t.Fatalf("marshal request: %v", errMarshal)
+	}
+	if _, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthDelete, req); errCall == nil {
+		t.Fatal("callFromPlugin() error = nil, want non-json rejection")
+	}
+	if _, errStat := os.Stat(notePath); errStat != nil {
+		t.Fatalf("stat note file after rejected delete: %v", errStat)
+	}
+}

--- a/internal/pluginhost/auth_callbacks_test.go
+++ b/internal/pluginhost/auth_callbacks_test.go
@@ -444,8 +444,16 @@ func TestHostAuthDeleteCallbackRejectsIndividualVirtualAuth(t *testing.T) {
 	if errMarshal != nil {
 		t.Fatalf("marshal delete by source: %v", errMarshal)
 	}
-	if _, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthDelete, bySource); errCall != nil {
+	rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthDelete, bySource)
+	if errCall != nil {
 		t.Fatalf("delete by source file name error = %v, want success", errCall)
+	}
+	resp, errDecode := decodeRPCEnvelope[pluginapi.HostAuthDeleteResponse](rawResp)
+	if errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if resp.Name != "source.json" {
+		t.Fatalf("response.Name = %q, want physical source name", resp.Name)
 	}
 	if _, errStat := os.Stat(sourcePath); !os.IsNotExist(errStat) {
 		t.Fatalf("stat source file after source delete err = %v, want not-exist", errStat)

--- a/internal/pluginhost/auth_callbacks_test.go
+++ b/internal/pluginhost/auth_callbacks_test.go
@@ -247,3 +247,149 @@ func TestHostAuthSaveCallbackWritesPhysicalFile(t *testing.T) {
 		t.Fatalf("auths = %#v, want one registered auth", auths)
 	}
 }
+
+func TestHostAuthSaveBatchCallbackWritesFiles(t *testing.T) {
+	authDir := t.TempDir()
+	host := New()
+	host.runtimeConfig = &config.Config{AuthDir: authDir}
+	host.SetAuthManager(coreauth.NewManager(nil, nil, nil))
+
+	req, errMarshal := json.Marshal(pluginapi.HostAuthSaveBatchRequest{
+		Files: []pluginapi.HostAuthSaveRequest{
+			{Name: "batch-a.json", JSON: json.RawMessage(`{"type":"demo","email":"a@example.com","api_key":"ka"}`)},
+			{Name: "batch-b.json", JSON: json.RawMessage(`{"type":"demo","email":"b@example.com","api_key":"kb"}`)},
+		},
+	})
+	if errMarshal != nil {
+		t.Fatalf("marshal request: %v", errMarshal)
+	}
+	rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthSaveBatch, req)
+	if errCall != nil {
+		t.Fatalf("callFromPlugin() error = %v", errCall)
+	}
+	resp, errDecode := decodeRPCEnvelope[pluginapi.HostAuthSaveBatchResponse](rawResp)
+	if errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if len(resp.Files) != 2 || resp.Files[0].Name != "batch-a.json" || resp.Files[1].Name != "batch-b.json" {
+		t.Fatalf("response = %#v, want two saved files in request order", resp)
+	}
+	for _, file := range resp.Files {
+		if _, errStat := os.Stat(file.Path); errStat != nil {
+			t.Fatalf("stat saved file %s: %v", file.Path, errStat)
+		}
+	}
+	if auths := host.currentAuthManager().List(); len(auths) != 2 {
+		t.Fatalf("auths = %#v, want two registered auths", auths)
+	}
+}
+
+func TestHostAuthSaveBatchCallbackRejectsInvalidBeforeAnyWrite(t *testing.T) {
+	authDir := t.TempDir()
+	host := New()
+	host.runtimeConfig = &config.Config{AuthDir: authDir}
+	host.SetAuthManager(coreauth.NewManager(nil, nil, nil))
+
+	req, errMarshal := json.Marshal(pluginapi.HostAuthSaveBatchRequest{
+		Files: []pluginapi.HostAuthSaveRequest{
+			{Name: "batch-ok.json", JSON: json.RawMessage(`{"type":"demo","email":"ok@example.com","api_key":"k"}`)},
+			{Name: "batch-bad.txt", JSON: json.RawMessage(`{"type":"demo"}`)},
+		},
+	})
+	if errMarshal != nil {
+		t.Fatalf("marshal request: %v", errMarshal)
+	}
+	if _, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthSaveBatch, req); errCall == nil {
+		t.Fatal("callFromPlugin() error = nil, want validation error")
+	}
+	entries, errReadDir := os.ReadDir(authDir)
+	if errReadDir != nil {
+		t.Fatalf("read auth dir: %v", errReadDir)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("auth dir entries = %d, want zero files after rejected batch", len(entries))
+	}
+	if auths := host.currentAuthManager().List(); len(auths) != 0 {
+		t.Fatalf("auths = %#v, want no registered auths after rejected batch", auths)
+	}
+}
+
+func TestHostAuthSaveBatchCallbackRejectsDuplicateNames(t *testing.T) {
+	authDir := t.TempDir()
+	host := New()
+	host.runtimeConfig = &config.Config{AuthDir: authDir}
+	host.SetAuthManager(coreauth.NewManager(nil, nil, nil))
+
+	req, errMarshal := json.Marshal(pluginapi.HostAuthSaveBatchRequest{
+		Files: []pluginapi.HostAuthSaveRequest{
+			{Name: "dup.json", JSON: json.RawMessage(`{"type":"demo","email":"a@example.com","api_key":"k1"}`)},
+			{Name: "DUP.json", JSON: json.RawMessage(`{"type":"demo","email":"b@example.com","api_key":"k2"}`)},
+		},
+	})
+	if errMarshal != nil {
+		t.Fatalf("marshal request: %v", errMarshal)
+	}
+	if _, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthSaveBatch, req); errCall == nil {
+		t.Fatal("callFromPlugin() error = nil, want duplicate name error")
+	}
+	if entries, errReadDir := os.ReadDir(authDir); errReadDir != nil || len(entries) != 0 {
+		t.Fatalf("auth dir entries = %v (err %v), want zero files after rejected batch", entries, errReadDir)
+	}
+}
+
+func TestHostAuthDeleteCallbackRemovesFileAndRuntime(t *testing.T) {
+	authDir := t.TempDir()
+	host := New()
+	host.runtimeConfig = &config.Config{AuthDir: authDir}
+	host.SetAuthManager(coreauth.NewManager(nil, nil, nil))
+
+	saveReq, errMarshal := json.Marshal(pluginapi.HostAuthSaveRequest{
+		Name: "delete-me.json",
+		JSON: json.RawMessage(`{"type":"demo","email":"gone@example.com","api_key":"kg"}`),
+	})
+	if errMarshal != nil {
+		t.Fatalf("marshal save request: %v", errMarshal)
+	}
+	if _, errSave := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthSave, saveReq); errSave != nil {
+		t.Fatalf("save auth file: %v", errSave)
+	}
+	if auths := host.currentAuthManager().List(); len(auths) != 1 {
+		t.Fatalf("auths = %#v, want one registered auth before delete", auths)
+	}
+
+	delReq, errMarshal := json.Marshal(pluginapi.HostAuthDeleteRequest{Name: "delete-me.json"})
+	if errMarshal != nil {
+		t.Fatalf("marshal delete request: %v", errMarshal)
+	}
+	rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthDelete, delReq)
+	if errCall != nil {
+		t.Fatalf("callFromPlugin() error = %v", errCall)
+	}
+	resp, errDecode := decodeRPCEnvelope[pluginapi.HostAuthDeleteResponse](rawResp)
+	if errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if resp.Name != "delete-me.json" || resp.Path == "" {
+		t.Fatalf("response = %#v, want deleted file identity", resp)
+	}
+	if _, errStat := os.Stat(resp.Path); !os.IsNotExist(errStat) {
+		t.Fatalf("stat deleted file err = %v, want not-exist", errStat)
+	}
+	if auths := host.currentAuthManager().List(); len(auths) != 0 {
+		t.Fatalf("auths = %#v, want no registered auths after delete", auths)
+	}
+}
+
+func TestHostAuthDeleteCallbackRequiresSelector(t *testing.T) {
+	host := New()
+	host.runtimeConfig = &config.Config{AuthDir: t.TempDir()}
+	host.SetAuthManager(coreauth.NewManager(nil, nil, nil))
+
+	req, errMarshal := json.Marshal(pluginapi.HostAuthDeleteRequest{})
+	if errMarshal != nil {
+		t.Fatalf("marshal request: %v", errMarshal)
+	}
+	if _, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthDelete, req); errCall == nil {
+		t.Fatal("callFromPlugin() error = nil, want missing selector error")
+	}
+}

--- a/internal/pluginhost/host_callbacks.go
+++ b/internal/pluginhost/host_callbacks.go
@@ -127,6 +127,10 @@ func (h *Host) callFromPlugin(ctx context.Context, method string, request []byte
 		return h.callHostAuthGetRuntime(ctx, request)
 	case pluginabi.MethodHostAuthSave:
 		return h.callHostAuthSave(ctx, request)
+	case pluginabi.MethodHostAuthSaveBatch:
+		return h.callHostAuthSaveBatch(ctx, request)
+	case pluginabi.MethodHostAuthDelete:
+		return h.callHostAuthDelete(ctx, request)
 	default:
 		return nil, fmt.Errorf("unsupported host callback %s", method)
 	}

--- a/sdk/pluginabi/types.go
+++ b/sdk/pluginabi/types.go
@@ -77,6 +77,8 @@ const (
 	MethodHostAuthGet            = "host.auth.get"
 	MethodHostAuthGetRuntime     = "host.auth.get_runtime"
 	MethodHostAuthSave           = "host.auth.save"
+	MethodHostAuthSaveBatch      = "host.auth.save_batch"
+	MethodHostAuthDelete         = "host.auth.delete"
 )
 
 type Envelope struct {

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -767,6 +767,38 @@ type HostAuthSaveResponse struct {
 	Path string `json:"path"`
 }
 
+// HostAuthSaveBatchRequest asks the host to persist multiple credential JSON files in one call.
+// The host validates every entry before writing; if any entry is invalid, nothing is saved.
+// Saving is performed sequentially after validation; a failure mid-batch reports the error
+// and leaves the already saved files in place.
+type HostAuthSaveBatchRequest struct {
+	// Files contains the ordered auth files to save.
+	Files []HostAuthSaveRequest `json:"files"`
+}
+
+// HostAuthSaveBatchResponse reports every auth file saved by a batch request.
+type HostAuthSaveBatchResponse struct {
+	// Files contains one response entry per saved auth file, in request order.
+	Files []HostAuthSaveResponse `json:"files"`
+}
+
+// HostAuthDeleteRequest asks the host to delete a credential through the authoritative token store.
+// Plugins must not delete auth paths themselves.
+type HostAuthDeleteRequest struct {
+	// AuthIndex identifies the credential index when known.
+	AuthIndex string `json:"auth_index,omitempty"`
+	// Name identifies the auth file name or auth ID when auth_index is unavailable.
+	Name string `json:"name,omitempty"`
+}
+
+// HostAuthDeleteResponse reports the deleted credential identity.
+type HostAuthDeleteResponse struct {
+	// Name is the deleted auth file name or auth ID.
+	Name string `json:"name"`
+	// Path is the deleted auth file path when available.
+	Path string `json:"path,omitempty"`
+}
+
 // HTTPRequest describes an upstream HTTP request issued through the host.
 type HTTPRequest struct {
 	// Method is the HTTP method.


### PR DESCRIPTION
## Motivation

The plugin RPC surface already lets plugins read and create credentials (`host.auth.list`, `host.auth.get`, `host.auth.save`), but offers no way to remove them, and no way to provision several related auth files together. Plugins that govern credential lifecycles — for example a governance plugin that projects one logical upstream account into multiple capability-scoped auth files — can create their projections but can never delete them, and multi-file provisioning requires one round trip per file with no shared validation step.

This PR adds two host callbacks that complete the lifecycle surface:

- **`host.auth.save_batch`** validates every entry up front (name safety, `.json` suffix, parseable JSON, no duplicate names) and writes nothing if any entry is invalid, then saves files sequentially through the existing `saveAuthFile` path and reports one response entry per file in request order.
- **`host.auth.delete`** resolves a credential by `auth_index`, auth ID, or file name, removes it through the registered token store, and unregisters every runtime auth bound to the same file path — mirroring the existing management API delete flow (`DeleteAuthFile` → `deleteTokenRecord` → runtime removal).

## Design notes

- **Atomicity trade-off**: the batch pre-validates all entries so an invalid batch writes nothing, but a failure mid-write leaves already-saved files in place (the error reports how many were saved). Fully atomic durable commit would require a `Store.SaveBatch` interface change plus implementations across all store backends; this PR deliberately avoids interface changes and keeps that as a possible follow-up.
- **Compatibility**: `SchemaVersion` stays at 1 — new host callbacks are gated by method name, and hosts without this change keep returning a clear "unsupported host callback" error, so plugins can feature-detect and degrade.
- Both callbacks reuse existing auth file validation, path resolution, and auth manager facilities; no behavior changes for existing callbacks.

## Testing

Five new tests in `internal/pluginhost/auth_callbacks_test.go`: batch write success, invalid-batch zero writes, duplicate-name rejection, delete removing file + runtime state, and delete requiring a selector. Full `internal/pluginhost`, `sdk/pluginapi`, `sdk/pluginabi` package tests pass; `cmd/server` builds clean.

Happy to split into two PRs (delete only / batch save only) if you prefer a smaller scope.
