### PR TITLE
feat: support route-specific auth priorities

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -698,6 +698,9 @@ nonstream-keepalive-interval: 0
 #   fork: true                  # keep the upstream model and also expose the alias as a separate client-visible model
 #   display-name: "Model Name" # override the human-readable name shown in model catalogs
 #   force-mapping: true         # rewrite upstream response model fields back to the client-visible alias (example below uses antigravity only)
+#   routing-priority: 300       # override this credential's priority only for the requested alias
+# `name` and `alias` may be identical when the entry only supplies a route-specific priority.
+# Rotated priorities can model a bounded fallback ring; request retry tracking still prevents revisiting a credential.
 # Per-auth OAuth aliases can also be stored in an OAuth auth JSON file as "model_aliases".
 # Legacy "model-aliases" credentials remain supported and are normalized at load time.
 # They apply only to that selected auth and take precedence over global aliases for the same client-visible alias.
@@ -706,7 +709,7 @@ nonstream-keepalive-interval: 0
 #   "type": "codex",
 #   "email": "user@example.com",
 #   "model_aliases": [
-#     {"name": "gpt-5.3-codex-spark", "alias": "gpt-5.5"},
+#     {"name": "gpt-5.3-codex-spark", "alias": "gpt-5.5", "routing-priority": 300},
 #     {"name": "gpt-5.3-codex-spark", "alias": "gpt-5.4"}
 #   ]
 # }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -698,12 +698,12 @@ nonstream-keepalive-interval: 0
 #   fork: true                  # keep the upstream model and also expose the alias as a separate client-visible model
 #   display-name: "Model Name" # override the human-readable name shown in model catalogs
 #   force-mapping: true         # rewrite upstream response model fields back to the client-visible alias (example below uses antigravity only)
-#   routing-priority: 300       # override this credential's priority only for the requested alias
-# `name` and `alias` may be identical when the entry only supplies a route-specific priority.
-# Rotated priorities can model a bounded fallback ring; request retry tracking still prevents revisiting a credential.
 # Per-auth OAuth aliases can also be stored in an OAuth auth JSON file as "model_aliases".
 # Legacy "model-aliases" credentials remain supported and are normalized at load time.
 # They apply only to that selected auth and take precedence over global aliases for the same client-visible alias.
+# Per-auth entries additionally support `routing-priority`, which overrides that credential's priority only for the requested alias.
+# For a priority-only override, `name` and `alias` may be identical. Rotated per-auth priorities can model a bounded
+# fallback ring; request retry tracking still prevents revisiting a credential.
 # Example auth JSON:
 # {
 #   "type": "codex",

