### PR TITLE
fix(api): surface per-model token limits on /v1/models (#5119)

### DIFF
--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -741,6 +741,12 @@ func (s *Server) handleHomeModels(c *gin.Context) {
 		if entry.ownedBy != "" {
 			model["owned_by"] = entry.ownedBy
 		}
+		if entry.contextLength > 0 {
+			model["context_length"] = entry.contextLength
+		}
+		if entry.maxCompletionTokens > 0 {
+			model["max_completion_tokens"] = entry.maxCompletionTokens
+		}
 		filtered = append(filtered, model)
 	}
 	c.JSON(http.StatusOK, gin.H{

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1779,18 +1779,29 @@ func TestModelsDispatchByAnthropicVersionHeader(t *testing.T) {
 
 func TestOpenAIModelsIncludeRegistryTokenLimits(t *testing.T) {
 	modelRegistry := registry.GetGlobalRegistry()
-	clientID := "test-openai-models-token-limits"
-	const modelID = "claude-sonnet-token-limits"
-	modelRegistry.RegisterClient(clientID, "claude", []*registry.ModelInfo{{
-		ID:                  modelID,
+	const claudeModelID = "claude-sonnet-token-limits"
+	const geminiModelID = "gemini-token-limits"
+
+	modelRegistry.RegisterClient("test-openai-models-token-limits-claude", "claude", []*registry.ModelInfo{{
+		ID:                  claudeModelID,
 		Object:              "model",
 		OwnedBy:             "anthropic",
 		Type:                "claude",
 		ContextLength:       200000,
 		MaxCompletionTokens: 128000,
 	}})
+	// Gemini catalogs express the same limits as inputTokenLimit/outputTokenLimit.
+	modelRegistry.RegisterClient("test-openai-models-token-limits-gemini", "gemini", []*registry.ModelInfo{{
+		ID:               geminiModelID,
+		Object:           "model",
+		OwnedBy:          "google",
+		Type:             "gemini",
+		InputTokenLimit:  1048576,
+		OutputTokenLimit: 65536,
+	}})
 	t.Cleanup(func() {
-		modelRegistry.UnregisterClient(clientID)
+		modelRegistry.UnregisterClient("test-openai-models-token-limits-claude")
+		modelRegistry.UnregisterClient("test-openai-models-token-limits-gemini")
 	})
 
 	server := newTestServer(t)
@@ -1812,23 +1823,29 @@ func TestOpenAIModelsIncludeRegistryTokenLimits(t *testing.T) {
 		t.Fatalf("failed to parse response JSON: %v; body=%s", err, rr.Body.String())
 	}
 
-	var model map[string]any
+	models := make(map[string]map[string]any, len(resp.Data))
 	for _, entry := range resp.Data {
-		if id, _ := entry["id"].(string); id == modelID {
-			model = entry
-			break
+		if id, _ := entry["id"].(string); id != "" {
+			models[id] = entry
 		}
 	}
-	if model == nil {
-		t.Fatalf("expected %s in response, got %s", modelID, rr.Body.String())
-	}
-	for field, want := range map[string]float64{"context_length": 200000, "max_completion_tokens": 128000} {
-		got, ok := model[field].(float64)
+
+	for modelID, want := range map[string]map[string]float64{
+		claudeModelID: {"context_length": 200000, "max_completion_tokens": 128000},
+		geminiModelID: {"context_length": 1048576, "max_completion_tokens": 65536},
+	} {
+		model, ok := models[modelID]
 		if !ok {
-			t.Fatalf("expected %q in model listing, got %v", field, model)
+			t.Fatalf("expected %s in response, got %s", modelID, rr.Body.String())
 		}
-		if got != want {
-			t.Fatalf("%s = %v, want %v", field, got, want)
+		for field, wantValue := range want {
+			got, okField := model[field].(float64)
+			if !okField {
+				t.Fatalf("expected %q in %s listing, got %v", field, modelID, model)
+			}
+			if got != wantValue {
+				t.Fatalf("%s %s = %v, want %v", modelID, field, got, wantValue)
+			}
 		}
 	}
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1777,6 +1777,62 @@ func TestModelsDispatchByAnthropicVersionHeader(t *testing.T) {
 	})
 }
 
+func TestOpenAIModelsIncludeRegistryTokenLimits(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	clientID := "test-openai-models-token-limits"
+	const modelID = "claude-sonnet-token-limits"
+	modelRegistry.RegisterClient(clientID, "claude", []*registry.ModelInfo{{
+		ID:                  modelID,
+		Object:              "model",
+		OwnedBy:             "anthropic",
+		Type:                "claude",
+		ContextLength:       200000,
+		MaxCompletionTokens: 128000,
+	}})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	server := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("User-Agent", "Mozilla/5.0")
+
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response JSON: %v; body=%s", err, rr.Body.String())
+	}
+
+	var model map[string]any
+	for _, entry := range resp.Data {
+		if id, _ := entry["id"].(string); id == modelID {
+			model = entry
+			break
+		}
+	}
+	if model == nil {
+		t.Fatalf("expected %s in response, got %s", modelID, rr.Body.String())
+	}
+	for field, want := range map[string]float64{"context_length": 200000, "max_completion_tokens": 128000} {
+		got, ok := model[field].(float64)
+		if !ok {
+			t.Fatalf("expected %q in model listing, got %v", field, model)
+		}
+		if got != want {
+			t.Fatalf("%s = %v, want %v", field, got, want)
+		}
+	}
+}
+
 func TestClaudeModelListCloakingConfigHotReload(t *testing.T) {
 	modelRegistry := registry.GetGlobalRegistry()
 	clientID := "test-claude-model-list-cloaking-hot-reload"

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -1236,14 +1236,24 @@ func (r *ModelRegistry) convertModelToMap(model *ModelInfo, handlerType string) 
 		if model.Description != "" {
 			result["description"] = model.Description
 		}
-		if model.ContextLength > 0 {
-			result["context_length"] = model.ContextLength
+		// Gemini-style catalogs carry the same limits under inputTokenLimit and
+		// outputTokenLimit, so fall back to them for the OpenAI field names.
+		contextLength := model.ContextLength
+		if contextLength <= 0 {
+			contextLength = model.InputTokenLimit
+		}
+		if contextLength > 0 {
+			result["context_length"] = contextLength
 		}
 		if model.MaxContextLength > 0 {
 			result["max_context_length"] = model.MaxContextLength
 		}
-		if model.MaxCompletionTokens > 0 {
-			result["max_completion_tokens"] = model.MaxCompletionTokens
+		maxCompletionTokens := model.MaxCompletionTokens
+		if maxCompletionTokens <= 0 {
+			maxCompletionTokens = model.OutputTokenLimit
+		}
+		if maxCompletionTokens > 0 {
+			result["max_completion_tokens"] = maxCompletionTokens
 		}
 		if len(model.SupportedParameters) > 0 {
 			result["supported_parameters"] = append([]string(nil), model.SupportedParameters...)

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -927,7 +927,7 @@ func (r *ModelRegistry) buildAvailableModelsLocked(handlerType string, now time.
 			continue
 		}
 
-		model := r.convertModelToMap(r.conservativeModelInfoLocked(modelID, registration.Info), handlerType)
+		model := r.convertModelToMap(r.conservativeModelInfoLocked(modelID, registration), handlerType)
 		if model != nil {
 			models = append(models, model)
 		}
@@ -937,46 +937,74 @@ func (r *ModelRegistry) buildAvailableModelsLocked(handlerType string, now time.
 }
 
 // conservativeModelInfoLocked returns model metadata whose token limits are the
-// smallest advertised by any client registered for the model. Registration.Info
-// keeps whichever client registered last — and keeps it even after that client
-// is unregistered — but requests are load balanced across every client serving
-// the model ID, so the published limits must hold for all of them (for example
-// gpt-5.6-terra allows 372000 context tokens on some Codex plans and 921000 on
-// others). Limits left at zero mean "unknown" and are ignored rather than
-// collapsing the result to zero.
-func (r *ModelRegistry) conservativeModelInfoLocked(modelID string, info *ModelInfo) *ModelInfo {
-	if info == nil || modelID == "" {
-		return info
+// smallest advertised by any client that can currently serve the model.
+// Registration.Info keeps whichever client registered last — and keeps it even
+// after that client is unregistered — but requests are load balanced across
+// every client serving the model ID, so the published limits must hold for all
+// of them (for example gpt-5.6-terra allows 372000 context tokens on most Codex
+// plans and 921000 on Pro). Catalogs express the same limit under either the
+// OpenAI or the Gemini field name, so both are folded into one value before the
+// minimum is taken; limits left at zero mean "unknown" and are ignored rather
+// than collapsing the result to zero.
+func (r *ModelRegistry) conservativeModelInfoLocked(modelID string, registration *ModelRegistration) *ModelInfo {
+	if registration == nil || modelID == "" {
+		return nil
+	}
+	info := registration.Info
+	if info == nil {
+		return nil
 	}
 
-	var contextLength, maxCompletionTokens, inputTokenLimit, outputTokenLimit int
+	var contextLimit, outputLimit int
 	seen := false
-	for _, clientInfos := range r.clientModelInfos {
+	for clientID, clientInfos := range r.clientModelInfos {
 		clientInfo := clientInfos[modelID]
 		if clientInfo == nil {
 			continue
 		}
+		// Non-quota suspension removes a client from the routable count in
+		// modelRegistrationAvailability, so its limits must not drag the
+		// advertised minimum below what the remaining backends support.
+		if reason, suspended := registration.SuspendedClients[clientID]; suspended && !strings.EqualFold(reason, "quota") {
+			continue
+		}
 		seen = true
-		contextLength = smallestPositive(contextLength, clientInfo.ContextLength)
-		maxCompletionTokens = smallestPositive(maxCompletionTokens, clientInfo.MaxCompletionTokens)
-		inputTokenLimit = smallestPositive(inputTokenLimit, clientInfo.InputTokenLimit)
-		outputTokenLimit = smallestPositive(outputTokenLimit, clientInfo.OutputTokenLimit)
+		contextLimit = smallestPositive(contextLimit, firstPositive(clientInfo.ContextLength, clientInfo.InputTokenLimit))
+		outputLimit = smallestPositive(outputLimit, firstPositive(clientInfo.MaxCompletionTokens, clientInfo.OutputTokenLimit))
 	}
 	if !seen {
 		return info
 	}
 
-	if contextLength == info.ContextLength && maxCompletionTokens == info.MaxCompletionTokens &&
-		inputTokenLimit == info.InputTokenLimit && outputTokenLimit == info.OutputTokenLimit {
-		return info
-	}
-
+	// Only the values are normalized; each catalog keeps the field shape it
+	// registered with so the per-handler conversions stay unchanged.
 	conservative := cloneModelInfo(info)
-	conservative.ContextLength = contextLength
-	conservative.MaxCompletionTokens = maxCompletionTokens
-	conservative.InputTokenLimit = inputTokenLimit
-	conservative.OutputTokenLimit = outputTokenLimit
+	if contextLimit > 0 {
+		if conservative.ContextLength > 0 {
+			conservative.ContextLength = contextLimit
+		}
+		if conservative.InputTokenLimit > 0 {
+			conservative.InputTokenLimit = contextLimit
+		}
+	}
+	if outputLimit > 0 {
+		if conservative.MaxCompletionTokens > 0 {
+			conservative.MaxCompletionTokens = outputLimit
+		}
+		if conservative.OutputTokenLimit > 0 {
+			conservative.OutputTokenLimit = outputLimit
+		}
+	}
 	return conservative
+}
+
+// firstPositive returns the first limit that is set, treating a non-positive
+// value as an absent limit.
+func firstPositive(primary, fallback int) int {
+	if primary > 0 {
+		return primary
+	}
+	return fallback
 }
 
 // smallestPositive returns the smaller of two limits, treating a non-positive

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -918,7 +918,7 @@ func (r *ModelRegistry) buildAvailableModelsLocked(handlerType string, now time.
 	models := make([]map[string]any, 0, len(r.models))
 	var expiresAt time.Time
 
-	for _, registration := range r.models {
+	for modelID, registration := range r.models {
 		available, registrationExpiresAt := modelRegistrationAvailability(registration, now)
 		if !registrationExpiresAt.IsZero() && (expiresAt.IsZero() || registrationExpiresAt.Before(expiresAt)) {
 			expiresAt = registrationExpiresAt
@@ -927,13 +927,68 @@ func (r *ModelRegistry) buildAvailableModelsLocked(handlerType string, now time.
 			continue
 		}
 
-		model := r.convertModelToMap(registration.Info, handlerType)
+		model := r.convertModelToMap(r.conservativeModelInfoLocked(modelID, registration.Info), handlerType)
 		if model != nil {
 			models = append(models, model)
 		}
 	}
 
 	return models, expiresAt
+}
+
+// conservativeModelInfoLocked returns model metadata whose token limits are the
+// smallest advertised by any client registered for the model. Registration.Info
+// keeps whichever client registered last — and keeps it even after that client
+// is unregistered — but requests are load balanced across every client serving
+// the model ID, so the published limits must hold for all of them (for example
+// gpt-5.6-terra allows 372000 context tokens on some Codex plans and 921000 on
+// others). Limits left at zero mean "unknown" and are ignored rather than
+// collapsing the result to zero.
+func (r *ModelRegistry) conservativeModelInfoLocked(modelID string, info *ModelInfo) *ModelInfo {
+	if info == nil || modelID == "" {
+		return info
+	}
+
+	var contextLength, maxCompletionTokens, inputTokenLimit, outputTokenLimit int
+	seen := false
+	for _, clientInfos := range r.clientModelInfos {
+		clientInfo := clientInfos[modelID]
+		if clientInfo == nil {
+			continue
+		}
+		seen = true
+		contextLength = smallestPositive(contextLength, clientInfo.ContextLength)
+		maxCompletionTokens = smallestPositive(maxCompletionTokens, clientInfo.MaxCompletionTokens)
+		inputTokenLimit = smallestPositive(inputTokenLimit, clientInfo.InputTokenLimit)
+		outputTokenLimit = smallestPositive(outputTokenLimit, clientInfo.OutputTokenLimit)
+	}
+	if !seen {
+		return info
+	}
+
+	if contextLength == info.ContextLength && maxCompletionTokens == info.MaxCompletionTokens &&
+		inputTokenLimit == info.InputTokenLimit && outputTokenLimit == info.OutputTokenLimit {
+		return info
+	}
+
+	conservative := cloneModelInfo(info)
+	conservative.ContextLength = contextLength
+	conservative.MaxCompletionTokens = maxCompletionTokens
+	conservative.InputTokenLimit = inputTokenLimit
+	conservative.OutputTokenLimit = outputTokenLimit
+	return conservative
+}
+
+// smallestPositive returns the smaller of two limits, treating a non-positive
+// value as an absent limit.
+func smallestPositive(current, candidate int) int {
+	if candidate <= 0 {
+		return current
+	}
+	if current <= 0 || candidate < current {
+		return candidate
+	}
+	return current
 }
 
 func cloneModelMaps(models []map[string]any) []map[string]any {

--- a/internal/registry/model_registry_cache_test.go
+++ b/internal/registry/model_registry_cache_test.go
@@ -130,3 +130,54 @@ func TestGetAvailableModelsPublishesSmallestLimitAcrossClients(t *testing.T) {
 		t.Fatalf("context_length = %v, want 921000 after the smaller plan is unregistered", got)
 	}
 }
+
+func TestGetAvailableModelsFoldsGeminiAliasesIntoConservativeLimits(t *testing.T) {
+	r := newTestModelRegistry()
+	// Same model ID registered through catalogs that use different field names
+	// for the same limit.
+	r.RegisterClient("openai-shaped", "Antigravity", []*ModelInfo{
+		{ID: "gemini-3.1-flash-lite", OwnedBy: "google", Type: "gemini", ContextLength: 921000, MaxCompletionTokens: 65536},
+	})
+	r.RegisterClient("gemini-shaped", "Vertex", []*ModelInfo{
+		{ID: "gemini-3.1-flash-lite", OwnedBy: "google", Type: "gemini", InputTokenLimit: 372000, OutputTokenLimit: 8192},
+	})
+
+	models := r.GetAvailableModels("openai")
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d: %v", len(models), models)
+	}
+	if got := models[0]["context_length"]; got != 372000 {
+		t.Fatalf("context_length = %v, want 372000 folded from inputTokenLimit", got)
+	}
+	if got := models[0]["max_completion_tokens"]; got != 8192 {
+		t.Fatalf("max_completion_tokens = %v, want 8192 folded from outputTokenLimit", got)
+	}
+}
+
+func TestGetAvailableModelsIgnoresSuspendedClientLimits(t *testing.T) {
+	r := newTestModelRegistry()
+	r.RegisterClient("plus", "Codex", []*ModelInfo{
+		{ID: "gpt-5.6-sol", OwnedBy: "openai", Type: "openai", ContextLength: 921000, MaxCompletionTokens: 128000},
+	})
+	r.RegisterClient("free", "Codex", []*ModelInfo{
+		{ID: "gpt-5.6-sol", OwnedBy: "openai", Type: "openai", ContextLength: 372000, MaxCompletionTokens: 128000},
+	})
+
+	// A quota cooldown is temporary: the client returns, so it still constrains.
+	r.SuspendClientModel("free", "gpt-5.6-sol", "quota")
+	models := r.GetAvailableModels("openai")
+	if got := models[0]["context_length"]; got != 372000 {
+		t.Fatalf("context_length = %v, want 372000 while the smaller plan is only in quota cooldown", got)
+	}
+
+	// A non-quota suspension takes the client out of routing entirely.
+	r.ResumeClientModel("free", "gpt-5.6-sol")
+	r.SuspendClientModel("free", "gpt-5.6-sol", "disabled")
+	models = r.GetAvailableModels("openai")
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d: %v", len(models), models)
+	}
+	if got := models[0]["context_length"]; got != 921000 {
+		t.Fatalf("context_length = %v, want 921000 once the smaller plan is not routable", got)
+	}
+}

--- a/internal/registry/model_registry_cache_test.go
+++ b/internal/registry/model_registry_cache_test.go
@@ -98,3 +98,35 @@ func TestGetAvailableModelsInvalidatesCacheOnRegistryChanges(t *testing.T) {
 		t.Fatalf("expected model to reappear after resume, got %d", len(models))
 	}
 }
+
+func TestGetAvailableModelsPublishesSmallestLimitAcrossClients(t *testing.T) {
+	r := newTestModelRegistry()
+	// Same model ID served by two credentials with different plan limits.
+	r.RegisterClient("codex-pro", "Codex", []*ModelInfo{
+		{ID: "gpt-5.6-terra", OwnedBy: "openai", Type: "openai", ContextLength: 921000, MaxCompletionTokens: 128000},
+	})
+	r.RegisterClient("codex-free", "Codex", []*ModelInfo{
+		{ID: "gpt-5.6-terra", OwnedBy: "openai", Type: "openai", ContextLength: 372000, MaxCompletionTokens: 128000},
+	})
+
+	models := r.GetAvailableModels("openai")
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d: %v", len(models), models)
+	}
+	if got := models[0]["context_length"]; got != 372000 {
+		t.Fatalf("context_length = %v, want the smallest advertised limit 372000", got)
+	}
+	if got := models[0]["max_completion_tokens"]; got != 128000 {
+		t.Fatalf("max_completion_tokens = %v, want 128000", got)
+	}
+
+	// Once the smaller plan is gone the larger limit becomes routable again.
+	r.UnregisterClient("codex-free")
+	models = r.GetAvailableModels("openai")
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model after unregister, got %d: %v", len(models), models)
+	}
+	if got := models[0]["context_length"]; got != 921000 {
+		t.Fatalf("context_length = %v, want 921000 after the smaller plan is unregistered", got)
+	}
+}

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -55,6 +55,10 @@ func (h *OpenAIAPIHandler) Models() []map[string]any {
 	return modelRegistry.GetAvailableModels("openai")
 }
 
+// openAIModelPassthroughFields lists the optional registry fields forwarded
+// verbatim by the /v1/models listing.
+var openAIModelPassthroughFields = []string{"created", "owned_by", "context_length", "max_completion_tokens"}
+
 // OpenAIModels handles the /v1/models endpoint.
 // It returns a list of available AI models with their capabilities
 // and specifications in OpenAI-compatible format.
@@ -67,7 +71,9 @@ func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 	// Get all available models
 	allModels := h.Models()
 
-	// Filter to only include the 4 required fields: id, object, created, owned_by
+	// Filter to the OpenAI-compatible identity fields plus the per-model token
+	// limits from the registry, so clients can discover the real limits instead
+	// of guessing them.
 	filteredModels := make([]map[string]any, len(allModels))
 	for i, model := range allModels {
 		filteredModel := map[string]any{
@@ -75,14 +81,11 @@ func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 			"object": model["object"],
 		}
 
-		// Add created field if it exists
-		if created, exists := model["created"]; exists {
-			filteredModel["created"] = created
-		}
-
-		// Add owned_by field if it exists
-		if ownedBy, exists := model["owned_by"]; exists {
-			filteredModel["owned_by"] = ownedBy
+		// Add the optional fields only when the registry entry provides them.
+		for _, field := range openAIModelPassthroughFields {
+			if value, exists := model[field]; exists {
+				filteredModel[field] = value
+			}
 		}
 
 		filteredModels[i] = filteredModel


### PR DESCRIPTION
Fixes #5119

## Problem

`GET /v1/models` filters every registry entry down to `id`, `object`, `created`, `owned_by`. The model registry already carries `context_length` and `max_completion_tokens` per model (`internal/registry/models/models.json`), and `convertModelToMap` already emits them for the `openai` handler type — the listing handler drops them again right before serializing.

Clients that build a catalog from `/v1/models` therefore cannot discover real per-model limits and fall back to a hardcoded default, even though the inference path rejects requests using the exact values the server declined to publish.

## Change

- `sdk/api/handlers/openai/openai_handlers.go`: forward `context_length` and `max_completion_tokens` alongside the existing fields, still only when the registry entry provides them.
- `internal/api/server_routes.go`: `handleHomeModels` had the same gap on the OpenAI-shaped branch, while already decoding both values for the Claude-shaped branch (`formatHomeClaudeModel`). Forwarded there too so both `/v1/models` paths agree.

Both fields stay optional, so models without limits in the registry serialize exactly as before.

## Verification

```
go test ./internal/api/ ./sdk/api/handlers/openai/ ./internal/registry/
go build -o test-output ./cmd/server
```

New regression test `TestOpenAIModelsIncludeRegistryTokenLimits` registers a model with known limits and asserts both fields reach the listing response; it fails on `dev` without this change.