### PR TITLE
fix(gemini): split cachedContentTokenCount into cache_read_input_tokens in Claude translation

### DIFF
--- a/internal/translator/gemini/claude/gemini_claude_response.go
+++ b/internal/translator/gemini/claude/gemini_claude_response.go
@@ -264,8 +264,17 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 
 			thoughtsTokenCount := usageResult.Get("thoughtsTokenCount").Int()
 			candidatesTokenCount := usageResult.Get("candidatesTokenCount").Int()
+			cachedTokenCount := usageResult.Get("cachedContentTokenCount").Int()
 			template, _ = sjson.SetBytes(template, "usage.output_tokens", candidatesTokenCount+thoughtsTokenCount)
-			template, _ = sjson.SetBytes(template, "usage.input_tokens", usageResult.Get("promptTokenCount").Int())
+			// Gemini's promptTokenCount is the TOTAL prompt including the
+			// cached part; Claude's input_tokens excludes cache (it travels
+			// in cache_read_input_tokens). Mirror antigravity_claude_response
+			// so downstream Claude-format consumers (usage metering) don't
+			// bill cached reads at full input price.
+			template, _ = sjson.SetBytes(template, "usage.input_tokens", usageResult.Get("promptTokenCount").Int()-cachedTokenCount)
+			if cachedTokenCount > 0 {
+				template, _ = sjson.SetBytes(template, "usage.cache_read_input_tokens", cachedTokenCount)
+			}
 
 			appendEvent("message_delta", string(template))
 			(*param).(*Params).HasFinalEvents = true
@@ -296,10 +305,16 @@ func ConvertGeminiResponseToClaudeNonStream(_ context.Context, _ string, origina
 	out, _ = sjson.SetBytes(out, "id", root.Get("responseId").String())
 	out, _ = sjson.SetBytes(out, "model", root.Get("modelVersion").String())
 
-	inputTokens := root.Get("usageMetadata.promptTokenCount").Int()
+	cachedTokens := root.Get("usageMetadata.cachedContentTokenCount").Int()
+	// promptTokenCount is the TOTAL prompt including the cached part; Claude's
+	// input_tokens excludes cache (mirror antigravity_claude_response.go).
+	inputTokens := root.Get("usageMetadata.promptTokenCount").Int() - cachedTokens
 	outputTokens := root.Get("usageMetadata.candidatesTokenCount").Int() + root.Get("usageMetadata.thoughtsTokenCount").Int()
 	out, _ = sjson.SetBytes(out, "usage.input_tokens", inputTokens)
 	out, _ = sjson.SetBytes(out, "usage.output_tokens", outputTokens)
+	if cachedTokens > 0 {
+		out, _ = sjson.SetBytes(out, "usage.cache_read_input_tokens", cachedTokens)
+	}
 
 	parts := root.Get("candidates.0.content.parts")
 	textBuilder := strings.Builder{}

--- a/internal/translator/gemini/claude/gemini_claude_response_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_response_test.go
@@ -202,3 +202,78 @@ func TestConvertGeminiResponseToClaudeNonStream_TrailingSignatureOnlyPart(t *tes
 		t.Fatalf("unexpected text block: %s", textBlock.Raw)
 	}
 }
+
+// Gemini's promptTokenCount is the TOTAL prompt including the cached part;
+// Claude's input_tokens excludes cache (cache_read_input_tokens is separate).
+// Mirror antigravity_claude_response.go so downstream Claude-format consumers
+// (Open WebUI quota metering) don't bill cached reads at full input price.
+func TestConvertGeminiResponseToClaude_SplitsCachedInputTokens(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	finishChunk := []byte(`{
+		"candidates": [{
+			"content": {"parts": [{"text": "answer"}]},
+			"finishReason": "STOP"
+		}],
+		"usageMetadata": {
+			"promptTokenCount": 100,
+			"candidatesTokenCount": 7,
+			"cachedContentTokenCount": 91,
+			"totalTokenCount": 107
+		},
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	var param any
+	ctx := context.Background()
+	output := bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, finishChunk, &param), nil)
+	outputText := string(output)
+
+	var delta gjson.Result
+	for _, line := range strings.Split(outputText, "\n") {
+		if strings.HasPrefix(line, "data: ") {
+			if ev := gjson.Parse(line[len("data: "):]); ev.Get("type").String() == "message_delta" {
+				delta = ev.Get("usage")
+				break
+			}
+		}
+	}
+	if !delta.Exists() {
+		t.Fatalf("expected a message_delta with usage, got: %s", outputText)
+	}
+	if got := delta.Get("input_tokens").Int(); got != 9 {
+		t.Fatalf("input_tokens must exclude the cached part (100-91), got %d: %s", got, outputText)
+	}
+	if got := delta.Get("cache_read_input_tokens").Int(); got != 91 {
+		t.Fatalf("cache_read_input_tokens must carry the cached part, got %d: %s", got, outputText)
+	}
+}
+
+func TestConvertGeminiResponseToClaudeNonStream_SplitsCachedInputTokens(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":"hi"}]}`)
+	geminiResponse := []byte(`{
+		"candidates": [{
+			"content": {"parts": [{"text": "answer"}]},
+			"finishReason": "STOP"
+		}],
+		"usageMetadata": {
+			"promptTokenCount": 100,
+			"candidatesTokenCount": 7,
+			"cachedContentTokenCount": 91,
+			"totalTokenCount": 107
+		},
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	ctx := context.Background()
+	output := ConvertGeminiResponseToClaudeNonStream(ctx, "gemini-test", requestJSON, requestJSON, geminiResponse, nil)
+	outputJSON := gjson.ParseBytes(output)
+
+	if got := outputJSON.Get("usage.input_tokens").Int(); got != 9 {
+		t.Fatalf("input_tokens must exclude the cached part (100-91), got %d: %s", got, string(output))
+	}
+	if got := outputJSON.Get("usage.cache_read_input_tokens").Int(); got != 91 {
+		t.Fatalf("cache_read_input_tokens must carry the cached part, got %d: %s", got, string(output))
+	}
+}


### PR DESCRIPTION
## Problem

`ConvertGeminiResponseToClaude` and `ConvertGeminiResponseToClaudeNonStream` write `usageMetadata.promptTokenCount` into Claude `usage.input_tokens` and drop `cachedContentTokenCount` entirely. Gemini's `promptTokenCount` is the **total** prompt **including** the cached part; Claude's `input_tokens` excludes cache (`cache_read_input_tokens` carries it). Downstream Claude-format consumers therefore:

- see a cache rate of 0%,
- bill cached reads at the full input price.

Observed in production: an aistudio-channel session with a real ~86% cache rate was recorded as 0% cached by an Open WebUI quota-metering filter; the same session through the antigravity channel was reported correctly, because `antigravity_claude_response.go` already performs the split.

Closes #5238

## Fix

Mirror the antigravity translator in both the streaming `message_delta` path and the non-stream path:

- `input_tokens = promptTokenCount - cachedContentTokenCount`
- emit `usage.cache_read_input_tokens` when the cached part is > 0

Two new unit tests pin both paths (they fail on current dev and pass with the fix):

- `TestConvertGeminiResponseToClaude_SplitsCachedInputTokens`
- `TestConvertGeminiResponseToClaudeNonStream_SplitsCachedInputTokens`

## Scope notes

- The streaming `message_start` event still emits hardcoded zero usage (same as the antigravity translator). Downstream cumulative-delta consumers are unaffected because the terminal `message_delta` carries the full usage. Left untouched to keep this fix focused.
- `go test ./internal/translator/...` and `go build ./cmd/server/` pass.