### PR TITLE
fix(pluginhost): defer active native plugin updates until restart

### DIFF
--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -69,6 +69,7 @@ type configReloadSnapshot struct {
 }
 
 type pluginUpdateDeferrer interface {
+	PreparePluginUpdate(id string) bool
 	DeferPluginUpdateUntilRestart(id, targetPath, targetVersion string, contentChanged bool) bool
 	ClearDeferredPluginUpdate(id string)
 }

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -76,6 +76,10 @@ type pluginUpdateDeferrer interface {
 	ClearDeferredPluginUpdate(id string)
 }
 
+type pluginArtifactLocker interface {
+	LockPluginArtifact(id string) func()
+}
+
 // NewHandler creates a new management handler instance.
 func NewHandler(cfg *config.Config, configFilePath string, manager *coreauth.Manager) *Handler {
 	envSecret, _ := os.LookupEnv("MANAGEMENT_PASSWORD")

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -56,6 +56,8 @@ type Handler struct {
 	postAuthPersistHook     coreauth.PostAuthHook
 	pluginHost              *pluginhost.Host
 	pluginUpdateDeferrer    pluginUpdateDeferrer
+	pluginInstallLocksMu    sync.Mutex
+	pluginInstallLocks      map[string]*sync.Mutex
 	configReloadHook        func(context.Context, *config.Config)
 	pluginStoreRegistryURL  string
 	pluginStoreHTTPClient   pluginstore.HTTPDoer
@@ -165,6 +167,25 @@ func (h *Handler) pluginUpdateDeferrerSnapshot() pluginUpdateDeferrer {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	return h.pluginUpdateDeferrer
+}
+
+func (h *Handler) lockPluginInstall(id string) func() {
+	if h == nil {
+		return func() {}
+	}
+	id = strings.TrimSpace(id)
+	h.pluginInstallLocksMu.Lock()
+	if h.pluginInstallLocks == nil {
+		h.pluginInstallLocks = make(map[string]*sync.Mutex)
+	}
+	installMu := h.pluginInstallLocks[id]
+	if installMu == nil {
+		installMu = &sync.Mutex{}
+		h.pluginInstallLocks[id] = installMu
+	}
+	h.pluginInstallLocksMu.Unlock()
+	installMu.Lock()
+	return installMu.Unlock
 }
 
 // SetConfigReloadHook updates the callback used after management saves config changes.

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -55,6 +55,7 @@ type Handler struct {
 	postAuthHook            coreauth.PostAuthHook
 	postAuthPersistHook     coreauth.PostAuthHook
 	pluginHost              *pluginhost.Host
+	pluginUpdateDeferrer    pluginUpdateDeferrer
 	configReloadHook        func(context.Context, *config.Config)
 	pluginStoreRegistryURL  string
 	pluginStoreHTTPClient   pluginstore.HTTPDoer
@@ -65,6 +66,11 @@ type Handler struct {
 type configReloadSnapshot struct {
 	cfg        *config.Config
 	generation uint64
+}
+
+type pluginUpdateDeferrer interface {
+	DeferPluginUpdateUntilRestart(id, targetPath, targetVersion string, contentChanged bool) bool
+	ClearDeferredPluginUpdate(id string)
 }
 
 // NewHandler creates a new management handler instance.
@@ -147,7 +153,17 @@ func (h *Handler) SetPluginHost(host *pluginhost.Host) {
 	}
 	h.mu.Lock()
 	h.pluginHost = host
+	h.pluginUpdateDeferrer = host
 	h.mu.Unlock()
+}
+
+func (h *Handler) pluginUpdateDeferrerSnapshot() pluginUpdateDeferrer {
+	if h == nil {
+		return nil
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.pluginUpdateDeferrer
 }
 
 // SetConfigReloadHook updates the callback used after management saves config changes.

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -69,8 +69,8 @@ type configReloadSnapshot struct {
 }
 
 type pluginUpdateDeferrer interface {
-	PreparePluginUpdate(id string) bool
-	DeferPluginUpdateUntilRestart(id, targetPath, targetVersion string, contentChanged bool) bool
+	PreparePluginUpdate(id string) (deferred bool, created bool)
+	DeferPluginUpdateUntilRestart(id, targetPath, targetVersion string, contentChanged bool) (deferred bool, created bool)
 	ClearDeferredPluginUpdate(id string)
 }
 

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -80,6 +80,10 @@ type pluginArtifactLocker interface {
 	LockPluginArtifact(id string) func()
 }
 
+type pluginOperationLocker interface {
+	LockPluginOperation(id string) func()
+}
+
 // NewHandler creates a new management handler instance.
 func NewHandler(cfg *config.Config, configFilePath string, manager *coreauth.Manager) *Handler {
 	envSecret, _ := os.LookupEnv("MANAGEMENT_PASSWORD")

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -264,14 +264,17 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 	}
 	deferredUpdate := h.pluginUpdateDeferrerSnapshot()
 	restartRequired := false
+	deferredUpdateCreated := false
 	if deferredUpdate != nil {
 		installOptions.BeforeWrite = func() error {
-			restartRequired = deferredUpdate.PreparePluginUpdate(id)
+			var created bool
+			restartRequired, created = deferredUpdate.PreparePluginUpdate(id)
+			deferredUpdateCreated = deferredUpdateCreated || created
 			return nil
 		}
 	}
 	clearDeferredUpdate := func() {
-		if restartRequired {
+		if deferredUpdateCreated {
 			deferredUpdate.ClearDeferredPluginUpdate(id)
 		}
 	}
@@ -320,14 +323,14 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 		}
 	}
 	if deferredUpdate != nil {
-		if deferredUpdate.DeferPluginUpdateUntilRestart(
+		deferred, created := deferredUpdate.DeferPluginUpdateUntilRestart(
 			id,
 			result.Path,
 			result.Version,
 			!result.Skipped,
-		) {
-			restartRequired = true
-		}
+		)
+		restartRequired = restartRequired || deferred
+		deferredUpdateCreated = deferredUpdateCreated || created
 	}
 
 	h.mu.Lock()

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -265,6 +265,13 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 		PluginLoaded: pluginIsBusy,
 	}
 	deferredUpdate := h.pluginUpdateDeferrerSnapshot()
+	unlockOperation := func() {}
+	if operationLocker, ok := deferredUpdate.(pluginOperationLocker); ok {
+		if unlock := operationLocker.LockPluginOperation(id); unlock != nil {
+			unlockOperation = unlock
+		}
+	}
+	defer unlockOperation()
 	restartRequired := false
 	deferredUpdateCreated := false
 	if deferredUpdate != nil {

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -339,7 +339,6 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 		return
 	}
 	if errSave := config.SaveConfigPreserveComments(h.configFilePath, h.cfg); errSave != nil {
-		clearDeferredUpdate()
 		h.mu.Unlock()
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error":   "config_save_failed",

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -262,6 +262,19 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 		GOARCH:       goarch,
 		PluginLoaded: pluginIsBusy,
 	}
+	deferredUpdate := h.pluginUpdateDeferrerSnapshot()
+	restartRequired := false
+	if deferredUpdate != nil {
+		installOptions.BeforeWrite = func() error {
+			restartRequired = deferredUpdate.PreparePluginUpdate(id)
+			return nil
+		}
+	}
+	clearDeferredUpdate := func() {
+		if restartRequired {
+			deferredUpdate.ClearDeferredPluginUpdate(id)
+		}
+	}
 	var manifest pluginstore.Manifest
 	var result pluginstore.InstallResult
 	var errInstall error
@@ -281,6 +294,7 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 		return
 	}
 	if errInstall != nil {
+		clearDeferredUpdate()
 		if errors.Is(errInstall, pluginstore.ErrLoadedPluginLocked) {
 			c.JSON(http.StatusConflict, gin.H{
 				"error":            "plugin_update_requires_restart",
@@ -296,6 +310,7 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 		var errManifest error
 		manifest, errManifest = pluginStoreManifestForInstall(source, plugin, result)
 		if errManifest != nil {
+			clearDeferredUpdate()
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error":   "plugin_manifest_failed",
 				"message": fmt.Sprintf("plugin file installed at %s but creating store manifest failed: %s", result.Path, errManifest.Error()),
@@ -304,16 +319,14 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 			return
 		}
 	}
-	deferredUpdate := h.pluginUpdateDeferrerSnapshot()
-	restartRequired := deferredUpdate != nil && deferredUpdate.DeferPluginUpdateUntilRestart(
-		id,
-		result.Path,
-		result.Version,
-		!result.Skipped,
-	)
-	clearDeferredUpdate := func() {
-		if restartRequired {
-			deferredUpdate.ClearDeferredPluginUpdate(id)
+	if deferredUpdate != nil {
+		if deferredUpdate.DeferPluginUpdateUntilRestart(
+			id,
+			result.Path,
+			result.Version,
+			!result.Skipped,
+		) {
+			restartRequired = true
 		}
 	}
 

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -230,6 +230,8 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 	if !okID {
 		return
 	}
+	unlockPluginInstall := h.lockPluginInstall(id)
+	defer unlockPluginInstall()
 	requestedVersion, errVersionRequest := pluginInstallRequestedVersion(c)
 	if errVersionRequest != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "message": errVersionRequest.Error()})

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -304,10 +304,22 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 			return
 		}
 	}
-	restartRequired := false
+	deferredUpdate := h.pluginUpdateDeferrerSnapshot()
+	restartRequired := deferredUpdate != nil && deferredUpdate.DeferPluginUpdateUntilRestart(
+		id,
+		result.Path,
+		result.Version,
+		!result.Skipped,
+	)
+	clearDeferredUpdate := func() {
+		if restartRequired {
+			deferredUpdate.ClearDeferredPluginUpdate(id)
+		}
+	}
 
 	h.mu.Lock()
 	if h.cfg == nil {
+		clearDeferredUpdate()
 		h.mu.Unlock()
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error":   "config_unavailable",
@@ -317,6 +329,7 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 		return
 	}
 	if errEnable := h.enablePluginConfigLocked(id, manifest); errEnable != nil {
+		clearDeferredUpdate()
 		h.mu.Unlock()
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error":   "config_update_failed",
@@ -326,6 +339,7 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 		return
 	}
 	if errSave := config.SaveConfigPreserveComments(h.configFilePath, h.cfg); errSave != nil {
+		clearDeferredUpdate()
 		h.mu.Unlock()
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error":   "config_save_failed",

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -268,6 +268,11 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 	restartRequired := false
 	deferredUpdateCreated := false
 	if deferredUpdate != nil {
+		if artifactLocker, ok := deferredUpdate.(pluginArtifactLocker); ok {
+			installOptions.WriteLock = func() func() {
+				return artifactLocker.LockPluginArtifact(id)
+			}
+		}
 		installOptions.BeforeWrite = func() error {
 			var created bool
 			restartRequired, created = deferredUpdate.PreparePluginUpdate(id)

--- a/internal/api/handlers/management/plugin_store_test.go
+++ b/internal/api/handlers/management/plugin_store_test.go
@@ -1184,6 +1184,76 @@ func TestInstallPluginFromStoreOverwritesFilePreservesConfigAndReloads(t *testin
 	}
 }
 
+func TestInstallPluginFromStoreConfigSaveFailureRetainsDeferredUpdate(t *testing.T) {
+	pluginsDir := t.TempDir()
+	existingPath := filepath.Join(pluginsDir, runtime.GOOS, runtime.GOARCH, "sample-provider-v0.1.0"+managementPluginExtension(runtime.GOOS))
+	if errMkdir := os.MkdirAll(filepath.Dir(existingPath), 0o755); errMkdir != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", filepath.Dir(existingPath), errMkdir)
+	}
+	if errWrite := os.WriteFile(existingPath, []byte("old-library-data"), 0o644); errWrite != nil {
+		t.Fatalf("WriteFile(%s) error = %v", existingPath, errWrite)
+	}
+	archiveData := makeManagementPluginStoreZip(t, "sample-provider"+managementPluginExtension(runtime.GOOS), "new-library-data")
+	archiveName := "sample-provider_0.1.0_" + runtime.GOOS + "_" + runtime.GOARCH + ".zip"
+	checksum := sha256.Sum256(archiveData)
+	h := &Handler{
+		cfg: &config.Config{
+			Plugins: config.PluginsConfig{
+				Enabled: true,
+				Dir:     pluginsDir,
+				Configs: map[string]config.PluginInstanceConfig{
+					"sample-provider": pluginConfigFromYAML(t, "enabled: true\n"),
+				},
+			},
+		},
+		// A directory cannot be read as the YAML config file, forcing the save path to fail.
+		configFilePath:         t.TempDir(),
+		pluginStoreRegistryURL: "https://registry.example/registry.json",
+		pluginStoreHTTPClient: fakePluginStoreHTTPClient{
+			"https://registry.example/registry.json": registryJSON(t),
+			"https://api.github.com/repos/author-name/cliproxy-sample-provider-plugin/releases/latest": []byte(`{
+				"tag_name": "v0.1.0",
+				"assets": [
+					{"name": "` + archiveName + `", "browser_download_url": "https://downloads.example/` + archiveName + `"},
+					{"name": "checksums.txt", "browser_download_url": "https://downloads.example/checksums.txt"}
+				]
+			}`),
+			"https://downloads.example/" + archiveName: archiveData,
+			"https://downloads.example/checksums.txt":  []byte(hex.EncodeToString(checksum[:]) + "  " + archiveName + "\n"),
+		},
+	}
+	deferredUpdate := &recordingPluginUpdateDeferrer{restart: true}
+	h.pluginUpdateDeferrer = deferredUpdate
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Params = gin.Params{{Key: "id", Value: "sample-provider"}}
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/plugin-store/sample-provider/install", nil)
+
+	h.InstallPluginFromStore(c)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "config_save_failed") {
+		t.Fatalf("body = %s, want config_save_failed", rec.Body.String())
+	}
+	data, errRead := os.ReadFile(existingPath)
+	if errRead != nil {
+		t.Fatalf("ReadFile(%s) error = %v", existingPath, errRead)
+	}
+	if string(data) != "new-library-data" {
+		t.Fatalf("installed file = %q, want new-library-data", data)
+	}
+	if !deferredUpdate.deferred || deferredUpdate.clearCalls != 0 {
+		t.Fatalf("deferred update state = deferred:%v clear_calls:%d, want retained without clearing", deferredUpdate.deferred, deferredUpdate.clearCalls)
+	}
+	item := h.cfg.Plugins.Configs["sample-provider"]
+	if item.Enabled == nil || !*item.Enabled {
+		t.Fatalf("plugin enabled = %#v, want desired config retained in memory", item.Enabled)
+	}
+}
+
 func TestInstallPluginFromStoreFailedVerificationPreservesActiveState(t *testing.T) {
 	pluginsDir := t.TempDir()
 	existingPath := filepath.Join(pluginsDir, runtime.GOOS, runtime.GOARCH, "sample-provider-v0.1.0"+managementPluginExtension(runtime.GOOS))
@@ -1326,8 +1396,10 @@ type countingPluginStoreHTTPClient struct {
 }
 
 type recordingPluginUpdateDeferrer struct {
-	restart bool
-	calls   []pluginUpdateDeferralCall
+	restart    bool
+	deferred   bool
+	clearCalls int
+	calls      []pluginUpdateDeferralCall
 }
 
 type pluginUpdateDeferralCall struct {
@@ -1344,10 +1416,14 @@ func (d *recordingPluginUpdateDeferrer) DeferPluginUpdateUntilRestart(id, target
 		targetVersion:  targetVersion,
 		contentChanged: contentChanged,
 	})
+	d.deferred = d.restart
 	return d.restart
 }
 
-func (d *recordingPluginUpdateDeferrer) ClearDeferredPluginUpdate(string) {}
+func (d *recordingPluginUpdateDeferrer) ClearDeferredPluginUpdate(string) {
+	d.clearCalls++
+	d.deferred = false
+}
 
 func (c *countingPluginStoreHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	c.mu.Lock()

--- a/internal/api/handlers/management/plugin_store_test.go
+++ b/internal/api/handlers/management/plugin_store_test.go
@@ -1257,6 +1257,78 @@ func TestInstallPluginFromStoreConfigSaveFailureRetainsDeferredUpdate(t *testing
 	}
 }
 
+func TestInstallPluginFromStoreConfigUnavailableRetainsExistingDeferredUpdate(t *testing.T) {
+	pluginsDir := t.TempDir()
+	existingPath := filepath.Join(pluginsDir, runtime.GOOS, runtime.GOARCH, "sample-provider-v0.1.0"+managementPluginExtension(runtime.GOOS))
+	if errMkdir := os.MkdirAll(filepath.Dir(existingPath), 0o755); errMkdir != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", filepath.Dir(existingPath), errMkdir)
+	}
+	if errWrite := os.WriteFile(existingPath, []byte("old-library-data"), 0o644); errWrite != nil {
+		t.Fatalf("WriteFile(%s) error = %v", existingPath, errWrite)
+	}
+	archiveData := makeManagementPluginStoreZip(t, "sample-provider"+managementPluginExtension(runtime.GOOS), "new-library-data")
+	archiveName := "sample-provider_0.1.0_" + runtime.GOOS + "_" + runtime.GOARCH + ".zip"
+	checksum := sha256.Sum256(archiveData)
+	h := &Handler{
+		cfg: &config.Config{
+			Plugins: config.PluginsConfig{
+				Enabled: true,
+				Dir:     pluginsDir,
+				Configs: map[string]config.PluginInstanceConfig{
+					"sample-provider": pluginConfigFromYAML(t, "enabled: true\n"),
+				},
+			},
+		},
+		configFilePath:         writeTestConfigFile(t),
+		pluginStoreRegistryURL: "https://registry.example/registry.json",
+	}
+	h.pluginStoreHTTPClient = &mutatingPluginStoreHTTPClient{
+		responses: fakePluginStoreHTTPClient{
+			"https://registry.example/registry.json": registryJSON(t),
+			"https://api.github.com/repos/author-name/cliproxy-sample-provider-plugin/releases/latest": []byte(`{
+				"tag_name": "v0.1.0",
+				"assets": [
+					{"name": "` + archiveName + `", "browser_download_url": "https://downloads.example/` + archiveName + `"},
+					{"name": "checksums.txt", "browser_download_url": "https://downloads.example/checksums.txt"}
+				]
+			}`),
+			"https://downloads.example/" + archiveName: archiveData,
+			"https://downloads.example/checksums.txt":  []byte(hex.EncodeToString(checksum[:]) + "  " + archiveName + "\n"),
+		},
+		mutate: func() {
+			h.mu.Lock()
+			h.cfg = nil
+			h.mu.Unlock()
+		},
+	}
+	deferredUpdate := &recordingPluginUpdateDeferrer{restart: true}
+	h.pluginUpdateDeferrer = deferredUpdate
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Params = gin.Params{{Key: "id", Value: "sample-provider"}}
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/plugin-store/sample-provider/install", nil)
+
+	h.InstallPluginFromStore(c)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "config_unavailable") {
+		t.Fatalf("body = %s, want config_unavailable", rec.Body.String())
+	}
+	data, errRead := os.ReadFile(existingPath)
+	if errRead != nil {
+		t.Fatalf("ReadFile(%s) error = %v", existingPath, errRead)
+	}
+	if string(data) != "new-library-data" {
+		t.Fatalf("installed file = %q, want new-library-data", data)
+	}
+	if !deferredUpdate.deferred || deferredUpdate.clearCalls != 0 {
+		t.Fatalf("deferred update state = deferred:%v clear_calls:%d, want existing marker retained", deferredUpdate.deferred, deferredUpdate.clearCalls)
+	}
+}
+
 func TestInstallPluginFromStoreFailedVerificationPreservesActiveState(t *testing.T) {
 	pluginsDir := t.TempDir()
 	existingPath := filepath.Join(pluginsDir, runtime.GOOS, runtime.GOARCH, "sample-provider-v0.1.0"+managementPluginExtension(runtime.GOOS))
@@ -1398,12 +1470,25 @@ type countingPluginStoreHTTPClient struct {
 	counts    map[string]int
 }
 
+type mutatingPluginStoreHTTPClient struct {
+	responses fakePluginStoreHTTPClient
+	mutate    func()
+	once      sync.Once
+}
+
+func (c *mutatingPluginStoreHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	c.once.Do(c.mutate)
+	return c.responses.Do(req)
+}
+
 type recordingPluginUpdateDeferrer struct {
-	restart      bool
-	deferred     bool
-	prepareCalls int
-	clearCalls   int
-	calls        []pluginUpdateDeferralCall
+	restart        bool
+	prepareCreated bool
+	deferCreated   bool
+	deferred       bool
+	prepareCalls   int
+	clearCalls     int
+	calls          []pluginUpdateDeferralCall
 }
 
 type pluginUpdateDeferralCall struct {
@@ -1413,13 +1498,13 @@ type pluginUpdateDeferralCall struct {
 	contentChanged bool
 }
 
-func (d *recordingPluginUpdateDeferrer) PreparePluginUpdate(string) bool {
+func (d *recordingPluginUpdateDeferrer) PreparePluginUpdate(string) (bool, bool) {
 	d.prepareCalls++
 	d.deferred = d.restart
-	return d.restart
+	return d.restart, d.prepareCreated
 }
 
-func (d *recordingPluginUpdateDeferrer) DeferPluginUpdateUntilRestart(id, targetPath, targetVersion string, contentChanged bool) bool {
+func (d *recordingPluginUpdateDeferrer) DeferPluginUpdateUntilRestart(id, targetPath, targetVersion string, contentChanged bool) (bool, bool) {
 	d.calls = append(d.calls, pluginUpdateDeferralCall{
 		id:             id,
 		targetPath:     targetPath,
@@ -1427,7 +1512,7 @@ func (d *recordingPluginUpdateDeferrer) DeferPluginUpdateUntilRestart(id, target
 		contentChanged: contentChanged,
 	})
 	d.deferred = d.restart
-	return d.restart
+	return d.restart, d.deferCreated
 }
 
 func (d *recordingPluginUpdateDeferrer) ClearDeferredPluginUpdate(string) {

--- a/internal/api/handlers/management/plugin_store_test.go
+++ b/internal/api/handlers/management/plugin_store_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -1326,6 +1327,30 @@ func TestInstallPluginFromStoreConfigUnavailableRetainsExistingDeferredUpdate(t 
 	}
 	if !deferredUpdate.deferred || deferredUpdate.clearCalls != 0 {
 		t.Fatalf("deferred update state = deferred:%v clear_calls:%d, want existing marker retained", deferredUpdate.deferred, deferredUpdate.clearCalls)
+	}
+}
+
+func TestLockPluginInstallSerializesSameID(t *testing.T) {
+	h := &Handler{}
+	unlockFirst := h.lockPluginInstall("alpha")
+	acquired := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		unlockSecond := h.lockPluginInstall("alpha")
+		close(acquired)
+		unlockSecond()
+		close(done)
+	}()
+	select {
+	case <-acquired:
+		t.Fatal("second install acquired the same plugin lock before the first released it")
+	case <-time.After(20 * time.Millisecond):
+	}
+	unlockFirst()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("second install did not acquire the plugin lock after release")
 	}
 }
 

--- a/internal/api/handlers/management/plugin_store_test.go
+++ b/internal/api/handlers/management/plugin_store_test.go
@@ -1125,6 +1125,8 @@ func TestInstallPluginFromStoreOverwritesFilePreservesConfigAndReloads(t *testin
 			"https://downloads.example/checksums.txt":  []byte(hex.EncodeToString(checksum[:]) + "  " + archiveName + "\n"),
 		},
 	}
+	deferredUpdate := &recordingPluginUpdateDeferrer{restart: true}
+	h.pluginUpdateDeferrer = deferredUpdate
 	reloads, reloadDone := captureConfigReload(h)
 
 	rec := httptest.NewRecorder()
@@ -1136,6 +1138,16 @@ func TestInstallPluginFromStoreOverwritesFilePreservesConfigAndReloads(t *testin
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body pluginInstallResponse
+	if errDecode := json.Unmarshal(rec.Body.Bytes(), &body); errDecode != nil {
+		t.Fatalf("Unmarshal() error = %v; body=%s", errDecode, rec.Body.String())
+	}
+	if !body.RestartRequired {
+		t.Fatal("restart_required = false, want true for an active update")
+	}
+	if len(deferredUpdate.calls) != 1 || !deferredUpdate.calls[0].contentChanged {
+		t.Fatalf("deferred update calls = %#v, want one changed-content classification", deferredUpdate.calls)
 	}
 	cfgSnapshot := waitForAsyncReload(t, reloads)
 	waitForReloadDone(t, reloadDone)
@@ -1169,6 +1181,71 @@ func TestInstallPluginFromStoreOverwritesFilePreservesConfigAndReloads(t *testin
 	}
 	if raw := marshalPluginRaw(t, snapshotItem); !strings.Contains(raw, "mode: fast") || !strings.Contains(raw, "extra: keep") {
 		t.Fatalf("snapshot plugin raw config lost custom fields:\n%s", raw)
+	}
+}
+
+func TestInstallPluginFromStoreFailedVerificationPreservesActiveState(t *testing.T) {
+	pluginsDir := t.TempDir()
+	existingPath := filepath.Join(pluginsDir, runtime.GOOS, runtime.GOARCH, "sample-provider-v0.1.0"+managementPluginExtension(runtime.GOOS))
+	if errMkdir := os.MkdirAll(filepath.Dir(existingPath), 0o755); errMkdir != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", filepath.Dir(existingPath), errMkdir)
+	}
+	if errWrite := os.WriteFile(existingPath, []byte("old-library-data"), 0o644); errWrite != nil {
+		t.Fatalf("WriteFile(%s) error = %v", existingPath, errWrite)
+	}
+	archiveData := makeManagementPluginStoreZip(t, "sample-provider"+managementPluginExtension(runtime.GOOS), "new-library-data")
+	archiveName := "sample-provider_0.1.0_" + runtime.GOOS + "_" + runtime.GOARCH + ".zip"
+	h := &Handler{
+		cfg: &config.Config{
+			Plugins: config.PluginsConfig{
+				Enabled: true,
+				Dir:     pluginsDir,
+				Configs: map[string]config.PluginInstanceConfig{
+					"sample-provider": pluginConfigFromYAML(t, "enabled: true\nmode: fast\n"),
+				},
+			},
+		},
+		configFilePath:         writeTestConfigFile(t),
+		pluginStoreRegistryURL: "https://registry.example/registry.json",
+		pluginStoreHTTPClient: fakePluginStoreHTTPClient{
+			"https://registry.example/registry.json": registryJSON(t),
+			"https://api.github.com/repos/author-name/cliproxy-sample-provider-plugin/releases/latest": []byte(`{
+				"tag_name": "v0.1.0",
+				"assets": [
+					{"name": "` + archiveName + `", "browser_download_url": "https://downloads.example/` + archiveName + `"},
+					{"name": "checksums.txt", "browser_download_url": "https://downloads.example/checksums.txt"}
+				]
+			}`),
+			"https://downloads.example/" + archiveName: archiveData,
+			"https://downloads.example/checksums.txt":  []byte(strings.Repeat("0", 64) + "  " + archiveName + "\n"),
+		},
+	}
+	deferredUpdate := &recordingPluginUpdateDeferrer{restart: true}
+	h.pluginUpdateDeferrer = deferredUpdate
+	originalConfig := marshalPluginRaw(t, h.cfg.Plugins.Configs["sample-provider"])
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Params = gin.Params{{Key: "id", Value: "sample-provider"}}
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/plugin-store/sample-provider/install", nil)
+
+	h.InstallPluginFromStore(c)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadGateway, rec.Body.String())
+	}
+	data, errRead := os.ReadFile(existingPath)
+	if errRead != nil {
+		t.Fatalf("ReadFile(%s) error = %v", existingPath, errRead)
+	}
+	if string(data) != "old-library-data" {
+		t.Fatalf("active artifact = %q, want old-library-data", data)
+	}
+	if got := marshalPluginRaw(t, h.cfg.Plugins.Configs["sample-provider"]); got != originalConfig {
+		t.Fatalf("config changed after failed verification:\n%s", got)
+	}
+	if len(deferredUpdate.calls) != 0 {
+		t.Fatalf("deferred update calls = %#v, want none after failed verification", deferredUpdate.calls)
 	}
 }
 
