### PR TITLE
fix(codex): strip unsupported response metadata

### DIFF
--- a/internal/translator/codex/openai/responses/codex_openai-responses_request.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request.go
@@ -31,7 +31,7 @@ func ConvertOpenAIResponsesRequestToCodex(modelName string, inputRawJSON []byte,
 		rawJSON = deleteCodexRequestFields(rawJSON, "service_tier")
 	}
 
-	rawJSON = deleteCodexRequestFields(rawJSON, "truncation", "prompt_cache_options", "prompt_cache_retention")
+	rawJSON = deleteCodexRequestFields(rawJSON, "truncation", "prompt_cache_options", "prompt_cache_retention", "metadata")
 	rawJSON = stripCodexResponsesCacheBreakpoints(rawJSON)
 	rawJSON = applyResponsesCompactionCompatibility(rawJSON)
 

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
@@ -317,6 +317,38 @@ func TestConvertOpenAIResponsesRequestToCodex_FiltersPromptCacheRetention(t *tes
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToCodex_FiltersMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata string
+	}{
+		{name: "empty", metadata: `{}`},
+		{name: "populated", metadata: `{"probe":"terra-metadata-test"}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			inputJSON := []byte(`{
+				"model":"gpt-5.6-terra",
+				"metadata":` + test.metadata + `,
+				"client_metadata":{"probe":"preserve"},
+				"input":"hello"
+			}`)
+
+			output := ConvertOpenAIResponsesRequestToCodex("gpt-5.6-terra", inputJSON, true)
+			if gjson.GetBytes(output, "metadata").Exists() {
+				t.Fatalf("metadata should be removed: %s", string(output))
+			}
+			if got := gjson.GetBytes(output, "client_metadata.probe").String(); got != "preserve" {
+				t.Fatalf("client_metadata.probe = %q, want preserve: %s", got, string(output))
+			}
+			if got := gjson.GetBytes(output, "input.0.content.0.text").String(); got != "hello" {
+				t.Fatalf("input text = %q, want hello: %s", got, string(output))
+			}
+		})
+	}
+}
+
 // TestConvertSystemRoleToDeveloper_AssistantRole tests that assistant role is preserved
 func TestConvertSystemRoleToDeveloper_AssistantRole(t *testing.T) {
 	inputJSON := []byte(`{


### PR DESCRIPTION
## Summary

- strip top-level `metadata` from OpenAI Responses requests before forwarding them to Codex
- preserve Codex-specific `client_metadata`
- add regression coverage for empty and populated metadata values

Codex currently rejects the top-level field with `400 Unsupported parameter: metadata`, while the same request succeeds when the field is absent. The change reuses the existing Codex-only unsupported-field filter and does not affect routing, authentication, or other providers.

Fixes #5112

## Validation

- `go test ./internal/translator/codex/openai/responses`
- `go build -o test-output ./cmd/server`
- `git diff --check upstream/main...HEAD`
- `go test ./...` (all relevant packages pass; the command remains non-zero only because `TestInPlaceByteWritesAreReviewed` scans the unrelated local `.claude/worktrees/feat+kiro-provider` directory)
- upstream `pr-test-build` workflow passes

## Upstream path guard

The repository's `translator-path-guard` intentionally rejects pull requests that modify `internal/translator/**` and directs contributors to open an issue for the maintenance team. Issue #5112 remains open; this draft PR provides the tested minimal implementation for maintainer review.
