### PR TITLE
fix(proxyutil): tunnel HTTPS proxies over an HTTP/1.1 CONNECT dialer

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -140,8 +140,19 @@ func cloneTransportWithHTTP11(base *http.Transport) *http.Transport {
 	if base == nil {
 		return nil
 	}
+	return forceHTTP11(base.Clone())
+}
 
-	clone := base.Clone()
+// forceHTTP11 applies the same settings in place, for a transport this package just
+// built and nobody else holds. Cloning such a transport is not free of meaning: a
+// transport from proxyutil.BuildHTTPTransport carries a proxy dial hook bound to itself,
+// and http.Transport.Clone copies that hook as a function value — the clone would keep
+// consulting the original that is about to be discarded.
+func forceHTTP11(clone *http.Transport) *http.Transport {
+	if clone == nil {
+		return nil
+	}
+
 	clone.ForceAttemptHTTP2 = false
 	// Wipe TLSNextProto to prevent implicit HTTP/2 upgrade.
 	clone.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
@@ -227,7 +238,8 @@ func antigravityProxiedHTTP11Transport(auth *cliproxyauth.Auth, proxyURL string)
 		if base == nil {
 			return nil, fmt.Errorf("antigravity executor: proxy setting produced no transport")
 		}
-		return cloneTransportWithHTTP11(base), nil
+		// In place, not cloned: base was built two lines up and has no other owner.
+		return forceHTTP11(base), nil
 	})
 	if errGet != nil {
 		// The caller falls back to NewProxyAwareHTTPClient, which reports the failure

--- a/internal/runtime/executor/antigravity_executor_transport_test.go
+++ b/internal/runtime/executor/antigravity_executor_transport_test.go
@@ -8,8 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -556,5 +558,100 @@ func TestAntigravityProxiedRequestsReuseOneConnection(t *testing.T) {
 	mu.Unlock()
 	if distinct != 1 {
 		t.Fatalf("expected %d requests to share one connection, got %d connections", requests, distinct)
+	}
+}
+
+// TestAntigravityProxiedTransportKeepsProxyDialerBound pins why the proxied transport is
+// built in place rather than cloned. A transport from proxyutil.BuildHTTPTransport
+// carries a proxy dial hook bound to the transport it was built for, and
+// http.Transport.Clone copies that hook as a plain function value — a clone keeps
+// consulting the original, which here would be discarded immediately. TLS settings
+// applied to what this function returns would then silently miss the connection to the
+// proxy, which is the one leg that has to trust the proxy's certificate.
+func TestAntigravityProxiedTransportKeepsProxyDialerBound(t *testing.T) {
+	target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	proxyServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodConnect {
+			http.Error(w, "expected CONNECT", http.StatusMethodNotAllowed)
+			return
+		}
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "connection is not hijackable", http.StatusInternalServerError)
+			return
+		}
+		upstreamConn, errDial := net.Dial("tcp", r.Host)
+		if errDial != nil {
+			http.Error(w, "dial upstream failed", http.StatusBadGateway)
+			return
+		}
+		clientConn, buffered, errHijack := hijacker.Hijack()
+		if errHijack != nil {
+			_ = upstreamConn.Close()
+			return
+		}
+		if _, errWrite := io.WriteString(clientConn, "HTTP/1.1 200 Connection Established\r\n\r\n"); errWrite != nil {
+			_ = upstreamConn.Close()
+			_ = clientConn.Close()
+			return
+		}
+		go func() {
+			defer func() { _ = upstreamConn.Close() }()
+			_, _ = io.Copy(upstreamConn, buffered)
+		}()
+		go func() {
+			defer func() { _ = clientConn.Close() }()
+			_, _ = io.Copy(clientConn, upstreamConn)
+		}()
+	}))
+	// An h2-offering proxy, the shape that made the ALPN pin necessary in the first place.
+	proxyServer.EnableHTTP2 = true
+	proxyServer.TLS = &tls.Config{NextProtos: []string{"h2", "http/1.1"}}
+	proxyServer.StartTLS()
+	defer proxyServer.Close()
+
+	proxyURL, errParse := url.Parse(proxyServer.URL)
+	if errParse != nil {
+		t.Fatalf("url.Parse() error = %v", errParse)
+	}
+	auth := antigravityAuthWithIDAndProxy("antigravity-proxy-dialer-binding", "https://"+proxyURL.Host)
+	transport := antigravityProxiedHTTP11Transport(auth, auth.ProxyURL)
+	if transport == nil {
+		t.Fatal("antigravityProxiedHTTP11Transport() returned nil")
+	}
+	defer transport.CloseIdleConnections()
+
+	client := &http.Client{Transport: transport, Timeout: 10 * time.Second}
+
+	// Neither leg can verify the httptest certificate yet, so this must fail. It also
+	// proves the request really does go through the proxy rather than around it.
+	if resp, errGet := client.Get(target.URL); errGet == nil {
+		_ = resp.Body.Close()
+		t.Fatal("request succeeded before the proxy's certificate was trusted")
+	}
+
+	// Trust it — on the transport this function handed back. A hook bound elsewhere
+	// would never see this, and the request would keep failing.
+	proxyClientTransport, ok := proxyServer.Client().Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("httptest proxy client transport is not an *http.Transport")
+	}
+	transport.TLSClientConfig.RootCAs = proxyClientTransport.TLSClientConfig.RootCAs
+
+	resp, errGet := client.Get(target.URL)
+	if errGet != nil {
+		t.Fatalf("request through the proxy failed after trusting its certificate: %v", errGet)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			t.Errorf("resp.Body.Close() error = %v", errClose)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 }

--- a/sdk/proxyutil/proxy.go
+++ b/sdk/proxyutil/proxy.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"golang.org/x/net/proxy"
 )
@@ -126,14 +127,22 @@ func BuildHTTPTransport(raw string) (*http.Transport, Mode, error) {
 			// picks h2 sees a bogus HTTP/2 preface and drops the connection, which
 			// surfaces to callers as "unexpected EOF". Tunnel through the CONNECT
 			// dialer instead; protocol negotiation with the target is untouched.
+			// Reuse the cloned transport's own dialer so the connection to the proxy
+			// keeps its TCP dial timeout and keep-alive settings; read it before it
+			// is overwritten below.
+			baseDialer := proxy.Dialer(proxy.Direct)
+			if dialContext := transport.DialContext; dialContext != nil {
+				baseDialer = contextDialerFunc(dialContext)
+			}
 			transport.Proxy = nil
 			transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 				// Built per dial: TLSClientConfig is still nil here and gets populated
 				// later, both by callers and by Go's own HTTP/2 setup.
 				dialer := &httpConnectDialer{
-					proxyURL:  setting.URL,
-					dialer:    proxy.Direct,
-					tlsConfig: transport.TLSClientConfig,
+					proxyURL:            setting.URL,
+					dialer:              baseDialer,
+					tlsConfig:           transport.TLSClientConfig,
+					tlsHandshakeTimeout: transport.TLSHandshakeTimeout,
 				}
 				return dialer.DialContext(ctx, network, addr)
 			}
