### PR TITLE
fix(codex): make Claude Code prompt cache key agent-scoping configurable

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -314,6 +314,15 @@ nonstream-keepalive-interval: 0
 # When false (default), only checks R/E prefix + base64 + first byte 0x12.
 # antigravity-signature-bypass-strict: false
 
+# Per-agent scoping of the upstream prompt_cache_key derived for Claude Code requests.
+# When true (default), every subagent of one Claude Code session gets its own cache
+# partition, so a fan-out of N subagents pays N first-turn cache misses even though they
+# share an identical system prompt and tool block.
+# When false, all agents of one session share a single partition keyed on the session, so a
+# fan-out can read the prefix the root agent already warmed. Reasoning-replay state stays
+# agent-scoped either way.
+# codex-cache-key-per-agent: true
+
 # Gemini API keys
 # gemini-api-key:
 #   - api-key: "AIzaSy...01"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,6 +105,24 @@ type Config struct {
 
 	AntigravitySignatureBypassStrict *bool `yaml:"antigravity-signature-bypass-strict,omitempty" json:"antigravity-signature-bypass-strict,omitempty"`
 
+	// CodexCacheKeyPerAgent controls whether the prompt_cache_key derived for a Claude Code
+	// request keeps its per-agent component.
+	//
+	// When true or unset (default, and the historical behavior) every subagent of one Claude
+	// Code session gets its own upstream cache partition. A fan-out of N subagents therefore
+	// pays N first-turn cache misses even though they share an identical system prompt and
+	// tool block.
+	//
+	// When false, all agents of one session share a single partition keyed on the session
+	// alone, so a fan-out can read the prefix the root agent already warmed. Only set this
+	// false if the shared prefix really is identical across agents; divergent prefixes will
+	// simply miss rather than corrupt anything, but they also gain nothing.
+	//
+	// This only affects the upstream cache key. Reasoning-replay state stays agent-scoped
+	// unconditionally (see helps.ClaudeCodeExecutionScope) so subagents can never replay each
+	// other's reasoning items.
+	CodexCacheKeyPerAgent *bool `yaml:"codex-cache-key-per-agent,omitempty" json:"codex-cache-key-per-agent,omitempty"`
+
 	// Antigravity configures provider-wide Antigravity request behavior.
 	Antigravity AntigravityConfig `yaml:"antigravity" json:"antigravity"`
 
@@ -171,4 +189,13 @@ type Config struct {
 
 	// Payload defines default and override rules for provider payload parameters.
 	Payload PayloadConfig `yaml:"payload" json:"payload"`
+}
+
+// CodexCacheKeyPerAgentEnabled reports whether Claude Code prompt cache keys stay agent-scoped.
+// A nil receiver or an unset key yields true, preserving the historical behavior.
+func (cfg *Config) CodexCacheKeyPerAgentEnabled() bool {
+	if cfg == nil || cfg.CodexCacheKeyPerAgent == nil {
+		return true
+	}
+	return *cfg.CodexCacheKeyPerAgent
 }

--- a/internal/runtime/executor/codex_executor_cache_test.go
+++ b/internal/runtime/executor/codex_executor_cache_test.go
@@ -384,7 +384,7 @@ func TestCodexExecutorCacheHelper_ClaudeAgentScopeUsesResolvedModelAcrossHTTPAnd
 		t.Fatalf("resolved model key fragmented by request alias: first=%q alias=%q", childKey, aliasKey)
 	}
 
-	websocketBody, _, errWebsocket := applyCodexPromptCacheHeadersWithContext(context.Background(), sdktranslator.FromString("claude"), aliasReq, rawJSON, childHeaders)
+	websocketBody, _, errWebsocket := applyCodexPromptCacheHeadersWithContext(context.Background(), sdktranslator.FromString("claude"), aliasReq, rawJSON, nil, childHeaders)
 	if errWebsocket != nil {
 		t.Fatalf("websocket prompt cache error: %v", errWebsocket)
 	}

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -108,7 +108,7 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 		if modelName == "" {
 			modelName = thinking.ParseSuffix(req.Model).ModelName
 		}