--- a/internal/config/config_normalization.go
+++ b/internal/config/config_normalization.go
@@ -79,7 +79,7 @@ func (cfg *Config) SanitizeOAuthModelAlias() {
 			if name == "" || alias == "" {
 				continue
 			}
-			if strings.EqualFold(name, alias) {
+			if strings.EqualFold(name, alias) && entry.RoutingPriority == nil {
 				continue
 			}
 			aliasKey := strings.ToLower(alias)
@@ -88,11 +88,12 @@ func (cfg *Config) SanitizeOAuthModelAlias() {
 			}
 			seenAlias[aliasKey] = struct{}{}
 			clean = append(clean, OAuthModelAlias{
-				Name:         name,
-				Alias:        alias,
-				Fork:         entry.Fork,
-				DisplayName:  strings.TrimSpace(entry.DisplayName),
-				ForceMapping: entry.ForceMapping,
+				Name:            name,
+				Alias:           alias,
+				Fork:            entry.Fork,
+				DisplayName:     strings.TrimSpace(entry.DisplayName),
+				ForceMapping:    entry.ForceMapping,
+				RoutingPriority: entry.RoutingPriority,
 			})
 		}
 		if len(clean) > 0 {

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -260,6 +260,10 @@ type OAuthModelAlias struct {
 	DisplayName string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
 
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// RoutingPriority overrides the credential priority only when this alias is requested.
+	// This lets several aliases expose rotated fallback orders without duplicating credentials.
+	RoutingPriority *int `yaml:"routing-priority,omitempty" json:"routing-priority,omitempty"`
 }
 
 // PayloadConfig defines default and override parameter rules applied to provider payloads.

--- a/internal/config/oauth_model_alias_test.go
+++ b/internal/config/oauth_model_alias_test.go
@@ -3,10 +3,11 @@ package config
 import "testing"
 
 func TestSanitizeOAuthModelAlias_PreservesOptionalFields(t *testing.T) {
+	routingPriority := 300
 	cfg := &Config{
 		OAuthModelAlias: map[string][]OAuthModelAlias{
 			" CoDeX ": {
-				{Name: " gpt-5 ", Alias: " g5 ", Fork: true, DisplayName: " GPT Five ", ForceMapping: true},
+				{Name: " gpt-5 ", Alias: " g5 ", Fork: true, DisplayName: " GPT Five ", ForceMapping: true, RoutingPriority: &routingPriority},
 				{Name: "gpt-6", Alias: "g6"},
 			},
 		},
@@ -18,11 +19,33 @@ func TestSanitizeOAuthModelAlias_PreservesOptionalFields(t *testing.T) {
 	if len(aliases) != 2 {
 		t.Fatalf("expected 2 sanitized aliases, got %d", len(aliases))
 	}
-	if aliases[0].Name != "gpt-5" || aliases[0].Alias != "g5" || !aliases[0].Fork || aliases[0].DisplayName != "GPT Five" || !aliases[0].ForceMapping {
+	if aliases[0].Name != "gpt-5" || aliases[0].Alias != "g5" || !aliases[0].Fork || aliases[0].DisplayName != "GPT Five" || !aliases[0].ForceMapping || aliases[0].RoutingPriority == nil || *aliases[0].RoutingPriority != routingPriority {
 		t.Fatalf("unexpected sanitized first alias: %+v", aliases[0])
 	}
 	if aliases[1].Name != "gpt-6" || aliases[1].Alias != "g6" || aliases[1].Fork || aliases[1].DisplayName != "" || aliases[1].ForceMapping {
 		t.Fatalf("unexpected sanitized second alias: %+v", aliases[1])
+	}
+}
+
+func TestSanitizeOAuthModelAlias_PreservesSameNameRoutingOverride(t *testing.T) {
+	routingPriority := -10
+	cfg := &Config{
+		OAuthModelAlias: map[string][]OAuthModelAlias{
+			"codex": {
+				{Name: " gpt-5.6-luna ", Alias: " GPT-5.6-LUNA ", RoutingPriority: &routingPriority},
+				{Name: "gpt-5.6-luna", Alias: "gpt-5.6-luna"},
+			},
+		},
+	}
+
+	cfg.SanitizeOAuthModelAlias()
+
+	aliases := cfg.OAuthModelAlias["codex"]
+	if len(aliases) != 1 {
+		t.Fatalf("expected only the same-name routing override, got %+v", aliases)
+	}
+	if aliases[0].Name != "gpt-5.6-luna" || aliases[0].Alias != "GPT-5.6-LUNA" || aliases[0].RoutingPriority == nil || *aliases[0].RoutingPriority != routingPriority {
+		t.Fatalf("unexpected same-name routing override: %+v", aliases[0])
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -336,7 +336,7 @@ func (m *Manager) availableAuthsForRouteModelWithPriorityMode(auths []*Auth, pro
 		checkModel := m.selectionModelForAuth(candidate, routeModel)
 		blocked, reason, next := isAuthBlockedForModel(candidate, checkModel, now)
 		if !blocked {
-			priority := authPriority(candidate)
+			priority := authPriorityForModel(candidate, routeModel)
 			availableByPriority[priority] = append(availableByPriority[priority], candidate)
 			continue
 		}
@@ -388,7 +388,7 @@ func (m *Manager) availableAuthsForSelector(selector Selector, auths []*Auth, pr
 		return nil, nil, err
 	}
 	selectorAuths = cloneAuthSlice(selectorAuths)
-	return highestPriorityAuths(selectorAuths), selectorAuths, nil
+	return highestPriorityAuthsForModel(selectorAuths, routeModel), selectorAuths, nil
 }
 
 func selectionArgForSelector(selector Selector, routeModel string) string {
@@ -475,7 +475,7 @@ func cloneAuthSlice(auths []*Auth) []*Auth {
 	return out
 }
 
-func schedulerAuthCandidates(auths []*Auth) []pluginapi.SchedulerAuthCandidate {
+func schedulerAuthCandidates(auths []*Auth, model string) []pluginapi.SchedulerAuthCandidate {
 	if len(auths) == 0 {
 		return nil
 	}
@@ -487,7 +487,7 @@ func schedulerAuthCandidates(auths []*Auth) []pluginapi.SchedulerAuthCandidate {
 		out = append(out, pluginapi.SchedulerAuthCandidate{
 			ID:         auth.ID,
 			Provider:   strings.ToLower(strings.TrimSpace(auth.Provider)),
-			Priority:   authPriority(auth),
+			Priority:   authPriorityForModel(auth, model),
 			Status:     string(auth.Status),
 			Attributes: schedulerSafeAttributes(auth.Attributes),
 		})
@@ -591,7 +591,7 @@ func (m *Manager) pickViaPluginScheduler(ctx context.Context, scheduler PluginSc
 		Model:      model,
 		Stream:     opts.Stream,
 		Options:    schedulerOptions(opts),
-		Candidates: schedulerAuthCandidates(candidates),
+		Candidates: schedulerAuthCandidates(candidates, model),
 	}
 	resp, handled, errPick := scheduler.PickAuth(ctx, req)
 	if errPick != nil {
@@ -1218,7 +1218,8 @@ func (m *Manager) routeAwareSelectionRequired(auth *Auth, routeModel string) boo
 	if auth == nil || strings.TrimSpace(routeModel) == "" {
 		return false
 	}
-	return m.selectionModelKeyForAuth(auth, routeModel) != canonicalModelKey(routeModel)
+	return m.selectionModelKeyForAuth(auth, routeModel) != canonicalModelKey(routeModel) ||
+		authPriorityForModel(auth, routeModel) != authPriority(auth)
 }
 
 func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, error) {

--- a/sdk/cliproxy/auth/routing_priority_test.go
+++ b/sdk/cliproxy/auth/routing_priority_test.go
@@ -165,3 +165,21 @@ func TestRoutingPriorityAppliesToAffinitySchedulerAndFastPath(t *testing.T) {
 		t.Fatalf("affinity sticky pick = %#v, want existing binding %q", selected, authA.ID)
 	}
 }
+
+func TestAuthPriorityForModelNormalizesPrefixAndPrefersExactSuffix(t *testing.T) {
+	auth := &Auth{
+		Prefix:     "account-b",
+		Attributes: map[string]string{"priority": "100"},
+	}
+	SetOAuthModelAliasesAttribute(auth, []internalconfig.OAuthModelAlias{
+		{Name: "native", Alias: "route", RoutingPriority: routePriority(200)},
+		{Name: "native", Alias: "route(high)", RoutingPriority: routePriority(300)},
+	})
+
+	if got := authPriorityForModel(auth, "account-b/route(high)"); got != 300 {
+		t.Fatalf("prefixed exact suffix priority = %d, want 300", got)
+	}
+	if got := authPriorityForModel(auth, "account-b/route(low)"); got != 200 {
+		t.Fatalf("prefixed base fallback priority = %d, want 200", got)
+	}
+}

--- a/sdk/cliproxy/auth/routing_priority_test.go
+++ b/sdk/cliproxy/auth/routing_priority_test.go
@@ -9,28 +9,27 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
-func TestRoutingPriorityRotatesFallbackRing(t *testing.T) {
+func TestRoutingPrioritySupportsPreferredRingEntryPoints(t *testing.T) {
 	const (
 		provider = "codex"
 		upstream = "ring-native-model"
 		routeA   = "ring-route-a"
 		routeB   = "ring-route-b"
-		routeArk = "ring-route-ark"
 	)
 
 	manager := NewManager(nil, nil, nil)
 	manager.SetSelector(&FillFirstSelector{})
 	manager.RegisterExecutor(schedulerTestExecutor{provider: provider})
 
-	routes := []string{routeA, routeB, routeArk}
+	routes := []string{routeA, routeB}
 	auths := []struct {
 		id              string
 		globalPriority  string
 		routingPriority []int
 	}{
-		{id: "account-a", globalPriority: "300", routingPriority: []int{300, 100, 200}},
-		{id: "account-b", globalPriority: "200", routingPriority: []int{200, 300, 100}},
-		{id: "ark", globalPriority: "100", routingPriority: []int{100, 200, 300}},
+		{id: "account-a", globalPriority: "300", routingPriority: []int{300, 200}},
+		{id: "account-b", globalPriority: "200", routingPriority: []int{200, 300}},
+		{id: "ark", globalPriority: "100", routingPriority: []int{100, 100}},
 	}
 
 	ctx := context.Background()
@@ -64,8 +63,7 @@ func TestRoutingPriorityRotatesFallbackRing(t *testing.T) {
 		want  []string
 	}{
 		{name: "route A starts at A", model: routeA, want: []string{"account-a", "account-b", "ark"}},
-		{name: "route B starts at B", model: routeB, want: []string{"account-b", "ark", "account-a"}},
-		{name: "route Ark starts at Ark", model: routeArk, want: []string{"ark", "account-a", "account-b"}},
+		{name: "route B starts at B", model: routeB, want: []string{"account-b", "account-a", "ark"}},
 		{name: "no override keeps global order", model: upstream, want: []string{"account-a", "account-b", "ark"}},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/sdk/cliproxy/auth/routing_priority_test.go
+++ b/sdk/cliproxy/auth/routing_priority_test.go
@@ -1,0 +1,92 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestRoutingPriorityRotatesFallbackRing(t *testing.T) {
+	const (
+		provider = "codex"
+		upstream = "ring-native-model"
+		routeA   = "ring-route-a"
+		routeB   = "ring-route-b"
+		routeArk = "ring-route-ark"
+	)
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetSelector(&FillFirstSelector{})
+	manager.RegisterExecutor(schedulerTestExecutor{provider: provider})
+
+	routes := []string{routeA, routeB, routeArk}
+	auths := []struct {
+		id              string
+		globalPriority  string
+		routingPriority []int
+	}{
+		{id: "account-a", globalPriority: "300", routingPriority: []int{300, 100, 200}},
+		{id: "account-b", globalPriority: "200", routingPriority: []int{200, 300, 100}},
+		{id: "ark", globalPriority: "100", routingPriority: []int{100, 200, 300}},
+	}
+
+	ctx := context.Background()
+	for _, authSpec := range auths {
+		auth := &Auth{
+			ID:         authSpec.id,
+			Provider:   provider,
+			Status:     StatusActive,
+			Attributes: map[string]string{"priority": authSpec.globalPriority},
+		}
+		aliases := make([]internalconfig.OAuthModelAlias, 0, len(routes))
+		for index, route := range routes {
+			priority := authSpec.routingPriority[index]
+			aliases = append(aliases, internalconfig.OAuthModelAlias{
+				Name:            upstream,
+				Alias:           route,
+				RoutingPriority: &priority,
+			})
+		}
+		SetOAuthModelAliasesAttribute(auth, aliases)
+		if _, errRegister := manager.Register(WithSkipPersist(ctx), auth); errRegister != nil {
+			t.Fatalf("Register(%s): %v", auth.ID, errRegister)
+		}
+		registry.GetGlobalRegistry().RegisterClient(auth.ID, provider, []*registry.ModelInfo{{ID: upstream}})
+		t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+	}
+
+	for _, testCase := range []struct {
+		name  string
+		model string
+		want  []string
+	}{
+		{name: "route A starts at A", model: routeA, want: []string{"account-a", "account-b", "ark"}},
+		{name: "route B starts at B", model: routeB, want: []string{"account-b", "ark", "account-a"}},
+		{name: "route Ark starts at Ark", model: routeArk, want: []string{"ark", "account-a", "account-b"}},
+		{name: "no override keeps global order", model: upstream, want: []string{"account-a", "account-b", "ark"}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			tried := make(map[string]struct{}, len(testCase.want))
+			for index, wantID := range testCase.want {
+				selected, _, errPick := manager.pickNext(ctx, provider, testCase.model, cliproxyexecutor.Options{}, tried)
+				if errPick != nil {
+					t.Fatalf("pick #%d: %v", index, errPick)
+				}
+				if selected == nil || selected.ID != wantID {
+					t.Fatalf("pick #%d = %#v, want %q", index, selected, wantID)
+				}
+				if _, duplicate := tried[selected.ID]; duplicate {
+					t.Fatalf("pick #%d repeated credential %q", index, selected.ID)
+				}
+				tried[selected.ID] = struct{}{}
+			}
+
+			if selected, _, errPick := manager.pickNext(ctx, provider, testCase.model, cliproxyexecutor.Options{}, tried); errPick == nil || selected != nil {
+				t.Fatalf("pick after one traversal = %#v, %v; want exhausted ring", selected, errPick)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/auth/routing_priority_test.go
+++ b/sdk/cliproxy/auth/routing_priority_test.go
@@ -3,11 +3,16 @@ package auth
 import (
 	"context"
 	"testing"
+	"time"
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
+
+func routePriority(value int) *int {
+	return &value
+}
 
 func TestRoutingPrioritySupportsPreferredRingEntryPoints(t *testing.T) {
 	const (
@@ -86,5 +91,77 @@ func TestRoutingPrioritySupportsPreferredRingEntryPoints(t *testing.T) {
 				t.Fatalf("pick after one traversal = %#v, %v; want exhausted ring", selected, errPick)
 			}
 		})
+	}
+}
+
+func TestRoutingPriorityAppliesToAffinitySchedulerAndFastPath(t *testing.T) {
+	const route = "gpt-5.6-luna"
+	authA := &Auth{
+		ID:         "account-a",
+		Provider:   "codex",
+		Status:     StatusActive,
+		Attributes: map[string]string{"priority": "300"},
+	}
+	authB := &Auth{
+		ID:         "account-b",
+		Provider:   "codex",
+		Status:     StatusActive,
+		Attributes: map[string]string{"priority": "200"},
+	}
+	SetOAuthModelAliasesAttribute(authA, []internalconfig.OAuthModelAlias{{
+		Name: route, Alias: route, RoutingPriority: routePriority(200),
+	}})
+	SetOAuthModelAliasesAttribute(authB, []internalconfig.OAuthModelAlias{{
+		Name: route, Alias: route, RoutingPriority: routePriority(300),
+	}})
+
+	manager := NewManager(nil, nil, nil)
+	if !manager.routeAwareSelectionRequired(authA, route) {
+		t.Fatal("same-name priority override did not require route-aware selection")
+	}
+
+	candidates := schedulerAuthCandidates([]*Auth{authA, authB}, route)
+	if len(candidates) != 2 || candidates[0].Priority != 200 || candidates[1].Priority != 300 {
+		t.Fatalf("scheduler candidates = %+v, want route priorities 200 and 300", candidates)
+	}
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &FillFirstSelector{},
+		TTL:      time.Hour,
+	})
+	defer selector.Stop()
+	opts := cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.DerivedSessionIDMetadataKey: "stable-session",
+	}}
+	selected, errPick := selector.Pick(
+		context.Background(), "codex", route, opts, []*Auth{authA, authB},
+	)
+	if errPick != nil {
+		t.Fatalf("affinity cold pick: %v", errPick)
+	}
+	if selected == nil || selected.ID != authB.ID {
+		t.Fatalf("affinity cold pick = %#v, want route-preferred %q", selected, authB.ID)
+	}
+
+	authB.Unavailable = true
+	selected, errPick = selector.Pick(
+		context.Background(), "codex", route, opts, []*Auth{authA, authB},
+	)
+	if errPick != nil {
+		t.Fatalf("affinity failover pick: %v", errPick)
+	}
+	if selected == nil || selected.ID != authA.ID {
+		t.Fatalf("affinity failover pick = %#v, want %q", selected, authA.ID)
+	}
+
+	authB.Unavailable = false
+	selected, errPick = selector.Pick(
+		context.Background(), "codex", route, opts, []*Auth{authA, authB},
+	)
+	if errPick != nil {
+		t.Fatalf("affinity sticky pick: %v", errPick)
+	}
+	if selected == nil || selected.ID != authA.ID {
+		t.Fatalf("affinity sticky pick = %#v, want existing binding %q", selected, authA.ID)
 	}
 }

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -165,15 +165,17 @@ func authPriority(auth *Auth) int {
 
 func authPriorityForModel(auth *Auth, model string) int {
 	defaultPriority := authPriority(auth)
-	_, candidates := modelAliasLookupCandidates(model)
+	requestedModel := rewriteModelForAuth(strings.TrimSpace(model), auth)
+	_, candidates := modelAliasLookupCandidates(requestedModel)
 	if len(candidates) == 0 {
 		return defaultPriority
 	}
-	for _, entry := range OAuthModelAliasesFromAttributes(authAttributes(auth)) {
-		if entry.RoutingPriority == nil {
-			continue
-		}
-		for _, candidate := range candidates {
+	entries := OAuthModelAliasesFromAttributes(authAttributes(auth))
+	for _, candidate := range candidates {
+		for _, entry := range entries {
+			if entry.RoutingPriority == nil {
+				continue
+			}
 			if strings.EqualFold(strings.TrimSpace(entry.Alias), strings.TrimSpace(candidate)) {
 				return *entry.RoutingPriority
 			}

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -163,6 +163,25 @@ func authPriority(auth *Auth) int {
 	return parsed
 }
 
+func authPriorityForModel(auth *Auth, model string) int {
+	defaultPriority := authPriority(auth)
+	_, candidates := modelAliasLookupCandidates(model)
+	if len(candidates) == 0 {
+		return defaultPriority
+	}
+	for _, entry := range OAuthModelAliasesFromAttributes(authAttributes(auth)) {
+		if entry.RoutingPriority == nil {
+			continue
+		}
+		for _, candidate := range candidates {
+			if strings.EqualFold(strings.TrimSpace(entry.Alias), strings.TrimSpace(candidate)) {
+				return *entry.RoutingPriority
+			}
+		}
+	}
+	return defaultPriority
+}
+
 func authWeight(auth *Auth) int64 {
 	if auth == nil {
 		return credentialweight.Default
@@ -259,7 +278,7 @@ func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (ava
 		candidate := auths[i]
 		blocked, reason, next := isAuthBlockedForModel(candidate, model, now)
 		if !blocked {
-			priority := authPriority(candidate)
+			priority := authPriorityForModel(candidate, model)
 			available[priority] = append(available[priority], candidate)
 			continue
 		}
@@ -344,13 +363,17 @@ func availableAuthsFromPriorityBuckets(availableByPriority map[int][]*Auth, allP
 // preserving the input order. The input slice is returned unchanged when every candidate
 // already shares the highest priority, so the common single-tier case allocates nothing.
 func highestPriorityAuths(auths []*Auth) []*Auth {
+	return highestPriorityAuthsForModel(auths, "")
+}
+
+func highestPriorityAuthsForModel(auths []*Auth, model string) []*Auth {
 	if len(auths) <= 1 {
 		return auths
 	}
 	bestPriority := 0
 	bestCount := 0
 	for _, auth := range auths {
-		priority := authPriority(auth)
+		priority := authPriorityForModel(auth, model)
 		switch {
 		case bestCount == 0 || priority > bestPriority:
 			bestPriority = priority
@@ -364,7 +387,7 @@ func highestPriorityAuths(auths []*Auth) []*Auth {
 	}
 	highest := make([]*Auth, 0, bestCount)
 	for _, auth := range auths {
-		if authPriority(auth) == bestPriority {
+		if authPriorityForModel(auth, model) == bestPriority {
 			highest = append(highest, auth)
 		}
 	}
@@ -729,7 +752,7 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	if err != nil {
 		return nil, err
 	}
-	fallbackAuths := highestPriorityAuths(available)
+	fallbackAuths := highestPriorityAuthsForModel(available, model)
 
 	modelKey := canonicalModelKey(model)
 	cacheKey := provider + "::" + primaryID + "::" + modelKey


### PR DESCRIPTION
## Summary
- add an optional routing-priority field to per-auth OAuth model aliases
- apply the effective route priority across legacy selection, session affinity, and plugin scheduler candidates
- preserve the existing global credential priority when no route override is configured
- allow same-name aliases to carry a priority-only override

This supports a bounded account fallback ring with preferred entry points, such as A -> B -> fallback and B -> A -> fallback. Existing per-request tried tracking still guarantees that a credential is visited at most once.

## Validation
- go test ./...
- go test ./sdk/cliproxy/auth ./internal/config ./internal/watcher/...
- go build -o test-output ./cmd/server
- git diff --check

## Compatibility
The new field is optional. Configurations without routing-priority retain the existing global-priority behavior.