### PR TITLE
fix(auth): share session-affinity binding across thinking-suffix model variants

### DIFF
--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -192,6 +192,36 @@ func canonicalModelKey(model string) string {
 	return modelName
 }
 
+// affinityModelKey canonicalizes only suffixes the thinking parsers recognize
+// (numeric budget, none/auto, discrete levels), so variants like "model" and
+// "model(high)" share one session binding. Parenthesized names that are not
+// thinking suffixes are kept intact: they may denote a distinct model or
+// configured alias rather than a thinking variant.
+func affinityModelKey(model string) string {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return ""
+	}
+	parsed := thinking.ParseSuffix(model)
+	if !parsed.HasSuffix {
+		return model
+	}
+	modelName := strings.TrimSpace(parsed.ModelName)
+	if modelName == "" {
+		return model
+	}
+	if _, ok := thinking.ParseNumericSuffix(parsed.RawSuffix); ok {
+		return modelName
+	}
+	if _, ok := thinking.ParseSpecialSuffix(parsed.RawSuffix); ok {
+		return modelName
+	}
+	if _, ok := thinking.ParseLevelSuffix(parsed.RawSuffix); ok {
+		return modelName
+	}
+	return model
+}
+
 func authWebsocketsEnabled(auth *Auth) bool {
 	if auth == nil {
 		return false
@@ -687,7 +717,7 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	// Canonicalize the route model so thinking-suffix variants of the same base
 	// model (e.g. "claude-3" and "claude-3(high)") share one session binding,
 	// matching the canonicalization used for cursors and cooldown states.
-	keyModel := canonicalModelKey(model)
+	keyModel := affinityModelKey(model)
 	cacheKey := provider + "::" + primaryID + "::" + keyModel
 	fallbackKey := ""
 	if fallbackID != "" && fallbackID != primaryID {
@@ -793,7 +823,7 @@ func (s *SessionAffinitySelector) OnResult(res Result) {
 	}
 	// Match the canonical model key used when the binding was created in Pick,
 	// so thinking-suffix variants resolve to the same cache entry.
-	nsModel = canonicalModelKey(nsModel)
+	nsModel = affinityModelKey(nsModel)
 
 	cacheKey := ns + "::" + primaryID + "::" + nsModel
 	var fallbackKey string

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -684,10 +684,14 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	}
 	fallbackAuths := highestPriorityAuths(available)
 
-	cacheKey := provider + "::" + primaryID + "::" + model
+	// Canonicalize the route model so thinking-suffix variants of the same base
+	// model (e.g. "claude-3" and "claude-3(high)") share one session binding,
+	// matching the canonicalization used for cursors and cooldown states.
+	keyModel := canonicalModelKey(model)
+	cacheKey := provider + "::" + primaryID + "::" + keyModel
 	fallbackKey := ""
 	if fallbackID != "" && fallbackID != primaryID {
-		fallbackKey = provider + "::" + fallbackID + "::" + model
+		fallbackKey = provider + "::" + fallbackID + "::" + keyModel
 	}
 	bind := func(authID string) {
 		if fallbackKey != "" {
@@ -787,6 +791,9 @@ func (s *SessionAffinitySelector) OnResult(res Result) {
 	if raw, ok := res.Options.Metadata[cliproxyexecutor.SessionAffinityModelMetadataKey].(string); ok && raw != "" {
 		nsModel = raw
 	}
+	// Match the canonical model key used when the binding was created in Pick,
+	// so thinking-suffix variants resolve to the same cache entry.
+	nsModel = canonicalModelKey(nsModel)
 
 	cacheKey := ns + "::" + primaryID + "::" + nsModel
 	var fallbackKey string

--- a/sdk/cliproxy/auth/session_affinity_canonical_model_test.go
+++ b/sdk/cliproxy/auth/session_affinity_canonical_model_test.go
@@ -86,3 +86,44 @@ func TestSessionAffinityOnResult_ThinkingSuffixReleasesBinding(t *testing.T) {
 		t.Fatalf("Pick() after failure auth.ID = %q, want reselection after the binding was released", third.ID)
 	}
 }
+
+// Parenthesized names that the thinking parsers do not recognize (e.g. a
+// configured alias like "claude-3(custom)") are distinct models, not thinking
+// variants, and must not be collapsed into the base model's session binding.
+func TestSessionAffinitySelector_UnrecognizedSuffixKeepsSeparateBinding(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer selector.Stop()
+
+	auths := []*Auth{
+		{ID: "auth-a"},
+		{ID: "auth-b"},
+	}
+	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_suffix-distinct"}}`)
+	opts := cliproxyexecutor.Options{OriginalRequest: payload}
+
+	first, err := selector.Pick(context.Background(), "claude", "claude-3(custom)", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+
+	// The unrecognized suffix must not collapse onto the base model's binding:
+	// the base model's first pick is a cache miss and round-robin moves on.
+	second, errPick := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+	if errPick != nil {
+		t.Fatalf("Pick() error = %v", errPick)
+	}
+	if second.ID == first.ID {
+		t.Fatalf("Pick() auth.ID = %q, want a separate binding for an unrecognized suffix", second.ID)
+	}
+
+	// Sanity: a recognized thinking level still shares the base binding.
+	third, errPick := selector.Pick(context.Background(), "claude", "claude-3(high)", opts, auths)
+	if errPick != nil {
+		t.Fatalf("Pick() error = %v", errPick)
+	}
+	if third.ID != second.ID {
+		t.Fatalf("Pick() auth.ID = %q, want sticky auth %q for a recognized thinking variant", third.ID, second.ID)
+	}
+}

--- a/sdk/cliproxy/auth/session_affinity_canonical_model_test.go
+++ b/sdk/cliproxy/auth/session_affinity_canonical_model_test.go
@@ -1,0 +1,88 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// Thinking-suffix variants of the same route model (e.g. "claude-3" and
+// "claude-3(high)") share one credential pool and one cooldown state, so a
+// session bound through one variant must stay bound when a later request in
+// the same session arrives with another variant.
+func TestSessionAffinitySelector_ThinkingSuffixSharesSessionBinding(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer selector.Stop()
+
+	auths := []*Auth{
+		{ID: "auth-a"},
+		{ID: "auth-b"},
+	}
+	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_suffix-share"}}`)
+	opts := cliproxyexecutor.Options{OriginalRequest: payload}
+
+	first, err := selector.Pick(context.Background(), "claude", "claude-3(high)", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+
+	for _, model := range []string{"claude-3", "claude-3(low)", "claude-3(high)"} {
+		got, errPick := selector.Pick(context.Background(), "claude", model, opts, auths)
+		if errPick != nil {
+			t.Fatalf("Pick(%q) error = %v", model, errPick)
+		}
+		if got.ID != first.ID {
+			t.Fatalf("Pick(%q) auth.ID = %q, want sticky auth %q (thinking-suffix variants must share the session binding)", model, got.ID, first.ID)
+		}
+	}
+}
+
+// A failure reported with the base model name must release a binding that was
+// created through a thinking-suffixed variant of the same route model.
+func TestSessionAffinityOnResult_ThinkingSuffixReleasesBinding(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer selector.Stop()
+
+	auths := []*Auth{
+		{ID: "auth-a"},
+		{ID: "auth-b"},
+	}
+	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_suffix-release"}}`)
+	opts := cliproxyexecutor.Options{OriginalRequest: payload}
+
+	first, err := selector.Pick(context.Background(), "claude", "claude-3(high)", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+
+	// The next request of the same session arrives without the suffix and fails.
+	second, errPick := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+	if errPick != nil {
+		t.Fatalf("Pick() error = %v", errPick)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("Pick() auth.ID = %q, want sticky auth %q before failure", second.ID, first.ID)
+	}
+	selector.OnResult(Result{
+		AuthID:   second.ID,
+		Provider: "claude",
+		Model:    "claude-3",
+		Success:  false,
+		Error:    &Error{Code: "upstream_error", Message: "upstream failed"},
+		Options:  opts,
+	})
+
+	// The binding is released, so the round-robin fallback must move on.
+	third, errPick := selector.Pick(context.Background(), "claude", "claude-3(high)", opts, auths)
+	if errPick != nil {
+		t.Fatalf("Pick() after failure error = %v", errPick)
+	}
+	if third.ID == first.ID {
+		t.Fatalf("Pick() after failure auth.ID = %q, want reselection after the binding was released", third.ID)
+	}
+}


### PR DESCRIPTION
Fixes #5016

## Summary

The session-affinity cache key in `SessionAffinitySelector.Pick`/`OnResult` embedded the raw route model, while round-robin cursors (`RoundRobinSelector.Pick`) and cooldown states already canonicalize thinking suffixes via `canonicalModelKey`. A session sending `model` and `model(high)` was therefore split into two independent bindings and could land on different credentials, silently breaking stickiness; `OnResult` failure cleanup could also miss the binding for the same reason. Both `Pick` and `OnResult` now canonicalize the model when building cache keys, matching the rest of the routing pipeline.

## Tests

New regression tests, red before the fix and green after:

- `TestSessionAffinitySelector_ThinkingSuffixSharesSessionBinding`
- `TestSessionAffinityOnResult_ThinkingSuffixReleasesBinding`

## Verification

- `go test ./sdk/cliproxy/...`: fully green.
- `go test -race ./sdk/cliproxy/auth/` on **Linux (WSL2, go1.26.0 linux/amd64)**: green.
