### PR TITLE
feat(responses): support web search tools and grounding translation for Gemini and Antigravity

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -635,10 +635,32 @@ func hasAntigravityGoogleSearchTool(payload []byte) bool {
 	return false
 }
 
+func hasAntigravityOpenAIResponsesWebSearchTool(payload []byte) bool {
+	tools := util.GetGJSONBytesNoCopy(payload, "tools")
+	if !tools.IsArray() {
+		return false
+	}
+	for _, tool := range tools.Array() {
+		toolType := strings.ToLower(strings.TrimSpace(tool.Get("type").String()))
+		if toolType == "web_search" || strings.HasPrefix(toolType, "web_search_") {
+			return true
+		}
+	}
+	return false
+}
+
 func shouldResolveAntigravityWebSearchGroundingURLs(from sdktranslator.Format, originalRequestRawJSON, requestRawJSON []byte) bool {
-	return from.String() == "claude" &&
-		hasAntigravityClaudeTypedWebSearchTool(originalRequestRawJSON) &&
-		hasAntigravityGoogleSearchTool(requestRawJSON)
+	if !hasAntigravityGoogleSearchTool(requestRawJSON) {
+		return false
+	}
+	switch from {
+	case sdktranslator.FormatClaude:
+		return hasAntigravityClaudeTypedWebSearchTool(originalRequestRawJSON)
+	case sdktranslator.FormatOpenAIResponse:
+		return hasAntigravityOpenAIResponsesWebSearchTool(originalRequestRawJSON)
+	default:
+		return false
+	}
 }
 
 func (e *AntigravityExecutor) resolveWebSearchGroundingURLs(ctx context.Context, auth *cliproxyauth.Auth, from sdktranslator.Format, originalRequestRawJSON, requestRawJSON, responseRawJSON []byte) []byte {

--- a/internal/runtime/executor/antigravity_executor_web_search_test.go
+++ b/internal/runtime/executor/antigravity_executor_web_search_test.go
@@ -1,0 +1,22 @@
+package executor
+
+import (
+	"testing"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func TestShouldResolveAntigravityWebSearchGroundingURLs_OpenAIResponses(t *testing.T) {
+	original := []byte(`{"tools":[{"type":"web_search"}]}`)
+	translated := []byte(`{"request":{"tools":[{"googleSearch":{}}]}}`)
+
+	if !shouldResolveAntigravityWebSearchGroundingURLs(sdktranslator.FormatOpenAIResponse, original, translated) {
+		t.Fatal("OpenAI Responses web search should resolve Antigravity grounding URLs")
+	}
+	if shouldResolveAntigravityWebSearchGroundingURLs(sdktranslator.FormatOpenAIResponse, []byte(`{"tools":[{"type":"function"}]}`), translated) {
+		t.Fatal("non-web-search Responses request should not resolve grounding URLs")
+	}
+	if shouldResolveAntigravityWebSearchGroundingURLs(sdktranslator.FormatOpenAIResponse, original, []byte(`{"request":{"tools":[]}}`)) {
+		t.Fatal("request without translated googleSearch should not resolve grounding URLs")
+	}
+}

--- a/internal/translator/antigravity/openai/responses/web_search_test.go
+++ b/internal/translator/antigravity/openai/responses/web_search_test.go
@@ -1,0 +1,68 @@
+package responses
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertOpenAIResponsesRequestToAntigravity_PreservesWebSearchTool(t *testing.T) {
+	input := []byte(`{
+		"model":"gemini-3.1-flash-lite",
+		"input":"latest Go release",
+		"tools":[
+			{"type":"web_search"},
+			{"type":"function","name":"save_release","parameters":{"type":"object"}}
+		]
+	}`)
+	output := ConvertOpenAIResponsesRequestToAntigravity("gemini-3.1-flash-lite", input, false)
+
+	tools := gjson.GetBytes(output, "request.tools").Array()
+	if len(tools) != 2 {
+		t.Fatalf("request.tools length = %d, want 2; output=%s", len(tools), output)
+	}
+	if got := tools[0].Get("functionDeclarations.0.name").String(); got != "save_release" {
+		t.Fatalf("function declaration name = %q, want save_release; output=%s", got, output)
+	}
+	if !tools[1].Get("googleSearch").Exists() {
+		t.Fatalf("Antigravity request dropped googleSearch: %s", output)
+	}
+}
+
+func TestConvertAntigravityResponseToOpenAIResponsesNonStream_WebSearchGrounding(t *testing.T) {
+	originalRequest := []byte(`{"model":"gemini-3.1-flash-lite","input":"latest Go release","tools":[{"type":"web_search"}]}`)
+	translatedRequest := []byte(`{"model":"gemini-3.1-flash-lite","request":{"tools":[{"googleSearch":{}}]}}`)
+	rawResponse := []byte(`{
+		"response":{
+			"responseId":"antigravity-search",
+			"candidates":[{
+				"content":{"parts":[{"text":"Go 1.26 is current."}]},
+				"groundingMetadata":{
+					"webSearchQueries":["latest Go release"],
+					"groundingChunks":[{"web":{"uri":"https://go.dev/doc/go1.26","title":"Go 1.26 Release Notes"}}],
+					"groundingSupports":[{"segment":{"startIndex":0,"endIndex":7,"text":"Go 1.26"},"groundingChunkIndices":[0]}]
+				},
+				"finishReason":"STOP"
+			}]
+		}
+	}`)
+
+	output := ConvertAntigravityResponseToOpenAIResponsesNonStream(
+		context.Background(),
+		"gemini-3.1-flash-lite",
+		originalRequest,
+		translatedRequest,
+		rawResponse,
+		nil,
+	)
+	if got := gjson.GetBytes(output, "output.0.type").String(); got != "web_search_call" {
+		t.Fatalf("output.0.type = %q, want web_search_call; output=%s", got, output)
+	}
+	if got := gjson.GetBytes(output, "output.0.action.sources.0.url").String(); got != "https://go.dev/doc/go1.26" {
+		t.Fatalf("web search source URL = %q; output=%s", got, output)
+	}
+	if got := gjson.GetBytes(output, "output.1.content.0.annotations.0.type").String(); got != "url_citation" {
+		t.Fatalf("citation type = %q, want url_citation; output=%s", got, output)
+	}
+}

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -28,10 +28,17 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 
 	// Extract tools and forward map early so request contents and toolDeclarations use the exact same forward map
 	functionDeclarations, forwardMap, _ := util.BuildGeminiFunctionDeclarations(root)
+	var geminiTools [][]byte
 	if len(functionDeclarations) > 0 {
-		geminiTools := []byte(`[{"functionDeclarations":[]}]`)
-		geminiTools, _ = sjson.SetRawBytes(geminiTools, "0.functionDeclarations", translatorcommon.JoinRawArray(functionDeclarations))
-		out, _ = sjson.SetRawBytes(out, "tools", geminiTools)
+		functionTool := []byte(`{"functionDeclarations":[]}`)
+		functionTool, _ = sjson.SetRawBytes(functionTool, "functionDeclarations", translatorcommon.JoinRawArray(functionDeclarations))
+		geminiTools = append(geminiTools, functionTool)
+	}
+	if hasOpenAIResponsesWebSearchTool(inputRawJSON) {
+		geminiTools = append(geminiTools, []byte(`{"googleSearch":{}}`))
+	}
+	if len(geminiTools) > 0 {
+		out = translatorcommon.SetRawArrayItems(out, "tools", geminiTools)
 	}
 
 	// Handle tool_choice if present

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_response.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_response.go
@@ -21,8 +21,9 @@ type geminiDetachedReasoningItem struct {
 }
 
 type geminiCompletedMessageItem struct {
-	ID   string
-	Text string
+	ID          string
+	Text        string
+	Annotations [][]byte
 }
 
 type geminiCompletedReasoningItem struct {
@@ -73,6 +74,21 @@ type geminiToResponsesState struct {
 	FuncDone         map[int]bool
 	SanitizedNameMap map[string]string
 	ToolIdentityMap  map[string]util.ResponsesToolIdentity
+
+	// web search buffering and grounding conversion
+	WebSearchConfigured        bool
+	WebSearchRequested         bool
+	WebSearchEmitted           bool
+	CompletedWebSearch         map[int][]byte
+	WebSearchAnnotations       [][]byte
+	VisibleTextOffset          int64
+	CurrentMsgStartOffset      int64
+	WebSearchBufferedParts     [][]byte
+	WebSearchGroundingMetadata []byte
+	WebSearchUsageMetadata     []byte
+	WebSearchResponseID        string
+	WebSearchCreateTime        string
+	WebSearchModelVersion      string
 }
 
 // responseIDCounter provides a process-wide unique counter for synthesized response identifiers.
@@ -133,6 +149,7 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 			DetachedReasoning:       make(map[int]geminiDetachedReasoningItem),
 			CompletedMessages:       make(map[int]geminiCompletedMessageItem),
 			CompletedReasoning:      make(map[int]geminiCompletedReasoningItem),
+			CompletedWebSearch:      make(map[int][]byte),
 			SeenReasoningSignatures: make(map[string]bool),
 			SanitizedNameMap:        util.SanitizedToolNameMap(originalRequestRawJSON),
 			ToolIdentityMap:         util.ResponsesToolReverseIdentityMap(reqJSON),
@@ -169,6 +186,9 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 	if st.CompletedReasoning == nil {
 		st.CompletedReasoning = make(map[int]geminiCompletedReasoningItem)
 	}
+	if st.CompletedWebSearch == nil {
+		st.CompletedWebSearch = make(map[int][]byte)
+	}
 	if st.SeenReasoningSignatures == nil {
 		st.SeenReasoningSignatures = make(map[string]bool)
 	}
@@ -177,6 +197,10 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 	}
 	if st.ToolIdentityMap == nil {
 		st.ToolIdentityMap = util.ResponsesToolReverseIdentityMap(reqJSON)
+	}
+	if !st.WebSearchConfigured {
+		st.WebSearchRequested = shouldTranslateOpenAIResponsesWebSearch(originalRequestRawJSON, requestRawJSON)
+		st.WebSearchConfigured = true
 	}
 
 	if bytes.HasPrefix(rawJSON, []byte("data:")) {
@@ -188,7 +212,7 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 		return [][]byte{}
 	}
 	if bytes.Equal(rawJSON, []byte("[DONE]")) {
-		if !st.Started {
+		if !st.Started && (!st.WebSearchRequested || len(st.WebSearchBufferedParts) == 0) {
 			return [][]byte{}
 		}
 		rawJSON = []byte(`{"candidates":[{"finishReason":"STOP"}]}`)
@@ -199,6 +223,13 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 		return [][]byte{}
 	}
 	root = unwrapGeminiResponseRoot(root)
+	if st.WebSearchRequested {
+		bufferedRoot, ready := bufferGeminiResponsesWebSearchStreamChunk(st, root)
+		if !ready {
+			return [][]byte{}
+		}
+		root = bufferedRoot
+	}
 
 	var out [][]byte
 	nextSeq := func() int { st.Seq++; return st.Seq }
@@ -298,6 +329,21 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 			return
 		}
 		fullText := st.ItemTextBuf.String()
+		annotations := openAIResponsesWebSearchAnnotationsForRange(
+			st.WebSearchAnnotations,
+			st.CurrentMsgStartOffset,
+			st.CurrentMsgStartOffset+int64(len(fullText)),
+		)
+		for annotationIndex, annotation := range annotations {
+			added := []byte(`{"type":"response.output_text.annotation.added","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"annotation_index":0,"annotation":{}}`)
+			added, _ = sjson.SetBytes(added, "sequence_number", nextSeq())
+			added, _ = sjson.SetBytes(added, "item_id", st.CurrentMsgID)
+			added, _ = sjson.SetBytes(added, "output_index", st.MsgIndex)
+			added, _ = sjson.SetBytes(added, "annotation_index", annotationIndex)
+			added, _ = sjson.SetRawBytes(added, "annotation", annotation)
+			out = append(out, emitEvent("response.output_text.annotation.added", added))
+		}
+
 		done := []byte(`{"type":"response.output_text.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"text":"","logprobs":[]}`)
 		done, _ = sjson.SetBytes(done, "sequence_number", nextSeq())
 		done, _ = sjson.SetBytes(done, "item_id", st.CurrentMsgID)
@@ -309,15 +355,25 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 		partDone, _ = sjson.SetBytes(partDone, "item_id", st.CurrentMsgID)
 		partDone, _ = sjson.SetBytes(partDone, "output_index", st.MsgIndex)
 		partDone, _ = sjson.SetBytes(partDone, "part.text", fullText)
+		if len(annotations) > 0 {
+			partDone, _ = sjson.SetRawBytes(partDone, "part.annotations", translatorcommon.JoinRawArray(annotations))
+		}
 		out = append(out, emitEvent("response.content_part.done", partDone))
 		final := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}}`)
 		final, _ = sjson.SetBytes(final, "sequence_number", nextSeq())
 		final, _ = sjson.SetBytes(final, "output_index", st.MsgIndex)
 		final, _ = sjson.SetBytes(final, "item.id", st.CurrentMsgID)
 		final, _ = sjson.SetBytes(final, "item.content.0.text", fullText)
+		if len(annotations) > 0 {
+			final, _ = sjson.SetRawBytes(final, "item.content.0.annotations", translatorcommon.JoinRawArray(annotations))
+		}
 		out = append(out, emitEvent("response.output_item.done", final))
 
-		st.CompletedMessages[st.MsgIndex] = geminiCompletedMessageItem{ID: st.CurrentMsgID, Text: fullText}
+		st.CompletedMessages[st.MsgIndex] = geminiCompletedMessageItem{
+			ID:          st.CurrentMsgID,
+			Text:        fullText,
+			Annotations: annotations,
+		}
 		st.MsgClosed = true
 	}
 
@@ -407,6 +463,43 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 
 		st.Started = true
 		st.NextIndex = 0
+	}
+
+	if st.WebSearchRequested && !st.WebSearchEmitted {
+		if groundingMetadata := root.Get("candidates.0.groundingMetadata"); groundingMetadata.Exists() {
+			idx := st.NextIndex
+			st.NextIndex++
+			item := buildOpenAIResponsesWebSearchCallItem(st.ResponseID, groundingMetadata)
+			itemID := gjson.GetBytes(item, "id").String()
+
+			added := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"web_search_call","status":"in_progress"}}`)
+			added, _ = sjson.SetBytes(added, "sequence_number", nextSeq())
+			added, _ = sjson.SetBytes(added, "output_index", idx)
+			added, _ = sjson.SetBytes(added, "item.id", itemID)
+			out = append(out, emitEvent("response.output_item.added", added))
+
+			searching := []byte(`{"type":"response.web_search_call.searching","sequence_number":0,"output_index":0,"item_id":""}`)
+			searching, _ = sjson.SetBytes(searching, "sequence_number", nextSeq())
+			searching, _ = sjson.SetBytes(searching, "output_index", idx)
+			searching, _ = sjson.SetBytes(searching, "item_id", itemID)
+			out = append(out, emitEvent("response.web_search_call.searching", searching))
+
+			completedSearch := []byte(`{"type":"response.web_search_call.completed","sequence_number":0,"output_index":0,"item_id":""}`)
+			completedSearch, _ = sjson.SetBytes(completedSearch, "sequence_number", nextSeq())
+			completedSearch, _ = sjson.SetBytes(completedSearch, "output_index", idx)
+			completedSearch, _ = sjson.SetBytes(completedSearch, "item_id", itemID)
+			out = append(out, emitEvent("response.web_search_call.completed", completedSearch))
+
+			itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{}}`)
+			itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+			itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
+			itemDone, _ = sjson.SetRawBytes(itemDone, "item", item)
+			out = append(out, emitEvent("response.output_item.done", itemDone))
+
+			st.CompletedWebSearch[idx] = item
+			st.WebSearchAnnotations = buildOpenAIResponsesWebSearchAnnotations(groundingMetadata)
+			st.WebSearchEmitted = true
+		}
 	}
 
 	// Handle parts (text/thought/functionCall)
@@ -562,6 +655,7 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 					st.MsgIndex = st.NextIndex
 					st.NextIndex++
 					st.CurrentMsgID = fmt.Sprintf("msg_%s_%d", st.ResponseID, st.MsgIndex)
+					st.CurrentMsgStartOffset = st.VisibleTextOffset
 					item := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"message","status":"in_progress","content":[],"role":"assistant"}}`)
 					item, _ = sjson.SetBytes(item, "sequence_number", nextSeq())
 					item, _ = sjson.SetBytes(item, "output_index", st.MsgIndex)
