### PR TITLE
feat(api): log why auth selection failed (#5085)

### DIFF
--- a/sdk/api/handlers/handlers_auth_selection_log_test.go
+++ b/sdk/api/handlers/handlers_auth_selection_log_test.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestEnrichAuthSelectionErrorLogsBlockedCredentials(t *testing.T) {
+	hook := test.NewGlobal()
+	t.Cleanup(hook.Reset)
+	previousLevel := log.GetLevel()
+	log.SetLevel(log.InfoLevel)
+	t.Cleanup(func() { log.SetLevel(previousLevel) })
+
+	now := time.Now()
+	auths := []*coreauth.Auth{
+		{
+			ID:            "codex-a",
+			Quota:         coreauth.QuotaState{Exceeded: true, Reason: "credential_quota", NextRecoverAt: now.Add(time.Minute)},
+			StatusMessage: "429 quota",
+		},
+		{ID: "codex-b", Disabled: true},
+	}
+	selector := &coreauth.FillFirstSelector{}
+	_, selectionErr := selector.Pick(context.Background(), "codex", "gpt-5.6-terra", cliproxyexecutor.Options{}, auths)
+	if selectionErr == nil {
+		t.Fatal("expected selection to fail when every auth is blocked")
+	}
+
+	enriched := enrichAuthSelectionError(context.Background(), selectionErr, []string{"codex"}, "gpt-5.6-terra")
+
+	entries := hook.AllEntries()
+	if len(entries) != 1 {
+		t.Fatalf("logged %d entries, want exactly 1: %v", len(entries), entries)
+	}
+	entry := entries[0]
+	if entry.Level != log.WarnLevel {
+		t.Fatalf("level = %s, want warn so the reason survives debug: false", entry.Level)
+	}
+	for _, want := range []string{"providers=codex", "model=gpt-5.6-terra", "codex-a=cooldown", "429 quota", "codex-b=disabled"} {
+		if !strings.Contains(entry.Message, want) {
+			t.Fatalf("log message %q missing %q", entry.Message, want)
+		}
+	}
+	if strings.Contains(enriched.Error(), "codex-a") {
+		t.Fatalf("client-facing error %q must not carry per-credential diagnostics", enriched.Error())
+	}
+}

--- a/sdk/api/handlers/handlers_error_response_test.go
+++ b/sdk/api/handlers/handlers_error_response_test.go
@@ -172,7 +172,7 @@ func TestWriteErrorResponse_AddonHeadersEnabled(t *testing.T) {
 
 func TestEnrichAuthSelectionError_DefaultsTo503WithContext(t *testing.T) {
 	in := &coreauth.Error{Code: "auth_not_found", Message: "no auth available"}
-	out := enrichAuthSelectionError(in, []string{"claude"}, "claude-sonnet-4-6")
+	out := enrichAuthSelectionError(context.Background(), in, []string{"claude"}, "claude-sonnet-4-6")
 
 	var got *coreauth.Error
 	if !errors.As(out, &got) || got == nil {
@@ -194,7 +194,7 @@ func TestEnrichAuthSelectionError_DefaultsTo503WithContext(t *testing.T) {
 
 func TestEnrichAuthSelectionError_PreservesExplicitStatus(t *testing.T) {
 	in := &coreauth.Error{Code: "auth_unavailable", Message: "no auth available", HTTPStatus: http.StatusTooManyRequests}
-	out := enrichAuthSelectionError(in, []string{"gemini"}, "gemini-2.5-pro")
+	out := enrichAuthSelectionError(context.Background(), in, []string{"gemini"}, "gemini-2.5-pro")
 
 	var got *coreauth.Error
 	if !errors.As(out, &got) || got == nil {
@@ -207,7 +207,7 @@ func TestEnrichAuthSelectionError_PreservesExplicitStatus(t *testing.T) {
 
 func TestEnrichAuthSelectionError_IgnoresOtherErrors(t *testing.T) {
 	in := errors.New("boom")
-	out := enrichAuthSelectionError(in, []string{"claude"}, "claude-sonnet-4-6")
+	out := enrichAuthSelectionError(context.Background(), in, []string{"claude"}, "claude-sonnet-4-6")
 	if out != in {
 		t.Fatalf("expected original error to be returned unchanged")
 	}

--- a/sdk/api/handlers/handlers_errors.go
+++ b/sdk/api/handlers/handlers_errors.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"golang.org/x/net/context"
 )
@@ -27,7 +28,7 @@ func isAuthSelectionUnavailable(err error) bool {
 	return code == "auth_not_found" || code == "auth_unavailable"
 }
 
-func enrichAuthSelectionError(err error, providers []string, model string) error {
+func enrichAuthSelectionError(ctx context.Context, err error, providers []string, model string) error {
 	if err == nil {
 		return nil
 	}
@@ -67,6 +68,15 @@ func enrichAuthSelectionError(err error, providers []string, model string) error
 		status = http.StatusServiceUnavailable
 	}
 
+	// The failure never reaches an upstream, so without this line the only trace
+	// of why the request was rejected is the error body the client receives.
+	if diagnostic := strings.TrimSpace(coreauth.SelectionDiagnostic(err)); diagnostic != "" {
+		helps.LogWithRequestID(ctx).Warnf("auth selection failed: %s; blocked credentials: %s", detail, diagnostic)
+	} else {
+		helps.LogWithRequestID(ctx).Warnf("auth selection failed: %s", detail)
+	}
+
+	// Diagnostic is deliberately dropped here: it is server-side detail.
 	return &coreauth.Error{
 		Code:       authErr.Code,
 		Message:    detail,

--- a/sdk/api/handlers/handlers_execution.go
+++ b/sdk/api/handlers/handlers_execution.go
@@ -91,7 +91,7 @@ func (h *BaseAPIHandler) executeWithAuthManagerFormats(ctx context.Context, entr
 	}
 	resp, err := h.AuthManager.Execute(ctx, providers, req, opts)
 	if err != nil {
-		err = enrichAuthSelectionError(err, providers, normalizedModel)
+		err = enrichAuthSelectionError(ctx, err, providers, normalizedModel)
 		errMsg := executionErrorMessage(err)
 		lifecycle.completeError(ctx, errMsg)
 		return nil, nil, errMsg
@@ -155,7 +155,7 @@ func (h *BaseAPIHandler) executeCountWithAuthManager(ctx context.Context, handle
 	}
 	resp, err := h.AuthManager.ExecuteCount(ctx, providers, req, opts)
 	if err != nil {
-		err = enrichAuthSelectionError(err, providers, normalizedModel)
+		err = enrichAuthSelectionError(ctx, err, providers, normalizedModel)
 		errMsg := executionErrorMessage(err)
 		lifecycle.completeError(ctx, errMsg)
 		return nil, nil, errMsg

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -352,7 +352,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	}
 	streamResult, err := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
 	if err != nil {
-		err = enrichAuthSelectionError(err, providers, normalizedModel)
+		err = enrichAuthSelectionError(ctx, err, providers, normalizedModel)
 		errMsg := executionErrorMessage(err)
 		lifecycle.completeError(ctx, errMsg)
 		errChan := make(chan *interfaces.ErrorMessage, 1)
@@ -552,7 +552,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 			if isAuthSelectionUnavailable(retryErr) && originalBootstrapErr.StatusCode >= http.StatusInternalServerError {
 				bootstrapErr = originalBootstrapErr
 			} else {
-				bootstrapErr = executionErrorMessage(enrichAuthSelectionError(retryErr, providers, normalizedModel))
+				bootstrapErr = executionErrorMessage(enrichAuthSelectionError(ctx, retryErr, providers, normalizedModel))
 			}
 			break
 		}

--- a/sdk/cliproxy/auth/errors.go
+++ b/sdk/cliproxy/auth/errors.go
@@ -1,5 +1,10 @@
 package auth
 
+import (
+	"errors"
+	"strings"
+)
+
 // ErrorCodeRequestScoped identifies failures tied to the current request rather
 // than the selected credential.
 const ErrorCodeRequestScoped = "request_scoped"
@@ -68,4 +73,52 @@ func NewRequestScopedError(message string, httpStatus int) *Error {
 		Message:    message,
 		HTTPStatus: httpStatus,
 	}
+}
+
+// diagnosticError attaches server-side detail to a selection failure. The detail
+// is kept beside the error rather than inside Error so the exported struct stays
+// usable as an unkeyed literal, and so the text can never be serialized toward a
+// client by accident.
+type diagnosticError struct {
+	cause      *Error
+	diagnostic string
+}
+
+// Error implements the error interface.
+func (e *diagnosticError) Error() string {
+	if e == nil || e.cause == nil {
+		return ""
+	}
+	return e.cause.Error()
+}
+
+// Unwrap exposes the underlying Error so errors.As keeps working on it.
+func (e *diagnosticError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+// withDiagnostic wraps err with server-side detail, returning err unchanged when
+// there is nothing to add.
+func withDiagnostic(err *Error, diagnostic string) error {
+	if err == nil {
+		return nil
+	}
+	if strings.TrimSpace(diagnostic) == "" {
+		return err
+	}
+	return &diagnosticError{cause: err, diagnostic: diagnostic}
+}
+
+// SelectionDiagnostic returns the server-side detail recorded for a failed auth
+// selection, or an empty string when the error carries none. The detail is meant
+// for logs and must not be returned to clients.
+func SelectionDiagnostic(err error) string {
+	var diagErr *diagnosticError
+	if errors.As(err, &diagErr) && diagErr != nil {
+		return diagErr.diagnostic
+	}
+	return ""
 }

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -268,6 +268,67 @@ func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (ava
 	return available, cooldownCount, earliest
 }
 
+// blockedAuthSummaryLimit caps how many blocked credentials a diagnostic lists so
+// a large pool cannot produce an unreadable log line.
+const blockedAuthSummaryLimit = 5
+
+// summarizeBlockedAuths describes why each candidate credential is unusable, so an
+// auth_unavailable failure can be explained from the server logs instead of only
+// from the error body the client receives.
+func summarizeBlockedAuths(auths []*Auth, model string, now time.Time) string {
+	entries := make([]string, 0, blockedAuthSummaryLimit)
+	omitted := 0
+	for i := 0; i < len(auths); i++ {
+		blocked, reason, next := isAuthBlockedForModel(auths[i], model, now)
+		if !blocked {
+			continue
+		}
+		if len(entries) >= blockedAuthSummaryLimit {
+			omitted++
+			continue
+		}
+		entries = append(entries, describeBlockedAuth(auths[i], reason, next, now))
+	}
+	if len(entries) == 0 {
+		return ""
+	}
+	summary := strings.Join(entries, ", ")
+	if omitted > 0 {
+		summary = fmt.Sprintf("%s, +%d more", summary, omitted)
+	}
+	return summary
+}
+
+func describeBlockedAuth(auth *Auth, reason blockReason, next, now time.Time) string {
+	id := "unknown"
+	detail := blockReasonLabel(reason)
+	if auth != nil {
+		if trimmed := strings.TrimSpace(auth.ID); trimmed != "" {
+			id = trimmed
+		}
+	}
+	if !next.IsZero() && next.After(now) {
+		detail = fmt.Sprintf("%s for %s", detail, next.Sub(now).Round(time.Second))
+	}
+	if auth != nil {
+		if message := strings.TrimSpace(auth.StatusMessage); message != "" {
+			detail = fmt.Sprintf("%s (%s)", detail, message)
+		}
+	}
+	return id + "=" + detail
+}
+
+func blockReasonLabel(reason blockReason) string {
+	switch reason {
+	case blockReasonCooldown:
+		return "cooldown"
+	case blockReasonDisabled:
+		return "disabled"
+	default:
+		return "unavailable"
+	}
+}
+
 func getAvailableAuths(auths []*Auth, provider, model string, now time.Time) ([]*Auth, error) {
 	return getAvailableAuthsWithPriorityMode(auths, provider, model, now, false)
 }
@@ -294,7 +355,10 @@ func getAvailableAuthsWithPriorityMode(auths []*Auth, provider, model string, no
 			}
 			return nil, newModelCooldownError(model, providerForError, resetIn)
 		}
-		return nil, &Error{Code: "auth_unavailable", Message: "no auth available"}
+		return nil, withDiagnostic(
+			&Error{Code: "auth_unavailable", Message: "no auth available"},
+			summarizeBlockedAuths(auths, model, now),
+		)
 	}
 
 	return availableAuthsFromPriorityBuckets(availableByPriority, allPriorities), nil

--- a/sdk/cliproxy/auth/selector_diagnostic_test.go
+++ b/sdk/cliproxy/auth/selector_diagnostic_test.go
@@ -1,0 +1,69 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetAvailableAuthsReportsWhyEveryAuthIsBlocked(t *testing.T) {
+	now := time.Now()
+	auths := []*Auth{
+		{
+			ID:            "cooling",
+			Quota:         QuotaState{Exceeded: true, Reason: "credential_quota", NextRecoverAt: now.Add(90 * time.Second)},
+			StatusMessage: "429 quota",
+		},
+		{ID: "off", Disabled: true},
+		{ID: "flaky", Unavailable: true, NextRetryAfter: now.Add(30 * time.Second)},
+	}
+
+	_, err := getAvailableAuths(auths, "codex", "gpt-5.6-terra", now)
+	if err == nil {
+		t.Fatal("expected selection to fail when every auth is blocked")
+	}
+	var authErr *Error
+	if !errors.As(err, &authErr) {
+		t.Fatalf("error type = %T, want it to unwrap to *Error", err)
+	}
+	if authErr.Code != "auth_unavailable" {
+		t.Fatalf("code = %q, want auth_unavailable", authErr.Code)
+	}
+	diagnostic := SelectionDiagnostic(err)
+	if !strings.Contains(diagnostic, "cooling=cooldown for 1m30s (429 quota)") {
+		t.Fatalf("diagnostic = %q, want the cooling auth with its remaining time and status message", diagnostic)
+	}
+	if !strings.Contains(diagnostic, "off=disabled") {
+		t.Fatalf("diagnostic = %q, want the disabled auth", diagnostic)
+	}
+	if !strings.Contains(diagnostic, "flaky=unavailable for 30s") {
+		t.Fatalf("diagnostic = %q, want the unavailable auth with its remaining time", diagnostic)
+	}
+	if strings.Contains(authErr.Message, "cooling") {
+		t.Fatalf("message = %q, diagnostics must stay out of the client-facing message", authErr.Message)
+	}
+}
+
+func TestSummarizeBlockedAuthsCapsTheListing(t *testing.T) {
+	now := time.Now()
+	auths := make([]*Auth, 0, blockedAuthSummaryLimit+2)
+	for i := 0; i < blockedAuthSummaryLimit+2; i++ {
+		auths = append(auths, &Auth{ID: string(rune('a' + i)), Disabled: true})
+	}
+
+	summary := summarizeBlockedAuths(auths, "gpt-5.6-terra", now)
+	if got := strings.Count(summary, "=disabled"); got != blockedAuthSummaryLimit {
+		t.Fatalf("listed %d auths, want %d; summary=%q", got, blockedAuthSummaryLimit, summary)
+	}
+	if !strings.HasSuffix(summary, "+2 more") {
+		t.Fatalf("summary = %q, want the omitted count as a suffix", summary)
+	}
+}
+
+func TestSummarizeBlockedAuthsIsEmptyWhenNothingIsBlocked(t *testing.T) {
+	summary := summarizeBlockedAuths([]*Auth{{ID: "ready"}}, "gpt-5.6-terra", time.Now())
+	if summary != "" {
+		t.Fatalf("summary = %q, want empty when no auth is blocked", summary)
+	}
+}


### PR DESCRIPTION
Addresses request 1 of #5085.

## Problem

When every credential for a model is blocked, the request is rejected before it reaches an upstream. At info level the only trace is the gin access line:

```
[info ] 503 | 7ms | POST /v1/responses
```

The reason — `auth_unavailable: no auth available (providers=..., model=...)` — exists only in the body the client receives. Which credentials were blocked, why, and for how long is reachable only by enabling debug, which is not an option in production.

## Change

- `sdk/cliproxy/auth/selector.go`: `getAvailableAuthsWithPriorityMode` already walks every candidate through `isAuthBlockedForModel` to decide availability. It now reuses that walk to build a compact summary — `codex-a=cooldown for 1m0s (429 quota), codex-b=disabled` — capped at 5 entries with a `+N more` suffix so a large pool cannot flood a log line. The three labels follow the existing `blockReason` classification, so `cooldown` means quota-backed cooldown and `unavailable` means a non-quota block, exactly as the selector already distinguishes them.
- `sdk/api/handlers/handlers_errors.go`: `enrichAuthSelectionError` is already the single point where the client-facing `(providers=..., model=...)` detail is assembled, and every rejected request passes it exactly once. It now emits one `Warnf` through `helps.LogWithRequestID(ctx)`, so the line carries `request_id` like the rest of the codebase and survives `debug: false`. It takes a `ctx` parameter for that; the four call sites are updated.

The summary travels beside `auth.Error` rather than inside it. `TestErrorLegacyUnkeyedLiteralCompatibility` pins that struct to four fields as an unkeyed literal, and keeping the text outside also makes it structurally impossible to serialize toward a client. `errors.As` still reaches the underlying `*Error` through `Unwrap`.

## Verification

```
go test ./...
go build -o test-output ./cmd/server
```

`TestEnrichAuthSelectionErrorLogsBlockedCredentials` asserts exactly one warn entry carrying the provider, model and per-credential reasons, and that the returned client error does not carry them. Dropping the log line to `Debugf` fails it, which is the regression the issue reports. `TestGetAvailableAuthsReportsWhyEveryAuthIsBlocked` covers the three block reasons and that the client-facing message stays clean.

## Not included

Request 2 (a warn line for upstream 5xx/timeout failures) is left out on purpose. That path has no chokepoint: 30 call sites across the executors each emit `helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, ...")`, and the level is chosen at each one. `helps.RecordAPIResponseError` is not an alternative — it writes into the request-log capture and only when `request-log: true`, never to logrus. So it is either a new shared helper plus a 30-site swap, or per-site edits. Happy to send that as a follow-up in whichever shape you prefer.

Request 3 (classifying deterministic provider 400s so they do not cool a credential) changes cooldown semantics and the issue itself raises it as a question, so it is left for a maintainer decision.