### PR TITLE
fix(pluginhost): preserve nested execution status

### DIFF
--- a/internal/pluginhost/host_callbacks.go
+++ b/internal/pluginhost/host_callbacks.go
@@ -291,6 +291,13 @@ func (h *Host) callHostModelExecute(ctx context.Context, request []byte) ([]byte
 	})
 }
 
+func statusCodeFromError(err error) int {
+	if statusProvider, ok := err.(interface{ StatusCode() int }); ok {
+		return statusProvider.StatusCode()
+	}
+	return 0
+}
+
 func modelExecutionRequestFromPlugin(req pluginapi.HostModelExecutionRequest, skipPluginID string) handlers.ModelExecutionRequest {
 	return handlers.ModelExecutionRequest{
 		EntryProtocol:           req.EntryProtocol,
@@ -310,13 +317,36 @@ func modelExecutionError(errMsg *interfaces.ErrorMessage) error {
 	if errMsg == nil {
 		return nil
 	}
+	if errMsg.StatusCode > 0 {
+		return modelExecutionStatusError{cause: errMsg.Error, status: errMsg.StatusCode}
+	}
 	if errMsg.Error != nil {
 		return errMsg.Error
 	}
-	if errMsg.StatusCode > 0 {
-		return fmt.Errorf("model execution failed with status %d", errMsg.StatusCode)
-	}
 	return fmt.Errorf("model execution failed")
+}
+
+type modelExecutionStatusError struct {
+	cause  error
+	status int
+}
+
+func (err modelExecutionStatusError) Error() string {
+	if err.cause != nil {
+		return err.cause.Error()
+	}
+	if err.status > 0 {
+		return fmt.Sprintf("model execution failed with status %d", err.status)
+	}
+	return "model execution failed"
+}
+
+func (err modelExecutionStatusError) Unwrap() error {
+	return err.cause
+}
+
+func (err modelExecutionStatusError) StatusCode() int {
+	return err.status
 }
 
 func (h *Host) callHostLog(ctx context.Context, request []byte) ([]byte, error) {

--- a/internal/pluginhost/host_callbacks_test.go
+++ b/internal/pluginhost/host_callbacks_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -290,6 +291,48 @@ func TestHostModelExecuteCallback(t *testing.T) {
 	}
 	if got.Alt != "raw" {
 		t.Fatalf("alt = %q, want raw", got.Alt)
+	}
+}
+
+func TestHostModelExecuteCallbackPreservesErrorStatus(t *testing.T) {
+	host := New()
+	errSentinel := errors.New("usage limit reached")
+	host.SetModelExecutor(&fakeHostModelExecutor{
+		executeModel: func(context.Context, handlers.ModelExecutionRequest) (handlers.ModelExecutionResponse, *interfaces.ErrorMessage) {
+			return handlers.ModelExecutionResponse{}, &interfaces.ErrorMessage{
+				StatusCode: http.StatusTooManyRequests,
+				Error:      errSentinel,
+			}
+		},
+	})
+
+	rawReq, errMarshal := json.Marshal(rpcHostModelExecutionRequest{
+		HostModelExecutionRequest: pluginapi.HostModelExecutionRequest{
+			EntryProtocol: "openai",
+			ExitProtocol:  "openai",
+			Model:         "model-1",
+			Body:          []byte(`{"request":true}`),
+		},
+	})
+	if errMarshal != nil {
+		t.Fatalf("marshal request: %v", errMarshal)
+	}
+	_, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostModelExecute, rawReq)
+	if errCall == nil {
+		t.Fatal("callFromPlugin returned nil error")
+	}
+	if got := errCall.Error(); got != "usage limit reached" {
+		t.Fatalf("error = %q, want original message", got)
+	}
+	if !errors.Is(errCall, errSentinel) {
+		t.Fatalf("error does not preserve original cause: %v", errCall)
+	}
+	statusProvider, ok := errCall.(interface{ StatusCode() int })
+	if !ok {
+		t.Fatalf("error %T does not expose StatusCode", errCall)
+	}
+	if got := statusProvider.StatusCode(); got != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", got, http.StatusTooManyRequests)
 	}
 }
 

