### PR TITLE
chore(models): remove Grok 4.5 from inventory

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -3752,33 +3752,6 @@
       ]
     },
     {
-      "id": "grok-4.5",
-      "object": "model",
-      "created": 1783526400,
-      "owned_by": "xai",
-      "type": "xai",
-      "display_name": "Grok 4.5",
-      "name": "grok-4.5",
-      "description": "SpaceXAI's intelligent coding model for agentic software, engineering, and workflow tasks.",
-      "context_length": 500000,
-      "max_completion_tokens": 65536,
-      "thinking": {
-        "zero_allowed": false,
-        "levels": [
-          "low",
-          "medium",
-          "high"
-        ]
-      },
-      "supportedInputModalities": [
-        "text",
-        "image"
-      ],
-      "supportedOutputModalities": [
-        "text"
-      ]
-    },
-    {
       "id": "grok-4.3",
       "object": "model",
       "created": 1775606400,


### PR DESCRIPTION
Production inventory correction: retain exact supported model ID `grok-4.6` and stop advertising retired `grok-4.5`. JSON validation passed; local registry contains one `grok-4.6` and zero `grok-4.5`.