### PR TITLE
feat: expose current quota resets as an iCalendar feed

### DIFF
--- a/examples/plugin/Makefile
+++ b/examples/plugin/Makefile
@@ -1,4 +1,4 @@
-EXAMPLES := simple model auth frontend-auth executor protocol-format request-translator request-normalizer response-translator response-normalizer thinking usage cli management-api host-callback host-callback-auth-files host-model-callback claude-web-search-router
+EXAMPLES := simple model auth frontend-auth executor protocol-format request-translator request-normalizer response-translator response-normalizer thinking usage cli management-api host-callback host-callback-auth-files host-model-callback quota-calendar claude-web-search-router
 LANGUAGES := go c rust
 BIN_DIR := $(CURDIR)/bin
 BUILD_DIR := $(BIN_DIR)/build

--- a/examples/plugin/README.md
+++ b/examples/plugin/README.md
@@ -26,6 +26,7 @@ This directory contains standard dynamic library plugin examples for the CLIProx
 - `host-callback/`: minimal plugin resource that demonstrates host callbacks.
 - `host-callback-auth-files/`: Go-only plugin resource that calls host auth file callbacks.
 - `host-model-callback/`: Go-only plugin resource that calls the host model execution callbacks.
+- `quota-calendar/`: Go-only plugin resource that exposes current per-model quota reset events as an iCalendar feed.
 
 Most standard capability examples contain `go/`, `c/`, and `rust/` subdirectories. Specialized examples may provide only the implementation language they need.
 

--- a/examples/plugin/quota-calendar/README.md
+++ b/examples/plugin/quota-calendar/README.md
@@ -1,0 +1,43 @@
+# Quota Calendar plugin
+
+This plugin exposes a live iCalendar feed containing the current per-model quota reset times.
+
+## Build
+
+From the repository root:
+
+```bash
+cd examples/plugin/quota-calendar/go
+go build -buildmode=c-shared -o quota-calendar.so .
+rm -f quota-calendar.h
+```
+
+The resulting `quota-calendar.so` belongs in the configured plugin directory. Enable it with:
+
+```yaml
+plugins:
+  enabled: true
+  dir: "plugins"
+  configs:
+    quota-calendar:
+      enabled: true
+      priority: 1
+```
+
+## Feed URL
+
+```text
+http://127.0.0.1:8080/v0/resource/plugins/quota-calendar/calendar.ics
+```
+
+The resource is intentionally unauthenticated by the plugin host's resource contract. Protect it with a reverse proxy or a private bind address if the feed contains sensitive model/account information. For a calendar client that cannot send custom auth headers, use an unguessable private subscription URL at the reverse proxy layer rather than placing credentials in the ICS content.
+
+The feed is generated on every request. It uses a stable `UID` per provider/model pair, chooses the latest reset seen across matching auth entries, omits expired or missing reset times, and emits at most one `VEVENT` per provider/model pair. Calendar subscribers therefore update the existing event when the reset time changes instead of accumulating duplicates.
+
+The response is `text/calendar`, uses deterministic CRLF/folding and source-derived `DTSTAMP`/`LAST-MODIFIED` values, sets `Cache-Control: no-store`, and advertises a 15-minute refresh interval. Calendar clients may still refresh less frequently according to their own policies.
+
+## Core SDK requirement
+
+Current CLIProxyAPI plugins can read auth-level runtime state, but per-model quota state is not exposed through the plugin callback contract. This plugin therefore requires the accompanying host callback change that adds `model_states` to `HostAuthFileEntry`.
+
+Only non-secret runtime fields are exposed: model status, availability, reset/retry times, quota flag/reason, and update time. Access tokens and credential JSON are never read.

--- a/examples/plugin/quota-calendar/go/go.mod
+++ b/examples/plugin/quota-calendar/go/go.mod
@@ -1,0 +1,7 @@
+module github.com/router-for-me/CLIProxyAPI/v7/examples/plugin/quota-calendar/go
+
+go 1.26.0
+
+require github.com/router-for-me/CLIProxyAPI/v7 v7.0.0
+
+replace github.com/router-for-me/CLIProxyAPI/v7 => ../../../../

