### PR TITLE
feat(codex): optional zstd/gzip compression for upstream /responses request bodies

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -272,6 +272,14 @@ codex:
   # than cooling down the entire credential across all sibling models.
   # Default: false
   model-level-cooling: false
+  # Compress the request body sent to the official ChatGPT Codex backend (chatgpt.com)
+  # for /responses and /responses/compact. "zstd" is the content coding the official
+  # Codex CLI sends (level 3); "gzip" is also accepted upstream; empty or "off" sends
+  # identity bodies. Custom codex-api-key base URLs are never compressed. Bodies under
+  # 1 KiB and bodies that would not shrink are sent as-is. Codex clients resend the
+  # whole conversation every turn, so JSON-heavy requests shrink several-fold; useful
+  # when upstream egress is metered.
+  upstream-request-compression: ""
   # Terminate and relay Codex Live WebRTC audio and DataChannel traffic in this process.
   # This requires inbound UDP reachability. Keep disabled to preserve direct media behavior.
   live-media-relay:

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -181,6 +181,12 @@ type CodexConfig struct {
 	// ModelLevelCooling scopes Codex usage_limit_reached quota cooldowns to the requested model
 	// rather than cooling down the entire credential across all sibling models.
 	ModelLevelCooling bool `yaml:"model-level-cooling" json:"model-level-cooling"`
+	// UpstreamRequestCompression compresses Codex /responses and /responses/compact upstream
+	// request bodies sent to the official ChatGPT backend. Accepted values: "zstd" (the
+	// content coding the official Codex CLI sends), "gzip", or empty/"off" for identity
+	// bodies. Codex conversations are resent in full on every turn, so this cuts upstream
+	// egress several-fold at a small CPU cost.
+	UpstreamRequestCompression string `yaml:"upstream-request-compression" json:"upstream-request-compression"`
 	// LiveMediaRelay terminates and relays Codex Live WebRTC media in this process.
 	LiveMediaRelay CodexLiveMediaRelayConfig `yaml:"live-media-relay" json:"live-media-relay"`
 }

--- a/internal/runtime/executor/codex_executor_execute.go
+++ b/internal/runtime/executor/codex_executor_execute.go
@@ -101,6 +101,11 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		AuthType:  authType,
 		AuthValue: authValue,
 	})
+	if encoding := helps.CodexUpstreamRequestEncoding(e.cfg, httpReq); encoding != "" {
+		if _, errCompress := helps.ApplyCodexUpstreamRequestCompression(httpReq, upstreamBody, encoding); errCompress != nil {
+			helps.LogWithRequestID(ctx).Warnf("codex executor: upstream request %s compression failed, sending identity body: %v", encoding, errCompress)
+		}
+	}
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
 	httpResp, err := httpClient.Do(httpReq)
@@ -272,6 +277,11 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 		AuthType:  authType,
 		AuthValue: authValue,
 	})
+	if encoding := helps.CodexUpstreamRequestEncoding(e.cfg, httpReq); encoding != "" {
+		if _, errCompress := helps.ApplyCodexUpstreamRequestCompression(httpReq, upstreamBody, encoding); errCompress != nil {
+			helps.LogWithRequestID(ctx).Warnf("codex executor: upstream request %s compression failed, sending identity body: %v", encoding, errCompress)
+		}
+	}
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
 	httpResp, err := httpClient.Do(httpReq)

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -108,6 +108,11 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		AuthValue: authValue,
 	})
 
+	if encoding := helps.CodexUpstreamRequestEncoding(e.cfg, httpReq); encoding != "" {
+		if _, errCompress := helps.ApplyCodexUpstreamRequestCompression(httpReq, upstreamBody, encoding); errCompress != nil {
+			helps.LogWithRequestID(ctx).Warnf("codex executor: upstream request %s compression failed, sending identity body: %v", encoding, errCompress)
+		}
+	}
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClientRoundTripOnly(httpClient)
 	httpResp, err := httpClient.Do(httpReq)

