### PR TITLE
fix(claude): harden Codex-backed Claude Code compatibility

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -172,11 +172,6 @@ transient-error-cooldown-seconds: 0
 # "auto" behavior (cloak only non-Claude-Code clients).
 disable-claude-cloak-mode: false
 
-# Claude Code compatibility settings.
-claude-code:
-  # When true, return original model IDs in Anthropic model list responses instead of cloaked IDs.
-  disable-cloaking-model-list: false
-
 # disable-image-generation supports: false (default), true, "chat", or "passthrough".
 # - true: disable image_generation everywhere (also returns 404 for /v1/images/generations and /v1/images/edits).
 # - "chat": disable image_generation injection on non-images endpoints, but keep /v1/images/generations and /v1/images/edits enabled.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -230,6 +230,21 @@ codex:
   # normalizes encrypted agent_message content for Codex, and converts agent_message input
   # into standard user messages for non-Codex upstream protocols.
   optimize-multi-agent-v2: false
+  # — WebSocket upstream transport (reduces mid-stream disconnection errors) —
+  #
+  # enable-websocket-upstream: When true, Codex OAuth credentials (prolite, etc.)
+  #   connect to the upstream via wss:// instead of https://. WebSocket provides
+  #   ping/pong keepalives, explicit disconnect detection, and automatic reconnect
+  #   on send failure — all of which HTTP/2 lacks. This significantly reduces
+  #   "stream closed before response.completed" (408) errors caused by silent
+  #   mid-stream disconnections from intermediate proxies or server-side timeouts.
+  #
+  #   Per-credential override: set "websockets": false in the auth JSON file or
+  #   toggle the credential's WebSockets switch off in the management UI. Both
+  #   overrides take precedence over this global default.
+  #
+  #   Default: false (opt-in, safe default — no behavioral change without explicit enable).
+  enable-websocket-upstream: false
   # Terminate and relay Codex Live WebRTC audio and DataChannel traffic in this process.
   # This requires inbound UDP reachability. Keep disabled to preserve direct media behavior.
   live-media-relay:

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -724,8 +724,7 @@ func (s *Server) handleHomeModels(c *gin.Context) {
 	isClaude := isAnthropicModelsRequest(c)
 
 	if isClaude {
-		disableCloaking := s.cfg != nil && s.cfg.ClaudeCode.DisableCloakingModelList
-		c.JSON(http.StatusOK, claudemodels.BuildResponse(formatHomeClaudeModels(entries), disableCloaking))
+		c.JSON(http.StatusOK, claudemodels.BuildResponse(formatHomeClaudeModels(entries)))
 		return
 	}
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -29,6 +29,7 @@ import (
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+	"github.com/tidwall/gjson"
 )
 
 type codexSearchCaptureExecutor struct {
@@ -1606,7 +1607,7 @@ func TestExampleAPIKeySafeModeShowsWarningAndKeepsManagement(t *testing.T) {
 	})
 
 	t.Run("proxy endpoints are blocked", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		req := httptest.NewRequest(http.MethodGet, "/v1/models?limit=1000", nil)
 		rr := httptest.NewRecorder()
 		server.engine.ServeHTTP(rr, req)
 		if rr.Code != http.StatusForbidden {
@@ -1718,22 +1719,47 @@ func TestModelsDispatchByAnthropicVersionHeader(t *testing.T) {
 			switch id {
 			case "claude-sonnet-4-6":
 				claudeModel = m
-			case "claude-fable-5-dd-o4-tpg":
+			case "claude/gpt-4o":
 				rewrittenModel = m
-			case "gpt-4o", "claude-gpt-4o":
-				t.Fatalf("expected non-claude model id to be rewritten as claude-fable-5-dd-<reversed>, got %q", id)
+			case "gpt-4o", "claude-gpt-4o", "claude-fable-5-dd-o4-tpg":
+				t.Fatalf("expected translated model id to use the claude/ namespace, got %q", id)
 			}
 		}
 		if claudeModel == nil {
 			t.Fatalf("expected claude-sonnet-4-6 in response, got %s", rr.Body.String())
 		}
 		if rewrittenModel == nil {
-			t.Fatalf("expected claude-fable-5-dd-o4-tpg in response, got %s", rr.Body.String())
+			t.Fatalf("expected claude/gpt-4o in response, got %s", rr.Body.String())
 		}
 		for _, field := range []string{"max_input_tokens", "max_tokens", "display_name"} {
 			if _, ok := claudeModel[field]; !ok {
 				t.Fatalf("expected Claude model to include %q, got %v", field, claudeModel)
 			}
+		}
+	})
+
+	t.Run("claude cli user agent routes gateway discovery to claude format", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/models?limit=1000", nil)
+		req.Header.Set("Authorization", "Bearer test-key")
+		req.Header.Set("User-Agent", "claude-cli/2.1.226 (external, cli)")
+
+		rr := httptest.NewRecorder()
+		server.engine.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d body=%s", rr.Code, http.StatusOK, rr.Body.String())
+		}
+		if !gjson.Get(rr.Body.String(), "has_more").Exists() {
+			t.Fatalf("expected Claude discovery envelope: %s", rr.Body.String())
+		}
+		found := false
+		for _, model := range gjson.Get(rr.Body.String(), "data").Array() {
+			if model.Get("id").String() == "claude/gpt-4o" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected translated model in Claude discovery: %s", rr.Body.String())
 		}
 	})
 
@@ -1767,7 +1793,7 @@ func TestModelsDispatchByAnthropicVersionHeader(t *testing.T) {
 			if id, _ := m["id"].(string); id == "gpt-4o" {
 				foundRawGPT = true
 			}
-			if id, _ := m["id"].(string); id == "claude-gpt-4o" || id == "claude-fable-5-dd-o4-tpg" {
+			if id, _ := m["id"].(string); id == "claude-gpt-4o" || id == "claude/gpt-4o" || id == "claude-fable-5-dd-o4-tpg" {
 				t.Fatalf("did not expect Anthropic id rewrite on OpenAI format models, got %v", m)
 			}
 		}
@@ -1777,11 +1803,11 @@ func TestModelsDispatchByAnthropicVersionHeader(t *testing.T) {
 	})
 }
 