-		cached, ok, errCache := helps.ClaudeCodePromptCache(ctx, modelName, req.Payload, headers)
+		cached, ok, errCache := helps.ClaudeCodePromptCache(ctx, modelName, req.Payload, headers, e.cfg)
 		if errCache != nil {
 			return nil, nil, codexIdentityConfuseState{}, errCache
 		}

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -77,7 +77,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		return resp, err
 	}
 
-	body, wsHeaders, errPromptCache := applyCodexPromptCacheHeadersWithContext(ctx, from, req, body, opts.Headers)
+	body, wsHeaders, errPromptCache := applyCodexPromptCacheHeadersWithContext(ctx, from, req, body, e.cfg, opts.Headers)
 	if errPromptCache != nil {
 		return resp, errPromptCache
 	}

--- a/internal/runtime/executor/codex_websockets_request.go
+++ b/internal/runtime/executor/codex_websockets_request.go
@@ -19,11 +19,11 @@ import (
 )
 
 func applyCodexPromptCacheHeaders(from sdktranslator.Format, req cliproxyexecutor.Request, rawJSON []byte) ([]byte, http.Header) {
-	body, headers, _ := applyCodexPromptCacheHeadersWithContext(context.Background(), from, req, rawJSON)
+	body, headers, _ := applyCodexPromptCacheHeadersWithContext(context.Background(), from, req, rawJSON, nil)
 	return body, headers
 }
 
