### PR TITLE
fix(claude): reject incomplete streaming responses

### DIFF
--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -306,6 +306,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			responseTracker := newClaudeResponseTracker(httpResp.Header)
 			scanner := bufio.NewScanner(responseTracker.reader(decodedBody))
 			scanner.Buffer(nil, claudeResponseScanLimit)
+			scanner.Split(scanClaudeResponseLines)
 			var event bytes.Buffer
 			var upstreamMessageID string
 			upstreamCompleted := false
@@ -375,6 +376,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		responseTracker := newClaudeResponseTracker(httpResp.Header)
 		scanner := bufio.NewScanner(responseTracker.reader(decodedBody))
 		scanner.Buffer(nil, claudeResponseScanLimit)
+		scanner.Split(scanClaudeResponseLines)
 		var param any
 		var upstreamMessageID string
 		upstreamCompleted := false
@@ -443,6 +445,29 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		result = wrapClaudeThinkingReplayStream(ctx, result, replayScope)
 	}
 	return result, nil
+}
+
+// scanClaudeResponseLines accepts every line ending allowed by SSE.
+// bufio.ScanLines does not split records separated by a lone carriage return.
+func scanClaudeResponseLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	for index, current := range data {
+		switch current {
+		case '\n':
+			return index + 1, data[:index], nil
+		case '\r':
+			if index+1 == len(data) && !atEOF {
+				return 0, nil, nil
+			}
+			if index+1 < len(data) && data[index+1] == '\n' {
+				return index + 2, data[:index], nil
+			}
+			return index + 1, data[:index], nil
+		}
+	}
+	if atEOF && len(data) != 0 {
+		return len(data), data, nil
+	}
+	return 0, nil, nil
 }
 
 func claudeStreamPrematureEOFError() error {

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"strings"
 
@@ -17,6 +18,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 )
+
+const claudeResponseScanLimit = 50 * 1024 * 1024
 
 func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	if opts.Alt == "responses/compact" {
@@ -300,8 +303,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 
 		// If the response target is Claude, directly forward complete SSE events without translation.
 		if responseFormat == to {
-			scanner := bufio.NewScanner(decodedBody)
-			scanner.Buffer(nil, 52_428_800) // 50MB
+			responseTracker := newClaudeResponseTracker(httpResp.Header)
+			scanner := bufio.NewScanner(responseTracker.reader(decodedBody))
+			scanner.Buffer(nil, claudeResponseScanLimit)
 			var event bytes.Buffer
 			var upstreamMessageID string
 			upstreamCompleted := false
@@ -321,6 +325,11 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			for scanner.Scan() {
 				line := scanner.Bytes()
 				observeClaudeStreamLine(line, &upstreamMessageID, &upstreamCompleted)
+				responseTracker.observe(line)
+				if responseTracker.exceededJSONLimit() {
+					emitResponseError(claudeJSONValidationLimitError())
+					return
+				}
 				helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 				if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
 					reporter.Publish(ctx, detail)
@@ -345,31 +354,38 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			if emitCancellation(scanner.Err()) {
 				return
 			}
-			if errScan := scanner.Err(); errScan != nil {
-				errScan = wrapClaudeFastRequestError(fastRequest, httpResp.StatusCode, errScan)
-				helps.RecordAPIResponseError(ctx, e.cfg, errScan)
-				reporter.PublishFailure(ctx, errScan)
-				select {
-				case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
-				case <-ctx.Done():
+			if !upstreamCompleted {
+				// A transport read error must surface regardless of the response
+				// kind: swallowing it would hand the client a truncated body as
+				// a successful stream.
+				if scanErr := scanner.Err(); scanErr != nil {
+					emitResponseError(scanErr)
+					return
 				}
-				return
+				if endErr := responseTracker.cleanEOFError(); endErr != nil {
+					emitResponseError(endErr)
+					return
+				}
 			}
-			if upstreamCompleted {
-				commitClaudeDiagnostics(diagnosticsState, upstreamMessageID)
-			}
+			commitClaudeDiagnostics(diagnosticsState, upstreamMessageID)
 			return
 		}
 
 		// For other formats, use translation
-		scanner := bufio.NewScanner(decodedBody)
-		scanner.Buffer(nil, 52_428_800) // 50MB
+		responseTracker := newClaudeResponseTracker(httpResp.Header)
+		scanner := bufio.NewScanner(responseTracker.reader(decodedBody))
+		scanner.Buffer(nil, claudeResponseScanLimit)
 		var param any
 		var upstreamMessageID string
 		upstreamCompleted := false
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			observeClaudeStreamLine(line, &upstreamMessageID, &upstreamCompleted)
+			responseTracker.observe(line)
+			if responseTracker.exceededJSONLimit() {
+				emitResponseError(claudeJSONValidationLimitError())
+				return
+			}
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
 				reporter.Publish(ctx, detail)
@@ -407,25 +423,118 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		if emitCancellation(scanner.Err()) {
 			return
 		}
-		if errScan := scanner.Err(); errScan != nil {
-			errScan = wrapClaudeFastRequestError(fastRequest, httpResp.StatusCode, errScan)
-			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
-			reporter.PublishFailure(ctx, errScan)
-			select {
-			case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
-			case <-ctx.Done():
+		if !upstreamCompleted {
+			// Same rule as the direct branch: a transport read error surfaces
+			// regardless of the response kind, and a clean EOF without
+			// message_stop on an actual SSE stream is an explicit failure.
+			if scanErr := scanner.Err(); scanErr != nil {
+				emitResponseError(scanErr)
+				return
 			}
-			return
+			if endErr := responseTracker.cleanEOFError(); endErr != nil {
+				emitResponseError(endErr)
+				return
+			}
 		}
-		if upstreamCompleted {
-			commitClaudeDiagnostics(diagnosticsState, upstreamMessageID)
-		}
+		commitClaudeDiagnostics(diagnosticsState, upstreamMessageID)
 	}()
 	result := &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}
 	if replayScope.valid() {
 		result = wrapClaudeThinkingReplayStream(ctx, result, replayScope)
 	}
 	return result, nil
+}
+
+func claudeStreamPrematureEOFError() error {
+	return statusErr{code: http.StatusBadGateway, msg: "claude executor: upstream stream ended before message_stop"}
+}
+
+func claudeJSONPrematureEOFError() error {
+	return statusErr{code: http.StatusBadGateway, msg: "claude executor: upstream response ended before complete JSON"}
+}
+
+func claudeJSONValidationLimitError() error {
+	return statusErr{code: http.StatusBadGateway, msg: "claude executor: upstream JSON response exceeds validation limit"}
+}
+
+// claudeResponseTracker keeps SSE framing distinct from a JSON response that
+// may legitimately arrive through ExecuteStream without stream=true.
+type claudeResponseTracker struct {
+	declaredSSE  bool
+	declaredJSON bool
+	sawSSELine   bool
+	captureJSON  bool
+	jsonTooLarge bool
+	jsonBody     bytes.Buffer
+}
+
+func newClaudeResponseTracker(header http.Header) *claudeResponseTracker {
+	mediaType, _, errParse := mime.ParseMediaType(header.Get("Content-Type"))
+	if errParse != nil {
+		// Observable SSE framing below still protects a response with a malformed header.
+		return &claudeResponseTracker{}
+	}
+	declaredJSON := strings.EqualFold(mediaType, "application/json")
+	return &claudeResponseTracker{
+		declaredSSE:  strings.EqualFold(mediaType, "text/event-stream"),
+		declaredJSON: declaredJSON,
+		captureJSON:  declaredJSON,
+	}
+}
+
+func (t *claudeResponseTracker) reader(body io.Reader) io.Reader {
+	if !t.captureJSON {
+		return body
+	}
+	return io.TeeReader(body, t)
+}
+
+func (t *claudeResponseTracker) Write(data []byte) (int, error) {
+	if !t.captureJSON {
+		return len(data), nil
+	}
+	remaining := claudeResponseScanLimit - t.jsonBody.Len()
+	if len(data) > remaining {
+		if remaining > 0 {
+			_, _ = t.jsonBody.Write(data[:remaining])
+		}
+		t.captureJSON = false
+		t.jsonTooLarge = true
+		return len(data), nil
+	}
+	_, _ = t.jsonBody.Write(data)
+	return len(data), nil
+}
+
+func (t *claudeResponseTracker) observe(line []byte) {
+	trimmed := bytes.TrimSpace(line)
+	if bytes.HasPrefix(trimmed, []byte("data:")) || bytes.HasPrefix(trimmed, []byte("event:")) {
+		t.sawSSELine = true
+		t.captureJSON = false
+		t.jsonTooLarge = false
+		t.jsonBody.Reset()
+	}
+}
+
+func (t *claudeResponseTracker) isSSE() bool {
+	return t.declaredSSE || t.sawSSELine
+}
+
+func (t *claudeResponseTracker) exceededJSONLimit() bool {
+	return t.jsonTooLarge && !t.isSSE()
+}
+
+func (t *claudeResponseTracker) cleanEOFError() error {
+	if t.isSSE() {
+		return claudeStreamPrematureEOFError()
+	}
+	if t.jsonTooLarge {
+		return claudeJSONValidationLimitError()
+	}
+	if t.declaredJSON && !gjson.ValidBytes(t.jsonBody.Bytes()) {
+		return claudeJSONPrematureEOFError()
+	}
+	return nil
 }
 
 func validateClaudeStreamingResponse(data []byte) error {

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -532,13 +532,30 @@ func (t *claudeResponseTracker) Write(data []byte) (int, error) {
 }
 
 func (t *claudeResponseTracker) observe(line []byte) {
-	trimmed := bytes.TrimSpace(line)
-	if bytes.HasPrefix(trimmed, []byte("data:")) || bytes.HasPrefix(trimmed, []byte("event:")) {
+	if isClaudeSSEFramingLine(line) {
 		t.sawSSELine = true
 		t.captureJSON = false
 		t.jsonTooLarge = false
 		t.jsonBody.Reset()
 	}
+}
+
+func isClaudeSSEFramingLine(line []byte) bool {
+	trimmed := bytes.TrimSpace(line)
+	if len(trimmed) == 0 {
+		return false
+	}
+	if trimmed[0] == ':' {
+		return true
+	}
+	field := trimmed
+	if separator := bytes.IndexByte(field, ':'); separator >= 0 {
+		field = field[:separator]
+	}
+	return bytes.Equal(field, []byte("data")) ||
+		bytes.Equal(field, []byte("event")) ||
+		bytes.Equal(field, []byte("id")) ||
+		bytes.Equal(field, []byte("retry"))
 }
 
 func (t *claudeResponseTracker) isSSE() bool {

--- a/internal/runtime/executor/claude_executor_stream_terminal_test.go
+++ b/internal/runtime/executor/claude_executor_stream_terminal_test.go
@@ -1,0 +1,547 @@
+package executor
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+// These regression tests distinguish completed Claude responses from
+// responses that end before their protocol-level terminal condition.
+
+const claudeStreamPrematureEOFBody = "event: message_start\n" +
+	`data: {"type":"message_start","message":{"id":"msg_premature","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[],"usage":{"input_tokens":1,"output_tokens":0}}}` + "\n" +
+	"\n" +
+	"event: content_block_delta\n" +
+	`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}` + "\n" +
+	"\n"
+
+const claudeStreamCompleteBody = claudeStreamPrematureEOFBody +
+	"event: message_stop\n" +
+	`data: {"type":"message_stop"}` + "\n" +
+	"\n"
+
+func newClaudeStreamTerminalExecutor(server *httptest.Server) (*ClaudeExecutor, *cliproxyauth.Auth) {
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-stream-terminal",
+		"base_url": server.URL,
+	}}
+	return executor, auth
+}
+
+type claudeStreamRecorder struct {
+	payloads []string
+	errs     []error
+}
+
+func (r *claudeStreamRecorder) record(result *cliproxyexecutor.StreamResult) {
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			r.errs = append(r.errs, chunk.Err)
+			continue
+		}
+		r.payloads = append(r.payloads, string(chunk.Payload))
+	}
+}
+
+func TestClaudeExecutor_ExecuteStreamDirectPassthroughPrematureEOFYieldsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(claudeStreamPrematureEOFBody))
+	}))
+	defer server.Close()
+
+	executor, auth := newClaudeStreamTerminalExecutor(server)
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	var rec claudeStreamRecorder
+	rec.record(result)
+
+	if len(rec.payloads) == 0 {
+		t.Fatal("no payloads emitted before premature EOF")
+	}
+	for _, p := range rec.payloads {
+		if strings.Contains(p, `"message_stop"`) {
+			t.Fatalf("synthetic message_stop emitted after premature EOF: %q", p)
+		}
+	}
+	if len(rec.errs) != 1 {
+		t.Fatalf("error chunk count = %d, want exactly 1 after payloads (premature EOF must not close the channel silently); payloads=%d", len(rec.errs), len(rec.payloads))
+	}
+}
+
+func TestClaudeExecutor_ExecuteStreamTranslatedPrematureEOFYieldsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(claudeStreamPrematureEOFBody))
+	}))
+	defer server.Close()
+
+	executor, auth := newClaudeStreamTerminalExecutor(server)
+	payload := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	var rec claudeStreamRecorder
+	rec.record(result)
+
+	if len(rec.payloads) == 0 {
+		t.Fatal("no translated payloads emitted before premature EOF")
+	}
+	for _, p := range rec.payloads {
+		if strings.Contains(p, "[DONE]") {
+			t.Fatalf("translated success terminal emitted after premature EOF: %q", p)
+		}
+	}
+	if len(rec.errs) != 1 {
+		t.Fatalf("error chunk count = %d, want exactly 1 after translated payloads (premature EOF must not close the channel silently); payloads=%d", len(rec.errs), len(rec.payloads))
+	}
+}
+
+func TestClaudeExecutor_ExecuteStreamMessageStopThenPlainEOFSucceeds(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(claudeStreamCompleteBody))
+	}))
+	defer server.Close()
+
+	executor, auth := newClaudeStreamTerminalExecutor(server)
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	var rec claudeStreamRecorder
+	rec.record(result)
+
+	if len(rec.payloads) == 0 {
+		t.Fatal("no payloads emitted for completed stream")
+	}
+	if len(rec.errs) != 0 {
+		t.Fatalf("completed stream produced %d error chunk(s): %v", len(rec.errs), rec.errs)
+	}
+	joined := strings.Join(rec.payloads, "")
+	if !strings.Contains(joined, `"message_stop"`) {
+		t.Fatalf("completed stream is missing real message_stop: %q", joined)
+	}
+}
+
+// runClaudeStreamTerminalSSE varies Content-Type without changing the SSE body
+// so classification is tested independently from the header.
+func runClaudeStreamTerminalSSE(t *testing.T, contentType string) claudeStreamRecorder {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if contentType != "" {
+			w.Header().Set("Content-Type", contentType)
+		}
+		_, _ = w.Write([]byte(claudeStreamPrematureEOFBody))
+	}))
+	defer server.Close()
+
+	executor, auth := newClaudeStreamTerminalExecutor(server)
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	var rec claudeStreamRecorder
+	rec.record(result)
+	return rec
+}
+
+func assertClaudeStreamPrematureEOFFails(t *testing.T, rec claudeStreamRecorder) {
+	t.Helper()
+	if len(rec.payloads) == 0 {
+		t.Fatal("no payloads emitted before premature EOF")
+	}
+	for _, p := range rec.payloads {
+		if strings.Contains(p, `"message_stop"`) {
+			t.Fatalf("synthetic message_stop emitted after premature EOF: %q", p)
+		}
+	}
+	if len(rec.errs) != 1 {
+		t.Fatalf("error chunk count = %d, want exactly 1 after payloads; payloads=%d", len(rec.errs), len(rec.payloads))
+	}
+}
+
+// Observable SSE framing must keep the truncation guard active even when the
+// upstream omits or mislabels Content-Type.
+func TestClaudeExecutor_ExecuteStreamSSEWithoutContentTypeHeaderStillFailsOnPrematureEOF(t *testing.T) {
+	assertClaudeStreamPrematureEOFFails(t, runClaudeStreamTerminalSSE(t, ""))
+}
+
+func TestClaudeExecutor_ExecuteStreamSSEWithMislabelledContentTypeStillFailsOnPrematureEOF(t *testing.T) {
+	assertClaudeStreamPrematureEOFFails(t, runClaudeStreamTerminalSSE(t, "application/json"))
+}
+
+func TestClaudeResponseTracker_MislabelledSSEStopsJSONCapture(t *testing.T) {
+	tracker := newClaudeResponseTracker(http.Header{"Content-Type": {"application/json"}})
+	body := strings.Repeat("event: content_block_delta\ndata: {}\n\n", 4096)
+	scanner := bufio.NewScanner(tracker.reader(strings.NewReader(body)))
+	for scanner.Scan() {
+		tracker.observe(scanner.Bytes())
+		if retained := tracker.jsonBody.Len(); retained != 0 {
+			t.Fatalf("mislabelled SSE retained %d JSON byte(s)", retained)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan mislabelled SSE: %v", err)
+	}
+	if !tracker.isSSE() {
+		t.Fatal("observable SSE framing was not recognized")
+	}
+}
+
+// A declared length larger than the body turns connection close into a read
+// error, which is distinct from a clean protocol-level EOF.
+func writeClaudeBodyWithTruncatedContentLength(w http.ResponseWriter, body string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Content-Length", "1048576")
+	_, _ = w.Write([]byte(body))
+}
+
+func TestClaudeExecutor_ExecuteStreamMessageStopThenReadErrorStaysSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeClaudeBodyWithTruncatedContentLength(w, claudeStreamCompleteBody)
+	}))
+	defer server.Close()
+
+	executor, auth := newClaudeStreamTerminalExecutor(server)
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	var rec claudeStreamRecorder
+	rec.record(result)
+
+	if len(rec.payloads) == 0 {
+		t.Fatal("no payloads emitted for completed stream")
+	}
+	joined := strings.Join(rec.payloads, "")
+	if !strings.Contains(joined, `"message_stop"`) {
+		t.Fatalf("stream is missing real message_stop: %q", joined)
+	}
+	if len(rec.errs) != 0 {
+		t.Fatalf("transport error after real message_stop turned completed stream into failure: %v", rec.errs)
+	}
+}
+
+func TestClaudeExecutor_ExecuteStreamReadErrorBeforeMessageStopYieldsSingleError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeClaudeBodyWithTruncatedContentLength(w, claudeStreamPrematureEOFBody)
+	}))
+	defer server.Close()
+
+	executor, auth := newClaudeStreamTerminalExecutor(server)
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	var rec claudeStreamRecorder
+	rec.record(result)
+
+	if len(rec.payloads) == 0 {
+		t.Fatal("no payloads emitted before read error")
+	}
+	for _, p := range rec.payloads {
+		if strings.Contains(p, `"message_stop"`) {
+			t.Fatalf("synthetic message_stop emitted after read error: %q", p)
+		}
+	}
+	if len(rec.errs) != 1 {
+		t.Fatalf("error chunk count = %d, want exactly 1 after read error before message_stop", len(rec.errs))
+	}
+}
+
+// Keep the JSON document valid so this helper isolates transport truncation
+// from application-level JSON completeness.
+func writeClaudeNonSSEBodyWithTruncatedContentLength(w http.ResponseWriter, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", "1048576")
+	_, _ = w.Write([]byte(body))
+}
+
+const claudeNonSSEMessageBody = `{"id":"msg_nonsse","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[{"type":"text","text":"partial"}],"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":1}}`
+
+func runClaudeStreamNonSSEResponse(
+	t *testing.T,
+	sourceFormat sdktranslator.Format,
+	writeResponse func(http.ResponseWriter),
+) claudeStreamRecorder {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeResponse(w)
+	}))
+	defer server.Close()
+
+	executor, auth := newClaudeStreamTerminalExecutor(server)
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	if sourceFormat != sdktranslator.FromString("claude") {
+		payload = []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sourceFormat})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	var rec claudeStreamRecorder
+	rec.record(result)
+	return rec
+}
+
+func runClaudeStreamNonSSEReadError(t *testing.T, sourceFormat sdktranslator.Format) claudeStreamRecorder {
+	t.Helper()
+	return runClaudeStreamNonSSEResponse(t, sourceFormat, func(w http.ResponseWriter) {
+		writeClaudeNonSSEBodyWithTruncatedContentLength(w, claudeNonSSEMessageBody)
+	})
+}
+
+const claudeNonSSEIncompleteMessageBody = `{"id":"msg_nonsse","type":"message","role":"assistant","content":[{"type":"text","text":"partial-json-canary"}]`
+
+func runClaudeStreamNonSSECleanEOF(t *testing.T, sourceFormat sdktranslator.Format, body string) claudeStreamRecorder {
+	t.Helper()
+	return runClaudeStreamNonSSEResponse(t, sourceFormat, func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+}
+
+func assertClaudeIncompleteJSONFails(t *testing.T, rec claudeStreamRecorder, terminal string) {
+	t.Helper()
+	for _, payload := range rec.payloads {
+		if terminal != "" && strings.Contains(payload, terminal) {
+			t.Fatalf("successful terminal emitted after incomplete JSON: %q", payload)
+		}
+	}
+	if len(rec.errs) != 1 {
+		t.Fatalf("error chunk count = %d, want exactly 1 after incomplete JSON", len(rec.errs))
+	}
+	status, ok := rec.errs[0].(interface{ StatusCode() int })
+	if !ok || status.StatusCode() != http.StatusBadGateway {
+		t.Fatalf("incomplete JSON error = %v, want HTTP 502", rec.errs[0])
+	}
+	if strings.Contains(rec.errs[0].Error(), "partial-json-canary") {
+		t.Fatalf("incomplete JSON error leaked response body: %v", rec.errs[0])
+	}
+}
+
+func TestClaudeExecutor_ExecuteStreamIncompleteJSONCleanEOFYieldsSingleError(t *testing.T) {
+	rec := runClaudeStreamNonSSECleanEOF(
+		t,
+		sdktranslator.FromString("claude"),
+		claudeNonSSEIncompleteMessageBody,
+	)
+	if len(rec.payloads) == 0 {
+		t.Fatal("no payload emitted before incomplete JSON EOF")
+	}
+	assertClaudeIncompleteJSONFails(t, rec, `"message_stop"`)
+}
+
+func TestClaudeExecutor_ExecuteStreamTranslatedIncompleteJSONCleanEOFYieldsSingleError(t *testing.T) {
+	rec := runClaudeStreamNonSSECleanEOF(
+		t,
+		sdktranslator.FormatOpenAI,
+		claudeNonSSEIncompleteMessageBody,
+	)
+	assertClaudeIncompleteJSONFails(t, rec, "[DONE]")
+}
+
+func writeClaudeOversizedMultilineJSON(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = io.WriteString(w, "{\"content\":[\n")
+	line := `"` + strings.Repeat("x", 1024) + `",` + "\n"
+	written := len("{\"content\":[\n")
+	for written <= claudeResponseScanLimit+len(line) {
+		_, _ = io.WriteString(w, line)
+		written += len(line)
+	}
+	_, _ = io.WriteString(w, `"end"]}`)
+}
+
+func runClaudeOversizedJSON(t *testing.T, sourceFormat sdktranslator.Format) claudeStreamRecorder {
+	t.Helper()
+	return runClaudeStreamNonSSEResponse(t, sourceFormat, writeClaudeOversizedMultilineJSON)
+}
+
+func assertClaudeOversizedJSONFails(t *testing.T, rec claudeStreamRecorder, terminal string) {
+	t.Helper()
+	if len(rec.errs) != 1 {
+		t.Fatalf("error chunk count = %d, want exactly 1 for oversized JSON", len(rec.errs))
+	}
+	status, ok := rec.errs[0].(interface{ StatusCode() int })
+	if !ok || status.StatusCode() != http.StatusBadGateway {
+		t.Fatalf("oversized JSON error = %v, want HTTP 502", rec.errs[0])
+	}
+	for _, payload := range rec.payloads {
+		if terminal != "" && strings.Contains(payload, terminal) {
+			t.Fatalf("successful terminal emitted after oversized JSON: %q", payload)
+		}
+	}
+}
+
+func TestClaudeExecutor_ExecuteStreamOversizedMultilineJSONYieldsSingleError(t *testing.T) {
+	assertClaudeOversizedJSONFails(
+		t,
+		runClaudeOversizedJSON(t, sdktranslator.FromString("claude")),
+		`"message_stop"`,
+	)
+}
+
+func TestClaudeExecutor_ExecuteStreamTranslatedOversizedMultilineJSONYieldsSingleError(t *testing.T) {
+	assertClaudeOversizedJSONFails(
+		t,
+		runClaudeOversizedJSON(t, sdktranslator.FormatOpenAI),
+		"[DONE]",
+	)
+}
+
+func TestClaudeExecutor_ExecuteStreamCompleteJSONCleanEOFSucceeds(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		sourceFormat sdktranslator.Format
+	}{
+		{name: "direct", sourceFormat: sdktranslator.FromString("claude")},
+		{name: "translated", sourceFormat: sdktranslator.FormatOpenAI},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rec := runClaudeStreamNonSSECleanEOF(t, test.sourceFormat, claudeNonSSEMessageBody)
+			if len(rec.errs) != 0 {
+				t.Fatalf("complete JSON produced %d error chunk(s): %v", len(rec.errs), rec.errs)
+			}
+		})
+	}
+}
+
+func TestClaudeExecutor_ExecuteStreamNonSSEReadErrorYieldsSingleError(t *testing.T) {
+	rec := runClaudeStreamNonSSEReadError(t, sdktranslator.FromString("claude"))
+	if len(rec.errs) != 1 {
+		t.Fatalf("error chunk count = %d, want exactly 1 (non-SSE read error must not close the channel silently)", len(rec.errs))
+	}
+	for _, p := range rec.payloads {
+		if strings.Contains(p, `"message_stop"`) {
+			t.Fatalf("synthetic message_stop emitted after non-SSE read error: %q", p)
+		}
+	}
+}
+
+func TestClaudeExecutor_ExecuteStreamTranslatedNonSSEReadErrorYieldsSingleError(t *testing.T) {
+	rec := runClaudeStreamNonSSEReadError(t, sdktranslator.FormatOpenAI)
+	for _, p := range rec.payloads {
+		if strings.Contains(p, "[DONE]") {
+			t.Fatalf("translated success terminal emitted after non-SSE read error: %q", p)
+		}
+	}
+	if len(rec.errs) != 1 {
+		t.Fatalf("error chunk count = %d, want exactly 1 (non-SSE read error must not close the channel silently)", len(rec.errs))
+	}
+}
+
+func TestClaudeExecutor_ExecuteStreamClientCancellationIsNotProviderFailure(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: message_start\n" +
+			`data: {"type":"message_start","message":{"id":"msg_cancel","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[],"usage":{"input_tokens":1,"output_tokens":0}}}` + "\n\n"))
+		w.(http.Flusher).Flush()
+		<-release
+	}))
+	defer server.Close()
+	defer close(release)
+
+	executor, auth := newClaudeStreamTerminalExecutor(server)
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	// Cancel only after the first payload so this exercises mid-stream cancellation.
+	first, ok := <-result.Chunks
+	if !ok || first.Err != nil {
+		t.Fatalf("first chunk = (%q, %v), want message_start payload", first.Payload, first.Err)
+	}
+
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for chunk := range result.Chunks {
+			if chunk.Err == nil {
+				continue
+			}
+			var statusErr interface{ StatusCode() int }
+			if as, ok := chunk.Err.(interface{ StatusCode() int }); ok {
+				statusErr = as
+			}
+			if statusErr != nil {
+				t.Errorf("client cancellation surfaced as provider failure with HTTP status: %v", chunk.Err)
+			}
+			if !strings.Contains(chunk.Err.Error(), "context canceled") {
+				t.Errorf("client cancellation surfaced as non-cancellation error: %v", chunk.Err)
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out draining stream after client cancellation")
+	}
+}