--- a/examples/plugin/quota-calendar/go/main.go
+++ b/examples/plugin/quota-calendar/go/main.go
@@ -1,0 +1,330 @@
+package main
+
+/*
+#cgo CFLAGS: -Wno-deprecated-declarations
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct { void* ptr; size_t len; } cliproxy_buffer;
+typedef int (*cliproxy_host_call_fn)(void*, const char*, const uint8_t*, size_t, cliproxy_buffer*);
+typedef void (*cliproxy_host_free_fn)(void*, size_t);
+typedef struct { uint32_t abi_version; void* host_ctx; cliproxy_host_call_fn call; cliproxy_host_free_fn free_buffer; } cliproxy_host_api;
+typedef int (*cliproxy_plugin_call_fn)(char*, uint8_t*, size_t, cliproxy_buffer*);
+typedef void (*cliproxy_plugin_free_fn)(void*, size_t);
+typedef void (*cliproxy_plugin_shutdown_fn)(void);
+typedef struct { uint32_t abi_version; cliproxy_plugin_call_fn call; cliproxy_plugin_free_fn free_buffer; cliproxy_plugin_shutdown_fn shutdown; } cliproxy_plugin_api;
+extern int cliproxyPluginCall(char*, uint8_t*, size_t, cliproxy_buffer*);
+extern void cliproxyPluginFree(void*, size_t);
+extern void cliproxyPluginShutdown(void);
+static const cliproxy_host_api* stored_host;
+static void store_host_api(const cliproxy_host_api* host) { stored_host = host; }
+static int call_host_api(const char* method, const uint8_t* request, size_t request_len, cliproxy_buffer* response) {
+	if (stored_host == NULL || stored_host->call == NULL) return 1;
+	return stored_host->call(stored_host->host_ctx, method, request, request_len, response);
+}
+static void free_host_buffer(void* ptr, size_t len) {
+	if (stored_host != NULL && stored_host->free_buffer != NULL && ptr != NULL) stored_host->free_buffer(ptr, len);
+}
+*/
+import "C"
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+	"unsafe"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginabi"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+const pluginName = "quota-calendar"
+
+type envelope struct {
+	OK     bool            `json:"ok"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  *envelopeError  `json:"error,omitempty"`
+}
+type envelopeError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+type registration struct {
+	SchemaVersion uint32             `json:"schema_version"`
+	Metadata      pluginapi.Metadata `json:"metadata"`
+	Capabilities  map[string]bool    `json:"capabilities"`
+}
+type managementRegistration struct {
+	Resources []managementResource `json:"resources,omitempty"`
+}
+type managementResource struct {
+	Path        string `json:"Path"`
+	Menu        string `json:"Menu"`
+	Description string `json:"Description"`
+}
+type managementRequest struct {
+	Query map[string][]string `json:"Query"`
+}
+type managementResponse struct {
+	StatusCode int         `json:"StatusCode"`
+	Headers    http.Header `json:"Headers"`
+	Body       []byte      `json:"Body"`
+}
+type authListResponse struct {
+	Files []pluginapi.HostAuthFileEntry `json:"files"`
+}
+type authRuntimeResponse struct {
+	Auth pluginapi.HostAuthFileEntry `json:"auth"`
+}
+
+type event struct {
+	Model    string
+	Reset    time.Time
+	Revision time.Time
+	Provider string
+}
+
+func main() {}
+
+//export cliproxy_plugin_init
+func cliproxy_plugin_init(host *C.cliproxy_host_api, plugin *C.cliproxy_plugin_api) C.int {
+	if plugin == nil {
+		return 1
+	}
+	C.store_host_api(host)
+	plugin.abi_version = C.uint32_t(pluginabi.ABIVersion)
+	plugin.call = C.cliproxy_plugin_call_fn(C.cliproxyPluginCall)
+	plugin.free_buffer = C.cliproxy_plugin_free_fn(C.cliproxyPluginFree)
+	plugin.shutdown = C.cliproxy_plugin_shutdown_fn(C.cliproxyPluginShutdown)
+	return 0
+}
+
+//export cliproxyPluginCall
+func cliproxyPluginCall(method *C.char, request *C.uint8_t, requestLen C.size_t, response *C.cliproxy_buffer) C.int {
+	if response != nil {
+		response.ptr = nil
+		response.len = 0
+	}
+	if method == nil {
+		writeResponse(response, errorEnvelope("invalid_method", "method is required"))
+		return 1
+	}
+	var raw []byte
+	if request != nil && requestLen > 0 {
+		raw = C.GoBytes(unsafe.Pointer(request), C.int(requestLen))
+	}
+	result, err := handleMethod(C.GoString(method), raw)
+	if err != nil {
+		writeResponse(response, errorEnvelope("plugin_error", err.Error()))
+		return 1
+	}
+	writeResponse(response, result)
+	return 0
+}
+
+//export cliproxyPluginFree
+func cliproxyPluginFree(ptr unsafe.Pointer, length C.size_t) {
+	if ptr != nil {
+		C.free(ptr)
+	}
+	_ = length
+}
+
+//export cliproxyPluginShutdown
+func cliproxyPluginShutdown() {}
+
+func handleMethod(method string, raw []byte) ([]byte, error) {
+	switch method {
+	case pluginabi.MethodPluginRegister, pluginabi.MethodPluginReconfigure:
+		return okEnvelope(registration{SchemaVersion: pluginabi.SchemaVersion, Metadata: pluginapi.Metadata{Name: pluginName, Version: "0.1.0", Author: "TheVerwalter", GitHubRepository: "https://github.com/TheVerwalter/CLIProxyAPI-quota-calendar"}, Capabilities: map[string]bool{"management_api": true}})
+	case pluginabi.MethodManagementRegister:
+		return okEnvelope(managementRegistration{Resources: []managementResource{{Path: "/calendar.ics", Menu: "Quota Calendar", Description: "Current per-model quota reset events as an iCalendar feed."}}})
+	case pluginabi.MethodManagementHandle:
+		return handleManagement(raw)
+	default:
+		return errorEnvelope("unknown_method", "unknown method: "+method), nil
+	}
+}
+
+func handleManagement(raw []byte) ([]byte, error) {
+	var req struct {
+		Query map[string][]string `json:"Query"`
+	}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &req); err != nil {
+			return nil, err
+		}
+	}
+	_ = req
+	ics, err := buildCalendar()
+	if err != nil {
+		return nil, err
+	}
+	return okEnvelope(managementResponse{StatusCode: http.StatusOK, Headers: http.Header{"Content-Type": {"text/calendar; charset=utf-8"}, "Cache-Control": {"no-store, max-age=0"}}, Body: []byte(ics)})
+}
+
+func buildCalendar() (string, error) {
+	listRaw, err := callHost(pluginabi.MethodHostAuthList, nil)
+	if err != nil {
+		return "", err
+	}
+	var list authListResponse
+	if err := json.Unmarshal(listRaw, &list); err != nil {
+		return "", err
+	}
+	events := make(map[string]event)
+	for _, entry := range list.Files {
+		if entry.AuthIndex == "" {
+			continue
+		}
+		runtimeRaw, err := callHost(pluginabi.MethodHostAuthGetRuntime, mustJSON(pluginapi.HostAuthGetRequest{AuthIndex: entry.AuthIndex}))
+		if err != nil {
+			continue
+		}
+		var runtime authRuntimeResponse
+		if err := json.Unmarshal(runtimeRaw, &runtime); err != nil {
+			continue
+		}
+		for model, state := range runtime.Auth.ModelStates {
+			if state.NextReset.IsZero() || !state.NextReset.After(time.Now()) {
+				continue
+			}
+			key := strings.TrimSpace(runtime.Auth.Provider) + "\x00" + strings.TrimSpace(model)
+			revision := state.UpdatedAt
+			if revision.IsZero() {
+				revision = state.NextReset
+			}
+			candidate := event{Model: model, Reset: state.NextReset, Revision: revision, Provider: runtime.Auth.Provider}
+			if old, ok := events[key]; !ok || candidate.Reset.After(old.Reset) || (candidate.Reset.Equal(old.Reset) && candidate.Revision.After(old.Revision)) {
+				events[key] = candidate
+			}
+		}
+	}
+	items := make([]event, 0, len(events))
+	for _, item := range events {
+		items = append(items, item)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Provider == items[j].Provider {
+			return items[i].Model < items[j].Model
+		}
+		return items[i].Provider < items[j].Provider
+	})
+	var b strings.Builder
+	writeICSLine(&b, "BEGIN:VCALENDAR")
+	writeICSLine(&b, "PRODID:-//TheVerwalter//CLIProxyAPI Quota Calendar//EN")
+	writeICSLine(&b, "VERSION:2.0")
+	writeICSLine(&b, "CALSCALE:GREGORIAN")
+	writeICSLine(&b, "NAME:Quota resets")
+	writeICSLine(&b, "REFRESH-INTERVAL;VALUE=DURATION:PT15M")
+	writeICSLine(&b, "X-PUBLISHED-TTL:PT15M")
+	for _, item := range items {
+		uid := stableUID(item.Provider, item.Model)
+		writeICSLine(&b, "BEGIN:VEVENT")
+		writeICSLine(&b, "UID:"+uid)
+		writeICSLine(&b, "DTSTAMP:"+formatICS(item.Revision))
+		writeICSLine(&b, "LAST-MODIFIED:"+formatICS(item.Revision))
+		writeICSLine(&b, "DTSTART:"+formatICS(item.Reset))
+		writeICSLine(&b, "DTEND:"+formatICS(item.Reset.Add(time.Minute)))
+		writeICSLine(&b, "SUMMARY:"+escapeICS(item.Model+" quota reset"))
+		writeICSLine(&b, "DESCRIPTION:"+escapeICS("Provider: "+item.Provider))
+		writeICSLine(&b, "STATUS:CONFIRMED")
+		writeICSLine(&b, "TRANSP:TRANSPARENT")
+		writeICSLine(&b, "END:VEVENT")
+	}
+	writeICSLine(&b, "END:VCALENDAR")
+	return b.String(), nil
+}
+
+func stableUID(provider, model string) string {
+	return "quota-" + fmt.Sprintf("%x", fnv1a(provider+"\x00"+model)) + "@cliproxyapi"
+}
+func fnv1a(value string) uint64 {
+	var hash uint64 = 14695981039346656037
+	for i := 0; i < len(value); i++ {
+		hash ^= uint64(value[i])
+		hash *= 1099511628211
+	}
+	return hash
+}
+func formatICS(t time.Time) string { return t.UTC().Format("20060102T150405Z") }
+func writeICSLine(builder *strings.Builder, line string) {
+	first := true
+	for len(line) > 75 {
+		cut := 75
+		if !first {
+			cut = 74
+		}
+		for cut > 0 && (line[cut]&0xc0) == 0x80 {
+			cut--
+		}
+		if cut == 0 {
+			cut = 75
+		}
+		builder.WriteString(line[:cut])
+		builder.WriteString("\r\n ")
+		line = line[cut:]
+		first = false
+	}
+	builder.WriteString(line)
+	builder.WriteString("\r\n")
+}
+func escapeICS(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, ";", `\;`)
+	value = strings.ReplaceAll(value, ",", `\,`)
+	return strings.ReplaceAll(value, "\n", `\n`)
+}
+func mustJSON(value any) []byte { raw, _ := json.Marshal(value); return raw }
+
+func callHost(method string, payload []byte) ([]byte, error) {
+	cMethod := C.CString(method)
+	defer C.free(unsafe.Pointer(cMethod))
+	var request *C.uint8_t
+	if len(payload) > 0 {
+		request = (*C.uint8_t)(C.CBytes(payload))
+		defer C.free(unsafe.Pointer(request))
+	}
+	var response C.cliproxy_buffer
+	if C.call_host_api(cMethod, request, C.size_t(len(payload)), &response) != 0 || response.ptr == nil {
+		return nil, fmt.Errorf("host callback %s failed", method)
+	}
+	defer C.free_host_buffer(response.ptr, response.len)
+	raw := C.GoBytes(response.ptr, C.int(response.len))
+	var envelopeResponse envelope
+	if err := json.Unmarshal(raw, &envelopeResponse); err != nil {
+		return nil, fmt.Errorf("decode host callback envelope %s: %w", method, err)
+	}
+	if !envelopeResponse.OK {
+		if envelopeResponse.Error != nil {
+			return nil, fmt.Errorf("%s: %s", envelopeResponse.Error.Code, envelopeResponse.Error.Message)
+		}
+		return nil, fmt.Errorf("host callback %s failed", method)
+	}
+	return envelopeResponse.Result, nil
+}
+func okEnvelope(value any) ([]byte, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(envelope{OK: true, Result: raw})
+}
+func errorEnvelope(code, message string) []byte {
+	raw, _ := json.Marshal(envelope{OK: false, Error: &envelopeError{Code: code, Message: message}})
+	return raw
+}
+func writeResponse(response *C.cliproxy_buffer, raw []byte) {
+	if response == nil || len(raw) == 0 {
+		return
+	}
+	ptr := C.CBytes(raw)
+	if ptr == nil {
+		return
+	}
+	response.ptr = ptr
+	response.len = C.size_t(len(raw))
+}

--- a/examples/plugin/quota-calendar/go/quota_calendar_test.go
+++ b/examples/plugin/quota-calendar/go/quota_calendar_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStableUIDDoesNotChangeWhenResetMoves(t *testing.T) {
+	first := stableUID("claude", "claude-sonnet")
+	second := stableUID("claude", "claude-sonnet")
+	if first != second {
+		t.Fatalf("UID changed: %q != %q", first, second)
+	}
+	if first == stableUID("claude", "claude-opus") {
+		t.Fatal("different models share a UID")
+	}
+}
+
+func TestEscapeICS(t *testing.T) {
+	got := escapeICS("a,b;c\\d\ne")
+	want := `a\,b\;c\\d\ne`
+	if got != want {
+		t.Fatalf("escapeICS() = %q, want %q", got, want)
+	}
+}
+
+func TestCalendarUsesOneEventPerKeyAndLatestReset(t *testing.T) {
+	items := []event{
+		{Provider: "claude", Model: "sonnet", Reset: time.Date(2026, 8, 20, 11, 0, 0, 0, time.UTC)},
+		{Provider: "claude", Model: "sonnet", Reset: time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)},
+	}
+	latest := make(map[string]event)
+	for _, item := range items {
+		key := item.Provider + "\x00" + item.Model
+		if current, ok := latest[key]; !ok || item.Reset.After(current.Reset) {
+			latest[key] = item
+		}
+	}
+	if len(latest) != 1 || !latest["claude\x00sonnet"].Reset.Equal(items[1].Reset) {
+		t.Fatalf("latest = %#v", latest)
+	}
+	if strings.Contains(stableUID("claude", "sonnet"), ":") {
+		t.Fatal("UID should not depend on a delimiter that can enter model names")
+	}
+}
+
+func TestWriteICSLineUsesCRLFAndFolding(t *testing.T) {
+	var builder strings.Builder
+	writeICSLine(&builder, "SUMMARY:"+strings.Repeat("x", 100))
+	got := builder.String()
+	if !strings.Contains(got, "\r\n ") {
+		t.Fatalf("line was not folded: %q", got)
+	}
+	if strings.Contains(got, "\n\n") {
+		t.Fatalf("unexpected bare/newline sequence: %q", got)
+	}
+}
+
+func TestCalendarUsesSourceRevisionInsteadOfRequestTime(t *testing.T) {
+	revision := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	reset := revision.Add(time.Hour)
+	if got := formatICS(revision); got != "20260820T120000Z" {
+		t.Fatalf("formatICS(revision) = %q", got)
+	}
+	if got := formatICS(reset); got == formatICS(time.Now()) {
+		t.Fatal("test data unexpectedly used request time")
+	}
+}

--- a/internal/pluginhost/auth_callbacks.go
+++ b/internal/pluginhost/auth_callbacks.go
@@ -442,6 +442,31 @@ func (h *Host) buildHostAuthFileEntry(auth *coreauth.Auth) *pluginapi.HostAuthFi
 	if !auth.NextRetryAfter.IsZero() {
 		entry.NextRetryAfter = auth.NextRetryAfter
 	}
+	if len(auth.ModelStates) > 0 {
+		entry.ModelStates = make(map[string]pluginapi.HostModelState, len(auth.ModelStates))
+		for model, state := range auth.ModelStates {
+			if state == nil {
+				continue
+			}
+			nextReset := state.NextRetryAfter
+			if state.Quota.NextRecoverAt.After(nextReset) {
+				nextReset = state.Quota.NextRecoverAt
+			}
+			entry.ModelStates[model] = pluginapi.HostModelState{
+				Status:         string(state.Status),
+				StatusMessage:  state.StatusMessage,
+				Unavailable:    state.Unavailable,
+				NextRetryAfter: state.NextRetryAfter,
+				QuotaExceeded:  state.Quota.Exceeded,
+				QuotaReason:    state.Quota.Reason,
+				NextReset:      nextReset,
+				UpdatedAt:      state.UpdatedAt,
+			}
+		}
+		if len(entry.ModelStates) == 0 {
+			entry.ModelStates = nil
+		}
+	}
 	if path != "" {
 		entry.Path = path
 		entry.Source = "file"

--- a/internal/pluginhost/quota_runtime_test.go
+++ b/internal/pluginhost/quota_runtime_test.go
@@ -1,0 +1,64 @@
+package pluginhost
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginabi"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+func TestHostAuthGetRuntimeIncludesPerModelQuotaResetState(t *testing.T) {
+	next := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	auth := &coreauth.Auth{
+		ID:       "quota.json",
+		Provider: "demo",
+		FileName: "quota.json",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"runtime_only": "true",
+		},
+		ModelStates: map[string]*coreauth.ModelState{
+			"demo-model": {
+				Unavailable:    true,
+				NextRetryAfter: next,
+				Quota: coreauth.QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: next,
+				},
+				UpdatedAt: next.Add(-time.Minute),
+			},
+		},
+	}
+	auth.EnsureIndex()
+
+	host := New()
+	host.SetAuthManager(coreauth.NewManager(nil, nil, nil))
+	if _, errRegister := host.currentAuthManager().Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	request, errMarshal := json.Marshal(pluginapi.HostAuthGetRequest{AuthIndex: auth.Index})
+	if errMarshal != nil {
+		t.Fatalf("marshal request: %v", errMarshal)
+	}
+	raw, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthGetRuntime, request)
+	if errCall != nil {
+		t.Fatalf("callFromPlugin() error = %v", errCall)
+	}
+	response, errDecode := decodeRPCEnvelope[pluginapi.HostAuthGetRuntimeResponse](raw)
+	if errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if len(response.Auth.ModelStates) != 1 {
+		t.Fatalf("model states = %#v, want one model", response.Auth.ModelStates)
+	}
+	state, ok := response.Auth.ModelStates["demo-model"]
+	if !ok || !state.NextReset.Equal(next) {
+		t.Fatalf("demo-model state = %#v, want reset %v", state, next)
+	}
+}

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -710,6 +710,8 @@ type HostAuthFileEntry struct {
 	LastRefresh time.Time `json:"last_refresh,omitempty"`
 	// NextRetryAfter is the next retry timestamp.
 	NextRetryAfter time.Time `json:"next_retry_after,omitempty"`
+	// ModelStates contains a safe per-model runtime quota snapshot.
+	ModelStates map[string]HostModelState `json:"model_states,omitempty"`
 	// Email is the credential email when available.
 	Email string `json:"email,omitempty"`
 	// ProjectID is the credential project identifier when available.
@@ -730,6 +732,18 @@ type HostAuthFileEntry struct {
 	Failed int64 `json:"failed,omitempty"`
 	// RecentRequests is the recent request snapshot.
 	RecentRequests []HostRecentRequestEntry `json:"recent_requests,omitempty"`
+}
+
+// HostModelState describes the runtime availability and reset time for one model.
+type HostModelState struct {
+	Status         string    `json:"status,omitempty"`
+	StatusMessage  string    `json:"status_message,omitempty"`
+	Unavailable    bool      `json:"unavailable,omitempty"`
+	NextRetryAfter time.Time `json:"next_retry_after,omitempty"`
+	QuotaExceeded  bool      `json:"quota_exceeded,omitempty"`
+	QuotaReason    string    `json:"quota_reason,omitempty"`
+	NextReset      time.Time `json:"next_reset,omitempty"`
+	UpdatedAt      time.Time `json:"updated_at,omitempty"`
 }
 
 // HostAuthGetRequest asks the host for credential JSON by auth index.


### PR DESCRIPTION
## Summary
- expose per-model quota reset runtime state through the plugin host callback
- add the `quota-calendar` dynamic plugin example
- serve one stable-UID VEVENT per provider/model with the latest observed reset

## Design
The current plugin callback exposed only auth-level retry data, while CLIProxyAPI already tracks per-model state in `Auth.ModelStates`. This adds a non-secret `HostModelState` snapshot to `HostAuthFileEntry` and uses it from the plugin.

The feed uses deterministic CRLF serialization, UTC timestamps, stable UIDs, source-derived `DTSTAMP`/`LAST-MODIFIED`, and a 15-minute refresh hint. Expired or missing reset times are omitted.

## Tests
- `go test ./internal/pluginhost ./sdk/pluginapi ./sdk/cliproxy/auth`
- `go test ./...` in `examples/plugin/quota-calendar/go`
- `go build -buildmode=c-shared -o /tmp/quota-calendar.so .`
- `go build -o /tmp/cli-proxy-api ./cmd/server`
- `git diff --check`

## Security
The feed resource is unauthenticated under the existing plugin resource contract. The README explicitly recommends a private bind or reverse-proxy protection. No tokens or credential JSON are exposed by the new callback fields.
