### PR TITLE
fix(auth): allow body-only request-scoped error rules

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -311,7 +311,7 @@ nonstream-keepalive-interval: 0
 #     disable-cooling: false # optional override: true disables cooling, false enables it; omit to inherit global
 #     request-retry: 3 # optional: per-auth override of the global request-retry; 0 disables retries; omit or set < 0 to use the global value
 #     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns
-#       - status: 400        # HTTP status code to match
+#       - status: 400        # HTTP status code to match; omit or set to 0 to match any status (body-only rule)
 #         match:             # optional: string contains matching
 #           - "maximum_context_length"
 #           - "context_length_exceeded"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -744,6 +744,8 @@ nonstream-keepalive-interval: 0
 #     - "grok-3-mini"
 
 # OAuth provider request-scoped error rules (custom error classification for OAuth credentials)
+# Supported actions: "stop", "stop-and-cooldown", "continue", "continue-and-cooldown"
+# The status field is optional; omit it or set it to 0 to match any HTTP status (body-only rule).
 # oauth-request-scoped-errors:
 #   vertex:
 #     - status: 400
@@ -753,7 +755,7 @@ nonstream-keepalive-interval: 0
 #       match-regexr:
 #         - "maximum_context_length$"
 #         - "^context_length_exceeded"
-#       action: "stop" # options: "stop", "stop-and-cooldown", "continue", "continue-and-cooldown"
+#       action: "stop"
 #   aistudio:
 #     - status: 400
 #       match:
@@ -765,8 +767,7 @@ nonstream-keepalive-interval: 0
 #         - "internal_server_error"
 #       action: "stop-and-cooldown"
 #   claude:
-#     - status: 400
-#       match:
+#     - match:
 #         - "prompt is too long"
 #       action: "stop"
 #   codex:

--- a/internal/config/config_normalization.go
+++ b/internal/config/config_normalization.go
@@ -129,7 +129,8 @@ func (cfg *Config) SanitizeOAuthRequestScopedErrors() {
 					matchRegexr = append(matchRegexr, tre)
 				}
 			}
