### PR TITLE
feat(executor): add provider request rate limiting

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -614,6 +614,8 @@ nonstream-keepalive-interval: 0
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
 #     support-prompt-cache-key: false # optional: derive prompt_cache_key for requests from all input protocols
+#     requests-per-minute: 0 # optional: smooth requests to this provider; 0 disables limiting
+#     # An upstream 429 also pauses the same credential until Retry-After, or for one minute when absent.
 #     disable-cooling: false # optional provider override: true disables cooling, false enables it; omit to inherit global
 #     request-retry: 3 # optional per-provider override; 0 disables additional rounds; omit or set < 0 to inherit global
 #     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
+	golang.org/x/time v0.14.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -55,7 +56,6 @@ require (
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 )
 
 require (

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -48,6 +48,7 @@ type openAICompatibilityWithAuthIndex struct {
 	Models                []config.OpenAICompatibilityModel        `json:"models,omitempty"`
 	Headers               map[string]string                        `json:"headers,omitempty"`
 	SupportPromptCacheKey bool                                     `json:"support-prompt-cache-key,omitempty"`
+	RequestsPerMinute     int                                      `json:"requests-per-minute,omitempty"`
 	DisableCooling        *bool                                    `json:"disable-cooling,omitempty"`
 	RequestRetry          *int                                     `json:"request-retry,omitempty"`
 	RequestScopedErrors   []config.RequestScopedErrorRule          `json:"request-scoped-errors,omitempty"`
@@ -309,6 +310,7 @@ func (h *Handler) openAICompatibilityWithAuthIndex() []openAICompatibilityWithAu
 			Models:                entry.Models,
 			Headers:               entry.Headers,
 			SupportPromptCacheKey: entry.SupportPromptCacheKey,
+			RequestsPerMinute:     entry.RequestsPerMinute,
 			DisableCooling:        entry.DisableCooling,
 			RequestRetry:          entry.RequestRetry,
 			RequestScopedErrors:   entry.RequestScopedErrors,

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -774,6 +774,10 @@ func (h *Handler) PutOpenAICompat(c *gin.Context) {
 	filtered := make([]config.OpenAICompatibility, 0, len(arr))
 	for i := range arr {
 		normalizeOpenAICompatibilityEntry(&arr[i])
+		if arr[i].RequestsPerMinute < 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("openai-compatibility[%d].requests-per-minute must be non-negative", i)})
+			return
+		}
 		if strings.TrimSpace(arr[i].BaseURL) == "" {
 			continue
 		}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -801,6 +802,7 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 		Models                *[]config.OpenAICompatibilityModel  `json:"models"`
 		Headers               *map[string]string                  `json:"headers"`
 		SupportPromptCacheKey *bool                               `json:"support-prompt-cache-key"`
+		RequestsPerMinute     *int                                `json:"requests-per-minute"`
 		RequestRetry          *int                                `json:"request-retry"`
 		RequestScopedErrors   *[]config.RequestScopedErrorRule    `json:"request-scoped-errors"`
 	}
