### PR TITLE
test(claude): regression coverage for X-Claude-Code-Agent-Id relay

### DIFF
--- a/internal/runtime/executor/claude_executor_agent_id_relay_test.go
+++ b/internal/runtime/executor/claude_executor_agent_id_relay_test.go
@@ -1,0 +1,135 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func newClaudeCustomUpstreamHeaderTestRequest(t *testing.T) *http.Request {
+	t.Helper()
+	return httptest.NewRequest(http.MethodPost, "https://gateway.example.com/v1/messages", nil)
+}
+
+// A chained CPA scopes execution state per (session, agent). Dropping the agent
+// header on relay collapsed every Claude Code subagent into the downstream
+// main-agent scope.
+func TestApplyClaudeHeaders_RelaysAgentIDToCustomUpstream(t *testing.T) {
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-agent-relay"}}
+	for _, confirmed := range []bool{false, true} {
+		incoming := http.Header{}
+		incoming.Set(helps.ClaudeCodeAgentHeader, "subagent-42")
+
+		req := newClaudeCustomUpstreamHeaderTestRequest(t)
+		if err := applyClaudeHeaders(req, auth, "key-agent-relay", false, nil,
+			[]byte(`{"model":"claude-opus-5"}`), nil, incoming, confirmed); err != nil {
+			t.Fatalf("applyClaudeHeaders(confirmed=%v) error = %v", confirmed, err)
+		}
+		if got := req.Header.Get(helps.ClaudeCodeAgentHeader); got != "subagent-42" {
+			t.Fatalf("confirmed=%v: %s = %q, want relayed subagent-42", confirmed, helps.ClaudeCodeAgentHeader, got)
+		}
+	}
+}
+
+// The client only sends the header for subagents; the relay must not fabricate
+// one (not even the "main" sentinel) when the caller omitted it.
+func TestApplyClaudeHeaders_NoAgentIDFabricatedWhenAbsent(t *testing.T) {
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-agent-absent"}}
+	req := newClaudeCustomUpstreamHeaderTestRequest(t)
+	if err := applyClaudeHeaders(req, auth, "key-agent-absent", false, nil,
+		[]byte(`{"model":"claude-opus-5"}`), nil, http.Header{}, false); err != nil {
+		t.Fatalf("applyClaudeHeaders() error = %v", err)
+	}
+	if got, ok := req.Header[helps.ClaudeCodeAgentHeader]; ok {
+		t.Fatalf("%s = %q, want the header absent", helps.ClaudeCodeAgentHeader, got)
+	}
+}
+
+// wsrelay and Home dispatch reconstruct header maps by hand, so the incoming
+// key may not be in Go's canonical form.
+func TestApplyClaudeHeaders_AgentIDRelayIsCaseInsensitive(t *testing.T) {
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-agent-case"}}
+	incoming := http.Header{"x-claude-code-agent-id": []string{"lower-agent"}}
+
+	req := newClaudeCustomUpstreamHeaderTestRequest(t)
+	if err := applyClaudeHeaders(req, auth, "key-agent-case", false, nil,
+		[]byte(`{"model":"claude-opus-5"}`), nil, incoming, false); err != nil {
+		t.Fatalf("applyClaudeHeaders() error = %v", err)
+	}
+	if got := req.Header.Get(helps.ClaudeCodeAgentHeader); got != "lower-agent" {
+		t.Fatalf("%s = %q, want relayed lower-agent", helps.ClaudeCodeAgentHeader, got)
+	}
+}
+
+// The native client sends the agent header to api.anthropic.com itself, so
+// relaying it there preserves the measured header set instead of altering it.
+// Absence still stays absence on the same upstream.
+func TestApplyClaudeHeaders_AgentIDRelayedOnDirectAnthropic(t *testing.T) {
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-agent-anthropic"}}
+	for _, confirmed := range []bool{false, true} {
+		incoming := http.Header{}
+		incoming.Set(helps.ClaudeCodeAgentHeader, "subagent-42")
+
+		req := newClaudeHeaderTestRequest(t, incoming)
+		if err := applyClaudeHeaders(req, auth, "key-agent-anthropic", false, nil,
+			[]byte(`{"model":"claude-opus-5"}`), nil, incoming, confirmed); err != nil {
+			t.Fatalf("applyClaudeHeaders(confirmed=%v) error = %v", confirmed, err)
+		}
+		if got := req.Header.Get(helps.ClaudeCodeAgentHeader); got != "subagent-42" {
+			t.Fatalf("confirmed=%v: %s = %q, want relayed subagent-42", confirmed, helps.ClaudeCodeAgentHeader, got)
+		}
+
+		bare := http.Header{}
+		bareReq := newClaudeHeaderTestRequest(t, bare)
+		if err := applyClaudeHeaders(bareReq, auth, "key-agent-anthropic", false, nil,
+			[]byte(`{"model":"claude-opus-5"}`), nil, bare, confirmed); err != nil {
+			t.Fatalf("applyClaudeHeaders(confirmed=%v, no agent) error = %v", confirmed, err)
+		}
+		if got, ok := bareReq.Header[helps.ClaudeCodeAgentHeader]; ok {
+			t.Fatalf("confirmed=%v: %s = %q, want the header absent when the caller sent none", confirmed, helps.ClaudeCodeAgentHeader, got)
+		}
+	}
+}
+
+// End to end through Execute: the incoming header travels from Options.Headers
+// to the custom upstream request.
+func TestClaudeExecutor_AgentIDReachesCustomUpstream(t *testing.T) {
+	var upstreamHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHeaders = r.Header.Clone()
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"msg_1","type":"message","role":"assistant","model":"claude-opus-5","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID:         "claude-agent-relay-upstream",
+		Attributes: map[string]string{"api_key": "sk-ant-oat-agent-relay", "base_url": server.URL},
+		Metadata:   claudeOAuthTestMetadata(),
+	}
+	incoming := http.Header{}
+	incoming.Set(helps.ClaudeCodeAgentHeader, "subagent-42")
+	payload := []byte(`{"model":"claude-opus-5","system":"p","messages":[{"role":"user","content":"hi"}]}`)
+
+	if _, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-opus-5",
+		Payload: bytes.Clone(payload),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude, Headers: incoming}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := upstreamHeaders.Get(helps.ClaudeCodeAgentHeader); got != "subagent-42" {
+		t.Fatalf("upstream %s = %q, want subagent-42", helps.ClaudeCodeAgentHeader, got)
+	}
+}

