### PR TITLE
fix(executor): strip cache_control for non-Anthropic embedders

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -24,6 +24,7 @@ type ClaudeExecutor struct {
 	cfg                     *config.Config
 	requestLogProvider      string
 	upstreamModelNormalizer func(string) string
+	cacheControlDisabled    bool
 	oauthProfileFetcher     claudeOAuthProfileFetcher
 }
 

--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -1245,6 +1245,46 @@ func countCacheControls(payload []byte) int {
 	return count
 }
 
+// stripCacheControls removes Anthropic-only prompt-caching fields before a
+// delegated Claude-format request is sent to a provider that does not support
+// them, such as Kimi. It only targets protocol-level cache_control markers on
+// system/tool/message blocks and nested content blocks (e.g. tool_result
+// content); arbitrary JSON like tool input_schema properties named
+// "cache_control" are left untouched.
+func stripCacheControls(payload []byte) []byte {
+	result := payload
+	for i := range gjson.GetBytes(result, "system").Array() {
+		result, _ = sjson.DeleteBytes(result, fmt.Sprintf("system.%d.cache_control", i))
+		result = stripContentCacheControls(result, fmt.Sprintf("system.%d.content", i))
+	}
+	for i := range gjson.GetBytes(result, "tools").Array() {
+		result, _ = sjson.DeleteBytes(result, fmt.Sprintf("tools.%d.cache_control", i))
+	}
+	for i := range gjson.GetBytes(result, "messages").Array() {
+		result, _ = sjson.DeleteBytes(result, fmt.Sprintf("messages.%d.cache_control", i))
+		result = stripContentCacheControls(result, fmt.Sprintf("messages.%d.content", i))
+	}
+	return result
+}
+
+// stripContentCacheControls removes cache_control from each block in a content
+// array and recurses into nested content arrays (e.g. a tool_result whose
+// content is an array of text/image blocks). It does not walk into siblings of
+// content such as tool_use input or tool input_schema.
+func stripContentCacheControls(payload []byte, contentPath string) []byte {
+	result := payload
+	arr := gjson.GetBytes(result, contentPath)
+	if !arr.IsArray() {
+		return result
+	}
+	for i := range arr.Array() {
+		itemPath := fmt.Sprintf("%s.%d", contentPath, i)
+		result, _ = sjson.DeleteBytes(result, fmt.Sprintf("%s.cache_control", itemPath))
+		result = stripContentCacheControls(result, fmt.Sprintf("%s.content", itemPath))
+	}
+	return result
+}
+
 // normalizeCacheControlTTL ensures cache_control TTL values don't violate the
 // prompt-caching-scope-2026-01-05 ordering constraint: a 1h-TTL block must not
 // appear after a 5m-TTL block anywhere in the evaluation order.

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -116,40 +116,46 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body = reconcileClaudeCodeContextManagement(body, contextManagementState)
 	body = normalizeClaudeSamplingForUpstream(body, confirmedClaudeCode)
 
-	// Default cache_control for translated entrypoints (Responses/Chat/Gemini) and other
-	// non-native callers. Confirmed native Claude Code owns its marker placement and must
-	// not be rewritten. Cloaked requests always run section-independent ensure so cloaking's
-	// first-user marker cannot suppress system/latest-user breakpoints.
+	// Embedders that do not support Anthropic cache_control (e.g. Kimi reusing
+	// the Claude path) must strip all existing cache_control fields. Otherwise,
+	// default cache_control for translated entrypoints and other non-native
+	// callers. Confirmed native Claude Code owns its marker placement and must
+	// not be rewritten. Cloaked requests always run section-independent ensure so
+	// cloaking's first-user marker cannot suppress system/latest-user breakpoints.
 	// cloaked and confirmedClaudeCode are mutually exclusive: resolveClaudeWirePolicy
 	// forces Cloak off for a confirmed native client.
