### PR TITLE
fix(responses): complete and persist Codex image outputs

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -182,6 +182,12 @@ claude-code:
 # - "passthrough": never inject or strip image_generation on non-images endpoints (forward the client payload unchanged); behaves like "chat" on /v1/images/* endpoints.
 disable-image-generation: false
 
+# Optional local compatibility mode for Codex Desktop/CLI custom providers.
+# When set, completed Responses image_generation results are saved here and an
+# absolute Markdown preview path is appended to the following assistant text.
+# Leave empty on remote servers because the path must be readable by the client.
+# codex-image-output-dir: "~/.codex/generated_images/cliproxy"
+
 # Base model used by the legacy hosted image_generation tool path when a Codex image request is not proxied directly through the Image API.
 # Must start with "gpt-" (case-insensitive). If unset or invalid, defaults to "gpt-5.4-mini".
 # gpt-image-2-base-model: "gpt-5.4-mini"

--- a/internal/config/codex_image_output_test.go
+++ b/internal/config/codex_image_output_test.go
@@ -1,0 +1,13 @@
+package config
+
+import "testing"
+
+func TestParseConfigBytesCodexImageOutputDir(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte(`codex-image-output-dir: "~/.codex/generated_images/cliproxy"`))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", err)
+	}
+	if got := cfg.CodexImageOutputDir; got != "~/.codex/generated_images/cliproxy" {
+		t.Fatalf("CodexImageOutputDir = %q", got)
+	}
+}

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -21,6 +21,12 @@ type SDKConfig struct {
 	//     sent it and do not inject it otherwise; on /v1/images/generations and /v1/images/edits behave like "chat".
 	DisableImageGeneration DisableImageGenerationMode `yaml:"disable-image-generation" json:"disable-image-generation"`
 
+	// CodexImageOutputDir enables local persistence for hosted image_generation
+	// results returned through the Responses API. When set, completed images are
+	// written to this directory and a Markdown preview path is appended to the
+	// following assistant text. Leave empty for remote or general-purpose servers.
+	CodexImageOutputDir string `yaml:"codex-image-output-dir,omitempty" json:"codex-image-output-dir,omitempty"`
+
 	// GPTImage2BaseModel sets the base (mainline) model used by the legacy hosted
 	// image_generation tool path when a Codex image request is not proxied directly
 	// through the Image API.

--- a/sdk/api/handlers/openai/codex_image_output.go
+++ b/sdk/api/handlers/openai/codex_image_output.go
@@ -1,0 +1,263 @@
+package openai
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+func (h *OpenAIResponsesAPIHandler) codexImageOutputDir() string {
+	if h == nil || h.Cfg == nil {
+		return ""
+	}
+	return strings.TrimSpace(h.Cfg.CodexImageOutputDir)
+}
+
+func resolveCodexImageOutputDir(configured string) (string, error) {
+	dir := os.ExpandEnv(strings.TrimSpace(configured))
+	if dir == "" {
+		return "", nil
+	}
+	if dir == "~" || strings.HasPrefix(dir, "~/") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		if dir == "~" {
+			dir = homeDir
+		} else {
+			dir = filepath.Join(homeDir, strings.TrimPrefix(dir, "~/"))
+		}
+	}
+	if !filepath.IsAbs(dir) {
+		absoluteDir, err := filepath.Abs(dir)
+		if err != nil {
+			return "", err
+		}
+		dir = absoluteDir
+	}
+	return filepath.Clean(dir), nil
+}
+
+func decodeResponsesImageResult(result string) ([]byte, string, bool) {
+	encoded := strings.TrimSpace(result)
+	if strings.HasPrefix(encoded, "data:") {
+		comma := strings.IndexByte(encoded, ',')
+		if comma < 0 || !strings.Contains(strings.ToLower(encoded[:comma]), ";base64") {
+			return nil, "", false
+		}
+		encoded = encoded[comma+1:]
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		decoded, err = base64.RawStdEncoding.DecodeString(encoded)
+	}
+	if err != nil || len(decoded) == 0 {
+		return nil, "", false
+	}
+
+	switch {
+	case bytes.HasPrefix(decoded, []byte("\x89PNG\r\n\x1a\n")):
+		return decoded, "png", true
+	case len(decoded) >= 3 && decoded[0] == 0xff && decoded[1] == 0xd8 && decoded[2] == 0xff:
+		return decoded, "jpg", true
+	case len(decoded) >= 12 && string(decoded[:4]) == "RIFF" && string(decoded[8:12]) == "WEBP":
+		return decoded, "webp", true
+	default:
+		return nil, "", false
+	}
+}
+
+func safeImageOutputID(value string, fallbackIndex int) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Sprintf("image-%d", fallbackIndex)
+	}
+
+	var out strings.Builder
+	out.Grow(min(len(value), 160))
+	for _, r := range value {
+		if out.Len() >= 160 {
+			break
+		}
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			out.WriteRune(r)
+		default:
+			out.WriteByte('_')
+		}
+	}
+	if out.Len() == 0 {
+		return fmt.Sprintf("image-%d", fallbackIndex)
+	}
+	return out.String()
+}
+
+func (f *responsesSSEFramer) resolvedCodexImageOutputDir() (string, error) {
+	if f.imageDirResolved {
+		return f.resolvedImageDir, nil
+	}
+	resolved, err := resolveCodexImageOutputDir(f.imageOutputDir)
+	if err != nil {
+		return "", err
+	}
+	f.imageDirResolved = true
+	f.resolvedImageDir = resolved
+	return resolved, nil
+}
+
+func (f *responsesSSEFramer) persistImageGenerationResult(payload []byte) {
+	if strings.TrimSpace(f.imageOutputDir) == "" {
+		return
+	}
+	item := gjson.GetBytes(payload, "item")
+	if item.Get("type").String() != "image_generation_call" {
+		return
+	}
+	result := item.Get("result").String()
+	if strings.TrimSpace(result) == "" {
+		return
+	}
+
+	itemID := strings.TrimSpace(item.Get("id").String())
+	key := itemID
+	if key == "" {
+		key = imageGenerationItemKey(payload, "item.id")
+	}
+	if f.savedImagePaths != nil {
+		if _, exists := f.savedImagePaths[key]; exists {
+			return
+		}
+	}
+
+	imageData, extension, ok := decodeResponsesImageResult(result)
+	if !ok {
+		log.Warn("responses image output: unsupported or invalid image result")
+		return
+	}
+	dir, err := f.resolvedCodexImageOutputDir()
+	if err != nil || dir == "" {
+		if err != nil {
+			log.WithError(err).Warn("responses image output: resolve output directory")
+		}
+		return
+	}
+	if err = os.MkdirAll(dir, 0o700); err != nil {
+		log.WithError(err).Warn("responses image output: create output directory")
+		return
+	}
+
+	filename := safeImageOutputID(itemID, len(f.savedImageOrder)+1) + "." + extension
+	outputPath := filepath.Join(dir, filename)
+	if err = os.WriteFile(outputPath, imageData, 0o600); err != nil {
+		log.WithError(err).Warn("responses image output: write generated image")
+		return
+	}
+
+	if f.savedImagePaths == nil {
+		f.savedImagePaths = make(map[string]string)
+	}
+	f.savedImagePaths[key] = outputPath
+	f.savedImageOrder = append(f.savedImageOrder, key)
+}
+
+func (f *responsesSSEFramer) imageMarkdown() string {
+	if len(f.savedImageOrder) == 0 {
+		return ""
+	}
+	var out strings.Builder
+	for index, key := range f.savedImageOrder {
+		imagePath := f.savedImagePaths[key]
+		if imagePath == "" {
+			continue
+		}
+		out.WriteString("\n\n![Generated image ")
+		out.WriteString(fmt.Sprintf("%d", index+1))
+		out.WriteString("](")
+		out.WriteString(imagePath)
+		out.WriteByte(')')
+	}
+	return out.String()
+}
+
+func appendImageMarkdownAtPath(payload []byte, path, markdown string) []byte {
+	current := gjson.GetBytes(payload, path)
+	if current.Type != gjson.String || strings.Contains(current.String(), strings.TrimSpace(markdown)) {
+		return payload
+	}
+	updated, err := sjson.SetBytes(payload, path, current.String()+markdown)
+	if err != nil {
+		return payload
+	}
+	return updated
+}
+
+func appendImageMarkdownToContent(payload []byte, contentPath, markdown string) []byte {
+	content := gjson.GetBytes(payload, contentPath)
+	if !content.IsArray() {
+		return payload
+	}
+	updated := payload
+	for index, part := range content.Array() {
+		if part.Get("type").String() != "output_text" {
+			continue
+		}
+		updated = appendImageMarkdownAtPath(updated, fmt.Sprintf("%s.%d.text", contentPath, index), markdown)
+	}
+	return updated
+}
+
+func appendImageMarkdownToResponseOutput(payload []byte, outputPath, markdown string) []byte {
+	output := gjson.GetBytes(payload, outputPath)
+	if !output.IsArray() {
+		return payload
+	}
+	updated := payload
+	for index, item := range output.Array() {
+		if item.Get("type").String() != "message" {
+			continue
+		}
+		updated = appendImageMarkdownToContent(updated, fmt.Sprintf("%s.%d.content", outputPath, index), markdown)
+	}
+	return updated
+}
+
+func (f *responsesSSEFramer) injectImageMarkdown(payload []byte) []byte {
+	markdown := f.imageMarkdown()
+	if markdown == "" {
+		return payload
+	}
+
+	switch gjson.GetBytes(payload, "type").String() {
+	case "response.output_text.delta":
+		if f.imageMarkdownInjected {
+			return payload
+		}
+		updated := appendImageMarkdownAtPath(payload, "delta", markdown)
+		if !bytes.Equal(updated, payload) {
+			f.imageMarkdownInjected = true
+		}
+		return updated
+	case "response.output_text.done":
+		return appendImageMarkdownAtPath(payload, "text", markdown)
+	case "response.content_part.added", "response.content_part.done":
+		if gjson.GetBytes(payload, "part.type").String() == "output_text" {
+			return appendImageMarkdownAtPath(payload, "part.text", markdown)
+		}
+	case "response.output_item.done":
+		if gjson.GetBytes(payload, "item.type").String() == "message" {
+			return appendImageMarkdownToContent(payload, "item.content", markdown)
+		}
+	case "response.completed":
+		return appendImageMarkdownToResponseOutput(payload, "response.output", markdown)
+	}
+	return payload
+}

