### PR TITLE
feat(tor): add Tor SOCKS5 proxy support with automatic IP rotation

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -49,34 +49,6 @@ pprof:
   enable: false
   addr: "127.0.0.1:8316"
 
-# Credential concurrency is configured by Home in Home mode. The synthesized Home config is
-# authoritative and local values, including the values below, are ignored. Do not use local
-# configuration to override a Home concurrency policy.
-# credential-concurrency:
-#   lifecycle-config-revision: 1
-#   observation-barrier-revision: 0
-#   cpa-heartbeat-timeout: "3s"
-#   cpa-cancel-bound: "5s"
-#   reclaim-grace: "5s"
-#   cleanup-interval: "5s"
-#   release-flush-interval: 250ms
-#   release-max-backoff: 2s
-#   busy-retry-min: 250ms
-#   busy-retry-max: 1s
-#   max-limit: 1000000
-
-# Credential in-flight observation snapshot contract.
-# credential-in-flight:
-#   snapshot-interval: 2s
-#   stale-after: 10s
-#   max-part-bytes: 262144
-#   max-part-count: 64
-#   max-revision-bytes: 16777216
-#   max-aggregate-groups: 100000
-#   max-details: 10000
-#   max-string-bytes: 256
-#   staging-retention: 1m
-
 # Standard dynamic library plugins are trusted in-process code. They are disabled by default.
 # Build Go examples with go build -buildmode=c-shared for the target GOOS/GOARCH.
 # Other languages can implement the same C ABI and JSON method protocol.
@@ -134,6 +106,34 @@ redis-usage-queue-retention-seconds: 60
 # Per-entry proxy-url also supports "direct" or "none" to bypass both the global proxy-url and environment proxies explicitly.
 proxy-url: ""
 
+# Proxy mode. Set to "proxy" (default) for regular HTTP/SOCKS proxy via proxy-url,
+# or "tor" to route all traffic through Tor SOCKS5 proxy with automatic IP rotation on error codes.
+# When set to "tor", the proxy-url field is ignored (use tor-proxy-addr instead).
+# proxy-mode: "proxy"
+
+# Tor SOCKS5 proxy address (used when proxy-mode is "tor").
+# Default: "127.0.0.1:9050"
+# tor-proxy-addr: "127.0.0.1:9050"
+
+# Tor control port address for sending NEWNYM signals to rotate the exit node IP.
+# Used when proxy-mode is "tor" and a retryable error code is received.
+# Default: "127.0.0.1:9051"
+# tor-control-addr: "127.0.0.1:9051"
+
+# Tor control port password (optional). Leave empty if no password is configured in torrc.
+# tor-control-password: ""
+
+# Maximum number of Tor IP rotation retries. When an error code from tor-retry-on-codes
+# is received, the system rotates the Tor IP and retries. Set to 0 for unlimited retries.
+# Default: 3
+# tor-retry-attempts: 3
+
+# HTTP status codes that trigger Tor IP rotation and retry.
+# When proxy-mode is "tor" and one of these codes is received from an upstream AI provider,
+# the system sends a NEWNYM signal to the Tor control port, waits for a new IP, and retries.
+# Default: [429, 403, 500, 502, 503]
+# tor-retry-on-codes: [429, 403, 500, 502, 503]
+
 # When true, unprefixed model requests only use credentials without a prefix (except when prefix == model name).
 force-model-prefix: false
 
@@ -141,31 +141,17 @@ force-model-prefix: false
 # Default is false (disabled).
 passthrough-headers: false
 
-# Number of additional credential retry rounds after the first round exhausts
-# its eligible credentials. Round 0 is the initial round; round r only admits
-# credentials whose effective request-retry is at least r. Explicit non-negative
-# credential/provider overrides take precedence; omitted or negative overrides
-# inherit this global value, and explicit 0 only admits round 0. New CPA nodes
-# send retry_round=0 for the initial round and increment it for additional rounds;
-# legacy dispatch methods omit the field and keep old semantics.
-# Additional rounds apply to HTTP 403, 408, 429, 500, 502, 503, and 504 failures.
-# Individual credential/provider overrides take precedence; 0 disables additional
-# rounds, while an omitted or negative override inherits this global setting.
+# Number of times to retry a request. Retries will occur if the HTTP response code is 403, 408, 500, 502, 503, or 504.
 request-retry: 3
 
-# Maximum number of different credentials to try in each credential retry round
-# after per-credential round filtering. Set to 0 to try all available
-# credentials. Credentials skipped by this cap still age with the global round,
-# so the cap does not guarantee a fixed number of actual retries per credential.
+# Maximum number of different credentials to try for one failed request.
+# Set to 0 to keep legacy behavior (try all available credentials).
 max-retry-credentials: 0
 
-# Maximum cooldown wait in seconds between retry rounds.
-# Set to 0 or below to never wait for credential cooldown.
-# Retry rounds that need no wait remain controlled by request-retry.
+# Maximum wait time in seconds for a cooled-down credential before triggering a retry.
 max-retry-interval: 30
 
 # When true, disable auth/model cooldown scheduling globally (prevents blackout windows after failure states).
-# A credential/provider disable-cooling value, when present, overrides this global value.
 disable-cooling: false
 
 # When true, persist per-auth cooldown status as .cds files next to auth files.
@@ -182,11 +168,6 @@ transient-error-cooldown-seconds: 0
 # or a Claude OAuth/token file via a "cloak_mode" value. Default false keeps the per-client
 # "auto" behavior (cloak only non-Claude-Code clients).
 disable-claude-cloak-mode: false
-
-# Claude Code compatibility settings.
-claude-code:
-  # When true, return original model IDs in Anthropic model list responses instead of cloaked IDs.
-  disable-cloaking-model-list: false
 
 # disable-image-generation supports: false (default), true, "chat", or "passthrough".
 # - true: disable image_generation everywhere (also returns 404 for /v1/images/generations and /v1/images/edits).
@@ -214,18 +195,12 @@ quota-exceeded:
 
 # Routing strategy for selecting credentials when multiple match.
 routing:
-  strategy: "round-robin" # round-robin (default), weighted-round-robin, fill-first
-  # weighted-round-robin uses each credential's integer weight (default 1, maximum 1,000,000).
-  # Non-positive weights exclude the credential while this strategy is active.
-  # For OAuth/file credentials, add a top-level numeric "weight" field to the auth JSON.
+  strategy: "round-robin" # round-robin (default), fill-first
   # Enable universal session-sticky routing for all clients.
-  # Explicit Claude Code, Codex, OpenCode, and pi session headers are preferred,
-  # followed by prompt_cache_key, Responses conversation IDs, legacy body IDs,
-  # execution or derived session identity, and the existing first-message hash fallback.
+  # Session IDs are extracted from: metadata.user_id (Claude Code session format),
+  # X-Session-ID, Session_id (Codex), X-Client-Request-Id (PI), conversation_id,
+  # or first few messages hash.
   # Automatic failover is always enabled when bound auth becomes unavailable.
-  # An established binding outranks credential priority: once a session is bound, that
-  # credential is kept even if a higher-priority credential recovers. Credential priority
-  # still decides cold bindings, requests without a session, and post-failover rebinding.
   session-affinity: false # default: false
   # How long session-to-auth bindings are retained. Default: 1h
   session-affinity-ttl: "1h"
@@ -237,62 +212,6 @@ codex:
   # Some superstitious users believe request tracking identifiers can be used
   # as evidence for TOS enforcement bans; this option only satisfies those odd concerns.
   identity-confuse: false
