### PR TITLE
fix(antigravity): reorder function responses in mixed tool-result contents

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -352,6 +352,14 @@ type antigravityContentEdit struct {
 	replacement []byte
 }
 
+// antigravityFunctionRef identifies a tool call or response by id, falling
+// back to the function name when the id is absent, mirroring the pairing
+// rules of the Gemini history validator.
+type antigravityFunctionRef struct {
+	id   string
+	name string
+}
+
 // normalizeAntigravityGeminiFunctionResponseRoles edits each response turn in
 // isolation, then splices all changed turns into the request with one body copy.
 // Applying SJSON once per field made large histories scale with history size
@@ -362,13 +370,9 @@ func normalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byte {
 	if !contents.IsArray() {
 		return rawJSON
 	}
-	type functionRef struct {
-		id   string
-		name string
-	}
 
 	edits := make([]antigravityContentEdit, 0)
-	var pending []functionRef
+	var pending []antigravityFunctionRef
 	validOffsets := true
 	contents.ForEach(func(contentIndex, content gjson.Result) bool {
 		parts := content.Get("parts")
@@ -377,18 +381,16 @@ func normalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byte {
 			return true
 		}
 
-		var calls, responses []functionRef
-		var responseParts []json.RawMessage
+		var calls, responses []antigravityFunctionRef
 		partCount := 0
 		hasOtherPart := false
 		parts.ForEach(func(_, part gjson.Result) bool {
 			partCount++
 			switch {
 			case part.Get("functionCall").Exists():
-				calls = append(calls, functionRef{id: part.Get("functionCall.id").String(), name: part.Get("functionCall.name").String()})
+				calls = append(calls, antigravityFunctionRef{id: part.Get("functionCall.id").String(), name: part.Get("functionCall.name").String()})
 			case part.Get("functionResponse").Exists():
-				responses = append(responses, functionRef{id: part.Get("functionResponse.id").String(), name: part.Get("functionResponse.name").String()})
-				responseParts = append(responseParts, json.RawMessage(part.Raw))
+				responses = append(responses, antigravityFunctionRef{id: part.Get("functionResponse.id").String(), name: part.Get("functionResponse.name").String()})
 			default:
 				hasOtherPart = true
 			}
@@ -408,35 +410,24 @@ func normalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byte {
 			}
 			return true
 		}
-		if hasOtherPart || len(calls) > 0 {
+		if len(calls) > 0 {
+			// functionCall and functionResponse parts interleaved in one
+			// content are an invalid shape that pairing validation rejects;
+			// leave it untouched instead of guessing a repair.
 			pending = nil
 			return true
 		}
 
+		// Claude clients may emit tool_result blocks in completion order while
+		// Gemini pairs calls and responses positionally, so reorder the
+		// functionResponse groups (each keeping its trailing image parts) into
+		// call order. Other parts keep their relative positions, and contents
+		// whose responses cannot be matched one-to-one stay untouched so the
+		// pairing validation can surface the real problem.
 		var contentJSON []byte
 		contentChanged := false
 		if len(pending) == len(responses) {
-			ordered := make([]json.RawMessage, 0, len(responseParts))
-			used := make([]bool, len(responses))
-			for _, call := range pending {
-				matched := -1
-				for responseIndex, response := range responses {
-					if used[responseIndex] {
-						continue
-					}
-					if (call.id != "" && response.id == call.id) || (call.id == "" && call.name != "" && response.name == call.name) {
-						matched = responseIndex
-						break
-					}
-				}
-				if matched < 0 {
-					ordered = nil
-					break
-				}
-				used[matched] = true
-				ordered = append(ordered, responseParts[matched])
-			}
-			if len(ordered) == len(responseParts) {
+			if ordered, orderedOK := orderAntigravityFunctionResponseGroups(parts, responses, pending); orderedOK {
 				encoded, errMarshal := json.Marshal(ordered)
 				if errMarshal == nil && !bytes.Equal(encoded, []byte(parts.Raw)) {
 					contentJSON = []byte(content.Raw)
@@ -448,7 +439,9 @@ func normalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byte {
 			}
 		}
 		pending = nil
-		if content.Get("role").String() != "model" {
+		// Only a pure tool-result turn carries the model role on Antigravity;
+		// mixed contents keep their original role.
+		if !hasOtherPart && content.Get("role").String() != "model" {
 			if contentJSON == nil {
 				contentJSON = []byte(content.Raw)
 			}
@@ -501,6 +494,85 @@ func normalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byte {
 		cursor = edit.end
 	}
 	return append(out, rawJSON[cursor:]...)
+}
+
+// orderAntigravityFunctionResponseGroups returns the parts of a tool-result
+// content with its functionResponse parts reordered to line up with pending,
+// keeping every other part in its original relative position. Each response
+// stays grouped with the inline media parts that directly follow it so tool
+// output images remain attached to the call they answer. It reports false when
+// the responses cannot be matched one-to-one with pending by id, or by name
+// when ids are absent; callers then leave the content untouched and let the
+// pairing validation surface the mismatch.
+func orderAntigravityFunctionResponseGroups(parts gjson.Result, responses, pending []antigravityFunctionRef) ([]json.RawMessage, bool) {
+	type layoutSlot struct {
+		isGroup bool
+		part    json.RawMessage
+	}
+	var (
+		groups  [][]json.RawMessage
+		layout  []layoutSlot
+		openIdx = -1
+	)
+	parts.ForEach(func(_, part gjson.Result) bool {
+		raw := json.RawMessage(part.Raw)
+		switch {
+		case part.Get("functionResponse").Exists():
+			groups = append(groups, []json.RawMessage{raw})
+			openIdx = len(groups) - 1
+			layout = append(layout, layoutSlot{isGroup: true})
+		case isAntigravityInlineMediaPart(part) && openIdx >= 0:
+			groups[openIdx] = append(groups[openIdx], raw)
+		default:
+			openIdx = -1
+			layout = append(layout, layoutSlot{part: raw})
+		}
+		return true
+	})
+	if len(groups) != len(responses) || len(groups) != len(pending) {
+		return nil, false
+	}
+
+	orderedGroups := make([][]json.RawMessage, len(pending))
+	used := make([]bool, len(groups))
+	for callIndex, call := range pending {
+		matched := -1
+		for groupIndex, response := range responses {
+			if used[groupIndex] {
+				continue
+			}
+			if (call.id != "" && response.id == call.id) || (call.id == "" && call.name != "" && response.name == call.name) {
+				matched = groupIndex
+				break
+			}
+		}
+		if matched < 0 {
+			return nil, false
+		}
+		used[matched] = true
+		orderedGroups[callIndex] = groups[matched]
+	}
+
+	ordered := make([]json.RawMessage, 0, len(layout))
+	nextGroup := 0
+	for _, slot := range layout {
+		if slot.isGroup {
+			ordered = append(ordered, orderedGroups[nextGroup]...)
+			nextGroup++
+			continue
+		}
+		ordered = append(ordered, slot.part)
+	}
+	return ordered, true
+}
+
+// isAntigravityInlineMediaPart reports whether a part only carries inline
+// media, the shape the translator emits for tool-output images.
+func isAntigravityInlineMediaPart(part gjson.Result) bool {
+	if part.Get("functionCall").Exists() || part.Get("functionResponse").Exists() {
+		return false
+	}
+	return part.Get("inline_data").Exists() || part.Get("inlineData").Exists()
 }
 
 // applyAntigravityContentEditsWithSJSON preserves the legacy path semantics if

--- a/internal/runtime/executor/antigravity_executor_signature_test.go
+++ b/internal/runtime/executor/antigravity_executor_signature_test.go
@@ -371,6 +371,59 @@ func TestNormalizeAntigravityGeminiFunctionResponseRolesDoesNotCrossEmptyContent
 	}
 }
 
+func TestNormalizeAntigravityGeminiFunctionResponseRolesOrdersMixedResponses(t *testing.T) {
+	// Claude clients answer parallel tool calls in completion order, which can
+	// arrive as a mixed user turn with trailing text.
+	payload := []byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"read","args":{"file":"one"}}},{"functionCall":{"id":"call-2","name":"read","args":{"file":"two"}}}]},{"role":"user","parts":[{"functionResponse":{"id":"call-2","name":"read","response":{"result":"two"}}},{"functionResponse":{"id":"call-1","name":"read","response":{"result":"one"}}},{"text":"user follow-up"}]}]}}`)
+	output := normalizeAntigravityGeminiFunctionResponseRoles(payload)
+	if got := gjson.GetBytes(output, "request.contents.1.role").String(); got != "user" {
+		t.Fatalf("mixed functionResponse/user content role = %q, want user; output=%s", got, output)
+	}
+	if got := gjson.GetBytes(output, "request.contents.1.parts.0.functionResponse.id").String(); got != "call-1" {
+		t.Fatalf("first functionResponse.id = %q, want call-1; output=%s", got, output)
+	}
+	if got := gjson.GetBytes(output, "request.contents.1.parts.1.functionResponse.id").String(); got != "call-2" {
+		t.Fatalf("second functionResponse.id = %q, want call-2; output=%s", got, output)
+	}
+	if got := gjson.GetBytes(output, "request.contents.1.parts.2.text").String(); got != "user follow-up" {
+		t.Fatalf("trailing text part moved = %q; output=%s", got, output)
+	}
+	if errValidate := internalsignature.ValidateGeminiFunctionCallPairing(output); errValidate != nil {
+		t.Fatalf("mixed reordered responses are invalid: %v; output=%s", errValidate, output)
+	}
+}
+
+func TestNormalizeAntigravityGeminiFunctionResponseRolesKeepsImagesWithReorderedResponses(t *testing.T) {
+	payload := []byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"shot","args":{}}},{"functionCall":{"id":"call-2","name":"shot","args":{}}}]},{"role":"user","parts":[{"functionResponse":{"id":"call-2","name":"shot","response":{"result":"two"}}},{"inline_data":{"mime_type":"image/png","data":"two"}},{"functionResponse":{"id":"call-1","name":"shot","response":{"result":"one"}}},{"inline_data":{"mime_type":"image/png","data":"one"}}]}]}}`)
+	output := normalizeAntigravityGeminiFunctionResponseRoles(payload)
+	if got := gjson.GetBytes(output, "request.contents.1.parts.0.functionResponse.id").String(); got != "call-1" {
+		t.Fatalf("first functionResponse.id = %q, want call-1; output=%s", got, output)
+	}
+	if got := gjson.GetBytes(output, "request.contents.1.parts.1.inline_data.data").String(); got != "one" {
+		t.Fatalf("first image no longer follows its response: %q; output=%s", got, output)
+	}
+	if got := gjson.GetBytes(output, "request.contents.1.parts.2.functionResponse.id").String(); got != "call-2" {
+		t.Fatalf("second functionResponse.id = %q, want call-2; output=%s", got, output)
+	}
+	if got := gjson.GetBytes(output, "request.contents.1.parts.3.inline_data.data").String(); got != "two" {
+		t.Fatalf("second image no longer follows its response: %q; output=%s", got, output)
+	}
+	if errValidate := internalsignature.ValidateGeminiFunctionCallPairing(output); errValidate != nil {
+		t.Fatalf("reordered responses with images are invalid: %v; output=%s", errValidate, output)
+	}
+}
+
+func TestNormalizeAntigravityGeminiFunctionResponseRolesLeavesUnmatchedMixedResponses(t *testing.T) {
+	payload := []byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"read","args":{}}}]},{"role":"user","parts":[{"functionResponse":{"id":"call-x","name":"read","response":{"result":"x"}}},{"text":"user follow-up"}]}]}}`)
+	output := normalizeAntigravityGeminiFunctionResponseRoles(payload)
+	if got := gjson.GetBytes(output, "request.contents.1.parts.0.functionResponse.id").String(); got != "call-x" {
+		t.Fatalf("unmatched mixed response was rewritten: %q; output=%s", got, output)
+	}
+	if errValidate := internalsignature.ValidateGeminiFunctionCallPairing(output); errValidate == nil {
+		t.Fatalf("unmatched mixed responses were accepted: %s", output)
+	}
+}
+
 func TestAntigravityExecutor_GeminiTargetPreservesGeminiThinkingCarrier(t *testing.T) {
 	inner := protowire.AppendTag(nil, 1, protowire.BytesType)
 	inner = protowire.AppendBytes(inner, []byte{0x01, 0x0c, 0x39, 0xd6, 0xc7, 0x34})

--- a/internal/runtime/executor/antigravity_preupstream_rewrite_legacy_oracle_test.go
+++ b/internal/runtime/executor/antigravity_preupstream_rewrite_legacy_oracle_test.go
@@ -93,14 +93,41 @@ func legacyNormalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byt
 			}
 			continue
 		}
-		if hasOtherPart || len(calls) > 0 {
+		if len(calls) > 0 {
 			pending = nil
 			continue
 		}
 
 		if len(pending) == len(responses) {
-			ordered := make([]json.RawMessage, 0, len(responseParts))
+			// Group-aware reorder: each functionResponse part keeps the inline
+			// media parts that directly follow it, standalone parts stay in
+			// place, and only a one-to-one match by id (or name when ids are
+			// absent) rewrites the parts array.
+			type slot struct {
+				group      int // response index, -1 marks a standalone part
+				standalone json.RawMessage
+			}
+			var layout []slot
+			grouped := make([][]json.RawMessage, 0, len(responseParts))
+			openGroup := -1
+			parts.ForEach(func(_, part gjson.Result) bool {
+				raw := json.RawMessage(part.Raw)
+				switch {
+				case part.Get("functionResponse").Exists():
+					grouped = append(grouped, []json.RawMessage{raw})
+					openGroup = len(grouped) - 1
+					layout = append(layout, slot{group: openGroup})
+				case (part.Get("inline_data").Exists() || part.Get("inlineData").Exists()) && !part.Get("functionCall").Exists() && openGroup >= 0:
+					grouped[openGroup] = append(grouped[openGroup], raw)
+				default:
+					openGroup = -1
+					layout = append(layout, slot{group: -1, standalone: raw})
+				}
+				return true
+			})
+			orderedGroups := make([][]json.RawMessage, 0, len(pending))
 			used := make([]bool, len(responses))
+			matchedAll := true
 			for _, call := range pending {
 				matched := -1
 				for responseIndex, response := range responses {
@@ -113,13 +140,23 @@ func legacyNormalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byt
 					}
 				}
 				if matched < 0 {
-					ordered = nil
+					matchedAll = false
 					break
 				}
 				used[matched] = true
-				ordered = append(ordered, responseParts[matched])
+				orderedGroups = append(orderedGroups, grouped[matched])
 			}
-			if len(ordered) == len(responseParts) {
+			if matchedAll {
+				var ordered []json.RawMessage
+				nextGroup := 0
+				for _, s := range layout {
+					if s.group >= 0 {
+						ordered = append(ordered, orderedGroups[nextGroup]...)
+						nextGroup++
+						continue
+					}
+					ordered = append(ordered, s.standalone)
+				}
 				if encoded, errMarshal := json.Marshal(ordered); errMarshal == nil {
 					if updated, errSet := sjson.SetRawBytes(out, fmt.Sprintf("request.contents.%d.parts", contentIndex), encoded); errSet == nil {
 						out = updated
@@ -128,7 +165,9 @@ func legacyNormalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byt
 			}
 		}
 		pending = nil
-		if content.Get("role").String() != "model" {
+		// Only a pure tool-result turn carries the model role; mixed contents
+		// keep their original role.
+		if !hasOtherPart && content.Get("role").String() != "model" {
 			if updated, errSet := sjson.SetBytes(out, fmt.Sprintf("request.contents.%d.role", contentIndex), "model"); errSet == nil {
 				out = updated
 			}


### PR DESCRIPTION
## Problem

When a Claude client runs parallel tool calls, it answers them in **completion order**: the `tool_result` blocks pair with their `tool_use` blocks via `tool_use_id`, so the order inside the user turn is arbitrary and perfectly legal in the Anthropic protocol.

For Antigravity requests, such a turn fails with a 400 before anything reaches Google:

```
antigravity executor: invalid Gemini function call history:
request.contents[126].parts[0]: functionResponse.id "call_5275867"
does not match functionCall.id "call_5275863" at request.contents[125].parts[0]
```

## Root cause

`normalizeAntigravityGeminiFunctionResponseRoles` already reorders functionResponse parts into call order, but it bails out on any content that contains a non-tool part (`hasOtherPart`). That is exactly what Claude Code produces when a turn answers parallel tools and then adds a short follow-up text, e.g.:

```
contents[i]   model: [functionCall A, functionCall B]
contents[i+1] user:  [functionResponse B, functionResponse A, text "…"]   ← arrival order
```

The mixed content is left in arrival order, while `ValidateGeminiFunctionCallPairing` pairs calls and responses **positionally** (and the Gemini backend expects the same ordering), so the id check trips on the first slot. Once such a turn enters a session history, every follow-up request of that session is rejected until the turn is compacted away.

Reproduced from a live Claude Code session over the Antigravity channel: 37/37 tool_use/tool_result pairs intact at the Anthropic layer, yet the request was rejected with the mismatch above.

## Fix

Reorder functionResponse groups into call order even when the content carries other parts:

- each functionResponse part stays grouped with the inline media parts that directly follow it, so tool-output images remain attached to the call they answer;
- every other part (text, thinking carriers) keeps its original relative position;
- the rewrite only happens when the responses match the pending calls one-to-one by id, or by name when ids are absent — anything else is left untouched so pairing validation still surfaces the real problem;
- mixed contents keep their original role; only pure tool-result turns are rewritten to the `model` role, preserving the existing behavior;
- a content that interleaves functionCall and functionResponse parts is still left untouched.

The differential oracle in `antigravity_preupstream_rewrite_legacy_oracle_test.go` is updated to the same semantics (still an independent implementation).

## Tests

- `TestNormalizeAntigravityGeminiFunctionResponseRolesOrdersMixedResponses` — reversed responses plus trailing text: reordered, text stays in place, role stays `user`, pairing validation passes
- `TestNormalizeAntigravityGeminiFunctionResponseRolesKeepsImagesWithReorderedResponses` — each response keeps its own inline image through the reorder
- `TestNormalizeAntigravityGeminiFunctionResponseRolesLeavesUnmatchedMixedResponses` — unmatched ids are not rewritten and still fail pairing validation

Existing normalize/replay/differential tests pass unchanged (four unrelated Claude header tests fail on `main` as well, before and after this change).