@@ -576,6 +670,7 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 				}
 				st.LastSemanticKind = geminiResponsesCarrierText
 				st.ItemTextBuf.WriteString(t.String())
+				st.VisibleTextOffset += int64(len(t.String()))
 				msg := []byte(`{"type":"response.output_text.delta","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"delta":"","logprobs":[]}`)
 				msg, _ = sjson.SetBytes(msg, "sequence_number", nextSeq())
 				msg, _ = sjson.SetBytes(msg, "item_id", st.CurrentMsgID)
@@ -852,6 +947,10 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 		// Compose outputs in output_index order.
 		outputs := make([][]byte, 0, st.NextIndex)
 		for idx := 0; idx < st.NextIndex; idx++ {
+			if completedWebSearch, ok := st.CompletedWebSearch[idx]; ok {
+				outputs = append(outputs, completedWebSearch)
+				continue
+			}
 			if completedReasoning, ok := st.CompletedReasoning[idx]; ok {
 				item := []byte(`{"id":"","type":"reasoning","encrypted_content":"","summary":[{"type":"summary_text","text":""}]}`)
 				item, _ = sjson.SetBytes(item, "id", completedReasoning.ID)
@@ -864,6 +963,9 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 				item := []byte(`{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}`)
 				item, _ = sjson.SetBytes(item, "id", completedMessage.ID)
 				item, _ = sjson.SetBytes(item, "content.0.text", completedMessage.Text)
+				if len(completedMessage.Annotations) > 0 {
+					item, _ = sjson.SetRawBytes(item, "content.0.annotations", translatorcommon.JoinRawArray(completedMessage.Annotations))
+				}
 				outputs = append(outputs, item)
 				continue
 			}
@@ -941,6 +1043,9 @@ func ConvertGeminiResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 	reqJSON := pickRequestJSON(originalRequestRawJSON, requestRawJSON)
 	sanitizedNameMap := util.SanitizedToolNameMap(originalRequestRawJSON)
 	toolIdentityMap := util.ResponsesToolReverseIdentityMap(reqJSON)
+	groundingMetadata := root.Get("candidates.0.groundingMetadata")
+	translateWebSearch := groundingMetadata.Exists() && shouldTranslateOpenAIResponsesWebSearch(originalRequestRawJSON, requestRawJSON)
+	var webSearchAnnotations [][]byte
 
 	// Base response scaffold
 	resp := []byte(`{"id":"","object":"response","created_at":0,"status":"completed","background":false,"error":null,"incomplete_details":null}`)
@@ -1100,6 +1205,10 @@ func ConvertGeminiResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 	appendOutput := func(itemJSON []byte) {
 		outputs = append(outputs, itemJSON)
 	}
+	if translateWebSearch {
+		appendOutput(buildOpenAIResponsesWebSearchCallItem(id, groundingMetadata))
+		webSearchAnnotations = buildOpenAIResponsesWebSearchAnnotations(groundingMetadata)
+	}
 	detachedOutputIndex := 0
 	seenDetachedOutputs := make(map[string]bool)
 	appendDetachedOutput := func(signature, direction, targetKind string) {
@@ -1245,6 +1354,7 @@ func ConvertGeminiResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 	flushReasoningOutput()
 	flushMessageOutput()
 
+	visibleTextOffset := int64(0)
 	for _, outputItem := range outputOrder {
 		switch outputItem.kind {
 		case "detached":
@@ -1291,6 +1401,15 @@ func ConvertGeminiResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 			itemJSON := []byte(`{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}`)
 			itemJSON, _ = sjson.SetBytes(itemJSON, "id", fmt.Sprintf("msg_%s_%d", strings.TrimPrefix(id, "resp_"), outputItem.index))
 			itemJSON, _ = sjson.SetBytes(itemJSON, "content.0.text", messageOutput.text)
+			messageAnnotations := openAIResponsesWebSearchAnnotationsForRange(
+				webSearchAnnotations,
+				visibleTextOffset,
+				visibleTextOffset+int64(len(messageOutput.text)),
+			)
+			visibleTextOffset += int64(len(messageOutput.text))
+			if len(messageAnnotations) > 0 {
+				itemJSON, _ = sjson.SetRawBytes(itemJSON, "content.0.annotations", translatorcommon.JoinRawArray(messageAnnotations))
+			}
 			appendOutput(itemJSON)
 		case "function":
 			if outputItem.index < 0 || outputItem.index >= len(functionOutputs) {

--- a/internal/translator/gemini/openai/responses/web_search.go
+++ b/internal/translator/gemini/openai/responses/web_search.go
@@ -1,0 +1,234 @@
+package responses
+
+import (
+	"fmt"
+	"strings"
+
+	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+type openAIResponsesGroundingChunk struct {
+	URL   string
+	Title string
+}
+
+func isOpenAIResponsesWebSearchToolType(toolType string) bool {
+	toolType = strings.ToLower(strings.TrimSpace(toolType))
+	return toolType == "web_search" || strings.HasPrefix(toolType, "web_search_")
+}
+
+func hasOpenAIResponsesWebSearchTool(payload []byte) bool {
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return false
+	}
+	root := gjson.ParseBytes(payload)
+	for _, path := range []string{"tools", "request.tools"} {
+		tools := root.Get(path)
+		if !tools.IsArray() {
+			continue
+		}
+		for _, tool := range tools.Array() {
+			if isOpenAIResponsesWebSearchToolType(tool.Get("type").String()) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasGeminiGoogleSearchTool(payload []byte) bool {
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return false
+	}
+	root := gjson.ParseBytes(payload)
+	for _, path := range []string{"tools", "request.tools"} {
+		tools := root.Get(path)
+		if !tools.IsArray() {
+			continue
+		}
+		for _, tool := range tools.Array() {
+			if tool.Get("googleSearch").Exists() || tool.Get("google_search").Exists() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func shouldTranslateOpenAIResponsesWebSearch(originalRequestRawJSON, requestRawJSON []byte) bool {
+	return hasOpenAIResponsesWebSearchTool(originalRequestRawJSON) ||
+		hasOpenAIResponsesWebSearchTool(requestRawJSON) ||
+		hasGeminiGoogleSearchTool(requestRawJSON)
+}
+
+func openAIResponsesGroundingChunks(groundingMetadata gjson.Result) []openAIResponsesGroundingChunk {
+	chunksResult := groundingMetadata.Get("groundingChunks")
+	if !chunksResult.IsArray() {
+		return nil
+	}
+	chunks := make([]openAIResponsesGroundingChunk, 0, len(chunksResult.Array()))
+	for _, chunk := range chunksResult.Array() {
+		web := chunk.Get("web")
+		chunks = append(chunks, openAIResponsesGroundingChunk{
+			URL:   strings.TrimSpace(web.Get("uri").String()),
+			Title: web.Get("title").String(),
+		})
+	}
+	return chunks
+}
+
+func buildOpenAIResponsesWebSearchSources(groundingMetadata gjson.Result) [][]byte {
+	seenURLs := make(map[string]bool)
+	var sources [][]byte
+	for _, chunk := range openAIResponsesGroundingChunks(groundingMetadata) {
+		if chunk.URL == "" || seenURLs[chunk.URL] {
+			continue
+		}
+		seenURLs[chunk.URL] = true
+		source := []byte(`{"type":"url","url":""}`)
+		source, _ = sjson.SetBytes(source, "url", chunk.URL)
+		sources = append(sources, source)
+	}
+	return sources
+}
+
+func buildOpenAIResponsesWebSearchAnnotations(groundingMetadata gjson.Result) [][]byte {
+	chunks := openAIResponsesGroundingChunks(groundingMetadata)
+	if len(chunks) == 0 {
+		return nil
+	}
+	supports := groundingMetadata.Get("groundingSupports")
+	if !supports.IsArray() {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var annotations [][]byte
+	for _, support := range supports.Array() {
+		segment := support.Get("segment")
+		if !segment.Exists() {
+			continue
+		}
+		startIndex := segment.Get("startIndex").Int()
+		endIndex := segment.Get("endIndex").Int()
+		if startIndex < 0 || endIndex <= startIndex {
+			continue
+		}
+		chunkIndices := support.Get("groundingChunkIndices")
+		if !chunkIndices.IsArray() {
+			continue
+		}
+		for _, chunkIndexResult := range chunkIndices.Array() {
+			chunkIndex := int(chunkIndexResult.Int())
+			if chunkIndex < 0 || chunkIndex >= len(chunks) || chunks[chunkIndex].URL == "" {
+				continue
+			}
+			chunk := chunks[chunkIndex]
+			key := fmt.Sprintf("%d:%d:%s", startIndex, endIndex, chunk.URL)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			annotation := []byte(`{"type":"url_citation","start_index":0,"end_index":0,"url":"","title":""}`)
+			annotation, _ = sjson.SetBytes(annotation, "start_index", startIndex)
+			annotation, _ = sjson.SetBytes(annotation, "end_index", endIndex)
+			annotation, _ = sjson.SetBytes(annotation, "url", chunk.URL)
+			annotation, _ = sjson.SetBytes(annotation, "title", chunk.Title)
+			annotations = append(annotations, annotation)
+		}
+	}
+	return annotations
+}
+
+func openAIResponsesWebSearchAnnotationsForRange(annotations [][]byte, startIndex, endIndex int64) [][]byte {
+	if len(annotations) == 0 || endIndex <= startIndex {
+		return nil
+	}
+	var ranged [][]byte
+	for _, annotation := range annotations {
+		result := gjson.ParseBytes(annotation)
+		annotationStart := result.Get("start_index").Int()
+		annotationEnd := result.Get("end_index").Int()
+		if annotationStart < startIndex || annotationEnd > endIndex || annotationEnd <= annotationStart {
+			continue
+		}
+		adjusted := append([]byte(nil), annotation...)
+		adjusted, _ = sjson.SetBytes(adjusted, "start_index", annotationStart-startIndex)
+		adjusted, _ = sjson.SetBytes(adjusted, "end_index", annotationEnd-startIndex)
+		ranged = append(ranged, adjusted)
+	}
+	return ranged
+}
+
+func buildOpenAIResponsesWebSearchCallItem(responseID string, groundingMetadata gjson.Result) []byte {
+	itemIDBase := strings.TrimPrefix(responseID, "resp_")
+	if itemIDBase == "" {
+		itemIDBase = "search"
+	}
+	item := []byte(`{"id":"","type":"web_search_call","status":"completed","action":{"type":"search","query":"","sources":[]}}`)
+	item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("ws_%s_0", itemIDBase))
+	if queries := groundingMetadata.Get("webSearchQueries"); queries.IsArray() {
+		for _, query := range queries.Array() {
+			if value := strings.TrimSpace(query.String()); value != "" {
+				item, _ = sjson.SetBytes(item, "action.query", value)
+				break
+			}
+		}
+	}
+	if sources := buildOpenAIResponsesWebSearchSources(groundingMetadata); len(sources) > 0 {
+		item, _ = sjson.SetRawBytes(item, "action.sources", translatorcommon.JoinRawArray(sources))
+	}
+	return item
+}
+
+func bufferGeminiResponsesWebSearchStreamChunk(st *geminiToResponsesState, root gjson.Result) (gjson.Result, bool) {
+	if parts := root.Get("candidates.0.content.parts"); parts.IsArray() {
+		for _, part := range parts.Array() {
+			st.WebSearchBufferedParts = append(st.WebSearchBufferedParts, []byte(part.Raw))
+		}
+	}
+	if value := root.Get("responseId"); value.Exists() && value.String() != "" {
+		st.WebSearchResponseID = value.String()
+	}
+	if value := root.Get("createTime"); value.Exists() && value.String() != "" {
+		st.WebSearchCreateTime = value.String()
+	}
+	if value := root.Get("modelVersion"); value.Exists() && value.String() != "" {
+		st.WebSearchModelVersion = value.String()
+	}
+	if value := root.Get("usageMetadata"); value.Exists() {
+		st.WebSearchUsageMetadata = []byte(value.Raw)
+	}
+	if value := root.Get("candidates.0.groundingMetadata"); value.Exists() {
+		st.WebSearchGroundingMetadata = []byte(value.Raw)
+	}
+
+	finishReason := root.Get("candidates.0.finishReason").String()
+	if finishReason == "" {
+		return gjson.Result{}, false
+	}
+
+	payload := []byte(`{"candidates":[{"content":{"parts":[]},"finishReason":""}]}`)
+	payload, _ = sjson.SetBytes(payload, "candidates.0.finishReason", finishReason)
+	if len(st.WebSearchBufferedParts) > 0 {
+		payload, _ = sjson.SetRawBytes(payload, "candidates.0.content.parts", translatorcommon.JoinRawArray(st.WebSearchBufferedParts))
+	}
+	if st.WebSearchResponseID != "" {
+		payload, _ = sjson.SetBytes(payload, "responseId", st.WebSearchResponseID)
+	}
+	if st.WebSearchCreateTime != "" {
+		payload, _ = sjson.SetBytes(payload, "createTime", st.WebSearchCreateTime)
+	}
+	if st.WebSearchModelVersion != "" {
+		payload, _ = sjson.SetBytes(payload, "modelVersion", st.WebSearchModelVersion)
+	}
+	if len(st.WebSearchUsageMetadata) > 0 {
+		payload, _ = sjson.SetRawBytes(payload, "usageMetadata", st.WebSearchUsageMetadata)
+	}
+	if len(st.WebSearchGroundingMetadata) > 0 {
+		payload, _ = sjson.SetRawBytes(payload, "candidates.0.groundingMetadata", st.WebSearchGroundingMetadata)
+	}
+	return gjson.ParseBytes(payload), true
+}

--- a/internal/translator/gemini/openai/responses/web_search_test.go
+++ b/internal/translator/gemini/openai/responses/web_search_test.go
@@ -1,0 +1,175 @@
+package responses
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertOpenAIResponsesRequestToGemini_WebSearchTools(t *testing.T) {
+	for _, toolType := range []string{"web_search", "web_search_preview", "web_search_preview_2025_03_11"} {
+		t.Run(toolType, func(t *testing.T) {
+			input := []byte(`{"model":"gemini-test","input":"latest Go release","tools":[{"type":"` + toolType + `"}]}`)
+			output := ConvertOpenAIResponsesRequestToGemini("gemini-test", input, false)
+
+			tools := gjson.GetBytes(output, "tools").Array()
+			if len(tools) != 1 {
+				t.Fatalf("tools length = %d, want 1; output=%s", len(tools), output)
+			}
+			if !tools[0].Get("googleSearch").Exists() {
+				t.Fatalf("googleSearch tool missing: %s", output)
+			}
+			if tools[0].Get("functionDeclarations").Exists() {
+				t.Fatalf("web search unexpectedly became a function declaration: %s", output)
+			}
+		})
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGemini_WebSearchAndFunctionToolsRemainSeparate(t *testing.T) {
+	input := []byte(`{
+		"model":"gemini-test",
+		"input":"find the release and save it",
+		"tools":[
+			{"type":"web_search"},
+			{"type":"function","name":"save_release","description":"Save a release","parameters":{"type":"object","properties":{"version":{"type":"string"}}}}
+		]
+	}`)
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-test", input, false)
+
+	tools := gjson.GetBytes(output, "tools").Array()
+	if len(tools) != 2 {
+		t.Fatalf("tools length = %d, want 2; output=%s", len(tools), output)
+	}
+	if got := tools[0].Get("functionDeclarations.0.name").String(); got != "save_release" {
+		t.Fatalf("function declaration name = %q, want save_release; output=%s", got, output)
+	}
+	if !tools[1].Get("googleSearch").Exists() {
+		t.Fatalf("googleSearch must be a separate Gemini tool: %s", output)
+	}
+}
+
+func TestConvertGeminiResponseToOpenAIResponsesNonStream_WebSearchGrounding(t *testing.T) {
+	request := []byte(`{"model":"gemini-test","input":"latest Go release","tools":[{"type":"web_search"}]}`)
+	response := []byte(`{
+		"responseId":"search-nonstream",
+		"candidates":[{
+			"content":{"parts":[{"text":"Go 1.26 is current."}]},
+			"groundingMetadata":{
+				"webSearchQueries":["latest Go release"],
+				"groundingChunks":[{"web":{"uri":"https://go.dev/doc/go1.26","title":"Go 1.26 Release Notes"}}],
+				"groundingSupports":[{"segment":{"startIndex":0,"endIndex":7,"text":"Go 1.26"},"groundingChunkIndices":[0]}]
+			},
+			"finishReason":"STOP"
+		}]
+	}`)
+
+	output := ConvertGeminiResponseToOpenAIResponsesNonStream(context.Background(), "gemini-test", request, nil, response, nil)
+	if got := gjson.GetBytes(output, "output.0.type").String(); got != "web_search_call" {
+		t.Fatalf("output.0.type = %q, want web_search_call; output=%s", got, output)
+	}
+	if got := gjson.GetBytes(output, "output.0.status").String(); got != "completed" {
+		t.Fatalf("web search status = %q, want completed; output=%s", got, output)
+	}
+	if got := gjson.GetBytes(output, "output.0.action.query").String(); got != "latest Go release" {
+		t.Fatalf("web search query = %q; output=%s", got, output)
+	}
+	if got := gjson.GetBytes(output, "output.0.action.sources.0.url").String(); got != "https://go.dev/doc/go1.26" {
+		t.Fatalf("web search source URL = %q; output=%s", got, output)
+	}
+	if got := gjson.GetBytes(output, "output.1.type").String(); got != "message" {
+		t.Fatalf("output.1.type = %q, want message; output=%s", got, output)
+	}
+	annotation := gjson.GetBytes(output, "output.1.content.0.annotations.0")
+	if annotation.Get("type").String() != "url_citation" || annotation.Get("url").String() != "https://go.dev/doc/go1.26" {
+		t.Fatalf("unexpected citation annotation: %s; output=%s", annotation.Raw, output)
+	}
+	if annotation.Get("start_index").Int() != 0 || annotation.Get("end_index").Int() != 7 {
+		t.Fatalf("citation offsets = %d..%d, want 0..7; output=%s", annotation.Get("start_index").Int(), annotation.Get("end_index").Int(), output)
+	}
+}
+
+func TestConvertGeminiResponseToOpenAIResponses_StreamBuffersWebSearchBeforeMessage(t *testing.T) {
+	request := []byte(`{"model":"gemini-test","input":"latest Go release","tools":[{"type":"web_search"}]}`)
+	var param any
+
+	first := []byte(`data: {"responseId":"search-stream","candidates":[{"content":{"parts":[{"text":"Go 1.26 "}]}}]}`)
+	if output := ConvertGeminiResponseToOpenAIResponses(context.Background(), "gemini-test", request, nil, first, &param); len(output) != 0 {
+		t.Fatalf("web-search stream emitted text before grounding metadata: %q", output)
+	}
+
+	final := []byte(`data: {
+		"responseId":"search-stream",
+		"candidates":[{
+			"content":{"parts":[{"text":"is current."}]},
+			"groundingMetadata":{
+				"webSearchQueries":["latest Go release"],
+				"groundingChunks":[{"web":{"uri":"https://go.dev/doc/go1.26","title":"Go 1.26 Release Notes"}}],
+				"groundingSupports":[{"segment":{"startIndex":0,"endIndex":7,"text":"Go 1.26"},"groundingChunkIndices":[0]}]
+			},
+			"finishReason":"STOP"
+		}],
+		"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":4,"totalTokenCount":9}
+	}`)
+	output := ConvertGeminiResponseToOpenAIResponses(context.Background(), "gemini-test", request, nil, final, &param)
+	if len(output) == 0 {
+		t.Fatal("final web-search stream emitted no events")
+	}
+
+	webSearchDoneIndex := -1
+	messageAddedIndex := -1
+	searchingSeen := false
+	completedSeen := false
+	annotationSeen := false
+	var completedResponse gjson.Result
+	for i, chunk := range output {
+		event, data := parseSSEEvent(t, chunk)
+		switch event {
+		case "response.output_item.done":
+			if data.Get("item.type").String() == "web_search_call" {
+				webSearchDoneIndex = i
+			}
+		case "response.output_item.added":
+			if data.Get("item.type").String() == "message" && messageAddedIndex < 0 {
+				messageAddedIndex = i
+			}
+		case "response.web_search_call.searching":
+			searchingSeen = true
+		case "response.web_search_call.completed":
+			completedSeen = true
+		case "response.output_text.annotation.added":
+			annotationSeen = data.Get("annotation.type").String() == "url_citation"
+		case "response.completed":
+			completedResponse = data.Get("response")
+		}
+	}
+
+	if webSearchDoneIndex < 0 || messageAddedIndex < 0 || webSearchDoneIndex >= messageAddedIndex {
+		t.Fatalf("web_search_call must complete before the message starts; web=%d message=%d", webSearchDoneIndex, messageAddedIndex)
+	}
+	if !searchingSeen || !completedSeen {
+		t.Fatalf("missing web search lifecycle events: searching=%v completed=%v", searchingSeen, completedSeen)
+	}
+	if !annotationSeen {
+		t.Fatal("missing response.output_text.annotation.added event")
+	}
+	if got := completedResponse.Get("output.0.type").String(); got != "web_search_call" {
+		t.Fatalf("completed response output.0.type = %q, want web_search_call; response=%s", got, completedResponse.Raw)
+	}
+	if got := completedResponse.Get("output.1.content.0.text").String(); got != "Go 1.26 is current." {
+		t.Fatalf("buffered message text = %q; response=%s", got, completedResponse.Raw)
+	}
+	if got := completedResponse.Get("output.1.content.0.annotations.0.url").String(); got != "https://go.dev/doc/go1.26" {
+		t.Fatalf("completed response citation URL = %q; response=%s", got, completedResponse.Raw)
+	}
+}
+
+func TestBuildOpenAIResponsesWebSearchCallItem_AlwaysIncludesQuery(t *testing.T) {
+	groundingMetadata := gjson.Parse(`{"groundingChunks":[{"web":{"uri":"https://example.com"}}]}`)
+	item := buildOpenAIResponsesWebSearchCallItem("resp_query-default", groundingMetadata)
+	query := gjson.GetBytes(item, "action.query")
+	if !query.Exists() || query.Type != gjson.String || query.String() != "" {
+		t.Fatalf("action.query must be an empty string when upstream omits queries: %s", item)
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds full support for OpenAI Responses (`/v1/responses`) built-in web search tools (`web_search` and `web_search_preview*`) when routed to Gemini and Antigravity backends.

### Problem
1. **Request Translation**: In `ConvertOpenAIResponsesRequestToGemini`, only `type: "function"` tools were processed; built-in `web_search` tools were silently dropped, so Gemini/Antigravity received no `googleSearch` tool.
2. **Response Grounding Translation**: When Gemini/Antigravity performed web searches and returned `groundingMetadata`, the Responses response translator did not convert this metadata into OpenAI Responses `web_search_call` items or message `url_citation` annotations.
3. **Streaming Event Ordering**: Gemini emits `groundingMetadata` in the final `STOP` chunk. In the OpenAI Responses SSE protocol, clients (and UI tools) expect the `web_search_call` lifecycle events (`response.output_item.added`, `searching`, `completed`, `response.output_item.done`) to precede the generated message content.
4. **Antigravity URL Resolution**: `AntigravityExecutor.shouldResolveAntigravityWebSearchGroundingURLs` only matched `FormatClaude`, skipping encrypted grounding URL redirection for Responses requests.

### Solution
1. **Request Translation**: Map `web_search` and `web_search_preview*` tool types to native Gemini `{"googleSearch":{}}` while ensuring function declarations and Google Search tools remain separate objects in the `tools` array (Gemini constraint).
2. **Response Translation (Non-Stream & Stream)**:
   - Construct `web_search_call` output items containing query and source URLs.
   - Map `groundingSupports` to message content part `url_citation` annotations with correct start/end character offsets.
   - For streaming responses with web search enabled, buffer response chunks until the terminal chunk with `groundingMetadata` arrives, ensuring `web_search_call` events are emitted before `message` content events.
3. **Antigravity Grounding Resolution**: Update Antigravity executor to resolve grounding URLs for `sdktranslator.FormatOpenAIResponse` requests.

---

## Changes

- `internal/runtime/executor/antigravity_executor.go`:
  - Added `hasAntigravityOpenAIResponsesWebSearchTool` to detect OpenAI Responses web search tools in original request payload.
  - Extended `shouldResolveAntigravityWebSearchGroundingURLs` to handle `FormatOpenAIResponse`.
- `internal/runtime/executor/antigravity_executor_web_search_test.go`:
  - Added unit tests for Antigravity executor Responses web search URL resolution condition.
- `internal/translator/gemini/openai/responses/gemini_openai-responses_request.go`:
  - Convert `web_search` and `web_search_preview*` to Gemini `googleSearch` tool while preserving function tools.
- `internal/translator/gemini/openai/responses/gemini_openai-responses_response.go`:
  - Emit `web_search_call` items and `url_citation` annotations in non-stream responses.
  - Add streaming chunk buffering and lifecycle event emission for grounded search streams.
- `internal/translator/gemini/openai/responses/web_search.go`:
  - Add helper functions for source URL extraction, citation annotation mapping, and stream chunk buffering.
- `internal/translator/gemini/openai/responses/web_search_test.go`:
  - Unit tests for request tool mapping, mixed tool separation, non-stream response grounding conversion, streaming event ordering, and fallback queries.
- `internal/translator/antigravity/openai/responses/web_search_test.go`:
  - Integration unit tests for Antigravity request conversion and non-stream response grounding translation.

---

## Related Issues and PRs

- **Closes / References**:
  - #4503 - `fix(antigravity): OpenAI Responses web_search is silently dropped`
  - #3404 - `Map OpenAI web_search tool to Gemini googleSearch`
- **Related Prior Work**:
  - #3824 - `[codex] Bridge Claude WebSearch to Antigravity googleSearch`
  - #3868 - `fix(translator): emit Claude server tool blocks for Codex web_search_call streams`
  - #2223 - `fix: normalize web_search_preview for codex responses`
  - #553 - `fix(translator): preserve built-in tools (web_search) to Responses API`
  - #2769 - `Buffer Gemini grounded-search streams to preserve Claude web_search event order`
  - #1077 - `functionDeclarations 和 googleSearch 合并到同一个 tool 对象导致 Gemini API 报错`

---

## Verification & Testing

1. **Automated Unit Tests**:
   ```bash
   go test -v ./internal/translator/gemini/openai/responses/...
   go test -v ./internal/translator/antigravity/openai/responses/...
   go test -v ./internal/runtime/executor -run TestAntigravity
   go build -o test-output ./cmd/server && rm test-output
   ```
   All tests pass and the server builds cleanly without errors or warnings.

2. **Live Environment Testing (实机测试声明)**:
   - Tested using **Gemini API** and **Antigravity subscription**.
   - **Note**: Only tested against the **`gemini-3.1-flash-lite`** model (声明：已使用 Gemini API 和 Antigravity 订阅进行实机测试验证，但目前仅测试了 `gemini-3.1-flash-lite` 模型。经测试，联网搜索被成功触发，并能正确回传搜索调用与引用信息)。

