### PR TITLE
WARE-177: fix(signature): reject foreign thinking signatures in Claude compat sanitizer

### DIFF
--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -14,8 +14,9 @@ type ClaudeMessagesSignatureSanitizeOptions struct {
 	DropEmptyMessages             bool
 	DropToolSignatures            bool
 	DropEmptyThinkingPlaceholders bool
-	// PreserveEmptyThinkingBlocks preserves compatibility-mode thinking blocks
-	// together with their original signatures, including opaque signatures.
+	// PreserveEmptyThinkingBlocks keeps compatibility-mode thinking block shape
+	// (including the signature member). Incompatible or opaque signatures are
+	// still cleared; this flag does not bypass provider validation.
 	PreserveEmptyThinkingBlocks bool
 }
 
@@ -124,10 +125,53 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 				continue
 			}
 
+			// Replay provenance is added only internally by the executor after the
+			// sanitizer has already run. Any client-supplied marker is untrusted and
+			// must be stripped so it cannot bypass signature validation.
+			if part.Get("_cliproxy_replay_provenance").Exists() {
+				updated, _ := sjson.Delete(part.Raw, "_cliproxy_replay_provenance")
+				part = gjson.Parse(updated)
+				messageModified = true
+			}
+
 			rawSignature := part.Get("signature").String()
 			if opts.PreserveEmptyThinkingBlocks {
-				report.Preserved++
-				keptParts = append(keptParts, part.Raw)
+				// In compat mode the block shape must survive, but the signature still
+				// needs to be normalized, emulated, or stripped to avoid sending an
+				// incompatible or opaque signature to the upstream.
+				decision := DecideSignatureCompatibilityForModel(targetProvider, opts.TargetModel, rawSignature, SignatureBlockKindClaudeThinking)
+				decision.Reason = fmt.Sprintf("messages[%d].content[%d]: %s", i, j, decision.Reason)
+				report.Decisions = append(report.Decisions, decision)
+
+				switch decision.Action {
+				case SignatureActionPreserve:
+					report.Preserved++
+					if decision.NormalizedSignature != "" && decision.NormalizedSignature != rawSignature {
+						updated, _ := sjson.Set(part.Raw, "signature", decision.NormalizedSignature)
+						keptParts = append(keptParts, updated)
+						messageModified = true
+					} else {
+						keptParts = append(keptParts, part.Raw)
+					}
+				case SignatureActionReplaceWithGeminiBypass:
+					report.ReplacedSignatures++
+					updated, _ := sjson.Set(part.Raw, "signature", decision.ReplacementSignature)
+					keptParts = append(keptParts, updated)
+					messageModified = true
+				default:
+					// DropBlock, DropSignature, or NoCompatibleReplacement: keep the
+					// block shape for the compat endpoint and preserve empty placeholders
+					// with their required signature member.
+					if isEmptyClaudeThinkingPlaceholder(part) {
+						report.Preserved++
+						keptParts = append(keptParts, part.Raw)
+					} else {
+						report.DroppedSignatures++
+						updated, _ := sjson.Set(part.Raw, "signature", "")
+						keptParts = append(keptParts, updated)
+					}
+					messageModified = true
+				}
 				continue
 			}
 			if targetProvider == SignatureProviderClaude && isEmptyClaudeThinkingPlaceholder(part) && !opts.DropEmptyThinkingPlaceholders {

--- a/internal/signature/claude_messages_sanitize_compat_test.go
+++ b/internal/signature/claude_messages_sanitize_compat_test.go
@@ -1,6 +1,8 @@
 package signature
 
 import (
+	"bytes"
+	"encoding/base64"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -16,12 +18,99 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamPreservesEmptyThinkingInCompatMo
 
 	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "deepseek-v4", true)
 	part := gjson.GetBytes(withCompat, "messages.0.content.0")
-	if part.Get("type").String() != "thinking" || part.Get("signature").String() != "" {
-		t.Fatalf("compat sanitizer dropped empty thinking: %s", withCompat)
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() {
+		t.Fatalf("compat sanitizer dropped empty thinking or its signature member: %s", withCompat)
 	}
 }
 
-func TestSanitizeClaudeMessagesForClaudeUpstreamPreservesOpaqueThinkingSignatureInCompatMode(t *testing.T) {
+func TestSanitizeClaudeMessagesForClaudeUpstreamRetainsEmptySignatureOnGeminiPrefixInCompatMode(t *testing.T) {
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"gemini#EgI="}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not retain empty signature member on foreign-prefixed thinking block: %s", withCompat)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamRetainsEmptySignatureOnMislabeledClaudePrefixInCompatMode(t *testing.T) {
+	geminiSig := testGemini3ThoughtSignature([]byte{0x01, 0x0c, 0x39, 0xd6, 0xc7, 0x34})
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"claude#` + geminiSig + `"}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not retain empty signature member on mislabeled claude# block: %s", withCompat)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamRetainsEmptySignatureOnNestedClaudePrefixInCompatMode(t *testing.T) {
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"claude#vendor#EgI="}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not retain empty signature member on nested claude# block: %s", withCompat)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamRetainsEmptySignatureOnUnknownVendorPrefixInCompatMode(t *testing.T) {
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"vendor#EgI="}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not retain empty signature member on unknown-vendor block: %s", withCompat)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamNormalizesWhitespacePaddedShortSignatureInCompatMode(t *testing.T) {
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"  EgI=  "}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() {
+		t.Fatalf("compat sanitizer dropped the thinking block: %s", withCompat)
+	}
+	if got := part.Get("signature").String(); got != "" {
+		t.Fatalf("compat sanitizer forwarded short signature %q, want empty signature", got)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamRejectsGrokOpaqueERInCompatMode(t *testing.T) {
+	// Grok/xAI encrypted_content is uniformly distributed and can base64-encode
+	// to a string starting with 'E' or 'R', but it is not a valid Claude
+	// thinking signature and must be cleared before forwarding.
+	grokLike := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	sig := base64.StdEncoding.EncodeToString(grokLike)
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"` + sig + `"}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not clear Grok-style E/R opaque signature: %s", withCompat)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamStripsClientReplayProvenanceMarkerInCompatMode(t *testing.T) {
+	// Client-supplied _cliproxy_replay_provenance must not bypass signature
+	// validation. The marker is stripped and the foreign signature is cleared.
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"opaque-foreign-sig","_cliproxy_replay_provenance":true}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" {
+		t.Fatalf("compat sanitizer dropped the thinking block: %s", withCompat)
+	}
+	if part.Get("_cliproxy_replay_provenance").Exists() {
+		t.Fatalf("compat sanitizer did not strip client-supplied replay provenance marker: %s", withCompat)
+	}
+	if part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer preserved foreign signature via client-supplied marker: %s", withCompat)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamStripsOpaqueThinkingSignatureInCompatMode(t *testing.T) {
 	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"opaque-deepseek-id"}]}]}`)
 
 	withoutCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "deepseek-v4")
@@ -31,7 +120,7 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamPreservesOpaqueThinkingSignature
 
 	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "deepseek-v4", true)
 	part := gjson.GetBytes(withCompat, "messages.0.content.0")
-	if part.Get("type").String() != "thinking" || part.Get("signature").String() != "opaque-deepseek-id" {
-		t.Fatalf("compat sanitizer dropped opaque signature: %s", withCompat)
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not retain empty signature member on opaque-signature block: %s", withCompat)
 	}
 }


### PR DESCRIPTION
## Summary

Narrow first slice of #5150. One subsystem (`internal/signature`), two files.

Compat mode used to keep Claude thinking-block shape by forwarding the original `signature`, including foreign and opaque blobs. That is a foreign signature presented as Claude's own. Compat mode now runs `DecideSignatureCompatibilityForModel`:

- thinking block shape and the `signature` member stay
- incompatible / opaque / vendor-prefixed / short-synthetic values are cleared to `""`
- client-supplied `_cliproxy_replay_provenance` is stripped and cannot bypass validation
- empty thinking placeholders keep their required empty signature member

Not in this slice: thinking-replay cache, executor wiring, session-id helpers, `sdk/cliproxy/auth/session_cache.go`, trusted cache-born provenance bypass, export of `StripClaudeToolUseSignatureFields`. Those remain on #5150 for later slices.

## Cutoff

- Size vs `dev`: 2 files, +142 / −9.
- Parent: #5150. This PR does not replace or close it.
- Finding set for this slice is closed. Further auto-review rounds will be recorded and not worked, except the closed list: secret leak, data loss, resource leak, compatibility break.
- Artifact is ready for maintainer review.

WARE-177

## Test plan

- [x] Before: `go test ./internal/signature/ -count=1 -run TestSanitizeClaudeMessagesForClaudeUpstream` — 8 new compat cases FAIL on `origin/dev` (foreign signatures forwarded unchanged).
- [x] After: same command — 12 PASS; full `go test ./internal/signature/ -count=1` — 179 PASS; `go build ./...` clean.