@@ -1247,6 +1324,30 @@ type countingPluginStoreHTTPClient struct {
 	mu        sync.Mutex
 	counts    map[string]int
 }
+
+type recordingPluginUpdateDeferrer struct {
+	restart bool
+	calls   []pluginUpdateDeferralCall
+}
+
+type pluginUpdateDeferralCall struct {
+	id             string
+	targetPath     string
+	targetVersion  string
+	contentChanged bool
+}
+
+func (d *recordingPluginUpdateDeferrer) DeferPluginUpdateUntilRestart(id, targetPath, targetVersion string, contentChanged bool) bool {
+	d.calls = append(d.calls, pluginUpdateDeferralCall{
+		id:             id,
+		targetPath:     targetPath,
+		targetVersion:  targetVersion,
+		contentChanged: contentChanged,
+	})
+	return d.restart
+}
+
+func (d *recordingPluginUpdateDeferrer) ClearDeferredPluginUpdate(string) {}
 
 func (c *countingPluginStoreHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	c.mu.Lock()

--- a/internal/api/handlers/management/plugin_store_test.go
+++ b/internal/api/handlers/management/plugin_store_test.go
@@ -1146,6 +1146,9 @@ func TestInstallPluginFromStoreOverwritesFilePreservesConfigAndReloads(t *testin
 	if !body.RestartRequired {
 		t.Fatal("restart_required = false, want true for an active update")
 	}
+	if deferredUpdate.prepareCalls != 1 {
+		t.Fatalf("prepare calls = %d, want one before artifact write", deferredUpdate.prepareCalls)
+	}
 	if len(deferredUpdate.calls) != 1 || !deferredUpdate.calls[0].contentChanged {
 		t.Fatalf("deferred update calls = %#v, want one changed-content classification", deferredUpdate.calls)
 	}
@@ -1396,10 +1399,11 @@ type countingPluginStoreHTTPClient struct {
 }
 
 type recordingPluginUpdateDeferrer struct {
-	restart    bool
-	deferred   bool
-	clearCalls int
-	calls      []pluginUpdateDeferralCall
+	restart      bool
+	deferred     bool
+	prepareCalls int
+	clearCalls   int
+	calls        []pluginUpdateDeferralCall
 }
 
 type pluginUpdateDeferralCall struct {
@@ -1407,6 +1411,12 @@ type pluginUpdateDeferralCall struct {
 	targetPath     string
 	targetVersion  string
 	contentChanged bool
+}
+
+func (d *recordingPluginUpdateDeferrer) PreparePluginUpdate(string) bool {
+	d.prepareCalls++
+	d.deferred = d.restart
+	return d.restart
 }
 
 func (d *recordingPluginUpdateDeferrer) DeferPluginUpdateUntilRestart(id, targetPath, targetVersion string, contentChanged bool) bool {

--- a/internal/api/handlers/management/plugin_store_test.go
+++ b/internal/api/handlers/management/plugin_store_test.go
@@ -1153,6 +1153,9 @@ func TestInstallPluginFromStoreOverwritesFilePreservesConfigAndReloads(t *testin
 	if len(deferredUpdate.calls) != 1 || !deferredUpdate.calls[0].contentChanged {
 		t.Fatalf("deferred update calls = %#v, want one changed-content classification", deferredUpdate.calls)
 	}
+	if deferredUpdate.operationCalls != 1 || deferredUpdate.operationHeld || deferredUpdate.operationViolations != 0 {
+		t.Fatalf("operation lock state = calls:%d held:%v violations:%d, want one completed operation around deferral", deferredUpdate.operationCalls, deferredUpdate.operationHeld, deferredUpdate.operationViolations)
+	}
 	cfgSnapshot := waitForAsyncReload(t, reloads)
 	waitForReloadDone(t, reloadDone)
 	if cfgSnapshot == h.cfg {
@@ -1507,13 +1510,16 @@ func (c *mutatingPluginStoreHTTPClient) Do(req *http.Request) (*http.Response, e
 }
 
 type recordingPluginUpdateDeferrer struct {
-	restart        bool
-	prepareCreated bool
-	deferCreated   bool
-	deferred       bool
-	prepareCalls   int
-	clearCalls     int
-	calls          []pluginUpdateDeferralCall
+	restart             bool
+	prepareCreated      bool
+	deferCreated        bool
+	deferred            bool
+	prepareCalls        int
+	clearCalls          int
+	operationCalls      int
+	operationHeld       bool
+	operationViolations int
+	calls               []pluginUpdateDeferralCall
 }
 
 type pluginUpdateDeferralCall struct {
@@ -1524,12 +1530,18 @@ type pluginUpdateDeferralCall struct {
 }
 
 func (d *recordingPluginUpdateDeferrer) PreparePluginUpdate(string) (bool, bool) {
+	if !d.operationHeld {
+		d.operationViolations++
+	}
 	d.prepareCalls++
 	d.deferred = d.restart
 	return d.restart, d.prepareCreated
 }
 
 func (d *recordingPluginUpdateDeferrer) DeferPluginUpdateUntilRestart(id, targetPath, targetVersion string, contentChanged bool) (bool, bool) {
+	if !d.operationHeld {
+		d.operationViolations++
+	}
 	d.calls = append(d.calls, pluginUpdateDeferralCall{
 		id:             id,
 		targetPath:     targetPath,
@@ -1543,6 +1555,12 @@ func (d *recordingPluginUpdateDeferrer) DeferPluginUpdateUntilRestart(id, target
 func (d *recordingPluginUpdateDeferrer) ClearDeferredPluginUpdate(string) {
 	d.clearCalls++
 	d.deferred = false
+}
+
+func (d *recordingPluginUpdateDeferrer) LockPluginOperation(string) func() {
+	d.operationCalls++
+	d.operationHeld = true
+	return func() { d.operationHeld = false }
 }
 
 func (c *countingPluginStoreHTTPClient) Do(req *http.Request) (*http.Response, error) {

--- a/internal/homeplugins/sync.go
+++ b/internal/homeplugins/sync.go
@@ -41,6 +41,10 @@ type pluginArtifactLocker interface {
 	LockPluginArtifact(id string) func()
 }
 
+type pluginOperationLocker interface {
+	LockPluginOperation(id string) func()
+}
+
 type pluginUpdateDeferrer interface {
 	PreparePluginUpdate(id string) (deferred bool, created bool)
 	DeferPluginUpdateUntilRestart(id, targetPath, targetVersion string, contentChanged bool) (deferred bool, created bool)
@@ -366,6 +370,13 @@ func installManifest(ctx context.Context, client sdkpluginstore.Client, manifest
 	if id == "" {
 		return sdkpluginstore.InstallResult{}, false, fmt.Errorf("home plugins: manifest plugin id is empty")
 	}
+	unlockOperation := func() {}
+	if operationLocker, ok := pluginRuntime.(pluginOperationLocker); ok {
+		if unlock := operationLocker.LockPluginOperation(id); unlock != nil {
+			unlockOperation = unlock
+		}
+	}
+	defer unlockOperation()
 	pluginIsBusy := func() bool {
 		return pluginRuntime != nil && pluginRuntime.PluginBusy(id)
 	}

--- a/internal/homeplugins/sync.go
+++ b/internal/homeplugins/sync.go
@@ -37,6 +37,10 @@ type contextualPluginUnloader interface {
 	UnloadPluginContext(ctx context.Context, id string) bool
 }
 
+type pluginArtifactLocker interface {
+	LockPluginArtifact(id string) func()
+}
+
 type SyncReport struct {
 	SchemaVersion int                   `json:"schema_version"`
 	TaskID        uint                  `json:"task_id,omitempty"`
@@ -355,12 +359,18 @@ func installManifest(ctx context.Context, client sdkpluginstore.Client, manifest
 	pluginIsBusy := func() bool {
 		return pluginRuntime != nil && pluginRuntime.PluginBusy(id)
 	}
-	result, errInstall := client.InstallManifest(ctx, manifest, sdkpluginstore.InstallOptions{
+	installOptions := sdkpluginstore.InstallOptions{
 		PluginsDir:   root,
 		GOOS:         platform.GOOS,
 		GOARCH:       platform.GOARCH,
 		PluginLoaded: pluginIsBusy,
-	})
+	}
+	if artifactLocker, ok := pluginRuntime.(pluginArtifactLocker); ok {
+		installOptions.WriteLock = func() func() {
+			return artifactLocker.LockPluginArtifact(id)
+		}
+	}
+	result, errInstall := client.InstallManifest(ctx, manifest, installOptions)
 	if errInstall != nil {
 		return sdkpluginstore.InstallResult{}, fmt.Errorf("home plugins: install %s: %w", id, errInstall)
 	}

--- a/internal/homeplugins/sync.go
+++ b/internal/homeplugins/sync.go
@@ -64,17 +64,18 @@ type SyncReport struct {
 }
 
 type PluginInstallStatus struct {
-	ID            string `json:"id"`
-	Version       string `json:"version,omitempty"`
-	ReleaseTag    string `json:"release_tag,omitempty"`
-	Repository    string `json:"repository,omitempty"`
-	InstallType   string `json:"install_type,omitempty"`
-	InstallStatus string `json:"install_status"`
-	LoadStatus    string `json:"load_status,omitempty"`
-	Path          string `json:"path,omitempty"`
-	Skipped       bool   `json:"skipped,omitempty"`
-	Overwritten   bool   `json:"overwritten,omitempty"`
-	Error         string `json:"error,omitempty"`
+	ID              string `json:"id"`
+	Version         string `json:"version,omitempty"`
+	ReleaseTag      string `json:"release_tag,omitempty"`
+	Repository      string `json:"repository,omitempty"`
+	InstallType     string `json:"install_type,omitempty"`
+	InstallStatus   string `json:"install_status"`
+	LoadStatus      string `json:"load_status,omitempty"`
+	RestartRequired bool   `json:"restart_required,omitempty"`
+	Path            string `json:"path,omitempty"`
+	Skipped         bool   `json:"skipped,omitempty"`
+	Overwritten     bool   `json:"overwritten,omitempty"`
+	Error           string `json:"error,omitempty"`
 }
 
 const (
@@ -86,13 +87,14 @@ const (
 	pluginTaskPhaseLoad    = "load"
 	pluginTaskPhaseDelete  = "delete"
 
-	pluginInstallStatusInstalled = "installed"
-	pluginInstallStatusSkipped   = "skipped"
-	pluginInstallStatusFailed    = "failed"
-	pluginInstallStatusDeleted   = "deleted"
-	pluginInstallStatusMissing   = "missing"
-	pluginLoadStatusLoaded       = "loaded"
-	pluginLoadStatusFailed       = "failed"
+	pluginInstallStatusInstalled    = "installed"
+	pluginInstallStatusSkipped      = "skipped"
+	pluginInstallStatusFailed       = "failed"
+	pluginInstallStatusDeleted      = "deleted"
+	pluginInstallStatusMissing      = "missing"
+	pluginLoadStatusLoaded          = "loaded"
+	pluginLoadStatusRestartRequired = "restart_required"
+	pluginLoadStatusFailed          = "failed"
 )
 
 // CurrentPlatform reports the platform used by pluginhost discovery.
@@ -183,7 +185,7 @@ func SyncPlatformWithReport(ctx context.Context, cfg *config.Config, pluginRunti
 			continue
 		}
 		status := pluginStatusFromManifest(manifest)
-		result, errSync := installManifest(ctx, client, manifest, root, platform, pluginRuntime)
+		result, restartRequired, errSync := installManifest(ctx, client, manifest, root, platform, pluginRuntime)
 		if errSync != nil {
 			status.InstallStatus = pluginInstallStatusFailed
 			status.Error = errSync.Error()
@@ -194,6 +196,7 @@ func SyncPlatformWithReport(ctx context.Context, cfg *config.Config, pluginRunti
 		status.Path = strings.TrimSpace(result.Path)
 		status.Skipped = result.Skipped
 		status.Overwritten = result.Overwritten
+		status.RestartRequired = restartRequired
 		if result.Skipped {
 			status.InstallStatus = pluginInstallStatusSkipped
 		} else {
@@ -235,7 +238,7 @@ func SyncResolvedWithReport(ctx context.Context, cfg *config.Config, items []sdk
 		item := &items[index]
 		manifest := item.Manifest
 		status := pluginStatusFromManifest(manifest)
-		result, errInstall := installResolvedManifest(ctx, cfg, manifest, item.Auth, expiresAt, root, platform, pluginRuntime)
+		result, restartRequired, errInstall := installResolvedManifest(ctx, cfg, manifest, item.Auth, expiresAt, root, platform, pluginRuntime)
 		item.Clear()
 		if errInstall != nil {
 			status.InstallStatus = pluginInstallStatusFailed
@@ -247,6 +250,7 @@ func SyncResolvedWithReport(ctx context.Context, cfg *config.Config, items []sdk
 		status.Path = strings.TrimSpace(result.Path)
 		status.Skipped = result.Skipped
 		status.Overwritten = result.Overwritten
+		status.RestartRequired = restartRequired
 		if result.Skipped {
 			status.InstallStatus = pluginInstallStatusSkipped
 		} else {
@@ -326,7 +330,7 @@ func upsertPluginInstallStatus(report *SyncReport, status PluginInstallStatus) {
 	report.Plugins = append(report.Plugins, status)
 }
 
-func installResolvedManifest(ctx context.Context, cfg *config.Config, manifest sdkpluginstore.Manifest, auth []sdkpluginstore.ResolvedAuthConfig, expiresAt time.Time, root string, platform Platform, pluginRuntime PluginRuntime) (sdkpluginstore.InstallResult, error) {
+func installResolvedManifest(ctx context.Context, cfg *config.Config, manifest sdkpluginstore.Manifest, auth []sdkpluginstore.ResolvedAuthConfig, expiresAt time.Time, root string, platform Platform, pluginRuntime PluginRuntime) (sdkpluginstore.InstallResult, bool, error) {
 	client := newResolvedPluginStoreClient(cfg, auth, expiresAt)
 	defer client.ClearAuth()
 	return installManifest(ctx, client, manifest, root, platform, pluginRuntime)
@@ -357,10 +361,10 @@ func InstalledVersions(cfg *config.Config) (map[string]string, error) {
 	return versions, nil
 }
 
-func installManifest(ctx context.Context, client sdkpluginstore.Client, manifest sdkpluginstore.Manifest, root string, platform Platform, pluginRuntime PluginRuntime) (sdkpluginstore.InstallResult, error) {
+func installManifest(ctx context.Context, client sdkpluginstore.Client, manifest sdkpluginstore.Manifest, root string, platform Platform, pluginRuntime PluginRuntime) (sdkpluginstore.InstallResult, bool, error) {
 	id := strings.TrimSpace(manifest.ID)
 	if id == "" {
-		return sdkpluginstore.InstallResult{}, fmt.Errorf("home plugins: manifest plugin id is empty")
+		return sdkpluginstore.InstallResult{}, false, fmt.Errorf("home plugins: manifest plugin id is empty")
 	}
 	pluginIsBusy := func() bool {
 		return pluginRuntime != nil && pluginRuntime.PluginBusy(id)
@@ -390,12 +394,13 @@ func installManifest(ctx context.Context, client sdkpluginstore.Client, manifest
 		if deferredUpdateCreated {
 			deferredUpdate.ClearDeferredPluginUpdate(id)
 		}
-		return sdkpluginstore.InstallResult{}, fmt.Errorf("home plugins: install %s: %w", id, errInstall)
+		return sdkpluginstore.InstallResult{}, false, fmt.Errorf("home plugins: install %s: %w", id, errInstall)
 	}
+	restartRequired := false
 	if deferredUpdate != nil {
-		deferredUpdate.DeferPluginUpdateUntilRestart(id, result.Path, result.Version, !result.Skipped)
+		restartRequired, _ = deferredUpdate.DeferPluginUpdateUntilRestart(id, result.Path, result.Version, !result.Skipped)
 	}
-	return result, nil
+	return result, restartRequired, nil
 }
 
 func DeleteWithReport(ctx context.Context, cfg *config.Config, pluginRuntime PluginRuntime, taskID uint, pluginID string) SyncReport {
@@ -728,6 +733,10 @@ func MarkLoadResults(report *SyncReport, inspector PluginLoadInspector) error {
 					loadErrors = append(loadErrors, fmt.Errorf("home plugins: plugin %s install failed", status.ID))
 				}
 			}
+			continue
+		}
+		if status.RestartRequired {
+			status.LoadStatus = pluginLoadStatusRestartRequired
 			continue
 		}
 		if inspector != nil && inspector.PluginRegistered(status.ID) {

--- a/internal/homeplugins/sync.go
+++ b/internal/homeplugins/sync.go
@@ -41,6 +41,12 @@ type pluginArtifactLocker interface {
 	LockPluginArtifact(id string) func()
 }
 
+type pluginUpdateDeferrer interface {
+	PreparePluginUpdate(id string) (deferred bool, created bool)
+	DeferPluginUpdateUntilRestart(id, targetPath, targetVersion string, contentChanged bool) (deferred bool, created bool)
+	ClearDeferredPluginUpdate(id string)
+}
+
 type SyncReport struct {
 	SchemaVersion int                   `json:"schema_version"`
 	TaskID        uint                  `json:"task_id,omitempty"`
@@ -365,6 +371,15 @@ func installManifest(ctx context.Context, client sdkpluginstore.Client, manifest
 		GOARCH:       platform.GOARCH,
 		PluginLoaded: pluginIsBusy,
 	}
+	deferredUpdate, _ := pluginRuntime.(pluginUpdateDeferrer)
+	deferredUpdateCreated := false
+	if deferredUpdate != nil {
+		installOptions.BeforeWrite = func() error {
+			_, created := deferredUpdate.PreparePluginUpdate(id)
+			deferredUpdateCreated = deferredUpdateCreated || created
+			return nil
+		}
+	}
 	if artifactLocker, ok := pluginRuntime.(pluginArtifactLocker); ok {
 		installOptions.WriteLock = func() func() {
 			return artifactLocker.LockPluginArtifact(id)
@@ -372,7 +387,13 @@ func installManifest(ctx context.Context, client sdkpluginstore.Client, manifest
 	}
 	result, errInstall := client.InstallManifest(ctx, manifest, installOptions)
 	if errInstall != nil {
+		if deferredUpdateCreated {
+			deferredUpdate.ClearDeferredPluginUpdate(id)
+		}
 		return sdkpluginstore.InstallResult{}, fmt.Errorf("home plugins: install %s: %w", id, errInstall)
+	}
+	if deferredUpdate != nil {
+		deferredUpdate.DeferPluginUpdateUntilRestart(id, result.Path, result.Version, !result.Skipped)
 	}
 	return result, nil
 }

--- a/internal/homeplugins/sync_test.go
+++ b/internal/homeplugins/sync_test.go
@@ -27,6 +27,13 @@ type fakePluginRuntime struct {
 	unloaded []string
 }
 
+type deferredPluginRuntime struct {
+	fakePluginRuntime
+	prepareCalls int
+	deferCalls   int
+	clearCalls   int
+}
+
 type fakePluginLoadInspector map[string]bool
 
 func (r *fakePluginRuntime) PluginBusy(id string) bool {
@@ -37,6 +44,20 @@ func (r *fakePluginRuntime) UnloadPlugin(id string) bool {
 	r.unloaded = append(r.unloaded, id)
 	r.busy = false
 	return true
+}
+
+func (r *deferredPluginRuntime) PreparePluginUpdate(string) (bool, bool) {
+	r.prepareCalls++
+	return r.busy, r.busy
+}
+
+func (r *deferredPluginRuntime) DeferPluginUpdateUntilRestart(string, string, string, bool) (bool, bool) {
+	r.deferCalls++
+	return r.busy, false
+}
+
+func (r *deferredPluginRuntime) ClearDeferredPluginUpdate(string) {
+	r.clearCalls++
 }
 
 func (i fakePluginLoadInspector) PluginRegistered(id string) bool {
@@ -321,6 +342,49 @@ func TestSyncPlatformWithReportRecordsSuccessfulInstall(t *testing.T) {
 	}
 	if wantPath := pluginTestPath(root, "windows", "amd64", "sample", "0.2.0"); plugin.Path != wantPath {
 		t.Fatalf("plugin path = %q, want %q", plugin.Path, wantPath)
+	}
+}
+
+func TestSyncPlatformWithReportDefersActiveUpdateUntilRestart(t *testing.T) {
+	root := t.TempDir()
+	target := pluginTestPath(root, "linux", "amd64", "sample", "0.2.0")
+	if errMkdir := os.MkdirAll(filepath.Dir(target), 0o755); errMkdir != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", filepath.Dir(target), errMkdir)
+	}
+	if errWrite := os.WriteFile(target, []byte("old-library-data"), 0o644); errWrite != nil {
+		t.Fatalf("WriteFile(%s) error = %v", target, errWrite)
+	}
+	archiveData := makeZip(t, map[string]string{"sample.so": "new-library-data"})
+	archiveName := "sample_0.2.0_linux_amd64.zip"
+	checksum := sha256.Sum256(archiveData)
+	httpClient := mapHTTPDoer{
+		"https://api.github.com/repos/owner/sample-plugin/releases/tags/v0.2.0": []byte(`{
+			"tag_name": "v0.2.0",
+			"assets": [
+				{"name": "` + archiveName + `", "browser_download_url": "https://downloads.example/` + archiveName + `"},
+				{"name": "checksums.txt", "browser_download_url": "https://downloads.example/checksums.txt"}
+			]
+		}`),
+		"https://downloads.example/" + archiveName: archiveData,
+		"https://downloads.example/checksums.txt":  []byte(hex.EncodeToString(checksum[:]) + "  " + archiveName + "\n"),
+	}
+	restore := replacePluginStoreClientForTest(httpClient)
+	defer restore()
+	runtimeHost := &deferredPluginRuntime{fakePluginRuntime: fakePluginRuntime{busy: true}}
+
+	report, errSync := SyncPlatformWithReport(context.Background(), syncTestConfig(t, root), runtimeHost, Platform{GOOS: "linux", GOARCH: "amd64"})
+	if errSync != nil {
+		t.Fatalf("SyncPlatformWithReport() error = %v", errSync)
+	}
+	if !report.OK || runtimeHost.prepareCalls != 1 || runtimeHost.deferCalls != 1 || runtimeHost.clearCalls != 0 {
+		t.Fatalf("report = %+v, runtime hooks = prepare:%d defer:%d clear:%d; want one prepare/defer and no clear", report, runtimeHost.prepareCalls, runtimeHost.deferCalls, runtimeHost.clearCalls)
+	}
+	data, errRead := os.ReadFile(target)
+	if errRead != nil {
+		t.Fatalf("ReadFile(%s) error = %v", target, errRead)
+	}
+	if string(data) != "new-library-data" {
+		t.Fatalf("installed file = %q, want new-library-data", data)
 	}
 }
 

--- a/internal/homeplugins/sync_test.go
+++ b/internal/homeplugins/sync_test.go
@@ -379,6 +379,15 @@ func TestSyncPlatformWithReportDefersActiveUpdateUntilRestart(t *testing.T) {
 	if !report.OK || runtimeHost.prepareCalls != 1 || runtimeHost.deferCalls != 1 || runtimeHost.clearCalls != 0 {
 		t.Fatalf("report = %+v, runtime hooks = prepare:%d defer:%d clear:%d; want one prepare/defer and no clear", report, runtimeHost.prepareCalls, runtimeHost.deferCalls, runtimeHost.clearCalls)
 	}
+	if len(report.Plugins) != 1 || !report.Plugins[0].RestartRequired {
+		t.Fatalf("plugin report = %+v, want restart_required for active update", report.Plugins)
+	}
+	if errLoad := MarkLoadResults(&report, fakePluginLoadInspector{"sample": true}); errLoad != nil {
+		t.Fatalf("MarkLoadResults() error = %v, want deferred update to remain successful", errLoad)
+	}
+	if report.Plugins[0].LoadStatus != pluginLoadStatusRestartRequired {
+		t.Fatalf("load status = %q, want %q", report.Plugins[0].LoadStatus, pluginLoadStatusRestartRequired)
+	}
 	data, errRead := os.ReadFile(target)
 	if errRead != nil {
 		t.Fatalf("ReadFile(%s) error = %v", target, errRead)

--- a/internal/homeplugins/sync_test.go
+++ b/internal/homeplugins/sync_test.go
@@ -29,9 +29,12 @@ type fakePluginRuntime struct {
 
 type deferredPluginRuntime struct {
 	fakePluginRuntime
-	prepareCalls int
-	deferCalls   int
-	clearCalls   int
+	prepareCalls        int
+	deferCalls          int
+	clearCalls          int
+	operationCalls      int
+	operationHeld       bool
+	operationViolations int
 }
 
 type fakePluginLoadInspector map[string]bool
@@ -47,17 +50,29 @@ func (r *fakePluginRuntime) UnloadPlugin(id string) bool {
 }
 
 func (r *deferredPluginRuntime) PreparePluginUpdate(string) (bool, bool) {
+	if !r.operationHeld {
+		r.operationViolations++
+	}
 	r.prepareCalls++
 	return r.busy, r.busy
 }
 
 func (r *deferredPluginRuntime) DeferPluginUpdateUntilRestart(string, string, string, bool) (bool, bool) {
+	if !r.operationHeld {
+		r.operationViolations++
+	}
 	r.deferCalls++
 	return r.busy, false
 }
 
 func (r *deferredPluginRuntime) ClearDeferredPluginUpdate(string) {
 	r.clearCalls++
+}
+
+func (r *deferredPluginRuntime) LockPluginOperation(string) func() {
+	r.operationCalls++
+	r.operationHeld = true
+	return func() { r.operationHeld = false }
 }
 
 func (i fakePluginLoadInspector) PluginRegistered(id string) bool {
@@ -376,8 +391,8 @@ func TestSyncPlatformWithReportDefersActiveUpdateUntilRestart(t *testing.T) {
 	if errSync != nil {
 		t.Fatalf("SyncPlatformWithReport() error = %v", errSync)
 	}
-	if !report.OK || runtimeHost.prepareCalls != 1 || runtimeHost.deferCalls != 1 || runtimeHost.clearCalls != 0 {
-		t.Fatalf("report = %+v, runtime hooks = prepare:%d defer:%d clear:%d; want one prepare/defer and no clear", report, runtimeHost.prepareCalls, runtimeHost.deferCalls, runtimeHost.clearCalls)
+	if !report.OK || runtimeHost.prepareCalls != 1 || runtimeHost.deferCalls != 1 || runtimeHost.clearCalls != 0 || runtimeHost.operationCalls != 1 || runtimeHost.operationHeld || runtimeHost.operationViolations != 0 {
+		t.Fatalf("report = %+v, runtime hooks = prepare:%d defer:%d clear:%d operation:%d held:%v violations:%d; want one operation around prepare/defer and no clear", report, runtimeHost.prepareCalls, runtimeHost.deferCalls, runtimeHost.clearCalls, runtimeHost.operationCalls, runtimeHost.operationHeld, runtimeHost.operationViolations)
 	}
 	if len(report.Plugins) != 1 || !report.Plugins[0].RestartRequired {
 		t.Fatalf("plugin report = %+v, want restart_required for active update", report.Plugins)

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -287,7 +287,7 @@ func (h *Host) deferredPluginFileLocked(file pluginFile) pluginFile {
 	}
 	deferred, ok := h.deferredPluginUpdates[id]
 	activePath, activeVersion := h.pluginIdentityLocked(id)
-	if !ok || activePath == "" || activePath != deferred.path || activeVersion != deferred.version {
+	if !ok || activePath == "" || activePath != deferred.path || (deferred.version != "" && activeVersion != deferred.version) {
 		return file
 	}
 	file.Path = deferred.path

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -43,6 +43,8 @@ type pluginUnloadTarget struct {
 type pluginLoadRequest struct {
 	result         chan pluginLoadResult
 	cleanupStarted bool
+	path           string
+	version        string
 }
 
 type pluginLoadResult struct {
@@ -215,12 +217,7 @@ func (h *Host) DeferPluginUpdateUntilRestart(id, targetPath, targetVersion strin
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	lp := h.loaded[id]
-	if lp == nil {
-		return false
-	}
-	activePath := cleanPluginPath(lp.path)
-	activeVersion := strings.TrimSpace(lp.version)
+	activePath, activeVersion := h.pluginIdentityLocked(id)
 	if activePath == "" {
 		return false
 	}
@@ -255,6 +252,21 @@ func (h *Host) ClearDeferredPluginUpdate(id string) {
 	h.mu.Unlock()
 }
 
+// pluginIdentityLocked returns the registered identity, or the identity being
+// loaded when registration has not completed yet. Callers must hold h.mu.
+func (h *Host) pluginIdentityLocked(id string) (string, string) {
+	if h == nil {
+		return "", ""
+	}
+	if lp := h.loaded[id]; lp != nil {
+		return cleanPluginPath(lp.path), strings.TrimSpace(lp.version)
+	}
+	if request := h.loading[id]; request != nil {
+		return cleanPluginPath(request.path), strings.TrimSpace(request.version)
+	}
+	return "", ""
+}
+
 func (h *Host) deferredPluginFile(file pluginFile) pluginFile {
 	if h == nil {
 		return file
@@ -265,13 +277,7 @@ func (h *Host) deferredPluginFile(file pluginFile) pluginFile {
 	}
 	h.mu.Lock()
 	deferred, ok := h.deferredPluginUpdates[id]
-	lp := h.loaded[id]
-	activePath := ""
-	activeVersion := ""
-	if lp != nil {
-		activePath = cleanPluginPath(lp.path)
-		activeVersion = strings.TrimSpace(lp.version)
-	}
+	activePath, activeVersion := h.pluginIdentityLocked(id)
 	h.mu.Unlock()
 	if !ok || activePath == "" || activePath != deferred.path || activeVersion != deferred.version {
 		return file
@@ -358,7 +364,11 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 		var plugin pluginapi.Plugin
 		registeredNow := false
 		if lp == nil {
-			request := &pluginLoadRequest{result: make(chan pluginLoadResult, 1)}
+			request := &pluginLoadRequest{
+				result:  make(chan pluginLoadResult, 1),
+				path:    file.Path,
+				version: file.Version,
+			}
 			h.mu.Lock()
 			if _, loading := h.loading[file.ID]; loading {
 				h.mu.Unlock()

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -565,6 +565,7 @@ func (h *Host) cleanupCanceledPluginLoad(id string, request *pluginLoadRequest) 
 		return
 	}
 	request.cleanupStarted = true
+	h.rebindDeferredPluginUpdateLocked(id, request)
 	h.mu.Unlock()
 
 	go func() {
@@ -585,9 +586,28 @@ func (h *Host) cleanupPluginLoad(id string, request *pluginLoadRequest, loaded *
 		return
 	}
 	request.cleanupStarted = true
+	h.rebindDeferredPluginUpdateLocked(id, request)
 	h.mu.Unlock()
 
 	h.finishPluginLoadCleanup(id, request, loaded)
+}
+
+func (h *Host) rebindDeferredPluginUpdateLocked(id string, request *pluginLoadRequest) {
+	if h == nil || request == nil {
+		return
+	}
+	deferred, ok := h.deferredPluginUpdates[id]
+	if !ok || cleanPluginPath(deferred.path) != cleanPluginPath(request.path) || (deferred.version != "" && strings.TrimSpace(deferred.version) != strings.TrimSpace(request.version)) {
+		return
+	}
+	if loaded := h.loaded[id]; loaded != nil && cleanPluginPath(loaded.path) != "" {
+		h.deferredPluginUpdates[id] = deferredPluginIdentity{
+			path:    cleanPluginPath(loaded.path),
+			version: strings.TrimSpace(loaded.version),
+		}
+		return
+	}
+	delete(h.deferredPluginUpdates, id)
 }
 
 func (h *Host) finishPluginLoadCleanup(id string, request *pluginLoadRequest, loaded *loadedPlugin) {

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -590,7 +590,13 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 	if cleanupFiles && len(loadedFiles) > 0 {
 		cleanupFilesToKeep := append([]pluginFile(nil), loadedFiles...)
 		cleanupFilesToKeep = append(cleanupFilesToKeep, deferredFiles...)
-		if errCleanup := cleanupUnselectedPluginFiles(rc.Dir, cleanupFilesToKeep); errCleanup != nil {
+		isDeferred := func(id string) bool {
+			h.mu.Lock()
+			_, ok := h.deferredPluginUpdates[strings.TrimSpace(id)]
+			h.mu.Unlock()
+			return ok
+		}
+		if errCleanup := cleanupUnselectedPluginFiles(rc.Dir, cleanupFilesToKeep, isDeferred, h.LockPluginArtifact); errCleanup != nil {
 			log.Warnf("pluginhost: failed to clean old plugin files: %v", errCleanup)
 		}
 	}

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -70,6 +70,7 @@ type Host struct {
 	fused                  map[string]string
 	deferredPluginUpdates  map[string]deferredPluginIdentity
 	artifactLocks          map[string]*sync.Mutex
+	operationLocks         map[string]*sync.Mutex
 	pluginFileVersions     map[string]string
 	activePluginVersions   map[string]string
 	activePluginPaths      map[string]string
@@ -105,6 +106,7 @@ func New() *Host {
 		fused:                  make(map[string]string),
 		deferredPluginUpdates:  make(map[string]deferredPluginIdentity),
 		artifactLocks:          make(map[string]*sync.Mutex),
+		operationLocks:         make(map[string]*sync.Mutex),
 		pluginFileVersions:     make(map[string]string),
 		activePluginVersions:   make(map[string]string),
 		activePluginPaths:      make(map[string]string),
@@ -222,6 +224,30 @@ func (h *Host) LockPluginArtifact(id string) func() {
 	if lock == nil {
 		lock = &sync.Mutex{}
 		h.artifactLocks[id] = lock
+	}
+	h.mu.Unlock()
+	lock.Lock()
+	return lock.Unlock
+}
+
+// LockPluginOperation serializes the complete install lifecycle for one plugin
+// across management and Home sync callers, including marker ownership cleanup.
+func (h *Host) LockPluginOperation(id string) func() {
+	if h == nil {
+		return func() {}
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return func() {}
+	}
+	h.mu.Lock()
+	if h.operationLocks == nil {
+		h.operationLocks = make(map[string]*sync.Mutex)
+	}
+	lock := h.operationLocks[id]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		h.operationLocks[id] = lock
 	}
 	h.mu.Unlock()
 	lock.Lock()

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -221,13 +221,36 @@ func (h *Host) DeferPluginUpdateUntilRestart(id, targetPath, targetVersion strin
 	if activePath == "" {
 		return false
 	}
+	if _, ok := h.deferredPluginUpdates[id]; ok {
+		return true
+	}
 	if !contentChanged && activePath == targetPath && activeVersion == targetVersion {
-		if deferred, ok := h.deferredPluginUpdates[id]; ok {
-			if deferred.path != activePath || deferred.version != activeVersion {
-				h.deferredPluginUpdates[id] = deferredPluginIdentity{path: activePath, version: activeVersion}
-			}
-			return true
-		}
+		return false
+	}
+	if h.deferredPluginUpdates == nil {
+		h.deferredPluginUpdates = make(map[string]deferredPluginIdentity)
+	}
+	h.deferredPluginUpdates[id] = deferredPluginIdentity{path: activePath, version: activeVersion}
+	return true
+}
+
+// PreparePluginUpdate pins the currently effective plugin before an artifact is
+// written, allowing concurrent config reloads to keep the old library active.
+func (h *Host) PreparePluginUpdate(id string) bool {
+	if h == nil {
+		return false
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return false
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.deferredPluginUpdates[id]; ok {
+		return true
+	}
+	activePath, activeVersion := h.pluginIdentityLocked(id)
+	if activePath == "" {
 		return false
 	}
 	if h.deferredPluginUpdates == nil {
@@ -344,8 +367,10 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 
 	records := make([]capabilityRecord, 0, len(files))
 	loadedFiles := make([]pluginFile, 0, len(files))
+	deferredFiles := make([]pluginFile, 0)
 	hotReloadLogs := make([]log.Fields, 0)
 	for _, file := range files {
+		selectedFile := file
 		item, ok := rc.Items[file.ID]
 		if !ok {
 			item = defaultRuntimeItemConfig(file.ID)
@@ -356,6 +381,9 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 		var request *pluginLoadRequest
 		h.mu.Lock()
 		file = h.deferredPluginFileLocked(file)
+		if cleanPluginPath(file.Path) != cleanPluginPath(selectedFile.Path) || file.Version != selectedFile.Version {
+			deferredFiles = append(deferredFiles, selectedFile)
+		}
 		lp := h.loaded[file.ID]
 		var replaced *loadedPlugin
 		if lp != nil && cleanPluginPath(lp.path) != cleanPluginPath(file.Path) {
@@ -475,7 +503,9 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 		log.WithFields(fields).Info("pluginhost: plugin hot reloaded")
 	}
 	if cleanupFiles && len(loadedFiles) > 0 {
-		if errCleanup := cleanupUnselectedPluginFiles(rc.Dir, loadedFiles); errCleanup != nil {
+		cleanupFilesToKeep := append([]pluginFile(nil), loadedFiles...)
+		cleanupFilesToKeep = append(cleanupFilesToKeep, deferredFiles...)
+		if errCleanup := cleanupUnselectedPluginFiles(rc.Dir, cleanupFilesToKeep); errCleanup != nil {
 			log.Warnf("pluginhost: failed to clean old plugin files: %v", errCleanup)
 		}
 	}

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -271,14 +271,22 @@ func (h *Host) deferredPluginFile(file pluginFile) pluginFile {
 	if h == nil {
 		return file
 	}
+	h.mu.Lock()
+	file = h.deferredPluginFileLocked(file)
+	h.mu.Unlock()
+	return file
+}
+
+func (h *Host) deferredPluginFileLocked(file pluginFile) pluginFile {
+	if h == nil {
+		return file
+	}
 	id := strings.TrimSpace(file.ID)
 	if id == "" {
 		return file
 	}
-	h.mu.Lock()
 	deferred, ok := h.deferredPluginUpdates[id]
 	activePath, activeVersion := h.pluginIdentityLocked(id)
-	h.mu.Unlock()
 	if !ok || activePath == "" || activePath != deferred.path || activeVersion != deferred.version {
 		return file
 	}
@@ -338,7 +346,6 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 	loadedFiles := make([]pluginFile, 0, len(files))
 	hotReloadLogs := make([]log.Fields, 0)
 	for _, file := range files {
-		file = h.deferredPluginFile(file)
 		item, ok := rc.Items[file.ID]
 		if !ok {
 			item = defaultRuntimeItemConfig(file.ID)
@@ -346,7 +353,9 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 		if !item.Enabled {
 			continue
 		}
+		var request *pluginLoadRequest
 		h.mu.Lock()
+		file = h.deferredPluginFileLocked(file)
 		lp := h.loaded[file.ID]
 		var replaced *loadedPlugin
 		if lp != nil && cleanPluginPath(lp.path) != cleanPluginPath(file.Path) {
@@ -354,28 +363,29 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 			lp = nil
 		}
 		_, disabled := h.fused[file.ID]
-		h.mu.Unlock()
 		if disabled && replaced == nil {
+			h.mu.Unlock()
 			continue
 		}
+		if lp == nil {
+			if _, loading := h.loading[file.ID]; loading {
+				h.mu.Unlock()
+				continue
+			}
+			request = &pluginLoadRequest{
+				result:  make(chan pluginLoadResult, 1),
+				path:    file.Path,
+				version: file.Version,
+			}
+			h.loading[file.ID] = request
+		}
+		h.mu.Unlock()
 
 		loadedNow := false
 		var hotReloadFields log.Fields
 		var plugin pluginapi.Plugin
 		registeredNow := false
-		if lp == nil {
-			request := &pluginLoadRequest{
-				result:  make(chan pluginLoadResult, 1),
-				path:    file.Path,
-				version: file.Version,
-			}
-			h.mu.Lock()
-			if _, loading := h.loading[file.ID]; loading {
-				h.mu.Unlock()
-				continue
-			}
-			h.loading[file.ID] = request
-			h.mu.Unlock()
+		if request != nil {
 			h.startPluginLoad(ctx, file, item, request)
 
 			loadResult, completed := h.waitForPluginLoad(ctx, file.ID, request)

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -51,6 +51,7 @@ type pluginLoadResult struct {
 	loaded      *loadedPlugin
 	plugin      pluginapi.Plugin
 	initialized bool
+	deferred    bool
 	err         error
 }
 
@@ -68,6 +69,7 @@ type Host struct {
 	loading                map[string]*pluginLoadRequest
 	fused                  map[string]string
 	deferredPluginUpdates  map[string]deferredPluginIdentity
+	artifactLocks          map[string]*sync.Mutex
 	pluginFileVersions     map[string]string
 	activePluginVersions   map[string]string
 	activePluginPaths      map[string]string
@@ -102,6 +104,7 @@ func New() *Host {
 		loading:                make(map[string]*pluginLoadRequest),
 		fused:                  make(map[string]string),
 		deferredPluginUpdates:  make(map[string]deferredPluginIdentity),
+		artifactLocks:          make(map[string]*sync.Mutex),
 		pluginFileVersions:     make(map[string]string),
 		activePluginVersions:   make(map[string]string),
 		activePluginPaths:      make(map[string]string),
@@ -201,6 +204,30 @@ func (h *Host) PluginBusy(id string) bool {
 	return ok
 }
 
+// LockPluginArtifact serializes a plugin artifact write with the library open
+// performed by a concurrent load. The returned function releases the lock.
+func (h *Host) LockPluginArtifact(id string) func() {
+	if h == nil {
+		return func() {}
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return func() {}
+	}
+	h.mu.Lock()
+	if h.artifactLocks == nil {
+		h.artifactLocks = make(map[string]*sync.Mutex)
+	}
+	lock := h.artifactLocks[id]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		h.artifactLocks[id] = lock
+	}
+	h.mu.Unlock()
+	lock.Lock()
+	return lock.Unlock
+}
+
 // DeferPluginUpdateUntilRestart keeps an active plugin identity pinned until a
 // fresh host is created. It returns whether restart is required and whether this
 // call created the deferral marker.
@@ -249,7 +276,7 @@ func (h *Host) PreparePluginUpdate(id string) (bool, bool) {
 	if _, ok := h.deferredPluginUpdates[id]; ok {
 		return true, false
 	}
-	activePath, activeVersion := h.pluginIdentityLocked(id)
+	activePath, activeVersion := h.pluginUpdateIdentityLocked(id)
 	if activePath == "" {
 		return false, false
 	}
@@ -288,6 +315,36 @@ func (h *Host) pluginIdentityLocked(id string) (string, string) {
 		return cleanPluginPath(lp.path), strings.TrimSpace(lp.version)
 	}
 	return "", ""
+}
+
+func (h *Host) pluginUpdateIdentityLocked(id string) (string, string) {
+	if h == nil {
+		return "", ""
+	}
+	if lp := h.loaded[id]; lp != nil {
+		return cleanPluginPath(lp.path), strings.TrimSpace(lp.version)
+	}
+	return h.pluginIdentityLocked(id)
+}
+
+func (h *Host) pluginLoadDeferredLocked(id string, request *pluginLoadRequest) bool {
+	if h == nil || request == nil || h.loading[id] != request {
+		return false
+	}
+	deferred, ok := h.deferredPluginUpdates[id]
+	if !ok {
+		return false
+	}
+	return cleanPluginPath(deferred.path) != cleanPluginPath(request.path) ||
+		(deferred.version != "" && strings.TrimSpace(deferred.version) != strings.TrimSpace(request.version))
+}
+
+func (h *Host) takeDeferredPluginLoadLocked(file pluginFile, request *pluginLoadRequest) (*loadedPlugin, pluginFile, bool) {
+	if !h.pluginLoadDeferredLocked(file.ID, request) {
+		return nil, file, false
+	}
+	delete(h.loading, file.ID)
+	return h.loaded[file.ID], h.deferredPluginFileLocked(file), true
 }
 
 func (h *Host) deferredPluginFile(file pluginFile) pluginFile {
@@ -420,37 +477,50 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 			if !completed {
 				return
 			}
-			if loadResult.err != nil {
-				h.cleanupPluginLoad(file.ID, request, loadResult.loaded)
-				log.Warnf("pluginhost: failed to load plugin %s from %s: %v", file.ID, file.Path, loadResult.err)
-				continue
-			}
-
 			h.mu.Lock()
-			if h.loading[file.ID] != request {
+			fallbackPlugin, fallbackFile, deferred := h.takeDeferredPluginLoadLocked(file, request)
+			if deferred {
 				h.mu.Unlock()
 				h.discardLoadedPlugin(loadResult.loaded)
-				return
-			}
-			if errContext := ctx.Err(); errContext != nil {
+				file = fallbackFile
+				deferredFiles = append(deferredFiles, selectedFile)
+				lp = fallbackPlugin
+				if lp == nil {
+					continue
+				}
+			} else if loadResult.err != nil || loadResult.deferred {
 				h.mu.Unlock()
 				h.cleanupPluginLoad(file.ID, request, loadResult.loaded)
-				return
+				if loadResult.err != nil {
+					log.Warnf("pluginhost: failed to load plugin %s from %s: %v", file.ID, file.Path, loadResult.err)
+				}
+				continue
+			} else {
+				if h.loading[file.ID] != request {
+					h.mu.Unlock()
+					h.discardLoadedPlugin(loadResult.loaded)
+					return
+				}
+				if errContext := ctx.Err(); errContext != nil {
+					h.mu.Unlock()
+					h.cleanupPluginLoad(file.ID, request, loadResult.loaded)
+					return
+				}
+				delete(h.loading, file.ID)
+				lp = loadResult.loaded
+				if replaced != nil {
+					hotReloadFields = pluginHotReloadLogFields(file.ID, file.Version, file.Path, replaced.version, replaced.path)
+					h.retireLoadedPluginLocked(replaced)
+					delete(h.fused, file.ID)
+					h.removePluginRuntimeStateLocked(file.ID)
+				}
+				h.loaded[file.ID] = lp
+				loadedNow = true
+				plugin = loadResult.plugin
+				registeredNow = loadResult.initialized
+				h.mu.Unlock()
+				log.WithFields(pluginLogFields(file.ID, "", file.Version, file.Path)).Info("pluginhost: plugin loaded")
 			}
-			delete(h.loading, file.ID)
-			lp = loadResult.loaded
-			if replaced != nil {
-				hotReloadFields = pluginHotReloadLogFields(file.ID, file.Version, file.Path, replaced.version, replaced.path)
-				h.retireLoadedPluginLocked(replaced)
-				delete(h.fused, file.ID)
-				h.removePluginRuntimeStateLocked(file.ID)
-			}
-			h.loaded[file.ID] = lp
-			loadedNow = true
-			plugin = loadResult.plugin
-			registeredNow = loadResult.initialized
-			h.mu.Unlock()
-			log.WithFields(pluginLogFields(file.ID, "", file.Version, file.Path)).Info("pluginhost: plugin loaded")
 		}
 
 		if !registeredNow {
@@ -519,7 +589,22 @@ func (h *Host) startPluginLoad(ctx context.Context, file pluginFile, item runtim
 		ctx = context.Background()
 	}
 	go func() {
-		client, errOpen := h.loader.Open(file, h)
+		client, errOpen, deferred := func() (pluginClient, error, bool) {
+			unlockArtifact := h.LockPluginArtifact(file.ID)
+			defer unlockArtifact()
+			h.mu.Lock()
+			deferred := h.pluginLoadDeferredLocked(file.ID, request)
+			h.mu.Unlock()
+			if deferred {
+				return nil, nil, true
+			}
+			client, errOpen := h.loader.Open(file, h)
+			return client, errOpen, false
+		}()
+		if deferred {
+			request.result <- pluginLoadResult{deferred: true}
+			return
+		}
 		if errOpen != nil {
 			request.result <- pluginLoadResult{err: errOpen}
 			return

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -252,17 +252,17 @@ func (h *Host) ClearDeferredPluginUpdate(id string) {
 	h.mu.Unlock()
 }
 
-// pluginIdentityLocked returns the registered identity, or the identity being
-// loaded when registration has not completed yet. Callers must hold h.mu.
+// pluginIdentityLocked returns the identity being loaded, or the registered
+// identity when no load is in flight. Callers must hold h.mu.
 func (h *Host) pluginIdentityLocked(id string) (string, string) {
 	if h == nil {
 		return "", ""
 	}
-	if lp := h.loaded[id]; lp != nil {
-		return cleanPluginPath(lp.path), strings.TrimSpace(lp.version)
-	}
 	if request := h.loading[id]; request != nil {
 		return cleanPluginPath(request.path), strings.TrimSpace(request.version)
+	}
+	if lp := h.loaded[id]; lp != nil {
+		return cleanPluginPath(lp.path), strings.TrimSpace(lp.version)
 	}
 	return "", ""
 }

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -347,6 +347,18 @@ func (h *Host) takeDeferredPluginLoadLocked(file pluginFile, request *pluginLoad
 	return h.loaded[file.ID], h.deferredPluginFileLocked(file), true
 }
 
+func (h *Host) takeRetainedPluginLoadLocked(file pluginFile, request *pluginLoadRequest) (*loadedPlugin, pluginFile, bool) {
+	if h == nil || request == nil || h.loading[file.ID] != request {
+		return nil, file, false
+	}
+	lp := h.loaded[file.ID]
+	if lp == nil {
+		return nil, file, false
+	}
+	delete(h.loading, file.ID)
+	return lp, pluginFile{ID: file.ID, Path: lp.path, Version: lp.version}, true
+}
+
 func (h *Host) deferredPluginFile(file pluginFile) pluginFile {
 	if h == nil {
 		return file
@@ -479,6 +491,9 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 			}
 			h.mu.Lock()
 			fallbackPlugin, fallbackFile, deferred := h.takeDeferredPluginLoadLocked(file, request)
+			if !deferred && loadResult.deferred {
+				fallbackPlugin, fallbackFile, deferred = h.takeRetainedPluginLoadLocked(file, request)
+			}
 			if deferred {
 				h.mu.Unlock()
 				h.discardLoadedPlugin(loadResult.loaded)

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -201,7 +201,8 @@ func (h *Host) PluginBusy(id string) bool {
 
 // DeferPluginUpdateUntilRestart keeps an active plugin identity pinned until a
 // fresh host is created. It reports whether the requested artifact differs from
-// the currently effective plugin or changed its bytes in place.
+// the currently effective plugin or changed its bytes in place, and keeps an
+// existing deferral pinned while queued reloads drain.
 func (h *Host) DeferPluginUpdateUntilRestart(id, targetPath, targetVersion string, contentChanged bool) bool {
 	if h == nil {
 		return false
@@ -224,7 +225,12 @@ func (h *Host) DeferPluginUpdateUntilRestart(id, targetPath, targetVersion strin
 		return false
 	}
 	if !contentChanged && activePath == targetPath && activeVersion == targetVersion {
-		delete(h.deferredPluginUpdates, id)
+		if deferred, ok := h.deferredPluginUpdates[id]; ok {
+			if deferred.path != activePath || deferred.version != activeVersion {
+				h.deferredPluginUpdates[id] = deferredPluginIdentity{path: activePath, version: activeVersion}
+			}
+			return true
+		}
 		return false
 	}
 	if h.deferredPluginUpdates == nil {

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -214,9 +214,13 @@ func (h *Host) DeferPluginUpdateUntilRestart(id, targetPath, targetVersion strin
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	activePath := cleanPluginPath(h.activePluginPaths[id])
-	activeVersion := strings.TrimSpace(h.activePluginVersions[id])
-	if activePath == "" || h.loaded[id] == nil {
+	lp := h.loaded[id]
+	if lp == nil {
+		return false
+	}
+	activePath := cleanPluginPath(lp.path)
+	activeVersion := strings.TrimSpace(lp.version)
+	if activePath == "" {
 		return false
 	}
 	if !contentChanged && activePath == targetPath && activeVersion == targetVersion {

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -202,62 +202,62 @@ func (h *Host) PluginBusy(id string) bool {
 }
 
 // DeferPluginUpdateUntilRestart keeps an active plugin identity pinned until a
-// fresh host is created. It reports whether the requested artifact differs from
-// the currently effective plugin or changed its bytes in place, and keeps an
-// existing deferral pinned while queued reloads drain.
-func (h *Host) DeferPluginUpdateUntilRestart(id, targetPath, targetVersion string, contentChanged bool) bool {
+// fresh host is created. It returns whether restart is required and whether this
+// call created the deferral marker.
+func (h *Host) DeferPluginUpdateUntilRestart(id, targetPath, targetVersion string, contentChanged bool) (bool, bool) {
 	if h == nil {
-		return false
+		return false, false
 	}
 	id = strings.TrimSpace(id)
 	targetPath = cleanPluginPath(targetPath)
 	targetVersion = strings.TrimSpace(targetVersion)
 	if id == "" || targetPath == "" {
-		return false
+		return false, false
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	activePath, activeVersion := h.pluginIdentityLocked(id)
 	if activePath == "" {
-		return false
+		return false, false
 	}
 	if _, ok := h.deferredPluginUpdates[id]; ok {
-		return true
+		return true, false
 	}
 	if !contentChanged && activePath == targetPath && activeVersion == targetVersion {
-		return false
+		return false, false
 	}
 	if h.deferredPluginUpdates == nil {
 		h.deferredPluginUpdates = make(map[string]deferredPluginIdentity)
 	}
 	h.deferredPluginUpdates[id] = deferredPluginIdentity{path: activePath, version: activeVersion}
-	return true
+	return true, true
 }
 
 // PreparePluginUpdate pins the currently effective plugin before an artifact is
 // written, allowing concurrent config reloads to keep the old library active.
-func (h *Host) PreparePluginUpdate(id string) bool {
+// It returns whether restart is required and whether this call created the marker.
+func (h *Host) PreparePluginUpdate(id string) (bool, bool) {
 	if h == nil {
-		return false
+		return false, false
 	}
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return false
+		return false, false
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if _, ok := h.deferredPluginUpdates[id]; ok {
-		return true
+		return true, false
 	}
 	activePath, activeVersion := h.pluginIdentityLocked(id)
 	if activePath == "" {
-		return false
+		return false, false
 	}
 	if h.deferredPluginUpdates == nil {
 		h.deferredPluginUpdates = make(map[string]deferredPluginIdentity)
 	}
 	h.deferredPluginUpdates[id] = deferredPluginIdentity{path: activePath, version: activeVersion}
-	return true
+	return true, true
 }
 
 // ClearDeferredPluginUpdate releases a pending update marker after an explicit
@@ -275,13 +275,13 @@ func (h *Host) ClearDeferredPluginUpdate(id string) {
 	h.mu.Unlock()
 }
 
-// pluginIdentityLocked returns the identity being loaded, or the registered
-// identity when no load is in flight. Callers must hold h.mu.
+// pluginIdentityLocked returns a non-canceled load identity, or the registered
+// identity when no such load is in flight. Callers must hold h.mu.
 func (h *Host) pluginIdentityLocked(id string) (string, string) {
 	if h == nil {
 		return "", ""
 	}
-	if request := h.loading[id]; request != nil {
+	if request := h.loading[id]; request != nil && !request.cleanupStarted {
 		return cleanPluginPath(request.path), strings.TrimSpace(request.version)
 	}
 	if lp := h.loaded[id]; lp != nil {

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -52,6 +52,11 @@ type pluginLoadResult struct {
 	err         error
 }
 
+type deferredPluginIdentity struct {
+	path    string
+	version string
+}
+
 type Host struct {
 	applyMu                chan struct{}
 	mu                     sync.Mutex
@@ -60,6 +65,7 @@ type Host struct {
 	retired                map[string][]*loadedPlugin
 	loading                map[string]*pluginLoadRequest
 	fused                  map[string]string
+	deferredPluginUpdates  map[string]deferredPluginIdentity
 	pluginFileVersions     map[string]string
 	activePluginVersions   map[string]string
 	activePluginPaths      map[string]string
@@ -93,6 +99,7 @@ func New() *Host {
 		retired:                make(map[string][]*loadedPlugin),
 		loading:                make(map[string]*pluginLoadRequest),
 		fused:                  make(map[string]string),
+		deferredPluginUpdates:  make(map[string]deferredPluginIdentity),
 		pluginFileVersions:     make(map[string]string),
 		activePluginVersions:   make(map[string]string),
 		activePluginPaths:      make(map[string]string),
@@ -192,6 +199,78 @@ func (h *Host) PluginBusy(id string) bool {
 	return ok
 }
 
+// DeferPluginUpdateUntilRestart keeps an active plugin identity pinned until a
+// fresh host is created. It reports whether the requested artifact differs from
+// the currently effective plugin or changed its bytes in place.
+func (h *Host) DeferPluginUpdateUntilRestart(id, targetPath, targetVersion string, contentChanged bool) bool {
+	if h == nil {
+		return false
+	}
+	id = strings.TrimSpace(id)
+	targetPath = cleanPluginPath(targetPath)
+	targetVersion = strings.TrimSpace(targetVersion)
+	if id == "" || targetPath == "" {
+		return false
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	activePath := cleanPluginPath(h.activePluginPaths[id])
+	activeVersion := strings.TrimSpace(h.activePluginVersions[id])
+	if activePath == "" || h.loaded[id] == nil {
+		return false
+	}
+	if !contentChanged && activePath == targetPath && activeVersion == targetVersion {
+		delete(h.deferredPluginUpdates, id)
+		return false
+	}
+	if h.deferredPluginUpdates == nil {
+		h.deferredPluginUpdates = make(map[string]deferredPluginIdentity)
+	}
+	h.deferredPluginUpdates[id] = deferredPluginIdentity{path: activePath, version: activeVersion}
+	return true
+}
+
+// ClearDeferredPluginUpdate releases a pending update marker after an explicit
+// management operation fails before its desired configuration is persisted.
+func (h *Host) ClearDeferredPluginUpdate(id string) {
+	if h == nil {
+		return
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return
+	}
+	h.mu.Lock()
+	delete(h.deferredPluginUpdates, id)
+	h.mu.Unlock()
+}
+
+func (h *Host) deferredPluginFile(file pluginFile) pluginFile {
+	if h == nil {
+		return file
+	}
+	id := strings.TrimSpace(file.ID)
+	if id == "" {
+		return file
+	}
+	h.mu.Lock()
+	deferred, ok := h.deferredPluginUpdates[id]
+	lp := h.loaded[id]
+	activePath := ""
+	activeVersion := ""
+	if lp != nil {
+		activePath = cleanPluginPath(lp.path)
+		activeVersion = strings.TrimSpace(lp.version)
+	}
+	h.mu.Unlock()
+	if !ok || activePath == "" || activePath != deferred.path || activeVersion != deferred.version {
+		return file
+	}
+	file.Path = deferred.path
+	file.Version = deferred.version
+	return file
+}
+
 func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 	if h == nil || !h.lockApply(ctx) {
 		return
@@ -243,6 +322,7 @@ func (h *Host) ApplyConfig(ctx context.Context, cfg *config.Config) {
 	loadedFiles := make([]pluginFile, 0, len(files))
 	hotReloadLogs := make([]log.Fields, 0)
 	for _, file := range files {
+		file = h.deferredPluginFile(file)
 		item, ok := rc.Items[file.ID]
 		if !ok {
 			item = defaultRuntimeItemConfig(file.ID)
@@ -545,12 +625,14 @@ func (h *Host) UnloadPluginContext(ctx context.Context, id string) bool {
 		targets = append(targets, pluginUnloadTarget{id: retired.id, name: retired.name, path: retired.path, version: retired.version, client: retired.client})
 	}
 	if len(targets) == 0 {
+		delete(h.deferredPluginUpdates, id)
 		h.mu.Unlock()
 		return false
 	}
 	delete(h.loaded, id)
 	delete(h.retired, id)
 	delete(h.fused, id)
+	delete(h.deferredPluginUpdates, id)
 	delete(h.activePluginVersions, id)
 	delete(h.activePluginPaths, id)
 	for _, target := range targets {
@@ -633,6 +715,7 @@ func (h *Host) ShutdownAllContext(ctx context.Context) {
 	h.pluginFileVersions = make(map[string]string)
 	h.activePluginVersions = make(map[string]string)
 	h.activePluginPaths = make(map[string]string)
+	h.deferredPluginUpdates = make(map[string]deferredPluginIdentity)
 	h.snapshot.Store(emptySnapshot())
 	h.mu.Unlock()
 

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -987,6 +987,53 @@ func TestHostDeferPluginUpdateSameIdentityUsesContentChange(t *testing.T) {
 	}
 }
 
+func TestHostDeferPluginUpdatePreservesPendingDeferralForSameIdentity(t *testing.T) {
+	loader := newExclusiveTestLoader(map[string]*testPlugin{
+		"1.0.0": {
+			registerResult:    validTestPlugin("alpha-v1"),
+			reconfigureResult: validTestPlugin("alpha-v1"),
+		},
+		"2.0.0": {
+			registerResult:    validTestPlugin("alpha-v2"),
+			reconfigureResult: validTestPlugin("alpha-v2"),
+		},
+	})
+	pluginsDir, paths := makeVersionedPluginDir(t, "alpha", "1.0.0", "2.0.0")
+	configForVersion := func(version string) *config.Config {
+		return &config.Config{
+			Plugins: config.PluginsConfig{
+				Enabled: true,
+				Dir:     pluginsDir,
+				Configs: map[string]config.PluginInstanceConfig{
+					"alpha": enabledPluginConfigWithStoreVersion(t, version),
+				},
+			},
+		}
+	}
+
+	h := NewForTest(loader)
+	h.ApplyConfig(context.Background(), configForVersion("1.0.0"))
+	if !h.DeferPluginUpdateUntilRestart("alpha", paths["2.0.0"], "2.0.0", false) {
+		t.Fatal("initial deferred update = false, want true")
+	}
+	if !h.DeferPluginUpdateUntilRestart("alpha", paths["1.0.0"], "1.0.0", false) {
+		t.Fatal("same-identity follow-up = false, want true while an update remains deferred")
+	}
+
+	h.ApplyConfig(context.Background(), configForVersion("2.0.0"))
+	h.ApplyConfig(context.Background(), configForVersion("1.0.0"))
+	if !h.PluginRegistered("alpha") || !h.pluginIdentityCurrent("alpha", paths["1.0.0"], "1.0.0") {
+		t.Fatal("retained v1 was not effective while deferred reloads drained")
+	}
+	if h.pluginIdentityCurrent("alpha", paths["2.0.0"], "2.0.0") {
+		t.Fatal("replacement v2 became active before restart")
+	}
+	if openCalls, active := loader.stats(); openCalls != 1 || !active {
+		t.Fatalf("exclusive loader state = calls %d active %v, want one active v1 client", openCalls, active)
+	}
+	h.ShutdownAll()
+}
+
 func TestHostApplyConfigLogsLoadedWhenRegistrationInvalid(t *testing.T) {
 	var out bytes.Buffer
 	originalOut := log.StandardLogger().Out

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -818,6 +818,170 @@ func TestHostApplyConfigKeepsLoadedVersionWhenPinnedVersionMissing(t *testing.T)
 	}
 }
 
+func TestHostApplyConfigDefersActiveUpdateUntilRestart(t *testing.T) {
+	loader := newExclusiveTestLoader(map[string]*testPlugin{
+		"1.0.0": {
+			registerResult:    validTestPlugin("alpha-v1"),
+			reconfigureResult: validTestPlugin("alpha-v1"),
+		},
+		"2.0.0": {
+			registerResult:    validTestPlugin("alpha-v2"),
+			reconfigureResult: validTestPlugin("alpha-v2"),
+		},
+	})
+	pluginsDir, paths := makeVersionedPluginDir(t, "alpha", "1.0.0")
+	cfgV1 := &config.Config{
+		Plugins: config.PluginsConfig{
+			Enabled: true,
+			Dir:     pluginsDir,
+			Configs: map[string]config.PluginInstanceConfig{
+				"alpha": enabledPluginConfigWithStoreVersion(t, "1.0.0"),
+			},
+		},
+	}
+	cfgV2 := &config.Config{
+		Plugins: config.PluginsConfig{
+			Enabled: true,
+			Dir:     pluginsDir,
+			Configs: map[string]config.PluginInstanceConfig{
+				"alpha": enabledPluginConfigWithStoreVersion(t, "2.0.0"),
+			},
+		},
+	}
+
+	h := NewForTest(loader)
+	h.ApplyConfig(context.Background(), cfgV1)
+	if !h.PluginRegistered("alpha") || !h.pluginIdentityCurrent("alpha", paths["1.0.0"], "1.0.0") {
+		t.Fatalf("initial plugin was not registered at v1: registered=%v", h.PluginRegistered("alpha"))
+	}
+	paths["2.0.0"] = writeVersionedPluginFile(t, pluginsDir, "alpha", "2.0.0")
+	if !h.DeferPluginUpdateUntilRestart("alpha", paths["2.0.0"], "2.0.0", false) {
+		t.Fatal("DeferPluginUpdateUntilRestart() = false, want true for staged v2")
+	}
+
+	h.ApplyConfig(context.Background(), cfgV2)
+	h.ApplyConfig(context.Background(), cfgV2)
+	h.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{Dir: pluginsDir}})
+	h.ApplyConfig(context.Background(), cfgV2)
+	if !h.PluginRegistered("alpha") {
+		t.Fatal("PluginRegistered(alpha) = false, want old v1 to remain effective before restart")
+	}
+	if !h.pluginIdentityCurrent("alpha", paths["1.0.0"], "1.0.0") {
+		t.Fatal("active plugin identity changed before restart")
+	}
+	if h.pluginIdentityCurrent("alpha", paths["2.0.0"], "2.0.0") {
+		t.Fatal("desired v2 became active before restart")
+	}
+	if got := len(h.activeRecords()); got != 1 {
+		t.Fatalf("active record count = %d, want 1 before restart", got)
+	}
+	if plugins := h.RegisteredPlugins(); len(plugins) != 1 || plugins[0].Metadata.Name != "alpha-v1" {
+		t.Fatalf("RegisteredPlugins() = %#v, want effective alpha-v1", plugins)
+	}
+	if openCalls, active := loader.stats(); openCalls != 1 || !active {
+		t.Fatalf("exclusive loader state = calls %d active %v, want one active v1 client", openCalls, active)
+	}
+
+	h.ShutdownAll()
+	fresh := NewForTest(loader)
+	fresh.ApplyConfig(context.Background(), cfgV2)
+	if !fresh.PluginRegistered("alpha") || !fresh.pluginIdentityCurrent("alpha", paths["2.0.0"], "2.0.0") {
+		t.Fatalf("fresh host did not register desired v2: registered=%v", fresh.PluginRegistered("alpha"))
+	}
+	if fresh.pluginIdentityCurrent("alpha", paths["1.0.0"], "1.0.0") {
+		t.Fatal("fresh host retained old v1 identity")
+	}
+	if plugins := fresh.RegisteredPlugins(); len(plugins) != 1 || plugins[0].Metadata.Name != "alpha-v2" {
+		t.Fatalf("fresh RegisteredPlugins() = %#v, want effective alpha-v2", plugins)
+	}
+	if openCalls, active := loader.stats(); openCalls != 2 || !active {
+		t.Fatalf("fresh exclusive loader state = calls %d active %v, want v2 as second active client", openCalls, active)
+	}
+	fresh.ShutdownAll()
+}
+
+func TestHostDeferPluginUpdateFreshInstallDoesNotRequireRestart(t *testing.T) {
+	loader := newExclusiveTestLoader(map[string]*testPlugin{
+		"1.0.0": {
+			registerResult:    validTestPlugin("alpha"),
+			reconfigureResult: validTestPlugin("alpha"),
+		},
+	})
+	pluginsDir, paths := makeVersionedPluginDir(t, "alpha", "1.0.0")
+	h := NewForTest(loader)
+	if h.DeferPluginUpdateUntilRestart("alpha", paths["1.0.0"], "1.0.0", true) {
+		t.Fatal("fresh install was marked restart-required before any active plugin existed")
+	}
+	h.ApplyConfig(context.Background(), &config.Config{
+		Plugins: config.PluginsConfig{
+			Enabled: true,
+			Dir:     pluginsDir,
+			Configs: enabledPluginConfigs("alpha"),
+		},
+	})
+	if !h.PluginRegistered("alpha") {
+		t.Fatal("fresh install did not register immediately")
+	}
+	if openCalls, _ := loader.stats(); openCalls != 1 {
+		t.Fatalf("Open calls = %d, want 1 for fresh install", openCalls)
+	}
+	h.ShutdownAll()
+}
+
+func TestHostDeferPluginUpdateSameIdentityUsesContentChange(t *testing.T) {
+	tests := []struct {
+		name           string
+		contentChanged bool
+		wantRestart    bool
+	}{
+		{name: "identical artifact", contentChanged: false, wantRestart: false},
+		{name: "changed bytes", contentChanged: true, wantRestart: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loader := newExclusiveTestLoader(map[string]*testPlugin{
+				"1.0.0": {
+					registerResult:    validTestPlugin("alpha"),
+					reconfigureResult: validTestPlugin("alpha"),
+				},
+			})
+			pluginsDir, paths := makeVersionedPluginDir(t, "alpha", "1.0.0")
+			cfg := &config.Config{
+				Plugins: config.PluginsConfig{
+					Enabled: true,
+					Dir:     pluginsDir,
+					Configs: enabledPluginConfigs("alpha"),
+				},
+			}
+			h := NewForTest(loader)
+			h.ApplyConfig(context.Background(), cfg)
+			if got := h.DeferPluginUpdateUntilRestart("alpha", paths["1.0.0"], "1.0.0", tt.contentChanged); got != tt.wantRestart {
+				t.Fatalf("DeferPluginUpdateUntilRestart() = %v, want %v", got, tt.wantRestart)
+			}
+			h.ApplyConfig(context.Background(), cfg)
+			if !h.PluginRegistered("alpha") || !h.pluginIdentityCurrent("alpha", paths["1.0.0"], "1.0.0") {
+				t.Fatal("same active plugin was not kept effective")
+			}
+			if openCalls, _ := loader.stats(); openCalls != 1 {
+				t.Fatalf("Open calls = %d, want 1", openCalls)
+			}
+			if tt.wantRestart {
+				if !h.UnloadPlugin("alpha") {
+					t.Fatal("UnloadPlugin(alpha) = false, want true")
+				}
+				h.ApplyConfig(context.Background(), cfg)
+				if !h.pluginIdentityCurrent("alpha", paths["1.0.0"], "1.0.0") {
+					t.Fatal("plugin did not load after explicit unload cleared deferred state")
+				}
+				if openCalls, _ := loader.stats(); openCalls != 2 {
+					t.Fatalf("Open calls after explicit unload = %d, want 2", openCalls)
+				}
+			}
+			h.ShutdownAll()
+		})
+	}
+}
+
 func TestHostApplyConfigLogsLoadedWhenRegistrationInvalid(t *testing.T) {
 	var out bytes.Buffer
 	originalOut := log.StandardLogger().Out

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -1750,6 +1750,65 @@ func TestHostDeferredWritePreventsPublishedLoadFromOpeningReplacement(t *testing
 	fresh.ShutdownAll()
 }
 
+func TestHostDeferredLoadMarkerClearRetainsLoadedPlugin(t *testing.T) {
+	loader := newExclusiveTestLoader(map[string]*testPlugin{
+		"1.0.0": {
+			registerResult:    validTestPlugin("alpha-v1"),
+			reconfigureResult: validTestPlugin("alpha-v1"),
+		},
+		"2.0.0": {
+			registerResult:    validTestPlugin("alpha-v2"),
+			reconfigureResult: validTestPlugin("alpha-v2"),
+		},
+	})
+	pluginsDir, paths := makeVersionedPluginDir(t, "alpha", "1.0.0", "2.0.0")
+	h := NewForTest(loader)
+	t.Cleanup(h.ShutdownAll)
+	h.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"alpha": enabledPluginConfigWithStoreVersion(t, "1.0.0"),
+		},
+	}})
+
+	request := &pluginLoadRequest{
+		result:  make(chan pluginLoadResult, 1),
+		path:    paths["2.0.0"],
+		version: "2.0.0",
+	}
+	file := pluginFile{ID: "alpha", Path: paths["2.0.0"], Version: "2.0.0"}
+	h.mu.Lock()
+	h.deferredPluginUpdates["alpha"] = deferredPluginIdentity{path: paths["1.0.0"], version: "1.0.0"}
+	h.loading["alpha"] = request
+	h.mu.Unlock()
+	h.startPluginLoad(context.Background(), file, runtimeItemConfig{}, request)
+	loadResult := <-request.result
+	if !loadResult.deferred {
+		t.Fatalf("load result = %+v, want deferred", loadResult)
+	}
+	h.ClearDeferredPluginUpdate("alpha")
+
+	h.mu.Lock()
+	fallback, fallbackFile, retained := h.takeRetainedPluginLoadLocked(file, request)
+	h.mu.Unlock()
+	if !retained || fallback == nil {
+		t.Fatalf("retained fallback = %v, %+v; want loaded plugin", retained, fallback)
+	}
+	if fallbackFile.Path != paths["1.0.0"] || fallbackFile.Version != "1.0.0" {
+		t.Fatalf("fallback file = %+v, want retained v1", fallbackFile)
+	}
+	if !h.PluginRegistered("alpha") || !h.pluginIdentityCurrent("alpha", paths["1.0.0"], "1.0.0") {
+		t.Fatal("retained v1 was not still registered and effective after marker cleanup")
+	}
+	h.mu.Lock()
+	_, loading := h.loading["alpha"]
+	h.mu.Unlock()
+	if loading {
+		t.Fatal("deferred load request remained after retaining the loaded plugin")
+	}
+}
+
 func TestHostCanceledInitializationDiscardsBlockedClient(t *testing.T) {
 	client := &blockingInitializationClient{
 		started:      make(chan struct{}),

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -907,6 +907,56 @@ func TestHostApplyConfigDefersActiveUpdateUntilRestart(t *testing.T) {
 	fresh.ShutdownAll()
 }
 
+func TestHostCleanupKeepsDeferredPluginArtifact(t *testing.T) {
+	loader := newExclusiveTestLoader(map[string]*testPlugin{
+		"1.0.0": {
+			registerResult:    validTestPlugin("alpha-v1"),
+			reconfigureResult: validTestPlugin("alpha-v1"),
+		},
+		"2.0.0": {
+			registerResult:    validTestPlugin("alpha-v2"),
+			reconfigureResult: validTestPlugin("alpha-v2"),
+		},
+	})
+	pluginsDir, paths := makeVersionedPluginDir(t, "alpha", "1.0.0", "2.0.0")
+	if errRemove := os.Remove(paths["2.0.0"]); errRemove != nil {
+		t.Fatalf("Remove(%s) error = %v", paths["2.0.0"], errRemove)
+	}
+	configForVersion := func(version string) *config.Config {
+		return &config.Config{
+			Plugins: config.PluginsConfig{
+				Enabled: true,
+				Dir:     pluginsDir,
+				Configs: map[string]config.PluginInstanceConfig{
+					"alpha": enabledPluginConfigWithStoreVersion(t, version),
+				},
+			},
+		}
+	}
+
+	h := NewForTest(loader)
+	h.ApplyConfig(context.Background(), configForVersion("1.0.0"))
+	h.mu.Lock()
+	h.cleanupFilesPending = true
+	h.mu.Unlock()
+	if !h.DeferPluginUpdateUntilRestart("alpha", paths["2.0.0"], "2.0.0", false) {
+		t.Fatal("DeferPluginUpdateUntilRestart() = false, want true for staged update")
+	}
+	paths["2.0.0"] = writeVersionedPluginFile(t, pluginsDir, "alpha", "2.0.0")
+
+	h.ApplyConfig(context.Background(), configForVersion("2.0.0"))
+	if !h.PluginRegistered("alpha") || !h.pluginIdentityCurrent("alpha", paths["1.0.0"], "1.0.0") {
+		t.Fatal("retained v1 was not effective during cleanup")
+	}
+	if _, errStat := os.Stat(paths["2.0.0"]); errStat != nil {
+		t.Fatalf("deferred target artifact was removed: %v", errStat)
+	}
+	if openCalls, active := loader.stats(); openCalls != 1 || !active {
+		t.Fatalf("exclusive loader state = calls %d active %v, want one active v1 client", openCalls, active)
+	}
+	h.ShutdownAll()
+}
+
 func TestHostDeferPluginUpdateFreshInstallDoesNotRequireRestart(t *testing.T) {
 	loader := newExclusiveTestLoader(map[string]*testPlugin{
 		"1.0.0": {

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -1113,7 +1113,7 @@ func TestHostPreparePluginUpdateReportsMarkerOwnership(t *testing.T) {
 	h.ShutdownAll()
 }
 
-func TestHostCanceledReplacementFallsBackToLoadedIdentity(t *testing.T) {
+func TestHostCanceledReplacementRepinsAndFallsBackToLoadedIdentity(t *testing.T) {
 	first := newTestSymbolLookup(&testPlugin{
 		registerResult:    validTestPlugin("alpha-v1"),
 		reconfigureResult: validTestPlugin("alpha-v1"),
@@ -1145,11 +1145,17 @@ func TestHostCanceledReplacementFallsBackToLoadedIdentity(t *testing.T) {
 		close(replacementDone)
 	}()
 	waitForHostTestSignal(t, second.started, "replacement registration")
+	if deferred, created := h.PreparePluginUpdate("alpha"); !deferred || !created {
+		t.Fatalf("PreparePluginUpdate() before cancellation = deferred:%v created:%v, want true,true", deferred, created)
+	}
 	cancel()
 	waitForHostTestSignal(t, replacementDone, "canceled replacement apply")
 
-	if deferred, created := h.PreparePluginUpdate("alpha"); !deferred || !created {
-		t.Fatalf("PreparePluginUpdate() = deferred:%v created:%v, want true,true", deferred, created)
+	h.mu.Lock()
+	deferred := h.deferredPluginUpdates["alpha"]
+	h.mu.Unlock()
+	if deferred.path != paths["1.0.0"] || deferred.version != "1.0.0" {
+		t.Fatalf("deferred identity after cancellation = %#v, want loaded v1", deferred)
 	}
 	h.ApplyConfig(context.Background(), configForVersion("2.0.0"))
 	if !h.PluginRegistered("alpha") || !h.pluginIdentityCurrent("alpha", paths["1.0.0"], "1.0.0") {

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1379,6 +1380,81 @@ func TestHostDeferPluginUpdateWhilePluginLoading(t *testing.T) {
 	fresh.ApplyConfig(context.Background(), configForVersion("2.0.0"))
 	if !fresh.PluginRegistered("alpha") || !fresh.pluginIdentityCurrent("alpha", paths["2.0.0"], "2.0.0") {
 		t.Fatal("fresh host did not register desired v2")
+	}
+	fresh.ShutdownAll()
+}
+
+func TestHostDeferPluginUpdatePinsUnversionedPluginAfterRegistration(t *testing.T) {
+	loader := newTestSymbolLoader()
+	loader.lookups["alpha"] = newTestSymbolLookup(&testPlugin{
+		registerResult:    validTestPlugin("alpha-v1"),
+		reconfigureResult: validTestPlugin("alpha-v1"),
+	})
+	pluginsDir := makePluginDir(t, "alpha")
+	versionedPath := writeVersionedPluginFile(t, pluginsDir, "alpha", "2.0.0")
+	if errRemove := os.Remove(versionedPath); errRemove != nil {
+		t.Fatalf("Remove(%s) error = %v", versionedPath, errRemove)
+	}
+	initialConfig := &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: enabledPluginConfigs("alpha"),
+	}}
+	versionedConfig := &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: map[string]config.PluginInstanceConfig{
+			"alpha": enabledPluginConfigWithStoreVersion(t, "2.0.0"),
+		},
+	}}
+
+	openStarted := make(chan struct{})
+	releaseOpen := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseOpen) }) }
+	t.Cleanup(release)
+	h := NewForTest(&blockingOpenLoader{
+		inner:   loader,
+		started: openStarted,
+		release: releaseOpen,
+	})
+
+	applyDone := make(chan struct{})
+	go func() {
+		h.ApplyConfig(context.Background(), initialConfig)
+		close(applyDone)
+	}()
+	waitForHostTestSignal(t, openStarted, "unversioned plugin open start")
+	if !h.DeferPluginUpdateUntilRestart("alpha", versionedPath, "2.0.0", false) {
+		t.Fatal("DeferPluginUpdateUntilRestart() = false, want true while unversioned plugin is loading")
+	}
+
+	release()
+	waitForHostTestSignal(t, applyDone, "unversioned plugin load")
+	versionedPath = writeVersionedPluginFile(t, pluginsDir, "alpha", "2.0.0")
+	h.ApplyConfig(context.Background(), versionedConfig)
+	unversionedPath := filepath.Join(pluginsDir, runtime.GOOS, runtime.GOARCH, "alpha"+pluginExtension(runtime.GOOS))
+	if !h.PluginRegistered("alpha") || !h.pluginIdentityCurrent("alpha", unversionedPath, "") {
+		t.Fatal("unversioned plugin was not kept effective after registration populated its metadata version")
+	}
+	h.mu.Lock()
+	loadedVersion := h.loaded["alpha"].version
+	h.mu.Unlock()
+	if loadedVersion != "1.0.0" {
+		t.Fatalf("loaded metadata version = %q, want 1.0.0", loadedVersion)
+	}
+	if h.pluginIdentityCurrent("alpha", versionedPath, "2.0.0") {
+		t.Fatal("versioned replacement became active before restart")
+	}
+	if loader.openCalls != 1 {
+		t.Fatalf("Open calls = %d, want one retained unversioned client", loader.openCalls)
+	}
+
+	h.ShutdownAll()
+	fresh := NewForTest(loader)
+	fresh.ApplyConfig(context.Background(), versionedConfig)
+	if !fresh.PluginRegistered("alpha") || !fresh.pluginIdentityCurrent("alpha", versionedPath, "2.0.0") {
+		t.Fatal("fresh host did not register desired versioned plugin")
 	}
 	fresh.ShutdownAll()
 }

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -855,13 +855,18 @@ func TestHostApplyConfigDefersActiveUpdateUntilRestart(t *testing.T) {
 		t.Fatalf("initial plugin was not registered at v1: registered=%v", h.PluginRegistered("alpha"))
 	}
 	paths["2.0.0"] = writeVersionedPluginFile(t, pluginsDir, "alpha", "2.0.0")
+	h.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{Dir: pluginsDir}})
+	if h.PluginRegistered("alpha") {
+		t.Fatal("PluginRegistered(alpha) = true after disabling plugins, want no active capability")
+	}
+	if !h.PluginLoaded("alpha") {
+		t.Fatal("PluginLoaded(alpha) = false after disabling plugins, want retained library")
+	}
 	if !h.DeferPluginUpdateUntilRestart("alpha", paths["2.0.0"], "2.0.0", false) {
-		t.Fatal("DeferPluginUpdateUntilRestart() = false, want true for staged v2")
+		t.Fatal("DeferPluginUpdateUntilRestart() = false, want true for staged v2 while v1 is retained")
 	}
 
 	h.ApplyConfig(context.Background(), cfgV2)
-	h.ApplyConfig(context.Background(), cfgV2)
-	h.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{Dir: pluginsDir}})
 	h.ApplyConfig(context.Background(), cfgV2)
 	if !h.PluginRegistered("alpha") {
 		t.Fatal("PluginRegistered(alpha) = false, want old v1 to remain effective before restart")

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -864,7 +864,7 @@ func TestHostApplyConfigDefersActiveUpdateUntilRestart(t *testing.T) {
 	if !h.PluginLoaded("alpha") {
 		t.Fatal("PluginLoaded(alpha) = false after disabling plugins, want retained library")
 	}
-	if !h.DeferPluginUpdateUntilRestart("alpha", paths["2.0.0"], "2.0.0", false) {
+	if deferred, _ := h.DeferPluginUpdateUntilRestart("alpha", paths["2.0.0"], "2.0.0", false); !deferred {
 		t.Fatal("DeferPluginUpdateUntilRestart() = false, want true for staged v2 while v1 is retained")
 	}
 
@@ -939,7 +939,7 @@ func TestHostCleanupKeepsDeferredPluginArtifact(t *testing.T) {
 	h.mu.Lock()
 	h.cleanupFilesPending = true
 	h.mu.Unlock()
-	if !h.DeferPluginUpdateUntilRestart("alpha", paths["2.0.0"], "2.0.0", false) {
+	if deferred, _ := h.DeferPluginUpdateUntilRestart("alpha", paths["2.0.0"], "2.0.0", false); !deferred {
 		t.Fatal("DeferPluginUpdateUntilRestart() = false, want true for staged update")
 	}
 	paths["2.0.0"] = writeVersionedPluginFile(t, pluginsDir, "alpha", "2.0.0")
@@ -966,7 +966,7 @@ func TestHostDeferPluginUpdateFreshInstallDoesNotRequireRestart(t *testing.T) {
 	})
 	pluginsDir, paths := makeVersionedPluginDir(t, "alpha", "1.0.0")
 	h := NewForTest(loader)
-	if h.DeferPluginUpdateUntilRestart("alpha", paths["1.0.0"], "1.0.0", true) {
+	if deferred, _ := h.DeferPluginUpdateUntilRestart("alpha", paths["1.0.0"], "1.0.0", true); deferred {
 		t.Fatal("fresh install was marked restart-required before any active plugin existed")
 	}
 	h.ApplyConfig(context.Background(), &config.Config{
@@ -1012,7 +1012,7 @@ func TestHostDeferPluginUpdateSameIdentityUsesContentChange(t *testing.T) {
 			}
 			h := NewForTest(loader)
 			h.ApplyConfig(context.Background(), cfg)
-			if got := h.DeferPluginUpdateUntilRestart("alpha", paths["1.0.0"], "1.0.0", tt.contentChanged); got != tt.wantRestart {
+			if got, _ := h.DeferPluginUpdateUntilRestart("alpha", paths["1.0.0"], "1.0.0", tt.contentChanged); got != tt.wantRestart {
 				t.Fatalf("DeferPluginUpdateUntilRestart() = %v, want %v", got, tt.wantRestart)
 			}
 			h.ApplyConfig(context.Background(), cfg)
@@ -1065,10 +1065,10 @@ func TestHostDeferPluginUpdatePreservesPendingDeferralForSameIdentity(t *testing
 
 	h := NewForTest(loader)
 	h.ApplyConfig(context.Background(), configForVersion("1.0.0"))
-	if !h.DeferPluginUpdateUntilRestart("alpha", paths["2.0.0"], "2.0.0", false) {
+	if deferred, _ := h.DeferPluginUpdateUntilRestart("alpha", paths["2.0.0"], "2.0.0", false); !deferred {
 		t.Fatal("initial deferred update = false, want true")
 	}
-	if !h.DeferPluginUpdateUntilRestart("alpha", paths["1.0.0"], "1.0.0", false) {
+	if deferred, _ := h.DeferPluginUpdateUntilRestart("alpha", paths["1.0.0"], "1.0.0", false); !deferred {
 		t.Fatal("same-identity follow-up = false, want true while an update remains deferred")
 	}
 
@@ -1082,6 +1082,93 @@ func TestHostDeferPluginUpdatePreservesPendingDeferralForSameIdentity(t *testing
 	}
 	if openCalls, active := loader.stats(); openCalls != 1 || !active {
 		t.Fatalf("exclusive loader state = calls %d active %v, want one active v1 client", openCalls, active)
+	}
+	h.ShutdownAll()
+}
+
+func TestHostPreparePluginUpdateReportsMarkerOwnership(t *testing.T) {
+	loader := newExclusiveTestLoader(map[string]*testPlugin{
+		"1.0.0": {
+			registerResult:    validTestPlugin("alpha-v1"),
+			reconfigureResult: validTestPlugin("alpha-v1"),
+		},
+	})
+	pluginsDir, paths := makeVersionedPluginDir(t, "alpha", "1.0.0")
+	h := NewForTest(loader)
+	h.ApplyConfig(context.Background(), &config.Config{Plugins: config.PluginsConfig{
+		Enabled: true,
+		Dir:     pluginsDir,
+		Configs: enabledPluginConfigs("alpha"),
+	}})
+
+	if deferred, created := h.PreparePluginUpdate("alpha"); !deferred || !created {
+		t.Fatalf("first PreparePluginUpdate() = deferred:%v created:%v, want true,true", deferred, created)
+	}
+	if deferred, created := h.PreparePluginUpdate("alpha"); !deferred || created {
+		t.Fatalf("second PreparePluginUpdate() = deferred:%v created:%v, want true,false", deferred, created)
+	}
+	if deferred, created := h.DeferPluginUpdateUntilRestart("alpha", paths["1.0.0"], "1.0.0", false); !deferred || created {
+		t.Fatalf("follow-up DeferPluginUpdateUntilRestart() = deferred:%v created:%v, want true,false", deferred, created)
+	}
+	h.ShutdownAll()
+}
+
+func TestHostCanceledReplacementFallsBackToLoadedIdentity(t *testing.T) {
+	first := newTestSymbolLookup(&testPlugin{
+		registerResult:    validTestPlugin("alpha-v1"),
+		reconfigureResult: validTestPlugin("alpha-v1"),
+	})
+	second := &blockingInitializationClient{
+		started:      make(chan struct{}),
+		release:      make(chan struct{}),
+		registration: validTestPlugin("alpha-v2"),
+	}
+	loader := &countingPluginLoader{client: first, replacement: second}
+	pluginsDir, paths := makeVersionedPluginDir(t, "alpha", "1.0.0", "2.0.0")
+	configForVersion := func(version string) *config.Config {
+		return &config.Config{Plugins: config.PluginsConfig{
+			Enabled: true,
+			Dir:     pluginsDir,
+			Configs: map[string]config.PluginInstanceConfig{
+				"alpha": enabledPluginConfigWithStoreVersion(t, version),
+			},
+		}}
+	}
+	h := NewForTest(loader)
+	h.ApplyConfig(context.Background(), configForVersion("1.0.0"))
+	paths["2.0.0"] = writeVersionedPluginFile(t, pluginsDir, "alpha", "2.0.0")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	replacementDone := make(chan struct{})
+	go func() {
+		h.ApplyConfig(ctx, configForVersion("2.0.0"))
+		close(replacementDone)
+	}()
+	waitForHostTestSignal(t, second.started, "replacement registration")
+	cancel()
+	waitForHostTestSignal(t, replacementDone, "canceled replacement apply")
+
+	if deferred, created := h.PreparePluginUpdate("alpha"); !deferred || !created {
+		t.Fatalf("PreparePluginUpdate() = deferred:%v created:%v, want true,true", deferred, created)
+	}
+	h.ApplyConfig(context.Background(), configForVersion("2.0.0"))
+	if !h.PluginRegistered("alpha") || !h.pluginIdentityCurrent("alpha", paths["1.0.0"], "1.0.0") {
+		t.Fatal("canceled replacement displaced the registered v1 plugin")
+	}
+	if h.pluginIdentityCurrent("alpha", paths["2.0.0"], "2.0.0") {
+		t.Fatal("canceled replacement became effective before restart")
+	}
+	if got := loader.calls.Load(); got != 2 {
+		t.Fatalf("Open calls = %d, want one initial and one canceled replacement load", got)
+	}
+
+	close(second.release)
+	deadline := time.Now().Add(time.Second)
+	for second.shutdown.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := second.shutdown.Load(); got != 1 {
+		t.Fatalf("canceled replacement shutdown calls = %d, want 1", got)
 	}
 	h.ShutdownAll()
 }
@@ -1407,7 +1494,7 @@ func TestHostDeferPluginUpdateWhilePluginLoading(t *testing.T) {
 	if h.PluginLoaded("alpha") {
 		t.Fatal("PluginLoaded(alpha) = true, want false while plugin is still loading")
 	}
-	if !h.DeferPluginUpdateUntilRestart("alpha", paths["2.0.0"], "2.0.0", false) {
+	if deferred, _ := h.DeferPluginUpdateUntilRestart("alpha", paths["2.0.0"], "2.0.0", false); !deferred {
 		t.Fatal("DeferPluginUpdateUntilRestart() = false, want true while v1 is loading")
 	}
 
@@ -1475,7 +1562,7 @@ func TestHostDeferPluginUpdatePinsUnversionedPluginAfterRegistration(t *testing.
 		close(applyDone)
 	}()
 	waitForHostTestSignal(t, openStarted, "unversioned plugin open start")
-	if !h.DeferPluginUpdateUntilRestart("alpha", versionedPath, "2.0.0", false) {
+	if deferred, _ := h.DeferPluginUpdateUntilRestart("alpha", versionedPath, "2.0.0", false); !deferred {
 		t.Fatal("DeferPluginUpdateUntilRestart() = false, want true while unversioned plugin is loading")
 	}
 
@@ -1555,7 +1642,7 @@ func TestHostDeferPluginUpdatePrefersInFlightReplacement(t *testing.T) {
 		close(replacementDone)
 	}()
 	waitForHostTestSignal(t, openStarted, "replacement plugin open start")
-	if !h.DeferPluginUpdateUntilRestart("alpha", paths["3.0.0"], "3.0.0", false) {
+	if deferred, _ := h.DeferPluginUpdateUntilRestart("alpha", paths["3.0.0"], "3.0.0", false); !deferred {
 		t.Fatal("DeferPluginUpdateUntilRestart() = false, want true while replacement v2 is loading")
 	}
 

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -957,6 +957,30 @@ func TestHostCleanupKeepsDeferredPluginArtifact(t *testing.T) {
 	h.ShutdownAll()
 }
 
+func TestHostCleanupKeepsDeferredPluginArtifactBeforeConfigSave(t *testing.T) {
+	h, cfg, registerStarted, releaseRegister := newBlockingRegisterHost(t)
+	applyDone := make(chan struct{})
+	go func() {
+		h.ApplyConfig(context.Background(), cfg)
+		close(applyDone)
+	}()
+	waitForHostTestSignal(t, registerStarted, "plugin registration")
+	if deferred, created := h.PreparePluginUpdate("alpha"); !deferred || !created {
+		t.Fatalf("PreparePluginUpdate() = deferred:%v created:%v, want true,true", deferred, created)
+	}
+	target := writeVersionedPluginFile(t, cfg.Plugins.Dir, "alpha", "2.0.0")
+	releaseRegister()
+	waitForHostTestSignal(t, applyDone, "initial plugin apply")
+
+	if !h.PluginRegistered("alpha") {
+		t.Fatal("PluginRegistered(alpha) = false, want initial version active")
+	}
+	if _, errStat := os.Stat(target); errStat != nil {
+		t.Fatalf("deferred target artifact was removed before config persistence: %v", errStat)
+	}
+	h.ShutdownAll()
+}
+
 func TestHostDeferPluginUpdateFreshInstallDoesNotRequireRestart(t *testing.T) {
 	loader := newExclusiveTestLoader(map[string]*testPlugin{
 		"1.0.0": {

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -1674,6 +1674,82 @@ func TestHostDeferPluginUpdatePrefersInFlightReplacement(t *testing.T) {
 	fresh.ShutdownAll()
 }
 
+func TestHostDeferredWritePreventsPublishedLoadFromOpeningReplacement(t *testing.T) {
+	loader := newExclusiveTestLoader(map[string]*testPlugin{
+		"1.0.0": {
+			registerResult:    validTestPlugin("alpha-v1"),
+			reconfigureResult: validTestPlugin("alpha-v1"),
+		},
+		"2.0.0": {
+			registerResult:    validTestPlugin("alpha-v2"),
+			reconfigureResult: validTestPlugin("alpha-v2"),
+		},
+	})
+	pluginsDir, paths := makeVersionedPluginDir(t, "alpha", "1.0.0", "2.0.0")
+	configForVersion := func(version string) *config.Config {
+		return &config.Config{Plugins: config.PluginsConfig{
+			Enabled: true,
+			Dir:     pluginsDir,
+			Configs: map[string]config.PluginInstanceConfig{
+				"alpha": enabledPluginConfigWithStoreVersion(t, version),
+			},
+		}}
+	}
+
+	if errRemove := os.Remove(paths["2.0.0"]); errRemove != nil {
+		t.Fatalf("Remove(%s) error = %v", paths["2.0.0"], errRemove)
+	}
+	h := NewForTest(loader)
+	h.ApplyConfig(context.Background(), configForVersion("1.0.0"))
+	paths["2.0.0"] = writeVersionedPluginFile(t, pluginsDir, "alpha", "2.0.0")
+
+	unlockArtifact := h.LockPluginArtifact("alpha")
+	applyDone := make(chan struct{})
+	go func() {
+		h.ApplyConfig(context.Background(), configForVersion("2.0.0"))
+		close(applyDone)
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		h.mu.Lock()
+		_, loading := h.loading["alpha"]
+		h.mu.Unlock()
+		if loading {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for replacement load request")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if deferred, created := h.PreparePluginUpdate("alpha"); !deferred || !created {
+		t.Fatalf("PreparePluginUpdate() = deferred:%v created:%v, want true,true", deferred, created)
+	}
+	if errWrite := os.WriteFile(paths["2.0.0"], []byte("replacement-bytes"), 0o755); errWrite != nil {
+		t.Fatalf("WriteFile(%s) error = %v", paths["2.0.0"], errWrite)
+	}
+	unlockArtifact()
+	waitForHostTestSignal(t, applyDone, "deferred replacement apply")
+
+	if !h.PluginRegistered("alpha") || !h.pluginIdentityCurrent("alpha", paths["1.0.0"], "1.0.0") {
+		t.Fatal("retained v1 was not effective after a published load was deferred")
+	}
+	if h.pluginIdentityCurrent("alpha", paths["2.0.0"], "2.0.0") {
+		t.Fatal("replacement v2 became active before restart")
+	}
+	if openCalls, active := loader.stats(); openCalls != 1 || !active {
+		t.Fatalf("exclusive loader state = calls %d active %v, want one active v1 client", openCalls, active)
+	}
+
+	h.ShutdownAll()
+	fresh := NewForTest(loader)
+	fresh.ApplyConfig(context.Background(), configForVersion("2.0.0"))
+	if !fresh.PluginRegistered("alpha") || !fresh.pluginIdentityCurrent("alpha", paths["2.0.0"], "2.0.0") {
+		t.Fatal("fresh host did not register desired replacement after restart")
+	}
+	fresh.ShutdownAll()
+}
+
 func TestHostCanceledInitializationDiscardsBlockedClient(t *testing.T) {
 	client := &blockingInitializationClient{
 		started:      make(chan struct{}),

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -1308,6 +1309,80 @@ func TestHostPluginBusyReportsLoadingPlugin(t *testing.T) {
 	}
 }
 
+func TestHostDeferPluginUpdateWhilePluginLoading(t *testing.T) {
+	loader := newExclusiveTestLoader(map[string]*testPlugin{
+		"1.0.0": {
+			registerResult:    validTestPlugin("alpha-v1"),
+			reconfigureResult: validTestPlugin("alpha-v1"),
+		},
+		"2.0.0": {
+			registerResult:    validTestPlugin("alpha-v2"),
+			reconfigureResult: validTestPlugin("alpha-v2"),
+		},
+	})
+	pluginsDir, paths := makeVersionedPluginDir(t, "alpha", "1.0.0", "2.0.0")
+	if errRemove := os.Remove(paths["2.0.0"]); errRemove != nil {
+		t.Fatalf("Remove(%s) error = %v", paths["2.0.0"], errRemove)
+	}
+	configForVersion := func(version string) *config.Config {
+		return &config.Config{
+			Plugins: config.PluginsConfig{
+				Enabled: true,
+				Dir:     pluginsDir,
+				Configs: map[string]config.PluginInstanceConfig{
+					"alpha": enabledPluginConfigWithStoreVersion(t, version),
+				},
+			},
+		}
+	}
+
+	openStarted := make(chan struct{})
+	releaseOpen := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseOpen) }) }
+	t.Cleanup(release)
+	h := NewForTest(&blockingOpenLoader{
+		inner:   loader,
+		started: openStarted,
+		release: releaseOpen,
+	})
+
+	applyDone := make(chan struct{})
+	go func() {
+		h.ApplyConfig(context.Background(), configForVersion("1.0.0"))
+		close(applyDone)
+	}()
+	waitForHostTestSignal(t, openStarted, "plugin open start")
+	if h.PluginLoaded("alpha") {
+		t.Fatal("PluginLoaded(alpha) = true, want false while plugin is still loading")
+	}
+	if !h.DeferPluginUpdateUntilRestart("alpha", paths["2.0.0"], "2.0.0", false) {
+		t.Fatal("DeferPluginUpdateUntilRestart() = false, want true while v1 is loading")
+	}
+
+	release()
+	waitForHostTestSignal(t, applyDone, "initial plugin load")
+	paths["2.0.0"] = writeVersionedPluginFile(t, pluginsDir, "alpha", "2.0.0")
+	h.ApplyConfig(context.Background(), configForVersion("2.0.0"))
+	if !h.PluginRegistered("alpha") || !h.pluginIdentityCurrent("alpha", paths["1.0.0"], "1.0.0") {
+		t.Fatal("retained v1 was not effective after deferred update")
+	}
+	if h.pluginIdentityCurrent("alpha", paths["2.0.0"], "2.0.0") {
+		t.Fatal("replacement v2 became active before restart")
+	}
+	if openCalls, active := loader.stats(); openCalls != 1 || !active {
+		t.Fatalf("exclusive loader state = calls %d active %v, want one active v1 client", openCalls, active)
+	}
+
+	h.ShutdownAll()
+	fresh := NewForTest(loader)
+	fresh.ApplyConfig(context.Background(), configForVersion("2.0.0"))
+	if !fresh.PluginRegistered("alpha") || !fresh.pluginIdentityCurrent("alpha", paths["2.0.0"], "2.0.0") {
+		t.Fatal("fresh host did not register desired v2")
+	}
+	fresh.ShutdownAll()
+}
+
 func TestHostCanceledInitializationDiscardsBlockedClient(t *testing.T) {
 	client := &blockingInitializationClient{
 		started:      make(chan struct{}),
@@ -1770,7 +1845,7 @@ func (c *blockingHostCallClient) Shutdown() {
 }
 
 type blockingOpenLoader struct {
-	inner     *testSymbolLoader
+	inner     pluginLoader
 	started   chan struct{}
 	release   <-chan struct{}
 	startOnce sync.Once

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -1383,6 +1383,78 @@ func TestHostDeferPluginUpdateWhilePluginLoading(t *testing.T) {
 	fresh.ShutdownAll()
 }
 
+func TestHostDeferPluginUpdatePrefersInFlightReplacement(t *testing.T) {
+	loader := newTestSymbolLoader()
+	loader.lookups["alpha"] = newTestSymbolLookup(&testPlugin{
+		registerResult:    validTestPlugin("alpha"),
+		reconfigureResult: validTestPlugin("alpha"),
+	})
+	pluginsDir, paths := makeVersionedPluginDir(t, "alpha", "1.0.0", "2.0.0", "3.0.0")
+	for _, version := range []string{"2.0.0", "3.0.0"} {
+		if errRemove := os.Remove(paths[version]); errRemove != nil {
+			t.Fatalf("Remove(%s) error = %v", paths[version], errRemove)
+		}
+	}
+	configForVersion := func(version string) *config.Config {
+		return &config.Config{
+			Plugins: config.PluginsConfig{
+				Enabled: true,
+				Dir:     pluginsDir,
+				Configs: map[string]config.PluginInstanceConfig{
+					"alpha": enabledPluginConfigWithStoreVersion(t, version),
+				},
+			},
+		}
+	}
+
+	h := NewForTest(loader)
+	h.ApplyConfig(context.Background(), configForVersion("1.0.0"))
+	paths["2.0.0"] = writeVersionedPluginFile(t, pluginsDir, "alpha", "2.0.0")
+	paths["3.0.0"] = writeVersionedPluginFile(t, pluginsDir, "alpha", "3.0.0")
+
+	openStarted := make(chan struct{})
+	releaseOpen := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseOpen) }) }
+	t.Cleanup(release)
+	h.loader = &blockingOpenLoader{
+		inner:   loader,
+		started: openStarted,
+		release: releaseOpen,
+	}
+
+	replacementDone := make(chan struct{})
+	go func() {
+		h.ApplyConfig(context.Background(), configForVersion("2.0.0"))
+		close(replacementDone)
+	}()
+	waitForHostTestSignal(t, openStarted, "replacement plugin open start")
+	if !h.DeferPluginUpdateUntilRestart("alpha", paths["3.0.0"], "3.0.0", false) {
+		t.Fatal("DeferPluginUpdateUntilRestart() = false, want true while replacement v2 is loading")
+	}
+
+	release()
+	waitForHostTestSignal(t, replacementDone, "replacement plugin load")
+	h.ApplyConfig(context.Background(), configForVersion("3.0.0"))
+	if !h.PluginRegistered("alpha") || !h.pluginIdentityCurrent("alpha", paths["2.0.0"], "2.0.0") {
+		t.Fatal("in-flight replacement v2 was not kept effective while v3 was deferred")
+	}
+	if h.pluginIdentityCurrent("alpha", paths["3.0.0"], "3.0.0") {
+		t.Fatal("staged v3 became active before restart")
+	}
+	if loader.openCalls != 2 {
+		t.Fatalf("Open calls = %d, want two calls through the replacement load", loader.openCalls)
+	}
+
+	h.ShutdownAll()
+	fresh := NewForTest(loader)
+	fresh.ApplyConfig(context.Background(), configForVersion("3.0.0"))
+	if !fresh.PluginRegistered("alpha") || !fresh.pluginIdentityCurrent("alpha", paths["3.0.0"], "3.0.0") {
+		t.Fatal("fresh host did not register desired v3")
+	}
+	fresh.ShutdownAll()
+}
+
 func TestHostCanceledInitializationDiscardsBlockedClient(t *testing.T) {
 	client := &blockingInitializationClient{
 		started:      make(chan struct{}),

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -981,6 +981,30 @@ func TestHostCleanupKeepsDeferredPluginArtifactBeforeConfigSave(t *testing.T) {
 	h.ShutdownAll()
 }
 
+func TestHostLockPluginOperationSerializesSameID(t *testing.T) {
+	h := New()
+	unlocked := h.LockPluginOperation("alpha")
+	acquired := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		unlockSecond := h.LockPluginOperation("alpha")
+		close(acquired)
+		unlockSecond()
+		close(done)
+	}()
+	select {
+	case <-acquired:
+		t.Fatal("second operation acquired the same plugin lock before the first released it")
+	case <-time.After(20 * time.Millisecond):
+	}
+	unlocked()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("second operation did not acquire the plugin lock after release")
+	}
+}
+
 func TestHostDeferPluginUpdateFreshInstallDoesNotRequireRestart(t *testing.T) {
 	loader := newExclusiveTestLoader(map[string]*testPlugin{
 		"1.0.0": {

--- a/internal/pluginhost/platform.go
+++ b/internal/pluginhost/platform.go
@@ -249,7 +249,7 @@ func pluginVersionSegment(segments []string, index int) (int64, bool) {
 	return number, true
 }
 
-func cleanupUnselectedPluginFiles(root string, loaded []pluginFile) error {
+func cleanupUnselectedPluginFiles(root string, loaded []pluginFile, isDeferred func(string) bool, lockArtifact func(string) func()) error {
 	if len(loaded) == 0 {
 		return nil
 	}
@@ -271,18 +271,32 @@ func cleanupUnselectedPluginFiles(root string, loaded []pluginFile) error {
 	}
 	var errs []error
 	for _, candidate := range candidates {
+		unlockArtifact := func() {}
+		if lockArtifact != nil {
+			if unlock := lockArtifact(candidate.ID); unlock != nil {
+				unlockArtifact = unlock
+			}
+		}
+		if isDeferred != nil && isDeferred(candidate.ID) {
+			unlockArtifact()
+			continue
+		}
 		paths := loadedByID[candidate.ID]
 		if len(paths) == 0 {
+			unlockArtifact()
 			continue
 		}
 		if _, selected := paths[filepath.Clean(candidate.Path)]; selected {
+			unlockArtifact()
 			continue
 		}
 		if errRemove := os.Remove(candidate.Path); errRemove != nil && !errors.Is(errRemove, os.ErrNotExist) {
+			unlockArtifact()
 			errs = append(errs, errRemove)
 			log.WithError(errRemove).Warnf("pluginhost: failed to remove old plugin file %s", candidate.Path)
 			continue
 		}
+		unlockArtifact()
 		log.WithFields(pluginLogFields(candidate.ID, "", candidate.Version, candidate.Path)).Info("pluginhost: old plugin file removed")
 	}
 	return errors.Join(errs...)

--- a/internal/pluginhost/test_helpers_test.go
+++ b/internal/pluginhost/test_helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -18,6 +19,60 @@ import (
 type testSymbolLoader struct {
 	openCalls int
 	lookups   map[string]*testSymbolLookup
+}
+
+type exclusiveTestLoader struct {
+	mu        sync.Mutex
+	active    bool
+	openCalls int
+	plugins   map[string]*testPlugin
+}
+
+func newExclusiveTestLoader(plugins map[string]*testPlugin) *exclusiveTestLoader {
+	return &exclusiveTestLoader{plugins: plugins}
+}
+
+func (l *exclusiveTestLoader) Open(file pluginFile, _ *Host) (pluginClient, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.active {
+		return nil, fmt.Errorf("exclusive test resource already open")
+	}
+	plugin := l.plugins[file.Version]
+	if plugin == nil {
+		return nil, fmt.Errorf("missing exclusive test plugin for %s", file.Version)
+	}
+	l.active = true
+	l.openCalls++
+	return &exclusiveTestClient{
+		lookup: newTestSymbolLookup(plugin),
+		loader: l,
+	}, nil
+}
+
+func (l *exclusiveTestLoader) stats() (int, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.openCalls, l.active
+}
+
+type exclusiveTestClient struct {
+	lookup *testSymbolLookup
+	loader *exclusiveTestLoader
+	once   sync.Once
+}
+
+func (c *exclusiveTestClient) Call(ctx context.Context, method string, request []byte) ([]byte, error) {
+	return c.lookup.Call(ctx, method, request)
+}
+
+func (c *exclusiveTestClient) Shutdown() {
+	c.once.Do(func() {
+		c.lookup.Shutdown()
+		c.loader.mu.Lock()
+		c.loader.active = false
+		c.loader.mu.Unlock()
+	})
 }
 
 func newTestSymbolLoader() *testSymbolLoader {

--- a/internal/pluginstore/install.go
+++ b/internal/pluginstore/install.go
@@ -28,6 +28,10 @@ type InstallOptions struct {
 	// BeforeWrite runs after the archive has been downloaded and verified, but
 	// before the target plugin file is written or replaced.
 	BeforeWrite func() error
+	// WriteLock serializes the target file replacement with a host load of the
+	// same plugin. The returned function is called after the write completes or
+	// fails.
+	WriteLock func() func()
 }
 
 // ErrLoadedPluginLocked is returned when an install would overwrite a plugin
@@ -286,6 +290,13 @@ func InstallArchive(archiveData []byte, plugin Plugin, options InstallOptions) (
 			}, nil
 		}
 	}
+	unlockWrite := func() {}
+	if options.WriteLock != nil {
+		if release := options.WriteLock(); release != nil {
+			unlockWrite = release
+		}
+	}
+	defer unlockWrite()
 	// Re-check immediately before writing: the same version may have been loaded
 	// while the archive was being downloaded and verified.
 	if options.BeforeWrite != nil {

--- a/internal/pluginstore/install.go
+++ b/internal/pluginstore/install.go
@@ -26,7 +26,7 @@ type InstallOptions struct {
 	// would overwrite an existing target file while it returns true.
 	PluginLoaded func() bool
 	// BeforeWrite runs after the archive has been downloaded and verified, but
-	// before an existing target plugin file is replaced.
+	// before the target plugin file is written or replaced.
 	BeforeWrite func() error
 }
 
@@ -286,9 +286,9 @@ func InstallArchive(archiveData []byte, plugin Plugin, options InstallOptions) (
 			}, nil
 		}
 	}
-	// Re-check immediately before replacing an existing file: the same version
-	// may have been loaded while the archive was being downloaded and verified.
-	if overwritten && options.BeforeWrite != nil {
+	// Re-check immediately before writing: the same version may have been loaded
+	// while the archive was being downloaded and verified.
+	if options.BeforeWrite != nil {
 		if errBeforeWrite := options.BeforeWrite(); errBeforeWrite != nil {
 			return InstallResult{}, fmt.Errorf("prepare plugin write: %w", errBeforeWrite)
 		}

--- a/internal/pluginstore/install_test.go
+++ b/internal/pluginstore/install_test.go
@@ -120,6 +120,33 @@ func TestInstallArchivePreparesLoadedWindowsPluginBeforeWrite(t *testing.T) {
 	}
 }
 
+func TestInstallArchivePreparesNewPluginBeforeWrite(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	prepared := false
+	result, errInstall := InstallArchive(makeZip(t, map[string]string{
+		"sample-provider.dll": "new",
+	}), testPlugin(), InstallOptions{
+		PluginsDir: root,
+		GOOS:       "windows",
+		GOARCH:     "amd64",
+		BeforeWrite: func() error {
+			prepared = true
+			return nil
+		},
+	})
+	if errInstall != nil {
+		t.Fatalf("InstallArchive() error = %v", errInstall)
+	}
+	if !prepared {
+		t.Fatal("BeforeWrite was not called for a new artifact")
+	}
+	if result.Overwritten {
+		t.Fatal("Overwritten = true, want false for a new artifact")
+	}
+}
+
 func TestInstallArchiveSkipsIdenticalLoadedWindowsPlugin(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pluginstore/install_test.go
+++ b/internal/pluginstore/install_test.go
@@ -147,6 +147,66 @@ func TestInstallArchivePreparesNewPluginBeforeWrite(t *testing.T) {
 	}
 }
 
+func TestInstallArchiveWriteLockCoversWriteAndPreparationFailure(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	targetPath := filepath.Join(root, "windows", "amd64", "sample-provider-v0.1.0.dll")
+	held := false
+	result, errInstall := InstallArchive(makeZip(t, map[string]string{
+		"sample-provider.dll": "new",
+	}), testPlugin(), InstallOptions{
+		PluginsDir: root,
+		GOOS:       "windows",
+		GOARCH:     "amd64",
+		WriteLock: func() func() {
+			held = true
+			return func() {
+				if _, errStat := os.Stat(targetPath); errStat != nil {
+					t.Errorf("target was not written before WriteLock release: %v", errStat)
+				}
+				held = false
+			}
+		},
+		BeforeWrite: func() error {
+			if !held {
+				t.Fatal("BeforeWrite ran without the write lock")
+			}
+			return nil
+		},
+	})
+	if errInstall != nil {
+		t.Fatalf("InstallArchive() error = %v", errInstall)
+	}
+	if result.Path != targetPath {
+		t.Fatalf("Path = %q, want %q", result.Path, targetPath)
+	}
+	if held {
+		t.Fatal("WriteLock remained held after a successful install")
+	}
+
+	releasedAfterFailure := false
+	_, errInstall = InstallArchive(makeZip(t, map[string]string{
+		"sample-provider.dll": "newer",
+	}), testPlugin(), InstallOptions{
+		PluginsDir: root,
+		GOOS:       "windows",
+		GOARCH:     "amd64",
+		WriteLock: func() func() {
+			return func() { releasedAfterFailure = true }
+		},
+		BeforeWrite: func() error {
+			return errors.New("stop before write")
+		},
+	})
+	if errInstall == nil {
+		t.Fatal("InstallArchive() error = nil, want preparation failure")
+	}
+	if !releasedAfterFailure {
+		t.Fatal("WriteLock was not released after preparation failure")
+	}
+}
+
 func TestInstallArchiveSkipsIdenticalLoadedWindowsPlugin(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Active native plugin updates can load and register a replacement while the current library still owns an exclusive resource. This keeps the active identity pinned until restart.

- classify verified store updates before config persistence
- return `restart_required: true` for active path/version or changed-byte updates
- keep the active path/version in every `Host.ApplyConfig` reload path
- load the desired artifact normally after a fresh host starts
- preserve fresh-install and Windows overwrite behavior

## Validation

- `go test ./internal/pluginhost ./internal/api/handlers/management ./internal/pluginstore -count=1`
- `go test -race ./internal/pluginhost ./internal/api/handlers/management`
- `go build -o test-output ./cmd/server`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/pluginhost`

`go test ./...` was also run. Three untouched `internal/runtime/executor` Claude fingerprint tests fail in this environment with `X-Stainless-Os = "MacOS", want "Linux"`; the same failures reproduce when that package is run alone. No executor files are changed in this PR.