### PR TITLE
fix(claude): keep Claude server-side web search across the Responses …

### DIFF
--- a/internal/translator/claude/openai/responses/claude_openai-responses_interleaved_search_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_interleaved_search_test.go
@@ -1,0 +1,89 @@
+package responses
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// Regression for a production incident: a Claude turn that interleaved thinking
+// with server-side web searches used to lose the search blocks, leaving two
+// adjacent reasoning items. Replaying those produced two adjacent Claude
+// `thinking` blocks, which Anthropic rejects with
+// "`thinking` ... blocks in the latest assistant message cannot be modified",
+// killing the session mid-turn.
+func TestInterleavedThinkingAndSearchSurvivesRoundTrip(t *testing.T) {
+	signature := mustTestSignature(t)
+	thinking := func(index int, text string) [][]byte {
+		prefix := `data: {"type":"content_block_`
+		return [][]byte{
+			[]byte(prefix + `start","index":` + strconv.Itoa(index) + `,"content_block":{"type":"thinking","thinking":""}}`),
+			[]byte(prefix + `delta","index":` + strconv.Itoa(index) + `,"delta":{"type":"thinking_delta","thinking":"` + text + `"}}`),
+			[]byte(prefix + `delta","index":` + strconv.Itoa(index) + `,"delta":{"type":"signature_delta","signature":"` + signature + `"}}`),
+			[]byte(prefix + `stop","index":` + strconv.Itoa(index) + `}`),
+		}
+	}
+	search := func(index int, id string) [][]byte {
+		prefix := `data: {"type":"content_block_`
+		return [][]byte{
+			[]byte(prefix + `start","index":` + strconv.Itoa(index) + `,"content_block":{"type":"server_tool_use","id":"` + id + `","name":"web_search","input":{}}}`),
+			[]byte(prefix + `delta","index":` + strconv.Itoa(index) + `,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"lindorm\"}"}}`),
+			[]byte(prefix + `stop","index":` + strconv.Itoa(index) + `}`),
+			[]byte(prefix + `start","index":` + strconv.Itoa(index+1) + `,"content_block":{"type":"web_search_tool_result","tool_use_id":"` + id + `","content":[{"type":"web_search_result","title":"T","url":"https://example.com/` + id + `"}]}}`),
+			[]byte(prefix + `stop","index":` + strconv.Itoa(index+1) + `}`),
+		}
+	}
+
+	chunks := [][]byte{[]byte(`data: {"type":"message_start","message":{"id":"msg_x","usage":{"input_tokens":1,"output_tokens":0}}}`)}
+	chunks = append(chunks, thinking(0, "first")...)
+	chunks = append(chunks, []byte(`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`),
+		[]byte(`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Researching."}}`),
+		[]byte(`data: {"type":"content_block_stop","index":1}`))
+	chunks = append(chunks, search(2, "srvtoolu_a")...)
+	chunks = append(chunks, thinking(6, "second")...)
+	chunks = append(chunks, search(7, "srvtoolu_b")...)
+	chunks = append(chunks, thinking(11, "third")...)
+	chunks = append(chunks,
+		[]byte(`data: {"type":"content_block_start","index":12,"content_block":{"type":"tool_use","id":"toolu_1","name":"exec","input":{}}}`),
+		[]byte(`data: {"type":"content_block_delta","index":12,"delta":{"type":"input_json_delta","partial_json":"{\"cmd\":\"pwd\"}"}}`),
+		[]byte(`data: {"type":"content_block_stop","index":12}`),
+		[]byte(`data: {"type":"message_stop"}`))
+
+	outputs := translateClaudeResponsesStreamThroughRegistry(chunks)
+	var completed gjson.Result
+	for _, output := range outputs {
+		if event, data := parseClaudeResponsesSSEEvent(t, output); event == "response.completed" {
+			completed = data
+		}
+	}
+
+	var kinds []string
+	var items []json.RawMessage
+	completed.Get("response.output").ForEach(func(_, v gjson.Result) bool {
+		kinds = append(kinds, v.Get("type").String())
+		items = append(items, json.RawMessage(v.Raw))
+		return true
+	})
+	for i := 1; i < len(kinds); i++ {
+		if kinds[i] == "reasoning" && kinds[i-1] == "reasoning" {
+			t.Fatalf("adjacent reasoning items leak the dropped search blocks: %v", kinds)
+		}
+	}
+	if searches := strings.Count(strings.Join(kinds, ","), "web_search_call"); searches != 2 {
+		t.Fatalf("web_search_call items = %d, want 2: %v", searches, kinds)
+	}
+
+	req, _ := json.Marshal(map[string]any{"model": "claude-test", "input": items})
+	blocks := claudeAssistantBlockTypes(t, ConvertOpenAIResponsesRequestToClaude("claude-test", req, false))
+	for i := 1; i < len(blocks); i++ {
+		if blocks[i] == "thinking" && blocks[i-1] == "thinking" {
+			t.Fatalf("Anthropic rejects adjacent thinking blocks: %v", blocks)
+		}
+	}
+	if got := strings.Count(strings.Join(blocks, ","), "web_search_tool_result"); got != 2 {
+		t.Fatalf("replayed web_search_tool_result blocks = %d, want 2: %v", got, blocks)
+	}
+}

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -3,6 +3,8 @@ package responses
 import (
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	sigcompat "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
@@ -189,7 +191,9 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 			msg, _ = sjson.SetBytes(msg, "role", pendingRole)
 			if len(parts) == 1 {
 				part := gjson.ParseBytes(parts[0])
-				if part.Get("type").String() == "text" && !part.Get("cache_control").Exists() {
+				// A lone plain text block collapses to Claude's string content form,
+				// but only when it carries nothing the string form would drop.
+				if part.Get("type").String() == "text" && !part.Get("cache_control").Exists() && !part.Get("citations").Exists() {
 					msg, _ = sjson.SetBytes(msg, "content", part.Get("text").String())
 				} else {
 					msg, _ = sjson.SetRawBytes(msg, "content", common.JoinRawArray(parts))
@@ -213,6 +217,35 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 		}
 		pendingRole = role
 		pendingParts = append(pendingParts, parts...)
+	}
+	// mergeAdjacentThinking folds a thinking block into the immediately preceding
+	// one so an assistant message never contains two adjacent thinking blocks,
+	// which Anthropic rejects outright. Merging is safe because Anthropic
+	// validates block structure and signature presence, not the thinking text.
+	// redacted_thinking blocks are deliberately left alone: their payload is
+	// opaque and cannot be concatenated.
+	mergeAdjacentThinking := func(thinkingPart []byte) bool {
+		if pendingRole != "assistant" || len(pendingToolUseParts) > 0 || len(pendingParts) == 0 {
+			return false
+		}
+		lastIdx := len(pendingParts) - 1
+		prev, next := gjson.ParseBytes(pendingParts[lastIdx]), gjson.ParseBytes(thinkingPart)
+		if prev.Get("type").String() != "thinking" || next.Get("type").String() != "thinking" {
+			return false
+		}
+		combined := prev.Get("thinking").String()
+		if text := next.Get("thinking").String(); text != "" {
+			if combined != "" {
+				combined += "\n\n"
+			}
+			combined += text
+		}
+		merged, err := sjson.SetBytes(pendingParts[lastIdx], "thinking", combined)
+		if err != nil {
+			return false
+		}
+		pendingParts[lastIdx] = merged
+		return true
 	}
 	appendToolUse := func(toolUse []byte) {
 		if len(toolUse) == 0 {
@@ -264,6 +297,7 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 								txt := t.String()
 								contentPart := []byte(`{"type":"text","text":""}`)
 								contentPart, _ = sjson.SetBytes(contentPart, "text", txt)
+								contentPart = attachClaudeCitations(contentPart, part.Get("annotations"))
 								contentPart = common.AttachCacheControl(contentPart, part)
 								partsJSON = append(partsJSON, contentPart)
 							}
@@ -272,6 +306,15 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 							} else {
 								role = "assistant"
 							}
+						case "refusal":
+							// Claude has no refusal block; the text keeps the turn intact.
+							if t := part.Get("refusal"); t.Exists() && t.String() != "" {
+								contentPart := []byte(`{"type":"text","text":""}`)
+								contentPart, _ = sjson.SetBytes(contentPart, "text", t.String())
+								contentPart = common.AttachCacheControl(contentPart, part)
+								partsJSON = append(partsJSON, contentPart)
+							}
+							role = "assistant"
 						case "input_image":
 							url := part.Get("image_url").String()
 							if url == "" {
@@ -359,9 +402,24 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 					appendParts(role, partsJSON...)
 				}
 
+			case "web_search_call":
+				// Rebuild the Claude server-side search pair so the replayed turn
+				// still shows the search and its hits.
+				if blocks := convertResponsesWebSearchCallToClaudeBlocks(item); len(blocks) > 0 {
+					appendParts("assistant", blocks...)
+				}
+
 			case "reasoning":
 				if thinkingPart := convertResponsesReasoningToClaudeThinking(item, preserveEmptyThinkingBlocks); len(thinkingPart) > 0 {
-					appendParts("assistant", thinkingPart)
+					// Anthropic rejects two adjacent thinking blocks in the same
+					// assistant message ("`thinking` ... blocks in the latest assistant
+					// message cannot be modified"). Upstream turns that interleave
+					// thinking with server-side tool blocks (e.g. web_search) reach us
+					// as consecutive reasoning items because those blocks carry no
+					// Responses representation, so fold them into one thinking block.
+					if !mergeAdjacentThinking(thinkingPart) {
+						appendParts("assistant", thinkingPart)
+					}
 				}
 
 			case "function_call", "custom_tool_call":
@@ -417,6 +475,15 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 				toolResult = applyResponsesToolResultContent(toolResult, output)
 
 				appendParts("user", toolResult)
+
+			default:
+				// Reachability guard: Claude only ever receives the item types this
+				// switch handles. A new one means the client gained a capability
+				// whose Claude counterpart still has to be decided, so make the gap
+				// visible instead of dropping the turn content in silence.
+				if typ := item.Get("type").String(); typ != "" {
+					log.Debugf("responses->claude: unmapped input item type %q", typ)
+				}
 			}
 			return true
 		})

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -42,8 +44,25 @@ type claudeToResponsesState struct {
 	ReasoningSignature string
 	ReasoningIndex     int
 	ReasoningItems     []claudeResponsesReasoningItem
+	// server-side web search state: a Claude server_tool_use block and its
+	// web_search_tool_result block fold into one Responses web_search_call item.
+	WebSearchByBlock  map[int]*claudeResponsesWebSearchItem
+	WebSearchByToolID map[string]*claudeResponsesWebSearchItem
+	WebSearchItems    []*claudeResponsesWebSearchItem
 	// usage aggregation
 	Usage claudeResponsesUsageTokens
+}
+
+type claudeResponsesWebSearchItem struct {
+	ToolUseID   string
+	OutputIndex int
+	InputBuf    strings.Builder
+	Results     []byte
+	Emitted     bool
+}
+
+func (item *claudeResponsesWebSearchItem) render() []byte {
+	return buildResponsesWebSearchCallItem(item.ToolUseID, claudeWebSearchQuery(item.InputBuf.String()), item.Results)
 }
 
 type claudeResponsesMessageItem struct {
@@ -179,6 +198,30 @@ func (st *claudeToResponsesState) functionOutputIndex(blockIndex int) int {
 	return index
 }
 
+// startWebSearch opens the Responses item that stands for a Claude server-side
+// search block.
+func (st *claudeToResponsesState) startWebSearch(blockIndex int, toolUseID string) *claudeResponsesWebSearchItem {
+	item := &claudeResponsesWebSearchItem{ToolUseID: toolUseID, OutputIndex: st.allocateOutputIndex()}
+	st.WebSearchByBlock[blockIndex] = item
+	st.WebSearchByToolID[toolUseID] = item
+	st.WebSearchItems = append(st.WebSearchItems, item)
+	return item
+}
+
+// finalizeWebSearch emits output_item.done once the result block has been seen,
+// or at message_stop when the turn ended without one.
+func (st *claudeToResponsesState) finalizeWebSearch(item *claudeResponsesWebSearchItem, nextSeq func() int) [][]byte {
+	if item == nil || item.Emitted {
+		return nil
+	}
+	item.Emitted = true
+	done := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{}}`)
+	done, _ = sjson.SetBytes(done, "sequence_number", nextSeq())
+	done, _ = sjson.SetBytes(done, "output_index", item.OutputIndex)
+	done, _ = sjson.SetRawBytes(done, "item", item.render())
+	return [][]byte{emitEvent("response.output_item.done", done)}
+}
+
 func (st *claudeToResponsesState) finalizeAssistantMessage(nextSeq func() int) [][]byte {
 	if !st.MessageOpen {
 		return nil
@@ -241,6 +284,8 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 			FuncCallIDs:        make(map[int]string),
 			FuncCustom:         make(map[int]bool),
 			FuncOutputIndices:  make(map[int]int),
+			WebSearchByBlock:   make(map[int]*claudeResponsesWebSearchItem),
+			WebSearchByToolID:  make(map[string]*claudeResponsesWebSearchItem),
 		}
 	}
 	st := (*param).(*claudeToResponsesState)
@@ -373,6 +418,32 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 			// Record function metadata for aggregation.
 			st.FuncCallIDs[idx] = st.CurrentFCID
 			st.FuncNames[idx] = name
+		} else if typ == "server_tool_use" {
+			// The surrounding text keeps aggregating into one message: Claude
+			// frequently searches mid-sentence, so flushing here would split a
+			// single sentence across two Responses message items.
+			if name := cb.Get("name").String(); name != claudeWebSearchToolName {
+				// Reachability guard: only web_search can be enabled on Claude by
+				// this translator, so anything else means a new upstream tool.
+				log.Debugf("claude->responses: unmapped server_tool_use %q at block %d", name, idx)
+			} else {
+				item := st.startWebSearch(idx, cb.Get("id").String())
+				added := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"web_search_call","status":"in_progress","action":{"type":"search","query":""}}}`)
+				added, _ = sjson.SetBytes(added, "sequence_number", nextSeq())
+				added, _ = sjson.SetBytes(added, "output_index", item.OutputIndex)
+				added, _ = sjson.SetBytes(added, "item.id", responsesWebSearchCallID(item.ToolUseID))
+				out = append(out, emitEvent("response.output_item.added", added))
+			}
+		} else if typ == "web_search_tool_result" {
+			// Unlike text or tool_use blocks, a result block carries its full
+			// content up front and has no deltas, so the item is closed here
+			// rather than at content_block_stop.
+			if item := st.WebSearchByToolID[cb.Get("tool_use_id").String()]; item != nil {
+				item.Results = claudeWebSearchResultsToResponses(cb.Get("content"))
+				out = append(out, st.finalizeWebSearch(item, nextSeq)...)
+			} else {
+				log.Debugf("claude->responses: web_search_tool_result without matching server_tool_use at block %d", idx)
+			}
 		} else if typ == "thinking" || typ == "redacted_thinking" {
 			out = append(out, st.finalizeAssistantMessage(nextSeq)...)
 			// start reasoning item
@@ -413,6 +484,12 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 				st.CurrentTextBuf.WriteString(t.String())
 			}
 		} else if dt == "input_json_delta" {
+			if item := st.WebSearchByBlock[int(root.Get("index").Int())]; item != nil {
+				if pj := d.Get("partial_json"); pj.Exists() {
+					item.InputBuf.WriteString(pj.String())
+				}
+				return [][]byte{}
+			}
 			if !st.InFuncBlock || st.CurrentFCID == "" {
 				return [][]byte{}
 			}
@@ -548,6 +625,9 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 		return [][]byte{}
 	case "message_stop":
 		out = append(out, st.finalizeAssistantMessage(nextSeq)...)
+		for _, item := range st.WebSearchItems {
+			out = append(out, st.finalizeWebSearch(item, nextSeq)...)
+		}
 
 		completed := []byte(`{"type":"response.completed","sequence_number":0,"response":{"id":"","object":"response","created_at":0,"status":"completed","background":false,"error":null}}`)
 		completed, _ = sjson.SetBytes(completed, "sequence_number", nextSeq())
@@ -641,6 +721,10 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 				item, _ = sjson.SetBytes(item, "content.0.annotations", message.Annotations)
 			}
 			outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, fmt.Sprintf("arr.%d", message.OutputIndex), item)
