### PR TITLE
fix(handlers): return 400 for image-only models on non-image endpoints

### DIFF
--- a/internal/clienterror/client_error.go
+++ b/internal/clienterror/client_error.go
@@ -95,7 +95,7 @@ func IsRequestFault(status int, err error) bool {
 	if hasRequestFaultBody(err) {
 		return true
 	}
-	if err != nil && IsItemNotPersisted(err.Error()) {
+	if err != nil && (IsItemNotPersisted(err.Error()) || isImageOnlyModelEndpointMismatch(err.Error())) {
 		return true
 	}
 	switch status {
@@ -122,6 +122,22 @@ func IsItemNotPersisted(message string) bool {
 	return strings.Contains(lower, "item with id") &&
 		strings.Contains(lower, "not found") &&
 		strings.Contains(lower, "items are not persisted when `store` is set to false")
+}
+
+// isImageOnlyModelEndpointMismatch recognizes an image-only model rejected on a
+// non-image endpoint when the message arrives as plain text, which is how an
+// upstream CLIProxyAPI node that predates the structured body reports it. This
+// proxy's own rejection is a JSON body already covered by hasRequestFaultBody,
+// so only the forwarded plain-text form needs matching here. All three markers
+// are required so that an unrelated failure whose message happens to mention an
+// image route is not reclassified: the fault belongs to the request, so the
+// local credential must not be penalized for it, and the client must call
+// /v1/images/generations or /v1/images/edits instead.
+func isImageOnlyModelEndpointMismatch(message string) bool {
+	lower := strings.ToLower(message)
+	return strings.Contains(lower, "model") &&
+		strings.Contains(lower, "only supported on") &&
+		(strings.Contains(lower, "/v1/images/generations") || strings.Contains(lower, "/v1/images/edits"))
 }
 
 func hasAuthenticationErrorBody(err error) bool {

--- a/internal/clienterror/client_error_test.go
+++ b/internal/clienterror/client_error_test.go
@@ -183,6 +183,32 @@ func TestIsRequestFault(t *testing.T) {
 			want:   true,
 		},
 		{
+			name:   "image-only model endpoint mismatch plain text",
+			status: http.StatusServiceUnavailable,
+			err:    errors.New("model gpt-image-2 is only supported on /v1/images/generations and /v1/images/edits"),
+			want:   true,
+		},
+		{
+			name:   "only-supported-on without image path is not image mismatch",
+			status: http.StatusServiceUnavailable,
+			err:    errors.New("feature is only supported on gpt-4"),
+		},
+		{
+			name:   "image path without only-supported-on is not request fault",
+			status: http.StatusBadGateway,
+			err:    errors.New("POST /v1/images/generations failed: unexpected EOF"),
+		},
+		{
+			name:   "only-supported-on image route without model is not image mismatch",
+			status: http.StatusBadGateway,
+			err:    errors.New("streaming is only supported on /v1/images/generations"),
+		},
+		{
+			name:   "image prefix alone is too weak to be an image mismatch",
+			status: http.StatusServiceUnavailable,
+			err:    errors.New("model gpt-image-2 is only supported on /v1/images"),
+		},
+		{
 			// An upstream internal error is not a request fault: it must stay eligible
 			// for credential rotation and (credential, model) cooldown.
 			name:   "upstream unknown internal error",

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -29,12 +29,16 @@ var imageOnlyBuiltinModelIDs = map[string]struct{}{
 	xaiBuiltinImage20ModelID:      {},
 }
 
-// IsImageOnlyModel reports whether modelID is a built-in image-only model.
-// Callers must pass a bare model ID: provider prefixes and thinking suffixes are
-// not stripped here.
+// IsImageOnlyModel reports whether modelID is a built-in or dynamically
+// registered image-only model. Callers must pass a bare model ID: provider
+// prefixes and thinking suffixes are not stripped here.
 func IsImageOnlyModel(modelID string) bool {
-	_, ok := imageOnlyBuiltinModelIDs[strings.ToLower(strings.TrimSpace(modelID))]
-	return ok
+	trimmedModelID := strings.TrimSpace(modelID)
+	if _, ok := imageOnlyBuiltinModelIDs[strings.ToLower(trimmedModelID)]; ok {
+		return true
+	}
+	info := LookupModelInfo(trimmedModelID)
+	return info != nil && info.Type == OpenAIImageModelType
 }
 
 // staticModelsJSON mirrors the top-level structure of models.json.

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -17,6 +17,26 @@ const (
 	xaiBuiltinVideo15PreviewID    = "grok-imagine-video-1.5-preview"
 )
 
+// imageOnlyBuiltinModelIDs lists the built-in models that can only be served by
+// the image endpoints (/v1/images/generations and /v1/images/edits). It is keyed
+// off the same constants used to register the built-ins, so a new image model is
+// declared in exactly one place.
+var imageOnlyBuiltinModelIDs = map[string]struct{}{
+	codexBuiltinImage15ModelID:    {},
+	codexBuiltinImageModelID:      {},
+	xaiBuiltinImageModelID:        {},
+	xaiBuiltinImageQualityModelID: {},
+	xaiBuiltinImage20ModelID:      {},
+}
+
+// IsImageOnlyModel reports whether modelID is a built-in image-only model.
+// Callers must pass a bare model ID: provider prefixes and thinking suffixes are
+// not stripped here.
+func IsImageOnlyModel(modelID string) bool {
+	_, ok := imageOnlyBuiltinModelIDs[strings.ToLower(strings.TrimSpace(modelID))]
+	return ok
+}
+
 // staticModelsJSON mirrors the top-level structure of models.json.
 type staticModelsJSON struct {
 	Claude      []*ModelInfo `json:"claude"`

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -1,6 +1,9 @@
 package registry
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestGetStaticModelDefinitionsByChannelSupportsGeminiInteractions(t *testing.T) {
 	models := GetStaticModelDefinitionsByChannel("gemini-interactions")
@@ -109,5 +112,56 @@ func TestAntigravityWebSearchModelForRequiresRequestedModelCapability(t *testing
 	}
 	if got := AntigravityWebSearchModelFor("unknown-model"); got != "" {
 		t.Fatalf("unknown model should not get Antigravity web search model, got %q", got)
+	}
+}
+
+func TestIsImageOnlyModel(t *testing.T) {
+	for _, id := range []string{
+		codexBuiltinImage15ModelID,
+		codexBuiltinImageModelID,
+		xaiBuiltinImageModelID,
+		xaiBuiltinImageQualityModelID,
+		xaiBuiltinImage20ModelID,
+	} {
+		if !IsImageOnlyModel(id) {
+			t.Fatalf("IsImageOnlyModel(%q) = false, want true", id)
+		}
+		if !IsImageOnlyModel(" " + strings.ToUpper(id) + " ") {
+			t.Fatalf("IsImageOnlyModel(%q) must ignore case and surrounding space", id)
+		}
+	}
+
+	// Video built-ins and chat models keep their existing routing.
+	for _, id := range []string{
+		xaiBuiltinVideoModelID,
+		xaiBuiltinVideo15ModelID,
+		xaiBuiltinVideo15PreviewID,
+		"gpt-5.6-luna",
+		"grok-imagine",
+		"gpt-image",
+		"",
+	} {
+		if IsImageOnlyModel(id) {
+			t.Fatalf("IsImageOnlyModel(%q) = true, want false", id)
+		}
+	}
+}
+
+// TestImageOnlyBuiltinsAreRegistered keeps the image-only set in sync with the
+// built-in definitions: every entry must still be injected by WithCodexBuiltins
+// or WithXAIBuiltins, so a renamed built-in cannot silently stop being rejected
+// on chat-style endpoints.
+func TestImageOnlyBuiltinsAreRegistered(t *testing.T) {
+	registered := make(map[string]struct{})
+	for _, model := range append(WithCodexBuiltins(nil), WithXAIBuiltins(nil)...) {
+		if model == nil {
+			continue
+		}
+		registered[strings.ToLower(strings.TrimSpace(model.ID))] = struct{}{}
+	}
+	for id := range imageOnlyBuiltinModelIDs {
+		if _, ok := registered[id]; !ok {
+			t.Fatalf("image-only model %q is not registered as a built-in", id)
+		}
 	}
 }

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -116,6 +116,20 @@ func TestAntigravityWebSearchModelForRequiresRequestedModelCapability(t *testing
 }
 
 func TestIsImageOnlyModel(t *testing.T) {
+	modelRegistry := GetGlobalRegistry()
+	const dynamicImageModelID = "registry-dynamic-image-model"
+	modelRegistry.RegisterClient("registry-dynamic-image-client", "openai-compatibility", []*ModelInfo{{
+		ID:   dynamicImageModelID,
+		Type: OpenAIImageModelType,
+	}})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient("registry-dynamic-image-client")
+	})
+
+	if !IsImageOnlyModel(dynamicImageModelID) {
+		t.Fatalf("IsImageOnlyModel(%q) = false, want true", dynamicImageModelID)
+	}
+
 	for _, id := range []string{
 		codexBuiltinImage15ModelID,
 		codexBuiltinImageModelID,

--- a/sdk/api/handlers/handlers_model_router_test.go
+++ b/sdk/api/handlers/handlers_model_router_test.go
@@ -653,9 +653,11 @@ func TestHandlerProvidersForExecutionRejectsImageOnlyModelOnProviderRoute(t *tes
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, _, errMsg := handler.providersForExecution("ignored", tc.originalModel, false, tc.decision, modelExecutionOptions{})
-			if errMsg == nil || errMsg.StatusCode != http.StatusServiceUnavailable {
-				t.Fatalf("providersForExecution() error = %+v, want image-only service unavailable", errMsg)
+			model := tc.decision.Model
+			if model == "" {
+				model = tc.originalModel
 			}
+			assertImageOnlyModelClientError(t, errMsg, model)
 		})
 	}
 }

--- a/sdk/api/handlers/handlers_request_details_test.go
+++ b/sdk/api/handlers/handlers_request_details_test.go
@@ -165,8 +165,19 @@ func TestGetRequestDetails_UnknownModelErrorResistsJSONInjection(t *testing.T) {
 
 func TestGetRequestDetails_ImageModelReturns400(t *testing.T) {
 	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, coreauth.NewManager(nil, nil, nil))
+	modelRegistry := registry.GetGlobalRegistry()
+	const dynamicImageModelClientID = "test-request-details-dynamic-image-client"
+	const dynamicImageModelID = "test-request-details-dynamic-image-model"
+	modelRegistry.RegisterClient(dynamicImageModelClientID, "openai-compatibility", []*registry.ModelInfo{{
+		ID:   dynamicImageModelID,
+		Type: registry.OpenAIImageModelType,
+	}})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(dynamicImageModelClientID)
+	})
 
 	imageOnlyModels := []string{
+		dynamicImageModelID,
 		"gpt-image-1.5",
 		"gpt-image-2",
 		"codex/gpt-image-2",

--- a/sdk/api/handlers/handlers_request_details_test.go
+++ b/sdk/api/handlers/handlers_request_details_test.go
@@ -11,7 +11,10 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
@@ -160,7 +163,7 @@ func TestGetRequestDetails_UnknownModelErrorResistsJSONInjection(t *testing.T) {
 	}
 }
 
-func TestGetRequestDetails_ImageModelReturns503(t *testing.T) {
+func TestGetRequestDetails_ImageModelReturns400(t *testing.T) {
 	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, coreauth.NewManager(nil, nil, nil))
 
 	imageOnlyModels := []string{
@@ -177,19 +180,7 @@ func TestGetRequestDetails_ImageModelReturns503(t *testing.T) {
 	for _, model := range imageOnlyModels {
 		t.Run(model, func(t *testing.T) {
 			_, _, errMsg := handler.getRequestDetails(model)
-			if errMsg == nil {
-				t.Fatalf("expected error for %s, got nil", model)
-			}
-			if errMsg.StatusCode != http.StatusServiceUnavailable {
-				t.Fatalf("unexpected status code: got %d want %d", errMsg.StatusCode, http.StatusServiceUnavailable)
-			}
-			if errMsg.Error == nil {
-				t.Fatalf("expected error message, got nil")
-			}
-			msg := errMsg.Error.Error()
-			if !strings.Contains(msg, "/v1/images/generations") || !strings.Contains(msg, "/v1/images/edits") {
-				t.Fatalf("unexpected error message: %q", msg)
-			}
+			assertImageOnlyModelClientError(t, errMsg, model)
 		})
 	}
 }
@@ -213,11 +204,7 @@ func TestValidateImageOnlyModel_AllowsImageEndpoints(t *testing.T) {
 			if errMsg := handler.validateImageOnlyModel(model, true); errMsg != nil {
 				t.Fatalf("validateImageOnlyModel(%q, true) = %+v, want nil", model, errMsg)
 			}
-			if errMsg := handler.validateImageOnlyModel(model, false); errMsg == nil {
-				t.Fatalf("validateImageOnlyModel(%q, false) = nil, want image-only error", model)
-			} else if errMsg.StatusCode != http.StatusServiceUnavailable {
-				t.Fatalf("unexpected status code: got %d want %d", errMsg.StatusCode, http.StatusServiceUnavailable)
-			}
+			assertImageOnlyModelClientError(t, handler.validateImageOnlyModel(model, false), model)
 		})
 	}
 }
@@ -277,12 +264,46 @@ func TestExecuteImageWithAuthManager_AllowsImageOnlyModels(t *testing.T) {
 			}
 
 			_, _, errMsg = handler.ExecuteWithAuthManager(context.Background(), "openai-image", model, body, "")
-			if errMsg == nil {
-				t.Fatal("expected image-only rejection for non-image execution path, got nil")
-			}
-			if errMsg.Error == nil || !strings.Contains(errMsg.Error.Error(), "only supported on /v1/images/generations") {
-				t.Fatalf("unexpected non-image execution error: %+v", errMsg)
-			}
+			assertImageOnlyModelClientError(t, errMsg, model)
 		})