-  # Disable forcing the official Codex User-Agent and Originator headers on HTTP/SSE and WebSocket requests.
-  disable-codex-cloaking: false
-  # Hold back the initial handshake events (response.created, response.in_progress and the
-  # websocket metadata frames) until the upstream emits its first generated event.
-  # Why: the upstream smuggles `server_is_overloaded` rejections *inside* an HTTP 200 stream,
-  # right after those handshake events, instead of returning 503 on the wire. Buffering them
-  # keeps the downstream response headers uncommitted long enough to transparently retry on
-  # another credential. Only overload/rate-limit rejections trigger failover; every other
-  # terminal failure is still delivered in-stream exactly as before.
-  # Trade-off: response headers are delayed until generation starts, which can trip client or
-  # reverse-proxy read timeouts (e.g. nginx proxy_read_timeout) on long reasoning requests.
-  # Default: false
-  stream-bootstrap-buffering: false
-  # When true, optimize Codex Desktop, codex-tui, and codex_cli_rs requests for multi-agent v2.
-  # This refreshes Codex spawn_agent model details, removes message parameter encryption,
-  # normalizes encrypted agent_message content for Codex, and converts agent_message input
-  # into standard user messages for non-Codex upstream protocols.
-  optimize-multi-agent-v2: false
-  # Terminate and relay Codex Live WebRTC audio and DataChannel traffic in this process.
-  # This requires inbound UDP reachability. Keep disabled to preserve direct media behavior.
-  live-media-relay:
-    enabled: false
-    # Maximum concurrent media sessions. Zero uses the default of 32.
-    max-sessions: 32
-    # Reject downstream SDP candidates that target private, loopback, link-local, or unspecified IPs.
-    # Keep false for local or trusted-network Codex Desktop connections.
-    disable-private-remote-ips: false
-    # Public IPv4 or IPv6 address advertised when CPA is behind 1:1 NAT.
-    public-ip: ""
-    # Optional UDP allocation range. Both values must be set together and provide at least two ports per session.
-    udp-port-min: 0
-    udp-port-max: 0
-    # Optional STUN/TURN servers. TURN credentials are never returned by the JSON config API.
-    # Without a concrete global/per-auth proxy-url, WebRTC uses normal direct ICE/STUN/TURN connectivity.
-    # With http, https, socks5, or socks5h proxy-url, the OpenAI-facing leg is forced through
-    # authenticated ICE-TCP over that proxy and never falls back to UDP or a direct connection.
-    # The Codex Desktop-facing leg remains direct, and configured ICE servers still apply to it.
-    # ice-servers:
-    #   - urls:
-    #       - "stun:stun.example.com:3478"
-    #   - urls:
-    #       - "turn:turn.example.com:3478?transport=udp"
-    #     username: "user"
-    #     credential: "secret"
-
-# Antigravity provider behavior.
-# antigravity:
-#   sensitive-words:             # optional: words to obfuscate with zero-width characters in system instructions
-#     - "API"
-#     - "proxy"
-
-# xAI provider behavior.
-xai:
-  # When true, inject the native x_search tool when the request does not declare it.
-  # The injected tool is also added to tool_choice.allowed_tools when applicable.
-  inject-x-search: false
 
 # When true, enable authentication for the WebSocket API (/v1/ws).
 ws-auth: true
@@ -317,36 +236,17 @@ nonstream-keepalive-interval: 0
 # Gemini API keys
 # gemini-api-key:
 #   - api-key: "AIzaSy...01"
-#     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test" # optional: require calls like "test/gemini-3-pro-preview" to target this credential
-#     disable-cooling: false # optional override: true disables cooling, false enables it; omit to inherit global
-#     request-retry: 3 # optional per-auth override; 0 disables additional rounds; omit or set < 0 to inherit global
-#     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns
-#       - status: 400        # HTTP status code to match
-#         match:             # optional: string contains matching
-#           - "maximum_context_length"
-#           - "context_length_exceeded"
-#         match-regexr:      # optional: regular expression matching
-#           - "maximum_context_length$"
-#           - "^context_length_exceeded"
-#         action: "stop"     # "stop" (return error, no cooling), "stop-and-cooldown" (return error and cool down),
-#                            # "continue" (try next credential, no cooling), "continue-and-cooldown" (try next credential and cool down)
+#     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://generativelanguage.googleapis.com"
 #     headers:
 #       X-Custom-Header: "custom-value"
-#       # Values starting with "$" dynamically copy the header value from downstream client requests.
-#       # If the client did not send the specified header, the header is omitted.
-#       # X-Claude-Code-Session-Id: "$ABC" # copies client's "ABC" header
 #     proxy-url: "socks5://proxy.example.com:1080"
 #     # proxy-url: "direct" # optional: explicit direct connect for this credential
 #     models:
 #       - name: "gemini-2.5-flash" # upstream model name
 #         alias: "gemini-flash"    # client alias mapped to the upstream model
 #         display-name: "Gemini Flash" # optional catalog display name
-#         max-context-length: 1048576 # optional: override Codex client context window metadata
-#         is-compat: false             # optional: preserve thinking blocks with empty signatures for compatible upstreams
-#         thinking:                    # optional: exact thinking capability for this configured model
-#           levels: ["high", "medium", "low", "none", "auto"]
 #     excluded-models:
 #       - "gemini-2.5-pro"     # exclude specific models from this provider (exact match)
 #       - "gemini-2.5-*"       # wildcard matching prefix (e.g. gemini-2.5-flash, gemini-2.5-pro)
@@ -359,68 +259,34 @@ nonstream-keepalive-interval: 0
 # send Gemini generateContent/streamGenerateContent requests when the client enters through the interactions API.
 # interactions-api-key:
 #   - api-key: "AIzaSy...03"
-#     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "native" # optional: require calls like "native/gemini-3-pro-preview" to target this credential
-#     disable-cooling: false # optional override: true disables cooling, false enables it; omit to inherit global
-#     request-retry: 3 # optional per-auth override; 0 disables additional rounds; omit or set < 0 to inherit global
-#     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns
-#       - status: 400
-#         match:
-#           - "invalid_argument"
-#         action: "continue"
+#     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://generativelanguage.googleapis.com"
 #     headers:
 #       X-Custom-Header: "custom-value"
-#       # Values starting with "$" dynamically copy the header value from downstream client requests.
-#       # If the client did not send the specified header, the header is omitted.
-#       # X-Claude-Code-Session-Id: "$ABC" # copies client's "ABC" header
 #     proxy-url: "socks5://proxy.example.com:1080"
 #     # proxy-url: "direct" # optional: explicit direct connect for this credential
 #     models:
 #       - name: "gemini-2.5-flash" # upstream model name
 #         alias: "native-gemini-flash" # client alias mapped to the upstream model
-#         max-context-length: 1048576 # optional: override Codex client context window metadata
-#         is-compat: false             # optional: preserve thinking blocks with empty signatures for compatible upstreams
-#         thinking:                    # optional: exact thinking capability for this configured model
-#           levels: ["high", "medium", "low", "none", "auto"]
 #     excluded-models:
 #       - "gemini-2.5-pro"
 
 # Codex API keys
 # codex-api-key:
 #   - api-key: "sk-atSM..."
-#     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test" # optional: require calls like "test/gpt-5-codex" to target this credential
-#     disable-cooling: false # optional override: true disables cooling, false enables it; omit to inherit global
-#     request-retry: 3 # optional per-auth override; 0 disables additional rounds; omit or set < 0 to inherit global
-#     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns
-#       - status: 400
-#         match:
-#           - "context_window_exceeded"
-#         action: "stop-and-cooldown"
+#     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://www.example.com" # use the custom codex API endpoint
-#     alpha-search: false # optional: allow this key to serve /v1/alpha/search via base-url + /alpha/search
 #     headers:
 #       X-Custom-Header: "custom-value"
-#       # Values starting with "$" dynamically copy the header value from downstream client requests.
-#       # If the client did not send the specified header, the header is omitted.
-#       # X-Claude-Code-Session-Id: "$ABC" # copies client's "ABC" header
 #     proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override
 #     # proxy-url: "direct" # optional: explicit direct connect for this credential
 #     models:
 #       - name: "gpt-5-codex"   # upstream model name
 #         alias: "codex-latest" # client alias mapped to the upstream model
 #         display-name: "Codex Latest" # optional catalog display name
-#         max-context-length: 1048576 # optional: override Codex client context window metadata
 #         force-mapping: true    # optional: rewrite response model fields back to the alias