--- a/sdk/api/handlers/openai/codex_image_output_test.go
+++ b/sdk/api/handlers/openai/codex_image_output_test.go
@@ -1,0 +1,62 @@
+package openai
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+const onePixelPNGBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9ZQMcAAAAASUVORK5CYII="
+
+func TestResponsesSSEFramerPersistsImageAndInjectsMarkdown(t *testing.T) {
+	outputDir := t.TempDir()
+	framer := &responsesSSEFramer{imageOutputDir: outputDir}
+	var output bytes.Buffer
+
+	framer.WriteChunk(&output, []byte(fmt.Sprintf("event: response.output_item.done\n"+
+		"data: {\"type\":\"response.output_item.done\",\"sequence_number\":6,\"output_index\":0,\"item\":{\"id\":\"ig-1\",\"type\":\"image_generation_call\",\"status\":\"generating\",\"result\":%q}}\n\n", onePixelPNGBase64)))
+	framer.WriteChunk(&output, []byte("event: response.output_text.done\n"+
+		"data: {\"type\":\"response.output_text.done\",\"sequence_number\":7,\"output_index\":1,\"content_index\":0,\"text\":\"\"}\n\n"))
+
+	imagePath := filepath.Join(outputDir, "ig-1.png")
+	imageData, err := os.ReadFile(imagePath)
+	if err != nil {
+		t.Fatalf("read persisted image: %v", err)
+	}
+	if !bytes.HasPrefix(imageData, []byte("\x89PNG\r\n\x1a\n")) {
+		t.Fatalf("persisted image is not a PNG: %x", imageData[:min(len(imageData), 8)])
+	}
+
+	frames := strings.Split(strings.TrimSpace(output.String()), "\n\n")
+	if len(frames) != 3 {
+		t.Fatalf("frames = %d, want 3; output=%q", len(frames), output.String())
+	}
+	payload, ok := responsesSSEDataPayload([]byte(frames[2]))
+	if !ok {
+		t.Fatalf("text frame has no data payload: %q", frames[2])
+	}
+	text := gjson.GetBytes(payload, "text").String()
+	if !strings.Contains(text, "![Generated image 1]("+imagePath+")") {
+		t.Fatalf("text does not contain generated image Markdown: %q", text)
+	}
+}
+
+func TestResolveCodexImageOutputDirExpandsHome(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+	resolved, err := resolveCodexImageOutputDir("~/.codex/generated_images/cliproxy")
+	if err != nil {
+		t.Fatalf("resolveCodexImageOutputDir: %v", err)
+	}
+	want := filepath.Join(homeDir, ".codex", "generated_images", "cliproxy")
+	if resolved != want {
+		t.Fatalf("resolved = %q, want %q", resolved, want)
+	}
+}

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -49,15 +50,23 @@ func writeResponsesSSEChunk(w io.Writer, chunk []byte) {
 }
 
 type responsesSSEFramer struct {
-	pending              []byte
-	outputItems          map[int][]byte
-	outputOrder          []int
-	unindexedOutputItems [][]byte
-	lastEvent            string
-	terminalEvent        string
-	terminalError        *interfaces.ErrorMessage
-	failureEvent         string
-	dataFrames           int
+	pending               []byte
+	outputItems           map[int][]byte
+	outputOrder           []int
+	unindexedOutputItems  [][]byte
+	lastEvent             string
+	terminalEvent         string
+	terminalError         *interfaces.ErrorMessage
+	failureEvent          string
+	dataFrames            int
+	completedImageItems   map[string]struct{}
+	sequenceOffset        int64
+	imageOutputDir        string
+	resolvedImageDir      string
+	imageDirResolved      bool
+	savedImagePaths       map[string]string
+	savedImageOrder       []string
+	imageMarkdownInjected bool
 }
 
 func (f *responsesSSEFramer) WriteChunk(w io.Writer, chunk []byte) {
@@ -116,29 +125,34 @@ func (f *responsesSSEFramer) Flush(w io.Writer) {
 }
 
 func (f *responsesSSEFramer) writeFrame(w io.Writer, frame []byte) {
-	writeResponsesSSEChunk(w, f.repairFrame(frame))
+	for _, repaired := range f.repairFrames(frame) {
+		writeResponsesSSEChunk(w, repaired)
+	}
 }
 
-func (f *responsesSSEFramer) repairFrame(frame []byte) []byte {
+func (f *responsesSSEFramer) repairFrames(frame []byte) [][]byte {
 	payload, ok := responsesSSEDataPayload(frame)
 	if !ok || len(payload) == 0 {
-		return frame
+		return [][]byte{frame}
 	}
 	if bytes.Equal(payload, []byte("[DONE]")) {
 		f.dataFrames++
-		return frame
+		return [][]byte{frame}
 	}
 	if !json.Valid(payload) {
-		return frame
+		return [][]byte{frame}
 	}
 	f.dataFrames++
+	payload = f.shiftSequenceNumber(payload)
+	payload = f.injectImageMarkdown(payload)
+	frame = responsesSSEFrameWithData(frame, payload)
 
 	payloadType := gjson.GetBytes(payload, "type").String()
 	if responsesSSEErrorEvent(payloadType) || responsesSSEPayloadHasError(payload) {
 		if payloadType != "" {
 			f.lastEvent = sanitizeResponsesStreamEventName(payloadType)
 		}
-		return f.repairErrorPayload(payload)
+		return [][]byte{f.repairErrorPayload(payload)}
 	}
 	streamEvent := responsesSSEEventName(frame)
 	eventType := payloadType
@@ -151,22 +165,131 @@ func (f *responsesSSEFramer) repairFrame(frame []byte) []byte {
 		f.lastEvent = sanitizeResponsesStreamEventName(eventType)
 	}
 	if responsesSSEErrorEvent(eventType) {
-		return f.repairErrorPayload(payload)
+		return [][]byte{f.repairErrorPayload(payload)}
 	}
 	if responsesSSETerminalEvent(eventType) {
 		f.terminalEvent = eventType
 	}
 
 	switch eventType {
+	case "response.image_generation_call.completed":
+		f.recordCompletedImageItem(payload)
 	case "response.output_item.done":
+		if completedPayload, repairedPayload, repaired := f.repairImageGenerationDone(payload); repaired {
+			f.persistImageGenerationResult(repairedPayload)
+			f.recordOutputItem(repairedPayload)
+			repairedFrame := responsesSSEFrameWithData(frame, repairedPayload)
+			if len(completedPayload) > 0 {
+				return [][]byte{
+					responsesSSEEventFrame("response.image_generation_call.completed", completedPayload),
+					repairedFrame,
+				}
+			}
+			return [][]byte{repairedFrame}
+		}
 		f.recordOutputItem(payload)
 	case "response.completed":
 		repaired := f.repairCompletedPayload(payload)
 		if !bytes.Equal(repaired, payload) {
-			return responsesSSEFrameWithData(frame, repaired)
+			return [][]byte{responsesSSEFrameWithData(frame, repaired)}
 		}
 	}
-	return frame
+	return [][]byte{frame}
+}
+
+func responsesSSEEventFrame(event string, payload []byte) []byte {
+	var out bytes.Buffer
+	out.Grow(len(event) + len(payload) + 16)
+	out.WriteString("event: ")
+	out.WriteString(event)
+	out.WriteByte('\n')
+	out.WriteString("data: ")
+	out.Write(payload)
+	return out.Bytes()
+}
+
+func (f *responsesSSEFramer) shiftSequenceNumber(payload []byte) []byte {
+	if f.sequenceOffset == 0 {
+		return payload
+	}
+	sequenceNumber := gjson.GetBytes(payload, "sequence_number")
+	if !sequenceNumber.Exists() {
+		return payload
+	}
+	shifted, err := sjson.SetBytes(payload, "sequence_number", sequenceNumber.Int()+f.sequenceOffset)
+	if err != nil {
+		return payload
+	}
+	return shifted
+}
+
+func imageGenerationItemKey(payload []byte, itemIDPath string) string {
+	if itemID := strings.TrimSpace(gjson.GetBytes(payload, itemIDPath).String()); itemID != "" {
+		return "id:" + itemID
+	}
+	if outputIndex := gjson.GetBytes(payload, "output_index"); outputIndex.Exists() {
+		return "index:" + strconv.FormatInt(outputIndex.Int(), 10)
+	}
+	return ""
+}
+
+func (f *responsesSSEFramer) recordCompletedImageItem(payload []byte) {
+	key := imageGenerationItemKey(payload, "item_id")
+	if key == "" {
+		return
+	}
+	if f.completedImageItems == nil {
+		f.completedImageItems = make(map[string]struct{})
+	}
+	f.completedImageItems[key] = struct{}{}
+}
+
+func (f *responsesSSEFramer) repairImageGenerationDone(payload []byte) (completedPayload, repairedPayload []byte, repaired bool) {
+	item := gjson.GetBytes(payload, "item")
+	if item.Get("type").String() != "image_generation_call" || strings.TrimSpace(item.Get("result").String()) == "" {
+		return nil, payload, false
+	}
+
+	repairedPayload = payload
+	if item.Get("status").String() != "completed" {
+		if updated, err := sjson.SetBytes(repairedPayload, "item.status", "completed"); err == nil {
+			repairedPayload = updated
+		}
+	}
+
+	key := imageGenerationItemKey(repairedPayload, "item.id")
+	if key != "" {
+		if _, exists := f.completedImageItems[key]; exists {
+			return nil, repairedPayload, true
+		}
+	}
+
+	completedPayload = []byte(`{"type":"response.image_generation_call.completed"}`)
+	for sourcePath, targetPath := range map[string]string{
+		"output_index": "output_index",
+		"item.id":      "item_id",
+	} {
+		value := gjson.GetBytes(repairedPayload, sourcePath)
+		if !value.Exists() {
+			continue
+		}
+		completedPayload, _ = sjson.SetBytes(completedPayload, targetPath, value.Value())
+	}
+
+	sequenceNumber := gjson.GetBytes(repairedPayload, "sequence_number")
+	if sequenceNumber.Exists() {
+		completedPayload, _ = sjson.SetBytes(completedPayload, "sequence_number", sequenceNumber.Int())
+		repairedPayload, _ = sjson.SetBytes(repairedPayload, "sequence_number", sequenceNumber.Int()+1)
+		f.sequenceOffset++
+	}
+
+	if key != "" {
+		if f.completedImageItems == nil {
+			f.completedImageItems = make(map[string]struct{})
+		}
+		f.completedImageItems[key] = struct{}{}
+	}
+	return completedPayload, repairedPayload, true
 }
 
 func responsesSSEPayloadErrorMessage(payload []byte) *interfaces.ErrorMessage {
@@ -288,6 +411,7 @@ func (f *responsesSSEFramer) recordOutputItem(payload []byte) {
 }
 
 func (f *responsesSSEFramer) repairCompletedPayload(payload []byte) []byte {
+	payload = normalizeResponsesImageGenerationOutput(payload)
 	if len(f.outputOrder) == 0 && len(f.unindexedOutputItems) == 0 {
 		return payload
 	}
@@ -324,6 +448,28 @@ func (f *responsesSSEFramer) repairCompletedPayload(payload []byte) []byte {
 	repaired, err := sjson.SetRawBytes(payload, "response.output", outputJSON.Bytes())
 	if err != nil {
 		return payload
+	}
+	return repaired
+}
+
+func normalizeResponsesImageGenerationOutput(payload []byte) []byte {
+	output := gjson.GetBytes(payload, "response.output")
+	if !output.IsArray() {
+		return payload
+	}
+
+	repaired := payload
+	for index, item := range output.Array() {
+		if item.Get("type").String() != "image_generation_call" || strings.TrimSpace(item.Get("result").String()) == "" {
+			continue
+		}
+		if item.Get("status").String() == "completed" {
+			continue
+		}
+		updated, err := sjson.SetBytes(repaired, "response.output."+strconv.Itoa(index)+".status", "completed")
+		if err == nil {
+			repaired = updated
+		}
 	}
 	return repaired
 }
@@ -647,7 +793,7 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 	if isCodexResponsesClientRequest(c) {
 		failureEvent = "response.failed"
 	}
-	framer := &responsesSSEFramer{failureEvent: failureEvent}
+	framer := &responsesSSEFramer{failureEvent: failureEvent, imageOutputDir: h.codexImageOutputDir()}
 	var initialOutput bytes.Buffer
 
 	// Peek at the first complete SSE data frame.
@@ -906,7 +1052,7 @@ func (h *OpenAIResponsesAPIHandler) logResponsesStreamError(c *gin.Context, fram
 
 func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage, framer *responsesSSEFramer) {
 	if framer == nil {
-		framer = &responsesSSEFramer{}
+		framer = &responsesSSEFramer{imageOutputDir: h.codexImageOutputDir()}
 	}
 	if isCodexResponsesClientRequest(c) {
 		framer.failureEvent = "response.failed"

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -153,6 +153,92 @@ func TestForwardResponsesStreamRepairsEmptyCompletedOutputFromDoneItems(t *testi
 	}
 }
 
+func TestForwardResponsesStreamSynthesizesMissingImageGenerationCompleted(t *testing.T) {
+	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
+
+	data := make(chan []byte, 2)
+	errs := make(chan *interfaces.ErrorMessage)
+	data <- []byte("event: response.output_item.done\n" +
+		`data: {"type":"response.output_item.done","sequence_number":6,"output_index":0,"item":{"id":"ig-1","type":"image_generation_call","status":"generating","result":"aW1hZ2U="}}`)
+	data <- []byte("event: response.completed\n" +
+		`data: {"type":"response.completed","sequence_number":7,"response":{"id":"resp-1","status":"completed","output":[{"id":"ig-1","type":"image_generation_call","status":"generating","result":"aW1hZ2U="}]}}`)
+	close(data)
+	close(errs)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+
+	frames := strings.Split(strings.TrimSpace(recorder.Body.String()), "\n\n")
+	if len(frames) != 3 {
+		t.Fatalf("expected synthesized completed, done, and response.completed frames; got %d: %q", len(frames), recorder.Body.String())
+	}
+
+	payloadAt := func(index int) gjson.Result {
+		payload, ok := responsesSSEDataPayload([]byte(frames[index]))
+		if !ok {
+			t.Fatalf("frame %d has no data payload: %q", index, frames[index])
+		}
+		return gjson.ParseBytes(payload)
+	}
+
+	synthesized := payloadAt(0)
+	if got := synthesized.Get("type").String(); got != "response.image_generation_call.completed" {
+		t.Fatalf("synthesized type = %q, want response.image_generation_call.completed", got)
+	}
+	if got := synthesized.Get("item_id").String(); got != "ig-1" {
+		t.Fatalf("synthesized item_id = %q, want ig-1", got)
+	}
+	if got := synthesized.Get("sequence_number").Int(); got != 6 {
+		t.Fatalf("synthesized sequence_number = %d, want 6", got)
+	}
+
+	done := payloadAt(1)
+	if got := done.Get("item.status").String(); got != "completed" {
+		t.Fatalf("done item status = %q, want completed", got)
+	}
+	if got := done.Get("sequence_number").Int(); got != 7 {
+		t.Fatalf("done sequence_number = %d, want 7", got)
+	}
+
+	completed := payloadAt(2)
+	if got := completed.Get("sequence_number").Int(); got != 8 {
+		t.Fatalf("response.completed sequence_number = %d, want 8", got)
+	}
+	if got := completed.Get("response.output.0.status").String(); got != "completed" {
+		t.Fatalf("completed output image status = %q, want completed", got)
+	}
+}
+
+func TestForwardResponsesStreamDoesNotDuplicateImageGenerationCompleted(t *testing.T) {
+	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
+
+	data := make(chan []byte, 3)
+	errs := make(chan *interfaces.ErrorMessage)
+	data <- []byte("event: response.image_generation_call.completed\n" +
+		`data: {"type":"response.image_generation_call.completed","sequence_number":5,"output_index":0,"item_id":"ig-1"}`)
+	data <- []byte("event: response.output_item.done\n" +
+		`data: {"type":"response.output_item.done","sequence_number":6,"output_index":0,"item":{"id":"ig-1","type":"image_generation_call","status":"generating","result":"aW1hZ2U="}}`)
+	data <- []byte("event: response.completed\n" +
+		`data: {"type":"response.completed","sequence_number":7,"response":{"id":"resp-1","status":"completed","output":[{"id":"ig-1","type":"image_generation_call","status":"generating","result":"aW1hZ2U="}]}}`)
+	close(data)
+	close(errs)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+
+	body := recorder.Body.String()
+	if got := strings.Count(body, `"type":"response.image_generation_call.completed"`); got != 1 {
+		t.Fatalf("image generation completed event count = %d, want 1; body=%q", got, body)
+	}
+	if got := gjson.Get(strings.Split(strings.TrimSpace(body), "\n\n")[1], "item.status").String(); got != "completed" {
+		payload, _ := responsesSSEDataPayload([]byte(strings.Split(strings.TrimSpace(body), "\n\n")[1]))
+		if got = gjson.GetBytes(payload, "item.status").String(); got != "completed" {
+			t.Fatalf("done item status = %q, want completed", got)
+		}
+	}
+	if !strings.Contains(body, `"sequence_number":7,"response"`) {
+		t.Fatalf("existing completion should not shift sequence numbers: %q", body)
+	}
+}
+
 func TestForwardResponsesStreamRepairsMixedIndexedAndUnindexedDoneItems(t *testing.T) {
 	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
 


### PR DESCRIPTION
## Summary

- synthesize a missing `response.image_generation_call.completed` event when Codex upstream finishes an image item with a result
- normalize terminal image generation statuses to `completed`, preserve monotonic SSE sequence numbers, and avoid duplicate completion events
- add an opt-in `codex-image-output-dir` setting that persists PNG, JPEG, or WebP results and appends a renderable absolute Markdown image path for local Codex clients

## Root cause

Codex upstream can emit a result-bearing `response.output_item.done` for an `image_generation_call` while leaving the item status as `generating` and omitting `response.image_generation_call.completed`. CLIProxy forwarded that incomplete lifecycle unchanged. Codex Desktop retained the Base64 result in its session data, but had no completed image event or local file reference it could render.

The output directory remains disabled by default, so existing remote and general-purpose deployments keep their current behavior.

## Tests

- `go test ./internal/config ./internal/translator/codex/openai/responses ./sdk/api/handlers/openai`
- end-to-end Codex Desktop -> CLIProxy image generation with no bridge layer; the generated PNG was persisted and rendered through the returned Markdown path
