### PR TITLE
fix(kimi): honor RFC 8628 slow_down poll interval

### DIFF
--- a/internal/auth/kimi/kimi.go
+++ b/internal/auth/kimi/kimi.go
@@ -238,33 +238,41 @@ func (c *DeviceFlowClient) PollForToken(ctx context.Context, deviceCode *DeviceC
 		}
 	}
 
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
+	// Use a timer (not a fixed ticker) so RFC 8628 slow_down can lengthen the wait.
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, fmt.Errorf("kimi: context cancelled: %w", ctx.Err())
-		case <-ticker.C:
+		case <-timer.C:
 			if time.Now().After(deadline) {
 				return nil, fmt.Errorf("kimi: device code expired")
 			}
 
-			token, pollErr, shouldContinue := c.exchangeDeviceCode(ctx, deviceCode.DeviceCode)
+			token, pollErr, nextInterval, shouldContinue := c.exchangeDeviceCode(ctx, deviceCode.DeviceCode, interval)
 			if token != nil {
 				return token, nil
 			}
 			if !shouldContinue {
 				return nil, pollErr
 			}
-			// Continue polling
+			interval = nextInterval
+			timer.Reset(interval)
 		}
 	}
 }
 
+// increasePollInterval implements RFC 8628 §3.5: each slow_down MUST increase
+// the polling interval by 5 seconds for this and all subsequent requests.
+func increasePollInterval(interval time.Duration) time.Duration {
+	return interval + defaultPollInterval
+}
+
 // exchangeDeviceCode attempts to exchange the device code for an access token.
