### PR TITLE
fix(codex): replace same-account OAuth into the existing auth file

### DIFF
--- a/internal/api/handlers/management/auth_files_codex_replace.go
+++ b/internal/api/handlers/management/auth_files_codex_replace.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -89,9 +90,77 @@ func (h *Handler) saveCodexOAuthRecord(ctx context.Context, record *coreauth.Aut
 	if deleteErr != nil {
 		return savedPath, deleteErr
 	}
+	// Nested files are ignored by the auth-dir watcher; update in-memory tokens explicitly.
+	h.refreshRuntimeAuthAfterReplace(ctx, record, writeName)
 	// Tokens on the kept file rotated; close retained websockets so they re-handshake.
 	h.closeCodexSessionsForRel(writeName)
 	return savedPath, nil
+}
+
+func (h *Handler) refreshRuntimeAuthAfterReplace(ctx context.Context, record *coreauth.Auth, writeName string) {
+	if h == nil || h.authManager == nil || record == nil {
+		return
+	}
+	writeName = sanitizeCodexAuthRelPath(writeName)
+	if writeName == "" {
+		return
+	}
+	path := h.resolveCodexAuthPath(writeName)
+	now := time.Now()
+	updated := false
+	for _, id := range h.authIDsForCodexPath(path, writeName) {
+		existing, ok := h.authManager.GetByID(id)
+		if !ok || existing == nil {
+			continue
+		}
+		applyCodexReplacementToRuntimeAuth(existing, record)
+		existing.UpdatedAt = now
+		if _, errUpdate := h.authManager.Update(ctx, existing); errUpdate != nil {
+			log.WithError(errUpdate).WithField("id", id).Warn("failed to update runtime auth after Codex OAuth replace")
+			continue
+		}
+		updated = true
+	}
+	if updated {
+		return
+	}
+	record.ID = writeName
+	record.FileName = writeName
+	if record.Attributes == nil {
+		record.Attributes = make(map[string]string)
+	}
+	record.Attributes["path"] = path
+	record.Disabled = false
+	record.Status = coreauth.StatusActive
+	if _, errRegister := h.authManager.Register(ctx, record); errRegister != nil {
+		log.WithError(errRegister).WithField("id", writeName).Warn("failed to register runtime auth after Codex OAuth replace")
+	}
+}
+
+func applyCodexReplacementToRuntimeAuth(existing, record *coreauth.Auth) {
+	if existing == nil || record == nil {
+		return
+	}
+	if existing.Metadata == nil {
+		existing.Metadata = make(map[string]any)
+	}
+	if storage, ok := record.Storage.(*codex.CodexTokenStorage); ok && storage != nil {
+		existing.Metadata["access_token"] = storage.AccessToken
+		existing.Metadata["refresh_token"] = storage.RefreshToken
+		existing.Metadata["id_token"] = storage.IDToken
+		existing.Metadata["expired"] = storage.Expire
+		existing.Metadata["last_refresh"] = storage.LastRefresh
+		existing.Metadata["email"] = storage.Email
+		existing.Metadata["account_id"] = storage.AccountID
+		existing.Metadata["type"] = "codex"
+	}
+	for key, value := range record.Metadata {
+		existing.Metadata[key] = value
+	}
+	existing.Disabled = false
+	existing.Status = coreauth.StatusActive
+	existing.StatusMessage = ""
+	existing.Unavailable = false
 }
 
 func prepareCodexOAuthRecordForSave(record *coreauth.Auth, writeName string) {

--- a/internal/api/handlers/management/auth_files_codex_replace.go
+++ b/internal/api/handlers/management/auth_files_codex_replace.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	log "github.com/sirupsen/logrus"
 )
@@ -234,11 +236,51 @@ func (h *Handler) deleteCodexAuthRel(ctx context.Context, relName string) error 
 	if h.cfg != nil && strings.TrimSpace(h.cfg.AuthDir) != "" && !filepath.IsAbs(path) {
 		path = filepath.Join(h.cfg.AuthDir, path)
 	}
+	ids := h.authIDsForCodexPath(path, relName)
 	if errDelete := store.Delete(ctx, path); errDelete != nil {
 		return errDelete
 	}
 	h.removeAuthsForPath(ctx, path, relName)
+	// Nested files are not seen by the auth-dir watcher, so unregister runtime
+	// state here instead of waiting for applyCoreAuthRemoval.
+	for _, id := range ids {
+		registry.GetGlobalRegistry().UnregisterClient(id)
+		executor.CloseCodexWebsocketSessionsForAuthID(id, "oauth_replaced")
+	}
 	return nil
+}
+
+func (h *Handler) authIDsForCodexPath(path, relName string) []string {
+	seen := make(map[string]struct{})
+	var ids []string
+	add := func(id string) {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return
+		}
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	if h != nil && h.authManager != nil {
+		for _, auth := range h.authManager.List() {
+			if auth == nil {
+				continue
+			}
+			if sameAuthFilePath(authAttribute(auth, "path"), path) ||
+				sameAuthFilePath(authAttribute(auth, coreauth.AttributeVirtualSource), path) ||
+				filepath.ToSlash(strings.TrimSpace(auth.FileName)) == relName ||
+				filepath.ToSlash(strings.TrimSpace(auth.ID)) == relName {
+				add(auth.ID)
+			}
+		}
+	}
+	if len(ids) == 0 {
+		add(relName)
+	}
+	return ids
 }
 
 func authPayloadAccountID(payload map[string]any) string {

--- a/internal/api/handlers/management/auth_files_codex_replace.go
+++ b/internal/api/handlers/management/auth_files_codex_replace.go
@@ -3,6 +3,7 @@ package management
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -506,17 +507,21 @@ func (h *Handler) deleteCodexAuthRel(ctx context.Context, relName string) error 
 	}
 	path := h.resolveCodexAuthPath(relName)
 	ids := h.authIDsForCodexPath(path, relName)
-	if errDelete := store.Delete(ctx, path); errDelete != nil {
-		return errDelete
+	errDelete := store.Delete(ctx, path)
+	// Object/postgres/git delete the local file before the remote call. If that
+	// remote call fails, the file is already gone and the watcher will not see a
+	// nested path, so drop runtime state anyway.
+	if errDelete != nil {
+		if _, errStat := os.Stat(path); errStat == nil {
+			return errDelete
+		}
 	}
 	h.removeAuthsForPath(ctx, path, relName)
-	// Nested files are not seen by the auth-dir watcher, so unregister runtime
-	// state here instead of waiting for applyCoreAuthRemoval.
 	for _, id := range ids {
 		registry.GetGlobalRegistry().UnregisterClient(id)
 		executor.CloseCodexWebsocketSessionsForAuthID(id, "oauth_replaced")
 	}
-	return nil
+	return errDelete
 }
 
 func (h *Handler) authIDsForCodexPath(path, relName string) []string {

--- a/internal/api/handlers/management/auth_files_codex_replace.go
+++ b/internal/api/handlers/management/auth_files_codex_replace.go
@@ -5,11 +5,17 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	log "github.com/sirupsen/logrus"
 )
