### PR TITLE
fix(auth): keep valid access token if proactive refresh fails

### DIFF
--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -349,6 +349,20 @@ func authAccessToken(auth *Auth) string {
 	return authMetadataString(auth, "accessToken")
 }
 
+func accessTokenStillValid(auth *Auth, now time.Time) bool {
+	if auth == nil || authAccessToken(auth) == "" {
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	expiry, ok := auth.ExpirationTime()
+	if !ok || expiry.IsZero() {
+		return false
+	}
+	return expiry.After(now)
+}
+
 func authHasRefreshCredential(auth *Auth) bool {
 	if authMetadataString(auth, "refresh_token") != "" {
 		return true
@@ -542,11 +556,18 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		m.mu.Lock()
 		if current := m.auths[id]; current != nil {
 			current.LastError = refreshErrorFromError(err)
-			if unauthorized {
+			// Proactive refresh is best-effort while the current access token
+			// remains valid. Reactive refresh (failedAccessToken set) still
+			// evicts on unauthorized.
+			keepUsableAccessToken := unauthorized && failedAccessToken == "" && accessTokenStillValid(current, now)
+			if unauthorized && !keepUsableAccessToken {
 				current.NextRefreshAfter = time.Time{}
 				current.Unavailable = true
 				current.Status = StatusError
 				current.StatusMessage = "unauthorized"
+			} else if keepUsableAccessToken {
+				current.NextRefreshAfter = time.Time{}
+				log.Warnf("proactive refresh failed for %s (%s); keeping still-valid access token: %v", current.Provider, current.ID, err)
 			} else {
 				current.NextRefreshAfter = now.Add(refreshFailureBackoff)
 			}

--- a/sdk/cliproxy/auth/conductor_refresh_valid_at_test.go
+++ b/sdk/cliproxy/auth/conductor_refresh_valid_at_test.go
@@ -1,0 +1,143 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestManager_ProactiveRefreshUnauthorizedKeepsValidAccessToken(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(unauthorizedRefreshTestExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "codex"},
+	})
+
+	now := time.Now()
+	auth := &Auth{
+		ID:       "codex-valid-at",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"email":         "x@example.com",
+			"access_token":  testAccessTokenJWT(now.Add(38 * time.Hour)),
+			"refresh_token": "rt-reused",
+			"expired":       now.Add(-time.Hour).Format(time.RFC3339),
+		},
+	}
+	registerSchedulerModels(t, "codex", "codex-keep-at-model", auth.ID)
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	manager.refreshAuth(ctx, auth.ID)
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatalf("expected auth %q after refresh", auth.ID)
+	}
+	if updated.LastError == nil {
+		t.Fatal("expected refresh failure to be recorded")
+	}
+	if got := updated.LastError.StatusCode(); got != http.StatusUnauthorized {
+		t.Fatalf("LastError.StatusCode() = %d, want %d", got, http.StatusUnauthorized)
+	}
+	if updated.Unavailable {
+		t.Fatal("expected still-valid access token to remain available")
+	}
+	if updated.Status != StatusActive {
+		t.Fatalf("Status = %q, want %q", updated.Status, StatusActive)
+	}
+	if updated.StatusMessage == "unauthorized" {
+		t.Fatal("StatusMessage = unauthorized, want to keep the credential active")
+	}
+	if !updated.NextRefreshAfter.IsZero() {
+		t.Fatalf("NextRefreshAfter = %s, want zero so unauthorized refresh stops retrying", updated.NextRefreshAfter)
+	}
+	if manager.shouldRefresh(updated, now) {
+		t.Fatal("expected unauthorized refresh failure to stop further proactive refresh")
+	}
+	if _, shouldSchedule := nextRefreshCheckAt(now, updated, time.Second); shouldSchedule {
+		t.Fatal("expected unauthorized refresh failure to leave the auto-refresh schedule")
+	}
+
+	got, errPick := manager.scheduler.pickSingle(ctx, "codex", "codex-keep-at-model", cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("pickSingle() error = %v, want still-valid credential to remain selectable", errPick)
+	}
+	if got == nil || got.ID != auth.ID {
+		t.Fatalf("pickSingle() auth = %v, want %q", got, auth.ID)
+	}
+}
+
+func TestManager_ProactiveRefreshUnauthorizedEvictsExpiredAccessToken(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(unauthorizedRefreshTestExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "codex"},
+	})
+
+	now := time.Now()
+	auth := &Auth{
+		ID:       "codex-expired-at",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"email":         "x@example.com",
+			"access_token":  testAccessTokenJWT(now.Add(-time.Minute)),
+			"refresh_token": "rt-reused",
+		},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	manager.refreshAuth(ctx, auth.ID)
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatalf("expected auth %q after refresh", auth.ID)
+	}
+	if !updated.Unavailable || updated.Status != StatusError || updated.StatusMessage != "unauthorized" {
+		t.Fatalf("expired AT eviction = unavailable=%v status=%q message=%q, want unavailable error/unauthorized", updated.Unavailable, updated.Status, updated.StatusMessage)
+	}
+}
+
+func TestManager_ReactiveRefreshUnauthorizedEvictsValidAccessToken(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(unauthorizedRefreshTestExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "codex"},
+	})
+
+	now := time.Now()
+	token := testAccessTokenJWT(now.Add(38 * time.Hour))
+	auth := &Auth{
+		ID:       "codex-reactive-at",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"email":         "x@example.com",
+			"access_token":  token,
+			"refresh_token": "rt-reused",
+		},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	if _, errRefresh := manager.refreshAuthForRequest(ctx, auth.ID, token); errRefresh == nil {
+		t.Fatal("expected reactive refresh to fail")
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatalf("expected auth %q after refresh", auth.ID)
+	}
+	if !updated.Unavailable || updated.Status != StatusError || updated.StatusMessage != "unauthorized" {
+		t.Fatalf("reactive eviction = unavailable=%v status=%q message=%q, want unavailable error/unauthorized", updated.Unavailable, updated.Status, updated.StatusMessage)
+	}
+}