@@ -877,6 +879,13 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 	}
 	if body.Value.SupportPromptCacheKey != nil {
 		entry.SupportPromptCacheKey = *body.Value.SupportPromptCacheKey
+	}
+	if body.Value.RequestsPerMinute != nil {
+		if *body.Value.RequestsPerMinute < 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "requests-per-minute must be non-negative"})
+			return
+		}
+		entry.RequestsPerMinute = *body.Value.RequestsPerMinute
 	}
 	if body.Value.RequestScopedErrors != nil {
 		entry.RequestScopedErrors = append([]config.RequestScopedErrorRule(nil), *body.Value.RequestScopedErrors...)

--- a/internal/api/handlers/management/config_openai_compat_test.go
+++ b/internal/api/handlers/management/config_openai_compat_test.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,17 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
+
+func TestPutOpenAICompatRejectsNegativeRequestsPerMinute(t *testing.T) {
+	h := NewHandlerWithoutConfigFilePath(&config.Config{}, nil)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPut, "/v0/management/openai-compatibility", bytes.NewBufferString(`[{"name":"bad","base-url":"https://example.com/v1","requests-per-minute":-1}]`))
+	h.PutOpenAICompat(ctx)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+}
 
 func TestGetOpenAICompatIncludesDisableCooling(t *testing.T) {
 	t.Setenv("MANAGEMENT_PASSWORD", "")

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -675,6 +675,9 @@ type OpenAICompatibility struct {
 	// SupportPromptCacheKey enables derived prompt_cache_key injection for supported requests.
 	SupportPromptCacheKey bool `yaml:"support-prompt-cache-key,omitempty" json:"support-prompt-cache-key,omitempty"`
 
+	// RequestsPerMinute smooths outgoing requests to this provider. Values <= 0 disable it.
+	RequestsPerMinute int `yaml:"requests-per-minute,omitempty" json:"requests-per-minute,omitempty"`
+
 	// DisableCooling overrides the global cooling policy for this provider when set.
 	// True disables auth/model cooldowns; false explicitly enables them.
 	DisableCooling *bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`

--- a/internal/runtime/executor/helps/provider_rate_limiter.go
+++ b/internal/runtime/executor/helps/provider_rate_limiter.go
@@ -1,0 +1,129 @@
+package helps
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"golang.org/x/time/rate"
+)
+
+const rateLimitWindowFallback = time.Minute
+
+type providerRateState struct {
+	limiter      *rate.Limiter
+	rpm          int
+	blockedUntil time.Time
+}
+
+// ProviderRateLimitRegistry owns limiters for one executor instance, allowing
+// configuration reloads to retire stale provider state with the old executor.
+type ProviderRateLimitRegistry struct {
+	mu     sync.Mutex
+	states map[string]*providerRateState
+}
+
+func NewProviderRateLimitRegistry() *ProviderRateLimitRegistry {
+	return &ProviderRateLimitRegistry{states: make(map[string]*providerRateState)}
+}
+
+func providerRateKey(compat *config.OpenAICompatibility, providerKey, authID string) string {
+	if compat == nil || compat.RequestsPerMinute <= 0 {
+		return ""
+	}
+	key := strings.TrimSpace(providerKey)
+	if key == "" {
+		return ""
+	}
+	if authID != "" {
+		key += "|" + authID
+	}
+	return key
+}
+
+// Wait blocks until the configured provider rate allows another request or the
+// request context is canceled. It also honors a previous upstream Retry-After.
+func (r *ProviderRateLimitRegistry) Wait(ctx context.Context, compat *config.OpenAICompatibility, providerKey, authID string) error {
+	key := providerRateKey(compat, providerKey, authID)
+	if key == "" || r == nil {
+		return nil
+	}
+	rpm := compat.RequestsPerMinute
+
+	r.mu.Lock()
+	state := r.states[key]
+	if state == nil || state.rpm != rpm {
+		state = &providerRateState{
+			limiter: rate.NewLimiter(rate.Every(time.Minute/time.Duration(rpm)), 1),
+			rpm:     rpm,
+		}
+		r.states[key] = state
+	}
+	blockedUntil := state.blockedUntil
+	limiter := state.limiter
+	r.mu.Unlock()
+
+	if pause := time.Until(blockedUntil); pause > 0 {
+		timer := time.NewTimer(pause)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return limiter.Wait(ctx)
+}
+
+// NoteLimited pauses subsequent requests after an upstream 429 response.
+func (r *ProviderRateLimitRegistry) NoteLimited(compat *config.OpenAICompatibility, providerKey, authID string, header http.Header) {
+	key := providerRateKey(compat, providerKey, authID)
+	if key == "" || r == nil {
+		return
+	}
+	pause := parseRetryAfter(header)
+	if pause <= 0 {
+		pause = rateLimitWindowFallback
+	}
+	until := time.Now().Add(pause)
+
+	r.mu.Lock()
+	state := r.states[key]
+	if state == nil || state.rpm != compat.RequestsPerMinute {
+		state = &providerRateState{
+			limiter: rate.NewLimiter(rate.Every(time.Minute/time.Duration(compat.RequestsPerMinute)), 1),
+			rpm:     compat.RequestsPerMinute,
+		}
+		r.states[key] = state
+	}
+	if until.After(state.blockedUntil) {
+		state.blockedUntil = until
+	}
+	r.mu.Unlock()
+}
+
+func parseRetryAfter(header http.Header) time.Duration {
+	if header == nil {
+		return 0
+	}
+	raw := strings.TrimSpace(header.Get("Retry-After"))
+	if raw == "" {
+		return 0
+	}
+	if seconds, errParse := strconv.Atoi(raw); errParse == nil {
+		if seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+		return 0
+	}
+	if when, errParse := http.ParseTime(raw); errParse == nil {
+		if delay := time.Until(when); delay > 0 {
+			return delay
+		}
+	}
+	return 0
+}

--- a/internal/runtime/executor/helps/provider_rate_limiter.go
+++ b/internal/runtime/executor/helps/provider_rate_limiter.go
@@ -98,8 +98,8 @@ func (r *ProviderRateLimitRegistry) NoteLimited(compat *config.OpenAICompatibili
 	if key == "" || r == nil {
 		return
 	}
-	pause := parseRetryAfter(header)
-	if pause <= 0 {
+	pause, validRetryAfter := parseRetryAfter(header)
+	if !validRetryAfter {
 		pause = rateLimitWindowFallback
 	}
 	until := time.Now().Add(pause)
@@ -119,24 +119,26 @@ func (r *ProviderRateLimitRegistry) NoteLimited(compat *config.OpenAICompatibili
 	r.mu.Unlock()
 }
 
-func parseRetryAfter(header http.Header) time.Duration {
+func parseRetryAfter(header http.Header) (time.Duration, bool) {
 	if header == nil {
-		return 0
+		return 0, false
 	}
 	raw := strings.TrimSpace(header.Get("Retry-After"))
 	if raw == "" {
-		return 0
+		return 0, false
 	}
 	if seconds, errParse := strconv.Atoi(raw); errParse == nil {
-		if seconds > 0 {
-			return time.Duration(seconds) * time.Second
+		if seconds >= 0 {
+			return time.Duration(seconds) * time.Second, true
 		}
-		return 0
+		return 0, false
 	}
 	if when, errParse := http.ParseTime(raw); errParse == nil {
-		if delay := time.Until(when); delay > 0 {
-			return delay
+		delay := time.Until(when)
+		if delay < 0 {
+			delay = 0
 		}
+		return delay, true
 	}
-	return 0
+	return 0, false
 }

--- a/internal/runtime/executor/helps/provider_rate_limiter.go
+++ b/internal/runtime/executor/helps/provider_rate_limiter.go
@@ -67,16 +67,29 @@ func (r *ProviderRateLimitRegistry) Wait(ctx context.Context, compat *config.Ope
 	limiter := state.limiter
 	r.mu.Unlock()
 
-	if pause := time.Until(blockedUntil); pause > 0 {
+	for {
+		if errWait := limiter.Wait(ctx); errWait != nil {
+			return errWait
+		}
+
+		// A queued caller may have started waiting before another request received
+		// a 429. Re-read the shared pause after every limiter wake so already queued
+		// calls also honor newly published Retry-After windows.
+		r.mu.Lock()
+		blockedUntil = state.blockedUntil
+		r.mu.Unlock()
+		pause := time.Until(blockedUntil)
+		if pause <= 0 {
+			return nil
+		}
 		timer := time.NewTimer(pause)
-		defer timer.Stop()
 		select {
 		case <-timer.C:
 		case <-ctx.Done():
+			timer.Stop()
 			return ctx.Err()
 		}
 	}
-	return limiter.Wait(ctx)
 }
 
 // NoteLimited pauses subsequent requests after an upstream 429 response.

--- a/internal/runtime/executor/helps/provider_rate_limiter_test.go
+++ b/internal/runtime/executor/helps/provider_rate_limiter_test.go
@@ -109,6 +109,17 @@ func TestNoteProviderRateLimited_IgnoredWhenUnconfigured(t *testing.T) {
 	}
 }
 
+func TestParseRetryAfterPreservesValidZero(t *testing.T) {
+	header := http.Header{}
+	header.Set("Retry-After", "0")
+	if delay, ok := parseRetryAfter(header); !ok || delay != 0 {
+		t.Fatalf("parseRetryAfter zero = %v, %v; want 0, true", delay, ok)
+	}
+	if _, ok := parseRetryAfter(http.Header{}); ok {
+		t.Fatal("missing Retry-After reported as valid")
+	}
+}
+
 func TestNoteProviderRateLimited_CancelledContext(t *testing.T) {
 	registry := NewProviderRateLimitRegistry()
 	cfg := &config.OpenAICompatibility{

--- a/internal/runtime/executor/helps/provider_rate_limiter_test.go
+++ b/internal/runtime/executor/helps/provider_rate_limiter_test.go
@@ -49,6 +49,30 @@ func TestWaitProviderRateLimit_EnforcesPacing(t *testing.T) {
 	}
 }
 
+func TestWaitProviderRateLimit_RechecksRetryAfterForQueuedCall(t *testing.T) {
+	registry := NewProviderRateLimitRegistry()
+	cfg := &config.OpenAICompatibility{Name: "queued-provider", RequestsPerMinute: 60}
+	ctx := context.Background()
+	if err := registry.Wait(ctx, cfg, "provider|config:0", "key1"); err != nil {
+		t.Fatalf("initial wait: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- registry.Wait(ctx, cfg, "provider|config:0", "key1")
+	}()
+	time.Sleep(100 * time.Millisecond)
+	header := http.Header{}
+	header.Set("Retry-After", "2")
+	registry.NoteLimited(cfg, "provider|config:0", "key1", header)
+
+	select {
+	case err := <-done:
+		t.Fatalf("queued call ignored new Retry-After: %v", err)
+	case <-time.After(1200 * time.Millisecond):
+	}
+}
+
 func TestNoteProviderRateLimited_HonoursRetryAfter(t *testing.T) {
 	registry := NewProviderRateLimitRegistry()
 	cfg := &config.OpenAICompatibility{

--- a/internal/runtime/executor/helps/provider_rate_limiter_test.go
+++ b/internal/runtime/executor/helps/provider_rate_limiter_test.go
@@ -1,0 +1,101 @@
+package helps
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestWaitProviderRateLimit_Disabled(t *testing.T) {
+	registry := NewProviderRateLimitRegistry()
+	ctx := context.Background()
+	if err := registry.Wait(ctx, nil, "p1", "a1"); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	cfg := &config.OpenAICompatibility{
+		Name:              "test-provider",
+		RequestsPerMinute: 0,
+	}
+	if err := registry.Wait(ctx, cfg, "test-provider", "a1"); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestWaitProviderRateLimit_EnforcesPacing(t *testing.T) {
+	registry := NewProviderRateLimitRegistry()
+	cfg := &config.OpenAICompatibility{
+		Name:              "limited-provider",
+		RequestsPerMinute: 60, // 1 req per second
+	}
+	ctx := context.Background()
+
+	start := time.Now()
+	// First request succeeds immediately
+	if err := registry.Wait(ctx, cfg, "limited-provider", "key1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Second request within a burst of 1 must wait ~1s
+	if err := registry.Wait(ctx, cfg, "limited-provider", "key1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed.Milliseconds() < 800 {
+		t.Fatalf("expected pacing wait of >= 800ms, got %v", elapsed)
+	}
+}
+
+func TestNoteProviderRateLimited_HonoursRetryAfter(t *testing.T) {
+	registry := NewProviderRateLimitRegistry()
+	cfg := &config.OpenAICompatibility{
+		Name:              "rejected-provider",
+		RequestsPerMinute: 600, // pacing alone would not delay the next call
+	}
+	header := http.Header{}
+	header.Set("Retry-After", "1")
+
+	registry.NoteLimited(cfg, "rejected-provider", "key1", header)
+
+	ctx := context.Background()
+	start := time.Now()
+	if err := registry.Wait(ctx, cfg, "rejected-provider", "key1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 800*time.Millisecond {
+		t.Fatalf("expected upstream rejection pause of >= 800ms, got %v", elapsed)
+	}
+}
+
+func TestNoteProviderRateLimited_IgnoredWhenUnconfigured(t *testing.T) {
+	registry := NewProviderRateLimitRegistry()
+	cfg := &config.OpenAICompatibility{Name: "unlimited-provider"}
+	registry.NoteLimited(cfg, "unlimited-provider", "key1", nil)
+
+	ctx := context.Background()
+	start := time.Now()
+	if err := registry.Wait(ctx, cfg, "unlimited-provider", "key1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("expected no pause without requests-per-minute, waited %v", elapsed)
+	}
+}
+
+func TestNoteProviderRateLimited_CancelledContext(t *testing.T) {
+	registry := NewProviderRateLimitRegistry()
+	cfg := &config.OpenAICompatibility{
+		Name:              "cancelled-provider",
+		RequestsPerMinute: 600,
+	}
+	registry.NoteLimited(cfg, "cancelled-provider", "key1", nil) // no header -> 1 minute fallback
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := registry.Wait(ctx, cfg, "cancelled-provider", "key1"); err == nil {
+		t.Fatal("expected context cancellation error while paused")
+	}
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -86,8 +86,21 @@ func (e *OpenAICompatExecutor) HttpRequest(ctx context.Context, auth *cliproxyau
 	if err := e.PrepareRequest(httpReq, auth); err != nil {
 		return nil, err
 	}
+	providerKey := e.providerConfigKey(auth)
+	compat := e.resolveCompatConfig(auth)
+	var authID string
+	if auth != nil {
+		authID = auth.ID
+	}
+	if errRate := e.rateLimiter.Wait(ctx, compat, providerKey, authID); errRate != nil {
+		return nil, errRate
+	}
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	return httpClient.Do(httpReq)
+	httpResp, errDo := httpClient.Do(httpReq)
+	if errDo == nil && httpResp != nil && httpResp.StatusCode == http.StatusTooManyRequests {
+		e.rateLimiter.NoteLimited(compat, providerKey, authID, httpResp.Header)
+	}
+	return httpResp, errDo
 }
 
 func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -40,13 +40,18 @@ const (
 // It performs request/response translation and executes against the provider base URL
 // using per-auth credentials (API key) and per-auth HTTP transport (proxy) from context.
 type OpenAICompatExecutor struct {
-	provider string
-	cfg      *config.Config
+	provider    string
+	cfg         *config.Config
+	rateLimiter *helps.ProviderRateLimitRegistry
 }
 
 // NewOpenAICompatExecutor creates an executor bound to a provider key (e.g., "openrouter").
 func NewOpenAICompatExecutor(provider string, cfg *config.Config) *OpenAICompatExecutor {
-	return &OpenAICompatExecutor{provider: provider, cfg: cfg}
+	return &OpenAICompatExecutor{
+		provider:    provider,
+		cfg:         cfg,
+		rateLimiter: helps.NewProviderRateLimitRegistry(),
+	}
 }
 
 // Identifier implements cliproxyauth.ProviderExecutor.
@@ -176,6 +181,10 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		AuthValue: authValue,
 	})
 
+	if errRate := e.rateLimiter.Wait(ctx, e.resolveCompatConfig(auth), e.providerConfigKey(auth), authID); errRate != nil {
+		return resp, errRate
+	}
+
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
 	httpResp, err := httpClient.Do(httpReq)
@@ -190,6 +199,9 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	}()
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		if httpResp.StatusCode == http.StatusTooManyRequests {
+			e.rateLimiter.NoteLimited(e.resolveCompatConfig(auth), e.providerConfigKey(auth), authID, httpResp.Header)
+		}
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
@@ -270,6 +282,10 @@ func (e *OpenAICompatExecutor) executeImages(ctx context.Context, auth *cliproxy
 		AuthValue: authValue,
 	})
 
+	if errRate := e.rateLimiter.Wait(ctx, e.resolveCompatConfig(auth), e.providerConfigKey(auth), authID); errRate != nil {
+		return resp, errRate
+	}
+
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
 	httpResp, err := httpClient.Do(httpReq)
@@ -293,6 +309,9 @@ func (e *OpenAICompatExecutor) executeImages(ctx context.Context, auth *cliproxy
 	helps.AppendAPIResponseChunk(ctx, e.cfg, body)
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		if httpResp.StatusCode == http.StatusTooManyRequests {
+			e.rateLimiter.NoteLimited(e.resolveCompatConfig(auth), e.providerConfigKey(auth), authID, httpResp.Header)
+		}
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), body))
 		err = statusErr{code: httpResp.StatusCode, msg: string(body)}
 		return resp, err
@@ -390,6 +409,10 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		AuthValue: authValue,
 	})
 
+	if errRate := e.rateLimiter.Wait(ctx, e.resolveCompatConfig(auth), e.providerConfigKey(auth), authID); errRate != nil {
+		return nil, errRate
+	}
+
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
 	httpResp, err := httpClient.Do(httpReq)
@@ -399,6 +422,9 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		if httpResp.StatusCode == http.StatusTooManyRequests {
+			e.rateLimiter.NoteLimited(e.resolveCompatConfig(auth), e.providerConfigKey(auth), authID, httpResp.Header)
+		}
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
@@ -627,6 +653,10 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 		AuthValue: authValue,
 	})
 
+	if errRate := e.rateLimiter.Wait(ctx, e.resolveCompatConfig(auth), e.providerConfigKey(auth), authID); errRate != nil {
+		return nil, errRate
+	}
+
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
 	httpResp, err := httpClient.Do(httpReq)
@@ -637,6 +667,9 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		if httpResp.StatusCode == http.StatusTooManyRequests {
+			e.rateLimiter.NoteLimited(e.resolveCompatConfig(auth), e.providerConfigKey(auth), authID, httpResp.Header)
+		}
 		body, errRead := io.ReadAll(httpResp.Body)
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("openai compat executor: close response body error: %v", errClose)
@@ -924,6 +957,16 @@ func (e *OpenAICompatExecutor) resolveCredentials(auth *cliproxyauth.Auth) (base
 		apiKey = strings.TrimSpace(auth.Attributes["api_key"])
 	}
 	return
+}
+
+func (e *OpenAICompatExecutor) providerConfigKey(auth *cliproxyauth.Auth) string {
+	key := e.Identifier()
+	if auth != nil && auth.Attributes != nil {
+		if configIndex := strings.TrimSpace(auth.Attributes[cliproxyauth.AttributeConfigIndex]); configIndex != "" {
+			key += "|config:" + configIndex
+		}
+	}
+	return key
 }
 
 func (e *OpenAICompatExecutor) resolveCompatConfig(auth *cliproxyauth.Auth) *config.OpenAICompatibility {


### PR DESCRIPTION
## Summary

Add an opt-in, per-credential request rate limiter for OpenAI-compatible upstream providers.

## Motivation

Some relay providers enforce strict requests-per-minute windows and count rejected attempts against the same quota. Bursty local traffic can therefore trigger a self-sustaining sequence of HTTP 429 responses even when average throughput is below the advertised limit.

## Changes

- Add `openai-compatibility[].requests-per-minute` (`0`/omitted disables limiting).
- Smooth requests with `golang.org/x/time/rate` using burst 1.
- Keep independent state per concrete provider configuration and credential.
- Apply the gate before opening upstream connections for chat, streaming chat, image, and streaming image requests.
- Observe HTTP 429 responses and pause the same credential for `Retry-After` (seconds or HTTP-date), with a one-minute fallback when absent/invalid.
- Scope limiter state to the executor lifecycle so hot reloads retire removed provider state.
- Expose the field through management API GET/PATCH; reject negative values.

## Safety

- Disabled by default; existing configurations are unaffected.
- Waiting is context-cancellable.
- No timeout or deadline is introduced after the upstream connection is established.
- API keys and request bodies are not retained by limiter state.

## Verification

- `go test ./...`
- `go build -o test-output ./cmd/server`
- `git diff --check`

All pass locally.
