### PR TITLE
fix(antigravity): preserve sibling inlineData images in functionResponse contents (#5070)

### DIFF
--- a/internal/translator/antigravity/gemini/antigravity_gemini_request.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request.go
@@ -639,6 +639,35 @@ type FunctionCallGroup struct {
 	CallNames       []string // ordered function call names for backfilling empty response names
 }
 
+func normalizeAntigravityInlineDataPart(part gjson.Result) ([]byte, bool) {
+	var inline gjson.Result
+	if rawInline := part.Get("inlineData"); rawInline.Exists() {
+		inline = rawInline
+	} else if rawInline := part.Get("inline_data"); rawInline.Exists() {
+		inline = rawInline
+	} else {
+		return nil, false
+	}
+
+	data := inline.Get("data").String()
+	if data == "" {
+		return nil, false
+	}
+
+	mimeType := inline.Get("mimeType").String()
+	if mimeType == "" {
+		mimeType = inline.Get("mime_type").String()
+	}
+	if mimeType == "" {
+		mimeType = "image/png"
+	}
+
+	out := []byte(`{"inlineData":{"mimeType":"","data":""}}`)
+	out, _ = sjson.SetBytes(out, "inlineData.mimeType", mimeType)
+	out, _ = sjson.SetBytes(out, "inlineData.data", data)
+	return out, true
+}
+
 // parseFunctionResponseRaw attempts to normalize a function response part into a JSON object string.
 // Falls back to a minimal "functionResponse" object when parsing fails.
 // fallbackName is used when the response's own name is empty.
@@ -751,15 +780,27 @@ func fixCLIToolResponse(input []byte) ([]byte, error) {
 
 		// Check if this content has function responses
 		var responsePartsInThisContent []gjson.Result
+		var imagePartsInThisContent [][]byte
 		parts.ForEach(func(_, part gjson.Result) bool {
 			if part.Get("functionResponse").Exists() {
 				responsePartsInThisContent = append(responsePartsInThisContent, part)
+			} else if imagePart, ok := normalizeAntigravityInlineDataPart(part); ok {
+				imagePartsInThisContent = append(imagePartsInThisContent, imagePart)
 			}
 			return true
 		})
 
 		// If this content has function responses, collect them
 		if len(responsePartsInThisContent) > 0 {
+			if len(imagePartsInThisContent) > 0 {
+				lastIdx := len(responsePartsInThisContent) - 1
+				target := []byte(responsePartsInThisContent[lastIdx].Raw)
+				for _, img := range imagePartsInThisContent {
+					target, _ = sjson.SetRawBytes(target, "functionResponse.parts.-1", img)
+				}
+				responsePartsInThisContent[lastIdx] = gjson.ParseBytes(target)
+			}
+
 			collectedResponses = append(collectedResponses, responsePartsInThisContent...)
 
 			// Check if pending groups can be satisfied (FIFO: oldest group first)

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
@@ -954,3 +954,64 @@ func TestSanitizeAntigravityClaudeGeminiRequestSignatures_LargeNumberDoesNotHalt
 		t.Fatalf("expected hidden thoughtSignature to be stripped despite large number, got %s", fcSig.Raw)
 	}
 }
+
+func TestFixCLIToolResponse_PreservesSiblingInlineDataInFunctionResponse(t *testing.T) {
+	input := `{
+		"model": "gemini-3.7-flash-high",
+		"request": {
+			"contents": [
+				{
+					"role": "user",
+					"parts": [{"text": "read file"}]
+				},
+				{
+					"role": "model",
+					"parts": [
+						{"functionCall": {"name": "read", "args": {}, "id": "call_1"}, "thoughtSignature": "skip_thought_signature_validator"}
+					]
+				},
+				{
+					"role": "user",
+					"parts": [
+						{"functionResponse": {"name": "read", "response": {"result": "Read image file [image/png]"}, "id": "call_1"}},
+						{"inline_data": {"mime_type": "image/png", "data": "QUJD"}}
+					]
+				}
+			]
+		}
+	}`
+
+	result, err := fixCLIToolResponse([]byte(input))
+	if err != nil {
+		t.Fatalf("fixCLIToolResponse failed: %v", err)
+	}
+
+	contents := gjson.GetBytes(result, "request.contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("expected 3 contents, got %d. Output: %s", len(contents), result)
+	}
+
+	funcContent := contents[2]
+	if funcContent.Get("role").String() != "function" {
+		t.Fatalf("expected role function, got %q. Output: %s", funcContent.Get("role").String(), result)
+	}
+
+	funcResp := funcContent.Get("parts.0.functionResponse")
+	if !funcResp.Exists() {
+		t.Fatalf("functionResponse should exist. Output: %s", result)
+	}
+	if got := funcResp.Get("id").String(); got != "call_1" {
+		t.Errorf("expected id call_1, got %q", got)
+	}
+
+	inlineData := funcResp.Get("parts.0.inlineData")
+	if !inlineData.Exists() {
+		t.Fatalf("functionResponse.parts.0.inlineData should exist. Output: %s", result)
+	}
+	if got := inlineData.Get("mimeType").String(); got != "image/png" {
+		t.Errorf("expected mimeType image/png, got %q", got)
+	}
+	if got := inlineData.Get("data").String(); got != "QUJD" {
+		t.Errorf("expected data QUJD, got %q", got)
+	}
+}

--- a/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
+++ b/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
@@ -265,3 +265,57 @@ func TestConvertOpenAIResponsesRequestToAntigravity_GeminiReasoningUsesNativeTho
 		t.Fatalf("parts[0].thoughtSignature = %q, want preserved Gemini signature. Output: %s", got, out)
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToAntigravity_PreservesToolResultImage(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.7-flash-high",
+		"input": [
+			{
+				"role": "user",
+				"content": [{"type": "input_text", "text": "请帮我读取分析这张图片"}]
+			},
+			{
+				"type": "function_call",
+				"id": "fc_read",
+				"call_id": "call_read_1",
+				"name": "read",
+				"arguments": "{\"path\":\"/path/to/image.png\"}"
+			},
+			{
+				"type": "function_call_output",
+				"call_id": "call_read_1",
+				"output": [
+					{"type": "input_text", "text": "Read image file [image/png]"},
+					{"type": "input_image", "detail": "auto", "image_url": "data:image/png;base64,QUJD"}
+				]
+			}
+		]
+	}`
+
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3.7-flash-high", []byte(inputJSON), false)
+	contents := gjson.GetBytes(out, "request.contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("expected 3 contents, got %d. Output: %s", len(contents), out)
+	}
+
+	funcContent := contents[2]
+	if r := funcContent.Get("role").String(); r != "function" && r != "user" {
+		t.Fatalf("expected role function or user, got %q. Output: %s", r, out)
+	}
+
+	funcResp := funcContent.Get("parts.0.functionResponse")
+	if !funcResp.Exists() {
+		t.Fatalf("functionResponse should exist. Output: %s", out)
+	}
+
+	inlineData := funcResp.Get("parts.0.inlineData")
+	if !inlineData.Exists() {
+		t.Fatalf("expected functionResponse.parts.0.inlineData to exist, got: %s", out)
+	}
+	if got := inlineData.Get("mimeType").String(); got != "image/png" {
+		t.Errorf("expected mimeType image/png, got %q", got)
+	}
+	if got := inlineData.Get("data").String(); got != "QUJD" {
+		t.Errorf("expected data QUJD, got %q", got)
+	}
+}


### PR DESCRIPTION
Closes #5070

Follow-up to #5039. The first fix (commit `20f84e78`) made `ConvertOpenAIResponsesRequestToGemini` emit sibling `functionResponse` + `inline_data` parts for tool images, but `ConvertGeminiRequestToAntigravity` → `fixCLIToolResponse` only collected parts containing `functionResponse` and dropped the sibling `inline_data`/`inlineData` image parts when regrouping function responses.

This preserves the sibling image parts by attaching them to the function response as `functionResponse.parts.inlineData`, matching the Antigravity multimodal convention already used by the Claude path (PR #1682).

## 改动内容

- `internal/translator/antigravity/gemini/antigravity_gemini_request.go`
  - 新增 `normalizeAntigravityInlineDataPart`：兼容 `inline_data`（snake_case）与 `inlineData`（camelCase），非空校验后标准化为 Antigravity `inlineData` 结构
  - `fixCLIToolResponse`：收集 functionResponse 的同时保留同级图片 part，挂载到最后一个 functionResponse 的 `parts` 字段
- 测试：
  - `internal/translator/antigravity/gemini/antigravity_gemini_request_test.go` → `TestFixCLIToolResponse_PreservesSiblingInlineDataInFunctionResponse`
  - `internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go` → `TestConvertOpenAIResponsesRequestToAntigravity_PreservesToolResultImage`

## 验证

- `go test ./internal/translator/...` 全量通过
- `go build ./cmd/server` 无警告

## 已知限制

1. 同一 content 内有多个并行 functionResponse 时，图片统一挂到最后一个 response 的 `parts`。当前 `read` 类工具一次调用只产生一个 response，不受影响。
2. 只有图片、没有 functionResponse 的 content 仍会被过滤（Responses→Gemini 路径不会产生这种结构）。