### PR TITLE
feat(xai): discover OAuth account models

### DIFF
--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -47,7 +47,9 @@ const (
 	xaiTokenAuthValue           = "xai-grok-cli"
 	xaiClientVersionHeader      = "x-grok-client-version"
 	// Keep in sync with the current Grok CLI client version that chat-proxy expects.
-	xaiClientVersionValue         = "0.2.120"
+	xaiClientVersionValue = "0.2.120"
+	// XAIClientVersionValue is shared with account model discovery requests.
+	XAIClientVersionValue         = xaiClientVersionValue
 	xaiClientIdentifierHeader     = "x-grok-client-identifier"
 	xaiClientIdentifierValue      = "grok-shell"
 	xaiAuthenticateResponseHeader = "x-authenticateresponse"

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -47,9 +47,7 @@ const (
 	xaiTokenAuthValue           = "xai-grok-cli"
 	xaiClientVersionHeader      = "x-grok-client-version"
 	// Keep in sync with the current Grok CLI client version that chat-proxy expects.
-	xaiClientVersionValue = "0.2.120"
-	// XAIClientVersionValue is shared with account model discovery requests.
-	XAIClientVersionValue         = xaiClientVersionValue
+	xaiClientVersionValue         = "0.2.120"
 	xaiClientIdentifierHeader     = "x-grok-client-identifier"
 	xaiClientIdentifierValue      = "grok-shell"
 	xaiAuthenticateResponseHeader = "x-authenticateresponse"

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -47,15 +47,18 @@ const (
 	xaiTokenAuthValue           = "xai-grok-cli"
 	xaiClientVersionHeader      = "x-grok-client-version"
 	// Keep in sync with the current Grok CLI client version that chat-proxy expects.
-	xaiClientVersionValue = "0.2.120"
-	// XAIClientVersionValue is shared with account model discovery requests.
-	XAIClientVersionValue         = xaiClientVersionValue
+	xaiClientVersionValue         = "0.2.120"
 	xaiClientIdentifierHeader     = "x-grok-client-identifier"
 	xaiClientIdentifierValue      = "grok-shell"
 	xaiAuthenticateResponseHeader = "x-authenticateresponse"
 	xaiAuthenticateResponseValue  = "authenticate-response"
 	// xaiUsingAPIAttr enables the official API path for non-media HTTP chat.
 	xaiUsingAPIAttr = "using_api"
+)
+
+const (
+	// XAIClientVersionValue is shared with account model discovery requests.
+	XAIClientVersionValue = xaiClientVersionValue
 )
 
 // xaiXSearchToolJSON is the native X Search tool injected when enabled by config.

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -38,11 +38,8 @@ type Service struct {
 	// configRuntimeMu orders side-effecting runtime application after config commits.
 	configRuntimeMu        sync.Mutex
 	executorRegistrationMu sync.Mutex
-	// xaiModels caches the last successful account-level OAuth model discovery.
-	xaiModelsMu         sync.Mutex
-	xaiModels           map[string]xaiModelCacheEntry
-	configSequence      uint64
-	appliedRoutingState *routingRuntimeState
+	configSequence         uint64
+	appliedRoutingState    *routingRuntimeState
 
 	// configPath is the path to the configuration file.
 	configPath string

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -38,8 +38,11 @@ type Service struct {
 	// configRuntimeMu orders side-effecting runtime application after config commits.
 	configRuntimeMu        sync.Mutex
 	executorRegistrationMu sync.Mutex
-	configSequence         uint64
-	appliedRoutingState    *routingRuntimeState
+	// xaiModels caches the last successful account-level OAuth model discovery.
+	xaiModelsMu         sync.Mutex
+	xaiModels           map[string]xaiModelCacheEntry
+	configSequence      uint64
+	appliedRoutingState *routingRuntimeState
 
 	// configPath is the path to the configuration file.
 	configPath string

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -11,6 +11,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	log "github.com/sirupsen/logrus"
 )
 
 // registerModelsForAuth (re)binds provider models in the global registry using the core auth ID as client identifier.
@@ -153,6 +154,20 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 			if authKind == "apikey" {
 				excluded = entry.ExcludedModels
 			}
+		}
+		// OAuth model IDs are account-scoped; static definitions only enrich the
+		// metadata returned by the account's model endpoint.
+		if authKind == coreauth.AuthKindOAuth {
+			discovered, errDiscover := s.xaiModelsForAuth(ctx, a)
+			if errDiscover != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				log.Warnf("xai models: no usable account catalog for auth %s: %v", a.ID, errDiscover)
+				GlobalModelRegistry().UnregisterClient(a.ID)
+				return
+			}
+			models = discovered
 		}
 		models = applyExcludedModels(models, excluded)
 	default:

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -159,9 +159,14 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 		if authKind == coreauth.AuthKindOAuth {
 			discovered, errDiscover := s.xaiModelsForAuth(ctx, a)
 			if errDiscover != nil {
-				return
+				if ctx.Err() != nil {
+					return
+				}
+				// Discovery failures must not fall back to the static catalog.
+				models = nil
+			} else {
+				models = discovered
 			}
-			models = discovered
 		}
 		models = applyExcludedModels(models, excluded)
 	default:

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -11,7 +11,6 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
-	log "github.com/sirupsen/logrus"
 )
 
 // registerModelsForAuth (re)binds provider models in the global registry using the core auth ID as client identifier.
