### PR TITLE
Revert commit 1502ac826d

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -307,9 +307,7 @@ func main() {
 			parsed = &config.Config{}
 		}
 		parsed.Home = homeCfg
-		if parsed.Port == 0 {
-			parsed.Port = 8317 // Default to 8317 for home mode, can be overridden by home config
-		}
+		parsed.Port = 8317 // Default to 8317 for home mode, can be overridden by home config
 		parsed.UsageStatisticsEnabled = true
 		pluginSyncCfg := *parsed
 		parsed.Plugins.StoreAuth = nil


### PR DESCRIPTION
This pull request reverts the changes made in commit [1502ac826dcf42095ac36873644a8446deb7f7ed](https://github.com/router-for-me/CLIProxyAPI/commit/1502ac826dcf42095ac36873644a8446deb7f7ed) on the `fix-home-refresh-logging` branch.

### Changes made:
- Reverted the specified commit in `cmd/server/main.go`, resulting in a net change of +1 line added and -3 lines removed.
- Verified that the revert did not introduce any new issues by successfully building the project with `go build -o test-output ./cmd/server`. 

This ensures that the previous functionality is restored while maintaining the integrity of the current branch.