### PR TITLE
fix(watcher): reload completed config writes

### DIFF
--- a/internal/config/config_yaml.go
+++ b/internal/config/config_yaml.go
@@ -89,12 +89,26 @@ func SaveConfigPreserveCommentsUpdateNestedScalar(configFile string, path []stri
 	if err != nil {
 		return err
 	}
-	var root yaml.Node
-	if err = yaml.Unmarshal(data, &root); err != nil {
+	data, err = updateNestedScalarBytes(data, path, value)
+	if err != nil {
 		return err
 	}
+	f, err := os.Create(configFile)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	_, err = f.Write(data)
+	return err
+}
+
+func updateNestedScalarBytes(data []byte, path []string, value string) ([]byte, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil, err
+	}
 	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
-		return fmt.Errorf("invalid yaml document structure")
+		return nil, fmt.Errorf("invalid yaml document structure")
 	}
 	node := root.Content[0]
 	// descend mapping nodes following path
@@ -114,24 +128,17 @@ func SaveConfigPreserveCommentsUpdateNestedScalar(configFile string, path []stri
 			node = next
 		}
 	}
-	f, err := os.Create(configFile)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
 	enc.SetIndent(2)
-	if err = enc.Encode(&root); err != nil {
+	if err := enc.Encode(&root); err != nil {
 		_ = enc.Close()
-		return err
+		return nil, err
 	}
-	if err = enc.Close(); err != nil {
-		return err
+	if err := enc.Close(); err != nil {
+		return nil, err
 	}
-	data = NormalizeCommentIndentation(buf.Bytes())
-	_, err = f.Write(data)
-	return err
+	return NormalizeCommentIndentation(buf.Bytes()), nil
 }
 
 // NormalizeCommentIndentation removes indentation from standalone YAML comment lines to keep them left aligned.

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -1,13 +1,90 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/yaml.v3"
 )
