### PR TITLE
fix(antigravity): safely synthesize terminal finish reasons (#5226)

### DIFF
--- a/internal/runtime/executor/antigravity_executor_finish_reason_test.go
+++ b/internal/runtime/executor/antigravity_executor_finish_reason_test.go
@@ -1,0 +1,263 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+// antigravityNoFinishReasonSSE mirrors a real upstream stream captured from
+// cloudcode-pa: a single tool-call chunk that carries usageMetadata but never
+// emits finishReason.
+const antigravityNoFinishReasonSSE = `data: {"response":{"candidates":[{"content":{"parts":[{"thoughtSignature":"CqcECqQEARFNMg8iZ3xVniKaulgBlzhJJDlc","functionCall":{"name":"bash","args":{"command":"ls -la .."},"id":"call_524881"}}],"role":"model"}}],"modelVersion":"gemini-3.7-flash","responseId":"resp-nofr","usageMetadata":{"promptTokenCount":153609,"candidatesTokenCount":17,"totalTokenCount":153720,"thoughtsTokenCount":94}}}
+`
+
+func newAntigravityNoFinishReasonServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, antigravityNoFinishReasonSSE)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}))
+}
+
+func collectAntigravityStream(t *testing.T, baseURL string, sourceFormat, responseFormat sdktranslator.Format, payload string) [][]byte {
+	t.Helper()
+	executor := NewAntigravityExecutor(&config.Config{
+		Antigravity:  config.AntigravityConfig{},
+		RequestRetry: 1,
+	})
+	result, errExecute := executor.ExecuteStream(context.Background(), &cliproxyauth.Auth{
+		Metadata: map[string]any{
+			"access_token": "token-123",
+			"expired":      time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+			"project_id":   "project-1",
+		},
+		Attributes: map[string]string{"base_url": baseURL},
+	}, cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash",
+		Payload: []byte(payload),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sourceFormat,
+		ResponseFormat: responseFormat,
+		Stream:         true,
+	})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+	var chunks [][]byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected stream error: %v", chunk.Err)
+		}
+		chunks = append(chunks, chunk.Payload)
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+	return chunks
+}
+
+// TestAntigravityStreamDoesNotEmitClaudeMessageStopOnReadError locks in the
+// executor ordering fix on the response format where it is observable: the
+// Claude translator has always synthesized a terminal event on [DONE], so
+// translating the tail before checking scanner.Err() reported a truncated
+// upstream stream to Claude clients as a completed message.
+func TestAntigravityStreamDoesNotEmitClaudeMessageStopOnReadError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+		_, _ = io.WriteString(w, `data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"partial"}]}}],"modelVersion":"gemini-3.7-flash","responseId":"resp-cut"}}`+"\n\n")
+		flusher.Flush()
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, _, errHijack := hijacker.Hijack()
+		if errHijack == nil {
+			_ = conn.Close()
+		}
+	}))
+	defer server.Close()
+
+	executor := NewAntigravityExecutor(&config.Config{
+		Antigravity:  config.AntigravityConfig{},
+		RequestRetry: 1,
+	})
+	result, errExecute := executor.ExecuteStream(context.Background(), &cliproxyauth.Auth{
+		Metadata: map[string]any{
+			"access_token": "token-123",
+			"expired":      time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+			"project_id":   "project-1",
+		},
+		Attributes: map[string]string{"base_url": server.URL},
+	}, cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash",
+		Payload: []byte(`{"model":"gemini-3.7-flash","max_tokens":256,"stream":true,"messages":[{"role":"user","content":"hello"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatClaude,
+		ResponseFormat: sdktranslator.FormatClaude,
+		Stream:         true,
+	})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+
+	var streamErr error
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			streamErr = chunk.Err
+			continue
+		}
+		if bytes.Contains(chunk.Payload, []byte("message_stop")) {
+			t.Fatalf("read error must not emit message_stop: %s", chunk.Payload)
+		}
+	}
+	if streamErr == nil {
+		t.Fatal("expected stream read error")
+	}
+}
+
+func TestAntigravityStreamDoesNotFinalizeEmptyUpstreamStream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name           string
+		sourceFormat   sdktranslator.Format
+		responseFormat sdktranslator.Format
+		payload        string
+	}{
+		{"gemini", sdktranslator.FormatGemini, sdktranslator.FormatGemini,
+			`{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`},
+		{"openai", sdktranslator.FormatOpenAI, sdktranslator.FormatOpenAI,
+			`{"model":"gemini-3.7-flash","messages":[{"role":"user","content":"hello"}],"stream":true}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			executor := NewAntigravityExecutor(&config.Config{
+				Antigravity:  config.AntigravityConfig{},
+				RequestRetry: 1,
+			})
+			result, errExecute := executor.ExecuteStream(context.Background(), &cliproxyauth.Auth{
+				Metadata: map[string]any{
+					"access_token": "token-123",
+					"expired":      time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+					"project_id":   "project-1",
+				},
+				Attributes: map[string]string{"base_url": server.URL},
+			}, cliproxyexecutor.Request{
+				Model:   "gemini-3.7-flash",
+				Payload: []byte(tc.payload),
+			}, cliproxyexecutor.Options{
+				SourceFormat:   tc.sourceFormat,
+				ResponseFormat: tc.responseFormat,
+				Stream:         true,
+			})
+			if errExecute != nil {
+				t.Fatalf("ExecuteStream() error = %v", errExecute)
+			}
+			for chunk := range result.Chunks {
+				if chunk.Err != nil {
+					t.Fatalf("unexpected stream error: %v", chunk.Err)
+				}
+				if finish := gjson.GetBytes(chunk.Payload, "candidates.0.finishReason").String(); finish != "" {
+					t.Fatalf("empty upstream stream must not synthesize a terminal chunk: %s", chunk.Payload)
+				}
+				if finish := gjson.GetBytes(chunk.Payload, "choices.0.finish_reason").String(); finish != "" {
+					t.Fatalf("empty upstream stream must not synthesize a terminal chunk: %s", chunk.Payload)
+				}
+			}
+		})
+	}
+}
+
+func TestAntigravityStreamSynthesizesGeminiTerminalChunkWithUsage(t *testing.T) {
+	server := newAntigravityNoFinishReasonServer(t)
+	defer server.Close()
+
+	chunks := collectAntigravityStream(t, server.URL, sdktranslator.FormatGemini, sdktranslator.FormatGemini,
+		`{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`)
+
+	terminal := chunks[len(chunks)-1]
+	if fr := gjson.GetBytes(terminal, "candidates.0.finishReason").String(); fr != "STOP" {
+		t.Fatalf("terminal finishReason = %q, want STOP", fr)
+	}
+	if role := gjson.GetBytes(terminal, "candidates.0.content.role").String(); role != "model" {
+		t.Fatalf("terminal content role = %q, want model", role)
+	}
+	if got := gjson.GetBytes(terminal, "usageMetadata.totalTokenCount").Int(); got != 153720 {
+		t.Fatalf("terminal totalTokenCount = %d, want 153720", got)
+	}
+	if got := gjson.GetBytes(terminal, "usageMetadata.promptTokenCount").Int(); got != 153609 {
+		t.Fatalf("terminal promptTokenCount = %d, want 153609", got)
+	}
+	if got := gjson.GetBytes(terminal, "modelVersion").String(); got != "gemini-3.7-flash" {
+		t.Fatalf("terminal modelVersion = %q, want gemini-3.7-flash", got)
+	}
+	if got := gjson.GetBytes(terminal, "responseId").String(); got != "resp-nofr" {
+		t.Fatalf("terminal responseId = %q, want resp-nofr", got)
+	}
+
+	var finishReasonCount int
+	for _, chunk := range chunks {
+		if gjson.GetBytes(chunk, "candidates.0.finishReason").String() != "" {
+			finishReasonCount++
+		}
+	}
+	if finishReasonCount != 1 {
+		t.Fatalf("expected exactly one finishReason chunk, got %d", finishReasonCount)
+	}
+}
+
+func TestAntigravityStreamSynthesizesOpenAIToolCallsFinishReason(t *testing.T) {
+	server := newAntigravityNoFinishReasonServer(t)
+	defer server.Close()
+
+	chunks := collectAntigravityStream(t, server.URL, sdktranslator.FormatOpenAI, sdktranslator.FormatOpenAI,
+		`{"model":"gemini-3.7-flash","messages":[{"role":"user","content":"hello"}],"stream":true}`)
+
+	terminal := chunks[len(chunks)-1]
+	if fr := gjson.GetBytes(terminal, "choices.0.finish_reason").String(); fr != "tool_calls" {
+		t.Fatalf("terminal finish_reason = %q, want tool_calls", fr)
+	}
+	if got := gjson.GetBytes(terminal, "usage.total_tokens").Int(); got != 153720 {
+		t.Fatalf("terminal total_tokens = %d, want 153720", got)
+	}
+	if got := gjson.GetBytes(terminal, "usage.prompt_tokens").Int(); got != 153609 {
+		t.Fatalf("terminal prompt_tokens = %d, want 153609", got)
+	}
+	if got := gjson.GetBytes(terminal, "model").String(); got != "gemini-3.7-flash" {
+		t.Fatalf("terminal model = %q, want gemini-3.7-flash", got)
+	}
+
+	var finishReasonCount int
+	for _, chunk := range chunks {
+		if gjson.GetBytes(chunk, "choices.0.finish_reason").String() != "" {
+			finishReasonCount++
+		}
+	}
+	if finishReasonCount != 1 {
+		t.Fatalf("expected exactly one finish_reason chunk, got %d", finishReasonCount)
+	}
+}

