### PR TITLE
Budget-awareness: external supplier + remaining/recovery

### DIFF
--- a/sdk/cliproxy/auth/budget_supplier.go
+++ b/sdk/cliproxy/auth/budget_supplier.go
@@ -1,0 +1,139 @@
+package auth
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// BudgetKind distinguishes a rolling time window from a prepaid remaining
+// balance. Hosts must not stuff a dollar amount into a window quota, and must
+// not invent a resets_at for prepaid balance.
+const (
+	BudgetKindWindow  = "window"
+	BudgetKindBalance = "balance"
+)
+
+// BudgetObservation is one auth's remaining budget as reported by a supplier.
+// Remaining is a fraction in [0,1] when known; Amount/Currency are optional
+// absolute prepaid fields. RecoverAt is zero when there is no clock (prepaid
+// $0 parks until the next supplier refresh).
+type BudgetObservation struct {
+	AuthID    string
+	Kind      string
+	Remaining *float64
+	Amount    string
+	Currency  string
+	Available *bool
+	RecoverAt time.Time
+}
+
+// BudgetSupplier is the host-owned seam for pushing collected usage into the
+// conductor. CLIProxyAPI stays agnostic about how numbers are gathered
+// (DeepSeek /user/balance, Zhipu quota API, a host ParkSource, etc.).
+//
+// A nil supplier is a no-op: selection stays on today's cooldown ladder.
+type BudgetSupplier interface {
+	Snapshot(ctx context.Context) ([]BudgetObservation, error)
+}
+
+// BudgetApplyConfig controls how observations become ineligibility.
+type BudgetApplyConfig struct {
+	// Threshold is the remaining fraction at or below which a window is
+	// exhausted. Default 0 (remaining <= 0).
+	Threshold float64
+	// Recheck is used when RecoverAt is zero (prepaid). Default 5m.
+	Recheck time.Duration
+	Now     func() time.Time
+}
+
+// ApplyBudgetObservations marks auths exhausted from supplier observations.
+// It never sets Result.CredentialScope — that flag is Anthropic-window
+// scoped and is the wrong tool for prepaid $ and non-Anthropic windows.
+//
+// Fail-open: missing remaining, unparseable amount, and absent observations
+// leave the auth eligible.
+func ApplyBudgetObservations(auths []*Auth, obs []BudgetObservation, cfg BudgetApplyConfig) {
+	if len(auths) == 0 || len(obs) == 0 {
+		return
+	}
+	now := time.Now()
+	if cfg.Now != nil {
+		now = cfg.Now()
+	}
+	recheck := cfg.Recheck
+	if recheck <= 0 {
+		recheck = 5 * time.Minute
+	}
+	byID := make(map[string]*Auth, len(auths))
+	for _, a := range auths {
+		if a != nil && a.ID != "" {
+			byID[a.ID] = a
+		}
+	}
+	for _, o := range obs {
+		a := byID[o.AuthID]
+		if a == nil {
+			continue
+		}
+		until, exhausted := observationExhausted(o, cfg.Threshold, recheck, now)
+		if !exhausted {
+			continue
+		}
+		a.Unavailable = true
+		a.Quota.Exceeded = true
+		a.Quota.Reason = "budget:" + normalizeBudgetKind(o.Kind)
+		a.Quota.NextRecoverAt = until
+	}
+}
+
+func observationExhausted(o BudgetObservation, threshold float64, recheck time.Duration, now time.Time) (time.Time, bool) {
+	kind := normalizeBudgetKind(o.Kind)
+	switch kind {
+	case BudgetKindBalance:
+		if o.Available != nil && !*o.Available {
+			return recoverOrRecheck(o.RecoverAt, recheck, now), true
+		}
+		if amt, ok := parseBudgetAmount(o.Amount); ok && amt <= 0 {
+			return recoverOrRecheck(o.RecoverAt, recheck, now), true
+		}
+		return time.Time{}, false
+	default:
+		if o.Remaining == nil {
+			return time.Time{}, false
+		}
+		if *o.Remaining > threshold {
+			return time.Time{}, false
+		}
+		return recoverOrRecheck(o.RecoverAt, recheck, now), true
+	}
+}
+
+func recoverOrRecheck(recoverAt time.Time, recheck time.Duration, now time.Time) time.Time {
+	if !recoverAt.IsZero() && recoverAt.After(now) {
+		return recoverAt
+	}
+	return now.Add(recheck)
+}
+
+func normalizeBudgetKind(kind string) string {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case BudgetKindBalance:
+		return BudgetKindBalance
+	default:
+		return BudgetKindWindow
+	}
+}
+
+func parseBudgetAmount(raw string) (float64, bool) {
+	s := strings.TrimSpace(strings.ReplaceAll(raw, ",", ""))
+	if s == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}