--- a/internal/runtime/executor/claude_executor_stream_terminal_test.go
+++ b/internal/runtime/executor/claude_executor_stream_terminal_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -120,6 +121,79 @@ func TestClaudeExecutor_ExecuteStreamTranslatedPrematureEOFYieldsError(t *testin
 	}
 	if len(rec.errs) != 1 {
 		t.Fatalf("error chunk count = %d, want exactly 1 after translated payloads (premature EOF must not close the channel silently); payloads=%d", len(rec.errs), len(rec.payloads))
+	}
+}
+
+func runClaudeStreamBody(
+	t *testing.T,
+	body string,
+	contentType string,
+	sourceFormat sdktranslator.Format,
+) claudeStreamRecorder {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	executor, auth := newClaudeStreamTerminalExecutor(server)
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	if sourceFormat != sdktranslator.FromString("claude") {
+		payload = []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	}
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sourceFormat})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	var rec claudeStreamRecorder
+	rec.record(result)
+	return rec
+}
+
+func TestScanClaudeResponseLinesAcceptsSSELineEndings(t *testing.T) {
+	for _, separator := range []string{"\n", "\r\n", "\r"} {
+		t.Run(fmt.Sprintf("%q", separator), func(t *testing.T) {
+			scanner := bufio.NewScanner(strings.NewReader(
+				"event: test" + separator + "data: {}" + separator + separator,
+			))
+			scanner.Split(scanClaudeResponseLines)
+			var lines []string
+			for scanner.Scan() {
+				lines = append(lines, scanner.Text())
+			}
+			if err := scanner.Err(); err != nil {
+				t.Fatalf("scan lines: %v", err)
+			}
+			if got := strings.Join(lines, "|"); got != "event: test|data: {}|" {
+				t.Fatalf("lines = %q", got)
+			}
+		})
+	}
+}
+
+func TestClaudeExecutor_ExecuteStreamCROnlyMessageStopSucceeds(t *testing.T) {
+	body := strings.ReplaceAll(claudeStreamCompleteBody, "\n", "\r")
+	for _, test := range []struct {
+		name         string
+		sourceFormat sdktranslator.Format
+	}{
+		{name: "direct", sourceFormat: sdktranslator.FromString("claude")},
+		{name: "translated", sourceFormat: sdktranslator.FormatOpenAI},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rec := runClaudeStreamBody(t, body, "text/event-stream", test.sourceFormat)
+			if len(rec.errs) != 0 {
+				t.Fatalf("complete CR-only stream produced %d error chunk(s): %v", len(rec.errs), rec.errs)
+			}
+			if len(rec.payloads) == 0 {
+				t.Fatal("complete CR-only stream emitted no payload")
+			}
+		})
 	}
 }
 

