### PR TITLE
fix(replay): split Claude and Kimi thinking replay cache

### DIFF
--- a/internal/cache/claude_thinking_replay_cache.go
+++ b/internal/cache/claude_thinking_replay_cache.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -38,7 +39,33 @@ const (
 	// ClaudeThinkingReplayCacheMaxTotalBytes bounds aggregate in-process Claude replay content.
 	ClaudeThinkingReplayCacheMaxTotalBytes = 256 << 20
 
+	// ClaudeThinkingReplayCacheMaxAliases bounds the number of message-to-scope
+	// aliases kept in the local fallback map.
+	ClaudeThinkingReplayCacheMaxAliases = 102400
+
+	// ClaudeThinkingReplayCacheMaxAliasBytes bounds the aggregate byte size of
+	// the local alias map so a caller with very large model names cannot exhaust
+	// process memory under the count cap.
+	ClaudeThinkingReplayCacheMaxAliasBytes = 64 << 20
+
+	// ClaudeThinkingReplayCacheMaxAliasesPerKey bounds how many distinct
+	// conversation scopes a single message can map to in the local alias map.
+	ClaudeThinkingReplayCacheMaxAliasesPerKey = 8
+
+	// ClaudeThinkingReplayCacheMaxAliasesPerCredential bounds how many distinct
+	// alias keys a single credential/model can create in Home KV. Keep small so
+	// the per-credential index value does not exceed the underlying KV entry
+	// size limit.
+	ClaudeThinkingReplayCacheMaxAliasesPerCredential = 256
+
 	claudeThinkingReplayCacheMaxSerializedBytes = ClaudeThinkingReplayCacheMaxBytesPerSession + 1024
+
+	// claudeThinkingReplayAliasTombstoneTTL is how long an evicted alias
+	// tombstone stays in Home KV. It must be long enough for the eviction
+	// compare-and-swap race window, but short enough that tombstones do not
+	// block legitimate re-registration or bloat physical storage under the
+	// per-credential alias cap.
+	claudeThinkingReplayAliasTombstoneTTL = 5 * time.Second
 )
 
 type claudeThinkingReplayEntry struct {
@@ -61,7 +88,35 @@ var (
 	claudeThinkingReplayMu         sync.Mutex
 	claudeThinkingReplayEntries    = make(map[string]claudeThinkingReplayEntry)
 	claudeThinkingReplayTotalBytes int
+
+	claudeThinkingReplayAliasMu sync.RWMutex
+	// claudeThinkingReplayAliases maps a per-model message hash to a list of
+	// conversation-scoped session keys that have contained that message. The list
+	// lets two sessionless conversations share a visible message without
+	// overwriting each other; Resolve scores candidates by how many request
+	// messages resolve to the same session and breaks ties by recency.
+	claudeThinkingReplayAliases    = make(map[string][]claudeThinkingReplayAliasEntry)
+	claudeThinkingReplayAliasBytes int
+	claudeThinkingReplayAliasCount int
+
+	claudeThinkingReplayAliasPurgeInterval = 1 * time.Minute
+	claudeThinkingReplayLastAliasPurge     time.Time
 )
+
+type claudeThinkingReplayAliasEntry struct {
+	sessionKey    string
+	firstUserHash string
+	timestamp     time.Time
+}
+
+// ClaudeThinkingReplayAliasMessage pairs a message hash with the weight it
+// should receive during alias resolution. User messages typically receive a
+// higher weight because they are a stronger conversation anchor than
+// an echoed assistant turn.
+type ClaudeThinkingReplayAliasMessage struct {
+	Hash   string
+	Weight int
+}
 
 var currentClaudeThinkingReplayKVClient = func() (kimiThinkingReplayKVClient, bool, error) {
 	return homekv.CurrentKVClient()
@@ -104,6 +159,69 @@ func CacheClaudeThinkingReplayBestEffort(ctx context.Context, modelFamily, sessi
 func GetClaudeThinkingReplayRequired(ctx context.Context, modelFamily, sessionKey string) ([][]byte, bool, error) {
 	contents, _, found, errGet := GetClaudeThinkingReplayWithSnapshotRequired(ctx, modelFamily, sessionKey)
 	return contents, found, errGet
+}
+
+// GetClaudeThinkingReplayWithSnapshotIfExists reads replay state without reserving a tombstone.
+// Use this for no-nonce fallback scopes so Home KV is only populated when a replayable
+// response is actually cached.
+func GetClaudeThinkingReplayWithSnapshotIfExists(ctx context.Context, modelFamily, sessionKey string) ([][]byte, ClaudeThinkingReplaySnapshot, bool, error) {
+	key := claudeThinkingReplayCacheKey(modelFamily, sessionKey)
+	if key == "" {
+		return nil, ClaudeThinkingReplaySnapshot{}, false, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	client, homeMode, errClient := currentClaudeThinkingReplayKVClient()
+	if homeMode {
+		if errClient != nil {
+			return nil, ClaudeThinkingReplaySnapshot{}, false, errClient
+		}
+		kvKey := claudeThinkingReplayKVKey(modelFamily, sessionKey)
+		raw, found, errRead := client.KVGet(ctx, kvKey)
+		if errRead != nil {
+			return nil, ClaudeThinkingReplaySnapshot{}, false, errRead
+		}
+		if !found {
+			// Represent the absent value as a loaded, not-found snapshot so the
+			// later Replace can use compare-and-swap against absence instead of an
+			// unconditional KVSet that could overwrite a concurrent writer.
+			return nil, ClaudeThinkingReplaySnapshot{loaded: true, found: false}, false, nil
+		}
+		snapshot := ClaudeThinkingReplaySnapshot{raw: append([]byte(nil), raw...), loaded: true, found: true}
+		contents, generation, deleted, okDecode := decodeClaudeThinkingReplayHomeValue(raw)
+		if !okDecode {
+			return nil, snapshot, false, fmt.Errorf("invalid Claude thinking replay content")
+		}
+		snapshot.generation = generation
+		if _, errExpire := client.KVExpire(ctx, kvKey, ClaudeThinkingReplayCacheTTL); errExpire != nil {
+			log.Warnf("home kv Claude thinking replay expire failed: %v", errExpire)
+		}
+		if deleted {
+			return nil, snapshot, false, nil
+		}
+		return cloneClaudeThinkingReplayContents(contents), snapshot, len(contents) > 0, nil
+	}
+
+	cacheCleanupOnce.Do(startCacheCleanup)
+	now := time.Now()
+	claudeThinkingReplayMu.Lock()
+	defer claudeThinkingReplayMu.Unlock()
+	entry, ok := claudeThinkingReplayEntries[key]
+	if !ok || now.Sub(entry.Timestamp) > ClaudeThinkingReplayCacheTTL {
+		if ok {
+			claudeThinkingReplayTotalBytes -= claudeThinkingReplayEntryBytes(entry.Contents)
+			delete(claudeThinkingReplayEntries, key)
+		}
+		return nil, ClaudeThinkingReplaySnapshot{loaded: true, found: false}, false, nil
+	}
+	entry.Timestamp = now
+	claudeThinkingReplayEntries[key] = entry
+	snapshot := ClaudeThinkingReplaySnapshot{generation: entry.Generation, loaded: true, found: true}
+	if entry.Deleted {
+		return nil, snapshot, false, nil
+	}
+	return cloneClaudeThinkingReplayContents(entry.Contents), snapshot, len(entry.Contents) > 0, nil
 }
 
 // GetClaudeThinkingReplayWithSnapshotRequired retrieves replay content and the exact cache state read.
@@ -178,9 +296,14 @@ func ReplaceClaudeThinkingReplayIfUnchanged(ctx context.Context, modelFamily, se
 		if errClient != nil {
 			return false, errClient
 		}
-		contents, _, deleted, okDecode := decodeClaudeThinkingReplayHomeValue(snapshot.raw)
-		if !okDecode {
-			return false, fmt.Errorf("invalid Claude thinking replay snapshot")
+		var contents [][]byte
+		var deleted bool
+		if snapshot.found {
+			var okDecode bool
+			contents, _, deleted, okDecode = decodeClaudeThinkingReplayHomeValue(snapshot.raw)
+			if !okDecode {
+				return false, fmt.Errorf("invalid Claude thinking replay snapshot")
+			}
 		}
 		if deleted {
 			contents = nil
@@ -230,6 +353,10 @@ func DeleteClaudeThinkingReplayIfUnchanged(ctx context.Context, modelFamily, ses
 		if errClient != nil {
 			return false, errClient
 		}
+		if !snapshot.found {
+			// The key was already absent when we read it; nothing to delete.
+			return true, nil
+		}
 		tombstone, errMarshal := marshalClaudeThinkingReplayHomeValue(generation, true, nil)
 		if errMarshal != nil {
 			return false, errMarshal
@@ -274,12 +401,612 @@ func DeleteClaudeThinkingReplayRequired(ctx context.Context, modelFamily, sessio
 	return nil
 }
 
-// ClearClaudeThinkingReplayCache clears only Claude replay state.
+// ClearClaudeThinkingReplayCache clears only Claude replay state and its
+// message-to-scope aliases.
 func ClearClaudeThinkingReplayCache() {
 	claudeThinkingReplayMu.Lock()
 	claudeThinkingReplayEntries = make(map[string]claudeThinkingReplayEntry)
 	claudeThinkingReplayTotalBytes = 0
 	claudeThinkingReplayMu.Unlock()
+
+	claudeThinkingReplayAliasMu.Lock()
+	claudeThinkingReplayAliases = make(map[string][]claudeThinkingReplayAliasEntry)
+	claudeThinkingReplayAliasBytes = 0
+	claudeThinkingReplayAliasCount = 0
+	claudeThinkingReplayLastAliasPurge = time.Time{}
+	claudeThinkingReplayAliasMu.Unlock()
+}
+
+// RegisterClaudeThinkingReplayAlias records that a request message belongs to a
+// conversation scope. Two different conversations can share the same visible
+// message, so the alias is a list of (session, timestamp) pairs rather than a
+// single mapping. In Home KV mode the alias is stored as a separate KV entry
+// with a per-credential index that enforces a cap and evicts oldest aliases.
+func RegisterClaudeThinkingReplayAlias(ctx context.Context, modelFamily, sessionKey, messageHash, firstUserHash string) {
+	if modelFamily == "" || sessionKey == "" || messageHash == "" {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	client, homeMode, errClient := currentClaudeThinkingReplayKVClient()
+	if homeMode {
+		if errClient != nil {
+			return
+		}
+		registerClaudeThinkingReplayAliasHome(ctx, client, modelFamily, sessionKey, messageHash, firstUserHash)
+		return
+	}
+
+	key := claudeThinkingReplayAliasKey(modelFamily, messageHash)
+	claudeThinkingReplayAliasMu.Lock()
+	defer claudeThinkingReplayAliasMu.Unlock()
+	now := time.Now()
+	if now.Sub(claudeThinkingReplayLastAliasPurge) >= claudeThinkingReplayAliasPurgeInterval {
+		purgeExpiredClaudeThinkingReplayAliasesLocked(now)
+		claudeThinkingReplayLastAliasPurge = now
+	}
+	claudeThinkingReplayUpsertAliasLocked(key, sessionKey, firstUserHash, now)
+	enforceClaudeThinkingReplayAliasLimitsLocked()
+}
+
+// ResolveClaudeThinkingReplaySessionKey looks for an existing conversation scope
+// that the request messages belong to. It scores each candidate session by the
+// weighted count of request messages that point to it and breaks ties by
+// recency, so shared messages do not resolve the wrong conversation when
+// multiple messages remain after compaction.
+func ResolveClaudeThinkingReplaySessionKey(ctx context.Context, modelFamily string, messages []ClaudeThinkingReplayAliasMessage, requestFirstUserHash string) (string, bool) {
+	if modelFamily == "" || len(messages) == 0 {
+		return "", false
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	client, homeMode, errClient := currentClaudeThinkingReplayKVClient()
+	if homeMode {
+		if errClient != nil {
+			return "", false
+		}
+		return resolveClaudeThinkingReplayAliasHome(ctx, client, modelFamily, messages, requestFirstUserHash)
+	}
+
+	claudeThinkingReplayAliasMu.RLock()
+	defer claudeThinkingReplayAliasMu.RUnlock()
+	return claudeThinkingReplayResolveBestAliasLocked(modelFamily, messages, requestFirstUserHash, time.Now())
+}
+
+func claudeThinkingReplayAliasKey(modelFamily, messageHash string) string {
+	return strings.Join([]string{modelFamily, messageHash}, "\x00")
+}
+
+func claudeThinkingReplayAliasKVKey(modelFamily, messageHash string) string {
+	return "cpa:claude:thinking-replay-alias:" + homekv.HashKeyPart(strings.TrimSpace(modelFamily)) + ":" + homekv.HashKeyPart(strings.TrimSpace(messageHash))
+}
+
+// claudeThinkingReplayCredentialHash extracts the stable credential hash embedded
+// in a modelFamily string ("claude:<hash>:<baseModel>"). The alias index is keyed
+// by credential so the per-credential cap applies across all model names a caller
+// may use.
+func claudeThinkingReplayCredentialHash(modelFamily string) string {
+	const prefix = "claude:"
+	if !strings.HasPrefix(modelFamily, prefix) {
+		return modelFamily
+	}
+	rest := modelFamily[len(prefix):]
+	if i := strings.IndexByte(rest, ':'); i > 0 {
+		return rest[:i]
+	}
+	return modelFamily
+}
+
+func claudeThinkingReplayAliasIndexKVKey(modelFamily string) string {
+	credentialHash := claudeThinkingReplayCredentialHash(modelFamily)
+	return "cpa:claude:thinking-replay-alias-index:" + homekv.HashKeyPart(strings.TrimSpace(credentialHash))
+}
+
+func claudeThinkingReplayUpsertAliasLocked(key, sessionKey, firstUserHash string, now time.Time) {
+	list := claudeThinkingReplayAliases[key]
+	for i := range list {
+		if list[i].sessionKey == sessionKey {
+			claudeThinkingReplayAliasBytes -= len(list[i].sessionKey) + len(list[i].firstUserHash)
+			list[i].timestamp = now
+			list[i].firstUserHash = firstUserHash
+			claudeThinkingReplayAliasBytes += len(sessionKey) + len(firstUserHash)
+			claudeThinkingReplayAliases[key] = list
+			return
+		}
+	}
+	list = append(list, claudeThinkingReplayAliasEntry{sessionKey: sessionKey, firstUserHash: firstUserHash, timestamp: now})
+	if len(list) == 1 {
+		claudeThinkingReplayAliasBytes += len(key)
+	}
+	claudeThinkingReplayAliasCount++
+	claudeThinkingReplayAliasBytes += len(sessionKey) + len(firstUserHash)
+	if len(list) > ClaudeThinkingReplayCacheMaxAliasesPerKey {
+		oldest := 0
+		for i := 1; i < len(list); i++ {
+			if list[i].timestamp.Before(list[oldest].timestamp) {
+				oldest = i
+			}
+		}
+		claudeThinkingReplayAliasBytes -= len(list[oldest].sessionKey) + len(list[oldest].firstUserHash)
+		list = append(list[:oldest], list[oldest+1:]...)
+		claudeThinkingReplayAliasCount--
+	}
+	claudeThinkingReplayAliases[key] = list
+}
+
+func claudeThinkingReplayResolveBestAliasLocked(modelFamily string, messages []ClaudeThinkingReplayAliasMessage, requestFirstUserHash string, now time.Time) (string, bool) {
+	const firstUserMatchBonus = 2
+	scores := make(map[string]int)
+	for _, m := range messages {
+		key := claudeThinkingReplayAliasKey(modelFamily, m.Hash)
+		list, ok := claudeThinkingReplayAliases[key]
+		if !ok {
+			continue
+		}
+		for _, entry := range list {
+			if now.Sub(entry.timestamp) > ClaudeThinkingReplayCacheTTL {
+				continue
+			}
+			scores[entry.sessionKey] += m.Weight
+			if requestFirstUserHash != "" && entry.firstUserHash == requestFirstUserHash {
+				scores[entry.sessionKey] += firstUserMatchBonus
+			}
+		}
+	}
+	return claudeThinkingReplayResolveBestAlias(scores)
+}
+
+// claudeThinkingReplayResolveBestAlias returns the session with the highest
+// score. If multiple sessions tie for the highest score the result is
+// ambiguous, so it returns no match rather than risk restoring the wrong
+// conversation.
+func claudeThinkingReplayResolveBestAlias(scores map[string]int) (string, bool) {
+	if len(scores) == 0 {
+		return "", false
+	}
+	maxScore := 0
+	for _, s := range scores {
+		if s > maxScore {
+			maxScore = s
+		}
+	}
+	if maxScore <= 0 {
+		return "", false
+	}
+	best := ""
+	tied := 0
+	for session, s := range scores {
+		if s == maxScore {
+			best = session
+			tied++
+		}
+	}
+	if tied > 1 {
+		return "", false
+	}
+	return best, true
+}
+
+func purgeExpiredClaudeThinkingReplayAliasesLocked(now time.Time) {
+	for key, list := range claudeThinkingReplayAliases {
+		kept := list[:0]
+		for _, entry := range list {
+			if now.Sub(entry.timestamp) <= ClaudeThinkingReplayCacheTTL {
+				kept = append(kept, entry)
+			} else {
+				claudeThinkingReplayAliasBytes -= len(entry.sessionKey) + len(entry.firstUserHash)
+				claudeThinkingReplayAliasCount--
+			}
+		}
+		if len(kept) == 0 {
+			claudeThinkingReplayAliasBytes -= len(key)
+			delete(claudeThinkingReplayAliases, key)
+		} else {
+			claudeThinkingReplayAliases[key] = kept
+		}
+	}
+}
+
+func enforceClaudeThinkingReplayAliasLimitsLocked() {
+	for claudeThinkingReplayAliasCount > ClaudeThinkingReplayCacheMaxAliases || claudeThinkingReplayAliasBytes > ClaudeThinkingReplayCacheMaxAliasBytes {
+		type candidate struct {
+			key           string
+			sessionKey    string
+			firstUserHash string
+			timestamp     time.Time
+		}
+		var candidates []candidate
+		for key, list := range claudeThinkingReplayAliases {
+			for _, entry := range list {
+				candidates = append(candidates, candidate{key: key, sessionKey: entry.sessionKey, firstUserHash: entry.firstUserHash, timestamp: entry.timestamp})
+			}
+		}
+		if len(candidates) == 0 {
+			break
+		}
+		sort.Slice(candidates, func(i, j int) bool {
+			return candidates[i].timestamp.Before(candidates[j].timestamp)
+		})
+		batch := ClaudeThinkingReplayCacheEvictBatchSize
+		if batch > len(candidates) {
+			batch = len(candidates)
+		}
+		for i := 0; i < batch; i++ {
+			c := candidates[i]
+			list := claudeThinkingReplayAliases[c.key]
+			found := -1
+			for j, e := range list {
+				if e.sessionKey == c.sessionKey {
+					found = j
+					break
+				}
+			}
+			if found < 0 {
+				continue
+			}
+			claudeThinkingReplayAliasBytes -= len(list[found].sessionKey) + len(list[found].firstUserHash)
+			list = append(list[:found], list[found+1:]...)
+			if len(list) == 0 {
+				claudeThinkingReplayAliasBytes -= len(c.key)
+				delete(claudeThinkingReplayAliases, c.key)
+			} else {
+				claudeThinkingReplayAliases[c.key] = list
+			}
+			claudeThinkingReplayAliasCount--
+		}
+	}
+}
+
+// claudeThinkingReplayAliasIndexRecord and claudeThinkingReplayAliasIndex are
+// used to cap Home KV aliases per credential. The index lists all alias keys
+// created by that credential so the oldest can be evicted.
+type claudeThinkingReplayAliasIndexRecord struct {
+	AliasKey  string    `json:"alias_key"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+type claudeThinkingReplayAliasIndex struct {
+	Aliases []claudeThinkingReplayAliasIndexRecord `json:"aliases"`
+}
+
+type claudeThinkingReplayAliasHomeValue struct {
+	Sessions []claudeThinkingReplayAliasHomeSession `json:"sessions"`
+}
+
+type claudeThinkingReplayAliasHomeSession struct {
+	SessionKey    string    `json:"session_key"`
+	FirstUserHash string    `json:"first_user_hash"`
+	Timestamp     time.Time `json:"timestamp"`
+}
+
+func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThinkingReplayKVClient, modelFamily, sessionKey, messageHash, firstUserHash string) {
+	aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHash)
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+	now := time.Now()
+
+	// Update the shared alias value atomically with compare-and-swap retries.
+	// Multiple sessionless conversations can register the same message hash
+	// concurrently, so an unconditional KVSet would let the last writer discard
+	// the others.
+	var committedAliasRaw []byte
+	var previousAliasRaw []byte
+	for attempt := 0; attempt < 4; attempt++ {
+		var value claudeThinkingReplayAliasHomeValue
+		raw, found, errGet := client.KVGet(ctx, aliasKey)
+		if errGet != nil {
+			log.Warnf("claude thinking replay alias read failed: %v", errGet)
+			return
+		}
+		if found {
+			previousAliasRaw = append([]byte(nil), raw...)
+		} else {
+			previousAliasRaw = nil
+		}
+		if found {
+			if err := json.Unmarshal(raw, &value); err != nil {
+				log.Warnf("claude thinking replay alias unmarshal failed: %v", err)
+				value = claudeThinkingReplayAliasHomeValue{}
+			}
+		}
+		value.Sessions = claudeThinkingReplayAliasHomeValueUpsert(value.Sessions, sessionKey, firstUserHash, now)
+		if len(value.Sessions) > ClaudeThinkingReplayCacheMaxAliasesPerKey {
+			sort.Slice(value.Sessions, func(i, j int) bool {
+				return value.Sessions[i].Timestamp.Before(value.Sessions[j].Timestamp)
+			})
+			value.Sessions = value.Sessions[len(value.Sessions)-ClaudeThinkingReplayCacheMaxAliasesPerKey:]
+		}
+		newRaw, errMarshal := json.Marshal(value)
+		if errMarshal != nil {
+			log.Warnf("claude thinking replay alias marshal failed: %v", errMarshal)
+			return
+		}
+		swapped, errSwap := client.KVCompareAndSwap(ctx, aliasKey, raw, found, newRaw, ClaudeThinkingReplayCacheTTL)
+		if errSwap != nil {
+			log.Warnf("claude thinking replay alias cas failed: %v", errSwap)
+			// The command may have been applied before the error was returned.
+			// Roll back if the alias value still matches the attempted raw.
+			rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, newRaw, previousAliasRaw, now)
+			return
+		}
+		if swapped {
+			committedAliasRaw = newRaw
+			break
+		}
+		if attempt == 3 {
+			log.Warnf("claude thinking replay alias cas exhausted after %d attempts", attempt+1)
+			return
+		}
+	}
+
+	// Maintain the per-credential index so old aliases can be evicted.
+	var evicted []claudeThinkingReplayAliasIndexRecord
+	indexUpdated := false
+	for attempt := 0; attempt < 4; attempt++ {
+		indexRaw, indexFound, errIndex := client.KVGet(ctx, indexKey)
+		if errIndex != nil {
+			log.Warnf("claude thinking replay alias index read failed: %v", errIndex)
+			rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, committedAliasRaw, previousAliasRaw, now)
+			return
+		}
+		index, ok := decodeClaudeThinkingReplayAliasIndex(indexRaw)
+		if !ok {
+			index = claudeThinkingReplayAliasIndex{}
+		}
+		index.Aliases = purgeExpiredClaudeThinkingReplayAliasIndex(index.Aliases, now)
+		index.Aliases = claudeThinkingReplayAliasIndexUpsert(index.Aliases, aliasKey, now)
+		evicted = evicted[:0]
+		if len(index.Aliases) > ClaudeThinkingReplayCacheMaxAliasesPerCredential {
+			sort.Slice(index.Aliases, func(i, j int) bool {
+				return index.Aliases[i].Timestamp.Before(index.Aliases[j].Timestamp)
+			})
+			for len(index.Aliases) > ClaudeThinkingReplayCacheMaxAliasesPerCredential {
+				evicted = append(evicted, index.Aliases[0])
+				index.Aliases = index.Aliases[1:]
+			}
+		}
+		indexBytes, errMarshal := json.Marshal(index)
+		if errMarshal != nil {
+			log.Warnf("claude thinking replay alias index marshal failed: %v", errMarshal)
+			rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, committedAliasRaw, previousAliasRaw, now)
+			return
+		}
+		swapped, errSwap := client.KVCompareAndSwap(ctx, indexKey, indexRaw, indexFound, indexBytes, ClaudeThinkingReplayCacheTTL)
+		if errSwap != nil {
+			log.Warnf("claude thinking replay alias index cas failed: %v", errSwap)
+			rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, committedAliasRaw, previousAliasRaw, now)
+			return
+		}
+		if swapped {
+			indexUpdated = true
+			break
+		}
+		if attempt == 3 {
+			log.Warnf("claude thinking replay alias index cas exhausted after %d attempts", attempt+1)
+			rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, committedAliasRaw, previousAliasRaw, now)
+			return
+		}
+	}
+
+	if !indexUpdated {
+		// Defensive: should have rolled back above, but ensure no half-registered state.
+		rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, committedAliasRaw, previousAliasRaw, now)
+		return
+	}
+
+	// Only delete evicted alias values after the index CAS succeeds and both the
+	// index and the alias value itself have been rechecked. A concurrent worker may
+	// have re-registered an evicted alias after our CAS; if the value has a session
+	// newer than the evicted index record we must not delete it.
+	currentIndexRaw, _, errCurrentIndex := client.KVGet(ctx, indexKey)
+	if errCurrentIndex != nil {
+		log.Warnf("claude thinking replay alias index re-read failed: %v", errCurrentIndex)
+		return
+	}
+	currentIndex, _ := decodeClaudeThinkingReplayAliasIndex(currentIndexRaw)
+	present := make(map[string]struct{}, len(currentIndex.Aliases))
+	for _, a := range currentIndex.Aliases {
+		present[a.AliasKey] = struct{}{}
+	}
+	for _, rec := range evicted {
+		if _, ok := present[rec.AliasKey]; ok {
+			continue
+		}
+		raw, found, errAlias := client.KVGet(ctx, rec.AliasKey)
+		if errAlias != nil || !found {
+			continue
+		}
+		if claudeThinkingReplayAliasValueRepopulated(raw, rec.Timestamp) {
+			continue
+		}
+		// Atomically replace the evicted alias value with a short-lived tombstone
+		// so a concurrent re-registration after the KVGet cannot be deleted, but
+		// the tombstone still expires promptly and does not block later reuse.
+		tombstone, errMarshal := json.Marshal(claudeThinkingReplayAliasHomeValue{})
+		if errMarshal != nil {
+			log.Warnf("claude thinking replay alias eviction tombstone marshal failed: %v", errMarshal)
+			continue
+		}
+		swapped, errCAS := client.KVCompareAndSwap(ctx, rec.AliasKey, raw, true, tombstone, claudeThinkingReplayAliasTombstoneTTL)
+		if errCAS != nil {
+			if errors.Is(errCAS, homekv.ErrCompareAndSwapUnsupported) {
+				if _, errDel := client.KVDel(ctx, rec.AliasKey); errDel != nil {
+					log.Warnf("claude thinking replay alias eviction failed: %v", errDel)
+				}
+				continue
+			}
+			log.Warnf("claude thinking replay alias eviction cas failed: %v", errCAS)
+			continue
+		}
+		if !swapped {
+			// The value changed; leave it for the next index update.
+			continue
+		}
+	}
+}
+
+// rollBackClaudeThinkingReplayAliasHome rolls an alias value back to the
+// previous value that existed before an unindexed commit. If there was no
+// previous value, it leaves an empty tombstone so the alias resolves to nothing
+// rather than a stale unindexed orphan. The rollback is conditional on the
+// committed value: if the alias still contains the exact bytes we wrote, it is
+// an orphan and should be removed. The index is consulted only as a best-effort
+// guard when it is readable; a failing index read does not prevent rollback
+// because the failed registration is precisely what produced the orphan.
+func rollBackClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThinkingReplayKVClient, aliasKey, indexKey string, committedAliasRaw, previousAliasRaw []byte, now time.Time) {
+	if len(committedAliasRaw) == 0 {
+		return
+	}
+	currentRaw, found, errCurrent := client.KVGet(ctx, aliasKey)
+	if errCurrent != nil || !found {
+		return
+	}
+	if !bytes.Equal(currentRaw, committedAliasRaw) {
+		return
+	}
+
+	// If we can confirm the alias is live in the index, another worker must
+	// have made it durable; leave it alone. The record must be from this
+	// registration (timestamp >= now); an older record means the index does not
+	// reflect the committed value and the alias will expire uncapped.
+	indexRaw, _, errIndex := client.KVGet(ctx, indexKey)
+	if errIndex == nil {
+		if index, ok := decodeClaudeThinkingReplayAliasIndex(indexRaw); ok {
+			for _, a := range index.Aliases {
+				if a.AliasKey == aliasKey {
+					if !a.Timestamp.Before(now) {
+						return
+					}
+					// Stale index record: keep rolling back.
+					break
+				}
+			}
+		}
+	} else {
+		log.Warnf("claude thinking replay alias rollback index check failed: %v", errIndex)
+	}
+
+	// Roll the alias value back to the previous value if there was one;
+	// otherwise leave an empty tombstone so the alias resolves to nothing
+	// rather than a stale unindexed orphan. The CAS is conditional on the
+	// current value still matching the committed value, so a concurrent
+	// re-registration cannot be overwritten.
+	var replacement []byte
+	ttl := claudeThinkingReplayAliasTombstoneTTL
+	if len(previousAliasRaw) > 0 {
+		replacement = append([]byte(nil), previousAliasRaw...)
+		ttl = ClaudeThinkingReplayCacheTTL
+	} else {
+		tombstone, errMarshal := json.Marshal(claudeThinkingReplayAliasHomeValue{})
+		if errMarshal != nil {
+			log.Warnf("claude thinking replay alias rollback tombstone marshal failed: %v", errMarshal)
+			return
+		}
+		replacement = tombstone
+	}
+	swapped, errCAS := client.KVCompareAndSwap(ctx, aliasKey, currentRaw, true, replacement, ttl)
+	if errCAS != nil {
+		if errors.Is(errCAS, homekv.ErrCompareAndSwapUnsupported) {
+			// CAS is unavailable; fall back to unconditional delete.
+			if _, errDel := client.KVDel(ctx, aliasKey); errDel != nil {
+				log.Warnf("claude thinking replay alias rollback failed: %v", errDel)
+			}
+			return
+		}
+		log.Warnf("claude thinking replay alias rollback CAS failed: %v", errCAS)
+		return
+	}
+	if !swapped {
+		// The value changed between KVGet and CAS; do not touch it.
+		return
+	}
+}
+
+func resolveClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThinkingReplayKVClient, modelFamily string, messages []ClaudeThinkingReplayAliasMessage, requestFirstUserHash string) (string, bool) {
+	const firstUserMatchBonus = 2
+	scores := make(map[string]int)
+	now := time.Now()
+	for _, m := range messages {
+		raw, found, err := client.KVGet(ctx, claudeThinkingReplayAliasKVKey(modelFamily, m.Hash))
+		if err != nil || !found {
+			continue
+		}
+		var value claudeThinkingReplayAliasHomeValue
+		if err := json.Unmarshal(raw, &value); err != nil {
+			continue
+		}
+		for _, s := range value.Sessions {
+			if now.Sub(s.Timestamp) > ClaudeThinkingReplayCacheTTL {
+				continue
+			}
+			scores[s.SessionKey] += m.Weight
+			if requestFirstUserHash != "" && s.FirstUserHash == requestFirstUserHash {
+				scores[s.SessionKey] += firstUserMatchBonus
+			}
+		}
+	}
+	return claudeThinkingReplayResolveBestAlias(scores)
+}
+
+func decodeClaudeThinkingReplayAliasIndex(raw []byte) (claudeThinkingReplayAliasIndex, bool) {
+	if len(raw) == 0 {
+		return claudeThinkingReplayAliasIndex{}, true
+	}
+	var index claudeThinkingReplayAliasIndex
+	if err := json.Unmarshal(raw, &index); err != nil {
+		return claudeThinkingReplayAliasIndex{}, false
+	}
+	return index, true
+}
+
+func purgeExpiredClaudeThinkingReplayAliasIndex(records []claudeThinkingReplayAliasIndexRecord, now time.Time) []claudeThinkingReplayAliasIndexRecord {
+	kept := records[:0]
+	for _, r := range records {
+		if now.Sub(r.Timestamp) <= ClaudeThinkingReplayCacheTTL {
+			kept = append(kept, r)
+		}
+	}
+	return kept
+}
+
+func claudeThinkingReplayAliasIndexUpsert(records []claudeThinkingReplayAliasIndexRecord, aliasKey string, now time.Time) []claudeThinkingReplayAliasIndexRecord {
+	for i := range records {
+		if records[i].AliasKey == aliasKey {
+			records[i].Timestamp = now
+			return records
+		}
+	}
+	return append(records, claudeThinkingReplayAliasIndexRecord{AliasKey: aliasKey, Timestamp: now})
+}
+
+// claudeThinkingReplayAliasValueRepopulated reports whether an alias value has
+// been refreshed by a concurrent worker after the index record for that alias
+// was evicted. We compare the session timestamps in the value against the
+// evicted index record timestamp; a session newer than the evicted record means
+// a re-registration happened and the alias value must not be deleted.
+func claudeThinkingReplayAliasValueRepopulated(raw []byte, evictedTimestamp time.Time) bool {
+	var value claudeThinkingReplayAliasHomeValue
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return false
+	}
+	for _, s := range value.Sessions {
+		if s.Timestamp.After(evictedTimestamp) {
+			return true
+		}
+	}
+	return false
+}
+
+func claudeThinkingReplayAliasHomeValueUpsert(sessions []claudeThinkingReplayAliasHomeSession, sessionKey, firstUserHash string, now time.Time) []claudeThinkingReplayAliasHomeSession {
+	for i := range sessions {
+		if sessions[i].SessionKey == sessionKey {
+			sessions[i].Timestamp = now
+			sessions[i].FirstUserHash = firstUserHash
+			return sessions
+		}
+	}
+	return append(sessions, claudeThinkingReplayAliasHomeSession{SessionKey: sessionKey, FirstUserHash: firstUserHash, Timestamp: now})
 }
 
 func readOrReserveClaudeThinkingReplayHomeValue(ctx context.Context, client kimiThinkingReplayKVClient, key string) ([]byte, error) {
@@ -479,4 +1206,8 @@ func purgeExpiredClaudeThinkingReplayCache(now time.Time) {
 		}
 	}
 	claudeThinkingReplayMu.Unlock()
+
+	claudeThinkingReplayAliasMu.Lock()
+	purgeExpiredClaudeThinkingReplayAliasesLocked(now)
+	claudeThinkingReplayAliasMu.Unlock()
 }

--- a/internal/cache/claude_thinking_replay_cache_test.go
+++ b/internal/cache/claude_thinking_replay_cache_test.go
@@ -3,87 +3,1167 @@ package cache
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
 	"testing"
+	"time"
+
+	homekv "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 )
 
-func useFakeClaudeThinkingReplayKVClient(t *testing.T, client *fakeKimiThinkingReplayKVClient) {
+type fakeClaudeThinkingReplayKVClient struct {
+	values    map[string][]byte
+	sets      int
+	dels      int
+	getErr    error
+	setErr    error
+	delErr    error
+	swapErr   error
+	swapsTTLs map[string]time.Duration
+}
+
+func newFakeClaudeThinkingReplayKVClient() *fakeClaudeThinkingReplayKVClient {
+	return &fakeClaudeThinkingReplayKVClient{
+		values:    make(map[string][]byte),
+		swapsTTLs: make(map[string]time.Duration),
+	}
+}
+
+func (c *fakeClaudeThinkingReplayKVClient) KVGet(_ context.Context, key string) ([]byte, bool, error) {
+	if c.getErr != nil {
+		return nil, false, c.getErr
+	}
+	v, ok := c.values[key]
+	return append([]byte(nil), v...), ok, nil
+}
+
+func (c *fakeClaudeThinkingReplayKVClient) KVSet(_ context.Context, key string, value []byte, _ homekv.KVSetOptions) (bool, error) {
+	if c.setErr != nil {
+		return false, c.setErr
+	}
+	c.values[key] = append([]byte(nil), value...)
+	c.sets++
+	return true, nil
+}
+
+func (c *fakeClaudeThinkingReplayKVClient) KVDel(_ context.Context, keys ...string) (int64, error) {
+	if c.delErr != nil {
+		return 0, c.delErr
+	}
+	var n int64
+	for _, k := range keys {
+		if _, ok := c.values[k]; ok {
+			delete(c.values, k)
+			n++
+		}
+	}
+	c.dels += int(n)
+	return n, nil
+}
+
+func (c *fakeClaudeThinkingReplayKVClient) KVCompareAndSwap(_ context.Context, key string, expected []byte, _ bool, newValue []byte, ttl time.Duration) (bool, error) {
+	if c.swapErr != nil {
+		return false, c.swapErr
+	}
+	current, ok := c.values[key]
+	if !ok && expected == nil {
+		c.values[key] = append([]byte(nil), newValue...)
+		c.sets++
+		c.swapsTTLs[key] = ttl
+		return true, nil
+	}
+	if ok && string(current) == string(expected) {
+		c.values[key] = append([]byte(nil), newValue...)
+		c.sets++
+		c.swapsTTLs[key] = ttl
+		return true, nil
+	}
+	return false, nil
+}
+
+func (c *fakeClaudeThinkingReplayKVClient) KVExpire(context.Context, string, time.Duration) (bool, error) {
+	return true, nil
+}
+
+func useFakeClaudeThinkingReplayKVClient(t *testing.T, client kimiThinkingReplayKVClient, homeMode bool) {
 	t.Helper()
-	previous := currentClaudeThinkingReplayKVClient
+	prev := currentClaudeThinkingReplayKVClient
 	currentClaudeThinkingReplayKVClient = func() (kimiThinkingReplayKVClient, bool, error) {
-		return client, true, nil
+		return client, homeMode, nil
 	}
 	t.Cleanup(func() {
-		currentClaudeThinkingReplayKVClient = previous
+		currentClaudeThinkingReplayKVClient = prev
+		ClearClaudeThinkingReplayCache()
 	})
 }
 
-func TestClaudeThinkingReplayAppendsAssistantTurns(t *testing.T) {
-	client := newFakeKimiThinkingReplayKVClient()
-	useFakeClaudeThinkingReplayKVClient(t, client)
+func TestResolveClaudeThinkingReplayAliasScoresByWeightAndFirstUser(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+
+	firstA := "firstA"
+	firstB := "firstB"
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionA", "msg1", firstA)
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionA", "msg2", firstA)
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionB", "msg1", firstB)
+
+	// A request with first user A and messages [msg1, msg2] should resolve to A.
+	msgs := []ClaudeThinkingReplayAliasMessage{{Hash: "msg1", Weight: 1}, {Hash: "msg2", Weight: 2}}
+	if s, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, firstA); !ok || s != "sessionA" {
+		t.Fatalf("resolve first A: got %q, want sessionA", s)
+	}
+
+	// Same messages with first user B should resolve to B, even though msg2
+	// only belongs to A; msg1 is shared, but the first-user bonus for B tips
+	// the scales.
+	msgs = []ClaudeThinkingReplayAliasMessage{{Hash: "msg1", Weight: 1}}
+	if s, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, firstB); !ok || s != "sessionB" {
+		t.Fatalf("resolve first B: got %q, want sessionB", s)
+	}
+}
+
+func TestResolveClaudeThinkingReplayAliasIgnoresExpiredEntries(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionA", "msg1", "firstA")
+
+	// Expire the alias by advancing time.
+	claudeThinkingReplayAliasMu.Lock()
+	for key, list := range claudeThinkingReplayAliases {
+		for i := range list {
+			list[i].timestamp = time.Now().Add(-2 * ClaudeThinkingReplayCacheTTL)
+		}
+		claudeThinkingReplayAliases[key] = list
+	}
+	claudeThinkingReplayAliasMu.Unlock()
+
+	msgs := []ClaudeThinkingReplayAliasMessage{{Hash: "msg1", Weight: 1}}
+	if _, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, "firstA"); ok {
+		t.Fatal("expected no resolve for expired alias")
+	}
+}
+
+func aliasValueIsLive(raw []byte) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var value claudeThinkingReplayAliasHomeValue
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return true
+	}
+	return len(value.Sessions) > 0
+}
+
+func TestClaudeThinkingReplayAliasHomeCappedPerCredential(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	client := newFakeClaudeThinkingReplayKVClient()
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+
+	// Register more than the per-credential cap and ensure the oldest keys
+	// are evicted from the index.
+	max := ClaudeThinkingReplayCacheMaxAliasesPerCredential
+	for i := 0; i < max+10; i++ {
+		RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHashFor(i), "first")
+	}
+
+	// The number of stored alias values should not exceed the cap.
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+	index, _ := decodeClaudeThinkingReplayAliasIndex(client.values[indexKey])
+	if len(index.Aliases) > max {
+		t.Fatalf("credential alias cap exceeded: %d > %d", len(index.Aliases), max)
+	}
+
+	// The oldest entries should have been deleted or tombstoned.
+	live := 0
+	for k, v := range client.values {
+		if k != indexKey && aliasValueIsLive(v) {
+			live++
+		}
+	}
+	if live > max+1 { // +1 for the index key itself
+		t.Fatalf("too many live alias keys: %d", live)
+	}
+}
+
+func TestClaudeThinkingReplayAliasHomeMultiSessionResolve(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	client := newFakeClaudeThinkingReplayKVClient()
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionA", "msg1", "firstA")
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionA", "msg2", "firstA")
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionB", "msg1", "firstB")
+
+	msgs := []ClaudeThinkingReplayAliasMessage{{Hash: "msg1", Weight: 1}, {Hash: "msg2", Weight: 2}}
+	if s, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, "firstA"); !ok || s != "sessionA" {
+		t.Fatalf("home resolve: got %q, want sessionA", s)
+	}
+}
+
+// raceyClaudeThinkingReplayKVClient is a test client that fails the first
+// KVCompareAndSwap on a specific alias key and injects a new value, simulating
+// a concurrent writer. This verifies that the alias update retries and merges
+// instead of overwriting the injected session.
+type raceyClaudeThinkingReplayKVClient struct {
+	*fakeClaudeThinkingReplayKVClient
+	aliasKey string
+	injected []byte
+	attempts int
+	mu       sync.Mutex
+}
+
+func (c *raceyClaudeThinkingReplayKVClient) KVCompareAndSwap(ctx context.Context, key string, expected []byte, expectedExists bool, newValue []byte, ttl time.Duration) (bool, error) {
+	if key == c.aliasKey {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if c.attempts == 0 {
+			c.attempts++
+			c.values[key] = append([]byte(nil), c.injected...)
+			return false, nil
+		}
+		c.values[key] = append([]byte(nil), newValue...)
+		return true, nil
+	}
+	return c.fakeClaudeThinkingReplayKVClient.KVCompareAndSwap(ctx, key, expected, expectedExists, newValue, ttl)
+}
+
+func TestClaudeThinkingReplayAliasHomeAtomicListUpdates(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, "msg")
+
+	aValue, _ := json.Marshal(claudeThinkingReplayAliasHomeValue{
+		Sessions: []claudeThinkingReplayAliasHomeSession{
+			{SessionKey: "sessionA", FirstUserHash: "firstA", Timestamp: time.Now()},
+		},
+	})
+	abValue, _ := json.Marshal(claudeThinkingReplayAliasHomeValue{
+		Sessions: []claudeThinkingReplayAliasHomeSession{
+			{SessionKey: "sessionA", FirstUserHash: "firstA", Timestamp: time.Now()},
+			{SessionKey: "sessionB", FirstUserHash: "firstB", Timestamp: time.Now()},
+		},
+	})
+
+	base := newFakeClaudeThinkingReplayKVClient()
+	base.values[aliasKey] = aValue
+	client := &raceyClaudeThinkingReplayKVClient{
+		fakeClaudeThinkingReplayKVClient: base,
+		aliasKey:                         aliasKey,
+		injected:                         abValue,
+	}
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	// Register session C. The first CAS sees the initial value A; the racey
+	// client simulates a concurrent writer changing it to A+B and returns
+	// false. The function must retry, read A+B, append C, and CAS successfully.
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionC", "msg", "firstC")
+
+	raw, ok := client.values[aliasKey]
+	if !ok {
+		t.Fatal("alias value not found")
+	}
+	var value claudeThinkingReplayAliasHomeValue
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatalf("unmarshal alias value: %v", err)
+	}
+	got := make(map[string]string)
+	for _, s := range value.Sessions {
+		got[s.SessionKey] = s.FirstUserHash
+	}
+	want := map[string]string{
+		"sessionA": "firstA",
+		"sessionB": "firstB",
+		"sessionC": "firstC",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("alias sessions = %v, want %v", got, want)
+	}
+}
+
+func TestResolveClaudeThinkingReplayAliasRejectsTies(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionA", "msg", "firstA")
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionB", "msg", "firstB")
+
+	// Without a first-user bonus the two sessions are tied; refuse the match.
+	msgs := []ClaudeThinkingReplayAliasMessage{{Hash: "msg", Weight: 1}}
+	if _, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, ""); ok {
+		t.Fatal("expected no resolve for ambiguous tie")
+	}
+
+	// With a matching first-user hash one session uniquely wins.
+	if s, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, "firstA"); !ok || s != "sessionA" {
+		t.Fatalf("resolve with first-user bonus: got %q ok=%v, want sessionA", s, ok)
+	}
+}
+
+func TestResolveClaudeThinkingReplayAliasHomeRejectsTies(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	client := newFakeClaudeThinkingReplayKVClient()
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionA", "msg", "firstA")
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionB", "msg", "firstB")
+
+	msgs := []ClaudeThinkingReplayAliasMessage{{Hash: "msg", Weight: 1}}
+	if _, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, ""); ok {
+		t.Fatal("expected no resolve for home ambiguous tie")
+	}
+
+	if s, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, "firstA"); !ok || s != "sessionA" {
+		t.Fatalf("home resolve with first-user bonus: got %q ok=%v, want sessionA", s, ok)
+	}
+}
+
+func TestClaudeThinkingReplayAliasHomeCappedAcrossModelsPerCredential(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	client := newFakeClaudeThinkingReplayKVClient()
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	ctx := context.Background()
+	const credentialHash = "deadbeef"
+	modelA := "claude:" + credentialHash + ":modelA"
+	modelB := "claude:" + credentialHash + ":modelB"
+
+	// Both model families should map to the same credential-scoped index.
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelA)
+	if indexKey != claudeThinkingReplayAliasIndexKVKey(modelB) {
+		t.Fatalf("index key not shared across models for same credential: %q vs %q", indexKey, claudeThinkingReplayAliasIndexKVKey(modelB))
+	}
+
+	max := ClaudeThinkingReplayCacheMaxAliasesPerCredential
+	for i := 0; i < max+10; i++ {
+		mf := modelA
+		if i%2 == 1 {
+			mf = modelB
+		}
+		RegisterClaudeThinkingReplayAlias(ctx, mf, "session", messageHashFor(i), "first")
+	}
+
+	index, _ := decodeClaudeThinkingReplayAliasIndex(client.values[indexKey])
+	if len(index.Aliases) > max {
+		t.Fatalf("credential alias cap exceeded across models: %d > %d", len(index.Aliases), max)
+	}
+
+	live := 0
+	for k, v := range client.values {
+		if k != indexKey && aliasValueIsLive(v) {
+			live++
+		}
+	}
+	if live > max+1 {
+		t.Fatalf("too many live alias keys across models: %d", live)
+	}
+}
+
+// failingIndexClaudeThinkingReplayKVClient fails every KVCompareAndSwap on the
+// index key, simulating a stale read that makes the index CAS lose. It verifies
+// that evicted alias values are NOT deleted before a successful index CAS.
+type failingIndexClaudeThinkingReplayKVClient struct {
+	*fakeClaudeThinkingReplayKVClient
+	indexKey string
+	mu       sync.Mutex
+}
+
+func (c *failingIndexClaudeThinkingReplayKVClient) KVCompareAndSwap(ctx context.Context, key string, expected []byte, expectedExists bool, newValue []byte, ttl time.Duration) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if key == c.indexKey {
+		return false, nil
+	}
+	return c.fakeClaudeThinkingReplayKVClient.KVCompareAndSwap(ctx, key, expected, expectedExists, newValue, ttl)
+}
+
+func TestClaudeThinkingReplayAliasHomeEvictionIsAtomicWithIndexCAS(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+
+	base := newFakeClaudeThinkingReplayKVClient()
+	client := &failingIndexClaudeThinkingReplayKVClient{
+		fakeClaudeThinkingReplayKVClient: base,
+		indexKey:                         indexKey,
+	}
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	// Pre-populate the index to the cap and create the matching alias values.
+	max := ClaudeThinkingReplayCacheMaxAliasesPerCredential
+	var index claudeThinkingReplayAliasIndex
+	now := time.Now()
+	for i := 0; i < max; i++ {
+		aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHashFor(i))
+		index.Aliases = append(index.Aliases, claudeThinkingReplayAliasIndexRecord{
+			AliasKey:  aliasKey,
+			Timestamp: now.Add(-time.Duration(max-i) * time.Second),
+		})
+		value, _ := json.Marshal(claudeThinkingReplayAliasHomeValue{
+			Sessions: []claudeThinkingReplayAliasHomeSession{
+				{SessionKey: "session", FirstUserHash: "first", Timestamp: now},
+			},
+		})
+		client.values[aliasKey] = value
+	}
+	indexBytes, _ := json.Marshal(index)
+	client.values[indexKey] = indexBytes
+
+	oldestAliasKey := index.Aliases[0].AliasKey
+
+	// The next registration will try to evict the oldest, but the index CAS is
+	// forced to fail. The evicted alias value must NOT be deleted.
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHashFor(max), "first")
+
+	if _, ok := client.values[oldestAliasKey]; !ok {
+		t.Fatalf("oldest alias %q deleted before successful index CAS", oldestAliasKey)
+	}
+}
+
+func TestClaudeThinkingReplayAliasHomeRollbackOnIndexFailure(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+	messageHash := "new-msg"
+	aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHash)
+
+	base := newFakeClaudeThinkingReplayKVClient()
+	client := &failingIndexClaudeThinkingReplayKVClient{
+		fakeClaudeThinkingReplayKVClient: base,
+		indexKey:                         indexKey,
+	}
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHash, "first")
+
+	raw, ok := client.values[aliasKey]
+	if !ok {
+		t.Fatalf("alias %q was removed; expected a tombstone", aliasKey)
+	}
+	var value claudeThinkingReplayAliasHomeValue
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatalf("tombstone unmarshal: %v", err)
+	}
+	if len(value.Sessions) != 0 {
+		t.Fatalf("alias %q still has %d sessions after rollback", aliasKey, len(value.Sessions))
+	}
+}
+
+// readdEvictedClaudeThinkingReplayKVClient simulates a concurrent worker that
+// re-registers the evicted alias between the successful index CAS and the
+// eviction re-read. The re-read should see the alias back in the index and skip
+// deletion.
+type readdEvictedClaudeThinkingReplayKVClient struct {
+	*fakeClaudeThinkingReplayKVClient
+	indexKey string
+	evicted  string
+	swapped  bool
+}
+
+func (c *readdEvictedClaudeThinkingReplayKVClient) KVGet(ctx context.Context, key string) ([]byte, bool, error) {
+	if key == c.indexKey && c.swapped {
+		idx, ok := decodeClaudeThinkingReplayAliasIndex(c.values[c.indexKey])
+		if !ok {
+			idx = claudeThinkingReplayAliasIndex{}
+		}
+		idx.Aliases = append(idx.Aliases, claudeThinkingReplayAliasIndexRecord{
+			AliasKey:  c.evicted,
+			Timestamp: time.Now(),
+		})
+		raw, _ := json.Marshal(idx)
+		return raw, true, nil
+	}
+	return c.fakeClaudeThinkingReplayKVClient.KVGet(ctx, key)
+}
+
+func (c *readdEvictedClaudeThinkingReplayKVClient) KVCompareAndSwap(ctx context.Context, key string, expected []byte, expectedExists bool, newValue []byte, ttl time.Duration) (bool, error) {
+	swapped, err := c.fakeClaudeThinkingReplayKVClient.KVCompareAndSwap(ctx, key, expected, expectedExists, newValue, ttl)
+	if err == nil && swapped && key == c.indexKey {
+		c.swapped = true
+	}
+	return swapped, err
+}
+
+func TestClaudeThinkingReplayAliasHomeEvictionSkipsReaddedAlias(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+
+	base := newFakeClaudeThinkingReplayKVClient()
+	client := &readdEvictedClaudeThinkingReplayKVClient{
+		fakeClaudeThinkingReplayKVClient: base,
+		indexKey:                         indexKey,
+	}
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	max := ClaudeThinkingReplayCacheMaxAliasesPerCredential
+	now := time.Now()
+	var index claudeThinkingReplayAliasIndex
+	for i := 0; i < max; i++ {
+		aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHashFor(i))
+		index.Aliases = append(index.Aliases, claudeThinkingReplayAliasIndexRecord{
+			AliasKey:  aliasKey,
+			Timestamp: now.Add(-time.Duration(max-i) * time.Second),
+		})
+		value, _ := json.Marshal(claudeThinkingReplayAliasHomeValue{
+			Sessions: []claudeThinkingReplayAliasHomeSession{
+				{SessionKey: "session", FirstUserHash: "first", Timestamp: now},
+			},
+		})
+		client.values[aliasKey] = value
+	}
+	client.evicted = index.Aliases[0].AliasKey
+	indexBytes, _ := json.Marshal(index)
+	client.values[indexKey] = indexBytes
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHashFor(max), "first")
+
+	if _, ok := client.values[client.evicted]; !ok {
+		t.Fatalf("evicted alias %q was deleted while re-added to index", client.evicted)
+	}
+}
+
+func TestClaudeThinkingReplayAliasHomeRechecksEvictedAliasValue(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+
+	client := newFakeClaudeThinkingReplayKVClient()
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	max := ClaudeThinkingReplayCacheMaxAliasesPerCredential
+	now := time.Now()
+	var index claudeThinkingReplayAliasIndex
+	for i := 0; i < max; i++ {
+		aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHashFor(i))
+		index.Aliases = append(index.Aliases, claudeThinkingReplayAliasIndexRecord{
+			AliasKey:  aliasKey,
+			Timestamp: now.Add(-time.Duration(max-i) * time.Second),
+		})
+		value, _ := json.Marshal(claudeThinkingReplayAliasHomeValue{
+			Sessions: []claudeThinkingReplayAliasHomeSession{
+				{SessionKey: "session", FirstUserHash: "first", Timestamp: now},
+			},
+		})
+		client.values[aliasKey] = value
+	}
+	evictedAlias := index.Aliases[0].AliasKey
+	indexBytes, _ := json.Marshal(index)
+	client.values[indexKey] = indexBytes
+
+	// Simulate a concurrent worker refreshing the evicted alias value after the
+	// index record was established but before the eviction pass.
+	refreshed, _ := json.Marshal(claudeThinkingReplayAliasHomeValue{
+		Sessions: []claudeThinkingReplayAliasHomeSession{
+			{SessionKey: "session", FirstUserHash: "first", Timestamp: now.Add(time.Minute)},
+		},
+	})
+	client.values[evictedAlias] = refreshed
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHashFor(max), "first")
+
+	if _, ok := client.values[evictedAlias]; !ok {
+		t.Fatalf("evicted alias %q was deleted despite a repopulated value", evictedAlias)
+	}
+}
+
+// indexGetFailingClaudeThinkingReplayKVClient fails KVGet for the index key.
+// This verifies rollback does not depend on an index read succeeding.
+type indexGetFailingClaudeThinkingReplayKVClient struct {
+	*fakeClaudeThinkingReplayKVClient
+	indexKey string
+}
+
+func (c *indexGetFailingClaudeThinkingReplayKVClient) KVGet(ctx context.Context, key string) ([]byte, bool, error) {
+	if key == c.indexKey {
+		return nil, false, fmt.Errorf("simulated index read failure")
+	}
+	return c.fakeClaudeThinkingReplayKVClient.KVGet(ctx, key)
+}
+
+func TestClaudeThinkingReplayAliasHomeRollbackConditionalOnCommittedValue(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+	messageHash := "new-msg"
+	aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHash)
+
+	base := newFakeClaudeThinkingReplayKVClient()
+	client := &indexGetFailingClaudeThinkingReplayKVClient{
+		fakeClaudeThinkingReplayKVClient: base,
+		indexKey:                         indexKey,
+	}
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHash, "first")
+
+	raw, ok := client.values[aliasKey]
+	if !ok {
+		t.Fatalf("alias %q was removed; expected a tombstone", aliasKey)
+	}
+	var value claudeThinkingReplayAliasHomeValue
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatalf("tombstone unmarshal: %v", err)
+	}
+	if len(value.Sessions) != 0 {
+		t.Fatalf("alias %q still has %d sessions after rollback", aliasKey, len(value.Sessions))
+	}
+}
+
+// erroredAliasCASClaudeThinkingReplayKVClient simulates an alias CAS that
+// returns an error after the value was already applied, leaving a partial
+// registration that must be rolled back.
+type erroredAliasCASClaudeThinkingReplayKVClient struct {
+	*fakeClaudeThinkingReplayKVClient
+	aliasKey string
+	errored  bool
+}
+
+func (c *erroredAliasCASClaudeThinkingReplayKVClient) KVCompareAndSwap(ctx context.Context, key string, expected []byte, expectedExists bool, newValue []byte, ttl time.Duration) (bool, error) {
+	if key == c.aliasKey && !c.errored {
+		c.errored = true
+		c.values[key] = append([]byte(nil), newValue...)
+		return false, fmt.Errorf("simulated alias CAS error")
+	}
+	return c.fakeClaudeThinkingReplayKVClient.KVCompareAndSwap(ctx, key, expected, expectedExists, newValue, ttl)
+}
+
+func TestClaudeThinkingReplayAliasHomeRollBackOnFailedRegistration(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	messageHash := "new-msg"
+	aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHash)
+
+	base := newFakeClaudeThinkingReplayKVClient()
+	client := &erroredAliasCASClaudeThinkingReplayKVClient{
+		fakeClaudeThinkingReplayKVClient: base,
+		aliasKey:                         aliasKey,
+	}
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHash, "first")
+
+	// Rollback writes an empty tombstone so the alias resolves to nothing
+	// rather than a stale unindexed orphan.
+	raw, ok := client.values[aliasKey]
+	if !ok {
+		t.Fatalf("alias %q was removed; expected a tombstone", aliasKey)
+	}
+	var value claudeThinkingReplayAliasHomeValue
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatalf("tombstone unmarshal: %v", err)
+	}
+	if len(value.Sessions) != 0 {
+		t.Fatalf("alias %q still has %d sessions after rollback", aliasKey, len(value.Sessions))
+	}
+}
+
+type concurrentAliasClaudeThinkingReplayKVClient struct {
+	*fakeClaudeThinkingReplayKVClient
+	aliasKey string
+	injected []byte
+}
+
+func (c *concurrentAliasClaudeThinkingReplayKVClient) KVCompareAndSwap(ctx context.Context, key string, expected []byte, expectedExists bool, newValue []byte, ttl time.Duration) (bool, error) {
+	if key == c.aliasKey {
+		c.values[key] = append([]byte(nil), c.injected...)
+	}
+	return c.fakeClaudeThinkingReplayKVClient.KVCompareAndSwap(ctx, key, expected, expectedExists, newValue, ttl)
+}
+
+func TestClaudeThinkingReplayAliasHomeRollBackDoesNotDeleteRepopulatedAlias(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	messageHash := "new-msg"
+	aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHash)
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+
+	committed := claudeThinkingReplayAliasHomeValue{Sessions: []claudeThinkingReplayAliasHomeSession{{SessionKey: "session", FirstUserHash: "first", Timestamp: time.Now()}}}
+	committedRaw, _ := json.Marshal(committed)
+	injected := claudeThinkingReplayAliasHomeValue{Sessions: []claudeThinkingReplayAliasHomeSession{{SessionKey: "other", FirstUserHash: "first", Timestamp: time.Now()}}}
+	injectedRaw, _ := json.Marshal(injected)
+
+	base := newFakeClaudeThinkingReplayKVClient()
+	base.values[aliasKey] = append([]byte(nil), committedRaw...)
+	client := &concurrentAliasClaudeThinkingReplayKVClient{fakeClaudeThinkingReplayKVClient: base, aliasKey: aliasKey, injected: injectedRaw}
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, committedRaw, nil, time.Now())
+
+	if string(client.values[aliasKey]) != string(injectedRaw) {
+		t.Fatalf("repopulated alias was overwritten during rollback")
+	}
+}
+
+func TestClaudeThinkingReplayAliasHomeRollbackRejectsStaleIndexRecord(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	messageHash := "new-msg"
+	aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHash)
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+
+	now := time.Now()
+	committed := claudeThinkingReplayAliasHomeValue{Sessions: []claudeThinkingReplayAliasHomeSession{{SessionKey: "session", FirstUserHash: "first", Timestamp: now}}}
+	committedRaw, _ := json.Marshal(committed)
+
+	client := newFakeClaudeThinkingReplayKVClient()
+	client.values[aliasKey] = append([]byte(nil), committedRaw...)
+	// Index references the alias with an older timestamp, so the value is not
+	// durably indexed for this registration and should be rolled back.
+	index, _ := json.Marshal(claudeThinkingReplayAliasIndex{Aliases: []claudeThinkingReplayAliasIndexRecord{{
+		AliasKey:  aliasKey,
+		Timestamp: now.Add(-time.Minute),
+	}}})
+	client.values[indexKey] = index
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, committedRaw, nil, now)
+
+	if aliasValueIsLive(client.values[aliasKey]) {
+		t.Fatalf("stale index record left alias value live; expected rollback")
+	}
+}
+
+func TestClaudeThinkingReplayAliasHomeRollbackKeepsFreshIndexRecord(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	messageHash := "new-msg"
+	aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHash)
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+
+	now := time.Now()
+	committed := claudeThinkingReplayAliasHomeValue{Sessions: []claudeThinkingReplayAliasHomeSession{{SessionKey: "session", FirstUserHash: "first", Timestamp: now}}}
+	committedRaw, _ := json.Marshal(committed)
+
+	client := newFakeClaudeThinkingReplayKVClient()
+	client.values[aliasKey] = append([]byte(nil), committedRaw...)
+	// Index references the alias with a timestamp from this registration.
+	index, _ := json.Marshal(claudeThinkingReplayAliasIndex{Aliases: []claudeThinkingReplayAliasIndexRecord{{
+		AliasKey:  aliasKey,
+		Timestamp: now,
+	}}})
+	client.values[indexKey] = index
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, committedRaw, nil, now)
+
+	if !aliasValueIsLive(client.values[aliasKey]) {
+		t.Fatalf("fresh index record allowed value to be rolled back")
+	}
+}
+
+func TestClaudeThinkingReplayAliasHomeRollBackRestoresPreviousValue(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	messageHash := "msg"
+	aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHash)
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+
+	now := time.Now()
+	previous := claudeThinkingReplayAliasHomeValue{Sessions: []claudeThinkingReplayAliasHomeSession{{SessionKey: "old", FirstUserHash: "first", Timestamp: now}}}
+	previousRaw, _ := json.Marshal(previous)
+	committed := claudeThinkingReplayAliasHomeValue{Sessions: []claudeThinkingReplayAliasHomeSession{
+		{SessionKey: "old", FirstUserHash: "first", Timestamp: now},
+		{SessionKey: "new", FirstUserHash: "first", Timestamp: now},
+	}}
+	committedRaw, _ := json.Marshal(committed)
+
+	client := newFakeClaudeThinkingReplayKVClient()
+	client.values[aliasKey] = append([]byte(nil), committedRaw...)
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, committedRaw, previousRaw, now)
+
+	if string(client.values[aliasKey]) != string(previousRaw) {
+		t.Fatalf("rollback did not restore previous alias value: got %s, want %s", client.values[aliasKey], previousRaw)
+	}
+}
+
+func TestClaudeThinkingReplayAliasHomeRollBackPreservesPriorDespiteConcurrentRepopulation(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	messageHash := "new-msg"
+	aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHash)
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+
+	now := time.Now()
+	previous := claudeThinkingReplayAliasHomeValue{Sessions: []claudeThinkingReplayAliasHomeSession{{SessionKey: "old", FirstUserHash: "first", Timestamp: now}}}
+	previousRaw, _ := json.Marshal(previous)
+	committed := claudeThinkingReplayAliasHomeValue{Sessions: []claudeThinkingReplayAliasHomeSession{
+		{SessionKey: "old", FirstUserHash: "first", Timestamp: now},
+		{SessionKey: "new", FirstUserHash: "first", Timestamp: now},
+	}}
+	committedRaw, _ := json.Marshal(committed)
+	injected := claudeThinkingReplayAliasHomeValue{Sessions: []claudeThinkingReplayAliasHomeSession{{SessionKey: "other", FirstUserHash: "first", Timestamp: now}}}
+	injectedRaw, _ := json.Marshal(injected)
+
+	base := newFakeClaudeThinkingReplayKVClient()
+	base.values[aliasKey] = append([]byte(nil), committedRaw...)
+	client := &concurrentAliasClaudeThinkingReplayKVClient{fakeClaudeThinkingReplayKVClient: base, aliasKey: aliasKey, injected: injectedRaw}
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, committedRaw, previousRaw, now)
+
+	if string(client.values[aliasKey]) != string(injectedRaw) {
+		t.Fatalf("concurrently repopulated alias was overwritten during rollback: got %s, want %s", client.values[aliasKey], injectedRaw)
+	}
+}
+
+func TestClaudeThinkingReplayAliasEnforcesByteLimitAndLRU(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	ctx := context.Background()
+
+	// The byte limit is large; construct an alias with a very long modelFamily
+	// to push the aggregate size over the cap.
+	large := make([]byte, ClaudeThinkingReplayCacheMaxAliasBytes)
+	for i := range large {
+		large[i] = 'x'
+	}
+	modelFamily := "claude:" + string(large) + ":model"
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session-a", "msg", "first")
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session-b", "msg2", "first")
+
+	if claudeThinkingReplayAliasBytes > ClaudeThinkingReplayCacheMaxAliasBytes {
+		t.Fatalf("alias bytes %d still over the %d cap after enforcement", claudeThinkingReplayAliasBytes, ClaudeThinkingReplayCacheMaxAliasBytes)
+	}
+}
+
+func TestClaudeThinkingReplayAliasPerKeyEvictsOldestByTimestamp(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	ctx := context.Background()
+
+	modelFamily := "claude:cred:model"
+	messageHash := "shared-msg"
+
+	// Fill the per-key list with 8 sessions, each with a distinct timestamp.
+	for i := 0; i < ClaudeThinkingReplayCacheMaxAliasesPerKey; i++ {
+		useFakeClaudeThinkingReplayKVClient(t, newFakeClaudeThinkingReplayKVClient(), false)
+		RegisterClaudeThinkingReplayAlias(ctx, modelFamily, fmt.Sprintf("session-%d", i), messageHash, "first")
+	}
+
+	// Refresh the oldest one (session-0) so it becomes newest.
+	useFakeClaudeThinkingReplayKVClient(t, newFakeClaudeThinkingReplayKVClient(), false)
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session-0", messageHash, "first")
+
+	// Add one more. The oldest remaining by timestamp should be session-1.
+	useFakeClaudeThinkingReplayKVClient(t, newFakeClaudeThinkingReplayKVClient(), false)
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session-9", messageHash, "first")
+
+	key := claudeThinkingReplayAliasKey(modelFamily, messageHash)
+	list := claudeThinkingReplayAliases[key]
+	for _, e := range list {
+		if e.sessionKey == "session-1" {
+			t.Fatalf("session-1 should have been evicted as oldest after session-0 refresh")
+		}
+	}
+	if len(list) != ClaudeThinkingReplayCacheMaxAliasesPerKey {
+		t.Fatalf("per-key list len = %d, want %d", len(list), ClaudeThinkingReplayCacheMaxAliasesPerKey)
+	}
+}
+
+func TestGetClaudeThinkingReplayWithSnapshotIfExistsDoesNotReserve(t *testing.T) {
+	client := newFakeClaudeThinkingReplayKVClient()
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	const sessionKey = "no-nonce-fallback"
+
+	_, _, found, err := GetClaudeThinkingReplayWithSnapshotIfExists(ctx, modelFamily, sessionKey)
+	if err != nil {
+		t.Fatalf("GetIfExists error: %v", err)
+	}
+	if found {
+		t.Fatal("expected no existing replay state")
+	}
+	if client.sets != 0 {
+		t.Fatalf("GetIfExists reserved a tombstone: sets=%d", client.sets)
+	}
+
+	// A subsequent cache write should then be able to set the value.
+	content := []byte(`[{"type":"thinking","thinking":"reason","signature":"EgI="}]`)
+	if !CacheClaudeThinkingReplayBestEffort(ctx, modelFamily, sessionKey, content) {
+		t.Fatal("CacheClaudeThinkingReplayBestEffort failed")
+	}
+
+	contents, _, found, err := GetClaudeThinkingReplayWithSnapshotIfExists(ctx, modelFamily, sessionKey)
+	if err != nil {
+		t.Fatalf("GetIfExists after cache error: %v", err)
+	}
+	if !found || len(contents) != 1 {
+		t.Fatalf("expected cached content, found=%v len=%d", found, len(contents))
+	}
+}
+
+func TestReplaceClaudeThinkingReplayIfUnchangedCASAvoidsOverwrite(t *testing.T) {
+	client := newFakeClaudeThinkingReplayKVClient()
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	const sessionKey = "concurrent-fallback"
+
+	_, snapshot, _, err := GetClaudeThinkingReplayWithSnapshotIfExists(ctx, modelFamily, sessionKey)
+	if err != nil {
+		t.Fatalf("GetIfExists error: %v", err)
+	}
+	if !snapshot.loaded || snapshot.found {
+		t.Fatalf("expected loaded not-found snapshot, got loaded=%v found=%v", snapshot.loaded, snapshot.found)
+	}
+
+	// Another request wins the race and writes first.
+	other := []byte(`[{"type":"thinking","thinking":"other","signature":"EgI="}]`)
+	if !CacheClaudeThinkingReplayBestEffort(ctx, modelFamily, sessionKey, other) {
+		t.Fatal("concurrent cache write failed")
+	}
+
+	// The original replace must fail and must not overwrite the winner.
+	content := []byte(`[{"type":"thinking","thinking":"loser","signature":"EgI="}]`)
+	ok, err := ReplaceClaudeThinkingReplayIfUnchanged(ctx, modelFamily, sessionKey, snapshot, content)
+	if err != nil {
+		t.Fatalf("Replace error: %v", err)
+	}
+	if ok {
+		t.Fatal("Replace should lose when another writer created the value")
+	}
+
+	got, _, found, err := GetClaudeThinkingReplayWithSnapshotIfExists(ctx, modelFamily, sessionKey)
+	if err != nil || !found {
+		t.Fatalf("expected winner value, found=%v err=%v", found, err)
+	}
+	if string(got[0]) != string(other) {
+		t.Fatalf("winner value was overwritten: got %q, want %q", got[0], other)
+	}
+}
+
+func TestClaudeThinkingReplayAliasBatchEvictCarriesIdentity(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+	ctx := context.Background()
+	useFakeClaudeThinkingReplayKVClient(t, newFakeClaudeThinkingReplayKVClient(), false)
+
+	// Each alias key is ~0.5MiB; 130 aliases exceed the 64MiB cap and force a
+	// 128-entry eviction batch, leaving the two newest entries.
+	const keySize = 1 << 19
+	modelFamily := "claude:" + strings.Repeat("x", keySize) + ":model"
+
+	for i := 0; i < 130; i++ {
+		RegisterClaudeThinkingReplayAlias(ctx, modelFamily, fmt.Sprintf("session-%d", i), messageHashFor(i), "first")
+	}
+
+	if claudeThinkingReplayAliasCount != 2 {
+		t.Fatalf("alias count = %d, want 2", claudeThinkingReplayAliasCount)
+	}
+
+	// The 128-entry batch should have removed the oldest sessions.
+	for _, evicted := range []string{"session-0", "session-1"} {
+		key := claudeThinkingReplayAliasKey(modelFamily, messageHashFor(0))
+		if strings.HasPrefix(evicted, "session-1") {
+			key = claudeThinkingReplayAliasKey(modelFamily, messageHashFor(1))
+		}
+		for _, entry := range claudeThinkingReplayAliases[key] {
+			if entry.sessionKey == evicted {
+				t.Fatalf("evicted session %q still present", evicted)
+			}
+		}
+	}
+	for _, kept := range []string{"session-128", "session-129"} {
+		i := 128
+		if kept == "session-129" {
+			i = 129
+		}
+		key := claudeThinkingReplayAliasKey(modelFamily, messageHashFor(i))
+		found := false
+		for _, entry := range claudeThinkingReplayAliases[key] {
+			if entry.sessionKey == kept {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("kept session %q not found", kept)
+		}
+	}
+}
+
+func messageHashFor(i int) string {
+	const chars = "abcdefghijklmnopqrstuvwxyz"
+	s := make([]byte, 0, 8)
+	v := i
+	for j := 0; j < 8; j++ {
+		s = append(s, chars[v%26])
+		v /= 26
+	}
+	return string(s)
+}
+
+func TestClaudeThinkingReplayAliasHomeEvictedTombstoneHasShortTTL(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	client := newFakeClaudeThinkingReplayKVClient()
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+
+	max := ClaudeThinkingReplayCacheMaxAliasesPerCredential
+	for i := 0; i < max+10; i++ {
+		RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHashFor(i), "first")
+	}
+
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+	index, _ := decodeClaudeThinkingReplayAliasIndex(client.values[indexKey])
+	if len(index.Aliases) > max {
+		t.Fatalf("credential alias cap exceeded: %d > %d", len(index.Aliases), max)
+	}
+
+	evictedKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHashFor(0))
+	if ttl, ok := client.swapsTTLs[evictedKey]; !ok || ttl != claudeThinkingReplayAliasTombstoneTTL {
+		t.Fatalf("evicted alias tombstone ttl = %v, want %v", ttl, claudeThinkingReplayAliasTombstoneTTL)
+	}
+
+	newKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHashFor(max+9))
+	if ttl, ok := client.swapsTTLs[newKey]; !ok || ttl != ClaudeThinkingReplayCacheTTL {
+		t.Fatalf("new alias value ttl = %v, want %v", ttl, ClaudeThinkingReplayCacheTTL)
+	}
+}
+
+func TestClaudeThinkingReplayAliasHomeRollbackTombstoneHasShortTTL(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+	messageHash := "new-msg"
+	aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHash)
+
+	base := newFakeClaudeThinkingReplayKVClient()
+	client := &failingIndexClaudeThinkingReplayKVClient{
+		fakeClaudeThinkingReplayKVClient: base,
+		indexKey:                         indexKey,
+	}
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHash, "first")
+
+	raw, ok := client.values[aliasKey]
+	if !ok {
+		t.Fatalf("alias %q was removed; expected a tombstone", aliasKey)
+	}
+	if aliasValueIsLive(raw) {
+		t.Fatalf("alias %q was committed but not indexed; expected rollback", aliasKey)
+	}
+	if ttl, ok := client.swapsTTLs[aliasKey]; !ok || ttl != claudeThinkingReplayAliasTombstoneTTL {
+		t.Fatalf("rollback tombstone ttl = %v, want %v", ttl, claudeThinkingReplayAliasTombstoneTTL)
+	}
+}
+
+func TestClaudeThinkingReplayIfExistsLocalAbsenceIsLoaded(t *testing.T) {
+	useFakeClaudeThinkingReplayKVClient(t, nil, false)
 
 	const modelFamily = "claude:auth:model"
-	const sessionKey = "execution:multi-turn"
-	first := []byte(`[{"type":"thinking","thinking":"first","signature":"sig-1"},{"type":"tool_use","id":"toolu-1","name":"Read","input":{"path":"one"}}]`)
-	second := []byte(`[{"type":"thinking","thinking":"second","signature":"sig-2"},{"type":"tool_use","id":"toolu-2","name":"Read","input":{"path":"two"}}]`)
+	const sessionKey = "if-exists-local"
+	first := []byte(`[{"type":"thinking","thinking":"first","signature":"sig-1"}]`)
+	second := []byte(`[{"type":"thinking","thinking":"second","signature":"sig-2"}]`)
 
-	if !CacheClaudeThinkingReplayBestEffort(context.Background(), modelFamily, sessionKey, first) {
-		t.Fatal("failed to seed first Claude replay turn")
+	_, snap1, found, err := GetClaudeThinkingReplayWithSnapshotIfExists(context.Background(), modelFamily, sessionKey)
+	if err != nil {
+		t.Fatalf("initial IfExists: %v", err)
 	}
-	_, snapshot, found, errGet := GetClaudeThinkingReplayWithSnapshotRequired(context.Background(), modelFamily, sessionKey)
-	if errGet != nil || !found {
-		t.Fatalf("initial Claude replay read = found %v, error %v", found, errGet)
+	if found {
+		t.Fatal("initial IfExists should not find replay")
 	}
-	replaced, errReplace := ReplaceClaudeThinkingReplayIfUnchanged(context.Background(), modelFamily, sessionKey, snapshot, second)
-	if errReplace != nil || !replaced {
-		t.Fatalf("append Claude replay turn = replaced %v, error %v", replaced, errReplace)
-	}
-
-	contents, found, errGet := GetClaudeThinkingReplayRequired(context.Background(), modelFamily, sessionKey)
-	if errGet != nil || !found || len(contents) != 2 {
-		t.Fatalf("Claude replay contents = %d, found %v, error %v; want two turns", len(contents), found, errGet)
-	}
-	if !bytes.Equal(contents[0], first) || !bytes.Equal(contents[1], second) {
-		t.Fatalf("Claude replay contents lost ordering: got %s / %s", contents[0], contents[1])
-	}
-}
-
-func TestClaudeThinkingReplayClearDoesNotClearKimiState(t *testing.T) {
-	previousClaudeClient := currentClaudeThinkingReplayKVClient
-	previousKimiClient := currentKimiThinkingReplayKVClient
-	currentClaudeThinkingReplayKVClient = func() (kimiThinkingReplayKVClient, bool, error) {
-		return nil, false, nil
-	}
-	currentKimiThinkingReplayKVClient = func() (kimiThinkingReplayKVClient, bool, error) {
-		return nil, false, nil
-	}
-	t.Cleanup(func() {
-		currentClaudeThinkingReplayKVClient = previousClaudeClient
-		currentKimiThinkingReplayKVClient = previousKimiClient
-	})
-	ClearClaudeThinkingReplayCache()
-	ClearKimiThinkingReplayCache()
-	t.Cleanup(ClearClaudeThinkingReplayCache)
-	t.Cleanup(ClearKimiThinkingReplayCache)
-
-	const modelFamily = "shared-model"
-	const sessionKey = "execution:shared-session"
-	kimiContent := []byte(`[{"type":"thinking","signature":"kimi"}]`)
-	claudeContent := []byte(`[{"type":"thinking","signature":"claude"}]`)
-	if !CacheKimiThinkingReplayBestEffort(context.Background(), modelFamily, sessionKey, kimiContent) {
-		t.Fatal("failed to seed Kimi replay state")
-	}
-	if !CacheClaudeThinkingReplayBestEffort(context.Background(), modelFamily, sessionKey, claudeContent) {
-		t.Fatal("failed to seed Claude replay state")
+	if !snap1.loaded || snap1.found {
+		t.Fatalf("initial IfExists snapshot = loaded %v found %v, want loaded=true found=false", snap1.loaded, snap1.found)
 	}
 
-	ClearClaudeThinkingReplayCache()
-
-	gotKimi, foundKimi, errKimi := GetKimiThinkingReplayRequired(context.Background(), modelFamily, sessionKey)
-	if errKimi != nil || !foundKimi || !bytes.Equal(gotKimi, kimiContent) {
-		t.Fatalf("Kimi replay after Claude clear = %s, found %v, error %v; want preserved state", gotKimi, foundKimi, errKimi)
+	_, snap2, found, err := GetClaudeThinkingReplayWithSnapshotIfExists(context.Background(), modelFamily, sessionKey)
+	if err != nil || found {
+		t.Fatalf("second IfExists before replace: found %v, err %v", found, err)
 	}
-	gotClaude, foundClaude, errClaude := GetClaudeThinkingReplayRequired(context.Background(), modelFamily, sessionKey)
-	if errClaude != nil || foundClaude || len(gotClaude) != 0 {
-		t.Fatalf("Claude replay after Claude clear = %d turns, found %v, error %v; want cleared state", len(gotClaude), foundClaude, errClaude)
+	if !snap2.loaded || snap2.found {
+		t.Fatalf("second IfExists snapshot = loaded %v found %v, want loaded=true found=false", snap2.loaded, snap2.found)
+	}
+
+	replaced, err := ReplaceClaudeThinkingReplayIfUnchanged(context.Background(), modelFamily, sessionKey, snap1, first)
+	if err != nil || !replaced {
+		t.Fatalf("first replace = %v, err %v", replaced, err)
+	}
+
+	replaced, err = ReplaceClaudeThinkingReplayIfUnchanged(context.Background(), modelFamily, sessionKey, snap2, second)
+	if err != nil || replaced {
+		t.Fatalf("second replace should lose race, got replaced=%v err=%v", replaced, err)
+	}
+
+	contents, foundFinal, err := GetClaudeThinkingReplayRequired(context.Background(), modelFamily, sessionKey)
+	if err != nil || !foundFinal || len(contents) != 1 {
+		t.Fatalf("final contents = %d, err %v; want one turn", len(contents), err)
+	}
+	if !bytes.Equal(contents[0], first) {
+		t.Fatalf("final contents = %s, want %s", contents[0], first)
 	}
 }

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -40,8 +40,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("claude")
 	var replayScope claudeThinkingReplayScope
+	var replayContents [][]byte
 	if claudeThinkingReplayEnabled(auth, req, opts) {
-		req, replayScope = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
+		replayScope, replayContents, _ = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
 	}
 	defer func() {
 		if err != nil && replayScope.replayApplied && shouldClearKimiThinkingReplayAfterError(err) {
@@ -89,6 +90,12 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	)
 	if err != nil {
 		return resp, err
+	}
+	// If cloaking obfuscated the upstream body, cached assistant content must be
+	// obfuscated with the same words before the replay match/restore runs.
+	_, cloakSettings := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
+	if cloaked && len(cloakSettings.sensitiveWords) > 0 && len(replayContents) > 0 {
+		replayContents = helps.ObfuscateClaudeThinkingReplayContents(replayContents, cloakSettings.sensitiveWords)
 	}
 	systemPlacementState := captureClaudeCodeSystemPlacement(bodyBeforeCloaking, body, cloaked)
 	// Only the Messages endpoint on Anthropic itself was captured; count_tokens
@@ -164,12 +171,15 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	extraBetas, body = extractAndRemoveBetas(body)
 	bodyForTranslation := body
 	bodyForUpstream := body
+	bodyForUpstream = sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, bodyForUpstream, baseModel, helps.APIKeyModelIsCompat(req))
+	if len(replayContents) > 0 && replayScope.valid() {
+		bodyForUpstream, replayScope.replayApplied = helps.RestoreClaudeThinkingReplayContents(bodyForUpstream, replayContents)
+	}
 	var oauthToolNamesReverseMap map[string]string
 	if fp.MCPAlias && cloaked {
 		mcpAliases := resolveClaudeMCPAliasOptions(ctx)
 		bodyForUpstream, oauthToolNamesReverseMap = prepareClaudeOAuthToolNamesForUpstream(bodyForUpstream, mcpAliases)
 	}
-	bodyForUpstream = sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, bodyForUpstream, baseModel, helps.APIKeyModelIsCompat(req))
 	if fp.ApplyCLIIdentity {
 		bodyForUpstream, err = applyClaudeCLIIdentity(bodyForUpstream, auth, apiKey, url, claudeSessionID, fp.SynthesizeIdentity)
 		if err != nil {

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -46,8 +46,13 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("claude")
 	var replayScope claudeThinkingReplayScope
+	var replayContents [][]byte
 	if claudeThinkingReplayEnabled(auth, req, opts) {
-		req, replayScope = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
+		replayScope, replayContents, _ = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
+	}
+	var replayAccum *kimiThinkingReplayStreamAccumulator
+	if replayScope.valid() && responseFormat != to {
+		replayAccum = newKimiThinkingReplayStreamAccumulator()
 	}
 	defer func() {
 		if err != nil && replayScope.replayApplied && shouldClearKimiThinkingReplayAfterError(err) {
@@ -92,6 +97,12 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	)
 	if err != nil {
 		return nil, err
+	}
+	// If cloaking obfuscated the upstream body, cached assistant content must be
+	// obfuscated with the same words before the replay match/restore runs.
+	_, cloakSettings := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
+	if cloaked && len(cloakSettings.sensitiveWords) > 0 && len(replayContents) > 0 {
+		replayContents = helps.ObfuscateClaudeThinkingReplayContents(replayContents, cloakSettings.sensitiveWords)
 	}
 	systemPlacementState := captureClaudeCodeSystemPlacement(bodyBeforeCloaking, body, cloaked)
 	// Only the Messages endpoint on Anthropic itself was captured; count_tokens
@@ -156,12 +167,15 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	extraBetas, body = extractAndRemoveBetas(body)
 	bodyForTranslation := body
 	bodyForUpstream := body
+	bodyForUpstream = sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, bodyForUpstream, baseModel, helps.APIKeyModelIsCompat(req))
+	if len(replayContents) > 0 && replayScope.valid() {
+		bodyForUpstream, replayScope.replayApplied = helps.RestoreClaudeThinkingReplayContents(bodyForUpstream, replayContents)
+	}
 	var oauthToolNamesReverseMap map[string]string
 	if fp.MCPAlias && cloaked {
 		mcpAliases := resolveClaudeMCPAliasOptions(ctx)
 		bodyForUpstream, oauthToolNamesReverseMap = prepareClaudeOAuthToolNamesForUpstream(bodyForUpstream, mcpAliases)
 	}
-	bodyForUpstream = sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, bodyForUpstream, baseModel, helps.APIKeyModelIsCompat(req))
 	if fp.ApplyCLIIdentity {
 		bodyForUpstream, err = applyClaudeCLIIdentity(bodyForUpstream, auth, apiKey, url, claudeSessionID, fp.SynthesizeIdentity)
 		if err != nil {
@@ -380,6 +394,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				return
 			}
 			line = e.restoreResponseModel(restoredLine, req.Model)
+			if replayAccum != nil {
+				replayAccum.observe(line)
+			}
 			chunks := sdktranslator.TranslateStream(
 				ctx,
 				to,
@@ -419,6 +436,13 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		}
 		if upstreamCompleted {
 			commitClaudeDiagnostics(diagnosticsState, upstreamMessageID)
+		}
+		if replayAccum != nil {
+			if content, completed := replayAccum.content(); completed {
+				cacheClaudeThinkingReplayContent(ctx, replayScope, content)
+			} else if replayAccum.upstreamError && replayScope.replayApplied {
+				clearClaudeThinkingReplayContent(ctx, replayScope)
+			}
 		}
 	}()
 	result := &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -2,13 +2,10 @@ package executor
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"strings"
 
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
@@ -33,71 +30,104 @@ func claudeThinkingReplayEnabled(auth *cliproxyauth.Auth, req cliproxyexecutor.R
 	return strings.TrimSpace(apiKey) != "" && !isClaudeOAuthToken(apiKey)
 }
 
-// A missing session identity intentionally disables replay instead of sharing hidden reasoning across callers.
+// claudeThinkingReplayScopeFromRequest selects a conversation replay scope.
+// It prefers an explicit execution/session metadata or prompt-cache/window key,
+// then a conversation nonce (client_metadata.conversation_id, conversation_id,
+// or X-Conversation-Id), and finally a content-derived fallback keyed by the
+// first user message and system prompt.
+//
+// When the fallback key is content-derived, history compaction changes
+// messages.0 and can orphan the cache. Resolve the original scope through any
+// remaining message aliases, then continue using that key for this request.
 func claudeThinkingReplayScopeFromRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) claudeThinkingReplayScope {
+	modelFamily := helps.ClaudeThinkingReplayModelFamily(auth, req.Model)
+	callerHash := helps.ClaudeThinkingReplayCallerHash(auth, req, opts)
+	firstUserHash := helps.ClaudeThinkingReplayFirstUserHash(modelFamily, callerHash, req.Payload)
 	sessionKey := codexReasoningReplaySessionKey(ctx, sdktranslator.FormatClaude, req, opts, req.Payload)
-	sessionKey = xaiReasoningReplayIsolateSessionKey(ctx, sessionKey)
-	return claudeThinkingReplayScope{
-		modelFamily: claudeThinkingReplayModelFamily(auth, req.Model),
-		sessionKey:  sessionKey,
+	fallback := false
+	if sessionKey != "" {
+		sessionKey = xaiReasoningReplayIsolateSessionKey(ctx, sessionKey)
 	}
-}
-
-func claudeThinkingReplayModelFamily(auth *cliproxyauth.Auth, model string) string {
-	baseModel := thinking.ParseSuffix(strings.TrimSpace(model)).ModelName
-	if baseModel == "" {
-		return ""
-	}
-	identity := ""
-	if auth != nil {
-		identity = strings.TrimSpace(auth.ID)
-		if identity == "" {
-			apiKey, baseURL := claudeCreds(auth)
-			identity = strings.TrimSpace(baseURL)
-			if identity == "" {
-				identity = strings.TrimSpace(apiKey)
+	if sessionKey == "" {
+		var usedNonce bool
+		sessionKey, usedNonce = helps.ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
+		fallback = sessionKey != "" && !usedNonce
+		if fallback {
+			resolvedMessages := capClaudeThinkingReplayAliasMessages(helps.ClaudeThinkingReplayMessageHashes(modelFamily, callerHash, req.Payload))
+			if resolved, ok := internalcache.ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, resolvedMessages, firstUserHash); ok {
+				sessionKey = resolved
 			}
 		}
 	}
-	if identity == "" {
-		return "claude:" + baseModel
+	return claudeThinkingReplayScope{
+		modelFamily:   modelFamily,
+		sessionKey:    sessionKey,
+		fallbackKey:   fallback,
+		callerHash:    callerHash,
+		firstUserHash: firstUserHash,
 	}
-	sum := sha256.Sum256([]byte(identity))
-	return "claude:" + hex.EncodeToString(sum[:8]) + ":" + baseModel
 }
 
-func prepareClaudeThinkingReplayRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Request, claudeThinkingReplayScope) {
+// claudeThinkingReplayMaxAliasesPerRequest caps how many message hashes are
+// registered as scope aliases for a single request. This prevents long
+// histories from generating unbounded alias registration round trips and
+// evicting useful earlier aliases.
+const claudeThinkingReplayMaxAliasesPerRequest = 64
+
+func capClaudeThinkingReplayAliasMessages(hashes []internalcache.ClaudeThinkingReplayAliasMessage) []internalcache.ClaudeThinkingReplayAliasMessage {
+	if len(hashes) <= claudeThinkingReplayMaxAliasesPerRequest {
+		return hashes
+	}
+	keep := make([]internalcache.ClaudeThinkingReplayAliasMessage, 0, claudeThinkingReplayMaxAliasesPerRequest)
+	keep = append(keep, hashes[0])
+	keep = append(keep, hashes[len(hashes)-claudeThinkingReplayMaxAliasesPerRequest+1:]...)
+	return keep
+}
+
+// prepareClaudeThinkingReplayRequest loads cached assistant content for this
+// request and strips any client-supplied _cliproxy_replay_provenance markers
+// from req.Payload. The actual restore is applied to bodyForUpstream after
+// signature sanitization and before MCP tool-name remapping, so cache-provenanced
+// signatures bypass the sanitizer while matching against the caller-facing body.
+func prepareClaudeThinkingReplayRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (claudeThinkingReplayScope, [][]byte, bool) {
 	scope := claudeThinkingReplayScopeFromRequest(ctx, auth, req, opts)
 	if !scope.valid() {
-		return req, scope
+		return scope, nil, false
 	}
-	contents, snapshot, found, errGet := internalcache.GetClaudeThinkingReplayWithSnapshotRequired(ctx, scope.modelFamily, scope.sessionKey)
+
+	req.Payload = helps.StripClaudeThinkingReplayProvenanceMarkers(req.Payload)
+
+	// Both content-derived fallback scopes and caller-controlled nonce scopes can
+	// supply arbitrary openings per request; avoid reserving a Home KV tombstone
+	// until a replayable response is actually cached.
+	contents, snapshot, found, errGet := internalcache.GetClaudeThinkingReplayWithSnapshotIfExists(ctx, scope.modelFamily, scope.sessionKey)
 	scope.snapshot = snapshot
 	scope.cacheReady = errGet == nil
 	if errGet != nil {
 		log.Warnf("claude compatible thinking replay cache read failed: %v", errGet)
-		return req, scope
+		return scope, nil, false
+	}
+	// Register the messages in this payload as aliases for this conversation
+	// scope, so later compacted requests can resolve the same scope even when
+	// messages.0 has changed. This is done even when the cache is empty so the
+	// first request in a conversation can be rediscovered after compaction.
+	if scope.fallbackKey {
+		hashes := capClaudeThinkingReplayAliasMessages(helps.ClaudeThinkingReplayMessageHashes(scope.modelFamily, scope.callerHash, req.Payload))
+		for _, m := range hashes {
+			internalcache.RegisterClaudeThinkingReplayAlias(ctx, scope.modelFamily, scope.sessionKey, m.Hash, scope.firstUserHash)
+		}
 	}
 	if !found {
-		return req, scope
+		return scope, nil, false
 	}
-	updated, restored := restoreClaudeThinkingReplayContents(req.Payload, contents)
-	if restored {
-		req.Payload = updated
-		scope.replayApplied = true
+	// Normalize cached tool_use parts to match the shape the sanitizer will apply
+	// to the upstream body, so an echo'd tool_use with provenance fields does not
+	// fail the canonical comparison.
+	normalized := make([][]byte, len(contents))
+	for i, content := range contents {
+		normalized[i] = helps.ClaudeThinkingReplayNormalizeCachedContent(content)
 	}
-	return req, scope
-}
-
-func restoreClaudeThinkingReplayContents(body []byte, cachedContents [][]byte) ([]byte, bool) {
-	updated := body
-	restored := false
-	for _, cachedContent := range cachedContents {
-		var restoredTurn bool
-		updated, restoredTurn = restoreKimiThinkingReplayContent(updated, cachedContent)
-		restored = restored || restoredTurn
-	}
-	return updated, restored
+	return scope, normalized, true
 }
 
 func cacheClaudeThinkingReplayResponse(ctx context.Context, scope claudeThinkingReplayScope, response []byte) {
@@ -113,17 +143,31 @@ func cacheClaudeThinkingReplayResponse(ctx context.Context, scope claudeThinking
 	}
 }
 
+// claudeThinkingReplayContentIsReplayable reports whether a content array
+// carries a decodable Claude thinking signature. Only provenanced signed turns
+// are cached; unsigned or malformed-signature responses must not evict earlier
+// replay state.
+
 func cacheClaudeThinkingReplayContent(ctx context.Context, scope claudeThinkingReplayScope, content []byte) {
 	if !scope.valid() || !scope.cacheReady {
 		return
 	}
-	if kimiThinkingReplayContentIsReplayable(content) {
-		if _, errReplace := internalcache.ReplaceClaudeThinkingReplayIfUnchanged(ctx, scope.modelFamily, scope.sessionKey, scope.snapshot, content); errReplace != nil {
+	// Unsigned or non-replayable responses must not evict earlier signed turns.
+	// Only append turns that carry signed thinking; prior replay state is retained
+	// for the next request that echoes an earlier assistant message.
+	if helps.ClaudeThinkingReplayContentIsReplayable(content) {
+		replaced, errReplace := internalcache.ReplaceClaudeThinkingReplayIfUnchanged(ctx, scope.modelFamily, scope.sessionKey, scope.snapshot, content)
+		if errReplace != nil {
 			log.Warnf("claude compatible thinking replay cache replace failed: %v", errReplace)
+		} else if replaced && scope.fallbackKey {
+			// Register the client-visible assistant shape as an alias only after a
+			// successful cache write, so aliases do not point at a missing or
+			// failed replay record.
+			if h := helps.ClaudeThinkingReplayAssistantMessageHash(scope.modelFamily, scope.callerHash, content); h != "" {
+				internalcache.RegisterClaudeThinkingReplayAlias(ctx, scope.modelFamily, scope.sessionKey, h, scope.firstUserHash)
+			}
 		}
-		return
 	}
-	clearClaudeThinkingReplayContent(ctx, scope)
 }
 
 func clearClaudeThinkingReplayContent(ctx context.Context, scope claudeThinkingReplayScope) {

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -3,21 +3,370 @@ package executor
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
+// claudeReplayPayloadWithConversationID adds a conversation nonce to a payload
+// so sessionless clients can use the fallback conversation replay scope.
+func claudeReplayPayloadWithConversationID(payload []byte, conversationID string) []byte {
+	if conversationID == "" {
+		return payload
+	}
+	updated, err := sjson.SetBytes(payload, "client_metadata.conversation_id", conversationID)
+	if err != nil {
+		return payload
+	}
+	return updated
+}
+
 const claudeReplayResolvedModelInfoKey = "cliproxy.resolved_api_key_model_info"
+
+func TestClaudeThinkingReplayScopeFromRequest_FallbackKeyOnlyForContent(t *testing.T) {
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+
+	noncePayload := []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-1"}}`)
+	withNonceReq := cliproxyexecutor.Request{Model: "claude-3-opus", Payload: noncePayload}
+	withNonce := claudeThinkingReplayScopeFromRequest(context.Background(), auth, withNonceReq, cliproxyexecutor.Options{})
+	if withNonce.fallbackKey {
+		t.Fatalf("fallbackKey must be false when a conversation nonce is used")
+	}
+
+	contentPayload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	contentReq := cliproxyexecutor.Request{Model: "claude-3-opus", Payload: contentPayload}
+	content := claudeThinkingReplayScopeFromRequest(context.Background(), auth, contentReq, cliproxyexecutor.Options{})
+	if !content.fallbackKey {
+		t.Fatalf("fallbackKey must be true for a content-derived fallback scope")
+	}
+}
+
+func TestCapClaudeThinkingReplayAliasMessages_KeepsFirstAndMostRecent(t *testing.T) {
+	var all []internalcache.ClaudeThinkingReplayAliasMessage
+	for i := 0; i < 100; i++ {
+		all = append(all, internalcache.ClaudeThinkingReplayAliasMessage{Hash: fmt.Sprintf("hash-%d", i)})
+	}
+	capped := capClaudeThinkingReplayAliasMessages(all)
+	if len(capped) != claudeThinkingReplayMaxAliasesPerRequest {
+		t.Fatalf("capped len = %d, want %d", len(capped), claudeThinkingReplayMaxAliasesPerRequest)
+	}
+	if capped[0].Hash != "hash-0" {
+		t.Fatalf("capped should keep first message, got %q", capped[0].Hash)
+	}
+	wantLast := "hash-99"
+	if capped[len(capped)-1].Hash != wantLast {
+		t.Fatalf("capped should keep most recent messages, got last %q, want %q", capped[len(capped)-1].Hash, wantLast)
+	}
+}
+
+func TestClaudeThinkingReplayFindStartIndex_RefusesPartialAnchor(t *testing.T) {
+	assistant := []gjson.Result{
+		gjson.Parse(`[{"type":"text","text":"A-old"}]`),
+		gjson.Parse(`[{"type":"text","text":"X"}]`),
+	}
+	cached := [][]byte{
+		[]byte(`[{"type":"text","text":"A-old"}]`),
+		[]byte(`[{"type":"text","text":"A-new"}]`),
+	}
+	if got, _ := helps.ClaudeThinkingReplayFindStartIndex(assistant, cached); got != -1 {
+		t.Fatalf("expected -1 for partial match with unsigned trailing turn, got %d", got)
+	}
+
+	assistantFull := []gjson.Result{
+		gjson.Parse(`[{"type":"text","text":"A-new"}]`),
+	}
+	if got, off := helps.ClaudeThinkingReplayFindStartIndex(assistantFull, cached); got != 1 || len(off) != 1 || off[0] != 0 {
+		t.Fatalf("expected latest full match start 1 off [0], got %d %v", got, off)
+	}
+
+	// Cached turns separated by an uncached unsigned assistant should still
+	// anchor both retained turns.
+	body := []byte(`{"messages":[{"role":"user","content":"u"},{"role":"assistant","content":[{"type":"thinking","thinking":"r","signature":"sig1"},{"type":"text","text":"A"}]},{"role":"assistant","content":[{"type":"text","text":"X"}]},{"role":"assistant","content":[{"type":"thinking","thinking":"r","signature":"sig2"},{"type":"text","text":"B"}]},{"role":"user","content":"u2"}]}`)
+	retained := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"r","signature":"sig1"},{"type":"text","text":"A"}]`),
+		[]byte(`[{"type":"thinking","thinking":"r","signature":"sig2"},{"type":"text","text":"B"}]`),
+	}
+	updated, _ := helps.RestoreClaudeThinkingReplayContents(body, retained)
+	a := gjson.GetBytes(updated, "messages.1.content").Array()
+	unsignedX := gjson.GetBytes(updated, "messages.2.content").Array()
+	b := gjson.GetBytes(updated, "messages.3.content").Array()
+	if a[0].Get("signature").String() != "sig1" {
+		t.Fatalf("first retained turn should keep sig1, got %s", a[0].Get("signature").String())
+	}
+	if unsignedX[0].Get("signature").String() != "" {
+		t.Fatalf("unsigned gap should not receive a cached signature: %s", unsignedX[0].Get("signature").String())
+	}
+	if b[0].Get("signature").String() != "sig2" {
+		t.Fatalf("second retained turn should keep sig2, got %s", b[0].Get("signature").String())
+	}
+}
+
+func TestClaudeThinkingReplayFindStartIndex_RefusesAmbiguousShorterSuffix(t *testing.T) {
+	assistant := []gjson.Result{
+		gjson.Parse(`[{"type":"text","text":"A"}]`),
+		gjson.Parse(`[{"type":"text","text":"X"}]`),
+	}
+	cached := [][]byte{
+		[]byte(`[{"type":"text","text":"A"}]`),
+		[]byte(`[{"type":"text","text":"A"}]`),
+	}
+	if got, _ := helps.ClaudeThinkingReplayFindStartIndex(assistant, cached); got != -1 {
+		t.Fatalf("expected -1 for ambiguous shorter suffix with duplicate cached visible turn, got %d", got)
+	}
+
+	// A leading unsigned duplicate with the same visible content as a later
+	// retained cached turn must not steal that cached signature. Request
+	// [B-unsigned, B-retained] and cached [A, B] (different visible) gives a
+	// length-1 match only at the latest offset, which should restore only the
+	// retained second turn.
+	body := []byte(`{"messages":[{"role":"user","content":"u"},{"role":"assistant","content":[{"type":"text","text":"B"}]},{"role":"assistant","content":[{"type":"thinking","thinking":"r"},{"type":"text","text":"B"}]},{"role":"user","content":"u2"}]}`)
+	retained := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"r","signature":"sig1"},{"type":"text","text":"A"}]`),
+		[]byte(`[{"type":"thinking","thinking":"r","signature":"sig2"},{"type":"text","text":"B"}]`),
+	}
+	updated, restored := helps.RestoreClaudeThinkingReplayContents(body, retained)
+	if !restored {
+		t.Fatal("expected restore for retained suffix")
+	}
+	first := gjson.GetBytes(updated, "messages.1.content").Array()
+	second := gjson.GetBytes(updated, "messages.2.content").Array()
+	if first[0].Get("signature").String() != "" {
+		t.Fatalf("first unsigned turn should not receive cached signature: %s", first[0].Get("signature").String())
+	}
+	if second[0].Get("signature").String() != "sig2" {
+		t.Fatalf("second retained turn should receive latest cached signature, got %s", second[0].Get("signature").String())
+	}
+}
+
+func TestClaudeThinkingReplayFindStartIndex_RefusesAmbiguousFullSuffix(t *testing.T) {
+	// A full-suffix request that matches multiple cached blocks of the same
+	// length must fail closed so the wrong cached signature is not restored.
+	assistant := []gjson.Result{
+		gjson.Parse(`[{"type":"text","text":"A"}]`),
+	}
+	cached := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"old","signature":"sig-old"},{"type":"text","text":"A"}]`),
+		[]byte(`[{"type":"thinking","thinking":"new","signature":"sig-new"},{"type":"text","text":"A"}]`),
+	}
+	if got, _ := helps.ClaudeThinkingReplayFindStartIndex(assistant, cached); got != -1 {
+		t.Fatalf("expected -1 for full-suffix match with duplicate cached visible turns, got %d", got)
+	}
+
+	// A full-suffix multi-turn request that matches more than one cached
+	// length-l block is also ambiguous.
+	assistant2 := []gjson.Result{
+		gjson.Parse(`[{"type":"text","text":"A"}]`),
+		gjson.Parse(`[{"type":"text","text":"B"}]`),
+	}
+	cached2 := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"old","signature":"sig-old-a"},{"type":"text","text":"A"}]`),
+		[]byte(`[{"type":"text","text":"B"}]`),
+		[]byte(`[{"type":"thinking","thinking":"new","signature":"sig-new-a"},{"type":"text","text":"A"}]`),
+		[]byte(`[{"type":"text","text":"B"}]`),
+	}
+	if got, _ := helps.ClaudeThinkingReplayFindStartIndex(assistant2, cached2); got != -1 {
+		t.Fatalf("expected -1 for full-suffix multi-turn match with duplicate cached blocks, got %d", got)
+	}
+
+	// An unambiguous full-suffix single match should still succeed.
+	assistant3 := []gjson.Result{
+		gjson.Parse(`[{"type":"text","text":"B"}]`),
+	}
+	cached3 := [][]byte{
+		[]byte(`[{"type":"text","text":"A"}]`),
+		[]byte(`[{"type":"thinking","thinking":"r","signature":"sig-b"},{"type":"text","text":"B"}]`),
+	}
+	if got, _ := helps.ClaudeThinkingReplayFindStartIndex(assistant3, cached3); got != 1 {
+		t.Fatalf("expected start 1 for unambiguous full-suffix, got %d", got)
+	}
+}
+
+func TestClaudeThinkingReplayFindStartIndex_RefusesPerTurnDuplicateCandidates(t *testing.T) {
+	// Cached [A, B] and request [A, B, B-unsigned-duplicate]: the two unsigned
+	// candidates for cached B are both viable because the preceding cached A can
+	// fit before either. This is per-turn sequence ambiguity and must fail closed.
+	assistant := []gjson.Result{
+		gjson.Parse(`[{"type":"text","text":"A"}]`),
+		gjson.Parse(`[{"type":"text","text":"B"}]`),
+		gjson.Parse(`[{"type":"text","text":"B"}]`),
+	}
+	cached := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"ra","signature":"sig-a"},{"type":"text","text":"A"}]`),
+		[]byte(`[{"type":"thinking","thinking":"rb","signature":"sig-b"},{"type":"text","text":"B"}]`),
+	}
+	if got, _ := helps.ClaudeThinkingReplayFindStartIndex(assistant, cached); got != -1 {
+		t.Fatalf("expected -1 for per-turn duplicate candidates, got %d", got)
+	}
+
+	// A retained B disambiguates the duplicate unsigned B: the matcher should
+	// still pick the retained one and not fail.
+	body := []byte(`{"messages":[{"role":"user","content":"u"},{"role":"assistant","content":[{"type":"text","text":"A"}]},{"role":"assistant","content":[{"type":"text","text":"B"}]},{"role":"assistant","content":[{"type":"thinking","thinking":"rb","signature":"sig-b"},{"type":"text","text":"B"}]},{"role":"user","content":"u2"}]}`)
+	retained := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"ra","signature":"sig-a"},{"type":"text","text":"A"}]`),
+		[]byte(`[{"type":"thinking","thinking":"rb","signature":"sig-b"},{"type":"text","text":"B"}]`),
+	}
+	updated, restored := helps.RestoreClaudeThinkingReplayContents(body, retained)
+	if !restored {
+		t.Fatal("expected restore when retained B disambiguates duplicate")
+	}
+	a := gjson.GetBytes(updated, "messages.1.content").Array()
+	b := gjson.GetBytes(updated, "messages.3.content").Array()
+	duplicate := gjson.GetBytes(updated, "messages.2.content").Array()
+	if a[0].Get("signature").String() != "sig-a" {
+		t.Fatalf("A should keep sig-a, got %s", a[0].Get("signature").String())
+	}
+	if b[0].Get("signature").String() != "sig-b" {
+		t.Fatalf("retained B should keep sig-b, got %s", b[0].Get("signature").String())
+	}
+	if duplicate[0].Get("signature").String() != "" {
+		t.Fatalf("earlier unsigned duplicate B should not receive signature: %s", duplicate[0].Get("signature").String())
+	}
+}
+
+func TestClaudeThinkingReplayFindStartIndex_RefusesMultipleRetainedCandidates(t *testing.T) {
+	// Cached [A, B] and request [A, B-retained, B-retained-duplicate]: the two
+	// retained B candidates are both viable and both thinking-bearing, so the
+	// per-turn match is ambiguous and must fail closed.
+	assistant := []gjson.Result{
+		gjson.Parse(`[{"type":"thinking","thinking":"ra","signature":"sig-a"},{"type":"text","text":"A"}]`),
+		gjson.Parse(`[{"type":"thinking","thinking":"rb","signature":"sig-b-1"},{"type":"text","text":"B"}]`),
+		gjson.Parse(`[{"type":"thinking","thinking":"rb","signature":"sig-b-2"},{"type":"text","text":"B"}]`),
+	}
+	cached := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"ra","signature":"sig-a"},{"type":"text","text":"A"}]`),
+		[]byte(`[{"type":"thinking","thinking":"rb","signature":"sig-b"},{"type":"text","text":"B"}]`),
+	}
+	if got, _ := helps.ClaudeThinkingReplayFindStartIndex(assistant, cached); got != -1 {
+		t.Fatalf("expected -1 for multiple retained candidates, got %d", got)
+	}
+}
+
+func TestClaudeThinkingReplayAssistantMessageHash_IgnoresToolProvenance(t *testing.T) {
+	const (
+		modelFamily = "claude:test"
+		callerHash  = "caller"
+	)
+
+	base := []byte(`[{"type":"thinking","thinking":"r","signature":"EgI="},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"},"signature":"sig-a","thoughtSignature":"tsig-a","extra_content":{"google":{"thought_signature":"esig-a"}}}]`)
+	echo := []byte(`[{"type":"thinking","thinking":"r","signature":"EgI="},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"},"signature":"sig-b","thoughtSignature":"tsig-b","extra_content":{"google":{"thought_signature":"esig-b"}}}]`)
+
+	h1 := helps.ClaudeThinkingReplayAssistantMessageHash(modelFamily, callerHash, base)
+	h2 := helps.ClaudeThinkingReplayAssistantMessageHash(modelFamily, callerHash, echo)
+	if h1 == "" || h2 == "" {
+		t.Fatal("hash should not be empty")
+	}
+	if h1 != h2 {
+		t.Fatalf("tool-use provenance changed the alias hash: %q vs %q", h1, h2)
+	}
+
+	// A different tool input should still produce a different hash.
+	different := []byte(`[{"type":"thinking","thinking":"r","signature":"EgI="},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"OTHER.md"},"signature":"sig-b","thoughtSignature":"tsig-b"}]`)
+	h3 := helps.ClaudeThinkingReplayAssistantMessageHash(modelFamily, callerHash, different)
+	if h3 == h1 {
+		t.Fatalf("different tool input produced same hash: %s", h3)
+	}
+}
+
+func TestRestoreClaudeThinkingReplayContents_RejectDuplicateRequestSideAnchors(t *testing.T) {
+	// A cached signed turn followed by an uncached unsigned duplicate with the
+	// same visible content must not have its signature injected into the later
+	// unsigned turn. The earlier retained turn should keep its signature.
+	body := []byte(`{"messages":[{"role":"user","content":"u"},{"role":"assistant","content":[{"type":"thinking","thinking":"r","signature":"sig"},{"type":"text","text":"A"}]},{"role":"assistant","content":[{"type":"text","text":"A"}]},{"role":"user","content":"u2"}]}`)
+	cached := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"r","signature":"sig"},{"type":"text","text":"A"}]`),
+	}
+
+	updated, _ := helps.RestoreClaudeThinkingReplayContents(body, cached)
+	first := gjson.GetBytes(updated, "messages.1.content").Array()
+	second := gjson.GetBytes(updated, "messages.2.content").Array()
+	if first[0].Get("signature").String() != "sig" {
+		t.Fatalf("first retained turn should keep cached signature, got %s", first[0].Get("signature").String())
+	}
+	if second[0].Get("signature").String() != "" {
+		t.Fatalf("later unsigned duplicate should not receive cached signature, got %s", second[0].Get("signature").String())
+	}
+}
+
+func TestRestoreClaudeThinkingReplayContents_RejectDuplicateAnchorsInMultiTurnSuffix(t *testing.T) {
+	// A cached [A, B] with duplicate visible A in the request (both unsigned)
+	// must not restore A's signature onto the later unsigned A. The match for
+	// the ambiguous A should fail and the algorithm should fall back to a
+	// length-1 suffix restoring only B.
+	body := []byte(`{"messages":[{"role":"user","content":"u1"},{"role":"assistant","content":[{"type":"text","text":"A"}]},{"role":"user","content":"u2"},{"role":"assistant","content":[{"type":"text","text":"A"}]},{"role":"user","content":"u3"},{"role":"assistant","content":[{"type":"text","text":"B"}]},{"role":"user","content":"u4"}]}`)
+	cached := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"a","signature":"sig-a"},{"type":"text","text":"A"}]`),
+		[]byte(`[{"type":"thinking","thinking":"b","signature":"sig-b"},{"type":"text","text":"B"}]`),
+	}
+
+	updated, restored := helps.RestoreClaudeThinkingReplayContents(body, cached)
+	if !restored {
+		t.Fatal("expected restore for unambiguous B suffix")
+	}
+
+	first := gjson.GetBytes(updated, "messages.1.content").Array()
+	duplicate := gjson.GetBytes(updated, "messages.3.content").Array()
+	last := gjson.GetBytes(updated, "messages.5.content").Array()
+
+	if first[0].Get("signature").String() != "" {
+		t.Fatalf("first A should remain unsigned: %s", first[0].Get("signature").String())
+	}
+	if duplicate[0].Get("signature").String() != "" {
+		t.Fatalf("duplicate A should not receive cached A signature: %s", duplicate[0].Get("signature").String())
+	}
+	if last[0].Get("signature").String() != "sig-b" {
+		t.Fatalf("B should be restored from latest cached suffix, got %s", last[0].Get("signature").String())
+	}
+}
+
+func TestClaudeThinkingReplayAssistantMessageHash_NormalizesStringShorthand(t *testing.T) {
+	modelFamily := "claude:test"
+	callerHash := "caller"
+	strHash := helps.ClaudeThinkingReplayAssistantMessageHash(modelFamily, callerHash, []byte(`"answer"`))
+	arrHash := helps.ClaudeThinkingReplayAssistantMessageHash(modelFamily, callerHash, []byte(`[{"type":"text","text":"answer"}]`))
+	if strHash == "" || arrHash == "" {
+		t.Fatalf("string shorthand or array form produced empty hash")
+	}
+	if strHash != arrHash {
+		t.Fatalf("string shorthand %q must match array form %q", strHash, arrHash)
+	}
+}
+
+func TestClaudeThinkingReplayCallerHash_IgnoresWhitespaceOnlyHeaders(t *testing.T) {
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+	payload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	req := cliproxyexecutor.Request{Payload: payload}
+
+	withWhitespace := helps.ClaudeThinkingReplayCallerHash(auth, req, cliproxyexecutor.Options{
+		Headers: http.Header{
+			"User-Agent":        []string{"client/1.0"},
+			"X-App":             []string{"   "},
+			"X-Codex-Client-Id": []string{"\t\n"},
+		},
+	})
+	withoutWhitespace := helps.ClaudeThinkingReplayCallerHash(auth, req, cliproxyexecutor.Options{
+		Headers: http.Header{
+			"User-Agent": []string{"client/1.0"},
+		},
+	})
+
+	if withWhitespace != withoutWhitespace {
+		t.Fatalf("whitespace-only headers changed caller hash: %q vs %q", withWhitespace, withoutWhitespace)
+	}
+}
 
 func claudeReplayTestAuth(baseURL string) *cliproxyauth.Auth {
 	return &cliproxyauth.Auth{
@@ -266,6 +615,147 @@ func claudeReplayThinkingStream() string {
 		"data: {\"type\":\"message_stop\"}\n\n"
 }
 
+func TestClaudeExecutorCompatThinkingReplayRestoresBeforeMCPToolNameRemap(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			// The upstream tool name is the alias; echo it back so the cache stores
+			// the caller-facing name after restoreClaudeOAuthToolNamesFromResponse.
+			aliasName := gjson.GetBytes(body, "tools.0.name").String()
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"tool_use","id":"toolu_1","name":"` + aliasName + `","input":{"path":"README.md"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	auth.Attributes["fingerprint_profile"] = "claude-code-cli"
+
+	tools := `[{"name":"my_tool","input_schema":{"type":"object"}}]`
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"call my_tool"}],"tools":` + tools + `}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "mcp-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error = %v", errExecute)
+	}
+
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"call my_tool"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"my_tool","input":{"path":"README.md"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}],"tools":` + tools + `}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "mcp-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error = %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+
+	secondContent := gjson.GetBytes(requestBodies[1], "messages.1.content").Array()
+	if len(secondContent) != 2 {
+		t.Fatalf("second assistant content = %s, want thinking and tool_use", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
+	}
+	if got := secondContent[0].Get("type").String(); got != "thinking" {
+		t.Fatalf("restored first content type = %q, want thinking", got)
+	}
+	if got := secondContent[0].Get("signature").String(); got != "EgI=" {
+		t.Fatalf("restored signature = %q, want EgI=", got)
+	}
+
+	// The restored tool_use name must be remapped for upstream, matching the
+	// alias in the second request's tools array.
+	secondToolName := gjson.GetBytes(requestBodies[1], "tools.0.name").String()
+	if secondToolName == "" || secondToolName == "my_tool" {
+		t.Fatalf("second request tool name was not aliased: %q", secondToolName)
+	}
+	if got := secondContent[1].Get("name").String(); got != secondToolName {
+		t.Fatalf("restored tool_use name = %q, want alias %q", got, secondToolName)
+	}
+}
+
+func TestClaudeExecutorCompatThinkingReplayRestoresOmittedThinkingWithToolProvenance(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			// Upstream returns a tool_use carrying provenance fields the sanitizer
+			// would strip before the replay match if the cached parts were not
+			// normalized.
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"},"signature":"bad","thoughtSignature":"bad","extra_content":{"google":{"thought_signature":"bad"}},"model":"claude-synthetic-4772"}],"stop_reason":"tool_use"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"inspect"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "tool-provenance-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error = %v", errExecute)
+	}
+
+	// Client echoes the previous assistant's tool_use, including the provenance
+	// fields it received from the translated response.
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"inspect"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"},"signature":"bad","thoughtSignature":"bad","extra_content":{"google":{"thought_signature":"bad"}},"model":"claude-synthetic-4772"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}]}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "tool-provenance-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error = %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	content := gjson.GetBytes(requestBodies[1], "messages.1.content").Array()
+	if len(content) != 2 {
+		t.Fatalf("second assistant content = %s, want thinking and tool_use", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
+	}
+	if got := content[0].Get("type").String(); got != "thinking" {
+		t.Fatalf("restored first content type = %q, want thinking", got)
+	}
+	if got := content[0].Get("signature").String(); got != "EgI=" {
+		t.Fatalf("restored signature = %q, want EgI=", got)
+	}
+	if got := content[1].Get("signature").String(); got != "" {
+		t.Fatalf("restored tool_use still carried a signature: %q", got)
+	}
+}
+
 func TestClaudeExecutorCompatThinkingReplayClearsAfterUpstreamBadRequest(t *testing.T) {
 	internalcacheClearClaudeThinkingReplay(t)
 
@@ -367,8 +857,1127 @@ func TestClaudeExecutorCompatThinkingReplayRestoresMultipleOmittedBlocks(t *test
 	}
 }
 