--- a/sdk/cliproxy/auth/budget_supplier.go
+++ b/sdk/cliproxy/auth/budget_supplier.go
@@ -79,11 +79,19 @@ func ApplyBudgetObservations(auths []*Auth, obs []BudgetObservation, cfg BudgetA
 		}
 		until, exhausted := observationExhausted(o, cfg.Threshold, recheck, now)
 		if !exhausted {
+			if a.Quota.Reason == "credential_quota" || strings.HasPrefix(a.Quota.Reason, "budget:") {
+				a.Unavailable = false
+				a.Quota.Exceeded = false
+				a.Quota.Reason = ""
+				a.Quota.NextRecoverAt = time.Time{}
+			}
 			continue
 		}
+		// Reason credential_quota is what isAuthBlockedForModel already
+		// treats as credential-wide. Do not set Result.CredentialScope.
 		a.Unavailable = true
 		a.Quota.Exceeded = true
-		a.Quota.Reason = "budget:" + normalizeBudgetKind(o.Kind)
+		a.Quota.Reason = "credential_quota"
 		a.Quota.NextRecoverAt = until
 	}
 }
@@ -98,12 +106,18 @@ func observationExhausted(o BudgetObservation, threshold float64, recheck time.D
 		if amt, ok := parseBudgetAmount(o.Amount); ok && amt <= 0 {
 			return recoverOrRecheck(o.RecoverAt, recheck, now), true
 		}
+		if o.Remaining != nil && *o.Remaining <= threshold {
+			return recoverOrRecheck(o.RecoverAt, recheck, now), true
+		}
 		return time.Time{}, false
 	default:
 		if o.Remaining == nil {
 			return time.Time{}, false
 		}
 		if *o.Remaining > threshold {
+			return time.Time{}, false
+		}
+		if !o.RecoverAt.IsZero() && !o.RecoverAt.After(now) {
 			return time.Time{}, false
 		}
 		return recoverOrRecheck(o.RecoverAt, recheck, now), true

--- a/sdk/cliproxy/auth/budget_supplier.go
+++ b/sdk/cliproxy/auth/budget_supplier.go
@@ -48,6 +48,41 @@ type BudgetApplyConfig struct {
 	Now     func() time.Time
 }
 
+const budgetReasonPrefix = "budget:"
+
+// BudgetReason is the Quota.Reason written for a supplier park. It is
+// distinct from credential_quota (Anthropic-window cooldown) so a host
+// budget observation cannot be mistaken for a provider 429.
+func BudgetReason(kind string) string {
+	return budgetReasonPrefix + normalizeBudgetKind(kind)
+}
+
+func isBudgetReason(reason string) bool {
+	return strings.HasPrefix(reason, budgetReasonPrefix)
+}
+
+// isCredentialWideQuotaReason is the conductor predicate for "this quota
+// parks the whole credential". credential_quota stays for Anthropic-window
+// cooldowns; budget:* is the supplier's own reason.
+func isCredentialWideQuotaReason(reason string) bool {
+	return reason == "credential_quota" || isBudgetReason(reason)
+}
+
+// ApplyBudgetSupplier is the honest host hook: Snapshot then apply.
+// A nil supplier is a no-op. Snapshot errors are returned and leave
+// auths unchanged (fail-open).
+func ApplyBudgetSupplier(ctx context.Context, auths []*Auth, supplier BudgetSupplier, cfg BudgetApplyConfig) error {
+	if supplier == nil || len(auths) == 0 {
+		return nil
+	}
+	obs, err := supplier.Snapshot(ctx)
+	if err != nil {
+		return err
+	}
+	ApplyBudgetObservations(auths, obs, cfg)
+	return nil
+}
+
 // ApplyBudgetObservations marks auths exhausted from supplier observations.
 // It never sets Result.CredentialScope — that flag is Anthropic-window
 // scoped and is the wrong tool for prepaid $ and non-Anthropic windows.
@@ -79,7 +114,7 @@ func ApplyBudgetObservations(auths []*Auth, obs []BudgetObservation, cfg BudgetA
 		}
 		until, exhausted := observationExhausted(o, cfg.Threshold, recheck, now)
 		if !exhausted {
-			if a.Quota.Reason == "credential_quota" || strings.HasPrefix(a.Quota.Reason, "budget:") {
+			if isBudgetReason(a.Quota.Reason) {
 				a.Unavailable = false
 				a.Quota.Exceeded = false
 				a.Quota.Reason = ""
@@ -87,11 +122,9 @@ func ApplyBudgetObservations(auths []*Auth, obs []BudgetObservation, cfg BudgetA
 			}
 			continue
 		}
-		// Reason credential_quota is what isAuthBlockedForModel already
-		// treats as credential-wide. Do not set Result.CredentialScope.
 		a.Unavailable = true
 		a.Quota.Exceeded = true
-		a.Quota.Reason = "credential_quota"
+		a.Quota.Reason = BudgetReason(o.Kind)
 		a.Quota.NextRecoverAt = until
 	}
 }

--- a/sdk/cliproxy/auth/budget_supplier_test.go
+++ b/sdk/cliproxy/auth/budget_supplier_test.go
@@ -1,0 +1,78 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestApplyBudgetObservations_WindowExhaustedUntilRecoverAt(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	recoverAt := now.Add(2 * time.Hour)
+	zero := 0.0
+	auth := &Auth{ID: "a1"}
+	ApplyBudgetObservations([]*Auth{auth}, []BudgetObservation{{
+		AuthID: "a1", Kind: BudgetKindWindow, Remaining: &zero, RecoverAt: recoverAt,
+	}}, BudgetApplyConfig{Now: func() time.Time { return now }})
+	if !auth.Unavailable || !auth.Quota.Exceeded {
+		t.Fatalf("window remaining=0 must park: %+v", auth.Quota)
+	}
+	if !auth.Quota.NextRecoverAt.Equal(recoverAt) {
+		t.Fatalf("recover = %v, want %v", auth.Quota.NextRecoverAt, recoverAt)
+	}
+	if auth.Quota.Reason != "budget:window" {
+		t.Fatalf("reason = %q", auth.Quota.Reason)
+	}
+}
+
+func TestApplyBudgetObservations_BalanceZeroUsesRecheck(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	auth := &Auth{ID: "ds"}
+	ApplyBudgetObservations([]*Auth{auth}, []BudgetObservation{{
+		AuthID: "ds", Kind: BudgetKindBalance, Amount: "0", Currency: "CNY",
+	}}, BudgetApplyConfig{Now: func() time.Time { return now }, Recheck: 5 * time.Minute})
+	if !auth.Quota.Exceeded || auth.Quota.Reason != "budget:balance" {
+		t.Fatalf("quota = %+v", auth.Quota)
+	}
+	if !auth.Quota.NextRecoverAt.Equal(now.Add(5 * time.Minute)) {
+		t.Fatalf("recheck until = %v", auth.Quota.NextRecoverAt)
+	}
+}
+
+func TestApplyBudgetObservations_UnparseableAndAbsenceFailOpen(t *testing.T) {
+	auth := &Auth{ID: "a1"}
+	ApplyBudgetObservations([]*Auth{auth}, []BudgetObservation{{
+		AuthID: "a1", Kind: BudgetKindBalance, Amount: "n/a",
+	}}, BudgetApplyConfig{})
+	if auth.Quota.Exceeded || auth.Unavailable {
+		t.Fatalf("unparseable amount must not park: %+v", auth.Quota)
+	}
+	ApplyBudgetObservations([]*Auth{auth}, []BudgetObservation{{
+		AuthID: "missing", Kind: BudgetKindWindow,
+	}}, BudgetApplyConfig{})
+	if auth.Quota.Exceeded {
+		t.Fatal("unknown auth id must be ignored")
+	}
+}
+
+func TestApplyBudgetObservations_PositiveRemainingStaysEligible(t *testing.T) {
+	half := 0.5
+	auth := &Auth{ID: "a1"}
+	ApplyBudgetObservations([]*Auth{auth}, []BudgetObservation{{
+		AuthID: "a1", Kind: BudgetKindWindow, Remaining: &half,
+	}}, BudgetApplyConfig{})
+	if auth.Quota.Exceeded {
+		t.Fatal("remaining 0.5 must stay eligible")
+	}
+}
+
+func TestApplyBudgetObservations_UnavailableBalanceParks(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	avail := false
+	auth := &Auth{ID: "ds"}
+	ApplyBudgetObservations([]*Auth{auth}, []BudgetObservation{{
+		AuthID: "ds", Kind: BudgetKindBalance, Amount: "12", Available: &avail,
+	}}, BudgetApplyConfig{Now: func() time.Time { return now }, Recheck: time.Minute})
+	if !auth.Quota.Exceeded {
+		t.Fatal("is_available=false must park")
+	}
+}

--- a/sdk/cliproxy/auth/budget_supplier_test.go
+++ b/sdk/cliproxy/auth/budget_supplier_test.go
@@ -19,8 +19,12 @@ func TestApplyBudgetObservations_WindowExhaustedUntilRecoverAt(t *testing.T) {
 	if !auth.Quota.NextRecoverAt.Equal(recoverAt) {
 		t.Fatalf("recover = %v, want %v", auth.Quota.NextRecoverAt, recoverAt)
 	}
-	if auth.Quota.Reason != "budget:window" {
+	if auth.Quota.Reason != "credential_quota" {
 		t.Fatalf("reason = %q", auth.Quota.Reason)
+	}
+	blocked, _, until := isAuthBlockedForModel(auth, "", now)
+	if !blocked || !until.Equal(recoverAt) {
+		t.Fatalf("conductor must treat the park as credential-wide: blocked=%v until=%v", blocked, until)
 	}
 }
 
@@ -30,7 +34,7 @@ func TestApplyBudgetObservations_BalanceZeroUsesRecheck(t *testing.T) {
 	ApplyBudgetObservations([]*Auth{auth}, []BudgetObservation{{
 		AuthID: "ds", Kind: BudgetKindBalance, Amount: "0", Currency: "CNY",
 	}}, BudgetApplyConfig{Now: func() time.Time { return now }, Recheck: 5 * time.Minute})
-	if !auth.Quota.Exceeded || auth.Quota.Reason != "budget:balance" {
+	if !auth.Quota.Exceeded || auth.Quota.Reason != "credential_quota" {
 		t.Fatalf("quota = %+v", auth.Quota)
 	}
 	if !auth.Quota.NextRecoverAt.Equal(now.Add(5 * time.Minute)) {
@@ -62,6 +66,30 @@ func TestApplyBudgetObservations_PositiveRemainingStaysEligible(t *testing.T) {
 	}}, BudgetApplyConfig{})
 	if auth.Quota.Exceeded {
 		t.Fatal("remaining 0.5 must stay eligible")
+	}
+}
+
+func TestApplyBudgetObservations_ClearsWhenRecovered(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	auth := &Auth{ID: "a1", Unavailable: true, Quota: QuotaState{Exceeded: true, Reason: "credential_quota", NextRecoverAt: now.Add(time.Hour)}}
+	half := 0.5
+	ApplyBudgetObservations([]*Auth{auth}, []BudgetObservation{{
+		AuthID: "a1", Kind: BudgetKindWindow, Remaining: &half,
+	}}, BudgetApplyConfig{Now: func() time.Time { return now }})
+	if auth.Quota.Exceeded || auth.Unavailable {
+		t.Fatalf("recovered observation must unpark: %+v", auth.Quota)
+	}
+}
+
+func TestApplyBudgetObservations_PastRecoverAtFailsOpen(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	zero := 0.0
+	auth := &Auth{ID: "a1"}
+	ApplyBudgetObservations([]*Auth{auth}, []BudgetObservation{{
+		AuthID: "a1", Kind: BudgetKindWindow, Remaining: &zero, RecoverAt: now.Add(-time.Minute),
+	}}, BudgetApplyConfig{Now: func() time.Time { return now }})
+	if auth.Quota.Exceeded {
+		t.Fatal("stale window remaining after reset must not park")
 	}
 }
 

--- a/sdk/cliproxy/auth/budget_supplier_test.go
+++ b/sdk/cliproxy/auth/budget_supplier_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -19,7 +21,7 @@ func TestApplyBudgetObservations_WindowExhaustedUntilRecoverAt(t *testing.T) {
 	if !auth.Quota.NextRecoverAt.Equal(recoverAt) {
 		t.Fatalf("recover = %v, want %v", auth.Quota.NextRecoverAt, recoverAt)
 	}
-	if auth.Quota.Reason != "credential_quota" {
+	if auth.Quota.Reason != "budget:window" {
 		t.Fatalf("reason = %q", auth.Quota.Reason)
 	}
 	blocked, _, until := isAuthBlockedForModel(auth, "", now)
@@ -34,7 +36,7 @@ func TestApplyBudgetObservations_BalanceZeroUsesRecheck(t *testing.T) {
 	ApplyBudgetObservations([]*Auth{auth}, []BudgetObservation{{
 		AuthID: "ds", Kind: BudgetKindBalance, Amount: "0", Currency: "CNY",
 	}}, BudgetApplyConfig{Now: func() time.Time { return now }, Recheck: 5 * time.Minute})
-	if !auth.Quota.Exceeded || auth.Quota.Reason != "credential_quota" {
+	if !auth.Quota.Exceeded || auth.Quota.Reason != "budget:balance" {
 		t.Fatalf("quota = %+v", auth.Quota)
 	}
 	if !auth.Quota.NextRecoverAt.Equal(now.Add(5 * time.Minute)) {
@@ -71,7 +73,7 @@ func TestApplyBudgetObservations_PositiveRemainingStaysEligible(t *testing.T) {
 
 func TestApplyBudgetObservations_ClearsWhenRecovered(t *testing.T) {
 	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
-	auth := &Auth{ID: "a1", Unavailable: true, Quota: QuotaState{Exceeded: true, Reason: "credential_quota", NextRecoverAt: now.Add(time.Hour)}}
+	auth := &Auth{ID: "a1", Unavailable: true, Quota: QuotaState{Exceeded: true, Reason: "budget:window", NextRecoverAt: now.Add(time.Hour)}}
 	half := 0.5
 	ApplyBudgetObservations([]*Auth{auth}, []BudgetObservation{{
 		AuthID: "a1", Kind: BudgetKindWindow, Remaining: &half,
@@ -90,6 +92,46 @@ func TestApplyBudgetObservations_PastRecoverAtFailsOpen(t *testing.T) {
 	}}, BudgetApplyConfig{Now: func() time.Time { return now }})
 	if auth.Quota.Exceeded {
 		t.Fatal("stale window remaining after reset must not park")
+	}
+}
+
+type snapshotSupplier struct {
+	obs []BudgetObservation
+	err error
+	n   int
+}
+
+func (s *snapshotSupplier) Snapshot(context.Context) ([]BudgetObservation, error) {
+	s.n++
+	return s.obs, s.err
+}
+
+func TestApplyBudgetSupplier_CallsSnapshot(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	zero := 0.0
+	auth := &Auth{ID: "a1"}
+	sup := &snapshotSupplier{obs: []BudgetObservation{{
+		AuthID: "a1", Kind: BudgetKindWindow, Remaining: &zero, RecoverAt: now.Add(time.Hour),
+	}}}
+	if err := ApplyBudgetSupplier(context.Background(), []*Auth{auth}, sup, BudgetApplyConfig{Now: func() time.Time { return now }}); err != nil {
+		t.Fatalf("ApplyBudgetSupplier: %v", err)
+	}
+	if sup.n != 1 {
+		t.Fatalf("Snapshot called %d times, want 1", sup.n)
+	}
+	if auth.Quota.Reason != "budget:window" || !auth.Quota.Exceeded {
+		t.Fatalf("quota = %+v", auth.Quota)
+	}
+}
+
+func TestApplyBudgetSupplier_SnapshotErrorFailsOpen(t *testing.T) {
+	auth := &Auth{ID: "a1"}
+	sup := &snapshotSupplier{err: errors.New("collector down")}
+	if err := ApplyBudgetSupplier(context.Background(), []*Auth{auth}, sup, BudgetApplyConfig{}); err == nil {
+		t.Fatal("expected snapshot error")
+	}
+	if auth.Quota.Exceeded {
+		t.Fatal("snapshot error must leave auth eligible")
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -731,7 +731,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 		}
 
 		if result.Success {
-			if auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
+			if isCredentialWideQuotaReason(auth.Quota.Reason) && auth.Quota.NextRecoverAt.After(now) {
 				// Retain active credential-scoped cooldown
 			} else if modelKey != "" {
 				state := ensureModelState(auth, modelKey)
@@ -1128,7 +1128,7 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 	if auth == nil {
 		return
 	}
-	if auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
+	if auth.Quota.Exceeded && isCredentialWideQuotaReason(auth.Quota.Reason) && auth.Quota.NextRecoverAt.After(now) {
 		auth.Unavailable = true
 		return
 	}

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -125,7 +125,7 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 		if len(auth.ModelStates) == 0 && len(existing.ModelStates) > 0 {
 			auth.ModelStates = existing.ModelStates
 		}
-		if existing.Quota.Exceeded && existing.Quota.Reason == "credential_quota" && existing.Quota.NextRecoverAt.After(time.Now()) {
+		if existing.Quota.Exceeded && isCredentialWideQuotaReason(existing.Quota.Reason) && existing.Quota.NextRecoverAt.After(time.Now()) {
 			auth.Unavailable = existing.Unavailable
 			auth.NextRetryAfter = existing.NextRetryAfter
 			auth.Quota = existing.Quota

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -541,7 +541,7 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	if auth.Disabled || auth.Status == StatusDisabled {
 		return true, blockReasonDisabled, time.Time{}
 	}
-	if auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
+	if auth.Quota.Exceeded && isCredentialWideQuotaReason(auth.Quota.Reason) && auth.Quota.NextRecoverAt.After(now) {
 		return true, blockReasonCooldown, auth.Quota.NextRecoverAt
 	}
 	if model != "" {


### PR DESCRIPTION
Fixes #5034.

Sketch + tests for a host-owned `BudgetSupplier` seam:

- Per-auth remaining (fraction or prepaid amount) + optional `RecoverAt`.
- Exhausted → ineligible until recovery, or until the next supplier refresh when there is no clock.
- Does **not** require hosts to set `Result.CredentialScope` (wrong tool for prepaid \$ and non-Anthropic windows).

Built-in DeepSeek / Zhipu pollers can adopt this later; this PR only lands the interface and `ApplyBudgetObservations`.