### PR TITLE
feat: expose OpenAI account OAuth provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ auths/*
 
 # Documentation
 docs/*
+!docs/adr/
+!docs/adr/*.md
 AGENTS.md
 CLAUDE.md
 GEMINI.md

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,29 @@
+# Provider and Account Authentication Context
+
+This context defines the provider and account terms used when the proxy exposes OpenAI subscription authentication through its Codex-compatible runtime.
+
+## Provider surfaces
+
+**OpenAI account**:
+An OpenAI subscription account authenticated through the ChatGPT OAuth flow. It is an external provider surface that lets clients select account authentication and Codex-compatible models.
+_Avoid_: OpenAI API key, OpenAI-compatible provider
+
+**Codex provider**:
+The canonical provider identity for OpenAI account credentials and Codex-compatible execution.
+_Avoid_: OpenAI account when referring to the internal provider identity
+
+**Canonical provider**:
+The provider identity used by credential storage, runtime selection, and account scheduling after an external provider name is normalized.
+_Avoid_: display provider, login label
+
+## Request capabilities
+
+**Model**:
+The model identifier selected for an OpenAI account request.
+
+**Reasoning effort**:
+The requested reasoning depth for a model, expressed as a supported level such as `low`, `medium`, `high`, or `xhigh`.
+
+**Fast mode**:
+A request preference for the accelerated service tier when the selected model and account support it.
+_Avoid_: a separate model, a separate account

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -75,6 +75,8 @@ func main() {
 	// Command-line flags to control the application's behavior.
 	var codexLogin bool
 	var codexDeviceLogin bool
+	var openaiLogin bool
+	var openaiDeviceLogin bool
 	var claudeLogin bool
 	var noBrowser bool
 	var oauthCallbackPort int
@@ -94,6 +96,8 @@ func main() {
 	// Define command-line flags for different operation modes.
 	flag.BoolVar(&codexLogin, "codex-login", false, "Login to Codex using OAuth")
 	flag.BoolVar(&codexDeviceLogin, "codex-device-login", false, "Login to Codex using device code flow")
+	flag.BoolVar(&openaiLogin, "openai-login", false, "Login to an OpenAI account using OAuth")
+	flag.BoolVar(&openaiDeviceLogin, "openai-device-login", false, "Login to an OpenAI account using device code flow")
 	flag.BoolVar(&claudeLogin, "claude-login", false, "Login to Claude using OAuth")
 	flag.BoolVar(&noBrowser, "no-browser", false, "Don't open browser automatically for OAuth")
 	flag.IntVar(&oauthCallbackPort, "oauth-callback-port", 0, "Override OAuth callback port (defaults to provider-specific port)")
@@ -588,7 +592,7 @@ func main() {
 		CallbackPort: oauthCallbackPort,
 	}
 
-	commandMode := vertexImport != "" || antigravityLogin || codexLogin || codexDeviceLogin || claudeLogin || kimiLogin || xaiLogin
+	commandMode := vertexImport != "" || antigravityLogin || codexLogin || codexDeviceLogin || openaiLogin || openaiDeviceLogin || claudeLogin || kimiLogin || xaiLogin
 	cloudConfigMissing := isCloudDeploy && !configFileExists
 	homeMode := configLoadedFromHome || (cfg != nil && cfg.Home.Enabled)
 	exampleAPIKeySafeMode := shouldEnableExampleAPIKeySafeMode(cfg, commandMode, tuiMode, standalone, cloudConfigMissing, homeMode)
@@ -655,6 +659,12 @@ func main() {
 	} else if codexDeviceLogin {
 		// Handle Codex device-code login
 		cmd.DoCodexDeviceLogin(cfg, options)
+	} else if openaiLogin {
+		// Handle OpenAI account login
+		cmd.DoOpenAILogin(cfg, options)
+	} else if openaiDeviceLogin {
+		// Handle OpenAI account device-code login
+		cmd.DoOpenAIDeviceLogin(cfg, options)
 	} else if claudeLogin {
 		// Handle Claude login
 		cmd.DoClaudeLogin(cfg, options)

--- a/docs/adr/0001-openai-account-codex-compatibility.md
+++ b/docs/adr/0001-openai-account-codex-compatibility.md
@@ -1,0 +1,12 @@
+# Expose OpenAI accounts through the Codex provider
+
+The proxy exposes `openai` as the external provider name for OpenAI account OAuth while retaining `codex` as the canonical provider for stored credentials, account scheduling, and execution. This preserves existing auth files and runtime behavior while allowing clients to discover an OpenAI account login surface and select model, reasoning effort, and Fast mode capabilities.
+
+## Considered Options
+
+- Rename the stored provider from `codex` to `openai`. Rejected because existing credentials and Codex-specific executor dispatch depend on the canonical identity.
+- Treat OpenAI accounts as OpenAI API-key compatibility providers. Rejected because ChatGPT subscription OAuth credentials use the Codex account and Responses flow.
+
+## Consequences
+
+Clients can use `/v0/management/openai-auth-url`, `/openai/callback`, `-openai-login`, and `-openai-device-login`. Existing Codex routes and account files remain valid. The Codex request adapter accepts `service_tier: "fast"` and normalizes it to the upstream `priority` tier.

--- a/internal/api/handlers/management/auth_files_provider_oauth.go
+++ b/internal/api/handlers/management/auth_files_provider_oauth.go
@@ -194,10 +194,34 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 }
 
 func (h *Handler) RequestCodexToken(c *gin.Context) {
+	h.requestCodexToken(c, "codex")
+}
+
+// RequestOpenAIToken starts the OpenAI account OAuth flow using the Codex
+// credential and execution path.
+func (h *Handler) RequestOpenAIToken(c *gin.Context) {
+	h.requestCodexToken(c, "openai")
+}
+
+func (h *Handler) requestCodexToken(c *gin.Context, surfaceProvider string) {
+	surfaceProvider = strings.ToLower(strings.TrimSpace(surfaceProvider))
+	canonicalProvider, errProvider := NormalizeOAuthProvider(surfaceProvider)
+	if errProvider != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported OAuth provider"})
+		return
+	}
+
+	providerLabel := "Codex"
+	callbackPath := "/codex/callback"
+	if surfaceProvider == "openai" {
+		providerLabel = "OpenAI account"
+		callbackPath = "/openai/callback"
+	}
+
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
 
-	fmt.Println("Initializing Codex authentication...")
+	fmt.Printf("Initializing %s authentication...\n", providerLabel)
 
 	// Generate PKCE codes
 	pkceCodes, err := codex.GeneratePKCECodes()
@@ -226,20 +250,20 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 		return
 	}
 
-	RegisterOAuthSession(state, "codex")
+	RegisterOAuthSession(state, canonicalProvider)
 
 	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
 	if isWebUI {
-		targetURL, errTarget := h.managementCallbackURL("/codex/callback")
+		targetURL, errTarget := h.managementCallbackURL(callbackPath)
 		if errTarget != nil {
-			log.WithError(errTarget).Error("failed to compute codex callback target")
+			log.WithError(errTarget).WithField("provider", surfaceProvider).Error("failed to compute OAuth callback target")
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "callback server unavailable"})
 			return
 		}
 		var errStart error
-		if forwarder, errStart = startCallbackForwarder(codexCallbackPort, "codex", targetURL); errStart != nil {
-			log.WithError(errStart).Error("failed to start codex callback forwarder")
+		if forwarder, errStart = startCallbackForwarder(codexCallbackPort, surfaceProvider, targetURL); errStart != nil {
+			log.WithError(errStart).WithField("provider", surfaceProvider).Error("failed to start OAuth callback server")
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to start callback server"})
 			return
 		}
@@ -255,7 +279,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 		deadline := time.Now().Add(5 * time.Minute)
 		var code string
 		for {
-			if !IsOAuthSessionPending(state, "codex") {
+			if !IsOAuthSessionPending(state, canonicalProvider) {
 				return
 			}
 			if time.Now().After(deadline) {
@@ -313,7 +337,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 		fileName := codex.CredentialFileName(tokenStorage.Email, planType, hashAccountID, true)
 		record := &coreauth.Auth{
 			ID:       fileName,
-			Provider: "codex",
+			Provider: canonicalProvider,
 			FileName: fileName,
 			Storage:  tokenStorage,
 			Metadata: map[string]any{
@@ -321,7 +345,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 				"account_id": tokenStorage.AccountID,
 			},
 		}
-		if errGuard := guardOAuthSessionPendingForSave(state, "codex"); errGuard != nil {
+		if errGuard := guardOAuthSessionPendingForSave(state, canonicalProvider); errGuard != nil {
 			return
 		}
 		savedPath, errSave := h.saveTokenRecord(ctx, record)
@@ -334,11 +358,17 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 		if bundle.APIKey != "" {
 			fmt.Println("API key obtained and saved")
 		}
-		fmt.Println("You can now use Codex services through this CLI")
+		fmt.Printf("You can now use %s services through this CLI\n", providerLabel)
 		CompleteOAuthSession(state)
 	}()
 
-	c.JSON(200, gin.H{"status": "ok", "url": authURL, "state": state})
+	c.JSON(http.StatusOK, gin.H{
+		"status":             "ok",
+		"url":                authURL,
+		"state":              state,
+		"provider":           surfaceProvider,
+		"canonical_provider": canonicalProvider,
+	})
 }
 
 func (h *Handler) RequestAntigravityToken(c *gin.Context) {

--- a/internal/api/handlers/management/oauth_codex_concurrency_test.go
+++ b/internal/api/handlers/management/oauth_codex_concurrency_test.go
@@ -75,6 +75,42 @@ func TestRequestCodexTokenCompletionKeepsConcurrentSessionPending(t *testing.T) 
 	}
 }
 
+func TestRequestOpenAITokenUsesCodexSession(t *testing.T) {
+	authDir := filepath.Join(t.TempDir(), "auths")
+	handler := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+	router := gin.New()
+	router.GET("/openai-auth-url", handler.RequestOpenAIToken)
+
+	req := httptest.NewRequest(http.MethodGet, "/openai-auth-url", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var payload struct {
+		State             string `json:"state"`
+		Provider          string `json:"provider"`
+		CanonicalProvider string `json:"canonical_provider"`
+	}
+	if errDecode := json.Unmarshal(w.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode OpenAI auth URL response: %v", errDecode)
+	}
+	if payload.State == "" {
+		t.Fatal("expected OpenAI auth URL response to include state")
+	}
+	if payload.Provider != "openai" || payload.CanonicalProvider != "codex" {
+		t.Fatalf("provider identity = (%q, %q), want (openai, codex)", payload.Provider, payload.CanonicalProvider)
+	}
+	provider, _, ok := GetOAuthSession(payload.State)
+	if !ok || provider != "codex" {
+		t.Fatalf("OAuth session = (%q, %t), want (codex, true)", provider, ok)
+	}
+	if !CancelOAuthSession(payload.State) {
+		t.Fatalf("CancelOAuthSession(%q) = false, want true", payload.State)
+	}
+}
+
 func requestCodexTokenState(t *testing.T, router http.Handler) string {
 	t.Helper()
 

--- a/internal/api/handlers/management/oauth_sessions_test.go
+++ b/internal/api/handlers/management/oauth_sessions_test.go
@@ -13,6 +13,29 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
 
+func TestNormalizeOAuthProvider(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		want     string
+	}{
+		{name: "codex", provider: "codex", want: "codex"},
+		{name: "openai account alias", provider: "OpenAI", want: "codex"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, errNormalize := NormalizeOAuthProvider(tt.provider)
+			if errNormalize != nil {
+				t.Fatalf("NormalizeOAuthProvider(%q) error = %v", tt.provider, errNormalize)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizeOAuthProvider(%q) = %q, want %q", tt.provider, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestOAuthSessionStoreCompleteKeepsShortLivedSession(t *testing.T) {
 	store := newOAuthSessionStore(time.Minute)
 	store.Register("completed-state", "codex")

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -167,6 +167,7 @@ func (s *Server) registerManagementRoutes() {
 
 		mgmt.GET("/anthropic-auth-url", s.mgmt.RequestAnthropicToken)
 		mgmt.GET("/codex-auth-url", s.mgmt.RequestCodexToken)
+		mgmt.GET("/openai-auth-url", s.mgmt.RequestOpenAIToken)
 		mgmt.GET("/antigravity-auth-url", s.mgmt.RequestAntigravityToken)
 		mgmt.GET("/kimi-auth-url", s.mgmt.RequestKimiToken)
 		mgmt.GET("/xai-auth-url", s.mgmt.RequestXAIToken)

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -141,7 +141,7 @@ func (s *Server) setupRoutes() {
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
 	})
 
-	s.engine.GET("/codex/callback", func(c *gin.Context) {
+	codexOAuthCallback := func(c *gin.Context) {
 		code := c.Query("code")
 		state := c.Query("state")
 		errStr := c.Query("error")
@@ -153,7 +153,10 @@ func (s *Server) setupRoutes() {
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
-	})
+	}
+	s.engine.GET("/codex/callback", codexOAuthCallback)
+	// OpenAI account is an external alias for the canonical Codex OAuth flow.
+	s.engine.GET("/openai/callback", codexOAuthCallback)
 
 	s.engine.GET("/antigravity/callback", func(c *gin.Context) {
 		code := c.Query("code")

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1096,6 +1096,19 @@ func TestManagementResponseExposesPluginSupportHeaderForCORS(t *testing.T) {
 	}
 }
 
+func TestManagementExposesOpenAIAccountOAuthRoute(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "test-management-key")
+
+	server := newTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/openai-auth-url", nil)
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d body=%s", rr.Code, http.StatusUnauthorized, rr.Body.String())
+	}
+}
+
 func TestOAuthCallbackRouteSkipsManagementKeyMiddleware(t *testing.T) {
 	t.Setenv("MANAGEMENT_PASSWORD", "test-management-key")
 
@@ -1117,6 +1130,25 @@ func TestOAuthCallbackRouteSkipsManagementKeyMiddleware(t *testing.T) {
 	callbackPath := filepath.Join(server.cfg.AuthDir, ".oauth-gemini-cli-"+state+".oauth")
 	if _, errRead := os.ReadFile(callbackPath); errRead != nil {
 		t.Fatalf("expected callback file to be written without management key: %v", errRead)
+	}
+}
+
+func TestOpenAIOAuthCallbackRouteWritesCodexSessionFile(t *testing.T) {
+	server := newTestServer(t)
+	state := "openai-account-callback-state"
+	managementHandlers.RegisterOAuthSession(state, "codex")
+	defer managementHandlers.CompleteOAuthSession(state)
+
+	req := httptest.NewRequest(http.MethodGet, "/openai/callback?state="+state+"&code=test-code", nil)
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	callbackPath := filepath.Join(server.cfg.AuthDir, ".oauth-codex-"+state+".oauth")
+	if _, errRead := os.ReadFile(callbackPath); errRead != nil {
+		t.Fatalf("expected OpenAI callback to write Codex session file: %v", errRead)
 	}
 }
 

--- a/internal/cmd/openai_device_login.go
+++ b/internal/cmd/openai_device_login.go
@@ -20,6 +20,16 @@ const (
 // DoCodexDeviceLogin triggers the Codex device-code flow while keeping the
 // existing codex-login OAuth callback flow intact.
 func DoCodexDeviceLogin(cfg *config.Config, options *LoginOptions) {
+	doCodexDeviceLogin(cfg, options, "Codex")
+}
+
+// DoOpenAIDeviceLogin triggers the OpenAI account device-code flow while
+// retaining the canonical Codex credential provider internally.
+func DoOpenAIDeviceLogin(cfg *config.Config, options *LoginOptions) {
+	doCodexDeviceLogin(cfg, options, "OpenAI account")
+}
+
+func doCodexDeviceLogin(cfg *config.Config, options *LoginOptions, providerLabel string) {
 	if options == nil {
 		options = &LoginOptions{}
 	}
@@ -49,12 +59,12 @@ func DoCodexDeviceLogin(cfg *config.Config, options *LoginOptions) {
 			}
 			return
 		}
-		fmt.Printf("Codex device authentication failed: %v\n", err)
+		fmt.Printf("%s device authentication failed: %v\n", providerLabel, err)
 		return
 	}
 
 	if savedPath != "" {
 		fmt.Printf("Authentication saved to %s\n", savedPath)
 	}
-	fmt.Println("Codex device authentication successful!")
+	fmt.Printf("%s device authentication successful!\n", providerLabel)
 }

--- a/internal/cmd/openai_login.go
+++ b/internal/cmd/openai_login.go
@@ -34,6 +34,16 @@ type LoginOptions struct {
 //   - cfg: The application configuration
 //   - options: Login options including browser behavior and prompts
 func DoCodexLogin(cfg *config.Config, options *LoginOptions) {
+	doCodexLogin(cfg, options, "Codex")
+}
+
+// DoOpenAILogin triggers the OpenAI account OAuth flow while retaining the
+// canonical Codex credential provider internally.
+func DoOpenAILogin(cfg *config.Config, options *LoginOptions) {
+	doCodexLogin(cfg, options, "OpenAI account")
+}
+
+func doCodexLogin(cfg *config.Config, options *LoginOptions, providerLabel string) {
 	if options == nil {
 		options = &LoginOptions{}
 	}
@@ -61,12 +71,12 @@ func DoCodexLogin(cfg *config.Config, options *LoginOptions) {
 			}
 			return
 		}
-		fmt.Printf("Codex authentication failed: %v\n", err)
+		fmt.Printf("%s authentication failed: %v\n", providerLabel, err)
 		return
 	}
 
 	if savedPath != "" {
 		fmt.Printf("Authentication saved to %s\n", savedPath)
 	}
-	fmt.Println("Codex authentication successful!")
+	fmt.Printf("%s authentication successful!\n", providerLabel)
 }

--- a/internal/translator/codex/openai/chat-completions/codex_openai_request.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_request.go
@@ -63,6 +63,12 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 	} else {
 		out, _ = sjson.SetBytes(out, "reasoning.effort", "medium")
 	}
+	if serviceTier := gjson.GetBytes(rawJSON, "service_tier"); serviceTier.Exists() {
+		switch strings.ToLower(strings.TrimSpace(serviceTier.String())) {
+		case "fast", "priority":
+			out, _ = sjson.SetBytes(out, "service_tier", "priority")
+		}
+	}
 	out, _ = sjson.SetBytes(out, "parallel_tool_calls", true)
 	// OpenAI documents reasoning summaries as explicit opt-in output. Leave
 	// reasoning.summary to the source request's canonical summary intent instead

--- a/internal/translator/codex/openai/chat-completions/codex_openai_request_test.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_request_test.go
@@ -6,6 +6,16 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func TestConvertOpenAIRequestToCodexPreservesFastServiceTier(t *testing.T) {
+	input := []byte(`{"model":"gpt-5.6","service_tier":"fast","messages":[{"role":"user","content":"hello"}]}`)
+
+	out := ConvertOpenAIRequestToCodex("gpt-5.6", input, true)
+
+	if got := gjson.GetBytes(out, "service_tier").String(); got != "priority" {
+		t.Fatalf("service_tier = %q, want priority", got)
+	}
+}
+
 // Basic tool-call: system + user + assistant(tool_calls, no content) + tool result.
 // Expects developer msg + user msg + function_call + function_call_output.
 // No empty assistant message should appear between user and function_call.

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request.go
@@ -2,6 +2,7 @@ package responses
 
 import (
 	"encoding/json"
+	"strings"
 
 	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	log "github.com/sirupsen/logrus"
@@ -25,8 +26,16 @@ func ConvertOpenAIResponsesRequestToCodex(modelName string, inputRawJSON []byte,
 	rawJSON = setCodexRequiredInclude(rawJSON)
 	// Codex Responses rejects token limit fields, so strip them out before forwarding.
 	rawJSON = deleteCodexRequestFields(rawJSON, "max_output_tokens", "max_completion_tokens", "temperature", "top_p")
-	if serviceTier := gjson.GetBytes(rawJSON, "service_tier"); serviceTier.Exists() && serviceTier.String() != "priority" {
-		rawJSON = deleteCodexRequestFields(rawJSON, "service_tier")
+	if serviceTier := gjson.GetBytes(rawJSON, "service_tier"); serviceTier.Exists() {
+		switch strings.ToLower(strings.TrimSpace(serviceTier.String())) {
+		case "fast":
+			// Accept the client-facing Fast mode name and send the upstream
+			// Codex service-tier value.
+			rawJSON, _ = sjson.SetBytes(rawJSON, "service_tier", "priority")
+		case "priority":
+		default:
+			rawJSON = deleteCodexRequestFields(rawJSON, "service_tier")
+		}
 	}
 
 	rawJSON = deleteCodexRequestFields(rawJSON, "truncation")

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
@@ -289,6 +289,16 @@ func TestConvertOpenAIResponsesRequestToCodexNormalizesRequiredFields(t *testing
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToCodexNormalizesFastServiceTier(t *testing.T) {
+	inputJSON := []byte(`{"model":"gpt-5.6","service_tier":"fast","input":"hello"}`)
+
+	output := ConvertOpenAIResponsesRequestToCodex("gpt-5.6", inputJSON, false)
+
+	if got := gjson.GetBytes(output, "service_tier").String(); got != "priority" {
+		t.Fatalf("service_tier = %q, want priority", got)
+	}
+}
+
 // TestConvertSystemRoleToDeveloper_AssistantRole tests that assistant role is preserved
 func TestConvertSystemRoleToDeveloper_AssistantRole(t *testing.T) {
 	inputJSON := []byte(`{

--- a/internal/tui/oauth_tab.go
+++ b/internal/tui/oauth_tab.go
@@ -21,7 +21,7 @@ type oauthProvider struct {
 
 var oauthProviders = []oauthProvider{
 	{"Claude (Anthropic)", "anthropic-auth-url", "🟧", false},
-	{"Codex (OpenAI)", "codex-auth-url", "🟩", false},
+	{"OpenAI account", "openai-auth-url", "🟩", false},
 	{"Antigravity", "antigravity-auth-url", "🟪", false},
 	{"Kimi", "kimi-auth-url", "🟫", true},
 	{"xAI", "xai-auth-url", "⬛", true},
@@ -350,7 +350,7 @@ func (m oauthTabModel) submitCallback(callbackURL string) tea.Cmd {
 				switch p.apiPath {
 				case "anthropic-auth-url":
 					providerKey = "anthropic"
-				case "codex-auth-url":
+				case "codex-auth-url", "openai-auth-url":
 					providerKey = "codex"
 				case "antigravity-auth-url":
 					providerKey = "antigravity"


### PR DESCRIPTION
## Summary

- expose `openai` as an OpenAI account OAuth surface while retaining canonical `codex` runtime credentials
- add management, CLI, and TUI login aliases with callback routing
- preserve model and reasoning metadata and normalize Fast service tier to upstream `priority`
- document the provider vocabulary and compatibility decision

## Verification

- `go test ./...`
- `go build -o cli-proxy-api ./cmd/server`