+func TestClaudeExecutorCompatThinkingReplayRestoresOpaqueOmittedBlock(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	opaque := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	opaqueSig := base64.StdEncoding.EncodeToString(opaque)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"` + opaqueSig + `"},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"inspect"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "opaque-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error = %v", errExecute)
+	}
+
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"inspect"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}]}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "opaque-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error = %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	content := gjson.GetBytes(requestBodies[1], "messages.1.content").Array()
+	if len(content) != 2 {
+		t.Fatalf("second assistant content = %s, want thinking and tool_use", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
+	}
+	if got := content[0].Get("type").String(); got != "thinking" {
+		t.Fatalf("restored first content type = %q, want thinking", got)
+	}
+	if got := content[0].Get("signature").String(); got != opaqueSig {
+		t.Fatalf("restored opaque signature = %q, want %q", got, opaqueSig)
+	}
+}
+
+func TestClaudeExecutorCompatThinkingReplayRestoresEchoedSignedThinking(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	opaque := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	opaqueSig := base64.StdEncoding.EncodeToString(opaque)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"` + opaqueSig + `"},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"inspect"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "echoed-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error = %v", errExecute)
+	}
+
+	// Client echoes the complete assistant content, including the signed thinking
+	// block. The sanitizer will clear the opaque signature; the replay cache must
+	// restore the original signed content.
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"inspect"},{"role":"assistant","content":[{"type":"thinking","thinking":"provider reasoning","signature":"` + opaqueSig + `"},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}]}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "echoed-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error = %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	content := gjson.GetBytes(requestBodies[1], "messages.1.content").Array()
+	if len(content) != 2 {
+		t.Fatalf("second assistant content = %s, want thinking and tool_use", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
+	}
+	if got := content[0].Get("type").String(); got != "thinking" {
+		t.Fatalf("restored first content type = %q, want thinking", got)
+	}
+	if got := content[0].Get("signature").String(); got != opaqueSig {
+		t.Fatalf("restored opaque signature = %q, want %q", got, opaqueSig)
+	}
+}
+
+func TestClaudeExecutorCompatThinkingReplayRestoresSessionlessSameUpstreamSignature(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	opaque := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	opaqueSig := base64.StdEncoding.EncodeToString(opaque)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"` + opaqueSig + `"},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	firstRequest, firstOptions := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"inspect"}]}`), "", true, sdktranslator.FormatClaude)
+	firstRequest.Payload = claudeReplayPayloadWithConversationID(firstRequest.Payload, "sessionless-inspect")
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error = %v", errExecute)
+	}
+
+	// Sessionless client echoes the assistant turn without execution session metadata.
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"inspect"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}]}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "", true, sdktranslator.FormatClaude)
+	secondRequest.Payload = claudeReplayPayloadWithConversationID(secondRequest.Payload, "sessionless-inspect")
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error = %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	content := gjson.GetBytes(requestBodies[1], "messages.1.content").Array()
+	if len(content) != 2 {
+		t.Fatalf("second assistant content = %s, want thinking and tool_use", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
+	}
+	if got := content[0].Get("type").String(); got != "thinking" {
+		t.Fatalf("restored first content type = %q, want thinking", got)
+	}
+	if got := content[0].Get("signature").String(); got != opaqueSig {
+		t.Fatalf("sessionless restored signature = %q, want %q", got, opaqueSig)
+	}
+}
+
+func TestClaudeExecutorCompatThinkingReplayIsConversationScopedForSessionlessClients(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	opaqueA := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	opaqueSigA := base64.StdEncoding.EncodeToString(opaqueA)
+	opaqueB := bytes.Repeat([]byte{0x12, 0x99, 0x99, 0x99, 0x22, 0x33, 0x44, 0x55}, 4)
+	opaqueSigB := base64.StdEncoding.EncodeToString(opaqueB)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning A","signature":"` + opaqueSigA + `"},{"type":"tool_use","id":"toolu_A","name":"Read","input":{"path":"A"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		if call == 2 {
+			_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning B","signature":"` + opaqueSigB + `"},{"type":"tool_use","id":"toolu_B","name":"Read","input":{"path":"B"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-3","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+
+	// Conversation A first turn, no session metadata.
+	firstAReq, firstAOpts := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"task A"}]}`), "", true, sdktranslator.FormatClaude)
+	firstAReq.Payload = claudeReplayPayloadWithConversationID(firstAReq.Payload, "conv-A")
+	if _, errExecute := executor.Execute(context.Background(), auth, firstAReq, firstAOpts); errExecute != nil {
+		t.Fatalf("conversation A first Execute() error = %v", errExecute)
+	}
+
+	// Conversation B first turn, same credential, different first user content.
+	firstBReq, firstBOpts := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"task B"}]}`), "", true, sdktranslator.FormatClaude)
+	firstBReq.Payload = claudeReplayPayloadWithConversationID(firstBReq.Payload, "conv-B")
+	if _, errExecute := executor.Execute(context.Background(), auth, firstBReq, firstBOpts); errExecute != nil {
+		t.Fatalf("conversation B first Execute() error = %v", errExecute)
+	}
+
+	// Conversation A second turn: same first message, so it must restore sigA.
+	secondAReq, secondAOpts := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"task A"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_A","name":"Read","input":{"path":"A"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_A","content":"ok"}]}]}`), "", true, sdktranslator.FormatClaude)
+	secondAReq.Payload = claudeReplayPayloadWithConversationID(secondAReq.Payload, "conv-A")
+	if _, errExecute := executor.Execute(context.Background(), auth, secondAReq, secondAOpts); errExecute != nil {
+		t.Fatalf("conversation A second Execute() error = %v", errExecute)
+	}
+
+	// Conversation B second turn: same conversation as B, must restore sigB.
+	secondBReq, secondBOpts := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"task B"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_B","name":"Read","input":{"path":"B"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_B","content":"ok"}]}]}`), "", true, sdktranslator.FormatClaude)
+	secondBReq.Payload = claudeReplayPayloadWithConversationID(secondBReq.Payload, "conv-B")
+	if _, errExecute := executor.Execute(context.Background(), auth, secondBReq, secondBOpts); errExecute != nil {
+		t.Fatalf("conversation B second Execute() error = %v", errExecute)
+	}
+
+	// Conversation B third turn: uses the same assistant content as conversation A.
+	// Because the first user message differs, the cache for conversation B must not
+	// contain conversation A's signature, so the previous assistant signature is
+	// not restored.
+	thirdBReq, thirdBOpts := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"task B"},{"role":"assistant","content":[{"type":"thinking","thinking":"provider reasoning A","signature":"`+opaqueSigA+`"},{"type":"tool_use","id":"toolu_A","name":"Read","input":{"path":"A"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_A","content":"ok"}]}]}`), "", true, sdktranslator.FormatClaude)
+	thirdBReq.Payload = claudeReplayPayloadWithConversationID(thirdBReq.Payload, "conv-B")
+	if _, errExecute := executor.Execute(context.Background(), auth, thirdBReq, thirdBOpts); errExecute != nil {
+		t.Fatalf("conversation B third Execute() error = %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 5 {
+		t.Fatalf("upstream request count = %d, want 5", len(requestBodies))
+	}
+
+	aContent := gjson.GetBytes(requestBodies[2], "messages.1.content").Array()
+	if aContent[0].Get("signature").String() != opaqueSigA {
+		t.Fatalf("conversation A did not restore its own signature: %s", aContent[0].Get("signature").String())
+	}
+
+	bContent := gjson.GetBytes(requestBodies[3], "messages.1.content").Array()
+	if bContent[0].Get("signature").String() != opaqueSigB {
+		t.Fatalf("conversation B did not restore its own signature: %s", bContent[0].Get("signature").String())
+	}
+
+	leakContent := gjson.GetBytes(requestBodies[4], "messages.1.content").Array()
+	if leakContent[0].Get("signature").String() != "" {
+		t.Fatalf("conversation B leaked conversation A's signature: %s", leakContent[0].Get("signature").String())
+	}
+}
+
+func TestClaudeExecutorCompatThinkingReplayIsCallerScopedForSessionlessClients(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	opaqueA := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	opaqueSigA := base64.StdEncoding.EncodeToString(opaqueA)
+	opaqueB := bytes.Repeat([]byte{0x12, 0x99, 0x99, 0x99, 0x22, 0x33, 0x44, 0x55}, 4)
+	opaqueSigB := base64.StdEncoding.EncodeToString(opaqueB)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"` + opaqueSigA + `"},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"one"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		if call == 2 {
+			_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"` + opaqueSigB + `"},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"one"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-3","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	basePayload := []byte(`{"messages":[{"role":"user","content":"same task"}]}`)
+
+	// Caller A: first turn.
+	aReq, aOpts := claudeReplayTestRequest(basePayload, "", true, sdktranslator.FormatClaude)
+	aReq.Payload = claudeReplayPayloadWithConversationID(aReq.Payload, "caller-scoped")
+	aOpts.Headers = http.Header{"User-Agent": []string{"client-A"}}
+	if _, errExecute := executor.Execute(context.Background(), auth, aReq, aOpts); errExecute != nil {
+		t.Fatalf("caller A first Execute() error = %v", errExecute)
+	}
+
+	// Caller B: same credential, same first message, different caller signal.
+	bReq, bOpts := claudeReplayTestRequest(basePayload, "", true, sdktranslator.FormatClaude)
+	bReq.Payload = claudeReplayPayloadWithConversationID(bReq.Payload, "caller-scoped")
+	bOpts.Headers = http.Header{"User-Agent": []string{"client-B"}}
+	if _, errExecute := executor.Execute(context.Background(), auth, bReq, bOpts); errExecute != nil {
+		t.Fatalf("caller B first Execute() error = %v", errExecute)
+	}
+
+	// Caller A second turn: same User-Agent, must restore sigA.
+	a2Payload := []byte(`{"messages":[{"role":"user","content":"same task"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"one"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}]}`)
+	a2Req, a2Opts := claudeReplayTestRequest(a2Payload, "", true, sdktranslator.FormatClaude)
+	a2Req.Payload = claudeReplayPayloadWithConversationID(a2Req.Payload, "caller-scoped")
+	a2Opts.Headers = http.Header{"User-Agent": []string{"client-A"}}
+	if _, errExecute := executor.Execute(context.Background(), auth, a2Req, a2Opts); errExecute != nil {
+		t.Fatalf("caller A second Execute() error = %v", errExecute)
+	}
+
+	// Caller B second turn: same User-Agent, must restore sigB (not sigA).
+	b2Req, b2Opts := claudeReplayTestRequest(a2Payload, "", true, sdktranslator.FormatClaude)
+	b2Req.Payload = claudeReplayPayloadWithConversationID(b2Req.Payload, "caller-scoped")
+	b2Opts.Headers = http.Header{"User-Agent": []string{"client-B"}}
+	if _, errExecute := executor.Execute(context.Background(), auth, b2Req, b2Opts); errExecute != nil {
+		t.Fatalf("caller B second Execute() error = %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 4 {
+		t.Fatalf("upstream request count = %d, want 4", len(requestBodies))
+	}
+
+	aContent := gjson.GetBytes(requestBodies[2], "messages.1.content").Array()
+	if aContent[0].Get("signature").String() != opaqueSigA {
+		t.Fatalf("caller A did not restore its own signature: %s", aContent[0].Get("signature").String())
+	}
+
+	bContent := gjson.GetBytes(requestBodies[3], "messages.1.content").Array()
+	if bContent[0].Get("signature").String() != opaqueSigB {
+		t.Fatalf("caller B did not restore its own signature or leaked caller A's: %s", bContent[0].Get("signature").String())
+	}
+}
+
+func TestClaudeExecutorCompatThinkingReplayIdenticalOpeningsUseConversationNonce(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	opaqueA := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	opaqueSigA := base64.StdEncoding.EncodeToString(opaqueA)
+	opaqueB := bytes.Repeat([]byte{0x12, 0x99, 0x99, 0x99, 0x22, 0x33, 0x44, 0x55}, 4)
+	opaqueSigB := base64.StdEncoding.EncodeToString(opaqueB)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning A","signature":"` + opaqueSigA + `"},{"type":"tool_use","id":"toolu_A","name":"Read","input":{"path":"A"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		if call == 2 {
+			_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning B","signature":"` + opaqueSigB + `"},{"type":"tool_use","id":"toolu_A","name":"Read","input":{"path":"A"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-3","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	basePayload := []byte(`{"messages":[{"role":"user","content":"same task"}]}`)
+
+	// Conversation A starts with the same first message and same caller context
+	// as conversation B, but uses a different conversation nonce.
+	aReq, aOpts := claudeReplayTestRequest(basePayload, "", true, sdktranslator.FormatClaude)
+	aReq.Payload = claudeReplayPayloadWithConversationID(aReq.Payload, "conv-identical-A")
+	if _, errExecute := executor.Execute(context.Background(), auth, aReq, aOpts); errExecute != nil {
+		t.Fatalf("conversation A first Execute() error = %v", errExecute)
+	}
+
+	bReq, bOpts := claudeReplayTestRequest(basePayload, "", true, sdktranslator.FormatClaude)
+	bReq.Payload = claudeReplayPayloadWithConversationID(bReq.Payload, "conv-identical-B")
+	if _, errExecute := executor.Execute(context.Background(), auth, bReq, bOpts); errExecute != nil {
+		t.Fatalf("conversation B first Execute() error = %v", errExecute)
+	}
+
+	// Each conversation continues with the echoed assistant turn. The nonces keep
+	// the caches distinct, so A restores sigA and B restores sigB.
+	continuation := []byte(`{"messages":[{"role":"user","content":"same task"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_A","name":"Read","input":{"path":"A"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_A","content":"ok"}]}]}`)
+	a2Req, a2Opts := claudeReplayTestRequest(continuation, "", true, sdktranslator.FormatClaude)
+	a2Req.Payload = claudeReplayPayloadWithConversationID(a2Req.Payload, "conv-identical-A")
+	if _, errExecute := executor.Execute(context.Background(), auth, a2Req, a2Opts); errExecute != nil {
+		t.Fatalf("conversation A second Execute() error = %v", errExecute)
+	}
+
+	b2Req, b2Opts := claudeReplayTestRequest(continuation, "", true, sdktranslator.FormatClaude)
+	b2Req.Payload = claudeReplayPayloadWithConversationID(b2Req.Payload, "conv-identical-B")
+	if _, errExecute := executor.Execute(context.Background(), auth, b2Req, b2Opts); errExecute != nil {
+		t.Fatalf("conversation B second Execute() error = %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 4 {
+		t.Fatalf("upstream request count = %d, want 4", len(requestBodies))
+	}
+
+	aContent := gjson.GetBytes(requestBodies[2], "messages.1.content").Array()
+	if aContent[0].Get("signature").String() != opaqueSigA {
+		t.Fatalf("conversation A did not restore its own signature: %s", aContent[0].Get("signature").String())
+	}
+
+	bContent := gjson.GetBytes(requestBodies[3], "messages.1.content").Array()
+	if bContent[0].Get("signature").String() != opaqueSigB {
+		t.Fatalf("conversation B did not restore its own signature or leaked A's: %s", bContent[0].Get("signature").String())
+	}
+}
+
+func TestClaudeExecutorCompatThinkingReplayRestoresSignedNonToolResponse(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			// Upstream returns a signed thinking block followed by a plain text
+			// answer with no tool_use. This must be cached and restored on the
+			// next user turn.
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"text","text":"The answer is 42"}],"stop_reason":"end_turn"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"what is the answer"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "nonstream-replay-non-tool", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error: %v", errExecute)
+	}
+
+	// Client echoes the assistant's text block without the thinking part.
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"what is the answer"},{"role":"assistant","content":[{"type":"text","text":"The answer is 42"}]},{"role":"user","content":"thanks"}]}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "nonstream-replay-non-tool", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error: %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	content := gjson.GetBytes(requestBodies[1], "messages.1.content").Array()
+	if len(content) != 2 || content[0].Get("type").String() != "thinking" {
+		t.Fatalf("second assistant content = %s, want restored thinking and text", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
+	}
+	if got := content[0].Get("signature").String(); got != "EgI=" {
+		t.Fatalf("restored signature = %q, want EgI=", got)
+	}
+}
+
+func TestClaudeExecutorCompatThinkingReplayRestoresAfterSensitiveWordObfuscation(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"text","text":"the secret answer"}],"stop_reason":"end_turn"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	auth := claudeReplayTestAuth(server.URL)
+	auth.Attributes["cloak_mode"] = "always"
+	auth.Attributes["cloak_sensitive_words"] = "secret"
+
+	executor := NewClaudeExecutor(nil)
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"what is the secret"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "obfuscate-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error: %v", errExecute)
+	}
+
+	// Client echoes the assistant's text, which contains the sensitive word.
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"what is the secret"},{"role":"assistant","content":[{"type":"text","text":"the secret answer"}]},{"role":"user","content":"thanks"}]}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "obfuscate-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error: %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	content := gjson.GetBytes(requestBodies[1], "messages.1.content").Array()
+	if len(content) != 2 || content[0].Get("type").String() != "thinking" {
+		t.Fatalf("second assistant content = %s, want restored thinking and text", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
+	}
+	if got := content[0].Get("signature").String(); got != "EgI=" {
+		t.Fatalf("restored signature = %q, want EgI=", got)
+	}
+	text := content[1].Get("text").String()
+	if text == "the secret answer" {
+		t.Fatalf("sensitive word not obfuscated in restored text: %q", text)
+	}
+}
+
+func TestClaudeExecutorCompatThinkingReplaySkipsObfuscationWhenCloakingDisabled(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"text","text":"the secret answer"}],"stop_reason":"end_turn"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	auth := claudeReplayTestAuth(server.URL)
+	auth.Attributes["cloak_mode"] = "never"
+	auth.Attributes["cloak_sensitive_words"] = "secret"
+
+	executor := NewClaudeExecutor(nil)
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"what is the secret"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "obfuscate-replay-disabled", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error: %v", errExecute)
+	}
+
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"what is the secret"},{"role":"assistant","content":[{"type":"text","text":"the secret answer"}]},{"role":"user","content":"thanks"}]}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "obfuscate-replay-disabled", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error: %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	content := gjson.GetBytes(requestBodies[1], "messages.1.content").Array()
+	if len(content) != 2 || content[0].Get("type").String() != "thinking" {
+		t.Fatalf("second assistant content = %s, want restored thinking and text", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
+	}
+	if got := content[0].Get("signature").String(); got != "EgI=" {
+		t.Fatalf("restored signature = %q, want EgI=", got)
+	}
+	text := content[1].Get("text").String()
+	if text != "the secret answer" {
+		t.Fatalf("sensitive word incorrectly obfuscated when cloaking disabled: %q", text)
+	}
+}
+
+func TestRestoreClaudeThinkingReplayContents_MatchesDuplicateTurnsInChronologicalOrder(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"text","text":"same"}]},{"role":"user","content":"again"},{"role":"assistant","content":[{"type":"text","text":"same"}]}]}`)
+	cached := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"first","signature":"sig-1"},{"type":"text","text":"same"}]`),
+		[]byte(`[{"type":"thinking","thinking":"second","signature":"sig-2"},{"type":"text","text":"same"}]`),
+	}
+
+	updated, restored := helps.RestoreClaudeThinkingReplayContents(body, cached)
+	if !restored {
+		t.Fatal("expected restore")
+	}
+
+	first := gjson.GetBytes(updated, "messages.1.content").Array()
+	if first[0].Get("signature").String() != "sig-1" {
+		t.Fatalf("first turn matched wrong signature: %s", first[0].Get("signature").String())
+	}
+
+	second := gjson.GetBytes(updated, "messages.3.content").Array()
+	if second[0].Get("signature").String() != "sig-2" {
+		t.Fatalf("second turn matched wrong signature: %s", second[0].Get("signature").String())
+	}
+}
+
+func TestClaudeExecutorCompatThinkingReplayRetainsSignedTurnAfterUnsignedResponse(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"text","text":"signed answer"}],"stop_reason":"end_turn"}`))
+			return
+		}
+		if call == 2 {
+			_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"unsigned follow-up"}],"stop_reason":"end_turn"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-3","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	auth := claudeReplayTestAuth(server.URL)
+	executor := NewClaudeExecutor(nil)
+
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"first"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "retain-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error: %v", errExecute)
+	}
+
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"first"},{"role":"assistant","content":[{"type":"text","text":"signed answer"}]},{"role":"user","content":"second"}]}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "retain-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error: %v", errExecute)
+	}
+
+	thirdPayload := []byte(`{"messages":[{"role":"user","content":"first"},{"role":"assistant","content":[{"type":"text","text":"signed answer"}]},{"role":"user","content":"second"},{"role":"assistant","content":[{"type":"text","text":"unsigned follow-up"}]},{"role":"user","content":"third"}]}`)
+	thirdRequest, thirdOptions := claudeReplayTestRequest(thirdPayload, "retain-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, thirdRequest, thirdOptions); errExecute != nil {
+		t.Fatalf("third Execute() error: %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 3 {
+		t.Fatalf("upstream request count = %d, want 3", len(requestBodies))
+	}
+	firstAssistant := gjson.GetBytes(requestBodies[2], "messages.1.content").Array()
+	if firstAssistant[0].Get("signature").String() != "EgI=" {
+		t.Fatalf("first signed turn not replayed after unsigned response: %s", gjson.GetBytes(requestBodies[2], "messages.1.content").Raw)
+	}
+	secondAssistant := gjson.GetBytes(requestBodies[2], "messages.3.content").Array()
+	if len(secondAssistant) != 1 || secondAssistant[0].Get("text").String() != "unsigned follow-up" {
+		t.Fatalf("second assistant content changed unexpectedly: %s", gjson.GetBytes(requestBodies[2], "messages.3.content").Raw)
+	}
+}
+
+func TestRestoreClaudeThinkingReplayContents_AlignsAfterTruncatedHistory(t *testing.T) {
+	// Client drops the first assistant turn. The remaining sequence is a suffix
+	// of the conversation, so the first echoed assistant should align with the
+	// second cached turn, not the oldest one.
+	body := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"user","content":"continue"},{"role":"assistant","content":[{"type":"text","text":"second"}]},{"role":"user","content":"again"},{"role":"assistant","content":[{"type":"text","text":"third"}]},{"role":"user","content":"final"}]}`)
+	cached := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"first","signature":"sig-1"},{"type":"text","text":"first"}]`),
+		[]byte(`[{"type":"thinking","thinking":"second","signature":"sig-2"},{"type":"text","text":"second"}]`),
+		[]byte(`[{"type":"thinking","thinking":"third","signature":"sig-3"},{"type":"text","text":"third"}]`),
+	}
+
+	updated, restored := helps.RestoreClaudeThinkingReplayContents(body, cached)
+	if !restored {
+		t.Fatal("expected restore")
+	}
+
+	first := gjson.GetBytes(updated, "messages.2.content").Array()
+	if first[0].Get("signature").String() != "sig-2" {
+		t.Fatalf("first retained assistant matched wrong signature: %s", first[0].Get("signature").String())
+	}
+
+	second := gjson.GetBytes(updated, "messages.4.content").Array()
+	if second[0].Get("signature").String() != "sig-3" {
+		t.Fatalf("second retained assistant matched wrong signature: %s", second[0].Get("signature").String())
+	}
+
+	// The dropped first turn must not leak into the retained assistants.
+	if first[0].Get("thinking").String() == "first" || second[0].Get("thinking").String() == "first" {
+		t.Fatalf("dropped first turn leaked into retained assistants: %s", gjson.GetBytes(updated, "messages").Raw)
+	}
+}
+
+func TestRestoreClaudeThinkingReplayContents_SkipsUnsignedLeadingAssistant(t *testing.T) {
+	// Client dropped the first signed assistant and the leading assistant in the
+	// request is an unsigned new turn. No cached entry matches it, so matching
+	// must not start from an older cached turn and the later signed assistant
+	// should still align correctly.
+	body := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"text","text":"new unsigned"}]},{"role":"user","content":"again"},{"role":"assistant","content":[{"type":"text","text":"second"}]},{"role":"user","content":"final"}]}`)
+	cached := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"first","signature":"sig-1"},{"type":"text","text":"first"}]`),
+		[]byte(`[{"type":"thinking","thinking":"second","signature":"sig-2"},{"type":"text","text":"second"}]`),
+	}
+
+	updated, restored := helps.RestoreClaudeThinkingReplayContents(body, cached)
+	if !restored {
+		t.Fatal("expected restore")
+	}
+
+	unsigned := gjson.GetBytes(updated, "messages.1.content").Array()
+	if len(unsigned) != 1 || unsigned[0].Get("text").String() != "new unsigned" {
+		t.Fatalf("unsigned leading assistant content unexpectedly changed: %s", gjson.GetBytes(updated, "messages.1.content").Raw)
+	}
+
+	second := gjson.GetBytes(updated, "messages.3.content").Array()
+	if second[0].Get("signature").String() != "sig-2" {
+		t.Fatalf("later signed assistant matched wrong signature: %s", second[0].Get("signature").String())
+	}
+
+	if second[0].Get("thinking").String() == "first" {
+		t.Fatalf("dropped first signed turn leaked into later assistant: %s", gjson.GetBytes(updated, "messages.3.content").Raw)
+	}
+}
+
+func TestRestoreClaudeThinkingReplayContents_AnchorsDuplicateSuffixAfterTruncation(t *testing.T) {
+	// Client dropped an older signed turn whose visible content is identical to
+	// the first retained assistant. The retained duplicate must receive the
+	// newer cached thinking/signature, not the older one.
+	body := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"user","content":"continue"},{"role":"assistant","content":[{"type":"text","text":"same"}]},{"role":"user","content":"again"},{"role":"assistant","content":[{"type":"text","text":"different"}]},{"role":"user","content":"final"}]}`)
+	cached := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"old","signature":"sig-old"},{"type":"text","text":"same"}]`),
+		[]byte(`[{"type":"thinking","thinking":"new","signature":"sig-new"},{"type":"text","text":"same"}]`),
+		[]byte(`[{"type":"thinking","thinking":"other","signature":"sig-other"},{"type":"text","text":"different"}]`),
+	}
+
+	updated, restored := helps.RestoreClaudeThinkingReplayContents(body, cached)
+	if !restored {
+		t.Fatal("expected restore")
+	}
+
+	first := gjson.GetBytes(updated, "messages.2.content").Array()
+	if first[0].Get("signature").String() != "sig-new" {
+		t.Fatalf("first retained duplicate matched wrong signature: %s", first[0].Get("signature").String())
+	}
+
+	second := gjson.GetBytes(updated, "messages.4.content").Array()
+	if second[0].Get("signature").String() != "sig-other" {
+		t.Fatalf("second retained assistant matched wrong signature: %s", second[0].Get("signature").String())
+	}
+
+	// The dropped older duplicate must not leak into the retained turns.
+	if first[0].Get("signature").String() == "sig-old" {
+		t.Fatalf("dropped older duplicate leaked into first retained assistant: %s", gjson.GetBytes(updated, "messages").Raw)
+	}
+}
+
+func TestRestoreClaudeThinkingReplayContents_NormalizesStringShorthand(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":"answer"}]}`)
+	cached := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"reasoning","signature":"sig"},{"type":"text","text":"answer"}]`),
+	}
+
+	updated, restored := helps.RestoreClaudeThinkingReplayContents(body, cached)
+	if !restored {
+		t.Fatal("expected restore for string shorthand assistant content")
+	}
+	content := gjson.GetBytes(updated, "messages.1.content").Array()
+	if content[0].Get("signature").String() != "sig" {
+		t.Fatalf("shorthand content not restored with signature: %s", content[0].Get("signature").String())
+	}
+	if content[1].Get("text").String() != "answer" {
+		t.Fatalf("shorthand text not preserved: %s", content[1].Get("text").String())
+	}
+}
+
+func TestClaudeExecutorCompatThinkingReplayRetainsScopeAfterHistoryCompaction(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"text","text":"compact answer"}],"stop_reason":"end_turn"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	auth := claudeReplayTestAuth(server.URL)
+	executor := NewClaudeExecutor(nil)
+
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "compact-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error: %v", errExecute)
+	}
+
+	// Compacted follow-up: the first user message is removed, but the assistant
+	// turn that was just produced remains. The sessionless fallback scope must
+	// resolve to the original conversation through the assistant alias.
+	compactedPayload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"text","text":"compact answer"}]},{"role":"user","content":"next"}]}`)
+	compactedRequest, compactedOptions := claudeReplayTestRequest(compactedPayload, "compact-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, compactedRequest, compactedOptions); errExecute != nil {
+		t.Fatalf("compacted Execute() error: %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	assistant := gjson.GetBytes(requestBodies[1], "messages.0.content").Array()
+	if assistant[0].Get("signature").String() != "EgI=" {
+		t.Fatalf("compacted request did not resolve the original replay scope: %s", gjson.GetBytes(requestBodies[1], "messages.0.content").Raw)
+	}
+}
+
+func TestClaudeExecutorCompatThinkingReplayRetainsNoNonceScopeAfterHistoryCompaction(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"text","text":"compact answer"}],"stop_reason":"end_turn"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	auth := claudeReplayTestAuth(server.URL)
+	executor := NewClaudeExecutor(nil)
+
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error: %v", errExecute)
+	}
+
+	compactedPayload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"text","text":"compact answer"}]},{"role":"user","content":"next"}]}`)
+	compactedRequest, compactedOptions := claudeReplayTestRequest(compactedPayload, "", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, compactedRequest, compactedOptions); errExecute != nil {
+		t.Fatalf("compacted Execute() error: %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	assistant := gjson.GetBytes(requestBodies[1], "messages.0.content").Array()
+	if assistant[0].Get("signature").String() != "EgI=" {
+		t.Fatalf("compacted request did not resolve the no-nonce replay scope: %s", gjson.GetBytes(requestBodies[1], "messages.0.content").Raw)
+	}
+}
+
 func internalcacheClearClaudeThinkingReplay(t *testing.T) {
 	t.Helper()
 	internalcache.ClearClaudeThinkingReplayCache()
 	t.Cleanup(internalcache.ClearClaudeThinkingReplayCache)
+}
+
+func TestCacheClaudeThinkingReplayContent_DoesNotRegisterAliasOnFailedCacheWrite(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	ctx := context.Background()
+	const (
+		modelFamily   = "claude:test"
+		sessionKey    = "session-failed-alias"
+		callerHash    = "caller"
+		firstUserHash = "first"
+	)
+
+	content1 := []byte(`[{"type":"thinking","thinking":"r1","signature":"EgI="},{"type":"text","text":"answer one"}]`)
+	content2 := []byte(`[{"type":"thinking","thinking":"r2","signature":"EgI="},{"type":"text","text":"answer two"}]`)
+	hash1 := helps.ClaudeThinkingReplayAssistantMessageHash(modelFamily, callerHash, content1)
+	hash2 := helps.ClaudeThinkingReplayAssistantMessageHash(modelFamily, callerHash, content2)
+
+	_, snapshot, found, errGet := internalcache.GetClaudeThinkingReplayWithSnapshotIfExists(ctx, modelFamily, sessionKey)
+	if errGet != nil {
+		t.Fatalf("initial cache read: %v", errGet)
+	}
+	if found {
+		t.Fatal("initial cache should be empty")
+	}
+
+	scope := claudeThinkingReplayScope{
+		modelFamily:   modelFamily,
+		sessionKey:    sessionKey,
+		snapshot:      snapshot,
+		cacheReady:    true,
+		fallbackKey:   true,
+		callerHash:    callerHash,
+		firstUserHash: firstUserHash,
+	}
+
+	cacheClaudeThinkingReplayContent(ctx, scope, content1)
+	if resolved, ok := internalcache.ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, []internalcache.ClaudeThinkingReplayAliasMessage{{Hash: hash1, Weight: 1}}, firstUserHash); !ok || resolved != sessionKey {
+		t.Fatalf("first successful write should publish alias: ok=%v resolved=%q", ok, resolved)
+	}
+
+	// Re-using the same scope.snapshot after the first write is stale; the next
+	// cache write must fail CAS and the second response alias must not be
+	// published to a missing/failed replay record.
+	cacheClaudeThinkingReplayContent(ctx, scope, content2)
+	if resolved, ok := internalcache.ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, []internalcache.ClaudeThinkingReplayAliasMessage{{Hash: hash2, Weight: 1}}, firstUserHash); ok {
+		t.Fatalf("second alias should not be published after failed cache write, got %q", resolved)
+	}
+
+	// A fresh snapshot after the successful first write should allow the third
+	// response to be cached and its alias published.
+	_, snapshot2, _, errGet2 := internalcache.GetClaudeThinkingReplayWithSnapshotIfExists(ctx, modelFamily, sessionKey)
+	if errGet2 != nil {
+		t.Fatalf("fresh cache read: %v", errGet2)
+	}
+	scope.snapshot = snapshot2
+	content3 := []byte(`[{"type":"thinking","thinking":"r3","signature":"EgI="},{"type":"text","text":"answer three"}]`)
+	hash3 := helps.ClaudeThinkingReplayAssistantMessageHash(modelFamily, callerHash, content3)
+	cacheClaudeThinkingReplayContent(ctx, scope, content3)
+	if resolved, ok := internalcache.ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, []internalcache.ClaudeThinkingReplayAliasMessage{{Hash: hash3, Weight: 1}}, firstUserHash); !ok || resolved != sessionKey {
+		t.Fatalf("fresh-snapshot write should publish alias: ok=%v resolved=%q", ok, resolved)
+	}
+}
+
+func TestClaudeExecutorCompatThinkingReplayCrossFormatStream(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	opaque := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	opaqueSig := base64.StdEncoding.EncodeToString(opaque)
+
+	streamResponse := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_1","model":"claude-synthetic-4772"}}`,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"provider reasoning"}}`,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"` + opaqueSig + `"}}`,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"hello"}}`,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":1}`,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}`,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		if call == 1 {
+			_, _ = w.Write([]byte(streamResponse))
+			return
+		}
+		_, _ = w.Write([]byte(streamResponse))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	payload := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+	req, opts := claudeReplayTestRequest(payload, "stream-cross-format", true, sdktranslator.FormatClaude)
+	opts.Stream = true
+	opts.ResponseFormat = sdktranslator.FormatOpenAI
+
+	result, err := executor.ExecuteStream(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("first ExecuteStream() error: %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+	}
+
+	secondPayload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"text","text":"hello"}]},{"role":"user","content":"next"}]}`)
+	secondReq, secondOpts := claudeReplayTestRequest(secondPayload, "stream-cross-format", true, sdktranslator.FormatClaude)
+	secondOpts.Stream = true
+	secondOpts.ResponseFormat = sdktranslator.FormatOpenAI
+
+	result, err = executor.ExecuteStream(context.Background(), auth, secondReq, secondOpts)
+	if err != nil {
+		t.Fatalf("second ExecuteStream() error: %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	assistant := gjson.GetBytes(requestBodies[1], "messages.0.content").Array()
+	if len(assistant) == 0 || assistant[0].Get("signature").String() != opaqueSig {
+		t.Fatalf("cross-format stream did not replay signed thinking: %s", gjson.GetBytes(requestBodies[1], "messages.0.content").Raw)
+	}
 }

--- a/internal/runtime/executor/helps/claude_thinking_replay.go
+++ b/internal/runtime/executor/helps/claude_thinking_replay.go
@@ -1,0 +1,551 @@
+package helps
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"strings"
+
+	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ClaudeThinkingReplayModelFamily returns a stable per-credential, per-model
+// family name used to namespace replay state.
+func ClaudeThinkingReplayModelFamily(auth *cliproxyauth.Auth, model string) string {
+	baseModel := thinking.ParseSuffix(strings.TrimSpace(model)).ModelName
+	if baseModel == "" {
+		return ""
+	}
+	identity := ""
+	if auth != nil {
+		identity = strings.TrimSpace(auth.ID)
+		if identity == "" {
+			apiKey, baseURL := ClaudeCredentialKey(auth)
+			identity = strings.TrimSpace(baseURL)
+			if identity == "" {
+				identity = strings.TrimSpace(apiKey)
+			}
+		}
+	}
+	if identity == "" {
+		return "claude:" + baseModel
+	}
+	sum := sha256.Sum256([]byte(identity))
+	return "claude:" + hex.EncodeToString(sum[:8]) + ":" + baseModel
+}
+
+// ObfuscateClaudeThinkingReplayContents applies the same sensitive-word
+// obfuscation to cached assistant content that applyCloaking applies to the
+// upstream body. This lets the post-cloak replay match compare like-for-like
+// bytes instead of failing because the caller body is obfuscated and the cache
+// is not.
+func ObfuscateClaudeThinkingReplayContents(contents [][]byte, words []string) [][]byte {
+	matcher := BuildSensitiveWordMatcher(words)
+	if matcher == nil {
+		return contents
+	}
+	out := make([][]byte, len(contents))
+	for i, content := range contents {
+		wrapper, _ := sjson.SetRawBytes([]byte(`{"messages":[{"role":"assistant"}]}`), "messages.0.content", content)
+		obfuscated := ObfuscateSensitiveWords(wrapper, matcher)
+		obfuscatedContent := gjson.GetBytes(obfuscated, "messages.0.content")
+		if !obfuscatedContent.Exists() {
+			out[i] = content
+			continue
+		}
+		out[i] = []byte(obfuscatedContent.Raw)
+	}
+	return out
+}
+
+// ClaudeThinkingReplayNormalizeCachedContent strips tool-use signature/provenance
+// fields from a cached assistant content array. This lets the replay match compare
+// the same normalized shape the upstream sanitizer produces, while the restored
+// content still carries the trusted thinking signature.
+func ClaudeThinkingReplayNormalizeCachedContent(content []byte) []byte {
+	root := gjson.ParseBytes(content)
+	if !root.IsArray() {
+		return content
+	}
+	parts := root.Array()
+	outParts := make([]string, len(parts))
+	modified := false
+	for i, part := range parts {
+		if strings.TrimSpace(part.Get("type").String()) == "tool_use" {
+			updated, changed := signature.StripClaudeToolUseSignatureFields(part)
+			outParts[i] = updated
+			modified = modified || changed
+			continue
+		}
+		outParts[i] = part.Raw
+	}
+	if !modified {
+		return content
+	}
+	return []byte("[" + strings.Join(outParts, ",") + "]")
+}
+
+// StripClaudeThinkingReplayProvenanceMarkers removes any client-supplied
+// _cliproxy_replay_provenance fields from thinking blocks in the request payload
+// before the sanitizer runs. The marker is internal-only.
+func StripClaudeThinkingReplayProvenanceMarkers(payload []byte) []byte {
+	root := gjson.GetBytes(payload, "messages")
+	if !root.IsArray() {
+		return payload
+	}
+	updated := payload
+	modified := false
+	for i, message := range root.Array() {
+		content := message.Get("content")
+		if !content.IsArray() {
+			continue
+		}
+		for j, part := range content.Array() {
+			if strings.TrimSpace(part.Get("type").String()) != "thinking" {
+				continue
+			}
+			if !part.Get("_cliproxy_replay_provenance").Exists() {
+				continue
+			}
+			path := fmt.Sprintf("messages.%d.content.%d._cliproxy_replay_provenance", i, j)
+			out, _ := sjson.DeleteBytes(updated, path)
+			updated = out
+			modified = true
+		}
+	}
+	if !modified {
+		return payload
+	}
+	return updated
+}
+
+// RestoreClaudeThinkingReplayContents replaces visible assistant content in the
+// request body with cached normalized content when the visible parts match.
+func RestoreClaudeThinkingReplayContents(body []byte, cachedContents [][]byte) ([]byte, bool) {
+	updated := body
+	restored := false
+	messages := gjson.GetBytes(updated, "messages")
+	if !messages.IsArray() {
+		return body, false
+	}
+	msgList := messages.Array()
+
+	// Collect the assistant messages whose content we may be able to restore.
+	var assistantContents []gjson.Result
+	var assistantMsgIndices []int
+	for i, message := range msgList {
+		if !strings.EqualFold(strings.TrimSpace(message.Get("role").String()), "assistant") {
+			continue
+		}
+		content := message.Get("content")
+		if content.Type == gjson.String {
+			normalized, err := json.Marshal([]map[string]string{{"type": "text", "text": content.String()}})
+			if err != nil {
+				continue
+			}
+			content = gjson.ParseBytes(normalized)
+		} else if !content.IsArray() {
+			continue
+		}
+		assistantContents = append(assistantContents, content)
+		assistantMsgIndices = append(assistantMsgIndices, i)
+	}
+
+	// Anchor the match window to the latest suffix of cached turns that matches
+	// an ordered subsequence of the request's assistant sequence. When clients
+	// compact or truncate earlier history, the matched turns may be separated by
+	// unsigned assistant responses; those gaps are skipped rather than restored.
+	start, matches := -1, []int(nil)
+	if len(assistantContents) > 0 {
+		start, matches = ClaudeThinkingReplayFindStartIndex(assistantContents, cachedContents)
+	}
+
+	matchedCache := make([]int, len(assistantContents))
+	for i := range matchedCache {
+		matchedCache[i] = -1
+	}
+	if start >= 0 && len(matches) > 0 {
+		for k, ai := range matches {
+			matchedCache[ai] = start + k
+		}
+	}
+
+	for ai, i := range assistantMsgIndices {
+		content := assistantContents[ai]
+		j := matchedCache[ai]
+		if j < 0 {
+			continue
+		}
+		if !JSONEqual([]byte(content.Raw), cachedContents[j]) {
+			var errSet error
+			updated, errSet = sjson.SetRawBytes(updated, fmt.Sprintf("messages.%d.content", i), cachedContents[j])
+			if errSet != nil {
+				return body, false
+			}
+			restored = true
+		}
+	}
+	return updated, restored
+}
+
+// ClaudeThinkingReplayContentsMatch reports whether an incoming assistant
+// content array matches a cached assistant turn. It accepts exact equality or
+// non-thinking parts equal and, when the incoming content already contains a
+// thinking block, the thinking text matching the cached one.
+func ClaudeThinkingReplayContentsMatch(currentContent, cachedContent gjson.Result) bool {
+	if !currentContent.IsArray() || !cachedContent.IsArray() {
+		return false
+	}
+	if JSONEqual([]byte(currentContent.Raw), []byte(cachedContent.Raw)) {
+		return true
+	}
+	cachedParts, ok := NonThinkingContentParts(cachedContent)
+	if !ok {
+		return false
+	}
+	currentParts, ok := NonThinkingContentParts(currentContent)
+	if !ok || !CanonicalPartsEqual(currentParts, cachedParts) {
+		return false
+	}
+	if ContentHasThinking(currentContent) && !ThinkingMatchesCachedIgnoringSignature(currentContent, cachedContent) {
+		return false
+	}
+	return true
+}
+
+// ClaudeThinkingReplayFindStartIndex finds the latest suffix of cachedContents
+// that matches an ordered subsequence of the request's assistant contents. It
+// returns the starting index in cachedContents and a slice of request offsets
+// that map each matched cached turn to its request position, so restoration can
+// skip unsigned assistant gaps and leading turns. It returns -1, nil when no
+// unambiguous anchor exists.
+func ClaudeThinkingReplayFindStartIndex(assistantContents []gjson.Result, cachedContents [][]byte) (int, []int) {
+	if len(assistantContents) == 0 || len(cachedContents) == 0 {
+		return -1, nil
+	}
+	maxL := len(assistantContents)
+	if maxL > len(cachedContents) {
+		maxL = len(cachedContents)
+	}
+
+	type candidate struct {
+		start   int
+		matches []int
+	}
+	var candidates []candidate
+
+	for l := 1; l <= maxL; l++ {
+		start := len(cachedContents) - l
+		if matches := rightmostSubsequenceMatch(assistantContents, cachedContents, start, l); matches != nil {
+			candidates = append(candidates, candidate{start: start, matches: matches})
+		}
+	}
+	if len(candidates) == 0 {
+		return -1, nil
+	}
+
+	// Prefer the match whose last request offset is latest (so the anchor ends
+	// closest to the current request). If the last offset ties, prefer the
+	// longest match.
+	best := 0
+	for i := 1; i < len(candidates); i++ {
+		a, b := candidates[best], candidates[i]
+		aLast, bLast := a.matches[len(a.matches)-1], b.matches[len(b.matches)-1]
+		if bLast > aLast {
+			best = i
+		} else if bLast == aLast && len(b.matches) > len(a.matches) {
+			best = i
+		}
+	}
+	chosen := candidates[best]
+
+	// A cached suffix match is ambiguous when another cached block of the same
+	// length matches the same request positions. The check applies to both
+	// partial and full suffix-of-request matches so duplicate cached turns do not
+	// cause the wrong signature to be restored.
+	l := len(chosen.matches)
+	for d := 0; d <= len(cachedContents)-l; d++ {
+		if d == chosen.start {
+			continue
+		}
+		otherMatched := true
+		for k := 0; k < l; k++ {
+			if !ClaudeThinkingReplayContentsMatch(assistantContents[chosen.matches[k]], gjson.ParseBytes(cachedContents[d+k])) {
+				otherMatched = false
+				break
+			}
+		}
+		if otherMatched {
+			return -1, nil
+		}
+	}
+	return chosen.start, chosen.matches
+}
+
+// canMatchEarlier reports whether the first k cached turns (starting at start)
+// can be matched in order using only request positions before limit. A greedy
+// left-to-right scan is sufficient because choosing the earliest match for each
+// cached turn leaves the most room for the rest.
+func canMatchEarlier(assistantContents []gjson.Result, cachedContents [][]byte, start, k, limit int) bool {
+	j := 0
+	for i := 0; i < k; i++ {
+		cached := gjson.ParseBytes(cachedContents[start+i])
+		for j < limit && !ClaudeThinkingReplayContentsMatch(assistantContents[j], cached) {
+			j++
+		}
+		if j == limit {
+			return false
+		}
+		j++
+	}
+	return true
+}
+
+// rightmostSubsequenceMatch finds a strictly increasing sequence of request
+// indices such that assistantContents[matches[k]] matches cachedContents[start+k].
+// For each cached turn, multiple request candidates are accepted only when the
+// preceding cached turns can consume all but one of them. A single retained
+// (thinking-bearing) candidate disambiguates otherwise-duplicate candidates.
+func rightmostSubsequenceMatch(assistantContents []gjson.Result, cachedContents [][]byte, start, l int) []int {
+	matches := make([]int, l)
+	limit := len(assistantContents)
+	for k := l - 1; k >= 0; k-- {
+		cached := gjson.ParseBytes(cachedContents[start+k])
+		var candidates []int
+		for i := limit - 1; i >= 0; i-- {
+			if ClaudeThinkingReplayContentsMatch(assistantContents[i], cached) {
+				candidates = append(candidates, i)
+			}
+		}
+		if len(candidates) == 0 {
+			return nil
+		}
+
+		// A candidate is viable if the earlier cached turns can still fit in the
+		// request positions before it. This replaces the coarse `len(candidates) >
+		// remaining` check and accounts for which duplicate candidates the
+		// preceding cached turns can actually consume.
+		var viable []int
+		for _, i := range candidates {
+			if i < k {
+				continue
+			}
+			if canMatchEarlier(assistantContents, cachedContents, start, k, i) {
+				viable = append(viable, i)
+			}
+		}
+		if len(viable) == 0 {
+			return nil
+		}
+
+		// Prefer a single retained (thinking-bearing) viable candidate. If more
+		// than one retained candidate exists, or more than one unsigned candidate
+		// and none retained, the per-turn match is ambiguous.
+		var retained []int
+		for _, i := range viable {
+			if ContentHasThinking(assistantContents[i]) {
+				retained = append(retained, i)
+			}
+		}
+		if len(retained) > 1 {
+			return nil
+		}
+		if len(retained) == 1 {
+			matches[k] = retained[0]
+			limit = retained[0]
+			continue
+		}
+		if len(viable) > 1 {
+			return nil
+		}
+		matches[k] = viable[0]
+		limit = viable[0]
+	}
+	return matches
+}
+
+// ClaudeThinkingReplayMessageHashes returns a stable weighted hash for each
+// user and assistant message in the payload. User messages receive a higher
+// weight because they are the strongest conversation anchor; an echoed
+// assistant can be shared across conversations and is a weaker signal.
+func ClaudeThinkingReplayMessageHashes(modelFamily, callerHash string, payload []byte) []internalcache.ClaudeThinkingReplayAliasMessage {
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.IsArray() {
+		return nil
+	}
+	var out []internalcache.ClaudeThinkingReplayAliasMessage
+	for _, msg := range messages.Array() {
+		role := strings.ToLower(strings.TrimSpace(msg.Get("role").String()))
+		if role != "user" && role != "assistant" {
+			continue
+		}
+		var h string
+		if role == "assistant" {
+			h = ClaudeThinkingReplayAssistantMessageHash(modelFamily, callerHash, []byte(msg.Get("content").Raw))
+		} else {
+			h = ClaudeThinkingReplayUserMessageHash(modelFamily, callerHash, msg)
+		}
+		if h == "" {
+			continue
+		}
+		weight := 2
+		if role == "assistant" {
+			weight = 1
+		}
+		out = append(out, internalcache.ClaudeThinkingReplayAliasMessage{Hash: h, Weight: weight})
+	}
+	return out
+}
+
+// ClaudeThinkingReplayUserMessageHash returns a stable hash for a user message.
+func ClaudeThinkingReplayUserMessageHash(modelFamily, callerHash string, msg gjson.Result) string {
+	role := strings.TrimSpace(msg.Get("role").String())
+	content := msg.Get("content")
+	if role == "" {
+		return ""
+	}
+	m := map[string]json.RawMessage{
+		"role":    json.RawMessage(`"` + role + `"`),
+		"content": json.RawMessage(content.Raw),
+	}
+	raw, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	canon, ok := CanonicalJSON(raw)
+	if !ok {
+		return ""
+	}
+	return ClaudeThinkingReplayHash(modelFamily, callerHash, canon)
+}
+
+// ClaudeThinkingReplayAssistantMessageHash returns a stable hash for the
+// non-thinking parts of an assistant message.
+func ClaudeThinkingReplayAssistantMessageHash(modelFamily, callerHash string, content []byte) string {
+	// Strip tool-use signature/provenance fields before hashing, so an echoed
+	// tool_use with different provenance still resolves the same alias.
+	content = ClaudeThinkingReplayNormalizeCachedContent(content)
+	root := gjson.ParseBytes(content)
+	if root.Type == gjson.String {
+		normalized, err := json.Marshal([]map[string]string{{"type": "text", "text": root.String()}})
+		if err != nil {
+			return ""
+		}
+		content = normalized
+		root = gjson.ParseBytes(content)
+	}
+	parts, ok := NonThinkingContentParts(root)
+	if !ok || len(parts) == 0 {
+		return ""
+	}
+	partsJSON, err := json.Marshal(parts)
+	if err != nil {
+		return ""
+	}
+	m := map[string]json.RawMessage{
+		"role":    json.RawMessage(`"assistant"`),
+		"content": json.RawMessage(partsJSON),
+	}
+	raw, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	canon, ok := CanonicalJSON(raw)
+	if !ok {
+		return ""
+	}
+	return ClaudeThinkingReplayHash(modelFamily, callerHash, canon)
+}
+
+// ClaudeThinkingReplayHash returns a length-prefixed SHA-256 hash of the model
+// family, caller hash, and canonical content.
+func ClaudeThinkingReplayHash(modelFamily, callerHash string, canon []byte) string {
+	h := sha256.New()
+	h.Write([]byte(modelFamily))
+	h.Write([]byte{0})
+	h.Write([]byte(callerHash))
+	h.Write([]byte{0})
+	h.Write(canon)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ClaudeThinkingReplayFirstUserHash returns the hash of the first user message
+// in the payload.
+func ClaudeThinkingReplayFirstUserHash(modelFamily, callerHash string, payload []byte) string {
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.IsArray() {
+		return ""
+	}
+	for _, msg := range messages.Array() {
+		if strings.ToLower(strings.TrimSpace(msg.Get("role").String())) != "user" {
+			continue
+		}
+		if h := ClaudeThinkingReplayUserMessageHash(modelFamily, callerHash, msg); h != "" {
+			return h
+		}
+	}
+	return ""
+}
+
+// ClaudeThinkingReplayCallerHash returns a stable hash of the caller identity
+// and scope headers.
+func ClaudeThinkingReplayCallerHash(auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) string {
+	h := sha256.New()
+	var identity string
+	if auth != nil {
+		if id := strings.TrimSpace(auth.ID); id != "" {
+			identity = id
+		} else if apiKey, _ := ClaudeCredentialKey(auth); apiKey != "" {
+			identity = apiKey
+		}
+	}
+	claudeThinkingReplayHashString(h, identity)
+	claudeThinkingReplayHashString(h, MetadataString(opts.Metadata, cliproxyexecutor.CallerScopeMetadataKey))
+	claudeThinkingReplayHashString(h, MetadataString(req.Metadata, cliproxyexecutor.CallerScopeMetadataKey))
+	claudeThinkingReplayHashString(h, MetadataString(opts.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey))
+	claudeThinkingReplayHashString(h, MetadataString(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey))
+	claudeThinkingReplayHashString(h, headerFirstValue(opts.Headers, "User-Agent"))
+	claudeThinkingReplayHashString(h, headerFirstValue(opts.Headers, "X-App"))
+	claudeThinkingReplayHashString(h, headerFirstValue(opts.Headers, "X-Codex-Client-Id"))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func claudeThinkingReplayHashString(h hash.Hash, s string) {
+	claudeThinkingReplayHashBytes(h, []byte(s))
+}
+
+func claudeThinkingReplayHashBytes(h hash.Hash, b []byte) {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(b)))
+	h.Write(length[:])
+	h.Write(b)
+}
+
+// ClaudeThinkingReplayContentIsReplayable reports whether a content array
+// carries a decodable Claude thinking signature. Only provenanced signed turns
+// are cached; unsigned or malformed-signature responses must not evict earlier
+// replay state.
+func ClaudeThinkingReplayContentIsReplayable(content []byte) bool {
+	root := gjson.ParseBytes(content)
+	if !root.IsArray() {
+		return false
+	}
+	for _, part := range root.Array() {
+		if strings.TrimSpace(part.Get("type").String()) != "thinking" {
+			continue
+		}
+		if signature.HasDecodableClaudeThinkingSignature(part.Get("signature").String()) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/executor/helps/claude_thinking_replay_session.go
+++ b/internal/runtime/executor/helps/claude_thinking_replay_session.go
@@ -1,0 +1,188 @@
+package helps
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"hash"
+	"net/http"
+	"sort"
+	"strings"
+
+	claudeauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/claude"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+)
+
+// conversationNonceSources lists the gjson paths and header names that may
+// carry an explicit conversation identifier. An explicit nonce is required for
+// the fallback conversation key so two identical conversation openings do not
+// share a replay scope.
+var conversationNonceSources = struct {
+	paths  []string
+	header []string
+}{
+	paths:  []string{"client_metadata.conversation_id", "client_metadata.conversationId", "conversation_id"},
+	header: []string{"X-Conversation-Id", "Conversation-Id", "Conversation_id"},
+}
+
+// claudeReplayConversationNonce returns a genuine conversation nonce when one
+// is explicitly provided by the caller. It returns an empty string when no
+// nonce exists, signaling that fallback replay should not be used.
+func claudeReplayConversationNonce(payload []byte, headers http.Header) string {
+	for _, path := range conversationNonceSources.paths {
+		if value := strings.TrimSpace(gjson.GetBytes(payload, path).String()); value != "" {
+			return value
+		}
+	}
+	for _, key := range conversationNonceSources.header {
+		if value := headerFirstValue(headers, key); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+// ClaudeThinkingReplayConversationSessionKey returns a stable per-conversation
+// key for sessionless clients. It returns usedNonce=true when an explicit
+// conversation nonce (client_metadata.conversation_id, conversation_id, or
+// X-Conversation-Id) was used. A nonce-based key is derived from stable
+// caller fields only, so it survives history compaction and gives two
+// identical openings with different nonces distinct scopes.
+//
+// When no nonce is present, the key falls back to the first user message and
+// system prompt so replay still works for stateless clients; alias resolution
+// in the executor can then recover the original conversation after history
+// compaction.
+func ClaudeThinkingReplayConversationSessionKey(auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (string, bool) {
+	if len(req.Payload) == 0 {
+		return "", false
+	}
+
+	h := sha256.New()
+	hashString(h, "conversation")
+
+	if auth != nil {
+		if id := strings.TrimSpace(auth.ID); id != "" {
+			hashString(h, id)
+		} else if apiKey, _ := ClaudeCredentialKey(auth); apiKey != "" {
+			hashString(h, apiKey)
+		} else {
+			hashString(h, "")
+		}
+	} else {
+		hashString(h, "")
+	}
+
+	hashString(h, MetadataString(opts.Metadata, cliproxyexecutor.CallerScopeMetadataKey))
+	hashString(h, MetadataString(req.Metadata, cliproxyexecutor.CallerScopeMetadataKey))
+	hashString(h, MetadataString(opts.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey))
+	hashString(h, MetadataString(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey))
+
+	// Read identity headers case-insensitively so callers that supply lowercase
+	// keys (e.g. x-codex-client-id) are not collapsed with missing values.
+	hashString(h, headerFirstValue(opts.Headers, "User-Agent"))
+	hashString(h, headerFirstValue(opts.Headers, "X-App"))
+	hashString(h, headerFirstValue(opts.Headers, "X-Codex-Client-Id"))
+
+	nonce := claudeReplayConversationNonce(req.Payload, opts.Headers)
+	if nonce != "" {
+		hashString(h, nonce)
+		return "conversation:" + hex.EncodeToString(h.Sum(nil)[:16]), true
+	}
+
+	// No explicit nonce: fall back to the first user message and system prompt.
+	// Two different callers with the same opening are still separated by the
+	// caller fields above; two conversations from the same caller with the same
+	// opening share a scope. Use a conversation nonce to avoid that.
+	for _, path := range []string{"messages.0", "system"} {
+		part := gjson.GetBytes(req.Payload, path)
+		if !part.Exists() {
+			hashBytes(h, nil)
+			continue
+		}
+		if canon, ok := claudeReplayCanonicalJSON([]byte(part.Raw)); ok {
+			hashBytes(h, canon)
+		} else {
+			hashBytes(h, []byte(part.Raw))
+		}
+	}
+	return "conversation:" + hex.EncodeToString(h.Sum(nil)[:16]), false
+}
+
+// headerFirstValue returns the first non-empty, trimmed value for key from
+// headers, matching the key case-insensitively. Matching header names are
+// collected and sorted so the same logical header under multiple casings always
+// returns the same value. Whitespace-only values are treated as missing.
+func headerFirstValue(headers http.Header, key string) string {
+	if headers == nil {
+		return ""
+	}
+	var keys []string
+	for k := range headers {
+		if strings.EqualFold(k, key) {
+			keys = append(keys, k)
+		}
+	}
+	if len(keys) == 0 {
+		return ""
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		for _, v := range headers[k] {
+			if v := strings.TrimSpace(v); v != "" {
+				return v
+			}
+		}
+	}
+	return ""
+}
+
+// hashString writes s to h as a length-prefixed UTF-8 string so adjacent
+// fields cannot be confused when concatenated.
+func hashString(h hash.Hash, s string) {
+	hashBytes(h, []byte(s))
+}
+
+// hashBytes writes b to h as a length-prefixed byte slice.
+func hashBytes(h hash.Hash, b []byte) {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(b)))
+	h.Write(length[:])
+	h.Write(b)
+}
+
+// ClaudeCredentialKey returns the most identifying credential value available
+// for an auth without importing the executor package.
+func ClaudeCredentialKey(auth *cliproxyauth.Auth) (apiKey, baseURL string) {
+	if auth == nil {
+		return "", ""
+	}
+	if auth.Attributes != nil {
+		apiKey = auth.Attributes["api_key"]
+		baseURL = auth.Attributes["base_url"]
+	}
+	if apiKey == "" {
+		apiKey = claudeauth.ReadMetadataString(&auth.Metadata, "access_token")
+	}
+	return apiKey, baseURL
+}
+
+// claudeReplayCanonicalJSON returns a stable JSON encoding for the given value,
+// matching the ordering used by the executor's replay match.
+func claudeReplayCanonicalJSON(raw []byte) ([]byte, bool) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, false
+	}
+	canon, err := json.Marshal(value)
+	if err != nil {
+		return nil, false
+	}
+	return canon, true
+}

--- a/internal/runtime/executor/helps/claude_thinking_replay_session_test.go
+++ b/internal/runtime/executor/helps/claude_thinking_replay_session_test.go
@@ -1,0 +1,226 @@
+package helps
+
+import (
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/sjson"
+)
+
+func TestClaudeThinkingReplayConversationSessionKey_DelimitsConcatenatedFields(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-1"}}`)
+	req := cliproxyexecutor.Request{Payload: payload}
+
+	// auth.ID="ab" and no caller scope. The raw concatenation of relevant
+	// caller fields is "ab".
+	keyA, _ := ClaudeThinkingReplayConversationSessionKey(
+		&cliproxyauth.Auth{ID: "ab"},
+		req,
+		cliproxyexecutor.Options{},
+	)
+
+	// auth.ID="a" and caller scope "bc". The raw concatenation of the same
+	// fields is also "abc", but the field boundaries must differ.
+	keyB, _ := ClaudeThinkingReplayConversationSessionKey(
+		&cliproxyauth.Auth{ID: "a"},
+		req,
+		cliproxyexecutor.Options{
+			Metadata: map[string]any{
+				cliproxyexecutor.CallerScopeMetadataKey: "bc",
+			},
+		},
+	)
+
+	if keyA == "" || keyB == "" {
+		t.Fatalf("conversation key empty: %q, %q", keyA, keyB)
+	}
+	if keyA == keyB {
+		t.Fatalf("distinct caller tuples collided on the same replay key: %q", keyA)
+	}
+}
+
+func TestClaudeThinkingReplayConversationSessionKey_IgnoresToolsList(t *testing.T) {
+	base := []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-tools"}}`)
+	a := append([]byte(nil), base...)
+	b, _ := sjson.SetRawBytes(base, "tools", []byte(`[{"name":"tool_a"}]`))
+
+	optsA := cliproxyexecutor.Options{}
+	optsB := cliproxyexecutor.Options{}
+
+	keyA, _ := ClaudeThinkingReplayConversationSessionKey(&cliproxyauth.Auth{ID: "caller"}, cliproxyexecutor.Request{Payload: a}, optsA)
+	keyB, _ := ClaudeThinkingReplayConversationSessionKey(&cliproxyauth.Auth{ID: "caller"}, cliproxyexecutor.Request{Payload: b}, optsB)
+	if keyA == "" || keyB == "" {
+		t.Fatalf("empty key: %q, %q", keyA, keyB)
+	}
+	if keyA != keyB {
+		t.Fatalf("different tools list changed the replay key: %q vs %q", keyA, keyB)
+	}
+}
+
+func TestClaudeThinkingReplayConversationSessionKey_ReadsHeadersCaseInsensitively(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-header"}}`)
+	req := cliproxyexecutor.Request{Payload: payload}
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+
+	lowerOpts := cliproxyexecutor.Options{
+		Headers: map[string][]string{
+			"x-codex-client-id": {"client-lowercase"},
+			"x-app":             {"app-lowercase"},
+			"user-agent":        {"agent-lowercase"},
+		},
+	}
+	upperOpts := cliproxyexecutor.Options{
+		Headers: map[string][]string{
+			"X-Codex-Client-Id": {"client-lowercase"},
+			"X-App":             {"app-lowercase"},
+			"User-Agent":        {"agent-lowercase"},
+		},
+	}
+
+	lowerKey, _ := ClaudeThinkingReplayConversationSessionKey(auth, req, lowerOpts)
+	upperKey, _ := ClaudeThinkingReplayConversationSessionKey(auth, req, upperOpts)
+	if lowerKey == "" || upperKey == "" {
+		t.Fatalf("conversation key empty: %q, %q", lowerKey, upperKey)
+	}
+	if lowerKey != upperKey {
+		t.Fatalf("lowercase and canonical headers produced different keys: %q vs %q", lowerKey, upperKey)
+	}
+}
+
+func TestClaudeThinkingReplayConversationSessionKey_IgnoresWhitespaceOnlyHeaders(t *testing.T) {
+	basePayload := []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-ws"}}`)
+	req := cliproxyexecutor.Request{Payload: basePayload}
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+
+	withWhitespace := cliproxyexecutor.Options{
+		Headers: map[string][]string{
+			"User-Agent":        {"client/1.0"},
+			"X-App":             {"   "},
+			"X-Codex-Client-Id": {"\t\n"},
+		},
+	}
+	withoutWhitespace := cliproxyexecutor.Options{
+		Headers: map[string][]string{
+			"User-Agent": {"client/1.0"},
+		},
+	}
+
+	withKey, _ := ClaudeThinkingReplayConversationSessionKey(auth, req, withWhitespace)
+	withoutKey, _ := ClaudeThinkingReplayConversationSessionKey(auth, req, withoutWhitespace)
+	if withKey == "" || withoutKey == "" {
+		t.Fatalf("conversation key empty: %q, %q", withKey, withoutKey)
+	}
+	if withKey != withoutKey {
+		t.Fatalf("whitespace-only headers changed the replay key: %q vs %q", withKey, withoutKey)
+	}
+
+	// A whitespace-only conversation header must not become the nonce, but the
+	// no-nonce content-derived fallback should still produce a key.
+	wsNoncePayload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	wsNonceReq := cliproxyexecutor.Request{Payload: wsNoncePayload}
+	wsOpts := cliproxyexecutor.Options{
+		Headers: map[string][]string{
+			"X-Conversation-Id": {"   "},
+		},
+	}
+	got, usedNonce := ClaudeThinkingReplayConversationSessionKey(auth, wsNonceReq, wsOpts)
+	if got == "" {
+		t.Fatal("whitespace-only conversation header disabled the content fallback")
+	}
+	if usedNonce {
+		t.Fatalf("whitespace-only conversation header was used as nonce: %q", got)
+	}
+}
+
+func TestClaudeThinkingReplayConversationSessionKey_StableForIdenticalInputs(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-stable"}}`)
+	req := cliproxyexecutor.Request{Payload: payload}
+	opts := cliproxyexecutor.Options{
+		Headers: map[string][]string{
+			"User-Agent": {"client/1.0"},
+		},
+		Metadata: map[string]any{
+			cliproxyexecutor.CallerScopeMetadataKey: "scope",
+		},
+	}
+
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+	first, _ := ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
+	second, _ := ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
+	if first == "" {
+		t.Fatal("conversation key empty for stable inputs")
+	}
+	if first != second {
+		t.Fatalf("same inputs produced different keys: %q vs %q", first, second)
+	}
+}
+
+func TestClaudeThinkingReplayConversationSessionKey_DistinctForDifferentConversationIDs(t *testing.T) {
+	basePayload := []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-a"}}`)
+	reqA := cliproxyexecutor.Request{Payload: basePayload}
+	reqB := cliproxyexecutor.Request{Payload: []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-b"}}`)}
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+	opts := cliproxyexecutor.Options{}
+
+	keyA, _ := ClaudeThinkingReplayConversationSessionKey(auth, reqA, opts)
+	keyB, _ := ClaudeThinkingReplayConversationSessionKey(auth, reqB, opts)
+	if keyA == "" || keyB == "" {
+		t.Fatalf("conversation key empty: %q, %q", keyA, keyB)
+	}
+	if keyA == keyB {
+		t.Fatalf("different conversation ids produced the same key: %q", keyA)
+	}
+}
+
+func TestClaudeThinkingReplayConversationSessionKey_StableWithNonceAcrossHistoryCompaction(t *testing.T) {
+	// The caller keeps the same conversation nonce but removes the first user
+	// turn (history compaction). The nonce-based key must stay the same.
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-compact"}}`)
+	compactedPayload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"text","text":"hi"}]},{"role":"user","content":"next"}],"client_metadata":{"conversation_id":"conv-compact"}}`)
+
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+	opts := cliproxyexecutor.Options{}
+
+	firstKey, usedNonce1 := ClaudeThinkingReplayConversationSessionKey(auth, cliproxyexecutor.Request{Payload: firstPayload}, opts)
+	compactedKey, usedNonce2 := ClaudeThinkingReplayConversationSessionKey(auth, cliproxyexecutor.Request{Payload: compactedPayload}, opts)
+	if firstKey == "" || compactedKey == "" {
+		t.Fatalf("conversation key empty: %q, %q", firstKey, compactedKey)
+	}
+	if !usedNonce1 || !usedNonce2 {
+		t.Fatalf("expected conversation nonce to drive the key")
+	}
+	if firstKey != compactedKey {
+		t.Fatalf("nonce-based key changed across compaction: %q vs %q", firstKey, compactedKey)
+	}
+}
+
+func TestClaudeThinkingReplayConversationSessionKey_DerivesContentKeyWhenNoConversationNonce(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	req := cliproxyexecutor.Request{Payload: payload}
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+
+	key, usedNonce := ClaudeThinkingReplayConversationSessionKey(auth, req, cliproxyexecutor.Options{})
+	if key == "" {
+		t.Fatal("expected a content-derived key without conversation nonce")
+	}
+	if usedNonce {
+		t.Fatalf("expected no conversation nonce, got key %q", key)
+	}
+}
+
+func TestClaudeThinkingReplayConversationSessionKey_DistinctContentKeysForDifferentOpenings(t *testing.T) {
+	a := cliproxyexecutor.Request{Payload: []byte(`{"messages":[{"role":"user","content":"hello"}]}`)}
+	b := cliproxyexecutor.Request{Payload: []byte(`{"messages":[{"role":"user","content":"world"}]}`)}
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+	opts := cliproxyexecutor.Options{}
+
+	keyA, _ := ClaudeThinkingReplayConversationSessionKey(auth, a, opts)
+	keyB, _ := ClaudeThinkingReplayConversationSessionKey(auth, b, opts)
+	if keyA == "" || keyB == "" {
+		t.Fatalf("conversation key empty: %q, %q", keyA, keyB)
+	}
+	if keyA == keyB {
+		t.Fatalf("different content produced the same key: %q", keyA)
+	}
+}

--- a/internal/runtime/executor/helps/derived_session.go
+++ b/internal/runtime/executor/helps/derived_session.go
@@ -29,7 +29,7 @@ func DerivedSessionUUID(provider string, metadataSets ...map[string]any) string 
 // ProviderSessionUUID prefers a long-lived execution session and falls back to the derived identity.
 func ProviderSessionUUID(provider string, metadataSets ...map[string]any) string {
 	for _, metadata := range metadataSets {
-		if executionID := metadataString(metadata, cliproxyexecutor.ExecutionSessionMetadataKey); executionID != "" {
+		if executionID := MetadataString(metadata, cliproxyexecutor.ExecutionSessionMetadataKey); executionID != "" {
 			return stableProviderSessionUUID(provider, "execution-session", executionID)
 		}
 	}
@@ -57,7 +57,7 @@ func DerivedAntigravitySessionID(metadataSets ...map[string]any) string {
 	return "-" + strconv.FormatInt(value, 10)
 }
 
-func metadataString(metadata map[string]any, key string) string {
+func MetadataString(metadata map[string]any, key string) string {
 	if metadata == nil {
 		return ""
 	}

--- a/internal/runtime/executor/helps/replay_content.go
+++ b/internal/runtime/executor/helps/replay_content.go
@@ -1,0 +1,136 @@
+package helps
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ContentHasThinking reports whether a content array carries a thinking or
+// redacted_thinking part.
+func ContentHasThinking(content gjson.Result) bool {
+	if !content.IsArray() {
+		return false
+	}
+	for _, part := range content.Array() {
+		switch strings.TrimSpace(part.Get("type").String()) {
+		case "thinking", "redacted_thinking":
+			return true
+		}
+	}
+	return false
+}
+
+// ThinkingMatchesCachedIgnoringSignature checks that every thinking or
+// redacted_thinking part in current matches the corresponding cached part after
+// removing signature fields. Non-thinking parts are assumed to be equal by the
+// caller (NonThinkingContentParts/CanonicalPartsEqual).
+func ThinkingMatchesCachedIgnoringSignature(current, cached gjson.Result) bool {
+	if !current.IsArray() || !cached.IsArray() {
+		return false
+	}
+	currentParts := current.Array()
+	cachedParts := cached.Array()
+	if len(currentParts) != len(cachedParts) {
+		return false
+	}
+	for i, curPart := range currentParts {
+		cachedPart := cachedParts[i]
+		curType := strings.TrimSpace(curPart.Get("type").String())
+		cachedType := strings.TrimSpace(cachedPart.Get("type").String())
+		if curType != cachedType {
+			return false
+		}
+		switch curType {
+		case "thinking", "redacted_thinking":
+			curClean := ThinkingPartWithoutSignature(curPart)
+			cachedClean := ThinkingPartWithoutSignature(cachedPart)
+			curCanon, ok1 := CanonicalJSON([]byte(curClean))
+			cachedCanon, ok2 := CanonicalJSON([]byte(cachedClean))
+			if !ok1 || !ok2 || !bytes.Equal(curCanon, cachedCanon) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// ThinkingPartWithoutSignature returns a thinking/redacted_thinking part with
+// signature fields removed so two parts can be compared ignoring provenance.
+func ThinkingPartWithoutSignature(part gjson.Result) string {
+	updated := part.Raw
+	for _, path := range []string{"signature", "thoughtSignature", "thought_signature", "extra_content.google.thought_signature"} {
+		if gjson.Get(updated, path).Exists() {
+			updated, _ = sjson.Delete(updated, path)
+		}
+	}
+	return updated
+}
+
+// NonThinkingContentParts extracts the canonical non-thinking content parts.
+// It returns false when a part cannot be canonicalized or a tool_use part
+// is missing an id.
+func NonThinkingContentParts(content gjson.Result) ([][]byte, bool) {
+	if !content.IsArray() {
+		return nil, false
+	}
+	parts := make([][]byte, 0, len(content.Array()))
+	for _, part := range content.Array() {
+		switch strings.TrimSpace(part.Get("type").String()) {
+		case "thinking", "redacted_thinking":
+			continue
+		case "tool_use":
+			if strings.TrimSpace(part.Get("id").String()) == "" {
+				return nil, false
+			}
+		}
+		canonical, ok := CanonicalJSON([]byte(part.Raw))
+		if !ok {
+			return nil, false
+		}
+		parts = append(parts, canonical)
+	}
+	if len(parts) == 0 {
+		return nil, false
+	}
+	return parts, true
+}
+
+// CanonicalPartsEqual reports whether two canonical part slices are equal.
+func CanonicalPartsEqual(left, right [][]byte) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if !bytes.Equal(left[i], right[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// JSONEqual reports whether two JSON values are equal after canonicalization.
+func JSONEqual(left, right []byte) bool {
+	canonicalLeft, leftOK := CanonicalJSON(left)
+	canonicalRight, rightOK := CanonicalJSON(right)
+	return leftOK && rightOK && bytes.Equal(canonicalLeft, canonicalRight)
+}
+
+// CanonicalJSON returns a compact, key-ordered JSON representation for value
+// equality comparison.
+func CanonicalJSON(raw []byte) ([]byte, bool) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if errDecode := decoder.Decode(&value); errDecode != nil {
+		return nil, false
+	}
+	canonical, errMarshal := json.Marshal(value)
+	if errMarshal != nil {
+		return nil, false
+	}
+	return canonical, true
+}

--- a/internal/runtime/executor/helps/replay_content_test.go
+++ b/internal/runtime/executor/helps/replay_content_test.go
@@ -1,0 +1,35 @@
+package helps
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestNonThinkingContentParts_RejectsEmptyVisibleParts(t *testing.T) {
+	onlyThinking := gjson.Parse(`[{"type":"thinking","thinking":"x","signature":"sig"}]`)
+	parts, ok := NonThinkingContentParts(onlyThinking)
+	if ok {
+		t.Fatalf("content with no visible anchor must fail closed, got %d parts", len(parts))
+	}
+
+	redactedOnly := gjson.Parse(`[{"type":"redacted_thinking"}]`)
+	parts, ok = NonThinkingContentParts(redactedOnly)
+	if ok {
+		t.Fatalf("content with only redacted thinking must fail closed, got %d parts", len(parts))
+	}
+}
+
+func TestNonThinkingContentParts_AcceptsTextOrToolUse(t *testing.T) {
+	textOnly := gjson.Parse(`[{"type":"text","text":"hi"}]`)
+	parts, ok := NonThinkingContentParts(textOnly)
+	if !ok || len(parts) != 1 {
+		t.Fatalf("text-only content should produce one visible part, got ok=%v parts=%d", ok, len(parts))
+	}
+
+	toolUse := gjson.Parse(`[{"type":"tool_use","id":"t1","name":"x"}]`)
+	parts, ok = NonThinkingContentParts(toolUse)
+	if !ok || len(parts) != 1 {
+		t.Fatalf("tool_use content should produce one visible part, got ok=%v parts=%d", ok, len(parts))
+	}
+}

--- a/internal/runtime/executor/kimi_thinking_replay.go
+++ b/internal/runtime/executor/kimi_thinking_replay.go
@@ -3,7 +3,6 @@ package executor
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -25,6 +24,9 @@ type kimiThinkingReplayScope struct {
 	snapshot      internalcache.KimiThinkingReplaySnapshot
 	cacheReady    bool
 	replayApplied bool
+	fallbackKey   bool
+	callerHash    string
+	firstUserHash string
 }
 
 func (s kimiThinkingReplayScope) valid() bool {
@@ -125,24 +127,19 @@ func kimiThinkingReplayContentIsReplayable(content []byte) bool {
 		return false
 	}
 	hasSignedThinking := false
-	hasToolUse := false
 	for _, part := range root.Array() {
 		switch strings.TrimSpace(part.Get("type").String()) {
 		case "thinking":
 			if strings.TrimSpace(part.Get("signature").String()) != "" {
 				hasSignedThinking = true
 			}
-		case "tool_use":
-			if strings.TrimSpace(part.Get("id").String()) != "" {
-				hasToolUse = true
-			}
 		}
 	}
-	return hasSignedThinking && hasToolUse
+	return hasSignedThinking
 }
 
 func restoreKimiThinkingReplayContent(body, cachedContent []byte) ([]byte, bool) {
-	cachedParts, cachedOK := kimiNonThinkingContentParts(gjson.ParseBytes(cachedContent))
+	cachedParts, cachedOK := helps.NonThinkingContentParts(gjson.ParseBytes(cachedContent))
 	if !cachedOK {
 		return body, false
 	}
@@ -151,99 +148,57 @@ func restoreKimiThinkingReplayContent(body, cachedContent []byte) ([]byte, bool)
 		return body, false
 	}
 	messageItems := messages.Array()
+	var matches []int
 	for index := len(messageItems) - 1; index >= 0; index-- {
 		message := messageItems[index]
 		if !strings.EqualFold(strings.TrimSpace(message.Get("role").String()), "assistant") {
 			continue
 		}
 		currentContent := message.Get("content")
-		if kimiJSONEqual([]byte(currentContent.Raw), cachedContent) {
+		if helps.JSONEqual([]byte(currentContent.Raw), cachedContent) {
 			return body, false
 		}
-		if kimiContentHasThinking(currentContent) {
+		currentParts, currentOK := helps.NonThinkingContentParts(currentContent)
+		if !currentOK || !helps.CanonicalPartsEqual(currentParts, cachedParts) {
 			continue
 		}
-		currentParts, currentOK := kimiNonThinkingContentParts(currentContent)
-		if !currentOK || !kimiCanonicalPartsEqual(currentParts, cachedParts) {
+		// Non-thinking parts already match. If the current content has a
+		// thinking block, restore only when it matches the cached thinking block
+		// ignoring signature, so a sanitized echoed turn gets its cached
+		// provenance back.
+		if helps.ContentHasThinking(currentContent) && !helps.ThinkingMatchesCachedIgnoringSignature(currentContent, gjson.ParseBytes(cachedContent)) {
 			continue
 		}
-		updated, errSet := sjson.SetRawBytes(body, fmt.Sprintf("messages.%d.content", index), cachedContent)
-		if errSet != nil {
-			return body, false
-		}
-		return updated, true
+		matches = append(matches, index)
 	}
-	return body, false
-}
 
-func kimiContentHasThinking(content gjson.Result) bool {
-	if !content.IsArray() {
-		return false
+	if len(matches) == 0 {
+		return body, false
 	}
-	for _, part := range content.Array() {
-		switch strings.TrimSpace(part.Get("type").String()) {
-		case "thinking", "redacted_thinking":
-			return true
-		}
-	}
-	return false
-}
 
-func kimiNonThinkingContentParts(content gjson.Result) ([][]byte, bool) {
-	if !content.IsArray() {
-		return nil, false
-	}
-	parts := make([][]byte, 0, len(content.Array()))
-	hasToolUse := false
-	for _, part := range content.Array() {
-		switch strings.TrimSpace(part.Get("type").String()) {
-		case "thinking", "redacted_thinking":
-			continue
-		case "tool_use":
-			if strings.TrimSpace(part.Get("id").String()) == "" {
-				return nil, false
+	// A single unambiguous match is fine. Multiple matches are only safe when
+	// exactly one carries thinking that matches the cached turn. More than one
+	// retained candidate is ambiguous; without any retained candidate, multiple
+	// text-only duplicates are indistinguishable. Both cases must fail closed.
+	if len(matches) > 1 {
+		var retained []int
+		for _, idx := range matches {
+			if helps.ContentHasThinking(messageItems[idx].Get("content")) {
+				retained = append(retained, idx)
 			}
-			hasToolUse = true
 		}
-		canonical, ok := kimiCanonicalJSON([]byte(part.Raw))
-		if !ok {
-			return nil, false
+		if len(retained) != 1 {
+			return body, false
 		}
-		parts = append(parts, canonical)
+		matches = retained
 	}
-	return parts, hasToolUse
-}
 
-func kimiCanonicalPartsEqual(left, right [][]byte) bool {
-	if len(left) != len(right) {
-		return false
+	idx := matches[0]
+	updated, errSet := sjson.SetRawBytes(body, fmt.Sprintf("messages.%d.content", idx), cachedContent)
+	if errSet != nil {
+		return body, false
 	}
-	for i := range left {
-		if !bytes.Equal(left[i], right[i]) {
-			return false
-		}
-	}
-	return true
-}
-
-func kimiJSONEqual(left, right []byte) bool {
-	canonicalLeft, leftOK := kimiCanonicalJSON(left)
-	canonicalRight, rightOK := kimiCanonicalJSON(right)
-	return leftOK && rightOK && bytes.Equal(canonicalLeft, canonicalRight)
-}
-
-func kimiCanonicalJSON(raw []byte) ([]byte, bool) {
-	decoder := json.NewDecoder(bytes.NewReader(raw))
-	decoder.UseNumber()
-	var value any
-	if errDecode := decoder.Decode(&value); errDecode != nil {
-		return nil, false
-	}
-	canonical, errMarshal := json.Marshal(value)
-	if errMarshal != nil {
-		return nil, false
-	}
-	return canonical, true
+	return updated, true
 }
 
 type kimiThinkingReplayStreamBlock struct {
@@ -252,6 +207,7 @@ type kimiThinkingReplayStreamBlock struct {
 	thinking             strings.Builder
 	signature            strings.Builder
 	input                strings.Builder
+	citations            []byte
 	textInitialized      bool
 	thinkingInitialized  bool
 	signatureInitialized bool
@@ -350,6 +306,27 @@ func (a *kimiThinkingReplayStreamAccumulator) observeBlockDelta(root gjson.Resul
 			block.input.WriteString(suffix)
 			block.hasInputDelta = true
 		}
+	case "citations_delta":
+		citation := delta.Get("citation")
+		if !citation.IsObject() {
+			a.abandon()
+			return
+		}
+		raw := []byte(citation.Raw)
+		if len(block.citations) == 0 {
+			if !a.reserveBytes(len(raw) + 2) {
+				return
+			}
+			block.citations = append(append([]byte("["), raw...), ']')
+		} else {
+			if !a.reserveBytes(len(raw) + 1) {
+				return
+			}
+			block.citations = block.citations[:len(block.citations)-1]
+			block.citations = append(block.citations, ',')
+			block.citations = append(block.citations, raw...)
+			block.citations = append(block.citations, ']')
+		}
 	default:
 		a.abandon()
 	}
@@ -426,6 +403,9 @@ func (a *kimiThinkingReplayStreamAccumulator) content() ([]byte, bool) {
 		}
 		if errSet == nil && block.hasInputDelta {
 			raw, errSet = sjson.SetRawBytes(raw, "input", []byte(block.input.String()))
+		}
+		if errSet == nil && len(block.citations) > 0 {
+			raw, errSet = sjson.SetRawBytes(raw, "citations", block.citations)
 		}
 		if errSet != nil {
 			a.abandon()

--- a/internal/runtime/executor/kimi_thinking_replay_test.go
+++ b/internal/runtime/executor/kimi_thinking_replay_test.go
@@ -10,6 +10,7 @@ import (
 
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
@@ -64,7 +65,7 @@ func TestRestoreKimiThinkingReplayContentPreservesCompleteAssistantContent(t *te
 		t.Fatal("expected cached thinking content to be restored")
 	}
 	got := gjson.GetBytes(updated, "messages.1.content")
-	if !kimiJSONEqual([]byte(got.Raw), cached) {
+	if !helps.JSONEqual([]byte(got.Raw), cached) {
 		t.Fatalf("restored content = %s, want complete cached content %s", got.Raw, cached)
 	}
 }
@@ -77,8 +78,74 @@ func TestRestoreKimiThinkingReplayContentDoesNotReplaceExistingThinking(t *testi
 	if restored {
 		t.Fatalf("existing thinking must not be replaced: %s", updated)
 	}
-	if !kimiJSONEqual(updated, body) {
+	if !helps.JSONEqual(updated, body) {
 		t.Fatalf("request changed despite existing thinking: got %s want %s", updated, body)
+	}
+}
+
+func TestRestoreKimiThinkingReplayContentRejectsDuplicateUnsignedCandidates(t *testing.T) {
+	cached := []byte(`[{"type":"thinking","thinking":"cached","signature":"cached-signature"},{"type":"text","text":"OK"}]`)
+	// The earlier assistant is the retained signed turn, the later one is a
+	// new unsigned duplicate with the same visible text. The reverse scan must
+	// not restore the cached signature into the later duplicate.
+	body := []byte(`{"messages":[
+		{"role":"user","content":"hi"},
+		{"role":"assistant","content":[{"type":"text","text":"OK"}]},
+		{"role":"user","content":"again"},
+		{"role":"assistant","content":[{"type":"text","text":"OK"}]}
+	]}`)
+
+	updated, restored := restoreKimiThinkingReplayContent(body, cached)
+	if restored {
+		t.Fatalf("duplicate unsigned candidates must not be restored: %s", updated)
+	}
+	if !helps.JSONEqual(updated, body) {
+		t.Fatalf("request body changed when it should not: %s", updated)
+	}
+}
+
+func TestRestoreKimiThinkingReplayContentPrefersRetainedDuplicate(t *testing.T) {
+	cached := []byte(`[{"type":"thinking","thinking":"cached","signature":"cached-signature"},{"type":"text","text":"OK"}]`)
+	// Two matching assistants; the earlier one still carries the cached
+	// thinking (retained), the later one is an unsigned duplicate. The
+	// retained turn should receive the signature.
+	body := []byte(`{"messages":[
+		{"role":"user","content":"hi"},
+		{"role":"assistant","content":[{"type":"thinking","thinking":"cached","signature":"existing-signature"},{"type":"text","text":"OK"}]},
+		{"role":"user","content":"again"},
+		{"role":"assistant","content":[{"type":"text","text":"OK"}]}
+	]}`)
+
+	updated, restored := restoreKimiThinkingReplayContent(body, cached)
+	if !restored {
+		t.Fatal("expected restore for retained duplicate")
+	}
+	// The retained turn is at index 1; the later duplicate at index 3 stays unsigned.
+	if sig := gjson.GetBytes(updated, "messages.1.content.0.signature").String(); sig != "cached-signature" {
+		t.Fatalf("retained assistant got signature %q, want cached-signature", sig)
+	}
+	if sig := gjson.GetBytes(updated, "messages.3.content.0.signature").String(); sig != "" {
+		t.Fatalf("later duplicate should remain unsigned, got signature %q", sig)
+	}
+}
+
+func TestRestoreKimiThinkingReplayContentRejectsMultipleRetainedCandidates(t *testing.T) {
+	cached := []byte(`[{"type":"thinking","thinking":"cached","signature":"cached-signature"},{"type":"text","text":"OK"}]`)
+	// Two matching assistants both retain a thinking block with the same visible
+	// text; the cached signature must not be restored because the match is ambiguous.
+	body := []byte(`{"messages":[
+		{"role":"user","content":"hi"},
+		{"role":"assistant","content":[{"type":"thinking","thinking":"cached","signature":"sig-1"},{"type":"text","text":"OK"}]},
+		{"role":"user","content":"again"},
+		{"role":"assistant","content":[{"type":"thinking","thinking":"cached","signature":"sig-2"},{"type":"text","text":"OK"}]}
+	]}`)
+
+	updated, restored := restoreKimiThinkingReplayContent(body, cached)
+	if restored {
+		t.Fatalf("multiple retained candidates must fail closed: %s", updated)
+	}
+	if !helps.JSONEqual(updated, body) {
+		t.Fatalf("request body changed when it should not: %s", updated)
 	}
 }
 
@@ -202,7 +269,7 @@ func TestKimiExecutorClaudeNonStreamReplaysThinkingAcrossK3VariantSwitch(t *test
 		t.Fatalf("upstream request count = %d, want 2", len(upstreamBodies))
 	}
 	gotContent := gjson.GetBytes(upstreamBodies[1], "messages.1.content")
-	if !kimiJSONEqual([]byte(gotContent.Raw), []byte(cachedContent)) {
+	if !helps.JSONEqual([]byte(gotContent.Raw), []byte(cachedContent)) {
 		t.Fatalf("second upstream assistant content = %s, want %s", gotContent.Raw, cachedContent)
 	}
 	if _, found, errGet := internalcache.GetKimiThinkingReplayRequired(context.Background(), "k3", "execution:nonstream-switch"); errGet != nil || found {
@@ -358,6 +425,35 @@ func TestKimiExecutorClaudeStreamReplaysThinkingAcrossK3VariantSwitch(t *testing
 	}
 }
 
+func TestKimiThinkingReplayStreamAccumulator_PreservesCitations(t *testing.T) {
+	accumulator := newKimiThinkingReplayStreamAccumulator()
+	chunks := []byte(
+		"event: message_start\n" +
+			`data: {"type":"message_start","message":{"id":"msg_1","model":"k3"}}` + "\n\n" +
+			"event: content_block_start\n" +
+			`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"","citations":[]}}` + "\n\n" +
+			"event: content_block_delta\n" +
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"citations_delta","citation":{"type":"web_search_result_location","url":"https://example.com"}}}` + "\n\n" +
+			"event: content_block_delta\n" +
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"answer"}}` + "\n\n" +
+			"event: content_block_stop\n" +
+			`data: {"type":"content_block_stop","index":0}` + "\n\n" +
+			"event: message_stop\n" +
+			`data: {"type":"message_stop"}` + "\n\n",
+	)
+	accumulator.observe(chunks)
+	content, ok := accumulator.content()
+	if !ok {
+		t.Fatal("accumulator did not complete")
+	}
+	if !strings.Contains(string(content), `"citations"`) {
+		t.Fatalf("cached content missing citations: %s", content)
+	}
+	if !strings.Contains(string(content), `"https://example.com"`) {
+		t.Fatalf("cached citation missing url: %s", content)
+	}
+}
+
 func TestKimiThinkingReplayUnknownStreamDeltaPreservesPreviousCache(t *testing.T) {
 	internalcache.ClearKimiThinkingReplayCache()
 	t.Cleanup(internalcache.ClearKimiThinkingReplayCache)
@@ -397,7 +493,7 @@ func TestKimiThinkingReplayUnknownStreamDeltaPreservesPreviousCache(t *testing.T
 	consumeKimiReplayStream(t, wrapKimiThinkingReplayStream(context.Background(), &cliproxyexecutor.StreamResult{Chunks: chunks}, scope))
 
 	got, found, errGet := internalcache.GetKimiThinkingReplayRequired(context.Background(), "k3", sessionKey)
-	if errGet != nil || !found || !kimiJSONEqual(got, cached) {
+	if errGet != nil || !found || !helps.JSONEqual(got, cached) {
 		t.Fatalf("unknown successful delta changed previous cache: got %s, found %v, error %v", got, found, errGet)
 	}
 }

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -92,7 +92,7 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 			partType := part.Get("type").String()
 			if partType == "tool_use" {
 				if opts.DropToolSignatures {
-					updatedPart, changed := stripClaudeToolUseSignatureFields(part)
+					updatedPart, changed := StripClaudeToolUseSignatureFields(part)
 					if changed {
 						messageModified = true
 						report.DroppedSignatures++
@@ -122,6 +122,15 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 			if partType != "thinking" {
 				keptParts = append(keptParts, part.Raw)
 				continue
+			}
+
+			// Replay provenance is added only internally by the executor after the
+			// sanitizer has already run. Any client-supplied marker is untrusted and
+			// must be stripped so it cannot bypass signature validation.
+			if part.Get("_cliproxy_replay_provenance").Exists() {
+				updated, _ := sjson.Delete(part.Raw, "_cliproxy_replay_provenance")
+				part = gjson.Parse(updated)
+				messageModified = true
 			}
 
 			rawSignature := part.Get("signature").String()
@@ -219,7 +228,11 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 	return output, report
 }
 
-func stripClaudeToolUseSignatureFields(part gjson.Result) (string, bool) {
+// StripClaudeToolUseSignatureFields removes tool-use signature/provenance
+// fields and empty extra_content.google/extra_content wrappers. It is exported
+// so the executor's replay-cache match can normalize cached tool_use parts with
+// the same logic the upstream sanitizer applies.
+func StripClaudeToolUseSignatureFields(part gjson.Result) (string, bool) {
 	updated := part.Raw
 	changed := false
 	for _, sigPath := range claudeToolUseProvenancePaths() {

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -126,8 +126,42 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 
 			rawSignature := part.Get("signature").String()
 			if opts.PreserveEmptyThinkingBlocks {
-				report.Preserved++
-				keptParts = append(keptParts, part.Raw)
+				// In compat mode the block shape must survive, but the signature still
+				// needs to be normalized, emulated, or stripped to avoid sending an
+				// incompatible or opaque signature to the upstream.
+				decision := DecideSignatureCompatibilityForModel(targetProvider, opts.TargetModel, rawSignature, SignatureBlockKindClaudeThinking)
+				decision.Reason = fmt.Sprintf("messages[%d].content[%d]: %s", i, j, decision.Reason)
+				report.Decisions = append(report.Decisions, decision)
+
+				switch decision.Action {
+				case SignatureActionPreserve:
+					report.Preserved++
+					if decision.NormalizedSignature != "" && decision.NormalizedSignature != rawSignature {
+						updated, _ := sjson.Set(part.Raw, "signature", decision.NormalizedSignature)
+						keptParts = append(keptParts, updated)
+						messageModified = true
+					} else {
+						keptParts = append(keptParts, part.Raw)
+					}
+				case SignatureActionReplaceWithGeminiBypass:
+					report.ReplacedSignatures++
+					updated, _ := sjson.Set(part.Raw, "signature", decision.ReplacementSignature)
+					keptParts = append(keptParts, updated)
+					messageModified = true
+				default:
+					// DropBlock, DropSignature, or NoCompatibleReplacement: keep the
+					// block shape for the compat endpoint and preserve empty placeholders
+					// with their required signature member.
+					if isEmptyClaudeThinkingPlaceholder(part) {
+						report.Preserved++
+						keptParts = append(keptParts, part.Raw)
+					} else {
+						report.DroppedSignatures++
+						updated, _ := sjson.Set(part.Raw, "signature", "")
+						keptParts = append(keptParts, updated)
+					}
+					messageModified = true
+				}
 				continue
 			}
 			if targetProvider == SignatureProviderClaude && isEmptyClaudeThinkingPlaceholder(part) && !opts.DropEmptyThinkingPlaceholders {

--- a/internal/signature/claude_messages_sanitize_compat_test.go
+++ b/internal/signature/claude_messages_sanitize_compat_test.go
@@ -1,6 +1,8 @@
 package signature
 
 import (
+	"bytes"
+	"encoding/base64"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -16,12 +18,81 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamPreservesEmptyThinkingInCompatMo
 
 	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "deepseek-v4", true)
 	part := gjson.GetBytes(withCompat, "messages.0.content.0")
-	if part.Get("type").String() != "thinking" || part.Get("signature").String() != "" {
-		t.Fatalf("compat sanitizer dropped empty thinking: %s", withCompat)
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() {
+		t.Fatalf("compat sanitizer dropped empty thinking or its signature member: %s", withCompat)
 	}
 }
 
-func TestSanitizeClaudeMessagesForClaudeUpstreamPreservesOpaqueThinkingSignatureInCompatMode(t *testing.T) {
+func TestSanitizeClaudeMessagesForClaudeUpstreamRetainsEmptySignatureOnGeminiPrefixInCompatMode(t *testing.T) {
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"gemini#EgI="}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not retain empty signature member on foreign-prefixed thinking block: %s", withCompat)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamRetainsEmptySignatureOnMislabeledClaudePrefixInCompatMode(t *testing.T) {
+	geminiSig := testGemini3ThoughtSignature([]byte{0x01, 0x0c, 0x39, 0xd6, 0xc7, 0x34})
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"claude#` + geminiSig + `"}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not retain empty signature member on mislabeled claude# block: %s", withCompat)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamRetainsEmptySignatureOnNestedClaudePrefixInCompatMode(t *testing.T) {
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"claude#vendor#EgI="}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not retain empty signature member on nested claude# block: %s", withCompat)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamRetainsEmptySignatureOnUnknownVendorPrefixInCompatMode(t *testing.T) {
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"vendor#EgI="}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not retain empty signature member on unknown-vendor block: %s", withCompat)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamNormalizesWhitespacePaddedShortSignatureInCompatMode(t *testing.T) {
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"  EgI=  "}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() {
+		t.Fatalf("compat sanitizer dropped the thinking block: %s", withCompat)
+	}
+	if got := part.Get("signature").String(); got != "" {
+		t.Fatalf("compat sanitizer forwarded short signature %q, want empty signature", got)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamRejectsGrokOpaqueERInCompatMode(t *testing.T) {
+	// Grok/xAI encrypted_content is uniformly distributed and can base64-encode
+	// to a string starting with 'E' or 'R', but it is not a valid Claude
+	// thinking signature and must be cleared before forwarding.
+	grokLike := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	sig := base64.StdEncoding.EncodeToString(grokLike)
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"` + sig + `"}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not clear Grok-style E/R opaque signature: %s", withCompat)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamStripsOpaqueThinkingSignatureInCompatMode(t *testing.T) {
 	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"opaque-deepseek-id"}]}]}`)
 
 	withoutCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "deepseek-v4")