-	cpaOwnsCacheControl := shouldEnsureCacheControl(body, cloaked, confirmedClaudeCode)
-	if cpaOwnsCacheControl {
-		body = ensureCacheControl(body)
+	if e.cacheControlDisabled {
+		body = stripCacheControls(body)
+	} else {
+		cpaOwnsCacheControl := shouldEnsureCacheControl(body, cloaked, confirmedClaudeCode)
+		if cpaOwnsCacheControl {
+			body = ensureCacheControl(body)
+		}
+
+		// Enforce Anthropic's cache_control block limit (max 4 breakpoints per request).
+		// Cloaking and ensureCacheControl may push the total over 4 when the client
+		// already sends multiple cache_control blocks.
+		body = enforceCacheControlLimit(body, 4)
+
+		// Native selects the 1h cache pool only for OAuth credentials and pairs it with
+		// extended-cache-ttl-2025-04-11, which claudeCodeCLIBetas emits on exactly the
+		// same credential condition. Upgrading after placement is settled mirrors the
+		// native ttl helper.
+		//
+		// This runs only while CPA owns placement, and it then owns the ttl of every
+		// breakpoint it can reach: a marker carrying no ttl is the wire default, not an
+		// opt-in to 5m, so a cloaked caller's bare {"type":"ephemeral"} is upgraded too.
+		// Only a ttl the caller wrote out explicitly survives, because
+		// upgradeClaudeCacheControlTTL skips any block that already has one.
+		// claude-code-cli fingerprint profiles emit extended-cache-ttl and must use the same 1h pool.
+		if cpaOwnsCacheControl && fp.ProfileClaudeCodeCLI {
+			body = upgradeClaudeCacheControlTTL(body, claudeCacheControlTTL1h)
+		}
+
+		// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
+		// A 1h-TTL block must not appear after a 5m-TTL block in evaluation order (tools→system→messages).
+		body = normalizeCacheControlTTL(body)
 	}
-
-	// Enforce Anthropic's cache_control block limit (max 4 breakpoints per request).
-	// Cloaking and ensureCacheControl may push the total over 4 when the client
-	// already sends multiple cache_control blocks.
-	body = enforceCacheControlLimit(body, 4)
-
-	// Native selects the 1h cache pool only for OAuth credentials and pairs it with
-	// extended-cache-ttl-2025-04-11, which claudeCodeCLIBetas emits on exactly the
-	// same credential condition. Upgrading after placement is settled mirrors the
-	// native ttl helper.
-	//
-	// This runs only while CPA owns placement, and it then owns the ttl of every
-	// breakpoint it can reach: a marker carrying no ttl is the wire default, not an
-	// opt-in to 5m, so a cloaked caller's bare {"type":"ephemeral"} is upgraded too.
-	// Only a ttl the caller wrote out explicitly survives, because
-	// upgradeClaudeCacheControlTTL skips any block that already has one.
-	// claude-code-cli fingerprint profiles emit extended-cache-ttl and must use the same 1h pool.
-	if cpaOwnsCacheControl && fp.ProfileClaudeCodeCLI {
-		body = upgradeClaudeCacheControlTTL(body, claudeCacheControlTTL1h)
-	}
-
-	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
-	// A 1h-TTL block must not appear after a 5m-TTL block in evaluation order (tools→system→messages).
-	body = normalizeCacheControlTTL(body)
 	// Payload rules and other request processing may rewrite stream. Keep the
 	// upstream body, transport headers, and response parser on one authority.
 	// Native non-stream Haiku helper requests omit stream rather than sending

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -119,37 +119,43 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body = reconcileClaudeCodeContextManagement(body, contextManagementState)
 	body = normalizeClaudeSamplingForUpstream(body, confirmedClaudeCode)
 
-	// Default cache_control for translated entrypoints (Responses/Chat/Gemini) and other
-	// non-native callers. Confirmed native Claude Code owns its marker placement and must
-	// not be rewritten. Cloaked requests always run section-independent ensure so cloaking's
-	// first-user marker cannot suppress system/latest-user breakpoints.
+	// Embedders that do not support Anthropic cache_control (e.g. Kimi reusing
+	// the Claude path) must strip all existing cache_control fields. Otherwise,
+	// default cache_control for translated entrypoints and other non-native
+	// callers. Confirmed native Claude Code owns its marker placement and must
+	// not be rewritten. Cloaked requests always run section-independent ensure so
+	// cloaking's first-user marker cannot suppress system/latest-user breakpoints.
 	// cloaked and confirmedClaudeCode are mutually exclusive: resolveClaudeWirePolicy
 	// forces Cloak off for a confirmed native client.
-	cpaOwnsCacheControl := shouldEnsureCacheControl(body, cloaked, confirmedClaudeCode)
-	if cpaOwnsCacheControl {
-		body = ensureCacheControl(body)
+	if e.cacheControlDisabled {
+		body = stripCacheControls(body)
+	} else {
+		cpaOwnsCacheControl := shouldEnsureCacheControl(body, cloaked, confirmedClaudeCode)
+		if cpaOwnsCacheControl {
+			body = ensureCacheControl(body)
+		}
+
+		// Enforce Anthropic's cache_control block limit (max 4 breakpoints per request).
+		body = enforceCacheControlLimit(body, 4)
+
+		// Native selects the 1h cache pool only for OAuth credentials and pairs it with
+		// extended-cache-ttl-2025-04-11, which claudeCodeCLIBetas emits on exactly the
+		// same credential condition. Upgrading after placement is settled mirrors the
+		// native ttl helper.
+		//
+		// This runs only while CPA owns placement, and it then owns the ttl of every
+		// breakpoint it can reach: a marker carrying no ttl is the wire default, not an
+		// opt-in to 5m, so a cloaked caller's bare {"type":"ephemeral"} is upgraded too.
+		// Only a ttl the caller wrote out explicitly survives, because
+		// upgradeClaudeCacheControlTTL skips any block that already has one.
+		// claude-code-cli fingerprint profiles emit extended-cache-ttl and must use the same 1h pool.
+		if cpaOwnsCacheControl && fp.ProfileClaudeCodeCLI {
+			body = upgradeClaudeCacheControlTTL(body, claudeCacheControlTTL1h)
+		}
+
+		// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
+		body = normalizeCacheControlTTL(body)
 	}
-
-	// Enforce Anthropic's cache_control block limit (max 4 breakpoints per request).
-	body = enforceCacheControlLimit(body, 4)
-
-	// Native selects the 1h cache pool only for OAuth credentials and pairs it with
-	// extended-cache-ttl-2025-04-11, which claudeCodeCLIBetas emits on exactly the
-	// same credential condition. Upgrading after placement is settled mirrors the
-	// native ttl helper.
-	//
-	// This runs only while CPA owns placement, and it then owns the ttl of every
-	// breakpoint it can reach: a marker carrying no ttl is the wire default, not an
-	// opt-in to 5m, so a cloaked caller's bare {"type":"ephemeral"} is upgraded too.
-	// Only a ttl the caller wrote out explicitly survives, because
-	// upgradeClaudeCacheControlTTL skips any block that already has one.
-	// claude-code-cli fingerprint profiles emit extended-cache-ttl and must use the same 1h pool.
-	if cpaOwnsCacheControl && fp.ProfileClaudeCodeCLI {
-		body = upgradeClaudeCacheControlTTL(body, claudeCacheControlTTL1h)
-	}
-
-	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
-	body = normalizeCacheControlTTL(body)
 
 	// Extract betas from body and convert to header
 	var extraBetas []string

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -6465,3 +6465,53 @@ func TestClaudeExecutor_PreservesNativeAgentAndEnvironmentHeaders(t *testing.T) 
 		})
 	}
 }
