### PR TITLE
fix(claude): keep alias restoration failures request-scoped

### DIFF
--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -1554,6 +1554,18 @@ type claudeMCPAliasResolver struct {
 	servers map[string]struct{}
 }
 
+type claudeMCPAliasRestoreError struct {
+	error
+}
+
+func (e claudeMCPAliasRestoreError) Unwrap() error {
+	return e.error
+}
+
+func (claudeMCPAliasRestoreError) IsRequestScoped() bool {
+	return true
+}
+
 func newClaudeMCPAliasResolver(reverseMap map[string]string) claudeMCPAliasResolver {
 	resolver := claudeMCPAliasResolver{
 		exact:   reverseMap,
@@ -1667,7 +1679,7 @@ func (resolver claudeMCPAliasResolver) resolve(name string) (string, bool, error
 		return matchedOriginal, true, nil
 	}
 	if matchCount > 1 {
-		return "", false, fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: matched multiple declared aliases", name)
+		return "", false, claudeMCPAliasRestoreError{fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: matched multiple declared aliases", name)}
 	}
 
 	parts, validAlias := parseClaudeMCPAlias(normalizedName)
@@ -1722,10 +1734,10 @@ func (resolver claudeMCPAliasResolver) resolve(name string) (string, bool, error
 		return matchedOriginal, true, nil
 	}
 	if matchCount > 1 {
-		return "", false, fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: semantic suffix matches multiple declared tools", name)
+		return "", false, claudeMCPAliasRestoreError{fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: semantic suffix matches multiple declared tools", name)}
 	}
 
-	return "", false, fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: no unique request-local match", name)
+	return "", false, claudeMCPAliasRestoreError{fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: no unique request-local match", name)}
 }
 
 // reverseRemapOAuthToolNames reverses the tool name mapping for non-stream responses

--- a/internal/runtime/executor/claude_executor_request_remap_test.go
+++ b/internal/runtime/executor/claude_executor_request_remap_test.go
@@ -2,12 +2,14 @@ package executor
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/tidwall/gjson"
 )
 
@@ -343,15 +345,57 @@ func TestReverseRemapOAuthToolNamesRejectsUnsafeMangledAliases(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			response := []byte(fmt.Sprintf(`{"content":[{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}]}`, test.alias))
-			if _, errReverse := reverseRemapOAuthToolNames(response, reverseMap); errReverse == nil || !strings.Contains(errReverse.Error(), test.wantError) {
+			_, errReverse := reverseRemapOAuthToolNames(response, reverseMap)
+			if errReverse == nil || !strings.Contains(errReverse.Error(), test.wantError) {
 				t.Fatalf("reverseRemapOAuthToolNames() error = %v, want %q", errReverse, test.wantError)
+			}
+			var requestErr cliproxyexecutor.RequestScopedError
+			if !errors.As(errReverse, &requestErr) || !requestErr.IsRequestScoped() {
+				t.Fatalf("reverseRemapOAuthToolNames() error = %T %v, want request-scoped", errReverse, errReverse)
 			}
 
 			line := []byte(fmt.Sprintf(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}}`, test.alias))
-			if _, errStream := reverseRemapOAuthToolNamesFromStreamLine(line, reverseMap); errStream == nil || !strings.Contains(errStream.Error(), test.wantError) {
+			_, errStream := reverseRemapOAuthToolNamesFromStreamLine(line, reverseMap)
+			if errStream == nil || !strings.Contains(errStream.Error(), test.wantError) {
 				t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %v, want %q", errStream, test.wantError)
 			}
+			requestErr = nil
+			if !errors.As(errStream, &requestErr) || !requestErr.IsRequestScoped() {
+				t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %T %v, want request-scoped", errStream, errStream)
+			}
 		})
+	}
+}
+
+func TestReverseRemapOAuthToolNamesMarksTrailingMarkupFailureRequestScoped(t *testing.T) {
+	const alias = "mcp__hmzqrngkulqv__xuo7jlxlpzee_clear_thinking"
+	malformedAlias := alias + "</parameter>\n<parameter name=\"merge\""
+	reverseMap := map[string]string{alias: "clear_thinking"}
+
+	response := []byte(fmt.Sprintf(`{"content":[{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}]}`, malformedAlias))
+	restored, errReverse := reverseRemapOAuthToolNames(response, reverseMap)
+	if errReverse == nil {
+		t.Fatal("reverseRemapOAuthToolNames() error = nil, want fail-closed alias error")
+	}
+	if !bytes.Equal(restored, response) {
+		t.Fatalf("reverseRemapOAuthToolNames() returned modified response: %s", restored)
+	}
+	var requestErr cliproxyexecutor.RequestScopedError
+	if !errors.As(errReverse, &requestErr) || !requestErr.IsRequestScoped() {
+		t.Fatalf("reverseRemapOAuthToolNames() error = %T %v, want request-scoped", errReverse, errReverse)
+	}
+
+	line := []byte(fmt.Sprintf(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}}`, malformedAlias))
+	restoredLine, errStream := reverseRemapOAuthToolNamesFromStreamLine(line, reverseMap)
+	if errStream == nil {
+		t.Fatal("reverseRemapOAuthToolNamesFromStreamLine() error = nil, want fail-closed alias error")
+	}
+	if !bytes.Equal(restoredLine, line) {
+		t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() returned modified line: %s", restoredLine)
+	}
+	requestErr = nil
+	if !errors.As(errStream, &requestErr) || !requestErr.IsRequestScoped() {
+		t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %T %v, want request-scoped", errStream, errStream)
 	}
 }
 


### PR DESCRIPTION
## Summary

- classify fail-closed Claude OAuth MCP alias restoration errors as request-scoped
- preserve the existing behavior that rejects malformed or ambiguous tool names
- let the existing auth manager avoid credential fallback and cooldown for this local response-conversion failure
- cover non-stream and stream responses, including the trailing parameter-markup shape from #4979 and #5035

## Why

Alias restoration happens after CPA has already selected a valid credential. A local restoration failure describes the current response, not the credential. Treating it as a generic failure can make a healthy Claude OAuth credential unavailable to immediate retries.

This change uses the existing `RequestScopedError` contract. It does not attempt to execute or repair a potentially corrupted tool call.

Addresses #5035.

## Verification

Passed in `golang:1.26` Docker:

- `go test ./internal/runtime/executor -run 'OAuthToolNames|OAuthMCP|ClaudeMCPAlias' -count=1`
- `go test ./internal/runtime/executor -run '^TestReverseRemapOAuthToolNamesMarksTrailingMarkupFailureRequestScoped$' -count=1 -v`
- `go test ./sdk/cliproxy/auth -run '^(TestManagerClaudeStreamTailCancellationIsAvailabilityNeutral|TestManagerClaudeUpstreamFailureStillCoolsCredential)$' -count=1 -v`
- `go test -race ./internal/runtime/executor -run '^TestReverseRemapOAuthToolNamesMarksTrailingMarkupFailureRequestScoped$' -count=1`
- `go vet ./internal/runtime/executor ./sdk/cliproxy/auth`
- `go build -buildvcs=false -o /tmp/cli-proxy-api ./cmd/server`
- `git diff --check`

The repository-wide `go test ./... -count=1` does not pass in this environment:

- `internal/home`: `TestGetPluginSyncCancellationInterruptsRead` timed out after 120 seconds.
- `internal/runtime/executor`: three device-profile header tests expect Linux but receive MacOS. The identical affected-package command reproduces those three failures on a detached clean `upstream/dev` worktree.
