### PR TITLE
fix(xai): simplify mcp__codex_app.automation_update schema

### DIFF
--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -27,9 +27,11 @@ const (
 	xaiToolSearchType          = "tool_search"
 	xaiWebSearchToolType       = "web_search"
 	xaiXSearchToolType         = "x_search"
-	// Codex Desktop injects codex_app.automation_update with a large oneOf+$ref
-	// schema. xAI's free/build Responses path accepts the HTTP request but never
-	// emits SSE when that schema is present, so Desktop hangs on "thinking".
+	// Codex Desktop injects automation_update under the codex_app namespace, and
+	// 0.150+ wraps the same surface as mcp__codex_app. The schema is a large
+	// oneOf+$ref union. xAI's free/build Responses path accepts the HTTP request
+	// but never emits SSE when that schema is present, so Desktop hangs on
+	// "thinking"; Grok CLI chat-proxy instead returns 400 invalid-argument.
 	xaiCodexAppNamespaceName    = "codex_app"
 	xaiAutomationUpdateToolName = "automation_update"
 	// Permissive placeholder schema: keeps the tool callable without the hang.

--- a/internal/runtime/executor/xai_executor_response.go
+++ b/internal/runtime/executor/xai_executor_response.go
@@ -408,10 +408,12 @@ func xaiIsCodexAppNamespace(namespaceName string) bool {
 	return name == xaiCodexAppNamespaceName || strings.HasSuffix(name, "__"+xaiCodexAppNamespaceName)
 }
 
-// xaiIsCodexAppAutomationUpdate 识别 Codex Desktop 的 automation_update。
-// 旧客户端 namespace 是 codex_app；0.150+ 变成 mcp__codex_app。拍扁后名字是
-// codex_app__automation_update 或 mcp__codex_app__automation_update。
-// 只按精确旧名匹配会把新 schema 原样发给 Grok，触发 400 invalid-argument。
+// xaiIsCodexAppAutomationUpdate reports whether a function tool is Codex
+// Desktop automation_update. Older clients use the codex_app namespace;
+// 0.150+ wraps it as mcp__codex_app. Flattened names are
+// codex_app__automation_update or mcp__codex_app__automation_update.
+// Matching only the old exact name forwards the new schema to Grok
+// unchanged and triggers 400 invalid-argument.
 func xaiIsCodexAppAutomationUpdate(toolName, namespaceName string) bool {
 	toolName = strings.TrimSpace(toolName)
 	if toolName == "" {
@@ -447,8 +449,9 @@ func xaiFunctionParametersNeedSimplification(tool gjson.Result, namespaceName st
 			continue
 		}
 		for _, branch := range union.Array() {
-			// $ref 分支即使标了 type=object，展开后仍可能含 non-object union，
-			// Grok 会按 invalid_client_tool_schema / invalid-argument 直接拒绝。
+			// A $ref branch can still resolve to a non-object union even when
+			// it also declares type=object. Grok rejects those with
+			// invalid_client_tool_schema / invalid-argument.
 			if branch.Get("$ref").Exists() || !xaiSchemaTypeIsObjectOnly(branch.Get("type")) {
 				return true
 			}

--- a/internal/runtime/executor/xai_executor_response.go
+++ b/internal/runtime/executor/xai_executor_response.go
@@ -398,6 +398,33 @@ func xaiSchemaTypeIsObjectOnly(schemaType gjson.Result) bool {
 	return true
 }
 
+// xaiIsCodexAppNamespace reports whether a Responses namespace is the Codex app
+// tool surface. Desktop 0.150+ exposes it as mcp__codex_app instead of codex_app.
+func xaiIsCodexAppNamespace(namespaceName string) bool {
+	name := strings.ToLower(strings.TrimSpace(namespaceName))
+	if name == "" {
+		return false
+	}
+	return name == xaiCodexAppNamespaceName || strings.HasSuffix(name, "__"+xaiCodexAppNamespaceName)
+}
+
+// xaiIsCodexAppAutomationUpdate 识别 Codex Desktop 的 automation_update。
+// 旧客户端 namespace 是 codex_app；0.150+ 变成 mcp__codex_app。拍扁后名字是
+// codex_app__automation_update 或 mcp__codex_app__automation_update。
+// 只按精确旧名匹配会把新 schema 原样发给 Grok，触发 400 invalid-argument。
+func xaiIsCodexAppAutomationUpdate(toolName, namespaceName string) bool {
+	toolName = strings.TrimSpace(toolName)
+	if toolName == "" {
+		return false
+	}
+	flattenedName := xaiCodexAppNamespaceName + "__" + xaiAutomationUpdateToolName
+	lowerName := strings.ToLower(toolName)
+	if strings.EqualFold(toolName, flattenedName) || strings.HasSuffix(lowerName, "__"+flattenedName) {
+		return true
+	}
+	return strings.EqualFold(toolName, xaiAutomationUpdateToolName) && xaiIsCodexAppNamespace(namespaceName)
+}
+
 // xaiFunctionParametersNeedSimplification reports whether a function tool, or
 // a custom tool normalized to a function, has a schema that xAI cannot accept.
 func xaiFunctionParametersNeedSimplification(tool gjson.Result, namespaceName string) bool {
@@ -409,10 +436,7 @@ func xaiFunctionParametersNeedSimplification(tool gjson.Result, namespaceName st
 	}
 
 	toolName := strings.TrimSpace(tool.Get("name").String())
-	qualifiedAutomationName := xaiCodexAppNamespaceName + "__" + xaiAutomationUpdateToolName
-	if isFunction && (strings.EqualFold(toolName, qualifiedAutomationName) ||
-		(strings.EqualFold(strings.TrimSpace(namespaceName), xaiCodexAppNamespaceName) &&
-			strings.EqualFold(toolName, xaiAutomationUpdateToolName))) {
+	if isFunction && xaiIsCodexAppAutomationUpdate(toolName, namespaceName) {
 		return true
 	}
 
@@ -423,7 +447,9 @@ func xaiFunctionParametersNeedSimplification(tool gjson.Result, namespaceName st
 			continue
 		}
 		for _, branch := range union.Array() {
-			if !xaiSchemaTypeIsObjectOnly(branch.Get("type")) {
+			// $ref 分支即使标了 type=object，展开后仍可能含 non-object union，
+			// Grok 会按 invalid_client_tool_schema / invalid-argument 直接拒绝。
+			if branch.Get("$ref").Exists() || !xaiSchemaTypeIsObjectOnly(branch.Get("type")) {
 				return true
 			}
 		}

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -3673,46 +3673,70 @@ func TestXAIExecutorExecuteVideosUsesNativeEndpointFromRequestPath(t *testing.T)
 }
 
 func TestNormalizeXAITools_SimplifiesCodexAppAutomationUpdateSchema(t *testing.T) {
-	// Large oneOf+$ref schema mimicking Codex Desktop codex_app.automation_update.
-	params := `{"type":"object","oneOf":[{"properties":{"mode":{"type":"string"}}}],"$defs":{"a":{"type":"string"}},"x":"` + strings.Repeat("y", 1600) + `"}`
-	body := []byte(`{"model":"grok-4.5","tools":[{"type":"namespace","name":"codex_app","tools":[{"type":"function","name":"automation_update","description":"sched","strict":true,"parameters":` + params + `}]},{"type":"function","name":"exec_command","parameters":{"type":"object","properties":{"cmd":{"type":"string"}}}}]}`)
-	out := normalizeXAITools(body)
+	// Large oneOf+$ref schema mimicking Codex Desktop automation_update.
+	params := `{"type":"object","oneOf":[{"$ref":"#/$defs/a","type":"object"}],"$defs":{"a":{"type":"object","oneOf":[{"type":"object"},{"type":"null"}]}},"x":"` + strings.Repeat("y", 1600) + `"}`
+	tests := []struct {
+		name         string
+		body         []byte
+		wantAutoName string
+	}{
+		{
+			name:         "codex_app namespace",
+			wantAutoName: "codex_app__automation_update",
+			body:         []byte(`{"model":"grok-4.5","tools":[{"type":"namespace","name":"codex_app","tools":[{"type":"function","name":"automation_update","description":"sched","strict":true,"parameters":` + params + `}]},{"type":"function","name":"exec_command","parameters":{"type":"object","properties":{"cmd":{"type":"string"}}}}]}`),
+		},
+		{
+			name:         "mcp__codex_app namespace",
+			wantAutoName: "mcp__codex_app__automation_update",
+			body:         []byte(`{"model":"grok-4.6","tools":[{"type":"namespace","name":"mcp__codex_app","tools":[{"type":"function","name":"automation_update","description":"sched","strict":true,"parameters":` + params + `}]},{"type":"function","name":"exec_command","parameters":{"type":"object","properties":{"cmd":{"type":"string"}}}}]}`),
+		},
+		{
+			name:         "flattened mcp__codex_app name",
+			wantAutoName: "mcp__codex_app__automation_update",
+			body:         []byte(`{"model":"grok-4.6","tools":[{"type":"function","name":"mcp__codex_app__automation_update","description":"sched","strict":true,"parameters":` + params + `},{"type":"function","name":"exec_command","parameters":{"type":"object","properties":{"cmd":{"type":"string"}}}}]}`),
+		},
+	}
 
-	tools := gjson.GetBytes(out, "tools")
-	if !tools.IsArray() {
-		t.Fatalf("tools missing: %s", string(out))
-	}
-	foundAuto := false
-	foundExec := false
-	for _, tool := range tools.Array() {
-		switch tool.Get("name").String() {
-		case "codex_app__automation_update":
-			foundAuto = true
-			paramsRaw := tool.Get("parameters").Raw
-			if strings.Contains(paramsRaw, `"oneOf"`) || strings.Contains(paramsRaw, `"$defs"`) {
-				t.Fatalf("automation_update parameters were not simplified: %s", paramsRaw)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := normalizeXAITools(tt.body)
+			tools := gjson.GetBytes(out, "tools")
+			if !tools.IsArray() {
+				t.Fatalf("tools missing: %s", string(out))
 			}
-			if tool.Get("parameters.type").String() != "object" {
-				t.Fatalf("automation_update parameters.type = %q, want object", tool.Get("parameters.type").String())
+			foundAuto := false
+			foundExec := false
+			for _, tool := range tools.Array() {
+				switch tool.Get("name").String() {
+				case tt.wantAutoName:
+					foundAuto = true
+					paramsRaw := tool.Get("parameters").Raw
+					if strings.Contains(paramsRaw, `"oneOf"`) || strings.Contains(paramsRaw, `"$defs"`) || strings.Contains(paramsRaw, `"$ref"`) {
+						t.Fatalf("automation_update parameters were not simplified: %s", paramsRaw)
+					}
+					if tool.Get("parameters.type").String() != "object" {
+						t.Fatalf("automation_update parameters.type = %q, want object", tool.Get("parameters.type").String())
+					}
+					if tool.Get("parameters.additionalProperties").Type != gjson.True {
+						t.Fatalf("automation_update parameters should allow additionalProperties: %s", paramsRaw)
+					}
+					if tool.Get("strict").Type != gjson.False {
+						t.Fatalf("automation_update strict = %s, want false", tool.Get("strict").Raw)
+					}
+				case "exec_command":
+					foundExec = true
+					if got := tool.Get("parameters.properties.cmd.type").String(); got != "string" {
+						t.Fatalf("exec_command schema should be preserved, got %q in %s", got, tool.Raw)
+					}
+				}
 			}
-			if tool.Get("parameters.additionalProperties").Type != gjson.True {
-				t.Fatalf("automation_update parameters should allow additionalProperties: %s", paramsRaw)
+			if !foundAuto {
+				t.Fatalf("automation_update tool missing after normalize: %s", string(out))
 			}
-			if tool.Get("strict").Type != gjson.False {
-				t.Fatalf("automation_update strict = %s, want false", tool.Get("strict").Raw)
+			if !foundExec {
+				t.Fatalf("exec_command tool missing after normalize: %s", string(out))
 			}
-		case "exec_command":
-			foundExec = true
-			if got := tool.Get("parameters.properties.cmd.type").String(); got != "string" {
-				t.Fatalf("exec_command schema should be preserved, got %q in %s", got, tool.Raw)
-			}
-		}
-	}
-	if !foundAuto {
-		t.Fatalf("automation_update tool missing after normalize: %s", string(out))
-	}
-	if !foundExec {
-		t.Fatalf("exec_command tool missing after normalize: %s", string(out))
+		})
 	}
 }
 
@@ -4060,6 +4084,17 @@ func TestXAIFunctionParametersNeedSimplification(t *testing.T) {
 	flattened := gjson.Parse(`{"type":"function","name":"codex_app__automation_update","parameters":{"type":"object"}}`)
 	if !xaiFunctionParametersNeedSimplification(flattened, "") {
 		t.Fatal("flattened codex_app__automation_update should need simplification")
+	}
+	if !xaiFunctionParametersNeedSimplification(auto, "mcp__codex_app") {
+		t.Fatal("mcp__codex_app.automation_update should need simplification")
+	}
+	mcpFlattened := gjson.Parse(`{"type":"function","name":"mcp__codex_app__automation_update","parameters":{"type":"object"}}`)
+	if !xaiFunctionParametersNeedSimplification(mcpFlattened, "") {
+		t.Fatal("flattened mcp__codex_app__automation_update should need simplification")
+	}
+	refUnion := gjson.Parse(`{"type":"function","name":"lookup","parameters":{"type":"object","oneOf":[{"$ref":"#/$defs/a","type":"object"}],"$defs":{"a":{"type":"object"}}}}`)
+	if !xaiFunctionParametersNeedSimplification(refUnion, "") {
+		t.Fatal("root oneOf branch with $ref should need simplification")
 	}
 	custom := gjson.Parse(`{"type":"custom","name":"automation_update","parameters":{"type":"object"}}`)
 	if xaiFunctionParametersNeedSimplification(custom, "codex_app") {


### PR DESCRIPTION
## Summary
Codex Desktop 0.150+ wraps app tools as `mcp__codex_app`. CLIProxyAPI only simplified the old `codex_app` / `codex_app__automation_update` names, so the flattened `mcp__codex_app__automation_update` `oneOf+$ref` schema was forwarded to `cli-chat-proxy.grok.com` and rejected with `400 invalid-argument`.

## What changed
- Treat Codex app namespaces that are exactly `codex_app` or end with `__codex_app`.
- Treat root `oneOf`/`anyOf` branches that carry `$ref` as unsafe even when they also declare `type: object`.
- Cover the Desktop 0.150 namespaced, flattened, and `$ref` union shapes in tests.

## Test plan
- [x] `go test ./internal/runtime/executor/ -run 'TestXAIFunctionParametersNeedSimplification|TestNormalizeXAITools_SimplifiesCodexAppAutomationUpdateSchema|TestNormalizeXAITools_PreservesUnrelatedSchemas'`
- Live Grok CLI-proxy first-turn with Codex Desktop `mcp__codex_app__automation_update` no longer returns `invalid-argument`.

Fixes the remaining gap after #4343. Related to #5214 (same opaque `invalid-argument`, different cause: schema vs 200-tool limit).