+
+// ParseConfigBytesAndPersistMigrations parses a config snapshot and persists
+// the same load-time management-secret migration as LoadConfig. The returned
+// bytes are the generation represented by the returned config.
+func ParseConfigBytesAndPersistMigrations(configFile string, data []byte) (*Config, []byte, error) {
+	var raw struct {
+		RemoteManagement struct {
+			SecretKey string `yaml:"secret-key"`
+		} `yaml:"remote-management"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, nil, fmt.Errorf("parse config payload: %w", err)
+	}
+	cfg, err := ParseConfigBytes(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	if errValidate := cfg.Codex.LiveMediaRelay.Validate(); errValidate != nil {
+		return nil, nil, errValidate
+	}
+	persisted := data
+	if raw.RemoteManagement.SecretKey != "" && !looksLikeBcrypt(raw.RemoteManagement.SecretKey) {
+		if migrated, errMigrate := updateNestedScalarBytes(data, []string{"remote-management", "secret-key"}, cfg.RemoteManagement.SecretKey); errMigrate == nil && persistMigrationIfUnchanged(configFile, data, migrated) {
+			persisted = migrated
+		}
+	}
+	return cfg, persisted, nil
+}
+
+type migrationFile interface {
+	io.Reader
+	io.Writer
+	io.Seeker
+	Close() error
+	Truncate(size int64) error
+}
+
+var openMigrationFile = func(configFile string) (migrationFile, error) {
+	return os.OpenFile(configFile, os.O_RDWR, 0)
+}
+
+func persistMigrationIfUnchanged(configFile string, original, migrated []byte) bool {
+	f, err := openMigrationFile(configFile)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	current, err := io.ReadAll(f)
+	if err != nil || !bytes.Equal(current, original) {
+		return false
+	}
+	if _, err = f.Seek(0, 0); err != nil {
+		return false
+	}
+	written, err := io.Copy(f, bytes.NewReader(migrated))
+	if err == nil && written == int64(len(migrated)) && f.Truncate(int64(len(migrated))) == nil {
+		return true
+	}
+	if !restoreMigrationOriginal(f, original) {
+		log.WithField("path", configFile).Error("failed to restore config after management-secret migration write failure")
+	}
+	return false
+}
+
+func restoreMigrationOriginal(f migrationFile, original []byte) bool {
+	if _, err := f.Seek(0, 0); err != nil {
+		return false
+	}
+	written, err := io.Copy(f, bytes.NewReader(original))
+	if err != nil || written != int64(len(original)) {
+		return false
+	}
+	return f.Truncate(int64(len(original))) == nil
+}
 
 // ParseConfigBytes parses a YAML configuration payload into Config and applies the same
 // in-memory normalizations as LoadConfigOptional, without persisting any changes to disk.

--- a/internal/config/parse_migrations_test.go
+++ b/internal/config/parse_migrations_test.go
@@ -1,0 +1,189 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseConfigBytesAndPersistMigrations(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	input := []byte("# keep\nport: 8317\nremote-management:\n  secret-key: plaintext\n")
+	if err := os.WriteFile(path, input, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, persisted, err := ParseConfigBytesAndPersistMigrations(path, input)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if cfg.Port != 8317 || !looksLikeBcrypt(cfg.RemoteManagement.SecretKey) {
+		t.Fatalf("unexpected parsed config: port=%d secret=%q", cfg.Port, cfg.RemoteManagement.SecretKey)
+	}
+	disk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migrated config: %v", err)
+	}
+	if !bytes.Equal(disk, persisted) {
+		t.Fatal("returned persisted bytes do not match disk")
+	}
+	if bytes.Contains(persisted, []byte("plaintext")) || !bytes.Contains(persisted, []byte("# keep")) {
+		t.Fatalf("unexpected migrated bytes: %s", persisted)
+	}
+}
+
+type failingMigrationFile struct {
+	*os.File
+	failWriteOnce bool
+	failTruncate  bool
+}
+
+func (f *failingMigrationFile) Write(p []byte) (int, error) {
+	if f.failWriteOnce {
+		f.failWriteOnce = false
+		n := len(p) / 2
+		written, err := f.File.Write(p[:n])
+		if err != nil {
+			return written, err
+		}
+		return written, errors.New("injected partial write failure")
+	}
+	return f.File.Write(p)
+}
+
+func (f *failingMigrationFile) Truncate(size int64) error {
+	if f.failTruncate {
+		f.failTruncate = false
+		return errors.New("injected truncate failure")
+	}
+	return f.File.Truncate(size)
+}
+
+func testMigrationPersistenceFailureIsNonFatal(t *testing.T, wrap func(*os.File) migrationFile) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	input := []byte("port: 8317\nremote-management:\n  secret-key: plaintext\n")
+	if err := os.WriteFile(path, input, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	originalOpen := openMigrationFile
+	openMigrationFile = func(configFile string) (migrationFile, error) {
+		f, err := os.OpenFile(configFile, os.O_RDWR, 0)
+		if err != nil {
+			return nil, err
+		}
+		return wrap(f), nil
+	}
+	t.Cleanup(func() { openMigrationFile = originalOpen })
+	cfg, persisted, err := ParseConfigBytesAndPersistMigrations(path, input)
+	if err != nil {
+		t.Fatalf("migration persistence failure rejected valid config: %v", err)
+	}
+	if cfg.Port != 8317 || !looksLikeBcrypt(cfg.RemoteManagement.SecretKey) {
+		t.Fatalf("unexpected parsed config: port=%d secret=%q", cfg.Port, cfg.RemoteManagement.SecretKey)
+	}
+	if !bytes.Equal(persisted, input) {
+		t.Fatal("reported migration bytes after persistence failure")
+	}
+	disk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !bytes.Equal(disk, input) {
+		t.Fatalf("persistence failure changed config: %s", disk)
+	}
+}
+
+func TestParseConfigBytesAndPersistMigrationsPartialWriteFailureIsNonFatal(t *testing.T) {
+	testMigrationPersistenceFailureIsNonFatal(t, func(f *os.File) migrationFile {
+		return &failingMigrationFile{File: f, failWriteOnce: true}
+	})
+}
+
+func TestParseConfigBytesAndPersistMigrationsTruncateFailureIsNonFatal(t *testing.T) {
+	testMigrationPersistenceFailureIsNonFatal(t, func(f *os.File) migrationFile {
+		return &failingMigrationFile{File: f, failTruncate: true}
+	})
+}
+
+func TestParseConfigBytesAndPersistMigrationsOpenFailureIsNonFatal(t *testing.T) {
+	input := []byte("port: 8317\nremote-management:\n  secret-key: plaintext\n")
+	cfg, persisted, err := ParseConfigBytesAndPersistMigrations(t.TempDir(), input)
+	if err != nil {
+		t.Fatalf("migration open failure rejected valid config: %v", err)
+	}
+	if cfg.Port != 8317 || !looksLikeBcrypt(cfg.RemoteManagement.SecretKey) {
+		t.Fatalf("unexpected parsed config: port=%d secret=%q", cfg.Port, cfg.RemoteManagement.SecretKey)
+	}
+	if !bytes.Equal(persisted, input) {
+		t.Fatal("reported migration bytes after open failure")
+	}
+}
+
+func TestParseConfigBytesAndPersistMigrationsLeavesNewerGenerationUntouched(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	old := []byte("remote-management:\n  secret-key: plaintext\n")
+	newer := []byte("port: 9999\n")
+	if err := os.WriteFile(path, newer, 0o644); err != nil {
+		t.Fatalf("write newer config: %v", err)
+	}
+	_, persisted, err := ParseConfigBytesAndPersistMigrations(path, old)
+	if err != nil {
+		t.Fatalf("parse old generation: %v", err)
+	}
+	disk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !bytes.Equal(disk, newer) {
+		t.Fatalf("old migration overwrote newer generation: %s", disk)
+	}
+	if !bytes.Equal(persisted, old) {
+		t.Fatal("reported migration that was not persisted")
+	}
+}
+
+func TestParseConfigBytesAndPersistMigrationsLeavesHashedConfigUntouched(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	input := []byte("remote-management:\n  secret-key: $2a$10$already-hashed\n")
+	if err := os.WriteFile(path, input, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	_, persisted, err := ParseConfigBytesAndPersistMigrations(path, input)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	disk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !bytes.Equal(persisted, input) || !bytes.Equal(disk, input) {
+		t.Fatal("hashed config was unexpectedly rewritten")
+	}
+}
+
+func TestSaveConfigPreserveCommentsUpdateNestedScalar(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	input := []byte("# keep\nremote-management:\n  secret-key: old\n")
+	if err := os.WriteFile(path, input, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := SaveConfigPreserveCommentsUpdateNestedScalar(path, []string{"remote-management", "secret-key"}, "new"); err != nil {
+		t.Fatalf("update scalar: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !bytes.Contains(data, []byte("# keep")) || !bytes.Contains(data, []byte("secret-key: new")) {
+		t.Fatalf("unexpected updated config: %s", data)
+	}
+}
+
+func TestParseConfigBytesAndPersistMigrationsValidatesCodexLiveMediaRelay(t *testing.T) {
+	_, _, err := ParseConfigBytesAndPersistMigrations(filepath.Join(t.TempDir(), "config.yaml"), []byte("codex:\n  live-media-relay:\n    enabled: true\n    ice-servers:\n      - urls: []\n"))
+	if err == nil {
+		t.Fatal("expected invalid live-media relay config to be rejected")
+	}
+}

--- a/internal/watcher/clients.go
+++ b/internal/watcher/clients.go
@@ -424,7 +424,9 @@ func (w *Watcher) persistConfigAsync() {
 	if w == nil || w.storePersister == nil {
 		return
 	}
+	w.persistConfigWG.Add(1)
 	go func() {
+		defer w.persistConfigWG.Done()
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		if err := w.storePersister.PersistConfig(ctx); err != nil {

--- a/internal/watcher/config_completion.go
+++ b/internal/watcher/config_completion.go
@@ -1,0 +1,34 @@
+package watcher
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type configCompletion interface {
+	Start(context.Context, func(), func(error), func()) error
+	Close() error
+}
+
+func (w *Watcher) notifyConfigComplete() {
+	if w == nil || w.stopped.Load() {
+		return
+	}
+	w.reloadConfigIfChanged()
+}
+
+func (w *Watcher) configCompletionUnavailable(err error) {
+	if w == nil || w.stopped.Load() {
+		return
+	}
+	if w.completionActive.Swap(false) {
+		log.WithError(err).Error("config completion watcher unavailable; using fsnotify debounce fallback")
+		w.reloadConfigIfChanged()
+	}
+}
+
+func configCompletionError(operation string, err error) error {
+	return fmt.Errorf("config completion watcher %s: %w", operation, err)
+}

--- a/internal/watcher/config_completion_linux.go
+++ b/internal/watcher/config_completion_linux.go
@@ -1,0 +1,180 @@
+//go:build linux
+
+package watcher
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+type configCompletionWatcher struct {
+	dir      string
+	base     string
+	fd       int
+	done     chan struct{}
+	cancel   context.CancelFunc
+	closeMu  sync.Mutex
+	started  bool
+	closed   bool
+	closeErr error
+}
+
+func newConfigCompletionWatcher(configPath string) (*configCompletionWatcher, error) {
+	path, err := filepath.Abs(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve config path: %w", err)
+	}
+	return &configCompletionWatcher{
+		dir:  filepath.Dir(path),
+		base: filepath.Base(path),
+		fd:   -1,
+		done: make(chan struct{}),
+	}, nil
+}
+
+func (w *configCompletionWatcher) Start(ctx context.Context, complete func(), unavailable func(error), admitted func()) error {
+	fd, err := unix.InotifyInit1(unix.IN_CLOEXEC | unix.IN_NONBLOCK)
+	if err != nil {
+		return fmt.Errorf("create config completion watcher: %w", err)
+	}
+	if _, err = unix.InotifyAddWatch(fd, w.dir, unix.IN_CLOSE_WRITE|unix.IN_MOVED_TO); err != nil {
+		_ = unix.Close(fd)
+		return fmt.Errorf("watch config completion in %s: %w", w.dir, err)
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+
+	w.closeMu.Lock()
+	if w.started || w.closed {
+		w.closeMu.Unlock()
+		cancel()
+		_ = unix.Close(fd)
+		return os.ErrClosed
+	}
+	w.fd = fd
+	w.cancel = cancel
+	w.started = true
+	w.closeMu.Unlock()
+
+	if admitted != nil {
+		admitted()
+	}
+	go w.readEvents(runCtx, fd, complete, unavailable)
+	return nil
+}
+
+func (w *configCompletionWatcher) Close() error {
+	w.closeMu.Lock()
+	if !w.closed {
+		w.closed = true
+		if w.cancel != nil {
+			w.cancel()
+		}
+	}
+	started := w.started
+	done := w.done
+	w.closeMu.Unlock()
+
+	if started {
+		<-done
+	}
+
+	w.closeMu.Lock()
+	err := w.closeErr
+	w.closeMu.Unlock()
+	return err
+}
+
+func (w *configCompletionWatcher) readEvents(ctx context.Context, fd int, complete func(), unavailable func(error)) {
+	expectedStop := false
+	defer func() {
+		errClose := unix.Close(fd)
+		w.closeMu.Lock()
+		w.fd = -1
+		w.closed = true
+		if errClose != nil && !errors.Is(errClose, unix.EBADF) {
+			w.closeErr = errClose
+		}
+		w.closeMu.Unlock()
+		close(w.done)
+		if !expectedStop {
+			unavailable(configCompletionError("stopped", errors.New("event stream ended")))
+		}
+	}()
+
+	buf := make([]byte, 4096)
+	pollFDs := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}}
+	for {
+		select {
+		case <-ctx.Done():
+			expectedStop = true
+			return
+		default:
+		}
+
+		pollFDs[0].Revents = 0
+		ready, errPoll := unix.Poll(pollFDs, 100)
+		if errors.Is(errPoll, unix.EINTR) {
+			continue
+		}
+		if errPoll != nil {
+			unavailable(configCompletionError("poll", errPoll))
+			return
+		}
+		if pollFDs[0].Revents&(unix.POLLERR|unix.POLLHUP|unix.POLLNVAL) != 0 {
+			unavailable(configCompletionError("poll", fmt.Errorf("revents %#x", pollFDs[0].Revents)))
+			return
+		}
+		if ready == 0 || pollFDs[0].Revents&unix.POLLIN == 0 {
+			continue
+		}
+
+		n, errRead := unix.Read(fd, buf)
+		if errors.Is(errRead, unix.EINTR) || errors.Is(errRead, unix.EAGAIN) {
+			continue
+		}
+		if errRead != nil {
+			unavailable(configCompletionError("read", errRead))
+			return
+		}
+		if errDecode := w.handleEvents(buf[:n], complete); errDecode != nil {
+			unavailable(errDecode)
+			return
+		}
+	}
+}
+
+func (w *configCompletionWatcher) handleEvents(buf []byte, complete func()) error {
+	for offset := 0; offset+unix.SizeofInotifyEvent <= len(buf); {
+		raw := buf[offset:]
+		mask := binary.NativeEndian.Uint32(raw[4:8])
+		nameLen := int(binary.NativeEndian.Uint32(raw[12:16]))
+		eventLen := unix.SizeofInotifyEvent + nameLen
+		if eventLen > len(buf)-offset {
+			return configCompletionError("decode", errors.New("truncated event"))
+		}
+		if mask&unix.IN_Q_OVERFLOW != 0 {
+			return configCompletionError("watch", errors.New("event queue overflow"))
+		}
+		if mask&unix.IN_IGNORED != 0 {
+			return configCompletionError("watch", errors.New("watch was removed"))
+		}
+		if nameLen > 0 {
+			name := raw[unix.SizeofInotifyEvent:eventLen]
+			for len(name) > 0 && name[len(name)-1] == 0 {
+				name = name[:len(name)-1]
+			}
+			if string(name) == w.base && mask&(unix.IN_CLOSE_WRITE|unix.IN_MOVED_TO) != 0 {
+				complete()
+			}
+		}
+		offset += eventLen
+	}
+	return nil
+}

--- a/internal/watcher/config_completion_linux.go
+++ b/internal/watcher/config_completion_linux.go
@@ -14,9 +14,14 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+type completionTarget struct {
+	dir  string
+	base string
+	wd   int32
+}
+
 type configCompletionWatcher struct {
-	dir      string
-	base     string
+	targets  []completionTarget
 	fd       int
 	done     chan struct{}
 	cancel   context.CancelFunc
@@ -26,16 +31,25 @@ type configCompletionWatcher struct {
 	closeErr error
 }
 
-func newConfigCompletionWatcher(configPath string) (*configCompletionWatcher, error) {
-	path, err := filepath.Abs(configPath)
-	if err != nil {
-		return nil, fmt.Errorf("resolve config path: %w", err)
+func newConfigCompletionWatcher(configPaths ...string) (configCompletion, error) {
+	targets := make([]completionTarget, 0, len(configPaths))
+	seen := make(map[completionTarget]struct{}, len(configPaths))
+	for _, configPath := range configPaths {
+		path, err := filepath.Abs(configPath)
+		if err != nil {
+			return nil, fmt.Errorf("resolve config path: %w", err)
+		}
+		target := completionTarget{dir: filepath.Dir(path), base: filepath.Base(path)}
+		if _, ok := seen[target]; ok {
+			continue
+		}
+		seen[target] = struct{}{}
+		targets = append(targets, target)
 	}
 	return &configCompletionWatcher{
-		dir:  filepath.Dir(path),
-		base: filepath.Base(path),
-		fd:   -1,
-		done: make(chan struct{}),
+		targets: targets,
+		fd:      -1,
+		done:    make(chan struct{}),
 	}, nil
 }
 
@@ -44,9 +58,13 @@ func (w *configCompletionWatcher) Start(ctx context.Context, complete func(), un
 	if err != nil {
 		return fmt.Errorf("create config completion watcher: %w", err)
 	}
-	if _, err = unix.InotifyAddWatch(fd, w.dir, unix.IN_CLOSE_WRITE|unix.IN_MOVED_TO); err != nil {
-		_ = unix.Close(fd)
-		return fmt.Errorf("watch config completion in %s: %w", w.dir, err)
+	for i := range w.targets {
+		wd, errWatch := unix.InotifyAddWatch(fd, w.targets[i].dir, unix.IN_CLOSE_WRITE|unix.IN_MOVED_TO)
+		if errWatch != nil {
+			_ = unix.Close(fd)
+			return fmt.Errorf("watch config completion in %s: %w", w.targets[i].dir, errWatch)
+		}
+		w.targets[i].wd = int32(wd)
 	}
 	runCtx, cancel := context.WithCancel(ctx)
 
@@ -154,6 +172,7 @@ func (w *configCompletionWatcher) handleEvents(buf []byte, complete func()) erro
 	for offset := 0; offset+unix.SizeofInotifyEvent <= len(buf); {
 		raw := buf[offset:]
 		mask := binary.NativeEndian.Uint32(raw[4:8])
+		wd := int32(binary.NativeEndian.Uint32(raw[0:4]))
 		nameLen := int(binary.NativeEndian.Uint32(raw[12:16]))
 		eventLen := unix.SizeofInotifyEvent + nameLen
 		if eventLen > len(buf)-offset {
@@ -170,11 +189,20 @@ func (w *configCompletionWatcher) handleEvents(buf []byte, complete func()) erro
 			for len(name) > 0 && name[len(name)-1] == 0 {
 				name = name[:len(name)-1]
 			}
-			if string(name) == w.base && mask&(unix.IN_CLOSE_WRITE|unix.IN_MOVED_TO) != 0 {
+			if mask&(unix.IN_CLOSE_WRITE|unix.IN_MOVED_TO) != 0 && w.matchesTarget(wd, string(name)) {
 				complete()
 			}
 		}
 		offset += eventLen
 	}
 	return nil
+}
+
+func (w *configCompletionWatcher) matchesTarget(wd int32, name string) bool {
+	for _, target := range w.targets {
+		if target.wd == wd && target.base == name {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/watcher/config_completion_linux_test.go
+++ b/internal/watcher/config_completion_linux_test.go
@@ -1,0 +1,257 @@
+//go:build linux
+
+package watcher
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"golang.org/x/sys/unix"
+)
+
+func TestConfigCompletionOverflowReconcilesAndEnablesFallback(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("port: 9002\nauth-dir: "+tmp+"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	reloaded := make(chan int, 1)
+	w := &Watcher{configPath: configPath, authDir: tmp, reloadCallback: func(cfg *config.Config) { reloaded <- cfg.Port }}
+	w.SetConfig(&config.Config{Port: 9001, AuthDir: tmp})
+	w.completionActive.Store(true)
+
+	buf := make([]byte, unix.SizeofInotifyEvent)
+	binary.NativeEndian.PutUint32(buf[4:8], unix.IN_Q_OVERFLOW)
+	completion := &configCompletionWatcher{base: filepath.Base(configPath)}
+	err := completion.handleEvents(buf, func() { t.Fatal("overflow invoked normal completion callback") })
+	if err == nil {
+		t.Fatal("overflow was not reported as unavailable")
+	}
+	w.configCompletionUnavailable(err)
+	if w.completionActive.Load() {
+		t.Fatal("overflow did not enable fsnotify fallback")
+	}
+	select {
+	case port := <-reloaded:
+		if port != 9002 {
+			t.Fatalf("overflow reconciliation loaded port %d, want 9002", port)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("overflow did not reconcile current config")
+	}
+}
+
+func TestStartCapturesConfigChangedAfterNativeAdmission(t *testing.T) {
+	tmpDir := t.TempDir()
+	authDir := filepath.Join(tmpDir, "auth")
+	if err := os.Mkdir(authDir, 0o755); err != nil {
+		t.Fatalf("create auth dir: %v", err)
+	}
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	writeConfig := func(port int) {
+		t.Helper()
+		if err := os.WriteFile(configPath, []byte(fmt.Sprintf("port: %d\nauth-dir: %s\n", port, authDir)), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+	}
+	writeConfig(5001)
+	reloads := make(chan int, 2)
+	w, err := NewWatcher(configPath, authDir, func(cfg *config.Config) { reloads <- cfg.Port })
+	if err != nil {
+		t.Fatalf("create watcher: %v", err)
+	}
+	w.SetConfig(&config.Config{Port: 5001, AuthDir: authDir})
+	w.startTestHook = func() { writeConfig(5002) }
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err = w.Start(ctx); err != nil {
+		t.Fatalf("start watcher: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case port := <-reloads:
+			if port == 5002 {
+				return
+			}
+		case <-deadline:
+			t.Fatal("native admission change was not observed")
+		}
+	}
+}
+
+func TestConfigCompletionUnavailableEnablesFallback(t *testing.T) {
+	w := &Watcher{}
+	w.completionActive.Store(true)
+	w.configCompletionUnavailable(errors.New("lost"))
+	if w.completionActive.Load() {
+		t.Fatal("expected native completion to be disabled")
+	}
+}
+
+func TestConfigCompletionWatcherLifecycle(t *testing.T) {
+	missingConfig := filepath.Join(t.TempDir(), "missing", "config.yaml")
+	completion, err := newConfigCompletionWatcher(missingConfig)
+	if err != nil {
+		t.Fatalf("create completion watcher: %v", err)
+	}
+	if err = completion.Start(context.Background(), func() {}, func(error) {}, nil); err == nil {
+		t.Fatal("expected completion watcher start to fail for missing directory")
+	}
+	if err = completion.Close(); err != nil {
+		t.Fatalf("close failed completion watcher: %v", err)
+	}
+
+	dir := t.TempDir()
+	completion, err = newConfigCompletionWatcher(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("create completion watcher: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	if err = completion.Start(ctx, func() {}, func(error) {}, nil); err != nil {
+		t.Fatalf("start completion watcher: %v", err)
+	}
+	cancel()
+	if err = completion.Close(); err != nil {
+		t.Fatalf("close completion watcher: %v", err)
+	}
+	if err = completion.Close(); err != nil {
+		t.Fatalf("second close completion watcher: %v", err)
+	}
+}
+
+func TestConfigWatcherReloadsRepeatedAtomicReplacements(t *testing.T) {
+	testConfigWatcherReloadsRepeatedAtomicReplacements(t, true)
+}
+
+func TestConfigWatcherWaitsForInPlaceWriterClose(t *testing.T) {
+	tmpDir := t.TempDir()
+	authDir := filepath.Join(tmpDir, "auth")
+	if err := os.Mkdir(authDir, 0o755); err != nil {
+		t.Fatalf("create auth dir: %v", err)
+	}
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(fmt.Sprintf("port: 2001\nauth-dir: %s\n", authDir)), 0o644); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	reloads := make(chan int, 4)
+	w, err := NewWatcher(configPath, authDir, func(cfg *config.Config) { reloads <- cfg.Port })
+	if err != nil {
+		t.Fatalf("create watcher: %v", err)
+	}
+	w.SetConfig(&config.Config{Port: 2001, AuthDir: authDir})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err = w.Start(ctx); err != nil {
+		t.Fatalf("start watcher: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	select {
+	case <-reloads: // initial client load
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial callback")
+	}
+
+	f, err := os.OpenFile(configPath, os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		t.Fatalf("open config: %v", err)
+	}
+	if _, err = f.WriteString("port: 2002\nauth-dir:"); err != nil {
+		t.Fatalf("write prefix: %v", err)
+	}
+
+	select {
+	case got := <-reloads:
+		_ = f.Close()
+		t.Fatalf("reloaded port %d before writer closed", got)
+	case <-time.After(2 * configReloadDebounce):
+	}
+
+	if _, err = f.WriteString(" " + authDir + "\n"); err != nil {
+		_ = f.Close()
+		t.Fatalf("write suffix: %v", err)
+	}
+	if err = f.Close(); err != nil {
+		t.Fatalf("close config: %v", err)
+	}
+
+	select {
+	case got := <-reloads:
+		if got != 2002 {
+			t.Fatalf("expected final port 2002, got %d", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for close-triggered reload")
+	}
+}
+
+func TestConfigWatcherWaitsForNewInPlaceFileClose(t *testing.T) {
+	tmpDir := t.TempDir()
+	authDir := filepath.Join(tmpDir, "auth")
+	if err := os.Mkdir(authDir, 0o755); err != nil {
+		t.Fatalf("create auth dir: %v", err)
+	}
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(fmt.Sprintf("port: 3001\nauth-dir: %s\n", authDir)), 0o644); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+	reloads := make(chan int, 4)
+	w, err := NewWatcher(configPath, authDir, func(cfg *config.Config) { reloads <- cfg.Port })
+	if err != nil {
+		t.Fatalf("create watcher: %v", err)
+	}
+	w.SetConfig(&config.Config{Port: 3001, AuthDir: authDir})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err = w.Start(ctx); err != nil {
+		t.Fatalf("start watcher: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+	select {
+	case <-reloads:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial callback")
+	}
+	if err = os.Remove(configPath); err != nil {
+		t.Fatalf("remove config: %v", err)
+	}
+	f, err := os.OpenFile(configPath, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("recreate config: %v", err)
+	}
+	if _, err = f.WriteString("port: 3002\nauth-dir:"); err != nil {
+		t.Fatalf("write prefix: %v", err)
+	}
+	select {
+	case got := <-reloads:
+		_ = f.Close()
+		t.Fatalf("reloaded port %d on create before close", got)
+	case <-time.After(2 * configReloadDebounce):
+	}
+	if _, err = f.WriteString(" " + authDir + "\n"); err != nil {
+		_ = f.Close()
+		t.Fatalf("write suffix: %v", err)
+	}
+	if err = f.Close(); err != nil {
+		t.Fatalf("close config: %v", err)
+	}
+	select {
+	case got := <-reloads:
+		if got != 3002 {
+			t.Fatalf("expected final port 3002, got %d", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for recreated file close")
+	}
+}

--- a/internal/watcher/config_completion_linux_test.go
+++ b/internal/watcher/config_completion_linux_test.go
@@ -29,7 +29,7 @@ func TestConfigCompletionOverflowReconcilesAndEnablesFallback(t *testing.T) {
 
 	buf := make([]byte, unix.SizeofInotifyEvent)
 	binary.NativeEndian.PutUint32(buf[4:8], unix.IN_Q_OVERFLOW)
-	completion := &configCompletionWatcher{base: filepath.Base(configPath)}
+	completion := &configCompletionWatcher{targets: []completionTarget{{base: filepath.Base(configPath), wd: 0}}}
 	err := completion.handleEvents(buf, func() { t.Fatal("overflow invoked normal completion callback") })
 	if err == nil {
 		t.Fatal("overflow was not reported as unavailable")
@@ -85,6 +85,129 @@ func TestStartCapturesConfigChangedAfterNativeAdmission(t *testing.T) {
 			}
 		case <-deadline:
 			t.Fatal("native admission change was not observed")
+		}
+	}
+}
+
+func TestConfigWatcherReloadsSymlinkTargetInPlace(t *testing.T) {
+	linkDir := t.TempDir()
+	targetDir := t.TempDir()
+	authDir := filepath.Join(linkDir, "auth")
+	if err := os.Mkdir(authDir, 0o755); err != nil {
+		t.Fatalf("create auth dir: %v", err)
+	}
+	targetPath := filepath.Join(targetDir, "real-config.yaml")
+	linkPath := filepath.Join(linkDir, "config.yaml")
+	writeTarget := func(port int) {
+		t.Helper()
+		if err := os.WriteFile(targetPath, []byte(fmt.Sprintf("port: %d\nauth-dir: %s\n", port, authDir)), 0o644); err != nil {
+			t.Fatalf("write target config: %v", err)
+		}
+	}
+	writeTarget(7001)
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Fatalf("create config symlink: %v", err)
+	}
+
+	reloads := make(chan int, 2)
+	w, err := NewWatcher(linkPath, authDir, func(cfg *config.Config) { reloads <- cfg.Port })
+	if err != nil {
+		t.Fatalf("create watcher: %v", err)
+	}
+	w.SetConfig(&config.Config{Port: 7001, AuthDir: authDir})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err = w.Start(ctx); err != nil {
+		t.Fatalf("start watcher: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+	select {
+	case <-reloads:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial callback")
+	}
+
+	f, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		t.Fatalf("open target config: %v", err)
+	}
+	if _, err = f.WriteString("port: 7002\nauth-dir:"); err != nil {
+		t.Fatalf("write target prefix: %v", err)
+	}
+	select {
+	case port := <-reloads:
+		_ = f.Close()
+		t.Fatalf("reloaded symlink target port %d before close", port)
+	case <-time.After(2 * configReloadDebounce):
+	}
+	if _, err = f.WriteString(" " + authDir + "\n"); err != nil {
+		_ = f.Close()
+		t.Fatalf("write target suffix: %v", err)
+	}
+	if err = f.Close(); err != nil {
+		t.Fatalf("close target config: %v", err)
+	}
+	select {
+	case port := <-reloads:
+		if port != 7002 {
+			t.Fatalf("symlink target loaded port %d, want 7002", port)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("symlink target in-place write was not reloaded")
+	}
+}
+
+func TestConfigWatcherReloadsSymlinkTargetAtomicReplacements(t *testing.T) {
+	linkDir := t.TempDir()
+	targetDir := t.TempDir()
+	authDir := filepath.Join(linkDir, "auth")
+	if err := os.Mkdir(authDir, 0o755); err != nil {
+		t.Fatalf("create auth dir: %v", err)
+	}
+	targetPath := filepath.Join(targetDir, "real-config.yaml")
+	linkPath := filepath.Join(linkDir, "config.yaml")
+	writeConfig := func(path string, port int) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(fmt.Sprintf("port: %d\nauth-dir: %s\n", port, authDir)), 0o644); err != nil {
+			t.Fatalf("write target config: %v", err)
+		}
+	}
+	writeConfig(targetPath, 7101)
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Fatalf("create config symlink: %v", err)
+	}
+
+	reloads := make(chan int, 4)
+	w, err := NewWatcher(linkPath, authDir, func(cfg *config.Config) { reloads <- cfg.Port })
+	if err != nil {
+		t.Fatalf("create watcher: %v", err)
+	}
+	w.SetConfig(&config.Config{Port: 7101, AuthDir: authDir})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err = w.Start(ctx); err != nil {
+		t.Fatalf("start watcher: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+	select {
+	case <-reloads:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial callback")
+	}
+
+	for _, port := range []int{7102, 7103} {
+		tmp := filepath.Join(targetDir, fmt.Sprintf(".real-config-%d.tmp", port))
+		writeConfig(tmp, port)
+		if err = os.Rename(tmp, targetPath); err != nil {
+			t.Fatalf("replace target config: %v", err)
+		}
+		select {
+		case got := <-reloads:
+			if got != port {
+				t.Fatalf("symlink target loaded port %d, want %d", got, port)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("symlink target replacement %d was not reloaded", port)
 		}
 	}
 }

--- a/internal/watcher/config_completion_other.go
+++ b/internal/watcher/config_completion_other.go
@@ -6,7 +6,7 @@ import "context"
 
 type configCompletionWatcher struct{}
 
-func newConfigCompletionWatcher(string) (*configCompletionWatcher, error) {
+func newConfigCompletionWatcher(...string) (configCompletion, error) {
 	return nil, nil
 }
 

--- a/internal/watcher/config_completion_other.go
+++ b/internal/watcher/config_completion_other.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package watcher
+
+import "context"
+
+type configCompletionWatcher struct{}
+
+func newConfigCompletionWatcher(string) (*configCompletionWatcher, error) {
+	return nil, nil
+}
+
+func (*configCompletionWatcher) Start(context.Context, func(), func(error), func()) error { return nil }
+func (*configCompletionWatcher) Close() error                                             { return nil }

--- a/internal/watcher/config_completion_other_test.go
+++ b/internal/watcher/config_completion_other_test.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package watcher
+
+import "testing"
+
+func TestNewConfigCompletionWatcherUsesFsnotifyFallback(t *testing.T) {
+	completion, err := newConfigCompletionWatcher("config.yaml")
+	if err != nil {
+		t.Fatalf("create completion watcher: %v", err)
+	}
+	if completion != nil {
+		t.Fatal("non-Linux completion watcher must be a nil interface")
+	}
+}

--- a/internal/watcher/config_reload.go
+++ b/internal/watcher/config_reload.go
@@ -49,6 +49,12 @@ func (w *Watcher) ReloadConfigIfChanged() {
 }
 
 func (w *Watcher) reloadConfigIfChanged() {
+	w.reloadRunMu.Lock()
+	defer w.reloadRunMu.Unlock()
+	if w.stopped.Load() {
+		return
+	}
+
 	data, err := os.ReadFile(w.configPath)
 	if err != nil {
 		log.Errorf("failed to read config file for hash check: %v", err)
@@ -70,19 +76,21 @@ func (w *Watcher) reloadConfigIfChanged() {
 		return
 	}
 	log.Infof("config file changed, reloading: %s", w.configPath)
-	if w.reloadConfig() {
-		finalHash := newHash
-		if updatedData, errRead := os.ReadFile(w.configPath); errRead == nil && len(updatedData) > 0 {
-			sumUpdated := sha256.Sum256(updatedData)
-			finalHash = hex.EncodeToString(sumUpdated[:])
-		} else if errRead != nil {
-			log.WithError(errRead).Debug("failed to compute updated config hash after reload")
-		}
-		w.clientsMutex.Lock()
-		w.lastConfigHash = finalHash
-		w.clientsMutex.Unlock()
-		w.persistConfigAsync()
+	if w.reloadTestHook != nil {
+		w.reloadTestHook()
 	}
+	newConfig, persisted, errLoadConfig := config.ParseConfigBytesAndPersistMigrations(w.configPath, data)
+	if errLoadConfig != nil {
+		log.Errorf("failed to reload config: %v", errLoadConfig)
+		return
+	}
+
+	w.applyConfig(newConfig)
+	persistedSum := sha256.Sum256(persisted)
+	w.clientsMutex.Lock()
+	w.lastConfigHash = hex.EncodeToString(persistedSum[:])
+	w.clientsMutex.Unlock()
+	w.persistConfigAsync()
 }
 
 func (w *Watcher) reloadConfig() bool {
@@ -94,7 +102,11 @@ func (w *Watcher) reloadConfig() bool {
 		log.Errorf("failed to reload config: %v", errLoadConfig)
 		return false
 	}
+	w.applyConfig(newConfig)
+	return true
+}
 
+func (w *Watcher) applyConfig(newConfig *config.Config) {
 	if w.mirroredAuthDir != "" {
 		newConfig.AuthDir = w.mirroredAuthDir
 	} else {
@@ -140,5 +152,4 @@ func (w *Watcher) reloadConfig() bool {
 
 	log.Infof("config successfully reloaded, triggering client reload")
 	w.reloadClients(authDirChanged, affectedOAuthProviders, forceAuthRefresh)
-	return true
 }

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -27,6 +27,18 @@ func matchProvider(provider string, targets []string) (string, bool) {
 	return p, false
 }
 
+func resolveConfigTargets(configPath string) []string {
+	path, err := filepath.Abs(configPath)
+	if err != nil {
+		path = filepath.Clean(configPath)
+	}
+	targets := []string{path}
+	if resolved, errEval := filepath.EvalSymlinks(path); errEval == nil && resolved != path {
+		targets = append(targets, resolved)
+	}
+	return targets
+}
+
 func (w *Watcher) start(ctx context.Context) error {
 	var fallbackSnapshot []byte
 	if w.completion != nil {
@@ -58,15 +70,24 @@ func (w *Watcher) start(ctx context.Context) error {
 		log.Errorf("failed to access config file %s: %v", w.configPath, errStatConfig)
 		return errStatConfig
 	}
-	configDir := filepath.Dir(w.configPath)
-	if errAddConfig := w.watcher.Add(configDir); errAddConfig != nil {
-		closeCompletionOnError()
-		log.Errorf("failed to watch config directory %s: %v", configDir, errAddConfig)
-		return errAddConfig
+	watchedDirs := make(map[string]struct{}, len(w.configTargets)+1)
+	for _, target := range w.configTargets {
+		configDir := filepath.Dir(target)
+		normalizedDir := w.normalizeAuthPath(configDir)
+		if _, watched := watchedDirs[normalizedDir]; watched {
+			continue
+		}
+		if errAddConfig := w.watcher.Add(configDir); errAddConfig != nil {
+			closeCompletionOnError()
+			log.Errorf("failed to watch config directory %s: %v", configDir, errAddConfig)
+			return errAddConfig
+		}
+		watchedDirs[normalizedDir] = struct{}{}
+		log.Debugf("watching config directory: %s", configDir)
 	}
-	log.Debugf("watching config directory: %s", configDir)
 
-	if w.normalizeAuthPath(configDir) != w.normalizeAuthPath(w.authDir) {
+	normalizedAuthDir := w.normalizeAuthPath(w.authDir)
+	if _, watched := watchedDirs[normalizedAuthDir]; !watched {
 		if errAddAuthDir := w.watcher.Add(w.authDir); errAddAuthDir != nil {
 			closeCompletionOnError()
 			log.Errorf("failed to watch auth directory %s: %v", w.authDir, errAddAuthDir)
@@ -112,9 +133,18 @@ func (w *Watcher) handleEvent(event fsnotify.Event) {
 	// Filter only relevant events: config file or auth-dir JSON files.
 	configOps := fsnotify.Write | fsnotify.Create | fsnotify.Rename
 	normalizedName := w.normalizeAuthPath(event.Name)
-	normalizedConfigPath := w.normalizeAuthPath(w.configPath)
+	configTargets := w.configTargets
+	if len(configTargets) == 0 {
+		configTargets = []string{w.configPath}
+	}
+	isConfigEvent := false
+	for _, target := range configTargets {
+		if normalizedName == w.normalizeAuthPath(target) {
+			isConfigEvent = event.Op&configOps != 0
+			break
+		}
+	}
 	normalizedAuthDir := w.normalizeAuthPath(w.authDir)
-	isConfigEvent := normalizedName == normalizedConfigPath && event.Op&configOps != 0
 	authOps := fsnotify.Create | fsnotify.Write | fsnotify.Remove | fsnotify.Rename
 	isAuthJSON := filepath.Dir(normalizedName) == normalizedAuthDir && strings.HasSuffix(normalizedName, ".json") && event.Op&authOps != 0
 	if !isConfigEvent && !isAuthJSON {

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -3,6 +3,7 @@
 package watcher
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -27,17 +28,60 @@ func matchProvider(provider string, targets []string) (string, bool) {
 }
 
 func (w *Watcher) start(ctx context.Context) error {
-	if errAddConfig := w.watcher.Add(w.configPath); errAddConfig != nil {
-		log.Errorf("failed to watch config file %s: %v", w.configPath, errAddConfig)
+	var fallbackSnapshot []byte
+	if w.completion != nil {
+		if errStartCompletion := w.completion.Start(ctx, w.notifyConfigComplete, w.configCompletionUnavailable, func() {
+			w.completionActive.Store(true)
+		}); errStartCompletion != nil {
+			w.completionActive.Store(false)
+			log.WithError(errStartCompletion).Warn("config completion watcher unavailable at startup; using fsnotify debounce fallback")
+			_ = w.completion.Close()
+			w.completion = nil
+			fallbackSnapshot, errStartCompletion = os.ReadFile(w.configPath)
+			if errStartCompletion != nil {
+				log.Errorf("failed to access config file %s: %v", w.configPath, errStartCompletion)
+				return errStartCompletion
+			}
+		}
+	}
+	closeCompletionOnError := func() {
+		w.completionActive.Store(false)
+		if w.completion != nil {
+			_ = w.completion.Close()
+		}
+	}
+	if w.startTestHook != nil {
+		w.startTestHook()
+	}
+	if _, errStatConfig := os.Stat(w.configPath); errStatConfig != nil {
+		closeCompletionOnError()
+		log.Errorf("failed to access config file %s: %v", w.configPath, errStatConfig)
+		return errStatConfig
+	}
+	configDir := filepath.Dir(w.configPath)
+	if errAddConfig := w.watcher.Add(configDir); errAddConfig != nil {
+		closeCompletionOnError()
+		log.Errorf("failed to watch config directory %s: %v", configDir, errAddConfig)
 		return errAddConfig
 	}
-	log.Debugf("watching config file: %s", w.configPath)
+	log.Debugf("watching config directory: %s", configDir)
 
-	if errAddAuthDir := w.watcher.Add(w.authDir); errAddAuthDir != nil {
-		log.Errorf("failed to watch auth directory %s: %v", w.authDir, errAddAuthDir)
-		return errAddAuthDir
+	if w.normalizeAuthPath(configDir) != w.normalizeAuthPath(w.authDir) {
+		if errAddAuthDir := w.watcher.Add(w.authDir); errAddAuthDir != nil {
+			closeCompletionOnError()
+			log.Errorf("failed to watch auth directory %s: %v", w.authDir, errAddAuthDir)
+			return errAddAuthDir
+		}
 	}
 	log.Debugf("watching auth directory: %s", w.authDir)
+
+	if fallbackSnapshot != nil {
+		if currentConfig, errReadCurrent := os.ReadFile(w.configPath); errReadCurrent != nil {
+			log.WithError(errReadCurrent).Error("failed to reconcile config after fallback watcher admission")
+		} else if !bytes.Equal(fallbackSnapshot, currentConfig) {
+			w.scheduleConfigReload()
+		}
+	}
 
 	go w.processEvents(ctx)
 
@@ -81,10 +125,13 @@ func (w *Watcher) handleEvent(event fsnotify.Event) {
 	now := time.Now()
 	log.Debugf("file system event detected: %s %s", event.Op.String(), event.Name)
 
-	// Handle config file changes
+	// Handle config file changes. Linux uses native close/move completion events;
+	// other platforms retain fsnotify's quiet-window fallback.
 	if isConfigEvent {
 		log.Debugf("config file change details - operation: %s, timestamp: %s", event.Op.String(), now.Format("2006-01-02 15:04:05.000"))
-		w.scheduleConfigReload()
+		if !w.completionActive.Load() {
+			w.scheduleConfigReload()
+		}
 		return
 	}
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -38,6 +38,11 @@ type Watcher struct {
 	authRescanMu      sync.Mutex
 	configReloadMu    sync.Mutex
 	configReloadTimer *time.Timer
+	reloadRunMu       sync.Mutex
+	reloadTestHook    func()
+	startTestHook     func()
+	completion        configCompletion
+	completionActive  atomic.Bool
 	serverUpdateMu    sync.Mutex
 	serverUpdateTimer *time.Timer
 	serverUpdateLast  time.Time
@@ -59,6 +64,7 @@ type Watcher struct {
 	pendingOrder      []string
 	dispatchCancel    context.CancelFunc
 	storePersister    storePersister
+	persistConfigWG   sync.WaitGroup
 	pluginAuthParser  synthesizer.PluginAuthParser
 	mirroredAuthDir   string
 	oldConfigYaml     []byte
@@ -95,11 +101,17 @@ func NewWatcher(configPath, authDir string, reloadCallback func(*config.Config))
 	if errNewWatcher != nil {
 		return nil, errNewWatcher
 	}
+	completionWatcher, errCompletionWatcher := newConfigCompletionWatcher(configPath)
+	if errCompletionWatcher != nil {
+		_ = watcher.Close()
+		return nil, errCompletionWatcher
+	}
 	w := &Watcher{
 		configPath:      configPath,
 		authDir:         authDir,
 		reloadCallback:  reloadCallback,
 		watcher:         watcher,
+		completion:      completionWatcher,
 		lastAuthHashes:  make(map[string]string),
 		fileAuthsByPath: make(map[string]map[string]*coreauth.Auth),
 	}
@@ -130,7 +142,18 @@ func (w *Watcher) Stop() error {
 	w.stopDispatch()
 	w.stopConfigReloadTimer()
 	w.stopServerUpdateTimer()
-	return w.watcher.Close()
+	var completionErr error
+	if w.completion != nil {
+		completionErr = w.completion.Close()
+	}
+	watchErr := w.watcher.Close()
+	w.reloadRunMu.Lock()
+	w.reloadRunMu.Unlock()
+	w.persistConfigWG.Wait()
+	if completionErr != nil {
+		return completionErr
+	}
+	return watchErr
 }
 
 // SetConfig updates the current configuration

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -32,6 +32,7 @@ type authDirProvider interface {
 // Watcher manages file watching for configuration and authentication files
 type Watcher struct {
 	configPath        string
+	configTargets     []string
 	authDir           string
 	config            *config.Config
 	clientsMutex      sync.RWMutex
@@ -101,13 +102,15 @@ func NewWatcher(configPath, authDir string, reloadCallback func(*config.Config))
 	if errNewWatcher != nil {
 		return nil, errNewWatcher
 	}
-	completionWatcher, errCompletionWatcher := newConfigCompletionWatcher(configPath)
+	configTargets := resolveConfigTargets(configPath)
+	completionWatcher, errCompletionWatcher := newConfigCompletionWatcher(configTargets...)
 	if errCompletionWatcher != nil {
 		_ = watcher.Close()
 		return nil, errCompletionWatcher
 	}
 	w := &Watcher{
 		configPath:      configPath,
+		configTargets:   configTargets,
 		authDir:         authDir,
 		reloadCallback:  reloadCallback,
 		watcher:         watcher,

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -264,6 +265,185 @@ func TestStartAndStopSuccess(t *testing.T) {
 	}
 }
 
+type failingCompletion struct {
+	startErr error
+	closed   bool
+}
+
+func (f *failingCompletion) Start(context.Context, func(), func(error), func()) error {
+	return f.startErr
+}
+func (f *failingCompletion) Close() error {
+	f.closed = true
+	return nil
+}
+
+func TestStartFallsBackWhenNativeCompletionUnavailable(t *testing.T) {
+	tmpDir := t.TempDir()
+	authDir := filepath.Join(tmpDir, "auth")
+	if err := os.Mkdir(authDir, 0o755); err != nil {
+		t.Fatalf("create auth dir: %v", err)
+	}
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("port: 6001\nauth-dir: "+authDir+"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	reloads := make(chan int, 2)
+	w, err := NewWatcher(configPath, authDir, func(cfg *config.Config) { reloads <- cfg.Port })
+	if err != nil {
+		t.Fatalf("create watcher: %v", err)
+	}
+	failed := &failingCompletion{startErr: errors.New("injected native start failure")}
+	w.completion = failed
+	w.startTestHook = func() {
+		if errWrite := os.WriteFile(configPath, []byte("port: 6002\nauth-dir: "+authDir+"\n"), 0o644); errWrite != nil {
+			t.Fatalf("update config during fallback admission: %v", errWrite)
+		}
+	}
+	w.SetConfig(&config.Config{Port: 6001, AuthDir: authDir})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err = w.Start(ctx); err != nil {
+		t.Fatalf("fallback start failed: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+	if w.completionActive.Load() || w.completion != nil || !failed.closed {
+		t.Fatal("failed native completion was not closed and replaced by fallback")
+	}
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case port := <-reloads:
+			if port == 6002 {
+				return
+			}
+		case <-deadline:
+			t.Fatal("fsnotify fallback did not reconcile admission change")
+		}
+	}
+}
+
+func TestStartAndStopWhenAuthDirIsConfigDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("auth-dir: "+tmpDir+"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	w, err := NewWatcher(configPath, tmpDir, nil)
+	if err != nil {
+		t.Fatalf("create watcher: %v", err)
+	}
+	w.SetConfig(&config.Config{AuthDir: tmpDir})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err = w.Start(ctx); err != nil {
+		t.Fatalf("start watcher with shared directory: %v", err)
+	}
+	if err = w.Stop(); err != nil {
+		t.Fatalf("stop watcher: %v", err)
+	}
+}
+
+func TestConfigWatcherIgnoresSiblingFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	authDir := filepath.Join(tmpDir, "auth")
+	if err := os.Mkdir(authDir, 0o755); err != nil {
+		t.Fatalf("create auth dir: %v", err)
+	}
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("port: 1001\nauth-dir: "+authDir+"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	reloads := make(chan struct{}, 2)
+	w, err := NewWatcher(configPath, authDir, func(*config.Config) { reloads <- struct{}{} })
+	if err != nil {
+		t.Fatalf("create watcher: %v", err)
+	}
+	w.SetConfig(&config.Config{Port: 1001, AuthDir: authDir})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err = w.Start(ctx); err != nil {
+		t.Fatalf("start watcher: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+	select {
+	case <-reloads:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial callback")
+	}
+	if err = os.WriteFile(filepath.Join(tmpDir, "config.yaml.tmp"), []byte("port: 9999\n"), 0o644); err != nil {
+		t.Fatalf("write sibling: %v", err)
+	}
+	select {
+	case <-reloads:
+		t.Fatal("sibling file triggered config reload")
+	case <-time.After(2 * configReloadDebounce):
+	}
+}
+
+func TestConfigWatcherFallbackReloadsRepeatedAtomicReplacements(t *testing.T) {
+	testConfigWatcherReloadsRepeatedAtomicReplacements(t, false)
+}
+
+func testConfigWatcherReloadsRepeatedAtomicReplacements(t *testing.T, nativeCompletion bool) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	authDir := filepath.Join(tmpDir, "auth")
+	if err := os.Mkdir(authDir, 0o755); err != nil {
+		t.Fatalf("create auth dir: %v", err)
+	}
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	writeConfig := func(path string, port int) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(fmt.Sprintf("port: %d\nauth-dir: %s\n", port, authDir)), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+	}
+	writeConfig(configPath, 1001)
+
+	reloads := make(chan int, 4)
+	w, err := NewWatcher(configPath, authDir, func(cfg *config.Config) { reloads <- cfg.Port })
+	if err != nil {
+		t.Fatalf("create watcher: %v", err)
+	}
+	if !nativeCompletion {
+		if w.completion != nil {
+			_ = w.completion.Close()
+		}
+		w.completion = nil
+		w.completionActive.Store(false)
+	}
+	w.SetConfig(&config.Config{Port: 1001, AuthDir: authDir})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err = w.Start(ctx); err != nil {
+		t.Fatalf("start watcher: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	select {
+	case <-reloads: // initial client load
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial callback")
+	}
+
+	for _, port := range []int{1002, 1003} {
+		tmp := filepath.Join(tmpDir, fmt.Sprintf(".config-%d.tmp", port))
+		writeConfig(tmp, port)
+		if err = os.Rename(tmp, configPath); err != nil {
+			t.Fatalf("replace config: %v", err)
+		}
+		select {
+		case got := <-reloads:
+			if got != port {
+				t.Fatalf("expected port %d after replacement, got %d", port, got)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for replacement %d", port)
+		}
+	}
+}
+
 func TestStartFailsWhenConfigMissing(t *testing.T) {
 	tmpDir := t.TempDir()
 	authDir := filepath.Join(tmpDir, "auth")
@@ -276,7 +456,7 @@ func TestStartFailsWhenConfigMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create watcher: %v", err)
 	}
-	defer w.Stop()
+	t.Cleanup(func() { _ = w.Stop() })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1513,6 +1693,48 @@ func TestNormalizeAuthNil(t *testing.T) {
 	}
 }
 
+type blockingConfigPersister struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (p *blockingConfigPersister) PersistConfig(context.Context) error {
+	close(p.started)
+	<-p.release
+	return nil
+}
+func (*blockingConfigPersister) PersistAuthFiles(context.Context, string, ...string) error {
+	return nil
+}
+
+func TestStopWaitsForConfigPersistence(t *testing.T) {
+	p := &blockingConfigPersister{started: make(chan struct{}), release: make(chan struct{})}
+	w := &Watcher{storePersister: p}
+	fsWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatalf("create fsnotify watcher: %v", err)
+	}
+	w.watcher = fsWatcher
+	w.persistConfigAsync()
+	<-p.started
+	stopped := make(chan error, 1)
+	go func() { stopped <- w.Stop() }()
+	select {
+	case err := <-stopped:
+		t.Fatalf("Stop returned before persistence completed: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(p.release)
+	select {
+	case err := <-stopped:
+		if err != nil {
+			t.Fatalf("Stop failed: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not return after persistence completed")
+	}
+}
+
 // stubStore implements coreauth.Store plus watcher-specific persistence helpers.
 type stubStore struct {
 	mu              sync.Mutex
@@ -1647,6 +1869,103 @@ func TestScheduleConfigReloadDebounces(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&reloads); got != 1 {
 		t.Fatalf("expected single debounced reload, got %d", got)
+	}
+}
+
+func TestReloadConfigIfChangedSerializesDuplicateTriggers(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("auth-dir: "+tmp+"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	var reloads int32
+	w := &Watcher{
+		configPath:     cfgPath,
+		authDir:        tmp,
+		reloadCallback: func(*config.Config) { atomic.AddInt32(&reloads, 1) },
+	}
+	w.SetConfig(&config.Config{AuthDir: tmp})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); w.reloadConfigIfChanged() }()
+	go func() { defer wg.Done(); w.reloadConfigIfChanged() }()
+	wg.Wait()
+	if got := atomic.LoadInt32(&reloads); got != 1 {
+		t.Fatalf("expected one reload for concurrent duplicate triggers, got %d", got)
+	}
+}
+
+func TestReloadConfigIfChangedAppliesHashedGeneration(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	write := func(port int) {
+		t.Helper()
+		if err := os.WriteFile(cfgPath, []byte(fmt.Sprintf("port: %d\nauth-dir: %s\n", port, tmp)), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+	}
+	write(4101)
+	got := make(chan int, 2)
+	w := &Watcher{configPath: cfgPath, authDir: tmp, reloadCallback: func(cfg *config.Config) { got <- cfg.Port }}
+	w.SetConfig(&config.Config{Port: 4100, AuthDir: tmp})
+	w.reloadTestHook = func() { write(4102); w.reloadTestHook = nil }
+	w.reloadConfigIfChanged()
+	select {
+	case port := <-got:
+		if port != 4101 {
+			t.Fatalf("applied generation %d, want hashed generation 4101", port)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for hashed generation")
+	}
+	w.reloadConfigIfChanged()
+	select {
+	case port := <-got:
+		if port != 4102 {
+			t.Fatalf("applied generation %d, want latest generation 4102", port)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for latest generation")
+	}
+}
+
+func TestStopWaitsForAdmittedConfigReload(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("port: 4201\nauth-dir: "+tmp+"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	w, err := NewWatcher(cfgPath, tmp, nil)
+	if err != nil {
+		t.Fatalf("create watcher: %v", err)
+	}
+	w.SetConfig(&config.Config{Port: 4200, AuthDir: tmp})
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	w.reloadTestHook = func() { close(entered); <-release }
+	reloadDone := make(chan struct{})
+	go func() { w.reloadConfigIfChanged(); close(reloadDone) }()
+	<-entered
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- w.Stop() }()
+	select {
+	case errStop := <-stopDone:
+		t.Fatalf("Stop returned before admitted reload completed: %v", errStop)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case <-reloadDone:
+	case <-time.After(time.Second):
+		t.Fatal("reload did not finish")
+	}
+	select {
+	case errStop := <-stopDone:
+		if errStop != nil {
+			t.Fatalf("Stop failed: %v", errStop)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not return after reload finished")
 	}
 }
 


### PR DESCRIPTION
## Problem

The config watcher registers `config.yaml` itself with fsnotify. Atomic-save tools replace that inode with a rename, so later replacements can stop producing reloads. The existing 150 ms debounce also reloads Linux in-place writes before the writer closes, which can expose an incomplete YAML prefix.

## Compatibility goals

This is a compatibility fix for both existing config-update styles, not a new save protocol:

1. **In-place writes:** a writer opens and updates the existing `config.yaml` inode. This remains supported; on Linux, reload waits for `IN_CLOSE_WRITE` instead of guessing completion from a 150 ms timer.
2. **Atomic replacements:** a writer completes a temporary file and renames it over `config.yaml`. Watching the stable parent directory and accepting `IN_MOVED_TO` keeps every replacement observable after the original inode disappears.

Both paths enter the same serialized snapshot/validation/hash reload flow. Writers do not need to adopt a new API or file format.

## Established design precedent

This does not invent a new filesystem-watching method:

- [fsnotify's official documentation](https://github.com/fsnotify/fsnotify#watching-files) recommends watching the parent directory and filtering `Event.Name`, specifically because editors commonly replace files atomically and invalidate an inode-level watch.
- Go's Linux syscall layer already exposes the standard inotify operations and event masks, including `InotifyAddWatch`, `IN_CLOSE_WRITE`, and `IN_MOVED_TO`. This implementation uses the Go project's maintained [`golang.org/x/sys/unix`](https://pkg.go.dev/golang.org/x/sys/unix) wrapper for those same kernel primitives rather than defining a custom protocol.
- Released fsnotify versions do not expose close-write as a portable public operation, so the patch keeps fsnotify as the cross-platform watcher and adds only a small Linux completion adapter using the already-present Go-maintained package.

## Changes

- watch the config parent directory and filter the exact normalized target path, while avoiding duplicate registration when the auth directory is shared;
- on Linux, use `IN_CLOSE_WRITE` and `IN_MOVED_TO` as completion signals through a small `golang.org/x/sys/unix` adapter;
- fall back to the existing fsnotify quiet-window behavior on non-Linux platforms and whenever native Linux completion is unavailable or loses events;
- serialize config reloads and parse/hash one byte snapshot so the applied config and deduplication hash represent the same generation;
- preserve load-time plaintext management-secret migration without overwriting a newer atomic replacement, and restore original bytes after recoverable partial-write or truncate failures;
- wait for admitted config reload and config-persistence work during `Stop`;
- add real-filesystem regression tests for repeated atomic replacement, in-place close gating, native/fallback admission, overflow fallback, generation consistency, migration failures, and shutdown fencing.

## Compatibility

- missing-config `Start` failure remains unchanged;
- auth watching, explicit `ReloadConfigIfChanged`, hash deduplication, `LoadConfig`-equivalent validation, and management-secret migration remain supported;
- non-Linux platforms keep the existing 150 ms debounce fallback;
- no public API or dependency changes.

## Not included

- config transaction or revision/CAS support;
- atomic or durable config persistence redesign;
- Docker mount or remote-store changes;
- plugin business logic;
- changes under `internal/translator`.

## Verification

```text
go test ./internal/config ./internal/watcher/... -count=1
go test -race ./internal/config ./internal/watcher -count=1
go test ./internal/config ./internal/watcher -run 'Test(ParseConfigBytesAndPersistMigrations|ConfigCompletion|ConfigWatcher|StartCaptures|StartFallsBack|ReloadConfigIfChanged|StopWaits)' -count=100
GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c ./internal/watcher
GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go test -c ./internal/watcher
GOOS=freebsd GOARCH=amd64 CGO_ENABLED=0 go test -c ./internal/watcher
go test ./cmd/server -run '^$'
go build -o /tmp/cli-proxy-api ./cmd/server
go vet ./internal/config ./internal/watcher/...
git diff --check origin/dev..HEAD
git verify-commit HEAD
```

Independent final review approved the current diff.

`go test ./... -count=1` still reports three Claude fingerprint tests expecting Linux while the host fingerprint resolves to macOS. The same three failures reproduce on a clean `origin/dev` worktree; this patch adds no full-suite regression.