--- a/internal/runtime/executor/codex_executor_upstream_compression_test.go
+++ b/internal/runtime/executor/codex_executor_upstream_compression_test.go
@@ -1,0 +1,261 @@
+package executor
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+type codexCompressionCapture struct {
+	path          string
+	encoding      string
+	contentLength int64
+	body          []byte
+	// streamOutput is the concatenated downstream payload for streaming runs.
+	streamOutput []byte
+	// requestLog is what helps.RecordAPIRequest stored for the request log.
+	requestLog string
+}
+
+const codexCompressionTestFiller = "The quick brown fox jumps over the lazy dog. "
+
+// runCodexCompressionRequest sends one request through the executor with the upstream
+// replaced by an in-memory round tripper and returns what the upstream received.
+// Request logging is enabled so the recorded request can be checked too.
+func runCodexCompressionRequest(t *testing.T, encoding string, alt string, stream bool, extraAttrs map[string]string, filler string) codexCompressionCapture {
+	t.Helper()
+	completed := []byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.5\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n")
+	compacted := []byte(`{"id":"resp_1","object":"response.compaction","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`)
+	payload := []byte(`{"model":"gpt-5.5","instructions":"You are helpful.","input":[{"type":"message","role":"user","content":"` + filler + `"}]}`)
+	if alt == "responses/compact" {
+		payload = []byte(`{"model":"gpt-5.5","instructions":"You are helpful.","input":[{"type":"message","role":"user","content":"` + filler + `"},{"type":"compaction_trigger"}]}`)
+	}
+
+	var got codexCompressionCapture
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+	ctx = context.WithValue(ctx, "cliproxy.roundtripper", roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		got.path = req.URL.Path
+		got.encoding = req.Header.Get("Content-Encoding")
+		got.contentLength = req.ContentLength
+		raw, errRead := io.ReadAll(req.Body)
+		if errRead != nil {
+			t.Fatalf("read upstream body: %v", errRead)
+		}
+		got.body = raw
+		if alt == "responses/compact" {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": {"application/json"}},
+				Body:       io.NopCloser(bytes.NewReader(compacted)),
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"text/event-stream"}},
+			Body:       io.NopCloser(bytes.NewReader(completed)),
+			Request:    req,
+		}, nil
+	}))
+
+	executor := NewCodexExecutor(&config.Config{SDKConfig: config.SDKConfig{RequestLog: true}, Codex: config.CodexConfig{UpstreamRequestCompression: encoding}})
+	attrs := map[string]string{
+		// The round tripper above never dials, so the official host can be used
+		// directly; compression is gated to it.
+		"base_url": "https://chatgpt.com/backend-api/codex",
+		"api_key":  "test",
+	}
+	for k, v := range extraAttrs {
+		attrs[k] = v
+	}
+	auth := &cliproxyauth.Auth{Attributes: attrs}
+	req := cliproxyexecutor.Request{Model: "gpt-5.5", Payload: payload}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response"), Alt: alt, Stream: stream}
+
+	if stream {
+		result, errStream := executor.ExecuteStream(ctx, auth, req, opts)
+		if errStream != nil {
+			t.Fatalf("ExecuteStream error: %v", errStream)
+		}
+		for chunk := range result.Chunks {
+			if chunk.Err != nil {
+				t.Fatalf("stream error: %v", chunk.Err)
+			}
+			got.streamOutput = append(got.streamOutput, chunk.Payload...)
+		}
+	} else if _, errExec := executor.Execute(ctx, auth, req, opts); errExec != nil {
+		t.Fatalf("Execute error: %v", errExec)
+	}
+	got.requestLog = recordedCodexRequestLog(ginCtx)
+	return got
+}
+
+// recordedCodexRequestLog returns the request text helps.RecordAPIRequest stored in the
+// Gin context. The attempt records are unexported to the helps package, so the test
+// reads the string field reflectively instead of widening the package API.
+func recordedCodexRequestLog(ginCtx *gin.Context) string {
+	var out strings.Builder
+	for _, value := range ginCtx.Keys {
+		rv := reflect.ValueOf(value)
+		if rv.Kind() != reflect.Slice {
+			continue
+		}
+		for i := 0; i < rv.Len(); i++ {
+			elem := rv.Index(i)
+			if elem.Kind() == reflect.Ptr {
+				elem = elem.Elem()
+			}
+			if elem.Kind() != reflect.Struct {
+				continue
+			}
+			if field := elem.FieldByName("request"); field.IsValid() && field.Kind() == reflect.String {
+				out.WriteString(field.String())
+			}
+		}
+	}
+	return out.String()
+}
+
+func decodeCodexUpstreamTestBody(t *testing.T, encoding string, raw []byte) []byte {
+	t.Helper()
+	switch encoding {
+	case "zstd":
+		dec, err := zstd.NewReader(bytes.NewReader(raw))
+		if err != nil {
+			t.Fatalf("upstream body is not zstd: %v", err)
+		}
+		defer dec.Close()
+		decoded, err := io.ReadAll(dec)
+		if err != nil {
+			t.Fatalf("decode upstream body: %v", err)
+		}
+		return decoded
+	case "gzip":
+		zr, err := gzip.NewReader(bytes.NewReader(raw))
+		if err != nil {
+			t.Fatalf("upstream body is not gzip: %v", err)
+		}
+		decoded, err := io.ReadAll(zr)
+		if err != nil {
+			t.Fatalf("decode upstream body: %v", err)
+		}
+		return decoded
+	default:
+		t.Fatalf("unknown encoding %q", encoding)
+		return nil
+	}
+}
+
+var codexExecutorTestEncodings = []string{"zstd", "gzip"}
+
+func TestCodexExecutorUpstreamRequestCompression(t *testing.T) {
+	tests := []struct {
+		name   string
+		alt    string
+		stream bool
+		path   string
+	}{
+		{name: "responses non-streaming", path: "/backend-api/codex/responses"},
+		{name: "responses streaming", stream: true, path: "/backend-api/codex/responses"},
+		{name: "responses compact", alt: "responses/compact", path: "/backend-api/codex/responses/compact"},
+	}
+	for _, encoding := range codexExecutorTestEncodings {
+		for _, tc := range tests {
+			t.Run(encoding+"/"+tc.name, func(t *testing.T) {
+				filler := strings.Repeat(codexCompressionTestFiller, 200)
+				// The disabled run is the identity baseline the compressed body must decode to.
+				baseline := runCodexCompressionRequest(t, "", tc.alt, tc.stream, nil, filler)
+				if baseline.path != tc.path {
+					t.Fatalf("path = %q, want %q", baseline.path, tc.path)
+				}
+				if baseline.encoding != "" {
+					t.Fatalf("Content-Encoding = %q, want none when disabled", baseline.encoding)
+				}
+				if len(baseline.body) < 1024 {
+					t.Fatalf("baseline body too small to exercise compression: %d bytes", len(baseline.body))
+				}
+
+				got := runCodexCompressionRequest(t, encoding, tc.alt, tc.stream, nil, filler)
+				if got.path != tc.path {
+					t.Fatalf("path = %q, want %q", got.path, tc.path)
+				}
+				if got.encoding != encoding {
+					t.Fatalf("Content-Encoding = %q, want %s", got.encoding, encoding)
+				}
+				if got.contentLength != int64(len(got.body)) {
+					t.Fatalf("ContentLength = %d, wire body = %d", got.contentLength, len(got.body))
+				}
+				if len(got.body) >= len(baseline.body) {
+					t.Fatalf("compressed upstream body %d not smaller than identity body %d", len(got.body), len(baseline.body))
+				}
+				if decoded := decodeCodexUpstreamTestBody(t, encoding, got.body); !bytes.Equal(decoded, baseline.body) {
+					t.Fatalf("decoded upstream body differs from identity body:\n got: %s\nwant: %s", decoded, baseline.body)
+				}
+				if tc.stream && !bytes.Contains(got.streamOutput, []byte(`"type":"response.completed"`)) {
+					t.Fatalf("streaming run produced no terminal event; output=%s", got.streamOutput)
+				}
+				// The request log is recorded before compression: plain body, no coding header.
+				if got.requestLog == "" {
+					t.Fatal("request log was not recorded")
+				}
+				if !strings.Contains(got.requestLog, filler) {
+					t.Fatal("request log must contain the plain request body")
+				}
+				if strings.Contains(strings.ToLower(got.requestLog), "content-encoding") {
+					t.Fatalf("request log must not carry the wire Content-Encoding header: %s", got.requestLog)
+				}
+			})
+		}
+	}
+}
+
+func TestCodexExecutorUpstreamRequestCompressionSkipsCustomBaseURL(t *testing.T) {
+	filler := strings.Repeat(codexCompressionTestFiller, 200)
+	got := runCodexCompressionRequest(t, "zstd", "", false, map[string]string{"base_url": "https://codex.example.com/v1"}, filler)
+	if got.encoding != "" {
+		t.Fatalf("Content-Encoding = %q, want none for a custom upstream host", got.encoding)
+	}
+	if !bytes.Contains(got.body, []byte(filler)) {
+		t.Fatalf("custom upstream must receive the plain body, got %d bytes", len(got.body))
+	}
+}
+
+func TestCodexExecutorUpstreamRequestCompressionReplacesHeaderOverride(t *testing.T) {
+	// A custom header override that claims another encoding never described the plain
+	// JSON body; with compression enabled the wire body and header must agree.
+	override := map[string]string{"header:Content-Encoding": "br"}
+	filler := strings.Repeat(codexCompressionTestFiller, 200)
+	baseline := runCodexCompressionRequest(t, "", "", false, nil, filler)
+	got := runCodexCompressionRequest(t, "zstd", "", false, override, filler)
+	if got.encoding != "zstd" {
+		t.Fatalf("Content-Encoding = %q, want zstd", got.encoding)
+	}
+	if decoded := decodeCodexUpstreamTestBody(t, "zstd", got.body); !bytes.Equal(decoded, baseline.body) {
+		t.Fatalf("decoded upstream body differs from identity body:\n got: %s\nwant: %s", decoded, baseline.body)
+	}
+
+	// A body below the threshold is sent as identity bytes, so the stale override
+	// header must not go out with it either.
+	small := runCodexCompressionRequest(t, "zstd", "", false, override, "hi")
+	if small.encoding != "" {
+		t.Fatalf("Content-Encoding = %q, want none for an identity body", small.encoding)
+	}
+	if len(small.body) >= 1024 || !bytes.Contains(small.body, []byte(`"hi"`)) {
+		t.Fatalf("small body should be plain JSON, got %d bytes: %s", len(small.body), small.body)
+	}
+}

