### PR TITLE
fix(claude): drop trailing assistant prefill for every model that rejects it

### DIFF
--- a/internal/translator/claude/openai/responses/claude_openai-responses_assistant_prefill_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_assistant_prefill_test.go
@@ -1,0 +1,36 @@
+package responses
+
+import "testing"
+
+// Anthropic reads a trailing assistant message as prefill, and the current
+// Claude generation rejects it: "This model does not support assistant message
+// prefill. The conversation must end with a user message." The Responses API
+// has no prefill concept, so a trailing assistant item is replayed history,
+// not a directive. Measured against Anthropic: claude-opus-5, claude-sonnet-4-6
+// and claude-fable-5 reject it, claude-haiku-4-5 accepts it. Only the Fable
+// name was handled, so every Codex compaction turn on Opus and Sonnet failed.
+func TestTrailingAssistantPrefillDroppedForModelsThatRejectIt(t *testing.T) {
+	raw := responsesRequestFromItems(
+		`{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}`,
+		`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"answer"}]}`,
+	)
+
+	for _, tc := range []struct {
+		model       string
+		wantDropped bool
+	}{
+		{"claude-fable-5", true},
+		{"claude-opus-5", true},
+		{"claude-sonnet-4-6", true},
+		{"claude-haiku-4-5-20251001", false},
+	} {
+		out := ConvertOpenAIResponsesRequestToClaude(tc.model, raw, false)
+		last := lastClaudeMessageRole(t, out)
+		if tc.wantDropped && last == "assistant" {
+			t.Fatalf("%s: conversation still ends with an assistant message. Output: %s", tc.model, string(out))
+		}
+		if !tc.wantDropped && last != "assistant" {
+			t.Fatalf("%s: prefill was dropped for a model that accepts it. Output: %s", tc.model, string(out))
+		}
+	}
+}

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -452,7 +452,7 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 	flushPendingMessage()
 	hadMessages := len(messageBlocks) > 0
 	if !preserveEmptyThinkingBlocks {
-		messageBlocks = dropUnsupportedFableAssistantPrefill(modelName, messageBlocks)
+		messageBlocks = dropUnsupportedAssistantPrefill(modelName, messageBlocks)
 	}
 	// Preserve a minimal conversational turn for system-only inputs or when messages became empty
 	// so downstream validation still sees a Claude-shaped request.
@@ -555,11 +555,21 @@ func isResponsesSystemLevelRole(role string) bool {
 	}
 }
 