@@ -178,6 +187,22 @@ type httpConnectDialer struct {
 	// tlsConfig carries caller-supplied TLS settings (roots, client certs) for the
 	// handshake with an HTTPS proxy. Nil means defaults.
 	tlsConfig *tls.Config
+	// tlsHandshakeTimeout bounds the TLS handshake with an HTTPS proxy. Setting up
+	// the tunnel here takes it out of reach of http.Transport.TLSHandshakeTimeout,
+	// so callers that rely on that bound must pass it through. Zero means no bound.
+	tlsHandshakeTimeout time.Duration
+}
+
+// contextDialerFunc adapts a net.Dialer-style dial function to proxy.Dialer so an
+// existing transport's dialer, timeouts included, can carry the proxy connection.
+type contextDialerFunc func(ctx context.Context, network, addr string) (net.Conn, error)
+
+func (f contextDialerFunc) Dial(network, addr string) (net.Conn, error) {
+	return f(context.Background(), network, addr)
+}
+
+func (f contextDialerFunc) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	return f(ctx, network, addr)
 }
 
 func (d *httpConnectDialer) Dial(network, addr string) (net.Conn, error) {
@@ -223,7 +248,13 @@ func (d *httpConnectDialer) DialContext(ctx context.Context, network, addr strin
 	}()
 	if d.proxyURL.Scheme == "https" {
 		tlsConn := tls.Client(conn, proxyTLSConfig(d.tlsConfig, d.proxyURL.Hostname()))
-		if errHandshake := tlsConn.HandshakeContext(ctx); errHandshake != nil {
+		handshakeCtx := ctx
+		if d.tlsHandshakeTimeout > 0 {
+			var cancelHandshake context.CancelFunc
+			handshakeCtx, cancelHandshake = context.WithTimeout(ctx, d.tlsHandshakeTimeout)
+			defer cancelHandshake()
+		}
+		if errHandshake := tlsConn.HandshakeContext(handshakeCtx); errHandshake != nil {
 			if errClose := conn.Close(); errClose != nil {
 				return nil, fmt.Errorf("HTTPS proxy TLS handshake failed: %w; close failed: %v", errHandshake, errClose)
 			}

--- a/sdk/proxyutil/proxy.go
+++ b/sdk/proxyutil/proxy.go
@@ -144,6 +144,9 @@ func BuildHTTPTransport(raw string) (*http.Transport, Mode, error) {
 					tlsConfig:           transport.TLSClientConfig,
 					tlsHandshakeTimeout: transport.TLSHandshakeTimeout,
 					connectTimeout:      defaultProxyConnectTimeout,
+					connectHeader:       transport.ProxyConnectHeader,
+					getConnectHeader:    transport.GetProxyConnectHeader,
+					onConnectResponse:   transport.OnProxyConnectResponse,
 				}
 				return dialer.DialContext(ctx, network, addr)
 			}
@@ -198,6 +201,38 @@ type httpConnectDialer struct {
 	tlsHandshakeTimeout time.Duration
 	// connectTimeout bounds the CONNECT exchange. Zero means no bound.
 	connectTimeout time.Duration
+	// The three knobs http.Transport documents for the CONNECT request it would have
+	// made itself. Performing the CONNECT here puts them out of its reach, so a caller
+	// that set them on the transport — an enterprise proxy demanding extra headers, a
+	// callback vetting the response — would otherwise lose them without a word.
+	// Semantics follow net/http's dialConn exactly; see connectRequestHeader.
+	connectHeader     http.Header
+	getConnectHeader  func(ctx context.Context, proxyURL *url.URL, target string) (http.Header, error)
+	onConnectResponse func(ctx context.Context, proxyURL *url.URL, connectReq *http.Request, connectRes *http.Response) error
+}
+
+// connectRequestHeader assembles the CONNECT headers the way net/http does:
+// GetProxyConnectHeader wins over ProxyConnectHeader, and the proxy URL's own
+// credentials are applied last — onto a copy, so a header the caller still owns is
+// never mutated.
+func (d *httpConnectDialer) connectRequestHeader(ctx context.Context, target string) (http.Header, error) {
+	header := d.connectHeader
+	if d.getConnectHeader != nil {
+		var errHeader error
+		header, errHeader = d.getConnectHeader(ctx, d.proxyURL, target)
+		if errHeader != nil {
+			return nil, errHeader
+		}
+	}
+	if header == nil {
+		header = make(http.Header)
+	} else {
+		header = header.Clone()
+	}
+	if d.proxyURL.User != nil {
+		header.Set("Proxy-Authorization", proxyAuthorization(d.proxyURL.User))
+	}
+	return header, nil
 }
 
 // defaultProxyConnectTimeout bounds the CONNECT exchange with the proxy. net/http applies
@@ -302,15 +337,19 @@ func (d *httpConnectDialer) DialContext(ctx context.Context, network, addr strin
 		}
 	}
 
+	header, errHeader := d.connectRequestHeader(ctx, addr)
+	if errHeader != nil {
+		if errClose := conn.Close(); errClose != nil {
+			return nil, fmt.Errorf("build CONNECT header failed: %w; close failed: %v", errHeader, errClose)
+		}
+		return nil, fmt.Errorf("build CONNECT header failed: %w", errHeader)
+	}
 	req := (&http.Request{
 		Method: http.MethodConnect,
 		URL:    &url.URL{Host: addr},
 		Host:   addr,
-		Header: make(http.Header),
+		Header: header,
 	}).WithContext(ctx)
-	if d.proxyURL.User != nil {
-		req.Header.Set("Proxy-Authorization", proxyAuthorization(d.proxyURL.User))
-	}
 	if errWrite := req.Write(conn); errWrite != nil {
 		errWrite = preferContextError(ctx, errWrite)
 		if errClose := conn.Close(); errClose != nil {
@@ -328,6 +367,20 @@ func (d *httpConnectDialer) DialContext(ctx context.Context, network, addr strin
 		}
 		return nil, fmt.Errorf("read CONNECT response failed: %w", errRead)
 	}
+	// Before the status check, as net/http does: the hook is the caller's chance to
+	// judge a response this code would otherwise accept or reject on status alone.
+	if d.onConnectResponse != nil {
+		if errHook := d.onConnectResponse(ctx, d.proxyURL, req, resp); errHook != nil {
+			if resp.Body != nil {
+				_ = resp.Body.Close()
+			}
+			if errClose := conn.Close(); errClose != nil {
+				return nil, fmt.Errorf("OnProxyConnectResponse rejected the CONNECT response: %w; close failed: %v", errHook, errClose)
+			}
+			return nil, fmt.Errorf("OnProxyConnectResponse rejected the CONNECT response: %w", errHook)
+		}
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		if resp.Body != nil {
 			_ = resp.Body.Close()

--- a/sdk/proxyutil/proxy.go
+++ b/sdk/proxyutil/proxy.go
@@ -119,44 +119,62 @@ func BuildHTTPTransport(raw string) (*http.Transport, Mode, error) {
 			return transport, setting.Mode, nil
 		}
 		transport := cloneDefaultTransport()
-		if setting.URL.Scheme == "https" {
-			// http.Transport cannot be used to reach an HTTPS proxy: it hands the
-			// transport-wide TLSClientConfig — whose NextProtos gain "h2" as soon as
-			// HTTP/2 is configured — to the handshake with the proxy itself, and then
-			// writes an HTTP/1.1 CONNECT over whatever ALPN selected. A proxy that
-			// picks h2 sees a bogus HTTP/2 preface and drops the connection, which
-			// surfaces to callers as "unexpected EOF". Tunnel through the CONNECT
-			// dialer instead; protocol negotiation with the target is untouched.
-			// Reuse the cloned transport's own dialer so the connection to the proxy
-			// keeps its TCP dial timeout and keep-alive settings; read it before it
-			// is overwritten below.
-			baseDialer := proxy.Dialer(proxy.Direct)
-			if dialContext := transport.DialContext; dialContext != nil {
-				baseDialer = contextDialerFunc(dialContext)
-			}
-			transport.Proxy = nil
-			transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-				// Built per dial: TLSClientConfig is still nil here and gets populated
-				// later, both by callers and by Go's own HTTP/2 setup.
-				dialer := &httpConnectDialer{
-					proxyURL:            setting.URL,
-					dialer:              baseDialer,
-					tlsConfig:           transport.TLSClientConfig,
-					tlsHandshakeTimeout: transport.TLSHandshakeTimeout,
-					connectTimeout:      defaultProxyConnectTimeout,
-					connectHeader:       transport.ProxyConnectHeader,
-					getConnectHeader:    transport.GetProxyConnectHeader,
-					onConnectResponse:   transport.OnProxyConnectResponse,
-				}
-				return dialer.DialContext(ctx, network, addr)
-			}
-			return transport, setting.Mode, nil
-		}
 		transport.Proxy = http.ProxyURL(setting.URL)
+		if setting.URL.Scheme == "https" {
+			// Only the connection *to the proxy* is ours. net/http hands the
+			// transport-wide TLSClientConfig — whose NextProtos gain "h2" as soon as
+			// HTTP/2 is configured — to that handshake, then writes an HTTP/1.1 CONNECT
+			// over whatever ALPN selected; a proxy that picks h2 sees a bogus HTTP/2
+			// preface and drops the connection ("unexpected EOF").
+			//
+			// DialTLSContext is the seam for exactly that: with Proxy set, net/http calls
+			// it for the first hop, which is the proxy (connectMethod.addr()). Everything
+			// after stays net/http's — CONNECT with its headers and hooks, the bound on
+			// that exchange, the target handshake and its own ALPN. Taking any of it over
+			// would mean reimplementing it, and then owning every guard it already has.
+			baseDialContext := transport.DialContext
+			transport.DialTLSContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return dialProxyTLS(ctx, network, addr, baseDialContext, transport, setting.URL)
+			}
+		}
 		return transport, setting.Mode, nil
 	default:
 		return nil, setting.Mode, nil
 	}
+}
+
+// dialProxyTLS makes the TLS connection to an HTTPS proxy, pinning that leg's ALPN to
+// http/1.1 so the CONNECT net/http writes next lands on an HTTP/1.1 connection.
+//
+// TLSClientConfig and TLSHandshakeTimeout are read here rather than captured up front:
+// net/http documents that it ignores both once DialTLSContext is set, so honouring them
+// falls to this function, and callers set them after the transport is built.
+func dialProxyTLS(ctx context.Context, network, addr string,
+	baseDialContext func(context.Context, string, string) (net.Conn, error),
+	transport *http.Transport, proxyURL *url.URL) (net.Conn, error) {
+	dial := baseDialContext
+	if dial == nil {
+		dial = (&net.Dialer{}).DialContext
+	}
+	conn, errDial := dial(ctx, network, addr)
+	if errDial != nil {
+		return nil, errDial
+	}
+
+	handshakeCtx := ctx
+	if timeout := transport.TLSHandshakeTimeout; timeout > 0 {
+		var cancelHandshake context.CancelFunc
+		handshakeCtx, cancelHandshake = context.WithTimeout(ctx, timeout)
+		defer cancelHandshake()
+	}
+	tlsConn := tls.Client(conn, proxyTLSConfig(transport.TLSClientConfig, proxyURL.Hostname()))
+	if errHandshake := tlsConn.HandshakeContext(handshakeCtx); errHandshake != nil {
+		if errClose := conn.Close(); errClose != nil {
+			return nil, fmt.Errorf("HTTPS proxy TLS handshake failed: %w; close failed: %v", errHandshake, errClose)
+		}
+		return nil, fmt.Errorf("HTTPS proxy TLS handshake failed: %w", errHandshake)
+	}
+	return tlsConn, nil
 }
 
 // BuildDialer constructs a proxy dialer for settings that operate at the connection layer.
@@ -189,102 +207,24 @@ func BuildDialer(raw string) (proxy.Dialer, Mode, error) {
 	}
 }
 
-type httpConnectDialer struct {
-	proxyURL *url.URL
-	dialer   proxy.Dialer
-	// tlsConfig carries caller-supplied TLS settings (roots, client certs) for the
-	// handshake with an HTTPS proxy. Nil means defaults.
-	tlsConfig *tls.Config
-	// tlsHandshakeTimeout bounds the TLS handshake with an HTTPS proxy. Setting up
-	// the tunnel here takes it out of reach of http.Transport.TLSHandshakeTimeout,
-	// so callers that rely on that bound must pass it through. Zero means no bound.
-	tlsHandshakeTimeout time.Duration
-	// connectTimeout bounds the CONNECT exchange. Zero means no bound.
-	connectTimeout time.Duration
-	// The three knobs http.Transport documents for the CONNECT request it would have
-	// made itself. Performing the CONNECT here puts them out of its reach, so a caller
-	// that set them on the transport — an enterprise proxy demanding extra headers, a
-	// callback vetting the response — would otherwise lose them without a word.
-	// Semantics follow net/http's dialConn exactly; see connectRequestHeader.
-	connectHeader     http.Header
-	getConnectHeader  func(ctx context.Context, proxyURL *url.URL, target string) (http.Header, error)
-	onConnectResponse func(ctx context.Context, proxyURL *url.URL, connectReq *http.Request, connectRes *http.Response) error
-}
-
-// connectRequestHeader assembles the CONNECT headers the way net/http does:
-// GetProxyConnectHeader wins over ProxyConnectHeader, and the proxy URL's own
-// credentials are applied last — onto a copy, so a header the caller still owns is
-// never mutated.
-func (d *httpConnectDialer) connectRequestHeader(ctx context.Context, target string) (http.Header, error) {
-	header := d.connectHeader
-	if d.getConnectHeader != nil {
-		var errHeader error
-		header, errHeader = d.getConnectHeader(ctx, d.proxyURL, target)
-		if errHeader != nil {
-			return nil, errHeader
-		}
-	}
-	if header == nil {
-		header = make(http.Header)
-	} else {
-		header = header.Clone()
-	}
-	if d.proxyURL.User != nil {
-		header.Set("Proxy-Authorization", proxyAuthorization(d.proxyURL.User))
-	}
-	return header, nil
-}
-
 // defaultProxyConnectTimeout bounds the CONNECT exchange with the proxy. net/http applies
 // the same one-minute bound in dialConn, for the same reason: a proxy that takes the
 // connection and then stops replying would otherwise hold the caller until the request
-// context is canceled, and most callers here pass a context that never is. Taking over
-// proxy setup means taking over this guard too.
+// context is canceled, and callers on this path pass contexts that never are.
 const defaultProxyConnectTimeout = time.Minute
 
