### PR TITLE
fix(util): inject items placeholder for array schemas missing items

### DIFF
--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -414,6 +414,17 @@ func repairSchemaNode(node map[string]any) (map[string]any, bool) {
 		}
 	}
 
+	// 2b. Gemini/Antigravity reject array schemas without "items"
+	// ("...parameters.properties[x].items: missing field"). Some MCP servers emit
+	// a bare {"type":"array"}; inject a permissive string item schema so the
+	// request is accepted instead of failing with HTTP 400.
+	if isArrayDeclaredType(clone["type"]) {
+		if _, hasItems := clone["items"]; !hasItems {
+			clone["items"] = map[string]any{"type": "string"}
+			modified = true
+		}
+	}
+
 	// 3. Recurse into all other standard schema containers
 	if itemsVal, ok := clone["items"].(map[string]any); ok {
 		repairedItems, itemsMod := repairSchemaNode(itemsVal)
@@ -1585,4 +1596,20 @@ func mergeDescriptionRaw(schemaRaw, parentDesc string) string {
 		updated, _ := sjson.SetBytes([]byte(schemaRaw), "description", combined)
 		return string(updated)
 	}
+}
+
+// isArrayDeclaredType reports whether a schema "type" value declares an array,
+// either as the string "array" or as a type list containing "array".
+func isArrayDeclaredType(t any) bool {
+	switch v := t.(type) {
+	case string:
+		return v == "array"
+	case []any:
+		for _, e := range v {
+			if s, ok := e.(string); ok && s == "array" {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/util/gemini_schema_array_items_test.go
+++ b/internal/util/gemini_schema_array_items_test.go
@@ -1,0 +1,21 @@
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCleanJSONSchemaForGeminiInjectsMissingArrayItems(t *testing.T) {
+	in := `{"type":"object","properties":{"params":{"type":"array"},"nested":{"type":"object","properties":{"times":{"type":["array","null"]}}},"ok":{"type":"array","items":{"type":"number"}}}}`
+	for _, out := range []string{CleanJSONSchemaForGemini(in), CleanJSONSchemaForAntigravity(in)} {
+		if strings.Contains(out, `"params":{"type":"array"}`) {
+			t.Fatalf("top-level array still missing items: %s", out)
+		}
+		if !strings.Contains(out, `"items":{"type":"number"}`) {
+			t.Fatalf("existing items were altered: %s", out)
+		}
+		if strings.Count(out, `"items":{"type":"string"}`) < 2 {
+			t.Fatalf("placeholder items not injected for both bare arrays: %s", out)
+		}
+	}
+}

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -1076,6 +1076,7 @@ func TestCleanJSONSchemaForGemini_RemovesGeminiUnsupportedMetadataFields(t *test
 			},
 			"enumDescriptions": {
 				"type": "array",
+				"items": {"type": "string"},
 				"description": "property name should not be removed"
 			}
 		}


### PR DESCRIPTION
## Summary
Fixes #5292.

Gemini and Antigravity reject tool parameter schemas that declare `"type": "array"` without `"items"`:

```
GenerateContentRequest.tools[0].function_declarations[N].parameters.properties[x].items: missing field.
```

Several MCP servers emit such bare array properties. Anthropic and OpenAI accept them, so users only hit the 400 when routing the same Claude Code / MCP session to `gemini-*` or Antigravity models.

## Changes
- `internal/util/gemini_schema.go`: in `repairSchemaNode` (phase 0, shared by the Gemini and Antigravity cleaners), inject `{"type": "string"}` as a permissive `items` whenever an array node — string type `"array"` or a type list containing `"array"` — has no `items`. Existing `items` are never touched. New helper `isArrayDeclaredType`.
- `internal/util/gemini_schema_array_items_test.go`: covers string- and list-typed bare arrays through both `CleanJSONSchemaForGemini` and `CleanJSONSchemaForAntigravity`, and asserts pre-existing `items` are preserved.
- `TestCleanJSONSchemaForGemini_RemovesGeminiUnsupportedMetadataFields`: its fixture contains a bare `enumDescriptions: {"type": "array"}` property; the golden now includes the injected `items`.

## Verification
- `go test ./internal/util/ ./internal/translator/...` passes.
- Built the image and verified against a live Gemini-backed route: the minimal repro from #5292 (previously 400) now returns a normal message; unrelated routes (OpenAI-compatible, Antigravity Gemini, DeepSeek) unaffected.