--- a/internal/runtime/executor/helps/claude_code_session_test.go
+++ b/internal/runtime/executor/helps/claude_code_session_test.go
@@ -72,6 +72,23 @@ func TestClaudeCodeExecutionScopeAcceptsLowercaseHeaderMapKeys(t *testing.T) {
 	}
 }
 
+// Relay paths read the agent header raw so an absent header stays absent; the
+// "main" sentinel must stay confined to ExtractClaudeCodeAgentID, which scopes
+// execution state and needs a value for the root agent.
+func TestClaudeCodeAgentIDHeaderLookupKeepsAbsenceRaw(t *testing.T) {
+	if got := HeaderValueCaseInsensitive(http.Header{}, ClaudeCodeAgentHeader); got != "" {
+		t.Fatalf("HeaderValueCaseInsensitive(absent) = %q, want empty", got)
+	}
+	headers := http.Header{}
+	headers.Set(ClaudeCodeAgentHeader, "agent-raw")
+	if got := HeaderValueCaseInsensitive(headers, ClaudeCodeAgentHeader); got != "agent-raw" {
+		t.Fatalf("HeaderValueCaseInsensitive() = %q, want agent-raw", got)
+	}
+	if got := ExtractClaudeCodeAgentID(context.Background(), http.Header{}); got != ClaudeCodeMainAgentID {
+		t.Fatalf("ExtractClaudeCodeAgentID(absent) = %q, want %q", got, ClaudeCodeMainAgentID)
+	}
+}
+
 func TestClaudeCodeExecutionScopeIsolatesAgents(t *testing.T) {
 	rootHeaders := http.Header{}
 	rootHeaders.Set(ClaudeCodeSessionHeader, "session-agents")


### PR DESCRIPTION
`dev` already contains `85d2fadd` (`fix(claude): preserve native subagent and environment headers`), which relays `X-Claude-Code-Agent-Id` (plus parent/container/session/client-app headers) as a strict superset of this PR's original source change.

This branch is therefore **tests only**: rebase onto current `dev`, drop the duplicate source path, and keep regression coverage that `applyClaudeHeaders` still relays a caller-supplied agent id (including lowercase keys, confirmed/unconfirmed clients, and a non-cloaked credential). Upstream's own test only exercises `Execute` with `cloak_mode: always`.

One semantic note: the original patch skipped the relay on direct `api.anthropic.com`; upstream relays unconditionally. This PR follows upstream, because native Claude Code already sends the header there for subagent traffic.

Related: original intent of #5042 / #4982.