### PR TITLE
feat(config): advertise OpenAI-compatible output limits

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -641,6 +641,7 @@ nonstream-keepalive-interval: 0
 #         alias: "kimi-k2"               # The alias used in the API.
 #         display-name: "Kimi K2"         # optional catalog display name
 #         max-context-length: 1048576    # optional: override Codex client context window metadata
+#         max-output-tokens: 64000       # optional: override Codex client max_tokens metadata
 #         image: false                   # optional: set true to allow this model on /v1/images/generations and /v1/images/edits (not chat/responses image input)
 #         input-modalities: [text, image] # optional: declare /v1/chat/completions and /v1/responses multimodal input for Codex clients. Use [text] for upstreams that reject multimodal tool result content.
 #         output-modalities: [text]       # optional: declare output modalities when known

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -715,6 +715,9 @@ type OpenAICompatibilityModel struct {
 	// MaxContextLength overrides the context window advertised to Codex clients.
 	MaxContextLength int `yaml:"max-context-length,omitempty" json:"max-context-length,omitempty"`
 
+	// MaxOutputTokens overrides the generation limit advertised to Codex clients.
+	MaxOutputTokens int `yaml:"max-output-tokens,omitempty" json:"max-output-tokens,omitempty"`
+
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
 

--- a/internal/config/max_context_length_test.go
+++ b/internal/config/max_context_length_test.go
@@ -84,3 +84,30 @@ openai-compatibility:
 		})
 	}
 }
+
+func TestOpenAICompatibilityMaxOutputTokensConfigDecoding(t *testing.T) {
+	const yamlConfig = `openai-compatibility:
+  - models:
+      - name: compat-upstream
+        max-output-tokens: 64000
+`
+	const jsonConfig = `{"openai-compatibility":[{"models":[{"name":"compat-upstream","max-output-tokens":64000}]}]}`
+
+	for _, testCase := range []struct {
+		name   string
+		decode func(*Config) error
+	}{
+		{name: "YAML", decode: func(cfg *Config) error { return yaml.Unmarshal([]byte(yamlConfig), cfg) }},
+		{name: "JSON", decode: func(cfg *Config) error { return json.Unmarshal([]byte(jsonConfig), cfg) }},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			var cfg Config
+			if err := testCase.decode(&cfg); err != nil {
+				t.Fatal(err)
+			}
+			if got := cfg.OpenAICompatibility[0].Models[0].MaxOutputTokens; got != 64000 {
+				t.Fatalf("max-output-tokens = %d, want 64000", got)
+			}
+		})
+	}
+}

--- a/internal/modelconfig/model_hash.go
+++ b/internal/modelconfig/model_hash.go
@@ -20,7 +20,7 @@ func ComputeOpenAICompatModelsHash(models []config.OpenAICompatibilityModel) str
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("image=%t", model.Image) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + "|" + fmt.Sprintf("is-compat=%t", model.IsCompat) + "|input=" + strings.Join(normalizeModalities(model.InputModalities), ",") + "|output=" + strings.Join(normalizeModalities(model.OutputModalities), ",") + thinkingHashSuffix(model.Thinking))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("image=%t", model.Image) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + "|" + fmt.Sprintf("is-compat=%t", model.IsCompat) + "|" + fmt.Sprintf("max-output=%d", model.MaxOutputTokens) + "|input=" + strings.Join(normalizeModalities(model.InputModalities), ",") + "|output=" + strings.Join(normalizeModalities(model.OutputModalities), ",") + thinkingHashSuffix(model.Thinking))
 		}
 	})
 	return hashJoined(keys)

--- a/internal/watcher/diff/model_hash_test.go
+++ b/internal/watcher/diff/model_hash_test.go
@@ -50,6 +50,14 @@ func TestComputeOpenAICompatModelsHashIncludesModalities(t *testing.T) {
 	}
 }
 
+func TestComputeOpenAICompatModelsHashIncludesMaxOutputTokens(t *testing.T) {
+	base := ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "model"}})
+	changed := ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "model", MaxOutputTokens: 64000}})
+	if base == changed {
+		t.Fatal("max-output-tokens did not change model hash")
+	}
+}
+
 func TestComputeOpenAICompatModelsHashPreservesRoutingOrderAndDuplicates(t *testing.T) {
 	a := []config.OpenAICompatibilityModel{
 		{Name: "gpt-4", Alias: "gpt4"},

--- a/sdk/cliproxy/config_model_max_context_length_test.go
+++ b/sdk/cliproxy/config_model_max_context_length_test.go
@@ -6,6 +6,18 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
 
+func TestBuildOpenAICompatibilityConfigModelsPropagatesMaxOutputTokens(t *testing.T) {
+	const want = 64000
+	model := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
+		Models: []config.OpenAICompatibilityModel{{
+			Name: "compat-upstream", Alias: "compat-alias", MaxOutputTokens: want,
+		}},
+	})[0]
+	if model.MaxCompletionTokens != want {
+		t.Fatalf("max completion tokens = %d, want %d", model.MaxCompletionTokens, want)
+	}
+}
+
 func TestBuildConfigModelsPropagatesMaxContextLength(t *testing.T) {
 	const want = 1048576
 

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -731,6 +731,9 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		if thinkingSupport == nil && !model.Image {
 			thinkingSupport = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
 		}
+		if model.MaxOutputTokens > 0 {
+			info.MaxCompletionTokens = model.MaxOutputTokens
+		}
 		info.Thinking = modelconfig.NormalizeThinkingSupport(thinkingSupport)
 		info.SupportedInputModalities = normalizeCompatConfigModalities(model.InputModalities)
 		info.SupportedOutputModalities = normalizeCompatConfigModalities(model.OutputModalities)


### PR DESCRIPTION
## Summary

Add an optional `max-output-tokens` override to configured OpenAI-compatible models and advertise it as `max_tokens` through the existing Codex-format detailed model catalog.

This intentionally leaves the strict default `GET /v1/models` response unchanged. Extended metadata remains scoped to:

```text
GET /v1/models?client_version=1
```

That follows the maintainer direction in #5119.

## Changes

- decode `openai-compatibility[].models[].max-output-tokens` from YAML and JSON;
- map positive configured values to the existing `ModelInfo.MaxCompletionTokens` field;
- reuse the existing Codex catalog conversion from `max_completion_tokens` to `max_tokens`;
- include the override in the OpenAI-compatible model hash so hot reload refreshes model metadata;
- document the option and add focused decoding, propagation, and hash regression tests.

## Relationship to existing work

#5123 proposes changing the default OpenAI-compatible model listing plus Home/global registry behavior. This PR does not replace or duplicate that broader approach: it implements only a configured OpenAI-compatible override on the already-supported Codex detailed catalog path recommended in #5119.

## Not included

- changes to the default `GET /v1/models` schema;
- Home model decoding or routing;
- global model-registry aggregation;
- Claude/Gemini model configuration;
- request token enforcement;
- changes under `internal/translator`.

## Verification

```text
go test ./internal/config ./sdk/cliproxy ./internal/watcher/diff ./internal/client/codex/models ./sdk/api/handlers/openai -count=1
go vet ./internal/config ./sdk/cliproxy ./internal/watcher/diff ./internal/client/codex/models ./sdk/api/handlers/openai
go build -o /tmp/cli-proxy-api ./cmd/server
bash .github/scripts/refresh-model-catalogs.sh
go build -o /tmp/cli-proxy-api ./cmd/server
```

The catalog refresh left the worktree clean. Both commits are signed and pass `git verify-commit`.