+	}
+}
+
+func assertImageOnlyModelClientError(t *testing.T, errMsg *interfaces.ErrorMessage, requestedModel string) {
+	t.Helper()
+	if errMsg == nil || errMsg.Error == nil {
+		t.Fatal("expected image-only error")
+	}
+	if errMsg.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", errMsg.StatusCode, http.StatusBadRequest)
+	}
+	body := errMsg.Error.Error()
+	if !json.Valid([]byte(body)) {
+		t.Fatalf("error body is not valid JSON: %s", body)
+	}
+	if got := gjson.Get(body, "error.type").String(); got != "invalid_request_error" {
+		t.Fatalf("error.type = %q, want invalid_request_error; body=%s", got, body)
+	}
+	if got := gjson.Get(body, "error.code").String(); got != "unsupported_value" {
+		t.Fatalf("error.code = %q, want unsupported_value; body=%s", got, body)
+	}
+	// Emitting model_not_supported would make an upstream-facing proxy suspend the
+	// (credential, model) pair for hours over a client mistake.
+	if strings.Contains(body, "model_not_supported") {
+		t.Fatalf("body must not contain model_not_supported; body=%s", body)
+	}
+	if got := gjson.Get(body, "error.param").String(); got != "model" {
+		t.Fatalf("error.param = %q, want model; body=%s", got, body)
+	}
+	base := strings.TrimSpace(thinking.ParseSuffix(requestedModel).ModelName)
+	if base == "" {
+		base = strings.TrimSpace(requestedModel)
+	}
+	wantMsg := "model " + routeModelBaseName(base) + " is only supported on /v1/images/generations and /v1/images/edits"
+	if got := gjson.Get(body, "error.message").String(); got != wantMsg {
+		t.Fatalf("error.message = %q, want %q", got, wantMsg)
+	}
+	if !clienterror.IsRequestFault(errMsg.StatusCode, errMsg.Error) {
+		t.Fatalf("image-only mismatch must be a request fault; status=%d body=%s", errMsg.StatusCode, body)
 	}
 }

