### PR TITLE
fix(codex): reduce Claude code-mode context overhead

### DIFF
--- a/internal/client/codex/models/models.go
+++ b/internal/client/codex/models/models.go
@@ -231,12 +231,14 @@ func applyCodexClientSearchToolSupport(entry map[string]any, id string, template
 
 func applyCodexClientModelMetadata(entry map[string]any, id string, model map[string]any, optimizeMultiAgentV2 bool) {
 	info := registry.LookupModelInfo(id)
+	isClaudeModel := strings.EqualFold(stringModelValue(model, "type"), "claude")
 
 	displayName := stringModelValue(model, "display_name")
 	description := stringModelValue(model, "description")
 	contextWindow := intModelValue(model, "context_length")
 
 	if info != nil {
+		isClaudeModel = isClaudeModel || strings.EqualFold(info.Type, "claude")
 		if info.DisplayName != "" {
 			displayName = info.DisplayName
 		}
@@ -271,6 +273,12 @@ func applyCodexClientModelMetadata(entry map[string]any, id string, model map[st
 	entry["display_name"] = displayName
 	entry["description"] = description
 	entry["prefer_websockets"] = false
+	if isClaudeModel {
+		entry["tool_mode"] = "code_mode_only"
+		entry["use_responses_lite"] = true
+		entry["include_skills_usage_instructions"] = false
+		entry["auto_compact_token_limit"] = 850000
+	}
 	if optimizeMultiAgentV2 {
 		entry["multi_agent_version"] = "v2"
 	}

--- a/internal/client/codex/models/models_test.go
+++ b/internal/client/codex/models/models_test.go
@@ -225,6 +225,30 @@ func TestCodexClientModelsResponse_RequiresTemplateAndCodexProvidersForSearchToo
 	}
 }
 
+func TestCodexClientModelsResponse_UsesCompactToolMetadataForClaudeModels(t *testing.T) {
+	models := []map[string]any{
+		{"id": "claude-opus-5", "type": "claude"},
+		{"id": "claude-sonnet-5", "type": "claude"},
+		{"id": "claude-fable-5", "type": "claude"},
+	}
+	resp := BuildResponse(models, func(string) []string { return []string{"claude"} }, false)
+
+	for _, model := range resp["models"].([]map[string]any) {
+		if got := stringModelValue(model, "tool_mode"); got != "code_mode_only" {
+			t.Errorf("%s tool_mode = %q, want code_mode_only", stringModelValue(model, "slug"), got)
+		}
+		if got, _ := model["use_responses_lite"].(bool); !got {
+			t.Errorf("%s use_responses_lite = false, want true", stringModelValue(model, "slug"))
+		}
+		if got, _ := model["include_skills_usage_instructions"].(bool); got {
+			t.Errorf("%s include_skills_usage_instructions = true, want false", stringModelValue(model, "slug"))
+		}
+		if got := intModelValue(model, "auto_compact_token_limit"); got != 850000 {
+			t.Errorf("%s auto_compact_token_limit = %d, want 850000", stringModelValue(model, "slug"), got)
+		}
+	}
+}
+
 func TestCodexClientModelsResponse_PreservesUltraReasoningEffort(t *testing.T) {
 	resp := BuildResponse([]map[string]any{{"id": "gpt-5.6-sol"}}, nil, false)
 	models, ok := resp["models"].([]map[string]any)

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -12,6 +12,10 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+const compactCodeModeExecDescription = `Run raw JavaScript in a V8 isolate to call nested tools through the global tools object; do not pass JSON or Markdown fences.
+Use ALL_TOOLS to discover tool names and descriptions, then call await tools.<name>(arguments).
+Return results with text(), image(), audio(), or generatedImage(). Other helpers: store(), load(), notify(), setTimeout(), clearTimeout(), exit(), and yield_control().`
+
 // ConvertOpenAIResponsesRequestToClaude transforms an OpenAI Responses API request
 // into a Claude Messages API request using only gjson/sjson for JSON handling.
 // It supports:
@@ -731,7 +735,11 @@ func convertResponsesToolDescriptorToClaude(descriptor responsesToolDescriptor) 
 	case "function":
 		return convertResponsesFunctionToolToClaude(descriptor.tool, overrideName)
 	case "custom":
-		return convertResponsesCustomToolToClaude(descriptor.tool, overrideName)
+		tool, ok := convertResponsesCustomToolToClaude(descriptor.tool, overrideName)
+		if ok && descriptor.namespace == "functions" && descriptor.childName == "exec" {
+			tool, _ = sjson.SetBytes(tool, "description", compactCodeModeExecDescription)
+		}
+		return tool, ok
 	case "web_search":
 		return convertResponsesWebSearchToolToClaude(descriptor.tool)
 	default:

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
@@ -685,6 +685,32 @@ func TestConvertOpenAIResponsesRequestToClaude_MergesAdditionalToolsAndPrefersTo
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToClaude_CompactsCodeModeExecDescription(t *testing.T) {
+	oversizedDescription := "Run JavaScript.\n" + strings.Repeat("nested tool schema ", 1000)
+	raw := []byte(fmt.Sprintf(`{
+		"model":"claude-test",
+		"input":[{"type":"additional_tools","tools":[{"type":"namespace","name":"functions","tools":[
+			{"type":"custom","name":"exec","description":%q},
+			{"type":"function","name":"wait","description":"wait","parameters":{"type":"object","properties":{}}}
+		]}]}]
+	}`, oversizedDescription))
+
+	root := gjson.ParseBytes(ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false))
+	if got := root.Get("tools.#").Int(); got != 2 {
+		t.Fatalf("tools count = %d, want exec and wait; output=%s", got, root.Raw)
+	}
+	description := root.Get(`tools.#(name=="functions__exec").description`).String()
+	if len(description) >= len(oversizedDescription) {
+		t.Fatalf("exec description was not compacted: got %d bytes, original %d", len(description), len(oversizedDescription))
+	}
+	if !strings.Contains(description, "ALL_TOOLS") {
+		t.Fatalf("compact exec description does not explain tool discovery: %q", description)
+	}
+	if !root.Get(`tools.#(name=="functions__wait")`).Exists() {
+		t.Fatal("sibling code-mode tool was dropped")
+	}
+}
+
 func TestConvertOpenAIResponsesRequestToClaude_DeduplicatesExpandedToolNames(t *testing.T) {
 	raw := []byte(`{
 		"model":"claude-test",


### PR DESCRIPTION
## Problem
Codex code-mode requests embed the full nested connector registry inside the `functions.exec` description when translated to Claude. With a large app catalogue this consumed roughly 650k tokens before the first user message and caused compaction to appear ineffective.

## Solution
- advertise compact Codex metadata for Claude models, including Responses Lite, code-mode-only tools, and an 850k auto-compaction threshold
- replace only the expanded `functions.exec` description with concise `ALL_TOOLS` discovery instructions while preserving the executable tool and every nested connector
- add regression coverage for both model metadata and tool-description compaction

## Verification
- `go test -count=1 ./...`
- `go build -o /private/tmp/cli-proxy-api-pr-check ./cmd/server`
- live Fable smoke test reduced first-request input from 654,197 to 48,654 tokens
- live tool-discovery smoke test still found all 46 Outlook Email tools without calling Outlook

## Screenshots / Recordings
Not applicable: backend translation and model metadata only.

Generated with an AI coding agent