### PR TITLE
fix(codex): filter reasoning levels by client version (#5262)

### DIFF
--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -681,7 +681,7 @@ func (s *Server) handleHomeCodexClientModels(c *gin.Context) {
 		models = append(models, model)
 	}
 
-	c.JSON(http.StatusOK, codexmodels.BuildResponse(models, nil, s.cfg.Codex.OptimizeMultiAgentV2))
+	c.JSON(http.StatusOK, codexmodels.BuildResponseForClient(models, nil, s.cfg.Codex.OptimizeMultiAgentV2, c.Query("client_version")))
 }
 
 func (s *Server) geminiModelsHandler(geminiHandler *gemini.GeminiAPIHandler) gin.HandlerFunc {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1851,7 +1851,7 @@ func TestModelsWithClientVersionReturnsCodexCatalog(t *testing.T) {
 			DisplayName:   "Custom Codex Model",
 			Description:   "Custom model from registry",
 			ContextLength: 123456,
-			Thinking:      &registry.ThinkingSupport{Levels: []string{"none", "minimal", "low", "medium", "unsupported", "high", "xhigh"}},
+			Thinking:      &registry.ThinkingSupport{Levels: []string{"none", "minimal", "low", "medium", "unsupported", "high", "xhigh", "max", "ultra"}},
 		},
 		{ID: "grok-imagine-image-quality", Object: "model", OwnedBy: "xai", Type: "openai"},
 		{ID: "gpt-image-2", Object: "model", OwnedBy: "openai", Type: "openai"},
@@ -1867,7 +1867,7 @@ func TestModelsWithClientVersionReturnsCodexCatalog(t *testing.T) {
 
 	server := newTestServer(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/models?client_version", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/models?client_version=0.137.0", nil)
 	req.Header.Set("Authorization", "Bearer test-key")
 	req.Header.Set("User-Agent", "claude-cli/1.0")
 

--- a/internal/client/codex/models/models.go
+++ b/internal/client/codex/models/models.go
@@ -4,6 +4,7 @@ package models
 import (
 	"encoding/json"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -37,14 +38,32 @@ var codexClientAllowedReasoningLevels = map[string]struct{}{
 	"ultra":   {},
 }
 
+const (
+	// Codex clients before 0.144.0 reject max and ultra while parsing the
+	// complete model catalog.
+	codexClientAdvancedReasoningMinMajor = 0
+	codexClientAdvancedReasoningMinMinor = 144
+	codexClientAdvancedReasoningMinPatch = 0
+)
+
 // BuildResponse builds a Codex client model response from available models.
 func BuildResponse(availableModels []map[string]any, providersForModel ProvidersForModelFunc, optimizeMultiAgentV2 bool) map[string]any {
+	return buildCodexClientModelsResponse(availableModels, providersForModel, optimizeMultiAgentV2, "", false)
+}
+
+// BuildResponseForClient builds a Codex client model response compatible with
+// the requested Codex client version.
+func BuildResponseForClient(availableModels []map[string]any, providersForModel ProvidersForModelFunc, optimizeMultiAgentV2 bool, clientVersion string) map[string]any {
+	return buildCodexClientModelsResponse(availableModels, providersForModel, optimizeMultiAgentV2, clientVersion, true)
+}
+
+func buildCodexClientModelsResponse(availableModels []map[string]any, providersForModel ProvidersForModelFunc, optimizeMultiAgentV2 bool, clientVersion string, filterForClient bool) map[string]any {
 	return map[string]any{
-		"models": buildCodexClientModels(availableModels, providersForModel, optimizeMultiAgentV2),
+		"models": buildCodexClientModels(availableModels, providersForModel, optimizeMultiAgentV2, clientVersion, filterForClient),
 	}
 }
 
-func buildCodexClientModels(models []map[string]any, providersForModel ProvidersForModelFunc, optimizeMultiAgentV2 bool) []map[string]any {
+func buildCodexClientModels(models []map[string]any, providersForModel ProvidersForModelFunc, optimizeMultiAgentV2 bool, clientVersion string, filterForClient bool) []map[string]any {
 	templates, defaultTemplate, err := loadCodexClientModelTemplates()
 	if err != nil || defaultTemplate == nil {
 		return nil
@@ -64,6 +83,7 @@ func buildCodexClientModels(models []map[string]any, providersForModel Providers
 			applyCodexClientMaxTokens(entry, model)
 			applyCodexClientSearchToolSupport(entry, id, true, providersForModel)
 			sanitizeCodexClientReasoningMetadata(entry)
+			filterCodexClientReasoningMetadata(entry, clientVersion, filterForClient)
 			applyCodexClientVisibilityOverride(entry, id)
 			if optimizeMultiAgentV2 {
 				entry["multi_agent_version"] = "v2"
@@ -77,6 +97,7 @@ func buildCodexClientModels(models []map[string]any, providersForModel Providers
 		applyCodexClientMaxTokens(entry, model)
 		applyCodexClientSearchToolSupport(entry, id, false, providersForModel)
 		sanitizeCodexClientReasoningMetadata(entry)
+		filterCodexClientReasoningMetadata(entry, clientVersion, filterForClient)
 		applyCodexClientVisibilityOverride(entry, id)
 		result = append(result, entry)
 	}
@@ -402,6 +423,78 @@ func sanitizeCodexClientReasoningMetadata(entry map[string]any) {
 
 	entry["supported_reasoning_levels"] = levels
 	entry["default_reasoning_level"] = defaultLevel
+}
+
+func filterCodexClientReasoningMetadata(entry map[string]any, clientVersion string, filterForClient bool) {
+	if !filterForClient || codexClientSupportsAdvancedReasoning(clientVersion) {
+		return
+	}
+
+	rawLevels, ok := entry["supported_reasoning_levels"].([]any)
+	if !ok {
+		return
+	}
+
+	levels := make([]any, 0, len(rawLevels))
+	allowedDefaults := make(map[string]struct{}, len(rawLevels))
+	for _, rawLevelEntry := range rawLevels {
+		levelEntry, ok := rawLevelEntry.(map[string]any)
+		if !ok {
+			continue
+		}
+		level := stringModelValue(levelEntry, "effort")
+		if level == "max" || level == "ultra" {
+			continue
+		}
+		levels = append(levels, levelEntry)
+		allowedDefaults[level] = struct{}{}
+	}
+
+	if len(levels) == 0 {
+		delete(entry, "supported_reasoning_levels")
+		delete(entry, "default_reasoning_level")
+		return
+	}
+
+	defaultLevel := stringModelValue(entry, "default_reasoning_level")
+	if _, ok := allowedDefaults[defaultLevel]; !ok {
+		defaultLevel = stringModelValue(levels[0].(map[string]any), "effort")
+	}
+	entry["supported_reasoning_levels"] = levels
+	entry["default_reasoning_level"] = defaultLevel
+}
+
+func codexClientSupportsAdvancedReasoning(clientVersion string) bool {
+	major, minor, patch, ok := parseCodexClientVersion(clientVersion)
+	if !ok {
+		return false
+	}
+	if major != codexClientAdvancedReasoningMinMajor {
+		return major > codexClientAdvancedReasoningMinMajor
+	}
+	if minor != codexClientAdvancedReasoningMinMinor {
+		return minor > codexClientAdvancedReasoningMinMinor
+	}
+	return patch >= codexClientAdvancedReasoningMinPatch
+}
+
+func parseCodexClientVersion(raw string) (int, int, int, bool) {
+	parts := strings.Split(strings.TrimPrefix(strings.TrimSpace(raw), "v"), ".")
+	if len(parts) < 2 || len(parts) > 3 {
+		return 0, 0, 0, false
+	}
+	values := [3]int{}
+	for index, part := range parts {
+		if part == "" {
+			return 0, 0, 0, false
+		}
+		value, err := strconv.Atoi(part)
+		if err != nil || value < 0 {
+			return 0, 0, 0, false
+		}
+		values[index] = value
+	}
+	return values[0], values[1], values[2], true
 }
 
 func normalizeCodexClientReasoningLevel(rawLevel string) string {

--- a/internal/client/codex/models/models_test.go
+++ b/internal/client/codex/models/models_test.go
@@ -226,7 +226,7 @@ func TestCodexClientModelsResponse_RequiresTemplateAndCodexProvidersForSearchToo
 }
 
 func TestCodexClientModelsResponse_PreservesUltraReasoningEffort(t *testing.T) {
-	resp := BuildResponse([]map[string]any{{"id": "gpt-5.6-sol"}}, nil, false)
+	resp := BuildResponseForClient([]map[string]any{{"id": "gpt-5.6-sol"}}, nil, false, "0.149.1")
 	models, ok := resp["models"].([]map[string]any)
 	if !ok {
 		t.Fatalf("models type = %T, want []map[string]any", resp["models"])
@@ -255,6 +255,46 @@ func TestCodexClientModelsResponse_PreservesUltraReasoningEffort(t *testing.T) {
 	}
 
 	t.Fatalf("supported_reasoning_levels = %#v, want ultra", levels)
+}
+
+func TestCodexClientModelsResponse_FiltersAdvancedReasoningForLegacyClient(t *testing.T) {
+	resp := BuildResponseForClient([]map[string]any{{"id": "gpt-5.6-sol"}}, nil, false, "0.137.0")
+	models, ok := resp["models"].([]map[string]any)
+	if !ok {
+		t.Fatalf("models type = %T, want []map[string]any", resp["models"])
+	}
+
+	var sol map[string]any
+	for _, entry := range models {
+		if stringModelValue(entry, "slug") == "gpt-5.6-sol" {
+			sol = entry
+			break
+		}
+	}
+	if sol == nil {
+		t.Fatal("expected codex client entry for gpt-5.6-sol")
+	}
+
+	rawLevels, ok := sol["supported_reasoning_levels"].([]any)
+	if !ok {
+		t.Fatalf("supported_reasoning_levels = %T, want []any", sol["supported_reasoning_levels"])
+	}
+	want := []string{"low", "medium", "high", "xhigh"}
+	if len(rawLevels) != len(want) {
+		t.Fatalf("supported_reasoning_levels length = %d, want %d: %#v", len(rawLevels), len(want), rawLevels)
+	}
+	for index, rawLevel := range rawLevels {
+		level, ok := rawLevel.(map[string]any)
+		if !ok {
+			t.Fatalf("supported_reasoning_levels[%d] = %#v, want object", index, rawLevel)
+		}
+		if got := stringModelValue(level, "effort"); got != want[index] {
+			t.Fatalf("supported_reasoning_levels[%d].effort = %q, want %q", index, got, want[index])
+		}
+	}
+	if got := stringModelValue(sol, "default_reasoning_level"); got != "low" {
+		t.Fatalf("default_reasoning_level = %q, want low", got)
+	}
 }
 
 func TestLoadCodexClientModelTemplatesRefreshesOnRevision(t *testing.T) {

--- a/sdk/api/handlers/openai/codex_client_models.go
+++ b/sdk/api/handlers/openai/codex_client_models.go
@@ -6,8 +6,12 @@ import (
 )
 
 func (h *OpenAIAPIHandler) codexClientModelsResponse() map[string]any {
+	return h.codexClientModelsResponseForClient("")
+}
+
+func (h *OpenAIAPIHandler) codexClientModelsResponseForClient(clientVersion string) map[string]any {
 	optimizeMultiAgentV2 := h != nil && h.Cfg != nil && h.Cfg.CodexOptimizeMultiAgentV2
-	return codexmodels.BuildResponse(h.Models(), registry.GetGlobalRegistry().GetModelProviders, optimizeMultiAgentV2)
+	return codexmodels.BuildResponseForClient(h.Models(), registry.GetGlobalRegistry().GetModelProviders, optimizeMultiAgentV2, clientVersion)
 }
 
 // CodexClientModelsResponse builds a Codex client model response.

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -60,7 +60,7 @@ func (h *OpenAIAPIHandler) Models() []map[string]any {
 // and specifications in OpenAI-compatible format.
 func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 	if _, ok := c.Request.URL.Query()["client_version"]; ok {
-		c.JSON(http.StatusOK, h.codexClientModelsResponse())
+		c.JSON(http.StatusOK, h.codexClientModelsResponseForClient(c.Query("client_version")))
 		return
 	}
 


### PR DESCRIPTION
## Summary

- Pass `client_version` into Codex model catalog generation.
- Filter `max` and `ultra` reasoning levels for Codex clients older than `0.144.0`.
- Ensure `default_reasoning_level` remains valid after filtering.
- Apply the compatibility handling to both standard and Home model catalog routes.

## Related Issue

Closes router-for-me/CLIProxyAPI#5262

## Tests

- Added regression coverage for legacy Codex client `0.137.0`.
- Verified newer client `0.149.1` still receives advanced reasoning levels.
- `go test ./internal/client/codex/models ./sdk/api/handlers/openai ./internal/api` passed.
- `go build -o test-output ./cmd/server` passed.

`go test ./...` was also executed, but the repository-wide run has unrelated existing/environment failures involving GitHub token headers, Windows file permissions, Claude platform fingerprint expectations, and stale nocopy metadata. All packages affected by this change passed.