@@ -31,7 +102,7 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamPreservesOpaqueThinkingSignature
 
 	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "deepseek-v4", true)
 	part := gjson.GetBytes(withCompat, "messages.0.content.0")
-	if part.Get("type").String() != "thinking" || part.Get("signature").String() != "opaque-deepseek-id" {
-		t.Fatalf("compat sanitizer dropped opaque signature: %s", withCompat)
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not retain empty signature member on opaque-signature block: %s", withCompat)
 	}
 }

--- a/internal/signature/claude_messages_sanitize_compat_test.go
+++ b/internal/signature/claude_messages_sanitize_compat_test.go
@@ -92,6 +92,24 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamRejectsGrokOpaqueERInCompatMode(
 	}
 }
 
+func TestSanitizeClaudeMessagesForClaudeUpstreamStripsClientReplayProvenanceMarkerInCompatMode(t *testing.T) {
+	// Client-supplied _cliproxy_replay_provenance must not bypass signature
+	// validation. The marker is stripped and the foreign signature is cleared.
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"opaque-foreign-sig","_cliproxy_replay_provenance":true}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" {
+		t.Fatalf("compat sanitizer dropped the thinking block: %s", withCompat)
+	}
+	if part.Get("_cliproxy_replay_provenance").Exists() {
+		t.Fatalf("compat sanitizer did not strip client-supplied replay provenance marker: %s", withCompat)
+	}
+	if part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer preserved foreign signature via client-supplied marker: %s", withCompat)
+	}
+}
+
 func TestSanitizeClaudeMessagesForClaudeUpstreamStripsOpaqueThinkingSignatureInCompatMode(t *testing.T) {
 	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"opaque-deepseek-id"}]}]}`)
 


### PR DESCRIPTION
## Summary

Split Claude/Kimi thinking replay-cache hardening from PR #5150.

- Keep replay matching aligned after truncated or compacted history.
- Preserve signed replay turns across unsigned responses.
- Bound and atomically update replay aliases, including Home KV aliases.
- Restore cached thinking before MCP remapping and cache cross-format Claude streams.
- Keep Claude and Kimi replay scopes isolated by credential, caller, and conversation.

This branch includes the sanitizer prerequisite from PR #5150 so replay restoration runs after signature sanitization. The prerequisite is identical to the sanitizer-only PR and becomes an ancestor when PR #5150 merges.

## Scope

Only replay-cache and replay-integration paths are changed. Cloaking/user identity changes remain in PR #5152; cache-control changes remain in PR #5154; selector/session-cache changes remain in their existing auth work.

## Test plan

- [x] `go test ./internal/cache ./internal/runtime/executor/helps -run 'Replay|replay|Alias|alias'`
- [x] `go test ./internal/runtime/executor -run 'Replay|replay|Thinking|thinking'`
