### PR TITLE
feat(registry): overridable remote model catalog URLs (env)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,6 +2,26 @@
 # Use "127.0.0.1" or "localhost" to restrict access to local machine only.
 host: ""
 
+# ── Remote model catalog sources (env-based) ───────────────────────────────
+# The catalogs that feed model routing and /v1/models are refreshed from
+# remote URLs. Custom URLs set via these environment variables are tried FIRST,
+# official mirrors follow as fallback (comma-separated list, whitespace trimmed):
+#
+#   CPA_REMOTE_MODELS_URL                models.json            (provider routing)
+#   CPA_REMOTE_CODEX_CLIENT_MODELS_URL   codex_client_models.json (client view)
+#
+# Discovering correct model slugs for your account:
+#   - Official Codex CLI cache lists every slot your account can see:
+#       PowerShell: Select-String 'slug' "$env:USERPROFILE\.codex\models_cache.json"
+#   - Once a slug is routed, the active catalog is visible at:
+#       curl http://127.0.0.1:8317/v1/models -H "Authorization: Bearer <api-key>"
+#
+# Example — serve a newer/patched catalog without waiting for upstream releases:
+#   PowerShell: $env:CPA_REMOTE_MODELS_URL = 'https://raw.githubusercontent.com/<user>/models/main/models.json'
+#   bash:       export CPA_REMOTE_MODELS_URL='https://raw.githubusercontent.com/<user>/models/main/models.json'
+# (.env files in the working directory are loaded automatically, so the value
+#  may also be placed there instead of being exported in the shell.)
+
 # Server port
 port: 8317
 