--- a/sdk/api/handlers/handlers_routing.go
+++ b/sdk/api/handlers/handlers_routing.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/router-for-me/CLIProxyAPI/v7/internal/constant"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -229,21 +230,32 @@ func (h *BaseAPIHandler) validateImageOnlyModel(modelName string, allowImageMode
 		baseModel = strings.TrimSpace(modelName)
 	}
 	if isOpenAIImageOnlyModel(baseModel) && !allowImageModel {
+		message := fmt.Sprintf("model %s is only supported on /v1/images/generations and /v1/images/edits", routeModelBaseName(baseModel))
+		// The code is deliberately unsupported_value rather than model_not_supported:
+		// the credential cooldown path matches the literal "model_not_supported"
+		// anywhere in an upstream error message, so emitting it would make a proxy
+		// chained in front of this one suspend the (credential, model) pair for hours
+		// over a pure client mistake.
+		body := `{"error":{"message":"","type":"invalid_request_error","code":"unsupported_value","param":"model"}}`
+		body, errSet := sjson.Set(body, "error.message", message)
+		if errSet != nil {
+			// Drop the model name if encoding fails so a quote cannot corrupt the JSON
+			// object or overwrite error.code the way a formatted literal would.
+			body = `{"error":{"message":"model is only supported on /v1/images/generations and /v1/images/edits","type":"invalid_request_error","code":"unsupported_value","param":"model"}}`
+		}
 		return &interfaces.ErrorMessage{
-			StatusCode: http.StatusServiceUnavailable,
-			Error:      fmt.Errorf("model %s is only supported on /v1/images/generations and /v1/images/edits", routeModelBaseName(baseModel)),
+			StatusCode: http.StatusBadRequest,
+			Error:      errors.New(body),
 		}
 	}
 	return nil
 }
 
