### PR TITLE
fix(auth): restrict OAuth credential file permissions

### DIFF
--- a/internal/auth/claude/token.go
+++ b/internal/auth/claude/token.go
@@ -86,7 +86,7 @@ func (ts *ClaudeTokenStorage) SaveTokenToFile(authFilePath string) error {
 	}
 
 	// Create the token file
-	f, err := os.Create(authFilePath)
+	f, err := os.OpenFile(authFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}
@@ -95,6 +95,9 @@ func (ts *ClaudeTokenStorage) SaveTokenToFile(authFilePath string) error {
 			log.Errorf("claude token storage: close token file error: %v", errClose)
 		}
 	}()
+	if errChmod := f.Chmod(0o600); errChmod != nil {
+		return fmt.Errorf("failed to restrict token file permissions: %w", errChmod)
+	}
 
 	// Encode and write the token data as JSON
 	if err = json.NewEncoder(f).Encode(data); err != nil {

--- a/internal/auth/codex/token.go
+++ b/internal/auth/codex/token.go
@@ -67,7 +67,7 @@ func (ts *CodexTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("failed to merge metadata: %w", errMerge)
 	}
 
-	f, err := os.Create(authFilePath)
+	f, err := os.OpenFile(authFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}
@@ -76,6 +76,9 @@ func (ts *CodexTokenStorage) SaveTokenToFile(authFilePath string) error {
 			log.Errorf("codex token storage: close token file error: %v", errClose)
 		}
 	}()
+	if errChmod := f.Chmod(0o600); errChmod != nil {
+		return fmt.Errorf("failed to restrict token file permissions: %w", errChmod)
+	}
 
 	if err = json.NewEncoder(f).Encode(data); err != nil {
 		return fmt.Errorf("failed to write token to file: %w", err)

--- a/internal/auth/kimi/token.go
+++ b/internal/auth/kimi/token.go
@@ -94,7 +94,7 @@ func (ts *KimiTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("failed to merge metadata: %w", errMerge)
 	}
 
-	f, err := os.Create(authFilePath)
+	f, err := os.OpenFile(authFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}
@@ -103,6 +103,9 @@ func (ts *KimiTokenStorage) SaveTokenToFile(authFilePath string) error {
 			log.Errorf("kimi token storage: close token file error: %v", errClose)
 		}
 	}()
+	if errChmod := f.Chmod(0o600); errChmod != nil {
+		return fmt.Errorf("failed to restrict token file permissions: %w", errChmod)
+	}
 
 	encoder := json.NewEncoder(f)
 	encoder.SetIndent("", "  ")

--- a/internal/auth/oauth_file_permissions_test.go
+++ b/internal/auth/oauth_file_permissions_test.go
@@ -1,0 +1,80 @@
+package auth_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/claude"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/kimi"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/vertex"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/xai"
+)
+
+type tokenFileSaver interface {
+	SaveTokenToFile(string) error
+}
+
+func TestTokenStorageSaveRestrictsFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose Unix file permissions")
+	}
+
+	tests := []struct {
+		name    string
+		storage tokenFileSaver
+	}{
+		{
+			name: "claude",
+			storage: &claude.ClaudeTokenStorage{
+				AccessToken: "access-token", RefreshToken: "refresh-token",
+			},
+		},
+		{
+			name: "codex",
+			storage: &codex.CodexTokenStorage{
+				AccessToken: "access-token", RefreshToken: "refresh-token",
+			},
+		},
+		{
+			name: "kimi",
+			storage: &kimi.KimiTokenStorage{
+				AccessToken: "access-token", RefreshToken: "refresh-token",
+			},
+		},
+		{
+			name: "vertex",
+			storage: &vertex.VertexCredentialStorage{
+				ServiceAccount: map[string]any{"type": "service_account"},
+			},
+		},
+		{
+			name: "xai",
+			storage: &xai.TokenStorage{
+				AccessToken: "access-token", RefreshToken: "refresh-token",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), tt.name+".json")
+			if errWrite := os.WriteFile(path, []byte(`{"insecure":true}`), 0o644); errWrite != nil {
+				t.Fatalf("os.WriteFile() error = %v", errWrite)
+			}
+			if errSave := tt.storage.SaveTokenToFile(path); errSave != nil {
+				t.Fatalf("SaveTokenToFile() error = %v", errSave)
+			}
+
+			info, errStat := os.Stat(path)
+			if errStat != nil {
+				t.Fatalf("os.Stat() error = %v", errStat)
+			}
+			if got := info.Mode().Perm(); got != 0o600 {
+				t.Fatalf("file permissions = %o, want 600", got)
+			}
+		})
+	}
+}

--- a/internal/auth/vertex/vertex_credentials.go
+++ b/internal/auth/vertex/vertex_credentials.go
@@ -66,7 +66,7 @@ func (s *VertexCredentialStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("vertex credential: merge metadata failed: %w", errMerge)
 	}
 
-	f, err := os.Create(authFilePath)
+	f, err := os.OpenFile(authFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("vertex credential: create file failed: %w", err)
 	}
@@ -75,6 +75,9 @@ func (s *VertexCredentialStorage) SaveTokenToFile(authFilePath string) error {
 			log.Errorf("vertex credential: failed to close file: %v", errClose)
 		}
 	}()
+	if errChmod := f.Chmod(0o600); errChmod != nil {
+		return fmt.Errorf("vertex credential: restrict file permissions: %w", errChmod)
+	}
 	enc := json.NewEncoder(f)
 	enc.SetIndent("", "  ")
 	if err = enc.Encode(data); err != nil {

--- a/internal/auth/xai/token.go
+++ b/internal/auth/xai/token.go
@@ -51,7 +51,7 @@ func (ts *TokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("xai token storage: merge metadata: %w", errMerge)
 	}
 
-	file, err := os.Create(authFilePath)
+	file, err := os.OpenFile(authFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("xai token storage: create token file: %w", err)
 	}
@@ -60,6 +60,9 @@ func (ts *TokenStorage) SaveTokenToFile(authFilePath string) error {
 			log.Errorf("xai token storage: close token file error: %v", errClose)
 		}
 	}()
+	if errChmod := file.Chmod(0o600); errChmod != nil {
+		return fmt.Errorf("xai token storage: restrict token file permissions: %w", errChmod)
+	}
 
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "  ")


### PR DESCRIPTION
Fixes #5045

## Summary

- Create OAuth credential files with private `0600` permissions.
- Reapply `0600` when saving an existing credential so refreshes remediate files created by older releases.
- Cover Claude, Codex, Kimi, Vertex, and xAI token storage implementations with a shared regression test.

## Verification

- `go test ./internal/auth/...`
- `go build -o cli-proxy-api-test.exe ./cmd/server`
