### PR TITLE
fix(claude): prefer Retry-After over 7d_oi-Reset for Fable-only rate limits

### DIFF
--- a/internal/runtime/executor/claude_executor_fable_ratelimit_test.go
+++ b/internal/runtime/executor/claude_executor_fable_ratelimit_test.go
@@ -102,16 +102,21 @@ func TestClassifyClaudeUpstreamError_FableRetryDurationRemainsAvailable(t *testi
 		min, max time.Duration
 	}{
 		{
-			name: "7d_oi reset",
+			// A Fable-only rejection must not inherit the 7d_oi reset as its
+			// cooldown: that window can be a full week out and would strand the
+			// model even though only the Fable-specific window is exhausted.
+			// Retry-After stays authoritative when Anthropic supplies it.
+			name: "7d_oi reset prefers retry-after",
 			headers: http.Header{
 				"Anthropic-Ratelimit-Unified-Status":       []string{"rejected"},
 				"Anthropic-Ratelimit-Unified-5h-Status":    []string{"allowed"},
 				"Anthropic-Ratelimit-Unified-7d-Status":    []string{"allowed"},
 				"Anthropic-Ratelimit-Unified-7d_oi-Status": []string{"rejected"},
 				"Anthropic-Ratelimit-Unified-7d_oi-Reset":  []string{strconv.FormatInt(time.Now().Add(2*time.Hour).Unix(), 10)},
+				"Retry-After": []string{"120"},
 			},
-			min: 2*time.Hour - 5*time.Second,
-			max: 2*time.Hour + 35*time.Second,
+			min: 2 * time.Minute,
+			max: 2*time.Minute + 30*time.Second,
 		},
 		{
 			name: "retry-after",

--- a/internal/runtime/executor/helps/claude_ratelimit.go
+++ b/internal/runtime/executor/helps/claude_ratelimit.go
@@ -102,8 +102,14 @@ func parseClaudeRateLimitResetWithFuzz(headers http.Header, now time.Time, minFu
 		}
 	}
 
-	// 4. Fable-specific 7-day window reset (only when rejected)
-	if status7dOI == "rejected" {
+	// A Fable-only rejection leaves both shared windows explicitly allowed. Its
+	// 7d_oi reset lies up to a week out, so folding it into the shared candidate
+	// set would cool the model down for the whole Fable week even though only the
+	// Fable-specific window is exhausted. Prefer the Retry-After hint instead.
+	fableOnlyRejection := unifiedStatus == "rejected" && status5h == "allowed" && status7d == "allowed" && status7dOI == "rejected"
+
+	// 4. Fable-specific 7-day window reset (only when rejected and not Fable-only)
+	if status7dOI == "rejected" && !fableOnlyRejection {
 		if raw := getHeaderCaseInsensitive(headers, "Anthropic-Ratelimit-Unified-7d_oi-Reset"); raw != "" {
 			if t, ok := parseUnixOrTimestamp(raw); ok && t.After(now) {
 				candidateDeadlines = append(candidateDeadlines, t)
@@ -112,7 +118,8 @@ func parseClaudeRateLimitResetWithFuzz(headers http.Header, now time.Time, minFu
 	}
 
 	// 5. Unified reset header:
-	unifiedRejected := unifiedStatus == "rejected" || status5h == "rejected" || status7d == "rejected" || status7dOI == "rejected" ||
+	unifiedRejected := (unifiedStatus == "rejected" && !fableOnlyRejection) || status5h == "rejected" || status7d == "rejected" ||
+		(status7dOI == "rejected" && !fableOnlyRejection) ||
 		(unifiedStatus == "" && status5h != "allowed" && status7d != "allowed")
 
 	if unifiedRejected {


### PR DESCRIPTION
## Problem

Closes #5101.

On v7.2.137, exhausting the Fable-specific usage window (`claude-fable-5`) puts the model state into a quota-exceeded cooldown of up to seven days, even though both shared Anthropic windows (5h and 7d) are reported as `allowed`.

Observed upstream headers:

```
Anthropic-Ratelimit-Unified-Status: rejected
Anthropic-Ratelimit-Unified-5h-Status: allowed
Anthropic-Ratelimit-Unified-7d-Status: allowed
Anthropic-Ratelimit-Unified-7d_oi-Status: rejected
Anthropic-Ratelimit-Unified-7d_oi-Reset: <up to 7 days out>
```

Commit a8f9814a fixed the *scope* half (the rejection is correctly classified as model-scoped, not credential-scoped) but not the *cooldown duration* half:

1. `internal/runtime/executor/claude_executor_request.go:296-297` unconditionally calls `ParseClaudeRateLimitReset`.
2. `internal/runtime/executor/helps/claude_ratelimit.go:106-112` folds `7d_oi-Reset` into `candidateDeadlines`, and lines 139-145 pick the *latest* candidate — yielding a retryAfter of up to seven days.
3. That retryAfter reaches `sdk/cliproxy/auth/conductor_cooldown.go:825-844`, where the 429 branch sets `next = now.Add(*result.RetryAfter)` and `state.Quota = QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: next}`.

Additionally `claude_ratelimit.go:115-116` included `status7dOI == "rejected"` in `unifiedRejected`, which also pulled the shared `Unified-Reset` into the candidate set.

## Change

- Detects the Fable-only rejection pattern (`unified=rejected, 5h=allowed, 7d=allowed, 7d_oi=rejected`).
- Excludes `7d_oi-Reset` and the shared `Unified-Reset` from the deadline candidates in that case.
- Lets `Retry-After` (typically seconds to minutes) drive the cooldown instead, so the model slot recovers promptly.
- Updates `TestClassifyClaudeUpstreamError_FableRetryDurationRemainsAvailable` to assert the Retry-After-based duration; a retry duration is still always present, so the existing contract holds.

## Verification

```
gofmt -w .
go test ./internal/runtime/executor/... -run 'Fable' # ok
go build -o test-output ./cmd/server && rm test-output # ok
```

Note: three pre-existing `X-Stainless-Os` test failures in `internal/runtime/executor` are present on `main` as well and are unrelated to this change.