-#         # When true and codex.optimize-multi-agent-v2 is also true, convert Codex
-#         # MultiAgentV2 agent_message items into portable Responses message/user input
-#         # for third-party Responses-compatible endpoints that reject agent_message.
-#         # Default false keeps agent_message unchanged for native OpenAI/Codex endpoints.
-#         # It also preserves thinking blocks with empty signatures for compatible upstreams.
-#         is-compat: false
-#         thinking:              # optional: exact thinking capability for this configured model
-#           levels: ["xhigh", "high", "medium", "low"]
 #     excluded-models:
 #       - "gpt-5.1"         # exclude specific models (exact match)
 #       - "gpt-5-*"         # wildcard matching prefix (e.g. gpt-5-medium, gpt-5-codex)
@@ -431,33 +297,19 @@ nonstream-keepalive-interval: 0
 # Uses the native xAI executor, including its Responses namespace-tool handling.
 # xai-api-key:
 #   - api-key: "xai-..."
-#     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "xai" # optional: require calls like "xai/grok-4.5" to target this credential
-#     disable-cooling: false # optional override: true disables cooling, false enables it; omit to inherit global
-#     request-retry: 3 # optional per-auth override; 0 disables additional rounds; omit or set < 0 to inherit global
-#     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns
-#       - status: 400
-#         match:
-#           - "rate_limit_exceeded"
-#         action: "continue-and-cooldown"
+#     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://api.x.ai/v1" # xAI-compatible Responses API endpoint
 #     websockets: true # optional: use the xAI upstream websocket transport for downstream websocket requests
 #     headers:
 #       X-Custom-Header: "custom-value"
-#       # Values starting with "$" dynamically copy the header value from downstream client requests.
-#       # If the client did not send the specified header, the header is omitted.
-#       # X-Claude-Code-Session-Id: "$ABC" # copies client's "ABC" header
 #     proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override
 #     # proxy-url: "direct" # optional: explicit direct connect for this credential
 #     models:
 #       - name: "grok-4.5"       # upstream model name
 #         alias: "grok-latest"   # client alias mapped to the upstream model
 #         display-name: "Grok Latest" # optional catalog display name
-#         max-context-length: 1048576 # optional: override Codex client context window metadata
 #         force-mapping: true     # optional: rewrite response model fields back to the alias
-#         is-compat: false        # optional: preserve thinking blocks with empty signatures for compatible upstreams
-#         thinking:               # optional: exact thinking capability for this configured model
-#           levels: ["xhigh", "high", "medium", "low"]
 #     excluded-models:
 #       - "grok-4.1"             # exclude specific models (exact match)
 #       - "grok-3-*"             # wildcard matching prefix
@@ -466,137 +318,54 @@ nonstream-keepalive-interval: 0
 # claude-api-key:
 #   - api-key: "sk-atSM..." # use the official claude API key, no need to set the base url
 #   - api-key: "sk-atSM..."
-#     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test" # optional: require calls like "test/claude-sonnet-latest" to target this credential
-#     disable-cooling: false # optional override: true disables cooling, false enables it; omit to inherit global
-#     request-retry: 3 # optional per-auth override; 0 disables additional rounds; omit or set < 0 to inherit global
-#     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns
-#       - status: 400
-#         match:
-#           - "prompt is too long"
-#         action: "stop"
+#     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://www.example.com" # use the custom claude API endpoint
 #     headers:
 #       X-Custom-Header: "custom-value"
-#       # Values starting with "$" dynamically copy the header value from downstream client requests.
-#       # If the client did not send the specified header, the header is omitted.
-#       # X-Claude-Code-Session-Id: "$ABC" # copies client's "ABC" header
 #     proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override
 #     # proxy-url: "direct" # optional: explicit direct connect for this credential
 #     models:
 #       - name: "claude-3-5-sonnet-20241022" # upstream model name
 #         alias: "claude-sonnet-latest"      # client alias mapped to the upstream model
 #         display-name: "Claude Sonnet"      # optional catalog display name
-#         max-context-length: 1048576         # optional: override Codex client context window metadata
 #         force-mapping: true                 # optional: rewrite response model fields back to the alias
-#         is-compat: false                    # optional: preserve thinking blocks with empty signatures for compatible upstreams
-#         thinking:                           # optional: exact thinking capability for this configured model
-#           levels: ["max", "xhigh", "high", "medium", "low", "minimal", "none", "auto"]
 #     excluded-models:
 #       - "claude-opus-4-5-20251101" # exclude specific models (exact match)
 #       - "claude-3-*"               # wildcard matching prefix (e.g. claude-3-7-sonnet-20250219)
 #       - "*-thinking"               # wildcard matching suffix (e.g. claude-opus-4-5-thinking)
 #       - "*haiku*"                  # wildcard matching substring (e.g. claude-3-5-haiku-20241022)
 #     rebuild-mid-system-message: false # optional: default is false; when true, move messages with role "system" into the top-level Claude system field
-#     cloak:                         # optional: explicitly enable request cloaking for non-Claude-Code clients
-#       mode: "auto"                 # "auto" (default inside this block): cloak only when client is not Claude Code
-#                                    # "always": cloak every unconfirmed client; confirmed native Claude Code still passes through
+#     cloak:                         # optional: request cloaking for non-Claude-Code clients
+#       mode: "auto"                 # "auto" (default): cloak only when client is not Claude Code
+#                                    # "always": always apply cloaking
 #                                    # "never": never apply cloaking
 #       # This "cloak" block applies to this claude-api-key entry only. For Claude OAuth
 #       # credentials, set the same options in the auth/token JSON file via "cloak_mode" /
 #       # "cloak_strict_mode" / "cloak_sensitive_words" / "cloak_cache_user_id". The top-level
 #       # "disable-claude-cloak-mode: true" disables cloaking for all Claude credentials at once.
-#       strict-mode: false           # false (default): legacy-model whitelist uses a user system-reminder;
-#                                    # all other and future models use messages[].role=system
-#                                    # true: strip caller prompts and keep only Claude Code billing and identity blocks
+#       strict-mode: false           # false (default): prepend Claude Code prompt to user system messages
+#                                    # true: strip all user system messages, keep only Claude Code prompt
 #       sensitive-words:             # optional: words to obfuscate with zero-width characters
 #         - "API"
 #         - "proxy"
 #       cache-user-id: true          # optional: default is false; set true to reuse cached user_id per API key instead of generating a random one each request
-#       # Every custom tool on a cloaked OAuth request automatically uses a caller-stable opaque mcp__<server>__<tool> alias.
-#
-#     # fingerprint-profile (optional, top-level on this claude-api-key entry; not a cloak sub-field):
-#     # OAuth and API-key fingerprints are different contracts.
-#     #   - Real Claude OAuth stays on the strict Claude Code CLI wire fingerprint.
-#     #   - API keys (official Anthropic, custom gateways, Kimi) stay loose and
-#     #     caller-owned unless this field is set.
-#     #
-#     # Default (omit / empty): keep the caller request fingerprint and headers.
-#     # Official api.anthropic.com API keys do not add extra CLI betas/identity unless
-#     # this field is set. Custom gateways and delegated providers are the same.
-#     #
-#     # Controls request fingerprint only on /v1/messages (and related Claude executor paths).
-#     # Auth scheme stays API key (x-api-key on api.anthropic.com; Bearer on custom base-url).
-#     # Does NOT enable OAuth refresh, profile fetch, or OAuth-cancellation semantics.
-#     #
-#     # Values:
-#     #   omit / empty        = caller-owned API-key fingerprint (respects caller)
-#     #   "claude-code-cli"   = same Messages fingerprint as Claude Code OAuth CLI,
-#     #                         including official Anthropic API keys: OAuth Anthropic-Beta
-#     #                         set, CCH signing on api.anthropic.com, stable CLI
-#     #                         metadata.user_id / session_id / device identity.
-#     #                         API keys seed identity from the key;
-#     #                         delegated OAuth providers use stable auth ID instead of
-#     #                         rotating access tokens. "oauth-cli" is a legacy alias.
-#     #
-#     # count_tokens keeps the native model/messages/tools shape for every origin, including
-#     # Kimi opt-in. It does not send billing/CCH, currentDate, metadata, or diagnostics.
-#     #
-#     # CCH: the billing block may carry a per-request cch hash. CPA emits it exactly where
-#     # Claude Code does, which is api.anthropic.com (first-party) and Vertex only. An opt-in
-#     # on any other gateway (including Kimi) still sends the billing block, but without cch,
-#     # so a per-request hash cannot bust that gateway's prompt cache. api.anthropic.com
-#     # strips the block itself (0 tokens, no cache impact). Kimi drops the whole block by
-#     # default and keeps it, unsigned, after an explicit fingerprint opt-in.
-#     # A real Claude OAuth credential always signs, on every upstream: a downstream Claude
-#     # Code pointed at CPA cannot produce that value itself.
-#     #
-#     # Example (official Anthropic or a custom Messages gateway):
-#     #   - api-key: "your-key"
-#     #     # base-url: "https://gateway.example"   # omit for api.anthropic.com
-#     #     fingerprint-profile: "claude-code-cli"
-#     #     cloak:
-#     #       mode: "always"   # recommended when upstream rejects non-CLI clients
-#     #
-#     # Delegated Anthropic Messages OAuth files (Kimi, etc.) use "fingerprint_profile"
-#     # in the auth JSON. Refresh keeps it. Example:
-#     #   {
-#     #     "type": "kimi",
-#     #     "access_token": "...",
-#     #     "refresh_token": "...",
-#     #     "fingerprint_profile": "claude-code-cli"
-#     #   }
-#     #   Legacy "fingerprint-profile" credentials remain supported and are normalized at load time.
-#     # fingerprint-profile: "claude-code-cli" # optional claude-api-key provider field; default is empty (caller-owned); uncomment to opt in
-#     experimental-cch-signing: false # deprecated compatibility field; CCH is generated automatically
-#                                     # for real Claude OAuth on any upstream, and for claude-code-cli profiles
-#                                     # only on api.anthropic.com; Vertex keeps provider-native signing
+#     experimental-cch-signing: false # optional: default is false; when true, sign the final /v1/messages body using the current Claude Code cch algorithm
+#                                     # keep this disabled unless you explicitly need the behavior, so upstream seed changes fall back to legacy proxy behavior
 