-// Returns (token, error, shouldContinue).
-func (c *DeviceFlowClient) exchangeDeviceCode(ctx context.Context, deviceCode string) (*KimiTokenData, error, bool) {
+// Returns (token, error, nextInterval, shouldContinue).
+func (c *DeviceFlowClient) exchangeDeviceCode(ctx context.Context, deviceCode string, interval time.Duration) (*KimiTokenData, error, time.Duration, bool) {
 	data := url.Values{}
 	data.Set("client_id", kimiClientID)
 	data.Set("device_code", deviceCode)
@@ -272,7 +280,7 @@ func (c *DeviceFlowClient) exchangeDeviceCode(ctx context.Context, deviceCode st
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, kimiTokenURL, strings.NewReader(data.Encode()))
 	if err != nil {
-		return nil, fmt.Errorf("kimi: failed to create token request: %w", err), false
+		return nil, fmt.Errorf("kimi: failed to create token request: %w", err), interval, false
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
@@ -282,7 +290,7 @@ func (c *DeviceFlowClient) exchangeDeviceCode(ctx context.Context, deviceCode st
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("kimi: token request failed: %w", err), false
+		return nil, fmt.Errorf("kimi: token request failed: %w", err), interval, false
 	}
 	defer func() {
 		if errClose := resp.Body.Close(); errClose != nil {
@@ -292,7 +300,7 @@ func (c *DeviceFlowClient) exchangeDeviceCode(ctx context.Context, deviceCode st
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("kimi: failed to read token response: %w", err), false
+		return nil, fmt.Errorf("kimi: failed to read token response: %w", err), interval, false
 	}
 
 	// Parse response - Kimi returns 200 for both success and pending states
@@ -307,26 +315,26 @@ func (c *DeviceFlowClient) exchangeDeviceCode(ctx context.Context, deviceCode st
 	}
 
 	if err = json.Unmarshal(bodyBytes, &oauthResp); err != nil {
-		return nil, fmt.Errorf("kimi: failed to parse token response: %w", err), false
+		return nil, fmt.Errorf("kimi: failed to parse token response: %w", err), interval, false
 	}
 
 	if oauthResp.Error != "" {
 		switch oauthResp.Error {
 		case "authorization_pending":
-			return nil, nil, true // Continue polling
+			return nil, nil, interval, true
 		case "slow_down":
-			return nil, nil, true // Continue polling (with increased interval handled by caller)
+			return nil, nil, increasePollInterval(interval), true
 		case "expired_token":
-			return nil, fmt.Errorf("kimi: device code expired"), false
+			return nil, fmt.Errorf("kimi: device code expired"), interval, false
 		case "access_denied":
-			return nil, fmt.Errorf("kimi: access denied by user"), false
+			return nil, fmt.Errorf("kimi: access denied by user"), interval, false
 		default:
-			return nil, fmt.Errorf("kimi: OAuth error: %s - %s", oauthResp.Error, oauthResp.ErrorDescription), false
+			return nil, fmt.Errorf("kimi: OAuth error: %s - %s", oauthResp.Error, oauthResp.ErrorDescription), interval, false
 		}
 	}
 
 	if oauthResp.AccessToken == "" {
-		return nil, fmt.Errorf("kimi: empty access token in response"), false
+		return nil, fmt.Errorf("kimi: empty access token in response"), interval, false
 	}
 
 	var expiresAt int64
@@ -340,7 +348,7 @@ func (c *DeviceFlowClient) exchangeDeviceCode(ctx context.Context, deviceCode st
 		TokenType:    oauthResp.TokenType,
 		ExpiresAt:    expiresAt,
 		Scope:        oauthResp.Scope,
-	}, nil, false
+	}, nil, interval, false
 }
 
 // RefreshToken exchanges a refresh token for a new access token.

--- a/internal/auth/kimi/kimi.go
+++ b/internal/auth/kimi/kimi.go
@@ -238,8 +238,13 @@ func (c *DeviceFlowClient) PollForToken(ctx context.Context, deviceCode *DeviceC
 		}
 	}
 
+	wait := pollWaitDuration(interval, deadline)
+	if wait <= 0 {
+		return nil, fmt.Errorf("kimi: device code expired")
+	}
+
 	// Use a timer (not a fixed ticker) so RFC 8628 slow_down can lengthen the wait.
-	timer := time.NewTimer(interval)
+	timer := time.NewTimer(wait)
 	defer timer.Stop()
 
 	for {
@@ -259,9 +264,26 @@ func (c *DeviceFlowClient) PollForToken(ctx context.Context, deviceCode *DeviceC
 				return nil, pollErr
 			}
 			interval = nextInterval
-			timer.Reset(interval)
+			wait = pollWaitDuration(interval, deadline)
+			if wait <= 0 {
+				return nil, fmt.Errorf("kimi: device code expired")
+			}
+			timer.Reset(wait)
 		}
 	}
+}
+
+// pollWaitDuration caps the next poll wait at the remaining authorization deadline.
+// A non-positive remaining duration means the deadline has already passed.
+func pollWaitDuration(interval time.Duration, deadline time.Time) time.Duration {
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return 0
+	}
+	if interval > remaining {
+		return remaining
+	}
+	return interval
 }
 
 // increasePollInterval implements RFC 8628 §3.5: each slow_down MUST increase

--- a/internal/auth/kimi/kimi.go
+++ b/internal/auth/kimi/kimi.go
@@ -252,7 +252,7 @@ func (c *DeviceFlowClient) PollForToken(ctx context.Context, deviceCode *DeviceC
 		case <-ctx.Done():
 			return nil, fmt.Errorf("kimi: context cancelled: %w", ctx.Err())
 		case <-timer.C:
-			if time.Now().After(deadline) {
+			if !time.Now().Before(deadline) {
 				return nil, fmt.Errorf("kimi: device code expired")
 			}
 

--- a/internal/auth/kimi/kimi_poll_test.go
+++ b/internal/auth/kimi/kimi_poll_test.go
@@ -150,6 +150,81 @@ func TestPollForTokenAuthorizationPendingKeepsInterval(t *testing.T) {
 	})
 }
 