--- a/internal/pluginhost/host_callbacks_unix.go
+++ b/internal/pluginhost/host_callbacks_unix.go
@@ -43,7 +43,7 @@ func cliproxyHostCall(hostCtx unsafe.Pointer, method *C.char, request *C.uint8_t
 	ctx := withHostCallbackPluginID(context.Background(), entry.pluginID)
 	resp, errCall := entry.host.callFromPlugin(ctx, C.GoString(method), requestBytes)
 	if errCall != nil {
-		resp = marshalRPCError("host_call_failed", errCall.Error())
+		resp = marshalRPCError("host_call_failed", errCall.Error(), statusCodeFromError(errCall))
 	}
 	if len(resp) == 0 || response == nil {
 		return 0

--- a/internal/pluginhost/loader_windows.go
+++ b/internal/pluginhost/loader_windows.go
@@ -366,7 +366,7 @@ func windowsHostCall(hostCtx uintptr, methodPtr uintptr, requestPtr uintptr, req
 	ctx := withHostCallbackPluginID(context.Background(), entry.pluginID)
 	resp, errCall := entry.host.callFromPlugin(ctx, windowsString(methodPtr), request)
 	if errCall != nil {
-		resp = marshalRPCError("host_call_failed", errCall.Error())
+		resp = marshalRPCError("host_call_failed", errCall.Error(), statusCodeFromError(errCall))
 	}
 	if len(resp) == 0 || responsePtr == 0 {
 		return 0

--- a/internal/pluginhost/rpc_client.go
+++ b/internal/pluginhost/rpc_client.go
@@ -333,12 +333,17 @@ func marshalRPCEnvelope(result json.RawMessage) ([]byte, error) {
 	return json.Marshal(pluginabi.Envelope{OK: true, Result: result})
 }
 
-func marshalRPCError(code, message string) []byte {
+func marshalRPCError(code, message string, status ...int) []byte {
+	httpStatus := 0
+	if len(status) > 0 {
+		httpStatus = status[0]
+	}
 	raw, _ := json.Marshal(pluginabi.Envelope{
 		OK: false,
 		Error: &pluginabi.Error{
-			Code:    code,
-			Message: message,
+			Code:       code,
+			Message:    message,
+			HTTPStatus: httpStatus,
 		},
 	})
 	return raw

--- a/internal/pluginhost/rpc_client_error_test.go
+++ b/internal/pluginhost/rpc_client_error_test.go
@@ -71,6 +71,17 @@ func TestCallPluginReturnsPluginErrorWithoutMethodWrapper(t *testing.T) {
 	}
 }
 
+func TestMarshalRPCErrorPreservesHTTPStatus(t *testing.T) {
+	raw := marshalRPCError("host_call_failed", "usage limit reached", http.StatusTooManyRequests)
+	var envelope pluginabi.Envelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	if envelope.Error == nil || envelope.Error.HTTPStatus != http.StatusTooManyRequests {
+		t.Fatalf("error = %#v, want HTTP status %d", envelope.Error, http.StatusTooManyRequests)
+	}
+}
+
 func TestIsPluginErrorEnvelopeAcceptsNonzeroReturnEnvelope(t *testing.T) {
 	raw := marshalRPCError("plugin_error", "upstream failed")
 	if !isPluginErrorEnvelope(raw) {


### PR DESCRIPTION
## Problem

When a native plugin calls the host model-execution callback, an upstream failure arrives as `interfaces.ErrorMessage` with both an error and an HTTP status. The plugin host converted that value to a plain Go error, then serialized a `host_call_failed` RPC envelope without `http_status`.

The nested plugin therefore received the message but lost status-based behavior such as fail-closed `409`, upstream `429`, or gateway `502` handling.

## Changes

- preserve positive model-execution status in a small typed error while keeping the original message and cause;
- serialize that status into the existing `pluginabi.Error.HTTPStatus` field for both Unix/cgo and Windows native host callbacks;
- keep status-zero errors and existing `marshalRPCError` callers backward-compatible;
- add focused regression tests for the model callback error and serialized RPC envelope.

No SDK ABI fields or protocol versions change; this uses the existing `http_status` envelope field and existing `rpcError` decoder.

## Verification

```text
go test ./internal/pluginhost -count=1
go test -race ./internal/pluginhost -count=1
GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c ./internal/pluginhost
go build -o /tmp/cli-proxy-api ./cmd/server
bash .github/scripts/refresh-model-catalogs.sh
go build -o /tmp/cli-proxy-api ./cmd/server
git verify-commit HEAD
```

The catalog refresh left the worktree clean. `go vet ./internal/pluginhost` reports four existing cancel-path warnings identically on clean `origin/dev`; this patch adds no vet regression.
