### PR TITLE
fix(auth): share session-affinity binding across thinking-suffix variants and stop replaced selectors

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -113,12 +113,17 @@ type Manager struct {
 	selector                  Selector
 	// selectorSlot pins the active selector generation so a replaced selector
 	// is stopped only after its in-flight Pick calls have drained.
-	selectorSlot     *selectorSlot
-	hook             Hook
-	mu               sync.RWMutex
-	configCooldownMu sync.Mutex
-	auths            map[string]*Auth
-	scheduler        *authScheduler
+	selectorSlot *selectorSlot
+	// parkedSelectorSlots remembers selectors that stay referenced as affinity
+	// fallbacks after serving as the active selector, along with the
+	// generations they were reachable through, so they can be stopped once no
+	// active chain references them anymore.
+	parkedSelectorSlots map[Selector][]*selectorSlot
+	hook                Hook
+	mu                  sync.RWMutex
+	configCooldownMu    sync.Mutex
+	auths               map[string]*Auth
+	scheduler           *authScheduler
 	// pluginScheduler runs outside m.mu before falling back to native selection.
 	pluginScheduler PluginScheduler
 	// homeRuntimeAuths retains legacy session auth lookups for non-execution callers.

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -111,19 +111,11 @@ type Manager struct {
 	pendingCooldownStateStore CooldownStateStore
 	executors                 map[string]ProviderExecutor
 	selector                  Selector
-	// selectorSlot pins the active selector generation so a replaced selector
-	// is stopped only after its in-flight Pick calls have drained.
-	selectorSlot *selectorSlot
-	// parkedSelectorSlots remembers selectors that stay referenced as affinity
-	// fallbacks after serving as the active selector, along with the
-	// generations they were reachable through, so they can be stopped once no
-	// active chain references them anymore.
-	parkedSelectorSlots map[Selector][]*selectorSlot
-	hook                Hook
-	mu                  sync.RWMutex
-	configCooldownMu    sync.Mutex
-	auths               map[string]*Auth
-	scheduler           *authScheduler
+	hook                      Hook
+	mu                        sync.RWMutex
+	configCooldownMu          sync.Mutex
+	auths                     map[string]*Auth
+	scheduler                 *authScheduler
 	// pluginScheduler runs outside m.mu before falling back to native selection.
 	pluginScheduler PluginScheduler
 	// homeRuntimeAuths retains legacy session auth lookups for non-execution callers.
@@ -182,7 +174,6 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 		store:                 store,
 		executors:             make(map[string]ProviderExecutor),
 		selector:              selector,
-		selectorSlot:          &selectorSlot{selector: selector},
 		hook:                  hook,
 		auths:                 make(map[string]*Auth),
 		homeRuntimeAuths:      make(map[string]map[string]*Auth),

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -111,11 +111,14 @@ type Manager struct {
 	pendingCooldownStateStore CooldownStateStore
 	executors                 map[string]ProviderExecutor
 	selector                  Selector
-	hook                      Hook
-	mu                        sync.RWMutex
-	configCooldownMu          sync.Mutex
-	auths                     map[string]*Auth
-	scheduler                 *authScheduler
+	// selectorSlot pins the active selector generation so a replaced selector
+	// is stopped only after its in-flight Pick calls have drained.
+	selectorSlot     *selectorSlot
+	hook             Hook
+	mu               sync.RWMutex
+	configCooldownMu sync.Mutex
+	auths            map[string]*Auth
+	scheduler        *authScheduler
 	// pluginScheduler runs outside m.mu before falling back to native selection.
 	pluginScheduler PluginScheduler
 	// homeRuntimeAuths retains legacy session auth lookups for non-execution callers.
@@ -174,6 +177,7 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 		store:                 store,
 		executors:             make(map[string]ProviderExecutor),
 		selector:              selector,
+		selectorSlot:          &selectorSlot{selector: selector},
 		hook:                  hook,
 		auths:                 make(map[string]*Auth),
 		homeRuntimeAuths:      make(map[string]map[string]*Auth),

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -5,10 +5,8 @@ import (
 	"errors"
 	"math/rand/v2"
 	"net/http"
-	"reflect"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
@@ -236,29 +234,6 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 	}
 }
 
-// selectorSlot pins one selector generation and counts its in-flight Pick
-// calls, so a replaced selector can be stopped only after active uses drain.
-type selectorSlot struct {
-	selector Selector
-	inflight sync.WaitGroup
-}
-
-// acquireSelector returns the current selector and pins its generation. The
-// returned release func must be called once the caller no longer invokes the
-// selector; SetSelector defers stopping the replaced selector until then.
-func (m *Manager) acquireSelector() (Selector, func()) {
-	m.mu.RLock()
-	slot := m.selectorSlot
-	if slot != nil {
-		slot.inflight.Add(1)
-	}
-	m.mu.RUnlock()
-	if slot == nil {
-		return nil, func() {}
-	}
-	return slot.selector, func() { slot.inflight.Done() }
-}
-
 func (m *Manager) SetSelector(selector Selector) {
 	if m == nil {
 		return
@@ -268,157 +243,42 @@ func (m *Manager) SetSelector(selector Selector) {
 	}
 	m.mu.Lock()
 	previous := m.selector
-	previousSlot := m.selectorSlot
-	if sameSelectorInstance(previous, selector) {
-		// Re-setting the same instance must keep its generation: a fresh slot
-		// would drop tracking of picks still in flight on this selector.
-		m.mu.Unlock()
-		if m.scheduler != nil {
-			m.scheduler.setSelector(selector)
-			m.syncScheduler()
-		}
-		return
-	}
 	m.selector = selector
-	m.selectorSlot = &selectorSlot{selector: selector}
-	retirees := m.planSelectorRetireesLocked(previous, previousSlot, selector)
 	m.mu.Unlock()
 
-	// Stop retired selectors asynchronously: pick paths release m.mu before
-	// invoking the selector, so each retiree first waits for the generations
-	// it was reachable through to drain.
-	if len(retirees) > 0 {
-		go func() {
-			for _, retiree := range retirees {
-				for _, slot := range retiree.slots {
-					slot.inflight.Wait()
-				}
-				retiree.stoppable.Stop()
-			}
-		}()
+	// Only the built-in session affinity selector is stopped here: its Stop is
+	// idempotent and Pick remains safe afterwards (Stop merely halts the cache
+	// cleanup goroutine), so an in-flight pick cannot break. A previous
+	// affinity selector that the replacement still wraps as its fallback is
+	// left running, since the active selector keeps invoking its Pick. Custom
+	// selectors are owned by the SDK caller, which manages their lifecycle.
+	if prev, ok := previous.(*SessionAffinitySelector); ok && prev != selector && !selectorRetainedAsFallback(selector, prev) {
+		prev.Stop()
 	}
+
 	if m.scheduler != nil {
 		m.scheduler.setSelector(selector)
 		m.syncScheduler()
 	}
 }
 
-// retiredStoppable is a selector instance no longer referenced by the active
-// selection chain, together with the generations whose in-flight picks must
-// drain before the instance can be stopped.
-type retiredStoppable struct {
-	stoppable StoppableSelector
-	slots     []*selectorSlot
-}
-
-// planSelectorRetireesLocked decides which stoppable selectors reachable from
-// the replaced selector are no longer referenced by next, parking the ones
-// still in use. Lifecycle policy:
-//   - a selector still referenced through the replacement's fallback chain
-//     (e.g. wrapped via NewSessionAffinitySelector) is parked, not stopped,
-//     because the active selector keeps invoking its Pick;
-//   - a parked selector is stopped once no active chain references it, after
-//     every generation it was reachable through has drained;
-//   - implementations with uncomparable dynamic types are conservatively kept
-//     alive: identity cannot be established without panicking, and a re-set
-//     value may share pointer-backed state with the active one.
-//
-// Must be called with m.mu held.
-func (m *Manager) planSelectorRetireesLocked(previous Selector, previousSlot *selectorSlot, next Selector) []retiredStoppable {
-	var retirees []retiredStoppable
-	for _, instance := range selectorChain(previous) {
-		stoppable, ok := instance.(StoppableSelector)
-		if !ok || !selectorIdentityComparable(instance) {
-			continue
-		}
-		if selectorChainContains(next, instance) {
-			m.parkSelectorSlotLocked(instance, previousSlot)
-			continue
-		}
-		slots := m.takeParkedSelectorSlotsLocked(instance)
-		slots = appendSelectorSlotIfMissing(slots, previousSlot)
-		retirees = append(retirees, retiredStoppable{stoppable: stoppable, slots: slots})
-	}
-	return retirees
-}
-
-// selectorChain walks root and its SessionAffinitySelector fallback chain,
-// returning every reachable selector. The walk is depth-capped as a defensive
-// measure against malformed wrappers.
-func selectorChain(root Selector) []Selector {
-	chain := make([]Selector, 0, 2)
-	for root != nil && len(chain) < 16 {
-		chain = append(chain, root)
-		affinity, ok := root.(*SessionAffinitySelector)
+// selectorRetainedAsFallback reports whether prev still serves as a fallback
+// somewhere in the SessionAffinitySelector wrapper chain of next; stopping it
+// would break the active composition.
+func selectorRetainedAsFallback(next Selector, prev *SessionAffinitySelector) bool {
+	current := next
+	// Depth-capped as a defensive measure against malformed wrapper chains.
+	for depth := 0; depth < 16; depth++ {
+		affinity, ok := current.(*SessionAffinitySelector)
 		if !ok || affinity == nil {
-			break
+			return false
 		}
-		root = affinity.fallback
-	}
-	return chain
-}
-
-// selectorChainContains reports whether target appears in the fallback chain
-// of root, in which case stopping it would break the active composition.
-func selectorChainContains(root, target Selector) bool {
-	for _, instance := range selectorChain(root) {
-		if sameSelectorInstance(instance, target) {
+		if affinity.fallback == prev {
 			return true
 		}
+		current = affinity.fallback
 	}
 	return false
-}
-
-// selectorIdentityComparable reports whether values of the selector's dynamic
-// type can be compared without panicking, the precondition for tracking the
-// instance in Manager bookkeeping.
-func selectorIdentityComparable(selector Selector) bool {
-	if selector == nil {
-		return false
-	}
-	return reflect.TypeOf(selector).Comparable()
-}
-
-func (m *Manager) parkSelectorSlotLocked(selector Selector, slot *selectorSlot) {
-	if slot == nil {
-		return
-	}
-	if m.parkedSelectorSlots == nil {
-		m.parkedSelectorSlots = make(map[Selector][]*selectorSlot)
-	}
-	m.parkedSelectorSlots[selector] = appendSelectorSlotIfMissing(m.parkedSelectorSlots[selector], slot)
-}
-
-func (m *Manager) takeParkedSelectorSlotsLocked(selector Selector) []*selectorSlot {
-	slots := m.parkedSelectorSlots[selector]
-	delete(m.parkedSelectorSlots, selector)
-	return slots
-}
-
-func appendSelectorSlotIfMissing(slots []*selectorSlot, slot *selectorSlot) []*selectorSlot {
-	if slot == nil {
-		return slots
-	}
-	for _, existing := range slots {
-		if existing == slot {
-			return slots
-		}
-	}
-	return append(slots, slot)
-}
-
-// sameSelectorInstance reports whether two selectors reference the same
-// instance. It returns false for uncomparable dynamic types instead of
-// panicking on a direct interface comparison.
-func sameSelectorInstance(a, b Selector) bool {
-	if a == nil || b == nil {
-		return false
-	}
-	typeA, typeB := reflect.TypeOf(a), reflect.TypeOf(b)
-	if typeA != typeB || !typeA.Comparable() {
-		return false
-	}
-	return a == b
 }
 
 // Selector returns the current credential selector.
@@ -1170,17 +1030,15 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		return auth, exec, err
 	}
 
-	selector, releaseSelector := m.acquireSelector()
-	defer releaseSelector()
-
 	opts.EnsureMetadata()
 	opts.Metadata[cliproxyexecutor.SessionAffinityProviderMetadataKey] = provider
-	opts.Metadata[cliproxyexecutor.SessionAffinityModelMetadataKey] = selectionArgForSelector(selector, model)
+	opts.Metadata[cliproxyexecutor.SessionAffinityModelMetadataKey] = selectionArgForSelector(m.selector, model)
 
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
 	eligibility := authSelectionEligibilityForRequest(ctx, opts)
 
 	m.mu.RLock()
+	selector := m.selector
 	pluginScheduler := m.pluginScheduler
 	executor, okExecutor := m.executors[provider]
 	if !okExecutor {
@@ -1482,12 +1340,9 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		return m.pickNextViaHome(ctx, model, opts, tried)
 	}
 
-	selector, releaseSelector := m.acquireSelector()
-	defer releaseSelector()
-
 	opts.EnsureMetadata()
 	opts.Metadata[cliproxyexecutor.SessionAffinityProviderMetadataKey] = "mixed"
-	opts.Metadata[cliproxyexecutor.SessionAffinityModelMetadataKey] = selectionArgForSelector(selector, model)
+	opts.Metadata[cliproxyexecutor.SessionAffinityModelMetadataKey] = selectionArgForSelector(m.selector, model)
 
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
 	eligibility := authSelectionEligibilityForRequest(ctx, opts)
@@ -1505,6 +1360,7 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 	}
 
 	m.mu.RLock()
+	selector := m.selector
 	pluginScheduler := m.pluginScheduler
 	candidates := make([]*Auth, 0, len(m.auths))
 	modelKey := strings.TrimSpace(model)

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -250,13 +250,33 @@ func (m *Manager) SetSelector(selector Selector) {
 	// cache cleanup goroutine) so routing config changes do not leak them.
 	// Identity is checked without a bare interface comparison: the public
 	// Selector interface does not require comparable dynamic types, and
-	// comparing two uncomparable implementations would panic.
-	if stoppable, ok := previous.(StoppableSelector); ok && !sameSelectorInstance(previous, selector) {
+	// comparing two uncomparable implementations would panic. A selector that
+	// the replacement still references as its fallback (e.g. wrapping the
+	// previous selector via NewSessionAffinitySelector) stays alive, because
+	// the active selector keeps invoking its Pick.
+	if stoppable, ok := previous.(StoppableSelector); ok &&
+		!sameSelectorInstance(previous, selector) && !selectorRetainedAsFallback(selector, previous) {
 		stoppable.Stop()
 	}
 	if m.scheduler != nil {
 		m.scheduler.setSelector(selector)
 		m.syncScheduler()
+	}
+}
+
+// selectorRetainedAsFallback reports whether candidate is still referenced
+// through the fallback chain of selector, in which case stopping it would
+// break the active composition.
+func selectorRetainedAsFallback(selector, candidate Selector) bool {
+	for {
+		affinity, ok := selector.(*SessionAffinitySelector)
+		if !ok || affinity == nil {
+			return false
+		}
+		if sameSelectorInstance(affinity.fallback, candidate) {
+			return true
+		}
+		selector = affinity.fallback
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
@@ -235,6 +236,29 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 	}
 }
 
+// selectorSlot pins one selector generation and counts its in-flight Pick
+// calls, so a replaced selector can be stopped only after active uses drain.
+type selectorSlot struct {
+	selector Selector
+	inflight sync.WaitGroup
+}
+
+// acquireSelector returns the current selector and pins its generation. The
+// returned release func must be called once the caller no longer invokes the
+// selector; SetSelector defers stopping the replaced selector until then.
+func (m *Manager) acquireSelector() (Selector, func()) {
+	m.mu.RLock()
+	slot := m.selectorSlot
+	if slot != nil {
+		slot.inflight.Add(1)
+	}
+	m.mu.RUnlock()
+	if slot == nil {
+		return nil, func() {}
+	}
+	return slot.selector, func() { slot.inflight.Done() }
+}
+
 func (m *Manager) SetSelector(selector Selector) {
 	if m == nil {
 		return
@@ -244,7 +268,9 @@ func (m *Manager) SetSelector(selector Selector) {
 	}
 	m.mu.Lock()
 	previous := m.selector
+	previousSlot := m.selectorSlot
 	m.selector = selector
+	m.selectorSlot = &selectorSlot{selector: selector}
 	m.mu.Unlock()
 	// Release resources of the replaced selector (e.g. the session affinity
 	// cache cleanup goroutine) so routing config changes do not leak them.
@@ -256,7 +282,14 @@ func (m *Manager) SetSelector(selector Selector) {
 	// the active selector keeps invoking its Pick.
 	if stoppable, ok := previous.(StoppableSelector); ok &&
 		!sameSelectorInstance(previous, selector) && !selectorRetainedAsFallback(selector, previous) {
-		stoppable.Stop()
+		// Pick paths release m.mu before invoking the selector, so a hot reload
+		// could otherwise stop it mid-request; wait for in-flight picks to drain.
+		go func(slot *selectorSlot) {
+			if slot != nil {
+				slot.inflight.Wait()
+			}
+			stoppable.Stop()
+		}(previousSlot)
 	}
 	if m.scheduler != nil {
 		m.scheduler.setSelector(selector)
@@ -1043,15 +1076,17 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		return auth, exec, err
 	}
 
+	selector, releaseSelector := m.acquireSelector()
+	defer releaseSelector()
+
 	opts.EnsureMetadata()
 	opts.Metadata[cliproxyexecutor.SessionAffinityProviderMetadataKey] = provider
-	opts.Metadata[cliproxyexecutor.SessionAffinityModelMetadataKey] = selectionArgForSelector(m.selector, model)
+	opts.Metadata[cliproxyexecutor.SessionAffinityModelMetadataKey] = selectionArgForSelector(selector, model)
 
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
 	eligibility := authSelectionEligibilityForRequest(ctx, opts)
 
 	m.mu.RLock()
-	selector := m.selector
 	pluginScheduler := m.pluginScheduler
 	executor, okExecutor := m.executors[provider]
 	if !okExecutor {
@@ -1353,9 +1388,12 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		return m.pickNextViaHome(ctx, model, opts, tried)
 	}
 
+	selector, releaseSelector := m.acquireSelector()
+	defer releaseSelector()
+
 	opts.EnsureMetadata()
 	opts.Metadata[cliproxyexecutor.SessionAffinityProviderMetadataKey] = "mixed"
-	opts.Metadata[cliproxyexecutor.SessionAffinityModelMetadataKey] = selectionArgForSelector(m.selector, model)
+	opts.Metadata[cliproxyexecutor.SessionAffinityModelMetadataKey] = selectionArgForSelector(selector, model)
 
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
 	eligibility := authSelectionEligibilityForRequest(ctx, opts)
@@ -1373,7 +1411,6 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 	}
 
 	m.mu.RLock()
-	selector := m.selector
 	pluginScheduler := m.pluginScheduler
 	candidates := make([]*Auth, 0, len(m.auths))
 	modelKey := strings.TrimSpace(model)

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -242,8 +242,16 @@ func (m *Manager) SetSelector(selector Selector) {
 		selector = &RoundRobinSelector{}
 	}
 	m.mu.Lock()
+	previous := m.selector
 	m.selector = selector
 	m.mu.Unlock()
+	// Release resources of the replaced selector (e.g. the session affinity
+	// cache cleanup goroutine) so routing config changes do not leak them.
+	if previous != nil && previous != selector {
+		if stoppable, ok := previous.(StoppableSelector); ok {
+			stoppable.Stop()
+		}
+	}
 	if m.scheduler != nil {
 		m.scheduler.setSelector(selector)
 		m.syncScheduler()

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math/rand/v2"
 	"net/http"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -247,15 +248,30 @@ func (m *Manager) SetSelector(selector Selector) {
 	m.mu.Unlock()
 	// Release resources of the replaced selector (e.g. the session affinity
 	// cache cleanup goroutine) so routing config changes do not leak them.
-	if previous != nil && previous != selector {
-		if stoppable, ok := previous.(StoppableSelector); ok {
-			stoppable.Stop()
-		}
+	// Identity is checked without a bare interface comparison: the public
+	// Selector interface does not require comparable dynamic types, and
+	// comparing two uncomparable implementations would panic.
+	if stoppable, ok := previous.(StoppableSelector); ok && !sameSelectorInstance(previous, selector) {
+		stoppable.Stop()
 	}
 	if m.scheduler != nil {
 		m.scheduler.setSelector(selector)
 		m.syncScheduler()
 	}
+}
+
+// sameSelectorInstance reports whether two selectors reference the same
+// instance. It returns false for uncomparable dynamic types instead of
+// panicking on a direct interface comparison.
+func sameSelectorInstance(a, b Selector) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	typeA, typeB := reflect.TypeOf(a), reflect.TypeOf(b)
+	if typeA != typeB || !typeA.Comparable() {
+		return false
+	}
+	return a == b
 }
 
 // Selector returns the current credential selector.

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -269,27 +269,33 @@ func (m *Manager) SetSelector(selector Selector) {
 	m.mu.Lock()
 	previous := m.selector
 	previousSlot := m.selectorSlot
+	if sameSelectorInstance(previous, selector) {
+		// Re-setting the same instance must keep its generation: a fresh slot
+		// would drop tracking of picks still in flight on this selector.
+		m.mu.Unlock()
+		if m.scheduler != nil {
+			m.scheduler.setSelector(selector)
+			m.syncScheduler()
+		}
+		return
+	}
 	m.selector = selector
 	m.selectorSlot = &selectorSlot{selector: selector}
+	retirees := m.planSelectorRetireesLocked(previous, previousSlot, selector)
 	m.mu.Unlock()
-	// Release resources of the replaced selector (e.g. the session affinity
-	// cache cleanup goroutine) so routing config changes do not leak them.
-	// Identity is checked without a bare interface comparison: the public
-	// Selector interface does not require comparable dynamic types, and
-	// comparing two uncomparable implementations would panic. A selector that
-	// the replacement still references as its fallback (e.g. wrapping the
-	// previous selector via NewSessionAffinitySelector) stays alive, because
-	// the active selector keeps invoking its Pick.
-	if stoppable, ok := previous.(StoppableSelector); ok &&
-		!sameSelectorInstance(previous, selector) && !selectorRetainedAsFallback(selector, previous) {
-		// Pick paths release m.mu before invoking the selector, so a hot reload
-		// could otherwise stop it mid-request; wait for in-flight picks to drain.
-		go func(slot *selectorSlot) {
-			if slot != nil {
-				slot.inflight.Wait()
+
+	// Stop retired selectors asynchronously: pick paths release m.mu before
+	// invoking the selector, so each retiree first waits for the generations
+	// it was reachable through to drain.
+	if len(retirees) > 0 {
+		go func() {
+			for _, retiree := range retirees {
+				for _, slot := range retiree.slots {
+					slot.inflight.Wait()
+				}
+				retiree.stoppable.Stop()
 			}
-			stoppable.Stop()
-		}(previousSlot)
+		}()
 	}
 	if m.scheduler != nil {
 		m.scheduler.setSelector(selector)
@@ -297,20 +303,108 @@ func (m *Manager) SetSelector(selector Selector) {
 	}
 }
 
-// selectorRetainedAsFallback reports whether candidate is still referenced
-// through the fallback chain of selector, in which case stopping it would
-// break the active composition.
-func selectorRetainedAsFallback(selector, candidate Selector) bool {
-	for {
-		affinity, ok := selector.(*SessionAffinitySelector)
-		if !ok || affinity == nil {
-			return false
+// retiredStoppable is a selector instance no longer referenced by the active
+// selection chain, together with the generations whose in-flight picks must
+// drain before the instance can be stopped.
+type retiredStoppable struct {
+	stoppable StoppableSelector
+	slots     []*selectorSlot
+}
+
+// planSelectorRetireesLocked decides which stoppable selectors reachable from
+// the replaced selector are no longer referenced by next, parking the ones
+// still in use. Lifecycle policy:
+//   - a selector still referenced through the replacement's fallback chain
+//     (e.g. wrapped via NewSessionAffinitySelector) is parked, not stopped,
+//     because the active selector keeps invoking its Pick;
+//   - a parked selector is stopped once no active chain references it, after
+//     every generation it was reachable through has drained;
+//   - implementations with uncomparable dynamic types are conservatively kept
+//     alive: identity cannot be established without panicking, and a re-set
+//     value may share pointer-backed state with the active one.
+//
+// Must be called with m.mu held.
+func (m *Manager) planSelectorRetireesLocked(previous Selector, previousSlot *selectorSlot, next Selector) []retiredStoppable {
+	var retirees []retiredStoppable
+	for _, instance := range selectorChain(previous) {
+		stoppable, ok := instance.(StoppableSelector)
+		if !ok || !selectorIdentityComparable(instance) {
+			continue
 		}
-		if sameSelectorInstance(affinity.fallback, candidate) {
+		if selectorChainContains(next, instance) {
+			m.parkSelectorSlotLocked(instance, previousSlot)
+			continue
+		}
+		slots := m.takeParkedSelectorSlotsLocked(instance)
+		slots = appendSelectorSlotIfMissing(slots, previousSlot)
+		retirees = append(retirees, retiredStoppable{stoppable: stoppable, slots: slots})
+	}
+	return retirees
+}
+
+// selectorChain walks root and its SessionAffinitySelector fallback chain,
+// returning every reachable selector. The walk is depth-capped as a defensive
+// measure against malformed wrappers.
+func selectorChain(root Selector) []Selector {
+	chain := make([]Selector, 0, 2)
+	for root != nil && len(chain) < 16 {
+		chain = append(chain, root)
+		affinity, ok := root.(*SessionAffinitySelector)
+		if !ok || affinity == nil {
+			break
+		}
+		root = affinity.fallback
+	}
+	return chain
+}
+
+// selectorChainContains reports whether target appears in the fallback chain
+// of root, in which case stopping it would break the active composition.
+func selectorChainContains(root, target Selector) bool {
+	for _, instance := range selectorChain(root) {
+		if sameSelectorInstance(instance, target) {
 			return true
 		}
-		selector = affinity.fallback
 	}
+	return false
+}
+
+// selectorIdentityComparable reports whether values of the selector's dynamic
+// type can be compared without panicking, the precondition for tracking the
+// instance in Manager bookkeeping.
+func selectorIdentityComparable(selector Selector) bool {
+	if selector == nil {
+		return false
+	}
+	return reflect.TypeOf(selector).Comparable()
+}
+
+func (m *Manager) parkSelectorSlotLocked(selector Selector, slot *selectorSlot) {
+	if slot == nil {
+		return
+	}
+	if m.parkedSelectorSlots == nil {
+		m.parkedSelectorSlots = make(map[Selector][]*selectorSlot)
+	}
+	m.parkedSelectorSlots[selector] = appendSelectorSlotIfMissing(m.parkedSelectorSlots[selector], slot)
+}
+
+func (m *Manager) takeParkedSelectorSlotsLocked(selector Selector) []*selectorSlot {
+	slots := m.parkedSelectorSlots[selector]
+	delete(m.parkedSelectorSlots, selector)
+	return slots
+}
+
+func appendSelectorSlotIfMissing(slots []*selectorSlot, slot *selectorSlot) []*selectorSlot {
+	if slot == nil {
+		return slots
+	}
+	for _, existing := range slots {
+		if existing == slot {
+			return slots
+		}
+	}
+	return append(slots, slot)
 }
 
 // sameSelectorInstance reports whether two selectors reference the same

--- a/sdk/cliproxy/auth/conductor_set_selector_test.go
+++ b/sdk/cliproxy/auth/conductor_set_selector_test.go
@@ -89,3 +89,33 @@ func TestManagerSetSelectorUncomparableSelectorDoesNotPanic(t *testing.T) {
 		t.Fatalf("replaced uncomparable selector Stop() calls = %d, want 1", got)
 	}
 }
+
+// Enabling affinity by wrapping the current selector via
+// NewSessionAffinitySelector(previous) keeps the previous selector in service
+// as the fallback, so SetSelector must not stop it. The same holds when the
+// fallback is nested inside another affinity wrapper.
+func TestManagerSetSelectorDoesNotStopRetainedFallback(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubStoppableSelector{}
+	manager := NewManager(nil, stub, nil)
+
+	direct := NewSessionAffinitySelector(stub)
+	defer direct.Stop()
+	manager.SetSelector(direct)
+	if got := stub.stopped.Load(); got != 0 {
+		t.Fatalf("retained fallback selector Stop() calls = %d, want 0", got)
+	}
+
+	nested := NewSessionAffinitySelector(direct)
+	defer nested.Stop()
+	manager.SetSelector(nested)
+	if got := stub.stopped.Load(); got != 0 {
+		t.Fatalf("nested retained fallback selector Stop() calls = %d, want 0", got)
+	}
+	select {
+	case <-direct.cache.stopCh:
+		t.Fatalf("direct affinity wrapper was stopped while still serving as nested fallback")
+	default:
+	}
+}

--- a/sdk/cliproxy/auth/conductor_set_selector_test.go
+++ b/sdk/cliproxy/auth/conductor_set_selector_test.go
@@ -1,0 +1,56 @@
+package auth
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type stubStoppableSelector struct {
+	stopped atomic.Int32
+}
+
+func (s *stubStoppableSelector) Pick(_ context.Context, _, _ string, _ cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	if len(auths) == 0 {
+		return nil, &Error{Code: "auth_not_found", Message: "no auth candidates"}
+	}
+	return auths[0], nil
+}
+
+func (s *stubStoppableSelector) Stop() {
+	s.stopped.Add(1)
+}
+
+// Replacing a selector must release resources held by the previous one;
+// otherwise every routing config change leaks the replaced selector's
+// background cleanup goroutine and cache.
+func TestManagerSetSelectorStopsReplacedStoppableSelector(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubStoppableSelector{}
+	manager := NewManager(nil, stub, nil)
+
+	manager.SetSelector(&RoundRobinSelector{})
+	if got := stub.stopped.Load(); got != 1 {
+		t.Fatalf("replaced selector Stop() calls = %d, want 1", got)
+	}
+}
+
+// Re-setting the same selector instance must not stop it: the selector is
+// still the active one and its resources must stay alive.
+func TestManagerSetSelectorSameInstanceIsNotStopped(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubStoppableSelector{}
+	manager := NewManager(nil, stub, nil)
+
+	manager.SetSelector(stub)
+	if got := stub.stopped.Load(); got != 0 {
+		t.Fatalf("re-set same selector Stop() calls = %d, want 0", got)
+	}
+	if current := manager.Selector(); current != Selector(stub) {
+		t.Fatalf("Selector() = %T, want the re-set stub instance", current)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_set_selector_test.go
+++ b/sdk/cliproxy/auth/conductor_set_selector_test.go
@@ -54,3 +54,38 @@ func TestManagerSetSelectorSameInstanceIsNotStopped(t *testing.T) {
 		t.Fatalf("Selector() = %T, want the re-set stub instance", current)
 	}
 }
+
+// uncomparableStoppableSelector carries a slice, so values of this type panic
+// on a direct == interface comparison. The public Selector interface does not
+// require comparable implementations, so SetSelector must tolerate them.
+type uncomparableStoppableSelector struct {
+	tags    []string
+	stopped *atomic.Int32
+}
+
+func (s uncomparableStoppableSelector) Pick(_ context.Context, _, _ string, _ cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	if len(auths) == 0 {
+		return nil, &Error{Code: "auth_not_found", Message: "no auth candidates"}
+	}
+	return auths[0], nil
+}
+
+func (s uncomparableStoppableSelector) Stop() {
+	s.stopped.Add(1)
+}
+
+// Replacing an uncomparable custom selector with another value of the same
+// type must not panic: a bare previous != selector comparison panics exactly
+// in this case. The replaced instance is still stopped because identity
+// cannot be established for uncomparable types.
+func TestManagerSetSelectorUncomparableSelectorDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	var stopped atomic.Int32
+	manager := NewManager(nil, uncomparableStoppableSelector{stopped: &stopped}, nil)
+
+	manager.SetSelector(uncomparableStoppableSelector{stopped: &atomic.Int32{}})
+	if got := stopped.Load(); got != 1 {
+		t.Fatalf("replaced uncomparable selector Stop() calls = %d, want 1", got)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_set_selector_test.go
+++ b/sdk/cliproxy/auth/conductor_set_selector_test.go
@@ -37,6 +37,23 @@ func waitForStopCount(t *testing.T, counter *atomic.Int32, want int32) {
 	}
 }
 
+// waitForChannelClosed polls until ch is closed.
+func waitForChannelClosed(t *testing.T, ch <-chan struct{}, message string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		select {
+		case <-ch:
+			return
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatal(message)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // Replacing a selector must release resources held by the previous one;
 // otherwise every routing config change leaks the replaced selector's
 // background cleanup goroutine and cache.
@@ -88,8 +105,9 @@ func (s uncomparableStoppableSelector) Stop() {
 
 // Replacing an uncomparable custom selector with another value of the same
 // type must not panic: a bare previous != selector comparison panics exactly
-// in this case. The replaced instance is still stopped because identity
-// cannot be established for uncomparable types.
+// in this case. Because identity cannot be established, the previous value is
+// conservatively kept alive — it may share pointer-backed state with the
+// active one, so stopping it could break routing.
 func TestManagerSetSelectorUncomparableSelectorDoesNotPanic(t *testing.T) {
 	t.Parallel()
 
@@ -97,7 +115,9 @@ func TestManagerSetSelectorUncomparableSelectorDoesNotPanic(t *testing.T) {
 	manager := NewManager(nil, uncomparableStoppableSelector{stopped: &stopped}, nil)
 
 	manager.SetSelector(uncomparableStoppableSelector{stopped: &atomic.Int32{}})
-	waitForStopCount(t, &stopped, 1)
+	if got := stopped.Load(); got != 0 {
+		t.Fatalf("ambiguous-identity selector Stop() calls = %d, want 0 (conservatively kept alive)", got)
+	}
 }
 
 // Enabling affinity by wrapping the current selector via
@@ -198,4 +218,87 @@ func TestManagerSetSelectorDefersStopUntilInFlightPickDrains(t *testing.T) {
 	}
 
 	waitForStopCount(t, &stub.stopped, 1)
+}
+
+// Re-setting the same selector instance while one of its picks is in flight
+// must preserve the in-flight tracking: a fresh generation would let a later
+// replacement stop the selector while the original pick is still running.
+func TestManagerSetSelectorSameInstanceKeepsInFlightTracking(t *testing.T) {
+	t.Parallel()
+
+	stub := &blockingStoppableSelector{entered: make(chan struct{}), proceed: make(chan struct{})}
+	manager := NewManager(nil, stub, nil)
+	manager.RegisterExecutor(&replaceAwareExecutor{id: "blocking"})
+	if _, err := manager.Register(context.Background(), &Auth{ID: "auth-a", Provider: "blocking"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	pickDone := make(chan error, 1)
+	go func() {
+		_, errPick := manager.SelectAuth(context.Background(), "blocking", "", cliproxyexecutor.Options{})
+		pickDone <- errPick
+	}()
+	<-stub.entered
+
+	// Same instance re-set mid-pick, then a real replacement. The replacement
+	// must still wait for the pick that started before both swaps.
+	manager.SetSelector(stub)
+	manager.SetSelector(&RoundRobinSelector{})
+
+	time.Sleep(50 * time.Millisecond)
+	if got := stub.stopped.Load(); got != 0 {
+		t.Fatalf("selector Stop() calls = %d while its Pick was still in flight, want 0", got)
+	}
+
+	close(stub.proceed)
+	if errPick := <-pickDone; errPick != nil {
+		t.Fatalf("SelectAuth() error = %v", errPick)
+	}
+	waitForStopCount(t, &stub.stopped, 1)
+}
+
+// A selector retained as an affinity fallback is parked, not stopped; once the
+// wrapper chain that referenced it is retired and nothing references it
+// anymore, it must eventually be stopped instead of leaking forever.
+func TestManagerSetSelectorEventuallyStopsRetiredFallback(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubStoppableSelector{}
+	manager := NewManager(nil, stub, nil)
+
+	direct := NewSessionAffinitySelector(stub)
+	manager.SetSelector(direct)
+	if got := stub.stopped.Load(); got != 0 {
+		t.Fatalf("retained fallback selector Stop() calls = %d, want 0", got)
+	}
+
+	manager.SetSelector(&RoundRobinSelector{})
+	waitForStopCount(t, &stub.stopped, 1)
+	select {
+	case <-direct.cache.stopCh:
+	default:
+		t.Fatal("retired affinity wrapper was not stopped")
+	}
+}
+
+// A fallback shared by two affinity wrappers must survive the retirement of
+// one wrapper while the other is still active.
+func TestManagerSetSelectorSharedFallbackSurvivesWrapperRetirement(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubStoppableSelector{}
+	manager := NewManager(nil, stub, nil)
+
+	first := NewSessionAffinitySelector(stub)
+	manager.SetSelector(first)
+	second := NewSessionAffinitySelector(stub)
+	defer second.Stop()
+	manager.SetSelector(second)
+
+	// The first wrapper is retired, but the shared fallback still serves the
+	// active second wrapper and must not be stopped.
+	waitForChannelClosed(t, first.cache.stopCh, "first affinity wrapper was not stopped after retirement")
+	if got := stub.stopped.Load(); got != 0 {
+		t.Fatalf("shared fallback selector Stop() calls = %d while still referenced, want 0", got)
+	}
 }

--- a/sdk/cliproxy/auth/conductor_set_selector_test.go
+++ b/sdk/cliproxy/auth/conductor_set_selector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
@@ -23,6 +24,19 @@ func (s *stubStoppableSelector) Stop() {
 	s.stopped.Add(1)
 }
 
+// waitForStopCount polls until counter reaches want, tolerating the
+// asynchronous, drain-aware stopping performed by SetSelector.
+func waitForStopCount(t *testing.T, counter *atomic.Int32, want int32) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for counter.Load() != want {
+		if time.Now().After(deadline) {
+			t.Fatalf("Stop() calls = %d, want %d", counter.Load(), want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // Replacing a selector must release resources held by the previous one;
 // otherwise every routing config change leaks the replaced selector's
 // background cleanup goroutine and cache.
@@ -33,9 +47,7 @@ func TestManagerSetSelectorStopsReplacedStoppableSelector(t *testing.T) {
 	manager := NewManager(nil, stub, nil)
 
 	manager.SetSelector(&RoundRobinSelector{})
-	if got := stub.stopped.Load(); got != 1 {
-		t.Fatalf("replaced selector Stop() calls = %d, want 1", got)
-	}
+	waitForStopCount(t, &stub.stopped, 1)
 }
 
 // Re-setting the same selector instance must not stop it: the selector is
@@ -85,9 +97,7 @@ func TestManagerSetSelectorUncomparableSelectorDoesNotPanic(t *testing.T) {
 	manager := NewManager(nil, uncomparableStoppableSelector{stopped: &stopped}, nil)
 
 	manager.SetSelector(uncomparableStoppableSelector{stopped: &atomic.Int32{}})
-	if got := stopped.Load(); got != 1 {
-		t.Fatalf("replaced uncomparable selector Stop() calls = %d, want 1", got)
-	}
+	waitForStopCount(t, &stopped, 1)
 }
 
 // Enabling affinity by wrapping the current selector via
@@ -118,4 +128,74 @@ func TestManagerSetSelectorDoesNotStopRetainedFallback(t *testing.T) {
 		t.Fatalf("direct affinity wrapper was stopped while still serving as nested fallback")
 	default:
 	}
+}
+
+// blockingStoppableSelector blocks inside Pick until released, simulating an
+// in-flight credential selection during a routing config change.
+type blockingStoppableSelector struct {
+	stopped atomic.Int32
+	entered chan struct{}
+	proceed chan struct{}
+}
+
+func (s *blockingStoppableSelector) Pick(_ context.Context, _, _ string, _ cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	close(s.entered)
+	<-s.proceed
+	if len(auths) == 0 {
+		return nil, &Error{Code: "auth_not_found", Message: "no auth candidates"}
+	}
+	return auths[0], nil
+}
+
+func (s *blockingStoppableSelector) Stop() {
+	s.stopped.Add(1)
+}
+
+// Pick paths release m.mu before invoking the selector, so a hot reload must
+// not stop the replaced selector while one of its Pick calls is still in
+// flight; the stop happens once the in-flight pick has drained.
+func TestManagerSetSelectorDefersStopUntilInFlightPickDrains(t *testing.T) {
+	t.Parallel()
+
+	stub := &blockingStoppableSelector{entered: make(chan struct{}), proceed: make(chan struct{})}
+	manager := NewManager(nil, stub, nil)
+	manager.RegisterExecutor(&replaceAwareExecutor{id: "blocking"})
+	if _, err := manager.Register(context.Background(), &Auth{ID: "auth-a", Provider: "blocking"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	pickDone := make(chan error, 1)
+	go func() {
+		// No route model: the auth carries no model list, so an explicit model
+		// would be filtered out before the selector is ever invoked.
+		_, errPick := manager.SelectAuth(context.Background(), "blocking", "", cliproxyexecutor.Options{})
+		pickDone <- errPick
+	}()
+	<-stub.entered
+
+	swapDone := make(chan struct{})
+	go func() {
+		manager.SetSelector(&RoundRobinSelector{})
+		close(swapDone)
+	}()
+	select {
+	case <-swapDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SetSelector blocked while a pick was in flight")
+	}
+
+	// The in-flight pick is still parked, so the replaced selector must not
+	// have been stopped yet. A short sleep gives a synchronous (broken)
+	// implementation room to run.
+	time.Sleep(50 * time.Millisecond)
+	if got := stub.stopped.Load(); got != 0 {
+		t.Fatalf("replaced selector Stop() calls = %d while a Pick was in flight, want 0", got)
+	}
+
+	close(stub.proceed)
+	if errPick := <-pickDone; errPick != nil {
+		t.Fatalf("SelectAuth() error = %v", errPick)
+	}
+
+	waitForStopCount(t, &stub.stopped, 1)
 }

--- a/sdk/cliproxy/auth/conductor_set_selector_test.go
+++ b/sdk/cliproxy/auth/conductor_set_selector_test.go
@@ -24,19 +24,6 @@ func (s *stubStoppableSelector) Stop() {
 	s.stopped.Add(1)
 }
 
-// waitForStopCount polls until counter reaches want, tolerating the
-// asynchronous, drain-aware stopping performed by SetSelector.
-func waitForStopCount(t *testing.T, counter *atomic.Int32, want int32) {
-	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	for counter.Load() != want {
-		if time.Now().After(deadline) {
-			t.Fatalf("Stop() calls = %d, want %d", counter.Load(), want)
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-}
-
 // waitForChannelClosed polls until ch is closed.
 func waitForChannelClosed(t *testing.T, ch <-chan struct{}, message string) {
 	t.Helper()
@@ -54,251 +41,71 @@ func waitForChannelClosed(t *testing.T, ch <-chan struct{}, message string) {
 	}
 }
 
-// Replacing a selector must release resources held by the previous one;
+// Replacing the built-in session affinity selector must release its resources;
 // otherwise every routing config change leaks the replaced selector's
-// background cleanup goroutine and cache.
-func TestManagerSetSelectorStopsReplacedStoppableSelector(t *testing.T) {
+// background cache cleanup goroutine.
+func TestManagerSetSelectorStopsReplacedAffinitySelector(t *testing.T) {
 	t.Parallel()
 
-	stub := &stubStoppableSelector{}
-	manager := NewManager(nil, stub, nil)
+	affinity := NewSessionAffinitySelector(&RoundRobinSelector{})
+	manager := NewManager(nil, affinity, nil)
 
 	manager.SetSelector(&RoundRobinSelector{})
-	waitForStopCount(t, &stub.stopped, 1)
-}
-
-// Re-setting the same selector instance must not stop it: the selector is
-// still the active one and its resources must stay alive.
-func TestManagerSetSelectorSameInstanceIsNotStopped(t *testing.T) {
-	t.Parallel()
-
-	stub := &stubStoppableSelector{}
-	manager := NewManager(nil, stub, nil)
-
-	manager.SetSelector(stub)
-	if got := stub.stopped.Load(); got != 0 {
-		t.Fatalf("re-set same selector Stop() calls = %d, want 0", got)
-	}
-	if current := manager.Selector(); current != Selector(stub) {
-		t.Fatalf("Selector() = %T, want the re-set stub instance", current)
-	}
-}
-
-// uncomparableStoppableSelector carries a slice, so values of this type panic
-// on a direct == interface comparison. The public Selector interface does not
-// require comparable implementations, so SetSelector must tolerate them.
-type uncomparableStoppableSelector struct {
-	tags    []string
-	stopped *atomic.Int32
-}
-
-func (s uncomparableStoppableSelector) Pick(_ context.Context, _, _ string, _ cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
-	if len(auths) == 0 {
-		return nil, &Error{Code: "auth_not_found", Message: "no auth candidates"}
-	}
-	return auths[0], nil
-}
-
-func (s uncomparableStoppableSelector) Stop() {
-	s.stopped.Add(1)
-}
-
-// Replacing an uncomparable custom selector with another value of the same
-// type must not panic: a bare previous != selector comparison panics exactly
-// in this case. Because identity cannot be established, the previous value is
-// conservatively kept alive — it may share pointer-backed state with the
-// active one, so stopping it could break routing.
-func TestManagerSetSelectorUncomparableSelectorDoesNotPanic(t *testing.T) {
-	t.Parallel()
-
-	var stopped atomic.Int32
-	manager := NewManager(nil, uncomparableStoppableSelector{stopped: &stopped}, nil)
-
-	manager.SetSelector(uncomparableStoppableSelector{stopped: &atomic.Int32{}})
-	if got := stopped.Load(); got != 0 {
-		t.Fatalf("ambiguous-identity selector Stop() calls = %d, want 0 (conservatively kept alive)", got)
-	}
+	waitForChannelClosed(t, affinity.cache.stopCh, "replaced affinity selector was not stopped")
 }
 
 // Enabling affinity by wrapping the current selector via
 // NewSessionAffinitySelector(previous) keeps the previous selector in service
-// as the fallback, so SetSelector must not stop it. The same holds when the
-// fallback is nested inside another affinity wrapper.
+// as the fallback, so SetSelector must not stop it.
 func TestManagerSetSelectorDoesNotStopRetainedFallback(t *testing.T) {
 	t.Parallel()
 
-	stub := &stubStoppableSelector{}
-	manager := NewManager(nil, stub, nil)
+	inner := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer inner.Stop()
+	manager := NewManager(nil, inner, nil)
 
-	direct := NewSessionAffinitySelector(stub)
-	defer direct.Stop()
-	manager.SetSelector(direct)
-	if got := stub.stopped.Load(); got != 0 {
-		t.Fatalf("retained fallback selector Stop() calls = %d, want 0", got)
-	}
+	outer := NewSessionAffinitySelector(inner)
+	defer outer.Stop()
+	manager.SetSelector(outer)
 
-	nested := NewSessionAffinitySelector(direct)
-	defer nested.Stop()
-	manager.SetSelector(nested)
-	if got := stub.stopped.Load(); got != 0 {
-		t.Fatalf("nested retained fallback selector Stop() calls = %d, want 0", got)
-	}
 	select {
-	case <-direct.cache.stopCh:
-		t.Fatalf("direct affinity wrapper was stopped while still serving as nested fallback")
+	case <-inner.cache.stopCh:
+		t.Fatal("affinity selector retained as fallback was stopped")
 	default:
 	}
 }
 
-// blockingStoppableSelector blocks inside Pick until released, simulating an
-// in-flight credential selection during a routing config change.
-type blockingStoppableSelector struct {
-	stopped atomic.Int32
-	entered chan struct{}
-	proceed chan struct{}
-}
-
-func (s *blockingStoppableSelector) Pick(_ context.Context, _, _ string, _ cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
-	close(s.entered)
-	<-s.proceed
-	if len(auths) == 0 {
-		return nil, &Error{Code: "auth_not_found", Message: "no auth candidates"}
-	}
-	return auths[0], nil
-}
-
-func (s *blockingStoppableSelector) Stop() {
-	s.stopped.Add(1)
-}
-
-// Pick paths release m.mu before invoking the selector, so a hot reload must
-// not stop the replaced selector while one of its Pick calls is still in
-// flight; the stop happens once the in-flight pick has drained.
-func TestManagerSetSelectorDefersStopUntilInFlightPickDrains(t *testing.T) {
+// Re-setting the same affinity selector instance must not stop it: the
+// selector is still the active one and its resources must stay alive.
+func TestManagerSetSelectorSameAffinityInstanceIsNotStopped(t *testing.T) {
 	t.Parallel()
 
-	stub := &blockingStoppableSelector{entered: make(chan struct{}), proceed: make(chan struct{})}
-	manager := NewManager(nil, stub, nil)
-	manager.RegisterExecutor(&replaceAwareExecutor{id: "blocking"})
-	if _, err := manager.Register(context.Background(), &Auth{ID: "auth-a", Provider: "blocking"}); err != nil {
-		t.Fatalf("Register() error = %v", err)
-	}
+	affinity := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer affinity.Stop()
+	manager := NewManager(nil, affinity, nil)
 
-	pickDone := make(chan error, 1)
-	go func() {
-		// No route model: the auth carries no model list, so an explicit model
-		// would be filtered out before the selector is ever invoked.
-		_, errPick := manager.SelectAuth(context.Background(), "blocking", "", cliproxyexecutor.Options{})
-		pickDone <- errPick
-	}()
-	<-stub.entered
-
-	swapDone := make(chan struct{})
-	go func() {
-		manager.SetSelector(&RoundRobinSelector{})
-		close(swapDone)
-	}()
+	manager.SetSelector(affinity)
 	select {
-	case <-swapDone:
-	case <-time.After(5 * time.Second):
-		t.Fatal("SetSelector blocked while a pick was in flight")
-	}
-
-	// The in-flight pick is still parked, so the replaced selector must not
-	// have been stopped yet. A short sleep gives a synchronous (broken)
-	// implementation room to run.
-	time.Sleep(50 * time.Millisecond)
-	if got := stub.stopped.Load(); got != 0 {
-		t.Fatalf("replaced selector Stop() calls = %d while a Pick was in flight, want 0", got)
-	}
-
-	close(stub.proceed)
-	if errPick := <-pickDone; errPick != nil {
-		t.Fatalf("SelectAuth() error = %v", errPick)
-	}
-
-	waitForStopCount(t, &stub.stopped, 1)
-}
-
-// Re-setting the same selector instance while one of its picks is in flight
-// must preserve the in-flight tracking: a fresh generation would let a later
-// replacement stop the selector while the original pick is still running.
-func TestManagerSetSelectorSameInstanceKeepsInFlightTracking(t *testing.T) {
-	t.Parallel()
-
-	stub := &blockingStoppableSelector{entered: make(chan struct{}), proceed: make(chan struct{})}
-	manager := NewManager(nil, stub, nil)
-	manager.RegisterExecutor(&replaceAwareExecutor{id: "blocking"})
-	if _, err := manager.Register(context.Background(), &Auth{ID: "auth-a", Provider: "blocking"}); err != nil {
-		t.Fatalf("Register() error = %v", err)
-	}
-
-	pickDone := make(chan error, 1)
-	go func() {
-		_, errPick := manager.SelectAuth(context.Background(), "blocking", "", cliproxyexecutor.Options{})
-		pickDone <- errPick
-	}()
-	<-stub.entered
-
-	// Same instance re-set mid-pick, then a real replacement. The replacement
-	// must still wait for the pick that started before both swaps.
-	manager.SetSelector(stub)
-	manager.SetSelector(&RoundRobinSelector{})
-
-	time.Sleep(50 * time.Millisecond)
-	if got := stub.stopped.Load(); got != 0 {
-		t.Fatalf("selector Stop() calls = %d while its Pick was still in flight, want 0", got)
-	}
-
-	close(stub.proceed)
-	if errPick := <-pickDone; errPick != nil {
-		t.Fatalf("SelectAuth() error = %v", errPick)
-	}
-	waitForStopCount(t, &stub.stopped, 1)
-}
-
-// A selector retained as an affinity fallback is parked, not stopped; once the
-// wrapper chain that referenced it is retired and nothing references it
-// anymore, it must eventually be stopped instead of leaking forever.
-func TestManagerSetSelectorEventuallyStopsRetiredFallback(t *testing.T) {
-	t.Parallel()
-
-	stub := &stubStoppableSelector{}
-	manager := NewManager(nil, stub, nil)
-
-	direct := NewSessionAffinitySelector(stub)
-	manager.SetSelector(direct)
-	if got := stub.stopped.Load(); got != 0 {
-		t.Fatalf("retained fallback selector Stop() calls = %d, want 0", got)
-	}
-
-	manager.SetSelector(&RoundRobinSelector{})
-	waitForStopCount(t, &stub.stopped, 1)
-	select {
-	case <-direct.cache.stopCh:
+	case <-affinity.cache.stopCh:
+		t.Fatal("re-set same affinity selector was stopped")
 	default:
-		t.Fatal("retired affinity wrapper was not stopped")
+	}
+	if current := manager.Selector(); current != Selector(affinity) {
+		t.Fatalf("Selector() = %T, want the re-set affinity instance", current)
 	}
 }
 
-// A fallback shared by two affinity wrappers must survive the retirement of
-// one wrapper while the other is still active.
-func TestManagerSetSelectorSharedFallbackSurvivesWrapperRetirement(t *testing.T) {
+// Custom selectors are owned by the SDK caller: SetSelector never stops them,
+// even when they implement StoppableSelector. Only the built-in affinity
+// selector is managed, because its Stop is idempotent and leaves Pick safe.
+func TestManagerSetSelectorLeavesCustomSelectorLifecycleToCaller(t *testing.T) {
 	t.Parallel()
 
 	stub := &stubStoppableSelector{}
 	manager := NewManager(nil, stub, nil)
 
-	first := NewSessionAffinitySelector(stub)
-	manager.SetSelector(first)
-	second := NewSessionAffinitySelector(stub)
-	defer second.Stop()
-	manager.SetSelector(second)
-
-	// The first wrapper is retired, but the shared fallback still serves the
-	// active second wrapper and must not be stopped.
-	waitForChannelClosed(t, first.cache.stopCh, "first affinity wrapper was not stopped after retirement")
+	manager.SetSelector(&RoundRobinSelector{})
 	if got := stub.stopped.Load(); got != 0 {
-		t.Fatalf("shared fallback selector Stop() calls = %d while still referenced, want 0", got)
+		t.Fatalf("custom selector Stop() calls = %d, want 0 (lifecycle owned by caller)", got)
 	}
 }

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -684,10 +684,14 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	}
 	fallbackAuths := highestPriorityAuths(available)
 
-	cacheKey := provider + "::" + primaryID + "::" + model
+	// Canonicalize the route model so thinking-suffix variants of the same base
+	// model (e.g. "claude-3" and "claude-3(high)") share one session binding,
+	// matching the canonicalization used for cursors and cooldown states.
+	keyModel := canonicalModelKey(model)
+	cacheKey := provider + "::" + primaryID + "::" + keyModel
 	fallbackKey := ""
 	if fallbackID != "" && fallbackID != primaryID {
-		fallbackKey = provider + "::" + fallbackID + "::" + model
+		fallbackKey = provider + "::" + fallbackID + "::" + keyModel
 	}
 	bind := func(authID string) {
 		if fallbackKey != "" {
@@ -787,6 +791,9 @@ func (s *SessionAffinitySelector) OnResult(res Result) {
 	if raw, ok := res.Options.Metadata[cliproxyexecutor.SessionAffinityModelMetadataKey].(string); ok && raw != "" {
 		nsModel = raw
 	}
+	// Match the canonical model key used when the binding was created in Pick,
+	// so thinking-suffix variants resolve to the same cache entry.
+	nsModel = canonicalModelKey(nsModel)
 
 	cacheKey := ns + "::" + primaryID + "::" + nsModel
 	var fallbackKey string

--- a/sdk/cliproxy/auth/session_affinity_canonical_model_test.go
+++ b/sdk/cliproxy/auth/session_affinity_canonical_model_test.go
@@ -1,0 +1,88 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// Thinking-suffix variants of the same route model (e.g. "claude-3" and
+// "claude-3(high)") share one credential pool and one cooldown state, so a
+// session bound through one variant must stay bound when a later request in
+// the same session arrives with another variant.
+func TestSessionAffinitySelector_ThinkingSuffixSharesSessionBinding(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer selector.Stop()
+
+	auths := []*Auth{
+		{ID: "auth-a"},
+		{ID: "auth-b"},
+	}
+	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_suffix-share"}}`)
+	opts := cliproxyexecutor.Options{OriginalRequest: payload}
+
+	first, err := selector.Pick(context.Background(), "claude", "claude-3(high)", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+
+	for _, model := range []string{"claude-3", "claude-3(low)", "claude-3(high)"} {
+		got, errPick := selector.Pick(context.Background(), "claude", model, opts, auths)
+		if errPick != nil {
+			t.Fatalf("Pick(%q) error = %v", model, errPick)
+		}
+		if got.ID != first.ID {
+			t.Fatalf("Pick(%q) auth.ID = %q, want sticky auth %q (thinking-suffix variants must share the session binding)", model, got.ID, first.ID)
+		}
+	}
+}
+
+// A failure reported with the base model name must release a binding that was
+// created through a thinking-suffixed variant of the same route model.
+func TestSessionAffinityOnResult_ThinkingSuffixReleasesBinding(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer selector.Stop()
+
+	auths := []*Auth{
+		{ID: "auth-a"},
+		{ID: "auth-b"},
+	}
+	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_suffix-release"}}`)
+	opts := cliproxyexecutor.Options{OriginalRequest: payload}
+
+	first, err := selector.Pick(context.Background(), "claude", "claude-3(high)", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+
+	// The next request of the same session arrives without the suffix and fails.
+	second, errPick := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+	if errPick != nil {
+		t.Fatalf("Pick() error = %v", errPick)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("Pick() auth.ID = %q, want sticky auth %q before failure", second.ID, first.ID)
+	}
+	selector.OnResult(Result{
+		AuthID:   second.ID,
+		Provider: "claude",
+		Model:    "claude-3",
+		Success:  false,
+		Error:    &Error{Code: "upstream_error", Message: "upstream failed"},
+		Options:  opts,
+	})
+
+	// The binding is released, so the round-robin fallback must move on.
+	third, errPick := selector.Pick(context.Background(), "claude", "claude-3(high)", opts, auths)
+	if errPick != nil {
+		t.Fatalf("Pick() after failure error = %v", errPick)
+	}
+	if third.ID == first.ID {
+		t.Fatalf("Pick() after failure auth.ID = %q, want reselection after the binding was released", third.ID)
+	}
+}


### PR DESCRIPTION
## Summary

Two small fixes in the session-affinity routing area:

1. **Thinking-suffix variants split session bindings** (`selector.go`): the affinity cache key embedded the raw route model, while round-robin cursors (`RoundRobinSelector.Pick`) and cooldown states already canonicalize thinking suffixes via `canonicalModelKey`. A session sending `model` and `model(high)` was therefore split into two independent bindings and could land on different credentials, silently breaking stickiness; `OnResult` failure cleanup could also miss the binding for the same reason. Both `Pick` and `OnResult` now canonicalize the model when building cache keys, matching the rest of the routing pipeline.

2. **`SetSelector` leaks the replaced selector** (`conductor_selection.go`): `SessionAffinitySelector` owns a `SessionCache` with a background cleanup goroutine, but `Manager.SetSelector` discarded the previous selector without stopping it. Every routing config change — and the first config apply at startup, which replaces the builder-created selector — leaked one goroutine and its cache map for the process lifetime. `SetSelector` now stops the replaced selector when it implements `StoppableSelector`, skipping the re-set-same-instance case.

## Tests

New regression tests, all red before the fix and green after:

- `TestSessionAffinitySelector_ThinkingSuffixSharesSessionBinding`
- `TestSessionAffinityOnResult_ThinkingSuffixReleasesBinding`
- `TestManagerSetSelectorStopsReplacedStoppableSelector`
- `TestManagerSetSelectorSameInstanceIsNotStopped`

## Verification

- `go build ./cmd/server`: OK
- `go test ./...` on **Linux (WSL2, go1.26.0 linux/amd64)**: everything passes except 3 pre-existing failures in `internal/runtime/executor` (`TestApplyClaudeHeaders_DisableDeviceProfileStabilization`, `TestApplyClaudeHeaders_LegacyModePreservesConfiguredUserAgentOverrideForClaudeClients`, `TestClaudeExecutor_NonClaudeRequestUsesClaudeCode220CLIFingerprint`). Verified these fail identically on unmodified `main` — they are unrelated to this change.
- `go test ./sdk/cliproxy/...`: fully green.