--- a/internal/runtime/executor/helps/codex_upstream_compression.go
+++ b/internal/runtime/executor/helps/codex_upstream_compression.go
@@ -1,0 +1,161 @@
+package helps
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	log "github.com/sirupsen/logrus"
+)
+
+// CodexUpstreamRequestCompressionMinBytes is the smallest request body worth compressing.
+// Below this size the content-coding framing and CPU outweigh the saving.
+const CodexUpstreamRequestCompressionMinBytes = 1024
+
+// codexUpstreamRequestCompressionHost is the only upstream verified to accept compressed
+// request bodies: the official ChatGPT Codex backend. Custom codex-api-key base URLs may
+// reject request content codings, so they are never compressed.
+const codexUpstreamRequestCompressionHost = "chatgpt.com"
+
+// Content codings accepted by codex.upstream-request-compression.
+const (
+	CodexUpstreamRequestEncodingGzip = "gzip"
+	// CodexUpstreamRequestEncodingZstd is what the official Codex CLI sends to the ChatGPT
+	// backend (enable_request_compression), so it is the recommended value.
+	CodexUpstreamRequestEncodingZstd = "zstd"
+)
+
+// codexZstdLevel mirrors the official Codex CLI, which encodes with zstd level 3.
+const codexZstdLevel = 3
+
+var (
+	codexZstdEncoderOnce sync.Once
+	codexZstdEncoder     *zstd.Encoder
+	codexZstdEncoderErr  error
+	codexUnknownEncoding sync.Map
+)
+
+func codexSharedZstdEncoder() (*zstd.Encoder, error) {
+	codexZstdEncoderOnce.Do(func() {
+		codexZstdEncoder, codexZstdEncoderErr = zstd.NewWriter(nil,
+			zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(codexZstdLevel)),
+			zstd.WithEncoderConcurrency(1),
+		)
+	})
+	if codexZstdEncoderErr != nil {
+		return nil, fmt.Errorf("create zstd encoder: %w", codexZstdEncoderErr)
+	}
+	return codexZstdEncoder, nil
+}
+
+// NormalizeCodexUpstreamRequestCompression maps the configured value of
+// codex.upstream-request-compression to a content coding, or "" when compression is off
+// or the value is not recognised.
+func NormalizeCodexUpstreamRequestCompression(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case CodexUpstreamRequestEncodingZstd:
+		return CodexUpstreamRequestEncodingZstd
+	case CodexUpstreamRequestEncodingGzip:
+		return CodexUpstreamRequestEncodingGzip
+	case "", "off", "none", "false", "identity":
+		return ""
+	default:
+		if _, seen := codexUnknownEncoding.LoadOrStore(value, struct{}{}); !seen {
+			log.Warnf("codex.upstream-request-compression: unsupported value %q, sending identity bodies (use zstd, gzip or off)", value)
+		}
+		return ""
+	}
+}
+
+// CodexUpstreamRequestEncoding returns the content coding the upstream request body of
+// req should be sent with, or "" to send it as-is. Only the Responses endpoints of the
+// official ChatGPT Codex backend are compressed: they carry the full conversation on
+// every turn and are known to accept zstd (what the official Codex CLI sends) and gzip.
+func CodexUpstreamRequestEncoding(cfg *config.Config, req *http.Request) string {
+	if cfg == nil || req == nil || req.URL == nil {
+		return ""
+	}
+	encoding := NormalizeCodexUpstreamRequestCompression(cfg.Codex.UpstreamRequestCompression)
+	if encoding == "" {
+		return ""
+	}
+	if !strings.EqualFold(req.URL.Hostname(), codexUpstreamRequestCompressionHost) {
+		return ""
+	}
+	path := strings.TrimSuffix(req.URL.Path, "/")
+	if strings.HasSuffix(path, "/responses") || strings.HasSuffix(path, "/responses/compact") {
+		return encoding
+	}
+	return ""
+}
+
+func codexCompressBody(body []byte, encoding string) ([]byte, error) {
+	switch encoding {
+	case CodexUpstreamRequestEncodingZstd:
+		enc, err := codexSharedZstdEncoder()
+		if err != nil {
+			return nil, err
+		}
+		return enc.EncodeAll(body, make([]byte, 0, len(body)/3)), nil
+	case CodexUpstreamRequestEncodingGzip:
+		var buf bytes.Buffer
+		buf.Grow(len(body) / 3)
+		zw, err := gzip.NewWriterLevel(&buf, gzip.DefaultCompression)
+		if err != nil {
+			return nil, fmt.Errorf("create gzip writer: %w", err)
+		}
+		if _, err = zw.Write(body); err != nil {
+			return nil, fmt.Errorf("gzip request body: %w", err)
+		}
+		if err = zw.Close(); err != nil {
+			return nil, fmt.Errorf("close gzip writer: %w", err)
+		}
+		return buf.Bytes(), nil
+	default:
+		return nil, fmt.Errorf("unsupported content coding %q", encoding)
+	}
+}
+
+// ApplyCodexUpstreamRequestCompression replaces the request body with its encoding
+// (zstd or gzip) and updates Content-Encoding, ContentLength and GetBody to match. body
+// must be the identity-encoded bytes currently held by req.Body, so any Content-Encoding
+// header set earlier (for example through a custom header override) cannot describe that
+// body: it is always removed, and set only once the body has actually been replaced. It
+// must run after all request headers are final, so that nothing can desync the header
+// from the body. It returns false, leaving the identity body in place, when the body is
+// smaller than CodexUpstreamRequestCompressionMinBytes or when compression would not
+// make it smaller.
+func ApplyCodexUpstreamRequestCompression(req *http.Request, body []byte, encoding string) (bool, error) {
+	if req == nil {
+		return false, nil
+	}
+	req.Header.Del("Content-Encoding")
+	if len(body) < CodexUpstreamRequestCompressionMinBytes {
+		return false, nil
+	}
+	compressed, err := codexCompressBody(body, encoding)
+	if err != nil {
+		return false, err
+	}
+	if len(compressed) >= len(body) {
+		return false, nil
+	}
+	if req.Body != nil {
+		if errClose := req.Body.Close(); errClose != nil {
+			log.WithError(errClose).Warn("codex upstream request compression: close original request body")
+		}
+	}
+	req.Body = io.NopCloser(bytes.NewReader(compressed))
+	req.ContentLength = int64(len(compressed))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(compressed)), nil
+	}
+	req.Header.Set("Content-Encoding", encoding)
+	return true, nil
+}

