### PR TITLE
fix(claude): merge adjacent thinking blocks in a replayed Responses conversation

### DIFF
--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -180,11 +180,14 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 		}
 
 		parts := pendingParts
-		if pendingRole == "assistant" && len(pendingToolUseParts) > 0 {
-			combined := make([][]byte, 0, len(pendingParts)+len(pendingToolUseParts))
-			combined = append(combined, pendingParts...)
-			combined = append(combined, pendingToolUseParts...)
-			parts = combined
+		if pendingRole == "assistant" {
+			parts = mergeAdjacentClaudeThinkingBlocks(parts)
+			if len(pendingToolUseParts) > 0 {
+				combined := make([][]byte, 0, len(parts)+len(pendingToolUseParts))
+				combined = append(combined, parts...)
+				combined = append(combined, pendingToolUseParts...)
+				parts = combined
+			}
 		}
 		if len(parts) > 0 {
 			msg := []byte(`{"role":"","content":[]}`)
@@ -567,6 +570,44 @@ func dropUnsupportedFableAssistantPrefill(modelName string, messages [][]byte) [
 		return messages
 	}
 	return messages[:len(messages)-1]
+}
+
+// mergeAdjacentClaudeThinkingBlocks folds a run of adjacent thinking blocks in
+// one assistant message into the first block of that run. Anthropic never emits
+// two adjacent thinking blocks, so a replayed message carrying them reads as
+// tampering and the whole request is rejected with "`thinking` or
+// `redacted_thinking` blocks in the latest assistant message cannot be
+// modified". A Responses conversation reaches that shape on an ordinary turn,
+// because an agent that thinks twice before acting emits two consecutive
+// reasoning items, and the rejection then repeats on every later turn of the
+// same conversation.
+//
+// The run's text is concatenated onto the first block and its signature is
+// kept. Anthropic does not verify thinking text against the signature, which is
+// what makes the merge lossless for the reasoning the model gets to read.
+// redacted_thinking blocks carry opaque data that cannot be concatenated, so
+// they are left untouched and only break a run.
+func mergeAdjacentClaudeThinkingBlocks(parts [][]byte) [][]byte {
+	isThinking := func(part []byte) bool {
+		return gjson.GetBytes(part, "type").String() == "thinking"
+	}
+	merged := make([][]byte, 0, len(parts))
+	for _, part := range parts {
+		if len(merged) == 0 || !isThinking(part) || !isThinking(merged[len(merged)-1]) {
+			merged = append(merged, part)
+			continue
+		}
+		last := len(merged) - 1
+		next := gjson.GetBytes(part, "thinking").String()
+		if next == "" {
+			continue
+		}
+		if prev := gjson.GetBytes(merged[last], "thinking").String(); prev != "" {
+			next = prev + "\n\n" + next
+		}
+		merged[last], _ = sjson.SetBytes(merged[last], "thinking", next)
+	}
+	return merged
 }
 
 // responsesSystemUnsupportedBlock represents a system-level content part that

--- a/internal/translator/claude/openai/responses/claude_openai-responses_thinking_adjacency_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_thinking_adjacency_test.go
@@ -1,0 +1,72 @@
+package responses
+
+import (
+	"strings"
+	"testing"
+)
+
+// Anthropic rejects a replayed assistant message that carries two adjacent
+// thinking blocks, because it never produces that shape itself. A Responses
+// conversation reaches it on an ordinary turn: an agent that thinks twice
+// before speaking emits two consecutive reasoning items, and every later turn
+// of that conversation is then rejected with
+// "`thinking` or `redacted_thinking` blocks in the latest assistant message
+// cannot be modified".
+func TestConsecutiveReasoningItemsDoNotProduceAdjacentThinkingBlocks(t *testing.T) {
+	signature := mustTestSignature(t)
+	reasoning := func(text string) string {
+		return `{"type":"reasoning","encrypted_content":"` + signature + `","summary":[{"type":"summary_text","text":"` + text + `"}]}`
+	}
+	raw := responsesRequestFromItems(
+		`{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}`,
+		reasoning("first thought"),
+		reasoning("second thought"),
+		`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"answer"}]}`,
+		`{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]}`,
+	)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
+
+	got := claudeAssistantBlockTypes(t, out)
+	want := []string{"thinking", "text"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("assistant blocks = %v\nwant %v\noutput: %s", got, want, string(out))
+	}
+	if body := string(out); !strings.Contains(body, "first thought") || !strings.Contains(body, "second thought") {
+		t.Fatalf("merged thinking block lost reasoning text: %s", body)
+	}
+}
+
+// The shape an agent actually produces: think, call a tool, think again, call
+// another tool. Tool calls are collected at the end of the assistant message so
+// they stay adjacent to their tool_result turn, which leaves the two reasoning
+// items side by side and makes every later turn of the conversation fail.
+func TestReasoningBetweenToolCallsStaysReplayable(t *testing.T) {
+	signature := mustTestSignature(t)
+	reasoning := func(text string) string {
+		return `{"type":"reasoning","encrypted_content":"` + signature + `","summary":[{"type":"summary_text","text":"` + text + `"}]}`
+	}
+	call := func(id string) string {
+		return `{"type":"function_call","call_id":"` + id + `","name":"shell","arguments":"{\"cmd\":\"ls\"}"}`
+	}
+	raw := responsesRequestFromItems(
+		`{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}`,
+		reasoning("plan the first call"),
+		call("call_one"),
+		reasoning("plan the second call"),
+		call("call_two"),
+		`{"type":"function_call_output","call_id":"call_one","output":"ok"}`,
+		`{"type":"function_call_output","call_id":"call_two","output":"ok"}`,
+	)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
+
+	got := claudeAssistantBlockTypes(t, out)
+	want := []string{"thinking", "tool_use", "tool_use"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("assistant blocks = %v\nwant %v\noutput: %s", got, want, string(out))
+	}
+	if body := string(out); !strings.Contains(body, "plan the first call") || !strings.Contains(body, "plan the second call") {
+		t.Fatalf("merged thinking block lost reasoning text: %s", body)
+	}
+}


### PR DESCRIPTION
Fixes #5317

## Why this must land

One ordinary turn permanently bricks a Codex session on Claude. An agent that thinks twice before acting emits two consecutive `reasoning` items; the translator turns them into two adjacent `thinking` blocks; Anthropic rejects the request with `"thinking" or "redacted_thinking" blocks in the latest assistant message cannot be modified`. The pair is now permanent history, so **every** later request fails the same way. Codex runs compaction pre-sampling on every turn, so the session cannot answer even a one-word prompt and never surfaces a recoverable state.

Two of my real sessions died this way, worth 1,094,153 and 488,300 tokens.

## The change

`mergeAdjacentClaudeThinkingBlocks` folds a run of adjacent `thinking` blocks in one assistant message into the first block of the run: text concatenated with a blank line, first signature kept. Anthropic does not verify thinking text against the signature, so the merge is lossless for the reasoning the model reads back. `redacted_thinking` carries opaque data that cannot be concatenated, so it is left untouched and only breaks a run.

Called from `flushPendingMessage` for assistant messages, before the existing tool_use combine step.

## Blast radius

A message with no adjacent pair is returned unchanged, so every shape that already returns 200 keeps returning 200. Verified against Anthropic through a locally built binary:

| shape | before | after |
| --- | --- | --- |
| reasoning, reasoning, assistant, user | 400 | **200** |
| reasoning, tool_call, reasoning, tool_call, outputs, user | 400 | **200** |
| reasoning, assistant, user (control) | 200 | 200 |

## Tests

Two regressions added, both verified red before the fix:

- `TestConsecutiveReasoningItemsDoNotProduceAdjacentThinkingBlocks` expects `thinking,text`
- `TestReasoningBetweenToolCallsStaysReplayable` expects `thinking,tool_use,tool_use`

`go test ./internal/translator/claude/... -count=1` passes, `go build ./...` exits 0. `TestInterleavedThinkingAndSearchSurvivesRoundTrip` and `TestConvertOpenAIResponsesRequestToClaude_KeepsToolUseAdjacentToToolResult` still pass unchanged.

## Not a duplicate of #3663 / #3624

Those are the native `/v1/messages` signature sanitizer emptying or dropping a block. This is the Responses translator emitting a block ordering Anthropic never produces, with every signature intact.