### PR TITLE
fix(translator): emit message_delta on [DONE] without finish_reason

### DIFF
--- a/internal/translator/openai/claude/openai_claude_response.go
+++ b/internal/translator/openai/claude/openai_claude_response.go
@@ -136,6 +136,16 @@ func effectiveOpenAIFinishReason(param *ConvertOpenAIResponseToAnthropicParams) 
 	return param.FinishReason
 }
 
+// terminalOpenAIFinishReason is the finish reason used when a stream ends.
+// Some OpenAI-compatible upstreams omit finish_reason on tool-only streams;
+// infer tool_calls from SawToolCall, otherwise default to stop.
+func terminalOpenAIFinishReason(param *ConvertOpenAIResponseToAnthropicParams) string {
+	if reason := effectiveOpenAIFinishReason(param); reason != "" {
+		return reason
+	}
+	return "stop"
+}
+
 // convertOpenAIStreamingChunkToAnthropic converts OpenAI streaming chunk to Anthropic streaming events
 func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAIResponseToAnthropicParams) [][]byte {
 	root := gjson.ParseBytes(rawJSON)
@@ -289,64 +299,22 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 			param.FinishReason = reason
 		}
 
-		// Send content_block_stop for thinking content if needed
-		if param.ThinkingContentBlockStarted {
-			contentBlockStopJSON := []byte(`{"type":"content_block_stop","index":0}`)
-			contentBlockStopJSON, _ = sjson.SetBytes(contentBlockStopJSON, "index", param.ThinkingContentBlockIndex)
-			results = append(results, translatorcommon.AppendSSEEventBytes(nil, "content_block_stop", contentBlockStopJSON, 2))
-			param.ThinkingContentBlockStarted = false
-			param.ThinkingContentBlockIndex = -1
-		}
-
-		// Send content_block_stop for text if text content block was started
-		stopTextContentBlock(param, &results)
-
-		// Send content_block_stop for any tool calls
-		if !param.ContentBlocksStopped {
-			for _, index := range toolCallAccumulatorIndexes(param.ToolCallsAccumulator) {
-				accumulator := param.ToolCallsAccumulator[index]
-				if !emitBelatedToolUseStart(param, index, accumulator, &results) {
-					continue
-				}
-				blockIndex := param.toolContentBlockIndex(index)
-
-				// Send complete input_json_delta with all accumulated arguments
-				if accumulator.Arguments.Len() > 0 {
-					inputDeltaJSON := []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`)
-					inputDeltaJSON, _ = sjson.SetBytes(inputDeltaJSON, "index", blockIndex)
-					inputDeltaJSON, _ = sjson.SetBytes(inputDeltaJSON, "delta.partial_json", util.FixJSON(accumulator.Arguments.String()))
-					results = append(results, translatorcommon.AppendSSEEventBytes(nil, "content_block_delta", inputDeltaJSON, 2))
-				}
-
-				contentBlockStopJSON := []byte(`{"type":"content_block_stop","index":0}`)
-				contentBlockStopJSON, _ = sjson.SetBytes(contentBlockStopJSON, "index", blockIndex)
-				results = append(results, translatorcommon.AppendSSEEventBytes(nil, "content_block_stop", contentBlockStopJSON, 2))
-				delete(param.ToolCallBlockIndexes, index)
-			}
-			param.ContentBlocksStopped = true
-		}
+		finalizeOpenAIAnthropicContentBlocks(param, &results)
 
 		// Don't send message_delta here - wait for usage info or [DONE]
 	}
 
-	// Handle usage information separately (this comes in a later chunk)
-	// Only process if usage has actual values (not null)
-	if param.FinishReason != "" && !param.MessageDeltaSent {
+	// Handle usage information separately (this comes in a later chunk).
+	// Some OpenAI-compatible upstreams omit finish_reason on tool-only
+	// streams; emit once a tool_use block was announced (SawToolCall) even
+	// when FinishReason is still empty. Do not finalize on usage alone so
+	// mid-stream usage on text does not close content blocks early.
+	if !param.MessageDeltaSent && (param.FinishReason != "" || param.SawToolCall) {
 		usage := root.Get("usage")
-		var inputTokens, outputTokens, cachedTokens int64
 		if usage.Exists() && usage.Type != gjson.Null {
-			inputTokens, outputTokens, cachedTokens = extractOpenAIUsage(usage)
-			// Send message_delta with usage
-			messageDeltaJSON := []byte(`{"type":"message_delta","delta":{"stop_reason":"","stop_sequence":null},"usage":{"input_tokens":0,"output_tokens":0}}`)
-			messageDeltaJSON, _ = sjson.SetBytes(messageDeltaJSON, "delta.stop_reason", mapOpenAIFinishReasonToAnthropic(effectiveOpenAIFinishReason(param)))
-			messageDeltaJSON, _ = sjson.SetBytes(messageDeltaJSON, "usage.input_tokens", inputTokens)
-			messageDeltaJSON, _ = sjson.SetBytes(messageDeltaJSON, "usage.output_tokens", outputTokens)
-			if cachedTokens > 0 {
-				messageDeltaJSON, _ = sjson.SetBytes(messageDeltaJSON, "usage.cache_read_input_tokens", cachedTokens)
-			}
-			results = append(results, translatorcommon.AppendSSEEventBytes(nil, "message_delta", messageDeltaJSON, 2))
-			param.MessageDeltaSent = true
-
+			finalizeOpenAIAnthropicContentBlocks(param, &results)
+			inputTokens, outputTokens, cachedTokens := extractOpenAIUsage(usage)
+			emitAnthropicMessageDelta(param, &results, inputTokens, outputTokens, cachedTokens)
 			emitMessageStopIfNeeded(param, &results)
 		}
 	}
@@ -358,46 +326,14 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 func convertOpenAIDoneToAnthropic(param *ConvertOpenAIResponseToAnthropicParams) [][]byte {
 	var results [][]byte
 
-	// Ensure all content blocks are stopped before final events
-	if param.ThinkingContentBlockStarted {
-		contentBlockStopJSON := []byte(`{"type":"content_block_stop","index":0}`)
-		contentBlockStopJSON, _ = sjson.SetBytes(contentBlockStopJSON, "index", param.ThinkingContentBlockIndex)
-		results = append(results, translatorcommon.AppendSSEEventBytes(nil, "content_block_stop", contentBlockStopJSON, 2))
-		param.ThinkingContentBlockStarted = false
-		param.ThinkingContentBlockIndex = -1
-	}
+	finalizeOpenAIAnthropicContentBlocks(param, &results)
 
-	stopTextContentBlock(param, &results)
-
-	if !param.ContentBlocksStopped {
-		for _, index := range toolCallAccumulatorIndexes(param.ToolCallsAccumulator) {
-			accumulator := param.ToolCallsAccumulator[index]
-			if !emitBelatedToolUseStart(param, index, accumulator, &results) {
-				continue
-			}
-			blockIndex := param.toolContentBlockIndex(index)
-
-			if accumulator.Arguments.Len() > 0 {
-				inputDeltaJSON := []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`)
-				inputDeltaJSON, _ = sjson.SetBytes(inputDeltaJSON, "index", blockIndex)
-				inputDeltaJSON, _ = sjson.SetBytes(inputDeltaJSON, "delta.partial_json", util.FixJSON(accumulator.Arguments.String()))
-				results = append(results, translatorcommon.AppendSSEEventBytes(nil, "content_block_delta", inputDeltaJSON, 2))
-			}
-
-			contentBlockStopJSON := []byte(`{"type":"content_block_stop","index":0}`)
-			contentBlockStopJSON, _ = sjson.SetBytes(contentBlockStopJSON, "index", blockIndex)
-			results = append(results, translatorcommon.AppendSSEEventBytes(nil, "content_block_stop", contentBlockStopJSON, 2))
-			delete(param.ToolCallBlockIndexes, index)
-		}
-		param.ContentBlocksStopped = true
-	}
-
-	// If we haven't sent message_delta yet (no usage info was received), send it now
-	if param.FinishReason != "" && !param.MessageDeltaSent {
-		messageDeltaJSON := []byte(`{"type":"message_delta","delta":{"stop_reason":"","stop_sequence":null},"usage":{"input_tokens":0,"output_tokens":0}}`)
-		messageDeltaJSON, _ = sjson.SetBytes(messageDeltaJSON, "delta.stop_reason", mapOpenAIFinishReasonToAnthropic(effectiveOpenAIFinishReason(param)))
-		results = append(results, translatorcommon.AppendSSEEventBytes(nil, "message_delta", messageDeltaJSON, 2))
-		param.MessageDeltaSent = true
+	// Always emit message_delta on [DONE] if it has not been sent yet.
+	// finish_reason may be omitted by OpenAI-compatible upstreams; infer
+	// tool_calls from SawToolCall and otherwise default to stop so Claude
+	// Code / SDK receive stop_reason and do not hang on an unfinished turn.
+	if !param.MessageDeltaSent {
+		emitAnthropicMessageDelta(param, &results, 0, 0, 0)
 	}
 
 	emitMessageStopIfNeeded(param, &results)
@@ -559,6 +495,57 @@ func emitMessageStopIfNeeded(param *ConvertOpenAIResponseToAnthropicParams, resu
 	}
 	*results = append(*results, translatorcommon.AppendSSEEventBytes(nil, "message_stop", []byte(`{"type":"message_stop"}`), 2))
 	param.MessageStopSent = true
+}
+
+func emitAnthropicMessageDelta(param *ConvertOpenAIResponseToAnthropicParams, results *[][]byte, inputTokens, outputTokens, cachedTokens int64) {
+	if param.MessageDeltaSent {
+		return
+	}
+	messageDeltaJSON := []byte(`{"type":"message_delta","delta":{"stop_reason":"","stop_sequence":null},"usage":{"input_tokens":0,"output_tokens":0}}`)
+	messageDeltaJSON, _ = sjson.SetBytes(messageDeltaJSON, "delta.stop_reason", mapOpenAIFinishReasonToAnthropic(terminalOpenAIFinishReason(param)))
+	messageDeltaJSON, _ = sjson.SetBytes(messageDeltaJSON, "usage.input_tokens", inputTokens)
+	messageDeltaJSON, _ = sjson.SetBytes(messageDeltaJSON, "usage.output_tokens", outputTokens)
+	if cachedTokens > 0 {
+		messageDeltaJSON, _ = sjson.SetBytes(messageDeltaJSON, "usage.cache_read_input_tokens", cachedTokens)
+	}
+	*results = append(*results, translatorcommon.AppendSSEEventBytes(nil, "message_delta", messageDeltaJSON, 2))
+	param.MessageDeltaSent = true
+}
+
+func finalizeOpenAIAnthropicContentBlocks(param *ConvertOpenAIResponseToAnthropicParams, results *[][]byte) {
+	if param.ThinkingContentBlockStarted {
+		contentBlockStopJSON := []byte(`{"type":"content_block_stop","index":0}`)
+		contentBlockStopJSON, _ = sjson.SetBytes(contentBlockStopJSON, "index", param.ThinkingContentBlockIndex)
+		*results = append(*results, translatorcommon.AppendSSEEventBytes(nil, "content_block_stop", contentBlockStopJSON, 2))
+		param.ThinkingContentBlockStarted = false
+		param.ThinkingContentBlockIndex = -1
+	}
+
+	stopTextContentBlock(param, results)
+
+	if param.ContentBlocksStopped {
+		return
+	}
+	for _, index := range toolCallAccumulatorIndexes(param.ToolCallsAccumulator) {
+		accumulator := param.ToolCallsAccumulator[index]
+		if !emitBelatedToolUseStart(param, index, accumulator, results) {
+			continue
+		}
+		blockIndex := param.toolContentBlockIndex(index)
+
+		if accumulator.Arguments.Len() > 0 {
+			inputDeltaJSON := []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`)
+			inputDeltaJSON, _ = sjson.SetBytes(inputDeltaJSON, "index", blockIndex)
+			inputDeltaJSON, _ = sjson.SetBytes(inputDeltaJSON, "delta.partial_json", util.FixJSON(accumulator.Arguments.String()))
+			*results = append(*results, translatorcommon.AppendSSEEventBytes(nil, "content_block_delta", inputDeltaJSON, 2))
+		}
+
+		contentBlockStopJSON := []byte(`{"type":"content_block_stop","index":0}`)
+		contentBlockStopJSON, _ = sjson.SetBytes(contentBlockStopJSON, "index", blockIndex)
+		*results = append(*results, translatorcommon.AppendSSEEventBytes(nil, "content_block_stop", contentBlockStopJSON, 2))
+		delete(param.ToolCallBlockIndexes, index)
+	}
+	param.ContentBlocksStopped = true
 }
 
 func stopTextContentBlock(param *ConvertOpenAIResponseToAnthropicParams, results *[][]byte) {

--- a/internal/translator/openai/claude/openai_claude_response_test.go
+++ b/internal/translator/openai/claude/openai_claude_response_test.go
@@ -103,6 +103,114 @@ func lastStopReason(events []sseEvent) string {
 
 const streamReq = `{"stream":true}`
 
+func TestStreamingTool_OmittedFinishReasonEmitsMessageDeltaOnDone(t *testing.T) {
+	events := runStream(t, streamReq,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_a","function":{"name":"do_it","arguments":"{}"}}]}}]}`,
+	)
+
+	if got := countByType(events, "message_delta"); got != 1 {
+		t.Fatalf("expected one message_delta on [DONE] when finish_reason is omitted, got %d (events=%+v)", got, events)
+	}
+	if got := lastStopReason(events); got != "tool_use" {
+		t.Fatalf("stop_reason = %q, want %q (events=%+v)", got, "tool_use", events)
+	}
+	if got := countByType(events, "message_stop"); got != 1 {
+		t.Fatalf("expected one message_stop, got %d (events=%+v)", got, events)
+	}
+	if len(events) == 0 || events[len(events)-1].Type != "message_stop" {
+		t.Fatalf("message_stop must be the last semantic event (events=%+v)", events)
+	}
+	if got := len(toolUseStarts(events)); got != 1 {
+		t.Fatalf("expected one tool_use start, got %d (events=%+v)", got, events)
+	}
+}
+
+func TestStreamingText_OmittedFinishReasonEmitsEndTurnOnDone(t *testing.T) {
+	events := runStream(t, streamReq,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"hello"}}]}`,
+	)
+
+	if got := countByType(events, "message_delta"); got != 1 {
+		t.Fatalf("expected one message_delta on [DONE] when finish_reason is omitted, got %d (events=%+v)", got, events)
+	}
+	if got := lastStopReason(events); got != "end_turn" {
+		t.Fatalf("stop_reason = %q, want %q (events=%+v)", got, "end_turn", events)
+	}
+	if got := countByType(events, "message_stop"); got != 1 {
+		t.Fatalf("expected one message_stop, got %d (events=%+v)", got, events)
+	}
+}
+
+func TestStreamingTool_UsageWithoutFinishReasonEmitsMessageDelta(t *testing.T) {
+	var paramAny any
+	var emitted [][]byte
+	for _, chunk := range []string{
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_a","function":{"name":"do_it","arguments":"{}"}}]}}]}`,
+		`{"id":"c1","model":"m","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":2}}`,
+	} {
+		emitted = append(emitted, ConvertOpenAIResponseToClaude(
+			context.Background(),
+			"",
+			[]byte(streamReq),
+			nil,
+			[]byte("data: "+chunk),
+			&paramAny,
+		)...)
+	}
+
+	var events []sseEvent
+	for _, raw := range emitted {
+		s := string(raw)
+		if !strings.HasPrefix(s, "event: ") {
+			continue
+		}
+		nl := strings.Index(s, "\n")
+		if nl < 0 {
+			continue
+		}
+		typ := strings.TrimPrefix(s[:nl], "event: ")
+		rest := s[nl+1:]
+		if !strings.HasPrefix(rest, "data: ") {
+			continue
+		}
+		payload := strings.TrimRight(strings.TrimPrefix(rest, "data: "), "\n")
+		events = append(events, sseEvent{Type: typ, Payload: payload})
+	}
+
+	if got := countByType(events, "message_delta"); got != 1 {
+		t.Fatalf("expected usage chunk to emit message_delta when finish_reason is omitted, got %d (events=%+v)", got, events)
+	}
+	if got := lastStopReason(events); got != "tool_use" {
+		t.Fatalf("stop_reason = %q, want %q (events=%+v)", got, "tool_use", events)
+	}
+	var sawUsage bool
+	for _, e := range events {
+		if e.Type != "message_delta" {
+			continue
+		}
+		if gjson.Get(e.Payload, "usage.input_tokens").Int() == 3 && gjson.Get(e.Payload, "usage.output_tokens").Int() == 2 {
+			sawUsage = true
+		}
+	}
+	if !sawUsage {
+		t.Fatalf("expected message_delta to carry usage from the usage chunk (events=%+v)", events)
+	}
+	if got := countByType(events, "message_stop"); got != 1 {
+		t.Fatalf("expected message_stop after usage-chunk message_delta, got %d (events=%+v)", got, events)
+	}
+
+	doneEvents := runStream(t, streamReq,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_a","function":{"name":"do_it","arguments":"{}"}}]}}]}`,
+		`{"id":"c1","model":"m","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":2}}`,
+	)
+	if got := countByType(doneEvents, "message_delta"); got != 1 {
+		t.Fatalf("expected exactly one message_delta after [DONE], got %d (events=%+v)", got, doneEvents)
+	}
+	if got := lastStopReason(doneEvents); got != "tool_use" {
+		t.Fatalf("stop_reason after [DONE] = %q, want %q", got, "tool_use")
+	}
+}
+
 func TestStreaming_LateUsageOnlyDoesNotEmitAfterMessageStop(t *testing.T) {
 	events := runStream(t, streamReq,
 		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,


### PR DESCRIPTION
## Problem

`convertOpenAIDoneToAnthropic` (and the usage-chunk path) gated `message_delta` on `param.FinishReason != ""`. A tool-only OpenAI stream that never sets `finish_reason` never emits `message_delta` / `stop_reason=tool_use`. Claude Code / SDK can hang or treat the turn as unfinished.

## Change

On `[DONE]`, emit `message_delta` even if `finish_reason` was omitted. Use existing `effectiveOpenAIFinishReason` (`SawToolCall` → `tool_calls`, else default `stop` → `end_turn`). Usage-chunk path also emits if `tool_use` was already announced, and closes any open content block first.

Fixes #5308

Based on official `dev`. Not a redo of #5267.

## Tests

`go test -count=1 ./internal/translator/openai/claude/`
`go build ./cmd/server`