--- a/internal/runtime/executor/helps/codex_upstream_compression_test.go
+++ b/internal/runtime/executor/helps/codex_upstream_compression_test.go
@@ -1,0 +1,365 @@
+package helps
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/rand"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+var codexTestEncodings = []string{CodexUpstreamRequestEncodingZstd, CodexUpstreamRequestEncodingGzip}
+
+func newCompressionTestRequest(t *testing.T, rawURL string, body []byte) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, rawURL, bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return req
+}
+
+// decodeCodexTestBody decodes raw with the given content coding.
+func decodeCodexTestBody(t *testing.T, encoding string, raw []byte) []byte {
+	t.Helper()
+	switch encoding {
+	case CodexUpstreamRequestEncodingZstd:
+		dec, err := zstd.NewReader(bytes.NewReader(raw))
+		if err != nil {
+			t.Fatalf("zstd reader: %v", err)
+		}
+		defer dec.Close()
+		decoded, err := io.ReadAll(dec)
+		if err != nil {
+			t.Fatalf("zstd decode: %v", err)
+		}
+		return decoded
+	case CodexUpstreamRequestEncodingGzip:
+		zr, err := gzip.NewReader(bytes.NewReader(raw))
+		if err != nil {
+			t.Fatalf("gzip reader: %v", err)
+		}
+		decoded, err := io.ReadAll(zr)
+		if err != nil {
+			t.Fatalf("gzip decode: %v", err)
+		}
+		return decoded
+	default:
+		t.Fatalf("unknown encoding %q", encoding)
+		return nil
+	}
+}
+
+func TestNormalizeCodexUpstreamRequestCompression(t *testing.T) {
+	cases := map[string]string{
+		"":          "",
+		"off":       "",
+		"none":      "",
+		"false":     "",
+		"identity":  "",
+		"zstd":      "zstd",
+		" ZSTD ":    "zstd",
+		"gzip":      "gzip",
+		"Gzip":      "gzip",
+		"br":        "",
+		"deflate":   "",
+		"true":      "",
+		"zstandard": "",
+	}
+	for in, want := range cases {
+		if got := NormalizeCodexUpstreamRequestCompression(in); got != want {
+			t.Fatalf("NormalizeCodexUpstreamRequestCompression(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCodexUpstreamRequestEncoding(t *testing.T) {
+	base := "https://chatgpt.com/backend-api/codex"
+	for _, encoding := range codexTestEncodings {
+		on := &config.Config{Codex: config.CodexConfig{UpstreamRequestCompression: encoding}}
+		cases := []struct {
+			name string
+			cfg  *config.Config
+			url  string
+			want string
+		}{
+			{name: "nil config", cfg: nil, url: base + "/responses", want: ""},
+			{name: "disabled", cfg: &config.Config{}, url: base + "/responses", want: ""},
+			{name: "off", cfg: &config.Config{Codex: config.CodexConfig{UpstreamRequestCompression: "off"}}, url: base + "/responses", want: ""},
+			{name: "unsupported coding", cfg: &config.Config{Codex: config.CodexConfig{UpstreamRequestCompression: "br"}}, url: base + "/responses", want: ""},
+			{name: "responses", cfg: on, url: base + "/responses", want: encoding},
+			{name: "compact", cfg: on, url: base + "/responses/compact", want: encoding},
+			{name: "query string", cfg: on, url: base + "/responses?x=1", want: encoding},
+			{name: "trailing slash and query", cfg: on, url: base + "/responses/?x=1", want: encoding},
+			{name: "fragment", cfg: on, url: base + "/responses#frag", want: encoding},
+			{name: "images", cfg: on, url: base + "/images/generations", want: ""},
+			{name: "unrelated suffix", cfg: on, url: base + "/responses_v2", want: ""},
+			{name: "host case-insensitive", cfg: on, url: "https://ChatGPT.com/backend-api/codex/responses", want: encoding},
+			{name: "custom base url host", cfg: on, url: "https://codex.example.com/v1/responses", want: ""},
+			{name: "subdomain is not the backend", cfg: on, url: "https://api.chatgpt.com/backend-api/codex/responses", want: ""},
+		}
+		for _, tc := range cases {
+			t.Run(encoding+"/"+tc.name, func(t *testing.T) {
+				req := newCompressionTestRequest(t, tc.url, nil)
+				if got := CodexUpstreamRequestEncoding(tc.cfg, req); got != tc.want {
+					t.Fatalf("CodexUpstreamRequestEncoding(%q) = %q, want %q", tc.url, got, tc.want)
+				}
+			})
+		}
+		if got := CodexUpstreamRequestEncoding(on, nil); got != "" {
+			t.Fatalf("nil request must not be compressed, got %q", got)
+		}
+	}
+}
+
+func TestApplyCodexUpstreamRequestCompressionSkipsSmallBodies(t *testing.T) {
+	for _, encoding := range codexTestEncodings {
+		for _, size := range []int{0, 1, CodexUpstreamRequestCompressionMinBytes - 1} {
+			body := bytes.Repeat([]byte("a"), size)
+			req := newCompressionTestRequest(t, "https://chatgpt.com/backend-api/codex/responses", body)
+			applied, err := ApplyCodexUpstreamRequestCompression(req, body, encoding)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if applied || req.Header.Get("Content-Encoding") != "" {
+				t.Fatalf("%s size %d: body must not be compressed (applied=%v, Content-Encoding=%q)", encoding, size, applied, req.Header.Get("Content-Encoding"))
+			}
+			got, _ := io.ReadAll(req.Body)
+			if !bytes.Equal(got, body) {
+				t.Fatalf("%s size %d: body changed", encoding, size)
+			}
+		}
+		if applied, err := ApplyCodexUpstreamRequestCompression(nil, bytes.Repeat([]byte("a"), 4096), encoding); applied || err != nil {
+			t.Fatalf("nil request: applied=%v err=%v", applied, err)
+		}
+	}
+}
+
+func TestApplyCodexUpstreamRequestCompressionCompressesAtThreshold(t *testing.T) {
+	for _, encoding := range codexTestEncodings {
+		body := bytes.Repeat([]byte("a"), CodexUpstreamRequestCompressionMinBytes)
+		req := newCompressionTestRequest(t, "https://chatgpt.com/backend-api/codex/responses", body)
+		applied, err := ApplyCodexUpstreamRequestCompression(req, body, encoding)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !applied || req.Header.Get("Content-Encoding") != encoding {
+			t.Fatalf("%s: threshold body must be compressed (applied=%v, Content-Encoding=%q)", encoding, applied, req.Header.Get("Content-Encoding"))
+		}
+	}
+}
+
+func TestApplyCodexUpstreamRequestCompressionRejectsUnknownEncoding(t *testing.T) {
+	body := bytes.Repeat([]byte("a"), 4096)
+	req := newCompressionTestRequest(t, "https://chatgpt.com/backend-api/codex/responses", body)
+	req.Header.Set("Content-Encoding", "br")
+	applied, err := ApplyCodexUpstreamRequestCompression(req, body, "br")
+	if err == nil || applied {
+		t.Fatalf("unknown coding must fail without replacing the body (applied=%v, err=%v)", applied, err)
+	}
+	if got := req.Header.Get("Content-Encoding"); got != "" {
+		t.Fatalf("stale Content-Encoding %q must be removed even when compression fails", got)
+	}
+	raw, _ := io.ReadAll(req.Body)
+	if !bytes.Equal(raw, body) {
+		t.Fatal("identity body changed")
+	}
+}
+
+func TestApplyCodexUpstreamRequestCompressionReplacesStaleEncodingHeader(t *testing.T) {
+	for _, encoding := range codexTestEncodings {
+		body := bytes.Repeat([]byte("a"), 4096)
+		req := newCompressionTestRequest(t, "https://chatgpt.com/backend-api/codex/responses", body)
+		// A header override may have set an encoding that does not describe the plain body.
+		req.Header.Set("Content-Encoding", "br")
+		applied, err := ApplyCodexUpstreamRequestCompression(req, body, encoding)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !applied || req.Header.Get("Content-Encoding") != encoding {
+			t.Fatalf("%s: stale header must be replaced (applied=%v, Content-Encoding=%q)", encoding, applied, req.Header.Get("Content-Encoding"))
+		}
+		if values := req.Header.Values("Content-Encoding"); len(values) != 1 {
+			t.Fatalf("Content-Encoding values = %v, want exactly one", values)
+		}
+		raw, _ := io.ReadAll(req.Body)
+		if decoded := decodeCodexTestBody(t, encoding, raw); !bytes.Equal(decoded, body) {
+			t.Fatalf("%s: wire body is not the encoding of the identity body", encoding)
+		}
+	}
+}
+
+func TestApplyCodexUpstreamRequestCompressionDropsStaleEncodingOnSkip(t *testing.T) {
+	incompressible := make([]byte, 2048)
+	if _, err := rand.Read(incompressible); err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{name: "small body", body: bytes.Repeat([]byte("a"), 16)},
+		{name: "incompressible body", body: incompressible},
+	}
+	for _, encoding := range codexTestEncodings {
+		for _, tc := range cases {
+			t.Run(encoding+"/"+tc.name, func(t *testing.T) {
+				req := newCompressionTestRequest(t, "https://chatgpt.com/backend-api/codex/responses", tc.body)
+				req.Header.Set("Content-Encoding", "gzip")
+				applied, err := ApplyCodexUpstreamRequestCompression(req, tc.body, encoding)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if applied {
+					t.Fatal("body must not be compressed")
+				}
+				if got := req.Header.Get("Content-Encoding"); got != "" {
+					t.Fatalf("stale Content-Encoding %q must be removed when the identity body is sent", got)
+				}
+				raw, _ := io.ReadAll(req.Body)
+				if !bytes.Equal(raw, tc.body) {
+					t.Fatal("identity body changed")
+				}
+			})
+		}
+	}
+}
+
+func TestApplyCodexUpstreamRequestCompressionSkipsIncompressibleBodies(t *testing.T) {
+	body := make([]byte, 2048)
+	if _, err := rand.Read(body); err != nil {
+		t.Fatal(err)
+	}
+	for _, encoding := range codexTestEncodings {
+		req := newCompressionTestRequest(t, "https://chatgpt.com/backend-api/codex/responses", body)
+		applied, err := ApplyCodexUpstreamRequestCompression(req, body, encoding)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if applied || req.Header.Get("Content-Encoding") != "" {
+			t.Fatalf("%s: incompressible body must be sent as-is (applied=%v, Content-Encoding=%q)", encoding, applied, req.Header.Get("Content-Encoding"))
+		}
+		got, _ := io.ReadAll(req.Body)
+		if !bytes.Equal(got, body) {
+			t.Fatal("incompressible body changed")
+		}
+	}
+}
+
+type trackingReadCloser struct {
+	io.Reader
+	closed int
+}
+
+func (c *trackingReadCloser) Close() error {
+	c.closed++
+	return nil
+}
+
+func TestApplyCodexUpstreamRequestCompressionClosesOriginalBodyOnce(t *testing.T) {
+	for _, encoding := range codexTestEncodings {
+		body := bytes.Repeat([]byte("a"), 4096)
+		req := newCompressionTestRequest(t, "https://chatgpt.com/backend-api/codex/responses", body)
+		original := &trackingReadCloser{Reader: bytes.NewReader(body)}
+		req.Body = original
+		applied, err := ApplyCodexUpstreamRequestCompression(req, body, encoding)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !applied {
+			t.Fatal("body should have been compressed")
+		}
+		if original.closed != 1 {
+			t.Fatalf("%s: original body closed %d times, want 1", encoding, original.closed)
+		}
+
+		// When compression is skipped the caller's body stays in place and open.
+		small := bytes.Repeat([]byte("a"), 16)
+		req = newCompressionTestRequest(t, "https://chatgpt.com/backend-api/codex/responses", small)
+		kept := &trackingReadCloser{Reader: bytes.NewReader(small)}
+		req.Body = kept
+		if _, err = ApplyCodexUpstreamRequestCompression(req, small, encoding); err != nil {
+			t.Fatal(err)
+		}
+		if kept.closed != 0 || req.Body != kept {
+			t.Fatalf("skipped body must be untouched (closed=%d, replaced=%v)", kept.closed, req.Body != kept)
+		}
+	}
+}
+
+func TestApplyCodexUpstreamRequestCompressionRoundTrip(t *testing.T) {
+	body := []byte(`{"model":"gpt-5","instructions":"` + strings.Repeat("You are a helpful assistant. ", 200) + `","input":[]}`)
+	for _, encoding := range codexTestEncodings {
+		req := newCompressionTestRequest(t, "https://chatgpt.com/backend-api/codex/responses", body)
+		applied, err := ApplyCodexUpstreamRequestCompression(req, body, encoding)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !applied || req.Header.Get("Content-Encoding") != encoding {
+			t.Fatalf("applied=%v Content-Encoding=%q, want %s", applied, req.Header.Get("Content-Encoding"), encoding)
+		}
+		raw, _ := io.ReadAll(req.Body)
+		if int64(len(raw)) != req.ContentLength {
+			t.Fatalf("ContentLength = %d, body = %d", req.ContentLength, len(raw))
+		}
+		if len(raw) >= len(body) {
+			t.Fatalf("compressed body %d not smaller than %d", len(raw), len(body))
+		}
+		if decoded := decodeCodexTestBody(t, encoding, raw); !bytes.Equal(decoded, body) {
+			t.Fatalf("%s round trip mismatch", encoding)
+		}
+		// GetBody must yield an identical copy so transports can replay the request.
+		rc, err := req.GetBody()
+		if err != nil {
+			t.Fatal(err)
+		}
+		again, _ := io.ReadAll(rc)
+		if !bytes.Equal(again, raw) {
+			t.Fatal("GetBody returned a different body")
+		}
+	}
+}
+
+// The shared zstd encoder is used from every executor goroutine at once.
+func TestApplyCodexUpstreamRequestCompressionZstdConcurrent(t *testing.T) {
+	body := []byte(`{"model":"gpt-5","instructions":"` + strings.Repeat("You are a helpful assistant. ", 200) + `","input":[]}`)
+	const workers = 16
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			req := newCompressionTestRequest(t, "https://chatgpt.com/backend-api/codex/responses", body)
+			applied, err := ApplyCodexUpstreamRequestCompression(req, body, CodexUpstreamRequestEncodingZstd)
+			if err != nil || !applied {
+				errs <- err
+				return
+			}
+			raw, _ := io.ReadAll(req.Body)
+			dec, err := zstd.NewReader(bytes.NewReader(raw))
+			if err != nil {
+				errs <- err
+				return
+			}
+			decoded, err := io.ReadAll(dec)
+			dec.Close()
+			if err != nil {
+				errs <- err
+				return
+			}
+			if !bytes.Equal(decoded, body) {
+				errs <- io.ErrUnexpectedEOF
+				return
+			}
+			errs <- nil
+		}()
+	}
+	for i := 0; i < workers; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("concurrent zstd: %v", err)
+		}
+	}
+}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -149,6 +149,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.Codex.OrphanDelegationCompatibility != newCfg.Codex.OrphanDelegationCompatibility {
 		changes = append(changes, fmt.Sprintf("codex.orphan-delegation-compatibility: %t -> %t", oldCfg.Codex.OrphanDelegationCompatibility, newCfg.Codex.OrphanDelegationCompatibility))
 	}