-# Anthropic-Beta is assembled per request rather than sent as a fixed list, matching
-# Claude Code 2.1.220: context-1m sits right after claude-code, mid-conversation-system
-# is added only for models that accept a role=system turn, advanced-tool-use only when
-# the request declares tools, and server-side-fallback / fallback-credit /
-# structured-outputs trail effort. On direct api.anthropic.com a caller may only ask for
-# betas real Claude Code also sends, and they are placed at their observed positions;
-# anything else is dropped so the outgoing set stays one a real client could produce.
-# Other Anthropic-compatible upstreams still forward caller betas verbatim.
-#
-# Default headers for Claude API requests. Update only after measuring a new Claude Code release.
-# Unconfirmed clients use this CLI baseline. Verified native Claude Code CLI, sdk-cli,
-# and VSCode requests preserve their measured entrypoint and software shape only when the
-# Claude Code version, package version, and runtime version exactly match this configured
-# baseline; unmeasured versions fall back to it. In legacy mode, timeout is a fallback and
-# verified native OS/arch values remain client-supplied. When stabilize-device-profile is
-# enabled, OS/arch are pinned to the values below and cached profiles remain constrained to
-# the same exact software baseline rather than learning newer client versions.
+# Default headers for Claude API requests. Update when Claude Code releases new versions.
+# In legacy mode, user-agent/package-version/runtime-version/timeout are used as fallbacks
+# when the client omits them, while OS/arch remain runtime-derived. When
+# stabilize-device-profile is enabled, OS/arch stay pinned to the baseline values below,
+# while user-agent/package-version/runtime-version seed a software fingerprint that can
+# still upgrade to newer official Claude client versions.
 # claude-header-defaults:
-#   user-agent: "claude-cli/2.1.220 (external, cli)"
-#   package-version: "0.94.0"
-#   runtime-version: "v26.3.0"
+#   user-agent: "claude-cli/2.1.44 (external, sdk-cli)"
+#   package-version: "0.74.0"
+#   runtime-version: "v24.3.0"
 #   os: "MacOS"
 #   arch: "arm64"
 #   timeout: "600"
-#   timezone: "Asia/Singapore"  # fallback IANA timezone for cloaked currentDate; a credential JSON "timezone" takes priority
 #   stabilize-device-profile: false  # optional, default false; set true to enable per-auth/API-key fingerprint pinning
 
 # Default headers for Codex OAuth model requests.
@@ -613,26 +382,11 @@ nonstream-keepalive-interval: 0
 #     disabled: false # optional: set to true to disable this provider without removing it
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
-#     support-prompt-cache-key: false # optional: derive prompt_cache_key for requests from all input protocols
-#     disable-cooling: false # optional provider override: true disables cooling, false enables it; omit to inherit global
-#     request-retry: 3 # optional per-provider override; 0 disables additional rounds; omit or set < 0 to inherit global
-#     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns
-#       - status: 400
-#         match:
-#           - "maximum_context_length"
-#           - "context_length_exceeded"
-#         match-regexr:
-#           - "maximum_context_length$"
-#           - "^context_length_exceeded"
-#         action: "stop" # "stop", "stop-and-cooldown", "continue", "continue-and-cooldown"
+#     disable-cooling: false # optional: per-provider override for auth/model cooldown scheduling
 #     headers:
 #       X-Custom-Header: "custom-value"
-#       # Values starting with "$" dynamically copy the header value from downstream client requests.
-#       # If the client did not send the specified header, the header is omitted.
-#       # X-Claude-Code-Session-Id: "$ABC" # copies client's "ABC" header
 #     api-key-entries:
 #       - api-key: "sk-or-v1-...b780"
-#         weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #         proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override
 #         # proxy-url: "direct" # optional: explicit direct connect for this credential
 #       - api-key: "sk-or-v1-...b781" # without proxy-url
@@ -640,11 +394,9 @@ nonstream-keepalive-interval: 0
 #       - name: "moonshotai/kimi-k2:free" # The actual model name.
 #         alias: "kimi-k2"               # The alias used in the API.
 #         display-name: "Kimi K2"         # optional catalog display name
-#         max-context-length: 1048576    # optional: override Codex client context window metadata
 #         image: false                   # optional: set true to allow this model on /v1/images/generations and /v1/images/edits (not chat/responses image input)
-#         input-modalities: [text, image] # optional: declare /v1/chat/completions and /v1/responses multimodal input for Codex clients. Use [text] for upstreams that reject multimodal tool result content.
+#         input-modalities: [text, image] # optional: declare /v1/chat/completions and /v1/responses multimodal input for Codex clients
 #         output-modalities: [text]       # optional: declare output modalities when known
-#         is-compat: false                # optional: preserve Claude thinking blocks for compatible upstreams
 #         thinking:                      # optional: omit to default to levels ["low","medium","high"]
 #           levels: ["low", "medium", "high"]
 #       # You may repeat the same alias to build an internal model pool.
@@ -662,24 +414,16 @@ nonstream-keepalive-interval: 0
 # Vertex API keys (Vertex-compatible endpoints, base-url is optional)
 # vertex-api-key:
 #   - api-key: "vk-123..."                        # x-goog-api-key header
-#     weight: 5                                    # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test"                              # optional: require calls like "test/vertex-pro" to target this credential
-#     disable-cooling: false                       # optional override: true disables cooling, false enables it; omit to inherit global
-#     request-retry: 3                             # optional per-auth override; 0 disables additional rounds; omit or set < 0 to inherit global
 #     base-url: "https://example.com/api"         # optional, e.g. https://zenmux.ai/api; falls back to Google Vertex when omitted
 #     proxy-url: "socks5://proxy.example.com:1080" # optional per-key proxy override
 #     # proxy-url: "direct" # optional: explicit direct connect for this credential
 #     headers:
 #       X-Custom-Header: "custom-value"
-#       # Values starting with "$" dynamically copy the header value from downstream client requests.
-#       # If the client did not send the specified header, the header is omitted.
-#       # X-Claude-Code-Session-Id: "$ABC" # copies client's "ABC" header
 #     models:                                     # optional: map aliases to upstream model names
 #       - name: "gemini-2.5-flash"                # upstream model name
 #         alias: "vertex-flash"                   # client-visible alias
 #         display-name: "Vertex Flash"            # optional catalog display name
