### PR TITLE
fix(antigravity,misc): add onboarding retry jitter and harden header scrubbing

### DIFF
--- a/internal/auth/antigravity/auth.go
+++ b/internal/auth/antigravity/auth.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"strings"
@@ -299,8 +300,13 @@ func (o *AntigravityAuth) OnboardUser(ctx context.Context, accessToken, tierID s
 		return "", fmt.Errorf("marshal request body: %w", errMarshal)
 	}
 
-	maxAttempts := 5
+	maxAttempts := 3
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if attempt > 1 {
+			// Random 3-6 second jitter delay between onboarding polling attempts
+			jitter := time.Duration(3000+rand.Intn(3000)) * time.Millisecond
+			time.Sleep(jitter)
+		}
 		log.Debugf("Polling attempt %d/%d", attempt, maxAttempts)
 
 		reqCtx := ctx
@@ -358,7 +364,6 @@ func (o *AntigravityAuth) OnboardUser(ctx context.Context, accessToken, tierID s
 				return "", fmt.Errorf("no project_id in response")
 			}
 
-			time.Sleep(2 * time.Second)
 			continue
 		}
 

--- a/internal/misc/header_utils.go
+++ b/internal/misc/header_utils.go
@@ -29,14 +29,17 @@ func ScrubProxyAndFingerprintHeaders(req *http.Request) {
 
 	// --- Client identity headers ---
 	req.Header.Del("X-Title")
-	req.Header.Del("X-Stainless-Lang")
-	req.Header.Del("X-Stainless-Package-Version")
-	req.Header.Del("X-Stainless-Os")
-	req.Header.Del("X-Stainless-Arch")
-	req.Header.Del("X-Stainless-Runtime")
-	req.Header.Del("X-Stainless-Runtime-Version")
+	req.Header.Del("X-Fingerprint")
+	req.Header.Del("X-Goog-Safety-Level")
+	req.Header.Del("X-Client-Trace-Id")
 	req.Header.Del("Http-Referer")
 	req.Header.Del("Referer")
+
+	for k := range req.Header {
+		if strings.HasPrefix(strings.ToLower(k), "x-stainless-") {
+			req.Header.Del(k)
+		}
+	}
 
 	// --- Browser / Chromium fingerprint headers ---
 	// These are sent by Electron-based clients (e.g. CherryStudio) using the


### PR DESCRIPTION
### Summary
This PR improves stealth and prevents rate-limit/bot-detection triggers during Antigravity OAuth onboarding and proxy request forwarding:

1. **Jittered & Bounded Onboarding (`internal/auth/antigravity/auth.go`):**
   - Bounds `onboardUser` polling attempts to 3 (down from 5).
   - Introduces a randomized 3-6 second jitter delay between polling attempts to avoid static polling spikes that trigger automated anti-bot detection (related to onboarding issues #1214, #2666).

2. **Wildcard & Security Header Scrubbing (`internal/misc/header_utils.go`):**
   - Expands `ScrubProxyAndFingerprintHeaders` to dynamically strip all `X-Stainless-*` headers using case-insensitive prefix matching.
   - Explicitly removes `X-Fingerprint`, `X-Goog-Safety-Level`, and `X-Client-Trace-Id` to prevent client fingerprint leaks (related to header issues #1621, #3698).

### Rationale
- Static polling without jitter during onboarding can flag accounts under high traffic or automated client setups.
- Dynamic prefix scrubbing ensures present and future Stainless SDK headers are removed regardless of language or version suffix without requiring manual maintenance per header name.

### Verification
- `gofmt -w .` applied.
- `go test ./internal/auth/antigravity/... ./internal/misc/...` PASSED.
- `go build -o test-output ./cmd/server` compiled cleanly (Exit code 0).