+func TestPollWaitDurationCapsAtDeadline(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		now := time.Now()
+		tests := []struct {
+			name     string
+			interval time.Duration
+			deadline time.Time
+			want     time.Duration
+		}{
+			{name: "interval shorter than remaining", interval: 10 * time.Second, deadline: now.Add(30 * time.Second), want: 10 * time.Second},
+			{name: "interval longer than remaining", interval: 10 * time.Second, deadline: now.Add(3 * time.Second), want: 3 * time.Second},
+			{name: "already expired", interval: 10 * time.Second, deadline: now.Add(-time.Second), want: 0},
+			{name: "deadline now", interval: 10 * time.Second, deadline: now, want: 0},
+		}
+		for _, tt := range tests {
+			got := pollWaitDuration(tt.interval, tt.deadline)
+			if got != tt.want {
+				t.Fatalf("%s: pollWaitDuration() = %s, want %s", tt.name, got, tt.want)
+			}
+		}
+	})
+}
+
+func TestPollForTokenSlowDownDoesNotSleepPastDeadline(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var pollTimes []time.Time
+		client := &DeviceFlowClient{httpClient: &http.Client{Transport: kimiRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			pollTimes = append(pollTimes, time.Now())
+			return oauthJSONResponse(req, `{"error":"slow_down"}`), nil
+		})}}
+
+		start := time.Now()
+		_, errPoll := client.PollForToken(context.Background(), &DeviceCodeResponse{
+			DeviceCode: "device-1",
+			ExpiresIn:  8, // first wait 5s; slow_down would otherwise reset for 10s
+			Interval:   5,
+		})
+		if errPoll == nil || !strings.Contains(errPoll.Error(), "device code expired") {
+			t.Fatalf("error = %v, want device code expired", errPoll)
+		}
+		if elapsed := time.Since(start); elapsed != 8*time.Second {
+			t.Fatalf("elapsed = %s, want 8s (deadline), not the uncapped 15s wait", elapsed)
+		}
+		if len(pollTimes) != 2 {
+			t.Fatalf("poll count = %d, want 2 (wake at deadline, then expire)", len(pollTimes))
+		}
+	})
+}
+
+func TestPollForTokenFirstWaitCappedToDeadline(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var calls int
+		client := &DeviceFlowClient{httpClient: &http.Client{Transport: kimiRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			calls++
+			return oauthJSONResponse(req, `{"error":"authorization_pending"}`), nil
+		})}}
+
+		start := time.Now()
+		_, errPoll := client.PollForToken(context.Background(), &DeviceCodeResponse{
+			DeviceCode: "device-1",
+			ExpiresIn:  3,
+			Interval:   5,
+		})
+		if errPoll == nil || !strings.Contains(errPoll.Error(), "device code expired") {
+			t.Fatalf("error = %v, want device code expired", errPoll)
+		}
+		if elapsed := time.Since(start); elapsed != 3*time.Second {
+			t.Fatalf("elapsed = %s, want 3s (deadline), not the 5s first interval", elapsed)
+		}
+		if calls != 1 {
+			t.Fatalf("poll count = %d, want 1", calls)
+		}
+	})
+}
+
 func TestPollForTokenNilDeviceCode(t *testing.T) {
 	client := &DeviceFlowClient{httpClient: &http.Client{}}
 	_, errPoll := client.PollForToken(context.Background(), nil)

--- a/internal/auth/kimi/kimi_poll_test.go
+++ b/internal/auth/kimi/kimi_poll_test.go
@@ -1,0 +1,159 @@
+package kimi
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+func oauthJSONResponse(req *http.Request, body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}
+}
+
+func TestIncreasePollIntervalFollowsRFC8628SlowDown(t *testing.T) {
+	interval := defaultPollInterval
+	want := []time.Duration{
+		10 * time.Second,
+		15 * time.Second,
+		20 * time.Second,
+	}
+	for i, next := range want {
+		got := increasePollInterval(interval)
+		if got != next {
+			t.Fatalf("slow_down %d: increasePollInterval(%s) = %s, want %s", i+1, interval, got, next)
+		}
+		interval = got
+	}
+}
+
+func TestExchangeDeviceCodeSlowDownIncreasesIntervalByFiveSeconds(t *testing.T) {
+	var calls int
+	client := &DeviceFlowClient{httpClient: &http.Client{Transport: kimiRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		return oauthJSONResponse(req, `{"error":"slow_down"}`), nil
+	})}}
+
+	interval := defaultPollInterval
+	for i, want := range []time.Duration{10 * time.Second, 15 * time.Second, 20 * time.Second} {
+		token, errExchange, next, cont := client.exchangeDeviceCode(context.Background(), "device-1", interval)
+		if token != nil || errExchange != nil {
+			t.Fatalf("slow_down %d: token=%v err=%v", i+1, token, errExchange)
+		}
+		if !cont {
+			t.Fatalf("slow_down %d: shouldContinue = false", i+1)
+		}
+		if next != want {
+			t.Fatalf("slow_down %d: nextInterval = %s, want %s", i+1, next, want)
+		}
+		interval = next
+	}
+	if calls != 3 {
+		t.Fatalf("calls = %d, want 3", calls)
+	}
+}
+
+func TestExchangeDeviceCodeAuthorizationPendingKeepsInterval(t *testing.T) {
+	client := &DeviceFlowClient{httpClient: &http.Client{Transport: kimiRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return oauthJSONResponse(req, `{"error":"authorization_pending"}`), nil
+	})}}
+
+	token, errExchange, next, cont := client.exchangeDeviceCode(context.Background(), "device-1", defaultPollInterval)
+	if token != nil || errExchange != nil || !cont {
+		t.Fatalf("token=%v err=%v shouldContinue=%v", token, errExchange, cont)
+	}
+	if next != defaultPollInterval {
+		t.Fatalf("nextInterval = %s, want %s", next, defaultPollInterval)
+	}
+}
+
+func TestPollForTokenSlowDownIncreasesIntervalByFiveSeconds(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var pollTimes []time.Time
+		var calls int
+		client := &DeviceFlowClient{httpClient: &http.Client{Transport: kimiRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			pollTimes = append(pollTimes, time.Now())
+			calls++
+			body := `{"error":"slow_down"}`
+			if calls == 3 {
+				body = `{"access_token":"access-slow","refresh_token":"refresh-slow","token_type":"Bearer","expires_in":3600}`
+			}
+			return oauthJSONResponse(req, body), nil
+		})}}
+
+		token, errPoll := client.PollForToken(context.Background(), &DeviceCodeResponse{
+			DeviceCode: "device-1",
+			ExpiresIn:  120,
+			Interval:   5,
+		})
+		if errPoll != nil {
+			t.Fatalf("PollForToken() error = %v", errPoll)
+		}
+		if token == nil || token.AccessToken != "access-slow" {
+			t.Fatalf("token = %#v, want access-slow", token)
+		}
+		if len(pollTimes) != 3 {
+			t.Fatalf("poll count = %d, want 3", len(pollTimes))
+		}
+		// RFC 8628 §3.5: each slow_down adds +5s (5→10→15), not exponential (5→10→20).
+		if gap := pollTimes[1].Sub(pollTimes[0]); gap != 10*time.Second {
+			t.Fatalf("gap after first slow_down = %s, want 10s", gap)
+		}
+		if gap := pollTimes[2].Sub(pollTimes[1]); gap != 15*time.Second {
+			t.Fatalf("gap after second slow_down = %s, want 15s", gap)
+		}
+	})
+}
+
+func TestPollForTokenAuthorizationPendingKeepsInterval(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var pollTimes []time.Time
+		var calls int
+		client := &DeviceFlowClient{httpClient: &http.Client{Transport: kimiRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			pollTimes = append(pollTimes, time.Now())
+			calls++
+			body := `{"error":"authorization_pending"}`
+			if calls == 3 {
+				body = `{"access_token":"access-ok","refresh_token":"refresh-ok","token_type":"Bearer","expires_in":3600}`
+			}
+			return oauthJSONResponse(req, body), nil
+		})}}
+
+		token, errPoll := client.PollForToken(context.Background(), &DeviceCodeResponse{
+			DeviceCode: "device-1",
+			ExpiresIn:  120,
+			Interval:   5,
+		})
+		if errPoll != nil {
+			t.Fatalf("PollForToken() error = %v", errPoll)
+		}
+		if token == nil || token.AccessToken != "access-ok" {
+			t.Fatalf("token = %#v, want access-ok", token)
+		}
+		if len(pollTimes) != 3 {
+			t.Fatalf("poll count = %d, want 3", len(pollTimes))
+		}
+		if gap := pollTimes[1].Sub(pollTimes[0]); gap != defaultPollInterval {
+			t.Fatalf("pending gap = %s, want %s", gap, defaultPollInterval)
+		}
+		if gap := pollTimes[2].Sub(pollTimes[1]); gap != defaultPollInterval {
+			t.Fatalf("pending gap = %s, want %s", gap, defaultPollInterval)
+		}
+	})
+}
+
+func TestPollForTokenNilDeviceCode(t *testing.T) {
+	client := &DeviceFlowClient{httpClient: &http.Client{}}
+	_, errPoll := client.PollForToken(context.Background(), nil)
+	if errPoll == nil {
+		t.Fatal("expected error for nil device code")
+	}
+}

