### PR TITLE
fix(auth): share session-affinity binding across thinking-suffix variants and stop replaced selectors

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -82,6 +82,15 @@ type StoppableSelector interface {
 	Stop()
 }
 
+// ResumableSelector is an optional interface for selectors whose background
+// resources can restart after a Stop. SetSelector calls Resume on the
+// installed selector, so a selector that was stopped while retired becomes
+// fully operational again when it is re-installed.
+type ResumableSelector interface {
+	Selector
+	Resume()
+}
+
 // Hook captures lifecycle callbacks for observing auth changes.
 type Hook interface {
 	// OnAuthRegistered fires when a new auth is registered.

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -250,6 +250,23 @@ func (m *Manager) SetSelector(selector Selector) {
 	}
 }
 
+// StopSelectorIfInactive stops target unless it is currently the active
+// selector, atomically with respect to SetSelector. It lets the owner of a
+// replaced selector retire it safely: a concurrent SetSelector re-installing
+// target wins and the stop is skipped. The Manager never stops selectors
+// implicitly; lifecycle stays with the selector's owner.
+func (m *Manager) StopSelectorIfInactive(target *SessionAffinitySelector) {
+	if m == nil || target == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.selector == target {
+		return
+	}
+	target.Stop()
+}
+
 // Selector returns the current credential selector.
 func (m *Manager) Selector() Selector {
 	if m == nil {

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -244,6 +244,13 @@ func (m *Manager) SetSelector(selector Selector) {
 	m.mu.Lock()
 	m.selector = selector
 	m.mu.Unlock()
+	// Re-installing a selector that was stopped while retired must restart its
+	// background resources. The install path is the only place that can tell
+	// this apart from in-flight picks on a retired selector, whose writes must
+	// not resume cleanup.
+	if resumable, ok := selector.(ResumableSelector); ok {
+		resumable.Resume()
+	}
 	if m.scheduler != nil {
 		m.scheduler.setSelector(selector)
 		m.syncScheduler()

--- a/sdk/cliproxy/auth/conductor_set_selector_test.go
+++ b/sdk/cliproxy/auth/conductor_set_selector_test.go
@@ -81,3 +81,31 @@ func TestManagerStopSelectorIfInactiveStopsReplacedSelector(t *testing.T) {
 		t.Fatal("inactive selector was not stopped")
 	}
 }
+
+// A cache stopped while still in service resumes cleanup on the next binding
+// write, so retiring a selector that a concurrent caller re-installs cannot
+// leave bindings without expiration sweeps. Reads keep lazily filtering
+// expired entries in the meantime.
+func TestSessionCacheStopResumesCleanupOnNextWrite(t *testing.T) {
+	t.Parallel()
+
+	cache := NewSessionCache(time.Minute)
+	firstStopCh := cache.stopCh
+	cache.Stop()
+	select {
+	case <-firstStopCh:
+	default:
+		t.Fatal("first Stop did not close stopCh")
+	}
+
+	cache.Set("session-1", "auth-1")
+	if cache.stopCh == firstStopCh {
+		t.Fatal("write after Stop did not resume cleanup")
+	}
+	select {
+	case <-cache.stopCh:
+		t.Fatal("resumed cleanup channel is already closed")
+	default:
+	}
+	cache.Stop()
+}

--- a/sdk/cliproxy/auth/conductor_set_selector_test.go
+++ b/sdk/cliproxy/auth/conductor_set_selector_test.go
@@ -46,3 +46,38 @@ func TestSessionCacheStopIsConcurrencySafe(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// StopSelectorIfInactive retires an owned selector only when it is no longer
+// active: a concurrent SetSelector re-installing the same instance must win,
+// otherwise the republished selector's cleanup goroutine would be stopped
+// underneath it.
+func TestManagerStopSelectorIfInactiveSkipsActiveSelector(t *testing.T) {
+	t.Parallel()
+
+	affinity := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer affinity.Stop()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.SetSelector(affinity)
+
+	manager.StopSelectorIfInactive(affinity)
+	select {
+	case <-affinity.cache.stopCh:
+		t.Fatal("active selector was stopped")
+	default:
+	}
+}
+
+func TestManagerStopSelectorIfInactiveStopsReplacedSelector(t *testing.T) {
+	t.Parallel()
+
+	affinity := NewSessionAffinitySelector(&RoundRobinSelector{})
+	manager := NewManager(nil, affinity, nil)
+	manager.SetSelector(&RoundRobinSelector{})
+
+	manager.StopSelectorIfInactive(affinity)
+	select {
+	case <-affinity.cache.stopCh:
+	default:
+		t.Fatal("inactive selector was not stopped")
+	}
+}

--- a/sdk/cliproxy/auth/conductor_set_selector_test.go
+++ b/sdk/cliproxy/auth/conductor_set_selector_test.go
@@ -82,11 +82,11 @@ func TestManagerStopSelectorIfInactiveStopsReplacedSelector(t *testing.T) {
 	}
 }
 
-// A cache stopped while still in service resumes cleanup on the next binding
-// write, so retiring a selector that a concurrent caller re-installs cannot
-// leave bindings without expiration sweeps. Reads keep lazily filtering
-// expired entries in the meantime.
-func TestSessionCacheStopResumesCleanupOnNextWrite(t *testing.T) {
+// A stopped cache must stay paused on writes: in-flight picks on a retired
+// selector call SetAliases, and resuming there would leak one cleanup
+// goroutine per reload under traffic. Only an explicit Resume (issued when a
+// selector is installed again) restarts cleanup.
+func TestSessionCacheStopStaysPausedUntilResume(t *testing.T) {
 	t.Parallel()
 
 	cache := NewSessionCache(time.Minute)
@@ -99,13 +99,45 @@ func TestSessionCacheStopResumesCleanupOnNextWrite(t *testing.T) {
 	}
 
 	cache.Set("session-1", "auth-1")
+	if cache.stopCh != firstStopCh {
+		t.Fatal("write after Stop resumed cleanup; only Resume may restart it")
+	}
+
+	cache.Resume()
+	defer cache.Stop()
 	if cache.stopCh == firstStopCh {
-		t.Fatal("write after Stop did not resume cleanup")
+		t.Fatal("Resume did not restart cleanup")
 	}
 	select {
 	case <-cache.stopCh:
 		t.Fatal("resumed cleanup channel is already closed")
 	default:
 	}
-	cache.Stop()
+}
+
+// SetSelector must resume a selector that was stopped while retired, so
+// re-installing it restores its expiration sweeps.
+func TestManagerSetSelectorResumesResumableSelector(t *testing.T) {
+	t.Parallel()
+
+	affinity := NewSessionAffinitySelector(&RoundRobinSelector{})
+	manager := NewManager(nil, affinity, nil)
+	manager.SetSelector(&RoundRobinSelector{})
+	manager.StopSelectorIfInactive(affinity)
+	stoppedCh := affinity.cache.stopCh
+	select {
+	case <-stoppedCh:
+	default:
+		t.Fatal("retired selector was not stopped")
+	}
+
+	manager.SetSelector(affinity)
+	if affinity.cache.stopCh == stoppedCh {
+		t.Fatal("re-installed selector was not resumed")
+	}
+	select {
+	case <-affinity.cache.stopCh:
+		t.Fatal("resumed selector cleanup channel is already closed")
+	default:
+	}
 }

--- a/sdk/cliproxy/auth/conductor_set_selector_test.go
+++ b/sdk/cliproxy/auth/conductor_set_selector_test.go
@@ -1,0 +1,48 @@
+package auth
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// SetSelector never stops the selector it replaces: selectors are owned by
+// whoever created them (the SDK caller or the Service's config path), and
+// implicitly stopping one breaks compositions that retain it, such as a
+// custom wrapper delegating to the previous selector.
+func TestManagerSetSelectorDoesNotStopReplacedSelector(t *testing.T) {
+	t.Parallel()
+
+	affinity := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer affinity.Stop()
+	manager := NewManager(nil, affinity, nil)
+
+	manager.SetSelector(&RoundRobinSelector{})
+	select {
+	case <-affinity.cache.stopCh:
+		t.Fatal("SetSelector stopped the caller-owned affinity selector")
+	default:
+	}
+	if current := manager.Selector(); current == Selector(affinity) {
+		t.Fatal("SetSelector did not swap the active selector")
+	}
+}
+
+// SessionCache.Stop must be safe to invoke concurrently: the Service's config
+// path, manager shutdown, and SDK caller cleanup can all stop the same
+// selector. A select-then-close idiom would double-close the channel and
+// panic.
+func TestSessionCacheStopIsConcurrencySafe(t *testing.T) {
+	t.Parallel()
+
+	cache := NewSessionCache(time.Minute)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cache.Stop()
+		}()
+	}
+	wg.Wait()
+}

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -765,6 +765,14 @@ func (s *SessionAffinitySelector) Stop() {
 	}
 }
 
+// Resume restarts the cache cleanup after a Stop, e.g. when the selector is
+// installed again after being retired. It is a no-op while cleanup runs.
+func (s *SessionAffinitySelector) Resume() {
+	if s.cache != nil {
+		s.cache.Resume()
+	}
+}
+
 // InvalidateAuth removes all session bindings for a specific auth.
 // Called when an auth becomes rate-limited or unavailable.
 func (s *SessionAffinitySelector) InvalidateAuth(authID string) {

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -684,10 +684,14 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	}
 	fallbackAuths := highestPriorityAuths(available)
 
-	cacheKey := provider + "::" + primaryID + "::" + model
+	// Canonicalize the route model so thinking-suffix variants of the same base
+	// model (e.g. "claude-3" and "claude-3(high)") share one session binding,
+	// matching the canonicalization used for cursors and cooldown states.
+	keyModel := canonicalModelKey(model)
+	cacheKey := provider + "::" + primaryID + "::" + keyModel
 	fallbackKey := ""
 	if fallbackID != "" && fallbackID != primaryID {
-		fallbackKey = provider + "::" + fallbackID + "::" + model
+		fallbackKey = provider + "::" + fallbackID + "::" + keyModel
 	}
 	bind := func(authID string) {
 		if fallbackKey != "" {
@@ -787,6 +791,9 @@ func (s *SessionAffinitySelector) OnResult(res Result) {
 	if raw, ok := res.Options.Metadata[cliproxyexecutor.SessionAffinityModelMetadataKey].(string); ok && raw != "" {
 		nsModel = raw
 	}
+	// Match the canonical model key used when the binding was created in Pick,
+	// so thinking-suffix variants resolve to the same cache entry.
+	nsModel = canonicalModelKey(nsModel)
 
 	cacheKey := ns + "::" + primaryID + "::" + nsModel
 	var fallbackKey string

--- a/sdk/cliproxy/auth/session_affinity_canonical_model_test.go
+++ b/sdk/cliproxy/auth/session_affinity_canonical_model_test.go
@@ -1,0 +1,88 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// Thinking-suffix variants of the same route model (e.g. "claude-3" and
+// "claude-3(high)") share one credential pool and one cooldown state, so a
+// session bound through one variant must stay bound when a later request in
+// the same session arrives with another variant.
+func TestSessionAffinitySelector_ThinkingSuffixSharesSessionBinding(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer selector.Stop()
+
+	auths := []*Auth{
+		{ID: "auth-a"},
+		{ID: "auth-b"},
+	}
+	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_suffix-share"}}`)
+	opts := cliproxyexecutor.Options{OriginalRequest: payload}
+
+	first, err := selector.Pick(context.Background(), "claude", "claude-3(high)", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+
+	for _, model := range []string{"claude-3", "claude-3(low)", "claude-3(high)"} {
+		got, errPick := selector.Pick(context.Background(), "claude", model, opts, auths)
+		if errPick != nil {
+			t.Fatalf("Pick(%q) error = %v", model, errPick)
+		}
+		if got.ID != first.ID {
+			t.Fatalf("Pick(%q) auth.ID = %q, want sticky auth %q (thinking-suffix variants must share the session binding)", model, got.ID, first.ID)
+		}
+	}
+}
+
+// A failure reported with the base model name must release a binding that was
+// created through a thinking-suffixed variant of the same route model.
+func TestSessionAffinityOnResult_ThinkingSuffixReleasesBinding(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer selector.Stop()
+
+	auths := []*Auth{
+		{ID: "auth-a"},
+		{ID: "auth-b"},
+	}
+	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_suffix-release"}}`)
+	opts := cliproxyexecutor.Options{OriginalRequest: payload}
+
+	first, err := selector.Pick(context.Background(), "claude", "claude-3(high)", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+
+	// The next request of the same session arrives without the suffix and fails.
+	second, errPick := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+	if errPick != nil {
+		t.Fatalf("Pick() error = %v", errPick)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("Pick() auth.ID = %q, want sticky auth %q before failure", second.ID, first.ID)
+	}
+	selector.OnResult(Result{
+		AuthID:   second.ID,
+		Provider: "claude",
+		Model:    "claude-3",
+		Success:  false,
+		Error:    &Error{Code: "upstream_error", Message: "upstream failed"},
+		Options:  opts,
+	})
+
+	// The binding is released, so the round-robin fallback must move on.
+	third, errPick := selector.Pick(context.Background(), "claude", "claude-3(high)", opts, auths)
+	if errPick != nil {
+		t.Fatalf("Pick() after failure error = %v", errPick)
+	}
+	if third.ID == first.ID {
+		t.Fatalf("Pick() after failure auth.ID = %q, want reselection after the binding was released", third.ID)
+	}
+}

--- a/sdk/cliproxy/auth/session_cache.go
+++ b/sdk/cliproxy/auth/session_cache.go
@@ -17,10 +17,11 @@ type sessionEntry struct {
 
 // SessionCache provides TTL-based session to auth mapping with automatic cleanup.
 type SessionCache struct {
-	mu      sync.RWMutex
-	entries map[string]sessionEntry
-	ttl     time.Duration
-	stopCh  chan struct{}
+	mu       sync.RWMutex
+	entries  map[string]sessionEntry
+	ttl      time.Duration
+	stopCh   chan struct{}
+	stopOnce sync.Once
 }
 
 // NewSessionCache creates a cache with the specified TTL.
@@ -317,13 +318,10 @@ func (c *SessionCache) InvalidateAuth(authID string) {
 	c.mu.Unlock()
 }
 
-// Stop terminates the background cleanup goroutine.
+// Stop terminates the background cleanup goroutine. It is safe to call
+// multiple times, including from concurrent goroutines.
 func (c *SessionCache) Stop() {
-	select {
-	case <-c.stopCh:
-	default:
-		close(c.stopCh)
-	}
+	c.stopOnce.Do(func() { close(c.stopCh) })
 }
 
 func (c *SessionCache) cleanupLoop() {

--- a/sdk/cliproxy/auth/session_cache.go
+++ b/sdk/cliproxy/auth/session_cache.go
@@ -21,9 +21,9 @@ type SessionCache struct {
 	entries map[string]sessionEntry
 	ttl     time.Duration
 	stopCh  chan struct{}
-	// stopped reports whether cleanup is paused; guarded by mu. A paused cache
-	// resumes cleanup on the next binding write, so Stop is a pause, not a
-	// terminal state.
+	// stopped reports whether cleanup is paused; guarded by mu. Cleanup resumes
+	// only via Resume (triggered when the selector is installed again), never
+	// from in-flight picks on a retired selector.
 	stopped bool
 }
 
@@ -110,13 +110,6 @@ func (c *SessionCache) SetAliases(authID string, sessionIDs ...string) {
 	now := time.Now()
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	// Resume cleanup if the cache was stopped while still in service (e.g. its
-	// owner retired the selector but a concurrent caller re-installed it).
-	if c.stopped {
-		c.stopped = false
-		c.stopCh = make(chan struct{})
-		go c.cleanupLoop(c.stopCh)
-	}
 
 	aliases := mergeSessionAliases(nil, sessionIDs...)
 	previousGroups := make([]sessionEntry, 0, len(sessionIDs))
@@ -330,13 +323,26 @@ func (c *SessionCache) InvalidateAuth(authID string) {
 
 // Stop pauses the background cleanup goroutine. It is safe to call multiple
 // times, including from concurrent goroutines. The cache stays fully usable:
-// reads keep lazily filtering expired entries, and the next binding write
-// resumes cleanup, so a cache stopped while still in service heals itself.
+// reads keep lazily filtering expired entries, and Resume restarts cleanup.
 func (c *SessionCache) Stop() {
 	c.mu.Lock()
 	if !c.stopped {
 		c.stopped = true
 		close(c.stopCh)
+	}
+	c.mu.Unlock()
+}
+
+// Resume restarts the cleanup goroutine after Stop. It is a no-op when
+// cleanup is already running. Only installation of a selector may resume its
+// cache — in-flight picks on a retired selector must not, otherwise reloads
+// under traffic would keep leaking one cleanup goroutine apiece.
+func (c *SessionCache) Resume() {
+	c.mu.Lock()
+	if c.stopped {
+		c.stopped = false
+		c.stopCh = make(chan struct{})
+		go c.cleanupLoop(c.stopCh)
 	}
 	c.mu.Unlock()
 }

--- a/sdk/cliproxy/auth/session_cache.go
+++ b/sdk/cliproxy/auth/session_cache.go
@@ -17,11 +17,14 @@ type sessionEntry struct {
 
 // SessionCache provides TTL-based session to auth mapping with automatic cleanup.
 type SessionCache struct {
-	mu       sync.RWMutex
-	entries  map[string]sessionEntry
-	ttl      time.Duration
-	stopCh   chan struct{}
-	stopOnce sync.Once
+	mu      sync.RWMutex
+	entries map[string]sessionEntry
+	ttl     time.Duration
+	stopCh  chan struct{}
+	// stopped reports whether cleanup is paused; guarded by mu. A paused cache
+	// resumes cleanup on the next binding write, so Stop is a pause, not a
+	// terminal state.
+	stopped bool
 }
 
 // NewSessionCache creates a cache with the specified TTL.
@@ -35,7 +38,7 @@ func NewSessionCache(ttl time.Duration) *SessionCache {
 		ttl:     ttl,
 		stopCh:  make(chan struct{}),
 	}
-	go c.cleanupLoop()
+	go c.cleanupLoop(c.stopCh)
 	return c
 }
 
@@ -107,6 +110,13 @@ func (c *SessionCache) SetAliases(authID string, sessionIDs ...string) {
 	now := time.Now()
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// Resume cleanup if the cache was stopped while still in service (e.g. its
+	// owner retired the selector but a concurrent caller re-installed it).
+	if c.stopped {
+		c.stopped = false
+		c.stopCh = make(chan struct{})
+		go c.cleanupLoop(c.stopCh)
+	}
 
 	aliases := mergeSessionAliases(nil, sessionIDs...)
 	previousGroups := make([]sessionEntry, 0, len(sessionIDs))
@@ -318,18 +328,25 @@ func (c *SessionCache) InvalidateAuth(authID string) {
 	c.mu.Unlock()
 }
 
-// Stop terminates the background cleanup goroutine. It is safe to call
-// multiple times, including from concurrent goroutines.
+// Stop pauses the background cleanup goroutine. It is safe to call multiple
+// times, including from concurrent goroutines. The cache stays fully usable:
+// reads keep lazily filtering expired entries, and the next binding write
+// resumes cleanup, so a cache stopped while still in service heals itself.
 func (c *SessionCache) Stop() {
-	c.stopOnce.Do(func() { close(c.stopCh) })
+	c.mu.Lock()
+	if !c.stopped {
+		c.stopped = true
+		close(c.stopCh)
+	}
+	c.mu.Unlock()
 }
 
-func (c *SessionCache) cleanupLoop() {
+func (c *SessionCache) cleanupLoop(stopCh chan struct{}) {
 	ticker := time.NewTicker(c.ttl / 2)
 	defer ticker.Stop()
 	for {
 		select {
-		case <-c.stopCh:
+		case <-stopCh:
 			return
 		case <-ticker.C:
 			c.cleanup()

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -241,6 +241,7 @@ func (b *Builder) Build() (*Service, error) {
 	coreManager := b.coreManager
 	cooldownStateStore := b.cooldownStateStore
 	var appliedRoutingState *routingRuntimeState
+	var appliedRoutingSelector coreauth.Selector
 	if coreManager == nil {
 		tokenStore := sdkAuth.GetTokenStore()
 		if dirSetter, ok := tokenStore.(interface{ SetBaseDir(string) }); ok && b.cfg != nil {
@@ -253,7 +254,8 @@ func (b *Builder) Build() (*Service, error) {
 		}
 
 		routingState := normalizedRoutingRuntimeState(b.cfg)
-		coreManager = coreauth.NewManager(tokenStore, newRoutingSelector(routingState), nil)
+		appliedRoutingSelector = newRoutingSelector(routingState)
+		coreManager = coreauth.NewManager(tokenStore, appliedRoutingSelector, nil)
 		appliedRoutingState = &routingState
 	}
 	// Attach a default RoundTripper provider so providers can opt-in per-auth transports.
@@ -265,19 +267,20 @@ func (b *Builder) Build() (*Service, error) {
 	}
 
 	service := &Service{
-		cfg:                 b.cfg,
-		configPath:          b.configPath,
-		tokenProvider:       tokenProvider,
-		apiKeyProvider:      apiKeyProvider,
-		watcherFactory:      watcherFactory,
-		hooks:               b.hooks,
-		authManager:         authManager,
-		accessManager:       accessManager,
-		coreManager:         coreManager,
-		cooldownStateStore:  cooldownStateStore,
-		pluginHost:          pluginHost,
-		appliedRoutingState: appliedRoutingState,
-		serverOptions:       append([]api.ServerOption(nil), b.serverOptions...),
+		cfg:                    b.cfg,
+		configPath:             b.configPath,
+		tokenProvider:          tokenProvider,
+		apiKeyProvider:         apiKeyProvider,
+		watcherFactory:         watcherFactory,
+		hooks:                  b.hooks,
+		authManager:            authManager,
+		accessManager:          accessManager,
+		coreManager:            coreManager,
+		cooldownStateStore:     cooldownStateStore,
+		pluginHost:             pluginHost,
+		appliedRoutingState:    appliedRoutingState,
+		appliedRoutingSelector: appliedRoutingSelector,
+		serverOptions:          append([]api.ServerOption(nil), b.serverOptions...),
 	}
 	if b.postAuthHook != nil {
 		service.serverOptions = append(service.serverOptions, api.WithPostAuthHook(b.postAuthHook))

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -40,6 +40,10 @@ type Service struct {
 	executorRegistrationMu sync.Mutex
 	configSequence         uint64
 	appliedRoutingState    *routingRuntimeState
+	// appliedRoutingSelector is the routing selector installed by this Service's
+	// config path. The Service owns its lifecycle and stops it when a config
+	// reload replaces it; caller-supplied selectors are never stopped.
+	appliedRoutingSelector coreauth.Selector
 
 	// configPath is the path to the configuration file.
 	configPath string

--- a/sdk/cliproxy/service_config.go
+++ b/sdk/cliproxy/service_config.go
@@ -208,10 +208,12 @@ func (s *Service) applyManagerConfig(ctx context.Context, commit configCommit) b
 		s.coreManager.SetSelector(selector)
 		// Stop the routing selector this Service installed previously: only the
 		// affinity selector holds resources (a cache cleanup goroutine), and
-		// without this every routing config change leaks it. Selectors supplied
+		// without this every routing config change leaks it. The conditional
+		// stop is atomic with respect to SetSelector, so a concurrent re-install
+		// of the previous selector wins and keeps it running. Selectors supplied
 		// by SDK callers are caller-owned and never stopped here.
 		if prev, ok := s.appliedRoutingSelector.(*coreauth.SessionAffinitySelector); ok {
-			prev.Stop()
+			s.coreManager.StopSelectorIfInactive(prev)
 		}
 		s.appliedRoutingSelector = selector
 		s.appliedRoutingState = &routingState

--- a/sdk/cliproxy/service_config.go
+++ b/sdk/cliproxy/service_config.go
@@ -204,7 +204,16 @@ func (s *Service) applyManagerConfig(ctx context.Context, commit configCommit) b
 	}
 	routingState := normalizedRoutingRuntimeState(commit.cfg)
 	if s.appliedRoutingState == nil || *s.appliedRoutingState != routingState {
-		s.coreManager.SetSelector(newRoutingSelector(routingState))
+		selector := newRoutingSelector(routingState)
+		s.coreManager.SetSelector(selector)
+		// Stop the routing selector this Service installed previously: only the
+		// affinity selector holds resources (a cache cleanup goroutine), and
+		// without this every routing config change leaks it. Selectors supplied
+		// by SDK callers are caller-owned and never stopped here.
+		if prev, ok := s.appliedRoutingSelector.(*coreauth.SessionAffinitySelector); ok {
+			prev.Stop()
+		}
+		s.appliedRoutingSelector = selector
 		s.appliedRoutingState = &routingState
 	}
 	s.applyRetryConfig(commit.cfg)

--- a/sdk/cliproxy/service_routing_selector_test.go
+++ b/sdk/cliproxy/service_routing_selector_test.go
@@ -1,0 +1,72 @@
+package cliproxy
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// Every routing config change installs a fresh routing selector; when session
+// affinity is enabled that selector owns a background cache cleanup goroutine.
+// The Service must stop the selector it previously installed, otherwise each
+// reload leaks one goroutine for the process lifetime.
+func TestApplyManagerConfigStopsReplacedServiceAffinitySelector(t *testing.T) {
+	service := &Service{coreManager: coreauth.NewManager(nil, nil, nil)}
+
+	apply := func(ttl string) {
+		t.Helper()
+		cfg := &internalconfig.Config{Routing: internalconfig.RoutingConfig{
+			SessionAffinity:    true,
+			SessionAffinityTTL: ttl,
+		}}
+		if !service.applyManagerConfig(context.Background(), configCommit{cfg: cfg}) {
+			t.Fatalf("applyManagerConfig(%q) failed", ttl)
+		}
+	}
+
+	apply("1h") // installs the first service-owned affinity selector
+	baseline := runtime.NumGoroutine()
+	apply("2h")
+	apply("3h")
+
+	deadline := time.Now().Add(5 * time.Second)
+	for runtime.NumGoroutine() > baseline {
+		if time.Now().After(deadline) {
+			t.Fatalf("goroutines = %d, want baseline %d: replaced affinity selectors were not stopped",
+				runtime.NumGoroutine(), baseline)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// The Service tracks the selector it installed so that only service-owned
+// affinity selectors are stopped on replacement; the freshly installed
+// selector becomes the new tracked instance.
+func TestApplyManagerConfigTracksServiceInstalledSelector(t *testing.T) {
+	service := &Service{coreManager: coreauth.NewManager(nil, nil, nil)}
+
+	cfg := &internalconfig.Config{Routing: internalconfig.RoutingConfig{SessionAffinity: true}}
+	if !service.applyManagerConfig(context.Background(), configCommit{cfg: cfg}) {
+		t.Fatal("first applyManagerConfig failed")
+	}
+	if _, ok := service.appliedRoutingSelector.(*coreauth.SessionAffinitySelector); !ok {
+		t.Fatalf("appliedRoutingSelector = %T, want *SessionAffinitySelector", service.appliedRoutingSelector)
+	}
+
+	// Disabling affinity swaps in a plain selector and stops the old one; the
+	// newly installed selector must stay service-owned and unstopped.
+	cfg = &internalconfig.Config{}
+	if !service.applyManagerConfig(context.Background(), configCommit{cfg: cfg}) {
+		t.Fatal("second applyManagerConfig failed")
+	}
+	if _, ok := service.appliedRoutingSelector.(*coreauth.RoundRobinSelector); !ok {
+		t.Fatalf("appliedRoutingSelector = %T, want *RoundRobinSelector", service.appliedRoutingSelector)
+	}
+	if current := service.coreManager.Selector(); current != service.appliedRoutingSelector {
+		t.Fatal("active selector diverged from the service-installed selector")
+	}
+}


### PR DESCRIPTION
## Summary

Two small fixes in the session-affinity routing area:

1. **Thinking-suffix variants split session bindings** (`selector.go`): the affinity cache key embedded the raw route model, while round-robin cursors (`RoundRobinSelector.Pick`) and cooldown states already canonicalize thinking suffixes via `canonicalModelKey`. A session sending `model` and `model(high)` was therefore split into two independent bindings and could land on different credentials, silently breaking stickiness; `OnResult` failure cleanup could also miss the binding for the same reason. Both `Pick` and `OnResult` now canonicalize the model when building cache keys, matching the rest of the routing pipeline.

2. **Routing config reloads leak the affinity selector's cleanup goroutine** (`service_config.go`): the Service's config path creates a fresh routing selector on every routing config change, and `SessionAffinitySelector` owns a `SessionCache` with a background cleanup goroutine — but the replaced selector was never stopped. Selector lifecycle now follows ownership:

   - The Service tracks the routing selector it installed (`appliedRoutingSelector`) and retires it via `Manager.StopSelectorIfInactive` — an atomic check under the manager lock that skips the stop if a concurrent `SetSelector` re-installed the selector.
   - `Manager.SetSelector` itself never stops anything (an implicit stop cannot see custom wrappers retaining the previous selector as a delegate), but it does *resume* a re-installed selector through the new optional `ResumableSelector` interface — the install path is the only layer that can distinguish re-publication from in-flight picks on a retired selector, whose writes must not restart cleanup.
   - `SessionCache.Stop` is an idempotent, concurrency-safe pause: reads keep lazily filtering expired entries, writes stay paused, and only `Resume` restarts the sweep goroutine.

## Tests

New regression tests, all red before the fix and green after:

- `TestSessionAffinitySelector_ThinkingSuffixSharesSessionBinding`
- `TestSessionAffinityOnResult_ThinkingSuffixReleasesBinding`
- `TestManagerSetSelectorDoesNotStopReplacedSelector`
- `TestManagerSetSelectorResumesResumableSelector`
- `TestManagerStopSelectorIfInactiveSkipsActiveSelector` / `...StopsReplacedSelector`
- `TestSessionCacheStopIsConcurrencySafe`
- `TestSessionCacheStopStaysPausedUntilResume`
- `TestApplyManagerConfigStopsReplacedServiceAffinitySelector`
- `TestApplyManagerConfigTracksServiceInstalledSelector`

## Verification

- `go test ./sdk/cliproxy/...`: fully green.
- `go test -race ./sdk/cliproxy/ ./sdk/cliproxy/auth/` on **Linux (WSL2, go1.26.0 linux/amd64)**: green.

Supersedes #5011.
