### PR TITLE
fix: preserve async usage callbacks after request cancellation

### DIFF
--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -313,6 +313,13 @@ func (m *Manager) Publish(ctx context.Context, record Record) {
 	if m == nil {
 		return
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	} else {
+		// Usage delivery is asynchronous and commonly runs after the request ends.
+		// Preserve request values without letting request cancellation drop the record.
+		ctx = context.WithoutCancel(ctx)
+	}
 	// ensure worker is running even if Start was not called explicitly
 	m.Start(context.Background())
 	m.mu.Lock()

--- a/sdk/cliproxy/usage/manager_test.go
+++ b/sdk/cliproxy/usage/manager_test.go
@@ -3,7 +3,14 @@ package usage
 import (
 	"context"
 	"testing"
+	"time"
 )
+
+type usagePluginFunc func(context.Context, Record)
+
+func (f usagePluginFunc) HandleUsage(ctx context.Context, record Record) {
+	f(ctx, record)
+}
 
 func TestGenerateEnabledDefaultsNilToTrue(t *testing.T) {
 	if !GenerateEnabled(nil) {
@@ -48,5 +55,46 @@ func TestRecordOmittedGenerateIsEnabled(t *testing.T) {
 	}
 	if !GenerateEnabled(record.Generate) {
 		t.Fatalf("GenerateEnabled(omitted) = false, want true")
+	}
+}
+
+func TestManagerPublishPreservesValuesAfterRequestCancellation(t *testing.T) {
+	manager := NewManager(1)
+	t.Cleanup(manager.Stop)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	manager.Register(usagePluginFunc(func(context.Context, Record) {
+		close(started)
+		<-release
+	}))
+
+	type contextKey struct{}
+	type delivery struct {
+		value string
+		err   error
+	}
+	delivered := make(chan delivery, 1)
+	manager.Register(usagePluginFunc(func(ctx context.Context, _ Record) {
+		delivered <- delivery{value: ctx.Value(contextKey{}).(string), err: ctx.Err()}
+	}))
+
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), contextKey{}, "request-value"))
+	manager.Publish(ctx, Record{Model: "test-model"})
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first usage plugin was not invoked")
+	}
+	cancel()
+	close(release)
+
+	select {
+	case got := <-delivered:
+		if got.err != nil || got.value != "request-value" {
+			t.Fatalf("delivery = %+v, want preserved value and active context", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second usage plugin was not invoked")
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/router-for-me/CLIProxyAPI/issues/5244

## Problem

Usage records are delivered asynchronously, but the queue keeps the original request context. If the request finishes before a queued record is dispatched, that context is canceled. Consumers that honor context cancellation can then reject the callback, causing the usage record to be dropped.

## Fix

Detach the context from request cancellation when the record is queued. context.WithoutCancel preserves context values needed by usage consumers while preventing request completion from canceling asynchronous delivery.

## Test

Add a deterministic regression test that blocks dispatch, cancels the original request context, then verifies that the next usage consumer still receives the context value with no cancellation error.

- go test ./sdk/cliproxy/usage ./internal/pluginhost
- go test -race -run TestManagerPublishPreservesValuesAfterRequestCancellation ./sdk/cliproxy/usage
- go build -o test-output ./cmd/server