@@ -160,11 +159,6 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 		if authKind == coreauth.AuthKindOAuth {
 			discovered, errDiscover := s.xaiModelsForAuth(ctx, a)
 			if errDiscover != nil {
-				if ctx.Err() != nil {
-					return
-				}
-				log.Warnf("xai models: no usable account catalog for auth %s: %v", a.ID, errDiscover)
-				GlobalModelRegistry().UnregisterClient(a.ID)
 				return
 			}
 			models = discovered

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -333,12 +333,15 @@ func (s *Service) refreshModelRegistrationForAuthWithContext(ctx context.Context
 		s.coreManager.RefreshSchedulerEntry(current.ID)
 		return false
 	}
+	reuseXAIRegistration := sameXAIModelRegistrationInputs(current, latest)
 
 	// Re-apply the latest auth snapshot so concurrent auth updates cannot leave
-	// stale model registrations behind. This may duplicate registration work when
-	// no auth fields changed, but keeps the refresh path simple and correct.
+	// stale model registrations behind. Avoid repeating account model discovery
+	// when the latest snapshot has the same xAI OAuth registration inputs.
 	s.ensureExecutorsForAuthWithContext(ctx, latest, false)
-	s.registerModelsForAuthWithCache(ctx, latest, compatCache)
+	if !reuseXAIRegistration {
+		s.registerModelsForAuthWithCache(ctx, latest, compatCache)
+	}
 	if ctx.Err() != nil {
 		return false
 	}

--- a/sdk/cliproxy/xai_models.go
+++ b/sdk/cliproxy/xai_models.go
@@ -2,23 +2,21 @@ package cliproxy
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
 	log "github.com/sirupsen/logrus"
 )
 
 const (
-	xaiModelsCacheTTL           = 10 * time.Minute
 	xaiModelsMaxResponseBytes   = int64(4 << 20)
 	xaiCLIModelsTokenAuthHeader = "X-XAI-Token-Auth"
 	xaiCLIModelsTokenAuthValue  = "xai-grok-cli"
@@ -26,16 +24,9 @@ const (
 	xaiCLIModelsVersionValue    = "0.2.93"
 )
 
-type xaiModelCacheEntry struct {
-	models      []*registry.ModelInfo
-	tokenDigest [sha256.Size]byte
-	routeKey    string
-	fetchedAt   time.Time
-}
-
 type xaiModelsResponse struct {
-	Data   []xaiRemoteModel `json:"data"`
-	Models []xaiRemoteModel `json:"models"`
+	Data   *[]xaiRemoteModel `json:"data"`
+	Models *[]xaiRemoteModel `json:"models"`
 }
 
 type xaiRemoteModel struct {
@@ -49,7 +40,7 @@ type xaiRemoteModel struct {
 	ContextWindow       int               `json:"context_window"`
 	ContextLength       int               `json:"context_length"`
 	MaxCompletionTokens int               `json:"max_completion_tokens"`
-	SupportsReasoning   bool              `json:"supports_reasoning_effort"`
+	SupportsReasoning   *bool             `json:"supports_reasoning_effort"`
 	ReasoningEffort     string            `json:"reasoning_effort"`
 	ReasoningEfforts    []xaiRemoteEffort `json:"reasoning_efforts"`
 }
@@ -67,38 +58,16 @@ func (s *Service) xaiModelsForAuth(ctx context.Context, auth *coreauth.Auth) ([]
 	if token == "" {
 		return nil, fmt.Errorf("xai models: access token is missing")
 	}
-	digest := sha256.Sum256([]byte(token))
 	baseURL, cli := resolveXAIModelsRoute(s, auth)
-	routeKey := baseURL + "\x00" + strconv.FormatBool(cli)
-
-	s.xaiModelsMu.Lock()
-	if entry, ok := s.xaiModels[auth.ID]; ok && entry.tokenDigest == digest && entry.routeKey == routeKey && time.Since(entry.fetchedAt) < xaiModelsCacheTTL {
-		models := cloneXAIModelInfos(entry.models)
-		s.xaiModelsMu.Unlock()
-		return models, nil
-	}
-	var stale []*registry.ModelInfo
-	if entry, ok := s.xaiModels[auth.ID]; ok && entry.tokenDigest == digest && entry.routeKey == routeKey {
-		stale = cloneXAIModelInfos(entry.models)
-	}
-	s.xaiModelsMu.Unlock()
-
 	models, errFetch := fetchXAIModels(ctx, s, auth, token, baseURL, cli)
 	if errFetch != nil {
-		if len(stale) > 0 {
-			log.Warnf("xai models: discovery failed for auth %s, using last successful result: %v", auth.ID, errFetch)
-			return stale, nil
+		if ctx.Err() != nil {
+			return nil, errFetch
 		}
-		return nil, errFetch
+		log.Warnf("xai models: discovery failed for auth %s: %v", auth.ID, errFetch)
+		GlobalModelRegistry().UnregisterClient(auth.ID)
 	}
-
-	s.xaiModelsMu.Lock()
-	if s.xaiModels == nil {
-		s.xaiModels = make(map[string]xaiModelCacheEntry)
-	}
-	s.xaiModels[auth.ID] = xaiModelCacheEntry{models: cloneXAIModelInfos(models), tokenDigest: digest, routeKey: routeKey, fetchedAt: time.Now()}
-	s.xaiModelsMu.Unlock()
-	return models, nil
+	return models, errFetch
 }
 
 func fetchXAIModels(ctx context.Context, s *Service, auth *coreauth.Auth, token, baseURL string, cli bool) ([]*registry.ModelInfo, error) {
@@ -114,6 +83,9 @@ func fetchXAIModels(ctx context.Context, s *Service, auth *coreauth.Auth, token,
 	if cli {
 		req.Header.Set(xaiCLIModelsTokenAuthHeader, xaiCLIModelsTokenAuthValue)
 		req.Header.Set(xaiCLIModelsVersionHeader, xaiCLIModelsVersionValue)
+	}
+	if auth != nil {
+		util.ApplyCustomHeadersFromAttrs(req, auth.Attributes)
 	}
 
 	client := &http.Client{}
@@ -158,12 +130,14 @@ func fetchXAIModels(ctx context.Context, s *Service, auth *coreauth.Auth, token,
 	if errUnmarshal := json.Unmarshal(body, &payload); errUnmarshal != nil {
 		return nil, fmt.Errorf("xai models: parse response: %w", errUnmarshal)
 	}
-	remote := payload.Data
-	if len(remote) == 0 {
-		remote = payload.Models
-	}
-	if len(remote) == 0 {
-		return nil, fmt.Errorf("xai models: response contains no models")
+	var remote []xaiRemoteModel
+	switch {
+	case payload.Data != nil:
+		remote = *payload.Data
+	case payload.Models != nil:
+		remote = *payload.Models
+	default:
+		return nil, fmt.Errorf("xai models: response missing data/models field")
 	}
 	return mergeXAIModels(remote, registry.GetXAIModels()), nil
 }
@@ -283,7 +257,7 @@ func mergeXAIModels(remote []xaiRemoteModel, catalog []*registry.ModelInfo) []*r
 		if len(levels) > 0 {
 			model.Thinking = &registry.ThinkingSupport{Levels: levels}
 		}
-		if !item.SupportsReasoning && len(levels) == 0 {
+		if item.SupportsReasoning != nil && !*item.SupportsReasoning {
 			model.Thinking = nil
 		}
 		result = append(result, model)
@@ -292,7 +266,12 @@ func mergeXAIModels(remote []xaiRemoteModel, catalog []*registry.ModelInfo) []*r
 }
 
 func mergeXAIModelMetadata(static, remote *registry.ModelInfo) *registry.ModelInfo {
-	merged := cloneXAIModelInfos([]*registry.ModelInfo{static})[0]
+	merged := *static
+	if static.Thinking != nil {
+		thinking := *static.Thinking
+		thinking.Levels = append([]string(nil), static.Thinking.Levels...)
+		merged.Thinking = &thinking
+	}
 	if remote.ID != "" {
 		merged.ID = remote.ID
 	}
@@ -323,24 +302,7 @@ func mergeXAIModelMetadata(static, remote *registry.ModelInfo) *registry.ModelIn
 	if remote.MaxCompletionTokens != 0 {
 		merged.MaxCompletionTokens = remote.MaxCompletionTokens
 	}
-	return merged
-}
-
-func cloneXAIModelInfos(models []*registry.ModelInfo) []*registry.ModelInfo {
-	result := make([]*registry.ModelInfo, 0, len(models))
-	for _, model := range models {
-		if model == nil {
-			continue
-		}
-		clone := *model
-		if model.Thinking != nil {
-			thinking := *model.Thinking
-			thinking.Levels = append([]string(nil), model.Thinking.Levels...)
-			clone.Thinking = &thinking
-		}
-		result = append(result, &clone)
-	}
-	return result
+	return &merged
 }
 
 func summarizeXAIModelError(body []byte) string {

--- a/sdk/cliproxy/xai_models.go
+++ b/sdk/cliproxy/xai_models.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -179,6 +180,27 @@ func xaiUsingAPIForModels(auth *coreauth.Auth) bool {
 	}
 	authKind := strings.ToLower(strings.TrimSpace(auth.AuthKind()))
 	return authKind != coreauth.AuthKindOAuth
+}
+
+func sameXAIModelRegistrationInputs(current, latest *coreauth.Auth) bool {
+	if current == nil || latest == nil || current.ID == "" || current.ID != latest.ID {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(current.Provider), "xai") || current.AuthKind() != coreauth.AuthKindOAuth || latest.AuthKind() != coreauth.AuthKindOAuth {
+		return false
+	}
+	if current.Prefix != latest.Prefix || current.Disabled != latest.Disabled || current.ProxyURL != latest.ProxyURL {
+		return false
+	}
+	if !reflect.DeepEqual(current.Attributes, latest.Attributes) {
+		return false
+	}
+	for _, key := range []string{"access_token", "api_key", "base_url"} {
+		if xaiAuthString(current, key) != xaiAuthString(latest, key) {
+			return false
+		}
+	}
+	return xaiUsingAPIForModels(current) == xaiUsingAPIForModels(latest)
 }
 
 func xaiAuthString(auth *coreauth.Auth, keys ...string) string {

--- a/sdk/cliproxy/xai_models.go
+++ b/sdk/cliproxy/xai_models.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
@@ -22,7 +23,7 @@ const (
 	xaiCLIModelsTokenAuthHeader = "X-XAI-Token-Auth"
 	xaiCLIModelsTokenAuthValue  = "xai-grok-cli"
 	xaiCLIModelsVersionHeader   = "x-grok-client-version"
-	xaiCLIModelsVersionValue    = "0.2.93"
+	xaiCLIModelsVersionValue    = runtimeexecutor.XAIClientVersionValue
 )
 
 type xaiModelsResponse struct {
@@ -124,7 +125,7 @@ func fetchXAIModels(ctx context.Context, s *Service, auth *coreauth.Auth, token,
 		return nil, fmt.Errorf("xai models: response exceeds %d bytes", xaiModelsMaxResponseBytes)
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, fmt.Errorf("xai models: upstream returned status %d: %s", resp.StatusCode, summarizeXAIModelError(body))
+		return nil, fmt.Errorf("xai models: upstream returned status %d", resp.StatusCode)
 	}
 
 	var payload xaiModelsResponse
@@ -325,13 +326,4 @@ func mergeXAIModelMetadata(static, remote *registry.ModelInfo) *registry.ModelIn
 		merged.MaxCompletionTokens = remote.MaxCompletionTokens
 	}
 	return &merged
-}
-
-func summarizeXAIModelError(body []byte) string {
-	const maxErrorBytes = 512
-	body = []byte(strings.TrimSpace(string(body)))
-	if len(body) > maxErrorBytes {
-		body = body[:maxErrorBytes]
-	}
-	return string(body)
 }

--- a/sdk/cliproxy/xai_models.go
+++ b/sdk/cliproxy/xai_models.go
@@ -19,11 +19,16 @@ import (
 )
 
 const (
-	xaiModelsMaxResponseBytes   = int64(4 << 20)
-	xaiCLIModelsTokenAuthHeader = "X-XAI-Token-Auth"
-	xaiCLIModelsTokenAuthValue  = "xai-grok-cli"
-	xaiCLIModelsVersionHeader   = "x-grok-client-version"
-	xaiCLIModelsVersionValue    = runtimeexecutor.XAIClientVersionValue
+	xaiModelsMaxResponseBytes      = int64(4 << 20)
+	xaiCLIModelsTokenAuthHeader    = "X-XAI-Token-Auth"
+	xaiCLIModelsTokenAuthValue     = "xai-grok-cli"
+	xaiCLIModelsVersionHeader      = "x-grok-client-version"
+	xaiCLIModelsVersionValue       = runtimeexecutor.XAIClientVersionValue
+	xaiCLIModelsUserAgent          = "xai-grok-workspace/" + xaiCLIModelsVersionValue
+	xaiCLIModelsIdentifierHeader   = "x-grok-client-identifier"
+	xaiCLIModelsIdentifierValue    = "grok-shell"
+	xaiCLIModelsAuthResponseHeader = "x-authenticateresponse"
+	xaiCLIModelsAuthResponseValue  = "authenticate-response"
 )
 
 type xaiModelsResponse struct {
@@ -85,6 +90,9 @@ func fetchXAIModels(ctx context.Context, s *Service, auth *coreauth.Auth, token,
 	if cli {
 		req.Header.Set(xaiCLIModelsTokenAuthHeader, xaiCLIModelsTokenAuthValue)
 		req.Header.Set(xaiCLIModelsVersionHeader, xaiCLIModelsVersionValue)
+		req.Header.Set("User-Agent", xaiCLIModelsUserAgent)
+		req.Header.Set(xaiCLIModelsIdentifierHeader, xaiCLIModelsIdentifierValue)
+		req.Header.Set(xaiCLIModelsAuthResponseHeader, xaiCLIModelsAuthResponseValue)
 	}
 	if auth != nil {
 		util.ApplyCustomHeadersFromAttrs(req, auth.Attributes)

--- a/sdk/cliproxy/xai_models.go
+++ b/sdk/cliproxy/xai_models.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
@@ -22,7 +23,7 @@ const (
 	xaiCLIModelsTokenAuthHeader = "X-XAI-Token-Auth"
 	xaiCLIModelsTokenAuthValue  = "xai-grok-cli"
 	xaiCLIModelsVersionHeader   = "x-grok-client-version"
-	xaiCLIModelsVersionValue    = "0.2.120"
+	xaiCLIModelsVersionValue    = runtimeexecutor.XAIClientVersionValue
 )
 
 type xaiModelsResponse struct {

--- a/sdk/cliproxy/xai_models.go
+++ b/sdk/cliproxy/xai_models.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
-	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
@@ -23,7 +22,7 @@ const (
 	xaiCLIModelsTokenAuthHeader = "X-XAI-Token-Auth"
 	xaiCLIModelsTokenAuthValue  = "xai-grok-cli"
 	xaiCLIModelsVersionHeader   = "x-grok-client-version"
-	xaiCLIModelsVersionValue    = runtimeexecutor.XAIClientVersionValue
+	xaiCLIModelsVersionValue    = "0.2.120"
 )
 
 type xaiModelsResponse struct {

--- a/sdk/cliproxy/xai_models.go
+++ b/sdk/cliproxy/xai_models.go
@@ -186,7 +186,7 @@ func sameXAIModelRegistrationInputs(current, latest *coreauth.Auth) bool {
 	if current == nil || latest == nil || current.ID == "" || current.ID != latest.ID {
 		return false
 	}
-	if !strings.EqualFold(strings.TrimSpace(current.Provider), "xai") || current.AuthKind() != coreauth.AuthKindOAuth || latest.AuthKind() != coreauth.AuthKindOAuth {
+	if !strings.EqualFold(strings.TrimSpace(current.Provider), "xai") || !strings.EqualFold(strings.TrimSpace(latest.Provider), "xai") || current.AuthKind() != coreauth.AuthKindOAuth || latest.AuthKind() != coreauth.AuthKindOAuth {
 		return false
 	}
 	if current.Prefix != latest.Prefix || current.Disabled != latest.Disabled || current.ProxyURL != latest.ProxyURL {
@@ -251,17 +251,17 @@ func mergeXAIModels(remote []xaiRemoteModel, catalog []*registry.ModelInfo) []*r
 		if model.OwnedBy == "" {
 			model.OwnedBy = "xAI"
 		}
-		if model.DisplayName == "" {
-			model.DisplayName = id
-		}
-		if model.Name == "" {
-			model.Name = id
-		}
 		if model.ContextLength == 0 {
 			model.ContextLength = item.ContextLength
 		}
 		if static := byID[key]; static != nil {
 			model = mergeXAIModelMetadata(static, model)
+		}
+		if model.DisplayName == "" {
+			model.DisplayName = id
+		}
+		if model.Name == "" {
+			model.Name = id
 		}
 		levels := make([]string, 0, len(item.ReasoningEfforts))
 		for _, effort := range item.ReasoningEfforts {

--- a/sdk/cliproxy/xai_models.go
+++ b/sdk/cliproxy/xai_models.go
@@ -1,0 +1,353 @@
+package cliproxy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	xaiModelsCacheTTL           = 10 * time.Minute
+	xaiModelsMaxResponseBytes   = int64(4 << 20)
+	xaiCLIModelsTokenAuthHeader = "X-XAI-Token-Auth"
+	xaiCLIModelsTokenAuthValue  = "xai-grok-cli"
+	xaiCLIModelsVersionHeader   = "x-grok-client-version"
+	xaiCLIModelsVersionValue    = "0.2.93"
+)
+
+type xaiModelCacheEntry struct {
+	models      []*registry.ModelInfo
+	tokenDigest [sha256.Size]byte
+	routeKey    string
+	fetchedAt   time.Time
+}
+
+type xaiModelsResponse struct {
+	Data   []xaiRemoteModel `json:"data"`
+	Models []xaiRemoteModel `json:"models"`
+}
+
+type xaiRemoteModel struct {
+	ID                  string            `json:"id"`
+	Model               string            `json:"model"`
+	Object              string            `json:"object"`
+	Created             int64             `json:"created"`
+	OwnedBy             string            `json:"owned_by"`
+	Name                string            `json:"name"`
+	Description         string            `json:"description"`
+	ContextWindow       int               `json:"context_window"`
+	ContextLength       int               `json:"context_length"`
+	MaxCompletionTokens int               `json:"max_completion_tokens"`
+	SupportsReasoning   bool              `json:"supports_reasoning_effort"`
+	ReasoningEffort     string            `json:"reasoning_effort"`
+	ReasoningEfforts    []xaiRemoteEffort `json:"reasoning_efforts"`
+}
+
+type xaiRemoteEffort struct {
+	ID    string `json:"id"`
+	Value string `json:"value"`
+}
+
+func (s *Service) xaiModelsForAuth(ctx context.Context, auth *coreauth.Auth) ([]*registry.ModelInfo, error) {
+	if auth == nil || auth.ID == "" {
+		return nil, fmt.Errorf("xai models: auth is required")
+	}
+	token := xaiAuthString(auth, "access_token", "api_key")
+	if token == "" {
+		return nil, fmt.Errorf("xai models: access token is missing")
+	}
+	digest := sha256.Sum256([]byte(token))
+	baseURL, cli := resolveXAIModelsRoute(s, auth)
+	routeKey := baseURL + "\x00" + strconv.FormatBool(cli)
+
+	s.xaiModelsMu.Lock()
+	if entry, ok := s.xaiModels[auth.ID]; ok && entry.tokenDigest == digest && entry.routeKey == routeKey && time.Since(entry.fetchedAt) < xaiModelsCacheTTL {
+		models := cloneXAIModelInfos(entry.models)
+		s.xaiModelsMu.Unlock()
+		return models, nil
+	}
+	var stale []*registry.ModelInfo
+	if entry, ok := s.xaiModels[auth.ID]; ok && entry.tokenDigest == digest && entry.routeKey == routeKey {
+		stale = cloneXAIModelInfos(entry.models)
+	}
+	s.xaiModelsMu.Unlock()
+
+	models, errFetch := fetchXAIModels(ctx, s, auth, token, baseURL, cli)
+	if errFetch != nil {
+		if len(stale) > 0 {
+			log.Warnf("xai models: discovery failed for auth %s, using last successful result: %v", auth.ID, errFetch)
+			return stale, nil
+		}
+		return nil, errFetch
+	}
+
+	s.xaiModelsMu.Lock()
+	if s.xaiModels == nil {
+		s.xaiModels = make(map[string]xaiModelCacheEntry)
+	}
+	s.xaiModels[auth.ID] = xaiModelCacheEntry{models: cloneXAIModelInfos(models), tokenDigest: digest, routeKey: routeKey, fetchedAt: time.Now()}
+	s.xaiModelsMu.Unlock()
+	return models, nil
+}
+
+func fetchXAIModels(ctx context.Context, s *Service, auth *coreauth.Auth, token, baseURL string, cli bool) ([]*registry.ModelInfo, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req, errReq := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+"/models", nil)
+	if errReq != nil {
+		return nil, fmt.Errorf("xai models: create request: %w", errReq)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	if cli {
+		req.Header.Set(xaiCLIModelsTokenAuthHeader, xaiCLIModelsTokenAuthValue)
+		req.Header.Set(xaiCLIModelsVersionHeader, xaiCLIModelsVersionValue)
+	}
+
+	client := &http.Client{}
+	proxyURL := ""
+	if auth != nil {
+		proxyURL = strings.TrimSpace(auth.ProxyURL)
+	}
+	if proxyURL == "" && s != nil {
+		s.cfgMu.RLock()
+		if s.cfg != nil {
+			proxyURL = strings.TrimSpace(s.cfg.ProxyURL)
+		}
+		s.cfgMu.RUnlock()
+	}
+	if proxyURL != "" {
+		if transport, _, errProxy := proxyutil.BuildHTTPTransport(proxyURL); errProxy == nil && transport != nil {
+			client.Transport = transport
+		}
+	}
+
+	resp, errDo := client.Do(req)
+	if errDo != nil {
+		return nil, fmt.Errorf("xai models: request failed: %w", errDo)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Debugf("xai models: close response body: %v", errClose)
+		}
+	}()
+	body, errRead := io.ReadAll(io.LimitReader(resp.Body, xaiModelsMaxResponseBytes+1))
+	if errRead != nil {
+		return nil, fmt.Errorf("xai models: read response: %w", errRead)
+	}
+	if int64(len(body)) > xaiModelsMaxResponseBytes {
+		return nil, fmt.Errorf("xai models: response exceeds %d bytes", xaiModelsMaxResponseBytes)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("xai models: upstream returned status %d: %s", resp.StatusCode, summarizeXAIModelError(body))
+	}
+
+	var payload xaiModelsResponse
+	if errUnmarshal := json.Unmarshal(body, &payload); errUnmarshal != nil {
+		return nil, fmt.Errorf("xai models: parse response: %w", errUnmarshal)
+	}
+	remote := payload.Data
+	if len(remote) == 0 {
+		remote = payload.Models
+	}
+	if len(remote) == 0 {
+		return nil, fmt.Errorf("xai models: response contains no models")
+	}
+	return mergeXAIModels(remote, registry.GetXAIModels()), nil
+}
+
+func resolveXAIModelsRoute(s *Service, auth *coreauth.Auth) (string, bool) {
+	baseURL := xaiAuthString(auth, "base_url")
+	if baseURL != "" && !strings.EqualFold(strings.TrimRight(baseURL, "/"), "https://api.x.ai/v1") && !strings.EqualFold(strings.TrimRight(baseURL, "/"), "https://cli-chat-proxy.grok.com/v1") {
+		return baseURL, false
+	}
+	if xaiUsingAPIForModels(auth) {
+		if baseURL == "" || strings.EqualFold(strings.TrimRight(baseURL, "/"), "https://cli-chat-proxy.grok.com/v1") {
+			return "https://api.x.ai/v1", false
+		}
+		return baseURL, false
+	}
+	return "https://cli-chat-proxy.grok.com/v1", true
+}
+
+func xaiUsingAPIForModels(auth *coreauth.Auth) bool {
+	if auth == nil {
+		return true
+	}
+	if auth.Attributes != nil {
+		if raw := strings.TrimSpace(auth.Attributes["using_api"]); raw != "" {
+			if value, errParse := strconv.ParseBool(raw); errParse == nil {
+				return value
+			}
+		}
+	}
+	if auth.Metadata != nil {
+		switch value := auth.Metadata["using_api"].(type) {
+		case bool:
+			return value
+		case string:
+			if parsed, errParse := strconv.ParseBool(strings.TrimSpace(value)); errParse == nil {
+				return parsed
+			}
+		}
+	}
+	authKind := strings.ToLower(strings.TrimSpace(auth.AuthKind()))
+	return authKind != coreauth.AuthKindOAuth
+}
+
+func xaiAuthString(auth *coreauth.Auth, keys ...string) string {
+	if auth == nil {
+		return ""
+	}
+	for _, key := range keys {
+		if auth.Attributes != nil {
+			if value := strings.TrimSpace(auth.Attributes[key]); value != "" {
+				return value
+			}
+		}
+		if auth.Metadata != nil {
+			if value, ok := auth.Metadata[key].(string); ok && strings.TrimSpace(value) != "" {
+				return strings.TrimSpace(value)
+			}
+		}
+	}
+	return ""
+}
+
+func mergeXAIModels(remote []xaiRemoteModel, catalog []*registry.ModelInfo) []*registry.ModelInfo {
+	byID := make(map[string]*registry.ModelInfo, len(catalog))
+	for _, model := range catalog {
+		if model != nil {
+			byID[strings.ToLower(strings.TrimSpace(model.ID))] = model
+		}
+	}
+	result := make([]*registry.ModelInfo, 0, len(remote))
+	seen := make(map[string]struct{}, len(remote))
+	for _, item := range remote {
+		id := strings.TrimSpace(item.ID)
+		if id == "" {
+			id = strings.TrimSpace(item.Model)
+		}
+		key := strings.ToLower(id)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		model := &registry.ModelInfo{ID: id, Object: item.Object, Created: item.Created, OwnedBy: item.OwnedBy, Type: "xai", DisplayName: item.Name, Name: item.Name, Description: item.Description, ContextLength: item.ContextWindow, MaxCompletionTokens: item.MaxCompletionTokens}
+		if model.Object == "" {
+			model.Object = "model"
+		}
+		if model.OwnedBy == "" {
+			model.OwnedBy = "xAI"
+		}
+		if model.DisplayName == "" {
+			model.DisplayName = id
+		}
+		if model.Name == "" {
+			model.Name = id
+		}
+		if model.ContextLength == 0 {
+			model.ContextLength = item.ContextLength
+		}
+		if static := byID[key]; static != nil {
+			model = mergeXAIModelMetadata(static, model)
+		}
+		levels := make([]string, 0, len(item.ReasoningEfforts))
+		for _, effort := range item.ReasoningEfforts {
+			value := strings.TrimSpace(effort.Value)
+			if value == "" {
+				value = strings.TrimSpace(effort.ID)
+			}
+			if value != "" {
+				levels = append(levels, value)
+			}
+		}
+		if len(levels) == 0 && strings.TrimSpace(item.ReasoningEffort) != "" {
+			levels = []string{strings.TrimSpace(item.ReasoningEffort)}
+		}
+		if len(levels) > 0 {
+			model.Thinking = &registry.ThinkingSupport{Levels: levels}
+		}
+		if !item.SupportsReasoning && len(levels) == 0 {
+			model.Thinking = nil
+		}
+		result = append(result, model)
+	}
+	return result
+}
+
+func mergeXAIModelMetadata(static, remote *registry.ModelInfo) *registry.ModelInfo {
+	merged := cloneXAIModelInfos([]*registry.ModelInfo{static})[0]
+	if remote.ID != "" {
+		merged.ID = remote.ID
+	}
+	if remote.Object != "" {
+		merged.Object = remote.Object
+	}
+	if remote.Created != 0 {
+		merged.Created = remote.Created
+	}
+	if remote.OwnedBy != "" {
+		merged.OwnedBy = remote.OwnedBy
+	}
+	if remote.Type != "" {
+		merged.Type = remote.Type
+	}
+	if remote.DisplayName != "" {
+		merged.DisplayName = remote.DisplayName
+	}
+	if remote.Name != "" {
+		merged.Name = remote.Name
+	}
+	if remote.Description != "" {
+		merged.Description = remote.Description
+	}
+	if remote.ContextLength != 0 {
+		merged.ContextLength = remote.ContextLength
+	}
+	if remote.MaxCompletionTokens != 0 {
+		merged.MaxCompletionTokens = remote.MaxCompletionTokens
+	}
+	return merged
+}
+
+func cloneXAIModelInfos(models []*registry.ModelInfo) []*registry.ModelInfo {
+	result := make([]*registry.ModelInfo, 0, len(models))
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		clone := *model
+		if model.Thinking != nil {
+			thinking := *model.Thinking
+			thinking.Levels = append([]string(nil), model.Thinking.Levels...)
+			clone.Thinking = &thinking
+		}
+		result = append(result, &clone)
+	}
+	return result
+}
+
+func summarizeXAIModelError(body []byte) string {
+	const maxErrorBytes = 512
+	body = []byte(strings.TrimSpace(string(body)))
+	if len(body) > maxErrorBytes {
+		body = body[:maxErrorBytes]
+	}
+	return string(body)
+}

--- a/sdk/cliproxy/xai_models_test.go
+++ b/sdk/cliproxy/xai_models_test.go
@@ -1,0 +1,146 @@
+package cliproxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestXAIModelsForAuthUsesAccountCatalogAndStaticMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("request path = %q, want /v1/models", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token" {
+			t.Fatalf("authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"grok-4.6","name":"Account Grok","context_window":500000,"reasoning_efforts":[{"id":"low"},{"id":"high"}]},{"id":"account-only-model","description":"new account model"}]}`))
+	}))
+	defer server.Close()
+
+	service := &Service{}
+	auth := &coreauth.Auth{
+		ID:       "xai-model-discovery-test",
+		Provider: "xai",
+		Attributes: map[string]string{
+			"auth_kind":    coreauth.AuthKindOAuth,
+			"base_url":     server.URL + "/v1",
+			"access_token": "test-access-token",
+		},
+	}
+
+	models, err := service.xaiModelsForAuth(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("xaiModelsForAuth() error = %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("model count = %d, want 2", len(models))
+	}
+	if models[0].ID != "grok-4.6" || models[0].ContextLength != 500000 {
+		t.Fatalf("first model = %#v", models[0])
+	}
+	if models[0].Thinking == nil || len(models[0].Thinking.Levels) != 2 {
+		t.Fatalf("first model thinking = %#v", models[0].Thinking)
+	}
+	if models[1].ID != "account-only-model" {
+		t.Fatalf("second model ID = %q", models[1].ID)
+	}
+}
+
+func TestRegisterModelsForAuthUsesDiscoveredOAuthModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"id":"account-only-model"}]}`))
+	}))
+	defer server.Close()
+
+	service := &Service{}
+	auth := &coreauth.Auth{
+		ID:       "xai-register-discovered-test",
+		Provider: "xai",
+		Attributes: map[string]string{
+			"auth_kind":    coreauth.AuthKindOAuth,
+			"base_url":     server.URL + "/v1",
+			"access_token": "test-access-token",
+		},
+	}
+	registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	defer registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+
+	service.registerModelsForAuth(context.Background(), auth)
+	models := registry.GetGlobalRegistry().GetModelsForClient(auth.ID)
+	if len(models) != 1 || models[0].ID != "account-only-model" {
+		t.Fatalf("registered models = %#v, want account-only-model only", models)
+	}
+}
+
+func TestXAIModelsForAuthUsesLastSuccessfulResultOnTemporaryFailure(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":[{"id":"grok-4.6"}]}`))
+			return
+		}
+		http.Error(w, "temporary failure", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	service := &Service{}
+	auth := &coreauth.Auth{
+		ID:       "xai-model-cache-test",
+		Provider: "xai",
+		Attributes: map[string]string{
+			"auth_kind":    coreauth.AuthKindOAuth,
+			"base_url":     server.URL + "/v1",
+			"access_token": "test-access-token",
+		},
+	}
+	first, err := service.xaiModelsForAuth(context.Background(), auth)
+	if err != nil || len(first) != 1 {
+		t.Fatalf("first discovery = %#v, %v", first, err)
+	}
+	service.xaiModelsMu.Lock()
+	entry := service.xaiModels[auth.ID]
+	entry.fetchedAt = entry.fetchedAt.Add(-xaiModelsCacheTTL)
+	service.xaiModels[auth.ID] = entry
+	service.xaiModelsMu.Unlock()
+	second, err := service.xaiModelsForAuth(context.Background(), auth)
+	if err != nil || len(second) != 1 || second[0].ID != "grok-4.6" {
+		t.Fatalf("cached discovery = %#v, %v", second, err)
+	}
+}
+
+func TestResolveXAIModelsRoute(t *testing.T) {
+	tests := []struct {
+		name string
+		auth *coreauth.Auth
+		want string
+		cli  bool
+	}{
+		{
+			name: "oauth defaults to cli",
+			auth: &coreauth.Auth{Provider: "xai", Attributes: map[string]string{"auth_kind": coreauth.AuthKindOAuth}},
+			want: "https://cli-chat-proxy.grok.com/v1",
+			cli:  true,
+		},
+		{
+			name: "oauth using api",
+			auth: &coreauth.Auth{Provider: "xai", Attributes: map[string]string{"auth_kind": coreauth.AuthKindOAuth, "using_api": "true"}},
+			want: "https://api.x.ai/v1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, cli := resolveXAIModelsRoute(nil, tt.auth)
+			if got != tt.want || cli != tt.cli {
+				t.Fatalf("route = %q, cli=%v; want %q, cli=%v", got, cli, tt.want, tt.cli)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/xai_models_test.go
+++ b/sdk/cliproxy/xai_models_test.go
@@ -204,6 +204,33 @@ func TestMergeXAIModelsReasoningMetadata(t *testing.T) {
 	}
 }
 
+func TestRefreshXAIRegistrationDoesNotRediscoverUnchangedAuth(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_, _ = w.Write([]byte(`{"data":[{"id":"refresh-model"}]}`))
+	}))
+	defer server.Close()
+
+	auth := &coreauth.Auth{ID: "xai-refresh-dedup-test", Provider: "xai", Attributes: map[string]string{
+		"auth_kind": coreauth.AuthKindOAuth, "base_url": server.URL + "/v1", "access_token": "token",
+	}}
+	manager := coreauth.NewManager(nil, nil, nil)
+	registered, errRegister := manager.Register(context.Background(), auth)
+	if errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	service := &Service{coreManager: manager}
+	reg := registry.GetGlobalRegistry()
+	defer reg.UnregisterClient(auth.ID)
+	if !service.refreshModelRegistrationForAuthWithContext(context.Background(), registered, nil) {
+		t.Fatal("refreshModelRegistrationForAuthWithContext() = false")
+	}
+	if requests != 1 {
+		t.Fatalf("upstream requests = %d, want 1 for unchanged refresh snapshot", requests)
+	}
+}
+
 func TestResolveXAIModelsRoute(t *testing.T) {
 	tests := []struct {
 		name string

--- a/sdk/cliproxy/xai_models_test.go
+++ b/sdk/cliproxy/xai_models_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
@@ -84,6 +85,20 @@ func TestXAIModelsForAuthAppliesCustomHeaders(t *testing.T) {
 	}
 	if len(models) != 1 || models[0].ID != "grok-4.6" {
 		t.Fatalf("models = %#v, want grok-4.6", models)
+	}
+}
+
+func TestXAIModelsErrorOmitsUpstreamBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "echoed-access-token-secret", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+	auth := &coreauth.Auth{ID: "xai-error-body-test", Provider: "xai", Attributes: map[string]string{
+		"auth_kind": coreauth.AuthKindOAuth, "base_url": server.URL + "/v1", "access_token": "token",
+	}}
+	_, err := (&Service{}).xaiModelsForAuth(context.Background(), auth)
+	if err == nil || strings.Contains(err.Error(), "echoed-access-token-secret") {
+		t.Fatalf("error = %v, want status-only error without upstream body", err)
 	}
 }
 

--- a/sdk/cliproxy/xai_models_test.go
+++ b/sdk/cliproxy/xai_models_test.go
@@ -52,6 +52,41 @@ func TestXAIModelsForAuthUsesAccountCatalogAndStaticMetadata(t *testing.T) {
 	}
 }
 
+func TestXAIModelsForAuthAppliesCustomHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Gateway custom-token" {
+			t.Fatalf("authorization = %q, want custom override", got)
+		}
+		if got := r.Header.Get("X-Gateway-Tenant"); got != "tenant-123" {
+			t.Fatalf("X-Gateway-Tenant = %q, want tenant-123", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"grok-4.6"}]}`))
+	}))
+	defer server.Close()
+
+	service := &Service{}
+	auth := &coreauth.Auth{
+		ID:       "xai-model-discovery-custom-headers-test",
+		Provider: "xai",
+		Attributes: map[string]string{
+			"auth_kind":               coreauth.AuthKindOAuth,
+			"base_url":                server.URL + "/v1",
+			"access_token":            "test-access-token",
+			"header:Authorization":    "Gateway custom-token",
+			"header:X-Gateway-Tenant": "tenant-123",
+		},
+	}
+
+	models, err := service.xaiModelsForAuth(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("xaiModelsForAuth() error = %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "grok-4.6" {
+		t.Fatalf("models = %#v, want grok-4.6", models)
+	}
+}
+
 func TestRegisterModelsForAuthUsesDiscoveredOAuthModels(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"data":[{"id":"account-only-model"}]}`))