-func TestClaudeModelListCloakingConfigHotReload(t *testing.T) {
+func TestClaudeModelListCloakingIsAlwaysEnabled(t *testing.T) {
 	modelRegistry := registry.GetGlobalRegistry()
-	clientID := "test-claude-model-list-cloaking-hot-reload"
-	const modelID = "gpt-model-list-hot-reload"
-	modelRegistry.RegisterClient(clientID, "claude", []*registry.ModelInfo{{
+	clientID := "test-claude-model-list-cloaking-always-enabled"
+	const modelID = "gpt-model-list-always-cloaked"
+	modelRegistry.RegisterClient(clientID, "codex", []*registry.ModelInfo{{
 		ID: modelID, Object: "model", OwnedBy: "test", Type: "openai",
 	}})
 	t.Cleanup(func() {
@@ -1789,42 +1815,34 @@ func TestClaudeModelListCloakingConfigHotReload(t *testing.T) {
 	})
 
 	server := newTestServer(t)
-	assertModelID := func(want string) {
-		t.Helper()
-		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
-		req.Header.Set("Authorization", "Bearer test-key")
-		req.Header.Set("Anthropic-Version", "2023-06-01")
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Anthropic-Version", "2023-06-01")
 
-		recorder := httptest.NewRecorder()
-		server.engine.ServeHTTP(recorder, req)
-		if recorder.Code != http.StatusOK {
-			t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
-		}
-
-		var response struct {
-			Data []struct {
-				ID string `json:"id"`
-			} `json:"data"`
-		}
-		if errUnmarshal := json.Unmarshal(recorder.Body.Bytes(), &response); errUnmarshal != nil {
-			t.Fatalf("decode response: %v", errUnmarshal)
-		}
-		for _, model := range response.Data {
-			if model.ID == want {
-				return
-			}
-		}
-		t.Fatalf("model %q not found in response: %s", want, recorder.Body.String())
+	recorder := httptest.NewRecorder()
+	server.engine.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
 	}
 
-	assertModelID(claudemodels.EnsureClaudeModelIDPrefix(modelID))
-
-	updatedCfg := *server.cfg
-	updatedCfg.SDKConfig = server.cfg.SDKConfig
-	updatedCfg.ClaudeCode.DisableCloakingModelList = true
-	server.UpdateClients(&updatedCfg)
-
-	assertModelID(modelID)
+	var response struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if errUnmarshal := json.Unmarshal(recorder.Body.Bytes(), &response); errUnmarshal != nil {
+		t.Fatalf("decode response: %v", errUnmarshal)
+	}
+	want := claudemodels.EnsureClaudeModelIDPrefix(modelID)
+	for _, model := range response.Data {
+		if model.ID == modelID {
+			t.Fatalf("translated model was listed without namespace: %s", recorder.Body.String())
+		}
+		if model.ID == want {
+			return
+		}
+	}
+	t.Fatalf("model %q not found in response: %s", want, recorder.Body.String())
 }
 
 func TestModelsWithClientVersionReturnsCodexCatalog(t *testing.T) {

--- a/internal/client/claude/models/models.go
+++ b/internal/client/claude/models/models.go
@@ -4,16 +4,19 @@ package models
 import (
 	"sort"
 	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 )
 
-const claudeDDModelPrefix = "claude-fable-5-dd-"
+const claudeTranslatedModelPrefix = "claude/"
 
 // BuildResponse builds an Anthropic model response from available models.
-func BuildResponse(availableModels []map[string]any, disableCloaking bool) map[string]any {
+func BuildResponse(availableModels []map[string]any) map[string]any {
 	models := make([]map[string]any, len(availableModels))
 	for i, model := range availableModels {
 		models[i] = cloneModel(model)
-		if id, ok := models[i]["id"].(string); ok && !disableCloaking {
+		if id, ok := models[i]["id"].(string); ok {
 			models[i]["id"] = EnsureClaudeModelIDPrefix(id)
 		}
 	}
@@ -44,35 +47,42 @@ func BuildResponse(availableModels []map[string]any, disableCloaking bool) map[s
 	}
 }
 
-// EnsureClaudeModelIDPrefix rewrites model IDs for Anthropic model listings.
-// IDs that already start with "claude-" are returned unchanged; all other IDs
-// become "claude-fable-5-dd-" plus the original ID with its characters reversed.
+// EnsureClaudeModelIDPrefix namespaces translated model IDs for Anthropic model listings.
+// Catalog Claude and already-namespaced IDs are returned unchanged.
 func EnsureClaudeModelIDPrefix(id string) string {
-	if id == "" || strings.HasPrefix(id, "claude-") {
+	if id == "" {
 		return id
 	}
-	return claudeDDModelPrefix + reverseModelID(id)
+	base := thinking.ParseSuffix(id).ModelName
+	if registry.IsClaudeModelID(base) || strings.HasPrefix(id, claudeTranslatedModelPrefix) {
+		return id
+	}
+	return claudeTranslatedModelPrefix + id
 }
 
-// ResolveClaudeModelIDPrefix reverses EnsureClaudeModelIDPrefix for request routing.
-// Optional thinking suffixes in model(value) form are preserved.
+// ResolveClaudeModelIDPrefix removes every translated-model namespace layer for request routing.
+// Catalog Claude IDs stop namespace removal, and thinking suffixes are preserved exactly.
 func ResolveClaudeModelIDPrefix(id string) string {
 	if id == "" {
 		return id
 	}
-	base, suffix, hasSuffix := splitModelThinkingSuffix(id)
-	if !strings.HasPrefix(base, claudeDDModelPrefix) {
+
+	base := thinking.ParseSuffix(id).ModelName
+	if registry.IsClaudeModelID(base) {
 		return id
 	}
-	encoded := base[len(claudeDDModelPrefix):]
-	if encoded == "" {
+
+	resolved := base
+	for strings.HasPrefix(resolved, claudeTranslatedModelPrefix) {
+		resolved = strings.TrimPrefix(resolved, claudeTranslatedModelPrefix)
+		if registry.IsClaudeModelID(resolved) {
+			break
+		}
+	}
+	if resolved == base {
 		return id
 	}
-	resolved := reverseModelID(encoded)
-	if hasSuffix {
-		return resolved + "(" + suffix + ")"
-	}
-	return resolved
+	return resolved + id[len(base):]
 }
 
 func cloneModel(model map[string]any) map[string]any {
@@ -81,20 +91,4 @@ func cloneModel(model map[string]any) map[string]any {
 		cloned[key] = value
 	}
 	return cloned
-}
-
-func splitModelThinkingSuffix(model string) (base, suffix string, hasSuffix bool) {
-	lastOpen := strings.LastIndex(model, "(")
-	if lastOpen == -1 || !strings.HasSuffix(model, ")") {
-		return model, "", false
-	}
-	return model[:lastOpen], model[lastOpen+1 : len(model)-1], true
-}
-
-func reverseModelID(id string) string {
-	runes := []rune(id)
-	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
-		runes[i], runes[j] = runes[j], runes[i]
-	}
-	return string(runes)
 }

--- a/internal/client/claude/models/models_test.go
+++ b/internal/client/claude/models/models_test.go
@@ -4,23 +4,23 @@ import "testing"
 
 func TestBuildResponse(t *testing.T) {
 	availableModels := []map[string]any{
-		{"id": "claude-z", "display_name": "Zebra", "max_tokens": 64000},
+		{"id": "custom-z", "display_name": "Zebra", "max_tokens": 64000},
 		{"id": "gpt-4o", "display_name": "Alpha"},
-		{"id": "claude-c", "display_name": "Alpha"},
-		{"id": "claude-b", "display_name": "Beta"},
+		{"id": "claude-opus-5", "display_name": "Alpha"},
+		{"id": "gemini-2.5-pro", "display_name": "Beta"},
 	}
 
-	response := BuildResponse(availableModels, false)
+	response := BuildResponse(availableModels)
 	models, ok := response["data"].([]map[string]any)
 	if !ok {
 		t.Fatalf("data type = %T, want []map[string]any", response["data"])
 	}
 
 	wantIDs := []string{
-		"claude-c",
-		"claude-fable-5-dd-o4-tpg",
-		"claude-b",
-		"claude-z",
+		"claude-opus-5",
+		"claude/gpt-4o",
+		"claude/gemini-2.5-pro",
+		"claude/custom-z",
 	}
 	if len(models) != len(wantIDs) {
 		t.Fatalf("len(data) = %d, want %d", len(models), len(wantIDs))
@@ -46,37 +46,13 @@ func TestBuildResponse(t *testing.T) {
 	if got := availableModels[1]["id"]; got != "gpt-4o" {
 		t.Fatalf("BuildResponse mutated input id to %v", got)
 	}
-	if got := availableModels[0]["id"]; got != "claude-z" {
+	if got := availableModels[0]["id"]; got != "custom-z" {
 		t.Fatalf("BuildResponse reordered input: first id = %v", got)
 	}
 }
 
-func TestBuildResponseWithCloakingDisabled(t *testing.T) {
-	availableModels := []map[string]any{
-		{"id": "gpt-4o", "display_name": "GPT-4o"},
-	}
-
-	response := BuildResponse(availableModels, true)
-	models, ok := response["data"].([]map[string]any)
-	if !ok {
-		t.Fatalf("data type = %T, want []map[string]any", response["data"])
-	}
-	if len(models) != 1 {
-		t.Fatalf("len(data) = %d, want 1", len(models))
-	}
-	if got := models[0]["id"]; got != "gpt-4o" {
-		t.Fatalf("data[0].id = %v, want gpt-4o", got)
-	}
-	if got := response["first_id"]; got != "gpt-4o" {
-		t.Fatalf("first_id = %v, want gpt-4o", got)
-	}
-	if got := response["last_id"]; got != "gpt-4o" {
-		t.Fatalf("last_id = %v, want gpt-4o", got)
-	}
-}
-
 func TestBuildResponseEmpty(t *testing.T) {
-	response := BuildResponse(nil, false)
+	response := BuildResponse(nil)
 	models, ok := response["data"].([]map[string]any)
 	if !ok {
 		t.Fatalf("data type = %T, want []map[string]any", response["data"])
@@ -96,11 +72,15 @@ func TestEnsureClaudeModelIDPrefix(t *testing.T) {
 		want string
 	}{
 		{"empty", "", ""},
-		{"already has claude prefix", "claude-sonnet-4-6", "claude-sonnet-4-6"},
-		{"contains claude mid-string is reversed", "my-claude-custom", "claude-fable-5-dd-motsuc-edualc-ym"},
-		{"uppercase Claude prefix is reversed", "Claude-Opus-4", "claude-fable-5-dd-4-supO-edualC"},
-		{"gpt model is reversed", "gpt-4o", "claude-fable-5-dd-o4-tpg"},
-		{"gemini model is reversed", "gemini-2.5-pro", "claude-fable-5-dd-orp-5.2-inimeg"},
+		{"catalog Claude model", "claude-opus-5", "claude-opus-5"},
+		{"catalog Claude model with thinking suffix", "claude-opus-5(high)", "claude-opus-5(high)"},
+		{"Claude lookalike is namespaced", "claude-team/gpt-4o", "claude/claude-team/gpt-4o"},
+		{"already namespaced", "claude/gpt-4o", "claude/gpt-4o"},
+		{"repeated namespace is not extended", "claude/claude/gpt-4o", "claude/claude/gpt-4o"},
+		{"contains claude mid-string is namespaced", "my-claude-custom", "claude/my-claude-custom"},
+		{"uppercase Claude prefix is namespaced", "Claude-Opus-5", "claude/Claude-Opus-5"},
+		{"gpt model is namespaced", "gpt-4o", "claude/gpt-4o"},
+		{"gemini model is namespaced", "gemini-2.5-pro", "claude/gemini-2.5-pro"},
 	}
 
 	for _, tt := range tests {
@@ -119,12 +99,20 @@ func TestResolveClaudeModelIDPrefix(t *testing.T) {
 		want string
 	}{
 		{"empty", "", ""},
-		{"plain claude id unchanged", "claude-sonnet-4-6", "claude-sonnet-4-6"},
-		{"non encoded id unchanged", "gpt-4o", "gpt-4o"},
-		{"encoded gpt model", "claude-fable-5-dd-o4-tpg", "gpt-4o"},
-		{"encoded gemini model", "claude-fable-5-dd-orp-5.2-inimeg", "gemini-2.5-pro"},
-		{"empty encoded body unchanged", "claude-fable-5-dd-", "claude-fable-5-dd-"},
-		{"preserves thinking suffix", "claude-fable-5-dd-o4-tpg(high)", "gpt-4o(high)"},
+		{"catalog Claude model", "claude-opus-5", "claude-opus-5"},
+		{"catalog Claude model with thinking suffix", "claude-opus-5(high)", "claude-opus-5(high)"},
+		{"non namespaced id unchanged", "gpt-4o", "gpt-4o"},
+		{"regular claude prefix unchanged", "claude-team/gpt-4o", "claude-team/gpt-4o"},
+		{"uppercase namespace unchanged", "Claude/gpt-4o", "Claude/gpt-4o"},
+		{"legacy cloaked id is no longer decoded", "claude-fable-5-dd-o4-tpg", "claude-fable-5-dd-o4-tpg"},
+		{"reserved claude credential prefix is consumed", "claude/gpt-4o", "gpt-4o"},
+		{"namespaced gemini model", "claude/gemini-2.5-pro", "gemini-2.5-pro"},
+		{"empty namespace is consumed", "claude/", ""},
+		{"strips every namespace", "claude/claude/claude/gpt-4o", "gpt-4o"},
+		{"stops at wrapped catalog Claude model", "claude/claude-opus-5", "claude-opus-5"},
+		{"stops at repeatedly wrapped catalog Claude model", "claude/claude/claude-opus-5", "claude-opus-5"},
+		{"preserves wrapped native thinking suffix", "claude/claude-opus-5(high)", "claude-opus-5(high)"},
+		{"preserves thinking suffix exactly", "claude/claude/gpt-4o( High )", "gpt-4o( High )"},
 		{"round trip", EnsureClaudeModelIDPrefix("custom-model-x"), "custom-model-x"},
 	}
 

--- a/internal/config/claude_code_test.go
+++ b/internal/config/claude_code_test.go
@@ -2,33 +2,12 @@ package config
 
 import "testing"
 
-func TestParseConfigBytesClaudeCodeModelListCloaking(t *testing.T) {
-	tests := []struct {
-		name string
-		yaml string
-		want bool
-	}{
-		{
-			name: "defaults to enabled cloaking",
-			yaml: "port: 8317\n",
-			want: false,
-		},
-		{
-			name: "disables model list cloaking",
-			yaml: "claude-code:\n  disable-cloaking-model-list: true\n",
-			want: true,
-		},
+func TestParseConfigBytesIgnoresRemovedClaudeCodeModelListCloaking(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte("port: 9123\nclaude-code:\n  disable-cloaking-model-list: true\n"))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", err)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg, errParse := ParseConfigBytes([]byte(tt.yaml))
-			if errParse != nil {
-				t.Fatalf("ParseConfigBytes() error = %v", errParse)
-			}
-			if got := cfg.ClaudeCode.DisableCloakingModelList; got != tt.want {
-				t.Fatalf("DisableCloakingModelList = %t, want %t", got, tt.want)
-			}
-		})
+	if cfg.Port != 9123 {
+		t.Fatalf("Port = %d, want 9123", cfg.Port)
 	}
 }

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -140,6 +140,12 @@ type CodexConfig struct {
 	OptimizeMultiAgentV2 bool `yaml:"optimize-multi-agent-v2" json:"optimize-multi-agent-v2"`
 	// LiveMediaRelay terminates and relays Codex Live WebRTC media in this process.
 	LiveMediaRelay CodexLiveMediaRelayConfig `yaml:"live-media-relay" json:"live-media-relay"`
+	// EnableWebsocketUpstream enables the WebSocket transport for Codex OAuth
+	// credentials (prolite, etc.) that would otherwise use HTTP/2. The WebSocket
+	// path provides ping/pong keepalives, explicit disconnect detection, and
+	// automatic reconnect-on-send-failure — all of which HTTP/2 lacks.
+	// Per-auth override: set "websockets": false in the auth metadata/attributes.
+	EnableWebsocketUpstream bool `yaml:"enable-websocket-upstream" json:"enable-websocket-upstream"`
 }
 
 // CodexLiveMediaRelayConfig configures the in-process Codex Live WebRTC gateway.

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -45,9 +45,6 @@ type SDKConfig struct {
 	// CodexOptimizeMultiAgentV2 mirrors the provider-wide runtime setting for API handlers.
 	CodexOptimizeMultiAgentV2 bool `yaml:"-" json:"-"`
 
-	// ClaudeCode configures Claude Code compatibility behavior.
-	ClaudeCode ClaudeCodeConfig `yaml:"claude-code" json:"claude-code"`
-
 	// APIKeys is a list of keys for authenticating clients to this proxy server.
 	APIKeys []string `yaml:"api-keys" json:"api-keys"`
 
@@ -61,12 +58,6 @@ type SDKConfig struct {
 	// NonStreamKeepAliveInterval controls how often blank lines are emitted for non-streaming responses.
 	// <= 0 disables keep-alives. Value is in seconds.
 	NonStreamKeepAliveInterval int `yaml:"nonstream-keepalive-interval,omitempty" json:"nonstream-keepalive-interval,omitempty"`
-}
-
-// ClaudeCodeConfig configures Claude Code compatibility behavior.
-type ClaudeCodeConfig struct {
-	// DisableCloakingModelList disables model ID cloaking in Anthropic model list responses.
-	DisableCloakingModelList bool `yaml:"disable-cloaking-model-list" json:"disable-cloaking-model-list"`
 }
 
 // StreamingConfig holds server streaming behavior configuration.

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -37,6 +37,11 @@ func GetClaudeModels() []*ModelInfo {
 	return cloneModelInfos(getModels().Claude)
 }
 
+// IsClaudeModelID reports whether id exactly matches the current Claude catalog.
+func IsClaudeModelID(id string) bool {
+	return modelsCatalogStore.isClaudeModelID(id)
+}
+
 // GetGeminiModels returns the standard Gemini model definitions.
 func GetGeminiModels() []*ModelInfo {
 	return cloneModelInfos(getModels().Gemini)

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -1,6 +1,9 @@
 package registry
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func TestModelOverrideHeadersFromEmbeddedModels(t *testing.T) {
 	const wantUA = "codex-tui/0.144.0 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.144.0)"
@@ -103,4 +106,62 @@ func TestAntigravityWebSearchModelForRequiresRequestedModelCapability(t *testing
 	if got := AntigravityWebSearchModelFor("unknown-model"); got != "" {
 		t.Fatalf("unknown model should not get Antigravity web search model, got %q", got)
 	}
+}
+
+func TestIsClaudeModelIDUsesCurrentCatalog(t *testing.T) {
+	if !IsClaudeModelID("claude-opus-5") {
+		t.Fatal("IsClaudeModelID(claude-opus-5) = false, want true")
+	}
+	for _, id := range []string{"claude-opus-5-lookalike", "Claude-Opus-5", "gpt-4o"} {
+		if IsClaudeModelID(id) {
+			t.Fatalf("IsClaudeModelID(%q) = true, want false", id)
+		}
+	}
+}
+
+func TestModelStoreClaudeModelIDsFollowReplacement(t *testing.T) {
+	store := &modelStore{}
+	store.replaceModels(&staticModelsJSON{Claude: []*ModelInfo{
+		{ID: "claude-first"},
+		{ID: "claude-second"},
+		nil,
+	}})
+	if !store.isClaudeModelID("claude-first") || !store.isClaudeModelID("claude-second") {
+		t.Fatal("initial Claude IDs were not indexed")
+	}
+
+	store.replaceModels(&staticModelsJSON{Claude: []*ModelInfo{{ID: "claude-third"}}})
+	if store.isClaudeModelID("claude-first") {
+		t.Fatal("removed Claude ID remained indexed")
+	}
+	if !store.isClaudeModelID("claude-third") {
+		t.Fatal("replacement Claude ID was not indexed")
+	}
+}
+
+func TestModelStoreClaudeModelIDsConcurrentAccess(t *testing.T) {
+	store := &modelStore{}
+	store.replaceModels(&staticModelsJSON{Claude: []*ModelInfo{{ID: "claude-first"}}})
+
+	const iterations = 500
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			store.replaceModels(&staticModelsJSON{Claude: []*ModelInfo{{ID: "claude-first"}}})
+			store.replaceModels(&staticModelsJSON{Claude: []*ModelInfo{{ID: "claude-second"}}})
+		}
+	}()
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				_ = store.isClaudeModelID("claude-first")
+				_ = store.isClaudeModelID("claude-second")
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -28,8 +28,9 @@ var modelsURLs = []string{
 var embeddedModelsJSON []byte
 
 type modelStore struct {
-	mu   sync.RWMutex
-	data *staticModelsJSON
+	mu             sync.RWMutex
+	data           *staticModelsJSON
+	claudeModelIDs map[string]struct{}
 }
 
 var modelsCatalogStore = &modelStore{}
@@ -125,9 +126,7 @@ func tryRefreshModels(ctx context.Context, label string) {
 	changed := detectChangedProviders(oldData, parsed)
 
 	// Update store with new data regardless.
-	modelsCatalogStore.mu.Lock()
-	modelsCatalogStore.data = parsed
-	modelsCatalogStore.mu.Unlock()
+	modelsCatalogStore.replaceModels(parsed)
 
 	if len(changed) == 0 {
 		log.Infof("%s completed from %s, no changes detected", label, url)
@@ -303,10 +302,33 @@ func loadModelsFromBytes(data []byte, source string) error {
 		return fmt.Errorf("%s: validate models catalog: %w", source, err)
 	}
 
-	modelsCatalogStore.mu.Lock()
-	modelsCatalogStore.data = &parsed
-	modelsCatalogStore.mu.Unlock()
+	modelsCatalogStore.replaceModels(&parsed)
 	return nil
+}
+
+func (s *modelStore) replaceModels(data *staticModelsJSON) {
+	claudeModelIDs := make(map[string]struct{})
+	if data != nil {
+		claudeModelIDs = make(map[string]struct{}, len(data.Claude))
+		for _, model := range data.Claude {
+			if model == nil || model.ID == "" {
+				continue
+			}
+			claudeModelIDs[model.ID] = struct{}{}
+		}
+	}
+
+	s.mu.Lock()
+	s.data = data
+	s.claudeModelIDs = claudeModelIDs
+	s.mu.Unlock()
+}
+
+func (s *modelStore) isClaudeModelID(id string) bool {
+	s.mu.RLock()
+	_, ok := s.claudeModelIDs[id]
+	s.mu.RUnlock()
+	return ok
 }
 
 func getModels() *staticModelsJSON {

--- a/internal/runtime/executor/codex_executor_execute.go
+++ b/internal/runtime/executor/codex_executor_execute.go
@@ -120,7 +120,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		}
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = newCodexStatusErr(httpResp.StatusCode, b)
+		err = newCodexStatusErrWithHeaders(httpResp.StatusCode, b, httpResp.Header)
 		return resp, err
 	}
 	data, errRead := io.ReadAll(httpResp.Body)
@@ -277,7 +277,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 		b = applyCodexIdentityConfuseResponsePayload(b, identityState)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = newCodexStatusErr(httpResp.StatusCode, b)
+		err = newCodexStatusErrWithHeaders(httpResp.StatusCode, b, httpResp.Header)
 		return resp, err
 	}
 	data, err := io.ReadAll(httpResp.Body)

--- a/internal/runtime/executor/codex_executor_execute.go
+++ b/internal/runtime/executor/codex_executor_execute.go
@@ -43,7 +43,10 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		originalPayloadSource = opts.OriginalRequest
 	}
 	originalPayload := originalPayloadSource
-	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false, helps.APIKeyModelIsCompat(req))
+	originalTranslated, body, errTranslate := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false, helps.APIKeyModelIsCompat(req))
+	if errTranslate != nil {
+		return resp, errTranslate
+	}
 
 	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
@@ -215,7 +218,10 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 		originalPayloadSource = opts.OriginalRequest
 	}
 	originalPayload := originalPayloadSource
-	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false, helps.APIKeyModelIsCompat(req))
+	originalTranslated, body, errTranslate := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false, helps.APIKeyModelIsCompat(req))
+	if errTranslate != nil {
+		return resp, errTranslate
+	}
 
 	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -14,6 +14,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	codexclaude "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/codex/claude"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -32,7 +33,18 @@ const (
 
 var dataTag = []byte("data:")
 
-func translateCodexRequestPair(from, to sdktranslator.Format, model string, originalPayload, payload []byte, stream bool, preserveEmptyThinkingBlocks ...bool) ([]byte, []byte) {
+func translateCodexRequestPair(from, to sdktranslator.Format, model string, originalPayload, payload []byte, stream bool, preserveEmptyThinkingBlocks ...bool) ([]byte, []byte, error) {
+	if sourceFormatEqual(from, sdktranslator.FormatClaude) {
+		if err := codexclaude.ValidateClaudeRequestForCodex(originalPayload); err != nil {
+			return nil, nil, newCodexClaudeValidationError("request", err)
+		}
+		if !bytes.Equal(originalPayload, payload) {
+			if err := codexclaude.ValidateClaudeRequestForCodex(payload); err != nil {
+				return nil, nil, newCodexClaudeValidationError("translated request", err)
+			}
+		}
+	}
+
 	isCompat := len(preserveEmptyThinkingBlocks) > 0 && preserveEmptyThinkingBlocks[0]
 	translate := func(raw []byte) []byte {
 		if isCompat && from == sdktranslator.FormatClaude && to == sdktranslator.FormatCodex {
@@ -42,11 +54,22 @@ func translateCodexRequestPair(from, to sdktranslator.Format, model string, orig
 	}
 	if bytes.Equal(originalPayload, payload) {
 		body := translate(payload)
-		return body, body
+		return body, body, nil
 	}
 	originalTranslated := translate(originalPayload)
 	body := translate(payload)
-	return originalTranslated, body
+	return originalTranslated, body, nil
+}
+
+type codexClaudeValidationError struct {
+	statusErr
+}
+
+func (codexClaudeValidationError) IsRequestScoped() bool { return true }
+
+func newCodexClaudeValidationError(label string, err error) error {
+	requestErr := codexClaudeValidationError{statusErr{code: http.StatusBadRequest, msg: err.Error()}}
+	return fmt.Errorf("codex executor: invalid Claude %s: %w", label, requestErr)
 }
 
 // PrepareRequest injects Codex credentials into the outgoing HTTP request.

--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -196,6 +196,48 @@ func TestNewCodexStatusErrPreservesUnclassifiedErrors(t *testing.T) {
 	}
 }
 
+func TestNewCodexStatusErrWithHeadersKeepsOnlyDocumentedRateLimits(t *testing.T) {
+	names := []string{
+		"Retry-After",
+		"X-Ratelimit-Limit-Project-Tokens",
+		"X-Ratelimit-Limit-Requests",
+		"X-Ratelimit-Limit-Tokens",
+		"X-Ratelimit-Remaining-Project-Tokens",
+		"X-Ratelimit-Remaining-Requests",
+		"X-Ratelimit-Remaining-Tokens",
+		"X-Ratelimit-Reset-Project-Tokens",
+		"X-Ratelimit-Reset-Requests",
+		"X-Ratelimit-Reset-Tokens",
+	}
+	headers := make(http.Header)
+	for _, name := range names {
+		headers.Set(name, "safe-value")
+	}
+	headers.Set("Authorization", "Bearer secret")
+	headers.Set("Set-Cookie", "credential=secret")
+	headers.Set("X-Upstream-Token", "secret")
+	headers.Set("X-Ratelimit-Limit-Requests", "safe\nunsafe")
+
+	err := newCodexStatusErrWithHeaders(http.StatusTooManyRequests, []byte(`{"error":{"message":"limited"}}`), headers)
+	got := err.Headers()
+	for _, name := range names {
+		if name == "X-Ratelimit-Limit-Requests" {
+			if got.Get(name) != "" {
+				t.Fatalf("invalid %s value was preserved", name)
+			}
+			continue
+		}
+		if got.Get(name) != "safe-value" {
+			t.Fatalf("%s = %q, want safe-value", name, got.Get(name))
+		}
+	}
+	for _, name := range []string{"Authorization", "Set-Cookie", "X-Upstream-Token"} {
+		if got.Get(name) != "" {
+			t.Fatalf("sensitive %s header was preserved", name)
+		}
+	}
+}
+
 func assertCodexErrorCode(t *testing.T, raw string, wantType string, wantCode string) {
 	t.Helper()
 

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -127,7 +127,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		}
 		helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
-		err = newCodexStatusErr(httpResp.StatusCode, data)
+		err = newCodexStatusErrWithHeaders(httpResp.StatusCode, data, httpResp.Header)
 		return nil, err
 	}
 	out := make(chan cliproxyexecutor.StreamChunk)

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -44,7 +44,10 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		originalPayloadSource = opts.OriginalRequest
 	}
 	originalPayload := originalPayloadSource
-	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, true, helps.APIKeyModelIsCompat(req))
+	originalTranslated, body, errTranslate := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, true, helps.APIKeyModelIsCompat(req))
+	if errTranslate != nil {
+		return nil, errTranslate
+	}
 
 	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {

--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -18,6 +18,56 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func TestCodexExecutorExecuteTranslatesClaudeRequestAndResponse(t *testing.T) {
+	var requestBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var errRead error
+		requestBody, errRead = io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"type":"response.output_item.done","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]},"output_index":0}` + "\n\n"))
+		_, _ = w.Write([]byte(`data: {"type":"response.completed","response":{"id":"resp_1","object":"response","status":"completed","model":"gpt-5.4","output":[],"usage":{"input_tokens":8,"output_tokens":1,"total_tokens":9}}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","max_tokens":64,"messages":[{"role":"user","content":"Say ok"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatClaude,
+		ResponseFormat: sdktranslator.FormatClaude,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if got := gjson.GetBytes(requestBody, "model").String(); got != "gpt-5.4" {
+		t.Fatalf("upstream model = %q, want gpt-5.4; body=%s", got, requestBody)
+	}
+	if got := gjson.GetBytes(requestBody, "input.0.content.0.text").String(); got != "Say ok" {
+		t.Fatalf("upstream input text = %q, want Say ok; body=%s", got, requestBody)
+	}
+	for _, field := range []string{"max_tokens", "max_completion_tokens", "max_output_tokens"} {
+		if gjson.GetBytes(requestBody, field).Exists() {
+			t.Fatalf("upstream field %q should be omitted; body=%s", field, requestBody)
+		}
+	}
+	if got := gjson.GetBytes(resp.Payload, "type").String(); got != "message" {
+		t.Fatalf("response type = %q, want message; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "content.0.text").String(); got != "ok" {
+		t.Fatalf("response text = %q, want ok; payload=%s", got, resp.Payload)
+	}
+}
+
 func TestCodexExecutorExecute_NonEmptyCompletionOutputHydratesMissingItemID(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/internal/runtime/executor/codex_executor_stream_parity_test.go
+++ b/internal/runtime/executor/codex_executor_stream_parity_test.go
@@ -1,0 +1,123 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func TestCodexExecutorExecuteStreamCancellationBeforeFirstEvent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+	result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":"hello"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+		Stream:       true,
+	})
+	if err != nil {
+		cancel()
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	cancel()
+
+	select {
+	case chunk, ok := <-result.Chunks:
+		if ok {
+			t.Fatalf("received chunk after cancellation before first event: payload=%q err=%v", chunk.Payload, chunk.Err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for canceled stream to close")
+	}
+}
+
+func TestCodexExecutorExecuteStreamCancellationAfterPartialOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`data: {"type":"response.created","response":{"id":"resp_cancel","model":"gpt-5.5","status":"in_progress","usage":{"input_tokens":1,"output_tokens":0}}}` + "\n\n"))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+	result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":"hello"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+		Stream:       true,
+	})
+	if err != nil {
+		cancel()
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var first cliproxyexecutor.StreamChunk
+	select {
+	case chunk, ok := <-result.Chunks:
+		if !ok {
+			cancel()
+			t.Fatal("stream closed before partial output")
+		}
+		first = chunk
+	case <-time.After(time.Second):
+		cancel()
+		t.Fatal("timed out waiting for partial output")
+	}
+	cancel()
+
+	chunks := []cliproxyexecutor.StreamChunk{first}
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case chunk, ok := <-result.Chunks:
+			if !ok {
+				for _, got := range chunks {
+					if got.Err != nil {
+						t.Fatalf("cancellation emitted a synthetic stream error: %v", got.Err)
+					}
+					if bytes.Contains(got.Payload, []byte(`"type":"message_stop"`)) {
+						t.Fatalf("cancellation emitted a synthetic successful terminal event: %s", got.Payload)
+					}
+				}
+				return
+			}
+			chunks = append(chunks, chunk)
+		case <-deadline:
+			t.Fatal("timed out waiting for canceled partial stream to close")
+		}
+	}
+}

--- a/internal/runtime/executor/codex_executor_terminal.go
+++ b/internal/runtime/executor/codex_executor_terminal.go
@@ -295,6 +295,36 @@ func newCodexStatusErr(statusCode int, body []byte) statusErr {
 	return err
 }
 
+var codexRateLimitResponseHeaders = map[string]struct{}{
+	"Retry-After":                          {},
+	"X-Ratelimit-Limit-Project-Tokens":     {},
+	"X-Ratelimit-Limit-Requests":           {},
+	"X-Ratelimit-Limit-Tokens":             {},
+	"X-Ratelimit-Remaining-Project-Tokens": {},
+	"X-Ratelimit-Remaining-Requests":       {},
+	"X-Ratelimit-Remaining-Tokens":         {},
+	"X-Ratelimit-Reset-Project-Tokens":     {},
+	"X-Ratelimit-Reset-Requests":           {},
+	"X-Ratelimit-Reset-Tokens":             {},
+}
+
+func newCodexStatusErrWithHeaders(statusCode int, body []byte, headers http.Header) statusErrWithHeaders {
+	safe := make(http.Header)
+	for name, values := range headers {
+		canonical := http.CanonicalHeaderKey(name)
+		if _, ok := codexRateLimitResponseHeaders[canonical]; !ok {
+			continue
+		}
+		for _, value := range values {
+			if strings.IndexFunc(value, func(character rune) bool { return character < 32 || character == 127 }) >= 0 {
+				continue
+			}
+			safe.Add(canonical, value)
+		}
+	}
+	return statusErrWithHeaders{statusErr: newCodexStatusErr(statusCode, body), headers: safe}
+}
+
 func classifyCodexStatusError(statusCode int, body []byte) []byte {
 	code, errType, ok := codexStatusErrorClassification(statusCode, body)
 	if !ok {

--- a/internal/runtime/executor/codex_executor_tokens.go
+++ b/internal/runtime/executor/codex_executor_tokens.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
@@ -49,7 +50,12 @@ func (e *CodexExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth
 
 	usageJSON := fmt.Sprintf(`{"response":{"usage":{"input_tokens":%d,"output_tokens":0,"total_tokens":%d}}}`, count, count)
 	translated := sdktranslator.TranslateTokenCount(ctx, to, responseFormat, count, []byte(usageJSON))
-	return cliproxyexecutor.Response{Payload: translated}, nil
+	if sourceFormatEqual(responseFormat, sdktranslator.FormatClaude) && gjson.GetBytes(req.Payload, "context_management").Exists() {
+		translated, _ = sjson.SetBytes(translated, "context_management.original_input_tokens", count)
+	}
+	headers := make(http.Header)
+	headers.Set("X-CLIProxyAPI-Token-Count-Mode", "estimate")
+	return cliproxyexecutor.Response{Payload: translated, Headers: headers}, nil
 }
 
 func tokenizerForCodexModel(model string) (tokenizer.Codec, error) {

--- a/internal/runtime/executor/codex_executor_tokens.go
+++ b/internal/runtime/executor/codex_executor_tokens.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	codexclaude "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/codex/claude"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
@@ -22,6 +23,11 @@ func (e *CodexExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("codex")
+	if sourceFormatEqual(from, sdktranslator.FormatClaude) {
+		if errValidate := codexclaude.ValidateClaudeRequestForCodex(req.Payload); errValidate != nil {
+			return cliproxyexecutor.Response{}, newCodexClaudeValidationError("token-count request", errValidate)
+		}
+	}
 	body := helps.TranslateRequestWithAPIKeyModelCompatibility(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false, helps.APIKeyModelIsCompat(req))
 
 	body, err := helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())

--- a/internal/runtime/executor/codex_executor_tokens_parity_test.go
+++ b/internal/runtime/executor/codex_executor_tokens_parity_test.go
@@ -1,0 +1,27 @@
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func TestCodexCountTokensRejectsMalformedClaudeRequest(t *testing.T) {
+	executor := NewCodexExecutor(nil)
+	_, err := executor.CountTokens(context.Background(), nil, cliproxyexecutor.Request{
+		Model:   "gpt-5.6-sol",
+		Payload: []byte(`{"model":"claude-opus-5","messages":[{"role":"operator","content":"hello"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatClaude,
+		ResponseFormat: sdktranslator.FormatClaude,
+	})
+	if err == nil {
+		t.Fatal("CountTokens() error = nil, want malformed request rejection")
+	}
+	if !strings.Contains(err.Error(), "message role") {
+		t.Fatalf("error = %q, want message-role validation", err)
+	}
+}

--- a/internal/runtime/executor/codex_executor_tokens_test.go
+++ b/internal/runtime/executor/codex_executor_tokens_test.go
@@ -1,0 +1,54 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestCodexCountTokensClaudeContract(t *testing.T) {
+	executor := NewCodexExecutor(&config.Config{})
+	response, err := executor.CountTokens(context.Background(), nil, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"Count these tokens"}],"context_management":{"edits":[]}}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatClaude,
+		ResponseFormat: sdktranslator.FormatClaude,
+	})
+	if err != nil {
+		t.Fatalf("CountTokens error: %v", err)
+	}
+
+	inputTokens := gjson.GetBytes(response.Payload, "input_tokens").Int()
+	if inputTokens <= 0 {
+		t.Fatalf("input_tokens = %d, want positive estimate; payload=%s", inputTokens, response.Payload)
+	}
+	if got := gjson.GetBytes(response.Payload, "context_management.original_input_tokens").Int(); got != inputTokens {
+		t.Fatalf("original_input_tokens = %d, want %d; payload=%s", got, inputTokens, response.Payload)
+	}
+	if got := response.Headers.Get("X-CLIProxyAPI-Token-Count-Mode"); got != "estimate" {
+		t.Fatalf("token count mode = %q, want estimate", got)
+	}
+}
+
+func TestCodexCountTokensClaudeOmitsContextManagementWhenNotRequested(t *testing.T) {
+	executor := NewCodexExecutor(&config.Config{})
+	response, err := executor.CountTokens(context.Background(), nil, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"Count these tokens"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatClaude,
+		ResponseFormat: sdktranslator.FormatClaude,
+	})
+	if err != nil {
+		t.Fatalf("CountTokens error: %v", err)
+	}
+	if gjson.GetBytes(response.Payload, "context_management").Exists() {
+		t.Fatalf("unexpected context_management; payload=%s", response.Payload)
+	}
+}

--- a/internal/runtime/executor/codex_executor_tokens_test.go
+++ b/internal/runtime/executor/codex_executor_tokens_test.go
@@ -2,6 +2,8 @@ package executor
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -33,6 +35,28 @@ func TestCodexCountTokensClaudeContract(t *testing.T) {
 	}
 	if got := response.Headers.Get("X-CLIProxyAPI-Token-Count-Mode"); got != "estimate" {
 		t.Fatalf("token count mode = %q, want estimate", got)
+	}
+}
+
+func TestCodexCountTokensRejectsLossyClaudeRequest(t *testing.T) {
+	executor := NewCodexExecutor(&config.Config{})
+	_, err := executor.CountTokens(context.Background(), nil, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"Count these tokens"}],"stop_sequences":["END"]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatClaude,
+		ResponseFormat: sdktranslator.FormatClaude,
+	})
+	if err == nil {
+		t.Fatal("CountTokens error = nil, want rejection")
+	}
+	var requestScoped interface{ IsRequestScoped() bool }
+	if !errors.As(err, &requestScoped) || !requestScoped.IsRequestScoped() {
+		t.Fatalf("error %T is not request-scoped: %v", err, err)
+	}
+	var status interface{ StatusCode() int }
+	if !errors.As(err, &status) || status.StatusCode() != http.StatusBadRequest {
+		t.Fatalf("error status = %v, want %d", err, http.StatusBadRequest)
 	}
 }
 

--- a/internal/runtime/executor/codex_executor_translate_parity_test.go
+++ b/internal/runtime/executor/codex_executor_translate_parity_test.go
@@ -1,0 +1,84 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestTranslateCodexRequestPairDoesNotForwardClaudeMaxTokens(t *testing.T) {
+	payload := []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":"hello"}]}`)
+	_, body, err := translateCodexRequestPair(sdktranslator.FormatClaude, sdktranslator.FormatCodex, "gpt-5.6-sol", payload, payload, true)
+	if err != nil {
+		t.Fatalf("translateCodexRequestPair() error = %v", err)
+	}
+	if gjson.GetBytes(body, "max_output_tokens").Exists() {
+		t.Fatalf("max_output_tokens must not reach the Codex subscription upstream; body=%s", body)
+	}
+}
+
+func TestTranslateCodexRequestPairAcceptsContemporaryClaudeCodeRequest(t *testing.T) {
+	payload := []byte(`{
+		"model":"claude/gpt-5.6-sol",
+		"max_tokens":32000,
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"run the check"}]},
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_current_1","name":"Bash","input":{"command":"go test ./..."}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_current_1","content":[{"type":"text","text":"ok"}]}]},
+			{"role":"system","content":[{"type":"text","text":"The Stop hook requires a final response."}]},
+			{"role":"user","content":[{"type":"text","text":"finish"}]}
+		],
+		"metadata":{"user_id":"user_test_account__session_test"},
+		"stream":true,
+		"system":[
+			{"type":"text","text":"You are Claude Code.","cache_control":{"type":"ephemeral"}},
+			{"type":"text","text":"Follow repository rules.","cache_control":{"type":"ephemeral"}}
+		],
+		"thinking":{"budget_tokens":31999,"type":"enabled"},
+		"tools":[
+			{"name":"Bash","description":"Run a command","input_schema":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}},
+			{"name":"Read","description":"Read a file","input_schema":{"type":"object","properties":{"file_path":{"type":"string"}},"required":["file_path"]}}
+		]
+	}`)
+	_, body, err := translateCodexRequestPair(sdktranslator.FormatClaude, sdktranslator.FormatCodex, "gpt-5.6-sol", payload, payload, true)
+	if err != nil {
+		t.Fatalf("translateCodexRequestPair() error = %v", err)
+	}
+
+	parsed := gjson.ParseBytes(body)
+	if got := parsed.Get("reasoning.effort").String(); got != "xhigh" {
+		t.Fatalf("reasoning.effort = %q, want xhigh; body=%s", got, body)
+	}
+	if got := parsed.Get("input.0.content.0.text").String(); got != "You are Claude Code." {
+		t.Fatalf("first system text = %q; body=%s", got, body)
+	}
+	if got := parsed.Get("input.0.content.1.text").String(); got != "Follow repository rules." {
+		t.Fatalf("second system text = %q; body=%s", got, body)
+	}
+	inputs := parsed.Get("input").Array()
+	if len(inputs) != 6 {
+		t.Fatalf("input items = %d, want 6; body=%s", len(inputs), body)
+	}
+	if got := inputs[2].Get("type").String(); got != "function_call" {
+		t.Fatalf("tool call type = %q, want function_call; body=%s", got, body)
+	}
+	if got := inputs[3].Get("type").String(); got != "function_call_output" {
+		t.Fatalf("tool result type = %q, want function_call_output; body=%s", got, body)
+	}
+	if got := inputs[4].Get("role").String(); got != "user" {
+		t.Fatalf("hook role = %q, want user; body=%s", got, body)
+	}
+	if got := inputs[4].Get("content.0.text").String(); !strings.Contains(got, "The Stop hook requires a final response.") {
+		t.Fatalf("hook text = %q; body=%s", got, body)
+	}
+	if got := parsed.Get("tools.#").Int(); got != 2 {
+		t.Fatalf("tools = %d, want 2; body=%s", got, body)
+	}
+	for _, field := range []string{"max_output_tokens", "thinking", "metadata"} {
+		if parsed.Get(field).Exists() {
+			t.Fatalf("Claude-only field %q reached Codex upstream; body=%s", field, body)
+		}
+	}
+}

--- a/internal/runtime/executor/codex_executor_translate_test.go
+++ b/internal/runtime/executor/codex_executor_translate_test.go
@@ -2,6 +2,8 @@ package executor
 
 import (
 	"bytes"
+	"errors"
+	"net/http"
 	"sync/atomic"
 	"testing"
 
@@ -24,7 +26,10 @@ func TestTranslateCodexRequestPairReusesEqualPayload(t *testing.T) {
 	}, sdktranslator.ResponseTransform{})
 
 	payload := []byte(`{"model":"test-model","input":[{"role":"user"}]}`)
-	originalTranslated, body := translateCodexRequestPair(from, to, "test-model", payload, bytes.Clone(payload), true)
+	originalTranslated, body, err := translateCodexRequestPair(from, to, "test-model", payload, bytes.Clone(payload), true)
+	if err != nil {
+		t.Fatalf("translateCodexRequestPair() error = %v", err)
+	}
 
 	if gotCalls := atomic.LoadInt32(&calls); gotCalls != 1 {
 		t.Fatalf("TranslateRequest calls = %d, want 1", gotCalls)
@@ -45,7 +50,10 @@ func TestTranslateCodexRequestPairTranslatesDifferentPayloads(t *testing.T) {
 
 	originalPayload := []byte(`{"model":"test-model","input":[{"role":"system"}]}`)
 	payload := []byte(`{"model":"test-model","input":[{"role":"user"}]}`)
-	originalTranslated, body := translateCodexRequestPair(from, to, "test-model", originalPayload, payload, false)
+	originalTranslated, body, err := translateCodexRequestPair(from, to, "test-model", originalPayload, payload, false)
+	if err != nil {
+		t.Fatalf("translateCodexRequestPair() error = %v", err)
+	}
 
 	if gotCalls := atomic.LoadInt32(&calls); gotCalls != 2 {
 		t.Fatalf("TranslateRequest calls = %d, want 2", gotCalls)
@@ -55,5 +63,41 @@ func TestTranslateCodexRequestPairTranslatesDifferentPayloads(t *testing.T) {
 	}
 	if !bytes.Equal(body, payload) {
 		t.Fatalf("body = %s, want %s", body, payload)
+	}
+}
+
+func TestTranslateCodexRequestPairRejectsLossyClaudePayload(t *testing.T) {
+	tests := []struct {
+		name     string
+		original []byte
+		payload  []byte
+	}{
+		{
+			name:     "original payload",
+			original: []byte(`{"messages":[{"role":"user","content":"hello"}],"stop_sequences":["END"]}`),
+			payload:  []byte(`{"messages":[{"role":"user","content":"hello"}],"stop_sequences":["END"]}`),
+		},
+		{
+			name:     "transformed payload",
+			original: []byte(`{"messages":[{"role":"user","content":"hello"}]}`),
+			payload:  []byte(`{"messages":[{"role":"user","content":[{"type":"audio","data":"ignored"}]}]}`),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := translateCodexRequestPair(sdktranslator.FormatClaude, sdktranslator.FormatCodex, "gpt-5.4", test.original, test.payload, true)
+			if err == nil {
+				t.Fatal("translateCodexRequestPair() error = nil, want rejection")
+			}
+			var requestScoped interface{ IsRequestScoped() bool }
+			if !errors.As(err, &requestScoped) || !requestScoped.IsRequestScoped() {
+				t.Fatalf("error %T is not request-scoped: %v", err, err)
+			}
+			var status interface{ StatusCode() int }
+			if !errors.As(err, &status) || status.StatusCode() != http.StatusBadRequest {
+				t.Fatalf("error status = %v, want %d", err, http.StatusBadRequest)
+			}
+		})
 	}
 }

--- a/internal/runtime/executor/codex_executor_translate_test.go
+++ b/internal/runtime/executor/codex_executor_translate_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"testing"
 
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
 )
 
 func TestTranslateCodexRequestPairReusesEqualPayload(t *testing.T) {
@@ -99,5 +101,88 @@ func TestTranslateCodexRequestPairRejectsLossyClaudePayload(t *testing.T) {
 				t.Fatalf("error status = %v, want %d", err, http.StatusBadRequest)
 			}
 		})
+	}
+}
+
+func TestTranslateCodexRequestPairPreservesModernClaudeToolResults(t *testing.T) {
+	sharedSuffix := strings.Repeat("a", 70)
+	firstToolName := "mcp__first_server__" + sharedSuffix
+	secondToolName := "mcp__second_server__" + sharedSuffix
+	payload := []byte(`{
+		"model":"claude-opus-5",
+		"max_tokens":4096,
+		"tools":[
+			{"name":"ToolSearch","input_schema":{"type":"object"}},
+			{"name":"` + firstToolName + `","input_schema":{"type":"object"},"defer_loading":true},
+			{"name":"` + secondToolName + `","input_schema":{"type":"object"},"defer_loading":true}
+		],
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_search","name":"ToolSearch","input":{"query":"resource"}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_search","content":[
+				{"type":"text","text":"found tools"},
+				{"type":"tool_reference","tool_name":"` + firstToolName + `"},
+				{"type":"search_result","source":"https://example.test/result","title":"Result","content":[{"type":"text","text":"search body"}]},
+				{"type":"document","source":{"type":"base64","media_type":"application/pdf","data":"JVBERi0xLjQK"},"title":"reference.pdf"},
+				{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aW1hZ2U="}},
+				{"type":"tool_reference","tool_name":"` + secondToolName + `"}
+			]}]},
+			{"role":"user","content":"continue"}
+		]
+	}`)
+
+	_, body, err := translateCodexRequestPair(sdktranslator.FormatClaude, sdktranslator.FormatCodex, "gpt-5.6-sol", payload, bytes.Clone(payload), false)
+	if err != nil {
+		t.Fatalf("translateCodexRequestPair() error = %v", err)
+	}
+
+	var functionOutput gjson.Result
+	inputs := gjson.GetBytes(body, "input").Array()
+	for _, input := range inputs {
+		if input.Get("type").String() == "function_call_output" {
+			functionOutput = input
+			break
+		}
+	}
+	if !functionOutput.Exists() {
+		t.Fatalf("missing function_call_output. Output: %s", body)
+	}
+
+	output := functionOutput.Get("output").Array()
+	wantTypes := []string{"input_text", "input_text", "input_text", "input_file", "input_image", "input_text"}
+	if len(output) != len(wantTypes) {
+		t.Fatalf("got %d tool result items, want %d. Output: %s", len(output), len(wantTypes), body)
+	}
+	for i, wantType := range wantTypes {
+		if got := output[i].Get("type").String(); got != wantType {
+			t.Fatalf("output[%d].type = %q, want %q. Output: %s", i, got, wantType, body)
+		}
+	}
+
+	firstReference := gjson.Parse(output[1].Get("text").String())
+	secondReference := gjson.Parse(output[5].Get("text").String())
+	if got, want := firstReference.Get("tool_name").String(), gjson.GetBytes(body, "tools.1.name").String(); got != want {
+		t.Fatalf("first reference name = %q, want translated tool name %q", got, want)
+	}
+	if got, want := secondReference.Get("tool_name").String(), gjson.GetBytes(body, "tools.2.name").String(); got != want {
+		t.Fatalf("second reference name = %q, want translated tool name %q", got, want)
+	}
+	if firstReference.Get("tool_name").String() == secondReference.Get("tool_name").String() {
+		t.Fatalf("collision-safe translated tool names must differ. Output: %s", body)
+	}
+
+	if got := gjson.Parse(output[2].Get("text").String()).Get("content.0.text").String(); got != "search body" {
+		t.Fatalf("search result content = %q, want search body", got)
+	}
+	if got := output[3].Get("file_data").String(); got != "data:application/pdf;base64,JVBERi0xLjQK" {
+		t.Fatalf("document file_data = %q, want PDF data URL", got)
+	}
+	if got := output[3].Get("filename").String(); got != "reference.pdf" {
+		t.Fatalf("document filename = %q, want reference.pdf", got)
+	}
+	if got := output[4].Get("image_url").String(); got != "data:image/png;base64,aW1hZ2U=" {
+		t.Fatalf("image_url = %q, want image data URL", got)
+	}
+	if got := inputs[len(inputs)-1].Get("content.0.text").String(); got != "continue" {
+		t.Fatalf("subsequent turn = %q, want continue", got)
 	}
 }

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -143,7 +143,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			helps.RecordAPIWebsocketUpgradeRejection(ctx, e.cfg, websocketUpgradeRequestLog(wsReqLog), respHS.StatusCode, respHS.Header.Clone(), bodyErr)
 		}
 		if respHS != nil && respHS.StatusCode == http.StatusUpgradeRequired {
-			if opts.ExecutionLifecycle != nil || cliproxyexecutor.DownstreamWebsocket(ctx) {
+			if cliproxyexecutor.DownstreamWebsocket(ctx) {
 				return resp, statusErr{code: respHS.StatusCode, msg: string(bodyErr)}
 			}
 			return e.CodexExecutor.Execute(ctx, auth, req, opts)

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -44,7 +44,10 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		originalPayloadSource = opts.OriginalRequest
 	}
 	originalPayload := originalPayloadSource
-	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
+	originalTranslated, body, errTranslate := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
+	if errTranslate != nil {
+		return resp, errTranslate
+	}
 
 	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -31,11 +31,13 @@ func NewCodexWebsocketsExecutor(cfg *config.Config) *CodexWebsocketsExecutor {
 	}
 }
 
-// CodexAutoExecutor routes Codex requests to the websocket transport only when:
-//  1. The downstream transport is websocket, and
-//  2. The selected auth enables websockets.
+// CodexAutoExecutor routes Codex requests to the websocket transport when the selected
+// auth enables websockets. HTTP downstream clients (e.g. Claude Code via SSE) benefit from
+// the websocket upstream's ping/pong keepalives, explicit disconnect detection, and automatic
+// reconnect-on-send-failure — all of which the legacy HTTP/2 transport lacks.
 //
-// For non-websocket downstream requests, it always uses the legacy HTTP implementation.
+// When the websocket upgrade fails (HTTP 426), the executor falls back to HTTP automatically.
+// Set codex.enable-websocket-upstream: false or auth attribute websockets: false to opt out.
 type CodexAutoExecutor struct {
 	httpExec *CodexExecutor
 	wsExec   *CodexWebsocketsExecutor
@@ -68,7 +70,7 @@ func (e *CodexAutoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth
 	if e == nil || e.httpExec == nil || e.wsExec == nil {
 		return cliproxyexecutor.Response{}, fmt.Errorf("codex auto executor: executor is nil")
 	}
-	if cliproxyexecutor.DownstreamWebsocket(ctx) && codexWebsocketsEnabled(auth) {
+	if codexWebsocketsEnabled(auth, e.httpExec.cfg) {
 		return e.wsExec.Execute(ctx, auth, req, opts)
 	}
 	if cliproxyexecutor.RequiredUpstreamWebsocket(ctx) {
@@ -81,7 +83,7 @@ func (e *CodexAutoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyaut
 	if e == nil || e.httpExec == nil || e.wsExec == nil {
 		return nil, fmt.Errorf("codex auto executor: executor is nil")
 	}
-	if cliproxyexecutor.DownstreamWebsocket(ctx) && codexWebsocketsEnabled(auth) {
+	if codexWebsocketsEnabled(auth, e.httpExec.cfg) {
 		return e.wsExec.ExecuteStream(ctx, auth, req, opts)
 	}
 	if cliproxyexecutor.RequiredUpstreamWebsocket(ctx) {
@@ -118,10 +120,14 @@ func (e *CodexAutoExecutor) UpstreamDisconnectChan(sessionID string) <-chan erro
 	return e.wsExec.UpstreamDisconnectChan(sessionID)
 }
 
-func codexWebsocketsEnabled(auth *cliproxyauth.Auth) bool {
+func codexWebsocketsEnabled(auth *cliproxyauth.Auth, cfg *config.Config) bool {
 	if auth == nil {
 		return false
 	}
+
+	// Per-auth websockets attribute overrides all other settings.
+	// Set "websockets": false in the auth JSON or toggle off in the management UI
+	// to force HTTP/2 for a specific credential while others continue using WebSocket.
 	if len(auth.Attributes) > 0 {
 		if raw := strings.TrimSpace(auth.Attributes["websockets"]); raw != "" {
 			parsed, errParse := strconv.ParseBool(raw)
@@ -130,22 +136,27 @@ func codexWebsocketsEnabled(auth *cliproxyauth.Auth) bool {
 			}
 		}
 	}
-	if len(auth.Metadata) == 0 {
-		return false
-	}
-	raw, ok := auth.Metadata["websockets"]
-	if !ok || raw == nil {
-		return false
-	}
-	switch v := raw.(type) {
-	case bool:
-		return v
-	case string:
-		parsed, errParse := strconv.ParseBool(strings.TrimSpace(v))
-		if errParse == nil {
-			return parsed
+	if len(auth.Metadata) > 0 {
+		raw, ok := auth.Metadata["websockets"]
+		if ok && raw != nil {
+			switch v := raw.(type) {
+			case bool:
+				return v
+			case string:
+				parsed, errParse := strconv.ParseBool(strings.TrimSpace(v))
+				if errParse == nil {
+					return parsed
+				}
+			}
 		}
-	default:
 	}
+
+	// Config-level opt-in for Codex OAuth credentials (prolite, etc.).
+	// codex.enable-websocket-upstream: true in config.yaml.
+	if cfg != nil && cfg.Codex.EnableWebsocketUpstream &&
+		auth.Provider == "codex" && auth.AuthKind() == cliproxyauth.AuthKindOAuth {
+		return true
+	}
+
 	return false
 }

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -1783,12 +1783,15 @@ func TestNewProxyAwareWebsocketDialerDirectDisablesProxy(t *testing.T) {
 	}
 }
 
-func TestCodexWebsocketUpgradeRequiredDoesNotFallbackToHTTPWithLifecycle(t *testing.T) {
+func TestCodexWebsocketUpgradeRequiredFallsBackToHTTPWithLifecycle(t *testing.T) {
 	var httpFallbackCalls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			httpFallbackCalls.Add(1)
-			http.Error(w, "unexpected HTTP fallback", http.StatusInternalServerError)
+			// Return a valid SSE stream so the HTTP fallback succeeds.
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5-codex\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n"))
 			return
 		}
 		http.Error(w, "websocket upgrade required", http.StatusUpgradeRequired)
@@ -1804,11 +1807,19 @@ func TestCodexWebsocketUpgradeRequiredDoesNotFallbackToHTTPWithLifecycle(t *test
 		ExecutionLifecycle: newTerminalFailureLifecycle(),
 	}
 
-	if _, errExecute := exec.ExecuteStream(context.Background(), auth, req, opts); errExecute == nil {
-		t.Fatal("ExecuteStream() error = nil, want failed Home lifecycle attempt")
+	// With the fix, non-WS downstream requests with ExecutionLifecycle should still
+	// fall back to HTTP on 426 instead of surfacing the upgrade error.
+	result, errExecute := exec.ExecuteStream(context.Background(), auth, req, opts)
+	if errExecute == nil {
+		// Drain stream chunks.
+		for range result.Chunks {
+		}
+	} else {
+		// The HTTP fallback may return an error if the mock server doesn't produce
+		// a valid streaming response. What matters is that the fallback was attempted.
 	}
-	if got := httpFallbackCalls.Load(); got != 0 {
-		t.Fatalf("HTTP fallback calls = %d, want 0 with an execution lifecycle", got)
+	if got := httpFallbackCalls.Load(); got != 1 {
+		t.Fatalf("HTTP fallback calls = %d, want 1 (fallback should be allowed for non-WS downstream with lifecycle)", got)
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -148,7 +148,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			if sess != nil {
 				sess.reqMu.Unlock()
 			}
-			if opts.ExecutionLifecycle != nil || cliproxyexecutor.DownstreamWebsocket(ctx) {
+			if cliproxyexecutor.DownstreamWebsocket(ctx) {
 				return nil, statusErr{code: respHS.StatusCode, msg: string(bodyErr)}
 			}
 			return e.CodexExecutor.ExecuteStream(ctx, auth, req, opts)

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -44,7 +44,10 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		originalPayloadSource = opts.OriginalRequest
 	}
 	originalPayload := originalPayloadSource
-	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, true)
+	originalTranslated, body, errTranslate := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, true)
+	if errTranslate != nil {
+		return nil, errTranslate
+	}
 
 	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {

--- a/internal/translator/claude/input/block.go
+++ b/internal/translator/claude/input/block.go
@@ -1,0 +1,51 @@
+package input
+
+import "github.com/tidwall/sjson"
+
+// ToolUseBlock builds a provider-independent Claude tool_use content block.
+func ToolUseBlock(id, name string, input []byte) []byte {
+	block := []byte(`{"type":"tool_use","id":"","name":"","input":{}}`)
+	block, _ = sjson.SetBytes(block, "id", id)
+	block, _ = sjson.SetBytes(block, "name", name)
+	if len(input) > 0 {
+		block, _ = sjson.SetRawBytes(block, "input", input)
+	}
+	return block
+}
+
+// ToolResultBlock builds a provider-independent Claude tool_result block. The
+// content argument must contain its final JSON representation.
+func ToolResultBlock(toolUseID string, content []byte) []byte {
+	block := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
+	block, _ = sjson.SetBytes(block, "tool_use_id", toolUseID)
+	if len(content) > 0 {
+		block, _ = sjson.SetRawBytes(block, "content", content)
+	}
+	return block
+}
+
+// ToolResultTextBlock builds a Claude tool_result with string content.
+func ToolResultTextBlock(toolUseID, content string) []byte {
+	block := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
+	block, _ = sjson.SetBytes(block, "tool_use_id", toolUseID)
+	block, _ = sjson.SetBytes(block, "content", content)
+	return block
+}
+
+// ThinkingBlock builds a Claude thinking block and includes a signature only
+// when one is available.
+func ThinkingBlock(text, signature string) []byte {
+	block := []byte(`{"type":"thinking","thinking":""}`)
+	block, _ = sjson.SetBytes(block, "thinking", text)
+	if signature != "" {
+		block, _ = sjson.SetBytes(block, "signature", signature)
+	}
+	return block
+}
+
+// RedactedThinkingBlock builds a Claude redacted_thinking content block.
+func RedactedThinkingBlock(data string) []byte {
+	block := []byte(`{"type":"redacted_thinking","data":""}`)
+	block, _ = sjson.SetBytes(block, "data", data)
+	return block
+}

--- a/internal/translator/claude/input/request.go
+++ b/internal/translator/claude/input/request.go
@@ -1,0 +1,203 @@
+package input
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/tidwall/gjson"
+)
+
+// Request is a lossless view of a Claude protocol request. It keeps the wire
+// payload intact while exposing provider-independent Claude fields to direct
+// pairwise adapters.
+type Request struct {
+	resolvedModel string
+	raw           []byte
+	root          gjson.Result
+}
+
+// Parse creates a lossless Claude request view.
+func Parse(resolvedModel string, raw []byte) Request {
+	return Request{
+		resolvedModel: resolvedModel,
+		raw:           raw,
+		root:          gjson.ParseBytes(raw),
+	}
+}
+
+// Raw returns the original request bytes without copying or rewriting them.
+func (r Request) Raw() []byte {
+	return r.raw
+}
+
+// Root returns the parsed Claude request object.
+func (r Request) Root() gjson.Result {
+	return r.root
+}
+
+// ResolvedModel returns the model selected by routing and alias resolution.
+func (r Request) ResolvedModel() string {
+	return r.resolvedModel
+}
+
+// SourceModel returns the model namespace supplied on the Claude wire request.
+func (r Request) SourceModel() string {
+	return r.root.Get("model").String()
+}
+
+// ModelOrSource prefers the routed model and falls back to the wire model.
+func (r Request) ModelOrSource() string {
+	if r.resolvedModel != "" {
+		return r.resolvedModel
+	}
+	return r.SourceModel()
+}
+
+// System returns the top-level Claude system content.
+func (r Request) System() gjson.Result {
+	return r.root.Get("system")
+}
+
+// MessagesResult returns the lossless messages array.
+func (r Request) MessagesResult() gjson.Result {
+	return r.root.Get("messages")
+}
+
+// Messages returns the ordered Claude messages.
+func (r Request) Messages() []gjson.Result {
+	messages := r.MessagesResult()
+	if !messages.IsArray() {
+		return nil
+	}
+	return messages.Array()
+}
+
+// Tools returns the Claude tool declarations.
+func (r Request) Tools() gjson.Result {
+	return r.root.Get("tools")
+}
+
+// ToolChoice returns the Claude tool selection policy.
+func (r Request) ToolChoice() gjson.Result {
+	return r.root.Get("tool_choice")
+}
+
+// Thinking returns the Claude thinking configuration.
+func (r Request) Thinking() gjson.Result {
+	return r.root.Get("thinking")
+}
+
+// OutputConfig returns the Claude output configuration.
+func (r Request) OutputConfig() gjson.Result {
+	return r.root.Get("output_config")
+}
+
+// DecodeObject decodes the lossless Claude request into its JSON object while
+// preserving JSON number spelling for pairwise validation.
+func (r Request) DecodeObject() (map[string]any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(r.raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, fmt.Errorf("Claude request must be a valid JSON object: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return nil, fmt.Errorf("Claude request must contain exactly one JSON object")
+	}
+	root, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("Claude request must be a valid JSON object")
+	}
+	return root, nil
+}
+
+// Validate checks provider-independent Claude request structure. Pairwise
+// adapters remain responsible for counterpart restrictions and field mapping.
+func (r Request) Validate() error {
+	object, err := r.DecodeObject()
+	if err != nil {
+		return err
+	}
+	messagesValue, exists := object["messages"]
+	if !exists {
+		return nil
+	}
+	messages, ok := messagesValue.([]any)
+	if !ok {
+		return fmt.Errorf("Claude messages must be an array")
+	}
+	for messageIndex, messageValue := range messages {
+		message, ok := messageValue.(map[string]any)
+		if !ok {
+			return fmt.Errorf("Claude message %d must be an object", messageIndex)
+		}
+		content, exists := message["content"]
+		if !exists {
+			continue
+		}
+		switch content := content.(type) {
+		case string:
+		case []any:
+			for blockIndex, blockValue := range content {
+				block, ok := blockValue.(map[string]any)
+				if !ok {
+					return fmt.Errorf("Claude message %d content block %d must be an object", messageIndex, blockIndex)
+				}
+				blockType, ok := block["type"].(string)
+				if !ok || blockType == "" {
+					return fmt.Errorf("Claude message %d content block %d requires a type", messageIndex, blockIndex)
+				}
+			}
+		default:
+			return fmt.Errorf("Claude message %d content must be text or an array", messageIndex)
+		}
+	}
+	return nil
+}
+
+// MessageRole returns a Claude message role.
+func MessageRole(message gjson.Result) string {
+	return message.Get("role").String()
+}
+
+// Block is a provider-independent view of one Claude content block.
+type Block struct {
+	value gjson.Result
+}
+
+// MessageBlocks returns ordered content blocks for array-form Claude content.
+func MessageBlocks(message gjson.Result) []Block {
+	content := message.Get("content")
+	if !content.IsArray() {
+		return nil
+	}
+	values := content.Array()
+	blocks := make([]Block, len(values))
+	for i, value := range values {
+		blocks[i] = Block{value: value}
+	}
+	return blocks
+}
+
+// Value returns the lossless parsed block.
+func (b Block) Value() gjson.Result {
+	return b.value
+}
+
+// Type returns the Claude content block type.
+func (b Block) Type() string {
+	return b.value.Get("type").String()
+}
+
+// ToolUseID returns the identity declared by a tool_use block.
+func (b Block) ToolUseID() string {
+	return b.value.Get("id").String()
+}
+
+// ToolResultID returns the tool_use identity referenced by a tool_result block.
+func (b Block) ToolResultID() string {
+	return b.value.Get("tool_use_id").String()
+}

--- a/internal/translator/claude/input/request_test.go
+++ b/internal/translator/claude/input/request_test.go
@@ -1,0 +1,136 @@
+package input
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestParsePreservesClaudeRequestAndResolvedModel(t *testing.T) {
+	raw := []byte(`{"model":"client/claude","system":[{"type":"text","text":"system"}],"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"sig"},{"type":"tool_use","id":"call-1","name":"run","input":{"command":"true"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"call-1","content":[{"type":"text","text":"ok"}]}]}],"tools":[{"name":"run","input_schema":{"type":"object"}}],"tool_choice":{"type":"tool","name":"run"},"thinking":{"type":"enabled","budget_tokens":1024},"output_config":{"effort":"high"}}`)
+
+	request := Parse("resolved-model", raw)
+
+	if !bytes.Equal(request.Raw(), raw) {
+		t.Fatalf("Raw() changed request bytes: %s", request.Raw())
+	}
+	if got := request.ResolvedModel(); got != "resolved-model" {
+		t.Fatalf("ResolvedModel() = %q, want resolved-model", got)
+	}
+	if got := request.SourceModel(); got != "client/claude" {
+		t.Fatalf("SourceModel() = %q, want client/claude", got)
+	}
+	if got := request.ModelOrSource(); got != "resolved-model" {
+		t.Fatalf("ModelOrSource() = %q, want resolved-model", got)
+	}
+	if got := request.System().Get("0.text").String(); got != "system" {
+		t.Fatalf("System() text = %q, want system", got)
+	}
+	if got := len(request.Messages()); got != 2 {
+		t.Fatalf("len(Messages()) = %d, want 2", got)
+	}
+	if got := request.Tools().Get("0.name").String(); got != "run" {
+		t.Fatalf("Tools() name = %q, want run", got)
+	}
+	if got := request.ToolChoice().Get("type").String(); got != "tool" {
+		t.Fatalf("ToolChoice() type = %q, want tool", got)
+	}
+	if got := request.Thinking().Get("type").String(); got != "enabled" {
+		t.Fatalf("Thinking() type = %q, want enabled", got)
+	}
+	if got := request.OutputConfig().Get("effort").String(); got != "high" {
+		t.Fatalf("OutputConfig() effort = %q, want high", got)
+	}
+}
+
+func TestParseUsesSourceModelOnlyWhenRequested(t *testing.T) {
+	request := Parse("", []byte(`{"model":"source-model","messages":[]}`))
+
+	if got := request.ResolvedModel(); got != "" {
+		t.Fatalf("ResolvedModel() = %q, want empty", got)
+	}
+	if got := request.ModelOrSource(); got != "source-model" {
+		t.Fatalf("ModelOrSource() = %q, want source-model", got)
+	}
+}
+
+func TestMessageBlocksExposeClaudeGenericIdentity(t *testing.T) {
+	request := Parse("model", []byte(`{"messages":[{"role":"assistant","content":[{"type":"text","text":"hi"},{"type":"tool_use","id":"call-1","name":"run","input":{}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"call-1","content":"ok"}]}]}`))
+	messages := request.Messages()
+
+	if got := MessageRole(messages[0]); got != "assistant" {
+		t.Fatalf("MessageRole() = %q, want assistant", got)
+	}
+	assistantBlocks := MessageBlocks(messages[0])
+	if got := len(assistantBlocks); got != 2 {
+		t.Fatalf("assistant block count = %d, want 2", got)
+	}
+	if got := assistantBlocks[1].Type(); got != "tool_use" {
+		t.Fatalf("tool block type = %q, want tool_use", got)
+	}
+	if got := assistantBlocks[1].ToolUseID(); got != "call-1" {
+		t.Fatalf("ToolUseID() = %q, want call-1", got)
+	}
+	resultBlocks := MessageBlocks(messages[1])
+	if got := resultBlocks[0].ToolResultID(); got != "call-1" {
+		t.Fatalf("ToolResultID() = %q, want call-1", got)
+	}
+}
+
+func TestValidateChecksOnlyClaudeGenericShape(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{name: "valid", raw: `{"messages":[{"role":"user","content":"hi"}]}`},
+		{name: "invalid JSON", raw: `{`, wantErr: true},
+		{name: "trailing JSON", raw: `{"messages":[]} {"messages":[]}`, wantErr: true},
+		{name: "non-object", raw: `[]`, wantErr: true},
+		{name: "messages not array", raw: `{"messages":{}}`, wantErr: true},
+		{name: "message not object", raw: `{"messages":["hi"]}`, wantErr: true},
+		{name: "content wrong shape", raw: `{"messages":[{"role":"user","content":1}]}`, wantErr: true},
+		{name: "block not object", raw: `{"messages":[{"role":"user","content":["hi"]}]}`, wantErr: true},
+		{name: "block missing type", raw: `{"messages":[{"role":"user","content":[{"text":"hi"}]}]}`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Parse("model", []byte(tt.raw)).Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestClaudeBlockConstructorsPreserveGenericFields(t *testing.T) {
+	toolUse := ToolUseBlock("call-1", "run", []byte(`{"command":"true"}`))
+	if got := string(toolUse); got != `{"type":"tool_use","id":"call-1","name":"run","input":{"command":"true"}}` {
+		t.Fatalf("ToolUseBlock() = %s", got)
+	}
+	if got := gjson.GetBytes(toolUse, "id").String(); got != "call-1" {
+		t.Fatalf("tool_use id = %q, want call-1", got)
+	}
+
+	toolResult := ToolResultBlock("call-1", []byte(`[{"type":"text","text":"ok"}]`))
+	if got := string(toolResult); got != `{"type":"tool_result","tool_use_id":"call-1","content":[{"type":"text","text":"ok"}]}` {
+		t.Fatalf("ToolResultBlock() = %s", got)
+	}
+
+	thinking := ThinkingBlock("reason", "signature")
+	if got := string(thinking); got != `{"type":"thinking","thinking":"reason","signature":"signature"}` {
+		t.Fatalf("ThinkingBlock() = %s", got)
+	}
+
+	unsignedThinking := ThinkingBlock("reason", "")
+	if gjson.GetBytes(unsignedThinking, "signature").Exists() {
+		t.Fatalf("unsigned ThinkingBlock() included signature: %s", unsignedThinking)
+	}
+
+	redacted := RedactedThinkingBlock("opaque")
+	if got := string(redacted); got != `{"type":"redacted_thinking","data":"opaque"}` {
+		t.Fatalf("RedactedThinkingBlock() = %s", got)
+	}
+}

--- a/internal/translator/claude/output/event.go
+++ b/internal/translator/claude/output/event.go
@@ -1,0 +1,281 @@
+package output
+
+import (
+	"bytes"
+
+	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// TerminalKind identifies a semantic Claude stream terminal.
+type TerminalKind string
+
+const (
+	TerminalNone        TerminalKind = ""
+	TerminalMessageStop TerminalKind = "message_stop"
+	TerminalError       TerminalKind = "error"
+)
+
+// SSEEvent is one encoded Claude SSE event plus its structured lifecycle state.
+type SSEEvent struct {
+	name     string
+	payload  []byte
+	wire     []byte
+	terminal TerminalKind
+}
+
+// Event encodes one Claude SSE event using the canonical wire framing.
+func Event(name string, payload []byte) SSEEvent {
+	return EventWithTrailingNewlines(name, payload, 2)
+}
+
+// EventWithTrailingNewlines encodes one Claude SSE event while preserving an
+// adapter's established chunk separator.
+func EventWithTrailingNewlines(name string, payload []byte, trailingNewlines int) SSEEvent {
+	payloadCopy := bytes.Clone(payload)
+	return SSEEvent{
+		name:     name,
+		payload:  payloadCopy,
+		wire:     translatorcommon.AppendSSEEventBytes(nil, name, payloadCopy, trailingNewlines),
+		terminal: terminalKind(name, payloadCopy),
+	}
+}
+
+// AppendEvent appends one encoded Claude SSE event to an existing chunk.
+func AppendEvent(out []byte, name string, payload []byte, trailingNewlines int) []byte {
+	return translatorcommon.AppendSSEEventBytes(out, name, payload, trailingNewlines)
+}
+
+// AppendEventString appends one encoded Claude SSE event with a string payload.
+func AppendEventString(out []byte, name, payload string, trailingNewlines int) []byte {
+	return translatorcommon.AppendSSEEventString(out, name, payload, trailingNewlines)
+}
+
+// Name returns the SSE event name.
+func (e SSEEvent) Name() string {
+	return e.name
+}
+
+// Payload returns the JSON event payload.
+func (e SSEEvent) Payload() []byte {
+	return e.payload
+}
+
+// Bytes returns the encoded SSE event.
+func (e SSEEvent) Bytes() []byte {
+	return e.wire
+}
+
+// Terminal reports whether the event semantically ends the Claude stream.
+func (e SSEEvent) Terminal() bool {
+	return e.terminal != TerminalNone
+}
+
+// TerminalKind returns the semantic terminal classification.
+func (e SSEEvent) TerminalKind() TerminalKind {
+	return e.terminal
+}
+
+func terminalKind(name string, payload []byte) TerminalKind {
+	switch name {
+	case "message_stop":
+		return TerminalMessageStop
+	case "error":
+		return TerminalError
+	}
+	switch gjson.GetBytes(payload, "type").String() {
+	case "message_stop":
+		return TerminalMessageStop
+	case "error":
+		return TerminalError
+	default:
+		return TerminalNone
+	}
+}
+
+// Payload returns one Claude JSON payload from exactly one SSE event.
+func Payload(raw []byte) ([]byte, bool) {
+	trimmed := bytes.TrimSpace(raw)
+	event, ok := ParseEvent(trimmed)
+	if !ok || !gjson.ValidBytes(event.Payload()) {
+		return nil, false
+	}
+	return bytes.Clone(event.Payload()), true
+}
+
+// Payloads returns ordered Claude JSON payloads from direct JSON or SSE.
+func Payloads(raw []byte) [][]byte {
+	trimmed := bytes.TrimSpace(raw)
+	if gjson.ValidBytes(trimmed) {
+		return [][]byte{bytes.Clone(trimmed)}
+	}
+	events := ParseEvents(trimmed)
+	payloads := make([][]byte, 0, len(events))
+	for _, event := range events {
+		if gjson.ValidBytes(event.Payload()) {
+			payloads = append(payloads, bytes.Clone(event.Payload()))
+		}
+	}
+	return payloads
+}
+
+// ParseEvent parses one Claude SSE event without interpreting JSON string data
+// as protocol metadata.
+func ParseEvent(chunk []byte) (SSEEvent, bool) {
+	events := ParseEvents(chunk)
+	if len(events) != 1 {
+		return SSEEvent{}, false
+	}
+	return events[0], true
+}
+
+// ParseEvents parses every Claude SSE event in a chunk.
+func ParseEvents(chunk []byte) []SSEEvent {
+	lines := bytes.Split(chunk, []byte("\n"))
+	events := make([]SSEEvent, 0, len(lines)/2+1)
+	var frame []byte
+	var name string
+	var data []byte
+	flush := func() {
+		if data == nil {
+			frame = nil
+			name = ""
+			return
+		}
+		eventName := name
+		if eventName == "" {
+			eventName = gjson.GetBytes(data, "type").String()
+		}
+		event := Event(eventName, data)
+		event.wire = bytes.Clone(frame)
+		event.wire = append(event.wire, '\n', '\n')
+		events = append(events, event)
+		frame = nil
+		name = ""
+		data = nil
+	}
+	for _, rawLine := range lines {
+		line := bytes.TrimSuffix(rawLine, []byte("\r"))
+		if len(bytes.TrimSpace(line)) == 0 {
+			flush()
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("event:")) && data != nil {
+			flush()
+		} else if bytes.HasPrefix(line, []byte("data:")) && data != nil && gjson.ValidBytes(data) {
+			flush()
+		}
+		if len(frame) > 0 {
+			frame = append(frame, '\n')
+		}
+		frame = append(frame, line...)
+		switch {
+		case bytes.HasPrefix(line, []byte("event:")):
+			name = string(bytes.TrimSpace(line[len("event:"):]))
+		case bytes.HasPrefix(line, []byte("data:")):
+			value := bytes.TrimPrefix(line[len("data:"):], []byte(" "))
+			if data != nil {
+				data = append(data, '\n')
+			}
+			data = append(data, value...)
+		}
+	}
+	flush()
+	return events
+}
+
+// HasTerminalEvent reports whether a chunk contains a semantic Claude stream
+// terminal event.
+func HasTerminalEvent(chunk []byte) bool {
+	for _, event := range ParseEvents(chunk) {
+		if event.Terminal() {
+			return true
+		}
+	}
+	return false
+}
+
+// Stream builds an ordered Claude response lifecycle with monotonic content
+// block indexes.
+type Stream struct {
+	events         []SSEEvent
+	nextBlockIndex int
+}
+
+// Append records an already-built Claude event.
+func (s *Stream) Append(event SSEEvent) {
+	s.events = append(s.events, event)
+}
+
+// MessageStart emits the Claude message_start event.
+func (s *Stream) MessageStart(id, model string, inputTokens int64) {
+	payload := []byte(`{"type":"message_start","message":{"id":"","type":"message","role":"assistant","model":"","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}`)
+	payload, _ = sjson.SetBytes(payload, "message.id", id)
+	payload, _ = sjson.SetBytes(payload, "message.model", model)
+	payload, _ = sjson.SetBytes(payload, "message.usage.input_tokens", inputTokens)
+	s.Append(Event("message_start", payload))
+}
+
+// StartBlock emits content_block_start and returns its allocated index.
+func (s *Stream) StartBlock(contentBlock []byte) int {
+	index := s.nextBlockIndex
+	s.nextBlockIndex++
+	payload := []byte(`{"type":"content_block_start","index":0,"content_block":{}}`)
+	payload, _ = sjson.SetBytes(payload, "index", index)
+	payload, _ = sjson.SetRawBytes(payload, "content_block", contentBlock)
+	s.Append(Event("content_block_start", payload))
+	return index
+}
+
+// BlockDelta emits content_block_delta for a previously allocated index.
+func (s *Stream) BlockDelta(index int, delta []byte) {
+	payload := []byte(`{"type":"content_block_delta","index":0,"delta":{}}`)
+	payload, _ = sjson.SetBytes(payload, "index", index)
+	payload, _ = sjson.SetRawBytes(payload, "delta", delta)
+	s.Append(Event("content_block_delta", payload))
+}
+
+// StopBlock emits content_block_stop for a previously allocated index.
+func (s *Stream) StopBlock(index int) {
+	payload := []byte(`{"type":"content_block_stop","index":0}`)
+	payload, _ = sjson.SetBytes(payload, "index", index)
+	s.Append(Event("content_block_stop", payload))
+}
+
+// MessageDelta emits the terminal message metadata before message_stop.
+func (s *Stream) MessageDelta(stopReason, stopSequence string, outputTokens int64) {
+	payload := []byte(`{"type":"message_delta","delta":{"stop_reason":null,"stop_sequence":null},"usage":{"output_tokens":0}}`)
+	if stopReason != "" {
+		payload, _ = sjson.SetBytes(payload, "delta.stop_reason", stopReason)
+	}
+	if stopSequence != "" {
+		payload, _ = sjson.SetBytes(payload, "delta.stop_sequence", stopSequence)
+	}
+	payload, _ = sjson.SetBytes(payload, "usage.output_tokens", outputTokens)
+	s.Append(Event("message_delta", payload))
+}
+
+// MessageStop emits the semantic Claude stream terminal.
+func (s *Stream) MessageStop() {
+	s.Append(Event("message_stop", []byte(`{"type":"message_stop"}`)))
+}
+
+// Error emits a semantic Claude stream error terminal.
+func (s *Stream) Error(payload []byte) {
+	s.Append(Event("error", payload))
+}
+
+// Events returns the ordered structured events.
+func (s *Stream) Events() []SSEEvent {
+	return append([]SSEEvent(nil), s.events...)
+}
+
+// Bytes returns the ordered encoded event chunks.
+func (s *Stream) Bytes() [][]byte {
+	chunks := make([][]byte, len(s.events))
+	for i, event := range s.events {
+		chunks[i] = event.Bytes()
+	}
+	return chunks
+}

--- a/internal/translator/claude/output/event_test.go
+++ b/internal/translator/claude/output/event_test.go
@@ -1,0 +1,170 @@
+package output
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestEventEncodingPreservesClaudeSSEWireFormat(t *testing.T) {
+	payload := []byte(`{"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"hello"}}`)
+
+	got := Event("content_block_delta", payload)
+	want := []byte("event: content_block_delta\ndata: " + string(payload) + "\n\n")
+	if !bytes.Equal(got.Bytes(), want) {
+		t.Fatalf("Event().Bytes() = %q, want %q", got.Bytes(), want)
+	}
+	if got.Name() != "content_block_delta" {
+		t.Fatalf("Event().Name() = %q", got.Name())
+	}
+	if got.Terminal() {
+		t.Fatal("content_block_delta must not be terminal")
+	}
+}
+
+func TestTerminalEventsCarryStructuredContract(t *testing.T) {
+	messageStop := Event("message_stop", []byte(`{"type":"message_stop"}`))
+	if !messageStop.Terminal() {
+		t.Fatal("message_stop must be terminal")
+	}
+	if messageStop.TerminalKind() != TerminalMessageStop {
+		t.Fatalf("message_stop terminal kind = %q", messageStop.TerminalKind())
+	}
+
+	errorEvent := Event("error", []byte(`{"type":"error","error":{"type":"api_error","message":"boom"}}`))
+	if !errorEvent.Terminal() {
+		t.Fatal("error must be terminal")
+	}
+	if errorEvent.TerminalKind() != TerminalError {
+		t.Fatalf("error terminal kind = %q", errorEvent.TerminalKind())
+	}
+}
+
+func TestLifecycleProducesStableIndexesAndTerminalOrder(t *testing.T) {
+	var stream Stream
+	stream.MessageStart("msg-1", "model-1", 7)
+	textIndex := stream.StartBlock([]byte(`{"type":"text","text":""}`))
+	stream.BlockDelta(textIndex, []byte(`{"type":"text_delta","text":"hello"}`))
+	stream.StopBlock(textIndex)
+	toolIndex := stream.StartBlock([]byte(`{"type":"tool_use","id":"call-1","name":"run","input":{}}`))
+	stream.BlockDelta(toolIndex, []byte(`{"type":"input_json_delta","partial_json":"{}"}`))
+	stream.StopBlock(toolIndex)
+	stream.MessageDelta("tool_use", "", 11)
+	stream.MessageStop()
+
+	events := stream.Events()
+	if len(events) != 9 {
+		t.Fatalf("event count = %d, want 9", len(events))
+	}
+	wantNames := []string{"message_start", "content_block_start", "content_block_delta", "content_block_stop", "content_block_start", "content_block_delta", "content_block_stop", "message_delta", "message_stop"}
+	for i, want := range wantNames {
+		if got := events[i].Name(); got != want {
+			t.Fatalf("event %d name = %q, want %q", i, got, want)
+		}
+	}
+	if textIndex != 0 || toolIndex != 1 {
+		t.Fatalf("block indexes = (%d, %d), want (0, 1)", textIndex, toolIndex)
+	}
+	if got := gjson.GetBytes(events[0].Payload(), "message.usage.input_tokens").Int(); got != 7 {
+		t.Fatalf("message_start input_tokens = %d, want 7", got)
+	}
+	if got := gjson.GetBytes(events[4].Payload(), "index").Int(); got != 1 {
+		t.Fatalf("tool block index = %d, want 1", got)
+	}
+	if got := gjson.GetBytes(events[7].Payload(), "delta.stop_reason").String(); got != "tool_use" {
+		t.Fatalf("message_delta stop_reason = %q, want tool_use", got)
+	}
+	if got := gjson.GetBytes(events[7].Payload(), "usage.output_tokens").Int(); got != 11 {
+		t.Fatalf("message_delta output_tokens = %d, want 11", got)
+	}
+	if !events[8].Terminal() {
+		t.Fatal("last event must be terminal")
+	}
+}
+
+func TestParseEventRejectsPayloadTextFalsePositive(t *testing.T) {
+	chunk := []byte("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"\\\"type\\\":\\\"message_stop\\\" event: error\"}}\n\n")
+
+	event, ok := ParseEvent(chunk)
+	if !ok {
+		t.Fatal("ParseEvent() did not parse valid SSE")
+	}
+	if event.Terminal() {
+		t.Fatal("payload text must not mark an event terminal")
+	}
+}
+
+func TestParseEventRecognizesTerminalByEventAndPayloadType(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		kind TerminalKind
+	}{
+		{name: "message stop event", raw: "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n", kind: TerminalMessageStop},
+		{name: "message stop payload", raw: "data: {\"type\":\"message_stop\"}\n\n", kind: TerminalMessageStop},
+		{name: "error event", raw: "event: error\ndata: {\"type\":\"error\"}\n\n", kind: TerminalError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event, ok := ParseEvent([]byte(tt.raw))
+			if !ok {
+				t.Fatal("ParseEvent() did not parse event")
+			}
+			if got := event.TerminalKind(); got != tt.kind {
+				t.Fatalf("TerminalKind() = %q, want %q", got, tt.kind)
+			}
+		})
+	}
+}
+
+func TestPayloadAcceptsSingleClaudeSSEEvent(t *testing.T) {
+	payload := []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}`)
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "data only", raw: append([]byte("data: "), payload...)},
+		{name: "named event", raw: Event("content_block_delta", payload).Bytes()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := Payload(tt.raw)
+			if !ok {
+				t.Fatal("Payload() rejected Claude payload")
+			}
+			if !bytes.Equal(got, payload) {
+				t.Fatalf("Payload() = %q, want %q", got, payload)
+			}
+		})
+	}
+}
+
+func TestPayloadRejectsMultiEventChunk(t *testing.T) {
+	chunk := append(Event("ping", []byte(`{"type":"ping"}`)).Bytes(), Event("message_stop", []byte(`{"type":"message_stop"}`)).Bytes()...)
+	if payload, ok := Payload(chunk); ok {
+		t.Fatalf("Payload() accepted multi-event chunk: %q", payload)
+	}
+}
+
+func TestPayloadsReturnsOrderedDirectAndSSEPayloads(t *testing.T) {
+	first := []byte(`{"type":"ping"}`)
+	second := []byte(`{"type":"message_stop"}`)
+	chunk := append(Event("ping", first).Bytes(), Event("message_stop", second).Bytes()...)
+
+	got := Payloads(chunk)
+	if len(got) != 2 || !bytes.Equal(got[0], first) || !bytes.Equal(got[1], second) {
+		t.Fatalf("Payloads() = %q, want [%q %q]", got, first, second)
+	}
+
+	dataOnly := append(append(append([]byte("data: "), first...), '\n'), append([]byte("data: "), second...)...)
+	got = Payloads(dataOnly)
+	if len(got) != 2 || !bytes.Equal(got[0], first) || !bytes.Equal(got[1], second) {
+		t.Fatalf("Payloads(data-only) = %q, want [%q %q]", got, first, second)
+	}
+
+	direct := Payloads(first)
+	if len(direct) != 1 || !bytes.Equal(direct[0], first) {
+		t.Fatalf("Payloads(direct) = %q, want [%q]", direct, first)
+	}
+}

--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -8,6 +8,7 @@ package claude
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -248,10 +249,19 @@ func convertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool, 
 							contentResults := contentResult.Array()
 							toolResultContentItems := make([][]byte, 0, len(contentResults))
 							for k := 0; k < len(contentResults); k++ {
-								toolResultContentType := contentResults[k].Get("type").String()
-								if toolResultContentType == "image" {
-									sourceResult := contentResults[k].Get("source")
+								contentResult := contentResults[k]
+								switch contentResult.Get("type").String() {
+								case "image":
+									sourceResult := contentResult.Get("source")
 									if sourceResult.Exists() {
+										if sourceResult.Get("type").String() == "url" {
+											if imageURL := sourceResult.Get("url").String(); imageURL != "" {
+												toolResultContent := []byte(`{"type":"input_image","image_url":""}`)
+												toolResultContent, _ = sjson.SetBytes(toolResultContent, "image_url", imageURL)
+												toolResultContentItems = append(toolResultContentItems, toolResultContent)
+											}
+											break
+										}
 										data := sourceResult.Get("data").String()
 										if data == "" {
 											data = sourceResult.Get("base64").String()
@@ -271,13 +281,32 @@ func convertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool, 
 											toolResultContentItems = append(toolResultContentItems, toolResultContent)
 										}
 									}
-								} else if toolResultContentType == "text" {
+								case "text":
 									toolResultContent := []byte(`{"type":"input_text","text":""}`)
-									toolResultContent, _ = sjson.SetBytes(toolResultContent, "text", contentResults[k].Get("text").String())
+									toolResultContent, _ = sjson.SetBytes(toolResultContent, "text", contentResult.Get("text").String())
 									toolResultContentItems = append(toolResultContentItems, toolResultContent)
+								case "document":
+									toolResultContentItems = append(toolResultContentItems, convertClaudeToolResultDocument(contentResult))
+								case "search_result":
+									toolResultContentItems = append(toolResultContentItems, codexClaudeToolResultJSON(contentResult.Value()))
+								case "tool_reference":
+									toolName := contentResult.Get("tool_name").String()
+									if short, ok := toolNameMap[toolName]; ok {
+										toolName = short
+									} else {
+										toolName = shortenNameIfNeeded(toolName)
+									}
+									reference := map[string]any{"type": "tool_reference"}
+									if value, ok := contentResult.Value().(map[string]any); ok {
+										reference = value
+									}
+									reference["tool_name"] = toolName
+									toolResultContentItems = append(toolResultContentItems, codexClaudeToolResultJSON(reference))
 								}
 							}
-							if len(toolResultContentItems) > 0 {
+							if len(contentResults) == 0 {
+								functionCallOutputMessage, _ = sjson.SetBytes(functionCallOutputMessage, "output", "")
+							} else if len(toolResultContentItems) > 0 {
 								functionCallOutputMessage, _ = sjson.SetRawBytes(functionCallOutputMessage, "output", translatorcommon.JoinRawArray(toolResultContentItems))
 							} else {
 								functionCallOutputMessage, _ = sjson.SetBytes(functionCallOutputMessage, "output", messageContentResult.Get("content").String())
@@ -530,6 +559,32 @@ func shortenNameIfNeeded(name string) string {
 		}
 	}
 	return name[:limit]
+}
+
+func codexClaudeToolResultJSON(value any) []byte {
+	payload, _ := json.Marshal(value)
+	content := []byte(`{"type":"input_text","text":""}`)
+	content, _ = sjson.SetBytes(content, "text", string(payload))
+	return content
+}
+
+func convertClaudeToolResultDocument(document gjson.Result) []byte {
+	source := document.Get("source")
+	if source.Get("type").String() != "base64" || source.Get("media_type").String() != "application/pdf" ||
+		(document.Get("context").Exists() && document.Get("context").Type != gjson.Null) ||
+		(document.Get("citations").Exists() && document.Get("citations").Type != gjson.Null) {
+		return codexClaudeToolResultJSON(document.Value())
+	}
+	data := source.Get("data").String()
+	if data == "" {
+		return codexClaudeToolResultJSON(document.Value())
+	}
+	content := []byte(`{"type":"input_file","file_data":"","filename":"document.pdf"}`)
+	content, _ = sjson.SetBytes(content, "file_data", "data:application/pdf;base64,"+data)
+	if title := document.Get("title").String(); title != "" {
+		content, _ = sjson.SetBytes(content, "filename", title)
+	}
+	return content
 }
 
 // buildShortNameMap ensures uniqueness of shortened names within a request.

--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -56,6 +56,11 @@ func convertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool, 
 	rootResult := gjson.ParseBytes(rawJSON)
 	toolNameMap := buildReverseMapFromClaudeOriginalToShort(rawJSON)
 	template, _ = sjson.SetBytes(template, "model", modelName)
+	if format := rootResult.Get("output_config.format"); format.IsObject() && format.Get("type").String() == "json_schema" && format.Get("schema").IsObject() {
+		translatedFormat := []byte(`{"type":"json_schema","name":"cli_proxy_structured_output","strict":true,"schema":{}}`)
+		translatedFormat, _ = sjson.SetRawBytes(translatedFormat, "schema", []byte(format.Get("schema").Raw))
+		template, _ = sjson.SetRawBytes(template, "text.format", translatedFormat)
+	}
 	inputItems := translatorcommon.NewRawArrayItems(rootResult.Get("messages.#").Int())
 
 	// Process system messages and convert them to input content format.

--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -15,6 +15,7 @@ import (
 
 	sigcompat "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	claudeinput "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/claude/input"
 	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
@@ -50,22 +51,22 @@ func ConvertClaudeRequestToCodexWithCompat(modelName string, inputRawJSON []byte
 }
 
 func convertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool, preserveEmptyThinkingBlocks bool) []byte {
-	rawJSON := inputRawJSON
+	request := claudeinput.Parse(modelName, inputRawJSON)
 
 	template := []byte(`{"model":"","instructions":"","input":[]}`)
 
-	rootResult := gjson.ParseBytes(rawJSON)
-	toolNameMap := buildReverseMapFromClaudeOriginalToShort(rawJSON)
-	template, _ = sjson.SetBytes(template, "model", modelName)
-	if format := rootResult.Get("output_config.format"); format.IsObject() && format.Get("type").String() == "json_schema" && format.Get("schema").IsObject() {
+	rootResult := request.Root()
+	toolNameMap := buildReverseMapFromClaudeTools(request.Tools())
+	template, _ = sjson.SetBytes(template, "model", request.ResolvedModel())
+	if format := request.OutputConfig().Get("format"); format.IsObject() && format.Get("type").String() == "json_schema" && format.Get("schema").IsObject() {
 		translatedFormat := []byte(`{"type":"json_schema","name":"cli_proxy_structured_output","strict":true,"schema":{}}`)
 		translatedFormat, _ = sjson.SetRawBytes(translatedFormat, "schema", []byte(format.Get("schema").Raw))
 		template, _ = sjson.SetRawBytes(template, "text.format", translatedFormat)
 	}
-	inputItems := translatorcommon.NewRawArrayItems(rootResult.Get("messages.#").Int())
+	inputItems := translatorcommon.NewRawArrayItems(int64(len(request.Messages())))
 
 	// Process system messages and convert them to input content format.
-	systemsResult := rootResult.Get("system")
+	systemsResult := request.System()
 	if systemsResult.Exists() {
 		contentItems := make([][]byte, 0, 2)
 
@@ -99,7 +100,7 @@ func convertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool, 
 	}
 
 	// Process messages and transform their contents to appropriate formats.
-	messagesResult := rootResult.Get("messages")
+	messagesResult := request.MessagesResult()
 	if messagesResult.IsArray() {
 		messageResults := messagesResult.Array()
 
@@ -328,11 +329,11 @@ func convertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool, 
 	}
 
 	// Convert tools declarations to the expected format for the Codex API.
-	toolsResult := rootResult.Get("tools")
+	toolsResult := request.Tools()
 	var toolItems [][]byte
 	if toolsResult.IsArray() {
 		webSearchToolNames := buildClaudeWebSearchToolNameSet(toolsResult)
-		template, _ = sjson.SetRawBytes(template, "tool_choice", convertClaudeToolChoiceToCodex(rootResult.Get("tool_choice"), toolNameMap, webSearchToolNames))
+		template, _ = sjson.SetRawBytes(template, "tool_choice", convertClaudeToolChoiceToCodex(request.ToolChoice(), toolNameMap, webSearchToolNames))
 		toolResults := toolsResult.Array()
 		toolItems = make([][]byte, 0, len(toolResults))
 		for i := 0; i < len(toolResults); i++ {
@@ -374,7 +375,7 @@ func convertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool, 
 
 	// Default to parallel tool calls unless tool_choice explicitly disables them.
 	parallelToolCalls := true
-	if disableParallelToolUse := rootResult.Get("tool_choice.disable_parallel_tool_use"); disableParallelToolUse.Exists() {
+	if disableParallelToolUse := request.ToolChoice().Get("disable_parallel_tool_use"); disableParallelToolUse.Exists() {
 		parallelToolCalls = !disableParallelToolUse.Bool()
 	}
 
@@ -383,7 +384,7 @@ func convertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool, 
 
 	// Convert thinking.budget_tokens to reasoning.effort.
 	reasoningEffort := "medium"
-	if thinkingConfig := rootResult.Get("thinking"); thinkingConfig.Exists() && thinkingConfig.IsObject() {
+	if thinkingConfig := request.Thinking(); thinkingConfig.Exists() && thinkingConfig.IsObject() {
 		switch thinkingConfig.Get("type").String() {
 		case "enabled":
 			if budgetTokens := thinkingConfig.Get("budget_tokens"); budgetTokens.Exists() {
@@ -396,7 +397,7 @@ func convertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool, 
 			// Adaptive thinking can carry an explicit effort in output_config.effort (Claude 4.6).
 			// Pass through directly; ApplyThinking handles clamping to target model's levels.
 			effort := ""
-			if v := rootResult.Get("output_config.effort"); v.Exists() && v.Type == gjson.String {
+			if v := request.OutputConfig().Get("effort"); v.Exists() && v.Type == gjson.String {
 				effort = strings.ToLower(strings.TrimSpace(v.String()))
 			}
 			if effort != "" {
@@ -641,9 +642,8 @@ func buildShortNameMap(names []string) map[string]string {
 	return m
 }
 
-// buildReverseMapFromClaudeOriginalToShort builds original->short map, used to map tool_use names to short.
-func buildReverseMapFromClaudeOriginalToShort(original []byte) map[string]string {
-	tools := gjson.GetBytes(original, "tools")
+// buildReverseMapFromClaudeTools builds original->short map, used to map tool_use names to short.
+func buildReverseMapFromClaudeTools(tools gjson.Result) map[string]string {
 	m := map[string]string{}
 	if !tools.IsArray() {
 		return m

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -602,6 +602,89 @@ func TestConvertClaudeRequestToCodex_PreservesContentOrderAcrossToolAndReasoning
 	}
 }
 
+func TestConvertClaudeRequestToCodex_PreservesToolResultURLImage(t *testing.T) {
+	payload := []byte(`{
+		"model":"claude-opus-5",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"lookup","input":{}}]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"toolu_1","content":[
+					{"type":"text","text":"before image"},
+					{"type":"image","source":{"type":"url","url":"https://example.test/image.png"}},
+					{"type":"text","text":"after image"}
+				]},
+				{"type":"text","text":"following turn"}
+			]}
+		]
+	}`)
+	if err := ValidateClaudeRequestForCodex(payload); err != nil {
+		t.Fatalf("ValidateClaudeRequestForCodex() error = %v", err)
+	}
+
+	result := ConvertClaudeRequestToCodex("gpt-5.6-sol", payload, false)
+	inputs := gjson.GetBytes(result, "input").Array()
+	if len(inputs) != 3 {
+		t.Fatalf("got %d input items, want 3. Output: %s", len(inputs), result)
+	}
+	output := inputs[1].Get("output").Array()
+	wantTypes := []string{"input_text", "input_image", "input_text"}
+	if len(output) != len(wantTypes) {
+		t.Fatalf("got %d tool result items, want %d. Output: %s", len(output), len(wantTypes), result)
+	}
+	for i, wantType := range wantTypes {
+		if got := output[i].Get("type").String(); got != wantType {
+			t.Fatalf("output[%d].type = %q, want %q. Output: %s", i, got, wantType, result)
+		}
+	}
+	if got := output[1].Get("image_url").String(); got != "https://example.test/image.png" {
+		t.Fatalf("output[1].image_url = %q, want URL image", got)
+	}
+	if got := inputs[2].Get("content.0.text").String(); got != "following turn" {
+		t.Fatalf("following turn = %q, want following turn", got)
+	}
+}
+
+func TestConvertClaudeRequestToCodex_PreservesNonFileToolResultDocuments(t *testing.T) {
+	payload := []byte(`{
+		"model":"claude-opus-5",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"lookup","input":{}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":[
+				{"type":"document","source":{"type":"text","media_type":"text/plain","data":"plain document"}},
+				{"type":"document","source":{"type":"url","url":"https://example.test/document.pdf"}},
+				{"type":"document","source":{"type":"content","content":[
+					{"type":"text","text":"embedded text"},
+					{"type":"image","source":{"type":"url","url":"https://example.test/image.png"}}
+				]}}
+			]}]}
+		]
+	}`)
+	if err := ValidateClaudeRequestForCodex(payload); err != nil {
+		t.Fatalf("ValidateClaudeRequestForCodex() error = %v", err)
+	}
+
+	result := ConvertClaudeRequestToCodex("gpt-5.6-sol", payload, false)
+	output := gjson.GetBytes(result, "input.1.output").Array()
+	if len(output) != 3 {
+		t.Fatalf("got %d document outputs, want 3. Output: %s", len(output), result)
+	}
+	wantSourceTypes := []string{"text", "url", "content"}
+	for i, wantSourceType := range wantSourceTypes {
+		if got := output[i].Get("type").String(); got != "input_text" {
+			t.Fatalf("output[%d].type = %q, want input_text", i, got)
+		}
+		document := gjson.Parse(output[i].Get("text").String())
+		if got := document.Get("source.type").String(); got != wantSourceType {
+			t.Fatalf("output[%d] source type = %q, want %q", i, got, wantSourceType)
+		}
+	}
+	if got := gjson.Parse(output[2].Get("text").String()).Get("source.content.1.source.url").String(); got != "https://example.test/image.png" {
+		t.Fatalf("nested document image URL = %q", got)
+	}
+}
+
 func TestConvertClaudeRequestToCodex_AssistantGrokSignatureToReasoningItem(t *testing.T) {
 	signature := "HmlYdr2aCAqCYP/m9mr8PS6KOsdMs72FGDigmydR+Jsmuv8KX97yWPlbOwmXJgWn0CbHaCacdQD3+n5EvpgLfPNmafS3kdICBjRuDf4bzHy7uBiUhNVhqPtp/ee1y9q4imPE4LYgD1VZ4J+bp9mTeqA1+nC9Oue58CiNEMV9SVaGenCD+aBnVuSTzQhD32Y+68i6HLJW0Dx6ifaRfb8hxYtA/sPM+/FTvAMW11nRho5a2BBSkpnzfqqAz/e/vGJ77/bygpXM823QA9wL9i0X"
 	payload := []byte(`{"model":"grok-4.5","messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"summary","signature":""},{"type":"text","text":"answer"}]},{"role":"user","content":"next"}]}`)

--- a/internal/translator/codex/claude/codex_claude_response.go
+++ b/internal/translator/codex/claude/codex_claude_response.go
@@ -101,6 +101,8 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 	switch typeStr {
 	case "error":
 		output = append(output, codexStreamErrorToClaudeError(rootResult)...)
+	case "keepalive":
+		output = translatorcommon.AppendSSEEventBytes(output, "ping", []byte(`{"type":"ping"}`), 2)
 	case "response.created":
 		template = []byte(`{"type":"message_start","message":{"id":"","type":"message","role":"assistant","model":"claude-opus-4-1-20250805","stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0},"content":[],"stop_reason":null}}`)
 		template, _ = sjson.SetBytes(template, "message.model", rootResult.Get("response.model").String())
@@ -279,7 +281,7 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 
 func shouldDeferCodexStreamEvent(typeStr string, rootResult gjson.Result) bool {
 	switch typeStr {
-	case "error", "response.completed", "response.incomplete", "response.function_call_arguments.delta", "response.function_call_arguments.done":
+	case "error", "keepalive", "response.completed", "response.incomplete", "response.function_call_arguments.delta", "response.function_call_arguments.done":
 		return false
 	case "response.output_item.added", "response.output_item.done":
 		return rootResult.Get("item.type").String() != "function_call"

--- a/internal/translator/codex/claude/codex_claude_response.go
+++ b/internal/translator/codex/claude/codex_claude_response.go
@@ -28,6 +28,8 @@ const codexThinkingSummaryPartSeparator = "\n\n"
 // ConvertCodexResponseToClaudeParams holds parameters for response conversion.
 type ConvertCodexResponseToClaudeParams struct {
 	HasEmittedToolUse      bool
+	HasRefusal             bool
+	Terminal               bool
 	BlockIndex             int
 	HasTextDelta           bool
 	TextBlockOpen          bool
@@ -79,16 +81,26 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 			BlockIndex: 0,
 		}
 	}
+	params := (*param).(*ConvertCodexResponseToClaudeParams)
+	if params.Terminal {
+		return [][]byte{}
+	}
 
 	if !bytes.HasPrefix(rawJSON, dataTag) {
 		return [][]byte{}
 	}
 	streamEventRawJSON := bytes.Clone(rawJSON)
 	rawJSON = bytes.TrimSpace(rawJSON[5:])
+	if !gjson.ValidBytes(rawJSON) {
+		params.Terminal = true
+		return [][]byte{codexProtocolError("Malformed Responses stream event JSON.")}
+	}
+	rootResult := gjson.ParseBytes(rawJSON)
+	if !rootResult.IsObject() {
+		return [][]byte{}
+	}
 
 	output := make([]byte, 0, 512)
-	rootResult := gjson.ParseBytes(rawJSON)
-	params := (*param).(*ConvertCodexResponseToClaudeParams)
 
 	typeResult := rootResult.Get("type")
 	typeStr := typeResult.String()
@@ -99,8 +111,12 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 	var template []byte
 
 	switch typeStr {
-	case "error":
+	case "error", "response.failed":
+		output = append(output, finalizeCodexThinkingBlock(params)...)
+		output = append(output, stopCodexTextBlock(params)...)
+		output = append(output, closeOpenCodexFunctionCall(params)...)
 		output = append(output, codexStreamErrorToClaudeError(rootResult)...)
+		params.Terminal = true
 	case "keepalive":
 		output = translatorcommon.AppendSSEEventBytes(output, "ping", []byte(`{"type":"ping"}`), 2)
 	case "response.created":
@@ -133,8 +149,9 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 		if rootResult.Get("part.type").String() == "output_text" {
 			output = append(output, startCodexTextBlock(params)...)
 		}
-	case "response.output_text.delta":
+	case "response.output_text.delta", "response.refusal.delta":
 		params.HasTextDelta = true
+		params.HasRefusal = params.HasRefusal || typeStr == "response.refusal.delta"
 		output = append(output, finalizeCodexThinkingBlock(params)...)
 		output = append(output, startCodexTextBlock(params)...)
 		template = []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":""}}`)
@@ -157,7 +174,11 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 		output = appendDeferredCodexStreamEvents(output, originalRequestRawJSON, param)
 		output = append(output, finalizeCodexThinkingBlock(params)...)
 		output = append(output, stopCodexTextBlock(params)...)
-		template, _ = sjson.SetBytes(template, "delta.stop_reason", mapCodexStopReasonToClaude(codexStopReason(responseData), params.HasEmittedToolUse))
+		stopReason := codexStopReason(responseData)
+		if stopReason == "" && params.HasRefusal {
+			stopReason = "refusal"
+		}
+		template, _ = sjson.SetBytes(template, "delta.stop_reason", mapCodexStopReasonToClaude(stopReason, params.HasEmittedToolUse))
 		template = setClaudeStopSequence(template, "delta.stop_sequence", responseData)
 		inputTokens, outputTokens, cachedTokens := extractResponsesUsage(responseData.Get("usage"))
 		template, _ = sjson.SetBytes(template, "usage.input_tokens", inputTokens)
@@ -165,9 +186,13 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 		if cachedTokens > 0 {
 			template, _ = sjson.SetBytes(template, "usage.cache_read_input_tokens", cachedTokens)
 		}
+		if gjson.GetBytes(originalRequestRawJSON, "context_management").Exists() {
+			template, _ = sjson.SetRawBytes(template, "context_management.applied_edits", []byte(`[]`))
+		}
 
 		output = translatorcommon.AppendSSEEventBytes(output, "message_delta", template, 2)
 		output = translatorcommon.AppendSSEEventBytes(output, "message_stop", []byte(`{"type":"message_stop"}`), 2)
+		params.Terminal = true
 	case "response.output_item.added":
 		itemResult := rootResult.Get("item")
 		itemType := itemResult.Get("type").String()
@@ -199,23 +224,28 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 		itemType := itemResult.Get("type").String()
 		switch itemType {
 		case "message":
-			if params.HasTextDelta {
-				return [][]byte{output}
-			}
 			contentResult := itemResult.Get("content")
 			if !contentResult.Exists() || !contentResult.IsArray() {
 				return [][]byte{output}
 			}
 			var textBuilder strings.Builder
 			contentResult.ForEach(func(_, part gjson.Result) bool {
-				if part.Get("type").String() != "output_text" {
-					return true
-				}
-				if txt := part.Get("text").String(); txt != "" {
-					textBuilder.WriteString(txt)
+				switch part.Get("type").String() {
+				case "output_text":
+					if txt := part.Get("text").String(); txt != "" {
+						textBuilder.WriteString(txt)
+					}
+				case "refusal":
+					params.HasRefusal = true
+					if txt := part.Get("refusal").String(); txt != "" {
+						textBuilder.WriteString(txt)
+					}
 				}
 				return true
 			})
+			if params.HasTextDelta {
+				return [][]byte{output}
+			}
 			text := textBuilder.String()
 			if text == "" {
 				return [][]byte{output}
@@ -281,7 +311,7 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 
 func shouldDeferCodexStreamEvent(typeStr string, rootResult gjson.Result) bool {
 	switch typeStr {
-	case "error", "keepalive", "response.completed", "response.incomplete", "response.function_call_arguments.delta", "response.function_call_arguments.done":
+	case "error", "response.failed", "keepalive", "response.completed", "response.incomplete", "response.function_call_arguments.delta", "response.function_call_arguments.done":
 		return false
 	case "response.output_item.added", "response.output_item.done":
 		return rootResult.Get("item.type").String() != "function_call"
@@ -311,7 +341,14 @@ func appendDeferredCodexStreamEvents(output []byte, originalRequestRawJSON []byt
 }
 
 func codexStreamErrorToClaudeError(rootResult gjson.Result) []byte {
+	return translatorcommon.AppendSSEEventBytes(nil, "error", codexErrorToClaudeError(rootResult), 2)
+}
+
+func codexErrorToClaudeError(rootResult gjson.Result) []byte {
 	errorResult := rootResult.Get("error")
+	if !errorResult.Exists() || !errorResult.IsObject() {
+		errorResult = rootResult.Get("response.error")
+	}
 	errType := strings.TrimSpace(errorResult.Get("type").String())
 	if errType == "" {
 		errType = strings.TrimSpace(rootResult.Get("error_type").String())
@@ -339,6 +376,12 @@ func codexStreamErrorToClaudeError(rootResult gjson.Result) []byte {
 	out := []byte(`{"type":"error","error":{"type":"api_error","message":""}}`)
 	out, _ = sjson.SetBytes(out, "error.type", errType)
 	out, _ = sjson.SetBytes(out, "error.message", message)
+	return out
+}
+
+func codexProtocolError(message string) []byte {
+	out := []byte(`{"type":"error","error":{"type":"api_error","message":""}}`)
+	out, _ = sjson.SetBytes(out, "error.message", message)
 	return translatorcommon.AppendSSEEventBytes(nil, "error", out, 2)
 }
 
@@ -351,6 +394,9 @@ func ConvertCodexResponseToClaudeNonStream(_ context.Context, _ string, original
 
 	rootResult := gjson.ParseBytes(rawJSON)
 	typeStr := rootResult.Get("type").String()
+	if typeStr == "response.failed" || typeStr == "error" {
+		return codexErrorToClaudeError(rootResult)
+	}
 	if typeStr != "response.completed" && typeStr != "response.incomplete" {
 		return []byte{}
 	}
@@ -371,6 +417,7 @@ func ConvertCodexResponseToClaudeNonStream(_ context.Context, _ string, original
 	}
 
 	hasToolCall := false
+	hasRefusal := false
 	webSearchSeen := make(map[string]struct{})
 	var contentBlocks [][]byte
 
@@ -422,13 +469,18 @@ func ConvertCodexResponseToClaudeNonStream(_ context.Context, _ string, original
 				if content := item.Get("content"); content.Exists() {
 					if content.IsArray() {
 						content.ForEach(func(_, part gjson.Result) bool {
-							if part.Get("type").String() == "output_text" {
-								text := part.Get("text").String()
-								if text != "" {
-									block := []byte(`{"type":"text","text":""}`)
-									block, _ = sjson.SetBytes(block, "text", text)
-									contentBlocks = append(contentBlocks, block)
-								}
+							text := ""
+							switch part.Get("type").String() {
+							case "output_text":
+								text = part.Get("text").String()
+							case "refusal":
+								hasRefusal = true
+								text = part.Get("refusal").String()
+							}
+							if text != "" {
+								block := []byte(`{"type":"text","text":""}`)
+								block, _ = sjson.SetBytes(block, "text", text)
+								contentBlocks = append(contentBlocks, block)
 							}
 							return true
 						})
@@ -471,8 +523,15 @@ func ConvertCodexResponseToClaudeNonStream(_ context.Context, _ string, original
 		out = translatorcommon.SetRawArrayItems(out, "content", contentBlocks)
 	}
 
-	out, _ = sjson.SetBytes(out, "stop_reason", mapCodexStopReasonToClaude(codexStopReason(responseData), hasToolCall))
+	stopReason := codexStopReason(responseData)
+	if stopReason == "" && hasRefusal {
+		stopReason = "refusal"
+	}
+	out, _ = sjson.SetBytes(out, "stop_reason", mapCodexStopReasonToClaude(stopReason, hasToolCall))
 	out = setClaudeStopSequence(out, "stop_sequence", responseData)
+	if gjson.GetBytes(originalRequestRawJSON, "context_management").Exists() {
+		out, _ = sjson.SetRawBytes(out, "context_management.applied_edits", []byte(`[]`))
+	}
 
 	return out
 }
@@ -775,6 +834,20 @@ func appendCodexFunctionCallsFromTerminal(output []byte, params *ConvertCodexRes
 	output = appendCodexFunctionCallQueue(output, params, originalRequestRawJSON)
 
 	clearCodexFunctionCalls(params)
+	return output
+}
+
+func closeOpenCodexFunctionCall(params *ConvertCodexResponseToClaudeParams) []byte {
+	if params == nil {
+		return nil
+	}
+	var output []byte
+	if call := params.ActiveFunctionCall; call != nil && call.Started && !call.Closed {
+		output = appendCodexFunctionCallStop(output, call.BlockIndex)
+		call.Closed = true
+	}
+	clearCodexFunctionCalls(params)
+	params.DeferredStreamEvents = nil
 	return output
 }
 

--- a/internal/translator/codex/claude/codex_claude_response.go
+++ b/internal/translator/codex/claude/codex_claude_response.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"strings"
 
+	claudeoutput "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/claude/output"
 	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
@@ -118,13 +119,13 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 		output = append(output, codexStreamErrorToClaudeError(rootResult)...)
 		params.Terminal = true
 	case "keepalive":
-		output = translatorcommon.AppendSSEEventBytes(output, "ping", []byte(`{"type":"ping"}`), 2)
+		output = claudeoutput.AppendEvent(output, "ping", []byte(`{"type":"ping"}`), 2)
 	case "response.created":
 		template = []byte(`{"type":"message_start","message":{"id":"","type":"message","role":"assistant","model":"claude-opus-4-1-20250805","stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0},"content":[],"stop_reason":null}}`)
 		template, _ = sjson.SetBytes(template, "message.model", rootResult.Get("response.model").String())
 		template, _ = sjson.SetBytes(template, "message.id", rootResult.Get("response.id").String())
 
-		output = translatorcommon.AppendSSEEventBytes(output, "message_start", template, 2)
+		output = claudeoutput.AppendEvent(output, "message_start", template, 2)
 	case "response.reasoning_summary_part.added":
 		output = append(output, stopCodexTextBlock(params)...)
 		// Codex splits a single reasoning item into several summary parts, but only
@@ -158,7 +159,7 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 		template, _ = sjson.SetBytes(template, "index", params.BlockIndex)
 		template, _ = sjson.SetBytes(template, "delta.text", rootResult.Get("delta").String())
 
-		output = translatorcommon.AppendSSEEventBytes(output, "content_block_delta", template, 2)
+		output = claudeoutput.AppendEvent(output, "content_block_delta", template, 2)
 	case "response.content_part.done":
 		if rootResult.Get("part.type").String() == "output_text" {
 			output = append(output, stopCodexTextBlock(params)...)
@@ -190,8 +191,8 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 			template, _ = sjson.SetRawBytes(template, "context_management.applied_edits", []byte(`[]`))
 		}
 
-		output = translatorcommon.AppendSSEEventBytes(output, "message_delta", template, 2)
-		output = translatorcommon.AppendSSEEventBytes(output, "message_stop", []byte(`{"type":"message_stop"}`), 2)
+		output = claudeoutput.AppendEvent(output, "message_delta", template, 2)
+		output = claudeoutput.AppendEvent(output, "message_stop", []byte(`{"type":"message_stop"}`), 2)
 		params.Terminal = true
 	case "response.output_item.added":
 		itemResult := rootResult.Get("item")
@@ -257,7 +258,7 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 			template = []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":""}}`)
 			template, _ = sjson.SetBytes(template, "index", params.BlockIndex)
 			template, _ = sjson.SetBytes(template, "delta.text", text)
-			output = translatorcommon.AppendSSEEventBytes(output, "content_block_delta", template, 2)
+			output = claudeoutput.AppendEvent(output, "content_block_delta", template, 2)
 
 			output = append(output, stopCodexTextBlock(params)...)
 			params.HasTextDelta = true
@@ -341,7 +342,7 @@ func appendDeferredCodexStreamEvents(output []byte, originalRequestRawJSON []byt
 }
 
 func codexStreamErrorToClaudeError(rootResult gjson.Result) []byte {
-	return translatorcommon.AppendSSEEventBytes(nil, "error", codexErrorToClaudeError(rootResult), 2)
+	return claudeoutput.AppendEvent(nil, "error", codexErrorToClaudeError(rootResult), 2)
 }
 
 func codexErrorToClaudeError(rootResult gjson.Result) []byte {
@@ -382,7 +383,7 @@ func codexErrorToClaudeError(rootResult gjson.Result) []byte {
 func codexProtocolError(message string) []byte {
 	out := []byte(`{"type":"error","error":{"type":"api_error","message":""}}`)
 	out, _ = sjson.SetBytes(out, "error.message", message)
-	return translatorcommon.AppendSSEEventBytes(nil, "error", out, 2)
+	return claudeoutput.AppendEvent(nil, "error", out, 2)
 }
 
 // ConvertCodexResponseToClaudeNonStream converts a non-streaming Codex response to a non-streaming Claude Code response.
@@ -703,20 +704,20 @@ func appendCodexFunctionCallStart(output []byte, originalRequestRawJSON []byte, 
 	template, _ = sjson.SetBytes(template, "index", blockIndex)
 	template, _ = sjson.SetBytes(template, "content_block.id", shortenCodexCallIDIfNeeded(util.SanitizeClaudeToolID(callID)))
 	template, _ = sjson.SetBytes(template, "content_block.name", resolveCodexClaudeToolUseName(originalRequestRawJSON, name))
-	return translatorcommon.AppendSSEEventBytes(output, "content_block_start", template, 2)
+	return claudeoutput.AppendEvent(output, "content_block_start", template, 2)
 }
 
 func appendCodexFunctionCallArgumentDelta(output []byte, partialJSON string, blockIndex int) []byte {
 	template := []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`)
 	template, _ = sjson.SetBytes(template, "index", blockIndex)
 	template, _ = sjson.SetBytes(template, "delta.partial_json", partialJSON)
-	return translatorcommon.AppendSSEEventBytes(output, "content_block_delta", template, 2)
+	return claudeoutput.AppendEvent(output, "content_block_delta", template, 2)
 }
 
 func appendCodexFunctionCallStop(output []byte, blockIndex int) []byte {
 	template := []byte(`{"type":"content_block_stop","index":0}`)
 	template, _ = sjson.SetBytes(template, "index", blockIndex)
-	return translatorcommon.AppendSSEEventBytes(output, "content_block_stop", template, 2)
+	return claudeoutput.AppendEvent(output, "content_block_stop", template, 2)
 }
 
 func appendCodexFunctionCallBufferedArguments(output []byte, params *ConvertCodexResponseToClaudeParams, call *codexFunctionCallStream) []byte {
@@ -926,7 +927,7 @@ func startCodexTextBlock(params *ConvertCodexResponseToClaudeParams) []byte {
 	template, _ = sjson.SetBytes(template, "index", params.BlockIndex)
 	params.TextBlockOpen = true
 
-	return translatorcommon.AppendSSEEventBytes(nil, "content_block_start", template, 2)
+	return claudeoutput.AppendEvent(nil, "content_block_start", template, 2)
 }
 
 func stopCodexTextBlock(params *ConvertCodexResponseToClaudeParams) []byte {
@@ -939,7 +940,7 @@ func stopCodexTextBlock(params *ConvertCodexResponseToClaudeParams) []byte {
 	params.TextBlockOpen = false
 	params.BlockIndex++
 
-	return translatorcommon.AppendSSEEventBytes(nil, "content_block_stop", template, 2)
+	return claudeoutput.AppendEvent(nil, "content_block_stop", template, 2)
 }
 
 func startCodexThinkingBlock(params *ConvertCodexResponseToClaudeParams) []byte {
@@ -951,7 +952,7 @@ func startCodexThinkingBlock(params *ConvertCodexResponseToClaudeParams) []byte 
 	template, _ = sjson.SetBytes(template, "index", params.BlockIndex)
 	params.ThinkingBlockOpen = true
 
-	return translatorcommon.AppendSSEEventBytes(nil, "content_block_start", template, 2)
+	return claudeoutput.AppendEvent(nil, "content_block_start", template, 2)
 }
 
 // appendCodexThinkingDelta emits a thinking_delta for the currently open thinking block.
@@ -964,7 +965,7 @@ func appendCodexThinkingDelta(params *ConvertCodexResponseToClaudeParams, text s
 	template, _ = sjson.SetBytes(template, "index", params.BlockIndex)
 	template, _ = sjson.SetBytes(template, "delta.thinking", text)
 
-	return translatorcommon.AppendSSEEventBytes(nil, "content_block_delta", template, 2)
+	return claudeoutput.AppendEvent(nil, "content_block_delta", template, 2)
 }
 
 func finalizeCodexSignatureOnlyThinkingBlock(params *ConvertCodexResponseToClaudeParams) []byte {
@@ -987,12 +988,12 @@ func finalizeCodexThinkingBlock(params *ConvertCodexResponseToClaudeParams) []by
 		signatureDelta := []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":""}}`)
 		signatureDelta, _ = sjson.SetBytes(signatureDelta, "index", params.BlockIndex)
 		signatureDelta, _ = sjson.SetBytes(signatureDelta, "delta.signature", params.ThinkingSignature)
-		output = translatorcommon.AppendSSEEventBytes(output, "content_block_delta", signatureDelta, 2)
+		output = claudeoutput.AppendEvent(output, "content_block_delta", signatureDelta, 2)
 	}
 
 	contentBlockStop := []byte(`{"type":"content_block_stop","index":0}`)
 	contentBlockStop, _ = sjson.SetBytes(contentBlockStop, "index", params.BlockIndex)
-	output = translatorcommon.AppendSSEEventBytes(output, "content_block_stop", contentBlockStop, 2)
+	output = claudeoutput.AppendEvent(output, "content_block_stop", contentBlockStop, 2)
 
 	params.BlockIndex++
 	params.ThinkingBlockOpen = false

--- a/internal/translator/codex/claude/codex_claude_response_test.go
+++ b/internal/translator/codex/claude/codex_claude_response_test.go
@@ -150,6 +150,168 @@ func TestConvertCodexResponseToClaude_StreamErrorTypeFallbackMessage(t *testing.
 	}
 }
 
+func TestConvertCodexResponseToClaude_StreamResponseFailedClosesBlocksAndTerminates(t *testing.T) {
+	var param any
+	original := []byte(`{"messages":[]}`)
+
+	_ = ConvertCodexResponseToClaude(context.Background(), "", original, nil, []byte(`data: {"type":"response.output_text.delta","delta":"before"}`), &param)
+	failed := ConvertCodexResponseToClaude(context.Background(), "", original, nil, []byte(`data: {"type":"response.failed","response":{"error":{"type":"server_error","message":"upstream failed"}}}`), &param)
+	after := ConvertCodexResponseToClaude(context.Background(), "", original, nil, []byte(`data: {"type":"response.output_text.delta","delta":"after"}`), &param)
+
+	if len(failed) != 1 {
+		t.Fatalf("response.failed chunks = %d, want 1", len(failed))
+	}
+	raw := string(failed[0])
+	stopAt := strings.Index(raw, "event: content_block_stop")
+	errorAt := strings.Index(raw, "event: error")
+	if stopAt < 0 || errorAt < 0 || stopAt > errorAt {
+		t.Fatalf("content block was not closed before error: %s", raw)
+	}
+	if !strings.Contains(raw, `"type":"server_error"`) || !strings.Contains(raw, `"message":"upstream failed"`) {
+		t.Fatalf("nested failure was not preserved: %s", raw)
+	}
+	if len(after) != 0 {
+		t.Fatalf("output after terminal failure = %q, want none", after)
+	}
+}
+
+func TestConvertCodexResponseToClaude_StreamResponseFailedClosesToolBlock(t *testing.T) {
+	var param any
+	original := []byte(`{"messages":[]}`)
+
+	_ = ConvertCodexResponseToClaude(context.Background(), "", original, nil, []byte(`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","call_id":"call_1","name":"lookup"}}`), &param)
+	failed := ConvertCodexResponseToClaude(context.Background(), "", original, nil, []byte(`data: {"type":"response.failed","response":{"error":{"type":"server_error","message":"upstream failed"}}}`), &param)
+
+	if len(failed) != 1 {
+		t.Fatalf("response.failed chunks = %d, want 1", len(failed))
+	}
+	raw := string(failed[0])
+	stopAt := strings.Index(raw, "event: content_block_stop")
+	errorAt := strings.Index(raw, "event: error")
+	if stopAt < 0 || errorAt < 0 || stopAt > errorAt {
+		t.Fatalf("tool block was not closed before error: %s", raw)
+	}
+}
+
+func TestConvertCodexResponseToClaude_StreamTerminalIsEmittedOnce(t *testing.T) {
+	var param any
+	original := []byte(`{"messages":[]}`)
+	terminal := []byte(`data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.4","usage":{"input_tokens":5,"output_tokens":1},"output":[]}}`)
+
+	first := ConvertCodexResponseToClaude(context.Background(), "", original, nil, terminal, &param)
+	second := ConvertCodexResponseToClaude(context.Background(), "", original, nil, terminal, &param)
+
+	if len(first) != 1 || strings.Count(string(first[0]), "event: message_stop") != 1 {
+		t.Fatalf("first terminal output = %q, want one message_stop", first)
+	}
+	if len(second) != 0 {
+		t.Fatalf("second terminal output = %q, want none", second)
+	}
+}
+
+func TestConvertCodexResponseToClaude_StreamRefusalUsesRefusalStopReason(t *testing.T) {
+	chunks := [][]byte{
+		[]byte(`data: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5.4"}}`),
+		[]byte(`data: {"type":"response.refusal.delta","delta":"I cannot help with that."}`),
+		[]byte(`data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.4","status":"completed","usage":{"input_tokens":5,"output_tokens":4},"output":[]}}`),
+		[]byte(`data: {"type":"response.output_text.delta","delta":"after"}`),
+	}
+
+	var param any
+	var output bytes.Buffer
+	for _, chunk := range chunks {
+		for _, part := range ConvertCodexResponseToClaude(context.Background(), "", []byte(`{"messages":[]}`), nil, chunk, &param) {
+			output.Write(part)
+		}
+	}
+	raw := output.String()
+	if !strings.Contains(raw, `"text":"I cannot help with that."`) {
+		t.Fatalf("refusal text missing: %s", raw)
+	}
+	if !strings.Contains(raw, `"stop_reason":"refusal"`) {
+		t.Fatalf("refusal stop reason missing: %s", raw)
+	}
+	if strings.Contains(raw, `"text":"after"`) {
+		t.Fatalf("output continued after message_stop: %s", raw)
+	}
+	if got := strings.Count(raw, "event: message_stop"); got != 1 {
+		t.Fatalf("message_stop count = %d, want 1: %s", got, raw)
+	}
+}
+
+func TestConvertCodexResponseToClaude_StreamMalformedEventTerminates(t *testing.T) {
+	var param any
+	outputs := ConvertCodexResponseToClaude(context.Background(), "", []byte(`{"messages":[]}`), nil, []byte(`data: {not-json`), &param)
+	if len(outputs) != 1 || !strings.Contains(string(outputs[0]), "event: error") {
+		t.Fatalf("malformed event output = %q, want protocol error", outputs)
+	}
+	after := ConvertCodexResponseToClaude(context.Background(), "", []byte(`{"messages":[]}`), nil, []byte(`data: {"type":"response.output_text.delta","delta":"after"}`), &param)
+	if len(after) != 0 {
+		t.Fatalf("output after malformed terminal event = %q, want none", after)
+	}
+}
+
+func TestConvertCodexResponseToClaude_StreamValidUnknownMetadataIsIgnored(t *testing.T) {
+	var param any
+	original := []byte(`{"messages":[]}`)
+	chunks := [][]byte{
+		[]byte(`data: null`),
+		[]byte(`data: {"type":"response.metadata","metadata":{"future":true}}`),
+		[]byte(`data: {"type":"response.output_text.delta","delta":"after"}`),
+	}
+
+	var output bytes.Buffer
+	for _, chunk := range chunks {
+		for _, part := range ConvertCodexResponseToClaude(context.Background(), "", original, nil, chunk, &param) {
+			output.Write(part)
+		}
+	}
+	if strings.Contains(output.String(), "event: error") {
+		t.Fatalf("valid unknown metadata produced an error: %s", output.String())
+	}
+	if !strings.Contains(output.String(), `"text":"after"`) {
+		t.Fatalf("stream did not continue after valid unknown metadata: %s", output.String())
+	}
+}
+
+func TestConvertCodexResponseToClaude_ContextManagementAppliedEdits(t *testing.T) {
+	original := []byte(`{"messages":[],"context_management":{"edits":[]}}`)
+	terminal := []byte(`data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.4","stop_reason":"stop","usage":{"input_tokens":5,"output_tokens":1},"output":[]}}`)
+	var param any
+	stream := ConvertCodexResponseToClaude(context.Background(), "", original, nil, terminal, &param)
+	if len(stream) != 1 || !strings.Contains(string(stream[0]), `"context_management":{"applied_edits":[]}`) {
+		t.Fatalf("stream context management missing: %q", stream)
+	}
+
+	nonStream := ConvertCodexResponseToClaudeNonStream(context.Background(), "", original, nil, []byte(`{"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.4","stop_reason":"stop","usage":{"input_tokens":5,"output_tokens":1},"output":[]}}`), nil)
+	if got := gjson.GetBytes(nonStream, "context_management.applied_edits").Raw; got != "[]" {
+		t.Fatalf("non-stream applied_edits = %s, want []; payload=%s", got, nonStream)
+	}
+}
+
+func TestConvertCodexResponseToClaudeNonStream_ResponseFailed(t *testing.T) {
+	out := ConvertCodexResponseToClaudeNonStream(context.Background(), "", []byte(`{"messages":[]}`), nil, []byte(`{"type":"response.failed","response":{"error":{"type":"server_error","message":"upstream failed"}}}`), nil)
+	if got := gjson.GetBytes(out, "type").String(); got != "error" {
+		t.Fatalf("response type = %q, want error; payload=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "error.type").String(); got != "server_error" {
+		t.Fatalf("error type = %q, want server_error; payload=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "error.message").String(); got != "upstream failed" {
+		t.Fatalf("error message = %q; payload=%s", got, out)
+	}
+}
+
+func TestConvertCodexResponseToClaudeNonStream_RefusalContent(t *testing.T) {
+	out := ConvertCodexResponseToClaudeNonStream(context.Background(), "", []byte(`{"messages":[]}`), nil, []byte(`{"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.4","status":"completed","usage":{"input_tokens":5,"output_tokens":4},"output":[{"type":"message","content":[{"type":"refusal","refusal":"I cannot help with that."}]}]}}`), nil)
+	if got := gjson.GetBytes(out, "content.0.text").String(); got != "I cannot help with that." {
+		t.Fatalf("refusal text = %q; payload=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "stop_reason").String(); got != "refusal" {
+		t.Fatalf("stop_reason = %q, want refusal; payload=%s", got, out)
+	}
+}
+
 func TestConvertCodexResponseToClaude_StreamThinkingWithoutReasoningItemStillIncludesSignatureField(t *testing.T) {
 	ctx := context.Background()
 	originalRequest := []byte(`{"messages":[]}`)

--- a/internal/translator/codex/claude/codex_claude_response_test.go
+++ b/internal/translator/codex/claude/codex_claude_response_test.go
@@ -9,6 +9,38 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func TestConvertCodexResponseToClaude_StreamKeepaliveEmitsPingAndContinues(t *testing.T) {
+	const pingFrame = "event: ping\ndata: {\"type\":\"ping\"}\n\n"
+
+	chunks := [][]byte{
+		[]byte(`data: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5.6-sol"}}`),
+		[]byte(`data: {"type":"keepalive","sequence_number":1}`),
+		[]byte(`data: {"type":"response.output_text.delta","output_index":0,"delta":"hello"}`),
+		[]byte(`data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.6-sol","stop_reason":"stop","usage":{"input_tokens":1,"output_tokens":1},"output":[]}}`),
+	}
+
+	var param any
+	var output bytes.Buffer
+	for _, chunk := range chunks {
+		translated := ConvertCodexResponseToClaude(context.Background(), "", []byte(`{"messages":[]}`), nil, chunk, &param)
+		for _, part := range translated {
+			output.Write(part)
+		}
+		if bytes.Contains(chunk, []byte(`"type":"keepalive"`)) {
+			if len(translated) != 1 || string(translated[0]) != pingFrame {
+				t.Fatalf("keepalive output = %q, want %q", translated, pingFrame)
+			}
+		}
+	}
+
+	raw := output.String()
+	for _, want := range []string{pingFrame, `"text":"hello"`, "event: message_stop"} {
+		if !strings.Contains(raw, want) {
+			t.Fatalf("stream output missing %q: %s", want, raw)
+		}
+	}
+}
+
 func TestConvertCodexResponseToClaude_StreamThinkingIncludesSignature(t *testing.T) {
 	ctx := context.Background()
 	originalRequest := []byte(`{"messages":[]}`)

--- a/internal/translator/codex/claude/codex_claude_response_web_search.go
+++ b/internal/translator/codex/claude/codex_claude_response_web_search.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	claudeoutput "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/claude/output"
 	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -33,7 +34,7 @@ func appendCodexWebSearchServerToolUse(output []byte, params *ConvertCodexRespon
 		template := []byte(`{"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"","name":"web_search","input":{}}}`)
 		template, _ = sjson.SetBytes(template, "index", params.BlockIndex)
 		template, _ = sjson.SetBytes(template, "content_block.id", toolUseID)
-		output = translatorcommon.AppendSSEEventBytes(output, "content_block_start", template, 2)
+		output = claudeoutput.AppendEvent(output, "content_block_start", template, 2)
 	}
 
 	if query != "" {
@@ -41,13 +42,13 @@ func appendCodexWebSearchServerToolUse(output []byte, params *ConvertCodexRespon
 		delta := []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`)
 		delta, _ = sjson.SetBytes(delta, "index", params.BlockIndex)
 		delta, _ = sjson.SetBytes(delta, "delta.partial_json", string(partialJSON))
-		output = translatorcommon.AppendSSEEventBytes(output, "content_block_delta", delta, 2)
+		output = claudeoutput.AppendEvent(output, "content_block_delta", delta, 2)
 	}
 
 	if !alreadyStarted {
 		stop := []byte(`{"type":"content_block_stop","index":0}`)
 		stop, _ = sjson.SetBytes(stop, "index", params.BlockIndex)
-		output = translatorcommon.AppendSSEEventBytes(output, "content_block_stop", stop, 2)
+		output = claudeoutput.AppendEvent(output, "content_block_stop", stop, 2)
 		params.WebSearchToolUseIDs[toolUseID] = struct{}{}
 		params.BlockIndex++
 	}
@@ -76,11 +77,11 @@ func appendCodexWebSearchToolResult(output []byte, params *ConvertCodexResponseT
 	if content := codexWebSearchResultContent(root, item); len(content) > 0 {
 		template, _ = sjson.SetRawBytes(template, "content_block.content", content)
 	}
-	output = translatorcommon.AppendSSEEventBytes(output, "content_block_start", template, 2)
+	output = claudeoutput.AppendEvent(output, "content_block_start", template, 2)
 
 	stop := []byte(`{"type":"content_block_stop","index":0}`)
 	stop, _ = sjson.SetBytes(stop, "index", params.BlockIndex)
-	output = translatorcommon.AppendSSEEventBytes(output, "content_block_stop", stop, 2)
+	output = claudeoutput.AppendEvent(output, "content_block_stop", stop, 2)
 	params.WebSearchToolResultIDs[toolUseID] = struct{}{}
 	params.BlockIndex++
 	if toolUseID == params.LastWebSearchToolUseID {

--- a/internal/translator/codex/claude/codex_claude_structured_output_test.go
+++ b/internal/translator/codex/claude/codex_claude_structured_output_test.go
@@ -1,0 +1,24 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertClaudeRequestToCodexPreservesStructuredOutput(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"user","content":"Return JSON"}],"output_config":{"format":{"type":"json_schema","schema":{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}}}}`)
+	out := ConvertClaudeRequestToCodex("gpt-5.4", payload, false)
+	if got := gjson.GetBytes(out, "text.format.type").String(); got != "json_schema" {
+		t.Fatalf("text.format.type = %q, want json_schema; payload=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "text.format.name").String(); got == "" {
+		t.Fatalf("text.format.name is empty; payload=%s", out)
+	}
+	if !gjson.GetBytes(out, "text.format.strict").Bool() {
+		t.Fatalf("text.format.strict is false; payload=%s", out)
+	}
+	if got := gjson.GetBytes(out, "text.format.schema.required.0").String(); got != "answer" {
+		t.Fatalf("structured output schema was not preserved; payload=%s", out)
+	}
+}

--- a/internal/translator/codex/claude/codex_claude_validation.go
+++ b/internal/translator/codex/claude/codex_claude_validation.go
@@ -1,0 +1,422 @@
+package claude
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/tidwall/gjson"
+)
+
+type claudeCodexValidationState struct {
+	thinkingTurns int
+	toolNames     map[string]string
+	toolResults   []string
+}
+
+// ValidateClaudeRequestForCodex rejects request features that the Codex
+// translation would otherwise silently discard.
+func ValidateClaudeRequestForCodex(inputRawJSON []byte) error {
+	if !gjson.ValidBytes(inputRawJSON) {
+		return fmt.Errorf("request must be valid JSON")
+	}
+	root := gjson.ParseBytes(inputRawJSON)
+	if !root.IsObject() {
+		return fmt.Errorf("request must be a JSON object")
+	}
+	if err := validateClaudeCodexControls(root); err != nil {
+		return err
+	}
+	state, err := validateClaudeCodexMessages(root.Get("messages"))
+	if err != nil {
+		return err
+	}
+	return validateClaudeCodexContextManagement(root.Get("context_management"), state)
+}
+
+func validateClaudeCodexControls(root gjson.Result) error {
+	if stopSequences := root.Get("stop_sequences"); stopSequences.Exists() && stopSequences.Type != gjson.Null {
+		if !stopSequences.IsArray() {
+			return fmt.Errorf("stop_sequences must be an array")
+		}
+		if len(stopSequences.Array()) > 0 {
+			return fmt.Errorf("stop_sequences are not supported by the Codex Responses upstream")
+		}
+	}
+	if root.Get("top_k").Exists() {
+		return fmt.Errorf("top_k is not supported by the Codex Responses upstream")
+	}
+	if outputConfig := root.Get("output_config"); outputConfig.Exists() && outputConfig.Type != gjson.Null {
+		if !outputConfig.IsObject() {
+			return fmt.Errorf("output_config must be an object")
+		}
+		if format := outputConfig.Get("format"); format.Exists() && format.Type != gjson.Null {
+			if !format.IsObject() || format.Get("type").String() != "json_schema" || !format.Get("schema").IsObject() {
+				return fmt.Errorf("output_config.format must be a json_schema object with an object schema")
+			}
+			if field := firstUnsupportedClaudeCodexField(format, "type", "schema"); field != "" {
+				return fmt.Errorf("unsupported output_config.format field: %s", boundedClaudeCodexLabel(field))
+			}
+		}
+	}
+	return nil
+}
+
+func validateClaudeCodexMessages(messages gjson.Result) (claudeCodexValidationState, error) {
+	state := claudeCodexValidationState{toolNames: make(map[string]string)}
+	if !messages.IsArray() || len(messages.Array()) == 0 {
+		return state, fmt.Errorf("messages must be a non-empty array")
+	}
+	for _, message := range messages.Array() {
+		if !message.IsObject() {
+			return state, fmt.Errorf("each message must be an object")
+		}
+		role := message.Get("role").String()
+		if role != "user" && role != "assistant" && role != "system" {
+			return state, fmt.Errorf("message role must be user, assistant, or system")
+		}
+		if role == "system" {
+			continue
+		}
+		content := message.Get("content")
+		if content.Type == gjson.String {
+			continue
+		}
+		if !content.IsArray() || len(content.Array()) == 0 {
+			return state, fmt.Errorf("message content must be text or a non-empty array")
+		}
+		turnHasThinking := false
+		for _, block := range content.Array() {
+			if !block.IsObject() {
+				return state, fmt.Errorf("message content blocks must be objects")
+			}
+			blockType := block.Get("type").String()
+			switch blockType {
+			case "text":
+				if block.Get("text").Type != gjson.String {
+					return state, fmt.Errorf("text block text must be a string")
+				}
+			case "image":
+				if role != "user" {
+					return state, fmt.Errorf("image blocks require a user message")
+				}
+				if err := validateClaudeCodexBase64Source(block.Get("source"), "image", false); err != nil {
+					return state, err
+				}
+			case "document":
+				if role != "user" {
+					return state, fmt.Errorf("document blocks require a user message")
+				}
+				if err := validateClaudeCodexBase64Source(block.Get("source"), "document", true); err != nil {
+					return state, err
+				}
+			case "thinking":
+				if role != "assistant" {
+					return state, fmt.Errorf("thinking blocks require an assistant message")
+				}
+				turnHasThinking = true
+			case "tool_use":
+				if role != "assistant" {
+					return state, fmt.Errorf("tool_use blocks require an assistant message")
+				}
+				id, err := requiredClaudeCodexString(block.Get("id"), "tool_use id")
+				if err != nil {
+					return state, err
+				}
+				name, err := requiredClaudeCodexString(block.Get("name"), "tool_use name")
+				if err != nil {
+					return state, err
+				}
+				if input := block.Get("input"); !input.IsObject() {
+					return state, fmt.Errorf("tool_use input must be an object")
+				}
+				state.toolNames[id] = name
+			case "tool_result":
+				if role != "user" {
+					return state, fmt.Errorf("tool_result blocks require a user message")
+				}
+				id, err := requiredClaudeCodexString(block.Get("tool_use_id"), "tool_result tool_use_id")
+				if err != nil {
+					return state, err
+				}
+				if err := validateClaudeCodexToolResult(block.Get("content")); err != nil {
+					return state, err
+				}
+				state.toolResults = append(state.toolResults, id)
+			default:
+				return state, fmt.Errorf("unsupported Claude content block: %s", boundedClaudeCodexLabel(blockType))
+			}
+		}
+		if turnHasThinking {
+			state.thinkingTurns++
+		}
+	}
+	return state, nil
+}
+
+func validateClaudeCodexBase64Source(source gjson.Result, label string, requirePDF bool) error {
+	if !source.IsObject() {
+		return fmt.Errorf("%s source must be a base64 object", label)
+	}
+	if sourceType := source.Get("type"); sourceType.Exists() && sourceType.String() != "base64" {
+		return fmt.Errorf("unsupported %s source type: %s", label, boundedClaudeCodexLabel(sourceType.String()))
+	}
+	if requirePDF && source.Get("media_type").String() != "application/pdf" {
+		return fmt.Errorf("document media type must be application/pdf")
+	}
+	data := source.Get("data")
+	if data.Type != gjson.String || data.String() == "" {
+		data = source.Get("base64")
+	}
+	if data.Type != gjson.String || data.String() == "" {
+		return fmt.Errorf("%s data must be a non-empty base64 string", label)
+	}
+	return nil
+}
+
+func validateClaudeCodexToolResult(content gjson.Result) error {
+	if content.Type == gjson.String {
+		return nil
+	}
+	if !content.IsArray() {
+		return fmt.Errorf("tool_result content must be text or an array")
+	}
+	for _, block := range content.Array() {
+		if !block.IsObject() {
+			return fmt.Errorf("tool_result content blocks must be objects")
+		}
+		switch block.Get("type").String() {
+		case "text":
+			if block.Get("text").Type != gjson.String {
+				return fmt.Errorf("tool_result text must be a string")
+			}
+		case "image":
+			if err := validateClaudeCodexBase64Source(block.Get("source"), "tool_result image", false); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported tool_result content block: %s", boundedClaudeCodexLabel(block.Get("type").String()))
+		}
+	}
+	return nil
+}
+
+func validateClaudeCodexContextManagement(value gjson.Result, state claudeCodexValidationState) error {
+	if !value.Exists() || value.Type == gjson.Null {
+		return nil
+	}
+	if !value.IsObject() {
+		return fmt.Errorf("context_management must be an object")
+	}
+	if field := firstUnsupportedClaudeCodexField(value, "edits"); field != "" {
+		return fmt.Errorf("unsupported context_management field: %s", boundedClaudeCodexLabel(field))
+	}
+	edits := value.Get("edits")
+	if !edits.Exists() {
+		return nil
+	}
+	if !edits.IsArray() {
+		return fmt.Errorf("context_management.edits must be an array")
+	}
+	sawNonThinkingEdit := false
+	for _, edit := range edits.Array() {
+		if !edit.IsObject() {
+			return fmt.Errorf("context_management edits must be objects with a type")
+		}
+		editType, err := requiredClaudeCodexString(edit.Get("type"), "context_management edit type")
+		if err != nil {
+			return err
+		}
+		switch editType {
+		case "clear_thinking_20251015":
+			if sawNonThinkingEdit {
+				return fmt.Errorf("clear_thinking_20251015 must precede other context_management edits")
+			}
+			if err := validateNoopClaudeCodexClearThinking(edit, state.thinkingTurns); err != nil {
+				return err
+			}
+		case "clear_tool_uses_20250919":
+			sawNonThinkingEdit = true
+			if err := validateNoopClaudeCodexClearToolUses(edit, state); err != nil {
+				return err
+			}
+		case "compact_20260112":
+			return fmt.Errorf("compact_20260112 has no exact single-request Responses mapping")
+		default:
+			return fmt.Errorf("unsupported context_management edit type: %s", boundedClaudeCodexLabel(editType))
+		}
+	}
+	return nil
+}
+
+func validateNoopClaudeCodexClearThinking(edit gjson.Result, thinkingTurns int) error {
+	if field := firstUnsupportedClaudeCodexField(edit, "type", "keep"); field != "" {
+		return fmt.Errorf("unsupported clear_thinking_20251015 field: %s", boundedClaudeCodexLabel(field))
+	}
+	keep := edit.Get("keep")
+	if !keep.Exists() {
+		if thinkingTurns > 0 {
+			return fmt.Errorf("clear_thinking_20251015 could alter supplied history and has no exact Responses equivalent")
+		}
+		return nil
+	}
+	if keep.Type == gjson.String && keep.String() == "all" {
+		return nil
+	}
+	if !keep.IsObject() {
+		return fmt.Errorf("clear_thinking_20251015.keep must be all or a thinking_turns object")
+	}
+	keepType := keep.Get("type").String()
+	if keepType == "all" {
+		if field := firstUnsupportedClaudeCodexField(keep, "type"); field != "" {
+			return fmt.Errorf("unsupported clear_thinking_20251015.keep field: %s", boundedClaudeCodexLabel(field))
+		}
+		return nil
+	}
+	if keepType != "thinking_turns" {
+		return fmt.Errorf("clear_thinking_20251015.keep must select thinking_turns")
+	}
+	if field := firstUnsupportedClaudeCodexField(keep, "type", "value"); field != "" {
+		return fmt.Errorf("unsupported clear_thinking_20251015.keep field: %s", boundedClaudeCodexLabel(field))
+	}
+	count, err := claudeCodexInteger(keep.Get("value"), "clear_thinking_20251015.keep.value", 1)
+	if err != nil {
+		return err
+	}
+	if int64(thinkingTurns) > count {
+		return fmt.Errorf("clear_thinking_20251015 could alter supplied history and has no exact Responses equivalent")
+	}
+	return nil
+}
+
+func validateNoopClaudeCodexClearToolUses(edit gjson.Result, state claudeCodexValidationState) error {
+	if field := firstUnsupportedClaudeCodexField(edit, "type", "clear_at_least", "clear_tool_inputs", "exclude_tools", "keep", "trigger"); field != "" {
+		return fmt.Errorf("unsupported clear_tool_uses_20250919 field: %s", boundedClaudeCodexLabel(field))
+	}
+	keep := int64(3)
+	if value := edit.Get("clear_at_least"); value.Exists() && value.Type != gjson.Null {
+		if _, err := claudeCodexTypedCount(value, "input_tokens", "clear_tool_uses_20250919.clear_at_least", 1); err != nil {
+			return err
+		}
+	}
+	if trigger := edit.Get("trigger"); trigger.Exists() {
+		triggerType := trigger.Get("type").String()
+		if triggerType != "input_tokens" && triggerType != "tool_uses" {
+			return fmt.Errorf("clear_tool_uses_20250919.trigger must select input_tokens or tool_uses")
+		}
+		if _, err := claudeCodexTypedCount(trigger, triggerType, "clear_tool_uses_20250919.trigger", 1); err != nil {
+			return err
+		}
+	}
+	if keepValue := edit.Get("keep"); keepValue.Exists() {
+		if keepValue.Get("type").String() != "tool_uses" {
+			return fmt.Errorf("clear_tool_uses_20250919.keep must be a tool_uses object")
+		}
+		if field := firstUnsupportedClaudeCodexField(keepValue, "type", "value"); field != "" {
+			return fmt.Errorf("unsupported clear_tool_uses_20250919.keep field: %s", boundedClaudeCodexLabel(field))
+		}
+		value, err := claudeCodexInteger(keepValue.Get("value"), "clear_tool_uses_20250919.keep.value", 0)
+		if err != nil {
+			return err
+		}
+		keep = value
+	}
+	excluded := make(map[string]struct{})
+	if excludeTools := edit.Get("exclude_tools"); excludeTools.Exists() && excludeTools.Type != gjson.Null {
+		values, err := claudeCodexStringList(excludeTools, "clear_tool_uses_20250919.exclude_tools")
+		if err != nil {
+			return err
+		}
+		for _, name := range values {
+			excluded[name] = struct{}{}
+		}
+	}
+	if clearInputs := edit.Get("clear_tool_inputs"); clearInputs.Exists() && clearInputs.Type != gjson.Null && clearInputs.Type != gjson.True && clearInputs.Type != gjson.False {
+		if _, err := claudeCodexStringList(clearInputs, "clear_tool_uses_20250919.clear_tool_inputs"); err != nil {
+			return err
+		}
+	}
+	clearable := int64(0)
+	for _, id := range state.toolResults {
+		if _, skip := excluded[state.toolNames[id]]; !skip {
+			clearable++
+		}
+	}
+	if clearable > keep {
+		return fmt.Errorf("clear_tool_uses_20250919 could alter supplied history and has no exact Responses equivalent")
+	}
+	return nil
+}
+
+func claudeCodexTypedCount(value gjson.Result, wantType, label string, minimum int64) (int64, error) {
+	if !value.IsObject() || value.Get("type").String() != wantType {
+		return 0, fmt.Errorf("%s must have type %s", label, wantType)
+	}
+	if field := firstUnsupportedClaudeCodexField(value, "type", "value"); field != "" {
+		return 0, fmt.Errorf("unsupported %s field: %s", label, boundedClaudeCodexLabel(field))
+	}
+	return claudeCodexInteger(value.Get("value"), label+".value", minimum)
+}
+
+func claudeCodexInteger(value gjson.Result, label string, minimum int64) (int64, error) {
+	if value.Type != gjson.Number {
+		return 0, fmt.Errorf("%s must be an integer of at least %d", label, minimum)
+	}
+	integer, err := strconv.ParseInt(value.Raw, 10, 64)
+	if err != nil || integer < minimum {
+		return 0, fmt.Errorf("%s must be an integer of at least %d", label, minimum)
+	}
+	return integer, nil
+}
+
+func claudeCodexStringList(value gjson.Result, label string) ([]string, error) {
+	if !value.IsArray() {
+		return nil, fmt.Errorf("%s must be an array of non-empty strings", label)
+	}
+	values := make([]string, 0, len(value.Array()))
+	for _, item := range value.Array() {
+		if item.Type != gjson.String || item.String() == "" {
+			return nil, fmt.Errorf("%s must be an array of non-empty strings", label)
+		}
+		values = append(values, item.String())
+	}
+	return values, nil
+}
+
+func requiredClaudeCodexString(value gjson.Result, label string) (string, error) {
+	if value.Type != gjson.String || strings.TrimSpace(value.String()) == "" {
+		return "", fmt.Errorf("%s must be a non-empty string", label)
+	}
+	return value.String(), nil
+}
+
+func firstUnsupportedClaudeCodexField(object gjson.Result, allowed ...string) string {
+	allowedFields := make(map[string]struct{}, len(allowed))
+	for _, field := range allowed {
+		allowedFields[field] = struct{}{}
+	}
+	unsupported := ""
+	object.ForEach(func(key, _ gjson.Result) bool {
+		if _, ok := allowedFields[key.String()]; !ok {
+			unsupported = key.String()
+			return false
+		}
+		return true
+	})
+	return unsupported
+}
+
+func boundedClaudeCodexLabel(value string) string {
+	value = strings.Map(func(character rune) rune {
+		if unicode.IsControl(character) {
+			return ' '
+		}
+		return character
+	}, strings.TrimSpace(value))
+	runes := []rune(value)
+	if len(runes) > 64 {
+		value = string(runes[:64]) + "…"
+	}
+	return strconv.Quote(value)
+}

--- a/internal/translator/codex/claude/codex_claude_validation.go
+++ b/internal/translator/codex/claude/codex_claude_validation.go
@@ -192,11 +192,121 @@ func validateClaudeCodexToolResult(content gjson.Result) error {
 				return fmt.Errorf("tool_result text must be a string")
 			}
 		case "image":
-			if err := validateClaudeCodexBase64Source(block.Get("source"), "tool_result image", false); err != nil {
+			source := block.Get("source")
+			switch source.Get("type").String() {
+			case "base64", "":
+				if err := validateClaudeCodexBase64Source(source, "tool_result image", false); err != nil {
+					return err
+				}
+			case "url":
+				if url := source.Get("url"); url.Type != gjson.String || url.String() == "" {
+					return fmt.Errorf("tool_result image URL must be a non-empty string")
+				}
+			default:
+				return fmt.Errorf("unsupported tool_result image source type: %s", boundedClaudeCodexLabel(source.Get("type").String()))
+			}
+		case "document":
+			if err := validateClaudeCodexToolResultDocument(block); err != nil {
 				return err
+			}
+		case "search_result":
+			if err := validateClaudeCodexSearchResult(block); err != nil {
+				return err
+			}
+		case "tool_reference":
+			if toolName := block.Get("tool_name"); toolName.Type != gjson.String || toolName.String() == "" {
+				return fmt.Errorf("tool_reference tool_name must be a non-empty string")
 			}
 		default:
 			return fmt.Errorf("unsupported tool_result content block: %s", boundedClaudeCodexLabel(block.Get("type").String()))
+		}
+	}
+	return nil
+}
+
+func validateClaudeCodexToolResultDocument(block gjson.Result) error {
+	source := block.Get("source")
+	if !source.IsObject() {
+		return fmt.Errorf("document source must be an object")
+	}
+	switch source.Get("type").String() {
+	case "base64":
+		return validateClaudeCodexBase64Source(source, "document", true)
+	case "text":
+		if source.Get("media_type").String() != "text/plain" {
+			return fmt.Errorf("document text source media type must be text/plain")
+		}
+		if data := source.Get("data"); data.Type != gjson.String || data.String() == "" {
+			return fmt.Errorf("document text source data must be a non-empty string")
+		}
+	case "url":
+		if url := source.Get("url"); url.Type != gjson.String || url.String() == "" {
+			return fmt.Errorf("document source URL must be a non-empty string")
+		}
+	case "content":
+		if err := validateClaudeCodexDocumentContentSource(source.Get("content")); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported document source type: %s", boundedClaudeCodexLabel(source.Get("type").String()))
+	}
+	return nil
+}
+
+func validateClaudeCodexDocumentContentSource(content gjson.Result) error {
+	if content.Type == gjson.String {
+		return nil
+	}
+	if !content.IsArray() {
+		return fmt.Errorf("document content source must be text or an array")
+	}
+	for _, block := range content.Array() {
+		if !block.IsObject() {
+			return fmt.Errorf("document content source blocks must be objects")
+		}
+		switch block.Get("type").String() {
+		case "text":
+			if block.Get("text").Type != gjson.String {
+				return fmt.Errorf("document content source text must be a string")
+			}
+		case "image":
+			source := block.Get("source")
+			switch source.Get("type").String() {
+			case "base64", "":
+				if err := validateClaudeCodexBase64Source(source, "document image", false); err != nil {
+					return err
+				}
+			case "url":
+				if url := source.Get("url"); url.Type != gjson.String || url.String() == "" {
+					return fmt.Errorf("document image source URL must be a non-empty string")
+				}
+			default:
+				return fmt.Errorf("unsupported document image source type: %s", boundedClaudeCodexLabel(source.Get("type").String()))
+			}
+		default:
+			return fmt.Errorf("unsupported document content source block: %s", boundedClaudeCodexLabel(block.Get("type").String()))
+		}
+	}
+	return nil
+}
+
+func validateClaudeCodexSearchResult(block gjson.Result) error {
+	if source := block.Get("source"); source.Type != gjson.String || source.String() == "" {
+		return fmt.Errorf("search_result source must be a non-empty string")
+	}
+	if title := block.Get("title"); title.Type != gjson.String || title.String() == "" {
+		return fmt.Errorf("search_result title must be a non-empty string")
+	}
+	content := block.Get("content")
+	if !content.IsArray() {
+		return fmt.Errorf("search_result content must be an array")
+	}
+	for _, text := range content.Array() {
+		if !text.IsObject() || text.Get("type").String() != "text" {
+			return fmt.Errorf("search_result content blocks must be text objects")
+		}
+		if text.Get("text").Type != gjson.String {
+			return fmt.Errorf("search_result content text must be a string")
 		}
 	}
 	return nil

--- a/internal/translator/codex/claude/codex_claude_validation.go
+++ b/internal/translator/codex/claude/codex_claude_validation.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"unicode"
 
+	claudeinput "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/claude/input"
 	"github.com/tidwall/gjson"
 )
 
@@ -18,13 +19,11 @@ type claudeCodexValidationState struct {
 // ValidateClaudeRequestForCodex rejects request features that the Codex
 // translation would otherwise silently discard.
 func ValidateClaudeRequestForCodex(inputRawJSON []byte) error {
-	if !gjson.ValidBytes(inputRawJSON) {
-		return fmt.Errorf("request must be valid JSON")
+	request := claudeinput.Parse("", inputRawJSON)
+	if err := request.Validate(); err != nil {
+		return err
 	}
-	root := gjson.ParseBytes(inputRawJSON)
-	if !root.IsObject() {
-		return fmt.Errorf("request must be a JSON object")
-	}
+	root := request.Root()
 	if err := validateClaudeCodexControls(root); err != nil {
 		return err
 	}

--- a/internal/translator/codex/claude/codex_claude_validation_test.go
+++ b/internal/translator/codex/claude/codex_claude_validation_test.go
@@ -48,12 +48,8 @@ func TestValidateClaudeRequestForCodexRejectsDroppedContent(t *testing.T) {
 			payload: `{"messages":[{"role":"user","content":[{"type":"image","source":{"type":"url","url":"https://example.test/image.png"}}]}]}`,
 		},
 		{
-			name:    "tool result URL image",
-			payload: `{"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":[{"type":"image","source":{"type":"url","url":"https://example.test/image.png"}}]}]}]}`,
-		},
-		{
-			name:    "tool result document",
-			payload: `{"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":[{"type":"document","source":{"type":"url","url":"https://example.test/document.pdf"}}]}]}]}`,
+			name:    "tool result URL image without URL",
+			payload: `{"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":[{"type":"image","source":{"type":"url"}}]}]}]}`,
 		},
 	}
 

--- a/internal/translator/codex/claude/codex_claude_validation_test.go
+++ b/internal/translator/codex/claude/codex_claude_validation_test.go
@@ -1,0 +1,171 @@
+package claude
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestValidateClaudeRequestForCodexRejectsLossyControls(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name:    "stop sequences",
+			payload: `{"messages":[{"role":"user","content":"hello"}],"stop_sequences":["END"]}`,
+		},
+		{
+			name:    "top k",
+			payload: `{"messages":[{"role":"user","content":"hello"}],"top_k":10}`,
+		},
+		{
+			name:    "unsupported structured output",
+			payload: `{"messages":[{"role":"user","content":"hello"}],"output_config":{"format":{"type":"text"}}}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := ValidateClaudeRequestForCodex([]byte(test.payload)); err == nil {
+				t.Fatal("ValidateClaudeRequestForCodex() error = nil, want rejection")
+			}
+		})
+	}
+}
+
+func TestValidateClaudeRequestForCodexRejectsDroppedContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name:    "unknown message block",
+			payload: `{"messages":[{"role":"user","content":[{"type":"audio","data":"ignored"}]}]}`,
+		},
+		{
+			name:    "top level URL image",
+			payload: `{"messages":[{"role":"user","content":[{"type":"image","source":{"type":"url","url":"https://example.test/image.png"}}]}]}`,
+		},
+		{
+			name:    "tool result URL image",
+			payload: `{"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":[{"type":"image","source":{"type":"url","url":"https://example.test/image.png"}}]}]}]}`,
+		},
+		{
+			name:    "tool result document",
+			payload: `{"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":[{"type":"document","source":{"type":"url","url":"https://example.test/document.pdf"}}]}]}]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := ValidateClaudeRequestForCodex([]byte(test.payload)); err == nil {
+				t.Fatal("ValidateClaudeRequestForCodex() error = nil, want rejection")
+			}
+		})
+	}
+}
+
+func TestValidateClaudeRequestForCodexContextManagementNoOpBoundary(t *testing.T) {
+	tests := []struct {
+		name      string
+		payload   []byte
+		wantError bool
+	}{
+		{
+			name:    "empty edits",
+			payload: []byte(`{"messages":[{"role":"user","content":"hello"}],"context_management":{"edits":[]}}`),
+		},
+		{
+			name:    "clear thinking keeps supplied turn",
+			payload: []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"work","signature":""}]}],"context_management":{"edits":[{"type":"clear_thinking_20251015","keep":{"type":"thinking_turns","value":1}}]}}`),
+		},
+		{
+			name:      "clear thinking would remove supplied turn",
+			payload:   []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"work","signature":""}]}],"context_management":{"edits":[{"type":"clear_thinking_20251015"}]}}`),
+			wantError: true,
+		},
+		{
+			name:      "compaction has no mapping",
+			payload:   []byte(`{"messages":[{"role":"user","content":"hello"}],"context_management":{"edits":[{"type":"compact_20260112"}]}}`),
+			wantError: true,
+		},
+		{
+			name:    "default clear tool policy keeps three results",
+			payload: claudeToolResultHistory(t, 3),
+		},
+		{
+			name:      "default clear tool policy would remove a result",
+			payload:   claudeToolResultHistory(t, 4),
+			wantError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateClaudeRequestForCodex(test.payload)
+			if test.wantError && err == nil {
+				t.Fatal("ValidateClaudeRequestForCodex() error = nil, want rejection")
+			}
+			if !test.wantError && err != nil {
+				t.Fatalf("ValidateClaudeRequestForCodex() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestValidateClaudeRequestForCodexPreservesCompatibilityInputs(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"system","content":[{"type":"text","text":"reminder"}]},{"role":"assistant","content":[{"type":"thinking","thinking":"work","signature":""}]}],"temperature":0.7,"top_p":0.9,"metadata":{"user_id":"test"},"output_config":{"effort":"high"}}`)
+	if err := ValidateClaudeRequestForCodex(payload); err != nil {
+		t.Fatalf("ValidateClaudeRequestForCodex() error = %v, want nil", err)
+	}
+}
+
+func TestValidateClaudeRequestForCodexRejectsMalformedEnvelope(t *testing.T) {
+	for _, payload := range [][]byte{
+		[]byte(`{"messages":`),
+		[]byte(`[]`),
+		[]byte(`{"messages":[]}`),
+	} {
+		if err := ValidateClaudeRequestForCodex(payload); err == nil {
+			t.Fatalf("ValidateClaudeRequestForCodex(%s) error = nil, want rejection", payload)
+		}
+	}
+}
+
+func claudeToolResultHistory(t *testing.T, count int) []byte {
+	t.Helper()
+	messages := make([]map[string]any, 0, count*2)
+	for index := 0; index < count; index++ {
+		id := fmt.Sprintf("call_%d", index)
+		messages = append(messages,
+			map[string]any{
+				"role": "assistant",
+				"content": []map[string]any{{
+					"type":  "tool_use",
+					"id":    id,
+					"name":  "lookup",
+					"input": map[string]any{},
+				}},
+			},
+			map[string]any{
+				"role": "user",
+				"content": []map[string]any{{
+					"type":        "tool_result",
+					"tool_use_id": id,
+					"content":     "ok",
+				}},
+			},
+		)
+	}
+	payload, err := json.Marshal(map[string]any{
+		"messages": messages,
+		"context_management": map[string]any{
+			"edits": []map[string]any{{"type": "clear_tool_uses_20250919"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	return payload
+}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -55,9 +55,6 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.DisableClaudeCloakMode != newCfg.DisableClaudeCloakMode {
 		changes = append(changes, fmt.Sprintf("disable-claude-cloak-mode: %t -> %t", oldCfg.DisableClaudeCloakMode, newCfg.DisableClaudeCloakMode))
 	}
-	if oldCfg.ClaudeCode.DisableCloakingModelList != newCfg.ClaudeCode.DisableCloakingModelList {
-		changes = append(changes, fmt.Sprintf("claude-code.disable-cloaking-model-list: %t -> %t", oldCfg.ClaudeCode.DisableCloakingModelList, newCfg.ClaudeCode.DisableCloakingModelList))
-	}
 	if oldCfg.DisableImageGeneration != newCfg.DisableImageGeneration {
 		changes = append(changes, fmt.Sprintf("disable-image-generation: %v -> %v", oldCfg.DisableImageGeneration, newCfg.DisableImageGeneration))
 	}

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -393,9 +393,6 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 			ForceModelPrefix:           true,
 			NonStreamKeepAliveInterval: 5,
 			DisableImageGeneration:     config.DisableImageGenerationAll,
-			ClaudeCode: sdkconfig.ClaudeCodeConfig{
-				DisableCloakingModelList: true,
-			},
 		},
 	}
 
@@ -407,7 +404,6 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 	expectContains(t, details, "save-cooldown-status: false -> true")
 	expectContains(t, details, "transient-error-cooldown-seconds: 0 -> -1")
 	expectContains(t, details, "disable-image-generation: false -> true")
-	expectContains(t, details, "claude-code.disable-cloaking-model-list: false -> true")
 	expectContains(t, details, "request-log: false -> true")
 	expectContains(t, details, "request-retry: 1 -> 2")
 	expectContains(t, details, "max-retry-credentials: 1 -> 3")

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/router-for-me/CLIProxyAPI/v7/internal/constant"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	claudeoutput "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/claude/output"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -277,9 +278,10 @@ func (h *ClaudeCodeAPIHandler) handleStreamingResponse(c *gin.Context, rawJSON [
 					}
 					return
 				}
-				// Stream closed without data? Send DONE or just headers.
+				// A clean close before a semantic terminal event is a protocol error.
 				setSSEHeaders()
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+				_, _ = c.Writer.Write(claudeIncompleteStreamError())
 				flusher.Flush()
 				cliCancel(nil)
 				return
@@ -296,19 +298,25 @@ func (h *ClaudeCodeAPIHandler) handleStreamingResponse(c *gin.Context, rawJSON [
 			}
 
 			// Continue streaming the rest
-			h.forwardClaudeStream(c, flusher, func(err error) { cliCancel(err) }, dataChan, errChan)
+			h.forwardClaudeStream(c, flusher, func(err error) { cliCancel(err) }, dataChan, errChan, claudeStreamChunkTerminal(chunk))
 			return
 		}
 	}
 }
 
-func (h *ClaudeCodeAPIHandler) forwardClaudeStream(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage) {
+func (h *ClaudeCodeAPIHandler) forwardClaudeStream(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage, terminalSeen bool) {
 	h.ForwardStream(c, flusher, cancel, data, errs, handlers.StreamForwardOptions{
 		WriteChunk: func(chunk []byte) {
 			if len(chunk) == 0 {
 				return
 			}
+			terminalSeen = terminalSeen || claudeStreamChunkTerminal(chunk)
 			_, _ = c.Writer.Write(chunk)
+		},
+		WriteDone: func() {
+			if !terminalSeen {
+				_, _ = c.Writer.Write(claudeIncompleteStreamError())
+			}
 		},
 		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) {
 			if errMsg == nil {
@@ -324,6 +332,14 @@ func (h *ClaudeCodeAPIHandler) forwardClaudeStream(c *gin.Context, flusher http.
 			_, _ = fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", errorBytes)
 		},
 	})
+}
+
+func claudeStreamChunkTerminal(chunk []byte) bool {
+	return claudeoutput.HasTerminalEvent(chunk)
+}
+
+func claudeIncompleteStreamError() []byte {
+	return []byte("event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"Upstream stream ended before response.completed.\"}}\n\n")
 }
 
 type claudeErrorDetail struct {

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -81,8 +81,7 @@ func (h *ClaudeCodeAPIHandler) ClaudeMessages(c *gin.Context) {
 		return
 	}
 
-	// Decode claude-fable-5-dd-<reversed> model IDs back to the real model name for routing.
-	rawJSON = rewriteClaudeDDModelInBody(rawJSON)
+	_, rawJSON = canonicalizeClaudeNamespacedRequest(rawJSON)
 
 	// Check if the client requested a streaming response.
 	streamResult := gjson.GetBytes(rawJSON, "stream")
@@ -113,15 +112,12 @@ func (h *ClaudeCodeAPIHandler) ClaudeCountTokens(c *gin.Context) {
 		return
 	}
 
-	// Decode claude-fable-5-dd-<reversed> model IDs back to the real model name for routing.
-	rawJSON = rewriteClaudeDDModelInBody(rawJSON)
-
 	c.Header("Content-Type", "application/json")
 
 	alt := h.GetAlt(c)
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
 
-	modelName := gjson.GetBytes(rawJSON, "model").String()
+	modelName, rawJSON := canonicalizeClaudeNamespacedRequest(rawJSON)
 
 	resp, upstreamHeaders, errMsg := h.ExecuteCountWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, alt)
 	if errMsg != nil {
@@ -134,19 +130,20 @@ func (h *ClaudeCodeAPIHandler) ClaudeCountTokens(c *gin.Context) {
 	cliCancel()
 }
 
-// rewriteClaudeDDModelInBody decodes model IDs of the form claude-fable-5-dd-<reversed>
-// back into the original model name used for routing and upstream requests.
-func rewriteClaudeDDModelInBody(rawJSON []byte) []byte {
+// canonicalizeClaudeNamespacedRequest removes the public Anthropic namespace
+// from both the routing model and the working request body. Native Claude model
+// IDs and requests without a model are returned unchanged.
+func canonicalizeClaudeNamespacedRequest(rawJSON []byte) (string, []byte) {
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	resolved := claudemodels.ResolveClaudeModelIDPrefix(modelName)
 	if resolved == modelName {
-		return rawJSON
+		return modelName, rawJSON
 	}
 	updated, errSet := sjson.SetBytes(rawJSON, "model", resolved)
 	if errSet != nil {
-		return rawJSON
+		return modelName, rawJSON
 	}
-	return updated
+	return resolved, updated
 }
 
 // ClaudeModels handles the Claude models listing endpoint.
@@ -155,8 +152,7 @@ func rewriteClaudeDDModelInBody(rawJSON []byte) []byte {
 // Parameters:
 //   - c: The Gin context for the request.
 func (h *ClaudeCodeAPIHandler) ClaudeModels(c *gin.Context) {
-	disableCloaking := h.Cfg != nil && h.Cfg.ClaudeCode.DisableCloakingModelList
-	c.JSON(http.StatusOK, claudemodels.BuildResponse(h.Models(), disableCloaking))
+	c.JSON(http.StatusOK, claudemodels.BuildResponse(h.Models()))
 }
 
 // handleNonStreamingResponse handles non-streaming content generation requests for Claude models.

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -257,6 +257,7 @@ func (h *ClaudeCodeAPIHandler) handleStreamingResponse(c *gin.Context, rawJSON [
 				continue
 			}
 			// Upstream failed immediately. Return proper error status and JSON.
+			logClaudeStreamBootstrapDiagnostic(c, cliCtx, "initial_error", modelName, errMsg)
 			h.WriteErrorResponse(c, errMsg)
 			if errMsg != nil {
 				cliCancel(errMsg.Error)
@@ -267,6 +268,7 @@ func (h *ClaudeCodeAPIHandler) handleStreamingResponse(c *gin.Context, rawJSON [
 		case chunk, ok := <-dataChan:
 			if !ok {
 				if errMsg, hasPendingError := handlers.PendingStreamError(errChan); hasPendingError {
+					logClaudeStreamBootstrapDiagnostic(c, cliCtx, "closed_before_first_chunk", modelName, errMsg)
 					h.WriteErrorResponse(c, errMsg)
 					if errMsg != nil {
 						cliCancel(errMsg.Error)

--- a/sdk/api/handlers/claude/code_handlers_diagnostics.go
+++ b/sdk/api/handlers/claude/code_handlers_diagnostics.go
@@ -1,0 +1,92 @@
+package claude
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"unicode"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+const claudeStreamBootstrapDiagnosticValueLimit = 512
+
+func logClaudeStreamBootstrapDiagnostic(c *gin.Context, ctx context.Context, phase, model string, msg *interfaces.ErrorMessage) {
+	fields, ok := claudeStreamBootstrapDiagnosticFields(c, ctx, phase, model, msg)
+	if !ok {
+		return
+	}
+	log.WithFields(fields).Warn("claude stream bootstrap 503")
+}
+
+func claudeStreamBootstrapDiagnosticFields(c *gin.Context, ctx context.Context, phase, model string, msg *interfaces.ErrorMessage) (log.Fields, bool) {
+	if msg == nil || msg.StatusCode != http.StatusServiceUnavailable {
+		return nil, false
+	}
+
+	authCode := ""
+	var authErr *coreauth.Error
+	if errors.As(msg.Error, &authErr) && authErr != nil {
+		authCode = authErr.Code
+	}
+
+	upstreamHeaders := internallogging.GetResponseHeaders(ctx)
+	safeHeaders := coreauth.SafeResponseHeaders(msg.Error)
+	fields := log.Fields{
+		"request_id":             sanitizeClaudeBootstrapDiagnosticValue(internallogging.GetGinRequestID(c)),
+		"phase":                  sanitizeClaudeBootstrapDiagnosticValue(phase),
+		"model":                  sanitizeClaudeBootstrapDiagnosticValue(model),
+		"status":                 msg.StatusCode,
+		"auth_selected":          internallogging.GetGinCPATraceID(c) != "",
+		"upstream_response_seen": len(upstreamHeaders) > 0 || msg.DirectResponse || claudeBootstrapErrorHasHeaders(msg.Error),
+		"auth_code":              sanitizeClaudeBootstrapDiagnosticValue(authCode),
+		"retry_after": sanitizeClaudeBootstrapDiagnosticValue(firstClaudeBootstrapDiagnosticHeader(
+			[]http.Header{upstreamHeaders, msg.Addon, msg.Headers, safeHeaders},
+			"Retry-After",
+		)),
+		"upstream_request_id": sanitizeClaudeBootstrapDiagnosticValue(firstClaudeBootstrapDiagnosticHeader(
+			[]http.Header{upstreamHeaders, msg.Addon, msg.Headers},
+			"X-Upstream-Request-Id", "X-Request-Id", "Openai-Request-Id", "Request-Id", "Cf-Ray",
+		)),
+	}
+	return fields, true
+}
+
+func claudeBootstrapErrorHasHeaders(err error) bool {
+	if err == nil {
+		return false
+	}
+	var headerErr interface{ Headers() http.Header }
+	return errors.As(err, &headerErr) && headerErr != nil
+}
+
+func firstClaudeBootstrapDiagnosticHeader(headers []http.Header, names ...string) string {
+	for _, header := range headers {
+		for _, name := range names {
+			if value := strings.TrimSpace(header.Get(name)); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func sanitizeClaudeBootstrapDiagnosticValue(value string) string {
+	value = strings.Map(func(character rune) rune {
+		if unicode.IsControl(character) {
+			return ' '
+		}
+		return character
+	}, strings.TrimSpace(value))
+	value = strings.Join(strings.Fields(value), " ")
+	runes := []rune(value)
+	if len(runes) > claudeStreamBootstrapDiagnosticValueLimit {
+		value = string(runes[:claudeStreamBootstrapDiagnosticValueLimit]) + "…"
+	}
+	return value
+}

--- a/sdk/api/handlers/claude/code_handlers_diagnostics_test.go
+++ b/sdk/api/handlers/claude/code_handlers_diagnostics_test.go
@@ -1,0 +1,116 @@
+package claude
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+type claudeBootstrapHeaderError struct {
+	message string
+	headers http.Header
+}
+
+func (e *claudeBootstrapHeaderError) Error() string        { return e.message }
+func (e *claudeBootstrapHeaderError) Headers() http.Header { return e.headers.Clone() }
+
+func TestClaudeStreamBootstrapDiagnosticClassifiesLocalAuth503(t *testing.T) {
+	fields, ok := claudeStreamBootstrapDiagnosticFields(nil, context.Background(), "initial_error", "gpt-5.4", &interfaces.ErrorMessage{
+		StatusCode: http.StatusServiceUnavailable,
+		Error: &coreauth.Error{
+			Code:       "auth_unavailable",
+			Message:    "no auth available",
+			HTTPStatus: http.StatusServiceUnavailable,
+		},
+	})
+	if !ok {
+		t.Fatal("expected diagnostic fields for HTTP 503")
+	}
+	if got := fields["phase"]; got != "initial_error" {
+		t.Fatalf("phase = %#v, want initial_error", got)
+	}
+	if got := fields["auth_selected"]; got != false {
+		t.Fatalf("auth_selected = %#v, want false", got)
+	}
+	if got := fields["upstream_response_seen"]; got != false {
+		t.Fatalf("upstream_response_seen = %#v, want false", got)
+	}
+	if got := fields["auth_code"]; got != "auth_unavailable" {
+		t.Fatalf("auth_code = %#v, want auth_unavailable", got)
+	}
+}
+
+func TestClaudeStreamBootstrapDiagnosticClassifiesSanitizedUpstream503(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	internallogging.SetGinRequestID(c, "request\nid")
+	internallogging.SetGinCPATraceID(c, "credential-secret-name")
+
+	longRequestID := "req\n" + strings.Repeat("x", 600)
+	ctx := internallogging.WithResponseHeadersHolder(context.Background())
+	internallogging.SetResponseHeaders(ctx, http.Header{
+		"Retry-After":           []string{"2\r\nseconds"},
+		"X-Upstream-Request-Id": []string{longRequestID},
+		"Authorization":         []string{"Bearer do-not-log"},
+		"Set-Cookie":            []string{"session=do-not-log"},
+	})
+	fields, ok := claudeStreamBootstrapDiagnosticFields(c, ctx, "closed_before_first_chunk", "gpt-5.4\nforged", &interfaces.ErrorMessage{
+		StatusCode: http.StatusServiceUnavailable,
+		Error: &claudeBootstrapHeaderError{
+			message: "token=do-not-log",
+			headers: http.Header{"X-Internal-Secret": []string{"do-not-log"}},
+		},
+	})
+	if !ok {
+		t.Fatal("expected diagnostic fields for HTTP 503")
+	}
+	if got := fields["phase"]; got != "closed_before_first_chunk" {
+		t.Fatalf("phase = %#v, want closed_before_first_chunk", got)
+	}
+	if got := fields["auth_selected"]; got != true {
+		t.Fatalf("auth_selected = %#v, want true", got)
+	}
+	if got := fields["upstream_response_seen"]; got != true {
+		t.Fatalf("upstream_response_seen = %#v, want true", got)
+	}
+	if got := fields["retry_after"]; got != "2 seconds" {
+		t.Fatalf("retry_after = %#v, want sanitized value", got)
+	}
+	upstreamRequestID, _ := fields["upstream_request_id"].(string)
+	if strings.ContainsAny(upstreamRequestID, "\r\n") || len([]rune(upstreamRequestID)) > claudeStreamBootstrapDiagnosticValueLimit+1 {
+		t.Fatalf("upstream_request_id was not bounded: %q", upstreamRequestID)
+	}
+	formatted := fmt.Sprint(fields)
+	for _, secret := range []string{"credential-secret-name", "Bearer do-not-log", "session=do-not-log", "token=do-not-log", "X-Internal-Secret"} {
+		if strings.Contains(formatted, secret) {
+			t.Fatalf("diagnostic fields leaked %q: %s", secret, formatted)
+		}
+	}
+}
+
+func TestClaudeStreamBootstrapDiagnosticRecognizesHeaderBearingUpstreamError(t *testing.T) {
+	fields, ok := claudeStreamBootstrapDiagnosticFields(nil, context.Background(), "initial_error", "gpt-5.4", &interfaces.ErrorMessage{
+		StatusCode: http.StatusServiceUnavailable,
+		Error:      &claudeBootstrapHeaderError{message: "unavailable"},
+	})
+	if !ok || fields["upstream_response_seen"] != true {
+		t.Fatalf("fields = %#v, ok = %v; want upstream response", fields, ok)
+	}
+}
+
+func TestClaudeStreamBootstrapDiagnosticIgnoresNon503(t *testing.T) {
+	fields, ok := claudeStreamBootstrapDiagnosticFields(nil, context.Background(), "initial_error", "gpt-5.4", &interfaces.ErrorMessage{
+		StatusCode: http.StatusBadGateway,
+	})
+	if ok || fields != nil {
+		t.Fatalf("fields = %#v, ok = %v; want no diagnostic", fields, ok)
+	}
+}

--- a/sdk/api/handlers/claude/code_handlers_model_test.go
+++ b/sdk/api/handlers/claude/code_handlers_model_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
-	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 	"github.com/tidwall/gjson"
 )
 
 func TestClaudeModelsResponseUsesConfiguredDisplayName(t *testing.T) {
 	const clientID = "claude-display-name-catalog-test"
 	const modelID = "claude-display-name-catalog-test"
+	const responseID = "claude/" + modelID
 	registryRef := registry.GetGlobalRegistry()
 	registryRef.RegisterClient(clientID, "claude", []*registry.ModelInfo{{
 		ID: modelID, Object: "model", OwnedBy: "test", DisplayName: "Configured Claude Name",
@@ -37,70 +37,108 @@ func TestClaudeModelsResponseUsesConfiguredDisplayName(t *testing.T) {
 		t.Fatalf("decode response: %v", errUnmarshal)
 	}
 	for _, model := range response.Data {
-		if model.ID == modelID {
+		if model.ID == responseID {
 			if model.DisplayName != "Configured Claude Name" {
 				t.Fatalf("display_name = %q, want Configured Claude Name", model.DisplayName)
 			}
 			return
 		}
 	}
-	t.Fatalf("model %q not found in response", modelID)
+	t.Fatalf("model %q not found in response", responseID)
 }
 
-func TestClaudeModelsResponseDisablesModelListCloaking(t *testing.T) {
-	const clientID = "claude-disable-model-list-cloaking-test"
-	const modelID = "gpt-disable-model-list-cloaking-test"
+func TestClaudeModelsResponseIncludesCodexProviderModels(t *testing.T) {
+	const clientID = "claude-codex-provider-catalog-test"
+	want := map[string]string{
+		"claude/gpt-5.6-sol":   "GPT-5.6-Sol",
+		"claude/gpt-5.6-terra": "GPT-5.6-Terra",
+		"claude/gpt-5.6-luna":  "GPT-5.6-Luna",
+	}
+	models := make([]*registry.ModelInfo, 0, len(want))
+	for id, displayName := range map[string]string{
+		"gpt-5.6-sol": "GPT-5.6-Sol", "gpt-5.6-terra": "GPT-5.6-Terra", "gpt-5.6-luna": "GPT-5.6-Luna",
+	} {
+		models = append(models, &registry.ModelInfo{
+			ID: id, Object: "model", OwnedBy: "openai", DisplayName: displayName,
+			ContextLength: 272000, MaxCompletionTokens: 128000,
+		})
+	}
 	registryRef := registry.GetGlobalRegistry()
-	registryRef.RegisterClient(clientID, "claude", []*registry.ModelInfo{{
-		ID: modelID, Object: "model", OwnedBy: "test",
-	}})
-	t.Cleanup(func() {
-		registryRef.UnregisterClient(clientID)
-	})
+	registryRef.RegisterClient(clientID, "codex", models)
+	t.Cleanup(func() { registryRef.UnregisterClient(clientID) })
 
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
-	baseHandler := &handlers.BaseAPIHandler{Cfg: &sdkconfig.SDKConfig{
-		ClaudeCode: sdkconfig.ClaudeCodeConfig{DisableCloakingModelList: true},
-	}}
-	NewClaudeCodeAPIHandler(baseHandler).ClaudeModels(ctx)
+	NewClaudeCodeAPIHandler(&handlers.BaseAPIHandler{}).ClaudeModels(ctx)
 
 	var response struct {
 		Data []struct {
-			ID string `json:"id"`
+			ID             string `json:"id"`
+			DisplayName    string `json:"display_name"`
+			MaxInputTokens int    `json:"max_input_tokens"`
+			MaxTokens      int    `json:"max_tokens"`
 		} `json:"data"`
 	}
-	if errUnmarshal := json.Unmarshal(recorder.Body.Bytes(), &response); errUnmarshal != nil {
-		t.Fatalf("decode response: %v", errUnmarshal)
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
 	}
 	for _, model := range response.Data {
-		if model.ID == modelID {
-			return
+		displayName, ok := want[model.ID]
+		if !ok {
+			continue
 		}
+		if model.DisplayName != displayName || model.MaxInputTokens != 272000 || model.MaxTokens != 128000 {
+			t.Fatalf("model %s metadata = %#v", model.ID, model)
+		}
+		delete(want, model.ID)
 	}
-	t.Fatalf("uncloaked model %q not found in response", modelID)
+	if len(want) != 0 {
+		t.Fatalf("missing Codex models from Claude discovery: %v", want)
+	}
 }
 
-func TestRewriteClaudeDDModelInBody(t *testing.T) {
+func TestCanonicalizeClaudeNamespacedRequest(t *testing.T) {
 	tests := []struct {
-		name      string
-		body      string
-		wantModel string
+		name            string
+		body            string
+		wantModel       string
+		wantModelExists bool
 	}{
 		{
-			name:      "encoded model is decoded",
-			body:      `{"model":"claude-fable-5-dd-o4-tpg","messages":[]}`,
-			wantModel: "gpt-4o",
+			name:            "namespaced model is resolved",
+			body:            `{"model":"claude/gpt-4o","messages":[]}`,
+			wantModel:       "gpt-4o",
+			wantModelExists: true,
 		},
 		{
-			name:      "plain claude model unchanged",
-			body:      `{"model":"claude-sonnet-4-6","messages":[]}`,
-			wantModel: "claude-sonnet-4-6",
+			name:            "every namespace is resolved",
+			body:            `{"model":"claude/claude/claude/gpt-4o","messages":[]}`,
+			wantModel:       "gpt-4o",
+			wantModelExists: true,
 		},
 		{
-			name:      "encoded model with thinking suffix",
-			body:      `{"model":"claude-fable-5-dd-o4-tpg(high)","stream":true}`,
-			wantModel: "gpt-4o(high)",
+			name:            "wrapped catalog Claude model is resolved",
+			body:            `{"model":"claude/claude/claude-opus-5","messages":[]}`,
+			wantModel:       "claude-opus-5",
+			wantModelExists: true,
+		},
+		{
+			name:            "plain catalog Claude model unchanged",
+			body:            `{"model":"claude-opus-5","messages":[]}`,
+			wantModel:       "claude-opus-5",
+			wantModelExists: true,
+		},
+		{
+			name:            "unprefixed translated model unchanged",
+			body:            `{"model":"gpt-4o","messages":[]}`,
+			wantModel:       "gpt-4o",
+			wantModelExists: true,
+		},
+		{
+			name:            "wrapped native model preserves thinking suffix",
+			body:            `{"model":"claude/claude-opus-5(high)","stream":true}`,
+			wantModel:       "claude-opus-5(high)",
+			wantModelExists: true,
 		},
 		{
 			name:      "missing model field unchanged",
@@ -111,9 +149,19 @@ func TestRewriteClaudeDDModelInBody(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := rewriteClaudeDDModelInBody([]byte(tt.body))
-			if model := gjson.GetBytes(got, "model").String(); model != tt.wantModel {
-				t.Fatalf("model = %q, want %q; body=%s", model, tt.wantModel, string(got))
+			model, body := canonicalizeClaudeNamespacedRequest([]byte(tt.body))
+			if model != tt.wantModel {
+				t.Fatalf("route model = %q, want %q", model, tt.wantModel)
+			}
+			bodyModel := gjson.GetBytes(body, "model")
+			if bodyModel.Exists() != tt.wantModelExists {
+				t.Fatalf("body model exists = %t, want %t; body=%s", bodyModel.Exists(), tt.wantModelExists, body)
+			}
+			if bodyModel.Exists() && bodyModel.String() != tt.wantModel {
+				t.Fatalf("body model = %q, want %q; body=%s", bodyModel.String(), tt.wantModel, body)
+			}
+			if !tt.wantModelExists && string(body) != tt.body {
+				t.Fatalf("body changed without a model: got %s, want %s", body, tt.body)
 			}
 		})
 	}

--- a/sdk/api/handlers/claude/code_handlers_parity_test.go
+++ b/sdk/api/handlers/claude/code_handlers_parity_test.go
@@ -1,0 +1,90 @@
+package claude
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+)
+
+func TestWriteClaudeDirectErrorPreservesRetryAndRequestMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	handler := &ClaudeCodeAPIHandler{}
+	body := []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"offline rate limit"}}`)
+	msg := &interfaces.ErrorMessage{
+		StatusCode:     http.StatusTooManyRequests,
+		DirectResponse: true,
+		Body:           body,
+		Headers: http.Header{
+			"Retry-After":  []string{"7"},
+			"X-Request-Id": []string{"req_legacy_contract"},
+		},
+	}
+
+	handler.WriteErrorResponse(c, msg)
+
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusTooManyRequests)
+	}
+	if got := recorder.Header().Get("Retry-After"); got != "7" {
+		t.Fatalf("Retry-After = %q, want 7", got)
+	}
+	if got := recorder.Header().Get("X-Request-Id"); got != "req_legacy_contract" {
+		t.Fatalf("X-Request-Id = %q", got)
+	}
+	if got := recorder.Body.String(); got != string(body) {
+		t.Fatalf("body = %q, want %q", got, body)
+	}
+}
+
+func TestForwardClaudeStreamRejectsCleanCloseBeforeTerminal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	data := make(chan []byte)
+	errs := make(chan *interfaces.ErrorMessage)
+	close(data)
+	close(errs)
+
+	NewClaudeCodeAPIHandler(&handlers.BaseAPIHandler{}).forwardClaudeStream(c, recorder, func(error) {}, data, errs, false)
+	if body := recorder.Body.String(); !strings.Contains(body, "Upstream stream ended before response.completed.") {
+		t.Fatalf("body = %q, want incomplete-stream Claude error", body)
+	}
+}
+
+func TestForwardClaudeStreamAcceptsCleanCloseAfterTerminal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	data := make(chan []byte)
+	errs := make(chan *interfaces.ErrorMessage)
+	close(data)
+	close(errs)
+
+	NewClaudeCodeAPIHandler(&handlers.BaseAPIHandler{}).forwardClaudeStream(c, recorder, func(error) {}, data, errs, true)
+	if recorder.Body.Len() != 0 {
+		t.Fatalf("body = %q, want no synthetic terminal after message_stop", recorder.Body.String())
+	}
+}
+
+func TestClaudeStreamTerminalDetectionIgnoresPayloadText(t *testing.T) {
+	chunk := []byte("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"\\\"type\\\":\\\"message_stop\\\" event: error\"}}\n\n")
+	if claudeStreamChunkTerminal(chunk) {
+		t.Fatal("payload text must not mark a Claude stream terminal")
+	}
+}
+
+func TestClaudeStreamTerminalDetectionHandlesMultiEventChunk(t *testing.T) {
+	chunk := []byte("event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+	if !claudeStreamChunkTerminal(chunk) {
+		t.Fatal("message_stop in a multi-event chunk must mark the stream terminal")
+	}
+}

--- a/sdk/api/handlers/model_execution_test.go
+++ b/sdk/api/handlers/model_execution_test.go
@@ -253,6 +253,40 @@ func TestExecuteModelCarriesEntryAndExitProtocols(t *testing.T) {
 	}
 }
 
+func TestExecuteModelRoutesClaudeProtocolToCodexProvider(t *testing.T) {
+	model := "claude-codex-route-model"
+	requestBody := []byte(fmt.Sprintf(`{"model":%q,"max_tokens":64,"messages":[{"role":"user","content":"hi"}]}`, model))
+	executor := &modelExecutionCaptureExecutor{}
+	handler := newModelExecutionHandler(t, model, executor, &sdkconfig.SDKConfig{})
+
+	resp, errMsg := handler.ExecuteModel(context.Background(), ModelExecutionRequest{
+		EntryProtocol: constant.Claude,
+		ExitProtocol:  constant.Claude,
+		Model:         model,
+		Body:          requestBody,
+	})
+	if errMsg != nil {
+		t.Fatalf("ExecuteModel() error = %+v", errMsg)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	gotReq, gotOpts := executor.captured()
+	if gotReq.Model != model {
+		t.Fatalf("executor model = %q, want %q", gotReq.Model, model)
+	}
+	if string(gotReq.Payload) != string(requestBody) {
+		t.Fatalf("executor payload = %q, want %q", gotReq.Payload, requestBody)
+	}
+	if gotOpts.SourceFormat != sdktranslator.FormatClaude {
+		t.Fatalf("SourceFormat = %q, want %q", gotOpts.SourceFormat, sdktranslator.FormatClaude)
+	}
+	if gotOpts.ResponseFormat != sdktranslator.FormatClaude {
+		t.Fatalf("ResponseFormat = %q, want %q", gotOpts.ResponseFormat, sdktranslator.FormatClaude)
+	}
+}
+
 func TestExecuteModelSkipsOriginatingPluginInterceptors(t *testing.T) {
 	model := "model-execution-skip-origin-model"
 	requestBody := []byte(fmt.Sprintf(`{"model":%q}`, model))

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -11,7 +11,6 @@ type SDKConfig = internalconfig.SDKConfig
 type Config = internalconfig.Config
 
 type StreamingConfig = internalconfig.StreamingConfig
-type ClaudeCodeConfig = internalconfig.ClaudeCodeConfig
 type TLSConfig = internalconfig.TLSConfig
 type RemoteManagement = internalconfig.RemoteManagement
 type OAuthModelAlias = internalconfig.OAuthModelAlias

--- a/test/claude_code_blueprint_parity_test.go
+++ b/test/claude_code_blueprint_parity_test.go
@@ -1,0 +1,55 @@
+package test
+
+import (
+	"strings"
+	"testing"
+
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/codex/claude"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestClaudeCodeSentinel_HookReminderSurvivesCodexTranslation(t *testing.T) {
+	payload := []byte(`{
+		"model":"claude-opus-5",
+		"max_tokens":1024,
+		"system":"Follow repository policy.",
+		"messages":[
+			{"role":"user","content":"run tests"},
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_stop_1","name":"Bash","input":{"command":"go test ./..."}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_stop_1","content":"ok"}]},
+			{"role":"system","content":[{"type":"text","text":"The Stop hook requires a final protocol-safe response."}]},
+			{"role":"user","content":"finish"}
+		]
+	}`)
+
+	translated := sdktranslator.TranslateRequest(
+		sdktranslator.FormatClaude,
+		sdktranslator.FormatCodex,
+		"gpt-5.6-sol",
+		payload,
+		true,
+	)
+	inputs := gjson.GetBytes(translated, "input").Array()
+	if len(inputs) != 6 {
+		t.Fatalf("translated input items = %d, want 6; output=%s", len(inputs), translated)
+	}
+	if got := inputs[0].Get("content.0.text").String(); got != "Follow repository policy." {
+		t.Fatalf("system policy = %q", got)
+	}
+	if got := inputs[2].Get("call_id").String(); got != "toolu_stop_1" {
+		t.Fatalf("tool call id = %q, want toolu_stop_1", got)
+	}
+	if got := inputs[3].Get("call_id").String(); got != "toolu_stop_1" {
+		t.Fatalf("tool result id = %q, want toolu_stop_1", got)
+	}
+	if got := inputs[4].Get("content.0.text").String(); !strings.Contains(got, "The Stop hook requires a final protocol-safe response.") {
+		t.Fatalf("hook reminder = %q", got)
+	}
+	if got := inputs[5].Get("content.0.text").String(); got != "finish" {
+		t.Fatalf("post-hook user turn = %q, want finish", got)
+	}
+	if gjson.GetBytes(translated, "max_output_tokens").Exists() {
+		t.Fatalf("max_output_tokens must not reach the Codex subscription upstream; output=%s", translated)
+	}
+}


### PR DESCRIPTION

## Summary

Harden CLIProxyAPI's existing Claude `/v1/messages` → Codex Responses path for real Claude Code sessions. The existing Claude route, provider registry, scheduler, and pairwise translator architecture remain intact; this PR strengthens the Claude ↔ Codex adapter, model-discovery boundary, transport behavior, and response lifecycle.

The exact public route `claude/gpt-5.6-sol` passed all 22 proxy-owned live acceptance cases, covering request validation, tools and structured output, HTTP/SSE/WebSocket lifecycle, model discovery, token estimates, and upstream error metadata.

## Required dependency

- **#4907 — merge first:** enables HTTP-downstream clients to use a WebSocket Codex upstream. Its six-file patch is temporarily replayed here so the dependent Claude path can be tested.

## Problem

CLIProxyAPI already exposes `/v1/messages` and routes Claude-format requests through provider-specific translators, including Codex. That architecture is retained, but the Codex Responses path had several gaps under real Claude Code traffic:

- valid modern tool results or structured-output requests could be degraded or rejected late;
- unsupported Claude semantics could be translated with data loss instead of rejected at the boundary;
- Codex keepalives, terminal events, bootstrap failures, and response-completion state did not always map to valid Claude streaming behavior;
- rate-limit metadata and token estimates were incomplete or implied stronger precision than the route can provide;
- model discovery and request canonicalization relied on an older cloak scheme and a deprecated opt-out.

## Changes

### Request boundary

- Validate Claude requests before Codex transport and reject unsupported, lossy mappings explicitly.
- Preserve modern `tool_result` shapes and structured-output semantics.
- Canonicalize the public Claude model namespace at the existing handler boundary before routing.
- Keep downstream HTTP/SSE behavior independent from the Codex upstream transport selected by #4907.

### Response lifecycle

- Translate Codex keepalives into Claude ping events.
- Preserve safe rate-limit headers and classify bootstrap failures.
- Emit valid Claude terminal events for streamed responses.
- Recover completed tool/output state without duplicating terminal content.
- Mark translated Codex token counts as estimates.

### Models and configuration

- Native Claude IDs remain unchanged; other discovered models receive one `claude/` prefix.
- The prefix is removed at the request boundary so discovery and routing share one stable, registry-driven contract.
- Keep model definitions and remote model updates available to Claude model discovery.
- Preserve configured display names and model capabilities.
- Remove the deprecated model-list cloak toggle and its watcher/config plumbing.

### Regression coverage

- Add focused translation, validation, terminal, WebSocket, token, route, registry, model-list, and lifecycle tests.
- Preserve existing Claude routes and provider behavior while hardening Codex-backed execution.

## Verification

### Live Claude Code acceptance

End-to-end execution was validated across the full path: Claude Code → this branch's running CLIProxyAPI instance → Codex → GPT-5.6-sol, using the exact public route `claude/gpt-5.6-sol`.

- **22/22 proxy-owned cases passed.**
- Model discovery and `claude/` namespace canonicalization passed.
- Non-streaming, streaming, `count_tokens`, thinking suffixes, Markdown, Unicode, and multiturn requests passed.
- Sequential and parallel tool calls passed, including forced choice, call/result association, and ordering.
- Streaming produced exactly one valid terminal event with no parse or error events.
- A three-stage inspect → verify → synthesize Workflow completed with every child using the exact GPT route.
- Bounded proxy evidence recorded 86 successful HTTP requests: 1 model-list request, 80 Messages requests, and 5 `count_tokens` requests.
- Logs showed Codex/GPT routing with no Anthropic fallback, warning, error, or stream-terminal-failure markers.

**Result:** no proxy-owned regression was observed within this acceptance scope.

Of 154 matrix cases, 137 passed; the remaining 17 were harness, environment, or unavailable-surface exceptions. None reproduced a proxy defect.

Repository and build tests passed.

## Review notes

The highest-value review areas are:

1. request features that should fail explicitly rather than translate approximately;
2. terminal-event uniqueness across HTTP/SSE and Codex WebSocket upstreams;
3. tool-result and structured-output fidelity;
4. safe upstream rate-limit and error-header retention.