### PR TITLE
feat: add managed users and OAuth invitations

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -34,9 +34,12 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/store"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/tui"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/usercontrol"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	sdkpluginstore "github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginstore"
 	log "github.com/sirupsen/logrus"
 )
@@ -599,6 +602,22 @@ func main() {
 		serverOptions = append(serverOptions, api.WithExampleAPIKeySafeMode())
 	}
 
+	var managedUsers *usercontrol.Service
+	if usePostgresStore {
+		repository := pgStoreInst.UserControlRepository()
+		ctxManagedUsers, cancelManagedUsers := context.WithTimeout(context.Background(), 30*time.Second)
+		errManagedUsers := repository.EnsureSchema(ctxManagedUsers)
+		cancelManagedUsers()
+		if errManagedUsers != nil {
+			log.Errorf("failed to initialize managed users: %v", errManagedUsers)
+			return
+		}
+		managedUsers = usercontrol.NewService(repository)
+		serverOptions = append(serverOptions, api.WithMiddleware(managedUsers.Middleware()), api.WithUserControl(managedUsers))
+		coreusage.RegisterNamedPlugin(managedUsers.Identifier(), managedUsers)
+		log.Info("managed users and OAuth invitations enabled with PostgreSQL")
+	}
+
 	// Register the shared token store once so all components use the same persistence backend.
 	if usePostgresStore {
 		sdkAuth.RegisterTokenStore(pgStoreInst)
@@ -612,6 +631,9 @@ func main() {
 
 	// Register built-in access providers before constructing services.
 	configaccess.Register(&cfg.SDKConfig)
+	if managedUsers != nil {
+		sdkaccess.RegisterProvider(managedUsers.Identifier(), managedUsers)
+	}
 	pluginHost.ApplyConfig(context.Background(), cfg)
 	if configLoadedFromHome && homePluginStatusReady {
 		errHomePluginLoad := homeplugins.MarkLoadResults(&homePluginSyncReport, pluginHost)

--- a/internal/api/handlers/management/auth_files_provider_oauth.go
+++ b/internal/api/handlers/management/auth_files_provider_oauth.go
@@ -67,6 +67,9 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 	}
 
 	RegisterOAuthSession(state, "anthropic")
+	if !h.reserveOAuthInvite(c, state, "anthropic") {
+		return
+	}
 
 	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
@@ -187,6 +190,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 			fmt.Println("API key obtained and saved")
 		}
 		fmt.Println("You can now use Claude services through this CLI")
+		h.completeOAuthContribution(ctx, state, record)
 		CompleteOAuthSession(state)
 	}()
 
@@ -227,6 +231,9 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 	}
 
 	RegisterOAuthSession(state, "codex")
+	if !h.reserveOAuthInvite(c, state, "codex") {
+		return
+	}
 
 	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
@@ -335,6 +342,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 			fmt.Println("API key obtained and saved")
 		}
 		fmt.Println("You can now use Codex services through this CLI")
+		h.completeOAuthContribution(ctx, state, record)
 		CompleteOAuthSession(state)
 	}()
 
@@ -360,6 +368,9 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 	authURL := authSvc.BuildAuthURL(state, redirectURI)
 
 	RegisterOAuthSession(state, "antigravity")
+	if !h.reserveOAuthInvite(c, state, "antigravity") {
+		return
+	}
 
 	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
@@ -497,6 +508,7 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 			return
 		}
 