--- a/internal/runtime/executor/claude_executor_stream_terminal_test.go
+++ b/internal/runtime/executor/claude_executor_stream_terminal_test.go
@@ -275,6 +275,51 @@ func assertClaudeStreamPrematureEOFFails(t *testing.T, rec claudeStreamRecorder)
 
 // Observable SSE framing must keep the truncation guard active even when the
 // upstream omits or mislabels Content-Type.
+func TestIsClaudeSSEFramingLine(t *testing.T) {
+	for _, test := range []struct {
+		line string
+		want bool
+	}{
+		{line: ": ping", want: true},
+		{line: "data: {}", want: true},
+		{line: "event: message", want: true},
+		{line: "id: checkpoint", want: true},
+		{line: "retry: 1000", want: true},
+		{line: "data", want: true},
+		{line: "", want: false},
+		{line: `{"id":"message"}`, want: false},
+		{line: `"retry: 1000"`, want: false},
+		{line: "field: value", want: false},
+	} {
+		t.Run(test.line, func(t *testing.T) {
+			if got := isClaudeSSEFramingLine([]byte(test.line)); got != test.want {
+				t.Fatalf("isClaudeSSEFramingLine(%q) = %t, want %t", test.line, got, test.want)
+			}
+		})
+	}
+}
+
+func TestClaudeExecutor_ExecuteStreamSSECommentWithoutValidContentTypeFailsOnEOF(t *testing.T) {
+	for _, contentType := range []string{"", "not a media type"} {
+		for _, sourceFormat := range []sdktranslator.Format{
+			sdktranslator.FromString("claude"),
+			sdktranslator.FormatOpenAI,
+		} {
+			name := fmt.Sprintf("content-type=%q/source=%s", contentType, sourceFormat)
+			t.Run(name, func(t *testing.T) {
+				rec := runClaudeStreamBody(t, ": ping\n\n", contentType, sourceFormat)
+				if len(rec.errs) != 1 {
+					t.Fatalf("error chunk count = %d, want exactly 1 after SSE comment EOF", len(rec.errs))
+				}
+				status, ok := rec.errs[0].(interface{ StatusCode() int })
+				if !ok || status.StatusCode() != http.StatusBadGateway {
+					t.Fatalf("SSE comment EOF error = %v, want HTTP 502", rec.errs[0])
+				}
+			})
+		}
+	}
+}
+
 func TestClaudeExecutor_ExecuteStreamSSEWithoutContentTypeHeaderStillFailsOnPrematureEOF(t *testing.T) {
 	assertClaudeStreamPrematureEOFFails(t, runClaudeStreamTerminalSSE(t, ""))
 }