-// dropUnsupportedFableAssistantPrefill removes a trailing assistant message for
-// Claude Fable models, which reject assistant message prefill.
-func dropUnsupportedFableAssistantPrefill(modelName string, messages [][]byte) [][]byte {
-	normalized := strings.ToLower(strings.TrimSpace(modelName))
-	if !strings.Contains(normalized, "fable") || len(messages) == 0 {
+// assistantPrefillRejectingModels lists the model families that reject a
+// trailing assistant message with "This model does not support assistant
+// message prefill. The conversation must end with a user message." Measured
+// directly against Anthropic: claude-fable-5, claude-opus-5 and
+// claude-sonnet-4-6 reject it, claude-haiku-4-5 accepts it. Thinking budget is
+// not the discriminator; the same trailing shape fails on Opus at every
+// reasoning effort including none. A new family is one entry here.
+var assistantPrefillRejectingModels = []string{"fable", "opus-5", "opus5", "sonnet-4-6", "sonnet4-6"}
+
+// dropUnsupportedAssistantPrefill removes a trailing assistant message for the
+// models that reject assistant message prefill. The Responses API has no
+// prefill concept, so a trailing assistant item is replayed history rather than
+// a directive, and dropping it is lossless for the request that follows.
+func dropUnsupportedAssistantPrefill(modelName string, messages [][]byte) [][]byte {
+	if len(messages) == 0 || !modelRejectsAssistantPrefill(modelName) {
 		return messages
 	}
 	last := gjson.ParseBytes(messages[len(messages)-1])
@@ -567,6 +577,18 @@ func dropUnsupportedFableAssistantPrefill(modelName string, messages [][]byte) [
 		return messages
 	}
 	return messages[:len(messages)-1]
+}
+
+// modelRejectsAssistantPrefill reports whether the model name belongs to a
+// family measured to reject assistant message prefill.
+func modelRejectsAssistantPrefill(modelName string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(modelName))
+	for _, family := range assistantPrefillRejectingModels {
+		if strings.Contains(normalized, family) {
+			return true
+		}
+	}
+	return false
 }
 
 // responsesSystemUnsupportedBlock represents a system-level content part that

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
@@ -1021,7 +1021,9 @@ func TestConvertOpenAIResponsesRequestToClaude_SystemLevelInputsBecomeSeparateSy
 		]
 	}`
 
-	result := ConvertOpenAIResponsesRequestToClaude("claude-opus-5", []byte(inputJSON), false)
+	// The model is one that accepts assistant prefill, so the trailing assistant
+	// message survives and this test keeps measuring system-block routing only.
+	result := ConvertOpenAIResponsesRequestToClaude("claude-haiku-4-5-20251001", []byte(inputJSON), false)
 	root := gjson.ParseBytes(result)
 
 	system := root.Get("system").Array()

--- a/internal/translator/claude/openai/responses/claude_openai-responses_testsupport_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_testsupport_test.go
@@ -41,3 +41,12 @@ func mustTestSignature(t *testing.T) string {
 	raw, _ := testClaudeResponsesThinkingSignature(t)
 	return raw
 }
+
+func lastClaudeMessageRole(t *testing.T, claudeReq []byte) string {
+	t.Helper()
+	messages := gjson.GetBytes(claudeReq, "messages").Array()
+	if len(messages) == 0 {
+		return ""
+	}
+	return messages[len(messages)-1].Get("role").String()
+}


### PR DESCRIPTION
Fixes #5319

## Why this must land

`dropUnsupportedFableAssistantPrefill` already encodes the right idea, but it matches only `fable`. `claude-opus-5` and `claude-sonnet-4-6` reject the identical shape and are not on the list, so every Responses conversation ending on an assistant turn returns:

```
This model does not support assistant message prefill. The conversation must end with a user message.
```

Codex runs compaction pre-sampling on every turn, so a session in this state answers nothing at all, not even a one-word prompt, and the failure looks permanent to the user.

## The change

- `dropUnsupportedFableAssistantPrefill` becomes `dropUnsupportedAssistantPrefill`, driven by `assistantPrefillRejectingModels`.
- The list holds the measured families: `fable`, `opus-5`, `sonnet-4-6` plus their unhyphenated spellings. Adding a family later is one entry.
- Behavior for Fable is byte-identical to before.

## Measured evidence in the doc comment

| model | trailing assistant message |
| --- | --- |
| claude-opus-5 | rejected |
| claude-sonnet-4-6 | rejected |
| claude-fable-5 | rejected (already handled) |
| claude-haiku-4-5 | accepted |

Reasoning effort is not the discriminator: `claude-opus-5` returns 400 at effort `none`, `minimal` and `high` alike.

## Blast radius

Verified against Anthropic through a locally built binary: `[user, assistant]` on `claude-opus-5` goes 400 -> **200**, and a conversation that already ends with a user turn is unaffected.

One existing test changed. `TestConvertOpenAIResponsesRequestToClaude_SystemLevelInputsBecomeSeparateSystemBlocks` incidentally used `claude-opus-5` while asserting system-block routing, and its fixture ends with an assistant message that Anthropic would now reject. It is pointed at `claude-haiku-4-5-20251001`, a prefill-accepting model, so the test keeps measuring exactly what it was written to measure.

## Tests

`TestTrailingAssistantPrefillDroppedForModelsThatRejectIt`, table-driven over fable / opus-5 / sonnet-4-6 (dropped) and haiku-4-5 (kept). Verified red before the fix.

`go test ./internal/translator/claude/... -count=1` passes, `go build ./...` exits 0.

## Scope

#5279 covered Fable only. #5094 reports the same error string on the Antigravity `compaction_trigger` route and needs a different, executor-level fix; this PR is orthogonal to it and correct regardless of how the trailing assistant turn arrived.