### PR TITLE
fix(auth): retain session affinity on transient errors

### DIFF
--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -610,8 +610,9 @@ func availabilityBlock(unavailable, quotaExceeded bool, nextRetryAfter, nextReco
 // It extracts session ID from multiple sources and maintains session-to-auth
 // mappings with automatic failover when the bound auth becomes unavailable.
 type SessionAffinitySelector struct {
-	fallback Selector
-	cache    *SessionCache
+	fallback      Selector
+	cache         *SessionCache
+	fallbackCache *SessionCache
 }
 
 // SessionAffinityConfig configures the session affinity selector.
@@ -637,8 +638,9 @@ func NewSessionAffinitySelectorWithConfig(cfg SessionAffinityConfig) *SessionAff
 		cfg.TTL = time.Hour
 	}
 	return &SessionAffinitySelector{
-		fallback: cfg.Fallback,
-		cache:    NewSessionCache(cfg.TTL),
+		fallback:      cfg.Fallback,
+		cache:         NewSessionCache(cfg.TTL),
+		fallbackCache: NewSessionCache(cfg.TTL),
 	}
 }
 
@@ -698,20 +700,15 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		s.cache.Set(cacheKey, authID)
 	}
 
-	tempFallbackKey := cacheKey + "::fallback"
-	var tempFallbackKeyFallback string
-	if fallbackKey != "" {
-		tempFallbackKeyFallback = fallbackKey + "::fallback"
-	}
 	collectTempFallbackKeys := func() []string {
-		keys := []string{tempFallbackKey}
-		if tempFallbackKeyFallback != "" {
-			keys = append(keys, tempFallbackKeyFallback)
+		keys := []string{cacheKey}
+		if fallbackKey != "" {
+			keys = append(keys, fallbackKey)
 		}
 		if aliases := s.cache.Aliases(cacheKey); len(aliases) > 0 {
 			for _, alias := range aliases {
 				if alias != "" {
-					keys = append(keys, alias+"::fallback")
+					keys = append(keys, alias)
 				}
 			}
 		}
@@ -719,7 +716,7 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 			if aliases := s.cache.Aliases(fallbackKey); len(aliases) > 0 {
 				for _, alias := range aliases {
 					if alias != "" {
-						keys = append(keys, alias+"::fallback")
+						keys = append(keys, alias)
 					}
 				}
 			}
@@ -727,16 +724,23 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		return keys
 	}
 	bindTempFallback := func(authID string) {
-		s.cache.SetAliases(authID, collectTempFallbackKeys()...)
+		if s.fallbackCache != nil {
+			s.fallbackCache.SetAliases(authID, collectTempFallbackKeys()...)
+		}
 	}
 	invalidateTempFallback := func() {
-		for _, key := range collectTempFallbackKeys() {
-			s.cache.Invalidate(key)
+		if s.fallbackCache != nil {
+			for _, key := range collectTempFallbackKeys() {
+				s.fallbackCache.Invalidate(key)
+			}
 		}
 	}
 	getTempFallbackAuth := func() (*Auth, bool) {
+		if s.fallbackCache == nil {
+			return nil, false
+		}
 		for _, key := range collectTempFallbackKeys() {
-			if tempAuthID, ok := s.cache.GetAndRefresh(key); ok {
+			if tempAuthID, ok := s.fallbackCache.GetAndRefresh(key); ok {
 				for _, auth := range available {
 					if auth.ID == tempAuthID {
 						return auth, true
@@ -828,6 +832,9 @@ func (s *SessionAffinitySelector) Stop() {
 	if s.cache != nil {
 		s.cache.Stop()
 	}
+	if s.fallbackCache != nil {
+		s.fallbackCache.Stop()
+	}
 }
 
 // InvalidateAuth removes all session bindings for a specific auth.
@@ -835,6 +842,9 @@ func (s *SessionAffinitySelector) Stop() {
 func (s *SessionAffinitySelector) InvalidateAuth(authID string) {
 	if s.cache != nil {
 		s.cache.InvalidateAuth(authID)
+	}
+	if s.fallbackCache != nil {
+		s.fallbackCache.InvalidateAuth(authID)
 	}
 }
 
@@ -858,21 +868,19 @@ func (s *SessionAffinitySelector) OnResult(res Result) {
 	}
 
 	cacheKey := ns + "::" + primaryID + "::" + nsModel
-	tempFallbackKey := cacheKey + "::fallback"
-	var fallbackKey, tempFallbackKeyFallback string
+	var fallbackKey string
 	if fallbackID != "" && fallbackID != primaryID {
 		fallbackKey = ns + "::" + fallbackID + "::" + nsModel
-		tempFallbackKeyFallback = fallbackKey + "::fallback"
 	}
 	collectResultTempFallbackKeys := func() []string {
-		keys := []string{tempFallbackKey}
-		if tempFallbackKeyFallback != "" {
-			keys = append(keys, tempFallbackKeyFallback)
+		keys := []string{cacheKey}
+		if fallbackKey != "" {
+			keys = append(keys, fallbackKey)
 		}
 		if aliases := s.cache.Aliases(cacheKey); len(aliases) > 0 {
 			for _, alias := range aliases {
 				if alias != "" {
-					keys = append(keys, alias+"::fallback")
+					keys = append(keys, alias)
 				}
 			}
 		}
@@ -880,7 +888,7 @@ func (s *SessionAffinitySelector) OnResult(res Result) {
 			if aliases := s.cache.Aliases(fallbackKey); len(aliases) > 0 {
 				for _, alias := range aliases {
 					if alias != "" {
-						keys = append(keys, alias+"::fallback")
+						keys = append(keys, alias)
 					}
 				}
 			}
@@ -892,8 +900,10 @@ func (s *SessionAffinitySelector) OnResult(res Result) {
 		if fallbackKey != "" {
 			s.cache.Touch(fallbackKey, res.AuthID)
 		}
-		for _, tk := range collectResultTempFallbackKeys() {
-			s.cache.Touch(tk, res.AuthID)
+		if s.fallbackCache != nil {
+			for _, tk := range collectResultTempFallbackKeys() {
+				s.fallbackCache.Touch(tk, res.AuthID)
+			}
 		}
 		return
 	}
@@ -903,8 +913,10 @@ func (s *SessionAffinitySelector) OnResult(res Result) {
 		if fallbackKey != "" {
 			s.cache.CompareAndDelete(fallbackKey, res.AuthID)
 		}
-		for _, tk := range collectResultTempFallbackKeys() {
-			s.cache.CompareAndDelete(tk, res.AuthID)
+		if s.fallbackCache != nil {
+			for _, tk := range collectResultTempFallbackKeys() {
+				s.fallbackCache.CompareAndDelete(tk, res.AuthID)
+			}
 		}
 	}
 }

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -711,7 +711,6 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		if err != nil {
 			return nil, err
 		}
-		bind(auth.ID)
 		entry.Infof("session-affinity: cache hit but auth unavailable, reselected | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
 		return auth, nil
 	}
@@ -725,6 +724,12 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 					return auth, nil
 				}
 			}
+			auth, err := s.fallback.Pick(ctx, provider, model, opts, fallbackAuths)
+			if err != nil {
+				return nil, err
+			}
+			entry.Infof("session-affinity: fallback cache hit but auth unavailable, reselected | session=%s fallback=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model)
+			return auth, nil
 		}
 	}
 
@@ -802,13 +807,42 @@ func (s *SessionAffinitySelector) OnResult(res Result) {
 		return
 	}
 
-	if res.Error != nil && shouldSkipCredentialCooldown(res.Error) {
-		return
+	if res.Error != nil && isTerminalSessionAffinityError(res.Error) {
+		s.cache.CompareAndDelete(cacheKey, res.AuthID)
+		if fallbackKey != "" {
+			s.cache.CompareAndDelete(fallbackKey, res.AuthID)
+		}
 	}
+}
 
-	s.cache.CompareAndDelete(cacheKey, res.AuthID)
-	if fallbackKey != "" {
-		s.cache.CompareAndDelete(fallbackKey, res.AuthID)
+// isTerminalSessionAffinityError reports whether a failure represents a permanent
+// credential or authorization rejection (such as an invalid API key, revoked grant,
+// depleted balance, or unsupported model on the account) that warrants purging
+// the long-lived session binding from cache. Transient errors (5xx, 429, timeouts,
+// cloudflare challenge) retain affinity so the session returns to its warm prompt
+// cache once the cooldown or rate limit clears.
+func isTerminalSessionAffinityError(err *Error) bool {
+	if err == nil {
+		return false
+	}
+	if shouldSkipCredentialCooldown(err) {
+		return false
+	}
+	if isInvalidGrantResultError(err) || isModelSupportResultError(err) {
+		return true
+	}
+	if isCloudflareChallengeResultError(err) {
+		return false
+	}
+	statusCode := statusCodeFromResult(err)
+	switch statusCode {
+	case http.StatusUnauthorized,   // 401: invalid API key / unauthorized
+		http.StatusPaymentRequired, // 402: insufficient balance / credits depleted
+		http.StatusForbidden,       // 403: account banned / forbidden
+		http.StatusNotFound:        // 404: model not found / unsupported for account
+		return true
+	default:
+		return false
 	}
 }
 

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -698,37 +698,61 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		s.cache.Set(cacheKey, authID)
 	}
 
+	tempFallbackKey := cacheKey + "::fallback"
 	if cachedAuthID, ok := s.cache.GetAndRefresh(cacheKey); ok {
 		for _, auth := range available {
 			if auth.ID == cachedAuthID {
+				s.cache.Invalidate(tempFallbackKey)
 				bind(auth.ID)
 				entry.Infof("session-affinity: cache hit | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
 				return auth, nil
 			}
 		}
-		// Cached auth not available, reselect via fallback selector for even distribution
+		// Primary cached auth is unavailable (cooling down).
+		// Check for an active sticky temporary fallback binding:
+		if tempAuthID, ok := s.cache.GetAndRefresh(tempFallbackKey); ok {
+			for _, auth := range available {
+				if auth.ID == tempAuthID {
+					entry.Infof("session-affinity: sticky fallback cache hit | session=%s primary_cooling=%s fallback_auth=%s provider=%s model=%s", truncateSessionID(primaryID), cachedAuthID, auth.ID, provider, model)
+					return auth, nil
+				}
+			}
+		}
+		// Reselect fallback auth and record it as the sticky temporary fallback
 		auth, err := s.fallback.Pick(ctx, provider, model, opts, fallbackAuths)
 		if err != nil {
 			return nil, err
 		}
-		entry.Infof("session-affinity: cache hit but auth unavailable, reselected | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
+		s.cache.Set(tempFallbackKey, auth.ID)
+		entry.Infof("session-affinity: cache hit but auth unavailable, reselected sticky fallback | session=%s primary_cooling=%s fallback_auth=%s provider=%s model=%s", truncateSessionID(primaryID), cachedAuthID, auth.ID, provider, model)
 		return auth, nil
 	}
 
 	if fallbackKey != "" {
+		tempFallbackKeyFallback := fallbackKey + "::fallback"
 		if cachedAuthID, ok := s.cache.Get(fallbackKey); ok {
 			for _, auth := range available {
 				if auth.ID == cachedAuthID {
+					s.cache.Invalidate(tempFallbackKeyFallback)
 					bind(auth.ID)
 					entry.Infof("session-affinity: fallback cache hit | session=%s fallback=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model)
 					return auth, nil
+				}
+			}
+			if tempAuthID, ok := s.cache.GetAndRefresh(tempFallbackKeyFallback); ok {
+				for _, auth := range available {
+					if auth.ID == tempAuthID {
+						entry.Infof("session-affinity: sticky secondary fallback cache hit | session=%s fallback=%s temp_auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model)
+						return auth, nil
+					}
 				}
 			}
 			auth, err := s.fallback.Pick(ctx, provider, model, opts, fallbackAuths)
 			if err != nil {
 				return nil, err
 			}
-			entry.Infof("session-affinity: fallback cache hit but auth unavailable, reselected | session=%s fallback=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model)
+			s.cache.Set(tempFallbackKeyFallback, auth.ID)
+			entry.Infof("session-affinity: fallback cache hit but auth unavailable, reselected sticky fallback | session=%s fallback=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model)
 			return auth, nil
 		}
 	}
@@ -795,22 +819,28 @@ func (s *SessionAffinitySelector) OnResult(res Result) {
 	}
 
 	cacheKey := ns + "::" + primaryID + "::" + nsModel
-	var fallbackKey string
+	tempFallbackKey := cacheKey + "::fallback"
+	var fallbackKey, tempFallbackKeyFallback string
 	if fallbackID != "" && fallbackID != primaryID {
 		fallbackKey = ns + "::" + fallbackID + "::" + nsModel
+		tempFallbackKeyFallback = fallbackKey + "::fallback"
 	}
 	if res.Success {
 		s.cache.Touch(cacheKey, res.AuthID)
+		s.cache.Touch(tempFallbackKey, res.AuthID)
 		if fallbackKey != "" {
 			s.cache.Touch(fallbackKey, res.AuthID)
+			s.cache.Touch(tempFallbackKeyFallback, res.AuthID)
 		}
 		return
 	}
 
 	if res.Error != nil && isTerminalSessionAffinityError(res.Error) {
 		s.cache.CompareAndDelete(cacheKey, res.AuthID)
+		s.cache.CompareAndDelete(tempFallbackKey, res.AuthID)
 		if fallbackKey != "" {
 			s.cache.CompareAndDelete(fallbackKey, res.AuthID)
+			s.cache.CompareAndDelete(tempFallbackKeyFallback, res.AuthID)
 		}
 	}
 }

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -942,7 +942,7 @@ func isTerminalSessionAffinityError(err *Error) bool {
 	}
 	statusCode := statusCodeFromResult(err)
 	switch statusCode {
-	case http.StatusUnauthorized,   // 401: invalid API key / unauthorized
+	case http.StatusUnauthorized, // 401: invalid API key / unauthorized
 		http.StatusPaymentRequired, // 402: insufficient balance / credits depleted
 		http.StatusForbidden,       // 403: account banned / forbidden
 		http.StatusNotFound:        // 404: model not found / unsupported for account

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -699,10 +699,58 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	}
 
 	tempFallbackKey := cacheKey + "::fallback"
+	var tempFallbackKeyFallback string
+	if fallbackKey != "" {
+		tempFallbackKeyFallback = fallbackKey + "::fallback"
+	}
+	collectTempFallbackKeys := func() []string {
+		keys := []string{tempFallbackKey}
+		if tempFallbackKeyFallback != "" {
+			keys = append(keys, tempFallbackKeyFallback)
+		}
+		if aliases := s.cache.Aliases(cacheKey); len(aliases) > 0 {
+			for _, alias := range aliases {
+				if alias != "" {
+					keys = append(keys, alias+"::fallback")
+				}
+			}
+		}
+		if fallbackKey != "" {
+			if aliases := s.cache.Aliases(fallbackKey); len(aliases) > 0 {
+				for _, alias := range aliases {
+					if alias != "" {
+						keys = append(keys, alias+"::fallback")
+					}
+				}
+			}
+		}
+		return keys
+	}
+	bindTempFallback := func(authID string) {
+		s.cache.SetAliases(authID, collectTempFallbackKeys()...)
+	}
+	invalidateTempFallback := func() {
+		for _, key := range collectTempFallbackKeys() {
+			s.cache.Invalidate(key)
+		}
+	}
+	getTempFallbackAuth := func() (*Auth, bool) {
+		for _, key := range collectTempFallbackKeys() {
+			if tempAuthID, ok := s.cache.GetAndRefresh(key); ok {
+				for _, auth := range available {
+					if auth.ID == tempAuthID {
+						return auth, true
+					}
+				}
+			}
+		}
+		return nil, false
+	}
+
 	if cachedAuthID, ok := s.cache.GetAndRefresh(cacheKey); ok {
 		for _, auth := range available {
 			if auth.ID == cachedAuthID {
-				s.cache.Invalidate(tempFallbackKey)
+				invalidateTempFallback()
 				bind(auth.ID)
 				entry.Infof("session-affinity: cache hit | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
 				return auth, nil
@@ -710,48 +758,39 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		}
 		// Primary cached auth is unavailable (cooling down).
 		// Check for an active sticky temporary fallback binding:
-		if tempAuthID, ok := s.cache.GetAndRefresh(tempFallbackKey); ok {
-			for _, auth := range available {
-				if auth.ID == tempAuthID {
-					entry.Infof("session-affinity: sticky fallback cache hit | session=%s primary_cooling=%s fallback_auth=%s provider=%s model=%s", truncateSessionID(primaryID), cachedAuthID, auth.ID, provider, model)
-					return auth, nil
-				}
-			}
+		if fallbackAuth, ok := getTempFallbackAuth(); ok {
+			entry.Infof("session-affinity: sticky fallback cache hit | session=%s primary_cooling=%s fallback_auth=%s provider=%s model=%s", truncateSessionID(primaryID), cachedAuthID, fallbackAuth.ID, provider, model)
+			return fallbackAuth, nil
 		}
-		// Reselect fallback auth and record it as the sticky temporary fallback
+		// Reselect fallback auth and record it as the sticky temporary fallback across aliases
 		auth, err := s.fallback.Pick(ctx, provider, model, opts, fallbackAuths)
 		if err != nil {
 			return nil, err
 		}
-		s.cache.Set(tempFallbackKey, auth.ID)
+		bindTempFallback(auth.ID)
 		entry.Infof("session-affinity: cache hit but auth unavailable, reselected sticky fallback | session=%s primary_cooling=%s fallback_auth=%s provider=%s model=%s", truncateSessionID(primaryID), cachedAuthID, auth.ID, provider, model)
 		return auth, nil
 	}
 
 	if fallbackKey != "" {
-		tempFallbackKeyFallback := fallbackKey + "::fallback"
 		if cachedAuthID, ok := s.cache.Get(fallbackKey); ok {
 			for _, auth := range available {
 				if auth.ID == cachedAuthID {
-					s.cache.Invalidate(tempFallbackKeyFallback)
+					invalidateTempFallback()
 					bind(auth.ID)
 					entry.Infof("session-affinity: fallback cache hit | session=%s fallback=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model)
 					return auth, nil
 				}
 			}
-			if tempAuthID, ok := s.cache.GetAndRefresh(tempFallbackKeyFallback); ok {
-				for _, auth := range available {
-					if auth.ID == tempAuthID {
-						entry.Infof("session-affinity: sticky secondary fallback cache hit | session=%s fallback=%s temp_auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model)
-						return auth, nil
-					}
-				}
+			if fallbackAuth, ok := getTempFallbackAuth(); ok {
+				entry.Infof("session-affinity: sticky secondary fallback cache hit | session=%s fallback=%s temp_auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), fallbackAuth.ID, provider, model)
+				return fallbackAuth, nil
 			}
 			auth, err := s.fallback.Pick(ctx, provider, model, opts, fallbackAuths)
 			if err != nil {
 				return nil, err
 			}
-			s.cache.Set(tempFallbackKeyFallback, auth.ID)
+			bindTempFallback(auth.ID)
 			entry.Infof("session-affinity: fallback cache hit but auth unavailable, reselected sticky fallback | session=%s fallback=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model)
 			return auth, nil
 		}
@@ -825,22 +864,47 @@ func (s *SessionAffinitySelector) OnResult(res Result) {
 		fallbackKey = ns + "::" + fallbackID + "::" + nsModel
 		tempFallbackKeyFallback = fallbackKey + "::fallback"
 	}
+	collectResultTempFallbackKeys := func() []string {
+		keys := []string{tempFallbackKey}
+		if tempFallbackKeyFallback != "" {
+			keys = append(keys, tempFallbackKeyFallback)
+		}
+		if aliases := s.cache.Aliases(cacheKey); len(aliases) > 0 {
+			for _, alias := range aliases {
+				if alias != "" {
+					keys = append(keys, alias+"::fallback")
+				}
+			}
+		}
+		if fallbackKey != "" {
+			if aliases := s.cache.Aliases(fallbackKey); len(aliases) > 0 {
+				for _, alias := range aliases {
+					if alias != "" {
+						keys = append(keys, alias+"::fallback")
+					}
+				}
+			}
+		}
+		return keys
+	}
 	if res.Success {
 		s.cache.Touch(cacheKey, res.AuthID)
-		s.cache.Touch(tempFallbackKey, res.AuthID)
 		if fallbackKey != "" {
 			s.cache.Touch(fallbackKey, res.AuthID)
-			s.cache.Touch(tempFallbackKeyFallback, res.AuthID)
+		}
+		for _, tk := range collectResultTempFallbackKeys() {
+			s.cache.Touch(tk, res.AuthID)
 		}
 		return
 	}
 
 	if res.Error != nil && isTerminalSessionAffinityError(res.Error) {
 		s.cache.CompareAndDelete(cacheKey, res.AuthID)
-		s.cache.CompareAndDelete(tempFallbackKey, res.AuthID)
 		if fallbackKey != "" {
 			s.cache.CompareAndDelete(fallbackKey, res.AuthID)
-			s.cache.CompareAndDelete(tempFallbackKeyFallback, res.AuthID)
+		}
+		for _, tk := range collectResultTempFallbackKeys() {
+			s.cache.CompareAndDelete(tk, res.AuthID)
 		}
 	}
 }

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -821,7 +821,7 @@ func TestSessionAffinitySelector_ThinkingSuffixVariantsPreserveBindingAndRelease
 		t.Fatalf("third Pick() auth.ID = %q, want %q (thinking suffix variant should keep session stickiness)", third.ID, first.ID)
 	}
 
-	// Failure on a thinking-suffix variant (with explicit metadata) should properly release the session binding
+	// Terminal failure on a thinking-suffix variant (with explicit metadata) should properly release the session binding
 	optsWithMetadata := cliproxyexecutor.Options{
 		OriginalRequest: payload,
 		Metadata: map[string]any{
@@ -834,7 +834,7 @@ func TestSessionAffinitySelector_ThinkingSuffixVariantsPreserveBindingAndRelease
 		Model:    "claude-sonnet-4-5(high)",
 		AuthID:   first.ID,
 		Success:  false,
-		Error:    &Error{Code: "rate_limited", Message: "rate limited"},
+		Error:    &Error{Code: "unauthorized", HTTPStatus: http.StatusUnauthorized, Message: "invalid api key"},
 		Options:  optsWithMetadata,
 	})
 
@@ -879,10 +879,21 @@ func TestSessionAffinitySelector_WeightedBindingRebindsAfterWeightBecomesZero(t 
 	authA.Attributes[AttributeWeight] = "10"
 	third, errThird := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
 	if errThird != nil {
-		t.Fatalf("Pick() after rebind error = %v", errThird)
+		t.Fatalf("Pick() after weight restored error = %v", errThird)
 	}
-	if third.ID != authB.ID {
-		t.Fatalf("Pick() after rebind auth.ID = %q, want sticky auth %q", third.ID, authB.ID)
+	if third.ID != authA.ID {
+		t.Fatalf("Pick() after weight restored auth.ID = %q, want original bound auth %q", third.ID, authA.ID)
+	}
+
+	// When authA is invalidated while remaining weight 0, session permanently rebinds to authB
+	authA.Attributes[AttributeWeight] = "0"
+	selector.InvalidateAuth(authA.ID)
+	fourth, errFourth := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+	if errFourth != nil {
+		t.Fatalf("Pick() after invalidation error = %v", errFourth)
+	}
+	if fourth.ID != authB.ID {
+		t.Fatalf("Pick() after invalidation auth.ID = %q, want %q", fourth.ID, authB.ID)
 	}
 }
 
@@ -1003,7 +1014,7 @@ func TestSessionAffinitySelector_FailoverWhenAuthUnavailable(t *testing.T) {
 		t.Fatalf("Pick() error = %v", err)
 	}
 
-	// Remove the bound auth from available list (simulating rate limit)
+	// Remove the bound auth from available list (simulating rate limit / transient exclusion)
 	availableWithoutFirst := make([]*Auth, 0, len(auths)-1)
 	for _, a := range auths {
 		if a.ID != first.ID {
@@ -1011,7 +1022,7 @@ func TestSessionAffinitySelector_FailoverWhenAuthUnavailable(t *testing.T) {
 		}
 	}
 
-	// With failover enabled, should pick a new auth
+	// While original auth is temporarily unavailable, should pick a fallback auth
 	second, err := selector.Pick(context.Background(), "claude", "claude-3", opts, availableWithoutFirst)
 	if err != nil {
 		t.Fatalf("Pick() after failover error = %v", err)
@@ -1020,11 +1031,28 @@ func TestSessionAffinitySelector_FailoverWhenAuthUnavailable(t *testing.T) {
 		t.Fatalf("Pick() after failover returned same auth %q, expected different", first.ID)
 	}
 
-	// Subsequent picks should consistently return the new binding
+	// When original bound auth becomes available again, affinity is retained (returns to warm cache)
+	recovered, errRecovered := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+	if errRecovered != nil {
+		t.Fatalf("Pick() after recovery error = %v", errRecovered)
+	}
+	if recovered.ID != first.ID {
+		t.Fatalf("Pick() after recovery = %q, want original bound auth %q", recovered.ID, first.ID)
+	}
+
+	// When original auth is explicitly invalidated (permanent failover), session rebinds
+	selector.InvalidateAuth(first.ID)
+	third, errThird := selector.Pick(context.Background(), "claude", "claude-3", opts, availableWithoutFirst)
+	if errThird != nil {
+		t.Fatalf("Pick() after invalidation error = %v", errThird)
+	}
+	if third.ID == first.ID {
+		t.Fatalf("Pick() after invalidation returned invalidated auth %q", first.ID)
+	}
 	for i := 0; i < 5; i++ {
 		got, _ := selector.Pick(context.Background(), "claude", "claude-3", opts, availableWithoutFirst)
-		if got.ID != second.ID {
-			t.Fatalf("Pick() #%d after failover inconsistent: got %q, want %q", i, got.ID, second.ID)
+		if got.ID != third.ID {
+			t.Fatalf("Pick() #%d after permanent rebind inconsistent: got %q, want %q", i, got.ID, third.ID)
 		}
 	}
 }

--- a/sdk/cliproxy/auth/session_affinity_metadata_test.go
+++ b/sdk/cliproxy/auth/session_affinity_metadata_test.go
@@ -19,11 +19,11 @@ type failExecutor struct {
 func (e *failExecutor) Identifier() string { return e.provider }
 func (e *failExecutor) Execute(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	e.calls.Add(1)
-	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusInternalServerError, Message: "upstream failure"}
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusUnauthorized, Message: "invalid api key"}
 }
 func (e *failExecutor) ExecuteStream(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
 	e.calls.Add(1)
-	return nil, &Error{HTTPStatus: http.StatusInternalServerError, Message: "upstream failure"}
+	return nil, &Error{HTTPStatus: http.StatusUnauthorized, Message: "invalid api key"}
 }
 func (e *failExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) { return auth, nil }
 func (e *failExecutor) CountTokens(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
@@ -252,7 +252,7 @@ func TestSessionAffinityOnResultWithMismatchedNamespaceFailsToUnbind(t *testing.
 		Provider: "gemini", // actual provider
 		Model:    model,
 		Success:  false,
-		Error:    &Error{HTTPStatus: http.StatusInternalServerError},
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "invalid api key"},
 		Options: cliproxyexecutor.Options{
 			Headers: http.Header{"X-Session-Id": []string{"sess-ns-1"}},
 			Metadata: map[string]any{

--- a/sdk/cliproxy/auth/session_affinity_priority_test.go
+++ b/sdk/cliproxy/auth/session_affinity_priority_test.go
@@ -91,8 +91,8 @@ func TestManagerSessionAffinityPreservesBindingAcrossHigherPriorityRecovery(t *t
 			}
 
 			expireSessionAffinityPriorityModelCooldown(t, manager, highID, model)
-			if got := pick(opts); got.ID != lowID {
-				t.Fatalf("binding after higher-priority recovery = %q, want sticky %q", got.ID, lowID)
+			if got := pick(opts); got.ID != highID {
+				t.Fatalf("binding after higher-priority recovery = %q, want recovered original %q", got.ID, highID)
 			}
 
 			newSessionOpts := cliproxyexecutor.Options{Metadata: map[string]any{

--- a/sdk/cliproxy/auth/session_affinity_retention_test.go
+++ b/sdk/cliproxy/auth/session_affinity_retention_test.go
@@ -780,7 +780,6 @@ func TestSessionAffinity_StickyTemporaryFallbackSecondaryBranch(t *testing.T) {
 	}
 }
 
-
 func TestSessionAffinity_ModelFallbackSuffixDoesNotCollideWithTemporaryFallback(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/cliproxy/auth/session_affinity_retention_test.go
+++ b/sdk/cliproxy/auth/session_affinity_retention_test.go
@@ -623,3 +623,159 @@ func TestSessionAffinity_StickyTemporaryFallbackTTLExpiry(t *testing.T) {
 		t.Fatal("fallback Pick() after TTL returned nil")
 	}
 }
+
+func TestSessionAffinity_StickyTemporaryFallbackSharedAcrossAliases(t *testing.T) {
+	t.Parallel()
+
+	fallback := &RoundRobinSelector{}
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: fallback,
+		TTL:      time.Hour,
+	})
+	defer selector.Stop()
+
+	authA := &Auth{ID: "auth-a"}
+	authB := &Auth{ID: "auth-b"}
+	authC := &Auth{ID: "auth-c"}
+	allAuths := []*Auth{authA, authB, authC}
+
+	// Payload with both prompt_cache_key (primary) and conversation.id (fallback alias)
+	payloadBoth := []byte(`{"prompt_cache_key":"pck-shared-test","conversation":{"id":"conv-shared-test"}}`)
+	optsBoth := cliproxyexecutor.Options{OriginalRequest: payloadBoth}
+
+	// Payload with ONLY conversation.id (the alias)
+	payloadConvOnly := []byte(`{"conversation":{"id":"conv-shared-test"}}`)
+	optsConvOnly := cliproxyexecutor.Options{OriginalRequest: payloadConvOnly}
+
+	// Payload with ONLY prompt_cache_key (the primary)
+	payloadPckOnly := []byte(`{"prompt_cache_key":"pck-shared-test"}`)
+	optsPckOnly := cliproxyexecutor.Options{OriginalRequest: payloadPckOnly}
+
+	// 1. Initial request with both aliases establishes binding to auth-a on both
+	first, err := selector.Pick(context.Background(), "claude", "claude-3", optsBoth, allAuths)
+	if err != nil {
+		t.Fatalf("initial Pick() error = %v", err)
+	}
+	if first.ID != "auth-a" {
+		t.Fatalf("initial Pick() = %q, want auth-a", first.ID)
+	}
+	selector.OnResult(Result{AuthID: first.ID, Provider: "claude", Model: "claude-3", Options: optsBoth, Success: true})
+
+	// 2. Primary auth-a cools down (only auth-b and auth-c available)
+	coolingAuths := []*Auth{authB, authC}
+
+	// Request under optsBoth selects fallback (e.g. auth-c) and must bind temp fallback to BOTH aliases
+	fallback1, err := selector.Pick(context.Background(), "claude", "claude-3", optsBoth, coolingAuths)
+	if err != nil {
+		t.Fatalf("first fallback Pick() error = %v", err)
+	}
+	expectedFallbackID := fallback1.ID
+
+	// 3. Subsequent request identifying the SAME session via conversation alias ONLY
+	// Must hit the sticky temporary fallback (expectedFallbackID) rather than alternating via round-robin to another auth!
+	gotConv, errConv := selector.Pick(context.Background(), "claude", "claude-3", optsConvOnly, coolingAuths)
+	if errConv != nil {
+		t.Fatalf("Pick() with conversation alias error = %v", errConv)
+	}
+	if gotConv.ID != expectedFallbackID {
+		t.Fatalf("Pick() with conversation alias = %q, want sticky fallback %q (temporary fallback must be shared across aliases)", gotConv.ID, expectedFallbackID)
+	}
+
+	// 4. Subsequent request identifying the session via prompt_cache_key ONLY
+	gotPck, errPck := selector.Pick(context.Background(), "claude", "claude-3", optsPckOnly, coolingAuths)
+	if errPck != nil {
+		t.Fatalf("Pick() with pck alias error = %v", errPck)
+	}
+	if gotPck.ID != expectedFallbackID {
+		t.Fatalf("Pick() with pck alias = %q, want sticky fallback %q", gotPck.ID, expectedFallbackID)
+	}
+
+	// 5. Primary auth-a recovers: request under either alias returns auth-a and clears temporary fallbacks
+	recoveredConv, errRecConv := selector.Pick(context.Background(), "claude", "claude-3", optsConvOnly, allAuths)
+	if errRecConv != nil {
+		t.Fatalf("recovered Pick(conv) error = %v", errRecConv)
+	}
+	if recoveredConv.ID != "auth-a" {
+		t.Fatalf("recovered Pick(conv) = %q, want primary %q", recoveredConv.ID, "auth-a")
+	}
+
+	recoveredPck, errRecPck := selector.Pick(context.Background(), "claude", "claude-3", optsPckOnly, allAuths)
+	if errRecPck != nil {
+		t.Fatalf("recovered Pick(pck) error = %v", errRecPck)
+	}
+	if recoveredPck.ID != "auth-a" {
+		t.Fatalf("recovered Pick(pck) = %q, want primary %q", recoveredPck.ID, "auth-a")
+	}
+}
+
+func TestSessionAffinity_StickyTemporaryFallbackSecondaryBranch(t *testing.T) {
+	t.Parallel()
+
+	fallback := &RoundRobinSelector{}
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: fallback,
+		TTL:      time.Hour,
+	})
+	defer selector.Stop()
+
+	authA := &Auth{ID: "auth-a"}
+	authB := &Auth{ID: "auth-b"}
+	authC := &Auth{ID: "auth-c"}
+	allAuths := []*Auth{authA, authB, authC}
+
+	payloadBoth := []byte(`{"prompt_cache_key":"pck-sec-branch","conversation":{"id":"conv-sec-branch"}}`)
+	optsBoth := cliproxyexecutor.Options{OriginalRequest: payloadBoth}
+
+	payloadConvOnly := []byte(`{"conversation":{"id":"conv-sec-branch"}}`)
+	optsConvOnly := cliproxyexecutor.Options{OriginalRequest: payloadConvOnly}
+
+	payloadPckOnly := []byte(`{"prompt_cache_key":"pck-sec-branch"}`)
+	optsPckOnly := cliproxyexecutor.Options{OriginalRequest: payloadPckOnly}
+
+	// 1. Initial request binds both aliases to auth-a
+	first, err := selector.Pick(context.Background(), "claude", "claude-3", optsBoth, allAuths)
+	if err != nil {
+		t.Fatalf("initial Pick() error = %v", err)
+	}
+	if first.ID != "auth-a" {
+		t.Fatalf("initial Pick() = %q, want auth-a", first.ID)
+	}
+	selector.OnResult(Result{AuthID: first.ID, Provider: "claude", Model: "claude-3", Options: optsBoth, Success: true})
+
+	// 2. Primary auth-a cools down
+	coolingAuths := []*Auth{authB, authC}
+
+	// Request under conv alias ONLY initiates fallback pick (secondary fallback branch)
+	fallbackFromConv, err := selector.Pick(context.Background(), "claude", "claude-3", optsConvOnly, coolingAuths)
+	if err != nil {
+		t.Fatalf("fallback Pick from conv alias error = %v", err)
+	}
+	expectedFallbackID := fallbackFromConv.ID
+
+	// 3. Subsequent request under pck alias MUST return the same fallback
+	gotPck, errPck := selector.Pick(context.Background(), "claude", "claude-3", optsPckOnly, coolingAuths)
+	if errPck != nil {
+		t.Fatalf("Pick() with pck alias error = %v", errPck)
+	}
+	if gotPck.ID != expectedFallbackID {
+		t.Fatalf("Pick() with pck alias = %q, want %q", gotPck.ID, expectedFallbackID)
+	}
+
+	// 4. Subsequent request under both aliases MUST return the same fallback
+	gotBoth, errBoth := selector.Pick(context.Background(), "claude", "claude-3", optsBoth, coolingAuths)
+	if errBoth != nil {
+		t.Fatalf("Pick() with both aliases error = %v", errBoth)
+	}
+	if gotBoth.ID != expectedFallbackID {
+		t.Fatalf("Pick() with both aliases = %q, want %q", gotBoth.ID, expectedFallbackID)
+	}
+
+	// 5. Recovery of auth-a returns to auth-a under any alias
+	recovered, errRec := selector.Pick(context.Background(), "claude", "claude-3", optsBoth, allAuths)
+	if errRec != nil {
+		t.Fatalf("recovered Pick() error = %v", errRec)
+	}
+	if recovered.ID != "auth-a" {
+		t.Fatalf("recovered Pick() = %q, want %q", recovered.ID, "auth-a")
+	}
+}

--- a/sdk/cliproxy/auth/session_affinity_retention_test.go
+++ b/sdk/cliproxy/auth/session_affinity_retention_test.go
@@ -779,3 +779,85 @@ func TestSessionAffinity_StickyTemporaryFallbackSecondaryBranch(t *testing.T) {
 		t.Fatalf("recovered Pick() = %q, want %q", recovered.ID, "auth-a")
 	}
 }
+
+
+func TestSessionAffinity_ModelFallbackSuffixDoesNotCollideWithTemporaryFallback(t *testing.T) {
+	t.Parallel()
+
+	fallback := &RoundRobinSelector{}
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: fallback,
+		TTL:      time.Hour,
+	})
+	defer selector.Stop()
+
+	authA := &Auth{ID: "auth-a"}
+	authB := &Auth{ID: "auth-b"}
+	authC := &Auth{ID: "auth-c"}
+	allAuths := []*Auth{authA, authB, authC}
+
+	sessionID := "sess-fallback-suffix-collision"
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{"X-Session-Id": []string{sessionID}},
+	}
+
+	baseModel := "gpt-4"
+	suffixedModel := "gpt-4::fallback"
+
+	// 1. Establish binding for suffixedModel ("gpt-4::fallback") to auth-a
+	pickSuffixed1, err := selector.Pick(context.Background(), "openai", suffixedModel, opts, allAuths)
+	if err != nil {
+		t.Fatalf("initial pick for suffixed model error = %v", err)
+	}
+	if pickSuffixed1.ID != "auth-a" {
+		t.Fatalf("initial pick for suffixed model = %q, want auth-a", pickSuffixed1.ID)
+	}
+	selector.OnResult(Result{AuthID: pickSuffixed1.ID, Provider: "openai", Model: suffixedModel, Options: opts, Success: true})
+
+	// 2. Establish binding for baseModel ("gpt-4") to auth-b
+	pickBase1, err := selector.Pick(context.Background(), "openai", baseModel, opts, []*Auth{authB, authC})
+	if err != nil {
+		t.Fatalf("initial pick for base model error = %v", err)
+	}
+	if pickBase1.ID != "auth-b" {
+		t.Fatalf("initial pick for base model = %q, want auth-b", pickBase1.ID)
+	}
+	selector.OnResult(Result{AuthID: pickBase1.ID, Provider: "openai", Model: baseModel, Options: opts, Success: true})
+
+	// 3. Primary auth-b for baseModel cools down; temporary fallback for baseModel is selected as auth-c
+	coolingBaseAuths := []*Auth{authC}
+	pickBaseFallback, err := selector.Pick(context.Background(), "openai", baseModel, opts, coolingBaseAuths)
+	if err != nil {
+		t.Fatalf("fallback pick for base model error = %v", err)
+	}
+	if pickBaseFallback.ID != "auth-c" {
+		t.Fatalf("fallback pick for base model = %q, want auth-c", pickBaseFallback.ID)
+	}
+	selector.OnResult(Result{AuthID: pickBaseFallback.ID, Provider: "openai", Model: baseModel, Options: opts, Success: true})
+
+	// 4. Request for suffixedModel ("gpt-4::fallback") MUST NOT be overwritten or corrupted by baseModel's temporary fallback
+	pickSuffixed2, err := selector.Pick(context.Background(), "openai", suffixedModel, opts, allAuths)
+	if err != nil {
+		t.Fatalf("subsequent pick for suffixed model error = %v", err)
+	}
+	if pickSuffixed2.ID != "auth-a" {
+		t.Fatalf("subsequent pick for suffixed model = %q, want bound %q (must not collide with base model's temporary fallback)", pickSuffixed2.ID, "auth-a")
+	}
+
+	// 5. When baseModel's primary auth-b recovers, invalidating baseModel's temporary fallback MUST NOT purge suffixedModel's binding
+	recoveredBase, err := selector.Pick(context.Background(), "openai", baseModel, opts, allAuths)
+	if err != nil {
+		t.Fatalf("recovered pick for base model error = %v", err)
+	}
+	if recoveredBase.ID != "auth-b" {
+		t.Fatalf("recovered pick for base model = %q, want auth-b", recoveredBase.ID)
+	}
+
+	pickSuffixed3, err := selector.Pick(context.Background(), "openai", suffixedModel, opts, allAuths)
+	if err != nil {
+		t.Fatalf("pick for suffixed model after base recovery error = %v", err)
+	}
+	if pickSuffixed3.ID != "auth-a" {
+		t.Fatalf("pick for suffixed model after base recovery = %q, want bound %q (must not be purged when base model clears temporary fallback)", pickSuffixed3.ID, "auth-a")
+	}
+}

--- a/sdk/cliproxy/auth/session_affinity_retention_test.go
+++ b/sdk/cliproxy/auth/session_affinity_retention_test.go
@@ -484,3 +484,142 @@ func TestSessionAffinitySelector_OnResult_TransientVsTerminalClassification(t *t
 		})
 	}
 }
+
+func TestSessionAffinity_StickyTemporaryFallbackDuringPrimaryCooldown(t *testing.T) {
+	t.Parallel()
+
+	fallback := &RoundRobinSelector{}
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: fallback,
+		TTL:      time.Hour,
+	})
+	defer selector.Stop()
+
+	authA := &Auth{ID: "auth-a"}
+	authB := &Auth{ID: "auth-b"}
+	authC := &Auth{ID: "auth-c"}
+	allAuths := []*Auth{authA, authB, authC}
+
+	sessionID := "sess-sticky-fallback-test"
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{"X-Session-Id": []string{sessionID}},
+	}
+
+	// 1. Initial Pick: auth-a is picked and bound as primary
+	first, err := selector.Pick(context.Background(), "claude", "claude-3", opts, allAuths)
+	if err != nil {
+		t.Fatalf("initial Pick() error = %v", err)
+	}
+	if first.ID != "auth-a" {
+		t.Fatalf("initial Pick() = %q, want auth-a", first.ID)
+	}
+	selector.OnResult(Result{AuthID: first.ID, Provider: "claude", Model: "claude-3", Options: opts, Success: true})
+
+	// 2. Primary auth-a is cooling down (only auth-b and auth-c available)
+	coolingAuths := []*Auth{authB, authC}
+
+	// First pick during cooldown chooses a fallback auth (e.g. auth-b)
+	firstFallback, err := selector.Pick(context.Background(), "claude", "claude-3", opts, coolingAuths)
+	if err != nil {
+		t.Fatalf("first fallback Pick() error = %v", err)
+	}
+	firstFallbackID := firstFallback.ID
+
+	// 5 consecutive picks during cooldown MUST all return the exact same fallback auth (sticky, no round-robin wandering)
+	for i := 1; i <= 5; i++ {
+		got, errPick := selector.Pick(context.Background(), "claude", "claude-3", opts, coolingAuths)
+		if errPick != nil {
+			t.Fatalf("consecutive fallback Pick %d error = %v", i, errPick)
+		}
+		if got.ID != firstFallbackID {
+			t.Fatalf("consecutive fallback Pick %d = %q, want sticky %q (prevent round-robin wandering during cooldown)", i, got.ID, firstFallbackID)
+		}
+		selector.OnResult(Result{AuthID: got.ID, Provider: "claude", Model: "claude-3", Options: opts, Success: true})
+	}
+
+	// 3. Primary auth-a recovers (allAuths available again)
+	recovered, errRecover := selector.Pick(context.Background(), "claude", "claude-3", opts, allAuths)
+	if errRecover != nil {
+		t.Fatalf("recovered Pick() error = %v", errRecover)
+	}
+	if recovered.ID != "auth-a" {
+		t.Fatalf("recovered Pick() = %q, want primary %q", recovered.ID, "auth-a")
+	}
+
+	// 4. If primary auth-a cools down again, and first fallback auth (auth-b) ALSO fails/cools down:
+	onlyC := []*Auth{authC}
+	nextFallback, errNext := selector.Pick(context.Background(), "claude", "claude-3", opts, onlyC)
+	if errNext != nil {
+		t.Fatalf("fallback when B down Pick() error = %v", errNext)
+	}
+	if nextFallback.ID != "auth-c" {
+		t.Fatalf("fallback when B down = %q, want auth-c", nextFallback.ID)
+	}
+
+	// Subsequent picks stick to auth-c
+	for i := 1; i <= 3; i++ {
+		got, errPick := selector.Pick(context.Background(), "claude", "claude-3", opts, onlyC)
+		if errPick != nil {
+			t.Fatalf("subsequent fallback C Pick %d error = %v", i, errPick)
+		}
+		if got.ID != "auth-c" {
+			t.Fatalf("subsequent fallback C Pick %d = %q, want auth-c", i, got.ID)
+		}
+	}
+}
+
+func TestSessionAffinity_StickyTemporaryFallbackTTLExpiry(t *testing.T) {
+	t.Parallel()
+
+	shortTTL := 50 * time.Millisecond
+	fallback := &RoundRobinSelector{}
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: fallback,
+		TTL:      shortTTL,
+	})
+	defer selector.Stop()
+
+	authA := &Auth{ID: "auth-a"}
+	authB := &Auth{ID: "auth-b"}
+	authC := &Auth{ID: "auth-c"}
+	allAuths := []*Auth{authA, authB, authC}
+
+	sessionID := "sess-sticky-fallback-ttl"
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{"X-Session-Id": []string{sessionID}},
+	}
+
+	// 1. Initial binding to auth-a
+	_, err := selector.Pick(context.Background(), "claude", "claude-3", opts, allAuths)
+	if err != nil {
+		t.Fatalf("initial Pick() error = %v", err)
+	}
+
+	// 2. Primary cooling down, pick fallback
+	coolingAuths := []*Auth{authB, authC}
+	fb1, err := selector.Pick(context.Background(), "claude", "claude-3", opts, coolingAuths)
+	if err != nil {
+		t.Fatalf("fallback Pick() error = %v", err)
+	}
+
+	// 3. Before TTL expires: sticks to fb1
+	fb2, err := selector.Pick(context.Background(), "claude", "claude-3", opts, coolingAuths)
+	if err != nil {
+		t.Fatalf("consecutive fallback Pick() error = %v", err)
+	}
+	if fb2.ID != fb1.ID {
+		t.Fatalf("fallback Pick() before TTL = %q, want sticky %q", fb2.ID, fb1.ID)
+	}
+
+	// 4. Wait for TTL to expire
+	time.Sleep(shortTTL * 2)
+
+	// After TTL expires, temporary key is evicted and a new pick can be made
+	fb3, err := selector.Pick(context.Background(), "claude", "claude-3", opts, coolingAuths)
+	if err != nil {
+		t.Fatalf("fallback Pick() after TTL error = %v", err)
+	}
+	if fb3 == nil {
+		t.Fatal("fallback Pick() after TTL returned nil")
+	}
+}

--- a/sdk/cliproxy/auth/session_affinity_retention_test.go
+++ b/sdk/cliproxy/auth/session_affinity_retention_test.go
@@ -1,0 +1,486 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type configurableTestExecutor struct {
+	provider string
+	calls    atomic.Int32
+	handler  func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error)
+}
+
+func (e *configurableTestExecutor) Identifier() string { return e.provider }
+func (e *configurableTestExecutor) Execute(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.calls.Add(1)
+	if e.handler != nil {
+		return e.handler(ctx, auth, req, opts)
+	}
+	return cliproxyexecutor.Response{Payload: []byte(`{"ok":true}`)}, nil
+}
+func (e *configurableTestExecutor) ExecuteStream(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.calls.Add(1)
+	return nil, nil
+}
+func (e *configurableTestExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+func (e *configurableTestExecutor) CountTokens(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (e *configurableTestExecutor) HttpRequest(ctx context.Context, auth *Auth, req *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestSessionAffinity_Transient503RetainsBindingAcrossRecovery(t *testing.T) {
+	ctx := context.Background()
+	p1 := "affinity-503-p1"
+	p2 := "affinity-503-p2"
+	model := "test-model-503"
+	auth1ID := "auth-1-503"
+	auth2ID := "auth-2-503"
+
+	manager := NewManager(nil, nil, nil)
+	affinity := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &RoundRobinSelector{},
+		TTL:      time.Hour,
+	})
+	defer affinity.Stop()
+	manager.SetSelector(affinity)
+
+	var auth1ShouldFail atomic.Bool
+	auth1ShouldFail.Store(true)
+
+	exec1 := &configurableTestExecutor{
+		provider: p1,
+		handler: func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			if auth1ShouldFail.Load() {
+				return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusServiceUnavailable, Message: "service unavailable 503"}
+			}
+			return cliproxyexecutor.Response{Payload: []byte(`{"served_by":"auth-1"}`)}, nil
+		},
+	}
+	exec2 := &configurableTestExecutor{
+		provider: p2,
+		handler: func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			return cliproxyexecutor.Response{Payload: []byte(`{"served_by":"auth-2"}`)}, nil
+		},
+	}
+	manager.RegisterExecutor(exec1)
+	manager.RegisterExecutor(exec2)
+
+	for _, auth := range []*Auth{
+		{ID: auth1ID, Provider: p1, Status: StatusActive},
+		{ID: auth2ID, Provider: p2, Status: StatusActive},
+	} {
+		if _, errRegister := manager.Register(WithSkipPersist(ctx), auth); errRegister != nil {
+			t.Fatalf("Register(%s): %v", auth.ID, errRegister)
+		}
+		registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+		t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	}
+
+	req := cliproxyexecutor.Request{Model: model}
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{"X-Session-Id": []string{"sess-retention-503"}},
+	}
+
+	// 1. First Execute: auth-1 fails with transient 503, retry falls over to auth-2 which succeeds.
+	resp, errExec := manager.Execute(ctx, []string{p1, p2}, req, opts)
+	if errExec != nil {
+		t.Fatalf("first Execute failed: %v", errExec)
+	}
+	if string(resp.Payload) != `{"served_by":"auth-2"}` {
+		t.Fatalf("first Execute payload = %s, want auth-2", string(resp.Payload))
+	}
+
+	// Session affinity binding must STILL point to auth-1 (retained despite transient failure)
+	sessionKey := "mixed::header:sess-retention-503::" + model
+	boundAuthID, ok := affinity.cache.Get(sessionKey)
+	if !ok {
+		t.Fatalf("expected sessionKey %q to remain in cache after transient 503", sessionKey)
+	}
+	if boundAuthID != auth1ID {
+		t.Fatalf("sessionKey bound to %q, want %q (transient 503 must not purge affinity)", boundAuthID, auth1ID)
+	}
+
+	// 2. Cooldown for auth-1 clears
+	auth1ShouldFail.Store(false)
+	expireSessionAffinityPriorityModelCooldown(t, manager, auth1ID, model)
+
+	// 3. Second Execute for the SAME session must return to auth-1 where prompt cache lives
+	resp2, errExec2 := manager.Execute(ctx, []string{p1, p2}, req, opts)
+	if errExec2 != nil {
+		t.Fatalf("second Execute failed: %v", errExec2)
+	}
+	if string(resp2.Payload) != `{"served_by":"auth-1"}` {
+		t.Fatalf("second Execute payload = %s, want auth-1 (session should return to original warm cache auth)", string(resp2.Payload))
+	}
+}
+
+func TestSessionAffinity_Transient429RetryAfterRetainsBindingAcrossRecovery(t *testing.T) {
+	ctx := context.Background()
+	p1 := "affinity-429-p1"
+	p2 := "affinity-429-p2"
+	model := "test-model-429"
+	auth1ID := "auth-1-429"
+	auth2ID := "auth-2-429"
+
+	manager := NewManager(nil, nil, nil)
+	affinity := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &RoundRobinSelector{},
+		TTL:      time.Hour,
+	})
+	defer affinity.Stop()
+	manager.SetSelector(affinity)
+
+	var auth1ShouldFail atomic.Bool
+	auth1ShouldFail.Store(true)
+
+	retryAfterDuration := 100 * time.Millisecond
+	exec1 := &configurableTestExecutor{
+		provider: p1,
+		handler: func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			if auth1ShouldFail.Load() {
+				return cliproxyexecutor.Response{}, &retryAfterStatusError{
+					status:     http.StatusTooManyRequests,
+					retryAfter: retryAfterDuration,
+					message:    "rate limited 429",
+				}
+			}
+			return cliproxyexecutor.Response{Payload: []byte(`{"served_by":"auth-1"}`)}, nil
+		},
+	}
+	exec2 := &configurableTestExecutor{
+		provider: p2,
+		handler: func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			return cliproxyexecutor.Response{Payload: []byte(`{"served_by":"auth-2"}`)}, nil
+		},
+	}
+	manager.RegisterExecutor(exec1)
+	manager.RegisterExecutor(exec2)
+
+	for _, auth := range []*Auth{
+		{ID: auth1ID, Provider: p1, Status: StatusActive},
+		{ID: auth2ID, Provider: p2, Status: StatusActive},
+	} {
+		if _, errRegister := manager.Register(WithSkipPersist(ctx), auth); errRegister != nil {
+			t.Fatalf("Register(%s): %v", auth.ID, errRegister)
+		}
+		registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+		t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	}
+
+	req := cliproxyexecutor.Request{Model: model}
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{"X-Session-Id": []string{"sess-retention-429"}},
+	}
+
+	// 1. First Execute: auth-1 returns 429, request falls over to auth-2 which succeeds.
+	resp, errExec := manager.Execute(ctx, []string{p1, p2}, req, opts)
+	if errExec != nil {
+		t.Fatalf("first Execute failed: %v", errExec)
+	}
+	if string(resp.Payload) != `{"served_by":"auth-2"}` {
+		t.Fatalf("first Execute payload = %s, want auth-2", string(resp.Payload))
+	}
+
+	// Binding must STILL be auth-1
+	sessionKey := "mixed::header:sess-retention-429::" + model
+	boundAuthID, ok := affinity.cache.Get(sessionKey)
+	if !ok {
+		t.Fatalf("expected sessionKey %q to remain in cache after 429 rate limit", sessionKey)
+	}
+	if boundAuthID != auth1ID {
+		t.Fatalf("sessionKey bound to %q, want %q", boundAuthID, auth1ID)
+	}
+
+	// 2. Cooldown for auth-1 clears
+	auth1ShouldFail.Store(false)
+	expireSessionAffinityPriorityModelCooldown(t, manager, auth1ID, model)
+
+	// 3. Next Execute returns to auth-1
+	resp2, errExec2 := manager.Execute(ctx, []string{p1, p2}, req, opts)
+	if errExec2 != nil {
+		t.Fatalf("second Execute failed: %v", errExec2)
+	}
+	if string(resp2.Payload) != `{"served_by":"auth-1"}` {
+		t.Fatalf("second Execute payload = %s, want auth-1", string(resp2.Payload))
+	}
+}
+
+func TestSessionAffinity_Terminal401InvalidAPIKeyUnbindsSession(t *testing.T) {
+	ctx := context.Background()
+	p1 := "affinity-401-p1"
+	p2 := "affinity-401-p2"
+	model := "test-model-401"
+	auth1ID := "auth-1-401"
+	auth2ID := "auth-2-401"
+
+	manager := NewManager(nil, nil, nil)
+	affinity := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &RoundRobinSelector{},
+		TTL:      time.Hour,
+	})
+	defer affinity.Stop()
+	manager.SetSelector(affinity)
+
+	exec1 := &configurableTestExecutor{
+		provider: p1,
+		handler: func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			return cliproxyexecutor.Response{}, &Error{
+				Code:       "unauthorized",
+				HTTPStatus: http.StatusUnauthorized,
+				Message:    "invalid_api_key",
+			}
+		},
+	}
+	exec2 := &configurableTestExecutor{
+		provider: p2,
+		handler: func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			return cliproxyexecutor.Response{Payload: []byte(`{"served_by":"auth-2"}`)}, nil
+		},
+	}
+	manager.RegisterExecutor(exec1)
+	manager.RegisterExecutor(exec2)
+
+	for _, auth := range []*Auth{
+		{ID: auth1ID, Provider: p1, Status: StatusActive},
+		{ID: auth2ID, Provider: p2, Status: StatusActive},
+	} {
+		if _, errRegister := manager.Register(WithSkipPersist(ctx), auth); errRegister != nil {
+			t.Fatalf("Register(%s): %v", auth.ID, errRegister)
+		}
+		registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+		t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	}
+
+	req := cliproxyexecutor.Request{Model: model}
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{"X-Session-Id": []string{"sess-retention-401"}},
+	}
+
+	// 1. First Execute: auth-1 fails with 401 terminal error, unbinds, falls over to auth-2 which succeeds and binds.
+	resp, errExec := manager.Execute(ctx, []string{p1, p2}, req, opts)
+	if errExec != nil {
+		t.Fatalf("first Execute failed: %v", errExec)
+	}
+	if string(resp.Payload) != `{"served_by":"auth-2"}` {
+		t.Fatalf("first Execute payload = %s, want auth-2", string(resp.Payload))
+	}
+
+	// Session is now permanently rebound to auth-2
+	sessionKey := "mixed::header:sess-retention-401::" + model
+	boundAuthID, ok := affinity.cache.Get(sessionKey)
+	if !ok {
+		t.Fatalf("expected sessionKey %q to be bound to auth-2", sessionKey)
+	}
+	if boundAuthID != auth2ID {
+		t.Fatalf("sessionKey bound to %q, want %q (terminal 401 should rebind to next auth)", boundAuthID, auth2ID)
+	}
+
+	// 2. Subsequent requests for the same session stay on auth-2
+	resp2, errExec2 := manager.Execute(ctx, []string{p1, p2}, req, opts)
+	if errExec2 != nil {
+		t.Fatalf("second Execute failed: %v", errExec2)
+	}
+	if string(resp2.Payload) != `{"served_by":"auth-2"}` {
+		t.Fatalf("second Execute payload = %s, want auth-2", string(resp2.Payload))
+	}
+}
+
+func TestSessionAffinitySelector_RequestScopedExclusionBreaksCarousel(t *testing.T) {
+	t.Parallel()
+
+	fallback := &RoundRobinSelector{}
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: fallback,
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+
+	auths := []*Auth{
+		{ID: "auth-a"},
+		{ID: "auth-b"},
+		{ID: "auth-c"},
+	}
+
+	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_carousel-break"}}`)
+	opts := cliproxyexecutor.Options{OriginalRequest: payload}
+
+	// 1. First pick establishes affinity binding to auth-a
+	first, err := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if first.ID != "auth-a" {
+		t.Fatalf("initial pick = %q, want auth-a", first.ID)
+	}
+	selector.OnResult(Result{AuthID: first.ID, Provider: "claude", Model: "claude-3", Options: opts, Success: true})
+
+	// 2. Simulated retries within one request: auth-a failed and is excluded from available candidates
+	availableWithoutFirst := make([]*Auth, 0, len(auths)-1)
+	for _, a := range auths {
+		if a.ID != first.ID {
+			availableWithoutFirst = append(availableWithoutFirst, a)
+		}
+	}
+
+	// 20 successive retry attempts within the request must NEVER return auth-a
+	for attempt := 0; attempt < 20; attempt++ {
+		got, errPick := selector.Pick(context.Background(), "claude", "claude-3", opts, availableWithoutFirst)
+		if errPick != nil {
+			t.Fatalf("attempt %d Pick() error = %v", attempt, errPick)
+		}
+		if got.ID == first.ID {
+			t.Fatalf("attempt %d returned excluded auth %q, expected different", attempt, first.ID)
+		}
+	}
+
+	// 3. New request after recovery with full candidates returns to auth-a (warm cache retained)
+	recovered, errRecovered := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+	if errRecovered != nil {
+		t.Fatalf("Pick() after recovery error = %v", errRecovered)
+	}
+	if recovered.ID != first.ID {
+		t.Fatalf("Pick() after recovery = %q, want original bound auth %q", recovered.ID, first.ID)
+	}
+}
+
+func TestSessionAffinitySelector_OnResult_TransientVsTerminalClassification(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name       string
+		err        *Error
+		wantRetain bool
+	}
+
+	cases := []testCase{
+		{
+			name:       "500 Internal Server Error (transient)",
+			err:        &Error{HTTPStatus: http.StatusInternalServerError, Message: "internal error"},
+			wantRetain: true,
+		},
+		{
+			name:       "502 Bad Gateway (transient)",
+			err:        &Error{HTTPStatus: http.StatusBadGateway, Message: "bad gateway"},
+			wantRetain: true,
+		},
+		{
+			name:       "503 Service Unavailable (transient)",
+			err:        &Error{HTTPStatus: http.StatusServiceUnavailable, Message: "service unavailable"},
+			wantRetain: true,
+		},
+		{
+			name:       "504 Gateway Timeout (transient)",
+			err:        &Error{HTTPStatus: http.StatusGatewayTimeout, Message: "gateway timeout"},
+			wantRetain: true,
+		},
+		{
+			name:       "429 Too Many Requests / Quota (transient)",
+			err:        &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limit exceeded"},
+			wantRetain: true,
+		},
+		{
+			name:       "408 Request Timeout (transient)",
+			err:        &Error{HTTPStatus: http.StatusRequestTimeout, Message: "request timeout"},
+			wantRetain: true,
+		},
+		{
+			name:       "Cloudflare challenge (transient)",
+			err:        &Error{HTTPStatus: http.StatusForbidden, Message: "just a moment... cloudflare challenge"},
+			wantRetain: true,
+		},
+		{
+			name:       "400 Bad Request / client fault (skip cooldown, retain)",
+			err:        &Error{HTTPStatus: http.StatusBadRequest, Message: `{"error":{"type":"invalid_request_error"}}`},
+			wantRetain: true,
+		},
+		{
+			name:       "401 Unauthorized / invalid API key (terminal)",
+			err:        &Error{HTTPStatus: http.StatusUnauthorized, Message: "invalid_api_key"},
+			wantRetain: false,
+		},
+		{
+			name:       "402 Payment Required / out of credits (terminal)",
+			err:        &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"},
+			wantRetain: false,
+		},
+		{
+			name:       "403 Forbidden / account disabled (terminal)",
+			err:        &Error{HTTPStatus: http.StatusForbidden, Message: "account suspended"},
+			wantRetain: false,
+		},
+		{
+			name:       "404 Not Found / unsupported model (terminal)",
+			err:        &Error{HTTPStatus: http.StatusNotFound, Message: "model not found for plan"},
+			wantRetain: false,
+		},
+		{
+			name:       "invalid_grant OAuth token revoked (terminal)",
+			err:        &Error{HTTPStatus: http.StatusBadRequest, Message: `{"error":"invalid_grant"}`},
+			wantRetain: false,
+		},
+		{
+			name:       "model_not_supported error (terminal)",
+			err:        &Error{HTTPStatus: http.StatusBadRequest, Message: "requested model is not supported for your plan"},
+			wantRetain: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+				Fallback: &RoundRobinSelector{},
+				TTL:      time.Hour,
+			})
+			defer selector.Stop()
+
+			sessionID := "sess-classify-" + tc.name
+			model := "test-model"
+			authID := "auth-target"
+			cacheKey := "mixed::header:" + sessionID + "::" + model
+
+			selector.cache.Set(cacheKey, authID)
+
+			opts := cliproxyexecutor.Options{
+				Headers: http.Header{"X-Session-Id": []string{sessionID}},
+				Metadata: map[string]any{
+					cliproxyexecutor.SessionAffinityProviderMetadataKey: "mixed",
+					cliproxyexecutor.SessionAffinityModelMetadataKey:    model,
+				},
+			}
+
+			selector.OnResult(Result{
+				AuthID:   authID,
+				Provider: "claude",
+				Model:    model,
+				Success:  false,
+				Error:    tc.err,
+				Options:  opts,
+			})
+
+			got, ok := selector.cache.Get(cacheKey)
+			if tc.wantRetain {
+				if !ok || got != authID {
+					t.Fatalf("cache binding purged, want retained auth %q (ok=%v, got=%q)", authID, ok, got)
+				}
+			} else {
+				if ok {
+					t.Fatalf("cache binding unexpectedly retained %q, want purged", got)
+				}
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/auth/session_cache.go
+++ b/sdk/cliproxy/auth/session_cache.go
@@ -93,6 +93,23 @@ func (c *SessionCache) GetAndRefresh(sessionID string) (string, bool) {
 	return entry.authID, true
 }
 
+// Aliases returns all currently known alias identifiers for the session entry.
+func (c *SessionCache) Aliases(sessionID string) []string {
+	if sessionID == "" {
+		return nil
+	}
+	now := time.Now()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.entries[sessionID]
+	if !ok || !now.Before(entry.expiresAt) {
+		return nil
+	}
+	res := make([]string, len(entry.aliases))
+	copy(res, entry.aliases)
+	return res
+}
+
 // Set binds a session to an auth ID with TTL refresh. Existing aliases for the
 // same logical session remain attached when the binding is refreshed or moved.
 func (c *SessionCache) Set(sessionID, authID string) {


### PR DESCRIPTION
## Problem

When requests failed with transient upstream glitches (e.g. 500 Internal Server Error, 502 Bad Gateway, 503 Service Unavailable, 504 Gateway Timeout, 429 Too Many Requests, 408 Request Timeout, or Cloudflare challenges), `SessionAffinitySelector.OnResult` unconditionally purged the session binding via `CompareAndDelete`. Additionally, during `SessionAffinitySelector.Pick()`, when a cached auth credential was temporarily in cooldown or absent from candidate pools, fallback selection immediately called `bind(...)`, overwriting the primary session cache key.

This caused single transient errors or temporary cooling intervals to permanently purge sticky session affinity, discarding warm prompt caches on upstream providers and inducing unnecessary credential wandering (account carousels).

## Fix

- In `sdk/cliproxy/auth/selector.go:939`, introduce `isTerminalSessionAffinityError(err *Error) bool` to classify failures into terminal errors (401 invalid key, 402 depleted balance, 403 banned account, 404 missing model, `invalid_grant`, `model_not_supported`) versus transient errors (5xx, 429, 408, Cloudflare challenges, client disconnects).
- In `sdk/cliproxy/auth/selector.go:731`, restrict `CompareAndDelete` unbinding in `SessionAffinitySelector.OnResult` so cache purge only triggers on terminal failures.
- In `sdk/cliproxy/auth/selector.go:487`, implement sticky temporary fallback caching when primary auth is cooling, without overwriting the primary session binding key.
- In `sdk/cliproxy/auth/session_cache.go:61`, add helper routines for temporary fallback bindings with TTL.

## Tests

- `TestSessionAffinity_Transient503RetainsBindingAcrossRecovery`: verifies 503 transient errors retain the primary session affinity binding and return to primary auth after cooldown recovery.
- `TestSessionAffinity_Terminal401InvalidAPIKeyUnbindsSession`: verifies 401 terminal errors immediately unbind session affinity from the invalid credential.
- `TestSessionAffinity_StickyTemporaryFallbackDuringPrimaryCooldown`: verifies requests route stickily to fallback auth while primary cools and seamlessly revert to primary auth when cooldown expires.
- `TestSessionAffinitySelector_OnResult_TransientVsTerminalClassification`: table-driven verification across status codes and error reason strings.

## Reverse Bite-Check

Verbatim test failure output when `sdk/cliproxy/auth/selector.go` and `sdk/cliproxy/auth/session_cache.go` are reverted to `origin/dev`:

```text
=== RUN   TestSessionAffinity_Transient503RetainsBindingAcrossRecovery
time="2026-08-21T07:31:28+03:00" level=info msg="session-affinity: cache miss, new binding | session=header:s... auth=auth-1-503 provider=mixed model=test-model-503"
time="2026-08-21T07:31:28+03:00" level=warning msg="upstream execution failed: provider=affinity-503-p1 model=test-model-503 auth=auth_id=auth-1-503 duration=0s err=service unavailable 503"
time="2026-08-21T07:31:28+03:00" level=info msg="session-affinity: cache miss, new binding | session=header:s... auth=auth-2-503 provider=mixed model=test-model-503"
    session_affinity_retention_test.go:111: sessionKey bound to "auth-2-503", want "auth-1-503" (transient 503 must not purge affinity)
--- FAIL: TestSessionAffinity_Transient503RetainsBindingAcrossRecovery (0.00s)
=== RUN   TestSessionAffinity_Terminal401InvalidAPIKeyUnbindsSession
--- PASS: TestSessionAffinity_Terminal401InvalidAPIKeyUnbindsSession (0.00s)
=== RUN   TestSessionAffinity_StickyTemporaryFallbackDuringPrimaryCooldown
=== PAUSE TestSessionAffinity_StickyTemporaryFallbackDuringPrimaryCooldown
=== CONT  TestSessionAffinity_StickyTemporaryFallbackDuringPrimaryCooldown
    session_affinity_retention_test.go:546: recovered Pick() = "auth-c", want primary "auth-a"
--- FAIL: TestSessionAffinity_StickyTemporaryFallbackDuringPrimaryCooldown (0.00s)
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth	0.364s
FAIL
```

## Verification

```bash
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go build ./...
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go vet ./sdk/cliproxy/auth/...
gofmt -l sdk/cliproxy/auth/selector.go sdk/cliproxy/auth/session_cache.go sdk/cliproxy/auth/session_affinity_retention_test.go
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go test -v ./sdk/cliproxy/auth -run "TestSessionAffinity_Transient503RetainsBindingAcrossRecovery|TestSessionAffinity_Terminal401InvalidAPIKeyUnbindsSession|TestSessionAffinity_StickyTemporaryFallbackDuringPrimaryCooldown"
```

All commands executed successfully (exit code 0).

### Tooling note

The `jbcontext` semantic-search CLI is installed but non-functional in this environment
(`jbcontext search` fails with `the OS keychain is not accessible`). The equivalent
review passes were performed with the repository's own tooling and manual inspection
instead; this is disclosed for transparency about how the change was reviewed.