### PR DESCRIPTION
## Problem

`ClaudeExecutor.ExecuteStream` can currently report an incomplete upstream response as a successful channel close when `bufio.Scanner.Err()` is nil:

- an Anthropic SSE response reaches clean EOF before the terminal `message_stop` event;
- a response declared as `application/json` reaches clean EOF while its JSON document is syntactically incomplete.

After payload bytes have reached the client, the HTTP status is already 200. Closing the channel without `StreamChunk.Err` leaves no native failure marker, so clients may accept a truncated answer as successful.

Both cases reproduce on the current `dev` baseline (`48749717645e0e91c75569209e6201b36bf0045e`) through the real HTTP/API boundary of a source-built CLIProxyAPI binary.

## Difference from #3996 / #3997

#3997 synthesized `message_stop` after premature EOF, hiding an incomplete response behind a fake success marker.

This change does the opposite:

- never creates `message_stop`, `[DONE]`, or another success terminal;
- emits exactly one `StreamChunk.Err` through the existing error path;
- preserves the existing no-retry contract after the first payload;
- lets the Anthropic handler render the propagated failure as native `event: error`.

## Implementation

The production diff is limited to `internal/runtime/executor/claude_executor_stream.go`.

Both direct Claude passthrough and translated output use the same termination order:

1. client cancellation keeps the existing cancellation path;
2. any non-cancellation `scanner.Err()` before protocol completion is emitted for both SSE and non-SSE responses;
3. clean EOF on observable SSE without `message_stop` returns a constant 502;
4. clean EOF on declared `application/json` whose body is not valid JSON returns a separate constant 502;
5. valid complete JSON remains successful;
6. total declared-JSON capture is bounded at 50 MiB, matching the scanner limit; exceeding it returns a constant 502 before more data is processed;
7. after a real `message_stop`, a later close error does not create a second failure.