@@ -78,16 +113,11 @@ func TestRegisterModelsForAuthUsesDiscoveredOAuthModels(t *testing.T) {
 	}
 }
 
-func TestXAIModelsForAuthUsesLastSuccessfulResultOnTemporaryFailure(t *testing.T) {
+func TestXAIModelsForAuthAlwaysFetches(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
-		if requests == 1 {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"data":[{"id":"grok-4.6"}]}`))
-			return
-		}
-		http.Error(w, "temporary failure", http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"data":[{"id":"grok-4.6"}]}`))
 	}))
 	defer server.Close()
 
@@ -101,18 +131,76 @@ func TestXAIModelsForAuthUsesLastSuccessfulResultOnTemporaryFailure(t *testing.T
 			"access_token": "test-access-token",
 		},
 	}
-	first, err := service.xaiModelsForAuth(context.Background(), auth)
-	if err != nil || len(first) != 1 {
-		t.Fatalf("first discovery = %#v, %v", first, err)
+	for i := 0; i < 2; i++ {
+		models, err := service.xaiModelsForAuth(context.Background(), auth)
+		if err != nil || len(models) != 1 || models[0].ID != "grok-4.6" {
+			t.Fatalf("discovery %d = %#v, %v", i+1, models, err)
+		}
 	}
-	service.xaiModelsMu.Lock()
-	entry := service.xaiModels[auth.ID]
-	entry.fetchedAt = entry.fetchedAt.Add(-xaiModelsCacheTTL)
-	service.xaiModels[auth.ID] = entry
-	service.xaiModelsMu.Unlock()
-	second, err := service.xaiModelsForAuth(context.Background(), auth)
-	if err != nil || len(second) != 1 || second[0].ID != "grok-4.6" {
-		t.Fatalf("cached discovery = %#v, %v", second, err)
+	if requests != 2 {
+		t.Fatalf("upstream requests = %d, want 2", requests)
+	}
+}
+
+func TestRegisterModelsForAuthUnregistersOnDiscoveryFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "temporary failure", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	service := &Service{}
+	auth := &coreauth.Auth{ID: "xai-register-failure-test", Provider: "xai", Attributes: map[string]string{
+		"auth_kind": coreauth.AuthKindOAuth, "base_url": server.URL + "/v1", "access_token": "test-access-token",
+	}}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "xai", []*registry.ModelInfo{{ID: "old-model"}})
+	defer reg.UnregisterClient(auth.ID)
+	service.registerModelsForAuth(context.Background(), auth)
+	if got := reg.GetModelsForClient(auth.ID); len(got) != 0 {
+		t.Fatalf("registered models after failure = %#v, want empty", got)
+	}
+}
+
+func TestXAIModelsResponseEmptyAndMissingFields(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{name: "explicit empty data", body: `{"data":[]}`},
+		{name: "explicit empty models", body: `{"models":[]}`},
+		{name: "missing fields", body: `{}`, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(tc.body)) }))
+			defer server.Close()
+			auth := &coreauth.Auth{ID: tc.name, Provider: "xai", Attributes: map[string]string{"auth_kind": coreauth.AuthKindOAuth, "base_url": server.URL + "/v1", "access_token": "token"}}
+			models, err := (&Service{}).xaiModelsForAuth(context.Background(), auth)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected protocol error")
+			}
+			if !tc.wantErr && (err != nil || len(models) != 0) {
+				t.Fatalf("models=%#v err=%v", models, err)
+			}
+		})
+	}
+}
+
+func TestMergeXAIModelsReasoningMetadata(t *testing.T) {
+	static := []*registry.ModelInfo{{ID: "grok", Thinking: &registry.ThinkingSupport{Levels: []string{"low", "high"}}}}
+	missing := mergeXAIModels([]xaiRemoteModel{{ID: "grok"}}, static)
+	if missing[0].Thinking == nil || len(missing[0].Thinking.Levels) != 2 {
+		t.Fatalf("missing reasoning metadata = %#v, want static thinking preserved", missing[0].Thinking)
+	}
+	falseValue := false
+	cleared := mergeXAIModels([]xaiRemoteModel{{ID: "grok", SupportsReasoning: &falseValue}}, static)
+	if cleared[0].Thinking != nil {
+		t.Fatalf("explicit false reasoning metadata = %#v, want cleared", cleared[0].Thinking)
+	}
+	trueValue := true
+	overridden := mergeXAIModels([]xaiRemoteModel{{ID: "grok", SupportsReasoning: &trueValue, ReasoningEfforts: []xaiRemoteEffort{{Value: "minimal"}, {Value: "max"}}}}, static)
+	if overridden[0].Thinking == nil || len(overridden[0].Thinking.Levels) != 2 || overridden[0].Thinking.Levels[0] != "minimal" {
+		t.Fatalf("remote reasoning levels = %#v, want remote levels", overridden[0].Thinking)
 	}
 }
 

