### PR TITLE
feat: support provider-level proxy for OpenAI-compatible providers

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -613,6 +613,7 @@ nonstream-keepalive-interval: 0
 #     disabled: false # optional: set to true to disable this provider without removing it
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
+#     proxy-url: "http://127.0.0.1:7890" # optional provider-level proxy; a key-level proxy-url overrides it
 #     support-prompt-cache-key: false # optional: derive prompt_cache_key for requests from all input protocols
 #     disable-cooling: false # optional provider override: true disables cooling, false enables it; omit to inherit global
 #     request-retry: 3 # optional per-provider override; 0 disables additional rounds; omit or set < 0 to inherit global

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -643,10 +643,13 @@ func resolveOpenAICompatAPIKeyProxyURL(cfg *config.Config, auth *coreauth.Auth, 
 				for j := range compat.APIKeyEntries {
 					entry := &compat.APIKeyEntries[j]
 					if strings.EqualFold(strings.TrimSpace(entry.APIKey), apiKey) {
-						return strings.TrimSpace(entry.ProxyURL)
+						if proxyURL := strings.TrimSpace(entry.ProxyURL); proxyURL != "" {
+							return proxyURL
+						}
+						return strings.TrimSpace(compat.ProxyURL)
 					}
 				}
-				return ""
+				return strings.TrimSpace(compat.ProxyURL)
 			}
 		}
 	}

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -315,3 +315,38 @@ func TestAuthByIndexDistinguishesSharedAPIKeysAcrossProviders(t *testing.T) {
 		t.Fatalf("authByIndex(compat) returned %q, want %q", gotCompat.ID, compatAuth.ID)
 	}
 }
+
+func TestResolveOpenAICompatAPIKeyProxyURLFallsBackToProviderProxy(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.OpenAICompatibility = []config.OpenAICompatibility{{
+		Name:    "provider",
+		ProxyURL: "http://provider-proxy.example.com:8080",
+		APIKeyEntries: []config.OpenAICompatibilityAPIKey{{
+			APIKey: "key",
+		}},
+	}}
+	auth := &coreauth.Auth{Provider: "openai-compatibility"}
+
+	got := resolveOpenAICompatAPIKeyProxyURL(cfg, auth, "key", "", "provider")
+	if got != "http://provider-proxy.example.com:8080" {
+		t.Fatalf("proxy = %q, want provider proxy", got)
+	}
+}
+
+func TestResolveOpenAICompatAPIKeyProxyURLPrefersEntryProxy(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.OpenAICompatibility = []config.OpenAICompatibility{{
+		Name:    "provider",
+		ProxyURL: "http://provider-proxy.example.com:8080",
+		APIKeyEntries: []config.OpenAICompatibilityAPIKey{{
+			APIKey:   "key",
+			ProxyURL: "http://entry-proxy.example.com:8080",
+		}},
+	}}
+	auth := &coreauth.Auth{Provider: "openai-compatibility"}
+
+	got := resolveOpenAICompatAPIKeyProxyURL(cfg, auth, "key", "", "provider")
+	if got != "http://entry-proxy.example.com:8080" {
+		t.Fatalf("proxy = %q, want entry proxy", got)
+	}
+}

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -663,6 +663,10 @@ type OpenAICompatibility struct {
 	// BaseURL is the base URL for the external OpenAI-compatible API endpoint.
 	BaseURL string `yaml:"base-url" json:"base-url"`
 
+	// ProxyURL is the provider-level proxy used when an API key does not define
+	// its own proxy override.
+	ProxyURL string `yaml:"proxy-url,omitempty" json:"proxy-url,omitempty"`
+
 	// APIKeyEntries defines API keys with optional per-key proxy configuration.
 	APIKeyEntries []OpenAICompatibilityAPIKey `yaml:"api-key-entries,omitempty" json:"api-key-entries,omitempty"`
 


### PR DESCRIPTION
## Summary
- add an optional provider-level `proxy-url` to OpenAI-compatible providers
- fall back to provider proxy when a matching API key has no per-key proxy
- preserve per-key proxy precedence
- document the new configuration field

## Resolution order
`api-key-entries[].proxy-url` > `openai-compatibility[].proxy-url` > global `proxy-url`

## Validation
- `git diff --check` passed
- Added unit tests for provider fallback and per-key override
- Go tests could not run in this environment because Go/gofmt are not installed.