-#         thinking:                                # optional: exact thinking capability for this configured model
-#           levels: ["high", "medium", "low", "none", "auto"]
 #       - name: "gemini-2.5-pro"
 #         alias: "vertex-pro"
 #     excluded-models:                            # optional: models to exclude from listing
@@ -698,14 +442,13 @@ nonstream-keepalive-interval: 0
 #   fork: true                  # keep the upstream model and also expose the alias as a separate client-visible model
 #   display-name: "Model Name" # override the human-readable name shown in model catalogs
 #   force-mapping: true         # rewrite upstream response model fields back to the client-visible alias (example below uses antigravity only)
-# Per-auth OAuth aliases can also be stored in an OAuth auth JSON file as "model_aliases".
-# Legacy "model-aliases" credentials remain supported and are normalized at load time.
+# Per-auth OAuth aliases can also be stored in an OAuth auth JSON file as "model-aliases".
 # They apply only to that selected auth and take precedence over global aliases for the same client-visible alias.
 # Example auth JSON:
 # {
 #   "type": "codex",
 #   "email": "user@example.com",
-#   "model_aliases": [
+#   "model-aliases": [
 #     {"name": "gpt-5.3-codex-spark", "alias": "gpt-5.5"},
 #     {"name": "gpt-5.3-codex-spark", "alias": "gpt-5.4"}
 #   ]
@@ -755,48 +498,6 @@ nonstream-keepalive-interval: 0
 #     - "kimi-k2-thinking"
 #   xai:
 #     - "grok-3-mini"
-
-# OAuth provider request-scoped error rules (custom error classification for OAuth credentials)
-# oauth-request-scoped-errors:
-#   vertex:
-#     - status: 400
-#       match:
-#         - "maximum_context_length"
-#         - "context_length_exceeded"
-#       match-regexr:
-#         - "maximum_context_length$"
-#         - "^context_length_exceeded"
-#       action: "stop" # options: "stop", "stop-and-cooldown", "continue", "continue-and-cooldown"
-#   aistudio:
-#     - status: 400
-#       match:
-#         - "invalid_argument"
-#       action: "stop"
-#   antigravity:
-#     - status: 500
-#       match:
-#         - "internal_server_error"
-#       action: "stop-and-cooldown"
-#   claude:
-#     - status: 400
-#       match:
-#         - "prompt is too long"
-#       action: "stop"
-#   codex:
-#     - status: 400
-#       match:
-#         - "context_window_exceeded"
-#       action: "stop"
-#   kimi:
-#     - status: 400
-#       match:
-#         - "length_limit"
-#       action: "stop"
-#   xai:
-#     - status: 400
-#       match:
-#         - "max_tokens_exceeded"
-#       action: "stop"
 
 # Optional payload configuration
 # payload:

--- a/internal/api/handlers/management/test_proxy.go
+++ b/internal/api/handlers/management/test_proxy.go
@@ -1,0 +1,405 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/net/proxy"
+)
+
+// TestProxyResponse is the JSON response for the test-proxy endpoint.
+type TestProxyResponse struct {
+	Success bool   `json:"success"`
+	IP      string `json:"ip,omitempty"`
+	Country string `json:"country,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+// TorRotateResponse is the JSON response for the tor-rotate endpoint.
+type TorRotateResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message,omitempty"`
+	OldIP   string `json:"old_ip,omitempty"`
+	NewIP   string `json:"new_ip,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+// TestProxy tests the proxy or Tor connection by fetching the external IP.
+func (h *Handler) TestProxy(c *gin.Context) {
+	cfg := h.cfg
+	if cfg == nil {
+		c.JSON(http.StatusInternalServerError, TestProxyResponse{
+			Success: false,
+			Error:   "config not available",
+		})
+		return
+	}
+
+	sdk := cfg
+	if sdk == nil {
+		c.JSON(http.StatusInternalServerError, TestProxyResponse{
+			Success: false,
+			Error:   "config not available",
+		})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 15*time.Second)
+	defer cancel()
+
+	var httpClient *http.Client
+
+	switch sdk.ProxyMode {
+	case "tor":
+		// Use Tor SOCKS5 proxy
+		torAddr := sdk.TorProxyAddr
+		if torAddr == "" {
+			torAddr = "127.0.0.1:9050"
+		}
+		if !strings.Contains(torAddr, ":") {
+			torAddr = torAddr + ":9050"
+		}
+
+		dialer, err := proxy.SOCKS5("tcp", torAddr, nil, proxy.Direct)
+		if err != nil {
+			c.JSON(http.StatusOK, TestProxyResponse{
+				Success: false,
+				Error:   fmt.Sprintf("failed to create Tor SOCKS5 dialer: %v", err),
+			})
+			return
+		}
+
+		httpClient = &http.Client{
+			Timeout: 15 * time.Second,
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					return dialer.Dial(network, addr)
+				},
+			},
+		}
+
+	default:
+		// Regular proxy or direct
+		proxyURL := sdk.ProxyURL
+		if proxyURL != "" {
+			transport, err := createProxyTransport(proxyURL)
+			if err != nil {
+				c.JSON(http.StatusOK, TestProxyResponse{
+					Success: false,
+					Error:   fmt.Sprintf("failed to create proxy transport: %v", err),
+				})
+				return
+			}
+			httpClient = &http.Client{
+				Timeout:   15 * time.Second,
+				Transport: transport,
+			}
+		} else {
+			httpClient = &http.Client{Timeout: 15 * time.Second}
+		}
+	}
+
+	// Try to fetch IP from ip-api.com (lightweight, no API key needed)
+	ip, country, err := fetchExternalIP(ctx, httpClient)
+	if err != nil {
+		c.JSON(http.StatusOK, TestProxyResponse{
+			Success: false,
+			Error:   fmt.Sprintf("failed to fetch external IP: %v", err),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, TestProxyResponse{
+		Success: true,
+		IP:      ip,
+		Country: country,
+	})
+}
+
+// TorRotate sends a NEWNYM signal to Tor's control port to rotate the exit node IP.
+func (h *Handler) TorRotate(c *gin.Context) {
+	cfg := h.cfg
+	if cfg == nil {
+		c.JSON(http.StatusInternalServerError, TorRotateResponse{
+			Success: false,
+			Error:   "config not available",
+		})
+		return
+	}
+
+	controlAddr := cfg.TorControlAddr
+	if controlAddr == "" {
+		controlAddr = "127.0.0.1:9051"
+	}
+	if !strings.Contains(controlAddr, ":") {
+		controlAddr = controlAddr + ":9051"
+	}
+
+	// Capture old IP before rotation
+	oldIP := ""
+	func() {
+		torAddr := cfg.TorProxyAddr
+		if torAddr == "" {
+			torAddr = "127.0.0.1:9050"
+		}
+		if !strings.Contains(torAddr, ":") {
+			torAddr = torAddr + ":9050"
+		}
+		dialer, err := proxy.SOCKS5("tcp", torAddr, nil, proxy.Direct)
+		if err != nil {
+			return
+		}
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+		defer cancel()
+		hc := &http.Client{
+			Timeout: 10 * time.Second,
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					return dialer.Dial(network, addr)
+				},
+			},
+		}
+		ip, _, err := fetchExternalIP(ctx, hc)
+		if err == nil {
+			oldIP = ip
+		}
+	}()
+
+	// Connect to Tor control port
+	conn, err := net.DialTimeout("tcp", controlAddr, 15*time.Second)
+	if err != nil {
+		c.JSON(http.StatusOK, TorRotateResponse{
+			Success: false,
+			Error:   fmt.Sprintf("cannot connect to Tor control port %s: %v", controlAddr, err),
+		})
+		return
+	}
+	defer conn.Close()
+
+	conn.SetDeadline(time.Now().Add(45 * time.Second))
+
+	// Tor control protocol requires the client to send PROTOCOLINFO first
+	// (Tor does not send unsolicited greetings on connect)
+	_, err = conn.Write([]byte("PROTOCOLINFO\r\n"))
+	if err != nil {
+		c.JSON(http.StatusOK, TorRotateResponse{
+			Success: false,
+			Error:   fmt.Sprintf("failed to send PROTOCOLINFO: %v", err),
+		})
+		return
+	}
+
+	// Read PROTOCOLINFO response
+	buf := make([]byte, 4096)
+	n, err := conn.Read(buf)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to read Tor PROTOCOLINFO response: %v", err)
+		if strings.Contains(err.Error(), "connection aborted") || strings.Contains(err.Error(), "reset by peer") {
+			errMsg += ". Check that Tor ControlPort is not restricted to localhost " +
+				"(add 'ControlPort 0.0.0.0:9051' to torrc on the Tor server and restart Tor)."
+		}
+		c.JSON(http.StatusOK, TorRotateResponse{
+			Success: false,
+			Error:   errMsg,
+		})
+		return
+	}
+	resp := string(buf[:n])
+	if !strings.HasPrefix(resp, "250") {
+		c.JSON(http.StatusOK, TorRotateResponse{
+			Success: false,
+			Error:   fmt.Sprintf("unexpected PROTOCOLINFO response: %s", resp),
+		})
+		return
+	}
+
+	// Send AUTHENTICATE with configured password (or empty if none)
+	authCmd := "AUTHENTICATE \"\"\r\n"
+	if cfg.TorControlPassword != "" {
+		authCmd = fmt.Sprintf("AUTHENTICATE \"%s\"\r\n", cfg.TorControlPassword)
+	}
+	_, err = conn.Write([]byte(authCmd))
+	if err != nil {
+		c.JSON(http.StatusOK, TorRotateResponse{
+			Success: false,
+			Error:   fmt.Sprintf("failed to send AUTHENTICATE: %v", err),
+		})
+		return
+	}
+
+	n, err = conn.Read(buf)
+	if err != nil {
+		c.JSON(http.StatusOK, TorRotateResponse{
+			Success: false,
+			Error:   fmt.Sprintf("failed to read AUTHENTICATE response: %v", err),
+		})
+		return
+	}
+	resp = strings.TrimSpace(string(buf[:n]))
+	if !strings.HasPrefix(resp, "250") {
+		c.JSON(http.StatusOK, TorRotateResponse{
+			Success: false,
+			Error:   fmt.Sprintf("Tor AUTHENTICATE failed: %s", resp),
+		})
+		return
+	}
+
+	// Send SIGNAL NEWNYM
+	_, err = conn.Write([]byte("SIGNAL NEWNYM\r\n"))
+	if err != nil {
+		c.JSON(http.StatusOK, TorRotateResponse{
+			Success: false,
+			Error:   fmt.Sprintf("failed to send NEWNYM signal: %v", err),
+		})
+		return
+	}
+
+	n, err = conn.Read(buf)
+	if err != nil {
+		c.JSON(http.StatusOK, TorRotateResponse{
+			Success: false,
+			Error:   fmt.Sprintf("failed to read NEWNYM response: %v", err),
+		})
+		return
+	}
+	resp = strings.TrimSpace(string(buf[:n]))
+	if !strings.HasPrefix(resp, "250") {
+		c.JSON(http.StatusOK, TorRotateResponse{
+			Success: false,
+			Error:   fmt.Sprintf("Tor NEWNYM failed: %s", resp),
+		})
+		return
+	}
+
+	// Wait a moment for Tor to establish new circuit
+	time.Sleep(2 * time.Second)
+
+	// Test the new IP
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 15*time.Second)
+	defer cancel()
+
+	torAddr := cfg.TorProxyAddr
+	if torAddr == "" {
+		torAddr = "127.0.0.1:9050"
+	}
+	if !strings.Contains(torAddr, ":") {
+		torAddr = torAddr + ":9050"
+	}
+
+	dialer, err := proxy.SOCKS5("tcp", torAddr, nil, proxy.Direct)
+	if err != nil {
+		c.JSON(http.StatusOK, TorRotateResponse{
+			Success: true,
+			Message: "NEWNYM signal sent but could not verify new IP",
+		})
+		return
+	}
+
+	httpClient := &http.Client{
+		Timeout: 15 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return dialer.Dial(network, addr)
+			},
+		},
+	}
+
+	newIP, _, err := fetchExternalIP(ctx, httpClient)
+	if err != nil {
+		c.JSON(http.StatusOK, TorRotateResponse{
+			Success: true,
+			Message: "NEWNYM signal sent, IP rotated successfully (could not verify)",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, TorRotateResponse{
+		Success: true,
+		Message: "Tor IP rotated successfully",
+		OldIP:   oldIP,
+		NewIP:   newIP,
+	})
+}
+
+// createProxyTransport creates an http.Transport that routes through the given proxy URL.
+func createProxyTransport(proxyURL string) (*http.Transport, error) {
+	proxyURL = strings.TrimSpace(proxyURL)
+	if proxyURL == "" {
+		return nil, nil
+	}
+
+	// Support socks5:// and http:// proxy URLs
+	transport := &http.Transport{}
+
+	if strings.HasPrefix(proxyURL, "socks5://") || strings.HasPrefix(proxyURL, "socks5h://") {
+		// SOCKS5 proxy
+		addr := strings.TrimPrefix(proxyURL, "socks5://")
+		addr = strings.TrimPrefix(addr, "socks5h://")
+
+		dialer, err := proxy.SOCKS5("tcp", addr, nil, proxy.Direct)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create SOCKS5 dialer: %v", err)
+		}
+
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return dialer.Dial(network, addr)
+		}
+		return transport, nil
+	}
+
+	// HTTP/HTTPS proxy - use http.Transport.Proxy field
+	transport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}
+
+	// Parse the custom proxy URL
+	parsedURL, err := transport.Proxy(nil)
+	if err == nil && parsedURL != nil {
+		transport.Proxy = http.ProxyURL(parsedURL)
+	}
+
+	return transport, nil
+}
+
+// fetchExternalIP calls ip-api.com to get the external IP and country.
+func fetchExternalIP(ctx context.Context, client *http.Client) (ip, country string, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://ip-api.com/json/", nil)
+	if err != nil {
+		return "", "", fmt.Errorf("create request: %v", err)
+	}
+	req.Header.Set("User-Agent", "CLIProxyAPI/1.0")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("http request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", fmt.Errorf("read response: %v", err)
+	}
+
+	var result struct {
+		Status  string `json:"status"`
+		Query   string `json:"query"`
+		Country string `json:"country"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", "", fmt.Errorf("parse response: %v", err)
+	}
+
+	if result.Status != "success" {
+		return "", "", fmt.Errorf("ip-api returned status: %s", result.Status)
+	}
+
+	return result.Query, result.Country, nil
+}

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -180,6 +180,8 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/xai-auth-url", s.mgmt.RequestXAIToken)
 		mgmt.GET("/get-auth-status", s.mgmt.GetAuthStatus)
 		mgmt.DELETE("/oauth-session", s.mgmt.CancelAuthSession)
+		mgmt.POST("/test-proxy", s.mgmt.TestProxy)
+		mgmt.POST("/tor-rotate", s.mgmt.TorRotate)
 	}
 }
 
@@ -318,3 +320,4 @@ func (s *Server) serveManagementControlPanel(c *gin.Context) {
 
 	c.File(filePath)
 }