+		h.completeOAuthContribution(ctx, state, record)
 		CompleteOAuthSession(state)
 		fmt.Printf("Authentication successful! Token saved to %s\n", savedPath)
 		if projectID != "" {
@@ -529,6 +541,9 @@ func (h *Handler) RequestXAIToken(c *gin.Context) {
 	}
 
 	RegisterOAuthSession(state, "xai")
+	if !h.reserveOAuthInvite(c, state, "xai") {
+		return
+	}
 
 	go func() {
 		pollCtx, cancelPoll := context.WithCancel(ctx)
@@ -604,6 +619,7 @@ func (h *Handler) RequestXAIToken(c *gin.Context) {
 			return
 		}
 
+		h.completeOAuthContribution(ctx, state, record)
 		CompleteOAuthSession(state)
 		fmt.Printf("Authentication successful! Token saved to %s\n", savedPath)
 		fmt.Println("You can now use xAI services through this CLI")
@@ -644,6 +660,9 @@ func (h *Handler) RequestKimiToken(c *gin.Context) {
 	}
 
 	RegisterOAuthSession(state, "kimi")
+	if !h.reserveOAuthInvite(c, state, "kimi") {
+		return
+	}
 
 	go func() {
 		pollCtx, cancelPoll := context.WithCancel(ctx)
@@ -704,6 +723,7 @@ func (h *Handler) RequestKimiToken(c *gin.Context) {
 
 		fmt.Printf("Authentication successful! Token saved to %s\n", savedPath)
 		fmt.Println("You can now use Kimi services through this CLI")
+		h.completeOAuthContribution(ctx, state, record)
 		CompleteOAuthSession(state)
 	}()
 

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginstore"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/usercontrol"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	log "github.com/sirupsen/logrus"
@@ -60,6 +61,7 @@ type Handler struct {
 	pluginStoreHTTPClient   pluginstore.HTTPDoer
 	pluginReleaseCacheMu    sync.Mutex
 	pluginReleaseCache      map[string]pluginReleaseCacheEntry
+	userControl             *usercontrol.Service
 }
 
 type configReloadSnapshot struct {
@@ -147,6 +149,16 @@ func (h *Handler) SetPluginHost(host *pluginhost.Host) {
 	}
 	h.mu.Lock()
 	h.pluginHost = host
+	h.mu.Unlock()
+}
+
+// SetUserControl enables managed users and public OAuth invitations.
+func (h *Handler) SetUserControl(service *usercontrol.Service) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	h.userControl = service
 	h.mu.Unlock()
 }
 

--- a/internal/api/handlers/management/public_oauth_invites.go
+++ b/internal/api/handlers/management/public_oauth_invites.go
@@ -1,0 +1,195 @@
+package management
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/usercontrol"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+const oauthInviteTokenContextKey = "oauth-invite-token"
+
+func (h *Handler) GetPublicOAuthInvite(c *gin.Context) {
+	service, ok := h.requireUserControl(c)
+	if !ok {
+		return
+	}
+	invite, err := service.GetOAuthInvite(c.Request.Context(), c.Param("token"))
+	if err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	c.Header("Cache-Control", "no-store")
+	c.JSON(http.StatusOK, gin.H{
+		"label": invite.Label, "providers": invite.Providers,
+		"remaining_uses": invite.MaxUses - invite.UsedUses - invite.ReservedUses,
+		"expires_at":     invite.ExpiresAt,
+	})
+}
+
+func (h *Handler) StartPublicOAuthInvite(c *gin.Context) {
+	service, ok := h.requireUserControl(c)
+	if !ok {
+		return
+	}
+	token := strings.TrimSpace(c.Param("token"))
+	if _, err := service.GetOAuthInvite(c.Request.Context(), token); err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	var request struct {
+		Provider string `json:"provider"`
+	}
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid provider payload"})
+		return
+	}
+	c.Set(oauthInviteTokenContextKey, token)
+	c.Header("Cache-Control", "no-store")
+	switch strings.ToLower(strings.TrimSpace(request.Provider)) {
+	case "anthropic":
+		h.RequestAnthropicToken(c)
+	case "codex":
+		h.RequestCodexToken(c)
+	case "antigravity":
+		h.RequestAntigravityToken(c)
+	case "kimi":
+		h.RequestKimiToken(c)
+	case "xai":
+		h.RequestXAIToken(c)
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported OAuth provider"})
+	}
+}
+
+func (h *Handler) GetPublicOAuthInviteStatus(c *gin.Context) {
+	service, ok := h.requireUserControl(c)
+	if !ok {
+		return
+	}
+	state := strings.TrimSpace(c.Query("state"))
+	if state == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "state is required"})
+		return
+	}
+	owns, err := service.OAuthInviteOwnsSession(c.Request.Context(), c.Param("token"), state)
+	if err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	if !owns {
+		c.JSON(http.StatusNotFound, gin.H{"error": "OAuth session not found"})
+		return
+	}
+	c.Header("Cache-Control", "no-store")
+	h.GetAuthStatus(c)
+}
+
+func (h *Handler) PostPublicOAuthInviteCallback(c *gin.Context) {
+	service, ok := h.requireUserControl(c)
+	if !ok {
+		return
+	}
+	var request oauthCallbackRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid callback payload"})
+		return
+	}
+	state := callbackRequestState(request)
+	if state == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "state is required"})
+		return
+	}
+	owns, err := service.OAuthInviteOwnsSession(c.Request.Context(), c.Param("token"), state)
+	if err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	if !owns {
+		c.JSON(http.StatusNotFound, gin.H{"error": "OAuth session not found"})
+		return
+	}
+	h.handleOAuthCallback(c, request)
+}
+
+func (h *Handler) ServePublicOAuthInvite(c *gin.Context) {
+	if _, ok := h.requireUserControl(c); !ok {
+		return
+	}
+	c.Header("Cache-Control", "no-store")
+	c.Header("Referrer-Policy", "no-referrer")
+	c.Header("X-Content-Type-Options", "nosniff")
+	c.Header("Content-Security-Policy", "default-src 'self'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'; base-uri 'none'; form-action 'self'")
+	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(oauthInviteHTML))
+}
+
+func (h *Handler) reserveOAuthInvite(c *gin.Context, state, provider string) bool {
+	rawToken, exists := c.Get(oauthInviteTokenContextKey)
+	if !exists {
+		return true
+	}
+	token, _ := rawToken.(string)
+	h.mu.Lock()
+	service := h.userControl
+	h.mu.Unlock()
+	if service == nil {
+		CancelOAuthSession(state)
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "OAuth invitations are unavailable"})
+		return false
+	}
+	if _, err := service.ReserveOAuthInvite(c.Request.Context(), token, state, provider); err != nil {
+		CancelOAuthSession(state)
+		writeUserControlError(c, err)
+		return false
+	}
+	return true
+}
+
+// completeOAuthContribution turns a temporary reservation into a consumed invitation.
+// Normal management logins have no reservation, so ErrNotFound is expected there.
+func (h *Handler) completeOAuthContribution(ctx context.Context, state string, record *coreauth.Auth) {
+	h.mu.Lock()
+	service := h.userControl
+	h.mu.Unlock()
+	if service == nil || record == nil {
+		return
+	}
+	email := ""
+	if record.Metadata != nil {
+		email, _ = record.Metadata["email"].(string)
+	}
+	if err := service.CompleteOAuthInvite(ctx, state, record.ID, email); err != nil && !errors.Is(err, usercontrol.ErrNotFound) {
+		log.WithError(err).WithField("state", state).Warn("failed to complete OAuth invitation contribution")
+	}
+}
+
+func callbackRequestState(request oauthCallbackRequest) string {
+	if state := strings.TrimSpace(request.State); state != "" {
+		return state
+	}
+	parsed, err := url.Parse(strings.TrimSpace(request.RedirectURL))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(parsed.Query().Get("state"))
+}
+
+const oauthInviteHTML = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Contribute an OAuth login</title><style>
+:root{color-scheme:dark;font-family:Inter,system-ui,sans-serif;background:#0b1020;color:#e8ecf6}body{margin:0;min-height:100vh;display:grid;place-items:center;padding:24px;box-sizing:border-box}.card{width:min(620px,100%);background:#141b2f;border:1px solid #27314d;border-radius:18px;padding:28px;box-shadow:0 24px 70px #0008}h1{margin:0 0 10px;font-size:28px}p{color:#aeb9d5;line-height:1.55}.providers{display:grid;gap:10px;margin:22px 0}button,a.action{border:0;border-radius:10px;background:#6d7cff;color:white;padding:12px 16px;font-weight:700;cursor:pointer;text-decoration:none;text-align:center}button:disabled{opacity:.5;cursor:not-allowed}.provider{display:flex;justify-content:space-between;align-items:center;background:#0e1528;border:1px solid #27314d;border-radius:12px;padding:13px}.status{padding:12px;border-radius:10px;background:#0e1528;min-height:22px}.callback{display:none;margin-top:16px}textarea{width:100%;min-height:90px;box-sizing:border-box;border:1px solid #39476d;border-radius:10px;background:#080d19;color:#fff;padding:11px;margin:8px 0 10px}.small{font-size:13px}
+</style></head><body><main class="card"><h1>Contribute an OAuth login</h1><p id="intro">Loading invitation…</p><div id="providers" class="providers"></div><div id="status" class="status">Waiting.</div><section id="callback" class="callback"><p class="small">If the provider redirects to localhost and the page does not close automatically, paste the complete redirected URL here.</p><textarea id="redirect" placeholder="http://localhost:.../?code=...&state=..."></textarea><button id="submitCallback">Send callback</button></section><p class="small">The server stores the OAuth credential in its normal OAuth Login list. This page never displays the credential.</p></main><script>
+const token=location.pathname.split('/').pop(),base='/v0/oauth/invites/'+encodeURIComponent(token);let state='',provider='',timer;
+const statusEl=document.getElementById('status'),providersEl=document.getElementById('providers'),callbackEl=document.getElementById('callback');
+async function json(url,options){const response=await fetch(url,options);const body=await response.json().catch(()=>({}));if(!response.ok)throw new Error(body.error||'Request failed');return body}
+async function load(){try{const invite=await json(base);document.getElementById('intro').textContent=invite.label+' · '+invite.remaining_uses+' use(s) remaining';invite.providers.forEach(name=>{const row=document.createElement('div');row.className='provider';const label=document.createElement('span');label.textContent=name;const button=document.createElement('button');button.textContent='Authorize';button.onclick=()=>start(name,button);row.append(label,button);providersEl.append(row)})}catch(error){statusEl.textContent=error.message}}
+async function start(name,button){try{document.querySelectorAll('button').forEach(item=>item.disabled=true);provider=name;const data=await json(base+'/start',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({provider:name})});state=data.state;statusEl.textContent=data.user_code?'Open the provider and enter code '+data.user_code:'Authorization opened in a new tab.';window.open(data.url,'_blank','noopener');callbackEl.style.display=data.flow==='device'?'none':'block';timer=setInterval(poll,1500)}catch(error){statusEl.textContent=error.message;button.disabled=false}}
+async function poll(){try{const data=await json(base+'/status?state='+encodeURIComponent(state));if(data.status==='ok'){clearInterval(timer);statusEl.textContent='Done. The OAuth login was saved.';callbackEl.style.display='none'}else if(data.status==='error'){clearInterval(timer);statusEl.textContent=data.error||'Authorization failed.'}}catch(error){clearInterval(timer);statusEl.textContent=error.message}}
+document.getElementById('submitCallback').onclick=async()=>{try{await json(base+'/callback',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({provider,state,redirect_url:document.getElementById('redirect').value})});statusEl.textContent='Callback received. Finishing authorization…'}catch(error){statusEl.textContent=error.message}};load();
+</script></body></html>`

--- a/internal/api/handlers/management/user_control.go
+++ b/internal/api/handlers/management/user_control.go
@@ -1,0 +1,230 @@
+package management
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/usercontrol"
+)
+
+func (h *Handler) ListManagedUsers(c *gin.Context) {
+	service, ok := h.requireUserControl(c)
+	if !ok {
+		return
+	}
+	users, err := service.ListUsers(c.Request.Context())
+	if err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"users": users})
+}
+
+func (h *Handler) CreateManagedUser(c *gin.Context) {
+	service, ok := h.requireUserControl(c)
+	if !ok {
+		return
+	}
+	var input usercontrol.CreateUserInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user payload"})
+		return
+	}
+	user, err := service.CreateUser(c.Request.Context(), input)
+	if err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, user)
+}
+
+func (h *Handler) GetManagedUser(c *gin.Context) {
+	service, ok := h.requireUserControl(c)
+	if !ok {
+		return
+	}
+	user, err := service.GetUser(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	keys, err := service.ListAPIKeys(c.Request.Context(), user.ID)
+	if err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	usage, err := service.GetUsage(c.Request.Context(), user.ID)
+	if err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"user": user, "api_keys": keys, "usage": usage})
+}
+
+func (h *Handler) UpdateManagedUser(c *gin.Context) {
+	service, ok := h.requireUserControl(c)
+	if !ok {
+		return
+	}
+	var input usercontrol.UpdateUserInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user payload"})
+		return
+	}
+	user, err := service.UpdateUser(c.Request.Context(), c.Param("id"), input)
+	if err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, user)
+}
+
+func (h *Handler) DeleteManagedUser(c *gin.Context) {
+	service, ok := h.requireUserControl(c)
+	if !ok {
+		return
+	}
+	if err := service.DeleteUser(c.Request.Context(), c.Param("id")); err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *Handler) ListManagedAPIKeys(c *gin.Context) {
+	service, ok := h.requireUserControl(c)
+	if !ok {
+		return
+	}
+	keys, err := service.ListAPIKeys(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"api_keys": keys})
+}
+
+func (h *Handler) CreateManagedAPIKey(c *gin.Context) {
+	service, ok := h.requireUserControl(c)
+	if !ok {
+		return
+	}
+	var input usercontrol.CreateAPIKeyInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid API key payload"})
+		return
+	}
+	key, err := service.CreateAPIKey(c.Request.Context(), c.Param("id"), input)
+	if err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	// The complete key is intentionally returned only by this response.
+	c.JSON(http.StatusCreated, key)
+}
+
+func (h *Handler) RevokeManagedAPIKey(c *gin.Context) {
+	service, ok := h.requireUserControl(c)
+	if !ok {
+		return
+	}
+	if err := service.RevokeAPIKey(c.Request.Context(), c.Param("id")); err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *Handler) GetManagedUserUsage(c *gin.Context) {
+	service, ok := h.requireUserControl(c)
+	if !ok {
+		return
+	}
+	usage, err := service.GetUsage(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, usage)
+}
+
+func (h *Handler) ListOAuthInvites(c *gin.Context) {
+	service, ok := h.requireUserControl(c)
+	if !ok {
+		return
+	}
+	invites, err := service.ListOAuthInvites(c.Request.Context())
+	if err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"invitations": invites})
+}
+
+func (h *Handler) CreateOAuthInvite(c *gin.Context) {
+	service, ok := h.requireUserControl(c)
+	if !ok {
+		return
+	}
+	var input usercontrol.CreateOAuthInviteInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid invitation payload"})
+		return
+	}
+	invite, err := service.CreateOAuthInvite(c.Request.Context(), input)
+	if err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	invite.URL = publicInviteURL(c, invite.Token)
+	c.JSON(http.StatusCreated, invite)
+}
+
+func (h *Handler) RevokeOAuthInvite(c *gin.Context) {
+	service, ok := h.requireUserControl(c)
+	if !ok {
+		return
+	}
+	if err := service.RevokeOAuthInvite(c.Request.Context(), c.Param("id")); err != nil {
+		writeUserControlError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *Handler) requireUserControl(c *gin.Context) (*usercontrol.Service, bool) {
+	h.mu.Lock()
+	service := h.userControl
+	h.mu.Unlock()
+	if service == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "managed users require PGSTORE_DSN"})
+		return nil, false
+	}
+	return service, true
+}
+
+func writeUserControlError(c *gin.Context, err error) {
+	status := http.StatusInternalServerError
+	switch {
+	case errors.Is(err, usercontrol.ErrNotFound):
+		status = http.StatusNotFound
+	case errors.Is(err, usercontrol.ErrInviteUnavailable):
+		status = http.StatusGone
+	case strings.Contains(strings.ToLower(err.Error()), "required"), strings.Contains(strings.ToLower(err.Error()), "unsupported"):
+		status = http.StatusBadRequest
+	}
+	c.JSON(status, gin.H{"error": err.Error()})
+}
+
+func publicInviteURL(c *gin.Context, token string) string {
+	scheme := "http"
+	if c.Request.TLS != nil {
+		scheme = "https"
+	} else if forwarded := strings.TrimSpace(strings.Split(c.GetHeader("X-Forwarded-Proto"), ",")[0]); forwarded == "http" || forwarded == "https" {
+		scheme = forwarded
+	}
+	host := strings.TrimSpace(c.Request.Host)
+	return scheme + "://" + host + "/oauth/invite/" + token
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -204,6 +204,7 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	s.mgmt = managementHandlers.NewHandler(cfg, configFilePath, authManager)
 	s.mgmt.SetPluginHost(optionState.pluginHost)
 	s.mgmt.SetConfigReloadHook(optionState.configReloadHook)
+	s.mgmt.SetUserControl(optionState.userControl)
 	if optionState.localPassword != "" {
 		s.mgmt.SetLocalPassword(optionState.localPassword)
 	}

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -23,6 +23,7 @@ func (s *Server) registerManagementRoutes() {
 
 	s.engine.POST("/v0/management/oauth-callback", s.managementAvailabilityMiddleware(), s.mgmt.PostOAuthCallback)
 	s.engine.GET("/v0/management/oauth-callback", s.managementAvailabilityMiddleware(), s.mgmt.GetOAuthCallback)
+	s.registerPublicOAuthInviteRoutes()
 
 	mgmt := s.engine.Group("/v0/management")
 	mgmt.Use(s.managementAvailabilityMiddleware(), s.mgmt.Middleware())
@@ -82,6 +83,19 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.DELETE("/api-keys", s.mgmt.DeleteAPIKeys)
 		mgmt.GET("/api-key-usage", s.mgmt.GetAPIKeyUsage)
 		mgmt.GET("/usage-queue", s.mgmt.GetUsageQueue)
+
+		mgmt.GET("/users", s.mgmt.ListManagedUsers)
+		mgmt.POST("/users", s.mgmt.CreateManagedUser)
+		mgmt.GET("/users/:id", s.mgmt.GetManagedUser)
+		mgmt.PATCH("/users/:id", s.mgmt.UpdateManagedUser)
+		mgmt.DELETE("/users/:id", s.mgmt.DeleteManagedUser)
+		mgmt.GET("/users/:id/api-keys", s.mgmt.ListManagedAPIKeys)
+		mgmt.POST("/users/:id/api-keys", s.mgmt.CreateManagedAPIKey)
+		mgmt.GET("/users/:id/usage", s.mgmt.GetManagedUserUsage)
+		mgmt.DELETE("/managed-api-keys/:id", s.mgmt.RevokeManagedAPIKey)
+		mgmt.GET("/oauth-invites", s.mgmt.ListOAuthInvites)
+		mgmt.POST("/oauth-invites", s.mgmt.CreateOAuthInvite)
+		mgmt.DELETE("/oauth-invites/:id", s.mgmt.RevokeOAuthInvite)
 
 		mgmt.GET("/gemini-api-key", s.mgmt.GetGeminiKeys)
 		mgmt.PUT("/gemini-api-key", s.mgmt.PutGeminiKeys)

--- a/internal/api/server_oauth_invites.go
+++ b/internal/api/server_oauth_invites.go
@@ -1,0 +1,12 @@
+package api
+
+func (s *Server) registerPublicOAuthInviteRoutes() {
+	if s == nil || s.engine == nil || s.mgmt == nil {
+		return
+	}
+	s.engine.GET("/oauth/invite/:token", s.managementAvailabilityMiddleware(), s.mgmt.ServePublicOAuthInvite)
+	s.engine.GET("/v0/oauth/invites/:token", s.managementAvailabilityMiddleware(), s.mgmt.GetPublicOAuthInvite)
+	s.engine.POST("/v0/oauth/invites/:token/start", s.managementAvailabilityMiddleware(), s.mgmt.StartPublicOAuthInvite)
+	s.engine.GET("/v0/oauth/invites/:token/status", s.managementAvailabilityMiddleware(), s.mgmt.GetPublicOAuthInviteStatus)
+	s.engine.POST("/v0/oauth/invites/:token/callback", s.managementAvailabilityMiddleware(), s.mgmt.PostPublicOAuthInviteCallback)
+}

--- a/internal/api/server_options.go
+++ b/internal/api/server_options.go
@@ -9,6 +9,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/usercontrol"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
@@ -27,6 +28,7 @@ type serverOptionConfig struct {
 	pluginHost            *pluginhost.Host
 	configReloadHook      func(context.Context, *config.Config)
 	exampleAPIKeySafeMode bool
+	userControl           *usercontrol.Service
 }
 
 // ServerOption customises HTTP server construction.
@@ -131,5 +133,12 @@ func WithConfigReloadHook(hook func(context.Context, *config.Config)) ServerOpti
 func WithExampleAPIKeySafeMode() ServerOption {
 	return func(cfg *serverOptionConfig) {
 		cfg.exampleAPIKeySafeMode = true
+	}
+}
+
+// WithUserControl enables managed accounts and OAuth invitation endpoints.
+func WithUserControl(service *usercontrol.Service) ServerOption {
+	return func(cfg *serverOptionConfig) {
+		cfg.userControl = service
 	}
 }

--- a/internal/store/postgresstore.go
+++ b/internal/store/postgresstore.go
@@ -15,6 +15,7 @@ import (
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/usercontrol"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	log "github.com/sirupsen/logrus"
 )
@@ -112,6 +113,14 @@ func (s *PostgresStore) Close() error {
 		return nil
 	}
 	return s.db.Close()
+}
+
+// UserControlRepository shares the existing connection pool without exposing it to callers.
+func (s *PostgresStore) UserControlRepository() *usercontrol.PostgresRepository {
+	if s == nil {
+		return nil
+	}
+	return usercontrol.NewPostgresRepository(s.db, s.cfg.Schema)
 }
 
 // EnsureSchema creates the required tables (and schema when provided).

--- a/internal/usercontrol/postgres_repository.go
+++ b/internal/usercontrol/postgres_repository.go
@@ -1,0 +1,464 @@
+package usercontrol
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const inviteReservationLifetime = 30 * time.Minute
+
+// PostgresRepository keeps account data beside the existing PostgreSQL auth store.
+// Table names are intentionally fixed; the configured schema still isolates deployments.
+type PostgresRepository struct {
+	db     *sql.DB
+	schema string
+}
+
+func NewPostgresRepository(db *sql.DB, schema string) *PostgresRepository {
+	return &PostgresRepository{db: db, schema: strings.TrimSpace(schema)}
+}
+
+func (r *PostgresRepository) EnsureSchema(ctx context.Context) error {
+	if r == nil || r.db == nil {
+		return fmt.Errorf("managed users: postgres is not initialized")
+	}
+	queries := []string{
+		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			email TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL,
+			requests_per_minute INTEGER NOT NULL DEFAULT 0,
+			concurrent_requests INTEGER NOT NULL DEFAULT 0,
+			monthly_tokens BIGINT NOT NULL DEFAULT 0,
+			allowed_models JSONB NOT NULL DEFAULT '[]'::jsonb,
+			expires_at TIMESTAMPTZ,
+			created_at TIMESTAMPTZ NOT NULL,
+			updated_at TIMESTAMPTZ NOT NULL
+		)`, r.table("managed_users")),
+		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES %s(id) ON DELETE CASCADE,
+			name TEXT NOT NULL,
+			prefix TEXT NOT NULL,
+			secret_hash BYTEA NOT NULL,
+			status TEXT NOT NULL,
+			expires_at TIMESTAMPTZ,
+			last_used_at TIMESTAMPTZ,
+			created_at TIMESTAMPTZ NOT NULL
+		)`, r.table("managed_api_keys"), r.table("managed_users")),
+		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+			user_id TEXT NOT NULL REFERENCES %s(id) ON DELETE CASCADE,
+			key_id TEXT NOT NULL REFERENCES %s(id) ON DELETE CASCADE,
+			period_start DATE NOT NULL,
+			requests BIGINT NOT NULL DEFAULT 0,
+			failed BIGINT NOT NULL DEFAULT 0,
+			input_tokens BIGINT NOT NULL DEFAULT 0,
+			output_tokens BIGINT NOT NULL DEFAULT 0,
+			total_tokens BIGINT NOT NULL DEFAULT 0,
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			PRIMARY KEY (user_id, key_id, period_start)
+		)`, r.table("managed_usage_monthly"), r.table("managed_users"), r.table("managed_api_keys")),
+		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+			id TEXT PRIMARY KEY,
+			token_hash BYTEA NOT NULL UNIQUE,
+			label TEXT NOT NULL,
+			providers JSONB NOT NULL,
+			max_uses INTEGER NOT NULL,
+			used_uses INTEGER NOT NULL DEFAULT 0,
+			reserved_uses INTEGER NOT NULL DEFAULT 0,
+			active BOOLEAN NOT NULL DEFAULT TRUE,
+			expires_at TIMESTAMPTZ,
+			created_at TIMESTAMPTZ NOT NULL
+		)`, r.table("oauth_invitations")),
+		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+			state TEXT PRIMARY KEY,
+			invite_id TEXT NOT NULL REFERENCES %s(id) ON DELETE CASCADE,
+			provider TEXT NOT NULL,
+			status TEXT NOT NULL,
+			auth_id TEXT NOT NULL DEFAULT '',
+			email TEXT NOT NULL DEFAULT '',
+			created_at TIMESTAMPTZ NOT NULL,
+			completed_at TIMESTAMPTZ
+		)`, r.table("oauth_invite_sessions"), r.table("oauth_invitations")),
+		fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s ON %s (user_id)`, quoteIdentifier("managed_api_keys_user_id_idx"), r.table("managed_api_keys")),
+		fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s ON %s (invite_id, status)`, quoteIdentifier("oauth_invite_sessions_invite_idx"), r.table("oauth_invite_sessions")),
+	}
+	for _, query := range queries {
+		if _, errExec := r.db.ExecContext(ctx, query); errExec != nil {
+			return fmt.Errorf("managed users: create schema: %w", errExec)
+		}
+	}
+	return nil
+}
+
+func (r *PostgresRepository) CreateUser(ctx context.Context, user User) (User, error) {
+	models, err := json.Marshal(user.Limits.AllowedModels)
+	if err != nil {
+		return User{}, fmt.Errorf("managed users: encode models: %w", err)
+	}
+	query := fmt.Sprintf(`INSERT INTO %s
+		(id, name, email, status, requests_per_minute, concurrent_requests, monthly_tokens, allowed_models, expires_at, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`, r.table("managed_users"))
+	_, err = r.db.ExecContext(ctx, query, user.ID, user.Name, user.Email, user.Status, user.Limits.RequestsPerMinute, user.Limits.ConcurrentRequests, user.Limits.MonthlyTokens, models, user.ExpiresAt, user.CreatedAt, user.UpdatedAt)
+	if err != nil {
+		return User{}, fmt.Errorf("managed users: create user: %w", err)
+	}
+	return user, nil
+}
+
+func (r *PostgresRepository) ListUsers(ctx context.Context) ([]User, error) {
+	query := fmt.Sprintf(`SELECT id, name, email, status, requests_per_minute, concurrent_requests, monthly_tokens, allowed_models, expires_at, created_at, updated_at FROM %s ORDER BY created_at DESC`, r.table("managed_users"))
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("managed users: list users: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	users := make([]User, 0)
+	for rows.Next() {
+		user, errScan := scanUser(rows)
+		if errScan != nil {
+			return nil, errScan
+		}
+		users = append(users, user)
+	}
+	return users, rows.Err()
+}
+
+func (r *PostgresRepository) GetUser(ctx context.Context, id string) (User, error) {
+	query := fmt.Sprintf(`SELECT id, name, email, status, requests_per_minute, concurrent_requests, monthly_tokens, allowed_models, expires_at, created_at, updated_at FROM %s WHERE id=$1`, r.table("managed_users"))
+	user, err := scanUser(r.db.QueryRowContext(ctx, query, id))
+	return user, normalizeNotFound(err)
+}
+
+func (r *PostgresRepository) UpdateUser(ctx context.Context, user User) (User, error) {
+	models, err := json.Marshal(user.Limits.AllowedModels)
+	if err != nil {
+		return User{}, fmt.Errorf("managed users: encode models: %w", err)
+	}
+	query := fmt.Sprintf(`UPDATE %s SET name=$2,email=$3,status=$4,requests_per_minute=$5,concurrent_requests=$6,monthly_tokens=$7,allowed_models=$8,expires_at=$9,updated_at=$10 WHERE id=$1`, r.table("managed_users"))
+	result, err := r.db.ExecContext(ctx, query, user.ID, user.Name, user.Email, user.Status, user.Limits.RequestsPerMinute, user.Limits.ConcurrentRequests, user.Limits.MonthlyTokens, models, user.ExpiresAt, user.UpdatedAt)
+	if err != nil {
+		return User{}, fmt.Errorf("managed users: update user: %w", err)
+	}
+	if err = requireChanged(result); err != nil {
+		return User{}, err
+	}
+	return user, nil
+}
+
+func (r *PostgresRepository) DeleteUser(ctx context.Context, id string) error {
+	result, err := r.db.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE id=$1`, r.table("managed_users")), id)
+	if err != nil {
+		return fmt.Errorf("managed users: delete user: %w", err)
+	}
+	return requireChanged(result)
+}
+
+func (r *PostgresRepository) CreateAPIKey(ctx context.Context, key APIKey, secretHash []byte) (APIKey, error) {
+	query := fmt.Sprintf(`INSERT INTO %s (id,user_id,name,prefix,secret_hash,status,expires_at,created_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`, r.table("managed_api_keys"))
+	_, err := r.db.ExecContext(ctx, query, key.ID, key.UserID, key.Name, key.Prefix, secretHash, key.Status, key.ExpiresAt, key.CreatedAt)
+	if err != nil {
+		return APIKey{}, fmt.Errorf("managed users: create API key: %w", err)
+	}
+	return key, nil
+}
+
+func (r *PostgresRepository) ListAPIKeys(ctx context.Context, userID string) ([]APIKey, error) {
+	query := fmt.Sprintf(`SELECT id,user_id,name,prefix,status,expires_at,last_used_at,created_at FROM %s WHERE user_id=$1 ORDER BY created_at DESC`, r.table("managed_api_keys"))
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("managed users: list API keys: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	keys := make([]APIKey, 0)
+	for rows.Next() {
+		key, errScan := scanAPIKey(rows)
+		if errScan != nil {
+			return nil, errScan
+		}
+		keys = append(keys, key)
+	}
+	return keys, rows.Err()
+}
+
+func (r *PostgresRepository) GetStoredAPIKey(ctx context.Context, id string) (StoredAPIKey, error) {
+	query := fmt.Sprintf(`SELECT
+		k.id,k.user_id,k.name,k.prefix,k.status,k.expires_at,k.last_used_at,k.created_at,k.secret_hash,
+		u.id,u.name,u.email,u.status,u.requests_per_minute,u.concurrent_requests,u.monthly_tokens,u.allowed_models,u.expires_at,u.created_at,u.updated_at,
+		COALESCE(SUM(m.total_tokens),0)
+		FROM %s k JOIN %s u ON u.id=k.user_id
+		LEFT JOIN %s m ON m.user_id=u.id AND m.period_start=DATE_TRUNC('month', NOW() AT TIME ZONE 'UTC')::date
+		WHERE k.id=$1 GROUP BY k.id,u.id`, r.table("managed_api_keys"), r.table("managed_users"), r.table("managed_usage_monthly"))
+	var stored StoredAPIKey
+	var models []byte
+	err := r.db.QueryRowContext(ctx, query, id).Scan(
+		&stored.ID, &stored.UserID, &stored.Name, &stored.Prefix, &stored.Status, &stored.ExpiresAt, &stored.LastUsedAt, &stored.CreatedAt, &stored.SecretHash,
+		&stored.User.ID, &stored.User.Name, &stored.User.Email, &stored.User.Status, &stored.User.Limits.RequestsPerMinute, &stored.User.Limits.ConcurrentRequests, &stored.User.Limits.MonthlyTokens, &models, &stored.User.ExpiresAt, &stored.User.CreatedAt, &stored.User.UpdatedAt,
+		&stored.UsedTokens,
+	)
+	if err != nil {
+		return StoredAPIKey{}, normalizeNotFound(err)
+	}
+	if err = json.Unmarshal(models, &stored.User.Limits.AllowedModels); err != nil {
+		return StoredAPIKey{}, fmt.Errorf("managed users: decode models: %w", err)
+	}
+	return stored, nil
+}
+
+func (r *PostgresRepository) RevokeAPIKey(ctx context.Context, id string) error {
+	result, err := r.db.ExecContext(ctx, fmt.Sprintf(`UPDATE %s SET status=$2 WHERE id=$1`, r.table("managed_api_keys")), id, KeyStatusRevoked)
+	if err != nil {
+		return fmt.Errorf("managed users: revoke API key: %w", err)
+	}
+	return requireChanged(result)
+}
+
+func (r *PostgresRepository) RecordUsage(ctx context.Context, delta UsageDelta) error {
+	query := fmt.Sprintf(`INSERT INTO %s AS usage (user_id,key_id,period_start,requests,failed,input_tokens,output_tokens,total_tokens,updated_at)
+		SELECT user_id,id,DATE_TRUNC('month', NOW() AT TIME ZONE 'UTC')::date,1,$2,$3,$4,$5,NOW() FROM %s WHERE id=$1
+		ON CONFLICT (user_id,key_id,period_start) DO UPDATE SET requests=usage.requests+1,failed=usage.failed+EXCLUDED.failed,input_tokens=usage.input_tokens+EXCLUDED.input_tokens,output_tokens=usage.output_tokens+EXCLUDED.output_tokens,total_tokens=usage.total_tokens+EXCLUDED.total_tokens,updated_at=NOW()`,
+		r.table("managed_usage_monthly"), r.table("managed_api_keys"))
+	failed := 0
+	if delta.Failed {
+		failed = 1
+	}
+	result, err := r.db.ExecContext(ctx, query, delta.KeyID, failed, delta.InputTokens, delta.OutputTokens, delta.TotalTokens)
+	if err != nil {
+		return fmt.Errorf("managed users: record usage: %w", err)
+	}
+	if affected, _ := result.RowsAffected(); affected == 0 {
+		return ErrNotFound
+	}
+	_, err = r.db.ExecContext(ctx, fmt.Sprintf(`UPDATE %s SET last_used_at=NOW() WHERE id=$1`, r.table("managed_api_keys")), delta.KeyID)
+	return err
+}
+
+func (r *PostgresRepository) GetUsage(ctx context.Context, userID string, periodStart time.Time) (UsageSummary, error) {
+	query := fmt.Sprintf(`SELECT COALESCE(SUM(requests),0),COALESCE(SUM(failed),0),COALESCE(SUM(input_tokens),0),COALESCE(SUM(output_tokens),0),COALESCE(SUM(total_tokens),0) FROM %s WHERE user_id=$1 AND period_start=$2`, r.table("managed_usage_monthly"))
+	summary := UsageSummary{UserID: userID, PeriodStart: periodStart}
+	err := r.db.QueryRowContext(ctx, query, userID, periodStart).Scan(&summary.Requests, &summary.Failed, &summary.InputTokens, &summary.OutputTokens, &summary.TotalTokens)
+	if err != nil {
+		return UsageSummary{}, fmt.Errorf("managed users: get usage: %w", err)
+	}
+	return summary, nil
+}
+
+func (r *PostgresRepository) CreateOAuthInvite(ctx context.Context, invite OAuthInvite, tokenHash []byte) (OAuthInvite, error) {
+	providers, err := json.Marshal(invite.Providers)
+	if err != nil {
+		return OAuthInvite{}, fmt.Errorf("OAuth invitations: encode providers: %w", err)
+	}
+	query := fmt.Sprintf(`INSERT INTO %s (id,token_hash,label,providers,max_uses,used_uses,reserved_uses,active,expires_at,created_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, r.table("oauth_invitations"))
+	_, err = r.db.ExecContext(ctx, query, invite.ID, tokenHash, invite.Label, providers, invite.MaxUses, invite.UsedUses, invite.ReservedUses, invite.Active, invite.ExpiresAt, invite.CreatedAt)
+	if err != nil {
+		return OAuthInvite{}, fmt.Errorf("OAuth invitations: create: %w", err)
+	}
+	return invite, nil
+}
+
+func (r *PostgresRepository) ListOAuthInvites(ctx context.Context) ([]OAuthInvite, error) {
+	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`SELECT id,label,providers,max_uses,used_uses,reserved_uses,active,expires_at,created_at FROM %s ORDER BY created_at DESC`, r.table("oauth_invitations")))
+	if err != nil {
+		return nil, fmt.Errorf("OAuth invitations: list: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	invites := make([]OAuthInvite, 0)
+	for rows.Next() {
+		invite, errScan := scanInvite(rows)
+		if errScan != nil {
+			return nil, errScan
+		}
+		invites = append(invites, invite)
+	}
+	return invites, rows.Err()
+}
+
+func (r *PostgresRepository) RevokeOAuthInvite(ctx context.Context, id string) error {
+	result, err := r.db.ExecContext(ctx, fmt.Sprintf(`UPDATE %s SET active=FALSE WHERE id=$1`, r.table("oauth_invitations")), id)
+	if err != nil {
+		return fmt.Errorf("OAuth invitations: revoke: %w", err)
+	}
+	return requireChanged(result)
+}
+
+func (r *PostgresRepository) GetOAuthInviteByTokenHash(ctx context.Context, tokenHash []byte) (OAuthInvite, error) {
+	query := fmt.Sprintf(`SELECT id,label,providers,max_uses,used_uses,reserved_uses,active,expires_at,created_at FROM %s WHERE token_hash=$1`, r.table("oauth_invitations"))
+	invite, err := scanInvite(r.db.QueryRowContext(ctx, query, tokenHash))
+	return invite, normalizeNotFound(err)
+}
+
+func (r *PostgresRepository) ReserveOAuthInvite(ctx context.Context, tokenHash []byte, state, provider string) (OAuthInvite, error) {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OAuthInvite{}, fmt.Errorf("OAuth invitations: start transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err = r.releaseStaleReservations(ctx, tx); err != nil {
+		return OAuthInvite{}, err
+	}
+	query := fmt.Sprintf(`SELECT id,label,providers,max_uses,used_uses,reserved_uses,active,expires_at,created_at FROM %s WHERE token_hash=$1 FOR UPDATE`, r.table("oauth_invitations"))
+	invite, err := scanInvite(tx.QueryRowContext(ctx, query, tokenHash))
+	if err != nil || !inviteAvailable(invite, time.Now()) || !containsProvider(invite.Providers, provider) {
+		return OAuthInvite{}, ErrInviteUnavailable
+	}
+	insert := fmt.Sprintf(`INSERT INTO %s (state,invite_id,provider,status,created_at) VALUES ($1,$2,$3,'pending',NOW())`, r.table("oauth_invite_sessions"))
+	if _, err = tx.ExecContext(ctx, insert, state, invite.ID, provider); err != nil {
+		return OAuthInvite{}, ErrInviteUnavailable
+	}
+	if _, err = tx.ExecContext(ctx, fmt.Sprintf(`UPDATE %s SET reserved_uses=reserved_uses+1 WHERE id=$1`, r.table("oauth_invitations")), invite.ID); err != nil {
+		return OAuthInvite{}, fmt.Errorf("OAuth invitations: reserve use: %w", err)
+	}
+	invite.ReservedUses++
+	if err = tx.Commit(); err != nil {
+		return OAuthInvite{}, fmt.Errorf("OAuth invitations: commit reservation: %w", err)
+	}
+	return invite, nil
+}
+
+func (r *PostgresRepository) OAuthInviteOwnsSession(ctx context.Context, tokenHash []byte, state string) (bool, error) {
+	query := fmt.Sprintf(`SELECT EXISTS(SELECT 1 FROM %s s JOIN %s i ON i.id=s.invite_id WHERE s.state=$1 AND i.token_hash=$2)`, r.table("oauth_invite_sessions"), r.table("oauth_invitations"))
+	var owns bool
+	if err := r.db.QueryRowContext(ctx, query, state, tokenHash).Scan(&owns); err != nil {
+		return false, fmt.Errorf("OAuth invitations: check session: %w", err)
+	}
+	return owns, nil
+}
+
+func (r *PostgresRepository) CompleteOAuthInvite(ctx context.Context, state, authID, email string) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("OAuth invitations: start completion: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var inviteID, status string
+	query := fmt.Sprintf(`SELECT invite_id,status FROM %s WHERE state=$1 FOR UPDATE`, r.table("oauth_invite_sessions"))
+	if err = tx.QueryRowContext(ctx, query, state).Scan(&inviteID, &status); err != nil {
+		return normalizeNotFound(err)
+	}
+	if status == "completed" {
+		return tx.Commit()
+	}
+	updateSession := fmt.Sprintf(`UPDATE %s SET status='completed',auth_id=$2,email=$3,completed_at=NOW() WHERE state=$1`, r.table("oauth_invite_sessions"))
+	if _, err = tx.ExecContext(ctx, updateSession, state, authID, email); err != nil {
+		return fmt.Errorf("OAuth invitations: complete session: %w", err)
+	}
+	updateInvite := fmt.Sprintf(`UPDATE %s SET reserved_uses=GREATEST(0,reserved_uses-1),used_uses=used_uses+1 WHERE id=$1`, r.table("oauth_invitations"))
+	if _, err = tx.ExecContext(ctx, updateInvite, inviteID); err != nil {
+		return fmt.Errorf("OAuth invitations: consume invitation: %w", err)
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("OAuth invitations: commit completion: %w", err)
+	}
+	return nil
+}
+
+func (r *PostgresRepository) releaseStaleReservations(ctx context.Context, tx *sql.Tx) error {
+	cutoff := time.Now().Add(-inviteReservationLifetime)
+	query := fmt.Sprintf(`UPDATE %s SET status='expired',completed_at=NOW() WHERE status='pending' AND created_at<$1 RETURNING invite_id`, r.table("oauth_invite_sessions"))
+	rows, err := tx.QueryContext(ctx, query, cutoff)
+	if err != nil {
+		return fmt.Errorf("OAuth invitations: release stale sessions: %w", err)
+	}
+	counts := make(map[string]int)
+	for rows.Next() {
+		var inviteID string
+		if errScan := rows.Scan(&inviteID); errScan != nil {
+			_ = rows.Close()
+			return fmt.Errorf("OAuth invitations: scan stale session: %w", errScan)
+		}
+		counts[inviteID]++
+	}
+	if err = rows.Close(); err != nil {
+		return fmt.Errorf("OAuth invitations: close stale sessions: %w", err)
+	}
+	for inviteID, count := range counts {
+		update := fmt.Sprintf(`UPDATE %s SET reserved_uses=GREATEST(0,reserved_uses-$2) WHERE id=$1`, r.table("oauth_invitations"))
+		if _, err = tx.ExecContext(ctx, update, inviteID, count); err != nil {
+			return fmt.Errorf("OAuth invitations: release stale reservation: %w", err)
+		}
+	}
+	return nil
+}
+
+type rowScanner interface {
+	Scan(...any) error
+}
+
+func scanUser(scanner rowScanner) (User, error) {
+	var user User
+	var models []byte
+	err := scanner.Scan(&user.ID, &user.Name, &user.Email, &user.Status, &user.Limits.RequestsPerMinute, &user.Limits.ConcurrentRequests, &user.Limits.MonthlyTokens, &models, &user.ExpiresAt, &user.CreatedAt, &user.UpdatedAt)
+	if err != nil {
+		return User{}, normalizeNotFound(err)
+	}
+	if err = json.Unmarshal(models, &user.Limits.AllowedModels); err != nil {
+		return User{}, fmt.Errorf("managed users: decode models: %w", err)
+	}
+	return user, nil
+}
+
+func scanAPIKey(scanner rowScanner) (APIKey, error) {
+	var key APIKey
+	err := scanner.Scan(&key.ID, &key.UserID, &key.Name, &key.Prefix, &key.Status, &key.ExpiresAt, &key.LastUsedAt, &key.CreatedAt)
+	if err != nil {
+		return APIKey{}, normalizeNotFound(err)
+	}
+	return key, nil
+}
+
+func scanInvite(scanner rowScanner) (OAuthInvite, error) {
+	var invite OAuthInvite
+	var providers []byte
+	err := scanner.Scan(&invite.ID, &invite.Label, &providers, &invite.MaxUses, &invite.UsedUses, &invite.ReservedUses, &invite.Active, &invite.ExpiresAt, &invite.CreatedAt)
+	if err != nil {
+		return OAuthInvite{}, normalizeNotFound(err)
+	}
+	if err = json.Unmarshal(providers, &invite.Providers); err != nil {
+		return OAuthInvite{}, fmt.Errorf("OAuth invitations: decode providers: %w", err)
+	}
+	return invite, nil
+}
+
+func (r *PostgresRepository) table(name string) string {
+	if r.schema == "" {
+		return quoteIdentifier(name)
+	}
+	return quoteIdentifier(r.schema) + "." + quoteIdentifier(name)
+}
+
+func quoteIdentifier(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
+}
+
+func normalizeNotFound(err error) error {
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrNotFound
+	}
+	return err
+}
+
+func requireChanged(result sql.Result) error {
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func containsProvider(providers []string, provider string) bool {
+	for _, candidate := range providers {
+		if strings.EqualFold(candidate, provider) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/usercontrol/service.go
+++ b/internal/usercontrol/service.go
@@ -1,0 +1,493 @@
+package usercontrol
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	log "github.com/sirupsen/logrus"
+)
+
+type requestPrincipalContextKey struct{}
+
+type limiterState struct {
+	windowStart time.Time
+	requests    int
+	inFlight    int
+}
+
+// Service joins persistent account data with the small amount of live state needed for rate limits.
+type Service struct {
+	repository Repository
+	mu         sync.Mutex
+	limits     map[string]*limiterState
+	now        func() time.Time
+}
+
+func NewService(repository Repository) *Service {
+	return &Service{repository: repository, limits: make(map[string]*limiterState), now: time.Now}
+}
+
+func (s *Service) Identifier() string { return "managed-users" }
+
+func (s *Service) Repository() Repository {
+	if s == nil {
+		return nil
+	}
+	return s.repository
+}
+
+// Authenticate implements the normal access-provider contract. The quota middleware has already
+// verified managed keys, so this path usually performs no second database lookup.
+func (s *Service) Authenticate(ctx context.Context, request *http.Request) (*sdkaccess.Result, *sdkaccess.AuthError) {
+	if principal, ok := principalFromContext(ctx); ok {
+		return principal.accessResult(s.Identifier()), nil
+	}
+	raw := credentialFromRequest(request)
+	if !strings.HasPrefix(raw, managedKeyPrefix) {
+		return nil, sdkaccess.NewNotHandledError()
+	}
+	principal, err := s.authenticateRaw(ctx, raw)
+	if err != nil {
+		return nil, sdkaccess.NewInvalidCredentialError()
+	}
+	return principal.accessResult(s.Identifier()), nil
+}
+
+// Middleware rejects exhausted managed keys before the request reaches an upstream provider.
+func (s *Service) Middleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if s == nil || s.repository == nil || skipManagedAuthentication(c.Request.URL.Path) {
+			c.Next()
+			return
+		}
+		raw := credentialFromRequest(c.Request)
+		if !strings.HasPrefix(raw, managedKeyPrefix) {
+			c.Next()
+			return
+		}
+
+		principal, err := s.authenticateRaw(c.Request.Context(), raw)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid or inactive API key"})
+			return
+		}
+		if model := requestModel(c.Request); !modelAllowed(model, principal.Key.User.Limits.AllowedModels) {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "model is not allowed for this user"})
+			return
+		}
+		release, retryAfter, errAcquire := s.acquire(principal)
+		if errAcquire != nil {
+			if retryAfter > 0 {
+				c.Header("Retry-After", fmt.Sprintf("%d", int(retryAfter.Round(time.Second)/time.Second)))
+			}
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": errAcquire.Error()})
+			return
+		}
+		defer release()
+
+		ctx := context.WithValue(c.Request.Context(), requestPrincipalContextKey{}, principal)
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	}
+}
+
+type requestPrincipal struct {
+	Key StoredAPIKey
+}
+
+func (p requestPrincipal) accessResult(provider string) *sdkaccess.Result {
+	return &sdkaccess.Result{
+		Provider:  provider,
+		Principal: principalPrefix + p.Key.ID,
+		Metadata: map[string]string{
+			"user_id": p.Key.UserID,
+			"key_id":  p.Key.ID,
+		},
+	}
+}
+
+func principalFromContext(ctx context.Context) (requestPrincipal, bool) {
+	if ctx == nil {
+		return requestPrincipal{}, false
+	}
+	principal, ok := ctx.Value(requestPrincipalContextKey{}).(requestPrincipal)
+	return principal, ok
+}
+
+func (s *Service) authenticateRaw(ctx context.Context, raw string) (requestPrincipal, error) {
+	keyID, secret, ok := parseManagedKey(raw)
+	if !ok {
+		return requestPrincipal{}, ErrInvalidCredential
+	}
+	stored, err := s.repository.GetStoredAPIKey(ctx, keyID)
+	if err != nil {
+		return requestPrincipal{}, ErrInvalidCredential
+	}
+	digest := sha256.Sum256([]byte(secret))
+	if len(stored.SecretHash) != len(digest) || subtle.ConstantTimeCompare(stored.SecretHash, digest[:]) != 1 {
+		return requestPrincipal{}, ErrInvalidCredential
+	}
+	now := s.now()
+	if stored.Status != KeyStatusActive || stored.User.Status != UserStatusActive {
+		return requestPrincipal{}, ErrDisabled
+	}
+	if expired(stored.ExpiresAt, now) || expired(stored.User.ExpiresAt, now) {
+		return requestPrincipal{}, ErrExpired
+	}
+	if limit := stored.User.Limits.MonthlyTokens; limit > 0 && stored.UsedTokens >= limit {
+		return requestPrincipal{}, ErrQuotaExceeded
+	}
+	return requestPrincipal{Key: stored}, nil
+}
+
+func (s *Service) acquire(principal requestPrincipal) (func(), time.Duration, error) {
+	limits := principal.Key.User.Limits
+	now := s.now()
+
+	s.mu.Lock()
+	state := s.limits[principal.Key.ID]
+	if state == nil {
+		state = &limiterState{windowStart: now}
+		s.limits[principal.Key.ID] = state
+	}
+	if now.Sub(state.windowStart) >= time.Minute {
+		state.windowStart = now
+		state.requests = 0
+	}
+	if limits.RequestsPerMinute > 0 && state.requests >= limits.RequestsPerMinute {
+		retry := time.Minute - now.Sub(state.windowStart)
+		s.mu.Unlock()
+		return func() {}, retry, ErrRateLimited
+	}
+	if limits.ConcurrentRequests > 0 && state.inFlight >= limits.ConcurrentRequests {
+		s.mu.Unlock()
+		return func() {}, time.Second, ErrRateLimited
+	}
+	state.requests++
+	state.inFlight++
+	s.mu.Unlock()
+
+	return func() {
+		s.mu.Lock()
+		if current := s.limits[principal.Key.ID]; current != nil && current.inFlight > 0 {
+			current.inFlight--
+		}
+		s.mu.Unlock()
+	}, 0, nil
+}
+
+func (s *Service) CreateUser(ctx context.Context, input CreateUserInput) (User, error) {
+	now := s.now().UTC()
+	status := normalizeStatus(input.Status, UserStatusActive)
+	user := User{ID: uuid.NewString(), Name: strings.TrimSpace(input.Name), Email: strings.TrimSpace(input.Email), Status: status, Limits: normalizeLimits(input.Limits), ExpiresAt: input.ExpiresAt, CreatedAt: now, UpdatedAt: now}
+	if user.Name == "" {
+		return User{}, fmt.Errorf("name is required")
+	}
+	return s.repository.CreateUser(ctx, user)
+}
+
+func (s *Service) ListUsers(ctx context.Context) ([]User, error) { return s.repository.ListUsers(ctx) }
+func (s *Service) GetUser(ctx context.Context, id string) (User, error) {
+	return s.repository.GetUser(ctx, id)
+}
+
+func (s *Service) UpdateUser(ctx context.Context, id string, input UpdateUserInput) (User, error) {
+	current, err := s.repository.GetUser(ctx, id)
+	if err != nil {
+		return User{}, err
+	}
+	current.Name = strings.TrimSpace(input.Name)
+	current.Email = strings.TrimSpace(input.Email)
+	current.Status = normalizeStatus(input.Status, current.Status)
+	current.Limits = normalizeLimits(input.Limits)
+	current.ExpiresAt = input.ExpiresAt
+	current.UpdatedAt = s.now().UTC()
+	if current.Name == "" {
+		return User{}, fmt.Errorf("name is required")
+	}
+	return s.repository.UpdateUser(ctx, current)
+}
+
+func (s *Service) DeleteUser(ctx context.Context, id string) error {
+	return s.repository.DeleteUser(ctx, id)
+}
+
+func (s *Service) CreateAPIKey(ctx context.Context, userID string, input CreateAPIKeyInput) (CreatedAPIKey, error) {
+	if _, err := s.repository.GetUser(ctx, userID); err != nil {
+		return CreatedAPIKey{}, err
+	}
+	keyID := uuid.NewString()
+	secret, err := randomToken(32)
+	if err != nil {
+		return CreatedAPIKey{}, err
+	}
+	digest := sha256.Sum256([]byte(secret))
+	prefix := managedKeyPrefix + keyID + "_"
+	key := APIKey{ID: keyID, UserID: userID, Name: strings.TrimSpace(input.Name), Prefix: prefix, Status: KeyStatusActive, ExpiresAt: input.ExpiresAt, CreatedAt: s.now().UTC()}
+	if key.Name == "" {
+		key.Name = "Default key"
+	}
+	stored, err := s.repository.CreateAPIKey(ctx, key, digest[:])
+	if err != nil {
+		return CreatedAPIKey{}, err
+	}
+	return CreatedAPIKey{APIKey: stored, Secret: prefix + secret}, nil
+}
+
+func (s *Service) ListAPIKeys(ctx context.Context, userID string) ([]APIKey, error) {
+	return s.repository.ListAPIKeys(ctx, userID)
+}
+
+func (s *Service) RevokeAPIKey(ctx context.Context, id string) error {
+	return s.repository.RevokeAPIKey(ctx, id)
+}
+
+func (s *Service) GetUsage(ctx context.Context, userID string) (UsageSummary, error) {
+	return s.repository.GetUsage(ctx, userID, monthStart(s.now()))
+}
+
+// HandleUsage receives final token counts asynchronously. APIKey contains our stable key ID,
+// never the secret that the user copied during key creation.
+func (s *Service) HandleUsage(ctx context.Context, record coreusage.Record) {
+	if s == nil || s.repository == nil || !strings.HasPrefix(record.APIKey, principalPrefix) {
+		return
+	}
+	keyID := strings.TrimPrefix(record.APIKey, principalPrefix)
+	delta := UsageDelta{KeyID: keyID, Failed: record.Failed, InputTokens: record.Detail.InputTokens, OutputTokens: record.Detail.OutputTokens, TotalTokens: record.Detail.TotalTokens}
+	if delta.TotalTokens == 0 {
+		delta.TotalTokens = delta.InputTokens + delta.OutputTokens
+	}
+	usageContext := context.Background()
+	if ctx != nil {
+		usageContext = context.WithoutCancel(ctx)
+	}
+	if err := s.repository.RecordUsage(usageContext, delta); err != nil {
+		log.WithError(err).WithField("key_id", keyID).Warn("failed to record managed user usage")
+	}
+}
+
+func (s *Service) CreateOAuthInvite(ctx context.Context, input CreateOAuthInviteInput) (CreatedOAuthInvite, error) {
+	providers, err := normalizeProviders(input.Providers)
+	if err != nil {
+		return CreatedOAuthInvite{}, err
+	}
+	token, err := randomToken(32)
+	if err != nil {
+		return CreatedOAuthInvite{}, err
+	}
+	digest := sha256.Sum256([]byte(token))
+	maxUses := input.MaxUses
+	if maxUses <= 0 {
+		maxUses = 1
+	}
+	invite := OAuthInvite{ID: uuid.NewString(), Label: strings.TrimSpace(input.Label), Providers: providers, MaxUses: maxUses, Active: true, ExpiresAt: input.ExpiresAt, CreatedAt: s.now().UTC()}
+	if invite.Label == "" {
+		invite.Label = "OAuth invitation"
+	}
+	stored, err := s.repository.CreateOAuthInvite(ctx, invite, digest[:])
+	if err != nil {
+		return CreatedOAuthInvite{}, err
+	}
+	return CreatedOAuthInvite{OAuthInvite: stored, Token: token}, nil
+}
+
+func (s *Service) ListOAuthInvites(ctx context.Context) ([]OAuthInvite, error) {
+	return s.repository.ListOAuthInvites(ctx)
+}
+
+func (s *Service) RevokeOAuthInvite(ctx context.Context, id string) error {
+	return s.repository.RevokeOAuthInvite(ctx, id)
+}
+
+func (s *Service) GetOAuthInvite(ctx context.Context, token string) (OAuthInvite, error) {
+	digest := sha256.Sum256([]byte(strings.TrimSpace(token)))
+	invite, err := s.repository.GetOAuthInviteByTokenHash(ctx, digest[:])
+	if err != nil {
+		return OAuthInvite{}, err
+	}
+	if !inviteAvailable(invite, s.now()) {
+		return OAuthInvite{}, ErrInviteUnavailable
+	}
+	return invite, nil
+}
+
+func (s *Service) ReserveOAuthInvite(ctx context.Context, token, state, provider string) (OAuthInvite, error) {
+	digest := sha256.Sum256([]byte(strings.TrimSpace(token)))
+	return s.repository.ReserveOAuthInvite(ctx, digest[:], strings.TrimSpace(state), strings.ToLower(strings.TrimSpace(provider)))
+}
+
+func (s *Service) OAuthInviteOwnsSession(ctx context.Context, token, state string) (bool, error) {
+	digest := sha256.Sum256([]byte(strings.TrimSpace(token)))
+	return s.repository.OAuthInviteOwnsSession(ctx, digest[:], strings.TrimSpace(state))
+}
+
+func (s *Service) CompleteOAuthInvite(ctx context.Context, state, authID, email string) error {
+	return s.repository.CompleteOAuthInvite(ctx, strings.TrimSpace(state), strings.TrimSpace(authID), strings.TrimSpace(email))
+}
+
+func parseManagedKey(raw string) (string, string, bool) {
+	parts := strings.SplitN(strings.TrimSpace(raw), "_", 3)
+	if len(parts) != 3 || parts[0] != "cpa" || strings.TrimSpace(parts[1]) == "" || strings.TrimSpace(parts[2]) == "" {
+		return "", "", false
+	}
+	if _, err := uuid.Parse(parts[1]); err != nil {
+		return "", "", false
+	}
+	return parts[1], parts[2], true
+}
+
+func credentialFromRequest(request *http.Request) string {
+	if request == nil {
+		return ""
+	}
+	if authorization := strings.TrimSpace(request.Header.Get("Authorization")); authorization != "" {
+		parts := strings.SplitN(authorization, " ", 2)
+		if len(parts) == 2 && strings.EqualFold(parts[0], "Bearer") {
+			return strings.TrimSpace(parts[1])
+		}
+		return authorization
+	}
+	for _, value := range []string{request.Header.Get("X-Goog-Api-Key"), request.Header.Get("X-Api-Key")} {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	if request.URL != nil {
+		if value := strings.TrimSpace(request.URL.Query().Get("key")); value != "" {
+			return value
+		}
+		return strings.TrimSpace(request.URL.Query().Get("auth_token"))
+	}
+	return ""
+}
+
+func requestModel(request *http.Request) string {
+	if request == nil || request.Body == nil {
+		return ""
+	}
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		return ""
+	}
+	request.Body = io.NopCloser(bytes.NewReader(body))
+	var payload struct {
+		Model string `json:"model"`
+	}
+	_ = json.Unmarshal(body, &payload)
+	return strings.TrimSpace(payload.Model)
+}
+
+func modelAllowed(model string, allowed []string) bool {
+	if len(allowed) == 0 || strings.TrimSpace(model) == "" {
+		return true
+	}
+	for _, pattern := range allowed {
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "*" || strings.EqualFold(pattern, model) {
+			return true
+		}
+		if matched, _ := path.Match(strings.ToLower(pattern), strings.ToLower(model)); matched {
+			return true
+		}
+	}
+	return false
+}
+
+func skipManagedAuthentication(requestPath string) bool {
+	return strings.HasPrefix(requestPath, "/v0/management") || strings.HasPrefix(requestPath, "/v0/oauth") || strings.HasPrefix(requestPath, "/oauth/invite") || requestPath == "/healthz"
+}
+
+func normalizeLimits(limits Limits) Limits {
+	if limits.RequestsPerMinute < 0 {
+		limits.RequestsPerMinute = 0
+	}
+	if limits.ConcurrentRequests < 0 {
+		limits.ConcurrentRequests = 0
+	}
+	if limits.MonthlyTokens < 0 {
+		limits.MonthlyTokens = 0
+	}
+	seen := make(map[string]struct{})
+	models := make([]string, 0, len(limits.AllowedModels))
+	for _, model := range limits.AllowedModels {
+		model = strings.TrimSpace(model)
+		if model == "" {
+			continue
+		}
+		key := strings.ToLower(model)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		models = append(models, model)
+	}
+	limits.AllowedModels = models
+	return limits
+}
+
+func normalizeStatus(status, fallback string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case UserStatusActive:
+		return UserStatusActive
+	case UserStatusDisabled:
+		return UserStatusDisabled
+	default:
+		return fallback
+	}
+}
+
+func normalizeProviders(providers []string) ([]string, error) {
+	allowed := map[string]struct{}{"anthropic": {}, "codex": {}, "antigravity": {}, "kimi": {}, "xai": {}}
+	seen := make(map[string]struct{})
+	out := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		provider = strings.ToLower(strings.TrimSpace(provider))
+		if _, ok := allowed[provider]; !ok {
+			return nil, fmt.Errorf("unsupported OAuth provider %q", provider)
+		}
+		if _, exists := seen[provider]; exists {
+			continue
+		}
+		seen[provider] = struct{}{}
+		out = append(out, provider)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("at least one OAuth provider is required")
+	}
+	return out, nil
+}
+
+func inviteAvailable(invite OAuthInvite, now time.Time) bool {
+	return invite.Active && !expired(invite.ExpiresAt, now) && invite.UsedUses+invite.ReservedUses < invite.MaxUses
+}
+
+func expired(value *time.Time, now time.Time) bool { return value != nil && !value.After(now) }
+
+func randomToken(size int) (string, error) {
+	buffer := make([]byte, size)
+	if _, err := rand.Read(buffer); err != nil {
+		return "", fmt.Errorf("generate secure token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buffer), nil
+}
+
+func monthStart(now time.Time) time.Time {
+	now = now.UTC()
+	return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+}

--- a/internal/usercontrol/service_test.go
+++ b/internal/usercontrol/service_test.go
@@ -1,0 +1,225 @@
+package usercontrol
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type memoryRepository struct {
+	Repository
+	mu       sync.Mutex
+	users    map[string]User
+	keys     map[string]StoredAPIKey
+	invites  map[string]OAuthInvite
+	sessions map[string]string
+}
+
+func newMemoryRepository() *memoryRepository {
+	return &memoryRepository{
+		users:    make(map[string]User),
+		keys:     make(map[string]StoredAPIKey),
+		invites:  make(map[string]OAuthInvite),
+		sessions: make(map[string]string),
+	}
+}
+
+func (r *memoryRepository) CreateUser(_ context.Context, user User) (User, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.users[user.ID] = user
+	return user, nil
+}
+
+func (r *memoryRepository) GetUser(_ context.Context, id string) (User, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	user, ok := r.users[id]
+	if !ok {
+		return User{}, ErrNotFound
+	}
+	return user, nil
+}
+
+func (r *memoryRepository) CreateAPIKey(_ context.Context, key APIKey, hash []byte) (APIKey, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.keys[key.ID] = StoredAPIKey{APIKey: key, SecretHash: append([]byte(nil), hash...), User: r.users[key.UserID]}
+	return key, nil
+}
+
+func (r *memoryRepository) GetStoredAPIKey(_ context.Context, id string) (StoredAPIKey, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key, ok := r.keys[id]
+	if !ok {
+		return StoredAPIKey{}, ErrNotFound
+	}
+	key.User = r.users[key.UserID]
+	return key, nil
+}
+
+func (r *memoryRepository) CreateOAuthInvite(_ context.Context, invite OAuthInvite, hash []byte) (OAuthInvite, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.invites[hex.EncodeToString(hash)] = invite
+	return invite, nil
+}
+
+func (r *memoryRepository) GetOAuthInviteByTokenHash(_ context.Context, hash []byte) (OAuthInvite, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	invite, ok := r.invites[hex.EncodeToString(hash)]
+	if !ok {
+		return OAuthInvite{}, ErrNotFound
+	}
+	return invite, nil
+}
+
+func (r *memoryRepository) ReserveOAuthInvite(_ context.Context, hash []byte, state, provider string) (OAuthInvite, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := hex.EncodeToString(hash)
+	invite, ok := r.invites[key]
+	if !ok || !inviteAvailable(invite, time.Now()) || !containsProvider(invite.Providers, provider) {
+		return OAuthInvite{}, ErrInviteUnavailable
+	}
+	invite.ReservedUses++
+	r.invites[key] = invite
+	r.sessions[state] = key
+	return invite, nil
+}
+
+func (r *memoryRepository) OAuthInviteOwnsSession(_ context.Context, hash []byte, state string) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.sessions[state] == hex.EncodeToString(hash), nil
+}
+
+func (r *memoryRepository) CompleteOAuthInvite(_ context.Context, state, _, _ string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key, ok := r.sessions[state]
+	if !ok {
+		return ErrNotFound
+	}
+	invite := r.invites[key]
+	invite.ReservedUses--
+	invite.UsedUses++
+	r.invites[key] = invite
+	return nil
+}
+
+func TestManagedAPIKeyAuthenticatesWithoutReturningTheSecret(t *testing.T) {
+	repository := newMemoryRepository()
+	service := NewService(repository)
+	user, err := service.CreateUser(context.Background(), CreateUserInput{Name: "Ada", Limits: Limits{MonthlyTokens: 1000}})
+	if err != nil {
+		t.Fatalf("CreateUser() error = %v", err)
+	}
+	created, err := service.CreateAPIKey(context.Background(), user.ID, CreateAPIKeyInput{Name: "Laptop"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey() error = %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	request.Header.Set("Authorization", "Bearer "+created.Secret)
+	result, authErr := service.Authenticate(context.Background(), request)
+	if authErr != nil {
+		t.Fatalf("Authenticate() error = %v", authErr)
+	}
+	if result.Principal != principalPrefix+created.ID {
+		t.Fatalf("Authenticate() principal = %q", result.Principal)
+	}
+	if strings.Contains(result.Principal, created.Secret) {
+		t.Fatal("principal exposed the API key secret")
+	}
+
+	stored := repository.keys[created.ID]
+	if string(stored.SecretHash) == created.Secret {
+		t.Fatal("repository stored the API key in plaintext")
+	}
+	parts := strings.SplitN(created.Secret, "_", 3)
+	wantHash := sha256.Sum256([]byte(parts[2]))
+	if string(stored.SecretHash) != string(wantHash[:]) {
+		t.Fatal("repository did not receive the expected secret digest")
+	}
+}
+
+func TestManagedMiddlewareEnforcesModelsAndRateLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repository := newMemoryRepository()
+	service := NewService(repository)
+	user, err := service.CreateUser(context.Background(), CreateUserInput{
+		Name: "Grace",
+		Limits: Limits{
+			RequestsPerMinute: 1,
+			AllowedModels:     []string{"gpt-*"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateUser() error = %v", err)
+	}
+	key, err := service.CreateAPIKey(context.Background(), user.ID, CreateAPIKeyInput{})
+	if err != nil {
+		t.Fatalf("CreateAPIKey() error = %v", err)
+	}
+
+	router := gin.New()
+	router.Use(service.Middleware())
+	router.POST("/v1/chat/completions", func(c *gin.Context) { c.Status(http.StatusNoContent) })
+
+	request := func(model string) int {
+		recorder := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"`+model+`"}`))
+		req.Header.Set("Authorization", "Bearer "+key.Secret)
+		router.ServeHTTP(recorder, req)
+		return recorder.Code
+	}
+	if got := request("claude-sonnet"); got != http.StatusForbidden {
+		t.Fatalf("disallowed model status = %d, want 403", got)
+	}
+	if got := request("gpt-5"); got != http.StatusNoContent {
+		t.Fatalf("first allowed request status = %d, want 204", got)
+	}
+	if got := request("gpt-5"); got != http.StatusTooManyRequests {
+		t.Fatalf("rate-limited request status = %d, want 429", got)
+	}
+}
+
+func TestOAuthInvitationCanOnlyConsumeAnAllowedSessionOnce(t *testing.T) {
+	repository := newMemoryRepository()
+	service := NewService(repository)
+	created, err := service.CreateOAuthInvite(context.Background(), CreateOAuthInviteInput{
+		Label:     "Community login",
+		Providers: []string{"kimi"},
+		MaxUses:   1,
+	})
+	if err != nil {
+		t.Fatalf("CreateOAuthInvite() error = %v", err)
+	}
+	if _, err = service.ReserveOAuthInvite(context.Background(), created.Token, "state-1", "codex"); err != ErrInviteUnavailable {
+		t.Fatalf("ReserveOAuthInvite(codex) error = %v, want ErrInviteUnavailable", err)
+	}
+	if _, err = service.ReserveOAuthInvite(context.Background(), created.Token, "state-1", "kimi"); err != nil {
+		t.Fatalf("ReserveOAuthInvite(kimi) error = %v", err)
+	}
+	owns, err := service.OAuthInviteOwnsSession(context.Background(), created.Token, "state-1")
+	if err != nil || !owns {
+		t.Fatalf("OAuthInviteOwnsSession() = %v, %v", owns, err)
+	}
+	if err = service.CompleteOAuthInvite(context.Background(), "state-1", "kimi.json", ""); err != nil {
+		t.Fatalf("CompleteOAuthInvite() error = %v", err)
+	}
+	if _, err = service.GetOAuthInvite(context.Background(), created.Token); err != ErrInviteUnavailable {
+		t.Fatalf("GetOAuthInvite() after use error = %v, want ErrInviteUnavailable", err)
+	}
+}

--- a/internal/usercontrol/types.go
+++ b/internal/usercontrol/types.go
@@ -1,0 +1,160 @@
+// Package usercontrol manages downstream users, API keys, quotas, and OAuth invitations.
+package usercontrol
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+const (
+	UserStatusActive   = "active"
+	UserStatusDisabled = "disabled"
+	KeyStatusActive    = "active"
+	KeyStatusRevoked   = "revoked"
+
+	managedKeyPrefix = "cpa_"
+	principalPrefix  = "managed:"
+)
+
+var (
+	ErrNotFound          = errors.New("managed resource not found")
+	ErrInvalidCredential = errors.New("invalid managed API key")
+	ErrDisabled          = errors.New("managed API key is disabled")
+	ErrExpired           = errors.New("managed API key is expired")
+	ErrQuotaExceeded     = errors.New("managed user quota exceeded")
+	ErrRateLimited       = errors.New("managed user rate limit exceeded")
+	ErrInviteUnavailable = errors.New("OAuth invitation is unavailable")
+)
+
+// Limits are inherited by every API key owned by a user.
+type Limits struct {
+	RequestsPerMinute  int      `json:"requests_per_minute"`
+	ConcurrentRequests int      `json:"concurrent_requests"`
+	MonthlyTokens      int64    `json:"monthly_tokens"`
+	AllowedModels      []string `json:"allowed_models"`
+}
+
+type User struct {
+	ID        string     `json:"id"`
+	Name      string     `json:"name"`
+	Email     string     `json:"email,omitempty"`
+	Status    string     `json:"status"`
+	Limits    Limits     `json:"limits"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+}
+
+type CreateUserInput struct {
+	Name      string     `json:"name"`
+	Email     string     `json:"email"`
+	Status    string     `json:"status"`
+	Limits    Limits     `json:"limits"`
+	ExpiresAt *time.Time `json:"expires_at"`
+}
+
+type UpdateUserInput = CreateUserInput
+
+type APIKey struct {
+	ID         string     `json:"id"`
+	UserID     string     `json:"user_id"`
+	Name       string     `json:"name"`
+	Prefix     string     `json:"prefix"`
+	Status     string     `json:"status"`
+	ExpiresAt  *time.Time `json:"expires_at,omitempty"`
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+	CreatedAt  time.Time  `json:"created_at"`
+}
+
+type CreatedAPIKey struct {
+	APIKey
+	// Secret is returned once. Only its SHA-256 digest is persisted.
+	Secret string `json:"secret"`
+}
+
+type CreateAPIKeyInput struct {
+	Name      string     `json:"name"`
+	ExpiresAt *time.Time `json:"expires_at"`
+}
+
+type StoredAPIKey struct {
+	APIKey
+	SecretHash []byte
+	User       User
+	UsedTokens int64
+}
+
+type UsageSummary struct {
+	UserID       string    `json:"user_id"`
+	PeriodStart  time.Time `json:"period_start"`
+	Requests     int64     `json:"requests"`
+	Failed       int64     `json:"failed"`
+	InputTokens  int64     `json:"input_tokens"`
+	OutputTokens int64     `json:"output_tokens"`
+	TotalTokens  int64     `json:"total_tokens"`
+}
+
+type UsageDelta struct {
+	KeyID        string
+	Failed       bool
+	InputTokens  int64
+	OutputTokens int64
+	TotalTokens  int64
+}
+
+type OAuthInvite struct {
+	ID           string     `json:"id"`
+	Label        string     `json:"label"`
+	Providers    []string   `json:"providers"`
+	MaxUses      int        `json:"max_uses"`
+	UsedUses     int        `json:"used_uses"`
+	ReservedUses int        `json:"reserved_uses"`
+	Active       bool       `json:"active"`
+	ExpiresAt    *time.Time `json:"expires_at,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+}
+
+type CreatedOAuthInvite struct {
+	OAuthInvite
+	// Token is deliberately omitted from every later list response.
+	Token string `json:"token"`
+	URL   string `json:"url,omitempty"`
+}
+
+type CreateOAuthInviteInput struct {
+	Label     string     `json:"label"`
+	Providers []string   `json:"providers"`
+	MaxUses   int        `json:"max_uses"`
+	ExpiresAt *time.Time `json:"expires_at"`
+}
+
+type OAuthContribution struct {
+	InviteID    string    `json:"invite_id"`
+	Provider    string    `json:"provider"`
+	AuthID      string    `json:"auth_id"`
+	Email       string    `json:"email,omitempty"`
+	CompletedAt time.Time `json:"completed_at"`
+}
+
+// Repository keeps the service independent from the concrete PostgreSQL implementation.
+type Repository interface {
+	CreateUser(context.Context, User) (User, error)
+	ListUsers(context.Context) ([]User, error)
+	GetUser(context.Context, string) (User, error)
+	UpdateUser(context.Context, User) (User, error)
+	DeleteUser(context.Context, string) error
+	CreateAPIKey(context.Context, APIKey, []byte) (APIKey, error)
+	ListAPIKeys(context.Context, string) ([]APIKey, error)
+	GetStoredAPIKey(context.Context, string) (StoredAPIKey, error)
+	RevokeAPIKey(context.Context, string) error
+	RecordUsage(context.Context, UsageDelta) error
+	GetUsage(context.Context, string, time.Time) (UsageSummary, error)
+	CreateOAuthInvite(context.Context, OAuthInvite, []byte) (OAuthInvite, error)
+	ListOAuthInvites(context.Context) ([]OAuthInvite, error)
+	RevokeOAuthInvite(context.Context, string) error
+	GetOAuthInviteByTokenHash(context.Context, []byte) (OAuthInvite, error)
+	ReserveOAuthInvite(context.Context, []byte, string, string) (OAuthInvite, error)
+	OAuthInviteOwnsSession(context.Context, []byte, string) (bool, error)
+	CompleteOAuthInvite(context.Context, string, string, string) error
+}


### PR DESCRIPTION
## Summary
- add PostgreSQL-backed managed users with individual API keys
- enforce per-user request/minute, concurrency, monthly token, expiration, status, and model allowlist limits
- add single-view hashed API keys and monthly usage accounting
- add revocable, expiring, limited-use public OAuth invitation links for Anthropic, Codex, Antigravity, Kimi, and xAI
- save contributed credentials through the existing OAuth Login/auth-files flow
- expose management endpoints for the companion Management Center UI

## Security
- managed API key secrets are returned once and only their SHA-256 digest is stored
- invitation tokens are also stored as SHA-256 digests
- callback and status requests must match the invitation-owned OAuth state
- public invitation responses use no-store and no-referrer protections
- the feature is enabled only when PGSTORE_DSN is configured

## Verification
- focused managed-user, management handler, and API tests passed
- management center integration is proposed separately in the companion repository
- the full Windows suite still has unrelated existing failures in Claude fingerprint expectations, git-store rename recovery, and stale util invariant entries