+		}
+		// web_search_call items
+		for _, item := range st.WebSearchItems {
+			outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, fmt.Sprintf("arr.%d", item.OutputIndex), item.render())
 		}
 		// function_call items (in ascending index order for determinism)
 		if len(st.FuncArgsBuf) > 0 {
@@ -762,9 +846,11 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 		signature   string
 		annotations []any
 		args        strings.Builder
+		results     []byte
 	}
 
 	blockToItem := make(map[int]*nonStreamOutputItem)
+	webSearchByToolID := make(map[string]*nonStreamOutputItem)
 	outputItems := make([]*nonStreamOutputItem, 0)
 	nextOutputIndex := 0
 	messageCount := 0
@@ -830,6 +916,28 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 					item.id = fmt.Sprintf("fc_%s", item.callID)
 				}
 				item.name = cb.Get("name").String()
+			case "server_tool_use":
+				name := cb.Get("name").String()
+				if name != claudeWebSearchToolName {
+					log.Debugf("claude->responses: unmapped server_tool_use %q at block %d", name, idx)
+					continue
+				}
+				toolUseID := cb.Get("id").String()
+				item := newOutputItem("web_search_call", idx)
+				item.id = responsesWebSearchCallID(toolUseID)
+				item.callID = toolUseID
+				webSearchByToolID[toolUseID] = item
+				// Streaming announces an empty input and fills it through
+				// input_json_delta; only seed when the query is already present.
+				if input := cb.Get("input"); input.IsObject() && claudeWebSearchQuery(input.Raw) != "" {
+					item.args.WriteString(input.Raw)
+				}
+			case "web_search_tool_result":
+				if item := webSearchByToolID[cb.Get("tool_use_id").String()]; item != nil {
+					item.results = claudeWebSearchResultsToResponses(cb.Get("content"))
+				} else {
+					log.Debugf("claude->responses: web_search_tool_result without matching server_tool_use at block %d", idx)
+				}
 			case "thinking", "redacted_thinking":
 				activeMessageItem = nil
 				item := newOutputItem("reasoning", idx)