+	if oldCfg.Codex.UpstreamRequestCompression != newCfg.Codex.UpstreamRequestCompression {
+		changes = append(changes, fmt.Sprintf("codex.upstream-request-compression: %q -> %q", oldCfg.Codex.UpstreamRequestCompression, newCfg.Codex.UpstreamRequestCompression))
+	}
 	if oldCfg.XAI.InjectXSearch != newCfg.XAI.InjectXSearch {
 		changes = append(changes, fmt.Sprintf("xai.inject-x-search: %t -> %t", oldCfg.XAI.InjectXSearch, newCfg.XAI.InjectXSearch))
 	}

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -196,6 +196,14 @@ func TestBuildConfigChangeDetails_ModelPrefixes(t *testing.T) {
 	expectContains(t, changes, "vertex[0].prefix: old-v -> new-v")
 }
 
+func TestBuildConfigChangeDetails_CodexUpstreamRequestCompression(t *testing.T) {
+	oldCfg := &config.Config{}
+	newCfg := &config.Config{Codex: config.CodexConfig{UpstreamRequestCompression: "zstd"}}
+
+	changes := BuildConfigChangeDetails(oldCfg, newCfg)
+	expectContains(t, changes, `codex.upstream-request-compression: "" -> "zstd"`)
+}
+
 func TestBuildConfigChangeDetails_CodexAlphaSearch(t *testing.T) {
 	oldCfg := &config.Config{CodexKey: []config.CodexKey{{APIKey: "key", BaseURL: "https://codex.example.com"}}}
 	newCfg := &config.Config{CodexKey: []config.CodexKey{{APIKey: "key", BaseURL: "https://codex.example.com", AlphaSearch: true}}}


### PR DESCRIPTION
## Summary

Codex clients resend the whole conversation on every turn, and the Codex executor forwards that body to `chatgpt.com` as-is (p50 ≈ 560 KB, p99 ≈ 3.5 MB per request in our deployment). Where upstream egress is metered this is by far the largest stream of bytes a CLIProxyAPI host sends.

This PR adds `codex.upstream-request-compression` (default off). When set to `zstd` or `gzip`, the body of upstream `/responses` and `/responses/compact` requests to the **official ChatGPT Codex backend** is compressed and sent with the matching `Content-Encoding`.

- **`zstd`** is the content coding the official Codex CLI itself sends to the backend (`enable_request_compression`, zstd level 3 — see `codex-rs/http-client/src/request.rs`), so it is the recommended value.
- **`gzip`** is also accepted upstream and was running in production for a day before switching to zstd.
- Only the `chatgpt.com` host is compressed; custom `codex-api-key` base URLs may not accept request content codings and are never touched. WebSocket and images paths are unchanged.

## Behaviour

- Runs after every header is final and after the request log has been recorded, so logs keep the plain body and nothing can desync header from body.
- Any pre-existing `Content-Encoding` (e.g. from a header override) is dropped, because it cannot describe the identity body actually held.
- Bodies under 1 KiB, and bodies that would not shrink, are sent as-is.
- Compression failure only warns and sends the identity body.
- `ContentLength` and `GetBody` are rewritten so transports can replay.
- The zstd encoder is shared (`EncodeAll` is concurrency-safe, concurrency 1); gzip uses `DefaultCompression`. Unknown values warn once and disable compression.
- The hot-reload diff reports changes to the option.

## Validation

- `go test ./internal/runtime/executor/... ./internal/watcher/diff/ ./internal/config/ -race -count=1`
- Tests cover host/path gating, threshold and incompressible bodies, stale header handling, body close semantics, concurrent zstd use, round trips for both codings, and end-to-end executor runs (stream, non-stream, compact) asserting the upstream receives the expected `Content-Encoding` and the decoded body equals the identity body.
- Production (2C/4G host, ~10k Codex requests/day): with `gzip` the metered egress for the same traffic dropped ≈40% (CloudMonitor ÷ nginx bytes 1.16 → 0.70); with `zstd` a 60-second capture shows wire bytes to chatgpt.com ≈ 0.30× of the request bodies. Ratios are bounded by the incompressible `reasoning.encrypted_content` items, not by the codec.

## Config

```yaml
codex:
  upstream-request-compression: "zstd"   # zstd | gzip | "" (off)
```