`claudeResponseTracker` combines parsed `Content-Type` with observed `event:` / `data:` framing. Observable SSE has priority over a missing or incorrect header. If SSE is mislabeled as JSON, provisional JSON state is cleared and further JSON capture is disabled.

Both scanner branches use an SSE-aware split function that recognizes LF, CRLF, and lone CR line endings. This keeps `message_stop` observable for CR-only event streams instead of misclassifying a completed response as premature EOF.

The tracker also treats SSE comment lines and the standard `data`, `event`, `id`, and `retry` fields as observable framing. A comment-only response with missing or malformed Content-Type therefore cannot silently close before `message_stop`.

All new errors are constant and contain no response body, headers, upstream URL, transport exception, or credential data.

## Tests

The new adjacent test file contains 20 test functions covering direct and translated paths, including:

- SSE clean EOF before `message_stop`;
- incomplete JSON at clean EOF;
- complete JSON at clean EOF;
- transport read errors for SSE and non-SSE;
- `message_stop` followed by EOF or a read error;
- missing and mislabeled SSE Content-Type;
- LF, CRLF, and CR-only SSE framing in both scanner branches;
- SSE comments and data/event/id/retry framing with missing or malformed Content-Type;
- 4096-event mislabeled SSE capture cleanup;
- valid multiline JSON above the 50 MiB total limit;
- client cancellation.

