### PR TITLE
fix(antigravity): obfuscate Claude Agent SDK fingerprint

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -262,7 +262,9 @@ codex:
 
 # Antigravity provider behavior.
 # antigravity:
-#   sensitive-words:             # optional: words to obfuscate with zero-width characters in system instructions
+#   # Additional words to obfuscate with zero-width characters in system instructions.
+#   # Known Antigravity fingerprints, such as "Claude Agent SDK", are protected automatically.
+#   sensitive-words:
 #     - "API"
 #     - "proxy"
 

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -139,7 +139,8 @@ type XAIConfig struct {
 
 // AntigravityConfig configures provider-wide Antigravity request behavior.
 type AntigravityConfig struct {
-	// SensitiveWords is a list of words to obfuscate with zero-width characters in system instructions.
+	// SensitiveWords is an additional list of words to obfuscate with zero-width characters in system instructions.
+	// Built-in Antigravity fingerprints are always obfuscated.
 	SensitiveWords []string `yaml:"sensitive-words,omitempty" json:"sensitive-words,omitempty"`
 }
 

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -44,6 +44,7 @@ const (
 	antigravityCreditsHintRefreshTimeout   = 5 * time.Second
 	antigravityShortQuotaCooldownThreshold = 5 * time.Minute
 	antigravityInstantRetryThreshold       = 3 * time.Second
+	antigravityClaudeAgentSDKFingerprint   = "Claude Agent SDK"
 	// systemInstruction              = "You are Antigravity, a powerful agentic AI coding assistant designed by the Google Deepmind team working on Advanced Agentic Coding.You are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.**Absolute paths only****Proactiveness**"
 )
 
@@ -64,10 +65,11 @@ func NewAntigravityExecutor(cfg *config.Config) *AntigravityExecutor {
 }
 
 func (e *AntigravityExecutor) obfuscateSensitiveWords(payload []byte) []byte {
-	if e == nil || e.cfg == nil || len(e.cfg.Antigravity.SensitiveWords) == 0 {
-		return payload
+	words := []string{antigravityClaudeAgentSDKFingerprint}
+	if e != nil && e.cfg != nil {
+		words = append(words, e.cfg.Antigravity.SensitiveWords...)
 	}
-	matcher := helps.BuildSensitiveWordMatcher(e.cfg.Antigravity.SensitiveWords)
+	matcher := helps.BuildSensitiveWordMatcher(words)
 	return helps.ObfuscateSensitiveWordsInSystemInstruction(payload, matcher)
 }
 

--- a/internal/runtime/executor/antigravity_executor_signature_test.go
+++ b/internal/runtime/executor/antigravity_executor_signature_test.go
@@ -145,18 +145,95 @@ func TestSanitizeAntigravityGeminiRequestSignaturesFinalizesParallelCalls(t *tes
 	}
 }
 
-func TestAntigravitySensitiveWordsObfuscatesSystemInstructionOnly(t *testing.T) {
+func TestAntigravityBuiltInClaudeAgentSDKFingerprintObfuscatesSystemInstructionOnly(t *testing.T) {
+	executor := NewAntigravityExecutor(&config.Config{})
+	payload := []byte(`{"request":{"systemInstruction":{"parts":[{"text":"You are a Claude agent, built on Anthropic's Claude Agent SDK."}]},"contents":[{"role":"user","parts":[{"text":"Claude Agent SDK remains unchanged in user content"}]}]}}`)
+
+	got := executor.obfuscateSensitiveWords(payload)
+	wantSystem := "You are a Claude agent, built on Anthropic's C\u200Blaude Agent SDK."
+	if systemText := gjson.GetBytes(got, "request.systemInstruction.parts.0.text").String(); systemText != wantSystem {
+		t.Fatalf("system instruction = %q, want %q; payload=%s", systemText, wantSystem, got)
+	}
+	wantContent := "Claude Agent SDK remains unchanged in user content"
+	if contentText := gjson.GetBytes(got, "request.contents.0.parts.0.text").String(); contentText != wantContent {
+		t.Fatalf("content text = %q, want unchanged %q", contentText, wantContent)
+	}
+}
+
+func TestAntigravityConfiguredSensitiveWordsAreAdditiveToBuiltIns(t *testing.T) {
 	executor := NewAntigravityExecutor(&config.Config{
 		Antigravity: config.AntigravityConfig{SensitiveWords: []string{"proxy"}},
 	})
-	payload := []byte(`{"request":{"systemInstruction":{"parts":[{"text":"Use proxy safely"}]},"contents":[{"role":"user","parts":[{"text":"proxy remains unchanged"}]}]}}`)
+	payload := []byte(`{"request":{"systemInstruction":{"parts":[{"text":"Use proxy with Claude Agent SDK"}]},"contents":[{"role":"user","parts":[{"text":"proxy and Claude Agent SDK remain unchanged"}]}]}}`)
 
 	got := executor.obfuscateSensitiveWords(payload)
-	if systemText := gjson.GetBytes(got, "request.systemInstruction.parts.0.text").String(); systemText != "Use p\u200Broxy safely" {
-		t.Fatalf("system instruction = %q, want zero-width obfuscation", systemText)
+	wantSystem := "Use p\u200Broxy with C\u200Blaude Agent SDK"
+	if systemText := gjson.GetBytes(got, "request.systemInstruction.parts.0.text").String(); systemText != wantSystem {
+		t.Fatalf("system instruction = %q, want %q", systemText, wantSystem)
 	}
-	if contentText := gjson.GetBytes(got, "request.contents.0.parts.0.text").String(); contentText != "proxy remains unchanged" {
-		t.Fatalf("content text = %q, want unchanged", contentText)
+	wantContent := "proxy and Claude Agent SDK remain unchanged"
+	if contentText := gjson.GetBytes(got, "request.contents.0.parts.0.text").String(); contentText != wantContent {
+		t.Fatalf("content text = %q, want unchanged %q", contentText, wantContent)
+	}
+}
+
+func TestAntigravityStreamObfuscatesBuiltInClaudeAgentSDKFingerprint(t *testing.T) {
+	captured := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		captured <- body
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewAntigravityExecutor(&config.Config{RequestRetry: 1})
+	payload := []byte(`{"model":"gemini-3.7-flash-high","system":[{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.234; cc_entrypoint=sdk-cli;"},{"type":"text","text":"You are a Claude agent, built on Anthropic's Claude Agent SDK."},{"type":"text","text":"User-provided system instruction"}],"messages":[{"role":"user","content":"hello"}],"tools":[{"name":"Echo","description":"Echo a value","input_schema":{"type":"object","properties":{"value":{"type":"string"}},"required":["value"]}}],"max_tokens":64,"stream":true}`)
+	result, errExecute := executor.ExecuteStream(context.Background(), &cliproxyauth.Auth{
+		Metadata: map[string]any{
+			"access_token": "token-123",
+			"expired":      time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+			"project_id":   "project-1",
+		},
+		Attributes: map[string]string{"base_url": server.URL},
+	}, cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash-high",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FormatClaude,
+		ResponseFormat:  sdktranslator.FormatClaude,
+		OriginalRequest: payload,
+		Stream:          true,
+	})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+	}
+
+	body := <-captured
+	wantIdentity := "You are a Claude agent, built on Anthropic's C\u200Blaude Agent SDK."
+	if got := gjson.GetBytes(body, "request.systemInstruction.parts.0.text").String(); got != wantIdentity {
+		t.Fatalf("identity system instruction = %q, want %q; body=%s", got, wantIdentity, body)
+	}
+	if got := gjson.GetBytes(body, "request.systemInstruction.parts.1.text").String(); got != "User-provided system instruction" {
+		t.Fatalf("caller system instruction = %q, want unchanged; body=%s", got, body)
+	}
+	if got := gjson.GetBytes(body, "request.contents.0.parts.0.text").String(); got != "hello" {
+		t.Fatalf("user content = %q, want unchanged; body=%s", got, body)
+	}
+	if got := gjson.GetBytes(body, "request.tools.0.functionDeclarations.0.name").String(); got != "Echo" {
+		t.Fatalf("tool name = %q, want unchanged; body=%s", got, body)
+	}
+	if strings.Contains(string(body), "x-anthropic-billing-header:") {
+		t.Fatalf("billing attribution reached Antigravity: %s", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

- treat `Claude Agent SDK` as a built-in Antigravity system-instruction fingerprint
- keep operator-defined `antigravity.sensitive-words` additive to the built-in rule
- preserve user message content and translated tool declarations
- document that configured sensitive words supplement built-in fingerprints

## Root cause

Claude Code print/Agent-SDK mode includes this system identity:

```text
You are a Claude agent, built on Anthropic's Claude Agent SDK.
```

Antigravity returns `429 RESOURCE_EXHAUSTED` when that phrase reaches the upstream request unchanged. Request-level A/B testing showed that changing only this identity reverses the result in both directions, and inserting a zero-width space into `Claude Agent SDK` changes the failing request from HTTP 429 to HTTP 200.

The existing Antigravity sensitive-word mechanism already performs the required system-instruction-only obfuscation, but it currently runs only for operator-configured words. This change adds the confirmed fingerprint to the effective matcher by default.

## Tests

- [x] New regression tests failed before the production change
- [x] Built-in fingerprint is obfuscated with empty Antigravity config
- [x] Configured sensitive words remain additive
- [x] Claude-to-Antigravity stream path strips billing attribution and preserves caller system text, user content, and tool declarations
- [x] `go test ./internal/runtime/executor -run 'TestAntigravity' -count=1`
- [x] `go test ./internal/config -count=1`
- [x] `go vet ./internal/runtime/executor ./internal/config`
- [x] `go build -o /tmp/cli-proxy-api ./cmd/server`
- [x] Live Docker image built from this branch: Claude Code `2.1.234` print mode with `gemini-3.7-flash-high` returned the exact requested marker, HTTP 200, zero retry events, and no 429 without configuring `antigravity.sensitive-words`

`go test ./... -count=1` reaches only three pre-existing failures in Claude header fingerprint tests (`MacOS` observed versus `Linux` expected). The same three tests fail identically on a clean `origin/main` checkout; all other packages pass.

## Scope and risk

The mutation is limited to Antigravity `request.systemInstruction`. User messages, tool schemas, and requests to other providers are unchanged. Existing operator-configured sensitive words continue to apply.

Closes #5037
