### PR TITLE
openai responses: forward sampling parameters to chat completions

### DIFF
--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -8,6 +8,19 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+// openAIResponsesSamplingParamKeys are forwarded unchanged from a Responses
+// request to the Chat Completions request.
+var openAIResponsesSamplingParamKeys = []string{
+	"temperature",
+	"top_p",
+	"top_k",
+	"min_p",
+	"seed",
+	"presence_penalty",
+	"frequency_penalty",
+	"repetition_penalty",
+}
+
 // ConvertOpenAIResponsesRequestToOpenAIChatCompletions converts OpenAI responses format to OpenAI chat completions format.
 // It transforms the OpenAI responses API format (with instructions and input array) into the standard
 // OpenAI chat completions format (with messages array and system content).
@@ -55,6 +68,14 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 	// Map generation parameters from responses format to chat completions format
 	if maxTokens := root.Get("max_output_tokens"); maxTokens.Exists() {
 		out, _ = sjson.SetBytes(out, "max_tokens", maxTokens.Int())
+	}
+	// Sampling parameters share names across both APIs. temperature/top_p are
+	// standard; the rest are the common extras OpenAI-compatible servers
+	// (vLLM, SGLang, llama.cpp) accept and clients send verbatim.
+	for _, key := range openAIResponsesSamplingParamKeys {
+		if v := root.Get(key); v.Exists() {
+			out, _ = sjson.SetRawBytes(out, key, []byte(v.Raw))
+		}
 	}
 
 	// Convert instructions to system message

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
@@ -1139,3 +1139,30 @@ func TestResponsesCustomToolNames_OnlyReportsMergedTools(t *testing.T) {
 		}
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_ForwardsSamplingParams(t *testing.T) {
+	t.Parallel()
+
+	in := []byte(`{"model":"m","input":"hi","max_output_tokens":10,"temperature":0.3,"top_p":0.9,"top_k":20,"min_p":0.05,"seed":7,"presence_penalty":0.1,"frequency_penalty":0.2,"repetition_penalty":1.1}`)
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("m", in, false)
+
+	checks := map[string]string{
+		"temperature":        "0.3",
+		"top_p":              "0.9",
+		"top_k":              "20",
+		"min_p":              "0.05",
+		"seed":               "7",
+		"presence_penalty":   "0.1",
+		"frequency_penalty":  "0.2",
+		"repetition_penalty": "1.1",
+		"max_tokens":         "10",
+	}
+	for key, want := range checks {
+		if got := gjson.GetBytes(out, key).Raw; got != want {
+			t.Fatalf("%s = %q, want %q; out=%s", key, got, want, out)
+		}
+	}
+	if gjson.GetBytes(out, "max_output_tokens").Exists() {
+		t.Fatalf("max_output_tokens must not leak into the chat request: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
`ConvertOpenAIResponsesRequestToOpenAIChatCompletions` mapped only `max_output_tokens`, so `temperature` / `top_p` on a `/v1/responses` request never reached an OpenAI-compatible upstream (nor the common extras clients send verbatim to vLLM / SGLang / llama.cpp: `top_k`, `min_p`, `seed`, `presence_penalty`, `frequency_penalty`, `repetition_penalty`). The upstream silently ran at its own defaults — observed against vLLM: `temperature: 0` through CPA was still non-deterministic, while the same request sent directly was deterministic.

This forwards those fields unchanged (same names on both APIs).

## Test
`go test ./internal/translator/openai/openai/responses/` — adds `TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_ForwardsSamplingParams`.