### PR TITLE
[WIP]feat(plugin): add request-scoped egress proxy resolver

### DIFF
--- a/internal/pluginhost/egress_proxy.go
+++ b/internal/pluginhost/egress_proxy.go
@@ -1,0 +1,107 @@
+package pluginhost
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
+	log "github.com/sirupsen/logrus"
+)
+
+// ResolveEgressProxy resolves request-scoped proxy behavior using the highest-priority
+// active resolver. An unhandled resolver preserves the configured proxy behavior.
+func (h *Host) ResolveEgressProxy(ctx context.Context, req pluginapi.EgressProxyRequest) (pluginapi.EgressProxyResponse, bool, error) {
+	if h == nil {
+		return pluginapi.EgressProxyResponse{}, false, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req.Provider = strings.ToLower(strings.TrimSpace(req.Provider))
+	req.Model = strings.TrimSpace(req.Model)
+	req.Operation = strings.ToLower(strings.TrimSpace(req.Operation))
+	req.Auth.ID = strings.TrimSpace(req.Auth.ID)
+	req.Auth.Index = strings.TrimSpace(req.Auth.Index)
+	req.Auth.Provider = strings.ToLower(strings.TrimSpace(req.Auth.Provider))
+	req.Auth.Label = strings.TrimSpace(req.Auth.Label)
+	req.Auth.Email = strings.TrimSpace(req.Auth.Email)
+
+	for _, record := range h.activeRecords() {
+		resolver := record.plugin.Capabilities.EgressProxyResolver
+		if resolver == nil || h.isPluginFused(record.id) {
+			continue
+		}
+		resp, ok, errResolve := h.callEgressProxyResolver(ctx, record, resolver, req)
+		if errResolve != nil {
+			return pluginapi.EgressProxyResponse{}, true, fmt.Errorf("egress proxy resolver %s failed", record.id)
+		}
+		if !ok || !resp.Handled {
+			continue
+		}
+		normalized, errNormalize := normalizeEgressProxyResponse(resp)
+		if errNormalize != nil {
+			return pluginapi.EgressProxyResponse{}, true, fmt.Errorf("resolve egress proxy with plugin %s: %w", record.id, errNormalize)
+		}
+		return normalized, true, nil
+	}
+	return pluginapi.EgressProxyResponse{}, false, nil
+}
+
+func (h *Host) callEgressProxyResolver(ctx context.Context, record capabilityRecord, resolver pluginapi.EgressProxyResolver, req pluginapi.EgressProxyRequest) (out pluginapi.EgressProxyResponse, ok bool, err error) {
+	if h == nil || resolver == nil || h.isPluginFused(record.id) || !h.recordCurrent(record) {
+		return pluginapi.EgressProxyResponse{}, false, nil
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			h.fusePlugin(record.id, "EgressProxyResolver.ResolveEgressProxy", recovered)
+			out = pluginapi.EgressProxyResponse{}
+			ok = false
+			err = fmt.Errorf("egress proxy resolver panic: %v", recovered)
+		}
+	}()
+	resp, errResolve := resolver.ResolveEgressProxy(ctx, req)
+	if errResolve != nil {
+		log.WithField("plugin_id", record.id).Warn("pluginhost: egress proxy resolver failed")
+		return pluginapi.EgressProxyResponse{}, true, errResolve
+	}
+	return resp, true, nil
+}
+
+func normalizeEgressProxyResponse(resp pluginapi.EgressProxyResponse) (pluginapi.EgressProxyResponse, error) {
+	if !resp.Handled {
+		return pluginapi.EgressProxyResponse{}, nil
+	}
+	resp.Mode = pluginapi.EgressProxyMode(strings.ToLower(strings.TrimSpace(string(resp.Mode))))
+	resp.ProxyURL = strings.TrimSpace(resp.ProxyURL)
+	switch resp.Mode {
+	case pluginapi.EgressProxyModeInherit:
+		resp.ProxyURL = ""
+		return resp, nil
+	case pluginapi.EgressProxyModeDirect:
+		resp.ProxyURL = ""
+		return resp, nil
+	case pluginapi.EgressProxyModeProxy:
+		setting, errParse := proxyutil.Parse(resp.ProxyURL)
+		if errParse != nil || setting.Mode != proxyutil.ModeProxy {
+			return pluginapi.EgressProxyResponse{}, fmt.Errorf("plugin returned invalid proxy URL")
+		}
+		return resp, nil
+	default:
+		return pluginapi.EgressProxyResponse{}, fmt.Errorf("plugin returned invalid proxy mode")
+	}
+}
+
+// HasEgressProxyResolver reports whether the active plugin snapshot contains a resolver.
+func (h *Host) HasEgressProxyResolver() bool {
+	if h == nil {
+		return false
+	}
+	for _, record := range h.activeRecords() {
+		if record.plugin.Capabilities.EgressProxyResolver != nil && !h.isPluginFused(record.id) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -852,6 +852,7 @@ func validPlugin(plugin pluginapi.Plugin) bool {
 		caps.FrontendAuthProvider != nil ||
 		caps.Scheduler != nil ||
 		caps.ModelRouter != nil ||
+		caps.EgressProxyResolver != nil ||
 		caps.Executor != nil ||
 		caps.RequestTranslator != nil ||
 		caps.RequestNormalizer != nil ||

--- a/internal/pluginhost/rpc_client.go
+++ b/internal/pluginhost/rpc_client.go
@@ -101,6 +101,9 @@ func registerRPCPlugin(ctx context.Context, host *Host, id string, client plugin
 	if resp.Capabilities.ModelRouter {
 		plugin.Capabilities.ModelRouter = adapter
 	}
+	if resp.Capabilities.EgressProxyResolver {
+		plugin.Capabilities.EgressProxyResolver = adapter
+	}
 	if resp.Capabilities.Executor {
 		plugin.Capabilities.Executor = rpcProviderExecutor{rpcPluginAdapter: adapter}
 	}
@@ -377,6 +380,10 @@ func (a *rpcPluginAdapter) RouteModel(ctx context.Context, req pluginapi.ModelRo
 		ModelRouteRequest: req,
 		HostCallbackID:    callbackID,
 	})
+}
+
+func (a *rpcPluginAdapter) ResolveEgressProxy(ctx context.Context, req pluginapi.EgressProxyRequest) (pluginapi.EgressProxyResponse, error) {
+	return callPlugin[pluginapi.EgressProxyResponse](ctx, a.client, pluginabi.MethodEgressProxyResolve, req)
 }
 
 func callPluginIdentifier(client pluginClient, method string) string {

--- a/internal/pluginhost/rpc_schema.go
+++ b/internal/pluginhost/rpc_schema.go
@@ -26,6 +26,7 @@ type rpcCapabilities struct {
 	FrontendAuthProviderExclusive bool                         `json:"frontend_auth_provider_exclusive"`
 	Scheduler                     bool                         `json:"scheduler"`
 	ModelRouter                   bool                         `json:"model_router"`
+	EgressProxyResolver           bool                         `json:"egress_proxy_resolver"`
 	Executor                      bool                         `json:"executor"`
 	ExecutorModelScope            pluginapi.ExecutorModelScope `json:"executor_model_scope"`
 	ExecutorInputFormats          []string                     `json:"executor_input_formats,omitempty"`
@@ -137,6 +138,7 @@ func rpcCapabilitiesFromPlugin(plugin pluginapi.Plugin) rpcCapabilities {
 		FrontendAuthProviderExclusive: caps.FrontendAuthProvider != nil && caps.FrontendAuthProviderExclusive,
 		Scheduler:                     caps.Scheduler != nil,
 		ModelRouter:                   caps.ModelRouter != nil,
+		EgressProxyResolver:           caps.EgressProxyResolver != nil,
 		Executor:                      caps.Executor != nil,
 		ExecutorModelScope:            normalizedExecutorModelScope(caps),
 		ExecutorInputFormats:          append([]string(nil), caps.ExecutorInputFormats...),

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -75,6 +75,11 @@ type pluginSchedulerState interface {
 	HasScheduler() bool
 }
 
+// EgressProxyResolver resolves request-scoped outbound proxy behavior after credential selection.
+type EgressProxyResolver interface {
+	ResolveEgressProxy(context.Context, pluginapi.EgressProxyRequest) (pluginapi.EgressProxyResponse, bool, error)
+}
+
 // StoppableSelector is an optional interface for selectors that hold resources.
 // Selectors that implement this interface will have Stop called during shutdown.
 type StoppableSelector interface {
@@ -119,6 +124,8 @@ type Manager struct {
 	scheduler                 *authScheduler
 	// pluginScheduler runs outside m.mu before falling back to native selection.
 	pluginScheduler PluginScheduler
+	// egressProxyResolver runs after credential selection to select request-scoped proxy behavior.
+	egressProxyResolver EgressProxyResolver
 	// homeRuntimeAuths retains legacy session auth lookups for non-execution callers.
 	homeRuntimeAuths map[string]map[string]*Auth
 	// homeRuntimeAuthOwners prevents a stale selection from clearing a replacement auth.

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -349,6 +349,12 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
+		selectedAuth := auth
+		resolvedAuth, errResolve := m.resolveEgressProxy(execCtx, provider, routeModel, "execute", auth)
+		if errResolve != nil {
+			return cliproxyexecutor.Response{}, errResolve
+		}
+		execCtx = m.egressProxyContext(execCtx, resolvedAuth)
 
 		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel)
 		if len(models) == 0 {
@@ -366,6 +372,8 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			lastErr = errPrepare
 			continue
 		}
+		auth = applyEgressProxyOverride(auth, selectedAuth, resolvedAuth)
+		execCtx = m.egressProxyContext(execCtx, auth)
 		var authErr error
 		didRefreshOnUnauthorized := false
 		for _, upstreamModel := range models {
@@ -523,6 +531,12 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
+		selectedAuth := auth
+		resolvedAuth, errResolve := m.resolveEgressProxy(execCtx, provider, routeModel, "execute", auth)
+		if errResolve != nil {
+			return cliproxyexecutor.Response{}, errResolve
+		}
+		execCtx = m.egressProxyContext(execCtx, resolvedAuth)
 
 		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel)
 		if len(models) == 0 {
@@ -540,6 +554,8 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			lastErr = errPrepare
 			continue
 		}
+		auth = applyEgressProxyOverride(auth, selectedAuth, resolvedAuth)
+		execCtx = m.egressProxyContext(execCtx, auth)
 		var authErr error
 		didRefreshOnUnauthorized := false
 		for _, upstreamModel := range models {
@@ -803,12 +819,20 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 				return nil, errBind
 			}
 		}
-		if rt := m.roundTripperFor(auth); rt != nil {
-			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
-			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
-		}
 		// Enrich before auth preparation so prepare-stage usage records observe the client request.
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
+		selectedAuth := auth
+		resolvedAuth, errResolve := m.resolveEgressProxy(execCtx, provider, routeModel, egressProxyOperationForContext(execCtx, true), auth)
+		if errResolve != nil {
+			if selection != nil {
+				releaseAttempt()
+				if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "egress_proxy_failed"); errEnd != nil {
+					return nil, errEnd
+				}
+			}
+			return nil, errResolve
+		}
+		execCtx = m.egressProxyContext(execCtx, resolvedAuth)
 		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel)
 		if selection != nil && aliasResult.ForceMapping && responseAlias != "" {
 			aliasResult.OriginalAlias = responseAlias
@@ -831,6 +855,11 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			auth, errPrepare = m.prepareHomeRequestAuth(execCtx, executor, selection)
 		} else {
 			auth, errPrepare = m.prepareRequestAuth(execCtx, executor, auth)
+		}
+		auth = applyEgressProxyOverride(auth, selectedAuth, resolvedAuth)
+		execCtx = m.egressProxyContext(execCtx, auth)
+		if selection != nil {
+			m.replaceHomeSelectionAuth(selection, auth)
 		}
 		if errPrepare != nil {
 			if selection != nil {
@@ -1699,5 +1728,9 @@ func (m *Manager) HttpRequest(ctx context.Context, auth *Auth, req *http.Request
 	if exec == nil {
 		return nil, &Error{Code: "provider_not_found", Message: "executor not registered for provider: " + providerKey}
 	}
-	return exec.HttpRequest(ctx, auth, req)
+	execCtx, resolvedAuth, errResolve := m.resolveEgressProxyHTTPRequest(ctx, auth, req)
+	if errResolve != nil {
+		return nil, errResolve
+	}
+	return exec.HttpRequest(execCtx, resolvedAuth, req)
 }

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1326,16 +1326,17 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			return cliproxyexecutor.Response{}, false, nil
 		}
 		creditsCtx := WithAntigravityCredits(ctx)
-		if rt := m.roundTripperFor(c.auth); rt != nil {
-			creditsCtx = context.WithValue(creditsCtx, roundTripperContextKey{}, rt)
-			creditsCtx = context.WithValue(creditsCtx, "cliproxy.roundtripper", rt)
-		}
 		creditsOpts := ensureRequestedModelMetadata(opts, routeModel)
 		creditsCtx = contextWithRequestedModelAlias(creditsCtx, creditsOpts, routeModel)
 		preparedAuth, errPrepare := m.prepareRequestAuth(creditsCtx, c.executor, c.auth)
 		if errPrepare != nil {
 			continue
 		}
+		preparedAuth, errPrepare = m.resolveEgressProxy(creditsCtx, c.provider, routeModel, "execute", preparedAuth)
+		if errPrepare != nil {
+			return cliproxyexecutor.Response{}, false, errPrepare
+		}
+		creditsCtx = m.egressProxyContext(creditsCtx, preparedAuth)
 		c.auth = preparedAuth
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth)
 		models, pooled, aliasResult, routing := m.executionModelCandidatesWithAlias(c.auth, routeModel)
@@ -1388,15 +1389,16 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 			return nil, false, nil
 		}
 		creditsCtx := WithAntigravityCredits(ctx)
-		if rt := m.roundTripperFor(c.auth); rt != nil {
-			creditsCtx = context.WithValue(creditsCtx, roundTripperContextKey{}, rt)
-			creditsCtx = context.WithValue(creditsCtx, "cliproxy.roundtripper", rt)
-		}
 		creditsOpts := ensureRequestedModelMetadata(opts, routeModel)
 		preparedAuth, errPrepare := m.prepareRequestAuth(creditsCtx, c.executor, c.auth)
 		if errPrepare != nil {
 			continue
 		}
+		preparedAuth, errPrepare = m.resolveEgressProxy(creditsCtx, c.provider, routeModel, "stream", preparedAuth)
+		if errPrepare != nil {
+			return nil, false, errPrepare
+		}
+		creditsCtx = m.egressProxyContext(creditsCtx, preparedAuth)
 		c.auth = preparedAuth
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth)
 		models, pooled, aliasResult, routing := m.executionModelCandidatesWithAlias(c.auth, routeModel)

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -122,10 +122,16 @@ func (m *Manager) executeHomeOnce(ctx context.Context, providers []string, req c
 		}
 		// Enrich before auth preparation so prepare-stage usage records observe the client request.
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
-		if rt := m.roundTripperFor(auth); rt != nil {
-			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
-			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
+		selectedAuth := auth
+		resolvedAuth, errResolve := m.resolveEgressProxy(execCtx, selection.Provider, routeModel, "execute", auth)
+		if errResolve != nil {
+			releaseAttempt()
+			if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "egress_proxy_failed"); errEnd != nil {
+				return cliproxyexecutor.Response{}, errEnd
+			}
+			return cliproxyexecutor.Response{}, errResolve
 		}
+		execCtx = m.egressProxyContext(execCtx, resolvedAuth)
 		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel)
 		if aliasResult.ForceMapping && responseAlias != "" {
 			aliasResult.OriginalAlias = responseAlias
@@ -144,6 +150,11 @@ func (m *Manager) executeHomeOnce(ctx context.Context, providers []string, req c
 			continue
 		}
 		preparedAuth, errPrepare := m.prepareHomeRequestAuth(execCtx, selection.Executor, selection)
+		preparedAuth = applyEgressProxyOverride(preparedAuth, selectedAuth, resolvedAuth)
+		execCtx = m.egressProxyContext(execCtx, preparedAuth)
+		if errPrepare == nil {
+			m.replaceHomeSelectionAuth(selection, preparedAuth)
+		}
 		if errPrepare != nil {
 			m.reportHomeResult(execCtx, Result{AuthID: auth.ID, Provider: selection.Provider, Model: routeModel, Success: false, Error: resultErrorFromError(errPrepare), Options: opts}, auth)
 			releaseAttempt()

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -529,7 +529,11 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 	}
 
 	cloned := auth.Clone()
-	updated, err := exec.Refresh(ctx, cloned)
+	refreshCtx, resolvedAuth, errResolve := m.resolveEgressProxyContext(ctx, auth.Provider, "", "refresh", cloned)
+	if errResolve != nil {
+		return nil, errResolve
+	}
+	updated, err := exec.Refresh(refreshCtx, resolvedAuth)
 	if err != nil && errors.Is(err, context.Canceled) {
 		log.Debugf("refresh canceled for %s, %s", auth.Provider, auth.ID)
 		return nil, err
@@ -563,8 +567,10 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		return nil, err
 	}
 	if updated == nil {
-		updated = cloned
+		updated = resolvedAuth
 	}
+	// The resolver override applies only to this refresh attempt and must never be persisted.
+	updated.ProxyURL = auth.ProxyURL
 	// Preserve runtime created by the executor during Refresh.
 	// If executor didn't set one, fall back to the previous runtime.
 	if updated.Runtime == nil {

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -26,6 +26,16 @@ func (m *Manager) SetPluginScheduler(scheduler PluginScheduler) {
 	m.mu.Unlock()
 }
 
+// SetEgressProxyResolver configures the request-scoped outbound proxy resolver.
+func (m *Manager) SetEgressProxyResolver(resolver EgressProxyResolver) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.egressProxyResolver = resolver
+	m.mu.Unlock()
+}
+
 func (m *Manager) hasPluginScheduler() bool {
 	if m == nil {
 		return false

--- a/sdk/cliproxy/auth/egress_proxy.go
+++ b/sdk/cliproxy/auth/egress_proxy.go
@@ -1,0 +1,107 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+func (m *Manager) resolveEgressProxy(ctx context.Context, provider, model, operation string, auth *Auth) (*Auth, error) {
+	if m == nil || auth == nil {
+		return auth, nil
+	}
+	m.mu.RLock()
+	resolver := m.egressProxyResolver
+	m.mu.RUnlock()
+	if resolver == nil {
+		return auth, nil
+	}
+
+	accountType, email := auth.AccountInfo()
+	if accountType != "oauth" {
+		email = ""
+	}
+	response, handled, errResolve := resolver.ResolveEgressProxy(ctx, pluginapi.EgressProxyRequest{
+		Provider:  strings.ToLower(strings.TrimSpace(provider)),
+		Model:     strings.TrimSpace(model),
+		Operation: strings.ToLower(strings.TrimSpace(operation)),
+		Auth: pluginapi.EgressProxyAuth{
+			ID:       strings.TrimSpace(auth.ID),
+			Index:    strings.TrimSpace(auth.EnsureIndex()),
+			Provider: strings.ToLower(strings.TrimSpace(auth.Provider)),
+			Label:    strings.TrimSpace(auth.Label),
+			Email:    email,
+		},
+	})
+	if errResolve != nil {
+		return nil, fmt.Errorf("resolve request egress proxy: %w", errResolve)
+	}
+	if !handled || !response.Handled || response.Mode == pluginapi.EgressProxyModeInherit {
+		return auth, nil
+	}
+
+	override := auth.Clone()
+	switch response.Mode {
+	case pluginapi.EgressProxyModeDirect:
+		override.ProxyURL = "direct"
+	case pluginapi.EgressProxyModeProxy:
+		override.ProxyURL = response.ProxyURL
+	default:
+		return nil, fmt.Errorf("resolve request egress proxy: invalid proxy mode")
+	}
+	return override, nil
+}
+
+func applyEgressProxyOverride(auth, selected, resolved *Auth) *Auth {
+	if auth == nil || selected == nil || resolved == nil || resolved.ProxyURL == selected.ProxyURL {
+		return auth
+	}
+	override := auth.Clone()
+	override.ProxyURL = resolved.ProxyURL
+	return override
+}
+
+func (m *Manager) egressProxyContext(ctx context.Context, auth *Auth) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if rt := m.roundTripperFor(auth); rt != nil {
+		ctx = context.WithValue(ctx, roundTripperContextKey{}, rt)
+		ctx = context.WithValue(ctx, "cliproxy.roundtripper", rt)
+	}
+	return ctx
+}
+
+func egressProxyOperationForContext(ctx context.Context, stream bool) string {
+	if stream && cliproxyexecutor.DownstreamWebsocket(ctx) {
+		return "websocket"
+	}
+	if stream {
+		return "stream"
+	}
+	return "execute"
+}
+
+func (m *Manager) resolveEgressProxyContext(ctx context.Context, provider, model, operation string, auth *Auth) (context.Context, *Auth, error) {
+	resolvedAuth, errResolve := m.resolveEgressProxy(ctx, provider, model, operation, auth)
+	if errResolve != nil {
+		return ctx, auth, errResolve
+	}
+	return m.egressProxyContext(ctx, resolvedAuth), resolvedAuth, nil
+}
+
+func (m *Manager) resolveEgressProxyHTTPRequest(ctx context.Context, auth *Auth, req *http.Request) (context.Context, *Auth, error) {
+	provider := ""
+	if auth != nil {
+		provider = auth.Provider
+	}
+	model := ""
+	if req != nil && req.URL != nil {
+		model = req.URL.Path
+	}
+	return m.resolveEgressProxyContext(ctx, provider, model, "http", auth)
+}

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -262,6 +262,7 @@ func (b *Builder) Build() (*Service, error) {
 	coreManager.SetOAuthModelAlias(b.cfg.OAuthModelAlias)
 	if pluginHost != nil {
 		coreManager.SetPluginScheduler(pluginHost)
+		coreManager.SetEgressProxyResolver(pluginHost)
 	}
 
 	service := &Service{

--- a/sdk/cliproxy/service_plugins.go
+++ b/sdk/cliproxy/service_plugins.go
@@ -106,6 +106,7 @@ func (s *Service) syncPluginRuntimeConfigForConfig(ctx context.Context, cfg *con
 	}
 	if s.coreManager != nil {
 		s.coreManager.SetPluginScheduler(s.pluginHost)
+		s.coreManager.SetEgressProxyResolver(s.pluginHost)
 	}
 	s.registerPluginAuthParser()
 	if s.pluginHost == nil {

--- a/sdk/pluginabi/types.go
+++ b/sdk/pluginabi/types.go
@@ -10,7 +10,8 @@ const (
 	// Version 3 omits OriginalRequest/RequestBody on payload stream chunks
 	// (ChunkIndex >= 0); those fields remain on StreamChunkHeaderInitIndex only.
 	// Plugins that still need per-chunk request bodies should keep schema_version < 3.
-	SchemaVersion uint32 = 3
+	// Version 4 adds the egress proxy resolver capability.
+	SchemaVersion uint32 = 4
 	// SchemaVersionStreamChunkOmitRequestBody is the first schema version that omits
 	// request bodies on payload stream-chunk interceptor calls.
 	SchemaVersionStreamChunkOmitRequestBody uint32 = 3
@@ -38,6 +39,8 @@ const (
 	MethodSchedulerPick = "scheduler.pick"
 	// MethodModelRoute asks a router plugin to select a plugin executor for a matching request.
 	MethodModelRoute = "model.route"
+	// MethodEgressProxyResolve asks a plugin to select proxy behavior for one outbound operation.
+	MethodEgressProxyResolve = "egress_proxy.resolve"
 
 	MethodExecutorIdentifier    = "executor.identifier"
 	MethodExecutorExecute       = "executor.execute"

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -85,6 +85,8 @@ type Capabilities struct {
 	// ModelRouter routes matching requests to a plugin executor, the router's own executor,
 	// or a built-in provider before model-to-provider resolution and auth selection.
 	ModelRouter ModelRouter
+	// EgressProxyResolver selects request-scoped outbound proxy behavior after credential selection.
+	EgressProxyResolver EgressProxyResolver
 	// Executor sends requests to an upstream provider or local backend.
 	Executor ProviderExecutor
 	// ExecutorModelScope declares whether Executor serves static models, OAuth auth models, or both.
@@ -580,6 +582,59 @@ type ModelRouteResponse struct {
 	TargetModel string
 	// Reason is an optional diagnostic reason for the route decision.
 	Reason string
+}
+
+// EgressProxyMode specifies how an egress proxy resolver handles one outbound operation.
+type EgressProxyMode string
+
+const (
+	// EgressProxyModeInherit keeps the configured auth-level and global proxy behavior.
+	EgressProxyModeInherit EgressProxyMode = "inherit"
+	// EgressProxyModeDirect bypasses configured proxies for this operation.
+	EgressProxyModeDirect EgressProxyMode = "direct"
+	// EgressProxyModeProxy uses the resolver-provided proxy URL for this operation.
+	EgressProxyModeProxy EgressProxyMode = "proxy"
+)
+
+// EgressProxyAuth identifies the selected credential without exposing credential secrets.
+type EgressProxyAuth struct {
+	// ID is the stable credential identifier.
+	ID string `json:"id"`
+	// Index is the stable runtime credential index.
+	Index string `json:"index"`
+	// Provider is the credential provider key.
+	Provider string `json:"provider"`
+	// Label is the user-facing credential label.
+	Label string `json:"label"`
+	// Email is the credential email when available.
+	Email string `json:"email"`
+}
+
+// EgressProxyRequest describes one outbound operation after credential selection.
+type EgressProxyRequest struct {
+	// Provider is the selected upstream provider key.
+	Provider string `json:"provider"`
+	// Model is the selected upstream model when applicable.
+	Model string `json:"model,omitempty"`
+	// Operation identifies the outbound operation, such as execute, stream, refresh, or websocket.
+	Operation string `json:"operation"`
+	// Auth identifies the selected credential. It contains no tokens, API keys, or metadata.
+	Auth EgressProxyAuth `json:"auth"`
+}
+
+// EgressProxyResponse returns the resolver decision for one outbound operation.
+type EgressProxyResponse struct {
+	// Handled reports whether the plugin made a proxy decision. False preserves existing behavior.
+	Handled bool `json:"handled"`
+	// Mode is inherit, direct, or proxy when Handled is true.
+	Mode EgressProxyMode `json:"mode,omitempty"`
+	// ProxyURL is used only when Mode is proxy. The host never persists or logs this value.
+	ProxyURL string `json:"proxy_url,omitempty"`
+}
+
+// EgressProxyResolver chooses request-scoped outbound proxy behavior after credential selection.
+type EgressProxyResolver interface {
+	ResolveEgressProxy(context.Context, EgressProxyRequest) (EgressProxyResponse, error)
 }
 
 // ProviderExecutor handles model execution, streaming, HTTP bridging, and token counting.


### PR DESCRIPTION
## Summary
- add the `egress_proxy_resolver` plugin capability and RPC contract
- resolve temporary per-auth proxy behavior for standard execution, streams, refresh, direct HTTP, Home paths, and Antigravity credits fallback
- preserve account proxy URLs by applying resolver results on request-scoped auth clones

## Issue
Closes #5215

## Verification
- `GOCACHE="$PWD/.gocache" go test ./internal/pluginhost ./sdk/cliproxy/auth ./sdk/cliproxy -run ^`
- `GOCACHE="$PWD/.gocache" go build -o test-output ./cmd/server`

## Review follow-ups
This initial PR intentionally retains the known review follow-ups around retained Home session overrides, Home refresh and model/profile/WebSocket coverage, and temporary transport caching. They will be addressed separately.