--- a/internal/runtime/executor/antigravity_executor_signature_test.go
+++ b/internal/runtime/executor/antigravity_executor_signature_test.go
@@ -255,6 +255,64 @@ func TestAntigravityStreamObfuscatesSensitiveSystemInstruction(t *testing.T) {
 	}
 }
 
+func TestAntigravityStreamDoesNotEmitSyntheticTerminalOnReadError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+		_, _ = io.WriteString(w, `data: {"response":{"candidates":[{"content":{"parts":[{"text":"partial"}]}}]}}`+"\n")
+		flusher.Flush()
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, _, errHijack := hijacker.Hijack()
+		if errHijack == nil {
+			_ = conn.Close()
+		}
+	}))
+	defer server.Close()
+
+	executor := NewAntigravityExecutor(&config.Config{
+		Antigravity:  config.AntigravityConfig{},
+		RequestRetry: 1,
+	})
+	result, errExecute := executor.ExecuteStream(context.Background(), &cliproxyauth.Auth{
+		Metadata: map[string]any{
+			"access_token": "token-123",
+			"expired":      time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+			"project_id":   "project-1",
+		},
+		Attributes: map[string]string{"base_url": server.URL},
+	}, cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash",
+		Payload: []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatGemini,
+		ResponseFormat: sdktranslator.FormatGemini,
+		Stream:         true,
+	})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+
+	var streamErr error
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			streamErr = chunk.Err
+			continue
+		}
+		if finishReason := gjson.GetBytes(chunk.Payload, "candidates.0.finishReason").String(); finishReason == "STOP" {
+			t.Fatalf("read error must not emit synthetic STOP: %s", chunk.Payload)
+		}
+	}
+	if streamErr == nil {
+		t.Fatal("expected stream read error")
+	}
+}
+
 func TestAntigravityStreamPrependsLeadingUserForGemini(t *testing.T) {
 	assertLeadingFunctionHistory := func(t *testing.T, body []byte) {
 		t.Helper()

--- a/internal/runtime/executor/antigravity_executor_split_usage_test.go
+++ b/internal/runtime/executor/antigravity_executor_split_usage_test.go
@@ -1,0 +1,98 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+// antigravitySplitTerminalSSE reproduces the only upstream shape that makes
+// FilterSSEUsageMetadata forward real usageMetadata on a chunk without
+// finishReason: a chunk carrying finishReason but no usage, whose traceId is
+// then matched by a usage-only tail chunk. The tail chunk is terminal, so the
+// stream must end with exactly one finish_reason that carries the usage.
+const antigravitySplitTerminalSSE = `data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"first"}]},"finishReason":"STOP"}],"modelVersion":"gemini-3.7-flash","responseId":"resp-split"},"traceId":"trace-split"}
+
+data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":""}]}}],"usageMetadata":{"promptTokenCount":11,"candidatesTokenCount":22,"totalTokenCount":33},"modelVersion":"gemini-3.7-flash","responseId":"resp-split"},"traceId":"trace-split"}
+
+`
+
+// TestAntigravityStreamFinalizesSplitTerminalUsageOnce covers a terminal
+// finishReason and its usage arriving in separate chunks: the stream must carry
+// exactly one finish_reason, on the last chunk, together with the token counts.
+func TestAntigravityStreamFinalizesSplitTerminalUsageOnce(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, antigravitySplitTerminalSSE)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	executor := NewAntigravityExecutor(&config.Config{
+		Antigravity:  config.AntigravityConfig{},
+		RequestRetry: 1,
+	})
+	result, errExecute := executor.ExecuteStream(context.Background(), &cliproxyauth.Auth{
+		Metadata: map[string]any{
+			"access_token": "token-123",
+			"expired":      time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+			"project_id":   "project-1",
+		},
+		Attributes: map[string]string{"base_url": server.URL},
+	}, cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash",
+		Payload: []byte(`{"model":"gemini-3.7-flash","messages":[{"role":"user","content":"hello"}],"stream":true}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatOpenAI,
+		ResponseFormat: sdktranslator.FormatOpenAI,
+		Stream:         true,
+	})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+
+	var (
+		chunks      [][]byte
+		finishIndex = -1
+	)
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected stream error: %v", chunk.Err)
+		}
+		if reason := gjson.GetBytes(chunk.Payload, "choices.0.finish_reason").String(); reason != "" {
+			if finishIndex >= 0 {
+				t.Fatalf("more than one terminal chunk: %s", chunk.Payload)
+			}
+			if reason != "stop" {
+				t.Fatalf("finish_reason = %q, want stop", reason)
+			}
+			finishIndex = len(chunks)
+		}
+		chunks = append(chunks, chunk.Payload)
+	}
+
+	if finishIndex < 0 {
+		t.Fatal("expected a terminal chunk")
+	}
+	if finishIndex != len(chunks)-1 {
+		t.Fatalf("terminal chunk at index %d of %d chunks, want the last one", finishIndex, len(chunks))
+	}
+	terminal := chunks[finishIndex]
+	if got := gjson.GetBytes(terminal, "usage.total_tokens").Int(); got != 33 {
+		t.Fatalf("terminal total_tokens = %d, want 33", got)
+	}
+	if got := gjson.GetBytes(terminal, "usage.prompt_tokens").Int(); got != 11 {
+		t.Fatalf("terminal prompt_tokens = %d, want 11", got)
+	}
+}

--- a/internal/runtime/executor/antigravity_executor_stream.go
+++ b/internal/runtime/executor/antigravity_executor_stream.go
@@ -210,14 +210,6 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 				}
 			}
 		}
-		tail := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, []byte("[DONE]"), &param, claudeInputTokens)
-		for i := range tail {
-			select {
-			case out <- cliproxyexecutor.StreamChunk{Payload: tail[i]}:
-			case <-ctx.Done():
-				return
-			}
-		}
 		if errScan := scanner.Err(); errScan != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.PublishFailure(ctx, errScan)
@@ -226,6 +218,17 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 			case <-ctx.Done():
 			}
 		} else {
+			// Only a clean end of stream may produce a synthetic terminal event.
+			// Translating [DONE] after a read error would report a truncated
+			// stream as a successful completion.
+			tail := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, []byte("[DONE]"), &param, claudeInputTokens)
+			for i := range tail {
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Payload: tail[i]}:
+				case <-ctx.Done():
+					return
+				}
+			}
 			if replayAccumulator != nil {
 				replayAccumulator.Commit(ctx)
 			}

--- a/internal/translator/antigravity/gemini/antigravity_gemini_response.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_response.go
@@ -16,6 +16,100 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+type convertAntigravityGeminiParams struct {
+	SawResponse     bool
+	SawFinishReason bool
+	ModelVersion    string
+	ResponseID      string
+	UsageMetadata   []byte
+}
+
+// observe records the metadata required to synthesize a faithful terminal chunk
+// when upstream never emits finishReason.
+func (p *convertAntigravityGeminiParams) observe(rawJSON []byte) {
+	if !p.SawResponse {
+		p.SawResponse = hasAntigravityResponsePayload(rawJSON)
+	}
+	if !p.SawFinishReason {
+		for _, path := range []string{"response.candidates", "candidates"} {
+			for _, candidate := range gjson.GetBytes(rawJSON, path).Array() {
+				if candidate.Get("finishReason").String() != "" {
+					p.SawFinishReason = true
+					break
+				}
+			}
+			if p.SawFinishReason {
+				break
+			}
+		}
+	}
+	if p.ModelVersion == "" {
+		p.ModelVersion = firstStringValue(rawJSON, "response.modelVersion", "modelVersion")
+	}
+	if p.ResponseID == "" {
+		p.ResponseID = firstStringValue(rawJSON, "response.responseId", "responseId")
+	}
+	// Keep the latest usage snapshot. FilterSSEUsageMetadata renames non-terminal
+	// usage to cpaUsageMetadata, so both spellings must be tracked.
+	for _, path := range []string{"response.usageMetadata", "response.cpaUsageMetadata", "usageMetadata", "cpaUsageMetadata"} {
+		if usage := gjson.GetBytes(rawJSON, path); usage.Exists() {
+			p.UsageMetadata = append(p.UsageMetadata[:0], usage.Raw...)
+			break
+		}
+	}
+}
+
+// syntheticTerminalChunk mirrors the terminal chunk shape observed from upstream:
+// a model-role candidate carrying an empty text part, finishReason, and the last
+// known usage metadata. Fields are set in upstream key order
+// (candidates, usageMetadata, modelVersion, responseId).
+func (p *convertAntigravityGeminiParams) syntheticTerminalChunk() []byte {
+	chunk := []byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":""}]},"finishReason":"STOP"}]}`)
+	if len(p.UsageMetadata) > 0 {
+		chunk, _ = sjson.SetRawBytes(chunk, "usageMetadata", p.UsageMetadata)
+	}
+	if p.ModelVersion != "" {
+		chunk, _ = sjson.SetBytes(chunk, "modelVersion", p.ModelVersion)
+	}
+	if p.ResponseID != "" {
+		chunk, _ = sjson.SetBytes(chunk, "responseId", p.ResponseID)
+	}
+	return chunk
+}
+
+// hasAntigravityResponsePayload reports whether a chunk carries actual generated
+// content or token accounting. Presence alone is not enough: an envelope such as
+// `{}`, `{"response":{}}` or `{"response":{"candidates":[]}}` must not count as a
+// started stream, otherwise a keepalive or malformed event would be enough to
+// finalize a stream that produced nothing.
+func hasAntigravityResponsePayload(rawJSON []byte) bool {
+	for _, path := range []string{"response.candidates", "candidates"} {
+		if candidates := gjson.GetBytes(rawJSON, path); candidates.IsArray() && len(candidates.Array()) > 0 {
+			return true
+		}
+	}
+	// FilterSSEUsageMetadata renames non-terminal usage to cpaUsageMetadata before
+	// the translator sees it, so both spellings must be accepted.
+	for _, path := range []string{
+		"response.usageMetadata", "response.cpaUsageMetadata",
+		"usageMetadata", "cpaUsageMetadata",
+	} {
+		if usage := gjson.GetBytes(rawJSON, path); usage.IsObject() && len(usage.Map()) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func firstStringValue(rawJSON []byte, paths ...string) string {
+	for _, path := range paths {
+		if value := gjson.GetBytes(rawJSON, path).String(); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
 // ConvertAntigravityResponseToGemini parses and transforms a Antigravity API request into Gemini API format.
 // It extracts the model name, system instruction, message contents, and tool declarations
 // from the raw JSON request and returns them in the format expected by the Gemini API.
@@ -23,18 +117,48 @@ import (
 // 1. Extracts the response data from the request
 // 2. Handles alternative response formats
 // 3. Processes array responses by extracting individual response objects
+// 4. Synthesizes finishReason: "STOP" on [DONE] if omitted by upstream
 //
 // Parameters:
 //   - ctx: The context for the request, used for cancellation and timeout handling
 //   - modelName: The name of the model to use for the request (unused in current implementation)
 //   - rawJSON: The raw JSON request data from the Antigravity API
-//   - param: A pointer to a parameter object for the conversion (unused in current implementation)
+//   - param: A pointer to a parameter object for the conversion
 //
 // Returns:
 //   - [][]byte: The transformed response data in Gemini API format.
-func ConvertAntigravityResponseToGemini(ctx context.Context, _ string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, _ *any) [][]byte {
+func ConvertAntigravityResponseToGemini(ctx context.Context, _ string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, param *any) [][]byte {
 	if bytes.HasPrefix(rawJSON, []byte("data:")) {
 		rawJSON = bytes.TrimSpace(rawJSON[5:])
+	}
+
+	var state *convertAntigravityGeminiParams
+	if param != nil {
+		if *param == nil {
+			*param = &convertAntigravityGeminiParams{}
+		}
+		if s, ok := (*param).(*convertAntigravityGeminiParams); ok {
+			state = s
+		}
+	}
+
+	if bytes.Equal(rawJSON, []byte("[DONE]")) {
+		// Never finalize a stream that produced no response at all: an empty
+		// upstream body must stay detectable as a failure rather than be reported
+		// as a successful empty completion.
+		if state == nil || !state.SawResponse || state.SawFinishReason {
+			return [][]byte{}
+		}
+		state.SawFinishReason = true
+		finalChunk := state.syntheticTerminalChunk()
+		if alt, ok := ctx.Value("alt").(string); ok && alt != "" {
+			finalChunk, _ = sjson.SetRawBytes([]byte("[]"), "-1", finalChunk)
+		}
+		return [][]byte{finalChunk}
+	}
+
+	if state != nil {
+		state.observe(rawJSON)
 	}
 
 	if alt, ok := ctx.Value("alt").(string); ok {
@@ -48,7 +172,7 @@ func ConvertAntigravityResponseToGemini(ctx context.Context, _ string, originalR
 			}
 		} else {
 			chunkTemplate := []byte("[]")
-			responseResult := gjson.ParseBytes(chunk)
+			responseResult := gjson.ParseBytes(rawJSON)
 			if responseResult.IsArray() {
 				responseResultItems := responseResult.Array()
 				for i := 0; i < len(responseResultItems); i++ {
@@ -78,12 +202,25 @@ func ConvertAntigravityResponseToGemini(ctx context.Context, _ string, originalR
 // Returns:
 //   - []byte: A Gemini-compatible JSON response containing the response data.
 func ConvertAntigravityResponseToGeminiNonStream(_ context.Context, _ string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, _ *any) []byte {
+	var chunk []byte
 	responseResult := gjson.GetBytes(rawJSON, "response")
 	if responseResult.Exists() {
-		chunk := restoreUsageMetadata([]byte(responseResult.Raw))
-		return restoreGeminiFunctionNames(chunk, originalRequestRawJSON)
+		chunk = restoreUsageMetadata([]byte(responseResult.Raw))
+		chunk = restoreGeminiFunctionNames(chunk, originalRequestRawJSON)
+	} else {
+		chunk = restoreGeminiFunctionNames(rawJSON, originalRequestRawJSON)
 	}
-	return restoreGeminiFunctionNames(rawJSON, originalRequestRawJSON)
+	candidates := gjson.GetBytes(chunk, "candidates")
+	if candidates.IsArray() {
+		// Default every candidate, not just the first one, so a multi-candidate
+		// response cannot leave some of them unterminated.
+		for i, candidate := range candidates.Array() {
+			if candidate.Get("finishReason").String() == "" {
+				chunk, _ = sjson.SetBytes(chunk, fmt.Sprintf("candidates.%d.finishReason", i), "STOP")
+			}
+		}
+	}
+	return chunk
 }
 
 func restoreGeminiFunctionNames(chunk, originalRequestRawJSON []byte) []byte {

--- a/internal/translator/antigravity/gemini/antigravity_gemini_response_test.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_response_test.go
@@ -2,6 +2,7 @@ package gemini
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
@@ -82,30 +83,159 @@ func TestConvertAntigravityResponseToGeminiNonStreamRestoresDisambiguatedName(t 
 	}
 }
 
-func TestConvertAntigravityResponseToGeminiStream(t *testing.T) {
+func TestConvertAntigravityResponseToGeminiStream_SynthesizesFinishReasonOnDoneWhenOmitted(t *testing.T) {
 	ctx := context.WithValue(context.Background(), "alt", "")
+	var param any
 
-	tests := []struct {
-		name     string
-		input    []byte
-		expected string
-	}{
-		{
-			name:     "cpaUsageMetadata restored in streaming response",
-			input:    []byte(`data: {"response":{"modelVersion":"gemini-3-pro","cpaUsageMetadata":{"promptTokenCount":100}}}`),
-			expected: `{"modelVersion":"gemini-3-pro","usageMetadata":{"promptTokenCount":100}}`,
-		},
+	// Pure thinking chunk with 0 output tokens and NO finishReason (reproducing real upstream Antigravity logs)
+	chunk1 := []byte(`data: {"response":{"candidates":[{"content":{"parts":[{"thought":true,"text":"Thinking..."}],"role":"model"}}],"usageMetadata":{"promptTokenCount":100,"totalTokenCount":150,"thoughtsTokenCount":50},"modelVersion":"gemini-3.7-flash","responseId":"resp-123"}}`)
+	results1 := ConvertAntigravityResponseToGemini(ctx, "gemini-3.7-flash", nil, nil, chunk1, &param)
+	if len(results1) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(results1))
+	}
+	if fr := gjson.GetBytes(results1[0], "candidates.0.finishReason").String(); fr != "" {
+		t.Fatalf("chunk1 should not have finishReason yet, got %q", fr)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			results := ConvertAntigravityResponseToGemini(ctx, "", nil, nil, tt.input, nil)
-			if len(results) != 1 {
-				t.Fatalf("expected 1 result, got %d", len(results))
-			}
-			if string(results[0]) != tt.expected {
-				t.Errorf("ConvertAntigravityResponseToGemini() = %s, want %s", string(results[0]), tt.expected)
-			}
-		})
+	// Upstream finishes cleanly with [DONE]
+	doneResults := ConvertAntigravityResponseToGemini(ctx, "gemini-3.7-flash", nil, nil, []byte("[DONE]"), &param)
+	if len(doneResults) != 1 {
+		t.Fatalf("expected synthetic terminal chunk on [DONE], got %d results", len(doneResults))
+	}
+	synthetic := doneResults[0]
+	if fr := gjson.GetBytes(synthetic, "candidates.0.finishReason").String(); fr != "STOP" {
+		t.Fatalf("synthetic chunk finishReason = %q, want STOP", fr)
+	}
+	// Upstream terminal chunks always carry a model-role candidate with an empty
+	// text part, so the synthetic chunk mirrors that shape for client compatibility.
+	if role := gjson.GetBytes(synthetic, "candidates.0.content.role").String(); role != "model" {
+		t.Fatalf("synthetic chunk content role = %q, want model", role)
+	}
+	if parts := gjson.GetBytes(synthetic, "candidates.0.content.parts"); parts.String() != `[{"text":""}]` {
+		t.Fatalf("synthetic chunk parts = %s, want [{\"text\":\"\"}]", parts.Raw)
+	}
+	// The last real chunk carries usage, so the synthetic terminal chunk must keep it.
+	if got := gjson.GetBytes(synthetic, "usageMetadata.promptTokenCount").Int(); got != 100 {
+		t.Fatalf("synthetic chunk promptTokenCount = %d, want 100", got)
+	}
+	if got := gjson.GetBytes(synthetic, "usageMetadata.totalTokenCount").Int(); got != 150 {
+		t.Fatalf("synthetic chunk totalTokenCount = %d, want 150", got)
+	}
+	if mv := gjson.GetBytes(synthetic, "modelVersion").String(); mv != "gemini-3.7-flash" {
+		t.Fatalf("synthetic chunk modelVersion = %q, want gemini-3.7-flash", mv)
+	}
+	if rid := gjson.GetBytes(synthetic, "responseId").String(); rid != "resp-123" {
+		t.Fatalf("synthetic chunk responseId = %q, want resp-123", rid)
+	}
+
+	// Repeated [DONE] should not emit another chunk
+	dupResults := ConvertAntigravityResponseToGemini(ctx, "gemini-3.7-flash", nil, nil, []byte("[DONE]"), &param)
+	if len(dupResults) != 0 {
+		t.Fatalf("duplicate [DONE] should yield 0 results, got %d", len(dupResults))
+	}
+}
+
+func TestConvertAntigravityResponseToGeminiStream_DoesNotDuplicateFinishReasonWhenPresent(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "alt", "")
+	var param any
+
+	// Chunk with explicit STOP finishReason
+	chunk1 := []byte(`data: {"response":{"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"},"finishReason":"STOP"}],"modelVersion":"gemini-3.7-flash"}}`)
+	results1 := ConvertAntigravityResponseToGemini(ctx, "gemini-3.7-flash", nil, nil, chunk1, &param)
+	if len(results1) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(results1))
+	}
+	if fr := gjson.GetBytes(results1[0], "candidates.0.finishReason").String(); fr != "STOP" {
+		t.Fatalf("chunk1 finishReason = %q, want STOP", fr)
+	}
+
+	// [DONE] should not emit a second chunk
+	doneResults := ConvertAntigravityResponseToGemini(ctx, "gemini-3.7-flash", nil, nil, []byte("[DONE]"), &param)
+	if len(doneResults) != 0 {
+		t.Fatalf("expected 0 results on [DONE] when finishReason already observed, got %d", len(doneResults))
+	}
+}
+
+func TestConvertAntigravityResponseToGeminiStream_CarriesFilteredUsageIntoSyntheticTerminal(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "alt", "")
+	var param any
+
+	// Real streams reach the translator after FilterSSEUsageMetadata, which renames
+	// non-terminal usage to cpaUsageMetadata because finishReason is missing. The
+	// filtered payload is inlined here so this package keeps no dependency on the
+	// executor helpers; the executor tests cover the real filter end to end.
+	filtered := []byte(`{"response":{"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"}}],"modelVersion":"gemini-3.7-flash","responseId":"resp-filtered","cpaUsageMetadata":{"promptTokenCount":42,"candidatesTokenCount":7,"totalTokenCount":49}}}`)
+	results := ConvertAntigravityResponseToGemini(ctx, "gemini-3.7-flash", nil, nil, filtered, &param)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(results))
+	}
+	if got := gjson.GetBytes(results[0], "usageMetadata.totalTokenCount").Int(); got != 49 {
+		t.Fatalf("restored chunk totalTokenCount = %d, want 49", got)
+	}
+
+	doneResults := ConvertAntigravityResponseToGemini(ctx, "gemini-3.7-flash", nil, nil, []byte("[DONE]"), &param)
+	if len(doneResults) != 1 {
+		t.Fatalf("expected synthetic terminal chunk, got %d results", len(doneResults))
+	}
+	if fr := gjson.GetBytes(doneResults[0], "candidates.0.finishReason").String(); fr != "STOP" {
+		t.Fatalf("synthetic finishReason = %q, want STOP", fr)
+	}
+	if got := gjson.GetBytes(doneResults[0], "usageMetadata.totalTokenCount").Int(); got != 49 {
+		t.Fatalf("synthetic totalTokenCount = %d, want 49", got)
+	}
+	if got := gjson.GetBytes(doneResults[0], "usageMetadata.candidatesTokenCount").Int(); got != 7 {
+		t.Fatalf("synthetic candidatesTokenCount = %d, want 7", got)
+	}
+}
+
+func TestConvertAntigravityResponseToGeminiStream_DoesNotFinalizeEmptyUpstreamStream(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "alt", "")
+	var param any
+
+	// A 200 response whose body carried no response chunk must not be reported as
+	// a successful empty completion.
+	doneResults := ConvertAntigravityResponseToGemini(ctx, "gemini-3.7-flash", nil, nil, []byte("[DONE]"), &param)
+	if len(doneResults) != 0 {
+		t.Fatalf("empty stream must not synthesize a terminal chunk, got %d results: %s", len(doneResults), doneResults[0])
+	}
+}
+
+func TestConvertAntigravityResponseToGeminiStream_ResponseFreeEventDoesNotStartStream(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "alt", "")
+	var param any
+
+	// A JSON keepalive or malformed envelope carries no candidates and no usage,
+	// so it must not make an otherwise empty stream look complete.
+	for _, chunk := range [][]byte{
+		[]byte(`{}`),
+		[]byte(`{"response":{}}`),
+		[]byte(`{"response":{"candidates":[]}}`),
+		[]byte(`{"response":{"candidates":[],"usageMetadata":{}}}`),
+	} {
+		ConvertAntigravityResponseToGemini(ctx, "gemini-3.7-flash", nil, nil, chunk, &param)
+	}
+	doneResults := ConvertAntigravityResponseToGemini(ctx, "gemini-3.7-flash", nil, nil, []byte("[DONE]"), &param)
+	if len(doneResults) != 0 {
+		t.Fatalf("response-free events must not synthesize a terminal chunk, got %d results: %s", len(doneResults), doneResults[0])
+	}
+}
+
+func TestConvertAntigravityResponseToGeminiNonStream_DefaultsEveryCandidate(t *testing.T) {
+	input := []byte(`{"response":{"candidates":[{"content":{"parts":[{"text":"a"}],"role":"model"}},{"content":{"parts":[{"text":"b"}],"role":"model"},"finishReason":"MAX_TOKENS"},{"content":{"parts":[{"text":"c"}],"role":"model"}}]}}`)
+	out := ConvertAntigravityResponseToGeminiNonStream(context.Background(), "", nil, nil, input, nil)
+	want := []string{"STOP", "MAX_TOKENS", "STOP"}
+	for i, expected := range want {
+		got := gjson.GetBytes(out, fmt.Sprintf("candidates.%d.finishReason", i)).String()
+		if got != expected {
+			t.Fatalf("candidates.%d.finishReason = %q, want %q", i, got, expected)
+		}
+	}
+}
+
+func TestConvertAntigravityResponseToGeminiNonStream_DefaultsMissingFinishReason(t *testing.T) {
+	input := []byte(`{"response":{"candidates":[{"content":{"parts":[{"text":"Hi"}],"role":"model"}}]}}`)
+	out := ConvertAntigravityResponseToGeminiNonStream(context.Background(), "", nil, nil, input, nil)
+	if fr := gjson.GetBytes(out, "candidates.0.finishReason").String(); fr != "STOP" {
+		t.Fatalf("ConvertAntigravityResponseToGeminiNonStream finishReason = %q, want STOP", fr)
 	}
 }

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_response.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_response.go
@@ -25,8 +25,13 @@ import (
 type convertCliResponseToOpenAIChatParams struct {
 	UnixTimestamp        int64
 	FunctionIndex        int
+	SawResponse          bool   // Tracks whether any upstream response chunk was seen
 	SawToolCall          bool   // Tracks if any tool call was seen in the entire stream
+	SawFinishReason      bool   // Tracks whether finish_reason has been emitted
 	UpstreamFinishReason string // Caches the upstream finish reason for final chunk
+	ModelVersion         string
+	ResponseID           string
+	PendingUsageMetadata []byte
 	SanitizedNameMap     map[string]string
 }
 
@@ -48,19 +53,45 @@ var functionCallIDCounter uint64
 // Returns:
 //   - [][]byte: A slice of OpenAI-compatible JSON responses
 func ConvertAntigravityResponseToOpenAI(_ context.Context, _ string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, param *any) [][]byte {
-	if *param == nil {
-		*param = &convertCliResponseToOpenAIChatParams{
-			UnixTimestamp:    0,
-			FunctionIndex:    0,
-			SanitizedNameMap: util.DisambiguatedToolNameMap(originalRequestRawJSON),
+	params, ok := (*param).(*convertCliResponseToOpenAIChatParams)
+	if !ok {
+		params = &convertCliResponseToOpenAIChatParams{
+			UnixTimestamp: 0,
+			FunctionIndex: 0,
 		}
+		*param = params
 	}
-	if (*param).(*convertCliResponseToOpenAIChatParams).SanitizedNameMap == nil {
-		(*param).(*convertCliResponseToOpenAIChatParams).SanitizedNameMap = util.DisambiguatedToolNameMap(originalRequestRawJSON)
+	if params.SanitizedNameMap == nil {
+		params.SanitizedNameMap = util.DisambiguatedToolNameMap(originalRequestRawJSON)
 	}
 
 	if bytes.Equal(rawJSON, []byte("[DONE]")) {
+		// Never finalize a stream that produced no response at all: an empty
+		// upstream body must stay detectable as a failure rather than be reported
+		// as a successful empty completion.
+		if params.SawResponse && !params.SawFinishReason {
+			params.SawFinishReason = true
+			finishReason, nativeFinishReason := resolveOpenAIFinishReason(params)
+			template := []byte(`{"id":"","object":"chat.completion.chunk","created":0,"model":"model","choices":[{"index":0,"delta":{},"finish_reason":"stop","native_finish_reason":"stop"}]}`)
+			template, _ = sjson.SetBytes(template, "created", params.UnixTimestamp)
+			if params.ModelVersion != "" {
+				template, _ = sjson.SetBytes(template, "model", params.ModelVersion)
+			}
+			if params.ResponseID != "" {
+				template, _ = sjson.SetBytes(template, "id", params.ResponseID)
+			}
+			if len(params.PendingUsageMetadata) > 0 {
+				template = setOpenAIUsageMetadata(template, gjson.ParseBytes(params.PendingUsageMetadata))
+			}
+			template, _ = sjson.SetBytes(template, "choices.0.finish_reason", finishReason)
+			template, _ = sjson.SetBytes(template, "choices.0.native_finish_reason", nativeFinishReason)
+			return [][]byte{template}
+		}
 		return [][]byte{}
+	}
+
+	if !params.SawResponse {
+		params.SawResponse = hasAntigravityResponsePayload(rawJSON)
 	}
 
 	// Initialize the OpenAI SSE template.
@@ -68,51 +99,42 @@ func ConvertAntigravityResponseToOpenAI(_ context.Context, _ string, originalReq
 
 	// Extract and set the model version.
 	if modelVersionResult := gjson.GetBytes(rawJSON, "response.modelVersion"); modelVersionResult.Exists() {
-		template, _ = sjson.SetBytes(template, "model", modelVersionResult.String())
+		params.ModelVersion = modelVersionResult.String()
+		template, _ = sjson.SetBytes(template, "model", params.ModelVersion)
 	}
 
 	// Extract and set the creation timestamp.
 	if createTimeResult := gjson.GetBytes(rawJSON, "response.createTime"); createTimeResult.Exists() {
 		t, err := time.Parse(time.RFC3339Nano, createTimeResult.String())
 		if err == nil {
-			(*param).(*convertCliResponseToOpenAIChatParams).UnixTimestamp = t.Unix()
+			params.UnixTimestamp = t.Unix()
 		}
-		template, _ = sjson.SetBytes(template, "created", (*param).(*convertCliResponseToOpenAIChatParams).UnixTimestamp)
+		template, _ = sjson.SetBytes(template, "created", params.UnixTimestamp)
 	} else {
-		template, _ = sjson.SetBytes(template, "created", (*param).(*convertCliResponseToOpenAIChatParams).UnixTimestamp)
+		template, _ = sjson.SetBytes(template, "created", params.UnixTimestamp)
 	}
 
 	// Extract and set the response ID.
 	if responseIDResult := gjson.GetBytes(rawJSON, "response.responseId"); responseIDResult.Exists() {
-		template, _ = sjson.SetBytes(template, "id", responseIDResult.String())
+		params.ResponseID = responseIDResult.String()
+		template, _ = sjson.SetBytes(template, "id", params.ResponseID)
 	}
 
 	// Cache the finish reason - do NOT set it in output yet (will be set on final chunk)
 	if finishReasonResult := gjson.GetBytes(rawJSON, "response.candidates.0.finishReason"); finishReasonResult.Exists() {
-		(*param).(*convertCliResponseToOpenAIChatParams).UpstreamFinishReason = strings.ToUpper(finishReasonResult.String())
+		params.UpstreamFinishReason = strings.ToUpper(finishReasonResult.String())
 	}
 
-	// Extract and set usage metadata (token counts).
-	if usageResult := gjson.GetBytes(rawJSON, "response.usageMetadata"); usageResult.Exists() {
-		cachedTokenCount := usageResult.Get("cachedContentTokenCount").Int()
-		template, _ = sjson.SetBytes(template, "usage.completion_tokens", usageResult.Get("candidatesTokenCount").Int())
-		if totalTokenCountResult := usageResult.Get("totalTokenCount"); totalTokenCountResult.Exists() {
-			template, _ = sjson.SetBytes(template, "usage.total_tokens", totalTokenCountResult.Int())
+	// Extract and set usage metadata (token counts). FilterSSEUsageMetadata renames
+	// non-terminal usage to cpaUsageMetadata, so retain the latest copy for [DONE]
+	// instead of treating an intermediate chunk as terminal.
+	usageResult := gjson.GetBytes(rawJSON, "response.usageMetadata")
+	if !usageResult.Exists() {
+		if pendingUsage := gjson.GetBytes(rawJSON, "response.cpaUsageMetadata"); pendingUsage.Exists() {
+			params.PendingUsageMetadata = append(params.PendingUsageMetadata[:0], pendingUsage.Raw...)
 		}
-		promptTokenCount := usageResult.Get("promptTokenCount").Int()
-		thoughtsTokenCount := usageResult.Get("thoughtsTokenCount").Int()
-		template, _ = sjson.SetBytes(template, "usage.prompt_tokens", promptTokenCount)
-		if thoughtsTokenCount > 0 {
-			template, _ = sjson.SetBytes(template, "usage.completion_tokens_details.reasoning_tokens", thoughtsTokenCount)
-		}
-		// Include cached token count if present (indicates prompt caching is working)
-		if cachedTokenCount > 0 {
-			var err error
-			template, err = sjson.SetBytes(template, "usage.prompt_tokens_details.cached_tokens", cachedTokenCount)
-			if err != nil {
-				log.Warnf("antigravity openai response: failed to set cached_tokens: %v", err)
-			}
-		}
+	} else {
+		template = setOpenAIUsageMetadata(template, usageResult)
 	}
 
 	// Process the main content part of the response.
@@ -199,28 +221,88 @@ func ConvertAntigravityResponseToOpenAI(_ context.Context, _ string, originalReq
 		}
 	}
 
-	// Determine finish_reason only on the final chunk (has both finishReason and usage metadata)
-	params := (*param).(*convertCliResponseToOpenAIChatParams)
-	upstreamFinishReason := params.UpstreamFinishReason
-	sawToolCall := params.SawToolCall
-
-	usageExists := gjson.GetBytes(rawJSON, "response.usageMetadata").Exists()
-	isFinalChunk := upstreamFinishReason != "" && usageExists
+	// Determine finish_reason only on the final chunk, which upstream marks with
+	// both finishReason and usage metadata. A usage-carrying chunk without
+	// finishReason must not be treated as terminal: upstream can split the two
+	// across chunks and keep streaming afterwards, and finalizing early would make
+	// strict clients drop the remaining content. When upstream never sends
+	// finishReason at all, the [DONE] branch synthesizes the terminal chunk.
+	usageMetadata := gjson.GetBytes(rawJSON, "response.usageMetadata")
+	isFinalChunk := params.UpstreamFinishReason != "" && usageMetadata.Exists()
 
 	if isFinalChunk {
-		var finishReason string
-		if sawToolCall {
-			finishReason = "tool_calls"
-		} else if upstreamFinishReason == "MAX_TOKENS" {
-			finishReason = "max_tokens"
-		} else {
-			finishReason = "stop"
-		}
+		finishReason, nativeFinishReason := resolveOpenAIFinishReason(params)
 		template, _ = sjson.SetBytes(template, "choices.0.finish_reason", finishReason)
-		template, _ = sjson.SetBytes(template, "choices.0.native_finish_reason", strings.ToLower(upstreamFinishReason))
+		template, _ = sjson.SetBytes(template, "choices.0.native_finish_reason", nativeFinishReason)
+		params.SawFinishReason = true
 	}
 
 	return [][]byte{template}
+}
+
+// hasAntigravityResponsePayload reports whether a chunk carries actual generated
+// content or token accounting. Presence alone is not enough: an envelope such as
+// `{}`, `{"response":{}}` or `{"response":{"candidates":[]}}` must not count as a
+// started stream, otherwise a keepalive or malformed event would be enough to
+// finalize a stream that produced nothing.
+func hasAntigravityResponsePayload(rawJSON []byte) bool {
+	for _, path := range []string{"response.candidates", "candidates"} {
+		if candidates := gjson.GetBytes(rawJSON, path); candidates.IsArray() && len(candidates.Array()) > 0 {
+			return true
+		}
+	}
+	// FilterSSEUsageMetadata renames non-terminal usage to cpaUsageMetadata before
+	// the translator sees it, so both spellings must be accepted.
+	for _, path := range []string{
+		"response.usageMetadata", "response.cpaUsageMetadata",
+		"usageMetadata", "cpaUsageMetadata",
+	} {
+		if usage := gjson.GetBytes(rawJSON, path); usage.IsObject() && len(usage.Map()) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveOpenAIFinishReason maps the cached upstream state to the OpenAI
+// finish_reason and native_finish_reason pair. Both the terminal upstream chunk
+// and the synthesized [DONE] chunk must agree on this mapping.
+func resolveOpenAIFinishReason(params *convertCliResponseToOpenAIChatParams) (finishReason, nativeFinishReason string) {
+	switch {
+	case params.SawToolCall:
+		finishReason = "tool_calls"
+	case params.UpstreamFinishReason == "MAX_TOKENS":
+		finishReason = "max_tokens"
+	default:
+		finishReason = "stop"
+	}
+	nativeFinishReason = "stop"
+	if params.UpstreamFinishReason != "" {
+		nativeFinishReason = strings.ToLower(params.UpstreamFinishReason)
+	}
+	return finishReason, nativeFinishReason
+}
+
+func setOpenAIUsageMetadata(template []byte, usageResult gjson.Result) []byte {
+	cachedTokenCount := usageResult.Get("cachedContentTokenCount").Int()
+	template, _ = sjson.SetBytes(template, "usage.completion_tokens", usageResult.Get("candidatesTokenCount").Int())
+	if totalTokenCountResult := usageResult.Get("totalTokenCount"); totalTokenCountResult.Exists() {
+		template, _ = sjson.SetBytes(template, "usage.total_tokens", totalTokenCountResult.Int())
+	}
+	promptTokenCount := usageResult.Get("promptTokenCount").Int()
+	thoughtsTokenCount := usageResult.Get("thoughtsTokenCount").Int()
+	template, _ = sjson.SetBytes(template, "usage.prompt_tokens", promptTokenCount)
+	if thoughtsTokenCount > 0 {
+		template, _ = sjson.SetBytes(template, "usage.completion_tokens_details.reasoning_tokens", thoughtsTokenCount)
+	}
+	if cachedTokenCount > 0 {
+		var err error
+		template, err = sjson.SetBytes(template, "usage.prompt_tokens_details.cached_tokens", cachedTokenCount)
+		if err != nil {
+			log.Warnf("antigravity openai response: failed to set cached_tokens: %v", err)
+		}
+	}
+	return template
 }
 
 // ConvertAntigravityResponseToOpenAINonStream converts a non-streaming Antigravity response to a non-streaming OpenAI response.

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_response_test.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_response_test.go
@@ -142,6 +142,129 @@ func TestConvertAntigravityResponseToOpenAIIncludesZeroCompletionTokensWhenMissi
 	}
 }
 
+func TestConvertAntigravityResponseToOpenAI_SynthesizesStopOnUsageChunkWhenFinishReasonOmitted(t *testing.T) {
+	ctx := context.Background()
+	var param any
+
+	// Pure thinking chunk with usageMetadata but NO finishReason (reproducing real Antigravity upstream logs).
+	// Usage alone does not make a chunk terminal: upstream can keep streaming after it.
+	chunk := []byte(`{"response":{"candidates":[{"content":{"parts":[{"thought":true,"text":"Analyzing..."}]}}],"usageMetadata":{"promptTokenCount":100,"totalTokenCount":150,"thoughtsTokenCount":50},"modelVersion":"gemini-3.7-flash","responseId":"resp-999"}}`)
+	result := ConvertAntigravityResponseToOpenAI(ctx, "gemini-3.7-flash", nil, nil, chunk, &param)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result from chunk, got %d", len(result))
+	}
+	if fr := gjson.GetBytes(result[0], "choices.0.finish_reason").String(); fr != "" {
+		t.Fatalf("usage chunk without finishReason must not be terminal, got %q", fr)
+	}
+
+	// The terminal chunk is synthesized on [DONE] instead.
+	done := ConvertAntigravityResponseToOpenAI(ctx, "gemini-3.7-flash", nil, nil, []byte("[DONE]"), &param)
+	if len(done) != 1 {
+		t.Fatalf("expected 1 synthesized terminal chunk on [DONE], got %d", len(done))
+	}
+	if fr := gjson.GetBytes(done[0], "choices.0.finish_reason").String(); fr != "stop" {
+		t.Fatalf("terminal finish_reason = %q, want stop", fr)
+	}
+}
+
+func TestConvertAntigravityResponseToOpenAI_PreservesFilteredUsageUntilDone(t *testing.T) {
+	ctx := context.Background()
+	var param any
+
+	// Mirrors a payload already processed by FilterSSEUsageMetadata, which renames
+	// non-terminal usage to cpaUsageMetadata. It is inlined so this package keeps no
+	// dependency on the executor helpers; the executor tests cover the real filter.
+	filtered := []byte(`{"response":{"candidates":[{"content":{"parts":[{"thought":true,"text":"Thinking..."}]}}],"modelVersion":"gemini-3.7-flash","responseId":"resp-filtered","cpaUsageMetadata":{"promptTokenCount":100,"totalTokenCount":150,"thoughtsTokenCount":50}}}`)
+	result := ConvertAntigravityResponseToOpenAI(ctx, "gemini-3.7-flash", nil, nil, filtered, &param)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 intermediate result, got %d", len(result))
+	}
+	if usage := gjson.GetBytes(result[0], "usage"); usage.Exists() {
+		t.Fatalf("intermediate filtered usage should not be emitted: %s", usage.Raw)
+	}
+	if finishReason := gjson.GetBytes(result[0], "choices.0.finish_reason"); finishReason.String() != "" {
+		t.Fatalf("intermediate finish_reason = %q, want null", finishReason.String())
+	}
+
+	done := ConvertAntigravityResponseToOpenAI(ctx, "gemini-3.7-flash", nil, nil, []byte("[DONE]"), &param)
+	if len(done) != 1 {
+		t.Fatalf("expected 1 synthetic terminal result, got %d", len(done))
+	}
+	if finishReason := gjson.GetBytes(done[0], "choices.0.finish_reason").String(); finishReason != "stop" {
+		t.Fatalf("terminal finish_reason = %q, want stop", finishReason)
+	}
+	if got := gjson.GetBytes(done[0], "usage.prompt_tokens").Int(); got != 100 {
+		t.Fatalf("terminal prompt_tokens = %d, want 100", got)
+	}
+	if got := gjson.GetBytes(done[0], "usage.total_tokens").Int(); got != 150 {
+		t.Fatalf("terminal total_tokens = %d, want 150", got)
+	}
+}
+
+func TestConvertAntigravityResponseToOpenAI_SynthesizesStopOnDoneWhenFinishReasonAndUsageOmitted(t *testing.T) {
+	ctx := context.Background()
+	var param any
+
+	// Intermediate text chunk without finishReason or usage
+	chunk := []byte(`{"response":{"candidates":[{"content":{"parts":[{"text":"Partial output"}]}}],"modelVersion":"gemini-3.7-flash","responseId":"resp-888"}}`)
+	result := ConvertAntigravityResponseToOpenAI(ctx, "gemini-3.7-flash", nil, nil, chunk, &param)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result from chunk, got %d", len(result))
+	}
+	fr1 := gjson.GetBytes(result[0], "choices.0.finish_reason")
+	if fr1.Exists() && fr1.String() != "" && fr1.Type.String() != "Null" {
+		t.Fatalf("expected finish_reason to be null on intermediate chunk, got %v", fr1)
+	}
+
+	// [DONE] without prior finishReason or usage -> synthesizes final chunk with finish_reason: "stop"
+	done := ConvertAntigravityResponseToOpenAI(ctx, "gemini-3.7-flash", nil, nil, []byte("[DONE]"), &param)
+	if len(done) != 1 {
+		t.Fatalf("expected 1 result on [DONE], got %d", len(done))
+	}
+	frDone := gjson.GetBytes(done[0], "choices.0.finish_reason").String()
+	if frDone != "stop" {
+		t.Fatalf("expected finish_reason 'stop' on [DONE], got %q", frDone)
+	}
+	if mv := gjson.GetBytes(done[0], "model").String(); mv != "gemini-3.7-flash" {
+		t.Fatalf("expected model 'gemini-3.7-flash', got %q", mv)
+	}
+	if rid := gjson.GetBytes(done[0], "id").String(); rid != "resp-888" {
+		t.Fatalf("expected id 'resp-888', got %q", rid)
+	}
+}
+
+func TestConvertAntigravityResponseToOpenAI_DoesNotFinalizeEmptyUpstreamStream(t *testing.T) {
+	ctx := context.Background()
+	var param any
+
+	// A 200 response whose body carried no response chunk must not be reported as
+	// a successful empty completion.
+	done := ConvertAntigravityResponseToOpenAI(ctx, "gemini-3.7-flash", nil, nil, []byte("[DONE]"), &param)
+	if len(done) != 0 {
+		t.Fatalf("empty stream must not synthesize a terminal chunk, got %d results: %s", len(done), done[0])
+	}
+}
+
+func TestConvertAntigravityResponseToOpenAI_ResponseFreeEventDoesNotStartStream(t *testing.T) {
+	ctx := context.Background()
+	var param any
+
+	// A JSON keepalive or malformed envelope carries no candidates and no usage,
+	// so it must not make an otherwise empty stream look complete.
+	for _, chunk := range [][]byte{
+		[]byte(`{}`),
+		[]byte(`{"response":{}}`),
+		[]byte(`{"response":{"candidates":[]}}`),
+		[]byte(`{"response":{"candidates":[],"usageMetadata":{}}}`),
+	} {
+		ConvertAntigravityResponseToOpenAI(ctx, "gemini-3.7-flash", nil, nil, chunk, &param)
+	}
+	done := ConvertAntigravityResponseToOpenAI(ctx, "gemini-3.7-flash", nil, nil, []byte("[DONE]"), &param)
+	if len(done) != 0 {
+		t.Fatalf("response-free events must not synthesize a terminal chunk, got %d results: %s", len(done), done[0])
+	}
+}
+
 func TestConvertAntigravityResponseToOpenAINonStreamRestoresDisambiguatedName(t *testing.T) {
 	first := "mcp__plugin_cloudflare_cloudflare-builds__workers_builds_get_build"
 	second := "mcp__plugin_cloudflare_cloudflare-builds__workers_builds_get_build_logs"


### PR DESCRIPTION
Fixes #5226

Antigravity ends some 200 streams without ever emitting `finishReason`
(proto3 omits `FINISH_REASON_UNSPECIFIED`). Local request logs: 25 of 18,346
captured cloudcode-pa streams have no `finishReason` at all
(`gemini-3.7-flash` x23, `gemini-3.6-flash` x2). Strict Gemini SDKs then fail
with `Google stream ended without a finish reason`, and OpenAI chat clients
see `finish_reason: null`.

## Changes

- `antigravity/gemini`: track stream state and synthesize a terminal chunk on
  `[DONE]` when upstream never sent one. The chunk mirrors the shape and key
  order of the 18,321 real terminal chunks in the logs
  (`candidates` / `usageMetadata` / `modelVersion` / `responseId`, model-role
  candidate with `parts: [{"text":""}]`), and carries the last known usage
  snapshot.
- `antigravity/openai/chat-completions`: keep the latest `cpaUsageMetadata` as
  pending usage and emit it on `[DONE]`; also derive `finish_reason` from a
  chunk carrying terminal token counts, since `FilterSSEUsageMetadata` can pass
  real `usageMetadata` through on a chunk without `finishReason`. Both the
  upstream terminal chunk and the synthesized one now share a single
  `resolveOpenAIFinishReason` helper so they cannot drift apart.
- `antigravity` stream executor: translate the `[DONE]` tail only when
  `scanner.Err()` is nil. A truncated upstream stream previously still produced
  a terminal event, so a cut connection looked like a clean completion.
- Non-stream Gemini conversion defaults a missing `finishReason` to `STOP`.
- Also fixes the unreachable `alt != ""` branch, which parsed an always-nil
  buffer, and replaces an unchecked `param` type assertion.

Only Antigravity translators synthesize on `[DONE]`, so the other executors
that emit the tail before checking `scanner.Err()` cannot leak a fake terminal
event and are left unchanged.

## Verification

Byte-exact upstream bodies extracted from request logs were replayed through a
mock backend:

- clean stream: exactly one terminal event, unchanged
- stream without `finishReason`: one synthetic terminal event carrying the last
  usage snapshot (single-chunk `153609/153720`; two-chunk case correctly uses
  the later `405790/406512` rather than the first snapshot)
- stream cut mid-chunk: read error surfaces, no synthetic terminal event

New executor-level tests replay a captured no-`finishReason` stream through the
full pipeline (including `FilterSSEUsageMetadata`) for both Gemini and OpenAI
chat response formats.

`go build ./...`, `go test ./...` and `gofmt` are clean.