### PR TITLE
feat: optional credential subset routing via X-Auth-Subset header (default off)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -141,6 +141,23 @@ force-model-prefix: false
 # Default is false (disabled).
 passthrough-headers: false
 
+# Optional credential subset routing via the X-Auth-Subset request header.
+# When enabled, a request may carry "X-Auth-Subset: <auth_index>,<auth_index>,..."
+# (the stable auth_index values surfaced by the management API) and selection is
+# narrowed to those credentials before the configured selector rotates and
+# fails over as usual. Disabled by default: with enabled=false, or without the
+# header, behavior is identical to an unpatched build.
+# empty-policy applies when every listed entry is unknown to the pool:
+#   fallback (default) - select from the full pool
+#   reject             - fail the request with HTTP 429
+# require-signature / signature-key reserve header signature verification and
+# are not enforced yet.
+# subset:
+#   enabled: false
+#   empty-policy: "fallback"
+#   require-signature: false
+#   signature-key: ""
+
 # Number of additional credential retry rounds after the first round exhausts
 # its eligible credentials. Round 0 is the initial round; round r only admits
 # credentials whose effective request-retry is at least r. Explicit non-negative

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -199,6 +199,7 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	managementasset.SetCurrentConfig(cfg)
 	auth.SetQuotaCooldownDisabled(cfg.DisableCooling)
 	auth.SetTransientErrorCooldownSeconds(cfg.TransientErrorCooldownSeconds)
+	auth.SetSubsetRouting(cfg.Subset.Enabled, cfg.Subset.EmptyPolicy, cfg.Subset.RequireSignature, cfg.Subset.SignatureKey)
 	applySignatureCacheConfig(nil, cfg)
 	// Initialize management handler
 	s.mgmt = managementHandlers.NewHandler(cfg, configFilePath, authManager)

--- a/internal/api/server_reload.go
+++ b/internal/api/server_reload.go
@@ -104,6 +104,9 @@ func (s *Server) UpdateClientsContext(ctx context.Context, cfg *config.Config) b
 	if oldCfg == nil || oldCfg.TransientErrorCooldownSeconds != cfg.TransientErrorCooldownSeconds {
 		auth.SetTransientErrorCooldownSeconds(cfg.TransientErrorCooldownSeconds)
 	}
+	if oldCfg == nil || oldCfg.Subset != cfg.Subset {
+		auth.SetSubsetRouting(cfg.Subset.Enabled, cfg.Subset.EmptyPolicy, cfg.Subset.RequireSignature, cfg.Subset.SignatureKey)
+	}
 
 	if oldCfg != nil && oldCfg.DisableImageGeneration != cfg.DisableImageGeneration {
 		log.Infof("disable-image-generation updated: %v -> %v", oldCfg.DisableImageGeneration, cfg.DisableImageGeneration)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,6 +76,9 @@ type Config struct {
 	// When <= 0, the default worker count is used.
 	AuthAutoRefreshWorkers int `yaml:"auth-auto-refresh-workers" json:"auth-auto-refresh-workers"`
 
+	// Subset configures optional X-Auth-Subset credential subset routing.
+	Subset SubsetConfig `yaml:"subset" json:"subset"`
+
 	// RequestRetry defines the number of additional credential retry rounds after
 	// the first round has exhausted its eligible credentials.
 	RequestRetry int `yaml:"request-retry" json:"request-retry"`

--- a/internal/config/subset.go
+++ b/internal/config/subset.go
@@ -1,0 +1,22 @@
+package config
+
+// SubsetConfig configures optional credential subset routing driven by the
+// X-Auth-Subset request header. The feature is disabled by default; when
+// disabled the header is ignored and selection behavior is unchanged.
+type SubsetConfig struct {
+	// Enabled toggles X-Auth-Subset subset routing. Default: false.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+
+	// EmptyPolicy controls behavior when every entry of a request's subset is
+	// unknown to the credential pool: "fallback" (default) selects from the
+	// full pool, "reject" fails the request with an HTTP 429 JSON error.
+	EmptyPolicy string `yaml:"empty-policy" json:"empty-policy"`
+
+	// RequireSignature reserves signature verification of the X-Auth-Subset
+	// header. Configuration only; verification is not implemented yet.
+	RequireSignature bool `yaml:"require-signature" json:"require-signature"`
+
+	// SignatureKey reserves the shared key for the future header signature
+	// verification. Configuration only; not used yet.
+	SignatureKey string `yaml:"signature-key" json:"signature-key"`
+}

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -48,6 +48,11 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 		resp, errHome := m.executeHome(ctx, normalized, req, opts, false)
 		return resp, unwrapRequestStopError(errHome)
 	}
+	subsetCtx, errSubset := m.applySubsetRouting(ctx, opts)
+	if errSubset != nil {
+		return cliproxyexecutor.Response{}, errSubset
+	}
+	ctx = subsetCtx
 
 	defaultRequestRetry, maxRetryCredentials, maxWait := m.retrySettings()
 
@@ -95,6 +100,11 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 		resp, errHome := m.executeHome(ctx, normalized, req, opts, true)
 		return resp, unwrapRequestStopError(errHome)
 	}
