### PR TITLE
fix(claude): treat allowed_warning as an allowed shared window (#5275)

### DIFF
--- a/internal/runtime/executor/helps/claude_ratelimit.go
+++ b/internal/runtime/executor/helps/claude_ratelimit.go
@@ -39,8 +39,19 @@ func ClaudeHeadersIndicateUnifiedRateLimitRejection(headers http.Header) bool {
 	return !isFableOnlyRejection(status5h, status7d, status7dOI)
 }
 
+// isSharedWindowAllowed reports whether a shared-window status still permits the request.
+// Anthropic reports "allowed_warning" once utilization passes the surpassed threshold
+// advertised in Anthropic-Ratelimit-Unified-<window>-Surpassed-Threshold (0.75 in practice).
+// That status still permits the request, so it must be treated the same as "allowed" when
+// deciding whether a shared window caused a rejection. Comparing against the "allowed"
+// literal alone misclassifies a Fable-only rejection as credential-scoped for every account
+// past the threshold, which benches the whole credential instead of just the Fable model.
+func isSharedWindowAllowed(status string) bool {
+	return status == "allowed" || status == "allowed_warning"
+}
+
 func isFableOnlyRejection(status5h, status7d, status7dOI string) bool {
-	return status5h == "allowed" && status7d == "allowed" && status7dOI == "rejected"
+	return isSharedWindowAllowed(status5h) && isSharedWindowAllowed(status7d) && status7dOI == "rejected"
 }
 
 // ParseClaudeRateLimitReset inspects Anthropic response headers for shared and Fable-specific
@@ -117,7 +128,7 @@ func parseClaudeRateLimitResetWithFuzz(headers http.Header, now time.Time, minFu
 
 	// 5. Unified reset header:
 	unifiedRejected := !fableOnlyRejection && (unifiedStatus == "rejected" || status5h == "rejected" || status7d == "rejected" || status7dOI == "rejected" ||
-		(unifiedStatus == "" && status5h != "allowed" && status7d != "allowed"))
+		(unifiedStatus == "" && !isSharedWindowAllowed(status5h) && !isSharedWindowAllowed(status7d)))
 
 	if unifiedRejected {
 		if raw := getHeaderCaseInsensitive(headers, "Anthropic-Ratelimit-Unified-Reset"); raw != "" {

--- a/internal/runtime/executor/helps/claude_ratelimit_allowedwarning_test.go
+++ b/internal/runtime/executor/helps/claude_ratelimit_allowedwarning_test.go
@@ -1,0 +1,37 @@
+package helps
+
+import (
+	"net/http"
+	"testing"
+)
+
+// Regression: an account past the surpassed threshold reports "allowed_warning" on the
+// shared 7d window. A Fable-only (7d_oi) rejection must stay model-scoped in that state,
+// otherwise the whole credential is benched until the Fable window resets.
+func TestFableOnlyRejectionWithAllowedWarningSharedWindow(t *testing.T) {
+	h := http.Header{}
+	h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+	h.Set("Anthropic-Ratelimit-Unified-5h-Status", "allowed")
+	h.Set("Anthropic-Ratelimit-Unified-7d-Status", "allowed_warning")
+	h.Set("Anthropic-Ratelimit-Unified-7d-Surpassed-Threshold", "0.75")
+	h.Set("Anthropic-Ratelimit-Unified-7d_oi-Status", "rejected")
+
+	if ClaudeHeadersIndicateUnifiedRateLimitRejection(h) {
+		t.Fatal("Fable-only rejection was classified as a shared/credential-scoped rejection " +
+			"while the 7d window was allowed_warning; the credential will be benched for all models")
+	}
+}
+
+// A genuine shared-window rejection must still be credential-scoped.
+func TestSharedWindowRejectionStillCredentialScoped(t *testing.T) {
+	for _, w := range []string{"5h", "7d"} {
+		h := http.Header{}
+		h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+		h.Set("Anthropic-Ratelimit-Unified-5h-Status", "allowed")
+		h.Set("Anthropic-Ratelimit-Unified-7d-Status", "allowed_warning")
+		h.Set("Anthropic-Ratelimit-Unified-"+w+"-Status", "rejected")
+		if !ClaudeHeadersIndicateUnifiedRateLimitRejection(h) {
+			t.Fatalf("%s rejection must remain credential-scoped", w)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #5275.

Anthropic reports `allowed_warning` on a unified rate-limit window once utilization passes the threshold advertised in `Anthropic-Ratelimit-Unified-<window>-Surpassed-Threshold` (0.75 in practice). The request is still permitted — only the status label changes.

`isFableOnlyRejection` compared the shared 5h/7d statuses against the `"allowed"` literal, so once an account crossed the threshold the Fable-only test returned false. A Fable-only (`7d_oi`) rejection was then misclassified as shared/credential-scoped, and `MarkResult` benched the **entire credential — every model —** until the Fable window reset, despite the shared windows still permitting requests.

Observed on a Max account at 77% of its 7d window: one `claude-fable-5` request removed the account from rotation for ~2 days, taking its remaining Sonnet capacity with it.

### Changes

- Add `isSharedWindowAllowed`, accepting both `allowed` and `allowed_warning`.
- Use it in `isFableOnlyRejection`.
- Use it in the unified-reset fallback in `parseClaudeRateLimitResetWithFuzz` (line ~120), which carried the same literal comparison and the same failure mode.
- Add a regression test for the `allowed_warning` case, plus one asserting a genuine 5h/7d rejection still classifies as credential-scoped.

### Notes

Searching the tree for `allowed_warning` returned no matches before this change, so no other call site depended on the previous behaviour.

The new test fails on `main` and passes with the fix:

```
--- FAIL: TestFableOnlyRejectionWithAllowedWarningSharedWindow
    Fable-only rejection was classified as a shared/credential-scoped rejection
    while the 7d window was allowed_warning; the credential will be benched for all models
```

Existing tests in `internal/runtime/executor/helps/` pass unchanged.