+
+// serializes list+save+delete so two concurrent OAuth completions for the same
+// account_id cannot each keep the other's file and then delete both.
+var codexOAuthReplaceMu sync.Mutex
 
 var oauthRuntimeMetadataKeys = []string{
 	"disabled",
@@ -45,10 +51,10 @@ func (h *Handler) saveCodexOAuthRecord(ctx context.Context, record *coreauth.Aut
 		canonicalName = strings.TrimSpace(record.ID)
 	}
 	accountID := codexAccountIDFromRecord(record)
-	replaceHint = filepath.Base(strings.TrimSpace(replaceHint))
-	if isUnsafeAuthFileName(replaceHint) {
-		replaceHint = ""
-	}
+	replaceHint = sanitizeCodexAuthRelPath(replaceHint)
+
+	codexOAuthReplaceMu.Lock()
+	defer codexOAuthReplaceMu.Unlock()
 
 	siblings, errList := h.listCodexFilesByAccountID(ctx, accountID)
 	if errList != nil {
@@ -72,7 +78,7 @@ func (h *Handler) saveCodexOAuthRecord(ctx context.Context, record *coreauth.Aut
 		if name == "" || name == writeName {
 			continue
 		}
-		if _, _, errDelete := h.deleteAuthFileByName(ctx, name); errDelete != nil {
+		if errDelete := h.deleteCodexAuthRel(ctx, name); errDelete != nil {
 			log.WithError(errDelete).WithField("file", name).Warn("failed to remove replaced Codex auth file")
 		}
 	}
@@ -136,8 +142,8 @@ func (h *Handler) listCodexFilesByAccountID(ctx context.Context, accountID strin
 		if id == "" || id != accountID {
 			continue
 		}
-		name := authRecordFileName(auth)
-		if name == "" || isUnsafeAuthFileName(name) {
+		name := authRecordFileName(auth, h.cfg)
+		if name == "" || isUnsafeCodexAuthRelPath(name) {
 			continue
 		}
 		out = append(out, codexAuthFileRef{
@@ -164,15 +170,75 @@ func isCodexAuthPayload(payload map[string]any) bool {
 	return strings.EqualFold(strings.TrimSpace(jsonString(payload["type"])), "codex")
 }
 
-func authRecordFileName(auth *coreauth.Auth) string {
+func authRecordFileName(auth *coreauth.Auth, cfg *config.Config) string {
 	if auth == nil {
 		return ""
 	}
-	name := filepath.Base(strings.TrimSpace(auth.FileName))
-	if name != "" && name != "." && name != string(filepath.Separator) {
-		return name
+	name := strings.TrimSpace(auth.FileName)
+	if name == "" {
+		name = strings.TrimSpace(auth.ID)
 	}
-	return filepath.Base(strings.TrimSpace(auth.ID))
+	name = filepath.ToSlash(name)
+	if name == "" || name == "." {
+		return ""
+	}
+	authDir := ""
+	if cfg != nil {
+		authDir = strings.TrimSpace(cfg.AuthDir)
+	}
+	if authDir != "" && filepath.IsAbs(filepath.FromSlash(name)) {
+		if rel, errRel := filepath.Rel(authDir, filepath.FromSlash(name)); errRel == nil {
+			name = filepath.ToSlash(rel)
+		}
+	}
+	return sanitizeCodexAuthRelPath(name)
+}
+
+func sanitizeCodexAuthRelPath(name string) string {
+	name = filepath.ToSlash(strings.TrimSpace(name))
+	if name == "" {
+		return ""
+	}
+	if isUnsafeCodexAuthRelPath(name) {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Clean(name))
+}
+
+func isUnsafeCodexAuthRelPath(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return true
+	}
+	from := filepath.FromSlash(name)
+	if filepath.IsAbs(from) || filepath.VolumeName(from) != "" {
+		return true
+	}
+	clean := filepath.ToSlash(filepath.Clean(from))
+	if clean == ".." || strings.HasPrefix(clean, "../") {
+		return true
+	}
+	return false
+}
+
+func (h *Handler) deleteCodexAuthRel(ctx context.Context, relName string) error {
+	relName = sanitizeCodexAuthRelPath(relName)
+	if relName == "" {
+		return fmt.Errorf("invalid auth path")
+	}
+	store := h.tokenStoreWithBaseDir()
+	if store == nil {
+		return fmt.Errorf("token store unavailable")
+	}
+	path := filepath.FromSlash(relName)
+	if h.cfg != nil && strings.TrimSpace(h.cfg.AuthDir) != "" && !filepath.IsAbs(path) {
+		path = filepath.Join(h.cfg.AuthDir, path)
+	}
+	if errDelete := store.Delete(ctx, path); errDelete != nil {
+		return errDelete
+	}
+	h.removeAuthsForPath(ctx, path, relName)
+	return nil
 }
 
 func authPayloadAccountID(payload map[string]any) string {

--- a/internal/api/handlers/management/auth_files_codex_replace.go
+++ b/internal/api/handlers/management/auth_files_codex_replace.go
@@ -122,8 +122,10 @@ func (h *Handler) refreshRuntimeAuthAfterReplace(ctx context.Context, record *co
 		}
 		applyCodexReplacementToRuntimeAuth(existing, record)
 		existing.UpdatedAt = now
-		if _, errUpdate := h.authManager.Update(ctx, existing); errUpdate != nil {
-			log.WithError(errUpdate).WithField("id", id).Warn("failed to update runtime auth after Codex OAuth replace")
+		// Register overwrites the same ID. Update copies ModelStates and an active
+		// credential_quota cooldown from the live entry when those fields are empty.
+		if _, errRegister := h.authManager.Register(ctx, existing); errRegister != nil {
+			log.WithError(errRegister).WithField("id", id).Warn("failed to update runtime auth after Codex OAuth replace")
 			continue
 		}
 		updated = true
@@ -170,6 +172,10 @@ func applyCodexReplacementToRuntimeAuth(existing, record *coreauth.Auth) {
 	existing.Status = coreauth.StatusActive
 	existing.StatusMessage = ""
 	existing.Unavailable = false
+	existing.NextRetryAfter = time.Time{}
+	existing.LastError = nil
+	existing.Quota = coreauth.QuotaState{}
+	existing.ModelStates = nil
 }
 
 func (h *Handler) preserveCodexRuntimeSettings(record *coreauth.Auth, writeName string) {

--- a/internal/api/handlers/management/auth_files_codex_replace.go
+++ b/internal/api/handlers/management/auth_files_codex_replace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -58,6 +59,9 @@ func (h *Handler) saveCodexOAuthRecord(ctx context.Context, record *coreauth.Aut
 
 	codexOAuthReplaceMu.Lock()
 	defer codexOAuthReplaceMu.Unlock()
+	if errGuard := guardOAuthSaveSession(ctx); errGuard != nil {
+		return "", errGuard
+	}
 
 	siblings, errList := h.listCodexFilesByAccountID(ctx, accountID)
 	if errList != nil {
@@ -71,6 +75,10 @@ func (h *Handler) saveCodexOAuthRecord(ctx context.Context, record *coreauth.Aut
 	}
 
 	prepareCodexOAuthRecordForSave(record, writeName)
+	h.preserveCodexRuntimeSettings(record, writeName)
+	if errGuard := guardOAuthSaveSession(ctx); errGuard != nil {
+		return "", errGuard
+	}
 
 	savedPath, errSave := h.saveTokenRecord(ctx, record)
 	if errSave != nil {
@@ -143,6 +151,16 @@ func applyCodexReplacementToRuntimeAuth(existing, record *coreauth.Auth) {
 	if existing.Metadata == nil {
 		existing.Metadata = make(map[string]any)
 	}
+	if strings.TrimSpace(existing.Prefix) == "" {
+		existing.Prefix = record.Prefix
+	}
+	if strings.TrimSpace(existing.ProxyURL) == "" {
+		existing.ProxyURL = record.ProxyURL
+	}
+	if strings.TrimSpace(existing.Label) == "" {
+		existing.Label = record.Label
+	}
+	existing.Attributes = mergeAuthAttributes(existing.Attributes, record.Attributes)
 	for key, value := range record.Metadata {
 		existing.Metadata[key] = value
 	}
@@ -152,6 +170,117 @@ func applyCodexReplacementToRuntimeAuth(existing, record *coreauth.Auth) {
 	existing.Status = coreauth.StatusActive
 	existing.StatusMessage = ""
 	existing.Unavailable = false
+}
+
+func (h *Handler) preserveCodexRuntimeSettings(record *coreauth.Auth, writeName string) {
+	if record == nil {
+		return
+	}
+	path := ""
+	if h != nil {
+		path = h.resolveCodexAuthPath(writeName)
+	}
+	var existing *coreauth.Auth
+	if h != nil && h.authManager != nil {
+		for _, id := range h.authIDsForCodexPath(path, writeName) {
+			got, ok := h.authManager.GetByID(id)
+			if ok && got != nil {
+				existing = got
+				break
+			}
+		}
+	}
+	if existing != nil {
+		if strings.TrimSpace(record.Prefix) == "" {
+			record.Prefix = existing.Prefix
+		}
+		if strings.TrimSpace(record.ProxyURL) == "" {
+			record.ProxyURL = existing.ProxyURL
+		}
+		if strings.TrimSpace(record.Label) == "" {
+			record.Label = existing.Label
+		}
+		record.Attributes = mergeAuthAttributes(existing.Attributes, record.Attributes)
+	}
+	applyCodexRuntimeFieldsFromMetadata(record, path)
+}
+
+func mergeAuthAttributes(base, overlay map[string]string) map[string]string {
+	if len(base) == 0 && len(overlay) == 0 {
+		return overlay
+	}
+	out := make(map[string]string, len(base)+len(overlay))
+	for key, value := range base {
+		out[key] = value
+	}
+	for key, value := range overlay {
+		if strings.TrimSpace(value) != "" {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func applyCodexRuntimeFieldsFromMetadata(record *coreauth.Auth, path string) {
+	if record == nil {
+		return
+	}
+	if record.Attributes == nil {
+		record.Attributes = make(map[string]string)
+	}
+	if path != "" {
+		if strings.TrimSpace(record.Attributes[coreauth.AttributePath]) == "" {
+			record.Attributes[coreauth.AttributePath] = path
+		}
+		if strings.TrimSpace(record.Attributes[coreauth.AttributeSource]) == "" {
+			record.Attributes[coreauth.AttributeSource] = path
+		}
+		if strings.TrimSpace(record.Attributes[coreauth.AttributeSourceBackend]) == "" {
+			record.Attributes[coreauth.AttributeSourceBackend] = coreauth.AuthSourceFile
+		}
+	}
+	if record.Metadata == nil {
+		return
+	}
+	if strings.TrimSpace(record.ProxyURL) == "" {
+		if proxyURL, ok := record.Metadata["proxy_url"].(string); ok {
+			record.ProxyURL = strings.TrimSpace(proxyURL)
+		}
+	}
+	if strings.TrimSpace(record.Prefix) == "" {
+		if prefix, ok := record.Metadata["prefix"].(string); ok {
+			trimmed := strings.Trim(strings.TrimSpace(prefix), "/")
+			if trimmed != "" && !strings.Contains(trimmed, "/") {
+				record.Prefix = trimmed
+			}
+		}
+	}
+	if strings.TrimSpace(record.Label) == "" {
+		if email, ok := record.Metadata["email"].(string); ok {
+			if trimmed := strings.TrimSpace(email); trimmed != "" {
+				record.Label = trimmed
+			}
+		}
+	}
+	if strings.TrimSpace(record.Attributes["priority"]) == "" {
+		switch value := record.Metadata["priority"].(type) {
+		case float64:
+			record.Attributes["priority"] = strconv.Itoa(int(value))
+		case string:
+			if trimmed := strings.TrimSpace(value); trimmed != "" {
+				record.Attributes["priority"] = trimmed
+			}
+		}
+	}
+	if strings.TrimSpace(record.Attributes["note"]) == "" {
+		if note, ok := record.Metadata["note"].(string); ok {
+			if trimmed := strings.TrimSpace(note); trimmed != "" {
+				record.Attributes["note"] = trimmed
+			}
+		}
+	}
+	coreauth.ApplyCustomHeadersFromMetadata(record)
+	_ = coreauth.ApplyAuthWeightMetadata(record, record.Metadata)
 }
 
 func applyCodexTokenStorageToMetadata(metadata map[string]any, storage any) {

--- a/internal/api/handlers/management/auth_files_codex_replace.go
+++ b/internal/api/handlers/management/auth_files_codex_replace.go
@@ -89,6 +89,8 @@ func (h *Handler) saveCodexOAuthRecord(ctx context.Context, record *coreauth.Aut
 	if deleteErr != nil {
 		return savedPath, deleteErr
 	}
+	// Tokens on the kept file rotated; close retained websockets so they re-handshake.
+	h.closeCodexSessionsForRel(writeName)
 	return savedPath, nil
 }
 
@@ -228,6 +230,25 @@ func isUnsafeCodexAuthRelPath(name string) bool {
 	return false
 }
 
+func (h *Handler) resolveCodexAuthPath(relName string) string {
+	path := filepath.FromSlash(relName)
+	if h != nil && h.cfg != nil && strings.TrimSpace(h.cfg.AuthDir) != "" && !filepath.IsAbs(path) {
+		path = filepath.Join(h.cfg.AuthDir, path)
+	}
+	return path
+}
+
+func (h *Handler) closeCodexSessionsForRel(relName string) {
+	relName = sanitizeCodexAuthRelPath(relName)
+	if relName == "" {
+		return
+	}
+	path := h.resolveCodexAuthPath(relName)
+	for _, id := range h.authIDsForCodexPath(path, relName) {
+		executor.CloseCodexWebsocketSessionsForAuthID(id, "oauth_replaced")
+	}
+}
+
 func (h *Handler) deleteCodexAuthRel(ctx context.Context, relName string) error {
 	relName = sanitizeCodexAuthRelPath(relName)
 	if relName == "" {
@@ -237,10 +258,7 @@ func (h *Handler) deleteCodexAuthRel(ctx context.Context, relName string) error 
 	if store == nil {
 		return fmt.Errorf("token store unavailable")
 	}
-	path := filepath.FromSlash(relName)
-	if h.cfg != nil && strings.TrimSpace(h.cfg.AuthDir) != "" && !filepath.IsAbs(path) {
-		path = filepath.Join(h.cfg.AuthDir, path)
-	}
+	path := h.resolveCodexAuthPath(relName)
 	ids := h.authIDsForCodexPath(path, relName)
 	if errDelete := store.Delete(ctx, path); errDelete != nil {
 		return errDelete

--- a/internal/api/handlers/management/auth_files_codex_replace.go
+++ b/internal/api/handlers/management/auth_files_codex_replace.go
@@ -143,24 +143,33 @@ func applyCodexReplacementToRuntimeAuth(existing, record *coreauth.Auth) {
 	if existing.Metadata == nil {
 		existing.Metadata = make(map[string]any)
 	}
-	if storage, ok := record.Storage.(*codex.CodexTokenStorage); ok && storage != nil {
-		existing.Metadata["access_token"] = storage.AccessToken
-		existing.Metadata["refresh_token"] = storage.RefreshToken
-		existing.Metadata["id_token"] = storage.IDToken
-		existing.Metadata["expired"] = storage.Expire
-		existing.Metadata["last_refresh"] = storage.LastRefresh
-		existing.Metadata["email"] = storage.Email
-		existing.Metadata["account_id"] = storage.AccountID
-		existing.Metadata["type"] = "codex"
-	}
 	for key, value := range record.Metadata {
 		existing.Metadata[key] = value
 	}
+	applyCodexTokenStorageToMetadata(existing.Metadata, record.Storage)
 	applyCodexPlanTypeFromIDToken(existing)
 	existing.Disabled = false
 	existing.Status = coreauth.StatusActive
 	existing.StatusMessage = ""
 	existing.Unavailable = false
+}
+
+func applyCodexTokenStorageToMetadata(metadata map[string]any, storage any) {
+	if metadata == nil {
+		return
+	}
+	codexStorage, ok := storage.(*codex.CodexTokenStorage)
+	if !ok || codexStorage == nil {
+		return
+	}
+	metadata["access_token"] = codexStorage.AccessToken
+	metadata["refresh_token"] = codexStorage.RefreshToken
+	metadata["id_token"] = codexStorage.IDToken
+	metadata["expired"] = codexStorage.Expire
+	metadata["last_refresh"] = codexStorage.LastRefresh
+	metadata["email"] = codexStorage.Email
+	metadata["account_id"] = codexStorage.AccountID
+	metadata["type"] = "codex"
 }
 
 func applyCodexPlanTypeFromIDToken(auth *coreauth.Auth) {
@@ -208,6 +217,7 @@ func prepareCodexOAuthRecordForSave(record *coreauth.Auth, writeName string) {
 	record.Metadata["status"] = ""
 	record.Metadata["status_message"] = ""
 	record.Metadata["unavailable"] = false
+	applyCodexTokenStorageToMetadata(record.Metadata, record.Storage)
 	applyCodexPlanTypeFromIDToken(record)
 	if setter, ok := record.Storage.(interface{ SetMetadata(map[string]any) }); ok {
 		setter.SetMetadata(record.Metadata)

--- a/internal/api/handlers/management/auth_files_codex_replace.go
+++ b/internal/api/handlers/management/auth_files_codex_replace.go
@@ -76,6 +76,9 @@ func (h *Handler) saveCodexOAuthRecord(ctx context.Context, record *coreauth.Aut
 	if errSave != nil {
 		return savedPath, errSave
 	}
+	// Nested files are ignored by the auth-dir watcher; refresh runtime before sibling cleanup.
+	h.refreshRuntimeAuthAfterReplace(ctx, record, writeName)
+	h.closeCodexSessionsForRel(writeName)
 
 	var deleteErr error
 	for _, name := range remove {
@@ -90,10 +93,6 @@ func (h *Handler) saveCodexOAuthRecord(ctx context.Context, record *coreauth.Aut
 	if deleteErr != nil {
 		return savedPath, deleteErr
 	}
-	// Nested files are ignored by the auth-dir watcher; update in-memory tokens explicitly.
-	h.refreshRuntimeAuthAfterReplace(ctx, record, writeName)
-	// Tokens on the kept file rotated; close retained websockets so they re-handshake.
-	h.closeCodexSessionsForRel(writeName)
 	return savedPath, nil
 }
 
@@ -157,10 +156,42 @@ func applyCodexReplacementToRuntimeAuth(existing, record *coreauth.Auth) {
 	for key, value := range record.Metadata {
 		existing.Metadata[key] = value
 	}
+	applyCodexPlanTypeFromIDToken(existing)
 	existing.Disabled = false
 	existing.Status = coreauth.StatusActive
 	existing.StatusMessage = ""
 	existing.Unavailable = false
+}
+
+func applyCodexPlanTypeFromIDToken(auth *coreauth.Auth) {
+	if auth == nil {
+		return
+	}
+	idToken := ""
+	if auth.Metadata != nil {
+		idToken, _ = auth.Metadata["id_token"].(string)
+	}
+	if strings.TrimSpace(idToken) == "" {
+		if storage, ok := auth.Storage.(*codex.CodexTokenStorage); ok && storage != nil {
+			idToken = storage.IDToken
+		}
+	}
+	idToken = strings.TrimSpace(idToken)
+	if idToken == "" {
+		return
+	}
+	claims, errParse := codex.ParseJWTToken(idToken)
+	if errParse != nil || claims == nil {
+		return
+	}
+	planType := strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType)
+	if planType == "" {
+		return
+	}
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	auth.Attributes["plan_type"] = planType
 }
 
 func prepareCodexOAuthRecordForSave(record *coreauth.Auth, writeName string) {
@@ -177,6 +208,7 @@ func prepareCodexOAuthRecordForSave(record *coreauth.Auth, writeName string) {
 	record.Metadata["status"] = ""
 	record.Metadata["status_message"] = ""
 	record.Metadata["unavailable"] = false
+	applyCodexPlanTypeFromIDToken(record)
 	if setter, ok := record.Storage.(interface{ SetMetadata(map[string]any) }); ok {
 		setter.SetMetadata(record.Metadata)
 	}

--- a/internal/api/handlers/management/auth_files_codex_replace.go
+++ b/internal/api/handlers/management/auth_files_codex_replace.go
@@ -2,9 +2,7 @@ package management
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -30,6 +28,7 @@ type codexAuthFileRef struct {
 	Name      string
 	AccountID string
 	Disabled  bool
+	Metadata  map[string]any
 }
 
 // saveCodexOAuthRecord persists a Codex OAuth credential. If this ChatGPT
@@ -51,12 +50,15 @@ func (h *Handler) saveCodexOAuthRecord(ctx context.Context, record *coreauth.Aut
 		replaceHint = ""
 	}
 
-	siblings := h.listCodexFilesByAccountID(accountID)
+	siblings, errList := h.listCodexFilesByAccountID(ctx, accountID)
+	if errList != nil {
+		return "", errList
+	}
 	keep, remove := pickCodexKeepAndRemove(siblings, canonicalName, replaceHint)
 	writeName := canonicalName
 	if keep != "" {
 		writeName = keep
-		h.mergeAuthFileMetadataFrom(record, keep)
+		mergeCodexOperatorMetadata(record, metadataForCodexRef(siblings, keep))
 	}
 
 	prepareCodexOAuthRecordForSave(record, writeName)
@@ -112,58 +114,65 @@ func codexAccountIDFromRecord(record *coreauth.Auth) string {
 	return strings.TrimSpace(id)
 }
 
-func (h *Handler) listCodexFilesByAccountID(accountID string) []codexAuthFileRef {
+func (h *Handler) listCodexFilesByAccountID(ctx context.Context, accountID string) ([]codexAuthFileRef, error) {
 	accountID = strings.TrimSpace(accountID)
-	if accountID == "" || h == nil || h.cfg == nil || strings.TrimSpace(h.cfg.AuthDir) == "" {
-		return nil
+	if accountID == "" || h == nil {
+		return nil, nil
 	}
-	entries, err := os.ReadDir(h.cfg.AuthDir)
+	store := h.tokenStoreWithBaseDir()
+	if store == nil {
+		return nil, fmt.Errorf("token store unavailable")
+	}
+	auths, err := store.List(ctx)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("list existing Codex auth records: %w", err)
 	}
 	var out []codexAuthFileRef
-	for _, entry := range entries {
-		if entry.IsDir() {
+	for _, auth := range auths {
+		if auth == nil || !isCodexAuthRecord(auth) {
 			continue
 		}
-		name := entry.Name()
-		if !strings.HasSuffix(strings.ToLower(name), ".json") || strings.HasPrefix(name, ".") {
-			continue
-		}
-		raw, errRead := os.ReadFile(filepath.Join(h.cfg.AuthDir, name))
-		if errRead != nil || len(raw) == 0 {
-			continue
-		}
-		var payload map[string]any
-		if errJSON := json.Unmarshal(raw, &payload); errJSON != nil {
-			continue
-		}
-		if !isCodexAuthPayload(payload) {
-			continue
-		}
-		id := authPayloadAccountID(payload)
+		id := authPayloadAccountID(auth.Metadata)
 		if id == "" || id != accountID {
+			continue
+		}
+		name := authRecordFileName(auth)
+		if name == "" || isUnsafeAuthFileName(name) {
 			continue
 		}
 		out = append(out, codexAuthFileRef{
 			Name:      name,
 			AccountID: id,
-			Disabled:  truthyJSON(payload["disabled"]),
+			Disabled:  auth.Disabled || truthyJSON(auth.Metadata["disabled"]),
+			Metadata:  cloneMetadataMap(auth.Metadata),
 		})
 	}
-	return out
+	return out, nil
+}
+
+func isCodexAuthRecord(auth *coreauth.Auth) bool {
+	if auth == nil {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return true
+	}
+	return isCodexAuthPayload(auth.Metadata)
 }
 
 func isCodexAuthPayload(payload map[string]any) bool {
-	if payload == nil {
-		return false
+	return strings.EqualFold(strings.TrimSpace(jsonString(payload["type"])), "codex")
+}
+
+func authRecordFileName(auth *coreauth.Auth) string {
+	if auth == nil {
+		return ""
 	}
-	switch strings.ToLower(strings.TrimSpace(jsonString(payload["type"]))) {
-	case "", "codex":
-		return true
-	default:
-		return false
+	name := filepath.Base(strings.TrimSpace(auth.FileName))
+	if name != "" && name != "." && name != string(filepath.Separator) {
+		return name
 	}
+	return filepath.Base(strings.TrimSpace(auth.ID))
 }
 
 func authPayloadAccountID(payload map[string]any) string {
@@ -234,20 +243,33 @@ func pickCodexKeepAndRemove(siblings []codexAuthFileRef, canonicalName, replaceH
 	return keep, remove
 }
 
-func (h *Handler) mergeAuthFileMetadataFrom(record *coreauth.Auth, fileName string) {
-	if h == nil || record == nil || h.cfg == nil || isUnsafeAuthFileName(fileName) {
+func metadataForCodexRef(siblings []codexAuthFileRef, name string) map[string]any {
+	for _, sibling := range siblings {
+		if sibling.Name == name {
+			return sibling.Metadata
+		}
+	}
+	return nil
+}
+
+func mergeCodexOperatorMetadata(record *coreauth.Auth, existingMap map[string]any) {
+	if record == nil || len(existingMap) == 0 {
 		return
 	}
-	raw, errRead := os.ReadFile(filepath.Join(h.cfg.AuthDir, filepath.Base(fileName)))
-	if errRead != nil || len(raw) == 0 {
-		return
-	}
-	var existingMap map[string]any
-	if errJSON := json.Unmarshal(raw, &existingMap); errJSON != nil || len(existingMap) == 0 {
-		return
-	}
+	cloned := cloneMetadataMap(existingMap)
 	for _, key := range oauthRuntimeMetadataKeys {
-		delete(existingMap, key)
+		delete(cloned, key)
 	}
-	coreauth.MergeExistingAuthMetadata(record, existingMap)
+	coreauth.MergeExistingAuthMetadata(record, cloned)
+}
+
+func cloneMetadataMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
 }

--- a/internal/api/handlers/management/auth_files_codex_replace.go
+++ b/internal/api/handlers/management/auth_files_codex_replace.go
@@ -1,0 +1,253 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+var oauthRuntimeMetadataKeys = []string{
+	"disabled",
+	"status",
+	"status_message",
+	"unavailable",
+	"last_error",
+	"quota",
+	"model_states",
+	"next_retry_after",
+	"failed",
+	"success",
+}
+
+type codexAuthFileRef struct {
+	Name      string
+	AccountID string
+	Disabled  bool
+}
+
+// saveCodexOAuthRecord persists a Codex OAuth credential. If this ChatGPT
+// account_id already has a file, tokens are written back to that filename so
+// usage stats and operator notes stay on the same row. Plan changes do not
+// rename the file. A replace hint selects which sibling to keep when several exist.
+func (h *Handler) saveCodexOAuthRecord(ctx context.Context, record *coreauth.Auth, replaceHint string) (string, error) {
+	if record == nil {
+		return "", fmt.Errorf("token record is nil")
+	}
+
+	canonicalName := strings.TrimSpace(record.FileName)
+	if canonicalName == "" {
+		canonicalName = strings.TrimSpace(record.ID)
+	}
+	accountID := codexAccountIDFromRecord(record)
+	replaceHint = filepath.Base(strings.TrimSpace(replaceHint))
+	if isUnsafeAuthFileName(replaceHint) {
+		replaceHint = ""
+	}
+
+	siblings := h.listCodexFilesByAccountID(accountID)
+	keep, remove := pickCodexKeepAndRemove(siblings, canonicalName, replaceHint)
+	writeName := canonicalName
+	if keep != "" {
+		writeName = keep
+		h.mergeAuthFileMetadataFrom(record, keep)
+	}
+
+	prepareCodexOAuthRecordForSave(record, writeName)
+
+	savedPath, errSave := h.saveTokenRecord(ctx, record)
+	if errSave != nil {
+		return savedPath, errSave
+	}
+
+	for _, name := range remove {
+		if name == "" || name == writeName {
+			continue
+		}
+		if _, _, errDelete := h.deleteAuthFileByName(ctx, name); errDelete != nil {
+			log.WithError(errDelete).WithField("file", name).Warn("failed to remove replaced Codex auth file")
+		}
+	}
+	return savedPath, nil
+}
+
+func prepareCodexOAuthRecordForSave(record *coreauth.Auth, writeName string) {
+	if record == nil {
+		return
+	}
+	record.ID = writeName
+	record.FileName = writeName
+	record.Disabled = false
+	if record.Metadata == nil {
+		record.Metadata = make(map[string]any)
+	}
+	record.Metadata["disabled"] = false
+	record.Metadata["status"] = ""
+	record.Metadata["status_message"] = ""
+	record.Metadata["unavailable"] = false
+	if setter, ok := record.Storage.(interface{ SetMetadata(map[string]any) }); ok {
+		setter.SetMetadata(record.Metadata)
+	}
+}
+
+func codexAccountIDFromRecord(record *coreauth.Auth) string {
+	if record == nil {
+		return ""
+	}
+	if storage, ok := record.Storage.(*codex.CodexTokenStorage); ok {
+		if id := strings.TrimSpace(storage.AccountID); id != "" {
+			return id
+		}
+	}
+	if record.Metadata == nil {
+		return ""
+	}
+	id, _ := record.Metadata["account_id"].(string)
+	return strings.TrimSpace(id)
+}
+
+func (h *Handler) listCodexFilesByAccountID(accountID string) []codexAuthFileRef {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" || h == nil || h.cfg == nil || strings.TrimSpace(h.cfg.AuthDir) == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(h.cfg.AuthDir)
+	if err != nil {
+		return nil
+	}
+	var out []codexAuthFileRef
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(strings.ToLower(name), ".json") || strings.HasPrefix(name, ".") {
+			continue
+		}
+		raw, errRead := os.ReadFile(filepath.Join(h.cfg.AuthDir, name))
+		if errRead != nil || len(raw) == 0 {
+			continue
+		}
+		var payload map[string]any
+		if errJSON := json.Unmarshal(raw, &payload); errJSON != nil {
+			continue
+		}
+		if !isCodexAuthPayload(payload) {
+			continue
+		}
+		id := authPayloadAccountID(payload)
+		if id == "" || id != accountID {
+			continue
+		}
+		out = append(out, codexAuthFileRef{
+			Name:      name,
+			AccountID: id,
+			Disabled:  truthyJSON(payload["disabled"]),
+		})
+	}
+	return out
+}
+
+func isCodexAuthPayload(payload map[string]any) bool {
+	if payload == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(jsonString(payload["type"]))) {
+	case "", "codex":
+		return true
+	default:
+		return false
+	}
+}
+
+func authPayloadAccountID(payload map[string]any) string {
+	if id := strings.TrimSpace(jsonString(payload["account_id"])); id != "" {
+		return id
+	}
+	return strings.TrimSpace(jsonString(payload["chatgpt_account_id"]))
+}
+
+func jsonString(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func truthyJSON(v any) bool {
+	switch n := v.(type) {
+	case bool:
+		return n
+	case string:
+		switch strings.ToLower(strings.TrimSpace(n)) {
+		case "1", "true", "yes", "on":
+			return true
+		}
+	}
+	return false
+}
+
+func pickCodexKeepAndRemove(siblings []codexAuthFileRef, canonicalName, replaceHint string) (keep string, remove []string) {
+	canonicalName = strings.TrimSpace(canonicalName)
+	replaceHint = strings.TrimSpace(replaceHint)
+
+	if replaceHint != "" {
+		for _, sibling := range siblings {
+			if sibling.Name == replaceHint {
+				keep = replaceHint
+				break
+			}
+		}
+	}
+	if keep == "" {
+		for _, sibling := range siblings {
+			if sibling.Name == canonicalName {
+				keep = canonicalName
+				break
+			}
+		}
+	}
+	if keep == "" && len(siblings) == 1 {
+		keep = siblings[0].Name
+	}
+	if keep == "" && len(siblings) > 1 {
+		for _, sibling := range siblings {
+			if !sibling.Disabled {
+				keep = sibling.Name
+				break
+			}
+		}
+		if keep == "" {
+			keep = siblings[0].Name
+		}
+	}
+
+	for _, sibling := range siblings {
+		if sibling.Name != keep {
+			remove = append(remove, sibling.Name)
+		}
+	}
+	return keep, remove
+}
+
+func (h *Handler) mergeAuthFileMetadataFrom(record *coreauth.Auth, fileName string) {
+	if h == nil || record == nil || h.cfg == nil || isUnsafeAuthFileName(fileName) {
+		return
+	}
+	raw, errRead := os.ReadFile(filepath.Join(h.cfg.AuthDir, filepath.Base(fileName)))
+	if errRead != nil || len(raw) == 0 {
+		return
+	}
+	var existingMap map[string]any
+	if errJSON := json.Unmarshal(raw, &existingMap); errJSON != nil || len(existingMap) == 0 {
+		return
+	}
+	for _, key := range oauthRuntimeMetadataKeys {
+		delete(existingMap, key)
+	}
+	coreauth.MergeExistingAuthMetadata(record, existingMap)
+}

--- a/internal/api/handlers/management/auth_files_codex_replace.go
+++ b/internal/api/handlers/management/auth_files_codex_replace.go
@@ -76,13 +76,18 @@ func (h *Handler) saveCodexOAuthRecord(ctx context.Context, record *coreauth.Aut
 		return savedPath, errSave
 	}
 
+	var deleteErr error
 	for _, name := range remove {
 		if name == "" || name == writeName {
 			continue
 		}
 		if errDelete := h.deleteCodexAuthRel(ctx, name); errDelete != nil {
-			log.WithError(errDelete).WithField("file", name).Warn("failed to remove replaced Codex auth file")
+			log.WithError(errDelete).WithField("file", name).Error("failed to remove replaced Codex auth file")
+			deleteErr = fmt.Errorf("saved %s but failed to remove %s: %w", writeName, name, errDelete)
 		}
+	}
+	if deleteErr != nil {
+		return savedPath, deleteErr
 	}
 	return savedPath, nil
 }

--- a/internal/api/handlers/management/auth_files_codex_replace_test.go
+++ b/internal/api/handlers/management/auth_files_codex_replace_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
@@ -249,6 +250,9 @@ func codexFileName(email, plan, accountID string) string {
 
 func writeCodexJSON(t *testing.T, dir, name string, content map[string]any) {
 	t.Helper()
+	if errMkdir := os.MkdirAll(dir, 0o700); errMkdir != nil {
+		t.Fatalf("mkdir %s: %v", dir, errMkdir)
+	}
 	raw, err := json.Marshal(content)
 	if err != nil {
 		t.Fatalf("marshal %s: %v", name, err)
@@ -290,6 +294,91 @@ func jsonFileNames(t *testing.T, dir string) []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+func TestSaveCodexOAuthRecordKeepsNestedRelativePath(t *testing.T) {
+	authDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+	nestedName := filepath.ToSlash(filepath.Join("team", "codex-user@example.com-free.json"))
+	writeCodexJSON(t, filepath.Join(authDir, "team"), "codex-user@example.com-free.json", map[string]any{
+		"type":       "codex",
+		"email":      "user@example.com",
+		"account_id": testCodexAccountID,
+		"note":       "nested",
+		"disabled":   true,
+	})
+
+	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "new-access", "new-refresh")
+	if _, errSave := h.saveCodexOAuthRecord(context.Background(), record, ""); errSave != nil {
+		t.Fatalf("saveCodexOAuthRecord: %v", errSave)
+	}
+
+	if _, errStat := os.Stat(filepath.Join(authDir, filepath.FromSlash(nestedName))); errStat != nil {
+		t.Fatalf("expected nested file %s: %v", nestedName, errStat)
+	}
+	rootNames := jsonFileNames(t, authDir)
+	for _, name := range rootNames {
+		if strings.HasSuffix(name, ".json") && !strings.Contains(name, string(filepath.Separator)) && name != "team" {
+			// jsonFileNames only lists top-level json files
+			t.Fatalf("unexpected root auth file %s", name)
+		}
+	}
+	saved := readJSONMap(t, filepath.Join(authDir, filepath.FromSlash(nestedName)))
+	if saved["access_token"] != "new-access" {
+		t.Errorf("access_token = %v, want new-access", saved["access_token"])
+	}
+	if saved["note"] != "nested" {
+		t.Errorf("note = %v, want nested", saved["note"])
+	}
+}
+
+func TestSaveCodexOAuthRecordConcurrentReplaceKeepsOneFile(t *testing.T) {
+	authDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+	freeName := codexFileName("user@example.com", "free", testCodexAccountID)
+	proName := codexFileName("user@example.com", "pro", testCodexAccountID)
+	writeCodexJSON(t, authDir, freeName, map[string]any{
+		"type":       "codex",
+		"email":      "user@example.com",
+		"account_id": testCodexAccountID,
+		"note":       "free-row",
+	})
+	writeCodexJSON(t, authDir, proName, map[string]any{
+		"type":       "codex",
+		"email":      "user@example.com",
+		"account_id": testCodexAccountID,
+		"note":       "pro-row",
+	})
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, errSave := h.saveCodexOAuthRecord(context.Background(), newCodexRecord("user@example.com", testCodexAccountID, "pro", "from-free", "refresh-free"), freeName)
+		errCh <- errSave
+	}()
+	go func() {
+		defer wg.Done()
+		_, errSave := h.saveCodexOAuthRecord(context.Background(), newCodexRecord("user@example.com", testCodexAccountID, "pro", "from-pro", "refresh-pro"), proName)
+		errCh <- errSave
+	}()
+	wg.Wait()
+	close(errCh)
+	for errSave := range errCh {
+		if errSave != nil {
+			t.Fatalf("saveCodexOAuthRecord: %v", errSave)
+		}
+	}
+
+	got := jsonFileNames(t, authDir)
+	if len(got) != 1 {
+		t.Fatalf("auth files = %v, want exactly one remaining file", got)
+	}
+	saved := readJSONMap(t, filepath.Join(authDir, got[0]))
+	if saved["access_token"] != "from-free" && saved["access_token"] != "from-pro" {
+		t.Errorf("access_token = %v, want one of the concurrent saves", saved["access_token"])
+	}
 }
 
 func TestSaveCodexOAuthRecordListErrorDoesNotCreateFile(t *testing.T) {

--- a/internal/api/handlers/management/auth_files_codex_replace_test.go
+++ b/internal/api/handlers/management/auth_files_codex_replace_test.go
@@ -3,6 +3,7 @@ package management
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -216,6 +217,20 @@ func TestSaveCodexOAuthRecordClearsDisabledOnSameFilename(t *testing.T) {
 	if saved["note"] != "keep" {
 		t.Errorf("note = %v, want keep", saved["note"])
 	}
+}
+
+func fakeCodexIDToken(planType string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payload, err := json.Marshal(map[string]any{
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": testCodexAccountID,
+			"chatgpt_plan_type":  planType,
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + "."
 }
 
 func newCodexRecord(email, accountID, plan, access, refresh string) *coreauth.Auth {
@@ -433,7 +448,8 @@ func TestSaveCodexOAuthRecordUpdatesRuntimeAuthMetadata(t *testing.T) {
 		FileName: nestedRel,
 		Provider: "codex",
 		Attributes: map[string]string{
-			"path": nestedPath,
+			"path":      nestedPath,
+			"plan_type": "free",
 		},
 		Metadata: map[string]any{
 			"type":         "codex",
@@ -446,6 +462,9 @@ func TestSaveCodexOAuthRecordUpdatesRuntimeAuthMetadata(t *testing.T) {
 	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
 
 	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "new-access", "new-refresh")
+	if storage, ok := record.Storage.(*codex.CodexTokenStorage); ok {
+		storage.IDToken = fakeCodexIDToken("pro")
+	}
 	if _, errSave := h.saveCodexOAuthRecord(context.Background(), record, nestedRel); errSave != nil {
 		t.Fatalf("saveCodexOAuthRecord: %v", errSave)
 	}
@@ -456,6 +475,9 @@ func TestSaveCodexOAuthRecordUpdatesRuntimeAuthMetadata(t *testing.T) {
 	}
 	if got.Metadata["access_token"] != "new-access" {
 		t.Errorf("runtime access_token = %v, want new-access", got.Metadata["access_token"])
+	}
+	if got.Attributes["plan_type"] != "pro" {
+		t.Errorf("runtime plan_type = %q, want pro", got.Attributes["plan_type"])
 	}
 	if got.Disabled {
 		t.Error("runtime auth still disabled")

--- a/internal/api/handlers/management/auth_files_codex_replace_test.go
+++ b/internal/api/handlers/management/auth_files_codex_replace_test.go
@@ -417,6 +417,51 @@ func TestSaveCodexOAuthRecordRemovesNestedSibling(t *testing.T) {
 	}
 }
 
+func TestSaveCodexOAuthRecordUpdatesRuntimeAuthMetadata(t *testing.T) {
+	authDir := t.TempDir()
+	nestedRel := filepath.ToSlash(filepath.Join("team", "codex-user.json"))
+	nestedPath := filepath.Join(authDir, filepath.FromSlash(nestedRel))
+	writeCodexJSON(t, filepath.Dir(nestedPath), filepath.Base(nestedPath), map[string]any{
+		"type":         "codex",
+		"account_id":   testCodexAccountID,
+		"access_token": "old-access",
+		"note":         "nested",
+	})
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       nestedRel,
+		FileName: nestedRel,
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": nestedPath,
+		},
+		Metadata: map[string]any{
+			"type":         "codex",
+			"account_id":   testCodexAccountID,
+			"access_token": "old-access",
+		},
+	}); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+
+	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "new-access", "new-refresh")
+	if _, errSave := h.saveCodexOAuthRecord(context.Background(), record, nestedRel); errSave != nil {
+		t.Fatalf("saveCodexOAuthRecord: %v", errSave)
+	}
+
+	got, ok := manager.GetByID(nestedRel)
+	if !ok || got == nil {
+		t.Fatal("runtime auth missing after replace")
+	}
+	if got.Metadata["access_token"] != "new-access" {
+		t.Errorf("runtime access_token = %v, want new-access", got.Metadata["access_token"])
+	}
+	if got.Disabled {
+		t.Error("runtime auth still disabled")
+	}
+}
+
 func TestSaveCodexOAuthRecordSiblingDeleteFailureIsReturned(t *testing.T) {
 	authDir := t.TempDir()
 	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)

--- a/internal/api/handlers/management/auth_files_codex_replace_test.go
+++ b/internal/api/handlers/management/auth_files_codex_replace_test.go
@@ -716,6 +716,51 @@ func TestSaveCodexOAuthRecordSiblingDeleteFailureIsReturned(t *testing.T) {
 	}
 }
 
+func TestSaveCodexOAuthRecordRemovesRuntimeWhenSiblingFileAlreadyGone(t *testing.T) {
+	authDir := t.TempDir()
+	keepRel := filepath.ToSlash(filepath.Join("team", "codex-keep.json"))
+	dropRel := filepath.ToSlash(filepath.Join("team", "codex-drop.json"))
+	dropPath := filepath.Join(authDir, filepath.FromSlash(dropRel))
+	writeCodexJSON(t, filepath.Join(authDir, "team"), "codex-keep.json", map[string]any{
+		"type":       "codex",
+		"account_id": testCodexAccountID,
+		"note":       "keep-nested",
+	})
+	writeCodexJSON(t, filepath.Join(authDir, "team"), "codex-drop.json", map[string]any{
+		"type":       "codex",
+		"account_id": testCodexAccountID,
+	})
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       dropRel,
+		FileName: dropRel,
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": dropPath,
+		},
+	}); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+	h.tokenStore = overlayListStore{
+		Store:              h.tokenStoreWithBaseDir(),
+		deleteErr:          fmt.Errorf("remote delete failed"),
+		deleteLocalThenErr: true,
+	}
+
+	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "new-access", "new-refresh")
+	_, errSave := h.saveCodexOAuthRecord(context.Background(), record, keepRel)
+	if errSave == nil || !strings.Contains(errSave.Error(), "remote delete failed") {
+		t.Fatalf("error = %v, want remote delete failed", errSave)
+	}
+	if _, errStat := os.Stat(dropPath); !os.IsNotExist(errStat) {
+		t.Fatalf("drop sibling still present: %v", errStat)
+	}
+	if _, ok := manager.GetByID(dropRel); ok {
+		t.Fatal("runtime auth for deleted sibling still registered")
+	}
+}
+
 func TestSaveCodexOAuthRecordListErrorDoesNotCreateFile(t *testing.T) {
 	authDir := t.TempDir()
 	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
@@ -775,10 +820,11 @@ func TestSaveCodexOAuthRecordUsesStoreListNotDiskScan(t *testing.T) {
 
 type overlayListStore struct {
 	coreauth.Store
-	list       []*coreauth.Auth
-	listErr    error
-	deleteErr  error
-	beforeList func()
+	list               []*coreauth.Auth
+	listErr            error
+	deleteErr          error
+	deleteLocalThenErr bool
+	beforeList         func()
 }
 
 func (s overlayListStore) List(ctx context.Context) ([]*coreauth.Auth, error) {
@@ -799,6 +845,9 @@ func (s overlayListStore) List(ctx context.Context) ([]*coreauth.Auth, error) {
 
 func (s overlayListStore) Delete(ctx context.Context, id string) error {
 	if s.deleteErr != nil {
+		if s.deleteLocalThenErr && s.Store != nil {
+			_ = s.Store.Delete(ctx, id)
+		}
 		return s.deleteErr
 	}
 	if s.Store == nil {

--- a/internal/api/handlers/management/auth_files_codex_replace_test.go
+++ b/internal/api/handlers/management/auth_files_codex_replace_test.go
@@ -473,6 +473,9 @@ func TestSaveCodexOAuthRecordUpdatesRuntimeAuthMetadata(t *testing.T) {
 	if !ok || got == nil {
 		t.Fatal("runtime auth missing after replace")
 	}
+	if record.Metadata["access_token"] != "new-access" {
+		t.Errorf("persist record access_token = %v, want new-access", record.Metadata["access_token"])
+	}
 	if got.Metadata["access_token"] != "new-access" {
 		t.Errorf("runtime access_token = %v, want new-access", got.Metadata["access_token"])
 	}

--- a/internal/api/handlers/management/auth_files_codex_replace_test.go
+++ b/internal/api/handlers/management/auth_files_codex_replace_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -487,6 +488,128 @@ func TestSaveCodexOAuthRecordUpdatesRuntimeAuthMetadata(t *testing.T) {
 	}
 }
 
+func TestSaveCodexOAuthRecordKeepsNestedRuntimeSettingsAfterPersistSync(t *testing.T) {
+	authDir := t.TempDir()
+	nestedRel := filepath.ToSlash(filepath.Join("team", "codex-user.json"))
+	nestedPath := filepath.Join(authDir, filepath.FromSlash(nestedRel))
+	writeCodexJSON(t, filepath.Dir(nestedPath), filepath.Base(nestedPath), map[string]any{
+		"type":            "codex",
+		"account_id":      testCodexAccountID,
+		"access_token":    "old-access",
+		"note":            "nested",
+		"priority":        float64(60),
+		"proxy_url":       "socks5://10.80.1.61:2083",
+		"prefix":          "team",
+		"excluded_models": []any{"gpt-4"},
+	})
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       nestedRel,
+		FileName: nestedRel,
+		Provider: "codex",
+		Prefix:   "team",
+		ProxyURL: "socks5://10.80.1.61:2083",
+		Label:    "user@example.com",
+		Attributes: map[string]string{
+			"path":            nestedPath,
+			"plan_type":       "free",
+			"priority":        "60",
+			"note":            "nested",
+			"excluded_models": "gpt-4",
+		},
+		Metadata: map[string]any{
+			"type":         "codex",
+			"account_id":   testCodexAccountID,
+			"access_token": "old-access",
+			"note":         "nested",
+			"priority":     float64(60),
+			"proxy_url":    "socks5://10.80.1.61:2083",
+			"prefix":       "team",
+		},
+	}); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+	h.postAuthPersistHook = func(ctx context.Context, auth *coreauth.Auth) error {
+		if _, ok := manager.GetByID(auth.ID); ok {
+			_, errUpdate := manager.Update(ctx, auth)
+			return errUpdate
+		}
+		_, errRegister := manager.Register(ctx, auth)
+		return errRegister
+	}
+
+	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "new-access", "new-refresh")
+	if storage, ok := record.Storage.(*codex.CodexTokenStorage); ok {
+		storage.IDToken = fakeCodexIDToken("pro")
+	}
+	if _, errSave := h.saveCodexOAuthRecord(context.Background(), record, nestedRel); errSave != nil {
+		t.Fatalf("saveCodexOAuthRecord: %v", errSave)
+	}
+
+	got, ok := manager.GetByID(nestedRel)
+	if !ok || got == nil {
+		t.Fatal("runtime auth missing after replace")
+	}
+	if got.Prefix != "team" {
+		t.Errorf("prefix = %q, want team", got.Prefix)
+	}
+	if got.ProxyURL != "socks5://10.80.1.61:2083" {
+		t.Errorf("proxy_url = %q", got.ProxyURL)
+	}
+	if got.Attributes["priority"] != "60" {
+		t.Errorf("priority = %q, want 60", got.Attributes["priority"])
+	}
+	if got.Attributes["note"] != "nested" {
+		t.Errorf("note = %q, want nested", got.Attributes["note"])
+	}
+	if got.Attributes["excluded_models"] != "gpt-4" {
+		t.Errorf("excluded_models = %q, want gpt-4", got.Attributes["excluded_models"])
+	}
+	if got.Attributes["plan_type"] != "pro" {
+		t.Errorf("plan_type = %q, want pro", got.Attributes["plan_type"])
+	}
+	if got.Metadata["access_token"] != "new-access" {
+		t.Errorf("access_token = %v, want new-access", got.Metadata["access_token"])
+	}
+}
+
+func TestSaveCodexOAuthRecordSkipsSaveWhenSessionCancelledDuringList(t *testing.T) {
+	authDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	h.tokenStore = overlayListStore{
+		Store: h.tokenStoreWithBaseDir(),
+		beforeList: func() {
+			close(started)
+			<-release
+		},
+	}
+	state := "codex-cancel-during-list"
+	RegisterOAuthSession(state, "codex")
+	t.Cleanup(func() { CancelOAuthSession(state) })
+
+	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "new-access", "new-refresh")
+	errCh := make(chan error, 1)
+	go func() {
+		_, errSave := h.saveCodexOAuthRecord(withOAuthSaveSession(context.Background(), state, "codex"), record, "")
+		errCh <- errSave
+	}()
+	<-started
+	if !CancelOAuthSession(state) {
+		t.Fatal("expected pending session to cancel")
+	}
+	close(release)
+	errSave := <-errCh
+	if !errors.Is(errSave, errOAuthSessionNotPending) {
+		t.Fatalf("error = %v, want %v", errSave, errOAuthSessionNotPending)
+	}
+	if names := jsonFileNames(t, authDir); len(names) != 0 {
+		t.Fatalf("auth files = %v, want none after cancelled save", names)
+	}
+}
+
 func TestSaveCodexOAuthRecordSiblingDeleteFailureIsReturned(t *testing.T) {
 	authDir := t.TempDir()
 	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
@@ -572,12 +695,16 @@ func TestSaveCodexOAuthRecordUsesStoreListNotDiskScan(t *testing.T) {
 
 type overlayListStore struct {
 	coreauth.Store
-	list      []*coreauth.Auth
-	listErr   error
-	deleteErr error
+	list       []*coreauth.Auth
+	listErr    error
+	deleteErr  error
+	beforeList func()
 }
 
 func (s overlayListStore) List(ctx context.Context) ([]*coreauth.Auth, error) {
+	if s.beforeList != nil {
+		s.beforeList()
+	}
 	if s.listErr != nil {
 		return nil, s.listErr
 	}

--- a/internal/api/handlers/management/auth_files_codex_replace_test.go
+++ b/internal/api/handlers/management/auth_files_codex_replace_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -485,6 +486,85 @@ func TestSaveCodexOAuthRecordUpdatesRuntimeAuthMetadata(t *testing.T) {
 	}
 	if got.Disabled {
 		t.Error("runtime auth still disabled")
+	}
+}
+
+func TestSaveCodexOAuthRecordClearsRuntimeCooldownOnReplace(t *testing.T) {
+	authDir := t.TempDir()
+	nestedRel := filepath.ToSlash(filepath.Join("team", "codex-user.json"))
+	nestedPath := filepath.Join(authDir, filepath.FromSlash(nestedRel))
+	writeCodexJSON(t, filepath.Dir(nestedPath), filepath.Base(nestedPath), map[string]any{
+		"type":         "codex",
+		"account_id":   testCodexAccountID,
+		"access_token": "old-access",
+	})
+	recoverAt := time.Now().Add(time.Hour)
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(context.Background(), &coreauth.Auth{
+		ID:             nestedRel,
+		FileName:       nestedRel,
+		Provider:       "codex",
+		Status:         coreauth.StatusError,
+		Unavailable:    true,
+		NextRetryAfter: recoverAt,
+		Quota: coreauth.QuotaState{
+			Exceeded:      true,
+			Reason:        "credential_quota",
+			NextRecoverAt: recoverAt,
+		},
+		ModelStates: map[string]*coreauth.ModelState{
+			"gpt-5": {
+				Status:         coreauth.StatusError,
+				Unavailable:    true,
+				NextRetryAfter: recoverAt,
+				LastError:      &coreauth.Error{Message: "quota"},
+				Quota: coreauth.QuotaState{
+					Exceeded:      true,
+					Reason:        "credential_quota",
+					NextRecoverAt: recoverAt,
+				},
+			},
+		},
+		Attributes: map[string]string{
+			"path":      nestedPath,
+			"plan_type": "free",
+		},
+		Metadata: map[string]any{
+			"type":         "codex",
+			"account_id":   testCodexAccountID,
+			"access_token": "old-access",
+		},
+	}); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+
+	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "new-access", "new-refresh")
+	if storage, ok := record.Storage.(*codex.CodexTokenStorage); ok {
+		storage.IDToken = fakeCodexIDToken("pro")
+	}
+	if _, errSave := h.saveCodexOAuthRecord(context.Background(), record, nestedRel); errSave != nil {
+		t.Fatalf("saveCodexOAuthRecord: %v", errSave)
+	}
+
+	got, ok := manager.GetByID(nestedRel)
+	if !ok || got == nil {
+		t.Fatal("runtime auth missing after replace")
+	}
+	if got.Status != coreauth.StatusActive {
+		t.Errorf("status = %q, want %q", got.Status, coreauth.StatusActive)
+	}
+	if got.Unavailable {
+		t.Error("runtime auth still unavailable")
+	}
+	if !got.NextRetryAfter.IsZero() {
+		t.Errorf("NextRetryAfter = %v, want zero", got.NextRetryAfter)
+	}
+	if got.Quota.Exceeded || got.Quota.Reason != "" {
+		t.Errorf("quota = %+v, want cleared", got.Quota)
+	}
+	if len(got.ModelStates) > 0 {
+		t.Errorf("ModelStates = %+v, want empty", got.ModelStates)
 	}
 }
 

--- a/internal/api/handlers/management/auth_files_codex_replace_test.go
+++ b/internal/api/handlers/management/auth_files_codex_replace_test.go
@@ -5,9 +5,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
@@ -288,6 +290,82 @@ func jsonFileNames(t *testing.T, dir string) []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+func TestSaveCodexOAuthRecordListErrorDoesNotCreateFile(t *testing.T) {
+	authDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+	h.tokenStore = overlayListStore{Store: h.tokenStoreWithBaseDir(), listErr: fmt.Errorf("store list failed")}
+
+	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "new-access", "new-refresh")
+	if _, errSave := h.saveCodexOAuthRecord(context.Background(), record, ""); errSave == nil {
+		t.Fatal("expected list error, got nil")
+	} else if !strings.Contains(errSave.Error(), "store list failed") {
+		t.Fatalf("error = %v, want store list failed", errSave)
+	}
+	if names := jsonFileNames(t, authDir); len(names) != 0 {
+		t.Fatalf("auth files = %v, want none after list failure", names)
+	}
+}
+
+func TestSaveCodexOAuthRecordUsesStoreListNotDiskScan(t *testing.T) {
+	authDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+	base := h.tokenStoreWithBaseDir()
+	keepName := "codex-store-keep.json"
+	h.tokenStore = overlayListStore{
+		Store: base,
+		list: []*coreauth.Auth{{
+			ID:       keepName,
+			Provider: "codex",
+			FileName: keepName,
+			Metadata: map[string]any{
+				"type":       "codex",
+				"account_id": testCodexAccountID,
+				"note":       "from-store",
+				"priority":   float64(7),
+			},
+		}},
+	}
+
+	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "new-access", "new-refresh")
+	if _, errSave := h.saveCodexOAuthRecord(context.Background(), record, ""); errSave != nil {
+		t.Fatalf("saveCodexOAuthRecord: %v", errSave)
+	}
+
+	got := jsonFileNames(t, authDir)
+	if !stringSlicesEqual(got, []string{keepName}) {
+		t.Fatalf("auth files = %v, want [%s]", got, keepName)
+	}
+	saved := readJSONMap(t, filepath.Join(authDir, keepName))
+	if saved["note"] != "from-store" {
+		t.Errorf("note = %v, want from-store", saved["note"])
+	}
+	if saved["priority"] != float64(7) {
+		t.Errorf("priority = %v, want 7", saved["priority"])
+	}
+	if saved["access_token"] != "new-access" {
+		t.Errorf("access_token = %v, want new-access", saved["access_token"])
+	}
+}
+
+type overlayListStore struct {
+	coreauth.Store
+	list    []*coreauth.Auth
+	listErr error
+}
+
+func (s overlayListStore) List(ctx context.Context) ([]*coreauth.Auth, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	if s.list != nil {
+		return s.list, nil
+	}
+	if s.Store == nil {
+		return nil, nil
+	}
+	return s.Store.List(ctx)
 }
 
 func stringSlicesEqual(a, b []string) bool {

--- a/internal/api/handlers/management/auth_files_codex_replace_test.go
+++ b/internal/api/handlers/management/auth_files_codex_replace_test.go
@@ -1,0 +1,303 @@
+package management
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+const testCodexAccountID = "acct-viisoso-1"
+
+func TestSaveCodexOAuthRecordKeepsExistingFreeFilename(t *testing.T) {
+	authDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+
+	freeName := codexFileName("user@example.com", "free", testCodexAccountID)
+	writeCodexJSON(t, authDir, freeName, map[string]any{
+		"type":          "codex",
+		"email":         "user@example.com",
+		"account_id":    testCodexAccountID,
+		"access_token":  "old-access",
+		"refresh_token": "old-refresh",
+		"note":          "程辉",
+		"priority":      float64(60),
+		"disabled":      true,
+		"proxy_url":     "socks5://10.80.1.61:2083",
+	})
+
+	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "new-access", "new-refresh")
+	if _, errSave := h.saveCodexOAuthRecord(context.Background(), record, ""); errSave != nil {
+		t.Fatalf("saveCodexOAuthRecord: %v", errSave)
+	}
+
+	got := jsonFileNames(t, authDir)
+	if !stringSlicesEqual(got, []string{freeName}) {
+		t.Fatalf("auth files = %v, want [%s]", got, freeName)
+	}
+
+	saved := readJSONMap(t, filepath.Join(authDir, freeName))
+	if saved["access_token"] != "new-access" {
+		t.Errorf("access_token = %v, want new-access", saved["access_token"])
+	}
+	if saved["note"] != "程辉" {
+		t.Errorf("note = %v, want 程辉", saved["note"])
+	}
+	if saved["priority"] != float64(60) {
+		t.Errorf("priority = %v, want 60", saved["priority"])
+	}
+	if saved["proxy_url"] != "socks5://10.80.1.61:2083" {
+		t.Errorf("proxy_url = %v, want socks5://10.80.1.61:2083", saved["proxy_url"])
+	}
+	if saved["disabled"] != false {
+		t.Errorf("disabled = %v, want false", saved["disabled"])
+	}
+}
+
+func TestSaveCodexOAuthRecordOverwritesExistingProFile(t *testing.T) {
+	authDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+
+	proName := codexFileName("user@example.com", "pro", testCodexAccountID)
+	writeCodexJSON(t, authDir, proName, map[string]any{
+		"type":          "codex",
+		"email":         "user@example.com",
+		"account_id":    testCodexAccountID,
+		"access_token":  "old-access",
+		"refresh_token": "old-refresh",
+		"note":          "keep-me",
+		"disabled":      false,
+	})
+
+	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "newer-access", "newer-refresh")
+	if _, errSave := h.saveCodexOAuthRecord(context.Background(), record, ""); errSave != nil {
+		t.Fatalf("saveCodexOAuthRecord: %v", errSave)
+	}
+
+	got := jsonFileNames(t, authDir)
+	if !stringSlicesEqual(got, []string{proName}) {
+		t.Fatalf("auth files = %v, want [%s]", got, proName)
+	}
+	saved := readJSONMap(t, filepath.Join(authDir, proName))
+	if saved["access_token"] != "newer-access" {
+		t.Errorf("access_token = %v, want newer-access", saved["access_token"])
+	}
+	if saved["note"] != "keep-me" {
+		t.Errorf("note = %v, want keep-me", saved["note"])
+	}
+}
+
+func TestSaveCodexOAuthRecordIgnoresReplaceWhenAccountIDDiffers(t *testing.T) {
+	authDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+
+	otherName := codexFileName("other@example.com", "free", "acct-other")
+	writeCodexJSON(t, authDir, otherName, map[string]any{
+		"type":       "codex",
+		"email":      "other@example.com",
+		"account_id": "acct-other",
+		"note":       "do-not-touch",
+		"disabled":   true,
+	})
+
+	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "new-access", "new-refresh")
+	if _, errSave := h.saveCodexOAuthRecord(context.Background(), record, otherName); errSave != nil {
+		t.Fatalf("saveCodexOAuthRecord: %v", errSave)
+	}
+
+	got := jsonFileNames(t, authDir)
+	newName := codexFileName("user@example.com", "pro", testCodexAccountID)
+	want := []string{otherName, newName}
+	sort.Strings(want)
+	if !stringSlicesEqual(got, want) {
+		t.Fatalf("auth files = %v, want %v", got, want)
+	}
+	other := readJSONMap(t, filepath.Join(authDir, otherName))
+	if other["note"] != "do-not-touch" || other["disabled"] != true {
+		t.Errorf("replace target was modified: %#v", other)
+	}
+}
+
+func TestSaveCodexOAuthRecordCreatesWhenNoExistingAccount(t *testing.T) {
+	authDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+
+	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "new-access", "new-refresh")
+	if _, errSave := h.saveCodexOAuthRecord(context.Background(), record, ""); errSave != nil {
+		t.Fatalf("saveCodexOAuthRecord: %v", errSave)
+	}
+
+	got := jsonFileNames(t, authDir)
+	want := []string{codexFileName("user@example.com", "pro", testCodexAccountID)}
+	if !stringSlicesEqual(got, want) {
+		t.Fatalf("auth files = %v, want %v", got, want)
+	}
+}
+
+func TestSaveCodexOAuthRecordCollapsesFreeAndProSiblings(t *testing.T) {
+	authDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+
+	freeName := codexFileName("user@example.com", "free", testCodexAccountID)
+	proName := codexFileName("user@example.com", "pro", testCodexAccountID)
+	writeCodexJSON(t, authDir, freeName, map[string]any{
+		"type":       "codex",
+		"email":      "user@example.com",
+		"account_id": testCodexAccountID,
+		"note":       "from-free",
+		"priority":   float64(60),
+		"disabled":   true,
+	})
+	writeCodexJSON(t, authDir, proName, map[string]any{
+		"type":       "codex",
+		"email":      "user@example.com",
+		"account_id": testCodexAccountID,
+		"note":       "from-pro",
+		"disabled":   false,
+	})
+
+	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "new-access", "new-refresh")
+	if _, errSave := h.saveCodexOAuthRecord(context.Background(), record, freeName); errSave != nil {
+		t.Fatalf("saveCodexOAuthRecord: %v", errSave)
+	}
+
+	got := jsonFileNames(t, authDir)
+	if !stringSlicesEqual(got, []string{freeName}) {
+		t.Fatalf("auth files = %v, want [%s]", got, freeName)
+	}
+	saved := readJSONMap(t, filepath.Join(authDir, freeName))
+	if saved["note"] != "from-free" {
+		t.Errorf("note = %v, want from-free (replace hint)", saved["note"])
+	}
+	if saved["priority"] != float64(60) {
+		t.Errorf("priority = %v, want 60", saved["priority"])
+	}
+	if saved["disabled"] != false {
+		t.Errorf("disabled = %v, want false", saved["disabled"])
+	}
+	if saved["access_token"] != "new-access" {
+		t.Errorf("access_token = %v, want new-access", saved["access_token"])
+	}
+}
+
+func TestSaveCodexOAuthRecordClearsDisabledOnSameFilename(t *testing.T) {
+	authDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+
+	proName := codexFileName("user@example.com", "pro", testCodexAccountID)
+	writeCodexJSON(t, authDir, proName, map[string]any{
+		"type":       "codex",
+		"email":      "user@example.com",
+		"account_id": testCodexAccountID,
+		"disabled":   true,
+		"note":       "keep",
+	})
+
+	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "new-access", "new-refresh")
+	if _, errSave := h.saveCodexOAuthRecord(context.Background(), record, ""); errSave != nil {
+		t.Fatalf("saveCodexOAuthRecord: %v", errSave)
+	}
+
+	saved := readJSONMap(t, filepath.Join(authDir, proName))
+	if saved["disabled"] != false {
+		t.Errorf("disabled = %v, want false", saved["disabled"])
+	}
+	if saved["note"] != "keep" {
+		t.Errorf("note = %v, want keep", saved["note"])
+	}
+}
+
+func newCodexRecord(email, accountID, plan, access, refresh string) *coreauth.Auth {
+	fileName := codexFileName(email, plan, accountID)
+	storage := &codex.CodexTokenStorage{
+		Type:         "codex",
+		Email:        email,
+		AccountID:    accountID,
+		AccessToken:  access,
+		RefreshToken: refresh,
+		IDToken:      "id-" + access,
+		Expire:       "2026-12-31T23:59:59Z",
+		LastRefresh:  "2026-08-23T12:00:00+08:00",
+	}
+	return &coreauth.Auth{
+		ID:       fileName,
+		Provider: "codex",
+		FileName: fileName,
+		Storage:  storage,
+		Metadata: map[string]any{
+			"email":      email,
+			"account_id": accountID,
+		},
+	}
+}
+
+func codexFileName(email, plan, accountID string) string {
+	sum := sha256.Sum256([]byte(accountID))
+	hash := hex.EncodeToString(sum[:])[:8]
+	return codex.CredentialFileName(email, plan, hash, true)
+}
+
+func writeCodexJSON(t *testing.T, dir, name string, content map[string]any) {
+	t.Helper()
+	raw, err := json.Marshal(content)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", name, err)
+	}
+	if err = os.WriteFile(filepath.Join(dir, name), raw, 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func readJSONMap(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var out map[string]any
+	if err = json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	return out
+}
+
+func jsonFileNames(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if filepath.Ext(name) != ".json" || name[0] == '.' {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/api/handlers/management/auth_files_codex_replace_test.go
+++ b/internal/api/handlers/management/auth_files_codex_replace_test.go
@@ -417,6 +417,32 @@ func TestSaveCodexOAuthRecordRemovesNestedSibling(t *testing.T) {
 	}
 }
 
+func TestSaveCodexOAuthRecordSiblingDeleteFailureIsReturned(t *testing.T) {
+	authDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+	freeName := codexFileName("user@example.com", "free", testCodexAccountID)
+	proName := codexFileName("user@example.com", "pro", testCodexAccountID)
+	writeCodexJSON(t, authDir, freeName, map[string]any{
+		"type":       "codex",
+		"account_id": testCodexAccountID,
+		"note":       "keep",
+	})
+	writeCodexJSON(t, authDir, proName, map[string]any{
+		"type":       "codex",
+		"account_id": testCodexAccountID,
+	})
+	h.tokenStore = overlayListStore{
+		Store:     h.tokenStoreWithBaseDir(),
+		deleteErr: fmt.Errorf("remote delete failed"),
+	}
+
+	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "new-access", "new-refresh")
+	_, errSave := h.saveCodexOAuthRecord(context.Background(), record, freeName)
+	if errSave == nil || !strings.Contains(errSave.Error(), "remote delete failed") {
+		t.Fatalf("error = %v, want remote delete failed", errSave)
+	}
+}
+
 func TestSaveCodexOAuthRecordListErrorDoesNotCreateFile(t *testing.T) {
 	authDir := t.TempDir()
 	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
@@ -476,8 +502,9 @@ func TestSaveCodexOAuthRecordUsesStoreListNotDiskScan(t *testing.T) {
 
 type overlayListStore struct {
 	coreauth.Store
-	list    []*coreauth.Auth
-	listErr error
+	list      []*coreauth.Auth
+	listErr   error
+	deleteErr error
 }
 
 func (s overlayListStore) List(ctx context.Context) ([]*coreauth.Auth, error) {
@@ -491,6 +518,16 @@ func (s overlayListStore) List(ctx context.Context) ([]*coreauth.Auth, error) {
 		return nil, nil
 	}
 	return s.Store.List(ctx)
+}
+
+func (s overlayListStore) Delete(ctx context.Context, id string) error {
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	if s.Store == nil {
+		return nil
+	}
+	return s.Store.Delete(ctx, id)
 }
 
 func stringSlicesEqual(a, b []string) bool {

--- a/internal/api/handlers/management/auth_files_codex_replace_test.go
+++ b/internal/api/handlers/management/auth_files_codex_replace_test.go
@@ -381,6 +381,42 @@ func TestSaveCodexOAuthRecordConcurrentReplaceKeepsOneFile(t *testing.T) {
 	}
 }
 
+func TestSaveCodexOAuthRecordRemovesNestedSibling(t *testing.T) {
+	authDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+	keepRel := filepath.ToSlash(filepath.Join("team", "codex-keep.json"))
+	dropRel := filepath.ToSlash(filepath.Join("team", "codex-drop.json"))
+	writeCodexJSON(t, filepath.Join(authDir, "team"), "codex-keep.json", map[string]any{
+		"type":       "codex",
+		"account_id": testCodexAccountID,
+		"note":       "keep-nested",
+		"disabled":   true,
+	})
+	writeCodexJSON(t, filepath.Join(authDir, "team"), "codex-drop.json", map[string]any{
+		"type":       "codex",
+		"account_id": testCodexAccountID,
+		"note":       "drop-nested",
+	})
+
+	record := newCodexRecord("user@example.com", testCodexAccountID, "pro", "new-access", "new-refresh")
+	if _, errSave := h.saveCodexOAuthRecord(context.Background(), record, keepRel); errSave != nil {
+		t.Fatalf("saveCodexOAuthRecord: %v", errSave)
+	}
+	if _, errStat := os.Stat(filepath.Join(authDir, filepath.FromSlash(keepRel))); errStat != nil {
+		t.Fatalf("keep file missing: %v", errStat)
+	}
+	if _, errStat := os.Stat(filepath.Join(authDir, filepath.FromSlash(dropRel))); !os.IsNotExist(errStat) {
+		t.Fatalf("drop sibling still present: %v", errStat)
+	}
+	saved := readJSONMap(t, filepath.Join(authDir, filepath.FromSlash(keepRel)))
+	if saved["note"] != "keep-nested" {
+		t.Errorf("note = %v, want keep-nested", saved["note"])
+	}
+	if saved["access_token"] != "new-access" {
+		t.Errorf("access_token = %v, want new-access", saved["access_token"])
+	}
+}
+
 func TestSaveCodexOAuthRecordListErrorDoesNotCreateFile(t *testing.T) {
 	authDir := t.TempDir()
 	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)

--- a/internal/api/handlers/management/auth_files_provider_oauth.go
+++ b/internal/api/handlers/management/auth_files_provider_oauth.go
@@ -228,6 +228,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 
 	RegisterOAuthSession(state, "codex")
 
+	replaceHint := strings.TrimSpace(c.Query("replace"))
 	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
 	if isWebUI {
@@ -324,7 +325,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 		if errGuard := guardOAuthSessionPendingForSave(state, "codex"); errGuard != nil {
 			return
 		}
-		savedPath, errSave := h.saveTokenRecord(ctx, record)
+		savedPath, errSave := h.saveCodexOAuthRecord(ctx, record, replaceHint)
 		if errSave != nil {
 			SetOAuthSessionError(state, "Failed to save authentication tokens")
 			log.Errorf("Failed to save authentication tokens: %v", errSave)

--- a/internal/api/handlers/management/auth_files_provider_oauth.go
+++ b/internal/api/handlers/management/auth_files_provider_oauth.go
@@ -325,8 +325,11 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 		if errGuard := guardOAuthSessionPendingForSave(state, "codex"); errGuard != nil {
 			return
 		}
-		savedPath, errSave := h.saveCodexOAuthRecord(ctx, record, replaceHint)
+		savedPath, errSave := h.saveCodexOAuthRecord(withOAuthSaveSession(ctx, state, "codex"), record, replaceHint)
 		if errSave != nil {
+			if errors.Is(errSave, errOAuthSessionNotPending) {
+				return
+			}
 			SetOAuthSessionError(state, "Failed to save authentication tokens")
 			log.Errorf("Failed to save authentication tokens: %v", errSave)
 			return

--- a/internal/api/handlers/management/oauth_sessions.go
+++ b/internal/api/handlers/management/oauth_sessions.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -303,6 +304,36 @@ func IsOAuthSessionPending(state, provider string) bool {
 // is no longer pending (cancelled, completed, errored, or expired).
 // Call immediately before persisting credentials so a cancel that races with token
 // exchange or metadata fetch cannot save credentials for a cancelled flow.
+
+type oauthSaveSessionKey struct{}
+
+type oauthSaveSession struct {
+	state    string
+	provider string
+}
+
+func withOAuthSaveSession(ctx context.Context, state, provider string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	state = strings.TrimSpace(state)
+	provider = strings.TrimSpace(provider)
+	if state == "" || provider == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, oauthSaveSessionKey{}, oauthSaveSession{state: state, provider: provider})
+}
+
+func guardOAuthSaveSession(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	session, ok := ctx.Value(oauthSaveSessionKey{}).(oauthSaveSession)
+	if !ok || strings.TrimSpace(session.state) == "" {
+		return nil
+	}
+	return guardOAuthSessionPendingForSave(session.state, session.provider)
+}
 func guardOAuthSessionPendingForSave(state, provider string) error {
 	if IsOAuthSessionPending(state, provider) {
 		return nil


### PR DESCRIPTION
Fixes #5186

## Problem

Codex auth filenames include the ChatGPT plan suffix. `RequestCodexToken` always saved to the canonical `{plan}` name, so re-login of `*-free.json` after the account is Pro created `*-pro.json` and dropped the original row. Usage stats keyed by filename then reset, and operator fields on the old file were not merged.

## Change

Management-only (`internal/api/handlers/management`, no translator edits):

- After a successful Codex token exchange, look up existing records by `account_id` via the configured token `Store.List()` (file / postgres / git / object).
- If one exists, write tokens back to that store-relative path (keep nested names such as `team/codex-user.json`; do not `filepath.Base`).
- Optional `replace=<filename>` on `GET /v0/management/codex-auth-url` selects which sibling to keep when several files share the same `account_id`.
- Preserve note/priority/proxy/weight; clear `disabled` on success.
- Delete leftover siblings through `Store.Delete`.
- If `replace` points at a different `account_id`, do not overwrite it; create a new file as today.
- New accounts with no existing file still use `CredentialFileName`.
- Serialize list + save + sibling delete so two concurrent completions cannot keep opposite files and then delete both.
- If `List` fails, abort the save so a store outage cannot create a second file.

Start login and re-login stay on the same endpoint. No `reauth` flag.

## Verification

```
go test ./internal/api/handlers/management -run 'TestSaveCodexOAuthRecord|TestSaveTokenRecord_Preserves|TestRequestCodexToken' -count=1
```

Tests cover keep-filename, overwrite, wrong-account replace hint, new account, sibling collapse, clear disabled, `List` failure, store-backed lookup, nested relative path, and concurrent replace.
