### PR TITLE
fix(websocket): drop consumed compaction triggers

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_websocket_requests.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_requests.go
@@ -344,6 +344,11 @@ func mergeResponsesWebsocketInput(lastRequest []byte, lastResponseOutput []byte,
 	trimmedResponse := bytes.TrimSpace(lastResponseOutput)
 	if len(trimmedResponse) > 0 && trimmedResponse[0] == '[' && json.Valid(trimmedResponse) {
 		responseInput := util.ParseGJSONBytesNoCopy(trimmedResponse)
+		if inputContainsFullTranscript(responseInput) {
+			items = slices.DeleteFunc(items, func(item responsesWebsocketMergeInputItem) bool {
+				return item.itemType == "compaction_trigger"
+			})
+		}
 		var errResponse error
 		items, errResponse = appendResponsesWebsocketMergeInputResult(items, responseInput)
 		if errResponse != nil {

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -5707,6 +5707,40 @@ func TestNormalizeSubsequentRequestCompactMergesWhenCompactionReplayUnsupported(
 	}
 }
 
+func TestNormalizeSubsequentRequestDropsConsumedCompactionTrigger(t *testing.T) {
+	lastRequest := []byte(`{"model":"gpt-5.6-sol","stream":true,"input":[
+		{"type":"message","role":"user","id":"msg-old","content":"old prompt"}
+	]}`)
+	triggerRequest := []byte(`{"type":"response.create","previous_response_id":"resp-before-compact","input":[
+		{"type":"message","role":"user","id":"msg-tool-output","content":"done"},
+		{"type":"compaction_trigger"}
+	]}`)
+
+	_, stateAfterTrigger, errMsg := normalizeResponsesWebsocketRequestWithMode(triggerRequest, lastRequest, nil, false, false)
+	if errMsg != nil {
+		t.Fatalf("normalize trigger request: %v", errMsg.Error)
+	}
+
+	compactionOutput := []byte(`[
+		{"type":"compaction","id":"cmp-1","encrypted_content":"opaque"}
+	]`)
+	replayRequest := []byte(`{"type":"response.create","input":[
+		{"type":"message","role":"developer","id":"msg-new-context","content":"new context"},
+		{"type":"compaction","id":"cmp-1","encrypted_content":"opaque"},
+		{"type":"message","role":"user","id":"msg-next","content":"continue"}
+	]}`)
+
+	normalized, _, errMsg := normalizeResponsesWebsocketRequestWithMode(replayRequest, stateAfterTrigger, compactionOutput, false, false)
+	if errMsg != nil {
+		t.Fatalf("normalize compact replay: %v", errMsg.Error)
+	}
+	for _, item := range gjson.GetBytes(normalized, "input").Array() {
+		if item.Get("type").String() == "compaction_trigger" {
+			t.Fatalf("consumed compaction_trigger was replayed: %s", normalized)
+		}
+	}
+}
+
 func TestNormalizeSubsequentRequestIncrementalInputStillMerges(t *testing.T) {
 	// Normal incremental flow: user sends function_call_output (no assistant message).
 	lastRequest := []byte(`{"model":"gpt-5.4","stream":true,"input":[


### PR DESCRIPTION
## Summary

- After remote compaction succeeds, the normalized previous request still contains the consumed `compaction_trigger`. The next WebSocket-to-HTTP merge replays that trigger before the `compaction` output and current input, causing the upstream 400 error.
- Remove `compaction_trigger` only from previous request items when the previous response contains `compaction` or `compaction_summary`.
- Add a two-step regression test covering trigger normalization followed by compact replay.
- Normal requests and compaction triggers that have not yet been consumed are unaffected.

## Test plan

- [x] Focused regression test
- [x] Focused regression test with `-race`
- [x] Full `sdk/api/handlers/openai` package tests
- [x] `go vet ./sdk/api/handlers/openai`
- [x] `go build -buildvcs=false ./cmd/server`
- [x] `git diff --check`

Fixes #5041
