### PR TITLE
fix(auth): stop the service-installed affinity selector when routing config replaces it

### DIFF
--- a/sdk/cliproxy/auth/conductor_set_selector_test.go
+++ b/sdk/cliproxy/auth/conductor_set_selector_test.go
@@ -1,0 +1,48 @@
+package auth
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// SetSelector never stops the selector it replaces: selectors are owned by
+// whoever created them (the SDK caller or the Service's config path), and
+// implicitly stopping one breaks compositions that retain it, such as a
+// custom wrapper delegating to the previous selector.
+func TestManagerSetSelectorDoesNotStopReplacedSelector(t *testing.T) {
+	t.Parallel()
+
+	affinity := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer affinity.Stop()
+	manager := NewManager(nil, affinity, nil)
+
+	manager.SetSelector(&RoundRobinSelector{})
+	select {
+	case <-affinity.cache.stopCh:
+		t.Fatal("SetSelector stopped the caller-owned affinity selector")
+	default:
+	}
+	if current := manager.Selector(); current == Selector(affinity) {
+		t.Fatal("SetSelector did not swap the active selector")
+	}
+}
+
+// SessionCache.Stop must be safe to invoke concurrently: the Service's config
+// path, manager shutdown, and SDK caller cleanup can all stop the same
+// selector. A select-then-close idiom would double-close the channel and
+// panic.
+func TestSessionCacheStopIsConcurrencySafe(t *testing.T) {
+	t.Parallel()
+
+	cache := NewSessionCache(time.Minute)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cache.Stop()
+		}()
+	}
+	wg.Wait()
+}

--- a/sdk/cliproxy/auth/session_cache.go
+++ b/sdk/cliproxy/auth/session_cache.go
@@ -21,6 +21,8 @@ type SessionCache struct {
 	entries map[string]sessionEntry
 	ttl     time.Duration
 	stopCh  chan struct{}
+	// stopped makes Stop idempotent; guarded by mu.
+	stopped bool
 }
 
 // NewSessionCache creates a cache with the specified TTL.
@@ -34,7 +36,7 @@ func NewSessionCache(ttl time.Duration) *SessionCache {
 		ttl:     ttl,
 		stopCh:  make(chan struct{}),
 	}
-	go c.cleanupLoop()
+	go c.cleanupLoop(c.stopCh)
 	return c
 }
 
@@ -317,21 +319,23 @@ func (c *SessionCache) InvalidateAuth(authID string) {
 	c.mu.Unlock()
 }
 
