### PR TITLE
feat(registry): register gemini-3.5-transcribe on the interactions channel

### DIFF
--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -7,14 +7,15 @@ import (
 )
 
 const (
-	codexBuiltinImage15ModelID    = "gpt-image-1.5"
-	codexBuiltinImageModelID      = "gpt-image-2"
-	xaiBuiltinImageModelID        = "grok-imagine-image"
-	xaiBuiltinImageQualityModelID = "grok-imagine-image-quality"
-	xaiBuiltinImage20ModelID      = "grok-imagine-image-2.0"
-	xaiBuiltinVideoModelID        = "grok-imagine-video"
-	xaiBuiltinVideo15ModelID      = "grok-imagine-video-1.5"
-	xaiBuiltinVideo15PreviewID    = "grok-imagine-video-1.5-preview"
+	codexBuiltinImage15ModelID     = "gpt-image-1.5"
+	codexBuiltinImageModelID       = "gpt-image-2"
+	xaiBuiltinImageModelID         = "grok-imagine-image"
+	xaiBuiltinImageQualityModelID  = "grok-imagine-image-quality"
+	xaiBuiltinImage20ModelID       = "grok-imagine-image-2.0"
+	xaiBuiltinVideoModelID         = "grok-imagine-video"
+	xaiBuiltinVideo15ModelID       = "grok-imagine-video-1.5"
+	xaiBuiltinVideo15PreviewID     = "grok-imagine-video-1.5-preview"
+	geminiInteractionsTranscribeID = "gemini-3.5-transcribe"
 )
 
 // staticModelsJSON mirrors the top-level structure of models.json.