Executed in a pinned Go 1.26.5 `linux/amd64` container:

```text
go test -mod=readonly ./internal/runtime/executor/ \
  -run 'TestIsClaudeSSEFramingLine|TestScanClaudeResponseLinesAcceptsSSELineEndings|TestClaudeResponseTracker_MislabelledSSEStopsJSONCapture|TestClaudeExecutor_ExecuteStream(SSECommentWithoutValidContentTypeFailsOnEOF|CROnlyMessageStopSucceeds|DirectPassthroughPrematureEOF|TranslatedPrematureEOF|MessageStopThen|ReadErrorBefore|NonSSEReadError|TranslatedNonSSEReadError|ClientCancellation|SSEWithoutContentTypeHeader|SSEWithMislabelledContentType|IncompleteJSONCleanEOF|TranslatedIncompleteJSONCleanEOF|CompleteJSONCleanEOF)' \
  -count=3

go test -mod=readonly ./internal/runtime/executor/ \
  -run 'TestClaudeExecutor_ExecuteStream(Translated)?OversizedMultilineJSONYieldsSingleError' \
  -count=3

go test -mod=readonly ./internal/runtime/executor/ \
  -run 'TestClaudeExecutor_PayloadOverrideReconcilesRelocatedSystemPrompt' \
  -count=3

go test -mod=readonly ./sdk/api/handlers/ \
  -run 'TestExecuteStreamWithAuthManager_DoesNotRetryAfterFirstByte' \
  -count=3

go vet -mod=readonly ./internal/runtime/executor/... ./sdk/api/handlers/...
go build -mod=readonly ./cmd/server
```