--- a/sdk/cliproxy/xai_models_test.go
+++ b/sdk/cliproxy/xai_models_test.go
@@ -204,6 +204,26 @@ func TestMergeXAIModelsReasoningMetadata(t *testing.T) {
 	}
 }
 
+func TestMergeXAIModelsPreservesStaticNamesWhenRemoteOmitsName(t *testing.T) {
+	models := mergeXAIModels([]xaiRemoteModel{{ID: "grok-4.6"}}, []*registry.ModelInfo{{
+		ID: "grok-4.6", Name: "Grok 4.6", DisplayName: "Grok 4.6",
+	}})
+	if len(models) != 1 || models[0].Name != "Grok 4.6" || models[0].DisplayName != "Grok 4.6" {
+		t.Fatalf("merged names = %#v, want static names preserved", models)
+	}
+}
+
+func TestSameXAIModelRegistrationInputsRequiresLatestXAIProvider(t *testing.T) {
+	current := &coreauth.Auth{ID: "same-inputs-test", Provider: "xai", Attributes: map[string]string{
+		"auth_kind": coreauth.AuthKindOAuth, "access_token": "token",
+	}}
+	latest := current.Clone()
+	latest.Provider = "claude"
+	if sameXAIModelRegistrationInputs(current, latest) {
+		t.Fatal("sameXAIModelRegistrationInputs() = true for non-xAI latest provider")
+	}
+}
+
 func TestRefreshXAIRegistrationDoesNotRediscoverUnchangedAuth(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sdk/cliproxy/xai_models_test.go
+++ b/sdk/cliproxy/xai_models_test.go
@@ -53,6 +53,28 @@ func TestXAIModelsForAuthUsesAccountCatalogAndStaticMetadata(t *testing.T) {
 	}
 }
 
