### PR TITLE
feat(registry): opt-in auto-import of Codex CLI cache slugs

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -189,6 +189,11 @@ func main() {
 			log.WithError(errLoad).Warn("failed to load .env file")
 		}
 	}
+	// Registry package init runs before .env loading; refresh the opt-in Codex
+	// CLI cache overlay now so --local-model/offline starts honor .env too.
+	if added := registry.RefreshCodexCacheOverlay(); len(added) > 0 {
+		log.Infof("codex-cache import: registered %d new model slug(s): %v", len(added), added)
+	}
 
 	lookupEnv := func(keys ...string) (string, bool) {
 		for _, key := range keys {

--- a/internal/registry/codex_cache_import.go
+++ b/internal/registry/codex_cache_import.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -27,6 +26,9 @@ func codexCacheImportEnabled() bool {
 // codexCachePath returns the official Codex CLI cache location or "" when
 // the home directory cannot be resolved.
 func codexCachePath() string {
+	if codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME")); codexHome != "" {
+		return filepath.Join(codexHome, "models_cache.json")
+	}
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		return ""
@@ -69,6 +71,12 @@ func importCodexCacheSlugs(data *staticModelsJSON, cachePath string) []string {
 	}
 	raw, err := os.ReadFile(cachePath)
 	if err != nil {
+		log.Warnf("codex-cache import: failed to read %s: %v", cachePath, err)
+		return nil
+	}
+	// Re-check after reading to close the Stat/Read time-of-check gap.
+	if len(raw) > maxCodexClientModelsSize {
+		log.Warnf("codex-cache import: %s exceeds the size limit, skipping", cachePath)
 		return nil
 	}
 	var cache codexCacheFile
@@ -102,7 +110,14 @@ func importCodexCacheSlugs(data *staticModelsJSON, cachePath string) []string {
 		base.Object = "model"
 		base.OwnedBy = "openai"
 		base.Type = "openai"
-		base.Created = time.Now().Unix()
+		// Preserve the template timestamp so equivalent overlays stay byte-stable
+		// across periodic refreshes and do not emit false change callbacks.
+		base.Created = template.Created
+		// Do not leak the template model's human metadata or reasoning contract
+		// into a cache entry that does not attest those fields.
+		base.DisplayName = entry.Slug
+		base.Description = ""
+		base.Thinking = nil
 		if entry.DisplayName != "" {
 			base.DisplayName = entry.DisplayName
 		}
@@ -124,27 +139,21 @@ func importCodexCacheSlugs(data *staticModelsJSON, cachePath string) []string {
 	return added
 }
 
-var codexRequestReasoningLevels = map[string]bool{
-	"minimal": true,
-	"low":     true,
-	"medium":  true,
-	"high":    true,
-	"xhigh":   true,
-	"max":     true,
-}
+var codexRequestReasoningOrder = []string{"minimal", "low", "medium", "high", "xhigh", "max"}
 
 func cacheReasoningLevels(raw []codexCacheReasoningLevel) []string {
 	seen := make(map[string]bool)
-	levels := make([]string, 0, len(raw))
 	for _, level := range raw {
 		effort := strings.ToLower(strings.TrimSpace(level.Effort))
-		// Cache metadata may lead the request API (for example `ultra`).
-		// Publish only levels accepted by internal/thinking's canonical parser.
-		if !codexRequestReasoningLevels[effort] || seen[effort] {
-			continue
-		}
 		seen[effort] = true
-		levels = append(levels, effort)
+	}
+	levels := make([]string, 0, len(codexRequestReasoningOrder))
+	for _, effort := range codexRequestReasoningOrder {
+		// Cache metadata may lead the request API (for example `ultra`).
+		// Publish only canonical levels, always in canonical ascending order.
+		if seen[effort] {
+			levels = append(levels, effort)
+		}
 	}
 	return levels
 }
@@ -196,15 +205,15 @@ func RefreshCodexCacheOverlay() []string {
 	if !codexCacheImportEnabled() {
 		return nil
 	}
-	modelsCatalogStore.mu.RLock()
+	// Keep clone, bounded cache I/O, overlay and publication under one writer
+	// lock so a concurrent remote refresh cannot be overwritten by a stale clone.
+	modelsCatalogStore.mu.Lock()
+	defer modelsCatalogStore.mu.Unlock()
 	next := cloneStaticModelsJSON(modelsCatalogStore.data)
-	modelsCatalogStore.mu.RUnlock()
 	added := overlayCodexCache(next)
 	if len(added) == 0 {
 		return nil
 	}
-	modelsCatalogStore.mu.Lock()
 	modelsCatalogStore.data = next
-	modelsCatalogStore.mu.Unlock()
 	return added
 }

--- a/internal/registry/codex_cache_import.go
+++ b/internal/registry/codex_cache_import.go
@@ -124,12 +124,23 @@ func importCodexCacheSlugs(data *staticModelsJSON, cachePath string) []string {
 	return added
 }
 
+var codexRequestReasoningLevels = map[string]bool{
+	"minimal": true,
+	"low":     true,
+	"medium":  true,
+	"high":    true,
+	"xhigh":   true,
+	"max":     true,
+}
+
 func cacheReasoningLevels(raw []codexCacheReasoningLevel) []string {
 	seen := make(map[string]bool)
 	levels := make([]string, 0, len(raw))
 	for _, level := range raw {
-		effort := strings.TrimSpace(level.Effort)
-		if effort == "" || seen[effort] {
+		effort := strings.ToLower(strings.TrimSpace(level.Effort))
+		// Cache metadata may lead the request API (for example `ultra`).
+		// Publish only levels accepted by internal/thinking's canonical parser.
+		if !codexRequestReasoningLevels[effort] || seen[effort] {
 			continue
 		}
 		seen[effort] = true

--- a/internal/registry/codex_cache_import.go
+++ b/internal/registry/codex_cache_import.go
@@ -1,0 +1,145 @@
+package registry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// codexCacheImportEnv enables importing model slugs from the official Codex
+// CLI cache into the routing catalog. Opt-in so default behavior stays
+// unchanged.
+const codexCacheImportEnv = "CPA_IMPORT_CODEX_CACHE_SLUGS"
+
+// codexCacheImportEnabled reports whether the opt-in import is turned on.
+func codexCacheImportEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(codexCacheImportEnv))) {
+	case "1", "true", "yes":
+		return true
+	}
+	return false
+}
+
+// codexCachePath returns the official Codex CLI cache location or "" when
+// the home directory cannot be resolved.
+func codexCachePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".codex", "models_cache.json")
+}
+
+type codexCacheEntry struct {
+	Slug           string `json:"slug"`
+	DisplayName    string `json:"display_name"`
+	Description    string `json:"description"`
+	Visibility     string `json:"visibility"`
+	SupportedInAPI bool   `json:"supported_in_api"`
+}
+
+type codexCacheFile struct {
+	Models []codexCacheEntry `json:"models"`
+}
+
+// importCodexCacheSlugs appends every slug from the cache that is missing
+// from all known model buckets. Entries are synthesized from the first
+// existing codex template (gpt-5.6-luna preferred) so capabilities like
+// context length, thinking levels and modalities carry over. Returns the
+// newly registered slugs.
+func importCodexCacheSlugs(s *modelStore, cachePath string) []string {
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		return nil // cache is optional; silent when absent
+	}
+	if len(data) > maxCodexClientModelsSize {
+		log.Warnf("codex-cache import: %s exceeds the size limit, skipping", cachePath)
+		return nil
+	}
+	var cache codexCacheFile
+	if err := json.Unmarshal(data, &cache); err != nil {
+		log.Warnf("codex-cache import: failed to parse %s: %v", cachePath, err)
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.data == nil {
+		return nil
+	}
+	known := make(map[string]bool)
+	for _, bucket := range [][]*ModelInfo{s.data.Claude, s.data.Gemini, s.data.Vertex, s.data.AIStudio, s.data.CodexFree, s.data.CodexTeam, s.data.CodexPlus, s.data.CodexPro, s.data.Kimi, s.data.Antigravity, s.data.XAI} {
+		for _, m := range bucket {
+			if m != nil {
+				known[m.ID] = true
+			}
+		}
+	}
+	template := codexTemplateEntry(s.data)
+	if template == nil {
+		return nil
+	}
+	var added []string
+	for _, entry := range cache.Models {
+		if entry.Slug == "" || known[entry.Slug] {
+			continue
+		}
+		if entry.Visibility == "hide" || !entry.SupportedInAPI {
+			continue
+		}
+		mi := *template
+		mi.ID = entry.Slug
+		mi.Object = "model"
+		mi.OwnedBy = "openai"
+		mi.Type = "openai"
+		mi.Created = time.Now().Unix()
+		if entry.DisplayName != "" {
+			mi.DisplayName = entry.DisplayName
+		}
+		if entry.Description != "" {
+			mi.Description = entry.Description
+		}
+		// Register in every codex plan bucket: the catalog is a superset and
+		// upstream enforces per-account entitlements at request time.
+		s.data.CodexFree = append(s.data.CodexFree, &mi)
+		s.data.CodexTeam = append(s.data.CodexTeam, &mi)
+		s.data.CodexPlus = append(s.data.CodexPlus, &mi)
+		s.data.CodexPro = append(s.data.CodexPro, &mi)
+		known[entry.Slug] = true
+		added = append(added, entry.Slug)
+	}
+	if len(added) > 0 {
+		log.Infof("codex-cache import: registered %d new model slug(s): %v", len(added), added)
+	}
+	return added
+}
+
+// codexTemplateEntry picks the catalog entry cloned for synthesized slugs:
+// prefer gpt-5.6-luna, then the first openai-typed codex entry.
+func codexTemplateEntry(data *staticModelsJSON) *ModelInfo {
+	for _, m := range data.CodexPro {
+		if m != nil && m.ID == "gpt-5.6-luna" {
+			return m
+		}
+	}
+	for _, m := range data.CodexPro {
+		if m != nil && m.Type == "openai" {
+			return m
+		}
+	}
+	return nil
+}
+
+// maybeImportCodexCache runs the opt-in import when enabled.
+func maybeImportCodexCache() {
+	if !codexCacheImportEnabled() {
+		return
+	}
+	if path := codexCachePath(); path != "" {
+		importCodexCacheSlugs(modelsCatalogStore, path)
+	}
+}

--- a/internal/registry/codex_cache_import.go
+++ b/internal/registry/codex_cache_import.go
@@ -34,52 +34,58 @@ func codexCachePath() string {
 	return filepath.Join(home, ".codex", "models_cache.json")
 }
 
+type codexCacheReasoningLevel struct {
+	Effort string `json:"effort"`
+}
+
 type codexCacheEntry struct {
-	Slug           string `json:"slug"`
-	DisplayName    string `json:"display_name"`
-	Description    string `json:"description"`
-	Visibility     string `json:"visibility"`
-	SupportedInAPI bool   `json:"supported_in_api"`
+	Slug                     string                     `json:"slug"`
+	DisplayName              string                     `json:"display_name"`
+	Description              string                     `json:"description"`
+	Visibility               string                     `json:"visibility"`
+	SupportedInAPI           bool                       `json:"supported_in_api"`
+	SupportedReasoningLevels []codexCacheReasoningLevel `json:"supported_reasoning_levels"`
 }
 
 type codexCacheFile struct {
 	Models []codexCacheEntry `json:"models"`
 }
 
-// importCodexCacheSlugs appends every slug from the cache that is missing
-// from all known model buckets. Entries are synthesized from the first
-// existing codex template (gpt-5.6-luna preferred) so capabilities like
-// context length, thinking levels and modalities carry over. Returns the
-// newly registered slugs.
-func importCodexCacheSlugs(s *modelStore, cachePath string) []string {
-	data, err := os.ReadFile(cachePath)
+// importCodexCacheSlugs overlays cache-only slugs onto one unpublished
+// catalog. Entries are synthesized from the first existing codex template
+// (gpt-5.6-luna preferred) so context length and modalities carry over.
+// Returns the newly registered slugs.
+func importCodexCacheSlugs(data *staticModelsJSON, cachePath string) []string {
+	if data == nil {
+		return nil
+	}
+	info, err := os.Stat(cachePath)
 	if err != nil {
 		return nil // cache is optional; silent when absent
 	}
-	if len(data) > maxCodexClientModelsSize {
+	if info.Size() > maxCodexClientModelsSize {
 		log.Warnf("codex-cache import: %s exceeds the size limit, skipping", cachePath)
 		return nil
 	}
+	raw, err := os.ReadFile(cachePath)
+	if err != nil {
+		return nil
+	}
 	var cache codexCacheFile
-	if err := json.Unmarshal(data, &cache); err != nil {
+	if err := json.Unmarshal(raw, &cache); err != nil {
 		log.Warnf("codex-cache import: failed to parse %s: %v", cachePath, err)
 		return nil
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.data == nil {
-		return nil
-	}
 	known := make(map[string]bool)
-	for _, bucket := range [][]*ModelInfo{s.data.Claude, s.data.Gemini, s.data.Vertex, s.data.AIStudio, s.data.CodexFree, s.data.CodexTeam, s.data.CodexPlus, s.data.CodexPro, s.data.Kimi, s.data.Antigravity, s.data.XAI} {
+	for _, bucket := range [][]*ModelInfo{data.Claude, data.Gemini, data.Vertex, data.AIStudio, data.CodexFree, data.CodexTeam, data.CodexPlus, data.CodexPro, data.Kimi, data.Antigravity, data.XAI} {
 		for _, m := range bucket {
 			if m != nil {
 				known[m.ID] = true
 			}
 		}
 	}
-	template := codexTemplateEntry(s.data)
+	template := codexTemplateEntry(data)
 	if template == nil {
 		return nil
 	}
@@ -91,31 +97,45 @@ func importCodexCacheSlugs(s *modelStore, cachePath string) []string {
 		if entry.Visibility == "hide" || !entry.SupportedInAPI {
 			continue
 		}
-		mi := *template
-		mi.ID = entry.Slug
-		mi.Object = "model"
-		mi.OwnedBy = "openai"
-		mi.Type = "openai"
-		mi.Created = time.Now().Unix()
+		base := cloneModelInfo(template)
+		base.ID = entry.Slug
+		base.Object = "model"
+		base.OwnedBy = "openai"
+		base.Type = "openai"
+		base.Created = time.Now().Unix()
 		if entry.DisplayName != "" {
-			mi.DisplayName = entry.DisplayName
+			base.DisplayName = entry.DisplayName
 		}
 		if entry.Description != "" {
-			mi.Description = entry.Description
+			base.Description = entry.Description
+		}
+		if levels := cacheReasoningLevels(entry.SupportedReasoningLevels); len(levels) > 0 {
+			base.Thinking = &ThinkingSupport{Levels: levels}
 		}
 		// Register in every codex plan bucket: the catalog is a superset and
 		// upstream enforces per-account entitlements at request time.
-		s.data.CodexFree = append(s.data.CodexFree, &mi)
-		s.data.CodexTeam = append(s.data.CodexTeam, &mi)
-		s.data.CodexPlus = append(s.data.CodexPlus, &mi)
-		s.data.CodexPro = append(s.data.CodexPro, &mi)
+		data.CodexFree = append(data.CodexFree, cloneModelInfo(base))
+		data.CodexTeam = append(data.CodexTeam, cloneModelInfo(base))
+		data.CodexPlus = append(data.CodexPlus, cloneModelInfo(base))
+		data.CodexPro = append(data.CodexPro, cloneModelInfo(base))
 		known[entry.Slug] = true
 		added = append(added, entry.Slug)
 	}
-	if len(added) > 0 {
-		log.Infof("codex-cache import: registered %d new model slug(s): %v", len(added), added)
-	}
 	return added
+}
+
+func cacheReasoningLevels(raw []codexCacheReasoningLevel) []string {
+	seen := make(map[string]bool)
+	levels := make([]string, 0, len(raw))
+	for _, level := range raw {
+		effort := strings.TrimSpace(level.Effort)
+		if effort == "" || seen[effort] {
+			continue
+		}
+		seen[effort] = true
+		levels = append(levels, effort)
+	}
+	return levels
 }
 
 // codexTemplateEntry picks the catalog entry cloned for synthesized slugs:
@@ -134,12 +154,46 @@ func codexTemplateEntry(data *staticModelsJSON) *ModelInfo {
 	return nil
 }
 
-// maybeImportCodexCache runs the opt-in import when enabled.
-func maybeImportCodexCache() {
+func cloneStaticModelsJSON(data *staticModelsJSON) *staticModelsJSON {
+	if data == nil {
+		return nil
+	}
+	return &staticModelsJSON{
+		Claude: cloneModelInfos(data.Claude), Gemini: cloneModelInfos(data.Gemini),
+		Vertex: cloneModelInfos(data.Vertex), AIStudio: cloneModelInfos(data.AIStudio),
+		CodexFree: cloneModelInfos(data.CodexFree), CodexTeam: cloneModelInfos(data.CodexTeam),
+		CodexPlus: cloneModelInfos(data.CodexPlus), CodexPro: cloneModelInfos(data.CodexPro),
+		Kimi: cloneModelInfos(data.Kimi), Antigravity: cloneModelInfos(data.Antigravity),
+		XAI: cloneModelInfos(data.XAI),
+	}
+}
+
+func overlayCodexCache(data *staticModelsJSON) []string {
 	if !codexCacheImportEnabled() {
-		return
+		return nil
 	}
-	if path := codexCachePath(); path != "" {
-		importCodexCacheSlugs(modelsCatalogStore, path)
+	path := codexCachePath()
+	if path == "" {
+		return nil
 	}
+	return importCodexCacheSlugs(data, path)
+}
+
+// RefreshCodexCacheOverlay applies the cache to the currently published
+// catalog after process-level environment loading (including .env).
+func RefreshCodexCacheOverlay() []string {
+	if !codexCacheImportEnabled() {
+		return nil
+	}
+	modelsCatalogStore.mu.RLock()
+	next := cloneStaticModelsJSON(modelsCatalogStore.data)
+	modelsCatalogStore.mu.RUnlock()
+	added := overlayCodexCache(next)
+	if len(added) == 0 {
+		return nil
+	}
+	modelsCatalogStore.mu.Lock()
+	modelsCatalogStore.data = next
+	modelsCatalogStore.mu.Unlock()
+	return added
 }

--- a/internal/registry/codex_cache_import_test.go
+++ b/internal/registry/codex_cache_import_test.go
@@ -30,7 +30,7 @@ func TestImportCodexCacheSlugs(t *testing.T) {
 	path := filepath.Join(dir, "models_cache.json")
 	payload, err := json.Marshal(map[string]any{
 		"models": []map[string]any{
-			{"slug": "gpt-daybreak-blue-latest", "display_name": "GPT Daybreak Blue", "visibility": "list", "supported_in_api": true},
+			{"slug": "gpt-daybreak-blue-latest", "display_name": "GPT Daybreak Blue", "visibility": "list", "supported_in_api": true, "supported_reasoning_levels": []map[string]any{{"effort": "medium"}, {"effort": "xhigh"}}},
 			{"slug": "gpt-5.5"},
 			{"slug": "hidden-slot", "visibility": "hide", "supported_in_api": true},
 			{"slug": "noapi-slot", "supported_in_api": false},
@@ -43,7 +43,7 @@ func TestImportCodexCacheSlugs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	store := &modelStore{data: &staticModelsJSON{
+	catalog := &staticModelsJSON{
 		CodexPro: []*ModelInfo{{
 			ID:                       "gpt-5.6-luna",
 			Type:                     "openai",
@@ -52,15 +52,15 @@ func TestImportCodexCacheSlugs(t *testing.T) {
 			Thinking:                 &ThinkingSupport{Levels: []string{"low", "high"}},
 			SupportedInputModalities: []string{"text"},
 		}},
-	}}
+	}
 
-	added := importCodexCacheSlugs(store, path)
+	added := importCodexCacheSlugs(catalog, path)
 	if len(added) != 1 || added[0] != "gpt-daybreak-blue-latest" {
 		t.Fatalf("added = %v, want only gpt-daybreak-blue-latest", added)
 	}
 
 	var imported *ModelInfo
-	for _, m := range store.data.CodexPro {
+	for _, m := range catalog.CodexPro {
 		if m.ID == "gpt-daybreak-blue-latest" {
 			imported = m
 		}
@@ -71,19 +71,44 @@ func TestImportCodexCacheSlugs(t *testing.T) {
 	if imported.ContextLength != 372000 || imported.Thinking == nil {
 		t.Fatalf("template capabilities not cloned: ctx=%d thinking=%v", imported.ContextLength, imported.Thinking)
 	}
-	if len(store.data.CodexFree) == 0 || store.data.CodexFree[0].ID != "gpt-daybreak-blue-latest" {
+	if got := imported.Thinking.Levels; len(got) != 2 || got[0] != "medium" || got[1] != "xhigh" {
+		t.Fatalf("cache reasoning levels not applied: %v", got)
+	}
+	if len(catalog.CodexFree) == 0 || catalog.CodexFree[0].ID != "gpt-daybreak-blue-latest" {
 		t.Fatal("slug missing from codex-free bucket")
 	}
 
 	// Idempotent: second run registers nothing new.
-	if again := importCodexCacheSlugs(store, path); len(again) != 0 {
+	if again := importCodexCacheSlugs(catalog, path); len(again) != 0 {
 		t.Fatalf("second run added %v, want none", again)
 	}
 }
 
+func TestOverlayBeforeComparisonIsStable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "models_cache.json")
+	payload, err := json.Marshal(map[string]any{"models": []map[string]any{{
+		"slug": "cache-only", "visibility": "list", "supported_in_api": true,
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	base := &staticModelsJSON{CodexPro: []*ModelInfo{{ID: "gpt-5.6-luna", Type: "openai"}}}
+	oldData := cloneStaticModelsJSON(base)
+	newData := cloneStaticModelsJSON(base)
+	importCodexCacheSlugs(oldData, path)
+	importCodexCacheSlugs(newData, path)
+	if changed := detectChangedProviders(oldData, newData); len(changed) != 0 {
+		t.Fatalf("equivalent overlaid catalogs changed: %v", changed)
+	}
+}
+
 func TestImportCodexCacheSlugsMissingFile(t *testing.T) {
-	store := &modelStore{data: &staticModelsJSON{}}
-	if added := importCodexCacheSlugs(store, filepath.Join(t.TempDir(), "absent.json")); added != nil {
+	catalog := &staticModelsJSON{}
+	if added := importCodexCacheSlugs(catalog, filepath.Join(t.TempDir(), "absent.json")); added != nil {
 		t.Fatalf("expected nil for missing cache, got %v", added)
 	}
 }

--- a/internal/registry/codex_cache_import_test.go
+++ b/internal/registry/codex_cache_import_test.go
@@ -47,6 +47,7 @@ func TestImportCodexCacheSlugs(t *testing.T) {
 		CodexPro: []*ModelInfo{{
 			ID:                       "gpt-5.6-luna",
 			Type:                     "openai",
+			Created:                  1700000000,
 			ContextLength:            372000,
 			MaxCompletionTokens:      128000,
 			Thinking:                 &ThinkingSupport{Levels: []string{"low", "high"}},
@@ -68,6 +69,9 @@ func TestImportCodexCacheSlugs(t *testing.T) {
 	if imported == nil {
 		t.Fatal("slug missing from codex-pro bucket")
 	}
+	if imported.Created != 1700000000 {
+		t.Fatalf("created = %d, want stable template timestamp", imported.Created)
+	}
 	if imported.ContextLength != 372000 || imported.Thinking == nil {
 		t.Fatalf("template capabilities not cloned: ctx=%d thinking=%v", imported.ContextLength, imported.Thinking)
 	}
@@ -81,6 +85,81 @@ func TestImportCodexCacheSlugs(t *testing.T) {
 	// Idempotent: second run registers nothing new.
 	if again := importCodexCacheSlugs(catalog, path); len(again) != 0 {
 		t.Fatalf("second run added %v, want none", again)
+	}
+}
+
+func TestCacheReasoningLevelsCanonicalOrder(t *testing.T) {
+	raw := []codexCacheReasoningLevel{{Effort: "xhigh"}, {Effort: "ultra"}, {Effort: "low"}, {Effort: "HIGH"}, {Effort: "low"}}
+	got := cacheReasoningLevels(raw)
+	want := []string{"low", "high", "xhigh"}
+	if len(got) != len(want) {
+		t.Fatalf("levels = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("levels = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestImportDoesNotLeakTemplateMetadata(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "models_cache.json")
+	payload, err := json.Marshal(map[string]any{"models": []map[string]any{{
+		"slug": "no-meta-slot", "visibility": "list", "supported_in_api": true,
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	catalog := &staticModelsJSON{CodexPro: []*ModelInfo{{
+		ID: "gpt-5.6-luna", Type: "openai", DisplayName: "GPT 5.6 Luna",
+		Description: "luna description", Thinking: &ThinkingSupport{Levels: []string{"low", "high"}},
+	}}}
+	if added := importCodexCacheSlugs(catalog, path); len(added) != 1 {
+		t.Fatalf("added = %v", added)
+	}
+	got := catalog.CodexPro[len(catalog.CodexPro)-1]
+	if got.DisplayName != "no-meta-slot" || got.Description != "" || got.Thinking != nil {
+		t.Fatalf("template metadata leaked: name=%q description=%q thinking=%v", got.DisplayName, got.Description, got.Thinking)
+	}
+}
+
+func TestRefreshCodexCacheOverlayPublishesCodexHome(t *testing.T) {
+	dir := t.TempDir()
+	payload, err := json.Marshal(map[string]any{"models": []map[string]any{{
+		"slug": "sdk-cache-slot", "visibility": "list", "supported_in_api": true,
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "models_cache.json"), payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(codexCacheImportEnv, "true")
+	t.Setenv("CODEX_HOME", dir)
+	modelsCatalogStore.mu.Lock()
+	original := modelsCatalogStore.data
+	modelsCatalogStore.data = &staticModelsJSON{CodexPro: []*ModelInfo{{ID: "gpt-5.6-luna", Type: "openai", Created: 123}}}
+	modelsCatalogStore.mu.Unlock()
+	t.Cleanup(func() {
+		modelsCatalogStore.mu.Lock()
+		modelsCatalogStore.data = original
+		modelsCatalogStore.mu.Unlock()
+	})
+	if added := RefreshCodexCacheOverlay(); len(added) != 1 || added[0] != "sdk-cache-slot" {
+		t.Fatalf("RefreshCodexCacheOverlay() = %v", added)
+	}
+	found := false
+	for _, model := range GetCodexProModels() {
+		if model.ID == "sdk-cache-slot" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("published catalog missing sdk-cache-slot")
 	}
 }
 
@@ -103,6 +182,14 @@ func TestOverlayBeforeComparisonIsStable(t *testing.T) {
 	importCodexCacheSlugs(newData, path)
 	if changed := detectChangedProviders(oldData, newData); len(changed) != 0 {
 		t.Fatalf("equivalent overlaid catalogs changed: %v", changed)
+	}
+}
+
+func TestCodexCachePathHonorsCodexHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+	if got, want := codexCachePath(), filepath.Join(home, "models_cache.json"); got != want {
+		t.Fatalf("codexCachePath() = %q, want %q", got, want)
 	}
 }
 

--- a/internal/registry/codex_cache_import_test.go
+++ b/internal/registry/codex_cache_import_test.go
@@ -30,7 +30,7 @@ func TestImportCodexCacheSlugs(t *testing.T) {
 	path := filepath.Join(dir, "models_cache.json")
 	payload, err := json.Marshal(map[string]any{
 		"models": []map[string]any{
-			{"slug": "gpt-daybreak-blue-latest", "display_name": "GPT Daybreak Blue", "visibility": "list", "supported_in_api": true, "supported_reasoning_levels": []map[string]any{{"effort": "medium"}, {"effort": "xhigh"}}},
+			{"slug": "gpt-daybreak-blue-latest", "display_name": "GPT Daybreak Blue", "visibility": "list", "supported_in_api": true, "supported_reasoning_levels": []map[string]any{{"effort": "medium"}, {"effort": "xhigh"}, {"effort": "ultra"}}},
 			{"slug": "gpt-5.5"},
 			{"slug": "hidden-slot", "visibility": "hide", "supported_in_api": true},
 			{"slug": "noapi-slot", "supported_in_api": false},

--- a/internal/registry/codex_cache_import_test.go
+++ b/internal/registry/codex_cache_import_test.go
@@ -1,0 +1,89 @@
+package registry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCodexCacheImportEnabled(t *testing.T) {
+	cases := map[string]bool{
+		"":     false,
+		"true": true,
+		"TRUE": true,
+		"1":    true,
+		"yes":  true,
+		"no":   false,
+		"off":  false,
+	}
+	for value, want := range cases {
+		t.Setenv(codexCacheImportEnv, value)
+		if got := codexCacheImportEnabled(); got != want {
+			t.Errorf("enabled(%q) = %v, want %v", value, got, want)
+		}
+	}
+}
+
+func TestImportCodexCacheSlugs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "models_cache.json")
+	payload, err := json.Marshal(map[string]any{
+		"models": []map[string]any{
+			{"slug": "gpt-daybreak-blue-latest", "display_name": "GPT Daybreak Blue", "visibility": "list", "supported_in_api": true},
+			{"slug": "gpt-5.5"},
+			{"slug": "hidden-slot", "visibility": "hide", "supported_in_api": true},
+			{"slug": "noapi-slot", "supported_in_api": false},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	store := &modelStore{data: &staticModelsJSON{
+		CodexPro: []*ModelInfo{{
+			ID:                       "gpt-5.6-luna",
+			Type:                     "openai",
+			ContextLength:            372000,
+			MaxCompletionTokens:      128000,
+			Thinking:                 &ThinkingSupport{Levels: []string{"low", "high"}},
+			SupportedInputModalities: []string{"text"},
+		}},
+	}}
+
+	added := importCodexCacheSlugs(store, path)
+	if len(added) != 1 || added[0] != "gpt-daybreak-blue-latest" {
+		t.Fatalf("added = %v, want only gpt-daybreak-blue-latest", added)
+	}
+
+	var imported *ModelInfo
+	for _, m := range store.data.CodexPro {
+		if m.ID == "gpt-daybreak-blue-latest" {
+			imported = m
+		}
+	}
+	if imported == nil {
+		t.Fatal("slug missing from codex-pro bucket")
+	}
+	if imported.ContextLength != 372000 || imported.Thinking == nil {
+		t.Fatalf("template capabilities not cloned: ctx=%d thinking=%v", imported.ContextLength, imported.Thinking)
+	}
+	if len(store.data.CodexFree) == 0 || store.data.CodexFree[0].ID != "gpt-daybreak-blue-latest" {
+		t.Fatal("slug missing from codex-free bucket")
+	}
+
+	// Idempotent: second run registers nothing new.
+	if again := importCodexCacheSlugs(store, path); len(again) != 0 {
+		t.Fatalf("second run added %v, want none", again)
+	}
+}
+
+func TestImportCodexCacheSlugsMissingFile(t *testing.T) {
+	store := &modelStore{data: &staticModelsJSON{}}
+	if added := importCodexCacheSlugs(store, filepath.Join(t.TempDir(), "absent.json")); added != nil {
+		t.Fatalf("expected nil for missing cache, got %v", added)
+	}
+}

--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -69,7 +69,6 @@ func init() {
 	if err := loadModelsFromBytes(embeddedModelsJSON, "embed"); err != nil {
 		log.Warnf("registry: failed to parse embedded models.json (embedded catalog may be incomplete or invalid; continuing startup and will rely on remote model refresh): %v", err)
 	}
-	maybeImportCodexCache()
 }
 
 // StartModelsUpdater starts a background updater that fetches models
@@ -122,14 +121,16 @@ func tryRefreshModels(ctx context.Context, label string) {
 		return
 	}
 
-	// Detect changes before updating store.
+	// Apply the optional local overlay before comparing or publishing so
+	// equivalent effective catalogs do not trigger false refresh callbacks and
+	// readers never observe a partially overlaid catalog.
+	overlayCodexCache(parsed)
 	changed := detectChangedProviders(oldData, parsed)
 
-	// Update store with new data regardless.
+	// Publish one complete effective catalog atomically.
 	modelsCatalogStore.mu.Lock()
 	modelsCatalogStore.data = parsed
 	modelsCatalogStore.mu.Unlock()
-	maybeImportCodexCache()
 
 	if len(changed) == 0 {
 		log.Infof("%s completed from %s, no changes detected", label, url)

--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -69,6 +69,7 @@ func init() {
 	if err := loadModelsFromBytes(embeddedModelsJSON, "embed"); err != nil {
 		log.Warnf("registry: failed to parse embedded models.json (embedded catalog may be incomplete or invalid; continuing startup and will rely on remote model refresh): %v", err)
 	}
+	maybeImportCodexCache()
 }
 
 // StartModelsUpdater starts a background updater that fetches models
@@ -128,6 +129,7 @@ func tryRefreshModels(ctx context.Context, label string) {
 	modelsCatalogStore.mu.Lock()
 	modelsCatalogStore.data = parsed
 	modelsCatalogStore.mu.Unlock()
+	maybeImportCodexCache()
 
 	if len(changed) == 0 {
 		log.Infof("%s completed from %s, no changes detected", label, url)

--- a/sdk/cliproxy/service_lifecycle.go
+++ b/sdk/cliproxy/service_lifecycle.go
@@ -70,6 +70,10 @@ func (s *Service) Run(ctx context.Context) error {
 		}
 	}
 
+	// SDK embedders do not pass through cmd/server's post-.env hook. Apply
+	// the opt-in Codex cache overlay before any auth publishes its model set.
+	registry.RefreshCodexCacheOverlay()
+
 	s.applyRetryConfig(s.cfg)
 	s.configureCooldownStateStore(s.cfg)
 


### PR DESCRIPTION
## What

Opt-in feature: when `CPA_IMPORT_CODEX_CACHE_SLUGS=true`, slugs from the official Codex CLI cache (`~/.codex/models_cache.json`) that are missing from all model buckets get registered into every codex plan bucket, synthesized from the closest existing template (gpt-5.6-luna preferred) so context length, thinking levels and modalities carry over.

## Why

New slots appear in the official client cache long before they land in any curated catalog. Today users must wait for a catalog update, fork a catalog repo, or patch source. With this change the workflow becomes exactly what users expect: **open the Codex CLI once, then type the model name** - the proxy discovers and serves it automatically.

## Behavior

- Opt-in via env (default off, no behavior change)
- Skips `visibility: "hide"` and `supported_in_api: false` entries
- Idempotent (dedup against all buckets; second run adds nothing)
- Registered in all four codex plan buckets: catalog is a superset, upstream enforces per-account entitlements at request time
- Runs after embedded load (works with `-local-model` and offline) and after every remote refresh

## Verification

Unit tests: gate table, import with dedup + template cloning + hidden/noapi filtering, idempotency, missing-file case - all green.

End-to-end against a real Pro account (binary built from this branch with the slot deliberately absent from the embedded catalog, no remote override, no .env):

```text
codex-cache import: registered 1 new model slug(s): [gpt-daybreak-blue-latest]
GET /v1/models contains gpt-daybreak-blue-latest
chat completion on that slot returned HTTP 200
```

## Relationship to other PRs

- models#44 adds the same slug to the curated catalog (independent; once merged the curated path serves it without this feature)
- #5291 adds env-overridable catalog URLs (independent; useful for custom catalogs, this one covers the zero-config case)