### PR TITLE
feat(auth): active credential health prober

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -85,7 +85,7 @@ pprof:
 #   interval: 60s
 #   max-concurrency: 4
 #   rate-limit-per-minute: 60
-#   default-probe-path: "/v1/models"
+#   default-probe-path: "/models"
 
 # Standard dynamic library plugins are trusted in-process code. They are disabled by default.
 # Build Go examples with go build -buildmode=c-shared for the target GOOS/GOARCH.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -77,6 +77,16 @@ pprof:
 #   max-string-bytes: 256
 #   staging-retention: 1m
 
+# Optional active credential health prober. Disabled by default.
+# Probes issue a lightweight HTTP request to each credential's base_url
+# and feed failures into the existing cooldown/suspension machinery.
+# credential-prober:
+#   enabled: false
+#   interval: 60s
+#   max-concurrency: 4
+#   rate-limit-per-minute: 60
+#   default-probe-path: "/v1/models"
+
 # Standard dynamic library plugins are trusted in-process code. They are disabled by default.
 # Build Go examples with go build -buildmode=c-shared for the target GOOS/GOARCH.
 # Other languages can implement the same C ABI and JSON method protocol.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,9 @@ type Config struct {
 	// CredentialInFlight configures credential observation snapshots.
 	CredentialInFlight CredentialInFlightConfig `yaml:"credential-in-flight" json:"credential-in-flight"`
 
+	// CredentialProber configures optional active credential health probing.
+	CredentialProber CredentialProberConfig `yaml:"credential-prober" json:"credential-prober"`
+
 	// RemoteManagement nests management-related options under 'remote-management'.
 	RemoteManagement RemoteManagement `yaml:"remote-management" json:"-"`
 

--- a/internal/config/prober.go
+++ b/internal/config/prober.go
@@ -6,7 +6,7 @@ const (
 	defaultCredentialProberInterval       = 60 * time.Second
 	defaultCredentialProberMaxConcurrency = 4
 	defaultCredentialProberRatePerMinute  = 60
-	defaultCredentialProberPath           = "/v1/models"
+	defaultCredentialProberPath           = "/models"
 )
 
 // CredentialProberConfig controls optional active health probing for registered credentials.

--- a/internal/config/prober.go
+++ b/internal/config/prober.go
@@ -1,0 +1,38 @@
+package config
+
+import "time"
+
+const (
+	defaultCredentialProberInterval       = 60 * time.Second
+	defaultCredentialProberMaxConcurrency = 4
+	defaultCredentialProberRatePerMinute  = 60
+	defaultCredentialProberPath           = "/v1/models"
+)
+
+// CredentialProberConfig controls optional active health probing for registered credentials.
+// When enabled, the conductor periodically issues a lightweight HTTP probe per credential
+// and feeds failures into the existing cooldown/suspension machinery.
+// Disabled by default.
+type CredentialProberConfig struct {
+	// Enabled turns active credential health probing on.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// Interval is the period between probe sweeps. Default 60s.
+	Interval time.Duration `yaml:"interval" json:"interval"`
+	// MaxConcurrency limits the number of in-flight probes. Default 4.
+	MaxConcurrency int `yaml:"max-concurrency" json:"max-concurrency"`
+	// RateLimitPerMinute caps the number of probe requests across all credentials per minute. Default 60.
+	RateLimitPerMinute int `yaml:"rate-limit-per-minute" json:"rate-limit-per-minute"`
+	// DefaultProbePath is the HTTP path resolved against the credential base_url for the probe. Default /v1/models.
+	DefaultProbePath string `yaml:"default-probe-path" json:"default-probe-path"`
+}
+
+// DefaultCredentialProberConfig returns the prober default configuration.
+func DefaultCredentialProberConfig() CredentialProberConfig {
+	return CredentialProberConfig{
+		Enabled:            false,
+		Interval:           defaultCredentialProberInterval,
+		MaxConcurrency:     defaultCredentialProberMaxConcurrency,
+		RateLimitPerMinute: defaultCredentialProberRatePerMinute,
+		DefaultProbePath:   defaultCredentialProberPath,
+	}
+}