+	subsetCtx, errSubset := m.applySubsetRouting(ctx, opts)
+	if errSubset != nil {
+		return cliproxyexecutor.Response{}, errSubset
+	}
+	ctx = subsetCtx
 
 	defaultRequestRetry, maxRetryCredentials, maxWait := m.retrySettings()
 
@@ -135,6 +145,13 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	normalized := m.normalizeProviders(providers)
 	if len(normalized) == 0 {
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
+	}
+	if !m.HomeEnabled() {
+		subsetCtx, errSubset := m.applySubsetRouting(ctx, opts)
+		if errSubset != nil {
+			return nil, errSubset
+		}
+		ctx = subsetCtx
 	}
 
 	defaultRequestRetry, maxRetryCredentials, maxWait := m.retrySettings()

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -58,6 +58,9 @@ type authSelectionEligibility struct {
 	requiredKind     string
 	credentialPolicy string
 	disallowFreeAuth bool
+	// subsetAuthIDs, when non-nil, restricts selection to the listed auth IDs
+	// (X-Auth-Subset routing; see subset.go).
+	subsetAuthIDs map[string]struct{}
 }
 
 func withRequiredAuthKind(ctx context.Context, requiredKind string) context.Context {
@@ -81,6 +84,7 @@ func authSelectionEligibilityForRequest(ctx context.Context, opts cliproxyexecut
 	if ctx != nil {
 		eligibility.requiredKind, _ = ctx.Value(requiredAuthKindContextKey{}).(string)
 		eligibility.credentialPolicy, _ = ctx.Value(credentialPolicyContextKey{}).(string)
+		eligibility.subsetAuthIDs = subsetAllowedAuthIDsFromContext(ctx)
 	}
 	return eligibility
 }
@@ -94,6 +98,11 @@ func (e authSelectionEligibility) allows(auth *Auth) bool {
 	}
 	if e.credentialPolicy != "" && !credentialPolicyAllows(e.credentialPolicy, auth) {
 		return false
+	}
+	if e.subsetAuthIDs != nil {
+		if _, ok := e.subsetAuthIDs[auth.ID]; !ok {
+			return false
+		}
 	}
 	return !e.disallowFreeAuth || !isFreeCodexAuth(auth)
 }

