### PR TITLE
feat(openai-compat): support Responses upstream protocol

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -613,6 +613,7 @@ nonstream-keepalive-interval: 0
 #     disabled: false # optional: set to true to disable this provider without removing it
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
+#     protocol: "responses" # optional: use the OpenAI Responses API (/responses); omitted uses /chat/completions
 #     support-prompt-cache-key: false # optional: derive prompt_cache_key for requests from all input protocols
 #     disable-cooling: false # optional provider override: true disables cooling, false enables it; omit to inherit global
 #     request-retry: 3 # optional per-provider override; 0 disables additional rounds; omit or set < 0 to inherit global

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -796,6 +796,7 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 		Prefix                *string                             `json:"prefix"`
 		Disabled              *bool                               `json:"disabled"`
 		DisableCooling        json.RawMessage                     `json:"disable-cooling"`
+		Protocol              *string                             `json:"protocol"`
 		BaseURL               *string                             `json:"base-url"`
 		APIKeyEntries         *[]config.OpenAICompatibilityAPIKey `json:"api-key-entries"`
 		Models                *[]config.OpenAICompatibilityModel  `json:"models"`
@@ -846,6 +847,9 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 	}
 	if !applyDisableCoolingPatch(c, body.Value.DisableCooling, &entry.DisableCooling) {
 		return
+	}
+	if body.Value.Protocol != nil {
+		entry.Protocol = strings.TrimSpace(*body.Value.Protocol)
 	}
 	if body.Value.RequestRetry != nil {
 		entry.RequestRetry = body.Value.RequestRetry
@@ -1792,6 +1796,7 @@ func normalizeOpenAICompatibilityEntry(entry *config.OpenAICompatibility) {
 	}
 	// Trim base-url; empty base-url indicates provider should be removed by sanitization
 	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+	entry.Protocol = strings.TrimSpace(entry.Protocol)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	existing := make(map[string]struct{}, len(entry.APIKeyEntries))
 	for i := range entry.APIKeyEntries {

--- a/internal/config/config_normalization.go
+++ b/internal/config/config_normalization.go
@@ -163,6 +163,7 @@ func (cfg *Config) SanitizeOpenAICompatibility() {
 		e.Name = strings.TrimSpace(e.Name)
 		e.Prefix = normalizeModelPrefix(e.Prefix)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
+		e.Protocol = strings.TrimSpace(e.Protocol)
 		e.Headers = NormalizeHeaders(e.Headers)
 		if e.BaseURL == "" {
 			// Skip providers with no base-url; treated as removed

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -663,6 +663,9 @@ type OpenAICompatibility struct {
 	// BaseURL is the base URL for the external OpenAI-compatible API endpoint.
 	BaseURL string `yaml:"base-url" json:"base-url"`
 
+	// Protocol selects the upstream API: "responses" for /responses; otherwise /chat/completions.
+	Protocol string `yaml:"protocol,omitempty" json:"protocol,omitempty"`
+
 	// APIKeyEntries defines API keys with optional per-key proxy configuration.
 	APIKeyEntries []OpenAICompatibilityAPIKey `yaml:"api-key-entries,omitempty" json:"api-key-entries,omitempty"`
 

--- a/internal/config/request_retry_test.go
+++ b/internal/config/request_retry_test.go
@@ -25,6 +25,7 @@ claude-api-key:
 openai-compatibility:
   - name: "compat"
     base-url: "https://compat.example.com/v1"
+    protocol: "responses"
     request-retry: 0
     api-key-entries:
       - api-key: "compat-key"
@@ -59,6 +60,9 @@ vertex-api-key:
 	}
 	if len(cfg.OpenAICompatibility) != 1 || cfg.OpenAICompatibility[0].RequestRetry == nil || *cfg.OpenAICompatibility[0].RequestRetry != 0 {
 		t.Fatalf("openai-compatibility[0].request-retry = %v, want 0", cfg.OpenAICompatibility[0].RequestRetry)
+	}
+	if cfg.OpenAICompatibility[0].Protocol != "responses" {
+		t.Fatalf("openai-compatibility[0].protocol = %q, want responses", cfg.OpenAICompatibility[0].Protocol)
 	}
 	if len(cfg.VertexCompatAPIKey) != 1 || cfg.VertexCompatAPIKey[0].RequestRetry == nil || *cfg.VertexCompatAPIKey[0].RequestRetry != 4 {
 		t.Fatalf("vertex[0].request-retry = %v, want 4", cfg.VertexCompatAPIKey[0].RequestRetry)

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -108,10 +108,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	to := sdktranslator.FromString("openai")
 	endpoint := "/chat/completions"
 	if isResponses {
-		to = sdktranslator.FromString("openai-response")
-		if from == sdktranslator.FormatClaude {
-			to = sdktranslator.FormatCodex
-		}
+		to = openAICompatResponsesTarget(from)
 		if opts.Alt == "responses/compact" {
 			endpoint = "/responses/compact"
 		} else {
@@ -349,10 +346,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	to := sdktranslator.FromString("openai")
 	endpoint := "/chat/completions"
 	if isResponses {
-		to = sdktranslator.FromString("openai-response")
-		if from == sdktranslator.FormatClaude {
-			to = sdktranslator.FormatCodex
-		}
+		to = openAICompatResponsesTarget(from)
 		if opts.Alt == "responses/compact" {
 			endpoint = "/responses/compact"
 		} else {
@@ -751,7 +745,7 @@ func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyau
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("openai")
 	if isResponses {
-		to = sdktranslator.FromString("openai-response")
+		to = openAICompatResponsesTarget(from)
 	}
 	isCompat := helps.APIKeyModelIsCompat(req)
 	translated := helps.TranslateRequestWithAPIKeyModelCompatibility(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false, isCompat)
@@ -784,6 +778,13 @@ func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyau
 	}
 	translatedUsage := sdktranslator.TranslateTokenCount(ctx, to, responseFormat, count, usageJSON)
 	return cliproxyexecutor.Response{Payload: translatedUsage}, nil
+}
+
+func openAICompatResponsesTarget(from sdktranslator.Format) sdktranslator.Format {
+	if from == sdktranslator.FormatOpenAIResponse {
+		return sdktranslator.FormatOpenAIResponse
+	}
+	return sdktranslator.FormatCodex
 }
 
 // Refresh is a no-op for API-key based compatibility providers.

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -100,14 +100,23 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		err = statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL"}
 		return
 	}
+	compat := e.resolveCompatConfig(auth)
+	isResponses := isOpenAICompatResponses(compat, opts)
 
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("openai")
 	endpoint := "/chat/completions"
-	if opts.Alt == "responses/compact" {
+	if isResponses {
 		to = sdktranslator.FromString("openai-response")
-		endpoint = "/responses/compact"
+		if from == sdktranslator.FormatClaude {
+			to = sdktranslator.FormatCodex
+		}
+		if opts.Alt == "responses/compact" {
+			endpoint = "/responses/compact"
+		} else {
+			endpoint = "/responses"
+		}
 	}
 	originalPayloadSource := req.Payload
 	if len(opts.OriginalRequest) > 0 {
@@ -126,19 +135,17 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
-	if helps.ShouldNormalizeOpenAIToolResultsForModel(e.resolveCompatConfig(auth), baseModel, requestedModel) {
+	if helps.ShouldNormalizeOpenAIToolResultsForModel(compat, baseModel, requestedModel) {
 		translated = helps.NormalizeOpenAIToolResultsTextOnly(translated)
 	}
-	if opts.Alt != "responses/compact" {
+	if !isResponses {
 		translated, err = e.applyPromptCacheKey(ctx, auth, from, baseModel, req, opts, translated)
 		if err != nil {
 			return resp, err
 		}
 	}
-	if opts.Alt == "responses/compact" {
-		if updated, errDelete := sjson.DeleteBytes(translated, "stream"); errDelete == nil {
-			translated = updated
-		}
+	if isResponses {
+		translated = helps.SetBoolIfDifferent(translated, "stream", false)
 		translated = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "openai compat executor", translated)
 	}
 	reporter.SetTranslatedReasoningEffort(translated, to.String())
@@ -202,12 +209,27 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		return resp, err
 	}
 	helps.AppendAPIResponseChunk(ctx, e.cfg, body)
-	reporter.Publish(ctx, helps.ParseOpenAIUsage(body))
+	if isResponses {
+		if detail, ok := helps.ParseCodexUsage(body); ok {
+			reporter.Publish(ctx, detail)
+		} else {
+			reporter.Publish(ctx, helps.ParseOpenAIUsage(body))
+		}
+	} else {
+		reporter.Publish(ctx, helps.ParseOpenAIUsage(body))
+	}
 	// Ensure we at least record the request even if upstream doesn't return usage
 	reporter.EnsurePublished(ctx)
 	// Translate response back to source format when needed
 	var param any
-	out := sdktranslator.TranslateNonStream(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, body, &param)
+	translationBody := body
+	if to == sdktranslator.FormatCodex && gjson.GetBytes(body, "object").String() == "response" {
+		wrapped := []byte(`{"type":"response.completed","response":{}}`)
+		if updated, errSet := sjson.SetRawBytes(wrapped, "response", body); errSet == nil {
+			translationBody = updated
+		}
+	}
+	out := sdktranslator.TranslateNonStream(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, translationBody, &param)
 	if responseFormat == sdktranslator.FormatOpenAIResponse {
 		out = helps.EnsureResponsesUsageDetails(out)
 	}
@@ -319,10 +341,24 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		err = statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL"}
 		return nil, err
 	}
+	compat := e.resolveCompatConfig(auth)
+	isResponses := isOpenAICompatResponses(compat, opts)
 
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("openai")
+	endpoint := "/chat/completions"
+	if isResponses {
+		to = sdktranslator.FromString("openai-response")
+		if from == sdktranslator.FormatClaude {
+			to = sdktranslator.FormatCodex
+		}
+		if opts.Alt == "responses/compact" {
+			endpoint = "/responses/compact"
+		} else {
+			endpoint = "/responses"
+		}
+	}
 	originalPayloadSource := req.Payload
 	if len(opts.OriginalRequest) > 0 {
 		originalPayloadSource = opts.OriginalRequest
@@ -340,22 +376,26 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
-	if helps.ShouldNormalizeOpenAIToolResultsForModel(e.resolveCompatConfig(auth), baseModel, requestedModel) {
+	if helps.ShouldNormalizeOpenAIToolResultsForModel(compat, baseModel, requestedModel) {
 		translated = helps.NormalizeOpenAIToolResultsTextOnly(translated)
 	}
-	if opts.Alt != "responses/compact" {
+	if !isResponses {
 		translated, err = e.applyPromptCacheKey(ctx, auth, from, baseModel, req, opts, translated)
 		if err != nil {
 			return nil, err
 		}
+		// Request usage data in the final streaming chunk so that token statistics
+		// are captured even when the upstream is an OpenAI-compatible provider.
+		translated = helps.SetBoolIfDifferent(translated, "stream_options.include_usage", true)
+	} else {
+		if updated, errDelete := sjson.DeleteBytes(translated, "stream_options"); errDelete == nil {
+			translated = updated
+		}
+		translated = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "openai compat executor", translated)
 	}
-
-	// Request usage data in the final streaming chunk so that token statistics
-	// are captured even when the upstream is an OpenAI-compatible provider.
-	translated = helps.SetBoolIfDifferent(translated, "stream_options.include_usage", true)
 	reporter.SetTranslatedReasoningEffort(translated, to.String())
 
-	url := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
+	url := strings.TrimSuffix(baseURL, "/") + endpoint
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
 	if err != nil {
 		return nil, err
@@ -490,7 +530,17 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 					return true
 				}
 			}
-			if isDone {
+			eventType := gjson.GetBytes(dataPayload, "type").String()
+			if eventType == "" {
+				eventType = eventName
+			}
+			isResponsesDone := isResponses && isResponsesTerminalEvent(eventType)
+			if isResponsesDone {
+				if detail, ok := helps.ParseCodexUsage(dataPayload); ok {
+					streamUsage.Observe(detail, true)
+				}
+			}
+			if isDone || isResponsesDone {
 				seenDone = true
 				return true
 			}
@@ -501,6 +551,11 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
+			if isResponses {
+				if detail, ok := helps.ParseCodexUsage(line); ok {
+					streamUsage.Observe(detail, true)
+				}
+			}
 			streamUsage.ObserveOpenAIStream(line)
 			trimmedLine := bytes.TrimSpace(line)
 			if len(trimmedLine) == 0 {
@@ -688,11 +743,16 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 }
 
 func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	compat := e.resolveCompatConfig(auth)
+	isResponses := isOpenAICompatResponses(compat, opts)
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("openai")
+	if isResponses {
+		to = sdktranslator.FromString("openai-response")
+	}
 	isCompat := helps.APIKeyModelIsCompat(req)
 	translated := helps.TranslateRequestWithAPIKeyModelCompatibility(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false, isCompat)
 
@@ -708,12 +768,20 @@ func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyau
 		return cliproxyexecutor.Response{}, fmt.Errorf("openai compat executor: tokenizer init failed: %w", err)
 	}
 
-	count, err := helps.CountOpenAIChatTokens(enc, translated)
+	var count int64
+	if isResponses {
+		count, err = countCodexInputTokens(enc, translated)
+	} else {
+		count, err = helps.CountOpenAIChatTokens(enc, translated)
+	}
 	if err != nil {
 		return cliproxyexecutor.Response{}, fmt.Errorf("openai compat executor: token counting failed: %w", err)
 	}
 
 	usageJSON := helps.BuildOpenAIUsageJSON(count)
+	if isResponses {
+		usageJSON = []byte(fmt.Sprintf(`{"response":{"usage":{"input_tokens":%d,"output_tokens":0,"total_tokens":%d}}}`, count, count))
+	}
 	translatedUsage := sdktranslator.TranslateTokenCount(ctx, to, responseFormat, count, usageJSON)
 	return cliproxyexecutor.Response{Payload: translatedUsage}, nil
 }
@@ -1024,3 +1092,23 @@ func (e statusErr) Error() string {
 }
 func (e statusErr) StatusCode() int            { return e.code }
 func (e statusErr) RetryAfter() *time.Duration { return e.retryAfter }
+
+func isOpenAICompatResponses(compat *config.OpenAICompatibility, opts cliproxyexecutor.Options) bool {
+	if opts.Alt == "responses/compact" {
+		return true
+	}
+	if compat == nil {
+		return false
+	}
+	protocol := strings.ToLower(strings.TrimSpace(compat.Protocol))
+	return protocol == "responses" || protocol == "openai-response" || protocol == "openai-responses"
+}
+
+func isResponsesTerminalEvent(eventType string) bool {
+	switch eventType {
+	case "response.completed", "response.done", "response.incomplete":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -76,6 +76,56 @@ func TestOpenAICompatExecutorCompactPassthrough(t *testing.T) {
 	}
 }
 
+func TestOpenAICompatExecutorResponsesProtocol(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","object":"response","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:     "compat-responses",
+			Protocol: "responses",
+		}},
+	})
+	auth := &cliproxyauth.Auth{
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			"base_url":     server.URL + "/v1",
+			"api_key":      "test",
+			"compat_name":  "compat-responses",
+			"provider_key": "compat-responses",
+		},
+	}
+	payload := []byte(`{"model":"ext-gpt-5-6-sol-1m","input":"hello","stream":true}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "ext-gpt-5-6-sol-1m",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotPath != "/v1/responses" {
+		t.Fatalf("path = %q, want /v1/responses", gotPath)
+	}
+	if got := gjson.GetBytes(gotBody, "input").String(); got != "hello" {
+		t.Fatalf("input = %q, want hello; body=%s", got, string(gotBody))
+	}
+	if got := gjson.GetBytes(gotBody, "stream").Bool(); got {
+		t.Fatalf("stream = true, want false; body=%s", string(gotBody))
+	}
+	if gjson.GetBytes(gotBody, "messages").Exists() {
+		t.Fatalf("unexpected messages in Responses request: %s", string(gotBody))
+	}
+}
+
 func TestOpenAICompatExecutorPayloadOverrideWinsOverThinkingSuffix(t *testing.T) {
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -126,6 +126,110 @@ func TestOpenAICompatExecutorResponsesProtocol(t *testing.T) {
 	}
 }
 
+func TestOpenAICompatExecutorResponsesProtocolFromChatCompletions(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","object":"response","created_at":1700000000,"model":"example-model","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:     "compat-responses",
+			Protocol: "responses",
+		}},
+	})
+	auth := &cliproxyauth.Auth{
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			"base_url":     server.URL + "/v1",
+			"api_key":      "test",
+			"compat_name":  "compat-responses",
+			"provider_key": "compat-responses",
+		},
+	}
+	payload := []byte(`{"model":"example-model","messages":[{"role":"user","content":"hello"}]}`)
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "example-model",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotPath != "/v1/responses" {
+		t.Fatalf("path = %q, want /v1/responses", gotPath)
+	}
+	if !gjson.GetBytes(gotBody, "input").Exists() {
+		t.Fatalf("expected input in Responses request: %s", string(gotBody))
+	}
+	if gjson.GetBytes(gotBody, "messages").Exists() {
+		t.Fatalf("unexpected messages in Responses request: %s", string(gotBody))
+	}
+	if got := gjson.GetBytes(resp.Payload, "choices.0.message.content").String(); got != "ok" {
+		t.Fatalf("response content = %q, want ok; payload=%s", got, string(resp.Payload))
+	}
+}
+
+func TestOpenAICompatExecutorResponsesProtocolStreamFromChatCompletions(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"created_at\":1700000000,\"model\":\"example-model\"}}\n\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"example-model\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n")
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:     "compat-responses",
+			Protocol: "responses",
+		}},
+	})
+	auth := &cliproxyauth.Auth{
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			"base_url":     server.URL + "/v1",
+			"api_key":      "test",
+			"compat_name":  "compat-responses",
+			"provider_key": "compat-responses",
+		},
+	}
+	payload := []byte(`{"model":"example-model","messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "example-model",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	var chunks []byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream error: %v", chunk.Err)
+		}
+		chunks = append(chunks, chunk.Payload...)
+	}
+	if !gjson.GetBytes(gotBody, "input").Exists() {
+		t.Fatalf("expected input in Responses request: %s", string(gotBody))
+	}
+	if gjson.GetBytes(gotBody, "messages").Exists() {
+		t.Fatalf("unexpected messages in Responses request: %s", string(gotBody))
+	}
+	if !bytes.Contains(chunks, []byte(`"content":"ok"`)) {
+		t.Fatalf("expected translated Chat Completions content; chunks=%s", string(chunks))
+	}
+}
+
 func TestOpenAICompatExecutorPayloadOverrideWinsOverThinkingSuffix(t *testing.T) {
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/watcher/diff/openai_compat.go
+++ b/internal/watcher/diff/openai_compat.go
@@ -77,6 +77,9 @@ func describeOpenAICompatibilityUpdate(oldEntry, newEntry config.OpenAICompatibi
 	oldModelCount := countOpenAIModels(oldEntry.Models)
 	newModelCount := countOpenAIModels(newEntry.Models)
 	details := make([]string, 0, 3)
+	if oldEntry.Protocol != newEntry.Protocol {
+		details = append(details, fmt.Sprintf("protocol %s -> %s", oldEntry.Protocol, newEntry.Protocol))
+	}
 	if oldEntry.Disabled != newEntry.Disabled {
 		details = append(details, fmt.Sprintf("disabled %t -> %t", oldEntry.Disabled, newEntry.Disabled))
 	}
@@ -164,6 +167,9 @@ func openAICompatSignature(entry config.OpenAICompatibility) string {
 	}
 	if v := strings.TrimSpace(entry.BaseURL); v != "" {
 		parts = append(parts, "base="+v)
+	}
+	if v := strings.TrimSpace(entry.Protocol); v != "" {
+		parts = append(parts, "protocol="+strings.ToLower(v))
 	}
 
 	models := make([]string, 0, len(entry.Models))


### PR DESCRIPTION
## Summary

- add an optional `protocol` field to `openai-compatibility` providers
- route providers configured with `protocol: responses` through `/responses` for streaming and non-streaming execution
- use Responses translation, usage accounting, and token counting for those providers
- expose the setting through config normalization, management PATCH, and watcher diffs
- preserve the existing `/responses/compact` special case and the default `/chat/completions` behavior

Example:

```yaml
openai-compatibility:
  - name: "responses-provider"
    base-url: "https://example.com/v1"
    protocol: "responses"
    api-key-entries:
      - api-key: "..."
    models:
      - name: "example-model"
        alias: "example-model"
```

This is provider-agnostic and contains no deployment-specific routing or model configuration.

## Compatibility

The change is additive. Providers without `protocol` continue to use `/chat/completions` exactly as before.

Accepted Responses aliases are `responses`, `openai-response`, and `openai-responses`; the documented value is `responses`.

## Validation

Passed:

```text
go test -v ./internal/runtime/executor -run 'TestOpenAICompatExecutor(ResponsesProtocol|CompactPassthrough)$'
go test -v ./internal/config -run TestParseConfigBytesRequestRetry
go test ./internal/config ./internal/watcher/diff ./internal/api/handlers/management
go build -o test-output ./cmd/server

git diff --check
```

The full `internal/runtime/executor` package also ran; three unrelated environment-sensitive Claude fingerprint tests expected Linux headers while the test environment reported MacOS. The focused OpenAI-compatible routing tests passed.

Closes #5195.