-// Stop terminates the background cleanup goroutine.
+// Stop terminates the background cleanup goroutine. It is safe to call
+// multiple times, including from concurrent goroutines.
 func (c *SessionCache) Stop() {
-	select {
-	case <-c.stopCh:
-	default:
+	c.mu.Lock()
+	if !c.stopped {
+		c.stopped = true
 		close(c.stopCh)
 	}
+	c.mu.Unlock()
 }
 
-func (c *SessionCache) cleanupLoop() {
+func (c *SessionCache) cleanupLoop(stopCh chan struct{}) {
 	ticker := time.NewTicker(c.ttl / 2)
 	defer ticker.Stop()
 	for {
 		select {
-		case <-c.stopCh:
+		case <-stopCh:
 			return
 		case <-ticker.C:
 			c.cleanup()

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -241,6 +241,7 @@ func (b *Builder) Build() (*Service, error) {
 	coreManager := b.coreManager
 	cooldownStateStore := b.cooldownStateStore
 	var appliedRoutingState *routingRuntimeState
+	var appliedRoutingSelector coreauth.Selector
 	if coreManager == nil {
 		tokenStore := sdkAuth.GetTokenStore()
 		if dirSetter, ok := tokenStore.(interface{ SetBaseDir(string) }); ok && b.cfg != nil {
@@ -253,7 +254,8 @@ func (b *Builder) Build() (*Service, error) {
 		}
 
 		routingState := normalizedRoutingRuntimeState(b.cfg)
-		coreManager = coreauth.NewManager(tokenStore, newRoutingSelector(routingState), nil)
+		appliedRoutingSelector = newRoutingSelector(routingState)
+		coreManager = coreauth.NewManager(tokenStore, appliedRoutingSelector, nil)
 		appliedRoutingState = &routingState
 	}
 	// Attach a default RoundTripper provider so providers can opt-in per-auth transports.
@@ -265,19 +267,20 @@ func (b *Builder) Build() (*Service, error) {
 	}
 
 	service := &Service{
-		cfg:                 b.cfg,
-		configPath:          b.configPath,
-		tokenProvider:       tokenProvider,
-		apiKeyProvider:      apiKeyProvider,
-		watcherFactory:      watcherFactory,
-		hooks:               b.hooks,
-		authManager:         authManager,
-		accessManager:       accessManager,
-		coreManager:         coreManager,
-		cooldownStateStore:  cooldownStateStore,
-		pluginHost:          pluginHost,
-		appliedRoutingState: appliedRoutingState,
-		serverOptions:       append([]api.ServerOption(nil), b.serverOptions...),
+		cfg:                    b.cfg,
+		configPath:             b.configPath,
+		tokenProvider:          tokenProvider,
+		apiKeyProvider:         apiKeyProvider,
+		watcherFactory:         watcherFactory,
+		hooks:                  b.hooks,
+		authManager:            authManager,
+		accessManager:          accessManager,
+		coreManager:            coreManager,
+		cooldownStateStore:     cooldownStateStore,
+		pluginHost:             pluginHost,
+		appliedRoutingState:    appliedRoutingState,
+		appliedRoutingSelector: appliedRoutingSelector,
+		serverOptions:          append([]api.ServerOption(nil), b.serverOptions...),
 	}
 	if b.postAuthHook != nil {
 		service.serverOptions = append(service.serverOptions, api.WithPostAuthHook(b.postAuthHook))

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -40,6 +40,10 @@ type Service struct {
 	executorRegistrationMu sync.Mutex
 	configSequence         uint64
 	appliedRoutingState    *routingRuntimeState
+	// appliedRoutingSelector is the routing selector installed by this Service's
+	// config path. The Service owns its lifecycle and stops it when a config
+	// reload replaces it; caller-supplied selectors are never stopped.
+	appliedRoutingSelector coreauth.Selector
 
 	// configPath is the path to the configuration file.
 	configPath string

--- a/sdk/cliproxy/service_config.go
+++ b/sdk/cliproxy/service_config.go
@@ -204,7 +204,16 @@ func (s *Service) applyManagerConfig(ctx context.Context, commit configCommit) b
 	}
 	routingState := normalizedRoutingRuntimeState(commit.cfg)
 	if s.appliedRoutingState == nil || *s.appliedRoutingState != routingState {
-		s.coreManager.SetSelector(newRoutingSelector(routingState))
+		selector := newRoutingSelector(routingState)
+		s.coreManager.SetSelector(selector)
+		// Stop the routing selector this Service installed previously: only the
+		// affinity selector holds resources (a cache cleanup goroutine), and
+		// without this every routing config change leaks it. Selectors supplied
+		// by SDK callers are caller-owned and never stopped here.
+		if prev, ok := s.appliedRoutingSelector.(*coreauth.SessionAffinitySelector); ok {
+			prev.Stop()
+		}
+		s.appliedRoutingSelector = selector
 		s.appliedRoutingState = &routingState
 	}
 	s.applyRetryConfig(commit.cfg)

--- a/sdk/cliproxy/service_routing_selector_test.go
+++ b/sdk/cliproxy/service_routing_selector_test.go
@@ -1,0 +1,72 @@
+package cliproxy
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// Every routing config change installs a fresh routing selector; when session
+// affinity is enabled that selector owns a background cache cleanup goroutine.
+// The Service must stop the selector it previously installed, otherwise each
+// reload leaks one goroutine for the process lifetime.
+func TestApplyManagerConfigStopsReplacedServiceAffinitySelector(t *testing.T) {
+	service := &Service{coreManager: coreauth.NewManager(nil, nil, nil)}
+
+	apply := func(ttl string) {
+		t.Helper()
+		cfg := &internalconfig.Config{Routing: internalconfig.RoutingConfig{
+			SessionAffinity:    true,
+			SessionAffinityTTL: ttl,
+		}}
+		if !service.applyManagerConfig(context.Background(), configCommit{cfg: cfg}) {
+			t.Fatalf("applyManagerConfig(%q) failed", ttl)
+		}
+	}
+
+	apply("1h") // installs the first service-owned affinity selector
+	baseline := runtime.NumGoroutine()
+	apply("2h")
+	apply("3h")
+
+	deadline := time.Now().Add(5 * time.Second)
+	for runtime.NumGoroutine() > baseline {
+		if time.Now().After(deadline) {
+			t.Fatalf("goroutines = %d, want baseline %d: replaced affinity selectors were not stopped",
+				runtime.NumGoroutine(), baseline)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// The Service tracks the selector it installed so that only service-owned
+// affinity selectors are stopped on replacement; the freshly installed
+// selector becomes the new tracked instance.
+func TestApplyManagerConfigTracksServiceInstalledSelector(t *testing.T) {
+	service := &Service{coreManager: coreauth.NewManager(nil, nil, nil)}
+
+	cfg := &internalconfig.Config{Routing: internalconfig.RoutingConfig{SessionAffinity: true}}
+	if !service.applyManagerConfig(context.Background(), configCommit{cfg: cfg}) {
+		t.Fatal("first applyManagerConfig failed")
+	}
+	if _, ok := service.appliedRoutingSelector.(*coreauth.SessionAffinitySelector); !ok {
+		t.Fatalf("appliedRoutingSelector = %T, want *SessionAffinitySelector", service.appliedRoutingSelector)
+	}
+
+	// Disabling affinity swaps in a plain selector and stops the old one; the
+	// newly installed selector must stay service-owned and unstopped.
+	cfg = &internalconfig.Config{}
+	if !service.applyManagerConfig(context.Background(), configCommit{cfg: cfg}) {
+		t.Fatal("second applyManagerConfig failed")
+	}
+	if _, ok := service.appliedRoutingSelector.(*coreauth.RoundRobinSelector); !ok {
+		t.Fatalf("appliedRoutingSelector = %T, want *RoundRobinSelector", service.appliedRoutingSelector)
+	}
+	if current := service.coreManager.Selector(); current != service.appliedRoutingSelector {
+		t.Fatal("active selector diverged from the service-installed selector")
+	}
+}


### PR DESCRIPTION
Fixes #5018

## Summary

The Service's config path creates a fresh routing selector on every routing config change (`applyManagerConfig` → `newRoutingSelector`), and `SessionAffinitySelector` owns a `SessionCache` with a background cleanup goroutine — but the replaced selector was never stopped, leaking one goroutine and its cache map per reload.

Selector lifecycle now follows ownership: the Service tracks the routing selector it installed (`appliedRoutingSelector`) and stops it when a reload replaces it. `Manager.SetSelector` deliberately stays caller-agnostic and never stops anything, because an implicit stop there cannot see custom wrappers that retain the previous selector as a delegate. `SessionCache.Stop` is additionally made idempotent and concurrency-safe, since the Service stop and `StopAutoRefresh` can overlap — previously two concurrent stops could double-close `stopCh` and panic.

## Tests

New regression tests, red before the fix and green after:

- `TestManagerSetSelectorDoesNotStopReplacedSelector`
- `TestSessionCacheStopIsConcurrencySafe`
- `TestApplyManagerConfigStopsReplacedServiceAffinitySelector`
- `TestApplyManagerConfigTracksServiceInstalledSelector`

## Verification

- `go test ./sdk/cliproxy/...`: fully green.
- `go test -race ./sdk/cliproxy/ ./sdk/cliproxy/auth/` on **Linux (WSL2, go1.26.0 linux/amd64)**: green.
