### PR TITLE
feat(plugin): add outbound header interception

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
 	sdkpluginstore "github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginstore"
 	log "github.com/sirupsen/logrus"
 )
@@ -642,6 +643,7 @@ func main() {
 	}
 
 	// Handle different command modes based on the provided flags.
+	options.Context = outbound.WithHeaderFinalizer(context.Background(), pluginHost)
 
 	if vertexImport != "" {
 		// Handle Vertex service account import
@@ -676,7 +678,7 @@ func main() {
 			if standalone {
 				// Standalone mode: start an embedded local server and connect TUI client to it.
 				managementasset.StartAutoUpdater(context.Background(), configFilePath)
-				misc.StartAntigravityVersionUpdater(context.Background())
+				misc.StartAntigravityVersionUpdater(outbound.WithHeaderFinalizer(context.Background(), pluginHost))
 				startModelCatalogUpdaters(localModel, cfg.Home.Enabled)
 				hook := tui.NewLogHook(2000)
 				hook.SetFormatter(&logging.LogFormatter{})
@@ -750,7 +752,7 @@ func main() {
 		} else {
 			// Start the main proxy service
 			managementasset.StartAutoUpdater(context.Background(), configFilePath)
-			misc.StartAntigravityVersionUpdater(context.Background())
+			misc.StartAntigravityVersionUpdater(outbound.WithHeaderFinalizer(context.Background(), pluginHost))
 			startModelCatalogUpdaters(localModel, cfg.Home.Enabled)
 			cmd.StartServiceWithPluginHost(cfg, configFilePath, password, pluginHost, serverOptions...)
 		}

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
 	log "github.com/sirupsen/logrus"
 )
@@ -97,6 +98,7 @@ type apiCallResponse struct {
 //	  -H "Content-Type: application/json" \
 //	  -d '{"auth_index":"<AUTH_INDEX>","method":"POST","url":"https://api.example.com/v1/fetchAvailableModels","header":{"Authorization":"Bearer $TOKEN$","Content-Type":"application/json","User-Agent":"cliproxyapi"},"data":"{}"}'
 func (h *Handler) APICall(c *gin.Context) {
+	ctx := h.populateAuthContext(c.Request.Context(), c)
 	var body apiCallRequest
 	if errBindJSON := c.ShouldBindJSON(&body); errBindJSON != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
@@ -145,7 +147,7 @@ func (h *Handler) APICall(c *gin.Context) {
 			continue
 		}
 		if !tokenResolved {
-			token, tokenErr = h.resolveTokenForAuth(c.Request.Context(), auth, requestProxyURL)
+			token, tokenErr = h.resolveTokenForAuth(ctx, auth, requestProxyURL)
 			tokenResolved = true
 		}
 		if auth != nil && token == "" {
@@ -167,7 +169,7 @@ func (h *Handler) APICall(c *gin.Context) {
 		requestBody = strings.NewReader(body.Data)
 	}
 
-	req, errNewRequest := http.NewRequestWithContext(c.Request.Context(), method, urlStr, requestBody)
+	req, errNewRequest := http.NewRequestWithContext(ctx, method, urlStr, requestBody)
 	if errNewRequest != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to build request"})
 		return
@@ -189,7 +191,11 @@ func (h *Handler) APICall(c *gin.Context) {
 	}
 	httpClient.Transport = h.apiCallTransport(auth, requestProxyURL)
 
-	resp, errDo := httpClient.Do(req)
+	provider := ""
+	if auth != nil {
+		provider = auth.Provider
+	}
+	resp, errDo := outbound.Do(ctx, provider, httpClient, req)
 	if errDo != nil {
 		log.WithError(errDo).Debug("management APICall request failed")
 		c.JSON(http.StatusBadGateway, gin.H{"error": "request failed"})
@@ -297,7 +303,7 @@ func (h *Handler) refreshAntigravityOAuthAccessToken(ctx context.Context, auth *
 		Timeout:   defaultAPICallTimeout,
 		Transport: h.apiCallTransport(auth, requestProxyURL),
 	}
-	resp, errDo := httpClient.Do(req)
+	resp, errDo := outbound.Do(ctx, "antigravity", httpClient, req)
 	if errDo != nil {
 		return "", errDo
 	}

--- a/internal/api/handlers/management/auth_files_oauth_callback.go
+++ b/internal/api/handlers/management/auth_files_oauth_callback.go
@@ -183,7 +183,7 @@ func (h *Handler) ServePluginAuthURL(c *gin.Context) bool {
 		return false
 	}
 
-	ctx := PopulateAuthContext(context.Background(), c)
+	ctx := h.populateAuthContext(context.Background(), c)
 	baseURL, errBaseURL := h.managementCallbackURL("/v0/management/oauth-callback")
 	if errBaseURL != nil {
 		log.WithError(errBaseURL).Error("failed to compute plugin auth callback URL")

--- a/internal/api/handlers/management/auth_files_provider_oauth.go
+++ b/internal/api/handlers/management/auth_files_provider_oauth.go
@@ -23,6 +23,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	log "github.com/sirupsen/logrus"
 )
@@ -35,7 +36,7 @@ type codexOAuthService interface {
 
 func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 	ctx := context.Background()
-	ctx = PopulateAuthContext(ctx, c)
+	ctx = h.populateAuthContext(ctx, c)
 
 	fmt.Println("Initializing Claude authentication...")
 
@@ -195,7 +196,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 
 func (h *Handler) RequestCodexToken(c *gin.Context) {
 	ctx := context.Background()
-	ctx = PopulateAuthContext(ctx, c)
+	ctx = h.populateAuthContext(ctx, c)
 
 	fmt.Println("Initializing Codex authentication...")
 
@@ -343,7 +344,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 
 func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 	ctx := context.Background()
-	ctx = PopulateAuthContext(ctx, c)
+	ctx = h.populateAuthContext(ctx, c)
 
 	fmt.Println("Initializing Antigravity authentication...")
 
@@ -510,7 +511,7 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 
 func (h *Handler) RequestXAIToken(c *gin.Context) {
 	ctx := context.Background()
-	ctx = PopulateAuthContext(ctx, c)
+	ctx = h.populateAuthContext(ctx, c)
 
 	fmt.Println("Initializing xAI authentication...")
 
@@ -623,7 +624,7 @@ func (h *Handler) RequestXAIToken(c *gin.Context) {
 
 func (h *Handler) RequestKimiToken(c *gin.Context) {
 	ctx := context.Background()
-	ctx = PopulateAuthContext(ctx, c)
+	ctx = h.populateAuthContext(ctx, c)
 
 	fmt.Println("Initializing Kimi authentication...")
 
@@ -782,7 +783,7 @@ func (h *Handler) GetAuthStatus(c *gin.Context) {
 	host := h.pluginHost
 	h.mu.Unlock()
 	if isPlugin && host != nil && host.HasAuthProvider(provider) {
-		ctx := PopulateAuthContext(context.Background(), c)
+		ctx := h.populateAuthContext(context.Background(), c)
 		resp, handled, errPoll := host.PollLogin(ctx, provider, state, metadata)
 		if handled {
 			if errPoll != nil {
@@ -885,4 +886,15 @@ func PopulateAuthContext(ctx context.Context, c *gin.Context) context.Context {
 		Headers: c.Request.Header,
 	}
 	return coreauth.WithRequestInfo(ctx, info)
+}
+
+func (h *Handler) populateAuthContext(ctx context.Context, c *gin.Context) context.Context {
+	ctx = PopulateAuthContext(ctx, c)
+	if h == nil {
+		return ctx
+	}
+	h.mu.Lock()
+	host := h.pluginHost
+	h.mu.Unlock()
+	return outbound.WithHeaderFinalizer(ctx, host)
 }

--- a/internal/auth/antigravity/auth.go
+++ b/internal/auth/antigravity/auth.go
@@ -14,6 +14,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -149,7 +150,7 @@ func (o *AntigravityAuth) ExchangeCodeForTokens(ctx context.Context, code, redir
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, errDo := o.httpClient.Do(req)
+	resp, errDo := outbound.Do(ctx, "antigravity", o.httpClient, req)
 	if errDo != nil {
 		return nil, fmt.Errorf("antigravity token exchange: execute request: %w", errDo)
 	}
@@ -191,7 +192,7 @@ func (o *AntigravityAuth) FetchUserInfo(ctx context.Context, accessToken string)
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("User-Agent", o.shortUserAgent())
 
-	resp, errDo := o.httpClient.Do(req)
+	resp, errDo := outbound.Do(ctx, "antigravity", o.httpClient, req)
 	if errDo != nil {
 		return "", fmt.Errorf("antigravity userinfo: execute request: %w", errDo)
 	}
@@ -245,7 +246,7 @@ func (o *AntigravityAuth) FetchProjectID(ctx context.Context, accessToken string
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", userAgent)
 
-	resp, errDo := o.httpClient.Do(req)
+	resp, errDo := outbound.Do(ctx, "antigravity", o.httpClient, req)
 	if errDo != nil {
 		return "", fmt.Errorf("execute request: %w", errDo)
 	}
@@ -322,7 +323,7 @@ func (o *AntigravityAuth) OnboardUser(ctx context.Context, accessToken, tierID s
 		req.Header.Set("User-Agent", userAgent)
 		req.Header.Set("X-Goog-Api-Client", misc.AntigravityGoogAPIClientUA)
 
-		resp, errDo := o.httpClient.Do(req)
+		resp, errDo := outbound.Do(ctx, "antigravity", o.httpClient, req)
 		if errDo != nil {
 			cancel()
 			return "", fmt.Errorf("execute request: %w", errDo)

--- a/internal/auth/claude/anthropic_auth.go
+++ b/internal/auth/claude/anthropic_auth.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/singleflight"
 )
@@ -238,7 +239,7 @@ func (o *ClaudeAuth) fetchOAuthControlPlaneJSON(ctx context.Context, endpoint, a
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("Cache-Control", "no-cache")
 
-	resp, errDo := o.httpClient.Do(req)
+	resp, errDo := outbound.Do(ctx, "claude", o.httpClient, req)
 	if errDo != nil {
 		return nil, fmt.Errorf("fetch Claude OAuth %s: %w", label, errDo)
 	}
@@ -403,7 +404,7 @@ func (o *ClaudeAuth) ExchangeCodeForTokens(ctx context.Context, code, state stri
 	}
 	applyClaudeOAuthAxiosHeaders(req)
 
-	resp, err := o.httpClient.Do(req)
+	resp, err := outbound.Do(ctx, "claude", o.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("token exchange request failed: %w", err)
 	}
@@ -541,7 +542,7 @@ func (o *ClaudeAuth) refreshTokensSingleFlight(ctx context.Context, refreshToken
 	}
 	applyClaudeOAuthAxiosHeaders(req)
 
-	resp, err := o.httpClient.Do(req)
+	resp, err := outbound.Do(ctx, "claude", o.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("token refresh request failed: %w", err)
 	}

--- a/internal/auth/codex/openai_auth.go
+++ b/internal/auth/codex/openai_auth.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/singleflight"
 )
@@ -121,7 +122,7 @@ func (o *CodexAuth) ExchangeCodeForTokensWithRedirect(ctx context.Context, code,
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := o.httpClient.Do(req)
+	resp, err := outbound.Do(ctx, "codex", o.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("token exchange request failed: %w", err)
 	}
@@ -226,7 +227,7 @@ func (o *CodexAuth) refreshTokensSingleFlight(ctx context.Context, refreshToken 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	resp, errDo := o.httpClient.Do(req)
+	resp, errDo := outbound.Do(ctx, "codex", o.httpClient, req)
 	if errDo != nil {
 		return nil, fmt.Errorf("token refresh request failed: %w", errDo)
 	}

--- a/internal/auth/codex/openai_auth_test.go
+++ b/internal/auth/codex/openai_auth_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -20,9 +22,47 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+type oauthHeaderFinalizerFunc func(context.Context, pluginapi.OutboundHeaderInterceptRequest) (http.Header, error)
+
+func (f oauthHeaderFinalizerFunc) FinalizeOutboundHeaders(ctx context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+	return f(ctx, req)
+}
+
 func TestNewCodexAuthDoesNotSetRequestTimeout(t *testing.T) {
 	if got := NewCodexAuth(nil).httpClient.Timeout; got != 0 {
 		t.Fatalf("HTTP client timeout = %s, want zero", got)
+	}
+}
+
+func TestExchangeCodeForTokensFinalizesOAuthHeaders(t *testing.T) {
+	var sawRequest bool
+	auth := &CodexAuth{httpClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		sawRequest = true
+		if req.Header.Get("User-Agent") != "oauth-plugin/1.0" {
+			t.Fatalf("User-Agent = %q", req.Header.Get("User-Agent"))
+		}
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"error":"probe"}`)),
+			Request:    req,
+		}, nil
+	})}}
+	ctx := outbound.WithHeaderFinalizer(context.Background(), oauthHeaderFinalizerFunc(func(_ context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+		if req.Provider != "codex" || req.Transport != pluginapi.OutboundTransportHTTP {
+			t.Fatalf("finalizer request identity = %#v", req)
+		}
+		headers := req.Headers.Clone()
+		headers.Set("User-Agent", "oauth-plugin/1.0")
+		return headers, nil
+	}))
+
+	_, errExchange := auth.ExchangeCodeForTokensWithRedirect(ctx, "code", "http://localhost/callback", &PKCECodes{CodeVerifier: "verifier"})
+	if errExchange == nil || !strings.Contains(errExchange.Error(), "status 400") {
+		t.Fatalf("ExchangeCodeForTokensWithRedirect() error = %v, want status 400", errExchange)
+	}
+	if !sawRequest {
+		t.Fatal("OAuth request was not sent")
 	}
 }
 

--- a/internal/auth/kimi/kimi.go
+++ b/internal/auth/kimi/kimi.go
@@ -18,6 +18,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/buildinfo"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/singleflight"
 )
@@ -192,7 +193,7 @@ func (c *DeviceFlowClient) RequestDeviceCode(ctx context.Context) (*DeviceCodeRe
 		req.Header.Set(k, v)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := outbound.Do(ctx, "kimi", c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("kimi: device code request failed: %w", err)
 	}
@@ -280,7 +281,7 @@ func (c *DeviceFlowClient) exchangeDeviceCode(ctx context.Context, deviceCode st
 		req.Header.Set(k, v)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := outbound.Do(ctx, "kimi", c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("kimi: token request failed: %w", err), false
 	}
@@ -382,7 +383,7 @@ func (c *DeviceFlowClient) refreshTokenSingleFlight(ctx context.Context, refresh
 		req.Header.Set(k, v)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := outbound.Do(ctx, "kimi", c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("kimi: refresh request failed: %w", err)
 	}

--- a/internal/auth/xai/xai.go
+++ b/internal/auth/xai/xai.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/singleflight"
 )
@@ -73,7 +74,7 @@ func (a *XAIAuth) Discover(ctx context.Context) (*Discovery, error) {
 		return nil, fmt.Errorf("xai discovery: create request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
-	resp, err := a.httpClient.Do(req)
+	resp, err := outbound.Do(ctx, "xai", a.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("xai discovery: request failed: %w", err)
 	}
@@ -140,7 +141,7 @@ func (a *XAIAuth) RequestDeviceCode(ctx context.Context, deviceAuthorizationEndp
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := a.httpClient.Do(req)
+	resp, err := outbound.Do(ctx, "xai", a.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("xai device code request failed: %w", err)
 	}
@@ -268,7 +269,7 @@ func (a *XAIAuth) exchangeDeviceCode(ctx context.Context, tokenEndpoint, deviceC
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := a.httpClient.Do(req)
+	resp, err := outbound.Do(ctx, "xai", a.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("xai device token request failed: %w", err), interval, false
 	}
@@ -377,7 +378,7 @@ func (a *XAIAuth) postTokenForm(ctx context.Context, tokenEndpoint string, form 
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
-	resp, err := a.httpClient.Do(req)
+	resp, err := outbound.Do(ctx, "xai", a.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("xai token request failed: %w", err)
 	}

--- a/internal/client/codex/live/live_test.go
+++ b/internal/client/codex/live/live_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 )
 
 type apiKeyFirstSelector struct{}
@@ -752,6 +753,11 @@ func TestHandleSidebandPinsAuthAndRelaysBidirectionally(t *testing.T) {
 	defer upstreamServer.Close()
 
 	manager := auth.NewManager(nil, nil, nil)
+	manager.SetOutboundHeaderFinalizer(liveHeaderFinalizerFunc(func(_ context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+		headers := req.Headers.Clone()
+		headers.Set("User-Agent", "sideband-plugin/1.0")
+		return headers, nil
+	}))
 	executor := &captureExecutor{}
 	manager.RegisterExecutor(executor)
 	registerCredential(t, manager, &auth.Auth{
@@ -804,6 +810,9 @@ func TestHandleSidebandPinsAuthAndRelaysBidirectionally(t *testing.T) {
 
 	select {
 	case captured := <-upstreamHeaders:
+		if got := captured.Get("User-Agent"); got != "sideband-plugin/1.0" {
+			t.Fatalf("upstream User-Agent = %q", got)
+		}
 		if got := captured.Get("Authorization"); got != "Bearer pinned-token" {
 			t.Fatalf("upstream Authorization = %q, want pinned OAuth token", got)
 		}

--- a/internal/client/codex/live/outbound_headers_test.go
+++ b/internal/client/codex/live/outbound_headers_test.go
@@ -1,0 +1,37 @@
+package live
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+type liveHeaderFinalizerFunc func(context.Context, pluginapi.OutboundHeaderInterceptRequest) (http.Header, error)
+
+func (f liveHeaderFinalizerFunc) FinalizeOutboundHeaders(ctx context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+	return f(ctx, req)
+}
+
+func TestFinalizeCodexWebsocketHeaders(t *testing.T) {
+	manager := auth.NewManager(nil, nil, nil)
+	manager.SetOutboundHeaderFinalizer(liveHeaderFinalizerFunc(func(_ context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+		if req.Provider != "codex" || req.Transport != pluginapi.OutboundTransportWebSocket {
+			t.Fatalf("finalizer request identity = %#v", req)
+		}
+		headers := req.Headers.Clone()
+		headers.Set("User-Agent", "live-plugin/1.0")
+		return headers, nil
+	}))
+	handler := &Handler{authManager: manager}
+
+	headers, errFinalize := handler.finalizeCodexWebsocketHeaders(context.Background(), http.Header{"User-Agent": {"host/1.0"}})
+	if errFinalize != nil {
+		t.Fatalf("finalizeCodexWebsocketHeaders() error = %v", errFinalize)
+	}
+	if headers.Get("User-Agent") != "live-plugin/1.0" {
+		t.Fatalf("User-Agent = %q", headers.Get("User-Agent"))
+	}
+}

--- a/internal/client/codex/live/sideband.go
+++ b/internal/client/codex/live/sideband.go
@@ -408,6 +408,11 @@ func (h *Handler) HandleSideband(c *gin.Context) {
 		if errPrepare := h.authManager.PrepareHttpRequest(ctx, current, req); errPrepare != nil {
 			return nil, nil, errPrepare
 		}
+		finalHeaders, errFinalize := h.finalizeCodexWebsocketHeaders(ctx, req.Header)
+		if errFinalize != nil {
+			return nil, nil, errFinalize
+		}
+		req.Header = finalHeaders
 		authType, authValue := current.AccountInfo()
 		helps.RecordAPIWebsocketRequest(ctx, runtimeConfig, helps.UpstreamRequestLog{
 			URL:       upstreamURL,

--- a/internal/client/codex/live/websocket.go
+++ b/internal/client/codex/live/websocket.go
@@ -3,6 +3,7 @@ package live
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -14,10 +15,18 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	log "github.com/sirupsen/logrus"
 )
 
 const defaultStandardRealtimeModel = "gpt-realtime"
+
+func (h *Handler) finalizeCodexWebsocketHeaders(ctx context.Context, headers http.Header) (http.Header, error) {
+	if h == nil || h.authManager == nil {
+		return nil, fmt.Errorf("codex live auth manager is unavailable")
+	}
+	return h.authManager.FinalizeProviderHeaders(ctx, "codex", pluginapi.OutboundTransportWebSocket, headers)
+}
 
 // HandleRealtimeWebsocket dispatches a standard Realtime WebSocket or an existing call sideband.
 func (h *Handler) HandleRealtimeWebsocket(c *gin.Context) {
@@ -93,6 +102,11 @@ func (h *Handler) HandleDirectWebsocket(c *gin.Context) {
 		if errPrepare := h.authManager.PrepareHttpRequest(ctx, current, request); errPrepare != nil {
 			return nil, nil, errPrepare
 		}
+		finalHeaders, errFinalize := h.finalizeCodexWebsocketHeaders(ctx, request.Header)
+		if errFinalize != nil {
+			return nil, nil, errFinalize
+		}
+		request.Header = finalHeaders
 		authType, authValue := current.AccountInfo()
 		helpersConfig := h.currentConfig()
 		helps.RecordAPIWebsocketRequest(ctx, helpersConfig, helps.UpstreamRequestLog{

--- a/internal/client/codex/live/websocket_test.go
+++ b/internal/client/codex/live/websocket_test.go
@@ -1,6 +1,7 @@
 package live
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 )
 
 func TestHandleDirectWebsocketRejectsClientSecretModelMismatch(t *testing.T) {
@@ -125,6 +127,11 @@ func TestHandleDirectWebsocketRelaysStandardRealtimeFrames(t *testing.T) {
 	defer upstreamServer.Close()
 
 	manager := auth.NewManager(nil, nil, nil)
+	manager.SetOutboundHeaderFinalizer(liveHeaderFinalizerFunc(func(_ context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+		headers := req.Headers.Clone()
+		headers.Set("User-Agent", "direct-live-plugin/1.0")
+		return headers, nil
+	}))
 	manager.RegisterExecutor(&captureExecutor{})
 	registerCredential(t, manager, &auth.Auth{
 		ID:       "codex-oauth",
@@ -173,6 +180,9 @@ func TestHandleDirectWebsocketRelaysStandardRealtimeFrames(t *testing.T) {
 
 	select {
 	case request := <-upstreamRequest:
+		if request.Header.Get("User-Agent") != "direct-live-plugin/1.0" {
+			t.Fatalf("User-Agent = %q", request.Header.Get("User-Agent"))
+		}
 		if request.Header.Get("Authorization") != "Bearer oauth-token" {
 			t.Fatalf("Authorization = %q", request.Header.Get("Authorization"))
 		}

--- a/internal/cmd/anthropic_login.go
+++ b/internal/cmd/anthropic_login.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -38,7 +37,7 @@ func DoClaudeLogin(cfg *config.Config, options *LoginOptions) {
 		Prompt:       promptFn,
 	}
 
-	_, savedPath, err := manager.Login(context.Background(), "claude", cfg, authOpts)
+	_, savedPath, err := manager.Login(loginContext(options), "claude", cfg, authOpts)
 	if err != nil {
 		if authErr, ok := errors.AsType[*claude.AuthenticationError](err); ok {
 			log.Error(claude.GetUserFriendlyMessage(authErr))

--- a/internal/cmd/antigravity_login.go
+++ b/internal/cmd/antigravity_login.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -28,7 +27,7 @@ func DoAntigravityLogin(cfg *config.Config, options *LoginOptions) {
 		Prompt:       promptFn,
 	}
 
-	record, savedPath, err := manager.Login(context.Background(), "antigravity", cfg, authOpts)
+	record, savedPath, err := manager.Login(loginContext(options), "antigravity", cfg, authOpts)
 	if err != nil {
 		log.Errorf("Antigravity authentication failed: %v", err)
 		return

--- a/internal/cmd/kimi_login.go
+++ b/internal/cmd/kimi_login.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -28,7 +27,7 @@ func DoKimiLogin(cfg *config.Config, options *LoginOptions) {
 		Prompt:    options.Prompt,
 	}
 
-	record, savedPath, err := manager.Login(context.Background(), "kimi", cfg, authOpts)
+	record, savedPath, err := manager.Login(loginContext(options), "kimi", cfg, authOpts)
 	if err != nil {
 		log.Errorf("Kimi authentication failed: %v", err)
 		return

--- a/internal/cmd/openai_device_login.go
+++ b/internal/cmd/openai_device_login.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -40,7 +39,7 @@ func DoCodexDeviceLogin(cfg *config.Config, options *LoginOptions) {
 		Prompt: promptFn,
 	}
 
-	_, savedPath, err := manager.Login(context.Background(), "codex", cfg, authOpts)
+	_, savedPath, err := manager.Login(loginContext(options), "codex", cfg, authOpts)
 	if err != nil {
 		if authErr, ok := errors.AsType[*codex.AuthenticationError](err); ok {
 			log.Error(codex.GetUserFriendlyMessage(authErr))

--- a/internal/cmd/openai_login.go
+++ b/internal/cmd/openai_login.go
@@ -16,6 +16,9 @@ import (
 // It provides configuration for authentication flows including browser behavior
 // and interactive prompting capabilities.
 type LoginOptions struct {
+	// Context carries request-scoped provider integrations into authentication flows.
+	Context context.Context
+
 	// NoBrowser indicates whether to skip opening the browser automatically.
 	NoBrowser bool
 
@@ -24,6 +27,13 @@ type LoginOptions struct {
 
 	// Prompt allows the caller to provide interactive input when needed.
 	Prompt func(prompt string) (string, error)
+}
+
+func loginContext(options *LoginOptions) context.Context {
+	if options != nil && options.Context != nil {
+		return options.Context
+	}
+	return context.Background()
 }
 
 // DoCodexLogin triggers the Codex OAuth flow through the shared authentication manager.
@@ -52,7 +62,7 @@ func DoCodexLogin(cfg *config.Config, options *LoginOptions) {
 		Prompt:       promptFn,
 	}
 
-	_, savedPath, err := manager.Login(context.Background(), "codex", cfg, authOpts)
+	_, savedPath, err := manager.Login(loginContext(options), "codex", cfg, authOpts)
 	if err != nil {
 		if authErr, ok := errors.AsType[*codex.AuthenticationError](err); ok {
 			log.Error(codex.GetUserFriendlyMessage(authErr))

--- a/internal/cmd/xai_login.go
+++ b/internal/cmd/xai_login.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -28,7 +27,7 @@ func DoXAILogin(cfg *config.Config, options *LoginOptions) {
 		Prompt:       promptFn,
 	}
 
-	record, savedPath, err := manager.Login(context.Background(), "xai", cfg, authOpts)
+	record, savedPath, err := manager.Login(loginContext(options), "xai", cfg, authOpts)
 	if err != nil {
 		log.Errorf("xAI authentication failed: %v", err)
 		return

--- a/internal/misc/antigravity_version.go
+++ b/internal/misc/antigravity_version.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
@@ -211,7 +212,7 @@ func fetchAntigravityHubLatestManifestVersion(ctx context.Context, client *http.
 	httpReq.Header.Set("User-Agent", "electron-builder")
 	httpReq.Header.Set("Cache-Control", "no-cache")
 
-	resp, errDo := client.Do(httpReq)
+	resp, errDo := outbound.Do(ctx, "antigravity", client, httpReq)
 	if errDo != nil {
 		return "", fmt.Errorf("fetch antigravity Hub updater manifest: %w", errDo)
 	}

--- a/internal/pluginhost/auth_provider.go
+++ b/internal/pluginhost/auth_provider.go
@@ -280,7 +280,7 @@ func (h *Host) callStartLogin(ctx context.Context, record capabilityRecord, prov
 		Provider:   normalizeProviderID(provider),
 		BaseURL:    strings.TrimSpace(baseURL),
 		Host:       h.hostConfigSummary(),
-		HTTPClient: h.newHTTPClient(nil),
+		HTTPClient: h.newHTTPClient(nil, provider),
 	}
 	resp, errStart := authProvider.StartLogin(ctx, req)
 	if errStart != nil {
@@ -318,7 +318,7 @@ func (h *Host) callPollLogin(ctx context.Context, record capabilityRecord, provi
 		Provider:   normalizeProviderID(provider),
 		State:      strings.TrimSpace(state),
 		Host:       h.hostConfigSummary(),
-		HTTPClient: h.newHTTPClient(nil),
+		HTTPClient: h.newHTTPClient(nil, provider),
 		Metadata:   cloneAnyMap(metadata),
 	}
 	resp, errPoll := authProvider.PollLogin(ctx, req)

--- a/internal/pluginhost/host_callbacks.go
+++ b/internal/pluginhost/host_callbacks.go
@@ -127,6 +127,8 @@ func (h *Host) callFromPlugin(ctx context.Context, method string, request []byte
 		return h.callHostAuthGetRuntime(ctx, request)
 	case pluginabi.MethodHostAuthSave:
 		return h.callHostAuthSave(ctx, request)
+	case pluginabi.MethodHostProviderList:
+		return h.callHostProviderList(ctx, request)
 	default:
 		return nil, fmt.Errorf("unsupported host callback %s", method)
 	}

--- a/internal/pluginhost/http_bridge.go
+++ b/internal/pluginhost/http_bridge.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	log "github.com/sirupsen/logrus"
 )
@@ -122,6 +124,16 @@ func (c *hostHTTPClient) doHTTP(ctx context.Context, req pluginapi.HTTPRequest) 
 		return nil, cfg, fmt.Errorf("create host http request: %w", errNewRequest)
 	}
 	httpReq.Header = cloneHeader(req.Headers)
+	provider := strings.TrimSpace(c.provider)
+	if provider == "" && c.auth != nil {
+		provider = strings.TrimSpace(c.auth.Provider)
+	}
+	ctx = outbound.WithHeaderFinalizer(ctx, c.host)
+	ctx = outbound.WithProvider(ctx, provider)
+	httpReq = httpReq.WithContext(ctx)
+	if errFinalize := outbound.FinalizeRequest(ctx, provider, httpReq); errFinalize != nil {
+		return nil, cfg, fmt.Errorf("finalize host http request: %w", errFinalize)
+	}
 	c.recordHTTPRequest(ctx, cfg, httpReq, req.Body)
 	client := helps.NewProxyAwareHTTPClient(ctx, cfg, c.auth, 0)
 	if client == nil {

--- a/internal/pluginhost/outbound_headers.go
+++ b/internal/pluginhost/outbound_headers.go
@@ -1,0 +1,137 @@
+package pluginhost
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+	"golang.org/x/net/http/httpguts"
+)
+
+var protectedOutboundHeaders = map[string]struct{}{
+	"authorization":       {},
+	"connection":          {},
+	"content-length":      {},
+	"cookie":              {},
+	"host":                {},
+	"keep-alive":          {},
+	"proxy-authenticate":  {},
+	"proxy-authorization": {},
+	"proxy-connection":    {},
+	"set-cookie":          {},
+	"te":                  {},
+	"trailer":             {},
+	"transfer-encoding":   {},
+	"upgrade":             {},
+}
+
+// FinalizeOutboundHeaders applies active outbound-header plugins in configured priority order.
+// Any plugin failure aborts the caller before network I/O.
+func (h *Host) FinalizeOutboundHeaders(ctx context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+	current := cloneHeader(req.Headers)
+	if h == nil {
+		return current, nil
+	}
+	provider := strings.ToLower(strings.TrimSpace(req.Provider))
+	if provider == "" {
+		return current, fmt.Errorf("outbound header provider is required")
+	}
+	transport := pluginapi.OutboundTransport(strings.ToLower(strings.TrimSpace(string(req.Transport))))
+	if transport != pluginapi.OutboundTransportHTTP && transport != pluginapi.OutboundTransportWebSocket {
+		return current, fmt.Errorf("unsupported outbound transport %q", req.Transport)
+	}
+	skipPluginID := hostCallbackPluginIDFromContext(ctx)
+	for _, record := range h.activeRecords() {
+		interceptor := record.plugin.Capabilities.OutboundHeaderInterceptor
+		if interceptor == nil || record.id == skipPluginID {
+			continue
+		}
+		if h.isPluginFused(record.id) {
+			return nil, fmt.Errorf("outbound header interceptor %s is unavailable", record.id)
+		}
+		resp, errIntercept := h.callOutboundHeaderInterceptor(ctx, record, interceptor, pluginapi.OutboundHeaderInterceptRequest{
+			Provider:  provider,
+			Transport: transport,
+			Headers:   mutableOutboundHeaders(current),
+		})
+		if errIntercept != nil {
+			return nil, fmt.Errorf("outbound header interceptor %s failed: %w", record.id, errIntercept)
+		}
+		if errValidate := validateOutboundHeaderResponse(resp); errValidate != nil {
+			return nil, fmt.Errorf("outbound header interceptor %s returned invalid headers: %w", record.id, errValidate)
+		}
+		current = mergeHeaders(current, resp.Headers, resp.ClearHeaders)
+	}
+	return current, nil
+}
+
+func (h *Host) callOutboundHeaderInterceptor(ctx context.Context, record capabilityRecord, interceptor pluginapi.OutboundHeaderInterceptor, req pluginapi.OutboundHeaderInterceptRequest) (resp pluginapi.OutboundHeaderInterceptResponse, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			h.fusePlugin(record.id, "OutboundHeaderInterceptor.InterceptOutboundHeaders", recovered)
+			resp = pluginapi.OutboundHeaderInterceptResponse{}
+			err = fmt.Errorf("plugin panic: %v", recovered)
+		}
+	}()
+	return interceptor.InterceptOutboundHeaders(ctx, req)
+}
+
+func mutableOutboundHeaders(headers http.Header) http.Header {
+	if len(headers) == 0 {
+		return nil
+	}
+	out := make(http.Header)
+	for key, values := range headers {
+		if protectedOutboundHeader(key) {
+			continue
+		}
+		out[key] = append([]string(nil), values...)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func validateOutboundHeaderResponse(resp pluginapi.OutboundHeaderInterceptResponse) error {
+	for key, values := range resp.Headers {
+		if !httpguts.ValidHeaderFieldName(key) {
+			return fmt.Errorf("invalid header name %q", key)
+		}
+		if protectedOutboundHeader(key) {
+			return fmt.Errorf("header %q is protected", key)
+		}
+		for _, value := range values {
+			if !httpguts.ValidHeaderFieldValue(value) {
+				return fmt.Errorf("header %q has an invalid value", key)
+			}
+		}
+	}
+	for _, key := range resp.ClearHeaders {
+		if !httpguts.ValidHeaderFieldName(key) {
+			return fmt.Errorf("invalid clear header name %q", key)
+		}
+		if protectedOutboundHeader(key) {
+			return fmt.Errorf("header %q is protected", key)
+		}
+	}
+	return nil
+}
+
+func protectedOutboundHeader(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if _, ok := protectedOutboundHeaders[lower]; ok {
+		return true
+	}
+	if strings.HasPrefix(lower, "sec-websocket-") {
+		return true
+	}
+	for _, marker := range []string{"api-key", "apikey", "token", "secret", "credential", "signature", "account-id", "account_id"} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pluginhost/outbound_headers_test.go
+++ b/internal/pluginhost/outbound_headers_test.go
@@ -1,0 +1,147 @@
+package pluginhost
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+func TestFinalizeOutboundHeadersChainsAndProtectsHostHeaders(t *testing.T) {
+	calls := make([]string, 0, 2)
+	host := newHostWithRecords(
+		capabilityRecord{
+			id:       "high",
+			priority: 20,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{OutboundHeaderInterceptor: outboundHeaderInterceptorFunc(func(_ context.Context, req pluginapi.OutboundHeaderInterceptRequest) (pluginapi.OutboundHeaderInterceptResponse, error) {
+				calls = append(calls, "high")
+				if req.Provider != "codex" || req.Transport != pluginapi.OutboundTransportHTTP {
+					t.Fatalf("request identity = %#v", req)
+				}
+				if req.Headers.Get("Authorization") != "" || req.Headers.Get("X-Api-Key") != "" || req.Headers.Get("Content-Length") != "" {
+					t.Fatalf("protected headers reached plugin: %#v", req.Headers)
+				}
+				return pluginapi.OutboundHeaderInterceptResponse{Headers: http.Header{"User-Agent": {"high/1.0"}}}, nil
+			})}},
+		},
+		capabilityRecord{
+			id:       "low",
+			priority: 10,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{OutboundHeaderInterceptor: outboundHeaderInterceptorFunc(func(_ context.Context, req pluginapi.OutboundHeaderInterceptRequest) (pluginapi.OutboundHeaderInterceptResponse, error) {
+				calls = append(calls, "low")
+				if req.Headers.Get("User-Agent") != "high/1.0" {
+					t.Fatalf("chained user agent = %q", req.Headers.Get("User-Agent"))
+				}
+				return pluginapi.OutboundHeaderInterceptResponse{
+					Headers:      http.Header{"User-Agent": {"low/1.0"}},
+					ClearHeaders: []string{"X-Remove"},
+				}, nil
+			})}},
+		},
+	)
+	original := http.Header{
+		"Authorization":  {"Bearer secret"},
+		"X-Api-Key":      {"secret"},
+		"Content-Length": {"10"},
+		"User-Agent":     {"original/1.0"},
+		"X-Remove":       {"yes"},
+	}
+	got, errFinalize := host.FinalizeOutboundHeaders(context.Background(), pluginapi.OutboundHeaderInterceptRequest{
+		Provider:  " CODEX ",
+		Transport: pluginapi.OutboundTransportHTTP,
+		Headers:   original,
+	})
+	if errFinalize != nil {
+		t.Fatalf("FinalizeOutboundHeaders() error = %v", errFinalize)
+	}
+	if len(calls) != 2 || calls[0] != "high" || calls[1] != "low" {
+		t.Fatalf("calls = %v", calls)
+	}
+	if got.Get("User-Agent") != "low/1.0" || got.Get("X-Remove") != "" {
+		t.Fatalf("final headers = %#v", got)
+	}
+	if got.Get("Authorization") != "Bearer secret" || got.Get("X-Api-Key") != "secret" || got.Get("Content-Length") != "10" {
+		t.Fatalf("protected headers changed: %#v", got)
+	}
+	if original.Get("User-Agent") != "original/1.0" || original.Get("X-Remove") != "yes" {
+		t.Fatalf("input headers mutated: %#v", original)
+	}
+}
+
+func TestFinalizeOutboundHeadersFailsClosed(t *testing.T) {
+	tests := []struct {
+		name        string
+		interceptor pluginapi.OutboundHeaderInterceptor
+	}{
+		{
+			name: "plugin error",
+			interceptor: outboundHeaderInterceptorFunc(func(context.Context, pluginapi.OutboundHeaderInterceptRequest) (pluginapi.OutboundHeaderInterceptResponse, error) {
+				return pluginapi.OutboundHeaderInterceptResponse{}, errors.New("broken")
+			}),
+		},
+		{
+			name: "protected update",
+			interceptor: outboundHeaderInterceptorFunc(func(context.Context, pluginapi.OutboundHeaderInterceptRequest) (pluginapi.OutboundHeaderInterceptResponse, error) {
+				return pluginapi.OutboundHeaderInterceptResponse{Headers: http.Header{"Authorization": {"changed"}}}, nil
+			}),
+		},
+		{
+			name: "protected clear",
+			interceptor: outboundHeaderInterceptorFunc(func(context.Context, pluginapi.OutboundHeaderInterceptRequest) (pluginapi.OutboundHeaderInterceptResponse, error) {
+				return pluginapi.OutboundHeaderInterceptResponse{ClearHeaders: []string{"Sec-WebSocket-Key"}}, nil
+			}),
+		},
+		{
+			name: "invalid value",
+			interceptor: outboundHeaderInterceptorFunc(func(context.Context, pluginapi.OutboundHeaderInterceptRequest) (pluginapi.OutboundHeaderInterceptResponse, error) {
+				return pluginapi.OutboundHeaderInterceptResponse{Headers: http.Header{"User-Agent": {"bad\r\nvalue"}}}, nil
+			}),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			host := newHostWithRecords(capabilityRecord{id: "headers", plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{OutboundHeaderInterceptor: test.interceptor}}})
+			if _, errFinalize := host.FinalizeOutboundHeaders(context.Background(), pluginapi.OutboundHeaderInterceptRequest{
+				Provider: "claude", Transport: pluginapi.OutboundTransportHTTP,
+			}); errFinalize == nil {
+				t.Fatal("FinalizeOutboundHeaders() error = nil")
+			}
+		})
+	}
+}
+
+func TestFinalizeOutboundHeadersPanicFusesAndFailsClosed(t *testing.T) {
+	host := newHostWithRecords(capabilityRecord{id: "panic", plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{OutboundHeaderInterceptor: outboundHeaderInterceptorFunc(func(context.Context, pluginapi.OutboundHeaderInterceptRequest) (pluginapi.OutboundHeaderInterceptResponse, error) {
+		panic("boom")
+	})}}})
+	req := pluginapi.OutboundHeaderInterceptRequest{Provider: "xai", Transport: pluginapi.OutboundTransportWebSocket}
+	if _, errFinalize := host.FinalizeOutboundHeaders(context.Background(), req); errFinalize == nil {
+		t.Fatal("first FinalizeOutboundHeaders() error = nil")
+	}
+	if !host.isPluginFused("panic") {
+		t.Fatal("plugin was not fused after panic")
+	}
+	if _, errFinalize := host.FinalizeOutboundHeaders(context.Background(), req); errFinalize == nil {
+		t.Fatal("second FinalizeOutboundHeaders() error = nil")
+	}
+}
+
+func TestFinalizeOutboundHeadersSkipsCallingPluginForOwnHostRequest(t *testing.T) {
+	called := false
+	host := newHostWithRecords(capabilityRecord{id: "self", plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{OutboundHeaderInterceptor: outboundHeaderInterceptorFunc(func(context.Context, pluginapi.OutboundHeaderInterceptRequest) (pluginapi.OutboundHeaderInterceptResponse, error) {
+		called = true
+		return pluginapi.OutboundHeaderInterceptResponse{}, nil
+	})}}})
+	ctx := context.WithValue(context.Background(), hostCallbackPluginIDKey{}, "self")
+	got, errFinalize := host.FinalizeOutboundHeaders(ctx, pluginapi.OutboundHeaderInterceptRequest{
+		Provider: "plugin-provider", Transport: pluginapi.OutboundTransportHTTP, Headers: http.Header{"User-Agent": {"original"}},
+	})
+	if errFinalize != nil {
+		t.Fatalf("FinalizeOutboundHeaders() error = %v", errFinalize)
+	}
+	if called || got.Get("User-Agent") != "original" {
+		t.Fatalf("self interception called=%v headers=%#v", called, got)
+	}
+}

--- a/internal/pluginhost/provider_catalog.go
+++ b/internal/pluginhost/provider_catalog.go
@@ -1,0 +1,43 @@
+package pluginhost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+func (h *Host) callHostProviderList(_ context.Context, request []byte) ([]byte, error) {
+	if len(bytesTrimSpace(request)) > 0 {
+		var req map[string]any
+		if errUnmarshal := json.Unmarshal(request, &req); errUnmarshal != nil {
+			return nil, fmt.Errorf("decode host provider list request: %w", errUnmarshal)
+		}
+	}
+	seen := make(map[string]struct{})
+	if manager := h.currentAuthManager(); manager != nil {
+		for _, provider := range manager.ProviderCatalog() {
+			provider = strings.ToLower(strings.TrimSpace(provider))
+			if provider != "" {
+				seen[provider] = struct{}{}
+			}
+		}
+	}
+	h.mu.Lock()
+	for provider := range h.executorProviders {
+		provider = strings.ToLower(strings.TrimSpace(provider))
+		if provider != "" {
+			seen[provider] = struct{}{}
+		}
+	}
+	h.mu.Unlock()
+	providers := make([]pluginapi.HostProviderInfo, 0, len(seen))
+	for provider := range seen {
+		providers = append(providers, pluginapi.HostProviderInfo{ID: provider})
+	}
+	sort.Slice(providers, func(i, j int) bool { return providers[i].ID < providers[j].ID })
+	return marshalRPCResult(pluginapi.HostProviderListResponse{Providers: providers})
+}

--- a/internal/pluginhost/provider_catalog_test.go
+++ b/internal/pluginhost/provider_catalog_test.go
@@ -1,0 +1,37 @@
+package pluginhost
+
+import (
+	"context"
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginabi"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+func TestHostProviderListCallbackReturnsSortedUnion(t *testing.T) {
+	host := New()
+	manager := coreauth.NewManager(nil, nil, nil)
+	host.SetAuthManager(manager)
+	if _, errRegister := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "claude-disabled",
+		Provider: " Claude ",
+		Disabled: true,
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	host.executorProviders["xai"] = struct{}{}
+	host.executorProviders["CLAUDE"] = struct{}{}
+
+	rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostProviderList, nil)
+	if errCall != nil {
+		t.Fatalf("callFromPlugin() error = %v", errCall)
+	}
+	resp, errDecode := decodeRPCEnvelope[pluginapi.HostProviderListResponse](rawResp)
+	if errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if len(resp.Providers) != 2 || resp.Providers[0].ID != "claude" || resp.Providers[1].ID != "xai" {
+		t.Fatalf("providers = %#v, want claude and xai", resp.Providers)
+	}
+}

--- a/internal/pluginhost/rpc_client.go
+++ b/internal/pluginhost/rpc_client.go
@@ -73,6 +73,9 @@ func registerRPCPlugin(ctx context.Context, host *Host, id string, client plugin
 		// Missing schema_version is treated as the original contract.
 		schemaVersion = 1
 	}
+	if resp.Capabilities.OutboundHeaderInterceptor && schemaVersion < pluginabi.SchemaVersionOutboundHeaderInterceptor {
+		return pluginapi.Plugin{}, fmt.Errorf("outbound header interceptor requires plugin schema version %d or newer", pluginabi.SchemaVersionOutboundHeaderInterceptor)
+	}
 	plugin := pluginapi.Plugin{
 		Metadata:      resp.Metadata,
 		SchemaVersion: schemaVersion,
@@ -112,6 +115,9 @@ func registerRPCPlugin(ctx context.Context, host *Host, id string, client plugin
 	}
 	if resp.Capabilities.RequestInterceptor {
 		plugin.Capabilities.RequestInterceptor = adapter
+	}
+	if resp.Capabilities.OutboundHeaderInterceptor {
+		plugin.Capabilities.OutboundHeaderInterceptor = adapter
 	}
 	if resp.Capabilities.RequestLifecyclePlugin {
 		plugin.Capabilities.RequestLifecyclePlugin = adapter
@@ -488,6 +494,15 @@ func (a *rpcPluginAdapter) InterceptRequestAfterAuth(ctx context.Context, req pl
 	return callPlugin[pluginapi.RequestInterceptResponse](ctx, a.client, pluginabi.MethodRequestInterceptAfter, rpcRequestInterceptRequest{
 		RequestInterceptRequest: req,
 		HostCallbackID:          callbackID,
+	})
+}
+
+func (a *rpcPluginAdapter) InterceptOutboundHeaders(ctx context.Context, req pluginapi.OutboundHeaderInterceptRequest) (pluginapi.OutboundHeaderInterceptResponse, error) {
+	callbackID, closeCallback := a.openHostCallbackContext(ctx)
+	defer closeCallback()
+	return callPlugin[pluginapi.OutboundHeaderInterceptResponse](ctx, a.client, pluginabi.MethodOutboundHeadersIntercept, rpcOutboundHeaderInterceptRequest{
+		OutboundHeaderInterceptRequest: req,
+		HostCallbackID:                 callbackID,
 	})
 }
 

--- a/internal/pluginhost/rpc_schema.go
+++ b/internal/pluginhost/rpc_schema.go
@@ -33,6 +33,7 @@ type rpcCapabilities struct {
 	RequestTranslator             bool                         `json:"request_translator"`
 	RequestNormalizer             bool                         `json:"request_normalizer"`
 	RequestInterceptor            bool                         `json:"request_interceptor"`
+	OutboundHeaderInterceptor     bool                         `json:"outbound_header_interceptor"`
 	RequestLifecyclePlugin        bool                         `json:"request_lifecycle_plugin"`
 	ResponseTranslator            bool                         `json:"response_translator"`
 	ResponseBeforeTranslator      bool                         `json:"response_before_translator"`
@@ -90,6 +91,11 @@ type rpcRequestInterceptRequest struct {
 	HostCallbackID string `json:"host_callback_id,omitempty"`
 }
 
+type rpcOutboundHeaderInterceptRequest struct {
+	pluginapi.OutboundHeaderInterceptRequest
+	HostCallbackID string `json:"host_callback_id,omitempty"`
+}
+
 type rpcModelRouteRequest struct {
 	pluginapi.ModelRouteRequest
 	HostCallbackID string `json:"host_callback_id,omitempty"`
@@ -144,6 +150,7 @@ func rpcCapabilitiesFromPlugin(plugin pluginapi.Plugin) rpcCapabilities {
 		RequestTranslator:             caps.RequestTranslator != nil,
 		RequestNormalizer:             caps.RequestNormalizer != nil,
 		RequestInterceptor:            caps.RequestInterceptor != nil,
+		OutboundHeaderInterceptor:     caps.OutboundHeaderInterceptor != nil,
 		RequestLifecyclePlugin:        caps.RequestLifecyclePlugin != nil,
 		ResponseTranslator:            caps.ResponseTranslator != nil,
 		ResponseBeforeTranslator:      caps.ResponseBeforeTranslator != nil,

--- a/internal/pluginhost/rpc_schema_test.go
+++ b/internal/pluginhost/rpc_schema_test.go
@@ -3,6 +3,7 @@ package pluginhost
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -103,6 +104,32 @@ func TestRPCCapabilitiesIncludeModelRouter(t *testing.T) {
 	}
 }
 
+func TestRPCCapabilitiesIncludeOutboundHeaderInterceptor(t *testing.T) {
+	plugin := pluginapi.Plugin{
+		Capabilities: pluginapi.Capabilities{
+			OutboundHeaderInterceptor: outboundHeaderInterceptorFunc(func(context.Context, pluginapi.OutboundHeaderInterceptRequest) (pluginapi.OutboundHeaderInterceptResponse, error) {
+				return pluginapi.OutboundHeaderInterceptResponse{}, nil
+			}),
+		},
+	}
+
+	caps := rpcCapabilitiesFromPlugin(plugin)
+	if !caps.OutboundHeaderInterceptor {
+		t.Fatal("OutboundHeaderInterceptor = false, want true")
+	}
+	raw, errMarshal := json.Marshal(caps)
+	if errMarshal != nil {
+		t.Fatalf("Marshal() error = %v", errMarshal)
+	}
+	var decoded map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &decoded); errUnmarshal != nil {
+		t.Fatalf("Unmarshal() error = %v", errUnmarshal)
+	}
+	if decoded["outbound_header_interceptor"] != true {
+		t.Fatalf("outbound_header_interceptor = %#v, want true", decoded["outbound_header_interceptor"])
+	}
+}
+
 func TestRegisterRPCPluginSendsHostSchemaVersion(t *testing.T) {
 	lookup := newTestSymbolLookup(&testPlugin{
 		registerResult: validTestPlugin("schema"),
@@ -132,6 +159,49 @@ func TestRegisterRPCPluginRejectsFutureSchemaVersion(t *testing.T) {
 	_, errRegister := registerRPCPlugin(context.Background(), nil, "future-schema", lookup, pluginabi.MethodPluginRegister, nil)
 	if errRegister == nil || !strings.Contains(errRegister.Error(), "schema version") {
 		t.Fatalf("registerRPCPlugin() error = %v, want unsupported schema version", errRegister)
+	}
+}
+
+func TestRegisterRPCPluginRejectsOutboundHeaderInterceptorBeforeSchema4(t *testing.T) {
+	plugin := validTestPlugin("headers-schema3")
+	plugin.Capabilities.OutboundHeaderInterceptor = outboundHeaderInterceptorFunc(func(context.Context, pluginapi.OutboundHeaderInterceptRequest) (pluginapi.OutboundHeaderInterceptResponse, error) {
+		return pluginapi.OutboundHeaderInterceptResponse{}, nil
+	})
+	lookup := newTestSymbolLookup(&testPlugin{registerResult: plugin})
+	lookup.schemaVersion = pluginabi.SchemaVersionOutboundHeaderInterceptor - 1
+
+	_, errRegister := registerRPCPlugin(context.Background(), nil, "headers-schema3", lookup, pluginabi.MethodPluginRegister, nil)
+	if errRegister == nil || !strings.Contains(errRegister.Error(), "outbound header interceptor requires") {
+		t.Fatalf("registerRPCPlugin() error = %v, want schema requirement", errRegister)
+	}
+}
+
+func TestRPCOutboundHeaderInterceptorUsesAdapter(t *testing.T) {
+	var gotReq pluginapi.OutboundHeaderInterceptRequest
+	plugin := validTestPlugin("headers")
+	plugin.Capabilities.OutboundHeaderInterceptor = outboundHeaderInterceptorFunc(func(_ context.Context, req pluginapi.OutboundHeaderInterceptRequest) (pluginapi.OutboundHeaderInterceptResponse, error) {
+		gotReq = req
+		return pluginapi.OutboundHeaderInterceptResponse{Headers: http.Header{"User-Agent": {"plugin/1.0"}}}, nil
+	})
+	lookup := newTestSymbolLookup(&testPlugin{registerResult: plugin})
+
+	registered, errRegister := registerRPCPlugin(context.Background(), nil, "headers", lookup, pluginabi.MethodPluginRegister, nil)
+	if errRegister != nil {
+		t.Fatalf("registerRPCPlugin() error = %v", errRegister)
+	}
+	resp, errIntercept := registered.Capabilities.OutboundHeaderInterceptor.InterceptOutboundHeaders(context.Background(), pluginapi.OutboundHeaderInterceptRequest{
+		Provider:  "codex",
+		Transport: pluginapi.OutboundTransportHTTP,
+		Headers:   http.Header{"User-Agent": {"host/1.0"}},
+	})
+	if errIntercept != nil {
+		t.Fatalf("InterceptOutboundHeaders() error = %v", errIntercept)
+	}
+	if gotReq.Provider != "codex" || gotReq.Transport != pluginapi.OutboundTransportHTTP || gotReq.Headers.Get("User-Agent") != "host/1.0" {
+		t.Fatalf("interceptor request = %#v", gotReq)
+	}
+	if resp.Headers.Get("User-Agent") != "plugin/1.0" {
+		t.Fatalf("interceptor response = %#v", resp)
 	}
 }
 

--- a/internal/pluginhost/test_helpers_test.go
+++ b/internal/pluginhost/test_helpers_test.go
@@ -94,6 +94,19 @@ func (l *testSymbolLookup) Call(ctx context.Context, method string, request []by
 			return nil, errIntercept
 		}
 		return marshalRPCResult(resp)
+	case pluginabi.MethodOutboundHeadersIntercept:
+		if l.active.Capabilities.OutboundHeaderInterceptor == nil {
+			return nil, fmt.Errorf("missing outbound header interceptor")
+		}
+		var req rpcOutboundHeaderInterceptRequest
+		if errUnmarshal := json.Unmarshal(request, &req); errUnmarshal != nil {
+			return nil, errUnmarshal
+		}
+		resp, errIntercept := l.active.Capabilities.OutboundHeaderInterceptor.InterceptOutboundHeaders(ctx, req.OutboundHeaderInterceptRequest)
+		if errIntercept != nil {
+			return nil, errIntercept
+		}
+		return marshalRPCResult(resp)
 	case pluginabi.MethodRequestComplete:
 		if l.active.Capabilities.RequestLifecyclePlugin == nil {
 			return nil, fmt.Errorf("missing request lifecycle plugin")
@@ -291,6 +304,15 @@ type requestInterceptorFunc func(context.Context, pluginapi.RequestInterceptRequ
 func (f requestInterceptorFunc) InterceptRequestBeforeAuth(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
 	if f == nil {
 		return pluginapi.RequestInterceptResponse{}, fmt.Errorf("missing request interceptor callback")
+	}
+	return f(ctx, req)
+}
+
+type outboundHeaderInterceptorFunc func(context.Context, pluginapi.OutboundHeaderInterceptRequest) (pluginapi.OutboundHeaderInterceptResponse, error)
+
+func (f outboundHeaderInterceptorFunc) InterceptOutboundHeaders(ctx context.Context, req pluginapi.OutboundHeaderInterceptRequest) (pluginapi.OutboundHeaderInterceptResponse, error) {
+	if f == nil {
+		return pluginapi.OutboundHeaderInterceptResponse{}, fmt.Errorf("missing outbound header interceptor callback")
 	}
 	return f(ctx, req)
 }

--- a/internal/runtime/executor/aistudio_executor.go
+++ b/internal/runtime/executor/aistudio_executor.go
@@ -20,6 +20,8 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/wsrelay"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -47,6 +49,18 @@ func NewAIStudioExecutor(cfg *config.Config, provider string, relay *wsrelay.Man
 
 // Identifier returns the executor identifier.
 func (e *AIStudioExecutor) Identifier() string { return "aistudio" }
+
+func finalizeAIStudioRequest(ctx context.Context, req *wsrelay.HTTPRequest) error {
+	if req == nil {
+		return fmt.Errorf("aistudio executor: outbound request is nil")
+	}
+	headers, errFinalize := outbound.FinalizeHeaders(ctx, "aistudio", pluginapi.OutboundTransportHTTP, req.Headers)
+	if errFinalize != nil {
+		return errFinalize
+	}
+	req.Headers = headers
+	return nil
+}
 
 // PrepareRequest prepares the HTTP request for execution.
 func (e *AIStudioExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth) error {
@@ -99,6 +113,9 @@ func (e *AIStudioExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.A
 		Headers: httpReq.Header.Clone(),
 		Body:    body,
 	}
+	if errFinalize := finalizeAIStudioRequest(ctx, wsReq); errFinalize != nil {
+		return nil, errFinalize
+	}
 	wsResp, errRelay := e.relay.NonStream(ctx, auth.ID, wsReq)
 	if errRelay != nil {
 		return nil, errRelay
@@ -149,6 +166,9 @@ func (e *AIStudioExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth,
 		attrs = auth.Attributes
 	}
 	util.ApplyCustomHeadersFromAttrs(&http.Request{Header: wsReq.Headers}, attrs)
+	if errFinalize := finalizeAIStudioRequest(ctx, wsReq); errFinalize != nil {
+		return resp, errFinalize
+	}
 
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
@@ -221,6 +241,9 @@ func (e *AIStudioExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth
 		attrs = auth.Attributes
 	}
 	util.ApplyCustomHeadersFromAttrs(&http.Request{Header: wsReq.Headers}, attrs)
+	if errFinalize := finalizeAIStudioRequest(ctx, wsReq); errFinalize != nil {
+		return nil, errFinalize
+	}
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -400,6 +423,9 @@ func (e *AIStudioExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.A
 		URL:     endpoint,
 		Headers: http.Header{"Content-Type": []string{"application/json"}},
 		Body:    body.payload,
+	}
+	if errFinalize := finalizeAIStudioRequest(ctx, wsReq); errFinalize != nil {
+		return cliproxyexecutor.Response{}, errFinalize
 	}
 	var authID, authLabel, authType, authValue string
 	if auth != nil {

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -735,5 +735,5 @@ func (e *AntigravityExecutor) HttpRequest(ctx context.Context, auth *cliproxyaut
 	}
 
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
-	return httpClient.Do(httpReq)
+	return helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 }

--- a/internal/runtime/executor/antigravity_executor_auth.go
+++ b/internal/runtime/executor/antigravity_executor_auth.go
@@ -162,7 +162,7 @@ func (e *AntigravityExecutor) refreshTokenSingleFlight(ctx context.Context, auth
 	httpReq.Header.Set("User-Agent", "Go-http-client/2.0")
 
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
-	httpResp, errDo := httpClient.Do(httpReq)
+	httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if errDo != nil {
 		return nil, errDo
 	}

--- a/internal/runtime/executor/antigravity_executor_credits.go
+++ b/internal/runtime/executor/antigravity_executor_credits.go
@@ -462,7 +462,7 @@ func (e *AntigravityExecutor) updateAntigravityCreditsBalance(ctx context.Contex
 	httpReq.Header.Set("User-Agent", userAgent)
 
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
-	httpResp, errDo := httpClient.Do(httpReq)
+	httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if errDo != nil {
 		log.Debugf("antigravity executor: loadCodeAssist request error: %v", errDo)
 		return

--- a/internal/runtime/executor/antigravity_executor_execute.go
+++ b/internal/runtime/executor/antigravity_executor_execute.go
@@ -117,7 +117,7 @@ attemptLoop:
 				return resp, err
 			}
 
-			httpResp, errDo := httpClient.Do(httpReq)
+			httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 			if errDo != nil {
 				helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 				if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
@@ -343,7 +343,7 @@ attemptLoop:
 				return resp, err
 			}
 
-			httpResp, errDo := httpClient.Do(httpReq)
+			httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 			if errDo != nil {
 				helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 				if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {

--- a/internal/runtime/executor/antigravity_executor_stream.go
+++ b/internal/runtime/executor/antigravity_executor_stream.go
@@ -112,7 +112,7 @@ attemptLoop:
 				err = errReq
 				return nil, err
 			}
-			httpResp, errDo := httpClient.Do(httpReq)
+			httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 			if errDo != nil {
 				helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 				if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {

--- a/internal/runtime/executor/antigravity_executor_tokens.go
+++ b/internal/runtime/executor/antigravity_executor_tokens.go
@@ -124,7 +124,7 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 			AuthValue: authValue,
 		})
 
-		httpResp, errDo := httpClient.Do(httpReq)
+		httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 		if errDo != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 			if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -245,5 +245,5 @@ func (e *ClaudeExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Aut
 		return nil, err
 	}
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
-	return httpClient.Do(httpReq)
+	return helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 }

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -857,7 +857,7 @@ func applyClaudeHeadersWithNativeProfile(
 // exactly how the streaming and non-streaming beta sets diverged before.
 func doClaudeUpstreamRequest(client *http.Client, req *http.Request) (*http.Response, error) {
 	applyClaudeWireHeaderCasing(req)
-	return client.Do(req)
+	return helps.DoProviderRequest(req.Context(), "", client, req)
 }
 
 // claudeWireHeaderCasing maps Go's canonical header name to the exact casing

--- a/internal/runtime/executor/codex_executor_execute.go
+++ b/internal/runtime/executor/codex_executor_execute.go
@@ -101,7 +101,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	})
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
@@ -261,7 +261,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	})
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -79,7 +79,7 @@ func (e *CodexExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth
 		return nil, err
 	}
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
-	return httpClient.Do(httpReq)
+	return helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 }
 
 type codexIdentityConfuseState struct {

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -106,7 +106,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return nil, err

--- a/internal/runtime/executor/codex_openai_images.go
+++ b/internal/runtime/executor/codex_openai_images.go
@@ -119,7 +119,7 @@ func (e *CodexExecutor) executeOpenAIImage(ctx context.Context, auth *cliproxyau
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, errDo := httpClient.Do(httpReq)
+	httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if errDo != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 		return resp, errDo
@@ -216,7 +216,7 @@ func (e *CodexExecutor) executeOpenAIImageStream(ctx context.Context, auth *clip
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, errDo := httpClient.Do(httpReq)
+	httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if errDo != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 		return nil, errDo
@@ -346,7 +346,7 @@ func (e *CodexExecutor) executeDirectOpenAIImage(ctx context.Context, auth *clip
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, errDo := httpClient.Do(httpReq)
+	httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if errDo != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 		return resp, errDo
@@ -407,7 +407,7 @@ func (e *CodexExecutor) executeDirectOpenAIImageStream(ctx context.Context, auth
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, errDo := httpClient.Do(httpReq)
+	httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if errDo != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 		return nil, errDo

--- a/internal/runtime/executor/codex_websockets_connection.go
+++ b/internal/runtime/executor/codex_websockets_connection.go
@@ -15,6 +15,8 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/sjson"
@@ -34,7 +36,11 @@ func (e *CodexWebsocketsExecutor) dialCodexWebsocket(ctx context.Context, auth *
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	conn, resp, err := dialer.DialContext(ctx, wsURL, headers)
+	finalHeaders, errFinalize := outbound.FinalizeHeaders(ctx, "codex", pluginapi.OutboundTransportWebSocket, headers)
+	if errFinalize != nil {
+		return nil, nil, nil, errFinalize
+	}
+	conn, resp, err := dialer.DialContext(ctx, wsURL, finalHeaders)
 	closer := newWebsocketConnectionCloser(conn)
 	if conn != nil {
 		// Avoid gorilla/websocket flate tail validation issues on some upstreams/Go versions.

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -106,7 +106,7 @@ func (e *GeminiExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Aut
 		return nil, err
 	}
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	return httpClient.Do(httpReq)
+	return helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 }
 
 // Execute performs a non-streaming request to the Gemini API.
@@ -204,7 +204,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
@@ -316,7 +316,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return nil, err
@@ -433,7 +433,7 @@ func (e *GeminiExecutor) executeInteractions(ctx context.Context, auth *cliproxy
 	})
 
 	httpClient := reporter.TrackHTTPClient(helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0))
-	httpResp, errDo := httpClient.Do(httpReq)
+	httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if errDo != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 		return resp, errDo
@@ -513,7 +513,7 @@ func (e *GeminiExecutor) executeInteractionsStream(ctx context.Context, auth *cl
 	})
 
 	httpClient := reporter.TrackHTTPClient(helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0))
-	httpResp, errDo := httpClient.Do(httpReq)
+	httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if errDo != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 		return nil, errDo
@@ -674,7 +674,7 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	})
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	resp, err := httpClient.Do(httpReq)
+	resp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return cliproxyexecutor.Response{}, err

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -230,7 +231,7 @@ func (e *GeminiVertexExecutor) HttpRequest(ctx context.Context, auth *cliproxyau
 		return nil, err
 	}
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	return httpClient.Do(httpReq)
+	return helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 }
 
 // Execute performs a non-streaming request to the Vertex AI API.
@@ -396,7 +397,7 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, errDo := httpClient.Do(httpReq)
+	httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if errDo != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 		return resp, errDo
@@ -524,7 +525,7 @@ func (e *GeminiVertexExecutor) executeWithAPIKey(ctx context.Context, auth *clip
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, errDo := httpClient.Do(httpReq)
+	httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if errDo != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 		return resp, errDo
@@ -641,7 +642,7 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, errDo := httpClient.Do(httpReq)
+	httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if errDo != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 		return nil, errDo
@@ -788,7 +789,7 @@ func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, errDo := httpClient.Do(httpReq)
+	httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if errDo != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 		return nil, errDo
@@ -915,7 +916,7 @@ func (e *GeminiVertexExecutor) countTokensWithServiceAccount(ctx context.Context
 	})
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	httpResp, errDo := httpClient.Do(httpReq)
+	httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if errDo != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 		return cliproxyexecutor.Response{}, errDo
@@ -1006,7 +1007,7 @@ func (e *GeminiVertexExecutor) countTokensWithAPIKey(ctx context.Context, auth *
 	})
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	httpResp, errDo := httpClient.Do(httpReq)
+	httpResp, errDo := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if errDo != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 		return cliproxyexecutor.Response{}, errDo
@@ -1103,6 +1104,7 @@ func vertexBaseURL(location string) string {
 
 func vertexAccessToken(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, saJSON []byte) (string, error) {
 	if httpClient := helps.NewProxyAwareHTTPClient(ctx, cfg, auth, 0); httpClient != nil {
+		httpClient = outbound.WrapHTTPClient(ctx, "vertex", httpClient)
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
 	}
 	// Use cloud-platform scope for Vertex AI.

--- a/internal/runtime/executor/helps/antigravity_grounding_urls_test.go
+++ b/internal/runtime/executor/helps/antigravity_grounding_urls_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	"github.com/tidwall/gjson"
 )
 
@@ -16,6 +18,12 @@ func (f groundingURLRoundTripper) RoundTrip(req *http.Request) (*http.Response, 
 	return f(req)
 }
 
+type groundingHeaderFinalizerFunc func(context.Context, pluginapi.OutboundHeaderInterceptRequest) (http.Header, error)
+
+func (f groundingHeaderFinalizerFunc) FinalizeOutboundHeaders(ctx context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+	return f(ctx, req)
+}
+
 func TestResolveAntigravityGroundingURLsResolvesVertexRedirects(t *testing.T) {
 	t.Parallel()
 
@@ -23,6 +31,7 @@ func TestResolveAntigravityGroundingURLsResolvesVertexRedirects(t *testing.T) {
 	const resolvedURL = "https://example.com/weather"
 
 	var sawRedirectRequest bool
+	var finalizerCalled bool
 	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", groundingURLRoundTripper(func(req *http.Request) (*http.Response, error) {
 		if req.Method != http.MethodHead {
 			t.Fatalf("method = %s, want HEAD", req.Method)
@@ -38,6 +47,10 @@ func TestResolveAntigravityGroundingURLsResolvesVertexRedirects(t *testing.T) {
 			},
 			Body: io.NopCloser(strings.NewReader("")),
 		}, nil
+	}))
+	ctx = outbound.WithHeaderFinalizer(ctx, groundingHeaderFinalizerFunc(func(_ context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+		finalizerCalled = true
+		return req.Headers, nil
 	}))
 
 	input := []byte(`{
@@ -56,6 +69,9 @@ func TestResolveAntigravityGroundingURLsResolvesVertexRedirects(t *testing.T) {
 	output := ResolveAntigravityGroundingURLs(ctx, nil, nil, input)
 	if !sawRedirectRequest {
 		t.Fatal("expected resolver to request the vertex redirect")
+	}
+	if finalizerCalled {
+		t.Fatal("provider-returned grounding URL unexpectedly used outbound header interception")
 	}
 	if got := gjson.GetBytes(output, "response.candidates.0.groundingMetadata.groundingChunks.0.web.uri").String(); got != resolvedURL {
 		t.Fatalf("resolved uri = %q, want %q; output=%s", got, resolvedURL, output)

--- a/internal/runtime/executor/helps/outbound_helpers.go
+++ b/internal/runtime/executor/helps/outbound_helpers.go
@@ -1,0 +1,14 @@
+package helps
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
+)
+
+// DoProviderRequest applies final provider headers and sends req through client.
+// The canonical provider normally comes from the auth manager's execution context.
+func DoProviderRequest(ctx context.Context, provider string, client *http.Client, req *http.Request) (*http.Response, error) {
+	return outbound.Do(ctx, provider, client, req)
+}

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -88,7 +88,7 @@ func (e *KimiExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth,
 		return nil, err
 	}
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	return httpClient.Do(httpReq)
+	return helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 }
 
 // Execute performs a non-streaming chat completion request to Kimi.
@@ -177,7 +177,7 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
@@ -301,7 +301,7 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return nil, err

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -82,7 +82,7 @@ func (e *OpenAICompatExecutor) HttpRequest(ctx context.Context, auth *cliproxyau
 		return nil, err
 	}
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	return httpClient.Do(httpReq)
+	return helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 }
 
 func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
@@ -178,7 +178,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
@@ -272,7 +272,7 @@ func (e *OpenAICompatExecutor) executeImages(ctx context.Context, auth *cliproxy
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
@@ -392,7 +392,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return nil, err
@@ -629,7 +629,7 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return nil, err

--- a/internal/runtime/executor/outbound_headers_test.go
+++ b/internal/runtime/executor/outbound_headers_test.go
@@ -1,0 +1,82 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/wsrelay"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+type executorHeaderFinalizerFunc func(context.Context, pluginapi.OutboundHeaderInterceptRequest) (http.Header, error)
+
+func (f executorHeaderFinalizerFunc) FinalizeOutboundHeaders(ctx context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+	return f(ctx, req)
+}
+
+func TestFinalizeAIStudioRequestAppliesOutboundHeaders(t *testing.T) {
+	ctx := outbound.WithHeaderFinalizer(context.Background(), executorHeaderFinalizerFunc(func(_ context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+		if req.Provider != "aistudio" || req.Transport != pluginapi.OutboundTransportHTTP {
+			t.Fatalf("finalizer request identity = %#v", req)
+		}
+		headers := req.Headers.Clone()
+		headers.Set("User-Agent", "aistudio-plugin/1.0")
+		return headers, nil
+	}))
+	req := &wsrelay.HTTPRequest{Headers: http.Header{"User-Agent": {"host/1.0"}}}
+
+	if errFinalize := finalizeAIStudioRequest(ctx, req); errFinalize != nil {
+		t.Fatalf("finalizeAIStudioRequest() error = %v", errFinalize)
+	}
+	if req.Headers.Get("User-Agent") != "aistudio-plugin/1.0" {
+		t.Fatalf("User-Agent = %q", req.Headers.Get("User-Agent"))
+	}
+}
+
+func TestWebsocketDialFailsClosedWhenOutboundHeaderFinalizerRejects(t *testing.T) {
+	errRejected := errors.New("header plugin rejected websocket")
+	tests := []struct {
+		name     string
+		provider string
+		dial     func(context.Context) error
+	}{
+		{
+			name:     "codex",
+			provider: "codex",
+			dial: func(ctx context.Context) error {
+				_, _, _, errDial := NewCodexWebsocketsExecutor(&config.Config{}).dialCodexWebsocket(ctx, nil, "ws://127.0.0.1:1", http.Header{"User-Agent": {"host/1.0"}})
+				return errDial
+			},
+		},
+		{
+			name:     "xai",
+			provider: "xai",
+			dial: func(ctx context.Context) error {
+				_, _, _, errDial := NewXAIWebsocketsExecutor(&config.Config{}).dialXAIWebsocket(ctx, nil, "ws://127.0.0.1:1", http.Header{"User-Agent": {"host/1.0"}})
+				return errDial
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var calls int
+			ctx := outbound.WithHeaderFinalizer(context.Background(), executorHeaderFinalizerFunc(func(_ context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+				calls++
+				if req.Provider != test.provider || req.Transport != pluginapi.OutboundTransportWebSocket {
+					t.Fatalf("finalizer request identity = %#v", req)
+				}
+				return nil, errRejected
+			}))
+			if errDial := test.dial(ctx); !errors.Is(errDial, errRejected) {
+				t.Fatalf("dial error = %v, want %v", errDial, errRejected)
+			}
+			if calls != 1 {
+				t.Fatalf("finalizer calls = %d, want 1", calls)
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -105,5 +105,5 @@ func (e *XAIExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, 
 		return nil, errPrepare
 	}
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	return httpClient.Do(httpReq)
+	return helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 }

--- a/internal/runtime/executor/xai_executor_execute.go
+++ b/internal/runtime/executor/xai_executor_execute.go
@@ -52,7 +52,7 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
@@ -164,7 +164,7 @@ func (e *XAIExecutor) executeCompactRequest(ctx context.Context, auth *cliproxya
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return nil, nil, nil, err

--- a/internal/runtime/executor/xai_executor_media.go
+++ b/internal/runtime/executor/xai_executor_media.go
@@ -44,7 +44,7 @@ func (e *XAIExecutor) executeImages(ctx context.Context, auth *cliproxyauth.Auth
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
@@ -121,7 +121,7 @@ func (e *XAIExecutor) executeVideos(ctx context.Context, auth *cliproxyauth.Auth
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err

--- a/internal/runtime/executor/xai_executor_stream.go
+++ b/internal/runtime/executor/xai_executor_stream.go
@@ -46,7 +46,7 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := helps.DoProviderRequest(ctx, "", httpClient, httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return nil, err

--- a/internal/runtime/executor/xai_websockets_executor.go
+++ b/internal/runtime/executor/xai_websockets_executor.go
@@ -21,6 +21,8 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -1047,7 +1049,11 @@ func (e *XAIWebsocketsExecutor) dialXAIWebsocket(ctx context.Context, auth *clip
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	conn, resp, err := dialer.DialContext(ctx, wsURL, headers)
+	finalHeaders, errFinalize := outbound.FinalizeHeaders(ctx, "xai", pluginapi.OutboundTransportWebSocket, headers)
+	if errFinalize != nil {
+		return nil, nil, nil, errFinalize
+	}
+	conn, resp, err := dialer.DialContext(ctx, wsURL, finalHeaders)
 	closer := newWebsocketConnectionCloser(conn)
 	if conn != nil {
 		// Avoid gorilla/websocket flate tail validation issues on some upstreams/Go versions.

--- a/sdk/auth/codex_device.go
+++ b/sdk/auth/codex_device.go
@@ -18,6 +18,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -138,7 +139,7 @@ func requestCodexDeviceUserCode(ctx context.Context, client *http.Client) (*code
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := client.Do(req)
+	resp, err := outbound.Do(ctx, "codex", client, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to request codex device code: %w", err)
 	}
@@ -191,7 +192,7 @@ func pollCodexDeviceToken(ctx context.Context, client *http.Client, deviceAuthID
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json")
 
-		resp, err := client.Do(req)
+		resp, err := outbound.Do(ctx, "codex", client, req)
 		if err != nil {
 			return nil, fmt.Errorf("failed to poll codex device token: %w", err)
 		}

--- a/sdk/auth/codex_device_test.go
+++ b/sdk/auth/codex_device_test.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+type codexDeviceRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f codexDeviceRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type codexDeviceHeaderFinalizerFunc func(context.Context, pluginapi.OutboundHeaderInterceptRequest) (http.Header, error)
+
+func (f codexDeviceHeaderFinalizerFunc) FinalizeOutboundHeaders(ctx context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+	return f(ctx, req)
+}
+
+func TestRequestCodexDeviceUserCodeFinalizesHeaders(t *testing.T) {
+	ctx := outbound.WithHeaderFinalizer(context.Background(), codexDeviceHeaderFinalizerFunc(func(_ context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+		if req.Provider != "codex" || req.Transport != pluginapi.OutboundTransportHTTP {
+			t.Fatalf("finalizer request identity = %#v", req)
+		}
+		headers := req.Headers.Clone()
+		headers.Set("User-Agent", "device-plugin/1.0")
+		return headers, nil
+	}))
+	client := &http.Client{Transport: codexDeviceRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Header.Get("User-Agent") != "device-plugin/1.0" {
+			t.Fatalf("User-Agent = %q", req.Header.Get("User-Agent"))
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"device_auth_id":"device","user_code":"code","interval":1}`)),
+			Request:    req,
+		}, nil
+	})}
+
+	resp, errRequest := requestCodexDeviceUserCode(ctx, client)
+	if errRequest != nil {
+		t.Fatalf("requestCodexDeviceUserCode() error = %v", errRequest)
+	}
+	if resp.DeviceAuthID != "device" || resp.UserCode != "code" {
+		t.Fatalf("response = %#v", resp)
+	}
+}

--- a/sdk/cliproxy/antigravity_models.go
+++ b/sdk/cliproxy/antigravity_models.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
 	log "github.com/sirupsen/logrus"
 )
@@ -36,6 +37,10 @@ func (s *Service) fetchAntigravityModelCapabilityHintsForAuth(ctx context.Contex
 	if accessToken == "" {
 		return antigravityModelCapabilityHints{}
 	}
+	if s != nil {
+		ctx = outbound.WithHeaderFinalizer(ctx, s.pluginHost)
+	}
+	ctx = outbound.WithProvider(ctx, "antigravity")
 
 	client := &http.Client{}
 	if transport, _, errProxy := proxyutil.BuildHTTPTransport(s.antigravityModelFetchProxyURL(auth)); errProxy == nil && transport != nil {
@@ -52,7 +57,7 @@ func (s *Service) fetchAntigravityModelCapabilityHintsForAuth(ctx context.Contex
 		req.Header.Set("Authorization", "Bearer "+accessToken)
 		req.Header.Set("User-Agent", misc.AntigravityUserAgent())
 
-		resp, errDo := client.Do(req)
+		resp, errDo := outbound.Do(ctx, "antigravity", client, req)
 		if errDo != nil {
 			continue
 		}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -9,6 +9,7 @@ import (
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 )
 
@@ -152,6 +153,8 @@ type Manager struct {
 
 	// Optional HTTP RoundTripper provider injected by host.
 	rtProvider RoundTripperProvider
+	// outboundHeaderFinalizer applies provider-tagged plugin headers at send boundaries.
+	outboundHeaderFinalizer outbound.HeaderFinalizer
 
 	// Auto refresh state
 	refreshCancel context.CancelFunc

--- a/sdk/cliproxy/auth/conductor_availability_test.go
+++ b/sdk/cliproxy/auth/conductor_availability_test.go
@@ -105,6 +105,23 @@ func TestManager_AvailableProvidersAndHasProviderAuth_ExcludeDisabled(t *testing
 	}
 }
 
+func TestManagerProviderCatalogIncludesExecutorsAndDisabledAuths(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.executors[" CODEX "] = nil
+	if _, errRegister := manager.Register(context.Background(), &Auth{
+		ID:       "disabled-claude",
+		Provider: " Claude ",
+		Disabled: true,
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	providers := manager.ProviderCatalog()
+	if len(providers) != 2 || providers[0] != "claude" || providers[1] != "codex" {
+		t.Fatalf("ProviderCatalog() = %v, want [claude codex]", providers)
+	}
+}
+
 func TestManager_ResetQuotaClearsRuntimeAndRegistryState(t *testing.T) {
 	manager := NewManager(nil, nil, nil)
 	ctx := context.Background()

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -317,6 +317,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
+		execCtx = m.outboundContext(execCtx, provider)
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 
 		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel)
@@ -473,6 +474,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
+		execCtx = m.outboundContext(execCtx, provider)
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 
 		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel)
@@ -1375,5 +1377,6 @@ func (m *Manager) HttpRequest(ctx context.Context, auth *Auth, req *http.Request
 	if exec == nil {
 		return nil, &Error{Code: "provider_not_found", Message: "executor not registered for provider: " + providerKey}
 	}
+	ctx = m.outboundContext(ctx, providerKey)
 	return exec.HttpRequest(ctx, auth, req)
 }

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1094,6 +1094,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			return cliproxyexecutor.Response{}, false, nil
 		}
 		creditsCtx := WithAntigravityCredits(ctx)
+		creditsCtx = m.outboundContext(creditsCtx, c.provider)
 		if rt := m.roundTripperFor(c.auth); rt != nil {
 			creditsCtx = context.WithValue(creditsCtx, roundTripperContextKey{}, rt)
 			creditsCtx = context.WithValue(creditsCtx, "cliproxy.roundtripper", rt)
@@ -1156,6 +1157,7 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 			return nil, false, nil
 		}
 		creditsCtx := WithAntigravityCredits(ctx)
+		creditsCtx = m.outboundContext(creditsCtx, c.provider)
 		if rt := m.roundTripperFor(c.auth); rt != nil {
 			creditsCtx = context.WithValue(creditsCtx, roundTripperContextKey{}, rt)
 			creditsCtx = context.WithValue(creditsCtx, "cliproxy.roundtripper", rt)

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -52,6 +52,7 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			selection.End("attempt_bind_failed")
 			return cliproxyexecutor.Response{}, errBind
 		}
+		execCtx = m.outboundContext(execCtx, selection.Provider)
 		// Enrich before auth preparation so prepare-stage usage records observe the client request.
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 		if rt := m.roundTripperFor(auth); rt != nil {

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -393,6 +393,7 @@ func (m *Manager) tryRefreshExecutionAuthAfterUnauthorized(ctx context.Context, 
 
 	log.Debugf("unauthorized Home response for %s (%s), refreshing credentials before redispatch", auth.Provider, auth.ID)
 	target := auth.Clone()
+	ctx = m.outboundContext(ctx, executor.Identifier())
 	updated, errRefresh := executor.Refresh(ctx, target)
 	if errRefresh != nil {
 		log.Debugf("Home credential refresh before redispatch failed for %s (%s)", auth.Provider, auth.ID)
@@ -529,6 +530,7 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 	}
 
 	cloned := auth.Clone()
+	ctx = m.outboundContext(ctx, executorKeyFromAuth(auth))
 	updated, err := exec.Refresh(ctx, cloned)
 	if err != nil && errors.Is(err, context.Canceled) {
 		log.Debugf("refresh canceled for %s, %s", auth.Provider, auth.ID)

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -13,6 +13,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/outbound"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 )
 
@@ -313,6 +314,36 @@ func (m *Manager) SetRoundTripperProvider(p RoundTripperProvider) {
 	m.mu.Lock()
 	m.rtProvider = p
 	m.mu.Unlock()
+}
+
+// SetOutboundHeaderFinalizer installs the host used by provider network send boundaries.
+func (m *Manager) SetOutboundHeaderFinalizer(finalizer outbound.HeaderFinalizer) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.outboundHeaderFinalizer = finalizer
+	m.mu.Unlock()
+}
+
+func (m *Manager) outboundContext(ctx context.Context, provider string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if m == nil {
+		return outbound.WithProvider(ctx, provider)
+	}
+	m.mu.RLock()
+	finalizer := m.outboundHeaderFinalizer
+	m.mu.RUnlock()
+	ctx = outbound.WithHeaderFinalizer(ctx, finalizer)
+	return outbound.WithProvider(ctx, provider)
+}
+
+// FinalizeProviderHeaders applies the configured outbound hook to a provider send boundary.
+func (m *Manager) FinalizeProviderHeaders(ctx context.Context, provider string, transport pluginapi.OutboundTransport, headers http.Header) (http.Header, error) {
+	ctx = m.outboundContext(ctx, provider)
+	return outbound.FinalizeHeaders(ctx, provider, transport, headers)
 }
 
 func (m *Manager) availableAuthsForRouteModel(auths []*Auth, provider, routeModel string, now time.Time) ([]*Auth, error) {
@@ -671,6 +702,39 @@ func (m *Manager) AvailableProviders() []string {
 			continue
 		}
 		seen[provider] = struct{}{}
+		out = append(out, provider)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ProviderCatalog returns canonical provider keys known to the auth manager through
+// registered executors or auth records. Unlike AvailableProviders, it includes providers
+// that do not currently have an enabled credential so management clients can preconfigure them.
+func (m *Manager) ProviderCatalog() []string {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	seen := make(map[string]struct{}, len(m.executors)+len(m.auths))
+	for provider := range m.executors {
+		provider = strings.ToLower(strings.TrimSpace(provider))
+		if provider != "" {
+			seen[provider] = struct{}{}
+		}
+	}
+	for _, auth := range m.auths {
+		if auth == nil {
+			continue
+		}
+		provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+		if provider != "" {
+			seen[provider] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for provider := range seen {
 		out = append(out, provider)
 	}
 	sort.Strings(out)

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -205,6 +205,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 	if executor == nil {
 		return nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
+	ctx = m.outboundContext(ctx, provider)
 	ctx = contextWithRequestedModelAlias(ctx, opts, routeModel)
 	var lastErr error
 	didRefreshOnUnauthorized := false

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -262,6 +262,7 @@ func (b *Builder) Build() (*Service, error) {
 	coreManager.SetOAuthModelAlias(b.cfg.OAuthModelAlias)
 	if pluginHost != nil {
 		coreManager.SetPluginScheduler(pluginHost)
+		coreManager.SetOutboundHeaderFinalizer(pluginHost)
 	}
 
 	service := &Service{

--- a/sdk/cliproxy/outbound/boundary_audit_test.go
+++ b/sdk/cliproxy/outbound/boundary_audit_test.go
@@ -1,0 +1,86 @@
+package outbound
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestProviderCodeHasNoUnaccountedDirectHTTPClientDo(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller() failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "../../.."))
+	allowed := map[string]bool{
+		"internal/api/handlers/management/config_basic.go":              true,
+		"internal/runtime/executor/helps/antigravity_grounding_urls.go": true,
+		"sdk/cliproxy/outbound/outbound.go":                             true,
+	}
+	roots := []string{
+		"internal/api/handlers/management",
+		"internal/auth",
+		"internal/client/codex/live",
+		"internal/misc",
+		"internal/runtime/executor",
+		"sdk/auth",
+		"sdk/cliproxy",
+	}
+	fset := token.NewFileSet()
+	for _, root := range roots {
+		errWalk := filepath.WalkDir(filepath.Join(repoRoot, root), func(path string, entry fs.DirEntry, errWalk error) error {
+			if errWalk != nil {
+				return errWalk
+			}
+			if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			rel, errRel := filepath.Rel(repoRoot, path)
+			if errRel != nil {
+				return errRel
+			}
+			rel = filepath.ToSlash(rel)
+			file, errParse := parser.ParseFile(fset, path, nil, 0)
+			if errParse != nil {
+				return errParse
+			}
+			ast.Inspect(file, func(node ast.Node) bool {
+				call, okCall := node.(*ast.CallExpr)
+				if !okCall {
+					return true
+				}
+				selector, okSelector := call.Fun.(*ast.SelectorExpr)
+				if !okSelector || selector.Sel.Name != "Do" {
+					return true
+				}
+				receiver := directHTTPClientReceiverName(selector.X)
+				if !strings.Contains(strings.ToLower(receiver), "client") || allowed[rel] {
+					return true
+				}
+				position := fset.Position(call.Pos())
+				t.Errorf("direct HTTP client.Do bypasses outbound finalization at %s:%d", rel, position.Line)
+				return true
+			})
+			return nil
+		})
+		if errWalk != nil {
+			t.Fatalf("audit %s: %v", root, errWalk)
+		}
+	}
+}
+
+func directHTTPClientReceiverName(expr ast.Expr) string {
+	switch receiver := expr.(type) {
+	case *ast.Ident:
+		return receiver.Name
+	case *ast.SelectorExpr:
+		return receiver.Sel.Name
+	default:
+		return ""
+	}
+}

--- a/sdk/cliproxy/outbound/outbound.go
+++ b/sdk/cliproxy/outbound/outbound.go
@@ -1,0 +1,162 @@
+// Package outbound carries provider identity and final outbound-header hooks to network send boundaries.
+package outbound
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+// HeaderFinalizer applies active host plugins to a provider request immediately before network I/O.
+type HeaderFinalizer interface {
+	FinalizeOutboundHeaders(context.Context, pluginapi.OutboundHeaderInterceptRequest) (http.Header, error)
+}
+
+type finalizerContextKey struct{}
+type providerContextKey struct{}
+
+type finalizingRoundTripper struct {
+	ctx       context.Context
+	provider  string
+	transport http.RoundTripper
+}
+
+// WithHeaderFinalizer attaches a final outbound-header host to ctx.
+func WithHeaderFinalizer(ctx context.Context, finalizer HeaderFinalizer) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if finalizer == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, finalizerContextKey{}, finalizer)
+}
+
+// WithProvider attaches the canonical provider identity used by nested send helpers.
+func WithProvider(ctx context.Context, provider string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	provider = normalizeProvider(provider)
+	if provider == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, providerContextKey{}, provider)
+}
+
+// Provider returns the canonical context provider or a normalized fallback.
+func Provider(ctx context.Context, fallback string) string {
+	if ctx != nil {
+		if provider, ok := ctx.Value(providerContextKey{}).(string); ok {
+			if provider = normalizeProvider(provider); provider != "" {
+				return provider
+			}
+		}
+	}
+	return normalizeProvider(fallback)
+}
+
+// FinalizeHeaders applies the host finalizer to a cloned header map.
+func FinalizeHeaders(ctx context.Context, provider string, transport pluginapi.OutboundTransport, headers http.Header) (http.Header, error) {
+	provider = Provider(ctx, provider)
+	if provider == "" {
+		return cloneHeader(headers), nil
+	}
+	finalizer := headerFinalizer(ctx)
+	if finalizer == nil {
+		return cloneHeader(headers), nil
+	}
+	return finalizer.FinalizeOutboundHeaders(ctx, pluginapi.OutboundHeaderInterceptRequest{
+		Provider:  provider,
+		Transport: transport,
+		Headers:   cloneHeader(headers),
+	})
+}
+
+// FinalizeRequest applies final HTTP headers to req without changing its body or context.
+func FinalizeRequest(ctx context.Context, provider string, req *http.Request) error {
+	if req == nil {
+		return fmt.Errorf("outbound request is nil")
+	}
+	if ctx == nil {
+		ctx = req.Context()
+	}
+	headers, errFinalize := FinalizeHeaders(ctx, provider, pluginapi.OutboundTransportHTTP, req.Header)
+	if errFinalize != nil {
+		return errFinalize
+	}
+	req.Header = headers
+	return nil
+}
+
+// Do finalizes req and sends it through client.
+func Do(ctx context.Context, provider string, client *http.Client, req *http.Request) (*http.Response, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if errFinalize := FinalizeRequest(ctx, provider, req); errFinalize != nil {
+		return nil, errFinalize
+	}
+	return client.Do(req)
+}
+
+// WrapHTTPClient returns a shallow client copy that finalizes requests created by
+// libraries which call Client.Do internally.
+func WrapHTTPClient(ctx context.Context, provider string, client *http.Client) *http.Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	wrapped := *client
+	transport := client.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	wrapped.Transport = &finalizingRoundTripper{
+		ctx:       ctx,
+		provider:  normalizeProvider(provider),
+		transport: transport,
+	}
+	return &wrapped
+}
+
+func (t *finalizingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, fmt.Errorf("outbound request is nil")
+	}
+	if t == nil || t.transport == nil {
+		return nil, fmt.Errorf("outbound transport is nil")
+	}
+	finalizeCtx := req.Context()
+	if headerFinalizer(finalizeCtx) == nil {
+		finalizeCtx = WithHeaderFinalizer(finalizeCtx, headerFinalizer(t.ctx))
+	}
+	provider := Provider(finalizeCtx, Provider(t.ctx, t.provider))
+	finalizeCtx = WithProvider(finalizeCtx, provider)
+	wireReq := req.Clone(finalizeCtx)
+	if errFinalize := FinalizeRequest(finalizeCtx, provider, wireReq); errFinalize != nil {
+		return nil, errFinalize
+	}
+	return t.transport.RoundTrip(wireReq)
+}
+
+func headerFinalizer(ctx context.Context) HeaderFinalizer {
+	if ctx == nil {
+		return nil
+	}
+	finalizer, _ := ctx.Value(finalizerContextKey{}).(HeaderFinalizer)
+	return finalizer
+}
+
+func normalizeProvider(provider string) string {
+	return strings.ToLower(strings.TrimSpace(provider))
+}
+
+func cloneHeader(headers http.Header) http.Header {
+	if len(headers) == 0 {
+		return nil
+	}
+	return headers.Clone()
+}

--- a/sdk/cliproxy/outbound/outbound_test.go
+++ b/sdk/cliproxy/outbound/outbound_test.go
@@ -1,0 +1,115 @@
+package outbound
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+type headerFinalizerFunc func(context.Context, pluginapi.OutboundHeaderInterceptRequest) (http.Header, error)
+
+func (f headerFinalizerFunc) FinalizeOutboundHeaders(ctx context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+	return f(ctx, req)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestDoFinalizesHeadersImmediatelyBeforeRoundTrip(t *testing.T) {
+	var finalized bool
+	ctx := WithHeaderFinalizer(context.Background(), headerFinalizerFunc(func(_ context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+		if req.Provider != "codex" || req.Transport != pluginapi.OutboundTransportHTTP {
+			t.Fatalf("finalizer request identity = %#v", req)
+		}
+		if req.Headers.Get("User-Agent") != "host/1.0" {
+			t.Fatalf("finalizer User-Agent = %q", req.Headers.Get("User-Agent"))
+		}
+		finalized = true
+		headers := req.Headers.Clone()
+		headers.Set("User-Agent", "plugin/1.0")
+		return headers, nil
+	}))
+	req, errRequest := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.test", nil)
+	if errRequest != nil {
+		t.Fatalf("NewRequestWithContext() error = %v", errRequest)
+	}
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("User-Agent", "host/1.0")
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if !finalized {
+			t.Fatal("RoundTrip called before finalizer")
+		}
+		if req.Header.Get("User-Agent") != "plugin/1.0" || req.Header.Get("Authorization") != "Bearer secret" {
+			t.Fatalf("wire headers = %#v", req.Header)
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader("ok")), Request: req}, nil
+	})}
+
+	resp, errDo := Do(ctx, "codex", client, req)
+	if errDo != nil {
+		t.Fatalf("Do() error = %v", errDo)
+	}
+	_ = resp.Body.Close()
+}
+
+func TestDoFailsClosedBeforeRoundTrip(t *testing.T) {
+	errRejected := errors.New("header plugin rejected request")
+	ctx := WithProvider(context.Background(), " XAI ")
+	ctx = WithHeaderFinalizer(ctx, headerFinalizerFunc(func(_ context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+		if req.Provider != "xai" {
+			t.Fatalf("provider = %q, want context provider xai", req.Provider)
+		}
+		return nil, errRejected
+	}))
+	req, errRequest := http.NewRequestWithContext(ctx, http.MethodPost, "https://example.test", nil)
+	if errRequest != nil {
+		t.Fatalf("NewRequestWithContext() error = %v", errRequest)
+	}
+	var roundTrips int
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		roundTrips++
+		return nil, errors.New("unexpected network call")
+	})}
+
+	if _, errDo := Do(ctx, "codex", client, req); !errors.Is(errDo, errRejected) {
+		t.Fatalf("Do() error = %v, want %v", errDo, errRejected)
+	}
+	if roundTrips != 0 {
+		t.Fatalf("round trips = %d, want 0", roundTrips)
+	}
+}
+
+func TestWrapHTTPClientFinalizesLibraryOwnedRequests(t *testing.T) {
+	errRejected := errors.New("library request rejected")
+	var roundTrips int
+	base := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		roundTrips++
+		return nil, errors.New("unexpected network call")
+	})}
+	ctx := WithHeaderFinalizer(context.Background(), headerFinalizerFunc(func(_ context.Context, req pluginapi.OutboundHeaderInterceptRequest) (http.Header, error) {
+		if req.Provider != "vertex" || req.Transport != pluginapi.OutboundTransportHTTP {
+			t.Fatalf("finalizer request identity = %#v", req)
+		}
+		return nil, errRejected
+	}))
+	client := WrapHTTPClient(ctx, "vertex", base)
+	req, errRequest := http.NewRequest(http.MethodPost, "https://oauth2.example.test/token", nil)
+	if errRequest != nil {
+		t.Fatalf("NewRequest() error = %v", errRequest)
+	}
+
+	if _, errDo := client.Do(req); !errors.Is(errDo, errRejected) {
+		t.Fatalf("wrapped client error = %v, want %v", errDo, errRejected)
+	}
+	if roundTrips != 0 {
+		t.Fatalf("round trips = %d, want 0", roundTrips)
+	}
+}

--- a/sdk/cliproxy/service_plugins.go
+++ b/sdk/cliproxy/service_plugins.go
@@ -106,6 +106,7 @@ func (s *Service) syncPluginRuntimeConfigForConfig(ctx context.Context, cfg *con
 	}
 	if s.coreManager != nil {
 		s.coreManager.SetPluginScheduler(s.pluginHost)
+		s.coreManager.SetOutboundHeaderFinalizer(s.pluginHost)
 	}
 	s.registerPluginAuthParser()
 	if s.pluginHost == nil {

--- a/sdk/pluginabi/types.go
+++ b/sdk/pluginabi/types.go
@@ -10,10 +10,14 @@ const (
 	// Version 3 omits OriginalRequest/RequestBody on payload stream chunks
 	// (ChunkIndex >= 0); those fields remain on StreamChunkHeaderInitIndex only.
 	// Plugins that still need per-chunk request bodies should keep schema_version < 3.
-	SchemaVersion uint32 = 3
+	// Version 4 adds provider-tagged final outbound-header interception.
+	SchemaVersion uint32 = 4
 	// SchemaVersionStreamChunkOmitRequestBody is the first schema version that omits
 	// request bodies on payload stream-chunk interceptor calls.
 	SchemaVersionStreamChunkOmitRequestBody uint32 = 3
+	// SchemaVersionOutboundHeaderInterceptor is the first schema version that supports
+	// final provider-tagged HTTP and websocket header interception.
+	SchemaVersionOutboundHeaderInterceptor uint32 = 4
 )
 
 const (
@@ -45,11 +49,12 @@ const (
 	MethodExecutorCountTokens   = "executor.count_tokens"
 	MethodExecutorHTTPRequest   = "executor.http_request"
 
-	MethodRequestTranslate       = "request.translate"
-	MethodRequestNormalize       = "request.normalize"
-	MethodRequestInterceptBefore = "request.intercept_before"
-	MethodRequestInterceptAfter  = "request.intercept_after"
-	MethodRequestComplete        = "request.complete"
+	MethodRequestTranslate         = "request.translate"
+	MethodRequestNormalize         = "request.normalize"
+	MethodRequestInterceptBefore   = "request.intercept_before"
+	MethodRequestInterceptAfter    = "request.intercept_after"
+	MethodOutboundHeadersIntercept = "outbound_headers.intercept"
+	MethodRequestComplete          = "request.complete"
 
 	MethodResponseTranslate            = "response.translate"
 	MethodResponseNormalizeBefore      = "response.normalize_before"
@@ -83,6 +88,7 @@ const (
 	MethodHostAuthGet            = "host.auth.get"
 	MethodHostAuthGetRuntime     = "host.auth.get_runtime"
 	MethodHostAuthSave           = "host.auth.save"
+	MethodHostProviderList       = "host.provider.list"
 )
 
 type Envelope struct {

--- a/sdk/pluginabi/types_test.go
+++ b/sdk/pluginabi/types_test.go
@@ -27,11 +27,14 @@ func TestEnvelopeRoundTrip(t *testing.T) {
 }
 
 func TestMethodNamesAreStable(t *testing.T) {
-	if SchemaVersion != 3 {
-		t.Fatalf("SchemaVersion = %d, want 3", SchemaVersion)
+	if SchemaVersion != 4 {
+		t.Fatalf("SchemaVersion = %d, want 4", SchemaVersion)
 	}
 	if SchemaVersionStreamChunkOmitRequestBody != 3 {
 		t.Fatalf("SchemaVersionStreamChunkOmitRequestBody = %d, want 3", SchemaVersionStreamChunkOmitRequestBody)
+	}
+	if SchemaVersionOutboundHeaderInterceptor != 4 {
+		t.Fatalf("SchemaVersionOutboundHeaderInterceptor = %d, want 4", SchemaVersionOutboundHeaderInterceptor)
 	}
 	if MethodPluginRegister != "plugin.register" {
 		t.Fatalf("MethodPluginRegister = %q", MethodPluginRegister)
@@ -41,6 +44,9 @@ func TestMethodNamesAreStable(t *testing.T) {
 	}
 	if MethodRequestInterceptAfter != "request.intercept_after" {
 		t.Fatalf("MethodRequestInterceptAfter = %q", MethodRequestInterceptAfter)
+	}
+	if MethodOutboundHeadersIntercept != "outbound_headers.intercept" {
+		t.Fatalf("MethodOutboundHeadersIntercept = %q", MethodOutboundHeadersIntercept)
 	}
 	if MethodRequestComplete != "request.complete" {
 		t.Fatalf("MethodRequestComplete = %q", MethodRequestComplete)
@@ -80,6 +86,9 @@ func TestMethodNamesAreStable(t *testing.T) {
 	}
 	if MethodHostAuthSave != "host.auth.save" {
 		t.Fatalf("MethodHostAuthSave = %q", MethodHostAuthSave)
+	}
+	if MethodHostProviderList != "host.provider.list" {
+		t.Fatalf("MethodHostProviderList = %q", MethodHostProviderList)
 	}
 	if MethodExecutorExecuteStream != "executor.execute_stream" {
 		t.Fatalf("MethodExecutorExecuteStream = %q", MethodExecutorExecuteStream)

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -106,6 +106,8 @@ type Capabilities struct {
 	ResponseAfterTranslator ResponseNormalizer
 	// RequestInterceptor rewrites execution requests before and after credential selection.
 	RequestInterceptor RequestInterceptor
+	// OutboundHeaderInterceptor rewrites provider request headers at the final network boundary.
+	OutboundHeaderInterceptor OutboundHeaderInterceptor
 	// RequestLifecyclePlugin asynchronously receives one terminal event for each request that reached request interception.
 	RequestLifecyclePlugin RequestLifecyclePlugin
 	// ResponseInterceptor rewrites successful non-streaming HTTP execution responses before downstream delivery.
@@ -670,6 +672,17 @@ type HostRecentRequestEntry struct {
 	Failed int64 `json:"failed"`
 }
 
+// HostProviderInfo identifies one canonical provider available to plugins.
+type HostProviderInfo struct {
+	// ID is the canonical provider key used for execution and outbound interception.
+	ID string `json:"id"`
+}
+
+// HostProviderListResponse returns the host provider catalog.
+type HostProviderListResponse struct {
+	Providers []HostProviderInfo `json:"providers"`
+}
+
 // HostAuthFileEntry describes one credential exposed through host auth callbacks.
 type HostAuthFileEntry struct {
 	// ID identifies the credential record.
@@ -934,6 +947,12 @@ type RequestInterceptor interface {
 	InterceptRequestAfterAuth(context.Context, RequestInterceptRequest) (RequestInterceptResponse, error)
 }
 
+// OutboundHeaderInterceptor rewrites provider request headers after provider defaults,
+// credentials, and request cloaking have been applied.
+type OutboundHeaderInterceptor interface {
+	InterceptOutboundHeaders(context.Context, OutboundHeaderInterceptRequest) (OutboundHeaderInterceptResponse, error)
+}
+
 // RequestLifecyclePlugin receives asynchronous terminal events after execution finishes, fails, is rejected, or is canceled.
 type RequestLifecyclePlugin interface {
 	HandleRequestComplete(context.Context, RequestCompletion) error
@@ -1024,6 +1043,35 @@ type RequestInterceptResponse struct {
 	ResponseHeaders http.Header
 	// ResponseBody contains the downstream response body used when Terminate is true.
 	ResponseBody []byte
+}
+
+// OutboundTransport identifies the provider network transport being finalized.
+type OutboundTransport string
+
+const (
+	// OutboundTransportHTTP identifies an outbound HTTP request, including streaming requests.
+	OutboundTransportHTTP OutboundTransport = "http"
+	// OutboundTransportWebSocket identifies an outbound websocket handshake.
+	OutboundTransportWebSocket OutboundTransport = "websocket"
+)
+
+// OutboundHeaderInterceptRequest describes mutable provider headers immediately before network I/O.
+// Credential and transport-owned headers are omitted by the host.
+type OutboundHeaderInterceptRequest struct {
+	// Provider is the canonical runtime provider identifier.
+	Provider string
+	// Transport identifies the HTTP or websocket send boundary.
+	Transport OutboundTransport
+	// Headers contains only headers the plugin may inspect or modify.
+	Headers http.Header
+}
+
+// OutboundHeaderInterceptResponse returns final outbound-header modifications.
+type OutboundHeaderInterceptResponse struct {
+	// Headers replaces matching mutable headers and preserves headers not mentioned here.
+	Headers http.Header
+	// ClearHeaders removes mutable headers before Headers is applied.
+	ClearHeaders []string
 }
 
 // RequestCompletionOutcome identifies how an intercepted request ended.

--- a/sdk/pluginapi/types_test.go
+++ b/sdk/pluginapi/types_test.go
@@ -24,6 +24,7 @@ var _ RequestNormalizer = (*compileTimePlugin)(nil)
 var _ ResponseTranslator = (*compileTimePlugin)(nil)
 var _ ResponseNormalizer = (*compileTimePlugin)(nil)
 var _ RequestInterceptor = (*compileTimePlugin)(nil)
+var _ OutboundHeaderInterceptor = (*compileTimePlugin)(nil)
 var _ RequestLifecyclePlugin = (*compileTimePlugin)(nil)
 var _ ResponseInterceptor = (*compileTimePlugin)(nil)
 var _ StreamChunkInterceptor = (*compileTimePlugin)(nil)
@@ -517,6 +518,10 @@ func (compileTimePlugin) InterceptRequestBeforeAuth(context.Context, RequestInte
 
 func (compileTimePlugin) InterceptRequestAfterAuth(context.Context, RequestInterceptRequest) (RequestInterceptResponse, error) {
 	return RequestInterceptResponse{}, nil
+}
+
+func (compileTimePlugin) InterceptOutboundHeaders(context.Context, OutboundHeaderInterceptRequest) (OutboundHeaderInterceptResponse, error) {
+	return OutboundHeaderInterceptResponse{}, nil
 }
 
 func (compileTimePlugin) HandleRequestComplete(context.Context, RequestCompletion) error { return nil }


### PR DESCRIPTION
## What changed

- Bump the native plugin RPC schema to v4 and add the `outbound_headers.intercept` capability.
- Run outbound-header plugins at the final HTTP or WebSocket boundary, after provider defaults, credentials, custom headers, and cloaking.
- Carry provider identity and the plugin host through standard execution, streaming, token counting, OAuth, discovery, quota, control-plane, AI Studio relay, Codex Live, and WebSocket paths.
- Add `host.provider.list` so management resources can discover the live provider catalog.
- Add fail-closed validation, protected credential/transport headers, panic fusion, priority-ordered chaining, and self-recursion avoidance for plugin-originated host calls.

## Why

Payload configuration only rewrites request bodies, and network configuration controls transports and proxies. Neither can reliably replace `User-Agent` after provider-specific authentication and cloaking have populated the final headers. This hook gives native plugins a single provider-tagged boundary for that job without exposing or allowing changes to credential headers.

## Coverage and exclusions

Covered paths include inference, streaming, token counting, images/media provider calls, OAuth exchange and refresh, provider discovery and quota calls, Vertex library-owned token requests, AI Studio relay requests, Codex/xAI WebSockets, and Codex Live/sideband WebSockets.

Provider-returned download/grounding URLs, CPA update and plugin-store traffic, and raw sockets without HTTP headers remain outside this hook. A source audit test prevents new direct provider `http.Client.Do` calls from bypassing finalization while preserving the explicit infrastructure and grounding exclusions.

## Validation

Passing checks:

- `gofmt -l .`
- `git diff --check`
- focused tests across the ABI/API, SDK auth, outbound helper, plugin host, management API, Codex Live, provider auth, and executor helper packages
- focused `-race` tests across the same concurrency-sensitive packages
- `go build -o <temporary-path>/cli-proxy-api ./cmd/server`

The repository-wide commands retain existing failures reproduced on the clean base commit `b8fbe70b`:

- `go test ./...`: three Claude fingerprint assertions expect Linux but the base implementation emits the configured MacOS value.
- `go vet ./...`: the existing logging `WriteTo` signature warning and two existing context-cancel warning pairs in plugin-host callbacks.