@@ -853,7 +961,7 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 					}
 				}
 			case "input_json_delta":
-				if item != nil && (item.itemType == "function_call" || item.itemType == "custom_tool_call") {
+				if item != nil && (item.itemType == "function_call" || item.itemType == "custom_tool_call" || item.itemType == "web_search_call") {
 					if pj := d.Get("partial_json"); pj.Exists() {
 						item.args.WriteString(pj.String())
 					}
@@ -971,6 +1079,8 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 			summary := []byte(`{"type":"summary_text","text":""}`)
 			summary, _ = sjson.SetBytes(summary, "text", outputItem.text.String())
 			item, _ = sjson.SetRawBytes(item, "summary", translatorcommon.JoinRawArray([][]byte{summary}))
+		case "web_search_call":
+			item = buildResponsesWebSearchCallItem(outputItem.callID, claudeWebSearchQuery(outputItem.args.String()), outputItem.results)
 		case "message":
 			item = []byte(`{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}`)
 			item, _ = sjson.SetBytes(item, "id", outputItem.id)

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
@@ -232,8 +232,10 @@ func TestConvertClaudeResponseToOpenAIResponses_AggregatesTextBlocksUntilMessage
 		}
 	}
 
-	if counts["response.output_item.added"] != 1 {
-		t.Fatalf("response.output_item.added count = %d, want 1", counts["response.output_item.added"])
+	// message + web_search_call: the search surfaces as its own item, while the
+	// text around it still aggregates into a single message.
+	if counts["response.output_item.added"] != 2 {
+		t.Fatalf("response.output_item.added count = %d, want 2", counts["response.output_item.added"])
 	}
 	if counts["response.content_part.added"] != 1 {
 		t.Fatalf("response.content_part.added count = %d, want 1", counts["response.content_part.added"])
@@ -244,8 +246,8 @@ func TestConvertClaudeResponseToOpenAIResponses_AggregatesTextBlocksUntilMessage
 	if counts["response.content_part.done"] != 1 {
 		t.Fatalf("response.content_part.done count = %d, want 1", counts["response.content_part.done"])
 	}
-	if counts["response.output_item.done"] != 1 {
-		t.Fatalf("response.output_item.done count = %d, want 1", counts["response.output_item.done"])
+	if counts["response.output_item.done"] != 2 {
+		t.Fatalf("response.output_item.done count = %d, want 2", counts["response.output_item.done"])
 	}
 	if counts["response.function_call_arguments.delta"] != 0 {
 		t.Fatalf("response.function_call_arguments.delta count = %d, want 0", counts["response.function_call_arguments.delta"])
@@ -392,24 +394,26 @@ func TestConvertClaudeResponseToOpenAIResponses_UsesContiguousIndicesForReasonin
 		case event == "response.output_item.added" || event == "response.output_item.done":
 			itemType = data.Get("item.type").String()
 			switch itemType {
-			case "reasoning":
+			case "web_search_call":
 				wantIndex = 0
-			case "message":
+			case "reasoning":
 				wantIndex = 1
-			case "function_call":
+			case "message":
 				wantIndex = 2
+			case "function_call":
+				wantIndex = 3
 			default:
 				continue
 			}
 		case strings.HasPrefix(event, "response.reasoning_"):
 			itemType = "reasoning"
-			wantIndex = 0
+			wantIndex = 1
 		case strings.HasPrefix(event, "response.output_text.") || strings.HasPrefix(event, "response.content_part."):
 			itemType = "message"
-			wantIndex = 1
+			wantIndex = 2
 		case strings.HasPrefix(event, "response.function_call_arguments."):
 			itemType = "function_call"
-			wantIndex = 2
+			wantIndex = 3
 		case event == "response.completed":
 			completed = data
 			continue
@@ -431,17 +435,17 @@ func TestConvertClaudeResponseToOpenAIResponses_UsesContiguousIndicesForReasonin
 			t.Fatalf("no indexed %s events observed", itemType)
 		}
 	}
-	if got := completed.Get("response.output.#").Int(); got != 3 {
-		t.Fatalf("completed output count = %d, want 3", got)
+	if got := completed.Get("response.output.#").Int(); got != 4 {
+		t.Fatalf("completed output count = %d, want 4", got)
 	}
-	for index, wantType := range []string{"reasoning", "message", "function_call"} {
+	for index, wantType := range []string{"web_search_call", "reasoning", "message", "function_call"} {
 		if got := completed.Get(fmt.Sprintf("response.output.%d.type", index)).String(); got != wantType {
 			t.Fatalf("completed output[%d].type = %q, want %q", index, got, wantType)
 		}
 	}
 }
 
-func TestConvertClaudeResponseToOpenAIResponses_HiddenServerToolsDoNotCreateOutputIndexGaps(t *testing.T) {
+func TestConvertClaudeResponseToOpenAIResponses_ServerToolsSurfaceWithoutOutputIndexGaps(t *testing.T) {
 	chunks := [][]byte{
 		[]byte(`data: {"type":"message_start","message":{"id":"msg_123","usage":{"input_tokens":1,"output_tokens":0}}}`),
 		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`),
@@ -490,8 +494,9 @@ func TestConvertClaudeResponseToOpenAIResponses_HiddenServerToolsDoNotCreateOutp
 		case event == "response.output_item.added" && data.Get("item.type").String() == "function_call",
 			event == "response.output_item.done" && data.Get("item.type").String() == "function_call",
 			strings.HasPrefix(event, "response.function_call_arguments."):
-			if got := data.Get("output_index").Int(); got != 1 {
-				t.Fatalf("%s output_index = %d, want 1", event, got)
+			// index 1 is the web_search_call standing for the server-side search
+			if got := data.Get("output_index").Int(); got != 2 {
+				t.Fatalf("%s output_index = %d, want 2", event, got)
 			}
 		case event == "response.completed":
 			completed = data
@@ -504,14 +509,13 @@ func TestConvertClaudeResponseToOpenAIResponses_HiddenServerToolsDoNotCreateOutp
 	if got := outputTextDone.Get("text").String(); got != "Searching. Found it." {
 		t.Fatalf("aggregated message text = %q, want %q", got, "Searching. Found it.")
 	}
-	if got := completed.Get("response.output.#").Int(); got != 2 {
-		t.Fatalf("completed output count = %d, want 2", got)
+	if got := completed.Get("response.output.#").Int(); got != 3 {
+		t.Fatalf("completed output count = %d, want 3", got)
 	}
-	if got := completed.Get("response.output.0.type").String(); got != "message" {
-		t.Fatalf("completed output[0].type = %q, want message", got)
-	}
-	if got := completed.Get("response.output.1.type").String(); got != "function_call" {
-		t.Fatalf("completed output[1].type = %q, want function_call", got)
+	for index, wantType := range []string{"message", "web_search_call", "function_call"} {
+		if got := completed.Get(fmt.Sprintf("response.output.%d.type", index)).String(); got != wantType {
+			t.Fatalf("completed output[%d].type = %q, want %q", index, got, wantType)
+		}
 	}
 }
 

--- a/internal/translator/claude/openai/responses/claude_openai-responses_server_tool_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_server_tool_test.go
@@ -1,0 +1,393 @@
+package responses
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// --- L1 direction A: Claude server tool blocks -> Responses web_search_call ---
+
+func claudeWebSearchStreamChunks() [][]byte {
+	return [][]byte{
+		[]byte(`data: {"type":"message_start","message":{"id":"msg_ws","usage":{"input_tokens":1,"output_tokens":0}}}`),
+		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtoolu_1","name":"web_search","input":{}}}`),
+		[]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"lindorm vector\"}"}}`),
+		[]byte(`data: {"type":"content_block_stop","index":0}`),
+		[]byte(`data: {"type":"content_block_start","index":1,"content_block":{"type":"web_search_tool_result","tool_use_id":"srvtoolu_1","content":[{"type":"web_search_result","title":"Lindorm Vector","url":"https://example.com/a","encrypted_content":"ENC_A","page_age":"1 day"},{"type":"web_search_result","title":"Docs","url":"https://example.com/b","encrypted_content":"ENC_B"}]}}`),
+		[]byte(`data: {"type":"content_block_stop","index":1}`),
+		[]byte(`data: {"type":"message_stop"}`),
+	}
+}
+
+func TestClaudeWebSearchBlocksBecomeWebSearchCallItem(t *testing.T) {
+	outputs := translateClaudeResponsesStreamThroughRegistry(claudeWebSearchStreamChunks())
+
+	var completed gjson.Result
+	for _, o := range outputs {
+		if ev, data := parseClaudeResponsesSSEEvent(t, o); ev == "response.completed" {
+			completed = data
+		}
+	}
+	items := completed.Get("response.output").Array()
+	if len(items) != 1 {
+		t.Fatalf("output items = %d, want 1: %s", len(items), completed.Get("response.output").Raw)
+	}
+	item := items[0]
+	if got := item.Get("type").String(); got != "web_search_call" {
+		t.Fatalf("item type = %q, want web_search_call", got)
+	}
+	if got := item.Get("action.query").String(); got != "lindorm vector" {
+		t.Fatalf("action.query = %q, want %q", got, "lindorm vector")
+	}
+	if got := item.Get("status").String(); got != "completed" {
+		t.Fatalf("status = %q, want completed", got)
+	}
+	if got := item.Get("results.#").Int(); got != 2 {
+		t.Fatalf("results = %d, want 2: %s", got, item.Raw)
+	}
+	if got := item.Get("results.0.url").String(); got != "https://example.com/a" {
+		t.Fatalf("results[0].url = %q", got)
+	}
+	// Anthropic validates encrypted_content on replay, so it must survive the hop.
+	if got := item.Get("results.0.encrypted_content").String(); got != "ENC_A" {
+		t.Fatalf("results[0].encrypted_content = %q, want ENC_A", got)
+	}
+}
+
+func TestClaudeWebSearchBlocksBecomeWebSearchCallItemNonStream(t *testing.T) {
+	var lines []string
+	for _, chunk := range claudeWebSearchStreamChunks() {
+		lines = append(lines, string(chunk))
+	}
+	out := ConvertClaudeResponseToOpenAIResponsesNonStream(
+		context.Background(), "claude-test", nil, nil, []byte(strings.Join(lines, "\n")), nil)
+
+	items := gjson.GetBytes(out, "output").Array()
+	if len(items) != 1 || items[0].Get("type").String() != "web_search_call" {
+		t.Fatalf("output = %s", gjson.GetBytes(out, "output").Raw)
+	}
+	if got := items[0].Get("action.query").String(); got != "lindorm vector" {
+		t.Fatalf("action.query = %q", got)
+	}
+	if got := items[0].Get("results.#").Int(); got != 2 {
+		t.Fatalf("results = %d, want 2", got)
+	}
+}
+
+// --- L1 direction B: Responses web_search_call -> Claude server tool blocks ---
+
+func TestWebSearchCallItemReplaysAsClaudeServerToolBlocks(t *testing.T) {
+	raw := responsesRequestFromItems(`{
+		"type":"web_search_call","id":"ws_srvtoolu_1","status":"completed",
+		"action":{"type":"search","query":"lindorm vector"},
+		"results":[{"title":"Lindorm Vector","url":"https://example.com/a","encrypted_content":"ENC_A"}]
+	}`)
+	out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
+
+	if got := claudeAssistantBlockTypes(t, out); len(got) != 2 ||
+		got[0] != "server_tool_use" || got[1] != "web_search_tool_result" {
+		t.Fatalf("assistant blocks = %v, want [server_tool_use web_search_tool_result]", got)
+	}
+	blocks := gjson.GetBytes(out, "messages.0.content")
+	use, result := blocks.Get("0"), blocks.Get("1")
+	if got := use.Get("id").String(); got != "srvtoolu_1" {
+		t.Fatalf("server_tool_use id = %q, want srvtoolu_1 (ws_ prefix stripped)", got)
+	}
+	if got := use.Get("name").String(); got != "web_search" {
+		t.Fatalf("server_tool_use name = %q", got)
+	}
+	if got := use.Get("input.query").String(); got != "lindorm vector" {
+		t.Fatalf("server_tool_use input.query = %q", got)
+	}
+	if got := result.Get("tool_use_id").String(); got != "srvtoolu_1" {
+		t.Fatalf("web_search_tool_result tool_use_id = %q", got)
+	}
+	if got := result.Get("content.0.url").String(); got != "https://example.com/a" {
+		t.Fatalf("result url = %q", got)
+	}
+	if got := result.Get("content.0.encrypted_content").String(); got != "ENC_A" {
+		t.Fatalf("result encrypted_content = %q, want ENC_A", got)
+	}
+}
+
+// Anthropic rejects a web_search_result without genuine encrypted_content and
+// rejects a server_tool_use with no result block at all, but accepts an empty
+// result list. A client that drops the field must therefore degrade, not break.
+func TestWebSearchCallWithoutEncryptedContentReplaysEmptyResults(t *testing.T) {
+	raw := responsesRequestFromItems(`{
+		"type":"web_search_call","id":"ws_srvtoolu_1","status":"completed",
+		"action":{"type":"search","query":"q"},
+		"results":[{"title":"T","url":"https://example.com/a"}]
+	}`)
+	out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
+	if got := claudeAssistantBlockTypes(t, out); len(got) != 2 {
+		t.Fatalf("assistant blocks = %v, want the server_tool_use/result pair", got)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.1.content.#").Int(); got != 0 {
+		t.Fatalf("result content entries = %d, want 0", got)
+	}
+}
+
+func TestOutputTextAnnotationsReplayAsClaudeCitations(t *testing.T) {
+	raw := responsesRequestFromItems(`{
+		"type":"message","role":"assistant",
+		"content":[{"type":"output_text","text":"Answer.","annotations":[
+			{"type":"web_search_result_location","url":"https://example.com/a","title":"A","cited_text":"Answer","encrypted_index":"IDX_A"}
+		]}]
+	}`)
+	out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
+	block := gjson.GetBytes(out, "messages.0.content.0")
+	if got := block.Get("type").String(); got != "text" {
+		t.Fatalf("block type = %q", got)
+	}
+	if got := block.Get("citations.#").Int(); got != 1 {
+		t.Fatalf("citations = %d, want 1: %s", got, block.Raw)
+	}
+	if got := block.Get("citations.0.url").String(); got != "https://example.com/a" {
+		t.Fatalf("citation url = %q", got)
+	}
+	// encrypted_index is mandatory on replay; the annotation must ride through verbatim.
+	if got := block.Get("citations.0.encrypted_index").String(); got != "IDX_A" {
+		t.Fatalf("citation encrypted_index = %q, want IDX_A", got)
+	}
+}
+
+func TestAnnotationsWithoutEncryptedIndexAreNotReplayedAsCitations(t *testing.T) {
+	raw := responsesRequestFromItems(`{
+		"type":"message","role":"assistant",
+		"content":[{"type":"output_text","text":"Answer.","annotations":[
+			{"type":"url_citation","url":"https://example.com/a","title":"A"}
+		]}]
+	}`)
+	out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
+	if gjson.GetBytes(out, "messages.0.content.0.citations").Exists() {
+		t.Fatal("citations without encrypted_index must be dropped, not sent")
+	}
+}
+
+func TestRefusalPartReplaysAsClaudeText(t *testing.T) {
+	raw := responsesRequestFromItems(`{
+		"type":"message","role":"assistant",
+		"content":[{"type":"refusal","refusal":"I cannot help with that."}]
+	}`)
+	out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
+	block := gjson.GetBytes(out, "messages.0.content")
+	text := block.Get("0.text").String()
+	if block.Type == gjson.String {
+		text = block.String()
+	}
+	if text != "I cannot help with that." {
+		t.Fatalf("refusal text = %q, raw=%s", text, block.Raw)
+	}
+}
+
+// --- L3 contract: every reachable Claude block survives a round trip ---
+
+func TestRoundTripPreservesReachableClaudeBlocks(t *testing.T) {
+	chunks := [][]byte{
+		[]byte(`data: {"type":"message_start","message":{"id":"msg_rt","usage":{"input_tokens":1,"output_tokens":0}}}`),
+		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`),
+		[]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"ponder"}}`),
+		[]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"` + mustTestSignature(t) + `"}}`),
+		[]byte(`data: {"type":"content_block_stop","index":0}`),
+		[]byte(`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`),
+		[]byte(`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Researching."}}`),
+		[]byte(`data: {"type":"content_block_stop","index":1}`),
+		[]byte(`data: {"type":"content_block_start","index":2,"content_block":{"type":"server_tool_use","id":"srvtoolu_1","name":"web_search","input":{}}}`),
+		[]byte(`data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"q\"}"}}`),
+		[]byte(`data: {"type":"content_block_stop","index":2}`),
+		[]byte(`data: {"type":"content_block_start","index":3,"content_block":{"type":"web_search_tool_result","tool_use_id":"srvtoolu_1","content":[{"type":"web_search_result","title":"T","url":"https://example.com/a"}]}}`),
+		[]byte(`data: {"type":"content_block_stop","index":3}`),
+		[]byte(`data: {"type":"content_block_start","index":4,"content_block":{"type":"thinking","thinking":""}}`),
+		[]byte(`data: {"type":"content_block_delta","index":4,"delta":{"type":"thinking_delta","thinking":"more"}}`),
+		[]byte(`data: {"type":"content_block_delta","index":4,"delta":{"type":"signature_delta","signature":"` + mustTestSignature(t) + `"}}`),
+		[]byte(`data: {"type":"content_block_stop","index":4}`),
+		[]byte(`data: {"type":"content_block_start","index":5,"content_block":{"type":"tool_use","id":"toolu_1","name":"exec","input":{}}}`),
+		[]byte(`data: {"type":"content_block_delta","index":5,"delta":{"type":"input_json_delta","partial_json":"{\"cmd\":\"pwd\"}"}}`),
+		[]byte(`data: {"type":"content_block_stop","index":5}`),
+		[]byte(`data: {"type":"message_stop"}`),
+	}
+
+	outputs := translateClaudeResponsesStreamThroughRegistry(chunks)
+	var completed gjson.Result
+	for _, o := range outputs {
+		if ev, data := parseClaudeResponsesSSEEvent(t, o); ev == "response.completed" {
+			completed = data
+		}
+	}
+	var items []json.RawMessage
+	completed.Get("response.output").ForEach(func(_, v gjson.Result) bool {
+		items = append(items, json.RawMessage(v.Raw))
+		return true
+	})
+	req, _ := json.Marshal(map[string]any{"model": "claude-test", "input": items})
+	out := ConvertOpenAIResponsesRequestToClaude("claude-test", req, false)
+
+	got := claudeAssistantBlockTypes(t, out)
+	want := []string{"thinking", "text", "server_tool_use", "web_search_tool_result", "thinking", "tool_use"}
+	if len(got) != len(want) {
+		t.Fatalf("round trip blocks = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("round trip blocks = %v, want %v", got, want)
+		}
+	}
+}
+
+// --- boundary and error cases ------------------------------------------------
+
+// Anthropic constrains server tool ids to ^srvtoolu_[a-zA-Z0-9_]+$. Responses
+// items that never came from Claude (a native OpenAI web_search_call) carry ids
+// that violate it, so the id must be normalised instead of trusted.
+func TestWebSearchCallIDNormalisedToClaudeServerToolPattern(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		responsesID string
+		want        string
+	}{
+		{"claude round trip keeps the original id", "ws_srvtoolu_abc123", "srvtoolu_abc123"},
+		{"native OpenAI id gains the required prefix", "ws_00112233aabb", "srvtoolu_00112233aabb"},
+		{"characters outside the pattern are replaced", "ws_00112233-aabb.cc", "srvtoolu_00112233_aabb_cc"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := responsesRequestFromItems(`{"type":"web_search_call","id":"` + tc.responsesID + `","status":"completed","action":{"type":"search","query":"q"}}`)
+			out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
+			blocks := gjson.GetBytes(out, "messages.0.content")
+			if got := blocks.Get("0.id").String(); got != tc.want {
+				t.Fatalf("server_tool_use id = %q, want %q", got, tc.want)
+			}
+			if got := blocks.Get("1.tool_use_id").String(); got != tc.want {
+				t.Fatalf("tool_use_id = %q, want %q (must pair with the use block)", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWebSearchCallWithoutIDProducesNoBlocks(t *testing.T) {
+	for _, id := range []string{``, `ws_`} {
+		raw := responsesRequestFromItems(`{"type":"web_search_call","id":"` + id + `","status":"completed","action":{"type":"search","query":"q"}}`)
+		out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
+		if got := claudeAssistantBlockTypes(t, out); len(got) != 0 {
+			t.Fatalf("id=%q produced %v; an unpairable server_tool_use is rejected by Anthropic", id, got)
+		}
+	}
+}
+
+// A turn can end after the search block when the upstream stream is cut short;
+// the item must still be closed so the client does not see a dangling item.
+func TestClaudeWebSearchWithoutResultBlockStillEmitsItem(t *testing.T) {
+	chunks := [][]byte{
+		[]byte(`data: {"type":"message_start","message":{"id":"msg_ws","usage":{"input_tokens":1,"output_tokens":0}}}`),
+		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtoolu_1","name":"web_search","input":{}}}`),
+		[]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"q\"}"}}`),
+		[]byte(`data: {"type":"content_block_stop","index":0}`),
+		[]byte(`data: {"type":"message_stop"}`),
+	}
+	outputs := translateClaudeResponsesStreamThroughRegistry(chunks)
+	done, completed := 0, gjson.Result{}
+	for _, o := range outputs {
+		event, data := parseClaudeResponsesSSEEvent(t, o)
+		if event == "response.output_item.done" && data.Get("item.type").String() == "web_search_call" {
+			done++
+		}
+		if event == "response.completed" {
+			completed = data
+		}
+	}
+	if done != 1 {
+		t.Fatalf("web_search_call output_item.done count = %d, want 1", done)
+	}
+	if got := completed.Get("response.output.0.results").Exists(); got {
+		t.Fatal("no result block arrived, so results must be absent")
+	}
+}
+
+func TestUnmappedServerToolProducesNoItem(t *testing.T) {
+	chunks := [][]byte{
+		[]byte(`data: {"type":"message_start","message":{"id":"msg_ws","usage":{"input_tokens":1,"output_tokens":0}}}`),
+		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtoolu_1","name":"code_execution","input":{}}}`),
+		[]byte(`data: {"type":"content_block_stop","index":0}`),
+		[]byte(`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`),
+		[]byte(`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"done"}}`),
+		[]byte(`data: {"type":"content_block_stop","index":1}`),
+		[]byte(`data: {"type":"message_stop"}`),
+	}
+	outputs := translateClaudeResponsesStreamThroughRegistry(chunks)
+	var completed gjson.Result
+	for _, o := range outputs {
+		if event, data := parseClaudeResponsesSSEEvent(t, o); event == "response.completed" {
+			completed = data
+		}
+	}
+	if got := completed.Get("response.output.#").Int(); got != 1 {
+		t.Fatalf("output items = %d, want 1 (message only): %s", got, completed.Get("response.output").Raw)
+	}
+	if got := completed.Get("response.output.0.type").String(); got != "message" {
+		t.Fatalf("output[0].type = %q, want message", got)
+	}
+}
+
+func TestWebSearchResultWithoutMatchingUseIsIgnored(t *testing.T) {
+	chunks := [][]byte{
+		[]byte(`data: {"type":"message_start","message":{"id":"msg_ws","usage":{"input_tokens":1,"output_tokens":0}}}`),
+		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"web_search_tool_result","tool_use_id":"srvtoolu_missing","content":[]}}`),
+		[]byte(`data: {"type":"content_block_stop","index":0}`),
+		[]byte(`data: {"type":"message_stop"}`),
+	}
+	outputs := translateClaudeResponsesStreamThroughRegistry(chunks)
+	for _, o := range outputs {
+		if event, data := parseClaudeResponsesSSEEvent(t, o); event == "response.completed" {
+			if got := data.Get("response.output.#").Int(); got != 0 {
+				t.Fatalf("orphan result produced %d output items, want 0", got)
+			}
+		}
+	}
+}
+
+// Native OpenAI clients emit `queries` alongside `query`, and use an `open_page`
+// action with a url instead of a query; both shapes reach this translator when a
+// session started on an OpenAI provider is resumed against Claude.
+func TestWebSearchCallQueryAcceptsNativeOpenAIActionShapes(t *testing.T) {
+	for _, tc := range []struct{ name, action, want string }{
+		{"search with query", `{"type":"search","query":"go release","queries":["go release"]}`, "go release"},
+		{"search with only queries", `{"type":"search","queries":["go release"]}`, "go release"},
+		{"open_page falls back to the url", `{"type":"open_page","url":"https://go.dev/dl"}`, "https://go.dev/dl"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := responsesRequestFromItems(`{"type":"web_search_call","id":"ws_srvtoolu_1","status":"completed","action":` + tc.action + `}`)
+			out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
+			if got := gjson.GetBytes(out, "messages.0.content.0.input.query").String(); got != tc.want {
+				t.Fatalf("input.query = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// An empty result list is distinct from a missing one: Claude reported a search
+// that returned nothing, which Anthropic accepts on replay.
+func TestClaudeWebSearchWithEmptyResultsKeepsEmptyList(t *testing.T) {
+	chunks := [][]byte{
+		[]byte(`data: {"type":"message_start","message":{"id":"msg_ws","usage":{"input_tokens":1,"output_tokens":0}}}`),
+		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtoolu_1","name":"web_search","input":{}}}`),
+		[]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"q\"}"}}`),
+		[]byte(`data: {"type":"content_block_stop","index":0}`),
+		[]byte(`data: {"type":"content_block_start","index":1,"content_block":{"type":"web_search_tool_result","tool_use_id":"srvtoolu_1","content":[]}}`),
+		[]byte(`data: {"type":"content_block_stop","index":1}`),
+		[]byte(`data: {"type":"message_stop"}`),
+	}
+	var completed gjson.Result
+	for _, o := range translateClaudeResponsesStreamThroughRegistry(chunks) {
+		if event, data := parseClaudeResponsesSSEEvent(t, o); event == "response.completed" {
+			completed = data
+		}
+	}
+	results := completed.Get("response.output.0.results")
+	if !results.Exists() || results.Int() != 0 && len(results.Array()) != 0 {
+		t.Fatalf("results = %s, want an empty array", results.Raw)
+	}
+}

--- a/internal/translator/claude/openai/responses/claude_openai-responses_testsupport_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_testsupport_test.go
@@ -1,0 +1,43 @@
+package responses
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// claudeAssistantBlockTypes returns the content block types of the last Claude
+// assistant message produced by the Responses -> Claude request translator.
+func claudeAssistantBlockTypes(t *testing.T, claudeReq []byte) []string {
+	t.Helper()
+	var kinds []string
+	gjson.GetBytes(claudeReq, "messages").ForEach(func(_, m gjson.Result) bool {
+		if m.Get("role").String() != "assistant" {
+			return true
+		}
+		kinds = kinds[:0]
+		m.Get("content").ForEach(func(_, b gjson.Result) bool {
+			kinds = append(kinds, b.Get("type").String())
+			return true
+		})
+		return true
+	})
+	return kinds
+}
+
+func responsesRequestFromItems(items ...string) []byte {
+	raw := `{"model":"claude-test","input":[`
+	for i, item := range items {
+		if i > 0 {
+			raw += ","
+		}
+		raw += item
+	}
+	return []byte(raw + `]}`)
+}
+
+func mustTestSignature(t *testing.T) string {
+	t.Helper()
+	raw, _ := testClaudeResponsesThinkingSignature(t)
+	return raw
+}

--- a/internal/translator/claude/openai/responses/claude_openai-responses_thinking_adjacency_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_thinking_adjacency_test.go
@@ -1,0 +1,38 @@
+package responses
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestAssistantContentNeverHasAdjacentThinking(t *testing.T) {
+	rawSignature, _ := testClaudeResponsesThinkingSignature(t)
+	reasoning := `{"type":"reasoning","encrypted_content":"` + rawSignature + `","summary":[{"type":"summary_text","text":"a"}]}`
+	raw := responsesRequestFromItems(reasoning, reasoning, reasoning,
+		`{"type":"function_call","call_id":"toolu_1","name":"x","arguments":"{}"}`)
+	out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
+
+	kinds := claudeAssistantBlockTypes(t, out)
+	for i := 1; i < len(kinds); i++ {
+		if kinds[i] == "thinking" && kinds[i-1] == "thinking" {
+			t.Fatalf("adjacent thinking blocks are rejected by Anthropic: %v", kinds)
+		}
+	}
+	if len(kinds) != 2 || kinds[0] != "thinking" || kinds[1] != "tool_use" {
+		t.Fatalf("blocks = %v, want [thinking tool_use]", kinds)
+	}
+}
+
+func TestAdjacentThinkingMergeKeepsNonEmptyText(t *testing.T) {
+	rawSignature, _ := testClaudeResponsesThinkingSignature(t)
+	item := func(text string) string {
+		return `{"type":"reasoning","encrypted_content":"` + rawSignature + `","summary":[{"type":"summary_text","text":"` + text + `"}]}`
+	}
+	raw := responsesRequestFromItems(item(""), item("second"),
+		`{"type":"function_call","call_id":"toolu_1","name":"x","arguments":"{}"}`)
+	out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
+	if got := gjson.GetBytes(out, "messages.0.content.0.thinking").String(); got != "second" {
+		t.Fatalf("merged thinking = %q, want %q (empty leading text must not add separators)", got, "second")
+	}
+}

--- a/internal/translator/claude/openai/responses/claude_openai-responses_web_search.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_web_search.go
@@ -1,0 +1,188 @@
+package responses
+
+import (
+	"regexp"
+	"strings"
+
+	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// Claude reports server-side web search as a pair of assistant content blocks: a
+// `server_tool_use` block carrying the query and a `web_search_tool_result` block
+// carrying the hits. OpenAI Responses models the same exchange as a single
+// `web_search_call` item. The representations are isomorphic, so the pair folds
+// into one item on the way out and expands back on the way in.
+//
+// Dropping the pair instead is not merely cosmetic: the replayed turn then shows
+// a conclusion with no search behind it, which makes the model treat its own
+// previous answer as unsourced and search again.
+const (
+	claudeWebSearchToolName = "web_search"
+
+	// responsesWebSearchIDPrefix namespaces the Claude server_tool_use id inside
+	// the Responses item id, mirroring the fc_/ctc_ prefixes used for tool calls
+	// so the original id can be recovered on replay.
+	responsesWebSearchIDPrefix = "ws_"
+
+	// claudeServerToolIDPrefix is mandated by Anthropic: server tool ids must
+	// match ^srvtoolu_[a-zA-Z0-9_]+$.
+	claudeServerToolIDPrefix = "srvtoolu_"
+)
+
+// claudeServerToolIDSanitizer matches the characters Anthropic forbids in a
+// server tool id. Note it is stricter than util.SanitizeClaudeToolID, which
+// targets tool_use ids and allows '-'.
+var claudeServerToolIDSanitizer = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+
+func responsesWebSearchCallID(claudeToolUseID string) string {
+	return responsesWebSearchIDPrefix + claudeToolUseID
+}
+
+// claudeWebSearchToolUseID recovers the Claude server_tool_use id from a
+// Responses item id, normalising it to Anthropic's required shape. A Responses
+// history need not come from Claude at all - a native OpenAI web_search_call
+// carries an id like "ws_00112233aabb" - and replaying such an id verbatim is
+// rejected outright, so the body is always sanitised and re-prefixed. The
+// transform is idempotent, leaving genuine Claude ids untouched.
+func claudeWebSearchToolUseID(responsesItemID string) string {
+	body := strings.TrimPrefix(strings.TrimSpace(responsesItemID), responsesWebSearchIDPrefix)
+	body = claudeServerToolIDSanitizer.ReplaceAllString(strings.TrimPrefix(body, claudeServerToolIDPrefix), "_")
+	if body == "" {
+		return ""
+	}
+	return claudeServerToolIDPrefix + body
+}
+
+// claudeWebSearchQuery extracts the query from a Claude server_tool_use input,
+// accepting either the accumulated streaming JSON or an already parsed object.
+func claudeWebSearchQuery(input string) string {
+	if input == "" {
+		return ""
+	}
+	return strings.TrimSpace(gjson.Get(input, "query").String())
+}
+
+// claudeWebSearchResultsToResponses converts the content of a Claude
+// `web_search_tool_result` block into the Responses `results` array.
+//
+// Entries ride through verbatim rather than being rebuilt field by field:
+// Anthropic requires a genuine `encrypted_content` on every result it is asked
+// to replay and rejects fabricated values, so anything we drop here can never be
+// reconstructed later.
+func claudeWebSearchResultsToResponses(content gjson.Result) []byte {
+	if !content.IsArray() {
+		return nil
+	}
+	var results [][]byte
+	content.ForEach(func(_, entry gjson.Result) bool {
+		if strings.TrimSpace(entry.Get("url").String()) != "" {
+			results = append(results, []byte(entry.Raw))
+		}
+		return true
+	})
+	if len(results) == 0 {
+		return []byte(`[]`)
+	}
+	return translatorcommon.JoinRawArray(results)
+}
+
+// buildResponsesWebSearchCallItem renders the Responses item that stands for one
+// Claude server-side search. results may be nil when the upstream turn ended
+// before the result block arrived.
+func buildResponsesWebSearchCallItem(claudeToolUseID, query string, results []byte) []byte {
+	item := []byte(`{"id":"","type":"web_search_call","status":"completed","action":{"type":"search","query":""}}`)
+	item, _ = sjson.SetBytes(item, "id", responsesWebSearchCallID(claudeToolUseID))
+	item, _ = sjson.SetBytes(item, "action.query", query)
+	if len(results) > 0 {
+		item, _ = sjson.SetRawBytes(item, "results", results)
+	}
+	return item
+}
+
+// convertResponsesWebSearchCallToClaudeBlocks is the inverse of
+// buildResponsesWebSearchCallItem: it rebuilds the Claude block pair so a
+// replayed turn still shows that the search happened and what it returned.
+func convertResponsesWebSearchCallToClaudeBlocks(item gjson.Result) [][]byte {
+	toolUseID := claudeWebSearchToolUseID(strings.TrimSpace(item.Get("id").String()))
+	if toolUseID == "" {
+		return nil
+	}
+
+	use := []byte(`{"type":"server_tool_use","id":"","name":"","input":{}}`)
+	use, _ = sjson.SetBytes(use, "id", toolUseID)
+	use, _ = sjson.SetBytes(use, "name", claudeWebSearchToolName)
+	if query := responsesWebSearchCallQuery(item); query != "" {
+		use, _ = sjson.SetBytes(use, "input.query", query)
+	}
+
+	result := []byte(`{"type":"web_search_tool_result","tool_use_id":"","content":[]}`)
+	result, _ = sjson.SetBytes(result, "tool_use_id", toolUseID)
+	if content := responsesWebSearchResultsToClaude(item.Get("results")); len(content) > 0 {
+		result, _ = sjson.SetRawBytes(result, "content", content)
+	}
+	return [][]byte{use, result}
+}
+
+// responsesWebSearchCallQuery reads the query from a Responses web_search_call,
+// tolerating the `queries` array and the `open_page` action shape that OpenAI
+// clients emit.
+func responsesWebSearchCallQuery(item gjson.Result) string {
+	if query := strings.TrimSpace(item.Get("action.query").String()); query != "" {
+		return query
+	}
+	if query := strings.TrimSpace(item.Get("action.queries.0").String()); query != "" {
+		return query
+	}
+	return strings.TrimSpace(item.Get("action.url").String())
+}
+
+func responsesWebSearchResultsToClaude(results gjson.Result) []byte {
+	if !results.IsArray() {
+		return nil
+	}
+	var blocks [][]byte
+	results.ForEach(func(_, entry gjson.Result) bool {
+		// Anthropic validates encrypted_content and rejects the whole request when
+		// it is missing or forged. An entry that lost it in transit is therefore
+		// unusable; an empty result list is the only safe degradation, and it is
+		// accepted alongside the mandatory server_tool_use block.
+		if strings.TrimSpace(entry.Get("encrypted_content").String()) == "" {
+			return true
+		}
+		block := []byte(entry.Raw)
+		block, _ = sjson.SetBytes(block, "type", "web_search_result")
+		blocks = append(blocks, block)
+		return true
+	})
+	if len(blocks) == 0 {
+		return nil
+	}
+	return translatorcommon.JoinRawArray(blocks)
+}
+
+// attachClaudeCitations mirrors Responses `annotations` back onto a Claude text
+// block as `citations`. The annotations were copied verbatim from Claude on the
+// way out, so they ride back unchanged; entries without the mandatory
+// `encrypted_index` cannot be replayed and are dropped rather than rejected.
+func attachClaudeCitations(textBlock []byte, annotations gjson.Result) []byte {
+	if !annotations.IsArray() {
+		return textBlock
+	}
+	var citations [][]byte
+	annotations.ForEach(func(_, annotation gjson.Result) bool {
+		if strings.TrimSpace(annotation.Get("encrypted_index").String()) != "" {
+			citations = append(citations, []byte(annotation.Raw))
+		}
+		return true
+	})
+	if len(citations) == 0 {
+		return textBlock
+	}
+	updated, err := sjson.SetRawBytes(textBlock, "citations", translatorcommon.JoinRawArray(citations))
+	if err != nil {
+		return textBlock
+	}
+	return updated
+}


### PR DESCRIPTION
Fixes #5236

## Summary

Maps Claude's server-side web search blocks to the Responses `web_search_call` item in both directions, and adds a structural invariant that keeps any comparable gap from killing a session.

Claude reports a server-side search as a `server_tool_use` block plus a `web_search_tool_result` block. Neither had a case in the Claude -> Responses translator, so both were dropped without a trace, and the Responses -> Claude translator had no case for `web_search_call` either. Replaying such a turn shows the model a conclusion with no search behind it, and the dropped blocks no longer separate the reasoning items around them, which leaves two adjacent `thinking` blocks that Anthropic rejects outright.

## Anthropic constraints this had to satisfy

Established against the live API. Several are not obvious from the docs, and two of them forced a redesign mid-implementation, so they are recorded here for reviewers:

| Replayed shape | Result |
| --- | --- |
| Two adjacent `thinking` blocks | 400 - applies to **every** assistant message, not only the last one |
| `thinking` reordered after text | 200 - ordering is not constrained |
| `thinking` blocks separated by any other block | 200 |
| `web_search_result` without `encrypted_content` | 400 - field is required |
| `web_search_result` with a forged `encrypted_content` | 400 - the value is validated |
| `web_search_tool_result` with `content: []` | 200 |
| `server_tool_use` with no matching result block | 400 - the pair is mandatory |
| `server_tool_use.id` not matching `^srvtoolu_[a-zA-Z0-9_]+$` | 400 |
| `web_search_result_location` citation without `encrypted_index` | 400 - field is required |

Two consequences worth calling out:

- **Nothing can be reconstructed later.** `encrypted_content` and `encrypted_index` are validated, so a field dropped in transit is gone for good. Result entries and citations ride through verbatim rather than being rebuilt field by field, and an entry that lost its field is skipped instead of forged. An empty result list is the only safe degradation.
- **Ids cannot be trusted.** A Responses history need not come from Claude at all; a native OpenAI `web_search_call` carries an id such as `ws_00112233aabb`, whose body violates Anthropic's server tool pattern. Replaying it verbatim would turn today's silent drop into a hard 400, so the id is sanitised and re-prefixed. The transform is idempotent and leaves genuine Claude ids untouched.

## What changed

**`claude_openai-responses_web_search.go` (new)** - the pure, bidirectional mapping between the Claude block pair and the Responses `web_search_call` item, plus citation passthrough.

**Response direction** - `server_tool_use` and `web_search_tool_result` fold into one `web_search_call` item. The text around a search keeps aggregating into a single message item, because Claude frequently searches mid-sentence and splitting there would break one sentence across two message items. Only the search becomes a separate item, which shifts output indices in three existing tests.

**Request direction** - `web_search_call` expands back into the block pair; `annotations` replay as `citations`; `refusal` parts replay as text. A lone text block no longer collapses to Claude's string content form when it carries citations that the string form would drop.

**Structural invariant** - the request translator folds a thinking block into the one immediately before it, so an assistant message can never carry an adjacent pair. This holds regardless of which block types the response translator maps, so it contains any future gap to context loss rather than a hard failure. Merging is safe because Anthropic validates block structure and signature presence, not the thinking text. `redacted_thinking` is deliberately excluded: its payload is opaque and cannot be concatenated.

**Observability** - both translators gained a default branch that logs an unmapped block or item type at debug level. Today only `web_search` can be enabled on Claude by this translator, so every other server tool is unreachable; the log makes it visible the moment that changes instead of letting the content vanish silently.

## Verification

Against a live Claude model, before and after:

| | before | after |
| --- | --- | --- |
| Replaying the turn that triggered the report | 400 | 200 |
| Turn 1 output items | `[message]` | `[web_search_call, message]` |
| Turn 2 asked for its sources | `NO SOURCES IN CONTEXT`, retracts turn 1 | lists the actual source URLs |
| Turn 2 repeat searches | - | none |
| Replaying a native OpenAI `web_search_call` | silently dropped | mapped, id normalised |

## Testing

`internal/translator/claude/openai/responses` grows from 63 to 81 tests.

- **Happy path** - streaming and non-streaming search; interleaved thinking/search; a full round trip asserting every block type a Claude turn can produce under this tool set survives `toClaude(toResponses(x))`.
- **Error paths** - unmapped server tool name; result block with no matching use block; result entry without `encrypted_content`; annotation without `encrypted_index`; empty or prefix-only item id.
- **Boundaries** - turn ending before the result block arrives; empty result list; id normalisation across Claude-origin, OpenAI-origin and illegal-character ids; the `queries` and `open_page` action shapes native OpenAI clients emit; merging into a thinking block whose text is empty.

Known gap: adjacency of two `redacted_thinking` blocks is not handled. Anthropic rejects a synthetic `data` payload before any adjacency check, so the rule could not be confirmed, and speculative handling was left out rather than guessed at. It is called out in the code comment.

## Scope

`internal/translator/codex/claude` carries a mirror-image `web_search_call` <-> server tool mapping. It is intentionally untouched here to keep this change free of regression risk; factoring the shared core into `internal/translator/common` is worth a follow-up.

Rebased onto `dev` @ 998dcfeb. 8 files changed, +958/-26; no other package is touched.