--- a/internal/config/prober.go
+++ b/internal/config/prober.go
@@ -22,8 +22,12 @@ type CredentialProberConfig struct {
 	MaxConcurrency int `yaml:"max-concurrency" json:"max-concurrency"`
 	// RateLimitPerMinute caps the number of probe requests across all credentials per minute. Default 60.
 	RateLimitPerMinute int `yaml:"rate-limit-per-minute" json:"rate-limit-per-minute"`
-	// DefaultProbePath is the HTTP path resolved against the credential base_url for the probe. Default /v1/models.
+	// DefaultProbePath is the HTTP path resolved against the credential base_url for the probe. Default /models.
 	DefaultProbePath string `yaml:"default-probe-path" json:"default-probe-path"`
+	// BackoffBase is the minimum cooldown applied by a probe failure. Default 30s.
+	BackoffBase time.Duration `yaml:"backoff-base" json:"backoff-base"`
+	// BackoffMax caps the cooldown applied by a probe failure. Default 5m.
+	BackoffMax time.Duration `yaml:"backoff-max" json:"backoff-max"`
 }
 
 // DefaultCredentialProberConfig returns the prober default configuration.

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -157,6 +157,10 @@ type Manager struct {
 	refreshCancel context.CancelFunc
 	refreshLoop   *authAutoRefreshLoop
 
+	// Active credential prober state
+	proberCancel context.CancelFunc
+	proberLoop   *authProberLoop
+
 	requestPrepareLocks sync.Map
 	// refreshLocks serializes credential refresh per auth ID so concurrent
 	// 401 recoveries and auto-refresh workers do not race the same refresh_token.

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -160,6 +160,8 @@ type Manager struct {
 	// Active credential prober state
 	proberCancel context.CancelFunc
 	proberLoop   *authProberLoop
+	proberParent context.Context
+	proberWg     sync.WaitGroup
 
 	requestPrepareLocks sync.Map
 	// refreshLocks serializes credential refresh per auth ID so concurrent

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -168,6 +168,7 @@ type Manager struct {
 	proberCancel      context.CancelFunc
 	proberLoop        *authProberLoop
 	proberParent      context.Context
+	proberCtx         context.Context
 	proberWg          sync.WaitGroup
 	proberLifecycleMu sync.Mutex
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -158,10 +158,11 @@ type Manager struct {
 	refreshLoop   *authAutoRefreshLoop
 
 	// Active credential prober state
-	proberCancel context.CancelFunc
-	proberLoop   *authProberLoop
-	proberParent context.Context
-	proberWg     sync.WaitGroup
+	proberCancel      context.CancelFunc
+	proberLoop        *authProberLoop
+	proberParent      context.Context
+	proberWg          sync.WaitGroup
+	proberLifecycleMu sync.Mutex
 
 	requestPrepareLocks sync.Map
 	// refreshLocks serializes credential refresh per auth ID so concurrent

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -61,6 +61,7 @@ type Result struct {
 	IsProbe bool
 	// SourceAuth is the auth pointer used at request time; MarkResult discards
 	// the result if the manager has replaced the auth with a newer copy before the update.
+	// It is cleared before the result is passed to hooks or selectors.
 	SourceAuth *Auth
 	// Error describes the failure when Success is false.
 	Error *Error

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -56,6 +56,12 @@ type Result struct {
 	RetryAfter *time.Duration
 	// CredentialScope indicates that the failure affects the whole credential across models (e.g. Anthropic 5h/7d unified limits).
 	CredentialScope bool
+	// IsProbe distinguishes prober health-check results from real execution results.
+	// Probe results update cooldown state but do not count toward user statistics or session affinity.
+	IsProbe bool
+	// SourceAuth is the auth pointer used at request time; MarkResult discards
+	// the result if the manager has replaced the auth with a newer copy before the update.
+	SourceAuth *Auth
 	// Error describes the failure when Success is false.
 	Error *Error
 	// Options carries execution request options (headers, metadata, etc.) for result tracking.

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -206,3 +206,16 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 	manager.scheduler = newAuthScheduler(selector)
 	return manager
 }
+
+// currentConfig returns the latest runtime config snapshot.
+func (m *Manager) currentConfig() *internalconfig.Config {
+	if m == nil {
+		return nil
+	}
+	if v := m.runtimeConfig.Load(); v != nil {
+		if cfg, ok := v.(*internalconfig.Config); ok {
+			return cfg
+		}
+	}
+	return nil
+}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -153,6 +153,7 @@ func (m *Manager) setConfigSnapshotLocked(cfg *internalconfig.Config) bool {
 		m.clearHomeRuntimeAuths()
 	}
 	m.rebuildAPIKeyModelAliasFromRuntimeConfig()
+	m.restartProberLocked(cfg)
 	return clearedCooldowns
 }
 

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -970,9 +970,13 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	result.SourceAuth = nil
 
 	if result.IsProbe {
-		// Detach the hook context from the probe lifetime so async observers
-		// see a usable (non-canceled) context.
-		hookCtx := context.WithoutCancel(ctx)
+		// Prober hooks should not be canceled when the individual probe
+		// returns, but they must still be tied to the prober/service lifecycle
+		// so shutdown can stop them.
+		hookCtx := m.proberParent
+		if hookCtx == nil {
+			hookCtx = context.WithoutCancel(ctx)
+		}
 		go m.hook.OnResult(hookCtx, result)
 		if result.Error != nil {
 			m.publishErrorEvent(result, authSnapshot)

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -395,6 +395,7 @@ func clearCooldownStateForAuth(auth *Auth, now time.Time) bool {
 		auth.authLevelCooldown = false
 		auth.authLevelUnavailable = false
 		auth.authLevelNextRetryAfter = time.Time{}
+		auth.proberCooldown = false
 		auth.NextRetryAfter = time.Time{}
 		auth.Quota = QuotaState{}
 		auth.UpdatedAt = now
@@ -1277,6 +1278,7 @@ func clearAuthStateOnSuccess(auth *Auth, now time.Time) {
 	auth.Quota.NextRecoverAt = time.Time{}
 	auth.Quota.BackoffLevel = 0
 	auth.proberBackoff = 0
+	auth.proberCooldown = false
 	auth.authLevelCooldown = false
 	auth.LastError = nil
 	auth.NextRetryAfter = time.Time{}
@@ -1287,10 +1289,15 @@ func clearProberStateOnSuccess(auth *Auth, now time.Time) {
 	if auth == nil {
 		return
 	}
-	if auth.proberBackoff == 0 && !auth.authLevelCooldown {
+	if !auth.proberCooldown && auth.proberBackoff == 0 {
 		return
 	}
+	owned := auth.proberCooldown
 	auth.proberBackoff = 0
+	auth.proberCooldown = false
+	if !owned {
+		return
+	}
 	auth.authLevelCooldown = false
 	auth.authLevelUnavailable = false
 	auth.authLevelNextRetryAfter = time.Time{}
@@ -1941,6 +1948,9 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	if shouldSkipCredentialCooldown(resultErr) {
 		return
 	}
+	// A non-probe credential-scoped failure overwrites any prober cooldown so
+	// the next successful probe does not clear cooldown state it did not create.
+	auth.proberCooldown = false
 	defer func() {
 		if disableCooling && auth.NextRetryAfter.IsZero() && auth.Quota.NextRecoverAt.IsZero() {
 			auth.Unavailable = false
@@ -1948,6 +1958,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			auth.authLevelUnavailable = false
 			auth.authLevelNextRetryAfter = time.Time{}
 			auth.Quota.Exceeded = false
+			auth.proberCooldown = false
 		}
 		auth.authLevelUnavailable = auth.Unavailable
 		auth.authLevelNextRetryAfter = auth.NextRetryAfter
@@ -1968,6 +1979,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	if resultErr != nil && resultErr.Code == ErrorCodeForceCooldown && retryAfter != nil {
 		auth.NextRetryAfter = now.Add(*retryAfter)
 		auth.proberBackoff++
+		auth.proberCooldown = true
 		return
 	}
 	statusCode := statusCodeFromResult(resultErr)

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -115,7 +115,7 @@ func (m *Manager) SetConfig(cfg *internalconfig.Config) {
 		m.persistCooldownStatesLocked(context.Background())
 	}
 	m.configCooldownMu.Unlock()
-	m.restartProberLocked()
+	go m.restartProberLocked()
 }
 
 // SetConfigSnapshot updates only in-memory configuration state. It reports whether
@@ -127,7 +127,7 @@ func (m *Manager) SetConfigSnapshot(cfg *internalconfig.Config) bool {
 	m.configCooldownMu.Lock()
 	changed := m.setConfigSnapshotLocked(cfg)
 	m.configCooldownMu.Unlock()
-	m.restartProberLocked()
+	go m.restartProberLocked()
 	return changed
 }
 

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -931,7 +931,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				if result.Error != nil && result.Error.Code == ErrorCodeForceCooldown {
 					disableCooling = false
 				}
-				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling)
+				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling, result.IsProbe)
 			}
 		}
 
@@ -1956,7 +1956,7 @@ func isRequestInvalidError(err error) bool {
 	return false
 }
 
-func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time, disableCooling bool) {
+func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time, disableCooling, isProbe bool) {
 	if auth == nil {
 		return
 	}
@@ -1991,10 +1991,14 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 
 	// Prober failures carry an explicit RetryAfter derived from the configured
 	// probe backoff bounds, overriding the generic status-code cooldowns.
+	// Only prober-originated results may take ownership of the prober cooldown
+	// state so caller-owned force cooldowns are not cleared by later probes.
 	if resultErr != nil && resultErr.Code == ErrorCodeForceCooldown && retryAfter != nil {
 		auth.NextRetryAfter = now.Add(*retryAfter)
-		auth.proberBackoff++
-		auth.proberCooldown = true
+		if isProbe {
+			auth.proberBackoff++
+			auth.proberCooldown = true
+		}
 		return
 	}
 	statusCode := statusCodeFromResult(resultErr)

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -962,6 +962,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 		registry.GetGlobalRegistry().SuspendClientModel(result.AuthID, modelKey, suspendReason)
 	}
 
+	// SourceAuth is used internally for stale-auth detection; do not propagate
+	// the live credential pointer (and its secrets) to hooks or selectors.
+	result.SourceAuth = nil
+
 	if result.IsProbe {
 		// Detach the hook context from the probe lifetime so async observers
 		// see a usable (non-canceled) context.
@@ -1005,6 +1009,7 @@ func (m *Manager) reportHomeResult(ctx context.Context, result Result, auth *Aut
 	if auth != nil {
 		snapshot = auth.Clone()
 	}
+	result.SourceAuth = nil
 	m.hook.OnResult(ctx, result)
 	m.publishErrorEvent(result, snapshot)
 }
@@ -1029,6 +1034,7 @@ func (m *Manager) recordAvailabilityNeutralResult(ctx context.Context, result Re
 	}
 	m.mu.Unlock()
 
+	result.SourceAuth = nil
 	m.hook.OnResult(ctx, result)
 	m.publishErrorEvent(result, authSnapshot)
 }

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -175,18 +175,11 @@ func (m *Manager) ApplyConfigWithCooldownStateStore(ctx context.Context, cfg *in
 	}
 
 	m.configCooldownMu.Lock()
-	restart := false
-	defer func() {
-		m.configCooldownMu.Unlock()
-		if restart {
-			m.restartProberLocked()
-		}
-	}()
+	defer m.configCooldownMu.Unlock()
 	m.mu.RLock()
 	oldStore := m.cooldownStore
 	m.mu.RUnlock()
 	m.setConfigSnapshotLocked(cfg)
-	restart = true
 	if oldStore != nil && !m.persistCooldownStatesToLocked(ctx, oldStore) {
 		return false
 	}
@@ -365,6 +358,8 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 	if model == "" {
 		auth.Unavailable = true
 		auth.authLevelCooldown = true
+		auth.authLevelUnavailable = true
+		auth.authLevelNextRetryAfter = record.NextRetryAfter
 		auth.Status = StatusError
 		auth.NextRetryAfter = record.NextRetryAfter
 		auth.Quota = quota
@@ -395,9 +390,11 @@ func clearCooldownStateForAuth(auth *Auth, now time.Time) bool {
 		return false
 	}
 	changed := false
-	if auth.Unavailable || !auth.NextRetryAfter.IsZero() || auth.Quota.Exceeded || !auth.Quota.NextRecoverAt.IsZero() {
+	if auth.Unavailable || !auth.NextRetryAfter.IsZero() || auth.authLevelUnavailable || !auth.authLevelNextRetryAfter.IsZero() || auth.Quota.Exceeded || !auth.Quota.NextRecoverAt.IsZero() {
 		auth.Unavailable = false
 		auth.authLevelCooldown = false
+		auth.authLevelUnavailable = false
+		auth.authLevelNextRetryAfter = time.Time{}
 		auth.NextRetryAfter = time.Time{}
 		auth.Quota = QuotaState{}
 		auth.UpdatedAt = now
@@ -660,7 +657,7 @@ func cooldownErrorEqual(a, b *Error) bool {
 }
 
 func authCooldownStateRecord(auth *Auth, now time.Time) (CooldownStateRecord, bool) {
-	if auth == nil || !auth.Unavailable || auth.NextRetryAfter.IsZero() || !auth.NextRetryAfter.After(now) {
+	if auth == nil || !auth.authLevelUnavailable || auth.authLevelNextRetryAfter.IsZero() || !auth.authLevelNextRetryAfter.After(now) {
 		return CooldownStateRecord{}, false
 	}
 	return CooldownStateRecord{
@@ -668,7 +665,7 @@ func authCooldownStateRecord(auth *Auth, now time.Time) (CooldownStateRecord, bo
 		AuthID:         auth.ID,
 		AuthFile:       cooldownAuthFile(auth),
 		Status:         "cooling",
-		NextRetryAfter: auth.NextRetryAfter,
+		NextRetryAfter: auth.authLevelNextRetryAfter,
 		Reason:         cooldownReason(auth.StatusMessage, auth.Quota, auth.LastError),
 		Quota:          auth.Quota,
 		LastError:      cloneError(auth.LastError),
@@ -730,17 +727,25 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 
 	m.mu.Lock()
 	if auth, ok := m.auths[result.AuthID]; ok && auth != nil {
+		// If the auth was replaced between request time and this update, the
+		// result belongs to stale state and must not be applied.
+		if result.SourceAuth != nil && result.SourceAuth != auth {
+			m.mu.Unlock()
+			return
+		}
 		now := time.Now()
 		var cooldownRecordsBefore []CooldownStateRecord
 		trackCooldownState := m.cooldownStore != nil
 		if trackCooldownState {
 			cooldownRecordsBefore = m.cooldownStateRecordsForAuthLocked(auth, now)
 		}
-		auth.recordRecentRequest(now, result.Success)
-		if result.Success {
-			auth.Success++
-		} else {
-			auth.Failed++
+		if !result.IsProbe {
+			auth.recordRecentRequest(now, result.Success)
+			if result.Success {
+				auth.Success++
+			} else {
+				auth.Failed++
+			}
 		}
 
 		if result.Success {
@@ -758,6 +763,8 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				auth.UpdatedAt = now
 				shouldResumeModel = true
 				clearModelQuota = true
+			} else if result.IsProbe {
+				clearProberStateOnSuccess(auth, now)
 			} else {
 				clearAuthStateOnSuccess(auth, now)
 			}
@@ -879,6 +886,8 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 									}
 								}
 								auth.Unavailable = true
+								auth.authLevelUnavailable = true
+								auth.authLevelCooldown = true
 								auth.Quota.Exceeded = true
 								auth.Quota.Reason = "credential_quota"
 								authNext := next
@@ -887,6 +896,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								}
 								auth.Quota.NextRecoverAt = authNext
 								auth.NextRetryAfter = authNext
+								auth.authLevelNextRetryAfter = authNext
 							}
 						case 408, 500, 502, 503, 504:
 							state.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
@@ -945,9 +955,16 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 		registry.GetGlobalRegistry().SuspendClientModel(result.AuthID, modelKey, suspendReason)
 	}
 
-	m.hook.OnResult(ctx, result)
-	m.publishErrorEvent(result, authSnapshot)
-	m.updateSessionAffinity(result)
+	if result.IsProbe {
+		go m.hook.OnResult(ctx, result)
+		if result.Error != nil {
+			m.publishErrorEvent(result, authSnapshot)
+		}
+	} else {
+		m.hook.OnResult(ctx, result)
+		m.publishErrorEvent(result, authSnapshot)
+		m.updateSessionAffinity(result)
+	}
 }
 
 func (m *Manager) updateSessionAffinity(result Result) {
@@ -1251,6 +1268,8 @@ func clearAuthStateOnSuccess(auth *Auth, now time.Time) {
 		return
 	}
 	auth.Unavailable = false
+	auth.authLevelUnavailable = false
+	auth.authLevelNextRetryAfter = time.Time{}
 	auth.Status = StatusActive
 	auth.StatusMessage = ""
 	auth.Quota.Exceeded = false
@@ -1262,6 +1281,38 @@ func clearAuthStateOnSuccess(auth *Auth, now time.Time) {
 	auth.LastError = nil
 	auth.NextRetryAfter = time.Time{}
 	auth.UpdatedAt = now
+}
+
+func clearProberStateOnSuccess(auth *Auth, now time.Time) {
+	if auth == nil {
+		return
+	}
+	if auth.proberBackoff == 0 && !auth.authLevelCooldown {
+		return
+	}
+	auth.proberBackoff = 0
+	auth.authLevelCooldown = false
+	auth.authLevelUnavailable = false
+	auth.authLevelNextRetryAfter = time.Time{}
+	if auth.LastError != nil && auth.LastError.Code == ErrorCodeForceCooldown {
+		auth.LastError = nil
+		auth.StatusMessage = ""
+	}
+	if auth.Status == StatusError && (auth.StatusMessage == "" || strings.HasPrefix(auth.StatusMessage, "prober:")) {
+		auth.Status = StatusActive
+	}
+	if strings.HasPrefix(auth.StatusMessage, "prober:") {
+		auth.StatusMessage = ""
+	}
+	auth.Unavailable = false
+	auth.NextRetryAfter = time.Time{}
+	auth.UpdatedAt = now
+	updateAggregatedAvailability(auth, now)
+	if auth.Unavailable || auth.Quota.Exceeded {
+		auth.Status = StatusError
+	} else {
+		auth.Status = StatusActive
+	}
 }
 
 func cloneError(err *Error) *Error {
@@ -1894,8 +1945,13 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		if disableCooling && auth.NextRetryAfter.IsZero() && auth.Quota.NextRecoverAt.IsZero() {
 			auth.Unavailable = false
 			auth.authLevelCooldown = false
+			auth.authLevelUnavailable = false
+			auth.authLevelNextRetryAfter = time.Time{}
 			auth.Quota.Exceeded = false
 		}
+		auth.authLevelUnavailable = auth.Unavailable
+		auth.authLevelNextRetryAfter = auth.NextRetryAfter
+		auth.authLevelCooldown = auth.authLevelUnavailable
 	}()
 	auth.Unavailable = true
 	auth.Status = StatusError
@@ -1912,7 +1968,6 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	if resultErr != nil && resultErr.Code == ErrorCodeForceCooldown && retryAfter != nil {
 		auth.NextRetryAfter = now.Add(*retryAfter)
 		auth.proberBackoff++
-		auth.authLevelCooldown = true
 		return
 	}
 	statusCode := statusCodeFromResult(resultErr)
@@ -1991,7 +2046,6 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.NextRetryAfter = now.Add(transientErrorCooldown)
 		auth.Unavailable = true
 	}
-	auth.authLevelCooldown = auth.Unavailable
 }
 
 // quotaCooldownAfterFailure returns the recovery deadline and backoff level for

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1245,6 +1245,7 @@ func clearAuthStateOnSuccess(auth *Auth, now time.Time) {
 	auth.Quota.Reason = ""
 	auth.Quota.NextRecoverAt = time.Time{}
 	auth.Quota.BackoffLevel = 0
+	auth.proberBackoff = 0
 	auth.LastError = nil
 	auth.NextRetryAfter = time.Time{}
 	auth.UpdatedAt = now
@@ -1890,6 +1891,14 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		if resultErr.Message != "" {
 			auth.StatusMessage = resultErr.Message
 		}
+	}
+
+	// Prober failures carry an explicit RetryAfter derived from the configured
+	// probe backoff bounds, overriding the generic status-code cooldowns.
+	if resultErr != nil && resultErr.Code == ErrorCodeForceCooldown && retryAfter != nil {
+		auth.NextRetryAfter = now.Add(*retryAfter)
+		auth.proberBackoff++
+		return
 	}
 	statusCode := statusCodeFromResult(resultErr)
 	if isCloudflareChallengeResultError(resultErr) {

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1246,6 +1246,7 @@ func clearAuthStateOnSuccess(auth *Auth, now time.Time) {
 	auth.Quota.NextRecoverAt = time.Time{}
 	auth.Quota.BackoffLevel = 0
 	auth.proberBackoff = 0
+	auth.authLevelCooldown = false
 	auth.LastError = nil
 	auth.NextRetryAfter = time.Time{}
 	auth.UpdatedAt = now
@@ -1880,6 +1881,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	defer func() {
 		if disableCooling && auth.NextRetryAfter.IsZero() && auth.Quota.NextRecoverAt.IsZero() {
 			auth.Unavailable = false
+			auth.authLevelCooldown = false
 			auth.Quota.Exceeded = false
 		}
 	}()
@@ -1898,6 +1900,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	if resultErr != nil && resultErr.Code == ErrorCodeForceCooldown && retryAfter != nil {
 		auth.NextRetryAfter = now.Add(*retryAfter)
 		auth.proberBackoff++
+		auth.authLevelCooldown = true
 		return
 	}
 	statusCode := statusCodeFromResult(resultErr)
@@ -1976,6 +1979,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.NextRetryAfter = now.Add(transientErrorCooldown)
 		auth.Unavailable = true
 	}
+	auth.authLevelCooldown = auth.Unavailable
 }
 
 // quotaCooldownAfterFailure returns the recovery deadline and backoff level for

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -368,6 +368,12 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 			auth.StatusMessage = reason
 		}
 		auth.LastError = cloneError(record.LastError)
+		if (record.LastError != nil && record.LastError.Code == ErrorCodeForceCooldown) || strings.HasPrefix(reason, "prober:") {
+			auth.proberCooldown = true
+			if auth.proberBackoff < 1 {
+				auth.proberBackoff = 1
+			}
+		}
 		return true
 	}
 

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -368,7 +368,10 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 			auth.StatusMessage = reason
 		}
 		auth.LastError = cloneError(record.LastError)
-		if (record.LastError != nil && record.LastError.Code == ErrorCodeForceCooldown) || strings.HasPrefix(reason, "prober:") {
+		// Only treat the restored cooldown as prober-owned when the reason is
+		// unambiguously from a probe; ErrorCodeForceCooldown is also used by
+		// request-scoped stop-and-cooldown and embeddable callers.
+		if strings.HasPrefix(reason, "prober:") {
 			auth.proberCooldown = true
 			if auth.proberBackoff < 1 {
 				auth.proberBackoff = 1

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -945,6 +945,14 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			cooldownStateChanged = !cooldownStateRecordsEqual(cooldownRecordsBefore, cooldownRecordsAfter)
 		}
 	}
+
+	var probeHookCtx context.Context
+	if result.IsProbe {
+		probeHookCtx = m.proberCtx
+		if probeHookCtx == nil {
+			probeHookCtx = m.proberParent
+		}
+	}
 	m.mu.Unlock()
 	if m.scheduler != nil && authSnapshot != nil {
 		m.scheduler.upsertAuth(authSnapshot)
@@ -972,8 +980,9 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	if result.IsProbe {
 		// Prober hooks should not be canceled when the individual probe
 		// returns, but they must still be tied to the prober/service lifecycle
-		// so shutdown can stop them.
-		hookCtx := m.proberParent
+		// so shutdown can stop them. Prefer the live loop context, then the
+		// registered service parent, then a detached context as a last resort.
+		hookCtx := probeHookCtx
 		if hookCtx == nil {
 			hookCtx = context.WithoutCancel(ctx)
 		}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -963,7 +963,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	}
 
 	if result.IsProbe {
-		go m.hook.OnResult(ctx, result)
+		// Detach the hook context from the probe lifetime so async observers
+		// see a usable (non-canceled) context.
+		hookCtx := context.WithoutCancel(ctx)
+		go m.hook.OnResult(hookCtx, result)
 		if result.Error != nil {
 			m.publishErrorEvent(result, authSnapshot)
 		}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -364,6 +364,7 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 
 	if model == "" {
 		auth.Unavailable = true
+		auth.authLevelCooldown = true
 		auth.Status = StatusError
 		auth.NextRetryAfter = record.NextRetryAfter
 		auth.Quota = quota
@@ -396,6 +397,7 @@ func clearCooldownStateForAuth(auth *Auth, now time.Time) bool {
 	changed := false
 	if auth.Unavailable || !auth.NextRetryAfter.IsZero() || auth.Quota.Exceeded || !auth.Quota.NextRecoverAt.IsZero() {
 		auth.Unavailable = false
+		auth.authLevelCooldown = false
 		auth.NextRetryAfter = time.Time{}
 		auth.Quota = QuotaState{}
 		auth.UpdatedAt = now

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -110,10 +110,12 @@ func (m *Manager) SetConfig(cfg *internalconfig.Config) {
 		return
 	}
 	m.configCooldownMu.Lock()
-	defer m.configCooldownMu.Unlock()
-	if m.setConfigSnapshotLocked(cfg) {
+	cleared := m.setConfigSnapshotLocked(cfg)
+	if cleared {
 		m.persistCooldownStatesLocked(context.Background())
 	}
+	m.configCooldownMu.Unlock()
+	m.restartProberLocked()
 }
 
 // SetConfigSnapshot updates only in-memory configuration state. It reports whether
@@ -123,8 +125,10 @@ func (m *Manager) SetConfigSnapshot(cfg *internalconfig.Config) bool {
 		return false
 	}
 	m.configCooldownMu.Lock()
-	defer m.configCooldownMu.Unlock()
-	return m.setConfigSnapshotLocked(cfg)
+	changed := m.setConfigSnapshotLocked(cfg)
+	m.configCooldownMu.Unlock()
+	m.restartProberLocked()
+	return changed
 }
 
 func (m *Manager) setConfigSnapshotLocked(cfg *internalconfig.Config) bool {
@@ -153,7 +157,6 @@ func (m *Manager) setConfigSnapshotLocked(cfg *internalconfig.Config) bool {
 		m.clearHomeRuntimeAuths()
 	}
 	m.rebuildAPIKeyModelAliasFromRuntimeConfig()
-	m.restartProberLocked(cfg)
 	return clearedCooldowns
 }
 
@@ -172,11 +175,18 @@ func (m *Manager) ApplyConfigWithCooldownStateStore(ctx context.Context, cfg *in
 	}
 
 	m.configCooldownMu.Lock()
-	defer m.configCooldownMu.Unlock()
+	restart := false
+	defer func() {
+		m.configCooldownMu.Unlock()
+		if restart {
+			m.restartProberLocked()
+		}
+	}()
 	m.mu.RLock()
 	oldStore := m.cooldownStore
 	m.mu.RUnlock()
 	m.setConfigSnapshotLocked(cfg)
+	restart = true
 	if oldStore != nil && !m.persistCooldownStatesToLocked(ctx, oldStore) {
 		return false
 	}

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -529,6 +529,41 @@ func (h *resultCaptureHook) Results() []Result {
 	return out
 }
 
+func TestMarkResultClearsSourceAuthBeforeHook(t *testing.T) {
+	ctx := context.Background()
+	hook := &resultCaptureHook{}
+	m := NewManager(nil, nil, hook)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "test",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"api_key": "secret-key",
+		},
+	}
+	m.mu.Lock()
+	m.auths[auth.ID] = auth
+	m.mu.Unlock()
+
+	m.MarkResult(ctx, Result{
+		AuthID:          auth.ID,
+		Provider:        auth.Provider,
+		Success:         false,
+		SourceAuth:      auth,
+		CredentialScope: true,
+		Error:           &Error{Code: ErrorCodeForceCooldown, Message: "upstream failure", HTTPStatus: http.StatusServiceUnavailable, Retryable: true},
+	})
+
+	results := hook.Results()
+	if len(results) != 1 {
+		t.Fatalf("hook results = %d, want 1", len(results))
+	}
+	if results[0].SourceAuth != nil {
+		t.Fatal("OnResult received non-nil SourceAuth; credential pointer must be cleared before hooks")
+	}
+}
+
 type retryAfterStatusError struct {
 	status     int
 	message    string

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -276,21 +276,19 @@ func (l *authProberLoop) snapshotAuths() []*Auth {
 }
 
 func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
+	// Re-fetch the auth and resolve its executor under the manager lock in one
+	// step. snapshotAuths may have returned a pointer that was replaced by an
+	// auto-refresh or watcher update while this probe was waiting in the
+	// rate-limit queue, and the replacement may use a different executor key.
 	l.manager.mu.RLock()
+	auth = l.manager.auths[auth.ID]
 	exec := l.manager.executors[executorKeyFromAuth(auth)]
 	l.manager.mu.RUnlock()
 
-	if exec == nil {
+	if auth == nil || auth.Disabled || auth.Status == StatusDisabled {
 		return
 	}
-
-	// Re-fetch the auth under the manager lock. snapshotAuths may have
-	// returned a pointer that was replaced by an auto-refresh or watcher
-	// update while this probe was waiting in the rate-limit queue.
-	l.manager.mu.RLock()
-	auth = l.manager.auths[auth.ID]
-	l.manager.mu.RUnlock()
-	if auth == nil || auth.Disabled || auth.Status == StatusDisabled {
+	if exec == nil {
 		return
 	}
 

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	xaiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/xai"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	log "github.com/sirupsen/logrus"
 )
@@ -493,6 +494,12 @@ func proberBaseURLForProvider(auth *Auth, cfg *internalconfig.Config) string {
 	if auth == nil {
 		return ""
 	}
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	if provider == "xai" {
+		// xAI routing depends on auth_kind/using_api as well as base_url, so use
+		// the same resolution the executor uses for chat requests.
+		return proberXAIChatBaseURL(auth)
+	}
 	if auth.Attributes != nil {
 		if baseURL := strings.TrimSpace(auth.Attributes["base_url"]); baseURL != "" {
 			return baseURL
@@ -505,7 +512,6 @@ func proberBaseURLForProvider(auth *Auth, cfg *internalconfig.Config) string {
 			}
 		}
 	}
-	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
 	if cfg != nil {
 		if u := proberOpenAICompatBaseURL(auth, cfg); u != "" {
 			return u
@@ -563,6 +569,99 @@ func proberOpenAICompatBaseURL(auth *Auth, cfg *internalconfig.Config) string {
 		}
 	}
 	return ""
+}
+
+// proberXAIChatBaseURL mirrors the executor's xaiChatBaseURL semantics so xAI
+// OAuth probes target the same upstream used for normal chat requests.
+func proberXAIChatBaseURL(auth *Auth) string {
+	_, baseURL := proberXAICreds(auth)
+	if proberXAIUsingAPI(auth) {
+		if baseURL == "" {
+			return xaiauth.DefaultAPIBaseURL
+		}
+		return baseURL
+	}
+	if baseURL != "" && !proberXAIIsDefaultAPIBaseURL(baseURL) {
+		return baseURL
+	}
+	return xaiauth.CLIChatProxyBaseURL
+}
+
+func proberXAICreds(auth *Auth) (token, baseURL string) {
+	if auth == nil {
+		return "", ""
+	}
+	if auth.Attributes != nil {
+		token = strings.TrimSpace(auth.Attributes["api_key"])
+		baseURL = strings.TrimSpace(auth.Attributes["base_url"])
+	}
+	if auth.Metadata != nil {
+		if token == "" {
+			token = proberXAIMetadataString(auth.Metadata, "access_token")
+		}
+		if baseURL == "" {
+			baseURL = proberXAIMetadataString(auth.Metadata, "base_url")
+		}
+	}
+	return token, baseURL
+}
+
+func proberXAIUsingAPI(auth *Auth) bool {
+	if auth == nil {
+		return true
+	}
+	if len(auth.Attributes) > 0 {
+		if raw := strings.TrimSpace(auth.Attributes["using_api"]); raw != "" {
+			if parsed, err := strconv.ParseBool(raw); err == nil {
+				return parsed
+			}
+		}
+	}
+	if len(auth.Metadata) > 0 {
+		raw, ok := auth.Metadata["using_api"]
+		if ok && raw != nil {
+			switch v := raw.(type) {
+			case bool:
+				return v
+			case string:
+				if parsed, err := strconv.ParseBool(strings.TrimSpace(v)); err == nil {
+					return parsed
+				}
+			}
+		}
+	}
+	if raw := strings.TrimSpace(auth.Attributes["auth_kind"]); raw != "" {
+		return !strings.EqualFold(raw, "oauth")
+	}
+	return !strings.EqualFold(proberXAIMetadataString(auth.Metadata, "auth_kind"), "oauth")
+}
+
+func proberXAIMetadataString(meta map[string]any, key string) string {
+	if len(meta) == 0 || key == "" {
+		return ""
+	}
+	value, ok := meta[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case []byte:
+		return strings.TrimSpace(string(typed))
+	case fmt.Stringer:
+		return strings.TrimSpace(typed.String())
+	default:
+		return strings.TrimSpace(fmt.Sprint(value))
+	}
+}
+
+func proberXAINormalizeBaseURL(baseURL string) string {
+	return strings.TrimRight(strings.TrimSpace(baseURL), "/")
+}
+
+func proberXAIIsDefaultAPIBaseURL(baseURL string) bool {
+	return proberXAINormalizeBaseURL(baseURL) == proberXAINormalizeBaseURL(xaiauth.DefaultAPIBaseURL)
 }
 
 // proberProbePathForProvider returns the probe path for the provider.

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -361,6 +361,9 @@ func (l *authProberLoop) probeWithLimiter(parent context.Context, auth *Auth, li
 		}
 		if strings.EqualFold(exec.Identifier(), "claude") {
 			req.Header.Set("Anthropic-Version", "2023-06-01")
+			if auth != nil && auth.AuthKind() != AuthKindAPIKey {
+				req.Header.Set("Anthropic-Beta", "oauth-2025-04-20")
+			}
 		}
 		resp, errExec = exec.HttpRequest(probeCtx, auth, req)
 		if resp != nil && resp.Body != nil {

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -21,6 +21,7 @@ import (
 const (
 	proberCheckInterval         = 60 * time.Second
 	proberMaxConcurrency        = 4
+	proberMaxConcurrencyCap     = 1024
 	proberRatePerMinute         = 60
 	proberMaxRateLimitPerMinute = 60_000_000
 	proberDefaultPath           = "/models"
@@ -205,6 +206,12 @@ func (l *authProberLoop) sweep(ctx context.Context) {
 	concurrency := l.cfg.MaxConcurrency
 	if concurrency <= 0 {
 		concurrency = proberMaxConcurrency
+	}
+	if concurrency > proberMaxConcurrencyCap {
+		concurrency = proberMaxConcurrencyCap
+	}
+	if concurrency > len(auths) {
+		concurrency = len(auths)
 	}
 
 	ratePerMinute := l.cfg.RateLimitPerMinute

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -140,18 +140,20 @@ func (l *authProberLoop) sweep(ctx context.Context) {
 		defer ticker.Stop()
 	}
 
+	authLoop := false
 	for _, auth := range auths {
 		if ctx.Err() != nil {
+			authLoop = true
 			break
 		}
 		if ticker != nil {
 			select {
 			case <-ctx.Done():
-				break
+				authLoop = true
 			case <-ticker.C:
 			}
 		}
-		if ctx.Err() != nil {
+		if authLoop {
 			break
 		}
 

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -339,6 +339,9 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 		if errReq != nil {
 			return
 		}
+		if strings.EqualFold(exec.Identifier(), "claude") {
+			req.Header.Set("Anthropic-Version", "2023-06-01")
+		}
 		resp, errExec = exec.HttpRequest(probeCtx, auth, req)
 		if resp != nil && resp.Body != nil {
 			_, _ = io.CopyN(io.Discard, resp.Body, proberMaxBodyBytes)

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -111,6 +111,7 @@ func (m *Manager) startProberUnlocked(parent context.Context, cfg internalconfig
 	m.mu.Lock()
 	m.proberCancel = cancel
 	m.proberLoop = loop
+	m.proberCtx = ctx
 	m.mu.Unlock()
 
 	m.proberWg.Add(1)
@@ -136,6 +137,7 @@ func (m *Manager) stopProberUnlocked() {
 	cancel := m.proberCancel
 	m.proberCancel = nil
 	m.proberLoop = nil
+	m.proberCtx = nil
 	m.mu.Unlock()
 	if cancel != nil {
 		cancel()

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -57,6 +57,8 @@ func newAuthProberLoop(manager *Manager, cfg internalconfig.CredentialProberConf
 
 // SetProberParentContext binds the prober to a service-wide context so it is
 // cancelled when the parent service shuts down instead of outliving it.
+// It does not start the prober; callers with a running manager must call
+// restartProberLocked/StartProber explicitly.
 func (m *Manager) SetProberParentContext(ctx context.Context) {
 	if m == nil {
 		return
@@ -124,6 +126,13 @@ func (m *Manager) stopProberUnlocked() {
 	m.proberWg.Wait()
 }
 
+// RestartProber re-evaluates the runtime prober config and starts or stops
+// the background loop. It is intended for the embeddable Service to start
+// probing after auth/executor initialization.
+func (m *Manager) RestartProber() {
+	m.restartProberLocked()
+}
+
 func (m *Manager) restartProberLocked() {
 	if m == nil {
 		return
@@ -134,11 +143,20 @@ func (m *Manager) restartProberLocked() {
 	}
 	m.proberLifecycleMu.Lock()
 	defer m.proberLifecycleMu.Unlock()
-	if cfg.CredentialProber.Enabled {
-		m.startProberUnlocked(context.Background(), cfg.CredentialProber)
-	} else {
+	if !cfg.CredentialProber.Enabled {
 		m.stopProberUnlocked()
+		return
 	}
+	m.mu.RLock()
+	parent := m.proberParent
+	m.mu.RUnlock()
+	if parent == nil {
+		// Service has not yet installed the lifecycle context; do not start
+		// a detached prober during build/initialization.
+		return
+	}
+	m.stopProberUnlocked()
+	m.startProberUnlocked(parent, cfg.CredentialProber)
 }
 
 func (l *authProberLoop) run(ctx context.Context) {

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -534,7 +534,7 @@ func proberOpenAICompatBaseURL(auth *Auth, cfg *internalconfig.Config) string {
 			continue
 		}
 		for _, cand := range candidates {
-			if cand != "" && (c.Name == cand || c.Name == strings.ToLower(cand)) {
+			if cand != "" && strings.EqualFold(c.Name, cand) {
 				return strings.TrimRight(c.BaseURL, "/")
 			}
 		}

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -72,8 +72,13 @@ func (m *Manager) StartProber(parent context.Context, cfg internalconfig.Credent
 	if m == nil {
 		return
 	}
+	m.proberLifecycleMu.Lock()
+	defer m.proberLifecycleMu.Unlock()
+	m.startProberUnlocked(parent, cfg)
+}
 
-	m.StopProber()
+func (m *Manager) startProberUnlocked(parent context.Context, cfg internalconfig.CredentialProberConfig) {
+	m.stopProberUnlocked()
 
 	m.mu.RLock()
 	if m.proberParent != nil {
@@ -102,6 +107,12 @@ func (m *Manager) StopProber() {
 	if m == nil {
 		return
 	}
+	m.proberLifecycleMu.Lock()
+	defer m.proberLifecycleMu.Unlock()
+	m.stopProberUnlocked()
+}
+
+func (m *Manager) stopProberUnlocked() {
 	m.mu.Lock()
 	cancel := m.proberCancel
 	m.proberCancel = nil
@@ -117,10 +128,12 @@ func (m *Manager) restartProberLocked(cfg *internalconfig.Config) {
 	if m == nil || cfg == nil {
 		return
 	}
+	m.proberLifecycleMu.Lock()
+	defer m.proberLifecycleMu.Unlock()
 	if cfg.CredentialProber.Enabled {
-		m.StartProber(context.Background(), cfg.CredentialProber)
+		m.startProberUnlocked(context.Background(), cfg.CredentialProber)
 	} else {
-		m.StopProber()
+		m.stopProberUnlocked()
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -17,11 +18,12 @@ import (
 )
 
 const (
-	proberCheckInterval  = 60 * time.Second
-	proberMaxConcurrency = 4
-	proberRatePerMinute  = 60
-	proberDefaultPath    = "/models"
-	proberMaxBodyBytes   = 1024
+	proberCheckInterval         = 60 * time.Second
+	proberMaxConcurrency        = 4
+	proberRatePerMinute         = 60
+	proberMaxRateLimitPerMinute = 60_000_000
+	proberDefaultPath           = "/models"
+	proberMaxBodyBytes          = 1024
 )
 
 // authProberLoop runs periodic lightweight health probes for registered auths.
@@ -40,6 +42,9 @@ func newAuthProberLoop(manager *Manager, cfg internalconfig.CredentialProberConf
 	}
 	if cfg.RateLimitPerMinute <= 0 {
 		cfg.RateLimitPerMinute = proberRatePerMinute
+	}
+	if cfg.RateLimitPerMinute > proberMaxRateLimitPerMinute {
+		cfg.RateLimitPerMinute = proberMaxRateLimitPerMinute
 	}
 	if strings.TrimSpace(cfg.DefaultProbePath) == "" {
 		cfg.DefaultProbePath = proberDefaultPath
@@ -204,7 +209,11 @@ func (l *authProberLoop) sweep(ctx context.Context) {
 
 	var ticker *time.Ticker
 	if ratePerMinute > 0 {
-		ticker = time.NewTicker(time.Minute / time.Duration(ratePerMinute))
+		period := time.Minute / time.Duration(ratePerMinute)
+		if period <= 0 {
+			period = time.Nanosecond
+		}
+		ticker = time.NewTicker(period)
 		defer ticker.Stop()
 	}
 
@@ -290,10 +299,7 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 	}()
 	defer cancel()
 
-	baseURL := ""
-	if auth.Attributes != nil {
-		baseURL = strings.TrimSpace(auth.Attributes["base_url"])
-	}
+	baseURL := proberBaseURLForProvider(auth)
 	if baseURL == "" {
 		return
 	}
@@ -308,57 +314,88 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 		return
 	}
 
-	req, errReq := http.NewRequestWithContext(probeCtx, http.MethodGet, probeURL, nil)
-	if errReq != nil {
-		return
-	}
+	var (
+		resp      *http.Response
+		errExec   error
+		bodyBytes int64
+		resultErr *Error
+	)
+	for attempt := 0; attempt < 2; attempt++ {
+		req, errReq := http.NewRequestWithContext(probeCtx, http.MethodGet, probeURL, nil)
+		if errReq != nil {
+			return
+		}
+		resp, errExec = exec.HttpRequest(probeCtx, auth, req)
+		bodyBytes = 0
+		if resp != nil && resp.Body != nil {
+			bodyBytes, _ = io.CopyN(io.Discard, resp.Body, proberMaxBodyBytes)
+			_ = resp.Body.Close()
+		}
 
-	resp, errExec := exec.HttpRequest(probeCtx, auth, req)
-	var bodyBytes int64
-	if resp != nil && resp.Body != nil {
-		bodyBytes, _ = io.CopyN(io.Discard, resp.Body, proberMaxBodyBytes)
-		_ = resp.Body.Close()
-	}
+		if errors.Is(probeCtx.Err(), context.Canceled) {
+			return
+		}
 
-	if errors.Is(probeCtx.Err(), context.Canceled) {
-		return
-	}
+		resultErr = nil
+		if errExec != nil {
+			resultErr = &Error{
+				Code:       ErrorCodeForceCooldown,
+				Message:    "prober: " + redactProbeError(errExec),
+				HTTPStatus: http.StatusServiceUnavailable,
+				Retryable:  true,
+			}
+		} else if resp == nil {
+			resultErr = &Error{
+				Code:       ErrorCodeForceCooldown,
+				Message:    "prober: empty upstream response",
+				HTTPStatus: http.StatusServiceUnavailable,
+				Retryable:  true,
+			}
+		} else if resp.StatusCode == http.StatusOK && bodyBytes == 0 {
+			resultErr = &Error{
+				Code:       ErrorCodeForceCooldown,
+				Message:    "prober: empty 200 response",
+				HTTPStatus: http.StatusServiceUnavailable,
+				Retryable:  true,
+			}
+		} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			resultErr = &Error{
+				Code:       ErrorCodeForceCooldown,
+				Message:    fmt.Sprintf("prober: upstream returned %d", resp.StatusCode),
+				HTTPStatus: resp.StatusCode,
+				Retryable:  resp.StatusCode >= 500 || resp.StatusCode == 429,
+			}
+		}
 
-	var resultErr *Error
-	if errExec != nil {
-		resultErr = &Error{
-			Code:       ErrorCodeForceCooldown,
-			Message:    "prober: " + errExec.Error(),
-			HTTPStatus: http.StatusServiceUnavailable,
-			Retryable:  true,
+		if resultErr == nil || resultErr.HTTPStatus != http.StatusUnauthorized || attempt > 0 {
+			break
 		}
-	} else if resp == nil {
-		resultErr = &Error{
-			Code:       ErrorCodeForceCooldown,
-			Message:    "prober: empty upstream response",
-			HTTPStatus: http.StatusServiceUnavailable,
-			Retryable:  true,
+
+		refreshed := proberTryRefreshOn401(probeCtx, exec, auth)
+		if refreshed == nil {
+			break
 		}
-	} else if resp.StatusCode == http.StatusNoContent || (resp.StatusCode == http.StatusOK && bodyBytes == 0) {
-		resultErr = &Error{
-			Code:       ErrorCodeForceCooldown,
-			Message:    "prober: empty 200/204 response",
-			HTTPStatus: http.StatusServiceUnavailable,
-			Retryable:  true,
+		if _, errRegister := l.manager.Register(probeCtx, refreshed); errRegister != nil {
+			break
 		}
-	} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		resultErr = &Error{
-			Code:       ErrorCodeForceCooldown,
-			Message:    fmt.Sprintf("prober: upstream returned %d", resp.StatusCode),
-			HTTPStatus: resp.StatusCode,
-			Retryable:  resp.StatusCode >= 500 || resp.StatusCode == 429,
+		l.manager.mu.RLock()
+		current := l.manager.auths[auth.ID]
+		l.manager.mu.RUnlock()
+		if current == nil {
+			return
 		}
+		auth = current
 	}
 
 	if resultErr == nil {
-		l.manager.mu.Lock()
-		auth.proberBackoff = 0
-		l.manager.mu.Unlock()
+		l.manager.MarkResult(probeCtx, Result{
+			AuthID:          auth.ID,
+			Provider:        auth.Provider,
+			Success:         true,
+			CredentialScope: true,
+			IsProbe:         true,
+			SourceAuth:      auth,
+		})
 		return
 	}
 
@@ -385,6 +422,8 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 		Provider:        auth.Provider,
 		Success:         false,
 		CredentialScope: true,
+		IsProbe:         true,
+		SourceAuth:      auth,
 		Error:           resultErr,
 		RetryAfter:      &retryAfter,
 	})
@@ -416,6 +455,39 @@ var proberProviderProbePaths = map[string]string{
 	"aistudio":            "/v1beta/models",
 	"xai":                 "/v1/models",
 	"kimi":                "/v1/models",
+	"claude":              "/v1/models",
+	"codex":               "/v1/models",
+}
+
+// proberProviderBaseURLs supplies a default base URL for file-backed OAuth
+// credentials that do not carry an explicit base_url attribute.
+var proberProviderBaseURLs = map[string]string{
+	"gemini":               "https://generativelanguage.googleapis.com",
+	"gemini-interactions":  "https://generativelanguage.googleapis.com",
+	"aistudio":             "https://generativelanguage.googleapis.com",
+	"xai":                  "https://api.x.ai/v1",
+	"kimi":                 "https://api.kimi.com/coding",
+	"claude":               "https://api.anthropic.com",
+	"codex":                "https://api.openai.com/v1",
+	"openai-compatibility": "https://api.openai.com/v1",
+}
+
+// proberBaseURLForProvider returns the base URL for the probe, using the
+// auth attribute if present and falling back to provider defaults for OAuth.
+func proberBaseURLForProvider(auth *Auth) string {
+	if auth == nil {
+		return ""
+	}
+	if auth.Attributes != nil {
+		if baseURL := strings.TrimSpace(auth.Attributes["base_url"]); baseURL != "" {
+			return baseURL
+		}
+	}
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	if p, ok := proberProviderBaseURLs[provider]; ok {
+		return p
+	}
+	return ""
 }
 
 // proberProbePathForProvider returns the probe path for the provider.
@@ -436,6 +508,58 @@ func proberProbePathForProvider(provider, configured string) string {
 		return configured
 	}
 	return ""
+}
+
+var proberURLRegex = regexp.MustCompile(`https?://[^ \t\n\r\"'<>]+`)
+
+// redactProbeError removes userinfo and query parameters from any URL that
+// appears in a transport error, so tokens in query strings are not logged or
+// stored in LastError.
+func redactProbeError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return proberURLRegex.ReplaceAllStringFunc(err.Error(), func(raw string) string {
+		u, parseErr := url.Parse(raw)
+		if parseErr != nil {
+			return raw
+		}
+		u.User = nil
+		u.RawQuery = ""
+		u.Fragment = ""
+		return u.String()
+	})
+}
+
+func proberAccessToken(auth *Auth) string {
+	if auth == nil || auth.Metadata == nil {
+		return ""
+	}
+	for _, key := range []string{"access_token", "token", "id_token"} {
+		if v := auth.Metadata[key]; v != nil {
+			return strings.TrimSpace(fmt.Sprint(v))
+		}
+	}
+	return ""
+}
+
+// proberTryRefreshOn401 attempts to refresh an OAuth credential and returns
+// the refreshed auth if the token changed. It returns nil if no refresh token
+// is available or the refresh did not produce a new token.
+func proberTryRefreshOn401(ctx context.Context, exec ProviderExecutor, auth *Auth) *Auth {
+	if exec == nil || auth == nil {
+		return nil
+	}
+	before := proberAccessToken(auth)
+	refreshed, err := exec.Refresh(ctx, auth)
+	if err != nil || refreshed == nil {
+		return nil
+	}
+	after := proberAccessToken(refreshed)
+	if before == after {
+		return nil
+	}
+	return refreshed
 }
 
 // resolveProbeURL resolves the probe path against baseURL without duplicating

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -267,6 +267,16 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 		return
 	}
 
+	// Re-fetch the auth under the manager lock. snapshotAuths may have
+	// returned a pointer that was replaced by an auto-refresh or watcher
+	// update while this probe was waiting in the rate-limit queue.
+	l.manager.mu.RLock()
+	auth = l.manager.auths[auth.ID]
+	l.manager.mu.RUnlock()
+	if auth == nil || auth.Disabled || auth.Status == StatusDisabled {
+		return
+	}
+
 	// The prober must not carry a whole-request deadline into response
 	// processing. Drop any inherited deadline while still allowing the parent
 	// cancellation to stop the probe.
@@ -354,6 +364,15 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 
 	if log.IsLevelEnabled(log.DebugLevel) {
 		log.Debugf("credential prober failure for %s: %s", auth.ID, resultErr.Message)
+	}
+
+	// If the credential was replaced while the request was in flight, the
+	// result belongs to stale state and must not be applied to the replacement.
+	l.manager.mu.RLock()
+	after := l.manager.auths[auth.ID]
+	l.manager.mu.RUnlock()
+	if after == nil || after != auth {
+		return
 	}
 
 	l.manager.mu.RLock()

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -157,14 +157,16 @@ func (m *Manager) restartProberLocked() {
 		// restart a prober.
 		return
 	}
-	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
-	if cfg == nil {
-		cfg = &internalconfig.Config{}
-	}
 	m.proberLifecycleMu.Lock()
 	defer m.proberLifecycleMu.Unlock()
 	if parent.Err() != nil {
 		return
+	}
+	// Snapshot the runtime config only after acquiring the lifecycle lock so
+	// concurrent SetConfig restarts see the most recently applied configuration.
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	if cfg == nil {
+		cfg = &internalconfig.Config{}
 	}
 	if !cfg.CredentialProber.Enabled {
 		m.stopProberUnlocked()
@@ -254,7 +256,7 @@ func (l *authProberLoop) sweep(ctx context.Context) {
 		go func(a *Auth) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			l.probe(ctx, a)
+			l.probeWithLimiter(ctx, a, ticker.C)
 		}(auth)
 	}
 
@@ -285,6 +287,10 @@ func (l *authProberLoop) snapshotAuths() []*Auth {
 }
 
 func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
+	l.probeWithLimiter(parent, auth, nil)
+}
+
+func (l *authProberLoop) probeWithLimiter(parent context.Context, auth *Auth, limiter <-chan time.Time) {
 	// Re-fetch the auth and resolve its executor under the manager lock in one
 	// step. snapshotAuths may have returned a pointer that was replaced by an
 	// auto-refresh or watcher update while this probe was waiting in the
@@ -335,6 +341,15 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 		resultErr *Error
 	)
 	for attempt := 0; attempt < 2; attempt++ {
+		if attempt > 0 && limiter != nil {
+			// A refreshed OAuth credential retry is a second probe request; consume
+			// another rate-limit token instead of doubling the request rate.
+			select {
+			case <-probeCtx.Done():
+				return
+			case <-limiter:
+			}
+		}
 		req, errReq := http.NewRequestWithContext(probeCtx, http.MethodGet, probeURL, nil)
 		if errReq != nil {
 			return

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -274,9 +274,8 @@ func (l *authProberLoop) snapshotAuths() []*Auth {
 		if auth.Disabled || auth.Status == StatusDisabled {
 			continue
 		}
-		if auth.Unavailable && auth.NextRetryAfter.After(now) {
-			continue
-		}
+		// Only credential-scoped auth-level cooldown blocks probes. Model-only
+		// cooldowns must not suppress the credential-wide health check.
 		if auth.authLevelUnavailable && auth.authLevelNextRetryAfter.After(now) {
 			continue
 		}

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -43,6 +43,15 @@ func newAuthProberLoop(manager *Manager, cfg internalconfig.CredentialProberConf
 	if strings.TrimSpace(cfg.DefaultProbePath) == "" {
 		cfg.DefaultProbePath = proberDefaultPath
 	}
+	if cfg.BackoffBase <= 0 {
+		cfg.BackoffBase = 30 * time.Second
+	}
+	if cfg.BackoffMax <= 0 {
+		cfg.BackoffMax = 5 * time.Minute
+	}
+	if cfg.BackoffMax < cfg.BackoffBase {
+		cfg.BackoffMax = cfg.BackoffBase
+	}
 	return &authProberLoop{manager: manager, cfg: cfg}
 }
 
@@ -297,6 +306,9 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 	}
 
 	if resultErr == nil {
+		l.manager.mu.Lock()
+		auth.proberBackoff = 0
+		l.manager.mu.Unlock()
 		return
 	}
 
@@ -304,13 +316,36 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 		log.Debugf("credential prober failure for %s: %s", auth.ID, resultErr.Message)
 	}
 
+	l.manager.mu.RLock()
+	level := auth.proberBackoff
+	l.manager.mu.RUnlock()
+	retryAfter := l.proberBackoffFor(level)
+
 	l.manager.MarkResult(probeCtx, Result{
 		AuthID:          auth.ID,
 		Provider:        auth.Provider,
 		Success:         false,
 		CredentialScope: true,
 		Error:           resultErr,
+		RetryAfter:      &retryAfter,
 	})
+}
+
+func (l *authProberLoop) proberBackoffFor(level int) time.Duration {
+	if level < 0 {
+		level = 0
+	}
+	d := l.cfg.BackoffBase
+	for i := 0; i < level; i++ {
+		d *= 2
+		if d >= l.cfg.BackoffMax {
+			return l.cfg.BackoffMax
+		}
+	}
+	if d < l.cfg.BackoffBase {
+		d = l.cfg.BackoffBase
+	}
+	return d
 }
 
 // resolveProbeURL resolves the probe path against baseURL without duplicating

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -727,12 +727,12 @@ func proberAccessToken(auth *Auth) string {
 	return ""
 }
 
-// proberTryRefreshOn401 attempts to refresh an OAuth credential and returns
-// the current auth if the token changed. It uses the manager's
-// refreshAuthForRequest path so the refresh is serialized per auth and the
-// live pointer is not mutated in place by the executor.
+// proberTryRefreshOn401 attempts to refresh a credential that has refresh
+// material and returns the current auth if the token changed. It uses the
+// manager's refreshAuthForRequest path so the refresh is serialized per auth
+// and the live pointer is not mutated in place by the executor.
 func proberTryRefreshOn401(ctx context.Context, m *Manager, auth *Auth) *Auth {
-	if m == nil || auth == nil {
+	if m == nil || auth == nil || !authHasRefreshCredential(auth) {
 		return nil
 	}
 	before := proberAccessToken(auth)

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -299,7 +300,7 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 	}()
 	defer cancel()
 
-	baseURL := proberBaseURLForProvider(auth)
+	baseURL := proberBaseURLForProvider(auth, l.manager.currentConfig())
 	if baseURL == "" {
 		return
 	}
@@ -474,7 +475,7 @@ var proberProviderBaseURLs = map[string]string{
 
 // proberBaseURLForProvider returns the base URL for the probe, using the
 // auth attribute if present and falling back to provider defaults for OAuth.
-func proberBaseURLForProvider(auth *Auth) string {
+func proberBaseURLForProvider(auth *Auth, cfg *internalconfig.Config) string {
 	if auth == nil {
 		return ""
 	}
@@ -486,6 +487,54 @@ func proberBaseURLForProvider(auth *Auth) string {
 	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
 	if p, ok := proberProviderBaseURLs[provider]; ok {
 		return p
+	}
+	if cfg != nil {
+		if u := proberOpenAICompatBaseURL(auth, cfg); u != "" {
+			return u
+		}
+	}
+	return ""
+}
+
+// proberOpenAICompatBaseURL resolves a base URL from the configured OpenAI
+// compatibility entries for custom openai-compatible providers that do not
+// carry an explicit base_url attribute.
+func proberOpenAICompatBaseURL(auth *Auth, cfg *internalconfig.Config) string {
+	if auth == nil || cfg == nil {
+		return ""
+	}
+
+	var candidates []string
+	if auth.Attributes != nil {
+		if v := strings.TrimSpace(auth.Attributes["config_index"]); v != "" {
+			if idx, err := strconv.Atoi(v); err == nil && idx >= 0 && idx < len(cfg.OpenAICompatibility) {
+				c := &cfg.OpenAICompatibility[idx]
+				if !c.Disabled && strings.TrimSpace(c.BaseURL) != "" {
+					return strings.TrimRight(c.BaseURL, "/")
+				}
+			}
+		}
+		if v := strings.TrimSpace(auth.Attributes["compat_name"]); v != "" {
+			candidates = append(candidates, v)
+		}
+		if v := strings.TrimSpace(auth.Attributes["provider_key"]); v != "" {
+			candidates = append(candidates, v)
+		}
+	}
+	if v := strings.TrimSpace(auth.Provider); v != "" {
+		candidates = append(candidates, v)
+	}
+
+	for i := range cfg.OpenAICompatibility {
+		c := &cfg.OpenAICompatibility[i]
+		if c.Disabled || strings.TrimSpace(c.BaseURL) == "" {
+			continue
+		}
+		for _, cand := range candidates {
+			if cand != "" && (c.Name == cand || c.Name == strings.ToLower(cand)) {
+				return strings.TrimRight(c.BaseURL, "/")
+			}
+		}
 	}
 	return ""
 }

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -277,6 +277,9 @@ func (l *authProberLoop) snapshotAuths() []*Auth {
 		if auth.Unavailable && auth.NextRetryAfter.After(now) {
 			continue
 		}
+		if auth.authLevelUnavailable && auth.authLevelNextRetryAfter.After(now) {
+			continue
+		}
 		out = append(out, auth)
 	}
 	return out

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -199,6 +199,19 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 		return
 	}
 
+	// The prober must not carry a whole-request deadline into response
+	// processing. Drop any inherited deadline while still allowing the parent
+	// cancellation to stop the probe.
+	probeCtx, cancel := context.WithCancel(context.WithoutCancel(parent))
+	go func() {
+		select {
+		case <-parent.Done():
+			cancel()
+		case <-probeCtx.Done():
+		}
+	}()
+	defer cancel()
+
 	baseURL := ""
 	if auth.Attributes != nil {
 		baseURL = strings.TrimSpace(auth.Attributes["base_url"])
@@ -217,12 +230,12 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 		return
 	}
 
-	req, errReq := http.NewRequestWithContext(parent, http.MethodGet, probeURL, nil)
+	req, errReq := http.NewRequestWithContext(probeCtx, http.MethodGet, probeURL, nil)
 	if errReq != nil {
 		return
 	}
 
-	resp, errExec := exec.HttpRequest(parent, auth, req)
+	resp, errExec := exec.HttpRequest(probeCtx, auth, req)
 	var bodyBytes int64
 	if resp != nil && resp.Body != nil {
 		bodyBytes, _ = io.CopyN(io.Discard, resp.Body, proberMaxBodyBytes)
@@ -268,7 +281,7 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 		log.Debugf("credential prober failure for %s: %s", auth.ID, resultErr.Message)
 	}
 
-	l.manager.MarkResult(parent, Result{
+	l.manager.MarkResult(probeCtx, Result{
 		AuthID:          auth.ID,
 		Provider:        auth.Provider,
 		Success:         false,

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -95,6 +95,10 @@ func (m *Manager) startProberUnlocked(parent context.Context, cfg internalconfig
 	}
 	m.mu.RUnlock()
 
+	if parent == nil || parent.Err() != nil {
+		return
+	}
+
 	ctx, cancel := context.WithCancel(parent)
 	loop := newAuthProberLoop(m, cfg)
 
@@ -144,22 +148,25 @@ func (m *Manager) restartProberLocked() {
 	if m == nil {
 		return
 	}
+	m.mu.RLock()
+	parent := m.proberParent
+	m.mu.RUnlock()
+	if parent == nil || parent.Err() != nil {
+		// No lifecycle parent or the service has shut down; do not start or
+		// restart a prober.
+		return
+	}
 	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
 	if cfg == nil {
 		cfg = &internalconfig.Config{}
 	}
 	m.proberLifecycleMu.Lock()
 	defer m.proberLifecycleMu.Unlock()
-	if !cfg.CredentialProber.Enabled {
-		m.stopProberUnlocked()
+	if parent.Err() != nil {
 		return
 	}
-	m.mu.RLock()
-	parent := m.proberParent
-	m.mu.RUnlock()
-	if parent == nil {
-		// Service has not yet installed the lifecycle context; do not start
-		// a detached prober during build/initialization.
+	if !cfg.CredentialProber.Enabled {
+		m.stopProberUnlocked()
 		return
 	}
 	m.stopProberUnlocked()
@@ -372,20 +379,11 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 			break
 		}
 
-		refreshed := proberTryRefreshOn401(probeCtx, exec, auth)
-		if refreshed == nil {
+		if refreshed := proberTryRefreshOn401(probeCtx, l.manager, auth); refreshed != nil {
+			auth = refreshed
+		} else {
 			break
 		}
-		if _, errRegister := l.manager.Register(probeCtx, refreshed); errRegister != nil {
-			break
-		}
-		l.manager.mu.RLock()
-		current := l.manager.auths[auth.ID]
-		l.manager.mu.RUnlock()
-		if current == nil {
-			return
-		}
-		auth = current
 	}
 
 	if resultErr == nil {
@@ -469,7 +467,6 @@ var proberProviderBaseURLs = map[string]string{
 	"xai":                  "https://api.x.ai/v1",
 	"kimi":                 "https://api.kimi.com/coding",
 	"claude":               "https://api.anthropic.com",
-	"codex":                "https://api.openai.com/v1",
 	"openai-compatibility": "https://api.openai.com/v1",
 }
 
@@ -485,13 +482,13 @@ func proberBaseURLForProvider(auth *Auth, cfg *internalconfig.Config) string {
 		}
 	}
 	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
-	if p, ok := proberProviderBaseURLs[provider]; ok {
-		return p
-	}
 	if cfg != nil {
 		if u := proberOpenAICompatBaseURL(auth, cfg); u != "" {
 			return u
 		}
+	}
+	if p, ok := proberProviderBaseURLs[provider]; ok {
+		return p
 	}
 	return ""
 }
@@ -593,22 +590,26 @@ func proberAccessToken(auth *Auth) string {
 }
 
 // proberTryRefreshOn401 attempts to refresh an OAuth credential and returns
-// the refreshed auth if the token changed. It returns nil if no refresh token
-// is available or the refresh did not produce a new token.
-func proberTryRefreshOn401(ctx context.Context, exec ProviderExecutor, auth *Auth) *Auth {
-	if exec == nil || auth == nil {
+// the current auth if the token changed. It uses the manager's
+// refreshAuthForRequest path so the refresh is serialized per auth and the
+// live pointer is not mutated in place by the executor.
+func proberTryRefreshOn401(ctx context.Context, m *Manager, auth *Auth) *Auth {
+	if m == nil || auth == nil {
 		return nil
 	}
 	before := proberAccessToken(auth)
-	refreshed, err := exec.Refresh(ctx, auth)
-	if err != nil || refreshed == nil {
+	_, _ = m.refreshAuthForRequest(ctx, auth.ID, before)
+
+	m.mu.RLock()
+	current := m.auths[auth.ID]
+	m.mu.RUnlock()
+	if current == nil {
 		return nil
 	}
-	after := proberAccessToken(refreshed)
-	if before == after {
+	if proberAccessToken(current) == before {
 		return nil
 	}
-	return refreshed
+	return current
 }
 
 // resolveProbeURL resolves the probe path against baseURL without duplicating

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -237,7 +237,7 @@ func (l *authProberLoop) snapshotAuths() []*Auth {
 
 func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 	l.manager.mu.RLock()
-	exec := l.manager.executors[auth.Provider]
+	exec := l.manager.executors[executorKeyFromAuth(auth)]
 	l.manager.mu.RUnlock()
 
 	if exec == nil {

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -46,6 +46,17 @@ func newAuthProberLoop(manager *Manager, cfg internalconfig.CredentialProberConf
 	return &authProberLoop{manager: manager, cfg: cfg}
 }
 
+// SetProberParentContext binds the prober to a service-wide context so it is
+// cancelled when the parent service shuts down instead of outliving it.
+func (m *Manager) SetProberParentContext(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.proberParent = ctx
+	m.mu.Unlock()
+}
+
 // StartProber launches a background credential health prober.
 // Only one loop is kept alive; starting a new one cancels the previous run.
 func (m *Manager) StartProber(parent context.Context, cfg internalconfig.CredentialProberConfig) {
@@ -55,6 +66,12 @@ func (m *Manager) StartProber(parent context.Context, cfg internalconfig.Credent
 
 	m.StopProber()
 
+	m.mu.RLock()
+	if m.proberParent != nil {
+		parent = m.proberParent
+	}
+	m.mu.RUnlock()
+
 	ctx, cancel := context.WithCancel(parent)
 	loop := newAuthProberLoop(m, cfg)
 
@@ -63,10 +80,15 @@ func (m *Manager) StartProber(parent context.Context, cfg internalconfig.Credent
 	m.proberLoop = loop
 	m.mu.Unlock()
 
-	go loop.run(ctx)
+	m.proberWg.Add(1)
+	go func() {
+		defer m.proberWg.Done()
+		loop.run(ctx)
+	}()
 }
 
-// StopProber cancels the background prober loop, if running.
+// StopProber cancels the background prober loop, if running, and waits for it
+// to return before service shutdown continues.
 func (m *Manager) StopProber() {
 	if m == nil {
 		return
@@ -79,6 +101,7 @@ func (m *Manager) StopProber() {
 	if cancel != nil {
 		cancel()
 	}
+	m.proberWg.Wait()
 }
 
 func (m *Manager) restartProberLocked(cfg *internalconfig.Config) {

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -307,6 +308,10 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 	if resp != nil && resp.Body != nil {
 		bodyBytes, _ = io.CopyN(io.Discard, resp.Body, proberMaxBodyBytes)
 		_ = resp.Body.Close()
+	}
+
+	if errors.Is(probeCtx.Err(), context.Canceled) {
+		return
 	}
 
 	var resultErr *Error

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -1,0 +1,304 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	proberCheckInterval  = 60 * time.Second
+	proberMaxConcurrency = 4
+	proberRatePerMinute  = 60
+	proberDefaultPath    = "/v1/models"
+	proberMaxBodyBytes   = 1024
+)
+
+// authProberLoop runs periodic lightweight health probes for registered auths.
+// Failures are fed back into the existing MarkResult/cooldown path.
+type authProberLoop struct {
+	manager *Manager
+	cfg     internalconfig.CredentialProberConfig
+}
+
+func newAuthProberLoop(manager *Manager, cfg internalconfig.CredentialProberConfig) *authProberLoop {
+	if cfg.Interval <= 0 {
+		cfg.Interval = proberCheckInterval
+	}
+	if cfg.MaxConcurrency <= 0 {
+		cfg.MaxConcurrency = proberMaxConcurrency
+	}
+	if cfg.RateLimitPerMinute <= 0 {
+		cfg.RateLimitPerMinute = proberRatePerMinute
+	}
+	if strings.TrimSpace(cfg.DefaultProbePath) == "" {
+		cfg.DefaultProbePath = proberDefaultPath
+	}
+	return &authProberLoop{manager: manager, cfg: cfg}
+}
+
+// StartProber launches a background credential health prober.
+// Only one loop is kept alive; starting a new one cancels the previous run.
+func (m *Manager) StartProber(parent context.Context, cfg internalconfig.CredentialProberConfig) {
+	if m == nil {
+		return
+	}
+
+	m.StopProber()
+
+	ctx, cancel := context.WithCancel(parent)
+	loop := newAuthProberLoop(m, cfg)
+
+	m.mu.Lock()
+	m.proberCancel = cancel
+	m.proberLoop = loop
+	m.mu.Unlock()
+
+	go loop.run(ctx)
+}
+
+// StopProber cancels the background prober loop, if running.
+func (m *Manager) StopProber() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	cancel := m.proberCancel
+	m.proberCancel = nil
+	m.proberLoop = nil
+	m.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (m *Manager) restartProberLocked(cfg *internalconfig.Config) {
+	if m == nil || cfg == nil {
+		return
+	}
+	if cfg.CredentialProber.Enabled {
+		m.StartProber(context.Background(), cfg.CredentialProber)
+	} else {
+		m.StopProber()
+	}
+}
+
+func (l *authProberLoop) run(ctx context.Context) {
+	if l == nil || l.manager == nil {
+		return
+	}
+
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			l.sweep(ctx)
+			interval := l.cfg.Interval
+			if interval <= 0 {
+				interval = proberCheckInterval
+			}
+			timer.Reset(interval)
+		}
+	}
+}
+
+func (l *authProberLoop) sweep(ctx context.Context) {
+	auths := l.snapshotAuths()
+	if len(auths) == 0 {
+		return
+	}
+
+	concurrency := l.cfg.MaxConcurrency
+	if concurrency <= 0 {
+		concurrency = proberMaxConcurrency
+	}
+
+	ratePerMinute := l.cfg.RateLimitPerMinute
+	if ratePerMinute <= 0 {
+		ratePerMinute = proberRatePerMinute
+	}
+
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, concurrency)
+
+	var ticker *time.Ticker
+	if ratePerMinute > 0 {
+		ticker = time.NewTicker(time.Minute / time.Duration(ratePerMinute))
+		defer ticker.Stop()
+	}
+
+	for _, auth := range auths {
+		if ctx.Err() != nil {
+			break
+		}
+		if ticker != nil {
+			select {
+			case <-ctx.Done():
+				break
+			case <-ticker.C:
+			}
+		}
+		if ctx.Err() != nil {
+			break
+		}
+
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(a *Auth) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			l.probe(ctx, a)
+		}(auth)
+	}
+
+	wg.Wait()
+}
+
+func (l *authProberLoop) snapshotAuths() []*Auth {
+	l.manager.mu.RLock()
+	defer l.manager.mu.RUnlock()
+
+	now := time.Now()
+	out := make([]*Auth, 0, len(l.manager.auths))
+	for _, auth := range l.manager.auths {
+		if auth == nil {
+			continue
+		}
+		if auth.Disabled || auth.Status == StatusDisabled {
+			continue
+		}
+		if auth.Unavailable && auth.NextRetryAfter.After(now) {
+			continue
+		}
+		out = append(out, auth)
+	}
+	return out
+}
+
+func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
+	l.manager.mu.RLock()
+	exec := l.manager.executors[auth.Provider]
+	l.manager.mu.RUnlock()
+
+	if exec == nil {
+		return
+	}
+
+	baseURL := ""
+	if auth.Attributes != nil {
+		baseURL = strings.TrimSpace(auth.Attributes["base_url"])
+	}
+	if baseURL == "" {
+		return
+	}
+
+	path := strings.TrimSpace(l.cfg.DefaultProbePath)
+	if path == "" {
+		path = proberDefaultPath
+	}
+
+	probeURL, errParse := resolveProbeURL(baseURL, path)
+	if errParse != nil {
+		return
+	}
+
+	req, errReq := http.NewRequestWithContext(parent, http.MethodGet, probeURL, nil)
+	if errReq != nil {
+		return
+	}
+
+	resp, errExec := exec.HttpRequest(parent, auth, req)
+	var bodyBytes int64
+	if resp != nil && resp.Body != nil {
+		bodyBytes, _ = io.CopyN(io.Discard, resp.Body, proberMaxBodyBytes)
+		_ = resp.Body.Close()
+	}
+
+	var resultErr *Error
+	if errExec != nil {
+		resultErr = &Error{
+			Code:       ErrorCodeForceCooldown,
+			Message:    "prober: " + errExec.Error(),
+			HTTPStatus: http.StatusServiceUnavailable,
+			Retryable:  true,
+		}
+	} else if resp == nil {
+		resultErr = &Error{
+			Code:       ErrorCodeForceCooldown,
+			Message:    "prober: empty upstream response",
+			HTTPStatus: http.StatusServiceUnavailable,
+			Retryable:  true,
+		}
+	} else if resp.StatusCode == http.StatusNoContent || (resp.StatusCode == http.StatusOK && bodyBytes == 0) {
+		resultErr = &Error{
+			Code:       ErrorCodeForceCooldown,
+			Message:    "prober: empty 200/204 response",
+			HTTPStatus: http.StatusServiceUnavailable,
+			Retryable:  true,
+		}
+	} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		resultErr = &Error{
+			Code:       ErrorCodeForceCooldown,
+			Message:    fmt.Sprintf("prober: upstream returned %d", resp.StatusCode),
+			HTTPStatus: resp.StatusCode,
+			Retryable:  resp.StatusCode >= 500 || resp.StatusCode == 429,
+		}
+	}
+
+	if resultErr == nil {
+		return
+	}
+
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.Debugf("credential prober failure for %s: %s", auth.ID, resultErr.Message)
+	}
+
+	l.manager.MarkResult(parent, Result{
+		AuthID:          auth.ID,
+		Provider:        auth.Provider,
+		Success:         false,
+		CredentialScope: true,
+		Error:           resultErr,
+	})
+}
+
+// resolveProbeURL resolves the probe path against baseURL without duplicating
+// the API version segment. If the base path already ends with the first segment
+// of the probe path, that segment is not duplicated.
+func resolveProbeURL(baseURL, probePath string) (string, error) {
+	base, err := url.Parse(strings.TrimRight(baseURL, "/"))
+	if err != nil {
+		return "", err
+	}
+	probePath = strings.Trim(probePath, "/")
+	if probePath == "" {
+		probePath = strings.Trim(proberDefaultPath, "/")
+	}
+
+	basePath := strings.Trim(base.Path, "/")
+	var baseSegs []string
+	if basePath != "" {
+		baseSegs = strings.Split(basePath, "/")
+	}
+	probeSegs := strings.Split(probePath, "/")
+
+	if len(baseSegs) > 0 && len(probeSegs) > 0 && baseSegs[len(baseSegs)-1] == probeSegs[0] {
+		probeSegs = probeSegs[1:]
+	}
+
+	base.Path = "/" + path.Join(append(baseSegs, probeSegs...)...)
+	return base.String(), nil
+}

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -678,12 +678,18 @@ func proberXAIIsDefaultAPIBaseURL(baseURL string) bool {
 }
 
 // proberProbePathForProvider returns the probe path for the provider.
-// OpenAI-compatible executors use /v1/models. Unknown providers fall back to
-// the configured default; if neither is set, the caller should skip the auth.
+// A custom default-probe-path takes precedence over provider defaults.
+// OpenAI-compatible executors use /v1/models when no custom path is
+// configured; unknown providers fall back to the configured default, and if
+// neither is set the caller should skip the auth.
 func proberProbePathForProvider(provider, configured string) string {
+	configured = strings.TrimSpace(configured)
+	if configured != "" && configured != proberDefaultPath {
+		return configured
+	}
 	provider = strings.ToLower(strings.TrimSpace(provider))
 	if provider == "" {
-		return strings.TrimSpace(configured)
+		return configured
 	}
 	if p, ok := proberProviderProbePaths[provider]; ok {
 		return p
@@ -691,10 +697,7 @@ func proberProbePathForProvider(provider, configured string) string {
 	if proberIsOpenAICompatibleProvider(provider) {
 		return "/v1/models"
 	}
-	if configured != "" {
-		return configured
-	}
-	return ""
+	return configured
 }
 
 var proberURLRegex = regexp.MustCompile(`https?://[^ \t\n\r\"'<>]+`)

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -323,7 +323,6 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 	var (
 		resp      *http.Response
 		errExec   error
-		bodyBytes int64
 		resultErr *Error
 	)
 	for attempt := 0; attempt < 2; attempt++ {
@@ -332,9 +331,8 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 			return
 		}
 		resp, errExec = exec.HttpRequest(probeCtx, auth, req)
-		bodyBytes = 0
 		if resp != nil && resp.Body != nil {
-			bodyBytes, _ = io.CopyN(io.Discard, resp.Body, proberMaxBodyBytes)
+			_, _ = io.CopyN(io.Discard, resp.Body, proberMaxBodyBytes)
 			_ = resp.Body.Close()
 		}
 
@@ -354,13 +352,6 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 			resultErr = &Error{
 				Code:       ErrorCodeForceCooldown,
 				Message:    "prober: empty upstream response",
-				HTTPStatus: http.StatusServiceUnavailable,
-				Retryable:  true,
-			}
-		} else if resp.StatusCode == http.StatusOK && bodyBytes == 0 {
-			resultErr = &Error{
-				Code:       ErrorCodeForceCooldown,
-				Message:    "prober: empty 200 response",
 				HTTPStatus: http.StatusServiceUnavailable,
 				Retryable:  true,
 			}
@@ -468,8 +459,9 @@ var proberProviderBaseURLs = map[string]string{
 	"openai-compatibility": "https://api.openai.com/v1",
 }
 
-// proberBaseURLForProvider returns the base URL for the probe, using the
-// auth attribute if present and falling back to provider defaults for OAuth.
+// proberBaseURLForProvider returns the base URL for the probe, using the auth
+// attribute or metadata if present and falling back to provider defaults for
+// OAuth. File-backed credentials store the configured base_url in Metadata.
 func proberBaseURLForProvider(auth *Auth, cfg *internalconfig.Config) string {
 	if auth == nil {
 		return ""
@@ -477,6 +469,13 @@ func proberBaseURLForProvider(auth *Auth, cfg *internalconfig.Config) string {
 	if auth.Attributes != nil {
 		if baseURL := strings.TrimSpace(auth.Attributes["base_url"]); baseURL != "" {
 			return baseURL
+		}
+	}
+	if auth.Metadata != nil {
+		if v := auth.Metadata["base_url"]; v != nil {
+			if baseURL := strings.TrimSpace(fmt.Sprint(v)); baseURL != "" {
+				return baseURL
+			}
 		}
 	}
 	provider := strings.ToLower(strings.TrimSpace(auth.Provider))

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	proberCheckInterval         = 60 * time.Second
-	proberMinInterval           = 5 * time.Millisecond
+	proberMinInterval           = 1 * time.Second
 	proberMaxConcurrency        = 4
 	proberMaxConcurrencyCap     = 1024
 	proberRatePerMinute         = 60
@@ -344,6 +344,7 @@ func (l *authProberLoop) probeWithLimiter(parent context.Context, auth *Auth, li
 
 	var (
 		resp      *http.Response
+		probeBody []byte
 		errExec   error
 		resultErr *Error
 	)
@@ -368,8 +369,9 @@ func (l *authProberLoop) probeWithLimiter(parent context.Context, auth *Auth, li
 			}
 		}
 		resp, errExec = exec.HttpRequest(probeCtx, auth, req)
+		probeBody = nil
 		if resp != nil && resp.Body != nil {
-			_, _ = io.CopyN(io.Discard, resp.Body, proberMaxBodyBytes)
+			probeBody, _ = io.ReadAll(io.LimitReader(resp.Body, proberMaxBodyBytes))
 			_ = resp.Body.Close()
 		}
 
@@ -392,6 +394,11 @@ func (l *authProberLoop) probeWithLimiter(parent context.Context, auth *Auth, li
 				HTTPStatus: http.StatusServiceUnavailable,
 				Retryable:  true,
 			}
+		} else if proberUnsupportedMethod(resp, probeBody) ||
+			(resp.StatusCode == http.StatusNotFound && path == proberDefaultPath) {
+			// A generic probe endpoint may not exist for this provider. An
+			// unsupported method or template /models 404 is not credential failure.
+			return
 		} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			resultErr = &Error{
 				Code:       ErrorCodeForceCooldown,
@@ -478,6 +485,9 @@ var proberProviderProbePaths = map[string]string{
 	"gemini":              "/v1beta/models",
 	"gemini-interactions": "/v1beta/models",
 	"aistudio":            "/v1beta/models",
+	// Vertex uses model-specific :generateContent routes and has no generic
+	// GET /models endpoint for the prober.
+	"vertex": "",
 	"xai":                 "/v1/models",
 	"kimi":                "/v1/models",
 	"claude":              "/v1/models",
@@ -703,6 +713,20 @@ func proberProbePathForProvider(provider, configured string) string {
 }
 
 var proberURLRegex = regexp.MustCompile(`https?://[^ \t\n\r\"'<>]+`)
+
+func proberUnsupportedMethod(resp *http.Response, body []byte) bool {
+	if resp == nil {
+		return false
+	}
+	if resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented {
+		return true
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return false
+	}
+	return strings.Contains(strings.ToLower(resp.Status), "method not allowed") ||
+		strings.Contains(strings.ToLower(string(body)), "method not allowed")
+}
 
 // redactProbeError removes userinfo and query parameters from any URL that
 // appears in a transport error, so tokens in query strings are not logged or

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -287,9 +287,9 @@ func (l *authProberLoop) probe(parent context.Context, auth *Auth) {
 		return
 	}
 
-	path := strings.TrimSpace(l.cfg.DefaultProbePath)
+	path := proberProbePathForProvider(exec.Identifier(), l.cfg.DefaultProbePath)
 	if path == "" {
-		path = proberDefaultPath
+		return
 	}
 
 	probeURL, errParse := resolveProbeURL(baseURL, path)
@@ -381,6 +381,37 @@ func (l *authProberLoop) proberBackoffFor(level int) time.Duration {
 		d = l.cfg.BackoffBase
 	}
 	return d
+}
+
+// proberProviderProbePaths maps canonical executor identifiers to probe paths
+// that include the provider's API version, since the global /models default is
+// only valid for OpenAI-compatible upstreams that embed the version in base_url.
+var proberProviderProbePaths = map[string]string{
+	"gemini":              "/v1beta/models",
+	"gemini-interactions": "/v1beta/models",
+	"aistudio":            "/v1beta/models",
+	"xai":                 "/v1/models",
+	"kimi":                "/v1/models",
+}
+
+// proberProbePathForProvider returns the probe path for the provider.
+// OpenAI-compatible executors use /v1/models. Unknown providers fall back to
+// the configured default; if neither is set, the caller should skip the auth.
+func proberProbePathForProvider(provider, configured string) string {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return strings.TrimSpace(configured)
+	}
+	if p, ok := proberProviderProbePaths[provider]; ok {
+		return p
+	}
+	if provider == "openai-compatibility" || strings.HasPrefix(provider, "openai-compatible-") {
+		return "/v1/models"
+	}
+	if configured != "" {
+		return configured
+	}
+	return ""
 }
 
 // resolveProbeURL resolves the probe path against baseURL without duplicating

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -124,9 +124,13 @@ func (m *Manager) stopProberUnlocked() {
 	m.proberWg.Wait()
 }
 
-func (m *Manager) restartProberLocked(cfg *internalconfig.Config) {
-	if m == nil || cfg == nil {
+func (m *Manager) restartProberLocked() {
+	if m == nil {
 		return
+	}
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	if cfg == nil {
+		cfg = &internalconfig.Config{}
 	}
 	m.proberLifecycleMu.Lock()
 	defer m.proberLifecycleMu.Unlock()

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	proberCheckInterval         = 60 * time.Second
+	proberMinInterval           = 5 * time.Millisecond
 	proberMaxConcurrency        = 4
 	proberMaxConcurrencyCap     = 1024
 	proberRatePerMinute         = 60
@@ -39,6 +40,9 @@ type authProberLoop struct {
 func newAuthProberLoop(manager *Manager, cfg internalconfig.CredentialProberConfig) *authProberLoop {
 	if cfg.Interval <= 0 {
 		cfg.Interval = proberCheckInterval
+	}
+	if cfg.Interval < proberMinInterval {
+		cfg.Interval = proberMinInterval
 	}
 	if cfg.MaxConcurrency <= 0 {
 		cfg.MaxConcurrency = proberMaxConcurrency
@@ -498,7 +502,13 @@ func proberBaseURLForProvider(auth *Auth, cfg *internalconfig.Config) string {
 	if provider == "xai" {
 		// xAI routing depends on auth_kind/using_api as well as base_url, so use
 		// the same resolution the executor uses for chat requests.
-		return proberXAIChatBaseURL(auth)
+		baseURL := proberXAIChatBaseURL(auth)
+		if baseURL == xaiauth.CLIChatProxyBaseURL {
+			// cli-chat-proxy only accepts POST chat requests; a GET /v1/models
+			// probe would 404/405 and falsely force-cool the credential.
+			return ""
+		}
+		return baseURL
 	}
 	if auth.Attributes != nil {
 		if baseURL := strings.TrimSpace(auth.Attributes["base_url"]); baseURL != "" {

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -19,7 +19,7 @@ const (
 	proberCheckInterval  = 60 * time.Second
 	proberMaxConcurrency = 4
 	proberRatePerMinute  = 60
-	proberDefaultPath    = "/v1/models"
+	proberDefaultPath    = "/models"
 	proberMaxBodyBytes   = 1024
 )
 

--- a/sdk/cliproxy/auth/conductor_prober.go
+++ b/sdk/cliproxy/auth/conductor_prober.go
@@ -517,11 +517,16 @@ func proberBaseURLForProvider(auth *Auth, cfg *internalconfig.Config) string {
 	return ""
 }
 
+func proberIsOpenAICompatibleProvider(provider string) bool {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	return provider == "openai-compatibility" || strings.HasPrefix(provider, "openai-compatible-")
+}
+
 // proberOpenAICompatBaseURL resolves a base URL from the configured OpenAI
 // compatibility entries for custom openai-compatible providers that do not
 // carry an explicit base_url attribute.
 func proberOpenAICompatBaseURL(auth *Auth, cfg *internalconfig.Config) string {
-	if auth == nil || cfg == nil {
+	if auth == nil || cfg == nil || !proberIsOpenAICompatibleProvider(auth.Provider) {
 		return ""
 	}
 
@@ -571,7 +576,7 @@ func proberProbePathForProvider(provider, configured string) string {
 	if p, ok := proberProviderProbePaths[provider]; ok {
 		return p
 	}
-	if provider == "openai-compatibility" || strings.HasPrefix(provider, "openai-compatible-") {
+	if proberIsOpenAICompatibleProvider(provider) {
 		return "/v1/models"
 	}
 	if configured != "" {

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -21,6 +21,8 @@ type proberTestExecutor struct {
 	err           error
 	calls         atomic.Int32
 	respondStatus int
+	deadlineSet   atomic.Bool
+	ctx           context.Context
 }
 
 func (e *proberTestExecutor) Identifier() string { return e.provider }
@@ -39,8 +41,12 @@ func (e *proberTestExecutor) CountTokens(context.Context, *Auth, cliproxyexecuto
 	return cliproxyexecutor.Response{}, nil
 }
 
-func (e *proberTestExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+func (e *proberTestExecutor) HttpRequest(ctx context.Context, auth *Auth, req *http.Request) (*http.Response, error) {
 	e.calls.Add(1)
+	e.ctx = ctx
+	if _, ok := ctx.Deadline(); ok {
+		e.deadlineSet.Store(true)
+	}
 	if e.err != nil {
 		return nil, e.err
 	}
@@ -195,6 +201,39 @@ func TestProberMarksAuthUnavailableOnEmptyResponse(t *testing.T) {
 	}
 	if !updated.Unavailable {
 		t.Fatalf("auth.Unavailable = %v, want true", updated.Unavailable)
+	}
+}
+
+func TestProberDropsContextDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 24*time.Hour)
+	defer cancel()
+
+	m := NewManager(nil, nil, nil)
+	exec := &proberTestExecutor{provider: "test", statusCode: http.StatusOK}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+
+	m.StopProber()
+
+	if exec.calls.Load() == 0 {
+		t.Fatal("prober did not call executor")
+	}
+	if exec.deadlineSet.Load() {
+		t.Fatal("prober passed a context with a deadline to the executor")
+	}
+	if exec.ctx != nil {
+		if _, ok := exec.ctx.Deadline(); ok {
+			t.Fatal("prober passed a context with a deadline to the executor")
+		}
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -1326,3 +1326,119 @@ func TestProberCapsMaxConcurrency(t *testing.T) {
 		t.Fatalf("prober calls = %d, want 2", exec.calls.Load())
 	}
 }
+
+func TestProberHonorsAuthLevelCooldown(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "test"}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "test",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://example.com",
+		},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	m.MarkResult(ctx, Result{
+		AuthID:          auth.ID,
+		Provider:        auth.Provider,
+		Success:         false,
+		CredentialScope: true,
+		Error: &Error{
+			Code:       "unauthorized",
+			Message:    "auth-level 401",
+			HTTPStatus: http.StatusUnauthorized,
+			Retryable:  true,
+		},
+	})
+
+	// A model success clears the aggregate Unavailable/NextRetryAfter fields but
+	// leaves the auth-level cooldown active, so the prober must still skip it.
+	m.MarkResult(ctx, Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Success:  true,
+		Model:    "test-model",
+	})
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+
+	if exec.calls.Load() != 0 {
+		t.Fatalf("prober calls = %d, want 0 while auth-level cooldown active", exec.calls.Load())
+	}
+}
+
+func TestProberSuccessDoesNotClearNonProberCooldown(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "test"}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "test",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://example.com",
+		},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	retryAfter := time.Hour
+	m.MarkResult(ctx, Result{
+		AuthID:          auth.ID,
+		Provider:        auth.Provider,
+		Success:         false,
+		CredentialScope: true,
+		IsProbe:         true,
+		Error: &Error{
+			Code:       ErrorCodeForceCooldown,
+			Message:    "prober: unreachable",
+			HTTPStatus: http.StatusServiceUnavailable,
+			Retryable:  true,
+		},
+		RetryAfter: &retryAfter,
+	})
+
+	// A concurrent non-probe credential-scoped failure overwrites prober ownership.
+	m.MarkResult(ctx, Result{
+		AuthID:          auth.ID,
+		Provider:        auth.Provider,
+		Success:         false,
+		CredentialScope: true,
+		Error: &Error{
+			Code:       "unauthorized",
+			Message:    "auth-level 401",
+			HTTPStatus: http.StatusUnauthorized,
+			Retryable:  true,
+		},
+	})
+
+	// A later successful probe must not clear the non-prober failure.
+	m.MarkResult(ctx, Result{
+		AuthID:          auth.ID,
+		Provider:        auth.Provider,
+		Success:         true,
+		CredentialScope: true,
+		IsProbe:         true,
+	})
+
+	updated, _ := m.GetByID(auth.ID)
+	if updated == nil || !updated.Unavailable || updated.NextRetryAfter.IsZero() {
+		t.Fatalf("non-prober cooldown should survive probe success; Unavailable=%v NextRetryAfter=%v", updated.Unavailable, updated.NextRetryAfter)
+	}
+	if !updated.authLevelCooldown {
+		t.Fatalf("auth-level cooldown should survive probe success")
+	}
+}

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -35,6 +35,7 @@ type proberTestExecutor struct {
 	blockUntil    chan struct{}
 	mu            sync.Mutex
 	lastURL       string
+	lastHeaders   http.Header
 
 	refreshCalled   atomic.Bool
 	refreshToken    string
@@ -80,6 +81,7 @@ func (e *proberTestExecutor) HttpRequest(ctx context.Context, auth *Auth, req *h
 	if req != nil {
 		e.mu.Lock()
 		e.lastURL = req.URL.String()
+		e.lastHeaders = req.Header.Clone()
 		e.mu.Unlock()
 	}
 	if e.manager != nil && e.replaceAuth && auth != nil {
@@ -144,6 +146,42 @@ func TestProberHonorsMetadataBaseURL(t *testing.T) {
 	exec.mu.Unlock()
 	if url != "https://custom.x.ai/v1/models" {
 		t.Fatalf("prober URL = %q, want %q", url, "https://custom.x.ai/v1/models")
+	}
+}
+
+func TestProberSetsAnthropicVersionHeaderForClaude(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "claude"}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "claude",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://api.anthropic.com",
+		},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+
+	if exec.calls.Load() != 1 {
+		t.Fatalf("prober calls = %d, want 1", exec.calls.Load())
+	}
+	exec.mu.Lock()
+	defer exec.mu.Unlock()
+	if exec.lastURL != "https://api.anthropic.com/v1/models" {
+		t.Fatalf("prober URL = %q, want %q", exec.lastURL, "https://api.anthropic.com/v1/models")
+	}
+	if got := exec.lastHeaders.Get("Anthropic-Version"); got != "2023-06-01" {
+		t.Fatalf("Anthropic-Version header = %q, want 2023-06-01", got)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -793,6 +793,7 @@ func TestProberBackoffEscalates(t *testing.T) {
 			Provider:        auth.Provider,
 			Success:         false,
 			CredentialScope: true,
+			IsProbe:         true,
 			Error:           &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusUnauthorized, Retryable: true},
 			RetryAfter:      &d,
 		})

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -23,6 +23,7 @@ type proberTestExecutor struct {
 	respondStatus int
 	deadlineSet   atomic.Bool
 	ctx           context.Context
+	blockUntil    chan struct{}
 }
 
 func (e *proberTestExecutor) Identifier() string { return e.provider }
@@ -46,6 +47,9 @@ func (e *proberTestExecutor) HttpRequest(ctx context.Context, auth *Auth, req *h
 	e.ctx = ctx
 	if _, ok := ctx.Deadline(); ok {
 		e.deadlineSet.Store(true)
+	}
+	if e.blockUntil != nil {
+		<-e.blockUntil
 	}
 	if e.err != nil {
 		return nil, e.err
@@ -235,6 +239,85 @@ func TestProberDropsContextDeadline(t *testing.T) {
 			t.Fatal("prober passed a context with a deadline to the executor")
 		}
 	}
+}
+
+func TestProberStopWaitsForInFlightProbe(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	block := make(chan struct{})
+	exec := &proberTestExecutor{provider: "test", statusCode: http.StatusOK, blockUntil: block}
+	m.RegisterExecutor(exec)
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.StartProber(ctx, cfg)
+
+	for exec.calls.Load() == 0 {
+		time.Sleep(time.Millisecond)
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		m.StopProber()
+		close(stopDone)
+	}()
+
+	// StopProber must not return while the probe is still blocked.
+	select {
+	case <-stopDone:
+		t.Fatal("StopProber returned before the in-flight probe completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(block)
+	<-stopDone
+}
+
+func TestProberRestartDuringStopIsBlocked(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	block := make(chan struct{})
+	first := &proberTestExecutor{provider: "test", statusCode: http.StatusOK, blockUntil: block}
+	m.RegisterExecutor(first)
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.StartProber(ctx, cfg)
+
+	for first.calls.Load() == 0 {
+		time.Sleep(time.Millisecond)
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		m.StopProber()
+		close(stopDone)
+	}()
+
+	startDone := make(chan struct{})
+	go func() {
+		m.StartProber(ctx, cfg)
+		close(startDone)
+	}()
+
+	// StartProber must not start a new prober while StopProber holds the lock.
+	select {
+	case <-startDone:
+		t.Fatal("StartProber returned before StopProber released the lock")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(block)
+	<-stopDone
+	<-startDone
 }
 
 func TestProberBackoffFor(t *testing.T) {

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -867,7 +867,10 @@ func TestProberClampsRateLimit(t *testing.T) {
 		MaxConcurrency:     1,
 		RateLimitPerMinute: 100_000_000_000,
 	}})
+	time.Sleep(50 * time.Millisecond)
+	m.mu.RLock()
 	l := m.proberLoop
+	m.mu.RUnlock()
 	if l == nil {
 		t.Fatal("prober not started")
 	}
@@ -939,6 +942,69 @@ func TestProberDiscardsStaleAuthResult(t *testing.T) {
 	}
 	if updated.Unavailable {
 		t.Fatalf("stale probe result should be discarded; Unavailable = %v", updated.Unavailable)
+	}
+}
+
+type proberCallbackHook struct {
+	didCall int32
+	manager *Manager
+	cfg     internalconfig.CredentialProberConfig
+}
+
+func (h *proberCallbackHook) OnAuthRegistered(ctx context.Context, auth *Auth) {
+	atomic.AddInt32(&h.didCall, 1)
+	h.manager.SetConfig(&internalconfig.Config{CredentialProber: h.cfg})
+}
+
+func (h *proberCallbackHook) OnAuthUpdated(ctx context.Context, auth *Auth) {}
+func (h *proberCallbackHook) OnResult(ctx context.Context, result Result) {
+	if !result.Success {
+		h.manager.SetConfig(&internalconfig.Config{CredentialProber: h.cfg})
+	}
+}
+
+func TestProberSetConfigFromCallbackDoesNotDeadlock(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	h := &proberCallbackHook{cfg: cfg}
+	m := NewManager(nil, nil, h)
+	h.manager = m
+	m.SetProberParentContext(ctx)
+
+	exec := &proberTestExecutor{
+		provider:      "test",
+		statusCode:    intPtr(http.StatusUnauthorized),
+		refreshToken:  "new-token",
+		refreshStatus: http.StatusOK,
+	}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "test",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://example.com",
+		},
+		Metadata: map[string]any{"refresh_token": "old-token"},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+		time.Sleep(100 * time.Millisecond)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("deadlock: prober callback blocked on SetConfig/RestartProber")
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -1286,13 +1286,14 @@ func TestProberDiscardsStaleAuthResult(t *testing.T) {
 
 type lifecycleProberHook struct {
 	done chan struct{}
+	once sync.Once
 }
 
 func (h *lifecycleProberHook) OnAuthRegistered(context.Context, *Auth) {}
 func (h *lifecycleProberHook) OnAuthUpdated(context.Context, *Auth)    {}
 func (h *lifecycleProberHook) OnResult(ctx context.Context, _ Result) {
 	<-ctx.Done()
-	close(h.done)
+	h.once.Do(func() { close(h.done) })
 }
 
 func TestProberHookContextTiedToServiceShutdown(t *testing.T) {
@@ -1320,6 +1321,37 @@ func TestProberHookContextTiedToServiceShutdown(t *testing.T) {
 	case <-h.done:
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("hook did not return after service shutdown")
+	}
+}
+
+func TestProberHookContextCancelsOnStopProber(t *testing.T) {
+	ctx := context.Background()
+	h := &lifecycleProberHook{done: make(chan struct{})}
+	m := NewManager(nil, nil, h)
+
+	exec := &proberTestExecutor{provider: "test"}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.StartProber(ctx, cfg)
+
+	select {
+	case <-h.done:
+		t.Fatal("hook returned before StopProber")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	m.StopProber()
+
+	select {
+	case <-h.done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("hook did not return after StopProber")
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -380,6 +380,44 @@ func TestProberRestartDuringStopIsBlocked(t *testing.T) {
 	<-startDone
 }
 
+func TestSetConfigDoesNotDeadlockWithFailingProbe(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	m.SetCooldownStateStore(&recordingCooldownStateStore{})
+
+	block := make(chan struct{})
+	exec := &proberTestExecutor{provider: "test", err: fmt.Errorf("upstream unreachable"), blockUntil: block}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	for exec.calls.Load() == 0 {
+		time.Sleep(time.Millisecond)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+		close(done)
+	}()
+
+	// Give SetConfig time to reach the restart, then let the probe finish.
+	time.Sleep(50 * time.Millisecond)
+	close(block)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SetConfig deadlocked with failing probe")
+	}
+}
+
 func TestProberBackoffFor(t *testing.T) {
 	l := newAuthProberLoop(nil, internalconfig.CredentialProberConfig{BackoffBase: 30 * time.Second, BackoffMax: 5 * time.Minute})
 	cases := []struct {

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -1043,6 +1043,47 @@ func TestProberBaseURLIgnoresOpenAICompatIndexForNativeProvider(t *testing.T) {
 	}
 }
 
+func TestProberXAIRoutesOAuthDefaultToCLIChatProxy(t *testing.T) {
+	cases := []struct {
+		name string
+		auth *Auth
+		want string
+	}{
+		{
+			name: "oauth default no base_url",
+			auth: &Auth{Provider: "xai", Attributes: map[string]string{"auth_kind": "oauth"}},
+			want: "https://cli-chat-proxy.grok.com/v1",
+		},
+		{
+			name: "oauth default official base_url",
+			auth: &Auth{Provider: "xai", Attributes: map[string]string{"auth_kind": "oauth", "base_url": "https://api.x.ai/v1"}},
+			want: "https://cli-chat-proxy.grok.com/v1",
+		},
+		{
+			name: "api-key default no base_url",
+			auth: &Auth{Provider: "xai", Attributes: map[string]string{"api_key": "secret"}},
+			want: "https://api.x.ai/v1",
+		},
+		{
+			name: "using_api true keeps official base",
+			auth: &Auth{Provider: "xai", Attributes: map[string]string{"auth_kind": "oauth", "using_api": "true", "base_url": "https://api.x.ai/v1"}},
+			want: "https://api.x.ai/v1",
+		},
+		{
+			name: "oauth explicit custom base_url",
+			auth: &Auth{Provider: "xai", Attributes: map[string]string{"auth_kind": "oauth", "base_url": "https://gateway.example.com/v1"}},
+			want: "https://gateway.example.com/v1",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := proberBaseURLForProvider(c.auth, nil); got != c.want {
+				t.Fatalf("proberBaseURLForProvider() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
 func TestProberRefreshOn401(t *testing.T) {
 	ctx := context.Background()
 	m := newProberManager()

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -1292,3 +1292,37 @@ func TestProberRestartGoroutineDoesNotSurviveParentCancel(t *testing.T) {
 		t.Fatalf("prober calls = %d, want 1 after canceled parent restart", exec.calls.Load())
 	}
 }
+
+func TestProberCapsMaxConcurrency(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "test"}
+	m.RegisterExecutor(exec)
+
+	for i := 0; i < 2; i++ {
+		auth := &Auth{
+			ID:       fmt.Sprintf("a%d", i),
+			Provider: "test",
+			Status:   StatusActive,
+			Attributes: map[string]string{
+				"base_url": "https://example.com",
+			},
+		}
+		if _, err := m.Register(ctx, auth); err != nil {
+			t.Fatalf("Register: %v", err)
+		}
+	}
+
+	cfg := internalconfig.CredentialProberConfig{
+		Enabled:            true,
+		MaxConcurrency:     1 << 30,
+		RateLimitPerMinute: 1000,
+	}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(200 * time.Millisecond)
+
+	if exec.calls.Load() != 2 {
+		t.Fatalf("prober calls = %d, want 2", exec.calls.Load())
+	}
+}

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -26,6 +26,7 @@ func newProberManager() *Manager {
 type proberTestExecutor struct {
 	provider      string
 	statusCode    *int
+	statusSeq     []int
 	body          string
 	err           error
 	calls         atomic.Int32
@@ -98,7 +99,10 @@ func (e *proberTestExecutor) HttpRequest(ctx context.Context, auth *Auth, req *h
 	}
 	e.mu.Lock()
 	status := 0
-	if e.statusCode != nil {
+	callIdx := int(e.calls.Load() - 1)
+	if callIdx >= 0 && callIdx < len(e.statusSeq) {
+		status = e.statusSeq[callIdx]
+	} else if e.statusCode != nil {
 		status = *e.statusCode
 	}
 	if status <= 0 {
@@ -1269,6 +1273,117 @@ func TestProberUsesOpenAICompatBaseURL(t *testing.T) {
 	exec.mu.Unlock()
 	if url != "https://custom.example.com/v1/models" {
 		t.Fatalf("prober URL = %q, want %q", url, "https://custom.example.com/v1/models")
+	}
+}
+
+func TestProberRefreshOn401WaitsForRateLimitToken(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{
+		provider:     "test",
+		statusSeq:    []int{http.StatusUnauthorized, http.StatusOK},
+		refreshToken: "new-token",
+	}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "test",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://example.com",
+		},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	loop := newAuthProberLoop(m, cfg)
+
+	limiter := make(chan time.Time)
+	done := make(chan struct{})
+	go func() {
+		loop.probeWithLimiter(ctx, auth, limiter)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	if got := exec.calls.Load(); got != 1 {
+		t.Fatalf("prober calls before retry = %d, want 1", got)
+	}
+
+	select {
+	case <-done:
+		t.Fatal("probe finished before retry token was provided")
+	default:
+	}
+
+	limiter <- time.Now()
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("probe did not complete after retry token")
+	}
+
+	if got := exec.calls.Load(); got != 2 {
+		t.Fatalf("prober calls = %d, want 2", got)
+	}
+	if !exec.refreshCalled.Load() {
+		t.Fatal("Refresh not called on 401")
+	}
+}
+
+func TestRestartProberReadsConfigAfterLifecycleLock(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "test"}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "test",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://example.com",
+		},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	enabled := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	disabled := internalconfig.CredentialProberConfig{Enabled: false}
+
+	m.SetProberParentContext(ctx)
+	m.SetConfig(&internalconfig.Config{CredentialProber: enabled})
+	time.Sleep(100 * time.Millisecond)
+
+	m.mu.RLock()
+	runningBefore := m.proberLoop != nil
+	m.mu.RUnlock()
+	if !runningBefore {
+		t.Fatal("prober should be running with enabled config")
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(2)
+		go func() { defer wg.Done(); m.SetConfig(&internalconfig.Config{CredentialProber: enabled}) }()
+		go func() { defer wg.Done(); m.RestartProber() }()
+	}
+	wg.Wait()
+
+	m.SetConfig(&internalconfig.Config{CredentialProber: disabled})
+	m.RestartProber()
+	time.Sleep(100 * time.Millisecond)
+
+	m.mu.RLock()
+	runningAfter := m.proberLoop != nil
+	m.mu.RUnlock()
+	if runningAfter {
+		t.Fatal("prober should be stopped with disabled config")
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -1327,6 +1327,52 @@ func TestProberCapsMaxConcurrency(t *testing.T) {
 	}
 }
 
+func TestProberNotBlockedByModelOnlyCooldown(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "test"}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "test",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://example.com",
+		},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	m.MarkResult(ctx, Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Success:  false,
+		Model:    "missing-model",
+		Error: &Error{
+			Code:       "rate_limit",
+			Message:    "model rate limited",
+			HTTPStatus: http.StatusTooManyRequests,
+			Retryable:  true,
+		},
+	})
+
+	updated, _ := m.GetByID(auth.ID)
+	if updated == nil || !updated.Unavailable {
+		t.Fatal("expected aggregate Unavailable after model-only failure")
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+
+	if exec.calls.Load() != 1 {
+		t.Fatalf("prober calls = %d, want 1 for model-only cooldown", exec.calls.Load())
+	}
+}
+
 func TestProberHonorsAuthLevelCooldown(t *testing.T) {
 	ctx := context.Background()
 	m := newProberManager()

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -895,13 +895,16 @@ func TestProberProbePathForProvider(t *testing.T) {
 		configured string
 		want       string
 	}{
-		{"gemini", "/models", "/v1beta/models"},
+		{"gemini", "", "/v1beta/models"},
 		{"Gemini", "", "/v1beta/models"},
-		{"aistudio", "/models", "/v1beta/models"},
-		{"xai", "/models", "/v1/models"},
-		{"kimi", "/models", "/v1/models"},
-		{"openai-compatible-groq", "/models", "/v1/models"},
+		{"aistudio", "", "/v1beta/models"},
+		{"xai", "", "/v1/models"},
+		{"kimi", "", "/v1/models"},
+		{"openai-compatible-groq", "", "/v1/models"},
 		{"openai-compatibility", "", "/v1/models"},
+		{"gemini", "/health", "/health"},
+		{"claude", "/v1/health", "/v1/health"},
+		{"openai-compatible-groq", "/custom", "/custom"},
 		{"test", "/models", "/models"},
 		{"test", "", ""},
 	}

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -1,0 +1,199 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type proberTestExecutor struct {
+	provider      string
+	statusCode    int
+	body          string
+	err           error
+	calls         atomic.Int32
+	respondStatus int
+}
+
+func (e *proberTestExecutor) Identifier() string { return e.provider }
+
+func (e *proberTestExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *proberTestExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+
+func (e *proberTestExecutor) Refresh(context.Context, *Auth) (*Auth, error) { return nil, nil }
+
+func (e *proberTestExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *proberTestExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	e.calls.Add(1)
+	if e.err != nil {
+		return nil, e.err
+	}
+	status := e.statusCode
+	if status <= 0 {
+		status = e.respondStatus
+	}
+	if status <= 0 {
+		status = http.StatusOK
+	}
+	body := e.body
+	if body == "" {
+		body = "{}"
+	}
+	return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(body))}, nil
+}
+
+func TestProberDisabledByDefault(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	exec := &proberTestExecutor{provider: "test"}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: false}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+	if exec.calls.Load() != 0 {
+		t.Fatalf("prober called disabled executor %d times", exec.calls.Load())
+	}
+}
+
+func TestProberSkipsDisabledAuth(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	exec := &proberTestExecutor{provider: "test", err: fmt.Errorf("boom")}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusDisabled, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+	if exec.calls.Load() != 0 {
+		t.Fatalf("prober probed disabled auth %d times", exec.calls.Load())
+	}
+}
+
+func TestProberMarksAuthUnavailableOnFailure(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	exec := &proberTestExecutor{provider: "test", err: fmt.Errorf("upstream unreachable")}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	// wait for the immediate first sweep
+	time.Sleep(100 * time.Millisecond)
+
+	m.mu.RLock()
+	updated := m.auths["a1"]
+	m.mu.RUnlock()
+
+	if updated == nil {
+		t.Fatal("auth disappeared")
+	}
+	if exec.calls.Load() != 1 {
+		t.Fatalf("prober calls = %d, want 1", exec.calls.Load())
+	}
+	if !updated.Unavailable {
+		t.Fatalf("auth.Unavailable = %v, want true", updated.Unavailable)
+	}
+	if updated.Status != StatusError {
+		t.Fatalf("auth.Status = %v, want %v", updated.Status, StatusError)
+	}
+	if updated.NextRetryAfter.IsZero() {
+		t.Fatalf("auth.NextRetryAfter not set after prober failure")
+	}
+}
+
+func TestProberLeavesAuthActiveOnSuccess(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	exec := &proberTestExecutor{provider: "test", statusCode: http.StatusOK}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+
+	m.mu.RLock()
+	updated := m.auths["a1"]
+	m.mu.RUnlock()
+
+	if updated == nil {
+		t.Fatal("auth disappeared")
+	}
+	if exec.calls.Load() != 1 {
+		t.Fatalf("prober calls = %d, want 1", exec.calls.Load())
+	}
+	if updated.Unavailable {
+		t.Fatalf("auth.Unavailable = %v, want false", updated.Unavailable)
+	}
+	if updated.Status != StatusActive {
+		t.Fatalf("auth.Status = %v, want %v", updated.Status, StatusActive)
+	}
+}
+
+func TestProberMarksAuthUnavailableOnEmptyResponse(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	exec := &proberTestExecutor{provider: "test", statusCode: http.StatusNoContent}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+
+	m.mu.RLock()
+	updated := m.auths["a1"]
+	m.mu.RUnlock()
+
+	if updated == nil {
+		t.Fatal("auth disappeared")
+	}
+	if !updated.Unavailable {
+		t.Fatalf("auth.Unavailable = %v, want true", updated.Unavailable)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -15,6 +15,8 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
+func intPtr(v int) *int { return &v }
+
 func newProberManager() *Manager {
 	m := NewManager(nil, nil, nil)
 	m.SetProberParentContext(context.Background())
@@ -23,7 +25,7 @@ func newProberManager() *Manager {
 
 type proberTestExecutor struct {
 	provider      string
-	statusCode    int
+	statusCode    *int
 	body          string
 	err           error
 	calls         atomic.Int32
@@ -33,6 +35,12 @@ type proberTestExecutor struct {
 	blockUntil    chan struct{}
 	mu            sync.Mutex
 	lastURL       string
+
+	refreshCalled atomic.Bool
+	refreshToken  string
+	refreshStatus int
+	manager       *Manager
+	replaceAuth   bool
 }
 
 func (e *proberTestExecutor) Identifier() string { return e.provider }
@@ -45,7 +53,18 @@ func (e *proberTestExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecu
 	return nil, nil
 }
 
-func (e *proberTestExecutor) Refresh(context.Context, *Auth) (*Auth, error) { return nil, nil }
+func (e *proberTestExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	if e.refreshToken == "" {
+		return nil, nil
+	}
+	e.refreshCalled.Store(true)
+	refreshed := auth.Clone()
+	if refreshed.Metadata == nil {
+		refreshed.Metadata = map[string]any{}
+	}
+	refreshed.Metadata["access_token"] = e.refreshToken
+	return refreshed, nil
+}
 
 func (e *proberTestExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	return cliproxyexecutor.Response{}, nil
@@ -59,6 +78,9 @@ func (e *proberTestExecutor) HttpRequest(ctx context.Context, auth *Auth, req *h
 		e.lastURL = req.URL.String()
 		e.mu.Unlock()
 	}
+	if e.manager != nil && e.replaceAuth && auth != nil {
+		e.manager.Register(ctx, auth.Clone())
+	}
 	if _, ok := ctx.Deadline(); ok {
 		e.deadlineSet.Store(true)
 	}
@@ -68,17 +90,25 @@ func (e *proberTestExecutor) HttpRequest(ctx context.Context, auth *Auth, req *h
 	if e.err != nil {
 		return nil, e.err
 	}
-	status := e.statusCode
+	e.mu.Lock()
+	status := 0
+	if e.statusCode != nil {
+		status = *e.statusCode
+	}
 	if status <= 0 {
 		status = e.respondStatus
 	}
 	if status <= 0 {
 		status = http.StatusOK
 	}
+	if e.refreshCalled.Load() && e.refreshStatus > 0 {
+		status = e.refreshStatus
+	}
 	body := e.body
 	if body == "" {
 		body = "{}"
 	}
+	e.mu.Unlock()
 	return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(body))}, nil
 }
 
@@ -163,7 +193,7 @@ func TestProberMarksAuthUnavailableOnFailure(t *testing.T) {
 func TestProberLeavesAuthActiveOnSuccess(t *testing.T) {
 	ctx := context.Background()
 	m := newProberManager()
-	exec := &proberTestExecutor{provider: "test", statusCode: http.StatusOK}
+	exec := &proberTestExecutor{provider: "test", statusCode: intPtr(http.StatusOK)}
 	m.RegisterExecutor(exec)
 
 	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
@@ -199,7 +229,7 @@ func TestProberUsesCanonicalExecutorKey(t *testing.T) {
 	m := newProberManager()
 
 	// Executor is registered under the lower-cased canonical key.
-	exec := &proberTestExecutor{provider: "openai", statusCode: http.StatusOK}
+	exec := &proberTestExecutor{provider: "openai", statusCode: intPtr(http.StatusOK)}
 	m.RegisterExecutor(exec)
 
 	auth := &Auth{
@@ -228,7 +258,7 @@ func TestProberUsesCompatNameExecutorKey(t *testing.T) {
 	ctx := context.Background()
 	m := newProberManager()
 
-	exec := &proberTestExecutor{provider: "openai-compatible-custom", statusCode: http.StatusOK}
+	exec := &proberTestExecutor{provider: "openai-compatible-custom", statusCode: intPtr(http.StatusOK)}
 	m.RegisterExecutor(exec)
 
 	auth := &Auth{
@@ -254,10 +284,10 @@ func TestProberUsesCompatNameExecutorKey(t *testing.T) {
 	}
 }
 
-func TestProberMarksAuthUnavailableOnEmptyResponse(t *testing.T) {
+func TestProberAcceptsNoContentResponse(t *testing.T) {
 	ctx := context.Background()
 	m := newProberManager()
-	exec := &proberTestExecutor{provider: "test", statusCode: http.StatusNoContent}
+	exec := &proberTestExecutor{provider: "test", statusCode: intPtr(http.StatusNoContent)}
 	m.RegisterExecutor(exec)
 
 	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
@@ -277,8 +307,11 @@ func TestProberMarksAuthUnavailableOnEmptyResponse(t *testing.T) {
 	if updated == nil {
 		t.Fatal("auth disappeared")
 	}
-	if !updated.Unavailable {
-		t.Fatalf("auth.Unavailable = %v, want true", updated.Unavailable)
+	if updated.Unavailable {
+		t.Fatalf("auth.Unavailable = %v, want false", updated.Unavailable)
+	}
+	if updated.proberBackoff != 0 {
+		t.Fatalf("auth.proberBackoff = %d, want 0", updated.proberBackoff)
 	}
 }
 
@@ -287,7 +320,7 @@ func TestProberDropsContextDeadline(t *testing.T) {
 	defer cancel()
 
 	m := newProberManager()
-	exec := &proberTestExecutor{provider: "test", statusCode: http.StatusOK}
+	exec := &proberTestExecutor{provider: "test", statusCode: intPtr(http.StatusOK)}
 	m.RegisterExecutor(exec)
 
 	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
@@ -324,7 +357,7 @@ func TestProberStopWaitsForInFlightProbe(t *testing.T) {
 	}
 
 	block := make(chan struct{})
-	exec := &proberTestExecutor{provider: "test", statusCode: http.StatusOK, blockUntil: block}
+	exec := &proberTestExecutor{provider: "test", statusCode: intPtr(http.StatusOK), blockUntil: block}
 	m.RegisterExecutor(exec)
 
 	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
@@ -360,7 +393,7 @@ func TestProberRestartDuringStopIsBlocked(t *testing.T) {
 	}
 
 	block := make(chan struct{})
-	first := &proberTestExecutor{provider: "test", statusCode: http.StatusOK, blockUntil: block}
+	first := &proberTestExecutor{provider: "test", statusCode: intPtr(http.StatusOK), blockUntil: block}
 	m.RegisterExecutor(first)
 
 	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
@@ -435,7 +468,7 @@ func TestSetConfigDoesNotDeadlockWithFailingProbe(t *testing.T) {
 func TestProberDoesNotStartBeforeParentContext(t *testing.T) {
 	ctx := context.Background()
 	m := NewManager(nil, nil, nil)
-	exec := &proberTestExecutor{provider: "test", statusCode: http.StatusOK}
+	exec := &proberTestExecutor{provider: "test", statusCode: intPtr(http.StatusOK)}
 	m.RegisterExecutor(exec)
 
 	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
@@ -463,7 +496,7 @@ func TestProberDoesNotStartBeforeParentContext(t *testing.T) {
 func TestProberUsesProviderSpecificProbePath(t *testing.T) {
 	ctx := context.Background()
 	m := newProberManager()
-	exec := &proberTestExecutor{provider: "gemini", statusCode: http.StatusOK}
+	exec := &proberTestExecutor{provider: "gemini", statusCode: intPtr(http.StatusOK)}
 	m.RegisterExecutor(exec)
 
 	auth := &Auth{
@@ -695,6 +728,217 @@ func TestProberProbePathForProvider(t *testing.T) {
 		if got := proberProbePathForProvider(c.provider, c.configured); got != c.want {
 			t.Fatalf("proberProbePathForProvider(%q, %q) = %q, want %q", c.provider, c.configured, got, c.want)
 		}
+	}
+}
+
+func TestProberRedactsTransportErrorURL(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "test", err: fmt.Errorf("Get \"https://example.com/v1/models?api_key=super-secret-token&x=1\": connection refused")}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+
+	updated, _ := m.GetByID(auth.ID)
+	if updated == nil || updated.LastError == nil {
+		t.Fatal("expected LastError")
+	}
+	if strings.Contains(updated.LastError.Message, "api_key=super-secret-token") || strings.Contains(updated.LastError.Message, "super-secret") {
+		t.Fatalf("LastError message leaks token: %s", updated.LastError.Message)
+	}
+}
+
+func TestProberUsesDefaultBaseURL(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "claude"}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "claude", Status: StatusActive}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+
+	if exec.calls.Load() != 1 {
+		t.Fatalf("prober calls = %d, want 1", exec.calls.Load())
+	}
+	exec.mu.Lock()
+	url := exec.lastURL
+	exec.mu.Unlock()
+	if url != "https://api.anthropic.com/v1/models" {
+		t.Fatalf("prober URL = %q, want %q", url, "https://api.anthropic.com/v1/models")
+	}
+}
+
+func TestProberDoesNotCountStats(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "test", statusCode: intPtr(http.StatusInternalServerError)}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+
+	updated, _ := m.GetByID(auth.ID)
+	if updated == nil {
+		t.Fatal("auth disappeared")
+	}
+	if !updated.Unavailable {
+		t.Fatalf("auth.Unavailable = %v, want true", updated.Unavailable)
+	}
+	if updated.Success != 0 || updated.Failed != 0 {
+		t.Fatalf("auth stats = %d/%d, want 0/0", updated.Success, updated.Failed)
+	}
+}
+
+func TestProberClearsProberStateOnRecovery(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "test", statusCode: intPtr(http.StatusInternalServerError)}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{
+		Enabled:            true,
+		Interval:           50 * time.Millisecond,
+		MaxConcurrency:     1,
+		RateLimitPerMinute: 1000,
+		BackoffBase:        25 * time.Millisecond,
+		BackoffMax:         100 * time.Millisecond,
+	}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+
+	updated, _ := m.GetByID(auth.ID)
+	if updated == nil || !updated.Unavailable {
+		t.Fatal("auth should be unavailable after first failure")
+	}
+
+	exec.mu.Lock()
+	*exec.statusCode = http.StatusOK
+	exec.mu.Unlock()
+	time.Sleep(200 * time.Millisecond)
+
+	updated, _ = m.GetByID(auth.ID)
+	if updated == nil {
+		t.Fatal("auth disappeared")
+	}
+	if updated.Unavailable {
+		t.Fatalf("auth.Unavailable = %v, want false", updated.Unavailable)
+	}
+	if updated.proberBackoff != 0 {
+		t.Fatalf("auth.proberBackoff = %d, want 0", updated.proberBackoff)
+	}
+	if updated.LastError != nil && strings.Contains(updated.LastError.Message, "prober:") {
+		t.Fatalf("auth.LastError not cleared: %v", updated.LastError)
+	}
+}
+
+func TestProberClampsRateLimit(t *testing.T) {
+	m := newProberManager()
+	m.SetConfig(&internalconfig.Config{CredentialProber: internalconfig.CredentialProberConfig{
+		Enabled:            true,
+		Interval:           time.Hour,
+		MaxConcurrency:     1,
+		RateLimitPerMinute: 100_000_000_000,
+	}})
+	l := m.proberLoop
+	if l == nil {
+		t.Fatal("prober not started")
+	}
+	if l.cfg.RateLimitPerMinute != proberMaxRateLimitPerMinute {
+		t.Fatalf("RateLimitPerMinute = %d, want %d", l.cfg.RateLimitPerMinute, proberMaxRateLimitPerMinute)
+	}
+}
+
+func TestProberRefreshOn401(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{
+		provider:      "test",
+		statusCode:    intPtr(http.StatusUnauthorized),
+		refreshToken:  "new-token",
+		refreshStatus: http.StatusOK,
+	}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "test",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://example.com",
+		},
+		Metadata: map[string]any{"refresh_token": "old-token"},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(200 * time.Millisecond)
+
+	if !exec.refreshCalled.Load() {
+		t.Fatal("Refresh not called on 401")
+	}
+	if exec.calls.Load() < 2 {
+		t.Fatalf("prober calls = %d, want >= 2", exec.calls.Load())
+	}
+	updated, _ := m.GetByID(auth.ID)
+	if updated == nil || updated.Unavailable {
+		t.Fatalf("auth should recover after refresh; Unavailable = %v", updated.Unavailable)
+	}
+}
+
+func TestProberDiscardsStaleAuthResult(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "test", statusCode: intPtr(http.StatusInternalServerError), manager: m, replaceAuth: true}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+
+	updated, _ := m.GetByID(auth.ID)
+	if updated == nil {
+		t.Fatal("auth disappeared")
+	}
+	if updated.Unavailable {
+		t.Fatalf("stale probe result should be discarded; Unavailable = %v", updated.Unavailable)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -1018,6 +1018,31 @@ func TestProberBaseURLCaseInsensitiveOpenAICompatName(t *testing.T) {
 	}
 }
 
+func TestProberBaseURLIgnoresOpenAICompatIndexForNativeProvider(t *testing.T) {
+	cfg := &internalconfig.Config{
+		OpenAICompatibility: []internalconfig.OpenAICompatibility{
+			{
+				Name:    "native-looking",
+				BaseURL: "https://compat.example.com/v1",
+			},
+		},
+	}
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "claude",
+		Attributes: map[string]string{
+			"config_index": "0",
+		},
+	}
+	if got := proberBaseURLForProvider(auth, cfg); got != "https://api.anthropic.com" {
+		t.Fatalf("proberBaseURLForProvider() = %q, want %q", got, "https://api.anthropic.com")
+	}
+	if got := proberOpenAICompatBaseURL(auth, cfg); got != "" {
+		t.Fatalf("proberOpenAICompatBaseURL() = %q, want empty", got)
+	}
+}
+
 func TestProberRefreshOn401(t *testing.T) {
 	ctx := context.Background()
 	m := newProberManager()

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -1284,6 +1284,45 @@ func TestProberDiscardsStaleAuthResult(t *testing.T) {
 	}
 }
 
+type lifecycleProberHook struct {
+	done chan struct{}
+}
+
+func (h *lifecycleProberHook) OnAuthRegistered(context.Context, *Auth) {}
+func (h *lifecycleProberHook) OnAuthUpdated(context.Context, *Auth)    {}
+func (h *lifecycleProberHook) OnResult(ctx context.Context, _ Result) {
+	<-ctx.Done()
+	close(h.done)
+}
+
+func TestProberHookContextTiedToServiceShutdown(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	h := &lifecycleProberHook{done: make(chan struct{})}
+	m := NewManager(nil, nil, h)
+	m.SetProberParentContext(parent)
+
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	m.MarkResult(context.Background(), Result{AuthID: "a1", Provider: "test", Success: true, IsProbe: true})
+
+	select {
+	case <-h.done:
+		t.Fatal("hook returned before service shutdown")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case <-h.done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("hook did not return after service shutdown")
+	}
+}
+
 type proberCallbackHook struct {
 	didCall int32
 	manager *Manager

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -535,6 +535,51 @@ func TestProberIgnoresCancellationResult(t *testing.T) {
 	}
 }
 
+func TestProberDiscardsResultIfAuthReplaced(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	block := make(chan struct{})
+	exec := &proberTestExecutor{provider: "test", err: fmt.Errorf("unauthorized"), blockUntil: block}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "test",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://example.com",
+		},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.StartProber(ctx, cfg)
+
+	for exec.calls.Load() == 0 {
+		time.Sleep(time.Millisecond)
+	}
+
+	auth2 := auth.Clone()
+	auth2.Metadata = map[string]any{"token": "refreshed"}
+	if _, err := m.Register(ctx, auth2); err != nil {
+		t.Fatalf("Register replacement: %v", err)
+	}
+
+	close(block)
+	time.Sleep(100 * time.Millisecond)
+	m.StopProber()
+
+	updated, ok := m.GetByID("a1")
+	if !ok {
+		t.Fatal("auth not found")
+	}
+	if updated.Unavailable || !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("probe result for stale credential should have been discarded; got Unavailable=%v NextRetryAfter=%v", updated.Unavailable, updated.NextRetryAfter)
+	}
+}
+
 func TestProberBackoffFor(t *testing.T) {
 	l := newAuthProberLoop(nil, internalconfig.CredentialProberConfig{BackoffBase: 30 * time.Second, BackoffMax: 5 * time.Minute})
 	cases := []struct {

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -493,6 +493,48 @@ func TestProberUsesProviderSpecificProbePath(t *testing.T) {
 	}
 }
 
+func TestProberIgnoresCancellationResult(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	block := make(chan struct{})
+	exec := &proberTestExecutor{provider: "test", blockUntil: block}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.StartProber(ctx, cfg)
+
+	for exec.calls.Load() == 0 {
+		time.Sleep(time.Millisecond)
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		m.StopProber()
+		close(stopDone)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(block)
+
+	select {
+	case <-stopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StopProber timed out")
+	}
+
+	m.mu.RLock()
+	updated := m.auths["a1"]
+	m.mu.RUnlock()
+	if updated != nil && (updated.Unavailable || !updated.NextRetryAfter.IsZero()) {
+		t.Fatalf("canceled probe should not mark auth unavailable; got Unavailable=%v NextRetryAfter=%v", updated.Unavailable, updated.NextRetryAfter)
+	}
+}
+
 func TestProberBackoffFor(t *testing.T) {
 	l := newAuthProberLoop(nil, internalconfig.CredentialProberConfig{BackoffBase: 30 * time.Second, BackoffMax: 5 * time.Minute})
 	cases := []struct {

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -197,3 +197,30 @@ func TestProberMarksAuthUnavailableOnEmptyResponse(t *testing.T) {
 		t.Fatalf("auth.Unavailable = %v, want true", updated.Unavailable)
 	}
 }
+
+func TestResolveProbeURL(t *testing.T) {
+	cases := []struct {
+		baseURL string
+		path    string
+		want    string
+	}{
+		{"https://api.openai.com/v1", "/models", "https://api.openai.com/v1/models"},
+		{"https://api.x.ai/v1", "/models", "https://api.x.ai/v1/models"},
+		{"https://generativelanguage.googleapis.com/v1beta", "/models", "https://generativelanguage.googleapis.com/v1beta/models"},
+		{"https://example.com", "/models", "https://example.com/models"},
+		{"https://example.com/v1", "/v1/models", "https://example.com/v1/models"},
+		{"https://example.com/v1/", "/v1/models", "https://example.com/v1/models"},
+		{"https://example.com/v1/models", "/models", "https://example.com/v1/models"},
+		{"https://example.com", "/v1/models", "https://example.com/v1/models"},
+	}
+
+	for _, c := range cases {
+		got, err := resolveProbeURL(c.baseURL, c.path)
+		if err != nil {
+			t.Fatalf("resolveProbeURL(%q, %q): %v", c.baseURL, c.path, err)
+		}
+		if got != c.want {
+			t.Fatalf("resolveProbeURL(%q, %q) = %q, want %q", c.baseURL, c.path, got, c.want)
+		}
+	}
+}

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -36,11 +36,12 @@ type proberTestExecutor struct {
 	mu            sync.Mutex
 	lastURL       string
 
-	refreshCalled atomic.Bool
-	refreshToken  string
-	refreshStatus int
-	manager       *Manager
-	replaceAuth   bool
+	refreshCalled   atomic.Bool
+	refreshToken    string
+	refreshStatus   int
+	manager         *Manager
+	replaceAuth     bool
+	lastRefreshAuth *Auth
 }
 
 func (e *proberTestExecutor) Identifier() string { return e.provider }
@@ -54,10 +55,13 @@ func (e *proberTestExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecu
 }
 
 func (e *proberTestExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	e.refreshCalled.Store(true)
+	e.mu.Lock()
+	e.lastRefreshAuth = auth
+	e.mu.Unlock()
 	if e.refreshToken == "" {
 		return nil, nil
 	}
-	e.refreshCalled.Store(true)
 	refreshed := auth.Clone()
 	if refreshed.Metadata == nil {
 		refreshed.Metadata = map[string]any{}
@@ -1032,5 +1036,152 @@ func TestResolveProbeURL(t *testing.T) {
 		if got != c.want {
 			t.Fatalf("resolveProbeURL(%q, %q) = %q, want %q", c.baseURL, c.path, got, c.want)
 		}
+	}
+}
+
+func TestProberSkipsCodexWithoutBaseURL(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "codex"}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "codex", Status: StatusActive}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+	if exec.calls.Load() != 0 {
+		t.Fatalf("prober calls = %d, want 0 for codex without base_url", exec.calls.Load())
+	}
+}
+
+func TestProberUsesOpenAICompatBaseURL(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "openai-compatible-my-comp"}
+	m.RegisterExecutor(exec)
+
+	cfg := &internalconfig.Config{
+		CredentialProber: internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000},
+		OpenAICompatibility: []internalconfig.OpenAICompatibility{
+			{Name: "my-comp", BaseURL: "https://custom.example.com"},
+		},
+	}
+	m.SetConfig(cfg)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "openai-compatibility",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"compat_name": "my-comp",
+		},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	if exec.calls.Load() != 1 {
+		t.Fatalf("prober calls = %d, want 1", exec.calls.Load())
+	}
+	exec.mu.Lock()
+	url := exec.lastURL
+	exec.mu.Unlock()
+	if url != "https://custom.example.com/v1/models" {
+		t.Fatalf("prober URL = %q, want %q", url, "https://custom.example.com/v1/models")
+	}
+}
+
+func TestProberRefreshOn401DoesNotPassLiveAuthPointer(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{
+		provider:      "test",
+		statusCode:    intPtr(http.StatusUnauthorized),
+		refreshToken:  "new-token",
+		refreshStatus: http.StatusOK,
+	}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "test",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://example.com",
+		},
+		Metadata: map[string]any{"refresh_token": "old-token"},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(200 * time.Millisecond)
+
+	if !exec.refreshCalled.Load() {
+		t.Fatal("Refresh not called on 401")
+	}
+	exec.mu.Lock()
+	lastRefreshAuth := exec.lastRefreshAuth
+	exec.mu.Unlock()
+	if lastRefreshAuth == auth {
+		t.Fatal("Refresh received live auth pointer, want a clone")
+	}
+	updated, _ := m.GetByID(auth.ID)
+	if updated == nil || updated.Unavailable {
+		t.Fatalf("auth should recover after refresh; Unavailable = %v", updated.Unavailable)
+	}
+}
+
+func TestProberRestartGoroutineDoesNotSurviveParentCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "test", statusCode: intPtr(http.StatusOK)}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "test",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://example.com",
+		},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	m.SetProberParentContext(ctx)
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+	if exec.calls.Load() != 1 {
+		t.Fatalf("prober calls = %d, want 1 before parent cancel", exec.calls.Load())
+	}
+
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+	m.StopProber()
+
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+	time.Sleep(100 * time.Millisecond)
+
+	m.mu.RLock()
+	loop := m.proberLoop
+	m.mu.RUnlock()
+	if loop != nil {
+		t.Fatal("prober restarted after parent context was canceled")
+	}
+	if exec.calls.Load() != 1 {
+		t.Fatalf("prober calls = %d, want 1 after canceled parent restart", exec.calls.Load())
 	}
 }

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -985,6 +985,26 @@ func TestProberClampsRateLimit(t *testing.T) {
 	}
 }
 
+func TestProberClampsMinimumInterval(t *testing.T) {
+	m := newProberManager()
+	m.SetConfig(&internalconfig.Config{CredentialProber: internalconfig.CredentialProberConfig{
+		Enabled:            true,
+		Interval:           1,
+		MaxConcurrency:     1,
+		RateLimitPerMinute: 1000,
+	}})
+	time.Sleep(20 * time.Millisecond)
+	m.mu.RLock()
+	l := m.proberLoop
+	m.mu.RUnlock()
+	if l == nil {
+		t.Fatal("prober not started")
+	}
+	if l.cfg.Interval != proberMinInterval {
+		t.Fatalf("Interval = %v, want %v", l.cfg.Interval, proberMinInterval)
+	}
+}
+
 func TestProberBaseURLCaseInsensitiveOpenAICompatName(t *testing.T) {
 	cfg := &internalconfig.Config{
 		OpenAICompatibility: []internalconfig.OpenAICompatibility{
@@ -1043,24 +1063,24 @@ func TestProberBaseURLIgnoresOpenAICompatIndexForNativeProvider(t *testing.T) {
 	}
 }
 
-func TestProberXAIRoutesOAuthDefaultToCLIChatProxy(t *testing.T) {
+func TestProberXAIBaseURL(t *testing.T) {
 	cases := []struct {
 		name string
 		auth *Auth
 		want string
 	}{
 		{
-			name: "oauth default no base_url",
+			name: "oauth default skipped",
 			auth: &Auth{Provider: "xai", Attributes: map[string]string{"auth_kind": "oauth"}},
-			want: "https://cli-chat-proxy.grok.com/v1",
+			want: "",
 		},
 		{
-			name: "oauth default official base_url",
+			name: "oauth default official base_url skipped",
 			auth: &Auth{Provider: "xai", Attributes: map[string]string{"auth_kind": "oauth", "base_url": "https://api.x.ai/v1"}},
-			want: "https://cli-chat-proxy.grok.com/v1",
+			want: "",
 		},
 		{
-			name: "api-key default no base_url",
+			name: "api-key default uses official api",
 			auth: &Auth{Provider: "xai", Attributes: map[string]string{"api_key": "secret"}},
 			want: "https://api.x.ai/v1",
 		},
@@ -1070,7 +1090,7 @@ func TestProberXAIRoutesOAuthDefaultToCLIChatProxy(t *testing.T) {
 			want: "https://api.x.ai/v1",
 		},
 		{
-			name: "oauth explicit custom base_url",
+			name: "oauth explicit custom base_url probed",
 			auth: &Auth{Provider: "xai", Attributes: map[string]string{"auth_kind": "oauth", "base_url": "https://gateway.example.com/v1"}},
 			want: "https://gateway.example.com/v1",
 		},

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -189,6 +189,80 @@ func TestProberSetsAnthropicVersionHeaderForClaude(t *testing.T) {
 	}
 }
 
+func TestProberSetsClaudeOAuthBetaHeader(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name        string
+		auth        *Auth
+		wantBeta    bool
+		wantBetaVal string
+	}{
+		{
+			name: "oauth credential gets oauth beta",
+			auth: &Auth{
+				ID:       "a1",
+				Provider: "claude",
+				Status:   StatusActive,
+				Attributes: map[string]string{
+					AttributeAuthKind: AuthKindOAuth,
+					"base_url":        "https://api.anthropic.com",
+				},
+			},
+			wantBeta:    true,
+			wantBetaVal: "oauth-2025-04-20",
+		},
+		{
+			name: "api-key credential does not get oauth beta",
+			auth: &Auth{
+				ID:       "a2",
+				Provider: "claude",
+				Status:   StatusActive,
+				Attributes: map[string]string{
+					AttributeAuthKind: AuthKindAPIKey,
+					"api_key":         "secret",
+					"base_url":        "https://api.anthropic.com",
+				},
+			},
+			wantBeta: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := newProberManager()
+			exec := &proberTestExecutor{provider: "claude"}
+			m.RegisterExecutor(exec)
+
+			if _, err := m.Register(ctx, c.auth); err != nil {
+				t.Fatalf("Register: %v", err)
+			}
+
+			cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+			m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+			time.Sleep(100 * time.Millisecond)
+
+			if exec.calls.Load() != 1 {
+				t.Fatalf("prober calls = %d, want 1", exec.calls.Load())
+			}
+			exec.mu.Lock()
+			defer exec.mu.Unlock()
+			if got := exec.lastHeaders.Get("Anthropic-Version"); got != "2023-06-01" {
+				t.Fatalf("Anthropic-Version header = %q, want 2023-06-01", got)
+			}
+			got := exec.lastHeaders.Get("Anthropic-Beta")
+			if c.wantBeta {
+				if got != c.wantBetaVal {
+					t.Fatalf("Anthropic-Beta header = %q, want %q", got, c.wantBetaVal)
+				}
+			} else if got != "" {
+				t.Fatalf("Anthropic-Beta header = %q, want empty", got)
+			}
+		})
+	}
+}
+
 func TestProberAcceptsEmpty200(t *testing.T) {
 	ctx := context.Background()
 	m := newProberManager()

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -237,6 +237,101 @@ func TestProberDropsContextDeadline(t *testing.T) {
 	}
 }
 
+func TestProberBackoffFor(t *testing.T) {
+	l := newAuthProberLoop(nil, internalconfig.CredentialProberConfig{BackoffBase: 30 * time.Second, BackoffMax: 5 * time.Minute})
+	cases := []struct {
+		level int
+		want  time.Duration
+	}{
+		{0, 30 * time.Second},
+		{1, 1 * time.Minute},
+		{2, 2 * time.Minute},
+		{3, 4 * time.Minute},
+		{4, 5 * time.Minute},
+		{5, 5 * time.Minute},
+		{10, 5 * time.Minute},
+	}
+	for _, c := range cases {
+		got := l.proberBackoffFor(c.level)
+		if got != c.want {
+			t.Fatalf("proberBackoffFor(%d) = %v, want %v", c.level, got, c.want)
+		}
+	}
+}
+
+func TestProberBackoffOverridesStatusCooldowns(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	max := 5 * time.Minute
+	m.MarkResult(ctx, Result{
+		AuthID:          auth.ID,
+		Provider:        auth.Provider,
+		Success:         false,
+		CredentialScope: true,
+		Error: &Error{
+			Code:       ErrorCodeForceCooldown,
+			Message:    "prober: upstream returned 401",
+			HTTPStatus: http.StatusUnauthorized,
+			Retryable:  true,
+		},
+		RetryAfter: durationPtr(30 * time.Second),
+	})
+
+	m.mu.RLock()
+	updated := m.auths["a1"]
+	m.mu.RUnlock()
+	if updated == nil {
+		t.Fatal("auth disappeared")
+	}
+	if got := time.Until(updated.NextRetryAfter); got > max || got < 0 {
+		t.Fatalf("NextRetryAfter = %v, want <= %v", updated.NextRetryAfter, max)
+	}
+}
+
+func TestProberBackoffEscalates(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{BackoffBase: 30 * time.Second, BackoffMax: 5 * time.Minute}
+	l := newAuthProberLoop(m, cfg)
+
+	for i := 0; i < 6; i++ {
+		d := l.proberBackoffFor(i)
+		m.MarkResult(ctx, Result{
+			AuthID:          auth.ID,
+			Provider:        auth.Provider,
+			Success:         false,
+			CredentialScope: true,
+			Error:           &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusUnauthorized, Retryable: true},
+			RetryAfter:      &d,
+		})
+	}
+
+	m.mu.RLock()
+	updated := m.auths["a1"]
+	m.mu.RUnlock()
+	if updated == nil {
+		t.Fatal("auth disappeared")
+	}
+	if got := time.Until(updated.NextRetryAfter); got > cfg.BackoffMax {
+		t.Fatalf("NextRetryAfter = %v, want <= %v", updated.NextRetryAfter, cfg.BackoffMax)
+	}
+	if updated.proberBackoff != 6 {
+		t.Fatalf("proberBackoff = %d, want 6", updated.proberBackoff)
+	}
+}
+
+func durationPtr(d time.Duration) *time.Duration { return &d }
+
 func TestResolveProbeURL(t *testing.T) {
 	cases := []struct {
 		baseURL string

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -1105,6 +1105,50 @@ func TestProberSetConfigFromCallbackDoesNotDeadlock(t *testing.T) {
 	}
 }
 
+func TestProbeHookReceivesDetachedContext(t *testing.T) {
+	hookCtxErr := make(chan error, 1)
+	hook := &contextCheckingHook{errC: hookCtxErr}
+	m := NewManager(nil, nil, hook)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before MarkResult so the synchronous path would see ctx.Err()
+
+	m.MarkResult(ctx, Result{
+		AuthID:   "a1",
+		Provider: "test",
+		Success:  false,
+		IsProbe:  true,
+		Error: &Error{
+			Code:       ErrorCodeForceCooldown,
+			Message:    "prober: unreachable",
+			HTTPStatus: http.StatusServiceUnavailable,
+		},
+	})
+
+	select {
+	case err := <-hookCtxErr:
+		if err != nil {
+			t.Fatalf("probe hook received canceled context: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("probe hook was not called")
+	}
+}
+
+type contextCheckingHook struct {
+	errC chan error
+}
+
+func (h *contextCheckingHook) OnAuthRegistered(context.Context, *Auth) {}
+func (h *contextCheckingHook) OnAuthUpdated(context.Context, *Auth)    {}
+func (h *contextCheckingHook) OnResult(ctx context.Context, result Result) {
+	if err := ctx.Err(); err != nil {
+		h.errC <- err
+		return
+	}
+	h.errC <- nil
+}
+
 func TestResolveProbeURL(t *testing.T) {
 	cases := []struct {
 		baseURL string

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -1141,6 +1141,53 @@ func TestProberRefreshOn401DoesNotPassLiveAuthPointer(t *testing.T) {
 	}
 }
 
+func TestProberReResolvesExecutorAfterAuthReplacement(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	oldExec := &proberTestExecutor{provider: "test"}
+	newExec := &proberTestExecutor{provider: "new"}
+	m.RegisterExecutor(oldExec)
+	m.RegisterExecutor(newExec)
+
+	oldAuth := &Auth{
+		ID:       "a1",
+		Provider: "test",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://old.example.com",
+		},
+	}
+	if _, err := m.Register(ctx, oldAuth); err != nil {
+		t.Fatalf("Register old auth: %v", err)
+	}
+
+	newAuth := oldAuth.Clone()
+	newAuth.Provider = "new"
+	newAuth.Attributes = map[string]string{
+		"base_url": "https://new.example.com",
+	}
+	if _, err := m.Register(ctx, newAuth); err != nil {
+		t.Fatalf("Register replacement auth: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	loop := newAuthProberLoop(m, cfg)
+	loop.probe(ctx, oldAuth)
+
+	if oldExec.calls.Load() != 0 {
+		t.Fatalf("old exec calls = %d, want 0", oldExec.calls.Load())
+	}
+	if newExec.calls.Load() != 1 {
+		t.Fatalf("new exec calls = %d, want 1", newExec.calls.Load())
+	}
+	newExec.mu.Lock()
+	url := newExec.lastURL
+	newExec.mu.Unlock()
+	if url != "https://new.example.com/models" {
+		t.Fatalf("prober URL = %q, want %q", url, "https://new.example.com/models")
+	}
+}
+
 func TestProberRestartGoroutineDoesNotSurviveParentCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	m := newProberManager()

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -109,11 +109,71 @@ func (e *proberTestExecutor) HttpRequest(ctx context.Context, auth *Auth, req *h
 		status = e.refreshStatus
 	}
 	body := e.body
-	if body == "" {
-		body = "{}"
-	}
 	e.mu.Unlock()
 	return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(body))}, nil
+}
+
+func TestProberHonorsMetadataBaseURL(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "xai"}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "xai",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"base_url": "https://custom.x.ai",
+		},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+
+	if exec.calls.Load() != 1 {
+		t.Fatalf("prober calls = %d, want 1", exec.calls.Load())
+	}
+	exec.mu.Lock()
+	url := exec.lastURL
+	exec.mu.Unlock()
+	if url != "https://custom.x.ai/v1/models" {
+		t.Fatalf("prober URL = %q, want %q", url, "https://custom.x.ai/v1/models")
+	}
+}
+
+func TestProberAcceptsEmpty200(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "test", statusCode: intPtr(http.StatusOK)}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "test",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://example.com",
+		},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+
+	updated, _ := m.GetByID(auth.ID)
+	if updated == nil || updated.Unavailable || !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("empty 200 should not force cooldown; Unavailable=%v NextRetryAfter=%v", updated.Unavailable, updated.NextRetryAfter)
+	}
 }
 
 func TestProberDisabledByDefault(t *testing.T) {

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -1145,6 +1145,42 @@ func TestProberRefreshOn401(t *testing.T) {
 	}
 }
 
+func TestProber401DoesNotRefreshAPIKeyCredential(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{
+		provider:   "test",
+		statusCode: intPtr(http.StatusUnauthorized),
+	}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "test",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://example.com",
+			"api_key":  "secret",
+		},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(200 * time.Millisecond)
+
+	if exec.refreshCalled.Load() {
+		t.Fatal("Refresh called for API-key credential with no refresh_token")
+	}
+	updated, _ := m.GetByID(auth.ID)
+	if updated == nil || !updated.Unavailable {
+		t.Fatalf("API-key 401 should force-cool the credential; Unavailable = %v", updated != nil && updated.Unavailable)
+	}
+}
+
 func TestProberDiscardsStaleAuthResult(t *testing.T) {
 	ctx := context.Background()
 	m := newProberManager()
@@ -1379,6 +1415,7 @@ func TestProberRefreshOn401WaitsForRateLimitToken(t *testing.T) {
 		Attributes: map[string]string{
 			"base_url": "https://example.com",
 		},
+		Metadata: map[string]any{"refresh_token": "old-token"},
 	}
 	if _, err := m.Register(ctx, auth); err != nil {
 		t.Fatalf("Register: %v", err)

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -943,6 +943,39 @@ func TestProberClampsRateLimit(t *testing.T) {
 	}
 }
 
+func TestProberBaseURLCaseInsensitiveOpenAICompatName(t *testing.T) {
+	cfg := &internalconfig.Config{
+		OpenAICompatibility: []internalconfig.OpenAICompatibility{
+			{
+				Name:    "MyOpenAI",
+				BaseURL: "https://custom.example.com/v1",
+			},
+		},
+	}
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			"compat_name": "myopenai",
+		},
+	}
+	if got := proberBaseURLForProvider(auth, cfg); got != "https://custom.example.com/v1" {
+		t.Fatalf("proberBaseURLForProvider() = %q, want %q", got, "https://custom.example.com/v1")
+	}
+
+	auth.Attributes["compat_name"] = "MYOPENAI"
+	if got := proberBaseURLForProvider(auth, cfg); got != "https://custom.example.com/v1" {
+		t.Fatalf("proberBaseURLForProvider() = %q, want %q", got, "https://custom.example.com/v1")
+	}
+
+	auth.Attributes["provider_key"] = "MyOpenAI"
+	auth.Attributes["compat_name"] = ""
+	if got := proberBaseURLForProvider(auth, cfg); got != "https://custom.example.com/v1" {
+		t.Fatalf("proberBaseURLForProvider() = %q, want %q", got, "https://custom.example.com/v1")
+	}
+}
+
 func TestProberRefreshOn401(t *testing.T) {
 	ctx := context.Background()
 	m := newProberManager()

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -495,6 +495,108 @@ func TestProberAcceptsNoContentResponse(t *testing.T) {
 	}
 }
 
+func TestProberSkipsUnsupportedMethodResponses(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "405 status", status: http.StatusMethodNotAllowed},
+		{name: "501 status", status: http.StatusNotImplemented},
+		{name: "method not allowed body", status: http.StatusBadRequest, body: "method not allowed"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			m := newProberManager()
+			exec := &proberTestExecutor{provider: "test", statusCode: intPtr(tc.status), body: tc.body}
+			m.RegisterExecutor(exec)
+
+			auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+			if _, err := m.Register(ctx, auth); err != nil {
+				t.Fatalf("Register: %v", err)
+			}
+
+			loop := newAuthProberLoop(m, internalconfig.CredentialProberConfig{})
+			loop.probe(ctx, auth)
+
+			updated, _ := m.GetByID(auth.ID)
+			if updated == nil {
+				t.Fatal("auth disappeared")
+			}
+			if updated.Unavailable || !updated.NextRetryAfter.IsZero() {
+				t.Fatalf("unsupported probe response should be ignored; Unavailable=%v NextRetryAfter=%v", updated.Unavailable, updated.NextRetryAfter)
+			}
+		})
+	}
+}
+
+func TestProberSkipsNotFoundOnTemplatePath(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "test", statusCode: intPtr(http.StatusNotFound)}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	loop := newAuthProberLoop(m, internalconfig.CredentialProberConfig{})
+	loop.probe(ctx, auth)
+
+	updated, _ := m.GetByID(auth.ID)
+	if updated == nil {
+		t.Fatal("auth disappeared")
+	}
+	if updated.Unavailable || !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("template probe 404 should be ignored; Unavailable=%v NextRetryAfter=%v", updated.Unavailable, updated.NextRetryAfter)
+	}
+}
+
+func TestProberMarksNotFoundOnProviderPath(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "claude", statusCode: intPtr(http.StatusNotFound)}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "claude", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	loop := newAuthProberLoop(m, internalconfig.CredentialProberConfig{})
+	loop.probe(ctx, auth)
+
+	updated, _ := m.GetByID(auth.ID)
+	if updated == nil {
+		t.Fatal("auth disappeared")
+	}
+	if !updated.Unavailable || updated.NextRetryAfter.IsZero() {
+		t.Fatalf("provider probe 404 should force cooldown; Unavailable=%v NextRetryAfter=%v", updated.Unavailable, updated.NextRetryAfter)
+	}
+}
+
+func TestProberSkipsVertexDefaultPath(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "vertex", statusCode: intPtr(http.StatusOK)}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "vertex", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	loop := newAuthProberLoop(m, internalconfig.CredentialProberConfig{})
+	loop.probe(ctx, auth)
+
+	if got := exec.calls.Load(); got != 0 {
+		t.Fatalf("Vertex default probe calls = %d, want 0", got)
+	}
+}
+
 func TestProberDropsContextDeadline(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 24*time.Hour)
 	defer cancel()
@@ -898,6 +1000,8 @@ func TestProberProbePathForProvider(t *testing.T) {
 		{"gemini", "", "/v1beta/models"},
 		{"Gemini", "", "/v1beta/models"},
 		{"aistudio", "", "/v1beta/models"},
+		{"vertex", "", ""},
+		{"vertex", "/health", "/health"},
 		{"xai", "", "/v1/models"},
 		{"kimi", "", "/v1/models"},
 		{"openai-compatible-groq", "", "/v1/models"},
@@ -1080,6 +1184,9 @@ func TestProberClampsMinimumInterval(t *testing.T) {
 	}
 	if l.cfg.Interval != proberMinInterval {
 		t.Fatalf("Interval = %v, want %v", l.cfg.Interval, proberMinInterval)
+	}
+	if l.cfg.Interval < time.Second {
+		t.Fatalf("Interval = %v, want at least one second", l.cfg.Interval)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -1112,7 +1112,7 @@ func TestProberClearsProberStateOnRecovery(t *testing.T) {
 
 	cfg := internalconfig.CredentialProberConfig{
 		Enabled:            true,
-		Interval:           50 * time.Millisecond,
+		Interval:           time.Second,
 		MaxConcurrency:     1,
 		RateLimitPerMinute: 1000,
 		BackoffBase:        25 * time.Millisecond,
@@ -1130,7 +1130,7 @@ func TestProberClearsProberStateOnRecovery(t *testing.T) {
 	exec.mu.Lock()
 	*exec.statusCode = http.StatusOK
 	exec.mu.Unlock()
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(1200 * time.Millisecond)
 
 	updated, _ = m.GetByID(auth.ID)
 	if updated == nil {

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -14,6 +14,12 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
+func newProberManager() *Manager {
+	m := NewManager(nil, nil, nil)
+	m.SetProberParentContext(context.Background())
+	return m
+}
+
 type proberTestExecutor struct {
 	provider      string
 	statusCode    int
@@ -70,7 +76,7 @@ func (e *proberTestExecutor) HttpRequest(ctx context.Context, auth *Auth, req *h
 
 func TestProberDisabledByDefault(t *testing.T) {
 	ctx := context.Background()
-	m := NewManager(nil, nil, nil)
+	m := newProberManager()
 	exec := &proberTestExecutor{provider: "test"}
 	m.RegisterExecutor(exec)
 
@@ -90,7 +96,7 @@ func TestProberDisabledByDefault(t *testing.T) {
 
 func TestProberSkipsDisabledAuth(t *testing.T) {
 	ctx := context.Background()
-	m := NewManager(nil, nil, nil)
+	m := newProberManager()
 	exec := &proberTestExecutor{provider: "test", err: fmt.Errorf("boom")}
 	m.RegisterExecutor(exec)
 
@@ -110,7 +116,7 @@ func TestProberSkipsDisabledAuth(t *testing.T) {
 
 func TestProberMarksAuthUnavailableOnFailure(t *testing.T) {
 	ctx := context.Background()
-	m := NewManager(nil, nil, nil)
+	m := newProberManager()
 	exec := &proberTestExecutor{provider: "test", err: fmt.Errorf("upstream unreachable")}
 	m.RegisterExecutor(exec)
 
@@ -148,7 +154,7 @@ func TestProberMarksAuthUnavailableOnFailure(t *testing.T) {
 
 func TestProberLeavesAuthActiveOnSuccess(t *testing.T) {
 	ctx := context.Background()
-	m := NewManager(nil, nil, nil)
+	m := newProberManager()
 	exec := &proberTestExecutor{provider: "test", statusCode: http.StatusOK}
 	m.RegisterExecutor(exec)
 
@@ -182,7 +188,7 @@ func TestProberLeavesAuthActiveOnSuccess(t *testing.T) {
 
 func TestProberUsesCanonicalExecutorKey(t *testing.T) {
 	ctx := context.Background()
-	m := NewManager(nil, nil, nil)
+	m := newProberManager()
 
 	// Executor is registered under the lower-cased canonical key.
 	exec := &proberTestExecutor{provider: "openai", statusCode: http.StatusOK}
@@ -212,7 +218,7 @@ func TestProberUsesCanonicalExecutorKey(t *testing.T) {
 
 func TestProberUsesCompatNameExecutorKey(t *testing.T) {
 	ctx := context.Background()
-	m := NewManager(nil, nil, nil)
+	m := newProberManager()
 
 	exec := &proberTestExecutor{provider: "openai-compatible-custom", statusCode: http.StatusOK}
 	m.RegisterExecutor(exec)
@@ -242,7 +248,7 @@ func TestProberUsesCompatNameExecutorKey(t *testing.T) {
 
 func TestProberMarksAuthUnavailableOnEmptyResponse(t *testing.T) {
 	ctx := context.Background()
-	m := NewManager(nil, nil, nil)
+	m := newProberManager()
 	exec := &proberTestExecutor{provider: "test", statusCode: http.StatusNoContent}
 	m.RegisterExecutor(exec)
 
@@ -272,7 +278,7 @@ func TestProberDropsContextDeadline(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 24*time.Hour)
 	defer cancel()
 
-	m := NewManager(nil, nil, nil)
+	m := newProberManager()
 	exec := &proberTestExecutor{provider: "test", statusCode: http.StatusOK}
 	m.RegisterExecutor(exec)
 
@@ -303,7 +309,7 @@ func TestProberDropsContextDeadline(t *testing.T) {
 
 func TestProberStopWaitsForInFlightProbe(t *testing.T) {
 	ctx := context.Background()
-	m := NewManager(nil, nil, nil)
+	m := newProberManager()
 	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
 	if _, err := m.Register(ctx, auth); err != nil {
 		t.Fatalf("Register: %v", err)
@@ -339,7 +345,7 @@ func TestProberStopWaitsForInFlightProbe(t *testing.T) {
 
 func TestProberRestartDuringStopIsBlocked(t *testing.T) {
 	ctx := context.Background()
-	m := NewManager(nil, nil, nil)
+	m := newProberManager()
 	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
 	if _, err := m.Register(ctx, auth); err != nil {
 		t.Fatalf("Register: %v", err)
@@ -382,7 +388,7 @@ func TestProberRestartDuringStopIsBlocked(t *testing.T) {
 
 func TestSetConfigDoesNotDeadlockWithFailingProbe(t *testing.T) {
 	ctx := context.Background()
-	m := NewManager(nil, nil, nil)
+	m := newProberManager()
 	m.SetCooldownStateStore(&recordingCooldownStateStore{})
 
 	block := make(chan struct{})
@@ -418,6 +424,34 @@ func TestSetConfigDoesNotDeadlockWithFailingProbe(t *testing.T) {
 	}
 }
 
+func TestProberDoesNotStartBeforeParentContext(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	exec := &proberTestExecutor{provider: "test", statusCode: http.StatusOK}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+	if exec.calls.Load() != 0 {
+		t.Fatalf("prober calls = %d, want 0 before parent context is set", exec.calls.Load())
+	}
+
+	m.SetProberParentContext(ctx)
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+	if exec.calls.Load() != 1 {
+		t.Fatalf("prober calls = %d, want 1 after parent context is set", exec.calls.Load())
+	}
+}
+
 func TestProberBackoffFor(t *testing.T) {
 	l := newAuthProberLoop(nil, internalconfig.CredentialProberConfig{BackoffBase: 30 * time.Second, BackoffMax: 5 * time.Minute})
 	cases := []struct {
@@ -442,7 +476,7 @@ func TestProberBackoffFor(t *testing.T) {
 
 func TestProberBackoffOverridesStatusCooldowns(t *testing.T) {
 	ctx := context.Background()
-	m := NewManager(nil, nil, nil)
+	m := newProberManager()
 	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
 	if _, err := m.Register(ctx, auth); err != nil {
 		t.Fatalf("Register: %v", err)
@@ -476,7 +510,7 @@ func TestProberBackoffOverridesStatusCooldowns(t *testing.T) {
 
 func TestProberBackoffEscalates(t *testing.T) {
 	ctx := context.Background()
-	m := NewManager(nil, nil, nil)
+	m := newProberManager()
 	auth := &Auth{ID: "a1", Provider: "test", Status: StatusActive, Attributes: map[string]string{"base_url": "https://example.com"}}
 	if _, err := m.Register(ctx, auth); err != nil {
 		t.Fatalf("Register: %v", err)

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -30,6 +31,8 @@ type proberTestExecutor struct {
 	deadlineSet   atomic.Bool
 	ctx           context.Context
 	blockUntil    chan struct{}
+	mu            sync.Mutex
+	lastURL       string
 }
 
 func (e *proberTestExecutor) Identifier() string { return e.provider }
@@ -51,6 +54,11 @@ func (e *proberTestExecutor) CountTokens(context.Context, *Auth, cliproxyexecuto
 func (e *proberTestExecutor) HttpRequest(ctx context.Context, auth *Auth, req *http.Request) (*http.Response, error) {
 	e.calls.Add(1)
 	e.ctx = ctx
+	if req != nil {
+		e.mu.Lock()
+		e.lastURL = req.URL.String()
+		e.mu.Unlock()
+	}
 	if _, ok := ctx.Deadline(); ok {
 		e.deadlineSet.Store(true)
 	}
@@ -452,6 +460,39 @@ func TestProberDoesNotStartBeforeParentContext(t *testing.T) {
 	}
 }
 
+func TestProberUsesProviderSpecificProbePath(t *testing.T) {
+	ctx := context.Background()
+	m := newProberManager()
+	exec := &proberTestExecutor{provider: "gemini", statusCode: http.StatusOK}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "g1",
+		Provider: "gemini",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://generativelanguage.googleapis.com",
+		},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+	if exec.calls.Load() != 1 {
+		t.Fatalf("prober calls = %d, want 1", exec.calls.Load())
+	}
+	exec.mu.Lock()
+	lastURL := exec.lastURL
+	exec.mu.Unlock()
+	if !strings.Contains(lastURL, "/v1beta/models") {
+		t.Fatalf("probe URL = %q, want /v1beta/models path", lastURL)
+	}
+}
+
 func TestProberBackoffFor(t *testing.T) {
 	l := newAuthProberLoop(nil, internalconfig.CredentialProberConfig{BackoffBase: 30 * time.Second, BackoffMax: 5 * time.Minute})
 	cases := []struct {
@@ -546,6 +587,29 @@ func TestProberBackoffEscalates(t *testing.T) {
 }
 
 func durationPtr(d time.Duration) *time.Duration { return &d }
+
+func TestProberProbePathForProvider(t *testing.T) {
+	cases := []struct {
+		provider   string
+		configured string
+		want       string
+	}{
+		{"gemini", "/models", "/v1beta/models"},
+		{"Gemini", "", "/v1beta/models"},
+		{"aistudio", "/models", "/v1beta/models"},
+		{"xai", "/models", "/v1/models"},
+		{"kimi", "/models", "/v1/models"},
+		{"openai-compatible-groq", "/models", "/v1/models"},
+		{"openai-compatibility", "", "/v1/models"},
+		{"test", "/models", "/models"},
+		{"test", "", ""},
+	}
+	for _, c := range cases {
+		if got := proberProbePathForProvider(c.provider, c.configured); got != c.want {
+			t.Fatalf("proberProbePathForProvider(%q, %q) = %q, want %q", c.provider, c.configured, got, c.want)
+		}
+	}
+}
 
 func TestResolveProbeURL(t *testing.T) {
 	cases := []struct {

--- a/sdk/cliproxy/auth/conductor_prober_test.go
+++ b/sdk/cliproxy/auth/conductor_prober_test.go
@@ -180,6 +180,66 @@ func TestProberLeavesAuthActiveOnSuccess(t *testing.T) {
 	}
 }
 
+func TestProberUsesCanonicalExecutorKey(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+
+	// Executor is registered under the lower-cased canonical key.
+	exec := &proberTestExecutor{provider: "openai", statusCode: http.StatusOK}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "OpenAI",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://example.com",
+		},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+
+	if exec.calls.Load() != 1 {
+		t.Fatalf("prober calls = %d, want 1", exec.calls.Load())
+	}
+}
+
+func TestProberUsesCompatNameExecutorKey(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+
+	exec := &proberTestExecutor{provider: "openai-compatible-custom", statusCode: http.StatusOK}
+	m.RegisterExecutor(exec)
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "openai-compatibility",
+		Label:    "custom",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"base_url": "https://example.com",
+		},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cfg := internalconfig.CredentialProberConfig{Enabled: true, Interval: time.Hour, MaxConcurrency: 1, RateLimitPerMinute: 1000}
+	m.SetConfig(&internalconfig.Config{CredentialProber: cfg})
+
+	time.Sleep(100 * time.Millisecond)
+
+	if exec.calls.Load() != 1 {
+		t.Fatalf("prober calls = %d, want 1", exec.calls.Load())
+	}
+}
+
 func TestProberMarksAuthUnavailableOnEmptyResponse(t *testing.T) {
 	ctx := context.Background()
 	m := NewManager(nil, nil, nil)

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -579,6 +579,12 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		updated.Status = StatusActive
 	}
 	updated.UpdatedAt = now
+	updated.NextRetryAfter = time.Time{}
+	updated.authLevelCooldown = false
+	updated.authLevelUnavailable = false
+	updated.authLevelNextRetryAfter = time.Time{}
+	updated.proberCooldown = false
+	updated.proberBackoff = 0
 	modelsToResume := clearUnauthorizedModelStates(updated, now)
 	if m.shouldRefresh(updated, now) {
 		updated.NextRefreshAfter = now.Add(refreshIneffectiveBackoff)

--- a/sdk/cliproxy/auth/conductor_refresh_executor_key_test.go
+++ b/sdk/cliproxy/auth/conductor_refresh_executor_key_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
@@ -39,6 +40,65 @@ func (e *countingRefreshExecutor) CountTokens(context.Context, *Auth, cliproxyex
 
 func (e *countingRefreshExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
 	return nil, nil
+}
+
+func TestRefreshAuthForRequest_ClearsAuthLevelCooldownAndProberState(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	executor := &countingRefreshExecutor{id: "openai-compatible-custom"}
+	manager.RegisterExecutor(executor)
+
+	next := time.Now().Add(time.Hour)
+	auth := &Auth{
+		ID:       "compat-oauth",
+		Provider: "plugin-provider",
+		Attributes: map[string]string{
+			"compat_name":  "custom",
+			"provider_key": "custom",
+			"base_url":     "https://compat.example.com/v1",
+		},
+		Metadata: map[string]any{
+			"access_token":  "old-token",
+			"refresh_token": "refresh-1",
+		},
+		Status:                  StatusError,
+		Unavailable:             true,
+		NextRetryAfter:          next,
+		authLevelCooldown:       true,
+		authLevelUnavailable:    true,
+		authLevelNextRetryAfter: next,
+		proberCooldown:          true,
+		proberBackoff:           3,
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	refreshed, errRefresh := manager.refreshAuthForRequest(ctx, auth.ID, "old-token")
+	if errRefresh != nil {
+		t.Fatalf("refreshAuthForRequest() error = %v", errRefresh)
+	}
+	if refreshed == nil {
+		t.Fatal("refreshAuthForRequest() returned nil auth")
+	}
+	if refreshed.NextRetryAfter.Equal(next) {
+		t.Fatalf("NextRetryAfter was not cleared: %v", refreshed.NextRetryAfter)
+	}
+	if refreshed.authLevelCooldown {
+		t.Fatal("authLevelCooldown was not cleared")
+	}
+	if refreshed.authLevelUnavailable {
+		t.Fatal("authLevelUnavailable was not cleared")
+	}
+	if !refreshed.authLevelNextRetryAfter.IsZero() {
+		t.Fatalf("authLevelNextRetryAfter was not cleared: %v", refreshed.authLevelNextRetryAfter)
+	}
+	if refreshed.proberCooldown {
+		t.Fatal("proberCooldown was not cleared")
+	}
+	if refreshed.proberBackoff != 0 {
+		t.Fatalf("proberBackoff = %d, want 0", refreshed.proberBackoff)
+	}
 }
 
 func TestRefreshAuthForRequest_UsesExecutorKeyFromAuth(t *testing.T) {

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -117,7 +117,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	quotaErr := &Error{Code: "rate_limit", Message: "quota", HTTPStatus: http.StatusTooManyRequests}
 	auth := &Auth{ID: "auth-level-quota"}
 
-	applyAuthFailureState(auth, quotaErr, nil, now, false)
+	applyAuthFailureState(auth, quotaErr, nil, now, false, false)
 	if auth.Quota.BackoffLevel != 1 {
 		t.Fatalf("expected BackoffLevel 1 after first failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -127,7 +127,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	}
 
 	// In-window failure keeps the current window and level.
-	applyAuthFailureState(auth, quotaErr, nil, now.Add(100*time.Millisecond), false)
+	applyAuthFailureState(auth, quotaErr, nil, now.Add(100*time.Millisecond), false, false)
 	if auth.Quota.BackoffLevel != 1 {
 		t.Fatalf("expected BackoffLevel to stay 1 for in-window failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -136,7 +136,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	}
 
 	// A failure after the window expired escalates to the next level.
-	applyAuthFailureState(auth, quotaErr, nil, now.Add(2*time.Second), false)
+	applyAuthFailureState(auth, quotaErr, nil, now.Add(2*time.Second), false, false)
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel 2 after post-window failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -146,12 +146,42 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 
 	// A provider supplied retry hint always takes effect, even in-window.
 	retryAfter := 10 * time.Second
-	applyAuthFailureState(auth, quotaErr, &retryAfter, now.Add(3*time.Second), false)
+	applyAuthFailureState(auth, quotaErr, &retryAfter, now.Add(3*time.Second), false, false)
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel to stay 2 with retry hint, got %d", auth.Quota.BackoffLevel)
 	}
 	if !auth.Quota.NextRecoverAt.Equal(now.Add(13 * time.Second)) {
 		t.Fatalf("expected retry hint window to close at %v, got %v", now.Add(13*time.Second), auth.Quota.NextRecoverAt)
+	}
+}
+
+func TestApplyAuthFailureStateForceCooldownOwnership(t *testing.T) {
+	now := time.Now()
+	retryAfter := 30 * time.Second
+	err := &Error{Code: ErrorCodeForceCooldown, Message: "force cooldown", Retryable: true}
+
+	nonProbe := &Auth{ID: "non-probe"}
+	applyAuthFailureState(nonProbe, err, &retryAfter, now, false, false)
+	if nonProbe.proberCooldown {
+		t.Fatal("non-probe force cooldown marked proberCooldown")
+	}
+	if nonProbe.proberBackoff != 0 {
+		t.Fatalf("non-probe force cooldown set proberBackoff = %d, want 0", nonProbe.proberBackoff)
+	}
+	if !nonProbe.NextRetryAfter.Equal(now.Add(retryAfter)) {
+		t.Fatalf("non-probe NextRetryAfter = %v, want %v", nonProbe.NextRetryAfter, now.Add(retryAfter))
+	}
+
+	probe := &Auth{ID: "probe"}
+	applyAuthFailureState(probe, err, &retryAfter, now, false, true)
+	if !probe.proberCooldown {
+		t.Fatal("probe force cooldown did not mark proberCooldown")
+	}
+	if probe.proberBackoff != 1 {
+		t.Fatalf("probe force cooldown set proberBackoff = %d, want 1", probe.proberBackoff)
+	}
+	if !probe.NextRetryAfter.Equal(now.Add(retryAfter)) {
+		t.Fatalf("probe NextRetryAfter = %v, want %v", probe.NextRetryAfter, now.Add(retryAfter))
 	}
 }
 

--- a/sdk/cliproxy/auth/cooldown_state_test.go
+++ b/sdk/cliproxy/auth/cooldown_state_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
@@ -559,6 +560,44 @@ func TestManager_RestoreCooldownStatesCanonicalizesThinkingSuffixes(t *testing.T
 	}
 	if len(modelRecords) != 1 || modelRecords[0].Model != "gemini-3.1-pro-preview" || !modelRecords[0].NextRetryAfter.Equal(laterRetry) {
 		t.Fatalf("persisted model records = %+v, want one canonical record until %v", modelRecords, laterRetry)
+	}
+}
+
+func TestManager_RestoreCooldownStatesRestoresProberOwnership(t *testing.T) {
+	nextRetry := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	now := time.Now().UTC().Truncate(time.Second)
+	store := &recordingCooldownStateStore{
+		load: []CooldownStateRecord{
+			{
+				Provider:       "xai",
+				AuthID:         "auth-prober",
+				Status:         "cooling",
+				NextRetryAfter: nextRetry,
+				Reason:         "prober: unreachable",
+				LastError:      &Error{Code: ErrorCodeForceCooldown, Message: "prober: unreachable", HTTPStatus: http.StatusServiceUnavailable, Retryable: true},
+				UpdatedAt:      now,
+			},
+		},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetCooldownStateStore(store)
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: "auth-prober", Provider: "xai"}); errRegister != nil {
+		t.Fatalf("Register() returned error: %v", errRegister)
+	}
+
+	if errRestore := manager.RestoreCooldownStates(context.Background()); errRestore != nil {
+		t.Fatalf("RestoreCooldownStates() returned error: %v", errRestore)
+	}
+
+	auth, ok := manager.GetByID("auth-prober")
+	if !ok || auth == nil {
+		t.Fatal("restored auth was not found")
+	}
+	if !auth.proberCooldown {
+		t.Fatalf("proberCooldown = false, want true after restoring prober cooldown")
+	}
+	if auth.proberBackoff == 0 {
+		t.Fatalf("proberBackoff = 0, want > 0 after restoring prober cooldown")
 	}
 }
 

--- a/sdk/cliproxy/auth/cooldown_state_test.go
+++ b/sdk/cliproxy/auth/cooldown_state_test.go
@@ -601,6 +601,47 @@ func TestManager_RestoreCooldownStatesRestoresProberOwnership(t *testing.T) {
 	}
 }
 
+func TestManager_RestoreCooldownStatesDoesNotMarkNonProberForceCooldownAsProber(t *testing.T) {
+	nextRetry := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	now := time.Now().UTC().Truncate(time.Second)
+	store := &recordingCooldownStateStore{
+		load: []CooldownStateRecord{
+			{
+				Provider:       "test",
+				AuthID:         "auth-non-prober",
+				Status:         "cooling",
+				NextRetryAfter: nextRetry,
+				Reason:         "stop-and-cooldown",
+				LastError:      &Error{Code: ErrorCodeForceCooldown, Message: "stop-and-cooldown", HTTPStatus: http.StatusServiceUnavailable, Retryable: true},
+				UpdatedAt:      now,
+			},
+		},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetCooldownStateStore(store)
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: "auth-non-prober", Provider: "test"}); errRegister != nil {
+		t.Fatalf("Register() returned error: %v", errRegister)
+	}
+
+	if errRestore := manager.RestoreCooldownStates(context.Background()); errRestore != nil {
+		t.Fatalf("RestoreCooldownStates() returned error: %v", errRestore)
+	}
+
+	auth, ok := manager.GetByID("auth-non-prober")
+	if !ok || auth == nil {
+		t.Fatal("restored auth was not found")
+	}
+	if auth.proberCooldown {
+		t.Fatal("proberCooldown = true, want false for non-prober force cooldown")
+	}
+	if auth.proberBackoff != 0 {
+		t.Fatalf("proberBackoff = %d, want 0 for non-prober force cooldown", auth.proberBackoff)
+	}
+	if !auth.NextRetryAfter.Equal(nextRetry) {
+		t.Fatalf("NextRetryAfter = %v, want %v", auth.NextRetryAfter, nextRetry)
+	}
+}
+
 func TestManagerResultSaveWaitsForCooldownStoreTransition(t *testing.T) {
 	oldStore := &blockingCooldownStateStore{started: make(chan struct{}), release: make(chan struct{})}
 	newStore := &recordingCooldownStateStore{}

--- a/sdk/cliproxy/auth/cooldown_state_test.go
+++ b/sdk/cliproxy/auth/cooldown_state_test.go
@@ -609,3 +609,49 @@ func TestManagerResultSaveWaitsForCooldownStoreTransition(t *testing.T) {
 		t.Fatalf("new store save count = %d, want 1", got)
 	}
 }
+
+func TestManager_RestoreAuthLevelCooldownBlocksCleanModelState(t *testing.T) {
+	nextRetry := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	store := &recordingCooldownStateStore{
+		load: []CooldownStateRecord{
+			{
+				Provider:       "test",
+				AuthID:         "auth-1",
+				Status:         "cooling",
+				NextRetryAfter: nextRetry,
+				Reason:         "prober: upstream unreachable",
+			},
+		},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetCooldownStateStore(store)
+	if _, err := manager.Register(WithSkipPersist(context.Background()), &Auth{
+		ID:       "auth-1",
+		Provider: "test",
+		Status:   StatusActive,
+		ModelStates: map[string]*ModelState{
+			"test-model": {
+				Status:      StatusActive,
+				Unavailable: false,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Register() returned error: %v", err)
+	}
+
+	if err := manager.RestoreCooldownStates(context.Background()); err != nil {
+		t.Fatalf("RestoreCooldownStates() returned error: %v", err)
+	}
+
+	auth, ok := manager.GetByID("auth-1")
+	if !ok {
+		t.Fatal("restored auth was not found")
+	}
+	if !auth.authLevelCooldown {
+		t.Fatal("auth.authLevelCooldown = false, want true")
+	}
+	blocked, _, _ := isAuthBlockedForModel(auth, "test-model", time.Now())
+	if !blocked {
+		t.Fatal("restored auth-level cooldown did not block the clean model state")
+	}
+}

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -541,9 +541,15 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	if auth.Disabled || auth.Status == StatusDisabled {
 		return true, blockReasonDisabled, time.Time{}
 	}
+	if auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
+		return true, blockReasonCooldown, auth.Quota.NextRecoverAt
+	}
 	// Auth-level cooldowns (prober, invalid grant, auth-level 429/5xx) must
 	// take precedence over per-model state so a credential-scoped failure
 	// blocks every model even if some model state still appears active.
+	// Do not fold the model-state aggregate stored in auth.Quota into this
+	// gate: a per-model quota recovery window must not extend an auth-level
+	// cooldown to models that are still usable.
 	if auth.authLevelCooldown {
 		unavailable := auth.authLevelUnavailable
 		next := auth.authLevelNextRetryAfter
@@ -551,12 +557,9 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 			unavailable = auth.Unavailable
 			next = auth.NextRetryAfter
 		}
-		if blocked, reason, next := availabilityBlock(unavailable, auth.Quota.Exceeded, next, auth.Quota.NextRecoverAt, now); blocked {
+		if blocked, reason, next := availabilityBlock(unavailable, false, next, time.Time{}, now); blocked {
 			return true, reason, next
 		}
-	}
-	if auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
-		return true, blockReasonCooldown, auth.Quota.NextRecoverAt
 	}
 	if model != "" {
 		if len(auth.ModelStates) > 0 {

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -541,6 +541,14 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	if auth.Disabled || auth.Status == StatusDisabled {
 		return true, blockReasonDisabled, time.Time{}
 	}
+	// Auth-level cooldowns (prober, invalid grant, auth-level 429/5xx) must
+	// take precedence over per-model state so a credential-scoped failure
+	// blocks every model even if some model state still appears active.
+	if auth.authLevelCooldown {
+		if blocked, reason, next := availabilityBlock(auth.Unavailable, auth.Quota.Exceeded, auth.NextRetryAfter, auth.Quota.NextRecoverAt, now); blocked {
+			return true, reason, next
+		}
+	}
 	if auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
 		return true, blockReasonCooldown, auth.Quota.NextRecoverAt
 	}

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -545,7 +545,13 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	// take precedence over per-model state so a credential-scoped failure
 	// blocks every model even if some model state still appears active.
 	if auth.authLevelCooldown {
-		if blocked, reason, next := availabilityBlock(auth.Unavailable, auth.Quota.Exceeded, auth.NextRetryAfter, auth.Quota.NextRecoverAt, now); blocked {
+		unavailable := auth.authLevelUnavailable
+		next := auth.authLevelNextRetryAfter
+		if !unavailable && (auth.Unavailable || !auth.NextRetryAfter.IsZero()) {
+			unavailable = auth.Unavailable
+			next = auth.NextRetryAfter
+		}
+		if blocked, reason, next := availabilityBlock(unavailable, auth.Quota.Exceeded, next, auth.Quota.NextRecoverAt, now); blocked {
 			return true, reason, next
 		}
 	}

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -679,6 +679,57 @@ func TestIsAuthBlockedForModel_ProberFailureBlocksCleanModelState(t *testing.T) 
 	}
 }
 
+func TestIsAuthBlockedForModel_AuthLevelNotOverriddenByModelAggregate(t *testing.T) {
+	t.Parallel()
+
+	m := NewManager(nil, nil, nil)
+	now := time.Now()
+	model := "test-model"
+	auth := &Auth{ID: "a", Provider: "test", Status: StatusActive}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	retryAfter := time.Minute
+	m.MarkResult(context.Background(), Result{
+		AuthID:          auth.ID,
+		Provider:        auth.Provider,
+		Success:         false,
+		CredentialScope: true,
+		IsProbe:         true,
+		Error: &Error{
+			Code:       ErrorCodeForceCooldown,
+			Message:    "prober: unreachable",
+			HTTPStatus: http.StatusServiceUnavailable,
+			Retryable:  true,
+		},
+		RetryAfter: &retryAfter,
+	})
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  true,
+	})
+
+	updated, _ := m.GetByID(auth.ID)
+	if updated == nil {
+		t.Fatal("auth disappeared")
+	}
+	if !updated.authLevelUnavailable || updated.authLevelNextRetryAfter.IsZero() {
+		t.Fatal("auth-level cooldown missing")
+	}
+
+	blocked, reason, _ := isAuthBlockedForModel(updated, model, now)
+	if !blocked {
+		t.Fatalf("blocked = false, want true")
+	}
+	if reason != blockReasonOther {
+		t.Fatalf("reason = %v, want %v", reason, blockReasonOther)
+	}
+}
+
 func TestIsAuthBlockedForModel_ThinkingSuffixStatesBlockCanonicalModel(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -598,6 +598,87 @@ func TestFillFirstSelectorPick_ThinkingSuffixFallsBackToBaseModelState(t *testin
 	}
 }
 
+func TestIsAuthBlockedForModel_AuthLevelBlockOverridesCleanModelState(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	model := "test-model"
+	auth := &Auth{
+		ID: "a",
+		// Simulate a credential-scoped probe failure.
+		Unavailable:       true,
+		NextRetryAfter:    now.Add(time.Minute),
+		authLevelCooldown: true,
+		Status:            StatusError,
+		ModelStates: map[string]*ModelState{
+			model: {
+				Status:      StatusActive,
+				Unavailable: false,
+			},
+		},
+	}
+
+	blocked, reason, next := isAuthBlockedForModel(auth, model, now)
+	if !blocked {
+		t.Fatalf("blocked = false, want true")
+	}
+	if !next.Equal(auth.NextRetryAfter) {
+		t.Fatalf("next = %v, want %v", next, auth.NextRetryAfter)
+	}
+	if reason != blockReasonOther {
+		t.Fatalf("reason = %v, want %v", reason, blockReasonOther)
+	}
+}
+
+func TestIsAuthBlockedForModel_ProberFailureBlocksCleanModelState(t *testing.T) {
+	t.Parallel()
+
+	m := NewManager(nil, nil, nil)
+	now := time.Now()
+	model := "test-model"
+	auth := &Auth{
+		ID:       "a",
+		Provider: "test",
+		Status:   StatusActive,
+		ModelStates: map[string]*ModelState{
+			model: {
+				Status:      StatusActive,
+				Unavailable: false,
+			},
+		},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	retryAfter := time.Minute
+	m.MarkResult(context.Background(), Result{
+		AuthID:          auth.ID,
+		Provider:        auth.Provider,
+		Success:         false,
+		CredentialScope: true,
+		Error: &Error{
+			Code:       ErrorCodeForceCooldown,
+			Message:    "prober: upstream unreachable",
+			HTTPStatus: http.StatusServiceUnavailable,
+			Retryable:  true,
+		},
+		RetryAfter: &retryAfter,
+	})
+
+	updated, _ := m.GetByID(auth.ID)
+	blocked, reason, next := isAuthBlockedForModel(updated, model, now)
+	if !blocked {
+		t.Fatalf("blocked = false, want true")
+	}
+	if !next.Equal(updated.NextRetryAfter) {
+		t.Fatalf("next = %v, want %v", next, updated.NextRetryAfter)
+	}
+	if reason != blockReasonOther {
+		t.Fatalf("reason = %v, want %v", reason, blockReasonOther)
+	}
+}
+
 func TestIsAuthBlockedForModel_ThinkingSuffixStatesBlockCanonicalModel(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -730,6 +730,54 @@ func TestIsAuthBlockedForModel_AuthLevelNotOverriddenByModelAggregate(t *testing
 	}
 }
 
+func TestIsAuthBlockedForModel_AuthLevelProbeNotExtendedByModelQuota(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	model := "test-model"
+	auth := &Auth{
+		ID:                      "a",
+		Provider:                "test",
+		Status:                  StatusActive,
+		Unavailable:             false,
+		NextRetryAfter:          time.Time{},
+		authLevelCooldown:       true,
+		authLevelUnavailable:    true,
+		authLevelNextRetryAfter: now.Add(time.Minute),
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: now.Add(time.Hour),
+		},
+		ModelStates: map[string]*ModelState{
+			model: {
+				Status:      StatusActive,
+				Unavailable: false,
+			},
+			"other-model": {
+				Status:         StatusError,
+				Unavailable:    true,
+				NextRetryAfter: now.Add(time.Hour),
+				Quota: QuotaState{
+					Exceeded:      true,
+					NextRecoverAt: now.Add(time.Hour),
+				},
+			},
+		},
+	}
+
+	blocked, reason, next := isAuthBlockedForModel(auth, model, now)
+	if !blocked {
+		t.Fatalf("blocked = false, want true")
+	}
+	if reason != blockReasonOther {
+		t.Fatalf("reason = %v, want %v", reason, blockReasonOther)
+	}
+	if !next.Equal(auth.authLevelNextRetryAfter) {
+		t.Fatalf("next = %v, want %v", next, auth.authLevelNextRetryAfter)
+	}
+}
+
 func TestIsAuthBlockedForModel_ThinkingSuffixStatesBlockCanonicalModel(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -102,6 +102,10 @@ type Auth struct {
 	// proberBackoff counts consecutive probe failures for the exponential
 	// prober backoff ladder. It is not persisted.
 	proberBackoff int `json:"-"`
+
+	// authLevelCooldown marks an auth-level (non-aggregated) cooldown such as
+	// a prober or invalid_grant failure. It is not persisted.
+	authLevelCooldown bool `json:"-"`
 }
 
 const (

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -98,6 +98,10 @@ type Auth struct {
 
 	recentRequests recentRequestRing `json:"-"`
 	indexAssigned  bool              `json:"-"`
+
+	// proberBackoff counts consecutive probe failures for the exponential
+	// prober backoff ladder. It is not persisted.
+	proberBackoff int `json:"-"`
 }
 
 const (

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -103,6 +103,11 @@ type Auth struct {
 	// prober backoff ladder. It is not persisted.
 	proberBackoff int `json:"-"`
 
+	// proberCooldown marks that the current auth-level cooldown was set by
+	// the health prober. Only prober-owned cooldown may be cleared by a
+	// successful probe. It is not persisted.
+	proberCooldown bool `json:"-"`
+
 	// authLevelCooldown marks an auth-level (non-aggregated) cooldown such as
 	// a prober or invalid_grant failure. It is not persisted.
 	authLevelCooldown bool `json:"-"`

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -106,6 +106,12 @@ type Auth struct {
 	// authLevelCooldown marks an auth-level (non-aggregated) cooldown such as
 	// a prober or invalid_grant failure. It is not persisted.
 	authLevelCooldown bool `json:"-"`
+
+	// authLevelUnavailable and authLevelNextRetryAfter keep credential-scoped
+	// cooldown state separate from the model-state aggregate stored in Unavailable
+	// and NextRetryAfter. They are not persisted.
+	authLevelUnavailable    bool      `json:"-"`
+	authLevelNextRetryAfter time.Time `json:"-"`
 }
 
 const (

--- a/sdk/cliproxy/service_config.go
+++ b/sdk/cliproxy/service_config.go
@@ -189,6 +189,9 @@ func (s *Service) applyConfigRuntime(ctx context.Context, commit configCommit, s
 		return false
 	}
 	s.syncPluginModelRuntime(registrationCtx)
+	if s.coreManager != nil {
+		s.coreManager.RestartProber()
+	}
 	return ctx.Err() == nil
 }
 

--- a/sdk/cliproxy/service_executor_registration_test.go
+++ b/sdk/cliproxy/service_executor_registration_test.go
@@ -179,6 +179,38 @@ func TestRegisterExecutorForAuth_OpenAICompatUsesNamespacedProviderKey(t *testin
 	}
 }
 
+type customXAIExecutor struct{ serviceTestPluginExecutor }
+
+func (customXAIExecutor) Identifier() string { return "xai" }
+
+func TestRegisterAvailableExecutorsPreservesCallerProvidedExecutors(t *testing.T) {
+	service := &Service{
+		cfg:         &config.Config{},
+		coreManager: coreauth.NewManager(nil, nil, nil),
+	}
+
+	customExec := customXAIExecutor{}
+	service.coreManager.RegisterExecutor(customExec)
+
+	auth := &coreauth.Auth{
+		ID:       "xai-caller",
+		Provider: "xai",
+		Status:   coreauth.StatusActive,
+	}
+	service.coreManager.Register(context.Background(), auth)
+
+	service.registerAvailableExecutors(context.Background(), executorRegistrationOptions{
+		includeBaseline:   true,
+		forceReplaceAuths: false,
+		auths:             service.coreManager.List(),
+	})
+
+	existing, ok := service.coreManager.Executor("xai")
+	if !ok || existing != customExec {
+		t.Fatal("caller-provided xai executor should not be replaced at startup")
+	}
+}
+
 func openAICompatKimiAuth() *coreauth.Auth {
 	return &coreauth.Auth{
 		ID:       "compat-kimi",

--- a/sdk/cliproxy/service_executors.go
+++ b/sdk/cliproxy/service_executors.go
@@ -238,6 +238,24 @@ func (s *Service) registerExecutorsForAuths(auths []*coreauth.Auth, forceReplace
 	}
 }
 
+func (s *Service) bindExecutor(providerKey string, forceReplace bool, make func() coreauth.ProviderExecutor) {
+	if s == nil || s.coreManager == nil {
+		return
+	}
+	providerKey = strings.ToLower(strings.TrimSpace(providerKey))
+	if providerKey == "" {
+		return
+	}
+	if !forceReplace {
+		if _, has := s.coreManager.Executor(providerKey); has {
+			return
+		}
+	}
+	if make != nil {
+		s.coreManager.RegisterExecutor(make())
+	}
+}
+
 func (s *Service) registerExecutorForAuth(a *coreauth.Auth, forceReplace bool) {
 	if s == nil || s.coreManager == nil || a == nil {
 		return
@@ -246,16 +264,9 @@ func (s *Service) registerExecutorForAuth(a *coreauth.Auth, forceReplace bool) {
 	cfg := s.cfg
 	s.cfgMu.RUnlock()
 	if strings.EqualFold(strings.TrimSpace(a.Provider), "codex") {
-		if !forceReplace {
-			existingExecutor, hasExecutor := s.coreManager.Executor("codex")
-			if hasExecutor {
-				_, isCodexAutoExecutor := existingExecutor.(*executor.CodexAutoExecutor)
-				if isCodexAutoExecutor {
-					return
-				}
-			}
-		}
-		s.coreManager.RegisterExecutor(executor.NewCodexAutoExecutor(cfg))
+		s.bindExecutor("codex", forceReplace, func() coreauth.ProviderExecutor {
+			return executor.NewCodexAutoExecutor(cfg)
+		})
 		return
 	}
 	// Skip disabled auth entries when (re)binding executors.
@@ -276,28 +287,46 @@ func (s *Service) registerExecutorForAuth(a *coreauth.Auth, forceReplace bool) {
 	}
 	switch strings.ToLower(a.Provider) {
 	case constant.Gemini:
-		s.coreManager.RegisterExecutor(executor.NewGeminiExecutor(cfg))
+		s.bindExecutor("gemini", forceReplace, func() coreauth.ProviderExecutor {
+			return executor.NewGeminiExecutor(cfg)
+		})
 	case constant.GeminiInteractions:
-		s.coreManager.RegisterExecutor(executor.NewGeminiInteractionsExecutor(cfg))
+		s.bindExecutor("gemini-interactions", forceReplace, func() coreauth.ProviderExecutor {
+			return executor.NewGeminiInteractionsExecutor(cfg)
+		})
 	case "vertex":
-		s.coreManager.RegisterExecutor(executor.NewGeminiVertexExecutor(cfg))
+		s.bindExecutor("vertex", forceReplace, func() coreauth.ProviderExecutor {
+			return executor.NewGeminiVertexExecutor(cfg)
+		})
 	case "aistudio":
 		if s.wsGateway != nil {
-			s.coreManager.RegisterExecutor(executor.NewAIStudioExecutor(cfg, a.ID, s.wsGateway))
+			s.bindExecutor("aistudio", forceReplace, func() coreauth.ProviderExecutor {
+				return executor.NewAIStudioExecutor(cfg, a.ID, s.wsGateway)
+			})
 		}
 		return
 	case "antigravity":
-		s.coreManager.RegisterExecutor(executor.NewAntigravityExecutor(cfg))
+		s.bindExecutor("antigravity", forceReplace, func() coreauth.ProviderExecutor {
+			return executor.NewAntigravityExecutor(cfg)
+		})
 	case "claude":
-		s.coreManager.RegisterExecutor(executor.NewClaudeExecutor(cfg))
+		s.bindExecutor("claude", forceReplace, func() coreauth.ProviderExecutor {
+			return executor.NewClaudeExecutor(cfg)
+		})
 	case "kimi":
-		s.coreManager.RegisterExecutor(executor.NewKimiExecutor(cfg))
+		s.bindExecutor("kimi", forceReplace, func() coreauth.ProviderExecutor {
+			return executor.NewKimiExecutor(cfg)
+		})
 	case "xai":
 		if !forceReplace {
 			existingExecutor, hasExecutor := s.coreManager.Executor("xai")
 			if hasExecutor {
-				existingXAIAutoExecutor, isXAIAutoExecutor := existingExecutor.(*executor.XAIAutoExecutor)
-				if isXAIAutoExecutor && existingXAIAutoExecutor.UsesConfig(cfg) {
+				_, isXAIAutoExecutor := existingExecutor.(*executor.XAIAutoExecutor)
+				if !isXAIAutoExecutor {
+					return
+				}
+				existingXAIAutoExecutor := existingExecutor.(*executor.XAIAutoExecutor)
+				if existingXAIAutoExecutor.UsesConfig(cfg) {
 					return
 				}
 			}

--- a/sdk/cliproxy/service_lifecycle.go
+++ b/sdk/cliproxy/service_lifecycle.go
@@ -87,6 +87,12 @@ func (s *Service) Run(ctx context.Context) error {
 				log.Warnf("failed to restore cooldown state: %v", errRestoreCooldown)
 			}
 		}
+		auths := s.coreManager.List()
+		s.registerAvailableExecutors(coreauth.WithSkipPersist(ctx), executorRegistrationOptions{
+			includeBaseline:   true,
+			forceReplaceAuths: true,
+			auths:             auths,
+		})
 		s.coreManager.RestartProber()
 	}
 

--- a/sdk/cliproxy/service_lifecycle.go
+++ b/sdk/cliproxy/service_lifecycle.go
@@ -91,13 +91,6 @@ func (s *Service) Run(ctx context.Context) error {
 				log.Warnf("failed to restore cooldown state: %v", errRestoreCooldown)
 			}
 		}
-		auths := s.coreManager.List()
-		s.registerAvailableExecutors(coreauth.WithSkipPersist(ctx), executorRegistrationOptions{
-			includeBaseline:   true,
-			forceReplaceAuths: false,
-			auths:             auths,
-		})
-		s.coreManager.RestartProber()
 	}
 
 	if !homeEnabled {
@@ -127,9 +120,6 @@ func (s *Service) Run(ctx context.Context) error {
 		})
 		// Home mode does not expose in-process Redis RESP usage output; usage is forwarded to home instead.
 		redisqueue.SetEnabled(true)
-		if s.coreManager != nil {
-			s.coreManager.RestartProber()
-		}
 	}
 
 	// handlers no longer depend on legacy clients; pass nil slice initially
@@ -137,6 +127,20 @@ func (s *Service) Run(ctx context.Context) error {
 	s.syncPluginRuntimeConfig(ctx)
 	if homeEnabled {
 		s.syncPluginModelRuntime(ctx)
+	}
+
+	// Register executors and start the credential health prober only after
+	// websocket gateway and plugin runtime initialization are complete, so all
+	// startup executors are available before the first sweep.
+	if s.coreManager != nil {
+		if !homeEnabled {
+			s.registerAvailableExecutors(coreauth.WithSkipPersist(ctx), executorRegistrationOptions{
+				includeBaseline:   true,
+				forceReplaceAuths: false,
+				auths:             s.coreManager.List(),
+			})
+		}
+		s.coreManager.RestartProber()
 	}
 
 	if s.authManager == nil {

--- a/sdk/cliproxy/service_lifecycle.go
+++ b/sdk/cliproxy/service_lifecycle.go
@@ -286,6 +286,7 @@ func (s *Service) Shutdown(ctx context.Context) error {
 			s.watcherCancel()
 		}
 		if s.coreManager != nil {
+			s.coreManager.StopProber()
 			s.coreManager.StopAutoRefresh()
 		}
 		if s.watcher != nil {

--- a/sdk/cliproxy/service_lifecycle.go
+++ b/sdk/cliproxy/service_lifecycle.go
@@ -285,18 +285,20 @@ func (s *Service) Shutdown(ctx context.Context) error {
 
 		// legacy refresh loop removed; only stopping core auth manager below
 
+		// Fully stop the watcher before stopping the prober so no config update can
+		// start a fresh prober while shutdown is in progress.
 		if s.watcherCancel != nil {
 			s.watcherCancel()
-		}
-		if s.coreManager != nil {
-			s.coreManager.StopProber()
-			s.coreManager.StopAutoRefresh()
 		}
 		if s.watcher != nil {
 			if err := s.watcher.Stop(); err != nil {
 				log.Errorf("failed to stop file watcher: %v", err)
 				shutdownErr = err
 			}
+		}
+		if s.coreManager != nil {
+			s.coreManager.StopProber()
+			s.coreManager.StopAutoRefresh()
 		}
 		if s.wsGateway != nil {
 			if err := s.wsGateway.Stop(ctx); err != nil {

--- a/sdk/cliproxy/service_lifecycle.go
+++ b/sdk/cliproxy/service_lifecycle.go
@@ -94,7 +94,7 @@ func (s *Service) Run(ctx context.Context) error {
 		auths := s.coreManager.List()
 		s.registerAvailableExecutors(coreauth.WithSkipPersist(ctx), executorRegistrationOptions{
 			includeBaseline:   true,
-			forceReplaceAuths: true,
+			forceReplaceAuths: false,
 			auths:             auths,
 		})
 		s.coreManager.RestartProber()

--- a/sdk/cliproxy/service_lifecycle.go
+++ b/sdk/cliproxy/service_lifecycle.go
@@ -87,6 +87,7 @@ func (s *Service) Run(ctx context.Context) error {
 				log.Warnf("failed to restore cooldown state: %v", errRestoreCooldown)
 			}
 		}
+		s.coreManager.RestartProber()
 	}
 
 	if !homeEnabled {
@@ -116,6 +117,9 @@ func (s *Service) Run(ctx context.Context) error {
 		})
 		// Home mode does not expose in-process Redis RESP usage output; usage is forwarded to home instead.
 		redisqueue.SetEnabled(true)
+		if s.coreManager != nil {
+			s.coreManager.RestartProber()
+		}
 	}
 
 	// handlers no longer depend on legacy clients; pass nil slice initially

--- a/sdk/cliproxy/service_lifecycle.go
+++ b/sdk/cliproxy/service_lifecycle.go
@@ -36,6 +36,9 @@ func (s *Service) Run(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if s.coreManager != nil {
+		s.coreManager.SetProberParentContext(ctx)
+	}
 	ctx, runCancel := context.WithCancel(ctx)
 	s.homeMu.Lock()
 	s.runCancel = runCancel

--- a/sdk/cliproxy/service_lifecycle.go
+++ b/sdk/cliproxy/service_lifecycle.go
@@ -36,10 +36,10 @@ func (s *Service) Run(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	runCtx, runCancel := context.WithCancel(ctx)
 	if s.coreManager != nil {
-		s.coreManager.SetProberParentContext(ctx)
+		s.coreManager.SetProberParentContext(runCtx)
 	}
-	ctx, runCancel := context.WithCancel(ctx)
 	s.homeMu.Lock()
 	s.runCancel = runCancel
 	s.homeMu.Unlock()
@@ -305,6 +305,12 @@ func (s *Service) Shutdown(ctx context.Context) error {
 				log.Errorf("failed to stop file watcher: %v", err)
 				shutdownErr = err
 			}
+		}
+		s.homeMu.Lock()
+		runCancel := s.runCancel
+		s.homeMu.Unlock()
+		if runCancel != nil {
+			runCancel()
 		}
 		if s.coreManager != nil {
 			s.coreManager.StopProber()

--- a/sdk/cliproxy/service_lifecycle.go
+++ b/sdk/cliproxy/service_lifecycle.go
@@ -36,9 +36,13 @@ func (s *Service) Run(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	runCtx, runCancel := context.WithCancel(ctx)
+	// Derive the service-wide context once. Shutdown and Home-mode fatal errors
+	// cancel runCancel, so every operation in this run and the final select must
+	// observe runCtx instead of the caller's parent.
+	var runCancel context.CancelFunc
+	ctx, runCancel = context.WithCancel(ctx)
 	if s.coreManager != nil {
-		s.coreManager.SetProberParentContext(runCtx)
+		s.coreManager.SetProberParentContext(ctx)
 	}
 	s.homeMu.Lock()
 	s.runCancel = runCancel

--- a/sdk/cliproxy/service_lifecycle_test.go
+++ b/sdk/cliproxy/service_lifecycle_test.go
@@ -1,0 +1,139 @@
+package cliproxy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+type noopTokenProvider struct{}
+
+func (noopTokenProvider) Load(context.Context, *config.Config) (*TokenClientResult, error) {
+	return &TokenClientResult{}, nil
+}
+
+type noopAPIKeyProvider struct{}
+
+func (noopAPIKeyProvider) Load(context.Context, *config.Config) (*APIKeyClientResult, error) {
+	return &APIKeyClientResult{}, nil
+}
+
+func noopWatcherFactory(string, string, func(*config.Config)) (*WatcherWrapper, error) {
+	return &WatcherWrapper{}, nil
+}
+
+type proberResultHook struct {
+	results chan coreauth.Result
+}
+
+func (h *proberResultHook) OnAuthRegistered(context.Context, *coreauth.Auth) {}
+func (h *proberResultHook) OnAuthUpdated(context.Context, *coreauth.Auth)    {}
+func (h *proberResultHook) OnResult(_ context.Context, result coreauth.Result) {
+	h.results <- result
+}
+
+func TestServiceRunStartsProberAfterStartupExecutors(t *testing.T) {
+	// Pick a free port so we can poll the server for readiness before cancelling.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	cfg := &config.Config{
+		Host:    "127.0.0.1",
+		Port:    port,
+		AuthDir: t.TempDir(),
+	}
+
+	proberCfg := internalconfig.CredentialProberConfig{
+		Enabled:            true,
+		Interval:           time.Hour,
+		MaxConcurrency:     1,
+		RateLimitPerMinute: 1000,
+	}
+	hook := &proberResultHook{results: make(chan coreauth.Result, 1)}
+	manager := coreauth.NewManager(nil, nil, hook)
+	manager.SetConfig(&internalconfig.Config{CredentialProber: proberCfg})
+
+	if _, err := manager.Register(coreauth.WithSkipPersist(context.Background()), &coreauth.Auth{
+		ID:       "aistudio-auth",
+		Provider: "aistudio",
+		Status:   coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	service := &Service{
+		cfg:            cfg,
+		coreManager:    manager,
+		tokenProvider:  noopTokenProvider{},
+		apiKeyProvider: noopAPIKeyProvider{},
+		watcherFactory: noopWatcherFactory,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- service.Run(ctx)
+	}()
+
+	// Wait for the prober to sweep the aistudio executor, which is only
+	// registered after the websocket gateway is created.
+	var result coreauth.Result
+	select {
+	case result = <-hook.results:
+	case err := <-runErr:
+		t.Fatalf("service.Run returned before prober result: %v", err)
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for prober result")
+	}
+	if result.Provider != "aistudio" {
+		t.Fatalf("probed provider = %q, want aistudio", result.Provider)
+	}
+
+	// Wait for the HTTP server to be ready before cancelling, so Shutdown does
+	// not race Start.
+	healthURL := fmt.Sprintf("http://127.0.0.1:%d/healthz", port)
+	if err := waitForHTTP(healthURL, 5*time.Second); err != nil {
+		t.Fatalf("server healthz never ready: %v", err)
+	}
+
+	cancel()
+	select {
+	case err := <-runErr:
+		if err != nil && err != context.Canceled {
+			t.Fatalf("service.Run returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("service.Run did not stop after context cancel")
+	}
+}
+
+func waitForHTTP(url string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	client := &http.Client{Timeout: 100 * time.Millisecond}
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return fmt.Errorf("timeout waiting for %s", url)
+}


### PR DESCRIPTION
## Summary
Port of Plus #220 to stock. Adds an opt-in `credential-prober` config block and a periodic health prober in `sdk/cliproxy/auth`.

- New `internal/config/prober.go` with `CredentialProberConfig`; wired into `Config`.
- New `sdk/cliproxy/auth/conductor_prober.go` (+ tests) runs periodic `GET {base_url}/v1/models` probes via the existing `ProviderExecutor.HttpRequest`.
- Failures feed `Manager.MarkResult` with `CredentialScope: true` and `ErrorCodeForceCooldown`, reusing the existing cooldown/suspension machinery.
- `conductor.go` gains prober lifecycle fields; `conductor_cooldown.go` starts/stops the loop on config changes.
- Config docs added to `config.example.yaml`.
- Rate-limited by `rate-limit-per-minute`, concurrency-limited by `max-concurrency`, timeout-gated.

Relates to #220.