### PR TITLE
feat(compat): add opt-in fallback compaction for providers without compact endpoints

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -371,6 +371,7 @@ nonstream-keepalive-interval: 0
 #           - "context_window_exceeded"
 #         action: "stop-and-cooldown"
 #     base-url: "https://www.example.com" # use the custom codex API endpoint
+#     fallback-compaction: false # optional: synthesize compact responses through /chat/completions for third-party Responses endpoints without /responses/compact
 #     alpha-search: false # optional: allow this key to serve /v1/alpha/search via base-url + /alpha/search
 #     headers:
 #       X-Custom-Header: "custom-value"
@@ -522,6 +523,7 @@ nonstream-keepalive-interval: 0
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
 #     support-prompt-cache-key: false # optional: derive prompt_cache_key for requests from all input protocols
+#     fallback-compaction: false # optional: synthesize Responses compaction through /chat/completions when the provider has no /responses/compact endpoint
 #     disable-cooling: false # optional provider override: true disables cooling, false enables it; omit to inherit global
 #     request-retry: 3 # optional: per-provider override of the global request-retry; 0 disables retries; omit or set < 0 to use the global value
 #     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -452,6 +452,10 @@ type CodexKey struct {
 	// Websockets enables the Responses API websocket transport for this credential.
 	Websockets bool `yaml:"websockets,omitempty" json:"websockets,omitempty"`
 
+	// FallbackCompaction enables local summary-based Responses compaction when
+	// the configured endpoint does not implement /responses/compact.
+	FallbackCompaction bool `yaml:"fallback-compaction,omitempty" json:"fallback-compaction,omitempty"`
+
 	// AlphaSearch allows this Codex API key to serve the Alpha Search endpoint.
 	AlphaSearch bool `yaml:"alpha-search,omitempty" json:"alpha-search,omitempty"`
 