--- a/internal/auth/kimi/kimi_poll_test.go
+++ b/internal/auth/kimi/kimi_poll_test.go
@@ -193,8 +193,8 @@ func TestPollForTokenSlowDownDoesNotSleepPastDeadline(t *testing.T) {
 		if elapsed := time.Since(start); elapsed != 8*time.Second {
 			t.Fatalf("elapsed = %s, want 8s (deadline), not the uncapped 15s wait", elapsed)
 		}
-		if len(pollTimes) != 2 {
-			t.Fatalf("poll count = %d, want 2 (wake at deadline, then expire)", len(pollTimes))
+		if len(pollTimes) != 1 {
+			t.Fatalf("poll count = %d, want 1 (do not poll at the deadline)", len(pollTimes))
 		}
 	})
 }
@@ -219,8 +219,8 @@ func TestPollForTokenFirstWaitCappedToDeadline(t *testing.T) {
 		if elapsed := time.Since(start); elapsed != 3*time.Second {
 			t.Fatalf("elapsed = %s, want 3s (deadline), not the 5s first interval", elapsed)
 		}
-		if calls != 1 {
-			t.Fatalf("poll count = %d, want 1", calls)
+		if calls != 0 {
+			t.Fatalf("poll count = %d, want 0 (do not poll at the deadline)", calls)
 		}
 	})
 }


### PR DESCRIPTION
## Problem

Kimi device-code OAuth used a fixed ticker and did not implement the RFC 8628 `slow_down` interval increase. A naive enlarged timer can also wait past the device-code deadline, or issue one more request exactly at expiration.

RFC 8628 §3.5 requires every `slow_down` response to add 5 seconds for that and all subsequent requests (`5 → 10 → 15 → 20`, not exponential backoff).

## Fix

- return the next poll interval from `exchangeDeviceCode`
- add 5 seconds on each `slow_down`; keep the interval unchanged on `authorization_pending`
- use a resettable timer so subsequent polls honor the updated interval
- cap every wait at the remaining authorization deadline
- treat `time.Now() == deadline` as expired before starting another token request

No endpoint, client ID, credential, or translator changes.

## Validation

- `go test ./internal/auth/kimi -count=1`
- `go test -race ./internal/auth/kimi -count=1`
- `go test ./internal/auth/... -count=1`
- server build
- virtual-clock tests cover repeated slowdown, pending intervals, initial and later deadline caps, and zero requests at the exact deadline

RFC reference: https://www.rfc-editor.org/rfc/rfc8628.html#section-3.5