### PR TITLE
fix(antigravity): raise the fallback client version to 2.9.1 (#5175)

### DIFF
--- a/internal/misc/antigravity_version.go
+++ b/internal/misc/antigravity_version.go
@@ -16,7 +16,11 @@ import (
 )
 
 const (
-	antigravityFallbackVersion = "2.2.1"
+	// antigravityFallbackVersion is the client version reported when the hub
+	// manifest has not been fetched yet or cannot be reached. Cloud Code rejects
+	// newer models for clients below 2.9.0, so this floor must stay at or above
+	// that version.
+	antigravityFallbackVersion = "2.9.1"
 	antigravityHubPlatform     = "darwin/arm64"
 	antigravityVersionCacheTTL = 6 * time.Hour
 	antigravityFetchTimeout    = 10 * time.Second

--- a/internal/misc/antigravity_version_test.go
+++ b/internal/misc/antigravity_version_test.go
@@ -2,6 +2,7 @@ package misc
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -42,8 +43,22 @@ func TestAntigravityLatestVersionUsesCurrentHubFallback(t *testing.T) {
 	defer restore()
 
 	version := AntigravityLatestVersion()
-	if version != "2.2.1" {
-		t.Fatalf("AntigravityLatestVersion() = %q, want %q", version, "2.2.1")
+	if version != antigravityFallbackVersion {
+		t.Fatalf("AntigravityLatestVersion() = %q, want %q", version, antigravityFallbackVersion)
+	}
+}
+
+// Cloud Code resolves newer models only for clients reporting at least 2.9.0;
+// older versions get 404 Requested entity was not found.
+func TestAntigravityFallbackVersionMeetsBackendFloor(t *testing.T) {
+	const floorMajor, floorMinor = 2, 9
+
+	var major, minor, patch int
+	if _, err := fmt.Sscanf(antigravityFallbackVersion, "%d.%d.%d", &major, &minor, &patch); err != nil {
+		t.Fatalf("antigravityFallbackVersion = %q is not a dotted version: %v", antigravityFallbackVersion, err)
+	}
+	if major < floorMajor || (major == floorMajor && minor < floorMinor) {
+		t.Fatalf("antigravityFallbackVersion = %q, want at least %d.%d.0", antigravityFallbackVersion, floorMajor, floorMinor)
 	}
 }
 


### PR DESCRIPTION
Fixes #5175 (partially — see "Not included" below)

## Problem

`antigravityFallbackVersion` was `2.2.1`. It is what `AntigravityLatestVersion()` returns before the hub manifest has been fetched, and permanently in deployments that cannot reach the manifest URL. Every request in that window goes out as `antigravity/hub/2.2.1 darwin/arm64`.

#5175 reports live probes against `cloudcode-pa.googleapis.com` with identical payload, headers and OAuth token, varying only the User-Agent: `2.2.1` returns `404 Requested entity was not found` for `gemini-3.7-flash-high`, while `2.9.1` resolves the model. `gemini-3.6-flash-high` answers on both, which matches the reported symptom that 3.6 worked while 3.7 did not.

I did not run those probes myself. What I did verify independently: the manifest this code already polls (`antigravityHubLatestManifestURL`) currently publishes `version: 2.9.1`, so the fallback was three minor versions behind the value the online path resolves on its own.

## Change

- `internal/misc/antigravity_version.go`: fallback version `2.2.1` → `2.9.1`, with a comment recording why the floor exists.
- `internal/misc/antigravity_version_test.go`: `TestAntigravityLatestVersionUsesCurrentHubFallback` now compares against the constant instead of a duplicated literal, and a new `TestAntigravityFallbackVersionMeetsBackendFloor` asserts the constant stays at or above 2.9.0, so a future downgrade fails loudly instead of silently reintroducing the 404.

This only changes what is reported when the manifest has not been read; a successful fetch still wins, exactly as before.

## Not included

#5175 proposes two further changes that I left out, since the report does not carry evidence for them:

1. **Reordering `antigravityBaseURLFallbackOrder` to put prod before daily.** The issue asserts prod "should be primary" but shows no probe supporting it, and daily-first looks deliberate. Reordering the endpoint preference for every Antigravity request is a much wider behavior change than the 404 this issue is about.
2. **Treating 404 as a reason to fall back to the next base URL.** A 404 also legitimately means the model is absent, and this change would add a second upstream round trip to every such request across all models. With the User-Agent cause fixed, the 404 that motivated it should no longer occur; if it still does on some endpoint, that deserves its own capture.

Happy to add either if you would prefer them in this PR.

## Verification

```
go test ./...
go build -o test-output ./cmd/server
```

Full suite passes (7327 tests). `TestAntigravityFallbackVersionMeetsBackendFloor` fails on `dev` with `antigravityFallbackVersion = "2.2.1", want at least 2.9.0`.