### PR TITLE
feat(auth): add session affinity priority failback

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -218,6 +218,9 @@ routing:
   session-affinity: false # default: false
   # How long session-to-auth bindings are retained. Default: 1h
   session-affinity-ttl: "1h"
+  # When true, a recovered higher-priority credential preempts a lower-priority
+  # session binding. Equal-priority bindings remain sticky. Default: false.
+  session-affinity-priority-failback: false
 
 # Codex provider behavior.
 codex:

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -237,6 +237,10 @@ type RoutingConfig struct {
 	// SessionAffinityTTL specifies how long session-to-auth bindings are retained.
 	// Default: 1h. Accepts duration strings like "30m", "1h", "2h30m".
 	SessionAffinityTTL string `yaml:"session-affinity-ttl,omitempty" json:"session-affinity-ttl,omitempty"`
+
+	// SessionAffinityPriorityFailback lets a recovered higher-priority credential
+	// preempt an available lower-priority session binding. Default: false.
+	SessionAffinityPriorityFailback bool `yaml:"session-affinity-priority-failback,omitempty" json:"session-affinity-priority-failback,omitempty"`
 }
 
 // OAuthModelAlias defines a model ID alias for a specific channel.

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -610,14 +610,16 @@ func availabilityBlock(unavailable, quotaExceeded bool, nextRetryAfter, nextReco
 // It extracts session ID from multiple sources and maintains session-to-auth
 // mappings with automatic failover when the bound auth becomes unavailable.
 type SessionAffinitySelector struct {
-	fallback Selector
-	cache    *SessionCache
+	fallback         Selector
+	cache            *SessionCache
+	priorityFailback bool
 }
 
 // SessionAffinityConfig configures the session affinity selector.
 type SessionAffinityConfig struct {
-	Fallback Selector
-	TTL      time.Duration
+	Fallback         Selector
+	TTL              time.Duration
+	PriorityFailback bool
 }
 
 // NewSessionAffinitySelector creates a new session-aware selector.
@@ -637,8 +639,9 @@ func NewSessionAffinitySelectorWithConfig(cfg SessionAffinityConfig) *SessionAff
 		cfg.TTL = time.Hour
 	}
 	return &SessionAffinitySelector{
-		fallback: cfg.Fallback,
-		cache:    NewSessionCache(cfg.TTL),
+		fallback:         cfg.Fallback,
+		cache:            NewSessionCache(cfg.TTL),
+		priorityFailback: cfg.PriorityFailback,
 	}
 }
 
@@ -646,10 +649,10 @@ func NewSessionAffinitySelectorWithConfig(cfg SessionAffinityConfig) *SessionAff
 // Explicit Claude Code, Codex, OpenCode, pi, and request-body session signals
 // precede execution metadata, stable derived identity, and the legacy hash fallback.
 //
-// An established binding outranks credential priority: a bound credential that is still
-// available is reused even when a higher-priority credential recovers. Credential priority
-// applies to cold bindings, requests without a session, and genuine bound-credential
-// failover, so the fallback selector only ever receives the highest available priority tier.
+// By default, an established binding outranks credential priority: a bound credential that
+// is still available is reused even when a higher-priority credential recovers. When priority
+// failback is enabled, a recovered higher-priority tier preempts a lower-priority binding.
+// The fallback selector only ever receives the highest available priority tier.
 //
 // Note: The cache key includes provider, session ID, and model to handle cases where
 // a session uses multiple models (e.g., gemini-2.5-pro and gemini-3-flash-preview)
@@ -697,10 +700,28 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		}
 		s.cache.Set(cacheKey, authID)
 	}