+
+func TestStripCacheControls(t *testing.T) {
+	payload := []byte(`{"model":"claude-opus-4","system":[{"type":"text","text":"sys","cache_control":{"type":"ephemeral"}}],"tools":[{"name":"t","cache_control":{"type":"ephemeral"},"input_schema":{"type":"object","properties":{"cache_control":{"type":"string"}}}}],"messages":[{"role":"user","content":[{"type":"text","text":"hi","cache_control":{"type":"ephemeral"}},{"type":"tool_use","tool_use_id":"tu_1","name":"tool","input":{"cache_control":{"type":"string"}}}],"cache_control":{"type":"ephemeral"}}]}`)
+	got := stripCacheControls(payload)
+
+	for _, path := range []string{
+		"system.0.cache_control",
+		"tools.0.cache_control",
+		"messages.0.cache_control",
+		"messages.0.content.0.cache_control",
+	} {
+		if gjson.GetBytes(got, path).Exists() {
+			t.Fatalf("cache_control still present at %q: %s", path, got)
+		}
+	}
+	// cache_control inside a tool input_schema or tool_use input is data,
+	// not an Anthropic marker.
+	if gjson.GetBytes(got, "tools.0.input_schema.properties.cache_control.type").String() != "string" {
+		t.Fatalf("tool input_schema property cache_control should be preserved, got %s", got)
+	}
+	if gjson.GetBytes(got, "messages.0.content.1.input.cache_control.type").String() != "string" {
+		t.Fatalf("tool_use input property cache_control should be preserved, got %s", got)
+	}
+	if gjson.GetBytes(got, "system.0.text").String() != "sys" {
+		t.Fatalf("system text not preserved, got %s", got)
+	}
+	if gjson.GetBytes(got, "messages.0.content.0.text").String() != "hi" {
+		t.Fatalf("message content not preserved, got %s", got)
+	}
+}
+
+func TestStripCacheControls_NestedToolResultContent(t *testing.T) {
+	payload := []byte(`{"model":"claude-opus-4","messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_1","content":[{"type":"text","text":"result","cache_control":{"type":"ephemeral"}}],"cache_control":{"type":"ephemeral"}}]}]}`)
+	got := stripCacheControls(payload)
+
+	for _, path := range []string{
+		"messages.0.content.0.cache_control",
+		"messages.0.content.0.content.0.cache_control",
+	} {
+		if gjson.GetBytes(got, path).Exists() {
+			t.Fatalf("cache_control still present at %q: %s", path, got)
+		}
+	}
+	if gjson.GetBytes(got, "messages.0.content.0.tool_use_id").String() != "tu_1" {
+		t.Fatalf("tool_use_id not preserved, got %s", got)
+	}
+	if gjson.GetBytes(got, "messages.0.content.0.content.0.text").String() != "result" {
+		t.Fatalf("nested tool_result content not preserved, got %s", got)
+	}
+}

