### PR TITLE
openai responses: map completion_tokens_details.reasoning_tokens in non-stream conversion

### DIFF
--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -981,8 +981,11 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 				resp, _ = sjson.SetBytes(resp, "usage.input_tokens_details.cached_tokens", d.Int())
 			}
 			resp, _ = sjson.SetBytes(resp, "usage.output_tokens", usage.Get("completion_tokens").Int())
-			// Reasoning tokens not available in Chat Completions; set only if present under output_tokens_details
+			// Chat Completions report reasoning under completion_tokens_details
+			// (OpenAI, vLLM); some upstreams already use the Responses shape.
 			if d := usage.Get("output_tokens_details.reasoning_tokens"); d.Exists() {
+				resp, _ = sjson.SetBytes(resp, "usage.output_tokens_details.reasoning_tokens", d.Int())
+			} else if d := usage.Get("completion_tokens_details.reasoning_tokens"); d.Exists() {
 				resp, _ = sjson.SetBytes(resp, "usage.output_tokens_details.reasoning_tokens", d.Int())
 			}
 			resp, _ = sjson.SetBytes(resp, "usage.total_tokens", usage.Get("total_tokens").Int())

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -1349,3 +1349,35 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_Reasonin
 		})
 	}
 }
+
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_MapsReasoningTokens(t *testing.T) {
+	t.Parallel()
+
+	request := []byte(`{"model":"m","input":"hi"}`)
+	tests := []struct {
+		name  string
+		usage string
+		want  int64
+	}{
+		{
+			name:  "chat completions shape",
+			usage: `{"prompt_tokens":38,"completion_tokens":95,"total_tokens":133,"completion_tokens_details":{"reasoning_tokens":88}}`,
+			want:  88,
+		},
+		{
+			name:  "responses shape wins when both present",
+			usage: `{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3,"output_tokens_details":{"reasoning_tokens":5},"completion_tokens_details":{"reasoning_tokens":9}}`,
+			want:  5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := []byte(`{"id":"chatcmpl-1","object":"chat.completion","created":1,"model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"0.05"},"finish_reason":"stop"}],"usage":` + tt.usage + `}`)
+			out := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "m", request, request, raw, nil)
+			got := gjson.GetBytes(out, "usage.output_tokens_details.reasoning_tokens")
+			if !got.Exists() || got.Int() != tt.want {
+				t.Fatalf("reasoning_tokens = %v, want %d; usage=%s", got.Raw, tt.want, gjson.GetBytes(out, "usage").Raw)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
`ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream` only read `usage.output_tokens_details.reasoning_tokens`, so for OpenAI-compatible upstreams that report reasoning the Chat Completions way (`usage.completion_tokens_details.reasoning_tokens` — OpenAI, vLLM) the non-streaming `/v1/responses` reply always carried `reasoning_tokens: 0`. The streaming path already falls back to the Chat Completions field (`parseUsage`); this makes the non-stream path do the same, preferring the Responses-shaped field when both are present.

## Test
`go test ./internal/translator/openai/openai/responses/` — adds `TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_MapsReasoningTokens` covering both shapes.

Observed against vLLM (Qwen3.8-27B): streaming `/v1/responses` reported `reasoning_tokens: 112`, non-streaming reported 0 for the same prompt; with this change both report the upstream value.