+

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -48,6 +48,30 @@ type SDKConfig struct {
 	// ClaudeCode configures Claude Code compatibility behavior.
 	ClaudeCode ClaudeCodeConfig `yaml:"claude-code" json:"claude-code"`
 
+	// ProxyMode selects the proxy mode: "proxy" (default for regular HTTP/SOCKS proxy)
+	// or "tor" for Tor SOCKS5 proxy with automatic IP rotation on error codes.
+	ProxyMode string `yaml:"proxy-mode" json:"proxy-mode"`
+
+	// TorControlAddr is the address of the Tor control port for sending NEWNYM signals
+	// to rotate the Tor exit node IP. Format: "127.0.0.1:9051"
+	TorControlAddr string `yaml:"tor-control-addr" json:"tor-control-addr"`
+
+	// TorControlPassword is the password for the Tor control port.
+	// Leave empty if no password is configured (default Tor control port behavior).
+	TorControlPassword string `yaml:"tor-control-password" json:"tor-control-password"`
+
+	// TorProxyAddr is the address of the Tor SOCKS5 proxy.
+	// Format: "127.0.0.1:9050"
+	TorProxyAddr string `yaml:"tor-proxy-addr" json:"tor-proxy-addr"`
+
+	// TorRetryAttempts is the maximum number of times to retry a request after rotating
+	// the Tor exit node IP. Set to 0 for unlimited retries.
+	TorRetryAttempts int `yaml:"tor-retry-attempts" json:"tor-retry-attempts"`
+
+	// TorRetryOnCodes lists HTTP status codes that trigger a Tor IP rotation + retry.
+	// Example: [429, 403, 500, 502, 503]
+	TorRetryOnCodes []int `yaml:"tor-retry-on-codes" json:"tor-retry-on-codes"`
+
 	// APIKeys is a list of keys for authenticating clients to this proxy server.
 	APIKeys []string `yaml:"api-keys" json:"api-keys"`
 

--- a/internal/runtime/executor/helps/proxy_helpers.go
+++ b/internal/runtime/executor/helps/proxy_helpers.go
@@ -2,6 +2,8 @@ package helps
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -12,10 +14,39 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// errTorTransportUnavailable is the error returned when Tor mode is enabled
+// but the Tor SOCKS5 transport cannot be created.
+var errTorTransportUnavailable = errors.New("Tor proxy configured but unavailable")
+
+// torFailTransport is an http.RoundTripper that always returns errTorTransportUnavailable.
+// Used when Tor mode is enabled but the Tor SOCKS5 transport cannot be created,
+// guaranteeing that no traffic leaks outside Tor.
+type torFailTransport struct{}
+
+func (t *torFailTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("%w: check Tor daemon is running at %s", errTorTransportUnavailable, torAddrFromContext(req.Context()))
+}
+
+// torAddrFromContext extracts the Tor proxy address from the request context
+// if it was set by NewProxyAwareHTTPClient.
+type torAddrKey struct{}
+
+func torAddrFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(torAddrKey{}).(string); ok {
+		return v
+	}
+	return DefaultTorProxyAddr
+}
+
 // NewProxyAwareHTTPClient creates an HTTP client with proper proxy configuration priority:
 // 1. Use auth.ProxyURL if configured (highest priority)
-// 2. Use cfg.ProxyURL if auth proxy is not configured
-// 3. Use RoundTripper from context if neither are configured
+// 2. Use cfg.ProxyURL if auth proxy is not configured (unless cfg.ProxyMode is "tor")
+// 3. If cfg.ProxyMode is "tor", use the Tor SOCKS5 proxy via cfg.TorProxyAddr
+// 4. Otherwise, use RoundTripper from context if neither are configured
+//
+// CRITICAL: When Tor mode is enabled, this function guarantees no traffic escapes
+// outside Tor. If the Tor transport cannot be created, the returned client's
+// RoundTrip will always fail with errTorTransportUnavailable.
 //
 // Parameters:
 //   - ctx: The context containing optional RoundTripper
@@ -49,11 +80,32 @@ func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 			httpClient.Transport = transport
 			return httpClient
 		}
-		// If proxy setup failed, log and fall through to context RoundTripper
 		log.Debugf("failed to setup proxy from URL: %s, falling back to context transport", proxyutil.Redact(proxyURL))
 	}
 
-	// Priority 3: Use RoundTripper from context (typically from RoundTripperFor)
+	// Priority 3: If Tor mode is enabled, use Tor SOCKS5 proxy.
+	// CRITICAL: When Tor is enabled, we MUST NOT fall through to a non-Tor transport.
+	// If the Tor transport cannot be created, we use torFailTransport which will
+	// make every request fail with a clear error, guaranteeing no traffic leak.
+	if cfg != nil && IsTorMode(cfg) {
+		torProxyAddr := strings.TrimSpace(cfg.TorProxyAddr)
+		if torProxyAddr == "" {
+			torProxyAddr = DefaultTorProxyAddr
+		}
+		transport := NewTorHTTPTransport(torProxyAddr)
+		if transport != nil {
+			httpClient.Transport = transport
+			// Tag the context with the proxy address for error messages.
+			ctx = context.WithValue(ctx, torAddrKey{}, torProxyAddr)
+			return httpClient
+		}
+		// Tor transport creation failed — do NOT fall through to non-Tor transport.
+		log.Error("Tor mode enabled but Tor transport creation failed — all requests will fail")
+		httpClient.Transport = &torFailTransport{}
+		return httpClient
+	}
+
+	// Priority 4: Use RoundTripper from context (typically from RoundTripperFor)
 	if rt, ok := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); ok && rt != nil {
 		httpClient.Transport = rt
 	}