--- a/sdk/cliproxy/auth/jwt_expiry.go
+++ b/sdk/cliproxy/auth/jwt_expiry.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+func jwtExpiry(token string) (time.Time, bool) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return time.Time{}, false
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return time.Time{}, false
+	}
+	payload, err := decodeJWTPart(parts[1])
+	if err != nil {
+		return time.Time{}, false
+	}
+	var claims struct {
+		Exp json.Number `json:"exp"`
+	}
+	if err = json.Unmarshal(payload, &claims); err != nil {
+		return time.Time{}, false
+	}
+	unix, errUnix := claims.Exp.Int64()
+	if errUnix != nil {
+		seconds, errFloat := claims.Exp.Float64()
+		if errFloat != nil || seconds <= 0 {
+			return time.Time{}, false
+		}
+		unix = int64(seconds)
+	}
+	if unix <= 0 {
+		return time.Time{}, false
+	}
+	return time.Unix(unix, 0).UTC(), true
+}
+
+func decodeJWTPart(part string) ([]byte, error) {
+	switch len(part) % 4 {
+	case 2:
+		part += "=="
+	case 3:
+		part += "="
+	}
+	return base64.URLEncoding.DecodeString(part)
+}

--- a/sdk/cliproxy/auth/jwt_expiry_test.go
+++ b/sdk/cliproxy/auth/jwt_expiry_test.go
@@ -1,0 +1,97 @@
+package auth
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func testAccessTokenJWT(exp time.Time) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"exp":%d}`, exp.Unix())))
+	return header + "." + payload + ".sig"
+}
+
+func TestJWTExpiry(t *testing.T) {
+	t.Parallel()
+
+	exp := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+	got, ok := jwtExpiry(testAccessTokenJWT(exp))
+	if !ok {
+		t.Fatal("jwtExpiry() ok = false, want true")
+	}
+	if !got.Equal(exp) {
+		t.Fatalf("jwtExpiry() = %s, want %s", got, exp)
+	}
+
+	if _, ok := jwtExpiry("opaque-token"); ok {
+		t.Fatal("jwtExpiry(opaque) ok = true, want false")
+	}
+	if _, ok := jwtExpiry(""); ok {
+		t.Fatal("jwtExpiry(empty) ok = true, want false")
+	}
+	if _, ok := jwtExpiry("a.b"); ok {
+		t.Fatal("jwtExpiry(two-parts) ok = true, want false")
+	}
+}
+
+func TestExpirationTime_PrefersAccessTokenJWTExp(t *testing.T) {
+	t.Parallel()
+
+	jwtExp := time.Date(2026, 8, 30, 6, 0, 0, 0, time.UTC)
+	staleMeta := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	auth := &Auth{
+		Metadata: map[string]any{
+			"access_token": testAccessTokenJWT(jwtExp),
+			"expired":      staleMeta.Format(time.RFC3339),
+		},
+	}
+
+	got, ok := auth.ExpirationTime()
+	if !ok {
+		t.Fatal("ExpirationTime() ok = false, want true")
+	}
+	if !got.Equal(jwtExp) {
+		t.Fatalf("ExpirationTime() = %s, want JWT exp %s", got, jwtExp)
+	}
+}
+
+func TestExpirationTime_FallsBackToMetadataForOpaqueToken(t *testing.T) {
+	t.Parallel()
+
+	metaExp := time.Date(2026, 8, 29, 15, 0, 0, 0, time.UTC)
+	auth := &Auth{
+		Metadata: map[string]any{
+			"access_token": "opaque-access-token",
+			"expired":      metaExp.Format(time.RFC3339),
+		},
+	}
+
+	got, ok := auth.ExpirationTime()
+	if !ok {
+		t.Fatal("ExpirationTime() ok = false, want true")
+	}
+	if !got.Equal(metaExp) {
+		t.Fatalf("ExpirationTime() = %s, want metadata %s", got, metaExp)
+	}
+}
+
+func TestAccessTokenStillValid(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 28, 8, 0, 0, 0, time.UTC)
+	valid := &Auth{Metadata: map[string]any{"access_token": testAccessTokenJWT(now.Add(38 * time.Hour))}}
+	expired := &Auth{Metadata: map[string]any{"access_token": testAccessTokenJWT(now.Add(-time.Minute))}}
+	missing := &Auth{Metadata: map[string]any{"email": "x@example.com"}}
+
+	if !accessTokenStillValid(valid, now) {
+		t.Fatal("accessTokenStillValid(valid JWT) = false, want true")
+	}
+	if accessTokenStillValid(expired, now) {
+		t.Fatal("accessTokenStillValid(expired JWT) = true, want false")
+	}
+	if accessTokenStillValid(missing, now) {
+		t.Fatal("accessTokenStillValid(missing AT) = true, want false")
+	}
+}

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -600,12 +600,16 @@ func (a *Auth) AccountInfo() (string, string) {
 	}
 }
 
-// ExpirationTime attempts to extract the credential expiration timestamp from metadata.
-// It inspects common keys such as "expired", "expire", "expires_at", and also
-// nested "token" objects to remain compatible with legacy auth file formats.
+// ExpirationTime attempts to extract the credential expiration timestamp.
+// It prefers the access token JWT exp claim when the token is a JWT, then
+// falls back to metadata keys such as "expired", "expire", "expires_at",
+// including nested "token" objects for legacy auth file formats.
 func (a *Auth) ExpirationTime() (time.Time, bool) {
 	if a == nil {
 		return time.Time{}, false
+	}
+	if exp, ok := jwtExpiry(authAccessToken(a)); ok {
+		return exp, true
 	}
 	if ts, ok := expirationFromMap(a.Metadata); ok {
 		return ts, true


### PR DESCRIPTION
## Problem

A failed *proactive* refresh evicted a credential whose access token was still valid. See #5095: a single Codex cred hit `refresh_token_reused` while the AT JWT still had ~38h left; every Codex request then 503d.

`refreshAuthForRequest` marked `Unavailable=true` / `StatusError` / `unauthorized` on unauthorized refresh. `ExpirationTime()` only read metadata `expired`, not JWT `exp`.

## Change

- Proactive refresh (`failedAccessToken == ""`) while the AT is still inside its validity window: record `LastError`, stop retrying the RT, **do not evict**. The credential stays selectable.
- On-request (reactive) refresh, or an already expired/missing AT: keep the existing eviction behavior.
- `ExpirationTime()` prefers access-token JWT `exp`, then falls back to metadata.

Fixes #5095

Based on official `dev`. Not stacked on #4477 (opposite policy). Not a redo of #5267.

## Tests

`go test -count=1 ./sdk/cliproxy/auth/ ./sdk/auth/ ./internal/auth/codex/`
`go build ./cmd/server`
