### PR TITLE
[codex] bind API keys to credential groups

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -41,6 +41,15 @@ api-keys:
   - "your-api-key-2"
   - "your-api-key-3"
 
+# Optionally restrict a downstream API key to credentials carrying one of the
+# listed credential_group values in their auth JSON. Keys omitted here retain
+# unrestricted legacy behavior. Scoped keys never fall back outside their groups.
+# An explicitly empty list denies all credentials; use the management DELETE
+# endpoint to remove a binding and restore unrestricted behavior.
+# api-key-credential-groups:
+#   "your-api-key-1": ["team-a"]
+#   "your-api-key-2": ["team-b"]
+
 # Enable debug logging
 debug: false
 
@@ -632,6 +641,7 @@ nonstream-keepalive-interval: 0
 #       # X-Claude-Code-Session-Id: "$ABC" # copies client's "ABC" header
 #     api-key-entries:
 #       - api-key: "sk-or-v1-...b780"
+#         credential-group: "team-a" # optional: only downstream API keys assigned to team-a may use this credential
 #         weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #         proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override
 #         # proxy-url: "direct" # optional: explicit direct connect for this credential

--- a/internal/access/config_access/provider.go
+++ b/internal/access/config_access/provider.go
@@ -24,16 +24,17 @@ func Register(cfg *sdkconfig.SDKConfig) {
 
 	sdkaccess.RegisterProvider(
 		sdkaccess.AccessProviderTypeConfigAPIKey,
-		newProvider(sdkaccess.DefaultAccessProviderName, keys),
+		newProvider(sdkaccess.DefaultAccessProviderName, keys, cfg.APIKeyCredentialGroups),
 	)
 }
 
 type provider struct {
-	name string
-	keys map[string]struct{}
+	name             string
+	keys             map[string]struct{}
+	credentialGroups map[string]string
 }
 