--- a/internal/runtime/executor/claude_executor_tokens.go
+++ b/internal/runtime/executor/claude_executor_tokens.go
@@ -174,9 +174,13 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 		}
 	}
 
-	// Keep count_tokens requests compatible with Anthropic cache-control constraints too.
-	body = enforceCacheControlLimit(body, 4)
-	body = normalizeCacheControlTTL(body)
+	if e.cacheControlDisabled {
+		body = stripCacheControls(body)
+	} else {
+		// Keep count_tokens requests compatible with Anthropic cache-control constraints too.
+		body = enforceCacheControlLimit(body, 4)
+		body = normalizeCacheControlTTL(body)
+	}
 
 	// Extract betas from body and convert to header (for count_tokens too)
 	var extraBetas []string

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -42,6 +42,7 @@ func NewKimiExecutor(cfg *config.Config) *KimiExecutor {
 			cfg:                     cfg,
 			requestLogProvider:      "kimi",
 			upstreamModelNormalizer: normalizeKimiUpstreamModel,
+			cacheControlDisabled:    true,
 		},
 		cfg: cfg,
 	}


### PR DESCRIPTION
## Summary

When Kimi receives a Claude-format payload that already contains `cache_control` (native Claude clients commonly send it), the Claude executor was applying cache-control placement/limit/ttl normalization and forwarding the caller-provided fields to the Kimi upstream. Kimi does not accept Anthropic `cache_control` blocks and can reject the request.

- Add `cacheControlDisabled` to `ClaudeExecutor` and set it to `true` in `NewKimiExecutor`.
- Add `stripCacheControls()` that removes `cache_control` from `tools`, `system`, `messages`, and nested `content`.
- In `Execute`, `ExecuteStream`, and `CountTokens`: when `cacheControlDisabled` is true, strip all `cache_control` fields; otherwise keep the existing placement/limit/ttl logic unchanged.
- Add `TestStripCacheControls`.

## Test plan

- `go build -o cli-proxy-api ./cmd/server`
- `go test ./internal/runtime/executor`

## Cross-links

- P1 review comment: https://github.com/router-for-me/CLIProxyAPI/pull/5152#discussion_r3833029694
- Plus already has this behavior (`ClaudeExecutor.cacheControlDisabled` and `stripCacheControls` in `claude_executor_cloaking.go`); this is a stock port.