--- a/internal/runtime/executor/helps/tor_helpers.go
+++ b/internal/runtime/executor/helps/tor_helpers.go
@@ -1,0 +1,201 @@
+// Package helps provides utility functions for proxy configuration and Tor IP rotation.
+package helps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
+	"golang.org/x/net/proxy"
+)
+
+// TorRotator manages Tor exit node IP rotation via the Tor control port.
+type TorRotator struct {
+	mu              sync.Mutex
+	controlAddr     string
+	proxyAddr       string
+	controlPassword string
+	retryAttempts   int   // 0 = unlimited
+	retryCount      int   // current retry count
+	retryOnCodes    []int // HTTP status codes that trigger rotation
+}
+
+// DefaultTorControlAddr is the default Tor control port address.
+const DefaultTorControlAddr = "127.0.0.1:9051"
+
+// DefaultTorProxyAddr is the default Tor SOCKS5 proxy address.
+const DefaultTorProxyAddr = "127.0.0.1:9050"
+
+// ErrTorControlNotConnected is returned when the Tor control connection fails.
+var ErrTorControlNotConnected = errors.New("tor control connection failed")
+
+// NewTorRotator creates a new TorRotator from the config.
+func NewTorRotator(cfg *config.Config) *TorRotator {
+	if cfg == nil {
+		return nil
+	}
+
+	controlAddr := strings.TrimSpace(cfg.TorControlAddr)
+	if controlAddr == "" {
+		controlAddr = DefaultTorControlAddr
+	}
+
+	proxyAddr := strings.TrimSpace(cfg.TorProxyAddr)
+	if proxyAddr == "" {
+		proxyAddr = DefaultTorProxyAddr
+	}
+
+	codes := cfg.TorRetryOnCodes
+	if codes == nil {
+		codes = []int{429, 403, 500, 502, 503}
+	}
+
+	return &TorRotator{
+		controlAddr:     controlAddr,
+		proxyAddr:       proxyAddr,
+		controlPassword: strings.TrimSpace(cfg.TorControlPassword),
+		retryAttempts:   cfg.TorRetryAttempts,
+		retryOnCodes:    codes,
+	}
+}
+
+// ResetRetryCount resets the retry counter (call after a successful request).
+func (r *TorRotator) ResetRetryCount() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.retryCount = 0
+}
+
+// ShouldRetryWithNewTorIP checks whether the given status code should trigger a
+// Tor IP rotation + retry, and whether we still have retry attempts left.
+func (r *TorRotator) ShouldRetryWithNewTorIP(statusCode int) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Check if this status code should trigger rotation
+	if !r.isRetryableCode(statusCode) {
+		return false
+	}
+
+	// Check if we have retry attempts left
+	if r.retryAttempts > 0 && r.retryCount >= r.retryAttempts {
+		return false
+	}
+
+	return true
+}
+
+// RotateIP sends a NEWNYM signal to the Tor control port to request a new exit node IP.
+// It waits for the new circuit to be established before returning.
+func (r *TorRotator) RotateIP() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	conn, err := net.DialTimeout("tcp", r.controlAddr, 10*time.Second)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrTorControlNotConnected, err)
+	}
+	defer func() {
+		_, _ = conn.Write([]byte("QUIT\r\n"))
+		_ = conn.Close()
+	}()
+
+	// Set a deadline for the operation
+	if err := conn.SetDeadline(time.Now().Add(15 * time.Second)); err != nil {
+		return fmt.Errorf("set deadline: %w", err)
+	}
+	// Note: Some Tor versions/configs don't send an initial PROTOCOLINFO greeting.
+	// We skip reading it and go straight to AUTHENTICATE.
+	buf := make([]byte, 512)
+	var n int
+	var resp string
+	// Authenticate with the control port.
+	// If a password is configured, send it quoted (Tor control protocol expects
+	// AUTHENTICATE "password" for plaintext passwords).
+	var authCmd string
+	if r.controlPassword != "" {
+		authCmd = fmt.Sprintf("AUTHENTICATE %q\r\n", r.controlPassword)
+	} else {
+		authCmd = "AUTHENTICATE\r\n"
+	}
+	if _, err := conn.Write([]byte(authCmd)); err != nil {
+		return fmt.Errorf("send AUTHENTICATE: %w", err)
+	}
+	n, err = conn.Read(buf)
+	if err != nil {
+		return fmt.Errorf("read AUTHENTICATE response: %w", err)
+	}
+	resp = string(buf[:n])
+	if !strings.HasPrefix(resp, "250") {
+		return fmt.Errorf("AUTHENTICATE failed: %s", resp)
+	}
+	// Send NEWNYM signal to request a new identity
+	if _, err := conn.Write([]byte("SIGNAL NEWNYM\r\n")); err != nil {
+		return fmt.Errorf("send NEWNYM: %w", err)
+	}
+	n, err = conn.Read(buf)
+	if err != nil {
+		return fmt.Errorf("read NEWNYM response: %w", err)
+	}
+	resp = string(buf[:n])
+	if !strings.HasPrefix(resp, "250") {
+		return fmt.Errorf("NEWNYM failed: %s", resp)
+	}
+
+	r.retryCount++
+	return nil
+}
+
+// NewTorHTTPTransport creates an HTTP transport that routes through the Tor SOCKS5 proxy.
+func NewTorHTTPTransport(proxyAddr string) *http.Transport {
+	addr := strings.TrimSpace(proxyAddr)
+	if addr == "" {
+		addr = DefaultTorProxyAddr
+	}
+
+	dialer, err := proxy.SOCKS5("tcp", addr, nil, proxy.Direct)
+	if err != nil {
+		return nil
+	}
+
+	transport := proxyutil.NewDirectTransport()
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return dialer.Dial(network, addr)
+	}
+
+	return transport
+}
+
+// BuildTorDialer creates a SOCKS5 dialer for Tor connections.
+func BuildTorDialer(proxyAddr string) (proxy.Dialer, error) {
+	addr := strings.TrimSpace(proxyAddr)
+	if addr == "" {
+		addr = DefaultTorProxyAddr
+	}
+	return proxy.SOCKS5("tcp", addr, nil, proxy.Direct)
+}
+
+// IsTorMode returns true if the config specifies Tor proxy mode.
+func IsTorMode(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(cfg.ProxyMode), "tor")
+}
+
+// isRetryableCode checks if the given HTTP status code is in the retry list.
+func (r *TorRotator) isRetryableCode(statusCode int) bool {
+	for _, code := range r.retryOnCodes {
+		if code == statusCode {
+			return true
+		}
+	}
+	return false
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -160,6 +160,9 @@ type Manager struct {
 	// Optional HTTP RoundTripper provider injected by host.
 	rtProvider RoundTripperProvider
 
+	// torRotator handles Tor exit node IP rotation when Tor mode is enabled.
+	torRotator TorRotator
+
 	// Auto refresh state
 	refreshCancel context.CancelFunc
 	refreshLoop   *authAutoRefreshLoop
@@ -200,4 +203,25 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 	}
 	manager.scheduler = newAuthScheduler(selector)
 	return manager
+}
+
+// TorRotator defines the interface for Tor exit node IP rotation.
+type TorRotator interface {
+	ShouldRetryWithNewTorIP(statusCode int) bool
+	RotateIP() error
+	ResetRetryCount()
+}
+
+// SetTorRotator sets the Tor IP rotator for this manager.
+func (m *Manager) SetTorRotator(rotator TorRotator) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.torRotator = rotator
+}
+
+// GetTorRotator returns the Tor rotator, if set.
+func (m *Manager) GetTorRotator() TorRotator {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.torRotator
 }

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -1101,6 +1101,13 @@ func (m *Manager) shouldRetryAfterErrorWithHomeRetryLimit(ctx context.Context, o
 	eligibility := authSelectionEligibilityForRequest(ctx, opts)
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
 	if !isCredentialRetryRoundStatus(status) || !m.retryAllowed(attempt, providers, model, eligibility, pinnedAuthID, defaultRequestRetry) {
+		// Tor IP rotation: when Tor mode is enabled and a retryable status code
+		// is received, rotate the Tor exit node IP before retrying.
+		if rotator := m.GetTorRotator(); rotator != nil && rotator.ShouldRetryWithNewTorIP(status) {
+			if rotateErr := rotator.RotateIP(); rotateErr == nil {
+				return 0, true
+			}
+		}
 		return 0, false
 	}
 	wait, found := m.closestCooldownWait(providers, model, attempt, eligibility, pinnedAuthID, defaultRequestRetry)

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -10,11 +10,13 @@ import (
 	configaccess "github.com/router-for-me/CLIProxyAPI/v7/internal/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/api"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	log "github.com/sirupsen/logrus"
 )
 
 // Builder constructs a Service instance with customizable providers.
@@ -257,11 +259,25 @@ func (b *Builder) Build() (*Service, error) {
 		appliedRoutingState = &routingState
 	}
 	// Attach a default RoundTripper provider so providers can opt-in per-auth transports.
-	coreManager.SetRoundTripperProvider(newDefaultRoundTripperProvider())
+	if helps.IsTorMode(b.cfg) {
+		// In Tor mode, all outbound traffic routes through the Tor SOCKS5 proxy.
+		torTransport := helps.NewTorHTTPTransport(b.cfg.TorProxyAddr)
+		if torTransport != nil {
+			coreManager.SetRoundTripperProvider(&torRoundTripperProvider{transport: torTransport})
+		} else {
+			log.Warn("Tor mode enabled but Tor transport unavailable; falling back to default provider")
+			coreManager.SetRoundTripperProvider(newDefaultRoundTripperProvider())
+		}
+	} else {
+		coreManager.SetRoundTripperProvider(newDefaultRoundTripperProvider())
+	}
 	coreManager.SetConfig(b.cfg)
 	coreManager.SetOAuthModelAlias(b.cfg.OAuthModelAlias)
 	if pluginHost != nil {
 		coreManager.SetPluginScheduler(pluginHost)
+	}
+	if helps.IsTorMode(b.cfg) {
+		coreManager.SetTorRotator(helps.NewTorRotator(b.cfg))
 	}
 
 	service := &Service{

--- a/sdk/cliproxy/rtprovider.go
+++ b/sdk/cliproxy/rtprovider.go
@@ -49,3 +49,13 @@ func (p *defaultRoundTripperProvider) RoundTripperFor(auth *coreauth.Auth) http.
 	p.mu.Unlock()
 	return transport
 }
+
+// torRoundTripperProvider returns a Tor SOCKS5 transport for all auths.
+type torRoundTripperProvider struct {
+	transport *http.Transport
+}
+
+// RoundTripperFor implements coreauth.RoundTripperProvider.
+func (p *torRoundTripperProvider) RoundTripperFor(_ *coreauth.Auth) http.RoundTripper {
+	return p.transport
+}


### PR DESCRIPTION
Adds Tor SOCKS5 proxy with automatic IP rotation via NEWNYM signals.

Config fields:
- proxy-mode: proxy/tor
- tor-proxy-addr: SOCKS5 address
- tor-control-addr: control port for NEWNYM
- tor-control-password: auth password
- tor-retry-attempts: max retries after rotation
- tor-retry-on-codes: HTTP codes triggering rotation

New files:
- internal/runtime/executor/helps/tor_helpers.go

Modified:
- sdk/cliproxy/auth/conductor.go (TorRotator interface)
- sdk/cliproxy/builder.go (wiring)

Built: go build -o cli-proxy-api ./cmd/server ✓