+func TestFetchXAIModelsSendsCLIIdentityHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for header, want := range map[string]string{
+			xaiCLIModelsTokenAuthHeader:    xaiCLIModelsTokenAuthValue,
+			xaiCLIModelsVersionHeader:      xaiCLIModelsVersionValue,
+			"User-Agent":                   xaiCLIModelsUserAgent,
+			xaiCLIModelsIdentifierHeader:   xaiCLIModelsIdentifierValue,
+			xaiCLIModelsAuthResponseHeader: xaiCLIModelsAuthResponseValue,
+		} {
+			if got := r.Header.Get(header); got != want {
+				t.Errorf("%s = %q, want %q", header, got, want)
+			}
+		}
+		_, _ = w.Write([]byte(`{"data":[{"id":"cli-model"}]}`))
+	}))
+	defer server.Close()
+	auth := &coreauth.Auth{ID: "xai-cli-headers-test", Provider: "xai", Attributes: map[string]string{"access_token": "token"}}
+	if _, err := fetchXAIModels(context.Background(), &Service{}, auth, "token", server.URL+"/v1", true); err != nil {
+		t.Fatalf("fetchXAIModels() error = %v", err)
+	}
+}
+
 func TestXAIModelsForAuthAppliesCustomHeaders(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Gateway custom-token" {


### PR DESCRIPTION
## 设计方案

当前 xAI OAuth 凭证使用全局静态模型目录，导致模型 registry 和调度器会把某个 OAuth 凭证绑定到其账户实际不能调用的模型。本 PR 不把 CLIProxyAPI 的全局 `/v1/models` 误认为账户级能力列表，而是按 OAuth 凭证同步发现账户模型：

- 默认 OAuth 请求 `https://cli-chat-proxy.grok.com/v1/models`。
- `using_api: true` 请求 `https://api.x.ai/v1/models`。
- 自定义 `base_url` 请求对应网关的 `/models`。
- 上游返回的模型 ID 是账户可用模型的权威集合。
- `models.json` 只用于补充静态元数据，不额外注入账户未返回的模型。
- 凭证注册、凭证新增/修改或 token 刷新触发重注册时直接请求上游；同一次 refresh 对未变化的 `current`/`latest` 快照跳过重复发现，不做跨 refresh 缓存、stale fallback、singleflight 或后台定时刷新。
- 如果凭证和配置没有变化，服务运行期间账户权限变化不会自动触发重新发现；需要凭证重载或服务重启。
- 默认 CLI discovery 携带与正常 xAI chat 请求一致的完整 identity headers，并复用当前客户端版本 `0.2.120`。
- HTTP/网络/解析失败会注销该凭证已有模型；context 取消会直接返回且不会修改 registry。
- 上游错误响应 body 不进入错误或日志，避免回显凭证、租户等敏感信息。
- `data: []` 或 `models: []` 是权威空集合；完全缺少模型字段视为协议错误。
- 缺失 `supports_reasoning_effort` 时保留静态 thinking 配置，显式 `false` 时清除，远端 effort levels 优先。
- xAI API Key 的现有配置模型、别名和 `excluded-models` 行为保持不变。

实现复用了现有按凭证注册和刷新模型的生命周期，没有把账户网络请求放入全局 registry 模型定义函数。响应体限制为 4 MiB，并避免在日志中输出 token。

## 测试方案

- `httptest.Server` 验证连续两次独立发现产生两次真实上游请求。
- 验证同一次 refresh 对未变化快照只发现一次，以及 provider 变化时不错误复用。
- 验证自定义 `header:*`、`Authorization` override 和完整 CLI identity headers。
- 验证账户模型集合过滤、静态元数据合并、静态名称保留和 reasoning 三种覆盖规则。
- 验证 HTTP/网络/解析失败清理 registry，以及显式空目录与缺少字段的区别。
- 验证上游错误 body 不进入错误信息。
- 验证 OAuth 默认 CLI、`using_api: true` API、自定义 `base_url` 路由。
- 验证真实 registry 注册结果，而不是只测试解析函数。

## 测试报告

已通过：

- `go test ./...`
- `go test -race ./sdk/cliproxy -run 'TestXAI' -count=1`
- `go vet ./sdk/cliproxy`
- `go build -o cli-proxy-api ./cmd/server`
- `git diff --check`

本次更新提交：`658f21c8`。未修改 xAI 凭证文件，也未在日志或提交内容中写入任何 token。
