### PR TITLE
perf(chatgpt): reuse uTLS HTTP/2 connections

### DIFF
--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -30,6 +31,31 @@ type utlsRoundTripper struct {
 	sessionCache tls.ClientSessionCache
 	transport    *http2.Transport
 	tlsConfig    func(string, tls.ClientSessionCache) *tls.Config
+
+	lifecycleMu          sync.Mutex
+	draining             bool
+	activeResponses      int
+	closeIdleConnections func()
+}
+
+type utlsResponseBody struct {
+	io.ReadCloser
+	release func()
+	once    sync.Once
+}
+
+func (b *utlsResponseBody) Read(payload []byte) (int, error) {
+	read, errRead := b.ReadCloser.Read(payload)
+	if errRead != nil {
+		b.once.Do(b.release)
+	}
+	return read, errRead
+}
+
+func (b *utlsResponseBody) Close() error {
+	errClose := b.ReadCloser.Close()
+	b.once.Do(b.release)
+	return errClose
 }
 
 const (
@@ -40,6 +66,10 @@ const (
 var chatGPTRoundTripperCache = internalcache.NewBoundedLRU[string, http.RoundTripper](
 	chatGPTRoundTripperCacheCapacity,
 	func(_ string, roundTripper http.RoundTripper) {
+		if transport, ok := roundTripper.(interface{ closeWhenIdle() }); ok {
+			transport.closeWhenIdle()
+			return
+		}
 		if transport, ok := roundTripper.(interface{ CloseIdleConnections() }); ok {
 			transport.CloseIdleConnections()
 		}
@@ -75,6 +105,7 @@ func newUtlsRoundTripperWithDialer(
 		tlsConfig:    tlsConfig,
 	}
 	roundTripper.transport = &http2.Transport{DialTLSContext: roundTripper.dialTLSContext}
+	roundTripper.closeIdleConnections = roundTripper.transport.CloseIdleConnections
 	return roundTripper
 }
 
@@ -155,7 +186,10 @@ func (t *utlsRoundTripper) dialTLSContext(ctx context.Context, network, addr str
 
 func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := t.transport.RoundTrip(req)
-	if err == nil || !isRetryableUtlsConnectionError(err) {
+	if err == nil {
+		return t.trackResponse(resp), nil
+	}
+	if !isRetryableUtlsConnectionError(err) {
 		return resp, err
 	}
 	retryReq, ok := replayableUtlsRequest(req)
@@ -166,12 +200,65 @@ func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	// A connection-level failure before response headers may leave a stale
 	// pooled connection behind. Close idle entries and make one immediate retry;
 	// never replay a request whose HTTP semantics or body are not replay-safe.
-	t.transport.CloseIdleConnections()
-	return t.transport.RoundTrip(retryReq)
+	t.CloseIdleConnections()
+	retryResp, errRetry := t.transport.RoundTrip(retryReq)
+	if errRetry != nil {
+		return retryResp, errRetry
+	}
+	return t.trackResponse(retryResp), nil
 }
 
 func (t *utlsRoundTripper) CloseIdleConnections() {
-	t.transport.CloseIdleConnections()
+	if t.closeIdleConnections != nil {
+		t.closeIdleConnections()
+	}
+}
+
+// closeWhenIdle retires an evicted transport without interrupting active
+// streams. Existing clients may still hold the round tripper; every response
+// they finish after eviction closes any connection that has become idle.
+func (t *utlsRoundTripper) closeWhenIdle() {
+	t.lifecycleMu.Lock()
+	t.draining = true
+	t.lifecycleMu.Unlock()
+	t.CloseIdleConnections()
+}
+
+func (t *utlsRoundTripper) trackResponse(resp *http.Response) *http.Response {
+	if resp == nil || resp.Body == nil || resp.Body == http.NoBody {
+		t.closeIdleIfDraining()
+		return resp
+	}
+
+	t.lifecycleMu.Lock()
+	t.activeResponses++
+	t.lifecycleMu.Unlock()
+	resp.Body = &utlsResponseBody{
+		ReadCloser: resp.Body,
+		release:    t.releaseResponse,
+	}
+	return resp
+}
+
+func (t *utlsRoundTripper) releaseResponse() {
+	t.lifecycleMu.Lock()
+	if t.activeResponses > 0 {
+		t.activeResponses--
+	}
+	shouldClose := t.draining && t.activeResponses == 0
+	t.lifecycleMu.Unlock()
+	if shouldClose {
+		t.CloseIdleConnections()
+	}
+}
+
+func (t *utlsRoundTripper) closeIdleIfDraining() {
+	t.lifecycleMu.Lock()
+	shouldClose := t.draining && t.activeResponses == 0
+	t.lifecycleMu.Unlock()
+	if shouldClose {
+		t.CloseIdleConnections()
+	}
 }
 
 func isRetryableUtlsConnectionError(err error) bool {

--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -2,13 +2,14 @@ package helps
 
 import (
 	"context"
+	stdtls "crypto/tls"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"strings"
-	"sync"
+	"syscall"
 	"time"
 
 	tls "github.com/refraction-networking/utls"
@@ -22,37 +23,28 @@ import (
 	"golang.org/x/net/proxy"
 )
 
-// utlsRoundTripper implements http.RoundTripper using a Chrome fingerprint for
-// providers that require a browser-like TLS and HTTP/2 transport. Each request
-// gets a dedicated connection that is closed with the response body.
+// utlsRoundTripper implements http.RoundTripper using a Chrome fingerprint and
+// a reusable HTTP/2 connection pool for ChatGPT.
 type utlsRoundTripper struct {
-	dialer proxy.Dialer
+	dialer       proxy.Dialer
+	sessionCache tls.ClientSessionCache
+	transport    *http2.Transport
+	tlsConfig    func(string, tls.ClientSessionCache) *tls.Config
 }
 
-type closeConnectionBody struct {
-	io.ReadCloser
-	closeConnection func() error
-	once            sync.Once
-	err             error
-}
+const (
+	chatGPTSessionCacheCapacity      = 32
+	chatGPTRoundTripperCacheCapacity = 64
+)
 
-func (b *closeConnectionBody) Close() error {
-	if b == nil {
-		return nil
-	}
-	b.once.Do(func() {
-		var errConnection error
-		if b.closeConnection != nil {
-			errConnection = b.closeConnection()
+var chatGPTRoundTripperCache = internalcache.NewBoundedLRU[string, http.RoundTripper](
+	chatGPTRoundTripperCacheCapacity,
+	func(_ string, roundTripper http.RoundTripper) {
+		if transport, ok := roundTripper.(interface{ CloseIdleConnections() }); ok {
+			transport.CloseIdleConnections()
 		}
-		var errBody error
-		if b.ReadCloser != nil {
-			errBody = b.ReadCloser.Close()
-		}
-		b.err = errors.Join(errBody, errConnection)
-	})
-	return b.err
-}
+	},
+)
 
 func newUtlsRoundTripper(proxyURL string) *utlsRoundTripper {
 	var dialer proxy.Dialer = proxy.Direct
@@ -64,78 +56,158 @@ func newUtlsRoundTripper(proxyURL string) *utlsRoundTripper {
 			dialer = proxyDialer
 		}
 	}
-	return &utlsRoundTripper{dialer: dialer}
+	return newUtlsRoundTripperWithDialer(dialer, newChatGPTTLSConfig)
 }
 
-func (t *utlsRoundTripper) createConnection(ctx context.Context, host, addr string) (*http2.ClientConn, error) {
+func newUtlsRoundTripperWithDialer(
+	dialer proxy.Dialer,
+	tlsConfig func(string, tls.ClientSessionCache) *tls.Config,
+) *utlsRoundTripper {
+	if dialer == nil {
+		dialer = proxy.Direct
+	}
+	if tlsConfig == nil {
+		tlsConfig = newChatGPTTLSConfig
+	}
+	roundTripper := &utlsRoundTripper{
+		dialer:       dialer,
+		sessionCache: tls.NewLRUClientSessionCache(chatGPTSessionCacheCapacity),
+		tlsConfig:    tlsConfig,
+	}
+	roundTripper.transport = &http2.Transport{DialTLSContext: roundTripper.dialTLSContext}
+	return roundTripper
+}
+
+func newChatGPTTLSConfig(host string, sessionCache tls.ClientSessionCache) *tls.Config {
+	return &tls.Config{
+		ServerName:                         host,
+		ClientSessionCache:                 sessionCache,
+		OmitEmptyPsk:                       true,
+		PreferSkipResumptionOnNilExtension: true,
+	}
+}
+
+// chatGPTTLSClientHelloSpec extends the current Chrome fingerprint with an
+// empty PSK extension. uTLS omits it on a cold connection and populates it from
+// the per-transport session cache on later TLS 1.3 handshakes. RFC 8446
+// requires pre_shared_key to remain the final ClientHello extension.
+func chatGPTTLSClientHelloSpec() (*tls.ClientHelloSpec, error) {
+	spec, err := tls.UTLSIdToSpec(tls.HelloChrome_Auto)
+	if err != nil {
+		return nil, fmt.Errorf("utls: build Chrome ClientHello: %w", err)
+	}
+	spec.Extensions = append(spec.Extensions, &tls.UtlsPreSharedKeyExtension{})
+	return &spec, nil
+}
+
+func cachedChatGPTRoundTripper(proxyURL string) http.RoundTripper {
+	return chatGPTRoundTripperCache.GetOrAdd(proxyURL, func() http.RoundTripper {
+		return newUtlsRoundTripper(proxyURL)
+	})
+}
+
+func (t *utlsRoundTripper) dialTLSContext(ctx context.Context, network, addr string, _ *stdtls.Config) (net.Conn, error) {
 	contextDialer, ok := t.dialer.(proxy.ContextDialer)
 	if !ok {
 		return nil, fmt.Errorf("utls: dialer does not support context cancellation")
 	}
-	conn, errDial := contextDialer.DialContext(ctx, "tcp", addr)
+	conn, errDial := contextDialer.DialContext(ctx, network, addr)
 	if errDial != nil {
 		return nil, fmt.Errorf("utls: dial upstream: %w", errDial)
 	}
 
-	tlsConfig := &tls.Config{ServerName: host}
-	tlsConn := tls.UClient(conn, tlsConfig, tls.HelloChrome_Auto)
+	host, _, errSplit := net.SplitHostPort(addr)
+	if errSplit != nil {
+		if errClose := conn.Close(); errClose != nil {
+			log.Debugf("utls: close connection after address parse failure: %v", errClose)
+		}
+		return nil, fmt.Errorf("utls: split upstream address: %w", errSplit)
+	}
+	spec, errSpec := chatGPTTLSClientHelloSpec()
+	if errSpec != nil {
+		if errClose := conn.Close(); errClose != nil {
+			log.Debugf("utls: close connection after ClientHello failure: %v", errClose)
+		}
+		return nil, errSpec
+	}
+	tlsConn := tls.UClient(conn, t.tlsConfig(host, t.sessionCache), tls.HelloCustom)
+	if errPreset := tlsConn.ApplyPreset(spec); errPreset != nil {
+		if errClose := tlsConn.Close(); errClose != nil {
+			log.Debugf("utls: close connection after preset failure: %v", errClose)
+		}
+		return nil, fmt.Errorf("utls: apply Chrome ClientHello: %w", errPreset)
+	}
 
 	if errHandshake := tlsConn.HandshakeContext(ctx); errHandshake != nil {
-		if errors.Is(errHandshake, context.Canceled) || errors.Is(errHandshake, context.DeadlineExceeded) {
-			return nil, fmt.Errorf("utls: TLS handshake: %w", errHandshake)
-		}
-		if errClose := conn.Close(); errClose != nil {
-			return nil, fmt.Errorf("utls: TLS handshake: %w; close connection: %v", errHandshake, errClose)
+		if errClose := tlsConn.Close(); errClose != nil {
+			log.Debugf("utls: close connection after handshake failure: %v", errClose)
 		}
 		return nil, fmt.Errorf("utls: TLS handshake: %w", errHandshake)
 	}
-
-	tr := &http2.Transport{}
-	h2Conn, errClientConn := tr.NewClientConn(tlsConn)
-	if errClientConn != nil {
+	if negotiatedProtocol := tlsConn.ConnectionState().NegotiatedProtocol; negotiatedProtocol != http2.NextProtoTLS {
 		if errClose := tlsConn.Close(); errClose != nil {
-			return nil, fmt.Errorf("utls: initialize HTTP/2 connection: %w; close TLS connection: %v", errClientConn, errClose)
+			log.Debugf("utls: close connection after ALPN mismatch: %v", errClose)
 		}
-		return nil, fmt.Errorf("utls: initialize HTTP/2 connection: %w", errClientConn)
+		return nil, fmt.Errorf("utls: unexpected ALPN protocol %q; want %q", negotiatedProtocol, http2.NextProtoTLS)
 	}
-
-	return h2Conn, nil
+	return tlsConn, nil
 }
 
 func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	hostname := req.URL.Hostname()
-	port := req.URL.Port()
-	if port == "" {
-		port = "443"
+	resp, err := t.transport.RoundTrip(req)
+	if err == nil || !isRetryableUtlsConnectionError(err) {
+		return resp, err
 	}
-	addr := net.JoinHostPort(hostname, port)
-
-	h2Conn, err := t.createConnection(req.Context(), hostname, addr)
-	if err != nil {
-		return nil, err
+	retryReq, ok := replayableUtlsRequest(req)
+	if !ok {
+		return resp, err
 	}
 
-	resp, err := h2Conn.RoundTrip(req)
-	if err != nil {
-		if errClose := h2Conn.Close(); errClose != nil {
-			log.Debugf("utls: close connection after round trip failure: %v", errClose)
+	// A connection-level failure before response headers may leave a stale
+	// pooled connection behind. Close idle entries and make one immediate retry;
+	// never replay a request whose HTTP semantics or body are not replay-safe.
+	t.transport.CloseIdleConnections()
+	return t.transport.RoundTrip(retryReq)
+}
+
+func (t *utlsRoundTripper) CloseIdleConnections() {
+	t.transport.CloseIdleConnections()
+}
+
+func isRetryableUtlsConnectionError(err error) bool {
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, net.ErrClosed) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EPIPE)
+}
+
+func replayableUtlsRequest(req *http.Request) (*http.Request, bool) {
+	if req == nil || (req.Body != nil && req.Body != http.NoBody && req.GetBody == nil) {
+		return nil, false
+	}
+	method := req.Method
+	if method == "" {
+		method = http.MethodGet
+	}
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
+		// These methods are replay-safe when the body can be reconstructed.
+	default:
+		if req.Header.Get("Idempotency-Key") == "" && req.Header.Get("X-Idempotency-Key") == "" {
+			return nil, false
 		}
-		return nil, err
 	}
-	if resp == nil {
-		if errClose := h2Conn.Close(); errClose != nil {
-			log.Debugf("utls: close connection after empty response: %v", errClose)
+
+	retryReq := req.Clone(req.Context())
+	if req.Body != nil && req.Body != http.NoBody {
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, false
 		}
-		return nil, fmt.Errorf("utls: upstream returned an empty response")
+		retryReq.Body = body
 	}
-	if resp.Body == nil {
-		resp.Body = http.NoBody
-	}
-	resp.Body = &closeConnectionBody{
-		ReadCloser:      resp.Body,
-		closeConnection: h2Conn.Close,
-	}
-	return resp, nil
+	return retryReq, true
 }
 
 // claudeCodeSessionCacheCapacity bounds the per-transport TLS session cache for
@@ -380,7 +452,7 @@ func NewUtlsHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyau
 		ctxRoundTripper, _ = ctx.Value("cliproxy.roundtripper").(http.RoundTripper)
 	}
 
-	var chromeRT http.RoundTripper = newUtlsRoundTripper(proxyURL)
+	var chromeRT http.RoundTripper = cachedChatGPTRoundTripper(proxyURL)
 	var anthropicRT http.RoundTripper = cachedClaudeCodeRoundTripper(proxyURL)
 	var standardTransport http.RoundTripper = http.DefaultTransport
 	if proxyURL != "" {

--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -34,7 +34,6 @@ type utlsRoundTripper struct {
 
 	lifecycleMu          sync.Mutex
 	draining             bool
-	activeResponses      int
 	closeIdleConnections func()
 }
 
@@ -230,9 +229,6 @@ func (t *utlsRoundTripper) trackResponse(resp *http.Response) *http.Response {
 		return resp
 	}
 
-	t.lifecycleMu.Lock()
-	t.activeResponses++
-	t.lifecycleMu.Unlock()
 	resp.Body = &utlsResponseBody{
 		ReadCloser: resp.Body,
 		release:    t.releaseResponse,
@@ -242,10 +238,7 @@ func (t *utlsRoundTripper) trackResponse(resp *http.Response) *http.Response {
 
 func (t *utlsRoundTripper) releaseResponse() {
 	t.lifecycleMu.Lock()
-	if t.activeResponses > 0 {
-		t.activeResponses--
-	}
-	shouldClose := t.draining && t.activeResponses == 0
+	shouldClose := t.draining
 	t.lifecycleMu.Unlock()
 	if shouldClose {
 		t.CloseIdleConnections()
@@ -254,7 +247,7 @@ func (t *utlsRoundTripper) releaseResponse() {
 
 func (t *utlsRoundTripper) closeIdleIfDraining() {
 	t.lifecycleMu.Lock()
-	shouldClose := t.draining && t.activeResponses == 0
+	shouldClose := t.draining
 	t.lifecycleMu.Unlock()
 	if shouldClose {
 		t.CloseIdleConnections()

--- a/internal/runtime/executor/helps/utls_client_resumption_test.go
+++ b/internal/runtime/executor/helps/utls_client_resumption_test.go
@@ -1,6 +1,7 @@
 package helps
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -11,11 +12,128 @@ import (
 	"io"
 	"math/big"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	tls "github.com/refraction-networking/utls"
 )
+
+func TestChatGPTUtlsTransportReusesHTTP2AndResumesAfterReconnect(t *testing.T) {
+	var (
+		stateMu          sync.Mutex
+		seenConnections  = make(map[net.Conn]struct{})
+		resumptions      []bool
+		connectionClosed = make(chan struct{}, 1)
+	)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = io.WriteString(w, "ok")
+	}))
+	server.EnableHTTP2 = true
+	server.TLS = &gotls.Config{MinVersion: gotls.VersionTLS13}
+	server.Config.ConnState = func(conn net.Conn, state http.ConnState) {
+		if state == http.StateClosed {
+			select {
+			case connectionClosed <- struct{}{}:
+			default:
+			}
+			return
+		}
+		if state != http.StateActive {
+			return
+		}
+		tlsConn, ok := conn.(*gotls.Conn)
+		if !ok {
+			return
+		}
+		stateMu.Lock()
+		defer stateMu.Unlock()
+		if _, seen := seenConnections[conn]; seen {
+			return
+		}
+		seenConnections[conn] = struct{}{}
+		resumptions = append(resumptions, tlsConn.ConnectionState().DidResume)
+	}
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	var dialCount atomic.Int32
+	dialer := contextDialerFunc(func(ctx context.Context, network, _ string) (net.Conn, error) {
+		dialCount.Add(1)
+		return (&net.Dialer{}).DialContext(ctx, network, server.Listener.Addr().String())
+	})
+	clientTLSConfig := func(host string, sessionCache tls.ClientSessionCache) *tls.Config {
+		config := newChatGPTTLSConfig(host, sessionCache)
+		config.InsecureSkipVerify = true // Loopback test server uses an ephemeral certificate.
+		config.MinVersion = tls.VersionTLS13
+		return config
+	}
+	roundTripper := newUtlsRoundTripperWithDialer(dialer, clientTLSConfig)
+	t.Cleanup(roundTripper.CloseIdleConnections)
+
+	request := func() {
+		t.Helper()
+		req, errRequest := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://chatgpt.com/backend-api/codex/responses", nil)
+		if errRequest != nil {
+			t.Fatal(errRequest)
+		}
+		resp, errRoundTrip := roundTripper.RoundTrip(req)
+		if errRoundTrip != nil {
+			t.Fatal(errRoundTrip)
+		}
+		if resp.ProtoMajor != 2 {
+			t.Fatalf("HTTP protocol = %q, want HTTP/2", resp.Proto)
+		}
+		payload, errRead := io.ReadAll(resp.Body)
+		errClose := resp.Body.Close()
+		if errRead != nil {
+			t.Fatal(errRead)
+		}
+		if errClose != nil {
+			t.Fatal(errClose)
+		}
+		if got := strings.TrimSpace(string(payload)); got != "ok" {
+			t.Fatalf("response body = %q, want %q", got, "ok")
+		}
+	}
+
+	request()
+	request()
+	if got := dialCount.Load(); got != 1 {
+		t.Fatalf("dials after two requests = %d, want 1 reusable HTTP/2 connection", got)
+	}
+
+	// Simulate an upstream connection failure. The next safe request must cause
+	// the HTTP/2 pool to discard the dead connection and establish a new one.
+	server.CloseClientConnections()
+	select {
+	case <-connectionClosed:
+	case <-time.After(time.Second):
+		t.Fatal("HTTP/2 client did not observe the closed upstream connection")
+	}
+	request()
+	if got := dialCount.Load(); got != 2 {
+		t.Fatalf("dials after upstream close = %d, want 2 after automatic rebuild", got)
+	}
+
+	stateMu.Lock()
+	gotResumptions := append([]bool(nil), resumptions...)
+	stateMu.Unlock()
+	if len(gotResumptions) != 2 {
+		t.Fatalf("server TLS connections = %d, want 2", len(gotResumptions))
+	}
+	if gotResumptions[0] {
+		t.Fatal("first TLS connection unexpectedly resumed")
+	}
+	if !gotResumptions[1] {
+		t.Fatal("rebuilt TLS connection did not resume the cached session")
+	}
+}
 
 // newResumptionTestCertificate mints a short-lived self-signed leaf for the
 // loopback TLS server used by the resumption test.

--- a/internal/runtime/executor/helps/utls_client_test.go
+++ b/internal/runtime/executor/helps/utls_client_test.go
@@ -29,21 +29,6 @@ func (f utlsClientRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, e
 	return f(req)
 }
 
-type trackedReadCloser struct {
-	io.Reader
-	closeCount int
-	closeErr   error
-	onClose    func()
-}
-
-func (r *trackedReadCloser) Close() error {
-	r.closeCount++
-	if r.onClose != nil {
-		r.onClose()
-	}
-	return r.closeErr
-}
-
 type contextDialerFunc func(context.Context, string, string) (net.Conn, error)
 
 func (f contextDialerFunc) Dial(network, addr string) (net.Conn, error) {
@@ -64,63 +49,13 @@ func (c *trackedNetConn) Close() error {
 	return c.Conn.Close()
 }
 
-func TestCloseConnectionBodyClosesConnectionBeforeBodyOnce(t *testing.T) {
-	bodyErr := errors.New("body close failed")
-	connectionErr := errors.New("connection close failed")
-	var closeOrder []string
-	body := &trackedReadCloser{
-		Reader:   strings.NewReader("response"),
-		closeErr: bodyErr,
-		onClose: func() {
-			closeOrder = append(closeOrder, "body")
-		},
-	}
-	connectionCloseCount := 0
-	wrapped := &closeConnectionBody{
-		ReadCloser: body,
-		closeConnection: func() error {
-			connectionCloseCount++
-			closeOrder = append(closeOrder, "connection")
-			return connectionErr
-		},
-	}
-
-	payload, errRead := io.ReadAll(wrapped)
-	if errRead != nil {
-		t.Fatal(errRead)
-	}
-	if got, want := string(payload), "response"; got != want {
-		t.Fatalf("response body = %q, want %q", got, want)
-	}
-
-	errClose := wrapped.Close()
-	if !errors.Is(errClose, bodyErr) {
-		t.Fatalf("close error = %v, want body close error", errClose)
-	}
-	if !errors.Is(errClose, connectionErr) {
-		t.Fatalf("close error = %v, want connection close error", errClose)
-	}
-	if errCloseAgain := wrapped.Close(); errCloseAgain != errClose {
-		t.Fatalf("second close error = %v, want %v", errCloseAgain, errClose)
-	}
-	if body.closeCount != 1 {
-		t.Fatalf("body close count = %d, want 1", body.closeCount)
-	}
-	if connectionCloseCount != 1 {
-		t.Fatalf("connection close count = %d, want 1", connectionCloseCount)
-	}
-	if want := []string{"connection", "body"}; !reflect.DeepEqual(closeOrder, want) {
-		t.Fatalf("close order = %v, want %v", closeOrder, want)
-	}
-}
-
 func TestUtlsRoundTripperDialUsesRequestContext(t *testing.T) {
 	dialStarted := make(chan struct{})
-	roundTripper := &utlsRoundTripper{dialer: contextDialerFunc(func(ctx context.Context, _, _ string) (net.Conn, error) {
+	roundTripper := newUtlsRoundTripperWithDialer(contextDialerFunc(func(ctx context.Context, _, _ string) (net.Conn, error) {
 		close(dialStarted)
 		<-ctx.Done()
 		return nil, ctx.Err()
-	})}
+	}), nil)
 	ctx, cancel := context.WithCancel(t.Context())
 	req, errRequest := http.NewRequestWithContext(ctx, http.MethodGet, "https://chatgpt.com/backend-api/codex/responses", nil)
 	if errRequest != nil {
@@ -164,16 +99,21 @@ func TestUtlsRoundTripperHandshakeUsesRequestContext(t *testing.T) {
 
 	trackedConn := &trackedNetConn{Conn: clientConn}
 	dialDone := make(chan struct{})
-	roundTripper := &utlsRoundTripper{dialer: contextDialerFunc(func(context.Context, string, string) (net.Conn, error) {
+	roundTripper := newUtlsRoundTripperWithDialer(contextDialerFunc(func(context.Context, string, string) (net.Conn, error) {
 		close(dialDone)
 		return trackedConn, nil
-	})}
+	}), nil)
 	ctx, cancel := context.WithCancel(t.Context())
 	connectionDone := make(chan error, 1)
 	go func() {
-		h2Conn, errConnect := roundTripper.createConnection(ctx, "chatgpt.com", "chatgpt.com:443")
-		if h2Conn != nil {
-			errConnect = errors.Join(errConnect, h2Conn.Close())
+		req, errRequest := http.NewRequestWithContext(ctx, http.MethodGet, "https://chatgpt.com/backend-api/codex/responses", nil)
+		if errRequest != nil {
+			connectionDone <- errRequest
+			return
+		}
+		resp, errConnect := roundTripper.RoundTrip(req)
+		if resp != nil && resp.Body != nil {
+			errConnect = errors.Join(errConnect, resp.Body.Close())
 		}
 		connectionDone <- errConnect
 	}()
@@ -187,13 +127,39 @@ func TestUtlsRoundTripperHandshakeUsesRequestContext(t *testing.T) {
 	select {
 	case errConnect := <-connectionDone:
 		if !errors.Is(errConnect, context.Canceled) {
-			t.Fatalf("createConnection error = %v, want context canceled", errConnect)
+			t.Fatalf("RoundTrip error = %v, want context canceled", errConnect)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("TLS handshake did not stop after context cancellation")
 	}
-	if got := trackedConn.closeCount.Load(); got != 1 {
-		t.Fatalf("connection close count = %d, want 1", got)
+	if got := trackedConn.closeCount.Load(); got < 1 {
+		t.Fatalf("connection close count = %d, want at least 1", got)
+	}
+}
+
+func TestReplayableUtlsRequestRequiresIdempotentSemantics(t *testing.T) {
+	unsafePost, errRequest := http.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/codex/responses", strings.NewReader(`{"input":"hello"}`))
+	if errRequest != nil {
+		t.Fatal(errRequest)
+	}
+	if _, ok := replayableUtlsRequest(unsafePost); ok {
+		t.Fatal("POST without an idempotency key was marked replayable")
+	}
+
+	safePost, errRequest := http.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/codex/responses", strings.NewReader(`{"input":"hello"}`))
+	if errRequest != nil {
+		t.Fatal(errRequest)
+	}
+	safePost.Header.Set("Idempotency-Key", "test-request")
+	retry, ok := replayableUtlsRequest(safePost)
+	if !ok {
+		t.Fatal("POST with an idempotency key and GetBody was not replayable")
+	}
+	if retry.Body == safePost.Body {
+		t.Fatal("replayed request reused the original body")
+	}
+	if errClose := retry.Body.Close(); errClose != nil {
+		t.Fatal(errClose)
 	}
 }
 
@@ -353,6 +319,31 @@ func TestCachedClaudeCodeRoundTripperBoundsProxyCardinality(t *testing.T) {
 		t.Fatalf("transport cache entries = %d, want at most %d", got, claudeCodeRoundTripperCacheCapacity)
 	}
 	if recreated := cachedClaudeCodeRoundTripper(firstProxy); recreated == first {
+		t.Fatal("least recently used proxy transport was not evicted")
+	}
+}
+
+func TestCachedChatGPTRoundTripperReusesTransport(t *testing.T) {
+	t.Parallel()
+
+	const proxyURL = "http://127.0.0.1:29654"
+	first := cachedChatGPTRoundTripper(proxyURL)
+	second := cachedChatGPTRoundTripper(proxyURL)
+	if first != second {
+		t.Fatal("ChatGPT transport cache returned different transports for one proxy")
+	}
+}
+
+func TestCachedChatGPTRoundTripperBoundsProxyCardinality(t *testing.T) {
+	firstProxy := "http://127.0.0.1:31000"
+	first := cachedChatGPTRoundTripper(firstProxy)
+	for index := 1; index <= chatGPTRoundTripperCacheCapacity; index++ {
+		cachedChatGPTRoundTripper(fmt.Sprintf("http://127.0.0.1:%d", 31000+index))
+	}
+	if got := chatGPTRoundTripperCache.Len(); got > chatGPTRoundTripperCacheCapacity {
+		t.Fatalf("transport cache entries = %d, want at most %d", got, chatGPTRoundTripperCacheCapacity)
+	}
+	if recreated := cachedChatGPTRoundTripper(firstProxy); recreated == first {
 		t.Fatal("least recently used proxy transport was not evicted")
 	}
 }

--- a/internal/runtime/executor/helps/utls_client_test.go
+++ b/internal/runtime/executor/helps/utls_client_test.go
@@ -348,6 +348,45 @@ func TestCachedChatGPTRoundTripperBoundsProxyCardinality(t *testing.T) {
 	}
 }
 
+func TestUtlsRoundTripperClosesEvictedConnectionsAfterResponsesDrain(t *testing.T) {
+	var closeCalls atomic.Int32
+	roundTripper := &utlsRoundTripper{
+		closeIdleConnections: func() {
+			closeCalls.Add(1)
+		},
+	}
+	resp := roundTripper.trackResponse(&http.Response{
+		Body: io.NopCloser(strings.NewReader("stream")),
+	})
+
+	roundTripper.closeWhenIdle()
+	if got := closeCalls.Load(); got != 1 {
+		t.Fatalf("close calls at eviction = %d, want 1", got)
+	}
+	if _, errRead := io.ReadAll(resp.Body); errRead != nil {
+		t.Fatal(errRead)
+	}
+	if got := closeCalls.Load(); got != 2 {
+		t.Fatalf("close calls after active response drained = %d, want 2", got)
+	}
+	if errClose := resp.Body.Close(); errClose != nil {
+		t.Fatal(errClose)
+	}
+	if got := closeCalls.Load(); got != 2 {
+		t.Fatalf("close calls after repeated release = %d, want 2", got)
+	}
+
+	laterResp := roundTripper.trackResponse(&http.Response{
+		Body: io.NopCloser(strings.NewReader("later")),
+	})
+	if errClose := laterResp.Body.Close(); errClose != nil {
+		t.Fatal(errClose)
+	}
+	if got := closeCalls.Load(); got != 3 {
+		t.Fatalf("close calls after post-eviction response = %d, want 3", got)
+	}
+}
+
 func TestClaudeCodeTLSClientHelloCapture(t *testing.T) {
 	proxyURL := os.Getenv("CPA_TLS_FP_PROXY")
 	if proxyURL == "" {

--- a/internal/runtime/executor/helps/utls_client_test.go
+++ b/internal/runtime/executor/helps/utls_client_test.go
@@ -355,25 +355,34 @@ func TestUtlsRoundTripperClosesEvictedConnectionsAfterResponsesDrain(t *testing.
 			closeCalls.Add(1)
 		},
 	}
-	resp := roundTripper.trackResponse(&http.Response{
+	firstResp := roundTripper.trackResponse(&http.Response{
 		Body: io.NopCloser(strings.NewReader("stream")),
+	})
+	secondResp := roundTripper.trackResponse(&http.Response{
+		Body: io.NopCloser(strings.NewReader("long-lived stream")),
 	})
 
 	roundTripper.closeWhenIdle()
 	if got := closeCalls.Load(); got != 1 {
 		t.Fatalf("close calls at eviction = %d, want 1", got)
 	}
-	if _, errRead := io.ReadAll(resp.Body); errRead != nil {
+	if _, errRead := io.ReadAll(firstResp.Body); errRead != nil {
 		t.Fatal(errRead)
 	}
 	if got := closeCalls.Load(); got != 2 {
-		t.Fatalf("close calls after active response drained = %d, want 2", got)
+		t.Fatalf("close calls after first active response drained = %d, want 2", got)
 	}
-	if errClose := resp.Body.Close(); errClose != nil {
+	if errClose := firstResp.Body.Close(); errClose != nil {
 		t.Fatal(errClose)
 	}
 	if got := closeCalls.Load(); got != 2 {
 		t.Fatalf("close calls after repeated release = %d, want 2", got)
+	}
+	if errClose := secondResp.Body.Close(); errClose != nil {
+		t.Fatal(errClose)
+	}
+	if got := closeCalls.Load(); got != 3 {
+		t.Fatalf("close calls after second active response drained = %d, want 3", got)
 	}
 
 	laterResp := roundTripper.trackResponse(&http.Response{
@@ -382,8 +391,8 @@ func TestUtlsRoundTripperClosesEvictedConnectionsAfterResponsesDrain(t *testing.
 	if errClose := laterResp.Body.Close(); errClose != nil {
 		t.Fatal(errClose)
 	}
-	if got := closeCalls.Load(); got != 3 {
-		t.Fatalf("close calls after post-eviction response = %d, want 3", got)
+	if got := closeCalls.Load(); got != 4 {
+		t.Fatalf("close calls after post-eviction response = %d, want 4", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace the per-request ChatGPT uTLS HTTP/2 connection with a reusable, proxy-scoped HTTP/2 transport
- keep a bounded TLS session cache per transport and advertise a final PSK extension so rebuilt TLS 1.3 connections can resume
- evict proxy transports with a bounded LRU and close their idle connections
- rebuild after connection-level EOF/reset failures with one immediate replay only when HTTP semantics and the request body are replay-safe
- preserve context cancellation and reject non-h2 ALPN results

Ordinary generation POST requests are not transparently replayed unless they carry an idempotency key, so a connection failure cannot duplicate visible output or tool side effects.

## Validation

- go test ./internal/runtime/executor/helps -count=1
- go test -race ./internal/runtime/executor/helps -run Test(ChatGPT|CachedChatGPT|UtlsRoundTripper|ReplayableUtls) -count=1
- go test ./...
- go build -o <temporary-path>/cliproxyapi ./cmd/server

The loopback integration test verifies that two requests share one HTTP/2 connection, an upstream close causes an automatic rebuild, and the rebuilt TLS 1.3 connection resumes the cached session.