-// contextDialerFunc adapts a net.Dialer-style dial function to proxy.Dialer so an
-// existing transport's dialer, timeouts included, can carry the proxy connection.
-type contextDialerFunc func(ctx context.Context, network, addr string) (net.Conn, error)
-
-func (f contextDialerFunc) Dial(network, addr string) (net.Conn, error) {
-	return f(context.Background(), network, addr)
-}
-
-func (f contextDialerFunc) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	return f(ctx, network, addr)
-}
-
-// preferContextError reports the deadline rather than what closing the connection
-// produced. The bound above takes effect by closing the connection, so the I/O error
-// the caller would otherwise see is "use of closed network connection" — true, and
-// useless for telling a slow proxy apart from a broken one.
-func preferContextError(ctx context.Context, err error) error {
-	if errContext := ctx.Err(); errContext != nil {
-		return errContext
-	}
-	return err
+type httpConnectDialer struct {
+	proxyURL *url.URL
+	dialer   proxy.Dialer
+	// connectTimeout bounds the CONNECT exchange, the way net/http bounds its own in
+	// dialConn: a proxy that takes the connection and then stops replying would
+	// otherwise hold the caller until the context is canceled, and callers here pass
+	// contexts that never are. Zero means no bound.
+	connectTimeout time.Duration
 }
 
 func (d *httpConnectDialer) Dial(network, addr string) (net.Conn, error) {
 	return d.DialContext(context.Background(), network, addr)
-}
-
-// proxyTLSConfig derives the TLS settings for the connection to an HTTPS proxy.
-func proxyTLSConfig(base *tls.Config, serverName string) *tls.Config {
-	cfg := base.Clone()
-	if cfg == nil {
-		cfg = &tls.Config{}
-	}
-	// Filled in only when the caller left it empty, as net/http's addTLS does. A proxy
-	// reached at an address its certificate does not carry is the caller's to name.
-	if cfg.ServerName == "" {
-		cfg.ServerName = serverName
-	}
-	// ALPN, by contrast, is pinned unconditionally, and must stay that way: it is the fix.
-	// CONNECT is written as an HTTP/1.1 request, so a proxy allowed to select h2 receives
-	// one on an HTTP/2 connection and drops the whole thing.
-	cfg.NextProtos = []string{"http/1.1"}
-	return cfg
 }
 
 func (d *httpConnectDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -312,14 +252,8 @@ func (d *httpConnectDialer) DialContext(ctx context.Context, network, addr strin
 		}
 	}()
 	if d.proxyURL.Scheme == "https" {
-		tlsConn := tls.Client(conn, proxyTLSConfig(d.tlsConfig, d.proxyURL.Hostname()))
-		handshakeCtx := ctx
-		if d.tlsHandshakeTimeout > 0 {
-			var cancelHandshake context.CancelFunc
-			handshakeCtx, cancelHandshake = context.WithTimeout(ctx, d.tlsHandshakeTimeout)
-			defer cancelHandshake()
-		}
-		if errHandshake := tlsConn.HandshakeContext(handshakeCtx); errHandshake != nil {
+		tlsConn := tls.Client(conn, proxyTLSConfig(nil, d.proxyURL.Hostname()))
+		if errHandshake := tlsConn.HandshakeContext(ctx); errHandshake != nil {
 			if errClose := conn.Close(); errClose != nil {
 				return nil, fmt.Errorf("HTTPS proxy TLS handshake failed: %w; close failed: %v", errHandshake, errClose)
 			}
@@ -342,19 +276,15 @@ func (d *httpConnectDialer) DialContext(ctx context.Context, network, addr strin
 		}
 	}
 
-	header, errHeader := d.connectRequestHeader(ctx, addr)
-	if errHeader != nil {
-		if errClose := conn.Close(); errClose != nil {
-			return nil, fmt.Errorf("build CONNECT header failed: %w; close failed: %v", errHeader, errClose)
-		}
-		return nil, fmt.Errorf("build CONNECT header failed: %w", errHeader)
-	}
 	req := (&http.Request{
 		Method: http.MethodConnect,
 		URL:    &url.URL{Host: addr},
 		Host:   addr,
-		Header: header,
+		Header: make(http.Header),
 	}).WithContext(ctx)
+	if d.proxyURL.User != nil {
+		req.Header.Set("Proxy-Authorization", proxyAuthorization(d.proxyURL.User))
+	}
 	if errWrite := req.Write(conn); errWrite != nil {
 		errWrite = preferContextError(ctx, errWrite)
 		if errClose := conn.Close(); errClose != nil {
@@ -372,20 +302,6 @@ func (d *httpConnectDialer) DialContext(ctx context.Context, network, addr strin
 		}
 		return nil, fmt.Errorf("read CONNECT response failed: %w", errRead)
 	}
-	// Before the status check, as net/http does: the hook is the caller's chance to
-	// judge a response this code would otherwise accept or reject on status alone.
-	if d.onConnectResponse != nil {
-		if errHook := d.onConnectResponse(ctx, d.proxyURL, req, resp); errHook != nil {
-			if resp.Body != nil {
-				_ = resp.Body.Close()
-			}
-			if errClose := conn.Close(); errClose != nil {
-				return nil, fmt.Errorf("OnProxyConnectResponse rejected the CONNECT response: %w; close failed: %v", errHook, errClose)
-			}
-			return nil, fmt.Errorf("OnProxyConnectResponse rejected the CONNECT response: %w", errHook)
-		}
-	}
-
 	if resp.StatusCode != http.StatusOK {
 		if resp.Body != nil {
 			_ = resp.Body.Close()
@@ -457,6 +373,35 @@ func Redact(raw string) string {
 		redacted.User = url.User("redacted")
 	}
 	return redacted.String()
+}
+
+// proxyTLSConfig derives the TLS settings for the connection to an HTTPS proxy.
+func proxyTLSConfig(base *tls.Config, serverName string) *tls.Config {
+	cfg := base.Clone()
+	if cfg == nil {
+		cfg = &tls.Config{}
+	}
+	// Filled in only when the caller left it empty, as net/http's addTLS does. A proxy
+	// reached at an address its certificate does not carry is the caller's to name.
+	if cfg.ServerName == "" {
+		cfg.ServerName = serverName
+	}
+	// ALPN, by contrast, is pinned unconditionally, and must stay that way: it is the fix.
+	// CONNECT is written as an HTTP/1.1 request, so a proxy allowed to select h2 receives
+	// one on an HTTP/2 connection and drops the whole thing.
+	cfg.NextProtos = []string{"http/1.1"}
+	return cfg
+}
+
+// preferContextError reports the cancellation rather than what closing the connection
+// produced. The dialer unblocks a stuck read by closing the connection, so the I/O error
+// a caller would otherwise see is "use of closed network connection" — true, and useless
+// for telling a canceled request apart from a broken proxy.
+func preferContextError(ctx context.Context, err error) error {
+	if errContext := ctx.Err(); errContext != nil {
+		return errContext
+	}
+	return err
 }
 
 type bufferedConn struct {

--- a/sdk/proxyutil/proxy.go
+++ b/sdk/proxyutil/proxy.go
@@ -270,14 +270,19 @@ func (d *httpConnectDialer) Dial(network, addr string) (net.Conn, error) {
 }
 
 // proxyTLSConfig derives the TLS settings for the connection to an HTTPS proxy.
-// ALPN is pinned to http/1.1 because CONNECT is written as an HTTP/1.1 request:
-// letting the proxy select h2 would put an HTTP/1.1 request on an HTTP/2 connection.
 func proxyTLSConfig(base *tls.Config, serverName string) *tls.Config {
 	cfg := base.Clone()
 	if cfg == nil {
 		cfg = &tls.Config{}
 	}
-	cfg.ServerName = serverName
+	// Filled in only when the caller left it empty, as net/http's addTLS does. A proxy
+	// reached at an address its certificate does not carry is the caller's to name.
+	if cfg.ServerName == "" {
+		cfg.ServerName = serverName
+	}
+	// ALPN, by contrast, is pinned unconditionally, and must stay that way: it is the fix.
+	// CONNECT is written as an HTTP/1.1 request, so a proxy allowed to select h2 receives
+	// one on an HTTP/2 connection and drops the whole thing.
 	cfg.NextProtos = []string{"http/1.1"}
 	return cfg
 }

--- a/sdk/proxyutil/proxy.go
+++ b/sdk/proxyutil/proxy.go
@@ -88,6 +88,13 @@ func NewDirectTransport() *http.Transport {
 }
 
 // BuildHTTPTransport constructs an HTTP transport for the provided proxy setting.
+//
+// For an https:// proxy the returned transport carries a DialTLSContext bound to itself,
+// so use it as returned. http.Transport.Clone copies that hook as a function value: a
+// clone keeps consulting the original for the connection to the proxy, and TLS or dial
+// settings changed on the clone never reach that leg. The hook's signature offers no way
+// to learn which transport is calling it, so build a second transport rather than
+// cloning one.
 func BuildHTTPTransport(raw string) (*http.Transport, Mode, error) {
 	setting, errParse := Parse(raw)
 	if errParse != nil {

--- a/sdk/proxyutil/proxy.go
+++ b/sdk/proxyutil/proxy.go
@@ -132,9 +132,8 @@ func BuildHTTPTransport(raw string) (*http.Transport, Mode, error) {
 			// after stays net/http's — CONNECT with its headers and hooks, the bound on
 			// that exchange, the target handshake and its own ALPN. Taking any of it over
 			// would mean reimplementing it, and then owning every guard it already has.
-			baseDialContext := transport.DialContext
 			transport.DialTLSContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-				return dialProxyTLS(ctx, network, addr, baseDialContext, transport, setting.URL)
+				return dialProxyTLS(ctx, network, addr, transport, setting.URL)
 			}
 		}
 		return transport, setting.Mode, nil
@@ -146,17 +145,12 @@ func BuildHTTPTransport(raw string) (*http.Transport, Mode, error) {
 // dialProxyTLS makes the TLS connection to an HTTPS proxy, pinning that leg's ALPN to
 // http/1.1 so the CONNECT net/http writes next lands on an HTTP/1.1 connection.
 //
-// TLSClientConfig and TLSHandshakeTimeout are read here rather than captured up front:
-// net/http documents that it ignores both once DialTLSContext is set, so honouring them
-// falls to this function, and callers set them after the transport is built.
-func dialProxyTLS(ctx context.Context, network, addr string,
-	baseDialContext func(context.Context, string, string) (net.Conn, error),
-	transport *http.Transport, proxyURL *url.URL) (net.Conn, error) {
-	dial := baseDialContext
-	if dial == nil {
-		dial = (&net.Dialer{}).DialContext
-	}
-	conn, errDial := dial(ctx, network, addr)
+// Every hook it needs is read from the transport at dial time, never captured when the
+// transport is built: callers install them afterwards, and on this path they have no
+// other way in — every first hop goes to the proxy, so this function is the only thing
+// that dials at all.
+func dialProxyTLS(ctx context.Context, network, addr string, transport *http.Transport, proxyURL *url.URL) (net.Conn, error) {
+	conn, errDial := dialProxyTCP(ctx, transport, network, addr)
 	if errDial != nil {
 		return nil, errDial
 	}
@@ -175,6 +169,19 @@ func dialProxyTLS(ctx context.Context, network, addr string,
 		return nil, fmt.Errorf("HTTPS proxy TLS handshake failed: %w", errHandshake)
 	}
 	return tlsConn, nil
+}
+
+// dialProxyTCP mirrors net/http's Transport.dial, down to the order it consults the
+// hooks, so a caller that installs custom routing, a local bind or a test dialer keeps
+// reaching the proxy through it.
+func dialProxyTCP(ctx context.Context, transport *http.Transport, network, addr string) (net.Conn, error) {
+	if transport.DialContext != nil {
+		return transport.DialContext(ctx, network, addr)
+	}
+	if transport.Dial != nil {
+		return transport.Dial(network, addr)
+	}
+	return (&net.Dialer{}).DialContext(ctx, network, addr)
 }
 
 // BuildDialer constructs a proxy dialer for settings that operate at the connection layer.

--- a/sdk/proxyutil/proxy.go
+++ b/sdk/proxyutil/proxy.go
@@ -193,6 +193,14 @@ type httpConnectDialer struct {
 	tlsHandshakeTimeout time.Duration
 }
 
+// proxyConnectTimeout bounds the CONNECT exchange with the proxy. net/http applies the
+// same one-minute bound in dialConn, for the same reason: a proxy that takes the
+// connection and then stops replying would otherwise hold the caller — and leak the
+// goroutine reading the response — until the request context is canceled, and most
+// callers here pass a context that never is. Taking over proxy setup means taking over
+// this guard too. A var, not a const, so tests need not wait a minute for it.
+var proxyConnectTimeout = time.Minute
+
 // contextDialerFunc adapts a net.Dialer-style dial function to proxy.Dialer so an
 // existing transport's dialer, timeouts included, can carry the proxy connection.
 type contextDialerFunc func(ctx context.Context, network, addr string) (net.Conn, error)
@@ -203,6 +211,17 @@ func (f contextDialerFunc) Dial(network, addr string) (net.Conn, error) {
 
 func (f contextDialerFunc) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	return f(ctx, network, addr)
+}
+
+// preferContextError reports the deadline rather than what closing the connection
+// produced. The bound above takes effect by closing the connection, so the I/O error
+// the caller would otherwise see is "use of closed network connection" — true, and
+// useless for telling a slow proxy apart from a broken one.
+func preferContextError(ctx context.Context, err error) error {
+	if errContext := ctx.Err(); errContext != nil {
+		return errContext
+	}
+	return err
 }
 
 func (d *httpConnectDialer) Dial(network, addr string) (net.Conn, error) {
@@ -263,16 +282,33 @@ func (d *httpConnectDialer) DialContext(ctx context.Context, network, addr strin
 		conn = tlsConn
 	}
 
+	// Covers the write as well as the read: a proxy that stops draining blocks req.Write
+	// just as thoroughly as one that never answers. Closing the connection is what
+	// unblocks either of them, so the deadline has to reach the connection, not the request.
+	connectCtx, cancelConnect := context.WithTimeout(ctx, proxyConnectTimeout)
+	defer cancelConnect()
+	connectCancelDone := make(chan struct{})
+	stopConnectCancel := context.AfterFunc(connectCtx, func() {
+		_ = conn.Close()
+		close(connectCancelDone)
+	})
+	defer func() {
+		if !stopConnectCancel() {
+			<-connectCancelDone
+		}
+	}()
+
 	req := (&http.Request{
 		Method: http.MethodConnect,
 		URL:    &url.URL{Host: addr},
 		Host:   addr,
 		Header: make(http.Header),
-	}).WithContext(ctx)
+	}).WithContext(connectCtx)
 	if d.proxyURL.User != nil {
 		req.Header.Set("Proxy-Authorization", proxyAuthorization(d.proxyURL.User))
 	}
 	if errWrite := req.Write(conn); errWrite != nil {
+		errWrite = preferContextError(connectCtx, errWrite)
 		if errClose := conn.Close(); errClose != nil {
 			return nil, fmt.Errorf("write CONNECT request failed: %w; close failed: %v", errWrite, errClose)
 		}
@@ -282,6 +318,7 @@ func (d *httpConnectDialer) DialContext(ctx context.Context, network, addr strin
 	reader := bufio.NewReader(conn)
 	resp, errRead := http.ReadResponse(reader, req)
 	if errRead != nil {
+		errRead = preferContextError(connectCtx, errRead)
 		if errClose := conn.Close(); errClose != nil {
 			return nil, fmt.Errorf("read CONNECT response failed: %w; close failed: %v", errRead, errClose)
 		}

--- a/sdk/proxyutil/proxy.go
+++ b/sdk/proxyutil/proxy.go
@@ -143,6 +143,7 @@ func BuildHTTPTransport(raw string) (*http.Transport, Mode, error) {
 					dialer:              baseDialer,
 					tlsConfig:           transport.TLSClientConfig,
 					tlsHandshakeTimeout: transport.TLSHandshakeTimeout,
+					connectTimeout:      defaultProxyConnectTimeout,
 				}
 				return dialer.DialContext(ctx, network, addr)
 			}
@@ -169,7 +170,11 @@ func BuildDialer(raw string) (proxy.Dialer, Mode, error) {
 		return proxy.Direct, setting.Mode, nil
 	case ModeProxy:
 		if setting.URL.Scheme == "http" || setting.URL.Scheme == "https" {
-			return &httpConnectDialer{proxyURL: setting.URL, dialer: proxy.Direct}, setting.Mode, nil
+			return &httpConnectDialer{
+				proxyURL:       setting.URL,
+				dialer:         proxy.Direct,
+				connectTimeout: defaultProxyConnectTimeout,
+			}, setting.Mode, nil
 		}
 		dialer, errDialer := proxy.FromURL(setting.URL, proxy.Direct)
 		if errDialer != nil {
@@ -191,15 +196,16 @@ type httpConnectDialer struct {
 	// the tunnel here takes it out of reach of http.Transport.TLSHandshakeTimeout,
 	// so callers that rely on that bound must pass it through. Zero means no bound.
 	tlsHandshakeTimeout time.Duration
+	// connectTimeout bounds the CONNECT exchange. Zero means no bound.
+	connectTimeout time.Duration
 }
 
-// proxyConnectTimeout bounds the CONNECT exchange with the proxy. net/http applies the
-// same one-minute bound in dialConn, for the same reason: a proxy that takes the
-// connection and then stops replying would otherwise hold the caller — and leak the
-// goroutine reading the response — until the request context is canceled, and most
-// callers here pass a context that never is. Taking over proxy setup means taking over
-// this guard too. A var, not a const, so tests need not wait a minute for it.
-var proxyConnectTimeout = time.Minute
+// defaultProxyConnectTimeout bounds the CONNECT exchange with the proxy. net/http applies
+// the same one-minute bound in dialConn, for the same reason: a proxy that takes the
+// connection and then stops replying would otherwise hold the caller until the request
+// context is canceled, and most callers here pass a context that never is. Taking over
+// proxy setup means taking over this guard too.
+const defaultProxyConnectTimeout = time.Minute
 
 // contextDialerFunc adapts a net.Dialer-style dial function to proxy.Dialer so an
 // existing transport's dialer, timeouts included, can carry the proxy connection.
@@ -282,33 +288,31 @@ func (d *httpConnectDialer) DialContext(ctx context.Context, network, addr strin
 		conn = tlsConn
 	}
 
-	// Covers the write as well as the read: a proxy that stops draining blocks req.Write
-	// just as thoroughly as one that never answers. Closing the connection is what
-	// unblocks either of them, so the deadline has to reach the connection, not the request.
-	connectCtx, cancelConnect := context.WithTimeout(ctx, proxyConnectTimeout)
-	defer cancelConnect()
-	connectCancelDone := make(chan struct{})
-	stopConnectCancel := context.AfterFunc(connectCtx, func() {
-		_ = conn.Close()
-		close(connectCancelDone)
-	})
-	defer func() {
-		if !stopConnectCancel() {
-			<-connectCancelDone
+	// A socket deadline rather than a second context watcher: cancellation of ctx is
+	// already covered above, and the only thing left to bound is the proxy going quiet
+	// while ctx never ends. The netpoller enforces this one with no timer, goroutine or
+	// channel of its own, and it covers the write as well as the read — a proxy that
+	// stops draining blocks req.Write just as thoroughly as one that never answers.
+	if d.connectTimeout > 0 {
+		if errDeadline := conn.SetDeadline(time.Now().Add(d.connectTimeout)); errDeadline != nil {
+			if errClose := conn.Close(); errClose != nil {
+				return nil, fmt.Errorf("set CONNECT deadline failed: %w; close failed: %v", errDeadline, errClose)
+			}
+			return nil, fmt.Errorf("set CONNECT deadline failed: %w", errDeadline)
 		}
-	}()
+	}
 
 	req := (&http.Request{
 		Method: http.MethodConnect,
 		URL:    &url.URL{Host: addr},
 		Host:   addr,
 		Header: make(http.Header),
-	}).WithContext(connectCtx)
+	}).WithContext(ctx)
 	if d.proxyURL.User != nil {
 		req.Header.Set("Proxy-Authorization", proxyAuthorization(d.proxyURL.User))
 	}
 	if errWrite := req.Write(conn); errWrite != nil {
-		errWrite = preferContextError(connectCtx, errWrite)
+		errWrite = preferContextError(ctx, errWrite)
 		if errClose := conn.Close(); errClose != nil {
 			return nil, fmt.Errorf("write CONNECT request failed: %w; close failed: %v", errWrite, errClose)
 		}
@@ -318,7 +322,7 @@ func (d *httpConnectDialer) DialContext(ctx context.Context, network, addr strin
 	reader := bufio.NewReader(conn)
 	resp, errRead := http.ReadResponse(reader, req)
 	if errRead != nil {
-		errRead = preferContextError(connectCtx, errRead)
+		errRead = preferContextError(ctx, errRead)
 		if errClose := conn.Close(); errClose != nil {
 			return nil, fmt.Errorf("read CONNECT response failed: %w; close failed: %v", errRead, errClose)
 		}
@@ -332,6 +336,17 @@ func (d *httpConnectDialer) DialContext(ctx context.Context, network, addr strin
 			return nil, fmt.Errorf("proxy CONNECT returned status %s; close failed: %v", resp.Status, errClose)
 		}
 		return nil, fmt.Errorf("proxy CONNECT returned status %s", resp.Status)
+	}
+
+	// The deadline belongs to CONNECT, not to the tunnel. Leaving it on would cut the
+	// caller's own request short at whatever was left of the minute.
+	if d.connectTimeout > 0 {
+		if errDeadline := conn.SetDeadline(time.Time{}); errDeadline != nil {
+			if errClose := conn.Close(); errClose != nil {
+				return nil, fmt.Errorf("clear CONNECT deadline failed: %w; close failed: %v", errDeadline, errClose)
+			}
+			return nil, fmt.Errorf("clear CONNECT deadline failed: %w", errDeadline)
+		}
 	}
 
 	if errContext := ctx.Err(); errContext != nil {

--- a/sdk/proxyutil/proxy.go
+++ b/sdk/proxyutil/proxy.go
@@ -118,6 +118,27 @@ func BuildHTTPTransport(raw string) (*http.Transport, Mode, error) {
 			return transport, setting.Mode, nil
 		}
 		transport := cloneDefaultTransport()
+		if setting.URL.Scheme == "https" {
+			// http.Transport cannot be used to reach an HTTPS proxy: it hands the
+			// transport-wide TLSClientConfig — whose NextProtos gain "h2" as soon as
+			// HTTP/2 is configured — to the handshake with the proxy itself, and then
+			// writes an HTTP/1.1 CONNECT over whatever ALPN selected. A proxy that
+			// picks h2 sees a bogus HTTP/2 preface and drops the connection, which
+			// surfaces to callers as "unexpected EOF". Tunnel through the CONNECT
+			// dialer instead; protocol negotiation with the target is untouched.
+			transport.Proxy = nil
+			transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				// Built per dial: TLSClientConfig is still nil here and gets populated
+				// later, both by callers and by Go's own HTTP/2 setup.
+				dialer := &httpConnectDialer{
+					proxyURL:  setting.URL,
+					dialer:    proxy.Direct,
+					tlsConfig: transport.TLSClientConfig,
+				}
+				return dialer.DialContext(ctx, network, addr)
+			}
+			return transport, setting.Mode, nil
+		}
 		transport.Proxy = http.ProxyURL(setting.URL)
 		return transport, setting.Mode, nil
 	default:
@@ -154,10 +175,26 @@ func BuildDialer(raw string) (proxy.Dialer, Mode, error) {
 type httpConnectDialer struct {
 	proxyURL *url.URL
 	dialer   proxy.Dialer
+	// tlsConfig carries caller-supplied TLS settings (roots, client certs) for the
+	// handshake with an HTTPS proxy. Nil means defaults.
+	tlsConfig *tls.Config
 }
 
 func (d *httpConnectDialer) Dial(network, addr string) (net.Conn, error) {
 	return d.DialContext(context.Background(), network, addr)
+}
+
+// proxyTLSConfig derives the TLS settings for the connection to an HTTPS proxy.
+// ALPN is pinned to http/1.1 because CONNECT is written as an HTTP/1.1 request:
+// letting the proxy select h2 would put an HTTP/1.1 request on an HTTP/2 connection.
+func proxyTLSConfig(base *tls.Config, serverName string) *tls.Config {
+	cfg := base.Clone()
+	if cfg == nil {
+		cfg = &tls.Config{}
+	}
+	cfg.ServerName = serverName
+	cfg.NextProtos = []string{"http/1.1"}
+	return cfg
 }
 
 func (d *httpConnectDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -185,7 +222,7 @@ func (d *httpConnectDialer) DialContext(ctx context.Context, network, addr strin
 		}
 	}()
 	if d.proxyURL.Scheme == "https" {
-		tlsConn := tls.Client(conn, &tls.Config{ServerName: d.proxyURL.Hostname()})
+		tlsConn := tls.Client(conn, proxyTLSConfig(d.tlsConfig, d.proxyURL.Hostname()))
 		if errHandshake := tlsConn.HandshakeContext(ctx); errHandshake != nil {
 			if errClose := conn.Close(); errClose != nil {
 				return nil, fmt.Errorf("HTTPS proxy TLS handshake failed: %w; close failed: %v", errHandshake, errClose)

--- a/sdk/proxyutil/proxy_test.go
+++ b/sdk/proxyutil/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -575,5 +576,70 @@ func TestBuildHTTPTransportHTTPSProxyBoundsTLSHandshake(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("dial through a stalled HTTPS proxy was not bounded by TLSHandshakeTimeout")
+	}
+}
+
+// TestBuildDialerHTTPProxyBoundsCONNECTResponse pins the guard net/http applies in
+// dialConn: a proxy that takes the connection and then never answers CONNECT must not
+// hold a caller whose context has no deadline.
+func TestBuildDialerHTTPProxyBoundsCONNECTResponse(t *testing.T) {
+	// Not parallel: it swaps the package-level bound, the same way net/http's own tests
+	// drive testHookProxyConnectTimeout.
+	original := proxyConnectTimeout
+	proxyConnectTimeout = 200 * time.Millisecond
+	defer func() { proxyConnectTimeout = original }()
+
+	listener, errListen := net.Listen("tcp", "127.0.0.1:0")
+	if errListen != nil {
+		t.Fatalf("net.Listen returned error: %v", errListen)
+	}
+	defer func() {
+		if errClose := listener.Close(); errClose != nil {
+			t.Errorf("listener.Close returned error: %v", errClose)
+		}
+	}()
+	go func() {
+		conn, errAccept := listener.Accept()
+		if errAccept != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		// Read the CONNECT request, then go quiet — never write a response.
+		if _, errRead := http.ReadRequest(bufio.NewReader(conn)); errRead != nil {
+			return
+		}
+		<-time.After(30 * time.Second)
+	}()
+
+	dialer, _, errBuild := BuildDialer("http://" + listener.Addr().String())
+	if errBuild != nil {
+		t.Fatalf("BuildDialer returned error: %v", errBuild)
+	}
+	contextDialer, ok := dialer.(interface {
+		DialContext(context.Context, string, string) (net.Conn, error)
+	})
+	if !ok {
+		t.Fatal("HTTP CONNECT dialer does not support context cancellation")
+	}
+
+	dialDone := make(chan error, 1)
+	go func() {
+		conn, errDial := contextDialer.DialContext(context.Background(), "tcp", "target.example.com:443")
+		if conn != nil {
+			_ = conn.Close()
+		}
+		dialDone <- errDial
+	}()
+
+	select {
+	case errDial := <-dialDone:
+		if errDial == nil {
+			t.Fatal("dial through a silent proxy returned nil error")
+		}
+		if !errors.Is(errDial, context.DeadlineExceeded) {
+			t.Fatalf("error = %v, want it to wrap context.DeadlineExceeded", errDial)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("dial through a silent proxy was not bounded by proxyConnectTimeout")
 	}
 }

--- a/sdk/proxyutil/proxy_test.go
+++ b/sdk/proxyutil/proxy_test.go
@@ -526,3 +526,54 @@ func TestBuildHTTPTransportHTTPSProxyTunnelsThroughH2CapableProxy(t *testing.T) 
 		t.Fatal("CONNECT was sent over an h2 connection; ALPN must stay on http/1.1 for the proxy leg")
 	}
 }
+
+// TestBuildHTTPTransportHTTPSProxyBoundsTLSHandshake guards the proxy-setup timeouts that
+// move out of http.Transport's reach once the tunnel is established inside DialContext:
+// a proxy that accepts the TCP connection and then stalls must not hang the caller.
+func TestBuildHTTPTransportHTTPSProxyBoundsTLSHandshake(t *testing.T) {
+	t.Parallel()
+
+	listener, errListen := net.Listen("tcp", "127.0.0.1:0")
+	if errListen != nil {
+		t.Fatalf("net.Listen returned error: %v", errListen)
+	}
+	defer func() {
+		if errClose := listener.Close(); errClose != nil {
+			t.Errorf("listener.Close returned error: %v", errClose)
+		}
+	}()
+	go func() {
+		conn, errAccept := listener.Accept()
+		if errAccept != nil {
+			return
+		}
+		// Accept and stall: never complete the TLS handshake.
+		<-time.After(30 * time.Second)
+		_ = conn.Close()
+	}()
+
+	transport, _, errBuild := BuildHTTPTransport("https://" + listener.Addr().String())
+	if errBuild != nil {
+		t.Fatalf("BuildHTTPTransport returned error: %v", errBuild)
+	}
+	transport.TLSHandshakeTimeout = 200 * time.Millisecond
+	defer transport.CloseIdleConnections()
+
+	dialDone := make(chan error, 1)
+	go func() {
+		conn, errDial := transport.DialContext(context.Background(), "tcp", "target.example.com:443")
+		if conn != nil {
+			_ = conn.Close()
+		}
+		dialDone <- errDial
+	}()
+
+	select {
+	case errDial := <-dialDone:
+		if errDial == nil {
+			t.Fatal("dial through a stalled HTTPS proxy returned nil error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("dial through a stalled HTTPS proxy was not bounded by TLSHandshakeTimeout")
+	}
+}

--- a/sdk/proxyutil/proxy_test.go
+++ b/sdk/proxyutil/proxy_test.go
@@ -12,10 +12,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"golang.org/x/net/proxy"
 )
 
 func mustDefaultTransport(t *testing.T) *http.Transport {
@@ -583,11 +586,7 @@ func TestBuildHTTPTransportHTTPSProxyBoundsTLSHandshake(t *testing.T) {
 // dialConn: a proxy that takes the connection and then never answers CONNECT must not
 // hold a caller whose context has no deadline.
 func TestBuildDialerHTTPProxyBoundsCONNECTResponse(t *testing.T) {
-	// Not parallel: it swaps the package-level bound, the same way net/http's own tests
-	// drive testHookProxyConnectTimeout.
-	original := proxyConnectTimeout
-	proxyConnectTimeout = 200 * time.Millisecond
-	defer func() { proxyConnectTimeout = original }()
+	t.Parallel()
 
 	listener, errListen := net.Listen("tcp", "127.0.0.1:0")
 	if errListen != nil {
@@ -598,33 +597,39 @@ func TestBuildDialerHTTPProxyBoundsCONNECTResponse(t *testing.T) {
 			t.Errorf("listener.Close returned error: %v", errClose)
 		}
 	}()
+	accepted := make(chan net.Conn, 1)
 	go func() {
 		conn, errAccept := listener.Accept()
 		if errAccept != nil {
 			return
 		}
-		defer func() { _ = conn.Close() }()
+		accepted <- conn
 		// Read the CONNECT request, then go quiet — never write a response.
-		if _, errRead := http.ReadRequest(bufio.NewReader(conn)); errRead != nil {
-			return
+		_, _ = http.ReadRequest(bufio.NewReader(conn))
+	}()
+	defer func() {
+		select {
+		case conn := <-accepted:
+			_ = conn.Close()
+		default:
 		}
-		<-time.After(30 * time.Second)
 	}()
 
-	dialer, _, errBuild := BuildDialer("http://" + listener.Addr().String())
-	if errBuild != nil {
-		t.Fatalf("BuildDialer returned error: %v", errBuild)
+	proxyURL, errParse := url.Parse("http://" + listener.Addr().String())
+	if errParse != nil {
+		t.Fatalf("url.Parse returned error: %v", errParse)
 	}
-	contextDialer, ok := dialer.(interface {
-		DialContext(context.Context, string, string) (net.Conn, error)
-	})
-	if !ok {
-		t.Fatal("HTTP CONNECT dialer does not support context cancellation")
+	// Built directly rather than via BuildDialer: the bound is a field, so the test can
+	// carry a short one instead of waiting out the production minute.
+	dialer := &httpConnectDialer{
+		proxyURL:       proxyURL,
+		dialer:         proxy.Direct,
+		connectTimeout: 200 * time.Millisecond,
 	}
 
 	dialDone := make(chan error, 1)
 	go func() {
-		conn, errDial := contextDialer.DialContext(context.Background(), "tcp", "target.example.com:443")
+		conn, errDial := dialer.DialContext(context.Background(), "tcp", "target.example.com:443")
 		if conn != nil {
 			_ = conn.Close()
 		}
@@ -636,10 +641,110 @@ func TestBuildDialerHTTPProxyBoundsCONNECTResponse(t *testing.T) {
 		if errDial == nil {
 			t.Fatal("dial through a silent proxy returned nil error")
 		}
-		if !errors.Is(errDial, context.DeadlineExceeded) {
-			t.Fatalf("error = %v, want it to wrap context.DeadlineExceeded", errDial)
+		if !errors.Is(errDial, os.ErrDeadlineExceeded) {
+			t.Fatalf("error = %v, want it to wrap os.ErrDeadlineExceeded", errDial)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("dial through a silent proxy was not bounded by proxyConnectTimeout")
+		t.Fatal("dial through a silent proxy was not bounded by connectTimeout")
+	}
+}
+
+// TestBuildDialerHTTPProxyCarriesCONNECTTimeout keeps the wiring honest: the guard above
+// is only worth anything if the constructor actually installs it.
+func TestBuildDialerHTTPProxyCarriesCONNECTTimeout(t *testing.T) {
+	t.Parallel()
+
+	dialer, _, errBuild := BuildDialer("http://proxy.example.com:8080")
+	if errBuild != nil {
+		t.Fatalf("BuildDialer returned error: %v", errBuild)
+	}
+	connectDialer, ok := dialer.(*httpConnectDialer)
+	if !ok {
+		t.Fatalf("dialer is %T, want *httpConnectDialer", dialer)
+	}
+	if connectDialer.connectTimeout != defaultProxyConnectTimeout {
+		t.Fatalf("connectTimeout = %v, want %v", connectDialer.connectTimeout, defaultProxyConnectTimeout)
+	}
+}
+
+// TestBuildDialerHTTPProxyClearsCONNECTDeadline guards the failure mode that would be
+// worst in production and quietest in review: the CONNECT deadline is set on the socket
+// the caller goes on to use, so failing to clear it would cut real traffic off at
+// whatever was left of the bound, mid-stream and with no proxy involved.
+func TestBuildDialerHTTPProxyClearsCONNECTDeadline(t *testing.T) {
+	t.Parallel()
+
+	const connectTimeout = 200 * time.Millisecond
+
+	target, errTarget := net.Listen("tcp", "127.0.0.1:0")
+	if errTarget != nil {
+		t.Fatalf("net.Listen returned error: %v", errTarget)
+	}
+	defer func() { _ = target.Close() }()
+	go func() {
+		conn, errAccept := target.Accept()
+		if errAccept != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _ = io.Copy(conn, conn)
+	}()
+
+	proxyListener, errProxy := net.Listen("tcp", "127.0.0.1:0")
+	if errProxy != nil {
+		t.Fatalf("net.Listen returned error: %v", errProxy)
+	}
+	defer func() { _ = proxyListener.Close() }()
+	go func() {
+		clientConn, errAccept := proxyListener.Accept()
+		if errAccept != nil {
+			return
+		}
+		defer func() { _ = clientConn.Close() }()
+		request, errRead := http.ReadRequest(bufio.NewReader(clientConn))
+		if errRead != nil {
+			return
+		}
+		upstreamConn, errDial := net.Dial("tcp", request.Host)
+		if errDial != nil {
+			return
+		}
+		defer func() { _ = upstreamConn.Close() }()
+		if _, errWrite := io.WriteString(clientConn, "HTTP/1.1 200 Connection Established\r\n\r\n"); errWrite != nil {
+			return
+		}
+		go func() { _, _ = io.Copy(upstreamConn, clientConn) }()
+		_, _ = io.Copy(clientConn, upstreamConn)
+	}()
+
+	proxyURL, errParse := url.Parse("http://" + proxyListener.Addr().String())
+	if errParse != nil {
+		t.Fatalf("url.Parse returned error: %v", errParse)
+	}
+	dialer := &httpConnectDialer{
+		proxyURL:       proxyURL,
+		dialer:         proxy.Direct,
+		connectTimeout: connectTimeout,
+	}
+
+	conn, errDial := dialer.DialContext(context.Background(), "tcp", target.Addr().String())
+	if errDial != nil {
+		t.Fatalf("dialer.DialContext returned error: %v", errDial)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Idle past the bound, then use the tunnel. A deadline left over from CONNECT
+	// expires here and turns this into an i/o timeout.
+	<-time.After(2 * connectTimeout)
+
+	if _, errWrite := conn.Write([]byte("ping")); errWrite != nil {
+		t.Fatalf("write after the CONNECT bound elapsed failed: %v", errWrite)
+	}
+	buf := make([]byte, 4)
+	if _, errRead := io.ReadFull(conn, buf); errRead != nil {
+		t.Fatalf("read after the CONNECT bound elapsed failed: %v", errRead)
+	}
+	if string(buf) != "ping" {
+		t.Fatalf("tunnelled payload = %q, want ping", string(buf))
 	}
 }

--- a/sdk/proxyutil/proxy_test.go
+++ b/sdk/proxyutil/proxy_test.go
@@ -3,12 +3,16 @@ package proxyutil
 import (
 	"bufio"
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -393,5 +397,132 @@ func TestParseErrorDoesNotExposeProxyCredentials(t *testing.T) {
 		strings.Contains(errParse.Error(), "user") ||
 		strings.Contains(errParse.Error(), "secret") {
 		t.Fatalf("parse error exposes proxy credentials: %q", errParse.Error())
+	}
+}
+
+func TestBuildHTTPTransportHTTPSProxyUsesCONNECTDialer(t *testing.T) {
+	t.Parallel()
+
+	transport, mode, errBuild := BuildHTTPTransport("https://proxy.example.com:8443")
+	if errBuild != nil {
+		t.Fatalf("BuildHTTPTransport returned error: %v", errBuild)
+	}
+	if mode != ModeProxy {
+		t.Fatalf("mode = %d, want %d", mode, ModeProxy)
+	}
+	if transport == nil {
+		t.Fatal("expected transport, got nil")
+	}
+	if transport.Proxy != nil {
+		t.Fatal("expected HTTPS proxy transport to bypass http proxy function")
+	}
+	if transport.DialContext == nil {
+		t.Fatal("expected HTTPS proxy transport to have custom DialContext")
+	}
+}
+
+// TestBuildHTTPTransportHTTPSProxyTunnelsThroughH2CapableProxy pins the reason the HTTPS
+// proxy branch cannot use http.Transport.Proxy: Go reuses TLSClientConfig (whose NextProtos
+// carry "h2" once HTTP/2 is configured) for the handshake with the proxy itself, then writes
+// an HTTP/1.1 CONNECT over whatever was negotiated. A proxy that selects h2 receives a
+// malformed stream and drops the connection, surfacing as "unexpected EOF".
+func TestBuildHTTPTransportHTTPSProxyTunnelsThroughH2CapableProxy(t *testing.T) {
+	t.Parallel()
+
+	target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, errWrite := io.WriteString(w, "pong"); errWrite != nil {
+			t.Errorf("target write failed: %v", errWrite)
+		}
+	}))
+	defer target.Close()
+
+	var negotiatedProtocol atomic.Value
+	proxyServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.TLS != nil {
+			negotiatedProtocol.Store(r.TLS.NegotiatedProtocol)
+		}
+		if r.Method != http.MethodConnect {
+			http.Error(w, "expected CONNECT", http.StatusMethodNotAllowed)
+			return
+		}
+		wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
+		if r.Header.Get("Proxy-Authorization") != wantAuth {
+			http.Error(w, "missing proxy credentials", http.StatusProxyAuthRequired)
+			return
+		}
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "connection is not hijackable", http.StatusInternalServerError)
+			return
+		}
+		upstreamConn, errDial := net.Dial("tcp", r.Host)
+		if errDial != nil {
+			http.Error(w, "dial upstream failed", http.StatusBadGateway)
+			return
+		}
+		clientConn, buffered, errHijack := hijacker.Hijack()
+		if errHijack != nil {
+			_ = upstreamConn.Close()
+			return
+		}
+		if _, errWrite := io.WriteString(clientConn, "HTTP/1.1 200 Connection Established\r\n\r\n"); errWrite != nil {
+			_ = upstreamConn.Close()
+			_ = clientConn.Close()
+			return
+		}
+		go func() {
+			defer func() { _ = upstreamConn.Close() }()
+			_, _ = io.Copy(upstreamConn, buffered)
+		}()
+		go func() {
+			defer func() { _ = clientConn.Close() }()
+			_, _ = io.Copy(clientConn, upstreamConn)
+		}()
+	}))
+	// Mirror a real HTTPS proxy: h2 is offered and preferred, http/1.1 stays available.
+	proxyServer.EnableHTTP2 = true
+	proxyServer.TLS = &tls.Config{NextProtos: []string{"h2", "http/1.1"}}
+	proxyServer.StartTLS()
+	defer proxyServer.Close()
+
+	proxyURL, errParseProxy := url.Parse(proxyServer.URL)
+	if errParseProxy != nil {
+		t.Fatalf("url.Parse returned error: %v", errParseProxy)
+	}
+
+	transport, mode, errBuild := BuildHTTPTransport("https://user:pass@" + proxyURL.Host)
+	if errBuild != nil {
+		t.Fatalf("BuildHTTPTransport returned error: %v", errBuild)
+	}
+	if mode != ModeProxy {
+		t.Fatalf("mode = %d, want %d", mode, ModeProxy)
+	}
+	proxyClientTransport, ok := proxyServer.Client().Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("httptest proxy client transport is not an *http.Transport")
+	}
+	// The httptest servers share one self-signed certificate, so a single pool covers both legs.
+	transport.TLSClientConfig = proxyClientTransport.TLSClientConfig.Clone()
+	defer transport.CloseIdleConnections()
+
+	response, errGet := (&http.Client{Transport: transport, Timeout: 10 * time.Second}).Get(target.URL)
+	if errGet != nil {
+		t.Fatalf("request through HTTPS proxy failed: %v", errGet)
+	}
+	defer func() {
+		if errClose := response.Body.Close(); errClose != nil {
+			t.Errorf("response.Body.Close returned error: %v", errClose)
+		}
+	}()
+
+	body, errRead := io.ReadAll(response.Body)
+	if errRead != nil {
+		t.Fatalf("io.ReadAll returned error: %v", errRead)
+	}
+	if string(body) != "pong" {
+		t.Fatalf("body = %q, want pong", string(body))
+	}
+	if got, _ := negotiatedProtocol.Load().(string); got == "h2" {
+		t.Fatal("CONNECT was sent over an h2 connection; ALPN must stay on http/1.1 for the proxy leg")
 	}
 }

--- a/sdk/proxyutil/proxy_test.go
+++ b/sdk/proxyutil/proxy_test.go
@@ -748,3 +748,182 @@ func TestBuildDialerHTTPProxyClearsCONNECTDeadline(t *testing.T) {
 		t.Fatalf("tunnelled payload = %q, want ping", string(buf))
 	}
 }
+
+// TestBuildHTTPTransportHTTPSProxyHonoursCONNECTHooks pins the three knobs http.Transport
+// documents for the CONNECT request. Doing the CONNECT ourselves puts them out of its
+// reach, so they only keep working as long as this dialer carries them.
+func TestBuildHTTPTransportHTTPSProxyHonoursCONNECTHooks(t *testing.T) {
+	t.Parallel()
+
+	type observed struct {
+		tenant string
+		trace  string
+		auth   string
+	}
+	seen := make(chan observed, 1)
+
+	target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, errWrite := io.WriteString(w, "pong"); errWrite != nil {
+			t.Errorf("target write failed: %v", errWrite)
+		}
+	}))
+	defer target.Close()
+
+	proxyServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodConnect {
+			http.Error(w, "expected CONNECT", http.StatusMethodNotAllowed)
+			return
+		}
+		seen <- observed{
+			tenant: r.Header.Get("X-Tenant"),
+			trace:  r.Header.Get("X-Trace"),
+			auth:   r.Header.Get("Proxy-Authorization"),
+		}
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "connection is not hijackable", http.StatusInternalServerError)
+			return
+		}
+		upstreamConn, errDial := net.Dial("tcp", r.Host)
+		if errDial != nil {
+			http.Error(w, "dial upstream failed", http.StatusBadGateway)
+			return
+		}
+		clientConn, buffered, errHijack := hijacker.Hijack()
+		if errHijack != nil {
+			_ = upstreamConn.Close()
+			return
+		}
+		if _, errWrite := io.WriteString(clientConn, "HTTP/1.1 200 Connection Established\r\nX-Proxy-Note: hello\r\n\r\n"); errWrite != nil {
+			_ = upstreamConn.Close()
+			_ = clientConn.Close()
+			return
+		}
+		go func() {
+			defer func() { _ = upstreamConn.Close() }()
+			_, _ = io.Copy(upstreamConn, buffered)
+		}()
+		go func() {
+			defer func() { _ = clientConn.Close() }()
+			_, _ = io.Copy(clientConn, upstreamConn)
+		}()
+	}))
+	proxyServer.EnableHTTP2 = true
+	proxyServer.TLS = &tls.Config{NextProtos: []string{"h2", "http/1.1"}}
+	proxyServer.StartTLS()
+	defer proxyServer.Close()
+
+	proxyURL, errParseProxy := url.Parse(proxyServer.URL)
+	if errParseProxy != nil {
+		t.Fatalf("url.Parse returned error: %v", errParseProxy)
+	}
+
+	transport, _, errBuild := BuildHTTPTransport("https://user:pass@" + proxyURL.Host)
+	if errBuild != nil {
+		t.Fatalf("BuildHTTPTransport returned error: %v", errBuild)
+	}
+	proxyClientTransport, ok := proxyServer.Client().Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("httptest proxy client transport is not an *http.Transport")
+	}
+	transport.TLSClientConfig = proxyClientTransport.TLSClientConfig.Clone()
+	defer transport.CloseIdleConnections()
+
+	// Kept by the caller, so the dialer must not write Proxy-Authorization into it.
+	callerHeader := http.Header{"X-Tenant": []string{"acme"}}
+	transport.ProxyConnectHeader = callerHeader
+	transport.GetProxyConnectHeader = func(_ context.Context, _ *url.URL, connectTarget string) (http.Header, error) {
+		// Takes precedence over ProxyConnectHeader, so X-Tenant must NOT arrive.
+		return http.Header{"X-Trace": []string{connectTarget}}, nil
+	}
+	var hookResponseNote string
+	transport.OnProxyConnectResponse = func(_ context.Context, _ *url.URL, _ *http.Request, connectRes *http.Response) error {
+		hookResponseNote = connectRes.Header.Get("X-Proxy-Note")
+		return nil
+	}
+
+	response, errGet := (&http.Client{Transport: transport, Timeout: 10 * time.Second}).Get(target.URL)
+	if errGet != nil {
+		t.Fatalf("request through HTTPS proxy failed: %v", errGet)
+	}
+	defer func() {
+		if errClose := response.Body.Close(); errClose != nil {
+			t.Errorf("response.Body.Close returned error: %v", errClose)
+		}
+	}()
+	if _, errRead := io.ReadAll(response.Body); errRead != nil {
+		t.Fatalf("io.ReadAll returned error: %v", errRead)
+	}
+
+	var got observed
+	select {
+	case got = <-seen:
+	case <-time.After(5 * time.Second):
+		t.Fatal("proxy never saw a CONNECT request")
+	}
+
+	targetHost := strings.TrimPrefix(target.URL, "https://")
+	if got.trace != targetHost {
+		t.Fatalf("X-Trace = %q, want %q — GetProxyConnectHeader was not applied", got.trace, targetHost)
+	}
+	if got.tenant != "" {
+		t.Fatalf("X-Tenant = %q, want empty — GetProxyConnectHeader must win over ProxyConnectHeader", got.tenant)
+	}
+	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	if got.auth != wantAuth {
+		t.Fatalf("Proxy-Authorization = %q, want %q", got.auth, wantAuth)
+	}
+	if hookResponseNote != "hello" {
+		t.Fatalf("OnProxyConnectResponse saw X-Proxy-Note %q, want hello", hookResponseNote)
+	}
+	if len(callerHeader) != 1 || callerHeader.Get("X-Tenant") != "acme" {
+		t.Fatalf("caller header was mutated: %v", callerHeader)
+	}
+}
+
+// TestBuildHTTPTransportHTTPSProxyOnConnectResponseRejects pins the other half of the
+// hook: it runs before the status check, so it can refuse a CONNECT this code would
+// otherwise have accepted.
+func TestBuildHTTPTransportHTTPSProxyOnConnectResponseRejects(t *testing.T) {
+	t.Parallel()
+
+	listener, errListen := net.Listen("tcp", "127.0.0.1:0")
+	if errListen != nil {
+		t.Fatalf("net.Listen returned error: %v", errListen)
+	}
+	defer func() { _ = listener.Close() }()
+	go func() {
+		conn, errAccept := listener.Accept()
+		if errAccept != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		if _, errRead := http.ReadRequest(bufio.NewReader(conn)); errRead != nil {
+			return
+		}
+		_, _ = io.WriteString(conn, "HTTP/1.1 200 Connection Established\r\n\r\n")
+		<-time.After(time.Second)
+	}()
+
+	proxyURL, errParse := url.Parse("http://" + listener.Addr().String())
+	if errParse != nil {
+		t.Fatalf("url.Parse returned error: %v", errParse)
+	}
+	rejected := errors.New("proxy response rejected by policy")
+	dialer := &httpConnectDialer{
+		proxyURL:       proxyURL,
+		dialer:         proxy.Direct,
+		connectTimeout: defaultProxyConnectTimeout,
+		onConnectResponse: func(_ context.Context, _ *url.URL, _ *http.Request, _ *http.Response) error {
+			return rejected
+		},
+	}
+
+	conn, errDial := dialer.DialContext(context.Background(), "tcp", "target.example.com:443")
+	if conn != nil {
+		_ = conn.Close()
+	}
+	if !errors.Is(errDial, rejected) {
+		t.Fatalf("error = %v, want it to wrap the hook's error", errDial)
+	}
+}

--- a/sdk/proxyutil/proxy_test.go
+++ b/sdk/proxyutil/proxy_test.go
@@ -404,7 +404,7 @@ func TestParseErrorDoesNotExposeProxyCredentials(t *testing.T) {
 	}
 }
 
-func TestBuildHTTPTransportHTTPSProxyUsesCONNECTDialer(t *testing.T) {
+func TestBuildHTTPTransportHTTPSProxyKeepsNetHTTPInCharge(t *testing.T) {
 	t.Parallel()
 
 	transport, mode, errBuild := BuildHTTPTransport("https://proxy.example.com:8443")
@@ -417,11 +417,27 @@ func TestBuildHTTPTransportHTTPSProxyUsesCONNECTDialer(t *testing.T) {
 	if transport == nil {
 		t.Fatal("expected transport, got nil")
 	}
-	if transport.Proxy != nil {
-		t.Fatal("expected HTTPS proxy transport to bypass http proxy function")
+
+	// Proxy must stay set: it is what keeps CONNECT — and its headers, hooks and
+	// bounds — net/http's job rather than ours.
+	if transport.Proxy == nil {
+		t.Fatal("expected HTTPS proxy transport to keep net/http's proxy function")
 	}
-	if transport.DialContext == nil {
-		t.Fatal("expected HTTPS proxy transport to have custom DialContext")
+	req, errRequest := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if errRequest != nil {
+		t.Fatalf("http.NewRequest returned error: %v", errRequest)
+	}
+	proxyURL, errProxy := transport.Proxy(req)
+	if errProxy != nil {
+		t.Fatalf("transport.Proxy returned error: %v", errProxy)
+	}
+	if proxyURL == nil || proxyURL.String() != "https://proxy.example.com:8443" {
+		t.Fatalf("proxy URL = %v, want https://proxy.example.com:8443", proxyURL)
+	}
+
+	// The one thing we do take over: how the connection to the proxy is made.
+	if transport.DialTLSContext == nil {
+		t.Fatal("expected HTTPS proxy transport to dial the proxy leg itself")
 	}
 }
 
@@ -556,7 +572,8 @@ func TestBuildHTTPTransportHTTPSProxyBoundsTLSHandshake(t *testing.T) {
 		_ = conn.Close()
 	}()
 
-	transport, _, errBuild := BuildHTTPTransport("https://" + listener.Addr().String())
+	listenerAddr := listener.Addr().String()
+	transport, _, errBuild := BuildHTTPTransport("https://" + listenerAddr)
 	if errBuild != nil {
 		t.Fatalf("BuildHTTPTransport returned error: %v", errBuild)
 	}
@@ -565,7 +582,7 @@ func TestBuildHTTPTransportHTTPSProxyBoundsTLSHandshake(t *testing.T) {
 
 	dialDone := make(chan error, 1)
 	go func() {
-		conn, errDial := transport.DialContext(context.Background(), "tcp", "target.example.com:443")
+		conn, errDial := transport.DialTLSContext(context.Background(), "tcp", listenerAddr)
 		if conn != nil {
 			_ = conn.Close()
 		}
@@ -878,53 +895,6 @@ func TestBuildHTTPTransportHTTPSProxyHonoursCONNECTHooks(t *testing.T) {
 	}
 	if len(callerHeader) != 1 || callerHeader.Get("X-Tenant") != "acme" {
 		t.Fatalf("caller header was mutated: %v", callerHeader)
-	}
-}
-
-// TestBuildHTTPTransportHTTPSProxyOnConnectResponseRejects pins the other half of the
-// hook: it runs before the status check, so it can refuse a CONNECT this code would
-// otherwise have accepted.
-func TestBuildHTTPTransportHTTPSProxyOnConnectResponseRejects(t *testing.T) {
-	t.Parallel()
-
-	listener, errListen := net.Listen("tcp", "127.0.0.1:0")
-	if errListen != nil {
-		t.Fatalf("net.Listen returned error: %v", errListen)
-	}
-	defer func() { _ = listener.Close() }()
-	go func() {
-		conn, errAccept := listener.Accept()
-		if errAccept != nil {
-			return
-		}
-		defer func() { _ = conn.Close() }()
-		if _, errRead := http.ReadRequest(bufio.NewReader(conn)); errRead != nil {
-			return
-		}
-		_, _ = io.WriteString(conn, "HTTP/1.1 200 Connection Established\r\n\r\n")
-		<-time.After(time.Second)
-	}()
-
-	proxyURL, errParse := url.Parse("http://" + listener.Addr().String())
-	if errParse != nil {
-		t.Fatalf("url.Parse returned error: %v", errParse)
-	}
-	rejected := errors.New("proxy response rejected by policy")
-	dialer := &httpConnectDialer{
-		proxyURL:       proxyURL,
-		dialer:         proxy.Direct,
-		connectTimeout: defaultProxyConnectTimeout,
-		onConnectResponse: func(_ context.Context, _ *url.URL, _ *http.Request, _ *http.Response) error {
-			return rejected
-		},
-	}
-
-	conn, errDial := dialer.DialContext(context.Background(), "tcp", "target.example.com:443")
-	if conn != nil {
-		_ = conn.Close()
-	}
-	if !errors.Is(errDial, rejected) {
-		t.Fatalf("error = %v, want it to wrap the hook's error", errDial)
 	}
 }
 

--- a/sdk/proxyutil/proxy_test.go
+++ b/sdk/proxyutil/proxy_test.go
@@ -942,3 +942,134 @@ func TestProxyTLSConfig(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildHTTPTransportHTTPSProxyUsesLateDialHooks pins that the transport's dial hooks
+// are read when the connection is made, not when the transport is built. On this path
+// they have no other way in: every first hop goes to the proxy, so the TLS dial hook is
+// the only thing that dials at all, and freezing them would silence a caller's custom
+// routing, local bind or test dialer without a word.
+func TestBuildHTTPTransportHTTPSProxyUsesLateDialHooks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		install func(transport *http.Transport, dialed *atomic.Int32)
+	}{
+		{
+			name: "DialContext",
+			install: func(transport *http.Transport, dialed *atomic.Int32) {
+				transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+					dialed.Add(1)
+					return (&net.Dialer{}).DialContext(ctx, network, addr)
+				}
+			},
+		},
+		{
+			// Deprecated, but net/http still falls back to it, so this path must too.
+			name: "Dial",
+			install: func(transport *http.Transport, dialed *atomic.Int32) {
+				transport.DialContext = nil
+				transport.Dial = func(network, addr string) (net.Conn, error) {
+					dialed.Add(1)
+					return net.Dial(network, addr)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if _, errWrite := io.WriteString(w, "pong"); errWrite != nil {
+					t.Errorf("target write failed: %v", errWrite)
+				}
+			}))
+			defer target.Close()
+
+			proxyServer := httptest.NewUnstartedServer(http.HandlerFunc(connectTunnelHandler(t)))
+			proxyServer.EnableHTTP2 = true
+			proxyServer.TLS = &tls.Config{NextProtos: []string{"h2", "http/1.1"}}
+			proxyServer.StartTLS()
+			defer proxyServer.Close()
+
+			proxyURL, errParseProxy := url.Parse(proxyServer.URL)
+			if errParseProxy != nil {
+				t.Fatalf("url.Parse returned error: %v", errParseProxy)
+			}
+			transport, _, errBuild := BuildHTTPTransport("https://" + proxyURL.Host)
+			if errBuild != nil {
+				t.Fatalf("BuildHTTPTransport returned error: %v", errBuild)
+			}
+			proxyClientTransport, ok := proxyServer.Client().Transport.(*http.Transport)
+			if !ok {
+				t.Fatal("httptest proxy client transport is not an *http.Transport")
+			}
+			transport.TLSClientConfig = proxyClientTransport.TLSClientConfig.Clone()
+			defer transport.CloseIdleConnections()
+
+			// Installed after the transport is built — the whole point.
+			var dialed atomic.Int32
+			tt.install(transport, &dialed)
+
+			response, errGet := (&http.Client{Transport: transport, Timeout: 10 * time.Second}).Get(target.URL)
+			if errGet != nil {
+				t.Fatalf("request through HTTPS proxy failed: %v", errGet)
+			}
+			defer func() {
+				if errClose := response.Body.Close(); errClose != nil {
+					t.Errorf("response.Body.Close returned error: %v", errClose)
+				}
+			}()
+			if _, errRead := io.ReadAll(response.Body); errRead != nil {
+				t.Fatalf("io.ReadAll returned error: %v", errRead)
+			}
+
+			if dialed.Load() == 0 {
+				t.Fatalf("the caller's %s was never used to reach the proxy", tt.name)
+			}
+		})
+	}
+}
+
+// connectTunnelHandler is a minimal CONNECT proxy: read the request, splice the
+// connection to the requested target.
+func connectTunnelHandler(t *testing.T) func(http.ResponseWriter, *http.Request) {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodConnect {
+			http.Error(w, "expected CONNECT", http.StatusMethodNotAllowed)
+			return
+		}
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "connection is not hijackable", http.StatusInternalServerError)
+			return
+		}
+		upstreamConn, errDial := net.Dial("tcp", r.Host)
+		if errDial != nil {
+			http.Error(w, "dial upstream failed", http.StatusBadGateway)
+			return
+		}
+		clientConn, buffered, errHijack := hijacker.Hijack()
+		if errHijack != nil {
+			_ = upstreamConn.Close()
+			return
+		}
+		if _, errWrite := io.WriteString(clientConn, "HTTP/1.1 200 Connection Established\r\n\r\n"); errWrite != nil {
+			_ = upstreamConn.Close()
+			_ = clientConn.Close()
+			return
+		}
+		go func() {
+			defer func() { _ = upstreamConn.Close() }()
+			_, _ = io.Copy(upstreamConn, buffered)
+		}()
+		go func() {
+			defer func() { _ = clientConn.Close() }()
+			_, _ = io.Copy(clientConn, upstreamConn)
+		}()
+	}
+}

--- a/sdk/proxyutil/proxy_test.go
+++ b/sdk/proxyutil/proxy_test.go
@@ -927,3 +927,48 @@ func TestBuildHTTPTransportHTTPSProxyOnConnectResponseRejects(t *testing.T) {
 		t.Fatalf("error = %v, want it to wrap the hook's error", errDial)
 	}
 }
+
+func TestProxyTLSConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		base           *tls.Config
+		wantServerName string
+	}{
+		{name: "nil base", base: nil, wantServerName: "proxy.example.com"},
+		{name: "empty ServerName is filled", base: &tls.Config{}, wantServerName: "proxy.example.com"},
+		{
+			// A proxy reached at an address its certificate does not carry: net/http lets
+			// a caller-set ServerName stand, and so must this.
+			name:           "caller ServerName is kept",
+			base:           &tls.Config{ServerName: "proxy.internal"},
+			wantServerName: "proxy.internal",
+		},
+		{
+			// The ALPN pin is the fix, not a default — a caller asking for h2 on the
+			// proxy leg is asking for the bug back.
+			name:           "caller NextProtos is overridden",
+			base:           &tls.Config{NextProtos: []string{"h2"}},
+			wantServerName: "proxy.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := proxyTLSConfig(tt.base, "proxy.example.com")
+			if cfg.ServerName != tt.wantServerName {
+				t.Fatalf("ServerName = %q, want %q", cfg.ServerName, tt.wantServerName)
+			}
+			if len(cfg.NextProtos) != 1 || cfg.NextProtos[0] != "http/1.1" {
+				t.Fatalf("NextProtos = %v, want [http/1.1]", cfg.NextProtos)
+			}
+			if tt.base != nil && len(tt.base.NextProtos) > 0 && tt.base.NextProtos[0] != "h2" {
+				t.Fatal("the caller's config was mutated")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #5287.

## Summary

`BuildHTTPTransport` reached an `https://` proxy through `http.Transport.Proxy`. Go performs the TLS handshake with the proxy using the transport-wide `TLSClientConfig` — whose `NextProtos` gain `"h2"` as soon as HTTP/2 is configured (`ForceAttemptHTTP2` is true on `http.DefaultTransport`) — and then writes an HTTP/1.1 `CONNECT` over whatever ALPN selected. A proxy that picks `h2` sees a bogus HTTP/2 preface and drops the connection, so **every** caller of `BuildHTTPTransport` fails with `unexpected EOF` behind such a proxy: management `api-call`, `NewProxyAwareHTTPClient` (Gemini / Vertex / xAI / Kimi executors, plugin host), `util.SetProxy` (all OAuth token exchange, asset updater, plugin store), `rtprovider`, `cmd/fetch_*_models`.

`BuildDialer` was already immune — it returns `httpConnectDialer`, which speaks HTTP/1.1 `CONNECT` over a `tls.Config` with no ALPN. That is why the uTLS Claude/Codex relay paths keep working on the same proxy while everything else breaks, which makes this hard to spot in the field.

## Changes

- `BuildHTTPTransport`: for `https://` proxies, clear `Proxy` and dial through the existing `httpConnectDialer` instead. `TLSClientConfig` is read at dial time because Go's HTTP/2 setup (and callers) populate it after the transport is built.
- `httpConnectDialer`: pin the proxy-leg ALPN to `http/1.1` — `CONNECT` is an HTTP/1.1 request, so the proxy must never select `h2` — and honour caller-supplied TLS settings (roots, client certs) instead of discarding them. `BuildDialer`'s existing users inherit the explicit pin.

Negotiation with the **target** is untouched: requests still reach upstreams over HTTP/2 through the tunnel. `http://` and `socks5://` proxies are unaffected — neither performs a TLS handshake with the proxy, so no ALPN is involved.

## Testing

- [x] `gofmt -l ./sdk` clean
- [x] `go vet ./sdk/proxyutil/`
- [x] `go test ./sdk/proxyutil/`
- [x] `go build -o test-output ./cmd/server && rm test-output`
- [x] `go test ./...` — same three pre-existing failures on `dev` before and after this change (`TestApplyClaudeHeaders_DisableDeviceProfileStabilization`, `TestApplyClaudeHeaders_LegacyModePreservesConfiguredUserAgentOverrideForClaudeClients`, `TestClaudeExecutor_NonClaudeRequestUsesClaudeCode220CLIFingerprint` in `internal/runtime/executor`), unrelated to proxy handling

New test `TestBuildHTTPTransportHTTPSProxyTunnelsThroughH2CapableProxy` stands up an httptest TLS proxy advertising `NextProtos: ["h2", "http/1.1"]` and tunnels a real request through it. Against the previous code it fails exactly as reported in the field:

```
http2: server: error reading preface from client: bogus greeting "CONNECT 127.0.0.1:45427 "
    proxy_test.go:510: request through HTTPS proxy failed:
        Get "https://127.0.0.1:45427": unexpected EOF
```

Also verified against the commercial HTTPS proxy (port 995, ALPN `h2, http/1.1`) where this was first hit: `BuildHTTPTransport` now reaches `https://api.anthropic.com/api/oauth/usage`, and the response comes back over `HTTP/2.0`, confirming the target leg is not downgraded.