-func newProvider(name string, keys []string) *provider {
+func newProvider(name string, keys []string, credentialGroups map[string][]string) *provider {
 	providerName := strings.TrimSpace(name)
 	if providerName == "" {
 		providerName = sdkaccess.DefaultAccessProviderName
@@ -42,7 +43,30 @@ func newProvider(name string, keys []string) *provider {
 	for _, key := range keys {
 		keySet[key] = struct{}{}
 	}
-	return &provider{name: providerName, keys: keySet}
+	normalizedGroups := make(map[string]string)
+	for key, groups := range credentialGroups {
+		key = strings.TrimSpace(key)
+		if _, exists := keySet[key]; !exists {
+			continue
+		}
+		seenGroups := make(map[string]struct{}, len(groups))
+		cleanGroups := make([]string, 0, len(groups))
+		for _, group := range groups {
+			group = strings.TrimSpace(group)
+			if group == "" {
+				continue
+			}
+			if _, duplicate := seenGroups[group]; duplicate {
+				continue
+			}
+			seenGroups[group] = struct{}{}
+			cleanGroups = append(cleanGroups, group)
+		}
+		// Preserve explicitly configured empty groups. Their presence is a
+		// fail-closed restriction, while an omitted key retains legacy behavior.
+		normalizedGroups[key] = strings.Join(cleanGroups, ",")
+	}
+	return &provider{name: providerName, keys: keySet, credentialGroups: normalizedGroups}
 }
 
 func (p *provider) Identifier() string {
@@ -90,12 +114,14 @@ func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.
 			continue
 		}
 		if _, ok := p.keys[candidate.value]; ok {
+			metadata := map[string]string{"source": candidate.source}
+			if groups, restricted := p.credentialGroups[candidate.value]; restricted {
+				metadata["credential-groups"] = groups
+			}
 			return &sdkaccess.Result{
 				Provider:  p.Identifier(),
 				Principal: candidate.value,
-				Metadata: map[string]string{
-					"source": candidate.source,
-				},
+				Metadata:  metadata,
 			}, nil
 		}
 	}

--- a/internal/access/config_access/provider_test.go
+++ b/internal/access/config_access/provider_test.go
@@ -1,0 +1,59 @@
+package configaccess
+
+import (
+	"context"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestProviderCredentialGroupsMetadata(t *testing.T) {
+	provider := newProvider("", []string{"client-a", "client-b"}, map[string][]string{
+		"client-a": {" team-a ", "team-a", "team-b", ""},
+		"unknown":  {"ignored"},
+	})
+
+	request := httptest.NewRequest("GET", "/v1/models", nil)
+	request.Header.Set("Authorization", "Bearer client-a")
+	result, authErr := provider.Authenticate(context.Background(), request)
+	if authErr != nil {
+		t.Fatalf("Authenticate() error = %v", authErr)
+	}
+	want := map[string]string{"source": "authorization", "credential-groups": "team-a,team-b"}
+	if !reflect.DeepEqual(result.Metadata, want) {
+		t.Fatalf("Metadata = %#v, want %#v", result.Metadata, want)
+	}
+}
+
+func TestProviderUnscopedKeyKeepsLegacyBehavior(t *testing.T) {
+	provider := newProvider("", []string{"client-a", "client-b"}, map[string][]string{
+		"client-a": {"team-a"},
+	})
+
+	request := httptest.NewRequest("GET", "/v1/models", nil)
+	request.Header.Set("X-Api-Key", "client-b")
+	result, authErr := provider.Authenticate(context.Background(), request)
+	if authErr != nil {
+		t.Fatalf("Authenticate() error = %v", authErr)
+	}
+	if _, exists := result.Metadata["credential-groups"]; exists {
+		t.Fatalf("unscoped key unexpectedly received credential groups: %#v", result.Metadata)
+	}
+}
+
+func TestProviderExplicitEmptyGroupsRemainRestricted(t *testing.T) {
+	provider := newProvider("", []string{"client-a"}, map[string][]string{
+		"client-a": {"", "   "},
+	})
+
+	request := httptest.NewRequest("GET", "/v1/models", nil)
+	request.Header.Set("Authorization", "Bearer client-a")
+	result, authErr := provider.Authenticate(context.Background(), request)
+	if authErr != nil {
+		t.Fatalf("Authenticate() error = %v", authErr)
+	}
+	groups, exists := result.Metadata["credential-groups"]
+	if !exists || groups != "" {
+		t.Fatalf("credential-groups = %q, exists = %t; want explicit empty restriction", groups, exists)
+	}
+}

--- a/internal/api/handlers/management/config_api_key_credential_groups_test.go
+++ b/internal/api/handlers/management/config_api_key_credential_groups_test.go
@@ -1,0 +1,49 @@
+package management
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestNormalizeAPIKeyCredentialGroupsKeepsConfiguredKeysOnly(t *testing.T) {
+	got := normalizeAPIKeyCredentialGroups(map[string][]string{
+		" client-a ": {" team-a ", "team-a", "team-b", ""},
+		"removed":    {"team-c"},
+	}, []string{"client-a", "client-b"})
+	want := map[string][]string{"client-a": {"team-a", "team-b"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizeAPIKeyCredentialGroups() = %#v, want %#v", got, want)
+	}
+}
+
+func TestNormalizeAPIKeyCredentialGroupsPreservesExplicitEmptyRestriction(t *testing.T) {
+	got := normalizeAPIKeyCredentialGroups(map[string][]string{
+		"client-a": {"", "   "},
+	}, []string{"client-a", "client-b"})
+	want := map[string][]string{"client-a": {}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizeAPIKeyCredentialGroups() = %#v, want %#v", got, want)
+	}
+}
+
+func TestPruneAPIKeyCredentialGroupsAfterAPIKeyRemoval(t *testing.T) {
+	cfg := &config.Config{
+		SDKConfig: config.SDKConfig{
+			APIKeys: []string{"client-b"},
+			APIKeyCredentialGroups: map[string][]string{
+				"client-a": {"team-a"},
+				"client-b": {"team-b"},
+			},
+		},
+	}
+	handler := NewHandlerWithoutConfigFilePath(cfg, nil)
+
+	handler.pruneAPIKeyCredentialGroups()
+
+	want := map[string][]string{"client-b": {"team-b"}}
+	if !reflect.DeepEqual(cfg.APIKeyCredentialGroups, want) {
+		t.Fatalf("APIKeyCredentialGroups = %#v, want %#v", cfg.APIKeyCredentialGroups, want)
+	}
+}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -147,13 +147,131 @@ func (h *Handler) GetAPIKeys(c *gin.Context) { c.JSON(200, gin.H{"api-keys": h.c
 func (h *Handler) PutAPIKeys(c *gin.Context) {
 	h.putStringList(c, func(v []string) {
 		h.cfg.APIKeys = append([]string(nil), v...)
-	}, nil)
+	}, func() { h.pruneAPIKeyCredentialGroups() })
 }
 func (h *Handler) PatchAPIKeys(c *gin.Context) {
-	h.patchStringList(c, &h.cfg.APIKeys, func() {})
+	h.patchStringList(c, &h.cfg.APIKeys, func() { h.pruneAPIKeyCredentialGroups() })
 }
 func (h *Handler) DeleteAPIKeys(c *gin.Context) {
-	h.deleteFromStringList(c, &h.cfg.APIKeys, func() {})
+	h.deleteFromStringList(c, &h.cfg.APIKeys, func() { h.pruneAPIKeyCredentialGroups() })
+}
+
+// api-key-credential-groups
+func (h *Handler) GetAPIKeyCredentialGroups(c *gin.Context) {
+	c.JSON(200, gin.H{"api-key-credential-groups": h.cfg.APIKeyCredentialGroups})
+}
+
+func (h *Handler) PutAPIKeyCredentialGroups(c *gin.Context) {
+	data, err := c.GetRawData()
+	if err != nil {
+		c.JSON(400, gin.H{"error": "failed to read body"})
+		return
+	}
+	var groups map[string][]string
+	if err = json.Unmarshal(data, &groups); err != nil {
+		var body struct {
+			Items  map[string][]string `json:"items"`
+			Groups map[string][]string `json:"api-key-credential-groups"`
+		}
+		if errBody := json.Unmarshal(data, &body); errBody != nil || (body.Items == nil && body.Groups == nil) {
+			c.JSON(400, gin.H{"error": "invalid body"})
+			return
+		}
+		groups = body.Groups
+		if groups == nil {
+			groups = body.Items
+		}
+	}
+	h.cfg.APIKeyCredentialGroups = normalizeAPIKeyCredentialGroups(groups, h.cfg.APIKeys)
+	h.persist(c)
+}
+
+func (h *Handler) PatchAPIKeyCredentialGroups(c *gin.Context) {
+	var body struct {
+		Key    string   `json:"key"`
+		Groups []string `json:"groups"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || strings.TrimSpace(body.Key) == "" {
+		c.JSON(400, gin.H{"error": "invalid body"})
+		return
+	}
+	key := strings.TrimSpace(body.Key)
+	if !containsTrimmedString(h.cfg.APIKeys, key) {
+		c.JSON(400, gin.H{"error": "api key is not configured"})
+		return
+	}
+	if h.cfg.APIKeyCredentialGroups == nil {
+		h.cfg.APIKeyCredentialGroups = make(map[string][]string)
+	}
+	normalized := normalizeStringSet(body.Groups)
+	// An explicitly empty list is fail-closed. Use DELETE to remove the
+	// restriction and restore legacy unrestricted behavior for this key.
+	h.cfg.APIKeyCredentialGroups[key] = normalized
+	h.persist(c)
+}
+
+func (h *Handler) DeleteAPIKeyCredentialGroups(c *gin.Context) {
+	key := strings.TrimSpace(c.Query("key"))
+	if key == "" {
+		c.JSON(400, gin.H{"error": "missing key"})
+		return
+	}
+	delete(h.cfg.APIKeyCredentialGroups, key)
+	h.persist(c)
+}
+
+func (h *Handler) pruneAPIKeyCredentialGroups() {
+	h.cfg.APIKeyCredentialGroups = normalizeAPIKeyCredentialGroups(h.cfg.APIKeyCredentialGroups, h.cfg.APIKeys)
+}
+
+func normalizeAPIKeyCredentialGroups(groups map[string][]string, apiKeys []string) map[string][]string {
+	if len(groups) == 0 {
+		return nil
+	}
+	allowedKeys := make(map[string]struct{}, len(apiKeys))
+	for _, key := range apiKeys {
+		if key = strings.TrimSpace(key); key != "" {
+			allowedKeys[key] = struct{}{}
+		}
+	}
+	normalized := make(map[string][]string)
+	for key, values := range groups {
+		key = strings.TrimSpace(key)
+		if _, exists := allowedKeys[key]; !exists {
+			continue
+		}
+		normalized[key] = normalizeStringSet(values)
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
+}
+
+func normalizeStringSet(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	return normalized
+}
+
+func containsTrimmedString(values []string, target string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) == target {
+			return true
+		}
+	}
+	return false
 }
 
 // gemini-api-key: []GeminiKey

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -80,6 +80,10 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PUT("/api-keys", s.mgmt.PutAPIKeys)
 		mgmt.PATCH("/api-keys", s.mgmt.PatchAPIKeys)
 		mgmt.DELETE("/api-keys", s.mgmt.DeleteAPIKeys)
+		mgmt.GET("/api-key-credential-groups", s.mgmt.GetAPIKeyCredentialGroups)
+		mgmt.PUT("/api-key-credential-groups", s.mgmt.PutAPIKeyCredentialGroups)
+		mgmt.PATCH("/api-key-credential-groups", s.mgmt.PatchAPIKeyCredentialGroups)
+		mgmt.DELETE("/api-key-credential-groups", s.mgmt.DeleteAPIKeyCredentialGroups)
 		mgmt.GET("/api-key-usage", s.mgmt.GetAPIKeyUsage)
 		mgmt.GET("/usage-queue", s.mgmt.GetUsageQueue)
 

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -343,6 +343,9 @@ type ClaudeKey struct {
 	// APIKey is the authentication key for accessing Claude API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
+	// CredentialGroup restricts this credential to downstream keys assigned to the same group.
+	CredentialGroup string `yaml:"credential-group,omitempty" json:"credential-group,omitempty"`
+
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
@@ -458,6 +461,9 @@ type CodexKey struct {
 	// APIKey is the authentication key for accessing Codex API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
+	// CredentialGroup restricts this credential to downstream keys assigned to the same group.
+	CredentialGroup string `yaml:"credential-group,omitempty" json:"credential-group,omitempty"`
+
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
@@ -561,6 +567,9 @@ type XAIModel = CodexModel
 type GeminiKey struct {
 	// APIKey is the authentication key for accessing Gemini API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
+
+	// CredentialGroup restricts this credential to downstream keys assigned to the same group.
+	CredentialGroup string `yaml:"credential-group,omitempty" json:"credential-group,omitempty"`
 
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
@@ -691,6 +700,9 @@ type OpenAICompatibility struct {
 type OpenAICompatibilityAPIKey struct {
 	// APIKey is the authentication key for accessing the external API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
+
+	// CredentialGroup restricts this credential to downstream keys assigned to the same group.
+	CredentialGroup string `yaml:"credential-group,omitempty" json:"credential-group,omitempty"`
 
 	// Weight controls proportional selection under weighted-round-robin.
 	// An omitted value defaults to 1; non-positive values exclude this credential; maximum 1,000,000.

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -50,6 +50,10 @@ type SDKConfig struct {
 
 	// APIKeys is a list of keys for authenticating clients to this proxy server.
 	APIKeys []string `yaml:"api-keys" json:"api-keys"`
+	// APIKeyCredentialGroups optionally restricts each downstream API key to named
+	// credential groups. Keys omitted from this map retain unrestricted legacy behavior;
+	// keys explicitly mapped to an empty list cannot select any credential.
+	APIKeyCredentialGroups map[string][]string `yaml:"api-key-credential-groups,omitempty" json:"api-key-credential-groups,omitempty"`
 
 	// PassthroughHeaders controls whether upstream response headers are forwarded to downstream clients.
 	// Default is false (disabled).

--- a/internal/config/vertex_compat.go
+++ b/internal/config/vertex_compat.go
@@ -17,6 +17,9 @@ type VertexCompatKey struct {
 	// Maps to the x-goog-api-key header.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
+	// CredentialGroup restricts this credential to downstream keys assigned to the same group.
+	CredentialGroup string `yaml:"credential-group,omitempty" json:"credential-group,omitempty"`
+
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -161,6 +161,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	} else if !reflect.DeepEqual(trimStrings(oldCfg.APIKeys), trimStrings(newCfg.APIKeys)) {
 		changes = append(changes, "api-keys: values updated (count unchanged, redacted)")
 	}
+	if !reflect.DeepEqual(oldCfg.APIKeyCredentialGroups, newCfg.APIKeyCredentialGroups) {
+		changes = append(changes, fmt.Sprintf("api-key-credential-groups: updated (%d -> %d scoped keys, keys redacted)", len(oldCfg.APIKeyCredentialGroups), len(newCfg.APIKeyCredentialGroups)))
+	}
 	if len(oldCfg.GeminiKey) != len(newCfg.GeminiKey) {
 		changes = append(changes, fmt.Sprintf("gemini-api-key count: %d -> %d", len(oldCfg.GeminiKey), len(newCfg.GeminiKey)))
 	} else {

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -32,6 +32,12 @@ func addWeightToAttrs(weight *int, attrs map[string]string) {
 	attrs[coreauth.AttributeWeight] = strconv.Itoa(normalized)
 }
 
+func addCredentialGroupToAttrs(group string, attrs map[string]string) {
+	if group = strings.TrimSpace(group); group != "" {
+		attrs["credential_group"] = group
+	}
+}
+
 // Synthesize generates Auth entries from config API keys.
 func (s *ConfigSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, error) {
 	out := make([]*coreauth.Auth, 0, 32)
@@ -103,6 +109,7 @@ func (s *ConfigSynthesizer) synthesizeGeminiKeyEntries(ctx *SynthesisContext, en
 			attrs["priority"] = strconv.Itoa(entry.Priority)
 		}
 		addWeightToAttrs(entry.Weight, attrs)
+		addCredentialGroupToAttrs(entry.CredentialGroup, attrs)
 		if base != "" {
 			attrs["base_url"] = base
 		}
@@ -165,6 +172,7 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 			attrs["priority"] = strconv.Itoa(ck.Priority)
 		}
 		addWeightToAttrs(ck.Weight, attrs)
+		addCredentialGroupToAttrs(ck.CredentialGroup, attrs)
 		if base != "" {
 			attrs["base_url"] = base
 		}
@@ -242,6 +250,7 @@ func (s *ConfigSynthesizer) synthesizeCodexStyleKeys(ctx *SynthesisContext, entr
 			attrs["priority"] = strconv.Itoa(entry.Priority)
 		}
 		addWeightToAttrs(entry.Weight, attrs)
+		addCredentialGroupToAttrs(entry.CredentialGroup, attrs)
 		if baseURL != "" {
 			attrs["base_url"] = baseURL
 		}
@@ -322,6 +331,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				attrs["priority"] = strconv.Itoa(compat.Priority)
 			}
 			addWeightToAttrs(entry.Weight, attrs)
+			addCredentialGroupToAttrs(entry.CredentialGroup, attrs)
 			if key != "" {
 				attrs["api_key"] = key
 			}
@@ -418,6 +428,7 @@ func (s *ConfigSynthesizer) synthesizeVertexCompat(ctx *SynthesisContext) []*cor
 			attrs["priority"] = strconv.Itoa(compat.Priority)
 		}
 		addWeightToAttrs(compat.Weight, attrs)
+		addCredentialGroupToAttrs(compat.CredentialGroup, attrs)
 		if key != "" {
 			attrs["api_key"] = key
 		}

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -1,6 +1,7 @@
 package synthesizer
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -1071,6 +1072,44 @@ func TestConfigSynthesizer_PropagatesWeightsForAllAPIKeyTypes(t *testing.T) {
 		wantWeight := strconv.Itoa(index + 1)
 		if gotWeight := auth.Attributes[coreauth.AttributeWeight]; gotWeight != wantWeight {
 			t.Fatalf("auth[%d] weight = %q, want %q", index, gotWeight, wantWeight)
+		}
+	}
+}
+
+func TestConfigSynthesizer_PropagatesCredentialGroupsForAllAPIKeyTypes(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			GeminiKey:       []config.GeminiKey{{APIKey: "gemini", CredentialGroup: " team-a "}},
+			InteractionsKey: []config.GeminiKey{{APIKey: "interactions", CredentialGroup: "team-b"}},
+			ClaudeKey:       []config.ClaudeKey{{APIKey: "claude", CredentialGroup: "team-c"}},
+			CodexKey:        []config.CodexKey{{APIKey: "codex", CredentialGroup: "team-d"}},
+			XAIKey:          []config.XAIKey{{APIKey: "xai", CredentialGroup: "team-e"}},
+			OpenAICompatibility: []config.OpenAICompatibility{{
+				Name:    "compat",
+				BaseURL: "https://compat.example.com",
+				APIKeyEntries: []config.OpenAICompatibilityAPIKey{{
+					APIKey:          "compat",
+					CredentialGroup: "team-f",
+				}},
+			}},
+			VertexCompatAPIKey: []config.VertexCompatKey{{APIKey: "vertex", CredentialGroup: "team-g"}},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, errSynthesize := synth.Synthesize(ctx)
+	if errSynthesize != nil {
+		t.Fatalf("Synthesize() error = %v", errSynthesize)
+	}
+	if len(auths) != 7 {
+		t.Fatalf("auth count = %d, want 7", len(auths))
+	}
+	for index, auth := range auths {
+		wantGroup := fmt.Sprintf("team-%c", 'a'+index)
+		if gotGroup := auth.Attributes["credential_group"]; gotGroup != wantGroup {
+			t.Fatalf("auth[%d] credential_group = %q, want %q", index, gotGroup, wantGroup)
 		}
 	}
 }

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -193,6 +193,21 @@ func requestExecutionMetadata(ctx context.Context) map[string]any {
 	if callerScope := requestCallerScope(ginCtx); callerScope != "" {
 		meta[coreexecutor.CallerScopeMetadataKey] = callerScope
 	}
+	if ginCtx != nil {
+		if rawAccessMetadata, exists := ginCtx.Get("accessMetadata"); exists {
+			if accessMetadata, ok := rawAccessMetadata.(map[string]string); ok {
+				if rawGroups, restricted := accessMetadata["credential-groups"]; restricted {
+					groups := make([]string, 0)
+					for _, group := range strings.Split(rawGroups, ",") {
+						if group = strings.TrimSpace(group); group != "" {
+							groups = append(groups, group)
+						}
+					}
+					meta[coreexecutor.CredentialGroupsMetadataKey] = groups
+				}
+			}
+		}
+	}
 	if disallowFreeAuthFromContext(ctx) {
 		meta[coreexecutor.DisallowFreeAuthMetadataKey] = true
 	}

--- a/sdk/api/handlers/handlers_metadata_test.go
+++ b/sdk/api/handlers/handlers_metadata_test.go
@@ -68,6 +68,34 @@ func TestRequestExecutionMetadataIncludesHashedCallerScope(t *testing.T) {
 	}
 }
 
+func TestRequestExecutionMetadataIncludesCredentialGroups(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	ginCtx.Set("accessMetadata", map[string]string{"credential-groups": " team-a,team-b "})
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+
+	meta := requestExecutionMetadata(ctx)
+	got, ok := meta[coreexecutor.CredentialGroupsMetadataKey].([]string)
+	if !ok || len(got) != 2 || got[0] != "team-a" || got[1] != "team-b" {
+		t.Fatalf("CredentialGroupsMetadataKey = %#v, want [team-a team-b]", meta[coreexecutor.CredentialGroupsMetadataKey])
+	}
+}
+
+func TestRequestExecutionMetadataPreservesExplicitEmptyCredentialGroups(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	ginCtx.Set("accessMetadata", map[string]string{"credential-groups": ""})
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+
+	meta := requestExecutionMetadata(ctx)
+	got, ok := meta[coreexecutor.CredentialGroupsMetadataKey].([]string)
+	if !ok || len(got) != 0 {
+		t.Fatalf("CredentialGroupsMetadataKey = %#v, want explicit empty list", meta[coreexecutor.CredentialGroupsMetadataKey])
+	}
+}
+
 func TestRequestExecutionMetadataTraceCallbackWebsocketDetection(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -895,20 +895,42 @@ func (m *Manager) pickNextViaHome(ctx context.Context, model string, opts clipro
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	selection, errSelection := m.pickHomeDispatchSelection(ctx, model, withHomeExcludedAuthIDs(opts, tried))
-	if errSelection != nil {
-		return nil, nil, "", errSelection
+	credentialGroups, credentialGroupsRestricted := credentialGroupsFromMetadata(opts.Metadata)
+	excluded := make(map[string]struct{}, len(tried))
+	for authID := range tried {
+		excluded[authID] = struct{}{}
 	}
-	selectionAuth := selection.CloneAuth()
-	if selectionAuth == nil || homeAuthAlreadyTried(tried, selectionAuth.ID) {
-		selection.End("repeated_auth")
-		return nil, nil, "", repeatedHomeAuthError()
+	homeAuthCount := homeAuthCountFromMetadata(opts.Metadata)
+	for {
+		selectionOpts := withHomeAuthCount(opts, homeAuthCount)
+		selectionOpts = withHomeExcludedAuthIDs(selectionOpts, excluded)
+		selection, errSelection := m.pickHomeDispatchSelection(ctx, model, selectionOpts)
+		if errSelection != nil {
+			return nil, nil, "", errSelection
+		}
+		selectionAuth := selection.CloneAuth()
+		if selectionAuth == nil || homeAuthAlreadyTried(excluded, selectionAuth.ID) {
+			selection.End("repeated_auth")
+			return nil, nil, "", repeatedHomeAuthError()
+		}
+		if credentialGroupsRestricted && !authInCredentialGroups(selectionAuth, credentialGroups) {
+			authID := strings.TrimSpace(selectionAuth.ID)
+			if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "credential_group_mismatch"); errEnd != nil {
+				return nil, nil, "", errEnd
+			}
+			if authID == "" {
+				return nil, nil, "", &Error{Code: "auth_not_found", Message: "selected auth has no ID"}
+			}
+			excluded[authID] = struct{}{}
+			homeAuthCount++
+			continue
+		}
+		auth := selection.CloneAuthForRoute(model)
+		executor := selection.Executor
+		provider := selection.Provider
+		selection.End("legacy_selection_unbound")
+		return auth, executor, provider, nil
 	}
-	auth := selection.CloneAuthForRoute(model)
-	executor := selection.Executor
-	provider := selection.Provider
-	selection.End("legacy_selection_unbound")
-	return auth, executor, provider, nil
 }
 
 func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, opts cliproxyexecutor.Options) (*HomeDispatchSelection, error) {

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -55,9 +55,11 @@ type requiredAuthKindContextKey struct{}
 type credentialPolicyContextKey struct{}
 
 type authSelectionEligibility struct {
-	requiredKind     string
-	credentialPolicy string
-	disallowFreeAuth bool
+	requiredKind               string
+	credentialPolicy           string
+	credentialGroups           map[string]struct{}
+	credentialGroupsRestricted bool
+	disallowFreeAuth           bool
 }
 
 func withRequiredAuthKind(ctx context.Context, requiredKind string) context.Context {
@@ -77,7 +79,12 @@ func credentialPolicyFromContext(ctx context.Context) string {
 }
 
 func authSelectionEligibilityForRequest(ctx context.Context, opts cliproxyexecutor.Options) authSelectionEligibility {
-	eligibility := authSelectionEligibility{disallowFreeAuth: disallowFreeAuthFromMetadata(opts.Metadata)}
+	credentialGroups, credentialGroupsRestricted := credentialGroupsFromMetadata(opts.Metadata)
+	eligibility := authSelectionEligibility{
+		disallowFreeAuth:           disallowFreeAuthFromMetadata(opts.Metadata),
+		credentialGroups:           credentialGroups,
+		credentialGroupsRestricted: credentialGroupsRestricted,
+	}
 	if ctx != nil {
 		eligibility.requiredKind, _ = ctx.Value(requiredAuthKindContextKey{}).(string)
 		eligibility.credentialPolicy, _ = ctx.Value(credentialPolicyContextKey{}).(string)
@@ -95,7 +102,82 @@ func (e authSelectionEligibility) allows(auth *Auth) bool {
 	if e.credentialPolicy != "" && !credentialPolicyAllows(e.credentialPolicy, auth) {
 		return false
 	}
+	if e.credentialGroupsRestricted && !authInCredentialGroups(auth, e.credentialGroups) {
+		return false
+	}
 	return !e.disallowFreeAuth || !isFreeCodexAuth(auth)
+}
+
+func credentialGroupsFromMetadata(metadata map[string]any) (map[string]struct{}, bool) {
+	if len(metadata) == 0 {
+		return nil, false
+	}
+	raw, ok := metadata[cliproxyexecutor.CredentialGroupsMetadataKey]
+	if !ok {
+		return nil, false
+	}
+	groups := make(map[string]struct{})
+	add := func(value string) {
+		for _, group := range strings.Split(value, ",") {
+			if group = strings.TrimSpace(group); group != "" {
+				groups[group] = struct{}{}
+			}
+		}
+	}
+	switch value := raw.(type) {
+	case string:
+		add(value)
+	case []string:
+		for _, group := range value {
+			add(group)
+		}
+	case []any:
+		for _, group := range value {
+			if text, okString := group.(string); okString {
+				add(text)
+			}
+		}
+	}
+	if len(groups) == 0 {
+		return nil, true
+	}
+	return groups, true
+}
+
+func authInCredentialGroups(auth *Auth, allowed map[string]struct{}) bool {
+	if auth == nil || len(allowed) == 0 {
+		return false
+	}
+	values := make([]string, 0, 2)
+	for _, key := range []string{"credential_group", "credential-group", "credential_groups", "credential-groups"} {
+		if auth.Attributes != nil {
+			if value := strings.TrimSpace(auth.Attributes[key]); value != "" {
+				values = append(values, value)
+			}
+		}
+		if auth.Metadata != nil {
+			switch value := auth.Metadata[key].(type) {
+			case string:
+				values = append(values, value)
+			case []string:
+				values = append(values, value...)
+			case []any:
+				for _, item := range value {
+					if text, okString := item.(string); okString {
+						values = append(values, text)
+					}
+				}
+			}
+		}
+	}
+	for _, value := range values {
+		for _, group := range strings.Split(value, ",") {
+			if _, ok := allowed[strings.TrimSpace(group)]; ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (m *Manager) syncSchedulerFromSnapshot(auths []*Auth) {

--- a/sdk/cliproxy/auth/credential_groups_http_integration_test.go
+++ b/sdk/cliproxy/auth/credential_groups_http_integration_test.go
@@ -1,0 +1,158 @@
+package auth_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func TestCredentialGroupsRouteToDistinctHTTPUpstreams(t *testing.T) {
+	const (
+		provider = "openai-compatibility:credential-groups-http-test"
+		model    = "credential-groups-http-test-model"
+	)
+
+	var callsA atomic.Int32
+	var callsB atomic.Int32
+	var invalidAuthHeaders atomic.Int32
+	var failA atomic.Bool
+
+	newUpstream := func(accountID, apiKey string, calls *atomic.Int32, shouldFail *atomic.Bool) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			calls.Add(1)
+			if request.URL.Path != "/chat/completions" {
+				writer.WriteHeader(http.StatusNotFound)
+				return
+			}
+			if request.Header.Get("Authorization") != "Bearer "+apiKey {
+				invalidAuthHeaders.Add(1)
+				writer.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			if shouldFail != nil && shouldFail.Load() {
+				writer.Header().Set("Content-Type", "application/json")
+				writer.WriteHeader(http.StatusInternalServerError)
+				_, _ = writer.Write([]byte(`{"error":{"message":"simulated account failure"}}`))
+				return
+			}
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(`{"id":"chatcmpl-test","choices":[{"message":{"role":"assistant","content":"` + accountID + `"}}]}`))
+		}))
+	}
+
+	upstreamA := newUpstream("account-a", "upstream-key-a", &callsA, &failA)
+	defer upstreamA.Close()
+	upstreamB := newUpstream("account-b", "upstream-key-b", &callsB, nil)
+	defer upstreamB.Close()
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.SetRetryConfig(0, 0, 2)
+	manager.RegisterExecutor(runtimeexecutor.NewOpenAICompatExecutor(provider, &config.Config{}))
+
+	credentials := []*cliproxyauth.Auth{
+		{
+			ID:       "credential-http-a",
+			Provider: provider,
+			Status:   cliproxyauth.StatusActive,
+			Attributes: map[string]string{
+				"base_url":         upstreamA.URL,
+				"api_key":          "upstream-key-a",
+				"credential_group": "account-a-group",
+			},
+		},
+		{
+			ID:       "credential-http-b",
+			Provider: provider,
+			Status:   cliproxyauth.StatusActive,
+			Attributes: map[string]string{
+				"base_url":         upstreamB.URL,
+				"api_key":          "upstream-key-b",
+				"credential_group": "account-b-group",
+			},
+		},
+	}
+
+	modelRegistry := registry.GetGlobalRegistry()
+	for _, credential := range credentials {
+		modelRegistry.RegisterClient(credential.ID, provider, []*registry.ModelInfo{{ID: model, Type: provider}})
+		credentialID := credential.ID
+		t.Cleanup(func() { modelRegistry.UnregisterClient(credentialID) })
+		if _, errRegister := manager.Register(context.Background(), credential); errRegister != nil {
+			t.Fatalf("register %s: %v", credential.ID, errRegister)
+		}
+	}
+
+	payload := []byte(`{"model":"` + model + `","messages":[{"role":"user","content":"identify the upstream account"}]}`)
+	execute := func(group string) (string, error) {
+		response, errExecute := manager.Execute(
+			context.Background(),
+			[]string{provider},
+			cliproxyexecutor.Request{Model: model, Payload: payload},
+			cliproxyexecutor.Options{
+				SourceFormat:    sdktranslator.FormatOpenAI,
+				OriginalRequest: payload,
+				Metadata: map[string]any{
+					cliproxyexecutor.CredentialGroupsMetadataKey: []string{group},
+				},
+			},
+		)
+		if errExecute != nil {
+			return "", errExecute
+		}
+		var decoded struct {
+			Choices []struct {
+				Message struct {
+					Content string `json:"content"`
+				} `json:"message"`
+			} `json:"choices"`
+		}
+		if errDecode := json.Unmarshal(response.Payload, &decoded); errDecode != nil {
+			t.Fatalf("decode response: %v; payload = %s", errDecode, response.Payload)
+		}
+		if len(decoded.Choices) != 1 {
+			t.Fatalf("choices = %#v, want one choice", decoded.Choices)
+		}
+		return decoded.Choices[0].Message.Content, nil
+	}
+
+	accountA, errExecuteA := execute("account-a-group")
+	if errExecuteA != nil {
+		t.Fatalf("execute account A: %v", errExecuteA)
+	}
+	if accountA != "account-a" {
+		t.Fatalf("account A response = %q, want account-a", accountA)
+	}
+
+	accountB, errExecuteB := execute("account-b-group")
+	if errExecuteB != nil {
+		t.Fatalf("execute account B: %v", errExecuteB)
+	}
+	if accountB != "account-b" {
+		t.Fatalf("account B response = %q, want account-b", accountB)
+	}
+	if callsA.Load() != 1 || callsB.Load() != 1 {
+		t.Fatalf("successful upstream calls = (%d, %d), want (1, 1)", callsA.Load(), callsB.Load())
+	}
+	if invalidAuthHeaders.Load() != 0 {
+		t.Fatalf("invalid upstream authorization headers = %d, want 0", invalidAuthHeaders.Load())
+	}
+
+	failA.Store(true)
+	callsBBeforeFailure := callsB.Load()
+	if _, errExecuteFailure := execute("account-a-group"); errExecuteFailure == nil {
+		t.Fatal("account A failure unexpectedly succeeded")
+	}
+	if callsB.Load() != callsBBeforeFailure {
+		t.Fatalf("account A failure reached account B: calls before = %d, after = %d", callsBBeforeFailure, callsB.Load())
+	}
+}

--- a/sdk/cliproxy/auth/credential_groups_test.go
+++ b/sdk/cliproxy/auth/credential_groups_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"testing"
 
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
@@ -119,5 +121,33 @@ func TestManagerSelectAuthKeepsResidentialCredentialGroupsIsolated(t *testing.T)
 				t.Fatalf("SelectAuth() = %#v, want auth %q", selected, test.wantAuthID)
 			}
 		})
+	}
+}
+
+func TestPickNextViaHomeSkipsCredentialOutsideAuthorizedGroups(t *testing.T) {
+	dispatcher := &authKindHomeDispatcher{auths: []Auth{
+		{ID: "credential-b", Provider: "test", Attributes: map[string]string{"credential_group": "team-b"}},
+		{ID: "credential-a", Provider: "test", Attributes: map[string]string{"credential_group": "team-a"}},
+	}}
+	oldCurrentHomeDispatcher := currentHomeDispatcher
+	currentHomeDispatcher = func() homeAuthDispatcher { return dispatcher }
+	t.Cleanup(func() { currentHomeDispatcher = oldCurrentHomeDispatcher })
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetHomeExecutionRegistry(executionregistry.New())
+	manager.RegisterExecutor(schedulerTestExecutor{})
+
+	selected, _, _, errSelect := manager.pickNextViaHome(context.Background(), "model", cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.CredentialGroupsMetadataKey: []string{"team-a"},
+	}}, nil)
+	if errSelect != nil {
+		t.Fatalf("pickNextViaHome() error = %v", errSelect)
+	}
+	if selected == nil || selected.ID != "credential-a" {
+		t.Fatalf("pickNextViaHome() auth = %#v, want credential-a", selected)
+	}
+	if got := dispatcher.counts; len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("Home auth counts = %v, want [1 2]", got)
 	}
 }

--- a/sdk/cliproxy/auth/credential_groups_test.go
+++ b/sdk/cliproxy/auth/credential_groups_test.go
@@ -1,0 +1,123 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type credentialGroupTestExecutor struct{}
+
+func (*credentialGroupTestExecutor) Identifier() string { return "credential-group-test" }
+
+func (*credentialGroupTestExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, errors.New("not implemented")
+}
+
+func (*credentialGroupTestExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (*credentialGroupTestExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (*credentialGroupTestExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, errors.New("not implemented")
+}
+
+func (*credentialGroupTestExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestCredentialGroupEligibility(t *testing.T) {
+	eligibility := authSelectionEligibilityForRequest(nil, cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.CredentialGroupsMetadataKey: []string{"team-a"},
+	}})
+
+	tests := []struct {
+		name string
+		auth *Auth
+		want bool
+	}{
+		{name: "matching attribute", auth: &Auth{Attributes: map[string]string{"credential_group": "team-a"}}, want: true},
+		{name: "matching metadata list", auth: &Auth{Metadata: map[string]any{"credential_groups": []any{"team-b", "team-a"}}}, want: true},
+		{name: "different group", auth: &Auth{Metadata: map[string]any{"credential_group": "team-b"}}, want: false},
+		{name: "missing group", auth: &Auth{}, want: false},
+		{name: "nil auth", auth: nil, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := eligibility.allows(test.auth); got != test.want {
+				t.Fatalf("allows() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestEmptyCredentialGroupMetadataDeniesSelection(t *testing.T) {
+	eligibility := authSelectionEligibilityForRequest(nil, cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.CredentialGroupsMetadataKey: []string{"", "   "},
+	}})
+	if eligibility.allows(&Auth{Attributes: map[string]string{"credential_group": "team-a"}}) {
+		t.Fatal("explicit empty credential group metadata must deny every credential")
+	}
+}
+
+func TestMissingCredentialGroupMetadataKeepsLegacyBehavior(t *testing.T) {
+	eligibility := authSelectionEligibilityForRequest(nil, cliproxyexecutor.Options{})
+	if !eligibility.allows(&Auth{}) {
+		t.Fatal("missing credential group metadata must retain legacy unrestricted behavior")
+	}
+}
+
+func TestManagerSelectAuthKeepsResidentialCredentialGroupsIsolated(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	executor := &credentialGroupTestExecutor{}
+	manager.RegisterExecutor(executor)
+
+	ctx := context.Background()
+	credentials := []*Auth{
+		{ID: "credential-a", Provider: executor.Identifier(), Status: StatusActive, Attributes: map[string]string{"credential_group": "a-residential"}},
+		{ID: "credential-b", Provider: executor.Identifier(), Status: StatusActive, Attributes: map[string]string{"credential_group": "b-residential"}},
+	}
+	for _, credential := range credentials {
+		if _, err := manager.Register(ctx, credential); err != nil {
+			t.Fatalf("register %s: %v", credential.ID, err)
+		}
+	}
+
+	tests := []struct {
+		name       string
+		groups     []string
+		wantAuthID string
+		wantError  bool
+	}{
+		{name: "account A", groups: []string{"a-residential"}, wantAuthID: "credential-a"},
+		{name: "account B", groups: []string{"b-residential"}, wantAuthID: "credential-b"},
+		{name: "explicit empty groups", groups: []string{}, wantError: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			selected, err := manager.SelectAuth(ctx, executor.Identifier(), "", cliproxyexecutor.Options{Metadata: map[string]any{
+				cliproxyexecutor.CredentialGroupsMetadataKey: test.groups,
+			}})
+			if test.wantError {
+				if err == nil {
+					t.Fatalf("SelectAuth() selected %#v, want fail-closed error", selected)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SelectAuth() error = %v", err)
+			}
+			if selected == nil || selected.ID != test.wantAuthID {
+				t.Fatalf("SelectAuth() = %#v, want auth %q", selected, test.wantAuthID)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -48,6 +48,9 @@ const (
 	DerivedSessionIDMetadataKey = "derived_session_id"
 	// CallerScopeMetadataKey isolates inferred session identities between downstream callers.
 	CallerScopeMetadataKey = "caller_scope"
+	// CredentialGroupsMetadataKey restricts auth selection to credentials in one of
+	// the listed operator-defined groups. An explicitly empty list denies all credentials.
+	CredentialGroupsMetadataKey = "credential_groups"
 	// SessionAffinityProviderMetadataKey carries the affinity selection namespace
 	// (provider string, e.g. the literal "mixed" pool key) used by SessionAffinitySelector.Pick,
 	// so OnResult keys the session cache identically to how selection read it.


### PR DESCRIPTION
## Summary

This change adds optional downstream API-key-to-credential-group bindings so one client key can only use its assigned upstream credential set.

- Adds configuration and management API support for API key credential-group bindings.
- Propagates the authorized groups through request metadata and applies them in credential selection.
- Supports `credential-group` on configured credentials and auth-file metadata.
- Uses fail-closed selection for scoped keys: a scoped key never falls back to credentials outside its allowed groups.
- Preserves legacy unrestricted behavior for API keys without a binding.

## Validation

- Added targeted tests for configuration normalization, management endpoints, request metadata, credential selection and scheduler behavior.
- Verified all Go packages compile and the server builds.
- Re-ran the feature tests and build from a clean clone at commit `59675a3c`.
- Exercised two independent local HTTP upstreams with different endpoints, upstream keys and account markers; when upstream A failed, the request did not fall back to upstream B.

## Real-account testing help wanted

The local integration test uses controlled HTTP upstreams rather than real subscription credentials. Help is welcome to validate the complete flow with two independent real upstream subscription accounts:

1. Downstream key A must only use upstream account A.
2. Downstream key B must only use upstream account B.
3. Failure or quota exhaustion on A must never route to B.
4. Rotation within an allowed credential group should continue to work.

Please do not post real tokens, cookies, OAuth files or API keys in this PR, issues or logs. Configure credentials only in a private test environment and share redacted results.

## Disclosure

The implementation and this draft description were prepared with AI assistance. The repository maintainers should review and adjust them before this PR is marked ready for review.

Relates to #5188