All commands above pass. `gofmt` and `git diff --check` are clean; `go.mod` and `go.sum` are unchanged.

The broad executor+handlers suite still exits 1 on exactly three headers/User-Agent tests. The same three failures reproduce on the clean current `dev` baseline, and all handler packages pass:

- `TestApplyClaudeHeaders_DisableDeviceProfileStabilization`
- `TestApplyClaudeHeaders_LegacyModePreservesConfiguredUserAgentOverrideForClaudeClients`
- `TestClaudeExecutor_NonClaudeRequestUsesClaudeCode220CLIFingerprint`

## Source-built HTTP verification

The current `dev` baseline and current HEAD (`86a102e6`) were built with the same upstream Dockerfile for `linux/amd64` and exercised through the real `/v1/messages` HTTP entry point against a controlled HTTP/1.1 fake upstream.

| Scenario | current `dev` | this branch |
|---|---|---|
| normal SSE with real `message_stop` | completed | completed |
| complete CR-only SSE with real `message_stop` | silent truncation | completed |
| comment-only SSE mislabeled as JSON, then clean EOF | silent truncation | explicit failure, error event |
| SSE clean EOF before `message_stop` | silent truncation | explicit failure, error event, no terminal |
| complete JSON through `ExecuteStream` | HTTP 200, valid document | HTTP 200, valid document |
| incomplete JSON, honest length, clean EOF | silent truncation | explicit failure, error event |
| valid JSON body, oversized Content-Length | explicit failure | explicit failure |

Every failing branch scenario recorded only the primary attempt; no backup was started. No synthetic terminal was observed. The test network was internal, used synthetic credentials and a temporary CA, published no ports or images, and was removed after the run.

## Scope

- Claude executor and one adjacent test file only;
- no translator, handler, auth-manager, plugin, configuration, module, CI, image-pin, or release-tooling changes.

## Known boundary

The pre-existing direct SSE event assembler still buffers lines until an empty event delimiter. This PR does not add a total bound for malformed SSE that never terminates an event; the new 50 MiB bound applies to declared JSON.