--- a/sdk/cliproxy/auth/subset.go
+++ b/sdk/cliproxy/auth/subset.go
@@ -1,0 +1,216 @@
+// Package auth: optional credential subset routing via the X-Auth-Subset header.
+//
+// When enabled through SetSubsetRouting, a request may carry a comma separated
+// list of auth indexes (the same stable identifiers surfaced as "auth_index" by
+// the management API, derived in Auth.EnsureIndex from the credential identity,
+// not from load order). Selection for that request is then narrowed to the
+// listed credentials before the configured selector runs; rotation, cooldown
+// handling and failover are delegated unchanged to the existing selection
+// logic through authSelectionEligibility.
+//
+// Behavior contract:
+//   - feature disabled (default) or header absent/empty: current behavior, full pool;
+//   - header present with at least one entry matching a known credential:
+//     the pool is narrowed to the matching credentials;
+//   - every entry unknown: "fallback" policy uses the full pool, "reject"
+//     policy fails the request with HTTP 429;
+//   - malformed entries are ignored; if nothing valid remains the header is
+//     treated as empty (full pool).
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// SubsetHeaderName is the request header carrying the allowed auth index list.
+const SubsetHeaderName = "X-Auth-Subset"
+
+// Empty-subset policies applied when every subset entry is unknown to the pool.
+const (
+	SubsetEmptyPolicyFallback = "fallback"
+	SubsetEmptyPolicyReject   = "reject"
+)
+
+// subsetMaxEntryLength bounds a single subset entry; auth indexes are 16 hex
+// characters today, the bound only guards against abusive header values.
+const subsetMaxEntryLength = 64
+
+type subsetRoutingSettings struct {
+	enabled     bool
+	emptyPolicy string
+	// requireSignature and signatureKey reserve configuration for signing the
+	// X-Auth-Subset header. Verification is intentionally not implemented yet.
+	// TODO: enforce HMAC verification of the subset header when requireSignature is set.
+	requireSignature bool
+	signatureKey     string
+}
+
+var subsetRouting atomic.Pointer[subsetRoutingSettings]
+
+// SetSubsetRouting configures X-Auth-Subset credential subset routing globally.
+// The feature is disabled unless enabled is true. emptyPolicy accepts
+// "fallback" (default) or "reject"; any other value falls back to "fallback".
+func SetSubsetRouting(enabled bool, emptyPolicy string, requireSignature bool, signatureKey string) {
+	policy := strings.ToLower(strings.TrimSpace(emptyPolicy))
+	if policy != SubsetEmptyPolicyReject {
+		policy = SubsetEmptyPolicyFallback
+	}
+	subsetRouting.Store(&subsetRoutingSettings{
+		enabled:          enabled,
+		emptyPolicy:      policy,
+		requireSignature: requireSignature,
+		signatureKey:     strings.TrimSpace(signatureKey),
+	})
+}
+
+func subsetRoutingSnapshot() subsetRoutingSettings {
+	if settings := subsetRouting.Load(); settings != nil {
+		return *settings
+	}
+	return subsetRoutingSettings{emptyPolicy: SubsetEmptyPolicyFallback}
+}
+
+type subsetAllowedAuthIDsContextKey struct{}
+
+func withSubsetAllowedAuthIDs(ctx context.Context, ids map[string]struct{}) context.Context {
+	if len(ids) == 0 {
+		return ctx
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, subsetAllowedAuthIDsContextKey{}, ids)
+}
+
+func subsetAllowedAuthIDsFromContext(ctx context.Context) map[string]struct{} {
+	if ctx == nil {
+		return nil
+	}
+	ids, _ := ctx.Value(subsetAllowedAuthIDsContextKey{}).(map[string]struct{})
+	return ids
+}
+
+// subsetEntryValid accepts lowercase alphanumerics plus '.', '_' and '-'.
+func subsetEntryValid(entry string) bool {
+	if entry == "" || len(entry) > subsetMaxEntryLength {
+		return false
+	}
+	for _, r := range entry {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// parseSubsetHeader splits a comma separated auth index list, trimming
+// whitespace, lowercasing entries, dropping malformed items and de-duplicating
+// while preserving first-seen order.
+func parseSubsetHeader(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		entry := strings.ToLower(strings.TrimSpace(part))
+		if !subsetEntryValid(entry) {
+			continue
+		}
+		if _, ok := seen[entry]; ok {
+			continue
+		}
+		seen[entry] = struct{}{}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// subsetHeaderValue joins every occurrence of the subset header so repeated
+// header lines behave like one comma separated list.
+func subsetHeaderValue(headers http.Header) string {
+	if len(headers) == 0 {
+		return ""
+	}
+	return strings.Join(headers.Values(SubsetHeaderName), ",")
+}
+
+// authIndexNoMutate mirrors Auth.EnsureIndex without caching the result on the
+// Auth value, so it is safe on shared entries under the manager read lock.
+func authIndexNoMutate(a *Auth) string {
+	if a == nil {
+		return ""
+	}
+	if idx := strings.TrimSpace(a.Index); idx != "" {
+		return idx
+	}
+	return stableAuthIndex(a.indexSeed())
+}
+
+// resolveSubsetAuthIDs maps requested auth indexes to the IDs of currently
+// registered credentials. Unknown entries are ignored.
+func (m *Manager) resolveSubsetAuthIDs(entries []string) map[string]struct{} {
+	if m == nil || len(entries) == 0 {
+		return nil
+	}
+	requested := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		requested[entry] = struct{}{}
+	}
+	ids := make(map[string]struct{})
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, auth := range m.auths {
+		if auth == nil || strings.TrimSpace(auth.ID) == "" {
+			continue
+		}
+		idx := strings.ToLower(strings.TrimSpace(authIndexNoMutate(auth)))
+		if idx == "" {
+			continue
+		}
+		if _, ok := requested[idx]; ok {
+			ids[auth.ID] = struct{}{}
+		}
+	}
+	return ids
+}
+
+// applySubsetRouting narrows subsequent auth selection for one request to the
+// credentials named by the X-Auth-Subset header. It returns a context consumed
+// by authSelectionEligibilityForRequest, so every local selection path
+// (legacy pick, scheduler fast path, plugin scheduler candidates, retry
+// rounds) observes the same subset while rotation and failover stay with the
+// existing logic. With the feature disabled or no usable header the context is
+// returned unchanged and behavior is identical to an unpatched build.
+func (m *Manager) applySubsetRouting(ctx context.Context, opts cliproxyexecutor.Options) (context.Context, error) {
+	settings := subsetRoutingSnapshot()
+	if !settings.enabled || m == nil {
+		return ctx, nil
+	}
+	raw := subsetHeaderValue(opts.Headers)
+	if strings.TrimSpace(raw) == "" {
+		return ctx, nil
+	}
+	entries := parseSubsetHeader(raw)
+	if len(entries) == 0 {
+		return ctx, nil
+	}
+	ids := m.resolveSubsetAuthIDs(entries)
+	if len(ids) == 0 {
+		if settings.emptyPolicy == SubsetEmptyPolicyReject {
+			return ctx, &Error{
+				Code:       "auth_subset_unavailable",
+				Message:    fmt.Sprintf("no registered credential matches the %s header (%d entries)", SubsetHeaderName, len(entries)),
+				HTTPStatus: http.StatusTooManyRequests,
+			}
+		}
+		return ctx, nil
+	}
+	return withSubsetAllowedAuthIDs(ctx, ids), nil
+}

--- a/sdk/cliproxy/auth/subset_test.go
+++ b/sdk/cliproxy/auth/subset_test.go
@@ -1,0 +1,193 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func resetSubsetRouting(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { SetSubsetRouting(false, "", false, "") })
+}
+
+func newSubsetTestManager(t *testing.T, ids ...string) (*Manager, map[string]string) {
+	t.Helper()
+	m := NewManager(nil, nil, nil)
+	indexes := make(map[string]string, len(ids))
+	for _, id := range ids {
+		a := &Auth{
+			ID:       id,
+			Provider: "gemini",
+			Attributes: map[string]string{
+				"api_key": "key-" + id,
+			},
+		}
+		idx := a.EnsureIndex()
+		if idx == "" {
+			t.Fatalf("EnsureIndex returned empty index for %s", id)
+		}
+		m.auths[id] = a
+		indexes[id] = idx
+	}
+	return m, indexes
+}
+
+func subsetOptsWithHeader(values ...string) cliproxyexecutor.Options {
+	headers := http.Header{}
+	for _, value := range values {
+		headers.Add(SubsetHeaderName, value)
+	}
+	return cliproxyexecutor.Options{Headers: headers}
+}
+
+func TestParseSubsetHeaderTrimsDedupesAndIgnoresInvalid(t *testing.T) {
+	got := parseSubsetHeader(" abc123 ,ABC123,, def_456 ,bad entry,!!,def_456,x-y.z")
+	want := []string{"abc123", "def_456", "x-y.z"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseSubsetHeader = %v, want %v", got, want)
+	}
+}
+
+func TestApplySubsetRoutingDisabledKeepsFullPool(t *testing.T) {
+	resetSubsetRouting(t)
+	SetSubsetRouting(false, SubsetEmptyPolicyReject, false, "")
+	m, indexes := newSubsetTestManager(t, "auth-1")
+
+	ctx := context.Background()
+	outCtx, err := m.applySubsetRouting(ctx, subsetOptsWithHeader(indexes["auth-1"]))
+	if err != nil {
+		t.Fatalf("applySubsetRouting error = %v, want nil", err)
+	}
+	if outCtx != ctx {
+		t.Fatalf("applySubsetRouting changed the context while disabled")
+	}
+	if ids := subsetAllowedAuthIDsFromContext(outCtx); ids != nil {
+		t.Fatalf("subset ids = %v, want nil while disabled", ids)
+	}
+}
+
+func TestApplySubsetRoutingNoHeaderKeepsFullPool(t *testing.T) {
+	resetSubsetRouting(t)
+	SetSubsetRouting(true, SubsetEmptyPolicyReject, false, "")
+	m, _ := newSubsetTestManager(t, "auth-1")
+
+	ctx := context.Background()
+	outCtx, err := m.applySubsetRouting(ctx, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("applySubsetRouting error = %v, want nil", err)
+	}
+	if outCtx != ctx {
+		t.Fatalf("applySubsetRouting changed the context without a header")
+	}
+
+	// A header holding only malformed entries counts as empty as well.
+	outCtx, err = m.applySubsetRouting(ctx, subsetOptsWithHeader(" , !! , bad entry "))
+	if err != nil {
+		t.Fatalf("applySubsetRouting error = %v, want nil for malformed-only header", err)
+	}
+	if outCtx != ctx {
+		t.Fatalf("applySubsetRouting changed the context for a malformed-only header")
+	}
+}
+
+func TestApplySubsetRoutingFiltersEligibilityToSubset(t *testing.T) {
+	resetSubsetRouting(t)
+	SetSubsetRouting(true, SubsetEmptyPolicyFallback, false, "")
+	m, indexes := newSubsetTestManager(t, "auth-1", "auth-2", "auth-3")
+
+	opts := subsetOptsWithHeader(indexes["auth-1"] + ", " + indexes["auth-2"])
+	outCtx, err := m.applySubsetRouting(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("applySubsetRouting error = %v, want nil", err)
+	}
+	ids := subsetAllowedAuthIDsFromContext(outCtx)
+	want := map[string]struct{}{"auth-1": {}, "auth-2": {}}
+	if !reflect.DeepEqual(ids, want) {
+		t.Fatalf("subset ids = %v, want %v", ids, want)
+	}
+
+	eligibility := authSelectionEligibilityForRequest(outCtx, opts)
+	if !eligibility.allows(m.auths["auth-1"]) {
+		t.Fatalf("eligibility rejected auth-1, want allowed")
+	}
+	if !eligibility.allows(m.auths["auth-2"]) {
+		t.Fatalf("eligibility rejected auth-2, want allowed")
+	}
+	if eligibility.allows(m.auths["auth-3"]) {
+		t.Fatalf("eligibility allowed auth-3 outside the subset")
+	}
+}
+
+func TestApplySubsetRoutingIgnoresUnknownEntries(t *testing.T) {
+	resetSubsetRouting(t)
+	SetSubsetRouting(true, SubsetEmptyPolicyReject, false, "")
+	m, indexes := newSubsetTestManager(t, "auth-1", "auth-2")
+
+	// Repeated header lines behave like one comma separated list.
+	opts := subsetOptsWithHeader(indexes["auth-1"], "ffffffffffffffff")
+	outCtx, err := m.applySubsetRouting(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("applySubsetRouting error = %v, want nil", err)
+	}
+	ids := subsetAllowedAuthIDsFromContext(outCtx)
+	want := map[string]struct{}{"auth-1": {}}
+	if !reflect.DeepEqual(ids, want) {
+		t.Fatalf("subset ids = %v, want %v", ids, want)
+	}
+}
+
+func TestApplySubsetRoutingAllUnknownFallbackUsesFullPool(t *testing.T) {
+	resetSubsetRouting(t)
+	SetSubsetRouting(true, SubsetEmptyPolicyFallback, false, "")
+	m, _ := newSubsetTestManager(t, "auth-1")
+
+	ctx := context.Background()
+	outCtx, err := m.applySubsetRouting(ctx, subsetOptsWithHeader("ffffffffffffffff"))
+	if err != nil {
+		t.Fatalf("applySubsetRouting error = %v, want nil under fallback policy", err)
+	}
+	if outCtx != ctx {
+		t.Fatalf("applySubsetRouting changed the context under fallback policy")
+	}
+	if ids := subsetAllowedAuthIDsFromContext(outCtx); ids != nil {
+		t.Fatalf("subset ids = %v, want nil under fallback policy", ids)
+	}
+}
+
+func TestApplySubsetRoutingAllUnknownRejectReturns429(t *testing.T) {
+	resetSubsetRouting(t)
+	SetSubsetRouting(true, SubsetEmptyPolicyReject, false, "")
+	m, _ := newSubsetTestManager(t, "auth-1")
+
+	_, err := m.applySubsetRouting(context.Background(), subsetOptsWithHeader("ffffffffffffffff"))
+	if err == nil {
+		t.Fatalf("applySubsetRouting error = nil, want reject error")
+	}
+	var authErr *Error
+	if !errors.As(err, &authErr) {
+		t.Fatalf("applySubsetRouting error type = %T, want *Error", err)
+	}
+	if authErr.Code != "auth_subset_unavailable" {
+		t.Fatalf("error code = %q, want auth_subset_unavailable", authErr.Code)
+	}
+	if authErr.HTTPStatus != http.StatusTooManyRequests {
+		t.Fatalf("error status = %d, want %d", authErr.HTTPStatus, http.StatusTooManyRequests)
+	}
+}
+
+func TestSetSubsetRoutingNormalizesEmptyPolicy(t *testing.T) {
+	resetSubsetRouting(t)
+	SetSubsetRouting(true, "no-such-policy", false, "")
+	if policy := subsetRoutingSnapshot().emptyPolicy; policy != SubsetEmptyPolicyFallback {
+		t.Fatalf("empty policy = %q, want %q", policy, SubsetEmptyPolicyFallback)
+	}
+	SetSubsetRouting(true, " REJECT ", false, "")
+	if policy := subsetRoutingSnapshot().emptyPolicy; policy != SubsetEmptyPolicyReject {
+		t.Fatalf("empty policy = %q, want %q", policy, SubsetEmptyPolicyReject)
+	}
+}


### PR DESCRIPTION
## Motivation

In multi-tenant deployments where one CLIProxyAPI instance serves many users, operators sometimes need per-request control over *which* credentials from the auth pool a request may use — e.g. to bind specific subscription accounts to specific platform users for quota attribution and per-user accounting, while still keeping the built-in rotation and failover behavior within that subset.

## What this adds

An **opt-in** request header `X-Auth-Subset: <comma-separated auth indexes>` that filters the candidate auth pool *before* the existing selection logic runs. Selection, rotation, and failover semantics are untouched — the subset only narrows the candidates and then delegates to the existing conductor.

- `subset.enabled` (default **false**): with the default config this change is a strict no-op — no behavior difference at all.
- No header / empty header value → full pool (current behavior), even when enabled.
- Unknown indexes in the header are ignored; if the resulting subset is empty, `subset.empty-policy` decides: `fallback` (default, full pool) or `reject` (HTTP 429 with a JSON error).
- `subset.require-signature` + `subset.signature-key` are reserved config fields for a future HMAC check on the header (not implemented here; documented as TODO).

## Implementation notes

- Core logic is isolated in `sdk/cliproxy/auth/subset.go` (pure functions) with tests in `subset_test.go` (8 cases: hit/miss/unknown-ignored/empty-both-policies/no-header/disabled).
- Touch points in existing code are minimal (config struct + 2 small hooks in conductor selection/execution) to keep the change easy to review and rebase.
- `config.example.yaml` documents the new section.

## Verification

- `go build ./...`, `go vet` clean, `gofmt` clean.
- Full `go test ./...`: all packages pass (90 ok / 0 FAIL) with the patch applied.

Happy to adjust naming, placement, or split the reserved signature fields out if you prefer a smaller surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)