-			if r.Status <= 0 || (len(match) == 0 && len(matchRegexr) == 0) || action == "" {
+			// Status == 0 (unset) is a body-only rule and is valid; reject only negative statuses.
+			if r.Status < 0 || (len(match) == 0 && len(matchRegexr) == 0) || action == "" {
 				continue
 			}
 			clean = append(clean, RequestScopedErrorRule{

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -11,6 +11,7 @@ import (
 // RequestScopedErrorRule configures custom classification and handling for upstream errors.
 type RequestScopedErrorRule struct {
 	// Status matches the HTTP status code of the upstream response (e.g. 400).
+	// Zero or omitted matches any status, so the rule is evaluated by body patterns only.
 	Status int `yaml:"status,omitempty" json:"status,omitempty"`
 	// Match matches substrings in the upstream error body.
 	Match []string `yaml:"match,omitempty" json:"match,omitempty"`

--- a/internal/config/oauth_request_scoped_errors_test.go
+++ b/internal/config/oauth_request_scoped_errors_test.go
@@ -81,8 +81,13 @@ func TestSanitizeOAuthRequestScopedErrors(t *testing.T) {
 					Action:      " STOP ",
 				},
 				{
-					Status: 0, // invalid status
+					Status: 0, // body-only rule (valid)
 					Match:  []string{"foo"},
+					Action: "stop",
+				},
+				{
+					Status: -1, // invalid negative status
+					Match:  []string{"bar"},
 					Action: "stop",
 				},
 				{
@@ -100,8 +105,8 @@ func TestSanitizeOAuthRequestScopedErrors(t *testing.T) {
 	}
 
 	rules := cfg.OAuthRequestScopedErrors["vertex"]
-	if len(rules) != 1 {
-		t.Fatalf("expected 1 rule for vertex, got %d", len(rules))
+	if len(rules) != 2 {
+		t.Fatalf("expected 2 rules for vertex, got %d", len(rules))
 	}
 	if rules[0].Status != 400 || rules[0].Action != "stop" {
 		t.Errorf("unexpected sanitized rule: %+v", rules[0])
@@ -111,5 +116,13 @@ func TestSanitizeOAuthRequestScopedErrors(t *testing.T) {
 	}
 	if len(rules[0].MatchRegexr) != 1 || rules[0].MatchRegexr[0] != "^error.*" {
 		t.Errorf("unexpected sanitized regexr: %+v", rules[0].MatchRegexr)
+	}
+
+	// Body-only rule (status 0) must survive sanitization.
+	if rules[1].Status != 0 || rules[1].Action != "stop" {
+		t.Errorf("unexpected body-only rule: %+v", rules[1])
+	}
+	if len(rules[1].Match) != 1 || rules[1].Match[0] != "foo" {
+		t.Errorf("unexpected body-only match: %+v", rules[1].Match)
 	}
 }

--- a/internal/watcher/diff/oauth_request_scoped_errors.go
+++ b/internal/watcher/diff/oauth_request_scoped_errors.go
@@ -74,7 +74,8 @@ func summarizeOAuthRequestScopedErrorsList(list []config.RequestScopedErrorRule)
 	var b strings.Builder
 	valid := 0
 	for _, entry := range list {
-		if entry.Status <= 0 || (len(entry.Match) == 0 && len(entry.MatchRegexr) == 0) || entry.Action == "" {
+		// Status == 0 (unset) is a body-only rule and is valid; reject only negative statuses.
+		if entry.Status < 0 || (len(entry.Match) == 0 && len(entry.MatchRegexr) == 0) || entry.Action == "" {
 			continue
 		}
 		valid++

--- a/sdk/cliproxy/auth/conductor_request_scoped_errors.go
+++ b/sdk/cliproxy/auth/conductor_request_scoped_errors.go
@@ -188,7 +188,8 @@ func matchRequestScopedErrorAction(auth *Auth, err error, cfg *internalconfig.Co
 	body := extractErrorBody(err)
 
 	for _, rule := range rules {
-		if rule.Status <= 0 || rule.Status != statusCode {
+		// Status == 0 (unset or omitted) matches any HTTP status; otherwise the status must match exactly.
+		if rule.Status != 0 && rule.Status != statusCode {
 			continue
 		}
 		if len(rule.Match) == 0 && len(rule.MatchRegexr) == 0 {

--- a/sdk/cliproxy/auth/conductor_request_scoped_errors_test.go
+++ b/sdk/cliproxy/auth/conductor_request_scoped_errors_test.go
@@ -1238,3 +1238,60 @@ func TestRequestScopedErrors_ResponseBodyProvider_MatchesUnderlyingPayload(t *te
 		t.Fatal("expected auth1 to be in cooldown when matching ResponseBody()")
 	}
 }
+
+func TestRequestScopedErrors_BodyOnlyRule(t *testing.T) {
+	bodyOnlyRule := []internalconfig.RequestScopedErrorRule{
+		{
+			Match:  []string{"body_only_phrase"},
+			Action: "stop",
+		},
+	}
+	statusRule := []internalconfig.RequestScopedErrorRule{
+		{
+			Status: 400,
+			Match:  []string{"status_qualified_phrase"},
+			Action: "stop-and-cooldown",
+		},
+	}
+
+	bodyOnlyAuth := &Auth{
+		ID:       "auth-body-only",
+		Provider: "claude",
+		Metadata: map[string]any{"request_scoped_errors": bodyOnlyRule},
+	}
+	statusAuth := &Auth{
+		ID:       "auth-status-qualified",
+		Provider: "claude",
+		Metadata: map[string]any{"request_scoped_errors": statusRule},
+	}
+
+	// Body-only rule matches across multiple HTTP statuses.
+	for _, code := range []int{400, 500} {
+		action, ok := matchRequestScopedErrorAction(bodyOnlyAuth, customStatusError{code: code, msg: "body_only_phrase"}, nil)
+		if !ok || action != "stop" {
+			t.Fatalf("body-only rule should match status %d, got action=%q ok=%v", code, action, ok)
+		}
+	}
+
+	// Body-only rule matches a typed/internal error with no HTTP status.
+	action, ok := matchRequestScopedErrorAction(bodyOnlyAuth, errors.New("body_only_phrase"), nil)
+	if !ok || action != "stop" {
+		t.Fatalf("body-only rule should match typed error, got action=%q ok=%v", action, ok)
+	}
+
+	// Status-qualified rule still requires an exact status match.
+	action, ok = matchRequestScopedErrorAction(statusAuth, customStatusError{code: 400, msg: "status_qualified_phrase"}, nil)
+	if !ok || action != "stop-and-cooldown" {
+		t.Fatalf("status-qualified rule should match status 400, got action=%q ok=%v", action, ok)
+	}
+
+	action, ok = matchRequestScopedErrorAction(statusAuth, customStatusError{code: 500, msg: "status_qualified_phrase"}, nil)
+	if ok {
+		t.Fatalf("status-qualified rule should not match status 500, got action=%q", action)
+	}
+
+	action, ok = matchRequestScopedErrorAction(statusAuth, errors.New("status_qualified_phrase"), nil)
+	if ok {
+		t.Fatalf("status-qualified rule should not match typed error with no status, got action=%q", action)
+	}
+}


### PR DESCRIPTION
## Summary

Gap 6 from the failover/auth audit: request-scoped error rules required an exact HTTP status match, so operators could not write a rule that matched a body phrase across multiple statuses or a typed/internal error with no HTTP status.

## Change

- `rule.Status == 0` (unset or omitted) now matches any HTTP status.
- Body substring/regex matching still applies.
- Status-qualified rules still require an exact status match.
- Documented the new semantics in `config.example.yaml` and the `RequestScopedErrorRule` Go type.

## Tests

- `TestRequestScopedErrors_BodyOnlyRule` covers body-only matching across 400/500 and typed errors without a status, plus regression checks that status-qualified rules keep requiring an exact match.

## Related

- Plus counterpart: https://github.com/kaitranntt/CLIProxyAPIPlus/pull/207