+	rebindHigherPriority := func(cached *Auth) (*Auth, bool, error) {
+		if !s.shouldPriorityFailback(cached, fallbackAuths) {
+			return nil, false, nil
+		}
+		selected, errPick := s.fallback.Pick(ctx, provider, model, opts, fallbackAuths)
+		if errPick != nil {
+			return nil, true, errPick
+		}
+		bind(selected.ID)
+		return selected, true, nil
+	}
 
 	if cachedAuthID, ok := s.cache.GetAndRefresh(cacheKey); ok {
 		for _, auth := range available {
 			if auth.ID == cachedAuthID {
+				if selected, rebound, errPick := rebindHigherPriority(auth); rebound {
+					if errPick != nil {
+						return nil, errPick
+					}
+					entry.Infof("session-affinity: higher-priority auth available, rebound | session=%s previous_auth=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, selected.ID, provider, model)
+					return selected, nil
+				}
 				bind(auth.ID)
 				entry.Infof("session-affinity: cache hit | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
 				return auth, nil
@@ -720,6 +741,13 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		if cachedAuthID, ok := s.cache.Get(fallbackKey); ok {
 			for _, auth := range available {
 				if auth.ID == cachedAuthID {
+					if selected, rebound, errPick := rebindHigherPriority(auth); rebound {
+						if errPick != nil {
+							return nil, errPick
+						}
+						entry.Infof("session-affinity: higher-priority auth available, rebound | session=%s fallback=%s previous_auth=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, selected.ID, provider, model)
+						return selected, nil
+					}
 					bind(auth.ID)
 					entry.Infof("session-affinity: fallback cache hit | session=%s fallback=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model)
 					return auth, nil
@@ -735,6 +763,10 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	bind(auth.ID)
 	entry.Infof("session-affinity: cache miss, new binding | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
 	return auth, nil
+}
+
+func (s *SessionAffinitySelector) shouldPriorityFailback(cached *Auth, fallbackAuths []*Auth) bool {
+	return s.priorityFailback && len(fallbackAuths) > 0 && authPriority(fallbackAuths[0]) > authPriority(cached)
 }
 
 func selectorLogEntry(ctx context.Context) *log.Entry {

--- a/sdk/cliproxy/auth/session_affinity_priority_test.go
+++ b/sdk/cliproxy/auth/session_affinity_priority_test.go
@@ -116,6 +116,59 @@ func TestManagerSessionAffinityPreservesBindingAcrossHigherPriorityRecovery(t *t
 	}
 }
 
+func TestSessionAffinityPriorityFailbackRebindsRecoveredHigherPriority(t *testing.T) {
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback:         &RoundRobinSelector{},
+		TTL:              time.Hour,
+		PriorityFailback: true,
+	})
+	defer selector.Stop()
+
+	high := &Auth{
+		ID:          "high",
+		Provider:    "test",
+		Status:      StatusActive,
+		Unavailable: true,
+		Attributes:  map[string]string{"priority": "1"},
+	}
+	low := &Auth{
+		ID:         "low",
+		Provider:   "test",
+		Status:     StatusActive,
+		Attributes: map[string]string{"priority": "0"},
+	}
+	auths := []*Auth{high, low}
+	opts := cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.DerivedSessionIDMetadataKey: "stable-session",
+	}}
+
+	got, errPick := selector.Pick(context.Background(), "test", "model", opts, auths)
+	if errPick != nil {
+		t.Fatalf("initial Pick: %v", errPick)
+	}
+	if got.ID != low.ID {
+		t.Fatalf("initial binding = %q, want available lower priority %q", got.ID, low.ID)
+	}
+
+	high.Unavailable = false
+	got, errPick = selector.Pick(context.Background(), "test", "model", opts, auths)
+	if errPick != nil {
+		t.Fatalf("Pick after recovery: %v", errPick)
+	}
+	if got.ID != high.ID {
+		t.Fatalf("binding after higher-priority recovery = %q, want %q", got.ID, high.ID)
+	}
+
+	peer := &Auth{ID: "peer", Provider: "test", Status: StatusActive, Attributes: map[string]string{"priority": "1"}}
+	got, errPick = selector.Pick(context.Background(), "test", "model", opts, append(auths, peer))
+	if errPick != nil {
+		t.Fatalf("Pick with equal-priority peer: %v", errPick)
+	}
+	if got.ID != high.ID {
+		t.Fatalf("binding with equal-priority peer = %q, want sticky %q", got.ID, high.ID)
+	}
+}
+
 func TestSessionAffinityFallbackOnlyReceivesHighestAvailablePriority(t *testing.T) {
 	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
 		Fallback: lastAuthSelector{},

--- a/sdk/cliproxy/service_config.go
+++ b/sdk/cliproxy/service_config.go
@@ -25,9 +25,10 @@ type configCommit struct {
 }
 
 type routingRuntimeState struct {
-	strategy           string
-	sessionAffinity    bool
-	sessionAffinityTTL time.Duration
+	strategy                        string
+	sessionAffinity                 bool
+	sessionAffinityTTL              time.Duration
+	sessionAffinityPriorityFailback bool
 }
 
 func normalizedRoutingRuntimeState(cfg *config.Config) routingRuntimeState {
@@ -46,6 +47,7 @@ func normalizedRoutingRuntimeState(cfg *config.Config) routingRuntimeState {
 		state.strategy = "fill-first"
 	}
 	state.sessionAffinity = cfg.Routing.SessionAffinity
+	state.sessionAffinityPriorityFailback = cfg.Routing.SessionAffinityPriorityFailback
 	if ttl := strings.TrimSpace(cfg.Routing.SessionAffinityTTL); ttl != "" {
 		if parsed, errParse := time.ParseDuration(ttl); errParse == nil && parsed > 0 {
 			state.sessionAffinityTTL = parsed
@@ -66,8 +68,9 @@ func newRoutingSelector(state routingRuntimeState) coreauth.Selector {
 	}
 	if state.sessionAffinity {
 		selector = coreauth.NewSessionAffinitySelectorWithConfig(coreauth.SessionAffinityConfig{
-			Fallback: selector,
-			TTL:      state.sessionAffinityTTL,
+			Fallback:         selector,
+			TTL:              state.sessionAffinityTTL,
+			PriorityFailback: state.sessionAffinityPriorityFailback,
 		})
 	}
 	return selector

--- a/sdk/cliproxy/service_config_weight_test.go
+++ b/sdk/cliproxy/service_config_weight_test.go
@@ -21,6 +21,54 @@ func TestWeightedRoundRobinRoutingSelector(t *testing.T) {
 	}
 }
 
+func TestSessionAffinityPriorityFailbackRoutingConfig(t *testing.T) {
+	state := normalizedRoutingRuntimeState(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{
+			SessionAffinity:                 true,
+			SessionAffinityPriorityFailback: true,
+		},
+	})
+	selector, ok := newRoutingSelector(state).(*coreauth.SessionAffinitySelector)
+	if !ok {
+		t.Fatalf("selector type = %T, want *auth.SessionAffinitySelector", newRoutingSelector(state))
+	}
+	defer selector.Stop()
+
+	high := &coreauth.Auth{
+		ID:          "high",
+		Provider:    "test",
+		Status:      coreauth.StatusActive,
+		Unavailable: true,
+		Attributes:  map[string]string{"priority": "1"},
+	}
+	low := &coreauth.Auth{
+		ID:         "low",
+		Provider:   "test",
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"priority": "0"},
+	}
+	opts := cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.DerivedSessionIDMetadataKey: "stable-session",
+	}}
+
+	got, errPick := selector.Pick(context.Background(), "test", "model", opts, []*coreauth.Auth{high, low})
+	if errPick != nil {
+		t.Fatalf("initial Pick: %v", errPick)
+	}
+	if got.ID != low.ID {
+		t.Fatalf("initial binding = %q, want %q", got.ID, low.ID)
+	}
+
+	high.Unavailable = false
+	got, errPick = selector.Pick(context.Background(), "test", "model", opts, []*coreauth.Auth{high, low})
+	if errPick != nil {
+		t.Fatalf("Pick after recovery: %v", errPick)
+	}
+	if got.ID != high.ID {
+		t.Fatalf("binding after higher-priority recovery = %q, want %q", got.ID, high.ID)
+	}
+}
+
 func TestServiceRejectsInvalidCredentialWeightConfigCommit(t *testing.T) {
 	originalCfg := &internalconfig.Config{}
 	service := &Service{cfg: originalCfg}


### PR DESCRIPTION
## Summary

- add opt-in `routing.session-affinity-priority-failback` routing behavior
- rebind a cached lower-priority session when a higher-priority tier recovers
- preserve current sticky behavior by default and within equal-priority tiers
- document the setting in `config.example.yaml`

## Why

Session affinity can keep a session on a lower-priority overflow provider after the preferred credential recovers. Deployments that use priority for paid-provider overflow need an explicit way to fail back without restarting the proxy or waiting for the affinity TTL.

## Verification

- `go test ./sdk/cliproxy/auth ./sdk/cliproxy`
- `go build -o /dev/null ./cmd/server`

The selector tests cover default sticky behavior, lower-tier failover, opt-in higher-priority failback, and equal-priority stickiness.