+// isOpenAIImageOnlyModel reports whether the requested model can only run on the
+// image endpoints. The model set lives in the registry alongside the built-in
+// definitions so a newly added image model does not have to be duplicated here.
 func isOpenAIImageOnlyModel(model string) bool {
-	switch strings.ToLower(strings.TrimSpace(routeModelBaseName(model))) {
-	case "gpt-image-1.5", "gpt-image-2", "grok-imagine-image", "grok-imagine-image-quality", "grok-imagine-image-2.0":
-		return true
-	default:
-		return false
-	}
+	return registry.IsImageOnlyModel(routeModelBaseName(model))
 }
 
 func routeModelBaseName(model string) string {

--- a/sdk/cliproxy/auth/image_only_model_cooldown_test.go
+++ b/sdk/cliproxy/auth/image_only_model_cooldown_test.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+)
+
+// imageOnlyModelRejectionBody mirrors the body returned by
+// sdk/api/handlers.validateImageOnlyModel. A proxy chained in front of this one
+// receives it verbatim, so it must not look like a credential-level model
+// support failure.
+const imageOnlyModelRejectionBody = `{"error":{"message":"model gpt-image-2 is only supported on /v1/images/generations and /v1/images/edits","type":"invalid_request_error","code":"unsupported_value","param":"model"}}`
+
+// TestImageOnlyModelRejectionDoesNotPenalizeCredential pins the interaction
+// between the image-only rejection body and the credential cooldown path.
+//
+// isModelSupportErrorMessage matches the literal "model_not_supported" anywhere
+// in an upstream message, and isRequestInvalidError consults it before
+// clienterror.IsRequestFault. So a rejection carrying that code would suspend the
+// (credential, model) pair for 12 hours even though the request itself is at
+// fault and no other credential could satisfy it.
+func TestImageOnlyModelRejectionDoesNotPenalizeCredential(t *testing.T) {
+	err := &Error{HTTPStatus: http.StatusBadRequest, Message: imageOnlyModelRejectionBody}
+
+	if isModelSupportResultError(err) {
+		t.Fatalf("image-only rejection must not be treated as a credential model-support failure: %s", err.Message)
+	}
+	if !shouldSkipCredentialCooldown(err) {
+		t.Fatalf("image-only rejection must skip credential cooldown: %s", err.Message)
+	}
+
+	// Guard the root cause directly so a future edit to the emitted code is caught
+	// here rather than silently suspending credentials in production.
+	penalized := &Error{HTTPStatus: http.StatusBadRequest, Message: `{"error":{"code":"model_not_supported"}}`}
+	if !isModelSupportResultError(penalized) {
+		t.Fatal("expected model_not_supported to still drive the credential model-support path")
+	}
+	if shouldSkipCredentialCooldown(penalized) {
+		t.Fatal("expected model_not_supported to still enter the cooldown path")
+	}
+}


### PR DESCRIPTION
## Summary

- return HTTP 400 with a structured `invalid_request_error` when image-only built-in models are requested on chat, Responses, count, or other non-image endpoints
- classify both the new structured response and legacy plain-text upstream response as request faults so credentials are not rotated or cooled down
- centralize the built-in image-only model IDs in the registry and add routing/cooldown regression coverage

## Testing

- `go test ./internal/clienterror ./internal/registry ./sdk/api/handlers ./sdk/cliproxy/auth -count=1`
- `go build -o /tmp/cpa-review-head-build ./cmd/server`
- `git diff --check upstream/dev..HEAD`