@@ -40,6 +41,13 @@ func GetClaudeModels() []*ModelInfo {
 // GetGeminiModels returns the standard Gemini model definitions.
 func GetGeminiModels() []*ModelInfo {
 	return cloneModelInfos(getModels().Gemini)
+}
+
+// GetGeminiInteractionsModels returns the Gemini model definitions reachable through
+// the native Interactions API. It adds models that only answer on /v1beta/interactions
+// and therefore must not be offered to plain generateContent credentials.
+func GetGeminiInteractionsModels() []*ModelInfo {
+	return WithGeminiInteractionsBuiltins(cloneModelInfos(getModels().Gemini))
 }
 
 // GetGeminiVertexModels returns Gemini model definitions for Vertex AI.
@@ -123,6 +131,38 @@ func WithCodexBuiltins(models []*ModelInfo) []*ModelInfo {
 // not depend on remote models.json updates.
 func WithXAIBuiltins(models []*ModelInfo) []*ModelInfo {
 	return upsertModelInfos(models, xaiBuiltinImageModelInfo(), xaiBuiltinImageQualityModelInfo(), xaiBuiltinImage20ModelInfo(), xaiBuiltinVideoModelInfo(), xaiBuiltinVideo15ModelInfo(), xaiBuiltinVideo15PreviewModelInfo())
+}
+
+// WithGeminiInteractionsBuiltins injects hard-coded Interactions-only Gemini model
+// definitions that should not depend on remote models.json updates. Built-ins replace
+// any matching IDs already present in the provided slice.
+func WithGeminiInteractionsBuiltins(models []*ModelInfo) []*ModelInfo {
+	return upsertModelInfos(models, geminiInteractionsTranscribeModelInfo())
+}
+
+// geminiInteractionsTranscribeModelInfo describes Gemini 3.5 Transcribe. The model lists
+// generateContent among its supported generation methods, but that surface returns a
+// candidate with no parts: transcripts are only produced through the Interactions API,
+// so the model is registered for the interactions channel alone.
+func geminiInteractionsTranscribeModelInfo() *ModelInfo {
+	return &ModelInfo{
+		ID:                         geminiInteractionsTranscribeID,
+		Object:                     "model",
+		Created:                    1785542400, // 2026-08-01
+		OwnedBy:                    "google",
+		Type:                       "gemini",
+		DisplayName:                "Gemini 3.5 Transcribe",
+		Name:                       geminiInteractionsTranscribeID,
+		Version:                    "3.5-transcribe-08-2026",
+		Description:                "Speech-to-text model with language detection, speaker diarization and word timestamps.",
+		InputTokenLimit:            98304,
+		OutputTokenLimit:           32768,
+		SupportedGenerationMethods: []string{"generateContent", "countTokens"},
+		ContextLength:              98304,
+		MaxCompletionTokens:        32768,
+		SupportedInputModalities:   []string{"text", "audio"},
+		SupportedOutputModalities:  []string{"text"},
+	}
 }
 
 func normalizeAntigravityCapabilityModelID(modelID string) string {
@@ -314,7 +354,7 @@ func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 	case "gemini":
 		return GetGeminiModels()
 	case "gemini-interactions":
-		return GetGeminiModels()
+		return GetGeminiInteractionsModels()
 	case "vertex":
 		return GetGeminiVertexModels()
 	case "aistudio":

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -111,3 +111,24 @@ func TestAntigravityWebSearchModelForRequiresRequestedModelCapability(t *testing
 		t.Fatalf("unknown model should not get Antigravity web search model, got %q", got)
 	}
 }
+
+func TestWithGeminiInteractionsBuiltinsIncludesTranscribe(t *testing.T) {
+	models := WithGeminiInteractionsBuiltins(nil)
+	for _, model := range models {
+		if model != nil && model.ID == geminiInteractionsTranscribeID {
+			if len(model.SupportedInputModalities) == 0 {
+				t.Fatal("transcribe builtin must declare audio input")
+			}
+			return
+		}
+	}
+	t.Fatalf("expected Gemini interactions builtin model %s", geminiInteractionsTranscribeID)
+}
+
+func TestGetGeminiModelsExcludesInteractionsOnlyBuiltins(t *testing.T) {
+	for _, model := range GetGeminiModels() {
+		if model != nil && model.ID == geminiInteractionsTranscribeID {
+			t.Fatalf("%s answers only on the Interactions API and must stay out of the plain Gemini channel", geminiInteractionsTranscribeID)
+		}
+	}
+}

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -74,7 +74,7 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 		}
 		models = applyExcludedModels(models, excluded)
 	case constant.GeminiInteractions:
-		models = registry.GetGeminiModels()
+		models = registry.GetGeminiInteractionsModels()
 		if entry := s.resolveConfigInteractionsKey(a); entry != nil {
 			if len(entry.Models) > 0 {
 				models = buildGeminiConfigModels(entry)


### PR DESCRIPTION
## Problem

Gemini 3.5 Transcribe shipped on the Gemini API this week and answers on the native Interactions API. Requesting it today fails at routing:

```
POST /v1beta/interactions  {"model":"gemini-3.5-transcribe", ...}
→ {"error":{"message":"unknown provider for model gemini-3.5-transcribe", ...}}
```

The remote `models.json` does not carry the model yet, so `util.GetProviderName` finds no provider for it.

A user can already work around this by declaring the model under `interactions-api-key[].models`, which replaces the registry list for that credential. That works, but it means every user has to hand-write metadata for a first-party Google model.

## Change

Adds the model as a built-in, the same way `gpt-image-2` and the `grok-imagine-*` models are handled, so it does not depend on remote refreshes.

It is registered for the **interactions channel only**. The model's own metadata advertises `generateContent`:

```json
"supportedGenerationMethods": ["generateContent", "countTokens"]
```

but that surface returns `200` with a candidate carrying no parts. Registering it for plain `gemini-api-key` credentials would therefore list a model that never returns a transcript, so `GetGeminiModels` is left untouched and `GetGeminiInteractionsModels` is introduced for the interactions path.

## Verification

Built the branch and ran it against the live API with an `interactions-api-key` credential:

| surface | model | result |
|---|---|---|
| `/v1beta/interactions` | `gemini-3.5-transcribe` | 200, transcript returned (`audio/wav` and `audio/ogg`) |
| `generateContent` | `gemini-3.5-transcribe` | 200, candidate with no parts |
| OpenAI-compatible `chat/completions` | `gemini-3.5-transcribe` | 200, empty message, `completion_tokens: 0` |

`gofmt -w`, `go build ./cmd/server` and `go test ./...` all clean. Two tests added: one asserting the built-in is present with audio input declared, one asserting it stays out of the plain Gemini channel.