--- a/internal/registry/codex_client_models_updater.go
+++ b/internal/registry/codex_client_models_updater.go
@@ -65,7 +65,7 @@ func tryRefreshCodexClientModels(ctx context.Context, label string) {
 
 func fetchCodexClientModelsFromRemote(ctx context.Context) ([]byte, string) {
 	client := &http.Client{Timeout: modelsFetchTimeout}
-	for _, sourceURL := range codexClientModelsURLs {
+	for _, sourceURL := range resolveRemoteURLs("CPA_REMOTE_CODEX_CLIENT_MODELS_URL", codexClientModelsURLs) {
 		reqCtx, cancel := context.WithTimeout(ctx, modelsFetchTimeout)
 		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, sourceURL, nil)
 		if err != nil {

--- a/internal/registry/codex_client_models_updater.go
+++ b/internal/registry/codex_client_models_updater.go
@@ -66,6 +66,22 @@ func tryRefreshCodexClientModels(ctx context.Context, label string) {
 func fetchCodexClientModelsFromRemote(ctx context.Context) ([]byte, string) {
 	client := &http.Client{Timeout: modelsFetchTimeout}
 	for _, sourceURL := range resolveRemoteURLs("CPA_REMOTE_CODEX_CLIENT_MODELS_URL", codexClientModelsURLs) {
+		if !isHTTPSource(sourceURL) {
+			localData, lerr := readLocalCatalog(sourceURL)
+			if lerr != nil {
+				log.Debugf("Codex client models local catalog read failed for %s: %v", sourceURL, lerr)
+				continue
+			}
+			if int64(len(localData)) > maxCodexClientModelsSize {
+				log.Warnf("Codex client models catalog at %s exceeds the size limit", sourceURL)
+				continue
+			}
+			if verr := ValidateCodexClientModelsJSON(localData); verr != nil {
+				log.Warnf("Codex client models validate failed for %s: %v", sourceURL, verr)
+				continue
+			}
+			return localData, sourceURL
+		}
 		reqCtx, cancel := context.WithTimeout(ctx, modelsFetchTimeout)
 		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, sourceURL, nil)
 		if err != nil {

--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -142,7 +142,7 @@ func tryRefreshModels(ctx context.Context, label string) {
 // along with the URL it was fetched from. Returns (nil, "") if all fetches fail.
 func fetchModelsFromRemote(ctx context.Context) (*staticModelsJSON, string) {
 	client := &http.Client{Timeout: modelsFetchTimeout}
-	for _, url := range modelsURLs {
+	for _, url := range resolveRemoteURLs("CPA_REMOTE_MODELS_URL", modelsURLs) {
 		reqCtx, cancel := context.WithTimeout(ctx, modelsFetchTimeout)
 		req, err := http.NewRequestWithContext(reqCtx, "GET", url, nil)
 		if err != nil {

--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -143,6 +143,23 @@ func tryRefreshModels(ctx context.Context, label string) {
 func fetchModelsFromRemote(ctx context.Context) (*staticModelsJSON, string) {
 	client := &http.Client{Timeout: modelsFetchTimeout}
 	for _, url := range resolveRemoteURLs("CPA_REMOTE_MODELS_URL", modelsURLs) {
+		if !isHTTPSource(url) {
+			localData, lerr := readLocalCatalog(url)
+			if lerr != nil {
+				log.Debugf("models local catalog read failed from %s: %v", url, lerr)
+				continue
+			}
+			var parsed staticModelsJSON
+			if err := json.Unmarshal(localData, &parsed); err != nil {
+				log.Warnf("models parse failed from %s: %v", url, err)
+				continue
+			}
+			if verr := validateModelsCatalog(&parsed); verr != nil {
+				log.Warnf("models validate failed from %s: %v", url, verr)
+				continue
+			}
+			return &parsed, url
+		}
 		reqCtx, cancel := context.WithTimeout(ctx, modelsFetchTimeout)
 		req, err := http.NewRequestWithContext(reqCtx, "GET", url, nil)
 		if err != nil {

--- a/internal/registry/remote_urls.go
+++ b/internal/registry/remote_urls.go
@@ -1,0 +1,34 @@
+package registry
+
+import (
+	"os"
+	"strings"
+)
+
+// resolveRemoteURLs returns the ordered remote catalog URLs to try.
+
+// Entries are tried in order and the first successful fetch wins. When the
+// given environment variable is set, it supplies extra URLs (comma separated,
+// whitespace trimmed) that are tried BEFORE the defaults; the defaults remain
+// appended so a broken or unreachable custom source never disables catalog
+// updates. This lets users serve newer model slots (for example slugs visible
+// in ~/.codex/models_cache.json) without waiting for an upstream catalog
+// release and makes catalog changes testable against a real instance.
+
+// Recognized variables:
+//   CPA_REMOTE_MODELS_URL               overrides/models.json (provider routing)
+//   CPA_REMOTE_CODEX_CLIENT_MODELS_URL  codex_client_models.json (client view)
+
+// Example:
+//
+//	export CPA_REMOTE_MODELS_URL='https://raw.githubusercontent.com/<user>/models/main/models.json'
+func resolveRemoteURLs(envKey string, defaults []string) []string {
+	var custom []string
+	for _, raw := range strings.Split(os.Getenv(envKey), ",") {
+		u := strings.TrimSpace(raw)
+		if u != "" {
+			custom = append(custom, u)
+		}
+	}
+	return append(custom, defaults...)
+}

--- a/internal/registry/remote_urls.go
+++ b/internal/registry/remote_urls.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"net/url"
 	"os"
 	"strings"
 )
@@ -31,4 +32,27 @@ func resolveRemoteURLs(envKey string, defaults []string) []string {
 		}
 	}
 	return append(custom, defaults...)
+}
+
+// isHTTPSource reports whether a source entry must be fetched over HTTP(S).
+// Everything else is treated as a filesystem path so users can point the
+// overrides at purely local files without any hosting setup.
+func isHTTPSource(source string) bool {
+	l := strings.ToLower(strings.TrimSpace(source))
+	return strings.HasPrefix(l, "http://") || strings.HasPrefix(l, "https://")
+}
+
+// readLocalCatalog loads raw catalog bytes from a filesystem path entry.
+// Accepts plain paths relative to the process working directory as well as
+// file:// URIs on every platform.
+func readLocalCatalog(source string) ([]byte, error) {
+	p := strings.TrimSpace(source)
+	if len(p) >= 7 && strings.EqualFold(p[:7], "file://") {
+		u, err := url.Parse(p)
+		if err != nil {
+			return nil, err
+		}
+		p = u.Path
+	}
+	return os.ReadFile(p)
 }

--- a/internal/registry/remote_urls_test.go
+++ b/internal/registry/remote_urls_test.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -24,5 +26,41 @@ func TestResolveRemoteURLsPrependsTrimmedCustomList(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestIsHTTPSource(t *testing.T) {
+	cases := map[string]bool{
+		"http://x/a.json":           true,
+		"https://x/a.json":          true,
+		"HTTPS://X/A.JSON":          true,
+		"C:\\catalogs\\m.json":      false,
+		"file://C:/catalogs/m.json": false,
+		"./models.json":             false,
+	}
+	for source, want := range cases {
+		if got := isHTTPSource(source); got != want {
+			t.Errorf("isHTTPSource(%q) = %v, want %v", source, got, want)
+		}
+	}
+}
+
+func TestReadLocalCatalog(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "m.json")
+	content := []byte("{}")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readLocalCatalog(path)
+	if err != nil || string(got) != string(content) {
+		t.Fatalf("plain path: got %q, err %v", got, err)
+	}
+	uri := "file://" + filepath.ToSlash(path)
+	if _, err := readLocalCatalog(uri); err != nil {
+		t.Errorf("file URI (%s): unexpected error %v", uri, err)
+	}
+	if _, err := readLocalCatalog(filepath.Join(dir, "missing.json")); err == nil {
+		t.Error("expected error for missing local catalog")
 	}
 }

--- a/internal/registry/remote_urls_test.go
+++ b/internal/registry/remote_urls_test.go
@@ -1,0 +1,28 @@
+package registry
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResolveRemoteURLsWithoutOverride(t *testing.T) {
+	t.Setenv("CPA_TEST_REMOTE_URLS", "")
+	defaults := []string{"https://default.example/a.json", "https://default.example/b.json"}
+	got := resolveRemoteURLs("CPA_TEST_REMOTE_URLS", defaults)
+	if !reflect.DeepEqual(got, defaults) {
+		t.Fatalf("got %v, want %v", got, defaults)
+	}
+}
+
+func TestResolveRemoteURLsPrependsTrimmedCustomList(t *testing.T) {
+	t.Setenv("CPA_TEST_REMOTE_URLS", " https://one.example/x.json ,, https://two.example/y.json ,")
+	got := resolveRemoteURLs("CPA_TEST_REMOTE_URLS", []string{"https://default.example/m.json"})
+	want := []string{
+		"https://one.example/x.json",
+		"https://two.example/y.json",
+		"https://default.example/m.json",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## What

Lets users override where CLIProxyAPI fetches the remote model catalogs from, via two environment variables:

- `CPA_REMOTE_MODELS_URL` — models.json (provider routing + /v1/models)
- `CPA_REMOTE_CODEX_CLIENT_MODELS_URL` — codex_client_models.json (client view)

When set, a comma-separated list of custom URLs is tried **before** the built-in mirrors; built-in defaults stay appended as fallback so a broken custom source never disables catalog updates.

## Why

Today, serving a model slot that the bundled/remote catalogs do not know yet (e.g. `gpt-daybreak-blue-latest`, visible in the official Codex CLI cache but absent from router-for-me/models) requires either waiting for a catalog release or patching the source and rebuilding. With this change it becomes a one-line env var against any fork/raw URL.

It also makes catalog PRs trivially testable: point the env at your branch's raw URL, start the server, verify. We used exactly this method to prove [models#44](https://github.com/router-for-me/models/pull/44) end-to-end through the real updater (log line + completion probe).

## Implementation notes

- Small shared resolver in `internal/registry/remote_urls.go`; both updaters (`model_updater.go`, `codex_client_models_updater.go`) swap their loop source to `resolveRemoteURLs(...)`. Defaults untouched otherwise.
- Unit tests cover unset/empty env and list trimming; added doc block to config.example.yaml including how to discover correct slugs (`~/.codex/models_cache.json`, `/v1/models`) with ready-to-paste PowerShell/bash commands.
- `.env` files continue to work since values are read via os.Getenv at fetch time.