-func applyCodexPromptCacheHeadersWithContext(ctx context.Context, from sdktranslator.Format, req cliproxyexecutor.Request, rawJSON []byte, headerSets ...http.Header) ([]byte, http.Header, error) {
+func applyCodexPromptCacheHeadersWithContext(ctx context.Context, from sdktranslator.Format, req cliproxyexecutor.Request, rawJSON []byte, cfg *config.Config, headerSets ...http.Header) ([]byte, http.Header, error) {
 	headers := http.Header{}
 	if len(rawJSON) == 0 {
 		return rawJSON, headers, nil
@@ -39,7 +39,7 @@ func applyCodexPromptCacheHeadersWithContext(ctx context.Context, from sdktransl
 		if modelName == "" {
 			modelName = thinking.ParseSuffix(req.Model).ModelName
 		}
-		cached, ok, errCache := helps.ClaudeCodePromptCache(ctx, modelName, req.Payload, requestHeaders)
+		cached, ok, errCache := helps.ClaudeCodePromptCache(ctx, modelName, req.Payload, requestHeaders, cfg)
 		if errCache != nil {
 			return nil, nil, errCache
 		}

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -74,7 +74,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		return nil, err
 	}
 
-	body, wsHeaders, errPromptCache := applyCodexPromptCacheHeadersWithContext(ctx, from, req, body, opts.Headers)
+	body, wsHeaders, errPromptCache := applyCodexPromptCacheHeadersWithContext(ctx, from, req, body, e.cfg, opts.Headers)
 	if errPromptCache != nil {
 		return nil, errPromptCache
 	}

--- a/internal/runtime/executor/helps/claude_code_session.go
+++ b/internal/runtime/executor/helps/claude_code_session.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/tidwall/gjson"
 )
 
@@ -36,10 +37,20 @@ func ExtractClaudeCodeAgentID(ctx context.Context, headers http.Header) string {
 }
 
 // ClaudeCodeExecutionScope returns the stable root-session and agent identity used by Codex execution state.
+// This scope is always agent-qualified: it keys reasoning-replay state, which must never be
+// shared between sibling agents.
 func ClaudeCodeExecutionScope(ctx context.Context, payload []byte, headers http.Header) (string, bool) {
+	return claudeCodeScope(ctx, payload, headers, true)
+}
+
+// claudeCodeScope builds the Claude Code session identity, optionally qualified by agent.
+func claudeCodeScope(ctx context.Context, payload []byte, headers http.Header, perAgent bool) (string, bool) {
 	sessionID := ExtractClaudeCodeSessionID(ctx, payload, headers)
 	if sessionID == "" {
 		return "", false
+	}
+	if !perAgent {
+		return "claude:" + sessionID, true
 	}
 	return "claude:" + sessionID + ":agent:" + ExtractClaudeCodeAgentID(ctx, headers), true
 }
@@ -98,10 +109,19 @@ func extractClaudeCodeSessionIDFromPayload(payload []byte) string {
 	return ""
 }
 
-// ClaudeCodePromptCache derives a deterministic upstream prompt_cache_key for one Claude Code agent.
-func ClaudeCodePromptCache(ctx context.Context, modelName string, payload []byte, headers http.Header) (CodexCache, bool, error) {
+// ClaudeCodePromptCache derives a deterministic upstream prompt_cache_key for a Claude Code request.
+//
+// The key is agent-scoped by default. Set codex-cache-key-per-agent: false in the config to key
+// on the session alone, so a subagent fan-out shares one upstream partition instead of opening a
+// fresh one per agent. The optional cfg is variadic so existing callers without a config in scope
+// keep the default; a nil or absent config means agent-scoped.
+func ClaudeCodePromptCache(ctx context.Context, modelName string, payload []byte, headers http.Header, configs ...*config.Config) (CodexCache, bool, error) {
 	modelName = strings.TrimSpace(modelName)
-	executionScope, ok := ClaudeCodeExecutionScope(ctx, payload, headers)
+	var cfg *config.Config
+	if len(configs) > 0 {
+		cfg = configs[0]
+	}
+	executionScope, ok := claudeCodeScope(ctx, payload, headers, cfg.CodexCacheKeyPerAgentEnabled())
 	if modelName == "" || !ok {
 		return CodexCache{}, false, nil
 	}

--- a/internal/runtime/executor/helps/claude_code_session.go
+++ b/internal/runtime/executor/helps/claude_code_session.go
@@ -116,12 +116,27 @@ func extractClaudeCodeSessionIDFromPayload(payload []byte) string {
 // fresh one per agent. The optional cfg is variadic so existing callers without a config in scope
 // keep the default; a nil or absent config means agent-scoped.
 func ClaudeCodePromptCache(ctx context.Context, modelName string, payload []byte, headers http.Header, configs ...*config.Config) (CodexCache, bool, error) {
-	modelName = strings.TrimSpace(modelName)
 	var cfg *config.Config
 	if len(configs) > 0 {
 		cfg = configs[0]
 	}
-	executionScope, ok := claudeCodeScope(ctx, payload, headers, cfg.CodexCacheKeyPerAgentEnabled())
+	return claudeCodeCacheIdentity(ctx, modelName, payload, headers, cfg.CodexCacheKeyPerAgentEnabled())
+}
+
+// ClaudeCodeConversationCache derives the same deterministic identity as ClaudeCodePromptCache but
+// is always agent-scoped, ignoring codex-cache-key-per-agent.
+//
+// Callers use this value as an upstream conversation ID rather than as a cache key: sibling agents
+// of one Claude Code session must never land in the same upstream conversation, because that mixes
+// their conversation state. Only prompt-cache sharing is configurable; conversation identity is not.
+func ClaudeCodeConversationCache(ctx context.Context, modelName string, payload []byte, headers http.Header) (CodexCache, bool, error) {
+	return claudeCodeCacheIdentity(ctx, modelName, payload, headers, true)
+}
+
+// claudeCodeCacheIdentity hashes the model and the Claude Code scope into a stable UUID.
+func claudeCodeCacheIdentity(ctx context.Context, modelName string, payload []byte, headers http.Header, perAgent bool) (CodexCache, bool, error) {
+	modelName = strings.TrimSpace(modelName)
+	executionScope, ok := claudeCodeScope(ctx, payload, headers, perAgent)
 	if modelName == "" || !ok {
 		return CodexCache{}, false, nil
 	}

--- a/internal/runtime/executor/helps/claude_code_session_test.go
+++ b/internal/runtime/executor/helps/claude_code_session_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
 
 func TestExtractClaudeCodeSessionIDFromPayloadJSON(t *testing.T) {
@@ -118,5 +119,43 @@ func TestClaudeCodePromptCacheDeterministicAndAgentScoped(t *testing.T) {
 	otherModel, ok, errModel := ClaudeCodePromptCache(context.Background(), "gpt-5.5", nil, rootHeaders)
 	if errModel != nil || !ok || otherModel.ID == rootFirst.ID {
 		t.Fatalf("other model cache = %#v, %v, %v; root ID %q", otherModel, ok, errModel, rootFirst.ID)
+	}
+}
+
+func TestClaudeCodePromptCacheSharesPartitionWhenPerAgentDisabled(t *testing.T) {
+	rootHeaders := http.Header{}
+	rootHeaders.Set(ClaudeCodeSessionHeader, "session-shared-partition")
+	childA := rootHeaders.Clone()
+	childA.Set(ClaudeCodeAgentHeader, "agent-a")
+	childB := rootHeaders.Clone()
+	childB.Set(ClaudeCodeAgentHeader, "agent-b")
+
+	perAgent := false
+	cfg := &config.Config{CodexCacheKeyPerAgent: &perAgent}
+
+	root, ok, err := ClaudeCodePromptCache(context.Background(), "gpt-5.4", nil, rootHeaders, cfg)
+	if err != nil || !ok {
+		t.Fatalf("root cache = %#v, %v, %v", root, ok, err)
+	}
+	for name, headers := range map[string]http.Header{"agent-a": childA, "agent-b": childB} {
+		got, ok, errAgent := ClaudeCodePromptCache(context.Background(), "gpt-5.4", nil, headers, cfg)
+		if errAgent != nil || !ok || got.ID != root.ID {
+			t.Fatalf("%s cache = %#v, %v, %v; want root ID %q", name, got, ok, errAgent, root.ID)
+		}
+	}
+
+	// A different session must still get its own partition.
+	otherSession := http.Header{}
+	otherSession.Set(ClaudeCodeSessionHeader, "session-other")
+	other, ok, errOther := ClaudeCodePromptCache(context.Background(), "gpt-5.4", nil, otherSession, cfg)
+	if errOther != nil || !ok || other.ID == root.ID {
+		t.Fatalf("other session cache = %#v, %v, %v; root ID %q", other, ok, errOther, root.ID)
+	}
+
+	// Reasoning-replay scope stays agent-qualified regardless of the flag.
+	scopeA, _ := ClaudeCodeExecutionScope(context.Background(), nil, childA)
+	scopeB, _ := ClaudeCodeExecutionScope(context.Background(), nil, childB)
+	if scopeA == scopeB {
+		t.Fatalf("execution scopes collapsed: a=%q b=%q", scopeA, scopeB)
 	}
 }

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -887,7 +887,7 @@ func (e *OpenAICompatExecutor) applyPromptCacheKey(ctx context.Context, auth *cl
 		modelName = baseModel
 	}
 	if sourceFormatEqual(from, sdktranslator.FormatClaude) {
-		cached, ok, errCache := helps.ClaudeCodePromptCache(ctx, modelName, req.Payload, opts.Headers)
+		cached, ok, errCache := helps.ClaudeCodePromptCache(ctx, modelName, req.Payload, opts.Headers, e.cfg)
 		if errCache != nil {
 			return translated, errCache
 		}

--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/uuid"
 	xaiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/xai"
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
@@ -127,7 +126,7 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	body = sanitizeXAIResponsesBody(body, baseModel)
 	body = normalizeXAIImageRefs(body)
 
-	sessionID, errSession := xaiResolveComposerSessionID(ctx, req, opts, baseModel, e.cfg)
+	sessionID, errSession := xaiResolveComposerSessionID(ctx, req, opts, baseModel)
 	if errSession != nil {
 		return nil, errSession
 	}
@@ -339,14 +338,18 @@ func applyXAIChatHeaders(r *http.Request, auth *cliproxyauth.Auth, token string,
 	applyXAICustomHeaders(r, auth, clientHeaders...)
 }
 
-func xaiResolveComposerSessionID(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, baseModel string, cfg *config.Config) (string, error) {
+// xaiResolveComposerSessionID resolves the xAI Composer conversation ID. The result feeds both
+// prompt_cache_key and the x-grok-conv-id header, so it must stay agent-scoped: sharing it across
+// sibling Claude Code agents would merge their Composer conversations. It therefore uses the
+// unconditionally agent-scoped identity and does not honour codex-cache-key-per-agent.
+func xaiResolveComposerSessionID(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, baseModel string) (string, error) {
 	if sessionID := xaiExecutionSessionID(req, opts); sessionID != "" {
 		return sessionID, nil
 	}
 	if !xaiRequiresIsolatedConversation(baseModel) {
 		return "", nil
 	}
-	cached, ok, errCache := helps.ClaudeCodePromptCache(ctx, baseModel, req.Payload, opts.Headers, cfg)
+	cached, ok, errCache := helps.ClaudeCodeConversationCache(ctx, baseModel, req.Payload, opts.Headers)
 	if errCache != nil {
 		return "", errCache
 	}

--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	xaiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/xai"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
@@ -126,7 +127,7 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	body = sanitizeXAIResponsesBody(body, baseModel)
 	body = normalizeXAIImageRefs(body)
 
-	sessionID, errSession := xaiResolveComposerSessionID(ctx, req, opts, baseModel)
+	sessionID, errSession := xaiResolveComposerSessionID(ctx, req, opts, baseModel, e.cfg)
 	if errSession != nil {
 		return nil, errSession
 	}
@@ -338,14 +339,14 @@ func applyXAIChatHeaders(r *http.Request, auth *cliproxyauth.Auth, token string,
 	applyXAICustomHeaders(r, auth, clientHeaders...)
 }
 
-func xaiResolveComposerSessionID(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, baseModel string) (string, error) {
+func xaiResolveComposerSessionID(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, baseModel string, cfg *config.Config) (string, error) {
 	if sessionID := xaiExecutionSessionID(req, opts); sessionID != "" {
 		return sessionID, nil
 	}
 	if !xaiRequiresIsolatedConversation(baseModel) {
 		return "", nil
 	}
-	cached, ok, errCache := helps.ClaudeCodePromptCache(ctx, baseModel, req.Payload, opts.Headers)
+	cached, ok, errCache := helps.ClaudeCodePromptCache(ctx, baseModel, req.Payload, opts.Headers, cfg)
 	if errCache != nil {
 		return "", errCache
 	}

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -20,6 +20,7 @@ import (
 	xaiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/xai"
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -2400,6 +2401,58 @@ func TestXAIExecutorComposerSessionIsolation(t *testing.T) {
 				t.Fatalf("x-grok-conv-id = %q, want empty", gotGrokConvID)
 			}
 		})
+	}
+}
+
+func TestXAIExecutorComposerSessionStaysAgentScopedWhenCacheKeyPerAgentDisabled(t *testing.T) {
+	perAgent := false
+	exec := NewXAIExecutor(&config.Config{CodexCacheKeyPerAgent: &perAgent})
+	auth := &cliproxyauth.Auth{
+		Provider: "xai",
+		Metadata: map[string]any{"access_token": "xai-token"},
+	}
+	payload := []byte(`{"model":"grok-composer-2.5-fast","metadata":{"user_id":"{\"session_id\":\"cache-session-shared\"}"},"input":"hello"}`)
+	req := cliproxyexecutor.Request{Model: "grok-composer-2.5-fast", Payload: payload}
+
+	agentSession := func(agentID string) (string, string) {
+		t.Helper()
+		headers := http.Header{}
+		headers.Set(helps.ClaudeCodeSessionHeader, "cache-session-shared")
+		if agentID != "" {
+			headers.Set(helps.ClaudeCodeAgentHeader, agentID)
+		}
+		prepared, err := exec.prepareResponsesRequest(context.Background(), req, cliproxyexecutor.Options{
+			SourceFormat: sdktranslator.FormatClaude,
+			Stream:       true,
+			Headers:      headers,
+		}, true)
+		if err != nil {
+			t.Fatalf("prepareResponsesRequest(%q) error = %v", agentID, err)
+		}
+		httpReq, errRequest := http.NewRequest(http.MethodPost, "https://example.test/responses", bytes.NewReader(prepared.body))
+		if errRequest != nil {
+			t.Fatalf("NewRequest() error = %v", errRequest)
+		}
+		applyXAIHeaders(httpReq, auth, "xai-token", true, prepared.sessionID)
+		return prepared.sessionID, httpReq.Header.Get("x-grok-conv-id")
+	}
+
+	agentA, convA := agentSession("agent-a")
+	agentB, convB := agentSession("agent-b")
+	root, convRoot := agentSession("")
+
+	if agentA == "" || agentB == "" || root == "" {
+		t.Fatalf("empty Composer session: root=%q a=%q b=%q", root, agentA, agentB)
+	}
+	if agentA == agentB || agentA == root || agentB == root {
+		t.Fatalf("Composer sessions collapsed across agents: root=%q a=%q b=%q", root, agentA, agentB)
+	}
+	if convA != agentA || convB != agentB || convRoot != root {
+		t.Fatalf("x-grok-conv-id does not track the Composer session: root=%q/%q a=%q/%q b=%q/%q", root, convRoot, agentA, convA, agentB, convB)
+	}
+
+	if again, _ := agentSession("agent-a"); again != agentA {
+		t.Fatalf("Composer session for agent-a is unstable: %q then %q", agentA, again)
 	}
 }
 


### PR DESCRIPTION
## Problem

`helps.ClaudeCodeExecutionScope` builds the upstream `prompt_cache_key` as
`claude:<session>:agent:<agent>`. Every subagent of a single Claude Code session therefore
opens its own OpenAI prompt-cache partition.

A fan-out of 30 subagents pays 30 first-turn full cache misses (measured: 30/30) even though
every one of those requests carries an identical system prompt and tool block. Nothing ever
reads the partition the root agent has already warmed.

## Change

Adds a top-level config key `codex-cache-key-per-agent` (`*bool`).

- **unset or `true`** — current behavior, unchanged. This is the default, so the patch is
  inert for every existing deployment.
- **`false`** — the prompt cache key is derived from the session alone, so all agents of one
  session share a single partition and a fan-out can read the prefix the root agent warmed.

## Scoping

This is deliberately narrow, and the narrowness is the important part:

- **Only the prompt cache key changes.** `ClaudeCodeExecutionScope` stays agent-qualified
  unconditionally, because it is also the session key for Codex reasoning-replay state
  (`codex_executor_reasoning.go`, `antigravity_reasoning_replay.go`). Collapsing *that* would
  let sibling agents replay each other's reasoning items — a correctness bug, not a saving.
  The flag routes only `ClaudeCodePromptCache`. A regression test in
  `claude_code_session_test.go` asserts both halves: the cache key collapses under the flag,
  the execution scope does not.

- **Config threading.** The config reaches `ClaudeCodePromptCache` as a trailing variadic
  `...*config.Config`, the same shape `helps.DetectClaudeCodeRequest` already uses, so a
  caller without a config in scope keeps the default. `cfg` is threaded from the executor
  receivers at the three production call sites that share the prompt cache: codex HTTP,
  codex websockets, and openai-compat. The xai path intentionally ignores the flag: its
  Claude Code identity feeds both `prompt_cache_key` and the Composer conversation id
  (`x-grok-conv-id`), so it stays agent-scoped unconditionally via
  `ClaudeCodeConversationCache` (second commit).

## Risk

Low, and bounded by how prompt caching works: a cache key is a lookup hint, not a content
address. If the prefix is not in fact shared across agents, a request under the collapsed key
simply misses — it cannot return another agent's content. The cost of being wrong is a wasted
lookup; the flag defaults to off regardless.

## Verification

`go build ./...`, `go vet ./internal/...`, `go test ./...` and `gofmt -l internal/` are all
clean on this branch against current `main`.