@@ -650,6 +654,10 @@ type OpenAICompatibility struct {
 
 	// SupportPromptCacheKey enables derived prompt_cache_key injection for supported requests.
 	SupportPromptCacheKey bool `yaml:"support-prompt-cache-key,omitempty" json:"support-prompt-cache-key,omitempty"`
+
+	// FallbackCompaction enables local summary-based Responses compaction for providers
+	// that do not implement a native /responses/compact endpoint.
+	FallbackCompaction bool `yaml:"fallback-compaction,omitempty" json:"fallback-compaction,omitempty"`
 
 	// DisableCooling overrides the global cooling policy for this provider when set.
 	// True disables auth/model cooldowns; false explicitly enables them.

--- a/internal/config/fallback_compaction_test.go
+++ b/internal/config/fallback_compaction_test.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestOpenAICompatibilityFallbackCompactionYAML(t *testing.T) {
+	var cfg Config
+	err := yaml.Unmarshal([]byte(`openai-compatibility:
+  - name: deepseek
+    base-url: https://api.deepseek.com
+    fallback-compaction: true
+    models:
+      - name: deepseek-chat
+        alias: deepseek-chat
+`), &cfg)
+	if err != nil {
+		t.Fatalf("LoadConfigData: %v", err)
+	}
+	if len(cfg.OpenAICompatibility) != 1 || !cfg.OpenAICompatibility[0].FallbackCompaction {
+		t.Fatalf("fallback-compaction not loaded: %+v", cfg.OpenAICompatibility)
+	}
+}

--- a/internal/runtime/executor/codex_executor_execute.go
+++ b/internal/runtime/executor/codex_executor_execute.go
@@ -19,6 +19,17 @@ import (
 )
 
 func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	if fallback := e.codexFallbackCompactionExecutor(auth); fallback != nil {
+		fallbackAuth := codexFallbackCompactionAuth(auth, fallback)
+		if opts.Alt == "responses/compact" {
+			return fallback.executeFallbackCompaction(ctx, fallbackAuth, req, opts)
+		}
+		expanded, errExpand := fallback.expandFallbackCompactionCapsules(fallbackAuth, req.Payload)
+		if errExpand != nil {
+			return resp, statusErr{code: http.StatusBadRequest, msg: errExpand.Error()}
+		}
+		req.Payload = expanded
+	}
 	if opts.Alt == "responses/compact" {
 		return e.executeCompact(ctx, auth, req, opts)
 	}

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -20,6 +20,14 @@ import (
 )
 
 func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	if fallback := e.codexFallbackCompactionExecutor(auth); fallback != nil && opts.Alt != "responses/compact" {
+		fallbackAuth := codexFallbackCompactionAuth(auth, fallback)
+		expanded, errExpand := fallback.expandFallbackCompactionCapsules(fallbackAuth, req.Payload)
+		if errExpand != nil {
+			return nil, statusErr{code: http.StatusBadRequest, msg: errExpand.Error()}
+		}
+		req.Payload = expanded
+	}
 	if opts.Alt == "responses/compact" {
 		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /responses/compact"}
 	}

--- a/internal/runtime/executor/openai_compat_compaction.go
+++ b/internal/runtime/executor/openai_compat_compaction.go
@@ -1,0 +1,288 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const openAICompatFallbackCapsulePrefix = "cpa-compat-compaction-v1."
+
+var openAICompatFallbackSummaryInstruction = `Create a compact continuation summary of the conversation above. Preserve user requirements, decisions, constraints, file paths, identifiers, commands, errors, tool results, and unfinished work. Do not continue the task or add commentary. Return only the summary.`
+
+type openAICompatFallbackCapsule struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+	Summary  string `json:"summary"`
+}
+
+func (e *OpenAICompatExecutor) fallbackCompactionEnabled(auth *cliproxyauth.Auth) bool {
+	compat := e.resolveCompatConfig(auth)
+	return compat != nil && compat.FallbackCompaction
+}
+
+func (e *OpenAICompatExecutor) executeFallbackCompaction(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	baseURL, apiKey := e.resolveCredentials(auth)
+	if baseURL == "" {
+		return resp, statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL"}
+	}
+	payload, errExpand := e.expandFallbackCompactionCapsules(auth, req.Payload)
+	if errExpand != nil {
+		return resp, statusErr{code: http.StatusBadRequest, msg: errExpand.Error()}
+	}
+	payload = removeResponsesInputType(payload, "compaction_trigger")
+	translated := helps.TranslateRequestWithAPIKeyModelCompatibility(ctx, opts.Headers, e.cfg, opts.SourceFormat, sdktranslator.FromString("openai"), req.Model, payload, false, helps.APIKeyModelIsCompat(req))
+	translated, _ = sjson.SetBytes(translated, "stream", false)
+	translated, _ = sjson.DeleteBytes(translated, "tools")
+	translated, _ = sjson.DeleteBytes(translated, "tool_choice")
+	translated, _ = sjson.DeleteBytes(translated, "parallel_tool_calls")
+	translated, _ = sjson.SetBytes(translated, "messages.-1", map[string]any{"role": "user", "content": openAICompatFallbackSummaryInstruction})
+
+	url := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
+	httpReq, errRequest := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
+	if errRequest != nil {
+		return resp, errRequest
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("User-Agent", "cli-proxy-openai-compat")
+	if apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	if auth != nil {
+		util.ApplyCustomHeadersFromAttrs(httpReq, auth.Attributes)
+	}
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpResp, errDo := httpClient.Do(httpReq)
+	if errDo != nil {
+		return resp, errDo
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			helps.LogWithRequestID(ctx).Warnf("openai compat fallback compaction: close response body: %v", errClose)
+		}
+	}()
+	body, errRead := io.ReadAll(httpResp.Body)
+	if errRead != nil {
+		return resp, errRead
+	}
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return resp, statusErr{code: httpResp.StatusCode, msg: string(body)}
+	}
+	summary := openAICompatFallbackResponseText(body)
+	if summary == "" {
+		return resp, statusErr{code: http.StatusBadGateway, msg: "fallback compaction upstream returned no summary"}
+	}
+	capsule, errSeal := e.sealFallbackCompactionCapsule(auth, req.Model, summary)
+	if errSeal != nil {
+		return resp, errSeal
+	}
+	result := []byte(`{"id":"","object":"response.compaction","created_at":0,"output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}`)
+	result, _ = sjson.SetBytes(result, "id", "resp_compact_"+strings.ReplaceAll(uuid.NewString(), "-", ""))
+	result, _ = sjson.SetBytes(result, "created_at", time.Now().Unix())
+	result, _ = sjson.SetBytes(result, "model", req.Model)
+	result, _ = sjson.SetBytes(result, "output.0", map[string]any{"type": "compaction", "encrypted_content": capsule})
+	for _, pair := range [][2]string{{"usage.prompt_tokens", "usage.input_tokens"}, {"usage.completion_tokens", "usage.output_tokens"}, {"usage.total_tokens", "usage.total_tokens"}} {
+		if value := gjson.GetBytes(body, pair[0]); value.Exists() {
+			result, _ = sjson.SetBytes(result, pair[1], value.Int())
+		}
+	}
+	return cliproxyexecutor.Response{Payload: result, Headers: httpResp.Header.Clone()}, nil
+}
+
+func openAICompatFallbackResponseText(body []byte) string {
+	content := gjson.GetBytes(body, "choices.0.message.content")
+	if content.Type == gjson.String {
+		return strings.TrimSpace(content.String())
+	}
+	if !content.IsArray() {
+		return ""
+	}
+	var parts []string
+	for _, part := range content.Array() {
+		if text := strings.TrimSpace(part.Get("text").String()); text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func removeResponsesInputType(payload []byte, itemType string) []byte {
+	input := gjson.GetBytes(payload, "input")
+	if !input.IsArray() {
+		return payload
+	}
+	items := make([]json.RawMessage, 0, len(input.Array()))
+	for _, item := range input.Array() {
+		if item.Get("type").String() == itemType {
+			continue
+		}
+		items = append(items, json.RawMessage(item.Raw))
+	}
+	updated, err := sjson.SetBytes(payload, "input", items)
+	if err != nil {
+		return payload
+	}
+	return updated
+}
+
+func (e *OpenAICompatExecutor) expandFallbackCompactionCapsules(auth *cliproxyauth.Auth, payload []byte) ([]byte, error) {
+	input := gjson.GetBytes(payload, "input")
+	if !input.IsArray() {
+		return payload, nil
+	}
+	items := make([]json.RawMessage, 0, len(input.Array()))
+	changed := false
+	for _, item := range input.Array() {
+		if item.Get("type").String() != "compaction" {
+			items = append(items, json.RawMessage(item.Raw))
+			continue
+		}
+		encoded := item.Get("encrypted_content").String()
+		if !strings.HasPrefix(encoded, openAICompatFallbackCapsulePrefix) {
+			items = append(items, json.RawMessage(item.Raw))
+			continue
+		}
+		capsule, errOpen := e.openFallbackCompactionCapsule(auth, encoded)
+		if errOpen != nil {
+			return nil, errOpen
+		}
+		message, _ := json.Marshal(map[string]any{"type": "message", "role": "developer", "content": capsule.Summary})
+		items = append(items, message)
+		changed = true
+	}
+	if !changed {
+		return payload, nil
+	}
+	return sjson.SetBytes(payload, "input", items)
+}
+
+func (e *OpenAICompatExecutor) sealFallbackCompactionCapsule(auth *cliproxyauth.Auth, model, summary string) (string, error) {
+	keys := e.fallbackCompactionKeys(auth)
+	if len(keys) == 0 {
+		return "", fmt.Errorf("fallback compaction requires a configured API key")
+	}
+	plain, _ := json.Marshal(openAICompatFallbackCapsule{Provider: e.provider, Model: model, Summary: summary})
+	block, errBlock := aes.NewCipher(keys[0])
+	if errBlock != nil {
+		return "", errBlock
+	}
+	gcm, errGCM := cipher.NewGCM(block)
+	if errGCM != nil {
+		return "", errGCM
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, errRead := io.ReadFull(rand.Reader, nonce); errRead != nil {
+		return "", errRead
+	}
+	sealed := gcm.Seal(nonce, nonce, plain, []byte(e.provider))
+	return openAICompatFallbackCapsulePrefix + base64.RawURLEncoding.EncodeToString(sealed), nil
+}
+
+func (e *OpenAICompatExecutor) openFallbackCompactionCapsule(auth *cliproxyauth.Auth, encoded string) (openAICompatFallbackCapsule, error) {
+	var capsule openAICompatFallbackCapsule
+	raw, errDecode := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(encoded, openAICompatFallbackCapsulePrefix))
+	if errDecode != nil {
+		return capsule, fmt.Errorf("invalid fallback compaction capsule: %w", errDecode)
+	}
+	for _, key := range e.fallbackCompactionKeys(auth) {
+		block, errBlock := aes.NewCipher(key)
+		if errBlock != nil {
+			continue
+		}
+		gcm, errGCM := cipher.NewGCM(block)
+		if errGCM != nil || len(raw) < gcm.NonceSize() {
+			continue
+		}
+		plain, errOpen := gcm.Open(nil, raw[:gcm.NonceSize()], raw[gcm.NonceSize():], []byte(e.provider))
+		if errOpen != nil || json.Unmarshal(plain, &capsule) != nil {
+			continue
+		}
+		if capsule.Provider != e.provider || strings.TrimSpace(capsule.Summary) == "" {
+			continue
+		}
+		return capsule, nil
+	}
+	return capsule, fmt.Errorf("fallback compaction capsule cannot be decrypted by this provider")
+}
+
+func (e *OpenAICompatExecutor) fallbackCompactionKeys(auth *cliproxyauth.Auth) [][]byte {
+	secrets := make([]string, 0)
+	if compat := e.resolveCompatConfig(auth); compat != nil {
+		for _, entry := range compat.APIKeyEntries {
+			if secret := strings.TrimSpace(entry.APIKey); secret != "" {
+				secrets = append(secrets, secret)
+			}
+		}
+	}
+	if auth != nil && auth.Attributes != nil {
+		if secret := strings.TrimSpace(auth.Attributes["api_key"]); secret != "" {
+			secrets = append(secrets, secret)
+		}
+	}
+	seen := make(map[[32]byte]struct{})
+	keys := make([][]byte, 0, len(secrets))
+	for _, secret := range secrets {
+		hash := sha256.Sum256([]byte("cpa-openai-compat-compaction\x00" + e.provider + "\x00" + secret))
+		if _, ok := seen[hash]; ok {
+			continue
+		}
+		seen[hash] = struct{}{}
+		key := make([]byte, len(hash))
+		copy(key, hash[:])
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func (e *CodexExecutor) codexFallbackCompactionExecutor(auth *cliproxyauth.Auth) *OpenAICompatExecutor {
+	entry := e.resolveCodexConfig(auth)
+	if entry == nil || !entry.FallbackCompaction {
+		return nil
+	}
+	_, baseURL := codexCreds(auth)
+	baseURL = strings.TrimSpace(baseURL)
+	entries := make([]config.OpenAICompatibilityAPIKey, 0)
+	for _, candidate := range e.cfg.CodexKey {
+		if candidate.FallbackCompaction && strings.EqualFold(strings.TrimSpace(candidate.BaseURL), baseURL) && strings.TrimSpace(candidate.APIKey) != "" {
+			entries = append(entries, config.OpenAICompatibilityAPIKey{APIKey: candidate.APIKey})
+		}
+	}
+	compatName := "codex-fallback:" + baseURL
+	cfg := *e.cfg
+	cfg.OpenAICompatibility = []config.OpenAICompatibility{{Name: compatName, BaseURL: baseURL, FallbackCompaction: true, APIKeyEntries: entries}}
+	return NewOpenAICompatExecutor(compatName, &cfg)
+}
+
+func codexFallbackCompactionAuth(auth *cliproxyauth.Auth, executor *OpenAICompatExecutor) *cliproxyauth.Auth {
+	if auth == nil || executor == nil {
+		return auth
+	}
+	clone := *auth
+	clone.Provider = "openai-compatibility"
+	clone.Attributes = make(map[string]string, len(auth.Attributes)+1)
+	for key, value := range auth.Attributes {
+		clone.Attributes[key] = value
+	}
+	clone.Attributes["compat_name"] = executor.provider
+	return &clone
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -89,6 +89,16 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	if endpointPath := openAICompatImageEndpointPath(opts); endpointPath != "" {
 		return e.executeImages(ctx, auth, req, opts, endpointPath)
 	}
+	if e.fallbackCompactionEnabled(auth) {
+		if opts.Alt == "responses/compact" {
+			return e.executeFallbackCompaction(ctx, auth, req, opts)
+		}
+		expanded, errExpand := e.expandFallbackCompactionCapsules(auth, req.Payload)
+		if errExpand != nil {
+			return resp, statusErr{code: http.StatusBadRequest, msg: errExpand.Error()}
+		}
+		req.Payload = expanded
+	}
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 
@@ -307,6 +317,16 @@ func (e *OpenAICompatExecutor) executeImages(ctx context.Context, auth *cliproxy
 func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	if endpointPath := openAICompatImageEndpointPath(opts); endpointPath != "" {
 		return e.executeImagesStream(ctx, auth, req, opts, endpointPath)
+	}
+	if e.fallbackCompactionEnabled(auth) {
+		if opts.Alt == "responses/compact" {
+			return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for fallback compaction"}
+		}
+		expanded, errExpand := e.expandFallbackCompactionCapsules(auth, req.Payload)
+		if errExpand != nil {
+			return nil, statusErr{code: http.StatusBadRequest, msg: errExpand.Error()}
+		}
+		req.Payload = expanded
 	}
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"mime"
@@ -18,6 +19,7 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 func TestOpenAICompatExecutorCompactPassthrough(t *testing.T) {
@@ -1202,5 +1204,123 @@ func TestOpenAICompatExecutorStreamDropsChunksAfterDone(t *testing.T) {
 	}
 	if gjson.Get(payloads[1], "choices.0.finish_reason").String() != "stop" {
 		t.Fatalf("second chunk = %s", payloads[1])
+	}
+}
+
+func TestOpenAICompatExecutorFallbackCompactionRoundTripAcrossKeys(t *testing.T) {
+	var requests [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		requests = append(requests, body)
+		w.Header().Set("Content-Type", "application/json")
+		if len(requests) == 1 {
+			_, _ = w.Write([]byte(`{"id":"chatcmpl_summary","choices":[{"message":{"role":"assistant","content":"user needs the migration completed; tests remain"}}],"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_next","choices":[{"message":{"role":"assistant","content":"continued"}}],"usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{OpenAICompatibility: []config.OpenAICompatibility{{
+		Name:               "deepseek",
+		FallbackCompaction: true,
+		APIKeyEntries: []config.OpenAICompatibilityAPIKey{
+			{APIKey: "old-key"},
+			{APIKey: "new-key"},
+		},
+	}}}
+	executor := NewOpenAICompatExecutor("openai-compatibility:deepseek", cfg)
+	oldAuth := &cliproxyauth.Auth{Provider: "openai-compatibility", Attributes: map[string]string{
+		"base_url": server.URL + "/v1", "api_key": "old-key", "compat_name": "deepseek",
+	}}
+	compactResponse, errCompact := executor.Execute(context.Background(), oldAuth, cliproxyexecutor.Request{
+		Model:   "deepseek-chat",
+		Payload: []byte(`{"model":"deepseek-chat","input":[{"type":"message","role":"user","content":"finish migration"},{"type":"compaction_trigger"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response"), Alt: "responses/compact"})
+	if errCompact != nil {
+		t.Fatalf("compact: %v", errCompact)
+	}
+	if got := gjson.GetBytes(requests[0], "messages.0.content").String(); got != "finish migration" {
+		t.Fatalf("first message = %q; request=%s", got, requests[0])
+	}
+	if got := gjson.GetBytes(requests[0], "messages.1.content").String(); !strings.Contains(got, "compact continuation summary") {
+		t.Fatalf("summary instruction = %q", got)
+	}
+	capsule := gjson.GetBytes(compactResponse.Payload, "output.0.encrypted_content").String()
+	if !strings.HasPrefix(capsule, openAICompatFallbackCapsulePrefix) || strings.Contains(capsule, "tests remain") {
+		t.Fatalf("invalid capsule %q", capsule)
+	}
+	if got := gjson.GetBytes(compactResponse.Payload, "usage.total_tokens").Int(); got != 18 {
+		t.Fatalf("total_tokens = %d", got)
+	}
+
+	newAuth := &cliproxyauth.Auth{Provider: "openai-compatibility", Attributes: map[string]string{
+		"base_url": server.URL + "/v1", "api_key": "new-key", "compat_name": "deepseek",
+	}}
+	nextPayload := []byte(`{"model":"deepseek-chat","input":[{"type":"compaction","encrypted_content":""},{"type":"message","role":"user","content":"continue"}]}`)
+	nextPayload, _ = sjson.SetBytes(nextPayload, "input.0.encrypted_content", capsule)
+	_, errNext := executor.Execute(context.Background(), newAuth, cliproxyexecutor.Request{Model: "deepseek-chat", Payload: nextPayload}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response")})
+	if errNext != nil {
+		t.Fatalf("next request: %v", errNext)
+	}
+	if got := gjson.GetBytes(requests[1], "messages.0.content").String(); got != "user needs the migration completed; tests remain" {
+		t.Fatalf("expanded summary = %q; request=%s", got, requests[1])
+	}
+	if got := gjson.GetBytes(requests[1], "messages.1.content").String(); got != "continue" {
+		t.Fatalf("continuation = %q", got)
+	}
+}
+
+func TestOpenAICompatFallbackCompactionRejectsTamperedCapsule(t *testing.T) {
+	cfg := &config.Config{OpenAICompatibility: []config.OpenAICompatibility{{Name: "compat", FallbackCompaction: true, APIKeyEntries: []config.OpenAICompatibilityAPIKey{{APIKey: "key"}}}}}
+	executor := NewOpenAICompatExecutor("openai-compatibility:compat", cfg)
+	auth := &cliproxyauth.Auth{Provider: "openai-compatibility", Attributes: map[string]string{"api_key": "key", "compat_name": "compat"}}
+	capsule, errSeal := executor.sealFallbackCompactionCapsule(auth, "model", "summary")
+	if errSeal != nil {
+		t.Fatal(errSeal)
+	}
+	raw, errDecode := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(capsule, openAICompatFallbackCapsulePrefix))
+	if errDecode != nil {
+		t.Fatal(errDecode)
+	}
+	raw[len(raw)-1] ^= 0x01
+	capsule = openAICompatFallbackCapsulePrefix + base64.RawURLEncoding.EncodeToString(raw)
+	payload := []byte(`{"input":[{"type":"compaction","encrypted_content":""}]}`)
+	payload, _ = sjson.SetBytes(payload, "input.0.encrypted_content", capsule)
+	if _, errExpand := executor.expandFallbackCompactionCapsules(auth, payload); errExpand == nil {
+		t.Fatal("tampered capsule accepted")
+	}
+}
+
+func TestCodexExecutorFallbackCompactionUsesChatCompletions(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"compact summary"}}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{CodexKey: []config.CodexKey{{
+		APIKey:             "deepseek-key",
+		BaseURL:            server.URL + "/v1",
+		FallbackCompaction: true,
+	}}}
+	executor := NewCodexExecutor(cfg)
+	auth := &cliproxyauth.Auth{Provider: "codex", Attributes: map[string]string{
+		"api_key": "deepseek-key", "base_url": server.URL + "/v1",
+	}}
+	resp, errExecute := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: []byte(`{"model":"deepseek-v4-flash","input":"preserve this context"}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response"), Alt: "responses/compact"})
+	if errExecute != nil {
+		t.Fatalf("Execute: %v", errExecute)
+	}
+	if gotPath != "/v1/chat/completions" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if got := gjson.GetBytes(resp.Payload, "output.0.type").String(); got != "compaction" {
+		t.Fatalf("output type = %q; payload=%s", got, resp.Payload)
 	}
 }


### PR DESCRIPTION
## Summary

Codex clients send `/v1/responses/compact` and `compaction_trigger` items during long sessions. Official OpenAI/xAI/Codex endpoints implement that contract, but many OpenAI-compatible and third-party Responses providers only expose `/chat/completions` or `/responses`.

This adds an explicit `fallback-compaction` flag so those providers can still complete Codex remote compaction.

When the flag is enabled:

1. CPA recognizes `/v1/responses/compact` or a `compaction_trigger` item.
2. The conversation is summarized through `/chat/completions`.
3. The summary is sealed into a Codex-compatible `compaction` output item.
4. Later turns expand that capsule back into a developer message before the next request.

Default behavior is unchanged. Native `/responses/compact` passthrough remains the default for OpenAI-compatible providers and official Codex endpoints.

## Configuration

```yaml
openai-compatibility:
  - name: deepseek
    base-url: https://api.deepseek.com
    fallback-compaction: true

codex-api-key:
  - api-key: sk-...
    base-url: https://api.deepseek.com/v1
    fallback-compaction: true
```

DeepSeek is the validation scenario (`deepseek-v4-pro` via `openai-compatibility`, `deepseek-v4-flash` via third-party `codex-api-key`), but the implementation is not DeepSeek-specific.

## Notes

- Capsules are AES-GCM sealed from the provider API key. Later requests can recover the summary after credential rotation on the same provider/base URL.
- Tampered or foreign capsules are rejected.
- Streaming compact requests remain unsupported, matching the existing compact handler.
- Tests cover passthrough-by-default, fallback compact, multi-key capsule reuse, tamper rejection, and Codex-compatible endpoints.