### PR TITLE
fix(xai): map image_generation tool_choice to required

### DIFF
--- a/internal/runtime/executor/xai_executor_execute.go
+++ b/internal/runtime/executor/xai_executor_execute.go
@@ -149,7 +149,7 @@ func (e *XAIExecutor) executeCompactRequest(ctx context.Context, auth *cliproxya
 	prepared.body, _ = sjson.DeleteBytes(prepared.body, "stream")
 	prepared.body, _ = sjson.DeleteBytes(prepared.body, "tools")
 	// Compact deletes tools after prepareResponsesRequestTo, which can now keep
-	// image_generation and rewrite its forced choice to allowed_tools on grok-4.6+.
+	// image_generation and rewrite its forced choice to "required" on grok-4.6+.
 	// Drop the leftover selection so compact does not send tool_choice without tools.
 	prepared.body = normalizeXAIToolChoiceForTools(prepared.body)
 	for _, field := range []string{"max_output_tokens", "temperature", "top_p", "top_k", "stop"} {

--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -103,7 +103,10 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	body = pruneXAIOrphanedToolChoice(body)
 	body = normalizeXAIForcedImageGenerationToolChoice(body)
 	body = normalizeXAIToolChoiceForTools(body)
-	if e.cfg != nil && e.cfg.XAI.InjectXSearch {
+	// Skip x_search injection when the request was forced to image_generation and
+	// the remaining tools list is only that hosted tool. "required" plus extra
+	// tools would let Grok call x_search instead of Imagine.
+	if e.cfg != nil && e.cfg.XAI.InjectXSearch && !xaiToolChoiceRequiresImageGenerationOnly(body) {
 		body = ensureXAINativeXSearchTool(body)
 	}
 	var replayScope xaiReasoningReplayScope
@@ -683,10 +686,12 @@ func normalizeXAIForcedWebSearchToolChoice(body []byte) []byte {
 
 // normalizeXAIForcedImageGenerationToolChoice rewrites image_generation choices
 // into a ModelToolChoice variant accepted by xAI chat-proxy. `{type: image_generation}`
-// becomes the string "required". An allowed_tools list that only names that
-// hosted tool becomes the original mode ("auto" or "required"). Mixed lists
-// drop the image_generation entry so the remaining hosted/function choices can
-// still deserialize.
+// becomes the string "required" and the tools list is reduced to image_generation
+// so later x_search injection cannot broaden the restriction. An allowed_tools
+// list that only names that hosted tool becomes the original mode ("auto" or
+// "required") and is likewise reduced to image_generation. Mixed lists drop the
+// image_generation entry so the remaining hosted/function choices can still
+// deserialize.
 func normalizeXAIForcedImageGenerationToolChoice(body []byte) []byte {
 	choice := gjson.GetBytes(body, "tool_choice")
 	if !choice.IsObject() {
@@ -694,6 +699,7 @@ func normalizeXAIForcedImageGenerationToolChoice(body []byte) []byte {
 	}
 	choiceType := strings.TrimSpace(choice.Get("type").String())
 	if choiceType == xaiImageGenerationToolType {
+		body = xaiKeepOnlyImageGenerationTools(body)
 		return xaiSetToolChoiceString(body, "required")
 	}
 	if choiceType != "allowed_tools" {
@@ -720,6 +726,7 @@ func normalizeXAIForcedImageGenerationToolChoice(body []byte) []byte {
 		if mode != "auto" {
 			mode = "required"
 		}
+		body = xaiKeepOnlyImageGenerationTools(body)
 		return xaiSetToolChoiceString(body, mode)
 	}
 	updated, errSet := sjson.SetRawBytes(body, "tool_choice.tools", helps.JoinRawJSONArray(filtered))
@@ -727,6 +734,49 @@ func normalizeXAIForcedImageGenerationToolChoice(body []byte) []byte {
 		return body
 	}
 	return updated
+}
+
+func xaiKeepOnlyImageGenerationTools(body []byte) []byte {
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.IsArray() {
+		return body
+	}
+	kept := make([][]byte, 0, 1)
+	for _, tool := range tools.Array() {
+		if strings.TrimSpace(tool.Get("type").String()) == xaiImageGenerationToolType {
+			kept = append(kept, []byte(tool.Raw))
+		}
+	}
+	if len(kept) == 0 || len(kept) == len(tools.Array()) {
+		return body
+	}
+	updated, errSet := sjson.SetRawBytes(body, "tools", helps.JoinRawJSONArray(kept))
+	if errSet != nil {
+		return body
+	}
+	return updated
+}
+
+func xaiToolChoiceRequiresImageGenerationOnly(body []byte) bool {
+	choice := gjson.GetBytes(body, "tool_choice")
+	if choice.Type != gjson.String {
+		return false
+	}
+	switch choice.String() {
+	case "required", "auto":
+	default:
+		return false
+	}
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.IsArray() || len(tools.Array()) == 0 {
+		return false
+	}
+	for _, tool := range tools.Array() {
+		if strings.TrimSpace(tool.Get("type").String()) != xaiImageGenerationToolType {
+			return false
+		}
+	}
+	return true
 }
 
 func xaiSetToolChoiceString(body []byte, value string) []byte {

--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -683,9 +683,10 @@ func normalizeXAIForcedWebSearchToolChoice(body []byte) []byte {
 
 // normalizeXAIForcedImageGenerationToolChoice rewrites image_generation choices
 // into a ModelToolChoice variant accepted by xAI chat-proxy. `{type: image_generation}`
-// and allowed_tools lists that only name that hosted tool become the string
-// "required". Mixed allowed_tools lists drop the image_generation entry so the
-// remaining hosted/function choices can still deserialize.
+// becomes the string "required". An allowed_tools list that only names that
+// hosted tool becomes the original mode ("auto" or "required"). Mixed lists
+// drop the image_generation entry so the remaining hosted/function choices can
+// still deserialize.
 func normalizeXAIForcedImageGenerationToolChoice(body []byte) []byte {
 	choice := gjson.GetBytes(body, "tool_choice")
 	if !choice.IsObject() {
@@ -693,11 +694,7 @@ func normalizeXAIForcedImageGenerationToolChoice(body []byte) []byte {
 	}
 	choiceType := strings.TrimSpace(choice.Get("type").String())
 	if choiceType == xaiImageGenerationToolType {
-		updated, errSet := sjson.SetBytes(body, "tool_choice", "required")
-		if errSet != nil {
-			return body
-		}
-		return updated
+		return xaiSetToolChoiceString(body, "required")
 	}
 	if choiceType != "allowed_tools" {
 		return body
@@ -719,13 +716,21 @@ func normalizeXAIForcedImageGenerationToolChoice(body []byte) []byte {
 		return body
 	}
 	if len(filtered) == 0 {
-		updated, errSet := sjson.SetBytes(body, "tool_choice", "required")
-		if errSet != nil {
-			return body
+		mode := strings.TrimSpace(choice.Get("mode").String())
+		if mode != "auto" {
+			mode = "required"
 		}
-		return updated
+		return xaiSetToolChoiceString(body, mode)
 	}
 	updated, errSet := sjson.SetRawBytes(body, "tool_choice.tools", helps.JoinRawJSONArray(filtered))
+	if errSet != nil {
+		return body
+	}
+	return updated
+}
+
+func xaiSetToolChoiceString(body []byte, value string) []byte {
+	updated, errSet := sjson.SetBytes(body, "tool_choice", value)
 	if errSet != nil {
 		return body
 	}

--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -98,8 +98,10 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	// configured x_search injection, so no surviving choice references a deleted tool.
 	body = normalizeXAINamespaceToolChoice(body)
 	body = normalizeXAIForcedWebSearchToolChoice(body)
-	body = normalizeXAIForcedImageGenerationToolChoice(body)
+	// Prune before rewriting image_generation choices so older models that still
+	// strip the tool do not keep a leftover "required" selection.
 	body = pruneXAIOrphanedToolChoice(body)
+	body = normalizeXAIForcedImageGenerationToolChoice(body)
 	body = normalizeXAIToolChoiceForTools(body)
 	if e.cfg != nil && e.cfg.XAI.InjectXSearch {
 		body = ensureXAINativeXSearchTool(body)
@@ -679,10 +681,55 @@ func normalizeXAIForcedWebSearchToolChoice(body []byte) []byte {
 	return normalizeXAIForcedHostedToolChoice(body, xaiWebSearchToolType)
 }
 
-// normalizeXAIForcedImageGenerationToolChoice rewrites a forced image_generation
-// choice into the same allowed_tools form used for web_search.
+// normalizeXAIForcedImageGenerationToolChoice rewrites image_generation choices
+// into a ModelToolChoice variant accepted by xAI chat-proxy. `{type: image_generation}`
+// and allowed_tools lists that only name that hosted tool become the string
+// "required". Mixed allowed_tools lists drop the image_generation entry so the
+// remaining hosted/function choices can still deserialize.
 func normalizeXAIForcedImageGenerationToolChoice(body []byte) []byte {
-	return normalizeXAIForcedHostedToolChoice(body, xaiImageGenerationToolType)
+	choice := gjson.GetBytes(body, "tool_choice")
+	if !choice.IsObject() {
+		return body
+	}
+	choiceType := strings.TrimSpace(choice.Get("type").String())
+	if choiceType == xaiImageGenerationToolType {
+		updated, errSet := sjson.SetBytes(body, "tool_choice", "required")
+		if errSet != nil {
+			return body
+		}
+		return updated
+	}
+	if choiceType != "allowed_tools" {
+		return body
+	}
+	allowed := choice.Get("tools")
+	if !allowed.IsArray() {
+		return body
+	}
+	filtered := make([][]byte, 0, len(allowed.Array()))
+	stripped := false
+	for _, tool := range allowed.Array() {
+		if strings.TrimSpace(tool.Get("type").String()) == xaiImageGenerationToolType {
+			stripped = true
+			continue
+		}
+		filtered = append(filtered, []byte(tool.Raw))
+	}
+	if !stripped {
+		return body
+	}
+	if len(filtered) == 0 {
+		updated, errSet := sjson.SetBytes(body, "tool_choice", "required")
+		if errSet != nil {
+			return body
+		}
+		return updated
+	}
+	updated, errSet := sjson.SetRawBytes(body, "tool_choice.tools", helps.JoinRawJSONArray(filtered))
+	if errSet != nil {
+		return body
+	}
+	return updated
 }
 
 func normalizeXAIForcedHostedToolChoice(body []byte, toolType string) []byte {

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -1108,18 +1108,88 @@ func TestXAIExecutorPrepareKeepsNativeImageGenerationForGrok46(t *testing.T) {
 		t.Fatalf("tools.0.action = %q, want generate; body=%s", got, prepared.body)
 	}
 	choice := gjson.GetBytes(prepared.body, "tool_choice")
+	if choice.Type != gjson.String || choice.String() != "required" {
+		t.Fatalf("tool_choice = %s, want string required; body=%s", choice.Raw, prepared.body)
+	}
+}
+
+func TestXAIExecutorPrepareRewritesImageGenerationAllowedToolsToRequired(t *testing.T) {
+	t.Parallel()
+
+	exec := NewXAIExecutor(&config.Config{})
+	prepared, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+		Model: "grok-4.6",
+		Payload: []byte(`{
+			"model":"grok-4.6",
+			"input":"draw a red circle",
+			"tools":[{"type":"image_generation","action":"generate"},{"type":"web_search"}],
+			"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"image_generation"}]}
+		}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       false,
+	}, false)
+	if err != nil {
+		t.Fatalf("prepareResponsesRequest() error = %v", err)
+	}
+
+	choice := gjson.GetBytes(prepared.body, "tool_choice")
+	if choice.Type != gjson.String || choice.String() != "required" {
+		t.Fatalf("tool_choice = %s, want string required; body=%s", choice.Raw, prepared.body)
+	}
+	foundImage := false
+	foundWebSearch := false
+	for _, tool := range gjson.GetBytes(prepared.body, "tools").Array() {
+		switch tool.Get("type").String() {
+		case "image_generation":
+			foundImage = true
+		case "web_search":
+			foundWebSearch = true
+		}
+	}
+	if !foundImage || !foundWebSearch {
+		t.Fatalf("expected image_generation + web_search tools; body=%s", prepared.body)
+	}
+}
+
+func TestXAIExecutorPrepareStripsImageGenerationFromMixedAllowedTools(t *testing.T) {
+	t.Parallel()
+
+	exec := NewXAIExecutor(&config.Config{})
+	prepared, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+		Model: "grok-4.6",
+		Payload: []byte(`{
+			"model":"grok-4.6",
+			"input":"draw or search",
+			"tools":[{"type":"image_generation"},{"type":"web_search"},{"type":"function","name":"lookup","parameters":{"type":"object"}}],
+			"tool_choice":{"type":"allowed_tools","mode":"required","tools":[
+				{"type":"image_generation"},
+				{"type":"function","name":"lookup"}
+			]}
+		}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       false,
+	}, false)
+	if err != nil {
+		t.Fatalf("prepareResponsesRequest() error = %v", err)
+	}
+
+	choice := gjson.GetBytes(prepared.body, "tool_choice")
 	if got := choice.Get("type").String(); got != "allowed_tools" {
 		t.Fatalf("tool_choice.type = %q, want allowed_tools; body=%s", got, prepared.body)
-	}
-	if got := choice.Get("mode").String(); got != "required" {
-		t.Fatalf("tool_choice.mode = %q, want required; body=%s", got, prepared.body)
 	}
 	allowed := choice.Get("tools").Array()
 	if len(allowed) != 1 {
 		t.Fatalf("tool_choice.tools length = %d, want 1; body=%s", len(allowed), prepared.body)
 	}
-	if got := allowed[0].Get("type").String(); got != "image_generation" {
-		t.Fatalf("tool_choice.tools.0.type = %q, want image_generation; body=%s", got, prepared.body)
+	if got := allowed[0].Get("name").String(); got != "lookup" {
+		t.Fatalf("tool_choice.tools.0.name = %q, want lookup; body=%s", got, prepared.body)
+	}
+	for _, tool := range allowed {
+		if tool.Get("type").String() == "image_generation" {
+			t.Fatalf("image_generation must not remain in allowed_tools: %s", prepared.body)
+		}
 	}
 }
 

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -1137,18 +1137,45 @@ func TestXAIExecutorPrepareRewritesImageGenerationAllowedToolsToRequired(t *test
 	if choice.Type != gjson.String || choice.String() != "required" {
 		t.Fatalf("tool_choice = %s, want string required; body=%s", choice.Raw, prepared.body)
 	}
-	foundImage := false
-	foundWebSearch := false
-	for _, tool := range gjson.GetBytes(prepared.body, "tools").Array() {
-		switch tool.Get("type").String() {
-		case "image_generation":
-			foundImage = true
-		case "web_search":
-			foundWebSearch = true
-		}
+	tools := gjson.GetBytes(prepared.body, "tools").Array()
+	if len(tools) != 1 {
+		t.Fatalf("tools length = %d, want 1; body=%s", len(tools), prepared.body)
 	}
-	if !foundImage || !foundWebSearch {
-		t.Fatalf("expected image_generation + web_search tools; body=%s", prepared.body)
+	if got := tools[0].Get("type").String(); got != "image_generation" {
+		t.Fatalf("tools.0.type = %q, want image_generation; body=%s", got, prepared.body)
+	}
+}
+
+func TestXAIExecutorPrepareForcedImageGenerationDropsOtherToolsAndSkipsXSearchInject(t *testing.T) {
+	t.Parallel()
+
+	exec := NewXAIExecutor(&config.Config{XAI: config.XAIConfig{InjectXSearch: true}})
+	prepared, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+		Model: "grok-4.6",
+		Payload: []byte(`{
+			"model":"grok-4.6",
+			"input":"draw a red circle",
+			"tools":[{"type":"image_generation","action":"generate"},{"type":"web_search"},{"type":"function","name":"lookup","parameters":{"type":"object"}}],
+			"tool_choice":{"type":"image_generation"}
+		}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       false,
+	}, false)
+	if err != nil {
+		t.Fatalf("prepareResponsesRequest() error = %v", err)
+	}
+
+	choice := gjson.GetBytes(prepared.body, "tool_choice")
+	if choice.Type != gjson.String || choice.String() != "required" {
+		t.Fatalf("tool_choice = %s, want string required; body=%s", choice.Raw, prepared.body)
+	}
+	tools := gjson.GetBytes(prepared.body, "tools").Array()
+	if len(tools) != 1 {
+		t.Fatalf("tools length = %d, want 1; body=%s", len(tools), prepared.body)
+	}
+	if got := tools[0].Get("type").String(); got != "image_generation" {
+		t.Fatalf("tools.0.type = %q, want image_generation; body=%s", got, prepared.body)
 	}
 }
 

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -1152,6 +1152,32 @@ func TestXAIExecutorPrepareRewritesImageGenerationAllowedToolsToRequired(t *test
 	}
 }
 
+func TestXAIExecutorPrepareRewritesImageOnlyAllowedToolsAutoToAuto(t *testing.T) {
+	t.Parallel()
+
+	exec := NewXAIExecutor(&config.Config{})
+	prepared, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+		Model: "grok-4.6",
+		Payload: []byte(`{
+			"model":"grok-4.6",
+			"input":"draw a red circle",
+			"tools":[{"type":"image_generation"},{"type":"web_search"}],
+			"tool_choice":{"type":"allowed_tools","mode":"auto","tools":[{"type":"image_generation"}]}
+		}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       false,
+	}, false)
+	if err != nil {
+		t.Fatalf("prepareResponsesRequest() error = %v", err)
+	}
+
+	choice := gjson.GetBytes(prepared.body, "tool_choice")
+	if choice.Type != gjson.String || choice.String() != "auto" {
+		t.Fatalf("tool_choice = %s, want string auto; body=%s", choice.Raw, prepared.body)
+	}
+}
+
 func TestXAIExecutorPrepareStripsImageGenerationFromMixedAllowedTools(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #5183

## Problem

#5174 stopped stripping `image_generation` on grok-4.6+. It also rewrote a forced `{type: image_generation}` choice into the `allowed_tools` form used for `web_search`.

xAI chat-proxy accepts that shape for `web_search` and rejects it for `image_generation`:

```
tool_choice: data did not match any variant of untagged enum ModelToolChoice
```

HTTP 422. The tool itself is fine: omit `tool_choice`, or send the string `"required"` / `"auto"`, and `image_generation_calls` is 1.

## Change

Executor-only:

- `{type: image_generation}` → string `"required"`
- `allowed_tools` that only names `image_generation` → string `"required"`
- mixed `allowed_tools` drops the `image_generation` entry and keeps the rest
- prune orphaned choices *before* this rewrite so grok-4.5 still drops the leftover selection instead of inheriting `"required"`

## Verification

```
go test ./internal/runtime/executor -count=1
go build -o test-output ./cmd/server
```

Live checks against chat-proxy: `"required"` and `"auto"` return 200 with `image_generation_calls: 1`; `allowed_tools` + `image_generation` still 422 without this change.
