### PR TITLE
fix(claude): drop a trailing thinking block from the final assistant message

### DIFF
--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -453,6 +453,7 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 	hadMessages := len(messageBlocks) > 0
 	if !preserveEmptyThinkingBlocks {
 		messageBlocks = dropUnsupportedFableAssistantPrefill(modelName, messageBlocks)
+		messageBlocks = dropTrailingThinkingBlocks(messageBlocks)
 	}
 	// Preserve a minimal conversational turn for system-only inputs or when messages became empty
 	// so downstream validation still sees a Claude-shaped request.
@@ -567,6 +568,49 @@ func dropUnsupportedFableAssistantPrefill(modelName string, messages [][]byte) [
 		return messages
 	}
 	return messages[:len(messages)-1]
+}
+
+// dropTrailingThinkingBlocks removes thinking blocks from the end of a trailing
+// assistant message. Anthropic rejects that shape with "The final block in an
+// assistant message cannot be \`thinking\`", and it is reachable whenever a
+// replayed conversation ends on a reasoning item. A thinking block cannot act as
+// prefill, so it carries nothing the request needs and the message is dropped
+// entirely when no other block remains. Only the trailing message is touched;
+// thinking blocks in earlier turns are the replayed chain of thought and stay.
+func dropTrailingThinkingBlocks(messages [][]byte) [][]byte {
+	if len(messages) == 0 {
+		return messages
+	}
+	last := gjson.ParseBytes(messages[len(messages)-1])
+	if !strings.EqualFold(strings.TrimSpace(last.Get("role").String()), "assistant") {
+		return messages
+	}
+	blocks := last.Get("content").Array()
+	if len(blocks) == 0 {
+		return messages
+	}
+	kept := len(blocks)
+	for kept > 0 {
+		blockType := strings.TrimSpace(blocks[kept-1].Get("type").String())
+		if blockType != "thinking" && blockType != "redacted_thinking" {
+			break
+		}
+		kept--
+	}
+	if kept == len(blocks) {
+		return messages
+	}
+	if kept == 0 {
+		return messages[:len(messages)-1]
+	}
+	rebuilt := make([][]byte, 0, kept)
+	for _, block := range blocks[:kept] {
+		rebuilt = append(rebuilt, []byte(block.Raw))
+	}
+	message := []byte(`{"role":"assistant"}`)
+	message = common.SetRawArrayItems(message, "content", rebuilt)
+	messages[len(messages)-1] = message
+	return messages
 }
 
 // responsesSystemUnsupportedBlock represents a system-level content part that

--- a/internal/translator/claude/openai/responses/claude_openai-responses_trailing_thinking_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_trailing_thinking_test.go
@@ -1,0 +1,37 @@
+package responses
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// A replayed conversation can end on a reasoning item, which becomes an
+// assistant message whose only block is thinking. Anthropic rejects that with
+// "messages.N: The final block in an assistant message cannot be `thinking`."
+// The block is unusable as prefill anyway, so the message carries no
+// information the request needs and dropping it is lossless.
+func TestTrailingThinkingOnlyAssistantMessageIsNotSent(t *testing.T) {
+	raw := responsesRequestFromItems(
+		`{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}`,
+		`{"type":"reasoning","summary":[{"type":"summary_text","text":"thought"}],"encrypted_content":"`+mustTestSignature(t)+`"}`,
+	)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-haiku-4-5-20251001", raw, false)
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) == 0 {
+		t.Fatalf("translator produced no messages. Output: %s", string(out))
+	}
+	last := messages[len(messages)-1]
+	if last.Get("role").String() != "assistant" {
+		return
+	}
+	blocks := last.Get("content").Array()
+	if len(blocks) == 0 {
+		t.Fatalf("assistant message has no content blocks. Output: %s", string(out))
+	}
+	if kind := blocks[len(blocks)-1].Get("type").String(); kind == "thinking" || kind == "redacted_thinking" {
+		t.Fatalf("final assistant block is %q, which Anthropic rejects. Output: %s", kind, string(out))
+	}
+}


### PR DESCRIPTION
Fixes #5321

## Why this must land

When a replayed Responses history ends on a `reasoning` item, the translator emits an assistant message whose last block is `thinking`, and Anthropic returns:

```
messages.N: The final block in an assistant message cannot be `thinking`.
```

This fires on models that accept assistant prefill, so it survives the prefill fix and needs its own handling. Measured on `claude-haiku-4-5`: a trailing assistant *text* message is accepted, a trailing assistant *thinking* message is not.

## The change

`dropTrailingThinkingBlocks` removes `thinking` and `redacted_thinking` blocks from the end of the **trailing** assistant message, and drops the message entirely when no other block remains.

A thinking block cannot serve as prefill, so it carries nothing the request needs. Earlier turns are untouched, so the replayed chain of thought is preserved in full.

## Blast radius

Only the last message is examined, and only when it is an assistant message ending in a thinking block. Every other shape is returned byte-identical. Verified against Anthropic through a locally built binary:

| shape | model | before | after |
| --- | --- | --- | --- |
| user, reasoning | haiku-4-5 | 400 | **200** |
| user, assistant, reasoning | opus-5 | 400 | **200** |
| user, reasoning, user (control) | opus-5 | 200 | 200 |

## Tests

`TestTrailingThinkingOnlyAssistantMessageIsNotSent`, verified red before the fix with the exact rejected payload in the failure message.

`go test ./internal/translator/claude/... -count=1` passes, `go build ./...` exits 0.